### PR TITLE
Improve firecracker exec startup observability and rootfs prep

### DIFF
--- a/API_CONNECTRPC.md
+++ b/API_CONNECTRPC.md
@@ -4,6 +4,11 @@
 
 Define a minimal, functional API for creating and managing Cleanroom sandboxes with streaming execution support.
 
+Current implemented HTTP lifecycle endpoints:
+- `POST /v1/cleanrooms/launch`
+- `POST /v1/cleanrooms/run`
+- `POST /v1/cleanrooms/terminate`
+
 This document is intentionally small-scope:
 - management plane for sandbox lifecycle
 - execution plane for command runs and streaming output

--- a/README.md
+++ b/README.md
@@ -212,8 +212,13 @@ cleanroom status --run-id <run-id>
 `doctor` now reports host networking prerequisites for launched Firecracker runs (presence of `ip`/`iptables`/`sysctl`/`sudo`, plus `sudo -n` checks used by TAP/NAT setup).
 
 `status --run-id` prints per-run observability from `run-observability.json`, including:
+- policy host-resolution time
+- rootfs preparation time
+- Firecracker process start time
+- workspace archive preparation time
 - network setup time
-- VM ready/vsock wait time
+- VM ready time (process start -> guest agent ready)
+- vsock wait time (wait-to-connect for guest agent)
 - guest command runtime
 - network cleanup time
 - total run time

--- a/cmd/cleanroom-guest-agent/main.go
+++ b/cmd/cleanroom-guest-agent/main.go
@@ -243,7 +243,7 @@ func extractTarGz(content []byte, destRoot string) error {
 				return err
 			}
 		case tar.TypeSymlink:
-			return fmt.Errorf("symlinks are not supported in workspace copy mode: %q", hdr.Name)
+			return fmt.Errorf("symlinks are not supported in workspace snapshots: %q", hdr.Name)
 		default:
 			// Skip unsupported entries (devices, fifos, etc.) in MVP.
 		}

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -25,8 +25,6 @@ type FirecrackerConfig struct {
 	RootFSPath       string
 	RunDir           string
 	WorkspaceHost    string
-	WorkspaceMode    string // copy|mount
-	WorkspacePersist string // discard|commit
 	WorkspaceAccess  string // rw|ro
 	VCPUs            int64
 	MemoryMiB        int64

--- a/internal/backend/firecracker/copy_test.go
+++ b/internal/backend/firecracker/copy_test.go
@@ -1,0 +1,49 @@
+package firecracker
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCopyFileCopiesContentsAndMode(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.ext4")
+	dst := filepath.Join(dir, "dst.ext4")
+
+	srcData := []byte("rootfs-data-1234567890")
+	if err := os.WriteFile(src, srcData, 0o640); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	// Ensure destination truncate behavior is correct.
+	if err := os.WriteFile(dst, []byte("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"), 0o600); err != nil {
+		t.Fatalf("write preexisting dst: %v", err)
+	}
+
+	if err := copyFile(src, dst); err != nil {
+		t.Fatalf("copyFile: %v", err)
+	}
+
+	gotData, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read dst: %v", err)
+	}
+	if !bytes.Equal(gotData, srcData) {
+		t.Fatalf("unexpected dst contents: got %q want %q", string(gotData), string(srcData))
+	}
+
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		t.Fatalf("stat src: %v", err)
+	}
+	dstInfo, err := os.Stat(dst)
+	if err != nil {
+		t.Fatalf("stat dst: %v", err)
+	}
+	if dstInfo.Mode().Perm() != srcInfo.Mode().Perm() {
+		t.Fatalf("unexpected dst mode: got %o want %o", dstInfo.Mode().Perm(), srcInfo.Mode().Perm())
+	}
+}

--- a/internal/backend/firecracker/reflink_linux.go
+++ b/internal/backend/firecracker/reflink_linux.go
@@ -1,0 +1,13 @@
+//go:build linux
+
+package firecracker
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func tryCloneFile(dst, src *os.File) bool {
+	return unix.IoctlFileClone(int(dst.Fd()), int(src.Fd())) == nil
+}

--- a/internal/backend/firecracker/reflink_unsupported.go
+++ b/internal/backend/firecracker/reflink_unsupported.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package firecracker
+
+import "os"
+
+func tryCloneFile(dst, src *os.File) bool {
+	return false
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -345,19 +345,17 @@ func resolveBackendName(requested, configuredDefault string) string {
 
 func mergeFirecrackerConfig(cwd string, e *ExecCommand, cfg runtimeconfig.Config) backend.FirecrackerConfig {
 	out := backend.FirecrackerConfig{
-		BinaryPath:       cfg.Backends.Firecracker.BinaryPath,
-		KernelImagePath:  cfg.Backends.Firecracker.KernelImage,
-		RootFSPath:       cfg.Backends.Firecracker.RootFS,
-		WorkspaceHost:    cwd,
-		WorkspaceMode:    resolveWorkspaceMode(cfg.Workspace.Mode),
-		WorkspacePersist: resolveWorkspacePersist(cfg.Workspace.Persist),
-		WorkspaceAccess:  resolveWorkspaceAccess(e, cfg.Workspace.Access),
-		VCPUs:            cfg.Backends.Firecracker.VCPUs,
-		MemoryMiB:        cfg.Backends.Firecracker.MemoryMiB,
-		GuestCID:         cfg.Backends.Firecracker.GuestCID,
-		GuestPort:        cfg.Backends.Firecracker.GuestPort,
-		RetainWrites:     cfg.Backends.Firecracker.RetainWrites,
-		LaunchSeconds:    cfg.Backends.Firecracker.LaunchSeconds,
+		BinaryPath:      cfg.Backends.Firecracker.BinaryPath,
+		KernelImagePath: cfg.Backends.Firecracker.KernelImage,
+		RootFSPath:      cfg.Backends.Firecracker.RootFS,
+		WorkspaceHost:   cwd,
+		WorkspaceAccess: resolveWorkspaceAccess(e, cfg.Workspace.Access),
+		VCPUs:           cfg.Backends.Firecracker.VCPUs,
+		MemoryMiB:       cfg.Backends.Firecracker.MemoryMiB,
+		GuestCID:        cfg.Backends.Firecracker.GuestCID,
+		GuestPort:       cfg.Backends.Firecracker.GuestPort,
+		RetainWrites:    cfg.Backends.Firecracker.RetainWrites,
+		LaunchSeconds:   cfg.Backends.Firecracker.LaunchSeconds,
 	}
 
 	if e.RunDir != "" {
@@ -383,22 +381,6 @@ func resolveWorkspaceAccess(execCfg *ExecCommand, configured string) string {
 		access = "ro"
 	}
 	return access
-}
-
-func resolveWorkspaceMode(configured string) string {
-	mode := configured
-	if mode == "" {
-		mode = "copy"
-	}
-	return mode
-}
-
-func resolveWorkspacePersist(configured string) string {
-	persist := configured
-	if persist == "" {
-		persist = "discard"
-	}
-	return persist
 }
 
 func (s *StatusCommand) Run(ctx *runtimeContext) error {

--- a/internal/controlapi/types.go
+++ b/internal/controlapi/types.go
@@ -7,6 +7,54 @@ type ExecRequest struct {
 	Options ExecOptions `json:"options"`
 }
 
+type LaunchCleanroomRequest struct {
+	CWD     string                 `json:"cwd"`
+	Backend string                 `json:"backend,omitempty"`
+	Options LaunchCleanroomOptions `json:"options"`
+}
+
+type LaunchCleanroomOptions struct {
+	RunDir            string `json:"run_dir,omitempty"`
+	ReadOnlyWorkspace bool   `json:"read_only_workspace,omitempty"`
+	LaunchSeconds     int64  `json:"launch_seconds,omitempty"`
+}
+
+type LaunchCleanroomResponse struct {
+	CleanroomID  string `json:"cleanroom_id"`
+	Backend      string `json:"backend"`
+	PolicySource string `json:"policy_source"`
+	PolicyHash   string `json:"policy_hash"`
+	RunDirRoot   string `json:"run_dir_root,omitempty"`
+	Message      string `json:"message"`
+}
+
+type RunCleanroomRequest struct {
+	CleanroomID string   `json:"cleanroom_id"`
+	Command     []string `json:"command"`
+}
+
+type RunCleanroomResponse struct {
+	CleanroomID string `json:"cleanroom_id"`
+	RunID       string `json:"run_id"`
+	ExitCode    int    `json:"exit_code"`
+	LaunchedVM  bool   `json:"launched_vm"`
+	PlanPath    string `json:"plan_path"`
+	RunDir      string `json:"run_dir"`
+	Message     string `json:"message"`
+	Stdout      string `json:"stdout,omitempty"`
+	Stderr      string `json:"stderr,omitempty"`
+}
+
+type TerminateCleanroomRequest struct {
+	CleanroomID string `json:"cleanroom_id"`
+}
+
+type TerminateCleanroomResponse struct {
+	CleanroomID string `json:"cleanroom_id"`
+	Terminated  bool   `json:"terminated"`
+	Message     string `json:"message"`
+}
+
 type ExecOptions struct {
 	RunDir            string `json:"run_dir,omitempty"`
 	ReadOnlyWorkspace bool   `json:"read_only_workspace,omitempty"`

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/buildkite/cleanroom/internal/backend"
@@ -19,10 +21,195 @@ type Service struct {
 	Config   runtimeconfig.Config
 	Backends map[string]backend.Adapter
 	Logger   *log.Logger
+
+	mu         sync.RWMutex
+	cleanrooms map[string]launchedCleanroom
+}
+
+type launchedCleanroom struct {
+	ID               string
+	CWD              string
+	Backend          string
+	Policy           *policy.CompiledPolicy
+	PolicySource     string
+	Firecracker      backend.FirecrackerConfig
+	RunDirRoot       string
+	CreatedAt        time.Time
+	LastExecutionRun string
 }
 
 type loader interface {
 	LoadAndCompile(cwd string) (*policy.CompiledPolicy, string, error)
+}
+
+func (s *Service) LaunchCleanroom(_ context.Context, req controlapi.LaunchCleanroomRequest) (*controlapi.LaunchCleanroomResponse, error) {
+	if strings.TrimSpace(req.CWD) == "" {
+		return nil, errors.New("missing cwd")
+	}
+
+	backendName := resolveBackendName(req.Backend, s.Config.DefaultBackend)
+	if _, ok := s.Backends[backendName]; !ok {
+		return nil, fmt.Errorf("unknown backend %q", backendName)
+	}
+
+	compiled, source, err := s.Loader.LoadAndCompile(req.CWD)
+	if err != nil {
+		return nil, err
+	}
+
+	cleanroomID := fmt.Sprintf("cr-%d", time.Now().UTC().UnixNano())
+	launchOpts := controlapi.ExecOptions{
+		RunDir:            req.Options.RunDir,
+		ReadOnlyWorkspace: req.Options.ReadOnlyWorkspace,
+		LaunchSeconds:     req.Options.LaunchSeconds,
+	}
+	firecrackerCfg := mergeFirecrackerConfig(req.CWD, launchOpts, s.Config)
+	runDirRoot := strings.TrimSpace(req.Options.RunDir)
+	firecrackerCfg.RunDir = ""
+
+	state := launchedCleanroom{
+		ID:           cleanroomID,
+		CWD:          req.CWD,
+		Backend:      backendName,
+		Policy:       compiled,
+		PolicySource: source,
+		Firecracker:  firecrackerCfg,
+		RunDirRoot:   runDirRoot,
+		CreatedAt:    time.Now().UTC(),
+	}
+
+	s.mu.Lock()
+	if s.cleanrooms == nil {
+		s.cleanrooms = map[string]launchedCleanroom{}
+	}
+	s.cleanrooms[cleanroomID] = state
+	s.mu.Unlock()
+
+	if s.Logger != nil {
+		s.Logger.Info("cleanroom launched",
+			"cleanroom_id", cleanroomID,
+			"backend", backendName,
+			"cwd", req.CWD,
+			"policy_source", source,
+			"policy_hash", compiled.Hash,
+		)
+	}
+
+	return &controlapi.LaunchCleanroomResponse{
+		CleanroomID:  cleanroomID,
+		Backend:      backendName,
+		PolicySource: source,
+		PolicyHash:   compiled.Hash,
+		RunDirRoot:   runDirRoot,
+		Message:      "cleanroom launched and ready to run commands",
+	}, nil
+}
+
+func (s *Service) RunCleanroom(ctx context.Context, req controlapi.RunCleanroomRequest) (*controlapi.RunCleanroomResponse, error) {
+	cleanroomID := strings.TrimSpace(req.CleanroomID)
+	if cleanroomID == "" {
+		return nil, errors.New("missing cleanroom_id")
+	}
+
+	command := normalizeCommand(req.Command)
+	if len(command) == 0 {
+		return nil, errors.New("missing command")
+	}
+
+	s.mu.RLock()
+	state, ok := s.cleanrooms[cleanroomID]
+	s.mu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("unknown cleanroom %q", cleanroomID)
+	}
+
+	adapter, ok := s.Backends[state.Backend]
+	if !ok {
+		return nil, fmt.Errorf("unknown backend %q", state.Backend)
+	}
+
+	runID := fmt.Sprintf("run-%d", time.Now().UTC().UnixNano())
+	firecrackerCfg := state.Firecracker
+	if state.RunDirRoot != "" {
+		firecrackerCfg.RunDir = filepath.Join(state.RunDirRoot, runID)
+	}
+
+	result, err := adapter.Run(ctx, backend.RunRequest{
+		RunID:             runID,
+		CWD:               state.CWD,
+		Command:           append([]string(nil), command...),
+		Policy:            state.Policy,
+		FirecrackerConfig: firecrackerCfg,
+	})
+	if err != nil {
+		if s.Logger != nil {
+			s.Logger.Error("cleanroom command failed",
+				"cleanroom_id", cleanroomID,
+				"backend", state.Backend,
+				"error", err,
+			)
+		}
+		return nil, err
+	}
+
+	s.mu.Lock()
+	if current, found := s.cleanrooms[cleanroomID]; found {
+		current.LastExecutionRun = result.RunID
+		s.cleanrooms[cleanroomID] = current
+	}
+	s.mu.Unlock()
+
+	if s.Logger != nil {
+		s.Logger.Info("cleanroom command completed",
+			"cleanroom_id", cleanroomID,
+			"run_id", result.RunID,
+			"exit_code", result.ExitCode,
+			"launched_vm", result.LaunchedVM,
+		)
+	}
+
+	return &controlapi.RunCleanroomResponse{
+		CleanroomID: cleanroomID,
+		RunID:       result.RunID,
+		ExitCode:    result.ExitCode,
+		LaunchedVM:  result.LaunchedVM,
+		PlanPath:    result.PlanPath,
+		RunDir:      result.RunDir,
+		Message:     result.Message,
+		Stdout:      result.Stdout,
+		Stderr:      result.Stderr,
+	}, nil
+}
+
+func (s *Service) TerminateCleanroom(_ context.Context, req controlapi.TerminateCleanroomRequest) (*controlapi.TerminateCleanroomResponse, error) {
+	cleanroomID := strings.TrimSpace(req.CleanroomID)
+	if cleanroomID == "" {
+		return nil, errors.New("missing cleanroom_id")
+	}
+
+	s.mu.Lock()
+	state, ok := s.cleanrooms[cleanroomID]
+	if ok {
+		delete(s.cleanrooms, cleanroomID)
+	}
+	s.mu.Unlock()
+	if !ok {
+		return nil, fmt.Errorf("unknown cleanroom %q", cleanroomID)
+	}
+
+	if s.Logger != nil {
+		s.Logger.Info("cleanroom terminated",
+			"cleanroom_id", cleanroomID,
+			"backend", state.Backend,
+			"last_run_id", state.LastExecutionRun,
+		)
+	}
+
+	return &controlapi.TerminateCleanroomResponse{
+		CleanroomID: cleanroomID,
+		Terminated:  true,
+		Message:     "cleanroom terminated",
+	}, nil
 }
 
 func (s *Service) Exec(ctx context.Context, req controlapi.ExecRequest) (*controlapi.ExecResponse, error) {
@@ -118,19 +305,17 @@ func resolveBackendName(requested, configuredDefault string) string {
 
 func mergeFirecrackerConfig(cwd string, opts controlapi.ExecOptions, cfg runtimeconfig.Config) backend.FirecrackerConfig {
 	out := backend.FirecrackerConfig{
-		BinaryPath:       cfg.Backends.Firecracker.BinaryPath,
-		KernelImagePath:  cfg.Backends.Firecracker.KernelImage,
-		RootFSPath:       cfg.Backends.Firecracker.RootFS,
-		WorkspaceHost:    cwd,
-		WorkspaceMode:    resolveWorkspaceMode(cfg.Workspace.Mode),
-		WorkspacePersist: resolveWorkspacePersist(cfg.Workspace.Persist),
-		WorkspaceAccess:  resolveWorkspaceAccess(opts, cfg.Workspace.Access),
-		VCPUs:            cfg.Backends.Firecracker.VCPUs,
-		MemoryMiB:        cfg.Backends.Firecracker.MemoryMiB,
-		GuestCID:         cfg.Backends.Firecracker.GuestCID,
-		GuestPort:        cfg.Backends.Firecracker.GuestPort,
-		RetainWrites:     cfg.Backends.Firecracker.RetainWrites,
-		LaunchSeconds:    cfg.Backends.Firecracker.LaunchSeconds,
+		BinaryPath:      cfg.Backends.Firecracker.BinaryPath,
+		KernelImagePath: cfg.Backends.Firecracker.KernelImage,
+		RootFSPath:      cfg.Backends.Firecracker.RootFS,
+		WorkspaceHost:   cwd,
+		WorkspaceAccess: resolveWorkspaceAccess(opts, cfg.Workspace.Access),
+		VCPUs:           cfg.Backends.Firecracker.VCPUs,
+		MemoryMiB:       cfg.Backends.Firecracker.MemoryMiB,
+		GuestCID:        cfg.Backends.Firecracker.GuestCID,
+		GuestPort:       cfg.Backends.Firecracker.GuestPort,
+		RetainWrites:    cfg.Backends.Firecracker.RetainWrites,
+		LaunchSeconds:   cfg.Backends.Firecracker.LaunchSeconds,
 	}
 
 	if opts.RunDir != "" {
@@ -156,20 +341,4 @@ func resolveWorkspaceAccess(execCfg controlapi.ExecOptions, configured string) s
 		access = "ro"
 	}
 	return access
-}
-
-func resolveWorkspaceMode(configured string) string {
-	mode := configured
-	if mode == "" {
-		mode = "copy"
-	}
-	return mode
-}
-
-func resolveWorkspacePersist(configured string) string {
-	persist := configured
-	if persist == "" {
-		persist = "discard"
-	}
-	return persist
 }

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -2,6 +2,7 @@ package controlservice
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/buildkite/cleanroom/internal/backend"
@@ -10,15 +11,27 @@ import (
 )
 
 type stubAdapter struct {
-	result *backend.RunResult
-	req    backend.RunRequest
+	result   *backend.RunResult
+	req      backend.RunRequest
+	runCalls int
 }
 
 func (s *stubAdapter) Name() string { return "stub" }
 
 func (s *stubAdapter) Run(_ context.Context, req backend.RunRequest) (*backend.RunResult, error) {
 	s.req = req
-	return s.result, nil
+	s.runCalls++
+	if s.result != nil {
+		return s.result, nil
+	}
+	return &backend.RunResult{
+		RunID:      req.RunID,
+		ExitCode:   0,
+		LaunchedVM: true,
+		PlanPath:   "/tmp/plan",
+		RunDir:     "/tmp/run",
+		Message:    "ok",
+	}, nil
 }
 
 type stubLoader struct {
@@ -66,5 +79,70 @@ func TestExecForwardsBackendOutput(t *testing.T) {
 	}
 	if resp.Stderr != "hello stderr\n" {
 		t.Fatalf("expected stderr to be forwarded, got %q", resp.Stderr)
+	}
+}
+
+func TestLaunchRunTerminateLifecycle(t *testing.T) {
+	adapter := &stubAdapter{}
+	svc := &Service{
+		Loader: stubLoader{
+			compiled: &policy.CompiledPolicy{Hash: "hash-1", NetworkDefault: "deny"},
+			source:   "/repo/cleanroom.yaml",
+		},
+		Backends: map[string]backend.Adapter{"firecracker": adapter},
+	}
+
+	launchResp, err := svc.LaunchCleanroom(context.Background(), controlapi.LaunchCleanroomRequest{
+		CWD: "/repo",
+		Options: controlapi.LaunchCleanroomOptions{
+			RunDir: "/tmp/cleanrooms",
+		},
+	})
+	if err != nil {
+		t.Fatalf("LaunchCleanroom returned error: %v", err)
+	}
+	if launchResp.CleanroomID == "" {
+		t.Fatal("expected cleanroom_id to be set")
+	}
+	if launchResp.PolicyHash != "hash-1" {
+		t.Fatalf("unexpected policy hash: %q", launchResp.PolicyHash)
+	}
+
+	runResp, err := svc.RunCleanroom(context.Background(), controlapi.RunCleanroomRequest{
+		CleanroomID: launchResp.CleanroomID,
+		Command:     []string{"--", "pi", "run", "fix tests"},
+	})
+	if err != nil {
+		t.Fatalf("RunCleanroom returned error: %v", err)
+	}
+	if runResp.CleanroomID != launchResp.CleanroomID {
+		t.Fatalf("unexpected cleanroom id: got %q want %q", runResp.CleanroomID, launchResp.CleanroomID)
+	}
+	if got := adapter.req.Command[0]; got != "pi" {
+		t.Fatalf("expected normalized command to start with pi, got %q", got)
+	}
+	if !strings.HasPrefix(adapter.req.RunDir, "/tmp/cleanrooms/") {
+		t.Fatalf("expected run dir under run root, got %q", adapter.req.RunDir)
+	}
+	if adapter.runCalls != 1 {
+		t.Fatalf("expected exactly one run call, got %d", adapter.runCalls)
+	}
+
+	terminateResp, err := svc.TerminateCleanroom(context.Background(), controlapi.TerminateCleanroomRequest{
+		CleanroomID: launchResp.CleanroomID,
+	})
+	if err != nil {
+		t.Fatalf("TerminateCleanroom returned error: %v", err)
+	}
+	if !terminateResp.Terminated {
+		t.Fatal("expected terminated=true")
+	}
+
+	_, err = svc.RunCleanroom(context.Background(), controlapi.RunCleanroomRequest{
+		CleanroomID: launchResp.CleanroomID,
+		Command:     []string{"echo", "should fail"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "unknown cleanroom") {
+		t.Fatalf("expected unknown cleanroom error after terminate, got %v", err)
 	}
 }

--- a/internal/runtimeconfig/config.go
+++ b/internal/runtimeconfig/config.go
@@ -17,9 +17,7 @@ type Config struct {
 }
 
 type Workspace struct {
-	Mode    string `yaml:"mode"`    // copy|mount
-	Persist string `yaml:"persist"` // discard|commit
-	Access  string `yaml:"access"`  // rw|ro
+	Access string `yaml:"access"` // rw|ro
 }
 
 type Backends struct {
@@ -71,14 +69,6 @@ func Load() (Config, string, error) {
 	}
 
 	cfg.DefaultBackend = strings.TrimSpace(cfg.DefaultBackend)
-	cfg.Workspace.Mode = strings.TrimSpace(strings.ToLower(cfg.Workspace.Mode))
-	if cfg.Workspace.Mode == "" {
-		cfg.Workspace.Mode = "copy"
-	}
-	cfg.Workspace.Persist = strings.TrimSpace(strings.ToLower(cfg.Workspace.Persist))
-	if cfg.Workspace.Persist == "" {
-		cfg.Workspace.Persist = "discard"
-	}
 	cfg.Workspace.Access = strings.TrimSpace(strings.ToLower(cfg.Workspace.Access))
 	if cfg.Workspace.Access == "" {
 		cfg.Workspace.Access = "rw"


### PR DESCRIPTION
## Summary
- add finer-grained firecracker run observability (`policy_resolve_ms`, `rootfs_copy_ms`, `firecracker_start_ms`, `workspace_archive_ms`)
- fix readiness timing semantics so `vm_ready_ms` reflects process-start-to-agent-ready and `vsock_wait_ms` reflects dial wait
- optimize per-run rootfs prep with a Linux reflink (CoW) fast path and safe byte-copy fallback
- keep network cleanup behavior but batch privileged cleanup commands to reduce process overhead
- update README timing docs and add unit tests for copy behavior and network timing capture

## Validation
- `mise exec -- go test ./...`
- local perf sample against rebuilt server/binary (3 runs):
  - `total_ms`: 4504 / 4562 / 4253
  - `rootfs_copy_ms`: 2 / 1 / 1
