### PR TITLE
fix: allow console to force local exit on second interrupt

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -53,10 +53,11 @@ import (
 const defaultBumpRefSource = "ghcr.io/buildkite/cleanroom-base/alpine:latest"
 
 const (
-	systemdServiceName      = "cleanroom.service"
-	launchdServiceName      = "com.buildkite.cleanroom"
-	defaultDaemonListen     = "unix://" + endpoint.DefaultSystemSocketPath
-	sandboxTerminateTimeout = 2 * time.Second
+	systemdServiceName       = "cleanroom.service"
+	launchdServiceName       = "com.buildkite.cleanroom"
+	defaultDaemonListen      = "unix://" + endpoint.DefaultSystemSocketPath
+	sandboxTerminateTimeout  = 2 * time.Second
+	interruptForceExitWindow = 1200 * time.Millisecond
 )
 
 type policyLoader interface {
@@ -1038,10 +1039,18 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) error {
 	defer stopSignals(signalCh)
 
 	var interruptCount atomic.Int32
+	var lastInterruptAt atomic.Int64
 	forceLocalExit := make(chan struct{})
 	var forceLocalExitOnce sync.Once
 	requestInterrupt := func(signal int32) {
-		if interruptCount.Add(1) == 1 {
+		now := time.Now()
+		last := time.Unix(0, lastInterruptAt.Load())
+		if !last.IsZero() && now.Sub(last) > interruptForceExitWindow {
+			interruptCount.Store(0)
+		}
+		count := interruptCount.Add(1)
+		lastInterruptAt.Store(now.UnixNano())
+		if count == 1 {
 			go func() {
 				_ = interactiveSession.SendSignal(signal)
 			}()
@@ -1095,17 +1104,23 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) error {
 			if n > 0 {
 				payload := append([]byte(nil), buf[:n]...)
 				if rawMode {
+					filtered := payload[:0]
 					for _, b := range payload {
 						if b == 0x03 {
 							requestInterrupt(2)
+							continue
 						}
+						filtered = append(filtered, b)
 					}
+					payload = filtered
 					if isForceLocalExit() {
 						return
 					}
 				}
-				if sendErr := interactiveSession.WriteStdin(payload); sendErr != nil {
-					return
+				if len(payload) > 0 {
+					if sendErr := interactiveSession.WriteStdin(payload); sendErr != nil {
+						return
+					}
 				}
 			}
 			if readErr != nil {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1051,9 +1051,7 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) error {
 		count := interruptCount.Add(1)
 		lastInterruptAt.Store(now.UnixNano())
 		if count == 1 {
-			go func() {
-				_ = interactiveSession.SendSignal(signal)
-			}()
+			_ = interactiveSession.SendSignal(signal)
 			return
 		}
 		forceLocalExitOnce.Do(func() {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -17,6 +17,8 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"syscall"
 	"text/tabwriter"
 	"time"
@@ -1035,6 +1037,32 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) error {
 	notifySignals(signalCh, os.Interrupt, syscall.SIGTERM)
 	defer stopSignals(signalCh)
 
+	var interruptCount atomic.Int32
+	forceLocalExit := make(chan struct{})
+	var forceLocalExitOnce sync.Once
+	requestInterrupt := func(signal int32) {
+		if interruptCount.Add(1) == 1 {
+			go func() {
+				_ = interactiveSession.SendSignal(signal)
+			}()
+			return
+		}
+		forceLocalExitOnce.Do(func() {
+			close(forceLocalExit)
+			go func() {
+				_ = interactiveSession.Close()
+			}()
+		})
+	}
+	isForceLocalExit := func() bool {
+		select {
+		case <-forceLocalExit:
+			return true
+		default:
+			return false
+		}
+	}
+
 	if rawMode {
 		resizeSignalCh := make(chan os.Signal, 4)
 		signal.Notify(resizeSignalCh, syscall.SIGWINCH)
@@ -1056,7 +1084,7 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) error {
 			if sig == syscall.SIGTERM {
 				num = 15
 			}
-			_ = interactiveSession.SendSignal(num)
+			requestInterrupt(num)
 		}
 	}()
 
@@ -1066,6 +1094,16 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) error {
 			n, readErr := os.Stdin.Read(buf)
 			if n > 0 {
 				payload := append([]byte(nil), buf[:n]...)
+				if rawMode {
+					for _, b := range payload {
+						if b == 0x03 {
+							requestInterrupt(2)
+						}
+					}
+					if isForceLocalExit() {
+						return
+					}
+				}
 				if sendErr := interactiveSession.WriteStdin(payload); sendErr != nil {
 					return
 				}
@@ -1108,6 +1146,9 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) error {
 	buf := make([]byte, 4096)
 	for {
 		n, readErr := interactiveSession.ReadPTY(buf)
+		if isForceLocalExit() {
+			return exitCodeError{code: 130}
+		}
 		if n > 0 {
 			chunk := append([]byte(nil), buf[:n]...)
 			if rawMode {
@@ -1118,6 +1159,9 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) error {
 			}
 		}
 		if polledExitCode, gotExitCode, pollErr := pollInteractiveExitOrControlErr(exitCodeCh, &controlErrCh); pollErr != nil {
+			if isForceLocalExit() {
+				return exitCodeError{code: 130}
+			}
 			return pollErr
 		} else if gotExitCode {
 			exitCode = polledExitCode
@@ -1130,16 +1174,25 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) error {
 			break
 		}
 	}
+	if isForceLocalExit() {
+		return exitCodeError{code: 130}
+	}
 
 	if !haveExitCode {
 		waitedExitCode, gotExitCode, waitErr := waitForInteractiveExitOrControlErr(exitCodeCh, &controlErrCh, 2*time.Second)
 		if waitErr != nil {
+			if isForceLocalExit() {
+				return exitCodeError{code: 130}
+			}
 			return waitErr
 		}
 		if gotExitCode {
 			exitCode = waitedExitCode
 			haveExitCode = true
 		}
+	}
+	if isForceLocalExit() {
+		return exitCodeError{code: 130}
 	}
 
 	if !haveExitCode {

--- a/internal/cli/console_integration_test.go
+++ b/internal/cli/console_integration_test.go
@@ -194,6 +194,59 @@ func TestConsoleIntegrationSecondInterruptForcesLocalExitWhenExecutionIgnoresCan
 	}
 }
 
+func TestConsoleIntegrationSecondInterruptAfterWindowDoesNotForceLocalExit(t *testing.T) {
+	started := make(chan struct{}, 1)
+	releaseRun := make(chan struct{})
+	adapter := &integrationAdapter{
+		runStreamFn: func(_ context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+			if stream.OnAttach != nil {
+				stream.OnAttach(backend.AttachIO{WriteStdin: func(_ []byte) error { return nil }})
+			}
+			select {
+			case started <- struct{}{}:
+			default:
+			}
+			<-releaseRun
+			return &backend.RunResult{RunID: req.RunID, ExitCode: 0, Message: "released"}, nil
+		},
+	}
+
+	host, _ := startIntegrationServer(t, adapter)
+	signalCh := withTestSignalChannel(t)
+	cwd := t.TempDir()
+
+	done := make(chan execOutcome, 1)
+	go func() {
+		done <- runConsoleWithCapture(ConsoleCommand{
+			clientFlags: clientFlags{Host: host},
+			Chdir:       cwd,
+		}, "", runtimeContext{CWD: cwd, Loader: integrationLoader{}})
+	}()
+
+	_ = mustReceiveWithin(t, started, 2*time.Second, "timed out waiting for console execution to start")
+	signalCh <- os.Interrupt
+	time.Sleep(2*interruptForceExitWindow + 100*time.Millisecond)
+	signalCh <- os.Interrupt
+
+	select {
+	case outcome := <-done:
+		t.Fatalf("unexpected forced local exit after interrupt window elapsed: err=%v cause=%v", outcome.err, outcome.cause)
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	close(releaseRun)
+	outcome := mustReceiveWithin(t, done, 2*time.Second, "timed out waiting for console execution to finish after release")
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err == nil {
+		t.Fatal("expected canceled exit after interrupt")
+	}
+	if got, want := ExitCode(outcome.err), 130; got != want {
+		t.Fatalf("unexpected console exit code: got %d want %d (err=%v)", got, want, outcome.err)
+	}
+}
+
 func TestConsoleRejectsUnsupportedHostScheme(t *testing.T) {
 	outcome := runConsoleWithCapture(ConsoleCommand{
 		clientFlags: clientFlags{Host: "tssvc://cleanroom"},

--- a/internal/cli/console_integration_test.go
+++ b/internal/cli/console_integration_test.go
@@ -141,6 +141,59 @@ func TestConsoleIntegrationInterruptCancelsExecution(t *testing.T) {
 	}
 }
 
+func TestConsoleIntegrationSecondInterruptForcesLocalExitWhenExecutionIgnoresCancel(t *testing.T) {
+	started := make(chan struct{}, 1)
+	releaseRun := make(chan struct{})
+	t.Cleanup(func() {
+		close(releaseRun)
+	})
+	adapter := &integrationAdapter{
+		runStreamFn: func(_ context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+			if stream.OnAttach != nil {
+				stream.OnAttach(backend.AttachIO{
+					WriteStdin: func(_ []byte) error { return nil },
+				})
+			}
+			select {
+			case started <- struct{}{}:
+			default:
+			}
+			<-releaseRun
+			return &backend.RunResult{RunID: req.RunID, ExitCode: 0, Message: "released"}, nil
+		},
+	}
+
+	host, _ := startIntegrationServer(t, adapter)
+	signalCh := withTestSignalChannel(t)
+	cwd := t.TempDir()
+
+	done := make(chan execOutcome, 1)
+	go func() {
+		done <- runConsoleWithCapture(ConsoleCommand{
+			clientFlags: clientFlags{Host: host},
+			Chdir:       cwd,
+		}, "", runtimeContext{
+			CWD:    cwd,
+			Loader: integrationLoader{},
+		})
+	}()
+
+	_ = mustReceiveWithin(t, started, 2*time.Second, "timed out waiting for console execution to start")
+	signalCh <- os.Interrupt
+	signalCh <- os.Interrupt
+
+	outcome := mustReceiveWithin(t, done, 2*time.Second, "timed out waiting for second interrupt to force local console exit")
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err == nil {
+		t.Fatal("expected non-zero exit from forced local interrupt")
+	}
+	if got, want := ExitCode(outcome.err), 130; got != want {
+		t.Fatalf("unexpected console exit code: got %d want %d (err=%v)", got, want, outcome.err)
+	}
+}
+
 func TestConsoleRejectsUnsupportedHostScheme(t *testing.T) {
 	outcome := runConsoleWithCapture(ConsoleCommand{
 		clientFlags: clientFlags{Host: "tssvc://cleanroom"},


### PR DESCRIPTION
## Summary
- keep first interrupt behaviour unchanged by forwarding a signal to the interactive guest session
- add a local escape hatch: second interrupt forces client-side session close and exits with code `130`
- in raw TTY mode, treat byte `0x03` (`Ctrl-C`) as an interrupt trigger so users can still break out when host signals are not generated
- add an integration regression test covering an execution that ignores cancel and ensuring second interrupt exits promptly

## Testing
- go test ./internal/cli -run TestConsoleIntegrationSecondInterruptForcesLocalExitWhenExecutionIgnoresCancel -count=1
- go test ./internal/cli ./internal/imagemgr
