### PR TITLE
fix: publish multi-arch base images

### DIFF
--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -39,6 +39,12 @@ jobs:
         run: |
           echo "base_tag=$(scripts/base-image-tag.sh '${{ matrix.image_name }}' '${{ matrix.dockerfile }}')" >> "$GITHUB_OUTPUT"
 
+      - uses: docker/setup-qemu-action@v3
+        with:
+          platforms: amd64,arm64
+
+      - uses: docker/setup-buildx-action@v3
+
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -49,6 +55,7 @@ jobs:
         with:
           context: .
           file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ${{ matrix.repository }}:latest


### PR DESCRIPTION
## Summary
- add QEMU and Buildx setup to the base image workflow
- publish `linux/amd64` and `linux/arm64` variants for all base images
- keep existing image tags (`latest`, content hash tag, and commit SHA) unchanged

## Why
The base image workflow was only publishing the runner-native manifest from `ubuntu-latest`, which left GHCR tags as `linux/amd64` only. Cleanroom resolves OCI images for the host Linux platform, so arm64 hosts need arm64 variants published under the same tags.

## Validation
- `actionlint .github/workflows/base-image.yml`
- YAML parse check for `.github/workflows/base-image.yml`

## Notes
I could not run a live `docker buildx build` in this environment because the local Docker daemon was unavailable.