### PR TITLE
refactor: remove workspace copy mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ cleanroom serve --listen tsnet://cleanroom:7777
 Then connect with:
 
 ```bash
-cleanroom exec --host tsnet://cleanroom:7777 -- "npm test"
+cleanroom exec --host http://cleanroom.tailnet.ts.net:7777 -c /path/to/repo -- "npm test"
 ```
 
 ### 3) Launch -> Run -> Terminate via API
@@ -99,8 +99,6 @@ Request:
   "cwd": "/path/to/repo",
   "backend": "firecracker",
   "options": {
-    "run_dir": "/tmp/cleanroom-runs",
-    "read_only_workspace": false,
     "launch_seconds": 30
   }
 }
@@ -111,7 +109,6 @@ Response fields:
 - `backend`
 - `policy_source`
 - `policy_hash`
-- `run_dir_root`
 
 ### `POST /v1/cleanrooms/run`
 
@@ -173,8 +170,6 @@ Example:
 
 ```yaml
 default_backend: firecracker
-workspace:
-  access: rw
 backends:
   firecracker:
     binary_path: firecracker
@@ -189,8 +184,6 @@ backends:
 ## Isolation Model
 
 - Workload runs in a Firecracker microVM
-- Workspace is copied per run and sent to the guest agent
-- Workspace can be read-only (`workspace.access: ro` or request override)
 - Host egress is controlled with TAP + iptables rules from compiled policy
 - Default network behavior is deny
 - Rootfs writes are discarded after each run
@@ -217,7 +210,6 @@ cleanroom status --run-id <run-id>
 - policy host-resolution time
 - rootfs preparation time
 - Firecracker process start time
-- workspace archive preparation time
 - network setup time
 - VM ready time (process start -> guest agent ready)
 - vsock wait time (wait-to-connect for guest agent)

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -42,10 +42,8 @@ type FirecrackerConfig struct {
 	BinaryPath      string
 	KernelImagePath string
 	RootFSPath      string
-	RunDir          string
-	WorkspaceHost   string
-	WorkspaceAccess string // rw|ro
-	VCPUs           int64
+	RunDir string
+	VCPUs  int64
 	MemoryMiB       int64
 	GuestCID        uint32
 	GuestPort       uint32

--- a/internal/controlapi/types.go
+++ b/internal/controlapi/types.go
@@ -14,8 +14,7 @@ type LaunchCleanroomRequest struct {
 }
 
 type LaunchCleanroomOptions struct {
-	ReadOnlyWorkspace bool  `json:"read_only_workspace,omitempty"`
-	LaunchSeconds     int64 `json:"launch_seconds,omitempty"`
+	LaunchSeconds int64 `json:"launch_seconds,omitempty"`
 }
 
 type LaunchCleanroomResponse struct {
@@ -54,8 +53,7 @@ type TerminateCleanroomResponse struct {
 }
 
 type ExecOptions struct {
-	ReadOnlyWorkspace bool  `json:"read_only_workspace,omitempty"`
-	LaunchSeconds     int64 `json:"launch_seconds,omitempty"`
+	LaunchSeconds int64 `json:"launch_seconds,omitempty"`
 }
 
 type ExecResponse struct {

--- a/internal/gen/cleanroom/v1/control.pb.go
+++ b/internal/gen/cleanroom/v1/control.pb.go
@@ -226,11 +226,10 @@ func (x *Sandbox) GetUpdatedAt() *timestamppb.Timestamp {
 }
 
 type SandboxOptions struct {
-	state             protoimpl.MessageState `protogen:"open.v1"`
-	ReadOnlyWorkspace bool                   `protobuf:"varint,2,opt,name=read_only_workspace,json=readOnlyWorkspace,proto3" json:"read_only_workspace,omitempty"`
-	LaunchSeconds     int64                  `protobuf:"varint,3,opt,name=launch_seconds,json=launchSeconds,proto3" json:"launch_seconds,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	LaunchSeconds int64                  `protobuf:"varint,3,opt,name=launch_seconds,json=launchSeconds,proto3" json:"launch_seconds,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *SandboxOptions) Reset() {
@@ -261,13 +260,6 @@ func (x *SandboxOptions) ProtoReflect() protoreflect.Message {
 // Deprecated: Use SandboxOptions.ProtoReflect.Descriptor instead.
 func (*SandboxOptions) Descriptor() ([]byte, []int) {
 	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{1}
-}
-
-func (x *SandboxOptions) GetReadOnlyWorkspace() bool {
-	if x != nil {
-		return x.ReadOnlyWorkspace
-	}
-	return false
 }
 
 func (x *SandboxOptions) GetLaunchSeconds() int64 {
@@ -898,13 +890,12 @@ func (x *Execution) GetRunId() string {
 }
 
 type ExecutionOptions struct {
-	state             protoimpl.MessageState `protogen:"open.v1"`
-	ReadOnlyWorkspace bool                   `protobuf:"varint,2,opt,name=read_only_workspace,json=readOnlyWorkspace,proto3" json:"read_only_workspace,omitempty"`
-	LaunchSeconds     int64                  `protobuf:"varint,5,opt,name=launch_seconds,json=launchSeconds,proto3" json:"launch_seconds,omitempty"`
-	Tty               bool                   `protobuf:"varint,6,opt,name=tty,proto3" json:"tty,omitempty"`
-	Cwd               string                 `protobuf:"bytes,7,opt,name=cwd,proto3" json:"cwd,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	LaunchSeconds int64                  `protobuf:"varint,5,opt,name=launch_seconds,json=launchSeconds,proto3" json:"launch_seconds,omitempty"`
+	Tty           bool                   `protobuf:"varint,6,opt,name=tty,proto3" json:"tty,omitempty"`
+	Cwd           string                 `protobuf:"bytes,7,opt,name=cwd,proto3" json:"cwd,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ExecutionOptions) Reset() {
@@ -935,13 +926,6 @@ func (x *ExecutionOptions) ProtoReflect() protoreflect.Message {
 // Deprecated: Use ExecutionOptions.ProtoReflect.Descriptor instead.
 func (*ExecutionOptions) Descriptor() ([]byte, []int) {
 	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{13}
-}
-
-func (x *ExecutionOptions) GetReadOnlyWorkspace() bool {
-	if x != nil {
-		return x.ReadOnlyWorkspace
-	}
-	return false
 }
 
 func (x *ExecutionOptions) GetLaunchSeconds() int64 {
@@ -2036,10 +2020,9 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\n" +
 	"created_at\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x129\n" +
 	"\n" +
-	"updated_at\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\tupdatedAt\"g\n" +
-	"\x0eSandboxOptions\x12.\n" +
-	"\x13read_only_workspace\x18\x02 \x01(\bR\x11readOnlyWorkspace\x12%\n" +
-	"\x0elaunch_seconds\x18\x03 \x01(\x03R\rlaunchSeconds\"z\n" +
+	"updated_at\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\tupdatedAt\"R\n" +
+	"\x0eSandboxOptions\x12%\n" +
+	"\x0elaunch_seconds\x18\x03 \x01(\x03R\rlaunchSecondsJ\x04\b\x02\x10\x03R\x13read_only_workspace\"z\n" +
 	"\x14CreateSandboxRequest\x12\x10\n" +
 	"\x03cwd\x18\x01 \x01(\tR\x03cwd\x12\x18\n" +
 	"\abackend\x18\x02 \x01(\tR\abackend\x126\n" +
@@ -2089,12 +2072,11 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\vfinished_at\x18\a \x01(\v2\x1a.google.protobuf.TimestampR\n" +
 	"finishedAt\x12\x10\n" +
 	"\x03tty\x18\b \x01(\bR\x03tty\x12\x15\n" +
-	"\x06run_id\x18\t \x01(\tR\x05runId\"\x8d\x01\n" +
-	"\x10ExecutionOptions\x12.\n" +
-	"\x13read_only_workspace\x18\x02 \x01(\bR\x11readOnlyWorkspace\x12%\n" +
+	"\x06run_id\x18\t \x01(\tR\x05runId\"x\n" +
+	"\x10ExecutionOptions\x12%\n" +
 	"\x0elaunch_seconds\x18\x05 \x01(\x03R\rlaunchSeconds\x12\x10\n" +
 	"\x03tty\x18\x06 \x01(\bR\x03tty\x12\x10\n" +
-	"\x03cwd\x18\a \x01(\tR\x03cwd\"\x8b\x01\n" +
+	"\x03cwd\x18\a \x01(\tR\x03cwdJ\x04\b\x02\x10\x03R\x13read_only_workspace\"\x8b\x01\n" +
 	"\x16CreateExecutionRequest\x12\x1d\n" +
 	"\n" +
 	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\x12\x18\n" +

--- a/internal/runtimeconfig/config.go
+++ b/internal/runtimeconfig/config.go
@@ -12,12 +12,7 @@ import (
 
 type Config struct {
 	DefaultBackend string    `yaml:"default_backend"`
-	Workspace      Workspace `yaml:"workspace"`
-	Backends       Backends  `yaml:"backends"`
-}
-
-type Workspace struct {
-	Access string `yaml:"access"` // rw|ro
+	Backends Backends `yaml:"backends"`
 }
 
 type Backends struct {
@@ -68,9 +63,5 @@ func Load() (Config, string, error) {
 	}
 
 	cfg.DefaultBackend = strings.TrimSpace(cfg.DefaultBackend)
-	cfg.Workspace.Access = strings.TrimSpace(strings.ToLower(cfg.Workspace.Access))
-	if cfg.Workspace.Access == "" {
-		cfg.Workspace.Access = "rw"
-	}
 	return cfg, path, nil
 }

--- a/internal/vsockexec/protocol.go
+++ b/internal/vsockexec/protocol.go
@@ -13,11 +13,9 @@ const DefaultPort uint32 = 10700
 
 type ExecRequest struct {
 	Command         []string `json:"command"`
-	Dir             string   `json:"dir,omitempty"`
-	Env             []string `json:"env,omitempty"`
-	WorkspaceTarGz  []byte   `json:"workspace_tar_gz,omitempty"`
-	WorkspaceAccess string   `json:"workspace_access,omitempty"` // rw|ro
-	EntropySeed     []byte   `json:"entropy_seed,omitempty"`
+	Dir         string   `json:"dir,omitempty"`
+	Env         []string `json:"env,omitempty"`
+	EntropySeed []byte   `json:"entropy_seed,omitempty"`
 }
 
 type ExecResponse struct {

--- a/proto/cleanroom/v1/control.proto
+++ b/proto/cleanroom/v1/control.proto
@@ -41,7 +41,8 @@ enum SandboxStatus {
 }
 
 message SandboxOptions {
-  bool read_only_workspace = 2;
+  reserved 2;
+  reserved "read_only_workspace";
   int64 launch_seconds = 3;
 }
 
@@ -116,7 +117,8 @@ enum ExecutionStatus {
 }
 
 message ExecutionOptions {
-  bool read_only_workspace = 2;
+  reserved 2;
+  reserved "read_only_workspace";
   int64 launch_seconds = 5;
   bool tty = 6;
   string cwd = 7;


### PR DESCRIPTION
Remove the tar.gz workspace archive pipeline that copied host files into the guest VM via vsock. This was a temporary MVP approach that doesn't work for remote execution and needs redesigning with proper workspace delivery (git-based sync, streaming upload, or similar).

## What changed

Removed across the full stack (11 files, -382 lines):

- **CLI**: `--read-only-workspace` flag from `exec` and `console` commands
- **Proto**: `read_only_workspace` from `SandboxOptions` and `ExecutionOptions` (field numbers reserved for wire compatibility)
- **Backend types**: `WorkspaceHost`, `WorkspaceAccess` from `FirecrackerConfig`
- **Firecracker backend**: `createWorkspaceArchive`, `limitedWriter`, `buildGuestEnv`, workspace doctor checks, workspace archive timing
- **Guest agent**: `materializeWorkspace`, `extractTarGz`, `makeTreeReadOnly`
- **Vsock protocol**: `WorkspaceTarGz`, `WorkspaceAccess` from `ExecRequest`
- **Control service**: workspace access plumbing and `resolveWorkspaceAccess`
- **Control API**: `ReadOnlyWorkspace` from `ExecOptions` and `LaunchCleanroomOptions`
- **Runtime config**: `Workspace` struct and config section
- **Docs**: workspace copy references, config examples, remote client example

## Why

The current workspace copy model tars up the host directory and sends the entire archive over vsock to the guest agent. This has several problems:

1. Doesn't work for remote execution — the client's local workspace isn't on the server
2. Size-limited to 256MB (arbitrary)
3. Slow for large workspaces
4. No incremental updates

Workspace delivery will be re-added later with a proper design (likely git-based sync where the server clones a repo+ref).

## Testing

- `go build ./...` passes
- `go test ./...` passes (all existing tests)