### PR TITLE
feat: add versioned release process with GoReleaser and svu

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,38 @@
+version: 2
+
+builds:
+  - id: cleanroom
+    main: ./cmd/cleanroom
+    binary: cleanroom
+    env:
+      - CGO_ENABLED=0
+    goos: [linux, darwin]
+    goarch: [amd64, arm64]
+    ldflags:
+      - -s -w -X main.version={{.Version}}
+
+  - id: cleanroom-guest-agent
+    main: ./cmd/cleanroom-guest-agent
+    binary: cleanroom-guest-agent
+    env:
+      - CGO_ENABLED=0
+    goos: [linux]
+    goarch: [amd64, arm64]
+    ldflags:
+      - -s -w
+
+archives:
+  - formats: [tar.gz]
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else }}{{ .Arch }}{{ end }}
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  sort: asc
+  filters:
+    exclude: ["^docs:", "^test:", "^chore:"]

--- a/.mise.toml
+++ b/.mise.toml
@@ -13,7 +13,7 @@ run = "go test ./..."
 
 [tasks.lint-shell]
 description = "Lint shell scripts"
-run = "shellcheck -x scripts/*.sh"
+run = "shellcheck -x scripts/cleanroom-root-helper.sh scripts/benchmark-tti.sh scripts/build-go.sh scripts/install-go.sh scripts/release.sh"
 
 [tasks.test-full]
 description = "Run full Go test suite"

--- a/.mise.toml
+++ b/.mise.toml
@@ -2,6 +2,7 @@
 go = "1.23"
 shellcheck = "latest"
 hyperfine = "latest"
+svu = "3"
 
 [env]
 GOTOOLCHAIN = "local"
@@ -20,7 +21,12 @@ run = "go test ./..."
 
 [tasks."build:go"]
 description = "Build Go binaries into dist/"
-run = "mkdir -p dist && go build -o dist/cleanroom ./cmd/cleanroom && go build -o dist/cleanroom-guest-agent ./cmd/cleanroom-guest-agent"
+run = """
+VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo dev)
+mkdir -p dist
+go build -ldflags "-X main.version=$VERSION" -o dist/cleanroom ./cmd/cleanroom
+go build -o dist/cleanroom-guest-agent ./cmd/cleanroom-guest-agent
+"""
 
 [tasks."build:darwin"]
 description = "Build macOS darwin-vz helper into dist/"
@@ -33,7 +39,15 @@ run = "true"
 
 [tasks."install:go"]
 description = "Install Go binaries into GOBIN (or GOPATH/bin)"
-run = "BIN_DIR=\"$(go env GOBIN)\"; if [ -z \"$BIN_DIR\" ]; then BIN_DIR=\"$(go env GOPATH)/bin\"; fi; HOST_ARCH=\"$(go env GOARCH)\"; mkdir -p \"$BIN_DIR\" && go install ./cmd/cleanroom ./cmd/cleanroom-guest-agent && GOOS=linux GOARCH=\"$HOST_ARCH\" CGO_ENABLED=0 go build -trimpath -o \"$BIN_DIR/cleanroom-guest-agent-linux-$HOST_ARCH\" ./cmd/cleanroom-guest-agent"
+run = """
+VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo dev)
+BIN_DIR="$(go env GOBIN)"
+if [ -z "$BIN_DIR" ]; then BIN_DIR="$(go env GOPATH)/bin"; fi
+HOST_ARCH="$(go env GOARCH)"
+mkdir -p "$BIN_DIR"
+go install -ldflags "-X main.version=$VERSION" ./cmd/cleanroom ./cmd/cleanroom-guest-agent
+GOOS=linux GOARCH="$HOST_ARCH" CGO_ENABLED=0 go build -trimpath -o "$BIN_DIR/cleanroom-guest-agent-linux-$HOST_ARCH" ./cmd/cleanroom-guest-agent
+"""
 
 [tasks."install:darwin"]
 description = "Install macOS darwin-vz helper into GOBIN (or GOPATH/bin)"
@@ -52,3 +66,24 @@ run = "go run ./cmd/cleanroom doctor"
 [tasks.doctor-json]
 description = "Run cleanroom diagnostics as JSON"
 run = "go run ./cmd/cleanroom doctor --json"
+
+[tasks.check]
+description = "Run build, test, and lint"
+depends = ["build", "test", "lint-shell"]
+run = "true"
+
+[tasks.release]
+description = "Tag the next version and push to trigger a release"
+depends = ["check"]
+run = """
+NEXT=$(svu next)
+CURRENT=$(svu current)
+if [ "$NEXT" = "$CURRENT" ]; then
+  echo "No version bump detected (current: $CURRENT). Use conventional commits (feat:, fix:, etc.)."
+  exit 1
+fi
+echo "Releasing $CURRENT -> $NEXT"
+git tag "$NEXT"
+git push origin "$NEXT"
+echo "Tagged and pushed $NEXT — release workflow will run on GitHub."
+"""

--- a/.mise.toml
+++ b/.mise.toml
@@ -13,7 +13,7 @@ run = "go test ./..."
 
 [tasks.lint-shell]
 description = "Lint shell scripts"
-run = "shellcheck -x scripts/cleanroom-root-helper.sh scripts/benchmark-tti.sh"
+run = "shellcheck -x scripts/*.sh"
 
 [tasks.test-full]
 description = "Run full Go test suite"
@@ -21,12 +21,7 @@ run = "go test ./..."
 
 [tasks."build:go"]
 description = "Build Go binaries into dist/"
-run = """
-VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo dev)
-mkdir -p dist
-go build -ldflags "-X main.version=$VERSION" -o dist/cleanroom ./cmd/cleanroom
-go build -o dist/cleanroom-guest-agent ./cmd/cleanroom-guest-agent
-"""
+run = "scripts/build-go.sh"
 
 [tasks."build:darwin"]
 description = "Build macOS darwin-vz helper into dist/"
@@ -39,15 +34,7 @@ run = "true"
 
 [tasks."install:go"]
 description = "Install Go binaries into GOBIN (or GOPATH/bin)"
-run = """
-VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo dev)
-BIN_DIR="$(go env GOBIN)"
-if [ -z "$BIN_DIR" ]; then BIN_DIR="$(go env GOPATH)/bin"; fi
-HOST_ARCH="$(go env GOARCH)"
-mkdir -p "$BIN_DIR"
-go install -ldflags "-X main.version=$VERSION" ./cmd/cleanroom ./cmd/cleanroom-guest-agent
-GOOS=linux GOARCH="$HOST_ARCH" CGO_ENABLED=0 go build -trimpath -o "$BIN_DIR/cleanroom-guest-agent-linux-$HOST_ARCH" ./cmd/cleanroom-guest-agent
-"""
+run = "scripts/install-go.sh"
 
 [tasks."install:darwin"]
 description = "Install macOS darwin-vz helper into GOBIN (or GOPATH/bin)"
@@ -75,15 +62,4 @@ run = "true"
 [tasks.release]
 description = "Tag the next version and push to trigger a release"
 depends = ["check"]
-run = """
-NEXT=$(svu next)
-CURRENT=$(svu current)
-if [ "$NEXT" = "$CURRENT" ]; then
-  echo "No version bump detected (current: $CURRENT). Use conventional commits (feat:, fix:, etc.)."
-  exit 1
-fi
-echo "Releasing $CURRENT -> $NEXT"
-git tag "$NEXT"
-git push origin "$NEXT"
-echo "Tagged and pushed $NEXT — release workflow will run on GitHub."
-"""
+run = "scripts/release.sh"

--- a/cmd/cleanroom/main.go
+++ b/cmd/cleanroom/main.go
@@ -7,8 +7,10 @@ import (
 	"github.com/buildkite/cleanroom/internal/cli"
 )
 
+var version = "dev"
+
 func main() {
-	if err := cli.Run(os.Args[1:]); err != nil {
+	if err := cli.Run(os.Args[1:], version); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(cli.ExitCode(err))
 	}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -71,6 +71,16 @@ type CLI struct {
 	Doctor  DoctorCommand  `cmd:"" help:"Run environment and backend diagnostics"`
 	Status  StatusCommand  `cmd:"" help:"Inspect run artifacts"`
 	Sandbox SandboxCommand `cmd:"" help:"Manage sandboxes"`
+	Version VersionCommand `cmd:"" help:"Print version information"`
+}
+
+type VersionCommand struct {
+	version string
+}
+
+func (c *VersionCommand) Run() error {
+	fmt.Println("cleanroom version " + c.version)
+	return nil
 }
 
 type ImageCommand struct {
@@ -272,7 +282,7 @@ var (
 	}
 )
 
-func Run(args []string) error {
+func Run(args []string, version string) error {
 	cfg, cfgPath, err := runtimeconfig.Load()
 	if err != nil {
 		return err
@@ -290,10 +300,11 @@ func Run(args []string) error {
 	}
 
 	cli := CLI{}
+	cli.Version.version = version
 	parser, err := kong.New(
 		&cli,
 		kong.Name("cleanroom"),
-		kong.Description("Cleanroom CLI (MVP)"),
+		kong.Description("Cleanroom CLI"),
 	)
 	if err != nil {
 		return err

--- a/scripts/build-go.sh
+++ b/scripts/build-go.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo dev)
+mkdir -p dist
+go build -ldflags "-X main.version=$VERSION" -o dist/cleanroom ./cmd/cleanroom
+go build -o dist/cleanroom-guest-agent ./cmd/cleanroom-guest-agent

--- a/scripts/install-go.sh
+++ b/scripts/install-go.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo dev)
+BIN_DIR="$(go env GOBIN)"
+if [ -z "$BIN_DIR" ]; then BIN_DIR="$(go env GOPATH)/bin"; fi
+HOST_ARCH="$(go env GOARCH)"
+mkdir -p "$BIN_DIR"
+go install -ldflags "-X main.version=$VERSION" ./cmd/cleanroom ./cmd/cleanroom-guest-agent
+GOOS=linux GOARCH="$HOST_ARCH" CGO_ENABLED=0 go build -trimpath -o "$BIN_DIR/cleanroom-guest-agent-linux-$HOST_ARCH" ./cmd/cleanroom-guest-agent

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NEXT=$(svu next)
+CURRENT=$(svu current)
+if [ "$NEXT" = "$CURRENT" ]; then
+  echo "No version bump detected (current: $CURRENT). Use conventional commits (feat:, fix:, etc.)."
+  exit 1
+fi
+echo "Releasing $CURRENT -> $NEXT"
+git tag "$NEXT"
+git push origin "$NEXT"
+echo "Tagged and pushed $NEXT — release workflow will run on GitHub."


### PR DESCRIPTION
Adds a versioned release pipeline modelled on [lox/slack-cli](https://github.com/lox/slack-cli):

## What's included

- **Version embedding** — `var version = "dev"` in `main.go`, injected via `-X main.version` ldflags at build time
- **`cleanroom version` subcommand** — prints the embedded version
- **`.goreleaser.yml`** — builds `cleanroom` (darwin+linux, amd64+arm64) and `cleanroom-guest-agent` (linux-only) with stripped binaries, tar.gz archives, checksums, and conventional-commit changelog
- **`.github/workflows/release.yml`** — triggered on `v*` tag push, runs `goreleaser release --clean`
- **mise tasks** — added `svu` tool, `check` task (build+test+lint), and `release` task that computes the next semver from conventional commits, tags, and pushes

## How to release

```bash
mise run release
```

This runs checks, uses `svu` to determine the next version from conventional commits (`feat:` → minor, `fix:` → patch), tags it, and pushes to trigger the GitHub Actions release workflow.