### PR TITLE
fix: move Go client section after Architecture in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,48 +20,6 @@ Agent sandboxing tools are [proliferating fast](docs/research.md). Most focus on
 
 **Coming soon:** package registry proxy with lockfile enforcement, Docker pull caching, content caching for hermetic offline builds, and structured audit logging. See the [spec](docs/spec.md) for the full roadmap.
 
-## Go Client (Public API)
-
-Use `github.com/buildkite/cleanroom/client` from external Go modules.
-
-```go
-import (
-  "context"
-  "os"
-
-  "github.com/buildkite/cleanroom/client"
-)
-
-func example() error {
-  c := client.Must(client.NewFromEnv())
-
-  sb, err := c.EnsureSandbox(context.Background(), "thread:abc123", client.EnsureSandboxOptions{
-    Backend: "firecracker",
-    Policy: client.PolicyFromAllowlist(
-      "ghcr.io/buildkite/cleanroom-base/alpine@sha256:...",
-      "sha256:...",
-      client.Allow("api.github.com", 443),
-      client.Allow("registry.npmjs.org", 443),
-    ),
-  })
-  if err != nil { return err }
-
-  result, err := c.ExecAndWait(context.Background(), sb.ID, []string{"bash", "-lc", "echo hello"}, client.ExecOptions{
-    Stdout: os.Stdout,
-    Stderr: os.Stderr,
-  })
-  if err != nil { return err }
-  _ = result
-  return nil
-}
-```
-
-`client` exposes:
-- `client.Client` for RPC calls
-- protobuf request/response/event types (for example `client.CreateExecutionRequest`)
-- status enums (`client.SandboxStatus_*`, `client.ExecutionStatus_*`)
-- ergonomic wrappers (`client.NewFromEnv`, `client.EnsureSandbox`, `client.ExecAndWait`)
-
 ## Install
 
 Install the latest release:
@@ -194,6 +152,48 @@ cleanroom exec --backend darwin-vz -- npm test
 - **Client:** CLI and ConnectRPC clients
 - **Transport:** unix socket (default), [HTTPS with mTLS](docs/tls.md), or [Tailscale](docs/remote-access.md)
 - **RPC services:** `cleanroom.v1.SandboxService`, `cleanroom.v1.ExecutionService` ([API design](docs/api.md))
+
+## Go Client (Public API)
+
+Use `github.com/buildkite/cleanroom/client` from external Go modules.
+
+```go
+import (
+  "context"
+  "os"
+
+  "github.com/buildkite/cleanroom/client"
+)
+
+func example() error {
+  c := client.Must(client.NewFromEnv())
+
+  sb, err := c.EnsureSandbox(context.Background(), "thread:abc123", client.EnsureSandboxOptions{
+    Backend: "firecracker",
+    Policy: client.PolicyFromAllowlist(
+      "ghcr.io/buildkite/cleanroom-base/alpine@sha256:...",
+      "sha256:...",
+      client.Allow("api.github.com", 443),
+      client.Allow("registry.npmjs.org", 443),
+    ),
+  })
+  if err != nil { return err }
+
+  result, err := c.ExecAndWait(context.Background(), sb.ID, []string{"bash", "-lc", "echo hello"}, client.ExecOptions{
+    Stdout: os.Stdout,
+    Stderr: os.Stderr,
+  })
+  if err != nil { return err }
+  _ = result
+  return nil
+}
+```
+
+`client` exposes:
+- `client.Client` for RPC calls
+- protobuf request/response/event types (for example `client.CreateExecutionRequest`)
+- status enums (`client.SandboxStatus_*`, `client.ExecutionStatus_*`)
+- ergonomic wrappers (`client.NewFromEnv`, `client.EnsureSandbox`, `client.ExecAndWait`)
 
 ## Images
 


### PR DESCRIPTION
Moves the Go Client (Public API) section from near the top of the README to after the Architecture section, where API details are a better fit. Follow-up to #62.