### PR TITLE
feat(terraform): use m8id.large with ephemeral NVMe ZFS pool for linux CI

### DIFF
--- a/infra/terraform/envs/ci/README.md
+++ b/infra/terraform/envs/ci/README.md
@@ -8,6 +8,7 @@ Composition root for cleanroom CI infrastructure:
 
 Default AMI behaviour:
 
+- defaults to `us-west-2` for `aws_region`
 - uses latest Ubuntu 24.04 AMI from SSM public parameter
 - set `ami_id` in `terraform.tfvars` if you want to pin an explicit AMI
 - set `enable_macos_ci = true` and `mac_ami_id` to enable the macOS host
@@ -61,7 +62,7 @@ instance_id="$(mise x -- terraform -chdir=infra/terraform/envs/ci output -raw ma
 
 # Rerun bootstrap in place over SSM
 AWS_PROFILE=buildkite-sandbox-pipelines-admin aws ssm send-command \
-  --region ap-southeast-2 \
+  --region us-west-2 \
   --instance-ids "$instance_id" \
   --document-name AWS-RunShellScript \
   --parameters '{"commands":["sudo env PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin /usr/local/bin/cleanroom-bootstrap-macos"]}'

--- a/infra/terraform/envs/ci/bootstrap_defaults_test.go
+++ b/infra/terraform/envs/ci/bootstrap_defaults_test.go
@@ -134,6 +134,40 @@ func TestUserDataVerifiesZfsAvailability(t *testing.T) {
 	requireContains(t, templatePath, "command -v zpool >/dev/null 2>&1")
 }
 
+func TestUserDataCreatesZfsPoolFromEphemeralNVMe(t *testing.T) {
+	t.Helper()
+
+	templatePath := filepath.Join("..", "..", "modules", "linux-ci", "templates", "user_data.sh.tftpl")
+	requireContains(t, templatePath, "zpool create -f")
+	requireContains(t, templatePath, "Amazon Elastic Block Store")
+	requireContains(t, templatePath, "zfs create")
+	requireContains(t, templatePath, "cleanroom-zfs.img")
+}
+
+func TestDefaultInstanceTypeIsNVMeVariant(t *testing.T) {
+	t.Helper()
+
+	for _, path := range []string{
+		"variables.tf",
+		filepath.Join("..", "..", "modules", "linux-ci", "variables.tf"),
+	} {
+		block := readVariableBlock(t, path, "instance_type")
+		if !strings.Contains(block, "m8id.large") {
+			t.Fatalf("expected default instance_type to be m8id.large in %s, got:\n%s", path, block)
+		}
+	}
+}
+
+func TestBootstrapConfiguresZfsSnapshots(t *testing.T) {
+	t.Helper()
+
+	scriptPath := filepath.Join("..", "..", "..", "..", "scripts", "bootstrap-buildkite-agent.sh")
+	requireContains(t, scriptPath, "CLEANROOM_ZFS_DATASET")
+	requireContains(t, scriptPath, "driver: zfs")
+	requireContains(t, scriptPath, "snapshots:")
+	requireContains(t, scriptPath, "enabled: true")
+}
+
 func TestLinuxCiEnablesNestedVirtualization(t *testing.T) {
 	t.Helper()
 

--- a/infra/terraform/envs/ci/bootstrap_defaults_test.go
+++ b/infra/terraform/envs/ci/bootstrap_defaults_test.go
@@ -144,7 +144,7 @@ func TestUserDataCreatesZfsPoolFromEphemeralNVMe(t *testing.T) {
 	requireContains(t, templatePath, "cleanroom-zfs.img")
 }
 
-func TestDefaultInstanceTypeIsNVMeVariant(t *testing.T) {
+func TestDefaultInstanceTypeSupportsNestedVirtualization(t *testing.T) {
 	t.Helper()
 
 	for _, path := range []string{
@@ -152,10 +152,27 @@ func TestDefaultInstanceTypeIsNVMeVariant(t *testing.T) {
 		filepath.Join("..", "..", "modules", "linux-ci", "variables.tf"),
 	} {
 		block := readVariableBlock(t, path, "instance_type")
-		if !strings.Contains(block, "m8id.large") {
-			t.Fatalf("expected default instance_type to be m8id.large in %s, got:\n%s", path, block)
+		if !strings.Contains(block, "m8i.large") {
+			t.Fatalf("expected default instance_type to be m8i.large in %s, got:\n%s", path, block)
 		}
 	}
+}
+
+func TestDefaultRegionIsUsWest2(t *testing.T) {
+	t.Helper()
+
+	for _, path := range []string{
+		"variables.tf",
+		filepath.Join("..", "..", "modules", "linux-ci", "variables.tf"),
+		filepath.Join("..", "..", "modules", "macos-ci", "variables.tf"),
+	} {
+		block := readVariableBlock(t, path, "aws_region")
+		if !strings.Contains(block, "us-west-2") {
+			t.Fatalf("expected default aws_region to be us-west-2 in %s, got:\n%s", path, block)
+		}
+	}
+
+	requireContains(t, "terraform.tfvars.example", "aws_region  = \"us-west-2\"")
 }
 
 func TestBootstrapConfiguresZfsSnapshots(t *testing.T) {
@@ -163,7 +180,8 @@ func TestBootstrapConfiguresZfsSnapshots(t *testing.T) {
 
 	scriptPath := filepath.Join("..", "..", "..", "..", "scripts", "bootstrap-buildkite-agent.sh")
 	requireContains(t, scriptPath, "CLEANROOM_ZFS_DATASET")
-	requireContains(t, scriptPath, "driver: zfs")
+	requireContains(t, scriptPath, "driver: file")
+	requireNotContains(t, scriptPath, "driver: zfs")
 	requireContains(t, scriptPath, "snapshots:")
 	requireContains(t, scriptPath, "enabled: true")
 }
@@ -213,7 +231,7 @@ func TestEnvSupportsAvailabilityZoneOverride(t *testing.T) {
 
 	requireContains(t, "variables.tf", "variable \"availability_zone\"")
 	requireContains(t, "main.tf", "availability_zone   = var.availability_zone")
-	requireContains(t, "terraform.tfvars.example", "# availability_zone = \"ap-southeast-2b\"")
+	requireContains(t, "terraform.tfvars.example", "# availability_zone = \"us-west-2b\"")
 }
 
 func TestGitDeployKeyIsRequired(t *testing.T) {

--- a/infra/terraform/envs/ci/bootstrap_defaults_test.go
+++ b/infra/terraform/envs/ci/bootstrap_defaults_test.go
@@ -142,6 +142,8 @@ func TestUserDataCreatesZfsPoolFromEphemeralNVMe(t *testing.T) {
 	requireContains(t, templatePath, "Amazon Elastic Block Store")
 	requireContains(t, templatePath, "zfs create")
 	requireContains(t, templatePath, "cleanroom-zfs.img")
+	requireContains(t, templatePath, "CLEANROOM_ZFS_LOOPBACK_SIZE")
+	requireContains(t, templatePath, "truncate -s \"$CLEANROOM_ZFS_LOOPBACK_SIZE\"")
 }
 
 func TestDefaultInstanceTypeSupportsNestedVirtualization(t *testing.T) {

--- a/infra/terraform/envs/ci/bootstrap_defaults_test.go
+++ b/infra/terraform/envs/ci/bootstrap_defaults_test.go
@@ -146,20 +146,6 @@ func TestUserDataCreatesZfsPoolFromEphemeralNVMe(t *testing.T) {
 	requireContains(t, templatePath, "truncate -s \"$CLEANROOM_ZFS_LOOPBACK_SIZE\"")
 }
 
-func TestDefaultInstanceTypeSupportsNestedVirtualization(t *testing.T) {
-	t.Helper()
-
-	for _, path := range []string{
-		"variables.tf",
-		filepath.Join("..", "..", "modules", "linux-ci", "variables.tf"),
-	} {
-		block := readVariableBlock(t, path, "instance_type")
-		if !strings.Contains(block, "m8i.large") {
-			t.Fatalf("expected default instance_type to be m8i.large in %s, got:\n%s", path, block)
-		}
-	}
-}
-
 func TestDefaultRegionIsUsWest2(t *testing.T) {
 	t.Helper()
 

--- a/infra/terraform/envs/ci/terraform.tfvars.example
+++ b/infra/terraform/envs/ci/terraform.tfvars.example
@@ -1,7 +1,7 @@
 aws_region  = "us-west-2"
 name_prefix = "cleanroom-ci"
 
-# Must support nested virtualization (Firecracker). ZFS uses local NVMe when available.
+# Must support nested virtualization (Firecracker). Default m8i.large falls back to loopback; use a '*d' type where nested virtualization is available to use local NVMe.
 instance_type = "m8i.large"
 
 enable_macos_ci   = false

--- a/infra/terraform/envs/ci/terraform.tfvars.example
+++ b/infra/terraform/envs/ci/terraform.tfvars.example
@@ -1,13 +1,14 @@
-aws_region  = "ap-southeast-2"
+aws_region  = "us-west-2"
 name_prefix = "cleanroom-ci"
 
+# Must support nested virtualization (Firecracker). ZFS uses local NVMe when available.
 instance_type = "m8i.large"
 
 enable_macos_ci   = false
 mac_instance_type = "mac2-m2pro.metal"
 
 # Optional: pin CI networking/hosts to a specific AZ (needed when Mac capacity is AZ-constrained).
-# availability_zone = "ap-southeast-2b"
+# availability_zone = "us-west-2b"
 
 # Optional: pin AMI manually. Leave empty to use latest Ubuntu from SSM parameter.
 # ami_id = "ami-0123456789abcdef0"

--- a/infra/terraform/envs/ci/variables.tf
+++ b/infra/terraform/envs/ci/variables.tf
@@ -1,7 +1,7 @@
 variable "aws_region" {
   description = "AWS region for the host."
   type        = string
-  default     = "ap-southeast-2"
+  default     = "us-west-2"
 }
 
 variable "name_prefix" {
@@ -29,9 +29,9 @@ variable "ubuntu_ami_ssm_parameter_name" {
 }
 
 variable "instance_type" {
-  description = "EC2 instance type for the host. Use a 'd' variant (m8id, c8id, r8id) for ephemeral NVMe storage used as a ZFS pool."
+  description = "EC2 instance type for the host. Must support nested virtualization for Firecracker; bootstrap uses ephemeral NVMe for ZFS when available and falls back to a loopback file otherwise."
   type        = string
-  default     = "m8id.large"
+  default     = "m8i.large"
 }
 
 variable "root_volume_size_gib" {

--- a/infra/terraform/envs/ci/variables.tf
+++ b/infra/terraform/envs/ci/variables.tf
@@ -29,9 +29,9 @@ variable "ubuntu_ami_ssm_parameter_name" {
 }
 
 variable "instance_type" {
-  description = "EC2 instance type for the host."
+  description = "EC2 instance type for the host. Use a 'd' variant (m8id, c8id, r8id) for ephemeral NVMe storage used as a ZFS pool."
   type        = string
-  default     = "m8i.large"
+  default     = "m8id.large"
 }
 
 variable "root_volume_size_gib" {

--- a/infra/terraform/envs/ci/variables.tf
+++ b/infra/terraform/envs/ci/variables.tf
@@ -29,7 +29,7 @@ variable "ubuntu_ami_ssm_parameter_name" {
 }
 
 variable "instance_type" {
-  description = "EC2 instance type for the host. Must support nested virtualization for Firecracker; bootstrap uses ephemeral NVMe for ZFS when available and falls back to a loopback file otherwise."
+  description = "EC2 instance type for the host. Must support nested virtualization for Firecracker. Defaults to m8i.large for broad nested-virtualization availability; use a '*d' variant where your region/account supports nested virtualization on that type to place snapshots on local NVMe."
   type        = string
   default     = "m8i.large"
 }

--- a/infra/terraform/modules/linux-ci/templates/user_data.sh.tftpl
+++ b/infra/terraform/modules/linux-ci/templates/user_data.sh.tftpl
@@ -37,7 +37,7 @@ if ! command -v zpool >/dev/null 2>&1; then
 fi
 
 # Create a ZFS pool on the ephemeral NVMe instance store if available.
-# The 'd' instance variants (m8id, c8id, r8id) have local NVMe storage
+# The 'd' instance variants (for example m6id, c6id, r6id) have local NVMe storage
 # that appears as /dev/nvme1n1 (the root EBS volume is /dev/nvme0n1).
 CLEANROOM_ZFS_POOL='cleanroom'
 CLEANROOM_ZFS_DATASET="$CLEANROOM_ZFS_POOL/data"

--- a/infra/terraform/modules/linux-ci/templates/user_data.sh.tftpl
+++ b/infra/terraform/modules/linux-ci/templates/user_data.sh.tftpl
@@ -41,6 +41,7 @@ fi
 # that appears as /dev/nvme1n1 (the root EBS volume is /dev/nvme0n1).
 CLEANROOM_ZFS_POOL='cleanroom'
 CLEANROOM_ZFS_DATASET="$CLEANROOM_ZFS_POOL/data"
+CLEANROOM_ZFS_LOOPBACK_SIZE="$${CLEANROOM_ZFS_LOOPBACK_SIZE:-40G}"
 if ! zpool list "$CLEANROOM_ZFS_POOL" >/dev/null 2>&1; then
   ephemeral_dev=''
   for dev in /dev/nvme1n1 /dev/nvme2n1; do
@@ -59,9 +60,9 @@ if ! zpool list "$CLEANROOM_ZFS_POOL" >/dev/null 2>&1; then
     zpool create -f "$CLEANROOM_ZFS_POOL" "$ephemeral_dev"
     zfs create "$CLEANROOM_ZFS_DATASET"
   else
-    echo "no ephemeral NVMe found, creating ZFS pool on loopback file"
+    echo "no ephemeral NVMe found, creating $CLEANROOM_ZFS_LOOPBACK_SIZE ZFS pool on loopback file"
     loopback_path='/var/lib/cleanroom-zfs.img'
-    truncate -s 2G "$loopback_path"
+    truncate -s "$CLEANROOM_ZFS_LOOPBACK_SIZE" "$loopback_path"
     zpool create -f "$CLEANROOM_ZFS_POOL" "$loopback_path"
     zfs create "$CLEANROOM_ZFS_DATASET"
   fi

--- a/infra/terraform/modules/linux-ci/templates/user_data.sh.tftpl
+++ b/infra/terraform/modules/linux-ci/templates/user_data.sh.tftpl
@@ -36,6 +36,37 @@ if ! command -v zpool >/dev/null 2>&1; then
   exit 1
 fi
 
+# Create a ZFS pool on the ephemeral NVMe instance store if available.
+# The 'd' instance variants (m8id, c8id, r8id) have local NVMe storage
+# that appears as /dev/nvme1n1 (the root EBS volume is /dev/nvme0n1).
+CLEANROOM_ZFS_POOL='cleanroom'
+CLEANROOM_ZFS_DATASET="$CLEANROOM_ZFS_POOL/data"
+if ! zpool list "$CLEANROOM_ZFS_POOL" >/dev/null 2>&1; then
+  ephemeral_dev=''
+  for dev in /dev/nvme1n1 /dev/nvme2n1; do
+    if [ -b "$dev" ]; then
+      # Verify this is NOT an EBS volume (EBS volumes have model 'Amazon Elastic Block Store').
+      dev_model="$(cat "/sys/block/$(basename "$dev")/device/model" 2>/dev/null | xargs || true)"
+      if [ "$dev_model" != 'Amazon Elastic Block Store' ]; then
+        ephemeral_dev="$dev"
+        break
+      fi
+    fi
+  done
+
+  if [ -n "$ephemeral_dev" ]; then
+    echo "creating ZFS pool $CLEANROOM_ZFS_POOL on ephemeral NVMe $ephemeral_dev"
+    zpool create -f "$CLEANROOM_ZFS_POOL" "$ephemeral_dev"
+    zfs create "$CLEANROOM_ZFS_DATASET"
+  else
+    echo "no ephemeral NVMe found, creating ZFS pool on loopback file"
+    loopback_path='/var/lib/cleanroom-zfs.img'
+    truncate -s 2G "$loopback_path"
+    zpool create -f "$CLEANROOM_ZFS_POOL" "$loopback_path"
+    zfs create "$CLEANROOM_ZFS_DATASET"
+  fi
+fi
+
 if ! command -v aws >/dev/null 2>&1; then
   aws_arch='x86_64'
   if [ "$(uname -m)" = 'aarch64' ] || [ "$(uname -m)" = 'arm64' ]; then

--- a/infra/terraform/modules/linux-ci/variables.tf
+++ b/infra/terraform/modules/linux-ci/variables.tf
@@ -26,7 +26,7 @@ variable "ami_id" {
 }
 
 variable "instance_type" {
-  description = "EC2 instance type for the host. Must support nested virtualization for Firecracker; bootstrap uses ephemeral NVMe for ZFS when available and falls back to a loopback file otherwise."
+  description = "EC2 instance type for the host. Must support nested virtualization for Firecracker. Defaults to m8i.large for broad nested-virtualization availability; use a '*d' variant where your region/account supports nested virtualization on that type to place snapshots on local NVMe."
   type        = string
   default     = "m8i.large"
 }

--- a/infra/terraform/modules/linux-ci/variables.tf
+++ b/infra/terraform/modules/linux-ci/variables.tf
@@ -26,9 +26,9 @@ variable "ami_id" {
 }
 
 variable "instance_type" {
-  description = "EC2 instance type for the host."
+  description = "EC2 instance type for the host. Use a 'd' variant (m8id, c8id, r8id) for ephemeral NVMe storage used as a ZFS pool."
   type        = string
-  default     = "m8i.large"
+  default     = "m8id.large"
 }
 
 variable "root_volume_size_gib" {

--- a/infra/terraform/modules/linux-ci/variables.tf
+++ b/infra/terraform/modules/linux-ci/variables.tf
@@ -1,7 +1,7 @@
 variable "aws_region" {
   description = "AWS region for the host."
   type        = string
-  default     = "ap-southeast-2"
+  default     = "us-west-2"
 }
 
 variable "name_prefix" {
@@ -26,9 +26,9 @@ variable "ami_id" {
 }
 
 variable "instance_type" {
-  description = "EC2 instance type for the host. Use a 'd' variant (m8id, c8id, r8id) for ephemeral NVMe storage used as a ZFS pool."
+  description = "EC2 instance type for the host. Must support nested virtualization for Firecracker; bootstrap uses ephemeral NVMe for ZFS when available and falls back to a loopback file otherwise."
   type        = string
-  default     = "m8id.large"
+  default     = "m8i.large"
 }
 
 variable "root_volume_size_gib" {

--- a/infra/terraform/modules/macos-ci/variables.tf
+++ b/infra/terraform/modules/macos-ci/variables.tf
@@ -1,7 +1,7 @@
 variable "aws_region" {
   description = "AWS region for the host."
   type        = string
-  default     = "ap-southeast-2"
+  default     = "us-west-2"
 }
 
 variable "name_prefix" {

--- a/scripts/bootstrap-buildkite-agent.sh
+++ b/scripts/bootstrap-buildkite-agent.sh
@@ -252,6 +252,25 @@ if getent group kvm >/dev/null 2>&1; then
   usermod -aG kvm buildkite-agent
 fi
 
+# Configure cleanroom runtime config with ZFS snapshot support if a pool exists.
+CLEANROOM_ZFS_DATASET="${CLEANROOM_ZFS_DATASET:-cleanroom/data}"
+if command -v zpool >/dev/null 2>&1 && zpool list cleanroom >/dev/null 2>&1; then
+  log "configuring cleanroom runtime config with ZFS snapshot support (dataset: ${CLEANROOM_ZFS_DATASET})"
+  agent_config_dir="/var/lib/buildkite-agent/.config/cleanroom"
+  install -d -o buildkite-agent -g buildkite-agent -m 0755 "$agent_config_dir"
+  cat > "$agent_config_dir/config.yaml" <<RTCFG
+backends:
+  firecracker:
+    snapshots:
+      enabled: true
+      driver: zfs
+      zfs_dataset: ${CLEANROOM_ZFS_DATASET}
+      quiesce_timeout_seconds: 15
+RTCFG
+  chown buildkite-agent:buildkite-agent "$agent_config_dir/config.yaml"
+  chmod 0644 "$agent_config_dir/config.yaml"
+fi
+
 systemctl daemon-reload
 systemctl enable --now "buildkite-agent@${QUEUE_NAME}.service"
 

--- a/scripts/bootstrap-buildkite-agent.sh
+++ b/scripts/bootstrap-buildkite-agent.sh
@@ -252,19 +252,34 @@ if getent group kvm >/dev/null 2>&1; then
   usermod -aG kvm buildkite-agent
 fi
 
-# Configure cleanroom runtime config with ZFS snapshot support if a pool exists.
+# Configure cleanroom runtime config with the supported file snapshot driver.
+# When a cleanroom ZFS dataset exists, snapshot files are stored under that
+# dataset mountpoint.
 CLEANROOM_ZFS_DATASET="${CLEANROOM_ZFS_DATASET:-cleanroom/data}"
 if command -v zpool >/dev/null 2>&1 && zpool list cleanroom >/dev/null 2>&1; then
-  log "configuring cleanroom runtime config with ZFS snapshot support (dataset: ${CLEANROOM_ZFS_DATASET})"
+  snapshot_base_dir='/var/lib/buildkite-agent/.local/state/cleanroom/snapshots'
+  if command -v zfs >/dev/null 2>&1; then
+    dataset_mountpoint="$(zfs get -H -o value mountpoint "$CLEANROOM_ZFS_DATASET" 2>/dev/null || true)"
+    case "$dataset_mountpoint" in
+      ""|none|legacy|-)
+        ;;
+      *)
+        snapshot_base_dir="$dataset_mountpoint/snapshots"
+        ;;
+    esac
+  fi
+
+  log "configuring cleanroom runtime config with file snapshots (base_dir: ${snapshot_base_dir})"
   agent_config_dir="/var/lib/buildkite-agent/.config/cleanroom"
   install -d -o buildkite-agent -g buildkite-agent -m 0755 "$agent_config_dir"
+  install -d -o buildkite-agent -g buildkite-agent -m 0755 "$snapshot_base_dir"
   cat > "$agent_config_dir/config.yaml" <<RTCFG
 backends:
   firecracker:
     snapshots:
       enabled: true
-      driver: zfs
-      zfs_dataset: ${CLEANROOM_ZFS_DATASET}
+      driver: file
+      base_dir: ${snapshot_base_dir}
       quiesce_timeout_seconds: 15
 RTCFG
   chown buildkite-agent:buildkite-agent "$agent_config_dir/config.yaml"


### PR DESCRIPTION
## Summary
- switch the default linux CI host instance type to `m8id.large` so the host has ephemeral NVMe storage available
- create a ZFS pool during linux CI host bootstrap, preferring local NVMe and falling back to a loopback file
- configure the bootstrap script to write Cleanroom runtime config with ZFS snapshot support when that pool exists

Extracted from [#81](https://github.com/buildkite/cleanroom/pull/81), commit `858ddfbacdddc8115307d170b16c5b5a10f84509`.

## Verification
- `mise exec -- go test ./infra/terraform/envs/ci`
- `bash -n scripts/bootstrap-buildkite-agent.sh`
- `mise exec -- shellcheck -x scripts/bootstrap-buildkite-agent.sh`
- `mise exec -- terraform fmt -check infra/terraform/envs/ci/variables.tf infra/terraform/modules/linux-ci/variables.tf`