### PR TITLE
fix: hide stopped sandboxes from default list

### DIFF
--- a/internal/cli/cli_parse_test.go
+++ b/internal/cli/cli_parse_test.go
@@ -113,6 +113,18 @@ func TestSandboxCreateParses(t *testing.T) {
 	}
 }
 
+func TestSandboxListParsesAllFlag(t *testing.T) {
+	c := &CLI{}
+	parser := newParserForTest(t, c)
+
+	if _, err := parser.Parse([]string{"sandbox", "ls", "--all"}); err != nil {
+		t.Fatalf("parse sandbox ls --all returned error: %v", err)
+	}
+	if !c.Sandbox.List.All {
+		t.Fatal("expected sandbox list all flag to be set")
+	}
+}
+
 func TestSandboxCreateParsesImageOverride(t *testing.T) {
 	c := &CLI{}
 	parser := newParserForTest(t, c)

--- a/internal/cli/sandbox.go
+++ b/internal/cli/sandbox.go
@@ -31,6 +31,7 @@ type SandboxCreateCommand struct {
 
 type SandboxListCommand struct {
 	clientFlags
+	All  bool `help:"Include stopped sandboxes"`
 	JSON bool `help:"Print sandboxes as JSON"`
 }
 
@@ -59,15 +60,20 @@ func (c *SandboxListCommand) Run(ctx *runtimeContext) error {
 	if err != nil {
 		return err
 	}
+	sandboxes := filterSandboxList(resp.Sandboxes, c.All)
 
 	if c.JSON {
 		enc := json.NewEncoder(ctx.Stdout)
 		enc.SetIndent("", "  ")
-		return enc.Encode(resp.Sandboxes)
+		return enc.Encode(sandboxes)
 	}
 
-	if len(resp.Sandboxes) == 0 {
-		_, err := fmt.Fprintln(ctx.Stdout, "no active sandboxes")
+	if len(sandboxes) == 0 {
+		message := "no active sandboxes"
+		if c.All {
+			message = "no sandboxes"
+		}
+		_, err := fmt.Fprintln(ctx.Stdout, message)
 		return err
 	}
 
@@ -75,7 +81,7 @@ func (c *SandboxListCommand) Run(ctx *runtimeContext) error {
 	if _, err := fmt.Fprintln(tw, "ID\tSTATUS\tBACKEND\tCREATED"); err != nil {
 		return err
 	}
-	for _, sb := range resp.Sandboxes {
+	for _, sb := range sandboxes {
 		status := sandboxStatusString(sb.Status)
 		created := ""
 		if sb.CreatedAt != nil {
@@ -86,6 +92,20 @@ func (c *SandboxListCommand) Run(ctx *runtimeContext) error {
 		}
 	}
 	return tw.Flush()
+}
+
+func filterSandboxList(sandboxes []*cleanroomv1.Sandbox, includeStopped bool) []*cleanroomv1.Sandbox {
+	filtered := make([]*cleanroomv1.Sandbox, 0, len(sandboxes))
+	for _, sandbox := range sandboxes {
+		if sandbox == nil {
+			continue
+		}
+		if !includeStopped && sandbox.Status == cleanroomv1.SandboxStatus_SANDBOX_STATUS_STOPPED {
+			continue
+		}
+		filtered = append(filtered, sandbox)
+	}
+	return filtered
 }
 
 func (c *SandboxTerminateCommand) Run(ctx *runtimeContext) error {

--- a/internal/cli/sandbox_list_integration_test.go
+++ b/internal/cli/sandbox_list_integration_test.go
@@ -1,0 +1,63 @@
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+)
+
+func runSandboxListWithCapture(cmd SandboxListCommand, ctx runtimeContext) execOutcome {
+	return runWithCapture(func(runCtx *runtimeContext) error {
+		return cmd.Run(runCtx)
+	}, nil, ctx)
+}
+
+func TestSandboxListIntegrationHidesStoppedByDefault(t *testing.T) {
+	host, _ := startIntegrationServer(t, &integrationAdapter{})
+	cwd := t.TempDir()
+
+	client := mustNewControlClient(t, host)
+	readySandboxID := mustCreateSandbox(t, client)
+	stoppedSandboxID := mustCreateSandbox(t, client)
+	if _, err := client.TerminateSandbox(context.Background(), &cleanroomv1.TerminateSandboxRequest{SandboxId: stoppedSandboxID}); err != nil {
+		t.Fatalf("TerminateSandbox returned error: %v", err)
+	}
+
+	defaultOutcome := runSandboxListWithCapture(SandboxListCommand{
+		clientFlags: clientFlags{Host: host},
+	}, runtimeContext{CWD: cwd})
+	if defaultOutcome.cause != nil {
+		t.Fatalf("capture failure: %v", defaultOutcome.cause)
+	}
+	if defaultOutcome.err != nil {
+		t.Fatalf("SandboxListCommand.Run returned error: %v", defaultOutcome.err)
+	}
+	if !strings.Contains(defaultOutcome.stdout, readySandboxID) {
+		t.Fatalf("expected default list output to include ready sandbox %q, got %q", readySandboxID, defaultOutcome.stdout)
+	}
+	if strings.Contains(defaultOutcome.stdout, stoppedSandboxID) {
+		t.Fatalf("expected default list output to hide stopped sandbox %q, got %q", stoppedSandboxID, defaultOutcome.stdout)
+	}
+
+	allOutcome := runSandboxListWithCapture(SandboxListCommand{
+		clientFlags: clientFlags{Host: host},
+		All:         true,
+	}, runtimeContext{CWD: cwd})
+	if allOutcome.cause != nil {
+		t.Fatalf("capture failure: %v", allOutcome.cause)
+	}
+	if allOutcome.err != nil {
+		t.Fatalf("SandboxListCommand.Run with --all returned error: %v", allOutcome.err)
+	}
+	if !strings.Contains(allOutcome.stdout, readySandboxID) {
+		t.Fatalf("expected --all output to include ready sandbox %q, got %q", readySandboxID, allOutcome.stdout)
+	}
+	if !strings.Contains(allOutcome.stdout, stoppedSandboxID) {
+		t.Fatalf("expected --all output to include stopped sandbox %q, got %q", stoppedSandboxID, allOutcome.stdout)
+	}
+	if !strings.Contains(allOutcome.stdout, "stopped") {
+		t.Fatalf("expected --all output to include stopped status, got %q", allOutcome.stdout)
+	}
+}


### PR DESCRIPTION
## Summary
- hide `STOPPED` sandboxes from `cleanroom sandbox ls` by default
- add `--all` to include stopped sandboxes in both table and JSON output
- cover the flag with parse and integration tests

## Testing
- mise exec -- go test ./...
- mise run build:go
- mise exec -- go vet ./...

## Notes
- investigated cleanup/prune behavior while making this change
- `ListSandboxes` still returns every in-memory sandbox, and pruning remains opportunistic on mutating paths rather than background-driven, so `--all` can still surface older stopped sandboxes until another state change triggers pruning