### PR TITLE
feat: add cleanroom serve uninstall and status commands

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1278,8 +1278,12 @@ func uninstallSystemdDaemon(stdout io.Writer) error {
 		return fmt.Errorf("service file %s does not exist", serveInstallSystemdUnitPath)
 	}
 
-	_ = serveInstallRunCommand("systemctl", "stop", systemdServiceName)
-	_ = serveInstallRunCommand("systemctl", "disable", systemdServiceName)
+	if err := serveInstallRunCommand("systemctl", "stop", systemdServiceName); err != nil {
+		return fmt.Errorf("stop systemd service %s: %w", systemdServiceName, err)
+	}
+	if err := serveInstallRunCommand("systemctl", "disable", systemdServiceName); err != nil {
+		return fmt.Errorf("disable systemd service %s: %w", systemdServiceName, err)
+	}
 
 	if err := serveInstallRemoveFile(serveInstallSystemdUnitPath); err != nil {
 		return fmt.Errorf("remove service file %s: %w", serveInstallSystemdUnitPath, err)
@@ -1297,7 +1301,9 @@ func uninstallLaunchdDaemon(stdout io.Writer) error {
 		return fmt.Errorf("service file %s does not exist", serveInstallLaunchdPath)
 	}
 
-	_ = serveInstallRunCommand("launchctl", "bootout", "system/"+launchdServiceName)
+	if err := serveInstallRunCommand("launchctl", "bootout", "system/"+launchdServiceName); err != nil {
+		return fmt.Errorf("bootout launchd service %s: %w", launchdServiceName, err)
+	}
 
 	if err := serveInstallRemoveFile(serveInstallLaunchdPath); err != nil {
 		return fmt.Errorf("remove service file %s: %w", serveInstallLaunchdPath, err)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1301,7 +1301,7 @@ func uninstallLaunchdDaemon(stdout io.Writer) error {
 		return fmt.Errorf("service file %s does not exist", serveInstallLaunchdPath)
 	}
 
-	if err := serveInstallRunCommand("launchctl", "bootout", "system/"+launchdServiceName); err != nil {
+	if err := serveInstallRunCommand("launchctl", "bootout", "system/"+launchdServiceName); err != nil && !isExitError(err) {
 		return fmt.Errorf("bootout launchd service %s: %w", launchdServiceName, err)
 	}
 

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -539,7 +540,7 @@ func TestServeStatusSystemdNotInstalled(t *testing.T) {
 	serveInstallGOOS = "linux"
 	serveInstallSystemdUnitPath = unitPath
 	serveInstallRunCommand = func(name string, args ...string) error {
-		return errors.New("not found")
+		return &exec.ExitError{ProcessState: &os.ProcessState{}}
 	}
 	t.Cleanup(func() {
 		serveInstallGOOS = prevGOOS


### PR DESCRIPTION
Add two new `cleanroom serve` actions:

### `cleanroom serve uninstall`
Stops and disables the daemon service, removes the service file, and reloads the service manager. Requires root, mirrors the install flow.

- **systemd**: stop → disable → remove unit → daemon-reload
- **launchd**: bootout → remove plist

### `cleanroom serve status`
Reports daemon state as key=value lines. Does not require root.

- **systemd**: `installed`, `active`, `enabled`
- **launchd**: `installed`, `active`

### Tests
7 new tests covering root checks, systemd stop/disable/remove flow, missing-service errors, unsupported OS, and status output for both installed and not-installed states.