### PR TITLE
Add cleanroom lifecycle API and drop copy/discard config surface

### DIFF
--- a/API_CONNECTRPC.md
+++ b/API_CONNECTRPC.md
@@ -4,6 +4,11 @@
 
 Define a minimal, functional API for creating and managing Cleanroom sandboxes with streaming execution support.
 
+Current implemented HTTP lifecycle endpoints:
+- `POST /v1/cleanrooms/launch`
+- `POST /v1/cleanrooms/run`
+- `POST /v1/cleanrooms/terminate`
+
 This document is intentionally small-scope:
 - management plane for sandbox lifecycle
 - execution plane for command runs and streaming output

--- a/README.md
+++ b/README.md
@@ -1,87 +1,34 @@
-# 🧑‍🔬 Cleanroom
+# Cleanroom
 
-Cleanroom is a secure, hermetic execution environment for modern agentic and development workflows that need repeatability, speed, supply-chain safety, and safe execution of untrusted code.
+Cleanroom is an API-first control plane for isolated command execution.
 
-Agents and local automation often run with mixed trust levels (external prompts, unreviewed scripts, temporary tasks). Cleanroom solves this by enforcing a policy boundary: explicit, auditable egress rules around what can be reached and from where, while still allowing practical command execution.
+Current backend: **Firecracker** on Linux/KVM.
 
-At its core, Cleanroom gives you:
-- deny-by-default networking
-- explicit host/port allowlists for runtime access
-- cache-mediated dependency fetches (repeatable and faster)
-- safe secret injection without plaintext in repo policy or command lines
-- policy-constrained sandboxes for running untrusted scripts and agent output
-- pluggable backends (local execution today, remote execution tomorrow)
+It is built for this lifecycle:
+1. Launch a cleanroom context from repository policy.
+2. Run an agent/command in an isolated Firecracker VM.
+3. Terminate the cleanroom context.
 
-## Why this exists
+## What It Does
 
-Agentic tools and local CLIs also need package and API access to do their jobs. Cleanroom keeps dependency and network intent in one place (`cleanroom.yaml`) and makes each execution environment auditable and reproducible, so trusted launchers can execute untrusted workloads inside explicit policy boundaries.
+- Compiles repository policy from `cleanroom.yaml`
+- Enforces deny-by-default egress (`host:port` allow rules)
+- Runs commands in a Firecracker microVM via guest agent
+- Returns exit code + stdout/stderr over API
+- Stores run artifacts and timing metrics for inspection
 
-The result is a safer baseline:
-- accidental dependency drift gets reduced
-- unexpected outbound traffic is blocked by default
-- dependency fetches are routed through caching/proxy policy points
-- local and remote execution can use the same repository policy definition
+## Architecture
 
-## Install / use
+- Server: `cleanroom serve`
+- Client: CLI and direct HTTP JSON calls
+- Transport: unix socket by default (`unix://$XDG_RUNTIME_DIR/cleanroom/cleanroom.sock`)
+- Core endpoints:
+  - `POST /v1/cleanrooms/launch`
+  - `POST /v1/cleanrooms/run`
+  - `POST /v1/cleanrooms/terminate`
+  - `POST /v1/exec` (single-call compatibility path)
 
-Once implemented:
-
-```bash
-cleanroom serve --listen unix://$XDG_RUNTIME_DIR/cleanroom/cleanroom.sock
-cleanroom policy validate
-cleanroom exec -- "npm test"
-```
-
-## Configuration: `cleanroom.yaml`
-
-Place policy at repository root as `cleanroom.yaml` (legacy fallback: `.buildkite/cleanroom.yaml`).
-
-```yaml
-version: 1
-project:
-  name: example-repo
-  owner: team-platform
-
-backends:
-  default: local
-  allow_overrides: true
-
-sandbox:
-  ttl_minutes: 30
-  network:
-    default: deny
-    allow:
-      - host: registry.npmjs.org
-        ports: [443]
-      - host: api.github.com
-        ports: [443]
-
-registries:
-  npm:
-    enable: true
-    allowed_hosts:
-      - registry.npmjs.org
-      - registry.yarnpkg.com
-    cache_ref: content-cache
-    fallback: deny
-    lockfile_enforcement:
-      enabled: true
-      mode: deny_unknown
-      lockfiles:
-        - package-lock.json
-        - yarn.lock
-
-metadata:
-  team: platform-security
-  risk_class: low
-```
-
-The policy maps to three enforcement layers:
-- **network**: explicit outbound host/port controls for everything.
-- **registry**: package fetches only through content-cache and allowed registries.
-- **lockfile-aware dependency policy**: only allowed artifacts from lockfiles are fetched.
-
-## Quick usage
+## Quick Start
 
 ### 1) Validate policy
 
@@ -89,127 +36,169 @@ The policy maps to three enforcement layers:
 cleanroom policy validate
 ```
 
-### 2) Start the local control-plane server
+### 2) Start API server
 
 ```bash
 cleanroom serve --listen unix://$XDG_RUNTIME_DIR/cleanroom/cleanroom.sock
 ```
 
-All CLI commands (including `cleanroom exec`) talk to this API endpoint.
-
-### 3) Run a task in a sandbox
+### 3) Launch -> Run -> Terminate via API
 
 ```bash
-cleanroom exec -- "npm install && npm test"
+cleanroom_id="$(
+  curl --silent --show-error \
+    --unix-socket "$XDG_RUNTIME_DIR/cleanroom/cleanroom.sock" \
+    -H 'content-type: application/json' \
+    -d '{"cwd":"'"$PWD"'"}' \
+    http://localhost/v1/cleanrooms/launch | jq -r '.cleanroom_id'
+)"
+
+curl --silent --show-error \
+  --unix-socket "$XDG_RUNTIME_DIR/cleanroom/cleanroom.sock" \
+  -H 'content-type: application/json' \
+  -d '{"cleanroom_id":"'"$cleanroom_id"'","command":["pi","run","implement the requested refactor"]}' \
+  http://localhost/v1/cleanrooms/run
+
+curl --silent --show-error \
+  --unix-socket "$XDG_RUNTIME_DIR/cleanroom/cleanroom.sock" \
+  -H 'content-type: application/json' \
+  -d '{"cleanroom_id":"'"$cleanroom_id"'"}' \
+  http://localhost/v1/cleanrooms/terminate
 ```
 
-### 3b) Run an agentic task in a sandbox
+## CLI Shortcut
+
+`cleanroom exec` keeps a one-command flow, but lifecycle endpoints are the primary API model.
 
 ```bash
-cleanroom exec -- "agent-tool execute 'resolve docs updates and open PR branch'"
+cleanroom exec -- pi run "implement the requested refactor"
 ```
 
-Use `--backend sprites` to run using the remote backend once configured:
+## API Contract (Current)
 
-```bash
-cleanroom exec --backend sprites -- "pytest -q"
+### `POST /v1/cleanrooms/launch`
+
+Request:
+
+```json
+{
+  "cwd": "/path/to/repo",
+  "backend": "firecracker",
+  "options": {
+    "run_dir": "/tmp/cleanroom-runs",
+    "read_only_workspace": false,
+    "launch_seconds": 30
+  }
+}
 ```
 
-The same command shape works for local tools, local scripts, and agent tasks.
+Response fields:
+- `cleanroom_id`
+- `backend`
+- `policy_source`
+- `policy_hash`
+- `run_dir_root`
 
-## Server + `exec` UX
+### `POST /v1/cleanrooms/run`
 
-Cleanroom uses a client/server model with one binary:
+Request:
 
-```bash
-cleanroom serve --listen unix://$XDG_RUNTIME_DIR/cleanroom/cleanroom.sock
+```json
+{
+  "cleanroom_id": "cr-123",
+  "command": ["pi", "run", "implement the requested refactor"]
+}
 ```
 
-`cleanroom exec` remains the primary command UX and talks to the server API under the hood.
+Response fields:
+- `run_id`
+- `exit_code`
+- `stdout`
+- `stderr`
+- `run_dir`
+- `plan_path`
 
-```bash
-cleanroom exec -- "npm test"
+### `POST /v1/cleanrooms/terminate`
+
+Request:
+
+```json
+{
+  "cleanroom_id": "cr-123"
+}
 ```
 
-Useful forms:
+Response fields:
+- `terminated`
 
-```bash
-cleanroom exec -it -- bash
-cleanroom exec -d -- "npm run watch"
-cleanroom exec --sandbox dev --reuse -- "npm test"
-```
+## Policy File
 
-Execution behavior:
-- resolves policy and creates a sandbox (ephemeral by default)
-- creates an execution and streams output
-- returns the workload exit code
-- tears down ephemeral sandboxes after execution
-- first `Ctrl-C` cancels execution, second `Ctrl-C` detaches the client stream
+Repository policy path resolution:
+1. `cleanroom.yaml`
+2. `.buildkite/cleanroom.yaml` (fallback)
 
-## Mise integration (first class)
-
-If a repository contains `.mise.toml` (or `.mise/config.toml`), `cleanroom exec` treats `mise` as part of the runtime bootstrap path.
-
-```bash
-cleanroom exec --backend local -- "mise exec npm test"
-```
-
-You can also run through implicit bootstrap:
-
-```bash
-cleanroom exec "npm test"
-```
-
-In that mode, Cleanroom:
-
-- detects `mise` files in the workspace,
-- resolves tool versions from repository-managed config,
-- applies the resulting environment inside the sandbox before executing the command,
-- auto-trusts copied workspace mise config paths in launched mode (`/workspace/.mise.toml`, `/workspace/.mise/config.toml`),
-- and still enforces the same network/registry/secret rules.
-
-To keep command parsing predictable, prefer the explicit form in scripts:
-
-```bash
-cleanroom exec -- "mise exec node --version"
-```
-
-You can also pin this behavior in policy:
+Minimal example:
 
 ```yaml
+version: 1
 sandbox:
-  mise:
-    enabled: true
-    auto_bootstrap: true
-    config_files:
-      - .mise.toml
-      - .mise/config.toml
+  network:
+    default: deny
+    allow:
+      - host: api.github.com
+        ports: [443]
+      - host: registry.npmjs.org
+        ports: [443]
 ```
 
-### 4) Watch / inspect
+## Firecracker Runtime Config
 
-```bash
-cleanroom sandboxes list
-cleanroom executions get <sandbox-id> <execution-id>
-cleanroom sandboxes events <sandbox-id> --follow
+Runtime config path: `$XDG_CONFIG_HOME/cleanroom/config.yaml` (or `~/.config/cleanroom/config.yaml`).
+
+Example:
+
+```yaml
+default_backend: firecracker
+workspace:
+  access: rw
+backends:
+  firecracker:
+    binary_path: firecracker
+    kernel_image: /opt/cleanroom/vmlinux
+    rootfs: /opt/cleanroom/rootfs.ext4
+    vcpus: 2
+    memory_mib: 1024
+    guest_cid: 3
+    launch_seconds: 30
+    retain_writes: false
 ```
 
-### 5) See what would run
+## Isolation Model
 
-```bash
-cleanroom policy validate --json
-```
+- Workload runs in a Firecracker microVM
+- Workspace is snapshotted per run and sent to the guest agent
+- Workspace can be read-only (`workspace.access: ro` or request override)
+- Host egress is controlled with TAP + iptables rules from compiled policy
+- Default network behavior is deny
+- Rootfs writes are ephemeral by default (`retain_writes: false`)
 
-This prints the resolved policy and effective network/registry plan before execution.
+## Performance Notes
 
-### 6) Diagnose host networking + inspect run timings
+- Rootfs copy uses clone/reflink when available, with copy fallback
+- Per-run observability is written to `run-observability.json`
+- Metrics include:
+  - rootfs preparation time
+  - network setup time
+  - VM ready time
+  - guest command runtime
+  - total run time
+
+Inspect:
 
 ```bash
 cleanroom doctor
 cleanroom status --run-id <run-id>
 ```
-
-`doctor` now reports host networking prerequisites for launched Firecracker runs (presence of `ip`/`iptables`/`sysctl`/`sudo`, plus `sudo -n` checks used by TAP/NAT setup).
 
 `status --run-id` prints per-run observability from `run-observability.json`, including:
 - policy host-resolution time
@@ -223,23 +212,15 @@ cleanroom status --run-id <run-id>
 - network cleanup time
 - total run time
 
-## What happens at runtime
+## Host Requirements
 
-- `cleanroom exec` sends requests to the `cleanroom serve` API.
-- The control plane reads policy and builds an internal execution spec.
-- If both `cleanroom.yaml` and `.buildkite/cleanroom.yaml` exist, root config wins and `.buildkite` is ignored with a warning.
-- The server starts the selected backend and applies the deny-by-default egress policy.
-- Allowed package manager traffic is directed through `content-cache`.
-- Git operations can be routed through cache as well.
-- Secrets are injected only at runtime into runtime components, not from policy files.
+- Linux host
+- `/dev/kvm` available and writable
+- Firecracker binary installed
+- Kernel image + rootfs image configured
+- `sudo -n` access for `ip`, `iptables`, and `sysctl` (network setup/cleanup)
 
-## Safety model (developer-focused)
+## References
 
-- No plaintext secrets in source control.
-- No wildcard package/network access unless explicitly allowed.
-- Lockfile-aware package enforcement to avoid unexpected dependency resolution.
-- Audit logs include what was denied and why.
-
-## Learn more
-
-Detailed architecture and implementation plan: `SPEC.md`.
+- API design notes: `API_CONNECTRPC.md`
+- Full spec and roadmap: `SPEC.md`

--- a/cmd/cleanroom-guest-agent/main.go
+++ b/cmd/cleanroom-guest-agent/main.go
@@ -243,7 +243,7 @@ func extractTarGz(content []byte, destRoot string) error {
 				return err
 			}
 		case tar.TypeSymlink:
-			return fmt.Errorf("symlinks are not supported in workspace copy mode: %q", hdr.Name)
+			return fmt.Errorf("symlinks are not supported in workspace snapshots: %q", hdr.Name)
 		default:
 			// Skip unsupported entries (devices, fifos, etc.) in MVP.
 		}

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -25,8 +25,6 @@ type FirecrackerConfig struct {
 	RootFSPath       string
 	RunDir           string
 	WorkspaceHost    string
-	WorkspaceMode    string // copy|mount
-	WorkspacePersist string // discard|commit
 	WorkspaceAccess  string // rw|ro
 	VCPUs            int64
 	MemoryMiB        int64

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -345,19 +345,17 @@ func resolveBackendName(requested, configuredDefault string) string {
 
 func mergeFirecrackerConfig(cwd string, e *ExecCommand, cfg runtimeconfig.Config) backend.FirecrackerConfig {
 	out := backend.FirecrackerConfig{
-		BinaryPath:       cfg.Backends.Firecracker.BinaryPath,
-		KernelImagePath:  cfg.Backends.Firecracker.KernelImage,
-		RootFSPath:       cfg.Backends.Firecracker.RootFS,
-		WorkspaceHost:    cwd,
-		WorkspaceMode:    resolveWorkspaceMode(cfg.Workspace.Mode),
-		WorkspacePersist: resolveWorkspacePersist(cfg.Workspace.Persist),
-		WorkspaceAccess:  resolveWorkspaceAccess(e, cfg.Workspace.Access),
-		VCPUs:            cfg.Backends.Firecracker.VCPUs,
-		MemoryMiB:        cfg.Backends.Firecracker.MemoryMiB,
-		GuestCID:         cfg.Backends.Firecracker.GuestCID,
-		GuestPort:        cfg.Backends.Firecracker.GuestPort,
-		RetainWrites:     cfg.Backends.Firecracker.RetainWrites,
-		LaunchSeconds:    cfg.Backends.Firecracker.LaunchSeconds,
+		BinaryPath:      cfg.Backends.Firecracker.BinaryPath,
+		KernelImagePath: cfg.Backends.Firecracker.KernelImage,
+		RootFSPath:      cfg.Backends.Firecracker.RootFS,
+		WorkspaceHost:   cwd,
+		WorkspaceAccess: resolveWorkspaceAccess(e, cfg.Workspace.Access),
+		VCPUs:           cfg.Backends.Firecracker.VCPUs,
+		MemoryMiB:       cfg.Backends.Firecracker.MemoryMiB,
+		GuestCID:        cfg.Backends.Firecracker.GuestCID,
+		GuestPort:       cfg.Backends.Firecracker.GuestPort,
+		RetainWrites:    cfg.Backends.Firecracker.RetainWrites,
+		LaunchSeconds:   cfg.Backends.Firecracker.LaunchSeconds,
 	}
 
 	if e.RunDir != "" {
@@ -383,22 +381,6 @@ func resolveWorkspaceAccess(execCfg *ExecCommand, configured string) string {
 		access = "ro"
 	}
 	return access
-}
-
-func resolveWorkspaceMode(configured string) string {
-	mode := configured
-	if mode == "" {
-		mode = "copy"
-	}
-	return mode
-}
-
-func resolveWorkspacePersist(configured string) string {
-	persist := configured
-	if persist == "" {
-		persist = "discard"
-	}
-	return persist
 }
 
 func (s *StatusCommand) Run(ctx *runtimeContext) error {

--- a/internal/controlapi/types.go
+++ b/internal/controlapi/types.go
@@ -7,6 +7,54 @@ type ExecRequest struct {
 	Options ExecOptions `json:"options"`
 }
 
+type LaunchCleanroomRequest struct {
+	CWD     string                 `json:"cwd"`
+	Backend string                 `json:"backend,omitempty"`
+	Options LaunchCleanroomOptions `json:"options"`
+}
+
+type LaunchCleanroomOptions struct {
+	RunDir            string `json:"run_dir,omitempty"`
+	ReadOnlyWorkspace bool   `json:"read_only_workspace,omitempty"`
+	LaunchSeconds     int64  `json:"launch_seconds,omitempty"`
+}
+
+type LaunchCleanroomResponse struct {
+	CleanroomID  string `json:"cleanroom_id"`
+	Backend      string `json:"backend"`
+	PolicySource string `json:"policy_source"`
+	PolicyHash   string `json:"policy_hash"`
+	RunDirRoot   string `json:"run_dir_root,omitempty"`
+	Message      string `json:"message"`
+}
+
+type RunCleanroomRequest struct {
+	CleanroomID string   `json:"cleanroom_id"`
+	Command     []string `json:"command"`
+}
+
+type RunCleanroomResponse struct {
+	CleanroomID string `json:"cleanroom_id"`
+	RunID       string `json:"run_id"`
+	ExitCode    int    `json:"exit_code"`
+	LaunchedVM  bool   `json:"launched_vm"`
+	PlanPath    string `json:"plan_path"`
+	RunDir      string `json:"run_dir"`
+	Message     string `json:"message"`
+	Stdout      string `json:"stdout,omitempty"`
+	Stderr      string `json:"stderr,omitempty"`
+}
+
+type TerminateCleanroomRequest struct {
+	CleanroomID string `json:"cleanroom_id"`
+}
+
+type TerminateCleanroomResponse struct {
+	CleanroomID string `json:"cleanroom_id"`
+	Terminated  bool   `json:"terminated"`
+	Message     string `json:"message"`
+}
+
 type ExecOptions struct {
 	RunDir            string `json:"run_dir,omitempty"`
 	ReadOnlyWorkspace bool   `json:"read_only_workspace,omitempty"`

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/buildkite/cleanroom/internal/backend"
@@ -19,10 +21,195 @@ type Service struct {
 	Config   runtimeconfig.Config
 	Backends map[string]backend.Adapter
 	Logger   *log.Logger
+
+	mu         sync.RWMutex
+	cleanrooms map[string]launchedCleanroom
+}
+
+type launchedCleanroom struct {
+	ID               string
+	CWD              string
+	Backend          string
+	Policy           *policy.CompiledPolicy
+	PolicySource     string
+	Firecracker      backend.FirecrackerConfig
+	RunDirRoot       string
+	CreatedAt        time.Time
+	LastExecutionRun string
 }
 
 type loader interface {
 	LoadAndCompile(cwd string) (*policy.CompiledPolicy, string, error)
+}
+
+func (s *Service) LaunchCleanroom(_ context.Context, req controlapi.LaunchCleanroomRequest) (*controlapi.LaunchCleanroomResponse, error) {
+	if strings.TrimSpace(req.CWD) == "" {
+		return nil, errors.New("missing cwd")
+	}
+
+	backendName := resolveBackendName(req.Backend, s.Config.DefaultBackend)
+	if _, ok := s.Backends[backendName]; !ok {
+		return nil, fmt.Errorf("unknown backend %q", backendName)
+	}
+
+	compiled, source, err := s.Loader.LoadAndCompile(req.CWD)
+	if err != nil {
+		return nil, err
+	}
+
+	cleanroomID := fmt.Sprintf("cr-%d", time.Now().UTC().UnixNano())
+	launchOpts := controlapi.ExecOptions{
+		RunDir:            req.Options.RunDir,
+		ReadOnlyWorkspace: req.Options.ReadOnlyWorkspace,
+		LaunchSeconds:     req.Options.LaunchSeconds,
+	}
+	firecrackerCfg := mergeFirecrackerConfig(req.CWD, launchOpts, s.Config)
+	runDirRoot := strings.TrimSpace(req.Options.RunDir)
+	firecrackerCfg.RunDir = ""
+
+	state := launchedCleanroom{
+		ID:           cleanroomID,
+		CWD:          req.CWD,
+		Backend:      backendName,
+		Policy:       compiled,
+		PolicySource: source,
+		Firecracker:  firecrackerCfg,
+		RunDirRoot:   runDirRoot,
+		CreatedAt:    time.Now().UTC(),
+	}
+
+	s.mu.Lock()
+	if s.cleanrooms == nil {
+		s.cleanrooms = map[string]launchedCleanroom{}
+	}
+	s.cleanrooms[cleanroomID] = state
+	s.mu.Unlock()
+
+	if s.Logger != nil {
+		s.Logger.Info("cleanroom launched",
+			"cleanroom_id", cleanroomID,
+			"backend", backendName,
+			"cwd", req.CWD,
+			"policy_source", source,
+			"policy_hash", compiled.Hash,
+		)
+	}
+
+	return &controlapi.LaunchCleanroomResponse{
+		CleanroomID:  cleanroomID,
+		Backend:      backendName,
+		PolicySource: source,
+		PolicyHash:   compiled.Hash,
+		RunDirRoot:   runDirRoot,
+		Message:      "cleanroom launched and ready to run commands",
+	}, nil
+}
+
+func (s *Service) RunCleanroom(ctx context.Context, req controlapi.RunCleanroomRequest) (*controlapi.RunCleanroomResponse, error) {
+	cleanroomID := strings.TrimSpace(req.CleanroomID)
+	if cleanroomID == "" {
+		return nil, errors.New("missing cleanroom_id")
+	}
+
+	command := normalizeCommand(req.Command)
+	if len(command) == 0 {
+		return nil, errors.New("missing command")
+	}
+
+	s.mu.RLock()
+	state, ok := s.cleanrooms[cleanroomID]
+	s.mu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("unknown cleanroom %q", cleanroomID)
+	}
+
+	adapter, ok := s.Backends[state.Backend]
+	if !ok {
+		return nil, fmt.Errorf("unknown backend %q", state.Backend)
+	}
+
+	runID := fmt.Sprintf("run-%d", time.Now().UTC().UnixNano())
+	firecrackerCfg := state.Firecracker
+	if state.RunDirRoot != "" {
+		firecrackerCfg.RunDir = filepath.Join(state.RunDirRoot, runID)
+	}
+
+	result, err := adapter.Run(ctx, backend.RunRequest{
+		RunID:             runID,
+		CWD:               state.CWD,
+		Command:           append([]string(nil), command...),
+		Policy:            state.Policy,
+		FirecrackerConfig: firecrackerCfg,
+	})
+	if err != nil {
+		if s.Logger != nil {
+			s.Logger.Error("cleanroom command failed",
+				"cleanroom_id", cleanroomID,
+				"backend", state.Backend,
+				"error", err,
+			)
+		}
+		return nil, err
+	}
+
+	s.mu.Lock()
+	if current, found := s.cleanrooms[cleanroomID]; found {
+		current.LastExecutionRun = result.RunID
+		s.cleanrooms[cleanroomID] = current
+	}
+	s.mu.Unlock()
+
+	if s.Logger != nil {
+		s.Logger.Info("cleanroom command completed",
+			"cleanroom_id", cleanroomID,
+			"run_id", result.RunID,
+			"exit_code", result.ExitCode,
+			"launched_vm", result.LaunchedVM,
+		)
+	}
+
+	return &controlapi.RunCleanroomResponse{
+		CleanroomID: cleanroomID,
+		RunID:       result.RunID,
+		ExitCode:    result.ExitCode,
+		LaunchedVM:  result.LaunchedVM,
+		PlanPath:    result.PlanPath,
+		RunDir:      result.RunDir,
+		Message:     result.Message,
+		Stdout:      result.Stdout,
+		Stderr:      result.Stderr,
+	}, nil
+}
+
+func (s *Service) TerminateCleanroom(_ context.Context, req controlapi.TerminateCleanroomRequest) (*controlapi.TerminateCleanroomResponse, error) {
+	cleanroomID := strings.TrimSpace(req.CleanroomID)
+	if cleanroomID == "" {
+		return nil, errors.New("missing cleanroom_id")
+	}
+
+	s.mu.Lock()
+	state, ok := s.cleanrooms[cleanroomID]
+	if ok {
+		delete(s.cleanrooms, cleanroomID)
+	}
+	s.mu.Unlock()
+	if !ok {
+		return nil, fmt.Errorf("unknown cleanroom %q", cleanroomID)
+	}
+
+	if s.Logger != nil {
+		s.Logger.Info("cleanroom terminated",
+			"cleanroom_id", cleanroomID,
+			"backend", state.Backend,
+			"last_run_id", state.LastExecutionRun,
+		)
+	}
+
+	return &controlapi.TerminateCleanroomResponse{
+		CleanroomID: cleanroomID,
+		Terminated:  true,
+		Message:     "cleanroom terminated",
+	}, nil
 }
 
 func (s *Service) Exec(ctx context.Context, req controlapi.ExecRequest) (*controlapi.ExecResponse, error) {
@@ -118,19 +305,17 @@ func resolveBackendName(requested, configuredDefault string) string {
 
 func mergeFirecrackerConfig(cwd string, opts controlapi.ExecOptions, cfg runtimeconfig.Config) backend.FirecrackerConfig {
 	out := backend.FirecrackerConfig{
-		BinaryPath:       cfg.Backends.Firecracker.BinaryPath,
-		KernelImagePath:  cfg.Backends.Firecracker.KernelImage,
-		RootFSPath:       cfg.Backends.Firecracker.RootFS,
-		WorkspaceHost:    cwd,
-		WorkspaceMode:    resolveWorkspaceMode(cfg.Workspace.Mode),
-		WorkspacePersist: resolveWorkspacePersist(cfg.Workspace.Persist),
-		WorkspaceAccess:  resolveWorkspaceAccess(opts, cfg.Workspace.Access),
-		VCPUs:            cfg.Backends.Firecracker.VCPUs,
-		MemoryMiB:        cfg.Backends.Firecracker.MemoryMiB,
-		GuestCID:         cfg.Backends.Firecracker.GuestCID,
-		GuestPort:        cfg.Backends.Firecracker.GuestPort,
-		RetainWrites:     cfg.Backends.Firecracker.RetainWrites,
-		LaunchSeconds:    cfg.Backends.Firecracker.LaunchSeconds,
+		BinaryPath:      cfg.Backends.Firecracker.BinaryPath,
+		KernelImagePath: cfg.Backends.Firecracker.KernelImage,
+		RootFSPath:      cfg.Backends.Firecracker.RootFS,
+		WorkspaceHost:   cwd,
+		WorkspaceAccess: resolveWorkspaceAccess(opts, cfg.Workspace.Access),
+		VCPUs:           cfg.Backends.Firecracker.VCPUs,
+		MemoryMiB:       cfg.Backends.Firecracker.MemoryMiB,
+		GuestCID:        cfg.Backends.Firecracker.GuestCID,
+		GuestPort:       cfg.Backends.Firecracker.GuestPort,
+		RetainWrites:    cfg.Backends.Firecracker.RetainWrites,
+		LaunchSeconds:   cfg.Backends.Firecracker.LaunchSeconds,
 	}
 
 	if opts.RunDir != "" {
@@ -156,20 +341,4 @@ func resolveWorkspaceAccess(execCfg controlapi.ExecOptions, configured string) s
 		access = "ro"
 	}
 	return access
-}
-
-func resolveWorkspaceMode(configured string) string {
-	mode := configured
-	if mode == "" {
-		mode = "copy"
-	}
-	return mode
-}
-
-func resolveWorkspacePersist(configured string) string {
-	persist := configured
-	if persist == "" {
-		persist = "discard"
-	}
-	return persist
 }

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -2,6 +2,7 @@ package controlservice
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/buildkite/cleanroom/internal/backend"
@@ -10,15 +11,27 @@ import (
 )
 
 type stubAdapter struct {
-	result *backend.RunResult
-	req    backend.RunRequest
+	result   *backend.RunResult
+	req      backend.RunRequest
+	runCalls int
 }
 
 func (s *stubAdapter) Name() string { return "stub" }
 
 func (s *stubAdapter) Run(_ context.Context, req backend.RunRequest) (*backend.RunResult, error) {
 	s.req = req
-	return s.result, nil
+	s.runCalls++
+	if s.result != nil {
+		return s.result, nil
+	}
+	return &backend.RunResult{
+		RunID:      req.RunID,
+		ExitCode:   0,
+		LaunchedVM: true,
+		PlanPath:   "/tmp/plan",
+		RunDir:     "/tmp/run",
+		Message:    "ok",
+	}, nil
 }
 
 type stubLoader struct {
@@ -66,5 +79,70 @@ func TestExecForwardsBackendOutput(t *testing.T) {
 	}
 	if resp.Stderr != "hello stderr\n" {
 		t.Fatalf("expected stderr to be forwarded, got %q", resp.Stderr)
+	}
+}
+
+func TestLaunchRunTerminateLifecycle(t *testing.T) {
+	adapter := &stubAdapter{}
+	svc := &Service{
+		Loader: stubLoader{
+			compiled: &policy.CompiledPolicy{Hash: "hash-1", NetworkDefault: "deny"},
+			source:   "/repo/cleanroom.yaml",
+		},
+		Backends: map[string]backend.Adapter{"firecracker": adapter},
+	}
+
+	launchResp, err := svc.LaunchCleanroom(context.Background(), controlapi.LaunchCleanroomRequest{
+		CWD: "/repo",
+		Options: controlapi.LaunchCleanroomOptions{
+			RunDir: "/tmp/cleanrooms",
+		},
+	})
+	if err != nil {
+		t.Fatalf("LaunchCleanroom returned error: %v", err)
+	}
+	if launchResp.CleanroomID == "" {
+		t.Fatal("expected cleanroom_id to be set")
+	}
+	if launchResp.PolicyHash != "hash-1" {
+		t.Fatalf("unexpected policy hash: %q", launchResp.PolicyHash)
+	}
+
+	runResp, err := svc.RunCleanroom(context.Background(), controlapi.RunCleanroomRequest{
+		CleanroomID: launchResp.CleanroomID,
+		Command:     []string{"--", "pi", "run", "fix tests"},
+	})
+	if err != nil {
+		t.Fatalf("RunCleanroom returned error: %v", err)
+	}
+	if runResp.CleanroomID != launchResp.CleanroomID {
+		t.Fatalf("unexpected cleanroom id: got %q want %q", runResp.CleanroomID, launchResp.CleanroomID)
+	}
+	if got := adapter.req.Command[0]; got != "pi" {
+		t.Fatalf("expected normalized command to start with pi, got %q", got)
+	}
+	if !strings.HasPrefix(adapter.req.RunDir, "/tmp/cleanrooms/") {
+		t.Fatalf("expected run dir under run root, got %q", adapter.req.RunDir)
+	}
+	if adapter.runCalls != 1 {
+		t.Fatalf("expected exactly one run call, got %d", adapter.runCalls)
+	}
+
+	terminateResp, err := svc.TerminateCleanroom(context.Background(), controlapi.TerminateCleanroomRequest{
+		CleanroomID: launchResp.CleanroomID,
+	})
+	if err != nil {
+		t.Fatalf("TerminateCleanroom returned error: %v", err)
+	}
+	if !terminateResp.Terminated {
+		t.Fatal("expected terminated=true")
+	}
+
+	_, err = svc.RunCleanroom(context.Background(), controlapi.RunCleanroomRequest{
+		CleanroomID: launchResp.CleanroomID,
+		Command:     []string{"echo", "should fail"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "unknown cleanroom") {
+		t.Fatalf("expected unknown cleanroom error after terminate, got %v", err)
 	}
 }

--- a/internal/runtimeconfig/config.go
+++ b/internal/runtimeconfig/config.go
@@ -17,9 +17,7 @@ type Config struct {
 }
 
 type Workspace struct {
-	Mode    string `yaml:"mode"`    // copy|mount
-	Persist string `yaml:"persist"` // discard|commit
-	Access  string `yaml:"access"`  // rw|ro
+	Access string `yaml:"access"` // rw|ro
 }
 
 type Backends struct {
@@ -71,14 +69,6 @@ func Load() (Config, string, error) {
 	}
 
 	cfg.DefaultBackend = strings.TrimSpace(cfg.DefaultBackend)
-	cfg.Workspace.Mode = strings.TrimSpace(strings.ToLower(cfg.Workspace.Mode))
-	if cfg.Workspace.Mode == "" {
-		cfg.Workspace.Mode = "copy"
-	}
-	cfg.Workspace.Persist = strings.TrimSpace(strings.ToLower(cfg.Workspace.Persist))
-	if cfg.Workspace.Persist == "" {
-		cfg.Workspace.Persist = "discard"
-	}
 	cfg.Workspace.Access = strings.TrimSpace(strings.ToLower(cfg.Workspace.Access))
 	if cfg.Workspace.Access == "" {
 		cfg.Workspace.Access = "rw"


### PR DESCRIPTION
## Summary
- add explicit cleanroom lifecycle endpoints for launch/run/terminate:
  - `POST /v1/cleanrooms/launch`
  - `POST /v1/cleanrooms/run`
  - `POST /v1/cleanrooms/terminate`
- wire new request/response types through control API, service, server, and client
- simplify workspace config by removing copy/discard mode/persist surfaces
- keep `/v1/exec` as a compatibility path
- rewrite README to be API-first and Firecracker-focused

## Why
- reduce complexity by dropping copy/discard API surface
- expose a direct API model for agent workflows (`launch -> run -> terminate`)
- keep the implementation centered on Firecracker isolation and run observability

## Validation
- `go test ./...`
