### PR TITLE
Add coverage for control plane and E2E gaps

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -14,7 +14,7 @@ run = "go test ./..."
 
 [tasks.lint-shell]
 description = "Lint shell scripts"
-run = "shellcheck -x scripts/bootstrap-buildkite-agent.sh scripts/bootstrap-buildkite-agent-macos.sh scripts/cleanroom-root-helper.sh scripts/benchmark-tti.sh scripts/build-go.sh scripts/install-go.sh scripts/install.sh scripts/release.sh scripts/ci-darwin-vz-e2e.sh"
+run = "shellcheck -x scripts/bootstrap-buildkite-agent.sh scripts/bootstrap-buildkite-agent-macos.sh scripts/cleanroom-root-helper.sh scripts/benchmark-tti.sh scripts/build-go.sh scripts/install-go.sh scripts/install.sh scripts/release.sh scripts/ci-cleanroom-e2e.sh scripts/ci-darwin-vz-e2e.sh"
 
 [tasks.test-full]
 description = "Run full Go test suite"

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -3,8 +3,7 @@
 This repository uses Buildkite for CI with three queues:
 
 - `hosted`: Linux unit/integration tests (`mise run test`)
-- `cleanroom-mac`: macOS unit/integration tests (`mise run test`)
-- `cleanroom-mac`: macOS `darwin-vz` end-to-end checks (`scripts/ci-darwin-vz-e2e.sh`)
+- `cleanroom-mac`: macOS unit/integration tests (`mise run test`) and `darwin-vz` end-to-end checks (`scripts/ci-darwin-vz-e2e.sh`)
 - `cleanroom`: Linux Firecracker end-to-end checks (`scripts/ci-cleanroom-e2e.sh`)
 
 Pipeline config lives in `.buildkite/pipeline.yml`.
@@ -181,4 +180,4 @@ After setup:
 1. Trigger a build.
 2. Confirm `:test_tube: Test (Linux)` and `:test_tube: Test (macOS)` pass.
 3. Confirm `:apple: E2E (darwin-vz)` passes doctor, launched execution, exit-code, and policy checks.
-4. Confirm `:fire: E2E (Firecracker)` passes doctor, launch, exec, and observability checks.
+4. Confirm `:fire: E2E (Firecracker)` passes doctor, launch, exec, persistent sandbox lifecycle, and observability checks.

--- a/internal/controlclient/client_tls_integration_test.go
+++ b/internal/controlclient/client_tls_integration_test.go
@@ -1,0 +1,215 @@
+package controlclient
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/controlserver"
+	"github.com/buildkite/cleanroom/internal/controlservice"
+	"github.com/buildkite/cleanroom/internal/endpoint"
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+	"github.com/buildkite/cleanroom/internal/runtimeconfig"
+)
+
+type tlsTestAdapter struct{}
+
+func (tlsTestAdapter) Name() string { return "firecracker" }
+
+func (tlsTestAdapter) Run(_ context.Context, req backend.RunRequest) (*backend.RunResult, error) {
+	return &backend.RunResult{RunID: req.RunID, ExitCode: 0, Message: "ok"}, nil
+}
+
+func TestHTTPSControlPlaneDiscoversTLSMaterial(t *testing.T) {
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+
+	writeTLSMaterial(t, configHome, net.ParseIP("127.0.0.1"))
+
+	addr := reserveTCPAddr(t)
+	ep := endpoint.Endpoint{
+		Scheme:  "https",
+		Address: "https://" + addr,
+		BaseURL: "https://" + addr,
+	}
+
+	service := &controlservice.Service{
+		Config: runtimeconfig.Config{DefaultBackend: "firecracker"},
+		Backends: map[string]backend.Adapter{
+			"firecracker": tlsTestAdapter{},
+		},
+	}
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- controlserver.Serve(runCtx, ep, controlserver.New(service, nil).Handler(), nil, nil)
+	}()
+
+	waitForTLSServer(t, addr)
+
+	client, err := New(ep)
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	ctx, rpcCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer rpcCancel()
+
+	createResp, err := client.CreateSandbox(ctx, &cleanroomv1.CreateSandboxRequest{
+		Backend: "firecracker",
+		Policy:  tlsTestPolicy(),
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createResp.GetSandbox().GetSandboxId()
+	if sandboxID == "" {
+		t.Fatal("expected sandbox id")
+	}
+
+	getResp, err := client.GetSandbox(ctx, &cleanroomv1.GetSandboxRequest{SandboxId: sandboxID})
+	if err != nil {
+		t.Fatalf("GetSandbox returned error: %v", err)
+	}
+	if got, want := getResp.GetSandbox().GetSandboxId(), sandboxID; got != want {
+		t.Fatalf("GetSandbox id mismatch: got %q want %q", got, want)
+	}
+
+	untrustedConfigHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", untrustedConfigHome)
+
+	untrustedClient, err := New(ep)
+	if err != nil {
+		t.Fatalf("New for untrusted client returned error: %v", err)
+	}
+	_, err = untrustedClient.ListSandboxes(ctx, &cleanroomv1.ListSandboxesRequest{})
+	if err == nil {
+		t.Fatal("expected TLS verification failure without discovered CA")
+	}
+	if !strings.Contains(err.Error(), "unknown authority") && !strings.Contains(err.Error(), "certificate") {
+		t.Fatalf("unexpected TLS verification error: %v", err)
+	}
+
+	cancel()
+	if err := <-errCh; err != nil {
+		t.Fatalf("Serve returned error: %v", err)
+	}
+}
+
+func tlsTestPolicy() *cleanroomv1.Policy {
+	return &cleanroomv1.Policy{
+		Version:        1,
+		ImageRef:       "ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		ImageDigest:    "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		NetworkDefault: "deny",
+	}
+}
+
+func reserveTCPAddr(t *testing.T) string {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen returned error: %v", err)
+	}
+	addr := listener.Addr().String()
+	if err := listener.Close(); err != nil {
+		t.Fatalf("listener.Close returned error: %v", err)
+	}
+	return addr
+}
+
+func waitForTLSServer(t *testing.T, addr string) {
+	t.Helper()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", addr, 100*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for TLS server on %s", addr)
+}
+
+func writeTLSMaterial(t *testing.T, configHome string, ip net.IP) {
+	t.Helper()
+
+	tlsDir := filepath.Join(configHome, "cleanroom", "tls")
+	if err := os.MkdirAll(tlsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll returned error: %v", err)
+	}
+
+	now := time.Now().UTC()
+
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey for CA returned error: %v", err)
+	}
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "cleanroom-test-ca"},
+		NotBefore:             now.Add(-1 * time.Minute),
+		NotAfter:              now.Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("CreateCertificate for CA returned error: %v", err)
+	}
+
+	serverKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey for server returned error: %v", err)
+	}
+	serverTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "127.0.0.1"},
+		NotBefore:    now.Add(-1 * time.Minute),
+		NotAfter:     now.Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{ip},
+		DNSNames:     []string{"localhost"},
+	}
+	serverDER, err := x509.CreateCertificate(rand.Reader, serverTemplate, caTemplate, &serverKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("CreateCertificate for server returned error: %v", err)
+	}
+
+	writePEMFile(t, filepath.Join(tlsDir, "ca.pem"), "CERTIFICATE", caDER)
+
+	serverKeyDER, err := x509.MarshalECPrivateKey(serverKey)
+	if err != nil {
+		t.Fatalf("MarshalECPrivateKey returned error: %v", err)
+	}
+	writePEMFile(t, filepath.Join(tlsDir, "server.pem"), "CERTIFICATE", serverDER)
+	writePEMFile(t, filepath.Join(tlsDir, "server.key"), "EC PRIVATE KEY", serverKeyDER)
+}
+
+func writePEMFile(t *testing.T, path, blockType string, der []byte) {
+	t.Helper()
+
+	if err := os.WriteFile(path, pem.EncodeToMemory(&pem.Block{Type: blockType, Bytes: der}), 0o600); err != nil {
+		t.Fatalf("WriteFile(%s) returned error: %v", path, err)
+	}
+}

--- a/internal/controlserver/server_handler_test.go
+++ b/internal/controlserver/server_handler_test.go
@@ -1,0 +1,316 @@
+package controlserver
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/controlservice"
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+	"github.com/buildkite/cleanroom/internal/gen/cleanroom/v1/cleanroomv1connect"
+	"github.com/buildkite/cleanroom/internal/runtimeconfig"
+)
+
+type handlerTestAdapter struct {
+	started     chan struct{}
+	allowStdout chan struct{}
+	allowFinish chan struct{}
+}
+
+func newHandlerTestAdapter() *handlerTestAdapter {
+	return &handlerTestAdapter{
+		started:     make(chan struct{}, 1),
+		allowStdout: make(chan struct{}),
+		allowFinish: make(chan struct{}),
+	}
+}
+
+func (a *handlerTestAdapter) Name() string { return "firecracker" }
+
+func (a *handlerTestAdapter) Run(ctx context.Context, req backend.RunRequest) (*backend.RunResult, error) {
+	return a.RunStream(ctx, req, backend.OutputStream{})
+}
+
+func (a *handlerTestAdapter) RunStream(ctx context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+	select {
+	case a.started <- struct{}{}:
+	default:
+	}
+
+	select {
+	case <-a.allowStdout:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	if stream.OnStdout != nil {
+		stream.OnStdout([]byte("hello from handler\n"))
+	}
+
+	select {
+	case <-a.allowFinish:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	return &backend.RunResult{
+		RunID:    req.RunID,
+		ExitCode: 0,
+		Message:  "ok",
+	}, nil
+}
+
+func (a *handlerTestAdapter) ProvisionSandbox(context.Context, backend.ProvisionRequest) error {
+	return nil
+}
+
+func (a *handlerTestAdapter) RunInSandbox(ctx context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+	return a.RunStream(ctx, req, stream)
+}
+
+func (a *handlerTestAdapter) TerminateSandbox(context.Context, string) error {
+	return nil
+}
+
+func newHandlerTestService(adapter backend.Adapter) *controlservice.Service {
+	return &controlservice.Service{
+		Config: runtimeconfig.Config{DefaultBackend: "firecracker"},
+		Backends: map[string]backend.Adapter{
+			"firecracker": adapter,
+		},
+	}
+}
+
+func handlerTestPolicy() *cleanroomv1.Policy {
+	return &cleanroomv1.Policy{
+		Version:        1,
+		ImageRef:       "ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		ImageDigest:    "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		NetworkDefault: "deny",
+	}
+}
+
+func TestSandboxEventStreamReturnsHistoryThenFollowUpdates(t *testing.T) {
+	service := newHandlerTestService(newHandlerTestAdapter())
+	httpServer := httptest.NewServer(New(service, nil).Handler())
+	defer httpServer.Close()
+
+	sandboxClient := cleanroomv1connect.NewSandboxServiceClient(http.DefaultClient, httpServer.URL)
+
+	createResp, err := sandboxClient.CreateSandbox(context.Background(), connect.NewRequest(&cleanroomv1.CreateSandboxRequest{
+		Backend: "firecracker",
+		Policy:  handlerTestPolicy(),
+	}))
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createResp.Msg.GetSandbox().GetSandboxId()
+
+	stream, err := sandboxClient.StreamSandboxEvents(context.Background(), connect.NewRequest(&cleanroomv1.StreamSandboxEventsRequest{
+		SandboxId: sandboxID,
+		Follow:    true,
+	}))
+	if err != nil {
+		t.Fatalf("StreamSandboxEvents returned error: %v", err)
+	}
+
+	if !stream.Receive() {
+		t.Fatal("expected ready history event")
+	}
+	readyEvent := stream.Msg()
+	if got, want := readyEvent.GetStatus(), cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY; got != want {
+		t.Fatalf("unexpected history status: got %v want %v", got, want)
+	}
+	if got := readyEvent.GetMessage(); !strings.Contains(got, "created and ready") {
+		t.Fatalf("unexpected ready history message: %q", got)
+	}
+
+	terminateDone := make(chan error, 1)
+	go func() {
+		_, err := sandboxClient.TerminateSandbox(context.Background(), connect.NewRequest(&cleanroomv1.TerminateSandboxRequest{
+			SandboxId: sandboxID,
+		}))
+		terminateDone <- err
+	}()
+
+	var statuses []cleanroomv1.SandboxStatus
+	for stream.Receive() {
+		statuses = append(statuses, stream.Msg().GetStatus())
+	}
+	if err := stream.Err(); err != nil {
+		t.Fatalf("StreamSandboxEvents stream error: %v", err)
+	}
+	if err := <-terminateDone; err != nil {
+		t.Fatalf("TerminateSandbox returned error: %v", err)
+	}
+
+	wantStatuses := []cleanroomv1.SandboxStatus{
+		cleanroomv1.SandboxStatus_SANDBOX_STATUS_STOPPING,
+		cleanroomv1.SandboxStatus_SANDBOX_STATUS_STOPPED,
+	}
+	if len(statuses) != len(wantStatuses) {
+		t.Fatalf("unexpected sandbox update count: got %d want %d (%v)", len(statuses), len(wantStatuses), statuses)
+	}
+	for i, want := range wantStatuses {
+		if got := statuses[i]; got != want {
+			t.Fatalf("sandbox event %d status mismatch: got %v want %v", i, got, want)
+		}
+	}
+}
+
+func TestExecutionEventStreamReturnsHistoryThenFollowUpdates(t *testing.T) {
+	adapter := newHandlerTestAdapter()
+	service := newHandlerTestService(adapter)
+	httpServer := httptest.NewServer(New(service, nil).Handler())
+	defer httpServer.Close()
+
+	sandboxClient := cleanroomv1connect.NewSandboxServiceClient(http.DefaultClient, httpServer.URL)
+	executionClient := cleanroomv1connect.NewExecutionServiceClient(http.DefaultClient, httpServer.URL)
+
+	createSandboxResp, err := sandboxClient.CreateSandbox(context.Background(), connect.NewRequest(&cleanroomv1.CreateSandboxRequest{
+		Backend: "firecracker",
+		Policy:  handlerTestPolicy(),
+	}))
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createSandboxResp.Msg.GetSandbox().GetSandboxId()
+
+	createExecutionResp, err := executionClient.CreateExecution(context.Background(), connect.NewRequest(&cleanroomv1.CreateExecutionRequest{
+		SandboxId: sandboxID,
+		Command:   []string{"echo", "hello"},
+	}))
+	if err != nil {
+		t.Fatalf("CreateExecution returned error: %v", err)
+	}
+	executionID := createExecutionResp.Msg.GetExecution().GetExecutionId()
+
+	select {
+	case <-adapter.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for execution to start")
+	}
+
+	stream, err := executionClient.StreamExecution(context.Background(), connect.NewRequest(&cleanroomv1.StreamExecutionRequest{
+		SandboxId:   sandboxID,
+		ExecutionId: executionID,
+		Follow:      true,
+	}))
+	if err != nil {
+		t.Fatalf("StreamExecution returned error: %v", err)
+	}
+
+	if !stream.Receive() {
+		t.Fatal("expected queued history event")
+	}
+	queuedEvent := stream.Msg()
+	if got, want := queuedEvent.GetStatus(), cleanroomv1.ExecutionStatus_EXECUTION_STATUS_QUEUED; got != want {
+		t.Fatalf("unexpected queued history status: got %v want %v", got, want)
+	}
+	if got := queuedEvent.GetMessage(); !strings.Contains(got, "queued") {
+		t.Fatalf("unexpected queued history message: %q", got)
+	}
+
+	if !stream.Receive() {
+		t.Fatal("expected started history event")
+	}
+	startedEvent := stream.Msg()
+	if got, want := startedEvent.GetStatus(), cleanroomv1.ExecutionStatus_EXECUTION_STATUS_RUNNING; got != want {
+		t.Fatalf("unexpected started history status: got %v want %v", got, want)
+	}
+	if got := startedEvent.GetMessage(); !strings.Contains(got, "started") {
+		t.Fatalf("unexpected started history message: %q", got)
+	}
+
+	close(adapter.allowStdout)
+	if !stream.Receive() {
+		t.Fatal("expected stdout follow event")
+	}
+	stdoutEvent := stream.Msg()
+	if got, want := string(stdoutEvent.GetStdout()), "hello from handler\n"; got != want {
+		t.Fatalf("unexpected stdout follow event: got %q want %q", got, want)
+	}
+
+	close(adapter.allowFinish)
+	if !stream.Receive() {
+		t.Fatal("expected exit follow event")
+	}
+	exitEvent := stream.Msg().GetExit()
+	if exitEvent == nil {
+		t.Fatal("expected exit payload")
+	}
+	if got, want := exitEvent.GetStatus(), cleanroomv1.ExecutionStatus_EXECUTION_STATUS_SUCCEEDED; got != want {
+		t.Fatalf("unexpected exit status: got %v want %v", got, want)
+	}
+	if got, want := exitEvent.GetExitCode(), int32(0); got != want {
+		t.Fatalf("unexpected exit code: got %d want %d", got, want)
+	}
+
+	if stream.Receive() {
+		t.Fatal("did not expect extra execution events after exit")
+	}
+	if err := stream.Err(); err != nil {
+		t.Fatalf("StreamExecution stream error: %v", err)
+	}
+}
+
+func TestToConnectErrorMapsExpectedCodes(t *testing.T) {
+	t.Parallel()
+
+	connectErr := connect.NewError(connect.CodeUnauthenticated, errors.New("bad auth"))
+	tests := []struct {
+		name string
+		err  error
+		want connect.Code
+	}{
+		{
+			name: "canceled",
+			err:  context.Canceled,
+			want: connect.CodeCanceled,
+		},
+		{
+			name: "deadline exceeded",
+			err:  context.DeadlineExceeded,
+			want: connect.CodeDeadlineExceeded,
+		},
+		{
+			name: "missing maps to invalid argument",
+			err:  errors.New("missing sandbox_id"),
+			want: connect.CodeInvalidArgument,
+		},
+		{
+			name: "unknown maps to not found",
+			err:  errors.New("unknown sandbox \"sbx-123\""),
+			want: connect.CodeNotFound,
+		},
+		{
+			name: "not ready maps to failed precondition",
+			err:  errors.New("sandbox \"sbx-123\" is not ready"),
+			want: connect.CodeFailedPrecondition,
+		},
+		{
+			name: "existing connect error passes through",
+			err:  connectErr,
+			want: connect.CodeUnauthenticated,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := toConnectError(tc.err)
+			if got == nil {
+				t.Fatal("expected non-nil connect error")
+			}
+			if code := connect.CodeOf(got); code != tc.want {
+				t.Fatalf("unexpected connect code: got %v want %v", code, tc.want)
+			}
+		})
+	}
+}

--- a/internal/interactivequic/integration_test.go
+++ b/internal/interactivequic/integration_test.go
@@ -1,0 +1,397 @@
+package interactivequic
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/buildkite/cleanroom/internal/controlservice"
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+)
+
+type integrationInteractiveService struct {
+	expectedSessionID string
+	expectedToken     string
+	session           *controlservice.InteractiveSession
+	history           []*cleanroomv1.ExecutionStreamEvent
+	updates           chan *cleanroomv1.ExecutionStreamEvent
+	done              chan struct{}
+
+	mu       sync.Mutex
+	released []string
+
+	stdinCh   chan string
+	resizeCh  chan testResizeCall
+	cancelCh  chan int32
+	releaseCh chan string
+}
+
+func newIntegrationInteractiveService() *integrationInteractiveService {
+	return &integrationInteractiveService{
+		expectedSessionID: "sess-123",
+		expectedToken:     "token-456",
+		session: &controlservice.InteractiveSession{
+			SessionID:   "sess-123",
+			SandboxID:   "sandbox-123",
+			ExecutionID: "exec-123",
+			InitialCols: 100,
+			InitialRows: 40,
+		},
+		history: []*cleanroomv1.ExecutionStreamEvent{
+			{
+				SandboxId:   "sandbox-123",
+				ExecutionId: "exec-123",
+				Status:      cleanroomv1.ExecutionStatus_EXECUTION_STATUS_RUNNING,
+				Payload: &cleanroomv1.ExecutionStreamEvent_Stdout{
+					Stdout: []byte("history-stdout\n"),
+				},
+			},
+		},
+		updates:   make(chan *cleanroomv1.ExecutionStreamEvent, 4),
+		done:      make(chan struct{}),
+		stdinCh:   make(chan string, 4),
+		resizeCh:  make(chan testResizeCall, 4),
+		cancelCh:  make(chan int32, 4),
+		releaseCh: make(chan string, 4),
+	}
+}
+
+func (s *integrationInteractiveService) ConsumeInteractiveSession(sessionID, token string) (*controlservice.InteractiveSession, error) {
+	if sessionID != s.expectedSessionID {
+		return nil, fmt.Errorf("unexpected session id %q", sessionID)
+	}
+	if token != s.expectedToken {
+		return nil, fmt.Errorf("unexpected session token %q", token)
+	}
+	return s.session, nil
+}
+
+func (s *integrationInteractiveService) ReleaseInteractiveExecution(sandboxID, executionID string) {
+	key := sandboxID + "/" + executionID
+	s.mu.Lock()
+	s.released = append(s.released, key)
+	s.mu.Unlock()
+	select {
+	case s.releaseCh <- key:
+	default:
+	}
+}
+
+func (s *integrationInteractiveService) WriteExecutionStdin(sandboxID, executionID string, data []byte) error {
+	if sandboxID != s.session.SandboxID || executionID != s.session.ExecutionID {
+		return fmt.Errorf("unexpected stdin target %q/%q", sandboxID, executionID)
+	}
+	select {
+	case s.stdinCh <- string(data):
+	default:
+	}
+	return nil
+}
+
+func (s *integrationInteractiveService) ResizeExecutionTTY(sandboxID, executionID string, cols, rows uint32) error {
+	call := testResizeCall{
+		sandboxID:   sandboxID,
+		executionID: executionID,
+		cols:        cols,
+		rows:        rows,
+	}
+	select {
+	case s.resizeCh <- call:
+	default:
+	}
+	return nil
+}
+
+func (s *integrationInteractiveService) CancelExecution(_ context.Context, req *cleanroomv1.CancelExecutionRequest) (*cleanroomv1.CancelExecutionResponse, error) {
+	if req.GetSandboxId() != s.session.SandboxID || req.GetExecutionId() != s.session.ExecutionID {
+		return nil, fmt.Errorf("unexpected cancel target %q/%q", req.GetSandboxId(), req.GetExecutionId())
+	}
+	select {
+	case s.cancelCh <- req.GetSignal():
+	default:
+	}
+	return &cleanroomv1.CancelExecutionResponse{
+		SandboxId:   req.GetSandboxId(),
+		ExecutionId: req.GetExecutionId(),
+		Accepted:    true,
+		Status:      cleanroomv1.ExecutionStatus_EXECUTION_STATUS_RUNNING,
+	}, nil
+}
+
+func (s *integrationInteractiveService) SubscribeExecutionEvents(sandboxID, executionID string) ([]*cleanroomv1.ExecutionStreamEvent, <-chan *cleanroomv1.ExecutionStreamEvent, <-chan struct{}, func(), error) {
+	if sandboxID != s.session.SandboxID || executionID != s.session.ExecutionID {
+		return nil, nil, nil, nil, fmt.Errorf("unexpected subscribe target %q/%q", sandboxID, executionID)
+	}
+	return s.history, s.updates, s.done, func() {}, nil
+}
+
+func TestDialRoundTrip(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	service := newIntegrationInteractiveService()
+	server, err := Start(ctx, "127.0.0.1:0", service, nil)
+	if err != nil {
+		t.Fatalf("Start returned error: %v", err)
+	}
+	defer func() {
+		_ = server.Close()
+	}()
+
+	session, err := Dial(
+		context.Background(),
+		server.Addr().String(),
+		server.ALPN(),
+		"SHA256:"+strings.ToUpper(server.CertPinSHA256()),
+		service.expectedSessionID,
+		service.expectedToken,
+	)
+	if err != nil {
+		t.Fatalf("Dial returned error: %v", err)
+	}
+	defer session.Close()
+
+	initialResize := waitForResizeCall(t, service.resizeCh)
+	if got, want := initialResize.sandboxID, service.session.SandboxID; got != want {
+		t.Fatalf("initial resize sandbox mismatch: got %q want %q", got, want)
+	}
+	if got, want := initialResize.executionID, service.session.ExecutionID; got != want {
+		t.Fatalf("initial resize execution mismatch: got %q want %q", got, want)
+	}
+	if got, want := initialResize.cols, uint32(100); got != want {
+		t.Fatalf("initial resize cols mismatch: got %d want %d", got, want)
+	}
+	if got, want := initialResize.rows, uint32(40); got != want {
+		t.Fatalf("initial resize rows mismatch: got %d want %d", got, want)
+	}
+
+	historyChunk := readPTYChunk(t, session)
+	if got, want := historyChunk, "history-stdout\n"; got != want {
+		t.Fatalf("unexpected history PTY chunk: got %q want %q", got, want)
+	}
+
+	if err := session.WriteStdin([]byte("stdin-data")); err != nil {
+		t.Fatalf("WriteStdin returned error: %v", err)
+	}
+	if got, want := waitForString(t, service.stdinCh), "stdin-data"; got != want {
+		t.Fatalf("unexpected stdin payload: got %q want %q", got, want)
+	}
+
+	if err := session.SendResize(120, 50); err != nil {
+		t.Fatalf("SendResize returned error: %v", err)
+	}
+	resize := waitForResizeCall(t, service.resizeCh)
+	if got, want := resize.cols, uint32(120); got != want {
+		t.Fatalf("resize cols mismatch: got %d want %d", got, want)
+	}
+	if got, want := resize.rows, uint32(50); got != want {
+		t.Fatalf("resize rows mismatch: got %d want %d", got, want)
+	}
+
+	service.updates <- &cleanroomv1.ExecutionStreamEvent{
+		SandboxId:   service.session.SandboxID,
+		ExecutionId: service.session.ExecutionID,
+		Status:      cleanroomv1.ExecutionStatus_EXECUTION_STATUS_RUNNING,
+		Payload: &cleanroomv1.ExecutionStreamEvent_Stderr{
+			Stderr: []byte("update-stderr\n"),
+		},
+	}
+	if got, want := readPTYChunk(t, session), "update-stderr\n"; got != want {
+		t.Fatalf("unexpected update PTY chunk: got %q want %q", got, want)
+	}
+
+	if err := session.SendSignal(15); err != nil {
+		t.Fatalf("SendSignal returned error: %v", err)
+	}
+	if got, want := waitForSignal(t, service.cancelCh), int32(15); got != want {
+		t.Fatalf("unexpected cancel signal: got %d want %d", got, want)
+	}
+
+	service.updates <- &cleanroomv1.ExecutionStreamEvent{
+		SandboxId:   service.session.SandboxID,
+		ExecutionId: service.session.ExecutionID,
+		Status:      cleanroomv1.ExecutionStatus_EXECUTION_STATUS_FAILED,
+		Payload: &cleanroomv1.ExecutionStreamEvent_Exit{
+			Exit: &cleanroomv1.ExecutionExit{
+				ExitCode: 7,
+				Status:   cleanroomv1.ExecutionStatus_EXECUTION_STATUS_FAILED,
+				Message:  "boom",
+			},
+		},
+	}
+	close(service.done)
+	close(service.updates)
+
+	msg := waitForControlMessage(t, session.Events())
+	if got, want := msg.Type, controlTypeExit; got != want {
+		t.Fatalf("unexpected control message type: got %q want %q", got, want)
+	}
+	if got, want := msg.ExitCode, int32(7); got != want {
+		t.Fatalf("unexpected exit code: got %d want %d", got, want)
+	}
+	if got, want := msg.Status, cleanroomv1.ExecutionStatus_EXECUTION_STATUS_FAILED.String(); got != want {
+		t.Fatalf("unexpected exit status: got %q want %q", got, want)
+	}
+
+	if err := session.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+	if got, want := waitForString(t, service.releaseCh), "sandbox-123/exec-123"; got != want {
+		t.Fatalf("unexpected release target: got %q want %q", got, want)
+	}
+}
+
+func TestDialRejectsWrongCertPin(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	service := newIntegrationInteractiveService()
+	server, err := Start(ctx, "127.0.0.1:0", service, nil)
+	if err != nil {
+		t.Fatalf("Start returned error: %v", err)
+	}
+	defer func() {
+		_ = server.Close()
+	}()
+
+	_, err = Dial(
+		context.Background(),
+		server.Addr().String(),
+		server.ALPN(),
+		"sha256:0000000000000000000000000000000000000000000000000000000000000000",
+		service.expectedSessionID,
+		service.expectedToken,
+	)
+	if err == nil {
+		t.Fatal("expected cert pin validation error")
+	}
+	if !strings.Contains(err.Error(), "interactive cert pin mismatch") {
+		t.Fatalf("unexpected cert pin error: %v", err)
+	}
+}
+
+func readPTYChunk(t *testing.T, session *Session) string {
+	t.Helper()
+
+	type result struct {
+		data string
+		err  error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		buf := make([]byte, 1024)
+		n, err := session.ReadPTY(buf)
+		ch <- result{data: string(buf[:n]), err: err}
+	}()
+
+	select {
+	case res := <-ch:
+		if res.err != nil {
+			t.Fatalf("ReadPTY returned error: %v", res.err)
+		}
+		return res.data
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for PTY chunk")
+		return ""
+	}
+}
+
+func waitForResizeCall(t *testing.T, ch <-chan testResizeCall) testResizeCall {
+	t.Helper()
+
+	select {
+	case call := <-ch:
+		return call
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for resize call")
+		return testResizeCall{}
+	}
+}
+
+func waitForString(t *testing.T, ch <-chan string) string {
+	t.Helper()
+
+	select {
+	case value := <-ch:
+		return value
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for string value")
+		return ""
+	}
+}
+
+func waitForSignal(t *testing.T, ch <-chan int32) int32 {
+	t.Helper()
+
+	select {
+	case signal := <-ch:
+		return signal
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for signal")
+		return 0
+	}
+}
+
+func waitForControlMessage(t *testing.T, ch <-chan controlMessage) controlMessage {
+	t.Helper()
+
+	select {
+	case msg, ok := <-ch:
+		if !ok {
+			t.Fatal("control message channel closed before exit event")
+		}
+		return msg
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for control message")
+		return controlMessage{}
+	}
+}
+
+func TestSessionCloseIsIdempotentAfterRemoteEOF(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	service := newIntegrationInteractiveService()
+	server, err := Start(ctx, "127.0.0.1:0", service, nil)
+	if err != nil {
+		t.Fatalf("Start returned error: %v", err)
+	}
+	defer func() {
+		_ = server.Close()
+	}()
+
+	session, err := Dial(context.Background(), server.Addr().String(), server.ALPN(), server.CertPinSHA256(), service.expectedSessionID, service.expectedToken)
+	if err != nil {
+		t.Fatalf("Dial returned error: %v", err)
+	}
+
+	service.updates <- &cleanroomv1.ExecutionStreamEvent{
+		SandboxId:   service.session.SandboxID,
+		ExecutionId: service.session.ExecutionID,
+		Status:      cleanroomv1.ExecutionStatus_EXECUTION_STATUS_SUCCEEDED,
+		Payload: &cleanroomv1.ExecutionStreamEvent_Exit{
+			Exit: &cleanroomv1.ExecutionExit{
+				ExitCode: 0,
+				Status:   cleanroomv1.ExecutionStatus_EXECUTION_STATUS_SUCCEEDED,
+			},
+		},
+	}
+	close(service.done)
+	close(service.updates)
+
+	msg := waitForControlMessage(t, session.Events())
+	if got, want := msg.Type, controlTypeExit; got != want {
+		t.Fatalf("unexpected control message type: got %q want %q", got, want)
+	}
+
+	if err := session.Close(); err != nil && err != io.EOF {
+		t.Fatalf("first Close returned error: %v", err)
+	}
+	if err := session.Close(); err != nil && err != io.EOF {
+		t.Fatalf("second Close returned error: %v", err)
+	}
+}

--- a/scripts/ci-cleanroom-e2e.sh
+++ b/scripts/ci-cleanroom-e2e.sh
@@ -242,7 +242,7 @@ if ! grep -q '^persisted-data$' "$tmpdir/persist-read.out"; then
   exit 1
 fi
 
-mise exec -- go run ./scripts/download_sandbox_file.go \
+mise exec -- go run ./scripts/download_sandbox_file \
   --host "$listen_endpoint" \
   --sandbox-id "$sandbox_id" \
   --path /tmp/persist.txt \

--- a/scripts/ci-cleanroom-e2e.sh
+++ b/scripts/ci-cleanroom-e2e.sh
@@ -268,8 +268,8 @@ if [[ "$terminated_status" -eq 0 ]]; then
   echo "expected execution against terminated sandbox to fail" >&2
   exit 1
 fi
-if ! grep -q 'unknown sandbox' "$tmpdir/terminated.err"; then
-  echo "expected unknown sandbox error after termination" >&2
+if ! grep -Eq 'unknown sandbox|is not ready' "$tmpdir/terminated.err"; then
+  echo "expected unknown-sandbox or not-ready error after termination" >&2
   cat "$tmpdir/terminated.err" >&2 || true
   exit 1
 fi

--- a/scripts/ci-cleanroom-e2e.sh
+++ b/scripts/ci-cleanroom-e2e.sh
@@ -227,6 +227,53 @@ while true; do
   exit 1
 done
 
+echo "--- :recycle: Persistent sandbox lifecycle test"
+sandbox_id="$(./dist/cleanroom sandbox create --host "$listen_endpoint" -c "$PWD" | tr -d '\n')"
+if [[ -z "$sandbox_id" ]]; then
+  echo "sandbox create did not return an id" >&2
+  exit 1
+fi
+echo "sandbox id: $sandbox_id"
+
+./dist/cleanroom exec --host "$listen_endpoint" -c "$PWD" --sandbox-id "$sandbox_id" -- sh -lc 'printf persisted-data >/tmp/persist.txt'
+./dist/cleanroom exec --host "$listen_endpoint" -c "$PWD" --sandbox-id "$sandbox_id" -- sh -lc 'cat /tmp/persist.txt' | tee "$tmpdir/persist-read.out"
+if ! grep -q '^persisted-data$' "$tmpdir/persist-read.out"; then
+  echo "expected persisted sandbox file contents from second execution" >&2
+  exit 1
+fi
+
+mise exec -- go run ./scripts/download_sandbox_file.go \
+  --host "$listen_endpoint" \
+  --sandbox-id "$sandbox_id" \
+  --path /tmp/persist.txt \
+  --max-bytes 4096 >"$tmpdir/persist-download.out"
+if ! grep -q '^persisted-data$' "$tmpdir/persist-download.out"; then
+  echo "expected downloaded sandbox file contents" >&2
+  echo "downloaded payload:" >&2
+  cat "$tmpdir/persist-download.out" >&2 || true
+  exit 1
+fi
+
+./dist/cleanroom sandbox rm --host "$listen_endpoint" "$sandbox_id" | tee "$tmpdir/sandbox-rm.out"
+if ! grep -q 'sandbox terminated' "$tmpdir/sandbox-rm.out"; then
+  echo "expected sandbox terminate acknowledgement" >&2
+  exit 1
+fi
+
+set +e
+./dist/cleanroom exec --host "$listen_endpoint" -c "$PWD" --sandbox-id "$sandbox_id" -- sh -lc 'echo should-not-run' >"$tmpdir/terminated.out" 2>"$tmpdir/terminated.err"
+terminated_status=$?
+set -e
+if [[ "$terminated_status" -eq 0 ]]; then
+  echo "expected execution against terminated sandbox to fail" >&2
+  exit 1
+fi
+if ! grep -q 'unknown sandbox' "$tmpdir/terminated.err"; then
+  echo "expected unknown sandbox error after termination" >&2
+  cat "$tmpdir/terminated.err" >&2 || true
+  exit 1
+fi
+
 echo "--- :satellite: Git gateway allow/deny test"
 git_gateway_attempt=1
 git_gateway_max_attempts=3
@@ -432,7 +479,15 @@ if ! grep -q 'run-observability.json' "$tmpdir/status.out"; then
   exit 1
 fi
 
-obs_file="$(ls -1t "$XDG_STATE_HOME"/cleanroom/runs/*/run-observability.json 2>/dev/null | head -n 1 || true)"
+obs_file="$(
+  find "$XDG_STATE_HOME"/cleanroom/runs -name run-observability.json -type f -print 2>/dev/null \
+    | while IFS= read -r path; do
+        stat -c '%Y %n' "$path"
+      done \
+    | sort -nr \
+    | head -n 1 \
+    | cut -d' ' -f2-
+)"
 if [[ -n "$obs_file" && -f "$obs_file" ]]; then
   extract_json_number() {
     local key="$1"

--- a/scripts/download_sandbox_file.go
+++ b/scripts/download_sandbox_file.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/buildkite/cleanroom/internal/controlclient"
+	"github.com/buildkite/cleanroom/internal/endpoint"
+	"github.com/buildkite/cleanroom/internal/tlsconfig"
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+)
+
+func main() {
+	var (
+		host      string
+		tlsCA     string
+		sandboxID string
+		path      string
+		maxBytes  int64
+	)
+
+	flag.StringVar(&host, "host", "", "Control-plane endpoint")
+	flag.StringVar(&tlsCA, "tls-ca", "", "Path to CA certificate for HTTPS hosts")
+	flag.StringVar(&sandboxID, "sandbox-id", "", "Sandbox ID")
+	flag.StringVar(&path, "path", "", "Absolute guest path to download")
+	flag.Int64Var(&maxBytes, "max-bytes", 10*1024*1024, "Maximum bytes to download")
+	flag.Parse()
+
+	if strings.TrimSpace(host) == "" {
+		fail("missing --host")
+	}
+	if strings.TrimSpace(sandboxID) == "" {
+		fail("missing --sandbox-id")
+	}
+	if strings.TrimSpace(path) == "" {
+		fail("missing --path")
+	}
+
+	ep, err := endpoint.Resolve(host)
+	if err != nil {
+		fail("resolve host: %v", err)
+	}
+	client, err := controlclient.New(ep, controlclient.WithTLS(tlsconfig.Options{
+		CAPath: tlsCA,
+	}))
+	if err != nil {
+		fail("create control client: %v", err)
+	}
+
+	resp, err := client.DownloadSandboxFile(context.Background(), &cleanroomv1.DownloadSandboxFileRequest{
+		SandboxId: sandboxID,
+		Path:      path,
+		MaxBytes:  maxBytes,
+	})
+	if err != nil {
+		fail("download sandbox file: %v", err)
+	}
+	if _, err := os.Stdout.Write(resp.GetData()); err != nil {
+		fail("write download payload: %v", err)
+	}
+}
+
+func fail(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}

--- a/scripts/download_sandbox_file/main.go
+++ b/scripts/download_sandbox_file/main.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/buildkite/cleanroom/internal/controlclient"
 	"github.com/buildkite/cleanroom/internal/endpoint"
-	"github.com/buildkite/cleanroom/internal/tlsconfig"
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+	"github.com/buildkite/cleanroom/internal/tlsconfig"
 )
 
 func main() {


### PR DESCRIPTION
## Summary
- add live QUIC and HTTPS integration coverage for the interactive transport and control plane
- add direct controlserver handler coverage for streaming history/follow behavior and error mapping
- extend CI smoke coverage with persistent Firecracker sandbox lifecycle checks and a darwin-vz E2E step

## Testing
- mise run check
- scripts/ci-darwin-vz-e2e.sh
- Firecracker E2E script not run locally because this host is macOS rather than Linux with /dev/kvm