### PR TITLE
Remove workspace snapshot/reuse docs and retain_writes config

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,17 +170,16 @@ backends:
     memory_mib: 1024
     guest_cid: 3
     launch_seconds: 30
-    retain_writes: false
 ```
 
 ## Isolation Model
 
 - Workload runs in a Firecracker microVM
-- Workspace is snapshotted per run and sent to the guest agent
+- Workspace is copied per run and sent to the guest agent
 - Workspace can be read-only (`workspace.access: ro` or request override)
 - Host egress is controlled with TAP + iptables rules from compiled policy
 - Default network behavior is deny
-- Rootfs writes are ephemeral by default (`retain_writes: false`)
+- Rootfs writes are discarded after each run
 
 ## Performance Notes
 

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -20,20 +20,19 @@ type RunRequest struct {
 }
 
 type FirecrackerConfig struct {
-	BinaryPath       string
-	KernelImagePath  string
-	RootFSPath       string
-	RunDir           string
-	WorkspaceHost    string
-	WorkspaceAccess  string // rw|ro
-	VCPUs            int64
-	MemoryMiB        int64
-	GuestCID         uint32
-	GuestPort        uint32
-	RetainWrites     bool
-	HostPassthrough  bool
-	Launch           bool
-	LaunchSeconds    int64
+	BinaryPath      string
+	KernelImagePath string
+	RootFSPath      string
+	RunDir          string
+	WorkspaceHost   string
+	WorkspaceAccess string // rw|ro
+	VCPUs           int64
+	MemoryMiB       int64
+	GuestCID        uint32
+	GuestPort       uint32
+	HostPassthrough bool
+	Launch          bool
+	LaunchSeconds   int64
 }
 
 type RunResult struct {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -354,7 +354,6 @@ func mergeFirecrackerConfig(cwd string, e *ExecCommand, cfg runtimeconfig.Config
 		MemoryMiB:       cfg.Backends.Firecracker.MemoryMiB,
 		GuestCID:        cfg.Backends.Firecracker.GuestCID,
 		GuestPort:       cfg.Backends.Firecracker.GuestPort,
-		RetainWrites:    cfg.Backends.Firecracker.RetainWrites,
 		LaunchSeconds:   cfg.Backends.Firecracker.LaunchSeconds,
 	}
 

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -314,7 +314,6 @@ func mergeFirecrackerConfig(cwd string, opts controlapi.ExecOptions, cfg runtime
 		MemoryMiB:       cfg.Backends.Firecracker.MemoryMiB,
 		GuestCID:        cfg.Backends.Firecracker.GuestCID,
 		GuestPort:       cfg.Backends.Firecracker.GuestPort,
-		RetainWrites:    cfg.Backends.Firecracker.RetainWrites,
 		LaunchSeconds:   cfg.Backends.Firecracker.LaunchSeconds,
 	}
 

--- a/internal/runtimeconfig/config.go
+++ b/internal/runtimeconfig/config.go
@@ -32,7 +32,6 @@ type FirecrackerConfig struct {
 	MemoryMiB     int64  `yaml:"memory_mib"`
 	GuestCID      uint32 `yaml:"guest_cid"`
 	GuestPort     uint32 `yaml:"guest_port"`
-	RetainWrites  bool   `yaml:"retain_writes"`
 	LaunchSeconds int64  `yaml:"launch_seconds"` // VM boot/guest-agent readiness timeout
 }
 


### PR DESCRIPTION
## Summary
- update README exec examples to remove stale workspace snapshot/reuse references
- clarify launched runs start from a fresh workspace copy each time
- remove retain_writes from runtime config and backend wiring
- make launched firecracker runs always use ephemeral rootfs and discard writes

## Validation
- mise exec -- go test ./...