### PR TITLE
feat: add curl install path and release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,26 +11,41 @@ permissions:
 jobs:
   build-darwin-vz:
     runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: arm64
+            target: arm64-apple-macosx13.0
+          - arch: x86_64
+            target: x86_64-apple-macosx13.0
     steps:
       - uses: actions/checkout@v4
 
       - name: Build cleanroom-darwin-vz
         run: |
           mkdir -p dist
-          xcrun swiftc -O -target arm64-apple-macosx13.0 -framework Virtualization \
+          xcrun swiftc -O -target "${{ matrix.target }}" -framework Virtualization \
             cmd/cleanroom-darwin-vz/main.swift \
             -o dist/cleanroom-darwin-vz
 
       - name: Create archive
         run: |
+          ARCHIVE="cleanroom-darwin-vz_Darwin_${{ matrix.arch }}.tar.gz"
           cp cmd/cleanroom-darwin-vz/entitlements.plist dist/
-          tar -czf "dist/cleanroom-darwin-vz_Darwin_arm64.tar.gz" \
+          tar -czf "dist/${ARCHIVE}" \
             -C dist cleanroom-darwin-vz entitlements.plist
+          (
+            cd dist
+            shasum -a 256 "${ARCHIVE}" > "${ARCHIVE}.sha256"
+          )
 
       - uses: actions/upload-artifact@v4
         with:
-          name: cleanroom-darwin-vz
-          path: dist/cleanroom-darwin-vz_Darwin_arm64.tar.gz
+          name: cleanroom-darwin-vz-${{ matrix.arch }}
+          path: |
+            dist/cleanroom-darwin-vz_Darwin_${{ matrix.arch }}.tar.gz
+            dist/cleanroom-darwin-vz_Darwin_${{ matrix.arch }}.tar.gz.sha256
 
   release:
     runs-on: ubuntu-latest
@@ -53,7 +68,8 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: cleanroom-darwin-vz
+          pattern: cleanroom-darwin-vz-*
+          merge-multiple: true
           path: dist
 
       - name: Upload darwin-vz helper to release
@@ -61,4 +77,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload "${{ github.ref_name }}" \
-            dist/cleanroom-darwin-vz_Darwin_arm64.tar.gz
+            dist/cleanroom-darwin-vz_Darwin_*.tar.gz \
+            dist/cleanroom-darwin-vz_Darwin_*.tar.gz.sha256

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,9 +22,20 @@ builds:
       - -s -w
 
 archives:
-  - formats: [tar.gz]
+  - id: cleanroom
+    ids: [cleanroom]
+    formats: [tar.gz]
     name_template: >-
-      {{ .ProjectName }}_
+      {{ .Binary }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else }}{{ .Arch }}{{ end }}
+
+  - id: cleanroom-guest-agent
+    ids: [cleanroom-guest-agent]
+    formats: [tar.gz]
+    name_template: >-
+      {{ .Binary }}_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else }}{{ .Arch }}{{ end }}

--- a/.mise.toml
+++ b/.mise.toml
@@ -13,7 +13,7 @@ run = "go test ./..."
 
 [tasks.lint-shell]
 description = "Lint shell scripts"
-run = "shellcheck -x scripts/cleanroom-root-helper.sh scripts/benchmark-tti.sh scripts/build-go.sh scripts/install-go.sh scripts/release.sh"
+run = "shellcheck -x scripts/cleanroom-root-helper.sh scripts/benchmark-tti.sh scripts/build-go.sh scripts/install-go.sh scripts/install.sh scripts/release.sh"
 
 [tasks.test-full]
 description = "Run full Go test suite"

--- a/README.md
+++ b/README.md
@@ -71,6 +71,23 @@ func example() error {
 - status enums (`client.SandboxStatus_*`, `client.ExecutionStatus_*`)
 - ergonomic wrappers (`client.NewFromEnv`, `client.EnsureSandbox`, `client.ExecAndWait`)
 
+## Install
+
+Install the latest release:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/buildkite/cleanroom/main/scripts/install.sh | bash
+```
+
+Install a specific version:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/buildkite/cleanroom/main/scripts/install.sh | \
+  bash -s -- --version v0.1.0
+```
+
+By default this installs to `/usr/local/bin`. Override with `--install-dir` or `CLEANROOM_INSTALL_DIR`.
+
 ## Quick Start
 
 Initialize runtime config and check host prerequisites:
@@ -148,7 +165,7 @@ macOS note:
 
 - `darwin-vz` is the default backend on macOS
 - install host tools for rootfs derivation with `brew install e2fsprogs`
-- `cleanroom-darwin-vz` helper must be installed and signed with `com.apple.security.virtualization` entitlement (`mise run install` handles this in this repo)
+- `cleanroom-darwin-vz` helper must be installed and signed with `com.apple.security.virtualization` entitlement (the release install script handles this automatically; `mise run install` also handles it in this repo)
 
 ## CLI
 

--- a/scripts/ci-cleanroom-e2e.sh
+++ b/scripts/ci-cleanroom-e2e.sh
@@ -237,8 +237,18 @@ set +e
       echo "$allow_resp" >&2
       exit 5
     fi
+    if echo "$allow_resp" | grep -q "upstream_error"; then
+      echo "allowlisted host probe hit upstream_error" >&2
+      echo "$allow_resp" >&2
+      exit 5
+    fi
     if echo "$allow_resp" | grep -q "host_not_allowed"; then
       echo "allowlisted host was denied by gateway" >&2
+      echo "$allow_resp" >&2
+      exit 5
+    fi
+    if ! echo "$allow_resp" | grep -q "git-upload-pack"; then
+      echo "allowlisted host probe did not return git upload-pack response" >&2
       echo "$allow_resp" >&2
       exit 5
     fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,286 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() {
+  printf '[cleanroom-install] %s\n' "$*"
+}
+
+warn() {
+  printf '[cleanroom-install] warning: %s\n' "$*" >&2
+}
+
+die() {
+  printf '[cleanroom-install] error: %s\n' "$*" >&2
+  exit 1
+}
+
+usage() {
+  cat <<'USAGE'
+Install cleanroom from GitHub releases.
+
+Usage:
+  install.sh [--version <version>] [--install-dir <dir>] [--repo <owner/repo>] [--no-darwin-helper]
+
+Examples:
+  curl -fsSL https://raw.githubusercontent.com/buildkite/cleanroom/main/scripts/install.sh | bash
+  curl -fsSL https://raw.githubusercontent.com/buildkite/cleanroom/main/scripts/install.sh | \
+    bash -s -- --version v0.1.0
+
+Environment variables:
+  CLEANROOM_VERSION               Optional release version (example: v0.1.0)
+  CLEANROOM_INSTALL_DIR           Install destination (default: /usr/local/bin)
+  CLEANROOM_REPO                  GitHub repo in owner/repo format (default: buildkite/cleanroom)
+  CLEANROOM_INSTALL_DARWIN_HELPER Set to 0 to skip cleanroom-darwin-vz install on macOS
+USAGE
+}
+
+require_cmd() {
+  local cmd="$1"
+  command -v "$cmd" >/dev/null 2>&1 || die "required command not found: ${cmd}"
+}
+
+sha256_file() {
+  local file="$1"
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$file" | awk '{print $1}'
+    return
+  fi
+
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$file" | awk '{print $1}'
+    return
+  fi
+
+  die "sha256 tool not found (need sha256sum or shasum)"
+}
+
+download() {
+  local url="$1"
+  local dest="$2"
+  if ! curl -fsSL --retry 3 --connect-timeout 10 "$url" -o "$dest"; then
+    die "failed to download ${url}"
+  fi
+}
+
+download_optional() {
+  local url="$1"
+  local dest="$2"
+  curl -fsSL --retry 3 --connect-timeout 10 "$url" -o "$dest"
+}
+
+normalize_version() {
+  local raw="$1"
+  if [ -z "$raw" ] || [ "$raw" = "latest" ]; then
+    printf 'latest'
+    return
+  fi
+
+  case "$raw" in
+    v*) printf '%s' "$raw" ;;
+    *) printf 'v%s' "$raw" ;;
+  esac
+}
+
+lookup_checksum() {
+  local asset="$1"
+  local checksums_file="$2"
+  local checksum
+
+  checksum=$(awk -v name="$asset" '$2 == name { print $1 }' "$checksums_file")
+  if [ -z "$checksum" ]; then
+    die "checksum for ${asset} not found in ${checksums_file}"
+  fi
+
+  printf '%s' "$checksum"
+}
+
+verify_asset_against_checksums() {
+  local asset="$1"
+  local asset_path="$2"
+  local checksums_file="$3"
+  local expected actual
+
+  expected=$(lookup_checksum "$asset" "$checksums_file")
+  actual=$(sha256_file "$asset_path")
+
+  if [ "$expected" != "$actual" ]; then
+    die "checksum mismatch for ${asset}"
+  fi
+}
+
+verify_asset_against_sha_file() {
+  local asset="$1"
+  local asset_path="$2"
+  local sha_file="$3"
+  local expected actual
+
+  expected=$(awk 'NR==1 { print $1 }' "$sha_file")
+  if [ -z "$expected" ]; then
+    die "could not read expected checksum from ${sha_file}"
+  fi
+
+  actual=$(sha256_file "$asset_path")
+
+  if [ "$expected" != "$actual" ]; then
+    die "checksum mismatch for ${asset}"
+  fi
+}
+
+extract_binary() {
+  local archive="$1"
+  local output_dir="$2"
+  mkdir -p "$output_dir"
+  tar -xzf "$archive" -C "$output_dir"
+}
+
+declare -a SUDO_CMD=()
+
+prepare_install_dir() {
+  if [ ! -d "$INSTALL_DIR" ]; then
+    if [ "$(id -u)" -eq 0 ]; then
+      mkdir -p "$INSTALL_DIR"
+    else
+      command -v sudo >/dev/null 2>&1 || die "${INSTALL_DIR} does not exist and sudo is unavailable"
+      SUDO_CMD=(sudo)
+      "${SUDO_CMD[@]}" mkdir -p "$INSTALL_DIR"
+    fi
+  fi
+
+  if [ "$(id -u)" -ne 0 ] && [ ! -w "$INSTALL_DIR" ]; then
+    command -v sudo >/dev/null 2>&1 || die "${INSTALL_DIR} is not writable and sudo is unavailable"
+    SUDO_CMD=(sudo)
+  fi
+}
+
+install_binary() {
+  local src="$1"
+  local dst="$2"
+  "${SUDO_CMD[@]}" install -m 0755 "$src" "$dst"
+}
+
+HOST_OS_RAW="$(uname -s)"
+HOST_ARCH_RAW="$(uname -m)"
+
+case "$HOST_OS_RAW" in
+  Linux) HOST_OS="Linux" ;;
+  Darwin) HOST_OS="Darwin" ;;
+  *) die "unsupported operating system: ${HOST_OS_RAW}" ;;
+esac
+
+case "$HOST_ARCH_RAW" in
+  x86_64|amd64) HOST_ARCH="x86_64" ;;
+  arm64|aarch64) HOST_ARCH="arm64" ;;
+  *) die "unsupported architecture: ${HOST_ARCH_RAW}" ;;
+esac
+
+VERSION="${CLEANROOM_VERSION:-}"
+INSTALL_DIR="${CLEANROOM_INSTALL_DIR:-/usr/local/bin}"
+REPO="${CLEANROOM_REPO:-buildkite/cleanroom}"
+INSTALL_DARWIN_HELPER="${CLEANROOM_INSTALL_DARWIN_HELPER:-1}"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --version)
+      [ "$#" -ge 2 ] || die "--version requires a value"
+      VERSION="$2"
+      shift 2
+      ;;
+    --install-dir)
+      [ "$#" -ge 2 ] || die "--install-dir requires a value"
+      INSTALL_DIR="$2"
+      shift 2
+      ;;
+    --repo)
+      [ "$#" -ge 2 ] || die "--repo requires a value"
+      REPO="$2"
+      shift 2
+      ;;
+    --no-darwin-helper)
+      INSTALL_DARWIN_HELPER=0
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown option: $1"
+      ;;
+  esac
+done
+
+require_cmd curl
+require_cmd tar
+require_cmd awk
+
+VERSION="$(normalize_version "$VERSION")"
+if [ "$VERSION" = "latest" ]; then
+  RELEASE_BASE="https://github.com/${REPO}/releases/latest/download"
+  RELEASE_LABEL="latest"
+else
+  RELEASE_BASE="https://github.com/${REPO}/releases/download/${VERSION}"
+  RELEASE_LABEL="$VERSION"
+fi
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+DARWIN_HELPER_INSTALLED=0
+
+log "Installing cleanroom from ${REPO} (${RELEASE_LABEL}) for ${HOST_OS}/${HOST_ARCH}"
+
+CHECKSUMS_PATH="${WORK_DIR}/checksums.txt"
+download "${RELEASE_BASE}/checksums.txt" "$CHECKSUMS_PATH"
+
+CLEANROOM_ASSET="cleanroom_${HOST_OS}_${HOST_ARCH}.tar.gz"
+CLEANROOM_ARCHIVE_PATH="${WORK_DIR}/${CLEANROOM_ASSET}"
+
+download "${RELEASE_BASE}/${CLEANROOM_ASSET}" "$CLEANROOM_ARCHIVE_PATH"
+verify_asset_against_checksums "$CLEANROOM_ASSET" "$CLEANROOM_ARCHIVE_PATH" "$CHECKSUMS_PATH"
+
+CLEANROOM_EXTRACT_DIR="${WORK_DIR}/cleanroom"
+extract_binary "$CLEANROOM_ARCHIVE_PATH" "$CLEANROOM_EXTRACT_DIR"
+[ -f "${CLEANROOM_EXTRACT_DIR}/cleanroom" ] || die "cleanroom binary missing in ${CLEANROOM_ASSET}"
+
+prepare_install_dir
+install_binary "${CLEANROOM_EXTRACT_DIR}/cleanroom" "${INSTALL_DIR}/cleanroom"
+
+if [ "$HOST_OS" = "Darwin" ] && [ "$INSTALL_DARWIN_HELPER" != "0" ]; then
+  HELPER_ASSET="cleanroom-darwin-vz_Darwin_${HOST_ARCH}.tar.gz"
+  HELPER_ARCHIVE_PATH="${WORK_DIR}/${HELPER_ASSET}"
+  HELPER_SHA_PATH="${WORK_DIR}/${HELPER_ASSET}.sha256"
+
+  if download_optional "${RELEASE_BASE}/${HELPER_ASSET}" "$HELPER_ARCHIVE_PATH"; then
+    require_cmd codesign
+
+    if download_optional "${RELEASE_BASE}/${HELPER_ASSET}.sha256" "$HELPER_SHA_PATH"; then
+      verify_asset_against_sha_file "$HELPER_ASSET" "$HELPER_ARCHIVE_PATH" "$HELPER_SHA_PATH"
+    else
+      warn "${HELPER_ASSET}.sha256 not found; continuing without helper checksum verification"
+    fi
+
+    HELPER_EXTRACT_DIR="${WORK_DIR}/darwin-helper"
+    extract_binary "$HELPER_ARCHIVE_PATH" "$HELPER_EXTRACT_DIR"
+
+    [ -f "${HELPER_EXTRACT_DIR}/cleanroom-darwin-vz" ] || die "cleanroom-darwin-vz missing in ${HELPER_ASSET}"
+    [ -f "${HELPER_EXTRACT_DIR}/entitlements.plist" ] || die "entitlements.plist missing in ${HELPER_ASSET}"
+
+    install_binary "${HELPER_EXTRACT_DIR}/cleanroom-darwin-vz" "${INSTALL_DIR}/cleanroom-darwin-vz"
+    "${SUDO_CMD[@]}" codesign --force --sign - \
+      --entitlements "${HELPER_EXTRACT_DIR}/entitlements.plist" \
+      "${INSTALL_DIR}/cleanroom-darwin-vz"
+    DARWIN_HELPER_INSTALLED=1
+  else
+    warn "${HELPER_ASSET} not found in release; skipping cleanroom-darwin-vz install"
+  fi
+fi
+
+log "Installed cleanroom to ${INSTALL_DIR}/cleanroom"
+if [ "$DARWIN_HELPER_INSTALLED" = "1" ]; then
+  log "Installed cleanroom-darwin-vz to ${INSTALL_DIR}/cleanroom-darwin-vz"
+fi
+
+case ":${PATH}:" in
+  *":${INSTALL_DIR}:"*) ;;
+  *) warn "${INSTALL_DIR} is not in PATH" ;;
+esac


### PR DESCRIPTION
## Summary
- add a release installer script at `scripts/install.sh` for `curl ... | bash` usage
- verify downloaded release artifacts using `checksums.txt` and install the macOS helper when available
- fix Goreleaser archive configuration by splitting archives per build id (prevents multi-binary archive failure)
- update release workflow to publish `cleanroom-darwin-vz` archives + sha256 for both `arm64` and `x86_64`
- document install commands in the README and include the new script in shell linting

## Testing
- `mise run check`
- `mise x goreleaser@v2.12.7 -- goreleaser check`
- `mise x goreleaser@v2.12.7 -- goreleaser release --snapshot --skip=publish --clean`
- `bash scripts/install.sh --help`

## Notes
- live installer download against current `latest` release still returns 404 for `checksums.txt` until a new tagged release publishes the new assets.