### PR TITLE
feat: docker-in-guest autostart + alpine-docker base image pipeline

### DIFF
--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - Dockerfile.base-image
+      - Dockerfile.base-image-docker
       - scripts/base-image-tag.sh
       - .github/workflows/base-image.yml
   workflow_dispatch:
@@ -16,13 +17,23 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image_name: alpine
+            dockerfile: Dockerfile.base-image
+            repository: ghcr.io/buildkite/cleanroom-base/alpine
+          - image_name: alpine-docker
+            dockerfile: Dockerfile.base-image-docker
+            repository: ghcr.io/buildkite/cleanroom-base/alpine-docker
     steps:
       - uses: actions/checkout@v4
 
       - name: Compute base image tag
         id: meta
         run: |
-          echo "base_tag=$(scripts/base-image-tag.sh)" >> "$GITHUB_OUTPUT"
+          echo "base_tag=$(scripts/base-image-tag.sh \"${{ matrix.image_name }}\" \"${{ matrix.dockerfile }}\")" >> "$GITHUB_OUTPUT"
 
       - uses: docker/login-action@v3
         with:
@@ -33,9 +44,9 @@ jobs:
       - uses: docker/build-push-action@v6
         with:
           context: .
-          file: Dockerfile.base-image
+          file: ${{ matrix.dockerfile }}
           push: true
           tags: |
-            ghcr.io/buildkite/cleanroom-base/alpine:latest
-            ghcr.io/buildkite/cleanroom-base/alpine:${{ steps.meta.outputs.base_tag }}
-            ghcr.io/buildkite/cleanroom-base/alpine:${{ github.sha }}
+            ${{ matrix.repository }}:latest
+            ${{ matrix.repository }}:${{ steps.meta.outputs.base_tag }}
+            ${{ matrix.repository }}:${{ github.sha }}

--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Compute base image tag
         id: meta
         run: |
-          echo "base_tag=$(scripts/base-image-tag.sh \"${{ matrix.image_name }}\" \"${{ matrix.dockerfile }}\")" >> "$GITHUB_OUTPUT"
+          echo "base_tag=$(scripts/base-image-tag.sh '${{ matrix.image_name }}' '${{ matrix.dockerfile }}')" >> "$GITHUB_OUTPUT"
 
       - uses: docker/login-action@v3
         with:

--- a/Dockerfile.base-image-docker
+++ b/Dockerfile.base-image-docker
@@ -1,0 +1,9 @@
+FROM alpine:3.22
+
+RUN apk add --no-cache \
+  docker \
+  git \
+  strace \
+  mise
+
+CMD ["/bin/sh"]

--- a/README.md
+++ b/README.md
@@ -169,8 +169,9 @@ cleanroom image import ghcr.io/buildkite/cleanroom-base/alpine@sha256:... ./root
 cleanroom image bump-ref
 ```
 
-`ghcr.io/buildkite/cleanroom-base/alpine` is published from this repo on pushes to `main`
-via `.github/workflows/base-image.yml`.
+`ghcr.io/buildkite/cleanroom-base/alpine` and
+`ghcr.io/buildkite/cleanroom-base/alpine-docker` are published from this repo
+on pushes to `main` via `.github/workflows/base-image.yml`.
 
 Sandbox management:
 

--- a/README.md
+++ b/README.md
@@ -226,6 +226,15 @@ sandbox:
         ports: [443]
 ```
 
+Enable Docker as an explicit guest service:
+
+```yaml
+sandbox:
+  services:
+    docker:
+      required: true
+```
+
 ## Runtime Config
 
 Runtime config path: `$XDG_CONFIG_HOME/cleanroom/config.yaml` (or `~/.config/cleanroom/config.yaml`).

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -1,6 +1,6 @@
 # Basic Cleanroom Example
 
-This example is a minimal policy + command set you can use to verify current MVP behavior.
+This example is a minimal policy + command flow you can use to verify launched execution against the current client/server architecture.
 
 ## Prerequisites
 
@@ -10,67 +10,45 @@ From repository root:
 mise run install
 ```
 
-The CLI should be available in `GOBIN` (or `GOPATH/bin`).
-
 ## Files
 
 - `cleanroom.yaml`: digest-pinned sandbox image ref plus a deny-by-default network policy with one allowed host.
-- `marker.sh`: command that writes a local marker file.
-- `cleanup.sh`: removes marker files created during testing.
+- `marker.sh` / `cleanup.sh`: optional host-side helpers from earlier workflows.
 
 ## Quick test flow
 
 Run from this directory (`examples/basic`):
 
 ```bash
-cleanroom policy validate
+mise exec -- cleanroom policy validate
 ```
 
-### 1) Plan-only mode (no execution)
+Start a local control-plane server:
 
 ```bash
-./cleanup.sh
-cleanroom exec --dry-run -- ./marker.sh
-ls -la .marker-created
+mise exec -- cleanroom serve &
 ```
 
-Expected: `ls` fails because the command is not executed in plan-only mode.
-
-### 2) Explicit host passthrough execution
+Run a command in a darwin-vz sandbox:
 
 ```bash
-cleanroom exec --host-passthrough -- ./marker.sh
-ls -la .marker-created
-cat .marker-created
+mise exec -- cleanroom exec --backend darwin-vz -- sh -lc 'echo basic-example-ok'
 ```
 
-Expected: marker file exists and contains a timestamp.
+Expected output:
 
-### 3) Cleanup
-
-```bash
-./cleanup.sh
+```text
+basic-example-ok
 ```
 
-## Optional: launched backend path
-
-Launched execution requires runtime config (`~/.config/cleanroom/config.yaml`) with Firecracker `kernel_image`, plus a digest-pinned `sandbox.image.ref` in policy.
-
-Prewarm image cache (optional):
+Optional second check:
 
 ```bash
-cleanroom image pull ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+mise exec -- cleanroom exec --backend darwin-vz -- sh -lc 'cat /etc/alpine-release || cat /etc/os-release'
 ```
 
-Or import a local tarball into the cache:
+When finished:
 
 ```bash
-cleanroom image import ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef ./rootfs.tar.gz
-```
-
-Then run:
-
-```bash
-cleanroom exec -- ./marker.sh
-ls -la .marker-created
+pkill -f "cleanroom serve"
 ```

--- a/examples/basic/cleanroom.yaml
+++ b/examples/basic/cleanroom.yaml
@@ -1,7 +1,7 @@
 version: 1
 sandbox:
   image:
-    ref: ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+    ref: docker.io/library/alpine@sha256:a4f4213abb84c497377b8544c81b3564f313746700372ec4fe84653e4fb03805
   network:
     default: deny
     allow:

--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -1,6 +1,6 @@
 # Docker-In-Guest Example
 
-This example boots a sandbox from the Docker image, auto-starts `dockerd` in guest init, and runs `docker` commands inside the sandbox.
+This example boots a sandbox from the Docker image, enables the explicit Docker service contract in policy, and runs `docker` commands inside the sandbox.
 
 ## Prerequisites
 
@@ -12,7 +12,7 @@ mise run install
 
 ## Files
 
-- `cleanroom.yaml`: digest-pinned Docker image ref and a deny-by-default network allowlist for Docker Hub pull endpoints.
+- `cleanroom.yaml`: digest-pinned Docker image ref, `sandbox.services.docker.required: true`, and a deny-by-default network allowlist for Docker Hub pull endpoints.
 
 ## Quick test flow
 

--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -1,0 +1,53 @@
+# Docker-In-Guest Example
+
+This example boots a sandbox from the Docker image, auto-starts `dockerd` in guest init, and runs `docker` commands inside the sandbox.
+
+## Prerequisites
+
+From repository root:
+
+```bash
+mise run install
+```
+
+## Files
+
+- `cleanroom.yaml`: digest-pinned Docker image ref and a deny-by-default network allowlist for Docker Hub pull endpoints.
+
+## Quick test flow
+
+Run from this directory (`examples/docker`):
+
+```bash
+mise exec -- cleanroom policy validate
+```
+
+Start a local control-plane server:
+
+```bash
+mise exec -- cleanroom serve &
+```
+
+Confirm daemon + client are wired:
+
+```bash
+mise exec -- cleanroom exec --backend darwin-vz -- docker version
+```
+
+Run a container pull + execution smoke test:
+
+```bash
+mise exec -- cleanroom exec --backend darwin-vz -- docker run --rm --network none alpine:3.22 echo docker-example-ok
+```
+
+Expected output:
+
+```text
+docker-example-ok
+```
+
+When finished:
+
+```bash
+pkill -f "cleanroom serve"
+```

--- a/examples/docker/cleanroom.yaml
+++ b/examples/docker/cleanroom.yaml
@@ -1,0 +1,13 @@
+version: 1
+sandbox:
+  image:
+    ref: index.docker.io/library/docker@sha256:aa3df78ecf320f5fafdce71c659f1629e96e9de0968305fe1de670e0ca9176ce
+  network:
+    default: deny
+    allow:
+      - host: auth.docker.io
+        ports: [443]
+      - host: registry-1.docker.io
+        ports: [443]
+      - host: production.cloudflare.docker.com
+        ports: [443]

--- a/examples/docker/cleanroom.yaml
+++ b/examples/docker/cleanroom.yaml
@@ -2,6 +2,9 @@ version: 1
 sandbox:
   image:
     ref: index.docker.io/library/docker@sha256:aa3df78ecf320f5fafdce71c659f1629e96e9de0968305fe1de670e0ca9176ce
+  services:
+    docker:
+      required: true
   network:
     default: deny
     allow:

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -142,6 +142,9 @@ type FirecrackerConfig struct {
 	BinaryPath           string
 	KernelImagePath      string
 	RootFSPath           string
+	DockerStartupSeconds int64
+	DockerStorageDriver  string
+	DockerIPTables       bool
 	PrivilegedMode       string
 	PrivilegedHelperPath string
 	RunDir               string

--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -131,14 +131,34 @@ if [ -z "$GUEST_PORT" ]; then
 fi
 export CLEANROOM_VSOCK_PORT="$GUEST_PORT"
 
-if command -v dockerd >/dev/null 2>&1; then
+DOCKER_REQUIRED="$(arg_value cleanroom_service_docker_required || true)"
+if [ "$DOCKER_REQUIRED" = "1" ] && command -v dockerd >/dev/null 2>&1; then
+  DOCKER_STARTUP_TIMEOUT="$(arg_value cleanroom_service_docker_startup_timeout || true)"
+  case "$DOCKER_STARTUP_TIMEOUT" in
+    ''|*[!0-9]*) DOCKER_STARTUP_TIMEOUT="20" ;;
+  esac
+  if [ "$DOCKER_STARTUP_TIMEOUT" -le 0 ]; then
+    DOCKER_STARTUP_TIMEOUT="20"
+  fi
+  DOCKER_STORAGE_DRIVER="$(arg_value cleanroom_service_docker_storage_driver || true)"
+  if [ -z "$DOCKER_STORAGE_DRIVER" ]; then
+    DOCKER_STORAGE_DRIVER="vfs"
+  fi
+  DOCKER_IPTABLES="$(arg_value cleanroom_service_docker_iptables || true)"
+
+  DOCKER_ARGS="--host=unix:///var/run/docker.sock --storage-driver=$DOCKER_STORAGE_DRIVER"
+  if [ "$DOCKER_IPTABLES" = "0" ] || [ "$DOCKER_IPTABLES" = "false" ]; then
+    DOCKER_ARGS="$DOCKER_ARGS --iptables=false"
+  fi
+
   mkdir -p /var/log /var/lib/docker /etc/docker /var/run /sys/fs/cgroup
   mount -t cgroup2 none /sys/fs/cgroup 2>/dev/null || true
   if [ ! -S /var/run/docker.sock ]; then
-    dockerd --host=unix:///var/run/docker.sock --iptables=false --storage-driver=vfs >/var/log/dockerd.log 2>&1 &
+    dockerd $DOCKER_ARGS >/var/log/dockerd.log 2>&1 &
   fi
   i=0
-  while [ "$i" -lt 200 ]; do
+  DOCKER_WAIT_TICKS=$((DOCKER_STARTUP_TIMEOUT * 10))
+  while [ "$i" -lt "$DOCKER_WAIT_TICKS" ]; do
     if [ -S /var/run/docker.sock ]; then
       if command -v docker >/dev/null 2>&1; then
         if docker version >/dev/null 2>&1; then
@@ -457,7 +477,11 @@ func (a *Adapter) run(ctx context.Context, req backend.RunRequest, stream backen
 		_ = os.Remove(vmRootFSPath)
 	}()
 
-	bootArgs := fmt.Sprintf("console=hvc0 root=/dev/vda rw init=/sbin/cleanroom-init cleanroom_guest_port=%d", req.GuestPort)
+	bootArgs := fmt.Sprintf(
+		"console=hvc0 root=/dev/vda rw init=/sbin/cleanroom-init cleanroom_guest_port=%d %s",
+		req.GuestPort,
+		dockerServiceBootArgs(req.Policy, req.FirecrackerConfig),
+	)
 	consolePath := filepath.Join(runDir, "vm.console.log")
 
 	vmPlanPath := filepath.Join(runDir, "darwin-vz-config.json")
@@ -496,6 +520,7 @@ func (a *Adapter) run(ctx context.Context, req backend.RunRequest, stream backen
 		Op:              "StartVM",
 		KernelPath:      kernelPath,
 		RootFSPath:      vmRootFSPath,
+		BootArgs:        bootArgs,
 		VCPUs:           req.VCPUs,
 		MemoryMiB:       req.MemoryMiB,
 		GuestPort:       req.GuestPort,

--- a/internal/backend/darwinvz/docker_bootargs.go
+++ b/internal/backend/darwinvz/docker_bootargs.go
@@ -1,0 +1,49 @@
+package darwinvz
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/policy"
+)
+
+func dockerServiceBootArgs(compiled *policy.CompiledPolicy, cfg backend.FirecrackerConfig) string {
+	if compiled == nil || !compiled.RequiresDockerService() {
+		return "cleanroom_service_docker_required=0"
+	}
+
+	startupSeconds := cfg.DockerStartupSeconds
+	if startupSeconds <= 0 {
+		startupSeconds = 20
+	}
+
+	storageDriver := sanitizeKernelArgValue(strings.TrimSpace(cfg.DockerStorageDriver))
+	if storageDriver == "" {
+		storageDriver = "vfs"
+	}
+
+	iptables := 0
+	if cfg.DockerIPTables {
+		iptables = 1
+	}
+
+	return fmt.Sprintf(
+		"cleanroom_service_docker_required=1 cleanroom_service_docker_startup_timeout=%d cleanroom_service_docker_storage_driver=%s cleanroom_service_docker_iptables=%d",
+		startupSeconds,
+		storageDriver,
+		iptables,
+	)
+}
+
+func sanitizeKernelArgValue(value string) string {
+	var b strings.Builder
+	b.Grow(len(value))
+	for _, r := range value {
+		isAlphaNum := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')
+		if isAlphaNum || r == '.' || r == '_' || r == '-' {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}

--- a/internal/backend/darwinvz/docker_bootargs_test.go
+++ b/internal/backend/darwinvz/docker_bootargs_test.go
@@ -1,0 +1,43 @@
+//go:build darwin
+
+package darwinvz
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/policy"
+)
+
+func TestDockerServiceBootArgsDisabledByDefault(t *testing.T) {
+	got := dockerServiceBootArgs(nil, backend.FirecrackerConfig{})
+	if got != "cleanroom_service_docker_required=0" {
+		t.Fatalf("unexpected docker boot args: %q", got)
+	}
+}
+
+func TestDockerServiceBootArgsUsesPolicyAndRuntimeSettings(t *testing.T) {
+	compiled := &policy.CompiledPolicy{
+		Services: policy.Services{
+			Docker: policy.DockerService{Required: true},
+		},
+	}
+	cfg := backend.FirecrackerConfig{
+		DockerStartupSeconds: 45,
+		DockerStorageDriver:  "overlay2",
+		DockerIPTables:       true,
+	}
+
+	got := dockerServiceBootArgs(compiled, cfg)
+	for _, want := range []string{
+		"cleanroom_service_docker_required=1",
+		"cleanroom_service_docker_startup_timeout=45",
+		"cleanroom_service_docker_storage_driver=overlay2",
+		"cleanroom_service_docker_iptables=1",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %q in docker boot args %q", want, got)
+		}
+	}
+}

--- a/internal/backend/darwinvz/guest_init_script_test.go
+++ b/internal/backend/darwinvz/guest_init_script_test.go
@@ -31,12 +31,20 @@ func TestGuestInitScriptBootstrapsNetwork(t *testing.T) {
 }
 
 func TestGuestInitScriptAutostartsDockerWhenAvailable(t *testing.T) {
-	if !strings.Contains(guestInitScriptTemplate, "command -v dockerd") {
-		t.Fatal("expected dockerd availability check in init script")
+	if !strings.Contains(guestInitScriptTemplate, "DOCKER_REQUIRED=\"$(arg_value cleanroom_service_docker_required || true)\"") {
+		t.Fatal("expected docker service required flag lookup in init script")
 	}
 
-	if !strings.Contains(guestInitScriptTemplate, "dockerd --host=unix:///var/run/docker.sock --iptables=false --storage-driver=vfs") {
-		t.Fatal("expected dockerd to launch with unix socket in init script")
+	if !strings.Contains(guestInitScriptTemplate, "[ \"$DOCKER_REQUIRED\" = \"1\" ] && command -v dockerd >/dev/null 2>&1") {
+		t.Fatal("expected dockerd launch to be gated by docker service contract")
+	}
+
+	if !strings.Contains(guestInitScriptTemplate, "DOCKER_STORAGE_DRIVER=\"$(arg_value cleanroom_service_docker_storage_driver || true)\"") {
+		t.Fatal("expected docker storage driver boot arg lookup in init script")
+	}
+
+	if !strings.Contains(guestInitScriptTemplate, "DOCKER_IPTABLES=\"$(arg_value cleanroom_service_docker_iptables || true)\"") {
+		t.Fatal("expected docker iptables boot arg lookup in init script")
 	}
 
 	if !strings.Contains(guestInitScriptTemplate, "docker version >/dev/null 2>&1") {

--- a/internal/backend/darwinvz/guest_init_script_test.go
+++ b/internal/backend/darwinvz/guest_init_script_test.go
@@ -29,3 +29,17 @@ func TestGuestInitScriptBootstrapsNetwork(t *testing.T) {
 		t.Fatal("expected udhcpc DHCP bootstrap in init script")
 	}
 }
+
+func TestGuestInitScriptAutostartsDockerWhenAvailable(t *testing.T) {
+	if !strings.Contains(guestInitScriptTemplate, "command -v dockerd") {
+		t.Fatal("expected dockerd availability check in init script")
+	}
+
+	if !strings.Contains(guestInitScriptTemplate, "dockerd --host=unix:///var/run/docker.sock --iptables=false --storage-driver=vfs") {
+		t.Fatal("expected dockerd to launch with unix socket in init script")
+	}
+
+	if !strings.Contains(guestInitScriptTemplate, "docker version >/dev/null 2>&1") {
+		t.Fatal("expected init script to wait for dockerd API readiness")
+	}
+}

--- a/internal/backend/darwinvz/helper_client.go
+++ b/internal/backend/darwinvz/helper_client.go
@@ -31,6 +31,7 @@ type helperControlRequest struct {
 	Op              string `json:"op"`
 	KernelPath      string `json:"kernel_path,omitempty"`
 	RootFSPath      string `json:"rootfs_path,omitempty"`
+	BootArgs        string `json:"boot_args,omitempty"`
 	VCPUs           int64  `json:"vcpus,omitempty"`
 	MemoryMiB       int64  `json:"memory_mib,omitempty"`
 	GuestPort       uint32 `json:"guest_port,omitempty"`

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -147,14 +147,34 @@ if [ -z "$GUEST_PORT" ]; then
 fi
 export CLEANROOM_VSOCK_PORT="$GUEST_PORT"
 
-if command -v dockerd >/dev/null 2>&1; then
+DOCKER_REQUIRED="$(arg_value cleanroom_service_docker_required || true)"
+if [ "$DOCKER_REQUIRED" = "1" ] && command -v dockerd >/dev/null 2>&1; then
+  DOCKER_STARTUP_TIMEOUT="$(arg_value cleanroom_service_docker_startup_timeout || true)"
+  case "$DOCKER_STARTUP_TIMEOUT" in
+    ''|*[!0-9]*) DOCKER_STARTUP_TIMEOUT="20" ;;
+  esac
+  if [ "$DOCKER_STARTUP_TIMEOUT" -le 0 ]; then
+    DOCKER_STARTUP_TIMEOUT="20"
+  fi
+  DOCKER_STORAGE_DRIVER="$(arg_value cleanroom_service_docker_storage_driver || true)"
+  if [ -z "$DOCKER_STORAGE_DRIVER" ]; then
+    DOCKER_STORAGE_DRIVER="vfs"
+  fi
+  DOCKER_IPTABLES="$(arg_value cleanroom_service_docker_iptables || true)"
+
+  DOCKER_ARGS="--host=unix:///var/run/docker.sock --storage-driver=$DOCKER_STORAGE_DRIVER"
+  if [ "$DOCKER_IPTABLES" = "0" ] || [ "$DOCKER_IPTABLES" = "false" ]; then
+    DOCKER_ARGS="$DOCKER_ARGS --iptables=false"
+  fi
+
   mkdir -p /var/log /var/lib/docker /etc/docker /var/run /sys/fs/cgroup
   mount -t cgroup2 none /sys/fs/cgroup 2>/dev/null || true
   if [ ! -S /var/run/docker.sock ]; then
-    dockerd --host=unix:///var/run/docker.sock --iptables=false --storage-driver=vfs >/var/log/dockerd.log 2>&1 &
+    dockerd $DOCKER_ARGS >/var/log/dockerd.log 2>&1 &
   fi
   i=0
-  while [ "$i" -lt 200 ]; do
+  DOCKER_WAIT_TICKS=$((DOCKER_STARTUP_TIMEOUT * 10))
+  while [ "$i" -lt "$DOCKER_WAIT_TICKS" ]; do
     if [ -S /var/run/docker.sock ]; then
       if command -v docker >/dev/null 2>&1; then
         if docker version >/dev/null 2>&1; then
@@ -743,14 +763,16 @@ func (a *Adapter) run(ctx context.Context, req backend.RunRequest, stream backen
 	defer cleanupMeasured()
 
 	vsockPath := filepath.Join(runDir, "vsock.sock")
+	dockerBootArgs := dockerServiceBootArgs(req.Policy, req.FirecrackerConfig)
 	fcCfg := firecrackerConfig{
 		BootSource: bootSource{
 			KernelImagePath: kernelPath,
 			BootArgs: fmt.Sprintf(
-				"console=ttyS0 reboot=k panic=1 pci=off init=/sbin/cleanroom-init random.trust_cpu=on cleanroom_guest_ip=%s cleanroom_guest_gw=%s cleanroom_guest_mask=24 cleanroom_guest_dns=1.1.1.1 cleanroom_guest_port=%d",
+				"console=ttyS0 reboot=k panic=1 pci=off init=/sbin/cleanroom-init random.trust_cpu=on cleanroom_guest_ip=%s cleanroom_guest_gw=%s cleanroom_guest_mask=24 cleanroom_guest_dns=1.1.1.1 cleanroom_guest_port=%d %s",
 				networkCfg.GuestIP,
 				networkCfg.HostIP,
 				req.GuestPort,
+				dockerBootArgs,
 			),
 		},
 		Drives: []drive{
@@ -1339,14 +1361,16 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 	}
 
 	vsockPath := filepath.Join(runDir, "vsock.sock")
+	dockerBootArgs := dockerServiceBootArgs(compiled, cfg)
 	fcCfg := firecrackerConfig{
 		BootSource: bootSource{
 			KernelImagePath: kernelPath,
 			BootArgs: fmt.Sprintf(
-				"console=ttyS0 reboot=k panic=1 pci=off init=/sbin/cleanroom-init random.trust_cpu=on cleanroom_guest_ip=%s cleanroom_guest_gw=%s cleanroom_guest_mask=24 cleanroom_guest_dns=1.1.1.1 cleanroom_guest_port=%d",
+				"console=ttyS0 reboot=k panic=1 pci=off init=/sbin/cleanroom-init random.trust_cpu=on cleanroom_guest_ip=%s cleanroom_guest_gw=%s cleanroom_guest_mask=24 cleanroom_guest_dns=1.1.1.1 cleanroom_guest_port=%d %s",
 				networkCfg.GuestIP,
 				networkCfg.HostIP,
 				cfg.GuestPort,
+				dockerBootArgs,
 			),
 		},
 		Drives: []drive{{
@@ -1965,6 +1989,46 @@ func gatewayEnvVars(instance *sandboxInstance, gwPort int) []string {
 		env = append(env, fmt.Sprintf("GIT_CONFIG_VALUE_%d=https://%s/", i, host))
 	}
 	return env
+}
+
+func dockerServiceBootArgs(compiled *policy.CompiledPolicy, cfg backend.FirecrackerConfig) string {
+	if compiled == nil || !compiled.RequiresDockerService() {
+		return "cleanroom_service_docker_required=0"
+	}
+
+	startupSeconds := cfg.DockerStartupSeconds
+	if startupSeconds <= 0 {
+		startupSeconds = 20
+	}
+
+	storageDriver := sanitizeKernelArgValue(strings.TrimSpace(cfg.DockerStorageDriver))
+	if storageDriver == "" {
+		storageDriver = "vfs"
+	}
+
+	iptables := 0
+	if cfg.DockerIPTables {
+		iptables = 1
+	}
+
+	return fmt.Sprintf(
+		"cleanroom_service_docker_required=1 cleanroom_service_docker_startup_timeout=%d cleanroom_service_docker_storage_driver=%s cleanroom_service_docker_iptables=%d",
+		startupSeconds,
+		storageDriver,
+		iptables,
+	)
+}
+
+func sanitizeKernelArgValue(value string) string {
+	var b strings.Builder
+	b.Grow(len(value))
+	for _, r := range value {
+		isAlphaNum := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')
+		if isAlphaNum || r == '.' || r == '_' || r == '-' {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
 }
 
 func tapNameFromRunID(runID string) string {

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -147,6 +147,28 @@ if [ -z "$GUEST_PORT" ]; then
 fi
 export CLEANROOM_VSOCK_PORT="$GUEST_PORT"
 
+if command -v dockerd >/dev/null 2>&1; then
+  mkdir -p /var/log /var/lib/docker /etc/docker /var/run /sys/fs/cgroup
+  mount -t cgroup2 none /sys/fs/cgroup 2>/dev/null || true
+  if [ ! -S /var/run/docker.sock ]; then
+    dockerd --host=unix:///var/run/docker.sock --iptables=false --storage-driver=vfs >/var/log/dockerd.log 2>&1 &
+  fi
+  i=0
+  while [ "$i" -lt 200 ]; do
+    if [ -S /var/run/docker.sock ]; then
+      if command -v docker >/dev/null 2>&1; then
+        if docker version >/dev/null 2>&1; then
+          break
+        fi
+      else
+        break
+      fi
+    fi
+    sleep 0.1
+    i=$((i + 1))
+  done
+fi
+
 while true; do
   /usr/local/bin/cleanroom-guest-agent || true
   sleep 1

--- a/internal/backend/firecracker/docker_bootargs_test.go
+++ b/internal/backend/firecracker/docker_bootargs_test.go
@@ -1,0 +1,59 @@
+package firecracker
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/policy"
+)
+
+func TestDockerServiceBootArgsDisabledByDefault(t *testing.T) {
+	got := dockerServiceBootArgs(nil, backend.FirecrackerConfig{})
+	if got != "cleanroom_service_docker_required=0" {
+		t.Fatalf("unexpected docker boot args: %q", got)
+	}
+}
+
+func TestDockerServiceBootArgsUsesPolicyAndRuntimeSettings(t *testing.T) {
+	compiled := &policy.CompiledPolicy{
+		Services: policy.Services{
+			Docker: policy.DockerService{Required: true},
+		},
+	}
+	cfg := backend.FirecrackerConfig{
+		DockerStartupSeconds: 45,
+		DockerStorageDriver:  "overlay2",
+		DockerIPTables:       true,
+	}
+
+	got := dockerServiceBootArgs(compiled, cfg)
+	for _, want := range []string{
+		"cleanroom_service_docker_required=1",
+		"cleanroom_service_docker_startup_timeout=45",
+		"cleanroom_service_docker_storage_driver=overlay2",
+		"cleanroom_service_docker_iptables=1",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %q in docker boot args %q", want, got)
+		}
+	}
+}
+
+func TestDockerServiceBootArgsUsesSafeDefaults(t *testing.T) {
+	compiled := &policy.CompiledPolicy{
+		Services: policy.Services{
+			Docker: policy.DockerService{Required: true},
+		},
+	}
+	got := dockerServiceBootArgs(compiled, backend.FirecrackerConfig{})
+	for _, want := range []string{
+		"cleanroom_service_docker_startup_timeout=20",
+		"cleanroom_service_docker_storage_driver=vfs",
+		"cleanroom_service_docker_iptables=0",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %q in docker boot args %q", want, got)
+		}
+	}
+}

--- a/internal/backend/firecracker/guest_init_script_test.go
+++ b/internal/backend/firecracker/guest_init_script_test.go
@@ -6,11 +6,17 @@ import (
 )
 
 func TestGuestInitScriptAutostartsDockerWhenAvailable(t *testing.T) {
-	if !strings.Contains(guestInitScriptTemplate, "command -v dockerd") {
-		t.Fatal("expected dockerd availability check in init script")
+	if !strings.Contains(guestInitScriptTemplate, "DOCKER_REQUIRED=\"$(arg_value cleanroom_service_docker_required || true)\"") {
+		t.Fatal("expected docker service required flag lookup in init script")
 	}
-	if !strings.Contains(guestInitScriptTemplate, "dockerd --host=unix:///var/run/docker.sock --iptables=false --storage-driver=vfs") {
-		t.Fatal("expected dockerd to launch with unix socket in init script")
+	if !strings.Contains(guestInitScriptTemplate, "[ \"$DOCKER_REQUIRED\" = \"1\" ] && command -v dockerd >/dev/null 2>&1") {
+		t.Fatal("expected dockerd launch to be gated by docker service contract")
+	}
+	if !strings.Contains(guestInitScriptTemplate, "DOCKER_STORAGE_DRIVER=\"$(arg_value cleanroom_service_docker_storage_driver || true)\"") {
+		t.Fatal("expected docker storage driver boot arg lookup in init script")
+	}
+	if !strings.Contains(guestInitScriptTemplate, "DOCKER_IPTABLES=\"$(arg_value cleanroom_service_docker_iptables || true)\"") {
+		t.Fatal("expected docker iptables boot arg lookup in init script")
 	}
 	if !strings.Contains(guestInitScriptTemplate, "docker version >/dev/null 2>&1") {
 		t.Fatal("expected init script to wait for dockerd API readiness")

--- a/internal/backend/firecracker/guest_init_script_test.go
+++ b/internal/backend/firecracker/guest_init_script_test.go
@@ -1,0 +1,18 @@
+package firecracker
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGuestInitScriptAutostartsDockerWhenAvailable(t *testing.T) {
+	if !strings.Contains(guestInitScriptTemplate, "command -v dockerd") {
+		t.Fatal("expected dockerd availability check in init script")
+	}
+	if !strings.Contains(guestInitScriptTemplate, "dockerd --host=unix:///var/run/docker.sock --iptables=false --storage-driver=vfs") {
+		t.Fatal("expected dockerd to launch with unix socket in init script")
+	}
+	if !strings.Contains(guestInitScriptTemplate, "docker version >/dev/null 2>&1") {
+		t.Fatal("expected init script to wait for dockerd API readiness")
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -403,9 +403,16 @@ func defaultRuntimeConfig(defaultBackend string) runtimeconfig.Config {
 		DefaultBackend: defaultBackend,
 		Backends: runtimeconfig.Backends{
 			Firecracker: runtimeconfig.FirecrackerConfig{
-				BinaryPath:           "firecracker",
-				KernelImage:          "",
-				RootFS:               "",
+				BinaryPath:  "firecracker",
+				KernelImage: "",
+				RootFS:      "",
+				Services: runtimeconfig.ServicesConfig{
+					Docker: runtimeconfig.DockerServiceConfig{
+						StartupTimeoutSeconds: 20,
+						StorageDriver:         "vfs",
+						IPTables:              false,
+					},
+				},
 				PrivilegedMode:       "sudo",
 				PrivilegedHelperPath: "/usr/local/sbin/cleanroom-root-helper",
 				VCPUs:                2,
@@ -415,8 +422,15 @@ func defaultRuntimeConfig(defaultBackend string) runtimeconfig.Config {
 				LaunchSeconds:        30,
 			},
 			DarwinVZ: runtimeconfig.DarwinVZConfig{
-				KernelImage:   "",
-				RootFS:        "",
+				KernelImage: "",
+				RootFS:      "",
+				Services: runtimeconfig.ServicesConfig{
+					Docker: runtimeconfig.DockerServiceConfig{
+						StartupTimeoutSeconds: 20,
+						StorageDriver:         "vfs",
+						IPTables:              false,
+					},
+				},
 				VCPUs:         2,
 				MemoryMiB:     1024,
 				GuestPort:     10700,
@@ -1361,6 +1375,9 @@ func mergeBackendConfig(backendName string, launchSeconds int64, cfg runtimeconf
 		BinaryPath:           cfg.Backends.Firecracker.BinaryPath,
 		KernelImagePath:      cfg.Backends.Firecracker.KernelImage,
 		RootFSPath:           cfg.Backends.Firecracker.RootFS,
+		DockerStartupSeconds: cfg.Backends.Firecracker.Services.Docker.StartupTimeoutSeconds,
+		DockerStorageDriver:  cfg.Backends.Firecracker.Services.Docker.StorageDriver,
+		DockerIPTables:       cfg.Backends.Firecracker.Services.Docker.IPTables,
 		PrivilegedMode:       cfg.Backends.Firecracker.PrivilegedMode,
 		PrivilegedHelperPath: cfg.Backends.Firecracker.PrivilegedHelperPath,
 		VCPUs:                cfg.Backends.Firecracker.VCPUs,
@@ -1372,6 +1389,9 @@ func mergeBackendConfig(backendName string, launchSeconds int64, cfg runtimeconf
 	if backendName == "darwin-vz" {
 		out.KernelImagePath = cfg.Backends.DarwinVZ.KernelImage
 		out.RootFSPath = cfg.Backends.DarwinVZ.RootFS
+		out.DockerStartupSeconds = cfg.Backends.DarwinVZ.Services.Docker.StartupTimeoutSeconds
+		out.DockerStorageDriver = cfg.Backends.DarwinVZ.Services.Docker.StorageDriver
+		out.DockerIPTables = cfg.Backends.DarwinVZ.Services.Docker.IPTables
 		out.VCPUs = cfg.Backends.DarwinVZ.VCPUs
 		out.MemoryMiB = cfg.Backends.DarwinVZ.MemoryMiB
 		out.GuestPort = cfg.Backends.DarwinVZ.GuestPort

--- a/internal/cli/config_init_test.go
+++ b/internal/cli/config_init_test.go
@@ -45,6 +45,15 @@ func TestConfigInitWritesRuntimeConfig(t *testing.T) {
 	if got := strings.TrimSpace(cfg.Backends.DarwinVZ.KernelImage); got != "" {
 		t.Fatalf("expected backends.darwin-vz.kernel_image to default empty, got %q", got)
 	}
+	if got, want := cfg.Backends.Firecracker.Services.Docker.StartupTimeoutSeconds, int64(20); got != want {
+		t.Fatalf("expected backends.firecracker.services.docker.startup_timeout_seconds=%d, got %d", want, got)
+	}
+	if got, want := cfg.Backends.Firecracker.Services.Docker.StorageDriver, "vfs"; got != want {
+		t.Fatalf("expected backends.firecracker.services.docker.storage_driver=%q, got %q", want, got)
+	}
+	if cfg.Backends.Firecracker.Services.Docker.IPTables {
+		t.Fatal("expected backends.firecracker.services.docker.iptables to default false")
+	}
 }
 
 func TestConfigInitRefusesOverwriteWithoutForce(t *testing.T) {

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -109,10 +109,10 @@ var (
 )
 
 const (
-	attachStdinRegistrationWait   = 2 * time.Second
-	attachResizeRegistrationWait  = 250 * time.Millisecond
-	attachPollInterval            = 10 * time.Millisecond
-	defaultDownloadMaxBytes int64 = 10 * 1024 * 1024
+	attachStdinRegistrationWait        = 2 * time.Second
+	attachResizeRegistrationWait       = 250 * time.Millisecond
+	attachPollInterval                 = 10 * time.Millisecond
+	defaultDownloadMaxBytes      int64 = 10 * 1024 * 1024
 )
 
 func (s *Service) CreateSandbox(ctx context.Context, req *cleanroomv1.CreateSandboxRequest) (*cleanroomv1.CreateSandboxResponse, error) {
@@ -1612,6 +1612,9 @@ func mergeBackendConfig(backendName string, opts executionOptions, cfg runtimeco
 		BinaryPath:           cfg.Backends.Firecracker.BinaryPath,
 		KernelImagePath:      cfg.Backends.Firecracker.KernelImage,
 		RootFSPath:           cfg.Backends.Firecracker.RootFS,
+		DockerStartupSeconds: cfg.Backends.Firecracker.Services.Docker.StartupTimeoutSeconds,
+		DockerStorageDriver:  cfg.Backends.Firecracker.Services.Docker.StorageDriver,
+		DockerIPTables:       cfg.Backends.Firecracker.Services.Docker.IPTables,
 		PrivilegedMode:       cfg.Backends.Firecracker.PrivilegedMode,
 		PrivilegedHelperPath: cfg.Backends.Firecracker.PrivilegedHelperPath,
 		VCPUs:                cfg.Backends.Firecracker.VCPUs,
@@ -1623,6 +1626,9 @@ func mergeBackendConfig(backendName string, opts executionOptions, cfg runtimeco
 	if backendName == "darwin-vz" {
 		out.KernelImagePath = cfg.Backends.DarwinVZ.KernelImage
 		out.RootFSPath = cfg.Backends.DarwinVZ.RootFS
+		out.DockerStartupSeconds = cfg.Backends.DarwinVZ.Services.Docker.StartupTimeoutSeconds
+		out.DockerStorageDriver = cfg.Backends.DarwinVZ.Services.Docker.StorageDriver
+		out.DockerIPTables = cfg.Backends.DarwinVZ.Services.Docker.IPTables
 		out.VCPUs = cfg.Backends.DarwinVZ.VCPUs
 		out.MemoryMiB = cfg.Backends.DarwinVZ.MemoryMiB
 		out.GuestPort = cfg.Backends.DarwinVZ.GuestPort

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -362,6 +362,7 @@ func TestCreateSandboxMergesDarwinVZConfig(t *testing.T) {
 				Firecracker: runtimeconfig.FirecrackerConfig{
 					KernelImage:   "/firecracker-kernel",
 					RootFS:        "/firecracker-rootfs",
+					Services:      runtimeconfig.ServicesConfig{Docker: runtimeconfig.DockerServiceConfig{StartupTimeoutSeconds: 11, StorageDriver: "btrfs", IPTables: true}},
 					VCPUs:         1,
 					MemoryMiB:     256,
 					GuestPort:     10700,
@@ -370,6 +371,7 @@ func TestCreateSandboxMergesDarwinVZConfig(t *testing.T) {
 				DarwinVZ: runtimeconfig.DarwinVZConfig{
 					KernelImage:   "/darwin-vz-kernel",
 					RootFS:        "/darwin-vz-rootfs",
+					Services:      runtimeconfig.ServicesConfig{Docker: runtimeconfig.DockerServiceConfig{StartupTimeoutSeconds: 55, StorageDriver: "overlay2", IPTables: false}},
 					VCPUs:         4,
 					MemoryMiB:     2048,
 					GuestPort:     12000,
@@ -411,6 +413,15 @@ func TestCreateSandboxMergesDarwinVZConfig(t *testing.T) {
 	}
 	if got, want := gotCfg.LaunchSeconds, int64(33); got != want {
 		t.Fatalf("unexpected launch_seconds: got %d want %d", got, want)
+	}
+	if got, want := gotCfg.DockerStartupSeconds, int64(55); got != want {
+		t.Fatalf("unexpected docker startup timeout: got %d want %d", got, want)
+	}
+	if got, want := gotCfg.DockerStorageDriver, "overlay2"; got != want {
+		t.Fatalf("unexpected docker storage driver: got %q want %q", got, want)
+	}
+	if got := gotCfg.DockerIPTables; got {
+		t.Fatal("expected docker iptables=false from darwin-vz config")
 	}
 	if got := gotCfg.Launch; !got {
 		t.Fatalf("expected launch=true")

--- a/internal/gen/cleanroom/v1/control.pb.go
+++ b/internal/gen/cleanroom/v1/control.pb.go
@@ -277,6 +277,94 @@ func (x *PolicyAllowRule) GetPorts() []int32 {
 	return nil
 }
 
+type PolicyDockerService struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Required      bool                   `protobuf:"varint,1,opt,name=required,proto3" json:"required,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PolicyDockerService) Reset() {
+	*x = PolicyDockerService{}
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PolicyDockerService) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PolicyDockerService) ProtoMessage() {}
+
+func (x *PolicyDockerService) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PolicyDockerService.ProtoReflect.Descriptor instead.
+func (*PolicyDockerService) Descriptor() ([]byte, []int) {
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *PolicyDockerService) GetRequired() bool {
+	if x != nil {
+		return x.Required
+	}
+	return false
+}
+
+type PolicyServices struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Docker        *PolicyDockerService   `protobuf:"bytes,1,opt,name=docker,proto3" json:"docker,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PolicyServices) Reset() {
+	*x = PolicyServices{}
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PolicyServices) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PolicyServices) ProtoMessage() {}
+
+func (x *PolicyServices) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PolicyServices.ProtoReflect.Descriptor instead.
+func (*PolicyServices) Descriptor() ([]byte, []int) {
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *PolicyServices) GetDocker() *PolicyDockerService {
+	if x != nil {
+		return x.Docker
+	}
+	return nil
+}
+
 type Policy struct {
 	state          protoimpl.MessageState `protogen:"open.v1"`
 	Version        int32                  `protobuf:"varint,1,opt,name=version,proto3" json:"version,omitempty"`
@@ -285,13 +373,14 @@ type Policy struct {
 	NetworkDefault string                 `protobuf:"bytes,4,opt,name=network_default,json=networkDefault,proto3" json:"network_default,omitempty"`
 	Allow          []*PolicyAllowRule     `protobuf:"bytes,5,rep,name=allow,proto3" json:"allow,omitempty"`
 	Hash           string                 `protobuf:"bytes,6,opt,name=hash,proto3" json:"hash,omitempty"`
+	Services       *PolicyServices        `protobuf:"bytes,7,opt,name=services,proto3" json:"services,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
 
 func (x *Policy) Reset() {
 	*x = Policy{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[2]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -303,7 +392,7 @@ func (x *Policy) String() string {
 func (*Policy) ProtoMessage() {}
 
 func (x *Policy) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[2]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -316,7 +405,7 @@ func (x *Policy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Policy.ProtoReflect.Descriptor instead.
 func (*Policy) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{2}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *Policy) GetVersion() int32 {
@@ -361,6 +450,13 @@ func (x *Policy) GetHash() string {
 	return ""
 }
 
+func (x *Policy) GetServices() *PolicyServices {
+	if x != nil {
+		return x.Services
+	}
+	return nil
+}
+
 type SandboxOptions struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	LaunchSeconds int64                  `protobuf:"varint,3,opt,name=launch_seconds,json=launchSeconds,proto3" json:"launch_seconds,omitempty"`
@@ -370,7 +466,7 @@ type SandboxOptions struct {
 
 func (x *SandboxOptions) Reset() {
 	*x = SandboxOptions{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[3]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -382,7 +478,7 @@ func (x *SandboxOptions) String() string {
 func (*SandboxOptions) ProtoMessage() {}
 
 func (x *SandboxOptions) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[3]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -395,7 +491,7 @@ func (x *SandboxOptions) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxOptions.ProtoReflect.Descriptor instead.
 func (*SandboxOptions) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{3}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *SandboxOptions) GetLaunchSeconds() int64 {
@@ -416,7 +512,7 @@ type CreateSandboxRequest struct {
 
 func (x *CreateSandboxRequest) Reset() {
 	*x = CreateSandboxRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[4]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -428,7 +524,7 @@ func (x *CreateSandboxRequest) String() string {
 func (*CreateSandboxRequest) ProtoMessage() {}
 
 func (x *CreateSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[4]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -441,7 +537,7 @@ func (x *CreateSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSandboxRequest.ProtoReflect.Descriptor instead.
 func (*CreateSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{4}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *CreateSandboxRequest) GetBackend() string {
@@ -476,7 +572,7 @@ type CreateSandboxResponse struct {
 
 func (x *CreateSandboxResponse) Reset() {
 	*x = CreateSandboxResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[5]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -488,7 +584,7 @@ func (x *CreateSandboxResponse) String() string {
 func (*CreateSandboxResponse) ProtoMessage() {}
 
 func (x *CreateSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[5]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -501,7 +597,7 @@ func (x *CreateSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSandboxResponse.ProtoReflect.Descriptor instead.
 func (*CreateSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{5}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *CreateSandboxResponse) GetSandbox() *Sandbox {
@@ -534,7 +630,7 @@ type GetSandboxRequest struct {
 
 func (x *GetSandboxRequest) Reset() {
 	*x = GetSandboxRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[6]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -546,7 +642,7 @@ func (x *GetSandboxRequest) String() string {
 func (*GetSandboxRequest) ProtoMessage() {}
 
 func (x *GetSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[6]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -559,7 +655,7 @@ func (x *GetSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSandboxRequest.ProtoReflect.Descriptor instead.
 func (*GetSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{6}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *GetSandboxRequest) GetSandboxId() string {
@@ -578,7 +674,7 @@ type GetSandboxResponse struct {
 
 func (x *GetSandboxResponse) Reset() {
 	*x = GetSandboxResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[7]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -590,7 +686,7 @@ func (x *GetSandboxResponse) String() string {
 func (*GetSandboxResponse) ProtoMessage() {}
 
 func (x *GetSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[7]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -603,7 +699,7 @@ func (x *GetSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSandboxResponse.ProtoReflect.Descriptor instead.
 func (*GetSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{7}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *GetSandboxResponse) GetSandbox() *Sandbox {
@@ -621,7 +717,7 @@ type ListSandboxesRequest struct {
 
 func (x *ListSandboxesRequest) Reset() {
 	*x = ListSandboxesRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[8]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -633,7 +729,7 @@ func (x *ListSandboxesRequest) String() string {
 func (*ListSandboxesRequest) ProtoMessage() {}
 
 func (x *ListSandboxesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[8]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -646,7 +742,7 @@ func (x *ListSandboxesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSandboxesRequest.ProtoReflect.Descriptor instead.
 func (*ListSandboxesRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{8}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{10}
 }
 
 type ListSandboxesResponse struct {
@@ -658,7 +754,7 @@ type ListSandboxesResponse struct {
 
 func (x *ListSandboxesResponse) Reset() {
 	*x = ListSandboxesResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[9]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -670,7 +766,7 @@ func (x *ListSandboxesResponse) String() string {
 func (*ListSandboxesResponse) ProtoMessage() {}
 
 func (x *ListSandboxesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[9]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -683,7 +779,7 @@ func (x *ListSandboxesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSandboxesResponse.ProtoReflect.Descriptor instead.
 func (*ListSandboxesResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{9}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *ListSandboxesResponse) GetSandboxes() []*Sandbox {
@@ -704,7 +800,7 @@ type DownloadSandboxFileRequest struct {
 
 func (x *DownloadSandboxFileRequest) Reset() {
 	*x = DownloadSandboxFileRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[10]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -716,7 +812,7 @@ func (x *DownloadSandboxFileRequest) String() string {
 func (*DownloadSandboxFileRequest) ProtoMessage() {}
 
 func (x *DownloadSandboxFileRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[10]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -729,7 +825,7 @@ func (x *DownloadSandboxFileRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DownloadSandboxFileRequest.ProtoReflect.Descriptor instead.
 func (*DownloadSandboxFileRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{10}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *DownloadSandboxFileRequest) GetSandboxId() string {
@@ -765,7 +861,7 @@ type DownloadSandboxFileResponse struct {
 
 func (x *DownloadSandboxFileResponse) Reset() {
 	*x = DownloadSandboxFileResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[11]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -777,7 +873,7 @@ func (x *DownloadSandboxFileResponse) String() string {
 func (*DownloadSandboxFileResponse) ProtoMessage() {}
 
 func (x *DownloadSandboxFileResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[11]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -790,7 +886,7 @@ func (x *DownloadSandboxFileResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DownloadSandboxFileResponse.ProtoReflect.Descriptor instead.
 func (*DownloadSandboxFileResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{11}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *DownloadSandboxFileResponse) GetSandboxId() string {
@@ -830,7 +926,7 @@ type TerminateSandboxRequest struct {
 
 func (x *TerminateSandboxRequest) Reset() {
 	*x = TerminateSandboxRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[12]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -842,7 +938,7 @@ func (x *TerminateSandboxRequest) String() string {
 func (*TerminateSandboxRequest) ProtoMessage() {}
 
 func (x *TerminateSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[12]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -855,7 +951,7 @@ func (x *TerminateSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TerminateSandboxRequest.ProtoReflect.Descriptor instead.
 func (*TerminateSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{12}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *TerminateSandboxRequest) GetSandboxId() string {
@@ -876,7 +972,7 @@ type TerminateSandboxResponse struct {
 
 func (x *TerminateSandboxResponse) Reset() {
 	*x = TerminateSandboxResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[13]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -888,7 +984,7 @@ func (x *TerminateSandboxResponse) String() string {
 func (*TerminateSandboxResponse) ProtoMessage() {}
 
 func (x *TerminateSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[13]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -901,7 +997,7 @@ func (x *TerminateSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TerminateSandboxResponse.ProtoReflect.Descriptor instead.
 func (*TerminateSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{13}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *TerminateSandboxResponse) GetSandboxId() string {
@@ -935,7 +1031,7 @@ type StreamSandboxEventsRequest struct {
 
 func (x *StreamSandboxEventsRequest) Reset() {
 	*x = StreamSandboxEventsRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[14]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -947,7 +1043,7 @@ func (x *StreamSandboxEventsRequest) String() string {
 func (*StreamSandboxEventsRequest) ProtoMessage() {}
 
 func (x *StreamSandboxEventsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[14]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -960,7 +1056,7 @@ func (x *StreamSandboxEventsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamSandboxEventsRequest.ProtoReflect.Descriptor instead.
 func (*StreamSandboxEventsRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{14}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *StreamSandboxEventsRequest) GetSandboxId() string {
@@ -989,7 +1085,7 @@ type SandboxEvent struct {
 
 func (x *SandboxEvent) Reset() {
 	*x = SandboxEvent{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[15]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1001,7 +1097,7 @@ func (x *SandboxEvent) String() string {
 func (*SandboxEvent) ProtoMessage() {}
 
 func (x *SandboxEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[15]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1014,7 +1110,7 @@ func (x *SandboxEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxEvent.ProtoReflect.Descriptor instead.
 func (*SandboxEvent) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{15}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *SandboxEvent) GetSandboxId() string {
@@ -1062,7 +1158,7 @@ type Execution struct {
 
 func (x *Execution) Reset() {
 	*x = Execution{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[16]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1074,7 +1170,7 @@ func (x *Execution) String() string {
 func (*Execution) ProtoMessage() {}
 
 func (x *Execution) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[16]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1087,7 +1183,7 @@ func (x *Execution) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Execution.ProtoReflect.Descriptor instead.
 func (*Execution) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{16}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *Execution) GetExecutionId() string {
@@ -1163,7 +1259,7 @@ type ExecutionOptions struct {
 
 func (x *ExecutionOptions) Reset() {
 	*x = ExecutionOptions{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[17]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1175,7 +1271,7 @@ func (x *ExecutionOptions) String() string {
 func (*ExecutionOptions) ProtoMessage() {}
 
 func (x *ExecutionOptions) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[17]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1188,7 +1284,7 @@ func (x *ExecutionOptions) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionOptions.ProtoReflect.Descriptor instead.
 func (*ExecutionOptions) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{17}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *ExecutionOptions) GetLaunchSeconds() int64 {
@@ -1216,7 +1312,7 @@ type CreateExecutionRequest struct {
 
 func (x *CreateExecutionRequest) Reset() {
 	*x = CreateExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[18]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1228,7 +1324,7 @@ func (x *CreateExecutionRequest) String() string {
 func (*CreateExecutionRequest) ProtoMessage() {}
 
 func (x *CreateExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[18]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1241,7 +1337,7 @@ func (x *CreateExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateExecutionRequest.ProtoReflect.Descriptor instead.
 func (*CreateExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{18}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *CreateExecutionRequest) GetSandboxId() string {
@@ -1274,7 +1370,7 @@ type CreateExecutionResponse struct {
 
 func (x *CreateExecutionResponse) Reset() {
 	*x = CreateExecutionResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[19]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1286,7 +1382,7 @@ func (x *CreateExecutionResponse) String() string {
 func (*CreateExecutionResponse) ProtoMessage() {}
 
 func (x *CreateExecutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[19]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1299,7 +1395,7 @@ func (x *CreateExecutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateExecutionResponse.ProtoReflect.Descriptor instead.
 func (*CreateExecutionResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{19}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *CreateExecutionResponse) GetExecution() *Execution {
@@ -1319,7 +1415,7 @@ type GetExecutionRequest struct {
 
 func (x *GetExecutionRequest) Reset() {
 	*x = GetExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[20]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1331,7 +1427,7 @@ func (x *GetExecutionRequest) String() string {
 func (*GetExecutionRequest) ProtoMessage() {}
 
 func (x *GetExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[20]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1344,7 +1440,7 @@ func (x *GetExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetExecutionRequest.ProtoReflect.Descriptor instead.
 func (*GetExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{20}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *GetExecutionRequest) GetSandboxId() string {
@@ -1370,7 +1466,7 @@ type GetExecutionResponse struct {
 
 func (x *GetExecutionResponse) Reset() {
 	*x = GetExecutionResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[21]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1382,7 +1478,7 @@ func (x *GetExecutionResponse) String() string {
 func (*GetExecutionResponse) ProtoMessage() {}
 
 func (x *GetExecutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[21]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1395,7 +1491,7 @@ func (x *GetExecutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetExecutionResponse.ProtoReflect.Descriptor instead.
 func (*GetExecutionResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{21}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *GetExecutionResponse) GetExecution() *Execution {
@@ -1416,7 +1512,7 @@ type CancelExecutionRequest struct {
 
 func (x *CancelExecutionRequest) Reset() {
 	*x = CancelExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[22]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1428,7 +1524,7 @@ func (x *CancelExecutionRequest) String() string {
 func (*CancelExecutionRequest) ProtoMessage() {}
 
 func (x *CancelExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[22]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1441,7 +1537,7 @@ func (x *CancelExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelExecutionRequest.ProtoReflect.Descriptor instead.
 func (*CancelExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{22}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *CancelExecutionRequest) GetSandboxId() string {
@@ -1477,7 +1573,7 @@ type CancelExecutionResponse struct {
 
 func (x *CancelExecutionResponse) Reset() {
 	*x = CancelExecutionResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[23]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1489,7 +1585,7 @@ func (x *CancelExecutionResponse) String() string {
 func (*CancelExecutionResponse) ProtoMessage() {}
 
 func (x *CancelExecutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[23]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1502,7 +1598,7 @@ func (x *CancelExecutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelExecutionResponse.ProtoReflect.Descriptor instead.
 func (*CancelExecutionResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{23}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *CancelExecutionResponse) GetSandboxId() string {
@@ -1544,7 +1640,7 @@ type StreamExecutionRequest struct {
 
 func (x *StreamExecutionRequest) Reset() {
 	*x = StreamExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[24]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1556,7 +1652,7 @@ func (x *StreamExecutionRequest) String() string {
 func (*StreamExecutionRequest) ProtoMessage() {}
 
 func (x *StreamExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[24]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1569,7 +1665,7 @@ func (x *StreamExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamExecutionRequest.ProtoReflect.Descriptor instead.
 func (*StreamExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{24}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *StreamExecutionRequest) GetSandboxId() string {
@@ -1604,7 +1700,7 @@ type ExecutionExit struct {
 
 func (x *ExecutionExit) Reset() {
 	*x = ExecutionExit{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[25]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1616,7 +1712,7 @@ func (x *ExecutionExit) String() string {
 func (*ExecutionExit) ProtoMessage() {}
 
 func (x *ExecutionExit) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[25]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1629,7 +1725,7 @@ func (x *ExecutionExit) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionExit.ProtoReflect.Descriptor instead.
 func (*ExecutionExit) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{25}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *ExecutionExit) GetExitCode() int32 {
@@ -1674,7 +1770,7 @@ type ExecutionStreamEvent struct {
 
 func (x *ExecutionStreamEvent) Reset() {
 	*x = ExecutionStreamEvent{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[26]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1686,7 +1782,7 @@ func (x *ExecutionStreamEvent) String() string {
 func (*ExecutionStreamEvent) ProtoMessage() {}
 
 func (x *ExecutionStreamEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[26]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1699,7 +1795,7 @@ func (x *ExecutionStreamEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionStreamEvent.ProtoReflect.Descriptor instead.
 func (*ExecutionStreamEvent) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{26}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *ExecutionStreamEvent) GetSandboxId() string {
@@ -1825,7 +1921,7 @@ type ExecutionAttachOpen struct {
 
 func (x *ExecutionAttachOpen) Reset() {
 	*x = ExecutionAttachOpen{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[27]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1837,7 +1933,7 @@ func (x *ExecutionAttachOpen) String() string {
 func (*ExecutionAttachOpen) ProtoMessage() {}
 
 func (x *ExecutionAttachOpen) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[27]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1850,7 +1946,7 @@ func (x *ExecutionAttachOpen) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionAttachOpen.ProtoReflect.Descriptor instead.
 func (*ExecutionAttachOpen) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{27}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *ExecutionAttachOpen) GetSandboxId() string {
@@ -1877,7 +1973,7 @@ type ExecutionResize struct {
 
 func (x *ExecutionResize) Reset() {
 	*x = ExecutionResize{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[28]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1889,7 +1985,7 @@ func (x *ExecutionResize) String() string {
 func (*ExecutionResize) ProtoMessage() {}
 
 func (x *ExecutionResize) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[28]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1902,7 +1998,7 @@ func (x *ExecutionResize) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionResize.ProtoReflect.Descriptor instead.
 func (*ExecutionResize) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{28}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *ExecutionResize) GetCols() uint32 {
@@ -1928,7 +2024,7 @@ type ExecutionSignal struct {
 
 func (x *ExecutionSignal) Reset() {
 	*x = ExecutionSignal{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[29]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1940,7 +2036,7 @@ func (x *ExecutionSignal) String() string {
 func (*ExecutionSignal) ProtoMessage() {}
 
 func (x *ExecutionSignal) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[29]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1953,7 +2049,7 @@ func (x *ExecutionSignal) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionSignal.ProtoReflect.Descriptor instead.
 func (*ExecutionSignal) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{29}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *ExecutionSignal) GetSignal() int32 {
@@ -1971,7 +2067,7 @@ type ExecutionHeartbeat struct {
 
 func (x *ExecutionHeartbeat) Reset() {
 	*x = ExecutionHeartbeat{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[30]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1983,7 +2079,7 @@ func (x *ExecutionHeartbeat) String() string {
 func (*ExecutionHeartbeat) ProtoMessage() {}
 
 func (x *ExecutionHeartbeat) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[30]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1996,7 +2092,7 @@ func (x *ExecutionHeartbeat) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionHeartbeat.ProtoReflect.Descriptor instead.
 func (*ExecutionHeartbeat) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{30}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{32}
 }
 
 type ExecutionClose struct {
@@ -2008,7 +2104,7 @@ type ExecutionClose struct {
 
 func (x *ExecutionClose) Reset() {
 	*x = ExecutionClose{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[31]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2020,7 +2116,7 @@ func (x *ExecutionClose) String() string {
 func (*ExecutionClose) ProtoMessage() {}
 
 func (x *ExecutionClose) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[31]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2033,7 +2129,7 @@ func (x *ExecutionClose) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionClose.ProtoReflect.Descriptor instead.
 func (*ExecutionClose) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{31}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *ExecutionClose) GetDetach() bool {
@@ -2067,7 +2163,7 @@ type ExecutionAttachFrame struct {
 
 func (x *ExecutionAttachFrame) Reset() {
 	*x = ExecutionAttachFrame{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[32]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2079,7 +2175,7 @@ func (x *ExecutionAttachFrame) String() string {
 func (*ExecutionAttachFrame) ProtoMessage() {}
 
 func (x *ExecutionAttachFrame) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[32]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2092,7 +2188,7 @@ func (x *ExecutionAttachFrame) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionAttachFrame.ProtoReflect.Descriptor instead.
 func (*ExecutionAttachFrame) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{32}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *ExecutionAttachFrame) GetSandboxId() string {
@@ -2295,14 +2391,19 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"updated_at\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\tupdatedAt\";\n" +
 	"\x0fPolicyAllowRule\x12\x12\n" +
 	"\x04host\x18\x01 \x01(\tR\x04host\x12\x14\n" +
-	"\x05ports\x18\x02 \x03(\x05R\x05ports\"\xd4\x01\n" +
+	"\x05ports\x18\x02 \x03(\x05R\x05ports\"1\n" +
+	"\x13PolicyDockerService\x12\x1a\n" +
+	"\brequired\x18\x01 \x01(\bR\brequired\"K\n" +
+	"\x0ePolicyServices\x129\n" +
+	"\x06docker\x18\x01 \x01(\v2!.cleanroom.v1.PolicyDockerServiceR\x06docker\"\x8e\x02\n" +
 	"\x06Policy\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\x05R\aversion\x12\x1b\n" +
 	"\timage_ref\x18\x02 \x01(\tR\bimageRef\x12!\n" +
 	"\fimage_digest\x18\x03 \x01(\tR\vimageDigest\x12'\n" +
 	"\x0fnetwork_default\x18\x04 \x01(\tR\x0enetworkDefault\x123\n" +
 	"\x05allow\x18\x05 \x03(\v2\x1d.cleanroom.v1.PolicyAllowRuleR\x05allow\x12\x12\n" +
-	"\x04hash\x18\x06 \x01(\tR\x04hash\"R\n" +
+	"\x04hash\x18\x06 \x01(\tR\x04hash\x128\n" +
+	"\bservices\x18\a \x01(\v2\x1c.cleanroom.v1.PolicyServicesR\bservices\"R\n" +
 	"\x0eSandboxOptions\x12%\n" +
 	"\x0elaunch_seconds\x18\x03 \x01(\x03R\rlaunchSecondsJ\x04\b\x02\x10\x03R\x13read_only_workspace\"\xa1\x01\n" +
 	"\x14CreateSandboxRequest\x12\x18\n" +
@@ -2491,102 +2592,106 @@ func file_proto_cleanroom_v1_control_proto_rawDescGZIP() []byte {
 }
 
 var file_proto_cleanroom_v1_control_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_proto_cleanroom_v1_control_proto_msgTypes = make([]protoimpl.MessageInfo, 33)
+var file_proto_cleanroom_v1_control_proto_msgTypes = make([]protoimpl.MessageInfo, 35)
 var file_proto_cleanroom_v1_control_proto_goTypes = []any{
 	(SandboxStatus)(0),                  // 0: cleanroom.v1.SandboxStatus
 	(ExecutionStatus)(0),                // 1: cleanroom.v1.ExecutionStatus
 	(*Sandbox)(nil),                     // 2: cleanroom.v1.Sandbox
 	(*PolicyAllowRule)(nil),             // 3: cleanroom.v1.PolicyAllowRule
-	(*Policy)(nil),                      // 4: cleanroom.v1.Policy
-	(*SandboxOptions)(nil),              // 5: cleanroom.v1.SandboxOptions
-	(*CreateSandboxRequest)(nil),        // 6: cleanroom.v1.CreateSandboxRequest
-	(*CreateSandboxResponse)(nil),       // 7: cleanroom.v1.CreateSandboxResponse
-	(*GetSandboxRequest)(nil),           // 8: cleanroom.v1.GetSandboxRequest
-	(*GetSandboxResponse)(nil),          // 9: cleanroom.v1.GetSandboxResponse
-	(*ListSandboxesRequest)(nil),        // 10: cleanroom.v1.ListSandboxesRequest
-	(*ListSandboxesResponse)(nil),       // 11: cleanroom.v1.ListSandboxesResponse
-	(*DownloadSandboxFileRequest)(nil),  // 12: cleanroom.v1.DownloadSandboxFileRequest
-	(*DownloadSandboxFileResponse)(nil), // 13: cleanroom.v1.DownloadSandboxFileResponse
-	(*TerminateSandboxRequest)(nil),     // 14: cleanroom.v1.TerminateSandboxRequest
-	(*TerminateSandboxResponse)(nil),    // 15: cleanroom.v1.TerminateSandboxResponse
-	(*StreamSandboxEventsRequest)(nil),  // 16: cleanroom.v1.StreamSandboxEventsRequest
-	(*SandboxEvent)(nil),                // 17: cleanroom.v1.SandboxEvent
-	(*Execution)(nil),                   // 18: cleanroom.v1.Execution
-	(*ExecutionOptions)(nil),            // 19: cleanroom.v1.ExecutionOptions
-	(*CreateExecutionRequest)(nil),      // 20: cleanroom.v1.CreateExecutionRequest
-	(*CreateExecutionResponse)(nil),     // 21: cleanroom.v1.CreateExecutionResponse
-	(*GetExecutionRequest)(nil),         // 22: cleanroom.v1.GetExecutionRequest
-	(*GetExecutionResponse)(nil),        // 23: cleanroom.v1.GetExecutionResponse
-	(*CancelExecutionRequest)(nil),      // 24: cleanroom.v1.CancelExecutionRequest
-	(*CancelExecutionResponse)(nil),     // 25: cleanroom.v1.CancelExecutionResponse
-	(*StreamExecutionRequest)(nil),      // 26: cleanroom.v1.StreamExecutionRequest
-	(*ExecutionExit)(nil),               // 27: cleanroom.v1.ExecutionExit
-	(*ExecutionStreamEvent)(nil),        // 28: cleanroom.v1.ExecutionStreamEvent
-	(*ExecutionAttachOpen)(nil),         // 29: cleanroom.v1.ExecutionAttachOpen
-	(*ExecutionResize)(nil),             // 30: cleanroom.v1.ExecutionResize
-	(*ExecutionSignal)(nil),             // 31: cleanroom.v1.ExecutionSignal
-	(*ExecutionHeartbeat)(nil),          // 32: cleanroom.v1.ExecutionHeartbeat
-	(*ExecutionClose)(nil),              // 33: cleanroom.v1.ExecutionClose
-	(*ExecutionAttachFrame)(nil),        // 34: cleanroom.v1.ExecutionAttachFrame
-	(*timestamppb.Timestamp)(nil),       // 35: google.protobuf.Timestamp
+	(*PolicyDockerService)(nil),         // 4: cleanroom.v1.PolicyDockerService
+	(*PolicyServices)(nil),              // 5: cleanroom.v1.PolicyServices
+	(*Policy)(nil),                      // 6: cleanroom.v1.Policy
+	(*SandboxOptions)(nil),              // 7: cleanroom.v1.SandboxOptions
+	(*CreateSandboxRequest)(nil),        // 8: cleanroom.v1.CreateSandboxRequest
+	(*CreateSandboxResponse)(nil),       // 9: cleanroom.v1.CreateSandboxResponse
+	(*GetSandboxRequest)(nil),           // 10: cleanroom.v1.GetSandboxRequest
+	(*GetSandboxResponse)(nil),          // 11: cleanroom.v1.GetSandboxResponse
+	(*ListSandboxesRequest)(nil),        // 12: cleanroom.v1.ListSandboxesRequest
+	(*ListSandboxesResponse)(nil),       // 13: cleanroom.v1.ListSandboxesResponse
+	(*DownloadSandboxFileRequest)(nil),  // 14: cleanroom.v1.DownloadSandboxFileRequest
+	(*DownloadSandboxFileResponse)(nil), // 15: cleanroom.v1.DownloadSandboxFileResponse
+	(*TerminateSandboxRequest)(nil),     // 16: cleanroom.v1.TerminateSandboxRequest
+	(*TerminateSandboxResponse)(nil),    // 17: cleanroom.v1.TerminateSandboxResponse
+	(*StreamSandboxEventsRequest)(nil),  // 18: cleanroom.v1.StreamSandboxEventsRequest
+	(*SandboxEvent)(nil),                // 19: cleanroom.v1.SandboxEvent
+	(*Execution)(nil),                   // 20: cleanroom.v1.Execution
+	(*ExecutionOptions)(nil),            // 21: cleanroom.v1.ExecutionOptions
+	(*CreateExecutionRequest)(nil),      // 22: cleanroom.v1.CreateExecutionRequest
+	(*CreateExecutionResponse)(nil),     // 23: cleanroom.v1.CreateExecutionResponse
+	(*GetExecutionRequest)(nil),         // 24: cleanroom.v1.GetExecutionRequest
+	(*GetExecutionResponse)(nil),        // 25: cleanroom.v1.GetExecutionResponse
+	(*CancelExecutionRequest)(nil),      // 26: cleanroom.v1.CancelExecutionRequest
+	(*CancelExecutionResponse)(nil),     // 27: cleanroom.v1.CancelExecutionResponse
+	(*StreamExecutionRequest)(nil),      // 28: cleanroom.v1.StreamExecutionRequest
+	(*ExecutionExit)(nil),               // 29: cleanroom.v1.ExecutionExit
+	(*ExecutionStreamEvent)(nil),        // 30: cleanroom.v1.ExecutionStreamEvent
+	(*ExecutionAttachOpen)(nil),         // 31: cleanroom.v1.ExecutionAttachOpen
+	(*ExecutionResize)(nil),             // 32: cleanroom.v1.ExecutionResize
+	(*ExecutionSignal)(nil),             // 33: cleanroom.v1.ExecutionSignal
+	(*ExecutionHeartbeat)(nil),          // 34: cleanroom.v1.ExecutionHeartbeat
+	(*ExecutionClose)(nil),              // 35: cleanroom.v1.ExecutionClose
+	(*ExecutionAttachFrame)(nil),        // 36: cleanroom.v1.ExecutionAttachFrame
+	(*timestamppb.Timestamp)(nil),       // 37: google.protobuf.Timestamp
 }
 var file_proto_cleanroom_v1_control_proto_depIdxs = []int32{
 	0,  // 0: cleanroom.v1.Sandbox.status:type_name -> cleanroom.v1.SandboxStatus
-	35, // 1: cleanroom.v1.Sandbox.created_at:type_name -> google.protobuf.Timestamp
-	35, // 2: cleanroom.v1.Sandbox.updated_at:type_name -> google.protobuf.Timestamp
-	3,  // 3: cleanroom.v1.Policy.allow:type_name -> cleanroom.v1.PolicyAllowRule
-	5,  // 4: cleanroom.v1.CreateSandboxRequest.options:type_name -> cleanroom.v1.SandboxOptions
-	4,  // 5: cleanroom.v1.CreateSandboxRequest.policy:type_name -> cleanroom.v1.Policy
-	2,  // 6: cleanroom.v1.CreateSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
-	2,  // 7: cleanroom.v1.GetSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
-	2,  // 8: cleanroom.v1.ListSandboxesResponse.sandboxes:type_name -> cleanroom.v1.Sandbox
-	0,  // 9: cleanroom.v1.SandboxEvent.status:type_name -> cleanroom.v1.SandboxStatus
-	35, // 10: cleanroom.v1.SandboxEvent.occurred_at:type_name -> google.protobuf.Timestamp
-	1,  // 11: cleanroom.v1.Execution.status:type_name -> cleanroom.v1.ExecutionStatus
-	35, // 12: cleanroom.v1.Execution.started_at:type_name -> google.protobuf.Timestamp
-	35, // 13: cleanroom.v1.Execution.finished_at:type_name -> google.protobuf.Timestamp
-	19, // 14: cleanroom.v1.CreateExecutionRequest.options:type_name -> cleanroom.v1.ExecutionOptions
-	18, // 15: cleanroom.v1.CreateExecutionResponse.execution:type_name -> cleanroom.v1.Execution
-	18, // 16: cleanroom.v1.GetExecutionResponse.execution:type_name -> cleanroom.v1.Execution
-	1,  // 17: cleanroom.v1.CancelExecutionResponse.status:type_name -> cleanroom.v1.ExecutionStatus
-	1,  // 18: cleanroom.v1.ExecutionExit.status:type_name -> cleanroom.v1.ExecutionStatus
-	1,  // 19: cleanroom.v1.ExecutionStreamEvent.status:type_name -> cleanroom.v1.ExecutionStatus
-	27, // 20: cleanroom.v1.ExecutionStreamEvent.exit:type_name -> cleanroom.v1.ExecutionExit
-	35, // 21: cleanroom.v1.ExecutionStreamEvent.occurred_at:type_name -> google.protobuf.Timestamp
-	29, // 22: cleanroom.v1.ExecutionAttachFrame.open:type_name -> cleanroom.v1.ExecutionAttachOpen
-	30, // 23: cleanroom.v1.ExecutionAttachFrame.resize:type_name -> cleanroom.v1.ExecutionResize
-	31, // 24: cleanroom.v1.ExecutionAttachFrame.signal:type_name -> cleanroom.v1.ExecutionSignal
-	32, // 25: cleanroom.v1.ExecutionAttachFrame.heartbeat:type_name -> cleanroom.v1.ExecutionHeartbeat
-	33, // 26: cleanroom.v1.ExecutionAttachFrame.close:type_name -> cleanroom.v1.ExecutionClose
-	27, // 27: cleanroom.v1.ExecutionAttachFrame.exit:type_name -> cleanroom.v1.ExecutionExit
-	35, // 28: cleanroom.v1.ExecutionAttachFrame.occurred_at:type_name -> google.protobuf.Timestamp
-	6,  // 29: cleanroom.v1.SandboxService.CreateSandbox:input_type -> cleanroom.v1.CreateSandboxRequest
-	8,  // 30: cleanroom.v1.SandboxService.GetSandbox:input_type -> cleanroom.v1.GetSandboxRequest
-	10, // 31: cleanroom.v1.SandboxService.ListSandboxes:input_type -> cleanroom.v1.ListSandboxesRequest
-	12, // 32: cleanroom.v1.SandboxService.DownloadSandboxFile:input_type -> cleanroom.v1.DownloadSandboxFileRequest
-	14, // 33: cleanroom.v1.SandboxService.TerminateSandbox:input_type -> cleanroom.v1.TerminateSandboxRequest
-	16, // 34: cleanroom.v1.SandboxService.StreamSandboxEvents:input_type -> cleanroom.v1.StreamSandboxEventsRequest
-	20, // 35: cleanroom.v1.ExecutionService.CreateExecution:input_type -> cleanroom.v1.CreateExecutionRequest
-	22, // 36: cleanroom.v1.ExecutionService.GetExecution:input_type -> cleanroom.v1.GetExecutionRequest
-	24, // 37: cleanroom.v1.ExecutionService.CancelExecution:input_type -> cleanroom.v1.CancelExecutionRequest
-	26, // 38: cleanroom.v1.ExecutionService.StreamExecution:input_type -> cleanroom.v1.StreamExecutionRequest
-	34, // 39: cleanroom.v1.ExecutionService.AttachExecution:input_type -> cleanroom.v1.ExecutionAttachFrame
-	7,  // 40: cleanroom.v1.SandboxService.CreateSandbox:output_type -> cleanroom.v1.CreateSandboxResponse
-	9,  // 41: cleanroom.v1.SandboxService.GetSandbox:output_type -> cleanroom.v1.GetSandboxResponse
-	11, // 42: cleanroom.v1.SandboxService.ListSandboxes:output_type -> cleanroom.v1.ListSandboxesResponse
-	13, // 43: cleanroom.v1.SandboxService.DownloadSandboxFile:output_type -> cleanroom.v1.DownloadSandboxFileResponse
-	15, // 44: cleanroom.v1.SandboxService.TerminateSandbox:output_type -> cleanroom.v1.TerminateSandboxResponse
-	17, // 45: cleanroom.v1.SandboxService.StreamSandboxEvents:output_type -> cleanroom.v1.SandboxEvent
-	21, // 46: cleanroom.v1.ExecutionService.CreateExecution:output_type -> cleanroom.v1.CreateExecutionResponse
-	23, // 47: cleanroom.v1.ExecutionService.GetExecution:output_type -> cleanroom.v1.GetExecutionResponse
-	25, // 48: cleanroom.v1.ExecutionService.CancelExecution:output_type -> cleanroom.v1.CancelExecutionResponse
-	28, // 49: cleanroom.v1.ExecutionService.StreamExecution:output_type -> cleanroom.v1.ExecutionStreamEvent
-	34, // 50: cleanroom.v1.ExecutionService.AttachExecution:output_type -> cleanroom.v1.ExecutionAttachFrame
-	40, // [40:51] is the sub-list for method output_type
-	29, // [29:40] is the sub-list for method input_type
-	29, // [29:29] is the sub-list for extension type_name
-	29, // [29:29] is the sub-list for extension extendee
-	0,  // [0:29] is the sub-list for field type_name
+	37, // 1: cleanroom.v1.Sandbox.created_at:type_name -> google.protobuf.Timestamp
+	37, // 2: cleanroom.v1.Sandbox.updated_at:type_name -> google.protobuf.Timestamp
+	4,  // 3: cleanroom.v1.PolicyServices.docker:type_name -> cleanroom.v1.PolicyDockerService
+	3,  // 4: cleanroom.v1.Policy.allow:type_name -> cleanroom.v1.PolicyAllowRule
+	5,  // 5: cleanroom.v1.Policy.services:type_name -> cleanroom.v1.PolicyServices
+	7,  // 6: cleanroom.v1.CreateSandboxRequest.options:type_name -> cleanroom.v1.SandboxOptions
+	6,  // 7: cleanroom.v1.CreateSandboxRequest.policy:type_name -> cleanroom.v1.Policy
+	2,  // 8: cleanroom.v1.CreateSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
+	2,  // 9: cleanroom.v1.GetSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
+	2,  // 10: cleanroom.v1.ListSandboxesResponse.sandboxes:type_name -> cleanroom.v1.Sandbox
+	0,  // 11: cleanroom.v1.SandboxEvent.status:type_name -> cleanroom.v1.SandboxStatus
+	37, // 12: cleanroom.v1.SandboxEvent.occurred_at:type_name -> google.protobuf.Timestamp
+	1,  // 13: cleanroom.v1.Execution.status:type_name -> cleanroom.v1.ExecutionStatus
+	37, // 14: cleanroom.v1.Execution.started_at:type_name -> google.protobuf.Timestamp
+	37, // 15: cleanroom.v1.Execution.finished_at:type_name -> google.protobuf.Timestamp
+	21, // 16: cleanroom.v1.CreateExecutionRequest.options:type_name -> cleanroom.v1.ExecutionOptions
+	20, // 17: cleanroom.v1.CreateExecutionResponse.execution:type_name -> cleanroom.v1.Execution
+	20, // 18: cleanroom.v1.GetExecutionResponse.execution:type_name -> cleanroom.v1.Execution
+	1,  // 19: cleanroom.v1.CancelExecutionResponse.status:type_name -> cleanroom.v1.ExecutionStatus
+	1,  // 20: cleanroom.v1.ExecutionExit.status:type_name -> cleanroom.v1.ExecutionStatus
+	1,  // 21: cleanroom.v1.ExecutionStreamEvent.status:type_name -> cleanroom.v1.ExecutionStatus
+	29, // 22: cleanroom.v1.ExecutionStreamEvent.exit:type_name -> cleanroom.v1.ExecutionExit
+	37, // 23: cleanroom.v1.ExecutionStreamEvent.occurred_at:type_name -> google.protobuf.Timestamp
+	31, // 24: cleanroom.v1.ExecutionAttachFrame.open:type_name -> cleanroom.v1.ExecutionAttachOpen
+	32, // 25: cleanroom.v1.ExecutionAttachFrame.resize:type_name -> cleanroom.v1.ExecutionResize
+	33, // 26: cleanroom.v1.ExecutionAttachFrame.signal:type_name -> cleanroom.v1.ExecutionSignal
+	34, // 27: cleanroom.v1.ExecutionAttachFrame.heartbeat:type_name -> cleanroom.v1.ExecutionHeartbeat
+	35, // 28: cleanroom.v1.ExecutionAttachFrame.close:type_name -> cleanroom.v1.ExecutionClose
+	29, // 29: cleanroom.v1.ExecutionAttachFrame.exit:type_name -> cleanroom.v1.ExecutionExit
+	37, // 30: cleanroom.v1.ExecutionAttachFrame.occurred_at:type_name -> google.protobuf.Timestamp
+	8,  // 31: cleanroom.v1.SandboxService.CreateSandbox:input_type -> cleanroom.v1.CreateSandboxRequest
+	10, // 32: cleanroom.v1.SandboxService.GetSandbox:input_type -> cleanroom.v1.GetSandboxRequest
+	12, // 33: cleanroom.v1.SandboxService.ListSandboxes:input_type -> cleanroom.v1.ListSandboxesRequest
+	14, // 34: cleanroom.v1.SandboxService.DownloadSandboxFile:input_type -> cleanroom.v1.DownloadSandboxFileRequest
+	16, // 35: cleanroom.v1.SandboxService.TerminateSandbox:input_type -> cleanroom.v1.TerminateSandboxRequest
+	18, // 36: cleanroom.v1.SandboxService.StreamSandboxEvents:input_type -> cleanroom.v1.StreamSandboxEventsRequest
+	22, // 37: cleanroom.v1.ExecutionService.CreateExecution:input_type -> cleanroom.v1.CreateExecutionRequest
+	24, // 38: cleanroom.v1.ExecutionService.GetExecution:input_type -> cleanroom.v1.GetExecutionRequest
+	26, // 39: cleanroom.v1.ExecutionService.CancelExecution:input_type -> cleanroom.v1.CancelExecutionRequest
+	28, // 40: cleanroom.v1.ExecutionService.StreamExecution:input_type -> cleanroom.v1.StreamExecutionRequest
+	36, // 41: cleanroom.v1.ExecutionService.AttachExecution:input_type -> cleanroom.v1.ExecutionAttachFrame
+	9,  // 42: cleanroom.v1.SandboxService.CreateSandbox:output_type -> cleanroom.v1.CreateSandboxResponse
+	11, // 43: cleanroom.v1.SandboxService.GetSandbox:output_type -> cleanroom.v1.GetSandboxResponse
+	13, // 44: cleanroom.v1.SandboxService.ListSandboxes:output_type -> cleanroom.v1.ListSandboxesResponse
+	15, // 45: cleanroom.v1.SandboxService.DownloadSandboxFile:output_type -> cleanroom.v1.DownloadSandboxFileResponse
+	17, // 46: cleanroom.v1.SandboxService.TerminateSandbox:output_type -> cleanroom.v1.TerminateSandboxResponse
+	19, // 47: cleanroom.v1.SandboxService.StreamSandboxEvents:output_type -> cleanroom.v1.SandboxEvent
+	23, // 48: cleanroom.v1.ExecutionService.CreateExecution:output_type -> cleanroom.v1.CreateExecutionResponse
+	25, // 49: cleanroom.v1.ExecutionService.GetExecution:output_type -> cleanroom.v1.GetExecutionResponse
+	27, // 50: cleanroom.v1.ExecutionService.CancelExecution:output_type -> cleanroom.v1.CancelExecutionResponse
+	30, // 51: cleanroom.v1.ExecutionService.StreamExecution:output_type -> cleanroom.v1.ExecutionStreamEvent
+	36, // 52: cleanroom.v1.ExecutionService.AttachExecution:output_type -> cleanroom.v1.ExecutionAttachFrame
+	42, // [42:53] is the sub-list for method output_type
+	31, // [31:42] is the sub-list for method input_type
+	31, // [31:31] is the sub-list for extension type_name
+	31, // [31:31] is the sub-list for extension extendee
+	0,  // [0:31] is the sub-list for field type_name
 }
 
 func init() { file_proto_cleanroom_v1_control_proto_init() }
@@ -2594,13 +2699,13 @@ func file_proto_cleanroom_v1_control_proto_init() {
 	if File_proto_cleanroom_v1_control_proto != nil {
 		return
 	}
-	file_proto_cleanroom_v1_control_proto_msgTypes[26].OneofWrappers = []any{
+	file_proto_cleanroom_v1_control_proto_msgTypes[28].OneofWrappers = []any{
 		(*ExecutionStreamEvent_Stdout)(nil),
 		(*ExecutionStreamEvent_Stderr)(nil),
 		(*ExecutionStreamEvent_Exit)(nil),
 		(*ExecutionStreamEvent_Message)(nil),
 	}
-	file_proto_cleanroom_v1_control_proto_msgTypes[32].OneofWrappers = []any{
+	file_proto_cleanroom_v1_control_proto_msgTypes[34].OneofWrappers = []any{
 		(*ExecutionAttachFrame_Open)(nil),
 		(*ExecutionAttachFrame_Stdin)(nil),
 		(*ExecutionAttachFrame_Resize)(nil),
@@ -2618,7 +2723,7 @@ func file_proto_cleanroom_v1_control_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proto_cleanroom_v1_control_proto_rawDesc), len(file_proto_cleanroom_v1_control_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   33,
+			NumMessages:   35,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/internal/runtimeconfig/config.go
+++ b/internal/runtimeconfig/config.go
@@ -21,25 +21,37 @@ type Backends struct {
 }
 
 type FirecrackerConfig struct {
-	BinaryPath           string `yaml:"binary_path"`
-	KernelImage          string `yaml:"kernel_image"`
-	RootFS               string `yaml:"rootfs"`
-	PrivilegedMode       string `yaml:"privileged_mode"`
-	PrivilegedHelperPath string `yaml:"privileged_helper_path"`
-	VCPUs                int64  `yaml:"vcpus"`
-	MemoryMiB            int64  `yaml:"memory_mib"`
-	GuestCID             uint32 `yaml:"guest_cid"`
-	GuestPort            uint32 `yaml:"guest_port"`
-	LaunchSeconds        int64  `yaml:"launch_seconds"` // VM boot/guest-agent readiness timeout
+	BinaryPath           string         `yaml:"binary_path"`
+	KernelImage          string         `yaml:"kernel_image"`
+	RootFS               string         `yaml:"rootfs"`
+	Services             ServicesConfig `yaml:"services"`
+	PrivilegedMode       string         `yaml:"privileged_mode"`
+	PrivilegedHelperPath string         `yaml:"privileged_helper_path"`
+	VCPUs                int64          `yaml:"vcpus"`
+	MemoryMiB            int64          `yaml:"memory_mib"`
+	GuestCID             uint32         `yaml:"guest_cid"`
+	GuestPort            uint32         `yaml:"guest_port"`
+	LaunchSeconds        int64          `yaml:"launch_seconds"` // VM boot/guest-agent readiness timeout
 }
 
 type DarwinVZConfig struct {
-	KernelImage   string `yaml:"kernel_image"`
-	RootFS        string `yaml:"rootfs"`
-	VCPUs         int64  `yaml:"vcpus"`
-	MemoryMiB     int64  `yaml:"memory_mib"`
-	GuestPort     uint32 `yaml:"guest_port"`
-	LaunchSeconds int64  `yaml:"launch_seconds"` // VM boot/guest-agent readiness timeout
+	KernelImage   string         `yaml:"kernel_image"`
+	RootFS        string         `yaml:"rootfs"`
+	Services      ServicesConfig `yaml:"services"`
+	VCPUs         int64          `yaml:"vcpus"`
+	MemoryMiB     int64          `yaml:"memory_mib"`
+	GuestPort     uint32         `yaml:"guest_port"`
+	LaunchSeconds int64          `yaml:"launch_seconds"` // VM boot/guest-agent readiness timeout
+}
+
+type ServicesConfig struct {
+	Docker DockerServiceConfig `yaml:"docker"`
+}
+
+type DockerServiceConfig struct {
+	StartupTimeoutSeconds int64  `yaml:"startup_timeout_seconds"`
+	StorageDriver         string `yaml:"storage_driver"`
+	IPTables              bool   `yaml:"iptables"`
 }
 
 func Path() (string, error) {
@@ -91,6 +103,9 @@ func Load() (Config, string, error) {
 func darwinVZConfigIsZero(cfg DarwinVZConfig) bool {
 	return strings.TrimSpace(cfg.KernelImage) == "" &&
 		strings.TrimSpace(cfg.RootFS) == "" &&
+		cfg.Services.Docker.StartupTimeoutSeconds == 0 &&
+		strings.TrimSpace(cfg.Services.Docker.StorageDriver) == "" &&
+		!cfg.Services.Docker.IPTables &&
 		cfg.VCPUs == 0 &&
 		cfg.MemoryMiB == 0 &&
 		cfg.GuestPort == 0 &&

--- a/internal/runtimeconfig/config_test.go
+++ b/internal/runtimeconfig/config_test.go
@@ -19,6 +19,11 @@ backends:
   darwin-vz:
     kernel_image: /tmp/kernel
     rootfs: /tmp/rootfs
+    services:
+      docker:
+        startup_timeout_seconds: 25
+        storage_driver: overlay2
+        iptables: true
     vcpus: 2
     memory_mib: 1024
     guest_port: 10700
@@ -34,6 +39,15 @@ backends:
 	}
 	if got, want := cfg.Backends.DarwinVZ.KernelImage, "/tmp/kernel"; got != want {
 		t.Fatalf("unexpected darwin-vz kernel: got %q want %q", got, want)
+	}
+	if got, want := cfg.Backends.DarwinVZ.Services.Docker.StartupTimeoutSeconds, int64(25); got != want {
+		t.Fatalf("unexpected docker startup timeout: got %d want %d", got, want)
+	}
+	if got, want := cfg.Backends.DarwinVZ.Services.Docker.StorageDriver, "overlay2"; got != want {
+		t.Fatalf("unexpected docker storage driver: got %q want %q", got, want)
+	}
+	if !cfg.Backends.DarwinVZ.Services.Docker.IPTables {
+		t.Fatal("expected docker iptables to be enabled")
 	}
 }
 

--- a/proto/cleanroom/v1/control.proto
+++ b/proto/cleanroom/v1/control.proto
@@ -46,6 +46,14 @@ message PolicyAllowRule {
   repeated int32 ports = 2;
 }
 
+message PolicyDockerService {
+  bool required = 1;
+}
+
+message PolicyServices {
+  PolicyDockerService docker = 1;
+}
+
 message Policy {
   int32 version = 1;
   string image_ref = 2;
@@ -53,6 +61,7 @@ message Policy {
   string network_default = 4;
   repeated PolicyAllowRule allow = 5;
   string hash = 6;
+  PolicyServices services = 7;
 }
 
 message SandboxOptions {

--- a/scripts/base-image-tag.sh
+++ b/scripts/base-image-tag.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+image_name="${1:-alpine}"
+dockerfile="${2:-Dockerfile.base-image}"
+
+if [[ ! -f "$dockerfile" ]]; then
+  echo "dockerfile not found: $dockerfile" >&2
+  exit 1
+fi
+
 # Deterministic tag derived from image definition inputs.
-hash="$(sha256sum Dockerfile.base-image | awk '{print $1}')"
-printf 'alpine-%s\n' "${hash:0:12}"
+hash="$(sha256sum "$dockerfile" | awk '{print $1}')"
+printf '%s-%s\n' "$image_name" "${hash:0:12}"

--- a/scripts/prepare-firecracker-image.sh
+++ b/scripts/prepare-firecracker-image.sh
@@ -216,14 +216,34 @@ if command -v ip >/dev/null 2>&1 && [ -n "\$GUEST_IP" ]; then
 fi
 
 export CLEANROOM_VSOCK_PORT=$AGENT_PORT
-if command -v dockerd >/dev/null 2>&1; then
+DOCKER_REQUIRED="\$(arg_value cleanroom_service_docker_required || true)"
+if [ "\$DOCKER_REQUIRED" = "1" ] && command -v dockerd >/dev/null 2>&1; then
+  DOCKER_STARTUP_TIMEOUT="\$(arg_value cleanroom_service_docker_startup_timeout || true)"
+  case "\$DOCKER_STARTUP_TIMEOUT" in
+    ''|*[!0-9]*) DOCKER_STARTUP_TIMEOUT="20" ;;
+  esac
+  if [ "\$DOCKER_STARTUP_TIMEOUT" -le 0 ]; then
+    DOCKER_STARTUP_TIMEOUT="20"
+  fi
+  DOCKER_STORAGE_DRIVER="\$(arg_value cleanroom_service_docker_storage_driver || true)"
+  if [ -z "\$DOCKER_STORAGE_DRIVER" ]; then
+    DOCKER_STORAGE_DRIVER="vfs"
+  fi
+  DOCKER_IPTABLES="\$(arg_value cleanroom_service_docker_iptables || true)"
+
+  DOCKER_ARGS="--host=unix:///var/run/docker.sock --storage-driver=\$DOCKER_STORAGE_DRIVER"
+  if [ "\$DOCKER_IPTABLES" = "0" ] || [ "\$DOCKER_IPTABLES" = "false" ]; then
+    DOCKER_ARGS="\$DOCKER_ARGS --iptables=false"
+  fi
+
   mkdir -p /var/log /var/lib/docker /etc/docker /var/run /sys/fs/cgroup
   mount -t cgroup2 none /sys/fs/cgroup 2>/dev/null || true
   if [ ! -S /var/run/docker.sock ]; then
-    dockerd --host=unix:///var/run/docker.sock --iptables=false --storage-driver=vfs >/var/log/dockerd.log 2>&1 &
+    dockerd \$DOCKER_ARGS >/var/log/dockerd.log 2>&1 &
   fi
   i=0
-  while [ "\$i" -lt 200 ]; do
+  DOCKER_WAIT_TICKS=\$((DOCKER_STARTUP_TIMEOUT * 10))
+  while [ "\$i" -lt "\$DOCKER_WAIT_TICKS" ]; do
     if [ -S /var/run/docker.sock ]; then
       if command -v docker >/dev/null 2>&1; then
         if docker version >/dev/null 2>&1; then

--- a/scripts/prepare-firecracker-image.sh
+++ b/scripts/prepare-firecracker-image.sh
@@ -216,6 +216,27 @@ if command -v ip >/dev/null 2>&1 && [ -n "\$GUEST_IP" ]; then
 fi
 
 export CLEANROOM_VSOCK_PORT=$AGENT_PORT
+if command -v dockerd >/dev/null 2>&1; then
+  mkdir -p /var/log /var/lib/docker /etc/docker /var/run /sys/fs/cgroup
+  mount -t cgroup2 none /sys/fs/cgroup 2>/dev/null || true
+  if [ ! -S /var/run/docker.sock ]; then
+    dockerd --host=unix:///var/run/docker.sock --iptables=false --storage-driver=vfs >/var/log/dockerd.log 2>&1 &
+  fi
+  i=0
+  while [ "\$i" -lt 200 ]; do
+    if [ -S /var/run/docker.sock ]; then
+      if command -v docker >/dev/null 2>&1; then
+        if docker version >/dev/null 2>&1; then
+          break
+        fi
+      else
+        break
+      fi
+    fi
+    sleep 0.1
+    i=\$((i + 1))
+  done
+fi
 while true; do
   /usr/local/bin/cleanroom-guest-agent || true
   sleep 1


### PR DESCRIPTION
## Summary
- add explicit policy contract for Docker service startup:
  - `sandbox.services.docker.required: true`
- extend control proto policy transport with `services.docker.required`
- gate guest `dockerd` startup behind the policy service flag (no implicit startup)
- pass docker service runtime settings to guests via boot args:
  - startup timeout
  - storage driver
  - iptables enable/disable
- add runtime config defaults for docker service tuning under each backend
- keep docker startup logic aligned across darwin-vz, firecracker, and prepared init script
- add/update tests for policy compile/proto mapping, boot arg generation, and guest init templates
- update docker example to use `sandbox.services.docker.required: true`

## Testing
- `mise run test`
- `mise run lint-shell`
- `mise run build:darwin`
- docker service enabled smoke:
  - `cleanroom exec --backend darwin-vz -- docker version`
  - `cleanroom exec --backend darwin-vz -- docker run --rm --network none alpine:3.22 echo docker-service-mvp-ok`
- docker service disabled smoke (same image, no `services.docker.required`):
  - `cleanroom exec --backend darwin-vz -- docker version` returns `Cannot connect to the Docker daemon`
