### PR TITLE
feat: default mac CI to Tahoe

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -21,7 +21,7 @@ Pipeline config lives in `.buildkite/pipeline.yml`.
 
 No special setup is required beyond a working Buildkite agent image and internet access.
 
-For self-hosted macOS capacity, Terraform can provision a private EC2 Mac host and dedicated host via `infra/terraform/envs/ci` (`enable_macos_ci = true`, `mac_ami_id` required). This keeps mac queue access private-only (SSM, no inbound public rules).
+For self-hosted macOS capacity, Terraform can provision a private EC2 Mac host and dedicated host via `infra/terraform/envs/ci` (`enable_macos_ci = true`). By default it resolves the latest Tahoe AMI from the AWS public SSM parameter that matches `mac_instance_type`, and you can still override that with `mac_ami_id` or `mac_ami_ssm_parameter_name`. This keeps mac queue access private-only (SSM, no inbound public rules).
 
 Notes:
 

--- a/infra/terraform/envs/ci/README.md
+++ b/infra/terraform/envs/ci/README.md
@@ -11,7 +11,10 @@ Default AMI behaviour:
 - defaults to `us-west-2` for `aws_region`
 - uses latest Ubuntu 24.04 AMI from SSM public parameter
 - set `ami_id` in `terraform.tfvars` if you want to pin an explicit AMI
-- set `enable_macos_ci = true` and `mac_ami_id` to enable the macOS host
+- set `enable_macos_ci = true` to enable the macOS host
+- macOS defaults to the latest Tahoe AMI from the public SSM parameter that matches `mac_instance_type`
+- set `mac_ami_id` in `terraform.tfvars` if you want to pin an explicit macOS AMI
+- set `mac_ami_ssm_parameter_name` if you want a different public SSM parameter than the Tahoe default
 
 Network behaviour:
 

--- a/infra/terraform/envs/ci/bootstrap_defaults_test.go
+++ b/infra/terraform/envs/ci/bootstrap_defaults_test.go
@@ -84,6 +84,17 @@ func TestMacCiDefaultsUseBootstrapScript(t *testing.T) {
 	requireContains(t, "terraform.tfvars.example", "mac_buildkite_queue   = \"cleanroom-mac\"")
 }
 
+func TestMacCiDefaultsUseTahoePublicSsmParameter(t *testing.T) {
+	t.Helper()
+
+	requireContains(t, "main.tf", "/aws/service/ec2-macos/tahoe/x86_64_mac/latest/image_id")
+	requireContains(t, "main.tf", "/aws/service/ec2-macos/tahoe/arm64_mac/latest/image_id")
+	requireContains(t, "main.tf", "data \"aws_ssm_parameter\" \"mac_ami\"")
+	requireContains(t, "main.tf", "trimspace(var.mac_ami_id) == \"\" ? 1 : 0")
+	requireContains(t, "main.tf", "trimspace(var.mac_ami_id) != \"\" ? var.mac_ami_id : data.aws_ssm_parameter.mac_ami[0].value")
+	requireContains(t, "terraform.tfvars.example", "# mac_ami_ssm_parameter_name = \"/aws/service/ec2-macos/tahoe/arm64_mac/latest/image_id\"")
+}
+
 func TestBootstrapScriptConfiguresBuildkiteAgent(t *testing.T) {
 	t.Helper()
 

--- a/infra/terraform/envs/ci/main.tf
+++ b/infra/terraform/envs/ci/main.tf
@@ -2,8 +2,21 @@ data "aws_ssm_parameter" "ubuntu_ami" {
   name = var.ubuntu_ami_ssm_parameter_name
 }
 
+data "aws_ssm_parameter" "mac_ami" {
+  count = var.enable_macos_ci && trimspace(var.mac_ami_id) == "" ? 1 : 0
+  name  = local.selected_mac_ami_ssm_parameter_name
+}
+
 locals {
   selected_ami_id = var.ami_id != "" ? var.ami_id : data.aws_ssm_parameter.ubuntu_ami.value
+  selected_mac_ami_ssm_parameter_name = trimspace(var.mac_ami_ssm_parameter_name) != "" ? var.mac_ami_ssm_parameter_name : (
+    startswith(var.mac_instance_type, "mac1") ?
+    "/aws/service/ec2-macos/tahoe/x86_64_mac/latest/image_id" :
+    "/aws/service/ec2-macos/tahoe/arm64_mac/latest/image_id"
+  )
+  selected_mac_ami_id = !var.enable_macos_ci ? "" : (
+    trimspace(var.mac_ami_id) != "" ? var.mac_ami_id : data.aws_ssm_parameter.mac_ami[0].value
+  )
 
   # This env owns a fixed minimal private network shape.
   network = {
@@ -57,7 +70,7 @@ module "mac_ci" {
   name_prefix                    = "${var.name_prefix}-mac"
   vpc_id                         = module.network.vpc_id
   subnet_id                      = module.network.private_subnet_id
-  ami_id                         = var.mac_ami_id
+  ami_id                         = local.selected_mac_ami_id
   instance_type                  = var.mac_instance_type
   root_volume_size_gib           = var.mac_root_volume_size_gib
   buildkite_queue                = var.mac_buildkite_queue

--- a/infra/terraform/envs/ci/terraform.tfvars.example
+++ b/infra/terraform/envs/ci/terraform.tfvars.example
@@ -13,8 +13,10 @@ mac_instance_type = "mac2-m2pro.metal"
 # Optional: pin AMI manually. Leave empty to use latest Ubuntu from SSM parameter.
 # ami_id = "ami-0123456789abcdef0"
 
-# Required when enable_macos_ci is true.
+# Optional: pin the macOS AMI manually. Leave empty to use the latest Tahoe AMI
+# from the public SSM parameter that matches mac_instance_type.
 # mac_ami_id = "ami-0123456789abcdef0"
+# mac_ami_ssm_parameter_name = "/aws/service/ec2-macos/tahoe/arm64_mac/latest/image_id"
 
 buildkite_token_parameter_name    = "/buildkite/agent-token"
 tailscale_auth_key_parameter_name = "/tailscale/authkey/ci"

--- a/infra/terraform/envs/ci/variables.tf
+++ b/infra/terraform/envs/ci/variables.tf
@@ -47,14 +47,15 @@ variable "enable_macos_ci" {
 }
 
 variable "mac_ami_id" {
-  description = "AMI ID for macOS CI host. Required when enable_macos_ci is true."
+  description = "Optional AMI override for macOS CI host. Leave empty to use the Tahoe public SSM parameter that matches mac_instance_type."
   type        = string
   default     = ""
+}
 
-  validation {
-    condition     = !var.enable_macos_ci || trimspace(var.mac_ami_id) != ""
-    error_message = "mac_ami_id must be set when enable_macos_ci is true."
-  }
+variable "mac_ami_ssm_parameter_name" {
+  description = "Optional SSM public parameter name for the macOS CI host AMI. Leave empty to use the Tahoe public parameter that matches mac_instance_type."
+  type        = string
+  default     = ""
 }
 
 variable "mac_instance_type" {


### PR DESCRIPTION
## Summary
- default the macOS CI EC2 Mac AMI to the AWS public Tahoe SSM parameter instead of requiring a pinned `mac_ami_id`
- choose the Tahoe SSM path that matches `mac_instance_type`, while keeping `mac_ami_id` and `mac_ami_ssm_parameter_name` overrides
- update CI docs and file-based Terraform tests to cover the new default

## Testing
- `mise x -- go test ./infra/terraform/envs/ci`
- `mise x -- terraform -chdir=infra/terraform/envs/ci init -backend=false`
- `mise x -- terraform -chdir=infra/terraform/envs/ci validate`

Unblocks mac CI for vmnet-shared work by moving the default EC2 Mac image selection to Tahoe.