### PR TITLE
fix: remote execution issues (cwd, tsnet, guest_cid, error streaming)

### DIFF
--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -49,7 +49,6 @@ type FirecrackerConfig struct {
 	MemoryMiB       int64
 	GuestCID        uint32
 	GuestPort       uint32
-	HostPassthrough bool
 	Launch          bool
 	LaunchSeconds   int64
 }

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -19,15 +19,12 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"sync"
-	"syscall"
 	"time"
 
 	"github.com/buildkite/cleanroom/internal/backend"
 	"github.com/buildkite/cleanroom/internal/paths"
 	"github.com/buildkite/cleanroom/internal/policy"
 	"github.com/buildkite/cleanroom/internal/vsockexec"
-	"github.com/creack/pty"
 	fcvsock "github.com/firecracker-microvm/firecracker-go-sdk/vsock"
 )
 
@@ -227,50 +224,25 @@ func (a *Adapter) run(ctx context.Context, req backend.RunRequest, stream backen
 	}
 
 	if !req.Launch {
-		observation.Phase = "plan_or_host_passthrough"
-		planPath := filepath.Join(runDir, "passthrough-plan.json")
+		observation.Phase = "plan"
+		planPath := filepath.Join(runDir, "plan.json")
 		plan := map[string]any{
 			"backend":      "firecracker",
 			"mode":         "plan-only",
 			"command_path": cmdPath,
 		}
-		if req.HostPassthrough {
-			plan["mode"] = "host-passthrough"
-			plan["not_sandboxed"] = true
-		}
 		if err := writeJSON(planPath, plan); err != nil {
-			return nil, err
-		}
-
-		if !req.HostPassthrough {
-			observation.PlanPath = planPath
-			observation.RunDir = runDir
-			return &backend.RunResult{
-				RunID:      req.RunID,
-				ExitCode:   0,
-				LaunchedVM: false,
-				PlanPath:   planPath,
-				RunDir:     runDir,
-				Message:    "firecracker execution plan generated; command not executed (set --dry-run or --host-passthrough for non-launch modes)",
-			}, nil
-		}
-
-		exitCode, stdout, stderr, err := runHostPassthrough(ctx, req.CWD, req.Command, req.TTY, stream)
-		if err != nil {
 			return nil, err
 		}
 		observation.PlanPath = planPath
 		observation.RunDir = runDir
-		observation.ExitCode = exitCode
 		return &backend.RunResult{
 			RunID:      req.RunID,
-			ExitCode:   exitCode,
+			ExitCode:   0,
 			LaunchedVM: false,
 			PlanPath:   planPath,
 			RunDir:     runDir,
-			Message:    "host passthrough execution complete (not sandboxed)",
-			Stdout:     stdout,
-			Stderr:     stderr,
+			Message:    "firecracker execution plan generated; command not executed",
 		}, nil
 	}
 
@@ -284,7 +256,7 @@ func (a *Adapter) run(ctx context.Context, req backend.RunRequest, stream backen
 	}
 
 	if req.KernelImagePath == "" || req.RootFSPath == "" {
-		return nil, errors.New("kernel_image and rootfs must be configured for launched execution; use --dry-run or --host-passthrough for non-launch modes")
+		return nil, errors.New("kernel_image and rootfs must be configured for launched execution")
 	}
 	observation.Phase = "launch"
 
@@ -579,131 +551,6 @@ func copyFile(src, dst string) error {
 
 func runResultMessage(base string) string {
 	return base + "; rootfs writes discarded after run"
-}
-
-func runHostPassthrough(ctx context.Context, cwd string, command []string, tty bool, stream backend.OutputStream) (int, string, string, error) {
-	if tty {
-		return runHostPassthroughTTY(ctx, cwd, command, stream)
-	}
-
-	cmd := exec.CommandContext(ctx, command[0], command[1:]...)
-	cmd.Dir = cwd
-	stdoutPipe, err := cmd.StdoutPipe()
-	if err != nil {
-		return 1, "", "", fmt.Errorf("prepare stdout pipe: %w", err)
-	}
-	stderrPipe, err := cmd.StderrPipe()
-	if err != nil {
-		return 1, "", "", fmt.Errorf("prepare stderr pipe: %w", err)
-	}
-	if err := cmd.Start(); err != nil {
-		return 1, "", "", fmt.Errorf("start host passthrough command: %w", err)
-	}
-
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	copyErrCh := make(chan error, 2)
-	var wg sync.WaitGroup
-	wg.Add(2)
-	go func() {
-		defer wg.Done()
-		_, copyErr := io.Copy(io.MultiWriter(&stdout, callbackWriter{cb: stream.OnStdout}), stdoutPipe)
-		copyErrCh <- copyErr
-	}()
-	go func() {
-		defer wg.Done()
-		_, copyErr := io.Copy(io.MultiWriter(&stderr, callbackWriter{cb: stream.OnStderr}), stderrPipe)
-		copyErrCh <- copyErr
-	}()
-
-	err = cmd.Wait()
-	wg.Wait()
-	close(copyErrCh)
-	for copyErr := range copyErrCh {
-		if copyErr != nil && err == nil {
-			err = copyErr
-		}
-	}
-
-	if err == nil {
-		return 0, stdout.String(), stderr.String(), nil
-	}
-
-	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) {
-		return exitErr.ExitCode(), stdout.String(), stderr.String(), nil
-	}
-	return 1, stdout.String(), stderr.String(), fmt.Errorf("run host passthrough command: %w", err)
-}
-
-func runHostPassthroughTTY(ctx context.Context, cwd string, command []string, stream backend.OutputStream) (int, string, string, error) {
-	cmd := exec.CommandContext(ctx, command[0], command[1:]...)
-	cmd.Dir = cwd
-
-	ptyFile, err := pty.Start(cmd)
-	if err != nil {
-		return 1, "", "", fmt.Errorf("start host passthrough tty command: %w", err)
-	}
-	defer ptyFile.Close()
-
-	if stream.OnAttach != nil {
-		stream.OnAttach(backend.AttachIO{
-			WriteStdin: func(data []byte) error {
-				if len(data) == 0 {
-					return nil
-				}
-				_, writeErr := ptyFile.Write(data)
-				return writeErr
-			},
-			ResizeTTY: func(cols, rows uint32) error {
-				if cols == 0 || rows == 0 {
-					return nil
-				}
-				return pty.Setsize(ptyFile, &pty.Winsize{
-					Cols: uint16(cols),
-					Rows: uint16(rows),
-				})
-			},
-		})
-	}
-
-	var stdout bytes.Buffer
-	copyDone := make(chan error, 1)
-	go func() {
-		_, copyErr := io.Copy(io.MultiWriter(&stdout, callbackWriter{cb: stream.OnStdout}), ptyFile)
-		copyDone <- copyErr
-	}()
-
-	err = cmd.Wait()
-	_ = ptyFile.Close()
-	copyErr := <-copyDone
-	if copyErr != nil && !expectedPTYReadError(copyErr) && err == nil {
-		err = copyErr
-	}
-
-	if err == nil {
-		return 0, stdout.String(), "", nil
-	}
-
-	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) {
-		return exitErr.ExitCode(), stdout.String(), "", nil
-	}
-	return 1, stdout.String(), "", fmt.Errorf("run host passthrough tty command: %w", err)
-}
-
-func expectedPTYReadError(err error) bool {
-	if err == nil {
-		return false
-	}
-	if errors.Is(err, io.EOF) {
-		return true
-	}
-	var pathErr *os.PathError
-	if errors.As(err, &pathErr) {
-		return errors.Is(pathErr.Err, syscall.EIO)
-	}
-	return errors.Is(err, syscall.EIO)
 }
 
 type guestExecTiming struct {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -208,13 +208,16 @@ func (e *ExecCommand) Run(ctx *runtimeContext) error {
 		return err
 	}
 
+	ep, err := endpoint.Resolve(e.Host)
+	if err != nil {
+		return err
+	}
 	cwd, err := resolveCWD(ctx.CWD, e.Chdir)
 	if err != nil {
 		return err
 	}
-	ep, err := endpoint.Resolve(e.Host)
-	if err != nil {
-		return err
+	if ep.Scheme != "unix" && e.Chdir == "" {
+		return fmt.Errorf("remote endpoint %q requires an explicit -c/--chdir flag (local cwd %q would not exist on the server)", ep.Address, cwd)
 	}
 	logger.Debug("sending execution request",
 		"endpoint", ep.Address,
@@ -409,13 +412,16 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) error {
 		return err
 	}
 
+	ep, err := endpoint.Resolve(c.Host)
+	if err != nil {
+		return err
+	}
 	cwd, err := resolveCWD(ctx.CWD, c.Chdir)
 	if err != nil {
 		return err
 	}
-	ep, err := endpoint.Resolve(c.Host)
-	if err != nil {
-		return err
+	if ep.Scheme != "unix" && c.Chdir == "" {
+		return fmt.Errorf("remote endpoint %q requires an explicit -c/--chdir flag (local cwd %q would not exist on the server)", ep.Address, cwd)
 	}
 	command := append([]string(nil), c.Command...)
 	if len(command) == 0 {
@@ -624,7 +630,7 @@ func (s *ServeCommand) Run(ctx *runtimeContext) error {
 		return err
 	}
 
-	ep, err := endpoint.Resolve(s.Listen)
+	ep, err := endpoint.ResolveListen(s.Listen)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -212,12 +212,21 @@ func (e *ExecCommand) Run(ctx *runtimeContext) error {
 	if err != nil {
 		return err
 	}
-	cwd, err := resolveCWD(ctx.CWD, e.Chdir)
-	if err != nil {
-		return err
-	}
-	if ep.Scheme != "unix" && e.Chdir == "" {
-		return fmt.Errorf("remote endpoint %q requires an explicit -c/--chdir flag (local cwd %q would not exist on the server)", ep.Address, cwd)
+	var cwd string
+	if ep.Scheme != "unix" {
+		if e.Chdir == "" {
+			return fmt.Errorf("remote endpoint %q requires an explicit -c/--chdir with an absolute path", ep.Address)
+		}
+		if !filepath.IsAbs(e.Chdir) {
+			return fmt.Errorf("remote endpoint %q requires an absolute -c/--chdir path, got %q", ep.Address, e.Chdir)
+		}
+		cwd = filepath.Clean(e.Chdir)
+	} else {
+		var err error
+		cwd, err = resolveCWD(ctx.CWD, e.Chdir)
+		if err != nil {
+			return err
+		}
 	}
 	logger.Debug("sending execution request",
 		"endpoint", ep.Address,
@@ -416,12 +425,21 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) error {
 	if err != nil {
 		return err
 	}
-	cwd, err := resolveCWD(ctx.CWD, c.Chdir)
-	if err != nil {
-		return err
-	}
-	if ep.Scheme != "unix" && c.Chdir == "" {
-		return fmt.Errorf("remote endpoint %q requires an explicit -c/--chdir flag (local cwd %q would not exist on the server)", ep.Address, cwd)
+	var cwd string
+	if ep.Scheme != "unix" {
+		if c.Chdir == "" {
+			return fmt.Errorf("remote endpoint %q requires an explicit -c/--chdir with an absolute path", ep.Address)
+		}
+		if !filepath.IsAbs(c.Chdir) {
+			return fmt.Errorf("remote endpoint %q requires an absolute -c/--chdir path, got %q", ep.Address, c.Chdir)
+		}
+		cwd = filepath.Clean(c.Chdir)
+	} else {
+		var err error
+		cwd, err = resolveCWD(ctx.CWD, c.Chdir)
+		if err != nil {
+			return err
+		}
 	}
 	command := append([]string(nil), c.Command...)
 	if len(command) == 0 {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -59,15 +59,12 @@ type PolicyValidateCommand struct {
 
 type ExecCommand struct {
 	Chdir    string `short:"c" help:"Change to this directory before running commands"`
-	Host     string `help:"Control-plane endpoint (unix://path, tsnet://hostname[:port], http://host:port, or https://host:port)"`
+	Host     string `help:"Control-plane endpoint (unix://path, http://host:port, or https://host:port)"`
 	LogLevel string `help:"Client log level (debug|info|warn|error)"`
 	Backend  string `help:"Execution backend (defaults to runtime config or firecracker)"`
 
-	RunDir            string `help:"Run directory for generated artifacts (default: XDG runtime/state cleanroom path)"`
-	ReadOnlyWorkspace bool   `help:"Mount workspace read-only for this run"`
-	DryRun            bool   `help:"Generate execution plan without running a backend command"`
-	HostPassthrough   bool   `help:"Run command directly on host instead of launching a backend (unsafe, not sandboxed)"`
-	LaunchSeconds     int64  `help:"VM boot/guest-agent readiness timeout in seconds"`
+	ReadOnlyWorkspace bool  `help:"Mount workspace read-only for this run"`
+	LaunchSeconds     int64 `help:"VM boot/guest-agent readiness timeout in seconds"`
 
 	Command []string `arg:"" passthrough:"" required:"" help:"Command to execute"`
 }
@@ -78,10 +75,8 @@ type ConsoleCommand struct {
 	LogLevel string `help:"Client log level (debug|info|warn|error)"`
 	Backend  string `help:"Execution backend (defaults to runtime config or firecracker)"`
 
-	RunDir            string `help:"Run directory for generated artifacts (default: XDG runtime/state cleanroom path)"`
-	ReadOnlyWorkspace bool   `help:"Mount workspace read-only for this run"`
-	HostPassthrough   bool   `default:"true" help:"Run command directly on host instead of launching a backend (unsafe, not sandboxed)"`
-	LaunchSeconds     int64  `help:"VM boot/guest-agent readiness timeout in seconds"`
+	ReadOnlyWorkspace bool  `help:"Mount workspace read-only for this run"`
+	LaunchSeconds     int64 `help:"VM boot/guest-agent readiness timeout in seconds"`
 
 	Command []string `arg:"" passthrough:"" optional:"" help:"Command to run in the console (default: sh)"`
 }
@@ -233,15 +228,12 @@ func (e *ExecCommand) Run(ctx *runtimeContext) error {
 		"cwd", cwd,
 		"backend", e.Backend,
 		"command_argc", len(e.Command),
-		"dry_run", e.DryRun,
-		"host_passthrough", e.HostPassthrough,
 	)
 	client := controlclient.New(ep)
 	createSandboxResp, err := client.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
 		Cwd:     cwd,
 		Backend: e.Backend,
 		Options: &cleanroomv1.SandboxOptions{
-			RunDir:            e.RunDir,
 			ReadOnlyWorkspace: e.ReadOnlyWorkspace,
 			LaunchSeconds:     e.LaunchSeconds,
 		},
@@ -263,10 +255,7 @@ func (e *ExecCommand) Run(ctx *runtimeContext) error {
 		SandboxId: sandboxID,
 		Command:   append([]string(nil), e.Command...),
 		Options: &cleanroomv1.ExecutionOptions{
-			RunDir:            e.RunDir,
 			ReadOnlyWorkspace: e.ReadOnlyWorkspace,
-			DryRun:            e.DryRun,
-			HostPassthrough:   e.HostPassthrough,
 			LaunchSeconds:     e.LaunchSeconds,
 			Cwd:               cwd,
 		},
@@ -450,7 +439,6 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) error {
 		"cwd", cwd,
 		"backend", c.Backend,
 		"command_argc", len(command),
-		"host_passthrough", c.HostPassthrough,
 	)
 
 	client := controlclient.New(ep)
@@ -458,7 +446,6 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) error {
 		Cwd:     cwd,
 		Backend: c.Backend,
 		Options: &cleanroomv1.SandboxOptions{
-			RunDir:            c.RunDir,
 			ReadOnlyWorkspace: c.ReadOnlyWorkspace,
 			LaunchSeconds:     c.LaunchSeconds,
 		},
@@ -478,9 +465,7 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) error {
 		SandboxId: sandboxID,
 		Command:   command,
 		Options: &cleanroomv1.ExecutionOptions{
-			RunDir:            c.RunDir,
 			ReadOnlyWorkspace: c.ReadOnlyWorkspace,
-			HostPassthrough:   c.HostPassthrough,
 			LaunchSeconds:     c.LaunchSeconds,
 			Tty:               true,
 			Cwd:               cwd,
@@ -763,14 +748,7 @@ func mergeFirecrackerConfig(cwd string, e *ExecCommand, cfg runtimeconfig.Config
 		LaunchSeconds:   cfg.Backends.Firecracker.LaunchSeconds,
 	}
 
-	if e.RunDir != "" {
-		out.RunDir = e.RunDir
-	}
 	out.Launch = true
-	if e.DryRun || e.HostPassthrough {
-		out.Launch = false
-	}
-	out.HostPassthrough = e.HostPassthrough
 	if e.LaunchSeconds != 0 {
 		out.LaunchSeconds = e.LaunchSeconds
 	}

--- a/internal/cli/console_integration_test.go
+++ b/internal/cli/console_integration_test.go
@@ -132,12 +132,14 @@ func TestConsoleIntegrationForwardsStdinAndStreamsOutput(t *testing.T) {
 	}
 
 	host, _ := startIntegrationServer(t, adapter)
+	cwd := t.TempDir()
 	outcome := runConsoleWithCapture(ConsoleCommand{
-		Host: host,
+		Host:  host,
+		Chdir: cwd,
 		// Console defaults to host passthrough for this MVP.
 		Command: []string{"sh"},
 	}, "hello\nexit\n", runtimeContext{
-		CWD: t.TempDir(),
+		CWD: cwd,
 	})
 
 	if outcome.cause != nil {
@@ -175,13 +177,15 @@ func TestConsoleIntegrationInterruptCancelsExecution(t *testing.T) {
 
 	host, _ := startIntegrationServer(t, adapter)
 	signalCh := withTestSignalChannel(t)
+	cwd := t.TempDir()
 
 	done := make(chan execOutcome, 1)
 	go func() {
 		done <- runConsoleWithCapture(ConsoleCommand{
-			Host: host,
+			Host:  host,
+			Chdir: cwd,
 		}, "", runtimeContext{
-			CWD: t.TempDir(),
+			CWD: cwd,
 		})
 	}()
 

--- a/internal/cli/exec_integration_test.go
+++ b/internal/cli/exec_integration_test.go
@@ -211,11 +211,13 @@ func TestExecIntegrationStreamsOutput(t *testing.T) {
 	}
 
 	host, _ := startIntegrationServer(t, adapter)
+	cwd := t.TempDir()
 	outcome := runExecWithCapture(ExecCommand{
 		Host:    host,
+		Chdir:   cwd,
 		Command: []string{"echo", "ignored-by-adapter"},
 	}, runtimeContext{
-		CWD: t.TempDir(),
+		CWD: cwd,
 	})
 
 	if outcome.cause != nil {
@@ -246,11 +248,13 @@ func TestExecIntegrationPropagatesExitAndStderr(t *testing.T) {
 	}
 
 	host, _ := startIntegrationServer(t, adapter)
+	cwd := t.TempDir()
 	outcome := runExecWithCapture(ExecCommand{
 		Host:    host,
+		Chdir:   cwd,
 		Command: []string{"echo", "ignored-by-adapter"},
 	}, runtimeContext{
-		CWD: t.TempDir(),
+		CWD: cwd,
 	})
 
 	if outcome.cause != nil {
@@ -285,14 +289,16 @@ func TestExecIntegrationFirstInterruptCancelsExecution(t *testing.T) {
 
 	host, _ := startIntegrationServer(t, adapter)
 	signalCh := withTestSignalChannel(t)
+	cwd := t.TempDir()
 
 	done := make(chan execOutcome, 1)
 	go func() {
 		done <- runExecWithCapture(ExecCommand{
 			Host:    host,
+			Chdir:   cwd,
 			Command: []string{"sleep", "300"},
 		}, runtimeContext{
-			CWD: t.TempDir(),
+			CWD: cwd,
 		})
 	}()
 
@@ -339,15 +345,17 @@ func TestExecIntegrationSecondInterruptTerminatesSandbox(t *testing.T) {
 
 	host, _ := startIntegrationServer(t, adapter)
 	signalCh := withTestSignalChannel(t)
+	cwd := t.TempDir()
 
 	done := make(chan execOutcome, 1)
 	go func() {
 		done <- runExecWithCapture(ExecCommand{
 			Host:     host,
+			Chdir:    cwd,
 			LogLevel: "debug",
 			Command:  []string{"sleep", "300"},
 		}, runtimeContext{
-			CWD: t.TempDir(),
+			CWD: cwd,
 		})
 	}()
 
@@ -406,11 +414,13 @@ func TestExecIntegrationVmPathUsesShForGuestCompatibility(t *testing.T) {
 	}
 
 	host, _ := startIntegrationServer(t, adapter)
+	cwd := t.TempDir()
 	outcome := runExecWithCapture(ExecCommand{
 		Host:    host,
+		Chdir:   cwd,
 		Command: []string{"sh", "-lc", "echo guest-ok"},
 	}, runtimeContext{
-		CWD: t.TempDir(),
+		CWD: cwd,
 	})
 	if outcome.cause != nil {
 		t.Fatalf("capture failure: %v", outcome.cause)

--- a/internal/controlapi/types.go
+++ b/internal/controlapi/types.go
@@ -58,8 +58,6 @@ type TerminateCleanroomResponse struct {
 type ExecOptions struct {
 	RunDir            string `json:"run_dir,omitempty"`
 	ReadOnlyWorkspace bool   `json:"read_only_workspace,omitempty"`
-	DryRun            bool   `json:"dry_run,omitempty"`
-	HostPassthrough   bool   `json:"host_passthrough,omitempty"`
 	LaunchSeconds     int64  `json:"launch_seconds,omitempty"`
 }
 

--- a/internal/controlapi/types.go
+++ b/internal/controlapi/types.go
@@ -14,9 +14,8 @@ type LaunchCleanroomRequest struct {
 }
 
 type LaunchCleanroomOptions struct {
-	RunDir            string `json:"run_dir,omitempty"`
-	ReadOnlyWorkspace bool   `json:"read_only_workspace,omitempty"`
-	LaunchSeconds     int64  `json:"launch_seconds,omitempty"`
+	ReadOnlyWorkspace bool  `json:"read_only_workspace,omitempty"`
+	LaunchSeconds     int64 `json:"launch_seconds,omitempty"`
 }
 
 type LaunchCleanroomResponse struct {
@@ -24,7 +23,6 @@ type LaunchCleanroomResponse struct {
 	Backend      string `json:"backend"`
 	PolicySource string `json:"policy_source"`
 	PolicyHash   string `json:"policy_hash"`
-	RunDirRoot   string `json:"run_dir_root,omitempty"`
 	Message      string `json:"message"`
 }
 
@@ -56,9 +54,8 @@ type TerminateCleanroomResponse struct {
 }
 
 type ExecOptions struct {
-	RunDir            string `json:"run_dir,omitempty"`
-	ReadOnlyWorkspace bool   `json:"read_only_workspace,omitempty"`
-	LaunchSeconds     int64  `json:"launch_seconds,omitempty"`
+	ReadOnlyWorkspace bool  `json:"read_only_workspace,omitempty"`
+	LaunchSeconds     int64 `json:"launch_seconds,omitempty"`
 }
 
 type ExecResponse struct {

--- a/internal/controlserver/server.go
+++ b/internal/controlserver/server.go
@@ -472,8 +472,6 @@ func (s *Server) handleExec(w http.ResponseWriter, r *http.Request) {
 			"cwd", in.CWD,
 			"backend", in.Backend,
 			"command_argc", len(in.Command),
-			"dry_run", in.Options.DryRun,
-			"host_passthrough", in.Options.HostPassthrough,
 		)
 	}
 

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -324,8 +324,6 @@ func (s *Service) CreateExecution(_ context.Context, req *cleanroomv1.CreateExec
 		execOpts = controlapi.ExecOptions{
 			RunDir:            opts.GetRunDir(),
 			ReadOnlyWorkspace: opts.GetReadOnlyWorkspace(),
-			DryRun:            opts.GetDryRun(),
-			HostPassthrough:   opts.GetHostPassthrough(),
 			LaunchSeconds:     opts.GetLaunchSeconds(),
 		}
 		cwd = strings.TrimSpace(opts.GetCwd())
@@ -853,10 +851,6 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 	if ex.Options.ReadOnlyWorkspace {
 		firecrackerCfg.WorkspaceAccess = "ro"
 	}
-	if ex.Options.DryRun || ex.Options.HostPassthrough {
-		firecrackerCfg.Launch = false
-	}
-	firecrackerCfg.HostPassthrough = ex.Options.HostPassthrough
 	if ex.Options.LaunchSeconds != 0 {
 		firecrackerCfg.LaunchSeconds = ex.Options.LaunchSeconds
 	}
@@ -1112,8 +1106,6 @@ func (s *Service) Exec(ctx context.Context, req controlapi.ExecRequest) (*contro
 		Options: &cleanroomv1.ExecutionOptions{
 			RunDir:            req.Options.RunDir,
 			ReadOnlyWorkspace: req.Options.ReadOnlyWorkspace,
-			DryRun:            req.Options.DryRun,
-			HostPassthrough:   req.Options.HostPassthrough,
 			LaunchSeconds:     req.Options.LaunchSeconds,
 			Cwd:               req.CWD,
 		},
@@ -1605,10 +1597,6 @@ func mergeFirecrackerConfig(cwd string, opts controlapi.ExecOptions, cfg runtime
 		out.RunDir = opts.RunDir
 	}
 	out.Launch = true
-	if opts.DryRun || opts.HostPassthrough {
-		out.Launch = false
-	}
-	out.HostPassthrough = opts.HostPassthrough
 	if opts.LaunchSeconds != 0 {
 		out.LaunchSeconds = opts.LaunchSeconds
 	}

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -143,9 +143,6 @@ func TestLaunchRunTerminateLifecycle(t *testing.T) {
 
 	launchResp, err := svc.LaunchCleanroom(context.Background(), controlapi.LaunchCleanroomRequest{
 		CWD: "/repo",
-		Options: controlapi.LaunchCleanroomOptions{
-			RunDir: "/tmp/cleanrooms",
-		},
 	})
 	if err != nil {
 		t.Fatalf("LaunchCleanroom returned error: %v", err)
@@ -169,9 +166,6 @@ func TestLaunchRunTerminateLifecycle(t *testing.T) {
 	}
 	if got := adapter.req.Command[0]; got != "pi" {
 		t.Fatalf("expected normalized command to start with pi, got %q", got)
-	}
-	if !strings.HasPrefix(adapter.req.RunDir, "/tmp/cleanrooms/") {
-		t.Fatalf("expected run dir under run root, got %q", adapter.req.RunDir)
 	}
 	if adapter.runCalls != 1 {
 		t.Fatalf("expected exactly one run call, got %d", adapter.runCalls)

--- a/internal/endpoint/endpoint_test.go
+++ b/internal/endpoint/endpoint_test.go
@@ -1,11 +1,26 @@
 package endpoint
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
-func TestResolveTSNetEndpoint(t *testing.T) {
+func TestResolveTSNetEndpointRejectedByResolve(t *testing.T) {
 	t.Parallel()
 
-	ep, err := Resolve("tsnet://cleanroomd:8443")
+	_, err := Resolve("tsnet://cleanroomd:8443")
+	if err == nil {
+		t.Fatal("expected tsnet:// to be rejected by Resolve (client-side)")
+	}
+	if !strings.Contains(err.Error(), "server --listen") {
+		t.Fatalf("expected helpful error message, got %q", err)
+	}
+}
+
+func TestResolveTSNetEndpointViaResolveListen(t *testing.T) {
+	t.Parallel()
+
+	ep, err := ResolveListen("tsnet://cleanroomd:8443")
 	if err != nil {
 		t.Fatalf("resolve tsnet endpoint: %v", err)
 	}
@@ -30,7 +45,7 @@ func TestResolveTSNetEndpoint(t *testing.T) {
 func TestResolveTSNetEndpointDefaults(t *testing.T) {
 	t.Parallel()
 
-	ep, err := Resolve("tsnet://")
+	ep, err := ResolveListen("tsnet://")
 	if err != nil {
 		t.Fatalf("resolve tsnet endpoint with defaults: %v", err)
 	}
@@ -52,7 +67,7 @@ func TestResolveTSNetEndpointDefaults(t *testing.T) {
 func TestResolveTSNetEndpointRejectsInvalidPort(t *testing.T) {
 	t.Parallel()
 
-	if _, err := Resolve("tsnet://cleanroomd:99999"); err == nil {
+	if _, err := ResolveListen("tsnet://cleanroomd:99999"); err == nil {
 		t.Fatal("expected invalid tsnet port to fail")
 	}
 }
@@ -60,7 +75,7 @@ func TestResolveTSNetEndpointRejectsInvalidPort(t *testing.T) {
 func TestResolveTSNetEndpointRejectsPath(t *testing.T) {
 	t.Parallel()
 
-	if _, err := Resolve("tsnet://cleanroomd:8443/path"); err == nil {
+	if _, err := ResolveListen("tsnet://cleanroomd:8443/path"); err == nil {
 		t.Fatal("expected tsnet endpoint with path to fail")
 	}
 }

--- a/internal/gen/cleanroom/v1/control.pb.go
+++ b/internal/gen/cleanroom/v1/control.pb.go
@@ -227,7 +227,6 @@ func (x *Sandbox) GetUpdatedAt() *timestamppb.Timestamp {
 
 type SandboxOptions struct {
 	state             protoimpl.MessageState `protogen:"open.v1"`
-	RunDir            string                 `protobuf:"bytes,1,opt,name=run_dir,json=runDir,proto3" json:"run_dir,omitempty"`
 	ReadOnlyWorkspace bool                   `protobuf:"varint,2,opt,name=read_only_workspace,json=readOnlyWorkspace,proto3" json:"read_only_workspace,omitempty"`
 	LaunchSeconds     int64                  `protobuf:"varint,3,opt,name=launch_seconds,json=launchSeconds,proto3" json:"launch_seconds,omitempty"`
 	unknownFields     protoimpl.UnknownFields
@@ -262,13 +261,6 @@ func (x *SandboxOptions) ProtoReflect() protoreflect.Message {
 // Deprecated: Use SandboxOptions.ProtoReflect.Descriptor instead.
 func (*SandboxOptions) Descriptor() ([]byte, []int) {
 	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{1}
-}
-
-func (x *SandboxOptions) GetRunDir() string {
-	if x != nil {
-		return x.RunDir
-	}
-	return ""
 }
 
 func (x *SandboxOptions) GetReadOnlyWorkspace() bool {
@@ -907,10 +899,7 @@ func (x *Execution) GetRunId() string {
 
 type ExecutionOptions struct {
 	state             protoimpl.MessageState `protogen:"open.v1"`
-	RunDir            string                 `protobuf:"bytes,1,opt,name=run_dir,json=runDir,proto3" json:"run_dir,omitempty"`
 	ReadOnlyWorkspace bool                   `protobuf:"varint,2,opt,name=read_only_workspace,json=readOnlyWorkspace,proto3" json:"read_only_workspace,omitempty"`
-	DryRun            bool                   `protobuf:"varint,3,opt,name=dry_run,json=dryRun,proto3" json:"dry_run,omitempty"`
-	HostPassthrough   bool                   `protobuf:"varint,4,opt,name=host_passthrough,json=hostPassthrough,proto3" json:"host_passthrough,omitempty"`
 	LaunchSeconds     int64                  `protobuf:"varint,5,opt,name=launch_seconds,json=launchSeconds,proto3" json:"launch_seconds,omitempty"`
 	Tty               bool                   `protobuf:"varint,6,opt,name=tty,proto3" json:"tty,omitempty"`
 	Cwd               string                 `protobuf:"bytes,7,opt,name=cwd,proto3" json:"cwd,omitempty"`
@@ -948,30 +937,9 @@ func (*ExecutionOptions) Descriptor() ([]byte, []int) {
 	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{13}
 }
 
-func (x *ExecutionOptions) GetRunDir() string {
-	if x != nil {
-		return x.RunDir
-	}
-	return ""
-}
-
 func (x *ExecutionOptions) GetReadOnlyWorkspace() bool {
 	if x != nil {
 		return x.ReadOnlyWorkspace
-	}
-	return false
-}
-
-func (x *ExecutionOptions) GetDryRun() bool {
-	if x != nil {
-		return x.DryRun
-	}
-	return false
-}
-
-func (x *ExecutionOptions) GetHostPassthrough() bool {
-	if x != nil {
-		return x.HostPassthrough
 	}
 	return false
 }
@@ -2068,9 +2036,8 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\n" +
 	"created_at\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x129\n" +
 	"\n" +
-	"updated_at\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\tupdatedAt\"\x80\x01\n" +
-	"\x0eSandboxOptions\x12\x17\n" +
-	"\arun_dir\x18\x01 \x01(\tR\x06runDir\x12.\n" +
+	"updated_at\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\tupdatedAt\"g\n" +
+	"\x0eSandboxOptions\x12.\n" +
 	"\x13read_only_workspace\x18\x02 \x01(\bR\x11readOnlyWorkspace\x12%\n" +
 	"\x0elaunch_seconds\x18\x03 \x01(\x03R\rlaunchSeconds\"z\n" +
 	"\x14CreateSandboxRequest\x12\x10\n" +
@@ -2122,12 +2089,9 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\vfinished_at\x18\a \x01(\v2\x1a.google.protobuf.TimestampR\n" +
 	"finishedAt\x12\x10\n" +
 	"\x03tty\x18\b \x01(\bR\x03tty\x12\x15\n" +
-	"\x06run_id\x18\t \x01(\tR\x05runId\"\xea\x01\n" +
-	"\x10ExecutionOptions\x12\x17\n" +
-	"\arun_dir\x18\x01 \x01(\tR\x06runDir\x12.\n" +
-	"\x13read_only_workspace\x18\x02 \x01(\bR\x11readOnlyWorkspace\x12\x17\n" +
-	"\adry_run\x18\x03 \x01(\bR\x06dryRun\x12)\n" +
-	"\x10host_passthrough\x18\x04 \x01(\bR\x0fhostPassthrough\x12%\n" +
+	"\x06run_id\x18\t \x01(\tR\x05runId\"\x8d\x01\n" +
+	"\x10ExecutionOptions\x12.\n" +
+	"\x13read_only_workspace\x18\x02 \x01(\bR\x11readOnlyWorkspace\x12%\n" +
 	"\x0elaunch_seconds\x18\x05 \x01(\x03R\rlaunchSeconds\x12\x10\n" +
 	"\x03tty\x18\x06 \x01(\bR\x03tty\x12\x10\n" +
 	"\x03cwd\x18\a \x01(\tR\x03cwd\"\x8b\x01\n" +

--- a/proto/cleanroom/v1/control.proto
+++ b/proto/cleanroom/v1/control.proto
@@ -41,7 +41,6 @@ enum SandboxStatus {
 }
 
 message SandboxOptions {
-  string run_dir = 1;
   bool read_only_workspace = 2;
   int64 launch_seconds = 3;
 }
@@ -117,10 +116,7 @@ enum ExecutionStatus {
 }
 
 message ExecutionOptions {
-  string run_dir = 1;
   bool read_only_workspace = 2;
-  bool dry_run = 3;
-  bool host_passthrough = 4;
   int64 launch_seconds = 5;
   bool tty = 6;
   string cwd = 7;


### PR DESCRIPTION
Fixes issues discovered while testing the cleanroom server remotely over Tailscale.

## Changes

### Fix: require explicit absolute `-c/--chdir` for remote endpoints
When using `--host` to connect to a remote server, the client was silently sending its local cwd to the server. Now requires an explicit `-c` with an absolute path for non-unix endpoints. Relative paths are rejected since they'd be resolved against the local filesystem. Applies to both `exec` and `console` commands.

### Fix: reject `tsnet://` for client-side endpoint resolution
`tsnet://` only makes sense for `cleanroom serve --listen`. Client-side `Resolve()` now rejects it with a helpful error suggesting `http://HOSTNAME.tailnet.ts.net:PORT`. Added `ResolveListen()` for server-side use.

### Fix: random vsock guest CID per run
Previously every VM defaulted to CID 3, causing vsock conflicts for concurrent executions. Now generates a random CID in the valid range (3 to 2^32-2) using `crypto/rand`.

### Fix: guest errors streamed to client
When the backend returns a non-zero exit code with error detail in `Message`, it's now streamed as stderr so clients can see what went wrong.

### Refactor: remove `--dry-run`, `--host-passthrough`, `--run-dir` from CLI and proto
These flags exposed server-side implementation details to the client. `--dry-run` and `--host-passthrough` let clients bypass sandboxing on the server. `--run-dir` sent a client-local path. All three are removed from the CLI, the proto messages, and the JSON API types. Run directory is now purely a server-side concern.