### PR TITLE
Add global installer task and auto-size repo bootstrap rootfs

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -64,6 +64,11 @@ description = "Install all binaries into GOBIN (or GOPATH/bin)"
 depends = ["install:go", "install:darwin"]
 run = "true"
 
+[tasks."install:global"]
+description = "Install all runtime binaries into /usr/local/bin"
+depends = ["build"]
+run = "scripts/install-global.sh"
+
 [tasks.doctor]
 description = "Run cleanroom diagnostics"
 run = "go run ./cmd/cleanroom doctor"

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ curl -fsSL https://raw.githubusercontent.com/buildkite/cleanroom/main/scripts/in
 
 By default this installs to `/usr/local/bin`. Override with `--install-dir` or `CLEANROOM_INSTALL_DIR`.
 
+Install the locally built binaries from this checkout into `/usr/local/bin`:
+
+```bash
+mise run install:global
+```
+
 ## Quick start
 
 Initialize runtime config and check host prerequisites:

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -182,6 +182,7 @@ type FirecrackerConfig struct {
 	BinaryPath           string
 	KernelImagePath      string
 	RootFSPath           string
+	MinimumRootFSBytes   int64
 	DockerStartupSeconds int64
 	DockerStorageDriver  string
 	DockerIPTables       bool

--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/buildkite/cleanroom/internal/backend"
 	"github.com/buildkite/cleanroom/internal/bootassets"
+	"github.com/buildkite/cleanroom/internal/ext4image"
 	"github.com/buildkite/cleanroom/internal/gateway"
 	"github.com/buildkite/cleanroom/internal/hosttools"
 	"github.com/buildkite/cleanroom/internal/imagemgr"
@@ -828,6 +829,10 @@ func (a *Adapter) run(ctx context.Context, req backend.RunRequest, stream backen
 		return nil, fmt.Errorf("prepare per-run rootfs: %w", err)
 	}
 	vmRootFSPath = writableVolume.AttachmentPath
+	if err := ext4image.EnsureMinimumSize(ctx, vmRootFSPath, req.MinimumRootFSBytes); err != nil {
+		observation.Error = err.Error()
+		return nil, fmt.Errorf("resize writable rootfs: %w", err)
+	}
 	observation.RootFSCopyMS = time.Since(copyStart).Milliseconds()
 	defer func() {
 		_ = driver.DestroyVolume(context.Background(), volumestore.DestroyVolumeRequest{VolumeRef: vmRootFSPath})
@@ -1115,6 +1120,9 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 		return nil, fmt.Errorf("prepare persistent rootfs: %w", err)
 	}
 	vmRootFSPath = writableVolume.AttachmentPath
+	if err := ext4image.EnsureMinimumSize(ctx, vmRootFSPath, cfg.MinimumRootFSBytes); err != nil {
+		return nil, fmt.Errorf("resize persistent rootfs: %w", err)
+	}
 	rootFSCopyMS := time.Since(copyStart).Milliseconds()
 
 	guestInitPath, _ := guestInitExecutableForRootFS(vmRootFSPath)

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/buildkite/cleanroom/internal/backend"
 	"github.com/buildkite/cleanroom/internal/bootassets"
+	"github.com/buildkite/cleanroom/internal/ext4image"
 	"github.com/buildkite/cleanroom/internal/gateway"
 	"github.com/buildkite/cleanroom/internal/hosttools"
 	"github.com/buildkite/cleanroom/internal/imagemgr"
@@ -895,6 +896,10 @@ func (a *Adapter) run(ctx context.Context, req backend.RunRequest, stream backen
 		observation.RootFSCopyMS = durationMillisCeil(time.Since(rootfsCopyStart))
 		return nil, fmt.Errorf("prepare per-run rootfs: %w", err)
 	}
+	if err := ext4image.EnsureMinimumSize(ctx, vmRootFSPath, req.MinimumRootFSBytes); err != nil {
+		observation.RootFSCopyMS = durationMillisCeil(time.Since(rootfsCopyStart))
+		return nil, fmt.Errorf("resize writable rootfs: %w", err)
+	}
 	observation.RootFSCopyMS = durationMillisCeil(time.Since(rootfsCopyStart))
 
 	networkSetupStart := time.Now()
@@ -1510,6 +1515,9 @@ func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID strin
 		return nil, fmt.Errorf("prepare persistent rootfs: %w", err)
 	}
 	vmRootFSPath := writableVolume.AttachmentPath
+	if err := ext4image.EnsureMinimumSize(ctx, vmRootFSPath, cfg.MinimumRootFSBytes); err != nil {
+		return nil, fmt.Errorf("resize persistent rootfs: %w", err)
+	}
 
 	networkRunCommand := func(ctx context.Context, args ...string) error {
 		return runRootCommand(ctx, cfg, args...)

--- a/internal/controlservice/rootfs_sizing.go
+++ b/internal/controlservice/rootfs_sizing.go
@@ -1,0 +1,31 @@
+package controlservice
+
+import (
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/buildkite/cleanroom/internal/repositorycheckout"
+)
+
+const (
+	repositoryBootstrapMinimumRootFSBytes       int64 = 8 << 30
+	repositoryBootstrapDockerMinimumRootFSBytes int64 = 16 << 30
+)
+
+func withRepositoryBootstrapRootFSMinimum(
+	cfg backend.FirecrackerConfig,
+	compiled *policy.CompiledPolicy,
+	repository *repositorycheckout.Checkout,
+) backend.FirecrackerConfig {
+	if repository == nil {
+		return cfg
+	}
+
+	minimumBytes := repositoryBootstrapMinimumRootFSBytes
+	if compiled != nil && compiled.Services.Docker.Required {
+		minimumBytes = repositoryBootstrapDockerMinimumRootFSBytes
+	}
+	if cfg.MinimumRootFSBytes < minimumBytes {
+		cfg.MinimumRootFSBytes = minimumBytes
+	}
+	return cfg
+}

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -188,6 +188,7 @@ func (s *Service) CreateSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 	}
 	firecrackerCfg := runtimeconfig.MergeBackendConfig(s.Config, backendName, execOpts.LaunchSeconds)
 	firecrackerCfg.RunDir = ""
+	firecrackerCfg = withRepositoryBootstrapRootFSMinimum(firecrackerCfg, compiled, repository)
 
 	now := s.clock().Now()
 	sandboxID := s.ids().NewSandboxID()

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -1552,6 +1552,34 @@ func TestCreateSandboxMergesFirecrackerSnapshotConfig(t *testing.T) {
 	}
 }
 
+func TestCreateSandboxSetsRepositoryBootstrapRootFSMinimum(t *testing.T) {
+	adapter := &stubAdapter{}
+	svc := &Service{
+		Config: runtimeconfig.Config{
+			DefaultBackend: "darwin-vz",
+		},
+		Backends: map[string]backend.Adapter{"darwin-vz": adapter},
+	}
+
+	policyProto := testRepositoryPolicy()
+	policyProto.Services = &cleanroomv1.PolicyServices{
+		Docker: &cleanroomv1.PolicyDockerService{Required: true},
+	}
+
+	_, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Backend:            "darwin-vz",
+		Policy:             policyProto,
+		RepositoryCheckout: testRepositoryCheckoutProto(),
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+
+	if got, want := adapter.provisionReq.FirecrackerConfig.MinimumRootFSBytes, repositoryBootstrapDockerMinimumRootFSBytes; got != want {
+		t.Fatalf("unexpected minimum_rootfs_bytes: got %d want %d", got, want)
+	}
+}
+
 func TestCreateExecutionRejectsWhenSandboxBusy(t *testing.T) {
 	started := make(chan struct{}, 1)
 	adapter := &stubAdapter{

--- a/internal/ext4image/resize.go
+++ b/internal/ext4image/resize.go
@@ -1,0 +1,90 @@
+package ext4image
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/buildkite/cleanroom/internal/hosttools"
+)
+
+const imageSizeAlignBytes int64 = 4 << 20
+
+var (
+	resolveE2FSProgsBinary = hosttools.ResolveE2FSProgsBinary
+	runCommand             = runCommandWithAllowedExitCodes
+	truncateFile           = os.Truncate
+)
+
+func EnsureMinimumSize(ctx context.Context, imagePath string, minimumBytes int64) error {
+	if minimumBytes <= 0 {
+		return nil
+	}
+
+	info, err := os.Stat(imagePath)
+	if err != nil {
+		return fmt.Errorf("stat ext4 image %q: %w", imagePath, err)
+	}
+	if info.Size() >= minimumBytes {
+		return nil
+	}
+
+	targetBytes := alignBytes(minimumBytes)
+
+	e2fsckBinary, err := resolveE2FSProgsBinary("e2fsck")
+	if err != nil {
+		return fmt.Errorf("find e2fsck for rootfs resize: %w", err)
+	}
+	resize2fsBinary, err := resolveE2FSProgsBinary("resize2fs")
+	if err != nil {
+		return fmt.Errorf("find resize2fs for rootfs resize: %w", err)
+	}
+
+	if err := runCommand(ctx, e2fsckBinary, []string{"-fy", imagePath}, 0, 1); err != nil {
+		return fmt.Errorf("prepare ext4 image %q for resize: %w", imagePath, err)
+	}
+	if err := truncateFile(imagePath, targetBytes); err != nil {
+		return fmt.Errorf("truncate ext4 image %q to %d bytes: %w", imagePath, targetBytes, err)
+	}
+	if err := runCommand(ctx, resize2fsBinary, []string{imagePath}, 0); err != nil {
+		return fmt.Errorf("grow ext4 filesystem in %q: %w", imagePath, err)
+	}
+	return nil
+}
+
+func alignBytes(size int64) int64 {
+	if size <= 0 {
+		return imageSizeAlignBytes
+	}
+	remainder := size % imageSizeAlignBytes
+	if remainder == 0 {
+		return size
+	}
+	return size + (imageSizeAlignBytes - remainder)
+}
+
+func runCommandWithAllowedExitCodes(ctx context.Context, binary string, args []string, allowedExitCodes ...int) error {
+	cmd := exec.CommandContext(ctx, binary, args...)
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		return nil
+	}
+
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		for _, code := range allowedExitCodes {
+			if exitErr.ExitCode() == code {
+				return nil
+			}
+		}
+	}
+
+	trimmedOutput := strings.TrimSpace(string(output))
+	if trimmedOutput == "" {
+		return fmt.Errorf("run %s %v: %w", binary, args, err)
+	}
+	return fmt.Errorf("run %s %v: %w: %s", binary, args, err, trimmedOutput)
+}

--- a/internal/ext4image/resize_test.go
+++ b/internal/ext4image/resize_test.go
@@ -1,0 +1,124 @@
+package ext4image
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestEnsureMinimumSizeNoOpWhenAlreadyLarge(t *testing.T) {
+	restore := stubResizeDependencies()
+	defer restore()
+
+	imagePath := createSizedTempFile(t, 8<<20)
+	var commands [][]string
+	runCommand = func(context.Context, string, []string, ...int) error {
+		commands = append(commands, nil)
+		return nil
+	}
+
+	if err := EnsureMinimumSize(context.Background(), imagePath, 4<<20); err != nil {
+		t.Fatalf("EnsureMinimumSize returned error: %v", err)
+	}
+	if len(commands) != 0 {
+		t.Fatalf("expected no resize commands, got %d", len(commands))
+	}
+	info, err := os.Stat(imagePath)
+	if err != nil {
+		t.Fatalf("stat resized image: %v", err)
+	}
+	if got, want := info.Size(), int64(8<<20); got != want {
+		t.Fatalf("unexpected image size: got %d want %d", got, want)
+	}
+}
+
+func TestEnsureMinimumSizeGrowsAndRoundsUp(t *testing.T) {
+	restore := stubResizeDependencies()
+	defer restore()
+
+	imagePath := createSizedTempFile(t, 5<<20)
+	var gotCommands [][]string
+	runCommand = func(_ context.Context, binary string, args []string, allowedExitCodes ...int) error {
+		record := append([]string{binary}, append([]string(nil), args...)...)
+		gotCommands = append(gotCommands, record)
+		return nil
+	}
+
+	minimumBytes := int64((9 << 20) + 1)
+	if err := EnsureMinimumSize(context.Background(), imagePath, minimumBytes); err != nil {
+		t.Fatalf("EnsureMinimumSize returned error: %v", err)
+	}
+
+	wantCommands := [][]string{
+		{"e2fsck-path", "-fy", imagePath},
+		{"resize2fs-path", imagePath},
+	}
+	if !reflect.DeepEqual(gotCommands, wantCommands) {
+		t.Fatalf("unexpected resize commands: got %#v want %#v", gotCommands, wantCommands)
+	}
+
+	info, err := os.Stat(imagePath)
+	if err != nil {
+		t.Fatalf("stat resized image: %v", err)
+	}
+	if got, want := info.Size(), int64(12<<20); got != want {
+		t.Fatalf("unexpected image size: got %d want %d", got, want)
+	}
+}
+
+func TestEnsureMinimumSizePropagatesResolveError(t *testing.T) {
+	restore := stubResizeDependencies()
+	defer restore()
+
+	imagePath := createSizedTempFile(t, 4<<20)
+	resolveE2FSProgsBinary = func(binary string) (string, error) {
+		if binary == "e2fsck" {
+			return "", errors.New("missing tool")
+		}
+		return binary + "-path", nil
+	}
+
+	err := EnsureMinimumSize(context.Background(), imagePath, 8<<20)
+	if err == nil {
+		t.Fatal("expected resize to fail")
+	}
+	if !strings.Contains(err.Error(), "missing tool") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func stubResizeDependencies() func() {
+	prevResolve := resolveE2FSProgsBinary
+	prevRun := runCommand
+	prevTruncate := truncateFile
+
+	resolveE2FSProgsBinary = func(binary string) (string, error) {
+		return binary + "-path", nil
+	}
+	runCommand = runCommandWithAllowedExitCodes
+	truncateFile = os.Truncate
+
+	return func() {
+		resolveE2FSProgsBinary = prevResolve
+		runCommand = prevRun
+		truncateFile = prevTruncate
+	}
+}
+
+func createSizedTempFile(t *testing.T, size int64) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "rootfs.ext4")
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		t.Fatalf("write temp image: %v", err)
+	}
+	if err := os.Truncate(path, size); err != nil {
+		t.Fatalf("truncate temp image: %v", err)
+	}
+	return path
+}

--- a/scripts/install-global.sh
+++ b/scripts/install-global.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() {
+  printf '[install:global] %s\n' "$*"
+}
+
+die() {
+  printf '[install:global] error: %s\n' "$*" >&2
+  exit 1
+}
+
+require_cmd() {
+  local cmd="$1"
+  command -v "$cmd" >/dev/null 2>&1 || die "required command not found: ${cmd}"
+}
+
+INSTALL_DIR="${CLEANROOM_GLOBAL_INSTALL_DIR:-/usr/local/bin}"
+DIST_DIR="${CLEANROOM_GLOBAL_DIST_DIR:-dist}"
+HOST_OS="$(go env GOOS)"
+HOST_ARCH="$(go env GOARCH)"
+ENTITLEMENTS="cmd/cleanroom-darwin-vz/entitlements.plist"
+
+declare -a SUDO_CMD=()
+
+run_cmd() {
+  if [ "${#SUDO_CMD[@]}" -gt 0 ]; then
+    "${SUDO_CMD[@]}" "$@"
+  else
+    "$@"
+  fi
+}
+
+prepare_install_dir() {
+  if [ ! -d "$INSTALL_DIR" ]; then
+    if [ "$(id -u)" -eq 0 ]; then
+      mkdir -p "$INSTALL_DIR"
+    else
+      if mkdir -p "$INSTALL_DIR" 2>/dev/null; then
+        :
+      else
+        require_cmd sudo
+        SUDO_CMD=(sudo)
+        run_cmd mkdir -p "$INSTALL_DIR"
+      fi
+    fi
+  fi
+
+  if [ "$(id -u)" -ne 0 ] && [ ! -w "$INSTALL_DIR" ]; then
+    require_cmd sudo
+    SUDO_CMD=(sudo)
+  fi
+}
+
+install_binary() {
+  local src="$1"
+  local dst="$2"
+
+  [ -f "$src" ] || die "missing build artifact: ${src}"
+  run_cmd install -m 0755 "$src" "$dst"
+  log "installed $(basename "$dst") to $dst"
+}
+
+require_cmd go
+prepare_install_dir
+
+CLEANROOM_BIN="${DIST_DIR}/cleanroom"
+GUEST_AGENT_LINUX_BIN="${DIST_DIR}/cleanroom-guest-agent-linux-${HOST_ARCH}"
+GUEST_AGENT_BIN="${DIST_DIR}/cleanroom-guest-agent"
+
+if [ ! -f "$GUEST_AGENT_BIN" ]; then
+  GUEST_AGENT_BIN="$GUEST_AGENT_LINUX_BIN"
+fi
+
+install_binary "$CLEANROOM_BIN" "${INSTALL_DIR}/cleanroom"
+install_binary "$GUEST_AGENT_LINUX_BIN" "${INSTALL_DIR}/cleanroom-guest-agent-linux-${HOST_ARCH}"
+install_binary "$GUEST_AGENT_BIN" "${INSTALL_DIR}/cleanroom-guest-agent"
+
+if [ "$HOST_OS" = "darwin" ]; then
+  require_cmd codesign
+  HELPER_BIN="${DIST_DIR}/cleanroom-darwin-vz"
+  install_binary "$HELPER_BIN" "${INSTALL_DIR}/cleanroom-darwin-vz"
+  [ -f "$ENTITLEMENTS" ] || die "missing entitlements file: ${ENTITLEMENTS}"
+  run_cmd codesign --force --sign - --entitlements "$ENTITLEMENTS" "${INSTALL_DIR}/cleanroom-darwin-vz"
+  log "signed ${INSTALL_DIR}/cleanroom-darwin-vz"
+fi


### PR DESCRIPTION
## Summary
- add `mise run install:global` and a helper script to install cleanroom runtime binaries into `/usr/local/bin`
- automatically grow writable ext4 rootfs images for repo-bootstrap sandboxes, using a larger floor when Docker is required
- add tests for the rootfs sizing path and ext4 resize helper

## Testing
- PATH=/Users/lachlan/.local/share/mise/installs/go/1.25.3/bin:$PATH go test ./...