### PR TITLE
fix: prevent darwin-vz exec hangs on shell-less images

### DIFF
--- a/cmd/cleanroom-guest-agent/main.go
+++ b/cmd/cleanroom-guest-agent/main.go
@@ -12,7 +12,6 @@ import (
 	"net"
 	"os"
 	"os/exec"
-	"strconv"
 	"strings"
 	"sync"
 	"unsafe"
@@ -29,14 +28,10 @@ func main() {
 		return
 	}
 
-	port := vsockexec.DefaultPort
-	if raw := os.Getenv("CLEANROOM_VSOCK_PORT"); raw != "" {
-		parsed, err := strconv.ParseUint(raw, 10, 32)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "invalid CLEANROOM_VSOCK_PORT %q: %v\n", raw, err)
-			os.Exit(2)
-		}
-		port = uint32(parsed)
+	port, err := resolveGuestAgentPort(vsockexec.DefaultPort, os.Getenv("CLEANROOM_VSOCK_PORT"), readKernelCmdline())
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(2)
 	}
 
 	ln, err := listenVsock(port)

--- a/cmd/cleanroom-guest-agent/port.go
+++ b/cmd/cleanroom-guest-agent/port.go
@@ -28,7 +28,19 @@ func resolveGuestAgentPort(defaultPort uint32, envPort, cmdline string) (uint32,
 }
 
 func readKernelCmdline() string {
-	raw, err := os.ReadFile("/proc/cmdline")
+	return readKernelCmdlineWith(os.ReadFile, ensureProcMounted)
+}
+
+func readKernelCmdlineWith(readFileFn func(string) ([]byte, error), mountProcFn func() error) string {
+	raw, err := readFileFn("/proc/cmdline")
+	if err == nil {
+		return strings.TrimSpace(string(raw))
+	}
+	if mountProcFn != nil {
+		if mountErr := mountProcFn(); mountErr == nil {
+			raw, err = readFileFn("/proc/cmdline")
+		}
+	}
 	if err != nil {
 		return ""
 	}

--- a/cmd/cleanroom-guest-agent/port.go
+++ b/cmd/cleanroom-guest-agent/port.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+func resolveGuestAgentPort(defaultPort uint32, envPort, cmdline string) (uint32, error) {
+	rawPort := strings.TrimSpace(envPort)
+	source := "CLEANROOM_VSOCK_PORT"
+	if rawPort == "" {
+		if cmdlinePort, ok := kernelCmdlineValue(cmdline, "cleanroom_guest_port"); ok {
+			rawPort = strings.TrimSpace(cmdlinePort)
+			source = "cleanroom_guest_port"
+		}
+	}
+	if rawPort == "" {
+		return defaultPort, nil
+	}
+
+	parsed, err := strconv.ParseUint(rawPort, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s %q: %w", source, rawPort, err)
+	}
+	return uint32(parsed), nil
+}
+
+func readKernelCmdline() string {
+	raw, err := os.ReadFile("/proc/cmdline")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(raw))
+}
+
+func kernelCmdlineValue(cmdline, key string) (string, bool) {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return "", false
+	}
+	prefix := key + "="
+	for _, token := range strings.Fields(cmdline) {
+		if strings.HasPrefix(token, prefix) {
+			return strings.TrimPrefix(token, prefix), true
+		}
+	}
+	return "", false
+}

--- a/cmd/cleanroom-guest-agent/port_mount_linux.go
+++ b/cmd/cleanroom-guest-agent/port_mount_linux.go
@@ -1,0 +1,23 @@
+//go:build linux
+
+package main
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func ensureProcMounted() error {
+	if err := os.MkdirAll("/proc", 0o755); err != nil {
+		return err
+	}
+	if err := unix.Mount("proc", "/proc", "proc", 0, ""); err != nil {
+		if errors.Is(err, unix.EBUSY) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}

--- a/cmd/cleanroom-guest-agent/port_mount_nonlinux.go
+++ b/cmd/cleanroom-guest-agent/port_mount_nonlinux.go
@@ -1,0 +1,7 @@
+//go:build !linux
+
+package main
+
+func ensureProcMounted() error {
+	return nil
+}

--- a/cmd/cleanroom-guest-agent/port_test.go
+++ b/cmd/cleanroom-guest-agent/port_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"strings"
 	"testing"
 )
@@ -70,5 +71,83 @@ func TestKernelCmdlineValueReturnsExactKeyMatch(t *testing.T) {
 
 	if value, ok := kernelCmdlineValue("xcleanroom_guest_port=9999 cleanroom_guest_port=22222", "cleanroom_guest_port"); !ok || value != "22222" {
 		t.Fatalf("unexpected key parse result: ok=%t value=%q", ok, value)
+	}
+}
+
+func TestReadKernelCmdlineWithRetriesAfterMountingProc(t *testing.T) {
+	t.Parallel()
+
+	readCalls := 0
+	mountCalls := 0
+	got := readKernelCmdlineWith(
+		func(path string) ([]byte, error) {
+			if path != "/proc/cmdline" {
+				t.Fatalf("unexpected read path: %q", path)
+			}
+			readCalls++
+			if readCalls == 1 {
+				return nil, errors.New("not mounted")
+			}
+			return []byte("console=hvc0 cleanroom_guest_port=22222"), nil
+		},
+		func() error {
+			mountCalls++
+			return nil
+		},
+	)
+
+	if got != "console=hvc0 cleanroom_guest_port=22222" {
+		t.Fatalf("unexpected cmdline: %q", got)
+	}
+	if readCalls != 2 {
+		t.Fatalf("expected two read attempts, got %d", readCalls)
+	}
+	if mountCalls != 1 {
+		t.Fatalf("expected one mount attempt, got %d", mountCalls)
+	}
+}
+
+func TestReadKernelCmdlineWithSkipsMountWhenReadSucceeds(t *testing.T) {
+	t.Parallel()
+
+	mountCalls := 0
+	got := readKernelCmdlineWith(
+		func(path string) ([]byte, error) {
+			if path != "/proc/cmdline" {
+				t.Fatalf("unexpected read path: %q", path)
+			}
+			return []byte("console=hvc0"), nil
+		},
+		func() error {
+			mountCalls++
+			return nil
+		},
+	)
+
+	if got != "console=hvc0" {
+		t.Fatalf("unexpected cmdline: %q", got)
+	}
+	if mountCalls != 0 {
+		t.Fatalf("expected no mount attempts, got %d", mountCalls)
+	}
+}
+
+func TestReadKernelCmdlineWithReturnsEmptyWhenMountFails(t *testing.T) {
+	t.Parallel()
+
+	got := readKernelCmdlineWith(
+		func(path string) ([]byte, error) {
+			if path != "/proc/cmdline" {
+				t.Fatalf("unexpected read path: %q", path)
+			}
+			return nil, errors.New("not mounted")
+		},
+		func() error {
+			return errors.New("mount failed")
+		},
+	)
+
+	if got != "" {
+		t.Fatalf("expected empty cmdline, got %q", got)
 	}
 }

--- a/cmd/cleanroom-guest-agent/port_test.go
+++ b/cmd/cleanroom-guest-agent/port_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResolveGuestAgentPortPrefersEnvironment(t *testing.T) {
+	t.Parallel()
+
+	port, err := resolveGuestAgentPort(10700, "12345", "console=hvc0 cleanroom_guest_port=22222")
+	if err != nil {
+		t.Fatalf("resolveGuestAgentPort returned error: %v", err)
+	}
+	if got, want := port, uint32(12345); got != want {
+		t.Fatalf("unexpected port: got %d want %d", got, want)
+	}
+}
+
+func TestResolveGuestAgentPortFallsBackToKernelCmdline(t *testing.T) {
+	t.Parallel()
+
+	port, err := resolveGuestAgentPort(10700, "", "console=hvc0 cleanroom_guest_port=22222")
+	if err != nil {
+		t.Fatalf("resolveGuestAgentPort returned error: %v", err)
+	}
+	if got, want := port, uint32(22222); got != want {
+		t.Fatalf("unexpected port: got %d want %d", got, want)
+	}
+}
+
+func TestResolveGuestAgentPortUsesDefaultWhenUnset(t *testing.T) {
+	t.Parallel()
+
+	port, err := resolveGuestAgentPort(10700, "", "console=hvc0 root=/dev/vda")
+	if err != nil {
+		t.Fatalf("resolveGuestAgentPort returned error: %v", err)
+	}
+	if got, want := port, uint32(10700); got != want {
+		t.Fatalf("unexpected port: got %d want %d", got, want)
+	}
+}
+
+func TestResolveGuestAgentPortRejectsInvalidEnvironmentValue(t *testing.T) {
+	t.Parallel()
+
+	_, err := resolveGuestAgentPort(10700, "not-a-port", "cleanroom_guest_port=22222")
+	if err == nil {
+		t.Fatal("expected error for invalid environment port")
+	}
+	if !strings.Contains(err.Error(), "CLEANROOM_VSOCK_PORT") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestResolveGuestAgentPortRejectsInvalidKernelCmdlineValue(t *testing.T) {
+	t.Parallel()
+
+	_, err := resolveGuestAgentPort(10700, "", "cleanroom_guest_port=not-a-port")
+	if err == nil {
+		t.Fatal("expected error for invalid kernel cmdline port")
+	}
+	if !strings.Contains(err.Error(), "cleanroom_guest_port") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestKernelCmdlineValueReturnsExactKeyMatch(t *testing.T) {
+	t.Parallel()
+
+	if value, ok := kernelCmdlineValue("xcleanroom_guest_port=9999 cleanroom_guest_port=22222", "cleanroom_guest_port"); !ok || value != "22222" {
+		t.Fatalf("unexpected key parse result: ok=%t value=%q", ok, value)
+	}
+}

--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -72,6 +72,11 @@ const preparedRuntimeRootFSVersion = "v8-darwin-vz"
 
 var virtualizationEntitlementPattern = regexp.MustCompile(`(?s)<key>\s*com\.apple\.security\.virtualization\s*</key>\s*<true\s*/?>`)
 
+const (
+	guestInitScriptPath = "/sbin/cleanroom-init"
+	guestAgentPath      = "/usr/local/bin/cleanroom-guest-agent"
+)
+
 const guestInitScriptTemplate = `#!/bin/sh
 set -eu
 
@@ -477,8 +482,11 @@ func (a *Adapter) run(ctx context.Context, req backend.RunRequest, stream backen
 		_ = os.Remove(vmRootFSPath)
 	}()
 
+	guestInitPath, guestInitNotice := guestInitExecutableForRootFS(vmRootFSPath)
+	logRunNotice(a.Name(), req.RunID, guestInitNotice)
 	bootArgs := fmt.Sprintf(
-		"console=hvc0 root=/dev/vda rw init=/sbin/cleanroom-init cleanroom_guest_port=%d %s",
+		"console=hvc0 root=/dev/vda rw init=%s cleanroom_guest_port=%d %s",
+		guestInitPath,
 		req.GuestPort,
 		dockerServiceBootArgs(req.Policy, req.FirecrackerConfig),
 	)
@@ -731,12 +739,16 @@ func (a *Adapter) ensurePreparedRuntimeRootFSFromImage(ctx context.Context, imag
 		return preparedRootFS{}, err
 	}
 	if _, err := os.Stat(preparedPath); err == nil {
-		return preparedRootFS{
-			Ref:    artifact.Ref,
-			Digest: artifact.Digest,
-			Path:   preparedPath,
-			Hit:    true,
-		}, nil
+		if validateErr := validatePreparedRuntimeRootFS(preparedPath); validateErr == nil {
+			return preparedRootFS{
+				Ref:    artifact.Ref,
+				Digest: artifact.Digest,
+				Path:   preparedPath,
+				Hit:    true,
+			}, nil
+		}
+		// Stale/incomplete cache entries should be rebuilt instead of reused.
+		_ = os.Remove(preparedPath)
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return preparedRootFS{}, fmt.Errorf("inspect prepared runtime rootfs %q: %w", preparedPath, err)
 	}
@@ -745,12 +757,17 @@ func (a *Adapter) ensurePreparedRuntimeRootFSFromImage(ctx context.Context, imag
 	defer a.runtimeImageMu.Unlock()
 
 	if _, err := os.Stat(preparedPath); err == nil {
-		return preparedRootFS{
-			Ref:    artifact.Ref,
-			Digest: artifact.Digest,
-			Path:   preparedPath,
-			Hit:    true,
-		}, nil
+		if validateErr := validatePreparedRuntimeRootFS(preparedPath); validateErr == nil {
+			return preparedRootFS{
+				Ref:    artifact.Ref,
+				Digest: artifact.Digest,
+				Path:   preparedPath,
+				Hit:    true,
+			}, nil
+		}
+		if removeErr := os.Remove(preparedPath); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+			return preparedRootFS{}, fmt.Errorf("remove invalid prepared runtime rootfs %q: %w", preparedPath, removeErr)
+		}
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return preparedRootFS{}, fmt.Errorf("inspect prepared runtime rootfs %q: %w", preparedPath, err)
 	}
@@ -768,15 +785,22 @@ func (a *Adapter) ensurePreparedRuntimeRootFSFromImage(ctx context.Context, imag
 		_ = os.Remove(tmpPath)
 		return preparedRootFS{}, err
 	}
+	if err := validatePreparedRuntimeRootFS(tmpPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return preparedRootFS{}, fmt.Errorf("validate prepared runtime rootfs %q: %w", tmpPath, err)
+	}
 	if err := os.Rename(tmpPath, preparedPath); err != nil {
 		_ = os.Remove(tmpPath)
 		if _, statErr := os.Stat(preparedPath); statErr == nil {
-			return preparedRootFS{
-				Ref:    artifact.Ref,
-				Digest: artifact.Digest,
-				Path:   preparedPath,
-				Hit:    true,
-			}, nil
+			if validateErr := validatePreparedRuntimeRootFS(preparedPath); validateErr == nil {
+				return preparedRootFS{
+					Ref:    artifact.Ref,
+					Digest: artifact.Digest,
+					Path:   preparedPath,
+					Hit:    true,
+				}, nil
+			}
+			return preparedRootFS{}, fmt.Errorf("prepared runtime rootfs %q became invalid during rename race", preparedPath)
 		}
 		return preparedRootFS{}, fmt.Errorf("store prepared runtime rootfs %q: %w", preparedPath, err)
 	}
@@ -787,6 +811,31 @@ func (a *Adapter) ensurePreparedRuntimeRootFSFromImage(ctx context.Context, imag
 		Path:   preparedPath,
 		Hit:    false,
 	}, nil
+}
+
+var preparedRuntimeRootFSRequiredPaths = []string{
+	guestAgentPath,
+	guestInitScriptPath,
+}
+
+func validatePreparedRuntimeRootFS(path string) error {
+	for _, requiredPath := range preparedRuntimeRootFSRequiredPaths {
+		if err := runDebugFS(path, false, fmt.Sprintf("stat %s", requiredPath)); err != nil {
+			return fmt.Errorf("required runtime file %q is missing or unreadable: %w", requiredPath, err)
+		}
+	}
+	return nil
+}
+
+func guestInitExecutableForRootFS(rootFSPath string) (path, notice string) {
+	return guestInitExecutableForShellPresence(ext4PathExists(rootFSPath, "/bin/sh"))
+}
+
+func guestInitExecutableForShellPresence(hasShell bool) (path, notice string) {
+	if hasShell {
+		return guestInitScriptPath, ""
+	}
+	return guestAgentPath, fmt.Sprintf("rootfs is shell-less; using %s as init", guestAgentPath)
 }
 
 func preparedRuntimeRootFSPath(imageDigest, guestAgentHash string) (string, error) {
@@ -1065,10 +1114,40 @@ func runDebugFS(imagePath string, writable bool, command string) error {
 	args = append(args, "-R", command, imagePath)
 	cmd := exec.Command(debugfsBinary, args...)
 	output, err := cmd.CombinedOutput()
+	trimmedOutput := strings.TrimSpace(string(output))
 	if err != nil {
-		return fmt.Errorf("debugfs command %q failed: %w: %s", command, err, strings.TrimSpace(string(output)))
+		return fmt.Errorf("debugfs command %q failed: %w: %s", command, err, trimmedOutput)
+	}
+	if outputErr := debugFSCommandOutputError(trimmedOutput); outputErr != "" {
+		return fmt.Errorf("debugfs command %q reported error: %s", command, outputErr)
 	}
 	return nil
+}
+
+func debugFSCommandOutputError(output string) string {
+	trimmed := strings.TrimSpace(output)
+	if trimmed == "" {
+		return ""
+	}
+	for _, line := range strings.Split(trimmed, "\n") {
+		msg := strings.TrimSpace(line)
+		if msg == "" {
+			continue
+		}
+		lower := strings.ToLower(msg)
+		if strings.HasPrefix(lower, "debugfs ") {
+			// Version banner.
+			continue
+		}
+		if strings.Contains(lower, "file not found") ||
+			strings.Contains(lower, "ext2_lookup") ||
+			strings.Contains(lower, "command not found") ||
+			strings.Contains(lower, "no such file or directory") ||
+			strings.Contains(lower, "not a directory") {
+			return msg
+		}
+	}
+	return ""
 }
 
 func (a *Adapter) resolveKernelPath(ctx context.Context, configuredPath string) (path, notice string, err error) {

--- a/internal/backend/darwinvz/debugfs_test.go
+++ b/internal/backend/darwinvz/debugfs_test.go
@@ -1,0 +1,34 @@
+//go:build darwin
+
+package darwinvz
+
+import "testing"
+
+func TestDebugFSCommandOutputErrorReportsMissingFile(t *testing.T) {
+	t.Parallel()
+
+	output := "debugfs 1.47.3 (8-Jul-2025)\n/sbin: File not found by ext2_lookup while looking up \"/sbin\"\n"
+	got := debugFSCommandOutputError(output)
+	if got == "" {
+		t.Fatal("expected missing-file debugfs output to be treated as an error")
+	}
+}
+
+func TestDebugFSCommandOutputErrorReportsUnknownCommand(t *testing.T) {
+	t.Parallel()
+
+	output := "debugfs 1.47.3 (8-Jul-2025)\ndebugfs: Command not found writee\n"
+	got := debugFSCommandOutputError(output)
+	if got == "" {
+		t.Fatal("expected unknown-command debugfs output to be treated as an error")
+	}
+}
+
+func TestDebugFSCommandOutputErrorIgnoresSuccessfulOutput(t *testing.T) {
+	t.Parallel()
+
+	output := "debugfs 1.47.3 (8-Jul-2025)\nInode: 531   Type: regular    Mode:  0755   Flags: 0x80000\n"
+	if got := debugFSCommandOutputError(output); got != "" {
+		t.Fatalf("expected empty error for successful debugfs output, got %q", got)
+	}
+}

--- a/internal/backend/darwinvz/init_path_test.go
+++ b/internal/backend/darwinvz/init_path_test.go
@@ -1,0 +1,39 @@
+//go:build darwin
+
+package darwinvz
+
+import "testing"
+
+func TestGuestInitExecutableForShellPresenceUsesInitScriptWhenShellExists(t *testing.T) {
+	t.Parallel()
+
+	path, notice := guestInitExecutableForShellPresence(true)
+	if got, want := path, "/sbin/cleanroom-init"; got != want {
+		t.Fatalf("unexpected init path: got %q want %q", got, want)
+	}
+	if notice != "" {
+		t.Fatalf("expected empty notice for shell-enabled rootfs, got %q", notice)
+	}
+}
+
+func TestGuestInitExecutableForShellPresenceFallsBackToGuestAgentWhenShellMissing(t *testing.T) {
+	t.Parallel()
+
+	path, notice := guestInitExecutableForShellPresence(false)
+	if got, want := path, "/usr/local/bin/cleanroom-guest-agent"; got != want {
+		t.Fatalf("unexpected fallback init path: got %q want %q", got, want)
+	}
+	if notice == "" {
+		t.Fatal("expected shell-less fallback notice")
+	}
+}
+
+func TestPreparedRuntimeRootFSRequiredPathsDoNotRequireBinSh(t *testing.T) {
+	t.Parallel()
+
+	for _, path := range preparedRuntimeRootFSRequiredPaths {
+		if path == "/bin/sh" {
+			t.Fatal("shell-less rootfs should not be rejected at prepare time")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- fix darwin-vz runtime rootfs preparation to treat `debugfs` soft-fail output as errors
- validate prepared runtime-rootfs cache entries before reuse and self-heal invalid cache entries
- support shell-less images by selecting guest-agent as init when `/bin/sh` is missing
- add darwin-vz tests for debugfs output parsing and init path selection

## Root Cause
`cleanroom exec --image=hello-world -- /hello` could hang after rootfs derivation on macOS because:
- injected `/sbin/cleanroom-init` is a shell script requiring `/bin/sh`
- shell-less images (like `hello-world`) panic at boot (`Requested init ... failed`) and never return execution frames
- `debugfs` can emit errors while returning exit code 0, allowing invalid prepared rootfs cache entries to persist

## Verification
- `mise x -- go test ./internal/backend/darwinvz ./internal/controlservice ./internal/cli ./internal/vsockexec`
- manual repro before/after on macOS darwin-vz:
  - `cleanroom exec --image=hello-world -- /hello` no longer hangs and now succeeds
