### PR TITLE
fix: add release-extra to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /dist
+/release-extra


### PR DESCRIPTION
The `release-extra/` directory created by artifact downloads in the release workflow makes git dirty, causing GoReleaser to refuse to release.

This was the cause of the v0.1.1 release failure.