### PR TITLE
feat: add sandbox management CLI, suppress exec noise, fix healthz

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,10 @@ Run a command in a sandbox:
 cleanroom exec -- npm test
 ```
 
-The sandbox stays running after the command completes. Run more commands against it:
+The sandbox stays running after the command completes. List sandboxes and run more commands:
 
 ```bash
+cleanroom sandbox ls
 cleanroom exec --sandbox-id <id> -- npm run lint
 cleanroom exec --sandbox-id <id> -- npm run build
 ```
@@ -146,6 +147,13 @@ cleanroom image bump-ref
 
 `ghcr.io/buildkite/cleanroom-base/alpine` is published from this repo on pushes to `main`
 via `.github/workflows/base-image.yml`.
+
+Sandbox management:
+
+```bash
+cleanroom sandbox ls
+cleanroom sandbox rm <sandbox-id>
+```
 
 Diagnostics:
 

--- a/internal/cli/console_integration_test.go
+++ b/internal/cli/console_integration_test.go
@@ -137,8 +137,8 @@ func TestConsoleIntegrationForwardsStdinAndStreamsOutput(t *testing.T) {
 	host, _ := startIntegrationServer(t, adapter)
 	cwd := t.TempDir()
 	outcome := runConsoleWithCapture(ConsoleCommand{
-		Host:  host,
-		Chdir: cwd,
+		clientFlags: clientFlags{Host: host},
+		Chdir:       cwd,
 		// Console defaults to host passthrough for this MVP.
 		Command: []string{"sh"},
 	}, "hello\nexit\n", runtimeContext{
@@ -186,8 +186,8 @@ func TestConsoleIntegrationInterruptCancelsExecution(t *testing.T) {
 	done := make(chan execOutcome, 1)
 	go func() {
 		done <- runConsoleWithCapture(ConsoleCommand{
-			Host:  host,
-			Chdir: cwd,
+			clientFlags: clientFlags{Host: host},
+			Chdir:       cwd,
 		}, "", runtimeContext{
 			CWD:    cwd,
 			Loader: integrationLoader{},
@@ -211,7 +211,7 @@ func TestConsoleIntegrationInterruptCancelsExecution(t *testing.T) {
 
 func TestConsoleRejectsTailscaleServiceListenEndpointAsHost(t *testing.T) {
 	outcome := runConsoleWithCapture(ConsoleCommand{
-		Host: "tssvc://cleanroom",
+		clientFlags: clientFlags{Host: "tssvc://cleanroom"},
 	}, "", runtimeContext{
 		CWD: t.TempDir(),
 	})
@@ -274,9 +274,9 @@ func TestConsoleIntegrationReuseSandboxSkipsPolicyCompile(t *testing.T) {
 	}
 
 	outcome := runConsoleWithCapture(ConsoleCommand{
-		Host:      host,
-		SandboxID: createSandboxResp.GetSandbox().GetSandboxId(),
-		Command:   []string{"sh"},
+		clientFlags: clientFlags{Host: host},
+		SandboxID:   createSandboxResp.GetSandbox().GetSandboxId(),
+		Command:     []string{"sh"},
 	}, "exit\n", runtimeContext{
 		CWD:    t.TempDir(),
 		Loader: failingLoader{},

--- a/internal/controlserver/server.go
+++ b/internal/controlserver/server.go
@@ -80,6 +80,7 @@ func (s *Server) Handler() http.Handler {
 
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "ok\n")
 	})
 	return h2c.NewHandler(mux, &http2.Server{})
 }


### PR DESCRIPTION
## Changes

- **`sandbox ls` and `sandbox rm` CLI commands** — manage sandboxes without dropping to curl/API
- **Suppress sandbox_id/execution_id output** — moved to debug logging; exec output is now clean for scripting
- **`/healthz` returns `ok` body** — instead of empty 200
- **Extract shared `clientFlags`** — reduces duplication across ExecCommand, ConsoleCommand, and new sandbox commands
- **`sandboxStatusString` helper** — explicit switch instead of brittle proto enum prefix trimming

## Testing

- All existing tests updated and passing
- Verified against live Tailscale server