### PR TITLE
darwin-vz: enable unfiltered guest egress and gateway access

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Cleanroom uses fast Linux microVM backends to create isolated environments for u
 | Host OS | Backend | Status | Notes |
 |---------|---------|--------|-------|
 | Linux | `firecracker` | Full local backend | Supports persistent sandboxes, sandbox file download, and egress allowlist enforcement |
-| macOS | `darwin-vz` | Supported with known gaps | Per-run VMs (no persistent sandboxes yet), no sandbox file download, and no guest NIC/egress allowlist enforcement yet |
+| macOS | `darwin-vz` | Supported with known gaps | Per-run VMs (no persistent sandboxes yet), no sandbox file download, guest NIC with unfiltered egress, and no egress allowlist enforcement yet |
 
 Backend capabilities are exposed in `cleanroom doctor --json` under `capabilities`.
 
@@ -275,7 +275,7 @@ The helper (not the main `cleanroom` binary) needs the `com.apple.security.virtu
 
 - Workload runs in a Linux microVM backend (`firecracker` on Linux, `darwin-vz` on macOS)
 - `firecracker` enforces policy egress allowlists with TAP + iptables
-- `darwin-vz` currently requires `network.default: deny`, ignores `network.allow` entries, and attaches no guest NIC (warns on stderr during execution)
+- `darwin-vz` currently requires `network.default: deny`, ignores `network.allow` entries, and provides guest networking without egress filtering (warns on stderr during execution)
 - `firecracker` rootfs writes persist across executions within a sandbox and are discarded on sandbox termination
 - `darwin-vz` executes each command in a fresh VM/rootfs copy (writes are discarded after each run)
 - Per-run observability is written to `run-observability.json` (rootfs prep, network setup, VM ready, command runtime, total)

--- a/cmd/cleanroom-darwin-vz/main.swift
+++ b/cmd/cleanroom-darwin-vz/main.swift
@@ -492,6 +492,10 @@ private final class VMRuntime {
         let blockDevice = VZVirtioBlockDeviceConfiguration(attachment: diskAttachment)
         config.storageDevices = [blockDevice]
 
+        let networkDevice = VZVirtioNetworkDeviceConfiguration()
+        networkDevice.attachment = VZNATNetworkDeviceAttachment()
+        config.networkDevices = [networkDevice]
+
         config.entropyDevices = [VZVirtioEntropyDeviceConfiguration()]
         config.memoryBalloonDevices = [VZVirtioTraditionalMemoryBalloonDeviceConfiguration()]
         config.socketDevices = [VZVirtioSocketDeviceConfiguration()]

--- a/docs/darwin-vz.md
+++ b/docs/darwin-vz.md
@@ -99,7 +99,7 @@ On macOS, cleanroom also probes common Homebrew `e2fsprogs` locations.
 
 - `network.default` must be `deny`
 - `network.allow` entries are ignored and produce a warning
-- no virtual NIC is attached, so guest outbound networking is unavailable in current builds
+- a virtual NIC is attached (NAT), so guest outbound networking is available
 
 The backend currently has no allowlist egress enforcement equivalent to Linux Firecracker iptables rules.
 
@@ -116,7 +116,12 @@ Current `darwin-vz` capability values:
 - `sandbox.file_download=false`
 - `network.default_deny=true`
 - `network.allowlist_egress=false`
-- `network.guest_interface=false`
+- `network.guest_interface=true`
+
+Gateway access for git rewrite flow:
+
+- darwin guests can access the host gateway through the NAT host address
+- default host is `192.168.64.1`; override with `CLEANROOM_DARWIN_GATEWAY_HOST`
 
 ## Entitlements and Signing
 

--- a/internal/backend/darwinvz/backend_unsupported.go
+++ b/internal/backend/darwinvz/backend_unsupported.go
@@ -10,7 +10,11 @@ import (
 	"github.com/buildkite/cleanroom/internal/backend"
 )
 
-type Adapter struct{}
+type Adapter struct {
+	GatewayRegistry gatewayRegistry
+	GatewayPort     int
+	GatewayHost     string
+}
 
 func New() *Adapter {
 	return &Adapter{}
@@ -24,7 +28,7 @@ func (a *Adapter) Capabilities() map[string]bool {
 	return map[string]bool{
 		backend.CapabilityNetworkDefaultDeny:     true,
 		backend.CapabilityNetworkAllowlistEgress: false,
-		backend.CapabilityNetworkGuestInterface:  false,
+		backend.CapabilityNetworkGuestInterface:  true,
 	}
 }
 

--- a/internal/backend/darwinvz/capabilities_test.go
+++ b/internal/backend/darwinvz/capabilities_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/buildkite/cleanroom/internal/backend"
 )
 
-func TestCapabilitiesDeclareNoGuestNetworkInterface(t *testing.T) {
+func TestCapabilitiesDeclareGuestNetworkInterfaceWithoutAllowlistFiltering(t *testing.T) {
 	caps := New().Capabilities()
 
 	if !caps[backend.CapabilityNetworkDefaultDeny] {
@@ -15,7 +15,7 @@ func TestCapabilitiesDeclareNoGuestNetworkInterface(t *testing.T) {
 	if caps[backend.CapabilityNetworkAllowlistEgress] {
 		t.Fatalf("expected %s=false", backend.CapabilityNetworkAllowlistEgress)
 	}
-	if caps[backend.CapabilityNetworkGuestInterface] {
-		t.Fatalf("expected %s=false", backend.CapabilityNetworkGuestInterface)
+	if !caps[backend.CapabilityNetworkGuestInterface] {
+		t.Fatalf("expected %s=true", backend.CapabilityNetworkGuestInterface)
 	}
 }

--- a/internal/backend/darwinvz/gateway_env.go
+++ b/internal/backend/darwinvz/gateway_env.go
@@ -1,0 +1,73 @@
+package darwinvz
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/buildkite/cleanroom/internal/gateway"
+	"github.com/buildkite/cleanroom/internal/policy"
+)
+
+const defaultGatewayHost = "192.168.64.1"
+
+// gatewayRegistry is the subset of gateway.Registry used by the darwin
+// adapter.
+type gatewayRegistry interface {
+	RegisterScopeToken(scopeToken, sandboxID string, p *policy.CompiledPolicy) error
+	ReleaseScopeToken(scopeToken string)
+}
+
+func gatewayEnvVars(compiled *policy.CompiledPolicy, gatewayHost string, gatewayPort int, scopeToken string) []string {
+	if compiled == nil {
+		return nil
+	}
+	if gatewayPort <= 0 {
+		return nil
+	}
+	gatewayHost = strings.TrimSpace(gatewayHost)
+	scopeToken = strings.TrimSpace(scopeToken)
+	if gatewayHost == "" || scopeToken == "" {
+		return nil
+	}
+
+	type configEntry struct {
+		key   string
+		value string
+	}
+
+	entries := make([]configEntry, 0, len(compiled.Allow)+1)
+	for _, rule := range compiled.Allow {
+		host := strings.TrimSpace(rule.Host)
+		if host == "" {
+			continue
+		}
+		for _, port := range rule.Ports {
+			if port != 443 {
+				continue
+			}
+			entries = append(entries, configEntry{
+				key:   fmt.Sprintf("url.http://%s:%d/git/%s/.insteadOf", gatewayHost, gatewayPort, host),
+				value: fmt.Sprintf("https://%s/", host),
+			})
+			break
+		}
+	}
+
+	if len(entries) == 0 {
+		return nil
+	}
+
+	gatewayAddr := fmt.Sprintf("http://%s:%d", gatewayHost, gatewayPort)
+	entries = append(entries, configEntry{
+		key:   fmt.Sprintf("http.%s/.extraHeader", gatewayAddr),
+		value: fmt.Sprintf("%s: %s", gateway.ScopeTokenHeader, scopeToken),
+	})
+
+	env := make([]string, 0, 1+len(entries)*2)
+	env = append(env, fmt.Sprintf("GIT_CONFIG_COUNT=%d", len(entries)))
+	for i, entry := range entries {
+		env = append(env, fmt.Sprintf("GIT_CONFIG_KEY_%d=%s", i, entry.key))
+		env = append(env, fmt.Sprintf("GIT_CONFIG_VALUE_%d=%s", i, entry.value))
+	}
+	return env
+}

--- a/internal/backend/darwinvz/gateway_env_test.go
+++ b/internal/backend/darwinvz/gateway_env_test.go
@@ -1,0 +1,68 @@
+package darwinvz
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/gateway"
+	"github.com/buildkite/cleanroom/internal/policy"
+)
+
+func TestGatewayEnvVarsNilPolicy(t *testing.T) {
+	t.Parallel()
+	env := gatewayEnvVars(nil, defaultGatewayHost, 8170, "token")
+	if env != nil {
+		t.Fatalf("expected nil env for nil policy, got %v", env)
+	}
+}
+
+func TestGatewayEnvVarsNoHTTPSHosts(t *testing.T) {
+	t.Parallel()
+	p := &policy.CompiledPolicy{
+		Version:        1,
+		NetworkDefault: "deny",
+		Allow:          []policy.AllowRule{{Host: "example.com", Ports: []int{80}}},
+	}
+	env := gatewayEnvVars(p, defaultGatewayHost, 8170, "token")
+	if env != nil {
+		t.Fatalf("expected nil env without port 443 hosts, got %v", env)
+	}
+}
+
+func TestGatewayEnvVarsGeneratesGitRewriteAndHeader(t *testing.T) {
+	t.Parallel()
+	p := &policy.CompiledPolicy{
+		Version:        1,
+		NetworkDefault: "deny",
+		Allow: []policy.AllowRule{
+			{Host: "github.com", Ports: []int{443}},
+			{Host: "gitlab.com", Ports: []int{443}},
+		},
+	}
+	env := gatewayEnvVars(p, "192.168.64.1", 8170, "scope-token")
+	if len(env) != 7 {
+		t.Fatalf("expected 7 env vars (count + 3 key/value entries), got %d: %v", len(env), env)
+	}
+	if env[0] != "GIT_CONFIG_COUNT=3" {
+		t.Fatalf("expected GIT_CONFIG_COUNT=3, got %s", env[0])
+	}
+	if !strings.Contains(env[1], "url.http://192.168.64.1:8170/git/github.com/.insteadOf") {
+		t.Fatalf("expected github rewrite key, got %s", env[1])
+	}
+	if env[2] != "GIT_CONFIG_VALUE_0=https://github.com/" {
+		t.Fatalf("expected github rewrite value, got %s", env[2])
+	}
+	if !strings.Contains(env[3], "url.http://192.168.64.1:8170/git/gitlab.com/.insteadOf") {
+		t.Fatalf("expected gitlab rewrite key, got %s", env[3])
+	}
+	if env[4] != "GIT_CONFIG_VALUE_1=https://gitlab.com/" {
+		t.Fatalf("expected gitlab rewrite value, got %s", env[4])
+	}
+	if !strings.Contains(env[5], "http.http://192.168.64.1:8170/.extraHeader") {
+		t.Fatalf("expected extraHeader key, got %s", env[5])
+	}
+	wantHeader := "GIT_CONFIG_VALUE_2=" + gateway.ScopeTokenHeader + ": scope-token"
+	if env[6] != wantHeader {
+		t.Fatalf("expected %q, got %q", wantHeader, env[6])
+	}
+}

--- a/internal/backend/darwinvz/guest_init_script_test.go
+++ b/internal/backend/darwinvz/guest_init_script_test.go
@@ -20,3 +20,12 @@ func TestGuestInitScriptAlwaysStartsStdioAgentWhenSerialDeviceExists(t *testing.
 		t.Fatal("expected stdio guest-agent loop to run in background")
 	}
 }
+
+func TestGuestInitScriptBootstrapsNetwork(t *testing.T) {
+	if !strings.Contains(guestInitScriptTemplate, "setup_guest_network") {
+		t.Fatal("expected guest network setup function in init script")
+	}
+	if !strings.Contains(guestInitScriptTemplate, "udhcpc -q -n -t 3 -T 3 -i") {
+		t.Fatal("expected udhcpc DHCP bootstrap in init script")
+	}
+}

--- a/internal/backend/darwinvz/policy.go
+++ b/internal/backend/darwinvz/policy.go
@@ -6,7 +6,7 @@ import (
 )
 
 const allowRulesIgnoredWarning = "darwin-vz ignores sandbox.network.allow entries; allowlist egress filtering is not implemented"
-const guestNetworkUnavailableWarning = "darwin-vz currently exposes no guest network interface; guest outbound networking is unavailable"
+const guestNetworkUnavailableWarning = "darwin-vz guest networking is enabled without host-side egress filtering"
 
 func evaluateNetworkPolicy(networkDefault string, allowCount int) (string, error) {
 	if strings.TrimSpace(networkDefault) != "deny" {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1192,6 +1192,13 @@ func (s *ServeCommand) Run(ctx *runtimeContext) error {
 			}
 		}
 	}
+	if darwinAdapter, ok := ctx.Backends["darwin-vz"].(*darwinvz.Adapter); ok {
+		darwinAdapter.GatewayRegistry = gwRegistry
+		darwinAdapter.GatewayPort = gwPort
+		if host := strings.TrimSpace(os.Getenv("CLEANROOM_DARWIN_GATEWAY_HOST")); host != "" {
+			darwinAdapter.GatewayHost = host
+		}
+	}
 
 	var serverTLS *controlserver.TLSOptions
 	if ep.Scheme == "https" {


### PR DESCRIPTION
## Summary
- enable guest networking for `darwin-vz` by attaching a NAT NIC in the helper
- bootstrap guest network in darwin init (`udhcpc`/`dhclient`) so egress and DNS come up reliably
- add gateway token-based identity fallback (`X-Cleanroom-Scope-Token`) alongside existing source-IP identity
- wire darwin adapter to register/release per-run scope tokens and inject git rewrite + auth header env
- update darwin capabilities/docs/warnings to reflect `network.guest_interface=true` and unfiltered egress

## Why
Darwin runs previously had no guest NIC, so guests could not reach internet or the host gateway. That blocked practical git access for macOS cleanrooms.

## Validation
- `go test ./internal/backend/darwinvz ./internal/gateway ./internal/cli ./internal/backend/firecracker`
- `swiftc -typecheck cmd/cleanroom-darwin-vz/main.swift`
- manual checks against running server:
  - guest gets `eth0` address/route/DNS
  - HTTP egress succeeds from darwin guest
  - gateway reachable from guest only with injected scope token
  - git smart-HTTP endpoint reachable through gateway with token
