### PR TITLE
Fix launched mise doctor reliability in Firecracker guest

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -20,3 +20,11 @@ run = "go install ./cmd/cleanroom ./cmd/cleanroom-guest-agent"
 description = "Prepare rootfs image with guest agent and tiny init (requires sudo)"
 depends = ["build", "install"]
 run = "sudo scripts/prepare-firecracker-image.sh"
+
+[tasks.doctor]
+description = "Run cleanroom diagnostics"
+run = "go run ./cmd/cleanroom doctor"
+
+[tasks.doctor-json]
+description = "Run cleanroom diagnostics as JSON"
+run = "go run ./cmd/cleanroom doctor --json"

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ In that mode, Cleanroom:
 - detects `mise` files in the workspace,
 - resolves tool versions from repository-managed config,
 - applies the resulting environment inside the sandbox before executing the command,
+- auto-trusts copied workspace mise config paths in launched mode (`/workspace/.mise.toml`, `/workspace/.mise/config.toml`),
 - and still enforces the same network/registry/secret rules.
 
 To keep command parsing predictable, prefer the explicit form in scripts:

--- a/internal/vsockexec/protocol.go
+++ b/internal/vsockexec/protocol.go
@@ -15,6 +15,7 @@ type ExecRequest struct {
 	Env             []string `json:"env,omitempty"`
 	WorkspaceTarGz  []byte   `json:"workspace_tar_gz,omitempty"`
 	WorkspaceAccess string   `json:"workspace_access,omitempty"` // rw|ro
+	EntropySeed     []byte   `json:"entropy_seed,omitempty"`
 }
 
 type ExecResponse struct {


### PR DESCRIPTION
## Summary
Fix launched `cleanroom exec -- mise doctor` reliability/UX issues in Firecracker guest runs.

## Changes
- Add guest entropy seeding per exec request to avoid hangs in entropy-hungry binaries (notably Rust-based `mise`).
- Add Firecracker entropy device and boot arg `random.trust_cpu=on`.
- Auto-trust copied workspace mise config paths in launched mode by setting:
  - `MISE_TRUSTED_CONFIG_PATHS=/workspace/.mise.toml[:/workspace/.mise/config.toml]`
- Fix guest-agent command execution stream handling by draining stdout/stderr concurrently (prevents pipe deadlocks).
- Ensure guest command environment has sane defaults (`HOME`, `PATH`) and merges request env.
- Add `mise` doctor tasks:
  - `mise run doctor`
  - `mise run doctor-json`
- Update README to document auto-trusted workspace mise paths.

## Why
`mise doctor` in launched runs previously timed out/hung and also emitted trust warnings for copied `.mise.toml`. This PR makes launched behavior deterministic and aligned with README expectations.

## Verification
- `go test ./...`
- `mise run prepare-firecracker-image`
- `cleanroom exec --log-level=debug -- mise doctor`
  - now returns output (no vsock timeout)
  - workspace trust warning removed when `.mise.toml` exists in workspace copy
