### PR TITLE
fix: allow arm64 image indexes without variant metadata

### DIFF
--- a/internal/imagemgr/platform.go
+++ b/internal/imagemgr/platform.go
@@ -12,7 +12,9 @@ func HostLinuxPlatformForGOARCH(goarch string) v1.Platform {
 	case "amd64":
 		return v1.Platform{OS: "linux", Architecture: "amd64"}
 	case "arm64":
-		return v1.Platform{OS: "linux", Architecture: "arm64", Variant: "v8"}
+		// Many published arm64 OCI indexes omit variant metadata entirely.
+		// Keep selection broad enough to match standard linux/arm64 manifests.
+		return v1.Platform{OS: "linux", Architecture: "arm64"}
 	default:
 		return v1.Platform{OS: "linux", Architecture: strings.TrimSpace(goarch)}
 	}

--- a/internal/imagemgr/registry_test.go
+++ b/internal/imagemgr/registry_test.go
@@ -13,7 +13,7 @@ func TestHostLinuxPlatformForGOARCH(t *testing.T) {
 		wantVariant string
 	}{
 		{name: "amd64", goArch: "amd64", wantOS: "linux", wantArch: "amd64", wantVariant: ""},
-		{name: "arm64", goArch: "arm64", wantOS: "linux", wantArch: "arm64", wantVariant: "v8"},
+		{name: "arm64", goArch: "arm64", wantOS: "linux", wantArch: "arm64", wantVariant: ""},
 		{name: "fallback", goArch: "ppc64le", wantOS: "linux", wantArch: "ppc64le", wantVariant: ""},
 	}
 


### PR DESCRIPTION
## Summary
- stop requiring the `v8` variant when resolving linux/arm64 OCI images
- keep arm64 registry selection compatible with standard `linux/arm64` manifest entries
- update the arm64 platform regression test to cover the intended behavior

## Why
`cleanroom agent --image ghcr.io/buildkite/cleanroom-base/alpine-agents:latest` failed on arm64 hosts because Cleanroom requested `linux/arm64/v8`, while the published GHCR manifest was `linux/arm64` with no variant metadata.

## Verification
- mise exec -- go test ./internal/imagemgr ./internal/cli
- mise exec -- go test ./...
- mise run build:go
- mise run lint-shell