### PR TITLE
fix: print kept sandbox ids after command exit

### DIFF
--- a/internal/cli/console.go
+++ b/internal/cli/console.go
@@ -80,11 +80,22 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) (runErr error) {
 		}
 		return err
 	}
+	printedSandboxID := false
+	printSandboxID := func() error {
+		if printedSandboxID {
+			return nil
+		}
+		if err := writeSandboxID(os.Stderr, sandboxID); err != nil {
+			return err
+		}
+		printedSandboxID = true
+		return nil
+	}
 	defer func() {
 		if !createdSandbox || !c.Keep {
 			return
 		}
-		if err := writeSandboxID(os.Stderr, sandboxID); err != nil {
+		if err := printSandboxID(); err != nil {
 			if runErr == nil {
 				runErr = err
 				return
@@ -93,7 +104,7 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) (runErr error) {
 		}
 	}()
 	if c.PrintSandboxID {
-		if err := writeSandboxID(os.Stderr, sandboxID); err != nil {
+		if err := printSandboxID(); err != nil {
 			return err
 		}
 	}

--- a/internal/cli/console.go
+++ b/internal/cli/console.go
@@ -33,7 +33,7 @@ type ConsoleCommand struct {
 	Command []string `arg:"" passthrough:"" optional:"" help:"Command to run in the console (default: sh)"`
 }
 
-func (c *ConsoleCommand) Run(ctx *runtimeContext) error {
+func (c *ConsoleCommand) Run(ctx *runtimeContext) (runErr error) {
 	logger, err := newLogger(c.LogLevel, "client")
 	if err != nil {
 		return err
@@ -80,8 +80,20 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) error {
 		}
 		return err
 	}
+	defer func() {
+		if !createdSandbox || !c.Keep {
+			return
+		}
+		if err := writeSandboxID(os.Stderr, sandboxID); err != nil {
+			if runErr == nil {
+				runErr = err
+				return
+			}
+			runErr = errors.Join(runErr, err)
+		}
+	}()
 	if c.PrintSandboxID {
-		if _, err := fmt.Fprintf(os.Stderr, "sandbox_id=%s\n", sandboxID); err != nil {
+		if err := writeSandboxID(os.Stderr, sandboxID); err != nil {
 			return err
 		}
 	}

--- a/internal/cli/console_integration_test.go
+++ b/internal/cli/console_integration_test.go
@@ -326,6 +326,33 @@ func TestConsoleIntegrationKeepPreservesCreatedSandbox(t *testing.T) {
 	requireSandboxStatus(t, client, sandboxID, cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY)
 }
 
+func TestConsoleIntegrationKeepWithPrintSandboxIDPrintsOnce(t *testing.T) {
+	host, _ := startIntegrationServer(t, &integrationAdapter{
+		runStreamFn: func(_ context.Context, req backend.RunRequest, _ backend.OutputStream) (*backend.RunResult, error) {
+			return &backend.RunResult{RunID: req.RunID, ExitCode: 0, Stdout: "ok\n", Message: "ok"}, nil
+		},
+	})
+
+	outcome := runConsoleWithCapture(ConsoleCommand{
+		clientFlags:    clientFlags{Host: host},
+		Keep:           true,
+		PrintSandboxID: true,
+		Command:        []string{"sh"},
+	}, "", runtimeContext{
+		CWD:    t.TempDir(),
+		Loader: integrationLoader{},
+	})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err != nil {
+		t.Fatalf("ConsoleCommand.Run returned error: %v", outcome.err)
+	}
+	if got, want := strings.Count(outcome.stderr, "sandbox_id="), 1; got != want {
+		t.Fatalf("expected one sandbox_id marker in stderr, got %d: %q", got, outcome.stderr)
+	}
+}
+
 func TestConsoleIntegrationReuseSandboxSkipsPolicyCompile(t *testing.T) {
 	started := make(chan struct{}, 1)
 	host, _ := startIntegrationServer(t, &integrationAdapter{

--- a/internal/cli/console_integration_test.go
+++ b/internal/cli/console_integration_test.go
@@ -303,10 +303,9 @@ func TestConsoleIntegrationKeepPreservesCreatedSandbox(t *testing.T) {
 	})
 
 	outcome := runConsoleWithCapture(ConsoleCommand{
-		clientFlags:    clientFlags{Host: host},
-		Keep:           true,
-		PrintSandboxID: true,
-		Command:        []string{"sh"},
+		clientFlags: clientFlags{Host: host},
+		Keep:        true,
+		Command:     []string{"sh"},
 	}, "", runtimeContext{
 		CWD:    t.TempDir(),
 		Loader: integrationLoader{},

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -26,7 +26,7 @@ type ExecCommand struct {
 	Command []string `arg:"" passthrough:"" required:"" help:"Command to execute"`
 }
 
-func (e *ExecCommand) Run(ctx *runtimeContext) error {
+func (e *ExecCommand) Run(ctx *runtimeContext) (runErr error) {
 	logger, err := newLogger(e.LogLevel, "client")
 	if err != nil {
 		return err
@@ -69,8 +69,20 @@ func (e *ExecCommand) Run(ctx *runtimeContext) error {
 		}
 		return err
 	}
+	defer func() {
+		if !createdSandbox || !e.Keep {
+			return
+		}
+		if err := writeSandboxID(os.Stderr, sandboxID); err != nil {
+			if runErr == nil {
+				runErr = err
+				return
+			}
+			runErr = errors.Join(runErr, err)
+		}
+	}()
 	if e.PrintSandboxID {
-		if _, err := fmt.Fprintf(os.Stderr, "sandbox_id=%s\n", sandboxID); err != nil {
+		if err := writeSandboxID(os.Stderr, sandboxID); err != nil {
 			return err
 		}
 	}

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -69,11 +69,22 @@ func (e *ExecCommand) Run(ctx *runtimeContext) (runErr error) {
 		}
 		return err
 	}
+	printedSandboxID := false
+	printSandboxID := func() error {
+		if printedSandboxID {
+			return nil
+		}
+		if err := writeSandboxID(os.Stderr, sandboxID); err != nil {
+			return err
+		}
+		printedSandboxID = true
+		return nil
+	}
 	defer func() {
 		if !createdSandbox || !e.Keep {
 			return
 		}
-		if err := writeSandboxID(os.Stderr, sandboxID); err != nil {
+		if err := printSandboxID(); err != nil {
 			if runErr == nil {
 				runErr = err
 				return
@@ -82,7 +93,7 @@ func (e *ExecCommand) Run(ctx *runtimeContext) (runErr error) {
 		}
 	}()
 	if e.PrintSandboxID {
-		if err := writeSandboxID(os.Stderr, sandboxID); err != nil {
+		if err := printSandboxID(); err != nil {
 			return err
 		}
 	}

--- a/internal/cli/exec_integration_test.go
+++ b/internal/cli/exec_integration_test.go
@@ -877,11 +877,10 @@ func TestExecIntegrationKeepPreservesCreatedSandbox(t *testing.T) {
 	host, _ := startIntegrationServer(t, &integrationAdapter{})
 	cwd := t.TempDir()
 	outcome := runExecWithCapture(ExecCommand{
-		clientFlags:    clientFlags{Host: host},
-		Chdir:          cwd,
-		Keep:           true,
-		PrintSandboxID: true,
-		Command:        []string{"echo", "ok"},
+		clientFlags: clientFlags{Host: host},
+		Chdir:       cwd,
+		Keep:        true,
+		Command:     []string{"echo", "ok"},
 	}, runtimeContext{
 		CWD:    cwd,
 		Loader: integrationLoader{},

--- a/internal/cli/exec_integration_test.go
+++ b/internal/cli/exec_integration_test.go
@@ -845,6 +845,30 @@ func TestExecIntegrationPrintSandboxIDFlag(t *testing.T) {
 	}
 }
 
+func TestExecIntegrationKeepWithPrintSandboxIDPrintsOnce(t *testing.T) {
+	host, _ := startIntegrationServer(t, &integrationAdapter{})
+	cwd := t.TempDir()
+	outcome := runExecWithCapture(ExecCommand{
+		clientFlags:    clientFlags{Host: host},
+		Chdir:          cwd,
+		Keep:           true,
+		PrintSandboxID: true,
+		Command:        []string{"echo", "ok"},
+	}, runtimeContext{
+		CWD:    cwd,
+		Loader: integrationLoader{},
+	})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err != nil {
+		t.Fatalf("ExecCommand.Run returned error: %v", outcome.err)
+	}
+	if got, want := strings.Count(outcome.stderr, "sandbox_id="), 1; got != want {
+		t.Fatalf("expected one sandbox_id marker in stderr, got %d: %q", got, outcome.stderr)
+	}
+}
+
 func TestExecIntegrationDefaultTerminatesCreatedSandbox(t *testing.T) {
 	host, _ := startIntegrationServer(t, &integrationAdapter{})
 	cwd := t.TempDir()

--- a/internal/cli/execution_shared.go
+++ b/internal/cli/execution_shared.go
@@ -101,6 +101,15 @@ func writeExecutionWarning(stderr io.Writer, message string) error {
 	return err
 }
 
+func writeSandboxID(stderr io.Writer, sandboxID string) error {
+	sandboxID = strings.TrimSpace(sandboxID)
+	if stderr == nil || sandboxID == "" {
+		return nil
+	}
+	_, err := fmt.Fprintf(stderr, "sandbox_id=%s\n", sandboxID)
+	return err
+}
+
 func replayExecutionHistory(client *controlclient.Client, sandboxID, executionID string, stdout, stderr io.Writer) (int, bool, error) {
 	stream, err := client.StreamExecution(context.Background(), &cleanroomv1.StreamExecutionRequest{
 		SandboxId:   sandboxID,


### PR DESCRIPTION
## Summary
- print `sandbox_id=<id>` to stderr after `exec --keep` and `console --keep` finish when they created the sandbox
- reuse the same sandbox-id formatter for the existing `--print-sandbox-id` path
- cover the keep behavior in the exec and console integration tests without relying on `--print-sandbox-id`

## Verification
- `mise exec go@1.23.1 -- go test ./internal/cli`
- `mise exec go@1.23.1 -- go test ./...`
- `mise exec go@1.23.1 -- go vet ./...`
- `mise run build:go`