### PR TITLE
feat: support persistent darwin-vz sandboxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ cleanroom policy validate
 | Host OS | Backend | Status | Notes |
 |---------|---------|--------|-------|
 | Linux | `firecracker` | Full support | Persistent sandboxes, file download, egress allowlist enforcement |
-| macOS | `darwin-vz` | Supported with gaps | Per-run VMs (no persistent sandboxes yet), no file download, no egress filtering yet |
+| macOS | `darwin-vz` | Supported with gaps | Persistent sandboxes, no file download, no egress filtering yet |
 
 Backend capabilities are exposed in `cleanroom doctor --json` under `capabilities`. See [isolation model](docs/isolation.md) for enforcement and persistence details.
 

--- a/cmd/cleanroom-darwin-vz/main.swift
+++ b/cmd/cleanroom-darwin-vz/main.swift
@@ -218,13 +218,21 @@ private final class UnixListener {
 private final class GuestChannel {
     let readFD: Int32
     let writeFD: Int32
+    private let closeAfterUse: Bool
     private var closed = false
     private let onClose: () -> Void
 
-    init(readFD: Int32, writeFD: Int32, onClose: @escaping () -> Void) {
+    init(readFD: Int32, writeFD: Int32, closeAfterUse: Bool = true, onClose: @escaping () -> Void) {
         self.readFD = readFD
         self.writeFD = writeFD
+        self.closeAfterUse = closeAfterUse
         self.onClose = onClose
+    }
+
+    func finishSession() {
+        if closeAfterUse {
+            close()
+        }
     }
 
     func close() {
@@ -249,7 +257,7 @@ private final class ProxyServer {
 
     func start(connectGuest: @escaping () throws -> GuestChannel) {
         queue.async { [weak self] in
-            self?.acceptAndBridge(connectGuest: connectGuest)
+            self?.serve(connectGuest: connectGuest)
         }
     }
 
@@ -262,7 +270,18 @@ private final class ProxyServer {
         listener.close()
     }
 
-    private func acceptAndBridge(connectGuest: @escaping () throws -> GuestChannel) {
+    private func serve(connectGuest: @escaping () throws -> GuestChannel) {
+        while true {
+            if isStopped() {
+                return
+            }
+            if !acceptAndBridge(connectGuest: connectGuest), !isStopped() {
+                usleep(100_000)
+            }
+        }
+    }
+
+    private func acceptAndBridge(connectGuest: @escaping () throws -> GuestChannel) -> Bool {
         let hostFD: Int32
         do {
             hostFD = try listener.accept()
@@ -270,12 +289,11 @@ private final class ProxyServer {
             if !isStopped() {
                 fputs("cleanroom-darwin-vz proxy accept failed: \(error)\n", stderr)
             }
-            return
+            return false
         }
-
         defer { _ = Darwin.close(hostFD) }
         if isStopped() {
-            return
+            return false
         }
 
         let guestChannel: GuestChannel
@@ -283,7 +301,7 @@ private final class ProxyServer {
             guestChannel = try connectGuest()
         } catch {
             fputs("cleanroom-darwin-vz guest channel connect failed: \(error)\n", stderr)
-            return
+            return true
         }
 
         lock.lock()
@@ -291,13 +309,14 @@ private final class ProxyServer {
         lock.unlock()
 
         bridge(hostFD: hostFD, guestReadFD: guestChannel.readFD, guestWriteFD: guestChannel.writeFD)
-        guestChannel.close()
+        guestChannel.finishSession()
 
         lock.lock()
         if activeChannel === guestChannel {
             activeChannel = nil
         }
         lock.unlock()
+        return true
     }
 
     private func bridge(hostFD: Int32, guestReadFD: Int32, guestWriteFD: Int32) {
@@ -513,6 +532,7 @@ private final class VMRuntime {
         let channel = GuestChannel(
             readFD: guestToHost.fileHandleForReading.fileDescriptor,
             writeFD: hostToGuest.fileHandleForWriting.fileDescriptor,
+            closeAfterUse: false,
             onClose: {
                 guestToHost.fileHandleForReading.closeFile()
                 hostToGuest.fileHandleForWriting.closeFile()

--- a/docs/backend/darwin-vz.md
+++ b/docs/backend/darwin-vz.md
@@ -18,16 +18,16 @@ Implemented:
 - helper-managed VM lifecycle (`StartVM` / `StopVM`)
 - managed kernel fallback when `kernel_image` is unset or missing
 - rootfs derivation from `sandbox.image.ref` when `rootfs` is unset or missing
+- persistent sandboxes across multiple executions
 - doctor checks for helper availability and entitlement status
 
 Not implemented:
 
 - egress allowlist filtering for `sandbox.network.allow`
-- persistent `darwin-vz` sandboxes across multiple executions
 
 ## Process and Transport Model
 
-Each launched execution starts a dedicated helper process.
+Each provisioned sandbox starts a dedicated helper process and VM that are reused across executions until sandbox termination.
 
 Control plane:
 
@@ -42,19 +42,19 @@ Data plane:
 
 High-level flow:
 
-1. Go resolves kernel and rootfs paths.
-2. Go starts `cleanroom-darwin-vz --socket <run_dir>/vz-helper.sock`.
+1. Go resolves kernel and rootfs paths during sandbox provisioning.
+2. Go starts `cleanroom-darwin-vz --socket <sandbox_run_dir>/vz-helper.sock`.
 3. Go sends `StartVM`.
-4. Helper starts VM and binds proxy socket.
-5. Go dials proxy socket and runs normal `vsockexec` request/stream protocol.
-6. Go sends `StopVM` during teardown.
+4. Helper starts VM and binds a long-lived proxy socket.
+5. Each execution dials the proxy socket and runs normal `vsockexec` request/stream protocol.
+6. Go sends `StopVM` during sandbox teardown.
 
 ## Helper Request Schema
 
 `StartVM` request fields:
 
 - `kernel_path` absolute path to Linux kernel
-- `rootfs_path` absolute path to per-run ext4 rootfs copy
+- `rootfs_path` absolute path to sandbox-scoped ext4 rootfs copy
 - `vcpus`, `memory_mib`, `guest_port`, `launch_seconds`
 - `run_dir`
 - `proxy_socket_path`
@@ -84,7 +84,7 @@ Rootfs:
 - if configured rootfs exists, use it
 - otherwise derive rootfs from `sandbox.image.ref` using image manager
 - inject guest runtime (`cleanroom-guest-agent` and `/sbin/cleanroom-init`) into a prepared cached rootfs image
-- create a per-run copy (`rootfs-ephemeral.ext4`) and attach it read-write to the VM
+- create a per-sandbox copy (`rootfs-persistent.ext4`) and attach it read-write to the VM
 
 Host tools required for derivation/injection:
 
@@ -112,7 +112,7 @@ Backends now expose a machine-readable capability map (visible in `cleanroom doc
 Current `darwin-vz` capability values:
 
 - `exec.streaming=true`
-- `sandbox.persistent=false`
+- `sandbox.persistent=true`
 - `sandbox.file_download=false`
 - `network.default_deny=true`
 - `network.allowlist_egress=false`
@@ -143,8 +143,36 @@ The helper path is resolved in this order:
 
 If missing, runtime fails with an actionable error.
 
+## Testing
+
+Fast path:
+
+- `mise exec -- go test ./internal/backend/darwinvz`
+- `mise exec -- go test ./...`
+
+Real VM persistence e2e:
+
+1. Build the signed helper: `mise run build:darwin`
+2. Ensure the linux guest agent is installed or otherwise discoverable.
+3. If you are not providing `CLEANROOM_DARWIN_VZ_E2E_ROOTFS`, install `e2fsprogs` on macOS so `mkfs.ext4` and `debugfs` are available.
+4. Run the opt-in test:
+
+```bash
+CLEANROOM_DARWIN_VZ_E2E=1 \
+CLEANROOM_DARWIN_VZ_HELPER="$PWD/dist/cleanroom-darwin-vz" \
+CLEANROOM_DARWIN_VZ_E2E_IMAGE_REF="docker.io/library/alpine@sha256:a4f4213abb84c497377b8544c81b3564f313746700372ec4fe84653e4fb03805" \
+mise exec -- go test ./internal/backend/darwinvz -run TestPersistentSandboxE2E -v
+```
+
+Supported e2e overrides:
+
+- `CLEANROOM_DARWIN_VZ_E2E_IMAGE_REF` selects the sandbox image ref used for rootfs derivation.
+- `CLEANROOM_DARWIN_VZ_E2E_KERNEL_IMAGE` forces a specific kernel path instead of the managed kernel asset.
+- `CLEANROOM_DARWIN_VZ_E2E_ROOTFS` points at a prebuilt ext4 rootfs and skips the host `e2fsprogs` requirement.
+
+The e2e test provisions one sandbox, runs two commands against it, asserts that filesystem writes survive across executions, then terminates the sandbox and verifies runtime cleanup.
+
 ## Limitations
 
 - no allowlist egress filtering yet
-- per-run helper/VM lifecycle only (no long-lived helper daemon)
-- no cross-execution mutable sandbox state on `darwin-vz`
+- no sandbox file download support yet

--- a/docs/isolation.md
+++ b/docs/isolation.md
@@ -10,7 +10,7 @@ Workloads run in a Linux microVM (`firecracker` on Linux, `darwin-vz` on macOS).
 ## Filesystem persistence
 
 - `firecracker`: rootfs writes persist across executions within a sandbox and are discarded on sandbox termination. Rootfs copy uses clone/reflink when available, with copy fallback.
-- `darwin-vz`: each command runs in a fresh VM with a fresh rootfs copy. Writes are discarded after each run.
+- `darwin-vz`: rootfs writes persist across executions within a sandbox and are discarded on sandbox termination.
 
 ## Observability
 

--- a/docs/research.md
+++ b/docs/research.md
@@ -118,7 +118,7 @@ Current validated release: `v1.17.4` (published 2026-02-18). See also: [releases
 
 Apple's [Virtualization.framework](https://developer.apple.com/documentation/virtualization) provides hardware-accelerated VMs on macOS (Apple Silicon and Intel). Cleanroom's `darwin-vz` backend uses a dedicated Swift helper binary for VM lifecycle and keeps policy/image/control-plane orchestration in Go.
 
-Current status: per-run VMs only (no persistent sandboxes). Guest outbound networking is available via NAT, but allowlist egress filtering is not yet implemented. The backend enforces `network.default: deny` as a policy shape check and warns that `network.allow` entries are ignored. See [darwin-vz.md](backend/darwin-vz.md) for implementation details.
+Current status: persistent sandboxes are supported. Guest outbound networking is available via NAT, but allowlist egress filtering is not yet implemented. The backend enforces `network.default: deny` as a policy shape check and warns that `network.allow` entries are ignored. See [darwin-vz.md](backend/darwin-vz.md) for implementation details.
 
 Used by: Tart, Matchlock (macOS path), Cleanroom (macOS path).
 

--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -27,6 +27,7 @@ import (
 	"github.com/buildkite/cleanroom/internal/hosttools"
 	"github.com/buildkite/cleanroom/internal/imagemgr"
 	"github.com/buildkite/cleanroom/internal/paths"
+	"github.com/buildkite/cleanroom/internal/policy"
 	"github.com/buildkite/cleanroom/internal/vsockexec"
 	"github.com/charmbracelet/log"
 )
@@ -48,6 +49,12 @@ type Adapter struct {
 
 	runtimeImageMu sync.Mutex
 
+	sandboxMu          sync.Mutex
+	sandboxes          map[string]*sandboxInstance
+	provisioning       map[string]struct{}
+	launchSandboxVMFn  func(context.Context, string, *policy.CompiledPolicy, backend.FirecrackerConfig) (*sandboxInstance, error)
+	executeInSandboxFn func(context.Context, context.Context, *sandboxInstance, backend.RunRequest, backend.OutputStream) (*backend.RunResult, error)
+
 	ensurePreparedRootFSFn func(context.Context, string) (preparedRootFS, error)
 
 	GatewayRegistry gatewayRegistry
@@ -66,6 +73,21 @@ type preparedRootFS struct {
 	Digest string
 	Path   string
 	Hit    bool
+}
+
+type sandboxInstance struct {
+	SandboxID       string
+	RunDir          string
+	ConfigPath      string
+	ProxySocketPath string
+	GuestPort       uint32
+	Policy          *policy.CompiledPolicy
+	ImageRef        string
+	ImageDigest     string
+	CommandTimeout  int64
+	Helper          *helperSession
+	VMID            string
+	vmRootFSPath    string
 }
 
 const preparedRuntimeRootFSVersion = "v8-darwin-vz"
@@ -229,6 +251,136 @@ func (a *Adapter) Run(ctx context.Context, req backend.RunRequest) (*backend.Run
 
 func (a *Adapter) RunStream(ctx context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
 	return a.run(ctx, req, stream)
+}
+
+func (a *Adapter) ProvisionSandbox(ctx context.Context, req backend.ProvisionRequest) error {
+	sandboxID := strings.TrimSpace(req.SandboxID)
+	if sandboxID == "" {
+		return errors.New("missing sandbox_id")
+	}
+	if req.Policy == nil {
+		return errors.New("missing compiled policy")
+	}
+
+	a.sandboxMu.Lock()
+	if a.sandboxes == nil {
+		a.sandboxes = map[string]*sandboxInstance{}
+	}
+	if a.provisioning == nil {
+		a.provisioning = map[string]struct{}{}
+	}
+	if _, exists := a.sandboxes[sandboxID]; exists {
+		a.sandboxMu.Unlock()
+		return fmt.Errorf("sandbox %q already provisioned", sandboxID)
+	}
+	if _, exists := a.provisioning[sandboxID]; exists {
+		a.sandboxMu.Unlock()
+		return fmt.Errorf("sandbox %q is already provisioning", sandboxID)
+	}
+	a.provisioning[sandboxID] = struct{}{}
+	a.sandboxMu.Unlock()
+
+	launch := a.launchSandboxVMFn
+	if launch == nil {
+		launch = a.launchSandboxVM
+	}
+
+	instance, err := launch(ctx, sandboxID, req.Policy, req.FirecrackerConfig)
+	if err != nil {
+		a.sandboxMu.Lock()
+		delete(a.provisioning, sandboxID)
+		a.sandboxMu.Unlock()
+		return err
+	}
+
+	a.sandboxMu.Lock()
+	defer a.sandboxMu.Unlock()
+	delete(a.provisioning, sandboxID)
+	if _, exists := a.sandboxes[sandboxID]; exists {
+		instance.shutdown()
+		return fmt.Errorf("sandbox %q already provisioned", sandboxID)
+	}
+	a.sandboxes[sandboxID] = instance
+	return nil
+}
+
+func (a *Adapter) RunInSandbox(ctx context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+	sandboxID := strings.TrimSpace(req.SandboxID)
+	if sandboxID == "" {
+		return nil, errors.New("missing sandbox_id")
+	}
+	if len(req.Command) == 0 {
+		return nil, errors.New("missing command")
+	}
+	if strings.TrimSpace(req.RunID) == "" {
+		return nil, errors.New("missing run_id")
+	}
+
+	a.sandboxMu.Lock()
+	instance, ok := a.sandboxes[sandboxID]
+	a.sandboxMu.Unlock()
+	if !ok {
+		return nil, fmt.Errorf("unknown sandbox %q", sandboxID)
+	}
+
+	if req.Policy == nil {
+		req.Policy = instance.Policy
+	}
+	if req.Policy == nil {
+		return nil, errors.New("missing compiled policy")
+	}
+	if _, policyErr := evaluateNetworkPolicy(req.Policy.NetworkDefault, len(req.Policy.Allow)); policyErr != nil {
+		return nil, policyErr
+	}
+
+	runDir := strings.TrimSpace(req.RunDir)
+	if runDir == "" {
+		if baseDir, err := paths.RunBaseDir(); err == nil {
+			runDir = filepath.Join(baseDir, req.RunID)
+		}
+	}
+	if runDir != "" {
+		if err := os.MkdirAll(runDir, 0o755); err != nil {
+			return nil, fmt.Errorf("create run directory: %w", err)
+		}
+	}
+	req.RunDir = runDir
+
+	connectSeconds := req.LaunchSeconds
+	if connectSeconds <= 0 {
+		connectSeconds = instance.CommandTimeout
+	}
+	if connectSeconds <= 0 {
+		connectSeconds = 30
+	}
+	bootCtx, cancel := context.WithTimeout(ctx, time.Duration(connectSeconds)*time.Second)
+	defer cancel()
+
+	executeInSandbox := a.executeInSandboxFn
+	if executeInSandbox == nil {
+		executeInSandbox = a.executeInSandbox
+	}
+	return executeInSandbox(bootCtx, ctx, instance, req, stream)
+}
+
+func (a *Adapter) TerminateSandbox(_ context.Context, sandboxID string) error {
+	sandboxID = strings.TrimSpace(sandboxID)
+	if sandboxID == "" {
+		return errors.New("missing sandbox_id")
+	}
+
+	a.sandboxMu.Lock()
+	instance, ok := a.sandboxes[sandboxID]
+	if ok {
+		delete(a.sandboxes, sandboxID)
+	}
+	a.sandboxMu.Unlock()
+	if !ok {
+		return nil
+	}
+
+	instance.shutdown()
+	return nil
 }
 
 func (a *Adapter) Doctor(_ context.Context, req backend.DoctorRequest) (*backend.DoctorReport, error) {
@@ -660,6 +812,325 @@ func (a *Adapter) run(ctx context.Context, req backend.RunRequest, stream backen
 		Stdout:      guestRes.Stdout,
 		Stderr:      stderrPrefix + guestRes.Stderr,
 	}, nil
+}
+
+func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compiled *policy.CompiledPolicy, cfg backend.FirecrackerConfig) (*sandboxInstance, error) {
+	if compiled == nil {
+		return nil, errors.New("missing compiled policy")
+	}
+	if _, policyErr := evaluateNetworkPolicy(compiled.NetworkDefault, len(compiled.Allow)); policyErr != nil {
+		return nil, policyErr
+	}
+	if runtime.GOOS != "darwin" {
+		return nil, fmt.Errorf("darwin-vz backend is darwin-only, current OS is %s", runtime.GOOS)
+	}
+
+	if cfg.VCPUs <= 0 {
+		cfg.VCPUs = 1
+	}
+	if cfg.MemoryMiB <= 0 {
+		cfg.MemoryMiB = 512
+	}
+	if cfg.GuestPort == 0 {
+		cfg.GuestPort = vsockexec.DefaultPort
+	}
+	if cfg.LaunchSeconds <= 0 {
+		cfg.LaunchSeconds = 30
+	}
+
+	kernelPath, _, err := a.resolveKernelPath(ctx, cfg.KernelImagePath)
+	if err != nil {
+		return nil, err
+	}
+	rootFSPath, imageRef, imageDigest, _, err := a.resolveRootFSPath(ctx, backend.RunRequest{
+		Policy:            compiled,
+		FirecrackerConfig: cfg,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	runBaseDir, err := sandboxRuntimeBaseDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolve sandbox runtime base directory: %w", err)
+	}
+	runDir := filepath.Join(runBaseDir, sandboxID)
+	cleanupRunDir := true
+	defer func() {
+		if cleanupRunDir {
+			_ = os.RemoveAll(runDir)
+		}
+	}()
+	if err := os.MkdirAll(runDir, 0o755); err != nil {
+		return nil, fmt.Errorf("create sandbox runtime directory: %w", err)
+	}
+
+	rootFSPath, err = filepath.Abs(rootFSPath)
+	if err != nil {
+		return nil, fmt.Errorf("resolve rootfs path: %w", err)
+	}
+	if _, err := os.Stat(rootFSPath); err != nil {
+		return nil, fmt.Errorf("rootfs %s: %w", rootFSPath, err)
+	}
+
+	vmRootFSPath := filepath.Join(runDir, "rootfs-persistent.ext4")
+	if err := copyFile(rootFSPath, vmRootFSPath); err != nil {
+		return nil, fmt.Errorf("prepare persistent rootfs: %w", err)
+	}
+
+	guestInitPath, _ := guestInitExecutableForRootFS(vmRootFSPath)
+	bootArgs := fmt.Sprintf(
+		"console=hvc0 root=/dev/vda rw init=%s cleanroom_guest_port=%d %s",
+		guestInitPath,
+		cfg.GuestPort,
+		dockerServiceBootArgs(compiled, cfg),
+	)
+	consolePath := filepath.Join(runDir, "vm.console.log")
+
+	configPath := filepath.Join(runDir, "darwin-vz-config.json")
+	if err := writeJSON(configPath, map[string]any{
+		"backend":      a.Name(),
+		"kernel_image": kernelPath,
+		"rootfs":       vmRootFSPath,
+		"vcpus":        cfg.VCPUs,
+		"memory_mib":   cfg.MemoryMiB,
+		"guest_port":   cfg.GuestPort,
+		"launch_secs":  cfg.LaunchSeconds,
+		"boot_args":    bootArgs,
+	}); err != nil {
+		return nil, err
+	}
+
+	helper, err := startHelperSession(ctx, runDir, cfg.LaunchSeconds)
+	if err != nil {
+		return nil, fmt.Errorf("start darwin-vz helper: %w", err)
+	}
+	helperNeedsClose := true
+	defer func() {
+		if helperNeedsClose {
+			_ = helper.close()
+		}
+	}()
+
+	proxySocketPath := filepath.Join(runDir, helperProxySocketName)
+	if err := ensureUnixSocketPathFits(proxySocketPath); err != nil {
+		return nil, fmt.Errorf("proxy socket path %q is too long: %w", proxySocketPath, err)
+	}
+	_ = os.Remove(proxySocketPath)
+
+	startCtx, cancelStart := context.WithTimeout(ctx, time.Duration(cfg.LaunchSeconds)*time.Second)
+	defer cancelStart()
+	startRes, err := helper.request(startCtx, helperControlRequest{
+		Op:              "StartVM",
+		KernelPath:      kernelPath,
+		RootFSPath:      vmRootFSPath,
+		BootArgs:        bootArgs,
+		VCPUs:           cfg.VCPUs,
+		MemoryMiB:       cfg.MemoryMiB,
+		GuestPort:       cfg.GuestPort,
+		LaunchSeconds:   cfg.LaunchSeconds,
+		RunDir:          runDir,
+		ProxySocketPath: proxySocketPath,
+		ConsoleLogPath:  consolePath,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("start vm via darwin-vz helper: %w", err)
+	}
+
+	vmID := strings.TrimSpace(startRes.VMID)
+	if vmID == "" {
+		return nil, errors.New("darwin-vz helper returned empty vm_id")
+	}
+	if p := strings.TrimSpace(startRes.ProxySocketPath); p != "" {
+		proxySocketPath = p
+	}
+	if strings.TrimSpace(proxySocketPath) == "" {
+		return nil, errors.New("darwin-vz helper returned empty proxy socket path")
+	}
+	if err := ensureUnixSocketPathFits(proxySocketPath); err != nil {
+		return nil, fmt.Errorf("proxy socket path %q is too long: %w", proxySocketPath, err)
+	}
+
+	helperNeedsClose = false
+	cleanupRunDir = false
+	return &sandboxInstance{
+		SandboxID:       sandboxID,
+		RunDir:          runDir,
+		ConfigPath:      configPath,
+		ProxySocketPath: proxySocketPath,
+		GuestPort:       cfg.GuestPort,
+		Policy:          compiled,
+		ImageRef:        imageRef,
+		ImageDigest:     imageDigest,
+		CommandTimeout:  cfg.LaunchSeconds,
+		Helper:          helper,
+		VMID:            vmID,
+		vmRootFSPath:    vmRootFSPath,
+	}, nil
+}
+
+func (a *Adapter) executeInSandbox(bootCtx context.Context, runCtx context.Context, instance *sandboxInstance, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+	if instance == nil {
+		return nil, errors.New("nil sandbox instance")
+	}
+	if len(req.Command) == 0 {
+		return nil, errors.New("missing command")
+	}
+
+	policy := req.Policy
+	if policy == nil {
+		policy = instance.Policy
+	}
+	if policy == nil {
+		return nil, errors.New("missing compiled policy")
+	}
+	policyWarn, policyErr := evaluateNetworkPolicy(policy.NetworkDefault, len(policy.Allow))
+	if policyErr != nil {
+		return nil, policyErr
+	}
+
+	warnings := buildRuntimeWarnings(policyWarn)
+	stderrPrefix := ""
+	for _, warningText := range warnings {
+		warningLine := "warning: " + warningText + "\n"
+		stderrPrefix += warningLine
+		if stream.OnStderr != nil {
+			stream.OnStderr([]byte(warningLine))
+		}
+	}
+
+	helper := instance.Helper
+	if helper == nil {
+		return nil, errors.New("darwin-vz sandbox helper is not available")
+	}
+	proxySocketPath := strings.TrimSpace(instance.ProxySocketPath)
+	if proxySocketPath == "" {
+		return nil, errors.New("darwin-vz sandbox proxy socket path is empty")
+	}
+
+	conn, err := dialUnixSocketWithRetry(bootCtx, proxySocketPath)
+	if err != nil {
+		return nil, helper.decorateError(fmt.Errorf("connect darwin-vz proxy socket %q: %w", proxySocketPath, err))
+	}
+	defer conn.Close()
+
+	if dl, ok := runCtx.Deadline(); ok {
+		if err := conn.SetDeadline(dl); err != nil {
+			return nil, fmt.Errorf("set proxy socket deadline: %w", err)
+		}
+	}
+	go func() {
+		<-runCtx.Done()
+		_ = conn.Close()
+	}()
+
+	gatewayScopeToken := ""
+	if a.GatewayRegistry != nil {
+		token, tokenErr := randomScopeToken()
+		if tokenErr != nil {
+			return nil, fmt.Errorf("generate gateway scope token: %w", tokenErr)
+		}
+		scopeSandboxID := strings.TrimSpace(req.SandboxID)
+		if scopeSandboxID == "" {
+			scopeSandboxID = strings.TrimSpace(instance.SandboxID)
+		}
+		if scopeSandboxID == "" {
+			scopeSandboxID = strings.TrimSpace(req.RunID)
+		}
+		if err := a.GatewayRegistry.RegisterScopeToken(token, scopeSandboxID, policy); err != nil {
+			return nil, fmt.Errorf("register sandbox in gateway: %w", err)
+		}
+		gatewayScopeToken = token
+		defer a.GatewayRegistry.ReleaseScopeToken(gatewayScopeToken)
+	}
+
+	guestReq := vsockexec.ExecRequest{Command: append([]string(nil), req.Command...), TTY: req.TTY}
+	if a.GatewayRegistry != nil && gatewayScopeToken != "" {
+		gwPort := a.GatewayPort
+		if gwPort <= 0 {
+			gwPort = gateway.DefaultPort
+		}
+		gwHost := strings.TrimSpace(a.GatewayHost)
+		if gwHost == "" {
+			gwHost = defaultGatewayHost
+		}
+		guestReq.Env = append(guestReq.Env, gatewayEnvVars(policy, gwHost, gwPort, gatewayScopeToken)...)
+	}
+	seed := make([]byte, 64)
+	if _, err := cryptorand.Read(seed); err == nil {
+		guestReq.EntropySeed = seed
+	}
+	if err := vsockexec.EncodeRequest(conn, guestReq); err != nil {
+		return nil, fmt.Errorf("send guest exec request: %w", err)
+	}
+
+	inputSender := &inputFrameSender{w: conn}
+	if stream.OnAttach != nil {
+		stream.OnAttach(backend.AttachIO{
+			WriteStdin: func(data []byte) error {
+				return inputSender.Send(vsockexec.ExecInputFrame{Type: "stdin", Data: data})
+			},
+			ResizeTTY: func(cols, rows uint32) error {
+				return inputSender.Send(vsockexec.ExecInputFrame{Type: "resize", Cols: cols, Rows: rows})
+			},
+		})
+	}
+	if !req.TTY {
+		_ = inputSender.Send(vsockexec.ExecInputFrame{Type: "eof"})
+	}
+
+	guestRes, err := vsockexec.DecodeStreamResponse(conn, vsockexec.StreamCallbacks{
+		OnStdout: stream.OnStdout,
+		OnStderr: stream.OnStderr,
+	})
+	if err != nil {
+		if ctxErr := runCtx.Err(); ctxErr != nil {
+			return nil, fmt.Errorf("guest exec canceled while waiting for response: %w", ctxErr)
+		}
+		return nil, helper.decorateError(fmt.Errorf("decode guest exec response over darwin-vz proxy: %w", err))
+	}
+
+	return &backend.RunResult{
+		RunID:       req.RunID,
+		ExitCode:    guestRes.ExitCode,
+		LaunchedVM:  false,
+		PlanPath:    instance.ConfigPath,
+		RunDir:      req.RunDir,
+		ImageRef:    instance.ImageRef,
+		ImageDigest: instance.ImageDigest,
+		Message:     darwinVZResultMessage(guestRes.Error),
+		Stdout:      guestRes.Stdout,
+		Stderr:      stderrPrefix + guestRes.Stderr,
+	}, nil
+}
+
+func sandboxRuntimeBaseDir() (string, error) {
+	base, err := paths.StateBaseDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, "sandboxes"), nil
+}
+
+func (s *sandboxInstance) shutdown() {
+	if s == nil {
+		return
+	}
+	if s.Helper != nil {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		if strings.TrimSpace(s.VMID) != "" {
+			_, _ = s.Helper.request(stopCtx, helperControlRequest{Op: "StopVM", VMID: s.VMID})
+		}
+		cancel()
+		_ = s.Helper.close()
+	}
+	if strings.TrimSpace(s.RunDir) != "" {
+		_ = os.RemoveAll(s.RunDir)
+		return
+	}
+	if strings.TrimSpace(s.vmRootFSPath) != "" {
+		_ = os.Remove(s.vmRootFSPath)
+	}
 }
 
 func darwinVZResultMessage(guestErr string) string {

--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -88,6 +89,10 @@ type sandboxInstance struct {
 	Helper          *helperSession
 	VMID            string
 	vmRootFSPath    string
+	exitedCh        chan struct{}
+	exitMu          sync.RWMutex
+	exitErr         error
+	exitReady       bool
 }
 
 const preparedRuntimeRootFSVersion = "v8-darwin-vz"
@@ -321,6 +326,9 @@ func (a *Adapter) RunInSandbox(ctx context.Context, req backend.RunRequest, stre
 	a.sandboxMu.Unlock()
 	if !ok {
 		return nil, fmt.Errorf("unknown sandbox %q", sandboxID)
+	}
+	if err := instance.exitedErrOrNil(); err != nil {
+		return nil, fmt.Errorf("sandbox %q is not running: %w", sandboxID, err)
 	}
 
 	if req.Policy == nil {
@@ -951,9 +959,7 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 		return nil, fmt.Errorf("proxy socket path %q is too long: %w", proxySocketPath, err)
 	}
 
-	helperNeedsClose = false
-	cleanupRunDir = false
-	return &sandboxInstance{
+	instance := &sandboxInstance{
 		SandboxID:       sandboxID,
 		RunDir:          runDir,
 		ConfigPath:      configPath,
@@ -966,7 +972,31 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 		Helper:          helper,
 		VMID:            vmID,
 		vmRootFSPath:    vmRootFSPath,
-	}, nil
+		exitedCh:        make(chan struct{}),
+	}
+	go func() {
+		err, ok := <-helper.done
+		if !ok {
+			err = nil
+		}
+		if normalized := helper.normalizeHelperExitErr(err); normalized != nil {
+			err = fmt.Errorf("sandbox helper exited: %w", normalized)
+		} else {
+			err = nil
+		}
+		instance.setExited(err)
+		close(instance.exitedCh)
+	}()
+
+	bootCtx, cancel := context.WithTimeout(ctx, time.Duration(cfg.LaunchSeconds)*time.Second)
+	defer cancel()
+	if err := probeGuestExecReadyWithExit(bootCtx, helper, proxySocketPath, instance.exitedCh, instance.exitedErrOrNil); err != nil {
+		return nil, err
+	}
+
+	helperNeedsClose = false
+	cleanupRunDir = false
+	return instance, nil
 }
 
 func (a *Adapter) executeInSandbox(bootCtx context.Context, runCtx context.Context, instance *sandboxInstance, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
@@ -1007,8 +1037,11 @@ func (a *Adapter) executeInSandbox(bootCtx context.Context, runCtx context.Conte
 	if proxySocketPath == "" {
 		return nil, errors.New("darwin-vz sandbox proxy socket path is empty")
 	}
+	if err := instance.exitedErrOrNil(); err != nil {
+		return nil, fmt.Errorf("sandbox %q is not running: %w", instance.SandboxID, err)
+	}
 
-	conn, err := dialUnixSocketWithRetry(bootCtx, proxySocketPath)
+	conn, err := dialUnixSocketWithExit(bootCtx, proxySocketPath, instance.exitedCh, instance.exitedErrOrNil)
 	if err != nil {
 		return nil, helper.decorateError(fmt.Errorf("connect darwin-vz proxy socket %q: %w", proxySocketPath, err))
 	}
@@ -1112,6 +1145,72 @@ func sandboxRuntimeBaseDir() (string, error) {
 	return filepath.Join(base, "sandboxes"), nil
 }
 
+func probeGuestExecReady(ctx context.Context, helper *helperSession, socketPath string) error {
+	return probeGuestExecReadyWithExit(ctx, helper, socketPath, nil, nil)
+}
+
+func probeGuestExecReadyWithExit(ctx context.Context, helper *helperSession, socketPath string, exitedCh <-chan struct{}, exitedErrOrNil func() error) error {
+	conn, err := dialUnixSocketWithExit(ctx, socketPath, exitedCh, exitedErrOrNil)
+	if err != nil {
+		if helper != nil {
+			return helper.decorateError(fmt.Errorf("connect darwin-vz proxy socket %q for guest readiness probe: %w", socketPath, err))
+		}
+		return fmt.Errorf("connect darwin-vz proxy socket %q for guest readiness probe: %w", socketPath, err)
+	}
+	defer conn.Close()
+
+	if err := vsockexec.EncodeRequest(conn, vsockexec.ExecRequest{}); err != nil {
+		if helper != nil {
+			return helper.decorateError(fmt.Errorf("send guest readiness probe over darwin-vz proxy: %w", err))
+		}
+		return fmt.Errorf("send guest readiness probe over darwin-vz proxy: %w", err)
+	}
+	if _, err := vsockexec.DecodeResponse(conn); err != nil {
+		if helper != nil {
+			return helper.decorateError(fmt.Errorf("decode guest readiness probe over darwin-vz proxy: %w", err))
+		}
+		return fmt.Errorf("decode guest readiness probe over darwin-vz proxy: %w", err)
+	}
+	return nil
+}
+
+func dialUnixSocketWithExit(ctx context.Context, socketPath string, exitedCh <-chan struct{}, exitedErrOrNil func() error) (net.Conn, error) {
+	dialer := net.Dialer{}
+	ticker := time.NewTicker(25 * time.Millisecond)
+	defer ticker.Stop()
+
+	exitErr := func() error {
+		if exitedErrOrNil == nil {
+			return nil
+		}
+		return exitedErrOrNil()
+	}
+
+	for {
+		conn, err := dialer.DialContext(ctx, "unix", socketPath)
+		if err == nil {
+			return conn, nil
+		}
+		if err := exitErr(); err != nil {
+			return nil, fmt.Errorf("sandbox exited while waiting for unix socket %q: %w", socketPath, err)
+		}
+
+		select {
+		case <-ctx.Done():
+			if err := exitErr(); err != nil {
+				return nil, fmt.Errorf("sandbox exited while waiting for unix socket %q: %w", socketPath, err)
+			}
+			return nil, fmt.Errorf("timed out waiting for unix socket %q: %w", socketPath, ctx.Err())
+		case <-exitedCh:
+			if err := exitErr(); err != nil {
+				return nil, fmt.Errorf("sandbox exited while waiting for unix socket %q: %w", socketPath, err)
+			}
+			return nil, fmt.Errorf("sandbox exited while waiting for unix socket %q", socketPath)
+		case <-ticker.C:
+		}
+	}
+}
+
 func (s *sandboxInstance) shutdown() {
 	if s == nil {
 		return
@@ -1131,6 +1230,28 @@ func (s *sandboxInstance) shutdown() {
 	if strings.TrimSpace(s.vmRootFSPath) != "" {
 		_ = os.Remove(s.vmRootFSPath)
 	}
+}
+
+func (s *sandboxInstance) setExited(err error) {
+	s.exitMu.Lock()
+	defer s.exitMu.Unlock()
+	if s.exitReady {
+		return
+	}
+	s.exitErr = err
+	s.exitReady = true
+}
+
+func (s *sandboxInstance) exitedErrOrNil() error {
+	s.exitMu.RLock()
+	defer s.exitMu.RUnlock()
+	if !s.exitReady {
+		return nil
+	}
+	if s.exitErr == nil {
+		return errors.New("sandbox exited")
+	}
+	return s.exitErr
 }
 
 func darwinVZResultMessage(guestErr string) string {

--- a/internal/backend/darwinvz/persistent_e2e_test.go
+++ b/internal/backend/darwinvz/persistent_e2e_test.go
@@ -1,0 +1,176 @@
+//go:build darwin
+
+package darwinvz
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/hosttools"
+	"github.com/buildkite/cleanroom/internal/policy"
+)
+
+const (
+	darwinVZE2EEnvEnabled     = "CLEANROOM_DARWIN_VZ_E2E"
+	darwinVZE2EEnvImageRef    = "CLEANROOM_DARWIN_VZ_E2E_IMAGE_REF"
+	darwinVZE2EEnvKernelImage = "CLEANROOM_DARWIN_VZ_E2E_KERNEL_IMAGE"
+	darwinVZE2EEnvRootFS      = "CLEANROOM_DARWIN_VZ_E2E_ROOTFS"
+)
+
+func TestPersistentSandboxE2E(t *testing.T) {
+	if strings.TrimSpace(os.Getenv(darwinVZE2EEnvEnabled)) == "" {
+		t.Skipf("set %s=1 to run real darwin-vz persistence e2e", darwinVZE2EEnvEnabled)
+	}
+	if testing.Short() {
+		t.Skip("skipping darwin-vz e2e in short mode")
+	}
+
+	helperPath, err := resolveHelperBinaryPath()
+	if err != nil {
+		t.Fatalf("resolve helper binary: %v", err)
+	}
+	hasEntitlement, err := helperHasVirtualizationEntitlement(helperPath)
+	if err != nil {
+		t.Fatalf("verify helper entitlement: %v", err)
+	}
+	if !hasEntitlement {
+		t.Fatalf("helper %q is missing com.apple.security.virtualization entitlement", helperPath)
+	}
+	if _, _, err := New().getGuestAgentBinary(); err != nil {
+		t.Fatalf("resolve guest agent binary: %v", err)
+	}
+
+	rootFSOverride := strings.TrimSpace(os.Getenv(darwinVZE2EEnvRootFS))
+	if rootFSOverride == "" {
+		if _, err := hosttools.ResolveE2FSProgsBinary("mkfs.ext4"); err != nil {
+			t.Fatalf("resolve mkfs.ext4: %v", err)
+		}
+		if _, err := hosttools.ResolveE2FSProgsBinary("debugfs"); err != nil {
+			t.Fatalf("resolve debugfs: %v", err)
+		}
+	}
+
+	imageRef := strings.TrimSpace(os.Getenv(darwinVZE2EEnvImageRef))
+	if imageRef == "" {
+		imageRef = "ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	}
+
+	cfg := backend.FirecrackerConfig{
+		KernelImagePath: strings.TrimSpace(os.Getenv(darwinVZE2EEnvKernelImage)),
+		RootFSPath:      rootFSOverride,
+		VCPUs:           1,
+		MemoryMiB:       1024,
+		LaunchSeconds:   90,
+	}
+	compiled := &policy.CompiledPolicy{
+		Version:        1,
+		ImageRef:       imageRef,
+		NetworkDefault: "deny",
+	}
+	sandboxID := fmt.Sprintf("cr-e2e-%d", time.Now().UnixNano())
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	adapter := New()
+	if err := adapter.ProvisionSandbox(ctx, backend.ProvisionRequest{
+		SandboxID:         sandboxID,
+		Policy:            compiled,
+		FirecrackerConfig: cfg,
+	}); err != nil {
+		t.Fatalf("ProvisionSandbox returned error: %v", err)
+	}
+
+	adapter.sandboxMu.Lock()
+	instance := adapter.sandboxes[sandboxID]
+	adapter.sandboxMu.Unlock()
+	if instance == nil {
+		t.Fatal("expected provisioned sandbox instance")
+	}
+	sandboxRunDir := instance.RunDir
+
+	terminated := false
+	defer func() {
+		if terminated {
+			return
+		}
+		if err := adapter.TerminateSandbox(context.Background(), sandboxID); err != nil {
+			t.Fatalf("deferred TerminateSandbox returned error: %v", err)
+		}
+	}()
+
+	markerPath := fmt.Sprintf("/tmp/%s-marker.txt", sandboxID)
+	markerValue := "darwin-vz-persisted-state"
+
+	run1Dir := filepath.Join(t.TempDir(), "run-1")
+	first, err := adapter.RunInSandbox(ctx, backend.RunRequest{
+		SandboxID: sandboxID,
+		RunID:     "run-1",
+		Command: []string{
+			"sh", "-lc", fmt.Sprintf("printf %s > %s", markerValue, markerPath),
+		},
+		Policy: compiled,
+		FirecrackerConfig: backend.FirecrackerConfig{
+			RunDir:        run1Dir,
+			LaunchSeconds: cfg.LaunchSeconds,
+		},
+	}, backend.OutputStream{})
+	if err != nil {
+		t.Fatalf("first RunInSandbox returned error: %v", err)
+	}
+	if first.ExitCode != 0 {
+		t.Fatalf("expected first exit code 0, got %d (stderr=%q)", first.ExitCode, first.Stderr)
+	}
+	if first.LaunchedVM {
+		t.Fatalf("expected persistent execution to report LaunchedVM=false, got %#v", first)
+	}
+
+	run2Dir := filepath.Join(t.TempDir(), "run-2")
+	second, err := adapter.RunInSandbox(ctx, backend.RunRequest{
+		SandboxID: sandboxID,
+		RunID:     "run-2",
+		Command:   []string{"sh", "-lc", "cat " + markerPath},
+		Policy:    compiled,
+		FirecrackerConfig: backend.FirecrackerConfig{
+			RunDir:        run2Dir,
+			LaunchSeconds: cfg.LaunchSeconds,
+		},
+	}, backend.OutputStream{})
+	if err != nil {
+		t.Fatalf("second RunInSandbox returned error: %v", err)
+	}
+	if second.ExitCode != 0 {
+		t.Fatalf("expected second exit code 0, got %d (stderr=%q)", second.ExitCode, second.Stderr)
+	}
+	if second.LaunchedVM {
+		t.Fatalf("expected persistent execution to report LaunchedVM=false, got %#v", second)
+	}
+	if got, want := strings.TrimSpace(second.Stdout), markerValue; got != want {
+		t.Fatalf("unexpected persisted file contents: got %q want %q", got, want)
+	}
+	if got, want := second.PlanPath, first.PlanPath; got != want {
+		t.Fatalf("expected stable sandbox plan path across runs: got %q want %q", got, want)
+	}
+
+	if err := adapter.TerminateSandbox(ctx, sandboxID); err != nil {
+		t.Fatalf("TerminateSandbox returned error: %v", err)
+	}
+	terminated = true
+
+	if _, err := os.Stat(sandboxRunDir); !os.IsNotExist(err) {
+		t.Fatalf("expected sandbox runtime dir to be removed, got err=%v", err)
+	}
+	if _, err := adapter.RunInSandbox(context.Background(), backend.RunRequest{
+		SandboxID: sandboxID,
+		RunID:     "run-after-terminate",
+		Command:   []string{"true"},
+		Policy:    compiled,
+	}, backend.OutputStream{}); err == nil || !strings.Contains(err.Error(), "unknown sandbox") {
+		t.Fatalf("expected run after terminate to fail with unknown sandbox, got %v", err)
+	}
+}

--- a/internal/backend/darwinvz/persistent_e2e_test.go
+++ b/internal/backend/darwinvz/persistent_e2e_test.go
@@ -23,6 +23,10 @@ const (
 	darwinVZE2EEnvRootFS      = "CLEANROOM_DARWIN_VZ_E2E_ROOTFS"
 )
 
+func defaultDarwinVZE2EImageRef() string {
+	return "docker.io/library/alpine@sha256:a4f4213abb84c497377b8544c81b3564f313746700372ec4fe84653e4fb03805"
+}
+
 func TestPersistentSandboxE2E(t *testing.T) {
 	if strings.TrimSpace(os.Getenv(darwinVZE2EEnvEnabled)) == "" {
 		t.Skipf("set %s=1 to run real darwin-vz persistence e2e", darwinVZE2EEnvEnabled)
@@ -58,7 +62,7 @@ func TestPersistentSandboxE2E(t *testing.T) {
 
 	imageRef := strings.TrimSpace(os.Getenv(darwinVZE2EEnvImageRef))
 	if imageRef == "" {
-		imageRef = "ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+		imageRef = defaultDarwinVZE2EImageRef()
 	}
 
 	cfg := backend.FirecrackerConfig{

--- a/internal/backend/darwinvz/persistent_test.go
+++ b/internal/backend/darwinvz/persistent_test.go
@@ -1,0 +1,148 @@
+//go:build darwin
+
+package darwinvz
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/policy"
+)
+
+func TestCapabilitiesExposePersistentSandboxWithoutFileDownload(t *testing.T) {
+	t.Parallel()
+
+	caps := backend.CapabilitiesForAdapter(New())
+
+	if !caps[backend.CapabilitySandboxPersistent] {
+		t.Fatalf("expected %s=true", backend.CapabilitySandboxPersistent)
+	}
+	if caps[backend.CapabilitySandboxFileDownload] {
+		t.Fatalf("expected %s=false", backend.CapabilitySandboxFileDownload)
+	}
+}
+
+func TestProvisionSandboxRejectsConcurrentProvisionForSameID(t *testing.T) {
+	t.Parallel()
+
+	block := make(chan struct{})
+	started := make(chan struct{})
+	adapter := &Adapter{
+		launchSandboxVMFn: func(_ context.Context, sandboxID string, _ *policy.CompiledPolicy, _ backend.FirecrackerConfig) (*sandboxInstance, error) {
+			if sandboxID != "cr-test" {
+				t.Fatalf("unexpected sandbox id %q", sandboxID)
+			}
+			select {
+			case started <- struct{}{}:
+			default:
+			}
+			<-block
+			return &sandboxInstance{SandboxID: sandboxID}, nil
+		},
+	}
+
+	compiled := &policy.CompiledPolicy{
+		NetworkDefault: "deny",
+		ImageRef:       "ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+	}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- adapter.ProvisionSandbox(context.Background(), backend.ProvisionRequest{
+			SandboxID: "cr-test",
+			Policy:    compiled,
+		})
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first provision to start")
+	}
+
+	err := adapter.ProvisionSandbox(context.Background(), backend.ProvisionRequest{
+		SandboxID: "cr-test",
+		Policy:    compiled,
+	})
+	if err == nil {
+		t.Fatal("expected second provision to fail")
+	}
+
+	close(block)
+	if err := <-errCh; err != nil {
+		t.Fatalf("first provision returned error: %v", err)
+	}
+}
+
+func TestRunInSandboxUsesRequestLaunchSecondsOverride(t *testing.T) {
+	t.Parallel()
+
+	block := make(chan struct{})
+	defer close(block)
+	adapter := &Adapter{}
+	adapter.executeInSandboxFn = func(bootCtx context.Context, _ context.Context, instance *sandboxInstance, req backend.RunRequest, _ backend.OutputStream) (*backend.RunResult, error) {
+		if instance == nil || instance.SandboxID != "cr-test" {
+			t.Fatalf("unexpected sandbox instance: %#v", instance)
+		}
+		select {
+		case <-block:
+			return nil, errors.New("unexpected unblock")
+		case <-bootCtx.Done():
+			return nil, bootCtx.Err()
+		}
+	}
+	adapter.sandboxes = map[string]*sandboxInstance{
+		"cr-test": {
+			SandboxID:      "cr-test",
+			CommandTimeout: 1,
+		},
+	}
+
+	start := time.Now()
+	_, err := adapter.RunInSandbox(context.Background(), backend.RunRequest{
+		SandboxID: "cr-test",
+		RunID:     "run-timeout",
+		Command:   []string{"echo", "hello"},
+		Policy: &policy.CompiledPolicy{
+			NetworkDefault: "deny",
+		},
+		FirecrackerConfig: backend.FirecrackerConfig{
+			LaunchSeconds: 3,
+		},
+	}, backend.OutputStream{})
+	if err == nil {
+		t.Fatal("expected run to fail on timeout")
+	}
+	if elapsed := time.Since(start); elapsed < 2*time.Second {
+		t.Fatalf("expected launch-seconds override to increase timeout, elapsed=%s err=%v", elapsed, err)
+	}
+}
+
+func TestTerminateSandboxRemovesRunDir(t *testing.T) {
+	t.Parallel()
+
+	runDir := t.TempDir()
+	artifactPath := runDir + "/artifact.txt"
+	if err := os.WriteFile(artifactPath, []byte("hello"), 0o644); err != nil {
+		t.Fatalf("write artifact: %v", err)
+	}
+
+	adapter := &Adapter{
+		sandboxes: map[string]*sandboxInstance{
+			"cr-test": {
+				SandboxID: "cr-test",
+				RunDir:    runDir,
+			},
+		},
+	}
+
+	if err := adapter.TerminateSandbox(context.Background(), "cr-test"); err != nil {
+		t.Fatalf("TerminateSandbox returned error: %v", err)
+	}
+	if _, err := os.Stat(runDir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected run dir to be removed, got err=%v", err)
+	}
+}

--- a/internal/backend/darwinvz/persistent_test.go
+++ b/internal/backend/darwinvz/persistent_test.go
@@ -3,14 +3,19 @@
 package darwinvz
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"net"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/buildkite/cleanroom/internal/backend"
 	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/buildkite/cleanroom/internal/vsockexec"
 )
 
 func TestCapabilitiesExposePersistentSandboxWithoutFileDownload(t *testing.T) {
@@ -118,6 +123,89 @@ func TestRunInSandboxUsesRequestLaunchSecondsOverride(t *testing.T) {
 	}
 	if elapsed := time.Since(start); elapsed < 2*time.Second {
 		t.Fatalf("expected launch-seconds override to increase timeout, elapsed=%s err=%v", elapsed, err)
+	}
+}
+
+func TestRunInSandboxRejectsExitedSandbox(t *testing.T) {
+	t.Parallel()
+
+	instance := &sandboxInstance{SandboxID: "cr-test", exitedCh: make(chan struct{})}
+	instance.setExited(errors.New("helper crashed"))
+	close(instance.exitedCh)
+
+	adapter := &Adapter{
+		sandboxes: map[string]*sandboxInstance{
+			"cr-test": instance,
+		},
+	}
+
+	_, err := adapter.RunInSandbox(context.Background(), backend.RunRequest{
+		SandboxID: "cr-test",
+		RunID:     "run-dead",
+		Command:   []string{"true"},
+		Policy:    &policy.CompiledPolicy{NetworkDefault: "deny"},
+	}, backend.OutputStream{})
+	if err == nil {
+		t.Fatal("expected dead sandbox run to fail")
+	}
+	if got := err.Error(); got == "" || !bytes.Contains([]byte(got), []byte("not running")) {
+		t.Fatalf("expected not running error, got %v", err)
+	}
+}
+
+func TestProbeGuestExecReadyWaitsForGuestResponse(t *testing.T) {
+	t.Parallel()
+
+	socketDir, err := os.MkdirTemp("", "cr-probe-")
+	if err != nil {
+		t.Fatalf("create probe temp dir: %v", err)
+	}
+	defer os.RemoveAll(socketDir)
+
+	socketPath := filepath.Join(socketDir, "p.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen unix socket: %v", err)
+	}
+	defer listener.Close()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		conn, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			t.Errorf("accept probe connection: %v", acceptErr)
+			return
+		}
+		defer conn.Close()
+
+		var req vsockexec.ExecRequest
+		decodeErr := json.NewDecoder(conn).Decode(&req)
+		if decodeErr != nil {
+			t.Errorf("decode probe request: %v", decodeErr)
+			return
+		}
+		if len(req.Command) != 0 {
+			t.Errorf("expected empty probe command, got %v", req.Command)
+			return
+		}
+		if encodeErr := vsockexec.EncodeResponse(conn, vsockexec.ExecResponse{ExitCode: 1, Error: "missing command"}); encodeErr != nil {
+			t.Errorf("encode probe response: %v", encodeErr)
+		}
+	}()
+
+	if err := probeGuestExecReady(context.Background(), nil, socketPath); err != nil {
+		t.Fatalf("probeGuestExecReady returned error: %v", err)
+	}
+	<-done
+}
+
+func TestDefaultDarwinVZE2EImageRefUsesPublishedDigest(t *testing.T) {
+	t.Parallel()
+
+	const want = "docker.io/library/alpine@sha256:a4f4213abb84c497377b8544c81b3564f313746700372ec4fe84653e4fb03805"
+	if got := defaultDarwinVZE2EImageRef(); got != want {
+		t.Fatalf("unexpected default e2e image ref: got %q want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- implement persistent sandbox lifecycle for `darwin-vz` by provisioning one VM/rootfs per sandbox and reusing it across executions
- update the Swift helper proxy to accept multiple sequential exec sessions against the same running VM
- add unit coverage plus an opt-in real `darwin-vz` persistence e2e test, and document the local test workflow

## Testing
- `mise exec -- go test ./internal/backend/darwinvz`
- `mise exec -- go test ./internal/backend/darwinvz ./internal/backend ./internal/controlservice`
- `mise exec -- go test ./...`
- `mise run build:darwin`

```
CLEANROOM_DARWIN_VZ_E2E=1 CLEANROOM_DARWIN_VZ_HELPER="$PWD/dist/cleanroom-darwin-vz" CLEANROOM_DARWIN_VZ_E2E_IMAGE_REF="docker.io/library/alpine@sha256:a4f4213abb84c497377b8544c81b3564f313746700372ec4fe84653e4fb03805" mise exec -- go test ./internal/backend/darwinvz -run TestPersistentSandboxE2E -v
```