### PR TITLE
fix: prevent Firecracker e2e hangs on sandbox file download

### DIFF
--- a/scripts/ci-cleanroom-e2e.sh
+++ b/scripts/ci-cleanroom-e2e.sh
@@ -246,6 +246,7 @@ mise exec -- go run ./scripts/download_sandbox_file \
   --host "$listen_endpoint" \
   --sandbox-id "$sandbox_id" \
   --path /tmp/persist.txt \
+  --timeout 45s \
   --max-bytes 4096 >"$tmpdir/persist-download.out"
 if ! grep -q '^persisted-data$' "$tmpdir/persist-download.out"; then
   echo "expected downloaded sandbox file contents" >&2

--- a/scripts/ci_cleanroom_e2e_test.go
+++ b/scripts/ci_cleanroom_e2e_test.go
@@ -18,3 +18,16 @@ func TestCiCleanroomE2EUsesNonInteractiveSudo(t *testing.T) {
 		t.Fatalf("expected ci-cleanroom-e2e.sh to use non-interactive sudo (-n)")
 	}
 }
+
+func TestCiCleanroomE2EDownloadSandboxFileProbeUsesTimeout(t *testing.T) {
+	t.Helper()
+
+	content, err := os.ReadFile("ci-cleanroom-e2e.sh")
+	if err != nil {
+		t.Fatalf("read ci-cleanroom-e2e.sh: %v", err)
+	}
+
+	if !strings.Contains(string(content), "--timeout 45s") {
+		t.Fatalf("expected ci-cleanroom-e2e.sh to bound download_sandbox_file calls with --timeout")
+	}
+}

--- a/scripts/download_sandbox_file/main.go
+++ b/scripts/download_sandbox_file/main.go
@@ -2,16 +2,20 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/buildkite/cleanroom/internal/controlclient"
 	"github.com/buildkite/cleanroom/internal/endpoint"
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
 	"github.com/buildkite/cleanroom/internal/tlsconfig"
 )
+
+const defaultRequestTimeout = 45 * time.Second
 
 func main() {
 	var (
@@ -20,6 +24,7 @@ func main() {
 		sandboxID string
 		path      string
 		maxBytes  int64
+		timeout   time.Duration
 	)
 
 	flag.StringVar(&host, "host", "", "Control-plane endpoint")
@@ -27,6 +32,7 @@ func main() {
 	flag.StringVar(&sandboxID, "sandbox-id", "", "Sandbox ID")
 	flag.StringVar(&path, "path", "", "Absolute guest path to download")
 	flag.Int64Var(&maxBytes, "max-bytes", 10*1024*1024, "Maximum bytes to download")
+	flag.DurationVar(&timeout, "timeout", defaultRequestTimeout, "Request timeout (0 disables timeout)")
 	flag.Parse()
 
 	if strings.TrimSpace(host) == "" {
@@ -37,6 +43,9 @@ func main() {
 	}
 	if strings.TrimSpace(path) == "" {
 		fail("missing --path")
+	}
+	if timeout < 0 {
+		fail("invalid --timeout: must be >= 0")
 	}
 
 	ep, err := endpoint.Resolve(host)
@@ -50,17 +59,30 @@ func main() {
 		fail("create control client: %v", err)
 	}
 
-	resp, err := client.DownloadSandboxFile(context.Background(), &cleanroomv1.DownloadSandboxFileRequest{
+	ctx, cancel := requestContext(timeout)
+	defer cancel()
+
+	resp, err := client.DownloadSandboxFile(ctx, &cleanroomv1.DownloadSandboxFileRequest{
 		SandboxId: sandboxID,
 		Path:      path,
 		MaxBytes:  maxBytes,
 	})
 	if err != nil {
+		if timeout > 0 && errors.Is(err, context.DeadlineExceeded) {
+			fail("download sandbox file timed out after %s: %v", timeout, err)
+		}
 		fail("download sandbox file: %v", err)
 	}
 	if _, err := os.Stdout.Write(resp.GetData()); err != nil {
 		fail("write download payload: %v", err)
 	}
+}
+
+func requestContext(timeout time.Duration) (context.Context, context.CancelFunc) {
+	if timeout <= 0 {
+		return context.Background(), func() {}
+	}
+	return context.WithTimeout(context.Background(), timeout)
 }
 
 func fail(format string, args ...any) {

--- a/scripts/download_sandbox_file/main_test.go
+++ b/scripts/download_sandbox_file/main_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRequestContextAddsDeadlineWhenTimeoutPositive(t *testing.T) {
+	t.Helper()
+
+	const timeout = 200 * time.Millisecond
+	ctx, cancel := requestContext(timeout)
+	defer cancel()
+
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatalf("expected request context with timeout %s to set a deadline", timeout)
+	}
+
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		t.Fatalf("expected deadline to be in the future, got remaining=%s", remaining)
+	}
+	if remaining > timeout+200*time.Millisecond {
+		t.Fatalf("expected deadline close to timeout %s, got remaining=%s", timeout, remaining)
+	}
+}
+
+func TestRequestContextDisablesDeadlineWhenTimeoutZero(t *testing.T) {
+	t.Helper()
+
+	ctx, cancel := requestContext(0)
+	defer cancel()
+
+	if _, ok := ctx.Deadline(); ok {
+		t.Fatalf("expected timeout=0 to disable request deadline")
+	}
+}


### PR DESCRIPTION
## Summary
- add a timeout guard to the Firecracker e2e persistent sandbox download probe (`--timeout 45s`)
- teach `scripts/download_sandbox_file` to use a bounded request context instead of `context.Background()`
- add regression tests for script timeout wiring and helper request-context timeout behaviour

## Context
Buildkite `:fire: E2E (Firecracker)` in build 445 can stall after printing `persisted-data` during the persistent sandbox lifecycle section because the sandbox file download RPC had no deadline.

## Testing
- `go test ./scripts/... -count=1`
- `shellcheck -x scripts/ci-cleanroom-e2e.sh`
