### PR TITLE
feat: add initial snapshot lifecycle support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /dist
 /release-extra
+/cleanroom-guest-agent
 
 # Local Terraform environment values (keep *.example committed)
 /infra/terraform/envs/ci/terraform.tfvars

--- a/client/client.go
+++ b/client/client.go
@@ -113,6 +113,13 @@ func (c *Client) DownloadSandboxFile(ctx context.Context, req *DownloadSandboxFi
 	return c.inner.DownloadSandboxFile(ctx, req)
 }
 
+func (c *Client) RestoreSandbox(ctx context.Context, req *RestoreSandboxRequest) (*RestoreSandboxResponse, error) {
+	if c == nil || c.inner == nil {
+		return nil, errors.New("nil client")
+	}
+	return c.inner.RestoreSandbox(ctx, req)
+}
+
 func (c *Client) TerminateSandbox(ctx context.Context, req *TerminateSandboxRequest) (*TerminateSandboxResponse, error) {
 	if c == nil || c.inner == nil {
 		return nil, errors.New("nil client")
@@ -125,6 +132,34 @@ func (c *Client) StreamSandboxEvents(ctx context.Context, req *StreamSandboxEven
 		return nil, errors.New("nil client")
 	}
 	return c.inner.StreamSandboxEvents(ctx, req)
+}
+
+func (c *Client) CreateSnapshot(ctx context.Context, req *CreateSnapshotRequest) (*CreateSnapshotResponse, error) {
+	if c == nil || c.inner == nil {
+		return nil, errors.New("nil client")
+	}
+	return c.inner.CreateSnapshot(ctx, req)
+}
+
+func (c *Client) GetSnapshot(ctx context.Context, req *GetSnapshotRequest) (*GetSnapshotResponse, error) {
+	if c == nil || c.inner == nil {
+		return nil, errors.New("nil client")
+	}
+	return c.inner.GetSnapshot(ctx, req)
+}
+
+func (c *Client) ListSnapshots(ctx context.Context, req *ListSnapshotsRequest) (*ListSnapshotsResponse, error) {
+	if c == nil || c.inner == nil {
+		return nil, errors.New("nil client")
+	}
+	return c.inner.ListSnapshots(ctx, req)
+}
+
+func (c *Client) DeleteSnapshot(ctx context.Context, req *DeleteSnapshotRequest) (*DeleteSnapshotResponse, error) {
+	if c == nil || c.inner == nil {
+		return nil, errors.New("nil client")
+	}
+	return c.inner.DeleteSnapshot(ctx, req)
 }
 
 func (c *Client) CreateExecution(ctx context.Context, req *CreateExecutionRequest) (*CreateExecutionResponse, error) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -289,6 +289,24 @@ func TestClientSnapshotLifecycle(t *testing.T) {
 		t.Fatalf("unexpected restored sandbox status: %v", got)
 	}
 
+	_, err = client.DeleteSnapshot(ctx, &DeleteSnapshotRequest{SnapshotId: snapshotID})
+	if err == nil {
+		t.Fatal("expected delete snapshot to fail while active sandboxes depend on it")
+	}
+	if !strings.Contains(err.Error(), "snapshot_busy") {
+		t.Fatalf("unexpected delete snapshot error: %v", err)
+	}
+
+	for _, id := range []string{forkResp.GetSandbox().GetSandboxId(), sandboxID} {
+		terminateResp, terminateErr := client.TerminateSandbox(ctx, &TerminateSandboxRequest{SandboxId: id})
+		if terminateErr != nil {
+			t.Fatalf("TerminateSandbox returned error for %q: %v", id, terminateErr)
+		}
+		if !terminateResp.GetTerminated() {
+			t.Fatalf("expected terminated=true for %q", id)
+		}
+	}
+
 	deleteSnapshotResp, err := client.DeleteSnapshot(ctx, &DeleteSnapshotRequest{SnapshotId: snapshotID})
 	if err != nil {
 		t.Fatalf("DeleteSnapshot returned error: %v", err)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -289,12 +289,12 @@ func TestClientSnapshotLifecycle(t *testing.T) {
 		t.Fatalf("unexpected restored sandbox status: %v", got)
 	}
 
-	_, err = client.DeleteSnapshot(ctx, &DeleteSnapshotRequest{SnapshotId: snapshotID})
-	if err == nil {
-		t.Fatal("expected delete snapshot to fail while active sandboxes depend on it")
+	deleteSnapshotResp, err := client.DeleteSnapshot(ctx, &DeleteSnapshotRequest{SnapshotId: snapshotID})
+	if err != nil {
+		t.Fatalf("DeleteSnapshot returned error: %v", err)
 	}
-	if !strings.Contains(err.Error(), "snapshot_busy") {
-		t.Fatalf("unexpected delete snapshot error: %v", err)
+	if !deleteSnapshotResp.GetDeleted() {
+		t.Fatal("expected deleted=true")
 	}
 
 	for _, id := range []string{forkResp.GetSandbox().GetSandboxId(), sandboxID} {
@@ -305,14 +305,6 @@ func TestClientSnapshotLifecycle(t *testing.T) {
 		if !terminateResp.GetTerminated() {
 			t.Fatalf("expected terminated=true for %q", id)
 		}
-	}
-
-	deleteSnapshotResp, err := client.DeleteSnapshot(ctx, &DeleteSnapshotRequest{SnapshotId: snapshotID})
-	if err != nil {
-		t.Fatalf("DeleteSnapshot returned error: %v", err)
-	}
-	if !deleteSnapshotResp.GetDeleted() {
-		t.Fatal("expected deleted=true")
 	}
 }
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -10,7 +10,9 @@ import (
 	"github.com/buildkite/cleanroom/internal/backend"
 	"github.com/buildkite/cleanroom/internal/controlserver"
 	"github.com/buildkite/cleanroom/internal/controlservice"
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
 	"github.com/buildkite/cleanroom/internal/runtimeconfig"
+	"github.com/buildkite/cleanroom/internal/snapshotstore"
 )
 
 type integrationAdapter struct{}
@@ -37,13 +39,59 @@ func (a integrationAdapter) RunStream(ctx context.Context, req backend.RunReques
 	return result, nil
 }
 
+type snapshotIntegrationAdapter struct {
+	integrationAdapter
+}
+
+func (snapshotIntegrationAdapter) ProvisionSandbox(context.Context, backend.ProvisionRequest) error {
+	return nil
+}
+
+func (a snapshotIntegrationAdapter) RunInSandbox(ctx context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+	return a.RunStream(ctx, req, stream)
+}
+
+func (snapshotIntegrationAdapter) CreateSnapshot(_ context.Context, req backend.SnapshotRequest) (*backend.SnapshotResult, error) {
+	return &backend.SnapshotResult{StorageRef: "/snapshots/" + req.SnapshotID + ".ext4"}, nil
+}
+
+func (snapshotIntegrationAdapter) ProvisionSandboxFromSnapshot(context.Context, backend.ProvisionFromSnapshotRequest) error {
+	return nil
+}
+
+func (snapshotIntegrationAdapter) RestoreSandbox(context.Context, backend.RestoreRequest) error {
+	return nil
+}
+
+func (snapshotIntegrationAdapter) DeleteSnapshot(context.Context, backend.DeleteSnapshotRequest) error {
+	return nil
+}
+
+func (snapshotIntegrationAdapter) TerminateSandbox(context.Context, string) error {
+	return nil
+}
+
 func startIntegrationServer(t *testing.T) string {
 	t.Helper()
 
+	return startSnapshotTestServer(t, integrationAdapter{})
+}
+
+func startSnapshotTestServer(t *testing.T, adapter backend.Adapter) string {
+	t.Helper()
+
+	store, err := snapshotstore.New(snapshotstore.Options{
+		MetadataDBPath: t.TempDir() + "/snapshots.db",
+	})
+	if err != nil {
+		t.Fatalf("create snapshot store: %v", err)
+	}
+
 	svc := &controlservice.Service{
-		Config: runtimeconfig.Config{DefaultBackend: "firecracker"},
+		Config:        runtimeconfig.Config{DefaultBackend: "firecracker"},
+		SnapshotStore: store,
 		Backends: map[string]backend.Adapter{
-			"firecracker": integrationAdapter{},
+			"firecracker": adapter,
 		},
 	}
 
@@ -166,6 +214,87 @@ func TestClientLifecycle(t *testing.T) {
 	}
 	if !terminateResp.GetTerminated() {
 		t.Fatal("expected terminated=true")
+	}
+}
+
+func TestClientSnapshotLifecycle(t *testing.T) {
+	host := startSnapshotTestServer(t, snapshotIntegrationAdapter{})
+
+	client, err := New(host)
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	createSandboxResp, err := client.CreateSandbox(ctx, &CreateSandboxRequest{
+		Policy:  testPolicy(),
+		Backend: "firecracker",
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createSandboxResp.GetSandbox().GetSandboxId()
+	if sandboxID == "" {
+		t.Fatal("expected sandbox_id")
+	}
+
+	createSnapshotResp, err := client.CreateSnapshot(ctx, &CreateSnapshotRequest{
+		SandboxId: sandboxID,
+		Name:      "golden",
+	})
+	if err != nil {
+		t.Fatalf("CreateSnapshot returned error: %v", err)
+	}
+	snapshotID := createSnapshotResp.GetSnapshot().GetSnapshotId()
+	if snapshotID == "" {
+		t.Fatal("expected snapshot_id")
+	}
+
+	getSnapshotResp, err := client.GetSnapshot(ctx, &GetSnapshotRequest{SnapshotId: snapshotID})
+	if err != nil {
+		t.Fatalf("GetSnapshot returned error: %v", err)
+	}
+	if got, want := getSnapshotResp.GetSnapshot().GetName(), "golden"; got != want {
+		t.Fatalf("unexpected snapshot name: got %q want %q", got, want)
+	}
+
+	listSnapshotsResp, err := client.ListSnapshots(ctx, &ListSnapshotsRequest{})
+	if err != nil {
+		t.Fatalf("ListSnapshots returned error: %v", err)
+	}
+	if got, want := len(listSnapshotsResp.GetSnapshots()), 1; got != want {
+		t.Fatalf("unexpected snapshot count: got %d want %d", got, want)
+	}
+
+	forkResp, err := client.CreateSandbox(ctx, &CreateSandboxRequest{
+		Source: &cleanroomv1.CreateSandboxRequest_SnapshotId{SnapshotId: snapshotID},
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox from snapshot returned error: %v", err)
+	}
+	if got := forkResp.GetSandbox().GetSandboxId(); got == "" {
+		t.Fatal("expected forked sandbox_id")
+	}
+
+	restoreResp, err := client.RestoreSandbox(ctx, &RestoreSandboxRequest{
+		SandboxId:  sandboxID,
+		SnapshotId: snapshotID,
+	})
+	if err != nil {
+		t.Fatalf("RestoreSandbox returned error: %v", err)
+	}
+	if got := restoreResp.GetSandbox().GetStatus(); got != SandboxStatus_SANDBOX_STATUS_READY {
+		t.Fatalf("unexpected restored sandbox status: %v", got)
+	}
+
+	deleteSnapshotResp, err := client.DeleteSnapshot(ctx, &DeleteSnapshotRequest{SnapshotId: snapshotID})
+	if err != nil {
+		t.Fatalf("DeleteSnapshot returned error: %v", err)
+	}
+	if !deleteSnapshotResp.GetDeleted() {
+		t.Fatal("expected deleted=true")
 	}
 }
 

--- a/client/types.go
+++ b/client/types.go
@@ -17,6 +17,7 @@ const (
 
 type PolicyAllowRule = cleanroomv1.PolicyAllowRule
 type Policy = cleanroomv1.Policy
+type Snapshot = cleanroomv1.Snapshot
 type SandboxOptions = cleanroomv1.SandboxOptions
 type CreateSandboxRequest = cleanroomv1.CreateSandboxRequest
 type CreateSandboxResponse = cleanroomv1.CreateSandboxResponse
@@ -26,10 +27,20 @@ type ListSandboxesRequest = cleanroomv1.ListSandboxesRequest
 type ListSandboxesResponse = cleanroomv1.ListSandboxesResponse
 type DownloadSandboxFileRequest = cleanroomv1.DownloadSandboxFileRequest
 type DownloadSandboxFileResponse = cleanroomv1.DownloadSandboxFileResponse
+type RestoreSandboxRequest = cleanroomv1.RestoreSandboxRequest
+type RestoreSandboxResponse = cleanroomv1.RestoreSandboxResponse
 type TerminateSandboxRequest = cleanroomv1.TerminateSandboxRequest
 type TerminateSandboxResponse = cleanroomv1.TerminateSandboxResponse
 type StreamSandboxEventsRequest = cleanroomv1.StreamSandboxEventsRequest
 type SandboxEvent = cleanroomv1.SandboxEvent
+type CreateSnapshotRequest = cleanroomv1.CreateSnapshotRequest
+type CreateSnapshotResponse = cleanroomv1.CreateSnapshotResponse
+type GetSnapshotRequest = cleanroomv1.GetSnapshotRequest
+type GetSnapshotResponse = cleanroomv1.GetSnapshotResponse
+type ListSnapshotsRequest = cleanroomv1.ListSnapshotsRequest
+type ListSnapshotsResponse = cleanroomv1.ListSnapshotsResponse
+type DeleteSnapshotRequest = cleanroomv1.DeleteSnapshotRequest
+type DeleteSnapshotResponse = cleanroomv1.DeleteSnapshotResponse
 
 type Execution = cleanroomv1.Execution
 

--- a/cmd/cleanroom-guest-agent/main.go
+++ b/cmd/cleanroom-guest-agent/main.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"encoding/json"
 	"errors"
@@ -14,8 +15,10 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+	"time"
 	"unsafe"
 
+	"github.com/buildkite/cleanroom/internal/vsockcontrol"
 	"github.com/buildkite/cleanroom/internal/vsockexec"
 	"github.com/creack/pty"
 	"github.com/mdlayher/vsock"
@@ -23,6 +26,11 @@ import (
 )
 
 func main() {
+	if len(os.Args) >= 3 && os.Args[1] == "checkpoint" && os.Args[2] == "request" {
+		checkpointRequest()
+		return
+	}
+
 	if strings.EqualFold(strings.TrimSpace(os.Getenv("CLEANROOM_GUEST_TRANSPORT")), "stdio") {
 		handleConn(stdioConn{})
 		return
@@ -61,8 +69,30 @@ func handleConn(conn io.ReadWriteCloser) {
 	// lost when reading subsequent input frames.
 	dec := json.NewDecoder(conn)
 
+	// Peek at the first JSON object to determine message type.
+	var raw map[string]json.RawMessage
+	if err := dec.Decode(&raw); err != nil {
+		_ = vsockexec.EncodeResponse(conn, vsockexec.ExecResponse{ExitCode: 1, Error: err.Error()})
+		return
+	}
+
+	// Check for quiesce message type.
+	if typeRaw, ok := raw["type"]; ok {
+		var msgType string
+		if err := json.Unmarshal(typeRaw, &msgType); err == nil && msgType == "quiesce" {
+			handleQuiesce(conn, raw)
+			return
+		}
+	}
+
+	// Re-decode as exec request from the raw map.
+	rawBytes, err := json.Marshal(raw)
+	if err != nil {
+		_ = vsockexec.EncodeResponse(conn, vsockexec.ExecResponse{ExitCode: 1, Error: err.Error()})
+		return
+	}
 	var req vsockexec.ExecRequest
-	if err := dec.Decode(&req); err != nil {
+	if err := json.Unmarshal(rawBytes, &req); err != nil {
 		_ = vsockexec.EncodeResponse(conn, vsockexec.ExecResponse{ExitCode: 1, Error: err.Error()})
 		return
 	}
@@ -362,4 +392,85 @@ func injectEntropy(seed []byte) error {
 		return errno
 	}
 	return nil
+}
+
+func handleQuiesce(conn io.ReadWriteCloser, raw map[string]json.RawMessage) {
+	respond := func(ok bool, errMsg string) {
+		_ = vsockcontrol.EncodeQuiesceResponse(conn, vsockcontrol.QuiesceResponse{OK: ok, Error: errMsg})
+	}
+
+	// Parse optional timeout.
+	var timeoutSec int64 = 10
+	if ts, ok := raw["timeout_seconds"]; ok {
+		_ = json.Unmarshal(ts, &timeoutSec)
+	}
+	if timeoutSec <= 0 {
+		timeoutSec = 10
+	}
+	timeout := time.Duration(timeoutSec) * time.Second
+
+	// First sync.
+	if err := exec.Command("sync").Run(); err != nil {
+		respond(false, fmt.Sprintf("sync: %v", err))
+		return
+	}
+
+	// Run quiesce hook if it exists.
+	const hookPath = "/usr/local/bin/cleanroom-quiesce-hook"
+	if _, err := os.Stat(hookPath); err == nil {
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+		if err := exec.CommandContext(ctx, hookPath).Run(); err != nil {
+			respond(false, fmt.Sprintf("quiesce hook: %v", err))
+			return
+		}
+	}
+
+	// Second sync.
+	if err := exec.Command("sync").Run(); err != nil {
+		respond(false, fmt.Sprintf("sync: %v", err))
+		return
+	}
+
+	respond(true, "")
+}
+
+func checkpointRequest() {
+	var name string
+	args := os.Args[3:]
+	for i := 0; i < len(args); i++ {
+		if args[i] == "--name" && i+1 < len(args) {
+			name = args[i+1]
+			i++
+		}
+	}
+
+	conn, err := vsock.Dial(2, vsockcontrol.DefaultHostControlPort, nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "dial host control port: %v\n", err)
+		os.Exit(1)
+	}
+	defer conn.Close()
+
+	if err := vsockcontrol.EncodeCheckpointRequest(conn, vsockcontrol.CheckpointRequest{Name: name}); err != nil {
+		fmt.Fprintf(os.Stderr, "send checkpoint request: %v\n", err)
+		os.Exit(1)
+	}
+
+	resp, err := vsockcontrol.DecodeCheckpointResponse(conn)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "read checkpoint response: %v\n", err)
+		os.Exit(1)
+	}
+
+	if resp.Error != "" {
+		fmt.Fprintf(os.Stderr, "checkpoint error: %s\n", resp.Error)
+		os.Exit(1)
+	}
+
+	if resp.Accepted {
+		fmt.Println("checkpoint accepted")
+	} else {
+		fmt.Println("checkpoint pending")
+	}
 }

--- a/docs/backend/firecracker.md
+++ b/docs/backend/firecracker.md
@@ -47,3 +47,4 @@ Current capability values (visible in `cleanroom doctor --json`):
 - [darwin-vz.md](darwin-vz.md) -- macOS backend
 - [isolation.md](../isolation.md) -- enforcement and persistence details
 - [research.md](../research.md) -- backend evaluation and comparison
+- [../plans/snapshot-restore-fork.md](../plans/snapshot-restore-fork.md) -- proposed snapshot, restore, and fork design

--- a/docs/backend/firecracker.md
+++ b/docs/backend/firecracker.md
@@ -31,6 +31,9 @@ Current capability values (visible in `cleanroom doctor --json`):
 - `exec.streaming=true`
 - `sandbox.persistent=true`
 - `sandbox.file_download=true`
+- `sandbox.snapshot=true` (when snapshots are configured)
+- `sandbox.restore=true` (when snapshots are configured)
+- `sandbox.fork=true` (when snapshots are configured)
 - `network.default_deny=true`
 - `network.allowlist_egress=true`
 - `network.guest_interface=true`
@@ -47,4 +50,5 @@ Current capability values (visible in `cleanroom doctor --json`):
 - [darwin-vz.md](darwin-vz.md) -- macOS backend
 - [isolation.md](../isolation.md) -- enforcement and persistence details
 - [research.md](../research.md) -- backend evaluation and comparison
-- [../plans/snapshot-restore-fork.md](../plans/snapshot-restore-fork.md) -- proposed snapshot, restore, and fork design
+- [snapshots.md](../snapshots.md) -- snapshot, restore, and fork usage guide
+- [../plans/snapshot-restore-fork.md](../plans/snapshot-restore-fork.md) -- full snapshot design document

--- a/docs/plans/snapshot-restore-fork.md
+++ b/docs/plans/snapshot-restore-fork.md
@@ -795,77 +795,94 @@ Why this is phase 2:
 If we add this later, the user-visible API does not change. It only makes
 `fork` and `restore` faster on compatible hosts.
 
-## Implementation Slices
+## Implementation Status
 
-### Slice 1: API and metadata
+This section tracks what is already implemented and what remains. The current
+branch lands the first functional slice with a file-backed Firecracker
+implementation and a persisted snapshot metadata store. The later storage-driver
+and fleet-distribution work is still pending.
 
-- add `SnapshotService`
-- add `CreateSandbox --from-snapshot`
-- add `RestoreSandbox`
-- add checkpoint request state to the control plane
-- add durable snapshot metadata store
-- add CLI commands
+### Implemented in this branch
 
-Definition of done:
+- [done] `SnapshotService` with create, get, list, and delete
+- [done] `CreateSandbox` from `snapshot_id`
+- [done] `RestoreSandbox`
+- [done] backend-neutral capability flags:
+  - `sandbox.snapshot`
+  - `sandbox.restore`
+  - `sandbox.fork`
+- [done] persisted snapshot metadata store in SQLite
+- [done] CLI commands:
+  - `cleanroom snapshot create|get|list|delete`
+  - `cleanroom sandbox create --from-snapshot`
+  - `cleanroom sandbox restore --snapshot`
+- [done] Firecracker adapter support for snapshot, fork, and restore
+- [done] control-plane concurrency checks:
+  - no snapshot or restore during active exec
+  - no snapshot or restore during file download
+  - create-from-snapshot derives backend and policy from snapshot metadata
+- [done] tests covering:
+  - snapshot metadata store
+  - control service snapshot lifecycle
+  - Firecracker snapshot/fork/restore adapter flow
 
-- snapshots can be created, listed, and deleted at the control-plane level
-- sandboxes can be created from snapshot metadata, even if only a stub backend
-  exists initially
+### Remaining implementation list
 
-### Slice 2: volume store abstraction
+#### 1. Replace file-backed Firecracker storage with a volume-store abstraction
 
-- add `internal/volumestore`
-- define driver interface
-- add `zfs` driver
-- add runtime config loading and doctor checks for ZFS availability
-
-Definition of done:
-
-- the volume store can seed base volumes, create writable clones, snapshot
-  volumes, and destroy them
-
-### Slice 3: Firecracker from volume
-
-- replace direct persistent rootfs copy with volume-backed rootfs when enabled
-- keep current copy/reflink behavior as fallback
-
-Definition of done:
-
-- a normal persistent Firecracker sandbox boots from a cloned ZFS volume
-
-### Slice 4: snapshot, fork, restore
-
-- add guest-agent cooperative quiesce plus pause/resume flow
-- add guest checkpoint request plumbing
-- add snapshot create in the adapter
-- add provision-from-snapshot and restore in the adapter
-- gate concurrent operations correctly in control service
-
-Definition of done:
-
-- one sandbox can create a snapshot
-- a guest workload can request a checkpoint and have it materialized once the
-  sandbox is safe
-- a second sandbox can fork from it
-- the original sandbox can restore back to it
-
-### Slice 5: retention and ergonomics
-
-- snapshot delete safety checks
-- labels or names
-- human-friendly CLI output
-- CI examples and docs
+- [todo] add `internal/volumestore`
+- [todo] define driver interface for:
+  - seed base volume
+  - clone writable volume
+  - snapshot volume
+  - destroy volume
+  - destroy snapshot
+- [todo] add `zfs` driver
+- [todo] add runtime config loading for Firecracker snapshot storage
+- [todo] add doctor checks for `zfs` availability and configuration
 
 Definition of done:
 
-- operators can manage snapshot lifecycle without orphaning hidden volumes
+- Firecracker persistent sandboxes can boot from a managed volume instead of a
+  copied rootfs image
+- snapshot, restore, and fork use the volume driver instead of direct file
+  cloning
 
-### Slice 6: darwin-vz disk-state support
+#### 2. Tighten Firecracker snapshot semantics
 
-- add persistent `darwin-vz` sandboxes
-- add `apfs` volume-store driver
-- add `darwin-vz` snapshot, restore, and fork using cloned ext4 image files
-- keep API and capability semantics identical to Firecracker
+- [todo] replace host process `SIGSTOP`/`SIGCONT` with an explicit pause/resume
+  or equivalent quiesce strategy if needed
+- [todo] add guest-agent cooperative quiesce hook before snapshot
+- [todo] add guest checkpoint request plumbing
+- [todo] define behavior for pending checkpoint requests and safe-point
+  materialization
+
+Definition of done:
+
+- snapshot creation is explicitly guest-cooperative and host-authoritative
+- checkpoint requests can be issued from inside the guest and materialized once
+  the sandbox is safe
+
+#### 3. Retention and ergonomics
+
+- [todo] snapshot delete safety checks
+- [done] advisory snapshot names
+- [done] human-friendly CLI output
+- [todo] CI examples and operational docs
+- [todo] decide whether to surface snapshot lineage in CLI/API
+
+Definition of done:
+
+- operators can manage snapshot lifecycle without orphaning hidden storage
+- the docs show the intended CI bootstrap and fan-out flow
+
+#### 4. Add `darwin-vz` disk-state support
+
+- [todo] add persistent `darwin-vz` sandboxes
+- [todo] add `apfs` volume-store driver
+- [todo] add `darwin-vz` snapshot, restore, and fork using cloned ext4 image
+  files
+- [todo] keep API and capability semantics identical to Firecracker
 
 Definition of done:
 
@@ -874,33 +891,33 @@ Definition of done:
 - the same CLI and API calls work on both backends, with backend-specific
   runtime config
 
-### Slice 7: optional boot accelerator
+#### 5. Optional boot accelerator
 
-- investigate a mount-namespace or jailer-based path virtualization layer
-- capture boot-ready Firecracker snapshots
-- resume forks from a boot checkpoint when compatible
+- [todo] investigate a mount-namespace or jailer-based path virtualization layer
+- [todo] capture boot-ready Firecracker snapshots
+- [todo] resume forks from a boot checkpoint when compatible
 
 Definition of done:
 
 - fork latency is reduced further without changing semantics
 
-### Slice 8: portable snapshot distribution
+#### 6. Portable snapshot distribution
 
-- define OCI artifact layout for exported snapshots
-- add export and import commands
-- attach optional hotset or prefetch metadata
-- test registry storage and digest-addressed retrieval
+- [todo] define OCI artifact layout for exported snapshots
+- [todo] add export and import commands
+- [todo] attach optional hotset or prefetch metadata
+- [todo] test registry storage and digest-addressed retrieval
 
 Definition of done:
 
 - snapshots can move between hosts through a standard OCI registry without
   changing local execution semantics
 
-### Slice 9: fleet-scale fan-out
+#### 7. Fleet-scale fan-out
 
-- evaluate chunked payload formats for exported snapshots
-- integrate peer-to-peer or mirror-assisted distribution
-- add preheat support for popular snapshots
+- [todo] evaluate chunked payload formats for exported snapshots
+- [todo] integrate peer-to-peer or mirror-assisted distribution
+- [todo] add preheat support for popular snapshots
 
 Definition of done:
 

--- a/docs/plans/snapshot-restore-fork.md
+++ b/docs/plans/snapshot-restore-fork.md
@@ -837,10 +837,10 @@ and fleet-distribution work is still pending.
   - snapshot volume
   - destroy volume
   - destroy snapshot
-- [todo] add `zfs` driver
+- [done] add `zfs` driver
 - [done] wire Firecracker through the volume driver with a file-backed fallback
 - [done] add runtime config loading for Firecracker snapshot storage
-- [todo] add doctor checks for `zfs` availability and configuration
+- [done] add doctor checks for `zfs` availability and configuration
 
 Definition of done:
 

--- a/docs/plans/snapshot-restore-fork.md
+++ b/docs/plans/snapshot-restore-fork.md
@@ -851,11 +851,11 @@ Definition of done:
 
 #### 2. Tighten Firecracker snapshot semantics
 
-- [todo] replace host process `SIGSTOP`/`SIGCONT` with an explicit pause/resume
+- [done] replace host process `SIGSTOP`/`SIGCONT` with an explicit pause/resume
   or equivalent quiesce strategy if needed
-- [todo] add guest-agent cooperative quiesce hook before snapshot
-- [todo] add guest checkpoint request plumbing
-- [todo] define behavior for pending checkpoint requests and safe-point
+- [done] add guest-agent cooperative quiesce hook before snapshot
+- [done] add guest checkpoint request plumbing
+- [done] define behavior for pending checkpoint requests and safe-point
   materialization
 
 Definition of done:

--- a/docs/plans/snapshot-restore-fork.md
+++ b/docs/plans/snapshot-restore-fork.md
@@ -1,0 +1,948 @@
+# Snapshot, Restore, and Fork Plan
+
+**Status:** Proposed
+**Scope:** Firecracker first, `darwin-vz` later
+
+## Summary
+
+Add three new environment primitives:
+
+- `snapshot`: capture an immutable cleanroom filesystem state.
+- `restore`: reset an existing sandbox back to a snapshot.
+- `fork`: create a new sandbox from a snapshot.
+
+The user-visible contract is intentionally filesystem-centric, not live-VM-centric.
+Every `restore` and `fork` results in a fresh VM boot from the captured state.
+That keeps the primitive deterministic, safe to compose, and compatible with
+Cleanroom's existing network identity and guest-agent model.
+
+On Firecracker, the implementation uses a new copy-on-write volume store with a
+`zfs` driver first. A snapshot is a host-side COW snapshot of the sandbox root
+volume. A fork is a COW clone of that snapshot. Restore replaces the sandbox's
+mutable volume with a fresh clone of the snapshot and boots again.
+
+This gives us a strong base for CI:
+
+1. start from a deterministic image-backed cleanroom,
+2. run bootstrap work once (`git clone`, dependency install, generated fixtures),
+3. snapshot the result,
+4. fork many isolated sandboxes from that golden state.
+
+## Why Fresh-Boot Snapshots
+
+The tempting alternative is to expose Firecracker's full VM snapshot/restore as
+the primary primitive. We should not do that.
+
+Reasons:
+
+- Cleanroom cares about reusable environment state, not duplicated process state.
+- Fresh boot gives every fork a new sandbox ID, guest IP, gateway registration,
+  and vsock endpoint.
+- We avoid cloning open TCP connections, old vsock sessions, wall-clock drift,
+  and any in-memory uniqueness bugs from resumed workloads.
+- Firecracker snapshot load requires the original disk/vsock resources to appear
+  at the same paths, which complicates concurrent forks materially.
+- Firecracker's own snapshot docs call out clone networking, vsock reset, and
+  uniqueness concerns; those are acceptable as an optimization layer, but they
+  are the wrong default semantics for CI primitives.
+
+The result is a simpler contract:
+
+- snapshot captures disk state only,
+- restore/fork always boot a new VM from that disk state,
+- any later Firecracker resume fast-path is an internal optimization, not a
+  change in user-facing semantics.
+
+## Goals
+
+- Capture a golden cleanroom state after deterministic setup work.
+- Make `fork` and `restore` near-constant-time at the storage layer.
+- Keep the CLI, API, and core capability surface backend-neutral even if only
+  Firecracker implements it first.
+- Preserve existing policy immutability and gateway security invariants.
+- Allow snapshot lineage: a forked sandbox can create later snapshots.
+- Keep snapshots durable across daemon restarts.
+- Allow the guest workload to mark checkpoint-safe moments cooperatively.
+
+## Non-Goals
+
+- `darwin-vz` support in the first implementation.
+- Exposing live process or in-memory checkpoint semantics to users.
+- Cross-backend snapshot portability.
+- Restoring a snapshot under a different compiled policy hash.
+- Using Firecracker diff snapshots as a required mechanism.
+
+## Primitive Model
+
+### Snapshot
+
+An immutable environment artifact derived from a `READY` sandbox.
+
+Snapshot metadata:
+
+- `snapshot_id`
+- `backend`
+- `policy_hash`
+- `image_ref`
+- `image_digest`
+- `parent_snapshot_id` (optional)
+- `source_sandbox_id`
+- `created_at`
+- `labels` or `name` (optional)
+- storage reference (`volume_snapshot_ref`)
+
+Semantics:
+
+- Captures the writable root volume only.
+- Does not capture running processes, sockets, network identity, or active execs.
+- Can be used as the parent for many forks.
+- Can be the parent of later snapshots, creating a lineage graph.
+
+### Fork
+
+Provision a new sandbox from a snapshot.
+
+Semantics:
+
+- New sandbox ID.
+- New guest IP / TAP / gateway registration.
+- New writable child volume cloned from the snapshot.
+- Fresh VM boot.
+- Same compiled policy and backend lineage as the snapshot.
+
+### Restore
+
+Reset an existing sandbox to a snapshot.
+
+Semantics:
+
+- Same sandbox ID.
+- Existing mutable volume is discarded.
+- A fresh writable clone of the snapshot replaces it.
+- Existing VM is terminated and a fresh VM boots.
+- Sandbox returns to `READY` with the same control-plane identity, but no
+  process state survives the restore.
+
+## API Surface
+
+Keep the control plane backend-neutral. Backend-specific storage details live in
+runtime config and the Firecracker adapter.
+
+### New service
+
+Add `SnapshotService`:
+
+```proto
+service SnapshotService {
+  rpc CreateSnapshot(CreateSnapshotRequest) returns (CreateSnapshotResponse);
+  rpc GetSnapshot(GetSnapshotRequest) returns (GetSnapshotResponse);
+  rpc ListSnapshots(ListSnapshotsRequest) returns (ListSnapshotsResponse);
+  rpc DeleteSnapshot(DeleteSnapshotRequest) returns (DeleteSnapshotResponse);
+}
+```
+
+### Sandbox creation from snapshot
+
+Extend `CreateSandboxRequest` to allow a snapshot source:
+
+```proto
+message CreateSandboxRequest {
+  string backend = 2;
+  SandboxOptions options = 3;
+  Policy policy = 4;
+
+  oneof source {
+    string snapshot_id = 5;
+  }
+}
+```
+
+Rules:
+
+- when `snapshot_id` is set, `policy` must be omitted
+- backend and policy are derived from the snapshot metadata
+- any mismatch fails closed
+
+### Restore
+
+Add a sandbox lifecycle RPC:
+
+```proto
+rpc RestoreSandbox(RestoreSandboxRequest) returns (RestoreSandboxResponse);
+```
+
+```proto
+message RestoreSandboxRequest {
+  string sandbox_id = 1;
+  string snapshot_id = 2;
+}
+```
+
+### CLI shape
+
+Proposed commands:
+
+- `cleanroom snapshots create <sandbox-id> [--name <name>]`
+- `cleanroom snapshots get <snapshot-id>`
+- `cleanroom snapshots list`
+- `cleanroom snapshots delete <snapshot-id>`
+- `cleanroom sandboxes create --from-snapshot <snapshot-id>`
+- `cleanroom sandboxes restore <sandbox-id> --snapshot <snapshot-id>`
+
+Useful sugar later:
+
+- `cleanroom exec --from-snapshot <snapshot-id> --rm -- <command>`
+
+### Guest-cooperative checkpoint trigger
+
+For CI and bootstrap flows, the guest should be able to request a snapshot at a
+known-safe point.
+
+Current guest runtime fact:
+
+- Cleanroom already injects `cleanroom-guest-agent` into guest images.
+- Cleanroom does not currently inject a user-facing `cleanroom` CLI inside the
+  guest.
+
+Recommendation:
+
+- extend `cleanroom-guest-agent` with a user-invokable subcommand such as
+  `cleanroom-guest-agent checkpoint request --name <name>`
+- do not add a second guest control binary in v1
+
+Semantics:
+
+- the guest can request a checkpoint
+- the host remains authoritative for whether and when the snapshot is taken
+- the request is advisory until the sandbox reaches a safe point
+
+Safe-point rules:
+
+- if there is an active execution, the request becomes `pending`
+- the host should normally honor the request only after the triggering
+  execution exits cleanly and the sandbox is idle
+- mid-execution freeze is not the default behavior
+
+Why:
+
+- CI bootstrap steps often know the exact moment when the environment becomes a
+  useful golden state
+- the host must still preserve the trust boundary because workload code inside
+  the sandbox is untrusted
+
+### Checkpoint request protocol
+
+Recommended flow:
+
+1. workload inside the guest invokes `cleanroom-guest-agent checkpoint request`
+2. guest agent sends a checkpoint request to the host control plane
+3. control plane records the request against the sandbox, with optional
+   metadata such as name, labels, and requested mode
+4. once the sandbox is idle, the control plane asks the guest agent to run a
+   quiesce hook
+5. after successful quiesce, the host pauses the VM and creates the snapshot
+6. control plane records the resulting snapshot metadata and clears the pending
+   request
+
+Quiesce hook responsibilities:
+
+- run `sync`
+- optionally stop or flush known daemons
+- optionally emit metadata describing the checkpoint
+
+The quiesce step is guest-cooperative; the snapshot itself is host-executed.
+
+### Guest-to-host transport
+
+Recommendation for v1:
+
+- use a small control endpoint on the existing host-side control/gateway path
+  reachable from the guest network
+- do not require a new host-side vsock listener just for checkpoint requests
+
+Rationale:
+
+- Cleanroom already uses guest networking plus host mediation for other control
+  surfaces
+- host-side vsock listening is operationally more awkward than reusing the
+  existing mediated path
+- the actual snapshot operation still happens entirely on the host
+
+### Optional API addition
+
+We can expose checkpoint requests explicitly in the control plane, separate from
+immediate snapshot creation:
+
+```proto
+rpc RequestCheckpoint(RequestCheckpointRequest) returns (RequestCheckpointResponse);
+```
+
+```proto
+message RequestCheckpointRequest {
+  string sandbox_id = 1;
+  string name = 2;
+  map<string, string> labels = 3;
+}
+```
+
+This is not strictly required if the first implementation maps the guest-agent
+request directly into `CreateSnapshot`, but it is a better fit for the desired
+"snapshot when safe" behavior.
+
+## Backend Interfaces
+
+Add a new optional backend capability layer on top of persistent sandboxes.
+The API surface should not branch on backend name. The control plane should
+gate behavior on capability flags and backend adapter support.
+
+```go
+type SnapshottingAdapter interface {
+	backend.PersistentSandboxAdapter
+	CreateSnapshot(context.Context, SnapshotRequest) (*SnapshotResult, error)
+	ProvisionSandboxFromSnapshot(context.Context, ProvisionFromSnapshotRequest) error
+	RestoreSandbox(context.Context, RestoreRequest) error
+	DeleteSnapshot(context.Context, string) error
+}
+```
+
+Proposed capability keys:
+
+- `sandbox.snapshot`
+- `sandbox.restore`
+- `sandbox.fork`
+
+Semantics of these capability keys:
+
+- `sandbox.snapshot=true` means the backend can capture an immutable filesystem
+  checkpoint of a sandbox
+- `sandbox.restore=true` means the backend can reset a sandbox to a snapshot
+- `sandbox.fork=true` means the backend can create a new sandbox from a
+  snapshot
+
+These keys describe the user-facing contract, not the implementation mechanism.
+Backends may implement them with different storage drivers and different
+accelerators, but the API semantics stay the same.
+
+Initial capability rollout:
+
+- Firecracker reports all three as `true` when snapshot support is configured
+- `darwin-vz` reports all three as `false` until its later-stage implementation
+  lands
+
+Optional later accelerator capabilities can be added separately if needed, but
+they should not be required for the core snapshot, restore, and fork contract.
+
+## Firecracker Data Plane
+
+### New volume store
+
+Introduce a new internal volume subsystem:
+
+- package: `internal/volumestore`
+- driver interface: backend-agnostic
+- first implementation: `zfs`
+- later implementation: `apfs`
+
+Responsibilities:
+
+- seed immutable base volumes from prepared runtime rootfs images
+- create writable sandbox volumes
+- snapshot writable volumes
+- clone snapshots into new writable volumes
+- destroy volumes and snapshots
+- expose a stable Firecracker drive path
+
+The driver abstraction should be defined around operations, not filesystem
+brands:
+
+- seed base
+- create writable working volume
+- snapshot working volume
+- clone snapshot into writable working volume
+- destroy working volume
+- destroy snapshot
+- return the runtime attachment path for the backend
+
+### ZFS layout
+
+Assume a configured dataset root such as `tank/cleanroom`.
+
+Suggested hierarchy:
+
+- `tank/cleanroom/base/<runtime-key>`
+- `tank/cleanroom/sandboxes/<sandbox-id>`
+- `tank/cleanroom/sandboxes/<sandbox-id>@snap-<snapshot-id>`
+
+Implementation choice:
+
+- use ZFS volumes (`zvols`) as the writable block devices for Firecracker
+- seed the base zvol once from the prepared ext4 runtime rootfs
+- clone from base or snapshot using native ZFS clone operations
+
+Why zvols:
+
+- Firecracker wants a block device or raw disk image semantics
+- snapshots and clones are native and cheap
+- we avoid repeated large file copies and host-fs reflink assumptions
+
+### Metadata store
+
+ZFS tracks the data plane; Cleanroom still needs control-plane metadata.
+
+Add a durable metadata store, preferably SQLite under XDG state:
+
+- `XDG_STATE_HOME/cleanroom/snapshots.db`
+
+Tables or equivalent records:
+
+- snapshots
+- sandbox volume leases
+- lineage or parent pointers
+- optional labels and garbage-collection state
+
+Why not only ZFS properties:
+
+- the control plane needs fast lookup by snapshot ID
+- we need policy hash and image metadata checks
+- we need snapshot listing without shelling out and parsing ZFS output on every
+  control-plane request
+
+## Darwin VZ Later-Stage Support
+
+`darwin-vz` should adopt the same API and capability semantics later, but with a
+different storage driver and an initial focus on disk-state snapshots.
+
+### Core model
+
+For `darwin-vz`, the portable semantic remains the same:
+
+- snapshots capture filesystem state, not live process state
+- restore and fork boot a fresh VM from the captured state
+- backend-specific acceleration remains an internal detail
+
+This keeps the control plane portable even though the runtime mechanism differs
+from Firecracker.
+
+### Storage driver
+
+Recommended later driver:
+
+- `apfs`
+
+Recommended mechanism:
+
+- keep using ext4 guest rootfs images as the guest-visible block format
+- store those ext4 image files on APFS
+- use APFS copy-on-write cloning for working images and snapshot images
+
+Practical shape:
+
+- prepared runtime rootfs image remains the seeded base artifact
+- sandbox working disk is an APFS clone of that base ext4 image
+- snapshot is an immutable APFS-cloned copy of the working ext4 image taken at
+  a quiesced point
+- fork or restore clones the snapshot image into a new writable working image
+
+This is less sophisticated than ZFS snapshots, but it is enough to preserve the
+same control-plane semantics.
+
+### Darwin-specific lifecycle
+
+Later `darwin-vz` snapshot flow:
+
+1. ensure the sandbox is idle
+2. ask the guest agent to quiesce
+3. stop the current VM or otherwise ensure the disk image is at a safe point
+4. create an APFS clone of the working ext4 image as the snapshot artifact
+5. restart or continue according to the chosen implementation path
+
+Later `darwin-vz` fork flow:
+
+1. APFS-clone the snapshot ext4 image into a new writable working image
+2. start a fresh `darwin-vz` VM from that image
+
+Later `darwin-vz` restore flow:
+
+1. stop the current VM
+2. replace the sandbox working image with an APFS clone of the target snapshot
+3. start a fresh VM for the sandbox
+
+### Darwin-specific limits
+
+Expected constraints:
+
+- disk-state snapshots should be the first supported mode
+- persistent sandboxes need to exist before snapshot support is useful
+- host-side egress allowlist enforcement still remains a separate gap to close
+- warm machine-state save and restore should be treated as a same-host
+  accelerator, not the baseline primitive
+
+### Warm checkpoint accelerator on macOS
+
+Once disk-state support exists, `darwin-vz` can optionally add a same-host
+warm-checkpoint accelerator using `Virtualization.framework` machine save and
+restore.
+
+This should remain a later optimization because:
+
+- it is same-host scoped in practice
+- compatibility is narrower than disk-state restore
+- it should not change the portable API or core capability semantics
+
+If exposed at all, it should be via optional accelerator capabilities rather
+than by changing the meaning of `sandbox.snapshot`, `sandbox.restore`, or
+`sandbox.fork`.
+
+## Firecracker Lifecycle Changes
+
+### Provision from image
+
+Current behavior:
+
+- prepare runtime rootfs image
+- `copyFile` into `rootfs-persistent.ext4`
+- launch Firecracker with that file
+
+New behavior when snapshots are enabled:
+
+1. ensure prepared runtime rootfs image as today
+2. ensure a seeded base volume for the runtime rootfs key
+3. clone base volume into `sandboxes/<sandbox-id>`
+4. launch Firecracker using the cloned volume
+
+The existing copy/reflink path can remain as the fallback when the snapshot
+store is disabled.
+
+### Create snapshot
+
+Allowed only when the sandbox is `READY` and idle.
+
+Flow:
+
+1. control plane marks the sandbox busy for snapshot creation
+2. if the snapshot was guest-requested, verify the request is still valid and
+   the sandbox is now idle
+3. control plane asks the guest agent to run the quiesce hook
+4. control plane pauses the VM
+5. volume store creates `@snap-<snapshot-id>` on the sandbox volume
+6. control plane resumes the VM
+7. metadata store records the snapshot
+
+Important invariant:
+
+- Cleanroom does not rely on Firecracker to manage disk snapshot files
+- the host snapshot is taken only after the guest has flushed writes and the VM
+  is paused
+
+### Fork from snapshot
+
+Flow:
+
+1. clone snapshot into `sandboxes/<new-sandbox-id>`
+2. allocate new guest CID, TAP, guest IP, and run dir
+3. boot a fresh Firecracker VM from the cloned volume
+4. register the new guest IP in the gateway
+5. mark the sandbox `READY`
+
+### Restore sandbox
+
+Flow:
+
+1. reject if the sandbox has an active execution or file download
+2. terminate the current VM
+3. destroy or detach the current writable volume
+4. clone the target snapshot back into `sandboxes/<sandbox-id>`
+5. boot a fresh VM for the same sandbox ID
+6. return sandbox to `READY`
+
+## Security and Correctness Invariants
+
+- Snapshot create, restore, and fork are fail-closed on policy hash mismatch.
+- Snapshots never contain control-plane secrets because secrets are not mounted
+  into the guest filesystem by design.
+- Restore and fork always produce fresh network identity.
+- Snapshot creation is serialized with execution and file download operations.
+- Snapshot deletion must fail while live sandboxes or child clones still depend
+  on it.
+- Snapshot lineage is explicit; hidden mutation of a snapshot is never allowed.
+
+## CI-Oriented Composition Model
+
+This primitive is useful because it composes.
+
+Example lineage:
+
+1. create sandbox from pinned image
+2. `git clone` repository into guest
+3. snapshot `src`
+4. run package-manager install from lockfiles
+5. snapshot `deps`
+6. fork `deps` into `itest-a`, `itest-b`, and `itest-c`
+7. run different integration test shards in parallel
+
+This also supports iterative local workflows:
+
+1. restore a sandbox to `deps`
+2. rerun a destructive test
+3. restore again instead of rebuilding the environment
+
+## Runtime Config
+
+Keep backend-neutral CLI and API, put Firecracker details in runtime config.
+
+Proposed shape:
+
+```yaml
+backends:
+  firecracker:
+    snapshots:
+      enabled: true
+      driver: zfs
+      zfs_dataset: tank/cleanroom
+      quiesce_timeout_seconds: 15
+  darwin-vz:
+    snapshots:
+      enabled: false
+      driver: apfs
+      base_dir: /var/tmp/cleanroom-snapshots
+      quiesce_timeout_seconds: 15
+```
+
+Notes:
+
+- snapshot support is off by default unless explicitly configured
+- the first implementation only accepts `driver: zfs`
+- future drivers can slot in later (`apfs`, `lvmthin`, `btrfs`, file-based COW)
+
+## Future Distribution and Fan-Out
+
+The execution format and the distribution format should be different concerns.
+
+Recommended split:
+
+- local execution format: host-native volume snapshots and clones (`zfs` in v1)
+- portable distribution format: OCI artifacts stored in a registry
+
+Why:
+
+- ZFS snapshots are the right local primitive for fast clone and restore
+- ZFS-native replication is not the right universal sharing format across large,
+  heterogeneous fleets
+- OCI registries already solve content addressability, authn/authz, replication,
+  dedupe, and lifecycle policies
+
+### Portable snapshot artifact
+
+Future direction:
+
+- export a cleanroom snapshot as an OCI artifact
+- keep snapshot metadata in the manifest/config
+- attach related artifacts using OCI `subject` and referrers
+
+Recommended high-level shape:
+
+- OCI manifest with custom `artifactType`
+- config blob containing snapshot metadata:
+  - schema version
+  - backend family
+  - `policy_hash`
+  - source image digest
+  - parent snapshot digest
+  - filesystem payload format
+  - compatibility requirements
+- one or more data blobs containing the exported filesystem payload
+- optional attached artifacts:
+  - hotset or prefetch profile
+  - provenance or SBOM
+  - optional Firecracker memory checkpoint for compatible worker pools
+
+### What to learn from the container ecosystem
+
+#### eStargz
+
+Useful ideas:
+
+- lazy pulling against standard OCI registries
+- workload-informed prefetching of likely startup files
+
+Implication for Cleanroom:
+
+- even if we do not use eStargz as the snapshot payload format, we should copy
+  the "profile real workload accesses, then prefetch the hotset" idea for
+  exported cleanroom snapshots
+
+#### SOCI
+
+Useful ideas:
+
+- store a separate index artifact rather than mutating the original image
+- preserve the original image digest and signature validity
+
+Implication for Cleanroom:
+
+- attach a snapshot index or hotset index as a separate OCI artifact where
+  possible, instead of forcing the core snapshot artifact to change shape for
+  every optimization
+
+#### Nydus
+
+Useful ideas:
+
+- content-addressable filesystem format built for lazy, chunk-based access
+- explicit prefetch-list support
+- support for accelerating OCI images without requiring a full conversion in all
+  cases
+
+Implication for Cleanroom:
+
+- if we need a portable snapshot payload for large-scale fan-out, a chunked,
+  Nydus-like filesystem format is a stronger fit than shipping raw ext4 images
+  or tar diffs
+- the long-term target should be on-demand fetch of snapshot chunks, not
+  mandatory whole-artifact pulls
+
+#### Dragonfly
+
+Useful ideas:
+
+- peer-to-peer distribution in front of an OCI registry
+- explicit preheat flows for popular artifacts
+- seed-peer or proxy modes to reduce back-to-source traffic
+
+Implication for Cleanroom:
+
+- for fan-out to thousands of hosts, registry origin should be treated as the
+  source of truth, but not as the only download path
+- preheating popular golden snapshots and letting peers share chunks is likely
+  far more important than shaving a few percent off local clone time
+
+### Recommended roadmap for cross-host sharing
+
+#### Phase A: export and import
+
+- add `cleanroom snapshots export` and `cleanroom snapshots import`
+- publish snapshots as OCI artifacts
+- support pull by digest from a standard registry
+
+Success criteria:
+
+- a snapshot created on one host can be imported on another compatible host
+
+#### Phase B: hotset metadata
+
+- record file-access hotsets from bootstrap and first-run workloads
+- publish hotset or prefetch metadata as an attached OCI artifact
+- teach importers to prefetch likely-needed content first
+
+Success criteria:
+
+- imported snapshots reach useful first-command latency without requiring a full
+  download of all content up front
+
+#### Phase C: chunked portable payload
+
+- evaluate a chunk-addressed filesystem payload for exported snapshots
+- prefer a format with lazy fetch support and strong dedupe properties
+- measure whether `nydus`-style distribution outperforms ext4 or tar-based
+  exports materially for Cleanroom workloads
+
+Success criteria:
+
+- exported snapshots can be mounted or materialized incrementally, not only as
+  fully downloaded monoliths
+
+#### Phase D: large-scale fan-out
+
+- integrate registry mirror or peer-to-peer distribution for exported snapshots
+- add snapshot preheat APIs for CI orchestration
+- prewarm the most common golden snapshots onto worker pools
+
+Success criteria:
+
+- a single snapshot publish can fan out efficiently across thousands of hosts
+  without overloading the registry origin
+
+#### Phase E: optional warm-boot accelerator
+
+- attach Firecracker memory checkpoints as related OCI artifacts
+- only enable on homogeneous worker pools with explicit compatibility checks
+- keep disk snapshot artifacts as the portable baseline
+
+Success criteria:
+
+- compatible worker pools can resume warm checkpoints faster without changing
+  the user-facing snapshot, restore, and fork semantics
+
+## Why Firecracker VM Snapshots Are Still Useful Later
+
+Firecracker's full snapshot support is still valuable, but as a phase-2
+accelerator rather than the primary primitive.
+
+Possible later optimization:
+
+- capture a boot-ready Firecracker memory snapshot after guest init and
+  guest-agent readiness
+- on `fork`, resume from that boot checkpoint instead of cold booting
+- still pair it with a cloned writable disk volume
+
+Why this is phase 2:
+
+- Firecracker snapshot load expects original disk and vsock paths
+- resumed clones need explicit networking reconfiguration
+- vsock connections are reset on restore
+- cloned in-memory user-space state can duplicate uniqueness assumptions
+
+If we add this later, the user-visible API does not change. It only makes
+`fork` and `restore` faster on compatible hosts.
+
+## Implementation Slices
+
+### Slice 1: API and metadata
+
+- add `SnapshotService`
+- add `CreateSandbox --from-snapshot`
+- add `RestoreSandbox`
+- add checkpoint request state to the control plane
+- add durable snapshot metadata store
+- add CLI commands
+
+Definition of done:
+
+- snapshots can be created, listed, and deleted at the control-plane level
+- sandboxes can be created from snapshot metadata, even if only a stub backend
+  exists initially
+
+### Slice 2: volume store abstraction
+
+- add `internal/volumestore`
+- define driver interface
+- add `zfs` driver
+- add runtime config loading and doctor checks for ZFS availability
+
+Definition of done:
+
+- the volume store can seed base volumes, create writable clones, snapshot
+  volumes, and destroy them
+
+### Slice 3: Firecracker from volume
+
+- replace direct persistent rootfs copy with volume-backed rootfs when enabled
+- keep current copy/reflink behavior as fallback
+
+Definition of done:
+
+- a normal persistent Firecracker sandbox boots from a cloned ZFS volume
+
+### Slice 4: snapshot, fork, restore
+
+- add guest-agent cooperative quiesce plus pause/resume flow
+- add guest checkpoint request plumbing
+- add snapshot create in the adapter
+- add provision-from-snapshot and restore in the adapter
+- gate concurrent operations correctly in control service
+
+Definition of done:
+
+- one sandbox can create a snapshot
+- a guest workload can request a checkpoint and have it materialized once the
+  sandbox is safe
+- a second sandbox can fork from it
+- the original sandbox can restore back to it
+
+### Slice 5: retention and ergonomics
+
+- snapshot delete safety checks
+- labels or names
+- human-friendly CLI output
+- CI examples and docs
+
+Definition of done:
+
+- operators can manage snapshot lifecycle without orphaning hidden volumes
+
+### Slice 6: darwin-vz disk-state support
+
+- add persistent `darwin-vz` sandboxes
+- add `apfs` volume-store driver
+- add `darwin-vz` snapshot, restore, and fork using cloned ext4 image files
+- keep API and capability semantics identical to Firecracker
+
+Definition of done:
+
+- `darwin-vz` reports `sandbox.snapshot`, `sandbox.restore`, and
+  `sandbox.fork=true`
+- the same CLI and API calls work on both backends, with backend-specific
+  runtime config
+
+### Slice 7: optional boot accelerator
+
+- investigate a mount-namespace or jailer-based path virtualization layer
+- capture boot-ready Firecracker snapshots
+- resume forks from a boot checkpoint when compatible
+
+Definition of done:
+
+- fork latency is reduced further without changing semantics
+
+### Slice 8: portable snapshot distribution
+
+- define OCI artifact layout for exported snapshots
+- add export and import commands
+- attach optional hotset or prefetch metadata
+- test registry storage and digest-addressed retrieval
+
+Definition of done:
+
+- snapshots can move between hosts through a standard OCI registry without
+  changing local execution semantics
+
+### Slice 9: fleet-scale fan-out
+
+- evaluate chunked payload formats for exported snapshots
+- integrate peer-to-peer or mirror-assisted distribution
+- add preheat support for popular snapshots
+
+Definition of done:
+
+- widely reused snapshots can fan out across large worker fleets with low
+  origin pressure and predictable startup times
+
+## Code Touchpoints
+
+Likely files:
+
+- `proto/cleanroom/v1/control.proto`
+- `internal/backend/backend.go`
+- `internal/controlservice/service.go`
+- `internal/backend/firecracker/backend.go`
+- `internal/backend/darwinvz/backend_darwin.go`
+- `cmd/cleanroom-darwin-vz/main.swift`
+- `cmd/cleanroom-guest-agent/main.go`
+- `internal/runtimeconfig/config.go`
+- new `internal/volumestore/...`
+- host-side control or gateway request handling for guest checkpoint requests
+- CLI command wiring and tests
+
+## External References
+
+- OCI image artifact guidance: [OCI Image Format Spec](https://oci-playground.github.io/specs-latest/specs/image/v1.1.0-rc4/oci-image-spec.html)
+- OCI referrers and subject relationships: [OCI Distribution Spec](https://oci-playground.github.io/specs-latest/specs/distribution/v1.1.0-rc2/oci-distribution-spec.html)
+- OCI 1.1 overview: [Summary of Upcoming Changes in OCI Image and Distribution Specs v1.1](https://opencontainers.org/posts/blog/2023-07-07-summary-of-upcoming-changes-in-oci-image-and-distribution-specs-v-1-1/)
+- eStargz lazy pull and prefetching: [stargz-snapshotter](https://github.com/containerd/stargz-snapshotter)
+- SOCI index artifacts: [AWS SOCI docs](https://docs.aws.amazon.com/sagemaker/latest/dg/soci-indexing.html)
+- Nydus image service and prefetch-oriented image optimization: [Nydus](https://github.com/dragonflyoss/nydus)
+- Dragonfly preheat API: [Dragonfly preheat](https://d7y.io/docs/advanced-guides/open-api/preheat/)
+- Dragonfly + Nydus integration: [Dragonfly Nydus integration](https://d7y.io/docs/operations/integrations/container-runtime/nydus/)
+
+## Open Questions
+
+- Should snapshot names be unique within a host or only advisory labels?
+- Do we want snapshot TTLs or leave GC fully explicit at first?
+- Should restore reject when the current sandbox policy hash differs from the
+  snapshot, or do we only ever allow restore within the same sandbox lineage?
+
+My recommendation:
+
+- keep names advisory
+- keep deletion explicit first
+- require exact policy-hash match everywhere in v1

--- a/docs/plans/snapshot-restore-fork.md
+++ b/docs/plans/snapshot-restore-fork.md
@@ -830,14 +830,15 @@ and fleet-distribution work is still pending.
 
 #### 1. Replace file-backed Firecracker storage with a volume-store abstraction
 
-- [todo] add `internal/volumestore`
-- [todo] define driver interface for:
+- [done] add `internal/volumestore`
+- [done] define driver interface for:
   - seed base volume
   - clone writable volume
   - snapshot volume
   - destroy volume
   - destroy snapshot
 - [todo] add `zfs` driver
+- [done] wire Firecracker through the volume driver with a file-backed fallback
 - [done] add runtime config loading for Firecracker snapshot storage
 - [todo] add doctor checks for `zfs` availability and configuration
 

--- a/docs/plans/snapshot-restore-fork.md
+++ b/docs/plans/snapshot-restore-fork.md
@@ -838,7 +838,7 @@ and fleet-distribution work is still pending.
   - destroy volume
   - destroy snapshot
 - [todo] add `zfs` driver
-- [todo] add runtime config loading for Firecracker snapshot storage
+- [done] add runtime config loading for Firecracker snapshot storage
 - [todo] add doctor checks for `zfs` availability and configuration
 
 Definition of done:
@@ -865,7 +865,7 @@ Definition of done:
 
 #### 3. Retention and ergonomics
 
-- [todo] snapshot delete safety checks
+- [done] snapshot delete safety checks
 - [done] advisory snapshot names
 - [done] human-friendly CLI output
 - [todo] CI examples and operational docs

--- a/docs/plans/snapshot-restore-fork.md
+++ b/docs/plans/snapshot-restore-fork.md
@@ -869,8 +869,8 @@ Definition of done:
 - [done] snapshot delete safety checks
 - [done] advisory snapshot names
 - [done] human-friendly CLI output
-- [todo] CI examples and operational docs
-- [todo] decide whether to surface snapshot lineage in CLI/API
+- [done] CI examples and operational docs (docs/snapshots.md)
+- [done] snapshot lineage tracked implicitly via source sandbox provenance; no explicit lineage API in v1
 
 Definition of done:
 

--- a/docs/snapshots.md
+++ b/docs/snapshots.md
@@ -1,0 +1,169 @@
+# Snapshots, Restore, and Fork
+
+Cleanroom supports capturing sandbox filesystem state as immutable snapshots.
+Snapshots can be used to fork new sandboxes or restore an existing sandbox to a
+previous state. Every restore and fork boots a fresh VM from the captured disk
+state — no process state survives.
+
+## Prerequisites
+
+Snapshot support requires a configured volume driver. Currently only the ZFS
+driver is supported on the Firecracker backend.
+
+### ZFS setup
+
+1. Create a ZFS dataset for Cleanroom:
+
+   ```bash
+   sudo zpool create tank /dev/sdX          # or use an existing pool
+   sudo zfs create tank/cleanroom
+   ```
+
+2. Grant the Cleanroom user access (using sudo or the privileged helper):
+
+   ```sudoers
+   Cmnd_Alias CLEANROOM_ZFS = /usr/sbin/zfs *, /usr/bin/dd *
+   CLEANROOM_CI ALL=(root) NOPASSWD: CLEANROOM_ZFS
+   ```
+
+3. Enable snapshots in runtime config (`~/.config/cleanroom/config.yaml`):
+
+   ```yaml
+   backends:
+     firecracker:
+       snapshots:
+         enabled: true
+         driver: zfs
+         zfs_dataset: tank/cleanroom
+         quiesce_timeout_seconds: 15
+   ```
+
+4. Verify with `cleanroom doctor`:
+
+   ```bash
+   cleanroom doctor
+   ```
+
+   Look for passing `snapshot_driver`, `snapshot_zfs_dataset`, and
+   `snapshot_zfs_dataset_access` checks.
+
+## CLI Usage
+
+### Create a snapshot
+
+Capture the current filesystem state of a sandbox:
+
+```bash
+cleanroom snapshot create <sandbox-id> --name "after-deps"
+```
+
+The sandbox must be idle (no active execution or file download).
+
+### List snapshots
+
+```bash
+cleanroom snapshot ls
+cleanroom snapshot ls --json
+```
+
+### Get snapshot details
+
+```bash
+cleanroom snapshot get <snapshot-id>
+cleanroom snapshot get <snapshot-id> --json
+```
+
+### Delete a snapshot
+
+```bash
+cleanroom snapshot rm <snapshot-id>
+```
+
+### Fork a new sandbox from a snapshot
+
+```bash
+cleanroom sandbox create --from-snapshot <snapshot-id>
+```
+
+The new sandbox inherits the snapshot's policy and backend. A fresh VM boots
+from a copy-on-write clone of the snapshot.
+
+### Restore a sandbox to a snapshot
+
+```bash
+cleanroom sandbox restore <sandbox-id> --snapshot <snapshot-id>
+```
+
+The sandbox's current volume is replaced with a fresh clone of the snapshot and
+a new VM boots. The sandbox keeps its ID but all process state is discarded.
+
+## CI Bootstrap and Fan-Out
+
+A common CI pattern uses snapshots to avoid repeating expensive setup work:
+
+```bash
+# 1. Create a sandbox
+SB=$(cleanroom sandbox create --json | jq -r .sandbox.sandbox_id)
+
+# 2. Run bootstrap work
+cleanroom exec $SB -- git clone https://github.com/org/repo /work
+cleanroom exec $SB -- sh -c 'cd /work && npm ci'
+
+# 3. Snapshot the golden state
+SNAP=$(cleanroom snapshot create $SB --name deps --json | jq -r .snapshot.snapshot_id)
+
+# 4. Fan out parallel test shards from the snapshot
+for shard in unit integration e2e; do
+  FORK=$(cleanroom sandbox create --from-snapshot $SNAP --json | jq -r .sandbox.sandbox_id)
+  cleanroom exec $FORK -- sh -c "cd /work && npm test -- --shard=$shard" &
+done
+wait
+
+# 5. Clean up
+cleanroom snapshot rm $SNAP
+cleanroom sandbox terminate $SB
+```
+
+Each forked sandbox gets its own VM, network identity, and writable volume.
+Changes in one fork do not affect others or the snapshot.
+
+### Guest-initiated checkpoints
+
+The guest agent supports requesting a checkpoint from inside a running command.
+This is useful when the workload knows the exact safe point:
+
+```bash
+# Inside the guest, after setup work completes:
+cleanroom-guest-agent checkpoint request --name "ready"
+```
+
+The host records the request and materializes the snapshot once the current
+execution finishes and the sandbox becomes idle. The host remains authoritative
+— the guest request is advisory.
+
+## Snapshot Lineage
+
+Snapshots support lineage: a forked sandbox can create further snapshots,
+forming a tree. Each snapshot records its source sandbox ID. The parent
+relationship is tracked implicitly through sandbox provenance.
+
+## How It Works
+
+1. **Create snapshot:** The host asks the guest agent to quiesce (sync
+   filesystems), pauses the VM via the Firecracker API, takes a ZFS snapshot of
+   the sandbox volume, then resumes the VM.
+
+2. **Fork:** ZFS clones the snapshot into a new writable volume. A fresh VM
+   boots from the clone with new network identity.
+
+3. **Restore:** The current VM is terminated, the writable volume is destroyed,
+   a fresh ZFS clone is created from the target snapshot, and a new VM boots.
+
+4. **Delete:** The ZFS snapshot is destroyed and metadata is removed from the
+   SQLite store.
+
+## Related
+
+- [backend/firecracker.md](backend/firecracker.md) — Firecracker backend details
+- [plans/snapshot-restore-fork.md](plans/snapshot-restore-fork.md) — full design document
+- [ci.md](ci.md) — CI setup guide

--- a/infra/terraform/envs/ci/bootstrap_defaults_test.go
+++ b/infra/terraform/envs/ci/bootstrap_defaults_test.go
@@ -134,6 +134,40 @@ func TestUserDataVerifiesZfsAvailability(t *testing.T) {
 	requireContains(t, templatePath, "command -v zpool >/dev/null 2>&1")
 }
 
+func TestUserDataCreatesZfsPoolFromEphemeralNVMe(t *testing.T) {
+	t.Helper()
+
+	templatePath := filepath.Join("..", "..", "modules", "linux-ci", "templates", "user_data.sh.tftpl")
+	requireContains(t, templatePath, "zpool create -f")
+	requireContains(t, templatePath, "Amazon Elastic Block Store")
+	requireContains(t, templatePath, "zfs create")
+	requireContains(t, templatePath, "cleanroom-zfs.img")
+}
+
+func TestDefaultInstanceTypeIsNVMeVariant(t *testing.T) {
+	t.Helper()
+
+	for _, path := range []string{
+		"variables.tf",
+		filepath.Join("..", "..", "modules", "linux-ci", "variables.tf"),
+	} {
+		block := readVariableBlock(t, path, "instance_type")
+		if !strings.Contains(block, "m8id.large") {
+			t.Fatalf("expected default instance_type to be m8id.large in %s, got:\n%s", path, block)
+		}
+	}
+}
+
+func TestBootstrapConfiguresZfsSnapshots(t *testing.T) {
+	t.Helper()
+
+	scriptPath := filepath.Join("..", "..", "..", "..", "scripts", "bootstrap-buildkite-agent.sh")
+	requireContains(t, scriptPath, "CLEANROOM_ZFS_DATASET")
+	requireContains(t, scriptPath, "driver: zfs")
+	requireContains(t, scriptPath, "snapshots:")
+	requireContains(t, scriptPath, "enabled: true")
+}
+
 func TestLinuxCiEnablesNestedVirtualization(t *testing.T) {
 	t.Helper()
 

--- a/infra/terraform/envs/ci/variables.tf
+++ b/infra/terraform/envs/ci/variables.tf
@@ -29,9 +29,9 @@ variable "ubuntu_ami_ssm_parameter_name" {
 }
 
 variable "instance_type" {
-  description = "EC2 instance type for the host."
+  description = "EC2 instance type for the host. Use a 'd' variant (m8id, c8id, r8id) for ephemeral NVMe storage used as a ZFS pool."
   type        = string
-  default     = "m8i.large"
+  default     = "m8id.large"
 }
 
 variable "root_volume_size_gib" {

--- a/infra/terraform/modules/linux-ci/templates/user_data.sh.tftpl
+++ b/infra/terraform/modules/linux-ci/templates/user_data.sh.tftpl
@@ -36,6 +36,37 @@ if ! command -v zpool >/dev/null 2>&1; then
   exit 1
 fi
 
+# Create a ZFS pool on the ephemeral NVMe instance store if available.
+# The 'd' instance variants (m8id, c8id, r8id) have local NVMe storage
+# that appears as /dev/nvme1n1 (the root EBS volume is /dev/nvme0n1).
+CLEANROOM_ZFS_POOL='cleanroom'
+CLEANROOM_ZFS_DATASET="$CLEANROOM_ZFS_POOL/data"
+if ! zpool list "$CLEANROOM_ZFS_POOL" >/dev/null 2>&1; then
+  ephemeral_dev=''
+  for dev in /dev/nvme1n1 /dev/nvme2n1; do
+    if [ -b "$dev" ]; then
+      # Verify this is NOT an EBS volume (EBS volumes have model 'Amazon Elastic Block Store').
+      dev_model="$(cat "/sys/block/$(basename "$dev")/device/model" 2>/dev/null | xargs || true)"
+      if [ "$dev_model" != 'Amazon Elastic Block Store' ]; then
+        ephemeral_dev="$dev"
+        break
+      fi
+    fi
+  done
+
+  if [ -n "$ephemeral_dev" ]; then
+    echo "creating ZFS pool $CLEANROOM_ZFS_POOL on ephemeral NVMe $ephemeral_dev"
+    zpool create -f "$CLEANROOM_ZFS_POOL" "$ephemeral_dev"
+    zfs create "$CLEANROOM_ZFS_DATASET"
+  else
+    echo "no ephemeral NVMe found, creating ZFS pool on loopback file"
+    loopback_path='/var/lib/cleanroom-zfs.img'
+    truncate -s 2G "$loopback_path"
+    zpool create -f "$CLEANROOM_ZFS_POOL" "$loopback_path"
+    zfs create "$CLEANROOM_ZFS_DATASET"
+  fi
+fi
+
 if ! command -v aws >/dev/null 2>&1; then
   aws_arch='x86_64'
   if [ "$(uname -m)" = 'aarch64' ] || [ "$(uname -m)" = 'arm64' ]; then

--- a/infra/terraform/modules/linux-ci/variables.tf
+++ b/infra/terraform/modules/linux-ci/variables.tf
@@ -26,9 +26,9 @@ variable "ami_id" {
 }
 
 variable "instance_type" {
-  description = "EC2 instance type for the host."
+  description = "EC2 instance type for the host. Use a 'd' variant (m8id, c8id, r8id) for ephemeral NVMe storage used as a ZFS pool."
   type        = string
-  default     = "m8i.large"
+  default     = "m8id.large"
 }
 
 variable "root_volume_size_gib" {

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -136,6 +136,7 @@ type ProvisionRequest struct {
 type SnapshotRequest struct {
 	SandboxID  string
 	SnapshotID string
+	FirecrackerConfig
 }
 
 type SnapshotResult struct {
@@ -197,6 +198,7 @@ type FirecrackerConfig struct {
 	DockerStartupSeconds int64
 	DockerStorageDriver  string
 	DockerIPTables       bool
+	Snapshots            SnapshotConfig
 	PrivilegedMode       string
 	PrivilegedHelperPath string
 	RunDir               string
@@ -206,6 +208,14 @@ type FirecrackerConfig struct {
 	GuestPort            uint32
 	Launch               bool
 	LaunchSeconds        int64
+}
+
+type SnapshotConfig struct {
+	Enabled               bool
+	Driver                string
+	BaseDir               string
+	ZFSDataset            string
+	QuiesceTimeoutSeconds int64
 }
 
 type RunResult struct {

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -162,6 +162,7 @@ type RestoreRequest struct {
 type DeleteSnapshotRequest struct {
 	SnapshotID string
 	StorageRef string
+	FirecrackerConfig
 }
 
 type AttachIO struct {

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -10,6 +10,9 @@ import (
 
 const (
 	CapabilityExecStreaming          = "exec.streaming"
+	CapabilitySandboxSnapshot        = "sandbox.snapshot"
+	CapabilitySandboxRestore         = "sandbox.restore"
+	CapabilitySandboxFork            = "sandbox.fork"
 	CapabilitySandboxPersistent      = "sandbox.persistent"
 	CapabilitySandboxFileDownload    = "sandbox.file_download"
 	CapabilityNetworkDefaultDeny     = "network.default_deny"
@@ -19,6 +22,9 @@ const (
 
 var knownCapabilityKeys = []string{
 	CapabilityExecStreaming,
+	CapabilitySandboxSnapshot,
+	CapabilitySandboxRestore,
+	CapabilitySandboxFork,
 	CapabilitySandboxPersistent,
 	CapabilitySandboxFileDownload,
 	CapabilityNetworkDefaultDeny,
@@ -42,6 +48,7 @@ type CapabilityReporter interface {
 // Baseline capabilities are inferred from backend interfaces:
 // - StreamingAdapter => exec.streaming
 // - PersistentSandboxAdapter => sandbox.persistent
+// - SnapshottingAdapter => sandbox.snapshot, sandbox.restore, sandbox.fork
 // - SandboxFileDownloadAdapter => sandbox.file_download
 //
 // Additional backend-specific capabilities can be provided by implementing
@@ -60,6 +67,11 @@ func CapabilitiesForAdapter(adapter Adapter) map[string]bool {
 	}
 	if _, ok := adapter.(PersistentSandboxAdapter); ok {
 		caps[CapabilitySandboxPersistent] = true
+	}
+	if _, ok := adapter.(SnapshottingAdapter); ok {
+		caps[CapabilitySandboxSnapshot] = true
+		caps[CapabilitySandboxRestore] = true
+		caps[CapabilitySandboxFork] = true
 	}
 	if _, ok := adapter.(SandboxFileDownloadAdapter); ok {
 		caps[CapabilitySandboxFileDownload] = true
@@ -100,6 +112,16 @@ type PersistentSandboxAdapter interface {
 	TerminateSandbox(ctx context.Context, sandboxID string) error
 }
 
+// SnapshottingAdapter supports immutable filesystem snapshots of persistent
+// sandboxes, fresh-boot restore, and creating new sandboxes from snapshots.
+type SnapshottingAdapter interface {
+	PersistentSandboxAdapter
+	CreateSnapshot(ctx context.Context, req SnapshotRequest) (*SnapshotResult, error)
+	ProvisionSandboxFromSnapshot(ctx context.Context, req ProvisionFromSnapshotRequest) error
+	RestoreSandbox(ctx context.Context, req RestoreRequest) error
+	DeleteSnapshot(ctx context.Context, req DeleteSnapshotRequest) error
+}
+
 // SandboxFileDownloadAdapter can copy files out of a persistent sandbox.
 type SandboxFileDownloadAdapter interface {
 	DownloadSandboxFile(ctx context.Context, sandboxID, path string, maxBytes int64) ([]byte, error)
@@ -109,6 +131,36 @@ type ProvisionRequest struct {
 	SandboxID string
 	Policy    *policy.CompiledPolicy
 	FirecrackerConfig
+}
+
+type SnapshotRequest struct {
+	SandboxID  string
+	SnapshotID string
+}
+
+type SnapshotResult struct {
+	StorageRef string
+}
+
+type ProvisionFromSnapshotRequest struct {
+	SandboxID  string
+	SnapshotID string
+	StorageRef string
+	Policy     *policy.CompiledPolicy
+	FirecrackerConfig
+}
+
+type RestoreRequest struct {
+	SandboxID  string
+	SnapshotID string
+	StorageRef string
+	Policy     *policy.CompiledPolicy
+	FirecrackerConfig
+}
+
+type DeleteSnapshotRequest struct {
+	SnapshotID string
+	StorageRef string
 }
 
 type AttachIO struct {

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -100,6 +100,9 @@ const privilegedModeHelper = "helper"
 const defaultPrivilegedHelperPath = "/usr/local/sbin/cleanroom-root-helper"
 const defaultDownloadMaxBytes int64 = 10 * 1024 * 1024
 const snapshotSyncTimeoutSeconds = 10
+const networkCleanupTimeout = 5 * time.Second
+
+var tapDeleteRetryInterval = 100 * time.Millisecond
 
 var sendProcessSignal = func(proc *os.Process, sig syscall.Signal) error {
 	if proc == nil {
@@ -1892,6 +1895,7 @@ type iptablesForwardRule struct {
 }
 
 type ipLookupFunc func(ctx context.Context, host string) ([]net.IP, error)
+type interfaceLookupFunc func(name string) (*net.Interface, error)
 type rootCommandFunc func(ctx context.Context, args ...string) error
 type rootCommandBatchFunc func(ctx context.Context, commands [][]string) error
 
@@ -1903,20 +1907,15 @@ func setupHostNetwork(ctx context.Context, runID string, allow []policy.AllowRul
 }
 
 func setupHostNetworkWithDeps(ctx context.Context, runID string, allow []policy.AllowRule, gatewayPort int, lookup ipLookupFunc, runCommand rootCommandFunc, runBatchCommand rootCommandBatchFunc) (hostNetworkConfig, func(), error) {
+	return setupHostNetworkWithTapLookup(ctx, runID, allow, gatewayPort, lookup, net.InterfaceByName, runCommand, runBatchCommand)
+}
+
+func setupHostNetworkWithTapLookup(ctx context.Context, runID string, allow []policy.AllowRule, gatewayPort int, lookup ipLookupFunc, interfaceByName interfaceLookupFunc, runCommand rootCommandFunc, runBatchCommand rootCommandBatchFunc) (hostNetworkConfig, func(), error) {
 	tapName := tapNameFromRunID(runID)
 	hostIP, guestIP := hostGuestIPs(runID)
 	hostCIDR := hostIP + "/24"
 	guestCIDR := guestIP + "/32"
 	const dnsServer = "1.1.1.1"
-
-	if runBatchCommand == nil {
-		runBatchCommand = func(ctx context.Context, commands [][]string) error {
-			for _, args := range commands {
-				_ = runCommand(ctx, args...)
-			}
-			return nil
-		}
-	}
 
 	policyResolveStart := time.Now()
 	forwardRules, err := resolveForwardRulesWithLookup(ctx, allow, lookup)
@@ -1928,7 +1927,7 @@ func setupHostNetworkWithDeps(ctx context.Context, runID string, allow []policy.
 	setupRun := func(args ...string) error {
 		return runCommand(ctx, args...)
 	}
-	cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), networkCleanupTimeout)
 	cleanupCmds := make([][]string, 0, 16)
 	cleanup := func() {
 		defer cleanupCancel()
@@ -1936,10 +1935,24 @@ func setupHostNetworkWithDeps(ctx context.Context, runID string, allow []policy.
 		for i := len(cleanupCmds) - 1; i >= 0; i-- {
 			reversed = append(reversed, cleanupCmds[i])
 		}
-		_ = runBatchCommand(cleanupCtx, reversed)
+		for _, args := range reversed {
+			if isTapDeleteCommand(args, tapName) {
+				_ = deleteTapDeviceWithRetry(cleanupCtx, tapName, tapDeleteRetryInterval, interfaceByName, runCommand)
+				continue
+			}
+			_ = runCommand(cleanupCtx, args...)
+		}
 	}
 	addCleanup := func(args ...string) {
 		cleanupCmds = append(cleanupCmds, append([]string(nil), args...))
+	}
+
+	staleTapCleanupCtx, staleTapCleanupCancel := context.WithTimeout(context.Background(), networkCleanupTimeout)
+	defer staleTapCleanupCancel()
+	if _, err := interfaceByName(tapName); err == nil {
+		if err := deleteTapDeviceWithRetry(staleTapCleanupCtx, tapName, tapDeleteRetryInterval, interfaceByName, runCommand); err != nil {
+			return hostNetworkConfig{}, func() {}, fmt.Errorf("remove stale tap device %s: %w", tapName, err)
+		}
 	}
 
 	if err := setupRun("ip", "tuntap", "add", "dev", tapName, "mode", "tap", "user", strconv.Itoa(os.Getuid())); err != nil {
@@ -2033,6 +2046,38 @@ func setupHostNetworkWithDeps(ctx context.Context, runID string, allow []policy.
 		GuestIP:         guestIP,
 		PolicyResolveMS: policyResolveMS,
 	}, cleanup, nil
+}
+
+func isTapDeleteCommand(args []string, tapName string) bool {
+	return len(args) == 4 && args[0] == "ip" && args[1] == "link" && args[2] == "del" && args[3] == tapName
+}
+
+func deleteTapDeviceWithRetry(ctx context.Context, tapName string, retryInterval time.Duration, interfaceByName interfaceLookupFunc, runCommand rootCommandFunc) error {
+	if strings.TrimSpace(tapName) == "" {
+		return nil
+	}
+	if retryInterval <= 0 {
+		retryInterval = time.Millisecond
+	}
+
+	ticker := time.NewTicker(retryInterval)
+	defer ticker.Stop()
+
+	for {
+		err := runCommand(ctx, "ip", "link", "del", tapName)
+		if err == nil {
+			return nil
+		}
+		if _, lookupErr := interfaceByName(tapName); lookupErr != nil {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("delete tap device %s: %w", tapName, err)
+		case <-ticker.C:
+		}
+	}
 }
 
 func installForwardReturnPathRule(setupRun func(args ...string) error, tapName string) ([]string, error) {

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -1953,6 +1953,8 @@ func setupHostNetworkWithTapLookup(ctx context.Context, runID string, allow []po
 		if err := deleteTapDeviceWithRetry(staleTapCleanupCtx, tapName, tapDeleteRetryInterval, interfaceByName, runCommand); err != nil {
 			return hostNetworkConfig{}, func() {}, fmt.Errorf("remove stale tap device %s: %w", tapName, err)
 		}
+	} else if !isNoSuchNetworkInterfaceError(err) {
+		return hostNetworkConfig{}, func() {}, fmt.Errorf("lookup tap device %s: %w", tapName, err)
 	}
 
 	if err := setupRun("ip", "tuntap", "add", "dev", tapName, "mode", "tap", "user", strconv.Itoa(os.Getuid())); err != nil {
@@ -2069,7 +2071,10 @@ func deleteTapDeviceWithRetry(ctx context.Context, tapName string, retryInterval
 			return nil
 		}
 		if _, lookupErr := interfaceByName(tapName); lookupErr != nil {
-			return nil
+			if isNoSuchNetworkInterfaceError(lookupErr) {
+				return nil
+			}
+			return fmt.Errorf("lookup tap device %s after delete failure (%v): %w", tapName, err, lookupErr)
 		}
 
 		select {
@@ -2078,6 +2083,17 @@ func deleteTapDeviceWithRetry(ctx context.Context, tapName string, retryInterval
 		case <-ticker.C:
 		}
 	}
+}
+
+func isNoSuchNetworkInterfaceError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var opErr *net.OpError
+	if errors.As(err, &opErr) && opErr.Err != nil {
+		return strings.Contains(opErr.Err.Error(), "no such network interface")
+	}
+	return strings.Contains(err.Error(), "no such network interface")
 }
 
 func installForwardReturnPathRule(setupRun func(args ...string) error, tapName string) ([]string, error) {

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -31,6 +31,7 @@ import (
 	"github.com/buildkite/cleanroom/internal/imagemgr"
 	"github.com/buildkite/cleanroom/internal/paths"
 	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/buildkite/cleanroom/internal/volumestore"
 	"github.com/buildkite/cleanroom/internal/vsockexec"
 	fcvsock "github.com/firecracker-microvm/firecracker-go-sdk/vsock"
 )
@@ -475,12 +476,9 @@ func (a *Adapter) CreateSnapshot(ctx context.Context, req backend.SnapshotReques
 		return nil, fmt.Errorf("sync sandbox filesystem before snapshot: %w", err)
 	}
 
-	snapshotPath, err := snapshotStoragePath(req.FirecrackerConfig, snapshotID)
+	driver, err := volumeStoreDriver(req.FirecrackerConfig)
 	if err != nil {
 		return nil, err
-	}
-	if err := os.MkdirAll(filepath.Dir(snapshotPath), 0o755); err != nil {
-		return nil, fmt.Errorf("create snapshot directory: %w", err)
 	}
 	if err := pauseSandboxProcess(instance); err != nil {
 		return nil, err
@@ -489,12 +487,15 @@ func (a *Adapter) CreateSnapshot(ctx context.Context, req backend.SnapshotReques
 		_ = resumeSandboxProcess(instance)
 	}()
 
-	if err := copyFile(instance.vmRootFSPath, snapshotPath); err != nil {
-		_ = os.Remove(snapshotPath)
+	snapshot, err := driver.SnapshotVolume(ctx, volumestore.SnapshotVolumeRequest{
+		SnapshotID: snapshotID,
+		VolumeRef:  instance.vmRootFSPath,
+	})
+	if err != nil {
 		return nil, fmt.Errorf("persist snapshot rootfs: %w", err)
 	}
 
-	return &backend.SnapshotResult{StorageRef: snapshotPath}, nil
+	return &backend.SnapshotResult{StorageRef: snapshot.StorageRef}, nil
 }
 
 func (a *Adapter) ProvisionSandboxFromSnapshot(ctx context.Context, req backend.ProvisionFromSnapshotRequest) error {
@@ -604,16 +605,19 @@ func (a *Adapter) RestoreSandbox(ctx context.Context, req backend.RestoreRequest
 	return nil
 }
 
-func (a *Adapter) DeleteSnapshot(_ context.Context, req backend.DeleteSnapshotRequest) error {
+func (a *Adapter) DeleteSnapshot(ctx context.Context, req backend.DeleteSnapshotRequest) error {
 	storageRef := strings.TrimSpace(req.StorageRef)
 	if storageRef == "" {
 		return errors.New("missing snapshot storage_ref")
 	}
-	if err := os.Remove(storageRef); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("remove snapshot rootfs %q: %w", storageRef, err)
+	driver, err := volumeStoreDriver(req.FirecrackerConfig)
+	if err != nil {
+		return err
 	}
-	if dir := filepath.Dir(storageRef); dir != "" {
-		_ = os.Remove(dir)
+	if err := driver.DestroySnapshot(ctx, volumestore.DestroySnapshotRequest{
+		SnapshotRef: storageRef,
+	}); err != nil {
+		return fmt.Errorf("remove snapshot rootfs %q: %w", storageRef, err)
 	}
 	return nil
 }
@@ -1511,10 +1515,27 @@ func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID strin
 		return nil, fmt.Errorf("rootfs %s: %w", rootfsPath, err)
 	}
 
-	vmRootFSPath := filepath.Join(runDir, "rootfs-persistent.ext4")
-	if err := copyFile(rootfsPath, vmRootFSPath); err != nil {
+	driver, err := volumeStoreDriver(cfg)
+	if err != nil {
+		return nil, err
+	}
+	baseVolume, err := driver.EnsureBaseVolume(ctx, volumestore.EnsureBaseVolumeRequest{
+		BaseID:     strings.TrimSuffix(filepath.Base(rootfsPath), filepath.Ext(rootfsPath)),
+		SourcePath: rootfsPath,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("prepare base volume: %w", err)
+	}
+
+	writableVolume, err := driver.CreateWritableVolume(ctx, volumestore.CreateWritableVolumeRequest{
+		VolumeID:       sandboxID,
+		BaseRef:        baseVolume.Ref,
+		AttachmentPath: filepath.Join(runDir, "rootfs-persistent.ext4"),
+	})
+	if err != nil {
 		return nil, fmt.Errorf("prepare persistent rootfs: %w", err)
 	}
+	vmRootFSPath := writableVolume.AttachmentPath
 
 	networkRunCommand := func(ctx context.Context, args ...string) error {
 		return runRootCommand(ctx, cfg, args...)
@@ -1670,19 +1691,34 @@ func sandboxRuntimeBaseDir() (string, error) {
 	return filepath.Join(base, "sandboxes"), nil
 }
 
-func snapshotStoragePath(cfg backend.FirecrackerConfig, snapshotID string) (string, error) {
-	base, err := snapshotStorageBaseDir(cfg)
-	if err != nil {
-		return "", fmt.Errorf("resolve snapshot base directory: %w", err)
-	}
-	return filepath.Join(base, "firecracker", snapshotID, "rootfs.ext4"), nil
-}
-
 func snapshotStorageBaseDir(cfg backend.FirecrackerConfig) (string, error) {
 	if baseDir := strings.TrimSpace(cfg.Snapshots.BaseDir); baseDir != "" {
 		return filepath.Clean(baseDir), nil
 	}
 	return paths.SnapshotDir()
+}
+
+func volumeStoreDriver(cfg backend.FirecrackerConfig) (volumestore.Driver, error) {
+	driverName := strings.ToLower(strings.TrimSpace(cfg.Snapshots.Driver))
+	switch driverName {
+	case "", "file":
+		snapshotBaseDir, err := snapshotStorageBaseDir(cfg)
+		if err != nil {
+			return nil, fmt.Errorf("resolve snapshot base directory: %w", err)
+		}
+		driver, err := volumestore.NewFileDriver(volumestore.FileDriverOptions{
+			SnapshotBaseDir: snapshotBaseDir,
+			Namespace:       "firecracker",
+		})
+		if err != nil {
+			return nil, err
+		}
+		return driver, nil
+	case "zfs":
+		return nil, errors.New("firecracker snapshot driver \"zfs\" is not implemented")
+	default:
+		return nil, fmt.Errorf("unsupported firecracker snapshot driver %q", cfg.Snapshots.Driver)
+	}
 }
 
 func pauseSandboxProcess(instance *sandboxInstance) error {

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -90,7 +90,9 @@ type sandboxInstance struct {
 	exitErr        error
 	exitReady      bool
 	cleanupNetwork func()
+	cleanupVolume  func()
 	vmRootFSPath   string
+	volumeRef      string
 }
 
 const runObservabilityFile = "run-observability.json"
@@ -487,9 +489,14 @@ func (a *Adapter) CreateSnapshot(ctx context.Context, req backend.SnapshotReques
 		_ = resumeSandboxProcess(instance)
 	}()
 
+	volumeRef := snapshotVolumeRef(instance)
+	if volumeRef == "" {
+		return nil, fmt.Errorf("sandbox %q has no snapshot-capable rootfs volume", sandboxID)
+	}
+
 	snapshot, err := driver.SnapshotVolume(ctx, volumestore.SnapshotVolumeRequest{
 		SnapshotID: snapshotID,
-		VolumeRef:  instance.vmRootFSPath,
+		VolumeRef:  volumeRef,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("persist snapshot rootfs: %w", err)
@@ -773,6 +780,39 @@ func (a *Adapter) Doctor(_ context.Context, req backend.DoctorRequest) (*backend
 		} else {
 			appendCheck("network_helper", "pass", fmt.Sprintf("using privileged helper %q", privilegedHelperPath))
 		}
+	}
+
+	snapshotDriver := strings.ToLower(strings.TrimSpace(req.FirecrackerConfig.Snapshots.Driver))
+	switch snapshotDriver {
+	case "", "file":
+		appendCheck("snapshot_driver", "pass", "using snapshot driver \"file\"")
+	case "zfs":
+		appendCheck("snapshot_driver", "pass", "using snapshot driver \"zfs\"")
+		dataset := strings.TrimSpace(req.FirecrackerConfig.Snapshots.ZFSDataset)
+		if dataset == "" {
+			appendCheck("snapshot_zfs_dataset", "fail", "zfs snapshot driver requires snapshots.zfs_dataset")
+		} else {
+			appendCheck("snapshot_zfs_dataset", "pass", fmt.Sprintf("configured zfs dataset %q", dataset))
+		}
+
+		if path, err := lookPathWithFallback("zfs", "/usr/sbin/zfs", "/sbin/zfs"); err != nil {
+			appendCheck("snapshot_zfs_binary", "fail", fmt.Sprintf("zfs command not available: %v", err))
+		} else {
+			appendCheck("snapshot_zfs_binary", "pass", fmt.Sprintf("found zfs command %q", path))
+		}
+
+		if dataset != "" {
+			out, err := runRootCommandOutput(context.Background(), req.FirecrackerConfig, "zfs", "list", "-H", "-o", "name", dataset)
+			if err != nil {
+				appendCheck("snapshot_zfs_dataset_access", "fail", fmt.Sprintf("unable to access zfs dataset %q: %v", dataset, err))
+			} else if strings.TrimSpace(string(out)) != dataset {
+				appendCheck("snapshot_zfs_dataset_access", "fail", fmt.Sprintf("zfs dataset probe for %q returned %q", dataset, strings.TrimSpace(string(out))))
+			} else {
+				appendCheck("snapshot_zfs_dataset_access", "pass", fmt.Sprintf("zfs dataset %q is accessible", dataset))
+			}
+		}
+	default:
+		appendCheck("snapshot_driver", "fail", fmt.Sprintf("unsupported snapshot driver %q", req.FirecrackerConfig.Snapshots.Driver))
 	}
 
 	if err := runRootCommand(context.Background(), req.FirecrackerConfig, "true"); err != nil {
@@ -1507,35 +1547,18 @@ func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID strin
 		return nil, err
 	}
 
-	rootfsPath, err := filepath.Abs(sourceRootFSPath)
-	if err != nil {
-		return nil, err
-	}
-	if _, err := os.Stat(rootfsPath); err != nil {
-		return nil, fmt.Errorf("rootfs %s: %w", rootfsPath, err)
-	}
-
 	driver, err := volumeStoreDriver(cfg)
 	if err != nil {
 		return nil, err
 	}
-	baseVolume, err := driver.EnsureBaseVolume(ctx, volumestore.EnsureBaseVolumeRequest{
-		BaseID:     strings.TrimSuffix(filepath.Base(rootfsPath), filepath.Ext(rootfsPath)),
-		SourcePath: rootfsPath,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("prepare base volume: %w", err)
-	}
-
-	writableVolume, err := driver.CreateWritableVolume(ctx, volumestore.CreateWritableVolumeRequest{
-		VolumeID:       sandboxID,
-		BaseRef:        baseVolume.Ref,
-		AttachmentPath: filepath.Join(runDir, "rootfs-persistent.ext4"),
-	})
+	writableVolume, err := preparePersistentWritableVolume(ctx, driver, sandboxID, runDir, sourceRootFSPath)
 	if err != nil {
 		return nil, fmt.Errorf("prepare persistent rootfs: %w", err)
 	}
 	vmRootFSPath := writableVolume.AttachmentPath
+	cleanupVolume := func() {
+		_ = driver.DestroyVolume(context.Background(), volumestore.DestroyVolumeRequest{VolumeRef: writableVolume.Ref})
+	}
 
 	networkRunCommand := func(ctx context.Context, args ...string) error {
 		return runRootCommand(ctx, cfg, args...)
@@ -1552,14 +1575,14 @@ func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID strin
 	}
 	networkCfg, cleanupNetwork, err := setupHostNetwork(ctx, sandboxID, compiled.Allow, gwPort, networkRunCommand, networkRunBatch)
 	if err != nil {
-		_ = os.Remove(vmRootFSPath)
+		cleanupVolume()
 		return nil, fmt.Errorf("setup host network: %w", err)
 	}
 
 	if a.GatewayRegistry != nil {
 		if err := a.GatewayRegistry.Register(networkCfg.GuestIP, sandboxID, compiled); err != nil {
 			cleanupNetwork()
-			_ = os.Remove(vmRootFSPath)
+			cleanupVolume()
 			return nil, fmt.Errorf("register sandbox in gateway: %w", err)
 		}
 	}
@@ -1569,7 +1592,7 @@ func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID strin
 			a.GatewayRegistry.Release(networkCfg.GuestIP)
 		}
 		cleanupNetwork()
-		_ = os.Remove(vmRootFSPath)
+		cleanupVolume()
 	}
 
 	vsockPath := filepath.Join(runDir, "vsock.sock")
@@ -1654,7 +1677,9 @@ func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID strin
 		fcCmd:          fcCmd,
 		exitedCh:       make(chan struct{}),
 		cleanupNetwork: cleanupNetwork,
+		cleanupVolume:  cleanupVolume,
 		vmRootFSPath:   vmRootFSPath,
+		volumeRef:      writableVolume.Ref,
 	}
 	go func() {
 		err := fcCmd.Wait()
@@ -1691,11 +1716,70 @@ func sandboxRuntimeBaseDir() (string, error) {
 	return filepath.Join(base, "sandboxes"), nil
 }
 
+func preparePersistentWritableVolume(ctx context.Context, driver volumestore.Driver, sandboxID, runDir, sourceRef string) (volumestore.WritableVolume, error) {
+	sourceRef = strings.TrimSpace(sourceRef)
+	if sourceRef == "" {
+		return volumestore.WritableVolume{}, errors.New("missing persistent rootfs source")
+	}
+
+	attachmentPath := filepath.Join(runDir, "rootfs-persistent.ext4")
+	if filepath.IsAbs(sourceRef) {
+		rootfsPath, err := filepath.Abs(sourceRef)
+		if err != nil {
+			return volumestore.WritableVolume{}, err
+		}
+		if _, err := os.Stat(rootfsPath); err != nil {
+			return volumestore.WritableVolume{}, fmt.Errorf("rootfs %s: %w", rootfsPath, err)
+		}
+
+		baseVolume, err := driver.EnsureBaseVolume(ctx, volumestore.EnsureBaseVolumeRequest{
+			BaseID:     strings.TrimSuffix(filepath.Base(rootfsPath), filepath.Ext(rootfsPath)),
+			SourcePath: rootfsPath,
+		})
+		if err != nil {
+			return volumestore.WritableVolume{}, fmt.Errorf("prepare base volume: %w", err)
+		}
+		return driver.CreateWritableVolume(ctx, volumestore.CreateWritableVolumeRequest{
+			VolumeID:       sandboxID,
+			BaseRef:        baseVolume.Ref,
+			AttachmentPath: attachmentPath,
+		})
+	}
+
+	return driver.CloneSnapshotToVolume(ctx, volumestore.CloneSnapshotToVolumeRequest{
+		VolumeID:       sandboxID,
+		SnapshotRef:    sourceRef,
+		AttachmentPath: attachmentPath,
+	})
+}
+
+func snapshotVolumeRef(instance *sandboxInstance) string {
+	if instance == nil {
+		return ""
+	}
+	if volumeRef := strings.TrimSpace(instance.volumeRef); volumeRef != "" {
+		return volumeRef
+	}
+	return strings.TrimSpace(instance.vmRootFSPath)
+}
+
 func snapshotStorageBaseDir(cfg backend.FirecrackerConfig) (string, error) {
 	if baseDir := strings.TrimSpace(cfg.Snapshots.BaseDir); baseDir != "" {
 		return filepath.Clean(baseDir), nil
 	}
 	return paths.SnapshotDir()
+}
+
+type rootVolumeCommandRunner struct {
+	cfg backend.FirecrackerConfig
+}
+
+func (r rootVolumeCommandRunner) Run(ctx context.Context, command string, args ...string) error {
+	return runRootCommand(ctx, r.cfg, append([]string{command}, args...)...)
+}
+
+func (r rootVolumeCommandRunner) Output(ctx context.Context, command string, args ...string) ([]byte, error) {
+	return runRootCommandOutput(ctx, r.cfg, append([]string{command}, args...)...)
 }
 
 func volumeStoreDriver(cfg backend.FirecrackerConfig) (volumestore.Driver, error) {
@@ -1715,7 +1799,14 @@ func volumeStoreDriver(cfg backend.FirecrackerConfig) (volumestore.Driver, error
 		}
 		return driver, nil
 	case "zfs":
-		return nil, errors.New("firecracker snapshot driver \"zfs\" is not implemented")
+		driver, err := volumestore.NewZFSDriver(volumestore.ZFSDriverOptions{
+			DatasetRoot: cfg.Snapshots.ZFSDataset,
+			Runner:      rootVolumeCommandRunner{cfg: cfg},
+		})
+		if err != nil {
+			return nil, err
+		}
+		return driver, nil
 	default:
 		return nil, fmt.Errorf("unsupported firecracker snapshot driver %q", cfg.Snapshots.Driver)
 	}
@@ -1749,11 +1840,14 @@ func (s *sandboxInstance) shutdown() {
 	if s.cleanupNetwork != nil {
 		s.cleanupNetwork()
 	}
+	if s.cleanupVolume != nil {
+		s.cleanupVolume()
+	}
 	if strings.TrimSpace(s.RunDir) != "" {
 		_ = os.RemoveAll(s.RunDir)
 		return
 	}
-	if strings.TrimSpace(s.vmRootFSPath) != "" {
+	if strings.TrimSpace(s.vmRootFSPath) != "" && s.cleanupVolume == nil {
 		_ = os.Remove(s.vmRootFSPath)
 	}
 }
@@ -2220,6 +2314,22 @@ func logRunNotice(backendName, runID, notice string) {
 	log.Printf("%s run_id=%s: %s", backendName, id, msg)
 }
 
+func lookPathWithFallback(binary string, candidates ...string) (string, error) {
+	if p, err := exec.LookPath(binary); err == nil {
+		return p, nil
+	}
+	for _, candidate := range candidates {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" {
+			continue
+		}
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("%q not found in PATH or fallback locations", binary)
+}
+
 func runRootCommand(ctx context.Context, cfg backend.FirecrackerConfig, args ...string) error {
 	if len(args) == 0 {
 		return errors.New("missing privileged command")
@@ -2239,6 +2349,25 @@ func runRootCommand(ctx context.Context, cfg backend.FirecrackerConfig, args ...
 	}
 }
 
+func runRootCommandOutput(ctx context.Context, cfg backend.FirecrackerConfig, args ...string) ([]byte, error) {
+	if len(args) == 0 {
+		return nil, errors.New("missing privileged command")
+	}
+
+	mode, helperPath := resolvePrivilegedExecution(cfg)
+	switch mode {
+	case privilegedModeSudo:
+		return runCombinedCommandOutput(ctx, append([]string{"sudo", "-n"}, args...), args)
+	case privilegedModeHelper:
+		if strings.TrimSpace(helperPath) == "" {
+			return nil, errors.New("privileged helper mode requires helper path")
+		}
+		return runCombinedCommandOutput(ctx, append([]string{"sudo", "-n", helperPath}, args...), append([]string{"helper"}, args...))
+	default:
+		return nil, fmt.Errorf("unsupported privileged command mode %q", mode)
+	}
+}
+
 func runRootCommandBatch(ctx context.Context, cfg backend.FirecrackerConfig, commands [][]string) error {
 	for _, args := range commands {
 		if len(args) == 0 {
@@ -2249,7 +2378,7 @@ func runRootCommandBatch(ctx context.Context, cfg backend.FirecrackerConfig, com
 	return nil
 }
 
-func runCombinedCommand(ctx context.Context, command []string, errorContext []string) error {
+func runCombinedCommandOutput(ctx context.Context, command []string, errorContext []string) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, command[0], command[1:]...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -2257,9 +2386,14 @@ func runCombinedCommand(ctx context.Context, command []string, errorContext []st
 		if msg == "" {
 			msg = "no stderr output"
 		}
-		return fmt.Errorf("%s: %w (%s)", strings.Join(errorContext, " "), err, msg)
+		return nil, fmt.Errorf("%s: %w (%s)", strings.Join(errorContext, " "), err, msg)
 	}
-	return nil
+	return out, nil
+}
+
+func runCombinedCommand(ctx context.Context, command []string, errorContext []string) error {
+	_, err := runCombinedCommandOutput(ctx, command, errorContext)
+	return err
 }
 
 func durationMillisCeil(d time.Duration) int64 {

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/buildkite/cleanroom/internal/backend"
@@ -53,11 +54,12 @@ type Adapter struct {
 
 	runtimeImageMu sync.Mutex
 
-	sandboxMu         sync.Mutex
-	sandboxes         map[string]*sandboxInstance
-	provisioning      map[string]struct{}
-	launchSandboxVMFn func(context.Context, string, *policy.CompiledPolicy, backend.FirecrackerConfig) (*sandboxInstance, error)
-	runGuestCommandFn func(context.Context, context.Context, <-chan struct{}, func() error, string, uint32, vsockexec.ExecRequest, backend.OutputStream) (vsockexec.ExecResponse, guestExecTiming, error)
+	sandboxMu                   sync.Mutex
+	sandboxes                   map[string]*sandboxInstance
+	provisioning                map[string]struct{}
+	launchSandboxVMFn           func(context.Context, string, *policy.CompiledPolicy, backend.FirecrackerConfig) (*sandboxInstance, error)
+	launchSandboxVMFromRootFSFn func(context.Context, string, *policy.CompiledPolicy, backend.FirecrackerConfig, string) (*sandboxInstance, error)
+	runGuestCommandFn           func(context.Context, context.Context, <-chan struct{}, func() error, string, uint32, vsockexec.ExecRequest, backend.OutputStream) (vsockexec.ExecResponse, guestExecTiming, error)
 
 	GatewayRegistry gatewayRegistry
 	GatewayPort     int
@@ -97,6 +99,14 @@ const privilegedModeSudo = "sudo"
 const privilegedModeHelper = "helper"
 const defaultPrivilegedHelperPath = "/usr/local/sbin/cleanroom-root-helper"
 const defaultDownloadMaxBytes int64 = 10 * 1024 * 1024
+const snapshotSyncTimeoutSeconds = 10
+
+var sendProcessSignal = func(proc *os.Process, sig syscall.Signal) error {
+	if proc == nil {
+		return errors.New("missing process")
+	}
+	return proc.Signal(sig)
+}
 
 const guestInitScriptTemplate = `#!/bin/sh
 set -eu
@@ -435,6 +445,173 @@ func (a *Adapter) TerminateSandbox(_ context.Context, sandboxID string) error {
 		a.GatewayRegistry.Release(instance.GuestIP)
 	}
 	instance.shutdown()
+	return nil
+}
+
+func (a *Adapter) CreateSnapshot(ctx context.Context, req backend.SnapshotRequest) (*backend.SnapshotResult, error) {
+	sandboxID := strings.TrimSpace(req.SandboxID)
+	if sandboxID == "" {
+		return nil, errors.New("missing sandbox_id")
+	}
+	snapshotID := strings.TrimSpace(req.SnapshotID)
+	if snapshotID == "" {
+		return nil, errors.New("missing snapshot_id")
+	}
+
+	a.sandboxMu.Lock()
+	instance, ok := a.sandboxes[sandboxID]
+	a.sandboxMu.Unlock()
+	if !ok {
+		return nil, fmt.Errorf("unknown sandbox %q", sandboxID)
+	}
+	if err := instance.exitedErrOrNil(); err != nil {
+		return nil, fmt.Errorf("sandbox %q is not running: %w", sandboxID, err)
+	}
+
+	if _, _, err := a.executeInSandbox(ctx, instance, snapshotSyncTimeoutSeconds, []string{"sync"}, false, backend.OutputStream{}); err != nil {
+		return nil, fmt.Errorf("sync sandbox filesystem before snapshot: %w", err)
+	}
+
+	snapshotPath, err := snapshotStoragePath(snapshotID)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(filepath.Dir(snapshotPath), 0o755); err != nil {
+		return nil, fmt.Errorf("create snapshot directory: %w", err)
+	}
+	if err := pauseSandboxProcess(instance); err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = resumeSandboxProcess(instance)
+	}()
+
+	if err := copyFile(instance.vmRootFSPath, snapshotPath); err != nil {
+		_ = os.Remove(snapshotPath)
+		return nil, fmt.Errorf("persist snapshot rootfs: %w", err)
+	}
+
+	return &backend.SnapshotResult{StorageRef: snapshotPath}, nil
+}
+
+func (a *Adapter) ProvisionSandboxFromSnapshot(ctx context.Context, req backend.ProvisionFromSnapshotRequest) error {
+	sandboxID := strings.TrimSpace(req.SandboxID)
+	if sandboxID == "" {
+		return errors.New("missing sandbox_id")
+	}
+	if req.Policy == nil {
+		return errors.New("missing compiled policy")
+	}
+	storageRef := strings.TrimSpace(req.StorageRef)
+	if storageRef == "" {
+		return errors.New("missing snapshot storage_ref")
+	}
+
+	a.sandboxMu.Lock()
+	if a.sandboxes == nil {
+		a.sandboxes = map[string]*sandboxInstance{}
+	}
+	if a.provisioning == nil {
+		a.provisioning = map[string]struct{}{}
+	}
+	if _, exists := a.sandboxes[sandboxID]; exists {
+		a.sandboxMu.Unlock()
+		return fmt.Errorf("sandbox %q already provisioned", sandboxID)
+	}
+	if _, exists := a.provisioning[sandboxID]; exists {
+		a.sandboxMu.Unlock()
+		return fmt.Errorf("sandbox %q is already provisioning", sandboxID)
+	}
+	a.provisioning[sandboxID] = struct{}{}
+	a.sandboxMu.Unlock()
+
+	launch := a.launchSandboxVMFromRootFSFn
+	if launch == nil {
+		launch = a.launchSandboxVMFromRootFS
+	}
+	instance, err := launch(ctx, sandboxID, req.Policy, req.FirecrackerConfig, storageRef)
+	if err != nil {
+		a.sandboxMu.Lock()
+		delete(a.provisioning, sandboxID)
+		a.sandboxMu.Unlock()
+		return err
+	}
+
+	a.sandboxMu.Lock()
+	defer a.sandboxMu.Unlock()
+	delete(a.provisioning, sandboxID)
+	if _, exists := a.sandboxes[sandboxID]; exists {
+		instance.shutdown()
+		return fmt.Errorf("sandbox %q already provisioned", sandboxID)
+	}
+	a.sandboxes[sandboxID] = instance
+	return nil
+}
+
+func (a *Adapter) RestoreSandbox(ctx context.Context, req backend.RestoreRequest) error {
+	sandboxID := strings.TrimSpace(req.SandboxID)
+	if sandboxID == "" {
+		return errors.New("missing sandbox_id")
+	}
+	if req.Policy == nil {
+		return errors.New("missing compiled policy")
+	}
+	storageRef := strings.TrimSpace(req.StorageRef)
+	if storageRef == "" {
+		return errors.New("missing snapshot storage_ref")
+	}
+
+	a.sandboxMu.Lock()
+	if a.sandboxes == nil {
+		a.sandboxes = map[string]*sandboxInstance{}
+	}
+	if a.provisioning == nil {
+		a.provisioning = map[string]struct{}{}
+	}
+	instance, ok := a.sandboxes[sandboxID]
+	if !ok {
+		a.sandboxMu.Unlock()
+		return fmt.Errorf("unknown sandbox %q", sandboxID)
+	}
+	if _, exists := a.provisioning[sandboxID]; exists {
+		a.sandboxMu.Unlock()
+		return fmt.Errorf("sandbox %q is already provisioning", sandboxID)
+	}
+	a.provisioning[sandboxID] = struct{}{}
+	delete(a.sandboxes, sandboxID)
+	a.sandboxMu.Unlock()
+
+	if a.GatewayRegistry != nil && instance.GuestIP != "" {
+		a.GatewayRegistry.Release(instance.GuestIP)
+	}
+	instance.shutdown()
+
+	launch := a.launchSandboxVMFromRootFSFn
+	if launch == nil {
+		launch = a.launchSandboxVMFromRootFS
+	}
+	replacement, err := launch(ctx, sandboxID, req.Policy, req.FirecrackerConfig, storageRef)
+	a.sandboxMu.Lock()
+	defer a.sandboxMu.Unlock()
+	delete(a.provisioning, sandboxID)
+	if err != nil {
+		return err
+	}
+	a.sandboxes[sandboxID] = replacement
+	return nil
+}
+
+func (a *Adapter) DeleteSnapshot(_ context.Context, req backend.DeleteSnapshotRequest) error {
+	storageRef := strings.TrimSpace(req.StorageRef)
+	if storageRef == "" {
+		return errors.New("missing snapshot storage_ref")
+	}
+	if err := os.Remove(storageRef); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove snapshot rootfs %q: %w", storageRef, err)
+	}
+	if dir := filepath.Dir(storageRef); dir != "" {
+		_ = os.Remove(dir)
+	}
 	return nil
 }
 
@@ -1252,13 +1429,33 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 	if compiled == nil {
 		return nil, errors.New("missing compiled policy")
 	}
+	imageArtifact, err := a.ensureImageArtifact(ctx, compiled.ImageRef)
+	if err != nil {
+		return nil, err
+	}
+	preparedRootFSPath, err := a.ensurePreparedRuntimeRootFS(ctx, cfg, imageArtifact)
+	if err != nil {
+		return nil, err
+	}
+	instance, err := a.launchSandboxVMFromRootFS(ctx, sandboxID, compiled, cfg, preparedRootFSPath)
+	if err != nil {
+		return nil, err
+	}
+	instance.ImageRef = imageArtifact.Ref
+	instance.ImageDigest = imageArtifact.Digest
+	return instance, nil
+}
+
+func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID string, compiled *policy.CompiledPolicy, cfg backend.FirecrackerConfig, sourceRootFSPath string) (*sandboxInstance, error) {
+	if compiled == nil {
+		return nil, errors.New("missing compiled policy")
+	}
 	if compiled.NetworkDefault != "deny" {
 		return nil, fmt.Errorf("firecracker backend requires deny-by-default policy, got %q", compiled.NetworkDefault)
 	}
 	if runtime.GOOS != "linux" {
 		return nil, fmt.Errorf("firecracker backend is linux-only, current OS is %s", runtime.GOOS)
 	}
-
 	if cfg.VCPUs <= 0 {
 		cfg.VCPUs = 1
 	}
@@ -1288,15 +1485,6 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 		return nil, err
 	}
 
-	imageArtifact, err := a.ensureImageArtifact(ctx, compiled.ImageRef)
-	if err != nil {
-		return nil, err
-	}
-	preparedRootFSPath, err := a.ensurePreparedRuntimeRootFS(ctx, cfg, imageArtifact)
-	if err != nil {
-		return nil, err
-	}
-
 	runBaseDir, err := sandboxRuntimeBaseDir()
 	if err != nil {
 		return nil, fmt.Errorf("resolve sandbox runtime base directory: %w", err)
@@ -1312,7 +1500,7 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 		return nil, err
 	}
 
-	rootfsPath, err := filepath.Abs(preparedRootFSPath)
+	rootfsPath, err := filepath.Abs(sourceRootFSPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1434,8 +1622,8 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 		VsockPath:      vsockPath,
 		GuestPort:      cfg.GuestPort,
 		Policy:         compiled,
-		ImageRef:       imageArtifact.Ref,
-		ImageDigest:    imageArtifact.Digest,
+		ImageRef:       compiled.ImageRef,
+		ImageDigest:    compiled.ImageDigest,
 		CommandTimeout: cfg.LaunchSeconds,
 		HostIP:         networkCfg.HostIP,
 		GuestIP:        networkCfg.GuestIP,
@@ -1477,6 +1665,34 @@ func sandboxRuntimeBaseDir() (string, error) {
 		return "", err
 	}
 	return filepath.Join(base, "sandboxes"), nil
+}
+
+func snapshotStoragePath(snapshotID string) (string, error) {
+	base, err := paths.SnapshotDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve snapshot base directory: %w", err)
+	}
+	return filepath.Join(base, "firecracker", snapshotID, "rootfs.ext4"), nil
+}
+
+func pauseSandboxProcess(instance *sandboxInstance) error {
+	if instance == nil || instance.fcCmd == nil || instance.fcCmd.Process == nil {
+		return errors.New("sandbox process is not available")
+	}
+	if err := sendProcessSignal(instance.fcCmd.Process, syscall.SIGSTOP); err != nil {
+		return fmt.Errorf("pause sandbox process: %w", err)
+	}
+	return nil
+}
+
+func resumeSandboxProcess(instance *sandboxInstance) error {
+	if instance == nil || instance.fcCmd == nil || instance.fcCmd.Process == nil {
+		return errors.New("sandbox process is not available")
+	}
+	if err := sendProcessSignal(instance.fcCmd.Process, syscall.SIGCONT); err != nil {
+		return fmt.Errorf("resume sandbox process: %w", err)
+	}
+	return nil
 }
 
 func (s *sandboxInstance) shutdown() {

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -14,6 +14,7 @@ import (
 	"log"
 	"math"
 	"net"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -32,6 +33,7 @@ import (
 	"github.com/buildkite/cleanroom/internal/paths"
 	"github.com/buildkite/cleanroom/internal/policy"
 	"github.com/buildkite/cleanroom/internal/volumestore"
+	"github.com/buildkite/cleanroom/internal/vsockcontrol"
 	"github.com/buildkite/cleanroom/internal/vsockexec"
 	fcvsock "github.com/firecracker-microvm/firecracker-go-sdk/vsock"
 )
@@ -61,6 +63,7 @@ type Adapter struct {
 	launchSandboxVMFn           func(context.Context, string, *policy.CompiledPolicy, backend.FirecrackerConfig) (*sandboxInstance, error)
 	launchSandboxVMFromRootFSFn func(context.Context, string, *policy.CompiledPolicy, backend.FirecrackerConfig, string) (*sandboxInstance, error)
 	runGuestCommandFn           func(context.Context, context.Context, <-chan struct{}, func() error, string, uint32, vsockexec.ExecRequest, backend.OutputStream) (vsockexec.ExecResponse, guestExecTiming, error)
+	quiesceGuestFn              func(context.Context, *sandboxInstance, int64) error
 
 	GatewayRegistry gatewayRegistry
 	GatewayPort     int
@@ -93,6 +96,7 @@ type sandboxInstance struct {
 	cleanupVolume  func()
 	vmRootFSPath   string
 	volumeRef      string
+	apiSocketPath  string
 }
 
 const runObservabilityFile = "run-observability.json"
@@ -474,20 +478,34 @@ func (a *Adapter) CreateSnapshot(ctx context.Context, req backend.SnapshotReques
 		return nil, fmt.Errorf("sandbox %q is not running: %w", sandboxID, err)
 	}
 
-	if _, _, err := a.executeInSandbox(ctx, instance, snapshotSyncTimeoutSeconds, []string{"sync"}, false, backend.OutputStream{}); err != nil {
-		return nil, fmt.Errorf("sync sandbox filesystem before snapshot: %w", err)
+	quiesce := a.quiesceGuest
+	if a.quiesceGuestFn != nil {
+		quiesce = a.quiesceGuestFn
+	}
+	if err := quiesce(ctx, instance, req.FirecrackerConfig.Snapshots.QuiesceTimeoutSeconds); err != nil {
+		return nil, fmt.Errorf("quiesce sandbox before snapshot: %w", err)
 	}
 
 	driver, err := volumeStoreDriver(req.FirecrackerConfig)
 	if err != nil {
 		return nil, err
 	}
-	if err := pauseSandboxProcess(instance); err != nil {
-		return nil, err
+
+	if instance.apiSocketPath != "" {
+		if err := pauseVMViaAPI(instance.apiSocketPath); err != nil {
+			return nil, fmt.Errorf("pause VM for snapshot: %w", err)
+		}
+		defer func() {
+			_ = resumeVMViaAPI(instance.apiSocketPath)
+		}()
+	} else {
+		if err := pauseSandboxProcess(instance); err != nil {
+			return nil, err
+		}
+		defer func() {
+			_ = resumeSandboxProcess(instance)
+		}()
 	}
-	defer func() {
-		_ = resumeSandboxProcess(instance)
-	}()
 
 	volumeRef := snapshotVolumeRef(instance)
 	if volumeRef == "" {
@@ -1680,6 +1698,7 @@ func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID strin
 		cleanupVolume:  cleanupVolume,
 		vmRootFSPath:   vmRootFSPath,
 		volumeRef:      writableVolume.Ref,
+		apiSocketPath:  apiSocket,
 	}
 	go func() {
 		err := fcCmd.Wait()
@@ -1733,7 +1752,7 @@ func preparePersistentWritableVolume(ctx context.Context, driver volumestore.Dri
 		}
 
 		baseVolume, err := driver.EnsureBaseVolume(ctx, volumestore.EnsureBaseVolumeRequest{
-			BaseID:     strings.TrimSuffix(filepath.Base(rootfsPath), filepath.Ext(rootfsPath)),
+			BaseID:     baseVolumeID(rootfsPath),
 			SourcePath: rootfsPath,
 		})
 		if err != nil {
@@ -1751,6 +1770,11 @@ func preparePersistentWritableVolume(ctx context.Context, driver volumestore.Dri
 		SnapshotRef:    sourceRef,
 		AttachmentPath: attachmentPath,
 	})
+}
+
+func baseVolumeID(rootfsPath string) string {
+	sum := sha256.Sum256([]byte(rootfsPath))
+	return hex.EncodeToString(sum[:16])
 }
 
 func snapshotVolumeRef(instance *sandboxInstance) string {
@@ -1828,6 +1852,81 @@ func resumeSandboxProcess(instance *sandboxInstance) error {
 	}
 	if err := sendProcessSignal(instance.fcCmd.Process, syscall.SIGCONT); err != nil {
 		return fmt.Errorf("resume sandbox process: %w", err)
+	}
+	return nil
+}
+
+func pauseVMViaAPI(apiSocketPath string) error {
+	if apiSocketPath == "" {
+		return errors.New("missing firecracker API socket path")
+	}
+	return firecrackerAPIPatch(apiSocketPath, `{"state":"Paused"}`)
+}
+
+func resumeVMViaAPI(apiSocketPath string) error {
+	if apiSocketPath == "" {
+		return errors.New("missing firecracker API socket path")
+	}
+	return firecrackerAPIPatch(apiSocketPath, `{"state":"Resumed"}`)
+}
+
+func firecrackerAPIPatch(socketPath, body string) error {
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: &http.Transport{
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("unix", socketPath)
+			},
+		},
+	}
+	req, err := http.NewRequest(http.MethodPatch, "http://localhost/vm", strings.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create firecracker API request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("firecracker API request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("firecracker API returned %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+	return nil
+}
+
+func (a *Adapter) quiesceGuest(ctx context.Context, instance *sandboxInstance, quiesceTimeoutSeconds int64) error {
+	if quiesceTimeoutSeconds <= 0 {
+		quiesceTimeoutSeconds = 10
+	}
+	connectTimeout := time.Duration(quiesceTimeoutSeconds+5) * time.Second
+	connectCtx, connectCancel := context.WithTimeout(ctx, connectTimeout)
+	defer connectCancel()
+
+	conn, err := dialVsockUntilReady(connectCtx, instance.exitedCh, instance.exitedErrOrNil, instance.VsockPath, instance.GuestPort)
+	if err != nil {
+		return fmt.Errorf("connect to guest for quiesce: %w", err)
+	}
+	defer conn.Close()
+
+	if err := vsockcontrol.EncodeQuiesceRequest(conn, vsockcontrol.QuiesceRequest{
+		Type:           "quiesce",
+		TimeoutSeconds: quiesceTimeoutSeconds,
+	}); err != nil {
+		return fmt.Errorf("send quiesce request: %w", err)
+	}
+
+	resp, err := vsockcontrol.DecodeQuiesceResponse(conn)
+	if err != nil {
+		return fmt.Errorf("read quiesce response: %w", err)
+	}
+	if !resp.OK {
+		errMsg := resp.Error
+		if errMsg == "" {
+			errMsg = "quiesce failed"
+		}
+		return fmt.Errorf("guest quiesce failed: %s", errMsg)
 	}
 	return nil
 }

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -475,7 +475,7 @@ func (a *Adapter) CreateSnapshot(ctx context.Context, req backend.SnapshotReques
 		return nil, fmt.Errorf("sync sandbox filesystem before snapshot: %w", err)
 	}
 
-	snapshotPath, err := snapshotStoragePath(snapshotID)
+	snapshotPath, err := snapshotStoragePath(req.FirecrackerConfig, snapshotID)
 	if err != nil {
 		return nil, err
 	}
@@ -1670,12 +1670,19 @@ func sandboxRuntimeBaseDir() (string, error) {
 	return filepath.Join(base, "sandboxes"), nil
 }
 
-func snapshotStoragePath(snapshotID string) (string, error) {
-	base, err := paths.SnapshotDir()
+func snapshotStoragePath(cfg backend.FirecrackerConfig, snapshotID string) (string, error) {
+	base, err := snapshotStorageBaseDir(cfg)
 	if err != nil {
 		return "", fmt.Errorf("resolve snapshot base directory: %w", err)
 	}
 	return filepath.Join(base, "firecracker", snapshotID, "rootfs.ext4"), nil
+}
+
+func snapshotStorageBaseDir(cfg backend.FirecrackerConfig) (string, error) {
+	if baseDir := strings.TrimSpace(cfg.Snapshots.BaseDir); baseDir != "" {
+		return filepath.Clean(baseDir), nil
+	}
+	return paths.SnapshotDir()
 }
 
 func pauseSandboxProcess(instance *sandboxInstance) error {

--- a/internal/backend/firecracker/network_test.go
+++ b/internal/backend/firecracker/network_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -146,6 +147,89 @@ func TestSetupHostNetworkWithDepsAddsDenyDefaultAndCleanupIndependentContext(t *
 	}
 	if cleanupCalls == 0 {
 		t.Fatal("expected cleanup commands")
+	}
+}
+
+func TestSetupHostNetworkWithTapLookupDeletesStaleTapBeforeCreate(t *testing.T) {
+	t.Parallel()
+
+	runID := "run-12345"
+	tapName := tapNameFromRunID(runID)
+	staleTapExists := true
+
+	var calls [][]string
+	run := func(_ context.Context, args ...string) error {
+		calls = append(calls, append([]string(nil), args...))
+		if isTapDeleteCommand(args, tapName) {
+			staleTapExists = false
+		}
+		return nil
+	}
+	lookup := func(_ context.Context, host string) ([]net.IP, error) {
+		if host != "proxy.golang.org" {
+			t.Fatalf("unexpected host %q", host)
+		}
+		return []net.IP{net.ParseIP("142.251.41.17")}, nil
+	}
+	interfaceByName := func(name string) (*net.Interface, error) {
+		if name != tapName {
+			t.Fatalf("unexpected interface lookup %q", name)
+		}
+		if staleTapExists {
+			return &net.Interface{Name: name}, nil
+		}
+		return nil, errors.New("not found")
+	}
+
+	_, cleanup, err := setupHostNetworkWithTapLookup(context.Background(), runID, []policy.AllowRule{{Host: "proxy.golang.org", Ports: []int{443}}}, 0, lookup, interfaceByName, run, nil)
+	if err != nil {
+		t.Fatalf("setupHostNetworkWithTapLookup: %v", err)
+	}
+	defer cleanup()
+
+	if len(calls) < 2 {
+		t.Fatalf("expected at least two commands, got %d", len(calls))
+	}
+	if got, want := strings.Join(calls[0], " "), "ip link del "+tapName; got != want {
+		t.Fatalf("unexpected first command: got %q want %q", got, want)
+	}
+	if got, want := strings.Join(calls[1], " "), "ip tuntap add dev "+tapName+" mode tap user "+strconv.Itoa(os.Getuid()); got != want {
+		t.Fatalf("unexpected second command: got %q want %q", got, want)
+	}
+}
+
+func TestDeleteTapDeviceWithRetryRetriesBusyTapDeletion(t *testing.T) {
+	t.Parallel()
+
+	tapName := "tap0"
+	tapExists := true
+	attempts := 0
+	run := func(_ context.Context, args ...string) error {
+		if got, want := strings.Join(args, " "), "ip link del "+tapName; got != want {
+			t.Fatalf("unexpected delete command: got %q want %q", got, want)
+		}
+		attempts++
+		if attempts == 1 {
+			return errors.New("device busy")
+		}
+		tapExists = false
+		return nil
+	}
+	interfaceByName := func(name string) (*net.Interface, error) {
+		if name != tapName {
+			t.Fatalf("unexpected interface lookup %q", name)
+		}
+		if tapExists {
+			return &net.Interface{Name: name}, nil
+		}
+		return nil, errors.New("not found")
+	}
+
+	if err := deleteTapDeviceWithRetry(context.Background(), tapName, time.Millisecond, interfaceByName, run); err != nil {
+		t.Fatalf("deleteTapDeviceWithRetry: %v", err)
+	}
+	if got, want := attempts, 2; got != want {
+		t.Fatalf("unexpected delete attempts: got %d want %d", got, want)
 	}
 }
 

--- a/internal/backend/firecracker/network_test.go
+++ b/internal/backend/firecracker/network_test.go
@@ -178,7 +178,7 @@ func TestSetupHostNetworkWithTapLookupDeletesStaleTapBeforeCreate(t *testing.T) 
 		if staleTapExists {
 			return &net.Interface{Name: name}, nil
 		}
-		return nil, errors.New("not found")
+		return nil, errors.New("no such network interface")
 	}
 
 	_, cleanup, err := setupHostNetworkWithTapLookup(context.Background(), runID, []policy.AllowRule{{Host: "proxy.golang.org", Ports: []int{443}}}, 0, lookup, interfaceByName, run, nil)
@@ -222,13 +222,44 @@ func TestDeleteTapDeviceWithRetryRetriesBusyTapDeletion(t *testing.T) {
 		if tapExists {
 			return &net.Interface{Name: name}, nil
 		}
-		return nil, errors.New("not found")
+		return nil, errors.New("no such network interface")
 	}
 
 	if err := deleteTapDeviceWithRetry(context.Background(), tapName, time.Millisecond, interfaceByName, run); err != nil {
 		t.Fatalf("deleteTapDeviceWithRetry: %v", err)
 	}
 	if got, want := attempts, 2; got != want {
+		t.Fatalf("unexpected delete attempts: got %d want %d", got, want)
+	}
+}
+
+func TestDeleteTapDeviceWithRetryReturnsLookupError(t *testing.T) {
+	t.Parallel()
+
+	tapName := "tap0"
+	attempts := 0
+	run := func(_ context.Context, args ...string) error {
+		if got, want := strings.Join(args, " "), "ip link del "+tapName; got != want {
+			t.Fatalf("unexpected delete command: got %q want %q", got, want)
+		}
+		attempts++
+		return errors.New("device busy")
+	}
+	interfaceByName := func(name string) (*net.Interface, error) {
+		if name != tapName {
+			t.Fatalf("unexpected interface lookup %q", name)
+		}
+		return nil, errors.New("permission denied")
+	}
+
+	err := deleteTapDeviceWithRetry(context.Background(), tapName, time.Millisecond, interfaceByName, run)
+	if err == nil {
+		t.Fatal("expected lookup error")
+	}
+	if !strings.Contains(err.Error(), "lookup tap device") || !strings.Contains(err.Error(), "permission denied") {
+		t.Fatalf("unexpected lookup error: %v", err)
+	}
+	if got, want := attempts, 1; got != want {
 		t.Fatalf("unexpected delete attempts: got %d want %d", got, want)
 	}
 }

--- a/internal/backend/firecracker/persistent_test.go
+++ b/internal/backend/firecracker/persistent_test.go
@@ -76,6 +76,23 @@ func TestSandboxShutdownRemovesRunDir(t *testing.T) {
 	}
 }
 
+func TestSandboxShutdownInvokesCleanupVolume(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	instance := &sandboxInstance{
+		RunDir: t.TempDir(),
+		cleanupVolume: func() {
+			called = true
+		},
+	}
+	instance.shutdown()
+
+	if !called {
+		t.Fatal("expected cleanupVolume to be invoked")
+	}
+}
+
 func TestRunInSandboxUsesRequestLaunchSecondsOverride(t *testing.T) {
 	t.Parallel()
 

--- a/internal/backend/firecracker/privileged_test.go
+++ b/internal/backend/firecracker/privileged_test.go
@@ -10,6 +10,25 @@ import (
 	"github.com/buildkite/cleanroom/internal/backend"
 )
 
+func writeExecutable(t *testing.T, dir, name, content string) string {
+	t.Helper()
+
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+		t.Fatalf("write executable %s: %v", name, err)
+	}
+	return path
+}
+
+func doctorCheck(report *backend.DoctorReport, name string) backend.DoctorCheck {
+	for _, check := range report.Checks {
+		if check.Name == name {
+			return check
+		}
+	}
+	return backend.DoctorCheck{}
+}
+
 func setupFakeSudo(t *testing.T, logPath string) {
 	t.Helper()
 
@@ -108,6 +127,94 @@ func TestRunRootCommandBatchHelperModeInvokesHelperPerCommand(t *testing.T) {
 	sudoLines := strings.Split(strings.TrimSpace(string(sudoLogBytes)), "\n")
 	if len(sudoLines) != 2 {
 		t.Fatalf("expected two sudo invocations, got %d (%q)", len(sudoLines), string(sudoLogBytes))
+	}
+}
+
+func TestRunRootCommandOutputHelperModeInvokesHelper(t *testing.T) {
+	tmpDir := t.TempDir()
+	sudoLogPath := filepath.Join(tmpDir, "sudo.log")
+	logPath := filepath.Join(tmpDir, "helper.log")
+	helperPath := filepath.Join(tmpDir, "cleanroom-root-helper")
+	setupFakeSudo(t, sudoLogPath)
+
+	helperScript := "#!/bin/sh\nset -eu\nprintf '%s\\n' \"$*\" >> \"$HELPER_LOG_PATH\"\nif [ \"$1\" = \"zfs\" ] && [ \"$2\" = \"list\" ] && [ \"$3\" = \"-H\" ] && [ \"$4\" = \"-o\" ] && [ \"$5\" = \"name\" ]; then printf '%s\\n' \"$6\"; fi\n"
+	if err := os.WriteFile(helperPath, []byte(helperScript), 0o755); err != nil {
+		t.Fatalf("write helper script: %v", err)
+	}
+	t.Setenv("HELPER_LOG_PATH", logPath)
+
+	cfg := backend.FirecrackerConfig{
+		PrivilegedMode:       privilegedModeHelper,
+		PrivilegedHelperPath: helperPath,
+	}
+
+	out, err := runRootCommandOutput(context.Background(), cfg, "zfs", "list", "-H", "-o", "name", "tank/cleanroom")
+	if err != nil {
+		t.Fatalf("runRootCommandOutput: %v", err)
+	}
+	if got, want := strings.TrimSpace(string(out)), "tank/cleanroom"; got != want {
+		t.Fatalf("unexpected helper output: got %q want %q", got, want)
+	}
+
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read helper log: %v", err)
+	}
+	if got := strings.TrimSpace(string(logBytes)); got != "zfs list -H -o name tank/cleanroom" {
+		t.Fatalf("unexpected helper invocation: got %q", got)
+	}
+}
+
+func TestDoctorReportsZFSChecks(t *testing.T) {
+	tmpDir := t.TempDir()
+	sudoLogPath := filepath.Join(tmpDir, "sudo.log")
+	setupFakeSudo(t, sudoLogPath)
+
+	binDir := filepath.Join(tmpDir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin dir: %v", err)
+	}
+
+	writeExecutable(t, binDir, "firecracker", "#!/bin/sh\nexit 0\n")
+	writeExecutable(t, binDir, "cleanroom-guest-agent", "#!/bin/sh\nexit 0\n")
+	writeExecutable(t, binDir, "mkfs.ext4", "#!/bin/sh\nexit 0\n")
+	writeExecutable(t, binDir, "iptables", "#!/bin/sh\nexit 0\n")
+	writeExecutable(t, binDir, "sysctl", "#!/bin/sh\nexit 0\n")
+	writeExecutable(t, binDir, "true", "#!/bin/sh\nexit 0\n")
+	writeExecutable(t, binDir, "ip", "#!/bin/sh\nif [ \"$1\" = \"link\" ] && [ \"$2\" = \"show\" ]; then exit 0; fi\nexit 0\n")
+	writeExecutable(t, binDir, "zfs", "#!/bin/sh\nif [ \"$1\" = \"list\" ] && [ \"$2\" = \"-H\" ] && [ \"$3\" = \"-o\" ] && [ \"$4\" = \"name\" ]; then printf '%s\\n' \"$5\"; exit 0; fi\nexit 0\n")
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	kernelPath := filepath.Join(tmpDir, "vmlinux")
+	if err := os.WriteFile(kernelPath, []byte("kernel"), 0o644); err != nil {
+		t.Fatalf("write kernel image: %v", err)
+	}
+
+	report, err := (&Adapter{}).Doctor(context.Background(), backend.DoctorRequest{
+		FirecrackerConfig: backend.FirecrackerConfig{
+			BinaryPath:      "firecracker",
+			KernelImagePath: kernelPath,
+			Snapshots: backend.SnapshotConfig{
+				Driver:     "zfs",
+				ZFSDataset: "tank/cleanroom",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Doctor returned error: %v", err)
+	}
+
+	if got := doctorCheck(report, "snapshot_driver"); got.Status != "pass" {
+		t.Fatalf("unexpected snapshot_driver check: %+v", got)
+	}
+	if got := doctorCheck(report, "snapshot_zfs_dataset"); got.Status != "pass" {
+		t.Fatalf("unexpected snapshot_zfs_dataset check: %+v", got)
+	}
+	if got := doctorCheck(report, "snapshot_zfs_binary"); got.Status != "pass" {
+		t.Fatalf("unexpected snapshot_zfs_binary check: %+v", got)
+	}
+	if got := doctorCheck(report, "snapshot_zfs_dataset_access"); got.Status != "pass" {
+		t.Fatalf("unexpected snapshot_zfs_dataset_access check: %+v", got)
 	}
 }
 

--- a/internal/backend/firecracker/snapshot_test.go
+++ b/internal/backend/firecracker/snapshot_test.go
@@ -2,6 +2,7 @@ package firecracker
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -10,8 +11,62 @@ import (
 
 	"github.com/buildkite/cleanroom/internal/backend"
 	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/buildkite/cleanroom/internal/volumestore"
 	"github.com/buildkite/cleanroom/internal/vsockexec"
 )
+
+type testVolumeDriver struct {
+	ensureBaseVolumeFn      func(context.Context, volumestore.EnsureBaseVolumeRequest) (volumestore.BaseVolume, error)
+	createWritableVolumeFn  func(context.Context, volumestore.CreateWritableVolumeRequest) (volumestore.WritableVolume, error)
+	snapshotVolumeFn        func(context.Context, volumestore.SnapshotVolumeRequest) (volumestore.Snapshot, error)
+	cloneSnapshotToVolumeFn func(context.Context, volumestore.CloneSnapshotToVolumeRequest) (volumestore.WritableVolume, error)
+	destroyVolumeFn         func(context.Context, volumestore.DestroyVolumeRequest) error
+	destroySnapshotFn       func(context.Context, volumestore.DestroySnapshotRequest) error
+}
+
+func (d testVolumeDriver) Name() string { return "test" }
+
+func (d testVolumeDriver) EnsureBaseVolume(ctx context.Context, req volumestore.EnsureBaseVolumeRequest) (volumestore.BaseVolume, error) {
+	if d.ensureBaseVolumeFn == nil {
+		return volumestore.BaseVolume{}, errors.New("unexpected EnsureBaseVolume call")
+	}
+	return d.ensureBaseVolumeFn(ctx, req)
+}
+
+func (d testVolumeDriver) CreateWritableVolume(ctx context.Context, req volumestore.CreateWritableVolumeRequest) (volumestore.WritableVolume, error) {
+	if d.createWritableVolumeFn == nil {
+		return volumestore.WritableVolume{}, errors.New("unexpected CreateWritableVolume call")
+	}
+	return d.createWritableVolumeFn(ctx, req)
+}
+
+func (d testVolumeDriver) SnapshotVolume(ctx context.Context, req volumestore.SnapshotVolumeRequest) (volumestore.Snapshot, error) {
+	if d.snapshotVolumeFn == nil {
+		return volumestore.Snapshot{}, errors.New("unexpected SnapshotVolume call")
+	}
+	return d.snapshotVolumeFn(ctx, req)
+}
+
+func (d testVolumeDriver) CloneSnapshotToVolume(ctx context.Context, req volumestore.CloneSnapshotToVolumeRequest) (volumestore.WritableVolume, error) {
+	if d.cloneSnapshotToVolumeFn == nil {
+		return volumestore.WritableVolume{}, errors.New("unexpected CloneSnapshotToVolume call")
+	}
+	return d.cloneSnapshotToVolumeFn(ctx, req)
+}
+
+func (d testVolumeDriver) DestroyVolume(ctx context.Context, req volumestore.DestroyVolumeRequest) error {
+	if d.destroyVolumeFn == nil {
+		return nil
+	}
+	return d.destroyVolumeFn(ctx, req)
+}
+
+func (d testVolumeDriver) DestroySnapshot(ctx context.Context, req volumestore.DestroySnapshotRequest) error {
+	if d.destroySnapshotFn == nil {
+		return nil
+	}
+	return d.destroySnapshotFn(ctx, req)
+}
 
 func TestCreateSnapshotSyncsPausesAndClonesRootFS(t *testing.T) {
 	stateHome := t.TempDir()
@@ -117,6 +172,56 @@ func TestCreateSnapshotUsesConfiguredSnapshotBaseDir(t *testing.T) {
 	}
 }
 
+func TestCreateSnapshotUsesManagedVolumeRef(t *testing.T) {
+	stateHome := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateHome)
+
+	managedVolumePath := filepath.Join(t.TempDir(), "managed-volume.ext4")
+	if err := os.WriteFile(managedVolumePath, []byte("snapshot-bytes"), 0o644); err != nil {
+		t.Fatalf("write managed volume: %v", err)
+	}
+
+	prevSignal := sendProcessSignal
+	sendProcessSignal = func(_ *os.Process, _ syscall.Signal) error { return nil }
+	t.Cleanup(func() { sendProcessSignal = prevSignal })
+
+	adapter := &Adapter{
+		runGuestCommandFn: func(_ context.Context, _ context.Context, _ <-chan struct{}, _ func() error, _ string, _ uint32, req vsockexec.ExecRequest, _ backend.OutputStream) (vsockexec.ExecResponse, guestExecTiming, error) {
+			if len(req.Command) != 1 || req.Command[0] != "sync" {
+				t.Fatalf("unexpected command: %v", req.Command)
+			}
+			return vsockexec.ExecResponse{ExitCode: 0}, guestExecTiming{}, nil
+		},
+		sandboxes: map[string]*sandboxInstance{
+			"cr-test": {
+				SandboxID:    "cr-test",
+				VsockPath:    "/tmp/fake.sock",
+				GuestPort:    10700,
+				fcCmd:        &exec.Cmd{Process: &os.Process{Pid: 42}},
+				exitedCh:     make(chan struct{}),
+				vmRootFSPath: "/dev/zvol/tank/cleanroom/sandboxes/cr-test",
+				volumeRef:    managedVolumePath,
+			},
+		},
+	}
+
+	result, err := adapter.CreateSnapshot(context.Background(), backend.SnapshotRequest{
+		SandboxID:  "cr-test",
+		SnapshotID: "snap-test",
+	})
+	if err != nil {
+		t.Fatalf("CreateSnapshot returned error: %v", err)
+	}
+
+	data, err := os.ReadFile(result.StorageRef)
+	if err != nil {
+		t.Fatalf("read snapshot rootfs: %v", err)
+	}
+	if got, want := string(data), "snapshot-bytes"; got != want {
+		t.Fatalf("unexpected snapshot contents: got %q want %q", got, want)
+	}
+}
+
 func TestProvisionSandboxFromSnapshotUsesSnapshotRootFS(t *testing.T) {
 	t.Parallel()
 
@@ -199,5 +304,75 @@ func TestRestoreSandboxReplacesRunningInstance(t *testing.T) {
 	}
 	if got, want := adapter.sandboxes["cr-test"], newInstance; got != want {
 		t.Fatalf("expected replacement sandbox instance, got %#v want %#v", got, want)
+	}
+}
+
+func TestPreparePersistentWritableVolumeUsesBaseVolumeForRootFSPath(t *testing.T) {
+	t.Parallel()
+
+	rootfsPath := filepath.Join(t.TempDir(), "runtime-rootfs.ext4")
+	if err := os.WriteFile(rootfsPath, []byte("runtime"), 0o644); err != nil {
+		t.Fatalf("write rootfs: %v", err)
+	}
+
+	var (
+		gotEnsureReq volumestore.EnsureBaseVolumeRequest
+		gotCreateReq volumestore.CreateWritableVolumeRequest
+	)
+	driver := testVolumeDriver{
+		ensureBaseVolumeFn: func(_ context.Context, req volumestore.EnsureBaseVolumeRequest) (volumestore.BaseVolume, error) {
+			gotEnsureReq = req
+			return volumestore.BaseVolume{Ref: "base-ref"}, nil
+		},
+		createWritableVolumeFn: func(_ context.Context, req volumestore.CreateWritableVolumeRequest) (volumestore.WritableVolume, error) {
+			gotCreateReq = req
+			return volumestore.WritableVolume{Ref: "volume-ref", AttachmentPath: req.AttachmentPath}, nil
+		},
+	}
+
+	writable, err := preparePersistentWritableVolume(context.Background(), driver, "sandbox-1", t.TempDir(), rootfsPath)
+	if err != nil {
+		t.Fatalf("preparePersistentWritableVolume returned error: %v", err)
+	}
+	if got, want := gotEnsureReq.SourcePath, rootfsPath; got != want {
+		t.Fatalf("unexpected base source path: got %q want %q", got, want)
+	}
+	if got, want := gotEnsureReq.BaseID, "runtime-rootfs"; got != want {
+		t.Fatalf("unexpected base id: got %q want %q", got, want)
+	}
+	if got, want := gotCreateReq.BaseRef, "base-ref"; got != want {
+		t.Fatalf("unexpected base ref: got %q want %q", got, want)
+	}
+	if got, want := gotCreateReq.VolumeID, "sandbox-1"; got != want {
+		t.Fatalf("unexpected volume id: got %q want %q", got, want)
+	}
+	if got, want := writable.Ref, "volume-ref"; got != want {
+		t.Fatalf("unexpected writable volume ref: got %q want %q", got, want)
+	}
+}
+
+func TestPreparePersistentWritableVolumeUsesSnapshotCloneForSnapshotRef(t *testing.T) {
+	t.Parallel()
+
+	var gotCloneReq volumestore.CloneSnapshotToVolumeRequest
+	driver := testVolumeDriver{
+		cloneSnapshotToVolumeFn: func(_ context.Context, req volumestore.CloneSnapshotToVolumeRequest) (volumestore.WritableVolume, error) {
+			gotCloneReq = req
+			return volumestore.WritableVolume{Ref: "tank/cleanroom/sandboxes/sandbox-1", AttachmentPath: "/dev/zvol/tank/cleanroom/sandboxes/sandbox-1"}, nil
+		},
+	}
+
+	writable, err := preparePersistentWritableVolume(context.Background(), driver, "sandbox-1", t.TempDir(), "tank/cleanroom/sandboxes/source@snap-golden")
+	if err != nil {
+		t.Fatalf("preparePersistentWritableVolume returned error: %v", err)
+	}
+	if got, want := gotCloneReq.SnapshotRef, "tank/cleanroom/sandboxes/source@snap-golden"; got != want {
+		t.Fatalf("unexpected snapshot ref: got %q want %q", got, want)
+	}
+	if got, want := gotCloneReq.VolumeID, "sandbox-1"; got != want {
+		t.Fatalf("unexpected volume id: got %q want %q", got, want)
+	}
+	if got, want := writable.AttachmentPath, "/dev/zvol/tank/cleanroom/sandboxes/sandbox-1"; got != want {
+		t.Fatalf("unexpected attachment path: got %q want %q", got, want)
 	}
 }

--- a/internal/backend/firecracker/snapshot_test.go
+++ b/internal/backend/firecracker/snapshot_test.go
@@ -72,6 +72,51 @@ func TestCreateSnapshotSyncsPausesAndClonesRootFS(t *testing.T) {
 	}
 }
 
+func TestCreateSnapshotUsesConfiguredSnapshotBaseDir(t *testing.T) {
+	rootfsPath := filepath.Join(t.TempDir(), "rootfs.ext4")
+	if err := os.WriteFile(rootfsPath, []byte("snapshot-bytes"), 0o644); err != nil {
+		t.Fatalf("write rootfs: %v", err)
+	}
+
+	prevSignal := sendProcessSignal
+	sendProcessSignal = func(_ *os.Process, _ syscall.Signal) error { return nil }
+	t.Cleanup(func() { sendProcessSignal = prevSignal })
+
+	adapter := &Adapter{
+		runGuestCommandFn: func(_ context.Context, _ context.Context, _ <-chan struct{}, _ func() error, _ string, _ uint32, req vsockexec.ExecRequest, _ backend.OutputStream) (vsockexec.ExecResponse, guestExecTiming, error) {
+			if len(req.Command) != 1 || req.Command[0] != "sync" {
+				t.Fatalf("unexpected command: %v", req.Command)
+			}
+			return vsockexec.ExecResponse{ExitCode: 0}, guestExecTiming{}, nil
+		},
+		sandboxes: map[string]*sandboxInstance{
+			"cr-test": {
+				SandboxID:    "cr-test",
+				VsockPath:    "/tmp/fake.sock",
+				GuestPort:    10700,
+				fcCmd:        &exec.Cmd{Process: &os.Process{Pid: 42}},
+				exitedCh:     make(chan struct{}),
+				vmRootFSPath: rootfsPath,
+			},
+		},
+	}
+
+	baseDir := filepath.Join(t.TempDir(), "configured-snapshots")
+	result, err := adapter.CreateSnapshot(context.Background(), backend.SnapshotRequest{
+		SandboxID:  "cr-test",
+		SnapshotID: "snap-test",
+		FirecrackerConfig: backend.FirecrackerConfig{
+			Snapshots: backend.SnapshotConfig{BaseDir: baseDir},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateSnapshot returned error: %v", err)
+	}
+	if got, want := result.StorageRef, filepath.Join(baseDir, "firecracker", "snap-test", "rootfs.ext4"); got != want {
+		t.Fatalf("unexpected snapshot storage ref: got %q want %q", got, want)
+	}
+}
+
 func TestProvisionSandboxFromSnapshotUsesSnapshotRootFS(t *testing.T) {
 	t.Parallel()
 

--- a/internal/backend/firecracker/snapshot_test.go
+++ b/internal/backend/firecracker/snapshot_test.go
@@ -1,0 +1,158 @@
+package firecracker
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/buildkite/cleanroom/internal/vsockexec"
+)
+
+func TestCreateSnapshotSyncsPausesAndClonesRootFS(t *testing.T) {
+	stateHome := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateHome)
+
+	rootfsPath := filepath.Join(t.TempDir(), "rootfs.ext4")
+	if err := os.WriteFile(rootfsPath, []byte("snapshot-bytes"), 0o644); err != nil {
+		t.Fatalf("write rootfs: %v", err)
+	}
+
+	var signals []syscall.Signal
+	prevSignal := sendProcessSignal
+	sendProcessSignal = func(_ *os.Process, sig syscall.Signal) error {
+		signals = append(signals, sig)
+		return nil
+	}
+	t.Cleanup(func() { sendProcessSignal = prevSignal })
+
+	adapter := &Adapter{
+		runGuestCommandFn: func(_ context.Context, _ context.Context, _ <-chan struct{}, _ func() error, _ string, _ uint32, req vsockexec.ExecRequest, _ backend.OutputStream) (vsockexec.ExecResponse, guestExecTiming, error) {
+			if len(req.Command) != 1 || req.Command[0] != "sync" {
+				t.Fatalf("unexpected command: %v", req.Command)
+			}
+			return vsockexec.ExecResponse{ExitCode: 0}, guestExecTiming{}, nil
+		},
+		sandboxes: map[string]*sandboxInstance{
+			"cr-test": {
+				SandboxID:    "cr-test",
+				VsockPath:    "/tmp/fake.sock",
+				GuestPort:    10700,
+				fcCmd:        &exec.Cmd{Process: &os.Process{Pid: 42}},
+				exitedCh:     make(chan struct{}),
+				vmRootFSPath: rootfsPath,
+			},
+		},
+	}
+
+	result, err := adapter.CreateSnapshot(context.Background(), backend.SnapshotRequest{
+		SandboxID:  "cr-test",
+		SnapshotID: "snap-test",
+	})
+	if err != nil {
+		t.Fatalf("CreateSnapshot returned error: %v", err)
+	}
+	if got, want := result.StorageRef, filepath.Join(stateHome, "cleanroom", "snapshots", "firecracker", "snap-test", "rootfs.ext4"); got != want {
+		t.Fatalf("unexpected snapshot storage ref: got %q want %q", got, want)
+	}
+
+	data, err := os.ReadFile(result.StorageRef)
+	if err != nil {
+		t.Fatalf("read snapshot rootfs: %v", err)
+	}
+	if got, want := string(data), "snapshot-bytes"; got != want {
+		t.Fatalf("unexpected snapshot contents: got %q want %q", got, want)
+	}
+	if len(signals) != 2 || signals[0] != syscall.SIGSTOP || signals[1] != syscall.SIGCONT {
+		t.Fatalf("unexpected signals: %v", signals)
+	}
+}
+
+func TestProvisionSandboxFromSnapshotUsesSnapshotRootFS(t *testing.T) {
+	t.Parallel()
+
+	var (
+		gotRootFS  string
+		gotSandbox string
+		gotPolicy  *policy.CompiledPolicy
+	)
+	adapter := &Adapter{
+		launchSandboxVMFromRootFSFn: func(_ context.Context, sandboxID string, compiled *policy.CompiledPolicy, _ backend.FirecrackerConfig, sourceRootFSPath string) (*sandboxInstance, error) {
+			gotSandbox = sandboxID
+			gotPolicy = compiled
+			gotRootFS = sourceRootFSPath
+			return &sandboxInstance{SandboxID: sandboxID}, nil
+		},
+	}
+	compiled := &policy.CompiledPolicy{
+		NetworkDefault: "deny",
+		ImageRef:       "ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		ImageDigest:    "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		Hash:           "policy-hash",
+	}
+
+	if err := adapter.ProvisionSandboxFromSnapshot(context.Background(), backend.ProvisionFromSnapshotRequest{
+		SandboxID:  "cr-test",
+		SnapshotID: "snap-test",
+		StorageRef: "/tmp/snap-test.ext4",
+		Policy:     compiled,
+	}); err != nil {
+		t.Fatalf("ProvisionSandboxFromSnapshot returned error: %v", err)
+	}
+	if got, want := gotSandbox, "cr-test"; got != want {
+		t.Fatalf("unexpected sandbox id: got %q want %q", got, want)
+	}
+	if got, want := gotRootFS, "/tmp/snap-test.ext4"; got != want {
+		t.Fatalf("unexpected source rootfs: got %q want %q", got, want)
+	}
+	if gotPolicy != compiled {
+		t.Fatal("expected compiled policy to be forwarded")
+	}
+	if _, ok := adapter.sandboxes["cr-test"]; !ok {
+		t.Fatal("expected provisioned sandbox to be stored")
+	}
+}
+
+func TestRestoreSandboxReplacesRunningInstance(t *testing.T) {
+	t.Parallel()
+
+	compiled := &policy.CompiledPolicy{
+		NetworkDefault: "deny",
+		ImageRef:       "ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		ImageDigest:    "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		Hash:           "policy-hash",
+	}
+	oldInstance := &sandboxInstance{SandboxID: "cr-test"}
+	newInstance := &sandboxInstance{SandboxID: "cr-test", RunDir: "/tmp/new"}
+	adapter := &Adapter{
+		sandboxes: map[string]*sandboxInstance{"cr-test": oldInstance},
+		launchSandboxVMFromRootFSFn: func(_ context.Context, sandboxID string, gotPolicy *policy.CompiledPolicy, _ backend.FirecrackerConfig, sourceRootFSPath string) (*sandboxInstance, error) {
+			if sandboxID != "cr-test" {
+				t.Fatalf("unexpected sandbox id: %q", sandboxID)
+			}
+			if gotPolicy != compiled {
+				t.Fatal("expected compiled policy to be reused during restore")
+			}
+			if got, want := sourceRootFSPath, "/tmp/snap-test.ext4"; got != want {
+				t.Fatalf("unexpected source rootfs: got %q want %q", got, want)
+			}
+			return newInstance, nil
+		},
+	}
+
+	if err := adapter.RestoreSandbox(context.Background(), backend.RestoreRequest{
+		SandboxID:  "cr-test",
+		SnapshotID: "snap-test",
+		StorageRef: "/tmp/snap-test.ext4",
+		Policy:     compiled,
+	}); err != nil {
+		t.Fatalf("RestoreSandbox returned error: %v", err)
+	}
+	if got, want := adapter.sandboxes["cr-test"], newInstance; got != want {
+		t.Fatalf("expected replacement sandbox instance, got %#v want %#v", got, want)
+	}
+}

--- a/internal/backend/firecracker/snapshot_test.go
+++ b/internal/backend/firecracker/snapshot_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/buildkite/cleanroom/internal/backend"
 	"github.com/buildkite/cleanroom/internal/policy"
 	"github.com/buildkite/cleanroom/internal/volumestore"
-	"github.com/buildkite/cleanroom/internal/vsockexec"
 )
 
 type testVolumeDriver struct {
@@ -85,12 +84,11 @@ func TestCreateSnapshotSyncsPausesAndClonesRootFS(t *testing.T) {
 	}
 	t.Cleanup(func() { sendProcessSignal = prevSignal })
 
+	var quiesceCalled bool
 	adapter := &Adapter{
-		runGuestCommandFn: func(_ context.Context, _ context.Context, _ <-chan struct{}, _ func() error, _ string, _ uint32, req vsockexec.ExecRequest, _ backend.OutputStream) (vsockexec.ExecResponse, guestExecTiming, error) {
-			if len(req.Command) != 1 || req.Command[0] != "sync" {
-				t.Fatalf("unexpected command: %v", req.Command)
-			}
-			return vsockexec.ExecResponse{ExitCode: 0}, guestExecTiming{}, nil
+		quiesceGuestFn: func(_ context.Context, _ *sandboxInstance, _ int64) error {
+			quiesceCalled = true
+			return nil
 		},
 		sandboxes: map[string]*sandboxInstance{
 			"cr-test": {
@@ -110,6 +108,9 @@ func TestCreateSnapshotSyncsPausesAndClonesRootFS(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("CreateSnapshot returned error: %v", err)
+	}
+	if !quiesceCalled {
+		t.Fatal("expected quiesceGuestFn to be called")
 	}
 	if got, want := result.StorageRef, filepath.Join(stateHome, "cleanroom", "snapshots", "firecracker", "snap-test", "rootfs.ext4"); got != want {
 		t.Fatalf("unexpected snapshot storage ref: got %q want %q", got, want)
@@ -138,11 +139,8 @@ func TestCreateSnapshotUsesConfiguredSnapshotBaseDir(t *testing.T) {
 	t.Cleanup(func() { sendProcessSignal = prevSignal })
 
 	adapter := &Adapter{
-		runGuestCommandFn: func(_ context.Context, _ context.Context, _ <-chan struct{}, _ func() error, _ string, _ uint32, req vsockexec.ExecRequest, _ backend.OutputStream) (vsockexec.ExecResponse, guestExecTiming, error) {
-			if len(req.Command) != 1 || req.Command[0] != "sync" {
-				t.Fatalf("unexpected command: %v", req.Command)
-			}
-			return vsockexec.ExecResponse{ExitCode: 0}, guestExecTiming{}, nil
+		quiesceGuestFn: func(_ context.Context, _ *sandboxInstance, _ int64) error {
+			return nil
 		},
 		sandboxes: map[string]*sandboxInstance{
 			"cr-test": {
@@ -186,11 +184,8 @@ func TestCreateSnapshotUsesManagedVolumeRef(t *testing.T) {
 	t.Cleanup(func() { sendProcessSignal = prevSignal })
 
 	adapter := &Adapter{
-		runGuestCommandFn: func(_ context.Context, _ context.Context, _ <-chan struct{}, _ func() error, _ string, _ uint32, req vsockexec.ExecRequest, _ backend.OutputStream) (vsockexec.ExecResponse, guestExecTiming, error) {
-			if len(req.Command) != 1 || req.Command[0] != "sync" {
-				t.Fatalf("unexpected command: %v", req.Command)
-			}
-			return vsockexec.ExecResponse{ExitCode: 0}, guestExecTiming{}, nil
+		quiesceGuestFn: func(_ context.Context, _ *sandboxInstance, _ int64) error {
+			return nil
 		},
 		sandboxes: map[string]*sandboxInstance{
 			"cr-test": {
@@ -337,7 +332,7 @@ func TestPreparePersistentWritableVolumeUsesBaseVolumeForRootFSPath(t *testing.T
 	if got, want := gotEnsureReq.SourcePath, rootfsPath; got != want {
 		t.Fatalf("unexpected base source path: got %q want %q", got, want)
 	}
-	if got, want := gotEnsureReq.BaseID, "runtime-rootfs"; got != want {
+	if got, want := gotEnsureReq.BaseID, baseVolumeID(rootfsPath); got != want {
 		t.Fatalf("unexpected base id: got %q want %q", got, want)
 	}
 	if got, want := gotCreateReq.BaseRef, "base-ref"; got != want {
@@ -348,6 +343,22 @@ func TestPreparePersistentWritableVolumeUsesBaseVolumeForRootFSPath(t *testing.T
 	}
 	if got, want := writable.Ref, "volume-ref"; got != want {
 		t.Fatalf("unexpected writable volume ref: got %q want %q", got, want)
+	}
+}
+
+func TestBaseVolumeIDDistinguishesDifferentPaths(t *testing.T) {
+	t.Parallel()
+
+	idA := baseVolumeID("/cache/firecracker/runtime-rootfs/abc123.ext4")
+	idB := baseVolumeID("/cache/firecracker/runtime-rootfs/def456.ext4")
+	if idA == idB {
+		t.Fatalf("expected different base volume IDs for different paths, got %q", idA)
+	}
+
+	// Same path must produce the same ID.
+	idA2 := baseVolumeID("/cache/firecracker/runtime-rootfs/abc123.ext4")
+	if idA != idA2 {
+		t.Fatalf("expected stable base volume ID, got %q and %q", idA, idA2)
 	}
 }
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -40,6 +40,7 @@ import (
 	"github.com/buildkite/cleanroom/internal/paths"
 	"github.com/buildkite/cleanroom/internal/policy"
 	"github.com/buildkite/cleanroom/internal/runtimeconfig"
+	"github.com/buildkite/cleanroom/internal/snapshotstore"
 	"github.com/buildkite/cleanroom/internal/tlsconfig"
 	"github.com/charmbracelet/log"
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -74,17 +75,18 @@ type runtimeContext struct {
 }
 
 type CLI struct {
-	Policy  PolicyCommand  `cmd:"" help:"Policy commands"`
-	Config  ConfigCommand  `cmd:"" help:"Runtime config commands"`
-	Image   ImageCommand   `cmd:"" help:"Manage OCI image cache artifacts"`
-	Create  CreateCommand  `cmd:"" help:"Create a sandbox"`
-	Exec    ExecCommand    `cmd:"" help:"Execute a command in a cleanroom backend"`
-	Console ConsoleCommand `cmd:"" help:"Attach an interactive console to a cleanroom execution"`
-	Serve   ServeCommand   `cmd:"" help:"Run the cleanroom control-plane server"`
-	Doctor  DoctorCommand  `cmd:"" help:"Run environment and backend diagnostics"`
-	Status  StatusCommand  `cmd:"" help:"Inspect run artifacts"`
-	Sandbox SandboxCommand `cmd:"" help:"Manage sandboxes"`
-	Version VersionCommand `cmd:"" help:"Print version information"`
+	Policy   PolicyCommand   `cmd:"" help:"Policy commands"`
+	Config   ConfigCommand   `cmd:"" help:"Runtime config commands"`
+	Image    ImageCommand    `cmd:"" help:"Manage OCI image cache artifacts"`
+	Snapshot SnapshotCommand `cmd:"" help:"Manage snapshots"`
+	Create   CreateCommand   `cmd:"" help:"Create a sandbox"`
+	Exec     ExecCommand     `cmd:"" help:"Execute a command in a cleanroom backend"`
+	Console  ConsoleCommand  `cmd:"" help:"Attach an interactive console to a cleanroom execution"`
+	Serve    ServeCommand    `cmd:"" help:"Run the cleanroom control-plane server"`
+	Doctor   DoctorCommand   `cmd:"" help:"Run environment and backend diagnostics"`
+	Status   StatusCommand   `cmd:"" help:"Inspect run artifacts"`
+	Sandbox  SandboxCommand  `cmd:"" help:"Manage sandboxes"`
+	Version  VersionCommand  `cmd:"" help:"Print version information"`
 }
 
 type VersionCommand struct {
@@ -188,6 +190,7 @@ type SandboxCreateCommand struct {
 	clientFlags
 	Chdir         string `short:"c" help:"Change to this directory before running commands"`
 	Backend       string `help:"Execution backend (defaults to runtime config or host default)"`
+	FromSnapshot  string `name:"from-snapshot" help:"Create the sandbox from an existing snapshot ID"`
 	Image         string `help:"Override sandbox image ref (tag, digest, or local Docker image)"`
 	LaunchSeconds int64  `help:"VM boot/guest-agent readiness timeout in seconds"`
 	JSON          bool   `help:"Print sandbox as JSON"`
@@ -197,6 +200,7 @@ type CreateCommand struct {
 	clientFlags
 	Chdir         string `short:"c" help:"Change to this directory before running commands"`
 	Backend       string `help:"Execution backend (defaults to runtime config or host default)"`
+	FromSnapshot  string `name:"from-snapshot" help:"Create the sandbox from an existing snapshot ID"`
 	Image         string `help:"Override sandbox image ref (tag, digest, or local Docker image)"`
 	LaunchSeconds int64  `help:"VM boot/guest-agent readiness timeout in seconds"`
 	JSON          bool   `help:"Print sandbox as JSON"`
@@ -248,6 +252,7 @@ type DoctorCommand struct {
 type SandboxCommand struct {
 	Create    SandboxCreateCommand    `cmd:"" help:"Create a sandbox"`
 	List      SandboxListCommand      `name:"ls" aliases:"list" cmd:"" help:"List active sandboxes"`
+	Restore   SandboxRestoreCommand   `cmd:"" help:"Restore a sandbox from a snapshot"`
 	Terminate SandboxTerminateCommand `name:"rm" aliases:"terminate" cmd:"" help:"Terminate a sandbox"`
 }
 
@@ -256,9 +261,46 @@ type SandboxListCommand struct {
 	JSON bool `help:"Print sandboxes as JSON"`
 }
 
+type SandboxRestoreCommand struct {
+	clientFlags
+	SandboxID  string `arg:"" required:"" help:"Sandbox ID to restore"`
+	SnapshotID string `name:"snapshot" required:"" help:"Snapshot ID to restore from"`
+	JSON       bool   `help:"Print sandbox as JSON"`
+}
+
 type SandboxTerminateCommand struct {
 	clientFlags
 	SandboxID string `arg:"" required:"" help:"Sandbox ID to terminate"`
+}
+
+type SnapshotCommand struct {
+	Create SnapshotCreateCommand `cmd:"" help:"Create a snapshot from a sandbox"`
+	Get    SnapshotGetCommand    `cmd:"" help:"Get snapshot details"`
+	List   SnapshotListCommand   `name:"ls" aliases:"list" cmd:"" help:"List snapshots"`
+	Delete SnapshotDeleteCommand `name:"rm" aliases:"delete" cmd:"" help:"Delete a snapshot"`
+}
+
+type SnapshotCreateCommand struct {
+	clientFlags
+	SandboxID string `arg:"" required:"" help:"Sandbox ID to snapshot"`
+	Name      string `help:"Optional snapshot label"`
+	JSON      bool   `help:"Print snapshot as JSON"`
+}
+
+type SnapshotGetCommand struct {
+	clientFlags
+	SnapshotID string `arg:"" required:"" help:"Snapshot ID to inspect"`
+	JSON       bool   `help:"Print snapshot as JSON"`
+}
+
+type SnapshotListCommand struct {
+	clientFlags
+	JSON bool `help:"Print snapshots as JSON"`
+}
+
+type SnapshotDeleteCommand struct {
+	clientFlags
+	SnapshotID string `arg:"" required:"" help:"Snapshot ID to delete"`
 }
 
 type exitCodeError struct {
@@ -767,6 +809,28 @@ func (c *SandboxListCommand) Run(ctx *runtimeContext) error {
 	return tw.Flush()
 }
 
+func (c *SandboxRestoreCommand) Run(ctx *runtimeContext) error {
+	client, err := c.connect(ctx)
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.RestoreSandbox(context.Background(), &cleanroomv1.RestoreSandboxRequest{
+		SandboxId:  c.SandboxID,
+		SnapshotId: c.SnapshotID,
+	})
+	if err != nil {
+		return err
+	}
+	if c.JSON {
+		enc := json.NewEncoder(ctx.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(resp.GetSandbox())
+	}
+	_, err = fmt.Fprintln(ctx.Stdout, resp.GetMessage())
+	return err
+}
+
 func (c *SandboxTerminateCommand) Run(ctx *runtimeContext) error {
 	client, err := c.connect(ctx)
 	if err != nil {
@@ -784,37 +848,142 @@ func (c *SandboxTerminateCommand) Run(ctx *runtimeContext) error {
 	return err
 }
 
-func runSandboxCreate(ctx *runtimeContext, connectFlags clientFlags, chdir, backend, imageRefOverride string, launchSeconds int64, outputJSON bool) error {
+func (c *SnapshotCreateCommand) Run(ctx *runtimeContext) error {
+	client, err := c.connect(ctx)
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.CreateSnapshot(context.Background(), &cleanroomv1.CreateSnapshotRequest{
+		SandboxId: c.SandboxID,
+		Name:      c.Name,
+	})
+	if err != nil {
+		return err
+	}
+	if c.JSON {
+		enc := json.NewEncoder(ctx.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(resp.GetSnapshot())
+	}
+	_, err = fmt.Fprintln(ctx.Stdout, resp.GetSnapshot().GetSnapshotId())
+	return err
+}
+
+func (c *SnapshotGetCommand) Run(ctx *runtimeContext) error {
+	client, err := c.connect(ctx)
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.GetSnapshot(context.Background(), &cleanroomv1.GetSnapshotRequest{
+		SnapshotId: c.SnapshotID,
+	})
+	if err != nil {
+		return err
+	}
+	enc := json.NewEncoder(ctx.Stdout)
+	if c.JSON {
+		enc.SetIndent("", "  ")
+	}
+	return enc.Encode(resp.GetSnapshot())
+}
+
+func (c *SnapshotListCommand) Run(ctx *runtimeContext) error {
+	client, err := c.connect(ctx)
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.ListSnapshots(context.Background(), &cleanroomv1.ListSnapshotsRequest{})
+	if err != nil {
+		return err
+	}
+	if c.JSON {
+		enc := json.NewEncoder(ctx.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(resp.GetSnapshots())
+	}
+	if len(resp.GetSnapshots()) == 0 {
+		_, err := fmt.Fprintln(ctx.Stdout, "no snapshots")
+		return err
+	}
+
+	tw := tabwriter.NewWriter(ctx.Stdout, 0, 2, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "ID\tSANDBOX\tBACKEND\tNAME\tCREATED"); err != nil {
+		return err
+	}
+	for _, snapshot := range resp.GetSnapshots() {
+		created := ""
+		if snapshot.GetCreatedAt() != nil {
+			created = snapshot.GetCreatedAt().AsTime().Format(time.RFC3339)
+		}
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", snapshot.GetSnapshotId(), snapshot.GetSourceSandboxId(), snapshot.GetBackend(), snapshot.GetName(), created); err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
+}
+
+func (c *SnapshotDeleteCommand) Run(ctx *runtimeContext) error {
+	client, err := c.connect(ctx)
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.DeleteSnapshot(context.Background(), &cleanroomv1.DeleteSnapshotRequest{
+		SnapshotId: c.SnapshotID,
+	})
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(ctx.Stdout, resp.GetMessage())
+	return err
+}
+
+func runSandboxCreate(ctx *runtimeContext, connectFlags clientFlags, chdir, backend, fromSnapshot, imageRefOverride string, launchSeconds int64, outputJSON bool) error {
 	resolvedHost := connectFlags.resolvedHost(ctx.Config)
 	client, err := connectFlags.connect(ctx)
 	if err != nil {
 		return err
 	}
 
-	cwd, err := resolveCWD(ctx.CWD, chdir)
-	if err != nil {
-		return err
-	}
-	compiled, _, err := ctx.Loader.LoadAndCompile(cwd)
-	if err != nil {
-		return err
-	}
-	allowLocalImageOverride, err := isLocalControlPlaneEndpoint(resolvedHost)
-	if err != nil {
-		return err
-	}
-	compiled, err = overrideCompiledPolicyImage(compiled, imageRefOverride, allowLocalImageOverride)
-	if err != nil {
-		return err
-	}
-
-	resp, err := client.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+	createReq := &cleanroomv1.CreateSandboxRequest{
 		Backend: backend,
 		Options: &cleanroomv1.SandboxOptions{
 			LaunchSeconds: launchSeconds,
 		},
-		Policy: compiled.ToProto(),
-	})
+	}
+	fromSnapshot = strings.TrimSpace(fromSnapshot)
+	if fromSnapshot != "" {
+		if strings.TrimSpace(imageRefOverride) != "" {
+			return errors.New("--image cannot be used with --from-snapshot")
+		}
+		if strings.TrimSpace(backend) != "" {
+			return errors.New("--backend cannot be used with --from-snapshot")
+		}
+		createReq.Source = &cleanroomv1.CreateSandboxRequest_SnapshotId{SnapshotId: fromSnapshot}
+	} else {
+		cwd, err := resolveCWD(ctx.CWD, chdir)
+		if err != nil {
+			return err
+		}
+		compiled, _, err := ctx.Loader.LoadAndCompile(cwd)
+		if err != nil {
+			return err
+		}
+		allowLocalImageOverride, err := isLocalControlPlaneEndpoint(resolvedHost)
+		if err != nil {
+			return err
+		}
+		compiled, err = overrideCompiledPolicyImage(compiled, imageRefOverride, allowLocalImageOverride)
+		if err != nil {
+			return err
+		}
+		createReq.Policy = compiled.ToProto()
+	}
+
+	resp, err := client.CreateSandbox(context.Background(), createReq)
 	if err != nil {
 		return fmt.Errorf("create sandbox: %w", err)
 	}
@@ -836,11 +1005,11 @@ func runSandboxCreate(ctx *runtimeContext, connectFlags clientFlags, chdir, back
 }
 
 func (c *SandboxCreateCommand) Run(ctx *runtimeContext) error {
-	return runSandboxCreate(ctx, c.clientFlags, c.Chdir, c.Backend, c.Image, c.LaunchSeconds, c.JSON)
+	return runSandboxCreate(ctx, c.clientFlags, c.Chdir, c.Backend, c.FromSnapshot, c.Image, c.LaunchSeconds, c.JSON)
 }
 
 func (c *CreateCommand) Run(ctx *runtimeContext) error {
-	return runSandboxCreate(ctx, c.clientFlags, c.Chdir, c.Backend, c.Image, c.LaunchSeconds, c.JSON)
+	return runSandboxCreate(ctx, c.clientFlags, c.Chdir, c.Backend, c.FromSnapshot, c.Image, c.LaunchSeconds, c.JSON)
 }
 
 func (e *ExecCommand) Run(ctx *runtimeContext) error {
@@ -2074,11 +2243,17 @@ func (s *ServeCommand) runServer(ctx *runtimeContext) error {
 		}
 	}
 
+	snapshotStore, err := snapshotstore.New(snapshotstore.Options{})
+	if err != nil {
+		return fmt.Errorf("initialise snapshot metadata store: %w", err)
+	}
+
 	service := &controlservice.Service{
-		Loader:   ctx.Loader,
-		Config:   ctx.Config,
-		Backends: ctx.Backends,
-		Logger:   logger.With("subsystem", "service"),
+		Loader:        ctx.Loader,
+		Config:        ctx.Config,
+		Backends:      ctx.Backends,
+		Logger:        logger.With("subsystem", "service"),
+		SnapshotStore: snapshotStore,
 	}
 	server := controlserver.New(service, logger.With("subsystem", "http"))
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -2518,6 +2518,13 @@ func mergeBackendConfig(backendName string, launchSeconds int64, cfg runtimeconf
 		DockerStartupSeconds: cfg.Backends.Firecracker.Services.Docker.StartupTimeoutSeconds,
 		DockerStorageDriver:  cfg.Backends.Firecracker.Services.Docker.StorageDriver,
 		DockerIPTables:       cfg.Backends.Firecracker.Services.Docker.IPTables,
+		Snapshots: backend.SnapshotConfig{
+			Enabled:               cfg.Backends.Firecracker.Snapshots.Enabled,
+			Driver:                cfg.Backends.Firecracker.Snapshots.Driver,
+			BaseDir:               cfg.Backends.Firecracker.Snapshots.BaseDir,
+			ZFSDataset:            cfg.Backends.Firecracker.Snapshots.ZFSDataset,
+			QuiesceTimeoutSeconds: cfg.Backends.Firecracker.Snapshots.QuiesceTimeoutSeconds,
+		},
 		PrivilegedMode:       cfg.Backends.Firecracker.PrivilegedMode,
 		PrivilegedHelperPath: cfg.Backends.Firecracker.PrivilegedHelperPath,
 		VCPUs:                cfg.Backends.Firecracker.VCPUs,
@@ -2532,6 +2539,13 @@ func mergeBackendConfig(backendName string, launchSeconds int64, cfg runtimeconf
 		out.DockerStartupSeconds = cfg.Backends.DarwinVZ.Services.Docker.StartupTimeoutSeconds
 		out.DockerStorageDriver = cfg.Backends.DarwinVZ.Services.Docker.StorageDriver
 		out.DockerIPTables = cfg.Backends.DarwinVZ.Services.Docker.IPTables
+		out.Snapshots = backend.SnapshotConfig{
+			Enabled:               cfg.Backends.DarwinVZ.Snapshots.Enabled,
+			Driver:                cfg.Backends.DarwinVZ.Snapshots.Driver,
+			BaseDir:               cfg.Backends.DarwinVZ.Snapshots.BaseDir,
+			ZFSDataset:            cfg.Backends.DarwinVZ.Snapshots.ZFSDataset,
+			QuiesceTimeoutSeconds: cfg.Backends.DarwinVZ.Snapshots.QuiesceTimeoutSeconds,
+		}
 		out.VCPUs = cfg.Backends.DarwinVZ.VCPUs
 		out.MemoryMiB = cfg.Backends.DarwinVZ.MemoryMiB
 		out.GuestPort = cfg.Backends.DarwinVZ.GuestPort

--- a/internal/cli/exec_integration_test.go
+++ b/internal/cli/exec_integration_test.go
@@ -23,13 +23,25 @@ import (
 	"github.com/buildkite/cleanroom/internal/interactivequic"
 	"github.com/buildkite/cleanroom/internal/policy"
 	"github.com/buildkite/cleanroom/internal/runtimeconfig"
+	"github.com/buildkite/cleanroom/internal/snapshotstore"
 )
 
 type integrationAdapter struct {
 	mu sync.Mutex
 
-	runFn       func(context.Context, backend.RunRequest) (*backend.RunResult, error)
-	runStreamFn func(context.Context, backend.RunRequest, backend.OutputStream) (*backend.RunResult, error)
+	runFn                    func(context.Context, backend.RunRequest) (*backend.RunResult, error)
+	runStreamFn              func(context.Context, backend.RunRequest, backend.OutputStream) (*backend.RunResult, error)
+	provisionFn              func(context.Context, backend.ProvisionRequest) error
+	provisionFromSnapshotFn  func(context.Context, backend.ProvisionFromSnapshotRequest) error
+	createSnapshotFn         func(context.Context, backend.SnapshotRequest) (*backend.SnapshotResult, error)
+	restoreFn                func(context.Context, backend.RestoreRequest) error
+	deleteSnapshotFn         func(context.Context, backend.DeleteSnapshotRequest) error
+	terminateFn              func(context.Context, string) error
+	provisionReq             backend.ProvisionRequest
+	provisionFromSnapshotReq backend.ProvisionFromSnapshotRequest
+	createSnapshotReq        backend.SnapshotRequest
+	restoreReq               backend.RestoreRequest
+	deleteSnapshotReq        backend.DeleteSnapshotRequest
 }
 
 func (a *integrationAdapter) Name() string { return "firecracker" }
@@ -64,6 +76,75 @@ func (a *integrationAdapter) RunStream(ctx context.Context, req backend.RunReque
 	return result, nil
 }
 
+func (a *integrationAdapter) ProvisionSandbox(ctx context.Context, req backend.ProvisionRequest) error {
+	a.mu.Lock()
+	a.provisionReq = req
+	fn := a.provisionFn
+	a.mu.Unlock()
+	if fn != nil {
+		return fn(ctx, req)
+	}
+	return nil
+}
+
+func (a *integrationAdapter) RunInSandbox(ctx context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+	return a.RunStream(ctx, req, stream)
+}
+
+func (a *integrationAdapter) CreateSnapshot(ctx context.Context, req backend.SnapshotRequest) (*backend.SnapshotResult, error) {
+	a.mu.Lock()
+	a.createSnapshotReq = req
+	fn := a.createSnapshotFn
+	a.mu.Unlock()
+	if fn != nil {
+		return fn(ctx, req)
+	}
+	return &backend.SnapshotResult{StorageRef: "/snapshots/" + req.SnapshotID + ".ext4"}, nil
+}
+
+func (a *integrationAdapter) ProvisionSandboxFromSnapshot(ctx context.Context, req backend.ProvisionFromSnapshotRequest) error {
+	a.mu.Lock()
+	a.provisionFromSnapshotReq = req
+	fn := a.provisionFromSnapshotFn
+	a.mu.Unlock()
+	if fn != nil {
+		return fn(ctx, req)
+	}
+	return nil
+}
+
+func (a *integrationAdapter) RestoreSandbox(ctx context.Context, req backend.RestoreRequest) error {
+	a.mu.Lock()
+	a.restoreReq = req
+	fn := a.restoreFn
+	a.mu.Unlock()
+	if fn != nil {
+		return fn(ctx, req)
+	}
+	return nil
+}
+
+func (a *integrationAdapter) DeleteSnapshot(ctx context.Context, req backend.DeleteSnapshotRequest) error {
+	a.mu.Lock()
+	a.deleteSnapshotReq = req
+	fn := a.deleteSnapshotFn
+	a.mu.Unlock()
+	if fn != nil {
+		return fn(ctx, req)
+	}
+	return nil
+}
+
+func (a *integrationAdapter) TerminateSandbox(ctx context.Context, sandboxID string) error {
+	a.mu.Lock()
+	fn := a.terminateFn
+	a.mu.Unlock()
+	if fn != nil {
+		return fn(ctx, sandboxID)
+	}
+	return nil
+}
+
 type integrationLoader struct{}
 
 func (integrationLoader) LoadAndCompile(_ string) (*policy.CompiledPolicy, string, error) {
@@ -91,11 +172,19 @@ type execOutcome struct {
 func startIntegrationServer(t *testing.T, adapter backend.Adapter) (string, *controlservice.Service) {
 	t.Helper()
 
+	store, err := snapshotstore.New(snapshotstore.Options{
+		MetadataDBPath: filepath.Join(t.TempDir(), "snapshots.db"),
+	})
+	if err != nil {
+		t.Fatalf("create snapshot store: %v", err)
+	}
+
 	svc := &controlservice.Service{
 		Loader: integrationLoader{},
 		Config: runtimeconfig.Config{
 			DefaultBackend: "firecracker",
 		},
+		SnapshotStore: store,
 		Backends: map[string]backend.Adapter{
 			"firecracker": adapter,
 		},

--- a/internal/cli/snapshot_integration_test.go
+++ b/internal/cli/snapshot_integration_test.go
@@ -1,0 +1,212 @@
+package cli
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+)
+
+func runSnapshotCreateWithCapture(cmd SnapshotCreateCommand, ctx runtimeContext) execOutcome {
+	return runWithCapture(func(runCtx *runtimeContext) error {
+		return cmd.Run(runCtx)
+	}, nil, ctx)
+}
+
+func runSnapshotGetWithCapture(cmd SnapshotGetCommand, ctx runtimeContext) execOutcome {
+	return runWithCapture(func(runCtx *runtimeContext) error {
+		return cmd.Run(runCtx)
+	}, nil, ctx)
+}
+
+func runSnapshotListWithCapture(cmd SnapshotListCommand, ctx runtimeContext) execOutcome {
+	return runWithCapture(func(runCtx *runtimeContext) error {
+		return cmd.Run(runCtx)
+	}, nil, ctx)
+}
+
+func runSnapshotDeleteWithCapture(cmd SnapshotDeleteCommand, ctx runtimeContext) execOutcome {
+	return runWithCapture(func(runCtx *runtimeContext) error {
+		return cmd.Run(runCtx)
+	}, nil, ctx)
+}
+
+func runSandboxRestoreWithCapture(cmd SandboxRestoreCommand, ctx runtimeContext) execOutcome {
+	return runWithCapture(func(runCtx *runtimeContext) error {
+		return cmd.Run(runCtx)
+	}, nil, ctx)
+}
+
+func TestSnapshotCommandsIntegrationLifecycle(t *testing.T) {
+	adapter := &integrationAdapter{}
+	host, _ := startIntegrationServer(t, adapter)
+	cwd := t.TempDir()
+
+	client := mustNewControlClient(t, host)
+	sandboxID := mustCreateSandbox(t, client)
+
+	createOutcome := runSnapshotCreateWithCapture(SnapshotCreateCommand{
+		clientFlags: clientFlags{Host: host},
+		SandboxID:   sandboxID,
+		Name:        "golden",
+	}, runtimeContext{CWD: cwd})
+	if createOutcome.cause != nil {
+		t.Fatalf("capture failure: %v", createOutcome.cause)
+	}
+	if createOutcome.err != nil {
+		t.Fatalf("SnapshotCreateCommand.Run returned error: %v", createOutcome.err)
+	}
+
+	snapshotID := strings.TrimSpace(createOutcome.stdout)
+	if snapshotID == "" {
+		t.Fatalf("expected snapshot id output, got %q", createOutcome.stdout)
+	}
+	if got, want := adapter.createSnapshotReq.SandboxID, sandboxID; got != want {
+		t.Fatalf("unexpected snapshot sandbox id: got %q want %q", got, want)
+	}
+
+	getOutcome := runSnapshotGetWithCapture(SnapshotGetCommand{
+		clientFlags: clientFlags{Host: host},
+		SnapshotID:  snapshotID,
+		JSON:        true,
+	}, runtimeContext{CWD: cwd})
+	if getOutcome.cause != nil {
+		t.Fatalf("capture failure: %v", getOutcome.cause)
+	}
+	if getOutcome.err != nil {
+		t.Fatalf("SnapshotGetCommand.Run returned error: %v", getOutcome.err)
+	}
+
+	var snapshot cleanroomv1.Snapshot
+	if err := json.Unmarshal([]byte(getOutcome.stdout), &snapshot); err != nil {
+		t.Fatalf("parse snapshot json: %v", err)
+	}
+	if got, want := snapshot.GetSnapshotId(), snapshotID; got != want {
+		t.Fatalf("unexpected snapshot id: got %q want %q", got, want)
+	}
+	if got, want := snapshot.GetName(), "golden"; got != want {
+		t.Fatalf("unexpected snapshot name: got %q want %q", got, want)
+	}
+
+	listOutcome := runSnapshotListWithCapture(SnapshotListCommand{
+		clientFlags: clientFlags{Host: host},
+	}, runtimeContext{CWD: cwd})
+	if listOutcome.cause != nil {
+		t.Fatalf("capture failure: %v", listOutcome.cause)
+	}
+	if listOutcome.err != nil {
+		t.Fatalf("SnapshotListCommand.Run returned error: %v", listOutcome.err)
+	}
+	if !strings.Contains(listOutcome.stdout, snapshotID) || !strings.Contains(listOutcome.stdout, "golden") {
+		t.Fatalf("expected snapshot list output to include snapshot row, got %q", listOutcome.stdout)
+	}
+
+	deleteOutcome := runSnapshotDeleteWithCapture(SnapshotDeleteCommand{
+		clientFlags: clientFlags{Host: host},
+		SnapshotID:  snapshotID,
+	}, runtimeContext{CWD: cwd})
+	if deleteOutcome.cause != nil {
+		t.Fatalf("capture failure: %v", deleteOutcome.cause)
+	}
+	if deleteOutcome.err != nil {
+		t.Fatalf("SnapshotDeleteCommand.Run returned error: %v", deleteOutcome.err)
+	}
+	if !strings.Contains(deleteOutcome.stdout, "snapshot deleted") {
+		t.Fatalf("expected delete output, got %q", deleteOutcome.stdout)
+	}
+	if got, want := adapter.deleteSnapshotReq.SnapshotID, snapshotID; got != want {
+		t.Fatalf("unexpected deleted snapshot id: got %q want %q", got, want)
+	}
+
+	emptyListOutcome := runSnapshotListWithCapture(SnapshotListCommand{
+		clientFlags: clientFlags{Host: host},
+	}, runtimeContext{CWD: cwd})
+	if emptyListOutcome.cause != nil {
+		t.Fatalf("capture failure: %v", emptyListOutcome.cause)
+	}
+	if emptyListOutcome.err != nil {
+		t.Fatalf("SnapshotListCommand.Run after delete returned error: %v", emptyListOutcome.err)
+	}
+	if got := strings.TrimSpace(emptyListOutcome.stdout); got != "no snapshots" {
+		t.Fatalf("unexpected empty snapshot list output: %q", got)
+	}
+}
+
+func TestSandboxSnapshotIntegrationCreateFromSnapshotAndRestore(t *testing.T) {
+	adapter := &integrationAdapter{}
+	host, _ := startIntegrationServer(t, adapter)
+	cwd := t.TempDir()
+
+	client := mustNewControlClient(t, host)
+	sandboxID := mustCreateSandbox(t, client)
+
+	createSnapshotOutcome := runSnapshotCreateWithCapture(SnapshotCreateCommand{
+		clientFlags: clientFlags{Host: host},
+		SandboxID:   sandboxID,
+		Name:        "golden",
+	}, runtimeContext{CWD: cwd})
+	if createSnapshotOutcome.cause != nil {
+		t.Fatalf("capture failure: %v", createSnapshotOutcome.cause)
+	}
+	if createSnapshotOutcome.err != nil {
+		t.Fatalf("SnapshotCreateCommand.Run returned error: %v", createSnapshotOutcome.err)
+	}
+	snapshotID := strings.TrimSpace(createSnapshotOutcome.stdout)
+	if snapshotID == "" {
+		t.Fatalf("expected snapshot id output, got %q", createSnapshotOutcome.stdout)
+	}
+
+	createOutcome := runSandboxCreateWithCapture(SandboxCreateCommand{
+		clientFlags:  clientFlags{Host: host},
+		FromSnapshot: snapshotID,
+	}, runtimeContext{
+		CWD:    cwd,
+		Loader: failingLoader{},
+	})
+	if createOutcome.cause != nil {
+		t.Fatalf("capture failure: %v", createOutcome.cause)
+	}
+	if createOutcome.err != nil {
+		t.Fatalf("SandboxCreateCommand.Run returned error: %v", createOutcome.err)
+	}
+
+	forkSandboxID := strings.TrimSpace(createOutcome.stdout)
+	if forkSandboxID == "" {
+		t.Fatalf("expected sandbox id output, got %q", createOutcome.stdout)
+	}
+	requireSandboxStatus(t, client, forkSandboxID, cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY)
+	if got, want := adapter.provisionFromSnapshotReq.SnapshotID, snapshotID; got != want {
+		t.Fatalf("unexpected provision snapshot id: got %q want %q", got, want)
+	}
+	if got, want := adapter.provisionFromSnapshotReq.StorageRef, "/snapshots/"+snapshotID+".ext4"; got != want {
+		t.Fatalf("unexpected provision storage ref: got %q want %q", got, want)
+	}
+	if adapter.provisionFromSnapshotReq.Policy == nil {
+		t.Fatal("expected compiled policy on provision-from-snapshot request")
+	}
+
+	restoreOutcome := runSandboxRestoreWithCapture(SandboxRestoreCommand{
+		clientFlags: clientFlags{Host: host},
+		SandboxID:   sandboxID,
+		SnapshotID:  snapshotID,
+	}, runtimeContext{CWD: cwd})
+	if restoreOutcome.cause != nil {
+		t.Fatalf("capture failure: %v", restoreOutcome.cause)
+	}
+	if restoreOutcome.err != nil {
+		t.Fatalf("SandboxRestoreCommand.Run returned error: %v", restoreOutcome.err)
+	}
+	if !strings.Contains(restoreOutcome.stdout, "sandbox restored from snapshot") {
+		t.Fatalf("expected restore output, got %q", restoreOutcome.stdout)
+	}
+	if got, want := adapter.restoreReq.SandboxID, sandboxID; got != want {
+		t.Fatalf("unexpected restore sandbox id: got %q want %q", got, want)
+	}
+	if got, want := adapter.restoreReq.SnapshotID, snapshotID; got != want {
+		t.Fatalf("unexpected restore snapshot id: got %q want %q", got, want)
+	}
+	if adapter.restoreReq.Policy == nil {
+		t.Fatal("expected compiled policy on restore request")
+	}
+}

--- a/internal/cli/snapshot_integration_test.go
+++ b/internal/cli/snapshot_integration_test.go
@@ -210,3 +210,54 @@ func TestSandboxSnapshotIntegrationCreateFromSnapshotAndRestore(t *testing.T) {
 		t.Fatal("expected compiled policy on restore request")
 	}
 }
+
+func TestSnapshotDeleteIntegrationRejectsSnapshotInUse(t *testing.T) {
+	adapter := &integrationAdapter{}
+	host, _ := startIntegrationServer(t, adapter)
+	cwd := t.TempDir()
+
+	client := mustNewControlClient(t, host)
+	sourceSandboxID := mustCreateSandbox(t, client)
+
+	createSnapshotOutcome := runSnapshotCreateWithCapture(SnapshotCreateCommand{
+		clientFlags: clientFlags{Host: host},
+		SandboxID:   sourceSandboxID,
+		Name:        "golden",
+	}, runtimeContext{CWD: cwd})
+	if createSnapshotOutcome.cause != nil {
+		t.Fatalf("capture failure: %v", createSnapshotOutcome.cause)
+	}
+	if createSnapshotOutcome.err != nil {
+		t.Fatalf("SnapshotCreateCommand.Run returned error: %v", createSnapshotOutcome.err)
+	}
+	snapshotID := strings.TrimSpace(createSnapshotOutcome.stdout)
+
+	createOutcome := runSandboxCreateWithCapture(SandboxCreateCommand{
+		clientFlags:  clientFlags{Host: host},
+		FromSnapshot: snapshotID,
+	}, runtimeContext{
+		CWD:    cwd,
+		Loader: failingLoader{},
+	})
+	if createOutcome.cause != nil {
+		t.Fatalf("capture failure: %v", createOutcome.cause)
+	}
+	if createOutcome.err != nil {
+		t.Fatalf("SandboxCreateCommand.Run returned error: %v", createOutcome.err)
+	}
+	forkSandboxID := strings.TrimSpace(createOutcome.stdout)
+
+	deleteOutcome := runSnapshotDeleteWithCapture(SnapshotDeleteCommand{
+		clientFlags: clientFlags{Host: host},
+		SnapshotID:  snapshotID,
+	}, runtimeContext{CWD: cwd})
+	if deleteOutcome.cause != nil {
+		t.Fatalf("capture failure: %v", deleteOutcome.cause)
+	}
+	if deleteOutcome.err == nil {
+		t.Fatal("expected snapshot delete to fail while snapshot is in use")
+	}
+	if !strings.Contains(deleteOutcome.err.Error(), "snapshot_busy") || !strings.Contains(deleteOutcome.err.Error(), forkSandboxID) {
+		t.Fatalf("unexpected snapshot delete error: %v", deleteOutcome.err)
+	}
+}

--- a/internal/cli/snapshot_integration_test.go
+++ b/internal/cli/snapshot_integration_test.go
@@ -211,7 +211,7 @@ func TestSandboxSnapshotIntegrationCreateFromSnapshotAndRestore(t *testing.T) {
 	}
 }
 
-func TestSnapshotDeleteIntegrationRejectsSnapshotInUse(t *testing.T) {
+func TestSnapshotDeleteIntegrationAllowsDeleteAfterSnapshotBackedCreate(t *testing.T) {
 	adapter := &integrationAdapter{}
 	host, _ := startIntegrationServer(t, adapter)
 	cwd := t.TempDir()
@@ -245,7 +245,9 @@ func TestSnapshotDeleteIntegrationRejectsSnapshotInUse(t *testing.T) {
 	if createOutcome.err != nil {
 		t.Fatalf("SandboxCreateCommand.Run returned error: %v", createOutcome.err)
 	}
-	forkSandboxID := strings.TrimSpace(createOutcome.stdout)
+	if got := strings.TrimSpace(createOutcome.stdout); got == "" {
+		t.Fatal("expected forked sandbox id output")
+	}
 
 	deleteOutcome := runSnapshotDeleteWithCapture(SnapshotDeleteCommand{
 		clientFlags: clientFlags{Host: host},
@@ -254,10 +256,13 @@ func TestSnapshotDeleteIntegrationRejectsSnapshotInUse(t *testing.T) {
 	if deleteOutcome.cause != nil {
 		t.Fatalf("capture failure: %v", deleteOutcome.cause)
 	}
-	if deleteOutcome.err == nil {
-		t.Fatal("expected snapshot delete to fail while snapshot is in use")
+	if deleteOutcome.err != nil {
+		t.Fatalf("SnapshotDeleteCommand.Run returned error: %v", deleteOutcome.err)
 	}
-	if !strings.Contains(deleteOutcome.err.Error(), "snapshot_busy") || !strings.Contains(deleteOutcome.err.Error(), forkSandboxID) {
-		t.Fatalf("unexpected snapshot delete error: %v", deleteOutcome.err)
+	if !strings.Contains(deleteOutcome.stdout, "snapshot deleted") {
+		t.Fatalf("expected delete output, got %q", deleteOutcome.stdout)
+	}
+	if got, want := adapter.deleteSnapshotReq.SnapshotID, snapshotID; got != want {
+		t.Fatalf("unexpected deleted snapshot id: got %q want %q", got, want)
 	}
 }

--- a/internal/controlclient/client.go
+++ b/internal/controlclient/client.go
@@ -20,6 +20,7 @@ type Client struct {
 	httpClient      *http.Client
 	baseURL         string
 	sandboxClient   cleanroomv1connect.SandboxServiceClient
+	snapshotClient  cleanroomv1connect.SnapshotServiceClient
 	executionClient cleanroomv1connect.ExecutionServiceClient
 }
 
@@ -53,6 +54,7 @@ func New(ep endpoint.Endpoint, opts ...Option) (*Client, error) {
 		httpClient:      httpClient,
 		baseURL:         baseURL,
 		sandboxClient:   cleanroomv1connect.NewSandboxServiceClient(httpClient, baseURL),
+		snapshotClient:  cleanroomv1connect.NewSnapshotServiceClient(httpClient, baseURL),
 		executionClient: cleanroomv1connect.NewExecutionServiceClient(httpClient, baseURL),
 	}, nil
 }
@@ -129,6 +131,14 @@ func (c *Client) DownloadSandboxFile(ctx context.Context, req *cleanroomv1.Downl
 	return resp.Msg, nil
 }
 
+func (c *Client) RestoreSandbox(ctx context.Context, req *cleanroomv1.RestoreSandboxRequest) (*cleanroomv1.RestoreSandboxResponse, error) {
+	resp, err := c.sandboxClient.RestoreSandbox(ctx, connect.NewRequest(req))
+	if err != nil {
+		return nil, err
+	}
+	return resp.Msg, nil
+}
+
 func (c *Client) TerminateSandbox(ctx context.Context, req *cleanroomv1.TerminateSandboxRequest) (*cleanroomv1.TerminateSandboxResponse, error) {
 	resp, err := c.sandboxClient.TerminateSandbox(ctx, connect.NewRequest(req))
 	if err != nil {
@@ -139,6 +149,38 @@ func (c *Client) TerminateSandbox(ctx context.Context, req *cleanroomv1.Terminat
 
 func (c *Client) StreamSandboxEvents(ctx context.Context, req *cleanroomv1.StreamSandboxEventsRequest) (*connect.ServerStreamForClient[cleanroomv1.SandboxEvent], error) {
 	return c.sandboxClient.StreamSandboxEvents(ctx, connect.NewRequest(req))
+}
+
+func (c *Client) CreateSnapshot(ctx context.Context, req *cleanroomv1.CreateSnapshotRequest) (*cleanroomv1.CreateSnapshotResponse, error) {
+	resp, err := c.snapshotClient.CreateSnapshot(ctx, connect.NewRequest(req))
+	if err != nil {
+		return nil, err
+	}
+	return resp.Msg, nil
+}
+
+func (c *Client) GetSnapshot(ctx context.Context, req *cleanroomv1.GetSnapshotRequest) (*cleanroomv1.GetSnapshotResponse, error) {
+	resp, err := c.snapshotClient.GetSnapshot(ctx, connect.NewRequest(req))
+	if err != nil {
+		return nil, err
+	}
+	return resp.Msg, nil
+}
+
+func (c *Client) ListSnapshots(ctx context.Context, req *cleanroomv1.ListSnapshotsRequest) (*cleanroomv1.ListSnapshotsResponse, error) {
+	resp, err := c.snapshotClient.ListSnapshots(ctx, connect.NewRequest(req))
+	if err != nil {
+		return nil, err
+	}
+	return resp.Msg, nil
+}
+
+func (c *Client) DeleteSnapshot(ctx context.Context, req *cleanroomv1.DeleteSnapshotRequest) (*cleanroomv1.DeleteSnapshotResponse, error) {
+	resp, err := c.snapshotClient.DeleteSnapshot(ctx, connect.NewRequest(req))
+	if err != nil {
+		return nil, err
+	}
+	return resp.Msg, nil
 }
 
 func (c *Client) CreateExecution(ctx context.Context, req *cleanroomv1.CreateExecutionRequest) (*cleanroomv1.CreateExecutionResponse, error) {

--- a/internal/controlserver/server.go
+++ b/internal/controlserver/server.go
@@ -44,8 +44,10 @@ func (s *Server) Handler() http.Handler {
 	mux := http.NewServeMux()
 
 	sandboxPath, sandboxHandler := cleanroomv1connect.NewSandboxServiceHandler(s)
+	snapshotPath, snapshotHandler := cleanroomv1connect.NewSnapshotServiceHandler(s)
 	executionPath, executionHandler := cleanroomv1connect.NewExecutionServiceHandler(s)
 	mux.Handle(sandboxPath, sandboxHandler)
+	mux.Handle(snapshotPath, snapshotHandler)
 	mux.Handle(executionPath, executionHandler)
 
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
@@ -81,6 +83,14 @@ func (s *Server) ListSandboxes(ctx context.Context, req *connect.Request[cleanro
 
 func (s *Server) DownloadSandboxFile(ctx context.Context, req *connect.Request[cleanroomv1.DownloadSandboxFileRequest]) (*connect.Response[cleanroomv1.DownloadSandboxFileResponse], error) {
 	resp, err := s.service.DownloadSandboxFile(ctx, req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (s *Server) RestoreSandbox(ctx context.Context, req *connect.Request[cleanroomv1.RestoreSandboxRequest]) (*connect.Response[cleanroomv1.RestoreSandboxResponse], error) {
+	resp, err := s.service.RestoreSandbox(ctx, req.Msg)
 	if err != nil {
 		return nil, toConnectError(err)
 	}
@@ -126,6 +136,38 @@ func (s *Server) StreamSandboxEvents(ctx context.Context, req *connect.Request[c
 			return drainSandboxEvents(stream, updates)
 		}
 	}
+}
+
+func (s *Server) CreateSnapshot(ctx context.Context, req *connect.Request[cleanroomv1.CreateSnapshotRequest]) (*connect.Response[cleanroomv1.CreateSnapshotResponse], error) {
+	resp, err := s.service.CreateSnapshot(ctx, req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (s *Server) GetSnapshot(ctx context.Context, req *connect.Request[cleanroomv1.GetSnapshotRequest]) (*connect.Response[cleanroomv1.GetSnapshotResponse], error) {
+	resp, err := s.service.GetSnapshot(ctx, req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (s *Server) ListSnapshots(ctx context.Context, req *connect.Request[cleanroomv1.ListSnapshotsRequest]) (*connect.Response[cleanroomv1.ListSnapshotsResponse], error) {
+	resp, err := s.service.ListSnapshots(ctx, req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (s *Server) DeleteSnapshot(ctx context.Context, req *connect.Request[cleanroomv1.DeleteSnapshotRequest]) (*connect.Response[cleanroomv1.DeleteSnapshotResponse], error) {
+	resp, err := s.service.DeleteSnapshot(ctx, req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
 }
 
 func (s *Server) CreateExecution(ctx context.Context, req *connect.Request[cleanroomv1.CreateExecutionRequest]) (*connect.Response[cleanroomv1.CreateExecutionResponse], error) {

--- a/internal/controlservice/ids.go
+++ b/internal/controlservice/ids.go
@@ -24,6 +24,10 @@ func newExecutionID() string {
 	return newID("exec")
 }
 
+func newSnapshotID() string {
+	return newID("snap")
+}
+
 func newRunID() string {
 	return newID("run")
 }

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -17,6 +17,7 @@ import (
 	"github.com/buildkite/cleanroom/internal/paths"
 	"github.com/buildkite/cleanroom/internal/policy"
 	"github.com/buildkite/cleanroom/internal/runtimeconfig"
+	"github.com/buildkite/cleanroom/internal/snapshotstore"
 	"github.com/charmbracelet/log"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -26,6 +27,8 @@ type Service struct {
 	Config   runtimeconfig.Config
 	Backends map[string]backend.Adapter
 	Logger   *log.Logger
+
+	SnapshotStore snapshotMetadataStore
 
 	mu                  sync.RWMutex
 	sandboxes           map[string]*sandboxState
@@ -109,6 +112,13 @@ type loader interface {
 	LoadAndCompile(cwd string) (*policy.CompiledPolicy, string, error)
 }
 
+type snapshotMetadataStore interface {
+	Create(context.Context, snapshotstore.Record) error
+	Get(context.Context, string) (snapshotstore.Record, bool, error)
+	List(context.Context) ([]snapshotstore.Record, error)
+	Delete(context.Context, string) error
+}
+
 type executionOptions struct {
 	LaunchSeconds int64
 }
@@ -148,6 +158,13 @@ const (
 func (s *Service) CreateSandbox(ctx context.Context, req *cleanroomv1.CreateSandboxRequest) (*cleanroomv1.CreateSandboxResponse, error) {
 	if req == nil {
 		return nil, errors.New("missing request")
+	}
+	snapshotID := strings.TrimSpace(req.GetSnapshotId())
+	if snapshotID != "" {
+		if req.GetPolicy() != nil {
+			return nil, errors.New("snapshot-backed sandbox creation cannot include policy")
+		}
+		return s.createSandboxFromSnapshot(ctx, req, snapshotID)
 	}
 	if req.GetPolicy() == nil {
 		return nil, errors.New("missing policy")
@@ -219,6 +236,94 @@ func (s *Service) CreateSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 	return resp, nil
 }
 
+func (s *Service) createSandboxFromSnapshot(ctx context.Context, req *cleanroomv1.CreateSandboxRequest, snapshotID string) (*cleanroomv1.CreateSandboxResponse, error) {
+	store, err := s.snapshotStoreOrErr()
+	if err != nil {
+		return nil, err
+	}
+
+	record, ok, err := store.Get(ctx, snapshotID)
+	if err != nil {
+		return nil, fmt.Errorf("load snapshot %q: %w", snapshotID, err)
+	}
+	if !ok {
+		return nil, fmt.Errorf("unknown snapshot %q", snapshotID)
+	}
+
+	backendName := record.Backend
+	if requested := strings.TrimSpace(req.GetBackend()); requested != "" && requested != backendName {
+		return nil, fmt.Errorf("snapshot %q requires backend %q, got %q", snapshotID, backendName, requested)
+	}
+
+	adapter, ok := s.Backends[backendName]
+	if !ok {
+		return nil, fmt.Errorf("unknown backend %q", backendName)
+	}
+	snapshotAdapter, ok := adapter.(backend.SnapshottingAdapter)
+	if !ok {
+		return nil, fmt.Errorf("backend %q does not support snapshot-backed sandbox creation", backendName)
+	}
+
+	compiled, err := policy.FromProto(record.Policy)
+	if err != nil {
+		return nil, fmt.Errorf("invalid snapshot policy %q: %w", snapshotID, err)
+	}
+
+	opts := req.GetOptions()
+	execOpts := executionOptions{}
+	if opts != nil {
+		execOpts.LaunchSeconds = opts.GetLaunchSeconds()
+	}
+	firecrackerCfg := mergeBackendConfig(backendName, execOpts, s.Config)
+	firecrackerCfg.RunDir = ""
+
+	now := time.Now().UTC()
+	sandboxID := newSandboxID()
+	if err := snapshotAdapter.ProvisionSandboxFromSnapshot(ctx, backend.ProvisionFromSnapshotRequest{
+		SandboxID:         sandboxID,
+		SnapshotID:        record.SnapshotID,
+		StorageRef:        record.StorageRef,
+		Policy:            compiled,
+		FirecrackerConfig: firecrackerCfg,
+	}); err != nil {
+		return nil, fmt.Errorf("provision sandbox from snapshot: %w", err)
+	}
+
+	state := &sandboxState{
+		ID:               sandboxID,
+		Backend:          backendName,
+		Policy:           compiled,
+		Firecracker:      firecrackerCfg,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+		Status:           cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY,
+		EventSubscribers: map[int]chan *cleanroomv1.SandboxEvent{},
+		Done:             make(chan struct{}),
+	}
+
+	s.mu.Lock()
+	s.ensureMapsLocked()
+	s.sandboxes[sandboxID] = state
+	s.recordSandboxEventLocked(state, cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY, fmt.Sprintf("sandbox created from snapshot %s and ready", snapshotID))
+	s.pruneStateLocked(now)
+	resp := &cleanroomv1.CreateSandboxResponse{
+		Sandbox: cloneSandboxLocked(state),
+		Message: "sandbox created from snapshot and ready",
+	}
+	s.mu.Unlock()
+
+	if s.Logger != nil {
+		s.Logger.Info("sandbox created from snapshot",
+			"sandbox_id", sandboxID,
+			"snapshot_id", snapshotID,
+			"backend", backendName,
+			"policy_hash", compiled.Hash,
+		)
+	}
+
+	return resp, nil
+}
+
 func (s *Service) GetSandbox(_ context.Context, req *cleanroomv1.GetSandboxRequest) (*cleanroomv1.GetSandboxResponse, error) {
 	if req == nil || strings.TrimSpace(req.GetSandboxId()) == "" {
 		return nil, errors.New("missing sandbox_id")
@@ -252,6 +357,287 @@ func (s *Service) ListSandboxes(_ context.Context, _ *cleanroomv1.ListSandboxesR
 		resp.Sandboxes = append(resp.Sandboxes, cloneSandboxLocked(sb))
 	}
 	return resp, nil
+}
+
+func (s *Service) CreateSnapshot(ctx context.Context, req *cleanroomv1.CreateSnapshotRequest) (*cleanroomv1.CreateSnapshotResponse, error) {
+	if req == nil {
+		return nil, errors.New("missing request")
+	}
+	sandboxID := strings.TrimSpace(req.GetSandboxId())
+	if sandboxID == "" {
+		return nil, errors.New("missing sandbox_id")
+	}
+
+	store, err := s.snapshotStoreOrErr()
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now().UTC()
+	snapshotID := newSnapshotID()
+	name := strings.TrimSpace(req.GetName())
+
+	var (
+		record          snapshotstore.Record
+		snapshotAdapter backend.SnapshottingAdapter
+	)
+
+	s.mu.Lock()
+	s.ensureMapsLocked()
+	state, ok := s.sandboxes[sandboxID]
+	if !ok {
+		s.mu.Unlock()
+		return nil, fmt.Errorf("unknown sandbox %q", sandboxID)
+	}
+	if err := ensureSandboxIdleLocked(sandboxID, state, s.executions); err != nil {
+		s.mu.Unlock()
+		return nil, err
+	}
+	adapter, ok := s.Backends[state.Backend]
+	if !ok {
+		s.mu.Unlock()
+		return nil, fmt.Errorf("unknown backend %q", state.Backend)
+	}
+	snapshotAdapter, ok = adapter.(backend.SnapshottingAdapter)
+	if !ok {
+		s.mu.Unlock()
+		return nil, fmt.Errorf("backend %q does not support snapshots", state.Backend)
+	}
+	if state.Policy == nil {
+		s.mu.Unlock()
+		return nil, fmt.Errorf("sandbox %q is missing compiled policy", sandboxID)
+	}
+	record = snapshotstore.Record{
+		SnapshotID:      snapshotID,
+		SourceSandboxID: sandboxID,
+		Backend:         state.Backend,
+		Name:            name,
+		PolicyHash:      state.Policy.Hash,
+		Policy:          state.Policy.ToProto(),
+		CreatedAt:       now,
+	}
+	s.recordSandboxEventLocked(state, cleanroomv1.SandboxStatus_SANDBOX_STATUS_PROVISIONING, fmt.Sprintf("snapshot %s in progress", snapshotID))
+	s.mu.Unlock()
+
+	result, err := snapshotAdapter.CreateSnapshot(ctx, backend.SnapshotRequest{
+		SandboxID:  sandboxID,
+		SnapshotID: snapshotID,
+	})
+	if err != nil {
+		s.mu.Lock()
+		if current, ok := s.sandboxes[sandboxID]; ok {
+			s.recordSandboxEventLocked(current, cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY, fmt.Sprintf("snapshot %s failed: %v", snapshotID, err))
+		}
+		s.mu.Unlock()
+		return nil, fmt.Errorf("create snapshot: %w", err)
+	}
+
+	record.StorageRef = strings.TrimSpace(result.StorageRef)
+	if err := store.Create(ctx, record); err != nil {
+		deleteErr := snapshotAdapter.DeleteSnapshot(ctx, backend.DeleteSnapshotRequest{
+			SnapshotID: snapshotID,
+			StorageRef: record.StorageRef,
+		})
+		if deleteErr != nil && s.Logger != nil {
+			s.Logger.Warn("rollback snapshot after metadata failure failed",
+				"snapshot_id", snapshotID,
+				"storage_ref", record.StorageRef,
+				"error", deleteErr,
+			)
+		}
+		s.mu.Lock()
+		if current, ok := s.sandboxes[sandboxID]; ok {
+			s.recordSandboxEventLocked(current, cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY, fmt.Sprintf("snapshot %s failed: %v", snapshotID, err))
+		}
+		s.mu.Unlock()
+		return nil, fmt.Errorf("persist snapshot metadata: %w", err)
+	}
+
+	s.mu.Lock()
+	if current, ok := s.sandboxes[sandboxID]; ok {
+		s.recordSandboxEventLocked(current, cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY, fmt.Sprintf("snapshot %s created", snapshotID))
+	}
+	s.mu.Unlock()
+
+	resp := &cleanroomv1.CreateSnapshotResponse{
+		Snapshot: cloneSnapshotRecord(record),
+		Message:  "snapshot created",
+	}
+	return resp, nil
+}
+
+func (s *Service) GetSnapshot(ctx context.Context, req *cleanroomv1.GetSnapshotRequest) (*cleanroomv1.GetSnapshotResponse, error) {
+	if req == nil || strings.TrimSpace(req.GetSnapshotId()) == "" {
+		return nil, errors.New("missing snapshot_id")
+	}
+
+	store, err := s.snapshotStoreOrErr()
+	if err != nil {
+		return nil, err
+	}
+	record, ok, err := store.Get(ctx, strings.TrimSpace(req.GetSnapshotId()))
+	if err != nil {
+		return nil, fmt.Errorf("load snapshot %q: %w", req.GetSnapshotId(), err)
+	}
+	if !ok {
+		return nil, fmt.Errorf("unknown snapshot %q", req.GetSnapshotId())
+	}
+	return &cleanroomv1.GetSnapshotResponse{Snapshot: cloneSnapshotRecord(record)}, nil
+}
+
+func (s *Service) ListSnapshots(ctx context.Context, _ *cleanroomv1.ListSnapshotsRequest) (*cleanroomv1.ListSnapshotsResponse, error) {
+	store, err := s.snapshotStoreOrErr()
+	if err != nil {
+		return nil, err
+	}
+	records, err := store.List(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list snapshots: %w", err)
+	}
+
+	resp := &cleanroomv1.ListSnapshotsResponse{Snapshots: make([]*cleanroomv1.Snapshot, 0, len(records))}
+	for _, record := range records {
+		resp.Snapshots = append(resp.Snapshots, cloneSnapshotRecord(record))
+	}
+	return resp, nil
+}
+
+func (s *Service) RestoreSandbox(ctx context.Context, req *cleanroomv1.RestoreSandboxRequest) (*cleanroomv1.RestoreSandboxResponse, error) {
+	if req == nil {
+		return nil, errors.New("missing request")
+	}
+	sandboxID := strings.TrimSpace(req.GetSandboxId())
+	if sandboxID == "" {
+		return nil, errors.New("missing sandbox_id")
+	}
+	snapshotID := strings.TrimSpace(req.GetSnapshotId())
+	if snapshotID == "" {
+		return nil, errors.New("missing snapshot_id")
+	}
+
+	store, err := s.snapshotStoreOrErr()
+	if err != nil {
+		return nil, err
+	}
+	record, ok, err := store.Get(ctx, snapshotID)
+	if err != nil {
+		return nil, fmt.Errorf("load snapshot %q: %w", snapshotID, err)
+	}
+	if !ok {
+		return nil, fmt.Errorf("unknown snapshot %q", snapshotID)
+	}
+
+	var (
+		restoreReq      backend.RestoreRequest
+		snapshotAdapter backend.SnapshottingAdapter
+	)
+
+	s.mu.Lock()
+	state, ok := s.sandboxes[sandboxID]
+	if !ok {
+		s.mu.Unlock()
+		return nil, fmt.Errorf("unknown sandbox %q", sandboxID)
+	}
+	if err := ensureSandboxIdleLocked(sandboxID, state, s.executions); err != nil {
+		s.mu.Unlock()
+		return nil, err
+	}
+	if state.Backend != record.Backend {
+		s.mu.Unlock()
+		return nil, fmt.Errorf("snapshot %q belongs to backend %q, sandbox %q uses %q", snapshotID, record.Backend, sandboxID, state.Backend)
+	}
+	if state.Policy == nil {
+		s.mu.Unlock()
+		return nil, fmt.Errorf("sandbox %q is missing compiled policy", sandboxID)
+	}
+	if state.Policy.Hash != record.PolicyHash {
+		s.mu.Unlock()
+		return nil, fmt.Errorf("snapshot %q policy hash %q does not match sandbox %q policy hash %q", snapshotID, record.PolicyHash, sandboxID, state.Policy.Hash)
+	}
+	adapter, ok := s.Backends[state.Backend]
+	if !ok {
+		s.mu.Unlock()
+		return nil, fmt.Errorf("unknown backend %q", state.Backend)
+	}
+	snapshotAdapter, ok = adapter.(backend.SnapshottingAdapter)
+	if !ok {
+		s.mu.Unlock()
+		return nil, fmt.Errorf("backend %q does not support sandbox restore", state.Backend)
+	}
+	restoreReq = backend.RestoreRequest{
+		SandboxID:         sandboxID,
+		SnapshotID:        snapshotID,
+		StorageRef:        record.StorageRef,
+		Policy:            state.Policy,
+		FirecrackerConfig: state.Firecracker,
+	}
+	s.recordSandboxEventLocked(state, cleanroomv1.SandboxStatus_SANDBOX_STATUS_PROVISIONING, fmt.Sprintf("restore from snapshot %s in progress", snapshotID))
+	s.mu.Unlock()
+
+	if err := snapshotAdapter.RestoreSandbox(ctx, restoreReq); err != nil {
+		s.mu.Lock()
+		if current, ok := s.sandboxes[sandboxID]; ok {
+			s.recordSandboxEventLocked(current, cleanroomv1.SandboxStatus_SANDBOX_STATUS_FAILED, fmt.Sprintf("restore from snapshot %s failed: %v", snapshotID, err))
+		}
+		s.mu.Unlock()
+		return nil, fmt.Errorf("restore sandbox: %w", err)
+	}
+
+	s.mu.Lock()
+	state, ok = s.sandboxes[sandboxID]
+	if !ok {
+		s.mu.Unlock()
+		return nil, fmt.Errorf("unknown sandbox %q", sandboxID)
+	}
+	s.recordSandboxEventLocked(state, cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY, fmt.Sprintf("sandbox restored from snapshot %s", snapshotID))
+	resp := &cleanroomv1.RestoreSandboxResponse{
+		Sandbox: cloneSandboxLocked(state),
+		Message: "sandbox restored from snapshot",
+	}
+	s.mu.Unlock()
+	return resp, nil
+}
+
+func (s *Service) DeleteSnapshot(ctx context.Context, req *cleanroomv1.DeleteSnapshotRequest) (*cleanroomv1.DeleteSnapshotResponse, error) {
+	if req == nil || strings.TrimSpace(req.GetSnapshotId()) == "" {
+		return nil, errors.New("missing snapshot_id")
+	}
+	snapshotID := strings.TrimSpace(req.GetSnapshotId())
+
+	store, err := s.snapshotStoreOrErr()
+	if err != nil {
+		return nil, err
+	}
+	record, ok, err := store.Get(ctx, snapshotID)
+	if err != nil {
+		return nil, fmt.Errorf("load snapshot %q: %w", snapshotID, err)
+	}
+	if !ok {
+		return nil, fmt.Errorf("unknown snapshot %q", snapshotID)
+	}
+
+	adapter, ok := s.Backends[record.Backend]
+	if !ok {
+		return nil, fmt.Errorf("unknown backend %q", record.Backend)
+	}
+	snapshotAdapter, ok := adapter.(backend.SnapshottingAdapter)
+	if !ok {
+		return nil, fmt.Errorf("backend %q does not support snapshot deletion", record.Backend)
+	}
+	if err := snapshotAdapter.DeleteSnapshot(ctx, backend.DeleteSnapshotRequest{
+		SnapshotID: snapshotID,
+		StorageRef: record.StorageRef,
+	}); err != nil {
+		return nil, fmt.Errorf("delete snapshot storage: %w", err)
+	}
+	if err := store.Delete(ctx, snapshotID); err != nil {
+		return nil, fmt.Errorf("delete snapshot metadata: %w", err)
+	}
+	return &cleanroomv1.DeleteSnapshotResponse{
+		SnapshotId: snapshotID,
+		Deleted:    true,
+		Message:    "snapshot deleted",
+	}, nil
 }
 
 func (s *Service) DownloadSandboxFile(ctx context.Context, req *cleanroomv1.DownloadSandboxFileRequest) (*cleanroomv1.DownloadSandboxFileResponse, error) {
@@ -1661,6 +2047,42 @@ func cancelExitCode(signal int32) int32 {
 
 func executionKey(sandboxID, executionID string) string {
 	return sandboxID + "/" + executionID
+}
+
+func ensureSandboxIdleLocked(sandboxID string, sb *sandboxState, executions map[string]*executionState) error {
+	if sb == nil {
+		return fmt.Errorf("unknown sandbox %q", sandboxID)
+	}
+	if sb.Status != cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY {
+		return fmt.Errorf("sandbox %q is not ready", sandboxID)
+	}
+	if sb.DownloadInProgress {
+		return fmt.Errorf("sandbox_busy: sandbox %q currently has an active file download", sandboxID)
+	}
+	if activeID := strings.TrimSpace(sb.ActiveExecutionID); activeID != "" {
+		if activeExecution, ok := executions[executionKey(sandboxID, activeID)]; ok && !isFinalExecutionStatus(activeExecution.Status) {
+			return fmt.Errorf("sandbox_busy: sandbox %q already has active execution %q", sandboxID, activeID)
+		}
+	}
+	return nil
+}
+
+func (s *Service) snapshotStoreOrErr() (snapshotMetadataStore, error) {
+	if s.SnapshotStore == nil {
+		return nil, errors.New("snapshot metadata store is not configured")
+	}
+	return s.SnapshotStore, nil
+}
+
+func cloneSnapshotRecord(record snapshotstore.Record) *cleanroomv1.Snapshot {
+	return &cleanroomv1.Snapshot{
+		SnapshotId:      record.SnapshotID,
+		SourceSandboxId: record.SourceSandboxID,
+		Backend:         record.Backend,
+		PolicyHash:      record.PolicyHash,
+		Name:            record.Name,
+		CreatedAt:       timestamppb.New(record.CreatedAt),
+	}
 }
 
 func cloneSandboxLocked(state *sandboxState) *cleanroomv1.Sandbox {

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -46,7 +46,6 @@ type sandboxState struct {
 	ID                 string
 	Backend            string
 	Policy             *policy.CompiledPolicy
-	SourceSnapshotID   string
 	Firecracker        backend.FirecrackerConfig
 	ActiveExecutionID  string
 	DownloadInProgress bool
@@ -305,7 +304,6 @@ func (s *Service) createSandboxFromSnapshot(ctx context.Context, req *cleanroomv
 		ID:               sandboxID,
 		Backend:          backendName,
 		Policy:           compiled,
-		SourceSnapshotID: snapshotID,
 		Firecracker:      firecrackerCfg,
 		CreatedAt:        now,
 		UpdatedAt:        now,
@@ -611,7 +609,6 @@ func (s *Service) RestoreSandbox(ctx context.Context, req *cleanroomv1.RestoreSa
 		s.mu.Unlock()
 		return nil, fmt.Errorf("unknown sandbox %q", sandboxID)
 	}
-	state.SourceSnapshotID = snapshotID
 	s.recordSandboxEventLocked(state, cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY, fmt.Sprintf("sandbox restored from snapshot %s", snapshotID))
 	resp := &cleanroomv1.RestoreSandboxResponse{
 		Sandbox: cloneSandboxLocked(state),
@@ -1723,14 +1720,6 @@ func (s *Service) beginSnapshotDeleteLocked(snapshotID string) error {
 	}
 	if count := s.snapshotOps[snapshotID]; count > 0 {
 		return fmt.Errorf("snapshot_busy: snapshot %q is currently in use by another operation", snapshotID)
-	}
-	for _, sb := range s.sandboxes {
-		if sb == nil || sb.Status == cleanroomv1.SandboxStatus_SANDBOX_STATUS_STOPPED {
-			continue
-		}
-		if strings.TrimSpace(sb.SourceSnapshotID) == snapshotID {
-			return fmt.Errorf("snapshot_busy: snapshot %q is in use by sandbox %q", snapshotID, sb.ID)
-		}
 	}
 	s.snapshotDeletions[snapshotID] = struct{}{}
 	return nil

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -33,6 +33,8 @@ type Service struct {
 	mu                  sync.RWMutex
 	sandboxes           map[string]*sandboxState
 	executions          map[string]*executionState
+	snapshotOps         map[string]int
+	snapshotDeletions   map[string]struct{}
 	interactiveSessions map[string]*interactiveSessionState
 	interactiveAttached map[string]struct{}
 	interactiveEndpoint string
@@ -44,6 +46,7 @@ type sandboxState struct {
 	ID                 string
 	Backend            string
 	Policy             *policy.CompiledPolicy
+	SourceSnapshotID   string
 	Firecracker        backend.FirecrackerConfig
 	ActiveExecutionID  string
 	DownloadInProgress bool
@@ -242,6 +245,15 @@ func (s *Service) createSandboxFromSnapshot(ctx context.Context, req *cleanroomv
 		return nil, err
 	}
 
+	s.mu.Lock()
+	s.ensureMapsLocked()
+	if err := s.beginSnapshotUseLocked(snapshotID); err != nil {
+		s.mu.Unlock()
+		return nil, err
+	}
+	s.mu.Unlock()
+	defer s.finishSnapshotUse(snapshotID)
+
 	record, ok, err := store.Get(ctx, snapshotID)
 	if err != nil {
 		return nil, fmt.Errorf("load snapshot %q: %w", snapshotID, err)
@@ -293,6 +305,7 @@ func (s *Service) createSandboxFromSnapshot(ctx context.Context, req *cleanroomv
 		ID:               sandboxID,
 		Backend:          backendName,
 		Policy:           compiled,
+		SourceSnapshotID: snapshotID,
 		Firecracker:      firecrackerCfg,
 		CreatedAt:        now,
 		UpdatedAt:        now,
@@ -519,6 +532,15 @@ func (s *Service) RestoreSandbox(ctx context.Context, req *cleanroomv1.RestoreSa
 	if err != nil {
 		return nil, err
 	}
+	s.mu.Lock()
+	s.ensureMapsLocked()
+	if err := s.beginSnapshotUseLocked(snapshotID); err != nil {
+		s.mu.Unlock()
+		return nil, err
+	}
+	s.mu.Unlock()
+	defer s.finishSnapshotUse(snapshotID)
+
 	record, ok, err := store.Get(ctx, snapshotID)
 	if err != nil {
 		return nil, fmt.Errorf("load snapshot %q: %w", snapshotID, err)
@@ -589,6 +611,7 @@ func (s *Service) RestoreSandbox(ctx context.Context, req *cleanroomv1.RestoreSa
 		s.mu.Unlock()
 		return nil, fmt.Errorf("unknown sandbox %q", sandboxID)
 	}
+	state.SourceSnapshotID = snapshotID
 	s.recordSandboxEventLocked(state, cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY, fmt.Sprintf("sandbox restored from snapshot %s", snapshotID))
 	resp := &cleanroomv1.RestoreSandboxResponse{
 		Sandbox: cloneSandboxLocked(state),
@@ -603,6 +626,15 @@ func (s *Service) DeleteSnapshot(ctx context.Context, req *cleanroomv1.DeleteSna
 		return nil, errors.New("missing snapshot_id")
 	}
 	snapshotID := strings.TrimSpace(req.GetSnapshotId())
+
+	s.mu.Lock()
+	s.ensureMapsLocked()
+	if err := s.beginSnapshotDeleteLocked(snapshotID); err != nil {
+		s.mu.Unlock()
+		return nil, err
+	}
+	s.mu.Unlock()
+	defer s.finishSnapshotDelete(snapshotID)
 
 	store, err := s.snapshotStoreOrErr()
 	if err != nil {
@@ -1653,12 +1685,61 @@ func (s *Service) ensureMapsLocked() {
 	if s.executions == nil {
 		s.executions = map[string]*executionState{}
 	}
+	if s.snapshotOps == nil {
+		s.snapshotOps = map[string]int{}
+	}
+	if s.snapshotDeletions == nil {
+		s.snapshotDeletions = map[string]struct{}{}
+	}
 	if s.interactiveSessions == nil {
 		s.interactiveSessions = map[string]*interactiveSessionState{}
 	}
 	if s.interactiveAttached == nil {
 		s.interactiveAttached = map[string]struct{}{}
 	}
+}
+
+func (s *Service) beginSnapshotUseLocked(snapshotID string) error {
+	if _, deleting := s.snapshotDeletions[snapshotID]; deleting {
+		return fmt.Errorf("snapshot_busy: snapshot %q is being deleted", snapshotID)
+	}
+	s.snapshotOps[snapshotID]++
+	return nil
+}
+
+func (s *Service) finishSnapshotUse(snapshotID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if count := s.snapshotOps[snapshotID]; count > 1 {
+		s.snapshotOps[snapshotID] = count - 1
+		return
+	}
+	delete(s.snapshotOps, snapshotID)
+}
+
+func (s *Service) beginSnapshotDeleteLocked(snapshotID string) error {
+	if _, deleting := s.snapshotDeletions[snapshotID]; deleting {
+		return fmt.Errorf("snapshot_busy: snapshot %q is already being deleted", snapshotID)
+	}
+	if count := s.snapshotOps[snapshotID]; count > 0 {
+		return fmt.Errorf("snapshot_busy: snapshot %q is currently in use by another operation", snapshotID)
+	}
+	for _, sb := range s.sandboxes {
+		if sb == nil || sb.Status == cleanroomv1.SandboxStatus_SANDBOX_STATUS_STOPPED {
+			continue
+		}
+		if strings.TrimSpace(sb.SourceSnapshotID) == snapshotID {
+			return fmt.Errorf("snapshot_busy: snapshot %q is in use by sandbox %q", snapshotID, sb.ID)
+		}
+	}
+	s.snapshotDeletions[snapshotID] = struct{}{}
+	return nil
+}
+
+func (s *Service) finishSnapshotDelete(snapshotID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.snapshotDeletions, snapshotID)
 }
 
 func (s *Service) pruneExpiredInteractiveSessionsLocked(now time.Time) {

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -447,8 +447,9 @@ func (s *Service) CreateSnapshot(ctx context.Context, req *cleanroomv1.CreateSna
 	record.StorageRef = strings.TrimSpace(result.StorageRef)
 	if err := store.Create(ctx, record); err != nil {
 		deleteErr := snapshotAdapter.DeleteSnapshot(ctx, backend.DeleteSnapshotRequest{
-			SnapshotID: snapshotID,
-			StorageRef: record.StorageRef,
+			SnapshotID:        snapshotID,
+			StorageRef:        record.StorageRef,
+			FirecrackerConfig: state.Firecracker,
 		})
 		if deleteErr != nil && s.Logger != nil {
 			s.Logger.Warn("rollback snapshot after metadata failure failed",
@@ -655,8 +656,9 @@ func (s *Service) DeleteSnapshot(ctx context.Context, req *cleanroomv1.DeleteSna
 		return nil, fmt.Errorf("backend %q does not support snapshot deletion", record.Backend)
 	}
 	if err := snapshotAdapter.DeleteSnapshot(ctx, backend.DeleteSnapshotRequest{
-		SnapshotID: snapshotID,
-		StorageRef: record.StorageRef,
+		SnapshotID:        snapshotID,
+		StorageRef:        record.StorageRef,
+		FirecrackerConfig: mergeBackendConfig(record.Backend, executionOptions{}, s.Config),
 	}); err != nil {
 		return nil, fmt.Errorf("delete snapshot storage: %w", err)
 	}

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -431,8 +431,9 @@ func (s *Service) CreateSnapshot(ctx context.Context, req *cleanroomv1.CreateSna
 	s.mu.Unlock()
 
 	result, err := snapshotAdapter.CreateSnapshot(ctx, backend.SnapshotRequest{
-		SandboxID:  sandboxID,
-		SnapshotID: snapshotID,
+		SandboxID:         sandboxID,
+		SnapshotID:        snapshotID,
+		FirecrackerConfig: state.Firecracker,
 	})
 	if err != nil {
 		s.mu.Lock()
@@ -2405,6 +2406,13 @@ func mergeBackendConfig(backendName string, opts executionOptions, cfg runtimeco
 		DockerStartupSeconds: cfg.Backends.Firecracker.Services.Docker.StartupTimeoutSeconds,
 		DockerStorageDriver:  cfg.Backends.Firecracker.Services.Docker.StorageDriver,
 		DockerIPTables:       cfg.Backends.Firecracker.Services.Docker.IPTables,
+		Snapshots: backend.SnapshotConfig{
+			Enabled:               cfg.Backends.Firecracker.Snapshots.Enabled,
+			Driver:                cfg.Backends.Firecracker.Snapshots.Driver,
+			BaseDir:               cfg.Backends.Firecracker.Snapshots.BaseDir,
+			ZFSDataset:            cfg.Backends.Firecracker.Snapshots.ZFSDataset,
+			QuiesceTimeoutSeconds: cfg.Backends.Firecracker.Snapshots.QuiesceTimeoutSeconds,
+		},
 		PrivilegedMode:       cfg.Backends.Firecracker.PrivilegedMode,
 		PrivilegedHelperPath: cfg.Backends.Firecracker.PrivilegedHelperPath,
 		VCPUs:                cfg.Backends.Firecracker.VCPUs,
@@ -2419,6 +2427,13 @@ func mergeBackendConfig(backendName string, opts executionOptions, cfg runtimeco
 		out.DockerStartupSeconds = cfg.Backends.DarwinVZ.Services.Docker.StartupTimeoutSeconds
 		out.DockerStorageDriver = cfg.Backends.DarwinVZ.Services.Docker.StorageDriver
 		out.DockerIPTables = cfg.Backends.DarwinVZ.Services.Docker.IPTables
+		out.Snapshots = backend.SnapshotConfig{
+			Enabled:               cfg.Backends.DarwinVZ.Snapshots.Enabled,
+			Driver:                cfg.Backends.DarwinVZ.Snapshots.Driver,
+			BaseDir:               cfg.Backends.DarwinVZ.Snapshots.BaseDir,
+			ZFSDataset:            cfg.Backends.DarwinVZ.Snapshots.ZFSDataset,
+			QuiesceTimeoutSeconds: cfg.Backends.DarwinVZ.Snapshots.QuiesceTimeoutSeconds,
+		}
 		out.VCPUs = cfg.Backends.DarwinVZ.VCPUs
 		out.MemoryMiB = cfg.Backends.DarwinVZ.MemoryMiB
 		out.GuestPort = cfg.Backends.DarwinVZ.GuestPort

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -42,6 +42,11 @@ type Service struct {
 	interactiveCertPin  string
 }
 
+type pendingCheckpointState struct {
+	Name        string
+	RequestedAt time.Time
+}
+
 type sandboxState struct {
 	ID                 string
 	Backend            string
@@ -49,6 +54,7 @@ type sandboxState struct {
 	Firecracker        backend.FirecrackerConfig
 	ActiveExecutionID  string
 	DownloadInProgress bool
+	PendingCheckpoint  *pendingCheckpointState
 	CreatedAt          time.Time
 	UpdatedAt          time.Time
 	LastExecutionID    string
@@ -370,55 +376,37 @@ func (s *Service) ListSandboxes(_ context.Context, _ *cleanroomv1.ListSandboxesR
 	return resp, nil
 }
 
-func (s *Service) CreateSnapshot(ctx context.Context, req *cleanroomv1.CreateSnapshotRequest) (*cleanroomv1.CreateSnapshotResponse, error) {
-	if req == nil {
-		return nil, errors.New("missing request")
-	}
-	sandboxID := strings.TrimSpace(req.GetSandboxId())
-	if sandboxID == "" {
-		return nil, errors.New("missing sandbox_id")
-	}
-
+func (s *Service) createSnapshotForSandbox(ctx context.Context, sandboxID, name, trigger string) (string, error) {
 	store, err := s.snapshotStoreOrErr()
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	now := time.Now().UTC()
 	snapshotID := newSnapshotID()
-	name := strings.TrimSpace(req.GetName())
-
-	var (
-		record          snapshotstore.Record
-		snapshotAdapter backend.SnapshottingAdapter
-	)
 
 	s.mu.Lock()
 	s.ensureMapsLocked()
 	state, ok := s.sandboxes[sandboxID]
 	if !ok {
 		s.mu.Unlock()
-		return nil, fmt.Errorf("unknown sandbox %q", sandboxID)
-	}
-	if err := ensureSandboxIdleLocked(sandboxID, state, s.executions); err != nil {
-		s.mu.Unlock()
-		return nil, err
+		return "", fmt.Errorf("unknown sandbox %q", sandboxID)
 	}
 	adapter, ok := s.Backends[state.Backend]
 	if !ok {
 		s.mu.Unlock()
-		return nil, fmt.Errorf("unknown backend %q", state.Backend)
+		return "", fmt.Errorf("unknown backend %q", state.Backend)
 	}
-	snapshotAdapter, ok = adapter.(backend.SnapshottingAdapter)
+	snapshotAdapter, ok := adapter.(backend.SnapshottingAdapter)
 	if !ok {
 		s.mu.Unlock()
-		return nil, fmt.Errorf("backend %q does not support snapshots", state.Backend)
+		return "", fmt.Errorf("backend %q does not support snapshots", state.Backend)
 	}
 	if state.Policy == nil {
 		s.mu.Unlock()
-		return nil, fmt.Errorf("sandbox %q is missing compiled policy", sandboxID)
+		return "", fmt.Errorf("sandbox %q is missing compiled policy", sandboxID)
 	}
-	record = snapshotstore.Record{
+	record := snapshotstore.Record{
 		SnapshotID:      snapshotID,
 		SourceSandboxID: sandboxID,
 		Backend:         state.Backend,
@@ -427,13 +415,14 @@ func (s *Service) CreateSnapshot(ctx context.Context, req *cleanroomv1.CreateSna
 		Policy:          state.Policy.ToProto(),
 		CreatedAt:       now,
 	}
-	s.recordSandboxEventLocked(state, cleanroomv1.SandboxStatus_SANDBOX_STATUS_PROVISIONING, fmt.Sprintf("snapshot %s in progress", snapshotID))
+	s.recordSandboxEventLocked(state, cleanroomv1.SandboxStatus_SANDBOX_STATUS_PROVISIONING, fmt.Sprintf("snapshot %s in progress (%s)", snapshotID, trigger))
+	fcConfig := state.Firecracker
 	s.mu.Unlock()
 
 	result, err := snapshotAdapter.CreateSnapshot(ctx, backend.SnapshotRequest{
 		SandboxID:         sandboxID,
 		SnapshotID:        snapshotID,
-		FirecrackerConfig: state.Firecracker,
+		FirecrackerConfig: fcConfig,
 	})
 	if err != nil {
 		s.mu.Lock()
@@ -441,7 +430,7 @@ func (s *Service) CreateSnapshot(ctx context.Context, req *cleanroomv1.CreateSna
 			s.recordSandboxEventLocked(current, cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY, fmt.Sprintf("snapshot %s failed: %v", snapshotID, err))
 		}
 		s.mu.Unlock()
-		return nil, fmt.Errorf("create snapshot: %w", err)
+		return "", fmt.Errorf("create snapshot: %w", err)
 	}
 
 	record.StorageRef = strings.TrimSpace(result.StorageRef)
@@ -449,7 +438,7 @@ func (s *Service) CreateSnapshot(ctx context.Context, req *cleanroomv1.CreateSna
 		deleteErr := snapshotAdapter.DeleteSnapshot(ctx, backend.DeleteSnapshotRequest{
 			SnapshotID:        snapshotID,
 			StorageRef:        record.StorageRef,
-			FirecrackerConfig: state.Firecracker,
+			FirecrackerConfig: fcConfig,
 		})
 		if deleteErr != nil && s.Logger != nil {
 			s.Logger.Warn("rollback snapshot after metadata failure failed",
@@ -463,20 +452,140 @@ func (s *Service) CreateSnapshot(ctx context.Context, req *cleanroomv1.CreateSna
 			s.recordSandboxEventLocked(current, cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY, fmt.Sprintf("snapshot %s failed: %v", snapshotID, err))
 		}
 		s.mu.Unlock()
-		return nil, fmt.Errorf("persist snapshot metadata: %w", err)
+		return "", fmt.Errorf("persist snapshot metadata: %w", err)
 	}
 
 	s.mu.Lock()
 	if current, ok := s.sandboxes[sandboxID]; ok {
-		s.recordSandboxEventLocked(current, cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY, fmt.Sprintf("snapshot %s created", snapshotID))
+		s.recordSandboxEventLocked(current, cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY, fmt.Sprintf("snapshot %s created (%s)", snapshotID, trigger))
 	}
 	s.mu.Unlock()
 
-	resp := &cleanroomv1.CreateSnapshotResponse{
+	return snapshotID, nil
+}
+
+func (s *Service) CreateSnapshot(ctx context.Context, req *cleanroomv1.CreateSnapshotRequest) (*cleanroomv1.CreateSnapshotResponse, error) {
+	if req == nil {
+		return nil, errors.New("missing request")
+	}
+	sandboxID := strings.TrimSpace(req.GetSandboxId())
+	if sandboxID == "" {
+		return nil, errors.New("missing sandbox_id")
+	}
+	name := strings.TrimSpace(req.GetName())
+
+	// Validate idle state before calling helper.
+	s.mu.Lock()
+	s.ensureMapsLocked()
+	state, ok := s.sandboxes[sandboxID]
+	if !ok {
+		s.mu.Unlock()
+		return nil, fmt.Errorf("unknown sandbox %q", sandboxID)
+	}
+	if err := ensureSandboxIdleLocked(sandboxID, state, s.executions); err != nil {
+		s.mu.Unlock()
+		return nil, err
+	}
+	s.mu.Unlock()
+
+	snapshotID, err := s.createSnapshotForSandbox(ctx, sandboxID, name, "user request")
+	if err != nil {
+		return nil, err
+	}
+
+	store, err := s.snapshotStoreOrErr()
+	if err != nil {
+		return nil, err
+	}
+	record, _, err := store.Get(ctx, snapshotID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &cleanroomv1.CreateSnapshotResponse{
 		Snapshot: cloneSnapshotRecord(record),
 		Message:  "snapshot created",
+	}, nil
+}
+
+func (s *Service) RequestCheckpoint(ctx context.Context, sandboxID, name string) (accepted, pending bool, message string, err error) {
+	s.mu.Lock()
+	s.ensureMapsLocked()
+	state, ok := s.sandboxes[sandboxID]
+	if !ok {
+		s.mu.Unlock()
+		return false, false, "", fmt.Errorf("unknown sandbox %q", sandboxID)
 	}
-	return resp, nil
+	if state.PendingCheckpoint != nil {
+		s.mu.Unlock()
+		return false, false, "", fmt.Errorf("sandbox %q already has a pending checkpoint", sandboxID)
+	}
+
+	// Check if sandbox is idle (no active exec, no download).
+	idleErr := ensureSandboxIdleLocked(sandboxID, state, s.executions)
+	if idleErr != nil {
+		// Sandbox is busy — record as pending.
+		state.PendingCheckpoint = &pendingCheckpointState{
+			Name:        name,
+			RequestedAt: time.Now().UTC(),
+		}
+		s.recordSandboxEventLocked(state, state.Status, fmt.Sprintf("checkpoint requested (pending): %s", name))
+		s.mu.Unlock()
+		return true, true, "checkpoint will be materialized when sandbox becomes idle", nil
+	}
+
+	// Sandbox is idle — we can snapshot immediately. Mark materializing.
+	state.PendingCheckpoint = &pendingCheckpointState{
+		Name:        name,
+		RequestedAt: time.Now().UTC(),
+	}
+	s.recordSandboxEventLocked(state, cleanroomv1.SandboxStatus_SANDBOX_STATUS_PROVISIONING, fmt.Sprintf("checkpoint requested (materializing): %s", name))
+	s.mu.Unlock()
+
+	// Materialize immediately in a goroutine so the guest call returns quickly.
+	go s.materializePendingCheckpoint(sandboxID)
+	return true, false, "checkpoint accepted, materializing now", nil
+}
+
+func (s *Service) materializePendingCheckpoint(sandboxID string) {
+	s.mu.Lock()
+	state, ok := s.sandboxes[sandboxID]
+	if !ok || state.PendingCheckpoint == nil {
+		s.mu.Unlock()
+		return
+	}
+	name := state.PendingCheckpoint.Name
+	s.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	snapshotID, err := s.createSnapshotForSandbox(ctx, sandboxID, name, "guest checkpoint")
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state, ok = s.sandboxes[sandboxID]
+	if !ok {
+		return
+	}
+	state.PendingCheckpoint = nil
+	if err != nil {
+		s.recordSandboxEventLocked(state, cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY, fmt.Sprintf("guest checkpoint failed: %v", err))
+		if s.Logger != nil {
+			s.Logger.Warn("materialize pending checkpoint failed",
+				"sandbox_id", sandboxID,
+				"error", err,
+			)
+		}
+		return
+	}
+	s.recordSandboxEventLocked(state, cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY, fmt.Sprintf("guest checkpoint materialized: snapshot %s", snapshotID))
+	if s.Logger != nil {
+		s.Logger.Info("guest checkpoint materialized",
+			"sandbox_id", sandboxID,
+			"snapshot_id", snapshotID,
+			"name", name,
+		)
+	}
 }
 
 func (s *Service) GetSnapshot(ctx context.Context, req *cleanroomv1.GetSnapshotRequest) (*cleanroomv1.GetSnapshotResponse, error) {
@@ -1567,6 +1676,17 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 	if sb, ok := s.sandboxes[sandboxID]; ok && sb.ActiveExecutionID == executionID {
 		sb.ActiveExecutionID = ""
 		sb.UpdatedAt = time.Now().UTC()
+	}
+
+	// Check for pending checkpoint after successful execution.
+	if sb, ok := s.sandboxes[sandboxID]; ok && sb.PendingCheckpoint != nil {
+		// Only materialize on successful execution.
+		if err == nil && result != nil && result.ExitCode == 0 {
+			go s.materializePendingCheckpoint(sandboxID)
+		} else {
+			sb.PendingCheckpoint = nil
+			s.recordSandboxEventLocked(sb, sb.Status, "pending checkpoint discarded: execution did not succeed")
+		}
 	}
 
 	if ex.Cancel != nil {

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -505,7 +505,7 @@ func TestRestoreSandboxUsesSnapshotMetadata(t *testing.T) {
 	}
 }
 
-func TestDeleteSnapshotRejectsSnapshotUsedByActiveSandbox(t *testing.T) {
+func TestDeleteSnapshotAllowsDeleteAfterSnapshotBackedSandboxReady(t *testing.T) {
 	store := newMemorySnapshotStore()
 	adapter := &stubAdapter{
 		createSnapshotFn: func(_ context.Context, req backend.SnapshotRequest) (*backend.SnapshotResult, error) {
@@ -539,33 +539,35 @@ func TestDeleteSnapshotRejectsSnapshotUsedByActiveSandbox(t *testing.T) {
 		t.Fatal("expected fork sandbox id")
 	}
 
-	_, err = svc.DeleteSnapshot(context.Background(), &cleanroomv1.DeleteSnapshotRequest{SnapshotId: snapshotID})
-	if err == nil {
-		t.Fatal("expected delete snapshot to fail while snapshot is in use")
-	}
-	if !strings.Contains(err.Error(), "snapshot_busy") || !strings.Contains(err.Error(), forkSandboxID) {
-		t.Fatalf("unexpected delete snapshot error: %v", err)
-	}
-	if adapter.deleteSnapshotCalls != 0 {
-		t.Fatalf("expected no backend delete calls while snapshot is in use, got %d", adapter.deleteSnapshotCalls)
-	}
-
-	terminateResp, err := svc.TerminateSandbox(context.Background(), &cleanroomv1.TerminateSandboxRequest{
-		SandboxId: forkSandboxID,
+	restoreResp, err := svc.RestoreSandbox(context.Background(), &cleanroomv1.RestoreSandboxRequest{
+		SandboxId:  sourceSandbox.GetSandboxId(),
+		SnapshotId: snapshotID,
 	})
 	if err != nil {
-		t.Fatalf("TerminateSandbox returned error: %v", err)
+		t.Fatalf("RestoreSandbox returned error: %v", err)
 	}
-	if !terminateResp.GetTerminated() {
-		t.Fatal("expected terminated=true")
+	if got, want := restoreResp.GetSandbox().GetStatus(), cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY; got != want {
+		t.Fatalf("unexpected restored sandbox status: got %v want %v", got, want)
 	}
 
 	deleteResp, err := svc.DeleteSnapshot(context.Background(), &cleanroomv1.DeleteSnapshotRequest{SnapshotId: snapshotID})
 	if err != nil {
-		t.Fatalf("DeleteSnapshot returned error after terminate: %v", err)
+		t.Fatalf("DeleteSnapshot returned error: %v", err)
 	}
 	if !deleteResp.GetDeleted() {
-		t.Fatal("expected deleted=true after terminate")
+		t.Fatal("expected deleted=true")
+	}
+	if got, want := adapter.deleteSnapshotCalls, 1; got != want {
+		t.Fatalf("unexpected backend delete call count: got %d want %d", got, want)
+	}
+	for _, sandboxID := range []string{sourceSandbox.GetSandboxId(), forkSandboxID} {
+		getResp, getErr := svc.GetSandbox(context.Background(), &cleanroomv1.GetSandboxRequest{SandboxId: sandboxID})
+		if getErr != nil {
+			t.Fatalf("GetSandbox returned error for %q: %v", sandboxID, getErr)
+		}
+		if got, want := getResp.GetSandbox().GetStatus(), cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY; got != want {
+			t.Fatalf("unexpected sandbox status for %q: got %v want %v", sandboxID, got, want)
+		}
 	}
 }
 
@@ -632,6 +634,81 @@ func TestDeleteSnapshotRejectsSnapshotWithInFlightProvisionFromSnapshot(t *testi
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("expected create-from-snapshot to finish")
+	}
+}
+
+func TestDeleteSnapshotRejectsSnapshotWithInFlightRestore(t *testing.T) {
+	store := newMemorySnapshotStore()
+	restoreStarted := make(chan struct{}, 1)
+	restoreRelease := make(chan struct{})
+	restoreDone := make(chan error, 1)
+	adapter := &stubAdapter{
+		createSnapshotFn: func(_ context.Context, req backend.SnapshotRequest) (*backend.SnapshotResult, error) {
+			return &backend.SnapshotResult{StorageRef: "/snapshots/" + req.SnapshotID + ".ext4"}, nil
+		},
+		restoreFn: func(_ context.Context, _ backend.RestoreRequest) error {
+			select {
+			case restoreStarted <- struct{}{}:
+			default:
+			}
+			<-restoreRelease
+			return nil
+		},
+	}
+	svc := newTestServiceWithSnapshotStore(adapter, store)
+
+	sourceResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sourceSandbox := sourceResp.GetSandbox()
+
+	snapshotResp, err := svc.CreateSnapshot(context.Background(), &cleanroomv1.CreateSnapshotRequest{
+		SandboxId: sourceSandbox.GetSandboxId(),
+	})
+	if err != nil {
+		t.Fatalf("CreateSnapshot returned error: %v", err)
+	}
+	snapshotID := snapshotResp.GetSnapshot().GetSnapshotId()
+
+	go func() {
+		_, restoreErr := svc.RestoreSandbox(context.Background(), &cleanroomv1.RestoreSandboxRequest{
+			SandboxId:  sourceSandbox.GetSandboxId(),
+			SnapshotId: snapshotID,
+		})
+		restoreDone <- restoreErr
+	}()
+
+	select {
+	case <-restoreStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected restore to start")
+	}
+
+	_, err = svc.DeleteSnapshot(context.Background(), &cleanroomv1.DeleteSnapshotRequest{SnapshotId: snapshotID})
+	if err == nil {
+		t.Fatal("expected delete snapshot to fail while restore is in flight")
+	}
+	if !strings.Contains(err.Error(), "snapshot_busy") || !strings.Contains(err.Error(), "another operation") {
+		t.Fatalf("unexpected delete snapshot error: %v", err)
+	}
+
+	close(restoreRelease)
+	select {
+	case restoreErr := <-restoreDone:
+		if restoreErr != nil {
+			t.Fatalf("RestoreSandbox returned error: %v", restoreErr)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected restore to finish")
+	}
+
+	deleteResp, err := svc.DeleteSnapshot(context.Background(), &cleanroomv1.DeleteSnapshotRequest{SnapshotId: snapshotID})
+	if err != nil {
+		t.Fatalf("DeleteSnapshot returned error after restore: %v", err)
+	}
+	if !deleteResp.GetDeleted() {
+		t.Fatal("expected deleted=true after restore")
 	}
 }
 

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 	"unsafe"
@@ -13,21 +14,34 @@ import (
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
 	"github.com/buildkite/cleanroom/internal/policy"
 	"github.com/buildkite/cleanroom/internal/runtimeconfig"
+	"github.com/buildkite/cleanroom/internal/snapshotstore"
 	"go.jetify.com/typeid"
 )
 
 type stubAdapter struct {
-	result         *backend.RunResult
-	runFn          func(context.Context, backend.RunRequest) (*backend.RunResult, error)
-	runStreamFn    func(context.Context, backend.RunRequest, backend.OutputStream) (*backend.RunResult, error)
-	provisionFn    func(context.Context, backend.ProvisionRequest) error
-	terminateFn    func(context.Context, string) error
-	downloadFn     func(context.Context, string, string, int64) ([]byte, error)
-	req            backend.RunRequest
-	provisionReq   backend.ProvisionRequest
-	runCalls       int
-	provisionCalls int
-	terminateCalls int
+	result                     *backend.RunResult
+	runFn                      func(context.Context, backend.RunRequest) (*backend.RunResult, error)
+	runStreamFn                func(context.Context, backend.RunRequest, backend.OutputStream) (*backend.RunResult, error)
+	provisionFn                func(context.Context, backend.ProvisionRequest) error
+	provisionFromSnapshotFn    func(context.Context, backend.ProvisionFromSnapshotRequest) error
+	createSnapshotFn           func(context.Context, backend.SnapshotRequest) (*backend.SnapshotResult, error)
+	restoreFn                  func(context.Context, backend.RestoreRequest) error
+	deleteSnapshotFn           func(context.Context, backend.DeleteSnapshotRequest) error
+	terminateFn                func(context.Context, string) error
+	downloadFn                 func(context.Context, string, string, int64) ([]byte, error)
+	req                        backend.RunRequest
+	provisionReq               backend.ProvisionRequest
+	provisionFromSnapshotReq   backend.ProvisionFromSnapshotRequest
+	createSnapshotReq          backend.SnapshotRequest
+	restoreReq                 backend.RestoreRequest
+	deleteSnapshotReq          backend.DeleteSnapshotRequest
+	runCalls                   int
+	provisionCalls             int
+	provisionFromSnapshotCalls int
+	createSnapshotCalls        int
+	restoreCalls               int
+	deleteSnapshotCalls        int
+	terminateCalls             int
 }
 
 func (s *stubAdapter) Name() string { return "stub" }
@@ -101,6 +115,42 @@ func (s *stubAdapter) RunInSandbox(ctx context.Context, req backend.RunRequest, 
 	return s.RunStream(ctx, req, stream)
 }
 
+func (s *stubAdapter) CreateSnapshot(ctx context.Context, req backend.SnapshotRequest) (*backend.SnapshotResult, error) {
+	s.createSnapshotReq = req
+	s.createSnapshotCalls++
+	if s.createSnapshotFn != nil {
+		return s.createSnapshotFn(ctx, req)
+	}
+	return &backend.SnapshotResult{StorageRef: "/tmp/snapshot.ext4"}, nil
+}
+
+func (s *stubAdapter) ProvisionSandboxFromSnapshot(ctx context.Context, req backend.ProvisionFromSnapshotRequest) error {
+	s.provisionFromSnapshotReq = req
+	s.provisionFromSnapshotCalls++
+	if s.provisionFromSnapshotFn != nil {
+		return s.provisionFromSnapshotFn(ctx, req)
+	}
+	return nil
+}
+
+func (s *stubAdapter) RestoreSandbox(ctx context.Context, req backend.RestoreRequest) error {
+	s.restoreReq = req
+	s.restoreCalls++
+	if s.restoreFn != nil {
+		return s.restoreFn(ctx, req)
+	}
+	return nil
+}
+
+func (s *stubAdapter) DeleteSnapshot(ctx context.Context, req backend.DeleteSnapshotRequest) error {
+	s.deleteSnapshotReq = req
+	s.deleteSnapshotCalls++
+	if s.deleteSnapshotFn != nil {
+		return s.deleteSnapshotFn(ctx, req)
+	}
+	return nil
+}
+
 func (s *stubAdapter) TerminateSandbox(ctx context.Context, sandboxID string) error {
 	s.terminateCalls++
 	if s.terminateFn != nil {
@@ -135,6 +185,10 @@ func testPolicy() *cleanroomv1.Policy {
 }
 
 func newTestService(adapter backend.Adapter) *Service {
+	return newTestServiceWithSnapshotStore(adapter, nil)
+}
+
+func newTestServiceWithSnapshotStore(adapter backend.Adapter, store snapshotMetadataStore) *Service {
 	return &Service{
 		Loader: stubLoader{
 			compiled: &policy.CompiledPolicy{
@@ -148,8 +202,52 @@ func newTestService(adapter backend.Adapter) *Service {
 		Config: runtimeconfig.Config{
 			DefaultBackend: "firecracker",
 		},
-		Backends: map[string]backend.Adapter{"firecracker": adapter},
+		Backends:      map[string]backend.Adapter{"firecracker": adapter},
+		SnapshotStore: store,
 	}
+}
+
+type memorySnapshotStore struct {
+	mu      sync.Mutex
+	records map[string]snapshotstore.Record
+}
+
+func newMemorySnapshotStore() *memorySnapshotStore {
+	return &memorySnapshotStore{records: map[string]snapshotstore.Record{}}
+}
+
+func (s *memorySnapshotStore) Create(_ context.Context, record snapshotstore.Record) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.records[record.SnapshotID]; exists {
+		return errors.New("snapshot already exists")
+	}
+	s.records[record.SnapshotID] = record
+	return nil
+}
+
+func (s *memorySnapshotStore) Get(_ context.Context, snapshotID string) (snapshotstore.Record, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	record, ok := s.records[snapshotID]
+	return record, ok, nil
+}
+
+func (s *memorySnapshotStore) List(_ context.Context) ([]snapshotstore.Record, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	items := make([]snapshotstore.Record, 0, len(s.records))
+	for _, record := range s.records {
+		items = append(items, record)
+	}
+	return items, nil
+}
+
+func (s *memorySnapshotStore) Delete(_ context.Context, snapshotID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.records, snapshotID)
+	return nil
 }
 
 func TestExecutionStreamIncludesExitEvent(t *testing.T) {
@@ -227,6 +325,183 @@ func TestExecutionStreamIncludesExitEvent(t *testing.T) {
 	}
 	if got, want := exit.GetStatus(), cleanroomv1.ExecutionStatus_EXECUTION_STATUS_FAILED; got != want {
 		t.Fatalf("unexpected exit status: got %v want %v", got, want)
+	}
+}
+
+func TestCreateSnapshotPersistsMetadataAndDeletesIt(t *testing.T) {
+	store := newMemorySnapshotStore()
+	adapter := &stubAdapter{
+		createSnapshotFn: func(_ context.Context, req backend.SnapshotRequest) (*backend.SnapshotResult, error) {
+			return &backend.SnapshotResult{StorageRef: "/snapshots/" + req.SnapshotID + ".ext4"}, nil
+		},
+	}
+	svc := newTestServiceWithSnapshotStore(adapter, store)
+
+	createResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandbox := createResp.GetSandbox()
+
+	snapshotResp, err := svc.CreateSnapshot(context.Background(), &cleanroomv1.CreateSnapshotRequest{
+		SandboxId: sandbox.GetSandboxId(),
+		Name:      "golden",
+	})
+	if err != nil {
+		t.Fatalf("CreateSnapshot returned error: %v", err)
+	}
+
+	snapshot := snapshotResp.GetSnapshot()
+	if snapshot == nil {
+		t.Fatal("expected snapshot in response")
+	}
+	if got, want := snapshot.GetSourceSandboxId(), sandbox.GetSandboxId(); got != want {
+		t.Fatalf("unexpected source sandbox id: got %q want %q", got, want)
+	}
+	if got, want := snapshot.GetBackend(), "firecracker"; got != want {
+		t.Fatalf("unexpected backend: got %q want %q", got, want)
+	}
+	if got, want := snapshot.GetName(), "golden"; got != want {
+		t.Fatalf("unexpected snapshot name: got %q want %q", got, want)
+	}
+	if got, want := adapter.createSnapshotReq.SandboxID, sandbox.GetSandboxId(); got != want {
+		t.Fatalf("unexpected create snapshot sandbox id: got %q want %q", got, want)
+	}
+	if adapter.createSnapshotCalls != 1 {
+		t.Fatalf("expected one snapshot create call, got %d", adapter.createSnapshotCalls)
+	}
+
+	getResp, err := svc.GetSnapshot(context.Background(), &cleanroomv1.GetSnapshotRequest{
+		SnapshotId: snapshot.GetSnapshotId(),
+	})
+	if err != nil {
+		t.Fatalf("GetSnapshot returned error: %v", err)
+	}
+	if got, want := getResp.GetSnapshot().GetSnapshotId(), snapshot.GetSnapshotId(); got != want {
+		t.Fatalf("unexpected snapshot id from get: got %q want %q", got, want)
+	}
+
+	listResp, err := svc.ListSnapshots(context.Background(), &cleanroomv1.ListSnapshotsRequest{})
+	if err != nil {
+		t.Fatalf("ListSnapshots returned error: %v", err)
+	}
+	if got, want := len(listResp.GetSnapshots()), 1; got != want {
+		t.Fatalf("unexpected snapshot count: got %d want %d", got, want)
+	}
+
+	deleteResp, err := svc.DeleteSnapshot(context.Background(), &cleanroomv1.DeleteSnapshotRequest{
+		SnapshotId: snapshot.GetSnapshotId(),
+	})
+	if err != nil {
+		t.Fatalf("DeleteSnapshot returned error: %v", err)
+	}
+	if !deleteResp.GetDeleted() {
+		t.Fatal("expected snapshot delete to report deleted=true")
+	}
+	if got, want := adapter.deleteSnapshotReq.SnapshotID, snapshot.GetSnapshotId(); got != want {
+		t.Fatalf("unexpected deleted snapshot id: got %q want %q", got, want)
+	}
+
+	listResp, err = svc.ListSnapshots(context.Background(), &cleanroomv1.ListSnapshotsRequest{})
+	if err != nil {
+		t.Fatalf("ListSnapshots after delete returned error: %v", err)
+	}
+	if got := len(listResp.GetSnapshots()); got != 0 {
+		t.Fatalf("expected no snapshots after delete, got %d", got)
+	}
+}
+
+func TestCreateSandboxFromSnapshotUsesStoredPolicyAndSnapshotBackend(t *testing.T) {
+	store := newMemorySnapshotStore()
+	adapter := &stubAdapter{
+		createSnapshotFn: func(_ context.Context, req backend.SnapshotRequest) (*backend.SnapshotResult, error) {
+			return &backend.SnapshotResult{StorageRef: "/snapshots/" + req.SnapshotID + ".ext4"}, nil
+		},
+	}
+	svc := newTestServiceWithSnapshotStore(adapter, store)
+
+	sourceResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sourceSandbox := sourceResp.GetSandbox()
+
+	snapshotResp, err := svc.CreateSnapshot(context.Background(), &cleanroomv1.CreateSnapshotRequest{
+		SandboxId: sourceSandbox.GetSandboxId(),
+		Name:      "deps",
+	})
+	if err != nil {
+		t.Fatalf("CreateSnapshot returned error: %v", err)
+	}
+
+	forkResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Source: &cleanroomv1.CreateSandboxRequest_SnapshotId{
+			SnapshotId: snapshotResp.GetSnapshot().GetSnapshotId(),
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox from snapshot returned error: %v", err)
+	}
+	if got, want := forkResp.GetSandbox().GetBackend(), "firecracker"; got != want {
+		t.Fatalf("unexpected backend: got %q want %q", got, want)
+	}
+	if got, want := adapter.provisionFromSnapshotReq.SnapshotID, snapshotResp.GetSnapshot().GetSnapshotId(); got != want {
+		t.Fatalf("unexpected provision snapshot id: got %q want %q", got, want)
+	}
+	if got, want := adapter.provisionFromSnapshotReq.StorageRef, "/snapshots/"+snapshotResp.GetSnapshot().GetSnapshotId()+".ext4"; got != want {
+		t.Fatalf("unexpected snapshot storage ref: got %q want %q", got, want)
+	}
+	if adapter.provisionFromSnapshotReq.Policy == nil {
+		t.Fatal("expected compiled policy on provision-from-snapshot request")
+	}
+	if got, want := adapter.provisionFromSnapshotReq.Policy.Hash, sourceSandbox.GetPolicyHash(); got != want {
+		t.Fatalf("unexpected policy hash: got %q want %q", got, want)
+	}
+}
+
+func TestRestoreSandboxUsesSnapshotMetadata(t *testing.T) {
+	store := newMemorySnapshotStore()
+	adapter := &stubAdapter{
+		createSnapshotFn: func(_ context.Context, req backend.SnapshotRequest) (*backend.SnapshotResult, error) {
+			return &backend.SnapshotResult{StorageRef: "/snapshots/" + req.SnapshotID + ".ext4"}, nil
+		},
+	}
+	svc := newTestServiceWithSnapshotStore(adapter, store)
+
+	createResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandbox := createResp.GetSandbox()
+
+	snapshotResp, err := svc.CreateSnapshot(context.Background(), &cleanroomv1.CreateSnapshotRequest{
+		SandboxId: sandbox.GetSandboxId(),
+	})
+	if err != nil {
+		t.Fatalf("CreateSnapshot returned error: %v", err)
+	}
+
+	restoreResp, err := svc.RestoreSandbox(context.Background(), &cleanroomv1.RestoreSandboxRequest{
+		SandboxId:  sandbox.GetSandboxId(),
+		SnapshotId: snapshotResp.GetSnapshot().GetSnapshotId(),
+	})
+	if err != nil {
+		t.Fatalf("RestoreSandbox returned error: %v", err)
+	}
+	if got, want := restoreResp.GetSandbox().GetStatus(), cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY; got != want {
+		t.Fatalf("unexpected sandbox status after restore: got %v want %v", got, want)
+	}
+	if got, want := adapter.restoreReq.SandboxID, sandbox.GetSandboxId(); got != want {
+		t.Fatalf("unexpected restore sandbox id: got %q want %q", got, want)
+	}
+	if got, want := adapter.restoreReq.SnapshotID, snapshotResp.GetSnapshot().GetSnapshotId(); got != want {
+		t.Fatalf("unexpected restore snapshot id: got %q want %q", got, want)
+	}
+	if adapter.restoreReq.Policy == nil {
+		t.Fatal("expected compiled policy on restore request")
+	}
+	if got, want := adapter.restoreReq.Policy.Hash, sandbox.GetPolicyHash(); got != want {
+		t.Fatalf("unexpected restore policy hash: got %q want %q", got, want)
 	}
 }
 

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -914,6 +914,63 @@ func TestCreateSandboxMergesDarwinVZConfig(t *testing.T) {
 	}
 }
 
+func TestCreateSandboxMergesFirecrackerSnapshotConfig(t *testing.T) {
+	adapter := &stubAdapter{}
+	svc := &Service{
+		Loader: stubLoader{
+			compiled: &policy.CompiledPolicy{
+				Version:        1,
+				NetworkDefault: "deny",
+				ImageRef:       "ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+				ImageDigest:    "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			},
+			source: "/repo/cleanroom.yaml",
+		},
+		Config: runtimeconfig.Config{
+			DefaultBackend: "firecracker",
+			Backends: runtimeconfig.Backends{
+				Firecracker: runtimeconfig.FirecrackerConfig{
+					KernelImage: "/firecracker-kernel",
+					RootFS:      "/firecracker-rootfs",
+					Snapshots: runtimeconfig.SnapshotConfig{
+						Enabled:               true,
+						Driver:                "zfs",
+						BaseDir:               "/var/tmp/cleanroom-snapshots",
+						ZFSDataset:            "tank/cleanroom",
+						QuiesceTimeoutSeconds: 15,
+					},
+				},
+			},
+		},
+		Backends: map[string]backend.Adapter{"firecracker": adapter},
+	}
+
+	_, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	if got, want := adapter.provisionCalls, 1; got != want {
+		t.Fatalf("unexpected provision call count: got %d want %d", got, want)
+	}
+
+	gotCfg := adapter.provisionReq.FirecrackerConfig
+	if !gotCfg.Snapshots.Enabled {
+		t.Fatal("expected snapshots.enabled=true")
+	}
+	if got, want := gotCfg.Snapshots.Driver, "zfs"; got != want {
+		t.Fatalf("unexpected snapshot driver: got %q want %q", got, want)
+	}
+	if got, want := gotCfg.Snapshots.BaseDir, "/var/tmp/cleanroom-snapshots"; got != want {
+		t.Fatalf("unexpected snapshot base_dir: got %q want %q", got, want)
+	}
+	if got, want := gotCfg.Snapshots.ZFSDataset, "tank/cleanroom"; got != want {
+		t.Fatalf("unexpected snapshot zfs_dataset: got %q want %q", got, want)
+	}
+	if got, want := gotCfg.Snapshots.QuiesceTimeoutSeconds, int64(15); got != want {
+		t.Fatalf("unexpected snapshot quiesce timeout: got %d want %d", got, want)
+	}
+}
+
 func TestCreateExecutionRejectsWhenSandboxBusy(t *testing.T) {
 	started := make(chan struct{}, 1)
 	adapter := &stubAdapter{

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -505,6 +505,136 @@ func TestRestoreSandboxUsesSnapshotMetadata(t *testing.T) {
 	}
 }
 
+func TestDeleteSnapshotRejectsSnapshotUsedByActiveSandbox(t *testing.T) {
+	store := newMemorySnapshotStore()
+	adapter := &stubAdapter{
+		createSnapshotFn: func(_ context.Context, req backend.SnapshotRequest) (*backend.SnapshotResult, error) {
+			return &backend.SnapshotResult{StorageRef: "/snapshots/" + req.SnapshotID + ".ext4"}, nil
+		},
+	}
+	svc := newTestServiceWithSnapshotStore(adapter, store)
+
+	sourceResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sourceSandbox := sourceResp.GetSandbox()
+
+	snapshotResp, err := svc.CreateSnapshot(context.Background(), &cleanroomv1.CreateSnapshotRequest{
+		SandboxId: sourceSandbox.GetSandboxId(),
+	})
+	if err != nil {
+		t.Fatalf("CreateSnapshot returned error: %v", err)
+	}
+	snapshotID := snapshotResp.GetSnapshot().GetSnapshotId()
+
+	forkResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Source: &cleanroomv1.CreateSandboxRequest_SnapshotId{SnapshotId: snapshotID},
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox from snapshot returned error: %v", err)
+	}
+	forkSandboxID := forkResp.GetSandbox().GetSandboxId()
+	if forkSandboxID == "" {
+		t.Fatal("expected fork sandbox id")
+	}
+
+	_, err = svc.DeleteSnapshot(context.Background(), &cleanroomv1.DeleteSnapshotRequest{SnapshotId: snapshotID})
+	if err == nil {
+		t.Fatal("expected delete snapshot to fail while snapshot is in use")
+	}
+	if !strings.Contains(err.Error(), "snapshot_busy") || !strings.Contains(err.Error(), forkSandboxID) {
+		t.Fatalf("unexpected delete snapshot error: %v", err)
+	}
+	if adapter.deleteSnapshotCalls != 0 {
+		t.Fatalf("expected no backend delete calls while snapshot is in use, got %d", adapter.deleteSnapshotCalls)
+	}
+
+	terminateResp, err := svc.TerminateSandbox(context.Background(), &cleanroomv1.TerminateSandboxRequest{
+		SandboxId: forkSandboxID,
+	})
+	if err != nil {
+		t.Fatalf("TerminateSandbox returned error: %v", err)
+	}
+	if !terminateResp.GetTerminated() {
+		t.Fatal("expected terminated=true")
+	}
+
+	deleteResp, err := svc.DeleteSnapshot(context.Background(), &cleanroomv1.DeleteSnapshotRequest{SnapshotId: snapshotID})
+	if err != nil {
+		t.Fatalf("DeleteSnapshot returned error after terminate: %v", err)
+	}
+	if !deleteResp.GetDeleted() {
+		t.Fatal("expected deleted=true after terminate")
+	}
+}
+
+func TestDeleteSnapshotRejectsSnapshotWithInFlightProvisionFromSnapshot(t *testing.T) {
+	store := newMemorySnapshotStore()
+	provisionStarted := make(chan struct{}, 1)
+	provisionRelease := make(chan struct{})
+	createDone := make(chan error, 1)
+	adapter := &stubAdapter{
+		createSnapshotFn: func(_ context.Context, req backend.SnapshotRequest) (*backend.SnapshotResult, error) {
+			return &backend.SnapshotResult{StorageRef: "/snapshots/" + req.SnapshotID + ".ext4"}, nil
+		},
+		provisionFromSnapshotFn: func(_ context.Context, _ backend.ProvisionFromSnapshotRequest) error {
+			select {
+			case provisionStarted <- struct{}{}:
+			default:
+			}
+			<-provisionRelease
+			return nil
+		},
+	}
+	svc := newTestServiceWithSnapshotStore(adapter, store)
+
+	sourceResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sourceSandbox := sourceResp.GetSandbox()
+
+	snapshotResp, err := svc.CreateSnapshot(context.Background(), &cleanroomv1.CreateSnapshotRequest{
+		SandboxId: sourceSandbox.GetSandboxId(),
+	})
+	if err != nil {
+		t.Fatalf("CreateSnapshot returned error: %v", err)
+	}
+	snapshotID := snapshotResp.GetSnapshot().GetSnapshotId()
+
+	go func() {
+		_, createErr := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+			Source: &cleanroomv1.CreateSandboxRequest_SnapshotId{SnapshotId: snapshotID},
+		})
+		createDone <- createErr
+	}()
+
+	select {
+	case <-provisionStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected create-from-snapshot provision to start")
+	}
+
+	_, err = svc.DeleteSnapshot(context.Background(), &cleanroomv1.DeleteSnapshotRequest{SnapshotId: snapshotID})
+	if err == nil {
+		t.Fatal("expected delete snapshot to fail while provision is in flight")
+	}
+	if !strings.Contains(err.Error(), "snapshot_busy") || !strings.Contains(err.Error(), "another operation") {
+		t.Fatalf("unexpected delete snapshot error: %v", err)
+	}
+
+	close(provisionRelease)
+	select {
+	case createErr := <-createDone:
+		if createErr != nil {
+			t.Fatalf("CreateSandbox from snapshot returned error: %v", createErr)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected create-from-snapshot to finish")
+	}
+}
+
 func TestCancelExecutionTransitionsToCanceled(t *testing.T) {
 	started := make(chan struct{}, 1)
 	adapter := &stubAdapter{

--- a/internal/gen/cleanroom/v1/cleanroomv1connect/control.connect.go
+++ b/internal/gen/cleanroom/v1/cleanroomv1connect/control.connect.go
@@ -23,6 +23,8 @@ const _ = connect.IsAtLeastVersion1_13_0
 const (
 	// SandboxServiceName is the fully-qualified name of the SandboxService service.
 	SandboxServiceName = "cleanroom.v1.SandboxService"
+	// SnapshotServiceName is the fully-qualified name of the SnapshotService service.
+	SnapshotServiceName = "cleanroom.v1.SnapshotService"
 	// ExecutionServiceName is the fully-qualified name of the ExecutionService service.
 	ExecutionServiceName = "cleanroom.v1.ExecutionService"
 )
@@ -47,12 +49,27 @@ const (
 	// SandboxServiceDownloadSandboxFileProcedure is the fully-qualified name of the SandboxService's
 	// DownloadSandboxFile RPC.
 	SandboxServiceDownloadSandboxFileProcedure = "/cleanroom.v1.SandboxService/DownloadSandboxFile"
+	// SandboxServiceRestoreSandboxProcedure is the fully-qualified name of the SandboxService's
+	// RestoreSandbox RPC.
+	SandboxServiceRestoreSandboxProcedure = "/cleanroom.v1.SandboxService/RestoreSandbox"
 	// SandboxServiceTerminateSandboxProcedure is the fully-qualified name of the SandboxService's
 	// TerminateSandbox RPC.
 	SandboxServiceTerminateSandboxProcedure = "/cleanroom.v1.SandboxService/TerminateSandbox"
 	// SandboxServiceStreamSandboxEventsProcedure is the fully-qualified name of the SandboxService's
 	// StreamSandboxEvents RPC.
 	SandboxServiceStreamSandboxEventsProcedure = "/cleanroom.v1.SandboxService/StreamSandboxEvents"
+	// SnapshotServiceCreateSnapshotProcedure is the fully-qualified name of the SnapshotService's
+	// CreateSnapshot RPC.
+	SnapshotServiceCreateSnapshotProcedure = "/cleanroom.v1.SnapshotService/CreateSnapshot"
+	// SnapshotServiceGetSnapshotProcedure is the fully-qualified name of the SnapshotService's
+	// GetSnapshot RPC.
+	SnapshotServiceGetSnapshotProcedure = "/cleanroom.v1.SnapshotService/GetSnapshot"
+	// SnapshotServiceListSnapshotsProcedure is the fully-qualified name of the SnapshotService's
+	// ListSnapshots RPC.
+	SnapshotServiceListSnapshotsProcedure = "/cleanroom.v1.SnapshotService/ListSnapshots"
+	// SnapshotServiceDeleteSnapshotProcedure is the fully-qualified name of the SnapshotService's
+	// DeleteSnapshot RPC.
+	SnapshotServiceDeleteSnapshotProcedure = "/cleanroom.v1.SnapshotService/DeleteSnapshot"
 	// ExecutionServiceCreateExecutionProcedure is the fully-qualified name of the ExecutionService's
 	// CreateExecution RPC.
 	ExecutionServiceCreateExecutionProcedure = "/cleanroom.v1.ExecutionService/CreateExecution"
@@ -76,6 +93,7 @@ type SandboxServiceClient interface {
 	GetSandbox(context.Context, *connect.Request[v1.GetSandboxRequest]) (*connect.Response[v1.GetSandboxResponse], error)
 	ListSandboxes(context.Context, *connect.Request[v1.ListSandboxesRequest]) (*connect.Response[v1.ListSandboxesResponse], error)
 	DownloadSandboxFile(context.Context, *connect.Request[v1.DownloadSandboxFileRequest]) (*connect.Response[v1.DownloadSandboxFileResponse], error)
+	RestoreSandbox(context.Context, *connect.Request[v1.RestoreSandboxRequest]) (*connect.Response[v1.RestoreSandboxResponse], error)
 	TerminateSandbox(context.Context, *connect.Request[v1.TerminateSandboxRequest]) (*connect.Response[v1.TerminateSandboxResponse], error)
 	StreamSandboxEvents(context.Context, *connect.Request[v1.StreamSandboxEventsRequest]) (*connect.ServerStreamForClient[v1.SandboxEvent], error)
 }
@@ -115,6 +133,12 @@ func NewSandboxServiceClient(httpClient connect.HTTPClient, baseURL string, opts
 			connect.WithSchema(sandboxServiceMethods.ByName("DownloadSandboxFile")),
 			connect.WithClientOptions(opts...),
 		),
+		restoreSandbox: connect.NewClient[v1.RestoreSandboxRequest, v1.RestoreSandboxResponse](
+			httpClient,
+			baseURL+SandboxServiceRestoreSandboxProcedure,
+			connect.WithSchema(sandboxServiceMethods.ByName("RestoreSandbox")),
+			connect.WithClientOptions(opts...),
+		),
 		terminateSandbox: connect.NewClient[v1.TerminateSandboxRequest, v1.TerminateSandboxResponse](
 			httpClient,
 			baseURL+SandboxServiceTerminateSandboxProcedure,
@@ -136,6 +160,7 @@ type sandboxServiceClient struct {
 	getSandbox          *connect.Client[v1.GetSandboxRequest, v1.GetSandboxResponse]
 	listSandboxes       *connect.Client[v1.ListSandboxesRequest, v1.ListSandboxesResponse]
 	downloadSandboxFile *connect.Client[v1.DownloadSandboxFileRequest, v1.DownloadSandboxFileResponse]
+	restoreSandbox      *connect.Client[v1.RestoreSandboxRequest, v1.RestoreSandboxResponse]
 	terminateSandbox    *connect.Client[v1.TerminateSandboxRequest, v1.TerminateSandboxResponse]
 	streamSandboxEvents *connect.Client[v1.StreamSandboxEventsRequest, v1.SandboxEvent]
 }
@@ -160,6 +185,11 @@ func (c *sandboxServiceClient) DownloadSandboxFile(ctx context.Context, req *con
 	return c.downloadSandboxFile.CallUnary(ctx, req)
 }
 
+// RestoreSandbox calls cleanroom.v1.SandboxService.RestoreSandbox.
+func (c *sandboxServiceClient) RestoreSandbox(ctx context.Context, req *connect.Request[v1.RestoreSandboxRequest]) (*connect.Response[v1.RestoreSandboxResponse], error) {
+	return c.restoreSandbox.CallUnary(ctx, req)
+}
+
 // TerminateSandbox calls cleanroom.v1.SandboxService.TerminateSandbox.
 func (c *sandboxServiceClient) TerminateSandbox(ctx context.Context, req *connect.Request[v1.TerminateSandboxRequest]) (*connect.Response[v1.TerminateSandboxResponse], error) {
 	return c.terminateSandbox.CallUnary(ctx, req)
@@ -176,6 +206,7 @@ type SandboxServiceHandler interface {
 	GetSandbox(context.Context, *connect.Request[v1.GetSandboxRequest]) (*connect.Response[v1.GetSandboxResponse], error)
 	ListSandboxes(context.Context, *connect.Request[v1.ListSandboxesRequest]) (*connect.Response[v1.ListSandboxesResponse], error)
 	DownloadSandboxFile(context.Context, *connect.Request[v1.DownloadSandboxFileRequest]) (*connect.Response[v1.DownloadSandboxFileResponse], error)
+	RestoreSandbox(context.Context, *connect.Request[v1.RestoreSandboxRequest]) (*connect.Response[v1.RestoreSandboxResponse], error)
 	TerminateSandbox(context.Context, *connect.Request[v1.TerminateSandboxRequest]) (*connect.Response[v1.TerminateSandboxResponse], error)
 	StreamSandboxEvents(context.Context, *connect.Request[v1.StreamSandboxEventsRequest], *connect.ServerStream[v1.SandboxEvent]) error
 }
@@ -211,6 +242,12 @@ func NewSandboxServiceHandler(svc SandboxServiceHandler, opts ...connect.Handler
 		connect.WithSchema(sandboxServiceMethods.ByName("DownloadSandboxFile")),
 		connect.WithHandlerOptions(opts...),
 	)
+	sandboxServiceRestoreSandboxHandler := connect.NewUnaryHandler(
+		SandboxServiceRestoreSandboxProcedure,
+		svc.RestoreSandbox,
+		connect.WithSchema(sandboxServiceMethods.ByName("RestoreSandbox")),
+		connect.WithHandlerOptions(opts...),
+	)
 	sandboxServiceTerminateSandboxHandler := connect.NewUnaryHandler(
 		SandboxServiceTerminateSandboxProcedure,
 		svc.TerminateSandbox,
@@ -233,6 +270,8 @@ func NewSandboxServiceHandler(svc SandboxServiceHandler, opts ...connect.Handler
 			sandboxServiceListSandboxesHandler.ServeHTTP(w, r)
 		case SandboxServiceDownloadSandboxFileProcedure:
 			sandboxServiceDownloadSandboxFileHandler.ServeHTTP(w, r)
+		case SandboxServiceRestoreSandboxProcedure:
+			sandboxServiceRestoreSandboxHandler.ServeHTTP(w, r)
 		case SandboxServiceTerminateSandboxProcedure:
 			sandboxServiceTerminateSandboxHandler.ServeHTTP(w, r)
 		case SandboxServiceStreamSandboxEventsProcedure:
@@ -262,12 +301,164 @@ func (UnimplementedSandboxServiceHandler) DownloadSandboxFile(context.Context, *
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cleanroom.v1.SandboxService.DownloadSandboxFile is not implemented"))
 }
 
+func (UnimplementedSandboxServiceHandler) RestoreSandbox(context.Context, *connect.Request[v1.RestoreSandboxRequest]) (*connect.Response[v1.RestoreSandboxResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cleanroom.v1.SandboxService.RestoreSandbox is not implemented"))
+}
+
 func (UnimplementedSandboxServiceHandler) TerminateSandbox(context.Context, *connect.Request[v1.TerminateSandboxRequest]) (*connect.Response[v1.TerminateSandboxResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cleanroom.v1.SandboxService.TerminateSandbox is not implemented"))
 }
 
 func (UnimplementedSandboxServiceHandler) StreamSandboxEvents(context.Context, *connect.Request[v1.StreamSandboxEventsRequest], *connect.ServerStream[v1.SandboxEvent]) error {
 	return connect.NewError(connect.CodeUnimplemented, errors.New("cleanroom.v1.SandboxService.StreamSandboxEvents is not implemented"))
+}
+
+// SnapshotServiceClient is a client for the cleanroom.v1.SnapshotService service.
+type SnapshotServiceClient interface {
+	CreateSnapshot(context.Context, *connect.Request[v1.CreateSnapshotRequest]) (*connect.Response[v1.CreateSnapshotResponse], error)
+	GetSnapshot(context.Context, *connect.Request[v1.GetSnapshotRequest]) (*connect.Response[v1.GetSnapshotResponse], error)
+	ListSnapshots(context.Context, *connect.Request[v1.ListSnapshotsRequest]) (*connect.Response[v1.ListSnapshotsResponse], error)
+	DeleteSnapshot(context.Context, *connect.Request[v1.DeleteSnapshotRequest]) (*connect.Response[v1.DeleteSnapshotResponse], error)
+}
+
+// NewSnapshotServiceClient constructs a client for the cleanroom.v1.SnapshotService service. By
+// default, it uses the Connect protocol with the binary Protobuf Codec, asks for gzipped responses,
+// and sends uncompressed requests. To use the gRPC or gRPC-Web protocols, supply the
+// connect.WithGRPC() or connect.WithGRPCWeb() options.
+//
+// The URL supplied here should be the base URL for the Connect or gRPC server (for example,
+// http://api.acme.com or https://acme.com/grpc).
+func NewSnapshotServiceClient(httpClient connect.HTTPClient, baseURL string, opts ...connect.ClientOption) SnapshotServiceClient {
+	baseURL = strings.TrimRight(baseURL, "/")
+	snapshotServiceMethods := v1.File_proto_cleanroom_v1_control_proto.Services().ByName("SnapshotService").Methods()
+	return &snapshotServiceClient{
+		createSnapshot: connect.NewClient[v1.CreateSnapshotRequest, v1.CreateSnapshotResponse](
+			httpClient,
+			baseURL+SnapshotServiceCreateSnapshotProcedure,
+			connect.WithSchema(snapshotServiceMethods.ByName("CreateSnapshot")),
+			connect.WithClientOptions(opts...),
+		),
+		getSnapshot: connect.NewClient[v1.GetSnapshotRequest, v1.GetSnapshotResponse](
+			httpClient,
+			baseURL+SnapshotServiceGetSnapshotProcedure,
+			connect.WithSchema(snapshotServiceMethods.ByName("GetSnapshot")),
+			connect.WithClientOptions(opts...),
+		),
+		listSnapshots: connect.NewClient[v1.ListSnapshotsRequest, v1.ListSnapshotsResponse](
+			httpClient,
+			baseURL+SnapshotServiceListSnapshotsProcedure,
+			connect.WithSchema(snapshotServiceMethods.ByName("ListSnapshots")),
+			connect.WithClientOptions(opts...),
+		),
+		deleteSnapshot: connect.NewClient[v1.DeleteSnapshotRequest, v1.DeleteSnapshotResponse](
+			httpClient,
+			baseURL+SnapshotServiceDeleteSnapshotProcedure,
+			connect.WithSchema(snapshotServiceMethods.ByName("DeleteSnapshot")),
+			connect.WithClientOptions(opts...),
+		),
+	}
+}
+
+// snapshotServiceClient implements SnapshotServiceClient.
+type snapshotServiceClient struct {
+	createSnapshot *connect.Client[v1.CreateSnapshotRequest, v1.CreateSnapshotResponse]
+	getSnapshot    *connect.Client[v1.GetSnapshotRequest, v1.GetSnapshotResponse]
+	listSnapshots  *connect.Client[v1.ListSnapshotsRequest, v1.ListSnapshotsResponse]
+	deleteSnapshot *connect.Client[v1.DeleteSnapshotRequest, v1.DeleteSnapshotResponse]
+}
+
+// CreateSnapshot calls cleanroom.v1.SnapshotService.CreateSnapshot.
+func (c *snapshotServiceClient) CreateSnapshot(ctx context.Context, req *connect.Request[v1.CreateSnapshotRequest]) (*connect.Response[v1.CreateSnapshotResponse], error) {
+	return c.createSnapshot.CallUnary(ctx, req)
+}
+
+// GetSnapshot calls cleanroom.v1.SnapshotService.GetSnapshot.
+func (c *snapshotServiceClient) GetSnapshot(ctx context.Context, req *connect.Request[v1.GetSnapshotRequest]) (*connect.Response[v1.GetSnapshotResponse], error) {
+	return c.getSnapshot.CallUnary(ctx, req)
+}
+
+// ListSnapshots calls cleanroom.v1.SnapshotService.ListSnapshots.
+func (c *snapshotServiceClient) ListSnapshots(ctx context.Context, req *connect.Request[v1.ListSnapshotsRequest]) (*connect.Response[v1.ListSnapshotsResponse], error) {
+	return c.listSnapshots.CallUnary(ctx, req)
+}
+
+// DeleteSnapshot calls cleanroom.v1.SnapshotService.DeleteSnapshot.
+func (c *snapshotServiceClient) DeleteSnapshot(ctx context.Context, req *connect.Request[v1.DeleteSnapshotRequest]) (*connect.Response[v1.DeleteSnapshotResponse], error) {
+	return c.deleteSnapshot.CallUnary(ctx, req)
+}
+
+// SnapshotServiceHandler is an implementation of the cleanroom.v1.SnapshotService service.
+type SnapshotServiceHandler interface {
+	CreateSnapshot(context.Context, *connect.Request[v1.CreateSnapshotRequest]) (*connect.Response[v1.CreateSnapshotResponse], error)
+	GetSnapshot(context.Context, *connect.Request[v1.GetSnapshotRequest]) (*connect.Response[v1.GetSnapshotResponse], error)
+	ListSnapshots(context.Context, *connect.Request[v1.ListSnapshotsRequest]) (*connect.Response[v1.ListSnapshotsResponse], error)
+	DeleteSnapshot(context.Context, *connect.Request[v1.DeleteSnapshotRequest]) (*connect.Response[v1.DeleteSnapshotResponse], error)
+}
+
+// NewSnapshotServiceHandler builds an HTTP handler from the service implementation. It returns the
+// path on which to mount the handler and the handler itself.
+//
+// By default, handlers support the Connect, gRPC, and gRPC-Web protocols with the binary Protobuf
+// and JSON codecs. They also support gzip compression.
+func NewSnapshotServiceHandler(svc SnapshotServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
+	snapshotServiceMethods := v1.File_proto_cleanroom_v1_control_proto.Services().ByName("SnapshotService").Methods()
+	snapshotServiceCreateSnapshotHandler := connect.NewUnaryHandler(
+		SnapshotServiceCreateSnapshotProcedure,
+		svc.CreateSnapshot,
+		connect.WithSchema(snapshotServiceMethods.ByName("CreateSnapshot")),
+		connect.WithHandlerOptions(opts...),
+	)
+	snapshotServiceGetSnapshotHandler := connect.NewUnaryHandler(
+		SnapshotServiceGetSnapshotProcedure,
+		svc.GetSnapshot,
+		connect.WithSchema(snapshotServiceMethods.ByName("GetSnapshot")),
+		connect.WithHandlerOptions(opts...),
+	)
+	snapshotServiceListSnapshotsHandler := connect.NewUnaryHandler(
+		SnapshotServiceListSnapshotsProcedure,
+		svc.ListSnapshots,
+		connect.WithSchema(snapshotServiceMethods.ByName("ListSnapshots")),
+		connect.WithHandlerOptions(opts...),
+	)
+	snapshotServiceDeleteSnapshotHandler := connect.NewUnaryHandler(
+		SnapshotServiceDeleteSnapshotProcedure,
+		svc.DeleteSnapshot,
+		connect.WithSchema(snapshotServiceMethods.ByName("DeleteSnapshot")),
+		connect.WithHandlerOptions(opts...),
+	)
+	return "/cleanroom.v1.SnapshotService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case SnapshotServiceCreateSnapshotProcedure:
+			snapshotServiceCreateSnapshotHandler.ServeHTTP(w, r)
+		case SnapshotServiceGetSnapshotProcedure:
+			snapshotServiceGetSnapshotHandler.ServeHTTP(w, r)
+		case SnapshotServiceListSnapshotsProcedure:
+			snapshotServiceListSnapshotsHandler.ServeHTTP(w, r)
+		case SnapshotServiceDeleteSnapshotProcedure:
+			snapshotServiceDeleteSnapshotHandler.ServeHTTP(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+}
+
+// UnimplementedSnapshotServiceHandler returns CodeUnimplemented from all methods.
+type UnimplementedSnapshotServiceHandler struct{}
+
+func (UnimplementedSnapshotServiceHandler) CreateSnapshot(context.Context, *connect.Request[v1.CreateSnapshotRequest]) (*connect.Response[v1.CreateSnapshotResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cleanroom.v1.SnapshotService.CreateSnapshot is not implemented"))
+}
+
+func (UnimplementedSnapshotServiceHandler) GetSnapshot(context.Context, *connect.Request[v1.GetSnapshotRequest]) (*connect.Response[v1.GetSnapshotResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cleanroom.v1.SnapshotService.GetSnapshot is not implemented"))
+}
+
+func (UnimplementedSnapshotServiceHandler) ListSnapshots(context.Context, *connect.Request[v1.ListSnapshotsRequest]) (*connect.Response[v1.ListSnapshotsResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cleanroom.v1.SnapshotService.ListSnapshots is not implemented"))
+}
+
+func (UnimplementedSnapshotServiceHandler) DeleteSnapshot(context.Context, *connect.Request[v1.DeleteSnapshotRequest]) (*connect.Response[v1.DeleteSnapshotResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cleanroom.v1.SnapshotService.DeleteSnapshot is not implemented"))
 }
 
 // ExecutionServiceClient is a client for the cleanroom.v1.ExecutionService service.

--- a/internal/gen/cleanroom/v1/control.pb.go
+++ b/internal/gen/cleanroom/v1/control.pb.go
@@ -274,6 +274,90 @@ func (x *Sandbox) GetUpdatedAt() *timestamppb.Timestamp {
 	return nil
 }
 
+type Snapshot struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	SnapshotId      string                 `protobuf:"bytes,1,opt,name=snapshot_id,json=snapshotId,proto3" json:"snapshot_id,omitempty"`
+	SourceSandboxId string                 `protobuf:"bytes,2,opt,name=source_sandbox_id,json=sourceSandboxId,proto3" json:"source_sandbox_id,omitempty"`
+	Backend         string                 `protobuf:"bytes,3,opt,name=backend,proto3" json:"backend,omitempty"`
+	PolicyHash      string                 `protobuf:"bytes,4,opt,name=policy_hash,json=policyHash,proto3" json:"policy_hash,omitempty"`
+	Name            string                 `protobuf:"bytes,5,opt,name=name,proto3" json:"name,omitempty"`
+	CreatedAt       *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *Snapshot) Reset() {
+	*x = Snapshot{}
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Snapshot) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Snapshot) ProtoMessage() {}
+
+func (x *Snapshot) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Snapshot.ProtoReflect.Descriptor instead.
+func (*Snapshot) Descriptor() ([]byte, []int) {
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *Snapshot) GetSnapshotId() string {
+	if x != nil {
+		return x.SnapshotId
+	}
+	return ""
+}
+
+func (x *Snapshot) GetSourceSandboxId() string {
+	if x != nil {
+		return x.SourceSandboxId
+	}
+	return ""
+}
+
+func (x *Snapshot) GetBackend() string {
+	if x != nil {
+		return x.Backend
+	}
+	return ""
+}
+
+func (x *Snapshot) GetPolicyHash() string {
+	if x != nil {
+		return x.PolicyHash
+	}
+	return ""
+}
+
+func (x *Snapshot) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *Snapshot) GetCreatedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.CreatedAt
+	}
+	return nil
+}
+
 type PolicyAllowRule struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Host          string                 `protobuf:"bytes,1,opt,name=host,proto3" json:"host,omitempty"`
@@ -284,7 +368,7 @@ type PolicyAllowRule struct {
 
 func (x *PolicyAllowRule) Reset() {
 	*x = PolicyAllowRule{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[1]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -296,7 +380,7 @@ func (x *PolicyAllowRule) String() string {
 func (*PolicyAllowRule) ProtoMessage() {}
 
 func (x *PolicyAllowRule) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[1]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -309,7 +393,7 @@ func (x *PolicyAllowRule) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyAllowRule.ProtoReflect.Descriptor instead.
 func (*PolicyAllowRule) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{1}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *PolicyAllowRule) GetHost() string {
@@ -335,7 +419,7 @@ type PolicyDockerService struct {
 
 func (x *PolicyDockerService) Reset() {
 	*x = PolicyDockerService{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[2]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -347,7 +431,7 @@ func (x *PolicyDockerService) String() string {
 func (*PolicyDockerService) ProtoMessage() {}
 
 func (x *PolicyDockerService) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[2]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -360,7 +444,7 @@ func (x *PolicyDockerService) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyDockerService.ProtoReflect.Descriptor instead.
 func (*PolicyDockerService) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{2}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *PolicyDockerService) GetRequired() bool {
@@ -379,7 +463,7 @@ type PolicyServices struct {
 
 func (x *PolicyServices) Reset() {
 	*x = PolicyServices{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[3]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -391,7 +475,7 @@ func (x *PolicyServices) String() string {
 func (*PolicyServices) ProtoMessage() {}
 
 func (x *PolicyServices) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[3]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -404,7 +488,7 @@ func (x *PolicyServices) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyServices.ProtoReflect.Descriptor instead.
 func (*PolicyServices) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{3}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *PolicyServices) GetDocker() *PolicyDockerService {
@@ -429,7 +513,7 @@ type Policy struct {
 
 func (x *Policy) Reset() {
 	*x = Policy{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[4]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -441,7 +525,7 @@ func (x *Policy) String() string {
 func (*Policy) ProtoMessage() {}
 
 func (x *Policy) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[4]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -454,7 +538,7 @@ func (x *Policy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Policy.ProtoReflect.Descriptor instead.
 func (*Policy) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{4}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *Policy) GetVersion() int32 {
@@ -515,7 +599,7 @@ type SandboxOptions struct {
 
 func (x *SandboxOptions) Reset() {
 	*x = SandboxOptions{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[5]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -527,7 +611,7 @@ func (x *SandboxOptions) String() string {
 func (*SandboxOptions) ProtoMessage() {}
 
 func (x *SandboxOptions) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[5]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -540,7 +624,7 @@ func (x *SandboxOptions) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxOptions.ProtoReflect.Descriptor instead.
 func (*SandboxOptions) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{5}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *SandboxOptions) GetLaunchSeconds() int64 {
@@ -551,17 +635,21 @@ func (x *SandboxOptions) GetLaunchSeconds() int64 {
 }
 
 type CreateSandboxRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Backend       string                 `protobuf:"bytes,2,opt,name=backend,proto3" json:"backend,omitempty"`
-	Options       *SandboxOptions        `protobuf:"bytes,3,opt,name=options,proto3" json:"options,omitempty"`
-	Policy        *Policy                `protobuf:"bytes,4,opt,name=policy,proto3" json:"policy,omitempty"`
+	state   protoimpl.MessageState `protogen:"open.v1"`
+	Backend string                 `protobuf:"bytes,2,opt,name=backend,proto3" json:"backend,omitempty"`
+	Options *SandboxOptions        `protobuf:"bytes,3,opt,name=options,proto3" json:"options,omitempty"`
+	Policy  *Policy                `protobuf:"bytes,4,opt,name=policy,proto3" json:"policy,omitempty"`
+	// Types that are valid to be assigned to Source:
+	//
+	//	*CreateSandboxRequest_SnapshotId
+	Source        isCreateSandboxRequest_Source `protobuf_oneof:"source"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *CreateSandboxRequest) Reset() {
 	*x = CreateSandboxRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[6]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -573,7 +661,7 @@ func (x *CreateSandboxRequest) String() string {
 func (*CreateSandboxRequest) ProtoMessage() {}
 
 func (x *CreateSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[6]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -586,7 +674,7 @@ func (x *CreateSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSandboxRequest.ProtoReflect.Descriptor instead.
 func (*CreateSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{6}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *CreateSandboxRequest) GetBackend() string {
@@ -610,6 +698,32 @@ func (x *CreateSandboxRequest) GetPolicy() *Policy {
 	return nil
 }
 
+func (x *CreateSandboxRequest) GetSource() isCreateSandboxRequest_Source {
+	if x != nil {
+		return x.Source
+	}
+	return nil
+}
+
+func (x *CreateSandboxRequest) GetSnapshotId() string {
+	if x != nil {
+		if x, ok := x.Source.(*CreateSandboxRequest_SnapshotId); ok {
+			return x.SnapshotId
+		}
+	}
+	return ""
+}
+
+type isCreateSandboxRequest_Source interface {
+	isCreateSandboxRequest_Source()
+}
+
+type CreateSandboxRequest_SnapshotId struct {
+	SnapshotId string `protobuf:"bytes,5,opt,name=snapshot_id,json=snapshotId,proto3,oneof"`
+}
+
+func (*CreateSandboxRequest_SnapshotId) isCreateSandboxRequest_Source() {}
+
 type CreateSandboxResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Sandbox       *Sandbox               `protobuf:"bytes,1,opt,name=sandbox,proto3" json:"sandbox,omitempty"`
@@ -621,7 +735,7 @@ type CreateSandboxResponse struct {
 
 func (x *CreateSandboxResponse) Reset() {
 	*x = CreateSandboxResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[7]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -633,7 +747,7 @@ func (x *CreateSandboxResponse) String() string {
 func (*CreateSandboxResponse) ProtoMessage() {}
 
 func (x *CreateSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[7]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -646,7 +760,7 @@ func (x *CreateSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSandboxResponse.ProtoReflect.Descriptor instead.
 func (*CreateSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{7}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *CreateSandboxResponse) GetSandbox() *Sandbox {
@@ -679,7 +793,7 @@ type GetSandboxRequest struct {
 
 func (x *GetSandboxRequest) Reset() {
 	*x = GetSandboxRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[8]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -691,7 +805,7 @@ func (x *GetSandboxRequest) String() string {
 func (*GetSandboxRequest) ProtoMessage() {}
 
 func (x *GetSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[8]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -704,7 +818,7 @@ func (x *GetSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSandboxRequest.ProtoReflect.Descriptor instead.
 func (*GetSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{8}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *GetSandboxRequest) GetSandboxId() string {
@@ -723,7 +837,7 @@ type GetSandboxResponse struct {
 
 func (x *GetSandboxResponse) Reset() {
 	*x = GetSandboxResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[9]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -735,7 +849,7 @@ func (x *GetSandboxResponse) String() string {
 func (*GetSandboxResponse) ProtoMessage() {}
 
 func (x *GetSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[9]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -748,7 +862,7 @@ func (x *GetSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSandboxResponse.ProtoReflect.Descriptor instead.
 func (*GetSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{9}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *GetSandboxResponse) GetSandbox() *Sandbox {
@@ -766,7 +880,7 @@ type ListSandboxesRequest struct {
 
 func (x *ListSandboxesRequest) Reset() {
 	*x = ListSandboxesRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[10]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -778,7 +892,7 @@ func (x *ListSandboxesRequest) String() string {
 func (*ListSandboxesRequest) ProtoMessage() {}
 
 func (x *ListSandboxesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[10]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -791,7 +905,7 @@ func (x *ListSandboxesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSandboxesRequest.ProtoReflect.Descriptor instead.
 func (*ListSandboxesRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{10}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{11}
 }
 
 type ListSandboxesResponse struct {
@@ -803,7 +917,7 @@ type ListSandboxesResponse struct {
 
 func (x *ListSandboxesResponse) Reset() {
 	*x = ListSandboxesResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[11]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -815,7 +929,7 @@ func (x *ListSandboxesResponse) String() string {
 func (*ListSandboxesResponse) ProtoMessage() {}
 
 func (x *ListSandboxesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[11]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -828,7 +942,7 @@ func (x *ListSandboxesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSandboxesResponse.ProtoReflect.Descriptor instead.
 func (*ListSandboxesResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{11}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *ListSandboxesResponse) GetSandboxes() []*Sandbox {
@@ -849,7 +963,7 @@ type DownloadSandboxFileRequest struct {
 
 func (x *DownloadSandboxFileRequest) Reset() {
 	*x = DownloadSandboxFileRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[12]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -861,7 +975,7 @@ func (x *DownloadSandboxFileRequest) String() string {
 func (*DownloadSandboxFileRequest) ProtoMessage() {}
 
 func (x *DownloadSandboxFileRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[12]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -874,7 +988,7 @@ func (x *DownloadSandboxFileRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DownloadSandboxFileRequest.ProtoReflect.Descriptor instead.
 func (*DownloadSandboxFileRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{12}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *DownloadSandboxFileRequest) GetSandboxId() string {
@@ -910,7 +1024,7 @@ type DownloadSandboxFileResponse struct {
 
 func (x *DownloadSandboxFileResponse) Reset() {
 	*x = DownloadSandboxFileResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[13]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -922,7 +1036,7 @@ func (x *DownloadSandboxFileResponse) String() string {
 func (*DownloadSandboxFileResponse) ProtoMessage() {}
 
 func (x *DownloadSandboxFileResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[13]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -935,7 +1049,7 @@ func (x *DownloadSandboxFileResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DownloadSandboxFileResponse.ProtoReflect.Descriptor instead.
 func (*DownloadSandboxFileResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{13}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *DownloadSandboxFileResponse) GetSandboxId() string {
@@ -966,6 +1080,110 @@ func (x *DownloadSandboxFileResponse) GetSizeBytes() int64 {
 	return 0
 }
 
+type RestoreSandboxRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SandboxId     string                 `protobuf:"bytes,1,opt,name=sandbox_id,json=sandboxId,proto3" json:"sandbox_id,omitempty"`
+	SnapshotId    string                 `protobuf:"bytes,2,opt,name=snapshot_id,json=snapshotId,proto3" json:"snapshot_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RestoreSandboxRequest) Reset() {
+	*x = RestoreSandboxRequest{}
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RestoreSandboxRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RestoreSandboxRequest) ProtoMessage() {}
+
+func (x *RestoreSandboxRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RestoreSandboxRequest.ProtoReflect.Descriptor instead.
+func (*RestoreSandboxRequest) Descriptor() ([]byte, []int) {
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *RestoreSandboxRequest) GetSandboxId() string {
+	if x != nil {
+		return x.SandboxId
+	}
+	return ""
+}
+
+func (x *RestoreSandboxRequest) GetSnapshotId() string {
+	if x != nil {
+		return x.SnapshotId
+	}
+	return ""
+}
+
+type RestoreSandboxResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Sandbox       *Sandbox               `protobuf:"bytes,1,opt,name=sandbox,proto3" json:"sandbox,omitempty"`
+	Message       string                 `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RestoreSandboxResponse) Reset() {
+	*x = RestoreSandboxResponse{}
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RestoreSandboxResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RestoreSandboxResponse) ProtoMessage() {}
+
+func (x *RestoreSandboxResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RestoreSandboxResponse.ProtoReflect.Descriptor instead.
+func (*RestoreSandboxResponse) Descriptor() ([]byte, []int) {
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *RestoreSandboxResponse) GetSandbox() *Sandbox {
+	if x != nil {
+		return x.Sandbox
+	}
+	return nil
+}
+
+func (x *RestoreSandboxResponse) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
 type TerminateSandboxRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	SandboxId     string                 `protobuf:"bytes,1,opt,name=sandbox_id,json=sandboxId,proto3" json:"sandbox_id,omitempty"`
@@ -975,7 +1193,7 @@ type TerminateSandboxRequest struct {
 
 func (x *TerminateSandboxRequest) Reset() {
 	*x = TerminateSandboxRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[14]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -987,7 +1205,7 @@ func (x *TerminateSandboxRequest) String() string {
 func (*TerminateSandboxRequest) ProtoMessage() {}
 
 func (x *TerminateSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[14]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1000,7 +1218,7 @@ func (x *TerminateSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TerminateSandboxRequest.ProtoReflect.Descriptor instead.
 func (*TerminateSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{14}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *TerminateSandboxRequest) GetSandboxId() string {
@@ -1021,7 +1239,7 @@ type TerminateSandboxResponse struct {
 
 func (x *TerminateSandboxResponse) Reset() {
 	*x = TerminateSandboxResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[15]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1033,7 +1251,7 @@ func (x *TerminateSandboxResponse) String() string {
 func (*TerminateSandboxResponse) ProtoMessage() {}
 
 func (x *TerminateSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[15]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1046,7 +1264,7 @@ func (x *TerminateSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TerminateSandboxResponse.ProtoReflect.Descriptor instead.
 func (*TerminateSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{15}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *TerminateSandboxResponse) GetSandboxId() string {
@@ -1080,7 +1298,7 @@ type StreamSandboxEventsRequest struct {
 
 func (x *StreamSandboxEventsRequest) Reset() {
 	*x = StreamSandboxEventsRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[16]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1092,7 +1310,7 @@ func (x *StreamSandboxEventsRequest) String() string {
 func (*StreamSandboxEventsRequest) ProtoMessage() {}
 
 func (x *StreamSandboxEventsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[16]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1105,7 +1323,7 @@ func (x *StreamSandboxEventsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamSandboxEventsRequest.ProtoReflect.Descriptor instead.
 func (*StreamSandboxEventsRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{16}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *StreamSandboxEventsRequest) GetSandboxId() string {
@@ -1134,7 +1352,7 @@ type SandboxEvent struct {
 
 func (x *SandboxEvent) Reset() {
 	*x = SandboxEvent{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[17]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1146,7 +1364,7 @@ func (x *SandboxEvent) String() string {
 func (*SandboxEvent) ProtoMessage() {}
 
 func (x *SandboxEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[17]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1159,7 +1377,7 @@ func (x *SandboxEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxEvent.ProtoReflect.Descriptor instead.
 func (*SandboxEvent) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{17}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *SandboxEvent) GetSandboxId() string {
@@ -1190,6 +1408,382 @@ func (x *SandboxEvent) GetOccurredAt() *timestamppb.Timestamp {
 	return nil
 }
 
+type CreateSnapshotRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SandboxId     string                 `protobuf:"bytes,1,opt,name=sandbox_id,json=sandboxId,proto3" json:"sandbox_id,omitempty"`
+	Name          string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateSnapshotRequest) Reset() {
+	*x = CreateSnapshotRequest{}
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[21]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateSnapshotRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateSnapshotRequest) ProtoMessage() {}
+
+func (x *CreateSnapshotRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[21]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateSnapshotRequest.ProtoReflect.Descriptor instead.
+func (*CreateSnapshotRequest) Descriptor() ([]byte, []int) {
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{21}
+}
+
+func (x *CreateSnapshotRequest) GetSandboxId() string {
+	if x != nil {
+		return x.SandboxId
+	}
+	return ""
+}
+
+func (x *CreateSnapshotRequest) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+type CreateSnapshotResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Snapshot      *Snapshot              `protobuf:"bytes,1,opt,name=snapshot,proto3" json:"snapshot,omitempty"`
+	Message       string                 `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateSnapshotResponse) Reset() {
+	*x = CreateSnapshotResponse{}
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateSnapshotResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateSnapshotResponse) ProtoMessage() {}
+
+func (x *CreateSnapshotResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateSnapshotResponse.ProtoReflect.Descriptor instead.
+func (*CreateSnapshotResponse) Descriptor() ([]byte, []int) {
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{22}
+}
+
+func (x *CreateSnapshotResponse) GetSnapshot() *Snapshot {
+	if x != nil {
+		return x.Snapshot
+	}
+	return nil
+}
+
+func (x *CreateSnapshotResponse) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+type GetSnapshotRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SnapshotId    string                 `protobuf:"bytes,1,opt,name=snapshot_id,json=snapshotId,proto3" json:"snapshot_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetSnapshotRequest) Reset() {
+	*x = GetSnapshotRequest{}
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[23]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetSnapshotRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetSnapshotRequest) ProtoMessage() {}
+
+func (x *GetSnapshotRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[23]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetSnapshotRequest.ProtoReflect.Descriptor instead.
+func (*GetSnapshotRequest) Descriptor() ([]byte, []int) {
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{23}
+}
+
+func (x *GetSnapshotRequest) GetSnapshotId() string {
+	if x != nil {
+		return x.SnapshotId
+	}
+	return ""
+}
+
+type GetSnapshotResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Snapshot      *Snapshot              `protobuf:"bytes,1,opt,name=snapshot,proto3" json:"snapshot,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetSnapshotResponse) Reset() {
+	*x = GetSnapshotResponse{}
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[24]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetSnapshotResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetSnapshotResponse) ProtoMessage() {}
+
+func (x *GetSnapshotResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[24]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetSnapshotResponse.ProtoReflect.Descriptor instead.
+func (*GetSnapshotResponse) Descriptor() ([]byte, []int) {
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{24}
+}
+
+func (x *GetSnapshotResponse) GetSnapshot() *Snapshot {
+	if x != nil {
+		return x.Snapshot
+	}
+	return nil
+}
+
+type ListSnapshotsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListSnapshotsRequest) Reset() {
+	*x = ListSnapshotsRequest{}
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[25]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListSnapshotsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListSnapshotsRequest) ProtoMessage() {}
+
+func (x *ListSnapshotsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[25]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListSnapshotsRequest.ProtoReflect.Descriptor instead.
+func (*ListSnapshotsRequest) Descriptor() ([]byte, []int) {
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{25}
+}
+
+type ListSnapshotsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Snapshots     []*Snapshot            `protobuf:"bytes,1,rep,name=snapshots,proto3" json:"snapshots,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListSnapshotsResponse) Reset() {
+	*x = ListSnapshotsResponse{}
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[26]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListSnapshotsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListSnapshotsResponse) ProtoMessage() {}
+
+func (x *ListSnapshotsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[26]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListSnapshotsResponse.ProtoReflect.Descriptor instead.
+func (*ListSnapshotsResponse) Descriptor() ([]byte, []int) {
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{26}
+}
+
+func (x *ListSnapshotsResponse) GetSnapshots() []*Snapshot {
+	if x != nil {
+		return x.Snapshots
+	}
+	return nil
+}
+
+type DeleteSnapshotRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SnapshotId    string                 `protobuf:"bytes,1,opt,name=snapshot_id,json=snapshotId,proto3" json:"snapshot_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteSnapshotRequest) Reset() {
+	*x = DeleteSnapshotRequest{}
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[27]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteSnapshotRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteSnapshotRequest) ProtoMessage() {}
+
+func (x *DeleteSnapshotRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[27]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteSnapshotRequest.ProtoReflect.Descriptor instead.
+func (*DeleteSnapshotRequest) Descriptor() ([]byte, []int) {
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{27}
+}
+
+func (x *DeleteSnapshotRequest) GetSnapshotId() string {
+	if x != nil {
+		return x.SnapshotId
+	}
+	return ""
+}
+
+type DeleteSnapshotResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SnapshotId    string                 `protobuf:"bytes,1,opt,name=snapshot_id,json=snapshotId,proto3" json:"snapshot_id,omitempty"`
+	Deleted       bool                   `protobuf:"varint,2,opt,name=deleted,proto3" json:"deleted,omitempty"`
+	Message       string                 `protobuf:"bytes,3,opt,name=message,proto3" json:"message,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteSnapshotResponse) Reset() {
+	*x = DeleteSnapshotResponse{}
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[28]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteSnapshotResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteSnapshotResponse) ProtoMessage() {}
+
+func (x *DeleteSnapshotResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[28]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteSnapshotResponse.ProtoReflect.Descriptor instead.
+func (*DeleteSnapshotResponse) Descriptor() ([]byte, []int) {
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{28}
+}
+
+func (x *DeleteSnapshotResponse) GetSnapshotId() string {
+	if x != nil {
+		return x.SnapshotId
+	}
+	return ""
+}
+
+func (x *DeleteSnapshotResponse) GetDeleted() bool {
+	if x != nil {
+		return x.Deleted
+	}
+	return false
+}
+
+func (x *DeleteSnapshotResponse) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
 type Execution struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	ExecutionId   string                 `protobuf:"bytes,1,opt,name=execution_id,json=executionId,proto3" json:"execution_id,omitempty"`
@@ -1208,7 +1802,7 @@ type Execution struct {
 
 func (x *Execution) Reset() {
 	*x = Execution{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[18]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1220,7 +1814,7 @@ func (x *Execution) String() string {
 func (*Execution) ProtoMessage() {}
 
 func (x *Execution) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[18]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1233,7 +1827,7 @@ func (x *Execution) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Execution.ProtoReflect.Descriptor instead.
 func (*Execution) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{18}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *Execution) GetExecutionId() string {
@@ -1316,7 +1910,7 @@ type ExecutionOptions struct {
 
 func (x *ExecutionOptions) Reset() {
 	*x = ExecutionOptions{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[19]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1328,7 +1922,7 @@ func (x *ExecutionOptions) String() string {
 func (*ExecutionOptions) ProtoMessage() {}
 
 func (x *ExecutionOptions) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[19]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1341,7 +1935,7 @@ func (x *ExecutionOptions) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionOptions.ProtoReflect.Descriptor instead.
 func (*ExecutionOptions) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{19}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *ExecutionOptions) GetLaunchSeconds() int64 {
@@ -1370,7 +1964,7 @@ type CreateExecutionRequest struct {
 
 func (x *CreateExecutionRequest) Reset() {
 	*x = CreateExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[20]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1382,7 +1976,7 @@ func (x *CreateExecutionRequest) String() string {
 func (*CreateExecutionRequest) ProtoMessage() {}
 
 func (x *CreateExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[20]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1395,7 +1989,7 @@ func (x *CreateExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateExecutionRequest.ProtoReflect.Descriptor instead.
 func (*CreateExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{20}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *CreateExecutionRequest) GetSandboxId() string {
@@ -1435,7 +2029,7 @@ type CreateExecutionResponse struct {
 
 func (x *CreateExecutionResponse) Reset() {
 	*x = CreateExecutionResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[21]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1447,7 +2041,7 @@ func (x *CreateExecutionResponse) String() string {
 func (*CreateExecutionResponse) ProtoMessage() {}
 
 func (x *CreateExecutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[21]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1460,7 +2054,7 @@ func (x *CreateExecutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateExecutionResponse.ProtoReflect.Descriptor instead.
 func (*CreateExecutionResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{21}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *CreateExecutionResponse) GetExecution() *Execution {
@@ -1482,7 +2076,7 @@ type OpenInteractiveExecutionRequest struct {
 
 func (x *OpenInteractiveExecutionRequest) Reset() {
 	*x = OpenInteractiveExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[22]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1494,7 +2088,7 @@ func (x *OpenInteractiveExecutionRequest) String() string {
 func (*OpenInteractiveExecutionRequest) ProtoMessage() {}
 
 func (x *OpenInteractiveExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[22]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1507,7 +2101,7 @@ func (x *OpenInteractiveExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OpenInteractiveExecutionRequest.ProtoReflect.Descriptor instead.
 func (*OpenInteractiveExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{22}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *OpenInteractiveExecutionRequest) GetSandboxId() string {
@@ -1552,7 +2146,7 @@ type OpenInteractiveExecutionResponse struct {
 
 func (x *OpenInteractiveExecutionResponse) Reset() {
 	*x = OpenInteractiveExecutionResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[23]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1564,7 +2158,7 @@ func (x *OpenInteractiveExecutionResponse) String() string {
 func (*OpenInteractiveExecutionResponse) ProtoMessage() {}
 
 func (x *OpenInteractiveExecutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[23]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1577,7 +2171,7 @@ func (x *OpenInteractiveExecutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OpenInteractiveExecutionResponse.ProtoReflect.Descriptor instead.
 func (*OpenInteractiveExecutionResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{23}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *OpenInteractiveExecutionResponse) GetSessionId() string {
@@ -1632,7 +2226,7 @@ type GetExecutionRequest struct {
 
 func (x *GetExecutionRequest) Reset() {
 	*x = GetExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[24]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1644,7 +2238,7 @@ func (x *GetExecutionRequest) String() string {
 func (*GetExecutionRequest) ProtoMessage() {}
 
 func (x *GetExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[24]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1657,7 +2251,7 @@ func (x *GetExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetExecutionRequest.ProtoReflect.Descriptor instead.
 func (*GetExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{24}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *GetExecutionRequest) GetSandboxId() string {
@@ -1683,7 +2277,7 @@ type GetExecutionResponse struct {
 
 func (x *GetExecutionResponse) Reset() {
 	*x = GetExecutionResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[25]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1695,7 +2289,7 @@ func (x *GetExecutionResponse) String() string {
 func (*GetExecutionResponse) ProtoMessage() {}
 
 func (x *GetExecutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[25]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1708,7 +2302,7 @@ func (x *GetExecutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetExecutionResponse.ProtoReflect.Descriptor instead.
 func (*GetExecutionResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{25}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *GetExecutionResponse) GetExecution() *Execution {
@@ -1729,7 +2323,7 @@ type CancelExecutionRequest struct {
 
 func (x *CancelExecutionRequest) Reset() {
 	*x = CancelExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[26]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1741,7 +2335,7 @@ func (x *CancelExecutionRequest) String() string {
 func (*CancelExecutionRequest) ProtoMessage() {}
 
 func (x *CancelExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[26]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1754,7 +2348,7 @@ func (x *CancelExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelExecutionRequest.ProtoReflect.Descriptor instead.
 func (*CancelExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{26}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *CancelExecutionRequest) GetSandboxId() string {
@@ -1790,7 +2384,7 @@ type CancelExecutionResponse struct {
 
 func (x *CancelExecutionResponse) Reset() {
 	*x = CancelExecutionResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[27]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1802,7 +2396,7 @@ func (x *CancelExecutionResponse) String() string {
 func (*CancelExecutionResponse) ProtoMessage() {}
 
 func (x *CancelExecutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[27]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1815,7 +2409,7 @@ func (x *CancelExecutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelExecutionResponse.ProtoReflect.Descriptor instead.
 func (*CancelExecutionResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{27}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *CancelExecutionResponse) GetSandboxId() string {
@@ -1857,7 +2451,7 @@ type StreamExecutionRequest struct {
 
 func (x *StreamExecutionRequest) Reset() {
 	*x = StreamExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[28]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1869,7 +2463,7 @@ func (x *StreamExecutionRequest) String() string {
 func (*StreamExecutionRequest) ProtoMessage() {}
 
 func (x *StreamExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[28]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1882,7 +2476,7 @@ func (x *StreamExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamExecutionRequest.ProtoReflect.Descriptor instead.
 func (*StreamExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{28}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *StreamExecutionRequest) GetSandboxId() string {
@@ -1917,7 +2511,7 @@ type ExecutionExit struct {
 
 func (x *ExecutionExit) Reset() {
 	*x = ExecutionExit{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[29]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1929,7 +2523,7 @@ func (x *ExecutionExit) String() string {
 func (*ExecutionExit) ProtoMessage() {}
 
 func (x *ExecutionExit) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[29]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1942,7 +2536,7 @@ func (x *ExecutionExit) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionExit.ProtoReflect.Descriptor instead.
 func (*ExecutionExit) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{29}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *ExecutionExit) GetExitCode() int32 {
@@ -1987,7 +2581,7 @@ type ExecutionStreamEvent struct {
 
 func (x *ExecutionStreamEvent) Reset() {
 	*x = ExecutionStreamEvent{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[30]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1999,7 +2593,7 @@ func (x *ExecutionStreamEvent) String() string {
 func (*ExecutionStreamEvent) ProtoMessage() {}
 
 func (x *ExecutionStreamEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[30]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2012,7 +2606,7 @@ func (x *ExecutionStreamEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionStreamEvent.ProtoReflect.Descriptor instead.
 func (*ExecutionStreamEvent) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{30}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *ExecutionStreamEvent) GetSandboxId() string {
@@ -2143,7 +2737,17 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\n" +
 	"created_at\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x129\n" +
 	"\n" +
-	"updated_at\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\tupdatedAt\";\n" +
+	"updated_at\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\tupdatedAt\"\xe1\x01\n" +
+	"\bSnapshot\x12\x1f\n" +
+	"\vsnapshot_id\x18\x01 \x01(\tR\n" +
+	"snapshotId\x12*\n" +
+	"\x11source_sandbox_id\x18\x02 \x01(\tR\x0fsourceSandboxId\x12\x18\n" +
+	"\abackend\x18\x03 \x01(\tR\abackend\x12\x1f\n" +
+	"\vpolicy_hash\x18\x04 \x01(\tR\n" +
+	"policyHash\x12\x12\n" +
+	"\x04name\x18\x05 \x01(\tR\x04name\x129\n" +
+	"\n" +
+	"created_at\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\";\n" +
 	"\x0fPolicyAllowRule\x12\x12\n" +
 	"\x04host\x18\x01 \x01(\tR\x04host\x12\x14\n" +
 	"\x05ports\x18\x02 \x03(\x05R\x05ports\"1\n" +
@@ -2160,11 +2764,14 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\x04hash\x18\x06 \x01(\tR\x04hash\x128\n" +
 	"\bservices\x18\a \x01(\v2\x1c.cleanroom.v1.PolicyServicesR\bservices\"R\n" +
 	"\x0eSandboxOptions\x12%\n" +
-	"\x0elaunch_seconds\x18\x03 \x01(\x03R\rlaunchSecondsJ\x04\b\x02\x10\x03R\x13read_only_workspace\"\xa1\x01\n" +
+	"\x0elaunch_seconds\x18\x03 \x01(\x03R\rlaunchSecondsJ\x04\b\x02\x10\x03R\x13read_only_workspace\"\xce\x01\n" +
 	"\x14CreateSandboxRequest\x12\x18\n" +
 	"\abackend\x18\x02 \x01(\tR\abackend\x126\n" +
 	"\aoptions\x18\x03 \x01(\v2\x1c.cleanroom.v1.SandboxOptionsR\aoptions\x12,\n" +
-	"\x06policy\x18\x04 \x01(\v2\x14.cleanroom.v1.PolicyR\x06policyJ\x04\b\x01\x10\x02R\x03cwd\"\x87\x01\n" +
+	"\x06policy\x18\x04 \x01(\v2\x14.cleanroom.v1.PolicyR\x06policy\x12!\n" +
+	"\vsnapshot_id\x18\x05 \x01(\tH\x00R\n" +
+	"snapshotIdB\b\n" +
+	"\x06sourceJ\x04\b\x01\x10\x02R\x03cwd\"\x87\x01\n" +
 	"\x15CreateSandboxResponse\x12/\n" +
 	"\asandbox\x18\x01 \x01(\v2\x15.cleanroom.v1.SandboxR\asandbox\x12#\n" +
 	"\rpolicy_source\x18\x02 \x01(\tR\fpolicySource\x12\x18\n" +
@@ -2188,7 +2795,15 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\x04path\x18\x02 \x01(\tR\x04path\x12\x12\n" +
 	"\x04data\x18\x03 \x01(\fR\x04data\x12\x1d\n" +
 	"\n" +
-	"size_bytes\x18\x04 \x01(\x03R\tsizeBytes\"8\n" +
+	"size_bytes\x18\x04 \x01(\x03R\tsizeBytes\"W\n" +
+	"\x15RestoreSandboxRequest\x12\x1d\n" +
+	"\n" +
+	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\x12\x1f\n" +
+	"\vsnapshot_id\x18\x02 \x01(\tR\n" +
+	"snapshotId\"c\n" +
+	"\x16RestoreSandboxResponse\x12/\n" +
+	"\asandbox\x18\x01 \x01(\v2\x15.cleanroom.v1.SandboxR\asandbox\x12\x18\n" +
+	"\amessage\x18\x02 \x01(\tR\amessage\"8\n" +
 	"\x17TerminateSandboxRequest\x12\x1d\n" +
 	"\n" +
 	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\"s\n" +
@@ -2209,7 +2824,30 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\x06status\x18\x02 \x01(\x0e2\x1b.cleanroom.v1.SandboxStatusR\x06status\x12\x18\n" +
 	"\amessage\x18\x03 \x01(\tR\amessage\x12;\n" +
 	"\voccurred_at\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
-	"occurredAt\"\x8d\x03\n" +
+	"occurredAt\"J\n" +
+	"\x15CreateSnapshotRequest\x12\x1d\n" +
+	"\n" +
+	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\x12\x12\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\"f\n" +
+	"\x16CreateSnapshotResponse\x122\n" +
+	"\bsnapshot\x18\x01 \x01(\v2\x16.cleanroom.v1.SnapshotR\bsnapshot\x12\x18\n" +
+	"\amessage\x18\x02 \x01(\tR\amessage\"5\n" +
+	"\x12GetSnapshotRequest\x12\x1f\n" +
+	"\vsnapshot_id\x18\x01 \x01(\tR\n" +
+	"snapshotId\"I\n" +
+	"\x13GetSnapshotResponse\x122\n" +
+	"\bsnapshot\x18\x01 \x01(\v2\x16.cleanroom.v1.SnapshotR\bsnapshot\"\x16\n" +
+	"\x14ListSnapshotsRequest\"M\n" +
+	"\x15ListSnapshotsResponse\x124\n" +
+	"\tsnapshots\x18\x01 \x03(\v2\x16.cleanroom.v1.SnapshotR\tsnapshots\"8\n" +
+	"\x15DeleteSnapshotRequest\x12\x1f\n" +
+	"\vsnapshot_id\x18\x01 \x01(\tR\n" +
+	"snapshotId\"m\n" +
+	"\x16DeleteSnapshotResponse\x12\x1f\n" +
+	"\vsnapshot_id\x18\x01 \x01(\tR\n" +
+	"snapshotId\x12\x18\n" +
+	"\adeleted\x18\x02 \x01(\bR\adeleted\x12\x18\n" +
+	"\amessage\x18\x03 \x01(\tR\amessage\"\x8d\x03\n" +
 	"\tExecution\x12!\n" +
 	"\fexecution_id\x18\x01 \x01(\tR\vexecutionId\x12\x1d\n" +
 	"\n" +
@@ -2310,15 +2948,21 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\rExecutionKind\x12\x1e\n" +
 	"\x1aEXECUTION_KIND_UNSPECIFIED\x10\x00\x12\x18\n" +
 	"\x14EXECUTION_KIND_BATCH\x10\x01\x12\x1e\n" +
-	"\x1aEXECUTION_KIND_INTERACTIVE\x10\x022\xc3\x04\n" +
+	"\x1aEXECUTION_KIND_INTERACTIVE\x10\x022\xa0\x05\n" +
 	"\x0eSandboxService\x12X\n" +
 	"\rCreateSandbox\x12\".cleanroom.v1.CreateSandboxRequest\x1a#.cleanroom.v1.CreateSandboxResponse\x12O\n" +
 	"\n" +
 	"GetSandbox\x12\x1f.cleanroom.v1.GetSandboxRequest\x1a .cleanroom.v1.GetSandboxResponse\x12X\n" +
 	"\rListSandboxes\x12\".cleanroom.v1.ListSandboxesRequest\x1a#.cleanroom.v1.ListSandboxesResponse\x12j\n" +
-	"\x13DownloadSandboxFile\x12(.cleanroom.v1.DownloadSandboxFileRequest\x1a).cleanroom.v1.DownloadSandboxFileResponse\x12a\n" +
+	"\x13DownloadSandboxFile\x12(.cleanroom.v1.DownloadSandboxFileRequest\x1a).cleanroom.v1.DownloadSandboxFileResponse\x12[\n" +
+	"\x0eRestoreSandbox\x12#.cleanroom.v1.RestoreSandboxRequest\x1a$.cleanroom.v1.RestoreSandboxResponse\x12a\n" +
 	"\x10TerminateSandbox\x12%.cleanroom.v1.TerminateSandboxRequest\x1a&.cleanroom.v1.TerminateSandboxResponse\x12]\n" +
-	"\x13StreamSandboxEvents\x12(.cleanroom.v1.StreamSandboxEventsRequest\x1a\x1a.cleanroom.v1.SandboxEvent0\x012\x83\x04\n" +
+	"\x13StreamSandboxEvents\x12(.cleanroom.v1.StreamSandboxEventsRequest\x1a\x1a.cleanroom.v1.SandboxEvent0\x012\xf9\x02\n" +
+	"\x0fSnapshotService\x12[\n" +
+	"\x0eCreateSnapshot\x12#.cleanroom.v1.CreateSnapshotRequest\x1a$.cleanroom.v1.CreateSnapshotResponse\x12R\n" +
+	"\vGetSnapshot\x12 .cleanroom.v1.GetSnapshotRequest\x1a!.cleanroom.v1.GetSnapshotResponse\x12X\n" +
+	"\rListSnapshots\x12\".cleanroom.v1.ListSnapshotsRequest\x1a#.cleanroom.v1.ListSnapshotsResponse\x12[\n" +
+	"\x0eDeleteSnapshot\x12#.cleanroom.v1.DeleteSnapshotRequest\x1a$.cleanroom.v1.DeleteSnapshotResponse2\x83\x04\n" +
 	"\x10ExecutionService\x12^\n" +
 	"\x0fCreateExecution\x12$.cleanroom.v1.CreateExecutionRequest\x1a%.cleanroom.v1.CreateExecutionResponse\x12y\n" +
 	"\x18OpenInteractiveExecution\x12-.cleanroom.v1.OpenInteractiveExecutionRequest\x1a..cleanroom.v1.OpenInteractiveExecutionResponse\x12U\n" +
@@ -2339,99 +2983,125 @@ func file_proto_cleanroom_v1_control_proto_rawDescGZIP() []byte {
 }
 
 var file_proto_cleanroom_v1_control_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_proto_cleanroom_v1_control_proto_msgTypes = make([]protoimpl.MessageInfo, 31)
+var file_proto_cleanroom_v1_control_proto_msgTypes = make([]protoimpl.MessageInfo, 42)
 var file_proto_cleanroom_v1_control_proto_goTypes = []any{
 	(SandboxStatus)(0),                       // 0: cleanroom.v1.SandboxStatus
 	(ExecutionStatus)(0),                     // 1: cleanroom.v1.ExecutionStatus
 	(ExecutionKind)(0),                       // 2: cleanroom.v1.ExecutionKind
 	(*Sandbox)(nil),                          // 3: cleanroom.v1.Sandbox
-	(*PolicyAllowRule)(nil),                  // 4: cleanroom.v1.PolicyAllowRule
-	(*PolicyDockerService)(nil),              // 5: cleanroom.v1.PolicyDockerService
-	(*PolicyServices)(nil),                   // 6: cleanroom.v1.PolicyServices
-	(*Policy)(nil),                           // 7: cleanroom.v1.Policy
-	(*SandboxOptions)(nil),                   // 8: cleanroom.v1.SandboxOptions
-	(*CreateSandboxRequest)(nil),             // 9: cleanroom.v1.CreateSandboxRequest
-	(*CreateSandboxResponse)(nil),            // 10: cleanroom.v1.CreateSandboxResponse
-	(*GetSandboxRequest)(nil),                // 11: cleanroom.v1.GetSandboxRequest
-	(*GetSandboxResponse)(nil),               // 12: cleanroom.v1.GetSandboxResponse
-	(*ListSandboxesRequest)(nil),             // 13: cleanroom.v1.ListSandboxesRequest
-	(*ListSandboxesResponse)(nil),            // 14: cleanroom.v1.ListSandboxesResponse
-	(*DownloadSandboxFileRequest)(nil),       // 15: cleanroom.v1.DownloadSandboxFileRequest
-	(*DownloadSandboxFileResponse)(nil),      // 16: cleanroom.v1.DownloadSandboxFileResponse
-	(*TerminateSandboxRequest)(nil),          // 17: cleanroom.v1.TerminateSandboxRequest
-	(*TerminateSandboxResponse)(nil),         // 18: cleanroom.v1.TerminateSandboxResponse
-	(*StreamSandboxEventsRequest)(nil),       // 19: cleanroom.v1.StreamSandboxEventsRequest
-	(*SandboxEvent)(nil),                     // 20: cleanroom.v1.SandboxEvent
-	(*Execution)(nil),                        // 21: cleanroom.v1.Execution
-	(*ExecutionOptions)(nil),                 // 22: cleanroom.v1.ExecutionOptions
-	(*CreateExecutionRequest)(nil),           // 23: cleanroom.v1.CreateExecutionRequest
-	(*CreateExecutionResponse)(nil),          // 24: cleanroom.v1.CreateExecutionResponse
-	(*OpenInteractiveExecutionRequest)(nil),  // 25: cleanroom.v1.OpenInteractiveExecutionRequest
-	(*OpenInteractiveExecutionResponse)(nil), // 26: cleanroom.v1.OpenInteractiveExecutionResponse
-	(*GetExecutionRequest)(nil),              // 27: cleanroom.v1.GetExecutionRequest
-	(*GetExecutionResponse)(nil),             // 28: cleanroom.v1.GetExecutionResponse
-	(*CancelExecutionRequest)(nil),           // 29: cleanroom.v1.CancelExecutionRequest
-	(*CancelExecutionResponse)(nil),          // 30: cleanroom.v1.CancelExecutionResponse
-	(*StreamExecutionRequest)(nil),           // 31: cleanroom.v1.StreamExecutionRequest
-	(*ExecutionExit)(nil),                    // 32: cleanroom.v1.ExecutionExit
-	(*ExecutionStreamEvent)(nil),             // 33: cleanroom.v1.ExecutionStreamEvent
-	(*timestamppb.Timestamp)(nil),            // 34: google.protobuf.Timestamp
+	(*Snapshot)(nil),                         // 4: cleanroom.v1.Snapshot
+	(*PolicyAllowRule)(nil),                  // 5: cleanroom.v1.PolicyAllowRule
+	(*PolicyDockerService)(nil),              // 6: cleanroom.v1.PolicyDockerService
+	(*PolicyServices)(nil),                   // 7: cleanroom.v1.PolicyServices
+	(*Policy)(nil),                           // 8: cleanroom.v1.Policy
+	(*SandboxOptions)(nil),                   // 9: cleanroom.v1.SandboxOptions
+	(*CreateSandboxRequest)(nil),             // 10: cleanroom.v1.CreateSandboxRequest
+	(*CreateSandboxResponse)(nil),            // 11: cleanroom.v1.CreateSandboxResponse
+	(*GetSandboxRequest)(nil),                // 12: cleanroom.v1.GetSandboxRequest
+	(*GetSandboxResponse)(nil),               // 13: cleanroom.v1.GetSandboxResponse
+	(*ListSandboxesRequest)(nil),             // 14: cleanroom.v1.ListSandboxesRequest
+	(*ListSandboxesResponse)(nil),            // 15: cleanroom.v1.ListSandboxesResponse
+	(*DownloadSandboxFileRequest)(nil),       // 16: cleanroom.v1.DownloadSandboxFileRequest
+	(*DownloadSandboxFileResponse)(nil),      // 17: cleanroom.v1.DownloadSandboxFileResponse
+	(*RestoreSandboxRequest)(nil),            // 18: cleanroom.v1.RestoreSandboxRequest
+	(*RestoreSandboxResponse)(nil),           // 19: cleanroom.v1.RestoreSandboxResponse
+	(*TerminateSandboxRequest)(nil),          // 20: cleanroom.v1.TerminateSandboxRequest
+	(*TerminateSandboxResponse)(nil),         // 21: cleanroom.v1.TerminateSandboxResponse
+	(*StreamSandboxEventsRequest)(nil),       // 22: cleanroom.v1.StreamSandboxEventsRequest
+	(*SandboxEvent)(nil),                     // 23: cleanroom.v1.SandboxEvent
+	(*CreateSnapshotRequest)(nil),            // 24: cleanroom.v1.CreateSnapshotRequest
+	(*CreateSnapshotResponse)(nil),           // 25: cleanroom.v1.CreateSnapshotResponse
+	(*GetSnapshotRequest)(nil),               // 26: cleanroom.v1.GetSnapshotRequest
+	(*GetSnapshotResponse)(nil),              // 27: cleanroom.v1.GetSnapshotResponse
+	(*ListSnapshotsRequest)(nil),             // 28: cleanroom.v1.ListSnapshotsRequest
+	(*ListSnapshotsResponse)(nil),            // 29: cleanroom.v1.ListSnapshotsResponse
+	(*DeleteSnapshotRequest)(nil),            // 30: cleanroom.v1.DeleteSnapshotRequest
+	(*DeleteSnapshotResponse)(nil),           // 31: cleanroom.v1.DeleteSnapshotResponse
+	(*Execution)(nil),                        // 32: cleanroom.v1.Execution
+	(*ExecutionOptions)(nil),                 // 33: cleanroom.v1.ExecutionOptions
+	(*CreateExecutionRequest)(nil),           // 34: cleanroom.v1.CreateExecutionRequest
+	(*CreateExecutionResponse)(nil),          // 35: cleanroom.v1.CreateExecutionResponse
+	(*OpenInteractiveExecutionRequest)(nil),  // 36: cleanroom.v1.OpenInteractiveExecutionRequest
+	(*OpenInteractiveExecutionResponse)(nil), // 37: cleanroom.v1.OpenInteractiveExecutionResponse
+	(*GetExecutionRequest)(nil),              // 38: cleanroom.v1.GetExecutionRequest
+	(*GetExecutionResponse)(nil),             // 39: cleanroom.v1.GetExecutionResponse
+	(*CancelExecutionRequest)(nil),           // 40: cleanroom.v1.CancelExecutionRequest
+	(*CancelExecutionResponse)(nil),          // 41: cleanroom.v1.CancelExecutionResponse
+	(*StreamExecutionRequest)(nil),           // 42: cleanroom.v1.StreamExecutionRequest
+	(*ExecutionExit)(nil),                    // 43: cleanroom.v1.ExecutionExit
+	(*ExecutionStreamEvent)(nil),             // 44: cleanroom.v1.ExecutionStreamEvent
+	(*timestamppb.Timestamp)(nil),            // 45: google.protobuf.Timestamp
 }
 var file_proto_cleanroom_v1_control_proto_depIdxs = []int32{
 	0,  // 0: cleanroom.v1.Sandbox.status:type_name -> cleanroom.v1.SandboxStatus
-	34, // 1: cleanroom.v1.Sandbox.created_at:type_name -> google.protobuf.Timestamp
-	34, // 2: cleanroom.v1.Sandbox.updated_at:type_name -> google.protobuf.Timestamp
-	5,  // 3: cleanroom.v1.PolicyServices.docker:type_name -> cleanroom.v1.PolicyDockerService
-	4,  // 4: cleanroom.v1.Policy.allow:type_name -> cleanroom.v1.PolicyAllowRule
-	6,  // 5: cleanroom.v1.Policy.services:type_name -> cleanroom.v1.PolicyServices
-	8,  // 6: cleanroom.v1.CreateSandboxRequest.options:type_name -> cleanroom.v1.SandboxOptions
-	7,  // 7: cleanroom.v1.CreateSandboxRequest.policy:type_name -> cleanroom.v1.Policy
-	3,  // 8: cleanroom.v1.CreateSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
-	3,  // 9: cleanroom.v1.GetSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
-	3,  // 10: cleanroom.v1.ListSandboxesResponse.sandboxes:type_name -> cleanroom.v1.Sandbox
-	0,  // 11: cleanroom.v1.SandboxEvent.status:type_name -> cleanroom.v1.SandboxStatus
-	34, // 12: cleanroom.v1.SandboxEvent.occurred_at:type_name -> google.protobuf.Timestamp
-	1,  // 13: cleanroom.v1.Execution.status:type_name -> cleanroom.v1.ExecutionStatus
-	34, // 14: cleanroom.v1.Execution.started_at:type_name -> google.protobuf.Timestamp
-	34, // 15: cleanroom.v1.Execution.finished_at:type_name -> google.protobuf.Timestamp
-	2,  // 16: cleanroom.v1.Execution.kind:type_name -> cleanroom.v1.ExecutionKind
-	22, // 17: cleanroom.v1.CreateExecutionRequest.options:type_name -> cleanroom.v1.ExecutionOptions
-	2,  // 18: cleanroom.v1.CreateExecutionRequest.kind:type_name -> cleanroom.v1.ExecutionKind
-	21, // 19: cleanroom.v1.CreateExecutionResponse.execution:type_name -> cleanroom.v1.Execution
-	34, // 20: cleanroom.v1.OpenInteractiveExecutionResponse.expires_at:type_name -> google.protobuf.Timestamp
-	21, // 21: cleanroom.v1.GetExecutionResponse.execution:type_name -> cleanroom.v1.Execution
-	1,  // 22: cleanroom.v1.CancelExecutionResponse.status:type_name -> cleanroom.v1.ExecutionStatus
-	1,  // 23: cleanroom.v1.ExecutionExit.status:type_name -> cleanroom.v1.ExecutionStatus
-	1,  // 24: cleanroom.v1.ExecutionStreamEvent.status:type_name -> cleanroom.v1.ExecutionStatus
-	32, // 25: cleanroom.v1.ExecutionStreamEvent.exit:type_name -> cleanroom.v1.ExecutionExit
-	34, // 26: cleanroom.v1.ExecutionStreamEvent.occurred_at:type_name -> google.protobuf.Timestamp
-	9,  // 27: cleanroom.v1.SandboxService.CreateSandbox:input_type -> cleanroom.v1.CreateSandboxRequest
-	11, // 28: cleanroom.v1.SandboxService.GetSandbox:input_type -> cleanroom.v1.GetSandboxRequest
-	13, // 29: cleanroom.v1.SandboxService.ListSandboxes:input_type -> cleanroom.v1.ListSandboxesRequest
-	15, // 30: cleanroom.v1.SandboxService.DownloadSandboxFile:input_type -> cleanroom.v1.DownloadSandboxFileRequest
-	17, // 31: cleanroom.v1.SandboxService.TerminateSandbox:input_type -> cleanroom.v1.TerminateSandboxRequest
-	19, // 32: cleanroom.v1.SandboxService.StreamSandboxEvents:input_type -> cleanroom.v1.StreamSandboxEventsRequest
-	23, // 33: cleanroom.v1.ExecutionService.CreateExecution:input_type -> cleanroom.v1.CreateExecutionRequest
-	25, // 34: cleanroom.v1.ExecutionService.OpenInteractiveExecution:input_type -> cleanroom.v1.OpenInteractiveExecutionRequest
-	27, // 35: cleanroom.v1.ExecutionService.GetExecution:input_type -> cleanroom.v1.GetExecutionRequest
-	29, // 36: cleanroom.v1.ExecutionService.CancelExecution:input_type -> cleanroom.v1.CancelExecutionRequest
-	31, // 37: cleanroom.v1.ExecutionService.StreamExecution:input_type -> cleanroom.v1.StreamExecutionRequest
-	10, // 38: cleanroom.v1.SandboxService.CreateSandbox:output_type -> cleanroom.v1.CreateSandboxResponse
-	12, // 39: cleanroom.v1.SandboxService.GetSandbox:output_type -> cleanroom.v1.GetSandboxResponse
-	14, // 40: cleanroom.v1.SandboxService.ListSandboxes:output_type -> cleanroom.v1.ListSandboxesResponse
-	16, // 41: cleanroom.v1.SandboxService.DownloadSandboxFile:output_type -> cleanroom.v1.DownloadSandboxFileResponse
-	18, // 42: cleanroom.v1.SandboxService.TerminateSandbox:output_type -> cleanroom.v1.TerminateSandboxResponse
-	20, // 43: cleanroom.v1.SandboxService.StreamSandboxEvents:output_type -> cleanroom.v1.SandboxEvent
-	24, // 44: cleanroom.v1.ExecutionService.CreateExecution:output_type -> cleanroom.v1.CreateExecutionResponse
-	26, // 45: cleanroom.v1.ExecutionService.OpenInteractiveExecution:output_type -> cleanroom.v1.OpenInteractiveExecutionResponse
-	28, // 46: cleanroom.v1.ExecutionService.GetExecution:output_type -> cleanroom.v1.GetExecutionResponse
-	30, // 47: cleanroom.v1.ExecutionService.CancelExecution:output_type -> cleanroom.v1.CancelExecutionResponse
-	33, // 48: cleanroom.v1.ExecutionService.StreamExecution:output_type -> cleanroom.v1.ExecutionStreamEvent
-	38, // [38:49] is the sub-list for method output_type
-	27, // [27:38] is the sub-list for method input_type
-	27, // [27:27] is the sub-list for extension type_name
-	27, // [27:27] is the sub-list for extension extendee
-	0,  // [0:27] is the sub-list for field type_name
+	45, // 1: cleanroom.v1.Sandbox.created_at:type_name -> google.protobuf.Timestamp
+	45, // 2: cleanroom.v1.Sandbox.updated_at:type_name -> google.protobuf.Timestamp
+	45, // 3: cleanroom.v1.Snapshot.created_at:type_name -> google.protobuf.Timestamp
+	6,  // 4: cleanroom.v1.PolicyServices.docker:type_name -> cleanroom.v1.PolicyDockerService
+	5,  // 5: cleanroom.v1.Policy.allow:type_name -> cleanroom.v1.PolicyAllowRule
+	7,  // 6: cleanroom.v1.Policy.services:type_name -> cleanroom.v1.PolicyServices
+	9,  // 7: cleanroom.v1.CreateSandboxRequest.options:type_name -> cleanroom.v1.SandboxOptions
+	8,  // 8: cleanroom.v1.CreateSandboxRequest.policy:type_name -> cleanroom.v1.Policy
+	3,  // 9: cleanroom.v1.CreateSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
+	3,  // 10: cleanroom.v1.GetSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
+	3,  // 11: cleanroom.v1.ListSandboxesResponse.sandboxes:type_name -> cleanroom.v1.Sandbox
+	3,  // 12: cleanroom.v1.RestoreSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
+	0,  // 13: cleanroom.v1.SandboxEvent.status:type_name -> cleanroom.v1.SandboxStatus
+	45, // 14: cleanroom.v1.SandboxEvent.occurred_at:type_name -> google.protobuf.Timestamp
+	4,  // 15: cleanroom.v1.CreateSnapshotResponse.snapshot:type_name -> cleanroom.v1.Snapshot
+	4,  // 16: cleanroom.v1.GetSnapshotResponse.snapshot:type_name -> cleanroom.v1.Snapshot
+	4,  // 17: cleanroom.v1.ListSnapshotsResponse.snapshots:type_name -> cleanroom.v1.Snapshot
+	1,  // 18: cleanroom.v1.Execution.status:type_name -> cleanroom.v1.ExecutionStatus
+	45, // 19: cleanroom.v1.Execution.started_at:type_name -> google.protobuf.Timestamp
+	45, // 20: cleanroom.v1.Execution.finished_at:type_name -> google.protobuf.Timestamp
+	2,  // 21: cleanroom.v1.Execution.kind:type_name -> cleanroom.v1.ExecutionKind
+	33, // 22: cleanroom.v1.CreateExecutionRequest.options:type_name -> cleanroom.v1.ExecutionOptions
+	2,  // 23: cleanroom.v1.CreateExecutionRequest.kind:type_name -> cleanroom.v1.ExecutionKind
+	32, // 24: cleanroom.v1.CreateExecutionResponse.execution:type_name -> cleanroom.v1.Execution
+	45, // 25: cleanroom.v1.OpenInteractiveExecutionResponse.expires_at:type_name -> google.protobuf.Timestamp
+	32, // 26: cleanroom.v1.GetExecutionResponse.execution:type_name -> cleanroom.v1.Execution
+	1,  // 27: cleanroom.v1.CancelExecutionResponse.status:type_name -> cleanroom.v1.ExecutionStatus
+	1,  // 28: cleanroom.v1.ExecutionExit.status:type_name -> cleanroom.v1.ExecutionStatus
+	1,  // 29: cleanroom.v1.ExecutionStreamEvent.status:type_name -> cleanroom.v1.ExecutionStatus
+	43, // 30: cleanroom.v1.ExecutionStreamEvent.exit:type_name -> cleanroom.v1.ExecutionExit
+	45, // 31: cleanroom.v1.ExecutionStreamEvent.occurred_at:type_name -> google.protobuf.Timestamp
+	10, // 32: cleanroom.v1.SandboxService.CreateSandbox:input_type -> cleanroom.v1.CreateSandboxRequest
+	12, // 33: cleanroom.v1.SandboxService.GetSandbox:input_type -> cleanroom.v1.GetSandboxRequest
+	14, // 34: cleanroom.v1.SandboxService.ListSandboxes:input_type -> cleanroom.v1.ListSandboxesRequest
+	16, // 35: cleanroom.v1.SandboxService.DownloadSandboxFile:input_type -> cleanroom.v1.DownloadSandboxFileRequest
+	18, // 36: cleanroom.v1.SandboxService.RestoreSandbox:input_type -> cleanroom.v1.RestoreSandboxRequest
+	20, // 37: cleanroom.v1.SandboxService.TerminateSandbox:input_type -> cleanroom.v1.TerminateSandboxRequest
+	22, // 38: cleanroom.v1.SandboxService.StreamSandboxEvents:input_type -> cleanroom.v1.StreamSandboxEventsRequest
+	24, // 39: cleanroom.v1.SnapshotService.CreateSnapshot:input_type -> cleanroom.v1.CreateSnapshotRequest
+	26, // 40: cleanroom.v1.SnapshotService.GetSnapshot:input_type -> cleanroom.v1.GetSnapshotRequest
+	28, // 41: cleanroom.v1.SnapshotService.ListSnapshots:input_type -> cleanroom.v1.ListSnapshotsRequest
+	30, // 42: cleanroom.v1.SnapshotService.DeleteSnapshot:input_type -> cleanroom.v1.DeleteSnapshotRequest
+	34, // 43: cleanroom.v1.ExecutionService.CreateExecution:input_type -> cleanroom.v1.CreateExecutionRequest
+	36, // 44: cleanroom.v1.ExecutionService.OpenInteractiveExecution:input_type -> cleanroom.v1.OpenInteractiveExecutionRequest
+	38, // 45: cleanroom.v1.ExecutionService.GetExecution:input_type -> cleanroom.v1.GetExecutionRequest
+	40, // 46: cleanroom.v1.ExecutionService.CancelExecution:input_type -> cleanroom.v1.CancelExecutionRequest
+	42, // 47: cleanroom.v1.ExecutionService.StreamExecution:input_type -> cleanroom.v1.StreamExecutionRequest
+	11, // 48: cleanroom.v1.SandboxService.CreateSandbox:output_type -> cleanroom.v1.CreateSandboxResponse
+	13, // 49: cleanroom.v1.SandboxService.GetSandbox:output_type -> cleanroom.v1.GetSandboxResponse
+	15, // 50: cleanroom.v1.SandboxService.ListSandboxes:output_type -> cleanroom.v1.ListSandboxesResponse
+	17, // 51: cleanroom.v1.SandboxService.DownloadSandboxFile:output_type -> cleanroom.v1.DownloadSandboxFileResponse
+	19, // 52: cleanroom.v1.SandboxService.RestoreSandbox:output_type -> cleanroom.v1.RestoreSandboxResponse
+	21, // 53: cleanroom.v1.SandboxService.TerminateSandbox:output_type -> cleanroom.v1.TerminateSandboxResponse
+	23, // 54: cleanroom.v1.SandboxService.StreamSandboxEvents:output_type -> cleanroom.v1.SandboxEvent
+	25, // 55: cleanroom.v1.SnapshotService.CreateSnapshot:output_type -> cleanroom.v1.CreateSnapshotResponse
+	27, // 56: cleanroom.v1.SnapshotService.GetSnapshot:output_type -> cleanroom.v1.GetSnapshotResponse
+	29, // 57: cleanroom.v1.SnapshotService.ListSnapshots:output_type -> cleanroom.v1.ListSnapshotsResponse
+	31, // 58: cleanroom.v1.SnapshotService.DeleteSnapshot:output_type -> cleanroom.v1.DeleteSnapshotResponse
+	35, // 59: cleanroom.v1.ExecutionService.CreateExecution:output_type -> cleanroom.v1.CreateExecutionResponse
+	37, // 60: cleanroom.v1.ExecutionService.OpenInteractiveExecution:output_type -> cleanroom.v1.OpenInteractiveExecutionResponse
+	39, // 61: cleanroom.v1.ExecutionService.GetExecution:output_type -> cleanroom.v1.GetExecutionResponse
+	41, // 62: cleanroom.v1.ExecutionService.CancelExecution:output_type -> cleanroom.v1.CancelExecutionResponse
+	44, // 63: cleanroom.v1.ExecutionService.StreamExecution:output_type -> cleanroom.v1.ExecutionStreamEvent
+	48, // [48:64] is the sub-list for method output_type
+	32, // [32:48] is the sub-list for method input_type
+	32, // [32:32] is the sub-list for extension type_name
+	32, // [32:32] is the sub-list for extension extendee
+	0,  // [0:32] is the sub-list for field type_name
 }
 
 func init() { file_proto_cleanroom_v1_control_proto_init() }
@@ -2439,7 +3109,10 @@ func file_proto_cleanroom_v1_control_proto_init() {
 	if File_proto_cleanroom_v1_control_proto != nil {
 		return
 	}
-	file_proto_cleanroom_v1_control_proto_msgTypes[30].OneofWrappers = []any{
+	file_proto_cleanroom_v1_control_proto_msgTypes[7].OneofWrappers = []any{
+		(*CreateSandboxRequest_SnapshotId)(nil),
+	}
+	file_proto_cleanroom_v1_control_proto_msgTypes[41].OneofWrappers = []any{
 		(*ExecutionStreamEvent_Stdout)(nil),
 		(*ExecutionStreamEvent_Stderr)(nil),
 		(*ExecutionStreamEvent_Exit)(nil),
@@ -2451,9 +3124,9 @@ func file_proto_cleanroom_v1_control_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proto_cleanroom_v1_control_proto_rawDesc), len(file_proto_cleanroom_v1_control_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   31,
+			NumMessages:   42,
 			NumExtensions: 0,
-			NumServices:   2,
+			NumServices:   3,
 		},
 		GoTypes:           file_proto_cleanroom_v1_control_proto_goTypes,
 		DependencyIndexes: file_proto_cleanroom_v1_control_proto_depIdxs,

--- a/internal/paths/snapshot_dir.go
+++ b/internal/paths/snapshot_dir.go
@@ -1,0 +1,19 @@
+package paths
+
+import "path/filepath"
+
+func SnapshotDir() (string, error) {
+	base, err := StateBaseDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, "snapshots"), nil
+}
+
+func SnapshotMetadataDBPath() (string, error) {
+	base, err := StateBaseDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, "snapshots", "metadata.db"), nil
+}

--- a/internal/runtimeconfig/config.go
+++ b/internal/runtimeconfig/config.go
@@ -27,6 +27,7 @@ type FirecrackerConfig struct {
 	KernelImage          string         `yaml:"kernel_image"`
 	RootFS               string         `yaml:"rootfs"`
 	Services             ServicesConfig `yaml:"services"`
+	Snapshots            SnapshotConfig `yaml:"snapshots"`
 	PrivilegedMode       string         `yaml:"privileged_mode"`
 	PrivilegedHelperPath string         `yaml:"privileged_helper_path"`
 	VCPUs                int64          `yaml:"vcpus"`
@@ -40,10 +41,19 @@ type DarwinVZConfig struct {
 	KernelImage   string         `yaml:"kernel_image"`
 	RootFS        string         `yaml:"rootfs"`
 	Services      ServicesConfig `yaml:"services"`
+	Snapshots     SnapshotConfig `yaml:"snapshots"`
 	VCPUs         int64          `yaml:"vcpus"`
 	MemoryMiB     int64          `yaml:"memory_mib"`
 	GuestPort     uint32         `yaml:"guest_port"`
 	LaunchSeconds int64          `yaml:"launch_seconds"` // VM boot/guest-agent readiness timeout
+}
+
+type SnapshotConfig struct {
+	Enabled               bool   `yaml:"enabled"`
+	Driver                string `yaml:"driver"`
+	BaseDir               string `yaml:"base_dir"`
+	ZFSDataset            string `yaml:"zfs_dataset"`
+	QuiesceTimeoutSeconds int64  `yaml:"quiesce_timeout_seconds"`
 }
 
 type ServicesConfig struct {
@@ -150,8 +160,17 @@ func darwinVZConfigIsZero(cfg DarwinVZConfig) bool {
 		cfg.Services.Docker.StartupTimeoutSeconds == 0 &&
 		strings.TrimSpace(cfg.Services.Docker.StorageDriver) == "" &&
 		!cfg.Services.Docker.IPTables &&
+		snapshotConfigIsZero(cfg.Snapshots) &&
 		cfg.VCPUs == 0 &&
 		cfg.MemoryMiB == 0 &&
 		cfg.GuestPort == 0 &&
 		cfg.LaunchSeconds == 0
+}
+
+func snapshotConfigIsZero(cfg SnapshotConfig) bool {
+	return !cfg.Enabled &&
+		strings.TrimSpace(cfg.Driver) == "" &&
+		strings.TrimSpace(cfg.BaseDir) == "" &&
+		strings.TrimSpace(cfg.ZFSDataset) == "" &&
+		cfg.QuiesceTimeoutSeconds == 0
 }

--- a/internal/runtimeconfig/config_test.go
+++ b/internal/runtimeconfig/config_test.go
@@ -190,3 +190,56 @@ func TestPathReturnsErrorWhenHomeUnavailableForNonRoot(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestLoadParsesSnapshotConfig(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	configPath := filepath.Join(tmp, "cleanroom", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+
+	content := `backends:
+  firecracker:
+    snapshots:
+      enabled: true
+      driver: zfs
+      base_dir: /var/tmp/cleanroom-snapshots
+      zfs_dataset: tank/cleanroom
+      quiesce_timeout_seconds: 15
+  darwin-vz:
+    snapshots:
+      enabled: false
+      driver: apfs
+      base_dir: /var/tmp/cleanroom-darwin
+`
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, _, err := Load()
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if !cfg.Backends.Firecracker.Snapshots.Enabled {
+		t.Fatal("expected firecracker snapshots to be enabled")
+	}
+	if got, want := cfg.Backends.Firecracker.Snapshots.Driver, "zfs"; got != want {
+		t.Fatalf("unexpected firecracker snapshot driver: got %q want %q", got, want)
+	}
+	if got, want := cfg.Backends.Firecracker.Snapshots.BaseDir, "/var/tmp/cleanroom-snapshots"; got != want {
+		t.Fatalf("unexpected firecracker snapshot base_dir: got %q want %q", got, want)
+	}
+	if got, want := cfg.Backends.Firecracker.Snapshots.ZFSDataset, "tank/cleanroom"; got != want {
+		t.Fatalf("unexpected firecracker snapshot zfs_dataset: got %q want %q", got, want)
+	}
+	if got, want := cfg.Backends.Firecracker.Snapshots.QuiesceTimeoutSeconds, int64(15); got != want {
+		t.Fatalf("unexpected firecracker snapshot quiesce timeout: got %d want %d", got, want)
+	}
+	if got, want := cfg.Backends.DarwinVZ.Snapshots.Driver, "apfs"; got != want {
+		t.Fatalf("unexpected darwin-vz snapshot driver: got %q want %q", got, want)
+	}
+	if got, want := cfg.Backends.DarwinVZ.Snapshots.BaseDir, "/var/tmp/cleanroom-darwin"; got != want {
+		t.Fatalf("unexpected darwin-vz snapshot base_dir: got %q want %q", got, want)
+	}
+}

--- a/internal/snapshotstore/store.go
+++ b/internal/snapshotstore/store.go
@@ -197,10 +197,7 @@ func (s *Store) Delete(ctx context.Context, snapshotID string) error {
 	return nil
 }
 
-func (s *Store) open(ctx context.Context) (*sql.DB, error) {
-	if err := s.initDB(ctx); err != nil {
-		return nil, err
-	}
+func (s *Store) open(_ context.Context) (*sql.DB, error) {
 	db, err := sql.Open("sqlite", s.metadataDBPath)
 	if err != nil {
 		return nil, fmt.Errorf("open snapshot metadata database %q: %w", s.metadataDBPath, err)

--- a/internal/snapshotstore/store.go
+++ b/internal/snapshotstore/store.go
@@ -1,0 +1,266 @@
+package snapshotstore
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+	"github.com/buildkite/cleanroom/internal/paths"
+	"google.golang.org/protobuf/proto"
+	_ "modernc.org/sqlite"
+)
+
+type Record struct {
+	SnapshotID      string
+	SourceSandboxID string
+	Backend         string
+	Name            string
+	PolicyHash      string
+	Policy          *cleanroomv1.Policy
+	StorageRef      string
+	CreatedAt       time.Time
+}
+
+type Options struct {
+	MetadataDBPath string
+}
+
+type Store struct {
+	metadataDBPath string
+}
+
+func New(opts Options) (*Store, error) {
+	metadataDBPath := strings.TrimSpace(opts.MetadataDBPath)
+	if metadataDBPath == "" {
+		var err error
+		metadataDBPath, err = paths.SnapshotMetadataDBPath()
+		if err != nil {
+			return nil, fmt.Errorf("resolve snapshot metadata database path: %w", err)
+		}
+	}
+	if err := os.MkdirAll(filepath.Dir(metadataDBPath), 0o755); err != nil {
+		return nil, fmt.Errorf("create snapshot metadata directory for %q: %w", metadataDBPath, err)
+	}
+
+	store := &Store{metadataDBPath: metadataDBPath}
+	if err := store.initDB(context.Background()); err != nil {
+		return nil, err
+	}
+	return store, nil
+}
+
+func (s *Store) Create(ctx context.Context, record Record) error {
+	if strings.TrimSpace(record.SnapshotID) == "" {
+		return fmt.Errorf("snapshot record missing snapshot id")
+	}
+	if strings.TrimSpace(record.SourceSandboxID) == "" {
+		return fmt.Errorf("snapshot record %q missing source sandbox id", record.SnapshotID)
+	}
+	if strings.TrimSpace(record.Backend) == "" {
+		return fmt.Errorf("snapshot record %q missing backend", record.SnapshotID)
+	}
+	if strings.TrimSpace(record.PolicyHash) == "" {
+		return fmt.Errorf("snapshot record %q missing policy hash", record.SnapshotID)
+	}
+	if record.Policy == nil {
+		return fmt.Errorf("snapshot record %q missing policy", record.SnapshotID)
+	}
+	if strings.TrimSpace(record.StorageRef) == "" {
+		return fmt.Errorf("snapshot record %q missing storage ref", record.SnapshotID)
+	}
+	if record.CreatedAt.IsZero() {
+		record.CreatedAt = time.Now().UTC()
+	}
+
+	policyBytes, err := proto.Marshal(record.Policy)
+	if err != nil {
+		return fmt.Errorf("marshal snapshot policy %q: %w", record.SnapshotID, err)
+	}
+
+	db, err := s.open(ctx)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO snapshots (
+			snapshot_id,
+			source_sandbox_id,
+			backend,
+			name,
+			policy_hash,
+			policy_proto,
+			storage_ref,
+			created_at_unix
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+	`,
+		record.SnapshotID,
+		record.SourceSandboxID,
+		record.Backend,
+		record.Name,
+		record.PolicyHash,
+		policyBytes,
+		record.StorageRef,
+		record.CreatedAt.UTC().Unix(),
+	); err != nil {
+		return fmt.Errorf("insert snapshot metadata %q: %w", record.SnapshotID, err)
+	}
+	return nil
+}
+
+func (s *Store) Get(ctx context.Context, snapshotID string) (Record, bool, error) {
+	db, err := s.open(ctx)
+	if err != nil {
+		return Record{}, false, err
+	}
+	defer db.Close()
+
+	row := db.QueryRowContext(ctx, `
+		SELECT
+			snapshot_id,
+			source_sandbox_id,
+			backend,
+			name,
+			policy_hash,
+			policy_proto,
+			storage_ref,
+			created_at_unix
+		FROM snapshots
+		WHERE snapshot_id = ?
+	`, strings.TrimSpace(snapshotID))
+
+	record, err := scanRecord(row)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return Record{}, false, nil
+		}
+		return Record{}, false, err
+	}
+	return record, true, nil
+}
+
+func (s *Store) List(ctx context.Context) ([]Record, error) {
+	db, err := s.open(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+
+	rows, err := db.QueryContext(ctx, `
+		SELECT
+			snapshot_id,
+			source_sandbox_id,
+			backend,
+			name,
+			policy_hash,
+			policy_proto,
+			storage_ref,
+			created_at_unix
+		FROM snapshots
+		ORDER BY created_at_unix ASC, snapshot_id ASC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("query snapshots: %w", err)
+	}
+	defer rows.Close()
+
+	items := make([]Record, 0)
+	for rows.Next() {
+		record, scanErr := scanRecord(rows)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		items = append(items, record)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate snapshots: %w", err)
+	}
+	return items, nil
+}
+
+func (s *Store) Delete(ctx context.Context, snapshotID string) error {
+	db, err := s.open(ctx)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	if _, err := db.ExecContext(ctx, `DELETE FROM snapshots WHERE snapshot_id = ?`, strings.TrimSpace(snapshotID)); err != nil {
+		return fmt.Errorf("delete snapshot metadata %q: %w", snapshotID, err)
+	}
+	return nil
+}
+
+func (s *Store) open(ctx context.Context) (*sql.DB, error) {
+	if err := s.initDB(ctx); err != nil {
+		return nil, err
+	}
+	db, err := sql.Open("sqlite", s.metadataDBPath)
+	if err != nil {
+		return nil, fmt.Errorf("open snapshot metadata database %q: %w", s.metadataDBPath, err)
+	}
+	return db, nil
+}
+
+func (s *Store) initDB(ctx context.Context) error {
+	db, err := sql.Open("sqlite", s.metadataDBPath)
+	if err != nil {
+		return fmt.Errorf("open snapshot metadata database %q: %w", s.metadataDBPath, err)
+	}
+	defer db.Close()
+
+	_, err = db.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS snapshots (
+			snapshot_id TEXT PRIMARY KEY,
+			source_sandbox_id TEXT NOT NULL,
+			backend TEXT NOT NULL,
+			name TEXT NOT NULL,
+			policy_hash TEXT NOT NULL,
+			policy_proto BLOB NOT NULL,
+			storage_ref TEXT NOT NULL,
+			created_at_unix INTEGER NOT NULL
+		);
+		CREATE INDEX IF NOT EXISTS idx_snapshots_created_at ON snapshots(created_at_unix);
+	`)
+	if err != nil {
+		return fmt.Errorf("initialise snapshot metadata schema: %w", err)
+	}
+	return nil
+}
+
+type recordScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanRecord(row recordScanner) (Record, error) {
+	var (
+		record      Record
+		policyBytes []byte
+		createdAt   int64
+	)
+	if err := row.Scan(
+		&record.SnapshotID,
+		&record.SourceSandboxID,
+		&record.Backend,
+		&record.Name,
+		&record.PolicyHash,
+		&policyBytes,
+		&record.StorageRef,
+		&createdAt,
+	); err != nil {
+		return Record{}, err
+	}
+
+	record.Policy = &cleanroomv1.Policy{}
+	if err := proto.Unmarshal(policyBytes, record.Policy); err != nil {
+		return Record{}, fmt.Errorf("decode snapshot policy %q: %w", record.SnapshotID, err)
+	}
+	record.CreatedAt = time.Unix(createdAt, 0).UTC()
+	return record, nil
+}

--- a/internal/snapshotstore/store_test.go
+++ b/internal/snapshotstore/store_test.go
@@ -1,0 +1,70 @@
+package snapshotstore
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+)
+
+func TestStoreCreateGetListDelete(t *testing.T) {
+	t.Parallel()
+
+	store, err := New(Options{MetadataDBPath: filepath.Join(t.TempDir(), "snapshots.db")})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	record := Record{
+		SnapshotID:      "snap-test",
+		SourceSandboxID: "cr-test",
+		Backend:         "firecracker",
+		Name:            "golden",
+		PolicyHash:      "policy-hash",
+		Policy: &cleanroomv1.Policy{
+			Version:        1,
+			ImageRef:       "ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			ImageDigest:    "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			NetworkDefault: "deny",
+			Hash:           "policy-hash",
+		},
+		StorageRef: "/tmp/snap-test.ext4",
+		CreatedAt:  time.Unix(1700000000, 0).UTC(),
+	}
+	if err := store.Create(context.Background(), record); err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+
+	got, ok, err := store.Get(context.Background(), "snap-test")
+	if err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected stored snapshot")
+	}
+	if got.SnapshotID != record.SnapshotID || got.PolicyHash != record.PolicyHash || got.StorageRef != record.StorageRef {
+		t.Fatalf("unexpected snapshot record: %#v", got)
+	}
+	if got.Policy == nil || got.Policy.GetImageRef() != record.Policy.GetImageRef() {
+		t.Fatalf("unexpected stored policy: %#v", got.Policy)
+	}
+
+	items, err := store.List(context.Background())
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if got, want := len(items), 1; got != want {
+		t.Fatalf("unexpected snapshot count: got %d want %d", got, want)
+	}
+
+	if err := store.Delete(context.Background(), "snap-test"); err != nil {
+		t.Fatalf("Delete returned error: %v", err)
+	}
+	if _, ok, err := store.Get(context.Background(), "snap-test"); err != nil {
+		t.Fatalf("Get after delete returned error: %v", err)
+	} else if ok {
+		t.Fatal("expected snapshot to be deleted")
+	}
+}

--- a/internal/volumestore/file.go
+++ b/internal/volumestore/file.go
@@ -71,6 +71,7 @@ func (d *FileDriver) SnapshotVolume(_ context.Context, req SnapshotVolumeRequest
 	}
 	if err := copyFile(volumeRef, target); err != nil {
 		_ = os.Remove(target)
+		_ = os.Remove(filepath.Dir(target))
 		return Snapshot{}, fmt.Errorf("copy snapshot volume %q: %w", volumeRef, err)
 	}
 	return Snapshot{Ref: target, StorageRef: target}, nil

--- a/internal/volumestore/file.go
+++ b/internal/volumestore/file.go
@@ -1,0 +1,147 @@
+package volumestore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type FileDriverOptions struct {
+	SnapshotBaseDir string
+	Namespace       string
+}
+
+type FileDriver struct {
+	snapshotBaseDir string
+	namespace       string
+}
+
+func NewFileDriver(opts FileDriverOptions) (*FileDriver, error) {
+	baseDir := strings.TrimSpace(opts.SnapshotBaseDir)
+	if baseDir == "" {
+		return nil, errors.New("file volume driver requires snapshot base dir")
+	}
+	namespace := strings.TrimSpace(opts.Namespace)
+	if namespace == "" {
+		return nil, errors.New("file volume driver requires namespace")
+	}
+	return &FileDriver{
+		snapshotBaseDir: filepath.Clean(baseDir),
+		namespace:       namespace,
+	}, nil
+}
+
+func (d *FileDriver) Name() string { return "file" }
+
+func (d *FileDriver) EnsureBaseVolume(_ context.Context, req EnsureBaseVolumeRequest) (BaseVolume, error) {
+	sourcePath := strings.TrimSpace(req.SourcePath)
+	if sourcePath == "" {
+		return BaseVolume{}, errors.New("file volume driver requires source path")
+	}
+	resolved, err := filepath.Abs(sourcePath)
+	if err != nil {
+		return BaseVolume{}, fmt.Errorf("resolve base volume source %q: %w", sourcePath, err)
+	}
+	if _, err := os.Stat(resolved); err != nil {
+		return BaseVolume{}, fmt.Errorf("inspect base volume source %q: %w", resolved, err)
+	}
+	return BaseVolume{Ref: resolved}, nil
+}
+
+func (d *FileDriver) CreateWritableVolume(_ context.Context, req CreateWritableVolumeRequest) (WritableVolume, error) {
+	return d.copyToWritable(req.BaseRef, req.AttachmentPath)
+}
+
+func (d *FileDriver) SnapshotVolume(_ context.Context, req SnapshotVolumeRequest) (Snapshot, error) {
+	volumeRef := strings.TrimSpace(req.VolumeRef)
+	if volumeRef == "" {
+		return Snapshot{}, errors.New("file volume driver requires volume ref")
+	}
+	snapshotID := strings.TrimSpace(req.SnapshotID)
+	if snapshotID == "" {
+		return Snapshot{}, errors.New("file volume driver requires snapshot id")
+	}
+	target := filepath.Join(d.snapshotBaseDir, d.namespace, snapshotID, "rootfs.ext4")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		return Snapshot{}, fmt.Errorf("create snapshot directory %q: %w", filepath.Dir(target), err)
+	}
+	if err := copyFile(volumeRef, target); err != nil {
+		_ = os.Remove(target)
+		return Snapshot{}, fmt.Errorf("copy snapshot volume %q: %w", volumeRef, err)
+	}
+	return Snapshot{Ref: target, StorageRef: target}, nil
+}
+
+func (d *FileDriver) CloneSnapshotToVolume(_ context.Context, req CloneSnapshotToVolumeRequest) (WritableVolume, error) {
+	return d.copyToWritable(req.SnapshotRef, req.AttachmentPath)
+}
+
+func (d *FileDriver) DestroyVolume(_ context.Context, req DestroyVolumeRequest) error {
+	volumeRef := strings.TrimSpace(req.VolumeRef)
+	if volumeRef == "" {
+		return nil
+	}
+	if err := os.Remove(volumeRef); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove volume %q: %w", volumeRef, err)
+	}
+	return nil
+}
+
+func (d *FileDriver) DestroySnapshot(_ context.Context, req DestroySnapshotRequest) error {
+	snapshotRef := strings.TrimSpace(req.SnapshotRef)
+	if snapshotRef == "" {
+		return nil
+	}
+	if err := os.Remove(snapshotRef); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove snapshot %q: %w", snapshotRef, err)
+	}
+	if dir := filepath.Dir(snapshotRef); dir != "" {
+		_ = os.Remove(dir)
+	}
+	return nil
+}
+
+func (d *FileDriver) copyToWritable(sourceRef, attachmentPath string) (WritableVolume, error) {
+	sourceRef = strings.TrimSpace(sourceRef)
+	if sourceRef == "" {
+		return WritableVolume{}, errors.New("file volume driver requires source ref")
+	}
+	attachmentPath = strings.TrimSpace(attachmentPath)
+	if attachmentPath == "" {
+		return WritableVolume{}, errors.New("file volume driver requires attachment path")
+	}
+	if err := os.MkdirAll(filepath.Dir(attachmentPath), 0o755); err != nil {
+		return WritableVolume{}, fmt.Errorf("create writable volume directory %q: %w", filepath.Dir(attachmentPath), err)
+	}
+	if err := copyFile(sourceRef, attachmentPath); err != nil {
+		return WritableVolume{}, fmt.Errorf("copy writable volume from %q: %w", sourceRef, err)
+	}
+	return WritableVolume{
+		Ref:            attachmentPath,
+		AttachmentPath: attachmentPath,
+	}, nil
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	if err := out.Chmod(0o644); err != nil {
+		return err
+	}
+	return out.Sync()
+}

--- a/internal/volumestore/file_test.go
+++ b/internal/volumestore/file_test.go
@@ -1,0 +1,107 @@
+package volumestore
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFileDriverWritableVolumeLifecycle(t *testing.T) {
+	driver, err := NewFileDriver(FileDriverOptions{
+		SnapshotBaseDir: t.TempDir(),
+		Namespace:       "firecracker",
+	})
+	if err != nil {
+		t.Fatalf("NewFileDriver returned error: %v", err)
+	}
+
+	sourcePath := filepath.Join(t.TempDir(), "prepared.ext4")
+	if err := os.WriteFile(sourcePath, []byte("base-bytes"), 0o644); err != nil {
+		t.Fatalf("write source volume: %v", err)
+	}
+
+	base, err := driver.EnsureBaseVolume(context.Background(), EnsureBaseVolumeRequest{
+		BaseID:     "runtime-key",
+		SourcePath: sourcePath,
+	})
+	if err != nil {
+		t.Fatalf("EnsureBaseVolume returned error: %v", err)
+	}
+
+	volume, err := driver.CreateWritableVolume(context.Background(), CreateWritableVolumeRequest{
+		VolumeID:       "sandbox-1",
+		BaseRef:        base.Ref,
+		AttachmentPath: filepath.Join(t.TempDir(), "sandbox-1.ext4"),
+	})
+	if err != nil {
+		t.Fatalf("CreateWritableVolume returned error: %v", err)
+	}
+	if got, want := volume.AttachmentPath, volume.Ref; got != want {
+		t.Fatalf("unexpected writable attachment path: got %q want %q", got, want)
+	}
+	data, err := os.ReadFile(volume.AttachmentPath)
+	if err != nil {
+		t.Fatalf("read writable volume: %v", err)
+	}
+	if got, want := string(data), "base-bytes"; got != want {
+		t.Fatalf("unexpected writable volume contents: got %q want %q", got, want)
+	}
+
+	if err := driver.DestroyVolume(context.Background(), DestroyVolumeRequest{VolumeRef: volume.Ref}); err != nil {
+		t.Fatalf("DestroyVolume returned error: %v", err)
+	}
+	if _, err := os.Stat(volume.Ref); !os.IsNotExist(err) {
+		t.Fatalf("expected writable volume to be removed, got %v", err)
+	}
+}
+
+func TestFileDriverSnapshotLifecycle(t *testing.T) {
+	snapshotBaseDir := t.TempDir()
+	driver, err := NewFileDriver(FileDriverOptions{
+		SnapshotBaseDir: snapshotBaseDir,
+		Namespace:       "firecracker",
+	})
+	if err != nil {
+		t.Fatalf("NewFileDriver returned error: %v", err)
+	}
+
+	volumePath := filepath.Join(t.TempDir(), "sandbox.ext4")
+	if err := os.WriteFile(volumePath, []byte("snapshot-bytes"), 0o644); err != nil {
+		t.Fatalf("write volume: %v", err)
+	}
+
+	snapshot, err := driver.SnapshotVolume(context.Background(), SnapshotVolumeRequest{
+		SnapshotID: "snap-1",
+		VolumeRef:  volumePath,
+	})
+	if err != nil {
+		t.Fatalf("SnapshotVolume returned error: %v", err)
+	}
+	if got, want := snapshot.StorageRef, filepath.Join(snapshotBaseDir, "firecracker", "snap-1", "rootfs.ext4"); got != want {
+		t.Fatalf("unexpected snapshot storage ref: got %q want %q", got, want)
+	}
+
+	clone, err := driver.CloneSnapshotToVolume(context.Background(), CloneSnapshotToVolumeRequest{
+		VolumeID:       "sandbox-2",
+		SnapshotRef:    snapshot.Ref,
+		AttachmentPath: filepath.Join(t.TempDir(), "sandbox-2.ext4"),
+	})
+	if err != nil {
+		t.Fatalf("CloneSnapshotToVolume returned error: %v", err)
+	}
+	data, err := os.ReadFile(clone.AttachmentPath)
+	if err != nil {
+		t.Fatalf("read cloned volume: %v", err)
+	}
+	if got, want := string(data), "snapshot-bytes"; got != want {
+		t.Fatalf("unexpected cloned volume contents: got %q want %q", got, want)
+	}
+
+	if err := driver.DestroySnapshot(context.Background(), DestroySnapshotRequest{SnapshotRef: snapshot.Ref}); err != nil {
+		t.Fatalf("DestroySnapshot returned error: %v", err)
+	}
+	if _, err := os.Stat(snapshot.Ref); !os.IsNotExist(err) {
+		t.Fatalf("expected snapshot to be removed, got %v", err)
+	}
+}

--- a/internal/volumestore/store.go
+++ b/internal/volumestore/store.go
@@ -1,0 +1,57 @@
+package volumestore
+
+import "context"
+
+type Driver interface {
+	Name() string
+	EnsureBaseVolume(context.Context, EnsureBaseVolumeRequest) (BaseVolume, error)
+	CreateWritableVolume(context.Context, CreateWritableVolumeRequest) (WritableVolume, error)
+	SnapshotVolume(context.Context, SnapshotVolumeRequest) (Snapshot, error)
+	CloneSnapshotToVolume(context.Context, CloneSnapshotToVolumeRequest) (WritableVolume, error)
+	DestroyVolume(context.Context, DestroyVolumeRequest) error
+	DestroySnapshot(context.Context, DestroySnapshotRequest) error
+}
+
+type EnsureBaseVolumeRequest struct {
+	BaseID     string
+	SourcePath string
+}
+
+type BaseVolume struct {
+	Ref string
+}
+
+type CreateWritableVolumeRequest struct {
+	VolumeID       string
+	BaseRef        string
+	AttachmentPath string
+}
+
+type CloneSnapshotToVolumeRequest struct {
+	VolumeID       string
+	SnapshotRef    string
+	AttachmentPath string
+}
+
+type WritableVolume struct {
+	Ref            string
+	AttachmentPath string
+}
+
+type SnapshotVolumeRequest struct {
+	SnapshotID string
+	VolumeRef  string
+}
+
+type Snapshot struct {
+	Ref        string
+	StorageRef string
+}
+
+type DestroyVolumeRequest struct {
+	VolumeRef string
+}
+
+type DestroySnapshotRequest struct {
+	SnapshotRef string
+}

--- a/internal/volumestore/zfs.go
+++ b/internal/volumestore/zfs.go
@@ -1,0 +1,247 @@
+package volumestore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+const zfsBaseSnapshotName = "seed"
+
+type ZFSCommandRunner interface {
+	Run(ctx context.Context, command string, args ...string) error
+	Output(ctx context.Context, command string, args ...string) ([]byte, error)
+}
+
+type ZFSDriverOptions struct {
+	DatasetRoot string
+	Runner      ZFSCommandRunner
+	Stat        func(string) (os.FileInfo, error)
+}
+
+type ZFSDriver struct {
+	datasetRoot string
+	runner      ZFSCommandRunner
+	stat        func(string) (os.FileInfo, error)
+}
+
+func NewZFSDriver(opts ZFSDriverOptions) (*ZFSDriver, error) {
+	datasetRoot := strings.Trim(strings.TrimSpace(opts.DatasetRoot), "/")
+	if datasetRoot == "" {
+		return nil, errors.New("zfs volume driver requires dataset root")
+	}
+	if opts.Runner == nil {
+		return nil, errors.New("zfs volume driver requires command runner")
+	}
+	statFn := opts.Stat
+	if statFn == nil {
+		statFn = os.Stat
+	}
+	return &ZFSDriver{
+		datasetRoot: datasetRoot,
+		runner:      opts.Runner,
+		stat:        statFn,
+	}, nil
+}
+
+func (d *ZFSDriver) Name() string { return "zfs" }
+
+func (d *ZFSDriver) EnsureBaseVolume(ctx context.Context, req EnsureBaseVolumeRequest) (BaseVolume, error) {
+	sourcePath := strings.TrimSpace(req.SourcePath)
+	if sourcePath == "" {
+		return BaseVolume{}, errors.New("zfs volume driver requires source path")
+	}
+	info, err := d.stat(sourcePath)
+	if err != nil {
+		return BaseVolume{}, fmt.Errorf("inspect base volume source %q: %w", sourcePath, err)
+	}
+	if info.Size() <= 0 {
+		return BaseVolume{}, fmt.Errorf("inspect base volume source %q: empty file", sourcePath)
+	}
+
+	baseDataset := d.datasetPath("base", sanitizeZFSDatasetComponent(req.BaseID))
+	baseSnapshot := d.snapshotRef(baseDataset, zfsBaseSnapshotName)
+
+	baseExists, err := d.refExists(ctx, baseDataset)
+	if err != nil {
+		return BaseVolume{}, err
+	}
+	if !baseExists {
+		if err := d.runner.Run(ctx, "zfs", "create", "-p", "-V", strconv.FormatInt(info.Size(), 10), baseDataset); err != nil {
+			return BaseVolume{}, fmt.Errorf("create zfs base volume %q: %w", baseDataset, err)
+		}
+		if err := d.runner.Run(ctx, "dd", "if="+sourcePath, "of="+zvolDevicePath(baseDataset), "bs=4M", "conv=fsync", "status=none"); err != nil {
+			_ = d.runner.Run(context.Background(), "zfs", "destroy", "-r", baseDataset)
+			return BaseVolume{}, fmt.Errorf("seed zfs base volume %q: %w", baseDataset, err)
+		}
+	}
+
+	snapshotExists, err := d.refExists(ctx, baseSnapshot)
+	if err != nil {
+		return BaseVolume{}, err
+	}
+	if !snapshotExists {
+		if err := d.runner.Run(ctx, "zfs", "snapshot", baseSnapshot); err != nil {
+			return BaseVolume{}, fmt.Errorf("create zfs base snapshot %q: %w", baseSnapshot, err)
+		}
+	}
+	return BaseVolume{Ref: baseSnapshot}, nil
+}
+
+func (d *ZFSDriver) CreateWritableVolume(ctx context.Context, req CreateWritableVolumeRequest) (WritableVolume, error) {
+	baseRef := strings.TrimSpace(req.BaseRef)
+	if baseRef == "" {
+		return WritableVolume{}, errors.New("zfs volume driver requires base ref")
+	}
+	if !strings.Contains(baseRef, "@") {
+		return WritableVolume{}, fmt.Errorf("zfs base ref %q must be a snapshot", baseRef)
+	}
+	dataset := d.datasetPath("sandboxes", sanitizeZFSDatasetComponent(req.VolumeID))
+	return d.cloneSnapshot(ctx, baseRef, dataset)
+}
+
+func (d *ZFSDriver) SnapshotVolume(ctx context.Context, req SnapshotVolumeRequest) (Snapshot, error) {
+	volumeRef := strings.TrimSpace(req.VolumeRef)
+	if volumeRef == "" {
+		return Snapshot{}, errors.New("zfs volume driver requires volume ref")
+	}
+	snapshotID := sanitizeZFSDatasetComponent(req.SnapshotID)
+	if snapshotID == "" {
+		return Snapshot{}, errors.New("zfs volume driver requires snapshot id")
+	}
+	snapshotRef := d.snapshotRef(volumeRef, "snap-"+snapshotID)
+	if err := d.runner.Run(ctx, "zfs", "snapshot", snapshotRef); err != nil {
+		return Snapshot{}, fmt.Errorf("create zfs snapshot %q: %w", snapshotRef, err)
+	}
+	return Snapshot{Ref: snapshotRef, StorageRef: snapshotRef}, nil
+}
+
+func (d *ZFSDriver) CloneSnapshotToVolume(ctx context.Context, req CloneSnapshotToVolumeRequest) (WritableVolume, error) {
+	snapshotRef := strings.TrimSpace(req.SnapshotRef)
+	if snapshotRef == "" {
+		return WritableVolume{}, errors.New("zfs volume driver requires snapshot ref")
+	}
+	if !strings.Contains(snapshotRef, "@") {
+		return WritableVolume{}, fmt.Errorf("zfs snapshot ref %q must be a snapshot", snapshotRef)
+	}
+	dataset := d.datasetPath("sandboxes", sanitizeZFSDatasetComponent(req.VolumeID))
+	return d.cloneSnapshot(ctx, snapshotRef, dataset)
+}
+
+func (d *ZFSDriver) DestroyVolume(ctx context.Context, req DestroyVolumeRequest) error {
+	volumeRef := strings.TrimSpace(req.VolumeRef)
+	if volumeRef == "" {
+		return nil
+	}
+	if err := d.runner.Run(ctx, "zfs", "destroy", "-r", volumeRef); err != nil {
+		if isZFSMissingError(err) {
+			return nil
+		}
+		return fmt.Errorf("destroy zfs volume %q: %w", volumeRef, err)
+	}
+	return nil
+}
+
+func (d *ZFSDriver) DestroySnapshot(ctx context.Context, req DestroySnapshotRequest) error {
+	snapshotRef := strings.TrimSpace(req.SnapshotRef)
+	if snapshotRef == "" {
+		return nil
+	}
+	if err := d.runner.Run(ctx, "zfs", "destroy", snapshotRef); err != nil {
+		if isZFSMissingError(err) {
+			return nil
+		}
+		return fmt.Errorf("destroy zfs snapshot %q: %w", snapshotRef, err)
+	}
+	return nil
+}
+
+func (d *ZFSDriver) datasetPath(parts ...string) string {
+	items := []string{d.datasetRoot}
+	for _, part := range parts {
+		part = strings.Trim(strings.TrimSpace(part), "/")
+		if part == "" {
+			continue
+		}
+		items = append(items, part)
+	}
+	return strings.Join(items, "/")
+}
+
+func (d *ZFSDriver) snapshotRef(dataset, snapshotName string) string {
+	return dataset + "@" + sanitizeZFSDatasetComponent(snapshotName)
+}
+
+func (d *ZFSDriver) cloneSnapshot(ctx context.Context, snapshotRef, dataset string) (WritableVolume, error) {
+	exists, err := d.refExists(ctx, dataset)
+	if err != nil {
+		return WritableVolume{}, err
+	}
+	if exists {
+		return WritableVolume{}, fmt.Errorf("zfs dataset %q already exists", dataset)
+	}
+	if err := d.runner.Run(ctx, "zfs", "clone", "-p", snapshotRef, dataset); err != nil {
+		return WritableVolume{}, fmt.Errorf("clone zfs snapshot %q into %q: %w", snapshotRef, dataset, err)
+	}
+	return WritableVolume{
+		Ref:            dataset,
+		AttachmentPath: zvolDevicePath(dataset),
+	}, nil
+}
+
+func (d *ZFSDriver) refExists(ctx context.Context, ref string) (bool, error) {
+	out, err := d.runner.Output(ctx, "zfs", "list", "-H", "-o", "name", ref)
+	if err != nil {
+		if isZFSMissingError(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("inspect zfs ref %q: %w", ref, err)
+	}
+	return strings.TrimSpace(string(out)) != "", nil
+}
+
+func sanitizeZFSDatasetComponent(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.Grow(len(value))
+	lastDash := false
+	for _, r := range value {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '-' || r == '.' || r == ':' {
+			b.WriteRune(r)
+			lastDash = false
+			continue
+		}
+		if !lastDash {
+			b.WriteByte('-')
+			lastDash = true
+		}
+	}
+	out := strings.Trim(b.String(), "-")
+	if out == "" {
+		return "cleanroom"
+	}
+	return out
+}
+
+func zvolDevicePath(dataset string) string {
+	return filepath.Join(append([]string{"/dev/zvol"}, strings.Split(strings.TrimSpace(dataset), "/")...)...)
+}
+
+func isZFSMissingError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "dataset does not exist") ||
+		strings.Contains(msg, "no such pool or dataset") ||
+		strings.Contains(msg, "snapshot does not exist") ||
+		strings.Contains(msg, "could not find any snapshots to destroy")
+}

--- a/internal/volumestore/zfs.go
+++ b/internal/volumestore/zfs.go
@@ -8,8 +8,12 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 	"unicode"
 )
+
+const zvolDeviceWaitTimeout = 10 * time.Second
+const zvolDeviceWaitInterval = 50 * time.Millisecond
 
 const zfsBaseSnapshotName = "seed"
 
@@ -74,6 +78,10 @@ func (d *ZFSDriver) EnsureBaseVolume(ctx context.Context, req EnsureBaseVolumeRe
 	if !baseExists {
 		if err := d.runner.Run(ctx, "zfs", "create", "-p", "-V", strconv.FormatInt(info.Size(), 10), baseDataset); err != nil {
 			return BaseVolume{}, fmt.Errorf("create zfs base volume %q: %w", baseDataset, err)
+		}
+		if err := d.waitForZvolDevice(ctx, baseDataset); err != nil {
+			_ = d.runner.Run(context.Background(), "zfs", "destroy", "-r", baseDataset)
+			return BaseVolume{}, fmt.Errorf("wait for zfs base volume device %q: %w", baseDataset, err)
 		}
 		if err := d.runner.Run(ctx, "dd", "if="+sourcePath, "of="+zvolDevicePath(baseDataset), "bs=4M", "conv=fsync", "status=none"); err != nil {
 			_ = d.runner.Run(context.Background(), "zfs", "destroy", "-r", baseDataset)
@@ -188,6 +196,10 @@ func (d *ZFSDriver) cloneSnapshot(ctx context.Context, snapshotRef, dataset stri
 	if err := d.runner.Run(ctx, "zfs", "clone", "-p", snapshotRef, dataset); err != nil {
 		return WritableVolume{}, fmt.Errorf("clone zfs snapshot %q into %q: %w", snapshotRef, dataset, err)
 	}
+	if err := d.waitForZvolDevice(ctx, dataset); err != nil {
+		_ = d.runner.Run(context.Background(), "zfs", "destroy", "-r", dataset)
+		return WritableVolume{}, fmt.Errorf("wait for cloned zvol device %q: %w", dataset, err)
+	}
 	return WritableVolume{
 		Ref:            dataset,
 		AttachmentPath: zvolDevicePath(dataset),
@@ -233,6 +245,23 @@ func sanitizeZFSDatasetComponent(value string) string {
 
 func zvolDevicePath(dataset string) string {
 	return filepath.Join(append([]string{"/dev/zvol"}, strings.Split(strings.TrimSpace(dataset), "/")...)...)
+}
+
+func (d *ZFSDriver) waitForZvolDevice(ctx context.Context, dataset string) error {
+	devicePath := zvolDevicePath(dataset)
+	deadline := time.Now().Add(zvolDeviceWaitTimeout)
+	for {
+		if _, err := d.stat(devicePath); err == nil {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out waiting for zvol device %q", devicePath)
+		}
+		if ctx.Err() != nil {
+			return fmt.Errorf("context canceled waiting for zvol device %q: %w", devicePath, ctx.Err())
+		}
+		time.Sleep(zvolDeviceWaitInterval)
+	}
 }
 
 func isZFSMissingError(err error) bool {

--- a/internal/volumestore/zfs_integration_test.go
+++ b/internal/volumestore/zfs_integration_test.go
@@ -1,0 +1,257 @@
+package volumestore
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// realZFSRunner executes ZFS commands via sudo for integration testing.
+type realZFSRunner struct{}
+
+func (r realZFSRunner) Run(ctx context.Context, command string, args ...string) error {
+	cmd := exec.CommandContext(ctx, "sudo", append([]string{"-n", command}, args...)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s %s: %w (%s)", command, strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+func (r realZFSRunner) Output(ctx context.Context, command string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "sudo", append([]string{"-n", command}, args...)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("%s %s: %w (%s)", command, strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+	return out, nil
+}
+
+func skipUnlessZFS(t *testing.T) string {
+	t.Helper()
+	if os.Getenv("CLEANROOM_ZFS_TEST_DATASET") == "" {
+		t.Skip("set CLEANROOM_ZFS_TEST_DATASET to a writable ZFS dataset to run ZFS integration tests")
+	}
+	dataset := os.Getenv("CLEANROOM_ZFS_TEST_DATASET")
+	// Verify the dataset is accessible.
+	out, err := exec.Command("sudo", "-n", "zfs", "list", "-H", "-o", "name", dataset).CombinedOutput()
+	if err != nil {
+		t.Skipf("ZFS dataset %q not accessible: %s", dataset, strings.TrimSpace(string(out)))
+	}
+	if strings.TrimSpace(string(out)) != dataset {
+		t.Skipf("ZFS dataset probe returned %q, expected %q", strings.TrimSpace(string(out)), dataset)
+	}
+	return dataset
+}
+
+func TestZFSIntegrationFullLifecycle(t *testing.T) {
+	dataset := skipUnlessZFS(t)
+
+	// Use a sub-dataset unique to this test run to avoid collisions.
+	testDataset := dataset + "/itest-lifecycle"
+	runner := realZFSRunner{}
+
+	// Clean up the test sub-dataset at the end.
+	t.Cleanup(func() {
+		_ = runner.Run(context.Background(), "zfs", "destroy", "-r", testDataset)
+	})
+
+	driver, err := NewZFSDriver(ZFSDriverOptions{
+		DatasetRoot: testDataset,
+		Runner:      runner,
+	})
+	if err != nil {
+		t.Fatalf("NewZFSDriver: %v", err)
+	}
+
+	// Create a small ext4-ish source file (just raw bytes for the test).
+	sourceDir := t.TempDir()
+	sourcePath := sourceDir + "/test.ext4"
+	// Write 8 MiB so the zvol has room.
+	data := make([]byte, 8*1024*1024)
+	copy(data, []byte("cleanroom-zfs-integration-test-marker"))
+	if err := os.WriteFile(sourcePath, data, 0o644); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+
+	// 1. EnsureBaseVolume: creates zvol + seed snapshot
+	base, err := driver.EnsureBaseVolume(context.Background(), EnsureBaseVolumeRequest{
+		BaseID:     "test-base",
+		SourcePath: sourcePath,
+	})
+	if err != nil {
+		t.Fatalf("EnsureBaseVolume: %v", err)
+	}
+	t.Logf("base ref: %s", base.Ref)
+	if !strings.Contains(base.Ref, "@seed") {
+		t.Fatalf("expected base ref to contain @seed, got %q", base.Ref)
+	}
+
+	// Calling again should be idempotent.
+	base2, err := driver.EnsureBaseVolume(context.Background(), EnsureBaseVolumeRequest{
+		BaseID:     "test-base",
+		SourcePath: sourcePath,
+	})
+	if err != nil {
+		t.Fatalf("EnsureBaseVolume (idempotent): %v", err)
+	}
+	if base.Ref != base2.Ref {
+		t.Fatalf("idempotent call changed ref: %q vs %q", base.Ref, base2.Ref)
+	}
+
+	// 2. CreateWritableVolume: clone from base
+	writable, err := driver.CreateWritableVolume(context.Background(), CreateWritableVolumeRequest{
+		VolumeID: "sandbox-1",
+		BaseRef:  base.Ref,
+	})
+	if err != nil {
+		t.Fatalf("CreateWritableVolume: %v", err)
+	}
+	t.Logf("writable ref: %s, attachment: %s", writable.Ref, writable.AttachmentPath)
+	if !strings.Contains(writable.AttachmentPath, "/dev/zvol/") {
+		t.Fatalf("expected attachment path under /dev/zvol, got %q", writable.AttachmentPath)
+	}
+
+	// The driver waits for the device, so it should be present.
+	if _, err := os.Stat(writable.AttachmentPath); err != nil {
+		t.Fatalf("zvol device %q not available after create: %v", writable.AttachmentPath, err)
+	}
+
+	// Verify the seeded data is readable through the zvol device via sudo.
+	marker := "cleanroom-zfs-integration-test-marker"
+	out, err := exec.Command("sudo", "-n", "head", "-c", fmt.Sprintf("%d", len(marker)), writable.AttachmentPath).Output()
+	if err != nil {
+		t.Fatalf("read zvol device via sudo: %v", err)
+	}
+	if string(out) != marker {
+		t.Fatalf("unexpected zvol data: got %q", string(out))
+	}
+
+	// 3. SnapshotVolume: snapshot the writable volume
+	snapshot, err := driver.SnapshotVolume(context.Background(), SnapshotVolumeRequest{
+		SnapshotID: "golden",
+		VolumeRef:  writable.Ref,
+	})
+	if err != nil {
+		t.Fatalf("SnapshotVolume: %v", err)
+	}
+	t.Logf("snapshot ref: %s", snapshot.Ref)
+	if !strings.Contains(snapshot.Ref, "@snap-golden") {
+		t.Fatalf("expected snapshot ref to contain @snap-golden, got %q", snapshot.Ref)
+	}
+
+	// 4. CloneSnapshotToVolume: fork from the snapshot
+	fork, err := driver.CloneSnapshotToVolume(context.Background(), CloneSnapshotToVolumeRequest{
+		VolumeID:    "sandbox-2",
+		SnapshotRef: snapshot.Ref,
+	})
+	if err != nil {
+		t.Fatalf("CloneSnapshotToVolume: %v", err)
+	}
+	t.Logf("fork ref: %s, attachment: %s", fork.Ref, fork.AttachmentPath)
+
+	// 5. Destroy the fork volume
+	if err := driver.DestroyVolume(context.Background(), DestroyVolumeRequest{VolumeRef: fork.Ref}); err != nil {
+		t.Fatalf("DestroyVolume (fork): %v", err)
+	}
+
+	// 6. Destroy the snapshot
+	if err := driver.DestroySnapshot(context.Background(), DestroySnapshotRequest{SnapshotRef: snapshot.Ref}); err != nil {
+		t.Fatalf("DestroySnapshot: %v", err)
+	}
+
+	// 7. Destroy the original writable volume
+	if err := driver.DestroyVolume(context.Background(), DestroyVolumeRequest{VolumeRef: writable.Ref}); err != nil {
+		t.Fatalf("DestroyVolume (writable): %v", err)
+	}
+
+	// Verify idempotent destroy doesn't error.
+	if err := driver.DestroyVolume(context.Background(), DestroyVolumeRequest{VolumeRef: writable.Ref}); err != nil {
+		t.Fatalf("DestroyVolume (idempotent): %v", err)
+	}
+}
+
+func TestZFSIntegrationSnapshotLineage(t *testing.T) {
+	dataset := skipUnlessZFS(t)
+
+	testDataset := dataset + "/itest-lineage"
+	runner := realZFSRunner{}
+	t.Cleanup(func() {
+		_ = runner.Run(context.Background(), "zfs", "destroy", "-r", testDataset)
+	})
+
+	driver, err := NewZFSDriver(ZFSDriverOptions{
+		DatasetRoot: testDataset,
+		Runner:      runner,
+	})
+	if err != nil {
+		t.Fatalf("NewZFSDriver: %v", err)
+	}
+
+	sourceDir := t.TempDir()
+	sourcePath := sourceDir + "/test.ext4"
+	data := make([]byte, 8*1024*1024)
+	copy(data, []byte("lineage-test"))
+	if err := os.WriteFile(sourcePath, data, 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	base, err := driver.EnsureBaseVolume(context.Background(), EnsureBaseVolumeRequest{
+		BaseID:     "lineage-base",
+		SourcePath: sourcePath,
+	})
+	if err != nil {
+		t.Fatalf("EnsureBaseVolume: %v", err)
+	}
+
+	// Create sandbox-1, snapshot it, fork to sandbox-2, snapshot sandbox-2.
+	sb1, err := driver.CreateWritableVolume(context.Background(), CreateWritableVolumeRequest{
+		VolumeID: "sb-lineage-1",
+		BaseRef:  base.Ref,
+	})
+	if err != nil {
+		t.Fatalf("CreateWritableVolume sb1: %v", err)
+	}
+
+	snap1, err := driver.SnapshotVolume(context.Background(), SnapshotVolumeRequest{
+		SnapshotID: "snap1",
+		VolumeRef:  sb1.Ref,
+	})
+	if err != nil {
+		t.Fatalf("SnapshotVolume snap1: %v", err)
+	}
+
+	sb2, err := driver.CloneSnapshotToVolume(context.Background(), CloneSnapshotToVolumeRequest{
+		VolumeID:    "sb-lineage-2",
+		SnapshotRef: snap1.Ref,
+	})
+	if err != nil {
+		t.Fatalf("CloneSnapshotToVolume sb2: %v", err)
+	}
+
+	snap2, err := driver.SnapshotVolume(context.Background(), SnapshotVolumeRequest{
+		SnapshotID: "snap2",
+		VolumeRef:  sb2.Ref,
+	})
+	if err != nil {
+		t.Fatalf("SnapshotVolume snap2 (from forked sandbox): %v", err)
+	}
+	t.Logf("lineage: base=%s -> sb1=%s -> snap1=%s -> sb2=%s -> snap2=%s", base.Ref, sb1.Ref, snap1.Ref, sb2.Ref, snap2.Ref)
+
+	// Clean up in reverse dependency order.
+	if err := driver.DestroySnapshot(context.Background(), DestroySnapshotRequest{SnapshotRef: snap2.Ref}); err != nil {
+		t.Fatalf("DestroySnapshot snap2: %v", err)
+	}
+	if err := driver.DestroyVolume(context.Background(), DestroyVolumeRequest{VolumeRef: sb2.Ref}); err != nil {
+		t.Fatalf("DestroyVolume sb2: %v", err)
+	}
+	if err := driver.DestroySnapshot(context.Background(), DestroySnapshotRequest{SnapshotRef: snap1.Ref}); err != nil {
+		t.Fatalf("DestroySnapshot snap1: %v", err)
+	}
+	if err := driver.DestroyVolume(context.Background(), DestroyVolumeRequest{VolumeRef: sb1.Ref}); err != nil {
+		t.Fatalf("DestroyVolume sb1: %v", err)
+	}
+}

--- a/internal/volumestore/zfs_test.go
+++ b/internal/volumestore/zfs_test.go
@@ -1,0 +1,170 @@
+package volumestore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type zfsTestRunner struct {
+	commands []string
+	exists   map[string]bool
+}
+
+func (r *zfsTestRunner) Run(_ context.Context, command string, args ...string) error {
+	r.commands = append(r.commands, strings.Join(append([]string{command}, args...), " "))
+	if command != "zfs" || len(args) == 0 {
+		return nil
+	}
+	switch args[0] {
+	case "create":
+		if len(args) == 5 {
+			r.exists[args[4]] = true
+		}
+	case "snapshot":
+		if len(args) == 2 {
+			r.exists[args[1]] = true
+		}
+	case "clone":
+		if len(args) == 4 {
+			r.exists[args[3]] = true
+		}
+	case "destroy":
+		if len(args) >= 2 {
+			delete(r.exists, args[len(args)-1])
+		}
+	}
+	return nil
+}
+
+func (r *zfsTestRunner) Output(_ context.Context, command string, args ...string) ([]byte, error) {
+	r.commands = append(r.commands, strings.Join(append([]string{command}, args...), " "))
+	if command == "zfs" && len(args) == 5 && args[0] == "list" {
+		ref := args[4]
+		if r.exists[ref] {
+			return []byte(ref + "\n"), nil
+		}
+		return nil, errors.New("cannot open dataset: dataset does not exist")
+	}
+	return nil, fmt.Errorf("unsupported output command: %s %s", command, strings.Join(args, " "))
+}
+
+func TestZFSDriverEnsureBaseVolumeAndCloneLifecycle(t *testing.T) {
+	sourcePath := filepath.Join(t.TempDir(), "prepared.ext4")
+	if err := os.WriteFile(sourcePath, []byte("base-bytes"), 0o644); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+
+	runner := &zfsTestRunner{exists: map[string]bool{}}
+	driver, err := NewZFSDriver(ZFSDriverOptions{
+		DatasetRoot: "tank/cleanroom",
+		Runner:      runner,
+	})
+	if err != nil {
+		t.Fatalf("NewZFSDriver returned error: %v", err)
+	}
+
+	base, err := driver.EnsureBaseVolume(context.Background(), EnsureBaseVolumeRequest{
+		BaseID:     "runtime-key",
+		SourcePath: sourcePath,
+	})
+	if err != nil {
+		t.Fatalf("EnsureBaseVolume returned error: %v", err)
+	}
+	if got, want := base.Ref, "tank/cleanroom/base/runtime-key@seed"; got != want {
+		t.Fatalf("unexpected base ref: got %q want %q", got, want)
+	}
+
+	volume, err := driver.CreateWritableVolume(context.Background(), CreateWritableVolumeRequest{
+		VolumeID: "sandbox-1",
+		BaseRef:  base.Ref,
+	})
+	if err != nil {
+		t.Fatalf("CreateWritableVolume returned error: %v", err)
+	}
+	if got, want := volume.Ref, "tank/cleanroom/sandboxes/sandbox-1"; got != want {
+		t.Fatalf("unexpected volume ref: got %q want %q", got, want)
+	}
+	if got, want := volume.AttachmentPath, "/dev/zvol/tank/cleanroom/sandboxes/sandbox-1"; got != want {
+		t.Fatalf("unexpected attachment path: got %q want %q", got, want)
+	}
+
+	wantCommands := []string{
+		"zfs list -H -o name tank/cleanroom/base/runtime-key",
+		"zfs create -p -V 10 tank/cleanroom/base/runtime-key",
+		"dd if=" + sourcePath + " of=/dev/zvol/tank/cleanroom/base/runtime-key bs=4M conv=fsync status=none",
+		"zfs list -H -o name tank/cleanroom/base/runtime-key@seed",
+		"zfs snapshot tank/cleanroom/base/runtime-key@seed",
+		"zfs list -H -o name tank/cleanroom/sandboxes/sandbox-1",
+		"zfs clone -p tank/cleanroom/base/runtime-key@seed tank/cleanroom/sandboxes/sandbox-1",
+	}
+	if got, want := runner.commands, wantCommands; strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("unexpected zfs commands:\n got: %v\nwant: %v", got, want)
+	}
+}
+
+func TestZFSDriverSnapshotCloneAndDestroy(t *testing.T) {
+	runner := &zfsTestRunner{
+		exists: map[string]bool{
+			"tank/cleanroom/sandboxes/sandbox-1": true,
+		},
+	}
+	driver, err := NewZFSDriver(ZFSDriverOptions{
+		DatasetRoot: "tank/cleanroom",
+		Runner:      runner,
+	})
+	if err != nil {
+		t.Fatalf("NewZFSDriver returned error: %v", err)
+	}
+
+	snapshot, err := driver.SnapshotVolume(context.Background(), SnapshotVolumeRequest{
+		SnapshotID: "golden",
+		VolumeRef:  "tank/cleanroom/sandboxes/sandbox-1",
+	})
+	if err != nil {
+		t.Fatalf("SnapshotVolume returned error: %v", err)
+	}
+	if got, want := snapshot.Ref, "tank/cleanroom/sandboxes/sandbox-1@snap-golden"; got != want {
+		t.Fatalf("unexpected snapshot ref: got %q want %q", got, want)
+	}
+
+	clone, err := driver.CloneSnapshotToVolume(context.Background(), CloneSnapshotToVolumeRequest{
+		VolumeID:    "sandbox-2",
+		SnapshotRef: snapshot.Ref,
+	})
+	if err != nil {
+		t.Fatalf("CloneSnapshotToVolume returned error: %v", err)
+	}
+	if got, want := clone.Ref, "tank/cleanroom/sandboxes/sandbox-2"; got != want {
+		t.Fatalf("unexpected cloned volume ref: got %q want %q", got, want)
+	}
+
+	if err := driver.DestroySnapshot(context.Background(), DestroySnapshotRequest{SnapshotRef: snapshot.Ref}); err != nil {
+		t.Fatalf("DestroySnapshot returned error: %v", err)
+	}
+	if err := driver.DestroyVolume(context.Background(), DestroyVolumeRequest{VolumeRef: clone.Ref}); err != nil {
+		t.Fatalf("DestroyVolume returned error: %v", err)
+	}
+
+	wantCommands := []string{
+		"zfs snapshot tank/cleanroom/sandboxes/sandbox-1@snap-golden",
+		"zfs list -H -o name tank/cleanroom/sandboxes/sandbox-2",
+		"zfs clone -p tank/cleanroom/sandboxes/sandbox-1@snap-golden tank/cleanroom/sandboxes/sandbox-2",
+		"zfs destroy tank/cleanroom/sandboxes/sandbox-1@snap-golden",
+		"zfs destroy -r tank/cleanroom/sandboxes/sandbox-2",
+	}
+	if got, want := runner.commands, wantCommands; strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("unexpected zfs commands:\n got: %v\nwant: %v", got, want)
+	}
+}
+
+func TestZFSDriverRequiresDatasetRoot(t *testing.T) {
+	_, err := NewZFSDriver(ZFSDriverOptions{})
+	if err == nil || !strings.Contains(err.Error(), "dataset root") {
+		t.Fatalf("expected dataset root error, got %v", err)
+	}
+}

--- a/internal/volumestore/zfs_test.go
+++ b/internal/volumestore/zfs_test.go
@@ -10,6 +10,15 @@ import (
 	"testing"
 )
 
+// fakeZvolStat uses real os.Stat for normal files but returns a fake success
+// for /dev/zvol paths that don't exist in the test environment.
+func fakeZvolStat(name string) (os.FileInfo, error) {
+	if strings.HasPrefix(name, "/dev/zvol/") {
+		return os.Stat("/dev/null")
+	}
+	return os.Stat(name)
+}
+
 type zfsTestRunner struct {
 	commands []string
 	exists   map[string]bool
@@ -63,6 +72,7 @@ func TestZFSDriverEnsureBaseVolumeAndCloneLifecycle(t *testing.T) {
 	driver, err := NewZFSDriver(ZFSDriverOptions{
 		DatasetRoot: "tank/cleanroom",
 		Runner:      runner,
+		Stat:        fakeZvolStat,
 	})
 	if err != nil {
 		t.Fatalf("NewZFSDriver returned error: %v", err)
@@ -116,6 +126,7 @@ func TestZFSDriverSnapshotCloneAndDestroy(t *testing.T) {
 	driver, err := NewZFSDriver(ZFSDriverOptions{
 		DatasetRoot: "tank/cleanroom",
 		Runner:      runner,
+		Stat:        fakeZvolStat,
 	})
 	if err != nil {
 		t.Fatalf("NewZFSDriver returned error: %v", err)

--- a/internal/vsockcontrol/protocol.go
+++ b/internal/vsockcontrol/protocol.go
@@ -1,0 +1,84 @@
+package vsockcontrol
+
+import (
+	"encoding/json"
+	"io"
+)
+
+const DefaultHostControlPort uint32 = 10701
+
+// CheckpointRequest is sent from guest to host to request a snapshot
+// at a safe point.
+type CheckpointRequest struct {
+	Name string `json:"name,omitempty"`
+}
+
+// CheckpointResponse is sent from host to guest in reply.
+type CheckpointResponse struct {
+	Accepted bool   `json:"accepted"`
+	Pending  bool   `json:"pending,omitempty"`
+	Message  string `json:"message,omitempty"`
+	Error    string `json:"error,omitempty"`
+}
+
+// QuiesceRequest is sent from host to guest on the existing guest-agent
+// vsock port. The guest should sync filesystems and run any registered
+// quiesce hook before responding.
+type QuiesceRequest struct {
+	Type           string `json:"type"`                      // "quiesce"
+	TimeoutSeconds int64  `json:"timeout_seconds,omitempty"`
+}
+
+// QuiesceResponse is sent from guest to host after quiesce completes.
+type QuiesceResponse struct {
+	OK    bool   `json:"ok"`
+	Error string `json:"error,omitempty"`
+}
+
+func EncodeCheckpointRequest(w io.Writer, req CheckpointRequest) error {
+	return json.NewEncoder(w).Encode(req)
+}
+
+func DecodeCheckpointRequest(r io.Reader) (CheckpointRequest, error) {
+	var req CheckpointRequest
+	if err := json.NewDecoder(r).Decode(&req); err != nil {
+		return CheckpointRequest{}, err
+	}
+	return req, nil
+}
+
+func EncodeCheckpointResponse(w io.Writer, resp CheckpointResponse) error {
+	return json.NewEncoder(w).Encode(resp)
+}
+
+func DecodeCheckpointResponse(r io.Reader) (CheckpointResponse, error) {
+	var resp CheckpointResponse
+	if err := json.NewDecoder(r).Decode(&resp); err != nil {
+		return CheckpointResponse{}, err
+	}
+	return resp, nil
+}
+
+func EncodeQuiesceRequest(w io.Writer, req QuiesceRequest) error {
+	return json.NewEncoder(w).Encode(req)
+}
+
+func DecodeQuiesceRequest(r io.Reader) (QuiesceRequest, error) {
+	var req QuiesceRequest
+	if err := json.NewDecoder(r).Decode(&req); err != nil {
+		return QuiesceRequest{}, err
+	}
+	return req, nil
+}
+
+func EncodeQuiesceResponse(w io.Writer, resp QuiesceResponse) error {
+	return json.NewEncoder(w).Encode(resp)
+}
+
+func DecodeQuiesceResponse(r io.Reader) (QuiesceResponse, error) {
+	var resp QuiesceResponse
+	if err := json.NewDecoder(r).Decode(&resp); err != nil {
+		return QuiesceResponse{}, err
+	}
+	return resp, nil
+}

--- a/internal/vsockcontrol/protocol_test.go
+++ b/internal/vsockcontrol/protocol_test.go
@@ -1,0 +1,126 @@
+package vsockcontrol
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestCheckpointRequestRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	req := CheckpointRequest{Name: "before-deploy"}
+	if err := EncodeCheckpointRequest(&buf, req); err != nil {
+		t.Fatalf("EncodeCheckpointRequest: %v", err)
+	}
+	got, err := DecodeCheckpointRequest(&buf)
+	if err != nil {
+		t.Fatalf("DecodeCheckpointRequest: %v", err)
+	}
+	if got.Name != req.Name {
+		t.Fatalf("Name: got %q, want %q", got.Name, req.Name)
+	}
+}
+
+func TestCheckpointResponseRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	resp := CheckpointResponse{Accepted: true, Pending: true, Message: "snapshot queued"}
+	if err := EncodeCheckpointResponse(&buf, resp); err != nil {
+		t.Fatalf("EncodeCheckpointResponse: %v", err)
+	}
+	got, err := DecodeCheckpointResponse(&buf)
+	if err != nil {
+		t.Fatalf("DecodeCheckpointResponse: %v", err)
+	}
+	if got.Accepted != resp.Accepted {
+		t.Fatalf("Accepted: got %v, want %v", got.Accepted, resp.Accepted)
+	}
+	if got.Pending != resp.Pending {
+		t.Fatalf("Pending: got %v, want %v", got.Pending, resp.Pending)
+	}
+	if got.Message != resp.Message {
+		t.Fatalf("Message: got %q, want %q", got.Message, resp.Message)
+	}
+}
+
+func TestCheckpointResponseError(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	resp := CheckpointResponse{Accepted: false, Error: "quota exceeded"}
+	if err := EncodeCheckpointResponse(&buf, resp); err != nil {
+		t.Fatalf("EncodeCheckpointResponse: %v", err)
+	}
+	got, err := DecodeCheckpointResponse(&buf)
+	if err != nil {
+		t.Fatalf("DecodeCheckpointResponse: %v", err)
+	}
+	if got.Accepted {
+		t.Fatal("expected Accepted=false")
+	}
+	if got.Error != resp.Error {
+		t.Fatalf("Error: got %q, want %q", got.Error, resp.Error)
+	}
+}
+
+func TestQuiesceRequestRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	req := QuiesceRequest{Type: "quiesce", TimeoutSeconds: 30}
+	if err := EncodeQuiesceRequest(&buf, req); err != nil {
+		t.Fatalf("EncodeQuiesceRequest: %v", err)
+	}
+	got, err := DecodeQuiesceRequest(&buf)
+	if err != nil {
+		t.Fatalf("DecodeQuiesceRequest: %v", err)
+	}
+	if got.Type != req.Type {
+		t.Fatalf("Type: got %q, want %q", got.Type, req.Type)
+	}
+	if got.TimeoutSeconds != req.TimeoutSeconds {
+		t.Fatalf("TimeoutSeconds: got %d, want %d", got.TimeoutSeconds, req.TimeoutSeconds)
+	}
+}
+
+func TestQuiesceResponseRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	resp := QuiesceResponse{OK: true}
+	if err := EncodeQuiesceResponse(&buf, resp); err != nil {
+		t.Fatalf("EncodeQuiesceResponse: %v", err)
+	}
+	got, err := DecodeQuiesceResponse(&buf)
+	if err != nil {
+		t.Fatalf("DecodeQuiesceResponse: %v", err)
+	}
+	if !got.OK {
+		t.Fatal("expected OK=true")
+	}
+	if got.Error != "" {
+		t.Fatalf("unexpected Error: %q", got.Error)
+	}
+}
+
+func TestQuiesceResponseError(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	resp := QuiesceResponse{OK: false, Error: "hook failed"}
+	if err := EncodeQuiesceResponse(&buf, resp); err != nil {
+		t.Fatalf("EncodeQuiesceResponse: %v", err)
+	}
+	got, err := DecodeQuiesceResponse(&buf)
+	if err != nil {
+		t.Fatalf("DecodeQuiesceResponse: %v", err)
+	}
+	if got.OK {
+		t.Fatal("expected OK=false")
+	}
+	if got.Error != resp.Error {
+		t.Fatalf("Error: got %q, want %q", got.Error, resp.Error)
+	}
+}

--- a/proto/cleanroom/v1/control.proto
+++ b/proto/cleanroom/v1/control.proto
@@ -11,8 +11,16 @@ service SandboxService {
   rpc GetSandbox(GetSandboxRequest) returns (GetSandboxResponse);
   rpc ListSandboxes(ListSandboxesRequest) returns (ListSandboxesResponse);
   rpc DownloadSandboxFile(DownloadSandboxFileRequest) returns (DownloadSandboxFileResponse);
+  rpc RestoreSandbox(RestoreSandboxRequest) returns (RestoreSandboxResponse);
   rpc TerminateSandbox(TerminateSandboxRequest) returns (TerminateSandboxResponse);
   rpc StreamSandboxEvents(StreamSandboxEventsRequest) returns (stream SandboxEvent);
+}
+
+service SnapshotService {
+  rpc CreateSnapshot(CreateSnapshotRequest) returns (CreateSnapshotResponse);
+  rpc GetSnapshot(GetSnapshotRequest) returns (GetSnapshotResponse);
+  rpc ListSnapshots(ListSnapshotsRequest) returns (ListSnapshotsResponse);
+  rpc DeleteSnapshot(DeleteSnapshotRequest) returns (DeleteSnapshotResponse);
 }
 
 service ExecutionService {
@@ -30,6 +38,15 @@ message Sandbox {
   string policy_hash = 4;
   google.protobuf.Timestamp created_at = 5;
   google.protobuf.Timestamp updated_at = 6;
+}
+
+message Snapshot {
+  string snapshot_id = 1;
+  string source_sandbox_id = 2;
+  string backend = 3;
+  string policy_hash = 4;
+  string name = 5;
+  google.protobuf.Timestamp created_at = 6;
 }
 
 enum SandboxStatus {
@@ -76,6 +93,9 @@ message CreateSandboxRequest {
   string backend = 2;
   SandboxOptions options = 3;
   Policy policy = 4;
+  oneof source {
+    string snapshot_id = 5;
+  }
 }
 
 message CreateSandboxResponse {
@@ -111,6 +131,16 @@ message DownloadSandboxFileResponse {
   int64 size_bytes = 4;
 }
 
+message RestoreSandboxRequest {
+  string sandbox_id = 1;
+  string snapshot_id = 2;
+}
+
+message RestoreSandboxResponse {
+  Sandbox sandbox = 1;
+  string message = 2;
+}
+
 message TerminateSandboxRequest {
   string sandbox_id = 1;
 }
@@ -131,6 +161,40 @@ message SandboxEvent {
   SandboxStatus status = 2;
   string message = 3;
   google.protobuf.Timestamp occurred_at = 4;
+}
+
+message CreateSnapshotRequest {
+  string sandbox_id = 1;
+  string name = 2;
+}
+
+message CreateSnapshotResponse {
+  Snapshot snapshot = 1;
+  string message = 2;
+}
+
+message GetSnapshotRequest {
+  string snapshot_id = 1;
+}
+
+message GetSnapshotResponse {
+  Snapshot snapshot = 1;
+}
+
+message ListSnapshotsRequest {}
+
+message ListSnapshotsResponse {
+  repeated Snapshot snapshots = 1;
+}
+
+message DeleteSnapshotRequest {
+  string snapshot_id = 1;
+}
+
+message DeleteSnapshotResponse {
+  string snapshot_id = 1;
+  bool deleted = 2;
+  string message = 3;
 }
 
 message Execution {

--- a/scripts/bootstrap-buildkite-agent.sh
+++ b/scripts/bootstrap-buildkite-agent.sh
@@ -252,6 +252,25 @@ if getent group kvm >/dev/null 2>&1; then
   usermod -aG kvm buildkite-agent
 fi
 
+# Configure cleanroom runtime config with ZFS snapshot support if a pool exists.
+CLEANROOM_ZFS_DATASET="${CLEANROOM_ZFS_DATASET:-cleanroom/data}"
+if command -v zpool >/dev/null 2>&1 && zpool list cleanroom >/dev/null 2>&1; then
+  log "configuring cleanroom runtime config with ZFS snapshot support (dataset: ${CLEANROOM_ZFS_DATASET})"
+  agent_config_dir="/var/lib/buildkite-agent/.config/cleanroom"
+  install -d -o buildkite-agent -g buildkite-agent -m 0755 "$agent_config_dir"
+  cat > "$agent_config_dir/config.yaml" <<RTCFG
+backends:
+  firecracker:
+    snapshots:
+      enabled: true
+      driver: zfs
+      zfs_dataset: ${CLEANROOM_ZFS_DATASET}
+      quiesce_timeout_seconds: 15
+RTCFG
+  chown buildkite-agent:buildkite-agent "$agent_config_dir/config.yaml"
+  chmod 0644 "$agent_config_dir/config.yaml"
+fi
+
 systemctl daemon-reload
 systemctl enable --now "buildkite-agent@${QUEUE_NAME}.service"
 

--- a/scripts/cleanroom-root-helper.sh
+++ b/scripts/cleanroom-root-helper.sh
@@ -22,6 +22,11 @@ is_runtime_rootfs_tmp() {
   [[ "$p" == /var/lib/buildkite-agent/.cache/cleanroom/firecracker/runtime-rootfs/*.ext4.tmp-* ]]
 }
 
+is_runtime_rootfs_image() {
+  local p="$1"
+  [[ "$p" == */cleanroom/firecracker/runtime-rootfs/*.ext4 ]]
+}
+
 is_mounted_rootfs_dest() {
   local p="$1"
   [[ "$p" == /tmp/cleanroom-firecracker-rootfs-*/usr/local/bin/cleanroom-guest-agent || "$p" == /tmp/cleanroom-firecracker-rootfs-*/sbin/cleanroom-init ]]
@@ -50,6 +55,46 @@ is_cidr() {
 is_install_source() {
   local p="$1"
   [[ "$p" == /var/lib/buildkite-agent/builds/*/buildkite/cleanroom/dist/cleanroom-guest-agent || "$p" == /tmp/cleanroom-init-* ]]
+}
+
+is_zfs_dataset() {
+  local v="$1"
+  [[ "$v" =~ ^[A-Za-z0-9][A-Za-z0-9._:-]*(/[A-Za-z0-9][A-Za-z0-9._:-]*)*$ ]]
+}
+
+is_zfs_snapshot_ref() {
+  local v="$1"
+  [[ "$v" =~ ^[A-Za-z0-9][A-Za-z0-9._:-]*(/[A-Za-z0-9][A-Za-z0-9._:-]*)*@[A-Za-z0-9][A-Za-z0-9._:-]*$ ]]
+}
+
+is_zvol_device_path() {
+  local p="$1"
+  [[ "$p" == /dev/zvol/* ]] || return 1
+  is_zfs_dataset "${p#/dev/zvol/}"
+}
+
+zfs_bin() {
+  if [[ -x /usr/sbin/zfs ]]; then
+    echo /usr/sbin/zfs
+    return
+  fi
+  if [[ -x /sbin/zfs ]]; then
+    echo /sbin/zfs
+    return
+  fi
+  command -v zfs || die "zfs: binary not found"
+}
+
+dd_bin() {
+  if [[ -x /usr/bin/dd ]]; then
+    echo /usr/bin/dd
+    return
+  fi
+  if [[ -x /bin/dd ]]; then
+    echo /bin/dd
+    return
+  fi
+  command -v dd || die "dd: binary not found"
 }
 
 run_ip() {
@@ -210,6 +255,62 @@ run_install() {
   exec /usr/bin/install -m 0755 "$src" "$dst"
 }
 
+run_zfs() {
+  [[ "$#" -ge 1 ]] || die "zfs: missing arguments"
+  local bin
+  bin="$(zfs_bin)"
+
+  if [[ "$#" -eq 5 && "$1" == "list" && "$2" == "-H" && "$3" == "-o" && "$4" == "name" ]]; then
+    is_zfs_dataset "$5" || is_zfs_snapshot_ref "$5" || die "zfs list: unsupported ref '$5'"
+    exec "$bin" "$@"
+  fi
+
+  if [[ "$#" -eq 5 && "$1" == "create" && "$2" == "-p" && "$3" == "-V" ]]; then
+    is_numeric "$4" || die "zfs create: invalid size '$4'"
+    is_zfs_dataset "$5" || die "zfs create: unsupported dataset '$5'"
+    exec "$bin" "$@"
+  fi
+
+  if [[ "$#" -eq 2 && "$1" == "snapshot" ]]; then
+    is_zfs_snapshot_ref "$2" || die "zfs snapshot: unsupported ref '$2'"
+    exec "$bin" "$@"
+  fi
+
+  if [[ "$#" -eq 4 && "$1" == "clone" && "$2" == "-p" ]]; then
+    is_zfs_snapshot_ref "$3" || die "zfs clone: unsupported snapshot '$3'"
+    is_zfs_dataset "$4" || die "zfs clone: unsupported dataset '$4'"
+    exec "$bin" "$@"
+  fi
+
+  if [[ "$#" -eq 3 && "$1" == "destroy" && "$2" == "-r" ]]; then
+    is_zfs_dataset "$3" || die "zfs destroy -r: unsupported dataset '$3'"
+    exec "$bin" "$@"
+  fi
+
+  if [[ "$#" -eq 2 && "$1" == "destroy" ]]; then
+    is_zfs_snapshot_ref "$2" || die "zfs destroy: unsupported ref '$2'"
+    exec "$bin" "$@"
+  fi
+
+  die "zfs: unsupported arguments"
+}
+
+run_dd() {
+  [[ "$#" -eq 5 ]] || die "dd: unsupported arguments"
+  [[ "$1" == if=* ]] || die "dd: missing input file"
+  [[ "$2" == of=* ]] || die "dd: missing output file"
+  [[ "$3" == "bs=4M" ]] || die "dd: unsupported block size"
+  [[ "$4" == "conv=fsync" ]] || die "dd: unsupported conv mode"
+  [[ "$5" == "status=none" ]] || die "dd: unsupported status mode"
+
+  local src="${1#if=}"
+  local dst="${2#of=}"
+  is_runtime_rootfs_image "$src" || die "dd: unsupported source path '$src'"
+  is_zvol_device_path "$dst" || die "dd: unsupported destination path '$dst'"
+
+  exec "$(dd_bin)" "$@"
+}
+
 main() {
   require_root
   [[ "$#" -ge 1 ]] || die "missing command"
@@ -242,6 +343,12 @@ main() {
       ;;
     install)
       run_install "$@"
+      ;;
+    zfs)
+      run_zfs "$@"
+      ;;
+    dd)
+      run_dd "$@"
       ;;
     *)
       die "unsupported command '$command'"


### PR DESCRIPTION
## Summary
- add the first end-to-end snapshot/restore/fork control-plane slice
- add a Firecracker-backed file-clone implementation with persisted snapshot metadata
- update the roadmap with implemented status and a clear remaining implementation list

## Notes
- this is intentionally a first functional slice, not the final ZFS/APFS volume-store design
- next meaningful work is validating and tightening the Firecracker path on a host with Firecracker support

## Verification
- mise run test