### PR TITLE
chore: extract controlservice runtime and brokers

### DIFF
--- a/internal/controlservice/event_feed.go
+++ b/internal/controlservice/event_feed.go
@@ -1,0 +1,64 @@
+package controlservice
+
+type eventFeed[T any] struct {
+	history     []T
+	subscribers map[int]chan T
+	nextSubID   int
+	limit       int
+}
+
+func newEventFeed[T any](limit int) eventFeed[T] {
+	return eventFeed[T]{
+		subscribers: map[int]chan T{},
+		limit:       limit,
+	}
+}
+
+func (f *eventFeed[T]) snapshot() []T {
+	return append([]T(nil), f.history...)
+}
+
+func (f *eventFeed[T]) subscribe(done <-chan struct{}, buffer int) ([]T, <-chan T, int) {
+	history := f.snapshot()
+	updates := make(chan T, buffer)
+	subID := f.nextSubID
+	f.nextSubID++
+	if f.subscribers == nil {
+		f.subscribers = map[int]chan T{}
+	}
+
+	select {
+	case <-done:
+		close(updates)
+	default:
+		f.subscribers[subID] = updates
+	}
+
+	return history, updates, subID
+}
+
+func (f *eventFeed[T]) unsubscribe(subID int) {
+	if ch, ok := f.subscribers[subID]; ok {
+		delete(f.subscribers, subID)
+		close(ch)
+	}
+}
+
+func (f *eventFeed[T]) publish(item T) {
+	f.history = appendBounded(f.history, item, f.limit)
+	for id, ch := range f.subscribers {
+		select {
+		case ch <- item:
+		default:
+			close(ch)
+			delete(f.subscribers, id)
+		}
+	}
+}
+
+func (f *eventFeed[T]) closeSubscribers() {
+	for id, ch := range f.subscribers {
+		close(ch)
+		delete(f.subscribers, id)
+	}
+}

--- a/internal/controlservice/event_feed_test.go
+++ b/internal/controlservice/event_feed_test.go
@@ -1,0 +1,39 @@
+package controlservice
+
+import "testing"
+
+func TestEventFeedRetainsBoundedHistory(t *testing.T) {
+	feed := newEventFeed[int](2)
+
+	feed.publish(1)
+	feed.publish(2)
+	feed.publish(3)
+
+	history := feed.snapshot()
+	if got, want := len(history), 2; got != want {
+		t.Fatalf("unexpected history length: got %d want %d", got, want)
+	}
+	if got, want := history[0], 2; got != want {
+		t.Fatalf("unexpected first history item: got %d want %d", got, want)
+	}
+	if got, want := history[1], 3; got != want {
+		t.Fatalf("unexpected second history item: got %d want %d", got, want)
+	}
+}
+
+func TestEventFeedDropsSlowSubscriber(t *testing.T) {
+	feed := newEventFeed[int](4)
+	done := make(chan struct{})
+
+	_, updates, subID := feed.subscribe(done, 1)
+	feed.publish(1)
+	feed.publish(2)
+	feed.unsubscribe(subID)
+
+	if got, want := <-updates, 1; got != want {
+		t.Fatalf("unexpected first update: got %d want %d", got, want)
+	}
+	if _, ok := <-updates; ok {
+		t.Fatal("expected subscriber channel to be closed after overflow")
+	}
+}

--- a/internal/controlservice/interactive_sessions.go
+++ b/internal/controlservice/interactive_sessions.go
@@ -1,0 +1,184 @@
+package controlservice
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+)
+
+type interactiveSessionGrant struct {
+	SessionID           string
+	SessionToken        string
+	ExpiresAt           time.Time
+	QuicEndpoint        string
+	Alpn                string
+	ServerCertPinSHA256 string
+}
+
+type interactiveSessionBroker struct {
+	sessions map[string]*interactiveSessionState
+	attached map[string]struct{}
+	endpoint string
+	alpn     string
+	certPin  string
+}
+
+func (b *interactiveSessionBroker) ensureMaps() {
+	if b.sessions == nil {
+		b.sessions = map[string]*interactiveSessionState{}
+	}
+	if b.attached == nil {
+		b.attached = map[string]struct{}{}
+	}
+}
+
+func (b *interactiveSessionBroker) configureTransport(endpoint, alpn, certPinSHA256 string) {
+	b.endpoint = strings.TrimSpace(endpoint)
+	b.alpn = strings.TrimSpace(alpn)
+	b.certPin = strings.TrimSpace(certPinSHA256)
+}
+
+func (b *interactiveSessionBroker) open(
+	executions map[string]*executionState,
+	now time.Time,
+	ttl time.Duration,
+	sessionID, token, sandboxID, executionID string,
+	initialCols, initialRows uint32,
+) (*interactiveSessionGrant, error) {
+	b.ensureMaps()
+	b.pruneExpired(now)
+
+	if b.endpoint == "" || b.alpn == "" {
+		return nil, errors.New("interactive transport is not configured")
+	}
+
+	ex, ok := executions[executionKey(sandboxID, executionID)]
+	if !ok {
+		return nil, fmt.Errorf("unknown execution %q in sandbox %q", executionID, sandboxID)
+	}
+	if ex.Kind != cleanroomv1.ExecutionKind_EXECUTION_KIND_INTERACTIVE {
+		return nil, fmt.Errorf("execution %q is not interactive", executionID)
+	}
+	if isFinalExecutionStatus(ex.Status) {
+		return nil, fmt.Errorf("execution %q is no longer active", executionID)
+	}
+
+	execKey := executionKey(sandboxID, executionID)
+	if _, attached := b.attached[execKey]; attached {
+		return nil, fmt.Errorf("execution %q already has an active interactive session", executionID)
+	}
+	if b.hasPending(execKey) {
+		return nil, fmt.Errorf("execution %q already has a pending interactive session", executionID)
+	}
+
+	expiresAt := now.Add(ttl)
+	b.sessions[sessionID] = &interactiveSessionState{
+		SessionID:   sessionID,
+		SandboxID:   sandboxID,
+		ExecutionID: executionID,
+		Token:       token,
+		ExpiresAt:   expiresAt,
+		InitialCols: initialCols,
+		InitialRows: initialRows,
+	}
+
+	return &interactiveSessionGrant{
+		SessionID:           sessionID,
+		SessionToken:        token,
+		ExpiresAt:           expiresAt,
+		QuicEndpoint:        b.endpoint,
+		Alpn:                b.alpn,
+		ServerCertPinSHA256: b.certPin,
+	}, nil
+}
+
+func (b *interactiveSessionBroker) consume(
+	executions map[string]*executionState,
+	now time.Time,
+	sessionID, token string,
+) (*InteractiveSession, error) {
+	b.ensureMaps()
+	b.pruneExpired(now)
+
+	session, ok := b.sessions[sessionID]
+	if !ok || session == nil {
+		return nil, fmt.Errorf("unknown interactive session %q", sessionID)
+	}
+	if session.Token != token {
+		return nil, errors.New("invalid session token")
+	}
+
+	execKey := executionKey(session.SandboxID, session.ExecutionID)
+	ex, ok := executions[execKey]
+	if !ok {
+		delete(b.sessions, sessionID)
+		return nil, fmt.Errorf("unknown execution %q in sandbox %q", session.ExecutionID, session.SandboxID)
+	}
+	if ex.Kind != cleanroomv1.ExecutionKind_EXECUTION_KIND_INTERACTIVE {
+		delete(b.sessions, sessionID)
+		return nil, fmt.Errorf("execution %q is not interactive", session.ExecutionID)
+	}
+	if isFinalExecutionStatus(ex.Status) {
+		delete(b.sessions, sessionID)
+		return nil, fmt.Errorf("execution %q is no longer active", session.ExecutionID)
+	}
+	if _, attached := b.attached[execKey]; attached {
+		delete(b.sessions, sessionID)
+		return nil, fmt.Errorf("execution %q already has an active interactive session", session.ExecutionID)
+	}
+
+	delete(b.sessions, sessionID)
+	b.attached[execKey] = struct{}{}
+	return &InteractiveSession{
+		SessionID:   session.SessionID,
+		SandboxID:   session.SandboxID,
+		ExecutionID: session.ExecutionID,
+		InitialCols: session.InitialCols,
+		InitialRows: session.InitialRows,
+	}, nil
+}
+
+func (b *interactiveSessionBroker) release(sandboxID, executionID string) {
+	b.ensureMaps()
+	delete(b.attached, executionKey(sandboxID, executionID))
+}
+
+func (b *interactiveSessionBroker) clearExecution(execKey string) {
+	b.ensureMaps()
+	delete(b.attached, execKey)
+	for id, session := range b.sessions {
+		if session == nil {
+			delete(b.sessions, id)
+			continue
+		}
+		if executionKey(session.SandboxID, session.ExecutionID) == execKey {
+			delete(b.sessions, id)
+		}
+	}
+}
+
+func (b *interactiveSessionBroker) pruneExpired(now time.Time) {
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	for id, session := range b.sessions {
+		if session == nil || now.After(session.ExpiresAt) {
+			delete(b.sessions, id)
+		}
+	}
+}
+
+func (b *interactiveSessionBroker) hasPending(execKey string) bool {
+	for _, session := range b.sessions {
+		if session == nil {
+			continue
+		}
+		if executionKey(session.SandboxID, session.ExecutionID) == execKey {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/controlservice/interactive_sessions_test.go
+++ b/internal/controlservice/interactive_sessions_test.go
@@ -1,0 +1,70 @@
+package controlservice
+
+import (
+	"testing"
+	"time"
+
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+)
+
+func TestInteractiveSessionBrokerOpenConsumeSingleUse(t *testing.T) {
+	now := time.Date(2026, time.March, 15, 10, 0, 0, 0, time.UTC)
+	broker := &interactiveSessionBroker{}
+	broker.configureTransport("127.0.0.1:4433", "cleanroom-interactive-v1", "abc123")
+
+	executions := map[string]*executionState{
+		executionKey("sb-1", "exec-1"): {
+			ID:        "exec-1",
+			SandboxID: "sb-1",
+			Kind:      cleanroomv1.ExecutionKind_EXECUTION_KIND_INTERACTIVE,
+			Status:    cleanroomv1.ExecutionStatus_EXECUTION_STATUS_RUNNING,
+		},
+	}
+
+	grant, err := broker.open(executions, now, 30*time.Second, "session-1", "token-1", "sb-1", "exec-1", 80, 24)
+	if err != nil {
+		t.Fatalf("open returned error: %v", err)
+	}
+	if got, want := grant.SessionID, "session-1"; got != want {
+		t.Fatalf("unexpected session id: got %q want %q", got, want)
+	}
+	if got, want := grant.SessionToken, "token-1"; got != want {
+		t.Fatalf("unexpected session token: got %q want %q", got, want)
+	}
+	if got, want := grant.QuicEndpoint, "127.0.0.1:4433"; got != want {
+		t.Fatalf("unexpected endpoint: got %q want %q", got, want)
+	}
+
+	session, err := broker.consume(executions, now, "session-1", "token-1")
+	if err != nil {
+		t.Fatalf("consume returned error: %v", err)
+	}
+	if got, want := session.ExecutionID, "exec-1"; got != want {
+		t.Fatalf("unexpected execution id: got %q want %q", got, want)
+	}
+	if _, err := broker.consume(executions, now, "session-1", "token-1"); err == nil {
+		t.Fatal("expected interactive session to be single use")
+	}
+}
+
+func TestInteractiveSessionBrokerPrunesExpiredSessions(t *testing.T) {
+	now := time.Date(2026, time.March, 15, 10, 0, 0, 0, time.UTC)
+	broker := &interactiveSessionBroker{}
+	broker.configureTransport("127.0.0.1:4433", "cleanroom-interactive-v1", "abc123")
+
+	executions := map[string]*executionState{
+		executionKey("sb-1", "exec-1"): {
+			ID:        "exec-1",
+			SandboxID: "sb-1",
+			Kind:      cleanroomv1.ExecutionKind_EXECUTION_KIND_INTERACTIVE,
+			Status:    cleanroomv1.ExecutionStatus_EXECUTION_STATUS_RUNNING,
+		},
+	}
+
+	if _, err := broker.open(executions, now, time.Second, "session-1", "token-1", "sb-1", "exec-1", 80, 24); err != nil {
+		t.Fatalf("open returned error: %v", err)
+	}
+	if _, err := broker.consume(executions, now.Add(2*time.Second), "session-1", "token-1"); err == nil {
+		t.Fatal("expected expired interactive session to be pruned")
+	}
+}

--- a/internal/controlservice/repository_helpers.go
+++ b/internal/controlservice/repository_helpers.go
@@ -1,0 +1,55 @@
+package controlservice
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/buildkite/cleanroom/internal/repositorycheckout"
+)
+
+func cloneRepositoryCheckout(repository *repositorycheckout.Checkout) *repositorycheckout.Checkout {
+	if repository == nil {
+		return nil
+	}
+	return &repositorycheckout.Checkout{
+		RemoteURL:      repository.RemoteURL,
+		CommitSHA:      repository.CommitSHA,
+		DestinationDir: repository.DestinationDir,
+		Submodules:     repository.Submodules,
+		Branch:         repository.Branch,
+	}
+}
+
+func repositoryCheckoutsEqual(a, b *repositorycheckout.Checkout) bool {
+	switch {
+	case a == nil || b == nil:
+		return a == nil && b == nil
+	default:
+		return a.RemoteURL == b.RemoteURL &&
+			a.CommitSHA == b.CommitSHA &&
+			a.DestinationDir == b.DestinationDir &&
+			a.Submodules == b.Submodules &&
+			a.Branch == b.Branch
+	}
+}
+
+func validateRepositoryCheckoutForPolicy(compiled *policy.CompiledPolicy, repository *repositorycheckout.Checkout) error {
+	if repository == nil {
+		return nil
+	}
+	if err := repository.ValidateBootstrap(); err != nil {
+		return err
+	}
+	host, err := repository.NormalizeRemoteURL()
+	if err != nil {
+		return err
+	}
+	if compiled == nil {
+		return errors.New("repository checkout requires a compiled policy")
+	}
+	if !compiled.Allows(host, 443) {
+		return fmt.Errorf("repository remote host %q is not allowed by sandbox policy", host)
+	}
+	return nil
+}

--- a/internal/controlservice/runtime.go
+++ b/internal/controlservice/runtime.go
@@ -1,0 +1,115 @@
+package controlservice
+
+import "time"
+
+type serviceClock interface {
+	Now() time.Time
+	After(time.Duration) <-chan time.Time
+}
+
+type realServiceClock struct{}
+
+func (realServiceClock) Now() time.Time {
+	return time.Now().UTC()
+}
+
+func (realServiceClock) After(d time.Duration) <-chan time.Time {
+	return time.After(d)
+}
+
+type serviceIDSource interface {
+	NewSandboxID() string
+	NewExecutionID() string
+	NewInteractiveSessionID() string
+	NewRunID() string
+	NewSessionToken() (string, error)
+}
+
+type defaultServiceIDSource struct{}
+
+func (defaultServiceIDSource) NewSandboxID() string            { return newSandboxID() }
+func (defaultServiceIDSource) NewExecutionID() string          { return newExecutionID() }
+func (defaultServiceIDSource) NewInteractiveSessionID() string { return newInteractiveSessionID() }
+func (defaultServiceIDSource) NewRunID() string                { return newRunID() }
+func (defaultServiceIDSource) NewSessionToken() (string, error) {
+	return newSessionToken()
+}
+
+type retentionPolicy struct {
+	maxRetainedStoppedSandboxes     int
+	maxRetainedFinishedExecutions   int
+	maxRetainedSandboxEvents        int
+	maxRetainedExecutionEvents      int
+	maxRetainedExecutionOutputBytes int
+	retainedStateMaxAge             time.Duration
+}
+
+type serviceTimeouts struct {
+	attachStdinRegistrationWait  time.Duration
+	attachResizeRegistrationWait time.Duration
+	attachPollInterval           time.Duration
+	interactiveSessionTokenTTL   time.Duration
+	bootstrapCleanupTimeout      time.Duration
+}
+
+type serviceRuntime struct {
+	clock                   serviceClock
+	ids                     serviceIDSource
+	retention               *retentionPolicy
+	timeouts                *serviceTimeouts
+	defaultDownloadMaxBytes int64
+}
+
+var defaultRetentionPolicy = retentionPolicy{
+	maxRetainedStoppedSandboxes:     256,
+	maxRetainedFinishedExecutions:   2048,
+	maxRetainedSandboxEvents:        256,
+	maxRetainedExecutionEvents:      2048,
+	maxRetainedExecutionOutputBytes: 1 * 1024 * 1024,
+	retainedStateMaxAge:             24 * time.Hour,
+}
+
+var defaultServiceTimeouts = serviceTimeouts{
+	attachStdinRegistrationWait:  2 * time.Second,
+	attachResizeRegistrationWait: 250 * time.Millisecond,
+	attachPollInterval:           10 * time.Millisecond,
+	interactiveSessionTokenTTL:   30 * time.Second,
+	bootstrapCleanupTimeout:      10 * time.Second,
+}
+
+const defaultDownloadMaxBytes int64 = 10 * 1024 * 1024
+
+func (s *Service) clock() serviceClock {
+	if s.runtime.clock != nil {
+		return s.runtime.clock
+	}
+	return realServiceClock{}
+}
+
+func (s *Service) ids() serviceIDSource {
+	if s.runtime.ids != nil {
+		return s.runtime.ids
+	}
+	return defaultServiceIDSource{}
+}
+
+func (s *Service) retention() retentionPolicy {
+	if s.runtime.retention != nil {
+		return *s.runtime.retention
+	}
+	return defaultRetentionPolicy
+}
+
+func (s *Service) timeouts() serviceTimeouts {
+	if s.runtime.timeouts != nil {
+		return *s.runtime.timeouts
+	}
+	return defaultServiceTimeouts
+}
+
+func (s *Service) downloadMaxBytesDefault() int64 {
+	if s.runtime.defaultDownloadMaxBytes > 0 {
+		return s.runtime.defaultDownloadMaxBytes
+	}
+	return defaultDownloadMaxBytes
+}

--- a/internal/controlservice/runtime_config_helpers.go
+++ b/internal/controlservice/runtime_config_helpers.go
@@ -1,0 +1,51 @@
+package controlservice
+
+import (
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/runtimeconfig"
+)
+
+func resolveBackendName(requested, configuredDefault string) string {
+	if requested != "" {
+		return requested
+	}
+	if configuredDefault != "" {
+		return configuredDefault
+	}
+	return runtimeconfig.DefaultBackendForHost()
+}
+
+func mergeBackendConfig(backendName string, opts executionOptions, cfg runtimeconfig.Config) backend.FirecrackerConfig {
+	out := backend.FirecrackerConfig{
+		BinaryPath:           cfg.Backends.Firecracker.BinaryPath,
+		KernelImagePath:      cfg.Backends.Firecracker.KernelImage,
+		RootFSPath:           cfg.Backends.Firecracker.RootFS,
+		DockerStartupSeconds: cfg.Backends.Firecracker.Services.Docker.StartupTimeoutSeconds,
+		DockerStorageDriver:  cfg.Backends.Firecracker.Services.Docker.StorageDriver,
+		DockerIPTables:       cfg.Backends.Firecracker.Services.Docker.IPTables,
+		PrivilegedMode:       cfg.Backends.Firecracker.PrivilegedMode,
+		PrivilegedHelperPath: cfg.Backends.Firecracker.PrivilegedHelperPath,
+		VCPUs:                cfg.Backends.Firecracker.VCPUs,
+		MemoryMiB:            cfg.Backends.Firecracker.MemoryMiB,
+		GuestCID:             cfg.Backends.Firecracker.GuestCID,
+		GuestPort:            cfg.Backends.Firecracker.GuestPort,
+		LaunchSeconds:        cfg.Backends.Firecracker.LaunchSeconds,
+	}
+	if backendName == "darwin-vz" {
+		out.KernelImagePath = cfg.Backends.DarwinVZ.KernelImage
+		out.RootFSPath = cfg.Backends.DarwinVZ.RootFS
+		out.DockerStartupSeconds = cfg.Backends.DarwinVZ.Services.Docker.StartupTimeoutSeconds
+		out.DockerStorageDriver = cfg.Backends.DarwinVZ.Services.Docker.StorageDriver
+		out.DockerIPTables = cfg.Backends.DarwinVZ.Services.Docker.IPTables
+		out.VCPUs = cfg.Backends.DarwinVZ.VCPUs
+		out.MemoryMiB = cfg.Backends.DarwinVZ.MemoryMiB
+		out.GuestPort = cfg.Backends.DarwinVZ.GuestPort
+		out.LaunchSeconds = cfg.Backends.DarwinVZ.LaunchSeconds
+	}
+
+	out.Launch = true
+	if opts.LaunchSeconds != 0 {
+		out.LaunchSeconds = opts.LaunchSeconds
+	}
+	return out
+}

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -31,7 +31,7 @@ type Service struct {
 	RepositoryMirrors repositoryMirrorStore
 	runtime           serviceRuntime
 	interactive       interactiveSessionBroker
-	SnapshotStore snapshotMetadataStore
+	SnapshotStore     snapshotMetadataStore
 
 	mu                sync.RWMutex
 	sandboxes         map[string]*sandboxState
@@ -297,8 +297,8 @@ func (s *Service) createSandboxFromSnapshot(ctx context.Context, req *cleanroomv
 	firecrackerCfg.RunDir = ""
 	firecrackerCfg = withSnapshotDriver(firecrackerCfg, record.StorageDriver)
 
-	now := time.Now().UTC()
-	sandboxID := newSandboxID()
+	now := s.clock().Now()
+	sandboxID := s.ids().NewSandboxID()
 	if err := snapshotAdapter.ProvisionSandboxFromSnapshot(ctx, backend.ProvisionFromSnapshotRequest{
 		SandboxID:         sandboxID,
 		SnapshotID:        record.SnapshotID,
@@ -310,16 +310,16 @@ func (s *Service) createSandboxFromSnapshot(ctx context.Context, req *cleanroomv
 	}
 
 	state := &sandboxState{
-		ID:               sandboxID,
-		Backend:          backendName,
-		Policy:           compiled,
-		Firecracker:      firecrackerCfg,
-		Repository:       repositorycheckout.FromProto(record.Repository),
-		CreatedAt:        now,
-		UpdatedAt:        now,
-		Status:           cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY,
-		EventSubscribers: map[int]chan *cleanroomv1.SandboxEvent{},
-		Done:             make(chan struct{}),
+		ID:          sandboxID,
+		Backend:     backendName,
+		Policy:      compiled,
+		Firecracker: firecrackerCfg,
+		Repository:  repositorycheckout.FromProto(record.Repository),
+		CreatedAt:   now,
+		UpdatedAt:   now,
+		Status:      cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY,
+		events:      newEventFeed[*cleanroomv1.SandboxEvent](s.retention().maxRetainedSandboxEvents),
+		Done:        make(chan struct{}),
 	}
 
 	s.mu.Lock()
@@ -1743,7 +1743,6 @@ func (s *Service) finishSnapshotDelete(snapshotID string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	delete(s.snapshotDeletions, snapshotID)
-}
 }
 
 func (s *Service) mergeBufferedResultOutputLocked(ex *executionState, result *backend.RunResult, usedStreaming bool) {

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -3,8 +3,6 @@ package controlservice
 import (
 	"bytes"
 	"context"
-	"crypto/rand"
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"path/filepath"
@@ -1756,52 +1754,6 @@ func (s *Service) preparePersistentSandboxRepository(
 	return nil
 }
 
-func cloneRepositoryCheckout(repository *repositorycheckout.Checkout) *repositorycheckout.Checkout {
-	if repository == nil {
-		return nil
-	}
-	return &repositorycheckout.Checkout{
-		RemoteURL:      repository.RemoteURL,
-		CommitSHA:      repository.CommitSHA,
-		DestinationDir: repository.DestinationDir,
-		Submodules:     repository.Submodules,
-		Branch:         repository.Branch,
-	}
-}
-
-func repositoryCheckoutsEqual(a, b *repositorycheckout.Checkout) bool {
-	switch {
-	case a == nil || b == nil:
-		return a == nil && b == nil
-	default:
-		return a.RemoteURL == b.RemoteURL &&
-			a.CommitSHA == b.CommitSHA &&
-			a.DestinationDir == b.DestinationDir &&
-			a.Submodules == b.Submodules &&
-			a.Branch == b.Branch
-	}
-}
-
-func validateRepositoryCheckoutForPolicy(compiled *policy.CompiledPolicy, repository *repositorycheckout.Checkout) error {
-	if repository == nil {
-		return nil
-	}
-	if err := repository.ValidateBootstrap(); err != nil {
-		return err
-	}
-	host, err := repository.NormalizeRemoteURL()
-	if err != nil {
-		return err
-	}
-	if compiled == nil {
-		return errors.New("repository checkout requires a compiled policy")
-	}
-	if !compiled.Allows(host, 443) {
-		return fmt.Errorf("repository remote host %q is not allowed by sandbox policy", host)
-	}
-	return nil
-}
-
 func (s *Service) bootstrapRepositoryInPersistentSandbox(
 	ctx context.Context,
 	adapter backend.PersistentSandboxAdapter,
@@ -1860,19 +1812,6 @@ func (s *Service) bootstrapRepositoryInPersistentSandbox(
 		return errors.New(msg)
 	}
 	return nil
-}
-
-func executionRunErrorStatus(ex *executionState, runCtx context.Context) (cleanroomv1.ExecutionStatus, int32) {
-	if ex == nil {
-		return cleanroomv1.ExecutionStatus_EXECUTION_STATUS_FAILED, 1
-	}
-	if ex.CancelRequested || errors.Is(runCtx.Err(), context.Canceled) {
-		return cleanroomv1.ExecutionStatus_EXECUTION_STATUS_CANCELED, cancelExitCode(ex.CancelSignal)
-	}
-	if errors.Is(runCtx.Err(), context.DeadlineExceeded) {
-		return cleanroomv1.ExecutionStatus_EXECUTION_STATUS_TIMED_OUT, 124
-	}
-	return cleanroomv1.ExecutionStatus_EXECUTION_STATUS_FAILED, 1
 }
 
 func (s *Service) ensureMapsLocked() {
@@ -2099,30 +2038,6 @@ func (s *Service) executionDoneChannel(sandboxID, executionID string) (<-chan st
 	return ex.Done, nil
 }
 
-func closeSandboxDoneLocked(sb *sandboxState) {
-	if sb.DoneClosed {
-		return
-	}
-	close(sb.Done)
-	sb.DoneClosed = true
-}
-
-func closeExecutionDoneLocked(ex *executionState) {
-	if ex.DoneClosed {
-		return
-	}
-	close(ex.Done)
-	ex.DoneClosed = true
-}
-
-func clearExecutionAttachIOLocked(ex *executionState) {
-	if ex == nil {
-		return
-	}
-	ex.AttachStdin = nil
-	ex.AttachResize = nil
-}
-
 func (s *Service) setExecutionAttachIO(key string, io backend.AttachIO) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -2133,20 +2048,6 @@ func (s *Service) setExecutionAttachIO(key string, io backend.AttachIO) {
 	}
 	ex.AttachStdin = io.WriteStdin
 	ex.AttachResize = io.ResizeTTY
-}
-
-func closeSandboxSubscribersLocked(sb *sandboxState) {
-	for id, ch := range sb.EventSubscribers {
-		close(ch)
-		delete(sb.EventSubscribers, id)
-	}
-}
-
-func closeExecutionSubscribersLocked(ex *executionState) {
-	for id, ch := range ex.EventSubscribers {
-		close(ch)
-		delete(ex.EventSubscribers, id)
-	}
 }
 
 func (s *Service) dropSandboxLocked(sandboxID string, sb *sandboxState) {
@@ -2175,29 +2076,6 @@ func (s *Service) hasActiveExecutionLocked(sandboxID string) bool {
 		}
 	}
 	return false
-}
-
-func executionTerminalTime(ex *executionState) time.Time {
-	if ex == nil {
-		return time.Time{}
-	}
-	if ex.FinishedAt != nil {
-		return *ex.FinishedAt
-	}
-	if ex.StartedAt != nil {
-		return *ex.StartedAt
-	}
-	return time.Time{}
-}
-
-func sandboxTerminalTime(sb *sandboxState) time.Time {
-	if sb == nil {
-		return time.Time{}
-	}
-	if !sb.UpdatedAt.IsZero() {
-		return sb.UpdatedAt
-	}
-	return sb.CreatedAt
 }
 
 func (s *Service) pruneStateLocked(now time.Time) {
@@ -2324,29 +2202,6 @@ func (s *Service) pruneSandboxesLocked(now time.Time) {
 	}
 }
 
-func isFinalExecutionStatus(status cleanroomv1.ExecutionStatus) bool {
-	switch status {
-	case cleanroomv1.ExecutionStatus_EXECUTION_STATUS_SUCCEEDED,
-		cleanroomv1.ExecutionStatus_EXECUTION_STATUS_FAILED,
-		cleanroomv1.ExecutionStatus_EXECUTION_STATUS_CANCELED,
-		cleanroomv1.ExecutionStatus_EXECUTION_STATUS_TIMED_OUT:
-		return true
-	default:
-		return false
-	}
-}
-
-func cancelExitCode(signal int32) int32 {
-	if signal <= 0 || signal > 127 {
-		return 130
-	}
-	return 128 + signal
-}
-
-func executionKey(sandboxID, executionID string) string {
-	return sandboxID + "/" + executionID
-}
-
 func ensureSandboxIdleLocked(sandboxID string, sb *sandboxState, executions map[string]*executionState) error {
 	if sb == nil {
 		return fmt.Errorf("unknown sandbox %q", sandboxID)
@@ -2404,73 +2259,6 @@ func withSnapshotDriver(cfg backend.FirecrackerConfig, driver string) backend.Fi
 	cfg.Snapshots.Driver = runtimeconfig.SnapshotDriverOrDefault(driver)
 	return cfg
 }
-
-func cloneSandboxLocked(state *sandboxState) *cleanroomv1.Sandbox {
-	if state == nil {
-		return nil
-	}
-	policyHash := ""
-	if state.Policy != nil {
-		policyHash = state.Policy.Hash
-	}
-	return &cleanroomv1.Sandbox{
-		SandboxId:  state.ID,
-		Status:     state.Status,
-		Backend:    state.Backend,
-		PolicyHash: policyHash,
-		CreatedAt:  timestamppb.New(state.CreatedAt),
-		UpdatedAt:  timestamppb.New(state.UpdatedAt),
-	}
-}
-
-func cloneExecutionLocked(state *executionState) *cleanroomv1.Execution {
-	if state == nil {
-		return nil
-	}
-	out := &cleanroomv1.Execution{
-		ExecutionId: state.ID,
-		SandboxId:   state.SandboxID,
-		Status:      state.Status,
-		Command:     append([]string(nil), state.Command...),
-		ExitCode:    state.ExitCode,
-		Tty:         state.TTY,
-		RunId:       state.RunID,
-		Kind:        state.Kind,
-	}
-	if state.StartedAt != nil {
-		out.StartedAt = timestamppb.New(*state.StartedAt)
-	}
-	if state.FinishedAt != nil {
-		out.FinishedAt = timestamppb.New(*state.FinishedAt)
-	}
-	return out
-}
-
-func resolveExecutionKind(kind cleanroomv1.ExecutionKind, tty bool) (cleanroomv1.ExecutionKind, error) {
-	if kind == cleanroomv1.ExecutionKind_EXECUTION_KIND_UNSPECIFIED {
-		if tty {
-			return cleanroomv1.ExecutionKind_EXECUTION_KIND_INTERACTIVE, nil
-		}
-		return cleanroomv1.ExecutionKind_EXECUTION_KIND_BATCH, nil
-	}
-	switch kind {
-	case cleanroomv1.ExecutionKind_EXECUTION_KIND_BATCH:
-		return kind, nil
-	case cleanroomv1.ExecutionKind_EXECUTION_KIND_INTERACTIVE:
-		return kind, nil
-	default:
-		return cleanroomv1.ExecutionKind_EXECUTION_KIND_UNSPECIFIED, fmt.Errorf("unsupported execution kind %q", kind.String())
-	}
-}
-
-func newSessionToken() (string, error) {
-	buf := make([]byte, 24)
-	if _, err := rand.Read(buf); err != nil {
-		return "", err
-	}
-	return base64.RawURLEncoding.EncodeToString(buf), nil
-}
-
 func (s *Service) recordSandboxEventLocked(sb *sandboxState, status cleanroomv1.SandboxStatus, message string) {
 	now := time.Now().UTC()
 	sb.Status = status
@@ -2569,80 +2357,4 @@ func (s *Service) clearInteractiveExecutionStateLocked(execKey string) {
 			delete(s.interactiveSessions, id)
 		}
 	}
-}
-
-func normalizeCommand(command []string) []string {
-	if len(command) > 0 && command[0] == "--" {
-		return command[1:]
-	}
-	return command
-}
-
-func bufferedResultDelta(retained, buffered string, retentionLimit int) (string, bool) {
-	if buffered == "" {
-		return "", false
-	}
-	if retained == "" {
-		return buffered, false
-	}
-	if strings.HasSuffix(buffered, retained) {
-		// If retention is saturated, treat suffix-only overlap as a truncation artifact
-		// and avoid replaying duplicate tail bytes from the buffered result.
-		if retentionLimit > 0 && len(retained) >= retentionLimit {
-			return "", false
-		}
-		if strings.HasPrefix(buffered, retained) {
-			return buffered[len(retained):], false
-		}
-		// Stream callbacks likely missed earlier bytes; replace retained output with
-		// the complete buffered output so snapshots/history stay correct.
-		return buffered, true
-	}
-	if strings.HasPrefix(buffered, retained) {
-		return buffered[len(retained):], false
-	}
-	return buffered, true
-}
-
-func appendRetainedOutput(existing, chunk string, limit int) string {
-	if limit <= 0 {
-		return ""
-	}
-	if chunk == "" {
-		if len(existing) <= limit {
-			return existing
-		}
-		return strings.Clone(existing[len(existing)-limit:])
-	}
-	if len(chunk) >= limit {
-		return strings.Clone(chunk[len(chunk)-limit:])
-	}
-	keepExisting := limit - len(chunk)
-	if keepExisting < len(existing) {
-		existing = strings.Clone(existing[len(existing)-keepExisting:])
-	}
-	return existing + chunk
-}
-
-func appendBounded[T any](history []T, item T, limit int) []T {
-	if limit <= 0 {
-		return nil
-	}
-	history = append(history, item)
-	if len(history) <= limit {
-		return history
-	}
-	trimmed := make([]T, limit)
-	copy(trimmed, history[len(history)-limit:])
-	return trimmed
-}
-
-func resolveBackendName(requested, configuredDefault string) string {
-	if requested != "" {
-		return requested
-	}
-	if configuredDefault != "" {
-		return configuredDefault
-	}
-	return runtimeconfig.DefaultBackendForHost()
 }

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -29,19 +29,15 @@ type Service struct {
 	Backends          map[string]backend.Adapter
 	Logger            *log.Logger
 	RepositoryMirrors repositoryMirrorStore
-
+	runtime           serviceRuntime
+	interactive       interactiveSessionBroker
 	SnapshotStore snapshotMetadataStore
 
-	mu                  sync.RWMutex
-	sandboxes           map[string]*sandboxState
-	executions          map[string]*executionState
-	snapshotOps         map[string]int
-	snapshotDeletions   map[string]struct{}
-	interactiveSessions map[string]*interactiveSessionState
-	interactiveAttached map[string]struct{}
-	interactiveEndpoint string
-	interactiveALPN     string
-	interactiveCertPin  string
+	mu                sync.RWMutex
+	sandboxes         map[string]*sandboxState
+	executions        map[string]*executionState
+	snapshotOps       map[string]int
+	snapshotDeletions map[string]struct{}
 }
 
 type sandboxState struct {
@@ -57,43 +53,39 @@ type sandboxState struct {
 	UpdatedAt          time.Time
 	LastExecutionID    string
 	Status             cleanroomv1.SandboxStatus
-	EventHistory       []*cleanroomv1.SandboxEvent
-	EventSubscribers   map[int]chan *cleanroomv1.SandboxEvent
-	NextSubID          int
+	events             eventFeed[*cleanroomv1.SandboxEvent]
 	Done               chan struct{}
 	DoneClosed         bool
 }
 
 type executionState struct {
-	ID               string
-	SandboxID        string
-	RunID            string
-	ImageRef         string
-	ImageDigest      string
-	Command          []string
-	Options          executionOptions
-	TTY              bool
-	Kind             cleanroomv1.ExecutionKind
-	Status           cleanroomv1.ExecutionStatus
-	ExitCode         int32
-	StartedAt        *time.Time
-	FinishedAt       *time.Time
-	Message          string
-	Stdout           string
-	Stderr           string
-	LaunchedVM       bool
-	PlanPath         string
-	RunDir           string
-	CancelRequested  bool
-	CancelSignal     int32
-	Cancel           context.CancelFunc
-	AttachStdin      func([]byte) error
-	AttachResize     func(cols, rows uint32) error
-	EventHistory     []*cleanroomv1.ExecutionStreamEvent
-	EventSubscribers map[int]chan *cleanroomv1.ExecutionStreamEvent
-	NextSubID        int
-	Done             chan struct{}
-	DoneClosed       bool
+	ID              string
+	SandboxID       string
+	RunID           string
+	ImageRef        string
+	ImageDigest     string
+	Command         []string
+	Options         executionOptions
+	TTY             bool
+	Kind            cleanroomv1.ExecutionKind
+	Status          cleanroomv1.ExecutionStatus
+	ExitCode        int32
+	StartedAt       *time.Time
+	FinishedAt      *time.Time
+	Message         string
+	Stdout          string
+	Stderr          string
+	LaunchedVM      bool
+	PlanPath        string
+	RunDir          string
+	CancelRequested bool
+	CancelSignal    int32
+	Cancel          context.CancelFunc
+	AttachStdin     func([]byte) error
+	AttachResize    func(cols, rows uint32) error
+	events          eventFeed[*cleanroomv1.ExecutionStreamEvent]
+	Done            chan struct{}
+	DoneClosed      bool
 }
 
 type interactiveSessionState struct {
@@ -146,24 +138,8 @@ type executionSnapshot struct {
 }
 
 var (
-	maxRetainedStoppedSandboxes     = 256
-	maxRetainedFinishedExecutions   = 2048
-	maxRetainedSandboxEvents        = 256
-	maxRetainedExecutionEvents      = 2048
-	maxRetainedExecutionOutputBytes = 1 * 1024 * 1024
-	retainedStateMaxAge             = 24 * time.Hour
-
 	ErrExecutionStdinUnsupported  = errors.New("execution stdin attach is not supported by the current backend")
 	ErrExecutionResizeUnsupported = errors.New("execution resize is not supported by the current backend")
-)
-
-const (
-	attachStdinRegistrationWait        = 2 * time.Second
-	attachResizeRegistrationWait       = 250 * time.Millisecond
-	attachPollInterval                 = 10 * time.Millisecond
-	interactiveSessionTokenTTL         = 30 * time.Second
-	bootstrapCleanupTimeout            = 10 * time.Second
-	defaultDownloadMaxBytes      int64 = 10 * 1024 * 1024
 )
 
 func (s *Service) CreateSandbox(ctx context.Context, req *cleanroomv1.CreateSandboxRequest) (*cleanroomv1.CreateSandboxResponse, error) {
@@ -209,8 +185,8 @@ func (s *Service) CreateSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 	firecrackerCfg := runtimeconfig.MergeBackendConfig(s.Config, backendName, execOpts.LaunchSeconds)
 	firecrackerCfg.RunDir = ""
 
-	now := time.Now().UTC()
-	sandboxID := newSandboxID()
+	now := s.clock().Now()
+	sandboxID := s.ids().NewSandboxID()
 
 	if persistentAdapter, ok := adapter.(backend.PersistentSandboxAdapter); ok {
 		if err := persistentAdapter.ProvisionSandbox(ctx, backend.ProvisionRequest{
@@ -221,7 +197,7 @@ func (s *Service) CreateSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 			return nil, fmt.Errorf("provision sandbox: %w", err)
 		}
 		if err := s.bootstrapRepositoryInPersistentSandbox(ctx, persistentAdapter, sandboxID, compiled, firecrackerCfg, repository); err != nil {
-			cleanupCtx, cancel := context.WithTimeout(context.Background(), bootstrapCleanupTimeout)
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), s.timeouts().bootstrapCleanupTimeout)
 			defer cancel()
 			if terminateErr := persistentAdapter.TerminateSandbox(cleanupCtx, sandboxID); terminateErr != nil {
 				return nil, fmt.Errorf("bootstrap repository checkout: %w; cleanup failed: %v", err, terminateErr)
@@ -233,16 +209,16 @@ func (s *Service) CreateSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 	}
 
 	state := &sandboxState{
-		ID:               sandboxID,
-		Backend:          backendName,
-		Policy:           compiled,
-		Firecracker:      firecrackerCfg,
-		Repository:       cloneRepositoryCheckout(repository),
-		CreatedAt:        now,
-		UpdatedAt:        now,
-		Status:           cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY,
-		EventSubscribers: map[int]chan *cleanroomv1.SandboxEvent{},
-		Done:             make(chan struct{}),
+		ID:          sandboxID,
+		Backend:     backendName,
+		Policy:      compiled,
+		Firecracker: firecrackerCfg,
+		Repository:  cloneRepositoryCheckout(repository),
+		CreatedAt:   now,
+		UpdatedAt:   now,
+		Status:      cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY,
+		events:      newEventFeed[*cleanroomv1.SandboxEvent](s.retention().maxRetainedSandboxEvents),
+		Done:        make(chan struct{}),
 	}
 
 	s.mu.Lock()
@@ -637,7 +613,7 @@ func (s *Service) DownloadSandboxFile(ctx context.Context, req *cleanroomv1.Down
 
 	maxBytes := req.GetMaxBytes()
 	if maxBytes <= 0 {
-		maxBytes = defaultDownloadMaxBytes
+		maxBytes = s.downloadMaxBytesDefault()
 	}
 
 	s.mu.Lock()
@@ -733,7 +709,7 @@ func (s *Service) TerminateSandbox(ctx context.Context, req *cleanroomv1.Termina
 			s.recordSandboxEventLocked(state, cleanroomv1.SandboxStatus_SANDBOX_STATUS_STOPPING, "sandbox termination requested")
 		}
 
-		terminatedAt := time.Now().UTC()
+		terminatedAt := s.clock().Now()
 		for key, ex := range s.executions {
 			if ex.SandboxID != sandboxID {
 				continue
@@ -748,7 +724,7 @@ func (s *Service) TerminateSandbox(ctx context.Context, req *cleanroomv1.Termina
 				ExecutionId: ex.ID,
 				Status:      ex.Status,
 				Payload:     &cleanroomv1.ExecutionStreamEvent_Message{Message: "execution canceled due to sandbox termination"},
-				OccurredAt:  timestamppb.Now(),
+				OccurredAt:  timestamppb.New(s.clock().Now()),
 			})
 			if ex.Status == cleanroomv1.ExecutionStatus_EXECUTION_STATUS_QUEUED {
 				finished := terminatedAt
@@ -782,7 +758,7 @@ func (s *Service) TerminateSandbox(ctx context.Context, req *cleanroomv1.Termina
 		}
 	}
 
-	now := time.Now().UTC()
+	now := s.clock().Now()
 	s.mu.Lock()
 	state, ok = s.sandboxes[sandboxID]
 	if ok && state.Status != cleanroomv1.SandboxStatus_SANDBOX_STATUS_STOPPED {
@@ -843,8 +819,8 @@ func (s *Service) CreateExecution(ctx context.Context, req *cleanroomv1.CreateEx
 		tty = true
 	}
 
-	now := time.Now().UTC()
-	executionID := newExecutionID()
+	now := s.clock().Now()
+	executionID := s.ids().NewExecutionID()
 
 	s.mu.Lock()
 	s.ensureMapsLocked()
@@ -938,17 +914,17 @@ func (s *Service) CreateExecution(ctx context.Context, req *cleanroomv1.CreateEx
 		return nil, fmt.Errorf("sandbox_busy: sandbox %q is preparing repository state", sandboxID)
 	}
 	ex := &executionState{
-		ID:               executionID,
-		SandboxID:        sandboxID,
-		ImageRef:         imageRef,
-		ImageDigest:      imageDigest,
-		Command:          append([]string(nil), command...),
-		Options:          execOpts,
-		TTY:              tty,
-		Kind:             kind,
-		Status:           cleanroomv1.ExecutionStatus_EXECUTION_STATUS_QUEUED,
-		EventSubscribers: map[int]chan *cleanroomv1.ExecutionStreamEvent{},
-		Done:             make(chan struct{}),
+		ID:          executionID,
+		SandboxID:   sandboxID,
+		ImageRef:    imageRef,
+		ImageDigest: imageDigest,
+		Command:     append([]string(nil), command...),
+		Options:     execOpts,
+		TTY:         tty,
+		Kind:        kind,
+		Status:      cleanroomv1.ExecutionStatus_EXECUTION_STATUS_QUEUED,
+		events:      newEventFeed[*cleanroomv1.ExecutionStreamEvent](s.retention().maxRetainedExecutionEvents),
+		Done:        make(chan struct{}),
 	}
 	s.executions[executionKey(sandboxID, executionID)] = ex
 	sandbox.LastExecutionID = executionID
@@ -993,67 +969,45 @@ func (s *Service) OpenInteractiveExecution(_ context.Context, req *cleanroomv1.O
 		return nil, errors.New("missing execution_id")
 	}
 
-	now := time.Now().UTC()
-	token, err := newSessionToken()
+	now := s.clock().Now()
+	token, err := s.ids().NewSessionToken()
 	if err != nil {
 		return nil, fmt.Errorf("generate session token: %w", err)
 	}
-	sessionID := newInteractiveSessionID()
-	expiresAt := now.Add(interactiveSessionTokenTTL)
+	sessionID := s.ids().NewInteractiveSessionID()
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if strings.TrimSpace(s.interactiveEndpoint) == "" || strings.TrimSpace(s.interactiveALPN) == "" {
-		return nil, errors.New("interactive transport is not configured")
-	}
-
-	ex, ok := s.executions[executionKey(sandboxID, executionID)]
-	if !ok {
-		return nil, fmt.Errorf("unknown execution %q in sandbox %q", executionID, sandboxID)
-	}
-	if ex.Kind != cleanroomv1.ExecutionKind_EXECUTION_KIND_INTERACTIVE {
-		return nil, fmt.Errorf("execution %q is not interactive", executionID)
-	}
-	if isFinalExecutionStatus(ex.Status) {
-		return nil, fmt.Errorf("execution %q is no longer active", executionID)
-	}
-
-	s.ensureMapsLocked()
-	s.pruneExpiredInteractiveSessionsLocked(now)
-	execKey := executionKey(sandboxID, executionID)
-	if _, attached := s.interactiveAttached[execKey]; attached {
-		return nil, fmt.Errorf("execution %q already has an active interactive session", executionID)
-	}
-	if s.hasPendingInteractiveSessionLocked(execKey) {
-		return nil, fmt.Errorf("execution %q already has a pending interactive session", executionID)
-	}
-	s.interactiveSessions[sessionID] = &interactiveSessionState{
-		SessionID:   sessionID,
-		SandboxID:   sandboxID,
-		ExecutionID: executionID,
-		Token:       token,
-		ExpiresAt:   expiresAt,
-		InitialCols: req.GetInitialCols(),
-		InitialRows: req.GetInitialRows(),
+	grant, err := s.interactive.open(
+		s.executions,
+		now,
+		s.timeouts().interactiveSessionTokenTTL,
+		sessionID,
+		token,
+		sandboxID,
+		executionID,
+		req.GetInitialCols(),
+		req.GetInitialRows(),
+	)
+	if err != nil {
+		return nil, err
 	}
 
 	return &cleanroomv1.OpenInteractiveExecutionResponse{
-		SessionId:           sessionID,
-		SessionToken:        token,
-		ExpiresAt:           timestamppb.New(expiresAt),
-		QuicEndpoint:        s.interactiveEndpoint,
-		Alpn:                s.interactiveALPN,
-		ServerCertPinSha256: s.interactiveCertPin,
+		SessionId:           grant.SessionID,
+		SessionToken:        grant.SessionToken,
+		ExpiresAt:           timestamppb.New(grant.ExpiresAt),
+		QuicEndpoint:        grant.QuicEndpoint,
+		Alpn:                grant.Alpn,
+		ServerCertPinSha256: grant.ServerCertPinSHA256,
 	}, nil
 }
 
 func (s *Service) ConfigureInteractiveTransport(endpoint, alpn, certPinSHA256 string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.interactiveEndpoint = strings.TrimSpace(endpoint)
-	s.interactiveALPN = strings.TrimSpace(alpn)
-	s.interactiveCertPin = strings.TrimSpace(certPinSHA256)
+	s.interactive.configureTransport(endpoint, alpn, certPinSHA256)
 }
 
 func (s *Service) ConsumeInteractiveSession(sessionID, token string) (*InteractiveSession, error) {
@@ -1066,49 +1020,13 @@ func (s *Service) ConsumeInteractiveSession(sessionID, token string) (*Interacti
 		return nil, errors.New("missing session_token")
 	}
 
-	now := time.Now().UTC()
+	now := s.clock().Now()
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.ensureMapsLocked()
 
-	s.pruneExpiredInteractiveSessionsLocked(now)
-
-	session, ok := s.interactiveSessions[id]
-	if !ok || session == nil {
-		return nil, fmt.Errorf("unknown interactive session %q", id)
-	}
-	if session.Token != tok {
-		return nil, errors.New("invalid session token")
-	}
-	execKey := executionKey(session.SandboxID, session.ExecutionID)
-	ex, ok := s.executions[execKey]
-	if !ok {
-		delete(s.interactiveSessions, id)
-		return nil, fmt.Errorf("unknown execution %q in sandbox %q", session.ExecutionID, session.SandboxID)
-	}
-	if ex.Kind != cleanroomv1.ExecutionKind_EXECUTION_KIND_INTERACTIVE {
-		delete(s.interactiveSessions, id)
-		return nil, fmt.Errorf("execution %q is not interactive", session.ExecutionID)
-	}
-	if isFinalExecutionStatus(ex.Status) {
-		delete(s.interactiveSessions, id)
-		return nil, fmt.Errorf("execution %q is no longer active", session.ExecutionID)
-	}
-	if _, attached := s.interactiveAttached[execKey]; attached {
-		delete(s.interactiveSessions, id)
-		return nil, fmt.Errorf("execution %q already has an active interactive session", session.ExecutionID)
-	}
-
-	delete(s.interactiveSessions, id)
-	s.interactiveAttached[execKey] = struct{}{}
-	return &InteractiveSession{
-		SessionID:   session.SessionID,
-		SandboxID:   session.SandboxID,
-		ExecutionID: session.ExecutionID,
-		InitialCols: session.InitialCols,
-		InitialRows: session.InitialRows,
-	}, nil
+	return s.interactive.consume(s.executions, now, id, tok)
 }
 
 func (s *Service) ReleaseInteractiveExecution(sandboxID, executionID string) {
@@ -1117,11 +1035,10 @@ func (s *Service) ReleaseInteractiveExecution(sandboxID, executionID string) {
 	if sandboxID == "" || executionID == "" {
 		return
 	}
-	execKey := executionKey(sandboxID, executionID)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.ensureMapsLocked()
-	delete(s.interactiveAttached, execKey)
+	s.interactive.release(sandboxID, executionID)
 }
 
 func (s *Service) GetExecution(_ context.Context, req *cleanroomv1.GetExecutionRequest) (*cleanroomv1.GetExecutionResponse, error) {
@@ -1169,7 +1086,7 @@ func (s *Service) CancelExecution(_ context.Context, req *cleanroomv1.CancelExec
 		signalNum = 2
 	}
 
-	now := time.Now().UTC()
+	now := s.clock().Now()
 	s.mu.Lock()
 	ex, ok := s.executions[executionKey(sandboxID, executionID)]
 	if !ok {
@@ -1250,7 +1167,8 @@ func (s *Service) WriteExecutionStdin(sandboxID, executionID string, data []byte
 	}
 
 	payload := append([]byte(nil), data...)
-	deadline := time.Now().Add(attachStdinRegistrationWait)
+	clock := s.clock()
+	deadline := clock.Now().Add(s.timeouts().attachStdinRegistrationWait)
 	for {
 		var (
 			writeFn func([]byte) error
@@ -1273,12 +1191,12 @@ func (s *Service) WriteExecutionStdin(sandboxID, executionID string, data []byte
 		if writeFn != nil {
 			return writeFn(payload)
 		}
-		if time.Now().After(deadline) {
+		if clock.Now().After(deadline) {
 			return ErrExecutionStdinUnsupported
 		}
 		select {
 		case <-done:
-		case <-time.After(attachPollInterval):
+		case <-clock.After(s.timeouts().attachPollInterval):
 		}
 	}
 }
@@ -1293,7 +1211,8 @@ func (s *Service) ResizeExecutionTTY(sandboxID, executionID string, cols, rows u
 		return errors.New("missing execution_id")
 	}
 
-	deadline := time.Now().Add(attachResizeRegistrationWait)
+	clock := s.clock()
+	deadline := clock.Now().Add(s.timeouts().attachResizeRegistrationWait)
 	for {
 		var (
 			resizeFn func(cols, rows uint32) error
@@ -1316,12 +1235,12 @@ func (s *Service) ResizeExecutionTTY(sandboxID, executionID string, cols, rows u
 		if resizeFn != nil {
 			return resizeFn(cols, rows)
 		}
-		if time.Now().After(deadline) {
+		if clock.Now().After(deadline) {
 			return ErrExecutionResizeUnsupported
 		}
 		select {
 		case <-done:
-		case <-time.After(attachPollInterval):
+		case <-clock.After(s.timeouts().attachPollInterval):
 		}
 	}
 }
@@ -1340,22 +1259,8 @@ func (s *Service) SubscribeSandboxEvents(sandboxID string) ([]*cleanroomv1.Sandb
 		return nil, nil, nil, nil, fmt.Errorf("unknown sandbox %q", sandboxID)
 	}
 
-	history := append([]*cleanroomv1.SandboxEvent(nil), sb.EventHistory...)
-	updates := make(chan *cleanroomv1.SandboxEvent, 64)
+	history, updates, subID := sb.events.subscribe(sb.Done, 64)
 	done := sb.Done
-
-	subID := sb.NextSubID
-	sb.NextSubID++
-	if sb.EventSubscribers == nil {
-		sb.EventSubscribers = map[int]chan *cleanroomv1.SandboxEvent{}
-	}
-
-	select {
-	case <-done:
-		close(updates)
-	default:
-		sb.EventSubscribers[subID] = updates
-	}
 
 	unsubscribe := func() {
 		s.mu.Lock()
@@ -1364,12 +1269,7 @@ func (s *Service) SubscribeSandboxEvents(sandboxID string) ([]*cleanroomv1.Sandb
 		if !ok {
 			return
 		}
-		ch, ok := subSB.EventSubscribers[subID]
-		if !ok {
-			return
-		}
-		delete(subSB.EventSubscribers, subID)
-		close(ch)
+		subSB.events.unsubscribe(subID)
 	}
 
 	return history, updates, done, unsubscribe, nil
@@ -1393,22 +1293,8 @@ func (s *Service) SubscribeExecutionEvents(sandboxID, executionID string) ([]*cl
 		return nil, nil, nil, nil, fmt.Errorf("unknown execution %q in sandbox %q", executionID, sandboxID)
 	}
 
-	history := append([]*cleanroomv1.ExecutionStreamEvent(nil), ex.EventHistory...)
-	updates := make(chan *cleanroomv1.ExecutionStreamEvent, 2048)
+	history, updates, subID := ex.events.subscribe(ex.Done, 2048)
 	done := ex.Done
-
-	subID := ex.NextSubID
-	ex.NextSubID++
-	if ex.EventSubscribers == nil {
-		ex.EventSubscribers = map[int]chan *cleanroomv1.ExecutionStreamEvent{}
-	}
-
-	select {
-	case <-done:
-		close(updates)
-	default:
-		ex.EventSubscribers[subID] = updates
-	}
 
 	unsubscribe := func() {
 		s.mu.Lock()
@@ -1417,12 +1303,7 @@ func (s *Service) SubscribeExecutionEvents(sandboxID, executionID string) ([]*cl
 		if !ok {
 			return
 		}
-		ch, ok := subEx.EventSubscribers[subID]
-		if !ok {
-			return
-		}
-		delete(subEx.EventSubscribers, subID)
-		close(ch)
+		subEx.events.unsubscribe(subID)
 	}
 
 	return history, updates, done, unsubscribe, nil
@@ -1485,7 +1366,7 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 	}
 	sb, ok := s.sandboxes[sandboxID]
 	if !ok {
-		finished := time.Now().UTC()
+		finished := s.clock().Now()
 		s.finalizeExecutionLocked(
 			ex,
 			cleanroomv1.ExecutionStatus_EXECUTION_STATUS_FAILED,
@@ -1504,7 +1385,7 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 			finalStatus = cleanroomv1.ExecutionStatus_EXECUTION_STATUS_CANCELED
 			exitCode = cancelExitCode(ex.CancelSignal)
 		}
-		finished := time.Now().UTC()
+		finished := s.clock().Now()
 		s.finalizeExecutionLocked(
 			ex,
 			finalStatus,
@@ -1518,7 +1399,7 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 	}
 	adapter, ok := s.Backends[sb.Backend]
 	if !ok {
-		finished := time.Now().UTC()
+		finished := s.clock().Now()
 		s.finalizeExecutionLocked(
 			ex,
 			cleanroomv1.ExecutionStatus_EXECUTION_STATUS_FAILED,
@@ -1534,10 +1415,10 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 	runCtx, cancel := context.WithCancel(context.Background())
 	ex.Cancel = cancel
 
-	started := time.Now().UTC()
+	started := s.clock().Now()
 	ex.StartedAt = &started
 	ex.Status = cleanroomv1.ExecutionStatus_EXECUTION_STATUS_RUNNING
-	ex.RunID = newRunID()
+	ex.RunID = s.ids().NewRunID()
 	if sb.Policy != nil {
 		ex.ImageRef = sb.Policy.ImageRef
 		ex.ImageDigest = sb.Policy.ImageDigest
@@ -1580,7 +1461,7 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 	}
 	if sb, ok := s.sandboxes[sandboxID]; ok && sb.ActiveExecutionID == executionID {
 		sb.ActiveExecutionID = ""
-		sb.UpdatedAt = time.Now().UTC()
+		sb.UpdatedAt = s.clock().Now()
 	}
 
 	if ex.Cancel != nil {
@@ -1593,7 +1474,7 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 		if strings.TrimSpace(err.Error()) != "" {
 			s.appendExecutionStderrLocked(ex, finalStatus, []byte(err.Error()+"\n"))
 		}
-		finished := time.Now().UTC()
+		finished := s.clock().Now()
 		s.finalizeExecutionLocked(ex, finalStatus, exitCode, err.Error(), "", finished)
 		if s.Logger != nil {
 			s.Logger.Warn("execution failed",
@@ -1635,7 +1516,7 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 	} else if result.ExitCode == 0 {
 		finalStatus = cleanroomv1.ExecutionStatus_EXECUTION_STATUS_SUCCEEDED
 	}
-	finished := time.Now().UTC()
+	finished := s.clock().Now()
 	s.finalizeExecutionLocked(ex, finalStatus, finalExitCode, ex.Message, "", finished)
 
 	if s.Logger != nil {
@@ -1773,7 +1654,7 @@ func (s *Service) bootstrapRepositoryInPersistentSandbox(
 	var stderr bytes.Buffer
 	result, err := adapter.RunInSandbox(ctx, backend.RunRequest{
 		SandboxID:         sandboxID,
-		RunID:             newRunID(),
+		RunID:             s.ids().NewRunID(),
 		Command:           repositorycheckout.BuildBootstrapCommand(repository),
 		Policy:            compiled,
 		FirecrackerConfig: firecrackerCfg,
@@ -1827,12 +1708,6 @@ func (s *Service) ensureMapsLocked() {
 	if s.snapshotDeletions == nil {
 		s.snapshotDeletions = map[string]struct{}{}
 	}
-	if s.interactiveSessions == nil {
-		s.interactiveSessions = map[string]*interactiveSessionState{}
-	}
-	if s.interactiveAttached == nil {
-		s.interactiveAttached = map[string]struct{}{}
-	}
 }
 
 func (s *Service) beginSnapshotUseLocked(snapshotID string) error {
@@ -1869,28 +1744,6 @@ func (s *Service) finishSnapshotDelete(snapshotID string) {
 	defer s.mu.Unlock()
 	delete(s.snapshotDeletions, snapshotID)
 }
-
-func (s *Service) pruneExpiredInteractiveSessionsLocked(now time.Time) {
-	if now.IsZero() {
-		now = time.Now().UTC()
-	}
-	for id, session := range s.interactiveSessions {
-		if session == nil || now.After(session.ExpiresAt) {
-			delete(s.interactiveSessions, id)
-		}
-	}
-}
-
-func (s *Service) hasPendingInteractiveSessionLocked(execKey string) bool {
-	for _, session := range s.interactiveSessions {
-		if session == nil {
-			continue
-		}
-		if executionKey(session.SandboxID, session.ExecutionID) == execKey {
-			return true
-		}
-	}
-	return false
 }
 
 func (s *Service) mergeBufferedResultOutputLocked(ex *executionState, result *backend.RunResult, usedStreaming bool) {
@@ -1902,9 +1755,10 @@ func (s *Service) mergeBufferedResultOutputLocked(ex *executionState, result *ba
 	appendStderr := result.Stderr
 	replaceStdout := false
 	replaceStderr := false
+	retention := s.retention()
 	if usedStreaming {
-		appendStdout, replaceStdout = bufferedResultDelta(ex.Stdout, result.Stdout, maxRetainedExecutionOutputBytes)
-		appendStderr, replaceStderr = bufferedResultDelta(ex.Stderr, result.Stderr, maxRetainedExecutionOutputBytes)
+		appendStdout, replaceStdout = bufferedResultDelta(ex.Stdout, result.Stdout, retention.maxRetainedExecutionOutputBytes)
+		appendStderr, replaceStderr = bufferedResultDelta(ex.Stderr, result.Stderr, retention.maxRetainedExecutionOutputBytes)
 	}
 
 	if replaceStdout {
@@ -1976,13 +1830,13 @@ func (s *Service) appendExecutionStdoutLocked(ex *executionState, status cleanro
 	if ex == nil || len(chunk) == 0 {
 		return
 	}
-	ex.Stdout = appendRetainedOutput(ex.Stdout, string(chunk), maxRetainedExecutionOutputBytes)
+	ex.Stdout = appendRetainedOutput(ex.Stdout, string(chunk), s.retention().maxRetainedExecutionOutputBytes)
 	s.recordExecutionEventLocked(ex, &cleanroomv1.ExecutionStreamEvent{
 		SandboxId:   ex.SandboxID,
 		ExecutionId: ex.ID,
 		Status:      status,
 		Payload:     &cleanroomv1.ExecutionStreamEvent_Stdout{Stdout: append([]byte(nil), chunk...)},
-		OccurredAt:  timestamppb.Now(),
+		OccurredAt:  timestamppb.New(s.clock().Now()),
 	})
 }
 
@@ -1990,13 +1844,13 @@ func (s *Service) appendExecutionStderrLocked(ex *executionState, status cleanro
 	if ex == nil || len(chunk) == 0 {
 		return
 	}
-	ex.Stderr = appendRetainedOutput(ex.Stderr, string(chunk), maxRetainedExecutionOutputBytes)
+	ex.Stderr = appendRetainedOutput(ex.Stderr, string(chunk), s.retention().maxRetainedExecutionOutputBytes)
 	s.recordExecutionEventLocked(ex, &cleanroomv1.ExecutionStreamEvent{
 		SandboxId:   ex.SandboxID,
 		ExecutionId: ex.ID,
 		Status:      status,
 		Payload:     &cleanroomv1.ExecutionStreamEvent_Stderr{Stderr: append([]byte(nil), chunk...)},
-		OccurredAt:  timestamppb.Now(),
+		OccurredAt:  timestamppb.New(s.clock().Now()),
 	})
 }
 
@@ -2004,13 +1858,13 @@ func (s *Service) replaceExecutionStdoutFromBufferedLocked(ex *executionState, s
 	if ex == nil || output == "" {
 		return
 	}
-	ex.Stdout = appendRetainedOutput("", output, maxRetainedExecutionOutputBytes)
+	ex.Stdout = appendRetainedOutput("", output, s.retention().maxRetainedExecutionOutputBytes)
 	s.recordExecutionEventLocked(ex, &cleanroomv1.ExecutionStreamEvent{
 		SandboxId:   ex.SandboxID,
 		ExecutionId: ex.ID,
 		Status:      status,
 		Payload:     &cleanroomv1.ExecutionStreamEvent_Stdout{Stdout: []byte(output)},
-		OccurredAt:  timestamppb.Now(),
+		OccurredAt:  timestamppb.New(s.clock().Now()),
 	})
 }
 
@@ -2018,13 +1872,13 @@ func (s *Service) replaceExecutionStderrFromBufferedLocked(ex *executionState, s
 	if ex == nil || output == "" {
 		return
 	}
-	ex.Stderr = appendRetainedOutput("", output, maxRetainedExecutionOutputBytes)
+	ex.Stderr = appendRetainedOutput("", output, s.retention().maxRetainedExecutionOutputBytes)
 	s.recordExecutionEventLocked(ex, &cleanroomv1.ExecutionStreamEvent{
 		SandboxId:   ex.SandboxID,
 		ExecutionId: ex.ID,
 		Status:      status,
 		Payload:     &cleanroomv1.ExecutionStreamEvent_Stderr{Stderr: []byte(output)},
-		OccurredAt:  timestamppb.Now(),
+		OccurredAt:  timestamppb.New(s.clock().Now()),
 	})
 }
 
@@ -2065,7 +1919,7 @@ func (s *Service) dropExecutionLocked(key string, ex *executionState) {
 	}
 	closeExecutionSubscribersLocked(ex)
 	closeExecutionDoneLocked(ex)
-	s.clearInteractiveExecutionStateLocked(key)
+	s.interactive.clearExecution(key)
 	delete(s.executions, key)
 }
 
@@ -2080,7 +1934,7 @@ func (s *Service) hasActiveExecutionLocked(sandboxID string) bool {
 
 func (s *Service) pruneStateLocked(now time.Time) {
 	if now.IsZero() {
-		now = time.Now().UTC()
+		now = s.clock().Now()
 	}
 	s.pruneExecutionsLocked(now)
 	s.pruneSandboxesLocked(now)
@@ -2092,6 +1946,7 @@ func (s *Service) pruneExecutionsLocked(now time.Time) {
 		finished time.Time
 	}
 
+	retention := s.retention()
 	candidates := make([]candidate, 0, len(s.executions))
 	for key, ex := range s.executions {
 		if ex == nil || !isFinalExecutionStatus(ex.Status) {
@@ -2099,7 +1954,7 @@ func (s *Service) pruneExecutionsLocked(now time.Time) {
 		}
 
 		finished := executionTerminalTime(ex)
-		if retainedStateMaxAge > 0 && !finished.IsZero() && now.Sub(finished) > retainedStateMaxAge {
+		if retention.retainedStateMaxAge > 0 && !finished.IsZero() && now.Sub(finished) > retention.retainedStateMaxAge {
 			s.dropExecutionLocked(key, ex)
 			continue
 		}
@@ -2107,7 +1962,7 @@ func (s *Service) pruneExecutionsLocked(now time.Time) {
 		candidates = append(candidates, candidate{key: key, finished: finished})
 	}
 
-	limit := maxRetainedFinishedExecutions
+	limit := retention.maxRetainedFinishedExecutions
 	if limit < 0 {
 		limit = 0
 	}
@@ -2147,6 +2002,7 @@ func (s *Service) pruneSandboxesLocked(now time.Time) {
 		stopped time.Time
 	}
 
+	retention := s.retention()
 	candidates := make([]candidate, 0, len(s.sandboxes))
 	for sandboxID, sb := range s.sandboxes {
 		if sb == nil || sb.Status != cleanroomv1.SandboxStatus_SANDBOX_STATUS_STOPPED {
@@ -2157,7 +2013,7 @@ func (s *Service) pruneSandboxesLocked(now time.Time) {
 		}
 
 		stopped := sandboxTerminalTime(sb)
-		if retainedStateMaxAge > 0 && !stopped.IsZero() && now.Sub(stopped) > retainedStateMaxAge {
+		if retention.retainedStateMaxAge > 0 && !stopped.IsZero() && now.Sub(stopped) > retention.retainedStateMaxAge {
 			s.dropSandboxLocked(sandboxID, sb)
 			continue
 		}
@@ -2165,7 +2021,7 @@ func (s *Service) pruneSandboxesLocked(now time.Time) {
 		candidates = append(candidates, candidate{id: sandboxID, stopped: stopped})
 	}
 
-	limit := maxRetainedStoppedSandboxes
+	limit := retention.maxRetainedStoppedSandboxes
 	if limit < 0 {
 		limit = 0
 	}
@@ -2260,7 +2116,7 @@ func withSnapshotDriver(cfg backend.FirecrackerConfig, driver string) backend.Fi
 	return cfg
 }
 func (s *Service) recordSandboxEventLocked(sb *sandboxState, status cleanroomv1.SandboxStatus, message string) {
-	now := time.Now().UTC()
+	now := s.clock().Now()
 	sb.Status = status
 	sb.UpdatedAt = now
 	event := &cleanroomv1.SandboxEvent{
@@ -2269,16 +2125,7 @@ func (s *Service) recordSandboxEventLocked(sb *sandboxState, status cleanroomv1.
 		Message:    message,
 		OccurredAt: timestamppb.New(now),
 	}
-	sb.EventHistory = appendBounded(sb.EventHistory, event, maxRetainedSandboxEvents)
-
-	for id, ch := range sb.EventSubscribers {
-		select {
-		case ch <- event:
-		default:
-			close(ch)
-			delete(sb.EventSubscribers, id)
-		}
-	}
+	sb.events.publish(event)
 }
 
 func (s *Service) recordExecutionEventLocked(ex *executionState, event *cleanroomv1.ExecutionStreamEvent) {
@@ -2292,18 +2139,9 @@ func (s *Service) recordExecutionEventLocked(ex *executionState, event *cleanroo
 		event.ImageDigest = ex.ImageDigest
 	}
 	if event.GetOccurredAt() == nil {
-		event.OccurredAt = timestamppb.Now()
+		event.OccurredAt = timestamppb.New(s.clock().Now())
 	}
-	ex.EventHistory = appendBounded(ex.EventHistory, event, maxRetainedExecutionEvents)
-
-	for id, ch := range ex.EventSubscribers {
-		select {
-		case ch <- event:
-		default:
-			close(ch)
-			delete(ex.EventSubscribers, id)
-		}
-	}
+	ex.events.publish(event)
 }
 
 func (s *Service) finalizeExecutionLocked(ex *executionState, status cleanroomv1.ExecutionStatus, exitCode int32, message, exitMessage string, finished time.Time) {
@@ -2319,7 +2157,7 @@ func (s *Service) finalizeExecutionInternalLocked(ex *executionState, status cle
 		return
 	}
 	if finished.IsZero() {
-		finished = time.Now().UTC()
+		finished = s.clock().Now()
 	}
 	if exitMessage == "" {
 		exitMessage = message
@@ -2340,21 +2178,8 @@ func (s *Service) finalizeExecutionInternalLocked(ex *executionState, status cle
 		OccurredAt: timestamppb.New(finished),
 	})
 	closeExecutionDoneLocked(ex)
-	s.clearInteractiveExecutionStateLocked(executionKey(ex.SandboxID, ex.ID))
+	s.interactive.clearExecution(executionKey(ex.SandboxID, ex.ID))
 	if prune {
 		s.pruneStateLocked(finished)
-	}
-}
-
-func (s *Service) clearInteractiveExecutionStateLocked(execKey string) {
-	delete(s.interactiveAttached, execKey)
-	for id, session := range s.interactiveSessions {
-		if session == nil {
-			delete(s.interactiveSessions, id)
-			continue
-		}
-		if executionKey(session.SandboxID, session.ExecutionID) == execKey {
-			delete(s.interactiveSessions, id)
-		}
 	}
 }

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -31,7 +31,11 @@ type Service struct {
 	RepositoryMirrors repositoryMirrorStore
 	runtime           serviceRuntime
 	interactive       interactiveSessionBroker
-	SnapshotStore     snapshotMetadataStore
+	// Snapshot lifecycle still lives on Service because it coordinates backend
+	// adapters, sandbox state, and metadata persistence in one operation chain.
+	// If this grows again, extract a dedicated snapshot manager rather than
+	// adding more snapshot-specific branching here.
+	SnapshotStore snapshotMetadataStore
 
 	mu                sync.RWMutex
 	sandboxes         map[string]*sandboxState
@@ -1710,6 +1714,9 @@ func (s *Service) ensureMapsLocked() {
 	}
 }
 
+// Snapshot operation bookkeeping is the remaining piece of snapshot coordination
+// still owned by Service. If snapshot behavior expands beyond basic create/load/
+// delete flows, move this state and the snapshot RPC handlers into a collaborator.
 func (s *Service) beginSnapshotUseLocked(snapshotID string) error {
 	if _, deleting := s.snapshotDeletions[snapshotID]; deleting {
 		return fmt.Errorf("snapshot_busy: snapshot %q is being deleted", snapshotID)

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -2229,14 +2229,14 @@ func TestRunExecutionSkipsAlreadyFinalExecution(t *testing.T) {
 	sb.Status = cleanroomv1.SandboxStatus_SANDBOX_STATUS_STOPPED
 
 	ex := &executionState{
-		ID:               executionID,
-		SandboxID:        sandboxID,
-		Command:          []string{"echo", "stale"},
-		Status:           cleanroomv1.ExecutionStatus_EXECUTION_STATUS_CANCELED,
-		ExitCode:         143,
-		FinishedAt:       &finished,
-		events:           newEventFeed[*cleanroomv1.ExecutionStreamEvent](defaultRetentionPolicy.maxRetainedExecutionEvents),
-		Done:             make(chan struct{}),
+		ID:         executionID,
+		SandboxID:  sandboxID,
+		Command:    []string{"echo", "stale"},
+		Status:     cleanroomv1.ExecutionStatus_EXECUTION_STATUS_CANCELED,
+		ExitCode:   143,
+		FinishedAt: &finished,
+		events:     newEventFeed[*cleanroomv1.ExecutionStreamEvent](defaultRetentionPolicy.maxRetainedExecutionEvents),
+		Done:       make(chan struct{}),
 	}
 	svc.recordExecutionEventLocked(ex, &cleanroomv1.ExecutionStreamEvent{
 		SandboxId:   sandboxID,
@@ -2288,12 +2288,12 @@ func TestFinalizeExecutionWithoutPruneSkipsImmediateStatePruning(t *testing.T) {
 
 	now := time.Now().UTC()
 	ex := &executionState{
-		ID:               executionID,
-		SandboxID:        sandboxID,
-		Command:          []string{"echo", "ok"},
-		Status:           cleanroomv1.ExecutionStatus_EXECUTION_STATUS_QUEUED,
-		events:           newEventFeed[*cleanroomv1.ExecutionStreamEvent](retention.maxRetainedExecutionEvents),
-		Done:             make(chan struct{}),
+		ID:        executionID,
+		SandboxID: sandboxID,
+		Command:   []string{"echo", "ok"},
+		Status:    cleanroomv1.ExecutionStatus_EXECUTION_STATUS_QUEUED,
+		events:    newEventFeed[*cleanroomv1.ExecutionStreamEvent](retention.maxRetainedExecutionEvents),
+		Done:      make(chan struct{}),
 	}
 
 	svc.mu.Lock()
@@ -2333,11 +2333,11 @@ func TestBufferedResultDeltaModes(t *testing.T) {
 func TestMergeBufferedResultOutputReplacesMissingStreamPrefix(t *testing.T) {
 	svc := newTestService(&stubAdapter{})
 	ex := &executionState{
-		ID:               "exec-1",
-		SandboxID:        "sb-1",
-		Stdout:           "tail",
-		Status:           cleanroomv1.ExecutionStatus_EXECUTION_STATUS_RUNNING,
-		events:           newEventFeed[*cleanroomv1.ExecutionStreamEvent](defaultRetentionPolicy.maxRetainedExecutionEvents),
+		ID:        "exec-1",
+		SandboxID: "sb-1",
+		Stdout:    "tail",
+		Status:    cleanroomv1.ExecutionStatus_EXECUTION_STATUS_RUNNING,
+		events:    newEventFeed[*cleanroomv1.ExecutionStreamEvent](defaultRetentionPolicy.maxRetainedExecutionEvents),
 	}
 
 	svc.mergeBufferedResultOutputLocked(ex, &backend.RunResult{

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -229,6 +229,11 @@ func newTestServiceWithSnapshotStore(adapter backend.Adapter, store snapshotMeta
 	}
 }
 
+func testRetentionPolicy() *retentionPolicy {
+	retention := defaultRetentionPolicy
+	return &retention
+}
+
 func testRepositoryCheckoutProto() *cleanroomv1.RepositoryCheckout {
 	return &cleanroomv1.RepositoryCheckout{
 		RemoteUrl:      "https://github.com/buildkite/cleanroom.git",
@@ -2230,7 +2235,7 @@ func TestRunExecutionSkipsAlreadyFinalExecution(t *testing.T) {
 		Status:           cleanroomv1.ExecutionStatus_EXECUTION_STATUS_CANCELED,
 		ExitCode:         143,
 		FinishedAt:       &finished,
-		EventSubscribers: map[int]chan *cleanroomv1.ExecutionStreamEvent{},
+		events:           newEventFeed[*cleanroomv1.ExecutionStreamEvent](defaultRetentionPolicy.maxRetainedExecutionEvents),
 		Done:             make(chan struct{}),
 	}
 	svc.recordExecutionEventLocked(ex, &cleanroomv1.ExecutionStreamEvent{
@@ -2245,7 +2250,7 @@ func TestRunExecutionSkipsAlreadyFinalExecution(t *testing.T) {
 	})
 	closeExecutionDoneLocked(ex)
 	svc.executions[key] = ex
-	initialEvents := len(ex.EventHistory)
+	initialEvents := len(ex.events.snapshot())
 	svc.mu.Unlock()
 
 	svc.runExecution(sandboxID, executionID)
@@ -2257,7 +2262,7 @@ func TestRunExecutionSkipsAlreadyFinalExecution(t *testing.T) {
 	if gotEx == nil {
 		t.Fatal("expected execution state to exist")
 	}
-	if got, want := len(gotEx.EventHistory), initialEvents; got != want {
+	if got, want := len(gotEx.events.snapshot()), initialEvents; got != want {
 		t.Fatalf("expected no additional events, got %d want %d", got, want)
 	}
 	if got, want := gotEx.Status, cleanroomv1.ExecutionStatus_EXECUTION_STATUS_CANCELED; got != want {
@@ -2269,13 +2274,10 @@ func TestRunExecutionSkipsAlreadyFinalExecution(t *testing.T) {
 }
 
 func TestFinalizeExecutionWithoutPruneSkipsImmediateStatePruning(t *testing.T) {
-	origLimit := maxRetainedFinishedExecutions
-	maxRetainedFinishedExecutions = 0
-	defer func() {
-		maxRetainedFinishedExecutions = origLimit
-	}()
-
 	svc := newTestService(&stubAdapter{})
+	retention := testRetentionPolicy()
+	retention.maxRetainedFinishedExecutions = 0
+	svc.runtime.retention = retention
 	createResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
 	if err != nil {
 		t.Fatalf("CreateSandbox returned error: %v", err)
@@ -2290,7 +2292,7 @@ func TestFinalizeExecutionWithoutPruneSkipsImmediateStatePruning(t *testing.T) {
 		SandboxID:        sandboxID,
 		Command:          []string{"echo", "ok"},
 		Status:           cleanroomv1.ExecutionStatus_EXECUTION_STATUS_QUEUED,
-		EventSubscribers: map[int]chan *cleanroomv1.ExecutionStreamEvent{},
+		events:           newEventFeed[*cleanroomv1.ExecutionStreamEvent](retention.maxRetainedExecutionEvents),
 		Done:             make(chan struct{}),
 	}
 
@@ -2335,7 +2337,7 @@ func TestMergeBufferedResultOutputReplacesMissingStreamPrefix(t *testing.T) {
 		SandboxID:        "sb-1",
 		Stdout:           "tail",
 		Status:           cleanroomv1.ExecutionStatus_EXECUTION_STATUS_RUNNING,
-		EventSubscribers: map[int]chan *cleanroomv1.ExecutionStreamEvent{},
+		events:           newEventFeed[*cleanroomv1.ExecutionStreamEvent](defaultRetentionPolicy.maxRetainedExecutionEvents),
 	}
 
 	svc.mergeBufferedResultOutputLocked(ex, &backend.RunResult{
@@ -2345,10 +2347,11 @@ func TestMergeBufferedResultOutputReplacesMissingStreamPrefix(t *testing.T) {
 	if got, want := ex.Stdout, "head-tail"; got != want {
 		t.Fatalf("expected buffered replacement to preserve missing prefix: got %q want %q", got, want)
 	}
-	if got, want := len(ex.EventHistory), 1; got != want {
+	history := ex.events.snapshot()
+	if got, want := len(history), 1; got != want {
 		t.Fatalf("expected single buffered stdout event, got %d want %d", got, want)
 	}
-	if got, want := string(ex.EventHistory[0].GetStdout()), "head-tail"; got != want {
+	if got, want := string(history[0].GetStdout()), "head-tail"; got != want {
 		t.Fatalf("unexpected buffered stdout event payload: got %q want %q", got, want)
 	}
 }
@@ -2366,19 +2369,12 @@ func TestAppendRetainedOutputClonesTailSlice(t *testing.T) {
 }
 
 func TestStatePruningBoundsRetainedTerminalState(t *testing.T) {
-	origSandboxes := maxRetainedStoppedSandboxes
-	origExecutions := maxRetainedFinishedExecutions
-	origAge := retainedStateMaxAge
-	maxRetainedStoppedSandboxes = 1
-	maxRetainedFinishedExecutions = 2
-	retainedStateMaxAge = 24 * time.Hour
-	defer func() {
-		maxRetainedStoppedSandboxes = origSandboxes
-		maxRetainedFinishedExecutions = origExecutions
-		retainedStateMaxAge = origAge
-	}()
-
 	svc := newTestService(&stubAdapter{})
+	retention := testRetentionPolicy()
+	retention.maxRetainedStoppedSandboxes = 1
+	retention.maxRetainedFinishedExecutions = 2
+	retention.retainedStateMaxAge = 24 * time.Hour
+	svc.runtime.retention = retention
 
 	runOnce := func() (string, string) {
 		createSandboxResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
@@ -2442,12 +2438,6 @@ func TestStatePruningBoundsRetainedTerminalState(t *testing.T) {
 }
 
 func TestExecutionRetentionBoundsOutput(t *testing.T) {
-	origOutputLimit := maxRetainedExecutionOutputBytes
-	maxRetainedExecutionOutputBytes = 8
-	defer func() {
-		maxRetainedExecutionOutputBytes = origOutputLimit
-	}()
-
 	adapter := &stubAdapter{
 		runStreamFn: func(_ context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
 			for _, chunk := range []string{"1234", "5678", "90"} {
@@ -2473,6 +2463,9 @@ func TestExecutionRetentionBoundsOutput(t *testing.T) {
 		},
 	}
 	svc := newTestService(adapter)
+	retention := testRetentionPolicy()
+	retention.maxRetainedExecutionOutputBytes = 8
+	svc.runtime.retention = retention
 
 	createSandboxResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
 	if err != nil {
@@ -2506,12 +2499,6 @@ func TestExecutionRetentionBoundsOutput(t *testing.T) {
 }
 
 func TestExecutionRetentionBoundsEventHistory(t *testing.T) {
-	origEventLimit := maxRetainedExecutionEvents
-	maxRetainedExecutionEvents = 3
-	defer func() {
-		maxRetainedExecutionEvents = origEventLimit
-	}()
-
 	adapter := &stubAdapter{
 		runStreamFn: func(_ context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
 			for _, chunk := range []string{"1", "2", "3", "4"} {
@@ -2531,6 +2518,9 @@ func TestExecutionRetentionBoundsEventHistory(t *testing.T) {
 		},
 	}
 	svc := newTestService(adapter)
+	retention := testRetentionPolicy()
+	retention.maxRetainedExecutionEvents = 3
+	svc.runtime.retention = retention
 
 	createSandboxResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
 	if err != nil {
@@ -2557,7 +2547,7 @@ func TestExecutionRetentionBoundsEventHistory(t *testing.T) {
 		svc.mu.RUnlock()
 		t.Fatal("expected execution state to exist")
 	}
-	history := append([]*cleanroomv1.ExecutionStreamEvent(nil), ex.EventHistory...)
+	history := ex.events.snapshot()
 	svc.mu.RUnlock()
 
 	if got, want := len(history), 3; got != want {
@@ -2575,13 +2565,10 @@ func TestExecutionRetentionBoundsEventHistory(t *testing.T) {
 }
 
 func TestSandboxRetentionBoundsEventHistory(t *testing.T) {
-	origEventLimit := maxRetainedSandboxEvents
-	maxRetainedSandboxEvents = 2
-	defer func() {
-		maxRetainedSandboxEvents = origEventLimit
-	}()
-
 	svc := newTestService(&stubAdapter{})
+	retention := testRetentionPolicy()
+	retention.maxRetainedSandboxEvents = 2
+	svc.runtime.retention = retention
 
 	createResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
 	if err != nil {

--- a/internal/controlservice/state_helpers.go
+++ b/internal/controlservice/state_helpers.go
@@ -1,0 +1,243 @@
+package controlservice
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func executionRunErrorStatus(ex *executionState, runCtx context.Context) (cleanroomv1.ExecutionStatus, int32) {
+	if ex == nil {
+		return cleanroomv1.ExecutionStatus_EXECUTION_STATUS_FAILED, 1
+	}
+	if ex.CancelRequested || errors.Is(runCtx.Err(), context.Canceled) {
+		return cleanroomv1.ExecutionStatus_EXECUTION_STATUS_CANCELED, cancelExitCode(ex.CancelSignal)
+	}
+	if errors.Is(runCtx.Err(), context.DeadlineExceeded) {
+		return cleanroomv1.ExecutionStatus_EXECUTION_STATUS_TIMED_OUT, 124
+	}
+	return cleanroomv1.ExecutionStatus_EXECUTION_STATUS_FAILED, 1
+}
+
+func closeSandboxDoneLocked(sb *sandboxState) {
+	if sb.DoneClosed {
+		return
+	}
+	close(sb.Done)
+	sb.DoneClosed = true
+}
+
+func closeExecutionDoneLocked(ex *executionState) {
+	if ex.DoneClosed {
+		return
+	}
+	close(ex.Done)
+	ex.DoneClosed = true
+}
+
+func clearExecutionAttachIOLocked(ex *executionState) {
+	if ex == nil {
+		return
+	}
+	ex.AttachStdin = nil
+	ex.AttachResize = nil
+}
+
+func closeSandboxSubscribersLocked(sb *sandboxState) {
+	for id, ch := range sb.EventSubscribers {
+		close(ch)
+		delete(sb.EventSubscribers, id)
+	}
+}
+
+func closeExecutionSubscribersLocked(ex *executionState) {
+	for id, ch := range ex.EventSubscribers {
+		close(ch)
+		delete(ex.EventSubscribers, id)
+	}
+}
+
+func executionTerminalTime(ex *executionState) time.Time {
+	if ex == nil {
+		return time.Time{}
+	}
+	if ex.FinishedAt != nil {
+		return *ex.FinishedAt
+	}
+	if ex.StartedAt != nil {
+		return *ex.StartedAt
+	}
+	return time.Time{}
+}
+
+func sandboxTerminalTime(sb *sandboxState) time.Time {
+	if sb == nil {
+		return time.Time{}
+	}
+	if !sb.UpdatedAt.IsZero() {
+		return sb.UpdatedAt
+	}
+	return sb.CreatedAt
+}
+
+func isFinalExecutionStatus(status cleanroomv1.ExecutionStatus) bool {
+	switch status {
+	case cleanroomv1.ExecutionStatus_EXECUTION_STATUS_SUCCEEDED,
+		cleanroomv1.ExecutionStatus_EXECUTION_STATUS_FAILED,
+		cleanroomv1.ExecutionStatus_EXECUTION_STATUS_CANCELED,
+		cleanroomv1.ExecutionStatus_EXECUTION_STATUS_TIMED_OUT:
+		return true
+	default:
+		return false
+	}
+}
+
+func cancelExitCode(signal int32) int32 {
+	if signal <= 0 || signal > 127 {
+		return 130
+	}
+	return 128 + signal
+}
+
+func executionKey(sandboxID, executionID string) string {
+	return sandboxID + "/" + executionID
+}
+
+func cloneSandboxLocked(state *sandboxState) *cleanroomv1.Sandbox {
+	if state == nil {
+		return nil
+	}
+	policyHash := ""
+	if state.Policy != nil {
+		policyHash = state.Policy.Hash
+	}
+	return &cleanroomv1.Sandbox{
+		SandboxId:  state.ID,
+		Status:     state.Status,
+		Backend:    state.Backend,
+		PolicyHash: policyHash,
+		CreatedAt:  timestamppb.New(state.CreatedAt),
+		UpdatedAt:  timestamppb.New(state.UpdatedAt),
+	}
+}
+
+func cloneExecutionLocked(state *executionState) *cleanroomv1.Execution {
+	if state == nil {
+		return nil
+	}
+	out := &cleanroomv1.Execution{
+		ExecutionId: state.ID,
+		SandboxId:   state.SandboxID,
+		Status:      state.Status,
+		Command:     append([]string(nil), state.Command...),
+		ExitCode:    state.ExitCode,
+		Tty:         state.TTY,
+		RunId:       state.RunID,
+		Kind:        state.Kind,
+	}
+	if state.StartedAt != nil {
+		out.StartedAt = timestamppb.New(*state.StartedAt)
+	}
+	if state.FinishedAt != nil {
+		out.FinishedAt = timestamppb.New(*state.FinishedAt)
+	}
+	return out
+}
+
+func resolveExecutionKind(kind cleanroomv1.ExecutionKind, tty bool) (cleanroomv1.ExecutionKind, error) {
+	if kind == cleanroomv1.ExecutionKind_EXECUTION_KIND_UNSPECIFIED {
+		if tty {
+			return cleanroomv1.ExecutionKind_EXECUTION_KIND_INTERACTIVE, nil
+		}
+		return cleanroomv1.ExecutionKind_EXECUTION_KIND_BATCH, nil
+	}
+	switch kind {
+	case cleanroomv1.ExecutionKind_EXECUTION_KIND_BATCH:
+		return kind, nil
+	case cleanroomv1.ExecutionKind_EXECUTION_KIND_INTERACTIVE:
+		return kind, nil
+	default:
+		return cleanroomv1.ExecutionKind_EXECUTION_KIND_UNSPECIFIED, fmt.Errorf("unsupported execution kind %q", kind.String())
+	}
+}
+
+func newSessionToken() (string, error) {
+	buf := make([]byte, 24)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}
+
+func normalizeCommand(command []string) []string {
+	if len(command) > 0 && command[0] == "--" {
+		return command[1:]
+	}
+	return command
+}
+
+func bufferedResultDelta(retained, buffered string, retentionLimit int) (string, bool) {
+	if buffered == "" {
+		return "", false
+	}
+	if retained == "" {
+		return buffered, false
+	}
+	if strings.HasSuffix(buffered, retained) {
+		// If retention is saturated, treat suffix-only overlap as a truncation artifact
+		// and avoid replaying duplicate tail bytes from the buffered result.
+		if retentionLimit > 0 && len(retained) >= retentionLimit {
+			return "", false
+		}
+		if strings.HasPrefix(buffered, retained) {
+			return buffered[len(retained):], false
+		}
+		// Stream callbacks likely missed earlier bytes; replace retained output with
+		// the complete buffered output so snapshots/history stay correct.
+		return buffered, true
+	}
+	if strings.HasPrefix(buffered, retained) {
+		return buffered[len(retained):], false
+	}
+	return buffered, true
+}
+
+func appendRetainedOutput(existing, chunk string, limit int) string {
+	if limit <= 0 {
+		return ""
+	}
+	if chunk == "" {
+		if len(existing) <= limit {
+			return existing
+		}
+		return strings.Clone(existing[len(existing)-limit:])
+	}
+	if len(chunk) >= limit {
+		return strings.Clone(chunk[len(chunk)-limit:])
+	}
+	keepExisting := limit - len(chunk)
+	if keepExisting < len(existing) {
+		existing = strings.Clone(existing[len(existing)-keepExisting:])
+	}
+	return existing + chunk
+}
+
+func appendBounded[T any](history []T, item T, limit int) []T {
+	if limit <= 0 {
+		return nil
+	}
+	history = append(history, item)
+	if len(history) <= limit {
+		return history
+	}
+	trimmed := make([]T, limit)
+	copy(trimmed, history[len(history)-limit:])
+	return trimmed
+}

--- a/internal/controlservice/state_helpers.go
+++ b/internal/controlservice/state_helpers.go
@@ -51,17 +51,11 @@ func clearExecutionAttachIOLocked(ex *executionState) {
 }
 
 func closeSandboxSubscribersLocked(sb *sandboxState) {
-	for id, ch := range sb.EventSubscribers {
-		close(ch)
-		delete(sb.EventSubscribers, id)
-	}
+	sb.events.closeSubscribers()
 }
 
 func closeExecutionSubscribersLocked(ex *executionState) {
-	for id, ch := range ex.EventSubscribers {
-		close(ch)
-		delete(ex.EventSubscribers, id)
-	}
+	ex.events.closeSubscribers()
 }
 
 func executionTerminalTime(ex *executionState) time.Time {


### PR DESCRIPTION
## Summary
- keep `Service` as the controlservice facade while extracting concrete collaborators for runtime configuration, interactive session management, and bounded event feeds
- move retention, timeout, clock, and ID generation behind per-service runtime dependencies so tests no longer rely on package-global mutation
- preserve the snapshot-backed sandbox and snapshot lifecycle behavior from `origin/main` while integrating it with the rebased controlservice refactor

## Testing
- `mise x go@1.23.1 -- go test ./internal/controlservice -count=1`
- `mise x go@1.23.1 -- go test ./... -count=1`
