### PR TITLE
feat: expose public Go client API with ergonomic helpers

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -21,7 +21,7 @@ type Client struct {
 }
 
 type ensureKeyLock struct {
-	mu   sync.Mutex
+	gate chan struct{}
 	refs int
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -1,0 +1,156 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"connectrpc.com/connect"
+	"github.com/buildkite/cleanroom/internal/controlclient"
+	"github.com/buildkite/cleanroom/internal/endpoint"
+	"github.com/buildkite/cleanroom/internal/tlsconfig"
+)
+
+// Client is the public Go client for the cleanroom control-plane API.
+type Client struct {
+	inner *controlclient.Client
+
+	mu           sync.Mutex
+	sandboxByKey map[string]string
+}
+
+// TLSOptions configures optional TLS material for HTTPS connections.
+type TLSOptions struct {
+	CertPath string
+	KeyPath  string
+	CAPath   string
+}
+
+// Option configures the cleanroom client.
+type Option func(*options)
+
+type options struct {
+	tls tlsconfig.Options
+}
+
+// WithTLS configures TLS options for HTTPS endpoints.
+func WithTLS(opts TLSOptions) Option {
+	return func(o *options) {
+		o.tls = tlsconfig.Options{
+			CertPath: opts.CertPath,
+			KeyPath:  opts.KeyPath,
+			CAPath:   opts.CAPath,
+		}
+	}
+}
+
+// New creates a client for the provided endpoint.
+//
+// Supported endpoint formats match the CLI:
+// - unix:///path/to/cleanroom.sock
+// - absolute unix socket path
+// - http://host:port
+// - https://host:port
+//
+// If host is empty, CLEANROOM_HOST is used, then the default unix socket path.
+func New(host string, opts ...Option) (*Client, error) {
+	var o options
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&o)
+		}
+	}
+
+	ep, err := endpoint.Resolve(host)
+	if err != nil {
+		return nil, err
+	}
+	if ep.Scheme == "tssvc" {
+		return nil, errors.New("tssvc:// endpoints are listen-only; use https://<service>.<your-tailnet>.ts.net")
+	}
+	inner, err := controlclient.New(ep, controlclient.WithTLS(o.tls))
+	if err != nil {
+		return nil, err
+	}
+	return &Client{
+		inner:        inner,
+		sandboxByKey: map[string]string{},
+	}, nil
+}
+
+func (c *Client) CreateSandbox(ctx context.Context, req *CreateSandboxRequest) (*CreateSandboxResponse, error) {
+	if c == nil || c.inner == nil {
+		return nil, errors.New("nil client")
+	}
+	return c.inner.CreateSandbox(ctx, req)
+}
+
+func (c *Client) GetSandbox(ctx context.Context, req *GetSandboxRequest) (*GetSandboxResponse, error) {
+	if c == nil || c.inner == nil {
+		return nil, errors.New("nil client")
+	}
+	return c.inner.GetSandbox(ctx, req)
+}
+
+func (c *Client) ListSandboxes(ctx context.Context, req *ListSandboxesRequest) (*ListSandboxesResponse, error) {
+	if c == nil || c.inner == nil {
+		return nil, errors.New("nil client")
+	}
+	return c.inner.ListSandboxes(ctx, req)
+}
+
+func (c *Client) DownloadSandboxFile(ctx context.Context, req *DownloadSandboxFileRequest) (*DownloadSandboxFileResponse, error) {
+	if c == nil || c.inner == nil {
+		return nil, errors.New("nil client")
+	}
+	return c.inner.DownloadSandboxFile(ctx, req)
+}
+
+func (c *Client) TerminateSandbox(ctx context.Context, req *TerminateSandboxRequest) (*TerminateSandboxResponse, error) {
+	if c == nil || c.inner == nil {
+		return nil, errors.New("nil client")
+	}
+	return c.inner.TerminateSandbox(ctx, req)
+}
+
+func (c *Client) StreamSandboxEvents(ctx context.Context, req *StreamSandboxEventsRequest) (*connect.ServerStreamForClient[SandboxEvent], error) {
+	if c == nil || c.inner == nil {
+		return nil, errors.New("nil client")
+	}
+	return c.inner.StreamSandboxEvents(ctx, req)
+}
+
+func (c *Client) CreateExecution(ctx context.Context, req *CreateExecutionRequest) (*CreateExecutionResponse, error) {
+	if c == nil || c.inner == nil {
+		return nil, errors.New("nil client")
+	}
+	return c.inner.CreateExecution(ctx, req)
+}
+
+func (c *Client) GetExecution(ctx context.Context, req *GetExecutionRequest) (*GetExecutionResponse, error) {
+	if c == nil || c.inner == nil {
+		return nil, errors.New("nil client")
+	}
+	return c.inner.GetExecution(ctx, req)
+}
+
+func (c *Client) CancelExecution(ctx context.Context, req *CancelExecutionRequest) (*CancelExecutionResponse, error) {
+	if c == nil || c.inner == nil {
+		return nil, errors.New("nil client")
+	}
+	return c.inner.CancelExecution(ctx, req)
+}
+
+func (c *Client) StreamExecution(ctx context.Context, req *StreamExecutionRequest) (*connect.ServerStreamForClient[ExecutionStreamEvent], error) {
+	if c == nil || c.inner == nil {
+		return nil, errors.New("nil client")
+	}
+	return c.inner.StreamExecution(ctx, req)
+}
+
+func (c *Client) AttachExecution(ctx context.Context) *connect.BidiStreamForClient[ExecutionAttachFrame, ExecutionAttachFrame] {
+	if c == nil || c.inner == nil {
+		return nil
+	}
+	return c.inner.AttachExecution(ctx)
+}

--- a/client/client.go
+++ b/client/client.go
@@ -17,6 +17,12 @@ type Client struct {
 
 	mu           sync.Mutex
 	sandboxByKey map[string]string
+	ensureLocks  map[string]*ensureKeyLock
+}
+
+type ensureKeyLock struct {
+	mu   sync.Mutex
+	refs int
 }
 
 // TLSOptions configures optional TLS material for HTTPS connections.
@@ -75,6 +81,7 @@ func New(host string, opts ...Option) (*Client, error) {
 	return &Client{
 		inner:        inner,
 		sandboxByKey: map[string]string{},
+		ensureLocks:  map[string]*ensureKeyLock{},
 	}, nil
 }
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,0 +1,201 @@
+package client
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/controlserver"
+	"github.com/buildkite/cleanroom/internal/controlservice"
+	"github.com/buildkite/cleanroom/internal/runtimeconfig"
+)
+
+type integrationAdapter struct{}
+
+func (integrationAdapter) Name() string { return "firecracker" }
+
+func (integrationAdapter) Run(_ context.Context, req backend.RunRequest) (*backend.RunResult, error) {
+	return &backend.RunResult{
+		RunID:    req.RunID,
+		ExitCode: 0,
+		Stdout:   "hello from cleanroom\n",
+		Message:  "ok",
+	}, nil
+}
+
+func (a integrationAdapter) RunStream(ctx context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+	result, err := a.Run(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if stream.OnStdout != nil {
+		stream.OnStdout([]byte(result.Stdout))
+	}
+	return result, nil
+}
+
+func startIntegrationServer(t *testing.T) string {
+	t.Helper()
+
+	svc := &controlservice.Service{
+		Config: runtimeconfig.Config{DefaultBackend: "firecracker"},
+		Backends: map[string]backend.Adapter{
+			"firecracker": integrationAdapter{},
+		},
+	}
+
+	httpServer := httptest.NewServer(controlserver.New(svc, nil).Handler())
+	t.Cleanup(httpServer.Close)
+	return httpServer.URL
+}
+
+func testPolicy() *Policy {
+	return &Policy{
+		Version:        1,
+		ImageRef:       "ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		ImageDigest:    "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		NetworkDefault: "deny",
+	}
+}
+
+func TestClientLifecycle(t *testing.T) {
+	host := startIntegrationServer(t)
+
+	client, err := New(host)
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	createSandboxResp, err := client.CreateSandbox(ctx, &CreateSandboxRequest{
+		Policy:  testPolicy(),
+		Backend: "firecracker",
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	if createSandboxResp.GetSandbox().GetStatus() != SandboxStatus_SANDBOX_STATUS_READY {
+		t.Fatalf("unexpected sandbox status: %v", createSandboxResp.GetSandbox().GetStatus())
+	}
+
+	sandboxID := createSandboxResp.GetSandbox().GetSandboxId()
+	if sandboxID == "" {
+		t.Fatal("expected sandbox_id")
+	}
+
+	getSandboxResp, err := client.GetSandbox(ctx, &GetSandboxRequest{SandboxId: sandboxID})
+	if err != nil {
+		t.Fatalf("GetSandbox returned error: %v", err)
+	}
+	if getSandboxResp.GetSandbox().GetSandboxId() != sandboxID {
+		t.Fatalf("GetSandbox sandbox id mismatch: got %q want %q", getSandboxResp.GetSandbox().GetSandboxId(), sandboxID)
+	}
+
+	listResp, err := client.ListSandboxes(ctx, &ListSandboxesRequest{})
+	if err != nil {
+		t.Fatalf("ListSandboxes returned error: %v", err)
+	}
+	if len(listResp.GetSandboxes()) == 0 {
+		t.Fatal("expected at least one sandbox")
+	}
+
+	createExecutionResp, err := client.CreateExecution(ctx, &CreateExecutionRequest{
+		SandboxId: sandboxID,
+		Command:   []string{"echo", "hello"},
+	})
+	if err != nil {
+		t.Fatalf("CreateExecution returned error: %v", err)
+	}
+	executionID := createExecutionResp.GetExecution().GetExecutionId()
+	if executionID == "" {
+		t.Fatal("expected execution_id")
+	}
+
+	stream, err := client.StreamExecution(ctx, &StreamExecutionRequest{
+		SandboxId:   sandboxID,
+		ExecutionId: executionID,
+		Follow:      true,
+	})
+	if err != nil {
+		t.Fatalf("StreamExecution returned error: %v", err)
+	}
+
+	sawStdout := false
+	sawExit := false
+	for stream.Receive() {
+		event := stream.Msg()
+		if strings.Contains(string(event.GetStdout()), "hello from cleanroom") {
+			sawStdout = true
+		}
+		if exit := event.GetExit(); exit != nil {
+			sawExit = true
+			if exit.GetStatus() != ExecutionStatus_EXECUTION_STATUS_SUCCEEDED {
+				t.Fatalf("unexpected exit status: %v", exit.GetStatus())
+			}
+		}
+	}
+	if err := stream.Err(); err != nil {
+		t.Fatalf("StreamExecution stream error: %v", err)
+	}
+	if !sawStdout {
+		t.Fatal("expected stdout event")
+	}
+	if !sawExit {
+		t.Fatal("expected exit event")
+	}
+
+	getExecutionResp, err := client.GetExecution(ctx, &GetExecutionRequest{
+		SandboxId:   sandboxID,
+		ExecutionId: executionID,
+	})
+	if err != nil {
+		t.Fatalf("GetExecution returned error: %v", err)
+	}
+	if got := getExecutionResp.GetExecution().GetStatus(); got != ExecutionStatus_EXECUTION_STATUS_SUCCEEDED {
+		t.Fatalf("unexpected execution status: %v", got)
+	}
+
+	terminateResp, err := client.TerminateSandbox(ctx, &TerminateSandboxRequest{SandboxId: sandboxID})
+	if err != nil {
+		t.Fatalf("TerminateSandbox returned error: %v", err)
+	}
+	if !terminateResp.GetTerminated() {
+		t.Fatal("expected terminated=true")
+	}
+}
+
+func TestNewRejectsServerOnlyEndpoint(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+		want string
+	}{
+		{
+			name: "tsnet",
+			host: "tsnet://cleanroom:7777",
+			want: "only valid for server",
+		},
+		{
+			name: "tssvc",
+			host: "tssvc://cleanroom",
+			want: "listen-only",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := New(tc.host)
+			if err == nil {
+				t.Fatalf("expected error for endpoint %q", tc.host)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/client/ergonomics.go
+++ b/client/ergonomics.go
@@ -145,6 +145,9 @@ func PolicyFromAllowlist(imageRef, imageDigest string, entries ...HostPort) *Pol
 		}
 		ports := make([]int32, len(entry.Ports))
 		copy(ports, entry.Ports)
+		if len(ports) == 0 {
+			continue
+		}
 		policy.Allow = append(policy.Allow, &PolicyAllowRule{Host: host, Ports: ports})
 	}
 	return policy
@@ -405,7 +408,7 @@ func (c *Client) ExecAndWait(ctx context.Context, sandboxID string, command []st
 	}
 
 	if status == ExecutionStatus_EXECUTION_STATUS_UNSPECIFIED {
-		getResp, err := c.GetExecution(ctx, &GetExecutionRequest{SandboxId: sandboxID, ExecutionId: executionID})
+		getResp, err := c.GetExecution(waitCtx, &GetExecutionRequest{SandboxId: sandboxID, ExecutionId: executionID})
 		if err != nil {
 			return nil, err
 		}

--- a/client/ergonomics.go
+++ b/client/ergonomics.go
@@ -1,0 +1,396 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"connectrpc.com/connect"
+)
+
+// ErrorCode is a stable classifier for cleanroom API errors.
+type ErrorCode string
+
+const (
+	ErrorCodeUnknown                   ErrorCode = "unknown"
+	ErrorCodeCanceled                  ErrorCode = "canceled"
+	ErrorCodeDeadlineExceeded          ErrorCode = "deadline_exceeded"
+	ErrorCodeInvalidArgument           ErrorCode = "invalid_argument"
+	ErrorCodeNotFound                  ErrorCode = "not_found"
+	ErrorCodeUnavailable               ErrorCode = "unavailable"
+	ErrorCodeInternal                  ErrorCode = "internal"
+	ErrorCodePolicyInvalid             ErrorCode = "policy_invalid"
+	ErrorCodePolicyConflict            ErrorCode = "policy_conflict"
+	ErrorCodeBackendUnavailable        ErrorCode = "backend_unavailable"
+	ErrorCodeBackendCapabilityMismatch ErrorCode = "backend_capability_mismatch"
+	ErrorCodeHostNotAllowed            ErrorCode = "host_not_allowed"
+	ErrorCodeRegistryNotAllowed        ErrorCode = "registry_not_allowed"
+	ErrorCodeLockfileViolation         ErrorCode = "lockfile_violation"
+	ErrorCodeSecretScopeViolation      ErrorCode = "secret_scope_violation"
+	ErrorCodeRuntimeLaunchFailed       ErrorCode = "runtime_launch_failed"
+)
+
+// ErrCode classifies API errors into a stable code.
+//
+// When the server returns a semantic app-level code in the error message,
+// that code is preferred. Otherwise this falls back to transport-level
+// Connect codes.
+func ErrCode(err error) ErrorCode {
+	if err == nil {
+		return ErrorCodeUnknown
+	}
+
+	message := strings.ToLower(err.Error())
+	if appCode := classifyAppErrorCode(message); appCode != ErrorCodeUnknown {
+		return appCode
+	}
+
+	var connectErr *connect.Error
+	if errors.As(err, &connectErr) {
+		switch connectErr.Code() {
+		case connect.CodeCanceled:
+			return ErrorCodeCanceled
+		case connect.CodeDeadlineExceeded:
+			return ErrorCodeDeadlineExceeded
+		case connect.CodeInvalidArgument:
+			return ErrorCodeInvalidArgument
+		case connect.CodeNotFound:
+			return ErrorCodeNotFound
+		case connect.CodeUnavailable:
+			return ErrorCodeUnavailable
+		default:
+			return ErrorCodeInternal
+		}
+	}
+	if errors.Is(err, context.Canceled) {
+		return ErrorCodeCanceled
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return ErrorCodeDeadlineExceeded
+	}
+	return ErrorCodeUnknown
+}
+
+func classifyAppErrorCode(message string) ErrorCode {
+	switch {
+	case strings.Contains(message, string(ErrorCodePolicyInvalid)):
+		return ErrorCodePolicyInvalid
+	case strings.Contains(message, string(ErrorCodePolicyConflict)):
+		return ErrorCodePolicyConflict
+	case strings.Contains(message, string(ErrorCodeBackendUnavailable)):
+		return ErrorCodeBackendUnavailable
+	case strings.Contains(message, string(ErrorCodeBackendCapabilityMismatch)):
+		return ErrorCodeBackendCapabilityMismatch
+	case strings.Contains(message, string(ErrorCodeHostNotAllowed)):
+		return ErrorCodeHostNotAllowed
+	case strings.Contains(message, string(ErrorCodeRegistryNotAllowed)):
+		return ErrorCodeRegistryNotAllowed
+	case strings.Contains(message, string(ErrorCodeLockfileViolation)):
+		return ErrorCodeLockfileViolation
+	case strings.Contains(message, string(ErrorCodeSecretScopeViolation)):
+		return ErrorCodeSecretScopeViolation
+	case strings.Contains(message, string(ErrorCodeRuntimeLaunchFailed)):
+		return ErrorCodeRuntimeLaunchFailed
+	default:
+		return ErrorCodeUnknown
+	}
+}
+
+// Must returns the client if err is nil; otherwise it panics.
+func Must(c *Client, err error) *Client {
+	if err != nil {
+		panic(err)
+	}
+	return c
+}
+
+// NewFromEnv builds a client from CLEANROOM_HOST (or default endpoint when unset).
+func NewFromEnv(opts ...Option) (*Client, error) {
+	return New("", opts...)
+}
+
+// HostPort models a policy allowlist destination.
+type HostPort struct {
+	Host  string
+	Ports []int32
+}
+
+// Allow builds an allowlist destination entry for PolicyFromAllowlist.
+func Allow(host string, ports ...int32) HostPort {
+	trimmedHost := strings.TrimSpace(host)
+	copiedPorts := make([]int32, 0, len(ports))
+	for _, port := range ports {
+		copiedPorts = append(copiedPorts, port)
+	}
+	return HostPort{Host: trimmedHost, Ports: copiedPorts}
+}
+
+// PolicyFromAllowlist creates a minimal deny-by-default policy with explicit allows.
+func PolicyFromAllowlist(imageRef, imageDigest string, entries ...HostPort) *Policy {
+	policy := &Policy{
+		Version:        1,
+		ImageRef:       strings.TrimSpace(imageRef),
+		ImageDigest:    strings.TrimSpace(imageDigest),
+		NetworkDefault: "deny",
+		Allow:          make([]*PolicyAllowRule, 0, len(entries)),
+	}
+	for _, entry := range entries {
+		host := strings.TrimSpace(entry.Host)
+		if host == "" {
+			continue
+		}
+		ports := make([]int32, len(entry.Ports))
+		copy(ports, entry.Ports)
+		policy.Allow = append(policy.Allow, &PolicyAllowRule{Host: host, Ports: ports})
+	}
+	return policy
+}
+
+// EnsureSandboxOptions controls EnsureSandbox behavior.
+type EnsureSandboxOptions struct {
+	Backend   string
+	Policy    *Policy
+	Options   *SandboxOptions
+	SandboxID string
+}
+
+// SandboxHandle is a concise reusable sandbox descriptor.
+type SandboxHandle struct {
+	ID      string
+	Backend string
+	Status  SandboxStatus
+	Created bool
+}
+
+// EnsureSandbox returns a reusable sandbox for a key.
+//
+// It reuses a previously tracked sandbox when present and still available.
+// If opts.SandboxID is set, that sandbox is used directly and associated to key.
+func (c *Client) EnsureSandbox(ctx context.Context, key string, opts EnsureSandboxOptions) (*SandboxHandle, error) {
+	if c == nil || c.inner == nil {
+		return nil, errors.New("nil client")
+	}
+
+	trimmedKey := strings.TrimSpace(key)
+	if trimmedKey == "" {
+		return nil, errors.New("missing key")
+	}
+
+	if explicitID := strings.TrimSpace(opts.SandboxID); explicitID != "" {
+		handle, err := c.fetchSandboxHandle(ctx, explicitID, false)
+		if err != nil {
+			return nil, err
+		}
+		c.recordSandboxKey(trimmedKey, explicitID)
+		return handle, nil
+	}
+
+	if cachedID, ok := c.lookupSandboxKey(trimmedKey); ok {
+		handle, err := c.fetchSandboxHandle(ctx, cachedID, false)
+		if err == nil && !isTerminalSandboxStatus(handle.Status) {
+			return handle, nil
+		}
+		if ErrCode(err) != ErrorCodeNotFound {
+			return nil, err
+		}
+		c.clearSandboxKey(trimmedKey)
+	}
+
+	createReq := &CreateSandboxRequest{
+		Backend: strings.TrimSpace(opts.Backend),
+		Options: opts.Options,
+		Policy:  opts.Policy,
+	}
+	if createReq.Policy == nil {
+		return nil, errors.New("missing policy")
+	}
+
+	resp, err := c.CreateSandbox(ctx, createReq)
+	if err != nil {
+		return nil, err
+	}
+	sandbox := resp.GetSandbox()
+	if sandbox == nil || strings.TrimSpace(sandbox.GetSandboxId()) == "" {
+		return nil, errors.New("create sandbox returned empty sandbox_id")
+	}
+	c.recordSandboxKey(trimmedKey, sandbox.GetSandboxId())
+	return &SandboxHandle{
+		ID:      sandbox.GetSandboxId(),
+		Backend: sandbox.GetBackend(),
+		Status:  sandbox.GetStatus(),
+		Created: true,
+	}, nil
+}
+
+func isTerminalSandboxStatus(status SandboxStatus) bool {
+	return status == SandboxStatus_SANDBOX_STATUS_STOPPED || status == SandboxStatus_SANDBOX_STATUS_FAILED
+}
+
+func (c *Client) fetchSandboxHandle(ctx context.Context, sandboxID string, created bool) (*SandboxHandle, error) {
+	resp, err := c.GetSandbox(ctx, &GetSandboxRequest{SandboxId: sandboxID})
+	if err != nil {
+		return nil, err
+	}
+	sandbox := resp.GetSandbox()
+	if sandbox == nil {
+		return nil, fmt.Errorf("sandbox %q not found", sandboxID)
+	}
+	return &SandboxHandle{
+		ID:      sandbox.GetSandboxId(),
+		Backend: sandbox.GetBackend(),
+		Status:  sandbox.GetStatus(),
+		Created: created,
+	}, nil
+}
+
+func (c *Client) lookupSandboxKey(key string) (string, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	id, ok := c.sandboxByKey[key]
+	return id, ok
+}
+
+func (c *Client) recordSandboxKey(key, sandboxID string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.sandboxByKey[key] = sandboxID
+}
+
+func (c *Client) clearSandboxKey(key string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.sandboxByKey, key)
+}
+
+// ExecOptions controls how ExecAndWait streams command output.
+type ExecOptions struct {
+	Stdout  io.Writer
+	Stderr  io.Writer
+	TTY     bool
+	Timeout time.Duration
+}
+
+// ExecResult is the final execution outcome from ExecAndWait.
+type ExecResult struct {
+	SandboxID   string
+	ExecutionID string
+	Status      ExecutionStatus
+	ExitCode    int32
+	Message     string
+	Stdout      string
+	Stderr      string
+}
+
+// ExecAndWait creates an execution, streams output, and waits for completion.
+func (c *Client) ExecAndWait(ctx context.Context, sandboxID string, command []string, opts ExecOptions) (*ExecResult, error) {
+	if c == nil || c.inner == nil {
+		return nil, errors.New("nil client")
+	}
+	sandboxID = strings.TrimSpace(sandboxID)
+	if sandboxID == "" {
+		return nil, errors.New("missing sandbox_id")
+	}
+	if len(command) == 0 {
+		return nil, errors.New("missing command")
+	}
+
+	execCtx := ctx
+	cancel := func() {}
+	if opts.Timeout > 0 {
+		execCtx, cancel = context.WithTimeout(ctx, opts.Timeout)
+	}
+	defer cancel()
+
+	createReq := &CreateExecutionRequest{
+		SandboxId: sandboxID,
+		Command:   append([]string(nil), command...),
+	}
+	if opts.TTY {
+		createReq.Options = &ExecutionOptions{Tty: true}
+	}
+
+	created, err := c.CreateExecution(execCtx, createReq)
+	if err != nil {
+		return nil, err
+	}
+	executionID := strings.TrimSpace(created.GetExecution().GetExecutionId())
+	if executionID == "" {
+		return nil, errors.New("create execution returned empty execution_id")
+	}
+
+	stream, err := c.StreamExecution(execCtx, &StreamExecutionRequest{
+		SandboxId:   sandboxID,
+		ExecutionId: executionID,
+		Follow:      true,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		stdoutBuf bytes.Buffer
+		stderrBuf bytes.Buffer
+		status    = ExecutionStatus_EXECUTION_STATUS_UNSPECIFIED
+		exitCode  int32
+		message   string
+	)
+
+	for stream.Receive() {
+		event := stream.Msg()
+		if event == nil {
+			continue
+		}
+		status = event.GetStatus()
+		if chunk := event.GetStdout(); len(chunk) > 0 {
+			_, _ = stdoutBuf.Write(chunk)
+			if opts.Stdout != nil {
+				_, _ = opts.Stdout.Write(chunk)
+			}
+		}
+		if chunk := event.GetStderr(); len(chunk) > 0 {
+			_, _ = stderrBuf.Write(chunk)
+			if opts.Stderr != nil {
+				_, _ = opts.Stderr.Write(chunk)
+			}
+		}
+		if exit := event.GetExit(); exit != nil {
+			exitCode = exit.GetExitCode()
+			if exit.GetStatus() != ExecutionStatus_EXECUTION_STATUS_UNSPECIFIED {
+				status = exit.GetStatus()
+			}
+			message = exit.GetMessage()
+		}
+		if msg := strings.TrimSpace(event.GetMessage()); msg != "" {
+			message = msg
+		}
+	}
+	if streamErr := stream.Err(); streamErr != nil {
+		return nil, streamErr
+	}
+
+	if status == ExecutionStatus_EXECUTION_STATUS_UNSPECIFIED {
+		getResp, err := c.GetExecution(execCtx, &GetExecutionRequest{SandboxId: sandboxID, ExecutionId: executionID})
+		if err != nil {
+			return nil, err
+		}
+		execution := getResp.GetExecution()
+		if execution != nil {
+			status = execution.GetStatus()
+			exitCode = execution.GetExitCode()
+		}
+	}
+
+	return &ExecResult{
+		SandboxID:   sandboxID,
+		ExecutionID: executionID,
+		Status:      status,
+		ExitCode:    exitCode,
+		Message:     message,
+		Stdout:      stdoutBuf.String(),
+		Stderr:      stderrBuf.String(),
+	}, nil
+}

--- a/client/ergonomics_test.go
+++ b/client/ergonomics_test.go
@@ -1,0 +1,171 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+)
+
+func TestNewFromEnvUsesCLEANROOMHOST(t *testing.T) {
+	host := startIntegrationServer(t)
+	t.Setenv("CLEANROOM_HOST", host)
+
+	c, err := NewFromEnv()
+	if err != nil {
+		t.Fatalf("NewFromEnv returned error: %v", err)
+	}
+
+	resp, err := c.ListSandboxes(context.Background(), &ListSandboxesRequest{})
+	if err != nil {
+		t.Fatalf("ListSandboxes returned error: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("expected response")
+	}
+}
+
+func TestMustPanicsOnError(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic")
+		}
+	}()
+
+	_ = Must((*Client)(nil), errors.New("boom"))
+}
+
+func TestPolicyFromAllowlist(t *testing.T) {
+	policy := PolicyFromAllowlist(
+		"ghcr.io/buildkite/cleanroom-base/alpine@sha256:abc",
+		"sha256:abc",
+		Allow("api.github.com", 443),
+		Allow("registry.npmjs.org", 443, 80),
+	)
+
+	if policy.GetVersion() != 1 {
+		t.Fatalf("unexpected version: got %d", policy.GetVersion())
+	}
+	if policy.GetNetworkDefault() != "deny" {
+		t.Fatalf("unexpected network default: got %q", policy.GetNetworkDefault())
+	}
+	if len(policy.GetAllow()) != 2 {
+		t.Fatalf("unexpected allow length: got %d", len(policy.GetAllow()))
+	}
+	if policy.GetAllow()[0].GetHost() != "api.github.com" {
+		t.Fatalf("unexpected first allow host: %q", policy.GetAllow()[0].GetHost())
+	}
+}
+
+func TestEnsureSandboxReusesKey(t *testing.T) {
+	host := startIntegrationServer(t)
+	c, err := New(host)
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	opts := EnsureSandboxOptions{
+		Backend: "firecracker",
+		Policy:  testPolicy(),
+	}
+
+	first, err := c.EnsureSandbox(ctx, "thread:abc", opts)
+	if err != nil {
+		t.Fatalf("first EnsureSandbox returned error: %v", err)
+	}
+	if !first.Created {
+		t.Fatal("expected first call to create sandbox")
+	}
+
+	second, err := c.EnsureSandbox(ctx, "thread:abc", opts)
+	if err != nil {
+		t.Fatalf("second EnsureSandbox returned error: %v", err)
+	}
+	if second.Created {
+		t.Fatal("expected second call to reuse sandbox")
+	}
+	if first.ID != second.ID {
+		t.Fatalf("expected same sandbox id, got %q and %q", first.ID, second.ID)
+	}
+}
+
+func TestEnsureSandboxAcceptsExplicitSandboxID(t *testing.T) {
+	host := startIntegrationServer(t)
+	c, err := New(host)
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	ctx := context.Background()
+	created, err := c.CreateSandbox(ctx, &CreateSandboxRequest{Backend: "firecracker", Policy: testPolicy()})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	id := created.GetSandbox().GetSandboxId()
+
+	ensured, err := c.EnsureSandbox(ctx, "thread:explicit", EnsureSandboxOptions{SandboxID: id})
+	if err != nil {
+		t.Fatalf("EnsureSandbox returned error: %v", err)
+	}
+	if ensured.ID != id {
+		t.Fatalf("sandbox id mismatch: got %q want %q", ensured.ID, id)
+	}
+	if ensured.Created {
+		t.Fatal("expected ensured sandbox to be marked reused")
+	}
+}
+
+func TestExecAndWait(t *testing.T) {
+	host := startIntegrationServer(t)
+	c, err := New(host)
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	sb, err := c.EnsureSandbox(ctx, "thread:exec", EnsureSandboxOptions{
+		Backend: "firecracker",
+		Policy:  testPolicy(),
+	})
+	if err != nil {
+		t.Fatalf("EnsureSandbox returned error: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	result, err := c.ExecAndWait(ctx, sb.ID, []string{"echo", "hello"}, ExecOptions{Stdout: &stdout})
+	if err != nil {
+		t.Fatalf("ExecAndWait returned error: %v", err)
+	}
+	if result.Status != ExecutionStatus_EXECUTION_STATUS_SUCCEEDED {
+		t.Fatalf("unexpected status: %v", result.Status)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("unexpected exit code: %d", result.ExitCode)
+	}
+	if !strings.Contains(result.Stdout, "hello from cleanroom") {
+		t.Fatalf("expected stdout in result, got %q", result.Stdout)
+	}
+	if !strings.Contains(stdout.String(), "hello from cleanroom") {
+		t.Fatalf("expected stdout writer to receive output, got %q", stdout.String())
+	}
+}
+
+func TestErrCode(t *testing.T) {
+	if got := ErrCode(connect.NewError(connect.CodeNotFound, errors.New("unknown sandbox \"x\""))); got != ErrorCodeNotFound {
+		t.Fatalf("unexpected code for not found: %q", got)
+	}
+
+	if got := ErrCode(connect.NewError(connect.CodeInternal, errors.New("backend_capability_mismatch: denied"))); got != ErrorCodeBackendCapabilityMismatch {
+		t.Fatalf("unexpected code for backend mismatch: %q", got)
+	}
+}

--- a/client/types.go
+++ b/client/types.go
@@ -1,0 +1,63 @@
+package client
+
+import cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+
+type Sandbox = cleanroomv1.Sandbox
+
+type SandboxStatus = cleanroomv1.SandboxStatus
+
+const (
+	SandboxStatus_SANDBOX_STATUS_UNSPECIFIED  = cleanroomv1.SandboxStatus_SANDBOX_STATUS_UNSPECIFIED
+	SandboxStatus_SANDBOX_STATUS_PROVISIONING = cleanroomv1.SandboxStatus_SANDBOX_STATUS_PROVISIONING
+	SandboxStatus_SANDBOX_STATUS_READY        = cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY
+	SandboxStatus_SANDBOX_STATUS_STOPPING     = cleanroomv1.SandboxStatus_SANDBOX_STATUS_STOPPING
+	SandboxStatus_SANDBOX_STATUS_STOPPED      = cleanroomv1.SandboxStatus_SANDBOX_STATUS_STOPPED
+	SandboxStatus_SANDBOX_STATUS_FAILED       = cleanroomv1.SandboxStatus_SANDBOX_STATUS_FAILED
+)
+
+type PolicyAllowRule = cleanroomv1.PolicyAllowRule
+type Policy = cleanroomv1.Policy
+type SandboxOptions = cleanroomv1.SandboxOptions
+type CreateSandboxRequest = cleanroomv1.CreateSandboxRequest
+type CreateSandboxResponse = cleanroomv1.CreateSandboxResponse
+type GetSandboxRequest = cleanroomv1.GetSandboxRequest
+type GetSandboxResponse = cleanroomv1.GetSandboxResponse
+type ListSandboxesRequest = cleanroomv1.ListSandboxesRequest
+type ListSandboxesResponse = cleanroomv1.ListSandboxesResponse
+type DownloadSandboxFileRequest = cleanroomv1.DownloadSandboxFileRequest
+type DownloadSandboxFileResponse = cleanroomv1.DownloadSandboxFileResponse
+type TerminateSandboxRequest = cleanroomv1.TerminateSandboxRequest
+type TerminateSandboxResponse = cleanroomv1.TerminateSandboxResponse
+type StreamSandboxEventsRequest = cleanroomv1.StreamSandboxEventsRequest
+type SandboxEvent = cleanroomv1.SandboxEvent
+
+type Execution = cleanroomv1.Execution
+
+type ExecutionStatus = cleanroomv1.ExecutionStatus
+
+const (
+	ExecutionStatus_EXECUTION_STATUS_UNSPECIFIED = cleanroomv1.ExecutionStatus_EXECUTION_STATUS_UNSPECIFIED
+	ExecutionStatus_EXECUTION_STATUS_QUEUED      = cleanroomv1.ExecutionStatus_EXECUTION_STATUS_QUEUED
+	ExecutionStatus_EXECUTION_STATUS_RUNNING     = cleanroomv1.ExecutionStatus_EXECUTION_STATUS_RUNNING
+	ExecutionStatus_EXECUTION_STATUS_SUCCEEDED   = cleanroomv1.ExecutionStatus_EXECUTION_STATUS_SUCCEEDED
+	ExecutionStatus_EXECUTION_STATUS_FAILED      = cleanroomv1.ExecutionStatus_EXECUTION_STATUS_FAILED
+	ExecutionStatus_EXECUTION_STATUS_CANCELED    = cleanroomv1.ExecutionStatus_EXECUTION_STATUS_CANCELED
+	ExecutionStatus_EXECUTION_STATUS_TIMED_OUT   = cleanroomv1.ExecutionStatus_EXECUTION_STATUS_TIMED_OUT
+)
+
+type ExecutionOptions = cleanroomv1.ExecutionOptions
+type CreateExecutionRequest = cleanroomv1.CreateExecutionRequest
+type CreateExecutionResponse = cleanroomv1.CreateExecutionResponse
+type GetExecutionRequest = cleanroomv1.GetExecutionRequest
+type GetExecutionResponse = cleanroomv1.GetExecutionResponse
+type CancelExecutionRequest = cleanroomv1.CancelExecutionRequest
+type CancelExecutionResponse = cleanroomv1.CancelExecutionResponse
+type StreamExecutionRequest = cleanroomv1.StreamExecutionRequest
+type ExecutionExit = cleanroomv1.ExecutionExit
+type ExecutionStreamEvent = cleanroomv1.ExecutionStreamEvent
+type ExecutionAttachOpen = cleanroomv1.ExecutionAttachOpen
+type ExecutionResize = cleanroomv1.ExecutionResize
+type ExecutionSignal = cleanroomv1.ExecutionSignal
+type ExecutionHeartbeat = cleanroomv1.ExecutionHeartbeat
+type ExecutionClose = cleanroomv1.ExecutionClose
+type ExecutionAttachFrame = cleanroomv1.ExecutionAttachFrame


### PR DESCRIPTION
## Summary
- add a public `github.com/buildkite/cleanroom/client` package for external Go consumers
- expose protobuf request/response/event types and status enums via package aliases
- add ergonomic helpers for common flows: `NewFromEnv`, `Must`, `PolicyFromAllowlist`, `Allow`, `EnsureSandbox`, `ExecAndWait`, and `ErrCode`
- document the public Go client and ergonomic usage in README

## Why
This makes it straightforward to integrate cleanroom as a backend from external projects (including janebot) without importing internal packages or hand-rolling common lifecycle logic.

## Testing
- `mise exec -- go test ./client`
- `mise exec -- go test ./...`
- external smoke compile tests from standalone modules importing `github.com/buildkite/cleanroom/client` (local replace)
