### PR TITLE
feat: polish serve and doctor cli output

### DIFF
--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -12,7 +12,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -28,6 +27,7 @@ import (
 	"github.com/buildkite/cleanroom/internal/imagemgr"
 	"github.com/buildkite/cleanroom/internal/paths"
 	"github.com/buildkite/cleanroom/internal/vsockexec"
+	"github.com/charmbracelet/log"
 )
 
 // Adapter runs single-execution Linux VMs on macOS via Virtualization.framework.
@@ -1016,10 +1016,10 @@ func logRunNotice(backendName, runID, notice string) {
 	if msg == "" {
 		return
 	}
+	fields := []any{"backend", strings.TrimSpace(backendName)}
 	id := strings.TrimSpace(runID)
-	if id == "" {
-		log.Printf("%s: %s", backendName, msg)
-		return
+	if id != "" {
+		fields = append(fields, "run_id", id)
 	}
-	log.Printf("%s run_id=%s: %s", backendName, id, msg)
+	log.Info(msg, fields...)
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1146,12 +1146,30 @@ func (c *TLSIssueCommand) Run(ctx *runtimeContext) error {
 }
 
 func (s *ServeCommand) Run(ctx *runtimeContext) error {
-	logger, err := newLogger(s.LogLevel, "server")
+	ep, err := endpoint.ResolveListen(s.Listen)
 	if err != nil {
 		return err
 	}
+	if shouldShowStartupHeader(os.Stderr) {
+		gatewayListen := strings.TrimSpace(s.GatewayListen)
+		if gatewayListen == "" {
+			gatewayListen = fmt.Sprintf(":%d", gateway.DefaultPort)
+		}
+		if err := writeStartupHeader(os.Stderr, startupHeader{
+			Title: "cleanroom serve",
+			Fields: []startupField{
+				{Key: "workspace", Value: ctx.CWD},
+				{Key: "listen", Value: endpointDisplay(ep)},
+				{Key: "gateway_listen", Value: gatewayListen},
+				{Key: "runtime_config", Value: ctx.ConfigPath},
+				{Key: "log_level", Value: effectiveLogLevel(s.LogLevel)},
+			},
+		}, shouldUseANSI(os.Stderr)); err != nil {
+			return err
+		}
+	}
 
-	ep, err := endpoint.ResolveListen(s.Listen)
+	logger, err := newLogger(s.LogLevel, "server")
 	if err != nil {
 		return err
 	}
@@ -1295,16 +1313,8 @@ func (d *DoctorCommand) Run(ctx *runtimeContext) error {
 		return enc.Encode(payload)
 	}
 
-	_, err = fmt.Fprintf(ctx.Stdout, "doctor report (%s)\n", backendName)
-	if err != nil {
-		return err
-	}
-	for _, check := range checks {
-		if _, err := fmt.Fprintf(ctx.Stdout, "- [%s] %s: %s\n", check.Status, check.Name, check.Message); err != nil {
-			return err
-		}
-	}
-	return nil
+	_, err = fmt.Fprint(ctx.Stdout, renderDoctorReport(backendName, checks, shouldUseANSI(ctx.Stdout)))
+	return err
 }
 
 func resolveBackendName(requested, configuredDefault string) string {
@@ -1659,10 +1669,7 @@ func setMapInt(parent *yaml.Node, key string, value int) {
 }
 
 func newLogger(rawLevel, component string) (*log.Logger, error) {
-	levelName := strings.TrimSpace(strings.ToLower(rawLevel))
-	if levelName == "" {
-		levelName = "info"
-	}
+	levelName := effectiveLogLevel(rawLevel)
 	level, err := log.ParseLevel(levelName)
 	if err != nil {
 		return nil, fmt.Errorf("invalid --log-level %q: %w", rawLevel, err)
@@ -1671,5 +1678,6 @@ func newLogger(rawLevel, component string) (*log.Logger, error) {
 		Level:     level,
 		Formatter: log.TextFormatter,
 	})
+	applyPolishedLoggerStyles(logger, shouldUseANSI(os.Stderr))
 	return logger.With("component", component), nil
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1173,6 +1173,7 @@ func (s *ServeCommand) Run(ctx *runtimeContext) error {
 	if err != nil {
 		return err
 	}
+	log.SetDefault(logger)
 
 	gwRegistry := gateway.NewRegistry()
 	gwCredentials := gateway.NewEnvCredentialProvider()

--- a/internal/cli/ui.go
+++ b/internal/cli/ui.go
@@ -1,0 +1,267 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/endpoint"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/log"
+	"golang.org/x/term"
+)
+
+type startupHeader struct {
+	Title  string
+	Fields []startupField
+}
+
+type startupField struct {
+	Key   string
+	Value string
+}
+
+func renderStartupHeader(h startupHeader, color bool) string {
+	title := strings.TrimSpace(h.Title)
+	if title == "" {
+		title = "cleanroom"
+	}
+
+	var out strings.Builder
+	icon := "🧑‍🔬"
+	if color {
+		icon = ansiWrap("1;33", icon)
+		title = ansiWrap("1;36", title)
+	}
+
+	out.WriteByte('\n')
+	out.WriteString(icon)
+	out.WriteString(" ")
+	out.WriteString(title)
+	out.WriteByte('\n')
+
+	for _, field := range h.Fields {
+		key := strings.TrimSpace(field.Key)
+		value := strings.TrimSpace(field.Value)
+		if key == "" || value == "" {
+			continue
+		}
+
+		line := fmt.Sprintf("%s: %s", key, value)
+		if color {
+			line = ansiWrap("38;5;252", line)
+		}
+		out.WriteString("   ")
+		out.WriteString(line)
+		out.WriteByte('\n')
+	}
+	out.WriteByte('\n')
+
+	return out.String()
+}
+
+func renderDoctorReport(backendName string, checks []backend.DoctorCheck, color bool) string {
+	name := strings.TrimSpace(backendName)
+	if name == "" {
+		name = "unknown"
+	}
+
+	var out strings.Builder
+	title := fmt.Sprintf("doctor report (%s)", name)
+	if color {
+		title = ansiWrap("1;36", title)
+	}
+	out.WriteString(title)
+	out.WriteByte('\n')
+
+	passCount := 0
+	warnCount := 0
+	failCount := 0
+
+	for _, check := range checks {
+		status := normalizeDoctorStatus(check.Status)
+		switch status {
+		case "pass":
+			passCount++
+		case "warn":
+			warnCount++
+		case "fail":
+			failCount++
+		}
+
+		icon := "?"
+		switch status {
+		case "pass":
+			icon = "✓"
+		case "warn":
+			icon = "!"
+		case "fail":
+			icon = "✗"
+		}
+
+		statusBlock := fmt.Sprintf("%s [%s]", icon, status)
+		if color {
+			code := "1;37"
+			switch status {
+			case "pass":
+				code = "1;32"
+			case "warn":
+				code = "1;33"
+			case "fail":
+				code = "1;31"
+			}
+			statusBlock = ansiWrap(code, statusBlock)
+		}
+
+		checkName := strings.TrimSpace(check.Name)
+		if checkName == "" {
+			checkName = "unnamed_check"
+		}
+		message := strings.TrimSpace(check.Message)
+		if message == "" {
+			message = "(no message)"
+		}
+
+		out.WriteString(statusBlock)
+		out.WriteString(" ")
+		out.WriteString(checkName)
+		out.WriteString(": ")
+		out.WriteString(message)
+		out.WriteByte('\n')
+	}
+
+	summary := fmt.Sprintf("summary: %d pass, %d warn, %d fail", passCount, warnCount, failCount)
+	if color {
+		summary = ansiWrap("38;5;246", summary)
+	}
+	out.WriteString(summary)
+	out.WriteByte('\n')
+
+	return out.String()
+}
+
+func writeStartupHeader(w io.Writer, h startupHeader, color bool) error {
+	if w == nil {
+		return nil
+	}
+	_, err := io.WriteString(w, renderStartupHeader(h, color))
+	return err
+}
+
+func shouldShowStartupHeader(stderr *os.File) bool {
+	if stderr == nil {
+		return false
+	}
+	return term.IsTerminal(int(stderr.Fd()))
+}
+
+func shouldUseANSI(stderr *os.File) bool {
+	if noColorRequested() {
+		return false
+	}
+	if forceColorRequested() {
+		return true
+	}
+	if stderr == nil {
+		return false
+	}
+	return term.IsTerminal(int(stderr.Fd()))
+}
+
+func applyPolishedLoggerStyles(logger *log.Logger, color bool) {
+	if logger == nil || !color {
+		return
+	}
+
+	styles := log.DefaultStyles()
+	styles.Message = styles.Message.Foreground(lipgloss.Color("252"))
+	styles.Key = styles.Key.Bold(true).Foreground(lipgloss.Color("75"))
+	styles.Value = styles.Value.Foreground(lipgloss.Color("255"))
+	styles.Separator = styles.Separator.Foreground(lipgloss.Color("240"))
+	styles.Levels[log.DebugLevel] = styles.Levels[log.DebugLevel].Bold(true).Foreground(lipgloss.Color("45"))
+	styles.Levels[log.InfoLevel] = styles.Levels[log.InfoLevel].Bold(true).Foreground(lipgloss.Color("48"))
+	styles.Levels[log.WarnLevel] = styles.Levels[log.WarnLevel].Bold(true).Foreground(lipgloss.Color("214"))
+	styles.Levels[log.ErrorLevel] = styles.Levels[log.ErrorLevel].Bold(true).Foreground(lipgloss.Color("203"))
+	logger.SetStyles(styles)
+}
+
+func endpointDisplay(ep endpoint.Endpoint) string {
+	switch ep.Scheme {
+	case "unix":
+		return "unix://" + ep.Address
+	case "http", "https":
+		if ep.Address != "" {
+			return ep.Address
+		}
+		return ep.BaseURL
+	case "tsnet":
+		host := strings.TrimSpace(ep.TSNetHostname)
+		if host == "" {
+			host = "cleanroom"
+		}
+		if ep.TSNetPort > 0 {
+			return fmt.Sprintf("tsnet://%s:%d", host, ep.TSNetPort)
+		}
+		return "tsnet://" + host
+	case "tssvc":
+		label := strings.TrimSpace(strings.TrimPrefix(ep.TSServiceName, "svc:"))
+		if label == "" {
+			label = "cleanroom"
+		}
+		if ep.TSServicePort > 0 {
+			return fmt.Sprintf("tssvc://%s:%d", label, ep.TSServicePort)
+		}
+		return "tssvc://" + label
+	default:
+		if ep.Address != "" {
+			return ep.Address
+		}
+		return ep.BaseURL
+	}
+}
+
+func effectiveLogLevel(rawLevel string) string {
+	level := strings.TrimSpace(strings.ToLower(rawLevel))
+	if level == "" {
+		return "info"
+	}
+	return level
+}
+
+func noColorRequested() bool {
+	if _, ok := os.LookupEnv("NO_COLOR"); ok {
+		return true
+	}
+	return strings.TrimSpace(os.Getenv("CLICOLOR")) == "0"
+}
+
+func forceColorRequested() bool {
+	value := strings.TrimSpace(os.Getenv("CLICOLOR_FORCE"))
+	if value == "" {
+		return false
+	}
+	if parsed, err := strconv.Atoi(value); err == nil {
+		return parsed != 0
+	}
+	return true
+}
+
+func ansiWrap(code, value string) string {
+	return "\x1b[" + code + "m" + value + "\x1b[0m"
+}
+
+func normalizeDoctorStatus(raw string) string {
+	switch strings.TrimSpace(strings.ToLower(raw)) {
+	case "pass", "ok", "success":
+		return "pass"
+	case "warn", "warning":
+		return "warn"
+	case "fail", "failed", "error":
+		return "fail"
+	default:
+		return "unknown"
+	}
+}

--- a/internal/cli/ui_test.go
+++ b/internal/cli/ui_test.go
@@ -1,0 +1,121 @@
+package cli
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+)
+
+func TestRenderStartupHeaderPlain(t *testing.T) {
+	out := renderStartupHeader(startupHeader{
+		Title: "cleanroom exec",
+		Fields: []startupField{
+			{Key: "workspace", Value: "/tmp/repo"},
+			{Key: "backend", Value: "firecracker"},
+		},
+	}, false)
+
+	want := "\n🧑‍🔬 cleanroom exec\n   workspace: /tmp/repo\n   backend: firecracker\n\n"
+	if out != want {
+		t.Fatalf("unexpected header output:\n--- got ---\n%s--- want ---\n%s", out, want)
+	}
+	if strings.Contains(out, "\x1b[") {
+		t.Fatalf("plain output should not contain ANSI escapes: %q", out)
+	}
+}
+
+func TestRenderStartupHeaderColor(t *testing.T) {
+	out := renderStartupHeader(startupHeader{
+		Title: "cleanroom console",
+		Fields: []startupField{
+			{Key: "workspace", Value: "/tmp/repo"},
+		},
+	}, true)
+
+	if !strings.Contains(out, "\x1b[") {
+		t.Fatalf("expected ANSI escapes in color output: %q", out)
+	}
+	if !strings.Contains(out, "cleanroom console") {
+		t.Fatalf("missing title in header output: %q", out)
+	}
+	if !strings.Contains(out, "🧑‍🔬") {
+		t.Fatalf("missing icon in header output: %q", out)
+	}
+	if !strings.Contains(out, "workspace: /tmp/repo") {
+		t.Fatalf("missing field in header output: %q", out)
+	}
+	if !strings.HasPrefix(out, "\n") {
+		t.Fatalf("expected leading blank line in header output: %q", out)
+	}
+	if !strings.HasSuffix(out, "\n\n") {
+		t.Fatalf("expected trailing blank line in header output: %q", out)
+	}
+}
+
+func TestRenderStartupHeaderSkipsEmptyFields(t *testing.T) {
+	out := renderStartupHeader(startupHeader{
+		Title: "cleanroom exec",
+		Fields: []startupField{
+			{Key: "workspace", Value: "/tmp/repo"},
+			{Key: "backend", Value: ""},
+			{Key: "", Value: "ignored"},
+		},
+	}, false)
+
+	if strings.Contains(out, "backend:") {
+		t.Fatalf("expected empty backend field to be omitted: %q", out)
+	}
+	if strings.Contains(out, "ignored") {
+		t.Fatalf("expected field without key to be omitted: %q", out)
+	}
+}
+
+func TestRenderDoctorReportPlain(t *testing.T) {
+	out := renderDoctorReport("firecracker", []backend.DoctorCheck{
+		{Name: "runtime_config", Status: "pass", Message: "using /tmp/config.yaml"},
+		{Name: "network_guest_interface", Status: "warn", Message: "unsupported"},
+	}, false)
+
+	if !strings.Contains(out, "doctor report (firecracker)") {
+		t.Fatalf("missing doctor title: %q", out)
+	}
+	if !strings.Contains(out, "✓ [pass] runtime_config: using /tmp/config.yaml") {
+		t.Fatalf("missing pass line: %q", out)
+	}
+	if !strings.Contains(out, "! [warn] network_guest_interface: unsupported") {
+		t.Fatalf("missing warn line: %q", out)
+	}
+	if !strings.Contains(out, "summary: 1 pass, 1 warn, 0 fail") {
+		t.Fatalf("missing summary line: %q", out)
+	}
+	if strings.Contains(out, "\x1b[") {
+		t.Fatalf("plain output should not contain ANSI escapes: %q", out)
+	}
+}
+
+func TestRenderDoctorReportColor(t *testing.T) {
+	out := renderDoctorReport("darwin-vz", []backend.DoctorCheck{
+		{Name: "backend_doctor", Status: "fail", Message: "missing helper"},
+	}, true)
+	plain := stripANSI(out)
+
+	if !strings.Contains(out, "\x1b[") {
+		t.Fatalf("expected ANSI escapes in color output: %q", out)
+	}
+	if !strings.Contains(plain, "doctor report (darwin-vz)") {
+		t.Fatalf("missing doctor title: %q", out)
+	}
+	if !strings.Contains(plain, "✗ [fail] backend_doctor: missing helper") {
+		t.Fatalf("missing fail line: %q", out)
+	}
+	if !strings.Contains(plain, "summary: 0 pass, 0 warn, 1 fail") {
+		t.Fatalf("missing summary line: %q", out)
+	}
+}
+
+func stripANSI(value string) string {
+	ansi := regexp.MustCompile(`\x1b\[[0-9;]*m`)
+	return ansi.ReplaceAllString(value, "")
+}


### PR DESCRIPTION
## Summary
- keep the startup header for `cleanroom serve` only (remove it from client-side command paths)
- add polished ANSI-aware styling for charmbracelet/log output when color is enabled
- add a dedicated `doctor` text renderer with clear status icons and summary counts
- preserve plain, non-ANSI behavior for non-terminal and JSON flows

## Testing
- mise x -- go test ./internal/cli
- mise x -- go test ./...
- mise run build
- mise run lint-shell
