### PR TITLE
docs: invert sandbox lifecycle to persist-by-default

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,19 +21,23 @@ cleanroom serve &
 
 The server listens on `unix://$XDG_RUNTIME_DIR/cleanroom/cleanroom.sock` by default.
 
-The simplest way to run a command is `cleanroom exec`, which creates an ephemeral sandbox, runs the command, and tears it down:
+Run a command in a sandbox:
 
 ```bash
 cleanroom exec -- npm test
 ```
 
-For long-running sandboxes, create one explicitly and run multiple commands against it:
+The sandbox stays running after the command completes. Run more commands against it:
 
 ```bash
-cleanroom exec --keep-sandbox -- npm test
-# reuse the sandbox for another command
 cleanroom exec --sandbox-id <id> -- npm run lint
-# terminate when done
+cleanroom exec --sandbox-id <id> -- npm run build
+```
+
+Use `--rm` to tear down the sandbox after the command completes (useful for one-off CI jobs):
+
+```bash
+cleanroom exec --rm -- npm test
 ```
 
 ## CLI
@@ -141,7 +145,7 @@ The Firecracker adapter resolves `sandbox.image.ref` through the local image man
 - Workload runs in a Firecracker microVM
 - Host egress is controlled with TAP + iptables rules from compiled policy
 - Default network behaviour is deny
-- Rootfs writes are discarded after each run
+- Rootfs writes persist across executions within a sandbox and are discarded on sandbox termination
 - Per-run observability is written to `run-observability.json` (rootfs prep, network setup, VM ready, command runtime, total)
 - Rootfs copy uses clone/reflink when available, with copy fallback
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -245,13 +245,13 @@ Additional command forms:
 Behavior contract:
 1. Resolve server endpoint (`--host`, `CLEANROOM_HOST`, context, default unix socket).
 2. Resolve and compile repository policy.
-3. Create sandbox (default: ephemeral sandbox for this invocation).
+3. Create or reuse sandbox (`--sandbox-id <id>` reuses an existing sandbox).
 4. Create execution with command and TTY options.
 5. Stream output:
    - non-interactive: `StreamExecution`
    - interactive: `AttachExecution`
 6. Return the command exit code.
-7. If sandbox is ephemeral, terminate it after execution completion.
+7. Sandbox remains `READY` for further executions. Use `--rm` to terminate after execution.
 
 Signal behavior:
 1. First `Ctrl-C`: `CancelExecution`.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -20,7 +20,7 @@ We currently track two benchmark categories:
 
 Script: `scripts/benchmark-tti.sh`
 
-- Starts from `cleanroom exec --keep-sandbox -- echo benchmark`
+- Starts from `cleanroom exec -- echo benchmark`
 - Uses `hyperfine` for repeated runs
 - Excludes sandbox teardown from timed command
 - Performs termination in `--prepare/--cleanup` steps

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -109,7 +109,7 @@ type ExecCommand struct {
 	LogLevel    string `help:"Client log level (debug|info|warn|error)"`
 	Backend     string `help:"Execution backend (defaults to runtime config or firecracker)"`
 	SandboxID   string `help:"Reuse an existing sandbox instead of creating a new one"`
-	KeepSandbox bool   `help:"Keep a newly created sandbox running after command completion"`
+	Remove bool `name:"rm" help:"Terminate a newly created sandbox after command completion"`
 
 	LaunchSeconds int64 `help:"VM boot/guest-agent readiness timeout in seconds"`
 
@@ -122,7 +122,7 @@ type ConsoleCommand struct {
 	LogLevel    string `help:"Client log level (debug|info|warn|error)"`
 	Backend     string `help:"Execution backend (defaults to runtime config or firecracker)"`
 	SandboxID   string `help:"Reuse an existing sandbox instead of creating a new one"`
-	KeepSandbox bool   `help:"Keep a newly created sandbox running after console exits"`
+	Remove      bool   `name:"rm" help:"Terminate a newly created sandbox after console exits"`
 
 	LaunchSeconds int64 `help:"VM boot/guest-agent readiness timeout in seconds"`
 
@@ -468,7 +468,7 @@ func (e *ExecCommand) Run(ctx *runtimeContext) error {
 		createdSandbox = true
 	}
 	detached := false
-	autoTerminateSandbox := createdSandbox && !e.KeepSandbox
+	autoTerminateSandbox := createdSandbox && e.Remove
 	defer func() {
 		if detached || !autoTerminateSandbox || sandboxID == "" {
 			return
@@ -563,13 +563,11 @@ func (e *ExecCommand) Run(ctx *runtimeContext) error {
 	select {
 	case <-secondInterrupt:
 		detached = true
-		if autoTerminateSandbox {
-			terminateCtx, terminateCancel := context.WithTimeout(context.Background(), 2*time.Second)
-			_, terminateErr := client.TerminateSandbox(terminateCtx, &cleanroomv1.TerminateSandboxRequest{SandboxId: sandboxID})
-			terminateCancel()
-			if terminateErr != nil && logger != nil {
-				logger.Warn("terminate sandbox after detach failed", "sandbox_id", sandboxID, "error", terminateErr)
-			}
+		terminateCtx, terminateCancel := context.WithTimeout(context.Background(), 2*time.Second)
+		_, terminateErr := client.TerminateSandbox(terminateCtx, &cleanroomv1.TerminateSandboxRequest{SandboxId: sandboxID})
+		terminateCancel()
+		if terminateErr != nil && logger != nil {
+			logger.Warn("terminate sandbox after detach failed", "sandbox_id", sandboxID, "error", terminateErr)
 		}
 		return exitCodeError{code: 130}
 	default:
@@ -679,7 +677,7 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) error {
 		sandboxID = createSandboxResp.GetSandbox().GetSandboxId()
 		createdSandbox = true
 	}
-	autoTerminateSandbox := createdSandbox && !c.KeepSandbox
+	autoTerminateSandbox := createdSandbox && c.Remove
 	defer func() {
 		if sandboxID == "" || !autoTerminateSandbox {
 			return

--- a/internal/cli/exec_integration_test.go
+++ b/internal/cli/exec_integration_test.go
@@ -456,14 +456,13 @@ func TestParseSandboxID(t *testing.T) {
 	}
 }
 
-func TestExecIntegrationKeepSandboxLeavesSandboxRunning(t *testing.T) {
+func TestExecIntegrationDefaultLeavesSandboxRunning(t *testing.T) {
 	host, _ := startIntegrationServer(t, &integrationAdapter{})
 	cwd := t.TempDir()
 	outcome := runExecWithCapture(ExecCommand{
-		Host:        host,
-		Chdir:       cwd,
-		KeepSandbox: true,
-		Command:     []string{"echo", "ok"},
+		Host:    host,
+		Chdir:   cwd,
+		Command: []string{"echo", "ok"},
 	}, runtimeContext{
 		CWD:    cwd,
 		Loader: integrationLoader{},
@@ -490,6 +489,44 @@ func TestExecIntegrationKeepSandboxLeavesSandboxRunning(t *testing.T) {
 		t.Fatalf("GetSandbox returned error: %v", err)
 	}
 	if got, want := getResp.GetSandbox().GetStatus(), cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY; got != want {
+		t.Fatalf("unexpected sandbox status: got %v want %v", got, want)
+	}
+}
+
+func TestExecIntegrationRemoveTerminatesSandbox(t *testing.T) {
+	host, _ := startIntegrationServer(t, &integrationAdapter{})
+	cwd := t.TempDir()
+	outcome := runExecWithCapture(ExecCommand{
+		Host:    host,
+		Chdir:   cwd,
+		Remove:  true,
+		Command: []string{"echo", "ok"},
+	}, runtimeContext{
+		CWD:    cwd,
+		Loader: integrationLoader{},
+	})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err != nil {
+		t.Fatalf("ExecCommand.Run returned error: %v", outcome.err)
+	}
+
+	sandboxID := parseSandboxID(outcome.stderr)
+	if sandboxID == "" {
+		t.Fatalf("missing sandbox_id in stderr output: %q", outcome.stderr)
+	}
+
+	ep, err := endpoint.Resolve(host)
+	if err != nil {
+		t.Fatalf("resolve endpoint: %v", err)
+	}
+	client := controlclient.New(ep)
+	getResp, err := client.GetSandbox(context.Background(), &cleanroomv1.GetSandboxRequest{SandboxId: sandboxID})
+	if err != nil {
+		t.Fatalf("GetSandbox returned error: %v", err)
+	}
+	if got, want := getResp.GetSandbox().GetStatus(), cleanroomv1.SandboxStatus_SANDBOX_STATUS_STOPPED; got != want {
 		t.Fatalf("unexpected sandbox status: got %v want %v", got, want)
 	}
 }

--- a/scripts/benchmark-sandbox-workloads.sh
+++ b/scripts/benchmark-sandbox-workloads.sh
@@ -186,7 +186,7 @@ create_cmd=("$cleanroom_bin" exec --host "$host" -c "$chdir")
 if [[ -n "$backend" ]]; then
   create_cmd+=(--backend "$backend")
 fi
-create_cmd+=(--keep-sandbox -- sh -lc "true")
+create_cmd+=(-- sh -lc "true")
 
 create_stderr_file="$(mktemp)"
 "${create_cmd[@]}" >/dev/null 2>"$create_stderr_file"

--- a/scripts/benchmark-tti.sh
+++ b/scripts/benchmark-tti.sh
@@ -23,7 +23,7 @@ Environment:
 
 Notes:
   - This script expects the cleanroom server to already be running.
-  - The measured command is: cleanroom exec --keep-sandbox ... -- echo benchmark
+  - The measured command is: cleanroom exec ... -- echo benchmark
   - Sandbox termination runs in hyperfine cleanup and is excluded from timing.
 EOF
 }
@@ -138,7 +138,7 @@ benchmark_cmd=("$cleanroom_bin" exec --host "$host" -c "$chdir")
 if [[ -n "$backend" ]]; then
   benchmark_cmd+=(--backend "$backend")
 fi
-benchmark_cmd+=(--keep-sandbox -- echo benchmark)
+benchmark_cmd+=(-- echo benchmark)
 
 quoted_cmd=""
 for token in "${benchmark_cmd[@]}"; do


### PR DESCRIPTION
Sandboxes now remain `READY` after execution completes by default, making multi-exec the standard access pattern. Use `--rm` to tear down after execution (replaces `--keep-sandbox`, matching Docker convention).

Changes across README, spec, and API docs:
- Sandbox is the primary unit of lifecycle, accepting multiple executions
- Filesystem writes persist across executions within a sandbox
- Launch flow ends with sandbox staying `READY` instead of tearing down
- `--rm` flag for ephemeral one-off jobs (CI use case)