### PR TITLE
feat: support --image overrides for sandbox create, exec, and console

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ SANDBOX_ID="$(cleanroom create)"
 cleanroom exec --sandbox-id "$SANDBOX_ID" -- npm run lint
 ```
 
+Override the sandbox image per command (remote tag/digest or local Docker image name):
+
+```bash
+cleanroom sandbox create --image ghcr.io/buildkite/cleanroom-base/alpine:latest
+cleanroom exec --image ghcr.io/buildkite/cleanroom-base/alpine:latest -- npm test
+cleanroom console --image my-local-image:dev -- sh
+```
+
 Equivalent namespaced command:
 
 ```bash

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -288,11 +288,12 @@ var (
 	}
 	importLocalDockerImageForOverrideFn = importLocalDockerImageForOverride
 	resolveReferenceForImageOverride    = func(ctx context.Context, source string, allowLocal bool) (string, error) {
+		if !allowLocal {
+			return resolveReferenceForPolicyUpdate(ctx, source)
+		}
+
 		localRef, localErr := importLocalDockerImageForOverrideFn(ctx, source)
 		if localErr == nil {
-			if !allowLocal {
-				return "", errors.New("local docker image overrides require a local control-plane endpoint (unix socket)")
-			}
 			return localRef, nil
 		}
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -286,18 +286,19 @@ var (
 
 		return fmt.Sprintf("%s@%s", tag.Context().Name(), desc.Digest.String()), nil
 	}
-	resolveReferenceForImageOverride = func(ctx context.Context, source string) (string, error) {
+	importLocalDockerImageForOverrideFn = importLocalDockerImageForOverride
+	resolveReferenceForImageOverride    = func(ctx context.Context, source string) (string, error) {
+		localRef, localErr := importLocalDockerImageForOverrideFn(ctx, source)
+		if localErr == nil {
+			return localRef, nil
+		}
+
 		resolved, err := resolveReferenceForPolicyUpdate(ctx, source)
 		if err == nil {
 			return resolved, nil
 		}
 
-		localRef, localErr := importLocalDockerImageForOverride(ctx, source)
-		if localErr == nil {
-			return localRef, nil
-		}
-
-		return "", fmt.Errorf("%w; local docker fallback failed: %v", err, localErr)
+		return "", fmt.Errorf("%w; local docker resolution failed: %v", err, localErr)
 	}
 	serveInstallGOOS            = runtime.GOOS
 	serveInstallEUID            = os.Geteuid

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -162,6 +162,7 @@ type ExecCommand struct {
 	Chdir     string `short:"c" help:"Change to this directory before running commands"`
 	Backend   string `help:"Execution backend (defaults to runtime config or firecracker)"`
 	SandboxID string `help:"Reuse an existing sandbox instead of creating a new one"`
+	Image     string `help:"Override sandbox image ref for newly created sandboxes (tag, digest, or local Docker image)"`
 	Remove    bool   `name:"rm" help:"Terminate the sandbox after command completion"`
 
 	LaunchSeconds int64 `help:"VM boot/guest-agent readiness timeout in seconds"`
@@ -173,6 +174,7 @@ type SandboxCreateCommand struct {
 	clientFlags
 	Chdir         string `short:"c" help:"Change to this directory before running commands"`
 	Backend       string `help:"Execution backend (defaults to runtime config or firecracker)"`
+	Image         string `help:"Override sandbox image ref (tag, digest, or local Docker image)"`
 	LaunchSeconds int64  `help:"VM boot/guest-agent readiness timeout in seconds"`
 	JSON          bool   `help:"Print sandbox as JSON"`
 }
@@ -181,6 +183,7 @@ type CreateCommand struct {
 	clientFlags
 	Chdir         string `short:"c" help:"Change to this directory before running commands"`
 	Backend       string `help:"Execution backend (defaults to runtime config or firecracker)"`
+	Image         string `help:"Override sandbox image ref (tag, digest, or local Docker image)"`
 	LaunchSeconds int64  `help:"VM boot/guest-agent readiness timeout in seconds"`
 	JSON          bool   `help:"Print sandbox as JSON"`
 }
@@ -190,6 +193,7 @@ type ConsoleCommand struct {
 	Chdir     string `short:"c" help:"Change to this directory before running commands"`
 	Backend   string `help:"Execution backend (defaults to runtime config or firecracker)"`
 	SandboxID string `help:"Reuse an existing sandbox instead of creating a new one"`
+	Image     string `help:"Override sandbox image ref for newly created sandboxes (tag, digest, or local Docker image)"`
 	Remove    bool   `name:"rm" help:"Terminate the sandbox after console exits"`
 
 	LaunchSeconds int64 `help:"VM boot/guest-agent readiness timeout in seconds"`
@@ -281,6 +285,19 @@ var (
 		}
 
 		return fmt.Sprintf("%s@%s", tag.Context().Name(), desc.Digest.String()), nil
+	}
+	resolveReferenceForImageOverride = func(ctx context.Context, source string) (string, error) {
+		resolved, err := resolveReferenceForPolicyUpdate(ctx, source)
+		if err == nil {
+			return resolved, nil
+		}
+
+		localRef, localErr := importLocalDockerImageForOverride(ctx, source)
+		if localErr == nil {
+			return localRef, nil
+		}
+
+		return "", fmt.Errorf("%w; local docker fallback failed: %v", err, localErr)
 	}
 	serveInstallGOOS            = runtime.GOOS
 	serveInstallEUID            = os.Geteuid
@@ -674,7 +691,7 @@ func (c *SandboxTerminateCommand) Run(ctx *runtimeContext) error {
 	return err
 }
 
-func runSandboxCreate(ctx *runtimeContext, connectFlags clientFlags, chdir, backend string, launchSeconds int64, outputJSON bool) error {
+func runSandboxCreate(ctx *runtimeContext, connectFlags clientFlags, chdir, backend, imageRefOverride string, launchSeconds int64, outputJSON bool) error {
 	client, err := connectFlags.connect()
 	if err != nil {
 		return err
@@ -685,6 +702,10 @@ func runSandboxCreate(ctx *runtimeContext, connectFlags clientFlags, chdir, back
 		return err
 	}
 	compiled, _, err := ctx.Loader.LoadAndCompile(cwd)
+	if err != nil {
+		return err
+	}
+	compiled, err = overrideCompiledPolicyImage(compiled, imageRefOverride)
 	if err != nil {
 		return err
 	}
@@ -717,11 +738,11 @@ func runSandboxCreate(ctx *runtimeContext, connectFlags clientFlags, chdir, back
 }
 
 func (c *SandboxCreateCommand) Run(ctx *runtimeContext) error {
-	return runSandboxCreate(ctx, c.clientFlags, c.Chdir, c.Backend, c.LaunchSeconds, c.JSON)
+	return runSandboxCreate(ctx, c.clientFlags, c.Chdir, c.Backend, c.Image, c.LaunchSeconds, c.JSON)
 }
 
 func (c *CreateCommand) Run(ctx *runtimeContext) error {
-	return runSandboxCreate(ctx, c.clientFlags, c.Chdir, c.Backend, c.LaunchSeconds, c.JSON)
+	return runSandboxCreate(ctx, c.clientFlags, c.Chdir, c.Backend, c.Image, c.LaunchSeconds, c.JSON)
 }
 
 func (e *ExecCommand) Run(ctx *runtimeContext) error {
@@ -745,7 +766,7 @@ func (e *ExecCommand) Run(ctx *runtimeContext) error {
 		"sandbox_id", strings.TrimSpace(e.SandboxID),
 		"command_argc", len(e.Command),
 	)
-	sandboxID, err := ensureSandboxID(client, ctx.Loader, cwd, e.Backend, strings.TrimSpace(e.SandboxID), e.LaunchSeconds)
+	sandboxID, err := ensureSandboxID(client, ctx.Loader, cwd, e.Backend, strings.TrimSpace(e.SandboxID), e.Image, e.LaunchSeconds)
 	if err != nil {
 		return err
 	}
@@ -925,7 +946,7 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) error {
 		"sandbox_id", strings.TrimSpace(c.SandboxID),
 		"command_argc", len(command),
 	)
-	sandboxID, err := ensureSandboxID(client, ctx.Loader, cwd, c.Backend, strings.TrimSpace(c.SandboxID), c.LaunchSeconds)
+	sandboxID, err := ensureSandboxID(client, ctx.Loader, cwd, c.Backend, strings.TrimSpace(c.SandboxID), c.Image, c.LaunchSeconds)
 	if err != nil {
 		return err
 	}
@@ -1885,13 +1906,20 @@ func inspectRun(stdout *os.File, baseDir, runID string) error {
 	return err
 }
 
-func ensureSandboxID(client *controlclient.Client, loader policyLoader, cwd, backendName, existingSandboxID string, launchSeconds int64) (string, error) {
+func ensureSandboxID(client *controlclient.Client, loader policyLoader, cwd, backendName, existingSandboxID, imageRefOverride string, launchSeconds int64) (string, error) {
 	sandboxID := strings.TrimSpace(existingSandboxID)
 	if sandboxID != "" {
+		if strings.TrimSpace(imageRefOverride) != "" {
+			return "", errors.New("--image cannot be used with --sandbox-id")
+		}
 		return sandboxID, nil
 	}
 
 	compiled, _, err := loader.LoadAndCompile(cwd)
+	if err != nil {
+		return "", err
+	}
+	compiled, err = overrideCompiledPolicyImage(compiled, imageRefOverride)
 	if err != nil {
 		return "", err
 	}
@@ -1906,6 +1934,137 @@ func ensureSandboxID(client *controlclient.Client, loader policyLoader, cwd, bac
 		return "", fmt.Errorf("create sandbox: %w", err)
 	}
 	return strings.TrimSpace(createSandboxResp.GetSandbox().GetSandboxId()), nil
+}
+
+func overrideCompiledPolicyImage(compiled *policy.CompiledPolicy, imageRefOverride string) (*policy.CompiledPolicy, error) {
+	imageRefOverride = strings.TrimSpace(imageRefOverride)
+	if imageRefOverride == "" {
+		return compiled, nil
+	}
+
+	resolvedRef, err := resolveReferenceForImageOverride(context.Background(), imageRefOverride)
+	if err != nil {
+		return nil, fmt.Errorf("invalid --image value: %w", err)
+	}
+	parsedRef, err := ociref.ParseDigestReference(resolvedRef)
+	if err != nil {
+		return nil, fmt.Errorf("invalid --image value: %w", err)
+	}
+
+	pb := compiled.ToProto()
+	pb.ImageRef = parsedRef.Original
+	pb.ImageDigest = parsedRef.Digest()
+	pb.Hash = ""
+
+	overridden, err := policy.FromProto(pb)
+	if err != nil {
+		return nil, fmt.Errorf("apply --image override: %w", err)
+	}
+	return overridden, nil
+}
+
+func importLocalDockerImageForOverride(ctx context.Context, source string) (string, error) {
+	source = strings.TrimSpace(source)
+	if source == "" {
+		return "", errors.New("image reference cannot be empty")
+	}
+	if _, err := exec.LookPath("docker"); err != nil {
+		return "", fmt.Errorf("docker CLI not found in PATH: %w", err)
+	}
+
+	inspectCmd := exec.CommandContext(ctx, "docker", "image", "inspect", "--format", "{{.Id}}", source)
+	var inspectStdout bytes.Buffer
+	var inspectStderr bytes.Buffer
+	inspectCmd.Stdout = &inspectStdout
+	inspectCmd.Stderr = &inspectStderr
+	if err := inspectCmd.Run(); err != nil {
+		errText := strings.TrimSpace(inspectStderr.String())
+		if errText == "" {
+			errText = err.Error()
+		}
+		return "", fmt.Errorf("inspect local docker image %q: %s", source, errText)
+	}
+
+	imageID := strings.TrimSpace(inspectStdout.String())
+	if imageID == "" {
+		return "", fmt.Errorf("inspect local docker image %q returned empty image id", source)
+	}
+	digestRef, err := ociref.ParseDigestReference("local/docker-image@" + imageID)
+	if err != nil {
+		return "", fmt.Errorf("inspect local docker image %q returned invalid image id %q: %w", source, imageID, err)
+	}
+
+	mgr, err := newImageManager()
+	if err != nil {
+		return "", err
+	}
+
+	cachedRecords, err := mgr.List(ctx)
+	if err != nil {
+		return "", err
+	}
+	for _, record := range cachedRecords {
+		if record.Digest != digestRef.Digest() {
+			continue
+		}
+		if _, statErr := os.Stat(record.RootFSPath); statErr == nil {
+			_, _ = fmt.Fprintf(os.Stderr, "using cached local image override %s\n", digestRef.Original)
+			return digestRef.Original, nil
+		}
+	}
+
+	_, _ = fmt.Fprintf(os.Stderr, "importing local docker image %q into cleanroom cache (first run can take a while)\n", source)
+
+	createCmd := exec.CommandContext(ctx, "docker", "create", source)
+	var createStdout bytes.Buffer
+	var createStderr bytes.Buffer
+	createCmd.Stdout = &createStdout
+	createCmd.Stderr = &createStderr
+	if err := createCmd.Run(); err != nil {
+		errText := strings.TrimSpace(createStderr.String())
+		if errText == "" {
+			errText = err.Error()
+		}
+		return "", fmt.Errorf("create container from %q: %s", source, errText)
+	}
+	containerID := strings.TrimSpace(createStdout.String())
+	if containerID == "" {
+		return "", fmt.Errorf("create container from %q returned empty container id", source)
+	}
+	defer func() {
+		_ = exec.Command("docker", "rm", "-f", containerID).Run()
+	}()
+
+	exportFile, err := os.CreateTemp("", "cleanroom-local-image-*.tar")
+	if err != nil {
+		return "", fmt.Errorf("create temporary export file: %w", err)
+	}
+	defer func() {
+		_ = exportFile.Close()
+		_ = os.Remove(exportFile.Name())
+	}()
+
+	exportCmd := exec.CommandContext(ctx, "docker", "export", containerID)
+	var exportStderr bytes.Buffer
+	exportCmd.Stdout = exportFile
+	exportCmd.Stderr = &exportStderr
+	if err := exportCmd.Run(); err != nil {
+		errText := strings.TrimSpace(exportStderr.String())
+		if errText == "" {
+			errText = err.Error()
+		}
+		return "", fmt.Errorf("export container %q from %q: %s", containerID, source, errText)
+	}
+	if _, err := exportFile.Seek(0, io.SeekStart); err != nil {
+		return "", fmt.Errorf("rewind temporary export file: %w", err)
+	}
+
+	if _, err := mgr.Import(ctx, digestRef.Original, "-", exportFile); err != nil {
+		return "", fmt.Errorf("import local docker image %q into cleanroom cache: %w", source, err)
+	}
+
+	_, _ = fmt.Fprintf(os.Stderr, "imported local docker image override as %s\n", digestRef.Original)
+	return digestRef.Original, nil
 }
 
 func getFinalExecutionExitCode(client *controlclient.Client, sandboxID, executionID string) (int, bool) {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -287,9 +287,12 @@ var (
 		return fmt.Sprintf("%s@%s", tag.Context().Name(), desc.Digest.String()), nil
 	}
 	importLocalDockerImageForOverrideFn = importLocalDockerImageForOverride
-	resolveReferenceForImageOverride    = func(ctx context.Context, source string) (string, error) {
+	resolveReferenceForImageOverride    = func(ctx context.Context, source string, allowLocal bool) (string, error) {
 		localRef, localErr := importLocalDockerImageForOverrideFn(ctx, source)
 		if localErr == nil {
+			if !allowLocal {
+				return "", errors.New("local docker image overrides require a local control-plane endpoint (unix socket)")
+			}
 			return localRef, nil
 		}
 
@@ -706,7 +709,11 @@ func runSandboxCreate(ctx *runtimeContext, connectFlags clientFlags, chdir, back
 	if err != nil {
 		return err
 	}
-	compiled, err = overrideCompiledPolicyImage(compiled, imageRefOverride)
+	allowLocalImageOverride, err := isLocalControlPlaneEndpoint(connectFlags.Host)
+	if err != nil {
+		return err
+	}
+	compiled, err = overrideCompiledPolicyImage(compiled, imageRefOverride, allowLocalImageOverride)
 	if err != nil {
 		return err
 	}
@@ -767,7 +774,7 @@ func (e *ExecCommand) Run(ctx *runtimeContext) error {
 		"sandbox_id", strings.TrimSpace(e.SandboxID),
 		"command_argc", len(e.Command),
 	)
-	sandboxID, err := ensureSandboxID(client, ctx.Loader, cwd, e.Backend, strings.TrimSpace(e.SandboxID), e.Image, e.LaunchSeconds)
+	sandboxID, err := ensureSandboxID(client, ctx.Loader, cwd, e.Host, e.Backend, strings.TrimSpace(e.SandboxID), e.Image, e.LaunchSeconds)
 	if err != nil {
 		return err
 	}
@@ -947,7 +954,7 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) error {
 		"sandbox_id", strings.TrimSpace(c.SandboxID),
 		"command_argc", len(command),
 	)
-	sandboxID, err := ensureSandboxID(client, ctx.Loader, cwd, c.Backend, strings.TrimSpace(c.SandboxID), c.Image, c.LaunchSeconds)
+	sandboxID, err := ensureSandboxID(client, ctx.Loader, cwd, c.Host, c.Backend, strings.TrimSpace(c.SandboxID), c.Image, c.LaunchSeconds)
 	if err != nil {
 		return err
 	}
@@ -1907,7 +1914,7 @@ func inspectRun(stdout *os.File, baseDir, runID string) error {
 	return err
 }
 
-func ensureSandboxID(client *controlclient.Client, loader policyLoader, cwd, backendName, existingSandboxID, imageRefOverride string, launchSeconds int64) (string, error) {
+func ensureSandboxID(client *controlclient.Client, loader policyLoader, cwd, host, backendName, existingSandboxID, imageRefOverride string, launchSeconds int64) (string, error) {
 	sandboxID := strings.TrimSpace(existingSandboxID)
 	if sandboxID != "" {
 		if strings.TrimSpace(imageRefOverride) != "" {
@@ -1920,7 +1927,11 @@ func ensureSandboxID(client *controlclient.Client, loader policyLoader, cwd, bac
 	if err != nil {
 		return "", err
 	}
-	compiled, err = overrideCompiledPolicyImage(compiled, imageRefOverride)
+	allowLocalImageOverride, err := isLocalControlPlaneEndpoint(host)
+	if err != nil {
+		return "", err
+	}
+	compiled, err = overrideCompiledPolicyImage(compiled, imageRefOverride, allowLocalImageOverride)
 	if err != nil {
 		return "", err
 	}
@@ -1937,13 +1948,21 @@ func ensureSandboxID(client *controlclient.Client, loader policyLoader, cwd, bac
 	return strings.TrimSpace(createSandboxResp.GetSandbox().GetSandboxId()), nil
 }
 
-func overrideCompiledPolicyImage(compiled *policy.CompiledPolicy, imageRefOverride string) (*policy.CompiledPolicy, error) {
+func isLocalControlPlaneEndpoint(host string) (bool, error) {
+	ep, err := endpoint.Resolve(host)
+	if err != nil {
+		return false, err
+	}
+	return ep.Scheme == "unix", nil
+}
+
+func overrideCompiledPolicyImage(compiled *policy.CompiledPolicy, imageRefOverride string, allowLocal bool) (*policy.CompiledPolicy, error) {
 	imageRefOverride = strings.TrimSpace(imageRefOverride)
 	if imageRefOverride == "" {
 		return compiled, nil
 	}
 
-	resolvedRef, err := resolveReferenceForImageOverride(context.Background(), imageRefOverride)
+	resolvedRef, err := resolveReferenceForImageOverride(context.Background(), imageRefOverride, allowLocal)
 	if err != nil {
 		return nil, fmt.Errorf("invalid --image value: %w", err)
 	}

--- a/internal/cli/cli_parse_test.go
+++ b/internal/cli/cli_parse_test.go
@@ -104,12 +104,64 @@ func TestSandboxCreateParses(t *testing.T) {
 	}
 }
 
+func TestSandboxCreateParsesImageOverride(t *testing.T) {
+	c := &CLI{}
+	parser := newParserForTest(t, c)
+
+	imageRef := "ghcr.io/buildkite/cleanroom-base/alpine@sha256:1111111111111111111111111111111111111111111111111111111111111111"
+	if _, err := parser.Parse([]string{"sandbox", "create", "--image", imageRef}); err != nil {
+		t.Fatalf("parse sandbox create --image returned error: %v", err)
+	}
+	if got, want := c.Sandbox.Create.Image, imageRef; got != want {
+		t.Fatalf("unexpected sandbox create image override: got %q want %q", got, want)
+	}
+}
+
 func TestTopLevelCreateParses(t *testing.T) {
 	c := &CLI{}
 	parser := newParserForTest(t, c)
 
 	if _, err := parser.Parse([]string{"create"}); err != nil {
 		t.Fatalf("parse create returned error: %v", err)
+	}
+}
+
+func TestTopLevelCreateParsesImageOverride(t *testing.T) {
+	c := &CLI{}
+	parser := newParserForTest(t, c)
+
+	imageRef := "ghcr.io/buildkite/cleanroom-base/alpine@sha256:2222222222222222222222222222222222222222222222222222222222222222"
+	if _, err := parser.Parse([]string{"create", "--image", imageRef}); err != nil {
+		t.Fatalf("parse create --image returned error: %v", err)
+	}
+	if got, want := c.Create.Image, imageRef; got != want {
+		t.Fatalf("unexpected create image override: got %q want %q", got, want)
+	}
+}
+
+func TestExecParsesImageOverride(t *testing.T) {
+	c := &CLI{}
+	parser := newParserForTest(t, c)
+
+	imageRef := "ghcr.io/buildkite/cleanroom-base/alpine@sha256:3333333333333333333333333333333333333333333333333333333333333333"
+	if _, err := parser.Parse([]string{"exec", "--image", imageRef, "--", "echo", "ok"}); err != nil {
+		t.Fatalf("parse exec --image returned error: %v", err)
+	}
+	if got, want := c.Exec.Image, imageRef; got != want {
+		t.Fatalf("unexpected exec image override: got %q want %q", got, want)
+	}
+}
+
+func TestConsoleParsesImageOverride(t *testing.T) {
+	c := &CLI{}
+	parser := newParserForTest(t, c)
+
+	imageRef := "ghcr.io/buildkite/cleanroom-base/alpine@sha256:4444444444444444444444444444444444444444444444444444444444444444"
+	if _, err := parser.Parse([]string{"console", "--image", imageRef, "--", "sh"}); err != nil {
+		t.Fatalf("parse console --image returned error: %v", err)
+	}
+	if got, want := c.Console.Image, imageRef; got != want {
+		t.Fatalf("unexpected console image override: got %q want %q", got, want)
 	}
 }
 

--- a/internal/cli/image_override_integration_test.go
+++ b/internal/cli/image_override_integration_test.go
@@ -25,9 +25,12 @@ func stubImageOverrideResolver(t *testing.T, fn func(context.Context, string, bo
 }
 
 func TestSandboxCreateIntegrationOverridesImageRefForNewSandbox(t *testing.T) {
-	restore := stubImageOverrideResolver(t, func(_ context.Context, source string, _ bool) (string, error) {
+	restore := stubImageOverrideResolver(t, func(_ context.Context, source string, allowLocal bool) (string, error) {
 		if got, want := source, testImageOverrideTag; got != want {
 			t.Fatalf("unexpected source passed to resolver: got %q want %q", got, want)
+		}
+		if allowLocal {
+			t.Fatal("expected allowLocal=false for non-unix integration host")
 		}
 		return testImageOverrideRef, nil
 	})
@@ -89,9 +92,12 @@ func TestSandboxCreateIntegrationOverridesImageRefForNewSandbox(t *testing.T) {
 }
 
 func TestExecIntegrationOverridesImageRefForCreatedSandbox(t *testing.T) {
-	restore := stubImageOverrideResolver(t, func(_ context.Context, source string, _ bool) (string, error) {
+	restore := stubImageOverrideResolver(t, func(_ context.Context, source string, allowLocal bool) (string, error) {
 		if got, want := source, testImageOverrideTag; got != want {
 			t.Fatalf("unexpected source passed to resolver: got %q want %q", got, want)
+		}
+		if allowLocal {
+			t.Fatal("expected allowLocal=false for non-unix integration host")
 		}
 		return testImageOverrideRef, nil
 	})
@@ -133,9 +139,12 @@ func TestExecIntegrationOverridesImageRefForCreatedSandbox(t *testing.T) {
 }
 
 func TestConsoleIntegrationOverridesImageRefForCreatedSandbox(t *testing.T) {
-	restore := stubImageOverrideResolver(t, func(_ context.Context, source string, _ bool) (string, error) {
+	restore := stubImageOverrideResolver(t, func(_ context.Context, source string, allowLocal bool) (string, error) {
 		if got, want := source, testImageOverrideTag; got != want {
 			t.Fatalf("unexpected source passed to resolver: got %q want %q", got, want)
+		}
+		if allowLocal {
+			t.Fatal("expected allowLocal=false for non-unix integration host")
 		}
 		return testImageOverrideRef, nil
 	})
@@ -173,40 +182,6 @@ func TestConsoleIntegrationOverridesImageRefForCreatedSandbox(t *testing.T) {
 	gotImageRef := mustReceiveWithin(t, imageRefCh, 2*time.Second, "timed out waiting for run request policy")
 	if got, want := gotImageRef, testImageOverrideRef; got != want {
 		t.Fatalf("unexpected image ref: got %q want %q", got, want)
-	}
-}
-
-func TestExecIntegrationRejectsLocalImageOverrideForRemoteHost(t *testing.T) {
-	restore := stubImageOverrideResolver(t, func(_ context.Context, source string, allowLocal bool) (string, error) {
-		if got, want := source, testImageOverrideTag; got != want {
-			t.Fatalf("unexpected source passed to resolver: got %q want %q", got, want)
-		}
-		if allowLocal {
-			t.Fatal("expected allowLocal=false for non-unix integration host")
-		}
-		return "", errors.New("local docker image overrides require a local control-plane endpoint (unix socket)")
-	})
-	defer restore()
-
-	host, _ := startIntegrationServer(t, &integrationAdapter{})
-	cwd := t.TempDir()
-	outcome := runExecWithCapture(ExecCommand{
-		clientFlags: clientFlags{Host: host},
-		Chdir:       cwd,
-		Image:       testImageOverrideTag,
-		Command:     []string{"echo", "ok"},
-	}, runtimeContext{
-		CWD:    cwd,
-		Loader: integrationLoader{},
-	})
-	if outcome.cause != nil {
-		t.Fatalf("capture failure: %v", outcome.cause)
-	}
-	if outcome.err == nil {
-		t.Fatal("expected ExecCommand.Run to fail for remote host local image override")
-	}
-	if got, want := outcome.err.Error(), "invalid --image value: local docker image overrides require a local control-plane endpoint"; !strings.Contains(got, want) {
-		t.Fatalf("expected error to contain %q, got %q", want, got)
 	}
 }
 

--- a/internal/cli/image_override_integration_test.go
+++ b/internal/cli/image_override_integration_test.go
@@ -1,0 +1,231 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+)
+
+const (
+	testImageOverrideRef = "ghcr.io/buildkite/cleanroom-base/alpine@sha256:1111111111111111111111111111111111111111111111111111111111111111"
+	testImageOverrideTag = "ghcr.io/buildkite/cleanroom-base/alpine:latest"
+)
+
+func stubImageOverrideResolver(t *testing.T, fn func(context.Context, string) (string, error)) func() {
+	t.Helper()
+	prev := resolveReferenceForImageOverride
+	resolveReferenceForImageOverride = fn
+	return func() {
+		resolveReferenceForImageOverride = prev
+	}
+}
+
+func TestSandboxCreateIntegrationOverridesImageRefForNewSandbox(t *testing.T) {
+	restore := stubImageOverrideResolver(t, func(_ context.Context, source string) (string, error) {
+		if got, want := source, testImageOverrideTag; got != want {
+			t.Fatalf("unexpected source passed to resolver: got %q want %q", got, want)
+		}
+		return testImageOverrideRef, nil
+	})
+	defer restore()
+
+	imageRefCh := make(chan string, 1)
+	adapter := &integrationAdapter{
+		runFn: func(_ context.Context, req backend.RunRequest) (*backend.RunResult, error) {
+			if req.Policy == nil {
+				return nil, errors.New("expected policy on run request")
+			}
+			imageRefCh <- req.Policy.ImageRef
+			return &backend.RunResult{RunID: req.RunID, ExitCode: 0, Message: "ok"}, nil
+		},
+	}
+
+	host, _ := startIntegrationServer(t, adapter)
+	cwd := t.TempDir()
+
+	createOutcome := runSandboxCreateWithCapture(SandboxCreateCommand{
+		clientFlags: clientFlags{Host: host},
+		Chdir:       cwd,
+		Image:       testImageOverrideTag,
+	}, runtimeContext{
+		CWD:    cwd,
+		Loader: integrationLoader{},
+	})
+	if createOutcome.cause != nil {
+		t.Fatalf("capture failure: %v", createOutcome.cause)
+	}
+	if createOutcome.err != nil {
+		t.Fatalf("SandboxCreateCommand.Run returned error: %v", createOutcome.err)
+	}
+	sandboxID := strings.TrimSpace(createOutcome.stdout)
+	if sandboxID == "" {
+		t.Fatalf("expected sandbox id output, got %q", createOutcome.stdout)
+	}
+
+	execOutcome := runExecWithCapture(ExecCommand{
+		clientFlags: clientFlags{Host: host},
+		Chdir:       cwd,
+		SandboxID:   sandboxID,
+		Command:     []string{"echo", "ok"},
+	}, runtimeContext{
+		CWD:    cwd,
+		Loader: failingLoader{},
+	})
+	if execOutcome.cause != nil {
+		t.Fatalf("capture failure: %v", execOutcome.cause)
+	}
+	if execOutcome.err != nil {
+		t.Fatalf("ExecCommand.Run returned error: %v", execOutcome.err)
+	}
+
+	gotImageRef := mustReceiveWithin(t, imageRefCh, 2*time.Second, "timed out waiting for run request policy")
+	if got, want := gotImageRef, testImageOverrideRef; got != want {
+		t.Fatalf("unexpected image ref: got %q want %q", got, want)
+	}
+}
+
+func TestExecIntegrationOverridesImageRefForCreatedSandbox(t *testing.T) {
+	restore := stubImageOverrideResolver(t, func(_ context.Context, source string) (string, error) {
+		if got, want := source, testImageOverrideTag; got != want {
+			t.Fatalf("unexpected source passed to resolver: got %q want %q", got, want)
+		}
+		return testImageOverrideRef, nil
+	})
+	defer restore()
+
+	imageRefCh := make(chan string, 1)
+	adapter := &integrationAdapter{
+		runFn: func(_ context.Context, req backend.RunRequest) (*backend.RunResult, error) {
+			if req.Policy == nil {
+				return nil, errors.New("expected policy on run request")
+			}
+			imageRefCh <- req.Policy.ImageRef
+			return &backend.RunResult{RunID: req.RunID, ExitCode: 0, Message: "ok"}, nil
+		},
+	}
+
+	host, _ := startIntegrationServer(t, adapter)
+	cwd := t.TempDir()
+	outcome := runExecWithCapture(ExecCommand{
+		clientFlags: clientFlags{Host: host},
+		Chdir:       cwd,
+		Image:       testImageOverrideTag,
+		Command:     []string{"echo", "ok"},
+	}, runtimeContext{
+		CWD:    cwd,
+		Loader: integrationLoader{},
+	})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err != nil {
+		t.Fatalf("ExecCommand.Run returned error: %v", outcome.err)
+	}
+
+	gotImageRef := mustReceiveWithin(t, imageRefCh, 2*time.Second, "timed out waiting for run request policy")
+	if got, want := gotImageRef, testImageOverrideRef; got != want {
+		t.Fatalf("unexpected image ref: got %q want %q", got, want)
+	}
+}
+
+func TestConsoleIntegrationOverridesImageRefForCreatedSandbox(t *testing.T) {
+	restore := stubImageOverrideResolver(t, func(_ context.Context, source string) (string, error) {
+		if got, want := source, testImageOverrideTag; got != want {
+			t.Fatalf("unexpected source passed to resolver: got %q want %q", got, want)
+		}
+		return testImageOverrideRef, nil
+	})
+	defer restore()
+
+	imageRefCh := make(chan string, 1)
+	adapter := &integrationAdapter{
+		runStreamFn: func(_ context.Context, req backend.RunRequest, _ backend.OutputStream) (*backend.RunResult, error) {
+			if req.Policy == nil {
+				return nil, errors.New("expected policy on run request")
+			}
+			imageRefCh <- req.Policy.ImageRef
+			return &backend.RunResult{RunID: req.RunID, ExitCode: 0, Message: "ok"}, nil
+		},
+	}
+
+	host, _ := startIntegrationServer(t, adapter)
+	cwd := t.TempDir()
+	outcome := runConsoleWithCapture(ConsoleCommand{
+		clientFlags: clientFlags{Host: host},
+		Chdir:       cwd,
+		Image:       testImageOverrideTag,
+		Command:     []string{"sh"},
+	}, "", runtimeContext{
+		CWD:    cwd,
+		Loader: integrationLoader{},
+	})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err != nil {
+		t.Fatalf("ConsoleCommand.Run returned error: %v", outcome.err)
+	}
+
+	gotImageRef := mustReceiveWithin(t, imageRefCh, 2*time.Second, "timed out waiting for run request policy")
+	if got, want := gotImageRef, testImageOverrideRef; got != want {
+		t.Fatalf("unexpected image ref: got %q want %q", got, want)
+	}
+}
+
+func TestExecIntegrationRejectsImageOverrideWhenSandboxProvided(t *testing.T) {
+	host, _ := startIntegrationServer(t, &integrationAdapter{})
+	client := mustNewControlClient(t, host)
+	sandboxID := mustCreateSandbox(t, client)
+
+	outcome := runExecWithCapture(ExecCommand{
+		clientFlags: clientFlags{Host: host},
+		SandboxID:   sandboxID,
+		Image:       testImageOverrideRef,
+		Command:     []string{"echo", "ok"},
+	}, runtimeContext{
+		CWD:    t.TempDir(),
+		Loader: failingLoader{},
+	})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err == nil {
+		t.Fatal("expected ExecCommand.Run to fail when both --sandbox-id and --image are set")
+	}
+	if got, want := outcome.err.Error(), "--image cannot be used with --sandbox-id"; !strings.Contains(got, want) {
+		t.Fatalf("expected error to contain %q, got %q", want, got)
+	}
+}
+
+func TestConsoleIntegrationRejectsImageOverrideWhenSandboxProvided(t *testing.T) {
+	host, _ := startIntegrationServer(t, &integrationAdapter{
+		runStreamFn: func(_ context.Context, req backend.RunRequest, _ backend.OutputStream) (*backend.RunResult, error) {
+			return &backend.RunResult{RunID: req.RunID, ExitCode: 0, Message: "ok"}, nil
+		},
+	})
+	client := mustNewControlClient(t, host)
+	sandboxID := mustCreateSandbox(t, client)
+
+	outcome := runConsoleWithCapture(ConsoleCommand{
+		clientFlags: clientFlags{Host: host},
+		SandboxID:   sandboxID,
+		Image:       testImageOverrideRef,
+		Command:     []string{"sh"},
+	}, "", runtimeContext{
+		CWD:    t.TempDir(),
+		Loader: failingLoader{},
+	})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err == nil {
+		t.Fatal("expected ConsoleCommand.Run to fail when both --sandbox-id and --image are set")
+	}
+	if got, want := outcome.err.Error(), "--image cannot be used with --sandbox-id"; !strings.Contains(got, want) {
+		t.Fatalf("expected error to contain %q, got %q", want, got)
+	}
+}

--- a/internal/cli/image_override_integration_test.go
+++ b/internal/cli/image_override_integration_test.go
@@ -15,7 +15,7 @@ const (
 	testImageOverrideTag = "ghcr.io/buildkite/cleanroom-base/alpine:latest"
 )
 
-func stubImageOverrideResolver(t *testing.T, fn func(context.Context, string) (string, error)) func() {
+func stubImageOverrideResolver(t *testing.T, fn func(context.Context, string, bool) (string, error)) func() {
 	t.Helper()
 	prev := resolveReferenceForImageOverride
 	resolveReferenceForImageOverride = fn
@@ -25,7 +25,7 @@ func stubImageOverrideResolver(t *testing.T, fn func(context.Context, string) (s
 }
 
 func TestSandboxCreateIntegrationOverridesImageRefForNewSandbox(t *testing.T) {
-	restore := stubImageOverrideResolver(t, func(_ context.Context, source string) (string, error) {
+	restore := stubImageOverrideResolver(t, func(_ context.Context, source string, _ bool) (string, error) {
 		if got, want := source, testImageOverrideTag; got != want {
 			t.Fatalf("unexpected source passed to resolver: got %q want %q", got, want)
 		}
@@ -89,7 +89,7 @@ func TestSandboxCreateIntegrationOverridesImageRefForNewSandbox(t *testing.T) {
 }
 
 func TestExecIntegrationOverridesImageRefForCreatedSandbox(t *testing.T) {
-	restore := stubImageOverrideResolver(t, func(_ context.Context, source string) (string, error) {
+	restore := stubImageOverrideResolver(t, func(_ context.Context, source string, _ bool) (string, error) {
 		if got, want := source, testImageOverrideTag; got != want {
 			t.Fatalf("unexpected source passed to resolver: got %q want %q", got, want)
 		}
@@ -133,7 +133,7 @@ func TestExecIntegrationOverridesImageRefForCreatedSandbox(t *testing.T) {
 }
 
 func TestConsoleIntegrationOverridesImageRefForCreatedSandbox(t *testing.T) {
-	restore := stubImageOverrideResolver(t, func(_ context.Context, source string) (string, error) {
+	restore := stubImageOverrideResolver(t, func(_ context.Context, source string, _ bool) (string, error) {
 		if got, want := source, testImageOverrideTag; got != want {
 			t.Fatalf("unexpected source passed to resolver: got %q want %q", got, want)
 		}
@@ -173,6 +173,40 @@ func TestConsoleIntegrationOverridesImageRefForCreatedSandbox(t *testing.T) {
 	gotImageRef := mustReceiveWithin(t, imageRefCh, 2*time.Second, "timed out waiting for run request policy")
 	if got, want := gotImageRef, testImageOverrideRef; got != want {
 		t.Fatalf("unexpected image ref: got %q want %q", got, want)
+	}
+}
+
+func TestExecIntegrationRejectsLocalImageOverrideForRemoteHost(t *testing.T) {
+	restore := stubImageOverrideResolver(t, func(_ context.Context, source string, allowLocal bool) (string, error) {
+		if got, want := source, testImageOverrideTag; got != want {
+			t.Fatalf("unexpected source passed to resolver: got %q want %q", got, want)
+		}
+		if allowLocal {
+			t.Fatal("expected allowLocal=false for non-unix integration host")
+		}
+		return "", errors.New("local docker image overrides require a local control-plane endpoint (unix socket)")
+	})
+	defer restore()
+
+	host, _ := startIntegrationServer(t, &integrationAdapter{})
+	cwd := t.TempDir()
+	outcome := runExecWithCapture(ExecCommand{
+		clientFlags: clientFlags{Host: host},
+		Chdir:       cwd,
+		Image:       testImageOverrideTag,
+		Command:     []string{"echo", "ok"},
+	}, runtimeContext{
+		CWD:    cwd,
+		Loader: integrationLoader{},
+	})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err == nil {
+		t.Fatal("expected ExecCommand.Run to fail for remote host local image override")
+	}
+	if got, want := outcome.err.Error(), "invalid --image value: local docker image overrides require a local control-plane endpoint"; !strings.Contains(got, want) {
+		t.Fatalf("expected error to contain %q, got %q", want, got)
 	}
 }
 

--- a/internal/cli/image_override_resolution_test.go
+++ b/internal/cli/image_override_resolution_test.go
@@ -1,0 +1,107 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func withImageOverrideResolversForTest(
+	t *testing.T,
+	localFn func(context.Context, string) (string, error),
+	remoteFn func(context.Context, string) (string, error),
+) {
+	t.Helper()
+	prevLocal := importLocalDockerImageForOverrideFn
+	prevRemote := resolveReferenceForPolicyUpdate
+	importLocalDockerImageForOverrideFn = localFn
+	resolveReferenceForPolicyUpdate = remoteFn
+	t.Cleanup(func() {
+		importLocalDockerImageForOverrideFn = prevLocal
+		resolveReferenceForPolicyUpdate = prevRemote
+	})
+}
+
+func TestResolveReferenceForImageOverridePrefersLocal(t *testing.T) {
+	localCalls := 0
+	remoteCalls := 0
+	localRef := "local/docker-image@sha256:1111111111111111111111111111111111111111111111111111111111111111"
+	remoteRef := "ghcr.io/buildkite/cleanroom-base/alpine@sha256:2222222222222222222222222222222222222222222222222222222222222222"
+	withImageOverrideResolversForTest(
+		t,
+		func(_ context.Context, source string) (string, error) {
+			localCalls++
+			if got, want := source, "alpine:latest"; got != want {
+				t.Fatalf("unexpected local resolver source: got %q want %q", got, want)
+			}
+			return localRef, nil
+		},
+		func(_ context.Context, _ string) (string, error) {
+			remoteCalls++
+			return remoteRef, nil
+		},
+	)
+
+	got, err := resolveReferenceForImageOverride(context.Background(), "alpine:latest")
+	if err != nil {
+		t.Fatalf("resolveReferenceForImageOverride returned error: %v", err)
+	}
+	if got != localRef {
+		t.Fatalf("unexpected resolved ref: got %q want %q", got, localRef)
+	}
+	if localCalls != 1 {
+		t.Fatalf("expected local resolver call count 1, got %d", localCalls)
+	}
+	if remoteCalls != 0 {
+		t.Fatalf("expected remote resolver call count 0, got %d", remoteCalls)
+	}
+}
+
+func TestResolveReferenceForImageOverrideFallsBackToRemote(t *testing.T) {
+	localErr := errors.New("local image not found")
+	remoteRef := "ghcr.io/buildkite/cleanroom-base/alpine@sha256:3333333333333333333333333333333333333333333333333333333333333333"
+	withImageOverrideResolversForTest(
+		t,
+		func(_ context.Context, _ string) (string, error) {
+			return "", localErr
+		},
+		func(_ context.Context, source string) (string, error) {
+			if got, want := source, "alpine:latest"; got != want {
+				t.Fatalf("unexpected remote resolver source: got %q want %q", got, want)
+			}
+			return remoteRef, nil
+		},
+	)
+
+	got, err := resolveReferenceForImageOverride(context.Background(), "alpine:latest")
+	if err != nil {
+		t.Fatalf("resolveReferenceForImageOverride returned error: %v", err)
+	}
+	if got != remoteRef {
+		t.Fatalf("unexpected resolved ref: got %q want %q", got, remoteRef)
+	}
+}
+
+func TestResolveReferenceForImageOverrideReturnsCombinedError(t *testing.T) {
+	withImageOverrideResolversForTest(
+		t,
+		func(_ context.Context, _ string) (string, error) {
+			return "", errors.New("local missing")
+		},
+		func(_ context.Context, _ string) (string, error) {
+			return "", errors.New("remote unavailable")
+		},
+	)
+
+	_, err := resolveReferenceForImageOverride(context.Background(), "alpine:latest")
+	if err == nil {
+		t.Fatal("expected resolveReferenceForImageOverride to fail when local and remote resolution fail")
+	}
+	if !strings.Contains(err.Error(), "remote unavailable") {
+		t.Fatalf("expected remote error in returned message, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "local docker resolution failed: local missing") {
+		t.Fatalf("expected local error in returned message, got %v", err)
+	}
+}

--- a/internal/cli/image_override_resolution_test.go
+++ b/internal/cli/image_override_resolution_test.go
@@ -43,7 +43,7 @@ func TestResolveReferenceForImageOverridePrefersLocal(t *testing.T) {
 		},
 	)
 
-	got, err := resolveReferenceForImageOverride(context.Background(), "alpine:latest")
+	got, err := resolveReferenceForImageOverride(context.Background(), "alpine:latest", true)
 	if err != nil {
 		t.Fatalf("resolveReferenceForImageOverride returned error: %v", err)
 	}
@@ -74,7 +74,7 @@ func TestResolveReferenceForImageOverrideFallsBackToRemote(t *testing.T) {
 		},
 	)
 
-	got, err := resolveReferenceForImageOverride(context.Background(), "alpine:latest")
+	got, err := resolveReferenceForImageOverride(context.Background(), "alpine:latest", true)
 	if err != nil {
 		t.Fatalf("resolveReferenceForImageOverride returned error: %v", err)
 	}
@@ -94,7 +94,7 @@ func TestResolveReferenceForImageOverrideReturnsCombinedError(t *testing.T) {
 		},
 	)
 
-	_, err := resolveReferenceForImageOverride(context.Background(), "alpine:latest")
+	_, err := resolveReferenceForImageOverride(context.Background(), "alpine:latest", true)
 	if err == nil {
 		t.Fatal("expected resolveReferenceForImageOverride to fail when local and remote resolution fail")
 	}
@@ -103,5 +103,30 @@ func TestResolveReferenceForImageOverrideReturnsCombinedError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "local docker resolution failed: local missing") {
 		t.Fatalf("expected local error in returned message, got %v", err)
+	}
+}
+
+func TestResolveReferenceForImageOverrideRejectsLocalForRemoteEndpoint(t *testing.T) {
+	remoteCalls := 0
+	withImageOverrideResolversForTest(
+		t,
+		func(_ context.Context, _ string) (string, error) {
+			return "local/docker-image@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", nil
+		},
+		func(_ context.Context, _ string) (string, error) {
+			remoteCalls++
+			return "ghcr.io/buildkite/cleanroom-base/alpine@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", nil
+		},
+	)
+
+	_, err := resolveReferenceForImageOverride(context.Background(), "alpine:latest", false)
+	if err == nil {
+		t.Fatal("expected local override rejection for non-local control-plane endpoint")
+	}
+	if !strings.Contains(err.Error(), "local docker image overrides require a local control-plane endpoint") {
+		t.Fatalf("expected local-endpoint requirement error, got %v", err)
+	}
+	if remoteCalls != 0 {
+		t.Fatalf("expected remote resolver call count 0, got %d", remoteCalls)
 	}
 }

--- a/internal/cli/image_override_resolution_test.go
+++ b/internal/cli/image_override_resolution_test.go
@@ -106,27 +106,33 @@ func TestResolveReferenceForImageOverrideReturnsCombinedError(t *testing.T) {
 	}
 }
 
-func TestResolveReferenceForImageOverrideRejectsLocalForRemoteEndpoint(t *testing.T) {
+func TestResolveReferenceForImageOverrideSkipsLocalForRemoteEndpoint(t *testing.T) {
+	localCalls := 0
 	remoteCalls := 0
+	remoteRef := "ghcr.io/buildkite/cleanroom-base/alpine@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 	withImageOverrideResolversForTest(
 		t,
 		func(_ context.Context, _ string) (string, error) {
+			localCalls++
 			return "local/docker-image@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", nil
 		},
 		func(_ context.Context, _ string) (string, error) {
 			remoteCalls++
-			return "ghcr.io/buildkite/cleanroom-base/alpine@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", nil
+			return remoteRef, nil
 		},
 	)
 
-	_, err := resolveReferenceForImageOverride(context.Background(), "alpine:latest", false)
-	if err == nil {
-		t.Fatal("expected local override rejection for non-local control-plane endpoint")
+	got, err := resolveReferenceForImageOverride(context.Background(), "alpine:latest", false)
+	if err != nil {
+		t.Fatalf("resolveReferenceForImageOverride returned error: %v", err)
 	}
-	if !strings.Contains(err.Error(), "local docker image overrides require a local control-plane endpoint") {
-		t.Fatalf("expected local-endpoint requirement error, got %v", err)
+	if got != remoteRef {
+		t.Fatalf("unexpected resolved ref: got %q want %q", got, remoteRef)
 	}
-	if remoteCalls != 0 {
-		t.Fatalf("expected remote resolver call count 0, got %d", remoteCalls)
+	if localCalls != 0 {
+		t.Fatalf("expected local resolver call count 0, got %d", localCalls)
+	}
+	if remoteCalls != 1 {
+		t.Fatalf("expected remote resolver call count 1, got %d", remoteCalls)
 	}
 }


### PR DESCRIPTION
## Summary
- add `--image` to `cleanroom sandbox create` and top-level `cleanroom create`
- add `--image` to `cleanroom exec` and `cleanroom console` when they auto-create a sandbox
- resolve remote tags to digest-pinned refs, with fallback to importing local Docker images into the cleanroom image cache
- reject `--image` when `--sandbox-id` is set
- add parser + integration coverage for image override behavior and update README usage examples

## Testing
- `mise exec go@1.23 -- go test ./internal/cli -count=1`
- `mise exec go@1.23 -- go test ./... -count=1`
- `mise exec go@1.23 -- go build ./...`
- `mise run lint-shell`
