### PR TITLE
benchmarks: stabilize sandbox ID capture for exec-based runs

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -49,6 +49,7 @@ Script: `scripts/benchmark-sandbox-workloads.sh`
   - hashes a fixed byte count using `sha256sum`
   - reports elapsed seconds + MiB/s
 - Sandbox teardown happens outside measured workload sections
+- Git clone workload requires `git` in the guest image; use `--image <ref>` if your policy image does not include git
 
 Example:
 
@@ -56,6 +57,7 @@ Example:
 ./scripts/benchmark-sandbox-workloads.sh \
   --host unix:///tmp/cleanroom.sock \
   --iterations 5 \
+  --image ghcr.io/buildkite/cleanroom-base/alpine@sha256:962db9c461c02b86db105507bf2db4f01eb5d8fdf1a452598d140a569178324b \
   --repo-url https://github.com/hashicorp/terraform.git \
   --repo-depth 1
 ```

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -161,11 +161,12 @@ func (f *clientFlags) connect() (*controlclient.Client, error) {
 
 type ExecCommand struct {
 	clientFlags
-	Chdir     string `short:"c" help:"Change to this directory before running commands"`
-	Backend   string `help:"Execution backend (defaults to runtime config or host default)"`
-	SandboxID string `help:"Reuse an existing sandbox instead of creating a new one"`
-	Image     string `help:"Override sandbox image ref for newly created sandboxes (tag, digest, or local Docker image)"`
-	Remove    bool   `name:"rm" help:"Terminate the sandbox after command completion"`
+	Chdir          string `short:"c" help:"Change to this directory before running commands"`
+	Backend        string `help:"Execution backend (defaults to runtime config or host default)"`
+	SandboxID      string `help:"Reuse an existing sandbox instead of creating a new one"`
+	Image          string `help:"Override sandbox image ref for newly created sandboxes (tag, digest, or local Docker image)"`
+	Remove         bool   `name:"rm" help:"Terminate the sandbox after command completion"`
+	PrintSandboxID bool   `name:"print-sandbox-id" help:"Print resolved sandbox_id=<id> to stderr before streaming output"`
 
 	LaunchSeconds int64 `help:"VM boot/guest-agent readiness timeout in seconds"`
 
@@ -777,6 +778,11 @@ func (e *ExecCommand) Run(ctx *runtimeContext) error {
 	sandboxID, err := ensureSandboxID(client, ctx.Loader, cwd, e.Host, e.Backend, strings.TrimSpace(e.SandboxID), e.Image, e.LaunchSeconds)
 	if err != nil {
 		return err
+	}
+	if e.PrintSandboxID {
+		if _, err := fmt.Fprintf(os.Stderr, "sandbox_id=%s\n", sandboxID); err != nil {
+			return err
+		}
 	}
 	detached := false
 	autoTerminateSandbox := e.Remove

--- a/internal/cli/exec_integration_test.go
+++ b/internal/cli/exec_integration_test.go
@@ -594,8 +594,39 @@ func TestParseSandboxID(t *testing.T) {
 	if got, want := parseSandboxID(in), "cr-123"; got != want {
 		t.Fatalf("unexpected sandbox id: got %q want %q", got, want)
 	}
+	in = "sandbox_id=cr_123\n"
+	if got, want := parseSandboxID(in), "cr_123"; got != want {
+		t.Fatalf("unexpected sandbox id from print output: got %q want %q", got, want)
+	}
 	if got := parseSandboxID("no id here"); got != "" {
 		t.Fatalf("expected empty sandbox id for invalid input, got %q", got)
+	}
+}
+
+func TestExecIntegrationPrintSandboxIDFlag(t *testing.T) {
+	host, _ := startIntegrationServer(t, &integrationAdapter{})
+	cwd := t.TempDir()
+	outcome := runExecWithCapture(ExecCommand{
+		clientFlags:    clientFlags{Host: host},
+		Chdir:          cwd,
+		PrintSandboxID: true,
+		Command:        []string{"echo", "ok"},
+	}, runtimeContext{
+		CWD:    cwd,
+		Loader: integrationLoader{},
+	})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err != nil {
+		t.Fatalf("ExecCommand.Run returned error: %v", outcome.err)
+	}
+	sandboxID := parseSandboxID(outcome.stderr)
+	if sandboxID == "" {
+		t.Fatalf("missing sandbox_id in stderr output: %q", outcome.stderr)
+	}
+	if strings.Contains(outcome.stdout, "sandbox_id=") {
+		t.Fatalf("sandbox_id marker must not be written to stdout: %q", outcome.stdout)
 	}
 }
 

--- a/scripts/benchmark-sandbox-workloads.sh
+++ b/scripts/benchmark-sandbox-workloads.sh
@@ -16,10 +16,11 @@ Usage:
 Options:
   --host <endpoint>          Control-plane endpoint (default: unix://$XDG_RUNTIME_DIR/cleanroom/cleanroom.sock)
   --backend <name>           Optional backend override for initial sandbox creation
+  --image <ref>              Optional sandbox image override for initial sandbox creation
   -c, --chdir <path>         Repository/policy directory (default: current directory)
   -n, --iterations <count>   Iterations per workload (default: 5)
   --output-dir <path>        Output directory (default: benchmarks/results)
-  --cleanroom-bin <path>     cleanroom binary path (default: ./dist/cleanroom, then cleanroom from PATH)
+  --cleanroom-bin <path>     cleanroom binary path (default: cleanroom from PATH, then ./dist/cleanroom)
   --repo-url <url>           Git repo for clone benchmark (default: https://github.com/kubernetes/kubernetes.git)
   --repo-depth <count>       Git clone depth (default: 1)
   --iops-block-size <bytes>  Block size for IOPS benchmark (default: 4096)
@@ -43,7 +44,9 @@ else
   default_host="unix:///tmp/cleanroom.sock"
 fi
 
-if [[ -x "./dist/cleanroom" ]]; then
+if command -v cleanroom >/dev/null 2>&1; then
+  cleanroom_bin="$(command -v cleanroom)"
+elif [[ -x "./dist/cleanroom" ]]; then
   cleanroom_bin="./dist/cleanroom"
 else
   cleanroom_bin="cleanroom"
@@ -51,6 +54,7 @@ fi
 
 host="$default_host"
 backend=""
+image_ref=""
 chdir="$PWD"
 iterations=5
 output_dir="benchmarks/results"
@@ -68,6 +72,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --backend)
       backend="$2"
+      shift 2
+      ;;
+    --image)
+      image_ref="$2"
       shift 2
       ;;
     -c|--chdir)
@@ -138,8 +146,13 @@ if ! [[ "$cpu_bytes" =~ ^[0-9]+$ ]] || [[ "$cpu_bytes" -le 0 ]]; then
   echo "cpu-bytes must be a positive integer" >&2
   exit 1
 fi
-if ! command -v "$cleanroom_bin" >/dev/null 2>&1; then
-  echo "cleanroom binary not found: $cleanroom_bin" >&2
+if [[ "$cleanroom_bin" == */* ]]; then
+  if [[ ! -x "$cleanroom_bin" ]]; then
+    echo "cleanroom binary not found or not executable: $cleanroom_bin" >&2
+    exit 1
+  fi
+elif ! command -v "$cleanroom_bin" >/dev/null 2>&1; then
+  echo "cleanroom binary not found in PATH: $cleanroom_bin" >&2
   exit 1
 fi
 if ! command -v curl >/dev/null 2>&1; then
@@ -186,15 +199,18 @@ create_cmd=("$cleanroom_bin" exec --host "$host" -c "$chdir")
 if [[ -n "$backend" ]]; then
   create_cmd+=(--backend "$backend")
 fi
-create_cmd+=(-- sh -lc "true")
+if [[ -n "$image_ref" ]]; then
+  create_cmd+=(--image "$image_ref")
+fi
+create_cmd+=(--print-sandbox-id -- sh -lc "true")
 
 create_stderr_file="$(mktemp)"
 "${create_cmd[@]}" >/dev/null 2>"$create_stderr_file"
-sandbox_id="$(sed -n 's/.*sandbox_id=\([^ ]*\).*/\1/p' "$create_stderr_file" | tail -n1)"
+sandbox_id="$(grep -m1 '^sandbox_id=' "$create_stderr_file" | cut -d= -f2 || true)"
 rm -f "$create_stderr_file"
 
-if [[ -z "$sandbox_id" ]]; then
-  echo "failed to determine sandbox_id from cleanroom exec output" >&2
+if [[ -z "$sandbox_id" || "$sandbox_id" == "null" ]]; then
+  echo "failed to determine sandbox_id from cleanroom exec --print-sandbox-id" >&2
   exit 1
 fi
 
@@ -273,6 +289,7 @@ jq -n \
   --arg host "$host" \
   --arg sandbox_id "$sandbox_id" \
   --arg backend "${backend:-default}" \
+  --arg image_ref "$image_ref" \
   --arg repo_url "$repo_url" \
   --argjson repo_depth "$repo_depth" \
   --argjson iterations "$iterations" \
@@ -292,6 +309,7 @@ jq -n \
     sandbox_id: $sandbox_id,
     config: {
       iterations: $iterations,
+      image_ref: (if $image_ref == "" then "default" else $image_ref end),
       repo_url: $repo_url,
       repo_depth: $repo_depth,
       iops_block_size_bytes: $iops_block_size,

--- a/scripts/benchmark-tti.sh
+++ b/scripts/benchmark-tti.sh
@@ -15,7 +15,7 @@ Options:
   --backend <name>          Optional backend override for cleanroom exec
   -c, --chdir <path>        Repository/policy directory (default: current directory)
   --output-dir <path>       JSON output directory (default: benchmarks/results)
-  --cleanroom-bin <path>    cleanroom binary path (default: ./dist/cleanroom, then cleanroom from PATH)
+  --cleanroom-bin <path>    cleanroom binary path (default: cleanroom from PATH, then ./dist/cleanroom)
   -h, --help                Show this help
 
 Environment:
@@ -34,7 +34,9 @@ else
   default_host="unix:///tmp/cleanroom/cleanroom.sock"
 fi
 
-if [[ -x "./dist/cleanroom" ]]; then
+if command -v cleanroom >/dev/null 2>&1; then
+  cleanroom_bin="$(command -v cleanroom)"
+elif [[ -x "./dist/cleanroom" ]]; then
   cleanroom_bin="./dist/cleanroom"
 else
   cleanroom_bin="cleanroom"
@@ -101,54 +103,42 @@ if ! command -v hyperfine >/dev/null 2>&1; then
   echo "hyperfine is required but not found in PATH" >&2
   exit 1
 fi
-if ! command -v "$cleanroom_bin" >/dev/null 2>&1; then
-  echo "cleanroom binary not found: $cleanroom_bin" >&2
+if [[ "$cleanroom_bin" == */* ]]; then
+  if [[ ! -x "$cleanroom_bin" ]]; then
+    echo "cleanroom binary not found or not executable: $cleanroom_bin" >&2
+    exit 1
+  fi
+elif ! command -v "$cleanroom_bin" >/dev/null 2>&1; then
+  echo "cleanroom binary not found in PATH: $cleanroom_bin" >&2
   exit 1
 fi
-if ! command -v curl >/dev/null 2>&1; then
-  echo "curl is required but not found in PATH" >&2
+if ! command -v grep >/dev/null 2>&1; then
+  echo "grep is required but not found in PATH" >&2
   exit 1
 fi
 
 mkdir -p "$output_dir"
 timestamp="$(date -u +%Y-%m-%dT%H-%M-%SZ)"
 output_path="${output_dir}/${timestamp}.json"
-sandbox_id_path="${output_dir}/.last-sandbox-id.txt"
-: > "$sandbox_id_path"
-
-terminate_cmd=""
-case "$host" in
-  unix://*)
-    socket_path="${host#unix://}"
-    printf -v socket_escaped '%q' "$socket_path"
-    terminate_cmd="curl -sS --output /dev/null --unix-socket ${socket_escaped} -H 'Content-Type: application/json' -d \"{\\\"sandbox_id\\\":\\\"\${sid}\\\"}\" http://localhost/cleanroom.v1.SandboxService/TerminateSandbox"
-    ;;
-  http://*|https://*)
-    api_endpoint="${host%/}/cleanroom.v1.SandboxService/TerminateSandbox"
-    printf -v endpoint_escaped '%q' "$api_endpoint"
-    terminate_cmd="curl -sS --output /dev/null -H 'Content-Type: application/json' -d \"{\\\"sandbox_id\\\":\\\"\${sid}\\\"}\" ${endpoint_escaped}"
-    ;;
-  *)
-    echo "unsupported host scheme for cleanup: $host" >&2
-    exit 1
-    ;;
-esac
+sandbox_id_path="$(mktemp "${output_dir}/.tti-sandbox-id.XXXXXX")"
 
 benchmark_cmd=("$cleanroom_bin" exec --host "$host" -c "$chdir")
 if [[ -n "$backend" ]]; then
   benchmark_cmd+=(--backend "$backend")
 fi
-benchmark_cmd+=(-- echo benchmark)
+benchmark_cmd+=(--print-sandbox-id -- echo benchmark)
 
-quoted_cmd=""
+quoted_benchmark_cmd=""
 for token in "${benchmark_cmd[@]}"; do
   printf -v escaped '%q' "$token"
-  quoted_cmd+="${escaped} "
+  quoted_benchmark_cmd+="${escaped} "
 done
 printf -v sandbox_id_escaped '%q' "$sandbox_id_path"
-quoted_cmd+=">/dev/null 2>${sandbox_id_escaped}"
+quoted_benchmark_cmd+=" >/dev/null 2>${sandbox_id_escaped}"
 
-cleanup_cmd="sid=\$(sed -n 's/.*sandbox_id=\\([^ ]*\\).*/\\1/p' ${sandbox_id_escaped} | tail -n1); if [ -n \"\${sid}\" ]; then ${terminate_cmd} || true; fi; : > ${sandbox_id_escaped}"
+printf -v cleanroom_bin_escaped '%q' "$cleanroom_bin"
+printf -v host_escaped '%q' "$host"
+cleanup_cmd="sid=\$(grep -m1 '^sandbox_id=' ${sandbox_id_escaped} | cut -d= -f2 || true); if [ -n \"\${sid}\" ]; then ${cleanroom_bin_escaped} sandbox rm --host ${host_escaped} \"\${sid}\" >/dev/null 2>&1 || true; fi; : > ${sandbox_id_escaped}"
 
 echo "Benchmarking TTI with hyperfine"
 echo "- endpoint: ${host}"
@@ -162,7 +152,7 @@ hyperfine \
   --prepare "$cleanup_cmd" \
   --cleanup "$cleanup_cmd" \
   --export-json "$output_path" \
-  "$quoted_cmd"
+  "$quoted_benchmark_cmd"
 
 bash -lc "$cleanup_cmd"
 rm -f "$sandbox_id_path"


### PR DESCRIPTION
## Summary
- add `cleanroom exec --print-sandbox-id` to emit a stable `sandbox_id=<id>` marker on stderr before stream output
- update benchmark scripts to consume this marker instead of brittle log parsing or global last-run state
- keep TTI measurement as a single `exec` invocation, with deterministic cleanup via captured sandbox ID
- add workload benchmark `--image` override support and include image ref in output config
- document git requirement/image override for workload benchmark in benchmark docs

## Validation
- `go test ./internal/cli`
- `bash -n scripts/benchmark-tti.sh`
- `bash -n scripts/benchmark-sandbox-workloads.sh`
- `./scripts/benchmark-tti.sh --host unix:///tmp/cleanroom.sock --iterations 7 --warmup 1 --cleanroom-bin /tmp/cleanroom-dev`
- `./scripts/benchmark-sandbox-workloads.sh --host unix:///tmp/cleanroom.sock --iterations 5 --repo-url https://github.com/hashicorp/terraform.git --repo-depth 1 --image ghcr.io/buildkite/cleanroom-base/alpine@sha256:962db9c461c02b86db105507bf2db4f01eb5d8fdf1a452598d140a569178324b --cleanroom-bin /tmp/cleanroom-dev`
