### PR TITLE
refactor: simplify firecracker privileged helper flow

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -14,7 +14,7 @@ run = "go test ./..."
 
 [tasks.lint-shell]
 description = "Lint shell scripts"
-run = "shellcheck -x scripts/bootstrap-buildkite-agent.sh scripts/bootstrap-buildkite-agent-macos.sh scripts/bootstrap-cleanroom-host.sh scripts/cleanroom-root-helper.sh scripts/benchmark-tti.sh scripts/build-go.sh scripts/install-go.sh scripts/install.sh scripts/release.sh scripts/ci-cleanroom-e2e.sh scripts/ci-darwin-vz-e2e.sh"
+run = "shellcheck -x scripts/bootstrap-buildkite-agent.sh scripts/bootstrap-buildkite-agent-macos.sh scripts/bootstrap-cleanroom-host.sh scripts/cleanroom-root-helper.sh scripts/benchmark-tti.sh scripts/build-go.sh scripts/install-go.sh scripts/install.sh scripts/release.sh scripts/ci-bootstrap-linux-ssm.sh scripts/ci-cleanroom-e2e.sh scripts/ci-darwin-vz-e2e.sh"
 
 [tasks.test-full]
 description = "Run full Go test suite"
@@ -76,6 +76,14 @@ run = "go run ./cmd/cleanroom doctor"
 [tasks.doctor-json]
 description = "Run cleanroom diagnostics as JSON"
 run = "go run ./cmd/cleanroom doctor --json"
+
+[tasks."ci:bootstrap:linux"]
+description = "Rerun Linux CI bootstrap over SSM"
+run = "scripts/ci-bootstrap-linux-ssm.sh run"
+
+[tasks."ci:bootstrap:linux:logs"]
+description = "Fetch Linux CI bootstrap logs over SSM"
+run = "scripts/ci-bootstrap-linux-ssm.sh logs"
 
 [tasks.check]
 description = "Run build, test, and lint"

--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ backends:
   firecracker:
     binary_path: firecracker
     kernel_image: ""    # auto-managed when unset
-    privileged_mode: sudo
+    privileged_helper_path: /usr/local/sbin/cleanroom-root-helper
     vcpus: 2
     memory_mib: 1024
     launch_seconds: 30
@@ -371,7 +371,7 @@ When `rootfs` is unset, Cleanroom derives one from `sandbox.image.ref` and injec
 - `/dev/kvm` available and writable
 - Firecracker binary installed
 - `mkfs.ext4` for OCI-to-ext4 materialization
-- `sudo -n` access for `ip`, `iptables`, `sysctl`
+- `sudo -n` access to `/usr/local/sbin/cleanroom-root-helper`
 
 **macOS ([darwin-vz](docs/backend/darwin-vz.md)):**
 - `cleanroom-darwin-vz` helper signed with `com.apple.security.virtualization` entitlement

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -118,24 +118,21 @@ Linux cleanroom hosts should be treated as long-lived capacity.
 Rerun bootstrap in-place:
 
 ```bash
-instance_id="$(mise x -- terraform -chdir=infra/terraform/envs/ci output -raw instance_id)"
-
-AWS_PROFILE=buildkite-sandbox-pipelines-admin aws ssm send-command \
-  --region us-west-2 \
-  --instance-ids "$instance_id" \
-  --document-name AWS-RunShellScript \
-  --parameters '{"commands":["sudo env PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin /usr/local/bin/cleanroom-bootstrap-linux"]}'
+mise run ci:bootstrap:linux
 ```
 
 Check bootstrap logs and agent service:
 
 ```bash
-AWS_PROFILE=buildkite-sandbox-pipelines-admin aws ssm send-command \
-  --region us-west-2 \
-  --instance-ids "$instance_id" \
-  --document-name AWS-RunShellScript \
-  --parameters '{"commands":["sudo tail -n 120 /var/log/cleanroom-bootstrap-linux.log","sudo systemctl status buildkite-agent@cleanroom.service --no-pager","sudo tail -n 120 /var/lib/buildkite-agent/logs/buildkite-agent-cleanroom.log"]}'
+mise run ci:bootstrap:linux:logs
 ```
+
+Task defaults:
+
+- `AWS_PROFILE=buildkite-sandbox-pipelines-admin`
+- `AWS_REGION=us-west-2`
+- `CLEANROOM_CI_INSTANCE_ID` overrides Terraform lookup
+- `CLEANROOM_CI_TERRAFORM_DIR=infra/terraform/envs/ci`
 
 ### 4.3 Privileged helper execution
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -129,8 +129,8 @@ mise run ci:bootstrap:linux:logs
 
 Task defaults:
 
-- `AWS_PROFILE=buildkite-sandbox-pipelines-admin`
-- `AWS_REGION=us-west-2`
+- `CLEANROOM_CI_AWS_PROFILE=buildkite-sandbox-pipelines-admin`
+- `CLEANROOM_CI_AWS_REGION=us-west-2`
 - `CLEANROOM_CI_INSTANCE_ID` overrides Terraform lookup
 - `CLEANROOM_CI_TERRAFORM_DIR=infra/terraform/envs/ci`
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -137,41 +137,19 @@ AWS_PROFILE=buildkite-sandbox-pipelines-admin aws ssm send-command \
   --parameters '{"commands":["sudo tail -n 120 /var/log/cleanroom-bootstrap-linux.log","sudo systemctl status buildkite-agent@cleanroom.service --no-pager","sudo tail -n 120 /var/lib/buildkite-agent/logs/buildkite-agent-cleanroom.log"]}'
 ```
 
-### 4.3 Privileged command execution modes
+### 4.3 Privileged helper execution
 
-Firecracker backend supports two modes:
+Firecracker always executes privileged host operations through a single root-owned helper.
 
-- `sudo` (default): direct `sudo -n <command>` execution
-- `helper`: call a root-owned helper binary instead of direct sudo command execution
+Runtime config key:
 
-Runtime config keys:
-
-- `backends.firecracker.privileged_mode`
 - `backends.firecracker.privileged_helper_path`
 
 For CI script usage, you can also set:
 
-- `CLEANROOM_PRIVILEGED_MODE`
 - `CLEANROOM_PRIVILEGED_HELPER_PATH`
 
-#### Option A: default `sudo` mode
-
-`sudo` mode requires NOPASSWD for commands used by launched execution:
-
-```sudoers
-User_Alias CLEANROOM_CI = buildkite-agent
-Cmnd_Alias CLEANROOM_DOCTOR = /usr/bin/true, /usr/sbin/ip link show
-Cmnd_Alias CLEANROOM_NET = /usr/sbin/ip *, /usr/sbin/iptables *, /usr/sbin/sysctl -w net.ipv4.ip_forward=1
-Cmnd_Alias CLEANROOM_ROOTFS = /usr/bin/mount *, /usr/bin/umount *, /usr/bin/mkdir *, /usr/bin/install *
-
-CLEANROOM_CI ALL=(root) NOPASSWD: CLEANROOM_DOCTOR, CLEANROOM_NET, CLEANROOM_ROOTFS
-```
-
-#### Option B: hardened `helper` mode (recommended)
-
-Use a single root-owned helper binary and only grant sudo access to that helper:
-
-Install helper from this repository:
+Install the helper from this repository and only grant sudo access to that helper:
 
 ```bash
 sudo install -o root -g root -m 0755 scripts/cleanroom-root-helper.sh /usr/local/sbin/cleanroom-root-helper
@@ -181,14 +159,9 @@ sudo install -o root -g root -m 0755 scripts/cleanroom-root-helper.sh /usr/local
 buildkite-agent ALL=(root) NOPASSWD: /usr/local/sbin/cleanroom-root-helper *
 ```
 
-Then set:
+Then set `CLEANROOM_PRIVILEGED_HELPER_PATH=/usr/local/sbin/cleanroom-root-helper` if you need to override the runtime config.
 
-- `CLEANROOM_PRIVILEGED_MODE=helper`
-- `CLEANROOM_PRIVILEGED_HELPER_PATH=/usr/local/sbin/cleanroom-root-helper`
-
-In `helper` mode, `scripts/ci-cleanroom-e2e.sh` and `cleanroom doctor` probe the installed helper with `version` and `capabilities` before running Firecracker checks. They do not compare helper file hashes and they do not self-update the helper from the checkout.
-
-Older helpers that predate the probe are treated as legacy helpers with the baseline network/rootfs capability set. Branches only fail when they require a newer privileged capability, such as the ZFS helper surface.
+`scripts/ci-cleanroom-e2e.sh` probes the installed helper with `capabilities`, and `cleanroom doctor` also records the helper `version`, before running Firecracker checks. They do not compare helper file hashes and they do not self-update the helper from the checkout.
 
 If a branch needs a new privileged helper capability, roll out the updated helper on the CI host first, then rerun the branch. The normal path is:
 

--- a/infra/terraform/envs/ci/README.md
+++ b/infra/terraform/envs/ci/README.md
@@ -60,24 +60,21 @@ Rerun bootstrap on the existing Linux instance without replacing infrastructure:
 - Hosts provisioned before this runner existed need one trusted bootstrap rerun to install `/usr/local/bin/cleanroom-bootstrap-linux`.
 
 ```bash
-instance_id="$(mise x -- terraform -chdir=infra/terraform/envs/ci output -raw instance_id)"
-
-AWS_PROFILE=buildkite-sandbox-pipelines-admin aws ssm send-command \
-  --region us-west-2 \
-  --instance-ids "$instance_id" \
-  --document-name AWS-RunShellScript \
-  --parameters '{"commands":["sudo env PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin /usr/local/bin/cleanroom-bootstrap-linux"]}'
+mise run ci:bootstrap:linux
 ```
 
 Check bootstrap logs and the agent service:
 
 ```bash
-AWS_PROFILE=buildkite-sandbox-pipelines-admin aws ssm send-command \
-  --region us-west-2 \
-  --instance-ids "$instance_id" \
-  --document-name AWS-RunShellScript \
-  --parameters '{"commands":["sudo tail -n 120 /var/log/cleanroom-bootstrap-linux.log","sudo systemctl status buildkite-agent@cleanroom.service --no-pager","sudo tail -n 120 /var/lib/buildkite-agent/logs/buildkite-agent-cleanroom.log"]}'
+mise run ci:bootstrap:linux:logs
 ```
+
+Task defaults:
+
+- `AWS_PROFILE=buildkite-sandbox-pipelines-admin`
+- `AWS_REGION=us-west-2`
+- `CLEANROOM_CI_INSTANCE_ID` overrides Terraform lookup
+- `CLEANROOM_CI_TERRAFORM_DIR=infra/terraform/envs/ci`
 
 ## macOS Bootstrap Recovery (In-Place)
 

--- a/infra/terraform/envs/ci/README.md
+++ b/infra/terraform/envs/ci/README.md
@@ -71,8 +71,8 @@ mise run ci:bootstrap:linux:logs
 
 Task defaults:
 
-- `AWS_PROFILE=buildkite-sandbox-pipelines-admin`
-- `AWS_REGION=us-west-2`
+- `CLEANROOM_CI_AWS_PROFILE=buildkite-sandbox-pipelines-admin`
+- `CLEANROOM_CI_AWS_REGION=us-west-2`
 - `CLEANROOM_CI_INSTANCE_ID` overrides Terraform lookup
 - `CLEANROOM_CI_TERRAFORM_DIR=infra/terraform/envs/ci`
 

--- a/infra/terraform/envs/ci/bootstrap_defaults_test.go
+++ b/infra/terraform/envs/ci/bootstrap_defaults_test.go
@@ -97,7 +97,7 @@ func TestLinuxBootstrapScriptInstallsRerunnableBootstrapCommand(t *testing.T) {
 
 	scriptPath := filepath.Join("..", "..", "..", "..", "scripts", "bootstrap-buildkite-agent.sh")
 	requireContains(t, scriptPath, "BOOTSTRAP_ENV_PATH='/usr/local/etc/cleanroom-bootstrap-linux.env'")
-	requireContains(t, scriptPath, "local bootstrap_runner_path=\"${CLEANROOM_BOOTSTRAP_RUNNER_PATH:-/usr/local/bin/cleanroom-bootstrap-linux}\"")
+	requireContains(t, scriptPath, "local bootstrap_runner_path='/usr/local/bin/cleanroom-bootstrap-linux'")
 	requireContains(t, scriptPath, "CLEANROOM_BOOTSTRAP_REPO_URL")
 	requireContains(t, scriptPath, "CLEANROOM_BOOTSTRAP_REPO_REF")
 	requireContains(t, scriptPath, "CLEANROOM_BOOTSTRAP_SETUP_SCRIPT_PATH")

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -188,7 +188,6 @@ type FirecrackerConfig struct {
 	DockerStorageDriver  string
 	DockerIPTables       bool
 	Snapshots            SnapshotConfig
-	PrivilegedMode       string
 	PrivilegedHelperPath string
 	RunDir               string
 	VCPUs                int64

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -97,10 +97,7 @@ type sandboxInstance struct {
 const runObservabilityFile = "run-observability.json"
 const vsockDialRetryInterval = 50 * time.Millisecond
 const preparedRuntimeRootFSVersion = "v1"
-const privilegedModeSudo = "sudo"
-const privilegedModeHelper = "helper"
 const defaultPrivilegedHelperPath = "/usr/local/sbin/cleanroom-root-helper"
-const legacyHelperContractVersion = "legacy"
 const helperCapabilityFirecrackerNetwork = "firecracker-network"
 const helperCapabilityFirecrackerRootFS = "firecracker-rootfs"
 const helperCapabilityFirecrackerZFS = "firecracker-zfs"
@@ -734,8 +731,7 @@ func (a *Adapter) Doctor(_ context.Context, req backend.DoctorRequest) (*backend
 	}
 	appendCheck("network_policy_rules", policyRulesStatus, policyRulesMessage)
 
-	privilegedMode, privilegedHelperPath := resolvePrivilegedExecution(req.FirecrackerConfig)
-	appendCheck("network_privileged_mode", "pass", fmt.Sprintf("using privileged command mode %q", privilegedMode))
+	privilegedHelperPath := resolvePrivilegedHelperPath(req.FirecrackerConfig)
 
 	requiredCommands := []string{"ip", "iptables", "sysctl", "sudo"}
 	for _, cmd := range requiredCommands {
@@ -746,34 +742,28 @@ func (a *Adapter) Doctor(_ context.Context, req backend.DoctorRequest) (*backend
 		}
 	}
 
-	if privilegedMode == privilegedModeHelper {
-		if _, err := os.Stat(privilegedHelperPath); err != nil {
-			appendCheck("network_helper", "fail", fmt.Sprintf("privileged helper %q is not accessible: %v", privilegedHelperPath, err))
+	if _, err := os.Stat(privilegedHelperPath); err != nil {
+		appendCheck("network_helper", "fail", fmt.Sprintf("privileged helper %q is not accessible: %v", privilegedHelperPath, err))
+	} else {
+		appendCheck("network_helper", "pass", fmt.Sprintf("using privileged helper %q", privilegedHelperPath))
+
+		version, err := helperVersion(context.Background(), req.FirecrackerConfig)
+		if err != nil {
+			appendCheck("network_helper_version", "warn", fmt.Sprintf("privileged helper version probe failed: %v", err))
 		} else {
-			appendCheck("network_helper", "pass", fmt.Sprintf("using privileged helper %q", privilegedHelperPath))
+			appendCheck("network_helper_version", "pass", fmt.Sprintf("helper contract version %s", version))
+		}
 
-			version, legacyVersion, err := helperVersion(context.Background(), req.FirecrackerConfig)
-			if err != nil {
-				appendCheck("network_helper_version", "warn", fmt.Sprintf("privileged helper version probe failed: %v", err))
-			} else if legacyVersion {
-				appendCheck("network_helper_version", "warn", fmt.Sprintf("helper does not expose version; treating host helper as %s", legacyHelperContractVersion))
+		caps, err := helperCapabilities(context.Background(), req.FirecrackerConfig)
+		if err != nil {
+			appendCheck("network_helper_capabilities", "fail", fmt.Sprintf("privileged helper capability probe failed: %v", err))
+		} else {
+			requiredCaps := helperRequiredCapabilities(req.FirecrackerConfig)
+			missingCaps := helperMissingCapabilities(caps, requiredCaps)
+			if len(missingCaps) > 0 {
+				appendCheck("network_helper_capabilities", "fail", fmt.Sprintf("helper is missing required capabilities: %s (have: %s)", strings.Join(missingCaps, ", "), strings.Join(caps, ", ")))
 			} else {
-				appendCheck("network_helper_version", "pass", fmt.Sprintf("helper contract version %s", version))
-			}
-
-			caps, legacyCaps, err := helperCapabilities(context.Background(), req.FirecrackerConfig)
-			if err != nil {
-				appendCheck("network_helper_capabilities", "fail", fmt.Sprintf("privileged helper capability probe failed: %v", err))
-			} else {
-				requiredCaps := helperRequiredCapabilities(req.FirecrackerConfig)
-				missingCaps := helperMissingCapabilities(caps, requiredCaps)
-				if len(missingCaps) > 0 {
-					appendCheck("network_helper_capabilities", "fail", fmt.Sprintf("helper is missing required capabilities: %s (have: %s)", strings.Join(missingCaps, ", "), strings.Join(caps, ", ")))
-				} else if legacyCaps {
-					appendCheck("network_helper_capabilities", "warn", fmt.Sprintf("helper does not expose capabilities; assuming legacy capabilities: %s", strings.Join(caps, ", ")))
-				} else {
-					appendCheck("network_helper_capabilities", "pass", fmt.Sprintf("helper capabilities: %s", strings.Join(caps, ", ")))
-				}
+				appendCheck("network_helper_capabilities", "pass", fmt.Sprintf("helper capabilities: %s", strings.Join(caps, ", ")))
 			}
 		}
 	}
@@ -2206,16 +2196,12 @@ func resolveForwardRulesWithLookup(ctx context.Context, allow []policy.AllowRule
 	return rules, nil
 }
 
-func resolvePrivilegedExecution(cfg backend.FirecrackerConfig) (mode string, helperPath string) {
-	mode = strings.ToLower(strings.TrimSpace(cfg.PrivilegedMode))
-	if mode == "" {
-		mode = privilegedModeSudo
-	}
-	helperPath = strings.TrimSpace(cfg.PrivilegedHelperPath)
+func resolvePrivilegedHelperPath(cfg backend.FirecrackerConfig) string {
+	helperPath := strings.TrimSpace(cfg.PrivilegedHelperPath)
 	if helperPath == "" {
 		helperPath = defaultPrivilegedHelperPath
 	}
-	return mode, helperPath
+	return helperPath
 }
 
 func helperRequiredCapabilities(cfg backend.FirecrackerConfig) []string {
@@ -2229,13 +2215,6 @@ func helperRequiredCapabilities(cfg backend.FirecrackerConfig) []string {
 		required = append(required, helperCapabilityFirecrackerZFS)
 	}
 	return required
-}
-
-func helperLegacyCapabilities() []string {
-	return []string{
-		helperCapabilityFirecrackerNetwork,
-		helperCapabilityFirecrackerRootFS,
-	}
 }
 
 func helperMissingCapabilities(have, required []string) []string {
@@ -2257,13 +2236,10 @@ func helperMissingCapabilities(have, required []string) []string {
 	return missing
 }
 
-func helperCapabilities(ctx context.Context, cfg backend.FirecrackerConfig) ([]string, bool, error) {
+func helperCapabilities(ctx context.Context, cfg backend.FirecrackerConfig) ([]string, error) {
 	out, err := runRootCommandOutput(ctx, cfg, "capabilities")
 	if err != nil {
-		if helperProbeUnsupported(err, "capabilities") {
-			return helperLegacyCapabilities(), true, nil
-		}
-		return nil, false, err
+		return nil, err
 	}
 
 	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
@@ -2280,25 +2256,15 @@ func helperCapabilities(ctx context.Context, cfg backend.FirecrackerConfig) ([]s
 		seen[cap] = struct{}{}
 		caps = append(caps, cap)
 	}
-	return caps, false, nil
+	return caps, nil
 }
 
-func helperVersion(ctx context.Context, cfg backend.FirecrackerConfig) (string, bool, error) {
+func helperVersion(ctx context.Context, cfg backend.FirecrackerConfig) (string, error) {
 	out, err := runRootCommandOutput(ctx, cfg, "version")
 	if err != nil {
-		if helperProbeUnsupported(err, "version") {
-			return legacyHelperContractVersion, true, nil
-		}
-		return "", false, err
+		return "", err
 	}
-	return strings.TrimSpace(string(out)), false, nil
-}
-
-func helperProbeUnsupported(err error, command string) bool {
-	if err == nil {
-		return false
-	}
-	return strings.Contains(err.Error(), fmt.Sprintf("unsupported command '%s'", command))
+	return strings.TrimSpace(string(out)), nil
 }
 
 func logRunNotice(backendName, runID, notice string) {
@@ -2319,18 +2285,11 @@ func runRootCommand(ctx context.Context, cfg backend.FirecrackerConfig, args ...
 		return errors.New("missing privileged command")
 	}
 
-	mode, helperPath := resolvePrivilegedExecution(cfg)
-	switch mode {
-	case privilegedModeSudo:
-		return runCombinedCommand(ctx, append([]string{"sudo", "-n"}, args...), args)
-	case privilegedModeHelper:
-		if strings.TrimSpace(helperPath) == "" {
-			return errors.New("privileged helper mode requires helper path")
-		}
-		return runCombinedCommand(ctx, append([]string{"sudo", "-n", helperPath}, args...), append([]string{"helper"}, args...))
-	default:
-		return fmt.Errorf("unsupported privileged command mode %q", mode)
+	helperPath := resolvePrivilegedHelperPath(cfg)
+	if strings.TrimSpace(helperPath) == "" {
+		return errors.New("missing privileged helper path")
 	}
+	return runCombinedCommand(ctx, append([]string{"sudo", "-n", helperPath}, args...), append([]string{"helper"}, args...))
 }
 
 func runRootCommandOutput(ctx context.Context, cfg backend.FirecrackerConfig, args ...string) ([]byte, error) {
@@ -2338,18 +2297,11 @@ func runRootCommandOutput(ctx context.Context, cfg backend.FirecrackerConfig, ar
 		return nil, errors.New("missing privileged command")
 	}
 
-	mode, helperPath := resolvePrivilegedExecution(cfg)
-	switch mode {
-	case privilegedModeSudo:
-		return runCombinedCommandOutput(ctx, append([]string{"sudo", "-n"}, args...), args)
-	case privilegedModeHelper:
-		if strings.TrimSpace(helperPath) == "" {
-			return nil, errors.New("privileged helper mode requires helper path")
-		}
-		return runCombinedCommandOutput(ctx, append([]string{"sudo", "-n", helperPath}, args...), append([]string{"helper"}, args...))
-	default:
-		return nil, fmt.Errorf("unsupported privileged command mode %q", mode)
+	helperPath := resolvePrivilegedHelperPath(cfg)
+	if strings.TrimSpace(helperPath) == "" {
+		return nil, errors.New("missing privileged helper path")
 	}
+	return runCombinedCommandOutput(ctx, append([]string{"sudo", "-n", helperPath}, args...), append([]string{"helper"}, args...))
 }
 
 func runRootCommandBatch(ctx context.Context, cfg backend.FirecrackerConfig, commands [][]string) error {

--- a/internal/backend/firecracker/privileged_test.go
+++ b/internal/backend/firecracker/privileged_test.go
@@ -24,7 +24,7 @@ func setupFakeSudo(t *testing.T, logPath string) {
 	t.Setenv("PATH", tmpDir+":"+os.Getenv("PATH"))
 }
 
-func TestRunRootCommandHelperModeInvokesHelper(t *testing.T) {
+func TestRunRootCommandInvokesHelper(t *testing.T) {
 	tmpDir := t.TempDir()
 	sudoLogPath := filepath.Join(tmpDir, "sudo.log")
 	logPath := filepath.Join(tmpDir, "helper.log")
@@ -38,7 +38,6 @@ func TestRunRootCommandHelperModeInvokesHelper(t *testing.T) {
 	t.Setenv("HELPER_LOG_PATH", logPath)
 
 	cfg := backend.FirecrackerConfig{
-		PrivilegedMode:       privilegedModeHelper,
 		PrivilegedHelperPath: helperPath,
 	}
 
@@ -59,11 +58,11 @@ func TestRunRootCommandHelperModeInvokesHelper(t *testing.T) {
 		t.Fatalf("read sudo log: %v", err)
 	}
 	if got := strings.TrimSpace(string(sudoLogBytes)); !strings.HasPrefix(got, "-n "+helperPath+" ") {
-		t.Fatalf("expected helper mode to invoke helper via sudo, got %q", got)
+		t.Fatalf("expected helper invocation via sudo, got %q", got)
 	}
 }
 
-func TestRunRootCommandBatchHelperModeInvokesHelperPerCommand(t *testing.T) {
+func TestRunRootCommandBatchInvokesHelperPerCommand(t *testing.T) {
 	tmpDir := t.TempDir()
 	sudoLogPath := filepath.Join(tmpDir, "sudo.log")
 	logPath := filepath.Join(tmpDir, "helper.log")
@@ -77,7 +76,6 @@ func TestRunRootCommandBatchHelperModeInvokesHelperPerCommand(t *testing.T) {
 	t.Setenv("HELPER_LOG_PATH", logPath)
 
 	cfg := backend.FirecrackerConfig{
-		PrivilegedMode:       privilegedModeHelper,
 		PrivilegedHelperPath: helperPath,
 	}
 
@@ -111,7 +109,7 @@ func TestRunRootCommandBatchHelperModeInvokesHelperPerCommand(t *testing.T) {
 	}
 }
 
-func TestRunRootCommandOutputHelperModeInvokesHelper(t *testing.T) {
+func TestRunRootCommandOutputInvokesHelper(t *testing.T) {
 	tmpDir := t.TempDir()
 	sudoLogPath := filepath.Join(tmpDir, "sudo.log")
 	logPath := filepath.Join(tmpDir, "helper.log")
@@ -125,7 +123,6 @@ func TestRunRootCommandOutputHelperModeInvokesHelper(t *testing.T) {
 	t.Setenv("HELPER_LOG_PATH", logPath)
 
 	cfg := backend.FirecrackerConfig{
-		PrivilegedMode:       privilegedModeHelper,
 		PrivilegedHelperPath: helperPath,
 	}
 
@@ -146,7 +143,7 @@ func TestRunRootCommandOutputHelperModeInvokesHelper(t *testing.T) {
 	}
 }
 
-func TestHelperCapabilitiesFallsBackToLegacyWhenProbeUnsupported(t *testing.T) {
+func TestHelperCapabilitiesReturnsProbeError(t *testing.T) {
 	tmpDir := t.TempDir()
 	sudoLogPath := filepath.Join(tmpDir, "sudo.log")
 	helperPath := filepath.Join(tmpDir, "cleanroom-root-helper")
@@ -158,23 +155,19 @@ func TestHelperCapabilitiesFallsBackToLegacyWhenProbeUnsupported(t *testing.T) {
 	}
 
 	cfg := backend.FirecrackerConfig{
-		PrivilegedMode:       privilegedModeHelper,
 		PrivilegedHelperPath: helperPath,
 	}
 
-	caps, legacy, err := helperCapabilities(context.Background(), cfg)
-	if err != nil {
-		t.Fatalf("helperCapabilities: %v", err)
+	_, err := helperCapabilities(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("expected helperCapabilities to fail for unsupported probe")
 	}
-	if !legacy {
-		t.Fatal("expected helperCapabilities to report legacy fallback")
-	}
-	if got, want := strings.Join(caps, ","), strings.Join(helperLegacyCapabilities(), ","); got != want {
-		t.Fatalf("unexpected legacy helper capabilities: got %v want %v", caps, helperLegacyCapabilities())
+	if !strings.Contains(err.Error(), "unsupported command 'capabilities'") {
+		t.Fatalf("unexpected helperCapabilities error: %v", err)
 	}
 }
 
-func TestHelperVersionFallsBackToLegacyWhenProbeUnsupported(t *testing.T) {
+func TestHelperVersionReturnsProbeError(t *testing.T) {
 	tmpDir := t.TempDir()
 	sudoLogPath := filepath.Join(tmpDir, "sudo.log")
 	helperPath := filepath.Join(tmpDir, "cleanroom-root-helper")
@@ -186,30 +179,22 @@ func TestHelperVersionFallsBackToLegacyWhenProbeUnsupported(t *testing.T) {
 	}
 
 	cfg := backend.FirecrackerConfig{
-		PrivilegedMode:       privilegedModeHelper,
 		PrivilegedHelperPath: helperPath,
 	}
 
-	version, legacy, err := helperVersion(context.Background(), cfg)
-	if err != nil {
-		t.Fatalf("helperVersion: %v", err)
+	_, err := helperVersion(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("expected helperVersion to fail for unsupported probe")
 	}
-	if !legacy {
-		t.Fatal("expected helperVersion to report legacy fallback")
-	}
-	if got, want := version, legacyHelperContractVersion; got != want {
-		t.Fatalf("unexpected legacy helper version: got %q want %q", got, want)
+	if !strings.Contains(err.Error(), "unsupported command 'version'") {
+		t.Fatalf("unexpected helperVersion error: %v", err)
 	}
 }
 
-func TestResolvePrivilegedExecutionDefaultsToSudo(t *testing.T) {
+func TestResolvePrivilegedHelperPathDefaultsToInstalledPath(t *testing.T) {
 	t.Parallel()
 
-	mode, helperPath := resolvePrivilegedExecution(backend.FirecrackerConfig{})
-	if got, want := mode, privilegedModeSudo; got != want {
-		t.Fatalf("unexpected mode: got %q want %q", got, want)
-	}
-	if got, want := helperPath, defaultPrivilegedHelperPath; got != want {
+	if got, want := resolvePrivilegedHelperPath(backend.FirecrackerConfig{}), defaultPrivilegedHelperPath; got != want {
 		t.Fatalf("unexpected helper path: got %q want %q", got, want)
 	}
 }
@@ -217,14 +202,19 @@ func TestResolvePrivilegedExecutionDefaultsToSudo(t *testing.T) {
 func TestHelperRequiredCapabilitiesIncludesZFSWhenConfigured(t *testing.T) {
 	t.Parallel()
 
-	if got, want := helperRequiredCapabilities(backend.FirecrackerConfig{}), helperLegacyCapabilities(); strings.Join(got, ",") != strings.Join(want, ",") {
+	got := helperRequiredCapabilities(backend.FirecrackerConfig{})
+	want := []string{
+		helperCapabilityFirecrackerNetwork,
+		helperCapabilityFirecrackerRootFS,
+	}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
 		t.Fatalf("unexpected default helper capabilities: got %v want %v", got, want)
 	}
 
-	got := helperRequiredCapabilities(backend.FirecrackerConfig{
+	got = helperRequiredCapabilities(backend.FirecrackerConfig{
 		Snapshots: backend.SnapshotConfig{Driver: "zfs"},
 	})
-	want := []string{
+	want = []string{
 		helperCapabilityFirecrackerNetwork,
 		helperCapabilityFirecrackerRootFS,
 		helperCapabilityFirecrackerZFS,

--- a/internal/cli/policy_config.go
+++ b/internal/cli/policy_config.go
@@ -129,7 +129,6 @@ func defaultRuntimeConfig(defaultBackend string) runtimeconfig.Config {
 					Enabled: false,
 					Driver:  "file",
 				},
-				PrivilegedMode:       "sudo",
 				PrivilegedHelperPath: "/usr/local/sbin/cleanroom-root-helper",
 				VCPUs:                2,
 				MemoryMiB:            1024,

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -104,7 +104,6 @@ func (s *ServeCommand) runServer(ctx *runtimeContext) error {
 	if fcAdapter, ok := ctx.Backends["firecracker"].(*firecracker.Adapter); ok && fcAdapter.GatewayRegistry != nil {
 		if shouldInstallGatewayFirewall(runtime.GOOS) {
 			fwCfg := backend.FirecrackerConfig{
-				PrivilegedMode:       ctx.Config.Backends.Firecracker.PrivilegedMode,
 				PrivilegedHelperPath: ctx.Config.Backends.Firecracker.PrivilegedHelperPath,
 			}
 			fwCleanup, err := firecracker.SetupGatewayFirewall(context.Background(), gwPort, fwCfg)

--- a/internal/controlservice/runtime_config_helpers.go
+++ b/internal/controlservice/runtime_config_helpers.go
@@ -23,7 +23,6 @@ func mergeBackendConfig(backendName string, opts executionOptions, cfg runtimeco
 		DockerStartupSeconds: cfg.Backends.Firecracker.Services.Docker.StartupTimeoutSeconds,
 		DockerStorageDriver:  cfg.Backends.Firecracker.Services.Docker.StorageDriver,
 		DockerIPTables:       cfg.Backends.Firecracker.Services.Docker.IPTables,
-		PrivilegedMode:       cfg.Backends.Firecracker.PrivilegedMode,
 		PrivilegedHelperPath: cfg.Backends.Firecracker.PrivilegedHelperPath,
 		VCPUs:                cfg.Backends.Firecracker.VCPUs,
 		MemoryMiB:            cfg.Backends.Firecracker.MemoryMiB,

--- a/internal/runtimeconfig/config.go
+++ b/internal/runtimeconfig/config.go
@@ -29,7 +29,6 @@ type FirecrackerConfig struct {
 	RootFS               string         `yaml:"rootfs"`
 	Services             ServicesConfig `yaml:"services"`
 	Snapshots            SnapshotConfig `yaml:"snapshots"`
-	PrivilegedMode       string         `yaml:"privileged_mode"`
 	PrivilegedHelperPath string         `yaml:"privileged_helper_path"`
 	VCPUs                int64          `yaml:"vcpus"`
 	MemoryMiB            int64          `yaml:"memory_mib"`
@@ -95,7 +94,6 @@ func MergeBackendConfig(cfg Config, backendName string, launchSeconds int64) bac
 			BaseDir:               cfg.Backends.Firecracker.Snapshots.BaseDir,
 			QuiesceTimeoutSeconds: cfg.Backends.Firecracker.Snapshots.QuiesceTimeoutSeconds,
 		},
-		PrivilegedMode:       cfg.Backends.Firecracker.PrivilegedMode,
 		PrivilegedHelperPath: cfg.Backends.Firecracker.PrivilegedHelperPath,
 		VCPUs:                cfg.Backends.Firecracker.VCPUs,
 		MemoryMiB:            cfg.Backends.Firecracker.MemoryMiB,

--- a/internal/runtimeconfig/config_test.go
+++ b/internal/runtimeconfig/config_test.go
@@ -296,7 +296,6 @@ func TestMergeBackendConfig(t *testing.T) {
 				RootFS:               "/firecracker/rootfs.ext4",
 				Services:             ServicesConfig{Docker: DockerServiceConfig{StartupTimeoutSeconds: 12, StorageDriver: "overlay2", IPTables: true}},
 				Snapshots:            SnapshotConfig{Enabled: true, Driver: "file", BaseDir: "/firecracker/snapshots", QuiesceTimeoutSeconds: 15},
-				PrivilegedMode:       "helper",
 				PrivilegedHelperPath: "/usr/local/bin/cleanroom-root-helper",
 				VCPUs:                2,
 				MemoryMiB:            1024,

--- a/scripts/bootstrap-buildkite-agent.sh
+++ b/scripts/bootstrap-buildkite-agent.sh
@@ -20,8 +20,8 @@ require_cmd() {
 }
 
 install_linux_bootstrap_runner() {
-  local bootstrap_env_path="${CLEANROOM_BOOTSTRAP_ENV_PATH:-/usr/local/etc/cleanroom-bootstrap-linux.env}"
-  local bootstrap_runner_path="${CLEANROOM_BOOTSTRAP_RUNNER_PATH:-/usr/local/bin/cleanroom-bootstrap-linux}"
+  local bootstrap_env_path='/usr/local/etc/cleanroom-bootstrap-linux.env'
+  local bootstrap_runner_path='/usr/local/bin/cleanroom-bootstrap-linux'
   local bootstrap_repo_url="${CLEANROOM_BOOTSTRAP_REPO_URL:-}"
   local bootstrap_repo_ref="${CLEANROOM_BOOTSTRAP_REPO_REF:-main}"
   local bootstrap_setup_script_path="${CLEANROOM_BOOTSTRAP_SETUP_SCRIPT_PATH:-scripts/bootstrap-buildkite-agent.sh}"
@@ -207,11 +207,6 @@ install_sudo_if_missing() {
     return
   fi
 
-  if command -v dnf >/dev/null 2>&1; then
-    dnf install -y sudo
-    return
-  fi
-
   if command -v apt-get >/dev/null 2>&1; then
     export DEBIAN_FRONTEND=noninteractive
     apt-get update -y
@@ -219,12 +214,7 @@ install_sudo_if_missing() {
     return
   fi
 
-  if command -v yum >/dev/null 2>&1; then
-    yum install -y sudo
-    return
-  fi
-
-  die "sudo is required and no supported package manager was found"
+  die "sudo is required and this bootstrap script expects an Ubuntu apt-based host"
 }
 
 resolve_agent_arch() {
@@ -398,7 +388,7 @@ tags="$tags"
 build-path="/var/lib/buildkite-agent/builds"
 hooks-path="/var/lib/buildkite-agent/hooks"
 plugins-path="/var/lib/buildkite-agent/plugins"
-environment=["CLEANROOM_PRIVILEGED_MODE=helper","CLEANROOM_PRIVILEGED_HELPER_PATH=${HELPER_INSTALL_PATH}"]
+environment=["CLEANROOM_PRIVILEGED_HELPER_PATH=${HELPER_INSTALL_PATH}"]
 CFG
 chown root:buildkite-agent "/etc/buildkite-agent/${QUEUE_NAME}.cfg"
 chmod 0640 "/etc/buildkite-agent/${QUEUE_NAME}.cfg"

--- a/scripts/buildkite_pipeline_test.go
+++ b/scripts/buildkite_pipeline_test.go
@@ -83,3 +83,24 @@ func TestBuildkiteCIScriptsDoNotInvokeMiseDirectly(t *testing.T) {
 		})
 	}
 }
+
+func TestMiseIncludesLinuxBootstrapTasks(t *testing.T) {
+	t.Parallel()
+
+	content, err := os.ReadFile("../.mise.toml")
+	if err != nil {
+		t.Fatalf("read .mise.toml: %v", err)
+	}
+
+	mise := string(content)
+	for _, needle := range []string{
+		"[tasks.\"ci:bootstrap:linux\"]",
+		"run = \"scripts/ci-bootstrap-linux-ssm.sh run\"",
+		"[tasks.\"ci:bootstrap:linux:logs\"]",
+		"run = \"scripts/ci-bootstrap-linux-ssm.sh logs\"",
+	} {
+		if !strings.Contains(mise, needle) {
+			t.Fatalf("expected .mise.toml to contain %q", needle)
+		}
+	}
+}

--- a/scripts/ci-bootstrap-linux-ssm.sh
+++ b/scripts/ci-bootstrap-linux-ssm.sh
@@ -6,8 +6,8 @@ usage() {
 usage: scripts/ci-bootstrap-linux-ssm.sh <run|logs>
 
 Environment overrides:
-  AWS_PROFILE                AWS profile for the SSM command (default: buildkite-sandbox-pipelines-admin)
-  AWS_REGION                 AWS region for the SSM command (default: us-west-2)
+  CLEANROOM_CI_AWS_PROFILE   AWS profile for the SSM command (default: buildkite-sandbox-pipelines-admin)
+  CLEANROOM_CI_AWS_REGION    AWS region for the SSM command (default: us-west-2)
   CLEANROOM_CI_INSTANCE_ID   Explicit linux CI instance id (default: terraform output)
   CLEANROOM_CI_TERRAFORM_DIR Terraform dir used to resolve instance_id (default: infra/terraform/envs/ci)
 EOF
@@ -118,8 +118,8 @@ run_ssm() {
 
 main() {
   local mode="${1:-}"
-  local aws_profile="${AWS_PROFILE:-buildkite-sandbox-pipelines-admin}"
-  local aws_region="${AWS_REGION:-us-west-2}"
+  local aws_profile="${CLEANROOM_CI_AWS_PROFILE:-buildkite-sandbox-pipelines-admin}"
+  local aws_region="${CLEANROOM_CI_AWS_REGION:-us-west-2}"
   local terraform_dir="${CLEANROOM_CI_TERRAFORM_DIR:-infra/terraform/envs/ci}"
   local instance_id
   local parameters

--- a/scripts/ci-bootstrap-linux-ssm.sh
+++ b/scripts/ci-bootstrap-linux-ssm.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+usage: scripts/ci-bootstrap-linux-ssm.sh <run|logs>
+
+Environment overrides:
+  AWS_PROFILE                AWS profile for the SSM command (default: buildkite-sandbox-pipelines-admin)
+  AWS_REGION                 AWS region for the SSM command (default: us-west-2)
+  CLEANROOM_CI_INSTANCE_ID   Explicit linux CI instance id (default: terraform output)
+  CLEANROOM_CI_TERRAFORM_DIR Terraform dir used to resolve instance_id (default: infra/terraform/envs/ci)
+EOF
+  exit 1
+}
+
+require_cmd() {
+  local cmd="$1"
+  command -v "$cmd" >/dev/null 2>&1 || {
+    echo "required command not found: $cmd" >&2
+    exit 1
+  }
+}
+
+resolve_instance_id() {
+  local terraform_dir="$1"
+  local instance_id="${CLEANROOM_CI_INSTANCE_ID:-}"
+
+  if [ -n "$instance_id" ]; then
+    printf '%s\n' "$instance_id"
+    return
+  fi
+
+  require_cmd terraform
+  terraform -chdir="$terraform_dir" output -raw instance_id
+}
+
+run_ssm() {
+  local aws_profile="$1"
+  local aws_region="$2"
+  local instance_id="$3"
+  local parameters="$4"
+  local command_id
+  local wait_status
+  local status
+  local response_code
+  local stdout
+  local stderr
+
+  command_id="$(
+    AWS_PROFILE="$aws_profile" AWS_REGION="$aws_region" \
+      aws ssm send-command \
+        --instance-ids "$instance_id" \
+        --document-name AWS-RunShellScript \
+        --parameters "$parameters" \
+        --query 'Command.CommandId' \
+        --output text
+  )"
+
+  printf 'command_id: %s\n' "$command_id"
+
+  set +e
+  AWS_PROFILE="$aws_profile" AWS_REGION="$aws_region" \
+    aws ssm wait command-executed \
+      --command-id "$command_id" \
+      --instance-id "$instance_id"
+  wait_status=$?
+  set -e
+
+  status="$(
+    AWS_PROFILE="$aws_profile" AWS_REGION="$aws_region" \
+      aws ssm get-command-invocation \
+        --command-id "$command_id" \
+        --instance-id "$instance_id" \
+        --query 'Status' \
+        --output text
+  )"
+  response_code="$(
+    AWS_PROFILE="$aws_profile" AWS_REGION="$aws_region" \
+      aws ssm get-command-invocation \
+        --command-id "$command_id" \
+        --instance-id "$instance_id" \
+        --query 'ResponseCode' \
+        --output text
+  )"
+  stdout="$(
+    AWS_PROFILE="$aws_profile" AWS_REGION="$aws_region" \
+      aws ssm get-command-invocation \
+        --command-id "$command_id" \
+        --instance-id "$instance_id" \
+        --query 'StandardOutputContent' \
+        --output text
+  )"
+  stderr="$(
+    AWS_PROFILE="$aws_profile" AWS_REGION="$aws_region" \
+      aws ssm get-command-invocation \
+        --command-id "$command_id" \
+        --instance-id "$instance_id" \
+        --query 'StandardErrorContent' \
+        --output text
+  )"
+
+  printf 'status: %s\n' "$status"
+  printf 'response_code: %s\n' "$response_code"
+
+  if [ -n "$stdout" ] && [ "$stdout" != "None" ]; then
+    printf '%s\n%s\n' '--- stdout ---' "$stdout"
+  fi
+
+  if [ -n "$stderr" ] && [ "$stderr" != "None" ]; then
+    printf '%s\n%s\n' '--- stderr ---' "$stderr" >&2
+  fi
+
+  if [ "$wait_status" -ne 0 ] || [ "$status" != "Success" ]; then
+    exit 1
+  fi
+}
+
+main() {
+  local mode="${1:-}"
+  local aws_profile="${AWS_PROFILE:-buildkite-sandbox-pipelines-admin}"
+  local aws_region="${AWS_REGION:-us-west-2}"
+  local terraform_dir="${CLEANROOM_CI_TERRAFORM_DIR:-infra/terraform/envs/ci}"
+  local instance_id
+  local parameters
+
+  require_cmd aws
+
+  case "$mode" in
+    run)
+      parameters='{"commands":["sudo env PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin /usr/local/bin/cleanroom-bootstrap-linux"]}'
+      ;;
+    logs)
+      parameters='{"commands":["sudo tail -n 120 /var/log/cleanroom-bootstrap-linux.log","sudo systemctl status buildkite-agent@cleanroom.service --no-pager","sudo tail -n 120 /var/lib/buildkite-agent/logs/buildkite-agent-cleanroom.log"]}'
+      ;;
+    *)
+      usage
+      ;;
+  esac
+
+  instance_id="$(resolve_instance_id "$terraform_dir")"
+  if [ -z "$instance_id" ]; then
+    echo "failed to resolve linux CI instance_id" >&2
+    exit 1
+  fi
+
+  printf 'instance_id: %s\n' "$instance_id"
+  run_ssm "$aws_profile" "$aws_region" "$instance_id" "$parameters"
+}
+
+main "$@"

--- a/scripts/ci-cleanroom-e2e.sh
+++ b/scripts/ci-cleanroom-e2e.sh
@@ -3,15 +3,9 @@ set -euo pipefail
 
 KERNEL_IMAGE="${CLEANROOM_KERNEL_IMAGE:-}"
 FIRECRACKER_BINARY="${CLEANROOM_FIRECRACKER_BINARY:-firecracker}"
-PRIVILEGED_MODE="${CLEANROOM_PRIVILEGED_MODE:-}"
-PRIVILEGED_HELPER_PATH="${CLEANROOM_PRIVILEGED_HELPER_PATH:-}"
+PRIVILEGED_HELPER_PATH="${CLEANROOM_PRIVILEGED_HELPER_PATH:-/usr/local/sbin/cleanroom-root-helper}"
 
 ROOT_HELPER_REQUIRED_CAPABILITIES=(
-  firecracker-network
-  firecracker-rootfs
-)
-
-ROOT_HELPER_LEGACY_CAPABILITIES=(
   firecracker-network
   firecracker-rootfs
 )
@@ -21,29 +15,13 @@ if [[ -z "$KERNEL_IMAGE" ]]; then
   exit 1
 fi
 
-# run_privileged executes a privileged command via the root helper,
-# falling back to sudo, then direct execution.
+# run_privileged executes a privileged command via the installed root helper.
 run_privileged() {
-  case "${PRIVILEGED_MODE:-sudo}" in
-    helper)
-      if [[ -z "${PRIVILEGED_HELPER_PATH:-}" ]]; then
-        echo "CLEANROOM_PRIVILEGED_HELPER_PATH is required when CLEANROOM_PRIVILEGED_MODE=helper" >&2
-        return 1
-      fi
-      sudo -n "$PRIVILEGED_HELPER_PATH" "$@"
-      ;;
-    ""|sudo)
-      if command -v sudo >/dev/null 2>&1; then
-        sudo -n "$@"
-      else
-        "$@"
-      fi
-      ;;
-    *)
-      echo "unsupported CLEANROOM_PRIVILEGED_MODE: $PRIVILEGED_MODE" >&2
-      return 1
-      ;;
-  esac
+  if [[ -z "${PRIVILEGED_HELPER_PATH:-}" ]]; then
+    echo "CLEANROOM_PRIVILEGED_HELPER_PATH is required for Firecracker e2e CI" >&2
+    return 1
+  fi
+  sudo -n "$PRIVILEGED_HELPER_PATH" "$@"
 }
 
 annotate_root_helper_problem() {
@@ -60,26 +38,19 @@ EOF
 }
 
 verify_helper_capabilities() {
-  [[ "${PRIVILEGED_MODE:-}" == "helper" ]] || return 0
-
   if [[ -z "${PRIVILEGED_HELPER_PATH:-}" ]]; then
-    echo "CLEANROOM_PRIVILEGED_HELPER_PATH is required when CLEANROOM_PRIVILEGED_MODE=helper" >&2
+    echo "CLEANROOM_PRIVILEGED_HELPER_PATH is required for Firecracker e2e CI" >&2
     return 1
   fi
 
   local capabilities
   if ! capabilities="$(sudo -n "$PRIVILEGED_HELPER_PATH" capabilities 2>&1)"; then
-    if grep -Fq "unsupported command 'capabilities'" <<<"$capabilities"; then
-      echo "⚠️  Legacy root helper detected at $PRIVILEGED_HELPER_PATH; assuming baseline helper capabilities" >&2
-      capabilities="$(printf '%s\n' "${ROOT_HELPER_LEGACY_CAPABILITIES[@]}")"
-    else
-      echo "⚠️  Root helper capability probe failed via $PRIVILEGED_HELPER_PATH" >&2
-      echo "   $capabilities" >&2
-      annotate_root_helper_problem \
-        "### ❌ Root helper capability probe failed" \
-        "The installed root helper (\`$PRIVILEGED_HELPER_PATH\`) could not be queried for capabilities.\n\nRoll out the latest helper on the CI host, for example by rerunning \`scripts/bootstrap-buildkite-agent.sh\`, and then rerun the build."
-      return 1
-    fi
+    echo "⚠️  Root helper capability probe failed via $PRIVILEGED_HELPER_PATH" >&2
+    echo "   $capabilities" >&2
+    annotate_root_helper_problem \
+      "### ❌ Root helper capability probe failed" \
+      "The installed root helper (\`$PRIVILEGED_HELPER_PATH\`) could not be queried for capabilities.\n\nRoll out the latest helper on the CI host, for example by rerunning \`scripts/bootstrap-buildkite-agent.sh\`, and then rerun the build."
+    return 1
   fi
 
   local missing=()
@@ -194,12 +165,7 @@ backends:
     launch_seconds: 90
 EOF
 
-if [[ -n "$PRIVILEGED_MODE" ]]; then
-  echo "    privileged_mode: $PRIVILEGED_MODE" >> "$XDG_CONFIG_HOME/cleanroom/config.yaml"
-fi
-if [[ -n "$PRIVILEGED_HELPER_PATH" ]]; then
-  echo "    privileged_helper_path: $PRIVILEGED_HELPER_PATH" >> "$XDG_CONFIG_HOME/cleanroom/config.yaml"
-fi
+echo "    privileged_helper_path: $PRIVILEGED_HELPER_PATH" >> "$XDG_CONFIG_HOME/cleanroom/config.yaml"
 
 echo "--- :stethoscope: Doctor"
 ./dist/cleanroom doctor --json | tee "$tmpdir/doctor.json"

--- a/scripts/ci_bootstrap_linux_ssm_test.go
+++ b/scripts/ci_bootstrap_linux_ssm_test.go
@@ -17,8 +17,8 @@ func TestCIBootstrapLinuxSSMScriptSupportsRunAndLogs(t *testing.T) {
 	script := string(content)
 	for _, needle := range []string{
 		"usage: scripts/ci-bootstrap-linux-ssm.sh <run|logs>",
-		"AWS_PROFILE",
-		"AWS_REGION",
+		"CLEANROOM_CI_AWS_PROFILE",
+		"CLEANROOM_CI_AWS_REGION",
 		"CLEANROOM_CI_INSTANCE_ID",
 		"CLEANROOM_CI_TERRAFORM_DIR",
 		"terraform -chdir=\"$terraform_dir\" output -raw instance_id",

--- a/scripts/ci_bootstrap_linux_ssm_test.go
+++ b/scripts/ci_bootstrap_linux_ssm_test.go
@@ -1,0 +1,37 @@
+package scripts_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestCIBootstrapLinuxSSMScriptSupportsRunAndLogs(t *testing.T) {
+	t.Helper()
+
+	content, err := os.ReadFile("ci-bootstrap-linux-ssm.sh")
+	if err != nil {
+		t.Fatalf("read ci-bootstrap-linux-ssm.sh: %v", err)
+	}
+
+	script := string(content)
+	for _, needle := range []string{
+		"usage: scripts/ci-bootstrap-linux-ssm.sh <run|logs>",
+		"AWS_PROFILE",
+		"AWS_REGION",
+		"CLEANROOM_CI_INSTANCE_ID",
+		"CLEANROOM_CI_TERRAFORM_DIR",
+		"terraform -chdir=\"$terraform_dir\" output -raw instance_id",
+		"aws ssm send-command",
+		"aws ssm wait command-executed",
+		"aws ssm get-command-invocation",
+		"run)",
+		"logs)",
+		"/usr/local/bin/cleanroom-bootstrap-linux",
+		"/var/log/cleanroom-bootstrap-linux.log",
+	} {
+		if !strings.Contains(script, needle) {
+			t.Fatalf("expected ci-bootstrap-linux-ssm.sh to contain %q", needle)
+		}
+	}
+}

--- a/scripts/ci_cleanroom_e2e_test.go
+++ b/scripts/ci_cleanroom_e2e_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestCiCleanroomE2EUsesNonInteractiveSudo(t *testing.T) {
+func TestCiCleanroomE2EUsesHelperViaNonInteractiveSudo(t *testing.T) {
 	t.Helper()
 
 	content, err := os.ReadFile("ci-cleanroom-e2e.sh")
@@ -16,12 +16,20 @@ func TestCiCleanroomE2EUsesNonInteractiveSudo(t *testing.T) {
 
 	script := string(content)
 	for _, needle := range []string{
-		"case \"${PRIVILEGED_MODE:-sudo}\" in",
+		"PRIVILEGED_HELPER_PATH=\"${CLEANROOM_PRIVILEGED_HELPER_PATH:-/usr/local/sbin/cleanroom-root-helper}\"",
 		"sudo -n \"$PRIVILEGED_HELPER_PATH\" \"$@\"",
-		"sudo -n \"$@\"",
 	} {
 		if !strings.Contains(script, needle) {
 			t.Fatalf("expected ci-cleanroom-e2e.sh to contain %q", needle)
+		}
+	}
+
+	for _, needle := range []string{
+		"CLEANROOM_PRIVILEGED_MODE",
+		"sudo -n \"$@\"",
+	} {
+		if strings.Contains(script, needle) {
+			t.Fatalf("expected ci-cleanroom-e2e.sh not to contain %q", needle)
 		}
 	}
 }
@@ -50,11 +58,8 @@ func TestCiCleanroomE2EProbesHelperCapabilitiesInsteadOfHelperDrift(t *testing.T
 	script := string(content)
 	for _, needle := range []string{
 		"ROOT_HELPER_REQUIRED_CAPABILITIES=(",
-		"ROOT_HELPER_LEGACY_CAPABILITIES=(",
 		"sudo -n \"$PRIVILEGED_HELPER_PATH\" capabilities",
 		"verify_helper_capabilities",
-		"unsupported command 'capabilities'",
-		"assuming baseline helper capabilities",
 		"Roll out the latest helper on the CI host",
 	} {
 		if !strings.Contains(script, needle) {
@@ -63,6 +68,9 @@ func TestCiCleanroomE2EProbesHelperCapabilitiesInsteadOfHelperDrift(t *testing.T
 	}
 
 	for _, needle := range []string{
+		"ROOT_HELPER_LEGACY_CAPABILITIES=(",
+		"unsupported command 'capabilities'",
+		"assuming baseline helper capabilities",
 		"sha256sum scripts/cleanroom-root-helper.sh",
 		"Update with: sudo install -o root -g root -m 0755 scripts/cleanroom-root-helper.sh",
 	} {


### PR DESCRIPTION
## Summary
- make Firecracker always execute privileged work through the root-owned helper and remove the `privileged_mode` config branch
- drop the legacy helper probe fallback and the unused Linux bootstrap runner path overrides
- simplify the Firecracker CI/bootstrap/docs/test surface around the single helper contract

## Testing
- mise x go@1.23 -- go test ./internal/backend/firecracker ./internal/runtimeconfig ./scripts ./infra/terraform/envs/ci
- mise run lint-shell
- mise run check

## Rollout note
- This removes the legacy helper compatibility path, so Linux CI hosts need the post-#114 helper rolled out before the PR build will pass.