### PR TITLE
docs: reorganise and clean up spec, research, API, and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,20 +13,30 @@ Cleanroom uses fast Firecracker microVMs (under 2s to interactive) to create iso
 
 ## Quick Start
 
-Validate policy, start the server, run a command:
+Start the server (all CLI commands require a running server):
 
 ```bash
-cleanroom policy validate
-cleanroom serve
-cleanroom exec -- npm test
+cleanroom serve &
 ```
 
 The server listens on `unix://$XDG_RUNTIME_DIR/cleanroom/cleanroom.sock` by default.
-All CLI commands talk to this endpoint.
+
+The simplest way to run a command is `cleanroom exec`, which creates an ephemeral sandbox, runs the command, and tears it down:
+
+```bash
+cleanroom exec -- npm test
+```
+
+For long-running sandboxes, create one explicitly and run multiple commands against it:
+
+```bash
+cleanroom exec --keep-sandbox -- npm test
+# reuse the sandbox for another command
+cleanroom exec --sandbox-id <id> -- npm run lint
+# terminate when done
+```
 
 ## CLI
-
-`cleanroom exec` is the primary interface — it creates an ephemeral sandbox, runs the command, and tears down:
 
 ```bash
 cleanroom exec -- npm test
@@ -129,7 +139,7 @@ The Firecracker adapter resolves `sandbox.image.ref` through the local image man
 ## Isolation Model
 
 - Workload runs in a Firecracker microVM
-- Host egress is controlled with TAP + nftables rules from compiled policy
+- Host egress is controlled with TAP + iptables rules from compiled policy
 - Default network behaviour is deny
 - Rootfs writes are discarded after each run
 - Per-run observability is written to `run-observability.json` (rootfs prep, network setup, VM ready, command runtime, total)

--- a/README.md
+++ b/README.md
@@ -1,13 +1,6 @@
-# Cleanroom
+# 🧑‍🔬 Cleanroom
 
-Cleanroom is an API-first control plane for isolated command execution.
-
-Current backend: **Firecracker** on Linux/KVM.
-
-It is built for this lifecycle:
-1. Launch a cleanroom context from repository policy.
-2. Run an agent/command in an isolated Firecracker VM.
-3. Terminate the cleanroom context.
+Cleanroom uses fast Firecracker microVMs (under 2s to interactive) to create isolated environments for untrusted workloads like AI agents and CI jobs. Deny-by-default egress, digest-pinned images, and immutable policy make it safe to run code you don't trust.
 
 ## What It Does
 
@@ -18,70 +11,35 @@ It is built for this lifecycle:
 - Returns exit code + stdout/stderr over API
 - Stores run artifacts and timing metrics for inspection
 
-## Architecture
-
-- Server: `cleanroom serve`
-- Client: CLI and ConnectRPC clients
-- Transport: unix socket by default (`unix://$XDG_RUNTIME_DIR/cleanroom/cleanroom.sock`)
-- Core RPC services:
-  - `cleanroom.v1.SandboxService`
-  - `cleanroom.v1.ExecutionService`
-
 ## Quick Start
 
-### 1) Validate policy
+Validate policy, start the server, run a command:
 
 ```bash
 cleanroom policy validate
+cleanroom serve
+cleanroom exec -- npm test
 ```
 
-### 2) Start API server
+The server listens on `unix://$XDG_RUNTIME_DIR/cleanroom/cleanroom.sock` by default.
+All CLI commands talk to this endpoint.
+
+## CLI
+
+`cleanroom exec` is the primary interface — it creates an ephemeral sandbox, runs the command, and tears down:
 
 ```bash
-cleanroom serve --listen unix://$XDG_RUNTIME_DIR/cleanroom/cleanroom.sock
+cleanroom exec -- npm test
+cleanroom exec -c /path/to/repo -- make build
 ```
 
-All CLI commands (including `cleanroom exec`) talk to this API endpoint.
-
-To expose the API over Tailscale using embedded `tsnet`:
+Interactive console:
 
 ```bash
-cleanroom serve --listen tsnet://cleanroom:7777
+cleanroom console -- bash
 ```
 
-Then connect with:
-
-```bash
-cleanroom exec --host http://cleanroom.tailnet.ts.net:7777 -c /path/to/repo -- "npm test"
-```
-
-To expose the API as a Tailscale Service using the local `tailscaled` daemon:
-
-```bash
-cleanroom serve --listen tssvc://cleanroom
-```
-
-This configures `svc:cleanroom` with HTTPS on port 443 and advertises the
-service from this host. Connect from another tailnet device with:
-
-```bash
-cleanroom exec --host https://cleanroom.<your-tailnet>.ts.net -- "npm test"
-```
-
-### 3) Launch -> Run -> Terminate via API
-
-Use the generated ConnectRPC clients against `SandboxService` and
-`ExecutionService` for lifecycle and execution operations.
-
-## CLI Shortcut
-
-`cleanroom exec` keeps a one-command flow, but lifecycle endpoints are the primary API model.
-
-```bash
-cleanroom exec -- pi run "implement the requested refactor"
-```
-
-Image lifecycle commands:
+Image lifecycle:
 
 ```bash
 cleanroom image pull ghcr.io/buildkite/cleanroom-base/alpine@sha256:...
@@ -94,19 +52,37 @@ cleanroom image bump-ref
 `ghcr.io/buildkite/cleanroom-base/alpine` is published from this repo on pushes to `main`
 via `.github/workflows/base-image.yml`.
 
-Benchmark sandbox TTI (time from sandbox creation to first successful command):
+Diagnostics:
 
 ```bash
-scripts/benchmark-tti.sh --iterations 10
+cleanroom doctor
+cleanroom status --run-id <run-id>
+cleanroom status --last-run
 ```
 
-This uses `hyperfine` to benchmark `cleanroom exec ... -- echo benchmark` and
-writes a timestamped JSON report to `benchmarks/results/`.
+## Architecture
 
-## API Contract (Current)
+- Server: `cleanroom serve`
+- Client: CLI and ConnectRPC clients
+- Transport: unix socket by default
+- API: `cleanroom.v1.SandboxService` and `cleanroom.v1.ExecutionService`
+- Proto definition: `proto/cleanroom/v1/control.proto`
 
-Canonical API surface is defined in `proto/cleanroom/v1/control.proto` and
-served over ConnectRPC.
+### Remote Access
+
+The server supports Tailscale listeners for remote access:
+
+```bash
+# Embedded tsnet
+cleanroom serve --listen tsnet://cleanroom:7777
+cleanroom exec --host http://cleanroom.tailnet.ts.net:7777 -c /path/to/repo -- npm test
+
+# Tailscale Service (via local tailscaled)
+cleanroom serve --listen tssvc://cleanroom
+cleanroom exec --host https://cleanroom.<your-tailnet>.ts.net -- npm test
+```
+
+TCP is also supported: `cleanroom serve --listen tcp://0.0.0.0:7777`
 
 ## Policy File
 
@@ -130,11 +106,9 @@ sandbox:
         ports: [443]
 ```
 
-## Firecracker Runtime Config
+## Runtime Config
 
 Runtime config path: `$XDG_CONFIG_HOME/cleanroom/config.yaml` (or `~/.config/cleanroom/config.yaml`).
-
-Example:
 
 ```yaml
 default_backend: firecracker
@@ -155,49 +129,24 @@ The Firecracker adapter resolves `sandbox.image.ref` through the local image man
 ## Isolation Model
 
 - Workload runs in a Firecracker microVM
-- Host egress is controlled with TAP + iptables rules from compiled policy
-- Default network behavior is deny
+- Host egress is controlled with TAP + nftables rules from compiled policy
+- Default network behaviour is deny
 - Rootfs writes are discarded after each run
-
-## Performance Notes
-
+- Per-run observability is written to `run-observability.json` (rootfs prep, network setup, VM ready, command runtime, total)
 - Rootfs copy uses clone/reflink when available, with copy fallback
-- Per-run observability is written to `run-observability.json`
-- Metrics include:
-  - rootfs preparation time
-  - network setup time
-  - VM ready time
-  - guest command runtime
-  - total run time
-
-Inspect:
-
-```bash
-cleanroom doctor
-cleanroom status --run-id <run-id>
-```
-
-`status --run-id` prints per-run observability from `run-observability.json`, including:
-- policy host-resolution time
-- rootfs preparation time
-- Firecracker process start time
-- network setup time
-- VM ready time (process start -> guest agent ready)
-- vsock wait time (wait-to-connect for guest agent)
-- guest command runtime
-- network cleanup time
-- total run time
 
 ## Host Requirements
 
-- Linux host
-- `/dev/kvm` available and writable
+- Linux host with `/dev/kvm` available and writable
 - Firecracker binary installed
 - Kernel image configured
-- `mkfs.ext4` installed (used to materialise OCI layers into ext4 cache artifacts)
+- `mkfs.ext4` installed (materialises OCI layers into ext4 cache artifacts)
 - `sudo -n` access for `ip`, `iptables`, and `sysctl` (network setup/cleanup)
 
 ## References
 
-- API design notes: `API_CONNECTRPC.md`
-- Full spec and roadmap: `SPEC.md`
+- [API design](docs/api.md) — ConnectRPC surface and proto sketch
+- [Benchmarks](docs/benchmarks.md) — TTI measurement and results
+- [CI](docs/ci.md) — Buildkite pipeline and base image workflow
+- [Spec](docs/spec.md) — Full specification and roadmap
+- [Research](docs/research.md) — Backend and tooling evaluation notes

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ cleanroom serve --listen tssvc://cleanroom
 cleanroom exec --host https://cleanroom.<your-tailnet>.ts.net -- npm test
 ```
 
-TCP is also supported: `cleanroom serve --listen tcp://0.0.0.0:7777`
+HTTP is also supported: `cleanroom serve --listen http://0.0.0.0:7777`
 
 ## Policy File
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -56,7 +56,7 @@ Fallbacks:
 4. default unix socket path
 
 HTTP and Tailscale endpoints are also supported:
-- `http://host:port` or `https://host:port` for direct HTTP
+- `http://host:port` for direct HTTP (HTTPS not yet implemented)
 - `tsnet://hostname[:port]` for embedded Tailscale (server-side only)
 - `tssvc://service[:local-port]` for Tailscale Services (server-side only; clients connect via `https://service.<tailnet>.ts.net`)
 
@@ -213,7 +213,6 @@ Expose a server mode and API-driven commands in the same binary.
 
 - `cleanroom serve --listen unix:///run/user/1000/cleanroom/cleanroom.sock`
 - `cleanroom serve --listen http://127.0.0.1:7777`
-- `cleanroom serve --listen https://0.0.0.0:7777 --tls-cert ... --tls-key ...`
 - `cleanroom serve --listen tsnet://cleanroom:7777`
 - `cleanroom serve --listen tssvc://cleanroom`
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -55,8 +55,8 @@ Fallbacks:
 3. active context config
 4. default unix socket path
 
-TCP and Tailscale endpoints are also supported:
-- `tcp://host:port` for direct TCP
+HTTP and Tailscale endpoints are also supported:
+- `http://host:port` or `https://host:port` for direct HTTP
 - `tsnet://hostname[:port]` for embedded Tailscale (tsnet)
 - `tssvc://service[:local-port]` for Tailscale Services
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -7,7 +7,6 @@ Define a minimal, functional API for creating and managing Cleanroom sandboxes w
 This document is intentionally small-scope:
 - management plane for sandbox lifecycle
 - execution plane for command runs and streaming output
-- no requirement to match Sprites API shape
 
 ## 2) Terminology
 
@@ -56,7 +55,10 @@ Fallbacks:
 3. active context config
 4. default unix socket path
 
-TCP endpoints are supported later for remote control-plane use.
+TCP and Tailscale endpoints are also supported:
+- `tcp://host:port` for direct TCP
+- `tsnet://hostname[:port]` for embedded Tailscale (tsnet)
+- `tssvc://service[:local-port]` for Tailscale Services
 
 ## 4) API Surface (Minimal v1)
 
@@ -143,6 +145,8 @@ syntax = "proto3";
 
 package cleanroom.v1;
 
+import "google/protobuf/timestamp.proto";
+
 service SandboxService {
   rpc CreateSandbox(CreateSandboxRequest) returns (CreateSandboxResponse);
   rpc GetSandbox(GetSandboxRequest) returns (GetSandboxResponse);
@@ -165,8 +169,8 @@ message Sandbox {
   SandboxStatus status = 2;
   string backend = 3;
   string policy_hash = 4;
-  string created_at = 5;
-  string updated_at = 6;
+  google.protobuf.Timestamp created_at = 5;
+  google.protobuf.Timestamp updated_at = 6;
 }
 
 enum SandboxStatus {
@@ -182,10 +186,12 @@ message Execution {
   string execution_id = 1;
   string sandbox_id = 2;
   ExecutionStatus status = 3;
-  string command = 4;
+  repeated string command = 4;
   int32 exit_code = 5;
-  string started_at = 6;
-  string finished_at = 7;
+  google.protobuf.Timestamp started_at = 6;
+  google.protobuf.Timestamp finished_at = 7;
+  bool tty = 8;
+  string run_id = 9;
 }
 
 enum ExecutionStatus {
@@ -208,6 +214,8 @@ Expose a server mode and API-driven commands in the same binary.
 - `cleanroom serve --listen unix:///run/user/1000/cleanroom/cleanroom.sock`
 - `cleanroom serve --listen tcp://127.0.0.1:7777`
 - `cleanroom serve --listen tcp://0.0.0.0:7777 --tls-cert ... --tls-key ...`
+- `cleanroom serve --listen tsnet://cleanroom:7777`
+- `cleanroom serve --listen tssvc://cleanroom`
 
 ### 9.2 Sandbox commands
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -57,8 +57,8 @@ Fallbacks:
 
 HTTP and Tailscale endpoints are also supported:
 - `http://host:port` or `https://host:port` for direct HTTP
-- `tsnet://hostname[:port]` for embedded Tailscale (tsnet)
-- `tssvc://service[:local-port]` for Tailscale Services
+- `tsnet://hostname[:port]` for embedded Tailscale (server-side only)
+- `tssvc://service[:local-port]` for Tailscale Services (server-side only; clients connect via `https://service.<tailnet>.ts.net`)
 
 ## 4) API Surface (Minimal v1)
 
@@ -212,8 +212,8 @@ Expose a server mode and API-driven commands in the same binary.
 ### 9.1 Server
 
 - `cleanroom serve --listen unix:///run/user/1000/cleanroom/cleanroom.sock`
-- `cleanroom serve --listen tcp://127.0.0.1:7777`
-- `cleanroom serve --listen tcp://0.0.0.0:7777 --tls-cert ... --tls-key ...`
+- `cleanroom serve --listen http://127.0.0.1:7777`
+- `cleanroom serve --listen https://0.0.0.0:7777 --tls-cert ... --tls-key ...`
 - `cleanroom serve --listen tsnet://cleanroom:7777`
 - `cleanroom serve --listen tssvc://cleanroom`
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -345,9 +345,9 @@ Policy feature mapping:
 - Any unmet requirement results in `backend_capability_mismatch`.
 
 #### Local backend (firecracker)
-- Firecracker microVM with per-run TAP networking and nftables enforcement.
+- Firecracker microVM with per-run TAP networking and iptables enforcement.
 - Primary use: developer workflows and lightweight local CI.
-- Controls at runtime via host nftables rules + managed DNS from compiled policy.
+- Controls at runtime via host iptables rules + managed DNS from compiled policy.
 
 ## 8) Configuration and integration points
 - CLI command set (v1):


### PR DESCRIPTION
- Move SPEC.md, RESEARCH.md, API_CONNECTRPC.md into docs/ (lowercase)
- Remove sprites.dev from spec and research (dropped as backend)
- Update spec to reflect Firecracker as sole v1 backend
- Align spec backend interface with actual Go types
- Remove `backends` block from policy schema (runtime config concern)
- Remove `run_id` from CompiledPolicy (per-execution, not per-policy)
- Update API doc proto sketch to match actual control.proto
- Add Tailscale and TCP endpoint docs
- Rewrite README: tighter quick start, fix iptables→nftables, add pitch
- Link all docs/ files from README references section