### PR TITLE
feat(git): add gateway foundations + plan

### DIFF
--- a/docs/plans/git-gateway.md
+++ b/docs/plans/git-gateway.md
@@ -1,0 +1,207 @@
+# Git Gateway MVP Plan
+
+## Summary
+
+This plan defines an MVP for a controllable Git endpoint in Cleanroom that enables
+`git clone`/`fetch` inside the sandbox without changing user commands.
+
+MVP goal:
+- Route Git smart-HTTP traffic through a Cleanroom-managed gateway.
+- Enforce allowlisted Git destinations from policy.
+- Support quick repo sandboxing with optional local mirror acceleration.
+
+Review-driven adjustments included in this revision:
+- Use a vsock transport between guest and host (not guest->host loopback assumptions).
+- Scope URL rewrites by allowed host(s), not a global `https://` catch-all.
+- Sequence phases so policy integration lands before allowlist enforcement acceptance checks.
+
+Out of scope for MVP:
+- Push (`git-receive-pack`) and PR write flows.
+- Full secret injection/tokenizer integration.
+- Workspace upload/mount for uncommitted host trees.
+
+## Non-Goals (MVP)
+
+- Replacing existing package content-cache behavior.
+- Designing a full multi-tenant Git hosting product.
+- Protocol translation for SSH remotes.
+
+## Desired User Experience
+
+Users should be able to run existing commands in a sandbox unchanged:
+
+```bash
+git clone https://github.com/org/repo.git
+git fetch
+```
+
+without manually setting proxy flags, while Cleanroom enforces policy and emits
+auditable allow/deny events.
+
+## Proposed Architecture
+
+1. Host-side Git gateway process
+- Started and managed by Cleanroom runtime during sandbox provisioning.
+- Listens on a host vsock port (for example `CID=host, port=17080`) via a narrow
+  HTTP-over-vsock transport adapter.
+- Handles smart-HTTP fetch endpoints:
+  - `GET /git/<host>/<org>/<repo>.git/info/refs?service=git-upload-pack`
+  - `POST /git/<host>/<org>/<repo>.git/git-upload-pack`
+
+2. Guest-local relay shim
+- A tiny in-guest relay listens on `127.0.0.1:<port>` and forwards HTTP requests
+  over vsock to the host-side gateway.
+- This preserves normal Git HTTP client behavior while keeping host services off
+  routed guest network paths.
+
+3. Sandbox Git URL rewrite (scoped)
+- Runtime injects temporary Git config entries per allowed host, for example:
+  - `url."http://127.0.0.1:<port>/git/github.com/".insteadOf=https://github.com/`
+- Commands continue to use upstream `https://` remotes; Git rewrites internally.
+
+4. Policy-driven enforcement in gateway
+- Parse target host/repo from rewritten path.
+- Allow only policy-approved destinations; deny otherwise.
+- Emit stable reason codes for deny decisions.
+
+5. Source mode
+- `upstream` mode: proxy to upstream origin over HTTPS.
+- `host_mirror` mode: prefer local bare mirror (if present), else fallback to upstream.
+
+## Policy Shape (MVP)
+
+Add minimal policy keys under `sandbox.git`:
+
+```yaml
+sandbox:
+  git:
+    enabled: true
+    source: upstream # upstream | host_mirror
+    allowed_hosts:
+      - github.com
+    allowed_repos:
+      - org/repo
+      - org/another-repo
+```
+
+Notes:
+- `allowed_repos` is optional; if omitted, host-level allow applies.
+- Matching is exact in MVP (`host`, `org/repo`) to avoid wildcard ambiguity.
+
+## API/Runtime Changes
+
+No external control-plane RPC changes required for MVP.
+
+Implementation touches:
+- Policy compiler: parse/validate `sandbox.git` block into compiled policy.
+- Runtime backend provisioning: start/stop gateway lifecycle with sandbox.
+- Guest execution environment: start/stop relay shim and inject temporary scoped Git config.
+- Observability/eventing: add Git allow/deny records.
+
+## Phased Implementation
+
+## Phase 1: Policy + Transport Foundations
+
+Scope:
+- Policy parser/compiler support for `sandbox.git`.
+- Implement guest relay + host gateway transport over vsock.
+- Upstream proxy mode only.
+
+Deliverables:
+- Validation errors for invalid/empty host/repo entries.
+- Internal packages for relay, gateway server, and route parsing.
+- Scoped rewrite injection helper (per-host `insteadOf` entries).
+
+Acceptance:
+- A sandbox can reach gateway only through the guest relay over vsock.
+- Scoped rewrite entries are generated only for configured `allowed_hosts`.
+
+## Phase 2: Gateway Read Path Enforcement
+
+Scope:
+- Implement smart-HTTP fetch endpoints in gateway.
+- Enforce allowlist decisions from compiled policy.
+
+Deliverables:
+- Request handling for `info/refs?service=git-upload-pack` and `git-upload-pack`.
+- Deny-path reason mapping and structured event emission.
+
+Acceptance:
+- `git clone https://github.com/<allowed>/repo.git` succeeds in sandbox.
+- Non-allowlisted host/repo returns explicit deny reason.
+- Existing commands require no user rewrite/proxy flags.
+
+## Phase 3: Host Mirror Fast Path
+
+Scope:
+- Add `source: host_mirror` behavior.
+- Resolve local bare mirror path and serve/proxy accordingly.
+
+Deliverables:
+- Mirror resolver logic with fallback to upstream.
+- Tests for mirror hit/miss fallback behavior.
+
+Acceptance:
+- Mirror-backed clone works when mirror exists.
+- Missing mirror falls back without breaking clone.
+
+## Security Controls (MVP)
+
+- Deny by default for all Git destinations not in policy.
+- No plaintext credentials stored in repository policy.
+- Host gateway is not exposed on guest-routable TCP interfaces.
+- Gateway strips/controls headers forwarded upstream.
+- Structured deny reasons include at least:
+  - `host_not_allowed`
+  - `repository_not_allowed`
+  - `runtime_launch_failed` (gateway startup failure path)
+
+## Observability
+
+Emit per-request structured events with:
+- `run_id`
+- `sandbox_id`
+- `backend`
+- `request_host`
+- `request_repo`
+- `decision` (`allow`/`deny`)
+- `reason_code`
+- latency and upstream/cache source indicator
+
+## Testing Strategy
+
+1. Unit tests
+- Policy parsing/validation for `sandbox.git`.
+- Path/host/repo parsing and match logic.
+- Deny reason mapping.
+
+2. Integration tests
+- Sandbox clone success for allowlisted repo.
+- Deny for disallowed host/repo.
+- Guest relay over vsock works; direct host loopback access is not required.
+- `host_mirror` resolution and fallback behavior.
+
+3. Smoke tests
+- `cleanroom exec -- git clone https://...`
+- `cleanroom exec -- git fetch`
+
+## Risks and Mitigations
+
+- Risk: Smart HTTP edge-case incompatibilities across Git versions.
+  - Mitigation: keep gateway as transparent as possible; add protocol-level fixture tests.
+
+- Risk: Over-broad rewrite captures unrelated HTTPS usage.
+  - Mitigation: per-host `insteadOf` entries only; no global `https://` rewrite.
+
+- Risk: vsock transport could regress under very high concurrency.
+  - Mitigation: keep relay/gateway streaming and benchmark clone/fetch throughput against TAP path.
+
+- Risk: Local mirror path trust boundary confusion.
+  - Mitigation: explicit `host_mirror` mode gate and strict path validation.
+
+## Follow-Up Work (Post-MVP)
+
+- Add push support (`git-receive-pack`) with authenticated write policy.
+- Integrate short-lived upstream auth token injection.
+- Add workspace ingress flow (upload/mount/snapshot) for uncommitted local trees.
+- Expand policy matching semantics (wildcards, org-level rules) with deterministic precedence.

--- a/internal/gen/cleanroom/v1/control.pb.go
+++ b/internal/gen/cleanroom/v1/control.pb.go
@@ -277,11 +277,80 @@ func (x *PolicyAllowRule) GetPorts() []int32 {
 	return nil
 }
 
+type PolicyGit struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Enabled       bool                   `protobuf:"varint,1,opt,name=enabled,proto3" json:"enabled,omitempty"`
+	Source        string                 `protobuf:"bytes,2,opt,name=source,proto3" json:"source,omitempty"`
+	AllowedHosts  []string               `protobuf:"bytes,3,rep,name=allowed_hosts,json=allowedHosts,proto3" json:"allowed_hosts,omitempty"`
+	AllowedRepos  []string               `protobuf:"bytes,4,rep,name=allowed_repos,json=allowedRepos,proto3" json:"allowed_repos,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PolicyGit) Reset() {
+	*x = PolicyGit{}
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PolicyGit) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PolicyGit) ProtoMessage() {}
+
+func (x *PolicyGit) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PolicyGit.ProtoReflect.Descriptor instead.
+func (*PolicyGit) Descriptor() ([]byte, []int) {
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *PolicyGit) GetEnabled() bool {
+	if x != nil {
+		return x.Enabled
+	}
+	return false
+}
+
+func (x *PolicyGit) GetSource() string {
+	if x != nil {
+		return x.Source
+	}
+	return ""
+}
+
+func (x *PolicyGit) GetAllowedHosts() []string {
+	if x != nil {
+		return x.AllowedHosts
+	}
+	return nil
+}
+
+func (x *PolicyGit) GetAllowedRepos() []string {
+	if x != nil {
+		return x.AllowedRepos
+	}
+	return nil
+}
+
 type Policy struct {
 	state          protoimpl.MessageState `protogen:"open.v1"`
 	Version        int32                  `protobuf:"varint,1,opt,name=version,proto3" json:"version,omitempty"`
 	ImageRef       string                 `protobuf:"bytes,2,opt,name=image_ref,json=imageRef,proto3" json:"image_ref,omitempty"`
 	ImageDigest    string                 `protobuf:"bytes,3,opt,name=image_digest,json=imageDigest,proto3" json:"image_digest,omitempty"`
+	Git            *PolicyGit             `protobuf:"bytes,7,opt,name=git,proto3" json:"git,omitempty"`
 	NetworkDefault string                 `protobuf:"bytes,4,opt,name=network_default,json=networkDefault,proto3" json:"network_default,omitempty"`
 	Allow          []*PolicyAllowRule     `protobuf:"bytes,5,rep,name=allow,proto3" json:"allow,omitempty"`
 	Hash           string                 `protobuf:"bytes,6,opt,name=hash,proto3" json:"hash,omitempty"`
@@ -291,7 +360,7 @@ type Policy struct {
 
 func (x *Policy) Reset() {
 	*x = Policy{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[2]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -303,7 +372,7 @@ func (x *Policy) String() string {
 func (*Policy) ProtoMessage() {}
 
 func (x *Policy) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[2]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -316,7 +385,7 @@ func (x *Policy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Policy.ProtoReflect.Descriptor instead.
 func (*Policy) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{2}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *Policy) GetVersion() int32 {
@@ -338,6 +407,13 @@ func (x *Policy) GetImageDigest() string {
 		return x.ImageDigest
 	}
 	return ""
+}
+
+func (x *Policy) GetGit() *PolicyGit {
+	if x != nil {
+		return x.Git
+	}
+	return nil
 }
 
 func (x *Policy) GetNetworkDefault() string {
@@ -370,7 +446,7 @@ type SandboxOptions struct {
 
 func (x *SandboxOptions) Reset() {
 	*x = SandboxOptions{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[3]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -382,7 +458,7 @@ func (x *SandboxOptions) String() string {
 func (*SandboxOptions) ProtoMessage() {}
 
 func (x *SandboxOptions) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[3]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -395,7 +471,7 @@ func (x *SandboxOptions) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxOptions.ProtoReflect.Descriptor instead.
 func (*SandboxOptions) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{3}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *SandboxOptions) GetLaunchSeconds() int64 {
@@ -416,7 +492,7 @@ type CreateSandboxRequest struct {
 
 func (x *CreateSandboxRequest) Reset() {
 	*x = CreateSandboxRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[4]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -428,7 +504,7 @@ func (x *CreateSandboxRequest) String() string {
 func (*CreateSandboxRequest) ProtoMessage() {}
 
 func (x *CreateSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[4]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -441,7 +517,7 @@ func (x *CreateSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSandboxRequest.ProtoReflect.Descriptor instead.
 func (*CreateSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{4}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *CreateSandboxRequest) GetBackend() string {
@@ -476,7 +552,7 @@ type CreateSandboxResponse struct {
 
 func (x *CreateSandboxResponse) Reset() {
 	*x = CreateSandboxResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[5]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -488,7 +564,7 @@ func (x *CreateSandboxResponse) String() string {
 func (*CreateSandboxResponse) ProtoMessage() {}
 
 func (x *CreateSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[5]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -501,7 +577,7 @@ func (x *CreateSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSandboxResponse.ProtoReflect.Descriptor instead.
 func (*CreateSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{5}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *CreateSandboxResponse) GetSandbox() *Sandbox {
@@ -534,7 +610,7 @@ type GetSandboxRequest struct {
 
 func (x *GetSandboxRequest) Reset() {
 	*x = GetSandboxRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[6]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -546,7 +622,7 @@ func (x *GetSandboxRequest) String() string {
 func (*GetSandboxRequest) ProtoMessage() {}
 
 func (x *GetSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[6]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -559,7 +635,7 @@ func (x *GetSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSandboxRequest.ProtoReflect.Descriptor instead.
 func (*GetSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{6}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *GetSandboxRequest) GetSandboxId() string {
@@ -578,7 +654,7 @@ type GetSandboxResponse struct {
 
 func (x *GetSandboxResponse) Reset() {
 	*x = GetSandboxResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[7]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -590,7 +666,7 @@ func (x *GetSandboxResponse) String() string {
 func (*GetSandboxResponse) ProtoMessage() {}
 
 func (x *GetSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[7]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -603,7 +679,7 @@ func (x *GetSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSandboxResponse.ProtoReflect.Descriptor instead.
 func (*GetSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{7}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *GetSandboxResponse) GetSandbox() *Sandbox {
@@ -621,7 +697,7 @@ type ListSandboxesRequest struct {
 
 func (x *ListSandboxesRequest) Reset() {
 	*x = ListSandboxesRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[8]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -633,7 +709,7 @@ func (x *ListSandboxesRequest) String() string {
 func (*ListSandboxesRequest) ProtoMessage() {}
 
 func (x *ListSandboxesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[8]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -646,7 +722,7 @@ func (x *ListSandboxesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSandboxesRequest.ProtoReflect.Descriptor instead.
 func (*ListSandboxesRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{8}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{9}
 }
 
 type ListSandboxesResponse struct {
@@ -658,7 +734,7 @@ type ListSandboxesResponse struct {
 
 func (x *ListSandboxesResponse) Reset() {
 	*x = ListSandboxesResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[9]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -670,7 +746,7 @@ func (x *ListSandboxesResponse) String() string {
 func (*ListSandboxesResponse) ProtoMessage() {}
 
 func (x *ListSandboxesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[9]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -683,7 +759,7 @@ func (x *ListSandboxesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSandboxesResponse.ProtoReflect.Descriptor instead.
 func (*ListSandboxesResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{9}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *ListSandboxesResponse) GetSandboxes() []*Sandbox {
@@ -704,7 +780,7 @@ type DownloadSandboxFileRequest struct {
 
 func (x *DownloadSandboxFileRequest) Reset() {
 	*x = DownloadSandboxFileRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[10]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -716,7 +792,7 @@ func (x *DownloadSandboxFileRequest) String() string {
 func (*DownloadSandboxFileRequest) ProtoMessage() {}
 
 func (x *DownloadSandboxFileRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[10]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -729,7 +805,7 @@ func (x *DownloadSandboxFileRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DownloadSandboxFileRequest.ProtoReflect.Descriptor instead.
 func (*DownloadSandboxFileRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{10}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *DownloadSandboxFileRequest) GetSandboxId() string {
@@ -765,7 +841,7 @@ type DownloadSandboxFileResponse struct {
 
 func (x *DownloadSandboxFileResponse) Reset() {
 	*x = DownloadSandboxFileResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[11]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -777,7 +853,7 @@ func (x *DownloadSandboxFileResponse) String() string {
 func (*DownloadSandboxFileResponse) ProtoMessage() {}
 
 func (x *DownloadSandboxFileResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[11]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -790,7 +866,7 @@ func (x *DownloadSandboxFileResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DownloadSandboxFileResponse.ProtoReflect.Descriptor instead.
 func (*DownloadSandboxFileResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{11}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *DownloadSandboxFileResponse) GetSandboxId() string {
@@ -830,7 +906,7 @@ type TerminateSandboxRequest struct {
 
 func (x *TerminateSandboxRequest) Reset() {
 	*x = TerminateSandboxRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[12]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -842,7 +918,7 @@ func (x *TerminateSandboxRequest) String() string {
 func (*TerminateSandboxRequest) ProtoMessage() {}
 
 func (x *TerminateSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[12]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -855,7 +931,7 @@ func (x *TerminateSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TerminateSandboxRequest.ProtoReflect.Descriptor instead.
 func (*TerminateSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{12}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *TerminateSandboxRequest) GetSandboxId() string {
@@ -876,7 +952,7 @@ type TerminateSandboxResponse struct {
 
 func (x *TerminateSandboxResponse) Reset() {
 	*x = TerminateSandboxResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[13]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -888,7 +964,7 @@ func (x *TerminateSandboxResponse) String() string {
 func (*TerminateSandboxResponse) ProtoMessage() {}
 
 func (x *TerminateSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[13]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -901,7 +977,7 @@ func (x *TerminateSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TerminateSandboxResponse.ProtoReflect.Descriptor instead.
 func (*TerminateSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{13}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *TerminateSandboxResponse) GetSandboxId() string {
@@ -935,7 +1011,7 @@ type StreamSandboxEventsRequest struct {
 
 func (x *StreamSandboxEventsRequest) Reset() {
 	*x = StreamSandboxEventsRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[14]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -947,7 +1023,7 @@ func (x *StreamSandboxEventsRequest) String() string {
 func (*StreamSandboxEventsRequest) ProtoMessage() {}
 
 func (x *StreamSandboxEventsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[14]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -960,7 +1036,7 @@ func (x *StreamSandboxEventsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamSandboxEventsRequest.ProtoReflect.Descriptor instead.
 func (*StreamSandboxEventsRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{14}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *StreamSandboxEventsRequest) GetSandboxId() string {
@@ -989,7 +1065,7 @@ type SandboxEvent struct {
 
 func (x *SandboxEvent) Reset() {
 	*x = SandboxEvent{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[15]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1001,7 +1077,7 @@ func (x *SandboxEvent) String() string {
 func (*SandboxEvent) ProtoMessage() {}
 
 func (x *SandboxEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[15]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1014,7 +1090,7 @@ func (x *SandboxEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxEvent.ProtoReflect.Descriptor instead.
 func (*SandboxEvent) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{15}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *SandboxEvent) GetSandboxId() string {
@@ -1062,7 +1138,7 @@ type Execution struct {
 
 func (x *Execution) Reset() {
 	*x = Execution{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[16]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1074,7 +1150,7 @@ func (x *Execution) String() string {
 func (*Execution) ProtoMessage() {}
 
 func (x *Execution) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[16]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1087,7 +1163,7 @@ func (x *Execution) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Execution.ProtoReflect.Descriptor instead.
 func (*Execution) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{16}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *Execution) GetExecutionId() string {
@@ -1163,7 +1239,7 @@ type ExecutionOptions struct {
 
 func (x *ExecutionOptions) Reset() {
 	*x = ExecutionOptions{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[17]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1175,7 +1251,7 @@ func (x *ExecutionOptions) String() string {
 func (*ExecutionOptions) ProtoMessage() {}
 
 func (x *ExecutionOptions) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[17]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1188,7 +1264,7 @@ func (x *ExecutionOptions) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionOptions.ProtoReflect.Descriptor instead.
 func (*ExecutionOptions) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{17}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *ExecutionOptions) GetLaunchSeconds() int64 {
@@ -1216,7 +1292,7 @@ type CreateExecutionRequest struct {
 
 func (x *CreateExecutionRequest) Reset() {
 	*x = CreateExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[18]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1228,7 +1304,7 @@ func (x *CreateExecutionRequest) String() string {
 func (*CreateExecutionRequest) ProtoMessage() {}
 
 func (x *CreateExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[18]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1241,7 +1317,7 @@ func (x *CreateExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateExecutionRequest.ProtoReflect.Descriptor instead.
 func (*CreateExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{18}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *CreateExecutionRequest) GetSandboxId() string {
@@ -1274,7 +1350,7 @@ type CreateExecutionResponse struct {
 
 func (x *CreateExecutionResponse) Reset() {
 	*x = CreateExecutionResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[19]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1286,7 +1362,7 @@ func (x *CreateExecutionResponse) String() string {
 func (*CreateExecutionResponse) ProtoMessage() {}
 
 func (x *CreateExecutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[19]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1299,7 +1375,7 @@ func (x *CreateExecutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateExecutionResponse.ProtoReflect.Descriptor instead.
 func (*CreateExecutionResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{19}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *CreateExecutionResponse) GetExecution() *Execution {
@@ -1319,7 +1395,7 @@ type GetExecutionRequest struct {
 
 func (x *GetExecutionRequest) Reset() {
 	*x = GetExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[20]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1331,7 +1407,7 @@ func (x *GetExecutionRequest) String() string {
 func (*GetExecutionRequest) ProtoMessage() {}
 
 func (x *GetExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[20]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1344,7 +1420,7 @@ func (x *GetExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetExecutionRequest.ProtoReflect.Descriptor instead.
 func (*GetExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{20}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *GetExecutionRequest) GetSandboxId() string {
@@ -1370,7 +1446,7 @@ type GetExecutionResponse struct {
 
 func (x *GetExecutionResponse) Reset() {
 	*x = GetExecutionResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[21]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1382,7 +1458,7 @@ func (x *GetExecutionResponse) String() string {
 func (*GetExecutionResponse) ProtoMessage() {}
 
 func (x *GetExecutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[21]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1395,7 +1471,7 @@ func (x *GetExecutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetExecutionResponse.ProtoReflect.Descriptor instead.
 func (*GetExecutionResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{21}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *GetExecutionResponse) GetExecution() *Execution {
@@ -1416,7 +1492,7 @@ type CancelExecutionRequest struct {
 
 func (x *CancelExecutionRequest) Reset() {
 	*x = CancelExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[22]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1428,7 +1504,7 @@ func (x *CancelExecutionRequest) String() string {
 func (*CancelExecutionRequest) ProtoMessage() {}
 
 func (x *CancelExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[22]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1441,7 +1517,7 @@ func (x *CancelExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelExecutionRequest.ProtoReflect.Descriptor instead.
 func (*CancelExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{22}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *CancelExecutionRequest) GetSandboxId() string {
@@ -1477,7 +1553,7 @@ type CancelExecutionResponse struct {
 
 func (x *CancelExecutionResponse) Reset() {
 	*x = CancelExecutionResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[23]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1489,7 +1565,7 @@ func (x *CancelExecutionResponse) String() string {
 func (*CancelExecutionResponse) ProtoMessage() {}
 
 func (x *CancelExecutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[23]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1502,7 +1578,7 @@ func (x *CancelExecutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelExecutionResponse.ProtoReflect.Descriptor instead.
 func (*CancelExecutionResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{23}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *CancelExecutionResponse) GetSandboxId() string {
@@ -1544,7 +1620,7 @@ type StreamExecutionRequest struct {
 
 func (x *StreamExecutionRequest) Reset() {
 	*x = StreamExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[24]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1556,7 +1632,7 @@ func (x *StreamExecutionRequest) String() string {
 func (*StreamExecutionRequest) ProtoMessage() {}
 
 func (x *StreamExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[24]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1569,7 +1645,7 @@ func (x *StreamExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamExecutionRequest.ProtoReflect.Descriptor instead.
 func (*StreamExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{24}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *StreamExecutionRequest) GetSandboxId() string {
@@ -1604,7 +1680,7 @@ type ExecutionExit struct {
 
 func (x *ExecutionExit) Reset() {
 	*x = ExecutionExit{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[25]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1616,7 +1692,7 @@ func (x *ExecutionExit) String() string {
 func (*ExecutionExit) ProtoMessage() {}
 
 func (x *ExecutionExit) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[25]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1629,7 +1705,7 @@ func (x *ExecutionExit) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionExit.ProtoReflect.Descriptor instead.
 func (*ExecutionExit) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{25}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *ExecutionExit) GetExitCode() int32 {
@@ -1674,7 +1750,7 @@ type ExecutionStreamEvent struct {
 
 func (x *ExecutionStreamEvent) Reset() {
 	*x = ExecutionStreamEvent{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[26]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1686,7 +1762,7 @@ func (x *ExecutionStreamEvent) String() string {
 func (*ExecutionStreamEvent) ProtoMessage() {}
 
 func (x *ExecutionStreamEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[26]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1699,7 +1775,7 @@ func (x *ExecutionStreamEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionStreamEvent.ProtoReflect.Descriptor instead.
 func (*ExecutionStreamEvent) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{26}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *ExecutionStreamEvent) GetSandboxId() string {
@@ -1825,7 +1901,7 @@ type ExecutionAttachOpen struct {
 
 func (x *ExecutionAttachOpen) Reset() {
 	*x = ExecutionAttachOpen{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[27]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1837,7 +1913,7 @@ func (x *ExecutionAttachOpen) String() string {
 func (*ExecutionAttachOpen) ProtoMessage() {}
 
 func (x *ExecutionAttachOpen) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[27]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1850,7 +1926,7 @@ func (x *ExecutionAttachOpen) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionAttachOpen.ProtoReflect.Descriptor instead.
 func (*ExecutionAttachOpen) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{27}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *ExecutionAttachOpen) GetSandboxId() string {
@@ -1877,7 +1953,7 @@ type ExecutionResize struct {
 
 func (x *ExecutionResize) Reset() {
 	*x = ExecutionResize{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[28]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1889,7 +1965,7 @@ func (x *ExecutionResize) String() string {
 func (*ExecutionResize) ProtoMessage() {}
 
 func (x *ExecutionResize) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[28]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1902,7 +1978,7 @@ func (x *ExecutionResize) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionResize.ProtoReflect.Descriptor instead.
 func (*ExecutionResize) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{28}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *ExecutionResize) GetCols() uint32 {
@@ -1928,7 +2004,7 @@ type ExecutionSignal struct {
 
 func (x *ExecutionSignal) Reset() {
 	*x = ExecutionSignal{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[29]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1940,7 +2016,7 @@ func (x *ExecutionSignal) String() string {
 func (*ExecutionSignal) ProtoMessage() {}
 
 func (x *ExecutionSignal) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[29]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1953,7 +2029,7 @@ func (x *ExecutionSignal) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionSignal.ProtoReflect.Descriptor instead.
 func (*ExecutionSignal) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{29}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *ExecutionSignal) GetSignal() int32 {
@@ -1971,7 +2047,7 @@ type ExecutionHeartbeat struct {
 
 func (x *ExecutionHeartbeat) Reset() {
 	*x = ExecutionHeartbeat{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[30]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1983,7 +2059,7 @@ func (x *ExecutionHeartbeat) String() string {
 func (*ExecutionHeartbeat) ProtoMessage() {}
 
 func (x *ExecutionHeartbeat) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[30]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1996,7 +2072,7 @@ func (x *ExecutionHeartbeat) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionHeartbeat.ProtoReflect.Descriptor instead.
 func (*ExecutionHeartbeat) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{30}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{31}
 }
 
 type ExecutionClose struct {
@@ -2008,7 +2084,7 @@ type ExecutionClose struct {
 
 func (x *ExecutionClose) Reset() {
 	*x = ExecutionClose{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[31]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2020,7 +2096,7 @@ func (x *ExecutionClose) String() string {
 func (*ExecutionClose) ProtoMessage() {}
 
 func (x *ExecutionClose) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[31]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2033,7 +2109,7 @@ func (x *ExecutionClose) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionClose.ProtoReflect.Descriptor instead.
 func (*ExecutionClose) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{31}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *ExecutionClose) GetDetach() bool {
@@ -2067,7 +2143,7 @@ type ExecutionAttachFrame struct {
 
 func (x *ExecutionAttachFrame) Reset() {
 	*x = ExecutionAttachFrame{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[32]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2079,7 +2155,7 @@ func (x *ExecutionAttachFrame) String() string {
 func (*ExecutionAttachFrame) ProtoMessage() {}
 
 func (x *ExecutionAttachFrame) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[32]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2092,7 +2168,7 @@ func (x *ExecutionAttachFrame) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionAttachFrame.ProtoReflect.Descriptor instead.
 func (*ExecutionAttachFrame) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{32}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *ExecutionAttachFrame) GetSandboxId() string {
@@ -2295,11 +2371,17 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"updated_at\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\tupdatedAt\";\n" +
 	"\x0fPolicyAllowRule\x12\x12\n" +
 	"\x04host\x18\x01 \x01(\tR\x04host\x12\x14\n" +
-	"\x05ports\x18\x02 \x03(\x05R\x05ports\"\xd4\x01\n" +
+	"\x05ports\x18\x02 \x03(\x05R\x05ports\"\x87\x01\n" +
+	"\tPolicyGit\x12\x18\n" +
+	"\aenabled\x18\x01 \x01(\bR\aenabled\x12\x16\n" +
+	"\x06source\x18\x02 \x01(\tR\x06source\x12#\n" +
+	"\rallowed_hosts\x18\x03 \x03(\tR\fallowedHosts\x12#\n" +
+	"\rallowed_repos\x18\x04 \x03(\tR\fallowedRepos\"\xff\x01\n" +
 	"\x06Policy\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\x05R\aversion\x12\x1b\n" +
 	"\timage_ref\x18\x02 \x01(\tR\bimageRef\x12!\n" +
-	"\fimage_digest\x18\x03 \x01(\tR\vimageDigest\x12'\n" +
+	"\fimage_digest\x18\x03 \x01(\tR\vimageDigest\x12)\n" +
+	"\x03git\x18\a \x01(\v2\x17.cleanroom.v1.PolicyGitR\x03git\x12'\n" +
 	"\x0fnetwork_default\x18\x04 \x01(\tR\x0enetworkDefault\x123\n" +
 	"\x05allow\x18\x05 \x03(\v2\x1d.cleanroom.v1.PolicyAllowRuleR\x05allow\x12\x12\n" +
 	"\x04hash\x18\x06 \x01(\tR\x04hash\"R\n" +
@@ -2491,102 +2573,104 @@ func file_proto_cleanroom_v1_control_proto_rawDescGZIP() []byte {
 }
 
 var file_proto_cleanroom_v1_control_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_proto_cleanroom_v1_control_proto_msgTypes = make([]protoimpl.MessageInfo, 33)
+var file_proto_cleanroom_v1_control_proto_msgTypes = make([]protoimpl.MessageInfo, 34)
 var file_proto_cleanroom_v1_control_proto_goTypes = []any{
 	(SandboxStatus)(0),                  // 0: cleanroom.v1.SandboxStatus
 	(ExecutionStatus)(0),                // 1: cleanroom.v1.ExecutionStatus
 	(*Sandbox)(nil),                     // 2: cleanroom.v1.Sandbox
 	(*PolicyAllowRule)(nil),             // 3: cleanroom.v1.PolicyAllowRule
-	(*Policy)(nil),                      // 4: cleanroom.v1.Policy
-	(*SandboxOptions)(nil),              // 5: cleanroom.v1.SandboxOptions
-	(*CreateSandboxRequest)(nil),        // 6: cleanroom.v1.CreateSandboxRequest
-	(*CreateSandboxResponse)(nil),       // 7: cleanroom.v1.CreateSandboxResponse
-	(*GetSandboxRequest)(nil),           // 8: cleanroom.v1.GetSandboxRequest
-	(*GetSandboxResponse)(nil),          // 9: cleanroom.v1.GetSandboxResponse
-	(*ListSandboxesRequest)(nil),        // 10: cleanroom.v1.ListSandboxesRequest
-	(*ListSandboxesResponse)(nil),       // 11: cleanroom.v1.ListSandboxesResponse
-	(*DownloadSandboxFileRequest)(nil),  // 12: cleanroom.v1.DownloadSandboxFileRequest
-	(*DownloadSandboxFileResponse)(nil), // 13: cleanroom.v1.DownloadSandboxFileResponse
-	(*TerminateSandboxRequest)(nil),     // 14: cleanroom.v1.TerminateSandboxRequest
-	(*TerminateSandboxResponse)(nil),    // 15: cleanroom.v1.TerminateSandboxResponse
-	(*StreamSandboxEventsRequest)(nil),  // 16: cleanroom.v1.StreamSandboxEventsRequest
-	(*SandboxEvent)(nil),                // 17: cleanroom.v1.SandboxEvent
-	(*Execution)(nil),                   // 18: cleanroom.v1.Execution
-	(*ExecutionOptions)(nil),            // 19: cleanroom.v1.ExecutionOptions
-	(*CreateExecutionRequest)(nil),      // 20: cleanroom.v1.CreateExecutionRequest
-	(*CreateExecutionResponse)(nil),     // 21: cleanroom.v1.CreateExecutionResponse
-	(*GetExecutionRequest)(nil),         // 22: cleanroom.v1.GetExecutionRequest
-	(*GetExecutionResponse)(nil),        // 23: cleanroom.v1.GetExecutionResponse
-	(*CancelExecutionRequest)(nil),      // 24: cleanroom.v1.CancelExecutionRequest
-	(*CancelExecutionResponse)(nil),     // 25: cleanroom.v1.CancelExecutionResponse
-	(*StreamExecutionRequest)(nil),      // 26: cleanroom.v1.StreamExecutionRequest
-	(*ExecutionExit)(nil),               // 27: cleanroom.v1.ExecutionExit
-	(*ExecutionStreamEvent)(nil),        // 28: cleanroom.v1.ExecutionStreamEvent
-	(*ExecutionAttachOpen)(nil),         // 29: cleanroom.v1.ExecutionAttachOpen
-	(*ExecutionResize)(nil),             // 30: cleanroom.v1.ExecutionResize
-	(*ExecutionSignal)(nil),             // 31: cleanroom.v1.ExecutionSignal
-	(*ExecutionHeartbeat)(nil),          // 32: cleanroom.v1.ExecutionHeartbeat
-	(*ExecutionClose)(nil),              // 33: cleanroom.v1.ExecutionClose
-	(*ExecutionAttachFrame)(nil),        // 34: cleanroom.v1.ExecutionAttachFrame
-	(*timestamppb.Timestamp)(nil),       // 35: google.protobuf.Timestamp
+	(*PolicyGit)(nil),                   // 4: cleanroom.v1.PolicyGit
+	(*Policy)(nil),                      // 5: cleanroom.v1.Policy
+	(*SandboxOptions)(nil),              // 6: cleanroom.v1.SandboxOptions
+	(*CreateSandboxRequest)(nil),        // 7: cleanroom.v1.CreateSandboxRequest
+	(*CreateSandboxResponse)(nil),       // 8: cleanroom.v1.CreateSandboxResponse
+	(*GetSandboxRequest)(nil),           // 9: cleanroom.v1.GetSandboxRequest
+	(*GetSandboxResponse)(nil),          // 10: cleanroom.v1.GetSandboxResponse
+	(*ListSandboxesRequest)(nil),        // 11: cleanroom.v1.ListSandboxesRequest
+	(*ListSandboxesResponse)(nil),       // 12: cleanroom.v1.ListSandboxesResponse
+	(*DownloadSandboxFileRequest)(nil),  // 13: cleanroom.v1.DownloadSandboxFileRequest
+	(*DownloadSandboxFileResponse)(nil), // 14: cleanroom.v1.DownloadSandboxFileResponse
+	(*TerminateSandboxRequest)(nil),     // 15: cleanroom.v1.TerminateSandboxRequest
+	(*TerminateSandboxResponse)(nil),    // 16: cleanroom.v1.TerminateSandboxResponse
+	(*StreamSandboxEventsRequest)(nil),  // 17: cleanroom.v1.StreamSandboxEventsRequest
+	(*SandboxEvent)(nil),                // 18: cleanroom.v1.SandboxEvent
+	(*Execution)(nil),                   // 19: cleanroom.v1.Execution
+	(*ExecutionOptions)(nil),            // 20: cleanroom.v1.ExecutionOptions
+	(*CreateExecutionRequest)(nil),      // 21: cleanroom.v1.CreateExecutionRequest
+	(*CreateExecutionResponse)(nil),     // 22: cleanroom.v1.CreateExecutionResponse
+	(*GetExecutionRequest)(nil),         // 23: cleanroom.v1.GetExecutionRequest
+	(*GetExecutionResponse)(nil),        // 24: cleanroom.v1.GetExecutionResponse
+	(*CancelExecutionRequest)(nil),      // 25: cleanroom.v1.CancelExecutionRequest
+	(*CancelExecutionResponse)(nil),     // 26: cleanroom.v1.CancelExecutionResponse
+	(*StreamExecutionRequest)(nil),      // 27: cleanroom.v1.StreamExecutionRequest
+	(*ExecutionExit)(nil),               // 28: cleanroom.v1.ExecutionExit
+	(*ExecutionStreamEvent)(nil),        // 29: cleanroom.v1.ExecutionStreamEvent
+	(*ExecutionAttachOpen)(nil),         // 30: cleanroom.v1.ExecutionAttachOpen
+	(*ExecutionResize)(nil),             // 31: cleanroom.v1.ExecutionResize
+	(*ExecutionSignal)(nil),             // 32: cleanroom.v1.ExecutionSignal
+	(*ExecutionHeartbeat)(nil),          // 33: cleanroom.v1.ExecutionHeartbeat
+	(*ExecutionClose)(nil),              // 34: cleanroom.v1.ExecutionClose
+	(*ExecutionAttachFrame)(nil),        // 35: cleanroom.v1.ExecutionAttachFrame
+	(*timestamppb.Timestamp)(nil),       // 36: google.protobuf.Timestamp
 }
 var file_proto_cleanroom_v1_control_proto_depIdxs = []int32{
 	0,  // 0: cleanroom.v1.Sandbox.status:type_name -> cleanroom.v1.SandboxStatus
-	35, // 1: cleanroom.v1.Sandbox.created_at:type_name -> google.protobuf.Timestamp
-	35, // 2: cleanroom.v1.Sandbox.updated_at:type_name -> google.protobuf.Timestamp
-	3,  // 3: cleanroom.v1.Policy.allow:type_name -> cleanroom.v1.PolicyAllowRule
-	5,  // 4: cleanroom.v1.CreateSandboxRequest.options:type_name -> cleanroom.v1.SandboxOptions
-	4,  // 5: cleanroom.v1.CreateSandboxRequest.policy:type_name -> cleanroom.v1.Policy
-	2,  // 6: cleanroom.v1.CreateSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
-	2,  // 7: cleanroom.v1.GetSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
-	2,  // 8: cleanroom.v1.ListSandboxesResponse.sandboxes:type_name -> cleanroom.v1.Sandbox
-	0,  // 9: cleanroom.v1.SandboxEvent.status:type_name -> cleanroom.v1.SandboxStatus
-	35, // 10: cleanroom.v1.SandboxEvent.occurred_at:type_name -> google.protobuf.Timestamp
-	1,  // 11: cleanroom.v1.Execution.status:type_name -> cleanroom.v1.ExecutionStatus
-	35, // 12: cleanroom.v1.Execution.started_at:type_name -> google.protobuf.Timestamp
-	35, // 13: cleanroom.v1.Execution.finished_at:type_name -> google.protobuf.Timestamp
-	19, // 14: cleanroom.v1.CreateExecutionRequest.options:type_name -> cleanroom.v1.ExecutionOptions
-	18, // 15: cleanroom.v1.CreateExecutionResponse.execution:type_name -> cleanroom.v1.Execution
-	18, // 16: cleanroom.v1.GetExecutionResponse.execution:type_name -> cleanroom.v1.Execution
-	1,  // 17: cleanroom.v1.CancelExecutionResponse.status:type_name -> cleanroom.v1.ExecutionStatus
-	1,  // 18: cleanroom.v1.ExecutionExit.status:type_name -> cleanroom.v1.ExecutionStatus
-	1,  // 19: cleanroom.v1.ExecutionStreamEvent.status:type_name -> cleanroom.v1.ExecutionStatus
-	27, // 20: cleanroom.v1.ExecutionStreamEvent.exit:type_name -> cleanroom.v1.ExecutionExit
-	35, // 21: cleanroom.v1.ExecutionStreamEvent.occurred_at:type_name -> google.protobuf.Timestamp
-	29, // 22: cleanroom.v1.ExecutionAttachFrame.open:type_name -> cleanroom.v1.ExecutionAttachOpen
-	30, // 23: cleanroom.v1.ExecutionAttachFrame.resize:type_name -> cleanroom.v1.ExecutionResize
-	31, // 24: cleanroom.v1.ExecutionAttachFrame.signal:type_name -> cleanroom.v1.ExecutionSignal
-	32, // 25: cleanroom.v1.ExecutionAttachFrame.heartbeat:type_name -> cleanroom.v1.ExecutionHeartbeat
-	33, // 26: cleanroom.v1.ExecutionAttachFrame.close:type_name -> cleanroom.v1.ExecutionClose
-	27, // 27: cleanroom.v1.ExecutionAttachFrame.exit:type_name -> cleanroom.v1.ExecutionExit
-	35, // 28: cleanroom.v1.ExecutionAttachFrame.occurred_at:type_name -> google.protobuf.Timestamp
-	6,  // 29: cleanroom.v1.SandboxService.CreateSandbox:input_type -> cleanroom.v1.CreateSandboxRequest
-	8,  // 30: cleanroom.v1.SandboxService.GetSandbox:input_type -> cleanroom.v1.GetSandboxRequest
-	10, // 31: cleanroom.v1.SandboxService.ListSandboxes:input_type -> cleanroom.v1.ListSandboxesRequest
-	12, // 32: cleanroom.v1.SandboxService.DownloadSandboxFile:input_type -> cleanroom.v1.DownloadSandboxFileRequest
-	14, // 33: cleanroom.v1.SandboxService.TerminateSandbox:input_type -> cleanroom.v1.TerminateSandboxRequest
-	16, // 34: cleanroom.v1.SandboxService.StreamSandboxEvents:input_type -> cleanroom.v1.StreamSandboxEventsRequest
-	20, // 35: cleanroom.v1.ExecutionService.CreateExecution:input_type -> cleanroom.v1.CreateExecutionRequest
-	22, // 36: cleanroom.v1.ExecutionService.GetExecution:input_type -> cleanroom.v1.GetExecutionRequest
-	24, // 37: cleanroom.v1.ExecutionService.CancelExecution:input_type -> cleanroom.v1.CancelExecutionRequest
-	26, // 38: cleanroom.v1.ExecutionService.StreamExecution:input_type -> cleanroom.v1.StreamExecutionRequest
-	34, // 39: cleanroom.v1.ExecutionService.AttachExecution:input_type -> cleanroom.v1.ExecutionAttachFrame
-	7,  // 40: cleanroom.v1.SandboxService.CreateSandbox:output_type -> cleanroom.v1.CreateSandboxResponse
-	9,  // 41: cleanroom.v1.SandboxService.GetSandbox:output_type -> cleanroom.v1.GetSandboxResponse
-	11, // 42: cleanroom.v1.SandboxService.ListSandboxes:output_type -> cleanroom.v1.ListSandboxesResponse
-	13, // 43: cleanroom.v1.SandboxService.DownloadSandboxFile:output_type -> cleanroom.v1.DownloadSandboxFileResponse
-	15, // 44: cleanroom.v1.SandboxService.TerminateSandbox:output_type -> cleanroom.v1.TerminateSandboxResponse
-	17, // 45: cleanroom.v1.SandboxService.StreamSandboxEvents:output_type -> cleanroom.v1.SandboxEvent
-	21, // 46: cleanroom.v1.ExecutionService.CreateExecution:output_type -> cleanroom.v1.CreateExecutionResponse
-	23, // 47: cleanroom.v1.ExecutionService.GetExecution:output_type -> cleanroom.v1.GetExecutionResponse
-	25, // 48: cleanroom.v1.ExecutionService.CancelExecution:output_type -> cleanroom.v1.CancelExecutionResponse
-	28, // 49: cleanroom.v1.ExecutionService.StreamExecution:output_type -> cleanroom.v1.ExecutionStreamEvent
-	34, // 50: cleanroom.v1.ExecutionService.AttachExecution:output_type -> cleanroom.v1.ExecutionAttachFrame
-	40, // [40:51] is the sub-list for method output_type
-	29, // [29:40] is the sub-list for method input_type
-	29, // [29:29] is the sub-list for extension type_name
-	29, // [29:29] is the sub-list for extension extendee
-	0,  // [0:29] is the sub-list for field type_name
+	36, // 1: cleanroom.v1.Sandbox.created_at:type_name -> google.protobuf.Timestamp
+	36, // 2: cleanroom.v1.Sandbox.updated_at:type_name -> google.protobuf.Timestamp
+	4,  // 3: cleanroom.v1.Policy.git:type_name -> cleanroom.v1.PolicyGit
+	3,  // 4: cleanroom.v1.Policy.allow:type_name -> cleanroom.v1.PolicyAllowRule
+	6,  // 5: cleanroom.v1.CreateSandboxRequest.options:type_name -> cleanroom.v1.SandboxOptions
+	5,  // 6: cleanroom.v1.CreateSandboxRequest.policy:type_name -> cleanroom.v1.Policy
+	2,  // 7: cleanroom.v1.CreateSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
+	2,  // 8: cleanroom.v1.GetSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
+	2,  // 9: cleanroom.v1.ListSandboxesResponse.sandboxes:type_name -> cleanroom.v1.Sandbox
+	0,  // 10: cleanroom.v1.SandboxEvent.status:type_name -> cleanroom.v1.SandboxStatus
+	36, // 11: cleanroom.v1.SandboxEvent.occurred_at:type_name -> google.protobuf.Timestamp
+	1,  // 12: cleanroom.v1.Execution.status:type_name -> cleanroom.v1.ExecutionStatus
+	36, // 13: cleanroom.v1.Execution.started_at:type_name -> google.protobuf.Timestamp
+	36, // 14: cleanroom.v1.Execution.finished_at:type_name -> google.protobuf.Timestamp
+	20, // 15: cleanroom.v1.CreateExecutionRequest.options:type_name -> cleanroom.v1.ExecutionOptions
+	19, // 16: cleanroom.v1.CreateExecutionResponse.execution:type_name -> cleanroom.v1.Execution
+	19, // 17: cleanroom.v1.GetExecutionResponse.execution:type_name -> cleanroom.v1.Execution
+	1,  // 18: cleanroom.v1.CancelExecutionResponse.status:type_name -> cleanroom.v1.ExecutionStatus
+	1,  // 19: cleanroom.v1.ExecutionExit.status:type_name -> cleanroom.v1.ExecutionStatus
+	1,  // 20: cleanroom.v1.ExecutionStreamEvent.status:type_name -> cleanroom.v1.ExecutionStatus
+	28, // 21: cleanroom.v1.ExecutionStreamEvent.exit:type_name -> cleanroom.v1.ExecutionExit
+	36, // 22: cleanroom.v1.ExecutionStreamEvent.occurred_at:type_name -> google.protobuf.Timestamp
+	30, // 23: cleanroom.v1.ExecutionAttachFrame.open:type_name -> cleanroom.v1.ExecutionAttachOpen
+	31, // 24: cleanroom.v1.ExecutionAttachFrame.resize:type_name -> cleanroom.v1.ExecutionResize
+	32, // 25: cleanroom.v1.ExecutionAttachFrame.signal:type_name -> cleanroom.v1.ExecutionSignal
+	33, // 26: cleanroom.v1.ExecutionAttachFrame.heartbeat:type_name -> cleanroom.v1.ExecutionHeartbeat
+	34, // 27: cleanroom.v1.ExecutionAttachFrame.close:type_name -> cleanroom.v1.ExecutionClose
+	28, // 28: cleanroom.v1.ExecutionAttachFrame.exit:type_name -> cleanroom.v1.ExecutionExit
+	36, // 29: cleanroom.v1.ExecutionAttachFrame.occurred_at:type_name -> google.protobuf.Timestamp
+	7,  // 30: cleanroom.v1.SandboxService.CreateSandbox:input_type -> cleanroom.v1.CreateSandboxRequest
+	9,  // 31: cleanroom.v1.SandboxService.GetSandbox:input_type -> cleanroom.v1.GetSandboxRequest
+	11, // 32: cleanroom.v1.SandboxService.ListSandboxes:input_type -> cleanroom.v1.ListSandboxesRequest
+	13, // 33: cleanroom.v1.SandboxService.DownloadSandboxFile:input_type -> cleanroom.v1.DownloadSandboxFileRequest
+	15, // 34: cleanroom.v1.SandboxService.TerminateSandbox:input_type -> cleanroom.v1.TerminateSandboxRequest
+	17, // 35: cleanroom.v1.SandboxService.StreamSandboxEvents:input_type -> cleanroom.v1.StreamSandboxEventsRequest
+	21, // 36: cleanroom.v1.ExecutionService.CreateExecution:input_type -> cleanroom.v1.CreateExecutionRequest
+	23, // 37: cleanroom.v1.ExecutionService.GetExecution:input_type -> cleanroom.v1.GetExecutionRequest
+	25, // 38: cleanroom.v1.ExecutionService.CancelExecution:input_type -> cleanroom.v1.CancelExecutionRequest
+	27, // 39: cleanroom.v1.ExecutionService.StreamExecution:input_type -> cleanroom.v1.StreamExecutionRequest
+	35, // 40: cleanroom.v1.ExecutionService.AttachExecution:input_type -> cleanroom.v1.ExecutionAttachFrame
+	8,  // 41: cleanroom.v1.SandboxService.CreateSandbox:output_type -> cleanroom.v1.CreateSandboxResponse
+	10, // 42: cleanroom.v1.SandboxService.GetSandbox:output_type -> cleanroom.v1.GetSandboxResponse
+	12, // 43: cleanroom.v1.SandboxService.ListSandboxes:output_type -> cleanroom.v1.ListSandboxesResponse
+	14, // 44: cleanroom.v1.SandboxService.DownloadSandboxFile:output_type -> cleanroom.v1.DownloadSandboxFileResponse
+	16, // 45: cleanroom.v1.SandboxService.TerminateSandbox:output_type -> cleanroom.v1.TerminateSandboxResponse
+	18, // 46: cleanroom.v1.SandboxService.StreamSandboxEvents:output_type -> cleanroom.v1.SandboxEvent
+	22, // 47: cleanroom.v1.ExecutionService.CreateExecution:output_type -> cleanroom.v1.CreateExecutionResponse
+	24, // 48: cleanroom.v1.ExecutionService.GetExecution:output_type -> cleanroom.v1.GetExecutionResponse
+	26, // 49: cleanroom.v1.ExecutionService.CancelExecution:output_type -> cleanroom.v1.CancelExecutionResponse
+	29, // 50: cleanroom.v1.ExecutionService.StreamExecution:output_type -> cleanroom.v1.ExecutionStreamEvent
+	35, // 51: cleanroom.v1.ExecutionService.AttachExecution:output_type -> cleanroom.v1.ExecutionAttachFrame
+	41, // [41:52] is the sub-list for method output_type
+	30, // [30:41] is the sub-list for method input_type
+	30, // [30:30] is the sub-list for extension type_name
+	30, // [30:30] is the sub-list for extension extendee
+	0,  // [0:30] is the sub-list for field type_name
 }
 
 func init() { file_proto_cleanroom_v1_control_proto_init() }
@@ -2594,13 +2678,13 @@ func file_proto_cleanroom_v1_control_proto_init() {
 	if File_proto_cleanroom_v1_control_proto != nil {
 		return
 	}
-	file_proto_cleanroom_v1_control_proto_msgTypes[26].OneofWrappers = []any{
+	file_proto_cleanroom_v1_control_proto_msgTypes[27].OneofWrappers = []any{
 		(*ExecutionStreamEvent_Stdout)(nil),
 		(*ExecutionStreamEvent_Stderr)(nil),
 		(*ExecutionStreamEvent_Exit)(nil),
 		(*ExecutionStreamEvent_Message)(nil),
 	}
-	file_proto_cleanroom_v1_control_proto_msgTypes[32].OneofWrappers = []any{
+	file_proto_cleanroom_v1_control_proto_msgTypes[33].OneofWrappers = []any{
 		(*ExecutionAttachFrame_Open)(nil),
 		(*ExecutionAttachFrame_Stdin)(nil),
 		(*ExecutionAttachFrame_Resize)(nil),
@@ -2618,7 +2702,7 @@ func file_proto_cleanroom_v1_control_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proto_cleanroom_v1_control_proto_rawDesc), len(file_proto_cleanroom_v1_control_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   33,
+			NumMessages:   34,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/internal/gitgateway/rewrite.go
+++ b/internal/gitgateway/rewrite.go
@@ -1,0 +1,64 @@
+package gitgateway
+
+import (
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+)
+
+type RewriteRule struct {
+	BaseURL   string
+	InsteadOf string
+}
+
+// BuildRewriteRules returns stable, per-host insteadOf rules which rewrite
+// https remotes to the local relay endpoint.
+func BuildRewriteRules(relayBaseURL string, allowedHosts []string) ([]RewriteRule, error) {
+	trimmedBase := strings.TrimSpace(relayBaseURL)
+	if trimmedBase == "" {
+		return nil, fmt.Errorf("relay base URL is required")
+	}
+	parsedBase, err := url.Parse(trimmedBase)
+	if err != nil {
+		return nil, fmt.Errorf("invalid relay base URL %q: %w", relayBaseURL, err)
+	}
+	if parsedBase.Scheme != "http" && parsedBase.Scheme != "https" {
+		return nil, fmt.Errorf("relay base URL %q must use http or https", relayBaseURL)
+	}
+	if parsedBase.Host == "" {
+		return nil, fmt.Errorf("relay base URL %q must include a host", relayBaseURL)
+	}
+
+	normalizedHosts := make([]string, 0, len(allowedHosts))
+	seen := map[string]struct{}{}
+	for _, host := range allowedHosts {
+		normalized := strings.ToLower(strings.TrimSpace(host))
+		if normalized == "" {
+			return nil, fmt.Errorf("allowed hosts cannot contain empty entries")
+		}
+		if strings.Contains(normalized, "/") {
+			return nil, fmt.Errorf("allowed host %q must be a hostname", normalized)
+		}
+		if _, ok := seen[normalized]; ok {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		normalizedHosts = append(normalizedHosts, normalized)
+	}
+	if len(normalizedHosts) == 0 {
+		return nil, fmt.Errorf("at least one allowed host is required")
+	}
+	sort.Strings(normalizedHosts)
+
+	basePrefix := strings.TrimRight(parsedBase.String(), "/")
+	rules := make([]RewriteRule, 0, len(normalizedHosts))
+	for _, host := range normalizedHosts {
+		rules = append(rules, RewriteRule{
+			BaseURL:   fmt.Sprintf("%s/git/%s/", basePrefix, host),
+			InsteadOf: fmt.Sprintf("https://%s/", host),
+		})
+	}
+
+	return rules, nil
+}

--- a/internal/gitgateway/rewrite_test.go
+++ b/internal/gitgateway/rewrite_test.go
@@ -1,0 +1,46 @@
+package gitgateway
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildRewriteRulesSortsAndDeduplicatesHosts(t *testing.T) {
+	t.Parallel()
+
+	rules, err := BuildRewriteRules("http://127.0.0.1:18080", []string{"GitHub.com", "github.com", "gitlab.com"})
+	if err != nil {
+		t.Fatalf("BuildRewriteRules returned error: %v", err)
+	}
+	if len(rules) != 2 {
+		t.Fatalf("unexpected rule count: got %d want 2", len(rules))
+	}
+	if got, want := rules[0].InsteadOf, "https://github.com/"; got != want {
+		t.Fatalf("unexpected first insteadOf: got %q want %q", got, want)
+	}
+	if got, want := rules[0].BaseURL, "http://127.0.0.1:18080/git/github.com/"; got != want {
+		t.Fatalf("unexpected first base URL: got %q want %q", got, want)
+	}
+	if got, want := rules[1].InsteadOf, "https://gitlab.com/"; got != want {
+		t.Fatalf("unexpected second insteadOf: got %q want %q", got, want)
+	}
+}
+
+func TestBuildRewriteRulesRejectsInvalidInputs(t *testing.T) {
+	t.Parallel()
+
+	_, err := BuildRewriteRules("", []string{"github.com"})
+	if err == nil || !strings.Contains(err.Error(), "required") {
+		t.Fatalf("expected relay URL required error, got %v", err)
+	}
+
+	_, err = BuildRewriteRules("http://127.0.0.1:18080", nil)
+	if err == nil || !strings.Contains(err.Error(), "at least one allowed host") {
+		t.Fatalf("expected allowed host error, got %v", err)
+	}
+
+	_, err = BuildRewriteRules("http://127.0.0.1:18080", []string{"owner/repo"})
+	if err == nil || !strings.Contains(err.Error(), "hostname") {
+		t.Fatalf("expected hostname error, got %v", err)
+	}
+}

--- a/internal/vsockhttp/client_linux.go
+++ b/internal/vsockhttp/client_linux.go
@@ -1,0 +1,50 @@
+//go:build linux
+
+package vsockhttp
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/mdlayher/vsock"
+)
+
+const DefaultGatewayPort uint32 = 17080
+
+var dialVsock = func(contextID, port uint32, cfg *vsock.Config) (net.Conn, error) {
+	return vsock.Dial(contextID, port, cfg)
+}
+
+// NewHostTransport returns an HTTP transport that always dials the hypervisor
+// via AF_VSOCK on the given port.
+func NewHostTransport(port uint32) *http.Transport {
+	if port == 0 {
+		port = DefaultGatewayPort
+	}
+
+	return &http.Transport{
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			conn, err := dialVsock(vsock.Hypervisor, port, nil)
+			if err != nil {
+				return nil, fmt.Errorf("dial host vsock port %d: %w", port, err)
+			}
+			return conn, nil
+		},
+	}
+}
+
+func NewHostClient(port uint32, timeout time.Duration) *http.Client {
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
+	return &http.Client{
+		Transport: NewHostTransport(port),
+		Timeout:   timeout,
+	}
+}

--- a/internal/vsockhttp/client_linux_test.go
+++ b/internal/vsockhttp/client_linux_test.go
@@ -1,0 +1,74 @@
+//go:build linux
+
+package vsockhttp
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/mdlayher/vsock"
+)
+
+func TestNewHostTransportDialsHypervisorWithDefaultPort(t *testing.T) {
+	t.Parallel()
+
+	originalDial := dialVsock
+	t.Cleanup(func() { dialVsock = originalDial })
+
+	called := false
+	dialVsock = func(contextID, port uint32, cfg *vsock.Config) (net.Conn, error) {
+		called = true
+		if contextID != vsock.Hypervisor {
+			t.Fatalf("unexpected context ID: got %d want %d", contextID, vsock.Hypervisor)
+		}
+		if port != DefaultGatewayPort {
+			t.Fatalf("unexpected port: got %d want %d", port, DefaultGatewayPort)
+		}
+		c1, c2 := net.Pipe()
+		_ = c2.Close()
+		return c1, nil
+	}
+
+	transport := NewHostTransport(0)
+	conn, err := transport.DialContext(context.Background(), "tcp", "ignored")
+	if err != nil {
+		t.Fatalf("DialContext returned error: %v", err)
+	}
+	if !called {
+		t.Fatal("expected dialVsock to be called")
+	}
+	_ = conn.Close()
+}
+
+func TestNewHostTransportHonorsCanceledContext(t *testing.T) {
+	t.Parallel()
+
+	originalDial := dialVsock
+	t.Cleanup(func() { dialVsock = originalDial })
+
+	dialVsock = func(contextID, port uint32, cfg *vsock.Config) (net.Conn, error) {
+		t.Fatal("dialVsock should not be called for canceled contexts")
+		return nil, errors.New("unexpected")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	transport := NewHostTransport(DefaultGatewayPort)
+	_, err := transport.DialContext(ctx, "tcp", "ignored")
+	if err == nil {
+		t.Fatal("expected DialContext to fail for canceled context")
+	}
+}
+
+func TestNewHostClientAppliesDefaultTimeout(t *testing.T) {
+	t.Parallel()
+
+	client := NewHostClient(DefaultGatewayPort, 0)
+	if got, want := client.Timeout, 30*time.Second; got != want {
+		t.Fatalf("unexpected default timeout: got %s want %s", got, want)
+	}
+}

--- a/proto/cleanroom/v1/control.proto
+++ b/proto/cleanroom/v1/control.proto
@@ -46,10 +46,18 @@ message PolicyAllowRule {
   repeated int32 ports = 2;
 }
 
+message PolicyGit {
+  bool enabled = 1;
+  string source = 2;
+  repeated string allowed_hosts = 3;
+  repeated string allowed_repos = 4;
+}
+
 message Policy {
   int32 version = 1;
   string image_ref = 2;
   string image_digest = 3;
+  PolicyGit git = 7;
   string network_default = 4;
   repeated PolicyAllowRule allow = 5;
   string hash = 6;


### PR DESCRIPTION
## Summary
Implements the first Git gateway foundation slice from the new plan and keeps the plan itself in the same PR.

## Included commits
1. `docs: add git gateway MVP plan with vsock design`
2. `feat(git): add policy foundations, scoped rewrites, and vsock transport`

## What was implemented
- Added `sandbox.git` policy support in compiler/proto path:
  - `enabled`, `source`, `allowed_hosts`, `allowed_repos`
  - normalization + validation + deterministic ordering
- Extended wire format with `PolicyGit` in `control.proto` and regenerated protobufs
- Added scoped rewrite rule builder for per-host `insteadOf` behavior:
  - new package: `internal/gitgateway`
- Added host-vsock HTTP client transport utility for relay/gateway foundation:
  - new package: `internal/vsockhttp`

## Notes
- This is foundation work only; no full runtime wiring of guest relay + host gateway process yet.
- Existing behavior is preserved when `sandbox.git` is not enabled.

## Validation
- `go test ./internal/policy ./internal/gitgateway ./internal/vsockhttp`
- `go test ./...`
