### PR TITLE
Improve Firecracker startup observability and rootfs prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,8 +212,13 @@ cleanroom status --run-id <run-id>
 `doctor` now reports host networking prerequisites for launched Firecracker runs (presence of `ip`/`iptables`/`sysctl`/`sudo`, plus `sudo -n` checks used by TAP/NAT setup).
 
 `status --run-id` prints per-run observability from `run-observability.json`, including:
+- policy host-resolution time
+- rootfs preparation time
+- Firecracker process start time
+- workspace archive preparation time
 - network setup time
-- VM ready/vsock wait time
+- VM ready time (process start -> guest agent ready)
+- vsock wait time (wait-to-connect for guest agent)
 - guest command runtime
 - network cleanup time
 - total run time

--- a/internal/backend/firecracker/copy_test.go
+++ b/internal/backend/firecracker/copy_test.go
@@ -1,0 +1,49 @@
+package firecracker
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCopyFileCopiesContentsAndMode(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.ext4")
+	dst := filepath.Join(dir, "dst.ext4")
+
+	srcData := []byte("rootfs-data-1234567890")
+	if err := os.WriteFile(src, srcData, 0o640); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	// Ensure destination truncate behavior is correct.
+	if err := os.WriteFile(dst, []byte("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"), 0o600); err != nil {
+		t.Fatalf("write preexisting dst: %v", err)
+	}
+
+	if err := copyFile(src, dst); err != nil {
+		t.Fatalf("copyFile: %v", err)
+	}
+
+	gotData, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read dst: %v", err)
+	}
+	if !bytes.Equal(gotData, srcData) {
+		t.Fatalf("unexpected dst contents: got %q want %q", string(gotData), string(srcData))
+	}
+
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		t.Fatalf("stat src: %v", err)
+	}
+	dstInfo, err := os.Stat(dst)
+	if err != nil {
+		t.Fatalf("stat dst: %v", err)
+	}
+	if dstInfo.Mode().Perm() != srcInfo.Mode().Perm() {
+		t.Fatalf("unexpected dst mode: got %o want %o", dstInfo.Mode().Perm(), srcInfo.Mode().Perm())
+	}
+}

--- a/internal/backend/firecracker/reflink_linux.go
+++ b/internal/backend/firecracker/reflink_linux.go
@@ -1,0 +1,13 @@
+//go:build linux
+
+package firecracker
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func tryCloneFile(dst, src *os.File) bool {
+	return unix.IoctlFileClone(int(dst.Fd()), int(src.Fd())) == nil
+}

--- a/internal/backend/firecracker/reflink_unsupported.go
+++ b/internal/backend/firecracker/reflink_unsupported.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package firecracker
+
+import "os"
+
+func tryCloneFile(dst, src *os.File) bool {
+	return false
+}


### PR DESCRIPTION
## Summary
- improve Firecracker run observability around startup path and rootfs preparation
- add explicit timing capture for key launch phases
- add reflink/clone-aware rootfs copy path with copy fallback
- add tests for copy behavior and related network timing assertions

## Validation
- `go test ./...`
