### PR TITLE
fix: reject incompatible image architectures

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -304,13 +304,6 @@ var (
 		if err != nil {
 			return "", fmt.Errorf("resolve image digest for %q: %w", resolved, err)
 		}
-		imageOS, imageArch, err := resolveReferencePlatformConfig(ctx, ref)
-		if err != nil {
-			return "", fmt.Errorf("resolve image digest for %q: %w", resolved, err)
-		}
-		if err := imagemgr.ValidateImagePlatformForHost(imageOS, imageArch, runtime.GOARCH); err != nil {
-			return "", fmt.Errorf("resolve image digest for %q: %w", resolved, err)
-		}
 
 		return fmt.Sprintf("%s@%s", ref.Context().Name(), resolvedDigest), nil
 	}
@@ -327,6 +320,19 @@ var (
 
 		resolved, err := resolveReferenceForPolicyUpdate(ctx, source)
 		if err == nil {
+			if allowLocal {
+				resolvedRef, parseErr := name.ParseReference(resolved, name.WeakValidation)
+				if parseErr != nil {
+					return "", fmt.Errorf("resolve image digest for %q: %w", source, parseErr)
+				}
+				imageOS, imageArch, platformErr := resolveReferencePlatformConfig(ctx, resolvedRef)
+				if platformErr != nil {
+					return "", fmt.Errorf("resolve image digest for %q: %w", source, platformErr)
+				}
+				if err := imagemgr.ValidateImagePlatformForHost(imageOS, imageArch, runtime.GOARCH); err != nil {
+					return "", fmt.Errorf("resolve image digest for %q: %w", source, err)
+				}
+			}
 			return resolved, nil
 		}
 		if isExplicitRegistryReference(source) {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -272,21 +272,34 @@ var (
 			resolved = defaultBumpRefSource
 		}
 
-		if parsed, err := ociref.ParseDigestReference(resolved); err == nil {
-			return parsed.Original, nil
-		}
-
-		tag, err := name.NewTag(resolved, name.WeakValidation)
+		ref, err := name.ParseReference(resolved, name.WeakValidation)
 		if err != nil {
 			return "", fmt.Errorf("parse image ref %q: %w", resolved, err)
 		}
-
-		desc, err := remote.Head(tag, remote.WithContext(ctx), remote.WithAuthFromKeychain(authn.DefaultKeychain))
+		img, err := remote.Image(
+			ref,
+			remote.WithContext(ctx),
+			remote.WithAuthFromKeychain(authn.DefaultKeychain),
+			remote.WithPlatform(imagemgr.HostLinuxPlatformForGOARCH(runtime.GOARCH)),
+		)
 		if err != nil {
 			return "", fmt.Errorf("resolve image digest for %q: %w", resolved, err)
 		}
 
-		return fmt.Sprintf("%s@%s", tag.Context().Name(), desc.Digest.String()), nil
+		cfg, err := img.ConfigFile()
+		if err != nil {
+			return "", fmt.Errorf("read image config for %q: %w", resolved, err)
+		}
+		if err := imagemgr.ValidateImagePlatformForHost(cfg.OS, cfg.Architecture, runtime.GOARCH); err != nil {
+			return "", fmt.Errorf("resolve image digest for %q: %w", resolved, err)
+		}
+
+		digest, err := img.Digest()
+		if err != nil {
+			return "", fmt.Errorf("resolve image digest for %q: %w", resolved, err)
+		}
+
+		return fmt.Sprintf("%s@%s", ref.Context().Name(), digest.String()), nil
 	}
 	importLocalDockerImageForOverrideFn = importLocalDockerImageForOverride
 	resolveReferenceForImageOverride    = func(ctx context.Context, source string, allowLocal bool) (string, error) {
@@ -303,6 +316,9 @@ var (
 		if err == nil {
 			return resolved, nil
 		}
+		if isExplicitRegistryReference(source) {
+			return "", err
+		}
 
 		return "", fmt.Errorf("%w; local docker resolution failed: %v", err, localErr)
 	}
@@ -317,6 +333,36 @@ var (
 	serveInstallSystemdUnitPath = "/etc/systemd/system/" + systemdServiceName
 	serveInstallLaunchdPath     = "/Library/LaunchDaemons/" + launchdServiceName + ".plist"
 )
+
+func isExplicitRegistryReference(raw string) bool {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return false
+	}
+	if parsed, err := ociref.ParseDigestReference(trimmed); err == nil {
+		return isRegistryHostPrefix(parsed.Repository)
+	}
+	namePart := trimmed
+	if at := strings.Index(namePart, "@"); at >= 0 {
+		namePart = namePart[:at]
+	}
+	if colon := strings.LastIndex(namePart, ":"); colon > strings.LastIndex(namePart, "/") {
+		namePart = namePart[:colon]
+	}
+	first := strings.TrimSpace(strings.SplitN(namePart, "/", 2)[0])
+	return isRegistryHostPrefix(first)
+}
+
+func isRegistryHostPrefix(component string) bool {
+	component = strings.TrimSpace(strings.ToLower(component))
+	if component == "" {
+		return false
+	}
+	if component == "localhost" {
+		return true
+	}
+	return strings.Contains(component, ".") || strings.Contains(component, ":")
+}
 
 func Run(args []string, version string) error {
 	cfg, cfgPath, err := runtimeconfig.Load()

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -266,6 +266,30 @@ var (
 	stopSignals = func(ch chan os.Signal) {
 		signal.Stop(ch)
 	}
+	resolveRegistryDigestForReference = func(ctx context.Context, ref name.Reference) (string, error) {
+		desc, err := remote.Head(ref, remote.WithContext(ctx), remote.WithAuthFromKeychain(authn.DefaultKeychain))
+		if err != nil {
+			return "", err
+		}
+		return desc.Digest.String(), nil
+	}
+	resolveReferencePlatformConfig = func(ctx context.Context, ref name.Reference) (string, string, error) {
+		img, err := remote.Image(
+			ref,
+			remote.WithContext(ctx),
+			remote.WithAuthFromKeychain(authn.DefaultKeychain),
+			remote.WithPlatform(imagemgr.HostLinuxPlatformForGOARCH(runtime.GOARCH)),
+		)
+		if err != nil {
+			return "", "", err
+		}
+
+		cfg, err := img.ConfigFile()
+		if err != nil {
+			return "", "", err
+		}
+		return cfg.OS, cfg.Architecture, nil
+	}
 	resolveReferenceForPolicyUpdate = func(ctx context.Context, source string) (string, error) {
 		resolved := strings.TrimSpace(source)
 		if resolved == "" {
@@ -276,30 +300,19 @@ var (
 		if err != nil {
 			return "", fmt.Errorf("parse image ref %q: %w", resolved, err)
 		}
-		img, err := remote.Image(
-			ref,
-			remote.WithContext(ctx),
-			remote.WithAuthFromKeychain(authn.DefaultKeychain),
-			remote.WithPlatform(imagemgr.HostLinuxPlatformForGOARCH(runtime.GOARCH)),
-		)
+		resolvedDigest, err := resolveRegistryDigestForReference(ctx, ref)
 		if err != nil {
 			return "", fmt.Errorf("resolve image digest for %q: %w", resolved, err)
 		}
-
-		cfg, err := img.ConfigFile()
-		if err != nil {
-			return "", fmt.Errorf("read image config for %q: %w", resolved, err)
-		}
-		if err := imagemgr.ValidateImagePlatformForHost(cfg.OS, cfg.Architecture, runtime.GOARCH); err != nil {
-			return "", fmt.Errorf("resolve image digest for %q: %w", resolved, err)
-		}
-
-		digest, err := img.Digest()
+		imageOS, imageArch, err := resolveReferencePlatformConfig(ctx, ref)
 		if err != nil {
 			return "", fmt.Errorf("resolve image digest for %q: %w", resolved, err)
 		}
+		if err := imagemgr.ValidateImagePlatformForHost(imageOS, imageArch, runtime.GOARCH); err != nil {
+			return "", fmt.Errorf("resolve image digest for %q: %w", resolved, err)
+		}
 
-		return fmt.Sprintf("%s@%s", ref.Context().Name(), digest.String()), nil
+		return fmt.Sprintf("%s@%s", ref.Context().Name(), resolvedDigest), nil
 	}
 	importLocalDockerImageForOverrideFn = importLocalDockerImageForOverride
 	resolveReferenceForImageOverride    = func(ctx context.Context, source string, allowLocal bool) (string, error) {

--- a/internal/cli/image_override_resolution_test.go
+++ b/internal/cli/image_override_resolution_test.go
@@ -106,6 +106,29 @@ func TestResolveReferenceForImageOverrideReturnsCombinedError(t *testing.T) {
 	}
 }
 
+func TestResolveReferenceForImageOverrideReturnsRemoteErrorOnlyForExplicitRegistryRef(t *testing.T) {
+	withImageOverrideResolversForTest(
+		t,
+		func(_ context.Context, _ string) (string, error) {
+			return "", errors.New("local missing")
+		},
+		func(_ context.Context, _ string) (string, error) {
+			return "", errors.New("remote unavailable")
+		},
+	)
+
+	_, err := resolveReferenceForImageOverride(context.Background(), "ghcr.io/buildkite/cleanroom-base/alpine:latest", true)
+	if err == nil {
+		t.Fatal("expected resolveReferenceForImageOverride to fail when local and remote resolution fail")
+	}
+	if !strings.Contains(err.Error(), "remote unavailable") {
+		t.Fatalf("expected remote error in returned message, got %v", err)
+	}
+	if strings.Contains(err.Error(), "local docker resolution failed") {
+		t.Fatalf("expected explicit registry refs to omit local docker error details, got %v", err)
+	}
+}
+
 func TestResolveReferenceForImageOverrideSkipsLocalForRemoteEndpoint(t *testing.T) {
 	localCalls := 0
 	remoteCalls := 0

--- a/internal/cli/image_override_resolution_test.go
+++ b/internal/cli/image_override_resolution_test.go
@@ -3,8 +3,11 @@ package cli
 import (
 	"context"
 	"errors"
+	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
 )
 
 func withImageOverrideResolversForTest(
@@ -15,11 +18,16 @@ func withImageOverrideResolversForTest(
 	t.Helper()
 	prevLocal := importLocalDockerImageForOverrideFn
 	prevRemote := resolveReferenceForPolicyUpdate
+	prevPlatform := resolveReferencePlatformConfig
 	importLocalDockerImageForOverrideFn = localFn
 	resolveReferenceForPolicyUpdate = remoteFn
+	resolveReferencePlatformConfig = func(_ context.Context, _ name.Reference) (string, string, error) {
+		return "linux", runtime.GOARCH, nil
+	}
 	t.Cleanup(func() {
 		importLocalDockerImageForOverrideFn = prevLocal
 		resolveReferenceForPolicyUpdate = prevRemote
+		resolveReferencePlatformConfig = prevPlatform
 	})
 }
 

--- a/internal/cli/image_resolution_policy_update_test.go
+++ b/internal/cli/image_resolution_policy_update_test.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"runtime"
 	"strings"
 	"testing"
@@ -27,6 +29,7 @@ func withPolicyResolveDeps(
 
 func TestResolveReferenceForPolicyUpdatePreservesRegistryDigest(t *testing.T) {
 	const manifestListDigest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	platformResolverCalled := false
 	withPolicyResolveDeps(
 		t,
 		func(_ context.Context, ref name.Reference) (string, error) {
@@ -36,6 +39,7 @@ func TestResolveReferenceForPolicyUpdatePreservesRegistryDigest(t *testing.T) {
 			return manifestListDigest, nil
 		},
 		func(_ context.Context, _ name.Reference) (string, string, error) {
+			platformResolverCalled = true
 			return "linux", runtime.GOARCH, nil
 		},
 	)
@@ -47,28 +51,65 @@ func TestResolveReferenceForPolicyUpdatePreservesRegistryDigest(t *testing.T) {
 	if want := "ghcr.io/buildkite/cleanroom-base/alpine@" + manifestListDigest; got != want {
 		t.Fatalf("expected resolver to preserve registry digest: got %q want %q", got, want)
 	}
+	if platformResolverCalled {
+		t.Fatal("resolveReferenceForPolicyUpdate should not validate platform")
+	}
 }
 
-func TestResolveReferenceForPolicyUpdateRejectsIncompatiblePlatform(t *testing.T) {
+func TestResolveReferenceForImageOverrideLocalValidatesResolvedDigestPlatform(t *testing.T) {
 	incompatibleArch := "amd64"
 	if runtime.GOARCH == "amd64" {
 		incompatibleArch = "arm64"
 	}
-	withPolicyResolveDeps(
-		t,
-		func(_ context.Context, _ name.Reference) (string, error) {
-			return "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", nil
-		},
-		func(_ context.Context, _ name.Reference) (string, string, error) {
-			return "linux", incompatibleArch, nil
-		},
-	)
+	prevLocal := importLocalDockerImageForOverrideFn
+	prevResolve := resolveReferenceForPolicyUpdate
+	prevPlatform := resolveReferencePlatformConfig
+	importLocalDockerImageForOverrideFn = func(context.Context, string) (string, error) {
+		return "", errors.New("local missing")
+	}
+	resolveReferenceForPolicyUpdate = func(context.Context, string) (string, error) {
+		return "ghcr.io/buildkite/cleanroom-base/alpine@sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", nil
+	}
+	resolveReferencePlatformConfig = func(_ context.Context, ref name.Reference) (string, string, error) {
+		if got, want := ref.String(), "ghcr.io/buildkite/cleanroom-base/alpine@sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"; got != want {
+			return "", "", fmt.Errorf("unexpected platform validation ref: got %q want %q", got, want)
+		}
+		return "linux", incompatibleArch, nil
+	}
+	t.Cleanup(func() {
+		importLocalDockerImageForOverrideFn = prevLocal
+		resolveReferenceForPolicyUpdate = prevResolve
+		resolveReferencePlatformConfig = prevPlatform
+	})
 
-	_, err := resolveReferenceForPolicyUpdate(context.Background(), "ghcr.io/buildkite/cleanroom-base/alpine:latest")
+	_, err := resolveReferenceForImageOverride(context.Background(), "ghcr.io/buildkite/cleanroom-base/alpine:latest", true)
 	if err == nil {
 		t.Fatal("expected incompatible platform error")
 	}
 	if got, want := strings.ToLower(err.Error()), "incompatible"; !strings.Contains(got, want) {
 		t.Fatalf("expected incompatibility error, got %v", err)
+	}
+}
+
+func TestResolveReferenceForImageOverrideRemoteSkipsPlatformValidation(t *testing.T) {
+	prevResolve := resolveReferenceForPolicyUpdate
+	prevPlatform := resolveReferencePlatformConfig
+	resolveReferenceForPolicyUpdate = func(context.Context, string) (string, error) {
+		return "ghcr.io/buildkite/cleanroom-base/alpine@sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd", nil
+	}
+	resolveReferencePlatformConfig = func(context.Context, name.Reference) (string, string, error) {
+		return "", "", errors.New("platform resolver should not be called for remote endpoints")
+	}
+	t.Cleanup(func() {
+		resolveReferenceForPolicyUpdate = prevResolve
+		resolveReferencePlatformConfig = prevPlatform
+	})
+
+	got, err := resolveReferenceForImageOverride(context.Background(), "ghcr.io/buildkite/cleanroom-base/alpine:latest", false)
+	if err != nil {
+		t.Fatalf("resolveReferenceForImageOverride returned error: %v", err)
+	}
+	if want := "ghcr.io/buildkite/cleanroom-base/alpine@sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"; got != want {
+		t.Fatalf("unexpected resolved ref: got %q want %q", got, want)
 	}
 }

--- a/internal/cli/image_resolution_policy_update_test.go
+++ b/internal/cli/image_resolution_policy_update_test.go
@@ -1,0 +1,74 @@
+package cli
+
+import (
+	"context"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+)
+
+func withPolicyResolveDeps(
+	t *testing.T,
+	digestFn func(context.Context, name.Reference) (string, error),
+	platformFn func(context.Context, name.Reference) (string, string, error),
+) {
+	t.Helper()
+	prevDigestFn := resolveRegistryDigestForReference
+	prevPlatformFn := resolveReferencePlatformConfig
+	resolveRegistryDigestForReference = digestFn
+	resolveReferencePlatformConfig = platformFn
+	t.Cleanup(func() {
+		resolveRegistryDigestForReference = prevDigestFn
+		resolveReferencePlatformConfig = prevPlatformFn
+	})
+}
+
+func TestResolveReferenceForPolicyUpdatePreservesRegistryDigest(t *testing.T) {
+	const manifestListDigest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	withPolicyResolveDeps(
+		t,
+		func(_ context.Context, ref name.Reference) (string, error) {
+			if got, want := ref.Context().Name(), "ghcr.io/buildkite/cleanroom-base/alpine"; got != want {
+				t.Fatalf("unexpected image context: got %q want %q", got, want)
+			}
+			return manifestListDigest, nil
+		},
+		func(_ context.Context, _ name.Reference) (string, string, error) {
+			return "linux", runtime.GOARCH, nil
+		},
+	)
+
+	got, err := resolveReferenceForPolicyUpdate(context.Background(), "ghcr.io/buildkite/cleanroom-base/alpine:latest")
+	if err != nil {
+		t.Fatalf("resolveReferenceForPolicyUpdate returned error: %v", err)
+	}
+	if want := "ghcr.io/buildkite/cleanroom-base/alpine@" + manifestListDigest; got != want {
+		t.Fatalf("expected resolver to preserve registry digest: got %q want %q", got, want)
+	}
+}
+
+func TestResolveReferenceForPolicyUpdateRejectsIncompatiblePlatform(t *testing.T) {
+	incompatibleArch := "amd64"
+	if runtime.GOARCH == "amd64" {
+		incompatibleArch = "arm64"
+	}
+	withPolicyResolveDeps(
+		t,
+		func(_ context.Context, _ name.Reference) (string, error) {
+			return "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", nil
+		},
+		func(_ context.Context, _ name.Reference) (string, string, error) {
+			return "linux", incompatibleArch, nil
+		},
+	)
+
+	_, err := resolveReferenceForPolicyUpdate(context.Background(), "ghcr.io/buildkite/cleanroom-base/alpine:latest")
+	if err == nil {
+		t.Fatal("expected incompatible platform error")
+	}
+	if got, want := strings.ToLower(err.Error()), "incompatible"; !strings.Contains(got, want) {
+		t.Fatalf("expected incompatibility error, got %v", err)
+	}
+}

--- a/internal/imagemgr/imagemgr.go
+++ b/internal/imagemgr/imagemgr.go
@@ -202,10 +202,9 @@ func (m *Manager) validateCachedRecordPlatform(ctx context.Context, parsedRef oc
 	}
 	if needsPlatformMetadata(record.OCIConfig) && strings.EqualFold(strings.TrimSpace(record.Source), "registry") {
 		resolvedConfig, err := m.resolveOCIConfigFromRegistry(ctx, parsedRef.Original)
-		if err != nil {
-			return fmt.Errorf("resolve image platform for cached ref %q: %w", parsedRef.Original, err)
+		if err == nil {
+			record.OCIConfig = mergeOCIConfig(record.OCIConfig, resolvedConfig)
 		}
-		record.OCIConfig = mergeOCIConfig(record.OCIConfig, resolvedConfig)
 	}
 	if err := ValidateImagePlatformForHost(record.OCIConfig.OS, record.OCIConfig.Architecture, runtime.GOARCH); err != nil {
 		return fmt.Errorf("image %q platform is incompatible: %w", parsedRef.Original, err)

--- a/internal/imagemgr/imagemgr.go
+++ b/internal/imagemgr/imagemgr.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"sync"
@@ -24,11 +25,14 @@ import (
 const defaultMkfsBinary = "mkfs.ext4"
 
 type OCIConfig struct {
-	Entrypoint []string
-	Cmd        []string
-	Env        []string
-	Workdir    string
-	User       string
+	Entrypoint   []string
+	Cmd          []string
+	Env          []string
+	Workdir      string
+	User         string
+	OS           string
+	Architecture string
+	Variant      string
 }
 
 type Record struct {
@@ -149,6 +153,9 @@ func (m *Manager) Ensure(ctx context.Context, ref string) (EnsureResult, error) 
 	if found {
 		_, statErr := os.Stat(record.RootFSPath)
 		if statErr == nil {
+			if err := m.validateCachedRecordPlatform(ctx, parsedRef, &record); err != nil {
+				return EnsureResult{}, err
+			}
 			record.Ref = parsedRef.Original
 			record.LastUsedAt = now
 			if err := m.upsertRecord(ctx, record); err != nil {
@@ -169,6 +176,9 @@ func (m *Manager) Ensure(ctx context.Context, ref string) (EnsureResult, error) 
 		return EnsureResult{}, err
 	}
 	defer tarStream.Close()
+	if err := ValidateImagePlatformForHost(config.OS, config.Architecture, runtime.GOARCH); err != nil {
+		return EnsureResult{}, fmt.Errorf("image %q platform is incompatible: %w", parsedRef.Original, err)
+	}
 
 	record, err = m.persistFromTarStream(ctx, persistFromTarRequest{
 		Ref:        parsedRef.Original,
@@ -184,6 +194,54 @@ func (m *Manager) Ensure(ctx context.Context, ref string) (EnsureResult, error) 
 	}
 
 	return EnsureResult{Record: record, CacheHit: false}, nil
+}
+
+func (m *Manager) validateCachedRecordPlatform(ctx context.Context, parsedRef ociref.DigestReference, record *Record) error {
+	if record == nil {
+		return nil
+	}
+	if needsPlatformMetadata(record.OCIConfig) && strings.EqualFold(strings.TrimSpace(record.Source), "registry") {
+		resolvedConfig, err := m.resolveOCIConfigFromRegistry(ctx, parsedRef.Original)
+		if err != nil {
+			return fmt.Errorf("resolve image platform for cached ref %q: %w", parsedRef.Original, err)
+		}
+		record.OCIConfig = mergeOCIConfig(record.OCIConfig, resolvedConfig)
+	}
+	if err := ValidateImagePlatformForHost(record.OCIConfig.OS, record.OCIConfig.Architecture, runtime.GOARCH); err != nil {
+		return fmt.Errorf("image %q platform is incompatible: %w", parsedRef.Original, err)
+	}
+	return nil
+}
+
+func (m *Manager) resolveOCIConfigFromRegistry(ctx context.Context, ref string) (OCIConfig, error) {
+	if m == nil || m.pullImage == nil {
+		return OCIConfig{}, fmt.Errorf("image puller is not configured")
+	}
+	stream, config, err := m.pullImage(ctx, ref)
+	if stream != nil {
+		_ = stream.Close()
+	}
+	if err != nil {
+		return OCIConfig{}, err
+	}
+	return config, nil
+}
+
+func needsPlatformMetadata(cfg OCIConfig) bool {
+	return strings.TrimSpace(cfg.OS) == "" || strings.TrimSpace(cfg.Architecture) == ""
+}
+
+func mergeOCIConfig(base, overlay OCIConfig) OCIConfig {
+	if strings.TrimSpace(overlay.OS) != "" {
+		base.OS = overlay.OS
+	}
+	if strings.TrimSpace(overlay.Architecture) != "" {
+		base.Architecture = overlay.Architecture
+	}
+	if strings.TrimSpace(overlay.Variant) != "" {
+		base.Variant = overlay.Variant
+	}
+	return base
 }
 
 func (m *Manager) Pull(ctx context.Context, ref string) (EnsureResult, error) {
@@ -242,7 +300,10 @@ func (m *Manager) List(ctx context.Context) ([]Record, error) {
 			oci_cmd_json,
 			oci_env_json,
 			oci_workdir,
-			oci_user
+			oci_user,
+			oci_os,
+			oci_architecture,
+			oci_variant
 		FROM images
 		ORDER BY last_used_at_unix DESC, created_at_unix DESC, digest ASC
 	`)
@@ -390,12 +451,26 @@ func (m *Manager) initDB(ctx context.Context) error {
 			oci_cmd_json TEXT NOT NULL,
 			oci_env_json TEXT NOT NULL,
 			oci_workdir TEXT NOT NULL,
-			oci_user TEXT NOT NULL
+			oci_user TEXT NOT NULL,
+			oci_os TEXT NOT NULL DEFAULT '',
+			oci_architecture TEXT NOT NULL DEFAULT '',
+			oci_variant TEXT NOT NULL DEFAULT ''
 		);
 		CREATE INDEX IF NOT EXISTS idx_images_ref ON images(ref);
 	`)
 	if err != nil {
 		return fmt.Errorf("initialise image metadata schema: %w", err)
+	}
+	for _, stmt := range []string{
+		`ALTER TABLE images ADD COLUMN oci_os TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE images ADD COLUMN oci_architecture TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE images ADD COLUMN oci_variant TEXT NOT NULL DEFAULT ''`,
+	} {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			if !strings.Contains(strings.ToLower(err.Error()), "duplicate column name") {
+				return fmt.Errorf("migrate image metadata schema: %w", err)
+			}
+		}
 	}
 	return nil
 }
@@ -424,7 +499,10 @@ func (m *Manager) lookupByDigest(ctx context.Context, digest string) (Record, bo
 			oci_cmd_json,
 			oci_env_json,
 			oci_workdir,
-			oci_user
+			oci_user,
+			oci_os,
+			oci_architecture,
+			oci_variant
 		FROM images
 		WHERE digest = ?
 	`, digest)
@@ -491,8 +569,11 @@ func (m *Manager) upsertRecord(ctx context.Context, record Record) error {
 			oci_cmd_json,
 			oci_env_json,
 			oci_workdir,
-			oci_user
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			oci_user,
+			oci_os,
+			oci_architecture,
+			oci_variant
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(digest) DO UPDATE SET
 			ref = excluded.ref,
 			rootfs_path = excluded.rootfs_path,
@@ -504,7 +585,10 @@ func (m *Manager) upsertRecord(ctx context.Context, record Record) error {
 			oci_cmd_json = excluded.oci_cmd_json,
 			oci_env_json = excluded.oci_env_json,
 			oci_workdir = excluded.oci_workdir,
-			oci_user = excluded.oci_user
+			oci_user = excluded.oci_user,
+			oci_os = excluded.oci_os,
+			oci_architecture = excluded.oci_architecture,
+			oci_variant = excluded.oci_variant
 	`,
 		record.Digest,
 		record.Ref,
@@ -518,6 +602,9 @@ func (m *Manager) upsertRecord(ctx context.Context, record Record) error {
 		envJSON,
 		record.OCIConfig.Workdir,
 		record.OCIConfig.User,
+		record.OCIConfig.OS,
+		record.OCIConfig.Architecture,
+		record.OCIConfig.Variant,
 	)
 	if err != nil {
 		return fmt.Errorf("upsert image metadata for %s: %w", record.Digest, err)
@@ -561,7 +648,10 @@ func queryRecordsBySelector(ctx context.Context, db *sql.DB, selector string) ([
 			oci_cmd_json,
 			oci_env_json,
 			oci_workdir,
-			oci_user
+			oci_user,
+			oci_os,
+			oci_architecture,
+			oci_variant
 		FROM images
 		WHERE ref = ?
 	`, selector)
@@ -598,7 +688,10 @@ func queryRecordByDigest(ctx context.Context, db *sql.DB, digest string) (Record
 			oci_cmd_json,
 			oci_env_json,
 			oci_workdir,
-			oci_user
+			oci_user,
+			oci_os,
+			oci_architecture,
+			oci_variant
 		FROM images
 		WHERE digest = ?
 	`, digest)
@@ -639,6 +732,9 @@ func scanRecord(s scanner) (Record, error) {
 		&envJSON,
 		&record.OCIConfig.Workdir,
 		&record.OCIConfig.User,
+		&record.OCIConfig.OS,
+		&record.OCIConfig.Architecture,
+		&record.OCIConfig.Variant,
 	); err != nil {
 		return Record{}, err
 	}

--- a/internal/imagemgr/imagemgr_test.go
+++ b/internal/imagemgr/imagemgr_test.go
@@ -132,6 +132,40 @@ func TestEnsureRejectsIncompatibleImagePlatformFromCache(t *testing.T) {
 	}
 }
 
+func TestEnsureUsesLegacyCacheWhenPlatformBackfillUnavailable(t *testing.T) {
+	t.Parallel()
+
+	manager := newTestManager(t, func(_ context.Context, _ string) (io.ReadCloser, OCIConfig, error) {
+		return nil, OCIConfig{}, errors.New("registry unavailable")
+	})
+	cacheRootFS := filepath.Join(t.TempDir(), "cached.ext4")
+	if err := os.WriteFile(cacheRootFS, []byte("fake-ext4"), 0o644); err != nil {
+		t.Fatalf("write cached rootfs: %v", err)
+	}
+	now := time.Unix(1_700_000_005, 0).UTC()
+	record := Record{
+		Digest:     "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+		Ref:        "ghcr.io/buildkite/cleanroom-base/alpine@sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+		RootFSPath: cacheRootFS,
+		SizeBytes:  int64(len("fake-ext4")),
+		CreatedAt:  now,
+		LastUsedAt: now,
+		Source:     "registry",
+		OCIConfig:  OCIConfig{},
+	}
+	if err := manager.upsertRecord(context.Background(), record); err != nil {
+		t.Fatalf("upsert cached record: %v", err)
+	}
+
+	result, err := manager.Ensure(context.Background(), record.Ref)
+	if err != nil {
+		t.Fatalf("expected Ensure to reuse legacy cache record when platform backfill is unavailable, got %v", err)
+	}
+	if !result.CacheHit {
+		t.Fatal("expected Ensure to return cache hit for existing rootfs artifact")
+	}
+}
+
 func TestImportAndRemoveByDigestSelector(t *testing.T) {
 	t.Parallel()
 

--- a/internal/imagemgr/imagemgr_test.go
+++ b/internal/imagemgr/imagemgr_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -22,9 +23,11 @@ func TestEnsureCachesAndReusesImage(t *testing.T) {
 	manager := newTestManager(t, func(_ context.Context, _ string) (io.ReadCloser, OCIConfig, error) {
 		pulls++
 		return io.NopCloser(bytes.NewReader(testRootFSTar(t))), OCIConfig{
-			Entrypoint: []string{"/bin/sh"},
-			Cmd:        []string{"-lc", "echo hello"},
-			Workdir:    "/workspace",
+			Entrypoint:   []string{"/bin/sh"},
+			Cmd:          []string{"-lc", "echo hello"},
+			Workdir:      "/workspace",
+			OS:           "linux",
+			Architecture: NormalizePlatformArch(runtime.GOARCH),
 		}, nil
 	})
 
@@ -62,6 +65,70 @@ func TestEnsureCachesAndReusesImage(t *testing.T) {
 	}
 	if got, want := items[0].OCIConfig.Workdir, "/workspace"; got != want {
 		t.Fatalf("unexpected OCI workdir: got %q want %q", got, want)
+	}
+}
+
+func TestEnsureRejectsIncompatibleImagePlatformOnPull(t *testing.T) {
+	t.Parallel()
+
+	incompatibleArch := "amd64"
+	if runtime.GOARCH == "amd64" {
+		incompatibleArch = "arm64"
+	}
+
+	manager := newTestManager(t, func(_ context.Context, _ string) (io.ReadCloser, OCIConfig, error) {
+		return io.NopCloser(bytes.NewReader(testRootFSTar(t))), OCIConfig{
+			OS:           "linux",
+			Architecture: incompatibleArch,
+		}, nil
+	})
+
+	_, err := manager.Ensure(context.Background(), testImageRef)
+	if err == nil {
+		t.Fatal("expected Ensure to reject incompatible image platform")
+	}
+	if got, want := strings.ToLower(err.Error()), "incompatible"; !strings.Contains(got, want) {
+		t.Fatalf("expected incompatibility error, got %v", err)
+	}
+}
+
+func TestEnsureRejectsIncompatibleImagePlatformFromCache(t *testing.T) {
+	t.Parallel()
+
+	incompatibleArch := "amd64"
+	if runtime.GOARCH == "amd64" {
+		incompatibleArch = "arm64"
+	}
+
+	manager := newTestManager(t, nil)
+	cacheRootFS := filepath.Join(t.TempDir(), "cached.ext4")
+	if err := os.WriteFile(cacheRootFS, []byte("fake-ext4"), 0o644); err != nil {
+		t.Fatalf("write cached rootfs: %v", err)
+	}
+	now := time.Unix(1_700_000_004, 0).UTC()
+	record := Record{
+		Digest:     "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+		Ref:        "ghcr.io/buildkite/cleanroom-base/alpine@sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+		RootFSPath: cacheRootFS,
+		SizeBytes:  int64(len("fake-ext4")),
+		CreatedAt:  now,
+		LastUsedAt: now,
+		Source:     "registry",
+		OCIConfig: OCIConfig{
+			OS:           "linux",
+			Architecture: incompatibleArch,
+		},
+	}
+	if err := manager.upsertRecord(context.Background(), record); err != nil {
+		t.Fatalf("upsert cached record: %v", err)
+	}
+
+	_, err := manager.Ensure(context.Background(), record.Ref)
+	if err == nil {
+		t.Fatal("expected cached incompatible image platform to be rejected")
+	}
+	if got, want := strings.ToLower(err.Error()), "incompatible"; !strings.Contains(got, want) {
+		t.Fatalf("expected incompatibility error, got %v", err)
 	}
 }
 

--- a/internal/imagemgr/platform.go
+++ b/internal/imagemgr/platform.go
@@ -1,0 +1,50 @@
+package imagemgr
+
+import (
+	"fmt"
+	"strings"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+func HostLinuxPlatformForGOARCH(goarch string) v1.Platform {
+	switch NormalizePlatformArch(goarch) {
+	case "amd64":
+		return v1.Platform{OS: "linux", Architecture: "amd64"}
+	case "arm64":
+		return v1.Platform{OS: "linux", Architecture: "arm64", Variant: "v8"}
+	default:
+		return v1.Platform{OS: "linux", Architecture: strings.TrimSpace(goarch)}
+	}
+}
+
+func ValidateImagePlatformForHost(imageOS, imageArch, hostArch string) error {
+	resolvedOS := strings.TrimSpace(strings.ToLower(imageOS))
+	if resolvedOS == "" {
+		resolvedOS = "linux"
+	}
+	if resolvedOS != "linux" {
+		return fmt.Errorf("image OS %q is unsupported (expected linux)", resolvedOS)
+	}
+
+	resolvedImageArch := NormalizePlatformArch(imageArch)
+	resolvedHostArch := NormalizePlatformArch(hostArch)
+	if resolvedImageArch == "" || resolvedHostArch == "" {
+		return nil
+	}
+	if resolvedImageArch != resolvedHostArch {
+		return fmt.Errorf("image architecture linux/%s is incompatible with host guest architecture linux/%s", resolvedImageArch, resolvedHostArch)
+	}
+	return nil
+}
+
+func NormalizePlatformArch(raw string) string {
+	switch strings.TrimSpace(strings.ToLower(raw)) {
+	case "x86_64":
+		return "amd64"
+	case "aarch64":
+		return "arm64"
+	default:
+		return strings.TrimSpace(strings.ToLower(raw))
+	}
+}

--- a/internal/imagemgr/platform_test.go
+++ b/internal/imagemgr/platform_test.go
@@ -1,0 +1,49 @@
+package imagemgr
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateImagePlatformForHostAcceptsMatchingLinuxArch(t *testing.T) {
+	t.Parallel()
+
+	if err := ValidateImagePlatformForHost("linux", "arm64", "arm64"); err != nil {
+		t.Fatalf("ValidateImagePlatformForHost returned error for matching platform: %v", err)
+	}
+}
+
+func TestValidateImagePlatformForHostNormalizesEquivalentArchitectures(t *testing.T) {
+	t.Parallel()
+
+	if err := ValidateImagePlatformForHost("linux", "x86_64", "amd64"); err != nil {
+		t.Fatalf("ValidateImagePlatformForHost should treat x86_64 and amd64 as equivalent: %v", err)
+	}
+}
+
+func TestValidateImagePlatformForHostRejectsMismatchedArchitecture(t *testing.T) {
+	t.Parallel()
+
+	err := ValidateImagePlatformForHost("linux", "amd64", "arm64")
+	if err == nil {
+		t.Fatal("expected architecture mismatch to be rejected")
+	}
+	if got, want := err.Error(), "linux/amd64"; !strings.Contains(got, want) {
+		t.Fatalf("expected mismatch error to mention image architecture %q, got %q", want, got)
+	}
+	if got, want := err.Error(), "linux/arm64"; !strings.Contains(got, want) {
+		t.Fatalf("expected mismatch error to mention host architecture %q, got %q", want, got)
+	}
+}
+
+func TestValidateImagePlatformForHostRejectsNonLinuxImageOS(t *testing.T) {
+	t.Parallel()
+
+	err := ValidateImagePlatformForHost("windows", "amd64", "amd64")
+	if err == nil {
+		t.Fatal("expected non-linux image OS to be rejected")
+	}
+	if got, want := err.Error(), "unsupported"; !strings.Contains(got, want) {
+		t.Fatalf("expected unsupported OS error, got %q", got)
+	}
+}

--- a/internal/imagemgr/registry.go
+++ b/internal/imagemgr/registry.go
@@ -31,25 +31,17 @@ func pullImageFromRegistry(ctx context.Context, ref string) (io.ReadCloser, OCIC
 	rootFSTar := mutate.Extract(img)
 
 	return rootFSTar, OCIConfig{
-		Entrypoint: append([]string(nil), cfg.Config.Entrypoint...),
-		Cmd:        append([]string(nil), cfg.Config.Cmd...),
-		Env:        append([]string(nil), cfg.Config.Env...),
-		Workdir:    cfg.Config.WorkingDir,
-		User:       cfg.Config.User,
+		Entrypoint:   append([]string(nil), cfg.Config.Entrypoint...),
+		Cmd:          append([]string(nil), cfg.Config.Cmd...),
+		Env:          append([]string(nil), cfg.Config.Env...),
+		Workdir:      cfg.Config.WorkingDir,
+		User:         cfg.Config.User,
+		OS:           cfg.OS,
+		Architecture: cfg.Architecture,
+		Variant:      cfg.Variant,
 	}, nil
 }
 
 func hostLinuxPlatform() v1.Platform {
-	return linuxPlatformForArch(runtime.GOARCH)
-}
-
-func linuxPlatformForArch(goArch string) v1.Platform {
-	switch goArch {
-	case "amd64":
-		return v1.Platform{OS: "linux", Architecture: "amd64"}
-	case "arm64":
-		return v1.Platform{OS: "linux", Architecture: "arm64", Variant: "v8"}
-	default:
-		return v1.Platform{OS: "linux", Architecture: goArch}
-	}
+	return HostLinuxPlatformForGOARCH(runtime.GOARCH)
 }

--- a/internal/imagemgr/registry_test.go
+++ b/internal/imagemgr/registry_test.go
@@ -2,7 +2,7 @@ package imagemgr
 
 import "testing"
 
-func TestLinuxPlatformForArch(t *testing.T) {
+func TestHostLinuxPlatformForGOARCH(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -21,7 +21,7 @@ func TestLinuxPlatformForArch(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			got := linuxPlatformForArch(tc.goArch)
+			got := HostLinuxPlatformForGOARCH(tc.goArch)
 			if got.OS != tc.wantOS {
 				t.Fatalf("unexpected OS: got %q want %q", got.OS, tc.wantOS)
 			}


### PR DESCRIPTION
## Summary
- enforce image platform compatibility checks in `imagemgr` so incompatible architectures fail no matter how image refs are supplied
- persist OCI platform metadata (`os`, `architecture`, `variant`) in image metadata and migrate existing databases safely
- validate platform during CLI tag resolution to fail early before sandbox startup
- keep remote registry errors clean for explicit registry refs without appending local Docker fallback noise

## Testing
- go test ./internal/imagemgr ./internal/cli
- go test ./...
