### PR TITLE
fix: bundle release artifacts per platform

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,12 +50,12 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: darwin-vz-arm64
-          path: .
+          path: release-extra
 
       - uses: actions/download-artifact@v4
         with:
           name: darwin-vz-amd64
-          path: .
+          path: release-extra
 
       - name: Build release extra binaries
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,35 +17,23 @@ jobs:
         include:
           - arch: arm64
             target: arm64-apple-macosx13.0
-          - arch: x86_64
+          - arch: amd64
             target: x86_64-apple-macosx13.0
     steps:
       - uses: actions/checkout@v4
 
       - name: Build cleanroom-darwin-vz
         run: |
-          mkdir -p dist
+          mkdir -p "release-extra/darwin_${{ matrix.arch }}"
           xcrun swiftc -O -target "${{ matrix.target }}" -framework Virtualization \
             cmd/cleanroom-darwin-vz/main.swift \
-            -o dist/cleanroom-darwin-vz
-
-      - name: Create archive
-        run: |
-          ARCHIVE="cleanroom-darwin-vz_Darwin_${{ matrix.arch }}.tar.gz"
-          cp cmd/cleanroom-darwin-vz/entitlements.plist dist/
-          tar -czf "dist/${ARCHIVE}" \
-            -C dist cleanroom-darwin-vz entitlements.plist
-          (
-            cd dist
-            shasum -a 256 "${ARCHIVE}" > "${ARCHIVE}.sha256"
-          )
+            -o "release-extra/darwin_${{ matrix.arch }}/cleanroom-darwin-vz"
+          cp cmd/cleanroom-darwin-vz/entitlements.plist "release-extra/darwin_${{ matrix.arch }}/entitlements.plist"
 
       - uses: actions/upload-artifact@v4
         with:
-          name: cleanroom-darwin-vz-${{ matrix.arch }}
-          path: |
-            dist/cleanroom-darwin-vz_Darwin_${{ matrix.arch }}.tar.gz
-            dist/cleanroom-darwin-vz_Darwin_${{ matrix.arch }}.tar.gz.sha256
+          name: darwin-vz-${{ matrix.arch }}
+          path: release-extra
 
   release:
     runs-on: ubuntu-latest
@@ -59,23 +47,27 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - uses: actions/download-artifact@v4
+        with:
+          name: darwin-vz-arm64
+          path: .
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: darwin-vz-amd64
+          path: .
+
+      - name: Build release extra binaries
+        run: |
+          mkdir -p release-extra/linux_amd64 release-extra/linux_arm64
+          GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" \
+            -o release-extra/linux_amd64/cleanroom-guest-agent ./cmd/cleanroom-guest-agent
+          GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" \
+            -o release-extra/linux_arm64/cleanroom-guest-agent ./cmd/cleanroom-guest-agent
+
       - uses: goreleaser/goreleaser-action@v6
         with:
           version: "~> v2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: actions/download-artifact@v4
-        with:
-          pattern: cleanroom-darwin-vz-*
-          merge-multiple: true
-          path: dist
-
-      - name: Upload darwin-vz helper to release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release upload "${{ github.ref_name }}" \
-            dist/cleanroom-darwin-vz_Darwin_*.tar.gz \
-            dist/cleanroom-darwin-vz_Darwin_*.tar.gz.sha256

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,44 +1,54 @@
 version: 2
 
 builds:
-  - id: cleanroom
+  - id: cleanroom-linux
     main: ./cmd/cleanroom
     binary: cleanroom
-    env:
-      - CGO_ENABLED=0
-    goos: [linux, darwin]
-    goarch: [amd64, arm64]
-    ldflags:
-      - -s -w -X main.version={{.Version}}
-
-  - id: cleanroom-guest-agent
-    main: ./cmd/cleanroom-guest-agent
-    binary: cleanroom-guest-agent
     env:
       - CGO_ENABLED=0
     goos: [linux]
     goarch: [amd64, arm64]
     ldflags:
-      - -s -w
+      - -s -w -X main.version={{.Version}}
+
+  - id: cleanroom-darwin
+    main: ./cmd/cleanroom
+    binary: cleanroom
+    env:
+      - CGO_ENABLED=0
+    goos: [darwin]
+    goarch: [amd64, arm64]
+    ldflags:
+      - -s -w -X main.version={{.Version}}
 
 archives:
-  - id: cleanroom
-    ids: [cleanroom]
+  - id: cleanroom-linux
+    ids: [cleanroom-linux]
     formats: [tar.gz]
     name_template: >-
       {{ .Binary }}_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else }}{{ .Arch }}{{ end }}
+    files:
+      - src: release-extra/linux_{{ .Arch }}/cleanroom-guest-agent
+        strip_parent: true
 
-  - id: cleanroom-guest-agent
-    ids: [cleanroom-guest-agent]
+  - id: cleanroom-darwin
+    ids: [cleanroom-darwin]
     formats: [tar.gz]
     name_template: >-
       {{ .Binary }}_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else }}{{ .Arch }}{{ end }}
+    files:
+      - src: release-extra/linux_{{ .Arch }}/cleanroom-guest-agent
+        strip_parent: true
+      - src: release-extra/darwin_{{ .Arch }}/cleanroom-darwin-vz
+        strip_parent: true
+      - src: release-extra/darwin_{{ .Arch }}/entitlements.plist
+        strip_parent: true
 
 checksum:
   name_template: "checksums.txt"

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Install a specific version:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/buildkite/cleanroom/main/scripts/install.sh | \
-  bash -s -- --version v0.1.0
+  bash -s -- --version vX.Y.Z
 ```
 
 By default this installs to `/usr/local/bin`. Override with `--install-dir` or `CLEANROOM_INSTALL_DIR`.


### PR DESCRIPTION
## Summary
- package release tarballs per platform with all required binaries instead of separate helper and guest-agent artifacts
- include `cleanroom-guest-agent` in every platform tarball
- include `cleanroom-darwin-vz` + `entitlements.plist` in macOS tarballs
- simplify installer to install all binaries from a single `cleanroom_<OS>_<arch>.tar.gz` asset

## Artifact layout after this change
- `cleanroom_Darwin_arm64.tar.gz`: `cleanroom`, `cleanroom-guest-agent`, `cleanroom-darwin-vz`, `entitlements.plist`
- `cleanroom_Darwin_x86_64.tar.gz`: `cleanroom`, `cleanroom-guest-agent`, `cleanroom-darwin-vz`, `entitlements.plist`
- `cleanroom_Linux_arm64.tar.gz`: `cleanroom`, `cleanroom-guest-agent`
- `cleanroom_Linux_x86_64.tar.gz`: `cleanroom`, `cleanroom-guest-agent`
- `checksums.txt`

## Testing
- `mise run check`
- `mise x goreleaser@v2.12.7 -- goreleaser check`
- `mise x goreleaser@v2.12.7 -- goreleaser release --snapshot --skip=publish --clean` (with release extras staged)
- manual tarball content verification for all four platform archives
