### PR TITLE
fix: refactor CLI/controlservice execution flow and retention handling

### DIFF
--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -1555,11 +1555,11 @@ func bufferedResultDelta(retained, buffered string) string {
 	if retained == "" {
 		return buffered
 	}
-	if strings.HasPrefix(buffered, retained) {
-		return buffered[len(retained):]
-	}
 	if strings.HasSuffix(buffered, retained) {
 		return ""
+	}
+	if strings.HasPrefix(buffered, retained) {
+		return buffered[len(retained):]
 	}
 	return buffered
 }

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -1572,14 +1572,14 @@ func appendRetainedOutput(existing, chunk string, limit int) string {
 		if len(existing) <= limit {
 			return existing
 		}
-		return existing[len(existing)-limit:]
+		return strings.Clone(existing[len(existing)-limit:])
 	}
 	if len(chunk) >= limit {
-		return chunk[len(chunk)-limit:]
+		return strings.Clone(chunk[len(chunk)-limit:])
 	}
 	keepExisting := limit - len(chunk)
 	if keepExisting < len(existing) {
-		existing = existing[len(existing)-keepExisting:]
+		existing = strings.Clone(existing[len(existing)-keepExisting:])
 	}
 	return existing + chunk
 }

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -1197,6 +1197,18 @@ func TestFinalizeExecutionWithoutPruneSkipsImmediateStatePruning(t *testing.T) {
 	svc.mu.Unlock()
 }
 
+func TestBufferedResultDeltaPrefersSuffixMatch(t *testing.T) {
+	if got, want := bufferedResultDelta("abc", "abcabc"), ""; got != want {
+		t.Fatalf("expected suffix match to suppress duplicate delta: got %q want %q", got, want)
+	}
+	if got, want := bufferedResultDelta("prefix-", "prefix-tail"), "tail"; got != want {
+		t.Fatalf("expected prefix-only delta: got %q want %q", got, want)
+	}
+	if got, want := bufferedResultDelta("tail", "head-tail"), ""; got != want {
+		t.Fatalf("expected suffix-only delta suppression: got %q want %q", got, want)
+	}
+}
+
 func TestStatePruningBoundsRetainedTerminalState(t *testing.T) {
 	origSandboxes := maxRetainedStoppedSandboxes
 	origExecutions := maxRetainedFinishedExecutions


### PR DESCRIPTION
## Summary
- tighten CLI interrupt semantics coverage so second interrupt only tears down the sandbox when `--rm` is set, including supplied `--sandbox-id` flows
- bound controlservice in-memory retention for execution output and event history to reduce unbounded growth risk
- simplify execution lifecycle internals by consolidating duplicated finalization and adapter-run plumbing in controlservice
- reduce CLI duplication by sharing sandbox setup, exit-code fallback, and best-effort sandbox termination helpers across `exec` and `console`
- deduplicate integration test scaffolding and capture harness logic for clearer, lower-maintenance CLI tests

## Testing
- `mise exec go@1.23 -- go test ./...`
