### PR TITLE
Add persistent sandbox reuse for exec and console

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,10 @@ require (
 	connectrpc.com/connect v1.18.1
 	github.com/alecthomas/kong v1.12.1
 	github.com/charmbracelet/log v0.4.2
-	github.com/creack/pty v1.1.24
 	github.com/firecracker-microvm/firecracker-go-sdk v1.0.0
 	github.com/google/go-containerregistry v0.20.2
 	github.com/mdlayher/vsock v1.2.1
+	go.jetify.com/typeid v1.3.0
 	golang.org/x/net v0.38.0
 	golang.org/x/sys v0.32.0
 	golang.org/x/term v0.31.0
@@ -47,6 +47,7 @@ require (
 	github.com/coder/websocket v1.8.12 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.16.3 // indirect
 	github.com/coreos/go-iptables v0.7.1-0.20240112124308-65c67c9f46e6 // indirect
+	github.com/creack/pty v1.1.24 // indirect
 	github.com/dblohm7/wingoes v0.0.0-20240119213807-a09d6be7affa // indirect
 	github.com/digitalocean/go-smbios v0.0.0-20180907143718-390a4f403a8e // indirect
 	github.com/docker/cli v27.4.1+incompatible // indirect
@@ -59,6 +60,7 @@ require (
 	github.com/go-logfmt/logfmt v0.6.0 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/godbus/dbus/v5 v5.1.1-0.20230522191255-76236955d466 // indirect
+	github.com/gofrs/uuid/v5 v5.2.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/btree v1.1.2 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -420,6 +420,8 @@ github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5x
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.1.1-0.20230522191255-76236955d466 h1:sQspH8M4niEijh3PFscJRLDnkL547IeP7kpPe3uUhEg=
 github.com/godbus/dbus/v5 v5.1.1-0.20230522191255-76236955d466/go.mod h1:ZiQxhyQ+bbbfxUKVvjfO498oPYvtYhZzycal3G/NHmU=
+github.com/gofrs/uuid/v5 v5.2.0 h1:qw1GMx6/y8vhVsx626ImfKMuS5CvJmhIKKtuyvfajMM=
+github.com/gofrs/uuid/v5 v5.2.0/go.mod h1:CDOjlDMVAtN56jqyRUZh58JT31Tiw7/oQyEXZV+9bD8=
 github.com/gogo/googleapis v1.2.0/go.mod h1:Njal3psf3qN6dwBtQfUmBZh2ybovJ0tlu3o/AC7HYjU=
 github.com/gogo/googleapis v1.4.0/go.mod h1:5YRNX2z1oM5gXdAkurHa942MDgEJyk02w4OecKY87+c=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -902,6 +904,8 @@ go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.5/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
 go.etcd.io/etcd v0.5.0-alpha.5.0.20200910180754-dd1b699fc489/go.mod h1:yVHk9ub3CSBatqGNg7GRmsnfLWtoW60w4eDYfh7vHDg=
+go.jetify.com/typeid v1.3.0 h1:fuWV7oxO4mSsgpxwhaVpFXgt0IfjogR29p+XAjDCVKY=
+go.jetify.com/typeid v1.3.0/go.mod h1:CtVGyt2+TSp4Rq5+ARLvGsJqdNypKBAC6INQ9TLPlmk=
 go.mongodb.org/mongo-driver v1.7.3/go.mod h1:NqaYOwnXWr5Pm7AOpO5QFxKJ503nbMse/R79oO62zWg=
 go.mongodb.org/mongo-driver v1.7.5/go.mod h1:VXEWRZ6URJIkUq2SCAyapmhH0ZLRBP+FT4xhp5Zvxng=
 go.mongodb.org/mongo-driver v1.8.3/go.mod h1:0sQWfOeY63QTntERDJJ/0SuKK0T1uVSgKCuAROlKEPY=

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -11,6 +11,21 @@ type Adapter interface {
 	Run(ctx context.Context, req RunRequest) (*RunResult, error)
 }
 
+// PersistentSandboxAdapter supports provisioned sandbox instances that can run
+// multiple executions before explicit termination.
+type PersistentSandboxAdapter interface {
+	Adapter
+	ProvisionSandbox(ctx context.Context, req ProvisionRequest) error
+	RunInSandbox(ctx context.Context, req RunRequest, stream OutputStream) (*RunResult, error)
+	TerminateSandbox(ctx context.Context, sandboxID string) error
+}
+
+type ProvisionRequest struct {
+	SandboxID string
+	Policy    *policy.CompiledPolicy
+	FirecrackerConfig
+}
+
 type AttachIO struct {
 	WriteStdin func([]byte) error
 	ResizeTTY  func(cols, rows uint32) error
@@ -30,10 +45,11 @@ type StreamingAdapter interface {
 }
 
 type RunRequest struct {
-	RunID   string
-	Command []string
-	TTY     bool
-	Policy  *policy.CompiledPolicy
+	SandboxID string
+	RunID     string
+	Command   []string
+	TTY       bool
+	Policy    *policy.CompiledPolicy
 	FirecrackerConfig
 }
 

--- a/internal/backend/firecracker/persistent_test.go
+++ b/internal/backend/firecracker/persistent_test.go
@@ -1,0 +1,99 @@
+package firecracker
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/policy"
+)
+
+func TestProvisionSandboxRejectsConcurrentProvisionForSameID(t *testing.T) {
+	t.Parallel()
+
+	block := make(chan struct{})
+	started := make(chan struct{})
+	adapter := &Adapter{
+		launchSandboxVMFn: func(_ context.Context, sandboxID string, _ *policy.CompiledPolicy, _ backend.FirecrackerConfig) (*sandboxInstance, error) {
+			if sandboxID != "cr-test" {
+				t.Fatalf("unexpected sandbox id %q", sandboxID)
+			}
+			select {
+			case started <- struct{}{}:
+			default:
+			}
+			<-block
+			return &sandboxInstance{SandboxID: sandboxID}, nil
+		},
+	}
+
+	compiled := &policy.CompiledPolicy{NetworkDefault: "deny", ImageRef: "ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- adapter.ProvisionSandbox(context.Background(), backend.ProvisionRequest{SandboxID: "cr-test", Policy: compiled})
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first provision to start")
+	}
+
+	err := adapter.ProvisionSandbox(context.Background(), backend.ProvisionRequest{SandboxID: "cr-test", Policy: compiled})
+	if err == nil {
+		t.Fatal("expected second provision to fail")
+	}
+
+	close(block)
+	if err := <-errCh; err != nil {
+		t.Fatalf("first provision returned error: %v", err)
+	}
+}
+
+func TestSandboxShutdownRemovesRunDir(t *testing.T) {
+	t.Parallel()
+
+	runDir := t.TempDir()
+	artifactPath := filepath.Join(runDir, "artifact.txt")
+	if err := os.WriteFile(artifactPath, []byte("hello"), 0o644); err != nil {
+		t.Fatalf("write artifact: %v", err)
+	}
+
+	instance := &sandboxInstance{RunDir: runDir}
+	instance.shutdown()
+
+	if _, err := os.Stat(runDir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected run dir to be removed, got err=%v", err)
+	}
+}
+
+func TestRunInSandboxUsesRequestLaunchSecondsOverride(t *testing.T) {
+	t.Parallel()
+
+	adapter := &Adapter{}
+	adapter.sandboxes = map[string]*sandboxInstance{
+		"cr-test": {
+			SandboxID:      "cr-test",
+			VsockPath:      "/tmp/does-not-exist.sock",
+			GuestPort:      10700,
+			CommandTimeout: 1,
+		},
+	}
+
+	start := time.Now()
+	_, err := adapter.RunInSandbox(context.Background(), backend.RunRequest{
+		SandboxID:         "cr-test",
+		Command:           []string{"echo", "hello"},
+		FirecrackerConfig: backend.FirecrackerConfig{LaunchSeconds: 3},
+	}, backend.OutputStream{})
+	if err == nil {
+		t.Fatal("expected run to fail for missing vsock")
+	}
+	if elapsed := time.Since(start); elapsed < 2*time.Second {
+		t.Fatalf("expected launch-seconds override to increase timeout, elapsed=%s err=%v", elapsed, err)
+	}
+}

--- a/internal/controlservice/ids.go
+++ b/internal/controlservice/ids.go
@@ -1,0 +1,38 @@
+package controlservice
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"go.jetify.com/typeid"
+)
+
+var generateTypeID = func(prefix string) (string, error) {
+	id, err := typeid.WithPrefix(prefix)
+	if err != nil {
+		return "", err
+	}
+	return id.String(), nil
+}
+
+func newSandboxID() string {
+	return newID("cr")
+}
+
+func newExecutionID() string {
+	return newID("exec")
+}
+
+func newRunID() string {
+	return newID("run")
+}
+
+func newID(prefix string) string {
+	id, err := generateTypeID(prefix)
+	if err == nil && strings.TrimSpace(id) != "" {
+		return id
+	}
+
+	return fmt.Sprintf("%s-%d", prefix, time.Now().UTC().UnixNano())
+}

--- a/internal/controlservice/ids_test.go
+++ b/internal/controlservice/ids_test.go
@@ -1,0 +1,49 @@
+package controlservice
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"go.jetify.com/typeid"
+)
+
+func TestNewIDUsesTypeIDWhenGeneratorSucceeds(t *testing.T) {
+	originalGenerator := generateTypeID
+	t.Cleanup(func() {
+		generateTypeID = originalGenerator
+	})
+
+	generateTypeID = func(prefix string) (string, error) {
+		id, err := typeid.WithPrefix(prefix)
+		if err != nil {
+			return "", err
+		}
+		return id.String(), nil
+	}
+
+	id := newID("cr")
+	parsed, err := typeid.FromString(id)
+	if err != nil {
+		t.Fatalf("expected generated id to be parseable typeid, got %q: %v", id, err)
+	}
+	if got, want := parsed.Prefix(), "cr"; got != want {
+		t.Fatalf("unexpected generated id prefix: got %q want %q", got, want)
+	}
+}
+
+func TestNewIDFallsBackToTimestampShapeWhenGeneratorFails(t *testing.T) {
+	originalGenerator := generateTypeID
+	t.Cleanup(func() {
+		generateTypeID = originalGenerator
+	})
+
+	generateTypeID = func(string) (string, error) {
+		return "", errors.New("boom")
+	}
+
+	id := newID("exec")
+	if !strings.HasPrefix(id, "exec-") {
+		t.Fatalf("expected fallback id to keep legacy shape, got %q", id)
+	}
+}


### PR DESCRIPTION
## Summary
- add a persistent sandbox backend contract (`ProvisionSandbox`, `RunInSandbox`, `TerminateSandbox`) and plumb sandbox IDs through run requests
- provision persistent backends during `CreateSandbox`, run executions against the provisioned instance, and terminate backend resources on `TerminateSandbox`
- enforce one active execution per sandbox with a stable `sandbox_busy` error
- add CLI support for sandbox reuse with `--sandbox-id` and lifecycle control with `--keep-sandbox` for both `exec` and `console`
- implement persistent VM lifecycle in the firecracker adapter so multiple executions run against the same launched instance
- add integration/unit tests for keep/reuse paths and busy-sandbox behaviour

## Testing
- `go test ./...`
