### PR TITLE
feat: add mTLS support for control plane API

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ Cleanroom uses fast Firecracker microVMs (under 2s to interactive) to create iso
 - Returns exit code + stdout/stderr over API
 - Stores run artifacts and timing metrics for inspection
 
+## Architecture
+
+- Server: `cleanroom serve`
+- Client: CLI and ConnectRPC clients
+- Transport: unix socket (default), HTTPS with mTLS, or Tailscale
+- Core RPC services:
+  - `cleanroom.v1.SandboxService`
+  - `cleanroom.v1.ExecutionService`
+
 ## Quick Start
 
 Start the server (all CLI commands require a running server):
@@ -51,6 +60,78 @@ Interactive console:
 
 ```bash
 cleanroom console -- bash
+```
+
+## TLS / mTLS
+
+Cleanroom supports mutual TLS for HTTPS transport. TLS material is stored in
+`$XDG_CONFIG_HOME/cleanroom/tls/` (typically `~/.config/cleanroom/tls/`).
+
+### Bootstrap certificates
+
+```bash
+cleanroom tls init
+```
+
+This generates a CA, server certificate (with localhost + hostname SANs), and
+client certificate. Use `--force` to overwrite existing material.
+
+### Issue additional certificates
+
+```bash
+cleanroom tls issue worker-1 --san worker-1.internal --san 10.0.0.5
+```
+
+When `--san` is omitted, the certificate name is added as a SAN automatically.
+
+### Serve with HTTPS + mTLS
+
+```bash
+cleanroom serve --listen https://0.0.0.0:7777
+```
+
+TLS material is auto-discovered from the XDG TLS directory. To use explicit
+paths:
+
+```bash
+cleanroom serve --listen https://0.0.0.0:7777 \
+  --tls-cert /path/to/server.pem \
+  --tls-key /path/to/server.key \
+  --tls-ca /path/to/ca.pem
+```
+
+When a CA is configured, the server requires and verifies client certificates
+(mTLS). Without `--tls-ca`, the server accepts any TLS client.
+
+### Connect over HTTPS
+
+```bash
+cleanroom exec --host https://server.example.com:7777 -- echo hello
+```
+
+Client certificates and CA are auto-discovered from the XDG TLS directory, or
+specified with `--tls-cert`, `--tls-key`, and `--tls-ca`.
+
+Environment variables `CLEANROOM_TLS_CERT`, `CLEANROOM_TLS_KEY`, and
+`CLEANROOM_TLS_CA` are also supported.
+
+### Auto-discovery
+
+When no explicit TLS flags are provided, cleanroom looks for:
+
+| Role   | Cert                | Key                 | CA       |
+|--------|---------------------|---------------------|----------|
+| Server | `<tlsdir>/server.pem` | `<tlsdir>/server.key` | `<tlsdir>/ca.pem` |
+| Client | `<tlsdir>/client.pem` | `<tlsdir>/client.key` | `<tlsdir>/ca.pem` |
+
+CA auto-discovery is skipped when cert/key are explicitly provided, to avoid
+unexpectedly enabling mTLS.
+
+TLS commands:
+
+```bash
+cleanroom tls init                    # generate CA + server/client certs
+cleanroom tls issue myhost --san myhost.internal
 ```
 
 Image lifecycle:

--- a/docs/plans/mtls.md
+++ b/docs/plans/mtls.md
@@ -1,0 +1,147 @@
+# mTLS for cleanroom control plane
+
+## Goal
+
+Add mutual TLS to the cleanroom client/server transport so that both sides authenticate via certificates. This replaces the current `h2c` (cleartext HTTP/2) path for `https://` endpoints.
+
+## Non-goals
+
+- Replacing Tailscale transport (tsnet/tssvc continue to work as-is).
+- E2E encryption to the guest agent (tier 2 — future work).
+- OIDC or token-based auth (complementary, not blocked by this).
+- Certificate rotation or ACME integration.
+
+## Current state
+
+- `https://` scheme is parsed by `internal/endpoint` but the server returns an error: "TLS configuration is not implemented".
+- Client `buildTransport` returns a bare `http.Transport{}` for `https` (uses system roots, no client cert).
+- No CA, no cert generation, no client cert verification.
+
+## Design
+
+### Certificate layout
+
+All TLS material lives under `$XDG_CONFIG_HOME/cleanroom/tls/` (default `~/.config/cleanroom/tls/`):
+
+```
+tls/
+  ca.pem          # CA certificate (public)
+  ca.key          # CA private key
+  server.pem      # Server certificate signed by CA
+  server.key      # Server private key
+  client.pem      # Client certificate signed by CA
+  client.key      # Client private key
+```
+
+### CLI commands
+
+#### `cleanroom tls init`
+
+Generates a new CA keypair plus one server and one client certificate. Writes to XDG config dir. Refuses to overwrite existing CA unless `--force` is passed.
+
+- CA: self-signed, ECDSA P-256, 1 year validity, `CN=cleanroom-ca`.
+- Server cert: signed by CA, SANs include `localhost` and `127.0.0.1`, 1 year validity.
+- Client cert: signed by CA, `CN=cleanroom-client`, 1 year validity.
+
+#### `cleanroom tls issue --name <name> [--san <host>...]`
+
+Issues an additional certificate signed by the existing CA. Useful for issuing certs for specific hosts or additional clients.
+
+### Server changes (`cleanroom serve`)
+
+When `--listen https://...` is used:
+
+1. Auto-discover `server.pem`, `server.key`, `ca.pem` from XDG TLS dir.
+2. Build `tls.Config` with server certificate.
+3. If `ca.pem` is found, set `ClientAuth: tls.RequireAndVerifyClientCert` with CA pool (mTLS mode).
+4. Wrap TCP listener with `tls.NewListener`.
+5. Serve with standard `http2` (ALPN negotiation), not `h2c`.
+
+Override flags: `--tls-cert`, `--tls-key`, `--tls-ca`.
+
+### Client changes (`cleanroom exec`, `cleanroom console`, etc.)
+
+When `--host https://...` is used:
+
+1. Auto-discover `client.pem`, `client.key`, `ca.pem` from XDG TLS dir.
+2. Build `tls.Config` with client certificate and CA root pool.
+3. Use standard `http.Transport{TLSClientConfig: tlsConfig}`.
+
+Override flags: `--tls-cert`, `--tls-key`, `--tls-ca`.
+
+Environment variable fallbacks: `CLEANROOM_TLS_CERT`, `CLEANROOM_TLS_KEY`, `CLEANROOM_TLS_CA`.
+
+### Discovery order
+
+For each of cert, key, and CA:
+
+1. Explicit `--tls-*` flag
+2. `CLEANROOM_TLS_*` environment variable
+3. XDG config dir auto-discovery
+
+## Implementation slices
+
+### Slice 1: TLS bootstrap package
+
+New package `internal/tlsbootstrap` with:
+
+- `GenerateCA() (certPEM, keyPEM []byte, error)` — ECDSA P-256, self-signed.
+- `IssueCert(caCert, caKey, name string, sans []string) (certPEM, keyPEM []byte, error)` — signs a leaf cert.
+- `WriteTLSDir(dir string, ca, server, client materials)` — writes PEM files with `0600` permissions on keys.
+
+Tests: generate CA, issue cert, verify cert chains with `x509.Certificate.Verify`.
+
+### Slice 2: `cleanroom tls` CLI commands
+
+- Wire `tls init` subcommand in `internal/cli/cli.go`.
+- Wire `tls issue` subcommand.
+- Both use `internal/tlsbootstrap`.
+
+### Slice 3: Server TLS listener
+
+- Add `--tls-cert`, `--tls-key`, `--tls-ca` flags to `ServeCommand`.
+- Add TLS discovery function: `internal/tlsconfig.Discover(role, flagCert, flagKey, flagCA)`.
+- Update `createListener` in `server.go`: when scheme is `https`, build `tls.Config` and wrap listener.
+- When TLS is active, serve with `&http2.Server{}` directly (no `h2c` wrapper).
+
+### Slice 4: Client TLS transport
+
+- Add `--tls-cert`, `--tls-key`, `--tls-ca` flags to `ExecCommand` and `ConsoleCommand`.
+- Update `controlclient.New` to accept TLS config options.
+- Update `buildTransport` for `https` scheme: load client cert and CA, return `http.Transport` with `TLSClientConfig`.
+
+### Slice 5: Integration test
+
+- Start server with `--listen https://127.0.0.1:0` and generated certs.
+- Connect client with matching client cert.
+- Verify: successful RPC, rejected connection without client cert, rejected connection with wrong CA.
+
+## Files to modify
+
+| File | Change |
+|---|---|
+| `internal/tlsbootstrap/` (new) | CA + cert generation |
+| `internal/tlsconfig/` (new) | TLS config discovery and loading |
+| `internal/cli/cli.go` | `tls init`, `tls issue` commands, TLS flags on `serve`/`exec`/`console` |
+| `internal/controlserver/server.go` | `https` listener with TLS, drop `h2c` when TLS active |
+| `internal/controlclient/client.go` | `buildTransport` TLS path, accept TLS options |
+
+## UX examples
+
+```bash
+# One-time setup
+cleanroom tls init
+
+# Server (auto-discovers certs)
+cleanroom serve --listen https://0.0.0.0:7777
+
+# Client (auto-discovers certs)
+cleanroom exec --host https://remote-host:7777 -- npm test
+
+# Explicit cert paths (override)
+cleanroom exec --host https://remote-host:7777 \
+  --tls-cert /path/to/client.pem \
+  --tls-key /path/to/client.key \
+  --tls-ca /path/to/ca.pem \
+  -- npm test
+```

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -910,6 +910,10 @@ func (c *TLSInitCommand) Run(ctx *runtimeContext) error {
 }
 
 func (c *TLSIssueCommand) Run(ctx *runtimeContext) error {
+	if strings.ContainsAny(c.Name, "/\\") || strings.Contains(c.Name, "..") {
+		return fmt.Errorf("invalid certificate name %q: must not contain path separators or '..'", c.Name)
+	}
+
 	dir := c.Dir
 	if dir == "" {
 		d, err := paths.TLSDir()

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -25,6 +25,8 @@ import (
 	"github.com/buildkite/cleanroom/internal/controlserver"
 	"github.com/buildkite/cleanroom/internal/controlservice"
 	"github.com/buildkite/cleanroom/internal/endpoint"
+	"github.com/buildkite/cleanroom/internal/tlsbootstrap"
+	"github.com/buildkite/cleanroom/internal/tlsconfig"
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
 	"github.com/buildkite/cleanroom/internal/imagemgr"
 	"github.com/buildkite/cleanroom/internal/ociref"
@@ -60,6 +62,7 @@ type CLI struct {
 	Exec    ExecCommand    `cmd:"" help:"Execute a command in a cleanroom backend"`
 	Console ConsoleCommand `cmd:"" help:"Attach an interactive console to a cleanroom execution"`
 	Serve   ServeCommand   `cmd:"" help:"Run the cleanroom control-plane server"`
+	TLS     TLSCommand     `cmd:"" help:"Manage TLS certificates for mTLS"`
 	Doctor  DoctorCommand  `cmd:"" help:"Run environment and backend diagnostics"`
 	Status  StatusCommand  `cmd:"" help:"Inspect run artifacts"`
 }
@@ -110,7 +113,10 @@ type ExecCommand struct {
 	LogLevel    string `help:"Client log level (debug|info|warn|error)"`
 	Backend     string `help:"Execution backend (defaults to runtime config or firecracker)"`
 	SandboxID   string `help:"Reuse an existing sandbox instead of creating a new one"`
-	Remove bool `name:"rm" help:"Terminate a newly created sandbox after command completion"`
+	Remove  bool   `name:"rm" help:"Terminate a newly created sandbox after command completion"`
+	TLSCert string `help:"Path to TLS client certificate (auto-discovered from XDG config for https)"`
+	TLSKey  string `help:"Path to TLS client private key (auto-discovered from XDG config for https)"`
+	TLSCA   string `help:"Path to CA certificate for server verification (auto-discovered from XDG config for https)"`
 
 	LaunchSeconds int64 `help:"VM boot/guest-agent readiness timeout in seconds"`
 
@@ -123,7 +129,10 @@ type ConsoleCommand struct {
 	LogLevel    string `help:"Client log level (debug|info|warn|error)"`
 	Backend     string `help:"Execution backend (defaults to runtime config or firecracker)"`
 	SandboxID   string `help:"Reuse an existing sandbox instead of creating a new one"`
-	Remove      bool   `name:"rm" help:"Terminate a newly created sandbox after console exits"`
+	Remove  bool   `name:"rm" help:"Terminate a newly created sandbox after console exits"`
+	TLSCert string `help:"Path to TLS client certificate (auto-discovered from XDG config for https)"`
+	TLSKey  string `help:"Path to TLS client private key (auto-discovered from XDG config for https)"`
+	TLSCA   string `help:"Path to CA certificate for server verification (auto-discovered from XDG config for https)"`
 
 	LaunchSeconds int64 `help:"VM boot/guest-agent readiness timeout in seconds"`
 
@@ -133,6 +142,25 @@ type ConsoleCommand struct {
 type ServeCommand struct {
 	Listen   string `help:"Listen endpoint for control API (defaults to runtime endpoint; supports tsnet://hostname[:port] and tssvc://service[:local-port])"`
 	LogLevel string `help:"Server log level (debug|info|warn|error)"`
+	TLSCert  string `help:"Path to TLS server certificate (auto-discovered from XDG config for https)"`
+	TLSKey   string `help:"Path to TLS server private key (auto-discovered from XDG config for https)"`
+	TLSCA    string `help:"Path to CA certificate for client verification (auto-discovered from XDG config for https)"`
+}
+
+type TLSCommand struct {
+	Init  TLSInitCommand  `cmd:"" help:"Generate CA and server/client certificates"`
+	Issue TLSIssueCommand `cmd:"" help:"Issue an additional certificate signed by the CA"`
+}
+
+type TLSInitCommand struct {
+	Dir   string `help:"Output directory for TLS material (default: $XDG_CONFIG_HOME/cleanroom/tls)"`
+	Force bool   `help:"Overwrite existing CA and certificates"`
+}
+
+type TLSIssueCommand struct {
+	Name string   `arg:"" required:"" help:"Common name for the certificate"`
+	SAN  []string `help:"Subject alternative names (DNS names or IP addresses)"`
+	Dir  string   `help:"TLS directory containing CA material (default: $XDG_CONFIG_HOME/cleanroom/tls)"`
 }
 
 type StatusCommand struct {
@@ -447,7 +475,14 @@ func (e *ExecCommand) Run(ctx *runtimeContext) error {
 		"sandbox_id", strings.TrimSpace(e.SandboxID),
 		"command_argc", len(e.Command),
 	)
-	client := controlclient.New(ep)
+	client, err := controlclient.New(ep, controlclient.WithTLS(tlsconfig.Options{
+		CertPath: e.TLSCert,
+		KeyPath:  e.TLSKey,
+		CAPath:   e.TLSCA,
+	}))
+	if err != nil {
+		return fmt.Errorf("configure TLS: %w", err)
+	}
 	sandboxID := strings.TrimSpace(e.SandboxID)
 	createdSandbox := false
 	if sandboxID == "" {
@@ -657,7 +692,14 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) error {
 		"command_argc", len(command),
 	)
 
-	client := controlclient.New(ep)
+	client, err := controlclient.New(ep, controlclient.WithTLS(tlsconfig.Options{
+		CertPath: c.TLSCert,
+		KeyPath:  c.TLSKey,
+		CAPath:   c.TLSCA,
+	}))
+	if err != nil {
+		return fmt.Errorf("configure TLS: %w", err)
+	}
 	sandboxID := strings.TrimSpace(c.SandboxID)
 	createdSandbox := false
 	if sandboxID == "" {
@@ -850,6 +892,58 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) error {
 	return nil
 }
 
+func (c *TLSInitCommand) Run(ctx *runtimeContext) error {
+	dir := c.Dir
+	if dir == "" {
+		d, err := paths.TLSDir()
+		if err != nil {
+			return err
+		}
+		dir = d
+	}
+	if err := tlsbootstrap.Init(dir, c.Force); err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stderr, "TLS material written to %s\n", dir)
+	return nil
+}
+
+func (c *TLSIssueCommand) Run(ctx *runtimeContext) error {
+	dir := c.Dir
+	if dir == "" {
+		d, err := paths.TLSDir()
+		if err != nil {
+			return err
+		}
+		dir = d
+	}
+
+	caCertPEM, err := os.ReadFile(filepath.Join(dir, "ca.pem"))
+	if err != nil {
+		return fmt.Errorf("read CA certificate: %w (run 'cleanroom tls init' first)", err)
+	}
+	caKeyPEM, err := os.ReadFile(filepath.Join(dir, "ca.key"))
+	if err != nil {
+		return fmt.Errorf("read CA key: %w", err)
+	}
+
+	kp, err := tlsbootstrap.IssueCert(caCertPEM, caKeyPEM, c.Name, c.SAN)
+	if err != nil {
+		return err
+	}
+
+	certPath := filepath.Join(dir, c.Name+".pem")
+	keyPath := filepath.Join(dir, c.Name+".key")
+	if err := os.WriteFile(certPath, kp.CertPEM, 0o644); err != nil {
+		return err
+	}
+	if err := os.WriteFile(keyPath, kp.KeyPEM, 0o600); err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stderr, "Certificate written to %s\n", certPath)
+	return nil
+}
+
 func (s *ServeCommand) Run(ctx *runtimeContext) error {
 	logger, err := newLogger(s.LogLevel, "server")
 	if err != nil {
@@ -876,6 +970,15 @@ func (s *ServeCommand) Run(ctx *runtimeContext) error {
 		fcAdapter.GatewayRegistry = gwRegistry
 	}
 
+	var serverTLS *controlserver.TLSOptions
+	if ep.Scheme == "https" {
+		serverTLS = &controlserver.TLSOptions{
+			CertPath: s.TLSCert,
+			KeyPath:  s.TLSKey,
+			CAPath:   s.TLSCA,
+		}
+	}
+
 	service := &controlservice.Service{
 		Loader:   ctx.Loader,
 		Config:   ctx.Config,
@@ -886,7 +989,7 @@ func (s *ServeCommand) Run(ctx *runtimeContext) error {
 
 	runCtx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
-	runErr := controlserver.Serve(runCtx, ep, server.Handler(), logger)
+	runErr := controlserver.Serve(runCtx, ep, server.Handler(), logger, serverTLS)
 	gwStopCtx, gwStopCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer gwStopCancel()
 	_ = gwServer.Stop(gwStopCtx)

--- a/internal/cli/console_integration_test.go
+++ b/internal/cli/console_integration_test.go
@@ -260,7 +260,10 @@ func TestConsoleIntegrationReuseSandboxSkipsPolicyCompile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve endpoint: %v", err)
 	}
-	client := controlclient.New(ep)
+	client, err := controlclient.New(ep)
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
 	compiled, _, err := integrationLoader{}.LoadAndCompile(t.TempDir())
 	if err != nil {
 		t.Fatalf("load policy: %v", err)

--- a/internal/cli/exec_integration_test.go
+++ b/internal/cli/exec_integration_test.go
@@ -395,7 +395,10 @@ func TestExecIntegrationSecondInterruptTerminatesSandbox(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve endpoint: %v", err)
 	}
-	client := controlclient.New(ep)
+	client, err := controlclient.New(ep)
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
 	getResp, err := client.GetSandbox(context.Background(), &cleanroomv1.GetSandboxRequest{
 		SandboxId: sandboxID,
 	})
@@ -483,7 +486,10 @@ func TestExecIntegrationDefaultLeavesSandboxRunning(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve endpoint: %v", err)
 	}
-	client := controlclient.New(ep)
+	client, err := controlclient.New(ep)
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
 	getResp, err := client.GetSandbox(context.Background(), &cleanroomv1.GetSandboxRequest{SandboxId: sandboxID})
 	if err != nil {
 		t.Fatalf("GetSandbox returned error: %v", err)
@@ -521,7 +527,10 @@ func TestExecIntegrationRemoveTerminatesSandbox(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve endpoint: %v", err)
 	}
-	client := controlclient.New(ep)
+	client, err := controlclient.New(ep)
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
 	getResp, err := client.GetSandbox(context.Background(), &cleanroomv1.GetSandboxRequest{SandboxId: sandboxID})
 	if err != nil {
 		t.Fatalf("GetSandbox returned error: %v", err)
@@ -537,7 +546,10 @@ func TestExecIntegrationReuseSandboxSkipsPolicyCompile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve endpoint: %v", err)
 	}
-	client := controlclient.New(ep)
+	client, err := controlclient.New(ep)
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
 
 	compiled, _, err := integrationLoader{}.LoadAndCompile(t.TempDir())
 	if err != nil {

--- a/internal/controlclient/client.go
+++ b/internal/controlclient/client.go
@@ -68,7 +68,10 @@ func buildTransport(ep endpoint.Endpoint, baseURL string, tlsOpts tlsconfig.Opti
 		if tlsCfg == nil {
 			tlsCfg = &tls.Config{MinVersion: tls.VersionTLS13}
 		}
-		return &http.Transport{TLSClientConfig: tlsCfg}, nil
+		return &http.Transport{
+			Proxy:           http.ProxyFromEnvironment,
+			TLSClientConfig: tlsCfg,
+		}, nil
 	}
 
 	if ep.Scheme == "unix" {

--- a/internal/controlclient/client.go
+++ b/internal/controlclient/client.go
@@ -69,8 +69,9 @@ func buildTransport(ep endpoint.Endpoint, baseURL string, tlsOpts tlsconfig.Opti
 			tlsCfg = &tls.Config{MinVersion: tls.VersionTLS13}
 		}
 		return &http.Transport{
-			Proxy:           http.ProxyFromEnvironment,
-			TLSClientConfig: tlsCfg,
+			Proxy:              http.ProxyFromEnvironment,
+			TLSClientConfig:    tlsCfg,
+			ForceAttemptHTTP2:  true,
 		}, nil
 	}
 

--- a/internal/controlclient/client.go
+++ b/internal/controlclient/client.go
@@ -12,6 +12,7 @@ import (
 	"github.com/buildkite/cleanroom/internal/endpoint"
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
 	"github.com/buildkite/cleanroom/internal/gen/cleanroom/v1/cleanroomv1connect"
+	"github.com/buildkite/cleanroom/internal/tlsconfig"
 	"golang.org/x/net/http2"
 )
 
@@ -22,21 +23,52 @@ type Client struct {
 	executionClient cleanroomv1connect.ExecutionServiceClient
 }
 
-func New(ep endpoint.Endpoint) *Client {
+// Option configures the client.
+type Option func(*options)
+
+type options struct {
+	tlsOpts tlsconfig.Options
+}
+
+// WithTLS configures TLS options for the client.
+func WithTLS(opts tlsconfig.Options) Option {
+	return func(o *options) {
+		o.tlsOpts = opts
+	}
+}
+
+func New(ep endpoint.Endpoint, opts ...Option) (*Client, error) {
+	var o options
+	for _, opt := range opts {
+		opt(&o)
+	}
+
 	baseURL := strings.TrimRight(ep.BaseURL, "/")
-	httpClient := &http.Client{Transport: buildTransport(ep, baseURL)}
+	transport, err := buildTransport(ep, baseURL, o.tlsOpts)
+	if err != nil {
+		return nil, err
+	}
+	httpClient := &http.Client{Transport: transport}
 	return &Client{
 		httpClient:      httpClient,
 		baseURL:         baseURL,
 		sandboxClient:   cleanroomv1connect.NewSandboxServiceClient(httpClient, baseURL),
 		executionClient: cleanroomv1connect.NewExecutionServiceClient(httpClient, baseURL),
-	}
+	}, nil
 }
 
-func buildTransport(ep endpoint.Endpoint, baseURL string) http.RoundTripper {
+func buildTransport(ep endpoint.Endpoint, baseURL string, tlsOpts tlsconfig.Options) (http.RoundTripper, error) {
 	dialer := &net.Dialer{}
+
 	if ep.Scheme == "https" {
-		return &http.Transport{}
+		tlsCfg, err := tlsconfig.ResolveClient(tlsOpts)
+		if err != nil {
+			return nil, err
+		}
+		if tlsCfg == nil {
+			tlsCfg = &tls.Config{MinVersion: tls.VersionTLS13}
+		}
+		return &http.Transport{TLSClientConfig: tlsCfg}, nil
 	}
 
 	if ep.Scheme == "unix" {
@@ -45,12 +77,12 @@ func buildTransport(ep endpoint.Endpoint, baseURL string) http.RoundTripper {
 			DialTLSContext: func(ctx context.Context, _, _ string, _ *tls.Config) (net.Conn, error) {
 				return dialer.DialContext(ctx, "unix", ep.Address)
 			},
-		}
+		}, nil
 	}
 
 	parsed, err := url.Parse(baseURL)
 	if err != nil || parsed.Host == "" {
-		return &http.Transport{}
+		return &http.Transport{}, nil
 	}
 	host := parsed.Host
 	return &http2.Transport{
@@ -58,7 +90,7 @@ func buildTransport(ep endpoint.Endpoint, baseURL string) http.RoundTripper {
 		DialTLSContext: func(ctx context.Context, _, _ string, _ *tls.Config) (net.Conn, error) {
 			return dialer.DialContext(ctx, "tcp", host)
 		},
-	}
+	}, nil
 }
 
 func (c *Client) CreateSandbox(ctx context.Context, req *cleanroomv1.CreateSandboxRequest) (*cleanroomv1.CreateSandboxResponse, error) {

--- a/internal/controlserver/mtls_test.go
+++ b/internal/controlserver/mtls_test.go
@@ -1,0 +1,266 @@
+package controlserver
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/buildkite/cleanroom/internal/endpoint"
+	"github.com/buildkite/cleanroom/internal/tlsbootstrap"
+)
+
+func TestHTTPSListenerWithMTLS(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := tlsbootstrap.Init(dir, false); err != nil {
+		t.Fatalf("tls init: %v", err)
+	}
+
+	ep := endpoint.Endpoint{
+		Scheme:  "https",
+		Address: "127.0.0.1:0",
+		BaseURL: "https://127.0.0.1:0",
+	}
+
+	ln, _, err := listen(ep, nil, &TLSOptions{
+		CertPath: dir + "/server.pem",
+		KeyPath:  dir + "/server.key",
+		CAPath:   dir + "/ca.pem",
+	})
+	if err != nil {
+		t.Fatalf("listen https: %v", err)
+	}
+	defer ln.Close()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := &http.Server{Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+	go func() { _ = srv.Serve(ln) }()
+	defer srv.Close()
+
+	addr := ln.Addr().String()
+
+	t.Run("valid client cert succeeds", func(t *testing.T) {
+		client := mtlsHTTPClient(t, dir, dir+"/client.pem", dir+"/client.key")
+		resp, err := client.Get(fmt.Sprintf("https://%s/healthz", addr))
+		if err != nil {
+			t.Fatalf("request with valid client cert: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("no client cert rejected", func(t *testing.T) {
+		client := tlsHTTPClientNoClientCert(t, dir)
+		_, err := client.Get(fmt.Sprintf("https://%s/healthz", addr))
+		if err == nil {
+			t.Fatal("expected TLS handshake failure without client cert")
+		}
+	})
+
+	t.Run("wrong CA rejected", func(t *testing.T) {
+		wrongDir := t.TempDir()
+		if err := tlsbootstrap.Init(wrongDir, false); err != nil {
+			t.Fatalf("tls init (wrong CA): %v", err)
+		}
+		client := mtlsHTTPClient(t, wrongDir, wrongDir+"/client.pem", wrongDir+"/client.key")
+		_, err := client.Get(fmt.Sprintf("https://%s/healthz", addr))
+		if err == nil {
+			t.Fatal("expected TLS handshake failure with wrong CA")
+		}
+	})
+}
+
+func TestHTTPSListenerWithoutCA(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := tlsbootstrap.Init(dir, false); err != nil {
+		t.Fatalf("tls init: %v", err)
+	}
+
+	ep := endpoint.Endpoint{
+		Scheme:  "https",
+		Address: "127.0.0.1:0",
+		BaseURL: "https://127.0.0.1:0",
+	}
+
+	// No CAPath — server TLS without mTLS (no client cert required).
+	ln, _, err := listen(ep, nil, &TLSOptions{
+		CertPath: dir + "/server.pem",
+		KeyPath:  dir + "/server.key",
+	})
+	if err != nil {
+		t.Fatalf("listen https: %v", err)
+	}
+	defer ln.Close()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := &http.Server{Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+	go func() { _ = srv.Serve(ln) }()
+	defer srv.Close()
+
+	addr := ln.Addr().String()
+
+	client := tlsHTTPClientNoClientCert(t, dir)
+	resp, err := client.Get(fmt.Sprintf("https://%s/healthz", addr))
+	if err != nil {
+		t.Fatalf("request without client cert (non-mTLS server): %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestHTTPSListenerFailsWithoutCerts(t *testing.T) {
+	t.Parallel()
+
+	ep := endpoint.Endpoint{
+		Scheme:  "https",
+		Address: "127.0.0.1:0",
+		BaseURL: "https://127.0.0.1:0",
+	}
+
+	_, _, err := listen(ep, nil, &TLSOptions{})
+	if err == nil {
+		t.Fatal("expected error when no TLS certs are available")
+	}
+}
+
+func TestServeHTTPSEndToEnd(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := tlsbootstrap.Init(dir, false); err != nil {
+		t.Fatalf("tls init: %v", err)
+	}
+
+	ep := endpoint.Endpoint{
+		Scheme:  "https",
+		Address: "127.0.0.1:0",
+		BaseURL: "https://127.0.0.1:0",
+	}
+
+	ln, _, err := listen(ep, nil, &TLSOptions{
+		CertPath: dir + "/server.pem",
+		KeyPath:  dir + "/server.key",
+		CAPath:   dir + "/ca.pem",
+	})
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	handler := New(nil, nil).Handler()
+	srv := &http.Server{Handler: handler, ReadHeaderTimeout: 5 * time.Second}
+	go func() { _ = srv.Serve(ln) }()
+	defer srv.Close()
+
+	addr := ln.Addr().String()
+
+	client := mtlsHTTPClient(t, dir, dir+"/client.pem", dir+"/client.key")
+	resp, err := client.Get(fmt.Sprintf("https://%s/healthz", addr))
+	if err != nil {
+		t.Fatalf("healthz via mTLS: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestServeAcceptsTLSOptions(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := tlsbootstrap.Init(dir, false); err != nil {
+		t.Fatalf("tls init: %v", err)
+	}
+
+	ep := endpoint.Endpoint{
+		Scheme:  "https",
+		Address: "127.0.0.1:0",
+		BaseURL: "https://127.0.0.1:0",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	handler := New(nil, nil).Handler()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- Serve(ctx, ep, handler, nil, &TLSOptions{
+			CertPath: dir + "/server.pem",
+			KeyPath:  dir + "/server.key",
+			CAPath:   dir + "/ca.pem",
+		})
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	if err := <-errCh; err != nil {
+		t.Fatalf("Serve returned error: %v", err)
+	}
+}
+
+func mtlsHTTPClient(t *testing.T, caDir, certPath, keyPath string) *http.Client {
+	t.Helper()
+
+	caPool := testLoadCAPool(t, caDir+"/ca.pem")
+	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		t.Fatalf("load client cert: %v", err)
+	}
+
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs:      caPool,
+				Certificates: []tls.Certificate{cert},
+				MinVersion:   tls.VersionTLS13,
+			},
+		},
+	}
+}
+
+func tlsHTTPClientNoClientCert(t *testing.T, caDir string) *http.Client {
+	t.Helper()
+
+	caPool := testLoadCAPool(t, caDir+"/ca.pem")
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs:    caPool,
+				MinVersion: tls.VersionTLS13,
+			},
+		},
+	}
+}
+
+func testLoadCAPool(t *testing.T, path string) *x509.CertPool {
+	t.Helper()
+	caPEM, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read CA: %v", err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caPEM) {
+		t.Fatal("no valid certs in CA file")
+	}
+	return pool
+}

--- a/internal/controlserver/server.go
+++ b/internal/controlserver/server.go
@@ -598,6 +598,9 @@ func listen(ep endpoint.Endpoint, logger *log.Logger, tlsOpts *TLSOptions) (net.
 		if tlsCfg == nil {
 			return nil, nil, errors.New("https listen endpoint requires TLS certificates (run 'cleanroom tls init' or provide --tls-cert/--tls-key)")
 		}
+		if tlsCfg.ClientAuth != tls.RequireAndVerifyClientCert && logger != nil {
+			logger.Warn("HTTPS listener has no client CA configured; client certificate authentication is disabled")
+		}
 		addr := ep.Address
 		for _, prefix := range []string{"https://", "http://"} {
 			addr = strings.TrimPrefix(addr, prefix)

--- a/internal/controlserver/server_test.go
+++ b/internal/controlserver/server_test.go
@@ -93,7 +93,7 @@ func TestListenTSNetUsesStateDirAndCleanup(t *testing.T) {
 		TSNetHostname: "cleanroom",
 	}
 
-	ln, cleanup, err := listen(ep, nil)
+	ln, cleanup, err := listen(ep, nil, nil)
 	if err != nil {
 		t.Fatalf("listen tsnet: %v", err)
 	}
@@ -140,7 +140,7 @@ func TestListenTSNetClosesServerOnListenError(t *testing.T) {
 		Scheme:        "tsnet",
 		Address:       ":7777",
 		TSNetHostname: "cleanroom",
-	}, nil)
+	}, nil, nil)
 	if err == nil {
 		t.Fatal("expected listen error")
 	}
@@ -228,7 +228,7 @@ func TestListenTailscaleServiceConfiguresServeAndAdvertise(t *testing.T) {
 		TSServiceName: "svc:cleanroom",
 	}
 
-	ln, cleanup, err := listen(ep, nil)
+	ln, cleanup, err := listen(ep, nil, nil)
 	if err != nil {
 		t.Fatalf("listen tailscale service: %v", err)
 	}
@@ -308,7 +308,7 @@ func TestListenTailscaleServiceSkipsAdvertiseWhenAlreadyPresent(t *testing.T) {
 		Scheme:        "tssvc",
 		Address:       "127.0.0.1:0",
 		TSServiceName: "svc:cleanroom",
-	}, nil)
+	}, nil, nil)
 	if err != nil {
 		t.Fatalf("listen tailscale service: %v", err)
 	}
@@ -338,7 +338,7 @@ func TestListenTailscaleServiceReturnsErrorWhenStatusFails(t *testing.T) {
 		Scheme:        "tssvc",
 		Address:       "127.0.0.1:0",
 		TSServiceName: "svc:cleanroom",
-	}, nil)
+	}, nil, nil)
 	if err == nil {
 		t.Fatal("expected listen to fail when tailscale status is unavailable")
 	}
@@ -380,7 +380,7 @@ func TestListenTSNetWiresLogger(t *testing.T) {
 		Scheme:        "tsnet",
 		Address:       ":7777",
 		TSNetHostname: "cleanroom",
-	}, logger)
+	}, logger, nil)
 	if err != nil {
 		t.Fatalf("listen tsnet: %v", err)
 	}

--- a/internal/paths/state_dir.go
+++ b/internal/paths/state_dir.go
@@ -40,3 +40,18 @@ func TSNetStateDir() (string, error) {
 	}
 	return filepath.Join(base, "tsnet"), nil
 }
+
+// TLSDir returns the default directory for cleanroom TLS material.
+// Uses $XDG_CONFIG_HOME/cleanroom/tls or ~/.config/cleanroom/tls.
+func TLSDir() (string, error) {
+	configHome := strings.TrimSpace(os.Getenv("XDG_CONFIG_HOME"))
+	if configHome != "" {
+		return filepath.Join(configHome, "cleanroom", "tls"), nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".config", "cleanroom", "tls"), nil
+}

--- a/internal/tlsbootstrap/tlsbootstrap.go
+++ b/internal/tlsbootstrap/tlsbootstrap.go
@@ -129,7 +129,11 @@ func Init(dir string, force bool) error {
 		return err
 	}
 
-	server, err := IssueCert(ca.CertPEM, ca.KeyPEM, "cleanroom-server", []string{"localhost", "127.0.0.1", "::1"})
+	serverSANs := []string{"localhost", "127.0.0.1", "::1"}
+	if hostname, err := os.Hostname(); err == nil && hostname != "" && hostname != "localhost" {
+		serverSANs = append(serverSANs, hostname)
+	}
+	server, err := IssueCert(ca.CertPEM, ca.KeyPEM, "cleanroom-server", serverSANs)
 	if err != nil {
 		return fmt.Errorf("issue server certificate: %w", err)
 	}

--- a/internal/tlsbootstrap/tlsbootstrap.go
+++ b/internal/tlsbootstrap/tlsbootstrap.go
@@ -83,6 +83,13 @@ func IssueCert(caCertPEM, caKeyPEM []byte, name string, sans []string) (*KeyPair
 	}
 
 	dnsNames, ips := classifySANs(sans)
+	if len(dnsNames) == 0 && len(ips) == 0 {
+		if ip := net.ParseIP(name); ip != nil {
+			ips = append(ips, ip)
+		} else {
+			dnsNames = append(dnsNames, name)
+		}
+	}
 
 	now := time.Now()
 	template := &x509.Certificate{

--- a/internal/tlsbootstrap/tlsbootstrap.go
+++ b/internal/tlsbootstrap/tlsbootstrap.go
@@ -1,0 +1,208 @@
+// Package tlsbootstrap generates CA and leaf certificates for cleanroom mTLS.
+package tlsbootstrap
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	caCommonName = "cleanroom-ca"
+	validity     = 365 * 24 * time.Hour
+)
+
+// KeyPair holds PEM-encoded certificate and private key material.
+type KeyPair struct {
+	CertPEM []byte
+	KeyPEM  []byte
+}
+
+// GenerateCA creates a self-signed ECDSA P-256 CA certificate.
+func GenerateCA() (*KeyPair, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generate CA key: %w", err)
+	}
+
+	serial, err := randomSerial()
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now()
+	template := &x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: caCommonName},
+		NotBefore:             now,
+		NotAfter:              now.Add(validity),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		MaxPathLen:            0,
+		MaxPathLenZero:        true,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		return nil, fmt.Errorf("create CA certificate: %w", err)
+	}
+
+	return &KeyPair{
+		CertPEM: encodeCertPEM(certDER),
+		KeyPEM:  encodeKeyPEM(key),
+	}, nil
+}
+
+// IssueCert creates a leaf certificate signed by the given CA.
+// The name is used as the CommonName. SANs may include DNS names and IP
+// addresses (parsed automatically).
+func IssueCert(caCertPEM, caKeyPEM []byte, name string, sans []string) (*KeyPair, error) {
+	caCert, caKey, err := parseCA(caCertPEM, caKeyPEM)
+	if err != nil {
+		return nil, err
+	}
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generate leaf key: %w", err)
+	}
+
+	serial, err := randomSerial()
+	if err != nil {
+		return nil, err
+	}
+
+	dnsNames, ips := classifySANs(sans)
+
+	now := time.Now()
+	template := &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: name},
+		NotBefore:    now,
+		NotAfter:     now.Add(validity),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		DNSNames:     dnsNames,
+		IPAddresses:  ips,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, caCert, &key.PublicKey, caKey)
+	if err != nil {
+		return nil, fmt.Errorf("create leaf certificate: %w", err)
+	}
+
+	return &KeyPair{
+		CertPEM: encodeCertPEM(certDER),
+		KeyPEM:  encodeKeyPEM(key),
+	}, nil
+}
+
+// Init generates a full set of TLS material (CA, server cert, client cert) and
+// writes it to dir. Returns an error if the CA already exists unless force is true.
+func Init(dir string, force bool) error {
+	caPath := filepath.Join(dir, "ca.pem")
+	if !force {
+		if _, err := os.Stat(caPath); err == nil {
+			return fmt.Errorf("CA already exists at %s (use --force to overwrite)", caPath)
+		}
+	}
+
+	ca, err := GenerateCA()
+	if err != nil {
+		return err
+	}
+
+	server, err := IssueCert(ca.CertPEM, ca.KeyPEM, "cleanroom-server", []string{"localhost", "127.0.0.1", "::1"})
+	if err != nil {
+		return fmt.Errorf("issue server certificate: %w", err)
+	}
+
+	client, err := IssueCert(ca.CertPEM, ca.KeyPEM, "cleanroom-client", nil)
+	if err != nil {
+		return fmt.Errorf("issue client certificate: %w", err)
+	}
+
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create TLS directory: %w", err)
+	}
+
+	files := map[string][]byte{
+		"ca.pem":     ca.CertPEM,
+		"ca.key":     ca.KeyPEM,
+		"server.pem": server.CertPEM,
+		"server.key": server.KeyPEM,
+		"client.pem": client.CertPEM,
+		"client.key": client.KeyPEM,
+	}
+	for name, data := range files {
+		perm := os.FileMode(0o644)
+		if filepath.Ext(name) == ".key" {
+			perm = 0o600
+		}
+		if err := os.WriteFile(filepath.Join(dir, name), data, perm); err != nil {
+			return fmt.Errorf("write %s: %w", name, err)
+		}
+	}
+
+	return nil
+}
+
+func parseCA(certPEM, keyPEM []byte) (*x509.Certificate, *ecdsa.PrivateKey, error) {
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		return nil, nil, fmt.Errorf("decode CA certificate PEM")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse CA certificate: %w", err)
+	}
+
+	keyBlock, _ := pem.Decode(keyPEM)
+	if keyBlock == nil {
+		return nil, nil, fmt.Errorf("decode CA key PEM")
+	}
+	rawKey, err := x509.ParseECPrivateKey(keyBlock.Bytes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse CA key: %w", err)
+	}
+
+	return cert, rawKey, nil
+}
+
+func classifySANs(sans []string) (dnsNames []string, ips []net.IP) {
+	for _, s := range sans {
+		if ip := net.ParseIP(s); ip != nil {
+			ips = append(ips, ip)
+		} else {
+			dnsNames = append(dnsNames, s)
+		}
+	}
+	return dnsNames, ips
+}
+
+func randomSerial() (*big.Int, error) {
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, fmt.Errorf("generate serial number: %w", err)
+	}
+	return serial, nil
+}
+
+func encodeCertPEM(der []byte) []byte {
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+func encodeKeyPEM(key *ecdsa.PrivateKey) []byte {
+	der, _ := x509.MarshalECPrivateKey(key)
+	return pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: der})
+}

--- a/internal/tlsbootstrap/tlsbootstrap_test.go
+++ b/internal/tlsbootstrap/tlsbootstrap_test.go
@@ -1,0 +1,350 @@
+package tlsbootstrap
+
+import (
+	"crypto/ecdsa"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGenerateCA(t *testing.T) {
+	t.Parallel()
+
+	ca, err := GenerateCA()
+	if err != nil {
+		t.Fatalf("GenerateCA: %v", err)
+	}
+
+	cert := parseCert(t, ca.CertPEM)
+	if !cert.IsCA {
+		t.Fatal("expected CA certificate")
+	}
+	if cert.Subject.CommonName != caCommonName {
+		t.Fatalf("expected CN %q, got %q", caCommonName, cert.Subject.CommonName)
+	}
+	if cert.KeyUsage&x509.KeyUsageCertSign == 0 {
+		t.Fatal("expected CertSign key usage")
+	}
+
+	parseKey(t, ca.KeyPEM)
+}
+
+func TestIssueCert(t *testing.T) {
+	t.Parallel()
+
+	ca, err := GenerateCA()
+	if err != nil {
+		t.Fatalf("GenerateCA: %v", err)
+	}
+
+	leaf, err := IssueCert(ca.CertPEM, ca.KeyPEM, "test-server", []string{"example.com", "127.0.0.1", "::1"})
+	if err != nil {
+		t.Fatalf("IssueCert: %v", err)
+	}
+
+	cert := parseCert(t, leaf.CertPEM)
+	if cert.IsCA {
+		t.Fatal("leaf should not be CA")
+	}
+	if cert.Subject.CommonName != "test-server" {
+		t.Fatalf("expected CN %q, got %q", "test-server", cert.Subject.CommonName)
+	}
+
+	if len(cert.DNSNames) != 1 || cert.DNSNames[0] != "example.com" {
+		t.Fatalf("expected DNS SAN [example.com], got %v", cert.DNSNames)
+	}
+	expectedIPs := []string{"127.0.0.1", "::1"}
+	if len(cert.IPAddresses) != len(expectedIPs) {
+		t.Fatalf("expected %d IP SANs, got %d", len(expectedIPs), len(cert.IPAddresses))
+	}
+	for i, expected := range expectedIPs {
+		if !cert.IPAddresses[i].Equal(net.ParseIP(expected)) {
+			t.Fatalf("expected IP SAN %s, got %s", expected, cert.IPAddresses[i])
+		}
+	}
+
+	hasServerAuth := false
+	hasClientAuth := false
+	for _, usage := range cert.ExtKeyUsage {
+		if usage == x509.ExtKeyUsageServerAuth {
+			hasServerAuth = true
+		}
+		if usage == x509.ExtKeyUsageClientAuth {
+			hasClientAuth = true
+		}
+	}
+	if !hasServerAuth || !hasClientAuth {
+		t.Fatalf("expected both ServerAuth and ClientAuth EKU, got %v", cert.ExtKeyUsage)
+	}
+}
+
+func TestIssueCertVerifiesAgainstCA(t *testing.T) {
+	t.Parallel()
+
+	ca, err := GenerateCA()
+	if err != nil {
+		t.Fatalf("GenerateCA: %v", err)
+	}
+
+	leaf, err := IssueCert(ca.CertPEM, ca.KeyPEM, "test-leaf", []string{"localhost"})
+	if err != nil {
+		t.Fatalf("IssueCert: %v", err)
+	}
+
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(ca.CertPEM) {
+		t.Fatal("failed to add CA to pool")
+	}
+
+	cert := parseCert(t, leaf.CertPEM)
+	if _, err := cert.Verify(x509.VerifyOptions{
+		Roots:     pool,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}); err != nil {
+		t.Fatalf("leaf cert failed verification against CA: %v", err)
+	}
+}
+
+func TestIssueCertRejectsWrongCA(t *testing.T) {
+	t.Parallel()
+
+	ca1, err := GenerateCA()
+	if err != nil {
+		t.Fatalf("GenerateCA (1): %v", err)
+	}
+	ca2, err := GenerateCA()
+	if err != nil {
+		t.Fatalf("GenerateCA (2): %v", err)
+	}
+
+	leaf, err := IssueCert(ca1.CertPEM, ca1.KeyPEM, "test-leaf", []string{"localhost"})
+	if err != nil {
+		t.Fatalf("IssueCert: %v", err)
+	}
+
+	pool := x509.NewCertPool()
+	pool.AppendCertsFromPEM(ca2.CertPEM)
+
+	cert := parseCert(t, leaf.CertPEM)
+	if _, err := cert.Verify(x509.VerifyOptions{
+		Roots:     pool,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}); err == nil {
+		t.Fatal("expected verification to fail with wrong CA")
+	}
+}
+
+func TestMutualTLSHandshake(t *testing.T) {
+	t.Parallel()
+
+	ca, err := GenerateCA()
+	if err != nil {
+		t.Fatalf("GenerateCA: %v", err)
+	}
+
+	serverKP, err := IssueCert(ca.CertPEM, ca.KeyPEM, "server", []string{"localhost", "127.0.0.1"})
+	if err != nil {
+		t.Fatalf("issue server cert: %v", err)
+	}
+
+	clientKP, err := IssueCert(ca.CertPEM, ca.KeyPEM, "client", nil)
+	if err != nil {
+		t.Fatalf("issue client cert: %v", err)
+	}
+
+	caPool := x509.NewCertPool()
+	caPool.AppendCertsFromPEM(ca.CertPEM)
+
+	serverCert, err := tls.X509KeyPair(serverKP.CertPEM, serverKP.KeyPEM)
+	if err != nil {
+		t.Fatalf("load server keypair: %v", err)
+	}
+
+	serverTLS := &tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+		ClientCAs:    caPool,
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		MinVersion:   tls.VersionTLS13,
+	}
+
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", serverTLS)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	done := make(chan error, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			done <- err
+			return
+		}
+		defer conn.Close()
+		tlsConn := conn.(*tls.Conn)
+		done <- tlsConn.Handshake()
+	}()
+
+	clientCert, err := tls.X509KeyPair(clientKP.CertPEM, clientKP.KeyPEM)
+	if err != nil {
+		t.Fatalf("load client keypair: %v", err)
+	}
+
+	clientTLS := &tls.Config{
+		Certificates: []tls.Certificate{clientCert},
+		RootCAs:      caPool,
+		MinVersion:   tls.VersionTLS13,
+	}
+
+	conn, err := tls.Dial("tcp", ln.Addr().String(), clientTLS)
+	if err != nil {
+		t.Fatalf("client dial: %v", err)
+	}
+	defer conn.Close()
+
+	if err := <-done; err != nil {
+		t.Fatalf("server handshake: %v", err)
+	}
+}
+
+func TestMutualTLSRejectsNoClientCert(t *testing.T) {
+	t.Parallel()
+
+	ca, err := GenerateCA()
+	if err != nil {
+		t.Fatalf("GenerateCA: %v", err)
+	}
+
+	serverKP, err := IssueCert(ca.CertPEM, ca.KeyPEM, "server", []string{"127.0.0.1"})
+	if err != nil {
+		t.Fatalf("issue server cert: %v", err)
+	}
+
+	caPool := x509.NewCertPool()
+	caPool.AppendCertsFromPEM(ca.CertPEM)
+
+	serverCert, err := tls.X509KeyPair(serverKP.CertPEM, serverKP.KeyPEM)
+	if err != nil {
+		t.Fatalf("load server keypair: %v", err)
+	}
+
+	serverTLS := &tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+		ClientCAs:    caPool,
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		MinVersion:   tls.VersionTLS13,
+	}
+
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", serverTLS)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	done := make(chan error, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			done <- err
+			return
+		}
+		defer conn.Close()
+		tlsConn := conn.(*tls.Conn)
+		done <- tlsConn.Handshake()
+	}()
+
+	clientTLS := &tls.Config{
+		RootCAs:    caPool,
+		MinVersion: tls.VersionTLS13,
+	}
+
+	conn, err := tls.Dial("tcp", ln.Addr().String(), clientTLS)
+	if err != nil {
+		// Connection refused at dial is also acceptable.
+		return
+	}
+	defer conn.Close()
+
+	if err := <-done; err == nil {
+		t.Fatal("expected server handshake to fail without client cert")
+	}
+}
+
+func TestInit(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := Init(dir, false); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	expectedFiles := []string{"ca.pem", "ca.key", "server.pem", "server.key", "client.pem", "client.key"}
+	for _, name := range expectedFiles {
+		path := filepath.Join(dir, name)
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("expected %s to exist: %v", name, err)
+		}
+		if filepath.Ext(name) == ".key" {
+			if info.Mode().Perm() != 0o600 {
+				t.Fatalf("expected %s to have 0600 permissions, got %o", name, info.Mode().Perm())
+			}
+		}
+	}
+}
+
+func TestInitRefusesOverwrite(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := Init(dir, false); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	if err := Init(dir, false); err == nil {
+		t.Fatal("expected Init to refuse overwriting existing CA")
+	}
+}
+
+func TestInitForceOverwrite(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := Init(dir, false); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	if err := Init(dir, true); err != nil {
+		t.Fatalf("Init with force: %v", err)
+	}
+}
+
+func parseCert(t *testing.T, pemData []byte) *x509.Certificate {
+	t.Helper()
+	block, _ := pem.Decode(pemData)
+	if block == nil {
+		t.Fatal("failed to decode PEM")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("parse certificate: %v", err)
+	}
+	return cert
+}
+
+func parseKey(t *testing.T, pemData []byte) *ecdsa.PrivateKey {
+	t.Helper()
+	block, _ := pem.Decode(pemData)
+	if block == nil {
+		t.Fatal("failed to decode key PEM")
+	}
+	key, err := x509.ParseECPrivateKey(block.Bytes)
+	if err != nil {
+		t.Fatalf("parse EC key: %v", err)
+	}
+	return key
+}

--- a/internal/tlsconfig/tlsconfig.go
+++ b/internal/tlsconfig/tlsconfig.go
@@ -74,12 +74,17 @@ func ResolveClient(opts Options) (*tls.Config, error) {
 		tlsCfg.RootCAs = pool
 	}
 
-	if certPath != "" && keyPath != "" {
+	switch {
+	case certPath != "" && keyPath != "":
 		cert, err := tls.LoadX509KeyPair(certPath, keyPath)
 		if err != nil {
 			return nil, fmt.Errorf("load client certificate: %w", err)
 		}
 		tlsCfg.Certificates = []tls.Certificate{cert}
+	case certPath != "":
+		return nil, fmt.Errorf("client TLS cert provided (%s) but key is missing", certPath)
+	case keyPath != "":
+		return nil, fmt.Errorf("client TLS key provided (%s) but cert is missing", keyPath)
 	}
 
 	return tlsCfg, nil

--- a/internal/tlsconfig/tlsconfig.go
+++ b/internal/tlsconfig/tlsconfig.go
@@ -1,0 +1,148 @@
+// Package tlsconfig discovers and loads TLS material for cleanroom mTLS.
+package tlsconfig
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/buildkite/cleanroom/internal/paths"
+)
+
+// Options holds explicit TLS paths from CLI flags or environment variables.
+type Options struct {
+	CertPath string
+	KeyPath  string
+	CAPath   string
+}
+
+// ResolveServer returns a tls.Config for the server side. If no explicit paths
+// are provided, it auto-discovers from the XDG TLS directory.
+// Returns nil if no TLS material is found.
+func ResolveServer(opts Options) (*tls.Config, error) {
+	certPath, keyPath, caPath, err := resolvePaths(opts, "server")
+	if err != nil {
+		return nil, err
+	}
+	if certPath == "" || keyPath == "" {
+		return nil, nil
+	}
+
+	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("load server certificate: %w", err)
+	}
+
+	tlsCfg := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS13,
+	}
+
+	if caPath != "" {
+		pool, err := loadCAPool(caPath)
+		if err != nil {
+			return nil, err
+		}
+		tlsCfg.ClientCAs = pool
+		tlsCfg.ClientAuth = tls.RequireAndVerifyClientCert
+	}
+
+	return tlsCfg, nil
+}
+
+// ResolveClient returns a tls.Config for the client side. If no explicit paths
+// are provided, it auto-discovers from the XDG TLS directory.
+// Returns nil if no TLS material is found.
+func ResolveClient(opts Options) (*tls.Config, error) {
+	certPath, keyPath, caPath, err := resolvePaths(opts, "client")
+	if err != nil {
+		return nil, err
+	}
+
+	tlsCfg := &tls.Config{
+		MinVersion: tls.VersionTLS13,
+	}
+
+	if caPath != "" {
+		pool, err := loadCAPool(caPath)
+		if err != nil {
+			return nil, err
+		}
+		tlsCfg.RootCAs = pool
+	}
+
+	if certPath != "" && keyPath != "" {
+		cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+		if err != nil {
+			return nil, fmt.Errorf("load client certificate: %w", err)
+		}
+		tlsCfg.Certificates = []tls.Certificate{cert}
+	}
+
+	return tlsCfg, nil
+}
+
+func resolvePaths(opts Options, role string) (certPath, keyPath, caPath string, err error) {
+	certPath = firstNonEmpty(opts.CertPath, os.Getenv("CLEANROOM_TLS_CERT"))
+	keyPath = firstNonEmpty(opts.KeyPath, os.Getenv("CLEANROOM_TLS_KEY"))
+	caPath = firstNonEmpty(opts.CAPath, os.Getenv("CLEANROOM_TLS_CA"))
+
+	if certPath != "" && keyPath != "" {
+		return certPath, keyPath, caPath, nil
+	}
+
+	// Auto-discover from XDG TLS directory.
+	tlsDir, err := paths.TLSDir()
+	if err != nil {
+		return "", "", "", nil
+	}
+
+	if certPath == "" {
+		candidate := filepath.Join(tlsDir, role+".pem")
+		if fileExists(candidate) {
+			certPath = candidate
+		}
+	}
+	if keyPath == "" {
+		candidate := filepath.Join(tlsDir, role+".key")
+		if fileExists(candidate) {
+			keyPath = candidate
+		}
+	}
+	if caPath == "" {
+		candidate := filepath.Join(tlsDir, "ca.pem")
+		if fileExists(candidate) {
+			caPath = candidate
+		}
+	}
+
+	return certPath, keyPath, caPath, nil
+}
+
+func loadCAPool(path string) (*x509.CertPool, error) {
+	caPEM, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read CA certificate: %w", err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caPEM) {
+		return nil, fmt.Errorf("no valid certificates found in CA file %s", path)
+	}
+	return pool, nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}

--- a/internal/tlsconfig/tlsconfig.go
+++ b/internal/tlsconfig/tlsconfig.go
@@ -89,32 +89,28 @@ func resolvePaths(opts Options, role string) (certPath, keyPath, caPath string, 
 	keyPath = firstNonEmpty(opts.KeyPath, os.Getenv("CLEANROOM_TLS_KEY"))
 	caPath = firstNonEmpty(opts.CAPath, os.Getenv("CLEANROOM_TLS_CA"))
 
-	if certPath != "" && keyPath != "" {
-		return certPath, keyPath, caPath, nil
-	}
-
-	// Auto-discover from XDG TLS directory.
-	tlsDir, err := paths.TLSDir()
-	if err != nil {
-		return "", "", "", nil
-	}
-
-	if certPath == "" {
-		candidate := filepath.Join(tlsDir, role+".pem")
-		if fileExists(candidate) {
-			certPath = candidate
-		}
-	}
-	if keyPath == "" {
-		candidate := filepath.Join(tlsDir, role+".key")
-		if fileExists(candidate) {
-			keyPath = candidate
-		}
-	}
-	if caPath == "" {
-		candidate := filepath.Join(tlsDir, "ca.pem")
-		if fileExists(candidate) {
-			caPath = candidate
+	// Auto-discover missing paths from XDG TLS directory.
+	if certPath == "" || keyPath == "" || caPath == "" {
+		tlsDir, dirErr := paths.TLSDir()
+		if dirErr == nil {
+			if certPath == "" {
+				candidate := filepath.Join(tlsDir, role+".pem")
+				if fileExists(candidate) {
+					certPath = candidate
+				}
+			}
+			if keyPath == "" {
+				candidate := filepath.Join(tlsDir, role+".key")
+				if fileExists(candidate) {
+					keyPath = candidate
+				}
+			}
+			if caPath == "" {
+				candidate := filepath.Join(tlsDir, "ca.pem")
+				if fileExists(candidate) {
+					caPath = candidate
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

Add mutual TLS authentication between cleanroom CLI client and server for `https://` endpoints.

## Changes

**New packages:**
- `internal/tlsbootstrap` — CA and leaf certificate generation (ECDSA P-256, stdlib only)
- `internal/tlsconfig` — TLS config discovery and loading (flags → env → XDG auto-discovery)

**CLI commands:**
- `cleanroom tls init` — generates CA + server + client certs to `~/.config/cleanroom/tls/`
- `cleanroom tls issue <name>` — issues additional certs signed by the existing CA

**Server (`cleanroom serve`):**
- `https://` listener with TLS, optional mTLS when CA is configured
- HTTP/2 via ALPN negotiation (replaces h2c for TLS endpoints)

**Client (`cleanroom exec`, `cleanroom console`):**
- Auto-discovers client certs from XDG config dir for `https://` endpoints
- `--tls-cert`, `--tls-key`, `--tls-ca` flags for explicit paths
- Explicit error when only one of cert/key is provided

**Certificate generation improvements:**
- `IssueCert` adds the certificate name as a default SAN when no SANs are specified
- `tls init` includes machine hostname in default server cert SANs
- `tls issue` rejects names containing path separators or `..`

**Documentation:**
- New TLS/mTLS section in README covering bootstrap, cert issuance, server/client usage, auto-discovery, and environment variables
- TLS commands listed in CLI shortcuts section

## Usage

```bash
# One-time setup
cleanroom tls init

# Server
cleanroom serve --listen https://0.0.0.0:7777

# Client
cleanroom exec --host https://remote-host:7777 -- npm test

# Issue cert for a remote host
cleanroom tls issue worker-1 --san worker-1.internal --san 10.0.0.5
```

## Tests

- 9 tests in `tlsbootstrap` (CA generation, cert chain verification, mTLS handshake, rejection without client cert)
- 5 tests in `controlserver/mtls_test.go` (valid cert, no cert rejected, wrong CA rejected, TLS-only mode, end-to-end with ConnectRPC handler)
- All existing tests passing

## Plan

See `docs/plans/mtls.md` for the full design document.