### PR TITLE
feat(ci): add reproducible CloudFormation Buildkite hosts

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,9 +1,8 @@
 # CI Setup (Buildkite)
 
-This repository uses Buildkite for CI with three queues:
+This repository uses Buildkite for CI with two Linux queues:
 
 - `hosted`: Linux unit/integration tests (`mise run test`)
-- `mac-small`: macOS unit/integration tests (`mise run test`)
 - `cleanroom`: Linux Firecracker end-to-end checks (`scripts/ci-cleanroom-e2e.sh`)
 
 Pipeline config lives in `.buildkite/pipeline.yml`.
@@ -14,7 +13,6 @@ Pipeline config lives in `.buildkite/pipeline.yml`.
 2. Ensure the pipeline reads `.buildkite/pipeline.yml` from the repo.
 3. Ensure all required queues are available:
 - `hosted`
-- `mac-small`
 - `cleanroom`
 
 ## 2. Provision Hosts With CloudFormation
@@ -135,7 +133,7 @@ No extra host setup is needed if you use `infra/cloudformation/ci-hosts.yaml`.
 Notes:
 
 - `mise` is bootstrapped via repository hooks in `.buildkite/hooks/`.
-- Per-step cache is enabled for `hosted` and `mac-small` steps.
+- Per-step cache is enabled for `hosted`.
 - Avoid global pipeline `cache:` blocks if self-hosted queues are present.
 
 ## 4. Cleanroom Queue (Firecracker E2E)
@@ -257,5 +255,5 @@ This prevents collisions with any long-running cleanroom instance on the same ho
 After setup:
 
 1. Trigger a build.
-2. Confirm `:test_tube: Test (Linux)` and `:test_tube: Test (macOS)` pass.
+2. Confirm `:test_tube: Test (Linux)` passes.
 3. Confirm `:fire: E2E (Firecracker)` passes doctor, launch, exec, and observability checks.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -19,15 +19,14 @@ Pipeline config lives in `.buildkite/pipeline.yml`.
 
 ## 2. Provision Hosts With CloudFormation
 
-Use the stack template at `infra/cloudformation/ci-hosts.yaml` to create reproducible Linux + optional EC2 Mac workers.
+Use the stack template at `infra/cloudformation/ci-hosts.yaml` to create a reproducible Linux CI worker.
 
 What the stack provisions:
 
 - dedicated VPC, subnet, IGW, and an egress-only security group (no inbound SSH rule)
 - Linux host via Auto Scaling Group (`desired=1`) for self-healing replacement
-- optional EC2 Mac dedicated host + macOS instance for `mac-small`
 - IAM instance profile with least-privilege access to your Buildkite token in SSM Parameter Store
-- optional Tailscale bootstrap on both hosts (including `tailscale up --ssh`)
+- optional Tailscale bootstrap on Linux (including `tailscale up --ssh`)
 - host bootstrap in user data (Buildkite agent install + queue registration)
 
 ### 2.1 Prerequisites
@@ -52,9 +51,8 @@ aws ssm put-parameter \
   --overwrite
 ```
 
-3. Pick pinned AMI IDs for Linux and macOS in your region.
-4. Choose an Availability Zone that supports your selected EC2 Mac type.
-5. (Recommended) Store a read-only git deploy key in SSM:
+3. Pick a pinned Linux AMI ID in your region.
+4. (Recommended) Store a read-only git deploy key in SSM:
 
 ```bash
 aws ssm put-parameter \
@@ -74,7 +72,6 @@ aws cloudformation deploy \
   --parameter-overrides \
     AvailabilityZone=ap-southeast-2a \
     LinuxAmiId=ami-0123456789abcdef0 \
-    EnableMacHost=false \
     LinuxAsgRollingPauseTime=PT2M \
     BuildkiteTokenParameterName=/buildkite/agent-token \
     GitDeployKeyParameterName=/buildkite/cleanroom/deploy-key \
@@ -90,7 +87,6 @@ aws cloudformation deploy \
 Notes:
 
 - Default Linux instance type is `m8i.large` (nested virtualization) for the `cleanroom` queue.
-- `EnableMacHost=false` keeps Mac resources out of updates while you iterate on Linux/bootstrap.
 - `LinuxAsgRollingPauseTime` controls how long CloudFormation waits after Linux instance replacement.
 - `GitDeployKeyParameterName` installs a host-level `pre-checkout` hook that exports `GIT_SSH_COMMAND` for clone/fetch.
 - TODO(cleanroom-ci): when CloudFormation supports `LaunchTemplateData.CpuOptions.NestedVirtualization`, move nested virtualization enablement out of the post-deploy EC2/ASG workaround and back into `infra/cloudformation/ci-hosts.yaml`.
@@ -98,63 +94,32 @@ Notes:
   - `EnableCleanroomQueue=false`
   - `InstallFirecrackerOnLinux=false`
   - a smaller Linux instance type (for example `c7i.large`)
-- EC2 Mac dedicated hosts are billed with a 24-hour minimum allocation window.
 
-### 2.3 Re-enable macOS after Linux is stable
+### 2.3 Tailscale SSH access
 
-```bash
-aws cloudformation deploy \
-  --template-file infra/cloudformation/ci-hosts.yaml \
-  --stack-name cleanroom-ci \
-  --capabilities CAPABILITY_NAMED_IAM \
-  --parameter-overrides \
-    AvailabilityZone=ap-southeast-2a \
-    LinuxAmiId=ami-0123456789abcdef0 \
-    EnableMacHost=true \
-    LinuxAsgRollingPauseTime=PT5M \
-    MacAmiId=ami-0fedcba9876543210 \
-    MacInstanceType=mac2-m2.metal \
-    BuildkiteTokenParameterName=/buildkite/agent-token \
-    GitDeployKeyParameterName=/buildkite/cleanroom/deploy-key \
-    TailscaleAuthKeyParameterName=/tailscale/authkey/ci \
-    LinuxTailscaleAdvertiseTags='' \
-    TailscaleAdvertiseTags='' \
-    LinuxHostedAgentExtraTags=env=ci,team=platform \
-    LinuxCleanroomAgentExtraTags=env=ci,team=platform,role=firecracker \
-    MacAgentExtraTags=env=ci,team=platform \
-    CleanroomHelperGitRepositoryUrl=git@github.com:buildkite/cleanroom.git \
-    CleanroomHelperGitRef=main
-```
-
-### 2.4 Tailscale SSH access
-
-When `TailscaleAuthKeyParameterName` is set, bootstrap runs `tailscale up` on both hosts with:
+When `TailscaleAuthKeyParameterName` is set, bootstrap runs `tailscale up` on Linux with:
 
 - unique hostnames based on instance ID (`<prefix>-<instance-id>`)
 - `--ssh` enabled by default (set `TailscaleEnableSsh=false` to disable)
-- optional `--advertise-tags` via `TailscaleAdvertiseTags`
+- optional `--advertise-tags` via `LinuxTailscaleAdvertiseTags`
 
 Useful parameters:
 
 - `LinuxTailscaleHostnamePrefix` (default `cleanroom-ci-linux`)
-- `MacTailscaleHostnamePrefix` (default `cleanroom-ci-mac`)
 - `TailscaleAcceptRoutes` (default `false`)
 - `LinuxTailscaleAdvertiseTags` (Linux only)
-- `TailscaleAdvertiseTags` (macOS only)
 
-The stack outputs `LinuxTailscaleSshPattern` when Tailscale is enabled, and `MacTailscaleSshPattern` only when `EnableMacHost=true`.
+The stack outputs `LinuxTailscaleSshPattern` when Tailscale is enabled.
 For Linux, replace `<instance-id>` with the active ASG instance ID.
 
-### 2.5 Buildkite agent tags and config
+### 2.4 Buildkite agent tags and config
 
 The stack writes Buildkite config files on both hosts and supports extra per-agent tags/config:
 
 - `LinuxHostedAgentExtraTags`
 - `LinuxCleanroomAgentExtraTags`
-- `MacAgentExtraTags`
 - `LinuxHostedAgentExtraConfig`
 - `LinuxCleanroomAgentExtraConfig`
-- `MacAgentExtraConfig`
 
 `*ExtraConfig` values are semicolon-separated lines appended to agent config files.
 Example:
@@ -163,7 +128,7 @@ Example:
 priority=5;debug=true;no-command-eval=true
 ```
 
-## 3. Hosted and macOS Queues
+## 3. Hosted Queues
 
 No extra host setup is needed if you use `infra/cloudformation/ci-hosts.yaml`.
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -93,6 +93,7 @@ Notes:
 - `EnableMacHost=false` keeps Mac resources out of updates while you iterate on Linux/bootstrap.
 - `LinuxAsgRollingPauseTime` controls how long CloudFormation waits after Linux instance replacement.
 - `GitDeployKeyParameterName` installs a host-level `pre-checkout` hook that exports `GIT_SSH_COMMAND` for clone/fetch.
+- TODO(cleanroom-ci): when CloudFormation supports `LaunchTemplateData.CpuOptions.NestedVirtualization`, move nested virtualization enablement out of the post-deploy EC2/ASG workaround and back into `infra/cloudformation/ci-hosts.yaml`.
 - If you do not run Firecracker E2E, set:
   - `EnableCleanroomQueue=false`
   - `InstallFirecrackerOnLinux=false`

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -17,9 +17,154 @@ Pipeline config lives in `.buildkite/pipeline.yml`.
 - `mac-small`
 - `cleanroom`
 
-## 2. Hosted and macOS Queues
+## 2. Provision Hosts With CloudFormation
 
-No special setup is required beyond a working Buildkite agent image and internet access.
+Use the stack template at `infra/cloudformation/ci-hosts.yaml` to create reproducible Linux + optional EC2 Mac workers.
+
+What the stack provisions:
+
+- dedicated VPC, subnet, IGW, and an egress-only security group (no inbound SSH rule)
+- Linux host via Auto Scaling Group (`desired=1`) for self-healing replacement
+- optional EC2 Mac dedicated host + macOS instance for `mac-small`
+- IAM instance profile with least-privilege access to your Buildkite token in SSM Parameter Store
+- optional Tailscale bootstrap on both hosts (including `tailscale up --ssh`)
+- host bootstrap in user data (Buildkite agent install + queue registration)
+
+### 2.1 Prerequisites
+
+1. Store your Buildkite agent token in SSM Parameter Store (SecureString):
+
+```bash
+aws ssm put-parameter \
+  --name /buildkite/agent-token \
+  --type SecureString \
+  --value '<BUILDKITE_AGENT_TOKEN>' \
+  --overwrite
+```
+
+2. Store a Tailscale auth key in SSM Parameter Store (SecureString):
+
+```bash
+aws ssm put-parameter \
+  --name /tailscale/authkey/ci \
+  --type SecureString \
+  --value 'tskey-xxxxxxxxxxxxxxxx' \
+  --overwrite
+```
+
+3. Pick pinned AMI IDs for Linux and macOS in your region.
+4. Choose an Availability Zone that supports your selected EC2 Mac type.
+5. (Recommended) Store a read-only git deploy key in SSM:
+
+```bash
+aws ssm put-parameter \
+  --name /buildkite/cleanroom/deploy-key \
+  --type SecureString \
+  --value '<OPENSSH_PRIVATE_KEY>' \
+  --overwrite
+```
+
+### 2.2 Deploy (Linux-first recommended)
+
+```bash
+aws cloudformation deploy \
+  --template-file infra/cloudformation/ci-hosts.yaml \
+  --stack-name cleanroom-ci \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --parameter-overrides \
+    AvailabilityZone=ap-southeast-2a \
+    LinuxAmiId=ami-0123456789abcdef0 \
+    EnableMacHost=false \
+    LinuxAsgRollingPauseTime=PT2M \
+    BuildkiteTokenParameterName=/buildkite/agent-token \
+    GitDeployKeyParameterName=/buildkite/cleanroom/deploy-key \
+    TailscaleAuthKeyParameterName=/tailscale/authkey/ci \
+    LinuxTailscaleAdvertiseTags='' \
+    LinuxHostedAgentExtraTags=env=ci,team=platform \
+    LinuxHostedAgentExtraConfig='priority=5;debug=true' \
+    LinuxCleanroomAgentExtraTags=env=ci,team=platform,role=firecracker \
+    CleanroomHelperGitRepositoryUrl=git@github.com:buildkite/cleanroom.git \
+    CleanroomHelperGitRef=main
+```
+
+Notes:
+
+- Default Linux instance type is `m8i.large` (nested virtualization) for the `cleanroom` queue.
+- `EnableMacHost=false` keeps Mac resources out of updates while you iterate on Linux/bootstrap.
+- `LinuxAsgRollingPauseTime` controls how long CloudFormation waits after Linux instance replacement.
+- `GitDeployKeyParameterName` installs a host-level `pre-checkout` hook that exports `GIT_SSH_COMMAND` for clone/fetch.
+- If you do not run Firecracker E2E, set:
+  - `EnableCleanroomQueue=false`
+  - `InstallFirecrackerOnLinux=false`
+  - a smaller Linux instance type (for example `c7i.large`)
+- EC2 Mac dedicated hosts are billed with a 24-hour minimum allocation window.
+
+### 2.3 Re-enable macOS after Linux is stable
+
+```bash
+aws cloudformation deploy \
+  --template-file infra/cloudformation/ci-hosts.yaml \
+  --stack-name cleanroom-ci \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --parameter-overrides \
+    AvailabilityZone=ap-southeast-2a \
+    LinuxAmiId=ami-0123456789abcdef0 \
+    EnableMacHost=true \
+    LinuxAsgRollingPauseTime=PT5M \
+    MacAmiId=ami-0fedcba9876543210 \
+    MacInstanceType=mac2-m2.metal \
+    BuildkiteTokenParameterName=/buildkite/agent-token \
+    GitDeployKeyParameterName=/buildkite/cleanroom/deploy-key \
+    TailscaleAuthKeyParameterName=/tailscale/authkey/ci \
+    LinuxTailscaleAdvertiseTags='' \
+    TailscaleAdvertiseTags='' \
+    LinuxHostedAgentExtraTags=env=ci,team=platform \
+    LinuxCleanroomAgentExtraTags=env=ci,team=platform,role=firecracker \
+    MacAgentExtraTags=env=ci,team=platform \
+    CleanroomHelperGitRepositoryUrl=git@github.com:buildkite/cleanroom.git \
+    CleanroomHelperGitRef=main
+```
+
+### 2.4 Tailscale SSH access
+
+When `TailscaleAuthKeyParameterName` is set, bootstrap runs `tailscale up` on both hosts with:
+
+- unique hostnames based on instance ID (`<prefix>-<instance-id>`)
+- `--ssh` enabled by default (set `TailscaleEnableSsh=false` to disable)
+- optional `--advertise-tags` via `TailscaleAdvertiseTags`
+
+Useful parameters:
+
+- `LinuxTailscaleHostnamePrefix` (default `cleanroom-ci-linux`)
+- `MacTailscaleHostnamePrefix` (default `cleanroom-ci-mac`)
+- `TailscaleAcceptRoutes` (default `false`)
+- `LinuxTailscaleAdvertiseTags` (Linux only)
+- `TailscaleAdvertiseTags` (macOS only)
+
+The stack outputs `LinuxTailscaleSshPattern` when Tailscale is enabled, and `MacTailscaleSshPattern` only when `EnableMacHost=true`.
+For Linux, replace `<instance-id>` with the active ASG instance ID.
+
+### 2.5 Buildkite agent tags and config
+
+The stack writes Buildkite config files on both hosts and supports extra per-agent tags/config:
+
+- `LinuxHostedAgentExtraTags`
+- `LinuxCleanroomAgentExtraTags`
+- `MacAgentExtraTags`
+- `LinuxHostedAgentExtraConfig`
+- `LinuxCleanroomAgentExtraConfig`
+- `MacAgentExtraConfig`
+
+`*ExtraConfig` values are semicolon-separated lines appended to agent config files.
+Example:
+
+```text
+priority=5;debug=true;no-command-eval=true
+```
+
+## 3. Hosted and macOS Queues
+
+No extra host setup is needed if you use `infra/cloudformation/ci-hosts.yaml`.
 
 Notes:
 
@@ -27,11 +172,11 @@ Notes:
 - Per-step cache is enabled for `hosted` and `mac-small` steps.
 - Avoid global pipeline `cache:` blocks if self-hosted queues are present.
 
-## 3. Cleanroom Queue (Firecracker E2E)
+## 4. Cleanroom Queue (Firecracker E2E)
 
 The `:fire: E2E (Firecracker)` step runs a real launched Firecracker execution and needs host preparation.
 
-### 3.1 Required host capabilities
+### 4.1 Required host capabilities
 
 - Linux host with `/dev/kvm` available
 - Firecracker binary (default `/usr/local/bin/firecracker`)
@@ -40,7 +185,7 @@ The `:fire: E2E (Firecracker)` step runs a real launched Firecracker execution a
 - `mkfs.ext4` available for OCI-to-ext4 materialization
 - Passwordless sudo for required network setup commands
 
-### 3.2 Place runtime kernel image
+### 4.2 Place runtime kernel image
 
 Put kernel assets under the Buildkite agent home so CI can read them:
 
@@ -57,7 +202,7 @@ The pipeline is currently configured to use:
 - `CLEANROOM_KERNEL_IMAGE=/var/lib/buildkite-agent/.local/share/cleanroom/images/vmlinux.bin`
 - `CLEANROOM_FIRECRACKER_BINARY=/usr/local/bin/firecracker`
 
-### 3.3 Privileged command execution modes
+### 4.3 Privileged command execution modes
 
 Firecracker backend supports two modes:
 
@@ -106,7 +251,24 @@ Then set:
 - `CLEANROOM_PRIVILEGED_MODE=helper`
 - `CLEANROOM_PRIVILEGED_HELPER_PATH=/usr/local/sbin/cleanroom-root-helper`
 
-## 4. Optional Agent Environment Hook
+When using `infra/cloudformation/ci-hosts.yaml` with `EnableCleanroomQueue=true`, the Linux bootstrap:
+
+- starts a dedicated Buildkite agent process for the cleanroom queue
+- configures `helper` mode via agent environment
+- installs `/usr/local/sbin/refresh-cleanroom-helper` and downloads `/usr/local/sbin/cleanroom-root-helper` from git at host boot
+- defaults to `CleanroomHelperGitRepositoryUrl=git@github.com:buildkite/cleanroom.git` and `CleanroomHelperGitRef=main`
+- uses sudoers allowlist for `/usr/bin/install ... /usr/local/sbin/cleanroom-root-helper`
+
+You can refresh helper on demand with SSM:
+
+```bash
+aws ssm send-command \
+  --document-name AWS-RunShellScript \
+  --targets "Key=tag:Name,Values=cleanroom-ci-linux" \
+  --parameters commands='["sudo /usr/local/sbin/refresh-cleanroom-helper"]'
+```
+
+## 5. Optional Agent Environment Hook
 
 If you prefer host-level env over pipeline step env, set variables in `/etc/buildkite-agent/hooks/environment`.
 
@@ -118,13 +280,13 @@ export CLEANROOM_KERNEL_IMAGE="/var/lib/buildkite-agent/.local/share/cleanroom/i
 export CLEANROOM_FIRECRACKER_BINARY="/usr/local/bin/firecracker"
 ```
 
-## 5. Collision Safety
+## 6. Collision Safety
 
 `scripts/ci-cleanroom-e2e.sh` isolates CI runtime paths using temporary XDG directories (`XDG_CONFIG_HOME`, `XDG_STATE_HOME`, `XDG_RUNTIME_DIR`, `XDG_DATA_HOME`) and a job-local unix socket.
 
 This prevents collisions with any long-running cleanroom instance on the same host.
 
-## 6. Verification
+## 7. Verification
 
 After setup:
 

--- a/infra/cloudformation/ci-hosts.yaml
+++ b/infra/cloudformation/ci-hosts.yaml
@@ -432,7 +432,7 @@ Resources:
                 if [ "$agent_arch" = 'arm64' ]; then
                   ts_arch='arm64'
                 fi
-                ts_url="https://pkgs.tailscale.com/stable/tailscale_${!TAILSCALE_VERSION}_$ts_arch.tgz"
+                ts_url="https://pkgs.tailscale.com/stable/tailscale_${TAILSCALE_VERSION}_$ts_arch.tgz"
                 ts_tmp_dir="$(mktemp -d)"
                 curl -fsSL "$ts_url" -o "$ts_tmp_dir/tailscale.tgz"
                 tar -xzf "$ts_tmp_dir/tailscale.tgz" -C "$ts_tmp_dir"

--- a/infra/cloudformation/ci-hosts.yaml
+++ b/infra/cloudformation/ci-hosts.yaml
@@ -1,0 +1,881 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  Buildkite CI hosts for cleanroom: one Linux host and an optional EC2 Mac host.
+  The stack is reproducible (CloudFormation + user data bootstrap) and avoids
+  storing long-lived host state by hand.
+
+Parameters:
+  AvailabilityZone:
+    Type: AWS::EC2::AvailabilityZone::Name
+    Description: Availability Zone used for both Linux and EC2 Mac hosts.
+  VpcCidr:
+    Type: String
+    Default: 10.42.0.0/24
+    Description: CIDR block for the CI VPC.
+  SubnetCidr:
+    Type: String
+    Default: 10.42.0.0/25
+    Description: CIDR block for the public subnet.
+  LinuxAmiId:
+    Type: AWS::EC2::Image::Id
+    Description: Linux AMI ID for the CI host.
+  LinuxInstanceType:
+    Type: String
+    Default: m8i.large
+    Description: Linux instance type. Choose an instance type with nested virtualization support when enabling cleanroom queue.
+  LinuxRootVolumeSizeGiB:
+    Type: Number
+    Default: 150
+    MinValue: 20
+    Description: Root volume size for the Linux host.
+  LinuxAsgRollingPauseTime:
+    Type: String
+    Default: PT5M
+    Description: ISO-8601 pause after Linux ASG replacement batch (for example PT2M, PT5M, PT10M).
+  LinuxHostedQueueName:
+    Type: String
+    Default: hosted
+    Description: Buildkite queue name for regular Linux tests.
+  EnableCleanroomQueue:
+    Type: String
+    Default: "true"
+    AllowedValues:
+      - "true"
+      - "false"
+    Description: Run a second Buildkite agent on Linux for the cleanroom queue.
+  LinuxCleanroomQueueName:
+    Type: String
+    Default: cleanroom
+    Description: Buildkite queue name for Firecracker cleanroom tests.
+  InstallFirecrackerOnLinux:
+    Type: String
+    Default: "true"
+    AllowedValues:
+      - "true"
+      - "false"
+    Description: Install Firecracker binary and kernel image on Linux host.
+  FirecrackerVersion:
+    Type: String
+    Default: 1.14.2
+    Description: Firecracker version without leading v.
+  LinuxKernelImageUrl:
+    Type: String
+    Default: https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/x86_64/kernels/vmlinux.bin
+    Description: Kernel image URL saved to /var/lib/buildkite-agent/.local/share/cleanroom/images/vmlinux.bin.
+  CleanroomHelperGitRepositoryUrl:
+    Type: String
+    Default: git@github.com:buildkite/cleanroom.git
+    Description: Git repository URL used to fetch scripts/cleanroom-root-helper.sh.
+  CleanroomHelperGitRef:
+    Type: String
+    Default: main
+    Description: Git ref used to fetch scripts/cleanroom-root-helper.sh.
+  EnableMacHost:
+    Type: String
+    Default: "true"
+    AllowedValues:
+      - "true"
+      - "false"
+    Description: Create the EC2 Mac dedicated host and macOS instance.
+  MacAmiId:
+    Type: String
+    Default: ""
+    AllowedPattern: '^$|ami-[0-9a-fA-F]{8,17}$'
+    Description: macOS AMI ID for the EC2 Mac host (required when EnableMacHost=true).
+  MacInstanceType:
+    Type: String
+    Default: mac2.metal
+    Description: EC2 Mac instance type available in the selected AZ.
+  MacRootVolumeSizeGiB:
+    Type: Number
+    Default: 200
+    MinValue: 100
+    Description: Root volume size for the macOS host.
+  MacQueueName:
+    Type: String
+    Default: mac-small
+    Description: Buildkite queue name for macOS tests.
+  MacAgentUser:
+    Type: String
+    Default: ec2-user
+    Description: Local macOS user that runs buildkite-agent.
+  BuildkiteAgentVersion:
+    Type: String
+    Default: 3.119.1
+    Description: Buildkite agent version without leading v.
+  BuildkiteTokenParameterName:
+    Type: AWS::SSM::Parameter::Name
+    Description: SSM SecureString parameter that stores the Buildkite agent token.
+  GitDeployKeyParameterName:
+    Type: String
+    Default: ""
+    Description: Optional SSM SecureString parameter that stores an SSH private key used for git checkout.
+  LinuxHostedAgentExtraTags:
+    Type: String
+    Default: ""
+    Description: Extra comma-separated Buildkite tags appended to Linux hosted agent tags.
+  LinuxHostedAgentExtraConfig:
+    Type: String
+    Default: ""
+    Description: Extra Linux hosted agent config lines separated by semicolons (example key="value";debug=true).
+  LinuxCleanroomAgentExtraTags:
+    Type: String
+    Default: ""
+    Description: Extra comma-separated Buildkite tags appended to Linux cleanroom agent tags.
+  LinuxCleanroomAgentExtraConfig:
+    Type: String
+    Default: ""
+    Description: Extra Linux cleanroom agent config lines separated by semicolons.
+  MacAgentExtraTags:
+    Type: String
+    Default: ""
+    Description: Extra comma-separated Buildkite tags appended to macOS agent tags.
+  MacAgentExtraConfig:
+    Type: String
+    Default: ""
+    Description: Extra macOS agent config lines separated by semicolons.
+  TailscaleAuthKeyParameterName:
+    Type: String
+    Default: ""
+    Description: Optional SSM SecureString parameter that stores a Tailscale auth key. Leave blank to skip Tailscale bootstrap.
+  TailscaleVersion:
+    Type: String
+    Default: 1.82.5
+    Description: Tailscale version for host bootstrap.
+  LinuxTailscaleAdvertiseTags:
+    Type: String
+    Default: ""
+    Description: Optional comma-separated tag list passed as --advertise-tags on Linux only.
+  TailscaleAdvertiseTags:
+    Type: String
+    Default: ""
+    Description: Optional comma-separated tag list passed as --advertise-tags on macOS.
+  TailscaleEnableSsh:
+    Type: String
+    Default: "true"
+    AllowedValues:
+      - "true"
+      - "false"
+    Description: Enable Tailscale SSH during tailscale up.
+  TailscaleAcceptRoutes:
+    Type: String
+    Default: "false"
+    AllowedValues:
+      - "true"
+      - "false"
+    Description: Enable --accept-routes during tailscale up.
+  LinuxTailscaleHostnamePrefix:
+    Type: String
+    Default: cleanroom-ci-linux
+    Description: Prefix for Linux host Tailscale hostname (<prefix>-<instance-id>).
+  MacTailscaleHostnamePrefix:
+    Type: String
+    Default: cleanroom-ci-mac
+    Description: Prefix for macOS host Tailscale hostname (<prefix>-<instance-id>).
+  ResourceNamePrefix:
+    Type: String
+    Default: cleanroom-ci
+    Description: Prefix used in Name tags.
+
+Rules:
+  RequireMacAmiWhenEnabled:
+    RuleCondition: !Equals [!Ref EnableMacHost, "true"]
+    Assertions:
+      - Assert: !Not [!Equals [!Ref MacAmiId, ""]]
+        AssertDescription: MacAmiId must be set when EnableMacHost=true.
+
+Conditions:
+  UseTailscale: !Not [!Equals [!Ref TailscaleAuthKeyParameterName, ""]]
+  UseGitDeployKey: !Not [!Equals [!Ref GitDeployKeyParameterName, ""]]
+  EnableMac: !Equals [!Ref EnableMacHost, "true"]
+  UseTailscaleOnMac: !And
+    - !Condition UseTailscale
+    - !Condition EnableMac
+
+Resources:
+  CiVpc:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: !Ref VpcCidr
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
+      Tags:
+        - Key: Name
+          Value: !Sub ${ResourceNamePrefix}-vpc
+
+  CiInternetGateway:
+    Type: AWS::EC2::InternetGateway
+    Properties:
+      Tags:
+        - Key: Name
+          Value: !Sub ${ResourceNamePrefix}-igw
+
+  CiVpcIgwAttachment:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      InternetGatewayId: !Ref CiInternetGateway
+      VpcId: !Ref CiVpc
+
+  CiPublicSubnet:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref CiVpc
+      AvailabilityZone: !Ref AvailabilityZone
+      CidrBlock: !Ref SubnetCidr
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: Name
+          Value: !Sub ${ResourceNamePrefix}-public
+
+  CiPublicRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref CiVpc
+      Tags:
+        - Key: Name
+          Value: !Sub ${ResourceNamePrefix}-public
+
+  CiDefaultRoute:
+    Type: AWS::EC2::Route
+    DependsOn: CiVpcIgwAttachment
+    Properties:
+      RouteTableId: !Ref CiPublicRouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref CiInternetGateway
+
+  CiPublicSubnetRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref CiPublicRouteTable
+      SubnetId: !Ref CiPublicSubnet
+
+  CiSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Egress-only security group for Buildkite CI hosts.
+      VpcId: !Ref CiVpc
+      SecurityGroupEgress:
+        - IpProtocol: -1
+          CidrIp: 0.0.0.0/0
+      Tags:
+        - Key: Name
+          Value: !Sub ${ResourceNamePrefix}-egress-only
+
+  CiAgentRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ec2.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore
+      Policies:
+        - PolicyName: read-ci-bootstrap-secrets
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Sid: ReadBuildkiteToken
+                Effect: Allow
+                Action:
+                  - ssm:GetParameter
+                Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter${BuildkiteTokenParameterName}
+              - !If
+                - UseGitDeployKey
+                - Sid: ReadGitDeployKey
+                  Effect: Allow
+                  Action:
+                    - ssm:GetParameter
+                  Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter${GitDeployKeyParameterName}
+                - !Ref AWS::NoValue
+              - !If
+                - UseTailscale
+                - Sid: ReadTailscaleAuthKey
+                  Effect: Allow
+                  Action:
+                    - ssm:GetParameter
+                  Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter${TailscaleAuthKeyParameterName}
+                - !Ref AWS::NoValue
+              - Sid: DecryptSsmSecureString
+                Effect: Allow
+                Action:
+                  - kms:Decrypt
+                Resource: "*"
+                Condition:
+                  StringEquals:
+                    kms:CallerAccount: !Sub ${AWS::AccountId}
+                  StringLike:
+                    kms:ViaService: !Sub ssm.${AWS::Region}.amazonaws.com
+
+  CiAgentInstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Roles:
+        - !Ref CiAgentRole
+
+  LinuxLaunchTemplate:
+    Type: AWS::EC2::LaunchTemplate
+    Properties:
+      LaunchTemplateData:
+        ImageId: !Ref LinuxAmiId
+        InstanceType: !Ref LinuxInstanceType
+        IamInstanceProfile:
+          Arn: !GetAtt CiAgentInstanceProfile.Arn
+        MetadataOptions:
+          HttpEndpoint: enabled
+          HttpTokens: required
+        NetworkInterfaces:
+          - DeviceIndex: 0
+            AssociatePublicIpAddress: true
+            Groups:
+              - !Ref CiSecurityGroup
+        BlockDeviceMappings:
+          - DeviceName: /dev/xvda
+            Ebs:
+              DeleteOnTermination: true
+              Encrypted: true
+              VolumeSize: !Ref LinuxRootVolumeSizeGiB
+              VolumeType: gp3
+        TagSpecifications:
+          - ResourceType: instance
+            Tags:
+              - Key: Name
+                Value: !Sub ${ResourceNamePrefix}-linux
+          - ResourceType: volume
+            Tags:
+              - Key: Name
+                Value: !Sub ${ResourceNamePrefix}-linux-root
+        UserData:
+          Fn::Base64:
+            !Sub |
+              #!/bin/bash
+              set -euxo pipefail
+              exec > >(tee /var/log/user-data.log | logger -t user-data -s 2>/dev/console) 2>&1
+
+              BUILDKITE_TOKEN_PARAM='${BuildkiteTokenParameterName}'
+              GIT_DEPLOY_KEY_PARAM='${GitDeployKeyParameterName}'
+              AGENT_VERSION='${BuildkiteAgentVersion}'
+              HOSTED_QUEUE='${LinuxHostedQueueName}'
+              HOSTED_EXTRA_TAGS='${LinuxHostedAgentExtraTags}'
+              HOSTED_EXTRA_CONFIG='${LinuxHostedAgentExtraConfig}'
+              CLEANROOM_QUEUE='${LinuxCleanroomQueueName}'
+              CLEANROOM_EXTRA_TAGS='${LinuxCleanroomAgentExtraTags}'
+              CLEANROOM_EXTRA_CONFIG='${LinuxCleanroomAgentExtraConfig}'
+              ENABLE_CLEANROOM='${EnableCleanroomQueue}'
+              INSTALL_FIRECRACKER='${InstallFirecrackerOnLinux}'
+              FIRECRACKER_VERSION='${FirecrackerVersion}'
+              KERNEL_URL='${LinuxKernelImageUrl}'
+              HELPER_GIT_REPO='${CleanroomHelperGitRepositoryUrl}'
+              HELPER_GIT_REF='${CleanroomHelperGitRef}'
+              TAILSCALE_PARAM='${TailscaleAuthKeyParameterName}'
+              TAILSCALE_VERSION='${TailscaleVersion}'
+              TAILSCALE_TAGS='${LinuxTailscaleAdvertiseTags}'
+              TAILSCALE_SSH='${TailscaleEnableSsh}'
+              TAILSCALE_ACCEPT_ROUTES='${TailscaleAcceptRoutes}'
+              TAILSCALE_HOSTNAME_PREFIX='${LinuxTailscaleHostnamePrefix}'
+              STACK_NAME='${AWS::StackName}'
+              REGION='${AWS::Region}'
+
+              install_packages() {
+                if command -v dnf >/dev/null 2>&1; then
+                  dnf install -y --allowerasing awscli curl-minimal git jq tar gzip unzip sudo iproute iptables e2fsprogs shadow-utils
+                  return
+                fi
+                if command -v yum >/dev/null 2>&1; then
+                  yum install -y awscli curl git jq tar gzip unzip sudo iproute iptables e2fsprogs shadow-utils
+                  return
+                fi
+                if command -v apt-get >/dev/null 2>&1; then
+                  export DEBIAN_FRONTEND=noninteractive
+                  apt-get update
+                  apt-get install -y awscli ca-certificates curl git jq tar gzip unzip sudo iproute2 iptables e2fsprogs
+                  return
+                fi
+                echo "Unsupported package manager" >&2
+                exit 1
+              }
+
+              install_packages
+
+              if ! id buildkite-agent >/dev/null 2>&1; then
+                useradd --system --create-home --home-dir /var/lib/buildkite-agent --shell /bin/bash buildkite-agent
+              fi
+              install -d -o buildkite-agent -g buildkite-agent -m 0700 /var/lib/buildkite-agent/.ssh
+              install -d -o buildkite-agent -g buildkite-agent -m 0755 /var/lib/buildkite-agent/builds
+              install -d -o buildkite-agent -g buildkite-agent -m 0755 /var/lib/buildkite-agent/hooks
+              install -d -o buildkite-agent -g buildkite-agent -m 0755 /var/lib/buildkite-agent/plugins
+              install -d -o root -g root -m 0755 /etc/buildkite-agent
+
+              arch_name="$(uname -m)"
+              agent_arch='amd64'
+              firecracker_arch='x86_64'
+              if [ "$arch_name" = 'aarch64' ] || [ "$arch_name" = 'arm64' ]; then
+                agent_arch='arm64'
+                firecracker_arch='aarch64'
+              fi
+
+              agent_url="https://github.com/buildkite/agent/releases/download/v$AGENT_VERSION/buildkite-agent-linux-$agent_arch-$AGENT_VERSION.tar.gz"
+              curl -fsSL "$agent_url" -o /tmp/buildkite-agent.tar.gz
+              tar -xzf /tmp/buildkite-agent.tar.gz -C /tmp
+              install -o root -g root -m 0755 /tmp/buildkite-agent /usr/local/bin/buildkite-agent
+
+              imds_token="$(curl -fsS -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")"
+              instance_id="$(curl -fsS -H "X-aws-ec2-metadata-token: $imds_token" http://169.254.169.254/latest/meta-data/instance-id)"
+              agent_token="$(aws ssm get-parameter --name "$BUILDKITE_TOKEN_PARAM" --with-decryption --query Parameter.Value --output text --region "$REGION")"
+
+              if [ -n "$TAILSCALE_PARAM" ]; then
+                tailscale_auth_key="$(aws ssm get-parameter --name "$TAILSCALE_PARAM" --with-decryption --query Parameter.Value --output text --region "$REGION")"
+                ts_arch='amd64'
+                if [ "$agent_arch" = 'arm64' ]; then
+                  ts_arch='arm64'
+                fi
+                ts_url="https://pkgs.tailscale.com/stable/tailscale_${!TAILSCALE_VERSION}_$ts_arch.tgz"
+                ts_tmp_dir="$(mktemp -d)"
+                curl -fsSL "$ts_url" -o "$ts_tmp_dir/tailscale.tgz"
+                tar -xzf "$ts_tmp_dir/tailscale.tgz" -C "$ts_tmp_dir"
+                ts_extract_dir="$(find "$ts_tmp_dir" -maxdepth 1 -type d -name "tailscale_*" | head -n 1)"
+                install -o root -g root -m 0755 "$ts_extract_dir/tailscale" /usr/local/bin/tailscale
+                install -o root -g root -m 0755 "$ts_extract_dir/tailscaled" /usr/local/bin/tailscaled
+                install -d -o root -g root -m 0755 /var/lib/tailscale
+                cat > /etc/systemd/system/tailscaled.service <<'TAILSCALE_UNIT'
+              [Unit]
+              Description=Tailscale node agent
+              Wants=network-online.target
+              After=network-online.target
+
+              [Service]
+              Type=simple
+              RuntimeDirectory=tailscale
+              ExecStart=/usr/local/bin/tailscaled --state=/var/lib/tailscale/tailscaled.state --socket=/run/tailscale/tailscaled.sock
+              Restart=on-failure
+
+              [Install]
+              WantedBy=multi-user.target
+              TAILSCALE_UNIT
+                rm -rf "$ts_tmp_dir"
+                systemctl daemon-reload
+                systemctl enable --now tailscaled
+
+                tailscale_hostname="$TAILSCALE_HOSTNAME_PREFIX-$instance_id"
+                set -- up --auth-key "$tailscale_auth_key" --hostname "$tailscale_hostname"
+                if [ "$TAILSCALE_SSH" = 'true' ]; then
+                  set -- "$@" --ssh
+                fi
+                if [ "$TAILSCALE_ACCEPT_ROUTES" = 'true' ]; then
+                  set -- "$@" --accept-routes
+                fi
+                if [ -n "$TAILSCALE_TAGS" ]; then
+                  set -- "$@" --advertise-tags "$TAILSCALE_TAGS"
+                fi
+                /usr/local/bin/tailscale "$@"
+              fi
+
+              if [ -n "$GIT_DEPLOY_KEY_PARAM" ]; then
+                aws ssm get-parameter --name "$GIT_DEPLOY_KEY_PARAM" --with-decryption --query Parameter.Value --output text --region "$REGION" > /var/lib/buildkite-agent/.ssh/cleanroom_deploy_key
+                ssh-keyscan github.com > /var/lib/buildkite-agent/.ssh/known_hosts 2>/dev/null
+                chown buildkite-agent:buildkite-agent /var/lib/buildkite-agent/.ssh/cleanroom_deploy_key /var/lib/buildkite-agent/.ssh/known_hosts
+                chmod 0600 /var/lib/buildkite-agent/.ssh/cleanroom_deploy_key /var/lib/buildkite-agent/.ssh/known_hosts
+
+                cat > /var/lib/buildkite-agent/hooks/pre-checkout <<'HOOK'
+              #!/usr/bin/env bash
+              set -euo pipefail
+              export GIT_SSH_COMMAND='ssh -i /var/lib/buildkite-agent/.ssh/cleanroom_deploy_key -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=/var/lib/buildkite-agent/.ssh/known_hosts'
+              HOOK
+                chown buildkite-agent:buildkite-agent /var/lib/buildkite-agent/hooks/pre-checkout
+                chmod 0755 /var/lib/buildkite-agent/hooks/pre-checkout
+              fi
+
+              cat > /etc/systemd/system/buildkite-agent@.service <<'UNIT'
+              [Unit]
+              Description=Buildkite Agent (%i)
+              After=network-online.target
+              Wants=network-online.target
+
+              [Service]
+              Type=simple
+              User=buildkite-agent
+              Group=buildkite-agent
+              Environment=HOME=/var/lib/buildkite-agent
+              ExecStart=/usr/local/bin/buildkite-agent start --config /etc/buildkite-agent/%i.cfg
+              Restart=always
+              RestartSec=5
+              KillSignal=SIGTERM
+              TimeoutStopSec=30
+
+              [Install]
+              WantedBy=multi-user.target
+              UNIT
+
+              hosted_tags="queue=$HOSTED_QUEUE,stack=$STACK_NAME,host=$instance_id,os=linux"
+              if [ -n "$HOSTED_EXTRA_TAGS" ]; then
+                hosted_tags="$hosted_tags,$HOSTED_EXTRA_TAGS"
+              fi
+              cat > "/etc/buildkite-agent/$HOSTED_QUEUE.cfg" <<CFG
+              token="$agent_token"
+              name="$STACK_NAME-$instance_id-$HOSTED_QUEUE"
+              tags="$hosted_tags"
+              build-path="/var/lib/buildkite-agent/builds"
+              hooks-path="/var/lib/buildkite-agent/hooks"
+              plugins-path="/var/lib/buildkite-agent/plugins"
+              CFG
+              if [ -n "$HOSTED_EXTRA_CONFIG" ]; then
+                printf '%s\n' "$HOSTED_EXTRA_CONFIG" | tr ';' '\n' >> "/etc/buildkite-agent/$HOSTED_QUEUE.cfg"
+              fi
+              chown root:buildkite-agent "/etc/buildkite-agent/$HOSTED_QUEUE.cfg"
+              chmod 0640 "/etc/buildkite-agent/$HOSTED_QUEUE.cfg"
+
+              if [ "$ENABLE_CLEANROOM" = 'true' ]; then
+                cleanroom_tags="queue=$CLEANROOM_QUEUE,stack=$STACK_NAME,host=$instance_id,os=linux,role=cleanroom"
+                if [ -n "$CLEANROOM_EXTRA_TAGS" ]; then
+                  cleanroom_tags="$cleanroom_tags,$CLEANROOM_EXTRA_TAGS"
+                fi
+                cat > "/etc/buildkite-agent/$CLEANROOM_QUEUE.cfg" <<CFG
+              token="$agent_token"
+              name="$STACK_NAME-$instance_id-$CLEANROOM_QUEUE"
+              tags="$cleanroom_tags"
+              build-path="/var/lib/buildkite-agent/builds"
+              hooks-path="/var/lib/buildkite-agent/hooks"
+              plugins-path="/var/lib/buildkite-agent/plugins"
+              environment=["CLEANROOM_PRIVILEGED_MODE=helper","CLEANROOM_PRIVILEGED_HELPER_PATH=/usr/local/sbin/cleanroom-root-helper"]
+              CFG
+                if [ -n "$CLEANROOM_EXTRA_CONFIG" ]; then
+                  printf '%s\n' "$CLEANROOM_EXTRA_CONFIG" | tr ';' '\n' >> "/etc/buildkite-agent/$CLEANROOM_QUEUE.cfg"
+                fi
+                chown root:buildkite-agent "/etc/buildkite-agent/$CLEANROOM_QUEUE.cfg"
+                chmod 0640 "/etc/buildkite-agent/$CLEANROOM_QUEUE.cfg"
+
+                if [ "$INSTALL_FIRECRACKER" = 'true' ]; then
+                  firecracker_url="https://github.com/firecracker-microvm/firecracker/releases/download/v$FIRECRACKER_VERSION/firecracker-v$FIRECRACKER_VERSION-$firecracker_arch.tgz"
+                  tmp_fc_dir="$(mktemp -d)"
+                  curl -fsSL "$firecracker_url" -o "$tmp_fc_dir/firecracker.tgz"
+                  tar -xzf "$tmp_fc_dir/firecracker.tgz" -C "$tmp_fc_dir"
+                  firecracker_bin="$(find "$tmp_fc_dir" -type f -name "firecracker-v$FIRECRACKER_VERSION-$firecracker_arch" | head -n 1)"
+                  install -o root -g root -m 0755 "$firecracker_bin" /usr/local/bin/firecracker
+                  rm -rf "$tmp_fc_dir"
+                fi
+
+                install -d -o buildkite-agent -g buildkite-agent -m 0755 /var/lib/buildkite-agent/.local/share/cleanroom/images
+                curl -fsSL "$KERNEL_URL" -o /var/lib/buildkite-agent/.local/share/cleanroom/images/vmlinux.bin
+                chown buildkite-agent:buildkite-agent /var/lib/buildkite-agent/.local/share/cleanroom/images/vmlinux.bin
+                chmod 0644 /var/lib/buildkite-agent/.local/share/cleanroom/images/vmlinux.bin
+
+                cat > /etc/sudoers.d/buildkite-cleanroom <<'SUDOERS'
+              buildkite-agent ALL=(root) NOPASSWD: /usr/local/sbin/cleanroom-root-helper *
+              buildkite-agent ALL=(root) NOPASSWD: /usr/bin/install -o root -g root -m 0755 * /usr/local/sbin/cleanroom-root-helper
+              SUDOERS
+                chmod 0440 /etc/sudoers.d/buildkite-cleanroom
+
+                cat > /usr/local/sbin/refresh-cleanroom-helper <<REFRESH_HELPER
+              #!/usr/bin/env bash
+              set -euo pipefail
+
+              repo_url="$HELPER_GIT_REPO"
+              repo_ref="$HELPER_GIT_REF"
+              helper_rel="scripts/cleanroom-root-helper.sh"
+              helper_target="/usr/local/sbin/cleanroom-root-helper"
+              ssh_key="/var/lib/buildkite-agent/.ssh/cleanroom_deploy_key"
+              known_hosts="/var/lib/buildkite-agent/.ssh/known_hosts"
+
+              tmp_dir="\$(mktemp -d)"
+              tmp_helper="\$(mktemp)"
+              trap 'rm -rf "\$tmp_dir" "\$tmp_helper"' EXIT
+
+              if [ -f "\$ssh_key" ]; then
+                export GIT_SSH_COMMAND="ssh -i \$ssh_key -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=\$known_hosts"
+              fi
+
+              git -c init.defaultBranch=main init "\$tmp_dir/repo" >/dev/null 2>&1
+              git -C "\$tmp_dir/repo" remote add origin "\$repo_url"
+              git -C "\$tmp_dir/repo" fetch --depth=1 origin "\$repo_ref"
+              git -C "\$tmp_dir/repo" show "FETCH_HEAD:\$helper_rel" > "\$tmp_helper"
+              chmod 0755 "\$tmp_helper"
+              install -o root -g root -m 0755 "\$tmp_helper" "\$helper_target"
+              REFRESH_HELPER
+                chown root:root /usr/local/sbin/refresh-cleanroom-helper
+                chmod 0755 /usr/local/sbin/refresh-cleanroom-helper
+                /usr/local/sbin/refresh-cleanroom-helper
+
+                cat > /var/lib/buildkite-agent/hooks/pre-command <<'HOOK'
+              #!/usr/bin/env bash
+              set -eo pipefail
+
+              if [ "$CLEANROOM_PRIVILEGED_MODE" != "helper" ]; then
+                exit 0
+              fi
+
+              [ -x /usr/local/sbin/cleanroom-root-helper ] || {
+                echo "cleanroom-root-helper missing; run '/usr/local/sbin/refresh-cleanroom-helper' via SSM as root" >&2
+                exit 1
+              }
+              HOOK
+                chown buildkite-agent:buildkite-agent /var/lib/buildkite-agent/hooks/pre-command
+                chmod 0755 /var/lib/buildkite-agent/hooks/pre-command
+
+                if getent group kvm >/dev/null 2>&1; then
+                  usermod -aG kvm buildkite-agent
+                fi
+              fi
+
+              systemctl daemon-reload
+              systemctl enable --now "buildkite-agent@$HOSTED_QUEUE.service"
+              if [ "$ENABLE_CLEANROOM" = 'true' ]; then
+                systemctl enable --now "buildkite-agent@$CLEANROOM_QUEUE.service"
+              fi
+
+  LinuxAutoScalingGroup:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    Properties:
+      MinSize: "1"
+      MaxSize: "1"
+      DesiredCapacity: "1"
+      VPCZoneIdentifier:
+        - !Ref CiPublicSubnet
+      LaunchTemplate:
+        LaunchTemplateId: !Ref LinuxLaunchTemplate
+        Version: !GetAtt LinuxLaunchTemplate.LatestVersionNumber
+      Tags:
+        - Key: Name
+          Value: !Sub ${ResourceNamePrefix}-linux
+          PropagateAtLaunch: true
+    UpdatePolicy:
+      AutoScalingRollingUpdate:
+        MinInstancesInService: 0
+        MaxBatchSize: 1
+        PauseTime: !Ref LinuxAsgRollingPauseTime
+        WaitOnResourceSignals: false
+
+  MacDedicatedHost:
+    Type: AWS::EC2::Host
+    Condition: EnableMac
+    Properties:
+      AvailabilityZone: !Ref AvailabilityZone
+      AutoPlacement: "on"
+      InstanceType: !Ref MacInstanceType
+      Tags:
+        - Key: Name
+          Value: !Sub ${ResourceNamePrefix}-mac-host
+
+  MacInstance:
+    Type: AWS::EC2::Instance
+    Condition: EnableMac
+    Properties:
+      AvailabilityZone: !Ref AvailabilityZone
+      Affinity: host
+      HostId: !Ref MacDedicatedHost
+      IamInstanceProfile: !Ref CiAgentInstanceProfile
+      ImageId: !Ref MacAmiId
+      InstanceType: !Ref MacInstanceType
+      MetadataOptions:
+        HttpEndpoint: enabled
+        HttpTokens: required
+      SecurityGroupIds:
+        - !Ref CiSecurityGroup
+      SubnetId: !Ref CiPublicSubnet
+      Tenancy: host
+      BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+            DeleteOnTermination: true
+            Encrypted: true
+            VolumeSize: !Ref MacRootVolumeSizeGiB
+            VolumeType: gp3
+      Tags:
+        - Key: Name
+          Value: !Sub ${ResourceNamePrefix}-mac
+      UserData:
+        Fn::Base64:
+          !Sub |
+            #!/bin/bash
+            set -euxo pipefail
+            exec > >(tee /var/log/user-data.log) 2>&1
+
+            BUILDKITE_TOKEN_PARAM='${BuildkiteTokenParameterName}'
+            AGENT_VERSION='${BuildkiteAgentVersion}'
+            MAC_QUEUE='${MacQueueName}'
+            MAC_EXTRA_TAGS='${MacAgentExtraTags}'
+            MAC_EXTRA_CONFIG='${MacAgentExtraConfig}'
+            TAILSCALE_PARAM='${TailscaleAuthKeyParameterName}'
+            TAILSCALE_VERSION='${TailscaleVersion}'
+            TAILSCALE_TAGS='${TailscaleAdvertiseTags}'
+            TAILSCALE_SSH='${TailscaleEnableSsh}'
+            TAILSCALE_ACCEPT_ROUTES='${TailscaleAcceptRoutes}'
+            TAILSCALE_HOSTNAME_PREFIX='${MacTailscaleHostnamePrefix}'
+            STACK_NAME='${AWS::StackName}'
+            REGION='${AWS::Region}'
+            AGENT_USER='${MacAgentUser}'
+
+            if ! id "$AGENT_USER" >/dev/null 2>&1; then
+              AGENT_USER='root'
+            fi
+            AGENT_GROUP="$(id -gn "$AGENT_USER")"
+            AGENT_HOME="$(dscl . -read "/Users/$AGENT_USER" NFSHomeDirectory 2>/dev/null | awk '{print $2}')"
+            if [ -z "$AGENT_HOME" ]; then
+              if [ "$AGENT_USER" = 'root' ]; then
+                AGENT_HOME='/var/root'
+              else
+                AGENT_HOME="/Users/$AGENT_USER"
+              fi
+            fi
+
+            if ! command -v aws >/dev/null 2>&1; then
+              curl -fsSL "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o /tmp/AWSCLIV2.pkg
+              installer -pkg /tmp/AWSCLIV2.pkg -target /
+            fi
+
+            arch_name="$(uname -m)"
+            agent_arch='arm64'
+            if [ "$arch_name" = 'x86_64' ]; then
+              agent_arch='amd64'
+            fi
+
+            agent_url="https://github.com/buildkite/agent/releases/download/v$AGENT_VERSION/buildkite-agent-darwin-$agent_arch-$AGENT_VERSION.tar.gz"
+            curl -fsSL "$agent_url" -o /tmp/buildkite-agent.tar.gz
+            tar -xzf /tmp/buildkite-agent.tar.gz -C /tmp
+            install -o root -g wheel -m 0755 /tmp/buildkite-agent /usr/local/bin/buildkite-agent
+
+            imds_token="$(curl -fsS -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")"
+            instance_id="$(curl -fsS -H "X-aws-ec2-metadata-token: $imds_token" http://169.254.169.254/latest/meta-data/instance-id)"
+            agent_token="$(aws ssm get-parameter --name "$BUILDKITE_TOKEN_PARAM" --with-decryption --query Parameter.Value --output text --region "$REGION")"
+
+            if [ -n "$TAILSCALE_PARAM" ]; then
+              tailscale_auth_key="$(aws ssm get-parameter --name "$TAILSCALE_PARAM" --with-decryption --query Parameter.Value --output text --region "$REGION")"
+              tailscale_pkg_url="https://pkgs.tailscale.com/stable/Tailscale-$TAILSCALE_VERSION-macos.pkg"
+              curl -fsSL "$tailscale_pkg_url" -o /tmp/Tailscale.pkg
+              installer -pkg /tmp/Tailscale.pkg -target /
+              launchctl enable system/com.tailscale.tailscaled || true
+              launchctl kickstart -k system/com.tailscale.tailscaled || true
+
+              tailscale_cli=''
+              if [ -x /usr/local/bin/tailscale ]; then
+                tailscale_cli='/usr/local/bin/tailscale'
+              elif [ -x /opt/homebrew/bin/tailscale ]; then
+                tailscale_cli='/opt/homebrew/bin/tailscale'
+              elif [ -x /Applications/Tailscale.app/Contents/MacOS/Tailscale ]; then
+                tailscale_cli='/Applications/Tailscale.app/Contents/MacOS/Tailscale'
+              fi
+
+              if [ -n "$tailscale_cli" ]; then
+                tailscale_hostname="$TAILSCALE_HOSTNAME_PREFIX-$instance_id"
+                set -- up --auth-key "$tailscale_auth_key" --hostname "$tailscale_hostname"
+                if [ "$TAILSCALE_SSH" = 'true' ]; then
+                  set -- "$@" --ssh
+                fi
+                if [ "$TAILSCALE_ACCEPT_ROUTES" = 'true' ]; then
+                  set -- "$@" --accept-routes
+                fi
+                if [ -n "$TAILSCALE_TAGS" ]; then
+                  set -- "$@" --advertise-tags "$TAILSCALE_TAGS"
+                fi
+                "$tailscale_cli" "$@"
+              else
+                echo "tailscale CLI not found after package install" >&2
+                exit 1
+              fi
+            fi
+
+            install -d -o "$AGENT_USER" -g "$AGENT_GROUP" -m 0755 /opt/buildkite-agent
+            install -d -o "$AGENT_USER" -g "$AGENT_GROUP" -m 0755 /opt/buildkite-agent/builds
+            install -d -o "$AGENT_USER" -g "$AGENT_GROUP" -m 0755 /opt/buildkite-agent/hooks
+            install -d -o "$AGENT_USER" -g "$AGENT_GROUP" -m 0755 /opt/buildkite-agent/plugins
+
+            mac_tags="queue=$MAC_QUEUE,stack=$STACK_NAME,host=$instance_id,os=macos"
+            if [ -n "$MAC_EXTRA_TAGS" ]; then
+              mac_tags="$mac_tags,$MAC_EXTRA_TAGS"
+            fi
+            cat > /opt/buildkite-agent/buildkite-agent.cfg <<CFG
+            token="$agent_token"
+            name="$STACK_NAME-$instance_id-$MAC_QUEUE"
+            tags="$mac_tags"
+            build-path="/opt/buildkite-agent/builds"
+            hooks-path="/opt/buildkite-agent/hooks"
+            plugins-path="/opt/buildkite-agent/plugins"
+            CFG
+            if [ -n "$MAC_EXTRA_CONFIG" ]; then
+              printf '%s\n' "$MAC_EXTRA_CONFIG" | tr ';' '\n' >> /opt/buildkite-agent/buildkite-agent.cfg
+            fi
+            chown "$AGENT_USER:$AGENT_GROUP" /opt/buildkite-agent/buildkite-agent.cfg
+            chmod 0600 /opt/buildkite-agent/buildkite-agent.cfg
+
+            cat > /Library/LaunchDaemons/com.buildkite.agent.plist <<PLIST
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+            <plist version="1.0">
+              <dict>
+                <key>Label</key>
+                <string>com.buildkite.agent</string>
+                <key>ProgramArguments</key>
+                <array>
+                  <string>/usr/local/bin/buildkite-agent</string>
+                  <string>start</string>
+                  <string>--config</string>
+                  <string>/opt/buildkite-agent/buildkite-agent.cfg</string>
+                </array>
+                <key>UserName</key>
+                <string>$AGENT_USER</string>
+                <key>EnvironmentVariables</key>
+                <dict>
+                  <key>HOME</key>
+                  <string>$AGENT_HOME</string>
+                </dict>
+                <key>RunAtLoad</key>
+                <true/>
+                <key>KeepAlive</key>
+                <true/>
+                <key>StandardOutPath</key>
+                <string>/var/log/buildkite-agent.log</string>
+                <key>StandardErrorPath</key>
+                <string>/var/log/buildkite-agent-error.log</string>
+              </dict>
+            </plist>
+            PLIST
+            chown root:wheel /Library/LaunchDaemons/com.buildkite.agent.plist
+            chmod 0644 /Library/LaunchDaemons/com.buildkite.agent.plist
+
+            launchctl bootout system/com.buildkite.agent || true
+            launchctl bootstrap system /Library/LaunchDaemons/com.buildkite.agent.plist
+            launchctl enable system/com.buildkite.agent
+            launchctl kickstart -k system/com.buildkite.agent
+
+Outputs:
+  VpcId:
+    Description: VPC ID for CI hosts.
+    Value: !Ref CiVpc
+  PublicSubnetId:
+    Description: Public subnet ID for CI hosts.
+    Value: !Ref CiPublicSubnet
+  LinuxAutoScalingGroupName:
+    Description: Linux ASG name.
+    Value: !Ref LinuxAutoScalingGroup
+  MacDedicatedHostId:
+    Condition: EnableMac
+    Description: Dedicated host ID backing the EC2 Mac instance.
+    Value: !Ref MacDedicatedHost
+  MacInstanceId:
+    Condition: EnableMac
+    Description: EC2 Mac instance ID.
+    Value: !Ref MacInstance
+  MacSsmSessionCommand:
+    Condition: EnableMac
+    Description: Command to start SSM session to macOS host.
+    Value: !Sub aws ssm start-session --target ${MacInstance}
+  LinuxTailscaleSshPattern:
+    Condition: UseTailscale
+    Description: Tailscale SSH pattern for Linux host (replace <instance-id> with actual EC2 instance ID).
+    Value: !Join
+      - ""
+      - - "tailscale ssh root@"
+        - !Ref LinuxTailscaleHostnamePrefix
+        - "-<instance-id>"
+  MacTailscaleSshPattern:
+    Condition: UseTailscaleOnMac
+    Description: Tailscale SSH pattern for macOS host (replace <instance-id> with actual EC2 instance ID).
+    Value: !Join
+      - ""
+      - - "tailscale ssh "
+        - !Ref MacAgentUser
+        - "@"
+        - !Ref MacTailscaleHostnamePrefix
+        - "-<instance-id>"

--- a/infra/cloudformation/ci-hosts.yaml
+++ b/infra/cloudformation/ci-hosts.yaml
@@ -1,13 +1,13 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
-  Buildkite CI hosts for cleanroom: one Linux host and an optional EC2 Mac host.
+  Buildkite CI host for cleanroom.
   The stack is reproducible (CloudFormation + user data bootstrap) and avoids
   storing long-lived host state by hand.
 
 Parameters:
   AvailabilityZone:
     Type: AWS::EC2::AvailabilityZone::Name
-    Description: Availability Zone used for both Linux and EC2 Mac hosts.
+    Description: Availability Zone used for the Linux CI host.
   VpcCidr:
     Type: String
     Default: 10.42.0.0/24
@@ -70,35 +70,6 @@ Parameters:
     Type: String
     Default: main
     Description: Git ref used to fetch scripts/cleanroom-root-helper.sh.
-  EnableMacHost:
-    Type: String
-    Default: "true"
-    AllowedValues:
-      - "true"
-      - "false"
-    Description: Create the EC2 Mac dedicated host and macOS instance.
-  MacAmiId:
-    Type: String
-    Default: ""
-    AllowedPattern: '^$|ami-[0-9a-fA-F]{8,17}$'
-    Description: macOS AMI ID for the EC2 Mac host (required when EnableMacHost=true).
-  MacInstanceType:
-    Type: String
-    Default: mac2.metal
-    Description: EC2 Mac instance type available in the selected AZ.
-  MacRootVolumeSizeGiB:
-    Type: Number
-    Default: 200
-    MinValue: 100
-    Description: Root volume size for the macOS host.
-  MacQueueName:
-    Type: String
-    Default: mac-small
-    Description: Buildkite queue name for macOS tests.
-  MacAgentUser:
-    Type: String
-    Default: ec2-user
-    Description: Local macOS user that runs buildkite-agent.
   BuildkiteAgentVersion:
     Type: String
     Default: 3.119.1
@@ -126,14 +97,6 @@ Parameters:
     Type: String
     Default: ""
     Description: Extra Linux cleanroom agent config lines separated by semicolons.
-  MacAgentExtraTags:
-    Type: String
-    Default: ""
-    Description: Extra comma-separated Buildkite tags appended to macOS agent tags.
-  MacAgentExtraConfig:
-    Type: String
-    Default: ""
-    Description: Extra macOS agent config lines separated by semicolons.
   TailscaleAuthKeyParameterName:
     Type: String
     Default: ""
@@ -146,10 +109,6 @@ Parameters:
     Type: String
     Default: ""
     Description: Optional comma-separated tag list passed as --advertise-tags on Linux only.
-  TailscaleAdvertiseTags:
-    Type: String
-    Default: ""
-    Description: Optional comma-separated tag list passed as --advertise-tags on macOS.
   TailscaleEnableSsh:
     Type: String
     Default: "true"
@@ -168,29 +127,14 @@ Parameters:
     Type: String
     Default: cleanroom-ci-linux
     Description: Prefix for Linux host Tailscale hostname (<prefix>-<instance-id>).
-  MacTailscaleHostnamePrefix:
-    Type: String
-    Default: cleanroom-ci-mac
-    Description: Prefix for macOS host Tailscale hostname (<prefix>-<instance-id>).
   ResourceNamePrefix:
     Type: String
     Default: cleanroom-ci
     Description: Prefix used in Name tags.
 
-Rules:
-  RequireMacAmiWhenEnabled:
-    RuleCondition: !Equals [!Ref EnableMacHost, "true"]
-    Assertions:
-      - Assert: !Not [!Equals [!Ref MacAmiId, ""]]
-        AssertDescription: MacAmiId must be set when EnableMacHost=true.
-
 Conditions:
   UseTailscale: !Not [!Equals [!Ref TailscaleAuthKeyParameterName, ""]]
   UseGitDeployKey: !Not [!Equals [!Ref GitDeployKeyParameterName, ""]]
-  EnableMac: !Equals [!Ref EnableMacHost, "true"]
-  UseTailscaleOnMac: !And
-    - !Condition UseTailscale
-    - !Condition EnableMac
 
 Resources:
   CiVpc:
@@ -432,7 +376,7 @@ Resources:
                 if [ "$agent_arch" = 'arm64' ]; then
                   ts_arch='arm64'
                 fi
-                ts_url="https://pkgs.tailscale.com/stable/tailscale_${TAILSCALE_VERSION}_$ts_arch.tgz"
+                ts_url="$(printf 'https://pkgs.tailscale.com/stable/tailscale_%s_%s.tgz' "$TAILSCALE_VERSION" "$ts_arch")"
                 ts_tmp_dir="$(mktemp -d)"
                 curl -fsSL "$ts_url" -o "$ts_tmp_dir/tailscale.tgz"
                 tar -xzf "$ts_tmp_dir/tailscale.tgz" -C "$ts_tmp_dir"
@@ -650,198 +594,6 @@ Resources:
         PauseTime: !Ref LinuxAsgRollingPauseTime
         WaitOnResourceSignals: false
 
-  MacDedicatedHost:
-    Type: AWS::EC2::Host
-    Condition: EnableMac
-    Properties:
-      AvailabilityZone: !Ref AvailabilityZone
-      AutoPlacement: "on"
-      InstanceType: !Ref MacInstanceType
-      Tags:
-        - Key: Name
-          Value: !Sub ${ResourceNamePrefix}-mac-host
-
-  MacInstance:
-    Type: AWS::EC2::Instance
-    Condition: EnableMac
-    Properties:
-      AvailabilityZone: !Ref AvailabilityZone
-      Affinity: host
-      HostId: !Ref MacDedicatedHost
-      IamInstanceProfile: !Ref CiAgentInstanceProfile
-      ImageId: !Ref MacAmiId
-      InstanceType: !Ref MacInstanceType
-      MetadataOptions:
-        HttpEndpoint: enabled
-        HttpTokens: required
-      SecurityGroupIds:
-        - !Ref CiSecurityGroup
-      SubnetId: !Ref CiPublicSubnet
-      Tenancy: host
-      BlockDeviceMappings:
-        - DeviceName: /dev/sda1
-          Ebs:
-            DeleteOnTermination: true
-            Encrypted: true
-            VolumeSize: !Ref MacRootVolumeSizeGiB
-            VolumeType: gp3
-      Tags:
-        - Key: Name
-          Value: !Sub ${ResourceNamePrefix}-mac
-      UserData:
-        Fn::Base64:
-          !Sub |
-            #!/bin/bash
-            set -euxo pipefail
-            exec > >(tee /var/log/user-data.log) 2>&1
-
-            BUILDKITE_TOKEN_PARAM='${BuildkiteTokenParameterName}'
-            AGENT_VERSION='${BuildkiteAgentVersion}'
-            MAC_QUEUE='${MacQueueName}'
-            MAC_EXTRA_TAGS='${MacAgentExtraTags}'
-            MAC_EXTRA_CONFIG='${MacAgentExtraConfig}'
-            TAILSCALE_PARAM='${TailscaleAuthKeyParameterName}'
-            TAILSCALE_VERSION='${TailscaleVersion}'
-            TAILSCALE_TAGS='${TailscaleAdvertiseTags}'
-            TAILSCALE_SSH='${TailscaleEnableSsh}'
-            TAILSCALE_ACCEPT_ROUTES='${TailscaleAcceptRoutes}'
-            TAILSCALE_HOSTNAME_PREFIX='${MacTailscaleHostnamePrefix}'
-            STACK_NAME='${AWS::StackName}'
-            REGION='${AWS::Region}'
-            AGENT_USER='${MacAgentUser}'
-
-            if ! id "$AGENT_USER" >/dev/null 2>&1; then
-              AGENT_USER='root'
-            fi
-            AGENT_GROUP="$(id -gn "$AGENT_USER")"
-            AGENT_HOME="$(dscl . -read "/Users/$AGENT_USER" NFSHomeDirectory 2>/dev/null | awk '{print $2}')"
-            if [ -z "$AGENT_HOME" ]; then
-              if [ "$AGENT_USER" = 'root' ]; then
-                AGENT_HOME='/var/root'
-              else
-                AGENT_HOME="/Users/$AGENT_USER"
-              fi
-            fi
-
-            if ! command -v aws >/dev/null 2>&1; then
-              curl -fsSL "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o /tmp/AWSCLIV2.pkg
-              installer -pkg /tmp/AWSCLIV2.pkg -target /
-            fi
-
-            arch_name="$(uname -m)"
-            agent_arch='arm64'
-            if [ "$arch_name" = 'x86_64' ]; then
-              agent_arch='amd64'
-            fi
-
-            agent_url="https://github.com/buildkite/agent/releases/download/v$AGENT_VERSION/buildkite-agent-darwin-$agent_arch-$AGENT_VERSION.tar.gz"
-            curl -fsSL "$agent_url" -o /tmp/buildkite-agent.tar.gz
-            tar -xzf /tmp/buildkite-agent.tar.gz -C /tmp
-            install -o root -g wheel -m 0755 /tmp/buildkite-agent /usr/local/bin/buildkite-agent
-
-            imds_token="$(curl -fsS -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")"
-            instance_id="$(curl -fsS -H "X-aws-ec2-metadata-token: $imds_token" http://169.254.169.254/latest/meta-data/instance-id)"
-            agent_token="$(aws ssm get-parameter --name "$BUILDKITE_TOKEN_PARAM" --with-decryption --query Parameter.Value --output text --region "$REGION")"
-
-            if [ -n "$TAILSCALE_PARAM" ]; then
-              tailscale_auth_key="$(aws ssm get-parameter --name "$TAILSCALE_PARAM" --with-decryption --query Parameter.Value --output text --region "$REGION")"
-              tailscale_pkg_url="https://pkgs.tailscale.com/stable/Tailscale-$TAILSCALE_VERSION-macos.pkg"
-              curl -fsSL "$tailscale_pkg_url" -o /tmp/Tailscale.pkg
-              installer -pkg /tmp/Tailscale.pkg -target /
-              launchctl enable system/com.tailscale.tailscaled || true
-              launchctl kickstart -k system/com.tailscale.tailscaled || true
-
-              tailscale_cli=''
-              if [ -x /usr/local/bin/tailscale ]; then
-                tailscale_cli='/usr/local/bin/tailscale'
-              elif [ -x /opt/homebrew/bin/tailscale ]; then
-                tailscale_cli='/opt/homebrew/bin/tailscale'
-              elif [ -x /Applications/Tailscale.app/Contents/MacOS/Tailscale ]; then
-                tailscale_cli='/Applications/Tailscale.app/Contents/MacOS/Tailscale'
-              fi
-
-              if [ -n "$tailscale_cli" ]; then
-                tailscale_hostname="$TAILSCALE_HOSTNAME_PREFIX-$instance_id"
-                set -- up --auth-key "$tailscale_auth_key" --hostname "$tailscale_hostname"
-                if [ "$TAILSCALE_SSH" = 'true' ]; then
-                  set -- "$@" --ssh
-                fi
-                if [ "$TAILSCALE_ACCEPT_ROUTES" = 'true' ]; then
-                  set -- "$@" --accept-routes
-                fi
-                if [ -n "$TAILSCALE_TAGS" ]; then
-                  set -- "$@" --advertise-tags "$TAILSCALE_TAGS"
-                fi
-                "$tailscale_cli" "$@"
-              else
-                echo "tailscale CLI not found after package install" >&2
-                exit 1
-              fi
-            fi
-
-            install -d -o "$AGENT_USER" -g "$AGENT_GROUP" -m 0755 /opt/buildkite-agent
-            install -d -o "$AGENT_USER" -g "$AGENT_GROUP" -m 0755 /opt/buildkite-agent/builds
-            install -d -o "$AGENT_USER" -g "$AGENT_GROUP" -m 0755 /opt/buildkite-agent/hooks
-            install -d -o "$AGENT_USER" -g "$AGENT_GROUP" -m 0755 /opt/buildkite-agent/plugins
-
-            mac_tags="queue=$MAC_QUEUE,stack=$STACK_NAME,host=$instance_id,os=macos"
-            if [ -n "$MAC_EXTRA_TAGS" ]; then
-              mac_tags="$mac_tags,$MAC_EXTRA_TAGS"
-            fi
-            cat > /opt/buildkite-agent/buildkite-agent.cfg <<CFG
-            token="$agent_token"
-            name="$STACK_NAME-$instance_id-$MAC_QUEUE"
-            tags="$mac_tags"
-            build-path="/opt/buildkite-agent/builds"
-            hooks-path="/opt/buildkite-agent/hooks"
-            plugins-path="/opt/buildkite-agent/plugins"
-            CFG
-            if [ -n "$MAC_EXTRA_CONFIG" ]; then
-              printf '%s\n' "$MAC_EXTRA_CONFIG" | tr ';' '\n' >> /opt/buildkite-agent/buildkite-agent.cfg
-            fi
-            chown "$AGENT_USER:$AGENT_GROUP" /opt/buildkite-agent/buildkite-agent.cfg
-            chmod 0600 /opt/buildkite-agent/buildkite-agent.cfg
-
-            cat > /Library/LaunchDaemons/com.buildkite.agent.plist <<PLIST
-            <?xml version="1.0" encoding="UTF-8"?>
-            <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-            <plist version="1.0">
-              <dict>
-                <key>Label</key>
-                <string>com.buildkite.agent</string>
-                <key>ProgramArguments</key>
-                <array>
-                  <string>/usr/local/bin/buildkite-agent</string>
-                  <string>start</string>
-                  <string>--config</string>
-                  <string>/opt/buildkite-agent/buildkite-agent.cfg</string>
-                </array>
-                <key>UserName</key>
-                <string>$AGENT_USER</string>
-                <key>EnvironmentVariables</key>
-                <dict>
-                  <key>HOME</key>
-                  <string>$AGENT_HOME</string>
-                </dict>
-                <key>RunAtLoad</key>
-                <true/>
-                <key>KeepAlive</key>
-                <true/>
-                <key>StandardOutPath</key>
-                <string>/var/log/buildkite-agent.log</string>
-                <key>StandardErrorPath</key>
-                <string>/var/log/buildkite-agent-error.log</string>
-              </dict>
-            </plist>
-            PLIST
-            chown root:wheel /Library/LaunchDaemons/com.buildkite.agent.plist
-            chmod 0644 /Library/LaunchDaemons/com.buildkite.agent.plist
-
-            launchctl bootout system/com.buildkite.agent || true
-            launchctl bootstrap system /Library/LaunchDaemons/com.buildkite.agent.plist
-            launchctl enable system/com.buildkite.agent
-            launchctl kickstart -k system/com.buildkite.agent
-
 Outputs:
   VpcId:
     Description: VPC ID for CI hosts.
@@ -852,18 +604,6 @@ Outputs:
   LinuxAutoScalingGroupName:
     Description: Linux ASG name.
     Value: !Ref LinuxAutoScalingGroup
-  MacDedicatedHostId:
-    Condition: EnableMac
-    Description: Dedicated host ID backing the EC2 Mac instance.
-    Value: !Ref MacDedicatedHost
-  MacInstanceId:
-    Condition: EnableMac
-    Description: EC2 Mac instance ID.
-    Value: !Ref MacInstance
-  MacSsmSessionCommand:
-    Condition: EnableMac
-    Description: Command to start SSM session to macOS host.
-    Value: !Sub aws ssm start-session --target ${MacInstance}
   LinuxTailscaleSshPattern:
     Condition: UseTailscale
     Description: Tailscale SSH pattern for Linux host (replace <instance-id> with actual EC2 instance ID).
@@ -871,14 +611,4 @@ Outputs:
       - ""
       - - "tailscale ssh root@"
         - !Ref LinuxTailscaleHostnamePrefix
-        - "-<instance-id>"
-  MacTailscaleSshPattern:
-    Condition: UseTailscaleOnMac
-    Description: Tailscale SSH pattern for macOS host (replace <instance-id> with actual EC2 instance ID).
-    Value: !Join
-      - ""
-      - - "tailscale ssh "
-        - !Ref MacAgentUser
-        - "@"
-        - !Ref MacTailscaleHostnamePrefix
         - "-<instance-id>"

--- a/infra/cloudformation/ci-hosts.yaml
+++ b/infra/cloudformation/ci-hosts.yaml
@@ -557,6 +557,9 @@ Resources:
                   rm -rf "$tmp_fc_dir"
                 fi
 
+                install -d -o buildkite-agent -g buildkite-agent -m 0755 /var/lib/buildkite-agent/.local
+                install -d -o buildkite-agent -g buildkite-agent -m 0755 /var/lib/buildkite-agent/.local/share
+                install -d -o buildkite-agent -g buildkite-agent -m 0755 /var/lib/buildkite-agent/.local/share/cleanroom
                 install -d -o buildkite-agent -g buildkite-agent -m 0755 /var/lib/buildkite-agent/.local/share/cleanroom/images
                 curl -fsSL "$KERNEL_URL" -o /var/lib/buildkite-agent/.local/share/cleanroom/images/vmlinux.bin
                 chown buildkite-agent:buildkite-agent /var/lib/buildkite-agent/.local/share/cleanroom/images/vmlinux.bin

--- a/infra/cloudformation/ci_hosts_template_test.go
+++ b/infra/cloudformation/ci_hosts_template_test.go
@@ -1,0 +1,29 @@
+package cloudformation_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestLinuxBootstrapEnsuresAgentOwnsLocalTree(t *testing.T) {
+	t.Helper()
+
+	templateBytes, err := os.ReadFile("ci-hosts.yaml")
+	if err != nil {
+		t.Fatalf("read ci-hosts template: %v", err)
+	}
+
+	template := string(templateBytes)
+	requiredSnippets := []string{
+		"install -d -o buildkite-agent -g buildkite-agent -m 0755 /var/lib/buildkite-agent/.local",
+		"install -d -o buildkite-agent -g buildkite-agent -m 0755 /var/lib/buildkite-agent/.local/share",
+		"install -d -o buildkite-agent -g buildkite-agent -m 0755 /var/lib/buildkite-agent/.local/share/cleanroom",
+	}
+
+	for _, snippet := range requiredSnippets {
+		if !strings.Contains(template, snippet) {
+			t.Fatalf("linux bootstrap is missing required path ownership step: %q", snippet)
+		}
+	}
+}

--- a/infra/cloudformation/ci_hosts_template_test.go
+++ b/infra/cloudformation/ci_hosts_template_test.go
@@ -27,3 +27,22 @@ func TestLinuxBootstrapEnsuresAgentOwnsLocalTree(t *testing.T) {
 		}
 	}
 }
+
+func TestLinuxBootstrapUsesDirectTailscaleVersionExpansion(t *testing.T) {
+	t.Helper()
+
+	templateBytes, err := os.ReadFile("ci-hosts.yaml")
+	if err != nil {
+		t.Fatalf("read ci-hosts template: %v", err)
+	}
+
+	template := string(templateBytes)
+	if strings.Contains(template, "${!TAILSCALE_VERSION}") {
+		t.Fatalf("linux bootstrap must not use indirect expansion for Tailscale version")
+	}
+
+	requiredSnippet := "tailscale_${TAILSCALE_VERSION}_$ts_arch.tgz"
+	if !strings.Contains(template, requiredSnippet) {
+		t.Fatalf("linux bootstrap is missing direct Tailscale version expansion: %q", requiredSnippet)
+	}
+}

--- a/infra/cloudformation/ci_hosts_template_test.go
+++ b/infra/cloudformation/ci_hosts_template_test.go
@@ -41,8 +41,8 @@ func TestLinuxBootstrapUsesDirectTailscaleVersionExpansion(t *testing.T) {
 		t.Fatalf("linux bootstrap must not use indirect expansion for Tailscale version")
 	}
 
-	requiredSnippet := "tailscale_${TAILSCALE_VERSION}_$ts_arch.tgz"
+	requiredSnippet := "printf 'https://pkgs.tailscale.com/stable/tailscale_%s_%s.tgz' \"$TAILSCALE_VERSION\" \"$ts_arch\""
 	if !strings.Contains(template, requiredSnippet) {
-		t.Fatalf("linux bootstrap is missing direct Tailscale version expansion: %q", requiredSnippet)
+		t.Fatalf("linux bootstrap is missing Tailscale URL rendering via runtime variables: %q", requiredSnippet)
 	}
 }

--- a/scripts/ci-cleanroom-e2e.sh
+++ b/scripts/ci-cleanroom-e2e.sh
@@ -3,8 +3,11 @@ set -euo pipefail
 
 KERNEL_IMAGE="${CLEANROOM_KERNEL_IMAGE:-}"
 FIRECRACKER_BINARY="${CLEANROOM_FIRECRACKER_BINARY:-firecracker}"
+PRIVILEGED_HELPER_PATH="${CLEANROOM_PRIVILEGED_HELPER_PATH:-/usr/local/sbin/cleanroom-root-helper}"
 PRIVILEGED_MODE="${CLEANROOM_PRIVILEGED_MODE:-}"
-PRIVILEGED_HELPER_PATH="${CLEANROOM_PRIVILEGED_HELPER_PATH:-}"
+if [[ -z "$PRIVILEGED_MODE" && -x "$PRIVILEGED_HELPER_PATH" ]]; then
+  PRIVILEGED_MODE="helper"
+fi
 
 if [[ -z "$KERNEL_IMAGE" ]]; then
   echo "CLEANROOM_KERNEL_IMAGE is required for Firecracker e2e CI" >&2
@@ -14,10 +17,14 @@ fi
 # run_privileged executes a privileged command via the root helper,
 # falling back to sudo, then direct execution.
 run_privileged() {
-  if [[ -n "${PRIVILEGED_HELPER_PATH:-}" ]]; then
-    "$PRIVILEGED_HELPER_PATH" "$@"
+  if [[ "$PRIVILEGED_MODE" == "helper" && -x "$PRIVILEGED_HELPER_PATH" ]]; then
+    if command -v sudo >/dev/null 2>&1; then
+      sudo -n "$PRIVILEGED_HELPER_PATH" "$@"
+    else
+      "$PRIVILEGED_HELPER_PATH" "$@"
+    fi
   elif command -v sudo >/dev/null 2>&1; then
-    sudo "$@"
+    sudo -n "$@"
   else
     "$@"
   fi

--- a/scripts/ci_cleanroom_e2e_script_test.go
+++ b/scripts/ci_cleanroom_e2e_script_test.go
@@ -1,0 +1,28 @@
+package scripts_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestCICleanroomScriptUsesNonInteractivePrivilegedFallbacks(t *testing.T) {
+	t.Helper()
+
+	scriptBytes, err := os.ReadFile("ci-cleanroom-e2e.sh")
+	if err != nil {
+		t.Fatalf("read script: %v", err)
+	}
+
+	script := string(scriptBytes)
+	requiredSnippets := []string{
+		"PRIVILEGED_HELPER_PATH=\"${CLEANROOM_PRIVILEGED_HELPER_PATH:-/usr/local/sbin/cleanroom-root-helper}\"",
+		"sudo -n \"$@\"",
+	}
+
+	for _, snippet := range requiredSnippets {
+		if !strings.Contains(script, snippet) {
+			t.Fatalf("script is missing required privileged execution safeguard: %q", snippet)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add `infra/cloudformation/ci-hosts.yaml` as a reproducible Linux CI stack for Buildkite
- provision Linux networking and host infrastructure (VPC, subnet, IGW, security group, launch template, and ASG)
- bootstrap Linux Buildkite agents for `hosted` and optional `cleanroom` queues, including Firecracker helper integration
- add Linux Tailscale bootstrap and Linux-specific operational outputs
- document Linux deployment and operations in `docs/ci.md`
- harden Linux Tailscale package URL rendering in user data using runtime `printf` interpolation

## Validation
- `go test ./...`
- `aws cloudformation validate-template --profile admin-724772075326 --region ap-southeast-2 --template-body file://infra/cloudformation/ci-hosts.yaml`
