### PR TITLE
feat: separate daemon lifecycle from foreground serve

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,14 +58,23 @@ Install as a daemon:
 
 ```bash
 # macOS: installs a user LaunchAgent (user-scope only)
-cleanroom serve install
+cleanroom daemon install
 
 # Linux (systemd)
-sudo cleanroom serve install
+sudo cleanroom daemon install
 ```
 
 Use `--force` to overwrite an existing service file. On macOS, `--system`
 is unsupported; `--user` is accepted for explicitness.
+
+Manage the daemon lifecycle:
+
+```bash
+cleanroom daemon status
+cleanroom daemon start
+cleanroom daemon stop
+cleanroom daemon uninstall
+```
 
 The system daemon socket is root-owned (`unix:///var/run/cleanroom/cleanroom.sock`),
 so client commands against that daemon should be run with `sudo` unless you

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -477,7 +477,7 @@ Minimum v1 codes:
 - Core policy compiler to normalized allowlist + registry map
 - Local backend (Firecracker) implementation
 - content-cache wrapper integration for npm and one additional manager
-- `cleanroom serve` daemon plus CLI client command set (`exec`, `sandboxes`, `executions`)
+- `cleanroom serve` foreground server plus `cleanroom daemon` lifecycle management and CLI client command set (`exec`, `sandboxes`, `executions`)
 - `cleanroom exec` RPC wrapper flow
 
 ### Phase 2

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1768,22 +1768,25 @@ func stopLaunchdDaemonInDomain(stdout io.Writer, servicePath, domain string) err
 	}
 
 	target := launchdServiceTarget(domain)
-	if err := serveInstallRunCommand("launchctl", "disable", target); err != nil && !isExitError(err) {
-		return fmt.Errorf("disable launchd service %s: %w", launchdServiceName, err)
+	loaded, err := launchdServiceLoaded(target)
+	if err != nil {
+		return err
 	}
-	bootoutFoundService := true
-	if err := serveInstallRunCommand("launchctl", "bootout", target); err != nil {
-		if !isExitError(err) {
-			return fmt.Errorf("stop launchd service %s: %w", launchdServiceName, err)
-		}
-		bootoutFoundService = false
+	if !serviceFileExists && !loaded {
+		_, err := fmt.Fprintf(stdout, "daemon already stopped\nmanager=launchd\nservice=%s\n", launchdServiceName)
+		return err
 	}
 
-	message := "daemon stopped"
-	if !serviceFileExists && !bootoutFoundService {
-		message = "daemon already stopped"
+	if err := serveInstallRunCommand("launchctl", "disable", target); err != nil {
+		return fmt.Errorf("disable launchd service %s: %w", launchdServiceName, err)
 	}
-	_, err := fmt.Fprintf(stdout, "%s\nmanager=launchd\nservice=%s\n", message, launchdServiceName)
+	if loaded {
+		if err := serveInstallRunCommand("launchctl", "bootout", target); err != nil {
+			return fmt.Errorf("stop launchd service %s: %w", launchdServiceName, err)
+		}
+	}
+
+	_, err = fmt.Fprintf(stdout, "daemon stopped\nmanager=launchd\nservice=%s\n", launchdServiceName)
 	return err
 }
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1723,17 +1723,23 @@ func startLaunchdDaemonInDomain(stdout io.Writer, servicePath, domain string) er
 	}
 
 	target := launchdServiceTarget(domain)
-	if err := serveInstallRunCommand("launchctl", "bootstrap", domain, servicePath); err != nil && !isExitError(err) {
-		return fmt.Errorf("bootstrap launchd service %s: %w", launchdServiceName, err)
+	loaded, err := launchdServiceLoaded(target)
+	if err != nil {
+		return err
 	}
-	if err := serveInstallRunCommand("launchctl", "enable", target); err != nil && !isExitError(err) {
+	if !loaded {
+		if err := serveInstallRunCommand("launchctl", "bootstrap", domain, servicePath); err != nil {
+			return fmt.Errorf("bootstrap launchd service %s: %w", launchdServiceName, err)
+		}
+	}
+	if err := serveInstallRunCommand("launchctl", "enable", target); err != nil {
 		return fmt.Errorf("enable launchd service %s: %w", launchdServiceName, err)
 	}
-	if err := serveInstallRunCommand("launchctl", "kickstart", "-k", target); err != nil && !isExitError(err) {
+	if err := serveInstallRunCommand("launchctl", "kickstart", "-k", target); err != nil {
 		return fmt.Errorf("start launchd service %s: %w", launchdServiceName, err)
 	}
 
-	_, err := fmt.Fprintf(stdout, "daemon started\nmanager=launchd\nservice=%s\n", launchdServiceName)
+	_, err = fmt.Fprintf(stdout, "daemon started\nmanager=launchd\nservice=%s\n", launchdServiceName)
 	return err
 }
 
@@ -1750,21 +1756,34 @@ func stopLaunchdUserDaemon(stdout io.Writer) error {
 }
 
 func stopLaunchdDaemonInDomain(stdout io.Writer, servicePath, domain string) error {
-	if _, err := serveInstallStat(servicePath); errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("service file %s does not exist", servicePath)
-	} else if err != nil {
-		return fmt.Errorf("stat service file %s: %w", servicePath, err)
+	serviceFileExists := false
+	statErr := error(nil)
+	if _, err := serveInstallStat(servicePath); err == nil {
+		serviceFileExists = true
+	} else if !errors.Is(err, os.ErrNotExist) {
+		statErr = err
+	}
+	if statErr != nil {
+		return fmt.Errorf("stat service file %s: %w", servicePath, statErr)
 	}
 
 	target := launchdServiceTarget(domain)
 	if err := serveInstallRunCommand("launchctl", "disable", target); err != nil && !isExitError(err) {
 		return fmt.Errorf("disable launchd service %s: %w", launchdServiceName, err)
 	}
-	if err := serveInstallRunCommand("launchctl", "bootout", target); err != nil && !isExitError(err) {
-		return fmt.Errorf("stop launchd service %s: %w", launchdServiceName, err)
+	bootoutFoundService := true
+	if err := serveInstallRunCommand("launchctl", "bootout", target); err != nil {
+		if !isExitError(err) {
+			return fmt.Errorf("stop launchd service %s: %w", launchdServiceName, err)
+		}
+		bootoutFoundService = false
 	}
 
-	_, err := fmt.Fprintf(stdout, "daemon stopped\nmanager=launchd\nservice=%s\n", launchdServiceName)
+	message := "daemon stopped"
+	if !serviceFileExists && !bootoutFoundService {
+		message = "daemon already stopped"
+	}
+	_, err := fmt.Fprintf(stdout, "%s\nmanager=launchd\nservice=%s\n", message, launchdServiceName)
 	return err
 }
 
@@ -1894,6 +1913,16 @@ func launchdServiceState(output string) string {
 		return strings.TrimSpace(strings.TrimPrefix(trimmed, "state ="))
 	}
 	return ""
+}
+
+func launchdServiceLoaded(target string) (bool, error) {
+	if _, err := serveInstallRunCommandOutput("launchctl", "print", target); err == nil {
+		return true, nil
+	} else if isExitError(err) {
+		return false, nil
+	} else {
+		return false, fmt.Errorf("check launchd service %s: %w", target, err)
+	}
 }
 
 func launchdConfiguredListenEndpoint(plistPath string) (string, error) {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -80,7 +80,8 @@ type CLI struct {
 	Create  CreateCommand  `cmd:"" help:"Create a sandbox"`
 	Exec    ExecCommand    `cmd:"" help:"Execute a command in a cleanroom backend"`
 	Console ConsoleCommand `cmd:"" help:"Attach an interactive console to a cleanroom execution"`
-	Serve   ServeCommand   `cmd:"" help:"Run the cleanroom control-plane server"`
+	Serve   ServeCommand   `cmd:"" help:"Run the cleanroom control-plane server in the foreground"`
+	Daemon  DaemonCommand  `cmd:"" help:"Manage daemon/service lifecycle"`
 	Doctor  DoctorCommand  `cmd:"" help:"Run environment and backend diagnostics"`
 	Status  StatusCommand  `cmd:"" help:"Inspect run artifacts"`
 	Sandbox SandboxCommand `cmd:"" help:"Manage sandboxes"`
@@ -216,10 +217,18 @@ type ConsoleCommand struct {
 }
 
 type ServeCommand struct {
-	Action        string `arg:"" optional:"" help:"Serve action (install, uninstall, status)"`
-	Force         bool   `help:"Overwrite existing daemon service file (serve install only)"`
-	User          bool   `help:"Use user daemon scope (launchd only; install/uninstall/status actions)"`
-	System        bool   `help:"Use system daemon scope (linux only; install/uninstall/status actions)"`
+	Listen        string `help:"Listen endpoint for control API (defaults to runtime endpoint)"`
+	GatewayListen string `help:"Listen address for the host gateway (default :8170, use :0 for ephemeral port)"`
+	LogLevel      string `help:"Server log level (debug|info|warn|error)"`
+	TLSCert       string `help:"Path to TLS server certificate (auto-discovered from XDG config for https)" env:"CLEANROOM_TLS_CERT"`
+	TLSKey        string `help:"Path to TLS server private key (auto-discovered from XDG config for https)" env:"CLEANROOM_TLS_KEY"`
+}
+
+type DaemonCommand struct {
+	Action        string `arg:"" required:"" help:"Daemon action (install, uninstall, status, start, stop)"`
+	Force         bool   `help:"Overwrite existing daemon service file (daemon install only)"`
+	User          bool   `help:"Use user daemon scope (launchd only; install/uninstall/status/start/stop actions)"`
+	System        bool   `help:"Use system daemon scope (linux only; install/uninstall/status/start/stop actions)"`
 	Listen        string `help:"Listen endpoint for control API (defaults to runtime endpoint)"`
 	GatewayListen string `help:"Listen address for the host gateway (default :8170, use :0 for ephemeral port)"`
 	LogLevel      string `help:"Server log level (debug|info|warn|error)"`
@@ -1366,27 +1375,27 @@ func trimPassthroughSeparator(args []string) []string {
 }
 
 func (s *ServeCommand) Run(ctx *runtimeContext) error {
+	return s.runServer(ctx)
+}
+
+func (s *DaemonCommand) Run(ctx *runtimeContext) error {
 	switch strings.TrimSpace(strings.ToLower(s.Action)) {
-	case "":
-		if s.Force {
-			return errors.New("--force is only supported with 'cleanroom serve install'")
-		}
-		if s.User || s.System {
-			return errors.New("--user and --system are only supported with 'cleanroom serve install', 'cleanroom serve uninstall', or 'cleanroom serve status'")
-		}
-		return s.runServer(ctx)
 	case "install":
 		return s.installDaemon(ctx)
 	case "uninstall":
 		return s.uninstallDaemon(ctx)
 	case "status":
 		return s.daemonStatus(ctx)
+	case "start":
+		return s.startDaemon(ctx)
+	case "stop":
+		return s.stopDaemon(ctx)
 	default:
-		return fmt.Errorf("unsupported serve action %q", s.Action)
+		return fmt.Errorf("unsupported daemon action %q", s.Action)
 	}
 }
 
-func (s *ServeCommand) requestedDaemonScope() (daemonScope, bool, error) {
+func (s *DaemonCommand) requestedDaemonScope() (daemonScope, bool, error) {
 	if s.User && s.System {
 		return "", false, errors.New("--user and --system cannot be used together")
 	}
@@ -1399,7 +1408,7 @@ func (s *ServeCommand) requestedDaemonScope() (daemonScope, bool, error) {
 	return "", false, nil
 }
 
-func (s *ServeCommand) effectiveDaemonScope() (daemonScope, error) {
+func (s *DaemonCommand) effectiveDaemonScope() (daemonScope, error) {
 	requested, hasScope, err := s.requestedDaemonScope()
 	if err != nil {
 		return "", err
@@ -1416,7 +1425,7 @@ func (s *ServeCommand) effectiveDaemonScope() (daemonScope, error) {
 			return "", errors.New("--system is unsupported on darwin (macOS supports user launchd daemons only)")
 		}
 		if serveInstallEUID() == 0 {
-			return "", errors.New("darwin supports user launchd daemons only; run 'cleanroom serve' without sudo")
+			return "", errors.New("darwin supports user launchd daemons only; run 'cleanroom daemon' without sudo")
 		}
 		return daemonScopeUser, nil
 	default:
@@ -1427,7 +1436,7 @@ func (s *ServeCommand) effectiveDaemonScope() (daemonScope, error) {
 	}
 }
 
-func (s *ServeCommand) daemonRunArgs(cwd string, scope daemonScope) ([]string, error) {
+func (s *DaemonCommand) daemonRunArgs(cwd string, scope daemonScope) ([]string, error) {
 	listen := strings.TrimSpace(s.Listen)
 	if listen == "" {
 		if scope == daemonScopeUser {
@@ -1480,7 +1489,7 @@ func resolveDaemonInstallPath(cwd, value string) (string, error) {
 	return filepath.Clean(filepath.Join(base, value)), nil
 }
 
-func (s *ServeCommand) installDaemon(ctx *runtimeContext) error {
+func (s *DaemonCommand) installDaemon(ctx *runtimeContext) error {
 	scope, err := s.effectiveDaemonScope()
 	if err != nil {
 		return err
@@ -1497,11 +1506,11 @@ func (s *ServeCommand) installDaemon(ctx *runtimeContext) error {
 			installFn = installLaunchdDaemon
 		}
 	default:
-		return fmt.Errorf("serve install is unsupported on %s (expected linux or darwin)", serveInstallGOOS)
+		return fmt.Errorf("daemon install is unsupported on %s (expected linux or darwin)", serveInstallGOOS)
 	}
 
 	if scope == daemonScopeSystem && serveInstallEUID() != 0 {
-		return errors.New("serve install requires root privileges (use sudo cleanroom serve install)")
+		return errors.New("daemon install requires root privileges (use sudo cleanroom daemon install)")
 	}
 
 	executablePath, err := serveInstallExecutablePath()
@@ -1522,7 +1531,7 @@ func (s *ServeCommand) installDaemon(ctx *runtimeContext) error {
 	return installFn(ctx.Stdout, executablePath, args, s.Force)
 }
 
-func (s *ServeCommand) uninstallDaemon(ctx *runtimeContext) error {
+func (s *DaemonCommand) uninstallDaemon(ctx *runtimeContext) error {
 	scope, err := s.effectiveDaemonScope()
 	if err != nil {
 		return err
@@ -1539,14 +1548,68 @@ func (s *ServeCommand) uninstallDaemon(ctx *runtimeContext) error {
 			uninstallFn = uninstallLaunchdDaemon
 		}
 	default:
-		return fmt.Errorf("serve uninstall is unsupported on %s (expected linux or darwin)", serveInstallGOOS)
+		return fmt.Errorf("daemon uninstall is unsupported on %s (expected linux or darwin)", serveInstallGOOS)
 	}
 
 	if scope == daemonScopeSystem && serveInstallEUID() != 0 {
-		return errors.New("serve uninstall requires root privileges (use sudo cleanroom serve uninstall)")
+		return errors.New("daemon uninstall requires root privileges (use sudo cleanroom daemon uninstall)")
 	}
 
 	return uninstallFn(ctx.Stdout)
+}
+
+func (s *DaemonCommand) startDaemon(ctx *runtimeContext) error {
+	scope, err := s.effectiveDaemonScope()
+	if err != nil {
+		return err
+	}
+
+	var startFn func(io.Writer) error
+	switch serveInstallGOOS {
+	case "linux":
+		startFn = startSystemdDaemon
+	case "darwin":
+		if scope == daemonScopeUser {
+			startFn = startLaunchdUserDaemon
+		} else {
+			startFn = startLaunchdDaemon
+		}
+	default:
+		return fmt.Errorf("daemon start is unsupported on %s (expected linux or darwin)", serveInstallGOOS)
+	}
+
+	if scope == daemonScopeSystem && serveInstallEUID() != 0 {
+		return errors.New("daemon start requires root privileges (use sudo cleanroom daemon start)")
+	}
+
+	return startFn(ctx.Stdout)
+}
+
+func (s *DaemonCommand) stopDaemon(ctx *runtimeContext) error {
+	scope, err := s.effectiveDaemonScope()
+	if err != nil {
+		return err
+	}
+
+	var stopFn func(io.Writer) error
+	switch serveInstallGOOS {
+	case "linux":
+		stopFn = stopSystemdDaemon
+	case "darwin":
+		if scope == daemonScopeUser {
+			stopFn = stopLaunchdUserDaemon
+		} else {
+			stopFn = stopLaunchdDaemon
+		}
+	default:
+		return fmt.Errorf("daemon stop is unsupported on %s (expected linux or darwin)", serveInstallGOOS)
+	}
+
+	if scope == daemonScopeSystem && serveInstallEUID() != 0 {
+		return errors.New("daemon stop requires root privileges (use sudo cleanroom daemon stop)")
+	}
+
+	return stopFn(ctx.Stdout)
 }
 
 func uninstallSystemdDaemon(stdout io.Writer) error {
@@ -1585,29 +1648,133 @@ func uninstallLaunchdUserDaemon(stdout io.Writer) error {
 }
 
 func uninstallLaunchdDaemonInDomain(stdout io.Writer, servicePath, domain string) error {
-	if _, err := serveInstallStat(servicePath); errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("service file %s does not exist", servicePath)
+	serviceFileExists := false
+	if _, err := serveInstallStat(servicePath); err == nil {
+		serviceFileExists = true
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("stat service file %s: %w", servicePath, err)
 	}
 
-	if err := serveInstallRunCommand("launchctl", "bootout", launchdServiceTarget(domain)); err != nil && !isExitError(err) {
-		return fmt.Errorf("bootout launchd service %s: %w", launchdServiceName, err)
+	bootoutFoundService := true
+	if err := serveInstallRunCommand("launchctl", "bootout", launchdServiceTarget(domain)); err != nil {
+		if !isExitError(err) {
+			return fmt.Errorf("bootout launchd service %s: %w", launchdServiceName, err)
+		}
+		bootoutFoundService = false
 	}
 
-	if err := serveInstallRemoveFile(servicePath); err != nil {
-		return fmt.Errorf("remove service file %s: %w", servicePath, err)
+	if serviceFileExists {
+		if err := serveInstallRemoveFile(servicePath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("remove service file %s: %w", servicePath, err)
+		}
 	}
 
-	_, err := fmt.Fprintf(stdout, "daemon uninstalled\nmanager=launchd\nservice=%s\n", launchdServiceName)
+	message := "daemon uninstalled"
+	if !serviceFileExists && !bootoutFoundService {
+		message = "daemon already uninstalled"
+	}
+	_, err := fmt.Fprintf(stdout, "%s\nmanager=launchd\nservice=%s\n", message, launchdServiceName)
 	return err
 }
 
-func (s *ServeCommand) daemonStatus(ctx *runtimeContext) error {
+func startSystemdDaemon(stdout io.Writer) error {
+	if _, err := serveInstallStat(serveInstallSystemdUnitPath); errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("service file %s does not exist", serveInstallSystemdUnitPath)
+	}
+
+	if err := serveInstallRunCommand("systemctl", "start", systemdServiceName); err != nil {
+		return fmt.Errorf("start systemd service %s: %w", systemdServiceName, err)
+	}
+
+	_, err := fmt.Fprintf(stdout, "daemon started\nmanager=systemd\nservice=%s\n", systemdServiceName)
+	return err
+}
+
+func stopSystemdDaemon(stdout io.Writer) error {
+	if _, err := serveInstallStat(serveInstallSystemdUnitPath); errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("service file %s does not exist", serveInstallSystemdUnitPath)
+	}
+
+	if err := serveInstallRunCommand("systemctl", "stop", systemdServiceName); err != nil {
+		return fmt.Errorf("stop systemd service %s: %w", systemdServiceName, err)
+	}
+
+	_, err := fmt.Fprintf(stdout, "daemon stopped\nmanager=systemd\nservice=%s\n", systemdServiceName)
+	return err
+}
+
+func startLaunchdDaemon(stdout io.Writer) error {
+	return startLaunchdDaemonInDomain(stdout, serveInstallLaunchdPath, "system")
+}
+
+func startLaunchdUserDaemon(stdout io.Writer) error {
+	path, err := launchdUserServicePath()
+	if err != nil {
+		return err
+	}
+	return startLaunchdDaemonInDomain(stdout, path, launchdUserDomain())
+}
+
+func startLaunchdDaemonInDomain(stdout io.Writer, servicePath, domain string) error {
+	if _, err := serveInstallStat(servicePath); errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("service file %s does not exist", servicePath)
+	} else if err != nil {
+		return fmt.Errorf("stat service file %s: %w", servicePath, err)
+	}
+
+	target := launchdServiceTarget(domain)
+	if err := serveInstallRunCommand("launchctl", "bootstrap", domain, servicePath); err != nil && !isExitError(err) {
+		return fmt.Errorf("bootstrap launchd service %s: %w", launchdServiceName, err)
+	}
+	if err := serveInstallRunCommand("launchctl", "enable", target); err != nil && !isExitError(err) {
+		return fmt.Errorf("enable launchd service %s: %w", launchdServiceName, err)
+	}
+	if err := serveInstallRunCommand("launchctl", "kickstart", "-k", target); err != nil && !isExitError(err) {
+		return fmt.Errorf("start launchd service %s: %w", launchdServiceName, err)
+	}
+
+	_, err := fmt.Fprintf(stdout, "daemon started\nmanager=launchd\nservice=%s\n", launchdServiceName)
+	return err
+}
+
+func stopLaunchdDaemon(stdout io.Writer) error {
+	return stopLaunchdDaemonInDomain(stdout, serveInstallLaunchdPath, "system")
+}
+
+func stopLaunchdUserDaemon(stdout io.Writer) error {
+	path, err := launchdUserServicePath()
+	if err != nil {
+		return err
+	}
+	return stopLaunchdDaemonInDomain(stdout, path, launchdUserDomain())
+}
+
+func stopLaunchdDaemonInDomain(stdout io.Writer, servicePath, domain string) error {
+	if _, err := serveInstallStat(servicePath); errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("service file %s does not exist", servicePath)
+	} else if err != nil {
+		return fmt.Errorf("stat service file %s: %w", servicePath, err)
+	}
+
+	target := launchdServiceTarget(domain)
+	if err := serveInstallRunCommand("launchctl", "disable", target); err != nil && !isExitError(err) {
+		return fmt.Errorf("disable launchd service %s: %w", launchdServiceName, err)
+	}
+	if err := serveInstallRunCommand("launchctl", "bootout", target); err != nil && !isExitError(err) {
+		return fmt.Errorf("stop launchd service %s: %w", launchdServiceName, err)
+	}
+
+	_, err := fmt.Fprintf(stdout, "daemon stopped\nmanager=launchd\nservice=%s\n", launchdServiceName)
+	return err
+}
+
+func (s *DaemonCommand) daemonStatus(ctx *runtimeContext) error {
 	scope, err := s.effectiveDaemonScope()
 	if err != nil {
 		return err
 	}
 
-	var statusFn func(io.Writer) error
+	var statusFn func(*os.File) error
 	switch serveInstallGOOS {
 	case "linux":
 		statusFn = systemdDaemonStatus
@@ -1618,42 +1785,52 @@ func (s *ServeCommand) daemonStatus(ctx *runtimeContext) error {
 			statusFn = launchdDaemonStatus
 		}
 	default:
-		return fmt.Errorf("serve status is unsupported on %s (expected linux or darwin)", serveInstallGOOS)
+		return fmt.Errorf("daemon status is unsupported on %s (expected linux or darwin)", serveInstallGOOS)
 	}
 
 	return statusFn(ctx.Stdout)
 }
 
-func systemdDaemonStatus(stdout io.Writer) error {
-	installed := "false"
+func systemdDaemonStatus(stdout *os.File) error {
+	installed := false
 	if _, err := serveInstallStat(serveInstallSystemdUnitPath); err == nil {
-		installed = "true"
+		installed = true
 	}
 
-	active := "inactive"
+	active := false
 	if err := serveInstallRunCommand("systemctl", "is-active", "--quiet", systemdServiceName); err == nil {
-		active = "active"
+		active = true
 	} else if !isExitError(err) {
 		return fmt.Errorf("check systemd service active state: %w", err)
 	}
 
-	enabled := "false"
+	enabled := false
 	if err := serveInstallRunCommand("systemctl", "is-enabled", "--quiet", systemdServiceName); err == nil {
-		enabled = "true"
+		enabled = true
 	} else if !isExitError(err) {
 		return fmt.Errorf("check systemd service enabled state: %w", err)
 	}
 
-	_, err := fmt.Fprintf(stdout, "manager=systemd\nservice=%s\ninstalled=%s\nactive=%s\nenabled=%s\n",
-		systemdServiceName, installed, active, enabled)
+	_, err := fmt.Fprint(stdout, renderDaemonStatusReport(daemonStatusReport{
+		Manager:   "systemd",
+		Service:   systemdServiceName,
+		Installed: installed,
+		Active:    active,
+		Fields: []startupField{
+			{Key: "install", Value: daemonInstalledLabel(installed)},
+			{Key: "runtime", Value: daemonRuntimeLabel(active)},
+			{Key: "enabled", Value: daemonEnabledLabel(enabled)},
+			{Key: "path", Value: serveInstallSystemdUnitPath},
+		},
+	}, shouldUseANSI(stdout)))
 	return err
 }
 
-func launchdDaemonStatus(stdout io.Writer) error {
+func launchdDaemonStatus(stdout *os.File) error {
 	return launchdDaemonStatusInDomain(stdout, serveInstallLaunchdPath, "system")
 }
 
-func launchdUserDaemonStatus(stdout io.Writer) error {
+func launchdUserDaemonStatus(stdout *os.File) error {
 	path, err := launchdUserServicePath()
 	if err != nil {
 		return err
@@ -1661,46 +1838,51 @@ func launchdUserDaemonStatus(stdout io.Writer) error {
 	return launchdDaemonStatusInDomain(stdout, path, launchdUserDomain())
 }
 
-func launchdDaemonStatusInDomain(stdout io.Writer, servicePath, domain string) error {
-	installed := "false"
+func launchdDaemonStatusInDomain(stdout *os.File, servicePath, domain string) error {
+	installed := false
 	if _, err := serveInstallStat(servicePath); err == nil {
-		installed = "true"
+		installed = true
 	}
 
-	active := "inactive"
+	active := false
 	state := ""
 	if output, err := serveInstallRunCommandOutput("launchctl", "print", launchdServiceTarget(domain)); err == nil {
 		state = launchdServiceState(output)
 		if state == "running" {
-			active = "active"
+			active = true
 		}
 	} else if !isExitError(err) {
 		return fmt.Errorf("check launchd service state: %w", err)
 	}
 
 	listen := ""
-	if installed == "true" {
+	if installed {
 		if value, err := launchdConfiguredListenEndpoint(servicePath); err == nil {
 			listen = value
 		}
 	}
 
-	_, err := fmt.Fprintf(stdout, "manager=launchd\nservice=%s\ninstalled=%s\nactive=%s\n",
-		launchdServiceName, installed, active)
-	if err != nil {
-		return err
+	fields := []startupField{
+		{Key: "install", Value: daemonInstalledLabel(installed)},
+		{Key: "runtime", Value: daemonRuntimeLabel(active)},
+		{Key: "domain", Value: domain},
+		{Key: "path", Value: servicePath},
 	}
 	if state != "" {
-		if _, err := fmt.Fprintf(stdout, "state=%s\n", state); err != nil {
-			return err
-		}
+		fields = append(fields, startupField{Key: "state", Value: state})
 	}
 	if listen != "" {
-		if _, err := fmt.Fprintf(stdout, "listen=%s\n", listen); err != nil {
-			return err
-		}
+		fields = append(fields, startupField{Key: "listen", Value: listen})
 	}
-	return nil
+
+	_, err := fmt.Fprint(stdout, renderDaemonStatusReport(daemonStatusReport{
+		Manager:   "launchd",
+		Service:   launchdServiceName,
+		Installed: installed,
+		Active:    active,
+		Fields:    fields,
+	}, shouldUseANSI(stdout)))
+	return err
 }
 
 func launchdServiceState(output string) string {

--- a/internal/cli/cli_parse_test.go
+++ b/internal/cli/cli_parse_test.go
@@ -165,65 +165,72 @@ func TestConsoleParsesImageOverride(t *testing.T) {
 	}
 }
 
-func TestServeCommandParsesWithoutAction(t *testing.T) {
+func TestServeCommandParses(t *testing.T) {
 	c := &CLI{}
 	parser := newParserForTest(t, c)
 
 	if _, err := parser.Parse([]string{"serve"}); err != nil {
 		t.Fatalf("parse serve returned error: %v", err)
 	}
-	if got := c.Serve.Action; got != "" {
-		t.Fatalf("expected empty serve action, got %q", got)
-	}
 }
 
-func TestServeInstallParses(t *testing.T) {
+func TestServeInstallIsRejected(t *testing.T) {
 	c := &CLI{}
 	parser := newParserForTest(t, c)
 
-	if _, err := parser.Parse([]string{"serve", "install"}); err != nil {
-		t.Fatalf("parse serve install returned error: %v", err)
-	}
-	if got := c.Serve.Action; got != "install" {
-		t.Fatalf("expected serve action install, got %q", got)
+	_, err := parser.Parse([]string{"serve", "install"})
+	if err == nil {
+		t.Fatal("expected parse error for unexpected serve action")
 	}
 }
 
-func TestServeInstallForceParses(t *testing.T) {
+func TestDaemonInstallParses(t *testing.T) {
 	c := &CLI{}
 	parser := newParserForTest(t, c)
 
-	if _, err := parser.Parse([]string{"serve", "install", "--force"}); err != nil {
-		t.Fatalf("parse serve install --force returned error: %v", err)
+	if _, err := parser.Parse([]string{"daemon", "install"}); err != nil {
+		t.Fatalf("parse daemon install returned error: %v", err)
 	}
-	if got := c.Serve.Action; got != "install" {
-		t.Fatalf("expected serve action install, got %q", got)
-	}
-	if !c.Serve.Force {
-		t.Fatal("expected --force to set Serve.Force")
+	if got := c.Daemon.Action; got != "install" {
+		t.Fatalf("expected daemon action install, got %q", got)
 	}
 }
 
-func TestServeInstallUserParses(t *testing.T) {
+func TestDaemonInstallForceParses(t *testing.T) {
 	c := &CLI{}
 	parser := newParserForTest(t, c)
 
-	if _, err := parser.Parse([]string{"serve", "install", "--user"}); err != nil {
-		t.Fatalf("parse serve install --user returned error: %v", err)
+	if _, err := parser.Parse([]string{"daemon", "install", "--force"}); err != nil {
+		t.Fatalf("parse daemon install --force returned error: %v", err)
 	}
-	if !c.Serve.User {
-		t.Fatal("expected --user to set Serve.User")
+	if got := c.Daemon.Action; got != "install" {
+		t.Fatalf("expected daemon action install, got %q", got)
+	}
+	if !c.Daemon.Force {
+		t.Fatal("expected --force to set Daemon.Force")
 	}
 }
 
-func TestServeInstallSystemParses(t *testing.T) {
+func TestDaemonStatusUserParses(t *testing.T) {
 	c := &CLI{}
 	parser := newParserForTest(t, c)
 
-	if _, err := parser.Parse([]string{"serve", "install", "--system"}); err != nil {
-		t.Fatalf("parse serve install --system returned error: %v", err)
+	if _, err := parser.Parse([]string{"daemon", "status", "--user"}); err != nil {
+		t.Fatalf("parse daemon status --user returned error: %v", err)
 	}
-	if !c.Serve.System {
-		t.Fatal("expected --system to set Serve.System")
+	if !c.Daemon.User {
+		t.Fatal("expected --user to set Daemon.User")
+	}
+}
+
+func TestDaemonStartSystemParses(t *testing.T) {
+	c := &CLI{}
+	parser := newParserForTest(t, c)
+
+	if _, err := parser.Parse([]string{"daemon", "start", "--system"}); err != nil {
+		t.Fatalf("parse daemon start --system returned error: %v", err)
+	}
+	if !c.Daemon.System {
+		t.Fatal("expected --system to set Daemon.System")
 	}
 }

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -37,7 +37,7 @@ func TestShouldInstallGatewayFirewall(t *testing.T) {
 	}
 }
 
-func TestServeInstallRequiresRoot(t *testing.T) {
+func TestDaemonInstallRequiresRoot(t *testing.T) {
 	prevEUID := serveInstallEUID
 	prevGOOS := serveInstallGOOS
 	serveInstallEUID = func() int { return 1000 }
@@ -48,7 +48,7 @@ func TestServeInstallRequiresRoot(t *testing.T) {
 	})
 
 	stdout, _ := makeStdoutCapture(t)
-	cmd := &ServeCommand{Action: "install"}
+	cmd := &DaemonCommand{Action: "install"}
 	err := cmd.Run(&runtimeContext{CWD: t.TempDir(), Stdout: stdout})
 	if err == nil {
 		t.Fatal("expected root requirement error")
@@ -56,24 +56,12 @@ func TestServeInstallRequiresRoot(t *testing.T) {
 	if !strings.Contains(err.Error(), "requires root") {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(err.Error(), "sudo cleanroom serve install") {
+	if !strings.Contains(err.Error(), "sudo cleanroom daemon install") {
 		t.Fatalf("expected sudo guidance, got: %v", err)
 	}
 }
 
-func TestServeRunRejectsScopeFlags(t *testing.T) {
-	stdout, _ := makeStdoutCapture(t)
-	cmd := &ServeCommand{User: true}
-	err := cmd.Run(&runtimeContext{CWD: t.TempDir(), Stdout: stdout})
-	if err == nil {
-		t.Fatal("expected scope-flag validation error")
-	}
-	if !strings.Contains(err.Error(), "only supported with") {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func TestServeInstallRefusesOverwriteWithoutForce(t *testing.T) {
+func TestDaemonInstallRefusesOverwriteWithoutForce(t *testing.T) {
 	tmpDir := t.TempDir()
 	unitPath := filepath.Join(tmpDir, "cleanroom.service")
 	original := []byte("existing-unit")
@@ -104,7 +92,7 @@ func TestServeInstallRefusesOverwriteWithoutForce(t *testing.T) {
 	})
 
 	stdout, _ := makeStdoutCapture(t)
-	cmd := &ServeCommand{Action: "install"}
+	cmd := &DaemonCommand{Action: "install"}
 	err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout})
 	if err == nil {
 		t.Fatal("expected overwrite refusal")
@@ -128,7 +116,7 @@ func TestServeInstallRefusesOverwriteWithoutForce(t *testing.T) {
 	}
 }
 
-func TestServeInstallForceOverwritesAndEnablesService(t *testing.T) {
+func TestDaemonInstallForceOverwritesAndEnablesService(t *testing.T) {
 	tmpDir := t.TempDir()
 	unitPath := filepath.Join(tmpDir, "cleanroom.service")
 	if err := os.WriteFile(unitPath, []byte("existing-unit"), 0o644); err != nil {
@@ -159,9 +147,9 @@ func TestServeInstallForceOverwritesAndEnablesService(t *testing.T) {
 	})
 
 	stdout, _ := makeStdoutCapture(t)
-	cmd := &ServeCommand{Action: "install", Force: true}
+	cmd := &DaemonCommand{Action: "install", Force: true}
 	if err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout}); err != nil {
-		t.Fatalf("ServeCommand.Run returned error: %v", err)
+		t.Fatalf("DaemonCommand.Run returned error: %v", err)
 	}
 
 	raw, err := os.ReadFile(unitPath)
@@ -189,7 +177,7 @@ func TestServeInstallForceOverwritesAndEnablesService(t *testing.T) {
 	}
 }
 
-func TestServeInstallUnsupportedOSCheckedBeforeRoot(t *testing.T) {
+func TestDaemonInstallUnsupportedOSCheckedBeforeRoot(t *testing.T) {
 	prevEUID := serveInstallEUID
 	prevGOOS := serveInstallGOOS
 	serveInstallEUID = func() int { return 1000 }
@@ -200,7 +188,7 @@ func TestServeInstallUnsupportedOSCheckedBeforeRoot(t *testing.T) {
 	})
 
 	stdout, _ := makeStdoutCapture(t)
-	cmd := &ServeCommand{Action: "install"}
+	cmd := &DaemonCommand{Action: "install"}
 	err := cmd.Run(&runtimeContext{CWD: t.TempDir(), Stdout: stdout})
 	if err == nil {
 		t.Fatal("expected unsupported OS error")
@@ -213,7 +201,7 @@ func TestServeInstallUnsupportedOSCheckedBeforeRoot(t *testing.T) {
 	}
 }
 
-func TestServeInstallUsesProvidedListenInUnit(t *testing.T) {
+func TestDaemonInstallUsesProvidedListenInUnit(t *testing.T) {
 	tmpDir := t.TempDir()
 	unitPath := filepath.Join(tmpDir, "cleanroom.service")
 
@@ -236,9 +224,9 @@ func TestServeInstallUsesProvidedListenInUnit(t *testing.T) {
 	})
 
 	stdout, _ := makeStdoutCapture(t)
-	cmd := &ServeCommand{Action: "install", Listen: "unix:///tmp/custom-cleanroom.sock"}
+	cmd := &DaemonCommand{Action: "install", Listen: "unix:///tmp/custom-cleanroom.sock"}
 	if err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout}); err != nil {
-		t.Fatalf("ServeCommand.Run returned error: %v", err)
+		t.Fatalf("DaemonCommand.Run returned error: %v", err)
 	}
 
 	raw, err := os.ReadFile(unitPath)
@@ -254,7 +242,7 @@ func TestServeInstallUsesProvidedListenInUnit(t *testing.T) {
 	}
 }
 
-func TestServeInstallDarwinDefaultsToUserScopeForNonRoot(t *testing.T) {
+func TestDaemonInstallDarwinDefaultsToUserScopeForNonRoot(t *testing.T) {
 	tmpDir := t.TempDir()
 	plistPath := filepath.Join(tmpDir, "Library", "LaunchAgents", launchdServiceName+".plist")
 
@@ -284,9 +272,9 @@ func TestServeInstallDarwinDefaultsToUserScopeForNonRoot(t *testing.T) {
 	})
 
 	stdout, _ := makeStdoutCapture(t)
-	cmd := &ServeCommand{Action: "install"}
+	cmd := &DaemonCommand{Action: "install"}
 	if err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout}); err != nil {
-		t.Fatalf("ServeCommand.Run returned error: %v", err)
+		t.Fatalf("DaemonCommand.Run returned error: %v", err)
 	}
 
 	wantDomain := "gui/501"
@@ -308,7 +296,7 @@ func TestServeInstallDarwinDefaultsToUserScopeForNonRoot(t *testing.T) {
 	}
 }
 
-func TestServeInstallDarwinSystemScopeUnsupported(t *testing.T) {
+func TestDaemonInstallDarwinSystemScopeUnsupported(t *testing.T) {
 	prevEUID := serveInstallEUID
 	prevGOOS := serveInstallGOOS
 	serveInstallEUID = func() int { return 501 }
@@ -319,7 +307,7 @@ func TestServeInstallDarwinSystemScopeUnsupported(t *testing.T) {
 	})
 
 	stdout, _ := makeStdoutCapture(t)
-	cmd := &ServeCommand{Action: "install", System: true}
+	cmd := &DaemonCommand{Action: "install", System: true}
 	err := cmd.Run(&runtimeContext{CWD: t.TempDir(), Stdout: stdout})
 	if err == nil {
 		t.Fatal("expected unsupported --system error on darwin")
@@ -329,7 +317,7 @@ func TestServeInstallDarwinSystemScopeUnsupported(t *testing.T) {
 	}
 }
 
-func TestServeInstallDarwinRejectsRootByDefault(t *testing.T) {
+func TestDaemonInstallDarwinRejectsRootByDefault(t *testing.T) {
 	prevEUID := serveInstallEUID
 	prevGOOS := serveInstallGOOS
 	serveInstallEUID = func() int { return 0 }
@@ -340,17 +328,17 @@ func TestServeInstallDarwinRejectsRootByDefault(t *testing.T) {
 	})
 
 	stdout, _ := makeStdoutCapture(t)
-	cmd := &ServeCommand{Action: "install"}
+	cmd := &DaemonCommand{Action: "install"}
 	err := cmd.Run(&runtimeContext{CWD: t.TempDir(), Stdout: stdout})
 	if err == nil {
 		t.Fatal("expected root usage error on darwin")
 	}
-	if !strings.Contains(err.Error(), "run 'cleanroom serve' without sudo") {
+	if !strings.Contains(err.Error(), "run 'cleanroom daemon' without sudo") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
-func TestServeInstallLinuxUserScopeUnsupported(t *testing.T) {
+func TestDaemonInstallLinuxUserScopeUnsupported(t *testing.T) {
 	prevEUID := serveInstallEUID
 	prevGOOS := serveInstallGOOS
 	serveInstallEUID = func() int { return 1000 }
@@ -361,7 +349,7 @@ func TestServeInstallLinuxUserScopeUnsupported(t *testing.T) {
 	})
 
 	stdout, _ := makeStdoutCapture(t)
-	cmd := &ServeCommand{Action: "install", User: true}
+	cmd := &DaemonCommand{Action: "install", User: true}
 	err := cmd.Run(&runtimeContext{CWD: t.TempDir(), Stdout: stdout})
 	if err == nil {
 		t.Fatal("expected unsupported --user error on linux")
@@ -371,7 +359,7 @@ func TestServeInstallLinuxUserScopeUnsupported(t *testing.T) {
 	}
 }
 
-func TestServeInstallRejectsUserAndSystemTogether(t *testing.T) {
+func TestDaemonInstallRejectsUserAndSystemTogether(t *testing.T) {
 	prevEUID := serveInstallEUID
 	prevGOOS := serveInstallGOOS
 	serveInstallEUID = func() int { return 501 }
@@ -382,7 +370,7 @@ func TestServeInstallRejectsUserAndSystemTogether(t *testing.T) {
 	})
 
 	stdout, _ := makeStdoutCapture(t)
-	cmd := &ServeCommand{Action: "install", User: true, System: true}
+	cmd := &DaemonCommand{Action: "install", User: true, System: true}
 	err := cmd.Run(&runtimeContext{CWD: t.TempDir(), Stdout: stdout})
 	if err == nil {
 		t.Fatal("expected conflicting scope flags error")
@@ -392,7 +380,7 @@ func TestServeInstallRejectsUserAndSystemTogether(t *testing.T) {
 	}
 }
 
-func TestServeInstallCanonicalizesRelativeTLSPaths(t *testing.T) {
+func TestDaemonInstallCanonicalizesRelativeTLSPaths(t *testing.T) {
 	tmpDir := t.TempDir()
 	unitPath := filepath.Join(tmpDir, "cleanroom.service")
 
@@ -415,13 +403,13 @@ func TestServeInstallCanonicalizesRelativeTLSPaths(t *testing.T) {
 	})
 
 	stdout, _ := makeStdoutCapture(t)
-	cmd := &ServeCommand{
+	cmd := &DaemonCommand{
 		Action:  "install",
 		TLSCert: "certs/server.pem",
 		TLSKey:  "certs/server.key",
 	}
 	if err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout}); err != nil {
-		t.Fatalf("ServeCommand.Run returned error: %v", err)
+		t.Fatalf("DaemonCommand.Run returned error: %v", err)
 	}
 
 	raw, err := os.ReadFile(unitPath)
@@ -462,7 +450,7 @@ func TestServeInstallReturnsCommandErrors(t *testing.T) {
 	})
 
 	stdout, _ := makeStdoutCapture(t)
-	cmd := &ServeCommand{Action: "install"}
+	cmd := &DaemonCommand{Action: "install"}
 	err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout})
 	if err == nil {
 		t.Fatal("expected install command failure")
@@ -472,7 +460,7 @@ func TestServeInstallReturnsCommandErrors(t *testing.T) {
 	}
 }
 
-func TestServeUninstallRequiresRoot(t *testing.T) {
+func TestDaemonUninstallRequiresRoot(t *testing.T) {
 	prevEUID := serveInstallEUID
 	prevGOOS := serveInstallGOOS
 	serveInstallEUID = func() int { return 1000 }
@@ -483,7 +471,7 @@ func TestServeUninstallRequiresRoot(t *testing.T) {
 	})
 
 	stdout, _ := makeStdoutCapture(t)
-	cmd := &ServeCommand{Action: "uninstall"}
+	cmd := &DaemonCommand{Action: "uninstall"}
 	err := cmd.Run(&runtimeContext{CWD: t.TempDir(), Stdout: stdout})
 	if err == nil {
 		t.Fatal("expected root requirement error")
@@ -491,12 +479,12 @@ func TestServeUninstallRequiresRoot(t *testing.T) {
 	if !strings.Contains(err.Error(), "requires root") {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(err.Error(), "sudo cleanroom serve uninstall") {
+	if !strings.Contains(err.Error(), "sudo cleanroom daemon uninstall") {
 		t.Fatalf("expected sudo guidance, got: %v", err)
 	}
 }
 
-func TestServeUninstallRemovesServiceAndStops(t *testing.T) {
+func TestDaemonUninstallRemovesServiceAndStops(t *testing.T) {
 	tmpDir := t.TempDir()
 	unitPath := filepath.Join(tmpDir, "cleanroom.service")
 	if err := os.WriteFile(unitPath, []byte("existing-unit"), 0o644); err != nil {
@@ -527,9 +515,9 @@ func TestServeUninstallRemovesServiceAndStops(t *testing.T) {
 	})
 
 	stdout, readStdout := makeStdoutCapture(t)
-	cmd := &ServeCommand{Action: "uninstall"}
+	cmd := &DaemonCommand{Action: "uninstall"}
 	if err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout}); err != nil {
-		t.Fatalf("ServeCommand.Run returned error: %v", err)
+		t.Fatalf("DaemonCommand.Run returned error: %v", err)
 	}
 
 	if _, err := os.Stat(unitPath); !errors.Is(err, os.ErrNotExist) {
@@ -554,7 +542,7 @@ func TestServeUninstallRemovesServiceAndStops(t *testing.T) {
 	}
 }
 
-func TestServeUninstallFailsWhenNotInstalled(t *testing.T) {
+func TestDaemonUninstallFailsWhenNotInstalled(t *testing.T) {
 	tmpDir := t.TempDir()
 	unitPath := filepath.Join(tmpDir, "cleanroom.service")
 
@@ -571,7 +559,7 @@ func TestServeUninstallFailsWhenNotInstalled(t *testing.T) {
 	})
 
 	stdout, _ := makeStdoutCapture(t)
-	cmd := &ServeCommand{Action: "uninstall"}
+	cmd := &DaemonCommand{Action: "uninstall"}
 	err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout})
 	if err == nil {
 		t.Fatal("expected error when service file doesn't exist")
@@ -581,7 +569,121 @@ func TestServeUninstallFailsWhenNotInstalled(t *testing.T) {
 	}
 }
 
-func TestServeUninstallUnsupportedOS(t *testing.T) {
+func TestDaemonUninstallLaunchdRemovesUserServiceAndBootsOut(t *testing.T) {
+	tmpDir := t.TempDir()
+	plistPath := filepath.Join(tmpDir, "Library", "LaunchAgents", launchdServiceName+".plist")
+	if err := os.MkdirAll(filepath.Dir(plistPath), 0o755); err != nil {
+		t.Fatalf("mkdir launch agents dir: %v", err)
+	}
+	if err := os.WriteFile(plistPath, []byte("existing-plist"), 0o644); err != nil {
+		t.Fatalf("write existing plist: %v", err)
+	}
+
+	prevGOOS := serveInstallGOOS
+	prevEUID := serveInstallEUID
+	prevUID := serveInstallUID
+	prevUserHomeDir := serveInstallUserHomeDir
+	prevRunCommand := serveInstallRunCommand
+	prevRemoveFile := serveInstallRemoveFile
+	serveInstallGOOS = "darwin"
+	serveInstallEUID = func() int { return 501 }
+	serveInstallUID = func() int { return 501 }
+	serveInstallUserHomeDir = func() (string, error) { return tmpDir, nil }
+	serveInstallRemoveFile = os.Remove
+	var calls [][]string
+	serveInstallRunCommand = func(name string, args ...string) error {
+		calls = append(calls, append([]string{name}, args...))
+		return nil
+	}
+	t.Cleanup(func() {
+		serveInstallGOOS = prevGOOS
+		serveInstallEUID = prevEUID
+		serveInstallUID = prevUID
+		serveInstallUserHomeDir = prevUserHomeDir
+		serveInstallRunCommand = prevRunCommand
+		serveInstallRemoveFile = prevRemoveFile
+	})
+
+	stdout, readStdout := makeStdoutCapture(t)
+	cmd := &DaemonCommand{Action: "uninstall"}
+	if err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout}); err != nil {
+		t.Fatalf("DaemonCommand.Run returned error: %v", err)
+	}
+
+	if _, err := os.Stat(plistPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected launchd plist to be removed")
+	}
+
+	wantCalls := [][]string{
+		{"launchctl", "bootout", "gui/501/" + launchdServiceName},
+	}
+	if !reflect.DeepEqual(calls, wantCalls) {
+		t.Fatalf("unexpected launchctl commands: got %v want %v", calls, wantCalls)
+	}
+
+	out := readStdout()
+	if !strings.Contains(out, "daemon uninstalled") {
+		t.Fatalf("expected uninstalled message, got: %s", out)
+	}
+	if !strings.Contains(out, "manager=launchd") {
+		t.Fatalf("expected manager=launchd, got: %s", out)
+	}
+}
+
+func TestDaemonUninstallLaunchdSucceedsWhenUserServiceIsAlreadyAbsent(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	prevGOOS := serveInstallGOOS
+	prevEUID := serveInstallEUID
+	prevUID := serveInstallUID
+	prevUserHomeDir := serveInstallUserHomeDir
+	prevRunCommand := serveInstallRunCommand
+	prevRemoveFile := serveInstallRemoveFile
+	serveInstallGOOS = "darwin"
+	serveInstallEUID = func() int { return 501 }
+	serveInstallUID = func() int { return 501 }
+	serveInstallUserHomeDir = func() (string, error) { return tmpDir, nil }
+	serveInstallRemoveFile = func(string) error {
+		t.Fatal("did not expect remove to be called when plist is absent")
+		return nil
+	}
+	var calls [][]string
+	serveInstallRunCommand = func(name string, args ...string) error {
+		calls = append(calls, append([]string{name}, args...))
+		return &exec.ExitError{ProcessState: &os.ProcessState{}}
+	}
+	t.Cleanup(func() {
+		serveInstallGOOS = prevGOOS
+		serveInstallEUID = prevEUID
+		serveInstallUID = prevUID
+		serveInstallUserHomeDir = prevUserHomeDir
+		serveInstallRunCommand = prevRunCommand
+		serveInstallRemoveFile = prevRemoveFile
+	})
+
+	stdout, readStdout := makeStdoutCapture(t)
+	cmd := &DaemonCommand{Action: "uninstall"}
+	if err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout}); err != nil {
+		t.Fatalf("DaemonCommand.Run returned error: %v", err)
+	}
+
+	wantCalls := [][]string{
+		{"launchctl", "bootout", "gui/501/" + launchdServiceName},
+	}
+	if !reflect.DeepEqual(calls, wantCalls) {
+		t.Fatalf("unexpected launchctl commands: got %v want %v", calls, wantCalls)
+	}
+
+	out := readStdout()
+	if !strings.Contains(out, "daemon already uninstalled") {
+		t.Fatalf("expected already-uninstalled message, got: %s", out)
+	}
+	if !strings.Contains(out, "manager=launchd") {
+		t.Fatalf("expected manager=launchd, got: %s", out)
+	}
+}
+
+func TestDaemonUninstallUnsupportedOS(t *testing.T) {
 	prevGOOS := serveInstallGOOS
 	serveInstallGOOS = "windows"
 	t.Cleanup(func() {
@@ -589,7 +691,7 @@ func TestServeUninstallUnsupportedOS(t *testing.T) {
 	})
 
 	stdout, _ := makeStdoutCapture(t)
-	cmd := &ServeCommand{Action: "uninstall"}
+	cmd := &DaemonCommand{Action: "uninstall"}
 	err := cmd.Run(&runtimeContext{CWD: t.TempDir(), Stdout: stdout})
 	if err == nil {
 		t.Fatal("expected unsupported OS error")
@@ -599,7 +701,214 @@ func TestServeUninstallUnsupportedOS(t *testing.T) {
 	}
 }
 
-func TestServeStatusSystemdInstalled(t *testing.T) {
+func TestDaemonStartSystemdStartsService(t *testing.T) {
+	tmpDir := t.TempDir()
+	unitPath := filepath.Join(tmpDir, "cleanroom.service")
+	if err := os.WriteFile(unitPath, []byte("existing-unit"), 0o644); err != nil {
+		t.Fatalf("write existing unit: %v", err)
+	}
+
+	prevEUID := serveInstallEUID
+	prevGOOS := serveInstallGOOS
+	prevSystemdPath := serveInstallSystemdUnitPath
+	prevRunCommand := serveInstallRunCommand
+	serveInstallEUID = func() int { return 0 }
+	serveInstallGOOS = "linux"
+	serveInstallSystemdUnitPath = unitPath
+	var calls [][]string
+	serveInstallRunCommand = func(name string, args ...string) error {
+		calls = append(calls, append([]string{name}, args...))
+		return nil
+	}
+	t.Cleanup(func() {
+		serveInstallEUID = prevEUID
+		serveInstallGOOS = prevGOOS
+		serveInstallSystemdUnitPath = prevSystemdPath
+		serveInstallRunCommand = prevRunCommand
+	})
+
+	stdout, readStdout := makeStdoutCapture(t)
+	cmd := &DaemonCommand{Action: "start"}
+	if err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout}); err != nil {
+		t.Fatalf("DaemonCommand.Run returned error: %v", err)
+	}
+
+	wantCalls := [][]string{
+		{"systemctl", "start", "cleanroom.service"},
+	}
+	if !reflect.DeepEqual(calls, wantCalls) {
+		t.Fatalf("unexpected systemctl commands: got %v want %v", calls, wantCalls)
+	}
+
+	out := readStdout()
+	if !strings.Contains(out, "daemon started") {
+		t.Fatalf("expected started message, got: %s", out)
+	}
+	if !strings.Contains(out, "manager=systemd") {
+		t.Fatalf("expected manager=systemd, got: %s", out)
+	}
+}
+
+func TestDaemonStopSystemdStopsService(t *testing.T) {
+	tmpDir := t.TempDir()
+	unitPath := filepath.Join(tmpDir, "cleanroom.service")
+	if err := os.WriteFile(unitPath, []byte("existing-unit"), 0o644); err != nil {
+		t.Fatalf("write existing unit: %v", err)
+	}
+
+	prevEUID := serveInstallEUID
+	prevGOOS := serveInstallGOOS
+	prevSystemdPath := serveInstallSystemdUnitPath
+	prevRunCommand := serveInstallRunCommand
+	serveInstallEUID = func() int { return 0 }
+	serveInstallGOOS = "linux"
+	serveInstallSystemdUnitPath = unitPath
+	var calls [][]string
+	serveInstallRunCommand = func(name string, args ...string) error {
+		calls = append(calls, append([]string{name}, args...))
+		return nil
+	}
+	t.Cleanup(func() {
+		serveInstallEUID = prevEUID
+		serveInstallGOOS = prevGOOS
+		serveInstallSystemdUnitPath = prevSystemdPath
+		serveInstallRunCommand = prevRunCommand
+	})
+
+	stdout, readStdout := makeStdoutCapture(t)
+	cmd := &DaemonCommand{Action: "stop"}
+	if err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout}); err != nil {
+		t.Fatalf("DaemonCommand.Run returned error: %v", err)
+	}
+
+	wantCalls := [][]string{
+		{"systemctl", "stop", "cleanroom.service"},
+	}
+	if !reflect.DeepEqual(calls, wantCalls) {
+		t.Fatalf("unexpected systemctl commands: got %v want %v", calls, wantCalls)
+	}
+
+	out := readStdout()
+	if !strings.Contains(out, "daemon stopped") {
+		t.Fatalf("expected stopped message, got: %s", out)
+	}
+	if !strings.Contains(out, "manager=systemd") {
+		t.Fatalf("expected manager=systemd, got: %s", out)
+	}
+}
+
+func TestDaemonStartLaunchdBootstrapsAndKickstartsUserService(t *testing.T) {
+	tmpDir := t.TempDir()
+	plistPath := filepath.Join(tmpDir, "Library", "LaunchAgents", launchdServiceName+".plist")
+	if err := os.MkdirAll(filepath.Dir(plistPath), 0o755); err != nil {
+		t.Fatalf("mkdir launch agents dir: %v", err)
+	}
+	if err := os.WriteFile(plistPath, []byte("existing-plist"), 0o644); err != nil {
+		t.Fatalf("write existing plist: %v", err)
+	}
+
+	prevGOOS := serveInstallGOOS
+	prevEUID := serveInstallEUID
+	prevUID := serveInstallUID
+	prevUserHomeDir := serveInstallUserHomeDir
+	prevRunCommand := serveInstallRunCommand
+	serveInstallGOOS = "darwin"
+	serveInstallEUID = func() int { return 501 }
+	serveInstallUID = func() int { return 501 }
+	serveInstallUserHomeDir = func() (string, error) { return tmpDir, nil }
+	var calls [][]string
+	serveInstallRunCommand = func(name string, args ...string) error {
+		calls = append(calls, append([]string{name}, args...))
+		return nil
+	}
+	t.Cleanup(func() {
+		serveInstallGOOS = prevGOOS
+		serveInstallEUID = prevEUID
+		serveInstallUID = prevUID
+		serveInstallUserHomeDir = prevUserHomeDir
+		serveInstallRunCommand = prevRunCommand
+	})
+
+	stdout, readStdout := makeStdoutCapture(t)
+	cmd := &DaemonCommand{Action: "start"}
+	if err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout}); err != nil {
+		t.Fatalf("DaemonCommand.Run returned error: %v", err)
+	}
+
+	wantCalls := [][]string{
+		{"launchctl", "bootstrap", "gui/501", plistPath},
+		{"launchctl", "enable", "gui/501/" + launchdServiceName},
+		{"launchctl", "kickstart", "-k", "gui/501/" + launchdServiceName},
+	}
+	if !reflect.DeepEqual(calls, wantCalls) {
+		t.Fatalf("unexpected launchctl commands: got %v want %v", calls, wantCalls)
+	}
+
+	out := readStdout()
+	if !strings.Contains(out, "daemon started") {
+		t.Fatalf("expected started message, got: %s", out)
+	}
+	if !strings.Contains(out, "manager=launchd") {
+		t.Fatalf("expected manager=launchd, got: %s", out)
+	}
+}
+
+func TestDaemonStopLaunchdDisablesAndBootsOutUserService(t *testing.T) {
+	tmpDir := t.TempDir()
+	plistPath := filepath.Join(tmpDir, "Library", "LaunchAgents", launchdServiceName+".plist")
+	if err := os.MkdirAll(filepath.Dir(plistPath), 0o755); err != nil {
+		t.Fatalf("mkdir launch agents dir: %v", err)
+	}
+	if err := os.WriteFile(plistPath, []byte("existing-plist"), 0o644); err != nil {
+		t.Fatalf("write existing plist: %v", err)
+	}
+
+	prevGOOS := serveInstallGOOS
+	prevEUID := serveInstallEUID
+	prevUID := serveInstallUID
+	prevUserHomeDir := serveInstallUserHomeDir
+	prevRunCommand := serveInstallRunCommand
+	serveInstallGOOS = "darwin"
+	serveInstallEUID = func() int { return 501 }
+	serveInstallUID = func() int { return 501 }
+	serveInstallUserHomeDir = func() (string, error) { return tmpDir, nil }
+	var calls [][]string
+	serveInstallRunCommand = func(name string, args ...string) error {
+		calls = append(calls, append([]string{name}, args...))
+		return nil
+	}
+	t.Cleanup(func() {
+		serveInstallGOOS = prevGOOS
+		serveInstallEUID = prevEUID
+		serveInstallUID = prevUID
+		serveInstallUserHomeDir = prevUserHomeDir
+		serveInstallRunCommand = prevRunCommand
+	})
+
+	stdout, readStdout := makeStdoutCapture(t)
+	cmd := &DaemonCommand{Action: "stop"}
+	if err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout}); err != nil {
+		t.Fatalf("DaemonCommand.Run returned error: %v", err)
+	}
+
+	wantCalls := [][]string{
+		{"launchctl", "disable", "gui/501/" + launchdServiceName},
+		{"launchctl", "bootout", "gui/501/" + launchdServiceName},
+	}
+	if !reflect.DeepEqual(calls, wantCalls) {
+		t.Fatalf("unexpected launchctl commands: got %v want %v", calls, wantCalls)
+	}
+
+	out := readStdout()
+	if !strings.Contains(out, "daemon stopped") {
+		t.Fatalf("expected stopped message, got: %s", out)
+	}
+	if !strings.Contains(out, "manager=launchd") {
+		t.Fatalf("expected manager=launchd, got: %s", out)
+	}
+}
+
+func TestDaemonStatusSystemdInstalled(t *testing.T) {
 	tmpDir := t.TempDir()
 	unitPath := filepath.Join(tmpDir, "cleanroom.service")
 	if err := os.WriteFile(unitPath, []byte("unit"), 0o644); err != nil {
@@ -621,24 +930,33 @@ func TestServeStatusSystemdInstalled(t *testing.T) {
 	})
 
 	stdout, readStdout := makeStdoutCapture(t)
-	cmd := &ServeCommand{Action: "status", System: true}
+	cmd := &DaemonCommand{Action: "status", System: true}
 	if err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout}); err != nil {
-		t.Fatalf("ServeCommand.Run returned error: %v", err)
+		t.Fatalf("DaemonCommand.Run returned error: %v", err)
 	}
 
 	out := readStdout()
-	if !strings.Contains(out, "installed=true") {
-		t.Fatalf("expected installed=true, got: %s", out)
+	if !strings.Contains(out, "daemon status (systemd)") {
+		t.Fatalf("expected systemd status title, got: %s", out)
 	}
-	if !strings.Contains(out, "active=active") {
-		t.Fatalf("expected active=active, got: %s", out)
+	if !strings.Contains(out, "✓ [running] cleanroom.service") {
+		t.Fatalf("expected running summary, got: %s", out)
 	}
-	if !strings.Contains(out, "enabled=true") {
-		t.Fatalf("expected enabled=true, got: %s", out)
+	if !strings.Contains(out, "install: installed") {
+		t.Fatalf("expected install field, got: %s", out)
+	}
+	if !strings.Contains(out, "runtime: active") {
+		t.Fatalf("expected runtime field, got: %s", out)
+	}
+	if !strings.Contains(out, "enabled: enabled") {
+		t.Fatalf("expected enabled field, got: %s", out)
+	}
+	if !strings.Contains(out, "path: "+unitPath) {
+		t.Fatalf("expected path field, got: %s", out)
 	}
 }
 
-func TestServeStatusSystemdNotInstalled(t *testing.T) {
+func TestDaemonStatusSystemdNotInstalled(t *testing.T) {
 	tmpDir := t.TempDir()
 	unitPath := filepath.Join(tmpDir, "cleanroom.service")
 
@@ -657,24 +975,84 @@ func TestServeStatusSystemdNotInstalled(t *testing.T) {
 	})
 
 	stdout, readStdout := makeStdoutCapture(t)
-	cmd := &ServeCommand{Action: "status", System: true}
+	cmd := &DaemonCommand{Action: "status", System: true}
 	if err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout}); err != nil {
-		t.Fatalf("ServeCommand.Run returned error: %v", err)
+		t.Fatalf("DaemonCommand.Run returned error: %v", err)
 	}
 
 	out := readStdout()
-	if !strings.Contains(out, "installed=false") {
-		t.Fatalf("expected installed=false, got: %s", out)
+	if !strings.Contains(out, "daemon status (systemd)") {
+		t.Fatalf("expected systemd status title, got: %s", out)
 	}
-	if !strings.Contains(out, "active=inactive") {
-		t.Fatalf("expected active=inactive, got: %s", out)
+	if !strings.Contains(out, "! [not installed] cleanroom.service") {
+		t.Fatalf("expected not-installed summary, got: %s", out)
 	}
-	if !strings.Contains(out, "enabled=false") {
-		t.Fatalf("expected enabled=false, got: %s", out)
+	if !strings.Contains(out, "install: missing") {
+		t.Fatalf("expected install field, got: %s", out)
+	}
+	if !strings.Contains(out, "runtime: inactive") {
+		t.Fatalf("expected runtime field, got: %s", out)
+	}
+	if !strings.Contains(out, "enabled: disabled") {
+		t.Fatalf("expected enabled field, got: %s", out)
+	}
+	if !strings.Contains(out, "path: "+unitPath) {
+		t.Fatalf("expected path field, got: %s", out)
 	}
 }
 
-func TestServeStatusUnsupportedOS(t *testing.T) {
+func TestDaemonStatusLaunchdNotInstalled(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	prevGOOS := serveInstallGOOS
+	prevEUID := serveInstallEUID
+	prevUID := serveInstallUID
+	prevUserHomeDir := serveInstallUserHomeDir
+	prevRunCommandOutput := serveInstallRunCommandOutput
+	serveInstallGOOS = "darwin"
+	serveInstallEUID = func() int { return 501 }
+	serveInstallUID = func() int { return 501 }
+	serveInstallUserHomeDir = func() (string, error) { return tmpDir, nil }
+	serveInstallRunCommandOutput = func(name string, args ...string) (string, error) {
+		return "", &exec.ExitError{ProcessState: &os.ProcessState{}}
+	}
+	t.Cleanup(func() {
+		serveInstallGOOS = prevGOOS
+		serveInstallEUID = prevEUID
+		serveInstallUID = prevUID
+		serveInstallUserHomeDir = prevUserHomeDir
+		serveInstallRunCommandOutput = prevRunCommandOutput
+	})
+
+	stdout, readStdout := makeStdoutCapture(t)
+	cmd := &DaemonCommand{Action: "status"}
+	if err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout}); err != nil {
+		t.Fatalf("DaemonCommand.Run returned error: %v", err)
+	}
+
+	out := readStdout()
+	plistPath := filepath.Join(tmpDir, "Library", "LaunchAgents", launchdServiceName+".plist")
+	if !strings.Contains(out, "daemon status (launchd)") {
+		t.Fatalf("expected launchd status title, got: %s", out)
+	}
+	if !strings.Contains(out, "! [not installed] "+launchdServiceName) {
+		t.Fatalf("expected not-installed summary, got: %s", out)
+	}
+	if !strings.Contains(out, "install: missing") {
+		t.Fatalf("expected install field, got: %s", out)
+	}
+	if !strings.Contains(out, "runtime: inactive") {
+		t.Fatalf("expected runtime field, got: %s", out)
+	}
+	if !strings.Contains(out, "domain: gui/501") {
+		t.Fatalf("expected domain field, got: %s", out)
+	}
+	if !strings.Contains(out, "path: "+plistPath) {
+		t.Fatalf("expected path field, got: %s", out)
+	}
+}
+
+func TestDaemonStatusUnsupportedOS(t *testing.T) {
 	prevGOOS := serveInstallGOOS
 	serveInstallGOOS = "windows"
 	t.Cleanup(func() {
@@ -682,7 +1060,7 @@ func TestServeStatusUnsupportedOS(t *testing.T) {
 	})
 
 	stdout, _ := makeStdoutCapture(t)
-	cmd := &ServeCommand{Action: "status", System: true}
+	cmd := &DaemonCommand{Action: "status", System: true}
 	err := cmd.Run(&runtimeContext{CWD: t.TempDir(), Stdout: stdout})
 	if err == nil {
 		t.Fatal("expected unsupported OS error")
@@ -692,7 +1070,7 @@ func TestServeStatusUnsupportedOS(t *testing.T) {
 	}
 }
 
-func TestServeStatusLaunchdIncludesListenEndpoint(t *testing.T) {
+func TestDaemonStatusLaunchdIncludesListenEndpoint(t *testing.T) {
 	tmpDir := t.TempDir()
 	plistPath := filepath.Join(tmpDir, "Library", "LaunchAgents", launchdServiceName+".plist")
 	content := renderLaunchdService("/usr/local/bin/cleanroom", []string{"serve", "--listen", "unix:///tmp/custom-cleanroom.sock"})
@@ -727,18 +1105,24 @@ func TestServeStatusLaunchdIncludesListenEndpoint(t *testing.T) {
 	})
 
 	stdout, readStdout := makeStdoutCapture(t)
-	cmd := &ServeCommand{Action: "status"}
+	cmd := &DaemonCommand{Action: "status"}
 	if err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout}); err != nil {
-		t.Fatalf("ServeCommand.Run returned error: %v", err)
+		t.Fatalf("DaemonCommand.Run returned error: %v", err)
 	}
 
 	out := readStdout()
-	if !strings.Contains(out, "listen=unix:///tmp/custom-cleanroom.sock") {
+	if !strings.Contains(out, "daemon status (launchd)") {
+		t.Fatalf("expected launchd status title, got: %s", out)
+	}
+	if !strings.Contains(out, "✓ [running] "+launchdServiceName) {
+		t.Fatalf("expected running summary, got: %s", out)
+	}
+	if !strings.Contains(out, "listen: unix:///tmp/custom-cleanroom.sock") {
 		t.Fatalf("expected launchd status to include configured listen endpoint, got: %s", out)
 	}
 }
 
-func TestServeStatusLaunchdReportsInactiveWhenNotRunning(t *testing.T) {
+func TestDaemonStatusLaunchdReportsInactiveWhenNotRunning(t *testing.T) {
 	tmpDir := t.TempDir()
 	plistPath := filepath.Join(tmpDir, "Library", "LaunchAgents", launchdServiceName+".plist")
 	content := renderLaunchdService("/usr/local/bin/cleanroom", []string{"serve", "--listen", "unix:///tmp/custom-cleanroom.sock"})
@@ -770,16 +1154,22 @@ func TestServeStatusLaunchdReportsInactiveWhenNotRunning(t *testing.T) {
 	})
 
 	stdout, readStdout := makeStdoutCapture(t)
-	cmd := &ServeCommand{Action: "status"}
+	cmd := &DaemonCommand{Action: "status"}
 	if err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout}); err != nil {
-		t.Fatalf("ServeCommand.Run returned error: %v", err)
+		t.Fatalf("DaemonCommand.Run returned error: %v", err)
 	}
 
 	out := readStdout()
-	if !strings.Contains(out, "active=inactive") {
+	if !strings.Contains(out, "daemon status (launchd)") {
+		t.Fatalf("expected launchd status title, got: %s", out)
+	}
+	if !strings.Contains(out, "! [installed] "+launchdServiceName) {
+		t.Fatalf("expected installed summary, got: %s", out)
+	}
+	if !strings.Contains(out, "runtime: inactive") {
 		t.Fatalf("expected launchd status to report inactive for non-running state, got: %s", out)
 	}
-	if !strings.Contains(out, "state=spawn scheduled") {
+	if !strings.Contains(out, "state: spawn scheduled") {
 		t.Fatalf("expected launchd status to include raw launchd state, got: %s", out)
 	}
 }

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -1210,6 +1210,47 @@ func TestDaemonStatusLaunchdNotInstalled(t *testing.T) {
 	}
 }
 
+func TestDaemonStatusLaunchdRunningWithoutPlistShowsRunning(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	prevGOOS := serveInstallGOOS
+	prevEUID := serveInstallEUID
+	prevUID := serveInstallUID
+	prevUserHomeDir := serveInstallUserHomeDir
+	prevRunCommandOutput := serveInstallRunCommandOutput
+	serveInstallGOOS = "darwin"
+	serveInstallEUID = func() int { return 501 }
+	serveInstallUID = func() int { return 501 }
+	serveInstallUserHomeDir = func() (string, error) { return tmpDir, nil }
+	serveInstallRunCommandOutput = func(name string, args ...string) (string, error) {
+		return "state = running\n", nil
+	}
+	t.Cleanup(func() {
+		serveInstallGOOS = prevGOOS
+		serveInstallEUID = prevEUID
+		serveInstallUID = prevUID
+		serveInstallUserHomeDir = prevUserHomeDir
+		serveInstallRunCommandOutput = prevRunCommandOutput
+	})
+
+	stdout, readStdout := makeStdoutCapture(t)
+	cmd := &DaemonCommand{Action: "status"}
+	if err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout}); err != nil {
+		t.Fatalf("DaemonCommand.Run returned error: %v", err)
+	}
+
+	out := readStdout()
+	if !strings.Contains(out, "✓ [running] "+launchdServiceName) {
+		t.Fatalf("expected running summary, got: %s", out)
+	}
+	if !strings.Contains(out, "install: missing") {
+		t.Fatalf("expected install field, got: %s", out)
+	}
+	if !strings.Contains(out, "runtime: active") {
+		t.Fatalf("expected runtime field, got: %s", out)
+	}
+}
+
 func TestDaemonStatusUnsupportedOS(t *testing.T) {
 	prevGOOS := serveInstallGOOS
 	serveInstallGOOS = "windows"

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -812,10 +812,14 @@ func TestDaemonStartLaunchdBootstrapsAndKickstartsUserService(t *testing.T) {
 	prevUID := serveInstallUID
 	prevUserHomeDir := serveInstallUserHomeDir
 	prevRunCommand := serveInstallRunCommand
+	prevRunCommandOutput := serveInstallRunCommandOutput
 	serveInstallGOOS = "darwin"
 	serveInstallEUID = func() int { return 501 }
 	serveInstallUID = func() int { return 501 }
 	serveInstallUserHomeDir = func() (string, error) { return tmpDir, nil }
+	serveInstallRunCommandOutput = func(name string, args ...string) (string, error) {
+		return "", &exec.ExitError{ProcessState: &os.ProcessState{}}
+	}
 	var calls [][]string
 	serveInstallRunCommand = func(name string, args ...string) error {
 		calls = append(calls, append([]string{name}, args...))
@@ -827,6 +831,7 @@ func TestDaemonStartLaunchdBootstrapsAndKickstartsUserService(t *testing.T) {
 		serveInstallUID = prevUID
 		serveInstallUserHomeDir = prevUserHomeDir
 		serveInstallRunCommand = prevRunCommand
+		serveInstallRunCommandOutput = prevRunCommandOutput
 	})
 
 	stdout, readStdout := makeStdoutCapture(t)
@@ -850,6 +855,55 @@ func TestDaemonStartLaunchdBootstrapsAndKickstartsUserService(t *testing.T) {
 	}
 	if !strings.Contains(out, "manager=launchd") {
 		t.Fatalf("expected manager=launchd, got: %s", out)
+	}
+}
+
+func TestDaemonStartLaunchdReturnsKickstartFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+	plistPath := filepath.Join(tmpDir, "Library", "LaunchAgents", launchdServiceName+".plist")
+	if err := os.MkdirAll(filepath.Dir(plistPath), 0o755); err != nil {
+		t.Fatalf("mkdir launch agents dir: %v", err)
+	}
+	if err := os.WriteFile(plistPath, []byte("existing-plist"), 0o644); err != nil {
+		t.Fatalf("write existing plist: %v", err)
+	}
+
+	prevGOOS := serveInstallGOOS
+	prevEUID := serveInstallEUID
+	prevUID := serveInstallUID
+	prevUserHomeDir := serveInstallUserHomeDir
+	prevRunCommand := serveInstallRunCommand
+	prevRunCommandOutput := serveInstallRunCommandOutput
+	serveInstallGOOS = "darwin"
+	serveInstallEUID = func() int { return 501 }
+	serveInstallUID = func() int { return 501 }
+	serveInstallUserHomeDir = func() (string, error) { return tmpDir, nil }
+	serveInstallRunCommandOutput = func(name string, args ...string) (string, error) {
+		return "", &exec.ExitError{ProcessState: &os.ProcessState{}}
+	}
+	serveInstallRunCommand = func(name string, args ...string) error {
+		if len(args) > 0 && args[0] == "kickstart" {
+			return &exec.ExitError{ProcessState: &os.ProcessState{}}
+		}
+		return nil
+	}
+	t.Cleanup(func() {
+		serveInstallGOOS = prevGOOS
+		serveInstallEUID = prevEUID
+		serveInstallUID = prevUID
+		serveInstallUserHomeDir = prevUserHomeDir
+		serveInstallRunCommand = prevRunCommand
+		serveInstallRunCommandOutput = prevRunCommandOutput
+	})
+
+	stdout, _ := makeStdoutCapture(t)
+	cmd := &DaemonCommand{Action: "start"}
+	err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout})
+	if err == nil {
+		t.Fatal("expected launchd kickstart failure")
+	}
+	if !strings.Contains(err.Error(), "start launchd service") {
+		t.Fatalf("expected kickstart error context, got: %v", err)
 	}
 }
 
@@ -905,6 +959,51 @@ func TestDaemonStopLaunchdDisablesAndBootsOutUserService(t *testing.T) {
 	}
 	if !strings.Contains(out, "manager=launchd") {
 		t.Fatalf("expected manager=launchd, got: %s", out)
+	}
+}
+
+func TestDaemonStopLaunchdBootsOutWhenPlistIsMissing(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	prevGOOS := serveInstallGOOS
+	prevEUID := serveInstallEUID
+	prevUID := serveInstallUID
+	prevUserHomeDir := serveInstallUserHomeDir
+	prevRunCommand := serveInstallRunCommand
+	serveInstallGOOS = "darwin"
+	serveInstallEUID = func() int { return 501 }
+	serveInstallUID = func() int { return 501 }
+	serveInstallUserHomeDir = func() (string, error) { return tmpDir, nil }
+	var calls [][]string
+	serveInstallRunCommand = func(name string, args ...string) error {
+		calls = append(calls, append([]string{name}, args...))
+		return nil
+	}
+	t.Cleanup(func() {
+		serveInstallGOOS = prevGOOS
+		serveInstallEUID = prevEUID
+		serveInstallUID = prevUID
+		serveInstallUserHomeDir = prevUserHomeDir
+		serveInstallRunCommand = prevRunCommand
+	})
+
+	stdout, readStdout := makeStdoutCapture(t)
+	cmd := &DaemonCommand{Action: "stop"}
+	if err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout}); err != nil {
+		t.Fatalf("DaemonCommand.Run returned error: %v", err)
+	}
+
+	wantCalls := [][]string{
+		{"launchctl", "disable", "gui/501/" + launchdServiceName},
+		{"launchctl", "bootout", "gui/501/" + launchdServiceName},
+	}
+	if !reflect.DeepEqual(calls, wantCalls) {
+		t.Fatalf("unexpected launchctl commands: got %v want %v", calls, wantCalls)
+	}
+
+	out := readStdout()
+	if !strings.Contains(out, "daemon stopped") {
+		t.Fatalf("expected stopped message, got: %s", out)
 	}
 }
 

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -922,10 +922,14 @@ func TestDaemonStopLaunchdDisablesAndBootsOutUserService(t *testing.T) {
 	prevUID := serveInstallUID
 	prevUserHomeDir := serveInstallUserHomeDir
 	prevRunCommand := serveInstallRunCommand
+	prevRunCommandOutput := serveInstallRunCommandOutput
 	serveInstallGOOS = "darwin"
 	serveInstallEUID = func() int { return 501 }
 	serveInstallUID = func() int { return 501 }
 	serveInstallUserHomeDir = func() (string, error) { return tmpDir, nil }
+	serveInstallRunCommandOutput = func(name string, args ...string) (string, error) {
+		return "state = running\n", nil
+	}
 	var calls [][]string
 	serveInstallRunCommand = func(name string, args ...string) error {
 		calls = append(calls, append([]string{name}, args...))
@@ -937,6 +941,7 @@ func TestDaemonStopLaunchdDisablesAndBootsOutUserService(t *testing.T) {
 		serveInstallUID = prevUID
 		serveInstallUserHomeDir = prevUserHomeDir
 		serveInstallRunCommand = prevRunCommand
+		serveInstallRunCommandOutput = prevRunCommandOutput
 	})
 
 	stdout, readStdout := makeStdoutCapture(t)
@@ -970,10 +975,14 @@ func TestDaemonStopLaunchdBootsOutWhenPlistIsMissing(t *testing.T) {
 	prevUID := serveInstallUID
 	prevUserHomeDir := serveInstallUserHomeDir
 	prevRunCommand := serveInstallRunCommand
+	prevRunCommandOutput := serveInstallRunCommandOutput
 	serveInstallGOOS = "darwin"
 	serveInstallEUID = func() int { return 501 }
 	serveInstallUID = func() int { return 501 }
 	serveInstallUserHomeDir = func() (string, error) { return tmpDir, nil }
+	serveInstallRunCommandOutput = func(name string, args ...string) (string, error) {
+		return "state = running\n", nil
+	}
 	var calls [][]string
 	serveInstallRunCommand = func(name string, args ...string) error {
 		calls = append(calls, append([]string{name}, args...))
@@ -985,6 +994,7 @@ func TestDaemonStopLaunchdBootsOutWhenPlistIsMissing(t *testing.T) {
 		serveInstallUID = prevUID
 		serveInstallUserHomeDir = prevUserHomeDir
 		serveInstallRunCommand = prevRunCommand
+		serveInstallRunCommandOutput = prevRunCommandOutput
 	})
 
 	stdout, readStdout := makeStdoutCapture(t)
@@ -1004,6 +1014,55 @@ func TestDaemonStopLaunchdBootsOutWhenPlistIsMissing(t *testing.T) {
 	out := readStdout()
 	if !strings.Contains(out, "daemon stopped") {
 		t.Fatalf("expected stopped message, got: %s", out)
+	}
+}
+
+func TestDaemonStopLaunchdReturnsBootoutFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+	plistPath := filepath.Join(tmpDir, "Library", "LaunchAgents", launchdServiceName+".plist")
+	if err := os.MkdirAll(filepath.Dir(plistPath), 0o755); err != nil {
+		t.Fatalf("mkdir launch agents dir: %v", err)
+	}
+	if err := os.WriteFile(plistPath, []byte("existing-plist"), 0o644); err != nil {
+		t.Fatalf("write existing plist: %v", err)
+	}
+
+	prevGOOS := serveInstallGOOS
+	prevEUID := serveInstallEUID
+	prevUID := serveInstallUID
+	prevUserHomeDir := serveInstallUserHomeDir
+	prevRunCommand := serveInstallRunCommand
+	prevRunCommandOutput := serveInstallRunCommandOutput
+	serveInstallGOOS = "darwin"
+	serveInstallEUID = func() int { return 501 }
+	serveInstallUID = func() int { return 501 }
+	serveInstallUserHomeDir = func() (string, error) { return tmpDir, nil }
+	serveInstallRunCommandOutput = func(name string, args ...string) (string, error) {
+		return "state = running\n", nil
+	}
+	serveInstallRunCommand = func(name string, args ...string) error {
+		if len(args) > 0 && args[0] == "bootout" {
+			return &exec.ExitError{ProcessState: &os.ProcessState{}}
+		}
+		return nil
+	}
+	t.Cleanup(func() {
+		serveInstallGOOS = prevGOOS
+		serveInstallEUID = prevEUID
+		serveInstallUID = prevUID
+		serveInstallUserHomeDir = prevUserHomeDir
+		serveInstallRunCommand = prevRunCommand
+		serveInstallRunCommandOutput = prevRunCommandOutput
+	})
+
+	stdout, _ := makeStdoutCapture(t)
+	cmd := &DaemonCommand{Action: "stop"}
+	err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout})
+	if err == nil {
+		t.Fatal("expected launchd bootout failure")
+	}
+	if !strings.Contains(err.Error(), "stop launchd service") {
+		t.Fatalf("expected bootout error context, got: %v", err)
 	}
 }
 

--- a/internal/cli/ui.go
+++ b/internal/cli/ui.go
@@ -24,6 +24,14 @@ type startupField struct {
 	Value string
 }
 
+type daemonStatusReport struct {
+	Manager   string
+	Service   string
+	Installed bool
+	Active    bool
+	Fields    []startupField
+}
+
 func renderStartupHeader(h startupHeader, color bool) string {
 	title := strings.TrimSpace(h.Title)
 	if title == "" {
@@ -141,6 +149,81 @@ func renderDoctorReport(backendName string, checks []backend.DoctorCheck, color 
 	out.WriteByte('\n')
 
 	return out.String()
+}
+
+func renderDaemonStatusReport(report daemonStatusReport, color bool) string {
+	manager := strings.TrimSpace(report.Manager)
+	if manager == "" {
+		manager = "unknown"
+	}
+
+	service := strings.TrimSpace(report.Service)
+	if service == "" {
+		service = "unknown"
+	}
+
+	summary := "not installed"
+	icon := "!"
+	colorCode := "1;33"
+	switch {
+	case report.Installed && report.Active:
+		summary = "running"
+		icon = "✓"
+		colorCode = "1;32"
+	case report.Installed:
+		summary = "installed"
+	}
+
+	title := fmt.Sprintf("daemon status (%s)", manager)
+	statusLine := fmt.Sprintf("%s [%s] %s", icon, summary, service)
+	if color {
+		title = ansiWrap("1;36", title)
+		statusLine = ansiWrap(colorCode, statusLine)
+	}
+
+	var out strings.Builder
+	out.WriteString(title)
+	out.WriteByte('\n')
+	out.WriteString(statusLine)
+	out.WriteByte('\n')
+
+	for _, field := range report.Fields {
+		key := strings.TrimSpace(field.Key)
+		value := strings.TrimSpace(field.Value)
+		if key == "" || value == "" {
+			continue
+		}
+
+		line := fmt.Sprintf("  %s: %s", key, value)
+		if color {
+			line = "  " + ansiWrap("38;5;246", key+":") + " " + value
+		}
+		out.WriteString(line)
+		out.WriteByte('\n')
+	}
+
+	return out.String()
+}
+
+func daemonInstalledLabel(installed bool) string {
+	if installed {
+		return "installed"
+	}
+	return "missing"
+}
+
+func daemonRuntimeLabel(active bool) string {
+	if active {
+		return "active"
+	}
+	return "inactive"
+}
+
+func daemonEnabledLabel(enabled bool) string {
+	if enabled {
+		return "enabled"
+	}
+	return "disabled"
 }
 
 func writeStartupHeader(w io.Writer, h startupHeader, color bool) error {

--- a/internal/cli/ui.go
+++ b/internal/cli/ui.go
@@ -166,7 +166,7 @@ func renderDaemonStatusReport(report daemonStatusReport, color bool) string {
 	icon := "!"
 	colorCode := "1;33"
 	switch {
-	case report.Installed && report.Active:
+	case report.Active:
 		summary = "running"
 		icon = "✓"
 		colorCode = "1;32"

--- a/internal/cli/ui_test.go
+++ b/internal/cli/ui_test.go
@@ -115,6 +115,65 @@ func TestRenderDoctorReportColor(t *testing.T) {
 	}
 }
 
+func TestRenderDaemonStatusReportPlain(t *testing.T) {
+	out := renderDaemonStatusReport(daemonStatusReport{
+		Manager:   "launchd",
+		Service:   "com.buildkite.cleanroom",
+		Installed: false,
+		Active:    false,
+		Fields: []startupField{
+			{Key: "install", Value: "missing"},
+			{Key: "runtime", Value: "inactive"},
+			{Key: "domain", Value: "gui/501"},
+			{Key: "path", Value: "/Users/alice/Library/LaunchAgents/com.buildkite.cleanroom.plist"},
+		},
+	}, false)
+
+	if !strings.Contains(out, "daemon status (launchd)") {
+		t.Fatalf("missing status title: %q", out)
+	}
+	if !strings.Contains(out, "! [not installed] com.buildkite.cleanroom") {
+		t.Fatalf("missing summary line: %q", out)
+	}
+	if !strings.Contains(out, "  install: missing") {
+		t.Fatalf("missing install line: %q", out)
+	}
+	if !strings.Contains(out, "  runtime: inactive") {
+		t.Fatalf("missing runtime line: %q", out)
+	}
+	if strings.Contains(out, "\x1b[") {
+		t.Fatalf("plain output should not contain ANSI escapes: %q", out)
+	}
+}
+
+func TestRenderDaemonStatusReportColor(t *testing.T) {
+	out := renderDaemonStatusReport(daemonStatusReport{
+		Manager:   "systemd",
+		Service:   "cleanroom.service",
+		Installed: true,
+		Active:    true,
+		Fields: []startupField{
+			{Key: "install", Value: "installed"},
+			{Key: "runtime", Value: "active"},
+			{Key: "enabled", Value: "enabled"},
+		},
+	}, true)
+	plain := stripANSI(out)
+
+	if !strings.Contains(out, "\x1b[") {
+		t.Fatalf("expected ANSI escapes in color output: %q", out)
+	}
+	if !strings.Contains(plain, "daemon status (systemd)") {
+		t.Fatalf("missing status title: %q", out)
+	}
+	if !strings.Contains(plain, "✓ [running] cleanroom.service") {
+		t.Fatalf("missing summary line: %q", out)
+	}
+	if !strings.Contains(plain, "  enabled: enabled") {
+		t.Fatalf("missing enabled line: %q", out)
+	}
+}
+
 func stripANSI(value string) string {
 	ansi := regexp.MustCompile(`\x1b\[[0-9;]*m`)
 	return ansi.ReplaceAllString(value, "")

--- a/internal/cli/ui_test.go
+++ b/internal/cli/ui_test.go
@@ -174,6 +174,26 @@ func TestRenderDaemonStatusReportColor(t *testing.T) {
 	}
 }
 
+func TestRenderDaemonStatusReportShowsRunningWhenActiveWithoutInstall(t *testing.T) {
+	out := renderDaemonStatusReport(daemonStatusReport{
+		Manager:   "launchd",
+		Service:   "com.buildkite.cleanroom",
+		Installed: false,
+		Active:    true,
+		Fields: []startupField{
+			{Key: "install", Value: "missing"},
+			{Key: "runtime", Value: "active"},
+		},
+	}, false)
+
+	if !strings.Contains(out, "✓ [running] com.buildkite.cleanroom") {
+		t.Fatalf("expected running summary when runtime is active, got: %q", out)
+	}
+	if !strings.Contains(out, "  install: missing") {
+		t.Fatalf("missing install line: %q", out)
+	}
+}
+
 func stripANSI(value string) string {
 	ansi := regexp.MustCompile(`\x1b\[[0-9;]*m`)
 	return ansi.ReplaceAllString(value, "")


### PR DESCRIPTION
## Summary

This changes the CLI so `cleanroom serve` only runs the foreground server and `cleanroom daemon` owns service lifecycle management.

## Problem

We were overloading `cleanroom serve` with two different responsibilities:

- `cleanroom serve` meant "run the server in the foreground"
- `cleanroom serve install|uninstall|status` meant "manage the background daemon/service"

That made the command surface harder to read at a glance and left the daemon lifecycle incomplete. It also made the macOS uninstall behavior awkward when the launchd plist had already been removed: `status` could report `installed=false`, but `uninstall` still errored instead of behaving idempotently.

## What changed

- Added a dedicated `cleanroom daemon` command for service lifecycle management
- Moved install/uninstall/status under `cleanroom daemon`
- Added `cleanroom daemon start`
- Added `cleanroom daemon stop`
- Kept `cleanroom serve` as foreground server execution only
- Updated daemon status output to be easier to scan
- Made launchd uninstall report `daemon already uninstalled` when the service is already gone
- Updated docs and parser/tests for the new command tree

## Examples

Before:

```bash
cleanroom serve install
cleanroom serve status
cleanroom serve uninstall
```

After:

```bash
cleanroom daemon install
cleanroom daemon status
cleanroom daemon start
cleanroom daemon stop
cleanroom daemon uninstall
```

Foreground server execution stays:

```bash
cleanroom serve
```

Status output is now easier to read at a glance. For example, on macOS when nothing is installed:

```text
daemon status (launchd)
! [not installed] com.buildkite.cleanroom
  install: missing
  runtime: inactive
  domain: gui/501
  path: /Users/lachlan/Library/LaunchAgents/com.buildkite.cleanroom.plist
```

## Verification

- `go test ./...`
- `go build -o /tmp/cleanroom-codex-build ./cmd/cleanroom`
- `go run ./cmd/cleanroom daemon status`
- `go run ./cmd/cleanroom daemon uninstall`
