### PR TITLE
Add Firecracker networking and fix launched exec timeout semantics

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -61,7 +61,7 @@ type ExecCommand struct {
 	ReadOnlyWorkspace bool   `help:"Mount workspace read-only for this run"`
 	DryRun            bool   `help:"Generate execution plan without running a backend command"`
 	HostPassthrough   bool   `help:"Run command directly on host instead of launching a backend (unsafe, not sandboxed)"`
-	LaunchSeconds     int64  `help:"Launch/guest-exec timeout in seconds"`
+	LaunchSeconds     int64  `help:"VM boot/guest-agent readiness timeout in seconds"`
 
 	Command []string `arg:"" passthrough:"" required:"" help:"Command to execute"`
 }

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -121,20 +121,10 @@ func TestCompileHashStable(t *testing.T) {
 func TestLoadPropagatesPrimaryStatError(t *testing.T) {
 	t.Parallel()
 
-	parent := t.TempDir()
-	restricted := filepath.Join(parent, "restricted")
-	if err := os.MkdirAll(restricted, 0o700); err != nil {
-		t.Fatalf("mkdir restricted root: %v", err)
-	}
-	if err := os.Chmod(restricted, 0o000); err != nil {
-		t.Fatalf("chmod restricted root: %v", err)
-	}
-	defer os.Chmod(restricted, 0o700)
-
 	loader := Loader{}
-	_, _, err := loader.Load(restricted)
+	_, _, err := loader.Load(string([]byte{'b', 'a', 'd', 0, 'p', 'a', 't', 'h'}))
 	if err == nil {
-		t.Fatal("expected load to fail on stat permission error")
+		t.Fatal("expected load to fail on primary policy stat error")
 	}
 	if !strings.Contains(err.Error(), "check policy") {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/runtimeconfig/config.go
+++ b/internal/runtimeconfig/config.go
@@ -35,7 +35,7 @@ type FirecrackerConfig struct {
 	GuestCID      uint32 `yaml:"guest_cid"`
 	GuestPort     uint32 `yaml:"guest_port"`
 	RetainWrites  bool   `yaml:"retain_writes"`
-	LaunchSeconds int64  `yaml:"launch_seconds"`
+	LaunchSeconds int64  `yaml:"launch_seconds"` // VM boot/guest-agent readiness timeout
 }
 
 func Path() (string, error) {


### PR DESCRIPTION
## Summary
- add Firecracker TAP/NAT networking for launched VMs
- wire guest NIC config into Firecracker (`network-interfaces`) with per-run deterministic MAC
- pass guest network settings via kernel cmdline and configure `eth0`/route/DNS in `cleanroom-init`
- keep `launch_seconds` scoped to VM boot + guest-agent readiness only (no implicit runtime timeout)
- stabilize `TestLoadPropagatesPrimaryStatError` to be deterministic in both root and non-root environments

## Validation
- `go test ./...`
- `bash -n scripts/prepare-firecracker-image.sh`

## Behavior
- long-running launched commands are not timed out by default once the guest agent is connected
- launched VMs now have outbound network access via host NAT when host `sudo -n` networking setup succeeds
