### PR TITLE
feat(git): minimal scoped git gateway for firecracker

### DIFF
--- a/docs/git-gateway.md
+++ b/docs/git-gateway.md
@@ -1,0 +1,111 @@
+# Git Gateway Design (MVP)
+
+## Goal
+
+Allow sandboxed workloads to use normal Git commands (`git clone`, `git fetch`)
+while Cleanroom enforces explicit allowlist policy on remote Git destinations.
+
+## Scope
+
+This document describes the currently shipped MVP behavior.
+
+Included:
+- Git smart-HTTP read paths (`info/refs?service=git-upload-pack`, `git-upload-pack`)
+- Policy-controlled allow/deny by host and optional repo
+- Transparent Git URL rewrite inside the sandbox
+- `upstream` and `host_mirror` source modes
+
+Not included:
+- Push/write flows (`git-receive-pack`)
+- Auth token minting/injection pipeline
+- Wildcard policy semantics
+
+## Policy Model
+
+Git controls live under `sandbox.git`:
+
+```yaml
+sandbox:
+  git:
+    enabled: true
+    source: upstream # upstream | host_mirror
+    allowed_hosts:
+      - github.com
+    allowed_repos:
+      - org/repo
+```
+
+Behavior:
+- `allowed_hosts` is required when `enabled: true`
+- `allowed_repos` is optional; if omitted, any repo under allowed hosts is permitted
+- Matching is exact and case-normalized in MVP
+
+## Runtime Architecture
+
+1. Shared host gateway
+- Firecracker backend starts a shared HTTP Git gateway listener on host TCP.
+- A single gateway process is reused across many sandboxes for parallel scale.
+
+2. Per-sandbox scope registration
+- Each sandbox/run registers an ephemeral scope token in an in-memory registry.
+- Registry maps `scope -> compiled Git policy`.
+- Scope is removed on run/sandbox cleanup.
+
+3. Scoped rewrite in guest command environment
+- Runtime injects per-host Git rewrite entries using `GIT_CONFIG_COUNT` style env.
+- Rewrites:
+  - from `https://github.com/...`
+  - to `http://<sandbox-host-ip>:<gateway-port>/git/<scope>/github.com/...`
+
+4. Gateway enforcement path
+- Request route shape:
+  - `GET /git/<scope>/<host>/<owner>/<repo>.git/info/refs?service=git-upload-pack`
+  - `POST /git/<scope>/<host>/<owner>/<repo>.git/git-upload-pack`
+- Gateway resolves policy by scope, then enforces:
+  - host in `allowed_hosts`
+  - optional repo in `allowed_repos`
+- Deny responses use stable reason bodies (for example `host_not_allowed`,
+  `repository_not_allowed`).
+
+5. Source selection
+- `upstream`: proxy request to upstream HTTPS remote
+- `host_mirror`: serve from local bare mirror when available, otherwise fallback to upstream
+
+## Security Properties
+
+- Default deny for non-allowlisted destinations
+- Per-sandbox policy isolation via scope token even with shared gateway
+- No user-facing command changes required
+- Header forwarding is allowlisted and explicit
+
+## Validation Summary
+
+Validated for MVP:
+- Allowlisted clone succeeds
+- Disallowed clone is rejected with explicit deny reason and `403`
+- Parallel sandbox Git reads succeed through shared gateway
+
+## Future Improvements
+
+1. Request coalescing for `git-upload-pack`
+- Coalesce identical in-flight upload-pack requests (likely keyed by scope, repo,
+  and request body signature) to reduce upstream load under concurrent clones.
+
+2. Response cache/spool layer for read paths
+- Add bounded spool/cache for upload-pack responses, cache only successful
+  responses, and stream to client while writing cache.
+
+3. Stronger observability
+- Emit structured allow/deny and upstream-source metrics (mirror hit/miss,
+  upstream latency, in-flight coalescing stats).
+
+4. Capability-driven transport adapters
+- Keep shared tap TCP as baseline.
+- Optionally add alternative transports (for example vsock where reliable) behind
+  runtime capability checks.
+
+5. Policy evolution
+- Add deterministic wildcard/org-level matching with precedence rules.
+
+6. Write support
+- Add `git-receive-pack` with authenticated write policy and auditable decisioning.

--- a/internal/backend/firecracker/git_env_test.go
+++ b/internal/backend/firecracker/git_env_test.go
@@ -1,0 +1,61 @@
+package firecracker
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/policy"
+)
+
+func TestBuildGitScopedEnvDisabled(t *testing.T) {
+	t.Parallel()
+
+	env, err := buildGitScopedEnv(&policy.CompiledPolicy{}, "http://127.0.0.1:17080", "")
+	if err != nil {
+		t.Fatalf("buildGitScopedEnv returned error: %v", err)
+	}
+	if env != nil {
+		t.Fatalf("expected nil env when git policy is disabled, got %v", env)
+	}
+}
+
+func TestBuildGitScopedEnvEnabled(t *testing.T) {
+	t.Parallel()
+
+	env, err := buildGitScopedEnv(&policy.CompiledPolicy{
+		Git: &policy.GitPolicy{
+			Enabled:      true,
+			AllowedHosts: []string{"github.com"},
+		},
+	}, "http://127.0.0.1:17080", "scope-token")
+	if err != nil {
+		t.Fatalf("buildGitScopedEnv returned error: %v", err)
+	}
+	if len(env) != 3 {
+		t.Fatalf("unexpected git env count: got %d want 3", len(env))
+	}
+	joined := strings.Join(env, "\n")
+	if !strings.Contains(joined, "GIT_CONFIG_COUNT=1") {
+		t.Fatalf("expected git config count in env, got:\n%s", joined)
+	}
+	if !strings.Contains(joined, "https://github.com/") {
+		t.Fatalf("expected github rewrite in env, got:\n%s", joined)
+	}
+	if !strings.Contains(joined, "/git/scope-token/github.com/") {
+		t.Fatalf("expected scoped github rewrite in env, got:\n%s", joined)
+	}
+}
+
+func TestBuildGitScopedEnvErrorsWhenRelayURLMissing(t *testing.T) {
+	t.Parallel()
+
+	_, err := buildGitScopedEnv(&policy.CompiledPolicy{
+		Git: &policy.GitPolicy{
+			Enabled:      true,
+			AllowedHosts: []string{"github.com"},
+		},
+	}, "", "")
+	if err == nil {
+		t.Fatal("expected error when relay URL is missing")
+	}
+}

--- a/internal/gen/cleanroom/v1/control.pb.go
+++ b/internal/gen/cleanroom/v1/control.pb.go
@@ -277,11 +277,80 @@ func (x *PolicyAllowRule) GetPorts() []int32 {
 	return nil
 }
 
+type PolicyGit struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Enabled       bool                   `protobuf:"varint,1,opt,name=enabled,proto3" json:"enabled,omitempty"`
+	Source        string                 `protobuf:"bytes,2,opt,name=source,proto3" json:"source,omitempty"`
+	AllowedHosts  []string               `protobuf:"bytes,3,rep,name=allowed_hosts,json=allowedHosts,proto3" json:"allowed_hosts,omitempty"`
+	AllowedRepos  []string               `protobuf:"bytes,4,rep,name=allowed_repos,json=allowedRepos,proto3" json:"allowed_repos,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PolicyGit) Reset() {
+	*x = PolicyGit{}
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PolicyGit) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PolicyGit) ProtoMessage() {}
+
+func (x *PolicyGit) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PolicyGit.ProtoReflect.Descriptor instead.
+func (*PolicyGit) Descriptor() ([]byte, []int) {
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *PolicyGit) GetEnabled() bool {
+	if x != nil {
+		return x.Enabled
+	}
+	return false
+}
+
+func (x *PolicyGit) GetSource() string {
+	if x != nil {
+		return x.Source
+	}
+	return ""
+}
+
+func (x *PolicyGit) GetAllowedHosts() []string {
+	if x != nil {
+		return x.AllowedHosts
+	}
+	return nil
+}
+
+func (x *PolicyGit) GetAllowedRepos() []string {
+	if x != nil {
+		return x.AllowedRepos
+	}
+	return nil
+}
+
 type Policy struct {
 	state          protoimpl.MessageState `protogen:"open.v1"`
 	Version        int32                  `protobuf:"varint,1,opt,name=version,proto3" json:"version,omitempty"`
 	ImageRef       string                 `protobuf:"bytes,2,opt,name=image_ref,json=imageRef,proto3" json:"image_ref,omitempty"`
 	ImageDigest    string                 `protobuf:"bytes,3,opt,name=image_digest,json=imageDigest,proto3" json:"image_digest,omitempty"`
+	Git            *PolicyGit             `protobuf:"bytes,7,opt,name=git,proto3" json:"git,omitempty"`
 	NetworkDefault string                 `protobuf:"bytes,4,opt,name=network_default,json=networkDefault,proto3" json:"network_default,omitempty"`
 	Allow          []*PolicyAllowRule     `protobuf:"bytes,5,rep,name=allow,proto3" json:"allow,omitempty"`
 	Hash           string                 `protobuf:"bytes,6,opt,name=hash,proto3" json:"hash,omitempty"`
@@ -291,7 +360,7 @@ type Policy struct {
 
 func (x *Policy) Reset() {
 	*x = Policy{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[2]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -303,7 +372,7 @@ func (x *Policy) String() string {
 func (*Policy) ProtoMessage() {}
 
 func (x *Policy) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[2]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -316,7 +385,7 @@ func (x *Policy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Policy.ProtoReflect.Descriptor instead.
 func (*Policy) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{2}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *Policy) GetVersion() int32 {
@@ -338,6 +407,13 @@ func (x *Policy) GetImageDigest() string {
 		return x.ImageDigest
 	}
 	return ""
+}
+
+func (x *Policy) GetGit() *PolicyGit {
+	if x != nil {
+		return x.Git
+	}
+	return nil
 }
 
 func (x *Policy) GetNetworkDefault() string {
@@ -370,7 +446,7 @@ type SandboxOptions struct {
 
 func (x *SandboxOptions) Reset() {
 	*x = SandboxOptions{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[3]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -382,7 +458,7 @@ func (x *SandboxOptions) String() string {
 func (*SandboxOptions) ProtoMessage() {}
 
 func (x *SandboxOptions) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[3]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -395,7 +471,7 @@ func (x *SandboxOptions) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxOptions.ProtoReflect.Descriptor instead.
 func (*SandboxOptions) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{3}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *SandboxOptions) GetLaunchSeconds() int64 {
@@ -416,7 +492,7 @@ type CreateSandboxRequest struct {
 
 func (x *CreateSandboxRequest) Reset() {
 	*x = CreateSandboxRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[4]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -428,7 +504,7 @@ func (x *CreateSandboxRequest) String() string {
 func (*CreateSandboxRequest) ProtoMessage() {}
 
 func (x *CreateSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[4]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -441,7 +517,7 @@ func (x *CreateSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSandboxRequest.ProtoReflect.Descriptor instead.
 func (*CreateSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{4}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *CreateSandboxRequest) GetBackend() string {
@@ -476,7 +552,7 @@ type CreateSandboxResponse struct {
 
 func (x *CreateSandboxResponse) Reset() {
 	*x = CreateSandboxResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[5]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -488,7 +564,7 @@ func (x *CreateSandboxResponse) String() string {
 func (*CreateSandboxResponse) ProtoMessage() {}
 
 func (x *CreateSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[5]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -501,7 +577,7 @@ func (x *CreateSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSandboxResponse.ProtoReflect.Descriptor instead.
 func (*CreateSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{5}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *CreateSandboxResponse) GetSandbox() *Sandbox {
@@ -534,7 +610,7 @@ type GetSandboxRequest struct {
 
 func (x *GetSandboxRequest) Reset() {
 	*x = GetSandboxRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[6]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -546,7 +622,7 @@ func (x *GetSandboxRequest) String() string {
 func (*GetSandboxRequest) ProtoMessage() {}
 
 func (x *GetSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[6]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -559,7 +635,7 @@ func (x *GetSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSandboxRequest.ProtoReflect.Descriptor instead.
 func (*GetSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{6}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *GetSandboxRequest) GetSandboxId() string {
@@ -578,7 +654,7 @@ type GetSandboxResponse struct {
 
 func (x *GetSandboxResponse) Reset() {
 	*x = GetSandboxResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[7]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -590,7 +666,7 @@ func (x *GetSandboxResponse) String() string {
 func (*GetSandboxResponse) ProtoMessage() {}
 
 func (x *GetSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[7]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -603,7 +679,7 @@ func (x *GetSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSandboxResponse.ProtoReflect.Descriptor instead.
 func (*GetSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{7}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *GetSandboxResponse) GetSandbox() *Sandbox {
@@ -621,7 +697,7 @@ type ListSandboxesRequest struct {
 
 func (x *ListSandboxesRequest) Reset() {
 	*x = ListSandboxesRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[8]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -633,7 +709,7 @@ func (x *ListSandboxesRequest) String() string {
 func (*ListSandboxesRequest) ProtoMessage() {}
 
 func (x *ListSandboxesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[8]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -646,7 +722,7 @@ func (x *ListSandboxesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSandboxesRequest.ProtoReflect.Descriptor instead.
 func (*ListSandboxesRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{8}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{9}
 }
 
 type ListSandboxesResponse struct {
@@ -658,7 +734,7 @@ type ListSandboxesResponse struct {
 
 func (x *ListSandboxesResponse) Reset() {
 	*x = ListSandboxesResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[9]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -670,7 +746,7 @@ func (x *ListSandboxesResponse) String() string {
 func (*ListSandboxesResponse) ProtoMessage() {}
 
 func (x *ListSandboxesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[9]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -683,7 +759,7 @@ func (x *ListSandboxesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSandboxesResponse.ProtoReflect.Descriptor instead.
 func (*ListSandboxesResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{9}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *ListSandboxesResponse) GetSandboxes() []*Sandbox {
@@ -704,7 +780,7 @@ type DownloadSandboxFileRequest struct {
 
 func (x *DownloadSandboxFileRequest) Reset() {
 	*x = DownloadSandboxFileRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[10]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -716,7 +792,7 @@ func (x *DownloadSandboxFileRequest) String() string {
 func (*DownloadSandboxFileRequest) ProtoMessage() {}
 
 func (x *DownloadSandboxFileRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[10]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -729,7 +805,7 @@ func (x *DownloadSandboxFileRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DownloadSandboxFileRequest.ProtoReflect.Descriptor instead.
 func (*DownloadSandboxFileRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{10}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *DownloadSandboxFileRequest) GetSandboxId() string {
@@ -765,7 +841,7 @@ type DownloadSandboxFileResponse struct {
 
 func (x *DownloadSandboxFileResponse) Reset() {
 	*x = DownloadSandboxFileResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[11]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -777,7 +853,7 @@ func (x *DownloadSandboxFileResponse) String() string {
 func (*DownloadSandboxFileResponse) ProtoMessage() {}
 
 func (x *DownloadSandboxFileResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[11]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -790,7 +866,7 @@ func (x *DownloadSandboxFileResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DownloadSandboxFileResponse.ProtoReflect.Descriptor instead.
 func (*DownloadSandboxFileResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{11}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *DownloadSandboxFileResponse) GetSandboxId() string {
@@ -830,7 +906,7 @@ type TerminateSandboxRequest struct {
 
 func (x *TerminateSandboxRequest) Reset() {
 	*x = TerminateSandboxRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[12]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -842,7 +918,7 @@ func (x *TerminateSandboxRequest) String() string {
 func (*TerminateSandboxRequest) ProtoMessage() {}
 
 func (x *TerminateSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[12]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -855,7 +931,7 @@ func (x *TerminateSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TerminateSandboxRequest.ProtoReflect.Descriptor instead.
 func (*TerminateSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{12}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *TerminateSandboxRequest) GetSandboxId() string {
@@ -876,7 +952,7 @@ type TerminateSandboxResponse struct {
 
 func (x *TerminateSandboxResponse) Reset() {
 	*x = TerminateSandboxResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[13]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -888,7 +964,7 @@ func (x *TerminateSandboxResponse) String() string {
 func (*TerminateSandboxResponse) ProtoMessage() {}
 
 func (x *TerminateSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[13]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -901,7 +977,7 @@ func (x *TerminateSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TerminateSandboxResponse.ProtoReflect.Descriptor instead.
 func (*TerminateSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{13}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *TerminateSandboxResponse) GetSandboxId() string {
@@ -935,7 +1011,7 @@ type StreamSandboxEventsRequest struct {
 
 func (x *StreamSandboxEventsRequest) Reset() {
 	*x = StreamSandboxEventsRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[14]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -947,7 +1023,7 @@ func (x *StreamSandboxEventsRequest) String() string {
 func (*StreamSandboxEventsRequest) ProtoMessage() {}
 
 func (x *StreamSandboxEventsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[14]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -960,7 +1036,7 @@ func (x *StreamSandboxEventsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamSandboxEventsRequest.ProtoReflect.Descriptor instead.
 func (*StreamSandboxEventsRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{14}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *StreamSandboxEventsRequest) GetSandboxId() string {
@@ -989,7 +1065,7 @@ type SandboxEvent struct {
 
 func (x *SandboxEvent) Reset() {
 	*x = SandboxEvent{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[15]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1001,7 +1077,7 @@ func (x *SandboxEvent) String() string {
 func (*SandboxEvent) ProtoMessage() {}
 
 func (x *SandboxEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[15]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1014,7 +1090,7 @@ func (x *SandboxEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxEvent.ProtoReflect.Descriptor instead.
 func (*SandboxEvent) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{15}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *SandboxEvent) GetSandboxId() string {
@@ -1062,7 +1138,7 @@ type Execution struct {
 
 func (x *Execution) Reset() {
 	*x = Execution{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[16]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1074,7 +1150,7 @@ func (x *Execution) String() string {
 func (*Execution) ProtoMessage() {}
 
 func (x *Execution) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[16]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1087,7 +1163,7 @@ func (x *Execution) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Execution.ProtoReflect.Descriptor instead.
 func (*Execution) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{16}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *Execution) GetExecutionId() string {
@@ -1163,7 +1239,7 @@ type ExecutionOptions struct {
 
 func (x *ExecutionOptions) Reset() {
 	*x = ExecutionOptions{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[17]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1175,7 +1251,7 @@ func (x *ExecutionOptions) String() string {
 func (*ExecutionOptions) ProtoMessage() {}
 
 func (x *ExecutionOptions) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[17]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1188,7 +1264,7 @@ func (x *ExecutionOptions) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionOptions.ProtoReflect.Descriptor instead.
 func (*ExecutionOptions) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{17}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *ExecutionOptions) GetLaunchSeconds() int64 {
@@ -1216,7 +1292,7 @@ type CreateExecutionRequest struct {
 
 func (x *CreateExecutionRequest) Reset() {
 	*x = CreateExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[18]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1228,7 +1304,7 @@ func (x *CreateExecutionRequest) String() string {
 func (*CreateExecutionRequest) ProtoMessage() {}
 
 func (x *CreateExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[18]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1241,7 +1317,7 @@ func (x *CreateExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateExecutionRequest.ProtoReflect.Descriptor instead.
 func (*CreateExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{18}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *CreateExecutionRequest) GetSandboxId() string {
@@ -1274,7 +1350,7 @@ type CreateExecutionResponse struct {
 
 func (x *CreateExecutionResponse) Reset() {
 	*x = CreateExecutionResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[19]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1286,7 +1362,7 @@ func (x *CreateExecutionResponse) String() string {
 func (*CreateExecutionResponse) ProtoMessage() {}
 
 func (x *CreateExecutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[19]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1299,7 +1375,7 @@ func (x *CreateExecutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateExecutionResponse.ProtoReflect.Descriptor instead.
 func (*CreateExecutionResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{19}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *CreateExecutionResponse) GetExecution() *Execution {
@@ -1319,7 +1395,7 @@ type GetExecutionRequest struct {
 
 func (x *GetExecutionRequest) Reset() {
 	*x = GetExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[20]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1331,7 +1407,7 @@ func (x *GetExecutionRequest) String() string {
 func (*GetExecutionRequest) ProtoMessage() {}
 
 func (x *GetExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[20]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1344,7 +1420,7 @@ func (x *GetExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetExecutionRequest.ProtoReflect.Descriptor instead.
 func (*GetExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{20}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *GetExecutionRequest) GetSandboxId() string {
@@ -1370,7 +1446,7 @@ type GetExecutionResponse struct {
 
 func (x *GetExecutionResponse) Reset() {
 	*x = GetExecutionResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[21]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1382,7 +1458,7 @@ func (x *GetExecutionResponse) String() string {
 func (*GetExecutionResponse) ProtoMessage() {}
 
 func (x *GetExecutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[21]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1395,7 +1471,7 @@ func (x *GetExecutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetExecutionResponse.ProtoReflect.Descriptor instead.
 func (*GetExecutionResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{21}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *GetExecutionResponse) GetExecution() *Execution {
@@ -1416,7 +1492,7 @@ type CancelExecutionRequest struct {
 
 func (x *CancelExecutionRequest) Reset() {
 	*x = CancelExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[22]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1428,7 +1504,7 @@ func (x *CancelExecutionRequest) String() string {
 func (*CancelExecutionRequest) ProtoMessage() {}
 
 func (x *CancelExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[22]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1441,7 +1517,7 @@ func (x *CancelExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelExecutionRequest.ProtoReflect.Descriptor instead.
 func (*CancelExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{22}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *CancelExecutionRequest) GetSandboxId() string {
@@ -1477,7 +1553,7 @@ type CancelExecutionResponse struct {
 
 func (x *CancelExecutionResponse) Reset() {
 	*x = CancelExecutionResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[23]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1489,7 +1565,7 @@ func (x *CancelExecutionResponse) String() string {
 func (*CancelExecutionResponse) ProtoMessage() {}
 
 func (x *CancelExecutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[23]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1502,7 +1578,7 @@ func (x *CancelExecutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelExecutionResponse.ProtoReflect.Descriptor instead.
 func (*CancelExecutionResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{23}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *CancelExecutionResponse) GetSandboxId() string {
@@ -1544,7 +1620,7 @@ type StreamExecutionRequest struct {
 
 func (x *StreamExecutionRequest) Reset() {
 	*x = StreamExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[24]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1556,7 +1632,7 @@ func (x *StreamExecutionRequest) String() string {
 func (*StreamExecutionRequest) ProtoMessage() {}
 
 func (x *StreamExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[24]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1569,7 +1645,7 @@ func (x *StreamExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamExecutionRequest.ProtoReflect.Descriptor instead.
 func (*StreamExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{24}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *StreamExecutionRequest) GetSandboxId() string {
@@ -1604,7 +1680,7 @@ type ExecutionExit struct {
 
 func (x *ExecutionExit) Reset() {
 	*x = ExecutionExit{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[25]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1616,7 +1692,7 @@ func (x *ExecutionExit) String() string {
 func (*ExecutionExit) ProtoMessage() {}
 
 func (x *ExecutionExit) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[25]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1629,7 +1705,7 @@ func (x *ExecutionExit) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionExit.ProtoReflect.Descriptor instead.
 func (*ExecutionExit) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{25}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *ExecutionExit) GetExitCode() int32 {
@@ -1674,7 +1750,7 @@ type ExecutionStreamEvent struct {
 
 func (x *ExecutionStreamEvent) Reset() {
 	*x = ExecutionStreamEvent{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[26]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1686,7 +1762,7 @@ func (x *ExecutionStreamEvent) String() string {
 func (*ExecutionStreamEvent) ProtoMessage() {}
 
 func (x *ExecutionStreamEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[26]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1699,7 +1775,7 @@ func (x *ExecutionStreamEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionStreamEvent.ProtoReflect.Descriptor instead.
 func (*ExecutionStreamEvent) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{26}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *ExecutionStreamEvent) GetSandboxId() string {
@@ -1825,7 +1901,7 @@ type ExecutionAttachOpen struct {
 
 func (x *ExecutionAttachOpen) Reset() {
 	*x = ExecutionAttachOpen{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[27]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1837,7 +1913,7 @@ func (x *ExecutionAttachOpen) String() string {
 func (*ExecutionAttachOpen) ProtoMessage() {}
 
 func (x *ExecutionAttachOpen) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[27]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1850,7 +1926,7 @@ func (x *ExecutionAttachOpen) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionAttachOpen.ProtoReflect.Descriptor instead.
 func (*ExecutionAttachOpen) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{27}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *ExecutionAttachOpen) GetSandboxId() string {
@@ -1877,7 +1953,7 @@ type ExecutionResize struct {
 
 func (x *ExecutionResize) Reset() {
 	*x = ExecutionResize{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[28]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1889,7 +1965,7 @@ func (x *ExecutionResize) String() string {
 func (*ExecutionResize) ProtoMessage() {}
 
 func (x *ExecutionResize) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[28]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1902,7 +1978,7 @@ func (x *ExecutionResize) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionResize.ProtoReflect.Descriptor instead.
 func (*ExecutionResize) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{28}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *ExecutionResize) GetCols() uint32 {
@@ -1928,7 +2004,7 @@ type ExecutionSignal struct {
 
 func (x *ExecutionSignal) Reset() {
 	*x = ExecutionSignal{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[29]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1940,7 +2016,7 @@ func (x *ExecutionSignal) String() string {
 func (*ExecutionSignal) ProtoMessage() {}
 
 func (x *ExecutionSignal) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[29]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1953,7 +2029,7 @@ func (x *ExecutionSignal) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionSignal.ProtoReflect.Descriptor instead.
 func (*ExecutionSignal) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{29}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *ExecutionSignal) GetSignal() int32 {
@@ -1971,7 +2047,7 @@ type ExecutionHeartbeat struct {
 
 func (x *ExecutionHeartbeat) Reset() {
 	*x = ExecutionHeartbeat{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[30]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1983,7 +2059,7 @@ func (x *ExecutionHeartbeat) String() string {
 func (*ExecutionHeartbeat) ProtoMessage() {}
 
 func (x *ExecutionHeartbeat) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[30]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1996,7 +2072,7 @@ func (x *ExecutionHeartbeat) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionHeartbeat.ProtoReflect.Descriptor instead.
 func (*ExecutionHeartbeat) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{30}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{31}
 }
 
 type ExecutionClose struct {
@@ -2008,7 +2084,7 @@ type ExecutionClose struct {
 
 func (x *ExecutionClose) Reset() {
 	*x = ExecutionClose{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[31]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2020,7 +2096,7 @@ func (x *ExecutionClose) String() string {
 func (*ExecutionClose) ProtoMessage() {}
 
 func (x *ExecutionClose) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[31]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2033,7 +2109,7 @@ func (x *ExecutionClose) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionClose.ProtoReflect.Descriptor instead.
 func (*ExecutionClose) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{31}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *ExecutionClose) GetDetach() bool {
@@ -2067,7 +2143,7 @@ type ExecutionAttachFrame struct {
 
 func (x *ExecutionAttachFrame) Reset() {
 	*x = ExecutionAttachFrame{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[32]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2079,7 +2155,7 @@ func (x *ExecutionAttachFrame) String() string {
 func (*ExecutionAttachFrame) ProtoMessage() {}
 
 func (x *ExecutionAttachFrame) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[32]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2092,7 +2168,7 @@ func (x *ExecutionAttachFrame) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionAttachFrame.ProtoReflect.Descriptor instead.
 func (*ExecutionAttachFrame) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{32}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *ExecutionAttachFrame) GetSandboxId() string {
@@ -2295,11 +2371,17 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"updated_at\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\tupdatedAt\";\n" +
 	"\x0fPolicyAllowRule\x12\x12\n" +
 	"\x04host\x18\x01 \x01(\tR\x04host\x12\x14\n" +
-	"\x05ports\x18\x02 \x03(\x05R\x05ports\"\xd4\x01\n" +
+	"\x05ports\x18\x02 \x03(\x05R\x05ports\"\x87\x01\n" +
+	"\tPolicyGit\x12\x18\n" +
+	"\aenabled\x18\x01 \x01(\bR\aenabled\x12\x16\n" +
+	"\x06source\x18\x02 \x01(\tR\x06source\x12#\n" +
+	"\rallowed_hosts\x18\x03 \x03(\tR\fallowedHosts\x12#\n" +
+	"\rallowed_repos\x18\x04 \x03(\tR\fallowedRepos\"\xff\x01\n" +
 	"\x06Policy\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\x05R\aversion\x12\x1b\n" +
 	"\timage_ref\x18\x02 \x01(\tR\bimageRef\x12!\n" +
-	"\fimage_digest\x18\x03 \x01(\tR\vimageDigest\x12'\n" +
+	"\fimage_digest\x18\x03 \x01(\tR\vimageDigest\x12)\n" +
+	"\x03git\x18\a \x01(\v2\x17.cleanroom.v1.PolicyGitR\x03git\x12'\n" +
 	"\x0fnetwork_default\x18\x04 \x01(\tR\x0enetworkDefault\x123\n" +
 	"\x05allow\x18\x05 \x03(\v2\x1d.cleanroom.v1.PolicyAllowRuleR\x05allow\x12\x12\n" +
 	"\x04hash\x18\x06 \x01(\tR\x04hash\"R\n" +
@@ -2491,102 +2573,104 @@ func file_proto_cleanroom_v1_control_proto_rawDescGZIP() []byte {
 }
 
 var file_proto_cleanroom_v1_control_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_proto_cleanroom_v1_control_proto_msgTypes = make([]protoimpl.MessageInfo, 33)
+var file_proto_cleanroom_v1_control_proto_msgTypes = make([]protoimpl.MessageInfo, 34)
 var file_proto_cleanroom_v1_control_proto_goTypes = []any{
 	(SandboxStatus)(0),                  // 0: cleanroom.v1.SandboxStatus
 	(ExecutionStatus)(0),                // 1: cleanroom.v1.ExecutionStatus
 	(*Sandbox)(nil),                     // 2: cleanroom.v1.Sandbox
 	(*PolicyAllowRule)(nil),             // 3: cleanroom.v1.PolicyAllowRule
-	(*Policy)(nil),                      // 4: cleanroom.v1.Policy
-	(*SandboxOptions)(nil),              // 5: cleanroom.v1.SandboxOptions
-	(*CreateSandboxRequest)(nil),        // 6: cleanroom.v1.CreateSandboxRequest
-	(*CreateSandboxResponse)(nil),       // 7: cleanroom.v1.CreateSandboxResponse
-	(*GetSandboxRequest)(nil),           // 8: cleanroom.v1.GetSandboxRequest
-	(*GetSandboxResponse)(nil),          // 9: cleanroom.v1.GetSandboxResponse
-	(*ListSandboxesRequest)(nil),        // 10: cleanroom.v1.ListSandboxesRequest
-	(*ListSandboxesResponse)(nil),       // 11: cleanroom.v1.ListSandboxesResponse
-	(*DownloadSandboxFileRequest)(nil),  // 12: cleanroom.v1.DownloadSandboxFileRequest
-	(*DownloadSandboxFileResponse)(nil), // 13: cleanroom.v1.DownloadSandboxFileResponse
-	(*TerminateSandboxRequest)(nil),     // 14: cleanroom.v1.TerminateSandboxRequest
-	(*TerminateSandboxResponse)(nil),    // 15: cleanroom.v1.TerminateSandboxResponse
-	(*StreamSandboxEventsRequest)(nil),  // 16: cleanroom.v1.StreamSandboxEventsRequest
-	(*SandboxEvent)(nil),                // 17: cleanroom.v1.SandboxEvent
-	(*Execution)(nil),                   // 18: cleanroom.v1.Execution
-	(*ExecutionOptions)(nil),            // 19: cleanroom.v1.ExecutionOptions
-	(*CreateExecutionRequest)(nil),      // 20: cleanroom.v1.CreateExecutionRequest
-	(*CreateExecutionResponse)(nil),     // 21: cleanroom.v1.CreateExecutionResponse
-	(*GetExecutionRequest)(nil),         // 22: cleanroom.v1.GetExecutionRequest
-	(*GetExecutionResponse)(nil),        // 23: cleanroom.v1.GetExecutionResponse
-	(*CancelExecutionRequest)(nil),      // 24: cleanroom.v1.CancelExecutionRequest
-	(*CancelExecutionResponse)(nil),     // 25: cleanroom.v1.CancelExecutionResponse
-	(*StreamExecutionRequest)(nil),      // 26: cleanroom.v1.StreamExecutionRequest
-	(*ExecutionExit)(nil),               // 27: cleanroom.v1.ExecutionExit
-	(*ExecutionStreamEvent)(nil),        // 28: cleanroom.v1.ExecutionStreamEvent
-	(*ExecutionAttachOpen)(nil),         // 29: cleanroom.v1.ExecutionAttachOpen
-	(*ExecutionResize)(nil),             // 30: cleanroom.v1.ExecutionResize
-	(*ExecutionSignal)(nil),             // 31: cleanroom.v1.ExecutionSignal
-	(*ExecutionHeartbeat)(nil),          // 32: cleanroom.v1.ExecutionHeartbeat
-	(*ExecutionClose)(nil),              // 33: cleanroom.v1.ExecutionClose
-	(*ExecutionAttachFrame)(nil),        // 34: cleanroom.v1.ExecutionAttachFrame
-	(*timestamppb.Timestamp)(nil),       // 35: google.protobuf.Timestamp
+	(*PolicyGit)(nil),                   // 4: cleanroom.v1.PolicyGit
+	(*Policy)(nil),                      // 5: cleanroom.v1.Policy
+	(*SandboxOptions)(nil),              // 6: cleanroom.v1.SandboxOptions
+	(*CreateSandboxRequest)(nil),        // 7: cleanroom.v1.CreateSandboxRequest
+	(*CreateSandboxResponse)(nil),       // 8: cleanroom.v1.CreateSandboxResponse
+	(*GetSandboxRequest)(nil),           // 9: cleanroom.v1.GetSandboxRequest
+	(*GetSandboxResponse)(nil),          // 10: cleanroom.v1.GetSandboxResponse
+	(*ListSandboxesRequest)(nil),        // 11: cleanroom.v1.ListSandboxesRequest
+	(*ListSandboxesResponse)(nil),       // 12: cleanroom.v1.ListSandboxesResponse
+	(*DownloadSandboxFileRequest)(nil),  // 13: cleanroom.v1.DownloadSandboxFileRequest
+	(*DownloadSandboxFileResponse)(nil), // 14: cleanroom.v1.DownloadSandboxFileResponse
+	(*TerminateSandboxRequest)(nil),     // 15: cleanroom.v1.TerminateSandboxRequest
+	(*TerminateSandboxResponse)(nil),    // 16: cleanroom.v1.TerminateSandboxResponse
+	(*StreamSandboxEventsRequest)(nil),  // 17: cleanroom.v1.StreamSandboxEventsRequest
+	(*SandboxEvent)(nil),                // 18: cleanroom.v1.SandboxEvent
+	(*Execution)(nil),                   // 19: cleanroom.v1.Execution
+	(*ExecutionOptions)(nil),            // 20: cleanroom.v1.ExecutionOptions
+	(*CreateExecutionRequest)(nil),      // 21: cleanroom.v1.CreateExecutionRequest
+	(*CreateExecutionResponse)(nil),     // 22: cleanroom.v1.CreateExecutionResponse
+	(*GetExecutionRequest)(nil),         // 23: cleanroom.v1.GetExecutionRequest
+	(*GetExecutionResponse)(nil),        // 24: cleanroom.v1.GetExecutionResponse
+	(*CancelExecutionRequest)(nil),      // 25: cleanroom.v1.CancelExecutionRequest
+	(*CancelExecutionResponse)(nil),     // 26: cleanroom.v1.CancelExecutionResponse
+	(*StreamExecutionRequest)(nil),      // 27: cleanroom.v1.StreamExecutionRequest
+	(*ExecutionExit)(nil),               // 28: cleanroom.v1.ExecutionExit
+	(*ExecutionStreamEvent)(nil),        // 29: cleanroom.v1.ExecutionStreamEvent
+	(*ExecutionAttachOpen)(nil),         // 30: cleanroom.v1.ExecutionAttachOpen
+	(*ExecutionResize)(nil),             // 31: cleanroom.v1.ExecutionResize
+	(*ExecutionSignal)(nil),             // 32: cleanroom.v1.ExecutionSignal
+	(*ExecutionHeartbeat)(nil),          // 33: cleanroom.v1.ExecutionHeartbeat
+	(*ExecutionClose)(nil),              // 34: cleanroom.v1.ExecutionClose
+	(*ExecutionAttachFrame)(nil),        // 35: cleanroom.v1.ExecutionAttachFrame
+	(*timestamppb.Timestamp)(nil),       // 36: google.protobuf.Timestamp
 }
 var file_proto_cleanroom_v1_control_proto_depIdxs = []int32{
 	0,  // 0: cleanroom.v1.Sandbox.status:type_name -> cleanroom.v1.SandboxStatus
-	35, // 1: cleanroom.v1.Sandbox.created_at:type_name -> google.protobuf.Timestamp
-	35, // 2: cleanroom.v1.Sandbox.updated_at:type_name -> google.protobuf.Timestamp
-	3,  // 3: cleanroom.v1.Policy.allow:type_name -> cleanroom.v1.PolicyAllowRule
-	5,  // 4: cleanroom.v1.CreateSandboxRequest.options:type_name -> cleanroom.v1.SandboxOptions
-	4,  // 5: cleanroom.v1.CreateSandboxRequest.policy:type_name -> cleanroom.v1.Policy
-	2,  // 6: cleanroom.v1.CreateSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
-	2,  // 7: cleanroom.v1.GetSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
-	2,  // 8: cleanroom.v1.ListSandboxesResponse.sandboxes:type_name -> cleanroom.v1.Sandbox
-	0,  // 9: cleanroom.v1.SandboxEvent.status:type_name -> cleanroom.v1.SandboxStatus
-	35, // 10: cleanroom.v1.SandboxEvent.occurred_at:type_name -> google.protobuf.Timestamp
-	1,  // 11: cleanroom.v1.Execution.status:type_name -> cleanroom.v1.ExecutionStatus
-	35, // 12: cleanroom.v1.Execution.started_at:type_name -> google.protobuf.Timestamp
-	35, // 13: cleanroom.v1.Execution.finished_at:type_name -> google.protobuf.Timestamp
-	19, // 14: cleanroom.v1.CreateExecutionRequest.options:type_name -> cleanroom.v1.ExecutionOptions
-	18, // 15: cleanroom.v1.CreateExecutionResponse.execution:type_name -> cleanroom.v1.Execution
-	18, // 16: cleanroom.v1.GetExecutionResponse.execution:type_name -> cleanroom.v1.Execution
-	1,  // 17: cleanroom.v1.CancelExecutionResponse.status:type_name -> cleanroom.v1.ExecutionStatus
-	1,  // 18: cleanroom.v1.ExecutionExit.status:type_name -> cleanroom.v1.ExecutionStatus
-	1,  // 19: cleanroom.v1.ExecutionStreamEvent.status:type_name -> cleanroom.v1.ExecutionStatus
-	27, // 20: cleanroom.v1.ExecutionStreamEvent.exit:type_name -> cleanroom.v1.ExecutionExit
-	35, // 21: cleanroom.v1.ExecutionStreamEvent.occurred_at:type_name -> google.protobuf.Timestamp
-	29, // 22: cleanroom.v1.ExecutionAttachFrame.open:type_name -> cleanroom.v1.ExecutionAttachOpen
-	30, // 23: cleanroom.v1.ExecutionAttachFrame.resize:type_name -> cleanroom.v1.ExecutionResize
-	31, // 24: cleanroom.v1.ExecutionAttachFrame.signal:type_name -> cleanroom.v1.ExecutionSignal
-	32, // 25: cleanroom.v1.ExecutionAttachFrame.heartbeat:type_name -> cleanroom.v1.ExecutionHeartbeat
-	33, // 26: cleanroom.v1.ExecutionAttachFrame.close:type_name -> cleanroom.v1.ExecutionClose
-	27, // 27: cleanroom.v1.ExecutionAttachFrame.exit:type_name -> cleanroom.v1.ExecutionExit
-	35, // 28: cleanroom.v1.ExecutionAttachFrame.occurred_at:type_name -> google.protobuf.Timestamp
-	6,  // 29: cleanroom.v1.SandboxService.CreateSandbox:input_type -> cleanroom.v1.CreateSandboxRequest
-	8,  // 30: cleanroom.v1.SandboxService.GetSandbox:input_type -> cleanroom.v1.GetSandboxRequest
-	10, // 31: cleanroom.v1.SandboxService.ListSandboxes:input_type -> cleanroom.v1.ListSandboxesRequest
-	12, // 32: cleanroom.v1.SandboxService.DownloadSandboxFile:input_type -> cleanroom.v1.DownloadSandboxFileRequest
-	14, // 33: cleanroom.v1.SandboxService.TerminateSandbox:input_type -> cleanroom.v1.TerminateSandboxRequest
-	16, // 34: cleanroom.v1.SandboxService.StreamSandboxEvents:input_type -> cleanroom.v1.StreamSandboxEventsRequest
-	20, // 35: cleanroom.v1.ExecutionService.CreateExecution:input_type -> cleanroom.v1.CreateExecutionRequest
-	22, // 36: cleanroom.v1.ExecutionService.GetExecution:input_type -> cleanroom.v1.GetExecutionRequest
-	24, // 37: cleanroom.v1.ExecutionService.CancelExecution:input_type -> cleanroom.v1.CancelExecutionRequest
-	26, // 38: cleanroom.v1.ExecutionService.StreamExecution:input_type -> cleanroom.v1.StreamExecutionRequest
-	34, // 39: cleanroom.v1.ExecutionService.AttachExecution:input_type -> cleanroom.v1.ExecutionAttachFrame
-	7,  // 40: cleanroom.v1.SandboxService.CreateSandbox:output_type -> cleanroom.v1.CreateSandboxResponse
-	9,  // 41: cleanroom.v1.SandboxService.GetSandbox:output_type -> cleanroom.v1.GetSandboxResponse
-	11, // 42: cleanroom.v1.SandboxService.ListSandboxes:output_type -> cleanroom.v1.ListSandboxesResponse
-	13, // 43: cleanroom.v1.SandboxService.DownloadSandboxFile:output_type -> cleanroom.v1.DownloadSandboxFileResponse
-	15, // 44: cleanroom.v1.SandboxService.TerminateSandbox:output_type -> cleanroom.v1.TerminateSandboxResponse
-	17, // 45: cleanroom.v1.SandboxService.StreamSandboxEvents:output_type -> cleanroom.v1.SandboxEvent
-	21, // 46: cleanroom.v1.ExecutionService.CreateExecution:output_type -> cleanroom.v1.CreateExecutionResponse
-	23, // 47: cleanroom.v1.ExecutionService.GetExecution:output_type -> cleanroom.v1.GetExecutionResponse
-	25, // 48: cleanroom.v1.ExecutionService.CancelExecution:output_type -> cleanroom.v1.CancelExecutionResponse
-	28, // 49: cleanroom.v1.ExecutionService.StreamExecution:output_type -> cleanroom.v1.ExecutionStreamEvent
-	34, // 50: cleanroom.v1.ExecutionService.AttachExecution:output_type -> cleanroom.v1.ExecutionAttachFrame
-	40, // [40:51] is the sub-list for method output_type
-	29, // [29:40] is the sub-list for method input_type
-	29, // [29:29] is the sub-list for extension type_name
-	29, // [29:29] is the sub-list for extension extendee
-	0,  // [0:29] is the sub-list for field type_name
+	36, // 1: cleanroom.v1.Sandbox.created_at:type_name -> google.protobuf.Timestamp
+	36, // 2: cleanroom.v1.Sandbox.updated_at:type_name -> google.protobuf.Timestamp
+	4,  // 3: cleanroom.v1.Policy.git:type_name -> cleanroom.v1.PolicyGit
+	3,  // 4: cleanroom.v1.Policy.allow:type_name -> cleanroom.v1.PolicyAllowRule
+	6,  // 5: cleanroom.v1.CreateSandboxRequest.options:type_name -> cleanroom.v1.SandboxOptions
+	5,  // 6: cleanroom.v1.CreateSandboxRequest.policy:type_name -> cleanroom.v1.Policy
+	2,  // 7: cleanroom.v1.CreateSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
+	2,  // 8: cleanroom.v1.GetSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
+	2,  // 9: cleanroom.v1.ListSandboxesResponse.sandboxes:type_name -> cleanroom.v1.Sandbox
+	0,  // 10: cleanroom.v1.SandboxEvent.status:type_name -> cleanroom.v1.SandboxStatus
+	36, // 11: cleanroom.v1.SandboxEvent.occurred_at:type_name -> google.protobuf.Timestamp
+	1,  // 12: cleanroom.v1.Execution.status:type_name -> cleanroom.v1.ExecutionStatus
+	36, // 13: cleanroom.v1.Execution.started_at:type_name -> google.protobuf.Timestamp
+	36, // 14: cleanroom.v1.Execution.finished_at:type_name -> google.protobuf.Timestamp
+	20, // 15: cleanroom.v1.CreateExecutionRequest.options:type_name -> cleanroom.v1.ExecutionOptions
+	19, // 16: cleanroom.v1.CreateExecutionResponse.execution:type_name -> cleanroom.v1.Execution
+	19, // 17: cleanroom.v1.GetExecutionResponse.execution:type_name -> cleanroom.v1.Execution
+	1,  // 18: cleanroom.v1.CancelExecutionResponse.status:type_name -> cleanroom.v1.ExecutionStatus
+	1,  // 19: cleanroom.v1.ExecutionExit.status:type_name -> cleanroom.v1.ExecutionStatus
+	1,  // 20: cleanroom.v1.ExecutionStreamEvent.status:type_name -> cleanroom.v1.ExecutionStatus
+	28, // 21: cleanroom.v1.ExecutionStreamEvent.exit:type_name -> cleanroom.v1.ExecutionExit
+	36, // 22: cleanroom.v1.ExecutionStreamEvent.occurred_at:type_name -> google.protobuf.Timestamp
+	30, // 23: cleanroom.v1.ExecutionAttachFrame.open:type_name -> cleanroom.v1.ExecutionAttachOpen
+	31, // 24: cleanroom.v1.ExecutionAttachFrame.resize:type_name -> cleanroom.v1.ExecutionResize
+	32, // 25: cleanroom.v1.ExecutionAttachFrame.signal:type_name -> cleanroom.v1.ExecutionSignal
+	33, // 26: cleanroom.v1.ExecutionAttachFrame.heartbeat:type_name -> cleanroom.v1.ExecutionHeartbeat
+	34, // 27: cleanroom.v1.ExecutionAttachFrame.close:type_name -> cleanroom.v1.ExecutionClose
+	28, // 28: cleanroom.v1.ExecutionAttachFrame.exit:type_name -> cleanroom.v1.ExecutionExit
+	36, // 29: cleanroom.v1.ExecutionAttachFrame.occurred_at:type_name -> google.protobuf.Timestamp
+	7,  // 30: cleanroom.v1.SandboxService.CreateSandbox:input_type -> cleanroom.v1.CreateSandboxRequest
+	9,  // 31: cleanroom.v1.SandboxService.GetSandbox:input_type -> cleanroom.v1.GetSandboxRequest
+	11, // 32: cleanroom.v1.SandboxService.ListSandboxes:input_type -> cleanroom.v1.ListSandboxesRequest
+	13, // 33: cleanroom.v1.SandboxService.DownloadSandboxFile:input_type -> cleanroom.v1.DownloadSandboxFileRequest
+	15, // 34: cleanroom.v1.SandboxService.TerminateSandbox:input_type -> cleanroom.v1.TerminateSandboxRequest
+	17, // 35: cleanroom.v1.SandboxService.StreamSandboxEvents:input_type -> cleanroom.v1.StreamSandboxEventsRequest
+	21, // 36: cleanroom.v1.ExecutionService.CreateExecution:input_type -> cleanroom.v1.CreateExecutionRequest
+	23, // 37: cleanroom.v1.ExecutionService.GetExecution:input_type -> cleanroom.v1.GetExecutionRequest
+	25, // 38: cleanroom.v1.ExecutionService.CancelExecution:input_type -> cleanroom.v1.CancelExecutionRequest
+	27, // 39: cleanroom.v1.ExecutionService.StreamExecution:input_type -> cleanroom.v1.StreamExecutionRequest
+	35, // 40: cleanroom.v1.ExecutionService.AttachExecution:input_type -> cleanroom.v1.ExecutionAttachFrame
+	8,  // 41: cleanroom.v1.SandboxService.CreateSandbox:output_type -> cleanroom.v1.CreateSandboxResponse
+	10, // 42: cleanroom.v1.SandboxService.GetSandbox:output_type -> cleanroom.v1.GetSandboxResponse
+	12, // 43: cleanroom.v1.SandboxService.ListSandboxes:output_type -> cleanroom.v1.ListSandboxesResponse
+	14, // 44: cleanroom.v1.SandboxService.DownloadSandboxFile:output_type -> cleanroom.v1.DownloadSandboxFileResponse
+	16, // 45: cleanroom.v1.SandboxService.TerminateSandbox:output_type -> cleanroom.v1.TerminateSandboxResponse
+	18, // 46: cleanroom.v1.SandboxService.StreamSandboxEvents:output_type -> cleanroom.v1.SandboxEvent
+	22, // 47: cleanroom.v1.ExecutionService.CreateExecution:output_type -> cleanroom.v1.CreateExecutionResponse
+	24, // 48: cleanroom.v1.ExecutionService.GetExecution:output_type -> cleanroom.v1.GetExecutionResponse
+	26, // 49: cleanroom.v1.ExecutionService.CancelExecution:output_type -> cleanroom.v1.CancelExecutionResponse
+	29, // 50: cleanroom.v1.ExecutionService.StreamExecution:output_type -> cleanroom.v1.ExecutionStreamEvent
+	35, // 51: cleanroom.v1.ExecutionService.AttachExecution:output_type -> cleanroom.v1.ExecutionAttachFrame
+	41, // [41:52] is the sub-list for method output_type
+	30, // [30:41] is the sub-list for method input_type
+	30, // [30:30] is the sub-list for extension type_name
+	30, // [30:30] is the sub-list for extension extendee
+	0,  // [0:30] is the sub-list for field type_name
 }
 
 func init() { file_proto_cleanroom_v1_control_proto_init() }
@@ -2594,13 +2678,13 @@ func file_proto_cleanroom_v1_control_proto_init() {
 	if File_proto_cleanroom_v1_control_proto != nil {
 		return
 	}
-	file_proto_cleanroom_v1_control_proto_msgTypes[26].OneofWrappers = []any{
+	file_proto_cleanroom_v1_control_proto_msgTypes[27].OneofWrappers = []any{
 		(*ExecutionStreamEvent_Stdout)(nil),
 		(*ExecutionStreamEvent_Stderr)(nil),
 		(*ExecutionStreamEvent_Exit)(nil),
 		(*ExecutionStreamEvent_Message)(nil),
 	}
-	file_proto_cleanroom_v1_control_proto_msgTypes[32].OneofWrappers = []any{
+	file_proto_cleanroom_v1_control_proto_msgTypes[33].OneofWrappers = []any{
 		(*ExecutionAttachFrame_Open)(nil),
 		(*ExecutionAttachFrame_Stdin)(nil),
 		(*ExecutionAttachFrame_Resize)(nil),
@@ -2618,7 +2702,7 @@ func file_proto_cleanroom_v1_control_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proto_cleanroom_v1_control_proto_rawDesc), len(file_proto_cleanroom_v1_control_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   33,
+			NumMessages:   34,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/internal/gitgateway/env.go
+++ b/internal/gitgateway/env.go
@@ -1,0 +1,22 @@
+package gitgateway
+
+import "fmt"
+
+// BuildScopedGitConfigEnv builds GIT_CONFIG_COUNT style environment variables
+// for temporary per-process URL rewrite rules.
+func BuildScopedGitConfigEnv(rules []RewriteRule) []string {
+	if len(rules) == 0 {
+		return nil
+	}
+
+	out := make([]string, 0, 1+(len(rules)*2))
+	out = append(out, fmt.Sprintf("GIT_CONFIG_COUNT=%d", len(rules)))
+	for i, rule := range rules {
+		out = append(out,
+			fmt.Sprintf("GIT_CONFIG_KEY_%d=url.%s.insteadof", i, rule.BaseURL),
+			fmt.Sprintf("GIT_CONFIG_VALUE_%d=%s", i, rule.InsteadOf),
+		)
+	}
+
+	return out
+}

--- a/internal/gitgateway/env_test.go
+++ b/internal/gitgateway/env_test.go
@@ -1,0 +1,33 @@
+package gitgateway
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestBuildScopedGitConfigEnv(t *testing.T) {
+	t.Parallel()
+
+	env := BuildScopedGitConfigEnv([]RewriteRule{{
+		BaseURL:   "http://127.0.0.1:17080/git/github.com/",
+		InsteadOf: "https://github.com/",
+	}})
+
+	want := []string{
+		"GIT_CONFIG_COUNT=1",
+		"GIT_CONFIG_KEY_0=url.http://127.0.0.1:17080/git/github.com/.insteadof",
+		"GIT_CONFIG_VALUE_0=https://github.com/",
+	}
+	if !reflect.DeepEqual(env, want) {
+		t.Fatalf("unexpected env: got %v want %v", env, want)
+	}
+}
+
+func TestBuildScopedGitConfigEnvEmpty(t *testing.T) {
+	t.Parallel()
+
+	env := BuildScopedGitConfigEnv(nil)
+	if env != nil {
+		t.Fatalf("expected nil env for empty rules, got %v", env)
+	}
+}

--- a/internal/gitgateway/rewrite.go
+++ b/internal/gitgateway/rewrite.go
@@ -1,0 +1,69 @@
+package gitgateway
+
+import (
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+)
+
+type RewriteRule struct {
+	BaseURL   string
+	InsteadOf string
+}
+
+// BuildRewriteRulesForScope returns stable, per-host insteadOf rules which
+// rewrite https remotes to a scope-specific local gateway endpoint.
+func BuildRewriteRulesForScope(relayBaseURL, scope string, allowedHosts []string) ([]RewriteRule, error) {
+	trimmedBase := strings.TrimSpace(relayBaseURL)
+	if trimmedBase == "" {
+		return nil, fmt.Errorf("relay base URL is required")
+	}
+	parsedBase, err := url.Parse(trimmedBase)
+	if err != nil {
+		return nil, fmt.Errorf("invalid relay base URL %q: %w", relayBaseURL, err)
+	}
+	if parsedBase.Scheme != "http" && parsedBase.Scheme != "https" {
+		return nil, fmt.Errorf("relay base URL %q must use http or https", relayBaseURL)
+	}
+	if parsedBase.Host == "" {
+		return nil, fmt.Errorf("relay base URL %q must include a host", relayBaseURL)
+	}
+
+	normalizedHosts := make([]string, 0, len(allowedHosts))
+	seen := map[string]struct{}{}
+	for _, host := range allowedHosts {
+		normalized := strings.ToLower(strings.TrimSpace(host))
+		if normalized == "" {
+			return nil, fmt.Errorf("allowed hosts cannot contain empty entries")
+		}
+		if strings.Contains(normalized, "/") {
+			return nil, fmt.Errorf("allowed host %q must be a hostname", normalized)
+		}
+		if _, ok := seen[normalized]; ok {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		normalizedHosts = append(normalizedHosts, normalized)
+	}
+	if len(normalizedHosts) == 0 {
+		return nil, fmt.Errorf("at least one allowed host is required")
+	}
+	sort.Strings(normalizedHosts)
+
+	basePrefix := strings.TrimRight(parsedBase.String(), "/")
+	scopePrefix := ""
+	trimmedScope := strings.TrimSpace(scope)
+	if trimmedScope != "" {
+		scopePrefix = trimmedScope + "/"
+	}
+	rules := make([]RewriteRule, 0, len(normalizedHosts))
+	for _, host := range normalizedHosts {
+		rules = append(rules, RewriteRule{
+			BaseURL:   fmt.Sprintf("%s/git/%s%s/", basePrefix, scopePrefix, host),
+			InsteadOf: fmt.Sprintf("https://%s/", host),
+		})
+	}
+
+	return rules, nil
+}

--- a/internal/gitgateway/rewrite_test.go
+++ b/internal/gitgateway/rewrite_test.go
@@ -1,0 +1,61 @@
+package gitgateway
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildRewriteRulesForScopeSortsAndDeduplicatesHosts(t *testing.T) {
+	t.Parallel()
+
+	rules, err := BuildRewriteRulesForScope("http://127.0.0.1:18080", "", []string{"GitHub.com", "github.com", "gitlab.com"})
+	if err != nil {
+		t.Fatalf("BuildRewriteRulesForScope returned error: %v", err)
+	}
+	if len(rules) != 2 {
+		t.Fatalf("unexpected rule count: got %d want 2", len(rules))
+	}
+	if got, want := rules[0].InsteadOf, "https://github.com/"; got != want {
+		t.Fatalf("unexpected first insteadOf: got %q want %q", got, want)
+	}
+	if got, want := rules[0].BaseURL, "http://127.0.0.1:18080/git/github.com/"; got != want {
+		t.Fatalf("unexpected first base URL: got %q want %q", got, want)
+	}
+	if got, want := rules[1].InsteadOf, "https://gitlab.com/"; got != want {
+		t.Fatalf("unexpected second insteadOf: got %q want %q", got, want)
+	}
+}
+
+func TestBuildRewriteRulesForScopeRejectsInvalidInputs(t *testing.T) {
+	t.Parallel()
+
+	_, err := BuildRewriteRulesForScope("", "", []string{"github.com"})
+	if err == nil || !strings.Contains(err.Error(), "required") {
+		t.Fatalf("expected relay URL required error, got %v", err)
+	}
+
+	_, err = BuildRewriteRulesForScope("http://127.0.0.1:18080", "", nil)
+	if err == nil || !strings.Contains(err.Error(), "at least one allowed host") {
+		t.Fatalf("expected allowed host error, got %v", err)
+	}
+
+	_, err = BuildRewriteRulesForScope("http://127.0.0.1:18080", "", []string{"owner/repo"})
+	if err == nil || !strings.Contains(err.Error(), "hostname") {
+		t.Fatalf("expected hostname error, got %v", err)
+	}
+}
+
+func TestBuildRewriteRulesForScope(t *testing.T) {
+	t.Parallel()
+
+	rules, err := BuildRewriteRulesForScope("http://10.99.0.1:18080", "sandbox-scope", []string{"github.com"})
+	if err != nil {
+		t.Fatalf("BuildRewriteRulesForScope returned error: %v", err)
+	}
+	if len(rules) != 1 {
+		t.Fatalf("unexpected rule count: got %d want 1", len(rules))
+	}
+	if got, want := rules[0].BaseURL, "http://10.99.0.1:18080/git/sandbox-scope/github.com/"; got != want {
+		t.Fatalf("unexpected scoped base URL: got %q want %q", got, want)
+	}
+}

--- a/internal/gitgateway/scopes.go
+++ b/internal/gitgateway/scopes.go
@@ -1,0 +1,87 @@
+package gitgateway
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/buildkite/cleanroom/internal/policy"
+)
+
+type ScopeRegistry struct {
+	mu       sync.RWMutex
+	policies map[string]*policy.GitPolicy
+}
+
+func NewScopeRegistry() *ScopeRegistry {
+	return &ScopeRegistry{policies: map[string]*policy.GitPolicy{}}
+}
+
+func (r *ScopeRegistry) Set(scope string, gitPolicy *policy.GitPolicy) error {
+	if r == nil {
+		return fmt.Errorf("scope registry is nil")
+	}
+	normalizedScope := strings.TrimSpace(scope)
+	if normalizedScope == "" {
+		return fmt.Errorf("scope is required")
+	}
+	if gitPolicy == nil || !gitPolicy.Enabled {
+		return fmt.Errorf("enabled git policy is required")
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.policies[normalizedScope] = clonePolicy(gitPolicy)
+	return nil
+}
+
+func (r *ScopeRegistry) Resolve(scope string) (*policy.GitPolicy, bool) {
+	if r == nil {
+		return nil, false
+	}
+	normalizedScope := strings.TrimSpace(scope)
+	if normalizedScope == "" {
+		return nil, false
+	}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	p, ok := r.policies[normalizedScope]
+	if !ok {
+		return nil, false
+	}
+	return clonePolicy(p), true
+}
+
+func (r *ScopeRegistry) Delete(scope string) int {
+	if r == nil {
+		return 0
+	}
+	normalizedScope := strings.TrimSpace(scope)
+	if normalizedScope == "" {
+		return r.Count()
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.policies, normalizedScope)
+	return len(r.policies)
+}
+
+func (r *ScopeRegistry) Count() int {
+	if r == nil {
+		return 0
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.policies)
+}
+
+func clonePolicy(gitPolicy *policy.GitPolicy) *policy.GitPolicy {
+	if gitPolicy == nil {
+		return nil
+	}
+	copyPolicy := *gitPolicy
+	copyPolicy.AllowedHosts = append([]string(nil), gitPolicy.AllowedHosts...)
+	copyPolicy.AllowedRepos = append([]string(nil), gitPolicy.AllowedRepos...)
+	return &copyPolicy
+}

--- a/internal/gitgateway/scopes_test.go
+++ b/internal/gitgateway/scopes_test.go
@@ -1,0 +1,35 @@
+package gitgateway
+
+import (
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/policy"
+)
+
+func TestScopeRegistrySetResolveDelete(t *testing.T) {
+	t.Parallel()
+
+	r := NewScopeRegistry()
+	err := r.Set("scope-1", &policy.GitPolicy{Enabled: true, Source: "upstream", AllowedHosts: []string{"github.com"}})
+	if err != nil {
+		t.Fatalf("Set returned error: %v", err)
+	}
+
+	resolved, ok := r.Resolve("scope-1")
+	if !ok || resolved == nil {
+		t.Fatalf("expected scope to resolve")
+	}
+	if got, want := resolved.AllowedHosts[0], "github.com"; got != want {
+		t.Fatalf("unexpected allowed host: got %q want %q", got, want)
+	}
+
+	resolved.AllowedHosts[0] = "example.com"
+	resolvedAgain, ok := r.Resolve("scope-1")
+	if !ok || resolvedAgain == nil || resolvedAgain.AllowedHosts[0] != "github.com" {
+		t.Fatalf("expected Resolve to return defensive copy, got %+v", resolvedAgain)
+	}
+
+	if got, want := r.Delete("scope-1"), 0; got != want {
+		t.Fatalf("unexpected remaining count after delete: got %d want %d", got, want)
+	}
+}

--- a/internal/gitgateway/server.go
+++ b/internal/gitgateway/server.go
@@ -1,0 +1,342 @@
+package gitgateway
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/buildkite/cleanroom/internal/policy"
+)
+
+type Config struct {
+	ListenHost string
+	GitPolicy  *policy.GitPolicy
+
+	// PolicyForScope resolves policy by scope identifier for requests routed via
+	// /git/<scope>/<host>/<owner>/<repo>.git/...
+	PolicyForScope func(string) (*policy.GitPolicy, bool)
+	MirrorRoot     string
+	Client         *http.Client
+
+	// UpstreamScheme defaults to https and is exposed for tests.
+	UpstreamScheme string
+}
+
+type Server struct {
+	listener net.Listener
+	httpSrv  *http.Server
+}
+
+func (s *Server) Close() error {
+	if s == nil || s.httpSrv == nil {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	return s.httpSrv.Shutdown(ctx)
+}
+
+func Start(ctx context.Context, cfg Config) (*Server, error) {
+	if cfg.GitPolicy == nil || !cfg.GitPolicy.Enabled {
+		return nil, nil
+	}
+	listenHost := strings.TrimSpace(cfg.ListenHost)
+	if listenHost == "" {
+		return nil, fmt.Errorf("git gateway listen host is required")
+	}
+
+	ln, err := net.Listen("tcp", net.JoinHostPort(listenHost, "0"))
+	if err != nil {
+		return nil, fmt.Errorf("listen git gateway on %s: %w", listenHost, err)
+	}
+	return StartOnListener(ctx, ln, cfg)
+}
+
+func StartOnListener(ctx context.Context, ln net.Listener, cfg Config) (*Server, error) {
+	if cfg.GitPolicy == nil || !cfg.GitPolicy.Enabled {
+		return nil, nil
+	}
+	if ln == nil {
+		return nil, fmt.Errorf("git gateway listener is required")
+	}
+
+	upstreamScheme := strings.ToLower(strings.TrimSpace(cfg.UpstreamScheme))
+	if upstreamScheme == "" {
+		upstreamScheme = "https"
+	}
+	if upstreamScheme != "https" && upstreamScheme != "http" {
+		return nil, fmt.Errorf("unsupported upstream scheme %q", upstreamScheme)
+	}
+
+	client := cfg.Client
+	if client == nil {
+		client = &http.Client{Timeout: 60 * time.Second}
+	}
+
+	handler := newHandler(cfg.GitPolicy, cfg.PolicyForScope, strings.TrimSpace(cfg.MirrorRoot), upstreamScheme, client)
+
+	httpSrv := &http.Server{
+		Handler:           handler,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	server := &Server{
+		listener: ln,
+		httpSrv:  httpSrv,
+	}
+
+	go func() {
+		_ = httpSrv.Serve(ln)
+	}()
+
+	go func() {
+		<-ctx.Done()
+		_ = server.Close()
+	}()
+
+	return server, nil
+}
+
+type gatewayHandler struct {
+	policy         *policy.GitPolicy
+	policyForScope func(string) (*policy.GitPolicy, bool)
+	mirrorRoot     string
+	upstreamScheme string
+	client         *http.Client
+}
+
+func newHandler(policy *policy.GitPolicy, policyForScope func(string) (*policy.GitPolicy, bool), mirrorRoot string, upstreamScheme string, client *http.Client) *gatewayHandler {
+	return &gatewayHandler{policy: policy, policyForScope: policyForScope, mirrorRoot: mirrorRoot, upstreamScheme: upstreamScheme, client: client}
+}
+
+func (h *gatewayHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	req, ok := parseGatewayPath(r.URL.Path)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	requestPolicy := h.policy
+	if req.Scope != "" {
+		if h.policyForScope == nil {
+			http.Error(w, "scope_not_allowed", http.StatusForbidden)
+			return
+		}
+		resolved, found := h.policyForScope(req.Scope)
+		if !found || resolved == nil || !resolved.Enabled {
+			http.Error(w, "scope_not_allowed", http.StatusForbidden)
+			return
+		}
+		requestPolicy = resolved
+	}
+	if requestPolicy == nil || !requestPolicy.Enabled {
+		http.Error(w, "scope_not_allowed", http.StatusForbidden)
+		return
+	}
+	if req.Op == "info/refs" {
+		if r.Method != http.MethodGet || strings.TrimSpace(r.URL.Query().Get("service")) != "git-upload-pack" {
+			http.Error(w, "unsupported git service", http.StatusBadRequest)
+			return
+		}
+	} else {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+	}
+
+	if !contains(requestPolicy.AllowedHosts, req.Host) {
+		http.Error(w, "host_not_allowed", http.StatusForbidden)
+		return
+	}
+	if len(requestPolicy.AllowedRepos) > 0 && !contains(requestPolicy.AllowedRepos, req.RepoKey()) {
+		http.Error(w, "repository_not_allowed", http.StatusForbidden)
+		return
+	}
+
+	if requestPolicy.Source == "host_mirror" {
+		if mirrorPath, ok := h.resolveMirror(req); ok {
+			h.serveLocalUploadPack(r.Context(), w, r, req, mirrorPath)
+			return
+		}
+	}
+	h.proxyUpstream(w, r, req)
+}
+
+func (h *gatewayHandler) resolveMirror(req gatewayRequest) (string, bool) {
+	if h.mirrorRoot == "" {
+		return "", false
+	}
+	path := filepath.Join(h.mirrorRoot, req.Host, req.Owner, req.Repo+".git")
+	st, err := os.Stat(path)
+	if err != nil || !st.IsDir() {
+		return "", false
+	}
+	return path, true
+}
+
+func (h *gatewayHandler) serveLocalUploadPack(ctx context.Context, w http.ResponseWriter, r *http.Request, req gatewayRequest, repoPath string) {
+	switch req.Op {
+	case "info/refs":
+		w.Header().Set("Content-Type", "application/x-git-upload-pack-advertisement")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, pktLine("# service=git-upload-pack\n"))
+		_, _ = io.WriteString(w, "0000")
+
+		cmd := exec.CommandContext(ctx, "git", "upload-pack", "--stateless-rpc", "--advertise-refs", repoPath)
+		cmd.Stdout = w
+		if err := cmd.Run(); err != nil {
+			return
+		}
+	case "git-upload-pack":
+		cmd := exec.CommandContext(ctx, "git", "upload-pack", "--stateless-rpc", repoPath)
+		cmd.Stdin = r.Body
+		w.Header().Set("Content-Type", "application/x-git-upload-pack-result")
+		w.WriteHeader(http.StatusOK)
+		cmd.Stdout = w
+		if err := cmd.Run(); err != nil {
+			return
+		}
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (h *gatewayHandler) proxyUpstream(w http.ResponseWriter, r *http.Request, req gatewayRequest) {
+	upstream := fmt.Sprintf("%s://%s/%s/%s.git/%s", h.upstreamScheme, req.Host, req.Owner, req.Repo, req.Op)
+	upstreamURL, err := url.Parse(upstream)
+	if err != nil {
+		http.Error(w, "runtime_launch_failed", http.StatusBadGateway)
+		return
+	}
+	upstreamURL.RawQuery = r.URL.RawQuery
+
+	upstreamReq, err := http.NewRequestWithContext(r.Context(), r.Method, upstreamURL.String(), r.Body)
+	if err != nil {
+		http.Error(w, "runtime_launch_failed", http.StatusBadGateway)
+		return
+	}
+	copyProxyHeaders(upstreamReq.Header, r.Header)
+
+	resp, err := h.client.Do(upstreamReq)
+	if err != nil {
+		http.Error(w, "runtime_launch_failed", http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	for key, values := range resp.Header {
+		for _, value := range values {
+			w.Header().Add(key, value)
+		}
+	}
+	w.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(w, resp.Body)
+}
+
+func copyProxyHeaders(dst, src http.Header) {
+	for _, key := range []string{"Accept", "Content-Type", "Content-Encoding", "Git-Protocol", "Authorization", "User-Agent"} {
+		values := src.Values(key)
+		for _, value := range values {
+			dst.Add(key, value)
+		}
+	}
+}
+
+type gatewayRequest struct {
+	Scope string
+	Host  string
+	Owner string
+	Repo  string
+	Op    string
+}
+
+func (r gatewayRequest) RepoKey() string {
+	return r.Owner + "/" + r.Repo
+}
+
+func parseGatewayPath(path string) (gatewayRequest, bool) {
+	trimmed := strings.Trim(strings.TrimSpace(path), "/")
+	if trimmed == "" {
+		return gatewayRequest{}, false
+	}
+	parts := strings.Split(trimmed, "/")
+	if len(parts) < 5 || len(parts) > 7 {
+		return gatewayRequest{}, false
+	}
+	if parts[0] != "git" {
+		return gatewayRequest{}, false
+	}
+
+	scope := ""
+	hostIdx := 1
+	ownerIdx := 2
+	repoIdx := 3
+	opStartIdx := 4
+
+	if len(parts) == 6 && !strings.HasSuffix(strings.TrimSpace(parts[3]), ".git") {
+		scope = strings.TrimSpace(parts[1])
+		hostIdx = 2
+		ownerIdx = 3
+		repoIdx = 4
+		opStartIdx = 5
+	}
+	if len(parts) == 7 {
+		scope = strings.TrimSpace(parts[1])
+		hostIdx = 2
+		ownerIdx = 3
+		repoIdx = 4
+		opStartIdx = 5
+	}
+	if scope != "" {
+		scope = strings.TrimSpace(scope)
+		if scope == "" {
+			return gatewayRequest{}, false
+		}
+	}
+
+	repoWithSuffix := strings.TrimSpace(parts[repoIdx])
+	if !strings.HasSuffix(repoWithSuffix, ".git") {
+		return gatewayRequest{}, false
+	}
+	repo := strings.TrimSuffix(repoWithSuffix, ".git")
+	if repo == "" {
+		return gatewayRequest{}, false
+	}
+	op := strings.TrimSpace(parts[opStartIdx])
+	if opStartIdx+1 < len(parts) {
+		op = strings.TrimSpace(parts[opStartIdx]) + "/" + strings.TrimSpace(parts[opStartIdx+1])
+	}
+	if op != "info/refs" && op != "git-upload-pack" {
+		return gatewayRequest{}, false
+	}
+
+	return gatewayRequest{
+		Scope: scope,
+		Host:  strings.ToLower(strings.TrimSpace(parts[hostIdx])),
+		Owner: strings.ToLower(strings.TrimSpace(parts[ownerIdx])),
+		Repo:  strings.ToLower(strings.TrimSpace(repo)),
+		Op:    op,
+	}, true
+}
+
+func contains(values []string, needle string) bool {
+	needle = strings.ToLower(strings.TrimSpace(needle))
+	for _, value := range values {
+		if strings.ToLower(strings.TrimSpace(value)) == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func pktLine(s string) string {
+	return fmt.Sprintf("%04x%s", len(s)+4, s)
+}

--- a/internal/gitgateway/server_test.go
+++ b/internal/gitgateway/server_test.go
@@ -1,0 +1,181 @@
+package gitgateway
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/buildkite/cleanroom/internal/policy"
+)
+
+func TestCopyProxyHeadersIncludesContentEncoding(t *testing.T) {
+	t.Parallel()
+
+	src := http.Header{}
+	src.Set("Content-Encoding", "gzip")
+	dst := http.Header{}
+	copyProxyHeaders(dst, src)
+
+	if got, want := dst.Get("Content-Encoding"), "gzip"; got != want {
+		t.Fatalf("unexpected content-encoding: got %q want %q", got, want)
+	}
+}
+
+func TestParseGatewayPath(t *testing.T) {
+	t.Parallel()
+
+	req, ok := parseGatewayPath("/git/github.com/org/repo.git/git-upload-pack")
+	if !ok {
+		t.Fatal("expected path to parse")
+	}
+	if got, want := req.RepoKey(), "org/repo"; got != want {
+		t.Fatalf("unexpected repo key: got %q want %q", got, want)
+	}
+
+	scoped, ok := parseGatewayPath("/git/scope-abc/github.com/org/repo.git/git-upload-pack")
+	if !ok {
+		t.Fatal("expected scoped path to parse")
+	}
+	if got, want := scoped.Scope, "scope-abc"; got != want {
+		t.Fatalf("unexpected scope: got %q want %q", got, want)
+	}
+}
+
+func TestGatewayRejectsDisallowedRepo(t *testing.T) {
+	t.Parallel()
+
+	h := newHandler(&policy.GitPolicy{
+		Enabled:      true,
+		Source:       "upstream",
+		AllowedHosts: []string{"github.com"},
+		AllowedRepos: []string{"org/allowed"},
+	}, nil, "", "https", &http.Client{Timeout: 3 * time.Second})
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/git/github.com/org/repo.git/info/refs?service=git-upload-pack", nil)
+	h.ServeHTTP(rr, req)
+
+	if got, want := rr.Code, http.StatusForbidden; got != want {
+		t.Fatalf("unexpected status: got %d want %d", got, want)
+	}
+	if body := rr.Body.String(); !strings.Contains(body, "repository_not_allowed") {
+		t.Fatalf("expected repository_not_allowed body, got %q", body)
+	}
+}
+
+func TestGatewayProxiesUpstreamInUpstreamMode(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/org/repo.git/info/refs"; got != want {
+			t.Fatalf("unexpected upstream path: got %q want %q", got, want)
+		}
+		if got, want := r.URL.Query().Get("service"), "git-upload-pack"; got != want {
+			t.Fatalf("unexpected upstream service query: got %q want %q", got, want)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer upstream.Close()
+
+	host := strings.TrimPrefix(upstream.URL, "http://")
+	h := newHandler(&policy.GitPolicy{
+		Enabled:      true,
+		Source:       "upstream",
+		AllowedHosts: []string{host},
+	}, nil, "", "http", &http.Client{Timeout: 3 * time.Second})
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/git/"+host+"/org/repo.git/info/refs?service=git-upload-pack", nil)
+	h.ServeHTTP(rr, req)
+
+	if got, want := rr.Code, http.StatusOK; got != want {
+		t.Fatalf("unexpected status: got %d want %d", got, want)
+	}
+	if got, want := strings.TrimSpace(rr.Body.String()), "ok"; got != want {
+		t.Fatalf("unexpected response body: got %q want %q", got, want)
+	}
+}
+
+func TestStartRequiresHostWhenEnabled(t *testing.T) {
+	t.Parallel()
+
+	_, err := Start(context.Background(), Config{GitPolicy: &policy.GitPolicy{Enabled: true}})
+	if err == nil {
+		t.Fatal("expected Start to fail when listen host is missing")
+	}
+}
+
+func TestGatewayUsesLocalMirrorInHostMirrorMode(t *testing.T) {
+	t.Parallel()
+
+	mirrorRoot := t.TempDir()
+	repoPath := filepath.Join(mirrorRoot, "github.com", "org", "repo.git")
+	if err := os.MkdirAll(filepath.Dir(repoPath), 0o755); err != nil {
+		t.Fatalf("mkdir mirror parent: %v", err)
+	}
+	initCmd := exec.Command("git", "init", "--bare", repoPath)
+	if out, err := initCmd.CombinedOutput(); err != nil {
+		t.Fatalf("init bare mirror: %v\n%s", err, out)
+	}
+
+	h := newHandler(&policy.GitPolicy{
+		Enabled:      true,
+		Source:       "host_mirror",
+		AllowedHosts: []string{"github.com"},
+		AllowedRepos: []string{"org/repo"},
+	}, nil, mirrorRoot, "https", &http.Client{Timeout: 3 * time.Second})
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/git/github.com/org/repo.git/info/refs?service=git-upload-pack", nil)
+	h.ServeHTTP(rr, req)
+
+	if got, want := rr.Code, http.StatusOK; got != want {
+		t.Fatalf("unexpected status: got %d want %d", got, want)
+	}
+	if got := rr.Header().Get("Content-Type"); !strings.Contains(got, "application/x-git-upload-pack-advertisement") {
+		t.Fatalf("unexpected content type: %q", got)
+	}
+	if body := rr.Body.String(); !strings.Contains(body, "# service=git-upload-pack") {
+		t.Fatalf("expected upload-pack service header in body, got %q", body)
+	}
+}
+
+func TestScopedPolicyResolver(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "scoped-ok")
+	}))
+	defer upstream.Close()
+	host := strings.TrimPrefix(upstream.URL, "http://")
+
+	h := newHandler(nil, func(scope string) (*policy.GitPolicy, bool) {
+		if scope != "scope-ok" {
+			return nil, false
+		}
+		return &policy.GitPolicy{Enabled: true, Source: "upstream", AllowedHosts: []string{host}}, true
+	}, "", "http", &http.Client{Timeout: 3 * time.Second})
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/git/scope-ok/"+host+"/org/repo.git/info/refs?service=git-upload-pack", nil)
+	h.ServeHTTP(rr, req)
+	if got, want := rr.Code, http.StatusOK; got != want {
+		t.Fatalf("unexpected status: got %d want %d", got, want)
+	}
+
+	rrMissing := httptest.NewRecorder()
+	reqMissing := httptest.NewRequest(http.MethodGet, "/git/scope-missing/"+host+"/org/repo.git/info/refs?service=git-upload-pack", nil)
+	h.ServeHTTP(rrMissing, reqMissing)
+	if got, want := rrMissing.Code, http.StatusForbidden; got != want {
+		t.Fatalf("unexpected status for missing scope: got %d want %d", got, want)
+	}
+}

--- a/proto/cleanroom/v1/control.proto
+++ b/proto/cleanroom/v1/control.proto
@@ -46,10 +46,18 @@ message PolicyAllowRule {
   repeated int32 ports = 2;
 }
 
+message PolicyGit {
+  bool enabled = 1;
+  string source = 2;
+  repeated string allowed_hosts = 3;
+  repeated string allowed_repos = 4;
+}
+
 message Policy {
   int32 version = 1;
   string image_ref = 2;
   string image_digest = 3;
+  PolicyGit git = 7;
   string network_default = 4;
   repeated PolicyAllowRule allow = 5;
   string hash = 6;


### PR DESCRIPTION
## Summary
This PR adds a minimal Git smart-HTTP gateway for Firecracker sandboxes so users can run normal Git commands (`clone`, `fetch`) while Cleanroom enforces policy.

### What it does
- Adds `sandbox.git` policy controls:
  - `enabled`
  - `source` (`upstream` or `host_mirror`)
  - `allowed_hosts`
  - `allowed_repos`
- Rewrites Git HTTPS remotes inside the sandbox via scoped `insteadOf` config so users keep standard commands.
- Routes rewritten traffic to a host-side gateway.
- Enforces allow/deny decisions in the gateway by host/repo and returns explicit deny reasons.
- Supports two source modes:
  - `upstream`: proxy to origin
  - `host_mirror`: use local mirror when present, fallback to upstream

### Runtime design (minimal)
- Shared host gateway process.
- Per-sandbox scope token registration in memory.
- Request path shape: `/git/<scope>/<host>/<owner>/<repo>.git/<op>`.
- Scope token selects the sandbox’s Git policy; host/repo are then checked against that policy.

## Why this is minimal
- No control-plane API expansion beyond policy/proto fields needed for Git policy.
- No guest-side relay service.
- No vsock-specific gateway transport layer.
- No extra docs/planning artifacts included in this PR.

## Files in scope
- Policy/proto wiring:
  - `proto/cleanroom/v1/control.proto`
  - `internal/gen/cleanroom/v1/control.pb.go`
  - `internal/policy/policy.go`
- Firecracker runtime wiring:
  - `internal/backend/firecracker/backend.go`
- Gateway implementation:
  - `internal/gitgateway/*`

## Validation
- `go test ./...`
- Manual checks:
  - allowlisted clone succeeds
  - disallowed repo returns `repository_not_allowed` with HTTP 403
