### PR TITLE
Fix backend fallback on macOS when default_backend is unset

### DIFF
--- a/internal/cli/backend_resolution_test.go
+++ b/internal/cli/backend_resolution_test.go
@@ -1,0 +1,13 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/runtimeconfig"
+)
+
+func TestResolveBackendNameDefaultsToHostBackend(t *testing.T) {
+	if got, want := resolveBackendName("", ""), runtimeconfig.DefaultBackendForHost(); got != want {
+		t.Fatalf("resolveBackendName fallback = %q, want %q", got, want)
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -162,7 +162,7 @@ func (f *clientFlags) connect() (*controlclient.Client, error) {
 type ExecCommand struct {
 	clientFlags
 	Chdir     string `short:"c" help:"Change to this directory before running commands"`
-	Backend   string `help:"Execution backend (defaults to runtime config or firecracker)"`
+	Backend   string `help:"Execution backend (defaults to runtime config or host default)"`
 	SandboxID string `help:"Reuse an existing sandbox instead of creating a new one"`
 	Image     string `help:"Override sandbox image ref for newly created sandboxes (tag, digest, or local Docker image)"`
 	Remove    bool   `name:"rm" help:"Terminate the sandbox after command completion"`
@@ -175,7 +175,7 @@ type ExecCommand struct {
 type SandboxCreateCommand struct {
 	clientFlags
 	Chdir         string `short:"c" help:"Change to this directory before running commands"`
-	Backend       string `help:"Execution backend (defaults to runtime config or firecracker)"`
+	Backend       string `help:"Execution backend (defaults to runtime config or host default)"`
 	Image         string `help:"Override sandbox image ref (tag, digest, or local Docker image)"`
 	LaunchSeconds int64  `help:"VM boot/guest-agent readiness timeout in seconds"`
 	JSON          bool   `help:"Print sandbox as JSON"`
@@ -184,7 +184,7 @@ type SandboxCreateCommand struct {
 type CreateCommand struct {
 	clientFlags
 	Chdir         string `short:"c" help:"Change to this directory before running commands"`
-	Backend       string `help:"Execution backend (defaults to runtime config or firecracker)"`
+	Backend       string `help:"Execution backend (defaults to runtime config or host default)"`
 	Image         string `help:"Override sandbox image ref (tag, digest, or local Docker image)"`
 	LaunchSeconds int64  `help:"VM boot/guest-agent readiness timeout in seconds"`
 	JSON          bool   `help:"Print sandbox as JSON"`
@@ -193,7 +193,7 @@ type CreateCommand struct {
 type ConsoleCommand struct {
 	clientFlags
 	Chdir     string `short:"c" help:"Change to this directory before running commands"`
-	Backend   string `help:"Execution backend (defaults to runtime config or firecracker)"`
+	Backend   string `help:"Execution backend (defaults to runtime config or host default)"`
 	SandboxID string `help:"Reuse an existing sandbox instead of creating a new one"`
 	Image     string `help:"Override sandbox image ref for newly created sandboxes (tag, digest, or local Docker image)"`
 	Remove    bool   `name:"rm" help:"Terminate the sandbox after console exits"`
@@ -220,7 +220,7 @@ type StatusCommand struct {
 
 type DoctorCommand struct {
 	Chdir   string `short:"c" help:"Change to this directory before running commands"`
-	Backend string `help:"Execution backend to diagnose (defaults to runtime config or firecracker)"`
+	Backend string `help:"Execution backend to diagnose (defaults to runtime config or host default)"`
 	JSON    bool   `help:"Print doctor report as JSON"`
 }
 
@@ -439,10 +439,7 @@ func (c *ConfigInitCommand) Run(ctx *runtimeContext) error {
 }
 
 func hostDefaultBackend() string {
-	if runtime.GOOS == "darwin" {
-		return "darwin-vz"
-	}
-	return "firecracker"
+	return runtimeconfig.DefaultBackendForHost()
 }
 
 func defaultRuntimeConfig(defaultBackend string) runtimeconfig.Config {
@@ -1897,7 +1894,7 @@ func resolveBackendName(requested, configuredDefault string) string {
 	if configuredDefault != "" {
 		return configuredDefault
 	}
-	return "firecracker"
+	return runtimeconfig.DefaultBackendForHost()
 }
 
 func shouldInstallGatewayFirewall(goos string) bool {

--- a/internal/controlservice/backend_resolution_test.go
+++ b/internal/controlservice/backend_resolution_test.go
@@ -1,0 +1,13 @@
+package controlservice
+
+import (
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/runtimeconfig"
+)
+
+func TestResolveBackendNameDefaultsToHostBackend(t *testing.T) {
+	if got, want := resolveBackendName("", ""), runtimeconfig.DefaultBackendForHost(); got != want {
+		t.Fatalf("resolveBackendName fallback = %q, want %q", got, want)
+	}
+}

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -1902,7 +1902,7 @@ func resolveBackendName(requested, configuredDefault string) string {
 	if configuredDefault != "" {
 		return configuredDefault
 	}
-	return "firecracker"
+	return runtimeconfig.DefaultBackendForHost()
 }
 
 func mergeBackendConfig(backendName string, opts executionOptions, cfg runtimeconfig.Config) backend.FirecrackerConfig {

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -145,6 +145,9 @@ func newTestService(adapter backend.Adapter) *Service {
 			},
 			source: "/repo/cleanroom.yaml",
 		},
+		Config: runtimeconfig.Config{
+			DefaultBackend: "firecracker",
+		},
 		Backends: map[string]backend.Adapter{"firecracker": adapter},
 	}
 }

--- a/internal/runtimeconfig/config.go
+++ b/internal/runtimeconfig/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -54,6 +55,17 @@ type DockerServiceConfig struct {
 	IPTables              bool   `yaml:"iptables"`
 }
 
+func DefaultBackendForGOOS(goos string) string {
+	if strings.EqualFold(strings.TrimSpace(goos), "darwin") {
+		return "darwin-vz"
+	}
+	return "firecracker"
+}
+
+func DefaultBackendForHost() string {
+	return DefaultBackendForGOOS(runtime.GOOS)
+}
+
 func Path() (string, error) {
 	configHome := strings.TrimSpace(os.Getenv("XDG_CONFIG_HOME"))
 	if configHome != "" {
@@ -97,6 +109,9 @@ func Load() (Config, string, error) {
 	}
 
 	cfg.DefaultBackend = strings.TrimSpace(cfg.DefaultBackend)
+	if cfg.DefaultBackend == "" {
+		cfg.DefaultBackend = DefaultBackendForHost()
+	}
 	return cfg, path, nil
 }
 

--- a/internal/runtimeconfig/config_test.go
+++ b/internal/runtimeconfig/config_test.go
@@ -84,3 +84,28 @@ backends:
 		t.Fatalf("unexpected darwin-vz vcpus: got %d want %d", got, want)
 	}
 }
+
+func TestLoadDefaultsBackendWhenMissing(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	configPath := filepath.Join(tmp, "cleanroom", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+
+	content := `backends:
+  firecracker:
+    binary_path: firecracker
+`
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, _, err := Load()
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if got, want := cfg.DefaultBackend, DefaultBackendForHost(); got != want {
+		t.Fatalf("unexpected default backend: got %q want %q", got, want)
+	}
+}

--- a/internal/runtimeconfig/default_backend_test.go
+++ b/internal/runtimeconfig/default_backend_test.go
@@ -1,0 +1,24 @@
+package runtimeconfig
+
+import "testing"
+
+func TestDefaultBackendForGOOS(t *testing.T) {
+	tests := []struct {
+		name string
+		goos string
+		want string
+	}{
+		{name: "darwin", goos: "darwin", want: "darwin-vz"},
+		{name: "darwin case insensitive", goos: "Darwin", want: "darwin-vz"},
+		{name: "linux", goos: "linux", want: "firecracker"},
+		{name: "windows", goos: "windows", want: "firecracker"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DefaultBackendForGOOS(tt.goos); got != tt.want {
+				t.Fatalf("DefaultBackendForGOOS(%q) = %q, want %q", tt.goos, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- use host-aware backend fallback (`darwin-vz` on macOS, `firecracker` elsewhere) when no backend is requested and runtime config default is unset
- backfill `default_backend` in `runtimeconfig.Load()` when missing/blank so legacy/minimal configs behave correctly
- update CLI help text to refer to host default rather than firecracker
- add regression tests for backend resolution and config backfill behaviour

## Testing
- go test ./internal/runtimeconfig ./internal/cli ./internal/controlservice
