### PR TITLE
fix: add bash to published base images

### DIFF
--- a/images/Dockerfile.base-image
+++ b/images/Dockerfile.base-image
@@ -1,6 +1,7 @@
 FROM alpine:3.22
 
 RUN apk add --no-cache \
+  bash \
   git \
   strace \
   mise

--- a/images/Dockerfile.base-image-agents
+++ b/images/Dockerfile.base-image-agents
@@ -6,6 +6,7 @@ ARG GEMINI_CLI_VERSION=0.31.0
 
 # `gemini` currently needs native build deps on Alpine and GNU `env` for `env -S`.
 RUN apk add --no-cache \
+  bash \
   coreutils \
   g++ \
   git \

--- a/images/Dockerfile.base-image-docker
+++ b/images/Dockerfile.base-image-docker
@@ -1,6 +1,7 @@
 FROM alpine:3.22
 
 RUN apk add --no-cache \
+  bash \
   docker \
   git \
   strace \

--- a/images/dockerfiles_test.go
+++ b/images/dockerfiles_test.go
@@ -1,0 +1,31 @@
+package images_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPublishedBaseImagesInstallBash(t *testing.T) {
+	t.Parallel()
+
+	for _, relPath := range []string{
+		"Dockerfile.base-image",
+		"Dockerfile.base-image-docker",
+		"Dockerfile.base-image-agents",
+	} {
+		relPath := relPath
+		t.Run(relPath, func(t *testing.T) {
+			t.Parallel()
+
+			raw, err := os.ReadFile(filepath.Join(".", relPath))
+			if err != nil {
+				t.Fatalf("read %s: %v", relPath, err)
+			}
+			if !strings.Contains(string(raw), "\n  bash \\\n") {
+				t.Fatalf("%s does not install bash", relPath)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- install `bash` in the published Alpine base image variants
- add a regression test to keep `bash` in those Dockerfiles

## Why
`mise`-managed tooling such as `ruby-build` expects `bash` to be available. Without it, repo-managed provisioning on the standard cleanroom images fails and users need a custom overlay image for otherwise normal Ruby/Node repos.

## Testing
- `mise exec -- go test ./images`
- `docker build -f images/Dockerfile.base-image -t cleanroom-base-bash-test .`