### PR TITLE
feat: add bidirectional stdin/PTY support to vsock protocol

### DIFF
--- a/docs/vsock.md
+++ b/docs/vsock.md
@@ -1,0 +1,116 @@
+# Vsock Exec Protocol
+
+The guest agent (`cleanroom-guest-agent`) listens on a vsock port (default `10700`) inside the Firecracker VM. The host connects over the Firecracker vsock UDS proxy to execute commands in the guest.
+
+The protocol uses **newline-delimited JSON** over a single full-duplex vsock connection. Each connection handles one command execution.
+
+## Connection Lifecycle
+
+```
+Host                                    Guest
+ │                                        │
+ │──── ExecRequest ──────────────────────>│  (1 JSON line)
+ │                                        │
+ │──── ExecInputFrame (stdin) ──────────>│  (0..n JSON lines)
+ │──── ExecInputFrame (resize) ─────────>│
+ │──── ExecInputFrame (eof) ────────────>│
+ │                                        │
+ │<──── ExecStreamFrame (stdout) ────────│  (0..n JSON lines)
+ │<──── ExecStreamFrame (stderr) ────────│
+ │<──── ExecStreamFrame (exit) ──────────│  (terminates session)
+ │                                        │
+```
+
+Host→guest and guest→host streams are independent (full-duplex). Input frames and output frames flow concurrently.
+
+## Messages
+
+### ExecRequest (host → guest)
+
+Sent once at the start of the connection.
+
+```json
+{
+  "command": ["sh", "-c", "echo hello"],
+  "dir": "/workspace",
+  "env": ["FOO=bar"],
+  "entropy_seed": "<base64>",
+  "tty": true
+}
+```
+
+| Field          | Type       | Required | Description                                      |
+|----------------|------------|----------|--------------------------------------------------|
+| `command`      | `string[]` | yes      | Command and arguments                            |
+| `dir`          | `string`   | no       | Working directory                                |
+| `env`          | `string[]` | no       | Environment variables (`KEY=value`)              |
+| `entropy_seed` | `bytes`    | no       | Entropy to inject into guest `/dev/random`       |
+| `tty`          | `bool`     | no       | Allocate a PTY for the command (default `false`) |
+
+When `tty` is `true`, the guest allocates a pseudo-terminal. stdout and stderr are merged into a single PTY output stream (sent as `stdout` frames). Resize input frames control the terminal window size.
+
+### ExecInputFrame (host → guest)
+
+Sent after the request, zero or more times. Only processed if the guest agent version supports input frames; older agents ignore the host→guest direction after the request.
+
+**stdin** — forward data to the process's stdin (or PTY):
+```json
+{"type": "stdin", "data": "<base64>"}
+```
+
+**resize** — change PTY window size (TTY mode only):
+```json
+{"type": "resize", "cols": 120, "rows": 40}
+```
+
+**eof** — signal end of stdin without closing the connection:
+```json
+{"type": "eof"}
+```
+
+### ExecStreamFrame (guest → host)
+
+Sent zero or more times during command execution, terminated by an `exit` frame.
+
+**stdout/stderr** — output chunk:
+```json
+{"type": "stdout", "data": "<base64>"}
+{"type": "stderr", "data": "<base64>"}
+```
+
+In TTY mode, all output arrives as `stdout` (PTY merges streams).
+
+The `data` field is base64-encoded bytes. The decoder also tolerates plain string values for resilience.
+
+**exit** — command finished (final frame):
+```json
+{"type": "exit", "exit_code": 0, "error": ""}
+```
+
+| Field       | Type     | Description                                  |
+|-------------|----------|----------------------------------------------|
+| `exit_code` | `int`    | Process exit code (0 = success)              |
+| `error`     | `string` | Guest-side error message, if any             |
+
+### ExecResponse (legacy fallback)
+
+If the guest agent fails to send stream frames (protocol mismatch), it falls back to a single JSON response:
+
+```json
+{"exit_code": 0, "stdout": "hello\n", "stderr": "", "error": ""}
+```
+
+The host decoder detects this by checking for the absence of a `type` field.
+
+## Transport
+
+- **Port:** Configurable via `CLEANROOM_VSOCK_PORT` env var in the guest, default `10700`
+- **Encoding:** JSON with newline delimiter (`json.Encoder` / `json.Decoder`)
+- **Binary data:** `[]byte` fields are base64-encoded by Go's `encoding/json`
+- **Concurrency:** One command per connection. The guest agent accepts multiple sequential connections.
+
+## Implementation
+
+- Protocol types: `internal/vsockexec/protocol.go`
+- Guest agent: `cmd/cleanroom-guest-agent/main.go`
+- Host-side caller: `internal/backend/firecracker/backend.go` (`runGuestCommand`)

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -1501,6 +1501,10 @@ func runGuestCommand(bootCtx context.Context, execCtx context.Context, processEx
 				})
 			},
 		})
+	} else {
+		// No interactive input — immediately signal stdin EOF so the
+		// guest process doesn't block waiting for input.
+		_ = inputSender.Send(vsockexec.ExecInputFrame{Type: "eof"})
 	}
 
 	commandStart := time.Now()

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -1501,9 +1501,12 @@ func runGuestCommand(bootCtx context.Context, execCtx context.Context, processEx
 				})
 			},
 		})
-	} else {
-		// No interactive input — immediately signal stdin EOF so the
-		// guest process doesn't block waiting for input.
+	}
+	if !req.TTY {
+		// Non-TTY commands don't expect interactive stdin. Send eof
+		// immediately so the guest process sees stdin EOF rather than
+		// blocking. The control service always sets OnAttach even for
+		// non-interactive exec, so we can't rely on OnAttach == nil.
 		_ = inputSender.Send(vsockexec.ExecInputFrame{Type: "eof"})
 	}
 

--- a/internal/backend/firecracker/gateway_test.go
+++ b/internal/backend/firecracker/gateway_test.go
@@ -18,7 +18,7 @@ func TestGatewayEnvVarsEmptyWhenNoPolicyHosts(t *testing.T) {
 			Allow:          []policy.AllowRule{{Host: "example.com", Ports: []int{80}}},
 		},
 	}
-	env := gatewayEnvVars(instance)
+	env := gatewayEnvVars(instance, 8170)
 	if len(env) != 0 {
 		t.Fatalf("expected no env vars for host without port 443, got %v", env)
 	}
@@ -39,7 +39,7 @@ func TestGatewayEnvVarsGeneratesGitConfig(t *testing.T) {
 		},
 	}
 
-	env := gatewayEnvVars(instance)
+	env := gatewayEnvVars(instance, 8170)
 	if len(env) != 5 {
 		t.Fatalf("expected 5 env vars (1 count + 2*2 key/value), got %d: %v", len(env), env)
 	}
@@ -63,7 +63,7 @@ func TestGatewayEnvVarsNilPolicy(t *testing.T) {
 	t.Parallel()
 
 	instance := &sandboxInstance{HostIP: "10.1.1.1"}
-	env := gatewayEnvVars(instance)
+	env := gatewayEnvVars(instance, 8170)
 	if env != nil {
 		t.Fatalf("expected nil for nil policy, got %v", env)
 	}

--- a/internal/vsockexec/protocol_test.go
+++ b/internal/vsockexec/protocol_test.go
@@ -1,6 +1,7 @@
 package vsockexec
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 )
@@ -25,5 +26,69 @@ func TestDecodeRequestRejectsEmptyExecutableAfterTrim(t *testing.T) {
 	_, err := DecodeRequest(strings.NewReader(raw))
 	if err == nil {
 		t.Fatal("expected error for blank executable")
+	}
+}
+
+func TestDecodeRequestWithTTY(t *testing.T) {
+	t.Parallel()
+	raw := `{"command":["sh"],"tty":true}`
+	req, err := DecodeRequest(strings.NewReader(raw))
+	if err != nil {
+		t.Fatalf("DecodeRequest returned error: %v", err)
+	}
+	if !req.TTY {
+		t.Fatal("expected TTY to be true")
+	}
+}
+
+func TestDecodeRequestTTYDefaultsFalse(t *testing.T) {
+	t.Parallel()
+	raw := `{"command":["echo","hi"]}`
+	req, err := DecodeRequest(strings.NewReader(raw))
+	if err != nil {
+		t.Fatalf("DecodeRequest returned error: %v", err)
+	}
+	if req.TTY {
+		t.Fatal("expected TTY to default to false")
+	}
+}
+
+func TestInputFrameRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	err := EncodeInputFrame(&buf, ExecInputFrame{Type: "stdin", Data: []byte("hello\n")})
+	if err != nil {
+		t.Fatalf("EncodeInputFrame: %v", err)
+	}
+	frame, err := DecodeInputFrame(&buf)
+	if err != nil {
+		t.Fatalf("DecodeInputFrame: %v", err)
+	}
+	if frame.Type != "stdin" {
+		t.Fatalf("expected type stdin, got %q", frame.Type)
+	}
+	if string(frame.Data) != "hello\n" {
+		t.Fatalf("expected data %q, got %q", "hello\n", string(frame.Data))
+	}
+}
+
+func TestInputFrameResize(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	err := EncodeInputFrame(&buf, ExecInputFrame{Type: "resize", Cols: 120, Rows: 40})
+	if err != nil {
+		t.Fatalf("EncodeInputFrame: %v", err)
+	}
+	frame, err := DecodeInputFrame(&buf)
+	if err != nil {
+		t.Fatalf("DecodeInputFrame: %v", err)
+	}
+	if frame.Type != "resize" {
+		t.Fatalf("expected type resize, got %q", frame.Type)
+	}
+	if frame.Cols != 120 || frame.Rows != 40 {
+		t.Fatalf("unexpected size: %dx%d", frame.Cols, frame.Rows)
 	}
 }

--- a/internal/vsockexec/protocol_test.go
+++ b/internal/vsockexec/protocol_test.go
@@ -2,7 +2,11 @@ package vsockexec
 
 import (
 	"bytes"
+	"encoding/json"
+	"errors"
+	"net"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -90,5 +94,163 @@ func TestInputFrameResize(t *testing.T) {
 	}
 	if frame.Cols != 120 || frame.Rows != 40 {
 		t.Fatalf("unexpected size: %dx%d", frame.Cols, frame.Rows)
+	}
+}
+
+// TestProtocolRoundTripStdinEcho simulates a full bidirectional session over a
+// net.Pipe: the "host" side sends an ExecRequest followed by stdin input frames
+// and an eof, while a goroutine plays the "guest" side reading the request,
+// echoing stdin data back as stdout frames, and sending an exit frame.
+func TestProtocolRoundTripStdinEcho(t *testing.T) {
+	t.Parallel()
+
+	hostConn, guestConn := net.Pipe()
+	defer hostConn.Close()
+	defer guestConn.Close()
+
+	// Guest side: read request, echo stdin back as stdout, exit on eof.
+	var guestErr error
+	var guestWg sync.WaitGroup
+	guestWg.Add(1)
+	go func() {
+		defer guestWg.Done()
+		defer guestConn.Close()
+
+		dec := json.NewDecoder(guestConn)
+		var req ExecRequest
+		if err := dec.Decode(&req); err != nil {
+			guestErr = err
+			return
+		}
+
+		enc := json.NewEncoder(guestConn)
+		for {
+			var frame ExecInputFrame
+			if err := dec.Decode(&frame); err != nil {
+				guestErr = err
+				return
+			}
+			if frame.Type == "eof" {
+				break
+			}
+			if frame.Type == "stdin" && len(frame.Data) > 0 {
+				if err := enc.Encode(ExecStreamFrame{Type: "stdout", Data: frame.Data}); err != nil {
+					guestErr = err
+					return
+				}
+			}
+		}
+		_ = enc.Encode(ExecStreamFrame{Type: "exit", ExitCode: 0})
+	}()
+
+	// Host side: send request, then write stdin concurrently with reading
+	// output (net.Pipe is synchronous so both sides must be active).
+	if err := EncodeRequest(hostConn, ExecRequest{Command: []string{"cat"}}); err != nil {
+		t.Fatalf("EncodeRequest: %v", err)
+	}
+	go func() {
+		_ = EncodeInputFrame(hostConn, ExecInputFrame{Type: "stdin", Data: []byte("hello")})
+		_ = EncodeInputFrame(hostConn, ExecInputFrame{Type: "stdin", Data: []byte(" world")})
+		_ = EncodeInputFrame(hostConn, ExecInputFrame{Type: "eof"})
+	}()
+
+	var stdout bytes.Buffer
+	res, err := DecodeStreamResponse(hostConn, StreamCallbacks{
+		OnStdout: func(data []byte) { stdout.Write(data) },
+	})
+	if err != nil {
+		t.Fatalf("DecodeStreamResponse: %v", err)
+	}
+	if res.ExitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", res.ExitCode)
+	}
+	if got, want := stdout.String(), "hello world"; got != want {
+		t.Fatalf("streamed stdout: got %q want %q", got, want)
+	}
+	if got, want := res.Stdout, "hello world"; got != want {
+		t.Fatalf("accumulated stdout: got %q want %q", got, want)
+	}
+
+	guestWg.Wait()
+	if guestErr != nil {
+		t.Fatalf("guest side error: %v", guestErr)
+	}
+}
+
+// TestProtocolRoundTripResizeFrame verifies that resize frames are correctly
+// transmitted alongside stdin data.
+func TestProtocolRoundTripResizeFrame(t *testing.T) {
+	t.Parallel()
+
+	hostConn, guestConn := net.Pipe()
+	defer hostConn.Close()
+	defer guestConn.Close()
+
+	type resizeEvent struct{ Cols, Rows uint32 }
+	var resizes []resizeEvent
+	var guestErr error
+	var guestWg sync.WaitGroup
+	guestWg.Add(1)
+	go func() {
+		defer guestWg.Done()
+		defer guestConn.Close()
+
+		dec := json.NewDecoder(guestConn)
+		var req ExecRequest
+		if err := dec.Decode(&req); err != nil {
+			guestErr = err
+			return
+		}
+		if !req.TTY {
+			guestErr = errors.New("expected TTY=true")
+			return
+		}
+
+		for {
+			var frame ExecInputFrame
+			if err := dec.Decode(&frame); err != nil {
+				guestErr = err
+				return
+			}
+			if frame.Type == "eof" {
+				break
+			}
+			if frame.Type == "resize" {
+				resizes = append(resizes, resizeEvent{frame.Cols, frame.Rows})
+			}
+		}
+		enc := json.NewEncoder(guestConn)
+		_ = enc.Encode(ExecStreamFrame{Type: "exit", ExitCode: 0})
+	}()
+
+	if err := EncodeRequest(hostConn, ExecRequest{Command: []string{"sh"}, TTY: true}); err != nil {
+		t.Fatalf("EncodeRequest: %v", err)
+	}
+	go func() {
+		_ = EncodeInputFrame(hostConn, ExecInputFrame{Type: "resize", Cols: 80, Rows: 24})
+		_ = EncodeInputFrame(hostConn, ExecInputFrame{Type: "resize", Cols: 120, Rows: 40})
+		_ = EncodeInputFrame(hostConn, ExecInputFrame{Type: "eof"})
+	}()
+
+	res, err := DecodeStreamResponse(hostConn, StreamCallbacks{})
+	if err != nil {
+		t.Fatalf("DecodeStreamResponse: %v", err)
+	}
+	if res.ExitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", res.ExitCode)
+	}
+
+	guestWg.Wait()
+	if guestErr != nil {
+		t.Fatalf("guest side error: %v", guestErr)
+	}
+	if len(resizes) != 2 {
+		t.Fatalf("expected 2 resize events, got %d", len(resizes))
+	}
+	if resizes[0].Cols != 80 || resizes[0].Rows != 24 {
+		t.Fatalf("resize[0]: got %dx%d, want 80x24", resizes[0].Cols, resizes[0].Rows)
+	}
+	if resizes[1].Cols != 120 || resizes[1].Rows != 40 {
+		t.Fatalf("resize[1]: got %dx%d, want 120x40", resizes[1].Cols, resizes[1].Rows)
 	}
 }

--- a/scripts/ci-cleanroom-e2e.sh
+++ b/scripts/ci-cleanroom-e2e.sh
@@ -119,11 +119,17 @@ fi
 
 echo "--- :warning: Exit code propagation test"
 set +e
-./dist/cleanroom exec --host "$listen_endpoint" -c "$PWD" -- sh -lc 'exit 7' >/dev/null 2>&1
+./dist/cleanroom exec --host "$listen_endpoint" -c "$PWD" -- sh -lc 'exit 7' >"$tmpdir/exit7.out" 2>"$tmpdir/exit7.err"
 status=$?
 set -e
 if [[ "$status" -ne 7 ]]; then
   echo "expected exit code 7 from guest command, got $status" >&2
+  echo "stdout:" >&2
+  cat "$tmpdir/exit7.out" >&2 || true
+  echo "stderr:" >&2
+  cat "$tmpdir/exit7.err" >&2 || true
+  echo "server log (last 30 lines):" >&2
+  tail -n 30 "$tmpdir/server.log" >&2 || true
   exit 1
 fi
 

--- a/scripts/ci-cleanroom-e2e.sh
+++ b/scripts/ci-cleanroom-e2e.sh
@@ -135,8 +135,8 @@ if [[ -n "$PRIVILEGED_HELPER_PATH" && -f "scripts/cleanroom-root-helper.sh" ]]; 
     echo "   repo: $repo_sha"
     echo "   Update with: sudo install -o root -g root -m 0755 scripts/cleanroom-root-helper.sh $PRIVILEGED_HELPER_PATH"
     if command -v buildkite-agent >/dev/null 2>&1; then
-      buildkite-agent annotate --context root-helper-drift --style warning <<EOF
-### ⚠️ Root helper out of date
+      buildkite-agent annotate --context root-helper-drift --style error <<EOF
+### ❌ Root helper out of date
 
 The installed root helper (\`$PRIVILEGED_HELPER_PATH\`) does not match \`scripts/cleanroom-root-helper.sh\` from this commit.
 
@@ -151,6 +151,7 @@ sudo install -o root -g root -m 0755 scripts/cleanroom-root-helper.sh $PRIVILEGE
 \`\`\`
 EOF
     fi
+    exit 1
   fi
 fi
 


### PR DESCRIPTION
Fixes `cleanroom console` so interactive sessions actually work.

**Root cause:** The guest agent started commands with stdin as /dev/null, the vsock protocol was unidirectional (no way to send stdin after the initial request), and the firecracker backend never called `stream.OnAttach()` to wire up stdin/resize handlers.

**Changes:**

- **Protocol** (`internal/vsockexec/protocol.go`): Add `TTY` field to `ExecRequest`, add `ExecInputFrame` type for host→guest stdin/resize/eof messages
- **Guest agent** (`cmd/cleanroom-guest-agent/main.go`): Allocate PTY when `TTY=true`, forward input frames to process stdin, handle resize events. Non-TTY mode also gets stdin pipe support (was `/dev/null` before)
- **Firecracker backend** (`internal/backend/firecracker/backend.go`): Call `stream.OnAttach()` with `WriteStdin`/`ResizeTTY` handlers that write input frames to the vsock connection

Tested end-to-end on janebot — `cleanroom console --host http://cleanroom.tail952194.ts.net:7777` now opens a working interactive shell.