### PR TITLE
fix: isolate base image merge artifacts

### DIFF
--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -65,7 +65,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ env.IMAGE_NAME }}-${{ matrix.platform_key }}
+          name: digests__${{ env.IMAGE_NAME }}__${{ matrix.platform_key }}
           path: ${{ runner.temp }}/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -88,7 +88,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          pattern: digests-${{ env.IMAGE_NAME }}-*
+          pattern: digests__${{ env.IMAGE_NAME }}__*
           path: ${{ runner.temp }}/digests
           merge-multiple: true
 
@@ -174,7 +174,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ env.IMAGE_NAME }}-${{ matrix.platform_key }}
+          name: digests__${{ env.IMAGE_NAME }}__${{ matrix.platform_key }}
           path: ${{ runner.temp }}/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -197,7 +197,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          pattern: digests-${{ env.IMAGE_NAME }}-*
+          pattern: digests__${{ env.IMAGE_NAME }}__*
           path: ${{ runner.temp }}/digests
           merge-multiple: true
 
@@ -283,7 +283,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ env.IMAGE_NAME }}-${{ matrix.platform_key }}
+          name: digests__${{ env.IMAGE_NAME }}__${{ matrix.platform_key }}
           path: ${{ runner.temp }}/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -306,7 +306,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          pattern: digests-${{ env.IMAGE_NAME }}-*
+          pattern: digests__${{ env.IMAGE_NAME }}__*
           path: ${{ runner.temp }}/digests
           merge-multiple: true
 


### PR DESCRIPTION
## Summary
- make base-image digest artifact names unambiguous per image
- tighten each merge job's artifact download pattern to only match its own image digests
- keep the native amd64/arm64 runner split from #77 unchanged

## Why
After PR #77 merged, the `Base Image` run on `main` (run 22818490262, commit 403b8253eea5c75bf4710c2da2c04a6df62511ff, started March 8, 2026 at 09:41:36 UTC) still failed in `merge (alpine)`. That merge job downloaded both `digests-alpine-*` and `digests-alpine-docker-*`, then tried to create an alpine manifest using an alpine-docker digest.

## Validation
- YAML parse check for `.github/workflows/base-image.yml`
- `actionlint .github/workflows/base-image.yml`