### PR TITLE
feat: add firecracker zfs snapshot driver

### DIFF
--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -202,6 +202,7 @@ type SnapshotConfig struct {
 	Enabled               bool
 	Driver                string
 	BaseDir               string
+	ZFSDataset            string
 	QuiesceTimeoutSeconds int64
 }
 

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -91,7 +91,9 @@ type sandboxInstance struct {
 	exitErr        error
 	exitReady      bool
 	cleanupNetwork func()
+	cleanupVolume  func()
 	vmRootFSPath   string
+	volumeRef      string
 }
 
 const runObservabilityFile = "run-observability.json"
@@ -515,9 +517,14 @@ func (a *Adapter) CreateSnapshot(ctx context.Context, req backend.SnapshotReques
 		}
 	}()
 
+	volumeRef := snapshotVolumeRef(instance)
+	if volumeRef == "" {
+		return nil, fmt.Errorf("sandbox %q has no snapshot-capable rootfs volume", sandboxID)
+	}
+
 	snapshot, err := driver.SnapshotVolume(ctx, volumestore.SnapshotVolumeRequest{
 		SnapshotID: snapshotID,
-		VolumeRef:  instance.vmRootFSPath,
+		VolumeRef:  volumeRef,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("persist snapshot rootfs: %w", err)
@@ -766,6 +773,39 @@ func (a *Adapter) Doctor(_ context.Context, req backend.DoctorRequest) (*backend
 				appendCheck("network_helper_capabilities", "pass", fmt.Sprintf("helper capabilities: %s", strings.Join(caps, ", ")))
 			}
 		}
+	}
+
+	snapshotDriver := strings.ToLower(strings.TrimSpace(req.FirecrackerConfig.Snapshots.Driver))
+	switch snapshotDriver {
+	case "", "file":
+		appendCheck("snapshot_driver", "pass", "using snapshot driver \"file\"")
+	case "zfs":
+		appendCheck("snapshot_driver", "pass", "using snapshot driver \"zfs\"")
+		dataset := strings.TrimSpace(req.FirecrackerConfig.Snapshots.ZFSDataset)
+		if dataset == "" {
+			appendCheck("snapshot_zfs_dataset", "fail", "zfs snapshot driver requires snapshots.zfs_dataset")
+		} else {
+			appendCheck("snapshot_zfs_dataset", "pass", fmt.Sprintf("configured zfs dataset %q", dataset))
+		}
+
+		if path, err := lookPathWithFallback("zfs", "/usr/sbin/zfs", "/sbin/zfs"); err != nil {
+			appendCheck("snapshot_zfs_binary", "fail", fmt.Sprintf("zfs command not available: %v", err))
+		} else {
+			appendCheck("snapshot_zfs_binary", "pass", fmt.Sprintf("found zfs command %q", path))
+		}
+
+		if dataset != "" {
+			out, err := runRootCommandOutput(context.Background(), req.FirecrackerConfig, "zfs", "list", "-H", "-o", "name", dataset)
+			if err != nil {
+				appendCheck("snapshot_zfs_dataset_access", "fail", fmt.Sprintf("unable to access zfs dataset %q: %v", dataset, err))
+			} else if strings.TrimSpace(string(out)) != dataset {
+				appendCheck("snapshot_zfs_dataset_access", "fail", fmt.Sprintf("zfs dataset probe for %q returned %q", dataset, strings.TrimSpace(string(out))))
+			} else {
+				appendCheck("snapshot_zfs_dataset_access", "pass", fmt.Sprintf("zfs dataset %q is accessible", dataset))
+			}
+		}
+	default:
+		appendCheck("snapshot_driver", "fail", fmt.Sprintf("unsupported snapshot driver %q", req.FirecrackerConfig.Snapshots.Driver))
 	}
 
 	if err := runRootCommand(context.Background(), req.FirecrackerConfig, "true"); err != nil {
@@ -1504,37 +1544,20 @@ func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID strin
 		return nil, err
 	}
 
-	rootfsPath, err := filepath.Abs(sourceRootFSPath)
-	if err != nil {
-		return nil, err
-	}
-	if _, err := os.Stat(rootfsPath); err != nil {
-		return nil, fmt.Errorf("rootfs %s: %w", rootfsPath, err)
-	}
-
 	driver, err := rootFSVolumeStoreDriver(cfg)
 	if err != nil {
 		return nil, err
 	}
-	baseVolume, err := driver.EnsureBaseVolume(ctx, volumestore.EnsureBaseVolumeRequest{
-		BaseID:     strings.TrimSuffix(filepath.Base(rootfsPath), filepath.Ext(rootfsPath)),
-		SourcePath: rootfsPath,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("prepare base volume: %w", err)
-	}
-
-	writableVolume, err := driver.CreateWritableVolume(ctx, volumestore.CreateWritableVolumeRequest{
-		VolumeID:       sandboxID,
-		BaseRef:        baseVolume.Ref,
-		AttachmentPath: filepath.Join(runDir, "rootfs-persistent.ext4"),
-	})
+	writableVolume, err := preparePersistentWritableVolume(ctx, driver, sandboxID, runDir, sourceRootFSPath)
 	if err != nil {
 		return nil, fmt.Errorf("prepare persistent rootfs: %w", err)
 	}
 	vmRootFSPath := writableVolume.AttachmentPath
 	if err := ext4image.EnsureMinimumSize(ctx, vmRootFSPath, cfg.MinimumRootFSBytes); err != nil {
 		return nil, fmt.Errorf("resize persistent rootfs: %w", err)
+	}
+	cleanupVolume := func() {
+		_ = driver.DestroyVolume(context.Background(), volumestore.DestroyVolumeRequest{VolumeRef: writableVolume.Ref})
 	}
 
 	networkRunCommand := func(ctx context.Context, args ...string) error {
@@ -1552,14 +1575,14 @@ func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID strin
 	}
 	networkCfg, cleanupNetwork, err := setupHostNetwork(ctx, sandboxID, compiled.Allow, gwPort, networkRunCommand, networkRunBatch)
 	if err != nil {
-		_ = os.Remove(vmRootFSPath)
+		cleanupVolume()
 		return nil, fmt.Errorf("setup host network: %w", err)
 	}
 
 	if a.GatewayRegistry != nil {
 		if err := a.GatewayRegistry.Register(networkCfg.GuestIP, sandboxID, compiled); err != nil {
 			cleanupNetwork()
-			_ = os.Remove(vmRootFSPath)
+			cleanupVolume()
 			return nil, fmt.Errorf("register sandbox in gateway: %w", err)
 		}
 	}
@@ -1569,7 +1592,7 @@ func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID strin
 			a.GatewayRegistry.Release(networkCfg.GuestIP)
 		}
 		cleanupNetwork()
-		_ = os.Remove(vmRootFSPath)
+		cleanupVolume()
 	}
 
 	vsockPath := filepath.Join(runDir, "vsock.sock")
@@ -1654,7 +1677,9 @@ func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID strin
 		fcCmd:          fcCmd,
 		exitedCh:       make(chan struct{}),
 		cleanupNetwork: cleanupNetwork,
+		cleanupVolume:  cleanupVolume,
 		vmRootFSPath:   vmRootFSPath,
+		volumeRef:      writableVolume.Ref,
 	}
 	go func() {
 		err := fcCmd.Wait()
@@ -1691,11 +1716,70 @@ func sandboxRuntimeBaseDir() (string, error) {
 	return filepath.Join(base, "sandboxes"), nil
 }
 
+func preparePersistentWritableVolume(ctx context.Context, driver volumestore.Driver, sandboxID, runDir, sourceRef string) (volumestore.WritableVolume, error) {
+	sourceRef = strings.TrimSpace(sourceRef)
+	if sourceRef == "" {
+		return volumestore.WritableVolume{}, errors.New("missing persistent rootfs source")
+	}
+
+	attachmentPath := filepath.Join(runDir, "rootfs-persistent.ext4")
+	if filepath.IsAbs(sourceRef) {
+		rootfsPath, err := filepath.Abs(sourceRef)
+		if err != nil {
+			return volumestore.WritableVolume{}, err
+		}
+		if _, err := os.Stat(rootfsPath); err != nil {
+			return volumestore.WritableVolume{}, fmt.Errorf("rootfs %s: %w", rootfsPath, err)
+		}
+
+		baseVolume, err := driver.EnsureBaseVolume(ctx, volumestore.EnsureBaseVolumeRequest{
+			BaseID:     strings.TrimSuffix(filepath.Base(rootfsPath), filepath.Ext(rootfsPath)),
+			SourcePath: rootfsPath,
+		})
+		if err != nil {
+			return volumestore.WritableVolume{}, fmt.Errorf("prepare base volume: %w", err)
+		}
+		return driver.CreateWritableVolume(ctx, volumestore.CreateWritableVolumeRequest{
+			VolumeID:       sandboxID,
+			BaseRef:        baseVolume.Ref,
+			AttachmentPath: attachmentPath,
+		})
+	}
+
+	return driver.CloneSnapshotToVolume(ctx, volumestore.CloneSnapshotToVolumeRequest{
+		VolumeID:       sandboxID,
+		SnapshotRef:    sourceRef,
+		AttachmentPath: attachmentPath,
+	})
+}
+
+func snapshotVolumeRef(instance *sandboxInstance) string {
+	if instance == nil {
+		return ""
+	}
+	if volumeRef := strings.TrimSpace(instance.volumeRef); volumeRef != "" {
+		return volumeRef
+	}
+	return strings.TrimSpace(instance.vmRootFSPath)
+}
+
 func snapshotStorageBaseDir(cfg backend.FirecrackerConfig) (string, error) {
 	if baseDir := strings.TrimSpace(cfg.Snapshots.BaseDir); baseDir != "" {
 		return filepath.Clean(baseDir), nil
 	}
 	return paths.SnapshotDir()
+}
+
+type rootVolumeCommandRunner struct {
+	cfg backend.FirecrackerConfig
+}
+
+func (r rootVolumeCommandRunner) Run(ctx context.Context, command string, args ...string) error {
+	return runRootCommand(ctx, r.cfg, append([]string{command}, args...)...)
+}
+
+func (r rootVolumeCommandRunner) Output(ctx context.Context, command string, args ...string) ([]byte, error) {
+	return runRootCommandOutput(ctx, r.cfg, append([]string{command}, args...)...)
 }
 
 func rootFSVolumeStoreDriver(cfg backend.FirecrackerConfig) (volumestore.Driver, error) {
@@ -1709,6 +1793,15 @@ func rootFSVolumeStoreDriver(cfg backend.FirecrackerConfig) (volumestore.Driver,
 		driver, err := volumestore.NewFileDriver(volumestore.FileDriverOptions{
 			SnapshotBaseDir: snapshotBaseDir,
 			Namespace:       "firecracker",
+		})
+		if err != nil {
+			return nil, err
+		}
+		return driver, nil
+	case "zfs":
+		driver, err := volumestore.NewZFSDriver(volumestore.ZFSDriverOptions{
+			DatasetRoot: cfg.Snapshots.ZFSDataset,
+			Runner:      rootVolumeCommandRunner{cfg: cfg},
 		})
 		if err != nil {
 			return nil, err
@@ -1754,11 +1847,14 @@ func (s *sandboxInstance) shutdown() {
 	if s.cleanupNetwork != nil {
 		s.cleanupNetwork()
 	}
+	if s.cleanupVolume != nil {
+		s.cleanupVolume()
+	}
 	if strings.TrimSpace(s.RunDir) != "" {
 		_ = os.RemoveAll(s.RunDir)
 		return
 	}
-	if strings.TrimSpace(s.vmRootFSPath) != "" {
+	if strings.TrimSpace(s.vmRootFSPath) != "" && s.cleanupVolume == nil {
 		_ = os.Remove(s.vmRootFSPath)
 	}
 }
@@ -2280,6 +2376,22 @@ func logRunNotice(backendName, runID, notice string) {
 	log.Printf("%s run_id=%s: %s", backendName, id, msg)
 }
 
+func lookPathWithFallback(binary string, candidates ...string) (string, error) {
+	if path, err := exec.LookPath(binary); err == nil {
+		return path, nil
+	}
+	for _, candidate := range candidates {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" {
+			continue
+		}
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("%q not found in PATH or fallback locations", binary)
+}
+
 func runRootCommand(ctx context.Context, cfg backend.FirecrackerConfig, args ...string) error {
 	if len(args) == 0 {
 		return errors.New("missing privileged command")
@@ -2304,6 +2416,25 @@ func runRootCommandOutput(ctx context.Context, cfg backend.FirecrackerConfig, ar
 	return runCombinedCommandOutput(ctx, append([]string{"sudo", "-n", helperPath}, args...), append([]string{"helper"}, args...))
 }
 
+func runRootCommandOutput(ctx context.Context, cfg backend.FirecrackerConfig, args ...string) ([]byte, error) {
+	if len(args) == 0 {
+		return nil, errors.New("missing privileged command")
+	}
+
+	mode, helperPath := resolvePrivilegedExecution(cfg)
+	switch mode {
+	case privilegedModeSudo:
+		return runCombinedCommandOutput(ctx, append([]string{"sudo", "-n"}, args...), args)
+	case privilegedModeHelper:
+		if strings.TrimSpace(helperPath) == "" {
+			return nil, errors.New("privileged helper mode requires helper path")
+		}
+		return runCombinedCommandOutput(ctx, append([]string{"sudo", "-n", helperPath}, args...), append([]string{"helper"}, args...))
+	default:
+		return nil, fmt.Errorf("unsupported privileged command mode %q", mode)
+	}
+}
+
 func runRootCommandBatch(ctx context.Context, cfg backend.FirecrackerConfig, commands [][]string) error {
 	for _, args := range commands {
 		if len(args) == 0 {
@@ -2318,7 +2449,6 @@ func runCombinedCommand(ctx context.Context, command []string, errorContext []st
 	_, err := runCombinedCommandOutput(ctx, command, errorContext)
 	return err
 }
-
 func runCombinedCommandOutput(ctx context.Context, command []string, errorContext []string) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, command[0], command[1:]...)
 	out, err := cmd.CombinedOutput()

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -2416,25 +2416,6 @@ func runRootCommandOutput(ctx context.Context, cfg backend.FirecrackerConfig, ar
 	return runCombinedCommandOutput(ctx, append([]string{"sudo", "-n", helperPath}, args...), append([]string{"helper"}, args...))
 }
 
-func runRootCommandOutput(ctx context.Context, cfg backend.FirecrackerConfig, args ...string) ([]byte, error) {
-	if len(args) == 0 {
-		return nil, errors.New("missing privileged command")
-	}
-
-	mode, helperPath := resolvePrivilegedExecution(cfg)
-	switch mode {
-	case privilegedModeSudo:
-		return runCombinedCommandOutput(ctx, append([]string{"sudo", "-n"}, args...), args)
-	case privilegedModeHelper:
-		if strings.TrimSpace(helperPath) == "" {
-			return nil, errors.New("privileged helper mode requires helper path")
-		}
-		return runCombinedCommandOutput(ctx, append([]string{"sudo", "-n", helperPath}, args...), append([]string{"helper"}, args...))
-	default:
-		return nil, fmt.Errorf("unsupported privileged command mode %q", mode)
-	}
-}
-
 func runRootCommandBatch(ctx context.Context, cfg backend.FirecrackerConfig, commands [][]string) error {
 	for _, args := range commands {
 		if len(args) == 0 {

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -1548,17 +1548,11 @@ func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID strin
 	if err != nil {
 		return nil, err
 	}
-	writableVolume, err := preparePersistentWritableVolume(ctx, driver, sandboxID, runDir, sourceRootFSPath)
+	writableVolume, cleanupVolume, err := preparePersistentWritableVolume(ctx, driver, sandboxID, runDir, sourceRootFSPath, cfg.MinimumRootFSBytes)
 	if err != nil {
 		return nil, fmt.Errorf("prepare persistent rootfs: %w", err)
 	}
 	vmRootFSPath := writableVolume.AttachmentPath
-	if err := ext4image.EnsureMinimumSize(ctx, vmRootFSPath, cfg.MinimumRootFSBytes); err != nil {
-		return nil, fmt.Errorf("resize persistent rootfs: %w", err)
-	}
-	cleanupVolume := func() {
-		_ = driver.DestroyVolume(context.Background(), volumestore.DestroyVolumeRequest{VolumeRef: writableVolume.Ref})
-	}
 
 	networkRunCommand := func(ctx context.Context, args ...string) error {
 		return runRootCommand(ctx, cfg, args...)
@@ -1716,41 +1710,61 @@ func sandboxRuntimeBaseDir() (string, error) {
 	return filepath.Join(base, "sandboxes"), nil
 }
 
-func preparePersistentWritableVolume(ctx context.Context, driver volumestore.Driver, sandboxID, runDir, sourceRef string) (volumestore.WritableVolume, error) {
+func preparePersistentWritableVolume(ctx context.Context, driver volumestore.Driver, sandboxID, runDir, sourceRef string, minimumBytes int64) (volumestore.WritableVolume, func(), error) {
 	sourceRef = strings.TrimSpace(sourceRef)
 	if sourceRef == "" {
-		return volumestore.WritableVolume{}, errors.New("missing persistent rootfs source")
+		return volumestore.WritableVolume{}, nil, errors.New("missing persistent rootfs source")
 	}
 
 	attachmentPath := filepath.Join(runDir, "rootfs-persistent.ext4")
+	resizeVolume := func(volume volumestore.WritableVolume) (volumestore.WritableVolume, func(), error) {
+		cleanupVolume := func() {
+			_ = driver.DestroyVolume(context.Background(), volumestore.DestroyVolumeRequest{VolumeRef: volume.Ref})
+		}
+		if err := volumestore.EnsureWritableVolumeMinimumSize(ctx, volume, minimumBytes); err != nil {
+			cleanupVolume()
+			return volumestore.WritableVolume{}, nil, fmt.Errorf("resize persistent rootfs: %w", err)
+		}
+		return volume, cleanupVolume, nil
+	}
+
 	if filepath.IsAbs(sourceRef) {
 		rootfsPath, err := filepath.Abs(sourceRef)
 		if err != nil {
-			return volumestore.WritableVolume{}, err
+			return volumestore.WritableVolume{}, nil, err
 		}
 		if _, err := os.Stat(rootfsPath); err != nil {
-			return volumestore.WritableVolume{}, fmt.Errorf("rootfs %s: %w", rootfsPath, err)
+			return volumestore.WritableVolume{}, nil, fmt.Errorf("rootfs %s: %w", rootfsPath, err)
 		}
 
 		baseVolume, err := driver.EnsureBaseVolume(ctx, volumestore.EnsureBaseVolumeRequest{
-			BaseID:     strings.TrimSuffix(filepath.Base(rootfsPath), filepath.Ext(rootfsPath)),
-			SourcePath: rootfsPath,
+			BaseID:       strings.TrimSuffix(filepath.Base(rootfsPath), filepath.Ext(rootfsPath)),
+			SourcePath:   rootfsPath,
+			MinimumBytes: minimumBytes,
 		})
 		if err != nil {
-			return volumestore.WritableVolume{}, fmt.Errorf("prepare base volume: %w", err)
+			return volumestore.WritableVolume{}, nil, fmt.Errorf("prepare base volume: %w", err)
 		}
-		return driver.CreateWritableVolume(ctx, volumestore.CreateWritableVolumeRequest{
+		volume, err := driver.CreateWritableVolume(ctx, volumestore.CreateWritableVolumeRequest{
 			VolumeID:       sandboxID,
 			BaseRef:        baseVolume.Ref,
 			AttachmentPath: attachmentPath,
 		})
+		if err != nil {
+			return volumestore.WritableVolume{}, nil, err
+		}
+		return resizeVolume(volume)
 	}
 
-	return driver.CloneSnapshotToVolume(ctx, volumestore.CloneSnapshotToVolumeRequest{
+	volume, err := driver.CloneSnapshotToVolume(ctx, volumestore.CloneSnapshotToVolumeRequest{
 		VolumeID:       sandboxID,
 		SnapshotRef:    sourceRef,
 		AttachmentPath: attachmentPath,
 	})
+	if err != nil {
+		return volumestore.WritableVolume{}, nil, err
+	}
+	return resizeVolume(volume)
 }
 
 func snapshotVolumeRef(instance *sandboxInstance) string {

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -593,7 +593,10 @@ func (a *Adapter) DeleteSnapshot(ctx context.Context, req backend.DeleteSnapshot
 	if storageRef == "" {
 		return errors.New("missing snapshot storage_ref")
 	}
-	driverCfg := snapshotConfigForStorageRef(req.FirecrackerConfig, storageRef)
+	driverCfg, err := snapshotConfigForStorageRef(req.FirecrackerConfig, storageRef)
+	if err != nil {
+		return err
+	}
 	driver, err := snapshotVolumeStoreDriver(driverCfg)
 	if err != nil {
 		return err
@@ -801,8 +804,8 @@ func (a *Adapter) Doctor(_ context.Context, req backend.DoctorRequest) (*backend
 			if zfsBinary == "" {
 				appendCheck("snapshot_zfs_dataset_access", "fail", fmt.Sprintf("unable to access zfs dataset %q: zfs command not available", dataset))
 			} else {
-				command := []string{zfsBinary, "list", "-H", "-o", "name", dataset}
-				errorContext := []string{"zfs", "list", "-H", "-o", "name", dataset}
+				command := []string{zfsBinary, "list", "-H", "-d", "0", "-o", "name", dataset}
+				errorContext := []string{"zfs", "list", "-H", "-d", "0", "-o", "name", dataset}
 				out, err := runCombinedCommandOutput(context.Background(), command, errorContext)
 				if err != nil {
 					appendCheck("snapshot_zfs_dataset_access", "fail", fmt.Sprintf("unable to access zfs dataset %q: %v", dataset, err))
@@ -1553,7 +1556,11 @@ func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID strin
 		return nil, err
 	}
 
-	driver, err := rootFSVolumeStoreDriver(snapshotConfigForStorageRef(cfg, sourceRootFSPath))
+	driverCfg, err := snapshotConfigForStorageRef(cfg, sourceRootFSPath)
+	if err != nil {
+		return nil, err
+	}
+	driver, err := rootFSVolumeStoreDriver(driverCfg)
 	if err != nil {
 		return nil, err
 	}
@@ -1805,14 +1812,16 @@ func (r rootVolumeCommandRunner) Output(ctx context.Context, command string, arg
 	return runRootCommandOutput(ctx, r.cfg, append([]string{command}, args...)...)
 }
 
-func snapshotConfigForStorageRef(cfg backend.FirecrackerConfig, storageRef string) backend.FirecrackerConfig {
-	if strings.ToLower(strings.TrimSpace(cfg.Snapshots.Driver)) != "zfs" {
-		return cfg
-	}
+func snapshotConfigForStorageRef(cfg backend.FirecrackerConfig, storageRef string) (backend.FirecrackerConfig, error) {
 	if datasetRoot, ok := volumestore.ZFSDatasetRootFromStoredSnapshotRef(storageRef); ok {
+		driverName := strings.ToLower(strings.TrimSpace(cfg.Snapshots.Driver))
+		if driverName != "" && driverName != "zfs" {
+			return cfg, fmt.Errorf("snapshot storage_ref %q requires zfs driver, got %q", storageRef, cfg.Snapshots.Driver)
+		}
+		cfg.Snapshots.Driver = "zfs"
 		cfg.Snapshots.ZFSDataset = datasetRoot
 	}
-	return cfg
+	return cfg, nil
 }
 
 func rootFSVolumeStoreDriver(cfg backend.FirecrackerConfig) (volumestore.Driver, error) {

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -807,9 +807,7 @@ func (a *Adapter) Doctor(_ context.Context, req backend.DoctorRequest) (*backend
 			if zfsBinary == "" {
 				appendCheck("snapshot_zfs_dataset_access", "fail", fmt.Sprintf("unable to access zfs dataset %q: zfs command not available", dataset))
 			} else {
-				command := []string{zfsBinary, "list", "-H", "-d", "0", "-o", "name", dataset}
-				errorContext := []string{"zfs", "list", "-H", "-d", "0", "-o", "name", dataset}
-				out, err := runCombinedCommandOutput(context.Background(), command, errorContext)
+				out, err := runRootCommandOutput(context.Background(), req.FirecrackerConfig, "zfs", "list", "-H", "-d", "0", "-o", "name", dataset)
 				if err != nil {
 					appendCheck("snapshot_zfs_dataset_access", "fail", fmt.Sprintf("unable to access zfs dataset %q: %v", dataset, err))
 				} else if strings.TrimSpace(string(out)) != dataset {
@@ -1738,7 +1736,9 @@ func preparePersistentWritableVolume(ctx context.Context, driver volumestore.Dri
 	attachmentPath := filepath.Join(runDir, "rootfs-persistent.ext4")
 	resizeVolume := func(volume volumestore.WritableVolume) (volumestore.WritableVolume, func(), error) {
 		cleanupVolume := func() {
-			_ = driver.DestroyVolume(context.Background(), volumestore.DestroyVolumeRequest{VolumeRef: volume.Ref})
+			if err := driver.DestroyVolume(context.Background(), volumestore.DestroyVolumeRequest{VolumeRef: volume.Ref}); err != nil {
+				log.Printf("firecracker: cleanup persistent volume %q: %v", volume.Ref, err)
+			}
 		}
 		if err := volumestore.EnsureWritableVolumeMinimumSize(ctx, driver, volume, minimumBytes); err != nil {
 			cleanupVolume()

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -488,7 +488,15 @@ func (a *Adapter) CreateSnapshot(ctx context.Context, req backend.SnapshotReques
 		return nil, fmt.Errorf("sync sandbox filesystem before snapshot: guest sync command exited with code %d", syncResp.ExitCode)
 	}
 
-	driver, err := snapshotVolumeStoreDriver(req.FirecrackerConfig)
+	volumeRef := snapshotVolumeRef(instance)
+	if volumeRef == "" {
+		return nil, fmt.Errorf("sandbox %q has no snapshot-capable rootfs volume", sandboxID)
+	}
+	driverCfg, err := snapshotConfigForStorageRef(req.FirecrackerConfig, volumeRef)
+	if err != nil {
+		return nil, err
+	}
+	driver, err := snapshotVolumeStoreDriver(driverCfg)
 	if err != nil {
 		return nil, err
 	}
@@ -516,11 +524,6 @@ func (a *Adapter) CreateSnapshot(ctx context.Context, req backend.SnapshotReques
 			retErr = fmt.Errorf("resume firecracker sandbox after snapshot: %w", err)
 		}
 	}()
-
-	volumeRef := snapshotVolumeRef(instance)
-	if volumeRef == "" {
-		return nil, fmt.Errorf("sandbox %q has no snapshot-capable rootfs volume", sandboxID)
-	}
 
 	snapshot, err := driver.SnapshotVolume(ctx, volumestore.SnapshotVolumeRequest{
 		SnapshotID: snapshotID,
@@ -1737,7 +1740,7 @@ func preparePersistentWritableVolume(ctx context.Context, driver volumestore.Dri
 		cleanupVolume := func() {
 			_ = driver.DestroyVolume(context.Background(), volumestore.DestroyVolumeRequest{VolumeRef: volume.Ref})
 		}
-		if err := volumestore.EnsureWritableVolumeMinimumSize(ctx, volume, minimumBytes); err != nil {
+		if err := volumestore.EnsureWritableVolumeMinimumSize(ctx, driver, volume, minimumBytes); err != nil {
 			cleanupVolume()
 			return volumestore.WritableVolume{}, nil, fmt.Errorf("resize persistent rootfs: %w", err)
 		}
@@ -1813,7 +1816,7 @@ func (r rootVolumeCommandRunner) Output(ctx context.Context, command string, arg
 }
 
 func snapshotConfigForStorageRef(cfg backend.FirecrackerConfig, storageRef string) (backend.FirecrackerConfig, error) {
-	if datasetRoot, ok := volumestore.ZFSDatasetRootFromStoredSnapshotRef(storageRef); ok {
+	if datasetRoot, ok := volumestore.ZFSDatasetRootFromManagedRef(storageRef); ok {
 		driverName := strings.ToLower(strings.TrimSpace(cfg.Snapshots.Driver))
 		if driverName != "" && driverName != "zfs" {
 			return cfg, fmt.Errorf("snapshot storage_ref %q requires zfs driver, got %q", storageRef, cfg.Snapshots.Driver)

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -593,7 +593,8 @@ func (a *Adapter) DeleteSnapshot(ctx context.Context, req backend.DeleteSnapshot
 	if storageRef == "" {
 		return errors.New("missing snapshot storage_ref")
 	}
-	driver, err := snapshotVolumeStoreDriver(req.FirecrackerConfig)
+	driverCfg := snapshotConfigForStorageRef(req.FirecrackerConfig, storageRef)
+	driver, err := snapshotVolumeStoreDriver(driverCfg)
 	if err != nil {
 		return err
 	}
@@ -788,20 +789,28 @@ func (a *Adapter) Doctor(_ context.Context, req backend.DoctorRequest) (*backend
 			appendCheck("snapshot_zfs_dataset", "pass", fmt.Sprintf("configured zfs dataset %q", dataset))
 		}
 
+		zfsBinary := ""
 		if path, err := lookPathWithFallback("zfs", "/usr/sbin/zfs", "/sbin/zfs"); err != nil {
 			appendCheck("snapshot_zfs_binary", "fail", fmt.Sprintf("zfs command not available: %v", err))
 		} else {
+			zfsBinary = path
 			appendCheck("snapshot_zfs_binary", "pass", fmt.Sprintf("found zfs command %q", path))
 		}
 
 		if dataset != "" {
-			out, err := runRootCommandOutput(context.Background(), req.FirecrackerConfig, "zfs", "list", "-H", "-o", "name", dataset)
-			if err != nil {
-				appendCheck("snapshot_zfs_dataset_access", "fail", fmt.Sprintf("unable to access zfs dataset %q: %v", dataset, err))
-			} else if strings.TrimSpace(string(out)) != dataset {
-				appendCheck("snapshot_zfs_dataset_access", "fail", fmt.Sprintf("zfs dataset probe for %q returned %q", dataset, strings.TrimSpace(string(out))))
+			if zfsBinary == "" {
+				appendCheck("snapshot_zfs_dataset_access", "fail", fmt.Sprintf("unable to access zfs dataset %q: zfs command not available", dataset))
 			} else {
-				appendCheck("snapshot_zfs_dataset_access", "pass", fmt.Sprintf("zfs dataset %q is accessible", dataset))
+				command := []string{zfsBinary, "list", "-H", "-o", "name", dataset}
+				errorContext := []string{"zfs", "list", "-H", "-o", "name", dataset}
+				out, err := runCombinedCommandOutput(context.Background(), command, errorContext)
+				if err != nil {
+					appendCheck("snapshot_zfs_dataset_access", "fail", fmt.Sprintf("unable to access zfs dataset %q: %v", dataset, err))
+				} else if strings.TrimSpace(string(out)) != dataset {
+					appendCheck("snapshot_zfs_dataset_access", "fail", fmt.Sprintf("zfs dataset probe for %q returned %q", dataset, strings.TrimSpace(string(out))))
+				} else {
+					appendCheck("snapshot_zfs_dataset_access", "pass", fmt.Sprintf("zfs dataset %q is accessible", dataset))
+				}
 			}
 		}
 	default:
@@ -1544,7 +1553,7 @@ func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID strin
 		return nil, err
 	}
 
-	driver, err := rootFSVolumeStoreDriver(cfg)
+	driver, err := rootFSVolumeStoreDriver(snapshotConfigForStorageRef(cfg, sourceRootFSPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1794,6 +1803,16 @@ func (r rootVolumeCommandRunner) Run(ctx context.Context, command string, args .
 
 func (r rootVolumeCommandRunner) Output(ctx context.Context, command string, args ...string) ([]byte, error) {
 	return runRootCommandOutput(ctx, r.cfg, append([]string{command}, args...)...)
+}
+
+func snapshotConfigForStorageRef(cfg backend.FirecrackerConfig, storageRef string) backend.FirecrackerConfig {
+	if strings.ToLower(strings.TrimSpace(cfg.Snapshots.Driver)) != "zfs" {
+		return cfg
+	}
+	if datasetRoot, ok := volumestore.ZFSDatasetRootFromStoredSnapshotRef(storageRef); ok {
+		cfg.Snapshots.ZFSDataset = datasetRoot
+	}
+	return cfg
 }
 
 func rootFSVolumeStoreDriver(cfg backend.FirecrackerConfig) (volumestore.Driver, error) {

--- a/internal/backend/firecracker/persistent_test.go
+++ b/internal/backend/firecracker/persistent_test.go
@@ -76,6 +76,23 @@ func TestSandboxShutdownRemovesRunDir(t *testing.T) {
 	}
 }
 
+func TestSandboxShutdownInvokesCleanupVolume(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	instance := &sandboxInstance{
+		RunDir: t.TempDir(),
+		cleanupVolume: func() {
+			called = true
+		},
+	}
+	instance.shutdown()
+
+	if !called {
+		t.Fatal("expected cleanupVolume to be invoked")
+	}
+}
+
 func TestRunInSandboxUsesRequestLaunchSecondsOverride(t *testing.T) {
 	t.Parallel()
 

--- a/internal/backend/firecracker/privileged_test.go
+++ b/internal/backend/firecracker/privileged_test.go
@@ -215,7 +215,7 @@ func TestDoctorReportsZFSChecks(t *testing.T) {
 	writeExecutable(t, binDir, "ip", "#!/bin/sh\nif [ \"$1\" = \"link\" ] && [ \"$2\" = \"show\" ]; then exit 0; fi\nexit 0\n")
 	writeExecutable(t, binDir, "zfs", "#!/bin/sh\nif [ \"$1\" = \"list\" ] && [ \"$2\" = \"-H\" ] && [ \"$3\" = \"-o\" ] && [ \"$4\" = \"name\" ]; then printf '%s\\n' \"$5\"; exit 0; fi\nexit 0\n")
 	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
-	helperPath := writeExecutable(t, tmpDir, "cleanroom-root-helper", "#!/bin/sh\nset -eu\ncase \"$1\" in\n  version)\n    printf 'test-helper\\n'\n    ;;\n  capabilities)\n    printf 'firecracker-network\\nfirecracker-rootfs\\nfirecracker-zfs\\n'\n    ;;\n  *)\n    exec \"$@\"\n    ;;\n esac\n")
+	helperPath := writeExecutable(t, tmpDir, "cleanroom-root-helper", "#!/bin/sh\nset -eu\ncase \"$1\" in\n  version)\n    printf 'test-helper\\n'\n    ;;\n  capabilities)\n    printf 'firecracker-network\\nfirecracker-rootfs\\nfirecracker-zfs\\n'\n    ;;\n  true)\n    exec \"$@\"\n    ;;\n  zfs)\n    echo 'unexpected helper zfs probe' >&2\n    exit 2\n    ;;\n  *)\n    exec \"$@\"\n    ;;\n esac\n")
 
 	kernelPath := filepath.Join(tmpDir, "vmlinux")
 	if err := os.WriteFile(kernelPath, []byte("kernel"), 0o644); err != nil {
@@ -248,6 +248,38 @@ func TestDoctorReportsZFSChecks(t *testing.T) {
 	}
 	if got := doctorCheck(report, "snapshot_zfs_dataset_access"); got.Status != "pass" {
 		t.Fatalf("unexpected snapshot_zfs_dataset_access check: %+v", got)
+	}
+}
+
+func TestDeleteSnapshotDerivesZFSDatasetFromStorageRef(t *testing.T) {
+	tmpDir := t.TempDir()
+	sudoLogPath := filepath.Join(tmpDir, "sudo.log")
+	setupFakeSudo(t, sudoLogPath)
+
+	logPath := filepath.Join(tmpDir, "helper.log")
+	helperPath := writeExecutable(t, tmpDir, "cleanroom-root-helper", "#!/bin/sh\nset -eu\nprintf '%s\\n' \"$*\" >> \"$HELPER_LOG_PATH\"\nexit 0\n")
+	t.Setenv("HELPER_LOG_PATH", logPath)
+
+	err := (&Adapter{}).DeleteSnapshot(context.Background(), backend.DeleteSnapshotRequest{
+		StorageRef: "tank/cleanroom/snapshots/snap-test@seed",
+		FirecrackerConfig: backend.FirecrackerConfig{
+			PrivilegedHelperPath: helperPath,
+			Snapshots: backend.SnapshotConfig{
+				Enabled: true,
+				Driver:  "zfs",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("DeleteSnapshot returned error: %v", err)
+	}
+
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read helper log: %v", err)
+	}
+	if got, want := strings.TrimSpace(string(logBytes)), "zfs destroy -r tank/cleanroom/snapshots/snap-test"; got != want {
+		t.Fatalf("unexpected helper invocation: got %q want %q", got, want)
 	}
 }
 

--- a/internal/backend/firecracker/privileged_test.go
+++ b/internal/backend/firecracker/privileged_test.go
@@ -200,6 +200,8 @@ func TestDoctorReportsZFSChecks(t *testing.T) {
 	tmpDir := t.TempDir()
 	sudoLogPath := filepath.Join(tmpDir, "sudo.log")
 	setupFakeSudo(t, sudoLogPath)
+	logPath := filepath.Join(tmpDir, "helper.log")
+	t.Setenv("HELPER_LOG_PATH", logPath)
 
 	binDir := filepath.Join(tmpDir, "bin")
 	if err := os.MkdirAll(binDir, 0o755); err != nil {
@@ -215,7 +217,7 @@ func TestDoctorReportsZFSChecks(t *testing.T) {
 	writeExecutable(t, binDir, "ip", "#!/bin/sh\nif [ \"$1\" = \"link\" ] && [ \"$2\" = \"show\" ]; then exit 0; fi\nexit 0\n")
 	writeExecutable(t, binDir, "zfs", "#!/bin/sh\nif [ \"$1\" = \"list\" ] && [ \"$2\" = \"-H\" ] && [ \"$3\" = \"-d\" ] && [ \"$4\" = \"0\" ] && [ \"$5\" = \"-o\" ] && [ \"$6\" = \"name\" ]; then printf '%s\\n' \"$7\"; exit 0; fi\nif [ \"$1\" = \"list\" ] && [ \"$2\" = \"-H\" ] && [ \"$3\" = \"-o\" ] && [ \"$4\" = \"name\" ]; then printf '%s\\n%s/child\\n' \"$5\" \"$5\"; exit 0; fi\nexit 0\n")
 	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
-	helperPath := writeExecutable(t, tmpDir, "cleanroom-root-helper", "#!/bin/sh\nset -eu\ncase \"$1\" in\n  version)\n    printf 'test-helper\\n'\n    ;;\n  capabilities)\n    printf 'firecracker-network\\nfirecracker-rootfs\\nfirecracker-zfs\\n'\n    ;;\n  true)\n    exec \"$@\"\n    ;;\n  zfs)\n    echo 'unexpected helper zfs probe' >&2\n    exit 2\n    ;;\n  *)\n    exec \"$@\"\n    ;;\n esac\n")
+	helperPath := writeExecutable(t, tmpDir, "cleanroom-root-helper", "#!/bin/sh\nset -eu\nprintf '%s\\n' \"$*\" >> \"$HELPER_LOG_PATH\"\ncase \"$1\" in\n  version)\n    printf 'test-helper\\n'\n    ;;\n  capabilities)\n    printf 'firecracker-network\\nfirecracker-rootfs\\nfirecracker-zfs\\n'\n    ;;\n  true)\n    exec \"$@\"\n    ;;\n  zfs)\n    if [ \"$2\" = \"list\" ] && [ \"$3\" = \"-H\" ] && [ \"$4\" = \"-d\" ] && [ \"$5\" = \"0\" ] && [ \"$6\" = \"-o\" ] && [ \"$7\" = \"name\" ]; then\n      printf '%s\\n' \"$8\"\n      exit 0\n    fi\n    echo 'unexpected helper zfs args' >&2\n    exit 2\n    ;;\n  *)\n    exec \"$@\"\n    ;;\n esac\n")
 
 	kernelPath := filepath.Join(tmpDir, "vmlinux")
 	if err := os.WriteFile(kernelPath, []byte("kernel"), 0o644); err != nil {
@@ -248,6 +250,14 @@ func TestDoctorReportsZFSChecks(t *testing.T) {
 	}
 	if got := doctorCheck(report, "snapshot_zfs_dataset_access"); got.Status != "pass" {
 		t.Fatalf("unexpected snapshot_zfs_dataset_access check: %+v", got)
+	}
+
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read helper log: %v", err)
+	}
+	if !strings.Contains(string(logBytes), "zfs list -H -d 0 -o name tank/cleanroom") {
+		t.Fatalf("expected helper-mediated zfs probe, got log %q", string(logBytes))
 	}
 }
 

--- a/internal/backend/firecracker/privileged_test.go
+++ b/internal/backend/firecracker/privileged_test.go
@@ -10,6 +10,25 @@ import (
 	"github.com/buildkite/cleanroom/internal/backend"
 )
 
+func writeExecutable(t *testing.T, dir, name, content string) string {
+	t.Helper()
+
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+		t.Fatalf("write executable %s: %v", name, err)
+	}
+	return path
+}
+
+func doctorCheck(report *backend.DoctorReport, name string) backend.DoctorCheck {
+	for _, check := range report.Checks {
+		if check.Name == name {
+			return check
+		}
+	}
+	return backend.DoctorCheck{}
+}
+
 func setupFakeSudo(t *testing.T, logPath string) {
 	t.Helper()
 
@@ -140,6 +159,93 @@ func TestRunRootCommandOutputInvokesHelper(t *testing.T) {
 	}
 	if got := strings.TrimSpace(string(logBytes)); got != "capabilities" {
 		t.Fatalf("unexpected helper invocation: got %q want %q", got, "capabilities")
+	}
+}
+
+func TestRunRootCommandOutputInvokesHelperForZFSProbe(t *testing.T) {
+	tmpDir := t.TempDir()
+	sudoLogPath := filepath.Join(tmpDir, "sudo.log")
+	logPath := filepath.Join(tmpDir, "helper.log")
+	helperPath := filepath.Join(tmpDir, "cleanroom-root-helper")
+	setupFakeSudo(t, sudoLogPath)
+
+	helperScript := "#!/bin/sh\nset -eu\nprintf '%s\\n' \"$*\" >> \"$HELPER_LOG_PATH\"\nif [ \"$1\" = \"zfs\" ] && [ \"$2\" = \"list\" ] && [ \"$3\" = \"-H\" ] && [ \"$4\" = \"-o\" ] && [ \"$5\" = \"name\" ]; then printf '%s\\n' \"$6\"; fi\n"
+	if err := os.WriteFile(helperPath, []byte(helperScript), 0o755); err != nil {
+		t.Fatalf("write helper script: %v", err)
+	}
+	t.Setenv("HELPER_LOG_PATH", logPath)
+
+	cfg := backend.FirecrackerConfig{
+		PrivilegedHelperPath: helperPath,
+	}
+
+	out, err := runRootCommandOutput(context.Background(), cfg, "zfs", "list", "-H", "-o", "name", "tank/cleanroom")
+	if err != nil {
+		t.Fatalf("runRootCommandOutput: %v", err)
+	}
+	if got, want := strings.TrimSpace(string(out)), "tank/cleanroom"; got != want {
+		t.Fatalf("unexpected helper output: got %q want %q", got, want)
+	}
+
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read helper log: %v", err)
+	}
+	if got := strings.TrimSpace(string(logBytes)); got != "zfs list -H -o name tank/cleanroom" {
+		t.Fatalf("unexpected helper invocation: got %q", got)
+	}
+}
+
+func TestDoctorReportsZFSChecks(t *testing.T) {
+	tmpDir := t.TempDir()
+	sudoLogPath := filepath.Join(tmpDir, "sudo.log")
+	setupFakeSudo(t, sudoLogPath)
+
+	binDir := filepath.Join(tmpDir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin dir: %v", err)
+	}
+
+	writeExecutable(t, binDir, "firecracker", "#!/bin/sh\nexit 0\n")
+	writeExecutable(t, binDir, "cleanroom-guest-agent", "#!/bin/sh\nexit 0\n")
+	writeExecutable(t, binDir, "mkfs.ext4", "#!/bin/sh\nexit 0\n")
+	writeExecutable(t, binDir, "iptables", "#!/bin/sh\nexit 0\n")
+	writeExecutable(t, binDir, "sysctl", "#!/bin/sh\nexit 0\n")
+	writeExecutable(t, binDir, "true", "#!/bin/sh\nexit 0\n")
+	writeExecutable(t, binDir, "ip", "#!/bin/sh\nif [ \"$1\" = \"link\" ] && [ \"$2\" = \"show\" ]; then exit 0; fi\nexit 0\n")
+	writeExecutable(t, binDir, "zfs", "#!/bin/sh\nif [ \"$1\" = \"list\" ] && [ \"$2\" = \"-H\" ] && [ \"$3\" = \"-o\" ] && [ \"$4\" = \"name\" ]; then printf '%s\\n' \"$5\"; exit 0; fi\nexit 0\n")
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	kernelPath := filepath.Join(tmpDir, "vmlinux")
+	if err := os.WriteFile(kernelPath, []byte("kernel"), 0o644); err != nil {
+		t.Fatalf("write kernel image: %v", err)
+	}
+
+	report, err := (&Adapter{}).Doctor(context.Background(), backend.DoctorRequest{
+		FirecrackerConfig: backend.FirecrackerConfig{
+			BinaryPath:      "firecracker",
+			KernelImagePath: kernelPath,
+			Snapshots: backend.SnapshotConfig{
+				Driver:     "zfs",
+				ZFSDataset: "tank/cleanroom",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Doctor returned error: %v", err)
+	}
+
+	if got := doctorCheck(report, "snapshot_driver"); got.Status != "pass" {
+		t.Fatalf("unexpected snapshot_driver check: %+v", got)
+	}
+	if got := doctorCheck(report, "snapshot_zfs_dataset"); got.Status != "pass" {
+		t.Fatalf("unexpected snapshot_zfs_dataset check: %+v", got)
+	}
+	if got := doctorCheck(report, "snapshot_zfs_binary"); got.Status != "pass" {
+		t.Fatalf("unexpected snapshot_zfs_binary check: %+v", got)
+	}
+	if got := doctorCheck(report, "snapshot_zfs_dataset_access"); got.Status != "pass" {
+		t.Fatalf("unexpected snapshot_zfs_dataset_access check: %+v", got)
 	}
 }
 

--- a/internal/backend/firecracker/privileged_test.go
+++ b/internal/backend/firecracker/privileged_test.go
@@ -215,6 +215,7 @@ func TestDoctorReportsZFSChecks(t *testing.T) {
 	writeExecutable(t, binDir, "ip", "#!/bin/sh\nif [ \"$1\" = \"link\" ] && [ \"$2\" = \"show\" ]; then exit 0; fi\nexit 0\n")
 	writeExecutable(t, binDir, "zfs", "#!/bin/sh\nif [ \"$1\" = \"list\" ] && [ \"$2\" = \"-H\" ] && [ \"$3\" = \"-o\" ] && [ \"$4\" = \"name\" ]; then printf '%s\\n' \"$5\"; exit 0; fi\nexit 0\n")
 	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+	helperPath := writeExecutable(t, tmpDir, "cleanroom-root-helper", "#!/bin/sh\nset -eu\ncase \"$1\" in\n  version)\n    printf 'test-helper\\n'\n    ;;\n  capabilities)\n    printf 'firecracker-network\\nfirecracker-rootfs\\nfirecracker-zfs\\n'\n    ;;\n  *)\n    exec \"$@\"\n    ;;\n esac\n")
 
 	kernelPath := filepath.Join(tmpDir, "vmlinux")
 	if err := os.WriteFile(kernelPath, []byte("kernel"), 0o644); err != nil {
@@ -223,8 +224,9 @@ func TestDoctorReportsZFSChecks(t *testing.T) {
 
 	report, err := (&Adapter{}).Doctor(context.Background(), backend.DoctorRequest{
 		FirecrackerConfig: backend.FirecrackerConfig{
-			BinaryPath:      "firecracker",
-			KernelImagePath: kernelPath,
+			BinaryPath:           "firecracker",
+			KernelImagePath:      kernelPath,
+			PrivilegedHelperPath: helperPath,
 			Snapshots: backend.SnapshotConfig{
 				Driver:     "zfs",
 				ZFSDataset: "tank/cleanroom",

--- a/internal/backend/firecracker/privileged_test.go
+++ b/internal/backend/firecracker/privileged_test.go
@@ -213,7 +213,7 @@ func TestDoctorReportsZFSChecks(t *testing.T) {
 	writeExecutable(t, binDir, "sysctl", "#!/bin/sh\nexit 0\n")
 	writeExecutable(t, binDir, "true", "#!/bin/sh\nexit 0\n")
 	writeExecutable(t, binDir, "ip", "#!/bin/sh\nif [ \"$1\" = \"link\" ] && [ \"$2\" = \"show\" ]; then exit 0; fi\nexit 0\n")
-	writeExecutable(t, binDir, "zfs", "#!/bin/sh\nif [ \"$1\" = \"list\" ] && [ \"$2\" = \"-H\" ] && [ \"$3\" = \"-o\" ] && [ \"$4\" = \"name\" ]; then printf '%s\\n' \"$5\"; exit 0; fi\nexit 0\n")
+	writeExecutable(t, binDir, "zfs", "#!/bin/sh\nif [ \"$1\" = \"list\" ] && [ \"$2\" = \"-H\" ] && [ \"$3\" = \"-d\" ] && [ \"$4\" = \"0\" ] && [ \"$5\" = \"-o\" ] && [ \"$6\" = \"name\" ]; then printf '%s\\n' \"$7\"; exit 0; fi\nif [ \"$1\" = \"list\" ] && [ \"$2\" = \"-H\" ] && [ \"$3\" = \"-o\" ] && [ \"$4\" = \"name\" ]; then printf '%s\\n%s/child\\n' \"$5\" \"$5\"; exit 0; fi\nexit 0\n")
 	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 	helperPath := writeExecutable(t, tmpDir, "cleanroom-root-helper", "#!/bin/sh\nset -eu\ncase \"$1\" in\n  version)\n    printf 'test-helper\\n'\n    ;;\n  capabilities)\n    printf 'firecracker-network\\nfirecracker-rootfs\\nfirecracker-zfs\\n'\n    ;;\n  true)\n    exec \"$@\"\n    ;;\n  zfs)\n    echo 'unexpected helper zfs probe' >&2\n    exit 2\n    ;;\n  *)\n    exec \"$@\"\n    ;;\n esac\n")
 
@@ -267,6 +267,37 @@ func TestDeleteSnapshotDerivesZFSDatasetFromStorageRef(t *testing.T) {
 			Snapshots: backend.SnapshotConfig{
 				Enabled: true,
 				Driver:  "zfs",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("DeleteSnapshot returned error: %v", err)
+	}
+
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read helper log: %v", err)
+	}
+	if got, want := strings.TrimSpace(string(logBytes)), "zfs destroy -r tank/cleanroom/snapshots/snap-test"; got != want {
+		t.Fatalf("unexpected helper invocation: got %q want %q", got, want)
+	}
+}
+
+func TestDeleteSnapshotInfersZFSDriverFromStorageRef(t *testing.T) {
+	tmpDir := t.TempDir()
+	sudoLogPath := filepath.Join(tmpDir, "sudo.log")
+	setupFakeSudo(t, sudoLogPath)
+
+	logPath := filepath.Join(tmpDir, "helper.log")
+	helperPath := writeExecutable(t, tmpDir, "cleanroom-root-helper", "#!/bin/sh\nset -eu\nprintf '%s\\n' \"$*\" >> \"$HELPER_LOG_PATH\"\nexit 0\n")
+	t.Setenv("HELPER_LOG_PATH", logPath)
+
+	err := (&Adapter{}).DeleteSnapshot(context.Background(), backend.DeleteSnapshotRequest{
+		StorageRef: "tank/cleanroom/snapshots/snap-test@seed",
+		FirecrackerConfig: backend.FirecrackerConfig{
+			PrivilegedHelperPath: helperPath,
+			Snapshots: backend.SnapshotConfig{
+				Enabled: true,
 			},
 		},
 	})

--- a/internal/backend/firecracker/snapshot_test.go
+++ b/internal/backend/firecracker/snapshot_test.go
@@ -1,8 +1,10 @@
 package firecracker
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -67,6 +69,24 @@ func (d testVolumeDriver) DestroySnapshot(ctx context.Context, req volumestore.D
 		return nil
 	}
 	return d.destroySnapshotFn(ctx, req)
+}
+
+func captureFirecrackerLogOutput(t *testing.T) *bytes.Buffer {
+	t.Helper()
+
+	var buf bytes.Buffer
+	prevWriter := log.Writer()
+	prevFlags := log.Flags()
+	prevPrefix := log.Prefix()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	log.SetPrefix("")
+	t.Cleanup(func() {
+		log.SetOutput(prevWriter)
+		log.SetFlags(prevFlags)
+		log.SetPrefix(prevPrefix)
+	})
+	return &buf
 }
 
 func TestCreateSnapshotSyncsPausesAndClonesRootFS(t *testing.T) {
@@ -644,5 +664,35 @@ func TestPreparePersistentWritableVolumeCleansUpOnResizeFailure(t *testing.T) {
 	}
 	if got, want := destroyed, "tank/cleanroom/sandboxes/sandbox-1"; got != want {
 		t.Fatalf("unexpected destroyed volume ref: got %q want %q", got, want)
+	}
+}
+
+func TestPreparePersistentWritableVolumeLogsDestroyFailure(t *testing.T) {
+	logOutput := captureFirecrackerLogOutput(t)
+
+	driver := testVolumeDriver{
+		cloneSnapshotToVolumeFn: func(_ context.Context, req volumestore.CloneSnapshotToVolumeRequest) (volumestore.WritableVolume, error) {
+			return volumestore.WritableVolume{
+				Ref:            "tank/cleanroom/sandboxes/sandbox-1",
+				AttachmentPath: filepath.Join(t.TempDir(), "writable.ext4"),
+			}, nil
+		},
+		destroyVolumeFn: func(_ context.Context, req volumestore.DestroyVolumeRequest) error {
+			return errors.New("destroy failed")
+		},
+	}
+
+	_, cleanupVolume, err := preparePersistentWritableVolume(context.Background(), driver, "sandbox-1", t.TempDir(), "tank/cleanroom/sandboxes/source@snap-golden", 0)
+	if err != nil {
+		t.Fatalf("preparePersistentWritableVolume returned error: %v", err)
+	}
+	if cleanupVolume == nil {
+		t.Fatal("expected cleanup function")
+	}
+
+	cleanupVolume()
+
+	if got := logOutput.String(); !strings.Contains(got, "firecracker: cleanup persistent volume \"tank/cleanroom/sandboxes/sandbox-1\": destroy failed") {
+		t.Fatalf("expected destroy error to be logged, got %q", got)
 	}
 }

--- a/internal/backend/firecracker/snapshot_test.go
+++ b/internal/backend/firecracker/snapshot_test.go
@@ -455,6 +455,29 @@ func TestSnapshotConfigForStorageRefRejectsDriverMismatch(t *testing.T) {
 	}
 }
 
+func TestSnapshotConfigForStorageRefIgnoresFilesystemPathsWithZFSNamespaceComponents(t *testing.T) {
+	t.Parallel()
+
+	refs := []string{
+		"/var/lib/buildkite-agent/state/cleanroom/snapshots/firecracker/snap-test/rootfs.ext4",
+		"/var/lib/buildkite-agent/state/cleanroom/sandboxes/cr-test/rootfs-persistent.ext4",
+	}
+	for _, ref := range refs {
+		cfg, err := snapshotConfigForStorageRef(backend.FirecrackerConfig{
+			Snapshots: backend.SnapshotConfig{Driver: "file"},
+		}, ref)
+		if err != nil {
+			t.Fatalf("snapshotConfigForStorageRef returned error for %q: %v", ref, err)
+		}
+		if got, want := cfg.Snapshots.Driver, "file"; got != want {
+			t.Fatalf("unexpected snapshot driver for %q: got %q want %q", ref, got, want)
+		}
+		if cfg.Snapshots.ZFSDataset != "" {
+			t.Fatalf("expected no inferred zfs dataset root for %q, got %q", ref, cfg.Snapshots.ZFSDataset)
+		}
+	}
+}
+
 func TestRootFSVolumeStoreDriverAllowsWritableVolumesWhenSnapshotsDisabled(t *testing.T) {
 	t.Parallel()
 

--- a/internal/backend/firecracker/snapshot_test.go
+++ b/internal/backend/firecracker/snapshot_test.go
@@ -2,6 +2,7 @@ package firecracker
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -14,6 +15,59 @@ import (
 	"github.com/buildkite/cleanroom/internal/volumestore"
 	"github.com/buildkite/cleanroom/internal/vsockexec"
 )
+
+type testVolumeDriver struct {
+	ensureBaseVolumeFn      func(context.Context, volumestore.EnsureBaseVolumeRequest) (volumestore.BaseVolume, error)
+	createWritableVolumeFn  func(context.Context, volumestore.CreateWritableVolumeRequest) (volumestore.WritableVolume, error)
+	snapshotVolumeFn        func(context.Context, volumestore.SnapshotVolumeRequest) (volumestore.Snapshot, error)
+	cloneSnapshotToVolumeFn func(context.Context, volumestore.CloneSnapshotToVolumeRequest) (volumestore.WritableVolume, error)
+	destroyVolumeFn         func(context.Context, volumestore.DestroyVolumeRequest) error
+	destroySnapshotFn       func(context.Context, volumestore.DestroySnapshotRequest) error
+}
+
+func (d testVolumeDriver) Name() string { return "test" }
+
+func (d testVolumeDriver) EnsureBaseVolume(ctx context.Context, req volumestore.EnsureBaseVolumeRequest) (volumestore.BaseVolume, error) {
+	if d.ensureBaseVolumeFn == nil {
+		return volumestore.BaseVolume{}, errors.New("unexpected EnsureBaseVolume call")
+	}
+	return d.ensureBaseVolumeFn(ctx, req)
+}
+
+func (d testVolumeDriver) CreateWritableVolume(ctx context.Context, req volumestore.CreateWritableVolumeRequest) (volumestore.WritableVolume, error) {
+	if d.createWritableVolumeFn == nil {
+		return volumestore.WritableVolume{}, errors.New("unexpected CreateWritableVolume call")
+	}
+	return d.createWritableVolumeFn(ctx, req)
+}
+
+func (d testVolumeDriver) SnapshotVolume(ctx context.Context, req volumestore.SnapshotVolumeRequest) (volumestore.Snapshot, error) {
+	if d.snapshotVolumeFn == nil {
+		return volumestore.Snapshot{}, errors.New("unexpected SnapshotVolume call")
+	}
+	return d.snapshotVolumeFn(ctx, req)
+}
+
+func (d testVolumeDriver) CloneSnapshotToVolume(ctx context.Context, req volumestore.CloneSnapshotToVolumeRequest) (volumestore.WritableVolume, error) {
+	if d.cloneSnapshotToVolumeFn == nil {
+		return volumestore.WritableVolume{}, errors.New("unexpected CloneSnapshotToVolume call")
+	}
+	return d.cloneSnapshotToVolumeFn(ctx, req)
+}
+
+func (d testVolumeDriver) DestroyVolume(ctx context.Context, req volumestore.DestroyVolumeRequest) error {
+	if d.destroyVolumeFn == nil {
+		return nil
+	}
+	return d.destroyVolumeFn(ctx, req)
+}
+
+func (d testVolumeDriver) DestroySnapshot(ctx context.Context, req volumestore.DestroySnapshotRequest) error {
+	if d.destroySnapshotFn == nil {
+		return nil
+	}
+	return d.destroySnapshotFn(ctx, req)
+}
 
 func TestCreateSnapshotSyncsPausesAndClonesRootFS(t *testing.T) {
 	stateHome := t.TempDir()
@@ -163,6 +217,59 @@ func TestCreateSnapshotUsesConfiguredSnapshotBaseDir(t *testing.T) {
 	}
 	if got, want := result.StorageRef, filepath.Join(baseDir, "firecracker", "snap-test", "rootfs.ext4"); got != want {
 		t.Fatalf("unexpected snapshot storage ref: got %q want %q", got, want)
+	}
+}
+
+func TestCreateSnapshotUsesManagedVolumeRef(t *testing.T) {
+	stateHome := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateHome)
+
+	managedVolumePath := filepath.Join(t.TempDir(), "managed-volume.ext4")
+	if err := os.WriteFile(managedVolumePath, []byte("snapshot-bytes"), 0o644); err != nil {
+		t.Fatalf("write managed volume: %v", err)
+	}
+
+	prevSignal := sendProcessSignal
+	sendProcessSignal = func(_ *os.Process, _ syscall.Signal) error { return nil }
+	t.Cleanup(func() { sendProcessSignal = prevSignal })
+
+	adapter := &Adapter{
+		runGuestCommandFn: func(_ context.Context, _ context.Context, _ <-chan struct{}, _ func() error, _ string, _ uint32, req vsockexec.ExecRequest, _ backend.OutputStream) (vsockexec.ExecResponse, guestExecTiming, error) {
+			if len(req.Command) != 1 || req.Command[0] != "sync" {
+				t.Fatalf("unexpected command: %v", req.Command)
+			}
+			return vsockexec.ExecResponse{ExitCode: 0}, guestExecTiming{}, nil
+		},
+		sandboxes: map[string]*sandboxInstance{
+			"cr-test": {
+				SandboxID:    "cr-test",
+				VsockPath:    "/tmp/fake.sock",
+				GuestPort:    10700,
+				fcCmd:        &exec.Cmd{Process: &os.Process{Pid: 42}},
+				exitedCh:     make(chan struct{}),
+				vmRootFSPath: "/dev/zvol/tank/cleanroom/sandboxes/cr-test",
+				volumeRef:    managedVolumePath,
+			},
+		},
+	}
+
+	result, err := adapter.CreateSnapshot(context.Background(), backend.SnapshotRequest{
+		SandboxID:  "cr-test",
+		SnapshotID: "snap-test",
+		FirecrackerConfig: backend.FirecrackerConfig{
+			Snapshots: backend.SnapshotConfig{Enabled: true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateSnapshot returned error: %v", err)
+	}
+
+	data, err := os.ReadFile(result.StorageRef)
+	if err != nil {
+		t.Fatalf("read snapshot rootfs: %v", err)
+	}
+	if got, want := string(data), "snapshot-bytes"; got != want {
+		t.Fatalf("unexpected snapshot contents: got %q want %q", got, want)
 	}
 }
 
@@ -322,5 +429,75 @@ func TestSnapshotVolumeStoreDriverRejectsDisabledSnapshots(t *testing.T) {
 	}
 	if got := err.Error(); got == "" || !strings.Contains(got, "not enabled") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPreparePersistentWritableVolumeUsesBaseVolumeForRootFSPath(t *testing.T) {
+	t.Parallel()
+
+	rootfsPath := filepath.Join(t.TempDir(), "runtime-rootfs.ext4")
+	if err := os.WriteFile(rootfsPath, []byte("runtime"), 0o644); err != nil {
+		t.Fatalf("write rootfs: %v", err)
+	}
+
+	var (
+		gotEnsureReq volumestore.EnsureBaseVolumeRequest
+		gotCreateReq volumestore.CreateWritableVolumeRequest
+	)
+	driver := testVolumeDriver{
+		ensureBaseVolumeFn: func(_ context.Context, req volumestore.EnsureBaseVolumeRequest) (volumestore.BaseVolume, error) {
+			gotEnsureReq = req
+			return volumestore.BaseVolume{Ref: "base-ref"}, nil
+		},
+		createWritableVolumeFn: func(_ context.Context, req volumestore.CreateWritableVolumeRequest) (volumestore.WritableVolume, error) {
+			gotCreateReq = req
+			return volumestore.WritableVolume{Ref: "volume-ref", AttachmentPath: req.AttachmentPath}, nil
+		},
+	}
+
+	writable, err := preparePersistentWritableVolume(context.Background(), driver, "sandbox-1", t.TempDir(), rootfsPath)
+	if err != nil {
+		t.Fatalf("preparePersistentWritableVolume returned error: %v", err)
+	}
+	if got, want := gotEnsureReq.SourcePath, rootfsPath; got != want {
+		t.Fatalf("unexpected base source path: got %q want %q", got, want)
+	}
+	if got, want := gotEnsureReq.BaseID, "runtime-rootfs"; got != want {
+		t.Fatalf("unexpected base id: got %q want %q", got, want)
+	}
+	if got, want := gotCreateReq.BaseRef, "base-ref"; got != want {
+		t.Fatalf("unexpected base ref: got %q want %q", got, want)
+	}
+	if got, want := gotCreateReq.VolumeID, "sandbox-1"; got != want {
+		t.Fatalf("unexpected volume id: got %q want %q", got, want)
+	}
+	if got, want := writable.Ref, "volume-ref"; got != want {
+		t.Fatalf("unexpected writable volume ref: got %q want %q", got, want)
+	}
+}
+
+func TestPreparePersistentWritableVolumeUsesSnapshotCloneForSnapshotRef(t *testing.T) {
+	t.Parallel()
+
+	var gotCloneReq volumestore.CloneSnapshotToVolumeRequest
+	driver := testVolumeDriver{
+		cloneSnapshotToVolumeFn: func(_ context.Context, req volumestore.CloneSnapshotToVolumeRequest) (volumestore.WritableVolume, error) {
+			gotCloneReq = req
+			return volumestore.WritableVolume{Ref: "tank/cleanroom/sandboxes/sandbox-1", AttachmentPath: "/dev/zvol/tank/cleanroom/sandboxes/sandbox-1"}, nil
+		},
+	}
+
+	writable, err := preparePersistentWritableVolume(context.Background(), driver, "sandbox-1", t.TempDir(), "tank/cleanroom/sandboxes/source@snap-golden")
+	if err != nil {
+		t.Fatalf("preparePersistentWritableVolume returned error: %v", err)
+	}
+	if got, want := gotCloneReq.SnapshotRef, "tank/cleanroom/sandboxes/source@snap-golden"; got != want {
+		t.Fatalf("unexpected snapshot ref: got %q want %q", got, want)
+	}
+	if got, want := gotCloneReq.VolumeID, "sandbox-1"; got != want {
+		t.Fatalf("unexpected volume id: got %q want %q", got, want)
+	}
+	if got, want := writable.AttachmentPath, "/dev/zvol/tank/cleanroom/sandboxes/sandbox-1"; got != want {
+		t.Fatalf("unexpected attachment path: got %q want %q", got, want)
 	}
 }

--- a/internal/backend/firecracker/snapshot_test.go
+++ b/internal/backend/firecracker/snapshot_test.go
@@ -426,6 +426,21 @@ func TestSnapshotConfigForStorageRefInfersZFSDriverFromStoredRef(t *testing.T) {
 	}
 }
 
+func TestSnapshotConfigForStorageRefInfersZFSDriverFromManagedVolumeRef(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := snapshotConfigForStorageRef(backend.FirecrackerConfig{}, "tank/cleanroom/sandboxes/sandbox-1")
+	if err != nil {
+		t.Fatalf("snapshotConfigForStorageRef returned error: %v", err)
+	}
+	if got, want := cfg.Snapshots.Driver, "zfs"; got != want {
+		t.Fatalf("unexpected snapshot driver: got %q want %q", got, want)
+	}
+	if got, want := cfg.Snapshots.ZFSDataset, "tank/cleanroom"; got != want {
+		t.Fatalf("unexpected zfs dataset root: got %q want %q", got, want)
+	}
+}
+
 func TestSnapshotConfigForStorageRefRejectsDriverMismatch(t *testing.T) {
 	t.Parallel()
 

--- a/internal/backend/firecracker/snapshot_test.go
+++ b/internal/backend/firecracker/snapshot_test.go
@@ -377,6 +377,34 @@ func TestProvisionSandboxFromSnapshotUsesSnapshotRootFS(t *testing.T) {
 	}
 }
 
+func TestSnapshotConfigForStorageRefUsesStoredZFSDataset(t *testing.T) {
+	t.Parallel()
+
+	cfg := snapshotConfigForStorageRef(backend.FirecrackerConfig{
+		Snapshots: backend.SnapshotConfig{
+			Driver:     "zfs",
+			ZFSDataset: "tank/other",
+		},
+	}, "tank/cleanroom/snapshots/snap-test@seed")
+	if got, want := cfg.Snapshots.ZFSDataset, "tank/cleanroom"; got != want {
+		t.Fatalf("unexpected zfs dataset root: got %q want %q", got, want)
+	}
+}
+
+func TestSnapshotConfigForStorageRefLeavesConfiguredDatasetForNonStoredRef(t *testing.T) {
+	t.Parallel()
+
+	cfg := snapshotConfigForStorageRef(backend.FirecrackerConfig{
+		Snapshots: backend.SnapshotConfig{
+			Driver:     "zfs",
+			ZFSDataset: "tank/cleanroom",
+		},
+	}, "tank/cleanroom/sandboxes/sandbox-1@snap-golden")
+	if got, want := cfg.Snapshots.ZFSDataset, "tank/cleanroom"; got != want {
+		t.Fatalf("unexpected zfs dataset root: got %q want %q", got, want)
+	}
+}
+
 func TestRootFSVolumeStoreDriverAllowsWritableVolumesWhenSnapshotsDisabled(t *testing.T) {
 	t.Parallel()
 

--- a/internal/backend/firecracker/snapshot_test.go
+++ b/internal/backend/firecracker/snapshot_test.go
@@ -380,12 +380,15 @@ func TestProvisionSandboxFromSnapshotUsesSnapshotRootFS(t *testing.T) {
 func TestSnapshotConfigForStorageRefUsesStoredZFSDataset(t *testing.T) {
 	t.Parallel()
 
-	cfg := snapshotConfigForStorageRef(backend.FirecrackerConfig{
+	cfg, err := snapshotConfigForStorageRef(backend.FirecrackerConfig{
 		Snapshots: backend.SnapshotConfig{
 			Driver:     "zfs",
 			ZFSDataset: "tank/other",
 		},
 	}, "tank/cleanroom/snapshots/snap-test@seed")
+	if err != nil {
+		t.Fatalf("snapshotConfigForStorageRef returned error: %v", err)
+	}
 	if got, want := cfg.Snapshots.ZFSDataset, "tank/cleanroom"; got != want {
 		t.Fatalf("unexpected zfs dataset root: got %q want %q", got, want)
 	}
@@ -394,14 +397,46 @@ func TestSnapshotConfigForStorageRefUsesStoredZFSDataset(t *testing.T) {
 func TestSnapshotConfigForStorageRefLeavesConfiguredDatasetForNonStoredRef(t *testing.T) {
 	t.Parallel()
 
-	cfg := snapshotConfigForStorageRef(backend.FirecrackerConfig{
+	cfg, err := snapshotConfigForStorageRef(backend.FirecrackerConfig{
 		Snapshots: backend.SnapshotConfig{
 			Driver:     "zfs",
 			ZFSDataset: "tank/cleanroom",
 		},
 	}, "tank/cleanroom/sandboxes/sandbox-1@snap-golden")
+	if err != nil {
+		t.Fatalf("snapshotConfigForStorageRef returned error: %v", err)
+	}
 	if got, want := cfg.Snapshots.ZFSDataset, "tank/cleanroom"; got != want {
 		t.Fatalf("unexpected zfs dataset root: got %q want %q", got, want)
+	}
+}
+
+func TestSnapshotConfigForStorageRefInfersZFSDriverFromStoredRef(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := snapshotConfigForStorageRef(backend.FirecrackerConfig{}, "tank/cleanroom/snapshots/snap-test@seed")
+	if err != nil {
+		t.Fatalf("snapshotConfigForStorageRef returned error: %v", err)
+	}
+	if got, want := cfg.Snapshots.Driver, "zfs"; got != want {
+		t.Fatalf("unexpected snapshot driver: got %q want %q", got, want)
+	}
+	if got, want := cfg.Snapshots.ZFSDataset, "tank/cleanroom"; got != want {
+		t.Fatalf("unexpected zfs dataset root: got %q want %q", got, want)
+	}
+}
+
+func TestSnapshotConfigForStorageRefRejectsDriverMismatch(t *testing.T) {
+	t.Parallel()
+
+	_, err := snapshotConfigForStorageRef(backend.FirecrackerConfig{
+		Snapshots: backend.SnapshotConfig{Driver: "file"},
+	}, "tank/cleanroom/snapshots/snap-test@seed")
+	if err == nil {
+		t.Fatal("expected snapshotConfigForStorageRef to reject driver mismatch")
+	}
+	if !strings.Contains(err.Error(), "requires zfs driver") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/internal/backend/firecracker/snapshot_test.go
+++ b/internal/backend/firecracker/snapshot_test.go
@@ -451,19 +451,31 @@ func TestPreparePersistentWritableVolumeUsesBaseVolumeForRootFSPath(t *testing.T
 		},
 		createWritableVolumeFn: func(_ context.Context, req volumestore.CreateWritableVolumeRequest) (volumestore.WritableVolume, error) {
 			gotCreateReq = req
+			if err := os.WriteFile(req.AttachmentPath, nil, 0o644); err != nil {
+				return volumestore.WritableVolume{}, err
+			}
+			if err := os.Truncate(req.AttachmentPath, 8<<20); err != nil {
+				return volumestore.WritableVolume{}, err
+			}
 			return volumestore.WritableVolume{Ref: "volume-ref", AttachmentPath: req.AttachmentPath}, nil
 		},
 	}
 
-	writable, err := preparePersistentWritableVolume(context.Background(), driver, "sandbox-1", t.TempDir(), rootfsPath)
+	writable, cleanupVolume, err := preparePersistentWritableVolume(context.Background(), driver, "sandbox-1", t.TempDir(), rootfsPath, 8<<20)
 	if err != nil {
 		t.Fatalf("preparePersistentWritableVolume returned error: %v", err)
+	}
+	if cleanupVolume == nil {
+		t.Fatal("expected cleanup function")
 	}
 	if got, want := gotEnsureReq.SourcePath, rootfsPath; got != want {
 		t.Fatalf("unexpected base source path: got %q want %q", got, want)
 	}
 	if got, want := gotEnsureReq.BaseID, "runtime-rootfs"; got != want {
 		t.Fatalf("unexpected base id: got %q want %q", got, want)
+	}
+	if got, want := gotEnsureReq.MinimumBytes, int64(8<<20); got != want {
+		t.Fatalf("unexpected minimum bytes: got %d want %d", got, want)
 	}
 	if got, want := gotCreateReq.BaseRef, "base-ref"; got != want {
 		t.Fatalf("unexpected base ref: got %q want %q", got, want)
@@ -487,9 +499,12 @@ func TestPreparePersistentWritableVolumeUsesSnapshotCloneForSnapshotRef(t *testi
 		},
 	}
 
-	writable, err := preparePersistentWritableVolume(context.Background(), driver, "sandbox-1", t.TempDir(), "tank/cleanroom/sandboxes/source@snap-golden")
+	writable, cleanupVolume, err := preparePersistentWritableVolume(context.Background(), driver, "sandbox-1", t.TempDir(), "tank/cleanroom/sandboxes/source@snap-golden", 0)
 	if err != nil {
 		t.Fatalf("preparePersistentWritableVolume returned error: %v", err)
+	}
+	if cleanupVolume == nil {
+		t.Fatal("expected cleanup function")
 	}
 	if got, want := gotCloneReq.SnapshotRef, "tank/cleanroom/sandboxes/source@snap-golden"; got != want {
 		t.Fatalf("unexpected snapshot ref: got %q want %q", got, want)
@@ -499,5 +514,34 @@ func TestPreparePersistentWritableVolumeUsesSnapshotCloneForSnapshotRef(t *testi
 	}
 	if got, want := writable.AttachmentPath, "/dev/zvol/tank/cleanroom/sandboxes/sandbox-1"; got != want {
 		t.Fatalf("unexpected attachment path: got %q want %q", got, want)
+	}
+}
+
+func TestPreparePersistentWritableVolumeCleansUpOnResizeFailure(t *testing.T) {
+	t.Parallel()
+
+	var destroyed string
+	driver := testVolumeDriver{
+		cloneSnapshotToVolumeFn: func(_ context.Context, req volumestore.CloneSnapshotToVolumeRequest) (volumestore.WritableVolume, error) {
+			return volumestore.WritableVolume{
+				Ref:            "tank/cleanroom/sandboxes/sandbox-1",
+				AttachmentPath: filepath.Join(t.TempDir(), "missing.ext4"),
+			}, nil
+		},
+		destroyVolumeFn: func(_ context.Context, req volumestore.DestroyVolumeRequest) error {
+			destroyed = req.VolumeRef
+			return nil
+		},
+	}
+
+	_, cleanupVolume, err := preparePersistentWritableVolume(context.Background(), driver, "sandbox-1", t.TempDir(), "tank/cleanroom/sandboxes/source@snap-golden", 8<<20)
+	if err == nil {
+		t.Fatal("expected preparePersistentWritableVolume to fail")
+	}
+	if cleanupVolume != nil {
+		t.Fatal("expected cleanup function to be discarded on failure")
+	}
+	if got, want := destroyed, "tank/cleanroom/sandboxes/sandbox-1"; got != want {
+		t.Fatalf("unexpected destroyed volume ref: got %q want %q", got, want)
 	}
 }

--- a/internal/backend/firecracker/snapshot_zfs_e2e_test.go
+++ b/internal/backend/firecracker/snapshot_zfs_e2e_test.go
@@ -1,0 +1,309 @@
+//go:build linux
+
+package firecracker
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/policy"
+)
+
+const (
+	firecrackerZFSE2EEnvEnabled     = "CLEANROOM_FIRECRACKER_ZFS_E2E"
+	firecrackerZFSE2EEnvImageRef    = "CLEANROOM_FIRECRACKER_ZFS_E2E_IMAGE_REF"
+	firecrackerZFSE2EEnvKernelImage = "CLEANROOM_FIRECRACKER_ZFS_E2E_KERNEL_IMAGE"
+	firecrackerZFSE2EEnvBinary      = "CLEANROOM_FIRECRACKER_ZFS_E2E_BINARY"
+	firecrackerZFSE2EEnvHelper      = "CLEANROOM_FIRECRACKER_ZFS_E2E_HELPER"
+	firecrackerZFSE2EEnvDataset     = "CLEANROOM_FIRECRACKER_ZFS_E2E_ZFS_DATASET"
+)
+
+func defaultFirecrackerZFSE2EImageRef() string {
+	return "docker.io/library/alpine@sha256:a4f4213abb84c497377b8544c81b3564f313746700372ec4fe84653e4fb03805"
+}
+
+func defaultFirecrackerZFSE2EDataset() string {
+	if dataset := strings.TrimSpace(os.Getenv("CLEANROOM_ZFS_DATASET")); dataset != "" {
+		return dataset
+	}
+	return "cleanroom/data"
+}
+
+func TestSnapshotLifecycleZFSE2E(t *testing.T) {
+	if strings.TrimSpace(os.Getenv(firecrackerZFSE2EEnvEnabled)) == "" {
+		t.Skipf("set %s=1 to run real firecracker zfs snapshot e2e", firecrackerZFSE2EEnvEnabled)
+	}
+	if testing.Short() {
+		t.Skip("skipping firecracker zfs e2e in short mode")
+	}
+
+	imageRef := strings.TrimSpace(os.Getenv(firecrackerZFSE2EEnvImageRef))
+	if imageRef == "" {
+		imageRef = defaultFirecrackerZFSE2EImageRef()
+	}
+	cfg := backend.FirecrackerConfig{
+		BinaryPath:           strings.TrimSpace(os.Getenv(firecrackerZFSE2EEnvBinary)),
+		KernelImagePath:      strings.TrimSpace(os.Getenv(firecrackerZFSE2EEnvKernelImage)),
+		PrivilegedHelperPath: strings.TrimSpace(os.Getenv(firecrackerZFSE2EEnvHelper)),
+		VCPUs:                1,
+		MemoryMiB:            1024,
+		LaunchSeconds:        120,
+		Snapshots: backend.SnapshotConfig{
+			Enabled:               true,
+			Driver:                "zfs",
+			ZFSDataset:            strings.TrimSpace(os.Getenv(firecrackerZFSE2EEnvDataset)),
+			QuiesceTimeoutSeconds: 15,
+		},
+	}
+	if cfg.Snapshots.ZFSDataset == "" {
+		cfg.Snapshots.ZFSDataset = defaultFirecrackerZFSE2EDataset()
+	}
+
+	compiled := &policy.CompiledPolicy{
+		Version:        1,
+		ImageRef:       imageRef,
+		NetworkDefault: "deny",
+	}
+	adapter := New()
+
+	report, err := adapter.Doctor(context.Background(), backend.DoctorRequest{
+		Policy:            compiled,
+		FirecrackerConfig: cfg,
+	})
+	if err != nil {
+		t.Fatalf("Doctor returned error: %v", err)
+	}
+	if failures := firecrackerDoctorFailures(report); len(failures) > 0 {
+		t.Fatalf("firecracker doctor reported failures:\n%s", strings.Join(failures, "\n"))
+	}
+	if got := firecrackerDoctorCheckStatus(report, "snapshot_zfs_dataset_access"); got != "pass" {
+		t.Fatalf("expected snapshot_zfs_dataset_access=pass, got %q", got)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	sandboxID := fmt.Sprintf("cr-zfs-e2e-%d", time.Now().UnixNano())
+	fromSnapshotSandboxID := sandboxID + "-from-snapshot"
+	snapshotID := fmt.Sprintf("snap-%d", time.Now().UnixNano())
+	markerPath := fmt.Sprintf("/tmp/%s-marker.txt", sandboxID)
+
+	snapshotStorageRef := ""
+	sourceVolumeRef := ""
+	forkVolumeRef := ""
+	terminatedSource := false
+	terminatedFork := false
+	deletedSnapshot := false
+
+	defer func() {
+		if !terminatedFork {
+			if err := adapter.TerminateSandbox(context.Background(), fromSnapshotSandboxID); err != nil {
+				t.Errorf("deferred TerminateSandbox for snapshot-backed sandbox: %v", err)
+			}
+		}
+		if !terminatedSource {
+			if err := adapter.TerminateSandbox(context.Background(), sandboxID); err != nil {
+				t.Errorf("deferred TerminateSandbox for source sandbox: %v", err)
+			}
+		}
+		if snapshotStorageRef != "" && !deletedSnapshot {
+			if err := adapter.DeleteSnapshot(context.Background(), backend.DeleteSnapshotRequest{
+				SnapshotID:        snapshotID,
+				StorageRef:        snapshotStorageRef,
+				FirecrackerConfig: cfg,
+			}); err != nil {
+				t.Errorf("deferred DeleteSnapshot: %v", err)
+			}
+		}
+	}()
+
+	if err := adapter.ProvisionSandbox(ctx, backend.ProvisionRequest{
+		SandboxID:         sandboxID,
+		Policy:            compiled,
+		FirecrackerConfig: cfg,
+	}); err != nil {
+		t.Fatalf("ProvisionSandbox returned error: %v", err)
+	}
+	sourceVolumeRef = firecrackerSandboxVolumeRef(t, adapter, sandboxID)
+
+	runCommand := func(ctx context.Context, sandboxID, runID string, command ...string) string {
+		t.Helper()
+
+		result, err := adapter.RunInSandbox(ctx, backend.RunRequest{
+			SandboxID: sandboxID,
+			RunID:     runID,
+			Command:   command,
+			Policy:    compiled,
+			FirecrackerConfig: backend.FirecrackerConfig{
+				LaunchSeconds: cfg.LaunchSeconds,
+			},
+		}, backend.OutputStream{})
+		if err != nil {
+			t.Fatalf("%s returned error: %v", runID, err)
+		}
+		if result.ExitCode != 0 {
+			t.Fatalf("%s exit code=%d stdout=%q stderr=%q", runID, result.ExitCode, result.Stdout, result.Stderr)
+		}
+		return strings.TrimSpace(result.Stdout)
+	}
+
+	beforeValue := "snapshot-before"
+	afterValue := "snapshot-after"
+	fromSnapshotValue := "snapshot-backed-updated"
+
+	runCommand(ctx, sandboxID, "run-before", "sh", "-lc", fmt.Sprintf("printf '%%s' %s > %s", beforeValue, markerPath))
+
+	snapshot, err := adapter.CreateSnapshot(ctx, backend.SnapshotRequest{
+		SandboxID:         sandboxID,
+		SnapshotID:        snapshotID,
+		FirecrackerConfig: cfg,
+	})
+	if err != nil {
+		t.Fatalf("CreateSnapshot returned error: %v", err)
+	}
+	snapshotStorageRef = snapshot.StorageRef
+	if snapshotStorageRef == "" {
+		t.Fatal("expected snapshot storage ref")
+	}
+	firecrackerRequireZFSRefState(t, ctx, cfg, snapshotStorageRef, true)
+
+	runCommand(ctx, sandboxID, "run-after", "sh", "-lc", fmt.Sprintf("printf '%%s' %s > %s", afterValue, markerPath))
+	if got, want := runCommand(ctx, sandboxID, "cat-after", "sh", "-lc", "cat "+markerPath), afterValue; got != want {
+		t.Fatalf("unexpected post-snapshot marker: got %q want %q", got, want)
+	}
+
+	if err := adapter.TerminateSandbox(ctx, sandboxID); err != nil {
+		t.Fatalf("TerminateSandbox returned error: %v", err)
+	}
+	terminatedSource = true
+	firecrackerRequireZFSRefState(t, ctx, cfg, sourceVolumeRef, false)
+	firecrackerRequireZFSRefState(t, ctx, cfg, snapshotStorageRef, true)
+
+	restoreCfg := cfg
+	restoreCfg.Snapshots.ZFSDataset = ""
+	if err := adapter.ProvisionSandboxFromSnapshot(ctx, backend.ProvisionFromSnapshotRequest{
+		SandboxID:         fromSnapshotSandboxID,
+		SnapshotID:        snapshotID,
+		StorageRef:        snapshotStorageRef,
+		Policy:            compiled,
+		FirecrackerConfig: restoreCfg,
+	}); err != nil {
+		t.Fatalf("ProvisionSandboxFromSnapshot returned error: %v", err)
+	}
+	forkVolumeRef = firecrackerSandboxVolumeRef(t, adapter, fromSnapshotSandboxID)
+	if got, want := runCommand(ctx, fromSnapshotSandboxID, "cat-from-snapshot", "sh", "-lc", "cat "+markerPath), beforeValue; got != want {
+		t.Fatalf("unexpected snapshot-backed marker: got %q want %q", got, want)
+	}
+
+	runCommand(ctx, fromSnapshotSandboxID, "run-from-snapshot", "sh", "-lc", fmt.Sprintf("printf '%%s' %s > %s", fromSnapshotValue, markerPath))
+	if got, want := runCommand(ctx, fromSnapshotSandboxID, "cat-from-snapshot-updated", "sh", "-lc", "cat "+markerPath), fromSnapshotValue; got != want {
+		t.Fatalf("unexpected updated snapshot-backed marker: got %q want %q", got, want)
+	}
+	firecrackerRequireZFSRefState(t, ctx, cfg, snapshotStorageRef, true)
+
+	if err := adapter.TerminateSandbox(ctx, fromSnapshotSandboxID); err != nil {
+		t.Fatalf("TerminateSandbox for snapshot-backed sandbox returned error: %v", err)
+	}
+	terminatedFork = true
+	firecrackerRequireZFSRefState(t, ctx, cfg, forkVolumeRef, false)
+	firecrackerRequireZFSRefState(t, ctx, cfg, snapshotStorageRef, true)
+
+	deleteCfg := cfg
+	deleteCfg.Snapshots.ZFSDataset = ""
+	if err := adapter.DeleteSnapshot(ctx, backend.DeleteSnapshotRequest{
+		SnapshotID:        snapshotID,
+		StorageRef:        snapshotStorageRef,
+		FirecrackerConfig: deleteCfg,
+	}); err != nil {
+		t.Fatalf("DeleteSnapshot returned error: %v", err)
+	}
+	deletedSnapshot = true
+	firecrackerRequireZFSRefState(t, ctx, cfg, snapshotStorageRef, false)
+}
+
+func firecrackerSandboxVolumeRef(t *testing.T, adapter *Adapter, sandboxID string) string {
+	t.Helper()
+
+	adapter.sandboxMu.Lock()
+	defer adapter.sandboxMu.Unlock()
+
+	instance := adapter.sandboxes[sandboxID]
+	if instance == nil {
+		t.Fatalf("expected sandbox %q to be provisioned", sandboxID)
+	}
+	if volumeRef := strings.TrimSpace(instance.volumeRef); volumeRef != "" {
+		return volumeRef
+	}
+	t.Fatalf("sandbox %q is missing managed volume ref", sandboxID)
+	return ""
+}
+
+func firecrackerRequireZFSRefState(t *testing.T, ctx context.Context, cfg backend.FirecrackerConfig, ref string, wantExists bool) {
+	t.Helper()
+
+	exists, err := firecrackerZFSRefExists(ctx, cfg, ref)
+	if err != nil {
+		t.Fatalf("inspect zfs ref %q: %v", ref, err)
+	}
+	if exists != wantExists {
+		t.Fatalf("unexpected zfs ref state for %q: got exists=%t want exists=%t", ref, exists, wantExists)
+	}
+}
+
+func firecrackerZFSRefExists(ctx context.Context, cfg backend.FirecrackerConfig, ref string) (bool, error) {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return false, nil
+	}
+
+	out, err := runRootCommandOutput(ctx, cfg, "zfs", "list", "-H", "-o", "name", ref)
+	if err != nil {
+		if firecrackerZFSMissingError(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return strings.TrimSpace(string(out)) == ref, nil
+}
+
+func firecrackerZFSMissingError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "dataset does not exist") ||
+		strings.Contains(msg, "no such pool or dataset") ||
+		strings.Contains(msg, "snapshot does not exist") ||
+		strings.Contains(msg, "could not find any snapshots to destroy")
+}
+
+func firecrackerDoctorCheckStatus(report *backend.DoctorReport, name string) string {
+	if report == nil {
+		return ""
+	}
+	for _, check := range report.Checks {
+		if check.Name == name {
+			return check.Status
+		}
+	}
+	return ""
+}
+
+func firecrackerDoctorFailures(report *backend.DoctorReport) []string {
+	if report == nil {
+		return nil
+	}
+	failures := make([]string, 0)
+	for _, check := range report.Checks {
+		if check.Status != "fail" {
+			continue
+		}
+		failures = append(failures, fmt.Sprintf("%s: %s", check.Name, check.Message))
+	}
+	return failures
+}

--- a/internal/cli/config_init_test.go
+++ b/internal/cli/config_init_test.go
@@ -81,6 +81,9 @@ func TestConfigInitWritesRuntimeConfig(t *testing.T) {
 	if strings.Contains(string(raw), "base_dir:") {
 		t.Fatalf("expected generated config to omit empty snapshot base_dir, got:\n%s", raw)
 	}
+	if strings.Contains(string(raw), "zfs_dataset:") {
+		t.Fatalf("expected generated config to omit empty snapshot zfs_dataset, got:\n%s", raw)
+	}
 	if strings.Contains(string(raw), "quiesce_timeout_seconds:") {
 		t.Fatalf("expected generated config to omit empty snapshot quiesce timeout, got:\n%s", raw)
 	}

--- a/internal/ext4image/resize.go
+++ b/internal/ext4image/resize.go
@@ -103,6 +103,14 @@ func blockDeviceSizeBytes(imagePath string) (int64, error) {
 	return sectors * 512, nil
 }
 
+func PathSizeBytes(imagePath string) (int64, bool, error) {
+	return pathSizeBytes(imagePath)
+}
+
+func AlignBytes(size int64) int64 {
+	return alignBytes(size)
+}
+
 func alignBytes(size int64) int64 {
 	if size <= 0 {
 		return imageSizeAlignBytes

--- a/internal/ext4image/resize.go
+++ b/internal/ext4image/resize.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/buildkite/cleanroom/internal/hosttools"
@@ -16,7 +18,10 @@ const imageSizeAlignBytes int64 = 4 << 20
 var (
 	resolveE2FSProgsBinary = hosttools.ResolveE2FSProgsBinary
 	runCommand             = runCommandWithAllowedExitCodes
+	statPath               = os.Stat
 	truncateFile           = os.Truncate
+	evalSymlinks           = filepath.EvalSymlinks
+	readFile               = os.ReadFile
 )
 
 func EnsureMinimumSize(ctx context.Context, imagePath string, minimumBytes int64) error {
@@ -24,12 +29,15 @@ func EnsureMinimumSize(ctx context.Context, imagePath string, minimumBytes int64
 		return nil
 	}
 
-	info, err := os.Stat(imagePath)
+	currentBytes, isBlockDevice, err := pathSizeBytes(imagePath)
 	if err != nil {
-		return fmt.Errorf("stat ext4 image %q: %w", imagePath, err)
+		return err
 	}
-	if info.Size() >= minimumBytes {
+	if currentBytes >= minimumBytes && !isBlockDevice {
 		return nil
+	}
+	if isBlockDevice && currentBytes < minimumBytes {
+		return fmt.Errorf("block device %q is %d bytes, below requested minimum %d bytes", imagePath, currentBytes, minimumBytes)
 	}
 
 	targetBytes := alignBytes(minimumBytes)
@@ -46,13 +54,53 @@ func EnsureMinimumSize(ctx context.Context, imagePath string, minimumBytes int64
 	if err := runCommand(ctx, e2fsckBinary, []string{"-fy", imagePath}, 0, 1); err != nil {
 		return fmt.Errorf("prepare ext4 image %q for resize: %w", imagePath, err)
 	}
-	if err := truncateFile(imagePath, targetBytes); err != nil {
-		return fmt.Errorf("truncate ext4 image %q to %d bytes: %w", imagePath, targetBytes, err)
+	if !isBlockDevice {
+		if err := truncateFile(imagePath, targetBytes); err != nil {
+			return fmt.Errorf("truncate ext4 image %q to %d bytes: %w", imagePath, targetBytes, err)
+		}
 	}
 	if err := runCommand(ctx, resize2fsBinary, []string{imagePath}, 0); err != nil {
 		return fmt.Errorf("grow ext4 filesystem in %q: %w", imagePath, err)
 	}
 	return nil
+}
+
+func pathSizeBytes(imagePath string) (int64, bool, error) {
+	info, err := statPath(imagePath)
+	if err != nil {
+		return 0, false, fmt.Errorf("stat ext4 image %q: %w", imagePath, err)
+	}
+
+	mode := info.Mode()
+	isBlockDevice := mode&os.ModeDevice != 0 && mode&os.ModeCharDevice == 0
+	if !isBlockDevice {
+		return info.Size(), false, nil
+	}
+
+	sizeBytes, err := blockDeviceSizeBytes(imagePath)
+	if err != nil {
+		return 0, true, err
+	}
+	return sizeBytes, true, nil
+}
+
+func blockDeviceSizeBytes(imagePath string) (int64, error) {
+	resolvedPath, err := evalSymlinks(imagePath)
+	if err != nil {
+		return 0, fmt.Errorf("resolve block device %q: %w", imagePath, err)
+	}
+
+	sectorsPath := filepath.Join("/sys/class/block", filepath.Base(resolvedPath), "size")
+	data, err := readFile(sectorsPath)
+	if err != nil {
+		return 0, fmt.Errorf("read block device size for %q: %w", imagePath, err)
+	}
+
+	sectors, err := strconv.ParseInt(strings.TrimSpace(string(data)), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse block device size for %q: %w", imagePath, err)
+	}
+	return sectors * 512, nil
 }
 
 func alignBytes(size int64) int64 {

--- a/internal/ext4image/resize_test.go
+++ b/internal/ext4image/resize_test.go
@@ -3,11 +3,13 @@ package ext4image
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestEnsureMinimumSizeNoOpWhenAlreadyLarge(t *testing.T) {
@@ -91,23 +93,124 @@ func TestEnsureMinimumSizePropagatesResolveError(t *testing.T) {
 	}
 }
 
+func TestEnsureMinimumSizeGrowsBlockDeviceWithoutTruncate(t *testing.T) {
+	restore := stubResizeDependencies()
+	defer restore()
+
+	imagePath := "/dev/zvol/tank/cleanroom/sandboxes/sandbox-1"
+	statPath = func(string) (os.FileInfo, error) {
+		return fakeFileInfo{mode: os.ModeDevice}, nil
+	}
+	evalSymlinks = func(string) (string, error) {
+		return "/dev/zd42", nil
+	}
+	readFile = func(path string) ([]byte, error) {
+		wantPath := filepath.Join("/sys/class/block", "zd42", "size")
+		if path != wantPath {
+			return nil, fmt.Errorf("unexpected size path %q", path)
+		}
+		return []byte("24576\n"), nil
+	}
+	truncateCalled := false
+	truncateFile = func(string, int64) error {
+		truncateCalled = true
+		return nil
+	}
+
+	var gotCommands [][]string
+	runCommand = func(_ context.Context, binary string, args []string, allowedExitCodes ...int) error {
+		record := append([]string{binary}, append([]string(nil), args...)...)
+		gotCommands = append(gotCommands, record)
+		return nil
+	}
+
+	if err := EnsureMinimumSize(context.Background(), imagePath, int64((9<<20)+1)); err != nil {
+		t.Fatalf("EnsureMinimumSize returned error: %v", err)
+	}
+
+	wantCommands := [][]string{
+		{"e2fsck-path", "-fy", imagePath},
+		{"resize2fs-path", imagePath},
+	}
+	if !reflect.DeepEqual(gotCommands, wantCommands) {
+		t.Fatalf("unexpected resize commands: got %#v want %#v", gotCommands, wantCommands)
+	}
+	if truncateCalled {
+		t.Fatal("expected block-device resize to avoid truncate")
+	}
+}
+
+func TestEnsureMinimumSizeRejectsTooSmallBlockDevice(t *testing.T) {
+	restore := stubResizeDependencies()
+	defer restore()
+
+	imagePath := "/dev/zvol/tank/cleanroom/sandboxes/sandbox-1"
+	statPath = func(string) (os.FileInfo, error) {
+		return fakeFileInfo{mode: os.ModeDevice}, nil
+	}
+	evalSymlinks = func(string) (string, error) {
+		return "/dev/zd42", nil
+	}
+	readFile = func(string) ([]byte, error) {
+		return []byte("16384\n"), nil
+	}
+
+	var called bool
+	runCommand = func(context.Context, string, []string, ...int) error {
+		called = true
+		return nil
+	}
+
+	err := EnsureMinimumSize(context.Background(), imagePath, int64((9<<20)+1))
+	if err == nil {
+		t.Fatal("expected block-device resize to fail")
+	}
+	if !strings.Contains(err.Error(), "below requested minimum") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if called {
+		t.Fatal("expected resize commands to be skipped")
+	}
+}
+
 func stubResizeDependencies() func() {
 	prevResolve := resolveE2FSProgsBinary
 	prevRun := runCommand
+	prevStat := statPath
 	prevTruncate := truncateFile
+	prevEvalSymlinks := evalSymlinks
+	prevReadFile := readFile
 
 	resolveE2FSProgsBinary = func(binary string) (string, error) {
 		return binary + "-path", nil
 	}
 	runCommand = runCommandWithAllowedExitCodes
+	statPath = os.Stat
 	truncateFile = os.Truncate
+	evalSymlinks = filepath.EvalSymlinks
+	readFile = os.ReadFile
 
 	return func() {
 		resolveE2FSProgsBinary = prevResolve
 		runCommand = prevRun
+		statPath = prevStat
 		truncateFile = prevTruncate
+		evalSymlinks = prevEvalSymlinks
+		readFile = prevReadFile
 	}
 }
+
+type fakeFileInfo struct {
+	mode os.FileMode
+	size int64
+}
+
+func (f fakeFileInfo) Name() string       { return "fake" }
+func (f fakeFileInfo) Size() int64        { return f.size }
+func (f fakeFileInfo) Mode() os.FileMode  { return f.mode }
+func (f fakeFileInfo) ModTime() time.Time { return time.Time{} }
+func (f fakeFileInfo) IsDir() bool        { return false }
+func (f fakeFileInfo) Sys() any           { return nil }
 
 func createSizedTempFile(t *testing.T, size int64) string {
 	t.Helper()

--- a/internal/runtimeconfig/config.go
+++ b/internal/runtimeconfig/config.go
@@ -52,6 +52,7 @@ type SnapshotConfig struct {
 	Enabled               bool   `yaml:"enabled"`
 	Driver                string `yaml:"driver"`
 	BaseDir               string `yaml:"base_dir,omitempty"`
+	ZFSDataset            string `yaml:"zfs_dataset,omitempty"`
 	QuiesceTimeoutSeconds int64  `yaml:"quiesce_timeout_seconds,omitempty"`
 }
 
@@ -92,6 +93,7 @@ func MergeBackendConfig(cfg Config, backendName string, launchSeconds int64) bac
 			Enabled:               cfg.Backends.Firecracker.Snapshots.Enabled,
 			Driver:                cfg.Backends.Firecracker.Snapshots.Driver,
 			BaseDir:               cfg.Backends.Firecracker.Snapshots.BaseDir,
+			ZFSDataset:            cfg.Backends.Firecracker.Snapshots.ZFSDataset,
 			QuiesceTimeoutSeconds: cfg.Backends.Firecracker.Snapshots.QuiesceTimeoutSeconds,
 		},
 		PrivilegedHelperPath: cfg.Backends.Firecracker.PrivilegedHelperPath,
@@ -111,6 +113,7 @@ func MergeBackendConfig(cfg Config, backendName string, launchSeconds int64) bac
 			Enabled:               cfg.Backends.DarwinVZ.Snapshots.Enabled,
 			Driver:                cfg.Backends.DarwinVZ.Snapshots.Driver,
 			BaseDir:               cfg.Backends.DarwinVZ.Snapshots.BaseDir,
+			ZFSDataset:            cfg.Backends.DarwinVZ.Snapshots.ZFSDataset,
 			QuiesceTimeoutSeconds: cfg.Backends.DarwinVZ.Snapshots.QuiesceTimeoutSeconds,
 		}
 		out.VCPUs = cfg.Backends.DarwinVZ.VCPUs
@@ -241,5 +244,6 @@ func snapshotConfigIsZero(cfg SnapshotConfig) bool {
 	return !cfg.Enabled &&
 		strings.TrimSpace(cfg.Driver) == "" &&
 		strings.TrimSpace(cfg.BaseDir) == "" &&
+		strings.TrimSpace(cfg.ZFSDataset) == "" &&
 		cfg.QuiesceTimeoutSeconds == 0
 }

--- a/internal/runtimeconfig/config_test.go
+++ b/internal/runtimeconfig/config_test.go
@@ -205,8 +205,9 @@ func TestLoadParsesSnapshotConfig(t *testing.T) {
   firecracker:
     snapshots:
       enabled: true
-      driver: file
+      driver: zfs
       base_dir: /var/tmp/cleanroom-snapshots
+      zfs_dataset: tank/cleanroom
       quiesce_timeout_seconds: 15
   darwin-vz:
     snapshots:
@@ -225,11 +226,14 @@ func TestLoadParsesSnapshotConfig(t *testing.T) {
 	if !cfg.Backends.Firecracker.Snapshots.Enabled {
 		t.Fatal("expected firecracker snapshots to be enabled")
 	}
-	if got, want := cfg.Backends.Firecracker.Snapshots.Driver, "file"; got != want {
+	if got, want := cfg.Backends.Firecracker.Snapshots.Driver, "zfs"; got != want {
 		t.Fatalf("unexpected firecracker snapshot driver: got %q want %q", got, want)
 	}
 	if got, want := cfg.Backends.Firecracker.Snapshots.BaseDir, "/var/tmp/cleanroom-snapshots"; got != want {
 		t.Fatalf("unexpected firecracker snapshot base_dir: got %q want %q", got, want)
+	}
+	if got, want := cfg.Backends.Firecracker.Snapshots.ZFSDataset, "tank/cleanroom"; got != want {
+		t.Fatalf("unexpected firecracker snapshot zfs_dataset: got %q want %q", got, want)
 	}
 	if got, want := cfg.Backends.Firecracker.Snapshots.QuiesceTimeoutSeconds, int64(15); got != want {
 		t.Fatalf("unexpected firecracker snapshot quiesce timeout: got %d want %d", got, want)
@@ -295,7 +299,7 @@ func TestMergeBackendConfig(t *testing.T) {
 				KernelImage:          "/firecracker/kernel",
 				RootFS:               "/firecracker/rootfs.ext4",
 				Services:             ServicesConfig{Docker: DockerServiceConfig{StartupTimeoutSeconds: 12, StorageDriver: "overlay2", IPTables: true}},
-				Snapshots:            SnapshotConfig{Enabled: true, Driver: "file", BaseDir: "/firecracker/snapshots", QuiesceTimeoutSeconds: 15},
+				Snapshots:            SnapshotConfig{Enabled: true, Driver: "zfs", BaseDir: "/firecracker/snapshots", ZFSDataset: "tank/cleanroom", QuiesceTimeoutSeconds: 15},
 				PrivilegedHelperPath: "/usr/local/bin/cleanroom-root-helper",
 				VCPUs:                2,
 				MemoryMiB:            1024,
@@ -323,7 +327,7 @@ func TestMergeBackendConfig(t *testing.T) {
 	if got, want := firecrackerCfg.LaunchSeconds, int64(99); got != want {
 		t.Fatalf("unexpected firecracker launch seconds: got %d want %d", got, want)
 	}
-	if got, want := firecrackerCfg.Snapshots, (backend.SnapshotConfig{Enabled: true, Driver: "file", BaseDir: "/firecracker/snapshots", QuiesceTimeoutSeconds: 15}); got != want {
+	if got, want := firecrackerCfg.Snapshots, (backend.SnapshotConfig{Enabled: true, Driver: "zfs", BaseDir: "/firecracker/snapshots", ZFSDataset: "tank/cleanroom", QuiesceTimeoutSeconds: 15}); got != want {
 		t.Fatalf("unexpected firecracker snapshots config: got %#v want %#v", got, want)
 	}
 

--- a/internal/volumestore/resize.go
+++ b/internal/volumestore/resize.go
@@ -1,0 +1,11 @@
+package volumestore
+
+import (
+	"context"
+
+	"github.com/buildkite/cleanroom/internal/ext4image"
+)
+
+func EnsureWritableVolumeMinimumSize(ctx context.Context, volume WritableVolume, minimumBytes int64) error {
+	return ext4image.EnsureMinimumSize(ctx, volume.AttachmentPath, minimumBytes)
+}

--- a/internal/volumestore/resize.go
+++ b/internal/volumestore/resize.go
@@ -6,6 +6,19 @@ import (
 	"github.com/buildkite/cleanroom/internal/ext4image"
 )
 
-func EnsureWritableVolumeMinimumSize(ctx context.Context, volume WritableVolume, minimumBytes int64) error {
-	return ext4image.EnsureMinimumSize(ctx, volume.AttachmentPath, minimumBytes)
+type writableVolumeSizer interface {
+	EnsureWritableVolumeMinimumSize(context.Context, WritableVolume, int64) error
+}
+
+var (
+	ext4imageEnsureMinimumSize = ext4image.EnsureMinimumSize
+	ext4imagePathSizeBytes     = ext4image.PathSizeBytes
+	ext4imageAlignBytes        = ext4image.AlignBytes
+)
+
+func EnsureWritableVolumeMinimumSize(ctx context.Context, driver Driver, volume WritableVolume, minimumBytes int64) error {
+	if sizer, ok := driver.(writableVolumeSizer); ok {
+		return sizer.EnsureWritableVolumeMinimumSize(ctx, volume, minimumBytes)
+	}
+	return ext4imageEnsureMinimumSize(ctx, volume.AttachmentPath, minimumBytes)
 }

--- a/internal/volumestore/store.go
+++ b/internal/volumestore/store.go
@@ -13,8 +13,9 @@ type Driver interface {
 }
 
 type EnsureBaseVolumeRequest struct {
-	BaseID     string
-	SourcePath string
+	BaseID       string
+	SourcePath   string
+	MinimumBytes int64
 }
 
 type BaseVolume struct {

--- a/internal/volumestore/zfs.go
+++ b/internal/volumestore/zfs.go
@@ -307,21 +307,27 @@ func ZFSDatasetRootFromManagedRef(ref string) (string, bool) {
 		return "", false
 	}
 
-	components := strings.Split(strings.Trim(dataset, "/"), "/")
-	for idx, component := range components {
-		switch component {
-		case zfsBaseNamespace, zfsSandboxNamespace, zfsSnapshotNamespace:
-			if idx == 0 {
-				return "", false
-			}
-			root := strings.TrimSpace(strings.Join(components[:idx], "/"))
-			if root == "" {
-				return "", false
-			}
-			return root, true
+	components := strings.Split(dataset, "/")
+	if len(components) < 3 {
+		return "", false
+	}
+	for _, component := range components {
+		if strings.TrimSpace(component) == "" {
+			return "", false
 		}
 	}
-	return "", false
+
+	switch components[len(components)-2] {
+	case zfsBaseNamespace, zfsSandboxNamespace, zfsSnapshotNamespace:
+	default:
+		return "", false
+	}
+
+	root := strings.TrimSpace(strings.Join(components[:len(components)-2], "/"))
+	if root == "" {
+		return "", false
+	}
+	return root, true
 }
 
 func (d *ZFSDriver) cloneSnapshot(ctx context.Context, snapshotRef, dataset string) (WritableVolume, error) {

--- a/internal/volumestore/zfs.go
+++ b/internal/volumestore/zfs.go
@@ -161,6 +161,10 @@ func (d *ZFSDriver) SnapshotVolume(ctx context.Context, req SnapshotVolumeReques
 		_ = d.DestroyVolume(context.Background(), DestroyVolumeRequest{VolumeRef: storedDataset})
 	}()
 
+	if err := d.runner.Run(ctx, "zfs", "promote", storedDataset); err != nil {
+		return Snapshot{}, fmt.Errorf("promote zfs dataset %q: %w", storedDataset, err)
+	}
+
 	if err := d.runner.Run(ctx, "zfs", "snapshot", storedSnapshotRef); err != nil {
 		return Snapshot{}, fmt.Errorf("create zfs snapshot %q: %w", storedSnapshotRef, err)
 	}
@@ -203,8 +207,8 @@ func (d *ZFSDriver) DestroySnapshot(ctx context.Context, req DestroySnapshotRequ
 	}
 
 	command := []string{"zfs", "destroy", snapshotRef}
-	if d.isStoredSnapshot(snapshotRef) {
-		command = []string{"zfs", "destroy", "-r", datasetFromSnapshotRef(snapshotRef)}
+	if dataset, ok := storedZFSSnapshotDataset(snapshotRef); ok {
+		command = []string{"zfs", "destroy", "-r", dataset}
 	}
 	if err := d.runner.Run(ctx, command[0], command[1:]...); err != nil {
 		if isZFSMissingError(err) {
@@ -239,13 +243,38 @@ func (d *ZFSDriver) snapshotRef(dataset, snapshotName string) string {
 	return dataset + "@" + sanitizeZFSDatasetComponent(snapshotName)
 }
 
-func (d *ZFSDriver) isStoredSnapshot(snapshotRef string) bool {
+func storedZFSSnapshotDataset(snapshotRef string) (string, bool) {
 	dataset := datasetFromSnapshotRef(snapshotRef)
 	if dataset == "" {
-		return false
+		return "", false
 	}
-	prefix := d.datasetPath(zfsSnapshotNamespace)
-	return dataset == prefix || strings.HasPrefix(dataset, prefix+"/")
+	marker := "/" + zfsSnapshotNamespace + "/"
+	idx := strings.LastIndex(dataset, marker)
+	if idx <= 0 {
+		return "", false
+	}
+	if strings.TrimSpace(dataset[idx+len(marker):]) == "" {
+		return "", false
+	}
+	return dataset, true
+}
+
+func ZFSDatasetRootFromStoredSnapshotRef(snapshotRef string) (string, bool) {
+	dataset, ok := storedZFSSnapshotDataset(snapshotRef)
+	if !ok {
+		return "", false
+	}
+
+	marker := "/" + zfsSnapshotNamespace + "/"
+	idx := strings.LastIndex(dataset, marker)
+	if idx <= 0 {
+		return "", false
+	}
+	root := strings.TrimSpace(dataset[:idx])
+	if root == "" {
+		return "", false
+	}
+	return root, true
 }
 
 func (d *ZFSDriver) cloneSnapshot(ctx context.Context, snapshotRef, dataset string) (WritableVolume, error) {

--- a/internal/volumestore/zfs.go
+++ b/internal/volumestore/zfs.go
@@ -1,0 +1,257 @@
+package volumestore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+const zfsBaseSnapshotName = "seed"
+
+type ZFSCommandRunner interface {
+	Run(ctx context.Context, command string, args ...string) error
+	Output(ctx context.Context, command string, args ...string) ([]byte, error)
+}
+
+type ZFSDriverOptions struct {
+	DatasetRoot string
+	Runner      ZFSCommandRunner
+	Stat        func(string) (os.FileInfo, error)
+}
+
+type ZFSDriver struct {
+	datasetRoot string
+	runner      ZFSCommandRunner
+	stat        func(string) (os.FileInfo, error)
+}
+
+func NewZFSDriver(opts ZFSDriverOptions) (*ZFSDriver, error) {
+	datasetRoot := strings.Trim(strings.TrimSpace(opts.DatasetRoot), "/")
+	if datasetRoot == "" {
+		return nil, errors.New("zfs volume driver requires dataset root")
+	}
+	if opts.Runner == nil {
+		return nil, errors.New("zfs volume driver requires command runner")
+	}
+
+	statFn := opts.Stat
+	if statFn == nil {
+		statFn = os.Stat
+	}
+
+	return &ZFSDriver{
+		datasetRoot: datasetRoot,
+		runner:      opts.Runner,
+		stat:        statFn,
+	}, nil
+}
+
+func (d *ZFSDriver) Name() string { return "zfs" }
+
+func (d *ZFSDriver) EnsureBaseVolume(ctx context.Context, req EnsureBaseVolumeRequest) (BaseVolume, error) {
+	sourcePath := strings.TrimSpace(req.SourcePath)
+	if sourcePath == "" {
+		return BaseVolume{}, errors.New("zfs volume driver requires source path")
+	}
+	info, err := d.stat(sourcePath)
+	if err != nil {
+		return BaseVolume{}, fmt.Errorf("inspect base volume source %q: %w", sourcePath, err)
+	}
+	if info.Size() <= 0 {
+		return BaseVolume{}, fmt.Errorf("inspect base volume source %q: empty file", sourcePath)
+	}
+
+	baseDataset := d.datasetPath("base", sanitizeZFSDatasetComponent(req.BaseID))
+	baseSnapshot := d.snapshotRef(baseDataset, zfsBaseSnapshotName)
+
+	baseExists, err := d.refExists(ctx, baseDataset)
+	if err != nil {
+		return BaseVolume{}, err
+	}
+	if !baseExists {
+		if err := d.runner.Run(ctx, "zfs", "create", "-p", "-V", strconv.FormatInt(info.Size(), 10), baseDataset); err != nil {
+			return BaseVolume{}, fmt.Errorf("create zfs base volume %q: %w", baseDataset, err)
+		}
+		if err := d.runner.Run(ctx, "dd", "if="+sourcePath, "of="+zvolDevicePath(baseDataset), "bs=4M", "conv=fsync", "status=none"); err != nil {
+			_ = d.runner.Run(context.Background(), "zfs", "destroy", "-r", baseDataset)
+			return BaseVolume{}, fmt.Errorf("seed zfs base volume %q: %w", baseDataset, err)
+		}
+	}
+
+	snapshotExists, err := d.refExists(ctx, baseSnapshot)
+	if err != nil {
+		return BaseVolume{}, err
+	}
+	if !snapshotExists {
+		if err := d.runner.Run(ctx, "zfs", "snapshot", baseSnapshot); err != nil {
+			return BaseVolume{}, fmt.Errorf("create zfs base snapshot %q: %w", baseSnapshot, err)
+		}
+	}
+
+	return BaseVolume{Ref: baseSnapshot}, nil
+}
+
+func (d *ZFSDriver) CreateWritableVolume(ctx context.Context, req CreateWritableVolumeRequest) (WritableVolume, error) {
+	baseRef := strings.TrimSpace(req.BaseRef)
+	if baseRef == "" {
+		return WritableVolume{}, errors.New("zfs volume driver requires base ref")
+	}
+	if !strings.Contains(baseRef, "@") {
+		return WritableVolume{}, fmt.Errorf("zfs base ref %q must be a snapshot", baseRef)
+	}
+
+	dataset := d.datasetPath("sandboxes", sanitizeZFSDatasetComponent(req.VolumeID))
+	return d.cloneSnapshot(ctx, baseRef, dataset)
+}
+
+func (d *ZFSDriver) SnapshotVolume(ctx context.Context, req SnapshotVolumeRequest) (Snapshot, error) {
+	volumeRef := strings.TrimSpace(req.VolumeRef)
+	if volumeRef == "" {
+		return Snapshot{}, errors.New("zfs volume driver requires volume ref")
+	}
+
+	snapshotID := sanitizeZFSDatasetComponent(req.SnapshotID)
+	if snapshotID == "" {
+		return Snapshot{}, errors.New("zfs volume driver requires snapshot id")
+	}
+
+	snapshotRef := d.snapshotRef(volumeRef, "snap-"+snapshotID)
+	if err := d.runner.Run(ctx, "zfs", "snapshot", snapshotRef); err != nil {
+		return Snapshot{}, fmt.Errorf("create zfs snapshot %q: %w", snapshotRef, err)
+	}
+
+	return Snapshot{Ref: snapshotRef, StorageRef: snapshotRef}, nil
+}
+
+func (d *ZFSDriver) CloneSnapshotToVolume(ctx context.Context, req CloneSnapshotToVolumeRequest) (WritableVolume, error) {
+	snapshotRef := strings.TrimSpace(req.SnapshotRef)
+	if snapshotRef == "" {
+		return WritableVolume{}, errors.New("zfs volume driver requires snapshot ref")
+	}
+	if !strings.Contains(snapshotRef, "@") {
+		return WritableVolume{}, fmt.Errorf("zfs snapshot ref %q must be a snapshot", snapshotRef)
+	}
+
+	dataset := d.datasetPath("sandboxes", sanitizeZFSDatasetComponent(req.VolumeID))
+	return d.cloneSnapshot(ctx, snapshotRef, dataset)
+}
+
+func (d *ZFSDriver) DestroyVolume(ctx context.Context, req DestroyVolumeRequest) error {
+	volumeRef := strings.TrimSpace(req.VolumeRef)
+	if volumeRef == "" {
+		return nil
+	}
+	if err := d.runner.Run(ctx, "zfs", "destroy", "-r", volumeRef); err != nil {
+		if isZFSMissingError(err) {
+			return nil
+		}
+		return fmt.Errorf("destroy zfs volume %q: %w", volumeRef, err)
+	}
+	return nil
+}
+
+func (d *ZFSDriver) DestroySnapshot(ctx context.Context, req DestroySnapshotRequest) error {
+	snapshotRef := strings.TrimSpace(req.SnapshotRef)
+	if snapshotRef == "" {
+		return nil
+	}
+	if err := d.runner.Run(ctx, "zfs", "destroy", snapshotRef); err != nil {
+		if isZFSMissingError(err) {
+			return nil
+		}
+		return fmt.Errorf("destroy zfs snapshot %q: %w", snapshotRef, err)
+	}
+	return nil
+}
+
+func (d *ZFSDriver) datasetPath(parts ...string) string {
+	items := []string{d.datasetRoot}
+	for _, part := range parts {
+		part = strings.Trim(strings.TrimSpace(part), "/")
+		if part == "" {
+			continue
+		}
+		items = append(items, part)
+	}
+	return strings.Join(items, "/")
+}
+
+func (d *ZFSDriver) snapshotRef(dataset, snapshotName string) string {
+	return dataset + "@" + sanitizeZFSDatasetComponent(snapshotName)
+}
+
+func (d *ZFSDriver) cloneSnapshot(ctx context.Context, snapshotRef, dataset string) (WritableVolume, error) {
+	exists, err := d.refExists(ctx, dataset)
+	if err != nil {
+		return WritableVolume{}, err
+	}
+	if exists {
+		return WritableVolume{}, fmt.Errorf("zfs dataset %q already exists", dataset)
+	}
+	if err := d.runner.Run(ctx, "zfs", "clone", "-p", snapshotRef, dataset); err != nil {
+		return WritableVolume{}, fmt.Errorf("clone zfs snapshot %q into %q: %w", snapshotRef, dataset, err)
+	}
+	return WritableVolume{
+		Ref:            dataset,
+		AttachmentPath: zvolDevicePath(dataset),
+	}, nil
+}
+
+func (d *ZFSDriver) refExists(ctx context.Context, ref string) (bool, error) {
+	out, err := d.runner.Output(ctx, "zfs", "list", "-H", "-o", "name", ref)
+	if err != nil {
+		if isZFSMissingError(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("inspect zfs ref %q: %w", ref, err)
+	}
+	return strings.TrimSpace(string(out)) != "", nil
+}
+
+func sanitizeZFSDatasetComponent(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+
+	var b strings.Builder
+	b.Grow(len(value))
+	lastDash := false
+	for _, r := range value {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '-' || r == '.' || r == ':' {
+			b.WriteRune(r)
+			lastDash = false
+			continue
+		}
+		if !lastDash {
+			b.WriteByte('-')
+			lastDash = true
+		}
+	}
+
+	out := strings.Trim(b.String(), "-")
+	if out == "" {
+		return "cleanroom"
+	}
+	return out
+}
+
+func zvolDevicePath(dataset string) string {
+	return filepath.Join(append([]string{"/dev/zvol"}, strings.Split(strings.TrimSpace(dataset), "/")...)...)
+}
+
+func isZFSMissingError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "dataset does not exist") ||
+		strings.Contains(msg, "no such pool or dataset") ||
+		strings.Contains(msg, "snapshot does not exist") ||
+		strings.Contains(msg, "could not find any snapshots to destroy")
+}

--- a/internal/volumestore/zfs.go
+++ b/internal/volumestore/zfs.go
@@ -219,6 +219,24 @@ func (d *ZFSDriver) DestroySnapshot(ctx context.Context, req DestroySnapshotRequ
 	return nil
 }
 
+func (d *ZFSDriver) EnsureWritableVolumeMinimumSize(ctx context.Context, volume WritableVolume, minimumBytes int64) error {
+	if minimumBytes <= 0 {
+		return nil
+	}
+
+	currentBytes, isBlockDevice, err := ext4imagePathSizeBytes(volume.AttachmentPath)
+	if err != nil {
+		return err
+	}
+	if isBlockDevice && currentBytes < minimumBytes {
+		targetBytes := ext4imageAlignBytes(minimumBytes)
+		if err := d.runner.Run(ctx, "zfs", "set", "volsize="+strconv.FormatInt(targetBytes, 10), volume.Ref); err != nil {
+			return fmt.Errorf("grow zfs volume %q to %d bytes: %w", volume.Ref, targetBytes, err)
+		}
+	}
+	return ext4imageEnsureMinimumSize(ctx, volume.AttachmentPath, minimumBytes)
+}
+
 func (d *ZFSDriver) datasetPath(parts ...string) string {
 	items := []string{d.datasetRoot}
 	for _, part := range parts {
@@ -275,6 +293,35 @@ func ZFSDatasetRootFromStoredSnapshotRef(snapshotRef string) (string, bool) {
 		return "", false
 	}
 	return root, true
+}
+
+func ZFSDatasetRootFromManagedRef(ref string) (string, bool) {
+	dataset := strings.TrimSpace(ref)
+	if dataset == "" {
+		return "", false
+	}
+	if strings.Contains(dataset, "@") {
+		dataset = datasetFromSnapshotRef(dataset)
+	}
+	if dataset == "" {
+		return "", false
+	}
+
+	components := strings.Split(strings.Trim(dataset, "/"), "/")
+	for idx, component := range components {
+		switch component {
+		case zfsBaseNamespace, zfsSandboxNamespace, zfsSnapshotNamespace:
+			if idx == 0 {
+				return "", false
+			}
+			root := strings.TrimSpace(strings.Join(components[:idx], "/"))
+			if root == "" {
+				return "", false
+			}
+			return root, true
+		}
+	}
+	return "", false
 }
 
 func (d *ZFSDriver) cloneSnapshot(ctx context.Context, snapshotRef, dataset string) (WritableVolume, error) {

--- a/internal/volumestore/zfs.go
+++ b/internal/volumestore/zfs.go
@@ -69,15 +69,19 @@ func (d *ZFSDriver) EnsureBaseVolume(ctx context.Context, req EnsureBaseVolumeRe
 		return BaseVolume{}, fmt.Errorf("inspect base volume source %q: empty file", sourcePath)
 	}
 
-	baseDataset := d.datasetPath(zfsBaseNamespace, sanitizeZFSDatasetComponent(req.BaseID))
+	baseDataset := d.baseDataset(req.BaseID, req.MinimumBytes)
 	baseSnapshot := d.snapshotRef(baseDataset, zfsBaseSnapshotName)
+	volumeSize := info.Size()
+	if req.MinimumBytes > volumeSize {
+		volumeSize = req.MinimumBytes
+	}
 
 	baseExists, err := d.refExists(ctx, baseDataset)
 	if err != nil {
 		return BaseVolume{}, err
 	}
 	if !baseExists {
-		if err := d.runner.Run(ctx, "zfs", "create", "-p", "-V", strconv.FormatInt(info.Size(), 10), baseDataset); err != nil {
+		if err := d.runner.Run(ctx, "zfs", "create", "-p", "-V", strconv.FormatInt(volumeSize, 10), baseDataset); err != nil {
 			return BaseVolume{}, fmt.Errorf("create zfs base volume %q: %w", baseDataset, err)
 		}
 		if err := d.runner.Run(ctx, "dd", "if="+sourcePath, "of="+zvolDevicePath(baseDataset), "bs=4M", "conv=fsync", "status=none"); err != nil {
@@ -221,6 +225,14 @@ func (d *ZFSDriver) datasetPath(parts ...string) string {
 		items = append(items, part)
 	}
 	return strings.Join(items, "/")
+}
+
+func (d *ZFSDriver) baseDataset(baseID string, minimumBytes int64) string {
+	baseID = sanitizeZFSDatasetComponent(baseID)
+	if minimumBytes > 0 {
+		baseID = fmt.Sprintf("%s-min-%d", baseID, minimumBytes)
+	}
+	return d.datasetPath(zfsBaseNamespace, baseID)
 }
 
 func (d *ZFSDriver) snapshotRef(dataset, snapshotName string) string {

--- a/internal/volumestore/zfs.go
+++ b/internal/volumestore/zfs.go
@@ -12,6 +12,9 @@ import (
 )
 
 const zfsBaseSnapshotName = "seed"
+const zfsBaseNamespace = "base"
+const zfsSandboxNamespace = "sandboxes"
+const zfsSnapshotNamespace = "snapshots"
 
 type ZFSCommandRunner interface {
 	Run(ctx context.Context, command string, args ...string) error
@@ -66,7 +69,7 @@ func (d *ZFSDriver) EnsureBaseVolume(ctx context.Context, req EnsureBaseVolumeRe
 		return BaseVolume{}, fmt.Errorf("inspect base volume source %q: empty file", sourcePath)
 	}
 
-	baseDataset := d.datasetPath("base", sanitizeZFSDatasetComponent(req.BaseID))
+	baseDataset := d.datasetPath(zfsBaseNamespace, sanitizeZFSDatasetComponent(req.BaseID))
 	baseSnapshot := d.snapshotRef(baseDataset, zfsBaseSnapshotName)
 
 	baseExists, err := d.refExists(ctx, baseDataset)
@@ -105,7 +108,7 @@ func (d *ZFSDriver) CreateWritableVolume(ctx context.Context, req CreateWritable
 		return WritableVolume{}, fmt.Errorf("zfs base ref %q must be a snapshot", baseRef)
 	}
 
-	dataset := d.datasetPath("sandboxes", sanitizeZFSDatasetComponent(req.VolumeID))
+	dataset := d.datasetPath(zfsSandboxNamespace, sanitizeZFSDatasetComponent(req.VolumeID))
 	return d.cloneSnapshot(ctx, baseRef, dataset)
 }
 
@@ -120,12 +123,46 @@ func (d *ZFSDriver) SnapshotVolume(ctx context.Context, req SnapshotVolumeReques
 		return Snapshot{}, errors.New("zfs volume driver requires snapshot id")
 	}
 
-	snapshotRef := d.snapshotRef(volumeRef, "snap-"+snapshotID)
-	if err := d.runner.Run(ctx, "zfs", "snapshot", snapshotRef); err != nil {
-		return Snapshot{}, fmt.Errorf("create zfs snapshot %q: %w", snapshotRef, err)
+	sourceSnapshotRef := d.snapshotRef(volumeRef, "snap-"+snapshotID)
+	storedDataset := d.datasetPath(zfsSnapshotNamespace, snapshotID)
+	storedSnapshotRef := d.snapshotRef(storedDataset, zfsBaseSnapshotName)
+
+	exists, err := d.refExists(ctx, storedDataset)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	if exists {
+		return Snapshot{}, fmt.Errorf("zfs snapshot dataset %q already exists", storedDataset)
 	}
 
-	return Snapshot{Ref: snapshotRef, StorageRef: snapshotRef}, nil
+	if err := d.runner.Run(ctx, "zfs", "snapshot", sourceSnapshotRef); err != nil {
+		return Snapshot{}, fmt.Errorf("create zfs snapshot %q: %w", sourceSnapshotRef, err)
+	}
+	sourceSnapshotCreated := true
+	defer func() {
+		if !sourceSnapshotCreated {
+			return
+		}
+		_ = d.DestroySnapshot(context.Background(), DestroySnapshotRequest{SnapshotRef: sourceSnapshotRef})
+	}()
+
+	if _, err := d.cloneSnapshot(ctx, sourceSnapshotRef, storedDataset); err != nil {
+		return Snapshot{}, err
+	}
+	storedDatasetCreated := true
+	defer func() {
+		if !storedDatasetCreated {
+			return
+		}
+		_ = d.DestroyVolume(context.Background(), DestroyVolumeRequest{VolumeRef: storedDataset})
+	}()
+
+	if err := d.runner.Run(ctx, "zfs", "snapshot", storedSnapshotRef); err != nil {
+		return Snapshot{}, fmt.Errorf("create zfs snapshot %q: %w", storedSnapshotRef, err)
+	}
+	storedDatasetCreated = false
+
+	return Snapshot{Ref: storedSnapshotRef, StorageRef: storedSnapshotRef}, nil
 }
 
 func (d *ZFSDriver) CloneSnapshotToVolume(ctx context.Context, req CloneSnapshotToVolumeRequest) (WritableVolume, error) {
@@ -137,7 +174,7 @@ func (d *ZFSDriver) CloneSnapshotToVolume(ctx context.Context, req CloneSnapshot
 		return WritableVolume{}, fmt.Errorf("zfs snapshot ref %q must be a snapshot", snapshotRef)
 	}
 
-	dataset := d.datasetPath("sandboxes", sanitizeZFSDatasetComponent(req.VolumeID))
+	dataset := d.datasetPath(zfsSandboxNamespace, sanitizeZFSDatasetComponent(req.VolumeID))
 	return d.cloneSnapshot(ctx, snapshotRef, dataset)
 }
 
@@ -160,7 +197,12 @@ func (d *ZFSDriver) DestroySnapshot(ctx context.Context, req DestroySnapshotRequ
 	if snapshotRef == "" {
 		return nil
 	}
-	if err := d.runner.Run(ctx, "zfs", "destroy", snapshotRef); err != nil {
+
+	command := []string{"zfs", "destroy", snapshotRef}
+	if d.isStoredSnapshot(snapshotRef) {
+		command = []string{"zfs", "destroy", "-r", datasetFromSnapshotRef(snapshotRef)}
+	}
+	if err := d.runner.Run(ctx, command[0], command[1:]...); err != nil {
 		if isZFSMissingError(err) {
 			return nil
 		}
@@ -183,6 +225,15 @@ func (d *ZFSDriver) datasetPath(parts ...string) string {
 
 func (d *ZFSDriver) snapshotRef(dataset, snapshotName string) string {
 	return dataset + "@" + sanitizeZFSDatasetComponent(snapshotName)
+}
+
+func (d *ZFSDriver) isStoredSnapshot(snapshotRef string) bool {
+	dataset := datasetFromSnapshotRef(snapshotRef)
+	if dataset == "" {
+		return false
+	}
+	prefix := d.datasetPath(zfsSnapshotNamespace)
+	return dataset == prefix || strings.HasPrefix(dataset, prefix+"/")
 }
 
 func (d *ZFSDriver) cloneSnapshot(ctx context.Context, snapshotRef, dataset string) (WritableVolume, error) {
@@ -211,6 +262,14 @@ func (d *ZFSDriver) refExists(ctx context.Context, ref string) (bool, error) {
 		return false, fmt.Errorf("inspect zfs ref %q: %w", ref, err)
 	}
 	return strings.TrimSpace(string(out)) != "", nil
+}
+
+func datasetFromSnapshotRef(snapshotRef string) string {
+	dataset, _, ok := strings.Cut(strings.TrimSpace(snapshotRef), "@")
+	if !ok {
+		return ""
+	}
+	return dataset
 }
 
 func sanitizeZFSDatasetComponent(value string) string {

--- a/internal/volumestore/zfs_test.go
+++ b/internal/volumestore/zfs_test.go
@@ -269,10 +269,13 @@ func TestZFSDatasetRootFromManagedRef(t *testing.T) {
 	t.Parallel()
 
 	cases := map[string]string{
-		"tank/cleanroom/base/runtime-key@seed":        "tank/cleanroom",
-		"tank/cleanroom/sandboxes/sandbox-1":          "tank/cleanroom",
-		"tank/cleanroom/snapshots/golden@seed":        "tank/cleanroom",
-		"tank/cleanroom/sandboxes/source@snap-golden": "tank/cleanroom",
+		"tank/cleanroom/base/runtime-key@seed":                  "tank/cleanroom",
+		"tank/cleanroom/sandboxes/sandbox-1":                    "tank/cleanroom",
+		"tank/cleanroom/snapshots/golden@seed":                  "tank/cleanroom",
+		"tank/cleanroom/sandboxes/source@snap-golden":           "tank/cleanroom",
+		"tank/snapshots/cleanroom/sandboxes/sandbox-1":          "tank/snapshots/cleanroom",
+		"tank/base/cleanroom/snapshots/golden@seed":             "tank/base/cleanroom",
+		"tank/sandboxes/cleanroom/base/runtime-key-min-8388608": "tank/sandboxes/cleanroom",
 	}
 	for ref, want := range cases {
 		got, ok := ZFSDatasetRootFromManagedRef(ref)
@@ -280,8 +283,16 @@ func TestZFSDatasetRootFromManagedRef(t *testing.T) {
 			t.Fatalf("unexpected dataset root for %q: got %q ok=%t want %q", ref, got, ok, want)
 		}
 	}
-	if _, ok := ZFSDatasetRootFromManagedRef("/tmp/rootfs.ext4"); ok {
-		t.Fatal("expected non-zfs ref to be rejected")
+
+	rejected := []string{
+		"/tmp/rootfs.ext4",
+		"/var/lib/buildkite-agent/state/cleanroom/snapshots/firecracker/snap-test/rootfs.ext4",
+		"/var/lib/buildkite-agent/state/cleanroom/sandboxes/cr-test/rootfs-persistent.ext4",
+	}
+	for _, ref := range rejected {
+		if _, ok := ZFSDatasetRootFromManagedRef(ref); ok {
+			t.Fatalf("expected non-zfs ref %q to be rejected", ref)
+		}
 	}
 }
 

--- a/internal/volumestore/zfs_test.go
+++ b/internal/volumestore/zfs_test.go
@@ -13,6 +13,7 @@ import (
 type zfsTestRunner struct {
 	commands []string
 	exists   map[string]bool
+	origins  map[string]string
 }
 
 func (r *zfsTestRunner) Run(_ context.Context, command string, args ...string) error {
@@ -33,13 +34,40 @@ func (r *zfsTestRunner) Run(_ context.Context, command string, args ...string) e
 	case "clone":
 		if len(args) == 4 {
 			r.exists[args[3]] = true
+			if r.origins == nil {
+				r.origins = map[string]string{}
+			}
+			r.origins[args[3]] = args[2]
+		}
+	case "promote":
+		if len(args) == 2 {
+			delete(r.origins, args[1])
 		}
 	case "destroy":
 		if len(args) >= 2 {
+			recursive := len(args) >= 3 && args[1] == "-r"
 			target := args[len(args)-1]
+			if recursive {
+				for clone, origin := range r.origins {
+					if strings.HasPrefix(origin, target+"@") && clone != target && !strings.HasPrefix(clone, target+"/") {
+						return fmt.Errorf("cannot destroy %s: snapshot has dependent clones", target)
+					}
+				}
+			} else if strings.Contains(target, "@") {
+				for _, origin := range r.origins {
+					if origin == target {
+						return fmt.Errorf("cannot destroy %s: snapshot has dependent clones", target)
+					}
+				}
+			}
 			for ref := range r.exists {
 				if ref == target || strings.HasPrefix(ref, target+"@") || strings.HasPrefix(ref, target+"/") {
 					delete(r.exists, ref)
+				}
+			}
+			for clone := range r.origins {
+				if clone == target || strings.HasPrefix(clone, target+"/") {
+					delete(r.origins, clone)
 				}
 			}
 		}
@@ -154,11 +182,11 @@ func TestZFSDriverSnapshotSurvivesSourceVolumeDestroy(t *testing.T) {
 		t.Fatalf("unexpected cloned volume ref: got %q want %q", got, want)
 	}
 
-	if err := driver.DestroySnapshot(context.Background(), DestroySnapshotRequest{SnapshotRef: snapshot.Ref}); err != nil {
-		t.Fatalf("DestroySnapshot returned error: %v", err)
-	}
 	if err := driver.DestroyVolume(context.Background(), DestroyVolumeRequest{VolumeRef: clone.Ref}); err != nil {
 		t.Fatalf("DestroyVolume returned error: %v", err)
+	}
+	if err := driver.DestroySnapshot(context.Background(), DestroySnapshotRequest{SnapshotRef: snapshot.Ref}); err != nil {
+		t.Fatalf("DestroySnapshot returned error: %v", err)
 	}
 
 	wantCommands := []string{
@@ -166,13 +194,14 @@ func TestZFSDriverSnapshotSurvivesSourceVolumeDestroy(t *testing.T) {
 		"zfs snapshot tank/cleanroom/sandboxes/sandbox-1@snap-golden",
 		"zfs list -H -o name tank/cleanroom/snapshots/golden",
 		"zfs clone -p tank/cleanroom/sandboxes/sandbox-1@snap-golden tank/cleanroom/snapshots/golden",
+		"zfs promote tank/cleanroom/snapshots/golden",
 		"zfs snapshot tank/cleanroom/snapshots/golden@seed",
 		"zfs destroy tank/cleanroom/sandboxes/sandbox-1@snap-golden",
 		"zfs destroy -r tank/cleanroom/sandboxes/sandbox-1",
 		"zfs list -H -o name tank/cleanroom/sandboxes/sandbox-2",
 		"zfs clone -p tank/cleanroom/snapshots/golden@seed tank/cleanroom/sandboxes/sandbox-2",
-		"zfs destroy -r tank/cleanroom/snapshots/golden",
 		"zfs destroy -r tank/cleanroom/sandboxes/sandbox-2",
+		"zfs destroy -r tank/cleanroom/snapshots/golden",
 	}
 	if got, want := runner.commands, wantCommands; strings.Join(got, "\n") != strings.Join(want, "\n") {
 		t.Fatalf("unexpected zfs commands:\n got: %v\nwant: %v", got, want)
@@ -222,5 +251,16 @@ func TestZFSDriverRequiresDatasetRoot(t *testing.T) {
 	_, err := NewZFSDriver(ZFSDriverOptions{})
 	if err == nil || !strings.Contains(err.Error(), "dataset root") {
 		t.Fatalf("expected dataset root error, got %v", err)
+	}
+}
+
+func TestZFSDatasetRootFromStoredSnapshotRef(t *testing.T) {
+	t.Parallel()
+
+	if got, ok := ZFSDatasetRootFromStoredSnapshotRef("tank/cleanroom/snapshots/golden@seed"); !ok || got != "tank/cleanroom" {
+		t.Fatalf("unexpected dataset root: got %q ok=%t", got, ok)
+	}
+	if _, ok := ZFSDatasetRootFromStoredSnapshotRef("tank/cleanroom/sandboxes/sandbox-1@snap-golden"); ok {
+		t.Fatal("expected non-stored snapshot ref to be rejected")
 	}
 }

--- a/internal/volumestore/zfs_test.go
+++ b/internal/volumestore/zfs_test.go
@@ -1,0 +1,172 @@
+package volumestore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type zfsTestRunner struct {
+	commands []string
+	exists   map[string]bool
+}
+
+func (r *zfsTestRunner) Run(_ context.Context, command string, args ...string) error {
+	r.commands = append(r.commands, strings.Join(append([]string{command}, args...), " "))
+	if command != "zfs" || len(args) == 0 {
+		return nil
+	}
+
+	switch args[0] {
+	case "create":
+		if len(args) == 5 {
+			r.exists[args[4]] = true
+		}
+	case "snapshot":
+		if len(args) == 2 {
+			r.exists[args[1]] = true
+		}
+	case "clone":
+		if len(args) == 4 {
+			r.exists[args[3]] = true
+		}
+	case "destroy":
+		if len(args) >= 2 {
+			delete(r.exists, args[len(args)-1])
+		}
+	}
+
+	return nil
+}
+
+func (r *zfsTestRunner) Output(_ context.Context, command string, args ...string) ([]byte, error) {
+	r.commands = append(r.commands, strings.Join(append([]string{command}, args...), " "))
+	if command == "zfs" && len(args) == 5 && args[0] == "list" {
+		ref := args[4]
+		if r.exists[ref] {
+			return []byte(ref + "\n"), nil
+		}
+		return nil, errors.New("cannot open dataset: dataset does not exist")
+	}
+	return nil, fmt.Errorf("unsupported output command: %s %s", command, strings.Join(args, " "))
+}
+
+func TestZFSDriverEnsureBaseVolumeAndCloneLifecycle(t *testing.T) {
+	sourcePath := filepath.Join(t.TempDir(), "prepared.ext4")
+	if err := os.WriteFile(sourcePath, []byte("base-bytes"), 0o644); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+
+	runner := &zfsTestRunner{exists: map[string]bool{}}
+	driver, err := NewZFSDriver(ZFSDriverOptions{
+		DatasetRoot: "tank/cleanroom",
+		Runner:      runner,
+	})
+	if err != nil {
+		t.Fatalf("NewZFSDriver returned error: %v", err)
+	}
+
+	base, err := driver.EnsureBaseVolume(context.Background(), EnsureBaseVolumeRequest{
+		BaseID:     "runtime-key",
+		SourcePath: sourcePath,
+	})
+	if err != nil {
+		t.Fatalf("EnsureBaseVolume returned error: %v", err)
+	}
+	if got, want := base.Ref, "tank/cleanroom/base/runtime-key@seed"; got != want {
+		t.Fatalf("unexpected base ref: got %q want %q", got, want)
+	}
+
+	volume, err := driver.CreateWritableVolume(context.Background(), CreateWritableVolumeRequest{
+		VolumeID: "sandbox-1",
+		BaseRef:  base.Ref,
+	})
+	if err != nil {
+		t.Fatalf("CreateWritableVolume returned error: %v", err)
+	}
+	if got, want := volume.Ref, "tank/cleanroom/sandboxes/sandbox-1"; got != want {
+		t.Fatalf("unexpected volume ref: got %q want %q", got, want)
+	}
+	if got, want := volume.AttachmentPath, "/dev/zvol/tank/cleanroom/sandboxes/sandbox-1"; got != want {
+		t.Fatalf("unexpected attachment path: got %q want %q", got, want)
+	}
+
+	wantCommands := []string{
+		"zfs list -H -o name tank/cleanroom/base/runtime-key",
+		"zfs create -p -V 10 tank/cleanroom/base/runtime-key",
+		"dd if=" + sourcePath + " of=/dev/zvol/tank/cleanroom/base/runtime-key bs=4M conv=fsync status=none",
+		"zfs list -H -o name tank/cleanroom/base/runtime-key@seed",
+		"zfs snapshot tank/cleanroom/base/runtime-key@seed",
+		"zfs list -H -o name tank/cleanroom/sandboxes/sandbox-1",
+		"zfs clone -p tank/cleanroom/base/runtime-key@seed tank/cleanroom/sandboxes/sandbox-1",
+	}
+	if got, want := runner.commands, wantCommands; strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("unexpected zfs commands:\n got: %v\nwant: %v", got, want)
+	}
+}
+
+func TestZFSDriverSnapshotCloneAndDestroy(t *testing.T) {
+	runner := &zfsTestRunner{
+		exists: map[string]bool{
+			"tank/cleanroom/sandboxes/sandbox-1": true,
+		},
+	}
+	driver, err := NewZFSDriver(ZFSDriverOptions{
+		DatasetRoot: "tank/cleanroom",
+		Runner:      runner,
+	})
+	if err != nil {
+		t.Fatalf("NewZFSDriver returned error: %v", err)
+	}
+
+	snapshot, err := driver.SnapshotVolume(context.Background(), SnapshotVolumeRequest{
+		SnapshotID: "golden",
+		VolumeRef:  "tank/cleanroom/sandboxes/sandbox-1",
+	})
+	if err != nil {
+		t.Fatalf("SnapshotVolume returned error: %v", err)
+	}
+	if got, want := snapshot.Ref, "tank/cleanroom/sandboxes/sandbox-1@snap-golden"; got != want {
+		t.Fatalf("unexpected snapshot ref: got %q want %q", got, want)
+	}
+
+	clone, err := driver.CloneSnapshotToVolume(context.Background(), CloneSnapshotToVolumeRequest{
+		VolumeID:    "sandbox-2",
+		SnapshotRef: snapshot.Ref,
+	})
+	if err != nil {
+		t.Fatalf("CloneSnapshotToVolume returned error: %v", err)
+	}
+	if got, want := clone.Ref, "tank/cleanroom/sandboxes/sandbox-2"; got != want {
+		t.Fatalf("unexpected cloned volume ref: got %q want %q", got, want)
+	}
+
+	if err := driver.DestroySnapshot(context.Background(), DestroySnapshotRequest{SnapshotRef: snapshot.Ref}); err != nil {
+		t.Fatalf("DestroySnapshot returned error: %v", err)
+	}
+	if err := driver.DestroyVolume(context.Background(), DestroyVolumeRequest{VolumeRef: clone.Ref}); err != nil {
+		t.Fatalf("DestroyVolume returned error: %v", err)
+	}
+
+	wantCommands := []string{
+		"zfs snapshot tank/cleanroom/sandboxes/sandbox-1@snap-golden",
+		"zfs list -H -o name tank/cleanroom/sandboxes/sandbox-2",
+		"zfs clone -p tank/cleanroom/sandboxes/sandbox-1@snap-golden tank/cleanroom/sandboxes/sandbox-2",
+		"zfs destroy tank/cleanroom/sandboxes/sandbox-1@snap-golden",
+		"zfs destroy -r tank/cleanroom/sandboxes/sandbox-2",
+	}
+	if got, want := runner.commands, wantCommands; strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("unexpected zfs commands:\n got: %v\nwant: %v", got, want)
+	}
+}
+
+func TestZFSDriverRequiresDatasetRoot(t *testing.T) {
+	_, err := NewZFSDriver(ZFSDriverOptions{})
+	if err == nil || !strings.Contains(err.Error(), "dataset root") {
+		t.Fatalf("expected dataset root error, got %v", err)
+	}
+}

--- a/internal/volumestore/zfs_test.go
+++ b/internal/volumestore/zfs_test.go
@@ -36,7 +36,12 @@ func (r *zfsTestRunner) Run(_ context.Context, command string, args ...string) e
 		}
 	case "destroy":
 		if len(args) >= 2 {
-			delete(r.exists, args[len(args)-1])
+			target := args[len(args)-1]
+			for ref := range r.exists {
+				if ref == target || strings.HasPrefix(ref, target+"@") || strings.HasPrefix(ref, target+"/") {
+					delete(r.exists, ref)
+				}
+			}
 		}
 	}
 
@@ -109,7 +114,7 @@ func TestZFSDriverEnsureBaseVolumeAndCloneLifecycle(t *testing.T) {
 	}
 }
 
-func TestZFSDriverSnapshotCloneAndDestroy(t *testing.T) {
+func TestZFSDriverSnapshotSurvivesSourceVolumeDestroy(t *testing.T) {
 	runner := &zfsTestRunner{
 		exists: map[string]bool{
 			"tank/cleanroom/sandboxes/sandbox-1": true,
@@ -130,8 +135,12 @@ func TestZFSDriverSnapshotCloneAndDestroy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SnapshotVolume returned error: %v", err)
 	}
-	if got, want := snapshot.Ref, "tank/cleanroom/sandboxes/sandbox-1@snap-golden"; got != want {
+	if got, want := snapshot.Ref, "tank/cleanroom/snapshots/golden@seed"; got != want {
 		t.Fatalf("unexpected snapshot ref: got %q want %q", got, want)
+	}
+
+	if err := driver.DestroyVolume(context.Background(), DestroyVolumeRequest{VolumeRef: "tank/cleanroom/sandboxes/sandbox-1"}); err != nil {
+		t.Fatalf("DestroyVolume returned error: %v", err)
 	}
 
 	clone, err := driver.CloneSnapshotToVolume(context.Background(), CloneSnapshotToVolumeRequest{
@@ -153,10 +162,16 @@ func TestZFSDriverSnapshotCloneAndDestroy(t *testing.T) {
 	}
 
 	wantCommands := []string{
+		"zfs list -H -o name tank/cleanroom/snapshots/golden",
 		"zfs snapshot tank/cleanroom/sandboxes/sandbox-1@snap-golden",
-		"zfs list -H -o name tank/cleanroom/sandboxes/sandbox-2",
-		"zfs clone -p tank/cleanroom/sandboxes/sandbox-1@snap-golden tank/cleanroom/sandboxes/sandbox-2",
+		"zfs list -H -o name tank/cleanroom/snapshots/golden",
+		"zfs clone -p tank/cleanroom/sandboxes/sandbox-1@snap-golden tank/cleanroom/snapshots/golden",
+		"zfs snapshot tank/cleanroom/snapshots/golden@seed",
 		"zfs destroy tank/cleanroom/sandboxes/sandbox-1@snap-golden",
+		"zfs destroy -r tank/cleanroom/sandboxes/sandbox-1",
+		"zfs list -H -o name tank/cleanroom/sandboxes/sandbox-2",
+		"zfs clone -p tank/cleanroom/snapshots/golden@seed tank/cleanroom/sandboxes/sandbox-2",
+		"zfs destroy -r tank/cleanroom/snapshots/golden",
 		"zfs destroy -r tank/cleanroom/sandboxes/sandbox-2",
 	}
 	if got, want := runner.commands, wantCommands; strings.Join(got, "\n") != strings.Join(want, "\n") {

--- a/internal/volumestore/zfs_test.go
+++ b/internal/volumestore/zfs_test.go
@@ -179,6 +179,45 @@ func TestZFSDriverSnapshotSurvivesSourceVolumeDestroy(t *testing.T) {
 	}
 }
 
+func TestZFSDriverEnsureBaseVolumeUsesMinimumBytesNamespace(t *testing.T) {
+	sourcePath := filepath.Join(t.TempDir(), "prepared.ext4")
+	if err := os.WriteFile(sourcePath, []byte("base-bytes"), 0o644); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+
+	runner := &zfsTestRunner{exists: map[string]bool{}}
+	driver, err := NewZFSDriver(ZFSDriverOptions{
+		DatasetRoot: "tank/cleanroom",
+		Runner:      runner,
+	})
+	if err != nil {
+		t.Fatalf("NewZFSDriver returned error: %v", err)
+	}
+
+	base, err := driver.EnsureBaseVolume(context.Background(), EnsureBaseVolumeRequest{
+		BaseID:       "runtime-key",
+		SourcePath:   sourcePath,
+		MinimumBytes: 8 << 20,
+	})
+	if err != nil {
+		t.Fatalf("EnsureBaseVolume returned error: %v", err)
+	}
+	if got, want := base.Ref, "tank/cleanroom/base/runtime-key-min-8388608@seed"; got != want {
+		t.Fatalf("unexpected base ref: got %q want %q", got, want)
+	}
+
+	wantCommands := []string{
+		"zfs list -H -o name tank/cleanroom/base/runtime-key-min-8388608",
+		"zfs create -p -V 8388608 tank/cleanroom/base/runtime-key-min-8388608",
+		"dd if=" + sourcePath + " of=/dev/zvol/tank/cleanroom/base/runtime-key-min-8388608 bs=4M conv=fsync status=none",
+		"zfs list -H -o name tank/cleanroom/base/runtime-key-min-8388608@seed",
+		"zfs snapshot tank/cleanroom/base/runtime-key-min-8388608@seed",
+	}
+	if got, want := runner.commands, wantCommands; strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("unexpected zfs commands:\n got: %v\nwant: %v", got, want)
+	}
+}
+
 func TestZFSDriverRequiresDatasetRoot(t *testing.T) {
 	_, err := NewZFSDriver(ZFSDriverOptions{})
 	if err == nil || !strings.Contains(err.Error(), "dataset root") {

--- a/internal/volumestore/zfs_test.go
+++ b/internal/volumestore/zfs_test.go
@@ -264,3 +264,81 @@ func TestZFSDatasetRootFromStoredSnapshotRef(t *testing.T) {
 		t.Fatal("expected non-stored snapshot ref to be rejected")
 	}
 }
+
+func TestZFSDatasetRootFromManagedRef(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]string{
+		"tank/cleanroom/base/runtime-key@seed":        "tank/cleanroom",
+		"tank/cleanroom/sandboxes/sandbox-1":          "tank/cleanroom",
+		"tank/cleanroom/snapshots/golden@seed":        "tank/cleanroom",
+		"tank/cleanroom/sandboxes/source@snap-golden": "tank/cleanroom",
+	}
+	for ref, want := range cases {
+		got, ok := ZFSDatasetRootFromManagedRef(ref)
+		if !ok || got != want {
+			t.Fatalf("unexpected dataset root for %q: got %q ok=%t want %q", ref, got, ok, want)
+		}
+	}
+	if _, ok := ZFSDatasetRootFromManagedRef("/tmp/rootfs.ext4"); ok {
+		t.Fatal("expected non-zfs ref to be rejected")
+	}
+}
+
+func TestZFSDriverEnsureWritableVolumeMinimumSizeGrowsUndersizedZvol(t *testing.T) {
+	runner := &zfsTestRunner{exists: map[string]bool{}}
+	driver, err := NewZFSDriver(ZFSDriverOptions{
+		DatasetRoot: "tank/cleanroom",
+		Runner:      runner,
+	})
+	if err != nil {
+		t.Fatalf("NewZFSDriver returned error: %v", err)
+	}
+
+	prevEnsure := ext4imageEnsureMinimumSize
+	prevPathSize := ext4imagePathSizeBytes
+	prevAlign := ext4imageAlignBytes
+	defer func() {
+		ext4imageEnsureMinimumSize = prevEnsure
+		ext4imagePathSizeBytes = prevPathSize
+		ext4imageAlignBytes = prevAlign
+	}()
+
+	ext4imagePathSizeBytes = func(string) (int64, bool, error) {
+		return 4 << 20, true, nil
+	}
+	ext4imageAlignBytes = func(size int64) int64 {
+		return size + ((4 << 20) - (size % (4 << 20)))
+	}
+
+	var (
+		gotAttachmentPath string
+		gotMinimumBytes   int64
+	)
+	ext4imageEnsureMinimumSize = func(_ context.Context, attachmentPath string, minimumBytes int64) error {
+		gotAttachmentPath = attachmentPath
+		gotMinimumBytes = minimumBytes
+		return nil
+	}
+
+	volume := WritableVolume{
+		Ref:            "tank/cleanroom/sandboxes/sandbox-1",
+		AttachmentPath: "/dev/zvol/tank/cleanroom/sandboxes/sandbox-1",
+	}
+	if err := driver.EnsureWritableVolumeMinimumSize(context.Background(), volume, (8<<20)+1); err != nil {
+		t.Fatalf("EnsureWritableVolumeMinimumSize returned error: %v", err)
+	}
+
+	wantCommands := []string{
+		"zfs set volsize=12582912 tank/cleanroom/sandboxes/sandbox-1",
+	}
+	if got, want := runner.commands, wantCommands; strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("unexpected zfs commands:\n got: %v\nwant: %v", got, want)
+	}
+	if got, want := gotAttachmentPath, volume.AttachmentPath; got != want {
+		t.Fatalf("unexpected attachment path: got %q want %q", got, want)
+	}
+	if got, want := gotMinimumBytes, int64((8<<20)+1); got != want {
+		t.Fatalf("unexpected minimum bytes: got %d want %d", got, want)
+	}
+}

--- a/scripts/cleanroom-root-helper.sh
+++ b/scripts/cleanroom-root-helper.sh
@@ -341,6 +341,12 @@ run_zfs() {
     exec "$bin" "$@"
   fi
 
+  if [[ "$#" -eq 3 && "$1" == "set" && "$2" == volsize=* ]]; then
+    is_numeric "${2#volsize=}" || die "zfs set: invalid volsize '${2#volsize=}'"
+    is_cleanroom_zfs_dataset "$3" || die "zfs set: unsupported dataset '$3'"
+    exec "$bin" "$@"
+  fi
+
   if [[ "$#" -eq 2 && "$1" == "promote" ]]; then
     is_cleanroom_zfs_dataset "$2" || die "zfs promote: unsupported dataset '$2'"
     exec "$bin" "$@"

--- a/scripts/cleanroom-root-helper.sh
+++ b/scripts/cleanroom-root-helper.sh
@@ -341,6 +341,11 @@ run_zfs() {
     exec "$bin" "$@"
   fi
 
+  if [[ "$#" -eq 2 && "$1" == "promote" ]]; then
+    is_cleanroom_zfs_dataset "$2" || die "zfs promote: unsupported dataset '$2'"
+    exec "$bin" "$@"
+  fi
+
   if [[ "$#" -eq 3 && "$1" == "destroy" && "$2" == "-r" ]]; then
     is_cleanroom_zfs_dataset "$3" || die "zfs destroy -r: unsupported dataset '$3'"
     exec "$bin" "$@"

--- a/scripts/root_helper_test.go
+++ b/scripts/root_helper_test.go
@@ -32,6 +32,7 @@ func TestCleanroomRootHelperDeclaresCapabilitiesAndZFSSupport(t *testing.T) {
 		"is_cleanroom_zfs_snapshot_ref()",
 		"is_zvol_device_path()",
 		"run_zfs()",
+		"zfs promote: unsupported dataset",
 		"run_dd()",
 		"bin=\"$(zfs_bin)\"",
 		"exec \"$bin\" \"$@\"",

--- a/scripts/root_helper_test.go
+++ b/scripts/root_helper_test.go
@@ -32,6 +32,7 @@ func TestCleanroomRootHelperDeclaresCapabilitiesAndZFSSupport(t *testing.T) {
 		"is_cleanroom_zfs_snapshot_ref()",
 		"is_zvol_device_path()",
 		"run_zfs()",
+		"zfs set: unsupported dataset",
 		"zfs promote: unsupported dataset",
 		"run_dd()",
 		"bin=\"$(zfs_bin)\"",


### PR DESCRIPTION
## Summary
- add a ZFS-backed volumestore driver and wire Firecracker rootfs/snapshot operations through it
- carry `snapshots.zfs_dataset` through runtime config and surface ZFS validation in `cleanroom doctor`
- extend the privileged helper allowlist so helper mode can execute the required `zfs` and `dd` operations safely

This pulls the ZFS driver work forward from [#81](https://github.com/buildkite/cleanroom/pull/81), based on commit `ee6c9e0bab1d5437a220ef9466d8edaccc8cd057`, adapted onto current `origin/main`.

## Verification
- `mise exec -- go test ./internal/volumestore ./internal/runtimeconfig`
- `mise exec -- go test ./internal/cli -run TestConfigInitWritesRuntimeConfig`
- `mise exec -- go test ./internal/backend/firecracker -run 'Test(CreateSnapshotSyncsPausesAndClonesRootFS|CreateSnapshotUsesConfiguredSnapshotBaseDir|CreateSnapshotUsesManagedVolumeRef|CreateSnapshotReturnsErrorWhenSandboxResumeFails|PreparePersistentWritableVolumeUsesBaseVolumeForRootFSPath|PreparePersistentWritableVolumeUsesSnapshotCloneForSnapshotRef|SandboxShutdownInvokesCleanupVolume|RunRootCommandOutputHelperModeInvokesHelper|DoctorReportsZFSChecks|SnapshotVolumeStoreDriverRejectsDisabledSnapshots|RootFSVolumeStoreDriverAllowsWritableVolumesWhenSnapshotsDisabled)'`
- `mise exec -- go test ./internal/backend/firecracker`
- `bash -n scripts/cleanroom-root-helper.sh`
- `mise exec -- shellcheck -x scripts/cleanroom-root-helper.sh`