### PR TITLE
fix: harden gateway server listen address

### DIFF
--- a/internal/backend/firecracker/gateway_firewall.go
+++ b/internal/backend/firecracker/gateway_firewall.go
@@ -1,0 +1,52 @@
+package firecracker
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+)
+
+// SetupGatewayFirewall installs global iptables rules that restrict access to
+// the gateway port to loopback and TAP interfaces (cr+) only. All other
+// interfaces (e.g. eth0) are blocked from reaching the gateway.
+//
+// The rules are structured so that TAP traffic is NOT accepted here — it falls
+// through to the per-TAP anti-spoof and accept rules installed by
+// setupHostNetwork. This preserves sandbox identity isolation.
+//
+// Returns a cleanup function that removes the rules. The caller must invoke
+// cleanup on shutdown.
+func SetupGatewayFirewall(ctx context.Context, port int, cfg backend.FirecrackerConfig) (cleanup func(), err error) {
+	run := func(ctx context.Context, args ...string) error {
+		return runRootCommand(ctx, cfg, args...)
+	}
+	return setupGatewayFirewall(ctx, port, run)
+}
+
+func setupGatewayFirewall(ctx context.Context, port int, run rootCommandFunc) (cleanup func(), err error) {
+	portStr := strconv.Itoa(port)
+
+	// Allow loopback access to gateway port.
+	if err := run(ctx, "iptables", "-A", "INPUT", "-i", "lo", "-p", "tcp", "--dport", portStr, "-j", "ACCEPT"); err != nil {
+		return nil, fmt.Errorf("install gateway loopback rule: %w", err)
+	}
+
+	// Drop gateway traffic from non-TAP interfaces (eth0, docker0, etc.).
+	// TAP traffic (cr*) is intentionally NOT matched here so it falls through
+	// to the per-TAP anti-spoof rules installed by setupHostNetwork.
+	if err := run(ctx, "iptables", "-A", "INPUT", "!", "-i", "cr+", "-p", "tcp", "--dport", portStr, "-j", "DROP"); err != nil {
+		_ = run(ctx, "iptables", "-D", "INPUT", "-i", "lo", "-p", "tcp", "--dport", portStr, "-j", "ACCEPT")
+		return nil, fmt.Errorf("install gateway drop rule: %w", err)
+	}
+
+	cleanup = func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = run(cleanupCtx, "iptables", "-D", "INPUT", "!", "-i", "cr+", "-p", "tcp", "--dport", portStr, "-j", "DROP")
+		_ = run(cleanupCtx, "iptables", "-D", "INPUT", "-i", "lo", "-p", "tcp", "--dport", portStr, "-j", "ACCEPT")
+	}
+	return cleanup, nil
+}

--- a/internal/backend/firecracker/gateway_firewall_test.go
+++ b/internal/backend/firecracker/gateway_firewall_test.go
@@ -1,0 +1,50 @@
+package firecracker
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestSetupGatewayFirewall(t *testing.T) {
+	t.Parallel()
+
+	var calls []string
+	run := func(_ context.Context, args ...string) error {
+		calls = append(calls, strings.Join(args, " "))
+		return nil
+	}
+
+	cleanup, err := setupGatewayFirewall(context.Background(), 8170, run)
+	if err != nil {
+		t.Fatalf("setupGatewayFirewall: %v", err)
+	}
+
+	want := []string{
+		"iptables -A INPUT -i lo -p tcp --dport 8170 -j ACCEPT",
+		"iptables -A INPUT ! -i cr+ -p tcp --dport 8170 -j DROP",
+	}
+	if len(calls) != len(want) {
+		t.Fatalf("expected %d setup calls, got %d:\n%s", len(want), len(calls), strings.Join(calls, "\n"))
+	}
+	for i, w := range want {
+		if calls[i] != w {
+			t.Errorf("setup call %d:\n  got:  %s\n  want: %s", i, calls[i], w)
+		}
+	}
+
+	calls = nil
+	cleanup()
+	wantCleanup := []string{
+		"iptables -D INPUT ! -i cr+ -p tcp --dport 8170 -j DROP",
+		"iptables -D INPUT -i lo -p tcp --dport 8170 -j ACCEPT",
+	}
+	if len(calls) != len(wantCleanup) {
+		t.Fatalf("expected %d cleanup calls, got %d:\n%s", len(wantCleanup), len(calls), strings.Join(calls, "\n"))
+	}
+	for i, w := range wantCleanup {
+		if calls[i] != w {
+			t.Errorf("cleanup call %d:\n  got:  %s\n  want: %s", i, calls[i], w)
+		}
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1052,6 +1052,17 @@ func (s *ServeCommand) Run(ctx *runtimeContext) error {
 	if fcAdapter, ok := ctx.Backends["firecracker"].(*firecracker.Adapter); ok {
 		fcAdapter.GatewayRegistry = gwRegistry
 		fcAdapter.GatewayPort = gwPort
+
+		fwCfg := backend.FirecrackerConfig{
+			PrivilegedMode:       ctx.Config.Backends.Firecracker.PrivilegedMode,
+			PrivilegedHelperPath: ctx.Config.Backends.Firecracker.PrivilegedHelperPath,
+		}
+		fwCleanup, err := firecracker.SetupGatewayFirewall(context.Background(), gwPort, fwCfg)
+		if err != nil {
+			logger.Warn("failed to install gateway firewall rules", "error", err)
+		} else {
+			defer fwCleanup()
+		}
 	}
 
 	var serverTLS *controlserver.TLSOptions

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -77,7 +77,7 @@ func (s *Server) Start() error {
 		return errors.New("gateway server already started")
 	}
 
-	ln, err := net.Listen("tcp", s.addr)
+	ln, err := net.Listen("tcp4", s.addr)
 	if err != nil {
 		return err
 	}

--- a/scripts/cleanroom-root-helper.sh
+++ b/scripts/cleanroom-root-helper.sh
@@ -150,6 +150,18 @@ run_iptables() {
     exec /usr/sbin/iptables "$@"
   fi
 
+  # Global gateway loopback: iptables -A|-D INPUT -i lo -p tcp --dport <port> -j ACCEPT
+  if [[ "$#" -eq 10 && ( "$1" == "-A" || "$1" == "-D" ) && "$2" == "INPUT" && "$3" == "-i" && "$4" == "lo" && "$5" == "-p" && "$6" == "tcp" && "$7" == "--dport" && "$9" == "-j" && "${10}" == "ACCEPT" ]]; then
+    is_numeric "$8" || die "iptables INPUT gateway loopback: invalid port '$8'"
+    exec /usr/sbin/iptables "$@"
+  fi
+
+  # Global gateway drop (non-TAP): iptables -A|-D INPUT ! -i cr+ -p tcp --dport <port> -j DROP
+  if [[ "$#" -eq 11 && ( "$1" == "-A" || "$1" == "-D" ) && "$2" == "INPUT" && "$3" == "!" && "$4" == "-i" && "$5" == "cr+" && "$6" == "-p" && "$7" == "tcp" && "$8" == "--dport" && "${10}" == "-j" && "${11}" == "DROP" ]]; then
+    is_numeric "$9" || die "iptables INPUT gateway drop: invalid port '$9'"
+    exec /usr/sbin/iptables "$@"
+  fi
+
   die "iptables: unsupported arguments"
 }
 


### PR DESCRIPTION
## Changes

- Switch gateway listener from `tcp` (dual-stack) to `tcp4` to avoid IPv6 footgun
- Add global iptables rules restricting the gateway port to loopback and TAP interfaces (`cr+`) only, blocking access from `eth0` and other interfaces
- Update root helper to allow the new firewall rule patterns
- Firewall rules are installed on serve startup and cleaned up on shutdown, gated on the firecracker backend being present

## Context

The gateway was binding to `[::]:8170` (all interfaces including IPv6), relying solely on source-IP identity middleware and EC2 security groups for protection. While those layers work, binding wide increases pre-auth attack surface (DoS, IPv6 misconfiguration, SG drift). The new global iptables rules complement the existing per-TAP rules as defence-in-depth.