### PR TITLE
fix: harden prod host bootstrap

### DIFF
--- a/infra/terraform/envs/prod/bootstrap_defaults_test.go
+++ b/infra/terraform/envs/prod/bootstrap_defaults_test.go
@@ -73,6 +73,8 @@ func TestProdBootstrapBuildsAndInstallsCleanroom(t *testing.T) {
 
 	scriptPath := filepath.Join("..", "..", "..", "..", "scripts", "bootstrap-cleanroom-host.sh")
 	requireContains(t, scriptPath, "scripts/build-go.sh")
+	requireContains(t, scriptPath, "export GOPATH=\"${GOPATH:-$HOME/go}\"")
+	requireContains(t, scriptPath, "export GOMODCACHE=\"${GOMODCACHE:-$GOPATH/pkg/mod}\"")
 	requireContains(t, scriptPath, "daemon install --force --log-level info")
 	requireContains(t, scriptPath, "default_backend: firecracker")
 	requireContains(t, scriptPath, "memory_mib: ${CLEANROOM_FIRECRACKER_MEMORY_MIB}")
@@ -118,4 +120,5 @@ func TestSharedLinuxModuleSupportsNonCiBootstrap(t *testing.T) {
 	requireContains(t, moduleVarsPath, "variable \"buildkite_token_parameter_name\"")
 	requireContains(t, moduleVarsPath, "default     = \"\"")
 	requireContains(t, moduleUserDataPath, "if [ -n \"$BUILDKITE_TOKEN_PARAM\" ]; then")
+	requireContains(t, moduleUserDataPath, "warning: tailscale auth key parameter unavailable")
 }

--- a/infra/terraform/modules/linux-host/templates/user_data.sh.tftpl
+++ b/infra/terraform/modules/linux-host/templates/user_data.sh.tftpl
@@ -100,26 +100,30 @@ if [ -n "$BUILDKITE_TOKEN_PARAM" ]; then
 fi
 
 if [ -n "$TAILSCALE_PARAM" ]; then
-  tailscale_auth_key="$(aws ssm get-parameter --region "$AWS_REGION" --name "$TAILSCALE_PARAM" --with-decryption --query 'Parameter.Value' --output text)"
-
-  arch_name="$(uname -m)"
-  ts_arch='amd64'
-  if [ "$arch_name" = 'aarch64' ] || [ "$arch_name" = 'arm64' ]; then
-    ts_arch='arm64'
+  if ! tailscale_auth_key="$(aws ssm get-parameter --region "$AWS_REGION" --name "$TAILSCALE_PARAM" --with-decryption --query 'Parameter.Value' --output text)"; then
+    echo "warning: tailscale auth key parameter unavailable ($TAILSCALE_PARAM); skipping tailscale bootstrap" >&2
+    tailscale_auth_key=''
   fi
 
-  ts_url="$(printf 'https://pkgs.tailscale.com/stable/tailscale_%s_%s.tgz' "$TAILSCALE_VERSION" "$ts_arch")"
-  ts_tmp_dir="$(mktemp -d)"
-  trap 'rm -rf "$ts_tmp_dir"' EXIT
-  curl -fsSL "$ts_url" -o "$ts_tmp_dir/tailscale.tgz"
-  tar -xzf "$ts_tmp_dir/tailscale.tgz" -C "$ts_tmp_dir"
-  ts_extract_dir="$(find "$ts_tmp_dir" -maxdepth 1 -type d -name 'tailscale_*' | head -n 1)"
+  if [ -n "$tailscale_auth_key" ]; then
+    arch_name="$(uname -m)"
+    ts_arch='amd64'
+    if [ "$arch_name" = 'aarch64' ] || [ "$arch_name" = 'arm64' ]; then
+      ts_arch='arm64'
+    fi
 
-  install -o root -g root -m 0755 "$ts_extract_dir/tailscale" /usr/local/bin/tailscale
-  install -o root -g root -m 0755 "$ts_extract_dir/tailscaled" /usr/local/bin/tailscaled
-  install -d -o root -g root -m 0755 /var/lib/tailscale
+    ts_url="$(printf 'https://pkgs.tailscale.com/stable/tailscale_%s_%s.tgz' "$TAILSCALE_VERSION" "$ts_arch")"
+    ts_tmp_dir="$(mktemp -d)"
+    trap 'rm -rf "$ts_tmp_dir"' EXIT
+    curl -fsSL "$ts_url" -o "$ts_tmp_dir/tailscale.tgz"
+    tar -xzf "$ts_tmp_dir/tailscale.tgz" -C "$ts_tmp_dir"
+    ts_extract_dir="$(find "$ts_tmp_dir" -maxdepth 1 -type d -name 'tailscale_*' | head -n 1)"
 
-  cat > /etc/systemd/system/tailscaled.service <<'TAILSCALE_UNIT'
+    install -o root -g root -m 0755 "$ts_extract_dir/tailscale" /usr/local/bin/tailscale
+    install -o root -g root -m 0755 "$ts_extract_dir/tailscaled" /usr/local/bin/tailscaled
+    install -d -o root -g root -m 0755 /var/lib/tailscale
+
+    cat > /etc/systemd/system/tailscaled.service <<'TAILSCALE_UNIT'
 [Unit]
 Description=Tailscale node agent
 Wants=network-online.target
@@ -135,21 +139,22 @@ Restart=on-failure
 WantedBy=multi-user.target
 TAILSCALE_UNIT
 
-  systemctl daemon-reload
-  systemctl enable --now tailscaled
+    systemctl daemon-reload
+    systemctl enable --now tailscaled
 
-  hostname="$TAILSCALE_HOSTNAME_PREFIX-$instance_id"
-  set -- up --auth-key "$tailscale_auth_key" --hostname "$hostname"
-  if [ "$TAILSCALE_ENABLE_SSH" = 'true' ]; then
-    set -- "$@" --ssh
+    hostname="$TAILSCALE_HOSTNAME_PREFIX-$instance_id"
+    set -- up --auth-key "$tailscale_auth_key" --hostname "$hostname"
+    if [ "$TAILSCALE_ENABLE_SSH" = 'true' ]; then
+      set -- "$@" --ssh
+    fi
+    if [ "$TAILSCALE_ACCEPT_ROUTES" = 'true' ]; then
+      set -- "$@" --accept-routes
+    fi
+    if [ -n "$TAILSCALE_ADVERTISE_TAGS" ]; then
+      set -- "$@" --advertise-tags "$TAILSCALE_ADVERTISE_TAGS"
+    fi
+    /usr/local/bin/tailscale "$@"
   fi
-  if [ "$TAILSCALE_ACCEPT_ROUTES" = 'true' ]; then
-    set -- "$@" --accept-routes
-  fi
-  if [ -n "$TAILSCALE_ADVERTISE_TAGS" ]; then
-    set -- "$@" --advertise-tags "$TAILSCALE_ADVERTISE_TAGS"
-  fi
-  /usr/local/bin/tailscale "$@"
 fi
 
 if [ -n "$DEPLOY_KEY_PARAM" ]; then

--- a/internal/cli/daemon_systemd.go
+++ b/internal/cli/daemon_systemd.go
@@ -153,6 +153,10 @@ Wants=network-online.target
 
 [Service]
 Type=simple
+Environment=HOME=/root
+Environment=XDG_CONFIG_HOME=/root/.config
+Environment=XDG_STATE_HOME=/root/.local/state
+Environment=XDG_DATA_HOME=/root/.local/share
 ExecStart=%s
 Restart=on-failure
 RestartSec=5

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -308,6 +308,12 @@ func TestDaemonInstallForceOverwritesAndEnablesService(t *testing.T) {
 	if !strings.Contains(content, "ExecStart=/usr/local/bin/cleanroom serve") {
 		t.Fatalf("expected serve exec start, got:\n%s", content)
 	}
+	if !strings.Contains(content, "Environment=HOME=/root") {
+		t.Fatalf("expected HOME environment in systemd unit, got:\n%s", content)
+	}
+	if !strings.Contains(content, "Environment=XDG_CONFIG_HOME=/root/.config") {
+		t.Fatalf("expected XDG_CONFIG_HOME environment in systemd unit, got:\n%s", content)
+	}
 	if !strings.Contains(content, "--listen unix:///var/run/cleanroom/cleanroom.sock") {
 		t.Fatalf("expected explicit default --listen in unit, got:\n%s", content)
 	}

--- a/scripts/bootstrap-cleanroom-host.sh
+++ b/scripts/bootstrap-cleanroom-host.sh
@@ -74,6 +74,14 @@ CLEANROOM_FIRECRACKER_VCPUS="${CLEANROOM_FIRECRACKER_VCPUS:-4}"
 CLEANROOM_FIRECRACKER_MEMORY_MIB="${CLEANROOM_FIRECRACKER_MEMORY_MIB:-8192}"
 CLEANROOM_FIRECRACKER_LAUNCH_SECONDS="${CLEANROOM_FIRECRACKER_LAUNCH_SECONDS:-90}"
 
+HOME="${HOME:-/root}"
+export HOME
+export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
+export XDG_STATE_HOME="${XDG_STATE_HOME:-$HOME/.local/state}"
+export XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
+export GOPATH="${GOPATH:-$HOME/go}"
+export GOMODCACHE="${GOMODCACHE:-$GOPATH/pkg/mod}"
+
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
 
@@ -92,6 +100,9 @@ if [ "$INSTALL_FIRECRACKER" = "true" ]; then
   log "installing firecracker ${FIRECRACKER_VERSION}"
   install_firecracker_binary "$FIRECRACKER_VERSION"
 fi
+
+install -d -o root -g root -m 0755 "$XDG_CONFIG_HOME" "$XDG_STATE_HOME" "$XDG_DATA_HOME"
+install -d -o root -g root -m 0755 "$GOPATH" "$GOPATH/pkg" "$GOMODCACHE"
 
 log "building cleanroom binaries from ${REPO_ROOT}"
 export GOTOOLCHAIN=auto


### PR DESCRIPTION
## Summary
- make optional Tailscale bootstrap best-effort so a missing auth key parameter does not abort host bring-up
- set HOME/XDG/Go module cache paths in the prod bootstrap before building cleanroom
- include HOME/XDG environment in the Linux systemd daemon unit so `cleanroom serve` starts under systemd

## Testing
- mise run lint-shell
- mise x -- go test ./internal/cli ./infra/terraform/envs/prod ./infra/terraform/envs/ci
- mise x -- terraform -chdir=infra/terraform/envs/ci validate
- mise x -- terraform -chdir=infra/terraform/envs/prod validate

## Context
These are the follow-up fixes from the first prod host bring-up: the host bootstrap should continue when Tailscale is unavailable, and the installed cleanroom systemd unit needs a root HOME/XDG environment.