### PR TITLE
fix: add trusted cleanroom root helper rollout

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@ steps:
   - label: ":shell: Shellcheck"
     plugins:
       - github.com/lox/mise-buildkite-plugin#a172963b3d34e98601e2a65c7dd08211fb49b7f0:
-    command: shellcheck -x scripts/bootstrap-buildkite-agent.sh scripts/bootstrap-buildkite-agent-macos.sh scripts/cleanroom-root-helper.sh scripts/benchmark-tti.sh scripts/build-go.sh scripts/install-go.sh scripts/install.sh scripts/release.sh scripts/ci-cleanroom-e2e.sh scripts/ci-darwin-vz-e2e.sh
+    command: shellcheck -x scripts/bootstrap-buildkite-agent.sh scripts/bootstrap-buildkite-agent-macos.sh scripts/cleanroom-root-helper.sh scripts/update-cleanroom-root-helper.sh scripts/benchmark-tti.sh scripts/build-go.sh scripts/install-go.sh scripts/install.sh scripts/release.sh scripts/ci-cleanroom-e2e.sh scripts/ci-darwin-vz-e2e.sh
     agents:
       queue: hosted
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+/scripts/cleanroom-root-helper.sh @lox
+/scripts/update-cleanroom-root-helper.sh @lox
+/scripts/bootstrap-buildkite-agent.sh @lox
+/scripts/ci-cleanroom-e2e.sh @lox
+/.github/CODEOWNERS @lox

--- a/.mise.toml
+++ b/.mise.toml
@@ -14,7 +14,7 @@ run = "go test ./..."
 
 [tasks.lint-shell]
 description = "Lint shell scripts"
-run = "shellcheck -x scripts/bootstrap-buildkite-agent.sh scripts/bootstrap-buildkite-agent-macos.sh scripts/bootstrap-cleanroom-host.sh scripts/cleanroom-root-helper.sh scripts/benchmark-tti.sh scripts/build-go.sh scripts/install-go.sh scripts/install.sh scripts/release.sh scripts/ci-cleanroom-e2e.sh scripts/ci-darwin-vz-e2e.sh"
+run = "shellcheck -x scripts/bootstrap-buildkite-agent.sh scripts/bootstrap-buildkite-agent-macos.sh scripts/bootstrap-cleanroom-host.sh scripts/cleanroom-root-helper.sh scripts/update-cleanroom-root-helper.sh scripts/benchmark-tti.sh scripts/build-go.sh scripts/install-go.sh scripts/install.sh scripts/release.sh scripts/ci-cleanroom-e2e.sh scripts/ci-darwin-vz-e2e.sh"
 
 [tasks.test-full]
 description = "Run full Go test suite"

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -156,6 +156,14 @@ Then set:
 - `CLEANROOM_PRIVILEGED_MODE=helper`
 - `CLEANROOM_PRIVILEGED_HELPER_PATH=/usr/local/sbin/cleanroom-root-helper`
 
+Roll out future helper updates from a trusted `main` checkout:
+
+```bash
+sudo scripts/update-cleanroom-root-helper.sh
+```
+
+Only use that updater from trusted `main` automation or an operator-triggered SSM/bootstrap session. PR CI should detect helper drift and fail; it must not replace the installed helper itself.
+
 ## 5. Optional Agent Environment Hook
 
 If you prefer host-level env over pipeline step env, set variables in `/etc/buildkite-agent/hooks/environment`.

--- a/scripts/ci-cleanroom-e2e.sh
+++ b/scripts/ci-cleanroom-e2e.sh
@@ -15,7 +15,7 @@ fi
 # falling back to sudo, then direct execution.
 run_privileged() {
   if [[ -n "${PRIVILEGED_HELPER_PATH:-}" ]]; then
-    "$PRIVILEGED_HELPER_PATH" "$@"
+    sudo -n "$PRIVILEGED_HELPER_PATH" "$@"
   elif command -v sudo >/dev/null 2>&1; then
     sudo -n "$@"
   else
@@ -127,7 +127,8 @@ if [[ -n "$PRIVILEGED_HELPER_PATH" && -f "scripts/cleanroom-root-helper.sh" ]]; 
     echo "⚠️  Root helper on host ($PRIVILEGED_HELPER_PATH) does not match repo (scripts/cleanroom-root-helper.sh)"
     echo "   host: $host_sha"
     echo "   repo: $repo_sha"
-    echo "   Update with: sudo install -o root -g root -m 0755 scripts/cleanroom-root-helper.sh $PRIVILEGED_HELPER_PATH"
+    echo "   Update from a trusted main checkout with:"
+    echo "   sudo CLEANROOM_HELPER_INSTALL_PATH=$PRIVILEGED_HELPER_PATH scripts/update-cleanroom-root-helper.sh"
     if command -v buildkite-agent >/dev/null 2>&1; then
       buildkite-agent annotate --context root-helper-drift --style error <<EOF
 ### ❌ Root helper out of date
@@ -139,9 +140,9 @@ The installed root helper (\`$PRIVILEGED_HELPER_PATH\`) does not match \`scripts
 | Host | \`$host_sha\` |
 | Repo | \`$repo_sha\` |
 
-**Update on the CI host:**
+**Update on the CI host from a trusted \`main\` checkout:**
 \`\`\`
-sudo install -o root -g root -m 0755 scripts/cleanroom-root-helper.sh $PRIVILEGED_HELPER_PATH
+sudo CLEANROOM_HELPER_INSTALL_PATH=$PRIVILEGED_HELPER_PATH scripts/update-cleanroom-root-helper.sh
 \`\`\`
 EOF
     fi

--- a/scripts/ci_cleanroom_e2e_test.go
+++ b/scripts/ci_cleanroom_e2e_test.go
@@ -17,6 +17,9 @@ func TestCiCleanroomE2EUsesNonInteractiveSudo(t *testing.T) {
 	if !strings.Contains(string(content), "sudo -n \"$@\"") {
 		t.Fatalf("expected ci-cleanroom-e2e.sh to use non-interactive sudo (-n)")
 	}
+	if !strings.Contains(string(content), "sudo -n \"$PRIVILEGED_HELPER_PATH\" \"$@\"") {
+		t.Fatalf("expected ci-cleanroom-e2e.sh to invoke the privileged helper via non-interactive sudo (-n)")
+	}
 }
 
 func TestCiCleanroomE2EDownloadSandboxFileProbeUsesTimeout(t *testing.T) {
@@ -29,5 +32,18 @@ func TestCiCleanroomE2EDownloadSandboxFileProbeUsesTimeout(t *testing.T) {
 
 	if !strings.Contains(string(content), "--timeout 45s") {
 		t.Fatalf("expected ci-cleanroom-e2e.sh to bound download_sandbox_file calls with --timeout")
+	}
+}
+
+func TestCiCleanroomE2EDocumentsTrustedHelperRollout(t *testing.T) {
+	t.Helper()
+
+	content, err := os.ReadFile("ci-cleanroom-e2e.sh")
+	if err != nil {
+		t.Fatalf("read ci-cleanroom-e2e.sh: %v", err)
+	}
+
+	if !strings.Contains(string(content), "scripts/update-cleanroom-root-helper.sh") {
+		t.Fatalf("expected ci-cleanroom-e2e.sh to direct helper updates through scripts/update-cleanroom-root-helper.sh")
 	}
 }

--- a/scripts/cleanroom-root-helper.sh
+++ b/scripts/cleanroom-root-helper.sh
@@ -22,6 +22,11 @@ is_runtime_rootfs_tmp() {
   [[ "$p" == /var/lib/buildkite-agent/.cache/cleanroom/firecracker/runtime-rootfs/*.ext4.tmp-* ]]
 }
 
+is_runtime_rootfs_image() {
+  local p="$1"
+  [[ "$p" == */cleanroom/firecracker/runtime-rootfs/*.ext4 ]]
+}
+
 is_mounted_rootfs_dest() {
   local p="$1"
   [[ "$p" == /tmp/cleanroom-firecracker-rootfs-*/usr/local/bin/cleanroom-guest-agent || "$p" == /tmp/cleanroom-firecracker-rootfs-*/sbin/cleanroom-init ]]
@@ -50,6 +55,46 @@ is_cidr() {
 is_install_source() {
   local p="$1"
   [[ "$p" == /var/lib/buildkite-agent/builds/*/buildkite/cleanroom/dist/cleanroom-guest-agent || "$p" == /tmp/cleanroom-init-* ]]
+}
+
+is_zfs_dataset() {
+  local v="$1"
+  [[ "$v" =~ ^[A-Za-z0-9][A-Za-z0-9._:-]*(/[A-Za-z0-9][A-Za-z0-9._:-]*)*$ ]]
+}
+
+is_zfs_snapshot_ref() {
+  local v="$1"
+  [[ "$v" =~ ^[A-Za-z0-9][A-Za-z0-9._:-]*(/[A-Za-z0-9][A-Za-z0-9._:-]*)*@[A-Za-z0-9][A-Za-z0-9._:-]*$ ]]
+}
+
+is_zvol_device_path() {
+  local p="$1"
+  [[ "$p" == /dev/zvol/* ]] || return 1
+  is_zfs_dataset "${p#/dev/zvol/}"
+}
+
+zfs_bin() {
+  if [[ -x /usr/sbin/zfs ]]; then
+    echo /usr/sbin/zfs
+    return
+  fi
+  if [[ -x /sbin/zfs ]]; then
+    echo /sbin/zfs
+    return
+  fi
+  command -v zfs || die "zfs: binary not found"
+}
+
+dd_bin() {
+  if [[ -x /usr/bin/dd ]]; then
+    echo /usr/bin/dd
+    return
+  fi
+  if [[ -x /bin/dd ]]; then
+    echo /bin/dd
+    return
+  fi
+  command -v dd || die "dd: binary not found"
 }
 
 run_ip() {
@@ -210,6 +255,62 @@ run_install() {
   exec /usr/bin/install -m 0755 "$src" "$dst"
 }
 
+run_zfs() {
+  [[ "$#" -ge 1 ]] || die "zfs: missing arguments"
+  local bin
+  bin="$(zfs_bin)"
+
+  if [[ "$#" -eq 5 && "$1" == "list" && "$2" == "-H" && "$3" == "-o" && "$4" == "name" ]]; then
+    is_zfs_dataset "$5" || is_zfs_snapshot_ref "$5" || die "zfs list: unsupported ref '$5'"
+    exec "$bin" "$@"
+  fi
+
+  if [[ "$#" -eq 5 && "$1" == "create" && "$2" == "-p" && "$3" == "-V" ]]; then
+    is_numeric "$4" || die "zfs create: invalid size '$4'"
+    is_zfs_dataset "$5" || die "zfs create: unsupported dataset '$5'"
+    exec "$bin" "$@"
+  fi
+
+  if [[ "$#" -eq 2 && "$1" == "snapshot" ]]; then
+    is_zfs_snapshot_ref "$2" || die "zfs snapshot: unsupported ref '$2'"
+    exec "$bin" "$@"
+  fi
+
+  if [[ "$#" -eq 4 && "$1" == "clone" && "$2" == "-p" ]]; then
+    is_zfs_snapshot_ref "$3" || die "zfs clone: unsupported snapshot '$3'"
+    is_zfs_dataset "$4" || die "zfs clone: unsupported dataset '$4'"
+    exec "$bin" "$@"
+  fi
+
+  if [[ "$#" -eq 3 && "$1" == "destroy" && "$2" == "-r" ]]; then
+    is_zfs_dataset "$3" || die "zfs destroy -r: unsupported dataset '$3'"
+    exec "$bin" "$@"
+  fi
+
+  if [[ "$#" -eq 2 && "$1" == "destroy" ]]; then
+    is_zfs_snapshot_ref "$2" || die "zfs destroy: unsupported ref '$2'"
+    exec "$bin" "$@"
+  fi
+
+  die "zfs: unsupported arguments"
+}
+
+run_dd() {
+  [[ "$#" -eq 5 ]] || die "dd: unsupported arguments"
+  [[ "$1" == if=* ]] || die "dd: missing input file"
+  [[ "$2" == of=* ]] || die "dd: missing output file"
+  [[ "$3" == "bs=4M" ]] || die "dd: unsupported block size"
+  [[ "$4" == "conv=fsync" ]] || die "dd: unsupported conv mode"
+  [[ "$5" == "status=none" ]] || die "dd: unsupported status mode"
+
+  local src="${1#if=}"
+  local dst="${2#of=}"
+  is_runtime_rootfs_image "$src" || die "dd: unsupported source path '$src'"
+  is_zvol_device_path "$dst" || die "dd: unsupported destination path '$dst'"
+
+  exec "$(dd_bin)" "$@"
+}
+
 main() {
   require_root
   [[ "$#" -ge 1 ]] || die "missing command"
@@ -242,6 +343,12 @@ main() {
       ;;
     install)
       run_install "$@"
+      ;;
+    zfs)
+      run_zfs "$@"
+      ;;
+    dd)
+      run_dd "$@"
       ;;
     *)
       die "unsupported command '$command'"

--- a/scripts/cleanroom-root-helper.sh
+++ b/scripts/cleanroom-root-helper.sh
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Security model:
+# - This script is a root-owned allowlist for privileged cleanroom operations.
+# - Unprivileged callers reach it via `sudo -n /usr/local/sbin/cleanroom-root-helper ...`.
+# - Install or update it only from trusted `main` rollout paths, never from PR checkouts.
+#
+# Sharp edges:
+# - Every new command, flag shape, or path wildcard expands the root execution surface.
+# - Keep validation explicit; do not add generic passthroughs, shell evaluation, or broad writable paths.
+# - Helper changes should land and roll out before dependent PRs; CI should detect drift, not self-update.
+
 die() {
   echo "cleanroom-root-helper: $*" >&2
   exit 2

--- a/scripts/root_helper_test.go
+++ b/scripts/root_helper_test.go
@@ -1,0 +1,35 @@
+package scripts_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestCleanroomRootHelperSupportsZFSVolumeOperations(t *testing.T) {
+	t.Helper()
+
+	content, err := os.ReadFile("cleanroom-root-helper.sh")
+	if err != nil {
+		t.Fatalf("read cleanroom-root-helper.sh: %v", err)
+	}
+
+	script := string(content)
+	for _, needle := range []string{
+		"is_runtime_rootfs_image()",
+		"is_zfs_dataset()",
+		"is_zfs_snapshot_ref()",
+		"is_zvol_device_path()",
+		"run_zfs()",
+		"run_dd()",
+		"bin=\"$(zfs_bin)\"",
+		"exec \"$bin\" \"$@\"",
+		"exec \"$(dd_bin)\" \"$@\"",
+		"    zfs)",
+		"    dd)",
+	} {
+		if !strings.Contains(script, needle) {
+			t.Fatalf("expected cleanroom-root-helper.sh to contain %q", needle)
+		}
+	}
+}

--- a/scripts/update-cleanroom-root-helper.sh
+++ b/scripts/update-cleanroom-root-helper.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() {
+  printf '[update-cleanroom-root-helper] %s\n' "$*"
+}
+
+die() {
+  printf '[update-cleanroom-root-helper] error: %s\n' "$*" >&2
+  exit 1
+}
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/update-cleanroom-root-helper.sh [trusted-ref]
+
+Install scripts/cleanroom-root-helper.sh from a ref that is reachable from
+origin/main. The default trusted ref is origin/main.
+EOF
+}
+
+require_cmd() {
+  local cmd="$1"
+  command -v "$cmd" >/dev/null 2>&1 || die "required command not found: ${cmd}"
+}
+
+require_root() {
+  if [[ "$(id -u)" -ne 0 ]]; then
+    die "must run as root"
+  fi
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ "$#" -gt 1 ]]; then
+  usage >&2
+  exit 1
+fi
+
+require_root
+require_cmd git
+require_cmd install
+
+helper_install_path="${CLEANROOM_HELPER_INSTALL_PATH:-/usr/local/sbin/cleanroom-root-helper}"
+trusted_ref="${1:-${CLEANROOM_ROOT_HELPER_REF:-origin/main}}"
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "$script_dir/.." && pwd)"
+tmp_helper="$(mktemp)"
+trap 'rm -f "$tmp_helper"' EXIT
+
+cd "$repo_root"
+git fetch --quiet origin main
+
+trusted_commit="$(git rev-parse --verify "${trusted_ref}^{commit}")" || die "unable to resolve trusted ref ${trusted_ref}"
+origin_main_commit="$(git rev-parse --verify "origin/main^{commit}")" || die "unable to resolve origin/main"
+git merge-base --is-ancestor "$trusted_commit" "$origin_main_commit" || die "trusted ref ${trusted_ref} is not reachable from origin/main"
+
+git show "$trusted_commit:scripts/cleanroom-root-helper.sh" >"$tmp_helper" || die "unable to read scripts/cleanroom-root-helper.sh from ${trusted_ref}"
+install -o root -g root -m 0755 "$tmp_helper" "$helper_install_path"
+
+log "installed cleanroom root helper from ${trusted_commit} to ${helper_install_path}"

--- a/scripts/update_root_helper_test.go
+++ b/scripts/update_root_helper_test.go
@@ -1,0 +1,29 @@
+package scripts_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestUpdateCleanroomRootHelperUsesTrustedMainHistory(t *testing.T) {
+	t.Helper()
+
+	content, err := os.ReadFile("update-cleanroom-root-helper.sh")
+	if err != nil {
+		t.Fatalf("read update-cleanroom-root-helper.sh: %v", err)
+	}
+
+	script := string(content)
+	for _, needle := range []string{
+		"git fetch --quiet origin main",
+		"trusted_ref=\"${1:-${CLEANROOM_ROOT_HELPER_REF:-origin/main}}\"",
+		"git merge-base --is-ancestor \"$trusted_commit\" \"$origin_main_commit\"",
+		"git show \"$trusted_commit:scripts/cleanroom-root-helper.sh\" >\"$tmp_helper\"",
+		"install -o root -g root -m 0755 \"$tmp_helper\" \"$helper_install_path\"",
+	} {
+		if !strings.Contains(script, needle) {
+			t.Fatalf("expected update-cleanroom-root-helper.sh to contain %q", needle)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add ZFS and dd support to the root helper so Firecracker ZFS hosts can be updated ahead of the driver branch
- add a trusted update-cleanroom-root-helper.sh rollout path that installs helper content from refs reachable from origin/main
- require code owner review on the privileged helper rollout path and point CI drift failures at the trusted updater

## Testing
- mise x go@1.23 -- go test ./scripts
- mise run lint-shell
- mise run check

Unblocks #109 by splitting the privileged helper rollout into a separate PR.