### PR TITLE
feat(server): add Tailscale Services listen mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,19 @@ Then connect with:
 cleanroom exec --host tsnet://cleanroom:7777 -- "npm test"
 ```
 
+To expose the API as a Tailscale Service using the local `tailscaled` daemon:
+
+```bash
+cleanroom serve --listen tssvc://cleanroom
+```
+
+This configures `svc:cleanroom` with HTTPS on port 443 and advertises the
+service from this host. Connect from another tailnet device with:
+
+```bash
+cleanroom exec --host https://cleanroom.<your-tailnet>.ts.net -- "npm test"
+```
+
 ### 3) Launch -> Run -> Terminate via API
 
 ```bash

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -82,7 +82,7 @@ type ConsoleCommand struct {
 }
 
 type ServeCommand struct {
-	Listen   string `help:"Listen endpoint for control API (defaults to runtime endpoint; supports tsnet://hostname[:port])"`
+	Listen   string `help:"Listen endpoint for control API (defaults to runtime endpoint; supports tsnet://hostname[:port] and tssvc://service[:local-port])"`
 	LogLevel string `help:"Server log level (debug|info|warn|error)"`
 }
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -207,6 +207,9 @@ func (e *ExecCommand) Run(ctx *runtimeContext) error {
 	if err != nil {
 		return err
 	}
+	if err := validateClientEndpoint(ep); err != nil {
+		return err
+	}
 	var cwd string
 	if ep.Scheme != "unix" {
 		if e.Chdir == "" {
@@ -412,6 +415,9 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) error {
 
 	ep, err := endpoint.Resolve(c.Host)
 	if err != nil {
+		return err
+	}
+	if err := validateClientEndpoint(ep); err != nil {
 		return err
 	}
 	var cwd string
@@ -732,6 +738,13 @@ func resolveBackendName(requested, configuredDefault string) string {
 		return configuredDefault
 	}
 	return "firecracker"
+}
+
+func validateClientEndpoint(ep endpoint.Endpoint) error {
+	if ep.Scheme != "tssvc" {
+		return nil
+	}
+	return errors.New("tssvc:// endpoints are listen-only; use https://<service>.<your-tailnet>.ts.net for --host")
 }
 
 func mergeFirecrackerConfig(cwd string, e *ExecCommand, cfg runtimeconfig.Config) backend.FirecrackerConfig {

--- a/internal/cli/console_integration_test.go
+++ b/internal/cli/console_integration_test.go
@@ -203,3 +203,20 @@ func TestConsoleIntegrationInterruptCancelsExecution(t *testing.T) {
 		t.Fatalf("unexpected console exit code: got %d want %d (err=%v)", got, want, outcome.err)
 	}
 }
+
+func TestConsoleRejectsTailscaleServiceListenEndpointAsHost(t *testing.T) {
+	outcome := runConsoleWithCapture(ConsoleCommand{
+		Host: "tssvc://cleanroom",
+	}, "", runtimeContext{
+		CWD: t.TempDir(),
+	})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err == nil {
+		t.Fatal("expected host validation error")
+	}
+	if !strings.Contains(outcome.err.Error(), "listen-only") {
+		t.Fatalf("expected listen-only host error, got %v", outcome.err)
+	}
+}

--- a/internal/cli/exec_integration_test.go
+++ b/internal/cli/exec_integration_test.go
@@ -442,3 +442,21 @@ func TestParseSandboxID(t *testing.T) {
 		t.Fatalf("expected empty sandbox id for invalid input, got %q", got)
 	}
 }
+
+func TestExecRejectsTailscaleServiceListenEndpointAsHost(t *testing.T) {
+	outcome := runExecWithCapture(ExecCommand{
+		Host:    "tssvc://cleanroom",
+		Command: []string{"echo", "hi"},
+	}, runtimeContext{
+		CWD: t.TempDir(),
+	})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err == nil {
+		t.Fatal("expected host validation error")
+	}
+	if !strings.Contains(outcome.err.Error(), "listen-only") {
+		t.Fatalf("expected listen-only host error, got %v", outcome.err)
+	}
+}

--- a/internal/controlserver/server_test.go
+++ b/internal/controlserver/server_test.go
@@ -1,13 +1,20 @@
 package controlserver
 
 import (
+	"context"
 	"errors"
+	"io"
 	"net"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"connectrpc.com/connect"
 	"github.com/buildkite/cleanroom/internal/endpoint"
+	"github.com/charmbracelet/log"
+	"tailscale.com/ipn"
+	"tailscale.com/ipn/ipnstate"
+	"tailscale.com/tailcfg"
 )
 
 func TestStreamSubscriberDroppedErrWhileExecutionStillRunning(t *testing.T) {
@@ -72,7 +79,7 @@ func TestListenTSNetUsesStateDirAndCleanup(t *testing.T) {
 	var gotStateDir string
 
 	originalNewTSNetServer := newTSNetServer
-	newTSNetServer = func(_ endpoint.Endpoint, stateDir string) tsnetServer {
+	newTSNetServer = func(_ endpoint.Endpoint, stateDir string, _ func(format string, args ...any)) tsnetServer {
 		gotStateDir = stateDir
 		return stub
 	}
@@ -86,7 +93,7 @@ func TestListenTSNetUsesStateDirAndCleanup(t *testing.T) {
 		TSNetHostname: "cleanroom",
 	}
 
-	ln, cleanup, err := listen(ep)
+	ln, cleanup, err := listen(ep, nil)
 	if err != nil {
 		t.Fatalf("listen tsnet: %v", err)
 	}
@@ -122,7 +129,7 @@ func TestListenTSNetClosesServerOnListenError(t *testing.T) {
 	stub := &stubTSNetServer{listenErr: errors.New("boom")}
 
 	originalNewTSNetServer := newTSNetServer
-	newTSNetServer = func(_ endpoint.Endpoint, _ string) tsnetServer {
+	newTSNetServer = func(_ endpoint.Endpoint, _ string, _ func(format string, args ...any)) tsnetServer {
 		return stub
 	}
 	t.Cleanup(func() {
@@ -133,7 +140,7 @@ func TestListenTSNetClosesServerOnListenError(t *testing.T) {
 		Scheme:        "tsnet",
 		Address:       ":7777",
 		TSNetHostname: "cleanroom",
-	})
+	}, nil)
 	if err == nil {
 		t.Fatal("expected listen error")
 	}
@@ -142,5 +149,252 @@ func TestListenTSNetClosesServerOnListenError(t *testing.T) {
 	}
 	if stub.closeCalls != 1 {
 		t.Fatalf("expected listen failure to close tsnet server, got %d", stub.closeCalls)
+	}
+}
+
+type stubTailscaleLocalClient struct {
+	status    *ipnstate.Status
+	statusErr error
+
+	serveConfig    *ipn.ServeConfig
+	serveConfigErr error
+
+	setServeConfigErr   error
+	setServeConfigArg   *ipn.ServeConfig
+	setServeConfigCalls int
+
+	prefs       *ipn.Prefs
+	getPrefsErr error
+
+	editPrefsErr   error
+	editPrefsArg   *ipn.MaskedPrefs
+	editPrefsCalls int
+}
+
+func (s *stubTailscaleLocalClient) StatusWithoutPeers(context.Context) (*ipnstate.Status, error) {
+	return s.status, s.statusErr
+}
+
+func (s *stubTailscaleLocalClient) GetServeConfig(context.Context) (*ipn.ServeConfig, error) {
+	return s.serveConfig, s.serveConfigErr
+}
+
+func (s *stubTailscaleLocalClient) SetServeConfig(_ context.Context, config *ipn.ServeConfig) error {
+	s.setServeConfigCalls++
+	if config != nil {
+		s.setServeConfigArg = config.Clone()
+	}
+	return s.setServeConfigErr
+}
+
+func (s *stubTailscaleLocalClient) GetPrefs(context.Context) (*ipn.Prefs, error) {
+	return s.prefs, s.getPrefsErr
+}
+
+func (s *stubTailscaleLocalClient) EditPrefs(_ context.Context, prefs *ipn.MaskedPrefs) (*ipn.Prefs, error) {
+	s.editPrefsCalls++
+	if prefs != nil {
+		cp := *prefs
+		cp.Prefs.AdvertiseServices = append([]string{}, prefs.Prefs.AdvertiseServices...)
+		s.editPrefsArg = &cp
+	}
+	return s.prefs, s.editPrefsErr
+}
+
+func TestListenTailscaleServiceConfiguresServeAndAdvertise(t *testing.T) {
+	stub := &stubTailscaleLocalClient{
+		status: &ipnstate.Status{
+			CurrentTailnet: &ipnstate.TailnetStatus{
+				MagicDNSSuffix: "example.ts.net",
+			},
+		},
+		serveConfig: &ipn.ServeConfig{},
+		prefs: &ipn.Prefs{
+			AdvertiseServices: []string{"svc:existing"},
+		},
+	}
+
+	originalNewTailscaleLocalClient := newTailscaleLocalClient
+	newTailscaleLocalClient = func() tailscaleLocalClient {
+		return stub
+	}
+	t.Cleanup(func() {
+		newTailscaleLocalClient = originalNewTailscaleLocalClient
+	})
+
+	ep := endpoint.Endpoint{
+		Scheme:        "tssvc",
+		Address:       "127.0.0.1:0",
+		TSServiceName: "svc:cleanroom",
+	}
+
+	ln, cleanup, err := listen(ep, nil)
+	if err != nil {
+		t.Fatalf("listen tailscale service: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = ln.Close()
+	})
+	if cleanup != nil {
+		t.Fatal("expected no cleanup callback for tailscale service listener")
+	}
+
+	if stub.setServeConfigCalls != 1 {
+		t.Fatalf("expected serve config update call, got %d", stub.setServeConfigCalls)
+	}
+	if stub.setServeConfigArg == nil {
+		t.Fatal("expected serve config argument")
+	}
+
+	serviceName := tailcfg.ServiceName("svc:cleanroom")
+	serviceConfig := stub.setServeConfigArg.Services[serviceName]
+	if serviceConfig == nil {
+		t.Fatalf("expected service config for %q", serviceName)
+	}
+	handler := serviceConfig.TCP[443]
+	if handler == nil || !handler.HTTPS {
+		t.Fatalf("expected https handler on service port 443, got %+v", handler)
+	}
+
+	hostPort := ipn.HostPort("cleanroom.example.ts.net:443")
+	webConfig := serviceConfig.Web[hostPort]
+	if webConfig == nil {
+		t.Fatalf("expected web config for %q", hostPort)
+	}
+	root := webConfig.Handlers["/"]
+	if root == nil {
+		t.Fatalf("expected root proxy handler for %q", hostPort)
+	}
+	expectedProxy := "http://" + ln.Addr().String()
+	if root.Proxy != expectedProxy {
+		t.Fatalf("expected proxy target %q, got %q", expectedProxy, root.Proxy)
+	}
+
+	if stub.editPrefsCalls != 1 {
+		t.Fatalf("expected one advertise service update call, got %d", stub.editPrefsCalls)
+	}
+	if stub.editPrefsArg == nil {
+		t.Fatal("expected edit prefs argument")
+	}
+	gotAdvertise := stub.editPrefsArg.Prefs.AdvertiseServices
+	wantAdvertise := []string{"svc:existing", "svc:cleanroom"}
+	if !reflect.DeepEqual(gotAdvertise, wantAdvertise) {
+		t.Fatalf("expected advertised services %v, got %v", wantAdvertise, gotAdvertise)
+	}
+}
+
+func TestListenTailscaleServiceSkipsAdvertiseWhenAlreadyPresent(t *testing.T) {
+	stub := &stubTailscaleLocalClient{
+		status: &ipnstate.Status{
+			CurrentTailnet: &ipnstate.TailnetStatus{
+				MagicDNSSuffix: "example.ts.net",
+			},
+		},
+		serveConfig: &ipn.ServeConfig{},
+		prefs: &ipn.Prefs{
+			AdvertiseServices: []string{"svc:cleanroom"},
+		},
+	}
+
+	originalNewTailscaleLocalClient := newTailscaleLocalClient
+	newTailscaleLocalClient = func() tailscaleLocalClient {
+		return stub
+	}
+	t.Cleanup(func() {
+		newTailscaleLocalClient = originalNewTailscaleLocalClient
+	})
+
+	ln, _, err := listen(endpoint.Endpoint{
+		Scheme:        "tssvc",
+		Address:       "127.0.0.1:0",
+		TSServiceName: "svc:cleanroom",
+	}, nil)
+	if err != nil {
+		t.Fatalf("listen tailscale service: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = ln.Close()
+	})
+
+	if stub.editPrefsCalls != 0 {
+		t.Fatalf("expected no advertise update call, got %d", stub.editPrefsCalls)
+	}
+}
+
+func TestListenTailscaleServiceReturnsErrorWhenStatusFails(t *testing.T) {
+	stub := &stubTailscaleLocalClient{
+		statusErr: errors.New("tailscaled unavailable"),
+	}
+
+	originalNewTailscaleLocalClient := newTailscaleLocalClient
+	newTailscaleLocalClient = func() tailscaleLocalClient {
+		return stub
+	}
+	t.Cleanup(func() {
+		newTailscaleLocalClient = originalNewTailscaleLocalClient
+	})
+
+	ln, cleanup, err := listen(endpoint.Endpoint{
+		Scheme:        "tssvc",
+		Address:       "127.0.0.1:0",
+		TSServiceName: "svc:cleanroom",
+	}, nil)
+	if err == nil {
+		t.Fatal("expected listen to fail when tailscale status is unavailable")
+	}
+	if ln != nil {
+		t.Fatal("expected no listener on tailscale status failure")
+	}
+	if cleanup != nil {
+		t.Fatal("expected no cleanup callback on tailscale status failure")
+	}
+	if stub.setServeConfigCalls != 0 {
+		t.Fatalf("expected no serve config updates, got %d", stub.setServeConfigCalls)
+	}
+	if stub.editPrefsCalls != 0 {
+		t.Fatalf("expected no prefs updates, got %d", stub.editPrefsCalls)
+	}
+}
+
+func TestListenTSNetWiresLogger(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	stub := &stubTSNetServer{}
+	var gotLogf func(format string, args ...any)
+
+	originalNewTSNetServer := newTSNetServer
+	newTSNetServer = func(_ endpoint.Endpoint, _ string, tsLogf func(format string, args ...any)) tsnetServer {
+		gotLogf = tsLogf
+		return stub
+	}
+	t.Cleanup(func() {
+		newTSNetServer = originalNewTSNetServer
+	})
+
+	logger := log.NewWithOptions(io.Discard, log.Options{
+		Level:     log.DebugLevel,
+		Formatter: log.TextFormatter,
+	})
+
+	ln, cleanup, err := listen(endpoint.Endpoint{
+		Scheme:        "tsnet",
+		Address:       ":7777",
+		TSNetHostname: "cleanroom",
+	}, logger)
+	if err != nil {
+		t.Fatalf("listen tsnet: %v", err)
+	}
+	if ln == nil {
+		t.Fatal("expected listener")
+	}
+	if cleanup == nil {
+		t.Fatal("expected cleanup callback")
+	}
+	if gotLogf == nil {
+		t.Fatal("expected tsnet log callback to be wired")
+	}
+	gotLogf("tsnet test message %s", "ok")
+	if err := cleanup(); err != nil {
+		t.Fatalf("cleanup: %v", err)
 	}
 }

--- a/internal/controlserver/tailscale_service.go
+++ b/internal/controlserver/tailscale_service.go
@@ -1,0 +1,118 @@
+package controlserver
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"reflect"
+	"slices"
+	"strings"
+
+	"github.com/buildkite/cleanroom/internal/endpoint"
+	"tailscale.com/client/tailscale"
+	"tailscale.com/ipn"
+	"tailscale.com/ipn/ipnstate"
+	"tailscale.com/tailcfg"
+)
+
+type tailscaleLocalClient interface {
+	StatusWithoutPeers(ctx context.Context) (*ipnstate.Status, error)
+	GetServeConfig(ctx context.Context) (*ipn.ServeConfig, error)
+	SetServeConfig(ctx context.Context, config *ipn.ServeConfig) error
+	GetPrefs(ctx context.Context) (*ipn.Prefs, error)
+	EditPrefs(ctx context.Context, prefs *ipn.MaskedPrefs) (*ipn.Prefs, error)
+}
+
+var newTailscaleLocalClient = func() tailscaleLocalClient {
+	return &tailscale.LocalClient{}
+}
+
+func configureTailscaleService(ctx context.Context, ep endpoint.Endpoint, localAddr string) error {
+	serviceName := tailcfg.ServiceName(strings.TrimSpace(ep.TSServiceName))
+	if err := serviceName.Validate(); err != nil {
+		return fmt.Errorf("invalid tailscale service name %q: %w", ep.TSServiceName, err)
+	}
+	if strings.TrimSpace(localAddr) == "" {
+		return fmt.Errorf("empty local listen address for service %q", serviceName)
+	}
+
+	lc := newTailscaleLocalClient()
+	status, err := lc.StatusWithoutPeers(ctx)
+	if err != nil {
+		return fmt.Errorf("get tailscale status: %w", err)
+	}
+	if status == nil {
+		return fmt.Errorf("tailscale status missing tailnet MagicDNS suffix")
+	}
+	suffix := ""
+	if status.CurrentTailnet != nil {
+		suffix = strings.TrimSpace(status.CurrentTailnet.MagicDNSSuffix)
+	}
+	if suffix == "" {
+		suffix = strings.TrimSpace(status.MagicDNSSuffix)
+	}
+	if suffix == "" {
+		return fmt.Errorf("tailscale status missing tailnet MagicDNS suffix")
+	}
+	serviceHost := fmt.Sprintf("%s.%s", serviceName.WithoutPrefix(), suffix)
+	proxyTarget := fmt.Sprintf("http://%s", localAddr)
+
+	serveConfig, err := lc.GetServeConfig(ctx)
+	if err != nil {
+		return fmt.Errorf("get tailscale serve config: %w", err)
+	}
+	if serveConfig == nil {
+		serveConfig = &ipn.ServeConfig{}
+	}
+
+	desiredServiceConfig := &ipn.ServiceConfig{
+		TCP: map[uint16]*ipn.TCPPortHandler{
+			443: {
+				HTTPS: true,
+			},
+		},
+		Web: map[ipn.HostPort]*ipn.WebServerConfig{
+			ipn.HostPort(net.JoinHostPort(serviceHost, "443")): {
+				Handlers: map[string]*ipn.HTTPHandler{
+					"/": {
+						Proxy: proxyTarget,
+					},
+				},
+			},
+		},
+	}
+
+	currentServiceConfig := serveConfig.Services[serviceName]
+	if !reflect.DeepEqual(currentServiceConfig, desiredServiceConfig) {
+		if serveConfig.Services == nil {
+			serveConfig.Services = map[tailcfg.ServiceName]*ipn.ServiceConfig{}
+		}
+		serveConfig.Services[serviceName] = desiredServiceConfig
+		if err := lc.SetServeConfig(ctx, serveConfig); err != nil {
+			return fmt.Errorf("set tailscale serve config for %q: %w", serviceName, err)
+		}
+	}
+
+	prefs, err := lc.GetPrefs(ctx)
+	if err != nil {
+		return fmt.Errorf("get tailscale prefs: %w", err)
+	}
+	advertiseServices := []string{}
+	if prefs != nil {
+		advertiseServices = append(advertiseServices, prefs.AdvertiseServices...)
+	}
+	if slices.Contains(advertiseServices, serviceName.String()) {
+		return nil
+	}
+
+	advertiseServices = append(advertiseServices, serviceName.String())
+	if _, err := lc.EditPrefs(ctx, &ipn.MaskedPrefs{
+		AdvertiseServicesSet: true,
+		Prefs: ipn.Prefs{
+			AdvertiseServices: advertiseServices,
+		},
+	}); err != nil {
+		return fmt.Errorf("advertise tailscale service %q: %w", serviceName, err)
+	}
+	return nil
+}

--- a/internal/endpoint/endpoint_test.go
+++ b/internal/endpoint/endpoint_test.go
@@ -79,3 +79,52 @@ func TestResolveTSNetEndpointRejectsPath(t *testing.T) {
 		t.Fatal("expected tsnet endpoint with path to fail")
 	}
 }
+
+func TestResolveTailscaleServiceEndpoint(t *testing.T) {
+	t.Parallel()
+
+	ep, err := Resolve("tssvc://cleanroom:8443")
+	if err != nil {
+		t.Fatalf("resolve tssvc endpoint: %v", err)
+	}
+
+	if ep.Scheme != "tssvc" {
+		t.Fatalf("expected tssvc scheme, got %q", ep.Scheme)
+	}
+	if ep.Address != "127.0.0.1:8443" {
+		t.Fatalf("expected local listen address 127.0.0.1:8443, got %q", ep.Address)
+	}
+	if ep.BaseURL != "https://cleanroom.<tailnet>.ts.net" {
+		t.Fatalf("expected base url https://cleanroom.<tailnet>.ts.net, got %q", ep.BaseURL)
+	}
+	if ep.TSServiceName != "svc:cleanroom" {
+		t.Fatalf("expected service name svc:cleanroom, got %q", ep.TSServiceName)
+	}
+	if ep.TSServicePort != 8443 {
+		t.Fatalf("expected service port 8443, got %d", ep.TSServicePort)
+	}
+}
+
+func TestResolveTailscaleServiceEndpointDefaults(t *testing.T) {
+	t.Parallel()
+
+	ep, err := Resolve("tssvc://")
+	if err != nil {
+		t.Fatalf("resolve tssvc endpoint with defaults: %v", err)
+	}
+
+	if ep.Address != "127.0.0.1:7777" {
+		t.Fatalf("expected default local listen address 127.0.0.1:7777, got %q", ep.Address)
+	}
+	if ep.TSServiceName != "svc:cleanroom" {
+		t.Fatalf("expected default service name svc:cleanroom, got %q", ep.TSServiceName)
+	}
+}
+
+func TestResolveTailscaleServiceEndpointRejectsInvalidLabel(t *testing.T) {
+	t.Parallel()
+
+	if _, err := Resolve("tssvc://clean_room:8443"); err == nil {
+		t.Fatal("expected invalid tssvc service label to fail")
+	}
+}


### PR DESCRIPTION
## Summary
- add a new `tssvc://service[:local-port]` listen endpoint for `cleanroom serve`
- configure Tailscale Services through LocalAPI by writing `ServeConfig.Services` and advertising the service in prefs
- keep existing `tsnet://` behavior and wire `tsnet` internal logs into the existing structured logger
- add endpoint/server tests for parsing, service setup, and tsnet logger wiring
- document `tssvc://` usage in README and CLI help text

## Testing
- `go test ./...`
