### PR TITLE
feat(cli): default macOS daemon install to user scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,21 +54,26 @@ cleanroom serve &
 
 The server listens on `unix://$XDG_RUNTIME_DIR/cleanroom/cleanroom.sock` by default.
 
-Install as a system daemon (Linux `systemd` / macOS `launchd`):
+Install as a daemon:
 
 ```bash
+# macOS (non-root): installs a user LaunchAgent by default
+cleanroom serve install
+
+# macOS (system scope)
+sudo cleanroom serve install --system
+
+# Linux (systemd)
 sudo cleanroom serve install
 ```
 
-Use `--force` to overwrite an existing service file:
-
-```bash
-sudo cleanroom serve install --force
-```
+Use `--force` to overwrite an existing service file, and `--user`/`--system`
+to pick scope explicitly on macOS.
 
 The system daemon socket is root-owned (`unix:///var/run/cleanroom/cleanroom.sock`),
 so client commands against that daemon should be run with `sudo` unless you
-configure an alternate endpoint.
+configure an alternate endpoint. User-scope daemons listen on the runtime socket
+(`unix://$XDG_RUNTIME_DIR/cleanroom/cleanroom.sock` when `XDG_RUNTIME_DIR` is set).
 
 Run a command in a sandbox:
 
@@ -251,8 +256,11 @@ cleanroom config init
 On macOS this defaults `default_backend` to `darwin-vz`. On Linux it defaults to `firecracker`.
 If `default_backend` is omitted or blank in an existing config, Cleanroom falls back to the same host default at load time.
 
+Optional endpoint override precedence is `--host`, then `CLEANROOM_HOST`, then `control_host` from runtime config, then defaults (system socket when present, otherwise user runtime socket).
+
 ```yaml
 default_backend: firecracker
+control_host: ""             # optional override for client endpoint resolution
 backends:
   firecracker:
     binary_path: firecracker

--- a/README.md
+++ b/README.md
@@ -57,18 +57,15 @@ The server listens on `unix://$XDG_RUNTIME_DIR/cleanroom/cleanroom.sock` by defa
 Install as a daemon:
 
 ```bash
-# macOS (non-root): installs a user LaunchAgent by default
+# macOS: installs a user LaunchAgent (user-scope only)
 cleanroom serve install
-
-# macOS (system scope)
-sudo cleanroom serve install --system
 
 # Linux (systemd)
 sudo cleanroom serve install
 ```
 
-Use `--force` to overwrite an existing service file, and `--user`/`--system`
-to pick scope explicitly on macOS.
+Use `--force` to overwrite an existing service file. On macOS, `--system`
+is unsupported; `--user` is accepted for explicitness.
 
 The system daemon socket is root-owned (`unix:///var/run/cleanroom/cleanroom.sock`),
 so client commands against that daemon should be run with `sudo` unless you
@@ -256,7 +253,7 @@ cleanroom config init
 On macOS this defaults `default_backend` to `darwin-vz`. On Linux it defaults to `firecracker`.
 If `default_backend` is omitted or blank in an existing config, Cleanroom falls back to the same host default at load time.
 
-Optional endpoint override precedence is `--host`, then `CLEANROOM_HOST`, then `control_host` from runtime config, then defaults (system socket when present, otherwise user runtime socket).
+Optional endpoint override precedence is `--host`, then `CLEANROOM_HOST`, then `control_host` from runtime config, then defaults (macOS: user runtime socket; Linux: system socket when present, otherwise user runtime socket).
 
 ```yaml
 default_backend: firecracker

--- a/docs/api.md
+++ b/docs/api.md
@@ -47,8 +47,8 @@ This keeps one code path while still supporting systemd/launchd unit ergonomics 
 ## 3.2 Endpoint Model
 
 Default endpoint resolution:
-- system socket when present: `unix:///var/run/cleanroom/cleanroom.sock`
-- otherwise user socket: `unix://$XDG_RUNTIME_DIR/cleanroom/cleanroom.sock`
+- macOS: user socket `unix://$XDG_RUNTIME_DIR/cleanroom/cleanroom.sock`
+- Linux: system socket when present `unix:///var/run/cleanroom/cleanroom.sock`, otherwise user socket
 
 Fallbacks:
 1. `--host` flag

--- a/docs/api.md
+++ b/docs/api.md
@@ -46,14 +46,15 @@ This keeps one code path while still supporting systemd/launchd unit ergonomics 
 
 ## 3.2 Endpoint Model
 
-Default endpoint:
-- `unix://$XDG_RUNTIME_DIR/cleanroom/cleanroom.sock`
+Default endpoint resolution:
+- system socket when present: `unix:///var/run/cleanroom/cleanroom.sock`
+- otherwise user socket: `unix://$XDG_RUNTIME_DIR/cleanroom/cleanroom.sock`
 
 Fallbacks:
 1. `--host` flag
 2. `CLEANROOM_HOST`
-3. active context config
-4. default unix socket path
+3. runtime config `control_host`
+4. default endpoint resolution
 
 HTTP endpoints are also supported:
 - `http://host:port` for direct HTTP

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -152,8 +152,16 @@ type clientFlags struct {
 	TLSCA    string `name:"tls-ca" aliases:"tlsca" help:"Path to CA certificate for server verification (auto-discovered from XDG config for https)" env:"CLEANROOM_TLS_CA"`
 }
 
-func (f *clientFlags) connect() (*controlclient.Client, error) {
-	ep, err := endpoint.Resolve(f.Host)
+func (f *clientFlags) resolvedHost(cfg runtimeconfig.Config) string {
+	host := strings.TrimSpace(f.Host)
+	if host != "" {
+		return host
+	}
+	return strings.TrimSpace(cfg.ControlHost)
+}
+
+func (f *clientFlags) connect(ctx *runtimeContext) (*controlclient.Client, error) {
+	ep, err := endpoint.Resolve(f.resolvedHost(ctx.Config))
 	if err != nil {
 		return nil, err
 	}
@@ -210,12 +218,21 @@ type ConsoleCommand struct {
 type ServeCommand struct {
 	Action        string `arg:"" optional:"" help:"Serve action (install, uninstall, status)"`
 	Force         bool   `help:"Overwrite existing daemon service file (serve install only)"`
+	User          bool   `help:"Use user daemon scope (launchd only; install/uninstall/status actions)"`
+	System        bool   `help:"Use system daemon scope (install/uninstall/status actions)"`
 	Listen        string `help:"Listen endpoint for control API (defaults to runtime endpoint)"`
 	GatewayListen string `help:"Listen address for the host gateway (default :8170, use :0 for ephemeral port)"`
 	LogLevel      string `help:"Server log level (debug|info|warn|error)"`
 	TLSCert       string `help:"Path to TLS server certificate (auto-discovered from XDG config for https)" env:"CLEANROOM_TLS_CERT"`
 	TLSKey        string `help:"Path to TLS server private key (auto-discovered from XDG config for https)" env:"CLEANROOM_TLS_KEY"`
 }
+
+type daemonScope string
+
+const (
+	daemonScopeSystem daemonScope = "system"
+	daemonScopeUser   daemonScope = "user"
+)
 
 type StatusCommand struct {
 	RunID   string `help:"Run ID to inspect"`
@@ -345,16 +362,19 @@ var (
 
 		return "", fmt.Errorf("%w; local docker resolution failed: %v", err, localErr)
 	}
-	serveInstallGOOS            = runtime.GOOS
-	serveInstallEUID            = os.Geteuid
-	serveInstallStat            = os.Stat
-	serveInstallMkdirAll        = os.MkdirAll
-	serveInstallWriteFile       = os.WriteFile
-	serveInstallRemoveFile      = os.Remove
-	serveInstallExecutablePath  = os.Executable
-	serveInstallRunCommand      = runServeInstallCommand
-	serveInstallSystemdUnitPath = "/etc/systemd/system/" + systemdServiceName
-	serveInstallLaunchdPath     = "/Library/LaunchDaemons/" + launchdServiceName + ".plist"
+	serveInstallGOOS             = runtime.GOOS
+	serveInstallEUID             = os.Geteuid
+	serveInstallUID              = os.Getuid
+	serveInstallStat             = os.Stat
+	serveInstallMkdirAll         = os.MkdirAll
+	serveInstallWriteFile        = os.WriteFile
+	serveInstallRemoveFile       = os.Remove
+	serveInstallUserHomeDir      = os.UserHomeDir
+	serveInstallExecutablePath   = os.Executable
+	serveInstallRunCommand       = runServeInstallCommand
+	serveInstallRunCommandOutput = runServeInstallCommandOutput
+	serveInstallSystemdUnitPath  = "/etc/systemd/system/" + systemdServiceName
+	serveInstallLaunchdPath      = "/Library/LaunchDaemons/" + launchdServiceName + ".plist"
 )
 
 func isExplicitRegistryReference(raw string) bool {
@@ -709,7 +729,7 @@ func (c *ImageBumpRefCommand) Run(ctx *runtimeContext) error {
 }
 
 func (c *SandboxListCommand) Run(ctx *runtimeContext) error {
-	client, err := c.connect()
+	client, err := c.connect(ctx)
 	if err != nil {
 		return err
 	}
@@ -748,7 +768,7 @@ func (c *SandboxListCommand) Run(ctx *runtimeContext) error {
 }
 
 func (c *SandboxTerminateCommand) Run(ctx *runtimeContext) error {
-	client, err := c.connect()
+	client, err := c.connect(ctx)
 	if err != nil {
 		return err
 	}
@@ -765,7 +785,8 @@ func (c *SandboxTerminateCommand) Run(ctx *runtimeContext) error {
 }
 
 func runSandboxCreate(ctx *runtimeContext, connectFlags clientFlags, chdir, backend, imageRefOverride string, launchSeconds int64, outputJSON bool) error {
-	client, err := connectFlags.connect()
+	resolvedHost := connectFlags.resolvedHost(ctx.Config)
+	client, err := connectFlags.connect(ctx)
 	if err != nil {
 		return err
 	}
@@ -778,7 +799,7 @@ func runSandboxCreate(ctx *runtimeContext, connectFlags clientFlags, chdir, back
 	if err != nil {
 		return err
 	}
-	allowLocalImageOverride, err := isLocalControlPlaneEndpoint(connectFlags.Host)
+	allowLocalImageOverride, err := isLocalControlPlaneEndpoint(resolvedHost)
 	if err != nil {
 		return err
 	}
@@ -828,7 +849,8 @@ func (e *ExecCommand) Run(ctx *runtimeContext) error {
 		return err
 	}
 
-	client, err := e.connect()
+	host := e.resolvedHost(ctx.Config)
+	client, err := e.connect(ctx)
 	if err != nil {
 		return err
 	}
@@ -838,12 +860,12 @@ func (e *ExecCommand) Run(ctx *runtimeContext) error {
 	}
 
 	logger.Debug("sending execution request",
-		"host", e.Host,
+		"host", host,
 		"backend", e.Backend,
 		"sandbox_id", strings.TrimSpace(e.SandboxID),
 		"command_argc", len(e.Command),
 	)
-	sandboxID, err := ensureSandboxID(client, ctx.Loader, cwd, e.Host, e.Backend, strings.TrimSpace(e.SandboxID), e.Image, e.LaunchSeconds)
+	sandboxID, err := ensureSandboxID(client, ctx.Loader, cwd, host, e.Backend, strings.TrimSpace(e.SandboxID), e.Image, e.LaunchSeconds)
 	if err != nil {
 		return err
 	}
@@ -987,7 +1009,8 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) error {
 		return err
 	}
 
-	client, err := c.connect()
+	host := c.resolvedHost(ctx.Config)
+	client, err := c.connect(ctx)
 	if err != nil {
 		return err
 	}
@@ -1001,12 +1024,12 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) error {
 		command = []string{"sh"}
 	}
 	logger.Debug("starting interactive console",
-		"host", c.Host,
+		"host", host,
 		"backend", c.Backend,
 		"sandbox_id", strings.TrimSpace(c.SandboxID),
 		"command_argc", len(command),
 	)
-	sandboxID, err := ensureSandboxID(client, ctx.Loader, cwd, c.Host, c.Backend, strings.TrimSpace(c.SandboxID), c.Image, c.LaunchSeconds)
+	sandboxID, err := ensureSandboxID(client, ctx.Loader, cwd, host, c.Backend, strings.TrimSpace(c.SandboxID), c.Image, c.LaunchSeconds)
 	if err != nil {
 		return err
 	}
@@ -1063,7 +1086,7 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) error {
 		}
 		return fmt.Errorf("open interactive execution: %w", err)
 	}
-	controlEndpoint, err := endpoint.Resolve(c.Host)
+	controlEndpoint, err := endpoint.Resolve(host)
 	if err != nil {
 		return err
 	}
@@ -1348,6 +1371,9 @@ func (s *ServeCommand) Run(ctx *runtimeContext) error {
 		if s.Force {
 			return errors.New("--force is only supported with 'cleanroom serve install'")
 		}
+		if s.User || s.System {
+			return errors.New("--user and --system are only supported with 'cleanroom serve install', 'cleanroom serve uninstall', or 'cleanroom serve status'")
+		}
 		return s.runServer(ctx)
 	case "install":
 		return s.installDaemon(ctx)
@@ -1360,10 +1386,58 @@ func (s *ServeCommand) Run(ctx *runtimeContext) error {
 	}
 }
 
-func (s *ServeCommand) daemonRunArgs(cwd string) ([]string, error) {
+func (s *ServeCommand) requestedDaemonScope() (daemonScope, bool, error) {
+	if s.User && s.System {
+		return "", false, errors.New("--user and --system cannot be used together")
+	}
+	if s.User {
+		return daemonScopeUser, true, nil
+	}
+	if s.System {
+		return daemonScopeSystem, true, nil
+	}
+	return "", false, nil
+}
+
+func (s *ServeCommand) effectiveDaemonScope() (daemonScope, error) {
+	requested, hasScope, err := s.requestedDaemonScope()
+	if err != nil {
+		return "", err
+	}
+
+	switch serveInstallGOOS {
+	case "linux":
+		if hasScope && requested == daemonScopeUser {
+			return "", errors.New("--user is unsupported on linux (systemd user mode is not yet implemented)")
+		}
+		return daemonScopeSystem, nil
+	case "darwin":
+		if hasScope {
+			if requested == daemonScopeUser && serveInstallEUID() == 0 {
+				return "", errors.New("--user cannot be used as root on darwin (run without sudo)")
+			}
+			return requested, nil
+		}
+		if serveInstallEUID() == 0 {
+			return daemonScopeSystem, nil
+		}
+		return daemonScopeUser, nil
+	default:
+		if hasScope && requested == daemonScopeUser {
+			return "", fmt.Errorf("--user is unsupported on %s", serveInstallGOOS)
+		}
+		return daemonScopeSystem, nil
+	}
+}
+
+func (s *ServeCommand) daemonRunArgs(cwd string, scope daemonScope) ([]string, error) {
 	listen := strings.TrimSpace(s.Listen)
 	if listen == "" {
-		listen = defaultDaemonListen
+		if scope == daemonScopeUser {
+			listen = "unix://" + endpoint.Default().Address
+		} else {
+			listen = defaultDaemonListen
+		}
 	}
 
 	args := []string{"serve", "--listen", listen}
@@ -1410,17 +1484,26 @@ func resolveDaemonInstallPath(cwd, value string) (string, error) {
 }
 
 func (s *ServeCommand) installDaemon(ctx *runtimeContext) error {
+	scope, err := s.effectiveDaemonScope()
+	if err != nil {
+		return err
+	}
+
 	var installFn func(io.Writer, string, []string, bool) error
 	switch serveInstallGOOS {
 	case "linux":
 		installFn = installSystemdDaemon
 	case "darwin":
-		installFn = installLaunchdDaemon
+		if scope == daemonScopeUser {
+			installFn = installLaunchdUserDaemon
+		} else {
+			installFn = installLaunchdDaemon
+		}
 	default:
 		return fmt.Errorf("serve install is unsupported on %s (expected linux or darwin)", serveInstallGOOS)
 	}
 
-	if serveInstallEUID() != 0 {
+	if scope == daemonScopeSystem && serveInstallEUID() != 0 {
 		return errors.New("serve install requires root privileges (use sudo cleanroom serve install)")
 	}
 
@@ -1435,7 +1518,7 @@ func (s *ServeCommand) installDaemon(ctx *runtimeContext) error {
 		}
 	}
 
-	args, err := s.daemonRunArgs(ctx.CWD)
+	args, err := s.daemonRunArgs(ctx.CWD, scope)
 	if err != nil {
 		return err
 	}
@@ -1443,17 +1526,26 @@ func (s *ServeCommand) installDaemon(ctx *runtimeContext) error {
 }
 
 func (s *ServeCommand) uninstallDaemon(ctx *runtimeContext) error {
+	scope, err := s.effectiveDaemonScope()
+	if err != nil {
+		return err
+	}
+
 	var uninstallFn func(io.Writer) error
 	switch serveInstallGOOS {
 	case "linux":
 		uninstallFn = uninstallSystemdDaemon
 	case "darwin":
-		uninstallFn = uninstallLaunchdDaemon
+		if scope == daemonScopeUser {
+			uninstallFn = uninstallLaunchdUserDaemon
+		} else {
+			uninstallFn = uninstallLaunchdDaemon
+		}
 	default:
 		return fmt.Errorf("serve uninstall is unsupported on %s (expected linux or darwin)", serveInstallGOOS)
 	}
 
-	if serveInstallEUID() != 0 {
+	if scope == daemonScopeSystem && serveInstallEUID() != 0 {
 		return errors.New("serve uninstall requires root privileges (use sudo cleanroom serve uninstall)")
 	}
 
@@ -1484,16 +1576,28 @@ func uninstallSystemdDaemon(stdout io.Writer) error {
 }
 
 func uninstallLaunchdDaemon(stdout io.Writer) error {
-	if _, err := serveInstallStat(serveInstallLaunchdPath); errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("service file %s does not exist", serveInstallLaunchdPath)
+	return uninstallLaunchdDaemonInDomain(stdout, serveInstallLaunchdPath, "system")
+}
+
+func uninstallLaunchdUserDaemon(stdout io.Writer) error {
+	path, err := launchdUserServicePath()
+	if err != nil {
+		return err
+	}
+	return uninstallLaunchdDaemonInDomain(stdout, path, launchdUserDomain())
+}
+
+func uninstallLaunchdDaemonInDomain(stdout io.Writer, servicePath, domain string) error {
+	if _, err := serveInstallStat(servicePath); errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("service file %s does not exist", servicePath)
 	}
 
-	if err := serveInstallRunCommand("launchctl", "bootout", "system/"+launchdServiceName); err != nil && !isExitError(err) {
+	if err := serveInstallRunCommand("launchctl", "bootout", launchdServiceTarget(domain)); err != nil && !isExitError(err) {
 		return fmt.Errorf("bootout launchd service %s: %w", launchdServiceName, err)
 	}
 
-	if err := serveInstallRemoveFile(serveInstallLaunchdPath); err != nil {
-		return fmt.Errorf("remove service file %s: %w", serveInstallLaunchdPath, err)
+	if err := serveInstallRemoveFile(servicePath); err != nil {
+		return fmt.Errorf("remove service file %s: %w", servicePath, err)
 	}
 
 	_, err := fmt.Fprintf(stdout, "daemon uninstalled\nmanager=launchd\nservice=%s\n", launchdServiceName)
@@ -1501,12 +1605,21 @@ func uninstallLaunchdDaemon(stdout io.Writer) error {
 }
 
 func (s *ServeCommand) daemonStatus(ctx *runtimeContext) error {
+	scope, err := s.effectiveDaemonScope()
+	if err != nil {
+		return err
+	}
+
 	var statusFn func(io.Writer) error
 	switch serveInstallGOOS {
 	case "linux":
 		statusFn = systemdDaemonStatus
 	case "darwin":
-		statusFn = launchdDaemonStatus
+		if scope == daemonScopeUser {
+			statusFn = launchdUserDaemonStatus
+		} else {
+			statusFn = launchdDaemonStatus
+		}
 	default:
 		return fmt.Errorf("serve status is unsupported on %s (expected linux or darwin)", serveInstallGOOS)
 	}
@@ -1540,21 +1653,167 @@ func systemdDaemonStatus(stdout io.Writer) error {
 }
 
 func launchdDaemonStatus(stdout io.Writer) error {
+	return launchdDaemonStatusInDomain(stdout, serveInstallLaunchdPath, "system")
+}
+
+func launchdUserDaemonStatus(stdout io.Writer) error {
+	path, err := launchdUserServicePath()
+	if err != nil {
+		return err
+	}
+	return launchdDaemonStatusInDomain(stdout, path, launchdUserDomain())
+}
+
+func launchdDaemonStatusInDomain(stdout io.Writer, servicePath, domain string) error {
 	installed := "false"
-	if _, err := serveInstallStat(serveInstallLaunchdPath); err == nil {
+	if _, err := serveInstallStat(servicePath); err == nil {
 		installed = "true"
 	}
 
 	active := "inactive"
-	if err := serveInstallRunCommand("launchctl", "print", "system/"+launchdServiceName); err == nil {
-		active = "active"
+	state := ""
+	if output, err := serveInstallRunCommandOutput("launchctl", "print", launchdServiceTarget(domain)); err == nil {
+		state = launchdServiceState(output)
+		if state == "running" {
+			active = "active"
+		}
 	} else if !isExitError(err) {
 		return fmt.Errorf("check launchd service state: %w", err)
 	}
 
+	listen := ""
+	if installed == "true" {
+		if value, err := launchdConfiguredListenEndpoint(servicePath); err == nil {
+			listen = value
+		}
+	}
+
 	_, err := fmt.Fprintf(stdout, "manager=launchd\nservice=%s\ninstalled=%s\nactive=%s\n",
 		launchdServiceName, installed, active)
-	return err
+	if err != nil {
+		return err
+	}
+	if state != "" {
+		if _, err := fmt.Fprintf(stdout, "state=%s\n", state); err != nil {
+			return err
+		}
+	}
+	if listen != "" {
+		if _, err := fmt.Fprintf(stdout, "listen=%s\n", listen); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func launchdServiceState(output string) string {
+	for _, line := range strings.Split(output, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "state =") {
+			continue
+		}
+		return strings.TrimSpace(strings.TrimPrefix(trimmed, "state ="))
+	}
+	return ""
+}
+
+func launchdConfiguredListenEndpoint(plistPath string) (string, error) {
+	raw, err := os.ReadFile(plistPath)
+	if err != nil {
+		return "", err
+	}
+
+	args, err := launchdProgramArguments(raw)
+	if err != nil {
+		return "", err
+	}
+
+	for i := 0; i < len(args)-1; i++ {
+		if strings.TrimSpace(args[i]) == "--listen" {
+			return strings.TrimSpace(args[i+1]), nil
+		}
+	}
+	return "", nil
+}
+
+func launchdProgramArguments(plistContent []byte) ([]string, error) {
+	decoder := xml.NewDecoder(bytes.NewReader(plistContent))
+	for {
+		tok, err := decoder.Token()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, err
+		}
+
+		start, ok := tok.(xml.StartElement)
+		if !ok || start.Name.Local != "key" {
+			continue
+		}
+
+		var key string
+		if err := decoder.DecodeElement(&key, &start); err != nil {
+			return nil, err
+		}
+		if strings.TrimSpace(key) != "ProgramArguments" {
+			continue
+		}
+
+		for {
+			tok, err = decoder.Token()
+			if err != nil {
+				if errors.Is(err, io.EOF) {
+					return nil, errors.New("ProgramArguments value missing")
+				}
+				return nil, err
+			}
+
+			start, ok = tok.(xml.StartElement)
+			if !ok {
+				continue
+			}
+			if start.Name.Local != "array" {
+				if err := decoder.Skip(); err != nil {
+					return nil, err
+				}
+				continue
+			}
+			return plistStringArray(decoder)
+		}
+	}
+
+	return nil, errors.New("ProgramArguments not found")
+}
+
+func plistStringArray(decoder *xml.Decoder) ([]string, error) {
+	var values []string
+	for {
+		tok, err := decoder.Token()
+		if err != nil {
+			return nil, err
+		}
+
+		switch token := tok.(type) {
+		case xml.StartElement:
+			if token.Name.Local != "string" {
+				if err := decoder.Skip(); err != nil {
+					return nil, err
+				}
+				continue
+			}
+
+			var value string
+			if err := decoder.DecodeElement(&value, &token); err != nil {
+				return nil, err
+			}
+			values = append(values, value)
+		case xml.EndElement:
+			if token.Name.Local == "array" {
+				return values, nil
+			}
+		}
+	}
 }
 
 func installSystemdDaemon(stdout io.Writer, executablePath string, args []string, force bool) error {
@@ -1580,22 +1839,51 @@ func installSystemdDaemon(stdout io.Writer, executablePath string, args []string
 }
 
 func installLaunchdDaemon(stdout io.Writer, executablePath string, args []string, force bool) error {
+	return installLaunchdDaemonInDomain(stdout, executablePath, args, force, serveInstallLaunchdPath, "system")
+}
+
+func installLaunchdUserDaemon(stdout io.Writer, executablePath string, args []string, force bool) error {
+	path, err := launchdUserServicePath()
+	if err != nil {
+		return err
+	}
+	return installLaunchdDaemonInDomain(stdout, executablePath, args, force, path, launchdUserDomain())
+}
+
+func launchdUserServicePath() (string, error) {
+	home, err := serveInstallUserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve user home directory: %w", err)
+	}
+	return filepath.Join(home, "Library", "LaunchAgents", launchdServiceName+".plist"), nil
+}
+
+func launchdUserDomain() string {
+	return fmt.Sprintf("gui/%d", serveInstallUID())
+}
+
+func launchdServiceTarget(domain string) string {
+	return strings.TrimSpace(domain) + "/" + launchdServiceName
+}
+
+func installLaunchdDaemonInDomain(stdout io.Writer, executablePath string, args []string, force bool, servicePath, domain string) error {
 	content := renderLaunchdService(executablePath, args)
-	if err := writeDaemonFile(serveInstallLaunchdPath, content, force, 0o644); err != nil {
+	if err := writeDaemonFile(servicePath, content, force, 0o644); err != nil {
 		return err
 	}
 
+	target := launchdServiceTarget(domain)
 	if force {
-		_ = serveInstallRunCommand("launchctl", "bootout", "system/"+launchdServiceName)
+		_ = serveInstallRunCommand("launchctl", "bootout", target)
 	}
-	if err := serveInstallRunCommand("launchctl", "bootstrap", "system", serveInstallLaunchdPath); err != nil {
+	if err := serveInstallRunCommand("launchctl", "bootstrap", domain, servicePath); err != nil {
 		return fmt.Errorf("bootstrap launchd service %s: %w", launchdServiceName, err)
 	}
-	if err := serveInstallRunCommand("launchctl", "enable", "system/"+launchdServiceName); err != nil {
+	if err := serveInstallRunCommand("launchctl", "enable", target); err != nil {
 		return fmt.Errorf("enable launchd service %s: %w", launchdServiceName, err)
 	}
 
-	_, err := fmt.Fprintf(stdout, "daemon installed\nmanager=launchd\nservice=%s\npath=%s\n", launchdServiceName, serveInstallLaunchdPath)
+	_, err := fmt.Fprintf(stdout, "daemon installed\nmanager=launchd\nservice=%s\npath=%s\n", launchdServiceName, servicePath)
 	return err
 }
 
@@ -1692,6 +1980,11 @@ func isExitError(err error) bool {
 }
 
 func runServeInstallCommand(name string, args ...string) error {
+	_, err := runServeInstallCommandOutput(name, args...)
+	return err
+}
+
+func runServeInstallCommandOutput(name string, args ...string) (string, error) {
 	cmd := exec.Command(name, args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -1700,9 +1993,9 @@ func runServeInstallCommand(name string, args ...string) error {
 			msg = "no stderr output"
 		}
 		parts := append([]string{name}, args...)
-		return fmt.Errorf("%s: %w (%s)", strings.Join(parts, " "), err, msg)
+		return "", fmt.Errorf("%s: %w (%s)", strings.Join(parts, " "), err, msg)
 	}
-	return nil
+	return string(out), nil
 }
 
 func (s *ServeCommand) runServer(ctx *runtimeContext) error {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -219,7 +219,7 @@ type ServeCommand struct {
 	Action        string `arg:"" optional:"" help:"Serve action (install, uninstall, status)"`
 	Force         bool   `help:"Overwrite existing daemon service file (serve install only)"`
 	User          bool   `help:"Use user daemon scope (launchd only; install/uninstall/status actions)"`
-	System        bool   `help:"Use system daemon scope (install/uninstall/status actions)"`
+	System        bool   `help:"Use system daemon scope (linux only; install/uninstall/status actions)"`
 	Listen        string `help:"Listen endpoint for control API (defaults to runtime endpoint)"`
 	GatewayListen string `help:"Listen address for the host gateway (default :8170, use :0 for ephemeral port)"`
 	LogLevel      string `help:"Server log level (debug|info|warn|error)"`
@@ -1412,14 +1412,11 @@ func (s *ServeCommand) effectiveDaemonScope() (daemonScope, error) {
 		}
 		return daemonScopeSystem, nil
 	case "darwin":
-		if hasScope {
-			if requested == daemonScopeUser && serveInstallEUID() == 0 {
-				return "", errors.New("--user cannot be used as root on darwin (run without sudo)")
-			}
-			return requested, nil
+		if hasScope && requested == daemonScopeSystem {
+			return "", errors.New("--system is unsupported on darwin (macOS supports user launchd daemons only)")
 		}
 		if serveInstallEUID() == 0 {
-			return daemonScopeSystem, nil
+			return "", errors.New("darwin supports user launchd daemons only; run 'cleanroom serve' without sudo")
 		}
 		return daemonScopeUser, nil
 	default:
@@ -1774,10 +1771,7 @@ func launchdProgramArguments(plistContent []byte) ([]string, error) {
 				continue
 			}
 			if start.Name.Local != "array" {
-				if err := decoder.Skip(); err != nil {
-					return nil, err
-				}
-				continue
+				return nil, fmt.Errorf("ProgramArguments must be an array, got <%s>", start.Name.Local)
 			}
 			return plistStringArray(decoder)
 		}

--- a/internal/cli/cli_parse_test.go
+++ b/internal/cli/cli_parse_test.go
@@ -203,3 +203,27 @@ func TestServeInstallForceParses(t *testing.T) {
 		t.Fatal("expected --force to set Serve.Force")
 	}
 }
+
+func TestServeInstallUserParses(t *testing.T) {
+	c := &CLI{}
+	parser := newParserForTest(t, c)
+
+	if _, err := parser.Parse([]string{"serve", "install", "--user"}); err != nil {
+		t.Fatalf("parse serve install --user returned error: %v", err)
+	}
+	if !c.Serve.User {
+		t.Fatal("expected --user to set Serve.User")
+	}
+}
+
+func TestServeInstallSystemParses(t *testing.T) {
+	c := &CLI{}
+	parser := newParserForTest(t, c)
+
+	if _, err := parser.Parse([]string{"serve", "install", "--system"}); err != nil {
+		t.Fatalf("parse serve install --system returned error: %v", err)
+	}
+	if !c.Serve.System {
+		t.Fatal("expected --system to set Serve.System")
+	}
+}

--- a/internal/cli/client_flags_test.go
+++ b/internal/cli/client_flags_test.go
@@ -1,0 +1,40 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/runtimeconfig"
+)
+
+func TestClientFlagsResolvedHostPrefersExplicitHost(t *testing.T) {
+	t.Parallel()
+
+	flags := clientFlags{Host: "unix:///tmp/explicit.sock"}
+	cfg := runtimeconfig.Config{ControlHost: "unix:///tmp/from-config.sock"}
+
+	if got, want := flags.resolvedHost(cfg), "unix:///tmp/explicit.sock"; got != want {
+		t.Fatalf("resolvedHost mismatch: got %q want %q", got, want)
+	}
+}
+
+func TestClientFlagsResolvedHostUsesConfigFallback(t *testing.T) {
+	t.Parallel()
+
+	flags := clientFlags{}
+	cfg := runtimeconfig.Config{ControlHost: "unix:///tmp/from-config.sock"}
+
+	if got, want := flags.resolvedHost(cfg), "unix:///tmp/from-config.sock"; got != want {
+		t.Fatalf("resolvedHost mismatch: got %q want %q", got, want)
+	}
+}
+
+func TestClientFlagsResolvedHostReturnsEmptyWhenUnset(t *testing.T) {
+	t.Parallel()
+
+	flags := clientFlags{}
+	cfg := runtimeconfig.Config{}
+
+	if got := flags.resolvedHost(cfg); got != "" {
+		t.Fatalf("resolvedHost mismatch: got %q want empty", got)
+	}
+}

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -308,7 +308,7 @@ func TestServeInstallDarwinDefaultsToUserScopeForNonRoot(t *testing.T) {
 	}
 }
 
-func TestServeInstallDarwinSystemScopeRequiresRoot(t *testing.T) {
+func TestServeInstallDarwinSystemScopeUnsupported(t *testing.T) {
 	prevEUID := serveInstallEUID
 	prevGOOS := serveInstallGOOS
 	serveInstallEUID = func() int { return 501 }
@@ -322,9 +322,30 @@ func TestServeInstallDarwinSystemScopeRequiresRoot(t *testing.T) {
 	cmd := &ServeCommand{Action: "install", System: true}
 	err := cmd.Run(&runtimeContext{CWD: t.TempDir(), Stdout: stdout})
 	if err == nil {
-		t.Fatal("expected root requirement error for --system")
+		t.Fatal("expected unsupported --system error on darwin")
 	}
-	if !strings.Contains(err.Error(), "requires root") {
+	if !strings.Contains(err.Error(), "--system is unsupported on darwin") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestServeInstallDarwinRejectsRootByDefault(t *testing.T) {
+	prevEUID := serveInstallEUID
+	prevGOOS := serveInstallGOOS
+	serveInstallEUID = func() int { return 0 }
+	serveInstallGOOS = "darwin"
+	t.Cleanup(func() {
+		serveInstallEUID = prevEUID
+		serveInstallGOOS = prevGOOS
+	})
+
+	stdout, _ := makeStdoutCapture(t)
+	cmd := &ServeCommand{Action: "install"}
+	err := cmd.Run(&runtimeContext{CWD: t.TempDir(), Stdout: stdout})
+	if err == nil {
+		t.Fatal("expected root usage error on darwin")
+	}
+	if !strings.Contains(err.Error(), "run 'cleanroom serve' without sudo") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -673,31 +694,40 @@ func TestServeStatusUnsupportedOS(t *testing.T) {
 
 func TestServeStatusLaunchdIncludesListenEndpoint(t *testing.T) {
 	tmpDir := t.TempDir()
-	plistPath := filepath.Join(tmpDir, "com.buildkite.cleanroom.plist")
+	plistPath := filepath.Join(tmpDir, "Library", "LaunchAgents", launchdServiceName+".plist")
 	content := renderLaunchdService("/usr/local/bin/cleanroom", []string{"serve", "--listen", "unix:///tmp/custom-cleanroom.sock"})
+	if err := os.MkdirAll(filepath.Dir(plistPath), 0o755); err != nil {
+		t.Fatalf("mkdir launch agents dir: %v", err)
+	}
 	if err := os.WriteFile(plistPath, []byte(content), 0o644); err != nil {
 		t.Fatalf("write launchd plist: %v", err)
 	}
 
 	prevGOOS := serveInstallGOOS
-	prevLaunchdPath := serveInstallLaunchdPath
+	prevEUID := serveInstallEUID
+	prevUID := serveInstallUID
+	prevUserHomeDir := serveInstallUserHomeDir
 	prevRunCommand := serveInstallRunCommand
 	prevRunCommandOutput := serveInstallRunCommandOutput
 	serveInstallGOOS = "darwin"
-	serveInstallLaunchdPath = plistPath
+	serveInstallEUID = func() int { return 501 }
+	serveInstallUID = func() int { return 501 }
+	serveInstallUserHomeDir = func() (string, error) { return tmpDir, nil }
 	serveInstallRunCommand = func(name string, args ...string) error { return nil }
 	serveInstallRunCommandOutput = func(name string, args ...string) (string, error) {
 		return "state = running\n", nil
 	}
 	t.Cleanup(func() {
 		serveInstallGOOS = prevGOOS
-		serveInstallLaunchdPath = prevLaunchdPath
+		serveInstallEUID = prevEUID
+		serveInstallUID = prevUID
+		serveInstallUserHomeDir = prevUserHomeDir
 		serveInstallRunCommand = prevRunCommand
 		serveInstallRunCommandOutput = prevRunCommandOutput
 	})
 
 	stdout, readStdout := makeStdoutCapture(t)
-	cmd := &ServeCommand{Action: "status", System: true}
+	cmd := &ServeCommand{Action: "status"}
 	if err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout}); err != nil {
 		t.Fatalf("ServeCommand.Run returned error: %v", err)
 	}
@@ -710,28 +740,37 @@ func TestServeStatusLaunchdIncludesListenEndpoint(t *testing.T) {
 
 func TestServeStatusLaunchdReportsInactiveWhenNotRunning(t *testing.T) {
 	tmpDir := t.TempDir()
-	plistPath := filepath.Join(tmpDir, "com.buildkite.cleanroom.plist")
+	plistPath := filepath.Join(tmpDir, "Library", "LaunchAgents", launchdServiceName+".plist")
 	content := renderLaunchdService("/usr/local/bin/cleanroom", []string{"serve", "--listen", "unix:///tmp/custom-cleanroom.sock"})
+	if err := os.MkdirAll(filepath.Dir(plistPath), 0o755); err != nil {
+		t.Fatalf("mkdir launch agents dir: %v", err)
+	}
 	if err := os.WriteFile(plistPath, []byte(content), 0o644); err != nil {
 		t.Fatalf("write launchd plist: %v", err)
 	}
 
 	prevGOOS := serveInstallGOOS
-	prevLaunchdPath := serveInstallLaunchdPath
+	prevEUID := serveInstallEUID
+	prevUID := serveInstallUID
+	prevUserHomeDir := serveInstallUserHomeDir
 	prevRunCommandOutput := serveInstallRunCommandOutput
 	serveInstallGOOS = "darwin"
-	serveInstallLaunchdPath = plistPath
+	serveInstallEUID = func() int { return 501 }
+	serveInstallUID = func() int { return 501 }
+	serveInstallUserHomeDir = func() (string, error) { return tmpDir, nil }
 	serveInstallRunCommandOutput = func(name string, args ...string) (string, error) {
 		return "state = spawn scheduled\n", nil
 	}
 	t.Cleanup(func() {
 		serveInstallGOOS = prevGOOS
-		serveInstallLaunchdPath = prevLaunchdPath
+		serveInstallEUID = prevEUID
+		serveInstallUID = prevUID
+		serveInstallUserHomeDir = prevUserHomeDir
 		serveInstallRunCommandOutput = prevRunCommandOutput
 	})
 
 	stdout, readStdout := makeStdoutCapture(t)
-	cmd := &ServeCommand{Action: "status", System: true}
+	cmd := &ServeCommand{Action: "status"}
 	if err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout}); err != nil {
 		t.Fatalf("ServeCommand.Run returned error: %v", err)
 	}
@@ -762,6 +801,34 @@ func TestRenderLaunchdServiceOmitsEnvironmentVariables(t *testing.T) {
 	plist := renderLaunchdService("/usr/local/bin/cleanroom", []string{"serve"})
 	if strings.Contains(plist, "EnvironmentVariables") {
 		t.Fatalf("expected launchd plist to omit EnvironmentVariables, got:\n%s", plist)
+	}
+}
+
+func TestLaunchdProgramArgumentsRejectsNonArrayValue(t *testing.T) {
+	plist := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.buildkite.cleanroom</string>
+	<key>ProgramArguments</key>
+	<dict>
+		<key>unexpected</key>
+		<string>value</string>
+	</dict>
+	<key>EnvironmentVariables</key>
+	<array>
+		<string>SHOULD_NOT_BE_PARSED</string>
+	</array>
+</dict>
+</plist>`
+
+	_, err := launchdProgramArguments([]byte(plist))
+	if err == nil {
+		t.Fatal("expected ProgramArguments parsing error when value is not an array")
+	}
+	if !strings.Contains(err.Error(), "must be an array") {
+		t.Fatalf("expected non-array ProgramArguments error, got: %v", err)
 	}
 }
 

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -39,9 +39,12 @@ func TestShouldInstallGatewayFirewall(t *testing.T) {
 
 func TestServeInstallRequiresRoot(t *testing.T) {
 	prevEUID := serveInstallEUID
+	prevGOOS := serveInstallGOOS
 	serveInstallEUID = func() int { return 1000 }
+	serveInstallGOOS = "linux"
 	t.Cleanup(func() {
 		serveInstallEUID = prevEUID
+		serveInstallGOOS = prevGOOS
 	})
 
 	stdout, _ := makeStdoutCapture(t)
@@ -55,6 +58,18 @@ func TestServeInstallRequiresRoot(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "sudo cleanroom serve install") {
 		t.Fatalf("expected sudo guidance, got: %v", err)
+	}
+}
+
+func TestServeRunRejectsScopeFlags(t *testing.T) {
+	stdout, _ := makeStdoutCapture(t)
+	cmd := &ServeCommand{User: true}
+	err := cmd.Run(&runtimeContext{CWD: t.TempDir(), Stdout: stdout})
+	if err == nil {
+		t.Fatal("expected scope-flag validation error")
+	}
+	if !strings.Contains(err.Error(), "only supported with") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
@@ -236,6 +251,123 @@ func TestServeInstallUsesProvidedListenInUnit(t *testing.T) {
 	}
 	if strings.Contains(content, "--listen unix:///var/run/cleanroom/cleanroom.sock") {
 		t.Fatalf("did not expect default listen when custom listen is provided, got:\n%s", content)
+	}
+}
+
+func TestServeInstallDarwinDefaultsToUserScopeForNonRoot(t *testing.T) {
+	tmpDir := t.TempDir()
+	plistPath := filepath.Join(tmpDir, "Library", "LaunchAgents", launchdServiceName+".plist")
+
+	prevEUID := serveInstallEUID
+	prevUID := serveInstallUID
+	prevGOOS := serveInstallGOOS
+	prevUserHomeDir := serveInstallUserHomeDir
+	prevExecutable := serveInstallExecutablePath
+	prevRunCommand := serveInstallRunCommand
+	serveInstallEUID = func() int { return 501 }
+	serveInstallUID = func() int { return 501 }
+	serveInstallGOOS = "darwin"
+	serveInstallUserHomeDir = func() (string, error) { return tmpDir, nil }
+	serveInstallExecutablePath = func() (string, error) { return "/usr/local/bin/cleanroom", nil }
+	var calls [][]string
+	serveInstallRunCommand = func(name string, args ...string) error {
+		calls = append(calls, append([]string{name}, args...))
+		return nil
+	}
+	t.Cleanup(func() {
+		serveInstallEUID = prevEUID
+		serveInstallUID = prevUID
+		serveInstallGOOS = prevGOOS
+		serveInstallUserHomeDir = prevUserHomeDir
+		serveInstallExecutablePath = prevExecutable
+		serveInstallRunCommand = prevRunCommand
+	})
+
+	stdout, _ := makeStdoutCapture(t)
+	cmd := &ServeCommand{Action: "install"}
+	if err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout}); err != nil {
+		t.Fatalf("ServeCommand.Run returned error: %v", err)
+	}
+
+	wantDomain := "gui/501"
+	if !containsServeInstallCall(calls, []string{"launchctl", "bootstrap", wantDomain}) {
+		t.Fatalf("expected launchctl bootstrap for user domain %q, calls=%v", wantDomain, calls)
+	}
+	if containsServeInstallCall(calls, []string{"launchctl", "bootstrap", "system"}) {
+		t.Fatalf("did not expect launchctl bootstrap for system domain, calls=%v", calls)
+	}
+	if _, err := os.Stat(plistPath); err != nil {
+		t.Fatalf("expected user launchd plist to be written at %s: %v", plistPath, err)
+	}
+	raw, err := os.ReadFile(plistPath)
+	if err != nil {
+		t.Fatalf("read user launchd plist: %v", err)
+	}
+	if strings.Contains(string(raw), "--listen unix:///var/run/cleanroom/cleanroom.sock") {
+		t.Fatalf("did not expect user launchd plist to use system socket:\n%s", raw)
+	}
+}
+
+func TestServeInstallDarwinSystemScopeRequiresRoot(t *testing.T) {
+	prevEUID := serveInstallEUID
+	prevGOOS := serveInstallGOOS
+	serveInstallEUID = func() int { return 501 }
+	serveInstallGOOS = "darwin"
+	t.Cleanup(func() {
+		serveInstallEUID = prevEUID
+		serveInstallGOOS = prevGOOS
+	})
+
+	stdout, _ := makeStdoutCapture(t)
+	cmd := &ServeCommand{Action: "install", System: true}
+	err := cmd.Run(&runtimeContext{CWD: t.TempDir(), Stdout: stdout})
+	if err == nil {
+		t.Fatal("expected root requirement error for --system")
+	}
+	if !strings.Contains(err.Error(), "requires root") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestServeInstallLinuxUserScopeUnsupported(t *testing.T) {
+	prevEUID := serveInstallEUID
+	prevGOOS := serveInstallGOOS
+	serveInstallEUID = func() int { return 1000 }
+	serveInstallGOOS = "linux"
+	t.Cleanup(func() {
+		serveInstallEUID = prevEUID
+		serveInstallGOOS = prevGOOS
+	})
+
+	stdout, _ := makeStdoutCapture(t)
+	cmd := &ServeCommand{Action: "install", User: true}
+	err := cmd.Run(&runtimeContext{CWD: t.TempDir(), Stdout: stdout})
+	if err == nil {
+		t.Fatal("expected unsupported --user error on linux")
+	}
+	if !strings.Contains(err.Error(), "--user is unsupported on linux") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestServeInstallRejectsUserAndSystemTogether(t *testing.T) {
+	prevEUID := serveInstallEUID
+	prevGOOS := serveInstallGOOS
+	serveInstallEUID = func() int { return 501 }
+	serveInstallGOOS = "darwin"
+	t.Cleanup(func() {
+		serveInstallEUID = prevEUID
+		serveInstallGOOS = prevGOOS
+	})
+
+	stdout, _ := makeStdoutCapture(t)
+	cmd := &ServeCommand{Action: "install", User: true, System: true}
+	err := cmd.Run(&runtimeContext{CWD: t.TempDir(), Stdout: stdout})
+	if err == nil {
+		t.Fatal("expected conflicting scope flags error")
+	}
+	if !strings.Contains(err.Error(), "cannot be used together") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
@@ -468,7 +600,7 @@ func TestServeStatusSystemdInstalled(t *testing.T) {
 	})
 
 	stdout, readStdout := makeStdoutCapture(t)
-	cmd := &ServeCommand{Action: "status"}
+	cmd := &ServeCommand{Action: "status", System: true}
 	if err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout}); err != nil {
 		t.Fatalf("ServeCommand.Run returned error: %v", err)
 	}
@@ -504,7 +636,7 @@ func TestServeStatusSystemdNotInstalled(t *testing.T) {
 	})
 
 	stdout, readStdout := makeStdoutCapture(t)
-	cmd := &ServeCommand{Action: "status"}
+	cmd := &ServeCommand{Action: "status", System: true}
 	if err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout}); err != nil {
 		t.Fatalf("ServeCommand.Run returned error: %v", err)
 	}
@@ -529,13 +661,87 @@ func TestServeStatusUnsupportedOS(t *testing.T) {
 	})
 
 	stdout, _ := makeStdoutCapture(t)
-	cmd := &ServeCommand{Action: "status"}
+	cmd := &ServeCommand{Action: "status", System: true}
 	err := cmd.Run(&runtimeContext{CWD: t.TempDir(), Stdout: stdout})
 	if err == nil {
 		t.Fatal("expected unsupported OS error")
 	}
 	if !strings.Contains(err.Error(), "unsupported on windows") {
 		t.Fatalf("expected unsupported OS message, got: %v", err)
+	}
+}
+
+func TestServeStatusLaunchdIncludesListenEndpoint(t *testing.T) {
+	tmpDir := t.TempDir()
+	plistPath := filepath.Join(tmpDir, "com.buildkite.cleanroom.plist")
+	content := renderLaunchdService("/usr/local/bin/cleanroom", []string{"serve", "--listen", "unix:///tmp/custom-cleanroom.sock"})
+	if err := os.WriteFile(plistPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write launchd plist: %v", err)
+	}
+
+	prevGOOS := serveInstallGOOS
+	prevLaunchdPath := serveInstallLaunchdPath
+	prevRunCommand := serveInstallRunCommand
+	prevRunCommandOutput := serveInstallRunCommandOutput
+	serveInstallGOOS = "darwin"
+	serveInstallLaunchdPath = plistPath
+	serveInstallRunCommand = func(name string, args ...string) error { return nil }
+	serveInstallRunCommandOutput = func(name string, args ...string) (string, error) {
+		return "state = running\n", nil
+	}
+	t.Cleanup(func() {
+		serveInstallGOOS = prevGOOS
+		serveInstallLaunchdPath = prevLaunchdPath
+		serveInstallRunCommand = prevRunCommand
+		serveInstallRunCommandOutput = prevRunCommandOutput
+	})
+
+	stdout, readStdout := makeStdoutCapture(t)
+	cmd := &ServeCommand{Action: "status", System: true}
+	if err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout}); err != nil {
+		t.Fatalf("ServeCommand.Run returned error: %v", err)
+	}
+
+	out := readStdout()
+	if !strings.Contains(out, "listen=unix:///tmp/custom-cleanroom.sock") {
+		t.Fatalf("expected launchd status to include configured listen endpoint, got: %s", out)
+	}
+}
+
+func TestServeStatusLaunchdReportsInactiveWhenNotRunning(t *testing.T) {
+	tmpDir := t.TempDir()
+	plistPath := filepath.Join(tmpDir, "com.buildkite.cleanroom.plist")
+	content := renderLaunchdService("/usr/local/bin/cleanroom", []string{"serve", "--listen", "unix:///tmp/custom-cleanroom.sock"})
+	if err := os.WriteFile(plistPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write launchd plist: %v", err)
+	}
+
+	prevGOOS := serveInstallGOOS
+	prevLaunchdPath := serveInstallLaunchdPath
+	prevRunCommandOutput := serveInstallRunCommandOutput
+	serveInstallGOOS = "darwin"
+	serveInstallLaunchdPath = plistPath
+	serveInstallRunCommandOutput = func(name string, args ...string) (string, error) {
+		return "state = spawn scheduled\n", nil
+	}
+	t.Cleanup(func() {
+		serveInstallGOOS = prevGOOS
+		serveInstallLaunchdPath = prevLaunchdPath
+		serveInstallRunCommandOutput = prevRunCommandOutput
+	})
+
+	stdout, readStdout := makeStdoutCapture(t)
+	cmd := &ServeCommand{Action: "status", System: true}
+	if err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout}); err != nil {
+		t.Fatalf("ServeCommand.Run returned error: %v", err)
+	}
+
+	out := readStdout()
+	if !strings.Contains(out, "active=inactive") {
+		t.Fatalf("expected launchd status to report inactive for non-running state, got: %s", out)
+	}
+	if !strings.Contains(out, "state=spawn scheduled") {
+		t.Fatalf("expected launchd status to include raw launchd state, got: %s", out)
 	}
 }
 
@@ -550,4 +756,30 @@ func TestJoinSystemdExecArgsQuotesSingleQuoteArgs(t *testing.T) {
 	if !strings.Contains(joined, "\"/etc/cleanroom/bob's-key.pem\"") {
 		t.Fatalf("expected single-quote arg to be quoted, got: %q", joined)
 	}
+}
+
+func TestRenderLaunchdServiceOmitsEnvironmentVariables(t *testing.T) {
+	plist := renderLaunchdService("/usr/local/bin/cleanroom", []string{"serve"})
+	if strings.Contains(plist, "EnvironmentVariables") {
+		t.Fatalf("expected launchd plist to omit EnvironmentVariables, got:\n%s", plist)
+	}
+}
+
+func containsServeInstallCall(calls [][]string, wantPrefix []string) bool {
+	for _, call := range calls {
+		if len(call) < len(wantPrefix) {
+			continue
+		}
+		match := true
+		for i := range wantPrefix {
+			if call[i] != wantPrefix[i] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/endpoint/endpoint.go
+++ b/internal/endpoint/endpoint.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
@@ -18,6 +19,7 @@ const DefaultSystemSocketPath = "/var/run/cleanroom/cleanroom.sock"
 const defaultSystemSocketPath = DefaultSystemSocketPath
 
 var endpointStat = os.Stat
+var endpointGOOS = runtime.GOOS
 
 func defaultListenEndpoint() Endpoint {
 	runtimeDir := strings.TrimSpace(os.Getenv("XDG_RUNTIME_DIR"))
@@ -33,6 +35,10 @@ func defaultListenEndpoint() Endpoint {
 }
 
 func defaultClientEndpoint() Endpoint {
+	if strings.EqualFold(strings.TrimSpace(endpointGOOS), "darwin") {
+		return defaultListenEndpoint()
+	}
+
 	if st, err := endpointStat(defaultSystemSocketPath); err == nil && !st.IsDir() && st.Mode()&os.ModeSocket != 0 {
 		return Endpoint{
 			Scheme:  "unix",

--- a/internal/endpoint/endpoint.go
+++ b/internal/endpoint/endpoint.go
@@ -18,7 +18,6 @@ const DefaultSystemSocketPath = "/var/run/cleanroom/cleanroom.sock"
 const defaultSystemSocketPath = DefaultSystemSocketPath
 
 var endpointStat = os.Stat
-var endpointGeteuid = os.Geteuid
 
 func defaultListenEndpoint() Endpoint {
 	runtimeDir := strings.TrimSpace(os.Getenv("XDG_RUNTIME_DIR"))
@@ -34,13 +33,11 @@ func defaultListenEndpoint() Endpoint {
 }
 
 func defaultClientEndpoint() Endpoint {
-	if endpointGeteuid() == 0 {
-		if st, err := endpointStat(defaultSystemSocketPath); err == nil && !st.IsDir() && st.Mode()&os.ModeSocket != 0 {
-			return Endpoint{
-				Scheme:  "unix",
-				Address: defaultSystemSocketPath,
-				BaseURL: "http://unix",
-			}
+	if st, err := endpointStat(defaultSystemSocketPath); err == nil && !st.IsDir() && st.Mode()&os.ModeSocket != 0 {
+		return Endpoint{
+			Scheme:  "unix",
+			Address: defaultSystemSocketPath,
+			BaseURL: "http://unix",
 		}
 	}
 	return defaultListenEndpoint()

--- a/internal/endpoint/endpoint_test.go
+++ b/internal/endpoint/endpoint_test.go
@@ -55,11 +55,14 @@ func TestResolveDefaultClientPrefersSystemSocketWhenPresent(t *testing.T) {
 	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
 
 	prevStat := endpointStat
+	prevGOOS := endpointGOOS
 	endpointStat = func(string) (os.FileInfo, error) {
 		return fakeFileInfo{mode: os.ModeSocket}, nil
 	}
+	endpointGOOS = "linux"
 	t.Cleanup(func() {
 		endpointStat = prevStat
+		endpointGOOS = prevGOOS
 	})
 
 	ep, err := Resolve("")
@@ -71,6 +74,31 @@ func TestResolveDefaultClientPrefersSystemSocketWhenPresent(t *testing.T) {
 	}
 	if ep.Address != defaultSystemSocketPath {
 		t.Fatalf("expected system socket path %q, got %q", defaultSystemSocketPath, ep.Address)
+	}
+}
+
+func TestResolveDefaultClientUsesRuntimeSocketOnDarwinEvenWhenSystemSocketPresent(t *testing.T) {
+	runtimeDir := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
+
+	prevStat := endpointStat
+	prevGOOS := endpointGOOS
+	endpointStat = func(string) (os.FileInfo, error) {
+		return fakeFileInfo{mode: os.ModeSocket}, nil
+	}
+	endpointGOOS = "darwin"
+	t.Cleanup(func() {
+		endpointStat = prevStat
+		endpointGOOS = prevGOOS
+	})
+
+	ep, err := Resolve("")
+	if err != nil {
+		t.Fatalf("resolve default client endpoint: %v", err)
+	}
+	want := filepath.Join(runtimeDir, "cleanroom", "cleanroom.sock")
+	if ep.Address != want {
+		t.Fatalf("expected runtime socket path %q on darwin, got %q", want, ep.Address)
 	}
 }
 

--- a/internal/endpoint/endpoint_test.go
+++ b/internal/endpoint/endpoint_test.go
@@ -55,14 +55,11 @@ func TestResolveDefaultClientPrefersSystemSocketWhenPresent(t *testing.T) {
 	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
 
 	prevStat := endpointStat
-	prevEUID := endpointGeteuid
 	endpointStat = func(string) (os.FileInfo, error) {
 		return fakeFileInfo{mode: os.ModeSocket}, nil
 	}
-	endpointGeteuid = func() int { return 0 }
 	t.Cleanup(func() {
 		endpointStat = prevStat
-		endpointGeteuid = prevEUID
 	})
 
 	ep, err := Resolve("")
@@ -82,14 +79,11 @@ func TestResolveDefaultClientFallsBackToRuntimeSocketWhenSystemPathIsNotSocket(t
 	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
 
 	prevStat := endpointStat
-	prevEUID := endpointGeteuid
 	endpointStat = func(string) (os.FileInfo, error) {
 		return fakeFileInfo{mode: 0}, nil
 	}
-	endpointGeteuid = func() int { return 0 }
 	t.Cleanup(func() {
 		endpointStat = prevStat
-		endpointGeteuid = prevEUID
 	})
 
 	ep, err := Resolve("")
@@ -107,14 +101,11 @@ func TestResolveDefaultClientFallsBackToRuntimeSocketWhenSystemSocketMissing(t *
 	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
 
 	prevStat := endpointStat
-	prevEUID := endpointGeteuid
 	endpointStat = func(string) (os.FileInfo, error) {
 		return nil, errors.New("missing")
 	}
-	endpointGeteuid = func() int { return 0 }
 	t.Cleanup(func() {
 		endpointStat = prevStat
-		endpointGeteuid = prevEUID
 	})
 
 	ep, err := Resolve("")
@@ -124,31 +115,6 @@ func TestResolveDefaultClientFallsBackToRuntimeSocketWhenSystemSocketMissing(t *
 	want := filepath.Join(runtimeDir, "cleanroom", "cleanroom.sock")
 	if ep.Address != want {
 		t.Fatalf("expected runtime socket path %q, got %q", want, ep.Address)
-	}
-}
-
-func TestResolveDefaultClientFallsBackToRuntimeSocketWhenNotRoot(t *testing.T) {
-	runtimeDir := t.TempDir()
-	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
-
-	prevStat := endpointStat
-	prevEUID := endpointGeteuid
-	endpointStat = func(string) (os.FileInfo, error) {
-		return fakeFileInfo{mode: os.ModeSocket}, nil
-	}
-	endpointGeteuid = func() int { return 1000 }
-	t.Cleanup(func() {
-		endpointStat = prevStat
-		endpointGeteuid = prevEUID
-	})
-
-	ep, err := Resolve("")
-	if err != nil {
-		t.Fatalf("resolve default client endpoint: %v", err)
-	}
-	want := filepath.Join(runtimeDir, "cleanroom", "cleanroom.sock")
-	if ep.Address != want {
-		t.Fatalf("expected runtime socket path %q for non-root, got %q", want, ep.Address)
 	}
 }
 

--- a/internal/runtimeconfig/config.go
+++ b/internal/runtimeconfig/config.go
@@ -13,6 +13,7 @@ import (
 
 type Config struct {
 	DefaultBackend string   `yaml:"default_backend"`
+	ControlHost    string   `yaml:"control_host,omitempty"`
 	Backends       Backends `yaml:"backends"`
 }
 
@@ -55,6 +56,12 @@ type DockerServiceConfig struct {
 	IPTables              bool   `yaml:"iptables"`
 }
 
+var (
+	runtimeconfigUserHomeDir = os.UserHomeDir
+	runtimeconfigGeteuid     = os.Geteuid
+	runtimeconfigGOOS        = runtime.GOOS
+)
+
 func DefaultBackendForGOOS(goos string) string {
 	if strings.EqualFold(strings.TrimSpace(goos), "darwin") {
 		return "darwin-vz"
@@ -72,11 +79,32 @@ func Path() (string, error) {
 		return filepath.Join(configHome, "cleanroom", "config.yaml"), nil
 	}
 
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
+	home, err := runtimeconfigUserHomeDir()
+	if err != nil || strings.TrimSpace(home) == "" {
+		fallback, fallbackOK := defaultRootHomeDir()
+		if !fallbackOK {
+			if err != nil {
+				return "", err
+			}
+			return "", errors.New("home directory is not available")
+		}
+		home = fallback
 	}
 	return filepath.Join(home, ".config", "cleanroom", "config.yaml"), nil
+}
+
+func defaultRootHomeDir() (string, bool) {
+	if runtimeconfigGeteuid() != 0 {
+		return "", false
+	}
+
+	if strings.EqualFold(strings.TrimSpace(runtimeconfigGOOS), "darwin") {
+		return "/var/root", true
+	}
+	if strings.EqualFold(strings.TrimSpace(runtimeconfigGOOS), "windows") {
+		return "", false
+	}
+	return "/root", true
 }
 
 func Load() (Config, string, error) {
@@ -112,6 +140,7 @@ func Load() (Config, string, error) {
 	if cfg.DefaultBackend == "" {
 		cfg.DefaultBackend = DefaultBackendForHost()
 	}
+	cfg.ControlHost = strings.TrimSpace(cfg.ControlHost)
 	return cfg, path, nil
 }
 

--- a/internal/runtimeconfig/config_test.go
+++ b/internal/runtimeconfig/config_test.go
@@ -1,8 +1,10 @@
 package runtimeconfig
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -107,5 +109,84 @@ func TestLoadDefaultsBackendWhenMissing(t *testing.T) {
 	}
 	if got, want := cfg.DefaultBackend, DefaultBackendForHost(); got != want {
 		t.Fatalf("unexpected default backend: got %q want %q", got, want)
+	}
+}
+
+func TestLoadTrimsControlHost(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	configPath := filepath.Join(tmp, "cleanroom", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+
+	content := `default_backend: darwin-vz
+control_host: "  unix:///tmp/cleanroom.sock  "
+backends:
+  firecracker:
+    binary_path: firecracker
+`
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, _, err := Load()
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if got, want := cfg.ControlHost, "unix:///tmp/cleanroom.sock"; got != want {
+		t.Fatalf("unexpected control host: got %q want %q", got, want)
+	}
+}
+
+func TestPathFallsBackToRootHomeWhenHomeUnavailable(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	prevUserHome := runtimeconfigUserHomeDir
+	prevEUID := runtimeconfigGeteuid
+	prevGOOS := runtimeconfigGOOS
+	runtimeconfigUserHomeDir = func() (string, error) {
+		return "", errors.New("$HOME is not defined")
+	}
+	runtimeconfigGeteuid = func() int { return 0 }
+	runtimeconfigGOOS = "darwin"
+	t.Cleanup(func() {
+		runtimeconfigUserHomeDir = prevUserHome
+		runtimeconfigGeteuid = prevEUID
+		runtimeconfigGOOS = prevGOOS
+	})
+
+	path, err := Path()
+	if err != nil {
+		t.Fatalf("Path returned error: %v", err)
+	}
+	if got, want := path, filepath.Join("/var/root", ".config", "cleanroom", "config.yaml"); got != want {
+		t.Fatalf("unexpected fallback config path: got %q want %q", got, want)
+	}
+}
+
+func TestPathReturnsErrorWhenHomeUnavailableForNonRoot(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	prevUserHome := runtimeconfigUserHomeDir
+	prevEUID := runtimeconfigGeteuid
+	prevGOOS := runtimeconfigGOOS
+	runtimeconfigUserHomeDir = func() (string, error) {
+		return "", errors.New("$HOME is not defined")
+	}
+	runtimeconfigGeteuid = func() int { return 1000 }
+	runtimeconfigGOOS = "darwin"
+	t.Cleanup(func() {
+		runtimeconfigUserHomeDir = prevUserHome
+		runtimeconfigGeteuid = prevEUID
+		runtimeconfigGOOS = prevGOOS
+	})
+
+	_, err := Path()
+	if err == nil {
+		t.Fatal("expected Path to fail when home is unavailable for non-root")
+	}
+	if !strings.Contains(err.Error(), "$HOME is not defined") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- default `cleanroom serve install` on macOS to user scope when run as non-root
- add explicit `--user` and `--system` scope flags for `serve install|uninstall|status`
- keep Linux in system scope and reject `--user` until systemd user mode is implemented
- install user-scope launchd services under `~/Library/LaunchAgents` and default user-scope listen endpoint to runtime socket
- update client endpoint selection to prefer system socket then fallback to runtime socket, with optional `control_host` runtime config override
- refresh docs for daemon install scope and endpoint precedence

## Testing
- `go test ./internal/cli ./internal/runtimeconfig ./internal/endpoint -count=1`
