### PR TITLE
fix: unify cli terminal styling

### DIFF
--- a/client/ergonomics.go
+++ b/client/ergonomics.go
@@ -414,6 +414,12 @@ func (c *Client) ExecAndWait(ctx context.Context, sandboxID string, command []st
 				_, _ = opts.Stderr.Write(chunk)
 			}
 		}
+		if warning := execWarningLine(event.GetWarning()); warning != "" {
+			_, _ = stderrBuf.WriteString(warning)
+			if opts.Stderr != nil {
+				_, _ = io.WriteString(opts.Stderr, warning)
+			}
+		}
 		if exit := event.GetExit(); exit != nil {
 			exitCode = exit.GetExitCode()
 			if exit.GetStatus() != ExecutionStatus_EXECUTION_STATUS_UNSPECIFIED {
@@ -451,6 +457,14 @@ func (c *Client) ExecAndWait(ctx context.Context, sandboxID string, command []st
 		Stdout:      stdoutBuf.String(),
 		Stderr:      stderrBuf.String(),
 	}, nil
+}
+
+func execWarningLine(message string) string {
+	message = strings.TrimSpace(message)
+	if message == "" {
+		return ""
+	}
+	return "warning: " + message + "\n"
 }
 
 func (c *Client) cancelExecutionBestEffort(sandboxID, executionID string) {

--- a/client/ergonomics_test.go
+++ b/client/ergonomics_test.go
@@ -83,6 +83,26 @@ func (a *immediateStreamingAdapter) RunStream(context.Context, backend.RunReques
 	}, nil
 }
 
+type warningStreamingAdapter struct {
+	integrationAdapter
+	warning string
+}
+
+func (a *warningStreamingAdapter) RunStream(_ context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+	if stream.OnWarning != nil {
+		stream.OnWarning(a.warning)
+	}
+	if stream.OnStdout != nil {
+		stream.OnStdout([]byte("hello from cleanroom\n"))
+	}
+	return &backend.RunResult{
+		RunID:    req.RunID,
+		ExitCode: 0,
+		Stdout:   "hello from cleanroom\n",
+		Message:  "done",
+	}, nil
+}
+
 type integrationExecutionHooks struct {
 	beforeStreamExecution func(context.Context, *StreamExecutionRequest) error
 	overrideStream        func(context.Context, *connect.Request[StreamExecutionRequest], *connect.ServerStream[ExecutionStreamEvent]) error
@@ -581,6 +601,44 @@ func TestExecAndWait(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "hello from cleanroom") {
 		t.Fatalf("expected stdout writer to receive output, got %q", stdout.String())
+	}
+}
+
+func TestExecAndWaitIncludesStructuredWarningsInStderr(t *testing.T) {
+	const warningText = "darwin-vz guest networking is enabled without host-side egress filtering"
+
+	host := startIntegrationServerWithAdapter(t, &warningStreamingAdapter{warning: warningText})
+	c, err := New(host)
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	sb, err := c.EnsureSandbox(ctx, "thread:exec-warning", EnsureSandboxOptions{
+		Backend: "firecracker",
+		Policy:  testPolicy(),
+	})
+	if err != nil {
+		t.Fatalf("EnsureSandbox returned error: %v", err)
+	}
+
+	var stderr bytes.Buffer
+	result, err := c.ExecAndWait(ctx, sb.ID, []string{"echo", "hello"}, ExecOptions{Stderr: &stderr})
+	if err != nil {
+		t.Fatalf("ExecAndWait returned error: %v", err)
+	}
+
+	wantWarning := "warning: " + warningText + "\n"
+	if got := result.Stderr; !strings.Contains(got, wantWarning) {
+		t.Fatalf("expected warning in result stderr, got %q want substring %q", got, wantWarning)
+	}
+	if got := stderr.String(); !strings.Contains(got, wantWarning) {
+		t.Fatalf("expected warning in stderr writer, got %q want substring %q", got, wantWarning)
+	}
+	if strings.Contains(result.Stdout, warningText) {
+		t.Fatalf("expected warning to stay out of stdout, got %q", result.Stdout)
 	}
 }
 

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -156,9 +156,10 @@ type AttachIO struct {
 }
 
 type OutputStream struct {
-	OnStdout func([]byte)
-	OnStderr func([]byte)
-	OnAttach func(AttachIO)
+	OnStdout  func([]byte)
+	OnStderr  func([]byte)
+	OnWarning func(string)
+	OnAttach  func(AttachIO)
 }
 
 // StreamingAdapter can push stdout/stderr chunks while a command is running.

--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -661,11 +661,7 @@ func (a *Adapter) run(ctx context.Context, req backend.RunRequest, stream backen
 
 	stderrPrefix := ""
 	for _, warningText := range warnings {
-		warningLine := "warning: " + warningText + "\n"
-		stderrPrefix += warningLine
-		if stream.OnStderr != nil {
-			stream.OnStderr([]byte(warningLine))
-		}
+		stderrPrefix += emitExecutionWarning(stream, warningText)
 	}
 
 	resolvedImageRef := req.Policy.ImageRef
@@ -1154,11 +1150,7 @@ func (a *Adapter) executeInSandbox(bootCtx context.Context, runCtx context.Conte
 	warnings := buildRuntimeWarnings(policyWarn)
 	stderrPrefix := ""
 	for _, warningText := range warnings {
-		warningLine := "warning: " + warningText + "\n"
-		stderrPrefix += warningLine
-		if stream.OnStderr != nil {
-			stream.OnStderr([]byte(warningLine))
-		}
+		stderrPrefix += emitExecutionWarning(stream, warningText)
 	}
 
 	helper := instance.Helper
@@ -1432,6 +1424,22 @@ func buildRuntimeWarnings(policyWarning string) []string {
 	}
 	warnings = append(warnings, guestNetworkUnavailableWarning)
 	return warnings
+}
+
+func emitExecutionWarning(stream backend.OutputStream, warningText string) string {
+	warningText = strings.TrimSpace(warningText)
+	if warningText == "" {
+		return ""
+	}
+	if stream.OnWarning != nil {
+		stream.OnWarning(warningText)
+		return ""
+	}
+	warningLine := "warning: " + warningText + "\n"
+	if stream.OnStderr != nil {
+		stream.OnStderr([]byte(warningLine))
+	}
+	return warningLine
 }
 
 type imageArtifact struct {

--- a/internal/cli/daemon_launchd.go
+++ b/internal/cli/daemon_launchd.go
@@ -49,7 +49,18 @@ func uninstallLaunchdDaemonInDomain(stdout io.Writer, servicePath, domain string
 	if !serviceFileExists && !bootoutFoundService {
 		message = "daemon already uninstalled"
 	}
-	_, err := fmt.Fprintf(stdout, "%s\nmanager=launchd\nservice=%s\n", message, launchdServiceName)
+	titleStyle := defaultTerminalPalette().info
+	if strings.Contains(message, "already") {
+		titleStyle = defaultTerminalPalette().warn
+	}
+	_, err := fmt.Fprint(stdout, renderSummaryBlock(summaryBlock{
+		Title:      message,
+		TitleStyle: titleStyle,
+		Fields: []startupField{
+			{Key: "manager", Value: "launchd"},
+			{Key: "service", Value: launchdServiceName},
+		},
+	}, shouldUseANSI(stdout)))
 	return err
 }
 
@@ -89,7 +100,14 @@ func startLaunchdDaemonInDomain(stdout io.Writer, servicePath, domain string) er
 		return fmt.Errorf("start launchd service %s: %w", launchdServiceName, err)
 	}
 
-	_, err = fmt.Fprintf(stdout, "daemon started\nmanager=launchd\nservice=%s\n", launchdServiceName)
+	_, err = fmt.Fprint(stdout, renderSummaryBlock(summaryBlock{
+		Title:      "daemon started",
+		TitleStyle: defaultTerminalPalette().info,
+		Fields: []startupField{
+			{Key: "manager", Value: "launchd"},
+			{Key: "service", Value: launchdServiceName},
+		},
+	}, shouldUseANSI(stdout)))
 	return err
 }
 
@@ -123,7 +141,14 @@ func stopLaunchdDaemonInDomain(stdout io.Writer, servicePath, domain string) err
 		return err
 	}
 	if !serviceFileExists && !loaded {
-		_, err := fmt.Fprintf(stdout, "daemon already stopped\nmanager=launchd\nservice=%s\n", launchdServiceName)
+		_, err := fmt.Fprint(stdout, renderSummaryBlock(summaryBlock{
+			Title:      "daemon already stopped",
+			TitleStyle: defaultTerminalPalette().warn,
+			Fields: []startupField{
+				{Key: "manager", Value: "launchd"},
+				{Key: "service", Value: launchdServiceName},
+			},
+		}, shouldUseANSI(stdout)))
 		return err
 	}
 
@@ -136,7 +161,14 @@ func stopLaunchdDaemonInDomain(stdout io.Writer, servicePath, domain string) err
 		}
 	}
 
-	_, err = fmt.Fprintf(stdout, "daemon stopped\nmanager=launchd\nservice=%s\n", launchdServiceName)
+	_, err = fmt.Fprint(stdout, renderSummaryBlock(summaryBlock{
+		Title:      "daemon stopped",
+		TitleStyle: defaultTerminalPalette().info,
+		Fields: []startupField{
+			{Key: "manager", Value: "launchd"},
+			{Key: "service", Value: launchdServiceName},
+		},
+	}, shouldUseANSI(stdout)))
 	return err
 }
 
@@ -361,7 +393,15 @@ func installLaunchdDaemonInDomain(stdout io.Writer, executablePath string, args 
 		return fmt.Errorf("enable launchd service %s: %w", launchdServiceName, err)
 	}
 
-	_, err := fmt.Fprintf(stdout, "daemon installed\nmanager=launchd\nservice=%s\npath=%s\n", launchdServiceName, servicePath)
+	_, err := fmt.Fprint(stdout, renderSummaryBlock(summaryBlock{
+		Title:      "daemon installed",
+		TitleStyle: defaultTerminalPalette().info,
+		Fields: []startupField{
+			{Key: "manager", Value: "launchd"},
+			{Key: "service", Value: launchdServiceName},
+			{Key: "path", Value: servicePath},
+		},
+	}, shouldUseANSI(stdout)))
 	return err
 }
 

--- a/internal/cli/daemon_systemd.go
+++ b/internal/cli/daemon_systemd.go
@@ -28,7 +28,14 @@ func uninstallSystemdDaemon(stdout io.Writer) error {
 		return fmt.Errorf("reload systemd: %w", err)
 	}
 
-	_, err := fmt.Fprintf(stdout, "daemon uninstalled\nmanager=systemd\nservice=%s\n", systemdServiceName)
+	_, err := fmt.Fprint(stdout, renderSummaryBlock(summaryBlock{
+		Title:      "daemon uninstalled",
+		TitleStyle: defaultTerminalPalette().info,
+		Fields: []startupField{
+			{Key: "manager", Value: "systemd"},
+			{Key: "service", Value: systemdServiceName},
+		},
+	}, shouldUseANSI(stdout)))
 	return err
 }
 
@@ -41,7 +48,14 @@ func startSystemdDaemon(stdout io.Writer) error {
 		return fmt.Errorf("start systemd service %s: %w", systemdServiceName, err)
 	}
 
-	_, err := fmt.Fprintf(stdout, "daemon started\nmanager=systemd\nservice=%s\n", systemdServiceName)
+	_, err := fmt.Fprint(stdout, renderSummaryBlock(summaryBlock{
+		Title:      "daemon started",
+		TitleStyle: defaultTerminalPalette().info,
+		Fields: []startupField{
+			{Key: "manager", Value: "systemd"},
+			{Key: "service", Value: systemdServiceName},
+		},
+	}, shouldUseANSI(stdout)))
 	return err
 }
 
@@ -54,7 +68,14 @@ func stopSystemdDaemon(stdout io.Writer) error {
 		return fmt.Errorf("stop systemd service %s: %w", systemdServiceName, err)
 	}
 
-	_, err := fmt.Fprintf(stdout, "daemon stopped\nmanager=systemd\nservice=%s\n", systemdServiceName)
+	_, err := fmt.Fprint(stdout, renderSummaryBlock(summaryBlock{
+		Title:      "daemon stopped",
+		TitleStyle: defaultTerminalPalette().info,
+		Fields: []startupField{
+			{Key: "manager", Value: "systemd"},
+			{Key: "service", Value: systemdServiceName},
+		},
+	}, shouldUseANSI(stdout)))
 	return err
 }
 
@@ -111,7 +132,15 @@ func installSystemdDaemon(stdout io.Writer, executablePath string, args []string
 		}
 	}
 
-	_, err := fmt.Fprintf(stdout, "daemon installed\nmanager=systemd\nservice=%s\npath=%s\n", systemdServiceName, serveInstallSystemdUnitPath)
+	_, err := fmt.Fprint(stdout, renderSummaryBlock(summaryBlock{
+		Title:      "daemon installed",
+		TitleStyle: defaultTerminalPalette().info,
+		Fields: []startupField{
+			{Key: "manager", Value: "systemd"},
+			{Key: "service", Value: systemdServiceName},
+			{Key: "path", Value: serveInstallSystemdUnitPath},
+		},
+	}, shouldUseANSI(stdout)))
 	return err
 }
 

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -160,6 +160,10 @@ func (e *ExecCommand) Run(ctx *runtimeContext) error {
 			if _, err := fmt.Fprint(os.Stderr, string(payload.Stderr)); err != nil {
 				return err
 			}
+		case *cleanroomv1.ExecutionStreamEvent_Warning:
+			if err := writeExecutionWarning(os.Stderr, payload.Warning); err != nil {
+				return err
+			}
 		case *cleanroomv1.ExecutionStreamEvent_Exit:
 			exitCode = int(payload.Exit.GetExitCode())
 			haveExitCode = true

--- a/internal/cli/exec_integration_test.go
+++ b/internal/cli/exec_integration_test.go
@@ -534,6 +534,59 @@ func TestExecIntegrationPropagatesExitAndStderr(t *testing.T) {
 	}
 }
 
+func TestExecIntegrationRendersStructuredWarnings(t *testing.T) {
+	t.Setenv("CLICOLOR_FORCE", "1")
+
+	const warningText = "darwin-vz guest networking is enabled without host-side egress filtering"
+
+	adapter := &integrationAdapter{
+		runStreamFn: func(_ context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+			if stream.OnWarning != nil {
+				stream.OnWarning(warningText)
+			}
+			if stream.OnStdout != nil {
+				stream.OnStdout([]byte("hello world\n"))
+			}
+			return &backend.RunResult{
+				RunID:    req.RunID,
+				ExitCode: 0,
+				Stdout:   "hello world\n",
+				Message:  "ok",
+			}, nil
+		},
+	}
+
+	host, _ := startIntegrationServer(t, adapter)
+	cwd := t.TempDir()
+	outcome := runExecWithCapture(ExecCommand{
+		clientFlags: clientFlags{Host: host},
+		Chdir:       cwd,
+		Command:     []string{"echo", "ignored-by-adapter"},
+	}, runtimeContext{
+		CWD:    cwd,
+		Loader: integrationLoader{},
+	})
+
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err != nil {
+		t.Fatalf("ExecCommand.Run returned error: %v", outcome.err)
+	}
+	if !strings.Contains(stripANSI(outcome.stderr), "warning: "+warningText) {
+		t.Fatalf("expected structured warning in stderr, got %q", stripANSI(outcome.stderr))
+	}
+	if !strings.Contains(outcome.stderr, "\x1b[") {
+		t.Fatalf("expected ANSI styling in warning output, got %q", outcome.stderr)
+	}
+	if !strings.Contains(outcome.stdout, "hello world\n") {
+		t.Fatalf("expected stdout output, got %q", outcome.stdout)
+	}
+	if strings.Contains(outcome.stdout, warningText) {
+		t.Fatalf("expected warning to stay out of stdout, got %q", outcome.stdout)
+	}
+}
+
 func TestExecIntegrationFirstInterruptCancelsExecution(t *testing.T) {
 	started := make(chan struct{}, 1)
 	adapter := &integrationAdapter{

--- a/internal/cli/execution_shared.go
+++ b/internal/cli/execution_shared.go
@@ -91,6 +91,16 @@ func getFinalExecutionExitCode(client *controlclient.Client, sandboxID, executio
 	return int(execution.GetExitCode()), true
 }
 
+func writeExecutionWarning(stderr io.Writer, message string) error {
+	message = strings.TrimSpace(message)
+	if stderr == nil || message == "" {
+		return nil
+	}
+	palette := defaultTerminalPalette()
+	_, err := io.WriteString(stderr, renderNoticeLine("warning", message, palette.warn, shouldUseANSI(stderr)))
+	return err
+}
+
 func replayExecutionHistory(client *controlclient.Client, sandboxID, executionID string, stdout, stderr io.Writer) (int, bool, error) {
 	stream, err := client.StreamExecution(context.Background(), &cleanroomv1.StreamExecutionRequest{
 		SandboxId:   sandboxID,
@@ -112,6 +122,10 @@ func replayExecutionHistory(client *controlclient.Client, sandboxID, executionID
 			}
 		case *cleanroomv1.ExecutionStreamEvent_Stderr:
 			if _, err := stderr.Write(payload.Stderr); err != nil {
+				return 0, false, err
+			}
+		case *cleanroomv1.ExecutionStreamEvent_Warning:
+			if err := writeExecutionWarning(stderr, payload.Warning); err != nil {
 				return 0, false, err
 			}
 		case *cleanroomv1.ExecutionStreamEvent_Exit:

--- a/internal/cli/image.go
+++ b/internal/cli/image.go
@@ -62,15 +62,16 @@ func (c *ImagePullCommand) Run(ctx *runtimeContext) error {
 	if result.CacheHit {
 		status = "cached"
 	}
-	_, err = fmt.Fprintf(
-		ctx.Stdout,
-		"%s image\nref=%s\ndigest=%s\nrootfs=%s\nsize_bytes=%d\n",
-		status,
-		result.Record.Ref,
-		result.Record.Digest,
-		result.Record.RootFSPath,
-		result.Record.SizeBytes,
-	)
+	_, err = fmt.Fprint(ctx.Stdout, renderSummaryBlock(summaryBlock{
+		Title:      status + " image",
+		TitleStyle: defaultTerminalPalette().info,
+		Fields: []startupField{
+			{Key: "ref", Value: result.Record.Ref},
+			{Key: "digest", Value: result.Record.Digest},
+			{Key: "rootfs", Value: result.Record.RootFSPath},
+			{Key: "size_bytes", Value: fmt.Sprintf("%d", result.Record.SizeBytes)},
+		},
+	}, shouldUseANSI(ctx.Stdout)))
 	return err
 }
 
@@ -128,8 +129,10 @@ func (c *ImageRemoveCommand) Run(ctx *runtimeContext) error {
 		_, err := fmt.Fprintf(ctx.Stdout, "no cached images match %q\n", c.Selector)
 		return err
 	}
+	color := shouldUseANSI(ctx.Stdout)
 	for _, item := range removed {
-		if _, err := fmt.Fprintf(ctx.Stdout, "removed %s (%s)\n", item.Digest, item.Ref); err != nil {
+		line := renderActionLine("removed", fmt.Sprintf("%s (%s)", item.Digest, item.Ref), defaultTerminalPalette().info, color)
+		if _, err := fmt.Fprintln(ctx.Stdout, line); err != nil {
 			return err
 		}
 	}
@@ -145,13 +148,15 @@ func (c *ImageImportCommand) Run(ctx *runtimeContext) error {
 	if err != nil {
 		return err
 	}
-	_, err = fmt.Fprintf(
-		ctx.Stdout,
-		"imported image\nref=%s\ndigest=%s\nrootfs=%s\nsize_bytes=%d\n",
-		record.Ref,
-		record.Digest,
-		record.RootFSPath,
-		record.SizeBytes,
-	)
+	_, err = fmt.Fprint(ctx.Stdout, renderSummaryBlock(summaryBlock{
+		Title:      "imported image",
+		TitleStyle: defaultTerminalPalette().info,
+		Fields: []startupField{
+			{Key: "ref", Value: record.Ref},
+			{Key: "digest", Value: record.Digest},
+			{Key: "rootfs", Value: record.RootFSPath},
+			{Key: "size_bytes", Value: fmt.Sprintf("%d", record.SizeBytes)},
+		},
+	}, shouldUseANSI(ctx.Stdout)))
 	return err
 }

--- a/internal/cli/image_override.go
+++ b/internal/cli/image_override.go
@@ -250,12 +250,12 @@ func importLocalDockerImageForOverride(ctx context.Context, source string) (stri
 			continue
 		}
 		if _, statErr := os.Stat(record.RootFSPath); statErr == nil {
-			_, _ = fmt.Fprintf(os.Stderr, "using cached local image override %s\n", digestRef.Original)
+			_, _ = fmt.Fprintln(os.Stderr, renderActionLine("using", "cached local image override "+digestRef.Original, defaultTerminalPalette().info, shouldUseANSI(os.Stderr)))
 			return digestRef.Original, nil
 		}
 	}
 
-	_, _ = fmt.Fprintf(os.Stderr, "importing local docker image %q into cleanroom cache (first run can take a while)\n", source)
+	_, _ = fmt.Fprintln(os.Stderr, renderActionLine("importing", fmt.Sprintf("local docker image %q into cleanroom cache (first run can take a while)", source), defaultTerminalPalette().info, shouldUseANSI(os.Stderr)))
 
 	containerID, err := dockerCreateContainer(ctx, source)
 	if err != nil {
@@ -288,6 +288,6 @@ func importLocalDockerImageForOverride(ctx context.Context, source string) (stri
 		return "", fmt.Errorf("import local docker image %q into cleanroom cache: %w", source, err)
 	}
 
-	_, _ = fmt.Fprintf(os.Stderr, "imported local docker image override as %s\n", digestRef.Original)
+	_, _ = fmt.Fprintln(os.Stderr, renderActionLine("imported", "local docker image override as "+digestRef.Original, defaultTerminalPalette().info, shouldUseANSI(os.Stderr)))
 	return digestRef.Original, nil
 }

--- a/internal/cli/image_override_import_test.go
+++ b/internal/cli/image_override_import_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/buildkite/cleanroom/internal/imagemgr"
@@ -116,6 +117,73 @@ func TestImportLocalDockerImageForOverrideImportsContainerFS(t *testing.T) {
 		t.Fatalf("expected deferred docker rm for %q, got %q", containerID, got)
 	}
 	assertContainsAll(t, outcome.stderr,
+		"importing local docker image \""+source+"\" into cleanroom cache",
+		"imported local docker image override as "+wantRef,
+	)
+}
+
+func TestImportLocalDockerImageForOverrideUsesANSIWhenForced(t *testing.T) {
+	t.Setenv("CLICOLOR_FORCE", "1")
+
+	const (
+		source      = "alpine:dev"
+		imageID     = "sha256:8888888888888888888888888888888888888888888888888888888888888888"
+		containerID = "container-456"
+		wantRef     = "local/docker-image@" + imageID
+		exportedTar = "tar-stream"
+	)
+
+	mgr := &stubImageManager{
+		importRecord: imagemgr.Record{
+			Ref:        wantRef,
+			Digest:     imageID,
+			RootFSPath: "/cache/local.ext4",
+			SizeBytes:  int64(len(exportedTar)),
+		},
+	}
+	replaceImageManagerFactory(t, mgr, nil)
+
+	stubDockerImportHelpers(
+		t,
+		func(_ context.Context, gotSource string) (string, error) {
+			if gotSource != source {
+				t.Fatalf("unexpected source passed to inspect: got %q want %q", gotSource, source)
+			}
+			return imageID, nil
+		},
+		func(_ context.Context, gotSource string) (string, error) {
+			if gotSource != source {
+				t.Fatalf("unexpected source passed to create: got %q want %q", gotSource, source)
+			}
+			return containerID, nil
+		},
+		func(_ context.Context, gotContainerID, gotSource string, dst io.Writer) error {
+			if gotContainerID != containerID {
+				t.Fatalf("unexpected container passed to export: got %q want %q", gotContainerID, containerID)
+			}
+			if gotSource != source {
+				t.Fatalf("unexpected source passed to export: got %q want %q", gotSource, source)
+			}
+			_, err := io.WriteString(dst, exportedTar)
+			return err
+		},
+		func(string) error { return nil },
+	)
+
+	outcome := runWithCapture(func(*runtimeContext) error {
+		_, err := importLocalDockerImageForOverride(context.Background(), source)
+		return err
+	}, nil, runtimeContext{})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err != nil {
+		t.Fatalf("importLocalDockerImageForOverride returned error: %v", outcome.err)
+	}
+	if !strings.Contains(outcome.stderr, "\x1b[") {
+		t.Fatalf("expected ANSI escapes in color output: %q", outcome.stderr)
+	}
+	assertContainsAll(t, stripANSI(outcome.stderr),
 		"importing local docker image \""+source+"\" into cleanroom cache",
 		"imported local docker image override as "+wantRef,
 	)

--- a/internal/cli/image_policy_update.go
+++ b/internal/cli/image_policy_update.go
@@ -57,7 +57,15 @@ func (c *ImageBumpRefCommand) Run(ctx *runtimeContext) error {
 	if source == "" {
 		source = defaultBumpRefSource
 	}
-	_, err = fmt.Fprintf(ctx.Stdout, "updated sandbox.image.ref\npolicy=%s\nsource=%s\nref=%s\n", policyPath, source, resolvedRef)
+	_, err = fmt.Fprint(ctx.Stdout, renderSummaryBlock(summaryBlock{
+		Title:      "updated sandbox.image.ref",
+		TitleStyle: defaultTerminalPalette().info,
+		Fields: []startupField{
+			{Key: "policy", Value: policyPath},
+			{Key: "source", Value: source},
+			{Key: "ref", Value: resolvedRef},
+		},
+	}, shouldUseANSI(ctx.Stdout)))
 	return err
 }
 

--- a/internal/cli/image_test.go
+++ b/internal/cli/image_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -99,6 +100,41 @@ func TestImagePullCommandRunPrintsResult(t *testing.T) {
 		"digest="+mgr.pullResult.Record.Digest,
 		"rootfs="+mgr.pullResult.Record.RootFSPath,
 		"size_bytes=1234",
+	)
+}
+
+func TestImagePullCommandRunPrintsColorSummaryWhenForced(t *testing.T) {
+	t.Setenv("CLICOLOR_FORCE", "1")
+
+	mgr := &stubImageManager{
+		pullResult: imagemgr.EnsureResult{
+			Record: imagemgr.Record{
+				Ref:        "ghcr.io/buildkite/cleanroom-base/alpine@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				Digest:     "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				RootFSPath: "/tmp/rootfs.ext4",
+				SizeBytes:  1234,
+			},
+		},
+	}
+	replaceImageManagerFactory(t, mgr, nil)
+
+	stdout, readStdout := makeStdoutCapture(t)
+	t.Cleanup(func() { _ = stdout.Close() })
+
+	err := (&ImagePullCommand{Ref: mgr.pullResult.Record.Ref}).Run(&runtimeContext{Stdout: stdout})
+	if err != nil {
+		t.Fatalf("ImagePullCommand.Run returned error: %v", err)
+	}
+
+	output := readStdout()
+	plain := stripANSI(output)
+	if !strings.Contains(output, "\x1b[") {
+		t.Fatalf("expected ANSI escapes in color output: %q", output)
+	}
+	assertContainsAll(t, plain,
+		"pulled image",
+		"ref="+mgr.pullResult.Record.Ref,
+		"digest="+mgr.pullResult.Record.Digest,
 	)
 }
 

--- a/internal/cli/logging.go
+++ b/internal/cli/logging.go
@@ -17,6 +17,5 @@ func newLogger(rawLevel, component string) (*log.Logger, error) {
 		Level:     level,
 		Formatter: log.TextFormatter,
 	})
-	applyPolishedLoggerStyles(logger, shouldUseANSI(os.Stderr))
 	return logger.With("component", component), nil
 }

--- a/internal/cli/policy_config.go
+++ b/internal/cli/policy_config.go
@@ -50,7 +50,13 @@ func (c *PolicyValidateCommand) Run(ctx *runtimeContext) error {
 		return enc.Encode(payload)
 	}
 
-	_, err = fmt.Fprintf(ctx.Stdout, "policy valid: %s\npolicy hash: %s\n", source, compiled.Hash)
+	color := shouldUseANSI(ctx.Stdout)
+	var out strings.Builder
+	out.WriteString(renderStatusValueLine("policy valid", source, defaultTerminalPalette().info, color))
+	out.WriteByte('\n')
+	out.WriteString(renderKeyValueLine("", "policy hash", compiled.Hash, color, defaultTerminalPalette()))
+	out.WriteByte('\n')
+	_, err = fmt.Fprint(ctx.Stdout, out.String())
 	return err
 }
 
@@ -96,7 +102,7 @@ func (c *ConfigInitCommand) Run(ctx *runtimeContext) error {
 		return fmt.Errorf("write runtime config %s: %w", path, err)
 	}
 
-	_, err = fmt.Fprintf(ctx.Stdout, "runtime config written: %s\n", path)
+	_, err = fmt.Fprintln(ctx.Stdout, renderStatusValueLine("runtime config written", path, defaultTerminalPalette().info, shouldUseANSI(ctx.Stdout)))
 	return err
 }
 

--- a/internal/cli/policy_validate_test.go
+++ b/internal/cli/policy_validate_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"encoding/json"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/buildkite/cleanroom/internal/policy"
@@ -87,6 +88,37 @@ func TestPolicyValidateCommandRunText(t *testing.T) {
 
 	output := readStdout()
 	assertContainsAll(t, output,
+		"policy valid: "+loader.source,
+		"policy hash: "+loader.compiled.Hash,
+	)
+}
+
+func TestPolicyValidateCommandRunTextUsesANSIWhenForced(t *testing.T) {
+	t.Setenv("CLICOLOR_FORCE", "1")
+
+	loader := &policyValidateLoader{
+		compiled: &policy.CompiledPolicy{Hash: "policy-hash-text"},
+		source:   "/repo/cleanroom.yaml",
+	}
+
+	stdout, readStdout := makeStdoutCapture(t)
+	t.Cleanup(func() { _ = stdout.Close() })
+
+	err := (&PolicyValidateCommand{}).Run(&runtimeContext{
+		CWD:    t.TempDir(),
+		Stdout: stdout,
+		Loader: loader,
+	})
+	if err != nil {
+		t.Fatalf("PolicyValidateCommand.Run returned error: %v", err)
+	}
+
+	output := readStdout()
+	plain := stripANSI(output)
+	if !strings.Contains(output, "\x1b[") {
+		t.Fatalf("expected ANSI escapes in color output: %q", output)
+	}
+	assertContainsAll(t, plain,
 		"policy valid: "+loader.source,
 		"policy hash: "+loader.compiled.Hash,
 	)

--- a/internal/cli/repository.go
+++ b/internal/cli/repository.go
@@ -288,9 +288,13 @@ func warnDirtyRepositoryCheckout(repository *resolvedRepositoryCheckout) {
 	if repository == nil || !repository.Dirty {
 		return
 	}
-	_, _ = fmt.Fprintf(
+	_, _ = fmt.Fprint(
 		os.Stderr,
-		"warning: repository has local modifications; sandbox will use HEAD %s and ignore local changes\n",
-		repository.CommitSHA,
+		renderNoticeLine(
+			"warning",
+			fmt.Sprintf("repository has local modifications; sandbox will use HEAD %s and ignore local changes", repository.CommitSHA),
+			defaultTerminalPalette().warn,
+			shouldUseANSI(os.Stderr),
+		),
 	)
 }

--- a/internal/cli/repository_test.go
+++ b/internal/cli/repository_test.go
@@ -642,6 +642,54 @@ func TestCreateCommandWarnsWhenRepositoryIsDirty(t *testing.T) {
 	}
 }
 
+func TestCreateCommandWarnsWhenRepositoryIsDirtyUsesANSIWhenForced(t *testing.T) {
+	t.Setenv("CLICOLOR_FORCE", "1")
+
+	repoDir := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
+	if err := os.WriteFile(filepath.Join(repoDir, "dirty.txt"), []byte("dirty\n"), 0o644); err != nil {
+		t.Fatalf("write dirty file: %v", err)
+	}
+
+	adapter := &persistentIntegrationAdapter{}
+	host, _ := startIntegrationServer(t, adapter)
+	adapter.runStreamFn = func(_ context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+		return &backend.RunResult{RunID: req.RunID, ExitCode: 0, Message: "ok"}, nil
+	}
+
+	outcome := runCreateAliasWithCapture(CreateCommand{
+		clientFlags: clientFlags{Host: host},
+		Chdir:       repoDir,
+	}, runtimeContext{
+		CWD: repoDir,
+		Loader: repositoryIntegrationLoader{
+			compiled: &policy.CompiledPolicy{
+				Version:        1,
+				ImageRef:       "ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+				ImageDigest:    "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+				NetworkDefault: "deny",
+				Allow:          []policy.AllowRule{{Host: "github.com", Ports: []int{443}}},
+			},
+			repository: policy.RepositoryConfig{
+				Mode:   "current-repo",
+				Remote: "origin",
+				Path:   "/workspace",
+			},
+		},
+	})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err != nil {
+		t.Fatalf("CreateCommand.Run returned error: %v", outcome.err)
+	}
+	if !strings.Contains(outcome.stderr, "\x1b[") {
+		t.Fatalf("expected ANSI escapes in color output: %q", outcome.stderr)
+	}
+	if !strings.Contains(stripANSI(outcome.stderr), "repository has local modifications") {
+		t.Fatalf("expected dirty repository warning, got %q", outcome.stderr)
+	}
+}
+
 func TestCreateCommandRejectsRepositoryBootstrapForNonPersistentBackend(t *testing.T) {
 	repoDir := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
 	adapter := &integrationAdapter{}

--- a/internal/cli/test_helpers_test.go
+++ b/internal/cli/test_helpers_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -13,4 +14,9 @@ func assertContainsAll(t *testing.T, got string, want ...string) {
 			t.Fatalf("expected output to contain %q, got %q", expected, got)
 		}
 	}
+}
+
+func stripANSI(value string) string {
+	ansi := regexp.MustCompile(`\x1b\[[0-9;]*m`)
+	return ansi.ReplaceAllString(value, "")
 }

--- a/internal/cli/ui.go
+++ b/internal/cli/ui.go
@@ -32,7 +32,262 @@ type daemonStatusReport struct {
 	Fields    []startupField
 }
 
+type summaryBlock struct {
+	Title      string
+	TitleStyle terminalStyle
+	Fields     []startupField
+}
+
+type terminalStyle struct {
+	foregroundCode string
+	bold           bool
+	faint          bool
+}
+
+func (s terminalStyle) wrap(value string, enabled bool) string {
+	if !enabled || value == "" {
+		return value
+	}
+	code := s.ansiCode()
+	if code == "" {
+		return value
+	}
+	return ansiWrap(code, value)
+}
+
+func (s terminalStyle) ansiCode() string {
+	parts := make([]string, 0, 3)
+	if s.bold {
+		parts = append(parts, "1")
+	}
+	if s.faint {
+		parts = append(parts, "2")
+	}
+	if s.foregroundCode != "" {
+		parts = append(parts, s.foregroundCode)
+	}
+	return strings.Join(parts, ";")
+}
+
+func terminalStyleFromLipgloss(style lipgloss.Style) terminalStyle {
+	return terminalStyle{
+		foregroundCode: terminalForegroundCode(style.GetForeground()),
+		bold:           style.GetBold(),
+		faint:          style.GetFaint(),
+	}
+}
+
+type terminalPalette struct {
+	icon      terminalStyle
+	title     terminalStyle
+	text      terminalStyle
+	value     terminalStyle
+	muted     terminalStyle
+	separator terminalStyle
+	key       terminalStyle
+	debug     terminalStyle
+	info      terminalStyle
+	warn      terminalStyle
+	error     terminalStyle
+}
+
+func defaultTerminalPalette() terminalPalette {
+	styles := log.DefaultStyles()
+	return terminalPalette{
+		icon:      terminalStyleFromLipgloss(styles.Levels[log.InfoLevel]),
+		title:     terminalStyleFromLipgloss(styles.Levels[log.InfoLevel]),
+		text:      terminalStyleFromLipgloss(styles.Message),
+		value:     terminalStyleFromLipgloss(styles.Value),
+		muted:     terminalStyleFromLipgloss(styles.Separator),
+		separator: terminalStyleFromLipgloss(styles.Separator),
+		key:       terminalStyleFromLipgloss(styles.Key),
+		debug:     terminalStyleFromLipgloss(styles.Levels[log.DebugLevel]),
+		info:      terminalStyleFromLipgloss(styles.Levels[log.InfoLevel]),
+		warn:      terminalStyleFromLipgloss(styles.Levels[log.WarnLevel]),
+		error:     terminalStyleFromLipgloss(styles.Levels[log.ErrorLevel]),
+	}
+}
+
+func terminalForegroundCode(color lipgloss.TerminalColor) string {
+	switch c := color.(type) {
+	case lipgloss.NoColor:
+		return ""
+	case lipgloss.Color:
+		return terminalForegroundCodeFromString(string(c))
+	case lipgloss.ANSIColor:
+		return "38;5;" + strconv.FormatUint(uint64(c), 10)
+	case lipgloss.CompleteColor:
+		if code := terminalForegroundCodeFromString(c.ANSI256); code != "" {
+			return code
+		}
+		if code := terminalForegroundCodeFromString(c.TrueColor); code != "" {
+			return code
+		}
+		return terminalForegroundCodeFromString(c.ANSI)
+	case lipgloss.AdaptiveColor:
+		if code := terminalForegroundCodeFromString(c.Dark); code != "" {
+			return code
+		}
+		return terminalForegroundCodeFromString(c.Light)
+	case lipgloss.CompleteAdaptiveColor:
+		if code := terminalForegroundCode(lipgloss.CompleteColor(c.Dark)); code != "" {
+			return code
+		}
+		return terminalForegroundCode(lipgloss.CompleteColor(c.Light))
+	default:
+		return ""
+	}
+}
+
+func terminalForegroundCodeFromString(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	if strings.HasPrefix(value, "#") {
+		r, g, b, ok := parseHexColor(value)
+		if !ok {
+			return ""
+		}
+		return fmt.Sprintf("38;2;%d;%d;%d", r, g, b)
+	}
+	if _, err := strconv.Atoi(value); err == nil {
+		return "38;5;" + value
+	}
+	return ""
+}
+
+func parseHexColor(value string) (int, int, int, bool) {
+	trimmed := strings.TrimPrefix(value, "#")
+	switch len(trimmed) {
+	case 3:
+		r, err := strconv.ParseUint(strings.Repeat(string(trimmed[0]), 2), 16, 8)
+		if err != nil {
+			return 0, 0, 0, false
+		}
+		g, err := strconv.ParseUint(strings.Repeat(string(trimmed[1]), 2), 16, 8)
+		if err != nil {
+			return 0, 0, 0, false
+		}
+		b, err := strconv.ParseUint(strings.Repeat(string(trimmed[2]), 2), 16, 8)
+		if err != nil {
+			return 0, 0, 0, false
+		}
+		return int(r), int(g), int(b), true
+	case 6:
+		r, err := strconv.ParseUint(trimmed[0:2], 16, 8)
+		if err != nil {
+			return 0, 0, 0, false
+		}
+		g, err := strconv.ParseUint(trimmed[2:4], 16, 8)
+		if err != nil {
+			return 0, 0, 0, false
+		}
+		b, err := strconv.ParseUint(trimmed[4:6], 16, 8)
+		if err != nil {
+			return 0, 0, 0, false
+		}
+		return int(r), int(g), int(b), true
+	default:
+		return 0, 0, 0, false
+	}
+}
+
+func renderStyledFieldLine(
+	indent, key, separator, value string,
+	pad bool,
+	color bool,
+	keyStyle, separatorStyle, valueStyle terminalStyle,
+) string {
+	spacer := ""
+	if pad {
+		spacer = " "
+	}
+	if !color {
+		return indent + key + separator + spacer + value
+	}
+	return indent +
+		keyStyle.wrap(key, true) +
+		separatorStyle.wrap(separator, true) +
+		spacer +
+		valueStyle.wrap(value, true)
+}
+
+func renderKeyValueLine(indent, key, value string, color bool, palette terminalPalette) string {
+	return renderStyledFieldLine(indent, key, ":", value, true, color, palette.key, palette.separator, palette.value)
+}
+
+func renderAssignmentLine(indent, key, value string, color bool, palette terminalPalette) string {
+	return renderStyledFieldLine(indent, key, "=", value, false, color, palette.key, palette.separator, palette.value)
+}
+
+func renderStatusValueLine(label, value string, labelStyle terminalStyle, color bool) string {
+	palette := defaultTerminalPalette()
+	return renderStyledFieldLine("", label, ":", value, true, color, labelStyle, palette.separator, palette.value)
+}
+
+func renderNoticeLine(prefix, message string, prefixStyle terminalStyle, color bool) string {
+	palette := defaultTerminalPalette()
+	return renderStyledFieldLine("", prefix, ":", message, true, color, prefixStyle, prefixStyle, palette.text) + "\n"
+}
+
+func renderActionLine(action, message string, actionStyle terminalStyle, color bool) string {
+	palette := defaultTerminalPalette()
+	if !color {
+		return action + " " + message
+	}
+	return actionStyle.wrap(action, true) + " " + palette.text.wrap(message, true)
+}
+
+func renderSummaryBlock(block summaryBlock, color bool) string {
+	palette := defaultTerminalPalette()
+	title := strings.TrimSpace(block.Title)
+
+	var out strings.Builder
+	if title != "" {
+		if color {
+			title = block.TitleStyle.wrap(title, true)
+		}
+		out.WriteString(title)
+		out.WriteByte('\n')
+	}
+
+	for _, field := range block.Fields {
+		key := strings.TrimSpace(field.Key)
+		value := strings.TrimSpace(field.Value)
+		if key == "" || value == "" {
+			continue
+		}
+
+		out.WriteString(renderAssignmentLine("", key, value, color, palette))
+		out.WriteByte('\n')
+	}
+
+	return out.String()
+}
+
+func doctorStatusStyle(status string, palette terminalPalette) terminalStyle {
+	switch status {
+	case "pass":
+		return palette.info
+	case "warn":
+		return palette.warn
+	case "fail":
+		return palette.error
+	default:
+		return palette.text
+	}
+}
+
+func daemonSummaryStyle(report daemonStatusReport, palette terminalPalette) terminalStyle {
+	if report.Active {
+		return palette.info
+	}
+	return palette.warn
+}
+
 func renderStartupHeader(h startupHeader, color bool) string {
+	palette := defaultTerminalPalette()
 	title := strings.TrimSpace(h.Title)
 	if title == "" {
 		title = "cleanroom"
@@ -41,8 +296,8 @@ func renderStartupHeader(h startupHeader, color bool) string {
 	var out strings.Builder
 	icon := "🧑‍🔬"
 	if color {
-		icon = ansiWrap("1;33", icon)
-		title = ansiWrap("1;36", title)
+		icon = palette.icon.wrap(icon, true)
+		title = palette.title.wrap(title, true)
 	}
 
 	out.WriteByte('\n')
@@ -58,12 +313,7 @@ func renderStartupHeader(h startupHeader, color bool) string {
 			continue
 		}
 
-		line := fmt.Sprintf("%s: %s", key, value)
-		if color {
-			line = ansiWrap("38;5;252", line)
-		}
-		out.WriteString("   ")
-		out.WriteString(line)
+		out.WriteString(renderKeyValueLine("   ", key, value, color, palette))
 		out.WriteByte('\n')
 	}
 	out.WriteByte('\n')
@@ -72,6 +322,7 @@ func renderStartupHeader(h startupHeader, color bool) string {
 }
 
 func renderDoctorReport(backendName string, checks []backend.DoctorCheck, color bool) string {
+	palette := defaultTerminalPalette()
 	name := strings.TrimSpace(backendName)
 	if name == "" {
 		name = "unknown"
@@ -80,7 +331,7 @@ func renderDoctorReport(backendName string, checks []backend.DoctorCheck, color 
 	var out strings.Builder
 	title := fmt.Sprintf("doctor report (%s)", name)
 	if color {
-		title = ansiWrap("1;36", title)
+		title = palette.title.wrap(title, true)
 	}
 	out.WriteString(title)
 	out.WriteByte('\n')
@@ -112,16 +363,7 @@ func renderDoctorReport(backendName string, checks []backend.DoctorCheck, color 
 
 		statusBlock := fmt.Sprintf("%s [%s]", icon, status)
 		if color {
-			code := "1;37"
-			switch status {
-			case "pass":
-				code = "1;32"
-			case "warn":
-				code = "1;33"
-			case "fail":
-				code = "1;31"
-			}
-			statusBlock = ansiWrap(code, statusBlock)
+			statusBlock = doctorStatusStyle(status, palette).wrap(statusBlock, true)
 		}
 
 		checkName := strings.TrimSpace(check.Name)
@@ -135,15 +377,22 @@ func renderDoctorReport(backendName string, checks []backend.DoctorCheck, color 
 
 		out.WriteString(statusBlock)
 		out.WriteString(" ")
-		out.WriteString(checkName)
-		out.WriteString(": ")
-		out.WriteString(message)
+		if color {
+			out.WriteString(palette.key.wrap(checkName, true))
+			out.WriteString(palette.separator.wrap(":", true))
+			out.WriteString(" ")
+			out.WriteString(palette.text.wrap(message, true))
+		} else {
+			out.WriteString(checkName)
+			out.WriteString(": ")
+			out.WriteString(message)
+		}
 		out.WriteByte('\n')
 	}
 
 	summary := fmt.Sprintf("summary: %d pass, %d warn, %d fail", passCount, warnCount, failCount)
 	if color {
-		summary = ansiWrap("38;5;246", summary)
+		summary = palette.muted.wrap(summary, true)
 	}
 	out.WriteString(summary)
 	out.WriteByte('\n')
@@ -152,6 +401,7 @@ func renderDoctorReport(backendName string, checks []backend.DoctorCheck, color 
 }
 
 func renderDaemonStatusReport(report daemonStatusReport, color bool) string {
+	palette := defaultTerminalPalette()
 	manager := strings.TrimSpace(report.Manager)
 	if manager == "" {
 		manager = "unknown"
@@ -164,21 +414,20 @@ func renderDaemonStatusReport(report daemonStatusReport, color bool) string {
 
 	summary := "not installed"
 	icon := "!"
-	colorCode := "1;33"
 	switch {
 	case report.Active:
 		summary = "running"
 		icon = "✓"
-		colorCode = "1;32"
 	case report.Installed:
 		summary = "installed"
 	}
 
 	title := fmt.Sprintf("daemon status (%s)", manager)
-	statusLine := fmt.Sprintf("%s [%s] %s", icon, summary, service)
+	statusBlock := fmt.Sprintf("%s [%s]", icon, summary)
+	statusLine := statusBlock + " " + service
 	if color {
-		title = ansiWrap("1;36", title)
-		statusLine = ansiWrap(colorCode, statusLine)
+		title = palette.title.wrap(title, true)
+		statusLine = daemonSummaryStyle(report, palette).wrap(statusBlock, true) + " " + palette.text.wrap(service, true)
 	}
 
 	var out strings.Builder
@@ -194,11 +443,7 @@ func renderDaemonStatusReport(report daemonStatusReport, color bool) string {
 			continue
 		}
 
-		line := fmt.Sprintf("  %s: %s", key, value)
-		if color {
-			line = "  " + ansiWrap("38;5;246", key+":") + " " + value
-		}
-		out.WriteString(line)
+		out.WriteString(renderKeyValueLine("  ", key, value, color, palette))
 		out.WriteByte('\n')
 	}
 
@@ -241,34 +486,18 @@ func shouldShowStartupHeader(stderr *os.File) bool {
 	return term.IsTerminal(int(stderr.Fd()))
 }
 
-func shouldUseANSI(stderr *os.File) bool {
-	if noColorRequested() {
-		return false
-	}
+func shouldUseANSI(w io.Writer) bool {
 	if forceColorRequested() {
 		return true
 	}
-	if stderr == nil {
+	if noColorRequested() {
 		return false
 	}
-	return term.IsTerminal(int(stderr.Fd()))
-}
-
-func applyPolishedLoggerStyles(logger *log.Logger, color bool) {
-	if logger == nil || !color {
-		return
+	file, ok := w.(*os.File)
+	if !ok || file == nil {
+		return false
 	}
-
-	styles := log.DefaultStyles()
-	styles.Message = styles.Message.Foreground(lipgloss.Color("252"))
-	styles.Key = styles.Key.Bold(true).Foreground(lipgloss.Color("75"))
-	styles.Value = styles.Value.Foreground(lipgloss.Color("255"))
-	styles.Separator = styles.Separator.Foreground(lipgloss.Color("240"))
-	styles.Levels[log.DebugLevel] = styles.Levels[log.DebugLevel].Bold(true).Foreground(lipgloss.Color("45"))
-	styles.Levels[log.InfoLevel] = styles.Levels[log.InfoLevel].Bold(true).Foreground(lipgloss.Color("48"))
-	styles.Levels[log.WarnLevel] = styles.Levels[log.WarnLevel].Bold(true).Foreground(lipgloss.Color("214"))
-	styles.Levels[log.ErrorLevel] = styles.Levels[log.ErrorLevel].Bold(true).Foreground(lipgloss.Color("203"))
-	logger.SetStyles(styles)
+	return term.IsTerminal(int(file.Fd()))
 }
 
 func endpointDisplay(ep endpoint.Endpoint) string {

--- a/internal/cli/ui_test.go
+++ b/internal/cli/ui_test.go
@@ -1,11 +1,11 @@
 package cli
 
 import (
-	"regexp"
 	"strings"
 	"testing"
 
 	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/charmbracelet/log"
 )
 
 func TestRenderStartupHeaderPlain(t *testing.T) {
@@ -33,17 +33,18 @@ func TestRenderStartupHeaderColor(t *testing.T) {
 			{Key: "workspace", Value: "/tmp/repo"},
 		},
 	}, true)
+	plain := stripANSI(out)
 
 	if !strings.Contains(out, "\x1b[") {
 		t.Fatalf("expected ANSI escapes in color output: %q", out)
 	}
-	if !strings.Contains(out, "cleanroom console") {
+	if !strings.Contains(plain, "cleanroom console") {
 		t.Fatalf("missing title in header output: %q", out)
 	}
-	if !strings.Contains(out, "🧑‍🔬") {
+	if !strings.Contains(plain, "🧑‍🔬") {
 		t.Fatalf("missing icon in header output: %q", out)
 	}
-	if !strings.Contains(out, "workspace: /tmp/repo") {
+	if !strings.Contains(plain, "workspace: /tmp/repo") {
 		t.Fatalf("missing field in header output: %q", out)
 	}
 	if !strings.HasPrefix(out, "\n") {
@@ -115,6 +116,25 @@ func TestRenderDoctorReportColor(t *testing.T) {
 	}
 }
 
+func TestRenderDoctorReportColorUsesLoggerPalette(t *testing.T) {
+	out := renderDoctorReport("darwin-vz", []backend.DoctorCheck{
+		{Name: "runtime_config", Status: "pass", Message: "using /tmp/config.yaml"},
+		{Name: "network_guest_interface", Status: "warn", Message: "unsupported"},
+		{Name: "backend_doctor", Status: "fail", Message: "missing helper"},
+	}, true)
+	palette := defaultTerminalPalette()
+
+	if !strings.Contains(out, palette.info.wrap("✓ [pass]", true)) {
+		t.Fatalf("expected pass status to use info palette, got: %q", out)
+	}
+	if !strings.Contains(out, palette.warn.wrap("! [warn]", true)) {
+		t.Fatalf("expected warn status to use warn palette, got: %q", out)
+	}
+	if !strings.Contains(out, palette.error.wrap("✗ [fail]", true)) {
+		t.Fatalf("expected fail status to use error palette, got: %q", out)
+	}
+}
+
 func TestRenderDaemonStatusReportPlain(t *testing.T) {
 	out := renderDaemonStatusReport(daemonStatusReport{
 		Manager:   "launchd",
@@ -174,6 +194,55 @@ func TestRenderDaemonStatusReportColor(t *testing.T) {
 	}
 }
 
+func TestRenderDaemonStatusReportColorUsesLoggerPalette(t *testing.T) {
+	out := renderDaemonStatusReport(daemonStatusReport{
+		Manager:   "launchd",
+		Service:   "com.buildkite.cleanroom",
+		Installed: false,
+		Active:    false,
+		Fields: []startupField{
+			{Key: "install", Value: "missing"},
+			{Key: "runtime", Value: "inactive"},
+		},
+	}, true)
+	palette := defaultTerminalPalette()
+	expectedField := "  " + palette.key.wrap("install", true) + palette.separator.wrap(":", true) + " " + palette.value.wrap("missing", true)
+
+	if !strings.Contains(out, palette.warn.wrap("! [not installed]", true)) {
+		t.Fatalf("expected daemon summary to use warn palette, got: %q", out)
+	}
+	if !strings.Contains(out, expectedField) {
+		t.Fatalf("expected daemon fields to use shared key/value palette, got: %q", out)
+	}
+}
+
+func TestDefaultTerminalPaletteUsesLoggerDefaults(t *testing.T) {
+	styles := log.DefaultStyles()
+	palette := defaultTerminalPalette()
+
+	if got, want := palette.text, terminalStyleFromLipgloss(styles.Message); got != want {
+		t.Fatalf("message style mismatch: got %+v want %+v", got, want)
+	}
+	if got, want := palette.value, terminalStyleFromLipgloss(styles.Value); got != want {
+		t.Fatalf("value style mismatch: got %+v want %+v", got, want)
+	}
+	if got, want := palette.separator, terminalStyleFromLipgloss(styles.Separator); got != want {
+		t.Fatalf("separator style mismatch: got %+v want %+v", got, want)
+	}
+	if got, want := palette.key, terminalStyleFromLipgloss(styles.Key); got != want {
+		t.Fatalf("key style mismatch: got %+v want %+v", got, want)
+	}
+	if got, want := palette.info, terminalStyleFromLipgloss(styles.Levels[log.InfoLevel]); got != want {
+		t.Fatalf("info style mismatch: got %+v want %+v", got, want)
+	}
+	if got, want := palette.warn, terminalStyleFromLipgloss(styles.Levels[log.WarnLevel]); got != want {
+		t.Fatalf("warn style mismatch: got %+v want %+v", got, want)
+	}
+	if got, want := palette.error, terminalStyleFromLipgloss(styles.Levels[log.ErrorLevel]); got != want {
+		t.Fatalf("error style mismatch: got %+v want %+v", got, want)
+	}
+}
+
 func TestRenderDaemonStatusReportShowsRunningWhenActiveWithoutInstall(t *testing.T) {
 	out := renderDaemonStatusReport(daemonStatusReport{
 		Manager:   "launchd",
@@ -194,7 +263,37 @@ func TestRenderDaemonStatusReportShowsRunningWhenActiveWithoutInstall(t *testing
 	}
 }
 
-func stripANSI(value string) string {
-	ansi := regexp.MustCompile(`\x1b\[[0-9;]*m`)
-	return ansi.ReplaceAllString(value, "")
+func TestRenderSummaryBlockColorUsesSharedPalette(t *testing.T) {
+	out := renderSummaryBlock(summaryBlock{
+		Title:      "pulled image",
+		TitleStyle: defaultTerminalPalette().info,
+		Fields: []startupField{
+			{Key: "ref", Value: "ghcr.io/buildkite/cleanroom-base/alpine@sha256:1234"},
+			{Key: "digest", Value: "sha256:1234"},
+		},
+	}, true)
+	plain := stripANSI(out)
+	palette := defaultTerminalPalette()
+
+	if !strings.Contains(out, palette.info.wrap("pulled image", true)) {
+		t.Fatalf("expected summary title to use info palette, got: %q", out)
+	}
+	if !strings.Contains(out, "ref") || !strings.Contains(out, palette.separator.wrap("=", true)) {
+		t.Fatalf("expected assignment fields to be rendered with shared separator styling, got: %q", out)
+	}
+	if !strings.Contains(plain, "pulled image\nref=ghcr.io/buildkite/cleanroom-base/alpine@sha256:1234\ndigest=sha256:1234\n") {
+		t.Fatalf("unexpected plain summary output: %q", plain)
+	}
+}
+
+func TestRenderNoticeLineColorUsesSharedPalette(t *testing.T) {
+	out := renderNoticeLine("warning", "repository has local modifications", defaultTerminalPalette().warn, true)
+	plain := stripANSI(out)
+
+	if !strings.Contains(out, defaultTerminalPalette().warn.wrap("warning", true)) {
+		t.Fatalf("expected notice prefix to use warn palette, got: %q", out)
+	}
+	if plain != "warning: repository has local modifications\n" {
+		t.Fatalf("unexpected plain notice output: %q", plain)
+	}
 }

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -1675,6 +1675,9 @@ func (s *Service) executionOutputStream(key string) backend.OutputStream {
 		OnStderr: func(chunk []byte) {
 			s.recordExecutionOutputChunk(key, false, chunk)
 		},
+		OnWarning: func(message string) {
+			s.recordExecutionWarning(key, message)
+		},
 		OnAttach: func(io backend.AttachIO) {
 			s.setExecutionAttachIO(key, io)
 		},
@@ -2000,6 +2003,34 @@ func (s *Service) recordExecutionOutputChunk(key string, isStdout bool, chunk []
 	}
 
 	s.appendExecutionStderrLocked(ex, status, chunk)
+}
+
+func (s *Service) recordExecutionWarning(key, message string) {
+	message = strings.TrimSpace(message)
+	if message == "" {
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	ex, ok := s.executions[key]
+	if !ok {
+		return
+	}
+
+	status := ex.Status
+	if isFinalExecutionStatus(status) {
+		return
+	}
+
+	s.recordExecutionEventLocked(ex, &cleanroomv1.ExecutionStreamEvent{
+		SandboxId:   ex.SandboxID,
+		ExecutionId: ex.ID,
+		Status:      status,
+		Payload:     &cleanroomv1.ExecutionStreamEvent_Warning{Warning: message},
+		OccurredAt:  timestamppb.Now(),
+	})
 }
 
 func (s *Service) appendExecutionStdoutLocked(ex *executionState, status cleanroomv1.ExecutionStatus, chunk []byte) {

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -861,6 +861,71 @@ func TestCreateSnapshotDoesNotResurrectTerminatedSandbox(t *testing.T) {
 	}
 }
 
+func TestExecutionStreamIncludesStructuredWarnings(t *testing.T) {
+	const warningText = "darwin-vz guest networking is enabled without host-side egress filtering"
+
+	adapter := &stubAdapter{
+		runStreamFn: func(_ context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+			if stream.OnWarning != nil {
+				stream.OnWarning(warningText)
+			}
+			if stream.OnStdout != nil {
+				stream.OnStdout([]byte("hello stdout\n"))
+			}
+			return &backend.RunResult{
+				RunID:    req.RunID,
+				ExitCode: 0,
+				Stdout:   "hello stdout\n",
+				Message:  "done",
+			}, nil
+		},
+	}
+	svc := newTestService(adapter)
+
+	createSandboxResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createSandboxResp.GetSandbox().GetSandboxId()
+
+	createExecutionResp, err := svc.CreateExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
+		SandboxId: sandboxID,
+		Command:   []string{"--", "echo", "hi"},
+	})
+	if err != nil {
+		t.Fatalf("CreateExecution returned error: %v", err)
+	}
+	executionID := createExecutionResp.GetExecution().GetExecutionId()
+
+	history, updates, done, unsubscribe, err := svc.SubscribeExecutionEvents(sandboxID, executionID)
+	if err != nil {
+		t.Fatalf("SubscribeExecutionEvents returned error: %v", err)
+	}
+	defer unsubscribe()
+
+	events := collectExecutionEvents(t, history, updates, done)
+	var sawWarning bool
+	var sawStderr bool
+	for _, event := range events {
+		switch payload := event.Payload.(type) {
+		case *cleanroomv1.ExecutionStreamEvent_Warning:
+			if payload.Warning == warningText {
+				sawWarning = true
+			}
+		case *cleanroomv1.ExecutionStreamEvent_Stderr:
+			if strings.Contains(string(payload.Stderr), warningText) {
+				sawStderr = true
+			}
+		}
+	}
+	if !sawWarning {
+		t.Fatalf("expected warning event in stream, events=%d", len(events))
+	}
+	if sawStderr {
+		t.Fatalf("expected structured warning to stay out of stderr events, events=%d", len(events))
+	}
+}
+
 func TestCancelExecutionTransitionsToCanceled(t *testing.T) {
 	started := make(chan struct{}, 1)
 	adapter := &stubAdapter{

--- a/internal/gen/cleanroom/v1/control.pb.go
+++ b/internal/gen/cleanroom/v1/control.pb.go
@@ -2583,6 +2583,7 @@ type ExecutionStreamEvent struct {
 	//	*ExecutionStreamEvent_Stderr
 	//	*ExecutionStreamEvent_Exit
 	//	*ExecutionStreamEvent_Message
+	//	*ExecutionStreamEvent_Warning
 	Payload       isExecutionStreamEvent_Payload `protobuf_oneof:"payload"`
 	OccurredAt    *timestamppb.Timestamp         `protobuf:"bytes,8,opt,name=occurred_at,json=occurredAt,proto3" json:"occurred_at,omitempty"`
 	ImageRef      string                         `protobuf:"bytes,9,opt,name=image_ref,json=imageRef,proto3" json:"image_ref,omitempty"`
@@ -2685,6 +2686,15 @@ func (x *ExecutionStreamEvent) GetMessage() string {
 	return ""
 }
 
+func (x *ExecutionStreamEvent) GetWarning() string {
+	if x != nil {
+		if x, ok := x.Payload.(*ExecutionStreamEvent_Warning); ok {
+			return x.Warning
+		}
+	}
+	return ""
+}
+
 func (x *ExecutionStreamEvent) GetOccurredAt() *timestamppb.Timestamp {
 	if x != nil {
 		return x.OccurredAt
@@ -2726,6 +2736,10 @@ type ExecutionStreamEvent_Message struct {
 	Message string `protobuf:"bytes,7,opt,name=message,proto3,oneof"`
 }
 
+type ExecutionStreamEvent_Warning struct {
+	Warning string `protobuf:"bytes,11,opt,name=warning,proto3,oneof"`
+}
+
 func (*ExecutionStreamEvent_Stdout) isExecutionStreamEvent_Payload() {}
 
 func (*ExecutionStreamEvent_Stderr) isExecutionStreamEvent_Payload() {}
@@ -2733,6 +2747,8 @@ func (*ExecutionStreamEvent_Stderr) isExecutionStreamEvent_Payload() {}
 func (*ExecutionStreamEvent_Exit) isExecutionStreamEvent_Payload() {}
 
 func (*ExecutionStreamEvent_Message) isExecutionStreamEvent_Payload() {}
+
+func (*ExecutionStreamEvent_Warning) isExecutionStreamEvent_Payload() {}
 
 var File_proto_cleanroom_v1_control_proto protoreflect.FileDescriptor
 
@@ -2934,7 +2950,7 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\rExecutionExit\x12\x1b\n" +
 	"\texit_code\x18\x01 \x01(\x05R\bexitCode\x125\n" +
 	"\x06status\x18\x02 \x01(\x0e2\x1d.cleanroom.v1.ExecutionStatusR\x06status\x12\x18\n" +
-	"\amessage\x18\x03 \x01(\tR\amessage\"\x9a\x03\n" +
+	"\amessage\x18\x03 \x01(\tR\amessage\"\xb6\x03\n" +
 	"\x14ExecutionStreamEvent\x12\x1d\n" +
 	"\n" +
 	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\x12!\n" +
@@ -2943,7 +2959,8 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\x06stdout\x18\x04 \x01(\fH\x00R\x06stdout\x12\x18\n" +
 	"\x06stderr\x18\x05 \x01(\fH\x00R\x06stderr\x121\n" +
 	"\x04exit\x18\x06 \x01(\v2\x1b.cleanroom.v1.ExecutionExitH\x00R\x04exit\x12\x1a\n" +
-	"\amessage\x18\a \x01(\tH\x00R\amessage\x12;\n" +
+	"\amessage\x18\a \x01(\tH\x00R\amessage\x12\x1a\n" +
+	"\awarning\x18\v \x01(\tH\x00R\awarning\x12;\n" +
 	"\voccurred_at\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\n" +
 	"occurredAt\x12\x1b\n" +
 	"\timage_ref\x18\t \x01(\tR\bimageRef\x12!\n" +
@@ -3135,6 +3152,7 @@ func file_proto_cleanroom_v1_control_proto_init() {
 		(*ExecutionStreamEvent_Stderr)(nil),
 		(*ExecutionStreamEvent_Exit)(nil),
 		(*ExecutionStreamEvent_Message)(nil),
+		(*ExecutionStreamEvent_Warning)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{

--- a/internal/interactivequic/server.go
+++ b/internal/interactivequic/server.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"net"
+	"strings"
 	"sync"
 	"time"
 
@@ -423,6 +424,11 @@ func (s *Server) forwardEventToPTY(event *cleanroomv1.ExecutionStreamEvent, stre
 		_, _ = stream.Write(payload.Stdout)
 	case *cleanroomv1.ExecutionStreamEvent_Stderr:
 		_, _ = stream.Write(payload.Stderr)
+	case *cleanroomv1.ExecutionStreamEvent_Warning:
+		text := strings.TrimSpace(payload.Warning)
+		if text != "" {
+			_, _ = stream.Write([]byte("warning: " + text + "\n"))
+		}
 	case *cleanroomv1.ExecutionStreamEvent_Exit:
 		return true
 	}

--- a/proto/cleanroom/v1/control.proto
+++ b/proto/cleanroom/v1/control.proto
@@ -308,6 +308,7 @@ message ExecutionStreamEvent {
     bytes stderr = 5;
     ExecutionExit exit = 6;
     string message = 7;
+    string warning = 11;
   }
 
   google.protobuf.Timestamp occurred_at = 8;


### PR DESCRIPTION
## Summary
- derive CLI colors from `charmbracelet/log` defaults so `serve`, `doctor`, `daemon status`, and command summaries share one styling source
- reuse shared renderers for image, policy/config, repository, and daemon notices so human-facing output stays visually consistent
- add a structured execution warning stream so darwin-vz runtime warnings render like CLI warnings without mutating guest stderr

## Testing
- `mise x buf@1.57.0 -- buf generate`
- `mise exec -- go test ./...`
- `mise exec -- go vet ./...`
