### PR TITLE
feat: add darwin-vz backend with managed boot assets

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -36,7 +36,6 @@ steps:
     command: scripts/ci-cleanroom-e2e.sh
     env:
       CLEANROOM_KERNEL_IMAGE: /var/lib/buildkite-agent/.local/share/cleanroom/images/vmlinux.bin
-      CLEANROOM_ROOTFS: /var/lib/buildkite-agent/.local/share/cleanroom/images/rootfs.ext4
       CLEANROOM_FIRECRACKER_BINARY: /usr/local/bin/firecracker
     agents:
       queue: cleanroom

--- a/.mise.toml
+++ b/.mise.toml
@@ -18,18 +18,32 @@ run = "shellcheck -x scripts/cleanroom-root-helper.sh scripts/benchmark-tti.sh"
 description = "Run full Go test suite"
 run = "go test ./..."
 
-[tasks.build]
-description = "Build binaries into dist/"
+[tasks."build:go"]
+description = "Build Go binaries into dist/"
 run = "mkdir -p dist && go build -o dist/cleanroom ./cmd/cleanroom && go build -o dist/cleanroom-guest-agent ./cmd/cleanroom-guest-agent"
 
-[tasks.install]
-description = "Install binaries into GOBIN (or GOPATH/bin)"
-run = "go install ./cmd/cleanroom ./cmd/cleanroom-guest-agent"
+[tasks."build:darwin"]
+description = "Build macOS darwin-vz helper into dist/"
+run = "{% if os() == \"macos\" %}mkdir -p dist && xcrun swiftc -O -framework Virtualization cmd/cleanroom-darwin-vz/main.swift -o dist/cleanroom-darwin-vz && codesign --force --sign - --entitlements cmd/cleanroom-darwin-vz/entitlements.plist dist/cleanroom-darwin-vz{% else %}true{% endif %}"
 
-[tasks.prepare-firecracker-image]
-description = "Prepare rootfs image with guest agent and tiny init (requires sudo)"
-depends = ["build", "install"]
-run = "sudo scripts/prepare-firecracker-image.sh"
+[tasks.build]
+description = "Build binaries into dist/"
+depends = ["build:go", "build:darwin"]
+run = "true"
+
+[tasks."install:go"]
+description = "Install Go binaries into GOBIN (or GOPATH/bin)"
+run = "BIN_DIR=\"$(go env GOBIN)\"; if [ -z \"$BIN_DIR\" ]; then BIN_DIR=\"$(go env GOPATH)/bin\"; fi; HOST_ARCH=\"$(go env GOARCH)\"; mkdir -p \"$BIN_DIR\" && go install ./cmd/cleanroom ./cmd/cleanroom-guest-agent && GOOS=linux GOARCH=\"$HOST_ARCH\" CGO_ENABLED=0 go build -trimpath -o \"$BIN_DIR/cleanroom-guest-agent-linux-$HOST_ARCH\" ./cmd/cleanroom-guest-agent"
+
+[tasks."install:darwin"]
+description = "Install macOS darwin-vz helper into GOBIN (or GOPATH/bin)"
+depends = ["build:darwin"]
+run = "{% if os() == \"macos\" %}BIN_DIR=\"$(go env GOBIN)\"; if [ -z \"$BIN_DIR\" ]; then BIN_DIR=\"$(go env GOPATH)/bin\"; fi; ENTITLEMENTS=\"cmd/cleanroom-darwin-vz/entitlements.plist\"; mkdir -p \"$BIN_DIR\" && install -m 0755 dist/cleanroom-darwin-vz \"$BIN_DIR/cleanroom-darwin-vz\" && codesign --force --sign - --entitlements \"$ENTITLEMENTS\" \"$BIN_DIR/cleanroom-darwin-vz\"{% else %}true{% endif %}"
+
+[tasks.install]
+description = "Install all binaries into GOBIN (or GOPATH/bin)"
+depends = ["install:go", "install:darwin"]
+run = "true"
 
 [tasks.doctor]
 description = "Run cleanroom diagnostics"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,3 +2,4 @@
 
 - Keep implementation backend-agnostic by default.
 - Prefer backend-neutral CLI/API surfaces; place backend-specific runtime details in runtime config (XDG config) and adapter internals.
+- This project is in early development: breaking changes are acceptable, and legacy/backwards-compat paths are not required unless explicitly requested.

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ The helper (not the main `cleanroom` binary) needs the `com.apple.security.virtu
 
 - Workload runs in a Linux microVM backend (`firecracker` on Linux, `darwin-vz` on macOS)
 - `firecracker` enforces policy egress allowlists with TAP + iptables
-- `darwin-vz` currently requires `network.default: deny` and ignores `network.allow` entries (warns when present)
+- `darwin-vz` currently requires `network.default: deny`, ignores `network.allow` entries, and attaches no guest NIC (warns on stderr during execution)
 - `firecracker` rootfs writes persist across executions within a sandbox and are discarded on sandbox termination
 - `darwin-vz` executes each command in a fresh VM/rootfs copy (writes are discarded after each run)
 - Per-run observability is written to `run-observability.json` (rootfs prep, network setup, VM ready, command runtime, total)
@@ -274,6 +274,7 @@ The helper (not the main `cleanroom` binary) needs the `com.apple.security.virtu
 - `sudo -n` access for `ip`, `iptables`, and `sysctl` (network setup/cleanup)
 - macOS host requires `cleanroom-darwin-vz` helper plus `com.apple.security.virtualization` entitlement on that helper binary
 - macOS rootfs derivation requires `mkfs.ext4` and `debugfs` (install via `brew install e2fsprogs`)
+- `cleanroom doctor --json` includes a machine-readable `capabilities` map for the selected backend
 
 ## References
 

--- a/cleanroom.yaml
+++ b/cleanroom.yaml
@@ -1,7 +1,7 @@
 version: 1
 sandbox:
   image:
-    ref: ghcr.io/buildkite/cleanroom-base/alpine@sha256:962db9c461c02b86db105507bf2db4f01eb5d8fdf1a452598d140a569178324b
+    ref: docker.io/library/alpine@sha256:a4f4213abb84c497377b8544c81b3564f313746700372ec4fe84653e4fb03805
   network:
     default: deny
     allow:

--- a/cmd/cleanroom-darwin-vz/entitlements.plist
+++ b/cmd/cleanroom-darwin-vz/entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.virtualization</key>
+    <true/>
+</dict>
+</plist>

--- a/cmd/cleanroom-darwin-vz/main.swift
+++ b/cmd/cleanroom-darwin-vz/main.swift
@@ -1,0 +1,808 @@
+import Darwin
+import Foundation
+import Virtualization
+
+private struct CLIOptions {
+    let socketPath: String
+}
+
+private struct ControlRequest: Decodable {
+    let op: String
+    let kernelPath: String?
+    let rootFSPath: String?
+    let vcpus: Int?
+    let memoryMiB: Int64?
+    let guestPort: UInt32?
+    let launchSeconds: Int64?
+    let runDir: String?
+    let proxySocketPath: String?
+    let consoleLogPath: String?
+    let vmID: String?
+
+    enum CodingKeys: String, CodingKey {
+        case op
+        case kernelPath = "kernel_path"
+        case rootFSPath = "rootfs_path"
+        case vcpus
+        case memoryMiB = "memory_mib"
+        case guestPort = "guest_port"
+        case launchSeconds = "launch_seconds"
+        case runDir = "run_dir"
+        case proxySocketPath = "proxy_socket_path"
+        case consoleLogPath = "console_log_path"
+        case vmID = "vm_id"
+    }
+}
+
+private struct ControlResponse: Encodable {
+    let ok: Bool
+    let error: String?
+    let vmID: String?
+    let proxySocketPath: String?
+    let timingMS: [String: Int64]?
+
+    enum CodingKeys: String, CodingKey {
+        case ok
+        case error
+        case vmID = "vm_id"
+        case proxySocketPath = "proxy_socket_path"
+        case timingMS = "timing_ms"
+    }
+}
+
+private enum HelperError: LocalizedError {
+    case usage(String)
+    case invalidRequest(String)
+    case posix(String, Int32)
+    case timeout(String)
+    case vm(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .usage(let msg):
+            return msg
+        case .invalidRequest(let msg):
+            return msg
+        case .posix(let op, let code):
+            return "\(op): \(String(cString: strerror(code)))"
+        case .timeout(let msg):
+            return msg
+        case .vm(let msg):
+            return msg
+        }
+    }
+}
+
+private final class JSONLineConnection {
+    private let fd: Int32
+    private var buffer = Data()
+
+    init(fd: Int32) {
+        self.fd = fd
+    }
+
+    deinit {
+        _ = Darwin.close(fd)
+    }
+
+    func readRequest() throws -> ControlRequest? {
+        var chunk = [UInt8](repeating: 0, count: 4096)
+
+        while true {
+            if let newline = buffer.firstIndex(of: 0x0A) {
+                let line = buffer.subdata(in: 0..<newline)
+                buffer.removeSubrange(0...newline)
+                if line.isEmpty {
+                    continue
+                }
+                return try JSONDecoder().decode(ControlRequest.self, from: line)
+            }
+
+            let readCount = chunk.withUnsafeMutableBytes { rawBuffer -> Int in
+                guard let base = rawBuffer.baseAddress else {
+                    return 0
+                }
+                return Darwin.read(fd, base, rawBuffer.count)
+            }
+            if readCount == 0 {
+                if buffer.isEmpty {
+                    return nil
+                }
+                let line = buffer
+                buffer.removeAll(keepingCapacity: false)
+                return try JSONDecoder().decode(ControlRequest.self, from: line)
+            }
+            if readCount < 0 {
+                if errno == EINTR {
+                    continue
+                }
+                throw HelperError.posix("read", errno)
+            }
+            buffer.append(contentsOf: chunk[0..<readCount])
+        }
+    }
+
+    func writeResponse(_ res: ControlResponse) throws {
+        var payload = try JSONEncoder().encode(res)
+        payload.append(0x0A)
+        let bytes = [UInt8](payload)
+        try writeAll(dst: fd, buffer: bytes, count: bytes.count)
+    }
+}
+
+private final class UnixListener {
+    let path: String
+    private var fd: Int32
+    private let lock = NSLock()
+
+    init(path: String) throws {
+        self.path = path
+        self.fd = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else {
+            throw HelperError.posix("socket", errno)
+        }
+
+        _ = path.withCString { Darwin.unlink($0) }
+
+        var addr = sockaddr_un()
+        #if os(macOS)
+        addr.sun_len = UInt8(MemoryLayout<sockaddr_un>.size)
+        #endif
+        addr.sun_family = sa_family_t(AF_UNIX)
+
+        let pathBytes = Array(path.utf8CString)
+        let maxPathBytes = MemoryLayout.size(ofValue: addr.sun_path)
+        guard pathBytes.count <= maxPathBytes else {
+            close()
+            throw HelperError.invalidRequest("unix socket path is too long: \(path)")
+        }
+
+        withUnsafeMutablePointer(to: &addr.sun_path) { ptr in
+            ptr.withMemoryRebound(to: CChar.self, capacity: maxPathBytes) { cptr in
+                cptr.initialize(repeating: 0, count: maxPathBytes)
+                for i in 0..<pathBytes.count {
+                    cptr[i] = pathBytes[i]
+                }
+            }
+        }
+
+        let addrLen = socklen_t(MemoryLayout.offset(of: \sockaddr_un.sun_path)! + pathBytes.count)
+        let bindResult = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { saPtr in
+                Darwin.bind(fd, saPtr, addrLen)
+            }
+        }
+        guard bindResult == 0 else {
+            let code = errno
+            close()
+            throw HelperError.posix("bind(\(path))", code)
+        }
+
+        guard Darwin.listen(fd, 4) == 0 else {
+            let code = errno
+            close()
+            throw HelperError.posix("listen(\(path))", code)
+        }
+    }
+
+    func accept() throws -> Int32 {
+        while true {
+            let clientFD = Darwin.accept(fd, nil, nil)
+            if clientFD >= 0 {
+                return clientFD
+            }
+            if errno == EINTR {
+                continue
+            }
+            throw HelperError.posix("accept(\(path))", errno)
+        }
+    }
+
+    func close() {
+        lock.lock()
+        defer { lock.unlock() }
+        if fd >= 0 {
+            _ = Darwin.close(fd)
+            fd = -1
+        }
+        _ = path.withCString { Darwin.unlink($0) }
+    }
+
+    deinit {
+        close()
+    }
+}
+
+private final class GuestChannel {
+    let readFD: Int32
+    let writeFD: Int32
+    private var closed = false
+    private let onClose: () -> Void
+
+    init(readFD: Int32, writeFD: Int32, onClose: @escaping () -> Void) {
+        self.readFD = readFD
+        self.writeFD = writeFD
+        self.onClose = onClose
+    }
+
+    func close() {
+        if closed {
+            return
+        }
+        closed = true
+        onClose()
+    }
+}
+
+private final class ProxyServer {
+    private let listener: UnixListener
+    private let lock = NSLock()
+    private var stopped = false
+    private var activeChannel: GuestChannel?
+    private let queue = DispatchQueue(label: "cleanroom.darwin-vz.proxy")
+
+    init(path: String) throws {
+        self.listener = try UnixListener(path: path)
+    }
+
+    func start(connectGuest: @escaping () throws -> GuestChannel) {
+        queue.async { [weak self] in
+            self?.acceptAndBridge(connectGuest: connectGuest)
+        }
+    }
+
+    func stop() {
+        lock.lock()
+        stopped = true
+        activeChannel?.close()
+        activeChannel = nil
+        lock.unlock()
+        listener.close()
+    }
+
+    private func acceptAndBridge(connectGuest: @escaping () throws -> GuestChannel) {
+        let hostFD: Int32
+        do {
+            hostFD = try listener.accept()
+        } catch {
+            if !isStopped() {
+                fputs("cleanroom-darwin-vz proxy accept failed: \(error)\n", stderr)
+            }
+            return
+        }
+
+        defer { _ = Darwin.close(hostFD) }
+        if isStopped() {
+            return
+        }
+
+        let guestChannel: GuestChannel
+        do {
+            guestChannel = try connectGuest()
+        } catch {
+            fputs("cleanroom-darwin-vz guest channel connect failed: \(error)\n", stderr)
+            return
+        }
+
+        lock.lock()
+        activeChannel = guestChannel
+        lock.unlock()
+
+        bridge(hostFD: hostFD, guestReadFD: guestChannel.readFD, guestWriteFD: guestChannel.writeFD)
+        guestChannel.close()
+
+        lock.lock()
+        if activeChannel === guestChannel {
+            activeChannel = nil
+        }
+        lock.unlock()
+    }
+
+    private func bridge(hostFD: Int32, guestReadFD: Int32, guestWriteFD: Int32) {
+        let group = DispatchGroup()
+        let errorLock = NSLock()
+        var firstError: Error?
+
+        let captureError: (Error) -> Void = { err in
+            errorLock.lock()
+            defer { errorLock.unlock() }
+            if firstError == nil {
+                firstError = err
+            }
+        }
+
+        group.enter()
+        DispatchQueue.global(qos: .userInitiated).async {
+            defer { group.leave() }
+            do {
+                try pumpBytes(src: hostFD, dst: guestWriteFD)
+            } catch {
+                captureError(error)
+            }
+        }
+
+        group.enter()
+        DispatchQueue.global(qos: .userInitiated).async {
+            defer { group.leave() }
+            do {
+                try pumpBytes(src: guestReadFD, dst: hostFD)
+            } catch {
+                captureError(error)
+            }
+            _ = Darwin.shutdown(hostFD, SHUT_WR)
+        }
+
+        group.wait()
+        if let err = firstError, !isStopped() {
+            fputs("cleanroom-darwin-vz proxy transport warning: \(err)\n", stderr)
+        }
+    }
+
+    private func isStopped() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return stopped
+    }
+}
+
+private final class VMRuntime {
+    private let lock = NSLock()
+    private var vm: VZVirtualMachine?
+    private var vmID: String?
+    private var serialChannel: GuestChannel?
+    private var guestPort: UInt32 = 0
+    private var launchTimeout: TimeInterval = 30
+    private var vmQueue: DispatchQueue?
+    private var proxy: ProxyServer?
+
+    func start(from req: ControlRequest) throws -> ControlResponse {
+        guard VZVirtualMachine.isSupported else {
+            throw HelperError.vm("virtualization is not supported on this host")
+        }
+
+        let kernelPath = try requireAbsolutePath(req.kernelPath, field: "kernel_path")
+        let rootFSPath = try requireAbsolutePath(req.rootFSPath, field: "rootfs_path")
+        let runDir = try requireAbsolutePath(req.runDir, field: "run_dir")
+        let proxySocketPath = try requireAbsolutePath(req.proxySocketPath, field: "proxy_socket_path")
+        let consoleLogPath = try requireAbsolutePath(req.consoleLogPath, field: "console_log_path")
+
+        try requireFile(kernelPath, field: "kernel_path")
+        try requireFile(rootFSPath, field: "rootfs_path")
+        try ensureDirectory(runDir)
+        try ensureDirectory((proxySocketPath as NSString).deletingLastPathComponent)
+        try ensureDirectory((consoleLogPath as NSString).deletingLastPathComponent)
+
+        let vcpus = max(1, req.vcpus ?? 1)
+        let memoryMiB = max(Int64(256), req.memoryMiB ?? 512)
+        let guestPort = req.guestPort ?? 10_700
+        let launchSeconds = max(Int64(5), req.launchSeconds ?? 30)
+
+        lock.lock()
+        if vm != nil {
+            lock.unlock()
+            throw HelperError.invalidRequest("vm is already running")
+        }
+        lock.unlock()
+
+        let vmQueue = DispatchQueue(label: "cleanroom.darwin-vz.vm")
+        let vmID = UUID().uuidString
+        let startedAt = Date()
+
+        let (vm, serialChannel) = try buildVM(
+            kernelPath: kernelPath,
+            rootFSPath: rootFSPath,
+            vcpus: vcpus,
+            memoryMiB: memoryMiB,
+            guestPort: guestPort,
+            consoleLogPath: consoleLogPath,
+            queue: vmQueue
+        )
+
+        try startVM(vm, queue: vmQueue, timeoutSeconds: launchSeconds)
+
+        let proxy = try ProxyServer(path: proxySocketPath)
+        self.guestPort = guestPort
+        self.launchTimeout = TimeInterval(launchSeconds)
+        self.serialChannel = serialChannel
+        self.vmQueue = vmQueue
+        self.vm = vm
+        self.vmID = vmID
+        self.proxy = proxy
+        proxy.start { [weak self] in
+            guard let self else {
+                throw HelperError.vm("vm runtime no longer available")
+            }
+            return try self.connectGuestChannel()
+        }
+
+        let vmReadyMS = Int64(Date().timeIntervalSince(startedAt) * 1000)
+        return ControlResponse(
+            ok: true,
+            error: nil,
+            vmID: vmID,
+            proxySocketPath: proxySocketPath,
+            timingMS: ["vm_ready": vmReadyMS]
+        )
+    }
+
+    func stop(vmID requestedID: String?) throws {
+        lock.lock()
+        let currentID = vmID
+        let vm = self.vm
+        let serialChannel = self.serialChannel
+        let vmQueue = self.vmQueue
+        let proxy = self.proxy
+        self.vmID = nil
+        self.vm = nil
+        self.serialChannel = nil
+        self.guestPort = 0
+        self.launchTimeout = 30
+        self.vmQueue = nil
+        self.proxy = nil
+        lock.unlock()
+
+        if let requestedID, !requestedID.isEmpty, let currentID, requestedID != currentID {
+            throw HelperError.invalidRequest("unknown vm_id \(requestedID)")
+        }
+
+        proxy?.stop()
+        serialChannel?.close()
+        guard let vm else {
+            return
+        }
+        try stopVM(vm, queue: vmQueue)
+    }
+
+    private func buildVM(
+        kernelPath: String,
+        rootFSPath: String,
+        vcpus: Int,
+        memoryMiB: Int64,
+        guestPort: UInt32,
+        consoleLogPath: String,
+        queue: DispatchQueue
+    ) throws -> (VZVirtualMachine, GuestChannel) {
+        let kernelURL = URL(fileURLWithPath: kernelPath)
+        let rootFSURL = URL(fileURLWithPath: rootFSPath)
+        let consoleURL = URL(fileURLWithPath: consoleLogPath)
+
+        let bootLoader = VZLinuxBootLoader(kernelURL: kernelURL)
+        bootLoader.commandLine = "console=hvc0 root=/dev/vda rw init=/sbin/cleanroom-init cleanroom_guest_port=\(guestPort)"
+
+        let config = VZVirtualMachineConfiguration()
+        config.bootLoader = bootLoader
+        config.cpuCount = vcpus
+        config.memorySize = UInt64(memoryMiB) * 1024 * 1024
+
+        let serialAttachment = try VZFileSerialPortAttachment(url: consoleURL, append: false)
+        let serial = VZVirtioConsoleDeviceSerialPortConfiguration()
+        serial.attachment = serialAttachment
+
+        let hostToGuest = Pipe()
+        let guestToHost = Pipe()
+        let execAttachment = VZFileHandleSerialPortAttachment(
+            fileHandleForReading: hostToGuest.fileHandleForReading,
+            fileHandleForWriting: guestToHost.fileHandleForWriting
+        )
+        let execPort = VZVirtioConsoleDeviceSerialPortConfiguration()
+        execPort.attachment = execAttachment
+        config.serialPorts = [serial, execPort]
+
+        let diskAttachment = try VZDiskImageStorageDeviceAttachment(url: rootFSURL, readOnly: false)
+        let blockDevice = VZVirtioBlockDeviceConfiguration(attachment: diskAttachment)
+        config.storageDevices = [blockDevice]
+
+        config.entropyDevices = [VZVirtioEntropyDeviceConfiguration()]
+        config.memoryBalloonDevices = [VZVirtioTraditionalMemoryBalloonDeviceConfiguration()]
+        config.socketDevices = [VZVirtioSocketDeviceConfiguration()]
+
+        try config.validate()
+        let channel = GuestChannel(
+            readFD: guestToHost.fileHandleForReading.fileDescriptor,
+            writeFD: hostToGuest.fileHandleForWriting.fileDescriptor,
+            onClose: {
+                guestToHost.fileHandleForReading.closeFile()
+                hostToGuest.fileHandleForWriting.closeFile()
+            }
+        )
+        return (VZVirtualMachine(configuration: config, queue: queue), channel)
+    }
+
+    private func startVM(_ vm: VZVirtualMachine, queue: DispatchQueue, timeoutSeconds: Int64) throws {
+        let sem = DispatchSemaphore(value: 0)
+        var startError: Error?
+
+        queue.async {
+            vm.start { result in
+                if case .failure(let err) = result {
+                    startError = err
+                }
+                sem.signal()
+            }
+        }
+
+        if sem.wait(timeout: .now() + .seconds(Int(timeoutSeconds))) == .timedOut {
+            throw HelperError.timeout("timed out waiting for vm to start")
+        }
+        if let startError {
+            throw HelperError.vm("failed to start vm: \(startError)")
+        }
+    }
+
+    private func stopVM(_ vm: VZVirtualMachine, queue: DispatchQueue?) throws {
+        let workQueue = queue ?? DispatchQueue(label: "cleanroom.darwin-vz.vm.stop")
+
+        let requestStopSem = DispatchSemaphore(value: 0)
+        workQueue.async {
+            if vm.canRequestStop {
+                _ = try? vm.requestStop()
+            }
+            requestStopSem.signal()
+        }
+        _ = requestStopSem.wait(timeout: .now() + .seconds(2))
+
+        if #available(macOS 12.0, *) {
+            let stopSem = DispatchSemaphore(value: 0)
+            var stopError: Error?
+            workQueue.async {
+                if vm.canStop {
+                    vm.stop { err in
+                        stopError = err
+                        stopSem.signal()
+                    }
+                } else {
+                    stopSem.signal()
+                }
+            }
+            _ = stopSem.wait(timeout: .now() + .seconds(5))
+            if let stopError {
+                throw HelperError.vm("failed to stop vm: \(stopError)")
+            }
+        }
+    }
+
+    private func connectGuestChannel() throws -> GuestChannel {
+        lock.lock()
+        let vm = self.vm
+        let vmQueue = self.vmQueue
+        let guestPort = self.guestPort
+        let timeout = self.launchTimeout
+        let serialChannel = self.serialChannel
+        lock.unlock()
+
+        guard let vm else {
+            throw HelperError.vm("vm is not running")
+        }
+        guard vm.state == .running else {
+            throw HelperError.vm("vm is not running")
+        }
+        guard let vmQueue else {
+            throw HelperError.vm("vm queue is unavailable")
+        }
+
+        if let socketDevice = vm.socketDevices.first as? VZVirtioSocketDevice {
+            let deadline = Date().addingTimeInterval(timeout)
+            var lastError: Error?
+            while Date() < deadline {
+                let sem = DispatchSemaphore(value: 0)
+                var resultConnection: VZVirtioSocketConnection?
+                var resultError: Error?
+
+                vmQueue.async {
+                    socketDevice.connect(toPort: guestPort) { result in
+                        switch result {
+                        case .success(let conn):
+                            resultConnection = conn
+                        case .failure(let err):
+                            resultError = err
+                        }
+                        sem.signal()
+                    }
+                }
+
+                let remaining = max(0, deadline.timeIntervalSinceNow)
+                if sem.wait(timeout: .now() + remaining) == .timedOut {
+                    break
+                }
+                if let resultConnection {
+                    return GuestChannel(
+                        readFD: resultConnection.fileDescriptor,
+                        writeFD: resultConnection.fileDescriptor,
+                        onClose: { resultConnection.close() }
+                    )
+                }
+                if let resultError {
+                    lastError = resultError
+                } else {
+                    lastError = HelperError.vm("guest vsock connect returned no connection")
+                }
+                usleep(100_000)
+            }
+            if let lastError {
+                fputs("cleanroom-darwin-vz: vsock connect fallback to serial after error: \(lastError)\n", stderr)
+            } else {
+                fputs("cleanroom-darwin-vz: vsock connect timed out, falling back to serial\n", stderr)
+            }
+        }
+
+        guard let serialChannel else {
+            throw HelperError.vm("guest serial channel is not available")
+        }
+        return serialChannel
+    }
+}
+
+private final class HelperService {
+    private let socketPath: String
+    private let vmRuntime = VMRuntime()
+
+    init(socketPath: String) {
+        self.socketPath = socketPath
+    }
+
+    func run() throws {
+        let listener = try UnixListener(path: socketPath)
+        defer {
+            try? vmRuntime.stop(vmID: nil)
+            listener.close()
+        }
+
+        let controlFD = try listener.accept()
+        let conn = JSONLineConnection(fd: controlFD)
+
+        while true {
+            guard let req = try readRequest(conn) else {
+                break
+            }
+
+            do {
+                let response = try handle(req)
+                try conn.writeResponse(response)
+            } catch {
+                try conn.writeResponse(ControlResponse(
+                    ok: false,
+                    error: error.localizedDescription,
+                    vmID: nil,
+                    proxySocketPath: nil,
+                    timingMS: nil
+                ))
+            }
+        }
+    }
+
+    private func readRequest(_ conn: JSONLineConnection) throws -> ControlRequest? {
+        do {
+            return try conn.readRequest()
+        } catch {
+            throw HelperError.invalidRequest("failed to decode control request: \(error)")
+        }
+    }
+
+    private func handle(_ req: ControlRequest) throws -> ControlResponse {
+        switch req.op {
+        case "StartVM":
+            return try vmRuntime.start(from: req)
+        case "StopVM":
+            try vmRuntime.stop(vmID: req.vmID)
+            return ControlResponse(ok: true, error: nil, vmID: nil, proxySocketPath: nil, timingMS: nil)
+        case "Ping":
+            return ControlResponse(ok: true, error: nil, vmID: nil, proxySocketPath: nil, timingMS: nil)
+        default:
+            throw HelperError.invalidRequest("unsupported op \(req.op)")
+        }
+    }
+}
+
+private func parseCLI() throws -> CLIOptions {
+    var socketPath = ""
+
+    var i = 1
+    while i < CommandLine.arguments.count {
+        let arg = CommandLine.arguments[i]
+        switch arg {
+        case "--socket":
+            i += 1
+            guard i < CommandLine.arguments.count else {
+                throw HelperError.usage("missing value for --socket")
+            }
+            socketPath = CommandLine.arguments[i]
+        case "--help", "-h":
+            throw HelperError.usage("usage: cleanroom-darwin-vz --socket /abs/path/helper.sock")
+        default:
+            throw HelperError.usage("unknown argument \(arg)")
+        }
+        i += 1
+    }
+
+    if socketPath.isEmpty {
+        throw HelperError.usage("missing --socket")
+    }
+    if !socketPath.hasPrefix("/") {
+        throw HelperError.usage("--socket path must be absolute")
+    }
+    return CLIOptions(socketPath: socketPath)
+}
+
+private func requireAbsolutePath(_ rawValue: String?, field: String) throws -> String {
+    guard let rawValue else {
+        throw HelperError.invalidRequest("missing \(field)")
+    }
+    let path = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !path.isEmpty else {
+        throw HelperError.invalidRequest("missing \(field)")
+    }
+    guard path.hasPrefix("/") else {
+        throw HelperError.invalidRequest("\(field) must be absolute")
+    }
+    return path
+}
+
+private func requireFile(_ path: String, field: String) throws {
+    var isDir: ObjCBool = false
+    guard FileManager.default.fileExists(atPath: path, isDirectory: &isDir), !isDir.boolValue else {
+        throw HelperError.invalidRequest("\(field) does not exist: \(path)")
+    }
+}
+
+private func ensureDirectory(_ path: String) throws {
+    guard !path.isEmpty else {
+        throw HelperError.invalidRequest("directory path is empty")
+    }
+    try FileManager.default.createDirectory(atPath: path, withIntermediateDirectories: true)
+}
+
+private func pumpBytes(src: Int32, dst: Int32) throws {
+    var buffer = [UInt8](repeating: 0, count: 64 * 1024)
+
+    while true {
+        let readCount = buffer.withUnsafeMutableBytes { rawBuffer -> Int in
+            guard let base = rawBuffer.baseAddress else {
+                return 0
+            }
+            return Darwin.read(src, base, rawBuffer.count)
+        }
+
+        if readCount == 0 {
+            return
+        }
+        if readCount < 0 {
+            if errno == EINTR {
+                continue
+            }
+            throw HelperError.posix("read", errno)
+        }
+
+        try writeAll(dst: dst, buffer: buffer, count: readCount)
+    }
+}
+
+private func writeAll(dst: Int32, buffer: [UInt8], count: Int) throws {
+    var offset = 0
+    while offset < count {
+        let written = buffer.withUnsafeBytes { rawBuffer -> Int in
+            guard let base = rawBuffer.baseAddress else {
+                return 0
+            }
+            return Darwin.write(dst, base.advanced(by: offset), count - offset)
+        }
+        if written < 0 {
+            if errno == EINTR {
+                continue
+            }
+            throw HelperError.posix("write", errno)
+        }
+        if written == 0 {
+            throw HelperError.vm("short write on proxy stream")
+        }
+        offset += written
+    }
+}
+
+do {
+    let options = try parseCLI()
+    let service = HelperService(socketPath: options.socketPath)
+    try service.run()
+} catch {
+    fputs("cleanroom-darwin-vz: \(error.localizedDescription)\n", stderr)
+    exit(1)
+}

--- a/cmd/cleanroom-darwin-vz/main.swift
+++ b/cmd/cleanroom-darwin-vz/main.swift
@@ -428,6 +428,10 @@ private final class VMRuntime {
     func stop(vmID requestedID: String?) throws {
         lock.lock()
         let currentID = vmID
+        if let requestedID, !requestedID.isEmpty, let currentID, requestedID != currentID {
+            lock.unlock()
+            throw HelperError.invalidRequest("unknown vm_id \(requestedID)")
+        }
         let vm = self.vm
         let serialChannel = self.serialChannel
         let vmQueue = self.vmQueue
@@ -440,10 +444,6 @@ private final class VMRuntime {
         self.vmQueue = nil
         self.proxy = nil
         lock.unlock()
-
-        if let requestedID, !requestedID.isEmpty, let currentID, requestedID != currentID {
-            throw HelperError.invalidRequest("unknown vm_id \(requestedID)")
-        }
 
         proxy?.stop()
         serialChannel?.close()

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -35,24 +35,26 @@ The `:fire: E2E (Firecracker)` step runs a real launched Firecracker execution a
 
 - Linux host with `/dev/kvm` available
 - Firecracker binary (default `/usr/local/bin/firecracker`)
-- Readable kernel and rootfs images for the `buildkite-agent` user
+- Readable kernel image for the `buildkite-agent` user (or allow managed kernel auto-download)
+- Internet egress to pull `sandbox.image.ref` from registry on first run
+- `mkfs.ext4` available for OCI-to-ext4 materialization
 - Passwordless sudo for required network setup commands
 
-### 3.2 Place runtime images
+### 3.2 Place runtime kernel image
 
-Put image assets under the Buildkite agent home so CI can read them:
+Put kernel assets under the Buildkite agent home so CI can read them:
 
 ```bash
 sudo install -d -o buildkite-agent -g buildkite-agent /var/lib/buildkite-agent/.local/share/cleanroom/images
 sudo cp /path/to/vmlinux.bin /var/lib/buildkite-agent/.local/share/cleanroom/images/
-sudo cp /path/to/rootfs.ext4 /var/lib/buildkite-agent/.local/share/cleanroom/images/
-sudo chown buildkite-agent:buildkite-agent /var/lib/buildkite-agent/.local/share/cleanroom/images/*
+sudo chown buildkite-agent:buildkite-agent /var/lib/buildkite-agent/.local/share/cleanroom/images/vmlinux.bin
 ```
+
+The Firecracker backend derives runtime rootfs from `sandbox.image.ref` automatically; no prebuilt `rootfs.ext4` is required.
 
 The pipeline is currently configured to use:
 
 - `CLEANROOM_KERNEL_IMAGE=/var/lib/buildkite-agent/.local/share/cleanroom/images/vmlinux.bin`
-- `CLEANROOM_ROOTFS=/var/lib/buildkite-agent/.local/share/cleanroom/images/rootfs.ext4`
 - `CLEANROOM_FIRECRACKER_BINARY=/usr/local/bin/firecracker`
 
 ### 3.3 Privileged command execution modes
@@ -113,7 +115,6 @@ If you prefer host-level env over pipeline step env, set variables in `/etc/buil
 set -euo pipefail
 
 export CLEANROOM_KERNEL_IMAGE="/var/lib/buildkite-agent/.local/share/cleanroom/images/vmlinux.bin"
-export CLEANROOM_ROOTFS="/var/lib/buildkite-agent/.local/share/cleanroom/images/rootfs.ext4"
 export CLEANROOM_FIRECRACKER_BINARY="/usr/local/bin/firecracker"
 ```
 

--- a/docs/darwin-vz.md
+++ b/docs/darwin-vz.md
@@ -99,8 +99,24 @@ On macOS, cleanroom also probes common Homebrew `e2fsprogs` locations.
 
 - `network.default` must be `deny`
 - `network.allow` entries are ignored and produce a warning
+- no virtual NIC is attached, so guest outbound networking is unavailable in current builds
 
 The backend currently has no allowlist egress enforcement equivalent to Linux Firecracker iptables rules.
+
+At runtime, `darwin-vz` emits an explicit stderr warning for this so it is visible during `exec`/`console`.
+
+## Capability Surface
+
+Backends now expose a machine-readable capability map (visible in `cleanroom doctor --json` under `capabilities`).
+
+Current `darwin-vz` capability values:
+
+- `exec.streaming=true`
+- `sandbox.persistent=false`
+- `sandbox.file_download=false`
+- `network.default_deny=true`
+- `network.allowlist_egress=false`
+- `network.guest_interface=false`
 
 ## Entitlements and Signing
 

--- a/docs/darwin-vz.md
+++ b/docs/darwin-vz.md
@@ -1,0 +1,129 @@
+# Darwin VZ Backend
+
+## Overview
+
+`darwin-vz` is the macOS microVM backend for cleanroom. It uses a dedicated Swift helper binary (`cleanroom-darwin-vz`) for `Virtualization.framework` lifecycle operations and keeps policy/image/control-plane orchestration in Go.
+
+This split means:
+
+- Go owns policy validation, OCI/image preparation, kernel/rootfs selection, and command protocol semantics.
+- Swift owns VM create/start/stop and guest transport bridging.
+
+## Current Scope
+
+Implemented:
+
+- launched execution on macOS via `Virtualization.framework`
+- interactive and non-interactive command execution via existing `internal/vsockexec` protocol
+- helper-managed VM lifecycle (`StartVM` / `StopVM`)
+- managed kernel fallback when `kernel_image` is unset or missing
+- rootfs derivation from `sandbox.image.ref` when `rootfs` is unset or missing
+- doctor checks for helper availability and entitlement status
+
+Not implemented:
+
+- egress allowlist filtering for `sandbox.network.allow`
+- persistent `darwin-vz` sandboxes across multiple executions
+
+## Process and Transport Model
+
+Each launched execution starts a dedicated helper process.
+
+Control plane:
+
+- socket: `<run_dir>/vz-helper.sock`
+- protocol: newline-delimited JSON request/response
+- operations: `StartVM`, `StopVM`, `Ping`
+
+Data plane:
+
+- socket: `<run_dir>/vz-proxy.sock`
+- protocol: raw byte stream carrying existing `vsockexec` frames unchanged
+
+High-level flow:
+
+1. Go resolves kernel and rootfs paths.
+2. Go starts `cleanroom-darwin-vz --socket <run_dir>/vz-helper.sock`.
+3. Go sends `StartVM`.
+4. Helper starts VM and binds proxy socket.
+5. Go dials proxy socket and runs normal `vsockexec` request/stream protocol.
+6. Go sends `StopVM` during teardown.
+
+## Helper Request Schema
+
+`StartVM` request fields:
+
+- `kernel_path` absolute path to Linux kernel
+- `rootfs_path` absolute path to per-run ext4 rootfs copy
+- `vcpus`, `memory_mib`, `guest_port`, `launch_seconds`
+- `run_dir`
+- `proxy_socket_path`
+- `console_log_path`
+
+`StartVM` response fields:
+
+- `ok`
+- `vm_id`
+- `proxy_socket_path`
+- optional `timing_ms.vm_ready`
+
+`StopVM` request:
+
+- `op=StopVM`
+- optional `vm_id` (validated when provided)
+
+## Kernel and RootFS Strategy
+
+Kernel:
+
+- if configured kernel exists, use it
+- otherwise resolve and cache a managed kernel asset under XDG data paths
+
+Rootfs:
+
+- if configured rootfs exists, use it
+- otherwise derive rootfs from `sandbox.image.ref` using image manager
+- inject guest runtime (`cleanroom-guest-agent` and `/sbin/cleanroom-init`) into a prepared cached rootfs image
+- create a per-run copy (`rootfs-ephemeral.ext4`) and attach it read-write to the VM
+
+Host tools required for derivation/injection:
+
+- `mkfs.ext4`
+- `debugfs`
+
+On macOS, cleanroom also probes common Homebrew `e2fsprogs` locations.
+
+## Networking Semantics
+
+`darwin-vz` currently enforces only deny-by-default policy shape:
+
+- `network.default` must be `deny`
+- `network.allow` entries are ignored and produce a warning
+
+The backend currently has no allowlist egress enforcement equivalent to Linux Firecracker iptables rules.
+
+## Entitlements and Signing
+
+`cleanroom-darwin-vz` must include:
+
+- `com.apple.security.virtualization`
+
+The main `cleanroom` Go binary does not require this entitlement for `darwin-vz`.
+
+`mise run build:darwin` and `mise run install:darwin` both sign the helper with `cmd/cleanroom-darwin-vz/entitlements.plist`.
+
+## Runtime Discovery
+
+The helper path is resolved in this order:
+
+1. `CLEANROOM_DARWIN_VZ_HELPER`
+2. sibling binary next to `cleanroom`
+3. `PATH`
+
+If missing, runtime fails with an actionable error.
+
+## Limitations
+
+- no allowlist egress filtering yet
+- per-run helper/VM lifecycle only (no long-lived helper daemon)
+- no cross-execution mutable sandbox state on `darwin-vz`

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	connectrpc.com/connect v1.18.1
 	github.com/alecthomas/kong v1.12.1
 	github.com/charmbracelet/log v0.4.2
+	github.com/creack/pty v1.1.24
 	github.com/firecracker-microvm/firecracker-go-sdk v1.0.0
 	github.com/google/go-containerregistry v0.20.2
 	github.com/mdlayher/vsock v1.2.1
@@ -47,7 +48,6 @@ require (
 	github.com/coder/websocket v1.8.12 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.16.3 // indirect
 	github.com/coreos/go-iptables v0.7.1-0.20240112124308-65c67c9f46e6 // indirect
-	github.com/creack/pty v1.1.24 // indirect
 	github.com/dblohm7/wingoes v0.0.0-20240119213807-a09d6be7affa // indirect
 	github.com/digitalocean/go-smbios v0.0.0-20180907143718-390a4f403a8e // indirect
 	github.com/docker/cli v27.4.1+incompatible // indirect

--- a/internal/backend/capabilities_test.go
+++ b/internal/backend/capabilities_test.go
@@ -1,0 +1,72 @@
+package backend
+
+import (
+	"context"
+	"testing"
+)
+
+type testAdapter struct{}
+
+func (testAdapter) Name() string { return "test" }
+
+func (testAdapter) Run(context.Context, RunRequest) (*RunResult, error) {
+	return &RunResult{}, nil
+}
+
+type testStreamingAdapter struct{ testAdapter }
+
+func (testStreamingAdapter) RunStream(context.Context, RunRequest, OutputStream) (*RunResult, error) {
+	return &RunResult{}, nil
+}
+
+type testPersistentAdapter struct{ testStreamingAdapter }
+
+func (testPersistentAdapter) ProvisionSandbox(context.Context, ProvisionRequest) error { return nil }
+
+func (testPersistentAdapter) RunInSandbox(context.Context, RunRequest, OutputStream) (*RunResult, error) {
+	return &RunResult{}, nil
+}
+
+func (testPersistentAdapter) TerminateSandbox(context.Context, string) error { return nil }
+
+func (testPersistentAdapter) DownloadSandboxFile(context.Context, string, string, int64) ([]byte, error) {
+	return []byte("ok"), nil
+}
+
+type testReporterAdapter struct{ testAdapter }
+
+func (testReporterAdapter) Capabilities() map[string]bool {
+	return map[string]bool{
+		CapabilityNetworkDefaultDeny:     true,
+		CapabilityNetworkAllowlistEgress: false,
+		"custom.example":                 true,
+	}
+}
+
+func TestCapabilitiesForAdapterInfersInterfaceCapabilities(t *testing.T) {
+	caps := CapabilitiesForAdapter(testPersistentAdapter{})
+
+	if !caps[CapabilityExecStreaming] {
+		t.Fatalf("expected %s=true", CapabilityExecStreaming)
+	}
+	if !caps[CapabilitySandboxPersistent] {
+		t.Fatalf("expected %s=true", CapabilitySandboxPersistent)
+	}
+	if !caps[CapabilitySandboxFileDownload] {
+		t.Fatalf("expected %s=true", CapabilitySandboxFileDownload)
+	}
+}
+
+func TestCapabilitiesForAdapterMergesReporterCapabilities(t *testing.T) {
+	caps := CapabilitiesForAdapter(testReporterAdapter{})
+
+	if !caps[CapabilityNetworkDefaultDeny] {
+		t.Fatalf("expected %s=true", CapabilityNetworkDefaultDeny)
+	}
+	if caps[CapabilityNetworkAllowlistEgress] {
+		t.Fatalf("expected %s=false", CapabilityNetworkAllowlistEgress)
+	}
+	if !caps["custom.example"] {
+		t.Fatalf("expected custom capability key to be preserved")
+	}
+}

--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -1,0 +1,1004 @@
+//go:build darwin
+
+package darwinvz
+
+import (
+	"context"
+	cryptorand "crypto/rand"
+	"crypto/sha256"
+	"debug/elf"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/bootassets"
+	"github.com/buildkite/cleanroom/internal/hosttools"
+	"github.com/buildkite/cleanroom/internal/imagemgr"
+	"github.com/buildkite/cleanroom/internal/paths"
+	"github.com/buildkite/cleanroom/internal/vsockexec"
+)
+
+// Adapter runs single-execution Linux VMs on macOS via Virtualization.framework.
+//
+// Current scope intentionally excludes host/port egress allow rules. Policies
+// with allow entries still run, but those entries are ignored.
+type Adapter struct {
+	imageManagerOnce sync.Once
+	imageManager     imageEnsurer
+	imageManagerErr  error
+	newImageManager  imageManagerFactory
+
+	guestAgentOnce sync.Once
+	guestAgentPath string
+	guestAgentHash string
+	guestAgentErr  error
+
+	runtimeImageMu sync.Mutex
+
+	ensurePreparedRootFSFn func(context.Context, string) (preparedRootFS, error)
+}
+
+type imageEnsurer interface {
+	Ensure(context.Context, string) (imagemgr.EnsureResult, error)
+}
+
+type imageManagerFactory func() (imageEnsurer, error)
+
+type preparedRootFS struct {
+	Ref    string
+	Digest string
+	Path   string
+	Hit    bool
+}
+
+const preparedRuntimeRootFSVersion = "v8-darwin-vz"
+
+var virtualizationEntitlementPattern = regexp.MustCompile(`(?s)<key>\s*com\.apple\.security\.virtualization\s*</key>\s*<true\s*/?>`)
+
+const guestInitScriptTemplate = `#!/bin/sh
+set -eu
+
+mount -t proc proc /proc 2>/dev/null || true
+mount -t sysfs sysfs /sys 2>/dev/null || true
+mount -t devtmpfs devtmpfs /dev 2>/dev/null || true
+mkdir -p /dev/pts /run /tmp
+mount -t devpts devpts /dev/pts 2>/dev/null || true
+mount -t tmpfs tmpfs /run 2>/dev/null || true
+mount -t tmpfs tmpfs /tmp 2>/dev/null || true
+
+export HOME=/root
+export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/.local/bin
+
+cmdline="$(cat /proc/cmdline 2>/dev/null || true)"
+arg_value() {
+  key="$1"
+  for token in $cmdline; do
+    case "$token" in
+      "$key"=*) echo "${token#*=}"; return 0 ;;
+    esac
+  done
+  return 1
+}
+
+GUEST_PORT="$(arg_value cleanroom_guest_port || true)"
+if [ -z "$GUEST_PORT" ]; then
+  GUEST_PORT="10700"
+fi
+export CLEANROOM_VSOCK_PORT="$GUEST_PORT"
+
+AGENT_DEV=""
+if [ -c /dev/hvc1 ]; then
+  AGENT_DEV="/dev/hvc1"
+elif [ -c /dev/vport1p0 ]; then
+  AGENT_DEV="/dev/vport1p0"
+fi
+
+if [ -n "$AGENT_DEV" ]; then
+  stty raw -echo <"$AGENT_DEV" 2>/dev/null || true
+  (
+    while true; do
+      CLEANROOM_GUEST_TRANSPORT=stdio /usr/local/bin/cleanroom-guest-agent <"$AGENT_DEV" >"$AGENT_DEV" 2>/dev/hvc0 || true
+      sleep 1
+    done
+  ) &
+fi
+
+while true; do
+  /usr/local/bin/cleanroom-guest-agent || true
+  sleep 1
+done
+`
+
+func New() *Adapter {
+	return &Adapter{
+		newImageManager: defaultImageManagerFactory,
+	}
+}
+
+func defaultImageManagerFactory() (imageEnsurer, error) {
+	return imagemgr.New(imagemgr.Options{})
+}
+
+func (a *Adapter) Name() string {
+	return "darwin-vz"
+}
+
+func (a *Adapter) Run(ctx context.Context, req backend.RunRequest) (*backend.RunResult, error) {
+	return a.run(ctx, req, backend.OutputStream{})
+}
+
+func (a *Adapter) RunStream(ctx context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+	return a.run(ctx, req, stream)
+}
+
+func (a *Adapter) Doctor(_ context.Context, req backend.DoctorRequest) (*backend.DoctorReport, error) {
+	report := &backend.DoctorReport{Backend: a.Name()}
+	appendCheck := func(name, status, message string) {
+		report.Checks = append(report.Checks, backend.DoctorCheck{Name: name, Status: status, Message: message})
+	}
+
+	if runtime.GOOS == "darwin" {
+		appendCheck("os", "pass", "darwin host detected")
+	} else {
+		appendCheck("os", "fail", fmt.Sprintf("darwin required, current OS is %s", runtime.GOOS))
+	}
+
+	if configured := strings.TrimSpace(req.KernelImagePath); configured == "" {
+		if spec, ok := bootassets.LookupManagedKernelForHost(a.Name()); ok {
+			path, _ := bootassets.ManagedKernelPathForHost(a.Name())
+			appendCheck("kernel_image", "pass", fmt.Sprintf("kernel image will be auto-managed (%s -> %s)", spec.ID, path))
+		} else {
+			appendCheck("kernel_image", "fail", "kernel image must be configured")
+		}
+	} else if _, err := os.Stat(configured); err != nil {
+		if spec, ok := bootassets.LookupManagedKernelForHost(a.Name()); ok {
+			path, _ := bootassets.ManagedKernelPathForHost(a.Name())
+			appendCheck("kernel_image", "warn", fmt.Sprintf("configured kernel image is not accessible (%v); runtime will use managed kernel (%s -> %s)", err, spec.ID, path))
+		} else {
+			appendCheck("kernel_image", "fail", fmt.Sprintf("kernel image not accessible: %v", err))
+		}
+	} else {
+		appendCheck("kernel_image", "pass", fmt.Sprintf("kernel image configured: %s", configured))
+	}
+
+	if strings.TrimSpace(req.RootFSPath) == "" {
+		if req.Policy != nil && strings.TrimSpace(req.Policy.ImageRef) != "" {
+			appendCheck("rootfs", "pass", "rootfs will be derived from sandbox.image.ref")
+		} else {
+			appendCheck("rootfs", "warn", "rootfs is not configured; provide sandbox.image.ref for automatic OCI rootfs derivation")
+		}
+	} else if _, err := os.Stat(req.RootFSPath); err != nil {
+		if req.Policy != nil && strings.TrimSpace(req.Policy.ImageRef) != "" {
+			appendCheck("rootfs", "warn", fmt.Sprintf("configured rootfs is not accessible (%v); runtime will derive rootfs from sandbox.image.ref", err))
+		} else {
+			appendCheck("rootfs", "fail", fmt.Sprintf("rootfs not accessible: %v", err))
+		}
+	} else {
+		appendCheck("rootfs", "pass", fmt.Sprintf("rootfs configured: %s", req.RootFSPath))
+	}
+
+	if req.Policy == nil {
+		appendCheck("policy", "warn", "policy not loaded")
+	} else {
+		policyWarn, policyErr := evaluateNetworkPolicy(req.Policy.NetworkDefault, len(req.Policy.Allow))
+		if policyErr != nil {
+			appendCheck("policy_network_default", "fail", policyErr.Error())
+		} else {
+			appendCheck("policy_network_default", "pass", "deny-by-default policy")
+			if policyWarn != "" {
+				appendCheck("policy_network_allow", "warn", policyWarn)
+			} else {
+				appendCheck("policy_network_allow", "pass", "allow list empty")
+			}
+			if strings.TrimSpace(req.Policy.ImageRef) == "" {
+				appendCheck("sandbox_image_ref", "fail", "sandbox.image.ref is required when rootfs is not configured")
+			} else {
+				appendCheck("sandbox_image_ref", "pass", fmt.Sprintf("sandbox image ref configured: %s", req.Policy.ImageRef))
+			}
+		}
+	}
+
+	requiresDerivedRootFS := true
+	if configuredRootFS := strings.TrimSpace(req.RootFSPath); configuredRootFS != "" {
+		if _, err := os.Stat(configuredRootFS); err == nil {
+			requiresDerivedRootFS = false
+		}
+	}
+	mkfsMissingStatus := "warn"
+	debugfsMissingStatus := "warn"
+	if requiresDerivedRootFS {
+		mkfsMissingStatus = "fail"
+		debugfsMissingStatus = "fail"
+	}
+
+	if mkfsPath, err := hosttools.ResolveE2FSProgsBinary("mkfs.ext4"); err != nil {
+		appendCheck("mkfs_ext4", mkfsMissingStatus, fmt.Sprintf("mkfs.ext4 not available: %v", err))
+	} else {
+		appendCheck("mkfs_ext4", "pass", fmt.Sprintf("found mkfs.ext4 (%s) for OCI rootfs materialisation", mkfsPath))
+	}
+
+	if debugfsPath, err := hosttools.ResolveE2FSProgsBinary("debugfs"); err != nil {
+		appendCheck("debugfs", debugfsMissingStatus, fmt.Sprintf("debugfs not available: %v", err))
+	} else {
+		appendCheck("debugfs", "pass", fmt.Sprintf("found debugfs (%s) for runtime rootfs preparation", debugfsPath))
+	}
+
+	if guestAgentPath, err := discoverGuestAgentBinary(); err != nil {
+		appendCheck("guest_agent_binary", "fail", err.Error())
+	} else {
+		appendCheck("guest_agent_binary", "pass", fmt.Sprintf("linux guest-agent resolved at %s", guestAgentPath))
+	}
+
+	if helperPath, err := resolveHelperBinaryPath(); err != nil {
+		appendCheck("helper_binary", "fail", err.Error())
+	} else {
+		appendCheck("helper_binary", "pass", fmt.Sprintf("darwin-vz helper resolved at %s", helperPath))
+		hasEntitlement, entitlementErr := helperHasVirtualizationEntitlement(helperPath)
+		switch {
+		case entitlementErr != nil:
+			appendCheck(
+				"vm_entitlement",
+				"warn",
+				fmt.Sprintf(
+					"could not verify com.apple.security.virtualization entitlement on %s: %v",
+					helperPath,
+					entitlementErr,
+				),
+			)
+		case !hasEntitlement:
+			appendCheck(
+				"vm_entitlement",
+				"fail",
+				fmt.Sprintf(
+					"%s is missing com.apple.security.virtualization entitlement; run `mise run install` to install and sign the helper",
+					helperPath,
+				),
+			)
+		default:
+			appendCheck(
+				"vm_entitlement",
+				"pass",
+				fmt.Sprintf("%s includes com.apple.security.virtualization entitlement", helperPath),
+			)
+		}
+	}
+	return report, nil
+}
+
+func (a *Adapter) run(ctx context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+	if req.Policy == nil {
+		return nil, errors.New("missing compiled policy")
+	}
+	policyWarn, policyErr := evaluateNetworkPolicy(req.Policy.NetworkDefault, len(req.Policy.Allow))
+	if policyErr != nil {
+		return nil, policyErr
+	}
+	if len(req.Command) == 0 {
+		return nil, errors.New("missing command")
+	}
+	if runtime.GOOS != "darwin" {
+		return nil, fmt.Errorf("darwin-vz backend is darwin-only, current OS is %s", runtime.GOOS)
+	}
+
+	runDir := req.RunDir
+	if runDir == "" {
+		baseDir, err := paths.RunBaseDir()
+		if err != nil {
+			return nil, fmt.Errorf("resolve run base directory: %w", err)
+		}
+		runDir = filepath.Join(baseDir, req.RunID)
+	}
+	if err := os.MkdirAll(runDir, 0o755); err != nil {
+		return nil, fmt.Errorf("create run directory: %w", err)
+	}
+
+	if req.VCPUs <= 0 {
+		req.VCPUs = 1
+	}
+	if req.MemoryMiB <= 0 {
+		req.MemoryMiB = 512
+	}
+	if req.GuestPort == 0 {
+		req.GuestPort = vsockexec.DefaultPort
+	}
+	if req.LaunchSeconds <= 0 {
+		req.LaunchSeconds = 30
+	}
+
+	cmdPath := filepath.Join(runDir, "requested-command.json")
+	if err := writeJSON(cmdPath, req.Command); err != nil {
+		return nil, err
+	}
+
+	stderrPrefix := ""
+	if policyWarn != "" {
+		stderrPrefix = "warning: " + policyWarn + "\n"
+		if stream.OnStderr != nil {
+			stream.OnStderr([]byte(stderrPrefix))
+		}
+	}
+
+	resolvedImageRef := req.Policy.ImageRef
+	resolvedImageDigest := req.Policy.ImageDigest
+
+	if !req.Launch {
+		planPath := filepath.Join(runDir, "plan.json")
+		plan := map[string]any{
+			"backend":      a.Name(),
+			"mode":         "plan-only",
+			"command_path": cmdPath,
+		}
+		if err := writeJSON(planPath, plan); err != nil {
+			return nil, err
+		}
+		return &backend.RunResult{
+			RunID:       req.RunID,
+			ExitCode:    0,
+			LaunchedVM:  false,
+			PlanPath:    planPath,
+			RunDir:      runDir,
+			ImageRef:    resolvedImageRef,
+			ImageDigest: resolvedImageDigest,
+			Message:     "darwin-vz execution plan generated; command not executed",
+			Stderr:      stderrPrefix,
+		}, nil
+	}
+
+	kernelPath, kernelNotice, err := a.resolveKernelPath(ctx, req.KernelImagePath)
+	if err != nil {
+		return nil, err
+	}
+	logRunNotice(a.Name(), req.RunID, kernelNotice)
+
+	rootFSPath, imageRef, imageDigest, rootFSNotice, err := a.resolveRootFSPath(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	logRunNotice(a.Name(), req.RunID, rootFSNotice)
+	if strings.TrimSpace(imageRef) != "" {
+		resolvedImageRef = imageRef
+	}
+	if strings.TrimSpace(imageDigest) != "" {
+		resolvedImageDigest = imageDigest
+	}
+
+	rootFSPath, err = filepath.Abs(rootFSPath)
+	if err != nil {
+		return nil, fmt.Errorf("resolve rootfs path: %w", err)
+	}
+	if _, err := os.Stat(rootFSPath); err != nil {
+		return nil, fmt.Errorf("rootfs %s: %w", rootFSPath, err)
+	}
+
+	vmRootFSPath := filepath.Join(runDir, "rootfs-ephemeral.ext4")
+	if err := copyFile(rootFSPath, vmRootFSPath); err != nil {
+		return nil, fmt.Errorf("prepare per-run rootfs: %w", err)
+	}
+	defer func() {
+		_ = os.Remove(vmRootFSPath)
+	}()
+
+	bootArgs := fmt.Sprintf("console=hvc0 root=/dev/vda rw init=/sbin/cleanroom-init cleanroom_guest_port=%d", req.GuestPort)
+	consolePath := filepath.Join(runDir, "vm.console.log")
+
+	vmPlanPath := filepath.Join(runDir, "darwin-vz-config.json")
+	if err := writeJSON(vmPlanPath, map[string]any{
+		"backend":      a.Name(),
+		"kernel_image": kernelPath,
+		"rootfs":       vmRootFSPath,
+		"vcpus":        req.VCPUs,
+		"memory_mib":   req.MemoryMiB,
+		"guest_port":   req.GuestPort,
+		"launch_secs":  req.LaunchSeconds,
+		"boot_args":    bootArgs,
+	}); err != nil {
+		return nil, err
+	}
+
+	helper, err := startHelperSession(ctx, runDir, req.LaunchSeconds)
+	if err != nil {
+		return nil, fmt.Errorf("start darwin-vz helper: %w", err)
+	}
+	defer func() {
+		if closeErr := helper.close(); closeErr != nil && stream.OnStderr != nil {
+			stream.OnStderr([]byte("warning: failed to close darwin-vz helper: " + closeErr.Error() + "\n"))
+		}
+	}()
+
+	proxySocketPath := filepath.Join(runDir, helperProxySocketName)
+	if err := ensureUnixSocketPathFits(proxySocketPath); err != nil {
+		return nil, fmt.Errorf("proxy socket path %q is too long: %w", proxySocketPath, err)
+	}
+	_ = os.Remove(proxySocketPath)
+
+	startCtx, cancelStart := context.WithTimeout(ctx, time.Duration(req.LaunchSeconds)*time.Second)
+	defer cancelStart()
+	startRes, err := helper.request(startCtx, helperControlRequest{
+		Op:              "StartVM",
+		KernelPath:      kernelPath,
+		RootFSPath:      vmRootFSPath,
+		VCPUs:           req.VCPUs,
+		MemoryMiB:       req.MemoryMiB,
+		GuestPort:       req.GuestPort,
+		LaunchSeconds:   req.LaunchSeconds,
+		RunDir:          runDir,
+		ProxySocketPath: proxySocketPath,
+		ConsoleLogPath:  consolePath,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("start vm via darwin-vz helper: %w", err)
+	}
+
+	vmID := strings.TrimSpace(startRes.VMID)
+	if vmID == "" {
+		return nil, errors.New("darwin-vz helper returned empty vm_id")
+	}
+	if p := strings.TrimSpace(startRes.ProxySocketPath); p != "" {
+		proxySocketPath = p
+	}
+	if strings.TrimSpace(proxySocketPath) == "" {
+		return nil, errors.New("darwin-vz helper returned empty proxy socket path")
+	}
+	if err := ensureUnixSocketPathFits(proxySocketPath); err != nil {
+		return nil, fmt.Errorf("proxy socket path %q is too long: %w", proxySocketPath, err)
+	}
+	defer func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if _, stopErr := helper.request(stopCtx, helperControlRequest{Op: "StopVM", VMID: vmID}); stopErr != nil && stream.OnStderr != nil {
+			stream.OnStderr([]byte("warning: failed to stop darwin-vz vm: " + stopErr.Error() + "\n"))
+		}
+	}()
+
+	connCtx, cancelConn := context.WithTimeout(ctx, time.Duration(req.LaunchSeconds)*time.Second)
+	defer cancelConn()
+	conn, err := dialUnixSocketWithRetry(connCtx, proxySocketPath)
+	if err != nil {
+		return nil, fmt.Errorf("connect darwin-vz proxy socket %q: %w", proxySocketPath, err)
+	}
+	defer conn.Close()
+
+	if dl, ok := ctx.Deadline(); ok {
+		if err := conn.SetDeadline(dl); err != nil {
+			return nil, fmt.Errorf("set proxy socket deadline: %w", err)
+		}
+	}
+	go func() {
+		<-ctx.Done()
+		_ = conn.Close()
+	}()
+
+	guestReq := vsockexec.ExecRequest{Command: append([]string(nil), req.Command...), TTY: req.TTY}
+	seed := make([]byte, 64)
+	if _, err := cryptorand.Read(seed); err == nil {
+		guestReq.EntropySeed = seed
+	}
+	if err := vsockexec.EncodeRequest(conn, guestReq); err != nil {
+		return nil, fmt.Errorf("send guest exec request: %w", err)
+	}
+
+	inputSender := &inputFrameSender{w: conn}
+	if stream.OnAttach != nil {
+		stream.OnAttach(backend.AttachIO{
+			WriteStdin: func(data []byte) error {
+				return inputSender.Send(vsockexec.ExecInputFrame{Type: "stdin", Data: data})
+			},
+			ResizeTTY: func(cols, rows uint32) error {
+				return inputSender.Send(vsockexec.ExecInputFrame{Type: "resize", Cols: cols, Rows: rows})
+			},
+		})
+	}
+	if !req.TTY {
+		_ = inputSender.Send(vsockexec.ExecInputFrame{Type: "eof"})
+	}
+
+	guestRes, err := vsockexec.DecodeStreamResponse(conn, vsockexec.StreamCallbacks{
+		OnStdout: stream.OnStdout,
+		OnStderr: stream.OnStderr,
+	})
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, fmt.Errorf("guest exec canceled while waiting for response: %w", ctxErr)
+		}
+		return nil, helper.decorateError(fmt.Errorf("decode guest exec response over darwin-vz proxy: %w", err))
+	}
+
+	message := darwinVZResultMessage(guestRes.Error)
+
+	return &backend.RunResult{
+		RunID:       req.RunID,
+		ExitCode:    guestRes.ExitCode,
+		LaunchedVM:  true,
+		PlanPath:    vmPlanPath,
+		RunDir:      runDir,
+		ImageRef:    resolvedImageRef,
+		ImageDigest: resolvedImageDigest,
+		Message:     message,
+		Stdout:      guestRes.Stdout,
+		Stderr:      stderrPrefix + guestRes.Stderr,
+	}, nil
+}
+
+func darwinVZResultMessage(guestErr string) string {
+	guestErr = strings.TrimSpace(guestErr)
+	if guestErr == "" {
+		return ""
+	}
+	return guestErr
+}
+
+type imageArtifact struct {
+	Ref        string
+	Digest     string
+	RootFSPath string
+	CacheHit   bool
+}
+
+func (a *Adapter) resolveRootFSPath(ctx context.Context, req backend.RunRequest) (path, imageRef, imageDigest, notice string, err error) {
+	configuredPath := strings.TrimSpace(req.RootFSPath)
+	if configuredPath != "" {
+		if _, statErr := os.Stat(configuredPath); statErr == nil {
+			return configuredPath, strings.TrimSpace(req.Policy.ImageRef), strings.TrimSpace(req.Policy.ImageDigest), "", nil
+		}
+		notice = fmt.Sprintf("configured rootfs %q is not accessible; deriving rootfs from sandbox.image.ref", configuredPath)
+	}
+	ref := strings.TrimSpace(req.Policy.ImageRef)
+	if ref == "" {
+		return "", "", "", "", errors.New("rootfs is not configured and sandbox.image.ref is empty")
+	}
+
+	ensurePrepared := a.ensurePreparedRootFSFn
+	if ensurePrepared == nil {
+		ensurePrepared = a.ensurePreparedRuntimeRootFSFromImage
+	}
+	prepared, err := ensurePrepared(ctx, ref)
+	if err != nil {
+		return "", "", "", "", err
+	}
+
+	derivation := fmt.Sprintf("derived rootfs from sandbox.image.ref digest %s (%s)", prepared.Digest, map[bool]string{true: "cache hit", false: "cache miss"}[prepared.Hit])
+	if notice != "" {
+		notice += "; " + derivation
+	} else {
+		notice = derivation
+	}
+	return prepared.Path, prepared.Ref, prepared.Digest, notice, nil
+}
+
+func (a *Adapter) ensurePreparedRuntimeRootFSFromImage(ctx context.Context, imageRef string) (preparedRootFS, error) {
+	artifact, err := a.ensureImageArtifact(ctx, imageRef)
+	if err != nil {
+		return preparedRootFS{}, err
+	}
+	if strings.TrimSpace(artifact.RootFSPath) == "" {
+		return preparedRootFS{}, errors.New("resolved image rootfs path is empty")
+	}
+	if _, err := os.Stat(artifact.RootFSPath); err != nil {
+		return preparedRootFS{}, fmt.Errorf("resolved image rootfs %q: %w", artifact.RootFSPath, err)
+	}
+
+	guestAgentPath, guestAgentHash, err := a.getGuestAgentBinary()
+	if err != nil {
+		return preparedRootFS{}, err
+	}
+
+	preparedPath, err := preparedRuntimeRootFSPath(artifact.Digest, guestAgentHash)
+	if err != nil {
+		return preparedRootFS{}, err
+	}
+	if _, err := os.Stat(preparedPath); err == nil {
+		return preparedRootFS{
+			Ref:    artifact.Ref,
+			Digest: artifact.Digest,
+			Path:   preparedPath,
+			Hit:    true,
+		}, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return preparedRootFS{}, fmt.Errorf("inspect prepared runtime rootfs %q: %w", preparedPath, err)
+	}
+
+	a.runtimeImageMu.Lock()
+	defer a.runtimeImageMu.Unlock()
+
+	if _, err := os.Stat(preparedPath); err == nil {
+		return preparedRootFS{
+			Ref:    artifact.Ref,
+			Digest: artifact.Digest,
+			Path:   preparedPath,
+			Hit:    true,
+		}, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return preparedRootFS{}, fmt.Errorf("inspect prepared runtime rootfs %q: %w", preparedPath, err)
+	}
+
+	preparedDir := filepath.Dir(preparedPath)
+	if err := os.MkdirAll(preparedDir, 0o755); err != nil {
+		return preparedRootFS{}, fmt.Errorf("create prepared rootfs cache directory %q: %w", preparedDir, err)
+	}
+
+	tmpPath := preparedPath + fmt.Sprintf(".tmp-%d", time.Now().UnixNano())
+	if err := copyFile(artifact.RootFSPath, tmpPath); err != nil {
+		return preparedRootFS{}, fmt.Errorf("copy rootfs image for runtime preparation: %w", err)
+	}
+	if err := a.installGuestRuntimeIntoRootFS(tmpPath, guestAgentPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return preparedRootFS{}, err
+	}
+	if err := os.Rename(tmpPath, preparedPath); err != nil {
+		_ = os.Remove(tmpPath)
+		if _, statErr := os.Stat(preparedPath); statErr == nil {
+			return preparedRootFS{
+				Ref:    artifact.Ref,
+				Digest: artifact.Digest,
+				Path:   preparedPath,
+				Hit:    true,
+			}, nil
+		}
+		return preparedRootFS{}, fmt.Errorf("store prepared runtime rootfs %q: %w", preparedPath, err)
+	}
+
+	return preparedRootFS{
+		Ref:    artifact.Ref,
+		Digest: artifact.Digest,
+		Path:   preparedPath,
+		Hit:    false,
+	}, nil
+}
+
+func preparedRuntimeRootFSPath(imageDigest, guestAgentHash string) (string, error) {
+	cacheBase, err := paths.CacheBaseDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve cache base directory: %w", err)
+	}
+	key := runtimeRootFSCacheKey(imageDigest, guestAgentHash)
+	return filepath.Join(cacheBase, "darwin-vz", "runtime-rootfs", key+".ext4"), nil
+}
+
+func runtimeRootFSCacheKey(imageDigest, guestAgentHash string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(imageDigest) + "|" + guestAgentHash + "|" + runtime.GOARCH + "|" + preparedRuntimeRootFSVersion + "|" + guestInitScriptTemplate))
+	return hex.EncodeToString(sum[:])
+}
+
+func (a *Adapter) ensureImageArtifact(ctx context.Context, imageRef string) (imageArtifact, error) {
+	trimmedRef := strings.TrimSpace(imageRef)
+	if trimmedRef == "" {
+		return imageArtifact{}, errors.New("sandbox.image.ref is required for launched execution")
+	}
+
+	mgr, err := a.getImageManager()
+	if err != nil {
+		return imageArtifact{}, fmt.Errorf("initialise image manager: %w", err)
+	}
+
+	result, err := mgr.Ensure(ctx, trimmedRef)
+	if err != nil {
+		return imageArtifact{}, fmt.Errorf("resolve image %q: %w", trimmedRef, err)
+	}
+	return imageArtifact{
+		Ref:        result.Record.Ref,
+		Digest:     result.Record.Digest,
+		RootFSPath: result.Record.RootFSPath,
+		CacheHit:   result.CacheHit,
+	}, nil
+}
+
+func (a *Adapter) getImageManager() (imageEnsurer, error) {
+	if a.newImageManager == nil {
+		a.newImageManager = defaultImageManagerFactory
+	}
+	a.imageManagerOnce.Do(func() {
+		a.imageManager, a.imageManagerErr = a.newImageManager()
+	})
+	if a.imageManagerErr != nil {
+		return nil, a.imageManagerErr
+	}
+	if a.imageManager == nil {
+		return nil, errors.New("image manager factory returned nil manager")
+	}
+	return a.imageManager, nil
+}
+
+func (a *Adapter) getGuestAgentBinary() (string, string, error) {
+	a.guestAgentOnce.Do(func() {
+		a.guestAgentPath, a.guestAgentErr = discoverGuestAgentBinary()
+		if a.guestAgentErr != nil {
+			return
+		}
+		a.guestAgentHash, a.guestAgentErr = hashFileSHA256(a.guestAgentPath)
+	})
+	if a.guestAgentErr != nil {
+		return "", "", a.guestAgentErr
+	}
+	if strings.TrimSpace(a.guestAgentPath) == "" || strings.TrimSpace(a.guestAgentHash) == "" {
+		return "", "", errors.New("failed to resolve cleanroom guest agent binary")
+	}
+	return a.guestAgentPath, a.guestAgentHash, nil
+}
+
+func discoverGuestAgentBinary() (string, error) {
+	linuxName := fmt.Sprintf("cleanroom-guest-agent-linux-%s", runtime.GOARCH)
+	candidates := []string{linuxName, "cleanroom-guest-agent"}
+
+	self, err := os.Executable()
+	if err == nil {
+		candidates = append(candidates, filepath.Join(filepath.Dir(self), linuxName))
+		candidates = append(candidates, filepath.Join(filepath.Dir(self), "cleanroom-guest-agent"))
+	}
+
+	for _, candidate := range candidates {
+		if strings.TrimSpace(candidate) == "" {
+			continue
+		}
+		resolved := candidate
+		if !filepath.IsAbs(candidate) {
+			p, lookErr := exec.LookPath(candidate)
+			if lookErr != nil {
+				continue
+			}
+			resolved = p
+		}
+		info, statErr := os.Stat(resolved)
+		if statErr != nil || info.IsDir() {
+			continue
+		}
+		ok, validateErr := isLinuxGuestAgentBinary(resolved)
+		if validateErr != nil {
+			return "", fmt.Errorf("validate guest agent binary %q: %w", resolved, validateErr)
+		}
+		if ok {
+			return resolved, nil
+		}
+	}
+	return "", fmt.Errorf("linux guest-agent binary not found for architecture %s; run `mise run install` to build and install cleanroom-guest-agent-linux-%s", runtime.GOARCH, runtime.GOARCH)
+}
+
+func isLinuxGuestAgentBinary(path string) (bool, error) {
+	f, err := elf.Open(path)
+	if err != nil {
+		// Non-ELF binaries are not valid guest binaries.
+		return false, nil
+	}
+	defer f.Close()
+
+	expectedMachine, ok := expectedGuestAgentELFMachine(runtime.GOARCH)
+	if !ok {
+		return false, fmt.Errorf("unsupported host architecture %q", runtime.GOARCH)
+	}
+	return f.FileHeader.Machine == expectedMachine, nil
+}
+
+func expectedGuestAgentELFMachine(goarch string) (elf.Machine, bool) {
+	switch goarch {
+	case "arm64":
+		return elf.EM_AARCH64, true
+	case "amd64":
+		return elf.EM_X86_64, true
+	default:
+		return 0, false
+	}
+}
+
+func helperHasVirtualizationEntitlement(helperPath string) (bool, error) {
+	cmd := exec.Command("codesign", "-d", "--entitlements", ":-", helperPath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		msg := strings.TrimSpace(string(output))
+		if msg != "" {
+			return false, fmt.Errorf("%w: %s", err, msg)
+		}
+		return false, err
+	}
+	return hasVirtualizationEntitlement(string(output)), nil
+}
+
+func hasVirtualizationEntitlement(raw string) bool {
+	entitlements := strings.TrimSpace(raw)
+	if entitlements == "" {
+		return false
+	}
+
+	if start := strings.Index(entitlements, "<?xml"); start >= 0 {
+		entitlements = entitlements[start:]
+	} else if start := strings.Index(entitlements, "<plist"); start >= 0 {
+		entitlements = entitlements[start:]
+	}
+	return virtualizationEntitlementPattern.MatchString(entitlements)
+}
+
+func hashFileSHA256(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("open %q for hashing: %w", path, err)
+	}
+	defer f.Close()
+
+	hash := sha256.New()
+	if _, err := io.Copy(hash, f); err != nil {
+		return "", fmt.Errorf("hash %q: %w", path, err)
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+func (a *Adapter) installGuestRuntimeIntoRootFS(rootFSPath, guestAgentPath string) error {
+	if _, err := hosttools.ResolveE2FSProgsBinary("debugfs"); err != nil {
+		return fmt.Errorf("find debugfs for runtime rootfs preparation: %w", err)
+	}
+	initScriptPath, err := createGuestInitScript()
+	if err != nil {
+		return err
+	}
+	defer os.Remove(initScriptPath)
+
+	if err := injectFileIntoExt4(rootFSPath, guestAgentPath, "/usr/local/bin/cleanroom-guest-agent", 0o755); err != nil {
+		return fmt.Errorf("inject guest agent into rootfs image: %w", err)
+	}
+	if err := injectFileIntoExt4(rootFSPath, initScriptPath, "/sbin/cleanroom-init", 0o755); err != nil {
+		return fmt.Errorf("inject cleanroom init into rootfs image: %w", err)
+	}
+	return nil
+}
+
+func createGuestInitScript() (string, error) {
+	f, err := os.CreateTemp("", "cleanroom-init-*.sh")
+	if err != nil {
+		return "", fmt.Errorf("create guest init script: %w", err)
+	}
+	if _, err := f.WriteString(guestInitScriptTemplate); err != nil {
+		_ = f.Close()
+		_ = os.Remove(f.Name())
+		return "", fmt.Errorf("write guest init script: %w", err)
+	}
+	if err := f.Chmod(0o755); err != nil {
+		_ = f.Close()
+		_ = os.Remove(f.Name())
+		return "", fmt.Errorf("chmod guest init script: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(f.Name())
+		return "", fmt.Errorf("close guest init script: %w", err)
+	}
+	return f.Name(), nil
+}
+
+func injectFileIntoExt4(imagePath, srcPath, dstPath string, mode os.FileMode) error {
+	cleanDst := filepath.Clean(dstPath)
+	if !strings.HasPrefix(cleanDst, "/") {
+		return fmt.Errorf("destination path %q must be absolute", dstPath)
+	}
+	if err := ensureExt4Dir(imagePath, filepath.Dir(cleanDst)); err != nil {
+		return err
+	}
+
+	if ext4PathExists(imagePath, cleanDst) {
+		_ = runDebugFS(imagePath, true, fmt.Sprintf("rm %s", cleanDst))
+	}
+	if err := runDebugFS(imagePath, true, fmt.Sprintf("write %s %s", srcPath, cleanDst)); err != nil {
+		return err
+	}
+	modeValue := fmt.Sprintf("%#o", uint32(0o100000)|uint32(mode.Perm()))
+	return runDebugFS(imagePath, true, fmt.Sprintf("set_inode_field %s mode %s", cleanDst, modeValue))
+}
+
+func ensureExt4Dir(imagePath, dir string) error {
+	cleanDir := filepath.Clean(dir)
+	if cleanDir == "." || cleanDir == "/" {
+		return nil
+	}
+	if !strings.HasPrefix(cleanDir, "/") {
+		cleanDir = "/" + cleanDir
+	}
+	parts := strings.Split(strings.TrimPrefix(cleanDir, "/"), "/")
+	cur := ""
+	for _, part := range parts {
+		if strings.TrimSpace(part) == "" {
+			continue
+		}
+		cur += "/" + part
+		if ext4PathExists(imagePath, cur) {
+			continue
+		}
+		if err := runDebugFS(imagePath, true, fmt.Sprintf("mkdir %s", cur)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func ext4PathExists(imagePath, path string) bool {
+	return runDebugFS(imagePath, false, fmt.Sprintf("stat %s", path)) == nil
+}
+
+func runDebugFS(imagePath string, writable bool, command string) error {
+	debugfsBinary, err := hosttools.ResolveE2FSProgsBinary("debugfs")
+	if err != nil {
+		return fmt.Errorf("find debugfs for runtime rootfs preparation: %w", err)
+	}
+
+	args := make([]string, 0, 4)
+	if writable {
+		args = append(args, "-w")
+	}
+	args = append(args, "-R", command, imagePath)
+	cmd := exec.Command(debugfsBinary, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("debugfs command %q failed: %w: %s", command, err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+func (a *Adapter) resolveKernelPath(ctx context.Context, configuredPath string) (path, notice string, err error) {
+	resolved, err := bootassets.ResolveKernelPathForHost(ctx, a.Name(), configuredPath)
+	if err != nil {
+		return "", "", err
+	}
+	return resolved.Path, resolved.Notice, nil
+}
+
+type inputFrameSender struct {
+	w  io.Writer
+	mu sync.Mutex
+}
+
+func (s *inputFrameSender) Send(frame vsockexec.ExecInputFrame) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return vsockexec.EncodeInputFrame(s.w, frame)
+}
+
+func writeJSON(path string, v any) error {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, append(b, '\n'), 0o644)
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	info, err := in.Stat()
+	if err != nil {
+		return err
+	}
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_RDWR|os.O_TRUNC, info.Mode().Perm())
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return out.Sync()
+}
+
+func logRunNotice(backendName, runID, notice string) {
+	msg := strings.TrimSpace(notice)
+	if msg == "" {
+		return
+	}
+	id := strings.TrimSpace(runID)
+	if id == "" {
+		log.Printf("%s: %s", backendName, msg)
+		return
+	}
+	log.Printf("%s run_id=%s: %s", backendName, id, msg)
+}

--- a/internal/backend/darwinvz/backend_entitlement_test.go
+++ b/internal/backend/darwinvz/backend_entitlement_test.go
@@ -1,0 +1,39 @@
+//go:build darwin
+
+package darwinvz
+
+import "testing"
+
+func TestHasVirtualizationEntitlementHandlesFormattedXML(t *testing.T) {
+	raw := `Executable=/tmp/helper
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.virtualization</key>
+    <true/>
+  </dict>
+</plist>`
+	if !hasVirtualizationEntitlement(raw) {
+		t.Fatal("expected virtualization entitlement to be detected")
+	}
+}
+
+func TestHasVirtualizationEntitlementHandlesCompactXML(t *testing.T) {
+	raw := `<?xml version="1.0"?><plist version="1.0"><dict><key>com.apple.security.virtualization</key><true/></dict></plist>`
+	if !hasVirtualizationEntitlement(raw) {
+		t.Fatal("expected virtualization entitlement to be detected")
+	}
+}
+
+func TestHasVirtualizationEntitlementRejectsMissingOrFalseEntitlement(t *testing.T) {
+	missing := `<?xml version="1.0"?><plist version="1.0"><dict><key>com.apple.security.app-sandbox</key><true/></dict></plist>`
+	if hasVirtualizationEntitlement(missing) {
+		t.Fatal("expected missing virtualization entitlement to be rejected")
+	}
+
+	falseValue := `<?xml version="1.0"?><plist version="1.0"><dict><key>com.apple.security.virtualization</key><false/></dict></plist>`
+	if hasVirtualizationEntitlement(falseValue) {
+		t.Fatal("expected false virtualization entitlement to be rejected")
+	}
+}

--- a/internal/backend/darwinvz/backend_message_test.go
+++ b/internal/backend/darwinvz/backend_message_test.go
@@ -1,0 +1,22 @@
+//go:build darwin
+
+package darwinvz
+
+import "testing"
+
+func TestDarwinVZResultMessageEmptyWithoutGuestError(t *testing.T) {
+	if got := darwinVZResultMessage(""); got != "" {
+		t.Fatalf("expected empty message, got %q", got)
+	}
+	if got := darwinVZResultMessage("   "); got != "" {
+		t.Fatalf("expected empty message for whitespace guest error, got %q", got)
+	}
+}
+
+func TestDarwinVZResultMessageIncludesGuestError(t *testing.T) {
+	got := darwinVZResultMessage(" runtime failed ")
+	want := "runtime failed"
+	if got != want {
+		t.Fatalf("unexpected message: got %q want %q", got, want)
+	}
+}

--- a/internal/backend/darwinvz/backend_message_test.go
+++ b/internal/backend/darwinvz/backend_message_test.go
@@ -20,3 +20,26 @@ func TestDarwinVZResultMessageIncludesGuestError(t *testing.T) {
 		t.Fatalf("unexpected message: got %q want %q", got, want)
 	}
 }
+
+func TestBuildRuntimeWarningsAlwaysIncludesGuestNetworkWarning(t *testing.T) {
+	warnings := buildRuntimeWarnings("")
+	if len(warnings) != 1 {
+		t.Fatalf("expected one warning, got %d", len(warnings))
+	}
+	if warnings[0] != guestNetworkUnavailableWarning {
+		t.Fatalf("unexpected warning: got %q want %q", warnings[0], guestNetworkUnavailableWarning)
+	}
+}
+
+func TestBuildRuntimeWarningsIncludesPolicyWarningWhenPresent(t *testing.T) {
+	warnings := buildRuntimeWarnings("  policy warn  ")
+	if len(warnings) != 2 {
+		t.Fatalf("expected two warnings, got %d", len(warnings))
+	}
+	if warnings[0] != "policy warn" {
+		t.Fatalf("unexpected policy warning: got %q", warnings[0])
+	}
+	if warnings[1] != guestNetworkUnavailableWarning {
+		t.Fatalf("unexpected guest networking warning: got %q", warnings[1])
+	}
+}

--- a/internal/backend/darwinvz/backend_unsupported.go
+++ b/internal/backend/darwinvz/backend_unsupported.go
@@ -1,0 +1,42 @@
+//go:build !darwin
+
+package darwinvz
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+)
+
+type Adapter struct{}
+
+func New() *Adapter {
+	return &Adapter{}
+}
+
+func (a *Adapter) Name() string {
+	return "darwin-vz"
+}
+
+func (a *Adapter) Run(_ context.Context, _ backend.RunRequest) (*backend.RunResult, error) {
+	return nil, fmt.Errorf("darwin-vz backend requires macOS, current OS is %s", runtime.GOOS)
+}
+
+func (a *Adapter) RunStream(ctx context.Context, req backend.RunRequest, _ backend.OutputStream) (*backend.RunResult, error) {
+	return a.Run(ctx, req)
+}
+
+func (a *Adapter) Doctor(_ context.Context, _ backend.DoctorRequest) (*backend.DoctorReport, error) {
+	return &backend.DoctorReport{
+		Backend: a.Name(),
+		Checks: []backend.DoctorCheck{
+			{
+				Name:    "os",
+				Status:  "fail",
+				Message: fmt.Sprintf("darwin-vz backend requires macOS, current OS is %s", runtime.GOOS),
+			},
+		},
+	}, nil
+}

--- a/internal/backend/darwinvz/backend_unsupported.go
+++ b/internal/backend/darwinvz/backend_unsupported.go
@@ -20,6 +20,14 @@ func (a *Adapter) Name() string {
 	return "darwin-vz"
 }
 
+func (a *Adapter) Capabilities() map[string]bool {
+	return map[string]bool{
+		backend.CapabilityNetworkDefaultDeny:     true,
+		backend.CapabilityNetworkAllowlistEgress: false,
+		backend.CapabilityNetworkGuestInterface:  false,
+	}
+}
+
 func (a *Adapter) Run(_ context.Context, _ backend.RunRequest) (*backend.RunResult, error) {
 	return nil, fmt.Errorf("darwin-vz backend requires macOS, current OS is %s", runtime.GOOS)
 }
@@ -36,6 +44,11 @@ func (a *Adapter) Doctor(_ context.Context, _ backend.DoctorRequest) (*backend.D
 				Name:    "os",
 				Status:  "fail",
 				Message: fmt.Sprintf("darwin-vz backend requires macOS, current OS is %s", runtime.GOOS),
+			},
+			{
+				Name:    "guest_networking",
+				Status:  "warn",
+				Message: guestNetworkUnavailableWarning,
 			},
 		},
 	}, nil

--- a/internal/backend/darwinvz/capabilities_test.go
+++ b/internal/backend/darwinvz/capabilities_test.go
@@ -1,0 +1,21 @@
+package darwinvz
+
+import (
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+)
+
+func TestCapabilitiesDeclareNoGuestNetworkInterface(t *testing.T) {
+	caps := New().Capabilities()
+
+	if !caps[backend.CapabilityNetworkDefaultDeny] {
+		t.Fatalf("expected %s=true", backend.CapabilityNetworkDefaultDeny)
+	}
+	if caps[backend.CapabilityNetworkAllowlistEgress] {
+		t.Fatalf("expected %s=false", backend.CapabilityNetworkAllowlistEgress)
+	}
+	if caps[backend.CapabilityNetworkGuestInterface] {
+		t.Fatalf("expected %s=false", backend.CapabilityNetworkGuestInterface)
+	}
+}

--- a/internal/backend/darwinvz/guest_init_script_test.go
+++ b/internal/backend/darwinvz/guest_init_script_test.go
@@ -1,0 +1,22 @@
+//go:build darwin
+
+package darwinvz
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGuestInitScriptAlwaysStartsStdioAgentWhenSerialDeviceExists(t *testing.T) {
+	if strings.Contains(guestInitScriptTemplate, "CLEANROOM_USE_STDIO") {
+		t.Fatal("expected stdio transport to no longer be gated by CLEANROOM_USE_STDIO")
+	}
+
+	if !strings.Contains(guestInitScriptTemplate, "CLEANROOM_GUEST_TRANSPORT=stdio /usr/local/bin/cleanroom-guest-agent") {
+		t.Fatal("expected stdio guest-agent launch in init script")
+	}
+
+	if !strings.Contains(guestInitScriptTemplate, ") &") {
+		t.Fatal("expected stdio guest-agent loop to run in background")
+	}
+}

--- a/internal/backend/darwinvz/helper_client.go
+++ b/internal/backend/darwinvz/helper_client.go
@@ -1,0 +1,305 @@
+package darwinvz
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+const (
+	helperControlSocketName = "vz-helper.sock"
+	helperProxySocketName   = "vz-proxy.sock"
+)
+
+var (
+	helperInterruptWait = 2 * time.Second
+	helperKillWait      = 2 * time.Second
+)
+
+type helperControlRequest struct {
+	Op              string `json:"op"`
+	KernelPath      string `json:"kernel_path,omitempty"`
+	RootFSPath      string `json:"rootfs_path,omitempty"`
+	VCPUs           int64  `json:"vcpus,omitempty"`
+	MemoryMiB       int64  `json:"memory_mib,omitempty"`
+	GuestPort       uint32 `json:"guest_port,omitempty"`
+	LaunchSeconds   int64  `json:"launch_seconds,omitempty"`
+	RunDir          string `json:"run_dir,omitempty"`
+	ProxySocketPath string `json:"proxy_socket_path,omitempty"`
+	ConsoleLogPath  string `json:"console_log_path,omitempty"`
+	VMID            string `json:"vm_id,omitempty"`
+}
+
+type helperControlResponse struct {
+	OK              bool             `json:"ok"`
+	Error           string           `json:"error,omitempty"`
+	VMID            string           `json:"vm_id,omitempty"`
+	ProxySocketPath string           `json:"proxy_socket_path,omitempty"`
+	TimingMS        map[string]int64 `json:"timing_ms,omitempty"`
+}
+
+type helperSession struct {
+	cmd        *exec.Cmd
+	socketPath string
+
+	stderr bytes.Buffer
+	done   chan error
+
+	conn net.Conn
+	enc  *json.Encoder
+	dec  *json.Decoder
+	mu   sync.Mutex
+}
+
+func startHelperSession(ctx context.Context, runDir string, launchSeconds int64) (*helperSession, error) {
+	helperPath, err := resolveHelperBinaryPath()
+	if err != nil {
+		return nil, err
+	}
+
+	socketPath := filepath.Join(runDir, helperControlSocketName)
+	if err := ensureUnixSocketPathFits(socketPath); err != nil {
+		return nil, fmt.Errorf("helper control socket path %q is too long: %w", socketPath, err)
+	}
+	_ = os.Remove(socketPath)
+
+	cmd := exec.Command(helperPath, "--socket", socketPath)
+	cmd.Stdout = io.Discard
+
+	session := &helperSession{
+		cmd:        cmd,
+		socketPath: socketPath,
+		done:       make(chan error, 1),
+	}
+	cmd.Stderr = &session.stderr
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("start darwin-vz helper %q: %w", helperPath, err)
+	}
+	go func() {
+		session.done <- cmd.Wait()
+		close(session.done)
+	}()
+
+	startupCtx, cancel := context.WithTimeout(ctx, helperStartupTimeout(launchSeconds))
+	defer cancel()
+
+	conn, err := waitForHelperControlSocket(startupCtx, socketPath, session.done)
+	if err != nil {
+		_ = session.closeProcess()
+		return nil, fmt.Errorf("connect darwin-vz helper control socket: %w", session.decorateError(err))
+	}
+
+	session.conn = conn
+	session.enc = json.NewEncoder(conn)
+	session.dec = json.NewDecoder(conn)
+	return session, nil
+}
+
+func helperStartupTimeout(launchSeconds int64) time.Duration {
+	if launchSeconds <= 0 {
+		return 10 * time.Second
+	}
+	timeout := time.Duration(launchSeconds) * time.Second
+	if timeout < 5*time.Second {
+		return 5 * time.Second
+	}
+	return timeout
+}
+
+func waitForHelperControlSocket(ctx context.Context, socketPath string, helperDone <-chan error) (net.Conn, error) {
+	dialer := net.Dialer{}
+	ticker := time.NewTicker(25 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		conn, err := dialer.DialContext(ctx, "unix", socketPath)
+		if err == nil {
+			return conn, nil
+		}
+
+		select {
+		case doneErr := <-helperDone:
+			if doneErr == nil {
+				return nil, errors.New("helper exited before control socket was ready")
+			}
+			return nil, fmt.Errorf("helper exited before control socket was ready: %w", doneErr)
+		case <-ctx.Done():
+			return nil, fmt.Errorf("timed out waiting for helper control socket: %w", ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+func dialUnixSocketWithRetry(ctx context.Context, socketPath string) (net.Conn, error) {
+	dialer := net.Dialer{}
+	ticker := time.NewTicker(25 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		conn, err := dialer.DialContext(ctx, "unix", socketPath)
+		if err == nil {
+			return conn, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("timed out waiting for unix socket %q: %w", socketPath, ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+func (s *helperSession) request(ctx context.Context, req helperControlRequest) (helperControlResponse, error) {
+	if s == nil {
+		return helperControlResponse{}, errors.New("nil helper session")
+	}
+
+	deadline := time.Now().Add(10 * time.Second)
+	if dl, ok := ctx.Deadline(); ok {
+		deadline = dl
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := s.conn.SetDeadline(deadline); err != nil {
+		return helperControlResponse{}, fmt.Errorf("set helper control deadline: %w", err)
+	}
+	defer s.conn.SetDeadline(time.Time{})
+
+	if err := s.enc.Encode(req); err != nil {
+		return helperControlResponse{}, s.decorateError(fmt.Errorf("send helper request %q: %w", req.Op, err))
+	}
+
+	var res helperControlResponse
+	if err := s.dec.Decode(&res); err != nil {
+		return helperControlResponse{}, s.decorateError(fmt.Errorf("decode helper response %q: %w", req.Op, err))
+	}
+	if !res.OK {
+		msg := strings.TrimSpace(res.Error)
+		if msg == "" {
+			msg = "unknown helper error"
+		}
+		if strings.Contains(msg, "com.apple.security.virtualization") {
+			msg += "; run `mise run install` to install and sign cleanroom-darwin-vz with the virtualization entitlement"
+		}
+		return helperControlResponse{}, s.decorateError(fmt.Errorf("helper %s failed: %s", req.Op, msg))
+	}
+	return res, nil
+}
+
+func (s *helperSession) close() error {
+	if s == nil {
+		return nil
+	}
+	if s.conn != nil {
+		_ = s.conn.Close()
+	}
+
+	err := s.closeProcess()
+	_ = os.Remove(s.socketPath)
+	return err
+}
+
+func (s *helperSession) closeProcess() error {
+	if s == nil || s.cmd == nil || s.cmd.Process == nil {
+		return nil
+	}
+
+	if err, ok := recvDoneNonBlocking(s.done); ok {
+		return s.normalizeHelperExitErr(err)
+	}
+
+	_ = s.cmd.Process.Signal(os.Interrupt)
+	if err, ok := recvDoneWithTimeout(s.done, helperInterruptWait); ok {
+		return s.normalizeHelperExitErr(err)
+	}
+
+	_ = s.cmd.Process.Kill()
+	if err, ok := recvDoneWithTimeout(s.done, helperKillWait); ok {
+		return s.normalizeHelperExitErr(err)
+	}
+	return s.decorateError(errors.New("timed out waiting for helper process exit"))
+}
+
+func (s *helperSession) normalizeHelperExitErr(err error) error {
+	if err != nil && !isExpectedInterruptExit(err) {
+		return s.decorateError(fmt.Errorf("helper exited: %w", err))
+	}
+	return nil
+}
+
+func recvDoneNonBlocking(done <-chan error) (error, bool) {
+	select {
+	case err, ok := <-done:
+		if !ok {
+			return nil, true
+		}
+		return err, true
+	default:
+		return nil, false
+	}
+}
+
+func recvDoneWithTimeout(done <-chan error, timeout time.Duration) (error, bool) {
+	if timeout <= 0 {
+		return recvDoneNonBlocking(done)
+	}
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case err, ok := <-done:
+		if !ok {
+			return nil, true
+		}
+		return err, true
+	case <-timer.C:
+		return nil, false
+	}
+}
+
+func isExpectedInterruptExit(err error) bool {
+	if err == nil {
+		return false
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		if waitStatus, ok := exitErr.Sys().(syscall.WaitStatus); ok {
+			return waitStatus.Signaled() && waitStatus.Signal() == syscall.SIGINT
+		}
+	}
+	return strings.Contains(err.Error(), "signal: interrupt")
+}
+
+func (s *helperSession) decorateError(err error) error {
+	if err == nil {
+		return nil
+	}
+	stderr := strings.TrimSpace(s.stderr.String())
+	if stderr == "" {
+		return err
+	}
+	return fmt.Errorf("%w (helper stderr: %s)", err, stderr)
+}
+
+func ensureUnixSocketPathFits(path string) error {
+	const maxUnixSocketPath = 103
+	if len(path) <= maxUnixSocketPath {
+		return nil
+	}
+	return fmt.Errorf("max length is %d bytes, got %d", maxUnixSocketPath, len(path))
+}

--- a/internal/backend/darwinvz/helper_client_test.go
+++ b/internal/backend/darwinvz/helper_client_test.go
@@ -1,0 +1,61 @@
+package darwinvz
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCloseProcessReturnsWhenDoneChannelIsDrained(t *testing.T) {
+	sleepPath, err := exec.LookPath("sleep")
+	if err != nil {
+		t.Skipf("sleep not available: %v", err)
+	}
+
+	cmd := exec.Command(sleepPath, "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sleep process: %v", err)
+	}
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+			_ = cmd.Process.Release()
+		}
+	})
+
+	origInterruptWait := helperInterruptWait
+	origKillWait := helperKillWait
+	helperInterruptWait = 25 * time.Millisecond
+	helperKillWait = 25 * time.Millisecond
+	t.Cleanup(func() {
+		helperInterruptWait = origInterruptWait
+		helperKillWait = origKillWait
+	})
+
+	done := make(chan error, 1)
+	done <- nil
+	<-done // Simulate waitForHelperControlSocket consuming the only wait result.
+
+	session := &helperSession{
+		cmd:  cmd,
+		done: done,
+	}
+
+	resultCh := make(chan error, 1)
+	go func() {
+		resultCh <- session.closeProcess()
+	}()
+
+	select {
+	case closeErr := <-resultCh:
+		if closeErr == nil {
+			t.Fatal("expected timeout error when done channel has no further sender")
+		}
+		if !strings.Contains(closeErr.Error(), "timed out waiting for helper process exit") {
+			t.Fatalf("unexpected error: %v", closeErr)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("closeProcess blocked waiting on drained done channel")
+	}
+}

--- a/internal/backend/darwinvz/helper_path.go
+++ b/internal/backend/darwinvz/helper_path.go
@@ -1,0 +1,72 @@
+package darwinvz
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	helperBinaryName = "cleanroom-darwin-vz"
+	helperEnvVar     = "CLEANROOM_DARWIN_VZ_HELPER"
+)
+
+func resolveHelperBinaryPath() (string, error) {
+	return resolveHelperBinaryPathWith(os.Getenv(helperEnvVar), exec.LookPath, os.Executable, os.Stat)
+}
+
+func resolveHelperBinaryPathWith(
+	envOverride string,
+	lookPath func(string) (string, error),
+	executable func() (string, error),
+	stat func(string) (os.FileInfo, error),
+) (string, error) {
+	if override := strings.TrimSpace(envOverride); override != "" {
+		path, err := resolveHelperCandidatePath(override, stat)
+		if err != nil {
+			return "", fmt.Errorf("resolve darwin-vz helper from %s=%q: %w", helperEnvVar, override, err)
+		}
+		return path, nil
+	}
+
+	if self, err := executable(); err == nil {
+		sibling := filepath.Join(filepath.Dir(self), helperBinaryName)
+		if path, err := resolveHelperCandidatePath(sibling, stat); err == nil {
+			return path, nil
+		}
+	}
+
+	if path, err := lookPath(helperBinaryName); err == nil {
+		return path, nil
+	}
+
+	return "", fmt.Errorf(
+		"%s helper binary was not found (set %s or install %s in PATH)",
+		helperBinaryName,
+		helperEnvVar,
+		helperBinaryName,
+	)
+}
+
+func resolveHelperCandidatePath(path string, stat func(string) (os.FileInfo, error)) (string, error) {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return "", errors.New("path is empty")
+	}
+
+	absPath, err := filepath.Abs(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("resolve absolute path: %w", err)
+	}
+	info, err := stat(absPath)
+	if err != nil {
+		return "", err
+	}
+	if info.IsDir() {
+		return "", fmt.Errorf("%s is a directory", absPath)
+	}
+	return absPath, nil
+}

--- a/internal/backend/darwinvz/helper_path_test.go
+++ b/internal/backend/darwinvz/helper_path_test.go
@@ -1,0 +1,92 @@
+package darwinvz
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestResolveHelperBinaryPathPrefersEnvOverride(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	override := tmp + "/cleanroom-darwin-vz-override"
+	if err := os.WriteFile(override, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write override helper: %v", err)
+	}
+
+	got, err := resolveHelperBinaryPathWith(
+		override,
+		func(string) (string, error) { return "", errors.New("not found") },
+		func() (string, error) { return "", errors.New("no executable") },
+		os.Stat,
+	)
+	if err != nil {
+		t.Fatalf("resolveHelperBinaryPathWith returned error: %v", err)
+	}
+	if got != override {
+		t.Fatalf("unexpected helper path: got %q want %q", got, override)
+	}
+}
+
+func TestResolveHelperBinaryPathUsesSiblingBeforePath(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	self := tmp + "/cleanroom"
+	sibling := tmp + "/cleanroom-darwin-vz"
+	if err := os.WriteFile(self, []byte("binary"), 0o755); err != nil {
+		t.Fatalf("write self binary: %v", err)
+	}
+	if err := os.WriteFile(sibling, []byte("binary"), 0o755); err != nil {
+		t.Fatalf("write sibling helper: %v", err)
+	}
+
+	got, err := resolveHelperBinaryPathWith(
+		"",
+		func(string) (string, error) { return "/usr/local/bin/cleanroom-darwin-vz", nil },
+		func() (string, error) { return self, nil },
+		os.Stat,
+	)
+	if err != nil {
+		t.Fatalf("resolveHelperBinaryPathWith returned error: %v", err)
+	}
+	if got != sibling {
+		t.Fatalf("unexpected helper path: got %q want %q", got, sibling)
+	}
+}
+
+func TestResolveHelperBinaryPathFallsBackToPATH(t *testing.T) {
+	t.Parallel()
+
+	got, err := resolveHelperBinaryPathWith(
+		"",
+		func(string) (string, error) { return "/usr/local/bin/cleanroom-darwin-vz", nil },
+		func() (string, error) { return "", errors.New("no executable") },
+		func(string) (os.FileInfo, error) { return nil, os.ErrNotExist },
+	)
+	if err != nil {
+		t.Fatalf("resolveHelperBinaryPathWith returned error: %v", err)
+	}
+	if got != "/usr/local/bin/cleanroom-darwin-vz" {
+		t.Fatalf("unexpected helper path: got %q", got)
+	}
+}
+
+func TestResolveHelperBinaryPathReturnsActionableError(t *testing.T) {
+	t.Parallel()
+
+	_, err := resolveHelperBinaryPathWith(
+		"",
+		func(string) (string, error) { return "", errors.New("not found") },
+		func() (string, error) { return "", errors.New("no executable") },
+		func(string) (os.FileInfo, error) { return nil, os.ErrNotExist },
+	)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if got := err.Error(); got == "" || !strings.Contains(got, "cleanroom-darwin-vz") || !strings.Contains(got, "CLEANROOM_DARWIN_VZ_HELPER") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/backend/darwinvz/policy.go
+++ b/internal/backend/darwinvz/policy.go
@@ -6,6 +6,7 @@ import (
 )
 
 const allowRulesIgnoredWarning = "darwin-vz ignores sandbox.network.allow entries; allowlist egress filtering is not implemented"
+const guestNetworkUnavailableWarning = "darwin-vz currently exposes no guest network interface; guest outbound networking is unavailable"
 
 func evaluateNetworkPolicy(networkDefault string, allowCount int) (string, error) {
 	if strings.TrimSpace(networkDefault) != "deny" {

--- a/internal/backend/darwinvz/policy.go
+++ b/internal/backend/darwinvz/policy.go
@@ -1,0 +1,18 @@
+package darwinvz
+
+import (
+	"fmt"
+	"strings"
+)
+
+const allowRulesIgnoredWarning = "darwin-vz ignores sandbox.network.allow entries; allowlist egress filtering is not implemented"
+
+func evaluateNetworkPolicy(networkDefault string, allowCount int) (string, error) {
+	if strings.TrimSpace(networkDefault) != "deny" {
+		return "", fmt.Errorf("darwin-vz backend requires deny-by-default policy, got %q", networkDefault)
+	}
+	if allowCount > 0 {
+		return allowRulesIgnoredWarning, nil
+	}
+	return "", nil
+}

--- a/internal/backend/darwinvz/policy_test.go
+++ b/internal/backend/darwinvz/policy_test.go
@@ -1,0 +1,39 @@
+package darwinvz
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEvaluateNetworkPolicyRequiresDenyDefault(t *testing.T) {
+	warn, err := evaluateNetworkPolicy("allow", 0)
+	if err == nil {
+		t.Fatal("expected error for non-deny network default")
+	}
+	if warn != "" {
+		t.Fatalf("expected empty warning when validation fails, got %q", warn)
+	}
+	if !strings.Contains(err.Error(), "deny-by-default") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestEvaluateNetworkPolicyWarnsWhenAllowEntriesPresent(t *testing.T) {
+	warn, err := evaluateNetworkPolicy("deny", 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(warn, "ignores sandbox.network.allow") {
+		t.Fatalf("unexpected warning: %q", warn)
+	}
+}
+
+func TestEvaluateNetworkPolicyAcceptsDenyWithNoAllowEntries(t *testing.T) {
+	warn, err := evaluateNetworkPolicy("deny", 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if warn != "" {
+		t.Fatalf("expected no warning, got %q", warn)
+	}
+}

--- a/internal/backend/darwinvz/rootfs_test.go
+++ b/internal/backend/darwinvz/rootfs_test.go
@@ -1,0 +1,138 @@
+package darwinvz
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/policy"
+)
+
+func TestResolveRootFSPathUsesConfiguredRootFS(t *testing.T) {
+	t.Parallel()
+
+	configuredPath := filepath.Join(t.TempDir(), "rootfs.ext4")
+	if err := os.WriteFile(configuredPath, []byte("fake-ext4"), 0o644); err != nil {
+		t.Fatalf("write configured rootfs: %v", err)
+	}
+
+	adapter := New()
+	req := backend.RunRequest{
+		Policy: &policy.CompiledPolicy{
+			ImageRef:    "ghcr.io/buildkite/cleanroom-base/alpine@sha256:abc",
+			ImageDigest: "sha256:abc",
+		},
+		FirecrackerConfig: backend.FirecrackerConfig{
+			RootFSPath: configuredPath,
+		},
+	}
+
+	path, ref, digest, notice, err := adapter.resolveRootFSPath(context.Background(), req)
+	if err != nil {
+		t.Fatalf("resolveRootFSPath returned error: %v", err)
+	}
+	if got, want := path, configuredPath; got != want {
+		t.Fatalf("unexpected rootfs path: got %q want %q", got, want)
+	}
+	if got, want := ref, req.Policy.ImageRef; got != want {
+		t.Fatalf("unexpected image ref: got %q want %q", got, want)
+	}
+	if got, want := digest, req.Policy.ImageDigest; got != want {
+		t.Fatalf("unexpected image digest: got %q want %q", got, want)
+	}
+	if notice != "" {
+		t.Fatalf("expected empty notice, got %q", notice)
+	}
+}
+
+func TestResolveRootFSPathDerivesFromPolicyImageRef(t *testing.T) {
+	t.Parallel()
+
+	adapter := New()
+	adapter.ensurePreparedRootFSFn = func(_ context.Context, imageRef string) (preparedRootFS, error) {
+		if got, want := imageRef, "ghcr.io/buildkite/cleanroom-base/alpine@sha256:def"; got != want {
+			t.Fatalf("unexpected image ref: got %q want %q", got, want)
+		}
+		return preparedRootFS{
+			Ref:    imageRef,
+			Digest: "sha256:def",
+			Path:   "/tmp/prepared.ext4",
+			Hit:    true,
+		}, nil
+	}
+
+	req := backend.RunRequest{
+		Policy: &policy.CompiledPolicy{
+			ImageRef: "ghcr.io/buildkite/cleanroom-base/alpine@sha256:def",
+		},
+	}
+
+	path, ref, digest, notice, err := adapter.resolveRootFSPath(context.Background(), req)
+	if err != nil {
+		t.Fatalf("resolveRootFSPath returned error: %v", err)
+	}
+	if got, want := path, "/tmp/prepared.ext4"; got != want {
+		t.Fatalf("unexpected rootfs path: got %q want %q", got, want)
+	}
+	if got, want := ref, req.Policy.ImageRef; got != want {
+		t.Fatalf("unexpected image ref: got %q want %q", got, want)
+	}
+	if got, want := digest, "sha256:def"; got != want {
+		t.Fatalf("unexpected image digest: got %q want %q", got, want)
+	}
+	if notice == "" {
+		t.Fatal("expected non-empty derivation notice")
+	}
+}
+
+func TestResolveRootFSPathRequiresImageRefWhenRootFSUnset(t *testing.T) {
+	t.Parallel()
+
+	adapter := New()
+	req := backend.RunRequest{
+		Policy: &policy.CompiledPolicy{},
+	}
+	_, _, _, _, err := adapter.resolveRootFSPath(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected error when both rootfs and image ref are unset")
+	}
+}
+
+func TestResolveRootFSPathFallsBackWhenConfiguredRootFSMissing(t *testing.T) {
+	t.Parallel()
+
+	adapter := New()
+	adapter.ensurePreparedRootFSFn = func(_ context.Context, imageRef string) (preparedRootFS, error) {
+		return preparedRootFS{
+			Ref:    imageRef,
+			Digest: "sha256:xyz",
+			Path:   "/tmp/prepared-missing-fallback.ext4",
+			Hit:    false,
+		}, nil
+	}
+
+	req := backend.RunRequest{
+		Policy: &policy.CompiledPolicy{
+			ImageRef: "ghcr.io/buildkite/cleanroom-base/alpine@sha256:xyz",
+		},
+		FirecrackerConfig: backend.FirecrackerConfig{
+			RootFSPath: "/tmp/definitely-missing-cleanroom-rootfs.ext4",
+		},
+	}
+
+	path, _, digest, notice, err := adapter.resolveRootFSPath(context.Background(), req)
+	if err != nil {
+		t.Fatalf("resolveRootFSPath returned error: %v", err)
+	}
+	if got, want := path, "/tmp/prepared-missing-fallback.ext4"; got != want {
+		t.Fatalf("unexpected rootfs path: got %q want %q", got, want)
+	}
+	if got, want := digest, "sha256:xyz"; got != want {
+		t.Fatalf("unexpected digest: got %q want %q", got, want)
+	}
+	if notice == "" {
+		t.Fatal("expected fallback notice")
+	}
+}

--- a/internal/backend/darwinvz/rootfs_test.go
+++ b/internal/backend/darwinvz/rootfs_test.go
@@ -1,3 +1,5 @@
+//go:build darwin
+
 package darwinvz
 
 import (

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -165,6 +165,14 @@ func (a *Adapter) Name() string {
 	return "firecracker"
 }
 
+func (a *Adapter) Capabilities() map[string]bool {
+	return map[string]bool{
+		backend.CapabilityNetworkDefaultDeny:     true,
+		backend.CapabilityNetworkAllowlistEgress: true,
+		backend.CapabilityNetworkGuestInterface:  true,
+	}
+}
+
 func (a *Adapter) Run(ctx context.Context, req backend.RunRequest) (*backend.RunResult, error) {
 	return a.run(ctx, req, backend.OutputStream{})
 }

--- a/internal/backend/firecracker/capabilities_test.go
+++ b/internal/backend/firecracker/capabilities_test.go
@@ -1,0 +1,21 @@
+package firecracker
+
+import (
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+)
+
+func TestCapabilitiesDeclareNetworkSupport(t *testing.T) {
+	caps := New().Capabilities()
+
+	if !caps[backend.CapabilityNetworkDefaultDeny] {
+		t.Fatalf("expected %s=true", backend.CapabilityNetworkDefaultDeny)
+	}
+	if !caps[backend.CapabilityNetworkAllowlistEgress] {
+		t.Fatalf("expected %s=true", backend.CapabilityNetworkAllowlistEgress)
+	}
+	if !caps[backend.CapabilityNetworkGuestInterface] {
+		t.Fatalf("expected %s=true", backend.CapabilityNetworkGuestInterface)
+	}
+}

--- a/internal/bootassets/manager.go
+++ b/internal/bootassets/manager.go
@@ -1,0 +1,319 @@
+package bootassets
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/buildkite/cleanroom/internal/paths"
+)
+
+var ErrNoManagedKernelAsset = errors.New("no managed kernel asset")
+
+type Selector struct {
+	Backend string
+	GOOS    string
+	GOARCH  string
+}
+
+type KernelSpec struct {
+	ID       string
+	Filename string
+	URL      string
+	SHA256   string
+}
+
+type EnsureResult struct {
+	Path     string
+	CacheHit bool
+	Spec     KernelSpec
+}
+
+type ResolveResult struct {
+	Path     string
+	Managed  bool
+	CacheHit bool
+	Notice   string
+	Spec     KernelSpec
+}
+
+type Options struct {
+	HTTPClient *http.Client
+	AssetsDir  func() (string, error)
+	Specs      map[Selector]KernelSpec
+}
+
+type Manager struct {
+	client    *http.Client
+	assetsDir func() (string, error)
+	specs     map[Selector]KernelSpec
+	mu        sync.Mutex
+}
+
+func New(opts Options) *Manager {
+	client := opts.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 5 * time.Minute}
+	}
+	assetsDir := opts.AssetsDir
+	if assetsDir == nil {
+		assetsDir = paths.AssetsDir
+	}
+	specs := opts.Specs
+	if specs == nil {
+		specs = defaultKernelSpecs()
+	}
+
+	copied := make(map[Selector]KernelSpec, len(specs))
+	for k, v := range specs {
+		copied[k] = v
+	}
+
+	return &Manager{
+		client:    client,
+		assetsDir: assetsDir,
+		specs:     copied,
+	}
+}
+
+func defaultKernelSpecs() map[Selector]KernelSpec {
+	return map[Selector]KernelSpec{
+		{Backend: "firecracker", GOOS: "linux", GOARCH: "amd64"}: {
+			ID:       "fc-ci-v1.14-linux-amd64-vmlinux-6.1.155",
+			Filename: "vmlinux-6.1.155",
+			URL:      "https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/v1.14/x86_64/vmlinux-6.1.155",
+			SHA256:   "e41c7048bd2475e7e788153823fcb9166a7e0b78c4c443bd6446d015fa735f53",
+		},
+		{Backend: "firecracker", GOOS: "linux", GOARCH: "arm64"}: {
+			ID:       "fc-ci-v1.14-linux-arm64-vmlinux-6.1.155",
+			Filename: "vmlinux-6.1.155",
+			URL:      "https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/v1.14/aarch64/vmlinux-6.1.155",
+			SHA256:   "61baeae1ac6197be4fc5c71fa78df266acdc33c54570290d2f611c2b42c105be",
+		},
+		{Backend: "darwin-vz", GOOS: "darwin", GOARCH: "arm64"}: {
+			ID:       "fc-ci-v1.14-darwin-arm64-vmlinux-6.1.155",
+			Filename: "vmlinux-6.1.155",
+			URL:      "https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/v1.14/aarch64/vmlinux-6.1.155",
+			SHA256:   "61baeae1ac6197be4fc5c71fa78df266acdc33c54570290d2f611c2b42c105be",
+		},
+		{Backend: "darwin-vz", GOOS: "darwin", GOARCH: "amd64"}: {
+			ID:       "fc-ci-v1.14-darwin-amd64-vmlinux-6.1.155",
+			Filename: "vmlinux-6.1.155",
+			URL:      "https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/v1.14/x86_64/vmlinux-6.1.155",
+			SHA256:   "e41c7048bd2475e7e788153823fcb9166a7e0b78c4c443bd6446d015fa735f53",
+		},
+	}
+}
+
+func (m *Manager) Lookup(backendName, goos, goarch string) (KernelSpec, bool) {
+	spec, ok := m.specs[Selector{
+		Backend: strings.TrimSpace(backendName),
+		GOOS:    strings.TrimSpace(goos),
+		GOARCH:  strings.TrimSpace(goarch),
+	}]
+	return spec, ok
+}
+
+func (m *Manager) KernelPath(backendName, goos, goarch string) (string, error) {
+	spec, ok := m.Lookup(backendName, goos, goarch)
+	if !ok {
+		return "", fmt.Errorf("%w for backend=%s host=%s/%s", ErrNoManagedKernelAsset, backendName, goos, goarch)
+	}
+	base, err := m.assetsDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve assets directory: %w", err)
+	}
+	return filepath.Join(base, "kernels", spec.ID, spec.Filename), nil
+}
+
+func (m *Manager) EnsureKernel(ctx context.Context, backendName, goos, goarch string) (EnsureResult, error) {
+	spec, ok := m.Lookup(backendName, goos, goarch)
+	if !ok {
+		return EnsureResult{}, fmt.Errorf("%w for backend=%s host=%s/%s", ErrNoManagedKernelAsset, backendName, goos, goarch)
+	}
+	dest, err := m.KernelPath(backendName, goos, goarch)
+	if err != nil {
+		return EnsureResult{}, err
+	}
+
+	valid, err := fileMatchesSHA256(dest, spec.SHA256)
+	if err != nil {
+		return EnsureResult{}, err
+	}
+	if valid {
+		return EnsureResult{Path: dest, CacheHit: true, Spec: spec}, nil
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	valid, err = fileMatchesSHA256(dest, spec.SHA256)
+	if err != nil {
+		return EnsureResult{}, err
+	}
+	if valid {
+		return EnsureResult{Path: dest, CacheHit: true, Spec: spec}, nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return EnsureResult{}, fmt.Errorf("create kernel asset directory %q: %w", filepath.Dir(dest), err)
+	}
+
+	tmp := dest + fmt.Sprintf(".tmp-%d", time.Now().UnixNano())
+	if err := m.downloadAndVerify(ctx, spec, tmp); err != nil {
+		_ = os.Remove(tmp)
+		return EnsureResult{}, err
+	}
+
+	if err := os.Rename(tmp, dest); err != nil {
+		_ = os.Remove(tmp)
+		if valid, vErr := fileMatchesSHA256(dest, spec.SHA256); vErr == nil && valid {
+			return EnsureResult{Path: dest, CacheHit: true, Spec: spec}, nil
+		}
+		return EnsureResult{}, fmt.Errorf("store kernel asset %q: %w", dest, err)
+	}
+
+	return EnsureResult{Path: dest, CacheHit: false, Spec: spec}, nil
+}
+
+func (m *Manager) ResolveKernelPath(ctx context.Context, backendName, goos, goarch, configuredPath string) (ResolveResult, error) {
+	trimmed := strings.TrimSpace(configuredPath)
+	if trimmed != "" {
+		absPath, err := filepath.Abs(trimmed)
+		if err == nil {
+			trimmed = absPath
+		}
+		if st, err := os.Stat(trimmed); err == nil && !st.IsDir() {
+			return ResolveResult{Path: trimmed}, nil
+		}
+
+		ensured, err := m.EnsureKernel(ctx, backendName, goos, goarch)
+		if err != nil {
+			return ResolveResult{}, fmt.Errorf("configured kernel_image %q is not accessible and managed kernel resolution failed: %w", trimmed, err)
+		}
+		return ResolveResult{
+			Path:     ensured.Path,
+			Managed:  true,
+			CacheHit: ensured.CacheHit,
+			Spec:     ensured.Spec,
+			Notice: fmt.Sprintf(
+				"configured kernel_image %q is not accessible; using managed kernel asset %s (%s)",
+				trimmed,
+				ensured.Spec.ID,
+				cacheState(ensured.CacheHit),
+			),
+		}, nil
+	}
+
+	ensured, err := m.EnsureKernel(ctx, backendName, goos, goarch)
+	if err != nil {
+		return ResolveResult{}, err
+	}
+	return ResolveResult{
+		Path:     ensured.Path,
+		Managed:  true,
+		CacheHit: ensured.CacheHit,
+		Spec:     ensured.Spec,
+		Notice:   fmt.Sprintf("using managed kernel asset %s (%s)", ensured.Spec.ID, cacheState(ensured.CacheHit)),
+	}, nil
+}
+
+func (m *Manager) downloadAndVerify(ctx context.Context, spec KernelSpec, tmpPath string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, spec.URL, nil)
+	if err != nil {
+		return fmt.Errorf("create kernel asset request: %w", err)
+	}
+	req.Header.Set("User-Agent", "cleanroom")
+
+	res, err := m.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("download kernel asset from %s: %w", spec.URL, err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(res.Body, 1024))
+		return fmt.Errorf("download kernel asset from %s: unexpected status %d: %s", spec.URL, res.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	out, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("create temporary kernel asset %q: %w", tmpPath, err)
+	}
+	defer out.Close()
+
+	hash := sha256.New()
+	if _, err := io.Copy(io.MultiWriter(out, hash), res.Body); err != nil {
+		return fmt.Errorf("write kernel asset %q: %w", tmpPath, err)
+	}
+	got := hex.EncodeToString(hash.Sum(nil))
+	if !strings.EqualFold(got, spec.SHA256) {
+		return fmt.Errorf("kernel asset checksum mismatch for %s: got %s want %s", spec.URL, got, spec.SHA256)
+	}
+	return nil
+}
+
+func fileMatchesSHA256(path, wantSHA256 string) (bool, error) {
+	st, err := os.Stat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("stat kernel asset %q: %w", path, err)
+	}
+	if st.IsDir() {
+		return false, fmt.Errorf("kernel asset path %q is a directory", path)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return false, fmt.Errorf("open kernel asset %q: %w", path, err)
+	}
+	defer f.Close()
+
+	hash := sha256.New()
+	if _, err := io.Copy(hash, f); err != nil {
+		return false, fmt.Errorf("hash kernel asset %q: %w", path, err)
+	}
+	got := hex.EncodeToString(hash.Sum(nil))
+	return strings.EqualFold(got, wantSHA256), nil
+}
+
+func cacheState(hit bool) string {
+	if hit {
+		return "cache hit"
+	}
+	return "cache miss"
+}
+
+var defaultManager = New(Options{})
+
+func LookupManagedKernel(backendName, goos, goarch string) (KernelSpec, bool) {
+	return defaultManager.Lookup(backendName, goos, goarch)
+}
+
+func LookupManagedKernelForHost(backendName string) (KernelSpec, bool) {
+	return defaultManager.Lookup(backendName, runtime.GOOS, runtime.GOARCH)
+}
+
+func ManagedKernelPath(backendName, goos, goarch string) (string, error) {
+	return defaultManager.KernelPath(backendName, goos, goarch)
+}
+
+func ManagedKernelPathForHost(backendName string) (string, error) {
+	return defaultManager.KernelPath(backendName, runtime.GOOS, runtime.GOARCH)
+}
+
+func ResolveKernelPathForHost(ctx context.Context, backendName, configuredPath string) (ResolveResult, error) {
+	return defaultManager.ResolveKernelPath(ctx, backendName, runtime.GOOS, runtime.GOARCH, configuredPath)
+}

--- a/internal/bootassets/manager_test.go
+++ b/internal/bootassets/manager_test.go
@@ -1,0 +1,178 @@
+package bootassets
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestResolveKernelPathUsesConfiguredPathWhenPresent(t *testing.T) {
+	t.Parallel()
+
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte("remote-kernel"))
+	}))
+	t.Cleanup(srv.Close)
+
+	tmpDir := t.TempDir()
+	configured := filepath.Join(tmpDir, "configured-kernel")
+	if err := os.WriteFile(configured, []byte("local"), 0o644); err != nil {
+		t.Fatalf("write configured kernel: %v", err)
+	}
+
+	mgr := New(Options{
+		HTTPClient: srv.Client(),
+		AssetsDir: func() (string, error) {
+			return filepath.Join(tmpDir, "assets"), nil
+		},
+		Specs: map[Selector]KernelSpec{
+			{Backend: "darwin-vz", GOOS: "darwin", GOARCH: "arm64"}: {
+				ID:       "test-kernel",
+				Filename: "vmlinux-test",
+				URL:      srv.URL + "/kernel",
+				SHA256:   sha256Hex([]byte("remote-kernel")),
+			},
+		},
+	})
+
+	got, err := mgr.ResolveKernelPath(context.Background(), "darwin-vz", "darwin", "arm64", configured)
+	if err != nil {
+		t.Fatalf("ResolveKernelPath returned error: %v", err)
+	}
+	if got.Path != configured {
+		t.Fatalf("unexpected path: got %q want %q", got.Path, configured)
+	}
+	if got.Managed {
+		t.Fatal("expected configured path to not be managed")
+	}
+	if hits.Load() != 0 {
+		t.Fatalf("expected no network access, got %d hits", hits.Load())
+	}
+}
+
+func TestResolveKernelPathDownloadsAndCachesManagedKernel(t *testing.T) {
+	t.Parallel()
+
+	const payload = "remote-kernel"
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte(payload))
+	}))
+	t.Cleanup(srv.Close)
+
+	tmpDir := t.TempDir()
+	mgr := New(Options{
+		HTTPClient: srv.Client(),
+		AssetsDir: func() (string, error) {
+			return filepath.Join(tmpDir, "assets"), nil
+		},
+		Specs: map[Selector]KernelSpec{
+			{Backend: "darwin-vz", GOOS: "darwin", GOARCH: "arm64"}: {
+				ID:       "test-kernel",
+				Filename: "vmlinux-test",
+				URL:      srv.URL + "/kernel",
+				SHA256:   sha256Hex([]byte(payload)),
+			},
+		},
+	})
+
+	first, err := mgr.ResolveKernelPath(context.Background(), "darwin-vz", "darwin", "arm64", "")
+	if err != nil {
+		t.Fatalf("ResolveKernelPath first call returned error: %v", err)
+	}
+	if !first.Managed {
+		t.Fatal("expected first call to use managed kernel")
+	}
+	if first.CacheHit {
+		t.Fatal("expected first call to be cache miss")
+	}
+	if !strings.Contains(first.Notice, "managed kernel") {
+		t.Fatalf("expected managed notice, got %q", first.Notice)
+	}
+
+	second, err := mgr.ResolveKernelPath(context.Background(), "darwin-vz", "darwin", "arm64", "")
+	if err != nil {
+		t.Fatalf("ResolveKernelPath second call returned error: %v", err)
+	}
+	if !second.Managed {
+		t.Fatal("expected second call to use managed kernel")
+	}
+	if !second.CacheHit {
+		t.Fatal("expected second call to be cache hit")
+	}
+
+	if got := hits.Load(); got != 1 {
+		t.Fatalf("expected one download, got %d", got)
+	}
+}
+
+func TestResolveKernelPathFallsBackFromMissingConfiguredPath(t *testing.T) {
+	t.Parallel()
+
+	const payload = "remote-kernel"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(payload))
+	}))
+	t.Cleanup(srv.Close)
+
+	tmpDir := t.TempDir()
+	mgr := New(Options{
+		HTTPClient: srv.Client(),
+		AssetsDir: func() (string, error) {
+			return filepath.Join(tmpDir, "assets"), nil
+		},
+		Specs: map[Selector]KernelSpec{
+			{Backend: "firecracker", GOOS: "linux", GOARCH: "amd64"}: {
+				ID:       "test-kernel",
+				Filename: "vmlinux-test",
+				URL:      srv.URL + "/kernel",
+				SHA256:   sha256Hex([]byte(payload)),
+			},
+		},
+	})
+
+	res, err := mgr.ResolveKernelPath(context.Background(), "firecracker", "linux", "amd64", "/tmp/missing-kernel")
+	if err != nil {
+		t.Fatalf("ResolveKernelPath returned error: %v", err)
+	}
+	if !res.Managed {
+		t.Fatal("expected managed fallback")
+	}
+	if !strings.Contains(res.Notice, "configured kernel_image") {
+		t.Fatalf("expected fallback notice, got %q", res.Notice)
+	}
+}
+
+func TestResolveKernelPathReturnsErrorWhenUnsupported(t *testing.T) {
+	t.Parallel()
+
+	mgr := New(Options{
+		AssetsDir: func() (string, error) {
+			return t.TempDir(), nil
+		},
+		Specs: map[Selector]KernelSpec{},
+	})
+
+	_, err := mgr.ResolveKernelPath(context.Background(), "darwin-vz", "darwin", "arm64", "")
+	if err == nil {
+		t.Fatal("expected unsupported-platform error")
+	}
+	if !strings.Contains(err.Error(), "no managed kernel asset") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func sha256Hex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/cli/cli_parse_test.go
+++ b/internal/cli/cli_parse_test.go
@@ -85,3 +85,12 @@ func TestImageBumpRefAllowsNoArgs(t *testing.T) {
 		t.Fatalf("parse image bump-ref with default ref returned error: %v", err)
 	}
 }
+
+func TestConfigInitParses(t *testing.T) {
+	c := &CLI{}
+	parser := newParserForTest(t, c)
+
+	if _, err := parser.Parse([]string{"config", "init"}); err != nil {
+		t.Fatalf("parse config init returned error: %v", err)
+	}
+}

--- a/internal/cli/config_init_test.go
+++ b/internal/cli/config_init_test.go
@@ -1,0 +1,106 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/runtimeconfig"
+	"gopkg.in/yaml.v3"
+)
+
+func TestConfigInitWritesRuntimeConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	stdout, _ := makeStdoutCapture(t)
+	cmd := &ConfigInitCommand{}
+	if err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout}); err != nil {
+		t.Fatalf("ConfigInitCommand.Run returned error: %v", err)
+	}
+
+	configPath := filepath.Join(tmpDir, "cleanroom", "config.yaml")
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read generated config: %v", err)
+	}
+
+	var cfg runtimeconfig.Config
+	if err := yaml.Unmarshal(raw, &cfg); err != nil {
+		t.Fatalf("parse generated yaml: %v", err)
+	}
+	if !strings.Contains(string(raw), "darwin-vz:") {
+		t.Fatalf("expected generated config to use backends.darwin-vz key, got:\n%s", raw)
+	}
+	if got := strings.TrimSpace(cfg.DefaultBackend); got == "" {
+		t.Fatal("expected default_backend to be populated")
+	}
+	if got := strings.TrimSpace(cfg.Backends.Firecracker.BinaryPath); got == "" {
+		t.Fatal("expected backends.firecracker.binary_path to be populated")
+	}
+	if got := strings.TrimSpace(cfg.Backends.Firecracker.KernelImage); got != "" {
+		t.Fatalf("expected backends.firecracker.kernel_image to default empty, got %q", got)
+	}
+	if got := strings.TrimSpace(cfg.Backends.DarwinVZ.KernelImage); got != "" {
+		t.Fatalf("expected backends.darwin-vz.kernel_image to default empty, got %q", got)
+	}
+}
+
+func TestConfigInitRefusesOverwriteWithoutForce(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "cleanroom", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	original := "existing: true\n"
+	if err := os.WriteFile(configPath, []byte(original), 0o644); err != nil {
+		t.Fatalf("write existing config: %v", err)
+	}
+
+	stdout, _ := makeStdoutCapture(t)
+	cmd := &ConfigInitCommand{Path: configPath}
+	err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout})
+	if err == nil {
+		t.Fatal("expected overwrite error")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read existing config: %v", err)
+	}
+	if got, want := string(raw), original; got != want {
+		t.Fatalf("config changed unexpectedly: got %q want %q", got, want)
+	}
+}
+
+func TestConfigInitForceOverwritesExistingFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "runtime", "cleanroom.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte("existing: true\n"), 0o644); err != nil {
+		t.Fatalf("write existing config: %v", err)
+	}
+
+	stdout, _ := makeStdoutCapture(t)
+	cmd := &ConfigInitCommand{
+		Path:  filepath.Join("runtime", "cleanroom.yaml"),
+		Force: true,
+	}
+	if err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout}); err != nil {
+		t.Fatalf("ConfigInitCommand.Run returned error: %v", err)
+	}
+
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read overwritten config: %v", err)
+	}
+	if strings.Contains(string(raw), "existing: true") {
+		t.Fatalf("expected config to be overwritten, got:\n%s", raw)
+	}
+}

--- a/internal/cli/console_render_test.go
+++ b/internal/cli/console_render_test.go
@@ -1,0 +1,31 @@
+package cli
+
+import "testing"
+
+func TestNormalizeLineEndingsForRawTTYConvertsLoneLF(t *testing.T) {
+	got, endedCR := normalizeLineEndingsForRawTTY([]byte("warning\n/ # "), false)
+	if string(got) != "warning\r\n/ # " {
+		t.Fatalf("unexpected normalized output: %q", string(got))
+	}
+	if endedCR {
+		t.Fatal("expected endedCR=false")
+	}
+}
+
+func TestNormalizeLineEndingsForRawTTYPreservesCRLFAcrossChunks(t *testing.T) {
+	first, endedCR := normalizeLineEndingsForRawTTY([]byte("warning\r"), false)
+	if string(first) != "warning\r" {
+		t.Fatalf("unexpected first chunk: %q", string(first))
+	}
+	if !endedCR {
+		t.Fatal("expected endedCR=true after trailing carriage return")
+	}
+
+	second, endedCR := normalizeLineEndingsForRawTTY([]byte("\n/ # "), endedCR)
+	if string(second) != "\n/ # " {
+		t.Fatalf("unexpected second chunk: %q", string(second))
+	}
+	if endedCR {
+		t.Fatal("expected endedCR=false after second chunk")
+	}
+}

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -1,0 +1,115 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/buildkite/cleanroom/internal/runtimeconfig"
+)
+
+type doctorTestAdapter struct{}
+
+func (doctorTestAdapter) Name() string { return "doctor-test" }
+
+func (doctorTestAdapter) Run(context.Context, backend.RunRequest) (*backend.RunResult, error) {
+	return &backend.RunResult{Message: "ok"}, nil
+}
+
+func (doctorTestAdapter) Doctor(context.Context, backend.DoctorRequest) (*backend.DoctorReport, error) {
+	return &backend.DoctorReport{
+		Backend: "doctor-test",
+		Checks: []backend.DoctorCheck{
+			{Name: "backend_doctor_check", Status: "pass", Message: "ok"},
+		},
+	}, nil
+}
+
+func (doctorTestAdapter) Capabilities() map[string]bool {
+	return map[string]bool{
+		backend.CapabilityNetworkDefaultDeny:     true,
+		backend.CapabilityNetworkAllowlistEgress: false,
+		backend.CapabilityNetworkGuestInterface:  false,
+	}
+}
+
+type doctorFailingLoader struct{}
+
+func (doctorFailingLoader) LoadAndCompile(string) (*policy.CompiledPolicy, string, error) {
+	return nil, "", errors.New("policy unavailable")
+}
+
+func TestDoctorCommandJSONIncludesCapabilities(t *testing.T) {
+	tmpDir := t.TempDir()
+	stdoutPath := filepath.Join(tmpDir, "doctor.json")
+	stdout, err := os.Create(stdoutPath)
+	if err != nil {
+		t.Fatalf("create stdout file: %v", err)
+	}
+
+	cmd := DoctorCommand{
+		Backend: "doctor-test",
+		JSON:    true,
+	}
+	err = cmd.Run(&runtimeContext{
+		CWD:        tmpDir,
+		Stdout:     stdout,
+		Loader:     doctorFailingLoader{},
+		Config:     runtimeconfig.Config{},
+		ConfigPath: filepath.Join(tmpDir, "config.yaml"),
+		Backends: map[string]backend.Adapter{
+			"doctor-test": doctorTestAdapter{},
+		},
+	})
+	if closeErr := stdout.Close(); closeErr != nil {
+		t.Fatalf("close stdout file: %v", closeErr)
+	}
+	if err != nil {
+		t.Fatalf("DoctorCommand.Run returned error: %v", err)
+	}
+
+	raw, err := os.ReadFile(stdoutPath)
+	if err != nil {
+		t.Fatalf("read doctor output: %v", err)
+	}
+
+	var payload struct {
+		Backend      string                `json:"backend"`
+		Capabilities map[string]bool       `json:"capabilities"`
+		Checks       []backend.DoctorCheck `json:"checks"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("unmarshal doctor JSON: %v", err)
+	}
+
+	if payload.Backend != "doctor-test" {
+		t.Fatalf("unexpected backend: got %q", payload.Backend)
+	}
+	if payload.Capabilities == nil {
+		t.Fatal("expected capabilities map in doctor JSON")
+	}
+	if !payload.Capabilities[backend.CapabilityNetworkDefaultDeny] {
+		t.Fatalf("expected %s=true", backend.CapabilityNetworkDefaultDeny)
+	}
+	if payload.Capabilities[backend.CapabilityNetworkGuestInterface] {
+		t.Fatalf("expected %s=false", backend.CapabilityNetworkGuestInterface)
+	}
+
+	foundCapabilityCheck := false
+	for _, check := range payload.Checks {
+		if check.Name == "capability_network_guest_interface" {
+			foundCapabilityCheck = true
+			if check.Status != "warn" {
+				t.Fatalf("expected guest interface capability status warn, got %q", check.Status)
+			}
+		}
+	}
+	if !foundCapabilityCheck {
+		t.Fatal("expected capability_network_guest_interface check in doctor output")
+	}
+}

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -1,0 +1,30 @@
+package cli
+
+import "testing"
+
+func TestShouldInstallGatewayFirewall(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		goos string
+		want bool
+	}{
+		{name: "linux", goos: "linux", want: true},
+		{name: "linux case-insensitive", goos: "LiNuX", want: true},
+		{name: "darwin", goos: "darwin", want: false},
+		{name: "windows", goos: "windows", want: false},
+		{name: "whitespace", goos: "  linux  ", want: true},
+		{name: "empty", goos: "", want: false},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := shouldInstallGatewayFirewall(tc.goos); got != tc.want {
+				t.Fatalf("shouldInstallGatewayFirewall(%q) = %v, want %v", tc.goos, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/controlserver/attach_resize_test.go
+++ b/internal/controlserver/attach_resize_test.go
@@ -1,0 +1,97 @@
+package controlserver
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/controlservice"
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+)
+
+type resizeUnsupportedAdapter struct {
+	started chan struct{}
+}
+
+func (a *resizeUnsupportedAdapter) Name() string {
+	return "resize-unsupported"
+}
+
+func (a *resizeUnsupportedAdapter) Run(context.Context, backend.RunRequest) (*backend.RunResult, error) {
+	return nil, errors.New("unexpected Run call")
+}
+
+func (a *resizeUnsupportedAdapter) RunStream(ctx context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+	if stream.OnAttach != nil {
+		stream.OnAttach(backend.AttachIO{
+			WriteStdin: func([]byte) error { return nil },
+		})
+	}
+	select {
+	case a.started <- struct{}{}:
+	default:
+	}
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func TestApplyAttachInputIgnoresUnsupportedResize(t *testing.T) {
+	adapter := &resizeUnsupportedAdapter{started: make(chan struct{}, 1)}
+	svc := &controlservice.Service{
+		Backends: map[string]backend.Adapter{"firecracker": adapter},
+	}
+	server := New(svc, nil)
+
+	policy := &cleanroomv1.Policy{
+		Version:        1,
+		ImageRef:       "ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		ImageDigest:    "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		NetworkDefault: "deny",
+	}
+	createSandboxResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: policy})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createSandboxResp.GetSandbox().GetSandboxId()
+
+	createExecutionResp, err := svc.CreateExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
+		SandboxId: sandboxID,
+		Command:   []string{"sh"},
+		Options:   &cleanroomv1.ExecutionOptions{Tty: true},
+	})
+	if err != nil {
+		t.Fatalf("CreateExecution returned error: %v", err)
+	}
+	executionID := createExecutionResp.GetExecution().GetExecutionId()
+
+	select {
+	case <-adapter.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("execution did not start")
+	}
+
+	detached, err := server.applyAttachInput(context.Background(), sandboxID, executionID, &cleanroomv1.ExecutionAttachFrame{
+		Payload: &cleanroomv1.ExecutionAttachFrame_Resize{
+			Resize: &cleanroomv1.ExecutionResize{Cols: 120, Rows: 40},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected unsupported resize to be ignored, got error: %v", err)
+	}
+	if detached {
+		t.Fatal("expected resize frame to keep attach session open")
+	}
+
+	if _, err := svc.CancelExecution(context.Background(), &cleanroomv1.CancelExecutionRequest{
+		SandboxId:   sandboxID,
+		ExecutionId: executionID,
+		Signal:      2,
+	}); err != nil {
+		t.Fatalf("CancelExecution returned error: %v", err)
+	}
+	if _, err := svc.WaitExecution(context.Background(), sandboxID, executionID); err != nil {
+		t.Fatalf("WaitExecution returned error: %v", err)
+	}
+}

--- a/internal/controlserver/server.go
+++ b/internal/controlserver/server.go
@@ -335,7 +335,15 @@ func (s *Server) applyAttachInput(ctx context.Context, sandboxID, executionID st
 		}
 		if err := s.service.ResizeExecutionTTY(sandboxID, executionID, resize.GetCols(), resize.GetRows()); err != nil {
 			if errors.Is(err, controlservice.ErrExecutionResizeUnsupported) {
-				return false, connect.NewError(connect.CodeUnimplemented, err)
+				if s.logger != nil {
+					s.logger.Debug("ignoring unsupported execution resize request",
+						"sandbox_id", sandboxID,
+						"execution_id", executionID,
+						"cols", resize.GetCols(),
+						"rows", resize.GetRows(),
+					)
+				}
+				return false, nil
 			}
 			return false, toConnectError(err)
 		}

--- a/internal/hosttools/e2fsprogs.go
+++ b/internal/hosttools/e2fsprogs.go
@@ -1,0 +1,142 @@
+package hosttools
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+)
+
+var (
+	e2fsPrefixesOnce   sync.Once
+	e2fsCachedPrefixes []string
+)
+
+const darwinE2FSProgsInstallHint = "install it with `brew install e2fsprogs`"
+
+// ResolveE2FSProgsBinary resolves a requested e2fsprogs binary by checking:
+// 1. PATH
+// 2. Known Homebrew e2fsprogs locations on macOS.
+func ResolveE2FSProgsBinary(binary string) (string, error) {
+	return resolveBinary(binary, exec.LookPath, os.Stat, candidateBinaryPaths(binary, e2fsProgsPrefixes()))
+}
+
+func resolveBinary(
+	binary string,
+	lookPath func(string) (string, error),
+	stat func(string) (os.FileInfo, error),
+	candidates []string,
+) (string, error) {
+	trimmed := strings.TrimSpace(binary)
+	if trimmed == "" {
+		return "", fmt.Errorf("binary name is required")
+	}
+
+	if path, err := lookPath(trimmed); err == nil {
+		return path, nil
+	}
+
+	for _, candidate := range candidates {
+		if strings.TrimSpace(candidate) == "" {
+			continue
+		}
+		info, err := stat(candidate)
+		if err != nil || info.IsDir() {
+			continue
+		}
+		return candidate, nil
+	}
+
+	if len(candidates) == 0 {
+		msg := fmt.Sprintf("%s not found in PATH", trimmed)
+		if hint := e2fsProgsInstallHint(); hint != "" {
+			msg += "; " + hint
+		}
+		return "", errors.New(msg)
+	}
+	msg := fmt.Sprintf("%s not found in PATH or known Homebrew locations", trimmed)
+	if hint := e2fsProgsInstallHint(); hint != "" {
+		msg += "; " + hint
+	}
+	return "", errors.New(msg)
+}
+
+func candidateBinaryPaths(binary string, prefixes []string) []string {
+	trimmedBinary := strings.TrimSpace(binary)
+	if trimmedBinary == "" {
+		return nil
+	}
+
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(prefixes)*2)
+	appendCandidate := func(path string) {
+		if strings.TrimSpace(path) == "" {
+			return
+		}
+		if _, ok := seen[path]; ok {
+			return
+		}
+		seen[path] = struct{}{}
+		out = append(out, path)
+	}
+
+	for _, prefix := range prefixes {
+		trimmedPrefix := strings.TrimSpace(prefix)
+		if trimmedPrefix == "" {
+			continue
+		}
+		appendCandidate(filepath.Join(trimmedPrefix, "sbin", trimmedBinary))
+		appendCandidate(filepath.Join(trimmedPrefix, "bin", trimmedBinary))
+	}
+	return out
+}
+
+func e2fsProgsPrefixes() []string {
+	if runtime.GOOS != "darwin" {
+		return nil
+	}
+
+	e2fsPrefixesOnce.Do(func() {
+		prefixes := make([]string, 0, 3)
+		seen := map[string]struct{}{}
+		appendPrefix := func(value string) {
+			trimmed := strings.TrimSpace(value)
+			if trimmed == "" {
+				return
+			}
+			if _, ok := seen[trimmed]; ok {
+				return
+			}
+			seen[trimmed] = struct{}{}
+			prefixes = append(prefixes, trimmed)
+		}
+
+		if brewPath, err := exec.LookPath("brew"); err == nil {
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			out, err := exec.CommandContext(ctx, brewPath, "--prefix", "e2fsprogs").Output()
+			if err == nil {
+				appendPrefix(string(out))
+			}
+		}
+		appendPrefix("/opt/homebrew/opt/e2fsprogs")
+		appendPrefix("/usr/local/opt/e2fsprogs")
+
+		e2fsCachedPrefixes = prefixes
+	})
+
+	return append([]string(nil), e2fsCachedPrefixes...)
+}
+
+func e2fsProgsInstallHint() string {
+	if runtime.GOOS != "darwin" {
+		return ""
+	}
+	return darwinE2FSProgsInstallHint
+}

--- a/internal/hosttools/e2fsprogs_test.go
+++ b/internal/hosttools/e2fsprogs_test.go
@@ -1,0 +1,94 @@
+package hosttools
+
+import (
+	"errors"
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestResolveBinaryPrefersLookPath(t *testing.T) {
+	t.Parallel()
+
+	got, err := resolveBinary(
+		"mkfs.ext4",
+		func(string) (string, error) { return "/usr/bin/mkfs.ext4", nil },
+		func(string) (os.FileInfo, error) { return nil, os.ErrNotExist },
+		[]string{"/opt/homebrew/opt/e2fsprogs/sbin/mkfs.ext4"},
+	)
+	if err != nil {
+		t.Fatalf("resolveBinary returned error: %v", err)
+	}
+	if got != "/usr/bin/mkfs.ext4" {
+		t.Fatalf("unexpected resolved path: got %q", got)
+	}
+}
+
+func TestResolveBinaryFallsBackToCandidate(t *testing.T) {
+	t.Parallel()
+
+	candidate := "/opt/homebrew/opt/e2fsprogs/sbin/debugfs"
+	got, err := resolveBinary(
+		"debugfs",
+		func(string) (string, error) { return "", errors.New("not found") },
+		func(path string) (os.FileInfo, error) {
+			if path == candidate {
+				return &fakeFileInfo{}, nil
+			}
+			return nil, os.ErrNotExist
+		},
+		[]string{candidate},
+	)
+	if err != nil {
+		t.Fatalf("resolveBinary returned error: %v", err)
+	}
+	if got != candidate {
+		t.Fatalf("unexpected resolved path: got %q want %q", got, candidate)
+	}
+}
+
+func TestResolveBinaryReturnsHelpfulError(t *testing.T) {
+	t.Parallel()
+
+	_, err := resolveBinary(
+		"mkfs.ext4",
+		func(string) (string, error) { return "", errors.New("not found") },
+		func(string) (os.FileInfo, error) { return nil, os.ErrNotExist },
+		[]string{"/opt/homebrew/opt/e2fsprogs/sbin/mkfs.ext4"},
+	)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "mkfs.ext4") {
+		t.Fatalf("expected binary name in error, got %v", err)
+	}
+	if runtime.GOOS == "darwin" && !strings.Contains(err.Error(), "brew install e2fsprogs") {
+		t.Fatalf("expected brew hint on darwin, got %v", err)
+	}
+}
+
+func TestCandidateBinaryPathsIncludesSbinAndBin(t *testing.T) {
+	t.Parallel()
+
+	got := candidateBinaryPaths("mkfs.ext4", []string{"/opt/homebrew/opt/e2fsprogs"})
+	if len(got) != 2 {
+		t.Fatalf("unexpected candidate count: %d", len(got))
+	}
+	if got[0] != "/opt/homebrew/opt/e2fsprogs/sbin/mkfs.ext4" {
+		t.Fatalf("unexpected first candidate: %q", got[0])
+	}
+	if got[1] != "/opt/homebrew/opt/e2fsprogs/bin/mkfs.ext4" {
+		t.Fatalf("unexpected second candidate: %q", got[1])
+	}
+}
+
+type fakeFileInfo struct{}
+
+func (*fakeFileInfo) Name() string       { return "bin" }
+func (*fakeFileInfo) Size() int64        { return 1 }
+func (*fakeFileInfo) Mode() os.FileMode  { return 0o755 }
+func (*fakeFileInfo) ModTime() time.Time { return time.Time{} }
+func (*fakeFileInfo) IsDir() bool        { return false }
+func (*fakeFileInfo) Sys() any           { return nil }

--- a/internal/imagemgr/imagemgr.go
+++ b/internal/imagemgr/imagemgr.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/buildkite/cleanroom/internal/hosttools"
 	"github.com/buildkite/cleanroom/internal/ociref"
 	"github.com/buildkite/cleanroom/internal/paths"
 	_ "modernc.org/sqlite"
@@ -99,7 +100,11 @@ func New(opts Options) (*Manager, error) {
 
 	mkfsBinary := strings.TrimSpace(opts.MkfsBinary)
 	if mkfsBinary == "" {
-		mkfsBinary = defaultMkfsBinary
+		if resolvedMkfs, err := hosttools.ResolveE2FSProgsBinary(defaultMkfsBinary); err == nil {
+			mkfsBinary = resolvedMkfs
+		} else {
+			mkfsBinary = defaultMkfsBinary
+		}
 	}
 
 	manager := &Manager{

--- a/internal/imagemgr/materialize.go
+++ b/internal/imagemgr/materialize.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
@@ -64,6 +65,9 @@ func materializeExt4(ctx context.Context, mkfsBinary string, tarStream io.Reader
 	cmd := exec.CommandContext(ctx, mkfsBinary, "-F", "-d", rootFSDir, outputPath)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
+		if runtime.GOOS == "darwin" && (errors.Is(err, exec.ErrNotFound) || strings.Contains(err.Error(), "executable file not found")) {
+			return 0, fmt.Errorf("run %s for %q: %w; install it with `brew install e2fsprogs`", mkfsBinary, outputPath, err)
+		}
 		return 0, fmt.Errorf("run %s for %q: %w: %s", mkfsBinary, outputPath, err, strings.TrimSpace(string(output)))
 	}
 

--- a/internal/imagemgr/registry_test.go
+++ b/internal/imagemgr/registry_test.go
@@ -1,0 +1,36 @@
+package imagemgr
+
+import "testing"
+
+func TestLinuxPlatformForArch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		goArch      string
+		wantOS      string
+		wantArch    string
+		wantVariant string
+	}{
+		{name: "amd64", goArch: "amd64", wantOS: "linux", wantArch: "amd64", wantVariant: ""},
+		{name: "arm64", goArch: "arm64", wantOS: "linux", wantArch: "arm64", wantVariant: "v8"},
+		{name: "fallback", goArch: "ppc64le", wantOS: "linux", wantArch: "ppc64le", wantVariant: ""},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := linuxPlatformForArch(tc.goArch)
+			if got.OS != tc.wantOS {
+				t.Fatalf("unexpected OS: got %q want %q", got.OS, tc.wantOS)
+			}
+			if got.Architecture != tc.wantArch {
+				t.Fatalf("unexpected architecture: got %q want %q", got.Architecture, tc.wantArch)
+			}
+			if got.Variant != tc.wantVariant {
+				t.Fatalf("unexpected variant: got %q want %q", got.Variant, tc.wantVariant)
+			}
+		})
+	}
+}

--- a/internal/paths/data_dir.go
+++ b/internal/paths/data_dir.go
@@ -1,0 +1,42 @@
+package paths
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// DataBaseDir resolves the default base directory for cleanroom durable data.
+// Preference order:
+// 1. $XDG_DATA_HOME/cleanroom
+// 2. ~/.local/share/cleanroom
+// 3. $XDG_RUNTIME_DIR/cleanroom
+func DataBaseDir() (string, error) {
+	if dataHome := strings.TrimSpace(os.Getenv("XDG_DATA_HOME")); dataHome != "" {
+		return filepath.Join(dataHome, "cleanroom"), nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		if runtimeDir := strings.TrimSpace(os.Getenv("XDG_RUNTIME_DIR")); runtimeDir != "" {
+			return filepath.Join(runtimeDir, "cleanroom"), nil
+		}
+		return "", err
+	}
+	if home != "" {
+		return filepath.Join(home, ".local", "share", "cleanroom"), nil
+	}
+	if runtimeDir := strings.TrimSpace(os.Getenv("XDG_RUNTIME_DIR")); runtimeDir != "" {
+		return filepath.Join(runtimeDir, "cleanroom"), nil
+	}
+	return "", errors.New("unable to resolve data directory from XDG data/runtime or home")
+}
+
+func AssetsDir() (string, error) {
+	base, err := DataBaseDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, "assets"), nil
+}

--- a/internal/runtimeconfig/config_test.go
+++ b/internal/runtimeconfig/config_test.go
@@ -1,0 +1,72 @@
+package runtimeconfig
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadSupportsDarwinVZHyphenKey(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	configPath := filepath.Join(tmp, "cleanroom", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+
+	content := `default_backend: darwin-vz
+backends:
+  darwin-vz:
+    kernel_image: /tmp/kernel
+    rootfs: /tmp/rootfs
+    vcpus: 2
+    memory_mib: 1024
+    guest_port: 10700
+    launch_seconds: 30
+`
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, _, err := Load()
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if got, want := cfg.Backends.DarwinVZ.KernelImage, "/tmp/kernel"; got != want {
+		t.Fatalf("unexpected darwin-vz kernel: got %q want %q", got, want)
+	}
+}
+
+func TestLoadSupportsLegacyDarwinVZUnderscoreKey(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	configPath := filepath.Join(tmp, "cleanroom", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+
+	content := `default_backend: darwin-vz
+backends:
+  darwin_vz:
+    kernel_image: /tmp/legacy-kernel
+    rootfs: /tmp/legacy-rootfs
+    vcpus: 4
+    memory_mib: 2048
+    guest_port: 10701
+    launch_seconds: 45
+`
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, _, err := Load()
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if got, want := cfg.Backends.DarwinVZ.KernelImage, "/tmp/legacy-kernel"; got != want {
+		t.Fatalf("unexpected darwin-vz kernel: got %q want %q", got, want)
+	}
+	if got, want := cfg.Backends.DarwinVZ.VCPUs, int64(4); got != want {
+		t.Fatalf("unexpected darwin-vz vcpus: got %d want %d", got, want)
+	}
+}

--- a/scripts/ci-cleanroom-e2e.sh
+++ b/scripts/ci-cleanroom-e2e.sh
@@ -2,17 +2,12 @@
 set -euo pipefail
 
 KERNEL_IMAGE="${CLEANROOM_KERNEL_IMAGE:-}"
-ROOTFS_IMAGE="${CLEANROOM_ROOTFS:-}"
 FIRECRACKER_BINARY="${CLEANROOM_FIRECRACKER_BINARY:-firecracker}"
 PRIVILEGED_MODE="${CLEANROOM_PRIVILEGED_MODE:-}"
 PRIVILEGED_HELPER_PATH="${CLEANROOM_PRIVILEGED_HELPER_PATH:-}"
 
 if [[ -z "$KERNEL_IMAGE" ]]; then
   echo "CLEANROOM_KERNEL_IMAGE is required for Firecracker e2e CI" >&2
-  exit 1
-fi
-if [[ -z "$ROOTFS_IMAGE" ]]; then
-  echo "CLEANROOM_ROOTFS is required for Firecracker e2e CI" >&2
   exit 1
 fi
 
@@ -113,7 +108,6 @@ backends:
   firecracker:
     binary_path: $FIRECRACKER_BINARY
     kernel_image: $KERNEL_IMAGE
-    rootfs: $ROOTFS_IMAGE
     vcpus: 2
     memory_mib: 1024
     launch_seconds: 45


### PR DESCRIPTION
## Summary
- add a new `darwin-vz` backend using a dedicated Swift helper binary (`cleanroom-darwin-vz`) with a focused host/VM split
- implement managed boot assets and runtime rootfs preparation for macOS using OCI inputs, including host tool checks and clearer doctor/config UX
- align CLI/runtime behavior and docs for backend selection, config init, console/exec behavior, and CI/mise workflows (including removal of legacy firecracker image prep path)

## Key details
- backend implementation lives under `internal/backend/darwinvz`
- helper binary and entitlements live under `cmd/cleanroom-darwin-vz`
- added boot asset manager (`internal/bootassets`) and host e2fsprogs detection (`internal/hosttools`)
- improved robustness around helper startup/shutdown, entitlement parsing, serial fallback boot script behavior, and attach/resize handling
- added linux-only gating for gateway firewall installation during serve

## Docs
- add `docs/darwin-vz.md`
- update `README.md`, `docs/ci.md`, and `AGENTS.md`

## Verification
- `mise run lint-shell`
- `mise run test`
