### PR TITLE
Docs: clarify default_backend host fallback behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ cleanroom config init
 ```
 
 On macOS this defaults `default_backend` to `darwin-vz`. On Linux it defaults to `firecracker`.
+If `default_backend` is omitted or blank in an existing config, Cleanroom falls back to the same host default at load time.
 
 ```yaml
 default_backend: firecracker


### PR DESCRIPTION
## Summary
- document that `cleanroom config init` sets host-specific `default_backend`
- document that when `default_backend` is missing or blank, Cleanroom backfills host default at config load time

## Testing
- docs-only change
