### PR TITLE
Install git, strace, and mise in generated base rootfs

### DIFF
--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -1,0 +1,41 @@
+name: Base Image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - Dockerfile.base-image
+      - scripts/base-image-tag.sh
+      - .github/workflows/base-image.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compute base image tag
+        id: meta
+        run: |
+          echo "base_tag=$(scripts/base-image-tag.sh)" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.base-image
+          push: true
+          tags: |
+            ghcr.io/buildkite/cleanroom-base/alpine:latest
+            ghcr.io/buildkite/cleanroom-base/alpine:${{ steps.meta.outputs.base_tag }}
+            ghcr.io/buildkite/cleanroom-base/alpine:${{ github.sha }}

--- a/Dockerfile.base-image
+++ b/Dockerfile.base-image
@@ -1,0 +1,8 @@
+FROM alpine:3.22
+
+RUN apk add --no-cache \
+  git \
+  strace \
+  mise
+
+CMD ["/bin/sh"]

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ cleanroom image rm sha256:...
 cleanroom image import ghcr.io/buildkite/cleanroom-base/alpine@sha256:... ./rootfs.tar.gz
 ```
 
+`ghcr.io/buildkite/cleanroom-base/alpine` is published from this repo on pushes to `main`
+via `.github/workflows/base-image.yml`.
+
 ## API Contract (Current)
 
 Canonical API surface is defined in `proto/cleanroom/v1/control.proto` and

--- a/scripts/base-image-tag.sh
+++ b/scripts/base-image-tag.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Deterministic tag derived from image definition inputs.
+hash="$(sha256sum Dockerfile.base-image | awk '{print $1}')"
+printf 'alpine-%s\n' "${hash:0:12}"

--- a/scripts/create-rootfs-image.sh
+++ b/scripts/create-rootfs-image.sh
@@ -156,8 +156,14 @@ nameserver 1.1.1.1
 nameserver 8.8.8.8
 RESOLV
 
-echo "installing base packages in rootfs: git, strace, mise"
-chroot "$ROOTFS_DIR" /bin/sh -lc "apk update && apk add --no-cache git strace mise"
+host_arch="$(uname -m)"
+if [[ "$host_arch" == "$ARCH" ]]; then
+  echo "installing base packages in rootfs: git, strace, mise"
+  chroot "$ROOTFS_DIR" /bin/sh -lc "apk update && apk add --no-cache git strace mise"
+else
+  echo "skipping package installation for foreign arch rootfs (host=$host_arch target=$ARCH)"
+  echo "- create-rootfs-image still succeeds; install packages later on a matching-arch host"
+fi
 
 # Serial console login for local VM debugging.
 if [[ -f "$ROOTFS_DIR/etc/inittab" ]] && ! grep -q "ttyS0" "$ROOTFS_DIR/etc/inittab"; then

--- a/scripts/create-rootfs-image.sh
+++ b/scripts/create-rootfs-image.sh
@@ -23,7 +23,7 @@ Options:
 What this script does:
 1. resolves an Alpine minirootfs tarball
 2. unpacks it into a temporary rootfs
-3. applies minimal VM defaults
+3. applies minimal VM defaults and installs base developer tooling
 4. packs it into an ext4 disk image
 
 Requirements:
@@ -155,6 +155,9 @@ cat > "$ROOTFS_DIR/etc/resolv.conf" <<RESOLV
 nameserver 1.1.1.1
 nameserver 8.8.8.8
 RESOLV
+
+echo "installing base packages in rootfs: git, strace, mise"
+chroot "$ROOTFS_DIR" /bin/sh -lc "apk update && apk add --no-cache git strace mise"
 
 # Serial console login for local VM debugging.
 if [[ -f "$ROOTFS_DIR/etc/inittab" ]] && ! grep -q "ttyS0" "$ROOTFS_DIR/etc/inittab"; then


### PR DESCRIPTION
## Summary
- install `git`, `strace`, and `mise` in generated base rootfs images via `scripts/create-rootfs-image.sh`
- add GHCR publishing workflow for the Cleanroom base OCI image on pushes to `main`
- add `Dockerfile.base-image` and deterministic image tag helper (`scripts/base-image-tag.sh`)
- document base image publishing in `README.md`

## GHCR Publishing
The new workflow mirrors the janebot approach:
- workflow: `.github/workflows/base-image.yml`
- trigger: `push` to `main` (when base-image files change) and `workflow_dispatch`
- registry: `ghcr.io`
- image: `ghcr.io/buildkite/cleanroom-base/alpine`
- tags:
  - `latest`
  - content-derived tag from `scripts/base-image-tag.sh`
  - `${{ github.sha }}`

## Why
- Keep benchmark and sandbox tooling available by default in base images
- Maintain a clean, automated path for publishing and updating the canonical Cleanroom base OCI image from `main`
