### PR TITLE
Add interactive console command via AttachExecution

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,12 @@ require (
 	connectrpc.com/connect v1.18.1
 	github.com/alecthomas/kong v1.12.1
 	github.com/charmbracelet/log v0.4.2
+	github.com/creack/pty v1.1.24
 	github.com/firecracker-microvm/firecracker-go-sdk v1.0.0
 	github.com/mdlayher/vsock v1.1.1
-	golang.org/x/sys v0.31.0
+	golang.org/x/net v0.38.0
+	golang.org/x/sys v0.32.0
+	golang.org/x/term v0.31.0
 	google.golang.org/protobuf v1.36.10
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -30,6 +33,6 @@ require (
 	github.com/sirupsen/logrus v1.8.3 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
-	golang.org/x/net v0.38.0 // indirect
-	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
+	golang.org/x/sync v0.12.0 // indirect
+	golang.org/x/text v0.23.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -224,6 +224,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:ma
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
+github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
 github.com/d2g/dhcp4 v0.0.0-20170904100407-a1d1b6c41b1c/go.mod h1:Ct2BUK8SB0YC1SMSibvLzxjeJLnrYEVLULFNiHY9YfQ=
 github.com/d2g/dhcp4client v1.0.0/go.mod h1:j0hNfjhrt2SxUOw55nL0ATM/z4Yt3t2Kd1mW34z5W5s=
@@ -823,8 +825,9 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.12.0 h1:MHc5BpPuC30uJk597Ri8TV3CNZcTLu6B6z4lJy+g6Jw=
+golang.org/x/sync v0.12.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -899,11 +902,13 @@ golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220204135822-1c1b9b1eba6a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
-golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/sys v0.32.0 h1:s77OFDvIQeibCmezSnk/q6iAfkdiQaJi4VzroCFrN20=
+golang.org/x/sys v0.32.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+golang.org/x/term v0.31.0 h1:erwDkOK1Msy6offm1mOgvspSkslFnIGsFnxOKoufg3o=
+golang.org/x/term v0.31.0/go.mod h1:R4BeIy7D95HzImkxGkTW1UQTtP54tio2RyHz7PwK0aw=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -11,9 +11,15 @@ type Adapter interface {
 	Run(ctx context.Context, req RunRequest) (*RunResult, error)
 }
 
+type AttachIO struct {
+	WriteStdin func([]byte) error
+	ResizeTTY  func(cols, rows uint32) error
+}
+
 type OutputStream struct {
 	OnStdout func([]byte)
 	OnStderr func([]byte)
+	OnAttach func(AttachIO)
 }
 
 // StreamingAdapter can push stdout/stderr chunks while a command is running.
@@ -27,6 +33,7 @@ type RunRequest struct {
 	RunID   string
 	CWD     string
 	Command []string
+	TTY     bool
 	Policy  *policy.CompiledPolicy
 	FirecrackerConfig
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -83,7 +83,7 @@ type ConsoleCommand struct {
 	HostPassthrough   bool   `default:"true" help:"Run command directly on host instead of launching a backend (unsafe, not sandboxed)"`
 	LaunchSeconds     int64  `help:"VM boot/guest-agent readiness timeout in seconds"`
 
-	Command []string `arg:"" passthrough:"" help:"Command to run in the console (default: sh)"`
+	Command []string `arg:"" passthrough:"" optional:"" help:"Command to run in the console (default: sh)"`
 }
 
 type ServeCommand struct {

--- a/internal/cli/cli_parse_test.go
+++ b/internal/cli/cli_parse_test.go
@@ -1,0 +1,47 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/alecthomas/kong"
+)
+
+func newParserForTest(t *testing.T, c *CLI) *kong.Kong {
+	t.Helper()
+
+	parser, err := kong.New(
+		c,
+		kong.Name("cleanroom"),
+		kong.Description("Cleanroom CLI (MVP)"),
+	)
+	if err != nil {
+		t.Fatalf("create parser: %v", err)
+	}
+	return parser
+}
+
+func TestConsoleCommandAllowsNoCommandArgs(t *testing.T) {
+	c := &CLI{}
+	parser := newParserForTest(t, c)
+
+	if _, err := parser.Parse([]string{"console"}); err != nil {
+		t.Fatalf("parse console with no command returned error: %v", err)
+	}
+	if got := len(c.Console.Command); got != 0 {
+		t.Fatalf("expected no explicit command args, got %v", c.Console.Command)
+	}
+}
+
+func TestExecCommandStillRequiresArgs(t *testing.T) {
+	c := &CLI{}
+	parser := newParserForTest(t, c)
+
+	_, err := parser.Parse([]string{"exec"})
+	if err == nil {
+		t.Fatal("expected parse error for missing exec command")
+	}
+	if !strings.Contains(err.Error(), "<command>") {
+		t.Fatalf("expected missing command parse error, got %v", err)
+	}
+}

--- a/internal/cli/console_integration_test.go
+++ b/internal/cli/console_integration_test.go
@@ -1,0 +1,201 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+)
+
+func runConsoleWithCapture(cmd ConsoleCommand, stdinData string, ctx runtimeContext) execOutcome {
+	tmpDir, err := os.MkdirTemp("", "cleanroom-console-test-*")
+	if err != nil {
+		return execOutcome{cause: fmt.Errorf("create temp dir: %w", err)}
+	}
+	defer os.RemoveAll(tmpDir)
+
+	stdoutPath := filepath.Join(tmpDir, "stdout.log")
+	stderrPath := filepath.Join(tmpDir, "stderr.log")
+
+	stdoutFile, err := os.Create(stdoutPath)
+	if err != nil {
+		return execOutcome{cause: fmt.Errorf("create stdout capture file: %w", err)}
+	}
+	defer stdoutFile.Close()
+
+	stderrFile, err := os.Create(stderrPath)
+	if err != nil {
+		return execOutcome{cause: fmt.Errorf("create stderr capture file: %w", err)}
+	}
+	defer stderrFile.Close()
+
+	stdinReader, stdinWriter, err := os.Pipe()
+	if err != nil {
+		return execOutcome{cause: fmt.Errorf("create stdin pipe: %w", err)}
+	}
+	if stdinData != "" {
+		if _, err := io.WriteString(stdinWriter, stdinData); err != nil {
+			return execOutcome{cause: fmt.Errorf("write stdin payload: %w", err)}
+		}
+	}
+	_ = stdinWriter.Close()
+	defer stdinReader.Close()
+
+	oldStdin := os.Stdin
+	oldStderr := os.Stderr
+	os.Stdin = stdinReader
+	os.Stderr = stderrFile
+	defer func() {
+		os.Stdin = oldStdin
+		os.Stderr = oldStderr
+	}()
+
+	ctx.Stdout = stdoutFile
+	runErr := cmd.Run(&ctx)
+
+	if err := stdoutFile.Sync(); err != nil {
+		return execOutcome{cause: fmt.Errorf("sync stdout capture: %w", err)}
+	}
+	if err := stderrFile.Sync(); err != nil {
+		return execOutcome{cause: fmt.Errorf("sync stderr capture: %w", err)}
+	}
+
+	stdoutBytes, err := os.ReadFile(stdoutPath)
+	if err != nil {
+		return execOutcome{cause: fmt.Errorf("read stdout capture: %w", err)}
+	}
+	stderrBytes, err := os.ReadFile(stderrPath)
+	if err != nil {
+		return execOutcome{cause: fmt.Errorf("read stderr capture: %w", err)}
+	}
+
+	return execOutcome{
+		err:    runErr,
+		stdout: string(stdoutBytes),
+		stderr: string(stderrBytes),
+	}
+}
+
+func TestConsoleIntegrationForwardsStdinAndStreamsOutput(t *testing.T) {
+	started := make(chan struct{}, 1)
+	var captured bytes.Buffer
+	adapter := &integrationAdapter{
+		runStreamFn: func(ctx context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+			if !req.TTY {
+				return nil, errors.New("expected tty execution")
+			}
+
+			done := make(chan struct{})
+			if stream.OnAttach != nil {
+				stream.OnAttach(backend.AttachIO{
+					WriteStdin: func(data []byte) error {
+						captured.Write(data)
+						if stream.OnStdout != nil {
+							stream.OnStdout(data)
+						}
+						if bytes.Contains(captured.Bytes(), []byte("exit\n")) {
+							select {
+							case <-done:
+							default:
+								close(done)
+							}
+						}
+						return nil
+					},
+				})
+			}
+			select {
+			case started <- struct{}{}:
+			default:
+			}
+
+			select {
+			case <-done:
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+			return &backend.RunResult{
+				RunID:    req.RunID,
+				ExitCode: 0,
+				Stdout:   captured.String(),
+				Message:  "ok",
+			}, nil
+		},
+	}
+
+	host, _ := startIntegrationServer(t, adapter)
+	outcome := runConsoleWithCapture(ConsoleCommand{
+		Host: host,
+		// Console defaults to host passthrough for this MVP.
+		Command: []string{"sh"},
+	}, "hello\nexit\n", runtimeContext{
+		CWD: t.TempDir(),
+	})
+
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err != nil {
+		t.Fatalf("ConsoleCommand.Run returned error: %v", outcome.err)
+	}
+	if !strings.Contains(captured.String(), "hello\nexit\n") {
+		t.Fatalf("expected stdin to be forwarded to backend, got %q", captured.String())
+	}
+	if !strings.Contains(outcome.stdout, "hello\n") || !strings.Contains(outcome.stdout, "exit\n") {
+		t.Fatalf("expected streamed output to include echoed stdin, got %q", outcome.stdout)
+	}
+	_ = mustReceiveWithin(t, started, 2*time.Second, "timed out waiting for console execution to start")
+}
+
+func TestConsoleIntegrationInterruptCancelsExecution(t *testing.T) {
+	started := make(chan struct{}, 1)
+	adapter := &integrationAdapter{
+		runStreamFn: func(ctx context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+			if stream.OnAttach != nil {
+				stream.OnAttach(backend.AttachIO{
+					WriteStdin: func(_ []byte) error { return nil },
+				})
+			}
+			select {
+			case started <- struct{}{}:
+			default:
+			}
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+
+	host, _ := startIntegrationServer(t, adapter)
+	signalCh := withTestSignalChannel(t)
+
+	done := make(chan execOutcome, 1)
+	go func() {
+		done <- runConsoleWithCapture(ConsoleCommand{
+			Host: host,
+		}, "", runtimeContext{
+			CWD: t.TempDir(),
+		})
+	}()
+
+	_ = mustReceiveWithin(t, started, 2*time.Second, "timed out waiting for console execution to start")
+	signalCh <- os.Interrupt
+
+	outcome := mustReceiveWithin(t, done, 2*time.Second, "timed out waiting for interrupted console to exit")
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err == nil {
+		t.Fatal("expected non-zero exit from interrupted console")
+	}
+	if got, want := ExitCode(outcome.err), 130; got != want {
+		t.Fatalf("unexpected console exit code: got %d want %d (err=%v)", got, want, outcome.err)
+	}
+}

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -70,6 +70,8 @@ type executionState struct {
 	CancelRequested  bool
 	CancelSignal     int32
 	Cancel           context.CancelFunc
+	AttachStdin      func([]byte) error
+	AttachResize     func(cols, rows uint32) error
 	EventHistory     []*cleanroomv1.ExecutionStreamEvent
 	EventSubscribers map[int]chan *cleanroomv1.ExecutionStreamEvent
 	NextSubID        int
@@ -95,6 +97,9 @@ var (
 	maxRetainedStoppedSandboxes   = 256
 	maxRetainedFinishedExecutions = 2048
 	retainedStateMaxAge           = 24 * time.Hour
+
+	ErrExecutionStdinUnsupported  = errors.New("execution stdin attach is not supported by the current backend")
+	ErrExecutionResizeUnsupported = errors.New("execution resize is not supported by the current backend")
 )
 
 func (s *Service) CreateSandbox(_ context.Context, req *cleanroomv1.CreateSandboxRequest) (*cleanroomv1.CreateSandboxResponse, error) {
@@ -504,6 +509,69 @@ func (s *Service) CancelExecution(_ context.Context, req *cleanroomv1.CancelExec
 	}, nil
 }
 
+func (s *Service) WriteExecutionStdin(sandboxID, executionID string, data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
+	sandboxID = strings.TrimSpace(sandboxID)
+	executionID = strings.TrimSpace(executionID)
+	if sandboxID == "" {
+		return errors.New("missing sandbox_id")
+	}
+	if executionID == "" {
+		return errors.New("missing execution_id")
+	}
+
+	var writeFn func([]byte) error
+	s.mu.RLock()
+	ex, ok := s.executions[executionKey(sandboxID, executionID)]
+	if !ok {
+		s.mu.RUnlock()
+		return fmt.Errorf("unknown execution %q in sandbox %q", executionID, sandboxID)
+	}
+	if isFinalExecutionStatus(ex.Status) {
+		s.mu.RUnlock()
+		return errors.New("execution is not running")
+	}
+	writeFn = ex.AttachStdin
+	s.mu.RUnlock()
+
+	if writeFn == nil {
+		return ErrExecutionStdinUnsupported
+	}
+	return writeFn(append([]byte(nil), data...))
+}
+
+func (s *Service) ResizeExecutionTTY(sandboxID, executionID string, cols, rows uint32) error {
+	sandboxID = strings.TrimSpace(sandboxID)
+	executionID = strings.TrimSpace(executionID)
+	if sandboxID == "" {
+		return errors.New("missing sandbox_id")
+	}
+	if executionID == "" {
+		return errors.New("missing execution_id")
+	}
+
+	var resizeFn func(cols, rows uint32) error
+	s.mu.RLock()
+	ex, ok := s.executions[executionKey(sandboxID, executionID)]
+	if !ok {
+		s.mu.RUnlock()
+		return fmt.Errorf("unknown execution %q in sandbox %q", executionID, sandboxID)
+	}
+	if isFinalExecutionStatus(ex.Status) {
+		s.mu.RUnlock()
+		return errors.New("execution is not running")
+	}
+	resizeFn = ex.AttachResize
+	s.mu.RUnlock()
+
+	if resizeFn == nil {
+		return ErrExecutionResizeUnsupported
+	}
+	return resizeFn(cols, rows)
+}
+
 func (s *Service) SubscribeSandboxEvents(sandboxID string) ([]*cleanroomv1.SandboxEvent, <-chan *cleanroomv1.SandboxEvent, <-chan struct{}, func(), error) {
 	sandboxID = strings.TrimSpace(sandboxID)
 	if sandboxID == "" {
@@ -765,6 +833,7 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 		RunID:             ex.RunID,
 		CWD:               ex.CWD,
 		Command:           append([]string(nil), ex.Command...),
+		TTY:               ex.TTY,
 		Policy:            sb.Policy,
 		FirecrackerConfig: firecrackerCfg,
 	}
@@ -782,6 +851,9 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 			OnStderr: func(chunk []byte) {
 				s.recordExecutionOutputChunk(key, false, chunk)
 			},
+			OnAttach: func(io backend.AttachIO) {
+				s.setExecutionAttachIO(key, io)
+			},
 		})
 	} else {
 		result, err = adapter.Run(runCtx, runReq)
@@ -797,6 +869,7 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 	if ex.Cancel != nil {
 		ex.Cancel = nil
 	}
+	clearExecutionAttachIOLocked(ex)
 
 	if err != nil {
 		finalStatus := cleanroomv1.ExecutionStatus_EXECUTION_STATUS_FAILED
@@ -1139,6 +1212,26 @@ func closeExecutionDoneLocked(ex *executionState) {
 	}
 	close(ex.Done)
 	ex.DoneClosed = true
+}
+
+func clearExecutionAttachIOLocked(ex *executionState) {
+	if ex == nil {
+		return
+	}
+	ex.AttachStdin = nil
+	ex.AttachResize = nil
+}
+
+func (s *Service) setExecutionAttachIO(key string, io backend.AttachIO) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	ex, ok := s.executions[key]
+	if !ok || ex == nil || isFinalExecutionStatus(ex.Status) {
+		return
+	}
+	ex.AttachStdin = io.WriteStdin
+	ex.AttachResize = io.ResizeTTY
 }
 
 func closeSandboxSubscribersLocked(sb *sandboxState) {

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -429,6 +429,152 @@ func TestCancelExecutionTransitionsToCanceled(t *testing.T) {
 	}
 }
 
+func TestExecutionAttachIOForwarding(t *testing.T) {
+	started := make(chan struct{}, 1)
+	stdinChunks := make(chan string, 1)
+	resizes := make(chan [2]uint32, 1)
+	adapter := &stubAdapter{
+		runStreamFn: func(ctx context.Context, _ backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+			if stream.OnAttach != nil {
+				stream.OnAttach(backend.AttachIO{
+					WriteStdin: func(data []byte) error {
+						stdinChunks <- string(data)
+						return nil
+					},
+					ResizeTTY: func(cols, rows uint32) error {
+						resizes <- [2]uint32{cols, rows}
+						return nil
+					},
+				})
+			}
+			select {
+			case started <- struct{}{}:
+			default:
+			}
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+	svc := newTestService(adapter)
+
+	createSandboxResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Cwd: "/repo"})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createSandboxResp.GetSandbox().GetSandboxId()
+
+	createExecutionResp, err := svc.CreateExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
+		SandboxId: sandboxID,
+		Command:   []string{"sh"},
+		Options: &cleanroomv1.ExecutionOptions{
+			Tty: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateExecution returned error: %v", err)
+	}
+	executionID := createExecutionResp.GetExecution().GetExecutionId()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for execution to start")
+	}
+
+	if err := svc.WriteExecutionStdin(sandboxID, executionID, []byte("hello\n")); err != nil {
+		t.Fatalf("WriteExecutionStdin returned error: %v", err)
+	}
+	if err := svc.ResizeExecutionTTY(sandboxID, executionID, 120, 40); err != nil {
+		t.Fatalf("ResizeExecutionTTY returned error: %v", err)
+	}
+
+	select {
+	case got := <-stdinChunks:
+		if got != "hello\n" {
+			t.Fatalf("unexpected stdin payload: got %q want %q", got, "hello\n")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for stdin callback")
+	}
+
+	select {
+	case got := <-resizes:
+		if got != [2]uint32{120, 40} {
+			t.Fatalf("unexpected resize payload: got %v", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for resize callback")
+	}
+
+	if _, err := svc.CancelExecution(context.Background(), &cleanroomv1.CancelExecutionRequest{
+		SandboxId:   sandboxID,
+		ExecutionId: executionID,
+		Signal:      2,
+	}); err != nil {
+		t.Fatalf("CancelExecution returned error: %v", err)
+	}
+	if _, err := svc.WaitExecution(context.Background(), sandboxID, executionID); err != nil {
+		t.Fatalf("WaitExecution returned error: %v", err)
+	}
+}
+
+func TestExecutionAttachIOUnsupportedWhenBackendDoesNotExposeHandlers(t *testing.T) {
+	started := make(chan struct{}, 1)
+	adapter := &stubAdapter{
+		runStreamFn: func(ctx context.Context, _ backend.RunRequest, _ backend.OutputStream) (*backend.RunResult, error) {
+			select {
+			case started <- struct{}{}:
+			default:
+			}
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+	svc := newTestService(adapter)
+
+	createSandboxResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Cwd: "/repo"})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createSandboxResp.GetSandbox().GetSandboxId()
+
+	createExecutionResp, err := svc.CreateExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
+		SandboxId: sandboxID,
+		Command:   []string{"sh"},
+		Options: &cleanroomv1.ExecutionOptions{
+			Tty: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateExecution returned error: %v", err)
+	}
+	executionID := createExecutionResp.GetExecution().GetExecutionId()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for execution to start")
+	}
+
+	if err := svc.WriteExecutionStdin(sandboxID, executionID, []byte("hello\n")); !errors.Is(err, ErrExecutionStdinUnsupported) {
+		t.Fatalf("expected ErrExecutionStdinUnsupported, got %v", err)
+	}
+	if err := svc.ResizeExecutionTTY(sandboxID, executionID, 80, 24); !errors.Is(err, ErrExecutionResizeUnsupported) {
+		t.Fatalf("expected ErrExecutionResizeUnsupported, got %v", err)
+	}
+
+	if _, err := svc.CancelExecution(context.Background(), &cleanroomv1.CancelExecutionRequest{
+		SandboxId:   sandboxID,
+		ExecutionId: executionID,
+		Signal:      2,
+	}); err != nil {
+		t.Fatalf("CancelExecution returned error: %v", err)
+	}
+	if _, err := svc.WaitExecution(context.Background(), sandboxID, executionID); err != nil {
+		t.Fatalf("WaitExecution returned error: %v", err)
+	}
+}
+
 func TestTerminateRetainsStoppedSandboxState(t *testing.T) {
 	svc := newTestService(&stubAdapter{})
 


### PR DESCRIPTION
## Summary
Adds a working `cleanroom console` command backed by `ExecutionService.AttachExecution`, with attach input plumbing for stdin/resize and host-passthrough TTY support.

This PR is stacked on top of #14 (`feat/connectrpc-streaming-signals`).

## What changed
- CLI:
  - added `cleanroom console` command
  - creates sandbox + tty execution, attaches bidi stream, forwards stdin/stdout/stderr, and sends signals
- Service/server attach path:
  - added execution attach IO handlers in service state
  - implemented stdin + resize forwarding from `AttachExecution` frames
  - retained signal behavior via `CancelExecution`
- Backend:
  - extended `backend.OutputStream` with attach callbacks (`AttachIO`)
  - pass `TTY` in `backend.RunRequest`
  - firecracker adapter host-passthrough path now supports interactive TTY via PTY
- Transport:
  - enabled h2c handling on control server handler
  - switched control client to HTTP/2/h2c transport for bidi attach support
- Tests:
  - `internal/cli/console_integration_test.go` for console stdin/output and interrupt cancel
  - new service tests for attach stdin/resize forwarding and unsupported behavior

## Validation
- `go test ./...`
- `go vet ./...`
- manual check:
  - `go run ./cmd/cleanroom serve --listen unix:///tmp/cleanroom-console.sock`
  - `printf 'hello\n' | go run ./cmd/cleanroom console --host unix:///tmp/cleanroom-console.sock -- sh -lc 'read line; echo got:$line'`
