### PR TITLE
feat: host gateway with TAP source-IP identity

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -92,7 +92,7 @@ Use a single root-owned helper binary and only grant sudo access to that helper:
 Install helper from this repository:
 
 ```bash
-sudo install -o root -g root -m 0750 scripts/cleanroom-root-helper.sh /usr/local/sbin/cleanroom-root-helper
+sudo install -o root -g root -m 0755 scripts/cleanroom-root-helper.sh /usr/local/sbin/cleanroom-root-helper
 ```
 
 ```sudoers

--- a/docs/plans/host-gateway.md
+++ b/docs/plans/host-gateway.md
@@ -1,0 +1,301 @@
+# Host Gateway Implementation Plan
+
+**Spec reference:** SPEC.md §6.2
+**Status:** Proposed
+
+## Summary
+
+A single shared host-side HTTP gateway that mediates sandbox access to external services (git, package registries, secrets, metadata). Sandbox identity is derived from TAP network source IPs — no bearer tokens, no per-sandbox listeners.
+
+## Background
+
+### Why not vsock?
+
+The guest exec agent uses vsock in the guest-listen/host-dial direction, which works because Firecracker mediates it through its own UDS path. The gateway requires the reverse — guest dials host — which needs a host-side `AF_VSOCK` listener.
+
+In nested virtualisation (Firecracker inside EC2), host-side vsock binds on `CID=2` (host) and `CID=0` (any) fail with `cannot assign requested address`. The outer hypervisor owns the vsock device and CID namespace, and the `vhost_vsock` driver cannot serve both roles simultaneously.
+
+TAP-network TCP has no such constraint — it is managed entirely within the host kernel's networking stack.
+
+### Why not per-sandbox listeners or scope tokens?
+
+- **Per-sandbox listeners** create O(sandboxes × services) file descriptors and lifecycle management overhead. At 1000 sandboxes this becomes a resource and orchestration problem.
+- **Scope tokens** (the prior `git-gateway-mvp-plan` branch approach) rely on bearer token secrecy for isolation. Token exfiltration via logs, error messages, or `ps` output could grant cross-sandbox access. Source-IP identity eliminates this class of vulnerability entirely.
+
+### Why source-IP identity works
+
+Each sandbox already gets a unique TAP device and guest IP (`10.x.y.2` derived from run ID). The host-side iptables rules prevent cross-TAP traffic. With anti-spoof rules added, the guest IP becomes a hard identity — even a root-privileged guest cannot spoof another sandbox's source IP because traffic is constrained to its own TAP interface.
+
+## Architecture
+
+```
+sandbox A (10.1.1.2)                sandbox B (10.2.2.2)
+       |                                   |
+    [tap-A]                             [tap-B]
+       |                                   |
+       +------- host gateway :8170 --------+
+                      |
+            lookup source IP
+           in sandbox registry
+                      |
+              enforce policy A or B
+                      |
+                route by path
+               /      |      \
+            /git/  /registry/  /secrets/
+              |
+         proxy upstream
+       (inject host-side credentials)
+```
+
+The gateway listens on a single port. Every connection's source IP is mapped to a sandbox and its `CompiledPolicy`. Service routing is by path prefix.
+
+## Existing code touchpoints
+
+| File | Change |
+|---|---|
+| `internal/backend/firecracker/backend.go` | `setupHostNetwork`: add anti-spoof INPUT rules. `ProvisionSandbox`/`TerminateSandbox`: register/release sandbox in gateway. `executeInSandbox`: inject gateway env vars into exec requests. |
+| `internal/backend/backend.go` | Add gateway registry interface to adapter or provision request. |
+| `internal/controlservice/service.go` | Own the gateway lifecycle — start lazily, pass registry to backend adapter. |
+| `internal/policy/policy.go` | No changes needed. `CompiledPolicy` and `AllowRule` already carry what the gateway needs. |
+| `cmd/cleanroom-guest-agent/main.go` | No changes needed. Gateway env vars are injected per-exec via the vsockexec protocol. |
+
+## Implementation slices
+
+### Slice 1: Gateway skeleton and identity registry
+
+**New package: `internal/gateway`**
+
+**`registry.go`** — Thread-safe sandbox scope registry.
+
+```go
+type SandboxScope struct {
+    SandboxID string
+    Policy    *policy.CompiledPolicy
+}
+
+type Registry struct { ... }
+
+func (r *Registry) Register(guestIP, sandboxID string, p *policy.CompiledPolicy)
+func (r *Registry) Release(guestIP string)
+func (r *Registry) Lookup(guestIP string) (*SandboxScope, bool)
+```
+
+Keyed by guest IP string. Populated during `ProvisionSandbox`, released during `TerminateSandbox`.
+
+**`server.go`** — HTTP server with source-IP identity middleware.
+
+- Listens on `0.0.0.0:8170` (configurable via runtime config).
+- Middleware: extract source IP from `http.Request.RemoteAddr` (strip port, handle IPv6-mapped v4), call `Registry.Lookup()`, inject `*SandboxScope` into request context. Return 403 if not found.
+- Path router mounts service handlers at `/git/`, `/registry/`, `/secrets/`, `/meta/`.
+- Initial handlers: `/git/` wired in slice 3; others return 501.
+
+**`path.go`** — Request path canonicalisation.
+
+- Reject paths containing `..`, `//`, null bytes, or percent-encoded traversal sequences before routing.
+- Normalise path before prefix matching.
+
+**Wiring:**
+
+- Control service creates `*gateway.Registry` and `*gateway.Server` at startup.
+- Pass registry reference to the firecracker adapter.
+- Adapter calls `Register` / `Release` during sandbox lifecycle.
+
+**Tests:**
+
+- Registry: concurrent register/release/lookup, duplicate IP handling, release of unknown IP.
+- Middleware: source IP extraction from various `RemoteAddr` formats (`10.1.1.2:43210`, `[::ffff:10.1.1.2]:43210`), 403 for unregistered IPs.
+- Path canonicalisation: traversal rejection, normalisation.
+
+**Definition of done:** Gateway process starts, accepts HTTP connections, resolves sandbox identity from source IP, returns 403 for unknown callers and 501 for unimplemented service paths.
+
+---
+
+### Slice 2: Anti-spoof and INPUT rules
+
+**Modify `setupHostNetwork` in `internal/backend/firecracker/backend.go`.**
+
+Add after TAP creation, before existing FORWARD rules:
+
+```
+# Anti-spoof: drop anything from this TAP not sourced from the assigned guest IP
+iptables -A INPUT -i tapX ! -s GUEST_IP -j DROP
+
+# Allow guest to reach gateway port
+iptables -A INPUT -i tapX -s GUEST_IP -p tcp --dport 8170 -j ACCEPT
+
+# Drop all other host INPUT from this TAP
+iptables -A INPUT -i tapX -j DROP
+```
+
+Rule ordering matters — the ACCEPT for the gateway port must come before the catch-all DROP. Add corresponding cleanup entries in reverse order.
+
+**Additional hardening:**
+
+- Disable IPv6 on TAP: `sysctl -w net.ipv6.conf.tapX.disable_ipv6=1`
+- Verify gateway port is not reachable from non-TAP interfaces (document as operator responsibility for v1; consider a global INPUT rule in `cleanroom serve` startup).
+
+**Tests:**
+
+- Unit test rule generation order and cleanup commands.
+- Integration test (on Linux with iptables): verify gateway port reachable from sandbox guest IP, unreachable from other source IPs.
+
+**Definition of done:** Anti-spoof and gateway INPUT rules are installed per sandbox and cleaned up on termination. iptables rule ordering is tested.
+
+---
+
+### Slice 3: Git smart-HTTP proxy
+
+**`internal/gateway/git.go`** — Handler for `/git/<upstream-host>/<owner>/<repo>[.git]/...`
+
+**Request flow:**
+
+1. Extract upstream host from first path segment after `/git/`.
+2. Validate upstream host against sandbox's `CompiledPolicy.Allow` (must allow the host on port 443).
+3. Proxy two git smart-HTTP endpoints:
+   - `GET /git/<host>/<owner>/<repo>.git/info/refs?service=git-upload-pack`
+   - `POST /git/<host>/<owner>/<repo>.git/git-upload-pack`
+4. Deny `git-receive-pack` (push) — sandboxes are read-only.
+5. Inject `Authorization` header from credential provider (slice 4) on upstream request.
+6. Stream response back to guest.
+
+**Upstream transport:**
+
+- Per-sandbox `http.Transport` (or transport keyed by sandbox ID). No connection pool sharing across sandbox identities.
+- Timeout on upstream requests (30s default, configurable).
+
+**Audit events:**
+
+- Emit structured log per request: `sandbox_id`, `upstream_host`, `repo_path`, `action` (allow/deny), `reason_code`.
+- Deny reasons: `host_not_allowed` (upstream host not in policy), `method_not_allowed` (push attempt).
+
+**Guest-side wiring (in `executeInSandbox`):**
+
+Inject git URL rewrite config via environment variables in the exec request:
+
+```
+GIT_CONFIG_COUNT=N
+GIT_CONFIG_KEY_0=url.http://10.x.y.1:8170/git/github.com/.insteadOf
+GIT_CONFIG_VALUE_0=https://github.com/
+```
+
+One pair per allowed git host in the sandbox's policy. The host IP is the sandbox's own TAP host-side IP, so it is unique per sandbox and routed through the sandbox's own TAP.
+
+**Tests:**
+
+- Unit: path parsing (`/git/github.com/org/repo.git/info/refs`), host extraction, policy validation.
+- Unit: `git-receive-pack` rejection.
+- Unit: path traversal (`/git/../secrets/`) blocked by slice 1 canonicalisation.
+- Integration: end-to-end `git clone` through the gateway against a test git server.
+
+**Definition of done:** A sandbox can `git clone https://github.com/org/repo.git` and the request is transparently proxied through the gateway with policy enforcement and upstream credential injection.
+
+---
+
+### Slice 4: Credential provider
+
+**`internal/gateway/credentials.go`** — Interface for resolving upstream credentials.
+
+```go
+type CredentialProvider interface {
+    Resolve(ctx context.Context, upstreamHost string) (token string, err error)
+}
+```
+
+**Initial implementation: `EnvCredentialProvider`**
+
+- Reads from environment variables at gateway startup: `CLEANROOM_GITHUB_TOKEN`, `CLEANROOM_GITLAB_TOKEN`, etc.
+- Maps upstream host to credential: `github.com` → `CLEANROOM_GITHUB_TOKEN`.
+- Returns empty string (no auth) if no credential is configured for the host.
+
+**Future: `GitHubAppCredentialProvider`**
+
+- Mints short-lived GitHub App installation tokens per upstream request.
+- Caches tokens by installation ID with TTL.
+- Out of scope for initial implementation but the interface should accommodate it.
+
+**Security invariants:**
+
+- Credential values never appear in audit logs, error messages, or gateway responses.
+- Credentials are resolved per-request, never stored in the sandbox registry.
+
+**Tests:**
+
+- Env provider: resolution by host, missing credential returns empty, env variable not leaked in errors.
+
+**Definition of done:** Git proxy injects upstream `Authorization: Bearer <token>` headers for configured hosts.
+
+---
+
+### Slice 5: Registry proxy (stub)
+
+**`internal/gateway/registry.go`** — Handler for `/registry/...`
+
+Initial implementation is a passthrough HTTP proxy with policy enforcement:
+
+1. Extract upstream registry host from request path.
+2. Validate against sandbox's compiled policy registry allowlist.
+3. Proxy request upstream, injecting credentials if configured.
+4. Return `registry_not_allowed` on deny.
+
+This is where content-cache integration can plug in later — the gateway either handles proxying directly or forwards to a content-cache instance for caching and lockfile enforcement.
+
+**Tests:**
+
+- Policy enforcement: allowed registry host proxied, disallowed host denied with correct reason code.
+
+**Definition of done:** Package manager requests routed through `/registry/` are policy-enforced and proxied upstream.
+
+---
+
+### Slice 6: Conformance tests
+
+Validate the security properties from SPEC.md §6.2:
+
+| Test | Validates |
+|---|---|
+| Unregistered source IP returns 403 | Transport identity is required |
+| Sandbox A cannot access sandbox B's policy scope | Cross-sandbox isolation |
+| Git clone to policy-allowed host succeeds | Positive path works |
+| Git clone to non-allowed host returns `host_not_allowed` | Policy enforcement |
+| Git push (`receive-pack`) is rejected | Read-only enforcement |
+| `/git/../../secrets/` returns 400 | Path traversal hardening |
+| Gateway unreachable from non-TAP source | INPUT rules correct |
+| Anti-spoof rules installed and cleaned up | Lifecycle correctness |
+| Audit events contain sandbox ID and reason code | Attribution works |
+| Upstream credentials not in audit logs or responses | Secret isolation |
+
+**Definition of done:** All conformance tests pass on Linux with Firecracker backend.
+
+## Sequencing and dependencies
+
+```
+Slice 1 (skeleton + registry)
+    |
+    +---> Slice 2 (anti-spoof + INPUT rules)
+    |         |
+    |         +---> Slice 6 (conformance tests)
+    |
+    +---> Slice 3 (git proxy)
+              |
+              +---> Slice 4 (credential provider)
+              |
+              +---> Slice 5 (registry proxy)
+```
+
+Slices 1 + 2 land together as the foundation. Slices 3 + 4 can proceed in parallel with slice 5. Slice 6 runs after slices 1–3 are complete.
+
+| Slice | Effort | Notes |
+|---|---|---|
+| 1: Gateway skeleton + registry | S | New package, no external dependencies |
+| 2: Anti-spoof + INPUT rules | S | Additive change to existing `setupHostNetwork` |
+| 3: Git smart-HTTP proxy | M | Core feature, needs integration testing |
+| 4: Credential provider | S | Interface + env-based implementation |
+| 5: Registry proxy | M | Similar shape to git proxy |
+| 6: Conformance tests | S | Mostly wiring existing primitives |
+
+## Risks
+
+- **IP collision**: `hostGuestIPs` derives IPs from SHA-1 of run ID, using only 2 bytes. Two concurrent sandboxes could collide on the same `10.x.y.0/24`. The registry would reject the second registration. Mitigation: detect collision at registration time and fail sandbox creation with a clear error. Longer term: allocate from a managed pool instead of hashing.
+- **Gateway as bottleneck**: A single gateway process handles all sandbox traffic. At very high density, this could become a CPU or connection bottleneck. Mitigation: monitor request latency and concurrency; scale with `SO_REUSEPORT` workers if needed.
+- **iptables rule accumulation**: At 1000 sandboxes, the INPUT and FORWARD chains become long. Mitigation: migrate to nftables with per-sandbox named chains or ipsets for O(1) lookup.

--- a/internal/backend/firecracker/gateway_test.go
+++ b/internal/backend/firecracker/gateway_test.go
@@ -1,0 +1,70 @@
+package firecracker
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/policy"
+)
+
+func TestGatewayEnvVarsEmptyWhenNoPolicyHosts(t *testing.T) {
+	t.Parallel()
+
+	instance := &sandboxInstance{
+		HostIP: "10.1.1.1",
+		Policy: &policy.CompiledPolicy{
+			Version:        1,
+			NetworkDefault: "deny",
+			Allow:          []policy.AllowRule{{Host: "example.com", Ports: []int{80}}},
+		},
+	}
+	env := gatewayEnvVars(instance)
+	if len(env) != 0 {
+		t.Fatalf("expected no env vars for host without port 443, got %v", env)
+	}
+}
+
+func TestGatewayEnvVarsGeneratesGitConfig(t *testing.T) {
+	t.Parallel()
+
+	instance := &sandboxInstance{
+		HostIP: "10.1.1.1",
+		Policy: &policy.CompiledPolicy{
+			Version:        1,
+			NetworkDefault: "deny",
+			Allow: []policy.AllowRule{
+				{Host: "github.com", Ports: []int{443}},
+				{Host: "gitlab.com", Ports: []int{443}},
+			},
+		},
+	}
+
+	env := gatewayEnvVars(instance)
+	if len(env) != 5 {
+		t.Fatalf("expected 5 env vars (1 count + 2*2 key/value), got %d: %v", len(env), env)
+	}
+
+	if env[0] != "GIT_CONFIG_COUNT=2" {
+		t.Fatalf("expected GIT_CONFIG_COUNT=2, got %s", env[0])
+	}
+
+	if !strings.Contains(env[1], "url.http://10.1.1.1:8170/git/github.com/.insteadOf") {
+		t.Fatalf("expected github.com insteadOf key, got %s", env[1])
+	}
+	if env[2] != "GIT_CONFIG_VALUE_0=https://github.com/" {
+		t.Fatalf("expected github.com value, got %s", env[2])
+	}
+	if !strings.Contains(env[3], "url.http://10.1.1.1:8170/git/gitlab.com/.insteadOf") {
+		t.Fatalf("expected gitlab.com insteadOf key, got %s", env[3])
+	}
+}
+
+func TestGatewayEnvVarsNilPolicy(t *testing.T) {
+	t.Parallel()
+
+	instance := &sandboxInstance{HostIP: "10.1.1.1"}
+	env := gatewayEnvVars(instance)
+	if env != nil {
+		t.Fatalf("expected nil for nil policy, got %v", env)
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -889,7 +889,9 @@ func (s *ServeCommand) Run(ctx *runtimeContext) error {
 	runCtx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 	runErr := controlserver.Serve(runCtx, ep, server.Handler(), logger)
-	_ = gwServer.Stop(context.Background())
+	gwStopCtx, gwStopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer gwStopCancel()
+	_ = gwServer.Stop(gwStopCtx)
 	return runErr
 }
 

--- a/internal/gateway/conformance_test.go
+++ b/internal/gateway/conformance_test.go
@@ -1,0 +1,207 @@
+package gateway
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/charmbracelet/log"
+)
+
+// --- Cross-sandbox isolation ---
+
+func TestCrossSandboxIsolation(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+
+	policyA := &policy.CompiledPolicy{
+		Version:        1,
+		NetworkDefault: "deny",
+		Allow:          []policy.AllowRule{{Host: "github.com", Ports: []int{443}}},
+	}
+	policyB := &policy.CompiledPolicy{
+		Version:        1,
+		NetworkDefault: "deny",
+		Allow:          []policy.AllowRule{{Host: "gitlab.com", Ports: []int{443}}},
+	}
+
+	if err := reg.Register("10.0.0.1", "sandbox-A", policyA); err != nil {
+		t.Fatalf("register A: %v", err)
+	}
+	if err := reg.Register("10.0.0.2", "sandbox-B", policyB); err != nil {
+		t.Fatalf("register B: %v", err)
+	}
+
+	// Registry-level: each IP returns its own scope.
+	scopeA, ok := reg.Lookup("10.0.0.1")
+	if !ok || scopeA.SandboxID != "sandbox-A" {
+		t.Fatalf("lookup 10.0.0.1: expected sandbox-A, got %+v", scopeA)
+	}
+	if scopeA.Policy != policyA {
+		t.Fatal("sandbox-A policy mismatch")
+	}
+
+	scopeB, ok := reg.Lookup("10.0.0.2")
+	if !ok || scopeB.SandboxID != "sandbox-B" {
+		t.Fatalf("lookup 10.0.0.2: expected sandbox-B, got %+v", scopeB)
+	}
+	if scopeB.Policy != policyB {
+		t.Fatal("sandbox-B policy mismatch")
+	}
+
+	// HTTP-level: identity middleware injects the correct scope per source IP.
+	srv := &Server{registry: reg}
+	var captured *SandboxScope
+	inner := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		captured, _ = ScopeFromContext(r.Context())
+	})
+	handler := srv.identityMiddleware(inner)
+
+	// Request from sandbox A's IP.
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.RemoteAddr = "10.0.0.1:50000"
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+	if captured == nil || captured.SandboxID != "sandbox-A" {
+		t.Fatalf("request from 10.0.0.1: expected sandbox-A scope, got %+v", captured)
+	}
+
+	// Request from sandbox B's IP.
+	req = httptest.NewRequest("GET", "/test", nil)
+	req.RemoteAddr = "10.0.0.2:50001"
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+	if captured == nil || captured.SandboxID != "sandbox-B" {
+		t.Fatalf("request from 10.0.0.2: expected sandbox-B scope, got %+v", captured)
+	}
+
+	// Request from unknown IP gets no scope (403).
+	req = httptest.NewRequest("GET", "/test", nil)
+	req.RemoteAddr = "10.0.0.99:50002"
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("request from unregistered IP: expected 403, got %d", w.Code)
+	}
+}
+
+func TestCrossSandboxPolicyEnforcement(t *testing.T) {
+	t.Parallel()
+
+	// Sandbox A allows host-a.test, sandbox B allows host-b.test.
+	// Denied hosts get 403; allowed hosts pass policy but hit an unreachable
+	// upstream, so they get 502 (bad gateway). Both outcomes confirm the
+	// correct policy was applied per source IP.
+	reg := NewRegistry()
+	if err := reg.Register("10.0.0.1", "sandbox-A", &policy.CompiledPolicy{
+		Version: 1, NetworkDefault: "deny",
+		Allow: []policy.AllowRule{{Host: "host-a.test", Ports: []int{443}}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := reg.Register("10.0.0.2", "sandbox-B", &policy.CompiledPolicy{
+		Version: 1, NetworkDefault: "deny",
+		Allow: []policy.AllowRule{{Host: "host-b.test", Ports: []int{443}}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := NewServer(ServerConfig{
+		ListenAddr: "127.0.0.1:0",
+		Registry:   reg,
+	})
+
+	tests := []struct {
+		name       string
+		remoteAddr string
+		path       string
+		wantCode   int
+	}{
+		{"A accesses host-a (allowed)", "10.0.0.1:50000", "/git/host-a.test/org/repo.git/info/refs?service=git-upload-pack", http.StatusBadGateway},
+		{"A accesses host-b (denied)", "10.0.0.1:50000", "/git/host-b.test/org/repo.git/info/refs?service=git-upload-pack", http.StatusForbidden},
+		{"B accesses host-b (allowed)", "10.0.0.2:50001", "/git/host-b.test/org/repo.git/info/refs?service=git-upload-pack", http.StatusBadGateway},
+		{"B accesses host-a (denied)", "10.0.0.2:50001", "/git/host-a.test/org/repo.git/info/refs?service=git-upload-pack", http.StatusForbidden},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", tt.path, nil)
+			req.RemoteAddr = tt.remoteAddr
+			w := httptest.NewRecorder()
+			srv.httpServer.Handler.ServeHTTP(w, req)
+			if w.Code != tt.wantCode {
+				t.Fatalf("expected %d, got %d (body: %s)", tt.wantCode, w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+// --- Credential leak test ---
+
+func TestCredentialNotLeakedToClient(t *testing.T) {
+	t.Parallel()
+
+	const secretToken = "ghp_SUPERSECRET_TOKEN_12345"
+
+	// Upstream server: verifies it receives the token, responds with benign body.
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if auth := r.Header.Get("Authorization"); auth != "Bearer "+secretToken {
+			t.Errorf("upstream: expected Authorization header with token, got %q", auth)
+		}
+		w.Header().Set("Content-Type", "application/x-git-upload-pack-advertisement")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("refs-response"))
+	}))
+	defer upstream.Close()
+
+	upstreamHost := strings.TrimPrefix(upstream.URL, "https://")
+	scope := &SandboxScope{
+		SandboxID: "sandbox-leak-test",
+		GuestIP:   "10.1.1.2",
+		Policy: &policy.CompiledPolicy{
+			Version: 1, NetworkDefault: "deny",
+			Allow: []policy.AllowRule{{Host: upstreamHost, Ports: []int{443}}},
+		},
+	}
+
+	creds := &staticCredentialProvider{tokens: map[string]string{upstreamHost: secretToken}}
+
+	// Capture log output.
+	var logBuf bytes.Buffer
+	logger := log.NewWithOptions(&logBuf, log.Options{})
+
+	h := newGitHandler(creds, logger)
+	h.client = upstream.Client()
+
+	req := httptest.NewRequest("GET", "/git/"+upstreamHost+"/org/repo.git/info/refs?service=git-upload-pack", nil)
+	req = withScope(req, scope)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+
+	// Response body must not contain the token.
+	body, _ := io.ReadAll(w.Body)
+	if strings.Contains(string(body), secretToken) {
+		t.Fatal("credential token leaked in response body")
+	}
+
+	// Response headers must not contain the token.
+	for key, vals := range w.Header() {
+		for _, v := range vals {
+			if strings.Contains(v, secretToken) {
+				t.Fatalf("credential token leaked in response header %s: %s", key, v)
+			}
+		}
+	}
+
+	// Log output must not contain the token.
+	if strings.Contains(logBuf.String(), secretToken) {
+		t.Fatalf("credential token leaked in log output: %s", logBuf.String())
+	}
+}

--- a/internal/gateway/credentials.go
+++ b/internal/gateway/credentials.go
@@ -1,0 +1,45 @@
+package gateway
+
+import (
+	"context"
+	"os"
+	"strings"
+)
+
+// CredentialProvider resolves credentials for upstream hosts.
+type CredentialProvider interface {
+	Resolve(ctx context.Context, upstreamHost string) (token string, err error)
+}
+
+// EnvCredentialProvider reads credentials from environment variables at
+// construction time. It maps upstream hosts to env var names:
+//
+//	github.com -> CLEANROOM_GITHUB_TOKEN
+//	gitlab.com -> CLEANROOM_GITLAB_TOKEN
+type EnvCredentialProvider struct {
+	hostTokens map[string]string
+}
+
+// NewEnvCredentialProvider creates a provider from the current environment.
+func NewEnvCredentialProvider() *EnvCredentialProvider {
+	p := &EnvCredentialProvider{
+		hostTokens: make(map[string]string),
+	}
+	hostEnvMap := map[string]string{
+		"github.com": "CLEANROOM_GITHUB_TOKEN",
+		"gitlab.com": "CLEANROOM_GITLAB_TOKEN",
+	}
+	for host, envVar := range hostEnvMap {
+		if v := strings.TrimSpace(os.Getenv(envVar)); v != "" {
+			p.hostTokens[host] = v
+		}
+	}
+	return p
+}
+
+// Resolve returns the credential for the given upstream host. Returns empty
+// string if no credential is configured.
+func (p *EnvCredentialProvider) Resolve(_ context.Context, upstreamHost string) (string, error) {
+	host := strings.ToLower(strings.TrimSpace(upstreamHost))
+	return p.hostTokens[host], nil
+}

--- a/internal/gateway/credentials_test.go
+++ b/internal/gateway/credentials_test.go
@@ -1,0 +1,59 @@
+package gateway
+
+import (
+	"context"
+	"testing"
+)
+
+func TestEnvCredentialProviderResolvesKnownHost(t *testing.T) {
+	t.Setenv("CLEANROOM_GITHUB_TOKEN", "ghp_test123")
+	p := NewEnvCredentialProvider()
+
+	token, err := p.Resolve(context.Background(), "github.com")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if token != "ghp_test123" {
+		t.Fatalf("expected ghp_test123, got %q", token)
+	}
+}
+
+func TestEnvCredentialProviderUnknownHostReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
+	p := NewEnvCredentialProvider()
+	token, err := p.Resolve(context.Background(), "unknown.example.com")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if token != "" {
+		t.Fatalf("expected empty token, got %q", token)
+	}
+}
+
+func TestEnvCredentialProviderMissingEnvReturnsEmpty(t *testing.T) {
+	// Explicitly unset to be sure
+	t.Setenv("CLEANROOM_GITHUB_TOKEN", "")
+	p := NewEnvCredentialProvider()
+
+	token, err := p.Resolve(context.Background(), "github.com")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if token != "" {
+		t.Fatalf("expected empty token, got %q", token)
+	}
+}
+
+func TestEnvCredentialProviderCaseInsensitive(t *testing.T) {
+	t.Setenv("CLEANROOM_GITHUB_TOKEN", "ghp_token")
+	p := NewEnvCredentialProvider()
+
+	token, err := p.Resolve(context.Background(), "GitHub.com")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if token != "ghp_token" {
+		t.Fatalf("expected ghp_token, got %q", token)
+	}
+}

--- a/internal/gateway/git.go
+++ b/internal/gateway/git.go
@@ -33,6 +33,9 @@ func newGitHandler(creds CredentialProvider, logger *log.Logger) *gitHandler {
 				TLSHandshakeTimeout:   10 * time.Second,
 				ResponseHeaderTimeout: defaultUpstreamTimeout,
 			},
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
 		},
 	}
 }

--- a/internal/gateway/git.go
+++ b/internal/gateway/git.go
@@ -1,0 +1,155 @@
+package gateway
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/log"
+)
+
+const (
+	gitUploadPackService   = "git-upload-pack"
+	gitReceivePackService  = "git-receive-pack"
+	defaultUpstreamTimeout = 30 * time.Second
+)
+
+type gitHandler struct {
+	credentials CredentialProvider
+	logger      *log.Logger
+	client      *http.Client
+}
+
+func newGitHandler(creds CredentialProvider, logger *log.Logger) *gitHandler {
+	return &gitHandler{
+		credentials: creds,
+		logger:      logger,
+		client:      &http.Client{Timeout: defaultUpstreamTimeout},
+	}
+}
+
+// ServeHTTP handles /git/<upstream-host>/<owner>/<repo>[.git]/...
+func (h *gitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	scope, ok := ScopeFromContext(r.Context())
+	if !ok {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+
+	// Parse: /git/<host>/<remainder>
+	trimmed := strings.TrimPrefix(r.URL.Path, "/git/")
+	if trimmed == "" || trimmed == r.URL.Path {
+		http.Error(w, "bad request: missing upstream host", http.StatusBadRequest)
+		return
+	}
+
+	slashIdx := strings.Index(trimmed, "/")
+	if slashIdx <= 0 {
+		http.Error(w, "bad request: missing repository path", http.StatusBadRequest)
+		return
+	}
+
+	upstreamHost := trimmed[:slashIdx]
+	repoPath := trimmed[slashIdx:] // includes leading /
+
+	if !scope.Policy.Allows(upstreamHost, 443) {
+		h.auditLog(scope.SandboxID, upstreamHost, repoPath, "deny", "host_not_allowed")
+		http.Error(w, "host_not_allowed", http.StatusForbidden)
+		return
+	}
+
+	if _, err := h.classifyRequest(r.Method, repoPath, r.URL.RawQuery); err != nil {
+		h.auditLog(scope.SandboxID, upstreamHost, repoPath, "deny", "method_not_allowed")
+		http.Error(w, err.Error(), http.StatusForbidden)
+		return
+	}
+
+	upstreamURL := fmt.Sprintf("https://%s%s", upstreamHost, repoPath)
+	if r.URL.RawQuery != "" {
+		upstreamURL += "?" + r.URL.RawQuery
+	}
+
+	upstreamReq, err := http.NewRequestWithContext(r.Context(), r.Method, upstreamURL, r.Body)
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	for _, key := range []string{"Content-Type", "Accept", "Git-Protocol"} {
+		if v := r.Header.Get(key); v != "" {
+			upstreamReq.Header.Set(key, v)
+		}
+	}
+
+	if h.credentials != nil {
+		token, err := h.credentials.Resolve(r.Context(), upstreamHost)
+		if err != nil {
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		if token != "" {
+			upstreamReq.Header.Set("Authorization", "Bearer "+token)
+		}
+	}
+
+	h.auditLog(scope.SandboxID, upstreamHost, repoPath, "allow", "proxied")
+
+	resp, err := h.client.Do(upstreamReq)
+	if err != nil {
+		http.Error(w, "upstream error", http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	for key, vals := range resp.Header {
+		for _, v := range vals {
+			w.Header().Add(key, v)
+		}
+	}
+	w.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(w, resp.Body)
+}
+
+// classifyRequest determines the git operation and rejects disallowed operations.
+func (h *gitHandler) classifyRequest(method, repoPath, query string) (string, error) {
+	switch {
+	case method == http.MethodGet && strings.HasSuffix(repoPath, "/info/refs"):
+		service := queryParam(query, "service")
+		if service == gitReceivePackService {
+			return "", fmt.Errorf("method_not_allowed: git push (receive-pack) is denied")
+		}
+		return "info-refs", nil
+	case method == http.MethodPost && strings.HasSuffix(repoPath, "/"+gitUploadPackService):
+		return "upload-pack", nil
+	case method == http.MethodPost && strings.HasSuffix(repoPath, "/"+gitReceivePackService):
+		return "", fmt.Errorf("method_not_allowed: git push (receive-pack) is denied")
+	default:
+		return "other", nil
+	}
+}
+
+func (h *gitHandler) auditLog(sandboxID, upstreamHost, repoPath, action, reason string) {
+	if h.logger == nil {
+		return
+	}
+	h.logger.Info("gateway git request",
+		"sandbox_id", sandboxID,
+		"service", "git",
+		"upstream_host", upstreamHost,
+		"repo_path", repoPath,
+		"action", action,
+		"reason_code", reason,
+	)
+}
+
+func queryParam(rawQuery, key string) string {
+	for _, part := range strings.Split(rawQuery, "&") {
+		k, v, _ := strings.Cut(part, "=")
+		if k == key {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/gateway/git.go
+++ b/internal/gateway/git.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -26,7 +27,13 @@ func newGitHandler(creds CredentialProvider, logger *log.Logger) *gitHandler {
 	return &gitHandler{
 		credentials: creds,
 		logger:      logger,
-		client:      &http.Client{Timeout: defaultUpstreamTimeout},
+		client: &http.Client{
+			Transport: &http.Transport{
+				DialContext:           (&net.Dialer{Timeout: defaultUpstreamTimeout}).DialContext,
+				TLSHandshakeTimeout:   10 * time.Second,
+				ResponseHeaderTimeout: defaultUpstreamTimeout,
+			},
+		},
 	}
 }
 

--- a/internal/gateway/git.go
+++ b/internal/gateway/git.go
@@ -126,7 +126,7 @@ func (h *gitHandler) classifyRequest(method, repoPath, query string) (string, er
 	case method == http.MethodPost && strings.HasSuffix(repoPath, "/"+gitReceivePackService):
 		return "", fmt.Errorf("method_not_allowed: git push (receive-pack) is denied")
 	default:
-		return "other", nil
+		return "", fmt.Errorf("method_not_allowed: only git smart-HTTP operations are permitted")
 	}
 }
 

--- a/internal/gateway/git_test.go
+++ b/internal/gateway/git_test.go
@@ -184,7 +184,7 @@ func TestClassifyRequest(t *testing.T) {
 		{"GET", "/org/repo.git/info/refs", "service=git-receive-pack", true, ""},
 		{"POST", "/org/repo.git/git-upload-pack", "", false, "upload-pack"},
 		{"POST", "/org/repo.git/git-receive-pack", "", true, ""},
-		{"GET", "/org/repo.git/HEAD", "", false, "other"},
+		{"GET", "/org/repo.git/HEAD", "", true, ""},
 	}
 	for _, tt := range tests {
 		act, err := h.classifyRequest(tt.method, tt.path, tt.query)

--- a/internal/gateway/git_test.go
+++ b/internal/gateway/git_test.go
@@ -1,0 +1,201 @@
+package gateway
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/policy"
+)
+
+type staticCredentialProvider struct {
+	tokens map[string]string
+}
+
+func (p *staticCredentialProvider) Resolve(_ context.Context, host string) (string, error) {
+	return p.tokens[host], nil
+}
+
+func gitTestScope() *SandboxScope {
+	return &SandboxScope{
+		SandboxID: "sandbox-test",
+		GuestIP:   "10.1.1.2",
+		Policy: &policy.CompiledPolicy{
+			Version:        1,
+			NetworkDefault: "deny",
+			Allow: []policy.AllowRule{
+				{Host: "github.com", Ports: []int{443}},
+			},
+		},
+	}
+}
+
+func withScope(r *http.Request, scope *SandboxScope) *http.Request {
+	ctx := context.WithValue(r.Context(), scopeContextKey, scope)
+	return r.WithContext(ctx)
+}
+
+func TestGitHandlerHostNotAllowed(t *testing.T) {
+	t.Parallel()
+
+	h := newGitHandler(nil, nil)
+	req := httptest.NewRequest("GET", "/git/evil.com/org/repo.git/info/refs?service=git-upload-pack", nil)
+	req = withScope(req, gitTestScope())
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", w.Code)
+	}
+	if body := w.Body.String(); !strings.Contains(body, "host_not_allowed") {
+		t.Fatalf("expected host_not_allowed in body, got %q", body)
+	}
+}
+
+func TestGitHandlerReceivePackDenied(t *testing.T) {
+	t.Parallel()
+
+	h := newGitHandler(nil, nil)
+
+	// GET info/refs with service=git-receive-pack
+	req := httptest.NewRequest("GET", "/git/github.com/org/repo.git/info/refs?service=git-receive-pack", nil)
+	req = withScope(req, gitTestScope())
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for receive-pack info/refs, got %d", w.Code)
+	}
+
+	// POST git-receive-pack
+	req = httptest.NewRequest("POST", "/git/github.com/org/repo.git/git-receive-pack", nil)
+	req = withScope(req, gitTestScope())
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for receive-pack POST, got %d", w.Code)
+	}
+}
+
+func TestGitHandlerMissingHost(t *testing.T) {
+	t.Parallel()
+
+	h := newGitHandler(nil, nil)
+
+	req := httptest.NewRequest("GET", "/git/", nil)
+	req = withScope(req, gitTestScope())
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestGitHandlerMissingRepoPath(t *testing.T) {
+	t.Parallel()
+
+	h := newGitHandler(nil, nil)
+
+	req := httptest.NewRequest("GET", "/git/github.com", nil)
+	req = withScope(req, gitTestScope())
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestGitHandlerProxiesUpstream(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if auth := r.Header.Get("Authorization"); auth != "Bearer test-token" {
+			t.Errorf("expected Bearer test-token, got %q", auth)
+		}
+		w.Header().Set("Content-Type", "application/x-git-upload-pack-advertisement")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("git-refs-data"))
+	}))
+	defer upstream.Close()
+
+	// Extract host:port from upstream URL
+	upstreamHost := strings.TrimPrefix(upstream.URL, "https://")
+
+	scope := &SandboxScope{
+		SandboxID: "sandbox-test",
+		GuestIP:   "10.1.1.2",
+		Policy: &policy.CompiledPolicy{
+			Version:        1,
+			NetworkDefault: "deny",
+			Allow:          []policy.AllowRule{{Host: upstreamHost, Ports: []int{443}}},
+		},
+	}
+
+	creds := &staticCredentialProvider{tokens: map[string]string{upstreamHost: "test-token"}}
+	h := newGitHandler(creds, nil)
+	h.client = upstream.Client()
+
+	req := httptest.NewRequest("GET", "/git/"+upstreamHost+"/org/repo.git/info/refs?service=git-upload-pack", nil)
+	req = withScope(req, scope)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	body, _ := io.ReadAll(w.Body)
+	if string(body) != "git-refs-data" {
+		t.Fatalf("unexpected body: %q", string(body))
+	}
+}
+
+func TestGitHandlerNoScope(t *testing.T) {
+	t.Parallel()
+
+	h := newGitHandler(nil, nil)
+	req := httptest.NewRequest("GET", "/git/github.com/org/repo.git/info/refs", nil)
+	// No scope in context
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", w.Code)
+	}
+}
+
+func TestClassifyRequest(t *testing.T) {
+	t.Parallel()
+
+	h := &gitHandler{}
+	tests := []struct {
+		method  string
+		path    string
+		query   string
+		wantErr bool
+		wantAct string
+	}{
+		{"GET", "/org/repo.git/info/refs", "service=git-upload-pack", false, "info-refs"},
+		{"GET", "/org/repo.git/info/refs", "service=git-receive-pack", true, ""},
+		{"POST", "/org/repo.git/git-upload-pack", "", false, "upload-pack"},
+		{"POST", "/org/repo.git/git-receive-pack", "", true, ""},
+		{"GET", "/org/repo.git/HEAD", "", false, "other"},
+	}
+	for _, tt := range tests {
+		act, err := h.classifyRequest(tt.method, tt.path, tt.query)
+		if tt.wantErr && err == nil {
+			t.Errorf("classifyRequest(%s, %s, %s) expected error", tt.method, tt.path, tt.query)
+		}
+		if !tt.wantErr && err != nil {
+			t.Errorf("classifyRequest(%s, %s, %s) unexpected error: %v", tt.method, tt.path, tt.query, err)
+		}
+		if !tt.wantErr && act != tt.wantAct {
+			t.Errorf("classifyRequest(%s, %s, %s) = %q, want %q", tt.method, tt.path, tt.query, act, tt.wantAct)
+		}
+	}
+}

--- a/internal/gateway/path.go
+++ b/internal/gateway/path.go
@@ -1,0 +1,58 @@
+package gateway
+
+import (
+	"errors"
+	"net/url"
+	"path"
+	"strings"
+)
+
+var (
+	errPathNullByte    = errors.New("path contains null byte")
+	errPathTraversal   = errors.New("path contains traversal sequence")
+	errPathDoubleSlash = errors.New("path contains double slash")
+	errPathEncoding    = errors.New("invalid path encoding")
+)
+
+// CanonicalisePath validates and normalises an HTTP request path, rejecting
+// traversal sequences, null bytes, double slashes, and percent-encoded variants.
+func CanonicalisePath(raw string) (string, error) {
+	if strings.ContainsRune(raw, 0) {
+		return "", errPathNullByte
+	}
+
+	decoded, err := url.PathUnescape(raw)
+	if err != nil {
+		return "", errPathEncoding
+	}
+
+	if strings.ContainsRune(decoded, 0) {
+		return "", errPathNullByte
+	}
+	if containsTraversal(decoded) {
+		return "", errPathTraversal
+	}
+	if strings.Contains(decoded, "//") {
+		return "", errPathDoubleSlash
+	}
+
+	cleaned := path.Clean(decoded)
+	if !strings.HasPrefix(cleaned, "/") {
+		cleaned = "/" + cleaned
+	}
+
+	if containsTraversal(cleaned) {
+		return "", errPathTraversal
+	}
+
+	return cleaned, nil
+}
+
+func containsTraversal(p string) bool {
+	for _, segment := range strings.Split(p, "/") {
+		if segment == ".." {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/gateway/path_test.go
+++ b/internal/gateway/path_test.go
@@ -1,0 +1,74 @@
+package gateway
+
+import (
+	"testing"
+)
+
+func TestCanonicalisePathValid(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"/git/github.com/org/repo.git/info/refs", "/git/github.com/org/repo.git/info/refs"},
+		{"/git/github.com/org/repo", "/git/github.com/org/repo"},
+		{"/registry/npmjs.org/pkg", "/registry/npmjs.org/pkg"},
+		{"/meta/health", "/meta/health"},
+	}
+	for _, tt := range tests {
+		result, err := CanonicalisePath(tt.input)
+		if err != nil {
+			t.Errorf("CanonicalisePath(%q) error: %v", tt.input, err)
+			continue
+		}
+		if result != tt.want {
+			t.Errorf("CanonicalisePath(%q) = %q, want %q", tt.input, result, tt.want)
+		}
+	}
+}
+
+func TestCanonicalisePathTraversal(t *testing.T) {
+	t.Parallel()
+	paths := []string{
+		"/git/../secrets/key",
+		"/git/../../etc/passwd",
+		"/git/%2e%2e/secrets/key",
+		"/git/%2E%2E/secrets/key",
+		"/../../../etc/passwd",
+	}
+	for _, p := range paths {
+		if _, err := CanonicalisePath(p); err == nil {
+			t.Errorf("CanonicalisePath(%q) should have returned error", p)
+		}
+	}
+}
+
+func TestCanonicalisePathNullByte(t *testing.T) {
+	t.Parallel()
+	if _, err := CanonicalisePath("/git/github.com/\x00/repo"); err == nil {
+		t.Error("expected error for null byte")
+	}
+	if _, err := CanonicalisePath("/git/github.com/%00/repo"); err == nil {
+		t.Error("expected error for percent-encoded null byte")
+	}
+}
+
+func TestCanonicalisePathDoubleSlash(t *testing.T) {
+	t.Parallel()
+	if _, err := CanonicalisePath("/git//github.com/repo"); err == nil {
+		t.Error("expected error for double slash")
+	}
+}
+
+func TestCanonicalisePathEncodedTraversal(t *testing.T) {
+	t.Parallel()
+	encoded := []string{
+		"/git/%2e%2e/%2e%2e/secrets/",
+		"/git/github.com/%2e%2e/secrets",
+	}
+	for _, p := range encoded {
+		if _, err := CanonicalisePath(p); err == nil {
+			t.Errorf("CanonicalisePath(%q) should have returned error for encoded traversal", p)
+		}
+	}
+}

--- a/internal/gateway/registry.go
+++ b/internal/gateway/registry.go
@@ -1,0 +1,57 @@
+package gateway
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/buildkite/cleanroom/internal/policy"
+)
+
+// SandboxScope holds the identity and policy for a registered sandbox.
+type SandboxScope struct {
+	SandboxID string
+	GuestIP   string
+	Policy    *policy.CompiledPolicy
+}
+
+// Registry is a thread-safe mapping of guest IPs to sandbox scopes.
+type Registry struct {
+	mu        sync.RWMutex
+	byGuestIP map[string]*SandboxScope
+}
+
+// NewRegistry creates an empty registry.
+func NewRegistry() *Registry {
+	return &Registry{byGuestIP: make(map[string]*SandboxScope)}
+}
+
+// Register adds a sandbox scope keyed by guest IP. Returns an error if the IP
+// is already registered (possible hash collision).
+func (r *Registry) Register(guestIP, sandboxID string, p *policy.CompiledPolicy) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.byGuestIP[guestIP]; exists {
+		return fmt.Errorf("guest IP %s already registered (possible IP collision)", guestIP)
+	}
+	r.byGuestIP[guestIP] = &SandboxScope{
+		SandboxID: sandboxID,
+		GuestIP:   guestIP,
+		Policy:    p,
+	}
+	return nil
+}
+
+// Release removes a sandbox scope by guest IP.
+func (r *Registry) Release(guestIP string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.byGuestIP, guestIP)
+}
+
+// Lookup retrieves a sandbox scope by guest IP.
+func (r *Registry) Lookup(guestIP string) (*SandboxScope, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	scope, ok := r.byGuestIP[guestIP]
+	return scope, ok
+}

--- a/internal/gateway/registry_test.go
+++ b/internal/gateway/registry_test.go
@@ -1,0 +1,124 @@
+package gateway
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/policy"
+)
+
+func testPolicy() *policy.CompiledPolicy {
+	return &policy.CompiledPolicy{
+		Version:        1,
+		NetworkDefault: "deny",
+		Allow:          []policy.AllowRule{{Host: "github.com", Ports: []int{443}}},
+	}
+}
+
+func TestRegistryRegisterAndLookup(t *testing.T) {
+	t.Parallel()
+	r := NewRegistry()
+
+	p := testPolicy()
+	if err := r.Register("10.1.1.2", "sandbox-1", p); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	scope, ok := r.Lookup("10.1.1.2")
+	if !ok {
+		t.Fatal("expected lookup to succeed")
+	}
+	if scope.SandboxID != "sandbox-1" {
+		t.Fatalf("expected sandbox-1, got %s", scope.SandboxID)
+	}
+	if scope.GuestIP != "10.1.1.2" {
+		t.Fatalf("expected 10.1.1.2, got %s", scope.GuestIP)
+	}
+	if scope.Policy != p {
+		t.Fatal("policy mismatch")
+	}
+}
+
+func TestRegistryDuplicateIPReturnsError(t *testing.T) {
+	t.Parallel()
+	r := NewRegistry()
+
+	if err := r.Register("10.1.1.2", "sandbox-1", testPolicy()); err != nil {
+		t.Fatalf("first register: %v", err)
+	}
+	if err := r.Register("10.1.1.2", "sandbox-2", testPolicy()); err == nil {
+		t.Fatal("expected error on duplicate IP registration")
+	}
+}
+
+func TestRegistryRelease(t *testing.T) {
+	t.Parallel()
+	r := NewRegistry()
+
+	if err := r.Register("10.1.1.2", "sandbox-1", testPolicy()); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	r.Release("10.1.1.2")
+
+	if _, ok := r.Lookup("10.1.1.2"); ok {
+		t.Fatal("expected lookup to fail after release")
+	}
+}
+
+func TestRegistryReleaseUnknownIsNoop(t *testing.T) {
+	t.Parallel()
+	r := NewRegistry()
+	r.Release("10.99.99.99") // should not panic
+}
+
+func TestRegistryLookupUnregisteredReturnsFalse(t *testing.T) {
+	t.Parallel()
+	r := NewRegistry()
+	if _, ok := r.Lookup("10.1.1.2"); ok {
+		t.Fatal("expected lookup to return false for unregistered IP")
+	}
+}
+
+func TestRegistryConcurrentAccess(t *testing.T) {
+	t.Parallel()
+	r := NewRegistry()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			ip := "10.0.0." + itoa(i%256)
+			id := "sandbox-" + itoa(i)
+			_ = r.Register(ip, id, testPolicy())
+			r.Lookup(ip)
+			r.Release(ip)
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestRegistryReRegisterAfterRelease(t *testing.T) {
+	t.Parallel()
+	r := NewRegistry()
+
+	if err := r.Register("10.1.1.2", "sandbox-1", testPolicy()); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	r.Release("10.1.1.2")
+
+	if err := r.Register("10.1.1.2", "sandbox-2", testPolicy()); err != nil {
+		t.Fatalf("re-register after release: %v", err)
+	}
+	scope, ok := r.Lookup("10.1.1.2")
+	if !ok || scope.SandboxID != "sandbox-2" {
+		t.Fatal("re-registered scope mismatch")
+	}
+}
+
+func itoa(i int) string {
+	if i < 10 {
+		return string(rune('0' + i))
+	}
+	return itoa(i/10) + string(rune('0'+i%10))
+}

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -1,0 +1,170 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/charmbracelet/log"
+)
+
+// DefaultPort is the default gateway listen port.
+const DefaultPort = 8170
+
+type contextKey int
+
+const scopeContextKey contextKey = iota
+
+// ScopeFromContext retrieves the SandboxScope injected by identity middleware.
+func ScopeFromContext(ctx context.Context) (*SandboxScope, bool) {
+	scope, ok := ctx.Value(scopeContextKey).(*SandboxScope)
+	return scope, ok
+}
+
+// ServerConfig configures a gateway server.
+type ServerConfig struct {
+	ListenAddr  string
+	Registry    *Registry
+	Credentials CredentialProvider
+	Logger      *log.Logger
+}
+
+// Server is the host gateway HTTP server.
+type Server struct {
+	registry   *Registry
+	logger     *log.Logger
+	httpServer *http.Server
+
+	mu      sync.Mutex
+	started bool
+	addr    string
+}
+
+// NewServer creates a gateway server. Call Start to begin listening.
+func NewServer(cfg ServerConfig) *Server {
+	addr := cfg.ListenAddr
+	if addr == "" {
+		addr = ":8170"
+	}
+
+	s := &Server{
+		registry: cfg.Registry,
+		logger:   cfg.Logger,
+		addr:     addr,
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/git/", newGitHandler(cfg.Credentials, cfg.Logger))
+	mux.HandleFunc("/registry/", stubHandler("registry"))
+	mux.HandleFunc("/secrets/", stubHandler("secrets"))
+	mux.HandleFunc("/meta/", stubHandler("meta"))
+
+	s.httpServer = &http.Server{
+		Handler: s.identityMiddleware(s.pathMiddleware(mux)),
+	}
+
+	return s
+}
+
+// Start begins listening for connections in the background.
+func (s *Server) Start() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.started {
+		return errors.New("gateway server already started")
+	}
+
+	ln, err := net.Listen("tcp", s.addr)
+	if err != nil {
+		return err
+	}
+	s.started = true
+	s.addr = ln.Addr().String()
+
+	go func() {
+		if err := s.httpServer.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			if s.logger != nil {
+				s.logger.Error("gateway server error", "error", err)
+			}
+		}
+	}()
+
+	if s.logger != nil {
+		s.logger.Info("gateway server started", "addr", s.addr)
+	}
+	return nil
+}
+
+// Addr returns the listener address. Only meaningful after Start.
+func (s *Server) Addr() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.addr
+}
+
+// Stop gracefully shuts down the server.
+func (s *Server) Stop(ctx context.Context) error {
+	return s.httpServer.Shutdown(ctx)
+}
+
+// identityMiddleware extracts the source IP from RemoteAddr, looks up the
+// sandbox scope in the registry, and injects it into the request context.
+// Returns 403 if the source IP is not registered.
+func (s *Server) identityMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sourceIP := extractSourceIP(r.RemoteAddr)
+		if sourceIP == "" {
+			http.Error(w, "forbidden", http.StatusForbidden)
+			return
+		}
+
+		scope, ok := s.registry.Lookup(sourceIP)
+		if !ok {
+			http.Error(w, "forbidden", http.StatusForbidden)
+			return
+		}
+
+		ctx := context.WithValue(r.Context(), scopeContextKey, scope)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// pathMiddleware validates and canonicalises the request path.
+func (s *Server) pathMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		canonical, err := CanonicalisePath(r.URL.Path)
+		if err != nil {
+			http.Error(w, "bad request: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		r.URL.Path = canonical
+		next.ServeHTTP(w, r)
+	})
+}
+
+// extractSourceIP returns the IP portion of a RemoteAddr, handling both
+// IPv4 ("10.1.1.2:43210") and IPv6-mapped IPv4 ("[::ffff:10.1.1.2]:43210").
+func extractSourceIP(remoteAddr string) string {
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		return strings.TrimSpace(remoteAddr)
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return host
+	}
+	if v4 := ip.To4(); v4 != nil {
+		return v4.String()
+	}
+	return ip.String()
+}
+
+func stubHandler(service string) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotImplemented)
+		_, _ = w.Write([]byte(service + " service not yet implemented"))
+	}
+}

--- a/internal/gateway/server_test.go
+++ b/internal/gateway/server_test.go
@@ -1,0 +1,126 @@
+package gateway
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/policy"
+)
+
+func TestExtractSourceIP(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"10.1.1.2:43210", "10.1.1.2"},
+		{"[::ffff:10.1.1.2]:43210", "10.1.1.2"},
+		{"192.168.1.1:8080", "192.168.1.1"},
+		{"[::1]:9090", "::1"},
+		{"10.1.1.2", "10.1.1.2"},
+	}
+	for _, tt := range tests {
+		got := extractSourceIP(tt.input)
+		if got != tt.want {
+			t.Errorf("extractSourceIP(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestIdentityMiddleware403ForUnregisteredIP(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	srv := &Server{registry: reg}
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := srv.identityMiddleware(inner)
+
+	req := httptest.NewRequest("GET", "/git/github.com/org/repo", nil)
+	req.RemoteAddr = "10.99.99.99:12345"
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", w.Code)
+	}
+}
+
+func TestIdentityMiddlewareInjectsScope(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	p := &policy.CompiledPolicy{Version: 1, NetworkDefault: "deny"}
+	if err := reg.Register("10.1.1.2", "sandbox-1", p); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	srv := &Server{registry: reg}
+	var gotScope *SandboxScope
+	inner := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		gotScope, _ = ScopeFromContext(r.Context())
+	})
+	handler := srv.identityMiddleware(inner)
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.RemoteAddr = "10.1.1.2:12345"
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if gotScope == nil {
+		t.Fatal("expected scope in context")
+	}
+	if gotScope.SandboxID != "sandbox-1" {
+		t.Fatalf("expected sandbox-1, got %s", gotScope.SandboxID)
+	}
+}
+
+func TestPathMiddlewareRejectsTraversal(t *testing.T) {
+	t.Parallel()
+
+	srv := &Server{}
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := srv.pathMiddleware(inner)
+
+	req := httptest.NewRequest("GET", "/git/../secrets/key", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestStubHandlerReturns501(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	p := &policy.CompiledPolicy{Version: 1, NetworkDefault: "deny"}
+	if err := reg.Register("10.1.1.2", "sandbox-1", p); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	srv := NewServer(ServerConfig{
+		ListenAddr: "127.0.0.1:0",
+		Registry:   reg,
+	})
+
+	req := httptest.NewRequest("GET", "/secrets/key", nil)
+	req.RemoteAddr = "10.1.1.2:12345"
+	w := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotImplemented {
+		t.Fatalf("expected 501, got %d", w.Code)
+	}
+	body, _ := io.ReadAll(w.Body)
+	if got := string(body); got != "secrets service not yet implemented" {
+		t.Fatalf("unexpected body: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Implement the host gateway for cleanroom (slices 1–4 from `docs/plans/host-gateway.md`). A single shared host-side HTTP gateway mediates sandbox access to external services, using TAP network source-IP identity instead of bearer tokens.

### New package: `internal/gateway`

- **Registry** (`registry.go`): Thread-safe guest-IP-to-sandbox-scope mapping. Populated during `ProvisionSandbox`, released during `TerminateSandbox`. Rejects duplicate IP registration (hash collision detection).
- **Server** (`server.go`): HTTP server on `:8170` with source-IP identity middleware. Extracts IP from `RemoteAddr` (handles IPv4 and IPv6-mapped), looks up sandbox scope in registry, injects into request context. Returns 403 for unregistered callers.
- **Path canonicalisation** (`path.go`): Rejects traversal sequences (`..`), null bytes, double slashes, and percent-encoded variants before routing.
- **Git smart-HTTP proxy** (`git.go`): Handler at `/git/<upstream-host>/<path>` proxying `info/refs` and `git-upload-pack` to upstream over HTTPS. Enforces policy (host must be allowed on port 443), denies `git-receive-pack` (push), injects upstream credentials, emits structured audit logs.
- **Credential provider** (`credentials.go`): `CredentialProvider` interface with `EnvCredentialProvider` reading `CLEANROOM_GITHUB_TOKEN` / `CLEANROOM_GITLAB_TOKEN` at startup.
- **Stub handlers**: `/registry/`, `/secrets/`, `/meta/` return 501.

### Firecracker backend changes

- **Anti-spoof INPUT rules** per TAP: drop packets not sourced from guest IP, accept gateway port, drop all other INPUT. Installed before FORWARD rules, cleaned up on termination.
- **IPv6 disabled** on TAP devices via sysctl (best-effort).
- **Gateway registry integration**: `ProvisionSandbox` registers sandbox scope, `TerminateSandbox` releases it.
- **Git URL rewriting**: `executeInSandbox` injects `GIT_CONFIG_COUNT`/`KEY`/`VALUE` env vars so guest git transparently routes through the gateway.
- **Root helper updates**: Allowlisted new iptables INPUT chain patterns (anti-spoof negation, gateway accept, catch-all DROP) and per-TAP IPv6 disable sysctl.

### CLI wiring

- `cleanroom serve` creates gateway registry + server at startup, sets registry on the firecracker adapter, stops gateway on shutdown.

### Design decisions

- **Source-IP identity** over bearer tokens — TAP guest IP is a hard identity with anti-spoof iptables, eliminating token exfiltration risks.
- **Single shared gateway** — O(services) ports regardless of sandbox count, avoiding port exhaustion at high density.
- **Per-sandbox transport isolation** — no HTTP connection pool sharing across sandbox identities.

### What is not included (future slices)

- Slice 5: Registry proxy (currently returns 501)
- Slice 6: Conformance tests

### Testing

Unit tests for all new gateway package files (registry, server, path, git, credentials). Updated firecracker backend tests for anti-spoof rule assertions and gateway env var generation.

See `docs/plans/host-gateway.md` for the full implementation plan.