### PR TITLE
docs: clarify darwin-vz networking model and add vmnet plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,10 +222,16 @@ sandbox:
 
 | Host OS | Backend | Status | Notes |
 |---------|---------|--------|-------|
-| Linux | `firecracker` | Full support | Persistent sandboxes, file download, egress allowlist enforcement |
-| macOS | `darwin-vz` | Supported with gaps | Persistent sandboxes, no file download, no egress filtering yet |
+| Linux | `firecracker` | Full support | Persistent sandboxes, per-sandbox TAP + guest IP identity, file download, egress allowlist enforcement |
+| macOS | `darwin-vz` | Supported with gaps | Persistent sandboxes, helper-managed NAT outbound networking, no file download, no egress filtering, no host-visible guest IP/TAP identity yet |
 
 Backend capabilities are exposed in `cleanroom doctor --json` under `capabilities`. See [isolation model](docs/isolation.md) for enforcement and persistence details.
+
+Network model differs significantly by backend:
+
+- `firecracker` creates a dedicated TAP interface and host/guest IP pair per sandbox, which enables host-side identity and firewall enforcement.
+- `darwin-vz` currently uses `Virtualization.framework` NAT networking. Guests can reach outbound destinations, but the host does not get a Firecracker-style per-sandbox TAP device or guest IP identity.
+- A future `darwin-vz` vmnet-backed mode is planned in [docs/plans/darwin-vz-vmnet-mode.md](docs/plans/darwin-vz-vmnet-mode.md).
 
 Select a backend explicitly:
 

--- a/docs/backend/darwin-vz.md
+++ b/docs/backend/darwin-vz.md
@@ -24,6 +24,7 @@ Implemented:
 Not implemented:
 
 - egress allowlist filtering for `sandbox.network.allow`
+- host-visible per-sandbox guest IP / TAP identity
 
 ## Process and Transport Model
 
@@ -99,11 +100,19 @@ On macOS, cleanroom also probes common Homebrew `e2fsprogs` locations.
 
 - `network.default` must be `deny`
 - `network.allow` entries are ignored and produce a warning
-- a virtual NIC is attached (NAT), so guest outbound networking is available
+- a virtual NIC is attached with `Virtualization.framework` NAT networking, so guest outbound networking is available
 
 The backend currently has no allowlist egress enforcement equivalent to Linux Firecracker iptables rules.
 
 At runtime, `darwin-vz` emits an explicit stderr warning for this so it is visible during `exec`/`console`.
+
+This is not equivalent to Firecracker's network model:
+
+- the host does not get a dedicated per-sandbox TAP device
+- the host does not get a stable per-sandbox guest IP identity to key firewall or gateway policy on
+- there is no general host-to-guest inbound network path today beyond the existing helper-mediated control/exec path
+
+The current helper-managed NAT model is intentionally simpler, but it leaves `darwin-vz` behind Firecracker in network identity and enforcement. Planned vmnet-backed work is tracked in [../plans/darwin-vz-vmnet-mode.md](../plans/darwin-vz-vmnet-mode.md).
 
 ## Capability Surface
 
@@ -118,10 +127,12 @@ Current `darwin-vz` capability values:
 - `network.allowlist_egress=false`
 - `network.guest_interface=true`
 
-Git traffic for allowed HTTPS hosts is routed through the host gateway, using a
-scope-token header for sandbox identity because guests share the NAT source
-address. The default gateway host is `192.168.64.1`; override it for unusual
-host networking setups with `CLEANROOM_DARWIN_GATEWAY_HOST`.
+Git traffic for allowed HTTPS hosts is routed through the host gateway over the
+NAT host address. The default gateway host is `192.168.64.1`; override it for
+unusual host networking setups with `CLEANROOM_DARWIN_GATEWAY_HOST`. Because
+the host lacks a stable per-sandbox guest IP identity in this mode, gateway
+scoping currently relies on helper-managed scope-token headers rather than
+Firecracker-style source-IP identity.
 
 ## Entitlements and Signing
 
@@ -184,3 +195,4 @@ The e2e test provisions one sandbox, runs two commands against it, asserts that 
 
 - no allowlist egress filtering yet
 - no sandbox file download support yet
+- no host-visible per-sandbox guest IP / TAP identity yet

--- a/docs/backend/firecracker.md
+++ b/docs/backend/firecracker.md
@@ -16,6 +16,17 @@ Firecracker is purpose-built for secure multi-tenant workloads with a minimal de
 - Route package and git egress through `content-cache`.
 - Keep secret values out of guest env and policy files.
 
+## Network Model
+
+Firecracker networking is built around a dedicated per-sandbox TAP device on the host:
+
+- each sandbox gets a unique host IP / guest IP pair on that TAP-backed subnet
+- the host can identify the sandbox by guest source IP
+- host-side iptables rules enforce default-deny egress and exact allowlist exceptions
+- gateway access is bound to the sandbox's TAP/IP identity rather than a helper-managed token
+
+This is materially different from the current `darwin-vz` backend, which uses helper-managed NAT networking and does not expose a host-visible per-sandbox guest IP. See [darwin-vz.md](darwin-vz.md) for the current macOS model.
+
 ## Implementation slices
 
 1. Slice A: minimal Firecracker runner -- create backend adapter package and run lifecycle. Boot VM, run command over vsock, collect exit code/stdout/stderr.

--- a/docs/isolation.md
+++ b/docs/isolation.md
@@ -2,10 +2,12 @@
 
 Workloads run in a Linux microVM (`firecracker` on Linux, `darwin-vz` on macOS).
 
-## Network enforcement
+## Network model and enforcement
 
-- `firecracker` enforces policy egress allowlists with per-sandbox TAP interfaces and iptables rules.
-- `darwin-vz` currently requires `network.default: deny`, ignores `network.allow` entries, and provides guest networking without egress filtering. A warning is printed during execution.
+- `firecracker` creates a dedicated TAP interface and host/guest IP pair per sandbox. It enforces policy egress allowlists with host-side iptables rules, and the host can identify a sandbox by its guest IP on that TAP-backed network.
+- `darwin-vz` currently attaches a NAT-backed virtual NIC through `Virtualization.framework`. Guests get outbound networking and can reach the host gateway through the NAT host address, but the host does not get a Firecracker-style per-sandbox TAP device or host-visible guest IP identity.
+- `darwin-vz` currently requires `network.default: deny`, ignores `network.allow` entries, and provides no host-side egress allowlist enforcement. A warning is printed during execution.
+- Planned work for vmnet-backed `darwin-vz` networking is tracked in [plans/darwin-vz-vmnet-mode.md](plans/darwin-vz-vmnet-mode.md).
 
 ## Filesystem persistence
 

--- a/docs/plans/darwin-vz-vmnet-mode.md
+++ b/docs/plans/darwin-vz-vmnet-mode.md
@@ -1,0 +1,197 @@
+# Darwin VZ Vmnet Mode Plan
+
+## Goal
+
+Add an opt-in vmnet-backed networking mode for `darwin-vz` that moves the backend closer to Firecracker's per-sandbox network identity model without introducing LAN bridging.
+
+Target outcome:
+
+- one host-reachable guest IP per sandbox
+- no LAN presence
+- outbound internet access retained
+- groundwork for future host access to guest-bound ports
+
+This document is a plan only. It does not describe implemented behavior.
+
+## Why
+
+Current `darwin-vz` networking is helper-managed NAT:
+
+- guest outbound networking is available
+- `network.allow` is not enforced
+- the host does not have a Firecracker-style per-sandbox TAP device
+- the host does not have a stable per-sandbox guest IP identity
+- gateway access uses a NAT host address and scope-token headers
+
+That differs materially from Firecracker, where each sandbox has:
+
+- a dedicated TAP device
+- a unique host IP / guest IP pair
+- host-side firewall rules keyed to sandbox network identity
+
+Vmnet mode is meant to close the identity and host-reachability gap, not to claim exact TAP parity with Linux.
+
+## Non-Goals
+
+- no implementation in this slice
+- no claim of exact Linux TAP or iptables parity
+- no LAN bridging
+- no public API changes for port publishing in the first slice
+
+## Proposed Mode
+
+Introduce an opt-in `darwin-vz` network mode based on vmnet shared-mode logical networks.
+
+Recommended first mode:
+
+- `vmnet-shared`
+
+Characteristics:
+
+- one logical vmnet network per sandbox
+- one private `/30` subnet per sandbox
+- host IP is the second address in that subnet
+- guest IP is the only assignable guest address in that subnet
+- outbound internet access remains available through vmnet shared-mode NAT
+- no dependence on the physical LAN
+
+Why `/30`:
+
+- it fits the one-host / one-guest topology exactly
+- it keeps sandbox identity simple and deterministic
+- it minimizes accidental sandbox-to-sandbox overlap
+
+## Constraints
+
+- `VZVmnetNetworkDeviceAttachment` is available only on macOS 26+
+- vmnet-backed networking requires additional authorization beyond the current virtualization entitlement
+- the vmnet network object must be created in the same process that attaches it to the VM
+
+Operational implication:
+
+- the Swift helper must own vmnet network creation
+- Go can plan network identity, but it cannot create the vmnet object on behalf of the helper
+
+## Proposed Architecture
+
+### 1. Runtime Config
+
+Add darwin-specific runtime config for networking:
+
+- `backends.darwin-vz.network.mode`
+- `backends.darwin-vz.network.subnet_pool`
+- `backends.darwin-vz.network.dns`
+- optional `backends.darwin-vz.network.external_interface`
+
+Initial default should remain `nat` until vmnet mode is proven.
+
+### 2. Network Planning
+
+Before `StartVM`, the Go backend allocates a sandbox network plan:
+
+- subnet CIDR
+- host IP
+- guest IP
+- prefix length
+- deterministic guest MAC
+
+This plan is passed to the helper as part of the control request and persisted in sandbox state.
+
+### 3. Helper Networking
+
+In vmnet mode, the helper:
+
+- creates a vmnet shared-mode logical network
+- applies the requested subnet
+- attaches the VM NIC with `VZVmnetNetworkDeviceAttachment`
+- returns actual network identity in `StartVM` response
+
+The current NAT attachment remains as the fallback path.
+
+### 4. Guest Networking
+
+The guest should move from DHCP-only startup to explicit boot-arg networking in vmnet mode.
+
+Add darwin guest boot args mirroring Firecracker:
+
+- `cleanroom_guest_ip`
+- `cleanroom_guest_gw`
+- `cleanroom_guest_mask`
+- `cleanroom_guest_dns`
+
+This makes guest identity deterministic and avoids depending on guest DHCP behavior for the new mode.
+
+### 5. Gateway Integration
+
+In current NAT mode, gateway scoping relies on scope-token headers because there is no stable guest IP identity.
+
+In vmnet mode, darwin should move to source-IP sandbox identity similar to Firecracker:
+
+- register sandbox in the gateway by guest IP
+- use host IP as the guest-visible gateway address
+- keep scope-token flow only for NAT fallback mode
+
+### 6. Sandbox Metadata
+
+Expose vmnet network identity in sandbox state:
+
+- network mode
+- host IP
+- guest IP
+- subnet
+
+This enables future host-to-guest access patterns and debugging.
+
+## Testing Plan
+
+Add opt-in darwin-vz e2e coverage for vmnet mode:
+
+- sandbox gets deterministic guest IP
+- host can connect to a guest-bound TCP port
+- guest still has outbound internet access
+- two sandboxes get distinct subnets
+- terminating a sandbox tears down reachability
+- gateway registration uses guest IP in vmnet mode
+
+Keep existing NAT-mode tests intact.
+
+## Risks
+
+- macOS version support split between NAT mode and vmnet mode
+- additional entitlement/signing requirements
+- helper/network cleanup complexity on crash paths
+- vmnet mode improves identity but still does not create a literal Linux TAP device
+- egress allowlist enforcement remains a separate problem even after guest IP identity exists
+
+## Open Questions
+
+- Is vmnet shared-mode direct host-to-guest TCP reachability sufficient, or do we need explicit port-forward rules for the first host-access slice?
+- Do we want one NIC in shared mode, or a later dual-NIC design with one host-only interface and one outbound-NAT interface?
+- Should vmnet mode stay darwin-specific in runtime config, or is it worth defining a backend-neutral "host-reachable guest network" capability first?
+
+## Suggested Slices
+
+### Slice 0: Spike
+
+- Prove a single `darwin-vz` VM can boot with vmnet shared mode
+- Prove host can reach a guest-bound port
+- Prove guest still has outbound internet access
+
+### Slice 1: Experimental Mode
+
+- Add runtime config and helper wiring
+- Add per-sandbox subnet planning
+- Add boot-arg guest IP configuration
+- Persist network metadata
+
+### Slice 2: Gateway Identity
+
+- Switch vmnet mode from scope-token gateway identity to guest-IP identity
+- Keep NAT mode unchanged
+
+### Slice 3: Hardening
+
+- doctor checks for entitlement and vmnet support
+- teardown and crash recovery
+- observability fields for network identity and mode
+- CI strategy for supported macOS workers


### PR DESCRIPTION
## Summary
- clarify the current network-model differences between firecracker and darwin-vz
- document that darwin-vz currently uses helper-managed NAT rather than per-sandbox TAP/guest-IP identity
- add a vmnet-mode plan doc covering goals, constraints, risks, and suggested slices

## Testing
- mise exec -- go test ./internal/runtimeconfig ./internal/backend/firecracker ./internal/backend/darwinvz