### PR TITLE
feat: add APFS snapshot driver for darwin-vz

### DIFF
--- a/docs/backend/darwin-vz.md
+++ b/docs/backend/darwin-vz.md
@@ -19,7 +19,7 @@ Implemented:
 - managed kernel fallback when `kernel_image` is unset or missing
 - rootfs derivation from `sandbox.image.ref` when `rootfs` is unset or missing
 - persistent sandboxes across multiple executions
-- file-backed snapshot and create-from-snapshot for persistent sandboxes
+- `file` and `apfs` snapshot drivers for snapshot and create-from-snapshot flows
 - doctor checks for helper availability and entitlement status
 
 Not implemented:
@@ -92,6 +92,12 @@ Rootfs:
 - otherwise derive rootfs from `sandbox.image.ref` using image manager
 - inject guest runtime (`cleanroom-guest-agent` and `/usr/sbin/cleanroom-init`) into a prepared cached rootfs image
 - create a per-sandbox copy (`rootfs-persistent.ext4`) and attach it read-write to the VM
+
+Snapshot/rootfs volume drivers:
+
+- `snapshots.driver: file` copies ext4 images with standard file I/O
+- `snapshots.driver: apfs` uses macOS `clonefile(2)` for same-filesystem APFS copy-on-write clones
+- the selected driver is used for snapshot capture, snapshot-backed sandbox creation, and writable per-run/per-sandbox rootfs preparation
 
 Host tools required for derivation/injection:
 
@@ -176,6 +182,7 @@ Fast path:
 
 - `mise exec -- go test ./internal/backend/darwinvz`
 - `mise exec -- go test ./...`
+- `mise exec -- go test -run '^$' -bench BenchmarkDarwinSnapshotDrivers -benchmem -benchtime=5x ./internal/volumestore`
 
 Real VM persistence e2e:
 

--- a/docs/backend/darwin-vz.md
+++ b/docs/backend/darwin-vz.md
@@ -97,7 +97,7 @@ Snapshot/rootfs volume drivers:
 
 - omitted `snapshots.driver` defaults to `apfs` for `darwin-vz`
 - `snapshots.driver: file` copies ext4 images with standard file I/O
-- `snapshots.driver: apfs` uses macOS `clonefile(2)` for same-filesystem APFS copy-on-write clones
+- `snapshots.driver: apfs` uses macOS `clonefile(2)` for same-filesystem APFS copy-on-write clones and falls back to standard file copies when `clonefile(2)` is unavailable for the selected source/destination
 - the selected driver is used for snapshot capture, snapshot-backed sandbox creation, and writable per-run/per-sandbox rootfs preparation
 
 Host tools required for derivation/injection:

--- a/docs/backend/darwin-vz.md
+++ b/docs/backend/darwin-vz.md
@@ -95,6 +95,7 @@ Rootfs:
 
 Snapshot/rootfs volume drivers:
 
+- omitted `snapshots.driver` defaults to `apfs` for `darwin-vz`
 - `snapshots.driver: file` copies ext4 images with standard file I/O
 - `snapshots.driver: apfs` uses macOS `clonefile(2)` for same-filesystem APFS copy-on-write clones
 - the selected driver is used for snapshot capture, snapshot-backed sandbox creation, and writable per-run/per-sandbox rootfs preparation

--- a/docs/plans/snapshot-restore-fork.md
+++ b/docs/plans/snapshot-restore-fork.md
@@ -333,7 +333,7 @@ snapshot semantics.
 - [done] snapshot inspect output with stored metadata
 - [todo] guest-cooperative checkpoint request flow
 - [todo] ZFS volume store for Firecracker
-- [todo] APFS volume store for `darwin-vz`
+- [done] APFS volume store for `darwin-vz`
 - [todo] OCI export/import for cross-host distribution
 - [todo] chunked/lazy fleet fan-out
 - [todo] optional same-host machine-state acceleration

--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -33,6 +33,7 @@ import (
 	"github.com/buildkite/cleanroom/internal/volumestore"
 	"github.com/buildkite/cleanroom/internal/vsockexec"
 	"github.com/charmbracelet/log"
+	"golang.org/x/sys/unix"
 )
 
 // Adapter runs single-execution Linux VMs on macOS via Virtualization.framework.
@@ -1429,40 +1430,118 @@ func snapshotStorageBaseDir(cfg backend.FirecrackerConfig) (string, error) {
 }
 
 func rootFSVolumeDriver(cfg backend.FirecrackerConfig) (volumestore.Driver, error) {
+	return newRootFSVolumeDriver(cfg, newDarwinVZFileVolumeDriver, newDarwinVZAPFSVolumeDriver)
+}
+
+type volumeDriverFactory func(string) (volumestore.Driver, error)
+
+func newRootFSVolumeDriver(cfg backend.FirecrackerConfig, newFileDriver, newAPFSDriver volumeDriverFactory) (volumestore.Driver, error) {
 	driverName := strings.ToLower(strings.TrimSpace(cfg.Snapshots.Driver))
+	defaulted := driverName == ""
 	if driverName == "" {
 		driverName = "apfs"
 	}
+	snapshotBaseDir, err := snapshotStorageBaseDir(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("resolve snapshot base directory: %w", err)
+	}
 	switch driverName {
 	case "file":
-		snapshotBaseDir, err := snapshotStorageBaseDir(cfg)
-		if err != nil {
-			return nil, fmt.Errorf("resolve snapshot base directory: %w", err)
-		}
-		driver, err := volumestore.NewFileDriver(volumestore.FileDriverOptions{
-			SnapshotBaseDir: snapshotBaseDir,
-			Namespace:       "darwin-vz",
-		})
+		driver, err := newFileDriver(snapshotBaseDir)
 		if err != nil {
 			return nil, err
 		}
 		return driver, nil
 	case "apfs":
-		snapshotBaseDir, err := snapshotStorageBaseDir(cfg)
-		if err != nil {
-			return nil, fmt.Errorf("resolve snapshot base directory: %w", err)
-		}
-		driver, err := volumestore.NewAPFSDriver(volumestore.APFSDriverOptions{
-			SnapshotBaseDir: snapshotBaseDir,
-			Namespace:       "darwin-vz",
-		})
+		driver, err := newAPFSDriver(snapshotBaseDir)
 		if err != nil {
 			return nil, err
 		}
-		return driver, nil
+		if !defaulted {
+			return driver, nil
+		}
+		fileDriver, err := newFileDriver(snapshotBaseDir)
+		if err != nil {
+			return nil, err
+		}
+		return &fallbackVolumeDriver{
+			primary:        driver,
+			fallback:       fileDriver,
+			shouldFallback: shouldFallbackFromDefaultAPFS,
+		}, nil
 	default:
 		return nil, fmt.Errorf("unsupported darwin-vz snapshot driver %q", cfg.Snapshots.Driver)
 	}
+}
+
+func newDarwinVZFileVolumeDriver(snapshotBaseDir string) (volumestore.Driver, error) {
+	driver, err := volumestore.NewFileDriver(volumestore.FileDriverOptions{
+		SnapshotBaseDir: snapshotBaseDir,
+		Namespace:       "darwin-vz",
+	})
+	if err != nil {
+		return nil, err
+	}
+	return driver, nil
+}
+
+func newDarwinVZAPFSVolumeDriver(snapshotBaseDir string) (volumestore.Driver, error) {
+	driver, err := volumestore.NewAPFSDriver(volumestore.APFSDriverOptions{
+		SnapshotBaseDir: snapshotBaseDir,
+		Namespace:       "darwin-vz",
+	})
+	if err != nil {
+		return nil, err
+	}
+	return driver, nil
+}
+
+func shouldFallbackFromDefaultAPFS(err error) bool {
+	return errors.Is(err, unix.EXDEV) || errors.Is(err, unix.ENOTSUP) || errors.Is(err, unix.ENOSYS)
+}
+
+type fallbackVolumeDriver struct {
+	primary        volumestore.Driver
+	fallback       volumestore.Driver
+	shouldFallback func(error) bool
+}
+
+func (d *fallbackVolumeDriver) Name() string { return d.primary.Name() }
+
+func (d *fallbackVolumeDriver) EnsureBaseVolume(ctx context.Context, req volumestore.EnsureBaseVolumeRequest) (volumestore.BaseVolume, error) {
+	return d.primary.EnsureBaseVolume(ctx, req)
+}
+
+func (d *fallbackVolumeDriver) CreateWritableVolume(ctx context.Context, req volumestore.CreateWritableVolumeRequest) (volumestore.WritableVolume, error) {
+	writable, err := d.primary.CreateWritableVolume(ctx, req)
+	if err == nil || !d.shouldFallback(err) {
+		return writable, err
+	}
+	return d.fallback.CreateWritableVolume(ctx, req)
+}
+
+func (d *fallbackVolumeDriver) SnapshotVolume(ctx context.Context, req volumestore.SnapshotVolumeRequest) (volumestore.Snapshot, error) {
+	snapshot, err := d.primary.SnapshotVolume(ctx, req)
+	if err == nil || !d.shouldFallback(err) {
+		return snapshot, err
+	}
+	return d.fallback.SnapshotVolume(ctx, req)
+}
+
+func (d *fallbackVolumeDriver) CloneSnapshotToVolume(ctx context.Context, req volumestore.CloneSnapshotToVolumeRequest) (volumestore.WritableVolume, error) {
+	volume, err := d.primary.CloneSnapshotToVolume(ctx, req)
+	if err == nil || !d.shouldFallback(err) {
+		return volume, err
+	}
+	return d.fallback.CloneSnapshotToVolume(ctx, req)
+}
+
+func (d *fallbackVolumeDriver) DestroyVolume(ctx context.Context, req volumestore.DestroyVolumeRequest) error {
+	return d.primary.DestroyVolume(ctx, req)
+}
+
+func (d *fallbackVolumeDriver) DestroySnapshot(ctx context.Context, req volumestore.DestroySnapshotRequest) error {
+	return d.primary.DestroySnapshot(ctx, req)
 }
 
 func snapshotVolumeDriver(cfg backend.FirecrackerConfig) (volumestore.Driver, error) {

--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -804,15 +804,32 @@ func (a *Adapter) run(ctx context.Context, req backend.RunRequest, stream backen
 		return nil, fmt.Errorf("rootfs %s: %w", rootFSPath, err)
 	}
 
+	driver, err := rootFSVolumeDriver(req.FirecrackerConfig)
+	if err != nil {
+		return nil, err
+	}
+	baseVolume, err := driver.EnsureBaseVolume(ctx, volumestore.EnsureBaseVolumeRequest{
+		BaseID:     strings.TrimSuffix(filepath.Base(rootFSPath), filepath.Ext(rootFSPath)),
+		SourcePath: rootFSPath,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("prepare base volume: %w", err)
+	}
 	vmRootFSPath := filepath.Join(runDir, "rootfs-ephemeral.ext4")
 	copyStart := time.Now()
-	if err := copyFile(rootFSPath, vmRootFSPath); err != nil {
+	writableVolume, err := driver.CreateWritableVolume(ctx, volumestore.CreateWritableVolumeRequest{
+		VolumeID:       req.RunID,
+		BaseRef:        baseVolume.Ref,
+		AttachmentPath: vmRootFSPath,
+	})
+	if err != nil {
 		observation.Error = err.Error()
 		return nil, fmt.Errorf("prepare per-run rootfs: %w", err)
 	}
+	vmRootFSPath = writableVolume.AttachmentPath
 	observation.RootFSCopyMS = time.Since(copyStart).Milliseconds()
 	defer func() {
-		_ = os.Remove(vmRootFSPath)
+		_ = driver.DestroyVolume(context.Background(), volumestore.DestroyVolumeRequest{VolumeRef: vmRootFSPath})
 	}()
 
 	guestInitPath, guestInitNotice := guestInitExecutableForRootFS(vmRootFSPath)
@@ -1075,11 +1092,28 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 		return nil, fmt.Errorf("rootfs %s: %w", rootFSPath, err)
 	}
 
+	driver, err := rootFSVolumeDriver(cfg)
+	if err != nil {
+		return nil, err
+	}
+	baseVolume, err := driver.EnsureBaseVolume(ctx, volumestore.EnsureBaseVolumeRequest{
+		BaseID:     strings.TrimSuffix(filepath.Base(rootFSPath), filepath.Ext(rootFSPath)),
+		SourcePath: rootFSPath,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("prepare base volume: %w", err)
+	}
 	vmRootFSPath := filepath.Join(runDir, "rootfs-persistent.ext4")
 	copyStart := time.Now()
-	if err := copyFile(rootFSPath, vmRootFSPath); err != nil {
+	writableVolume, err := driver.CreateWritableVolume(ctx, volumestore.CreateWritableVolumeRequest{
+		VolumeID:       sandboxID,
+		BaseRef:        baseVolume.Ref,
+		AttachmentPath: vmRootFSPath,
+	})
+	if err != nil {
 		return nil, fmt.Errorf("prepare persistent rootfs: %w", err)
 	}
+	vmRootFSPath = writableVolume.AttachmentPath
 	rootFSCopyMS := time.Since(copyStart).Milliseconds()
 
 	guestInitPath, _ := guestInitExecutableForRootFS(vmRootFSPath)
@@ -1394,10 +1428,7 @@ func snapshotStorageBaseDir(cfg backend.FirecrackerConfig) (string, error) {
 	return paths.SnapshotDir()
 }
 
-func snapshotVolumeDriver(cfg backend.FirecrackerConfig) (volumestore.Driver, error) {
-	if !cfg.Snapshots.Enabled {
-		return nil, errors.New("darwin-vz snapshots are not enabled")
-	}
+func rootFSVolumeDriver(cfg backend.FirecrackerConfig) (volumestore.Driver, error) {
 	driverName := strings.ToLower(strings.TrimSpace(cfg.Snapshots.Driver))
 	switch driverName {
 	case "", "file":
@@ -1413,9 +1444,29 @@ func snapshotVolumeDriver(cfg backend.FirecrackerConfig) (volumestore.Driver, er
 			return nil, err
 		}
 		return driver, nil
+	case "apfs":
+		snapshotBaseDir, err := snapshotStorageBaseDir(cfg)
+		if err != nil {
+			return nil, fmt.Errorf("resolve snapshot base directory: %w", err)
+		}
+		driver, err := volumestore.NewAPFSDriver(volumestore.APFSDriverOptions{
+			SnapshotBaseDir: snapshotBaseDir,
+			Namespace:       "darwin-vz",
+		})
+		if err != nil {
+			return nil, err
+		}
+		return driver, nil
 	default:
 		return nil, fmt.Errorf("unsupported darwin-vz snapshot driver %q", cfg.Snapshots.Driver)
 	}
+}
+
+func snapshotVolumeDriver(cfg backend.FirecrackerConfig) (volumestore.Driver, error) {
+	if !cfg.Snapshots.Enabled {
+		return nil, errors.New("darwin-vz snapshots are not enabled")
+	}
+	return rootFSVolumeDriver(cfg)
 }
 
 func probeGuestExecReady(ctx context.Context, helper *helperSession, socketPath string) error {

--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -1437,7 +1437,6 @@ type volumeDriverFactory func(string) (volumestore.Driver, error)
 
 func newRootFSVolumeDriver(cfg backend.FirecrackerConfig, newFileDriver, newAPFSDriver volumeDriverFactory) (volumestore.Driver, error) {
 	driverName := strings.ToLower(strings.TrimSpace(cfg.Snapshots.Driver))
-	defaulted := driverName == ""
 	if driverName == "" {
 		driverName = "apfs"
 	}
@@ -1457,9 +1456,6 @@ func newRootFSVolumeDriver(cfg backend.FirecrackerConfig, newFileDriver, newAPFS
 		if err != nil {
 			return nil, err
 		}
-		if !defaulted {
-			return driver, nil
-		}
 		fileDriver, err := newFileDriver(snapshotBaseDir)
 		if err != nil {
 			return nil, err
@@ -1467,7 +1463,7 @@ func newRootFSVolumeDriver(cfg backend.FirecrackerConfig, newFileDriver, newAPFS
 		return &fallbackVolumeDriver{
 			primary:        driver,
 			fallback:       fileDriver,
-			shouldFallback: shouldFallbackFromDefaultAPFS,
+			shouldFallback: shouldFallbackFromAPFS,
 		}, nil
 	default:
 		return nil, fmt.Errorf("unsupported darwin-vz snapshot driver %q", cfg.Snapshots.Driver)
@@ -1496,7 +1492,7 @@ func newDarwinVZAPFSVolumeDriver(snapshotBaseDir string) (volumestore.Driver, er
 	return driver, nil
 }
 
-func shouldFallbackFromDefaultAPFS(err error) bool {
+func shouldFallbackFromAPFS(err error) bool {
 	return errors.Is(err, unix.EXDEV) || errors.Is(err, unix.ENOTSUP) || errors.Is(err, unix.ENOSYS)
 }
 

--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -1430,8 +1430,11 @@ func snapshotStorageBaseDir(cfg backend.FirecrackerConfig) (string, error) {
 
 func rootFSVolumeDriver(cfg backend.FirecrackerConfig) (volumestore.Driver, error) {
 	driverName := strings.ToLower(strings.TrimSpace(cfg.Snapshots.Driver))
+	if driverName == "" {
+		driverName = "apfs"
+	}
 	switch driverName {
-	case "", "file":
+	case "file":
 		snapshotBaseDir, err := snapshotStorageBaseDir(cfg)
 		if err != nil {
 			return nil, fmt.Errorf("resolve snapshot base directory: %w", err)

--- a/internal/backend/darwinvz/snapshot_test.go
+++ b/internal/backend/darwinvz/snapshot_test.go
@@ -194,3 +194,17 @@ func TestSnapshotVolumeDriverRejectsDisabledSnapshots(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestRootFSVolumeDriverAllowsAPFSDriver(t *testing.T) {
+	t.Parallel()
+
+	driver, err := rootFSVolumeDriver(backend.FirecrackerConfig{
+		Snapshots: backend.SnapshotConfig{Driver: "apfs"},
+	})
+	if err != nil {
+		t.Fatalf("rootFSVolumeDriver returned error: %v", err)
+	}
+	if got, want := driver.Name(), "apfs"; got != want {
+		t.Fatalf("unexpected rootfs driver name: got %q want %q", got, want)
+	}
+}

--- a/internal/backend/darwinvz/snapshot_test.go
+++ b/internal/backend/darwinvz/snapshot_test.go
@@ -4,6 +4,7 @@ package darwinvz
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,6 +12,8 @@ import (
 
 	"github.com/buildkite/cleanroom/internal/backend"
 	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/buildkite/cleanroom/internal/volumestore"
+	"golang.org/x/sys/unix"
 )
 
 func TestCreateSnapshotSyncsPausesAndClonesRootFS(t *testing.T) {
@@ -219,4 +222,210 @@ func TestRootFSVolumeDriverDefaultsToAPFSWhenUnset(t *testing.T) {
 	if got, want := driver.Name(), "apfs"; got != want {
 		t.Fatalf("unexpected default rootfs driver name: got %q want %q", got, want)
 	}
+}
+
+func TestRootFSVolumeDriverDefaultedAPFSFallsBackToFileSemantics(t *testing.T) {
+	apfs := &stubVolumeDriver{
+		name:             "apfs",
+		baseVolume:       volumestore.BaseVolume{Ref: "base-ref"},
+		writableErr:      fmt.Errorf("clonefile create writable volume: %w", unix.EXDEV),
+		snapshotErr:      fmt.Errorf("clonefile snapshot volume: %w", unix.ENOTSUP),
+		cloneSnapshotErr: fmt.Errorf("clonefile clone snapshot: %w", unix.ENOSYS),
+	}
+	file := &stubVolumeDriver{
+		name:           "file",
+		baseVolume:     volumestore.BaseVolume{Ref: "base-ref"},
+		writableVolume: volumestore.WritableVolume{Ref: "writable-ref", AttachmentPath: "writable-path"},
+		snapshot:       volumestore.Snapshot{Ref: "snapshot-ref", StorageRef: "snapshot-storage"},
+		clonedVolume:   volumestore.WritableVolume{Ref: "clone-ref", AttachmentPath: "clone-path"},
+	}
+
+	driver, err := newRootFSVolumeDriver(backend.FirecrackerConfig{}, func(string) (volumestore.Driver, error) {
+		return file, nil
+	}, func(string) (volumestore.Driver, error) {
+		return apfs, nil
+	})
+	if err != nil {
+		t.Fatalf("newRootFSVolumeDriver returned error: %v", err)
+	}
+	if got, want := driver.Name(), "apfs"; got != want {
+		t.Fatalf("unexpected default rootfs driver name: got %q want %q", got, want)
+	}
+
+	base, err := driver.EnsureBaseVolume(context.Background(), volumestore.EnsureBaseVolumeRequest{
+		BaseID:     "runtime-key",
+		SourcePath: "/tmp/source.ext4",
+	})
+	if err != nil {
+		t.Fatalf("EnsureBaseVolume returned error: %v", err)
+	}
+	if got, want := base.Ref, "base-ref"; got != want {
+		t.Fatalf("unexpected base ref: got %q want %q", got, want)
+	}
+
+	writable, err := driver.CreateWritableVolume(context.Background(), volumestore.CreateWritableVolumeRequest{
+		VolumeID:       "sandbox-1",
+		BaseRef:        base.Ref,
+		AttachmentPath: "/tmp/writable.ext4",
+	})
+	if err != nil {
+		t.Fatalf("CreateWritableVolume returned error: %v", err)
+	}
+	if got, want := writable.Ref, "writable-ref"; got != want {
+		t.Fatalf("unexpected fallback writable ref: got %q want %q", got, want)
+	}
+
+	snapshot, err := driver.SnapshotVolume(context.Background(), volumestore.SnapshotVolumeRequest{
+		SnapshotID: "snap-1",
+		VolumeRef:  writable.Ref,
+	})
+	if err != nil {
+		t.Fatalf("SnapshotVolume returned error: %v", err)
+	}
+	if got, want := snapshot.Ref, "snapshot-ref"; got != want {
+		t.Fatalf("unexpected fallback snapshot ref: got %q want %q", got, want)
+	}
+
+	clone, err := driver.CloneSnapshotToVolume(context.Background(), volumestore.CloneSnapshotToVolumeRequest{
+		VolumeID:       "sandbox-2",
+		SnapshotRef:    snapshot.Ref,
+		AttachmentPath: "/tmp/clone.ext4",
+	})
+	if err != nil {
+		t.Fatalf("CloneSnapshotToVolume returned error: %v", err)
+	}
+	if got, want := clone.Ref, "clone-ref"; got != want {
+		t.Fatalf("unexpected fallback clone ref: got %q want %q", got, want)
+	}
+
+	if got, want := apfs.ensureBaseCalls, 1; got != want {
+		t.Fatalf("unexpected apfs ensure base call count: got %d want %d", got, want)
+	}
+	if got, want := apfs.writableCalls, 1; got != want {
+		t.Fatalf("unexpected apfs writable call count: got %d want %d", got, want)
+	}
+	if got, want := apfs.snapshotCalls, 1; got != want {
+		t.Fatalf("unexpected apfs snapshot call count: got %d want %d", got, want)
+	}
+	if got, want := apfs.cloneSnapshotCalls, 1; got != want {
+		t.Fatalf("unexpected apfs clone call count: got %d want %d", got, want)
+	}
+	if got, want := file.ensureBaseCalls, 0; got != want {
+		t.Fatalf("unexpected file ensure base call count: got %d want %d", got, want)
+	}
+	if got, want := file.writableCalls, 1; got != want {
+		t.Fatalf("unexpected file writable call count: got %d want %d", got, want)
+	}
+	if got, want := file.snapshotCalls, 1; got != want {
+		t.Fatalf("unexpected file snapshot call count: got %d want %d", got, want)
+	}
+	if got, want := file.cloneSnapshotCalls, 1; got != want {
+		t.Fatalf("unexpected file clone call count: got %d want %d", got, want)
+	}
+}
+
+func TestRootFSVolumeDriverExplicitAPFSDoesNotFallback(t *testing.T) {
+	apfsErr := fmt.Errorf("clonefile create writable volume: %w", unix.EXDEV)
+	apfs := &stubVolumeDriver{
+		name:        "apfs",
+		baseVolume:  volumestore.BaseVolume{Ref: "base-ref"},
+		writableErr: apfsErr,
+	}
+	file := &stubVolumeDriver{
+		name:           "file",
+		baseVolume:     volumestore.BaseVolume{Ref: "base-ref"},
+		writableVolume: volumestore.WritableVolume{Ref: "writable-ref", AttachmentPath: "writable-path"},
+	}
+
+	driver, err := newRootFSVolumeDriver(backend.FirecrackerConfig{
+		Snapshots: backend.SnapshotConfig{Driver: "apfs"},
+	}, func(string) (volumestore.Driver, error) {
+		return file, nil
+	}, func(string) (volumestore.Driver, error) {
+		return apfs, nil
+	})
+	if err != nil {
+		t.Fatalf("newRootFSVolumeDriver returned error: %v", err)
+	}
+
+	base, err := driver.EnsureBaseVolume(context.Background(), volumestore.EnsureBaseVolumeRequest{
+		BaseID:     "runtime-key",
+		SourcePath: "/tmp/source.ext4",
+	})
+	if err != nil {
+		t.Fatalf("EnsureBaseVolume returned error: %v", err)
+	}
+
+	_, err = driver.CreateWritableVolume(context.Background(), volumestore.CreateWritableVolumeRequest{
+		VolumeID:       "sandbox-1",
+		BaseRef:        base.Ref,
+		AttachmentPath: "/tmp/writable.ext4",
+	})
+	if err == nil {
+		t.Fatal("expected explicit apfs driver to return clonefile error")
+	}
+	if err.Error() != apfsErr.Error() {
+		t.Fatalf("unexpected apfs error: got %v want %v", err, apfsErr)
+	}
+	if got, want := file.writableCalls, 0; got != want {
+		t.Fatalf("expected explicit apfs driver to avoid file fallback, got %d file calls", got)
+	}
+}
+
+type stubVolumeDriver struct {
+	name               string
+	baseVolume         volumestore.BaseVolume
+	baseErr            error
+	writableVolume     volumestore.WritableVolume
+	writableErr        error
+	snapshot           volumestore.Snapshot
+	snapshotErr        error
+	clonedVolume       volumestore.WritableVolume
+	cloneSnapshotErr   error
+	ensureBaseCalls    int
+	writableCalls      int
+	snapshotCalls      int
+	cloneSnapshotCalls int
+}
+
+func (d *stubVolumeDriver) Name() string { return d.name }
+
+func (d *stubVolumeDriver) EnsureBaseVolume(context.Context, volumestore.EnsureBaseVolumeRequest) (volumestore.BaseVolume, error) {
+	d.ensureBaseCalls++
+	if d.baseErr != nil {
+		return volumestore.BaseVolume{}, d.baseErr
+	}
+	return d.baseVolume, nil
+}
+
+func (d *stubVolumeDriver) CreateWritableVolume(context.Context, volumestore.CreateWritableVolumeRequest) (volumestore.WritableVolume, error) {
+	d.writableCalls++
+	if d.writableErr != nil {
+		return volumestore.WritableVolume{}, d.writableErr
+	}
+	return d.writableVolume, nil
+}
+
+func (d *stubVolumeDriver) SnapshotVolume(context.Context, volumestore.SnapshotVolumeRequest) (volumestore.Snapshot, error) {
+	d.snapshotCalls++
+	if d.snapshotErr != nil {
+		return volumestore.Snapshot{}, d.snapshotErr
+	}
+	return d.snapshot, nil
+}
+
+func (d *stubVolumeDriver) CloneSnapshotToVolume(context.Context, volumestore.CloneSnapshotToVolumeRequest) (volumestore.WritableVolume, error) {
+	d.cloneSnapshotCalls++
+	if d.cloneSnapshotErr != nil {
+		return volumestore.WritableVolume{}, d.cloneSnapshotErr
+	}
+	return d.clonedVolume, nil
+}
+
+func (*stubVolumeDriver) DestroyVolume(context.Context, volumestore.DestroyVolumeRequest) error {
+	return nil
+}
+
+func (*stubVolumeDriver) DestroySnapshot(context.Context, volumestore.DestroySnapshotRequest) error {
+	return nil
 }

--- a/internal/backend/darwinvz/snapshot_test.go
+++ b/internal/backend/darwinvz/snapshot_test.go
@@ -208,3 +208,15 @@ func TestRootFSVolumeDriverAllowsAPFSDriver(t *testing.T) {
 		t.Fatalf("unexpected rootfs driver name: got %q want %q", got, want)
 	}
 }
+
+func TestRootFSVolumeDriverDefaultsToAPFSWhenUnset(t *testing.T) {
+	t.Parallel()
+
+	driver, err := rootFSVolumeDriver(backend.FirecrackerConfig{})
+	if err != nil {
+		t.Fatalf("rootFSVolumeDriver returned error: %v", err)
+	}
+	if got, want := driver.Name(), "apfs"; got != want {
+		t.Fatalf("unexpected default rootfs driver name: got %q want %q", got, want)
+	}
+}

--- a/internal/backend/darwinvz/snapshot_test.go
+++ b/internal/backend/darwinvz/snapshot_test.go
@@ -324,17 +324,20 @@ func TestRootFSVolumeDriverDefaultedAPFSFallsBackToFileSemantics(t *testing.T) {
 	}
 }
 
-func TestRootFSVolumeDriverExplicitAPFSDoesNotFallback(t *testing.T) {
-	apfsErr := fmt.Errorf("clonefile create writable volume: %w", unix.EXDEV)
+func TestRootFSVolumeDriverExplicitAPFSFallsBackToFileSemantics(t *testing.T) {
 	apfs := &stubVolumeDriver{
-		name:        "apfs",
-		baseVolume:  volumestore.BaseVolume{Ref: "base-ref"},
-		writableErr: apfsErr,
+		name:             "apfs",
+		baseVolume:       volumestore.BaseVolume{Ref: "base-ref"},
+		writableErr:      fmt.Errorf("clonefile create writable volume: %w", unix.EXDEV),
+		snapshotErr:      fmt.Errorf("clonefile snapshot volume: %w", unix.ENOTSUP),
+		cloneSnapshotErr: fmt.Errorf("clonefile clone snapshot: %w", unix.ENOSYS),
 	}
 	file := &stubVolumeDriver{
 		name:           "file",
 		baseVolume:     volumestore.BaseVolume{Ref: "base-ref"},
 		writableVolume: volumestore.WritableVolume{Ref: "writable-ref", AttachmentPath: "writable-path"},
+		snapshot:       volumestore.Snapshot{Ref: "snapshot-ref", StorageRef: "snapshot-storage"},
+		clonedVolume:   volumestore.WritableVolume{Ref: "clone-ref", AttachmentPath: "clone-path"},
 	}
 
 	driver, err := newRootFSVolumeDriver(backend.FirecrackerConfig{
@@ -356,19 +359,58 @@ func TestRootFSVolumeDriverExplicitAPFSDoesNotFallback(t *testing.T) {
 		t.Fatalf("EnsureBaseVolume returned error: %v", err)
 	}
 
-	_, err = driver.CreateWritableVolume(context.Background(), volumestore.CreateWritableVolumeRequest{
+	writable, err := driver.CreateWritableVolume(context.Background(), volumestore.CreateWritableVolumeRequest{
 		VolumeID:       "sandbox-1",
 		BaseRef:        base.Ref,
 		AttachmentPath: "/tmp/writable.ext4",
 	})
-	if err == nil {
-		t.Fatal("expected explicit apfs driver to return clonefile error")
+	if err != nil {
+		t.Fatalf("CreateWritableVolume returned error: %v", err)
 	}
-	if err.Error() != apfsErr.Error() {
-		t.Fatalf("unexpected apfs error: got %v want %v", err, apfsErr)
+	if got, want := writable.Ref, "writable-ref"; got != want {
+		t.Fatalf("unexpected fallback writable ref: got %q want %q", got, want)
 	}
-	if got, want := file.writableCalls, 0; got != want {
-		t.Fatalf("expected explicit apfs driver to avoid file fallback, got %d file calls", got)
+
+	snapshot, err := driver.SnapshotVolume(context.Background(), volumestore.SnapshotVolumeRequest{
+		SnapshotID: "snap-1",
+		VolumeRef:  writable.Ref,
+	})
+	if err != nil {
+		t.Fatalf("SnapshotVolume returned error: %v", err)
+	}
+	if got, want := snapshot.Ref, "snapshot-ref"; got != want {
+		t.Fatalf("unexpected fallback snapshot ref: got %q want %q", got, want)
+	}
+
+	clone, err := driver.CloneSnapshotToVolume(context.Background(), volumestore.CloneSnapshotToVolumeRequest{
+		VolumeID:       "sandbox-2",
+		SnapshotRef:    snapshot.Ref,
+		AttachmentPath: "/tmp/clone.ext4",
+	})
+	if err != nil {
+		t.Fatalf("CloneSnapshotToVolume returned error: %v", err)
+	}
+	if got, want := clone.Ref, "clone-ref"; got != want {
+		t.Fatalf("unexpected fallback clone ref: got %q want %q", got, want)
+	}
+
+	if got, want := apfs.writableCalls, 1; got != want {
+		t.Fatalf("unexpected apfs writable call count: got %d want %d", got, want)
+	}
+	if got, want := apfs.snapshotCalls, 1; got != want {
+		t.Fatalf("unexpected apfs snapshot call count: got %d want %d", got, want)
+	}
+	if got, want := apfs.cloneSnapshotCalls, 1; got != want {
+		t.Fatalf("unexpected apfs clone call count: got %d want %d", got, want)
+	}
+	if got, want := file.writableCalls, 1; got != want {
+		t.Fatalf("unexpected file writable call count: got %d want %d", got, want)
+	}
+	if got, want := file.snapshotCalls, 1; got != want {
+		t.Fatalf("unexpected file snapshot call count: got %d want %d", got, want)
+	}
+	if got, want := file.cloneSnapshotCalls, 1; got != want {
+		t.Fatalf("unexpected file clone call count: got %d want %d", got, want)
 	}
 }
 

--- a/internal/cli/config_init_test.go
+++ b/internal/cli/config_init_test.go
@@ -51,7 +51,7 @@ func TestConfigInitWritesRuntimeConfig(t *testing.T) {
 	if cfg.Backends.Firecracker.Snapshots.Enabled {
 		t.Fatal("expected backends.firecracker.snapshots.enabled to default false")
 	}
-	if got, want := cfg.Backends.DarwinVZ.Snapshots.Driver, "file"; got != want {
+	if got, want := cfg.Backends.DarwinVZ.Snapshots.Driver, "apfs"; got != want {
 		t.Fatalf("expected backends.darwin-vz.snapshots.driver=%q, got %q", want, got)
 	}
 	if cfg.Backends.DarwinVZ.Snapshots.Enabled {
@@ -73,7 +73,10 @@ func TestConfigInitWritesRuntimeConfig(t *testing.T) {
 		t.Fatalf("expected generated config to include disabled snapshot default, got:\n%s", raw)
 	}
 	if !strings.Contains(string(raw), "driver: file") {
-		t.Fatalf("expected generated config to include snapshot driver default, got:\n%s", raw)
+		t.Fatalf("expected generated config to include firecracker snapshot driver default, got:\n%s", raw)
+	}
+	if !strings.Contains(string(raw), "driver: apfs") {
+		t.Fatalf("expected generated config to include darwin-vz snapshot driver default, got:\n%s", raw)
 	}
 	if strings.Contains(string(raw), "base_dir:") {
 		t.Fatalf("expected generated config to omit empty snapshot base_dir, got:\n%s", raw)

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/buildkite/cleanroom/internal/backend"
 	"github.com/buildkite/cleanroom/internal/gateway"
+	"github.com/buildkite/cleanroom/internal/paths"
 	"github.com/buildkite/cleanroom/internal/runtimeconfig"
 )
 
@@ -15,6 +17,13 @@ type DoctorCommand struct {
 	Chdir   string `short:"c" help:"Change to this directory before running commands"`
 	Backend string `help:"Execution backend to diagnose (defaults to runtime config or host default)"`
 	JSON    bool   `help:"Print doctor report as JSON"`
+}
+
+type snapshotDoctorConfig struct {
+	Enabled   bool   `json:"enabled"`
+	Driver    string `json:"driver"`
+	BaseDir   string `json:"base_dir"`
+	Defaulted bool   `json:"defaulted"`
 }
 
 func (d *DoctorCommand) Run(ctx *runtimeContext) error {
@@ -37,26 +46,32 @@ func (d *DoctorCommand) Run(ctx *runtimeContext) error {
 		credSummary = strings.Join(gwHosts, ", ")
 	}
 	routeSummary := strings.Join(gwRoutes, ", ")
+	snapshotCfg, snapshotCheck, hasSnapshotCfg := snapshotDoctorConfigForBackend(backendName, ctx.Config)
 
 	checks := []backend.DoctorCheck{
 		{Name: "runtime_config", Status: "pass", Message: fmt.Sprintf("using runtime config path %s", ctx.ConfigPath)},
 		{Name: "backend", Status: "pass", Message: fmt.Sprintf("selected backend %s", backendName)},
-		{
+	}
+	if hasSnapshotCfg {
+		checks = append(checks, snapshotCheck)
+	}
+	checks = append(checks,
+		backend.DoctorCheck{
 			Name:    "gateway_listen",
 			Status:  "pass",
 			Message: fmt.Sprintf("default listen %s (port %d; override with cleanroom serve --gateway-listen)", gateway.DefaultListenAddr, gateway.DefaultPort),
 		},
-		{
+		backend.DoctorCheck{
 			Name:    "gateway_routes",
 			Status:  "pass",
 			Message: fmt.Sprintf("enabled routes: %s", routeSummary),
 		},
-		{
+		backend.DoctorCheck{
 			Name:    "gateway_credentials",
 			Status:  "pass",
 			Message: fmt.Sprintf("configured credential hosts: %s", credSummary),
 		},
-	}
+	)
 	for _, key := range backend.SortedCapabilityKeys(capabilities) {
 		status := "warn"
 		message := fmt.Sprintf("%s: unsupported", key)
@@ -120,6 +135,9 @@ func (d *DoctorCommand) Run(ctx *runtimeContext) error {
 				"credential_hosts": gwHosts,
 			},
 		}
+		if hasSnapshotCfg {
+			payload["snapshot"] = snapshotCfg
+		}
 		enc := json.NewEncoder(ctx.Stdout)
 		enc.SetIndent("", "  ")
 		return enc.Encode(payload)
@@ -137,6 +155,44 @@ func resolveBackendName(requested, configuredDefault string) string {
 		return configuredDefault
 	}
 	return runtimeconfig.DefaultBackendForHost()
+}
+
+func snapshotDoctorConfigForBackend(backendName string, cfg runtimeconfig.Config) (snapshotDoctorConfig, backend.DoctorCheck, bool) {
+	snapshotCfg, ok := runtimeconfig.SnapshotConfigForBackend(cfg, backendName)
+	if !ok {
+		return snapshotDoctorConfig{}, backend.DoctorCheck{}, false
+	}
+
+	driver := runtimeconfig.SnapshotDriverOrDefault(backendName, snapshotCfg.Driver)
+	defaulted := strings.TrimSpace(snapshotCfg.Driver) == ""
+	baseDir := strings.TrimSpace(snapshotCfg.BaseDir)
+	if baseDir != "" {
+		baseDir = filepath.Clean(baseDir)
+	} else if resolved, err := paths.SnapshotDir(); err == nil {
+		baseDir = resolved
+	} else {
+		baseDir = fmt.Sprintf("<unresolved: %v>", err)
+	}
+
+	info := snapshotDoctorConfig{
+		Enabled:   snapshotCfg.Enabled,
+		Driver:    driver,
+		BaseDir:   baseDir,
+		Defaulted: defaulted,
+	}
+	return info, backend.DoctorCheck{
+		Name:    "snapshot_config",
+		Status:  "pass",
+		Message: formatSnapshotDoctorCheck(info),
+	}, true
+}
+
+func formatSnapshotDoctorCheck(cfg snapshotDoctorConfig) string {
+	driver := cfg.Driver
+	if cfg.Defaulted {
+		driver += " (defaulted)"
+	}
+	return fmt.Sprintf("enabled=%t driver=%s base_dir=%s", cfg.Enabled, driver, cfg.BaseDir)
 }
 
 var capabilityNameReplacer = strings.NewReplacer(".", "_", "-", "_")

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -299,3 +299,109 @@ func TestDoctorCommandHonorsRuntimeSnapshotCapabilityConfig(t *testing.T) {
 		t.Fatal("expected capability_sandbox_snapshot check in doctor output")
 	}
 }
+
+func TestDoctorCommandJSONIncludesEffectiveSnapshotConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", filepath.Join(tmpDir, "state"))
+
+	stdoutPath := filepath.Join(tmpDir, "doctor.json")
+	stdout, err := os.Create(stdoutPath)
+	if err != nil {
+		t.Fatalf("create stdout file: %v", err)
+	}
+
+	cmd := DoctorCommand{
+		Backend: "darwin-vz",
+		JSON:    true,
+	}
+	err = cmd.Run(&runtimeContext{
+		CWD:    tmpDir,
+		Stdout: stdout,
+		Loader: doctorFailingLoader{},
+		Config: runtimeconfig.Config{
+			Backends: runtimeconfig.Backends{
+				DarwinVZ: runtimeconfig.DarwinVZConfig{
+					Snapshots: runtimeconfig.SnapshotConfig{Enabled: true},
+				},
+			},
+		},
+		ConfigPath: filepath.Join(tmpDir, "config.yaml"),
+		Backends: map[string]backend.Adapter{
+			"darwin-vz": doctorSnapshotAdapter{},
+		},
+	})
+	if closeErr := stdout.Close(); closeErr != nil {
+		t.Fatalf("close stdout file: %v", closeErr)
+	}
+	if err != nil {
+		t.Fatalf("DoctorCommand.Run returned error: %v", err)
+	}
+
+	raw, err := os.ReadFile(stdoutPath)
+	if err != nil {
+		t.Fatalf("read doctor output: %v", err)
+	}
+
+	var payload struct {
+		Snapshot struct {
+			Enabled   bool   `json:"enabled"`
+			Driver    string `json:"driver"`
+			BaseDir   string `json:"base_dir"`
+			Defaulted bool   `json:"defaulted"`
+		} `json:"snapshot"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("unmarshal doctor JSON: %v", err)
+	}
+
+	if !payload.Snapshot.Enabled {
+		t.Fatal("expected snapshot config enabled=true")
+	}
+	if got, want := payload.Snapshot.Driver, "apfs"; got != want {
+		t.Fatalf("unexpected effective snapshot driver: got %q want %q", got, want)
+	}
+	if !payload.Snapshot.Defaulted {
+		t.Fatal("expected darwin-vz snapshot driver to be marked defaulted")
+	}
+	if got, want := payload.Snapshot.BaseDir, filepath.Join(tmpDir, "state", "cleanroom", "snapshots"); got != want {
+		t.Fatalf("unexpected effective snapshot base dir: got %q want %q", got, want)
+	}
+}
+
+func TestDoctorCommandTextIncludesEffectiveSnapshotConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", filepath.Join(tmpDir, "state"))
+
+	stdout, readStdout := makeStdoutCapture(t)
+
+	cmd := DoctorCommand{
+		Backend: "darwin-vz",
+	}
+	err := cmd.Run(&runtimeContext{
+		CWD:    tmpDir,
+		Stdout: stdout,
+		Loader: doctorFailingLoader{},
+		Config: runtimeconfig.Config{
+			Backends: runtimeconfig.Backends{
+				DarwinVZ: runtimeconfig.DarwinVZConfig{
+					Snapshots: runtimeconfig.SnapshotConfig{Enabled: false},
+				},
+			},
+		},
+		ConfigPath: filepath.Join(tmpDir, "config.yaml"),
+		Backends: map[string]backend.Adapter{
+			"darwin-vz": doctorSnapshotAdapter{},
+		},
+	})
+	if err != nil {
+		t.Fatalf("DoctorCommand.Run returned error: %v", err)
+	}
+
+	out := readStdout()
+	if !strings.Contains(out, "snapshot_config: enabled=false driver=apfs (defaulted)") {
+		t.Fatalf("expected snapshot config line in doctor output, got: %q", out)
+	}
+	if !strings.Contains(out, filepath.Join(tmpDir, "state", "cleanroom", "snapshots")) {
+		t.Fatalf("expected snapshot base dir in doctor output, got: %q", out)
+	}
+}

--- a/internal/cli/policy_config.go
+++ b/internal/cli/policy_config.go
@@ -149,7 +149,7 @@ func defaultRuntimeConfig(defaultBackend string) runtimeconfig.Config {
 				},
 				Snapshots: runtimeconfig.SnapshotConfig{
 					Enabled: false,
-					Driver:  "file",
+					Driver:  "apfs",
 				},
 				VCPUs:         2,
 				MemoryMiB:     1024,

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -299,7 +299,7 @@ func (s *Service) createSandboxFromSnapshot(ctx context.Context, req *cleanroomv
 	}
 	firecrackerCfg := runtimeconfig.MergeBackendConfig(s.Config, backendName, execOpts.LaunchSeconds)
 	firecrackerCfg.RunDir = ""
-	firecrackerCfg = withSnapshotDriver(firecrackerCfg, record.StorageDriver)
+	firecrackerCfg = withSnapshotDriver(backendName, firecrackerCfg, record.StorageDriver)
 
 	now := s.clock().Now()
 	sandboxID := s.ids().NewSandboxID()
@@ -436,7 +436,7 @@ func (s *Service) CreateSnapshot(ctx context.Context, req *cleanroomv1.CreateSna
 		s.mu.Unlock()
 		return nil, fmt.Errorf("sandbox %q is missing compiled policy", sandboxID)
 	}
-	snapshotCfg := withSnapshotDriver(state.Firecracker, state.Firecracker.Snapshots.Driver)
+	snapshotCfg := withSnapshotDriver(state.Backend, state.Firecracker, state.Firecracker.Snapshots.Driver)
 	record = snapshotstore.Record{
 		SnapshotID:      snapshotID,
 		SourceSandboxID: sandboxID,
@@ -581,7 +581,7 @@ func (s *Service) DeleteSnapshot(ctx context.Context, req *cleanroomv1.DeleteSna
 	if !ok {
 		return nil, fmt.Errorf("backend %q does not support snapshot deletion", record.Backend)
 	}
-	firecrackerCfg := withSnapshotDriver(runtimeconfig.MergeBackendConfig(s.Config, record.Backend, 0), record.StorageDriver)
+	firecrackerCfg := withSnapshotDriver(record.Backend, runtimeconfig.MergeBackendConfig(s.Config, record.Backend, 0), record.StorageDriver)
 	if err := snapshotAdapter.DeleteSnapshot(ctx, backend.DeleteSnapshotRequest{
 		SnapshotID:        snapshotID,
 		StorageRef:        record.StorageRef,
@@ -2116,9 +2116,9 @@ func snapshotOperationsEnabledForBackend(backendName string, cfg runtimeconfig.C
 	return ok && snapshotCfg.Enabled
 }
 
-func withSnapshotDriver(cfg backend.FirecrackerConfig, driver string) backend.FirecrackerConfig {
+func withSnapshotDriver(backendName string, cfg backend.FirecrackerConfig, driver string) backend.FirecrackerConfig {
 	cfg.Snapshots.Enabled = true
-	cfg.Snapshots.Driver = runtimeconfig.SnapshotDriverOrDefault(driver)
+	cfg.Snapshots.Driver = runtimeconfig.SnapshotDriverOrDefault(backendName, driver)
 	return cfg
 }
 func (s *Service) recordSandboxEventLocked(sb *sandboxState, status cleanroomv1.SandboxStatus, message string) {

--- a/internal/runtimeconfig/config.go
+++ b/internal/runtimeconfig/config.go
@@ -67,12 +67,18 @@ func SnapshotConfigForBackend(cfg Config, backendName string) (SnapshotConfig, b
 	}
 }
 
-func SnapshotDriverOrDefault(driver string) string {
+func SnapshotDriverOrDefault(backendName, driver string) string {
 	driver = strings.TrimSpace(driver)
-	if driver == "" {
+	if driver != "" {
+		return driver
+	}
+
+	switch strings.TrimSpace(backendName) {
+	case "darwin-vz":
+		return "apfs"
+	default:
 		return "file"
 	}
-	return driver
 }
 
 func MergeBackendConfig(cfg Config, backendName string, launchSeconds int64) backend.FirecrackerConfig {

--- a/internal/runtimeconfig/config_test.go
+++ b/internal/runtimeconfig/config_test.go
@@ -276,10 +276,13 @@ func TestSnapshotConfigForBackend(t *testing.T) {
 }
 
 func TestSnapshotDriverOrDefault(t *testing.T) {
-	if got, want := SnapshotDriverOrDefault(""), "file"; got != want {
-		t.Fatalf("unexpected default snapshot driver: got %q want %q", got, want)
+	if got, want := SnapshotDriverOrDefault("firecracker", ""), "file"; got != want {
+		t.Fatalf("unexpected firecracker default snapshot driver: got %q want %q", got, want)
 	}
-	if got, want := SnapshotDriverOrDefault(" file "), "file"; got != want {
+	if got, want := SnapshotDriverOrDefault("darwin-vz", ""), "apfs"; got != want {
+		t.Fatalf("unexpected darwin-vz default snapshot driver: got %q want %q", got, want)
+	}
+	if got, want := SnapshotDriverOrDefault("darwin-vz", " file "), "file"; got != want {
 		t.Fatalf("unexpected trimmed snapshot driver: got %q want %q", got, want)
 	}
 }

--- a/internal/volumestore/apfs_darwin.go
+++ b/internal/volumestore/apfs_darwin.go
@@ -1,0 +1,44 @@
+//go:build darwin
+
+package volumestore
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+type APFSDriverOptions struct {
+	SnapshotBaseDir string
+	Namespace       string
+}
+
+type APFSDriver struct {
+	*pathDriver
+}
+
+func NewAPFSDriver(opts APFSDriverOptions) (*APFSDriver, error) {
+	driver, err := newPathDriver("apfs", opts.SnapshotBaseDir, opts.Namespace, cloneFile)
+	if err != nil {
+		return nil, err
+	}
+	return &APFSDriver{pathDriver: driver}, nil
+}
+
+func cloneFile(src, dst string) error {
+	if err := unix.Clonefile(src, dst, 0); err != nil {
+		return fmt.Errorf("clonefile %q -> %q: %w", src, dst, err)
+	}
+
+	out, err := os.Open(dst)
+	if err != nil {
+		return fmt.Errorf("open cloned file %q: %w", dst, err)
+	}
+	defer out.Close()
+
+	if err := out.Sync(); err != nil {
+		return fmt.Errorf("sync cloned file %q: %w", dst, err)
+	}
+	return nil
+}

--- a/internal/volumestore/apfs_darwin.go
+++ b/internal/volumestore/apfs_darwin.go
@@ -27,6 +27,9 @@ func NewAPFSDriver(opts APFSDriverOptions) (*APFSDriver, error) {
 }
 
 func cloneFile(src, dst string) error {
+	if err := os.Remove(dst); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove existing clone target %q: %w", dst, err)
+	}
 	if err := unix.Clonefile(src, dst, 0); err != nil {
 		return fmt.Errorf("clonefile %q -> %q: %w", src, dst, err)
 	}

--- a/internal/volumestore/apfs_test.go
+++ b/internal/volumestore/apfs_test.go
@@ -1,0 +1,125 @@
+//go:build darwin
+
+package volumestore
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestAPFSDriverWritableVolumeLifecycle(t *testing.T) {
+	driver, err := NewAPFSDriver(APFSDriverOptions{
+		SnapshotBaseDir: t.TempDir(),
+		Namespace:       "darwin-vz",
+	})
+	if err != nil {
+		skipIfClonefileUnsupported(t, err)
+		t.Fatalf("NewAPFSDriver returned error: %v", err)
+	}
+
+	sourcePath := filepath.Join(t.TempDir(), "prepared.ext4")
+	if err := os.WriteFile(sourcePath, []byte("base-bytes"), 0o644); err != nil {
+		t.Fatalf("write source volume: %v", err)
+	}
+
+	base, err := driver.EnsureBaseVolume(context.Background(), EnsureBaseVolumeRequest{
+		BaseID:     "runtime-key",
+		SourcePath: sourcePath,
+	})
+	if err != nil {
+		t.Fatalf("EnsureBaseVolume returned error: %v", err)
+	}
+
+	volume, err := driver.CreateWritableVolume(context.Background(), CreateWritableVolumeRequest{
+		VolumeID:       "sandbox-1",
+		BaseRef:        base.Ref,
+		AttachmentPath: filepath.Join(t.TempDir(), "sandbox-1.ext4"),
+	})
+	if err != nil {
+		skipIfClonefileUnsupported(t, err)
+		t.Fatalf("CreateWritableVolume returned error: %v", err)
+	}
+	if got, want := volume.AttachmentPath, volume.Ref; got != want {
+		t.Fatalf("unexpected writable attachment path: got %q want %q", got, want)
+	}
+	data, err := os.ReadFile(volume.AttachmentPath)
+	if err != nil {
+		t.Fatalf("read writable volume: %v", err)
+	}
+	if got, want := string(data), "base-bytes"; got != want {
+		t.Fatalf("unexpected writable volume contents: got %q want %q", got, want)
+	}
+
+	if err := driver.DestroyVolume(context.Background(), DestroyVolumeRequest{VolumeRef: volume.Ref}); err != nil {
+		t.Fatalf("DestroyVolume returned error: %v", err)
+	}
+	if _, err := os.Stat(volume.Ref); !os.IsNotExist(err) {
+		t.Fatalf("expected writable volume to be removed, got %v", err)
+	}
+}
+
+func TestAPFSDriverSnapshotLifecycle(t *testing.T) {
+	snapshotBaseDir := t.TempDir()
+	driver, err := NewAPFSDriver(APFSDriverOptions{
+		SnapshotBaseDir: snapshotBaseDir,
+		Namespace:       "darwin-vz",
+	})
+	if err != nil {
+		skipIfClonefileUnsupported(t, err)
+		t.Fatalf("NewAPFSDriver returned error: %v", err)
+	}
+
+	volumePath := filepath.Join(t.TempDir(), "sandbox.ext4")
+	if err := os.WriteFile(volumePath, []byte("snapshot-bytes"), 0o644); err != nil {
+		t.Fatalf("write volume: %v", err)
+	}
+
+	snapshot, err := driver.SnapshotVolume(context.Background(), SnapshotVolumeRequest{
+		SnapshotID: "snap-1",
+		VolumeRef:  volumePath,
+	})
+	if err != nil {
+		skipIfClonefileUnsupported(t, err)
+		t.Fatalf("SnapshotVolume returned error: %v", err)
+	}
+	if got, want := snapshot.StorageRef, filepath.Join(snapshotBaseDir, "darwin-vz", "snap-1", "rootfs.ext4"); got != want {
+		t.Fatalf("unexpected snapshot storage ref: got %q want %q", got, want)
+	}
+
+	clone, err := driver.CloneSnapshotToVolume(context.Background(), CloneSnapshotToVolumeRequest{
+		VolumeID:       "sandbox-2",
+		SnapshotRef:    snapshot.Ref,
+		AttachmentPath: filepath.Join(t.TempDir(), "sandbox-2.ext4"),
+	})
+	if err != nil {
+		skipIfClonefileUnsupported(t, err)
+		t.Fatalf("CloneSnapshotToVolume returned error: %v", err)
+	}
+	data, err := os.ReadFile(clone.AttachmentPath)
+	if err != nil {
+		t.Fatalf("read cloned volume: %v", err)
+	}
+	if got, want := string(data), "snapshot-bytes"; got != want {
+		t.Fatalf("unexpected cloned volume contents: got %q want %q", got, want)
+	}
+
+	if err := driver.DestroySnapshot(context.Background(), DestroySnapshotRequest{SnapshotRef: snapshot.Ref}); err != nil {
+		t.Fatalf("DestroySnapshot returned error: %v", err)
+	}
+	if _, err := os.Stat(snapshot.Ref); !os.IsNotExist(err) {
+		t.Fatalf("expected snapshot to be removed, got %v", err)
+	}
+}
+
+func skipIfClonefileUnsupported(t *testing.T, err error) {
+	t.Helper()
+
+	if errors.Is(err, unix.ENOTSUP) || errors.Is(err, unix.ENOSYS) {
+		t.Skipf("clonefile is not supported on this filesystem: %v", err)
+	}
+}

--- a/internal/volumestore/apfs_test.go
+++ b/internal/volumestore/apfs_test.go
@@ -116,6 +116,55 @@ func TestAPFSDriverSnapshotLifecycle(t *testing.T) {
 	}
 }
 
+func TestAPFSDriverCreateWritableVolumeOverwritesExistingDestination(t *testing.T) {
+	driver, err := NewAPFSDriver(APFSDriverOptions{
+		SnapshotBaseDir: t.TempDir(),
+		Namespace:       "darwin-vz",
+	})
+	if err != nil {
+		skipIfClonefileUnsupported(t, err)
+		t.Fatalf("NewAPFSDriver returned error: %v", err)
+	}
+
+	sourcePath := filepath.Join(t.TempDir(), "prepared.ext4")
+	if err := os.WriteFile(sourcePath, []byte("fresh-bytes"), 0o644); err != nil {
+		t.Fatalf("write source volume: %v", err)
+	}
+
+	base, err := driver.EnsureBaseVolume(context.Background(), EnsureBaseVolumeRequest{
+		BaseID:     "runtime-key",
+		SourcePath: sourcePath,
+	})
+	if err != nil {
+		t.Fatalf("EnsureBaseVolume returned error: %v", err)
+	}
+
+	attachmentPath := filepath.Join(t.TempDir(), "sandbox-1.ext4")
+	if err := os.WriteFile(attachmentPath, []byte("stale-bytes"), 0o644); err != nil {
+		t.Fatalf("write stale attachment: %v", err)
+	}
+
+	volume, err := driver.CreateWritableVolume(context.Background(), CreateWritableVolumeRequest{
+		VolumeID:       "sandbox-1",
+		BaseRef:        base.Ref,
+		AttachmentPath: attachmentPath,
+	})
+	if err != nil {
+		skipIfClonefileUnsupported(t, err)
+		t.Fatalf("CreateWritableVolume returned error: %v", err)
+	}
+	if got, want := volume.AttachmentPath, attachmentPath; got != want {
+		t.Fatalf("unexpected writable attachment path: got %q want %q", got, want)
+	}
+	data, err := os.ReadFile(attachmentPath)
+	if err != nil {
+		t.Fatalf("read writable volume: %v", err)
+	}
+	if got, want := string(data), "fresh-bytes"; got != want {
+		t.Fatalf("unexpected overwritten writable volume contents: got %q want %q", got, want)
+	}
+}
+
 func skipIfClonefileUnsupported(t *testing.T, err error) {
 	t.Helper()
 

--- a/internal/volumestore/apfs_unsupported.go
+++ b/internal/volumestore/apfs_unsupported.go
@@ -1,0 +1,16 @@
+//go:build !darwin
+
+package volumestore
+
+import "errors"
+
+type APFSDriverOptions struct {
+	SnapshotBaseDir string
+	Namespace       string
+}
+
+type APFSDriver struct{}
+
+func NewAPFSDriver(APFSDriverOptions) (*APFSDriver, error) {
+	return nil, errors.New("apfs volume driver is darwin-only")
+}

--- a/internal/volumestore/driver_benchmark_test.go
+++ b/internal/volumestore/driver_benchmark_test.go
@@ -1,0 +1,139 @@
+//go:build darwin
+
+package volumestore
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const benchmarkVolumeBytes = 256 * 1024 * 1024
+
+func BenchmarkDarwinSnapshotDrivers(b *testing.B) {
+	drivers := map[string]func(string) (Driver, error){
+		"file": func(snapshotBaseDir string) (Driver, error) {
+			return NewFileDriver(FileDriverOptions{
+				SnapshotBaseDir: snapshotBaseDir,
+				Namespace:       "darwin-vz",
+			})
+		},
+		"apfs": func(snapshotBaseDir string) (Driver, error) {
+			return NewAPFSDriver(APFSDriverOptions{
+				SnapshotBaseDir: snapshotBaseDir,
+				Namespace:       "darwin-vz",
+			})
+		},
+	}
+
+	for driverName, factory := range drivers {
+		driverName := driverName
+		factory := factory
+		b.Run(driverName, func(b *testing.B) {
+			workDir := b.TempDir()
+			snapshotBaseDir := filepath.Join(workDir, "snapshots")
+			driver, err := factory(snapshotBaseDir)
+			if err != nil {
+				b.Fatalf("create %s driver: %v", driverName, err)
+			}
+
+			sourcePath := filepath.Join(workDir, "source.ext4")
+			writeBenchmarkVolume(b, sourcePath, benchmarkVolumeBytes)
+
+			b.Run("snapshot", func(b *testing.B) {
+				benchmarkSnapshotVolume(b, driver, sourcePath, benchmarkVolumeBytes)
+			})
+			b.Run("clone", func(b *testing.B) {
+				benchmarkCloneSnapshotToVolume(b, driver, sourcePath, benchmarkVolumeBytes)
+			})
+		})
+	}
+}
+
+func benchmarkSnapshotVolume(b *testing.B, driver Driver, volumePath string, size int64) {
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.SetBytes(size)
+
+	for i := 0; i < b.N; i++ {
+		snapshotID := fmt.Sprintf("snapshot-%d", i)
+		b.StartTimer()
+		snapshot, err := driver.SnapshotVolume(ctx, SnapshotVolumeRequest{
+			SnapshotID: snapshotID,
+			VolumeRef:  volumePath,
+		})
+		b.StopTimer()
+		if err != nil {
+			b.Fatalf("SnapshotVolume(%q): %v", snapshotID, err)
+		}
+		if err := driver.DestroySnapshot(ctx, DestroySnapshotRequest{SnapshotRef: snapshot.Ref}); err != nil {
+			b.Fatalf("DestroySnapshot(%q): %v", snapshotID, err)
+		}
+	}
+}
+
+func benchmarkCloneSnapshotToVolume(b *testing.B, driver Driver, volumePath string, size int64) {
+	ctx := context.Background()
+	snapshot, err := driver.SnapshotVolume(ctx, SnapshotVolumeRequest{
+		SnapshotID: "bench-snapshot",
+		VolumeRef:  volumePath,
+	})
+	if err != nil {
+		b.Fatalf("prepare clone benchmark snapshot: %v", err)
+	}
+	defer func() {
+		if err := driver.DestroySnapshot(ctx, DestroySnapshotRequest{SnapshotRef: snapshot.Ref}); err != nil {
+			b.Fatalf("cleanup clone benchmark snapshot: %v", err)
+		}
+	}()
+
+	b.ReportAllocs()
+	b.SetBytes(size)
+
+	for i := 0; i < b.N; i++ {
+		attachmentPath := filepath.Join(b.TempDir(), fmt.Sprintf("clone-%d.ext4", i))
+		b.StartTimer()
+		volume, err := driver.CloneSnapshotToVolume(ctx, CloneSnapshotToVolumeRequest{
+			VolumeID:       fmt.Sprintf("volume-%d", i),
+			SnapshotRef:    snapshot.Ref,
+			AttachmentPath: attachmentPath,
+		})
+		b.StopTimer()
+		if err != nil {
+			b.Fatalf("CloneSnapshotToVolume(%q): %v", attachmentPath, err)
+		}
+		if err := driver.DestroyVolume(ctx, DestroyVolumeRequest{VolumeRef: volume.Ref}); err != nil {
+			b.Fatalf("DestroyVolume(%q): %v", volume.Ref, err)
+		}
+	}
+}
+
+func writeBenchmarkVolume(b *testing.B, path string, size int64) {
+	b.Helper()
+
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o644)
+	if err != nil {
+		b.Fatalf("create benchmark volume %q: %v", path, err)
+	}
+	defer f.Close()
+
+	chunk := make([]byte, 1024*1024)
+	for i := range chunk {
+		chunk[i] = byte(i)
+	}
+
+	for written := int64(0); written < size; written += int64(len(chunk)) {
+		n := int64(len(chunk))
+		if remaining := size - written; remaining < n {
+			n = remaining
+		}
+		if _, err := f.Write(chunk[:int(n)]); err != nil {
+			b.Fatalf("write benchmark volume %q: %v", path, err)
+		}
+	}
+	if err := f.Sync(); err != nil {
+		b.Fatalf("sync benchmark volume %q: %v", path, err)
+	}
+}

--- a/internal/volumestore/file.go
+++ b/internal/volumestore/file.go
@@ -16,114 +16,15 @@ type FileDriverOptions struct {
 }
 
 type FileDriver struct {
-	snapshotBaseDir string
-	namespace       string
+	*pathDriver
 }
 
 func NewFileDriver(opts FileDriverOptions) (*FileDriver, error) {
-	baseDir := strings.TrimSpace(opts.SnapshotBaseDir)
-	if baseDir == "" {
-		return nil, errors.New("file volume driver requires snapshot base dir")
-	}
-	namespace := strings.TrimSpace(opts.Namespace)
-	if namespace == "" {
-		return nil, errors.New("file volume driver requires namespace")
-	}
-	return &FileDriver{
-		snapshotBaseDir: filepath.Clean(baseDir),
-		namespace:       namespace,
-	}, nil
-}
-
-func (d *FileDriver) Name() string { return "file" }
-
-func (d *FileDriver) EnsureBaseVolume(_ context.Context, req EnsureBaseVolumeRequest) (BaseVolume, error) {
-	sourcePath := strings.TrimSpace(req.SourcePath)
-	if sourcePath == "" {
-		return BaseVolume{}, errors.New("file volume driver requires source path")
-	}
-	resolved, err := filepath.Abs(sourcePath)
+	driver, err := newPathDriver("file", opts.SnapshotBaseDir, opts.Namespace, copyFile)
 	if err != nil {
-		return BaseVolume{}, fmt.Errorf("resolve base volume source %q: %w", sourcePath, err)
+		return nil, err
 	}
-	if _, err := os.Stat(resolved); err != nil {
-		return BaseVolume{}, fmt.Errorf("inspect base volume source %q: %w", resolved, err)
-	}
-	return BaseVolume{Ref: resolved}, nil
-}
-
-func (d *FileDriver) CreateWritableVolume(_ context.Context, req CreateWritableVolumeRequest) (WritableVolume, error) {
-	return d.copyToWritable(req.BaseRef, req.AttachmentPath)
-}
-
-func (d *FileDriver) SnapshotVolume(_ context.Context, req SnapshotVolumeRequest) (Snapshot, error) {
-	volumeRef := strings.TrimSpace(req.VolumeRef)
-	if volumeRef == "" {
-		return Snapshot{}, errors.New("file volume driver requires volume ref")
-	}
-	snapshotID := strings.TrimSpace(req.SnapshotID)
-	if snapshotID == "" {
-		return Snapshot{}, errors.New("file volume driver requires snapshot id")
-	}
-	target := filepath.Join(d.snapshotBaseDir, d.namespace, snapshotID, "rootfs.ext4")
-	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
-		return Snapshot{}, fmt.Errorf("create snapshot directory %q: %w", filepath.Dir(target), err)
-	}
-	if err := copyFile(volumeRef, target); err != nil {
-		_ = os.Remove(target)
-		return Snapshot{}, fmt.Errorf("copy snapshot volume %q: %w", volumeRef, err)
-	}
-	return Snapshot{Ref: target, StorageRef: target}, nil
-}
-
-func (d *FileDriver) CloneSnapshotToVolume(_ context.Context, req CloneSnapshotToVolumeRequest) (WritableVolume, error) {
-	return d.copyToWritable(req.SnapshotRef, req.AttachmentPath)
-}
-
-func (d *FileDriver) DestroyVolume(_ context.Context, req DestroyVolumeRequest) error {
-	volumeRef := strings.TrimSpace(req.VolumeRef)
-	if volumeRef == "" {
-		return nil
-	}
-	if err := os.Remove(volumeRef); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("remove volume %q: %w", volumeRef, err)
-	}
-	return nil
-}
-
-func (d *FileDriver) DestroySnapshot(_ context.Context, req DestroySnapshotRequest) error {
-	snapshotRef := strings.TrimSpace(req.SnapshotRef)
-	if snapshotRef == "" {
-		return nil
-	}
-	if err := os.Remove(snapshotRef); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("remove snapshot %q: %w", snapshotRef, err)
-	}
-	if dir := filepath.Dir(snapshotRef); dir != "" {
-		_ = os.Remove(dir)
-	}
-	return nil
-}
-
-func (d *FileDriver) copyToWritable(sourceRef, attachmentPath string) (WritableVolume, error) {
-	sourceRef = strings.TrimSpace(sourceRef)
-	if sourceRef == "" {
-		return WritableVolume{}, errors.New("file volume driver requires source ref")
-	}
-	attachmentPath = strings.TrimSpace(attachmentPath)
-	if attachmentPath == "" {
-		return WritableVolume{}, errors.New("file volume driver requires attachment path")
-	}
-	if err := os.MkdirAll(filepath.Dir(attachmentPath), 0o755); err != nil {
-		return WritableVolume{}, fmt.Errorf("create writable volume directory %q: %w", filepath.Dir(attachmentPath), err)
-	}
-	if err := copyFile(sourceRef, attachmentPath); err != nil {
-		return WritableVolume{}, fmt.Errorf("copy writable volume from %q: %w", sourceRef, err)
-	}
-	return WritableVolume{
-		Ref:            attachmentPath,
-		AttachmentPath: attachmentPath,
-	}, nil
+	return &FileDriver{pathDriver: driver}, nil
 }
 
 func copyFile(src, dst string) error {
@@ -144,4 +45,122 @@ func copyFile(src, dst string) error {
 		return err
 	}
 	return out.Sync()
+}
+
+type pathDriver struct {
+	name            string
+	snapshotBaseDir string
+	namespace       string
+	copyFn          func(string, string) error
+}
+
+func newPathDriver(name, snapshotBaseDir, namespace string, copyFn func(string, string) error) (*pathDriver, error) {
+	baseDir := strings.TrimSpace(snapshotBaseDir)
+	if baseDir == "" {
+		return nil, fmt.Errorf("%s volume driver requires snapshot base dir", name)
+	}
+	namespace = strings.TrimSpace(namespace)
+	if namespace == "" {
+		return nil, fmt.Errorf("%s volume driver requires namespace", name)
+	}
+	if copyFn == nil {
+		return nil, fmt.Errorf("%s volume driver requires copy function", name)
+	}
+	return &pathDriver{
+		name:            name,
+		snapshotBaseDir: filepath.Clean(baseDir),
+		namespace:       namespace,
+		copyFn:          copyFn,
+	}, nil
+}
+
+func (d *pathDriver) Name() string { return d.name }
+
+func (d *pathDriver) EnsureBaseVolume(_ context.Context, req EnsureBaseVolumeRequest) (BaseVolume, error) {
+	sourcePath := strings.TrimSpace(req.SourcePath)
+	if sourcePath == "" {
+		return BaseVolume{}, fmt.Errorf("%s volume driver requires source path", d.name)
+	}
+	resolved, err := filepath.Abs(sourcePath)
+	if err != nil {
+		return BaseVolume{}, fmt.Errorf("resolve base volume source %q: %w", sourcePath, err)
+	}
+	if _, err := os.Stat(resolved); err != nil {
+		return BaseVolume{}, fmt.Errorf("inspect base volume source %q: %w", resolved, err)
+	}
+	return BaseVolume{Ref: resolved}, nil
+}
+
+func (d *pathDriver) CreateWritableVolume(_ context.Context, req CreateWritableVolumeRequest) (WritableVolume, error) {
+	return d.copyToWritable(req.BaseRef, req.AttachmentPath)
+}
+
+func (d *pathDriver) SnapshotVolume(_ context.Context, req SnapshotVolumeRequest) (Snapshot, error) {
+	volumeRef := strings.TrimSpace(req.VolumeRef)
+	if volumeRef == "" {
+		return Snapshot{}, fmt.Errorf("%s volume driver requires volume ref", d.name)
+	}
+	snapshotID := strings.TrimSpace(req.SnapshotID)
+	if snapshotID == "" {
+		return Snapshot{}, fmt.Errorf("%s volume driver requires snapshot id", d.name)
+	}
+	target := filepath.Join(d.snapshotBaseDir, d.namespace, snapshotID, "rootfs.ext4")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		return Snapshot{}, fmt.Errorf("create snapshot directory %q: %w", filepath.Dir(target), err)
+	}
+	if err := d.copyFn(volumeRef, target); err != nil {
+		_ = os.Remove(target)
+		return Snapshot{}, fmt.Errorf("copy snapshot volume %q: %w", volumeRef, err)
+	}
+	return Snapshot{Ref: target, StorageRef: target}, nil
+}
+
+func (d *pathDriver) CloneSnapshotToVolume(_ context.Context, req CloneSnapshotToVolumeRequest) (WritableVolume, error) {
+	return d.copyToWritable(req.SnapshotRef, req.AttachmentPath)
+}
+
+func (d *pathDriver) DestroyVolume(_ context.Context, req DestroyVolumeRequest) error {
+	volumeRef := strings.TrimSpace(req.VolumeRef)
+	if volumeRef == "" {
+		return nil
+	}
+	if err := os.Remove(volumeRef); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove volume %q: %w", volumeRef, err)
+	}
+	return nil
+}
+
+func (d *pathDriver) DestroySnapshot(_ context.Context, req DestroySnapshotRequest) error {
+	snapshotRef := strings.TrimSpace(req.SnapshotRef)
+	if snapshotRef == "" {
+		return nil
+	}
+	if err := os.Remove(snapshotRef); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove snapshot %q: %w", snapshotRef, err)
+	}
+	if dir := filepath.Dir(snapshotRef); dir != "" {
+		_ = os.Remove(dir)
+	}
+	return nil
+}
+
+func (d *pathDriver) copyToWritable(sourceRef, attachmentPath string) (WritableVolume, error) {
+	sourceRef = strings.TrimSpace(sourceRef)
+	if sourceRef == "" {
+		return WritableVolume{}, fmt.Errorf("%s volume driver requires source ref", d.name)
+	}
+	attachmentPath = strings.TrimSpace(attachmentPath)
+	if attachmentPath == "" {
+		return WritableVolume{}, fmt.Errorf("%s volume driver requires attachment path", d.name)
+	}
+	if err := os.MkdirAll(filepath.Dir(attachmentPath), 0o755); err != nil {
+		return WritableVolume{}, fmt.Errorf("create writable volume directory %q: %w", filepath.Dir(attachmentPath), err)
+	}
+	if err := d.copyFn(sourceRef, attachmentPath); err != nil {
+		return WritableVolume{}, fmt.Errorf("copy writable volume from %q: %w", sourceRef, err)
+	}
+	return WritableVolume{
+		Ref:            attachmentPath,
+		AttachmentPath: attachmentPath,
+	}, nil
 }


### PR DESCRIPTION
## Summary
- add a darwin-only `apfs` volume driver backed by `clonefile(2)` for snapshot storage operations
- route `darwin-vz` writable rootfs preparation through the volume-store driver so `apfs` accelerates both snapshot capture and snapshot-backed sandbox creation
- default `darwin-vz` snapshot storage to `apfs` when the driver is omitted, and have `cleanroom config init` write `backends.darwin-vz.snapshots.driver: apfs`
- keep `file` as the default driver for Firecracker, add darwin-focused tests and benchmark coverage, and update the darwin-vz docs

## Benchmarks
Environment:
- host: `darwin/arm64` (`Apple M5`)
- workload: `256 MiB` ext4 image
- command: `go test -run '^$' -bench BenchmarkDarwinSnapshotDrivers -benchmem -benchtime=5x ./internal/volumestore`

Results:

| Benchmark | file | apfs | Speedup |
| --- | ---: | ---: | ---: |
| snapshot | `173.45 ms/op` | `3.78 ms/op` | `45.9x` |
| clone | `238.69 ms/op` | `4.60 ms/op` | `51.8x` |

## Testing
- `go test ./internal/volumestore`
- `go test ./internal/backend/darwinvz`
- `go test ./internal/runtimeconfig ./internal/cli ./internal/controlservice ./internal/backend/darwinvz`
- `go test ./...`
- `go vet ./...`
- `./scripts/build-go.sh`