### PR TITLE
chore: package macOS releases for notarized distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,35 +9,149 @@ permissions:
   contents: write
 
 jobs:
-  build-darwin-vz:
+  build-darwin-release:
     runs-on: macos-latest
     strategy:
       fail-fast: false
       matrix:
         include:
           - arch: arm64
+            asset_arch: arm64
+            goarch: arm64
             target: arm64-apple-macosx13.0
           - arch: amd64
+            asset_arch: x86_64
+            goarch: amd64
             target: x86_64-apple-macosx13.0
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build cleanroom-darwin-vz
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build signed macOS helper and package
+        env:
+          CLEANROOM_DARWIN_VZ_HELPER_CERT_P12_BASE64: ${{ secrets.CLEANROOM_DARWIN_VZ_HELPER_CERT_P12_BASE64 }}
+          CLEANROOM_DARWIN_VZ_HELPER_CERT_PASSWORD: ${{ secrets.CLEANROOM_DARWIN_VZ_HELPER_CERT_PASSWORD }}
+          CLEANROOM_DARWIN_VZ_HELPER_PROVISION_PROFILE_BASE64: ${{ secrets.CLEANROOM_DARWIN_VZ_HELPER_PROVISION_PROFILE_BASE64 }}
+          CLEANROOM_DARWIN_VZ_HELPER_SIGN_IDENTITY: ${{ secrets.CLEANROOM_DARWIN_VZ_HELPER_SIGN_IDENTITY }}
+          CLEANROOM_MACOS_INSTALLER_CERT_P12_BASE64: ${{ secrets.CLEANROOM_MACOS_INSTALLER_CERT_P12_BASE64 }}
+          CLEANROOM_MACOS_INSTALLER_CERT_PASSWORD: ${{ secrets.CLEANROOM_MACOS_INSTALLER_CERT_PASSWORD }}
+          CLEANROOM_MACOS_INSTALLER_SIGN_IDENTITY: ${{ secrets.CLEANROOM_MACOS_INSTALLER_SIGN_IDENTITY }}
+          CLEANROOM_MACOS_NOTARY_KEY_P8_BASE64: ${{ secrets.CLEANROOM_MACOS_NOTARY_KEY_P8_BASE64 }}
+          CLEANROOM_MACOS_NOTARY_KEY_ID: ${{ secrets.CLEANROOM_MACOS_NOTARY_KEY_ID }}
+          CLEANROOM_MACOS_NOTARY_ISSUER_ID: ${{ secrets.CLEANROOM_MACOS_NOTARY_ISSUER_ID }}
         run: |
+          for required in \
+            CLEANROOM_DARWIN_VZ_HELPER_CERT_P12_BASE64 \
+            CLEANROOM_DARWIN_VZ_HELPER_CERT_PASSWORD \
+            CLEANROOM_DARWIN_VZ_HELPER_PROVISION_PROFILE_BASE64 \
+            CLEANROOM_DARWIN_VZ_HELPER_SIGN_IDENTITY \
+            CLEANROOM_MACOS_INSTALLER_CERT_P12_BASE64 \
+            CLEANROOM_MACOS_INSTALLER_CERT_PASSWORD \
+            CLEANROOM_MACOS_INSTALLER_SIGN_IDENTITY \
+            CLEANROOM_MACOS_NOTARY_KEY_P8_BASE64 \
+            CLEANROOM_MACOS_NOTARY_KEY_ID \
+            CLEANROOM_MACOS_NOTARY_ISSUER_ID; do
+            if [[ -z "${!required:-}" ]]; then
+              echo "::error::missing required release secret ${required}" >&2
+              exit 1
+            fi
+          done
+
           mkdir -p "release-extra/darwin_${{ matrix.arch }}"
-          xcrun swiftc -O -target "${{ matrix.target }}" -framework Virtualization \
-            cmd/cleanroom-darwin-vz/main.swift \
-            -o "release-extra/darwin_${{ matrix.arch }}/cleanroom-darwin-vz"
+          APP_CERT_PATH="${RUNNER_TEMP}/cleanroom-developer-id-application.p12"
+          INSTALLER_CERT_PATH="${RUNNER_TEMP}/cleanroom-developer-id-installer.p12"
+          PROFILE_PATH="${RUNNER_TEMP}/Cleanroom_Darwin_Virtualization_Backend_Profile.provisionprofile"
+          NOTARY_KEY_PATH="${RUNNER_TEMP}/AuthKey_${CLEANROOM_MACOS_NOTARY_KEY_ID}.p8"
+          KEYCHAIN_PATH="${RUNNER_TEMP}/cleanroom-release-signing.keychain-db"
+          export APP_CERT_PATH INSTALLER_CERT_PATH PROFILE_PATH NOTARY_KEY_PATH
+          python3 - <<'PY'
+          import base64
+          import os
+          from pathlib import Path
+
+          Path(os.environ["APP_CERT_PATH"]).write_bytes(
+              base64.b64decode(os.environ["CLEANROOM_DARWIN_VZ_HELPER_CERT_P12_BASE64"])
+          )
+          Path(os.environ["INSTALLER_CERT_PATH"]).write_bytes(
+              base64.b64decode(os.environ["CLEANROOM_MACOS_INSTALLER_CERT_P12_BASE64"])
+          )
+          Path(os.environ["PROFILE_PATH"]).write_bytes(
+              base64.b64decode(os.environ["CLEANROOM_DARWIN_VZ_HELPER_PROVISION_PROFILE_BASE64"])
+          )
+          Path(os.environ["NOTARY_KEY_PATH"]).write_bytes(
+              base64.b64decode(os.environ["CLEANROOM_MACOS_NOTARY_KEY_P8_BASE64"])
+          )
+          PY
+
+          KEYCHAIN_PASSWORD="$(uuidgen)"
+          security create-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_PATH}"
+          security set-keychain-settings -lut 21600 "${KEYCHAIN_PATH}"
+          security unlock-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_PATH}"
+          security import "${APP_CERT_PATH}" \
+            -k "${KEYCHAIN_PATH}" \
+            -P "${CLEANROOM_DARWIN_VZ_HELPER_CERT_PASSWORD}" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/security
+          security import "${INSTALLER_CERT_PATH}" \
+            -k "${KEYCHAIN_PATH}" \
+            -P "${CLEANROOM_MACOS_INSTALLER_CERT_PASSWORD}" \
+            -T /usr/bin/productbuild \
+            -T /usr/bin/productsign \
+            -T /usr/bin/pkgbuild \
+            -T /usr/bin/security
+          security list-keychains -d user -s "${KEYCHAIN_PATH}"
+          security default-keychain -d user -s "${KEYCHAIN_PATH}"
+          security set-key-partition-list \
+            -S apple-tool:,apple:,codesign:,productsign: \
+            -s \
+            -k "${KEYCHAIN_PASSWORD}" \
+            "${KEYCHAIN_PATH}"
+
+          CLEANROOM_DARWIN_VZ_HELPER_SWIFT_TARGET="${{ matrix.target }}" \
+          CLEANROOM_DARWIN_VZ_HELPER_ENTITLEMENTS="cmd/cleanroom-darwin-vz/entitlements-vmnet.plist" \
+          CLEANROOM_DARWIN_VZ_HELPER_SIGN_IDENTITY="${CLEANROOM_DARWIN_VZ_HELPER_SIGN_IDENTITY}" \
+          CLEANROOM_DARWIN_VZ_HELPER_SIGN_IDENTIFIER="com.buildkite.cleanroom.darwin-vz" \
+          CLEANROOM_DARWIN_VZ_HELPER_PROVISION_PROFILE="${PROFILE_PATH}" \
+          CLEANROOM_DARWIN_VZ_HELPER_BUNDLE=1 \
+          CLEANROOM_DARWIN_VZ_HELPER_SIGN_RUNTIME=1 \
+            scripts/build-darwin-vz-helper.sh "release-extra/darwin_${{ matrix.arch }}/cleanroom-darwin-vz.app"
           cp cmd/cleanroom-darwin-vz/entitlements.plist "release-extra/darwin_${{ matrix.arch }}/entitlements.plist"
+          cp cmd/cleanroom-darwin-vz/entitlements-vmnet.plist "release-extra/darwin_${{ matrix.arch }}/entitlements-vmnet.plist"
+
+          GOOS=darwin GOARCH=${{ matrix.goarch }} CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -X main.version=${GITHUB_REF_NAME}" \
+            -o "release-extra/darwin_${{ matrix.arch }}/cleanroom" ./cmd/cleanroom
+          GOOS=linux GOARCH=${{ matrix.goarch }} CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" \
+            -o "release-extra/darwin_${{ matrix.arch }}/cleanroom-guest-agent" ./cmd/cleanroom-guest-agent
+
+          CLEANROOM_MACOS_RELEASE_VERSION="${GITHUB_REF_NAME#v}" \
+          CLEANROOM_MACOS_RELEASE_CLEANROOM_BINARY="release-extra/darwin_${{ matrix.arch }}/cleanroom" \
+          CLEANROOM_MACOS_RELEASE_GUEST_AGENT_BINARY="release-extra/darwin_${{ matrix.arch }}/cleanroom-guest-agent" \
+          CLEANROOM_MACOS_RELEASE_HELPER_APP="release-extra/darwin_${{ matrix.arch }}/cleanroom-darwin-vz.app" \
+          CLEANROOM_MACOS_RELEASE_APPLICATION_SIGN_IDENTITY="${CLEANROOM_DARWIN_VZ_HELPER_SIGN_IDENTITY}" \
+          CLEANROOM_MACOS_RELEASE_INSTALLER_SIGN_IDENTITY="${CLEANROOM_MACOS_INSTALLER_SIGN_IDENTITY}" \
+            scripts/build-macos-release-pkg.sh "release-extra/darwin_${{ matrix.arch }}/cleanroom_Darwin_${{ matrix.asset_arch }}.pkg"
+
+          CLEANROOM_MACOS_NOTARY_KEY_PATH="${NOTARY_KEY_PATH}" \
+          CLEANROOM_MACOS_NOTARY_KEY_ID="${CLEANROOM_MACOS_NOTARY_KEY_ID}" \
+          CLEANROOM_MACOS_NOTARY_ISSUER_ID="${CLEANROOM_MACOS_NOTARY_ISSUER_ID}" \
+            scripts/notarize-macos-package.sh "release-extra/darwin_${{ matrix.arch }}/cleanroom_Darwin_${{ matrix.asset_arch }}.pkg"
+
+          pkg_name="cleanroom_Darwin_${{ matrix.asset_arch }}.pkg"
+          shasum -a 256 "release-extra/darwin_${{ matrix.arch }}/${pkg_name}" \
+            | awk -v name="${pkg_name}" '{print $1 "  " name}' \
+            > "release-extra/darwin_${{ matrix.arch }}/${pkg_name}.sha256"
 
       - uses: actions/upload-artifact@v4
         with:
-          name: darwin-vz-${{ matrix.arch }}
-          path: release-extra
+          name: darwin-release-${{ matrix.arch }}
+          path: release-extra/darwin_${{ matrix.arch }}
 
   release:
     runs-on: ubuntu-latest
-    needs: build-darwin-vz
+    needs: build-darwin-release
     steps:
       - uses: actions/checkout@v4
         with:
@@ -49,13 +163,13 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: darwin-vz-arm64
-          path: release-extra
+          name: darwin-release-arm64
+          path: release-extra/darwin_arm64
 
       - uses: actions/download-artifact@v4
         with:
-          name: darwin-vz-amd64
-          path: release-extra
+          name: darwin-release-amd64
+          path: release-extra/darwin_amd64
 
       - name: Build release extra binaries
         run: |
@@ -71,3 +185,14 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload notarized macOS packages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${GITHUB_REF_NAME}" \
+            release-extra/darwin_arm64/cleanroom_Darwin_arm64.pkg \
+            release-extra/darwin_arm64/cleanroom_Darwin_arm64.pkg.sha256 \
+            release-extra/darwin_amd64/cleanroom_Darwin_x86_64.pkg \
+            release-extra/darwin_amd64/cleanroom_Darwin_x86_64.pkg.sha256 \
+            --clobber

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -45,7 +45,9 @@ archives:
     files:
       - src: release-extra/linux_{{ .Arch }}/cleanroom-guest-agent
         strip_parent: true
-      - src: release-extra/darwin_{{ .Arch }}/cleanroom-darwin-vz
+      - src: release-extra/darwin_{{ .Arch }}/cleanroom-darwin-vz.app
+        strip_parent: true
+      - src: release-extra/darwin_{{ .Arch }}/entitlements-vmnet.plist
         strip_parent: true
       - src: release-extra/darwin_{{ .Arch }}/entitlements.plist
         strip_parent: true

--- a/.mise.toml
+++ b/.mise.toml
@@ -26,7 +26,7 @@ run = "scripts/build-go.sh"
 
 [tasks."build:darwin"]
 description = "Build macOS darwin-vz helper into dist/"
-run = "{% if os() == \"macos\" %}mkdir -p dist && xcrun swiftc -O -framework Virtualization cmd/cleanroom-darwin-vz/main.swift -o dist/cleanroom-darwin-vz && codesign --force --sign - --entitlements cmd/cleanroom-darwin-vz/entitlements.plist dist/cleanroom-darwin-vz{% else %}true{% endif %}"
+run = "{% if os() == \"macos\" %}scripts/build-darwin-vz-helper.sh dist/cleanroom-darwin-vz{% else %}true{% endif %}"
 
 [tasks."build:image:alpine"]
 description = "Build local alpine base image"
@@ -57,7 +57,7 @@ run = "scripts/install-go.sh"
 [tasks."install:darwin"]
 description = "Install macOS darwin-vz helper into GOBIN (or GOPATH/bin)"
 depends = ["build:darwin"]
-run = "{% if os() == \"macos\" %}BIN_DIR=\"$(go env GOBIN)\"; if [ -z \"$BIN_DIR\" ]; then BIN_DIR=\"$(go env GOPATH)/bin\"; fi; ENTITLEMENTS=\"cmd/cleanroom-darwin-vz/entitlements.plist\"; mkdir -p \"$BIN_DIR\" && install -m 0755 dist/cleanroom-darwin-vz \"$BIN_DIR/cleanroom-darwin-vz\" && codesign --force --sign - --entitlements \"$ENTITLEMENTS\" \"$BIN_DIR/cleanroom-darwin-vz\"{% else %}true{% endif %}"
+run = "{% if os() == \"macos\" %}BIN_DIR=\"$(go env GOBIN)\"; if [ -z \"$BIN_DIR\" ]; then BIN_DIR=\"$(go env GOPATH)/bin\"; fi; mkdir -p \"$BIN_DIR\" && scripts/build-darwin-vz-helper.sh \"$BIN_DIR/cleanroom-darwin-vz\"{% else %}true{% endif %}"
 
 [tasks.install]
 description = "Install all binaries into GOBIN (or GOPATH/bin)"

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ curl -fsSL https://raw.githubusercontent.com/buildkite/cleanroom/main/scripts/in
 
 By default this installs to `/usr/local/bin`. Override with `--install-dir` or `CLEANROOM_INSTALL_DIR`.
 
+macOS releases also publish a signed, notarized `.pkg` on the GitHub releases page. Prefer that artifact when you want the standard macOS installer flow.
+
 ## Quick start
 
 Initialize runtime config and check host prerequisites:

--- a/README.md
+++ b/README.md
@@ -233,15 +233,16 @@ sandbox:
 | Host OS | Backend | Status | Notes |
 |---------|---------|--------|-------|
 | Linux | `firecracker` | Full support | Persistent sandboxes, per-sandbox TAP + guest IP identity, file download, egress allowlist enforcement |
-| macOS | `darwin-vz` | Supported with gaps | Persistent sandboxes, helper-managed NAT outbound networking, no file download, no egress filtering, no host-visible guest IP/TAP identity yet |
+| macOS | `darwin-vz` | Supported with gaps | Persistent sandboxes, `vmnet-shared` by default on macOS 26+, experimental custom subnet host reachability, no file download, no egress filtering, no TAP parity |
 
 Backend capabilities are exposed in `cleanroom doctor --json` under `capabilities`. See [isolation model](docs/isolation.md) for enforcement and persistence details.
 
 Network model differs significantly by backend:
 
 - `firecracker` creates a dedicated TAP interface and host/guest IP pair per sandbox, which enables host-side identity and firewall enforcement.
-- `darwin-vz` currently uses `Virtualization.framework` NAT networking. Guests can reach outbound destinations, but the host does not get a Firecracker-style per-sandbox TAP device or guest IP identity.
-- A future `darwin-vz` vmnet-backed mode is planned in [docs/plans/darwin-vz-vmnet-mode.md](docs/plans/darwin-vz-vmnet-mode.md).
+- `darwin-vz` now defaults to `vmnet-shared` on supported macOS 26+ hosts. It is still NAT-backed for outbound access, but the helper owns an explicit vmnet logical network and can provide guest IP metadata.
+- `darwin-vz` still does not expose Firecracker-style TAP devices or host firewall enforcement semantics. Explicit `nat` remains available as a fallback mode.
+- Current vmnet work and remaining gaps are tracked in [docs/plans/darwin-vz-vmnet-mode.md](docs/plans/darwin-vz-vmnet-mode.md).
 
 Select a backend explicitly:
 
@@ -350,6 +351,8 @@ backends:
   darwin-vz:
     kernel_image: ""    # auto-managed when unset
     rootfs: ""          # derived from sandbox.image.ref when unset
+    network:
+      mode: nat         # optional fallback; default is vmnet-shared on macOS 26+
     vcpus: 2
     memory_mib: 1024
     launch_seconds: 30
@@ -369,6 +372,8 @@ When `rootfs` is unset, Cleanroom derives one from `sandbox.image.ref` and injec
 
 **macOS ([darwin-vz](docs/backend/darwin-vz.md)):**
 - `cleanroom-darwin-vz` helper signed with `com.apple.security.virtualization` entitlement
+- `vmnet-shared` additionally needs `com.apple.developer.networking.vmnet` and a matching provisioning profile
+- explicit `nat` remains available as a compatibility fallback
 - `mkfs.ext4` and `debugfs` (`brew install e2fsprogs`)
 
 ## Diagnostics

--- a/cmd/cleanroom-darwin-vz/entitlements-vmnet.plist
+++ b/cmd/cleanroom-darwin-vz/entitlements-vmnet.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.virtualization</key>
+    <true/>
+    <key>com.apple.developer.networking.vmnet</key>
+    <true/>
+</dict>
+</plist>

--- a/cmd/cleanroom-darwin-vz/main.swift
+++ b/cmd/cleanroom-darwin-vz/main.swift
@@ -1,6 +1,7 @@
 import Darwin
 import Foundation
 import Virtualization
+import vmnet
 
 private struct CLIOptions {
     let socketPath: String
@@ -11,6 +12,8 @@ private struct ControlRequest: Decodable {
     let kernelPath: String?
     let rootFSPath: String?
     let bootArgs: String?
+    let networkMode: String?
+    let vmnetSubnetCIDR: String?
     let vcpus: Int?
     let memoryMiB: Int64?
     let guestPort: UInt32?
@@ -25,6 +28,8 @@ private struct ControlRequest: Decodable {
         case kernelPath = "kernel_path"
         case rootFSPath = "rootfs_path"
         case bootArgs = "boot_args"
+        case networkMode = "network_mode"
+        case vmnetSubnetCIDR = "vmnet_subnet_cidr"
         case vcpus
         case memoryMiB = "memory_mib"
         case guestPort = "guest_port"
@@ -41,6 +46,10 @@ private struct ControlResponse: Encodable {
     let error: String?
     let vmID: String?
     let proxySocketPath: String?
+    let vmnetSubnetCIDR: String?
+    let vmnetGuestIPv4: String?
+    let vmnetGatewayIPv4: String?
+    let vmnetPrefixLen: Int?
     let timingMS: [String: Int64]?
 
     enum CodingKeys: String, CodingKey {
@@ -48,6 +57,10 @@ private struct ControlResponse: Encodable {
         case error
         case vmID = "vm_id"
         case proxySocketPath = "proxy_socket_path"
+        case vmnetSubnetCIDR = "vmnet_subnet_cidr"
+        case vmnetGuestIPv4 = "vmnet_guest_ipv4"
+        case vmnetGatewayIPv4 = "vmnet_gateway_ipv4"
+        case vmnetPrefixLen = "vmnet_prefix_len"
         case timingMS = "timing_ms"
     }
 }
@@ -409,6 +422,15 @@ private final class ProxyServer {
 }
 
 private final class VMRuntime {
+    @available(macOS 26.0, *)
+    private struct VMNetSharedNetworkDetails {
+        let reference: vmnet_network_ref
+        let subnetCIDR: String
+        let gatewayIPv4: String
+        let guestIPv4: String
+        let prefixLength: Int
+    }
+
     private let lock = NSLock()
     private var vm: VZVirtualMachine?
     private var vmID: String?
@@ -417,6 +439,7 @@ private final class VMRuntime {
     private var launchTimeout: TimeInterval = 30
     private var vmQueue: DispatchQueue?
     private var proxy: ProxyServer?
+    private var vmnetNetwork: vmnet_network_ref?
 
     func start(from req: ControlRequest) throws -> ControlResponse {
         guard VZVirtualMachine.isSupported else {
@@ -458,15 +481,23 @@ private final class VMRuntime {
         let vmID = UUID().uuidString
         let startedAt = Date()
 
-        let (vm, serialChannel) = try buildVM(
+        let (vm, serialChannel, vmnetNetwork, vmnetSharedNetwork) = try buildVM(
             kernelPath: kernelPath,
             rootFSPath: rootFSPath,
             bootArgs: bootArgs,
+            networkMode: req.networkMode?.trimmingCharacters(in: .whitespacesAndNewlines),
+            vmnetSubnetCIDR: req.vmnetSubnetCIDR?.trimmingCharacters(in: .whitespacesAndNewlines),
             vcpus: vcpus,
             memoryMiB: memoryMiB,
             consoleLogPath: consoleLogPath,
             queue: vmQueue
         )
+        var releaseVMNetOnFailure = vmnetNetwork
+        defer {
+            if let releaseVMNetOnFailure {
+                releaseVMNetObject(releaseVMNetOnFailure)
+            }
+        }
 
         try startVM(vm, queue: vmQueue, timeoutSeconds: launchSeconds)
 
@@ -478,6 +509,8 @@ private final class VMRuntime {
         self.vm = vm
         self.vmID = vmID
         self.proxy = proxy
+        self.vmnetNetwork = vmnetNetwork
+        releaseVMNetOnFailure = nil
         proxy.start { [weak self] in
             guard let self else {
                 throw HelperError.vm("vm runtime no longer available")
@@ -491,6 +524,10 @@ private final class VMRuntime {
             error: nil,
             vmID: vmID,
             proxySocketPath: proxySocketPath,
+            vmnetSubnetCIDR: vmnetSharedNetwork?.subnetCIDR,
+            vmnetGuestIPv4: vmnetSharedNetwork?.guestIPv4,
+            vmnetGatewayIPv4: vmnetSharedNetwork?.gatewayIPv4,
+            vmnetPrefixLen: vmnetSharedNetwork?.prefixLength,
             timingMS: ["vm_ready": vmReadyMS]
         )
     }
@@ -506,6 +543,7 @@ private final class VMRuntime {
         let serialChannel = self.serialChannel
         let vmQueue = self.vmQueue
         let proxy = self.proxy
+        let vmnetNetwork = self.vmnetNetwork
         self.vmID = nil
         self.vm = nil
         self.serialChannel = nil
@@ -513,10 +551,16 @@ private final class VMRuntime {
         self.launchTimeout = 30
         self.vmQueue = nil
         self.proxy = nil
+        self.vmnetNetwork = nil
         lock.unlock()
 
         proxy?.stop()
         serialChannel?.close()
+        defer {
+            if let vmnetNetwork {
+                releaseVMNetObject(vmnetNetwork)
+            }
+        }
         guard let vm else {
             return
         }
@@ -611,21 +655,174 @@ private final class VMRuntime {
         }
     }
 
+    @available(macOS 26.0, *)
+    private func createVMNetSharedNetwork(subnetCIDR: String?) throws -> VMNetSharedNetworkDetails {
+        var status: vmnet_return_t = .VMNET_SUCCESS
+        guard let configuration = vmnet_network_configuration_create(.VMNET_SHARED_MODE, &status) else {
+            throw HelperError.vm("create vmnet network configuration: \(vmnetStatusDescription(status))")
+        }
+        defer { releaseVMNetObject(configuration) }
+
+        vmnet_network_configuration_disable_dhcp(configuration)
+
+        if let subnetCIDR, !subnetCIDR.isEmpty {
+            let components = subnetCIDR.split(separator: "/", omittingEmptySubsequences: false)
+            guard components.count == 2, let prefixLength = Int(components[1]), (0...32).contains(prefixLength) else {
+                throw HelperError.invalidRequest("vmnet_subnet_cidr must be a valid IPv4 CIDR")
+            }
+            let subnetAddress = try parseIPv4Address(String(components[0]))
+            let subnetValue = UInt32(bigEndian: subnetAddress.s_addr) & ipv4MaskValue(prefixLength: prefixLength)
+            let gatewayValue = subnetValue + 1
+            var gatewayAddress = in_addr(s_addr: gatewayValue.bigEndian)
+            var subnetMask = ipv4Mask(prefixLength: prefixLength)
+            let subnetStatus = vmnet_network_configuration_set_ipv4_subnet(configuration, &gatewayAddress, &subnetMask)
+            guard subnetStatus == .VMNET_SUCCESS else {
+                throw HelperError.vm("configure vmnet subnet \(subnetCIDR): \(vmnetStatusDescription(subnetStatus))")
+            }
+        }
+
+        guard let network = vmnet_network_create(configuration, &status) else {
+            throw HelperError.vm("create vmnet shared network: \(vmnetStatusDescription(status))")
+        }
+
+        do {
+            var subnetAddress = in_addr()
+            var subnetMask = in_addr()
+            vmnet_network_get_ipv4_subnet(network, &subnetAddress, &subnetMask)
+
+            let maskValue = UInt32(bigEndian: subnetMask.s_addr)
+            let networkValue = UInt32(bigEndian: subnetAddress.s_addr) & maskValue
+            let upperValue = networkValue + ~maskValue
+            let guestValue = networkValue + 2
+            guard guestValue < upperValue else {
+                throw HelperError.vm("vmnet shared subnet does not provide a guest address")
+            }
+
+            let prefixLength = maskValue.nonzeroBitCount
+            let subnetCIDR = "\(try formatIPv4Address(networkValue))/\(prefixLength)"
+            return VMNetSharedNetworkDetails(
+                reference: network,
+                subnetCIDR: subnetCIDR,
+                gatewayIPv4: try formatIPv4Address(networkValue + 1),
+                guestIPv4: try formatIPv4Address(guestValue),
+                prefixLength: prefixLength
+            )
+        } catch {
+            releaseVMNetObject(network)
+            throw error
+        }
+    }
+
+    private func releaseVMNetObject(_ value: OpaquePointer) {
+        Unmanaged<AnyObject>.fromOpaque(UnsafeRawPointer(value)).release()
+    }
+
+    private func parseIPv4Address(_ value: String) throws -> in_addr {
+        var address = in_addr()
+        let result = value.withCString { cs in
+            inet_pton(AF_INET, cs, &address)
+        }
+        guard result == 1 else {
+            throw HelperError.invalidRequest("invalid IPv4 address \(value)")
+        }
+        return address
+    }
+
+    private func ipv4Mask(prefixLength: Int) -> in_addr {
+        in_addr(s_addr: ipv4MaskValue(prefixLength: prefixLength).bigEndian)
+    }
+
+    private func ipv4MaskValue(prefixLength: Int) -> UInt32 {
+        if prefixLength <= 0 {
+            return 0
+        }
+        return UInt32.max << UInt32(32 - prefixLength)
+    }
+
+    private func formatIPv4Address(_ value: UInt32) throws -> String {
+        var address = in_addr(s_addr: value.bigEndian)
+        var buffer = [CChar](repeating: 0, count: Int(INET_ADDRSTRLEN))
+        let result = withUnsafePointer(to: &address) { addrPointer in
+            inet_ntop(AF_INET, addrPointer, &buffer, socklen_t(INET_ADDRSTRLEN))
+        }
+        guard result != nil else {
+            throw HelperError.vm("format IPv4 address \(value)")
+        }
+        return String(cString: buffer)
+    }
+
+    private func vmnetStatusDescription(_ status: vmnet_return_t) -> String {
+        switch status {
+        case .VMNET_SUCCESS:
+            return "success"
+        case .VMNET_FAILURE:
+            return "general failure"
+        case .VMNET_MEM_FAILURE:
+            return "memory allocation failure"
+        case .VMNET_INVALID_ARGUMENT:
+            return "invalid argument"
+        case .VMNET_SETUP_INCOMPLETE:
+            return "setup incomplete"
+        case .VMNET_INVALID_ACCESS:
+            return "invalid access (helper may be missing com.apple.developer.networking.vmnet entitlement)"
+        case .VMNET_PACKET_TOO_BIG:
+            return "packet too big"
+        case .VMNET_BUFFER_EXHAUSTED:
+            return "buffer exhausted"
+        case .VMNET_TOO_MANY_PACKETS:
+            return "too many packets"
+        case .VMNET_SHARING_SERVICE_BUSY:
+            return "sharing service busy"
+        case .VMNET_NOT_AUTHORIZED:
+            return "not authorized (helper may be missing com.apple.developer.networking.vmnet entitlement)"
+        default:
+            return "status \(status.rawValue)"
+        }
+    }
+
     private func buildVM(
         kernelPath: String,
         rootFSPath: String,
         bootArgs: String,
+        networkMode: String?,
+        vmnetSubnetCIDR: String?,
         vcpus: Int,
         memoryMiB: Int64,
         consoleLogPath: String,
         queue: DispatchQueue
-    ) throws -> (VZVirtualMachine, GuestChannel) {
+    ) throws -> (VZVirtualMachine, GuestChannel, vmnet_network_ref?, VMNetSharedNetworkDetails?) {
         let kernelURL = URL(fileURLWithPath: kernelPath)
         let rootFSURL = URL(fileURLWithPath: rootFSPath)
         let consoleURL = URL(fileURLWithPath: consoleLogPath)
 
+        let networkDevice = VZVirtioNetworkDeviceConfiguration()
+        let resolvedNetworkMode = (networkMode?.isEmpty == false ? networkMode! : "nat")
+        let vmnetNetwork: vmnet_network_ref?
+        let vmnetSharedNetwork: VMNetSharedNetworkDetails?
+        var resolvedBootArgs = bootArgs
+        switch resolvedNetworkMode {
+        case "nat":
+            networkDevice.attachment = VZNATNetworkDeviceAttachment()
+            vmnetNetwork = nil
+            vmnetSharedNetwork = nil
+        case "vmnet-shared":
+            guard #available(macOS 26.0, *) else {
+                throw HelperError.vm("vmnet-shared requires macOS 26 or later")
+            }
+            let networkDetails = try createVMNetSharedNetwork(subnetCIDR: vmnetSubnetCIDR)
+            resolvedBootArgs += " cleanroom_vmnet_guest_ipv4=\(networkDetails.guestIPv4)"
+            resolvedBootArgs += " cleanroom_vmnet_gateway_ipv4=\(networkDetails.gatewayIPv4)"
+            resolvedBootArgs += " cleanroom_vmnet_prefix_len=\(networkDetails.prefixLength)"
+            resolvedBootArgs += " cleanroom_vmnet_subnet_cidr=\(networkDetails.subnetCIDR)"
+            networkDevice.attachment = VZVmnetNetworkDeviceAttachment(network: networkDetails.reference)
+            vmnetNetwork = networkDetails.reference
+            vmnetSharedNetwork = networkDetails
+        default:
+            throw HelperError.invalidRequest("unsupported network_mode \(resolvedNetworkMode)")
+        }
+
         let bootLoader = VZLinuxBootLoader(kernelURL: kernelURL)
-        bootLoader.commandLine = bootArgs
+        bootLoader.commandLine = resolvedBootArgs
 
         let config = VZVirtualMachineConfiguration()
         config.bootLoader = bootLoader
@@ -649,16 +846,20 @@ private final class VMRuntime {
         let diskAttachment = try VZDiskImageStorageDeviceAttachment(url: rootFSURL, readOnly: false)
         let blockDevice = VZVirtioBlockDeviceConfiguration(attachment: diskAttachment)
         config.storageDevices = [blockDevice]
-
-        let networkDevice = VZVirtioNetworkDeviceConfiguration()
-        networkDevice.attachment = VZNATNetworkDeviceAttachment()
         config.networkDevices = [networkDevice]
 
         config.entropyDevices = [VZVirtioEntropyDeviceConfiguration()]
         config.memoryBalloonDevices = [VZVirtioTraditionalMemoryBalloonDeviceConfiguration()]
         config.socketDevices = [VZVirtioSocketDeviceConfiguration()]
 
-        try config.validate()
+        do {
+            try config.validate()
+        } catch {
+            if let vmnetNetwork {
+                releaseVMNetObject(vmnetNetwork)
+            }
+            throw error
+        }
         let channel = GuestChannel(
             readFD: guestToHost.fileHandleForReading.fileDescriptor,
             writeFD: hostToGuest.fileHandleForWriting.fileDescriptor,
@@ -668,7 +869,7 @@ private final class VMRuntime {
                 hostToGuest.fileHandleForWriting.closeFile()
             }
         )
-        return (VZVirtualMachine(configuration: config, queue: queue), channel)
+        return (VZVirtualMachine(configuration: config, queue: queue), channel, vmnetNetwork, vmnetSharedNetwork)
     }
 
     private func startVM(_ vm: VZVirtualMachine, queue: DispatchQueue, timeoutSeconds: Int64) throws {
@@ -827,6 +1028,10 @@ private final class HelperService {
                     error: error.localizedDescription,
                     vmID: nil,
                     proxySocketPath: nil,
+                    vmnetSubnetCIDR: nil,
+                    vmnetGuestIPv4: nil,
+                    vmnetGatewayIPv4: nil,
+                    vmnetPrefixLen: nil,
                     timingMS: nil
                 ))
             }
@@ -847,15 +1052,15 @@ private final class HelperService {
             return try vmRuntime.start(from: req)
         case "StopVM":
             try vmRuntime.stop(vmID: req.vmID)
-            return ControlResponse(ok: true, error: nil, vmID: nil, proxySocketPath: nil, timingMS: nil)
+            return ControlResponse(ok: true, error: nil, vmID: nil, proxySocketPath: nil, vmnetSubnetCIDR: nil, vmnetGuestIPv4: nil, vmnetGatewayIPv4: nil, vmnetPrefixLen: nil, timingMS: nil)
         case "PauseVM":
             try vmRuntime.pause(vmID: req.vmID)
-            return ControlResponse(ok: true, error: nil, vmID: nil, proxySocketPath: nil, timingMS: nil)
+            return ControlResponse(ok: true, error: nil, vmID: nil, proxySocketPath: nil, vmnetSubnetCIDR: nil, vmnetGuestIPv4: nil, vmnetGatewayIPv4: nil, vmnetPrefixLen: nil, timingMS: nil)
         case "ResumeVM":
             try vmRuntime.resume(vmID: req.vmID)
-            return ControlResponse(ok: true, error: nil, vmID: nil, proxySocketPath: nil, timingMS: nil)
+            return ControlResponse(ok: true, error: nil, vmID: nil, proxySocketPath: nil, vmnetSubnetCIDR: nil, vmnetGuestIPv4: nil, vmnetGatewayIPv4: nil, vmnetPrefixLen: nil, timingMS: nil)
         case "Ping":
-            return ControlResponse(ok: true, error: nil, vmID: nil, proxySocketPath: nil, timingMS: nil)
+            return ControlResponse(ok: true, error: nil, vmID: nil, proxySocketPath: nil, vmnetSubnetCIDR: nil, vmnetGuestIPv4: nil, vmnetGatewayIPv4: nil, vmnetPrefixLen: nil, timingMS: nil)
         default:
             throw HelperError.invalidRequest("unsupported op \(req.op)")
         }

--- a/cmd/cleanroom-vmnet-echo/main.go
+++ b/cmd/cleanroom-vmnet-echo/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"net"
+	"os"
+)
+
+func main() {
+	listenAddr := flag.String("listen", ":18080", "tcp listen address")
+	response := flag.String("response", "ok\n", "response written to the first client")
+	flag.Parse()
+
+	listener, err := net.Listen("tcp", *listenAddr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "listen %q: %v\n", *listenAddr, err)
+		os.Exit(1)
+	}
+	defer listener.Close()
+
+	conn, err := listener.Accept()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "accept %q: %v\n", *listenAddr, err)
+		os.Exit(1)
+	}
+	defer conn.Close()
+
+	if _, err := io.WriteString(conn, *response); err != nil {
+		fmt.Fprintf(os.Stderr, "write response: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/docs/backend/darwin-vz.md
+++ b/docs/backend/darwin-vz.md
@@ -16,6 +16,7 @@ Implemented:
 - launched execution on macOS via `Virtualization.framework`
 - interactive and non-interactive command execution via existing `internal/vsockexec` protocol
 - helper-managed VM lifecycle (`StartVM` / `StopVM` / `PauseVM` / `ResumeVM`)
+- `vmnet-shared` network mode on macOS 26+ with optional experimental custom RFC1918 subnet
 - managed kernel fallback when `kernel_image` is unset or missing
 - rootfs derivation from `sandbox.image.ref` when `rootfs` is unset or missing
 - persistent sandboxes across multiple executions
@@ -120,6 +121,18 @@ This is not equivalent to Firecracker's network model:
 
 The current helper-managed NAT model is intentionally simpler, but it leaves `darwin-vz` behind Firecracker in network identity and enforcement. Planned vmnet-backed work is tracked in [../plans/darwin-vz-vmnet-mode.md](../plans/darwin-vz-vmnet-mode.md).
 
+Experimental runtime config:
+
+- `backends.darwin-vz.network.mode: vmnet-shared|nat`
+- `backends.darwin-vz.network.subnet: 10.233.0.0/16` for custom vmnet shared-mode IPv4 ranges
+
+`vmnet-shared` is now the default on supported macOS 26+ hosts when the network
+block is omitted. Use explicit `nat` only as a compatibility fallback.
+`vmnet-shared` accepts only RFC1918 IPv4 CIDRs. For `vmnet-shared`, the helper
+now mirrors the Apple `containerization` pattern: create the vmnet shared
+network in-helper, disable vmnet DHCP, derive the actual subnet from vmnet, and
+pass a static guest IPv4/gateway/prefix to the guest init path via boot args.
+
 ## Capability Surface
 
 Backends now expose a machine-readable capability map (visible in `cleanroom doctor --json` under `capabilities`).
@@ -137,7 +150,7 @@ Current `darwin-vz` capability values when snapshot support is enabled:
 Git traffic for allowed HTTPS hosts is routed through the host gateway over the
 NAT host address. The default gateway host is `192.168.64.1`; override it for
 unusual host networking setups with `CLEANROOM_DARWIN_GATEWAY_HOST`. Because
-the host lacks a stable per-sandbox guest IP identity in this mode, gateway
+there is still no Firecracker-style source-IP identity in this mode, gateway
 scoping currently relies on helper-managed scope-token headers rather than
 Firecracker-style source-IP identity.
 
@@ -147,9 +160,44 @@ Firecracker-style source-IP identity.
 
 - `com.apple.security.virtualization`
 
+The default `vmnet-shared` path additionally requires:
+
+- `com.apple.developer.networking.vmnet`
+- a matching provisioning profile for the helper identifier
+
 The main `cleanroom` Go binary does not require this entitlement for `darwin-vz`.
 
-`mise run build:darwin` and `mise run install:darwin` both sign the helper with `cmd/cleanroom-darwin-vz/entitlements.plist`.
+`scripts/build-darwin-vz-helper.sh` is the canonical helper build/sign path. By
+default it emits a plain signed helper binary. When
+`CLEANROOM_DARWIN_VZ_HELPER_PROVISION_PROFILE` is set it emits a signed
+`cleanroom-darwin-vz.app` bundle with an embedded provisioning profile so the
+helper can carry restricted entitlements.
+
+When a prebuilt helper `.app` bundle is available, the install script preserves
+that bundle as-is and only re-signs it when the caller explicitly provides
+helper signing overrides.
+
+Relevant env vars:
+
+- `CLEANROOM_DARWIN_VZ_HELPER_ENTITLEMENTS`
+- `CLEANROOM_DARWIN_VZ_HELPER_SIGN_IDENTITY`
+- `CLEANROOM_DARWIN_VZ_HELPER_SIGN_IDENTIFIER` (defaults to `com.buildkite.cleanroom.darwin-vz` when a provisioning profile is embedded)
+- `CLEANROOM_DARWIN_VZ_HELPER_PROVISION_PROFILE`
+
+Known-good local setup for vmnet-shared:
+
+1. Enable the Apple `VMNet` capability for `com.buildkite.cleanroom.darwin-vz`.
+2. Regenerate and install the matching macOS provisioning profile.
+3. Keep the downloaded profile available locally, for example at `~/Downloads/Cleanroom_Darwin_VZ_Backend.provisionprofile`.
+4. Build the helper app with that embedded profile:
+
+```bash
+CLEANROOM_DARWIN_VZ_HELPER_ENTITLEMENTS=cmd/cleanroom-darwin-vz/entitlements-vmnet.plist \
+CLEANROOM_DARWIN_VZ_HELPER_SIGN_IDENTITY='Apple Development: <you> (<team>)' \
+CLEANROOM_DARWIN_VZ_HELPER_SIGN_IDENTIFIER='com.buildkite.cleanroom.darwin-vz' \
+CLEANROOM_DARWIN_VZ_HELPER_PROVISION_PROFILE="$HOME/Downloads/Cleanroom_Darwin_VZ_Backend.provisionprofile" \
+scripts/build-darwin-vz-helper.sh dist/cleanroom-darwin-vz
+```
 
 ## Runtime Discovery
 
@@ -157,8 +205,10 @@ The helper path is resolved in this order:
 
 1. `CLEANROOM_DARWIN_VZ_HELPER`
 2. sibling binary next to `cleanroom`
-3. `dist/` under the current working directory or one of its ancestors
-4. `PATH`
+3. sibling `cleanroom-darwin-vz.app` bundle next to `cleanroom`
+4. `dist/` under the current working directory or one of its ancestors
+5. `dist/cleanroom-darwin-vz.app` under the current working directory or one of its ancestors
+6. `PATH`
 
 If missing, runtime fails with an actionable error.
 
@@ -196,10 +246,48 @@ Supported e2e overrides:
 - `CLEANROOM_DARWIN_VZ_E2E_KERNEL_IMAGE` forces a specific kernel path instead of the managed kernel asset.
 - `CLEANROOM_DARWIN_VZ_E2E_ROOTFS` points at a prebuilt ext4 rootfs and skips the host `e2fsprogs` requirement.
 
-The e2e test provisions one sandbox, runs two commands against it, asserts that filesystem writes survive across executions, then terminates the sandbox and verifies runtime cleanup.
+Focused vmnet spike path:
+
+```bash
+CLEANROOM_DARWIN_VZ_HELPER="$PWD/dist/cleanroom-darwin-vz.app" \
+CLEANROOM_DARWIN_VZ_VMNET_E2E=1 \
+mise exec -- go test ./internal/backend/darwinvz -run TestVMNetSharedE2E -v
+```
+
+The vmnet e2e expects the helper to already be signed with
+`cmd/cleanroom-darwin-vz/entitlements-vmnet.plist` and a provisioning profile
+that actually grants `com.apple.developer.networking.vmnet`.
+
+The current automated vmnet path covers:
+
+- `vmnet-shared` on the default shared network
+- guest IPv4 assignment via helper-provided static config
+- custom RFC1918 shared subnet egress, currently exercised with `10.233.0.0/16`
+- host-to-guest TCP reachability on the custom subnet path
+- guest outbound egress
+
+The host-to-guest check builds a tiny Linux guest test binary from
+`cmd/cleanroom-vmnet-echo`, injects it into a temporary e2e rootfs, runs it
+inside the guest, then verifies the host can connect to the guest IP directly.
+
+Important implementation detail:
+
+- when configuring a custom subnet, the helper must pass the host/gateway
+  address to `vmnet_network_configuration_set_ipv4_subnet`, not the raw network
+  address. Apple’s `containerization` code does this, and matching that
+  behavior fixed the previous custom-subnet bring-up failure in this repo.
+
+Known limits from the macOS 26.1 spike:
+
+- identity persistence across restarts is still not proven
+- guest metadata is now persisted in darwin-vz config/observability files, but
+  it is still derived per launch rather than allocated from a longer-lived
+  identity model
 
 ## Limitations
 
 - no allowlist egress filtering yet
 - no sandbox file download support yet
-- no host-visible per-sandbox guest IP / TAP identity yet
+- no Firecracker-style TAP identity or host firewall enforcement yet
+- direct host-to-guest routing is only exercised on the experimental custom
+  subnet vmnet path

--- a/docs/plans/darwin-vz-vmnet-mode.md
+++ b/docs/plans/darwin-vz-vmnet-mode.md
@@ -2,16 +2,49 @@
 
 ## Goal
 
-Add an opt-in vmnet-backed networking mode for `darwin-vz` that moves the backend closer to Firecracker's per-sandbox network identity model without introducing LAN bridging.
+Make vmnet-backed networking the default path for `darwin-vz` on supported
+macOS 26+ hosts without over-committing to Linux-style TAP semantics.
 
-Target outcome:
+Near-term target:
 
-- one host-reachable guest IP per sandbox
-- no LAN presence
-- outbound internet access retained
-- groundwork for future host access to guest-bound ports
+- make `vmnet-shared` the default on supported macOS 26+ hosts
+- keep explicit `nat` only as a fallback
+- ship the minimum helper packaging and signing support needed to satisfy Apple
+  VMNet requirements
+- prove reliable end-to-end paths for:
+  - default shared network boot + egress
+  - custom RFC1918 shared subnet boot + egress
 
-This document is a plan only. It does not describe implemented behavior.
+This document is a planning document informed by the March 2026 spike. It
+includes verified findings, current limits, and recommended next slices.
+
+## Current Status
+
+Validated on March 16, 2026 on macOS 26.1 (25B78):
+
+- `vmnet-shared` can work with `Virtualization.framework` when the helper
+  creates the vmnet logical network and attaches it in the same process
+- the helper must be a signed `.app` bundle with an embedded macOS
+  provisioning profile for `com.buildkite.cleanroom.darwin-vz`
+- the working VMNet entitlement/profile key is
+  `com.apple.developer.networking.vmnet`
+- the default shared network path works: VM boots, guest gets a static IPv4
+  derived from the vmnet subnet, and guest has outbound egress
+- the custom RFC1918 subnet path also works for `10.233.0.0/16` when the helper
+  disables vmnet DHCP, passes the host/gateway address to
+  `vmnet_network_configuration_set_ipv4_subnet`, and configures the guest
+  statically from boot args
+
+Still not proven:
+
+- deterministic identity across restarts
+
+Also validated:
+
+- host-to-guest TCP reachability works on the custom `10.233.0.0/16` path when
+  the guest runs an injected one-shot TCP test binary
+- helper-reported vmnet metadata can be persisted into darwin-vz config and run
+  observability output for later inspection
 
 ## Why
 
@@ -29,169 +62,273 @@ That differs materially from Firecracker, where each sandbox has:
 - a unique host IP / guest IP pair
 - host-side firewall rules keyed to sandbox network identity
 
-Vmnet mode is meant to close the identity and host-reachability gap, not to claim exact TAP parity with Linux.
+Vmnet mode is meant to close some of the identity and reachability gap, not to
+claim exact TAP parity with Linux.
+
+## Decision
+
+Proceed with vmnet in narrow increments:
+
+1. Treat default `vmnet-shared` as the only known-good first slice.
+2. Treat custom RFC1918 shared subnets as experimental but viable when routed
+   through the helper-owned static vmnet path.
+3. Treat direct host-to-guest TCP reachability as proven on the custom shared
+   subnet path, but keep the automation fixture narrow and test-specific.
+4. Defer deterministic guest identity, gateway integration, and metadata until
+   host reachability and persistence behavior are proven stable enough to build
+   on.
 
 ## Non-Goals
 
-- no implementation in this slice
 - no claim of exact Linux TAP or iptables parity
-- no LAN bridging
-- no public API changes for port publishing in the first slice
+- no LAN bridging in the first slice
+- no port publishing API in the first slice
+- no gateway or policy plumbing changes in the first slice
 
-## Proposed Mode
-
-Introduce an opt-in `darwin-vz` network mode based on vmnet shared-mode logical networks.
-
-Recommended first mode:
-
-- `vmnet-shared`
-
-Characteristics:
-
-- one logical vmnet network per sandbox
-- one private `/30` subnet per sandbox
-- host IP is the second address in that subnet
-- guest IP is the only assignable guest address in that subnet
-- outbound internet access remains available through vmnet shared-mode NAT
-- no dependence on the physical LAN
-
-Why `/30`:
-
-- it fits the one-host / one-guest topology exactly
-- it keeps sandbox identity simple and deterministic
-- it minimizes accidental sandbox-to-sandbox overlap
-
-## Constraints
+## Verified Constraints
 
 - `VZVmnetNetworkDeviceAttachment` is available only on macOS 26+
-- vmnet-backed networking requires additional authorization beyond the current virtualization entitlement
-- the vmnet network object must be created in the same process that attaches it to the VM
+- a VM can only use a vmnet logical network that was created in the same
+  application process that attaches it to the VM
+- vmnet-backed networking requires authorization beyond
+  `com.apple.security.virtualization`
+- on current Apple-managed provisioning, the practical entitlement to satisfy is
+  `com.apple.developer.networking.vmnet`
 
-Operational implication:
+Operational implications:
 
 - the Swift helper must own vmnet network creation
-- Go can plan network identity, but it cannot create the vmnet object on behalf of the helper
+- Go can choose mode and optional subnet, but it should not attempt to create
+  vmnet objects
+- the helper signing path needs to support a bundled app with an embedded
+  profile, not just a loose binary
 
-## Proposed Architecture
+## Recommended Architecture
 
 ### 1. Runtime Config
 
-Add darwin-specific runtime config for networking:
+Keep the runtime surface small:
 
 - `backends.darwin-vz.network.mode`
-- `backends.darwin-vz.network.subnet_pool`
-- `backends.darwin-vz.network.dns`
-- optional `backends.darwin-vz.network.external_interface`
+- optional `backends.darwin-vz.network.subnet`
 
-Initial default should remain `nat` until vmnet mode is proven.
+Defaults:
 
-### 2. Network Planning
+- `vmnet-shared` becomes the default on supported macOS 26+ hosts
+- explicit `nat` remains available as a fallback
+- custom subnet support stays explicitly experimental until Apple shared-mode
+  subnet behavior is reliable
 
-Before `StartVM`, the Go backend allocates a sandbox network plan:
+Do not add subnet pools, DNS overrides, or gateway-facing config in this slice.
 
-- subnet CIDR
-- host IP
-- guest IP
-- prefix length
-- deterministic guest MAC
+### 2. Helper Packaging and Signing
 
-This plan is passed to the helper as part of the control request and persisted in sandbox state.
+Use the dedicated helper App ID:
+
+- `com.buildkite.cleanroom.darwin-vz`
+
+Required local setup:
+
+1. Enable Apple `VMNet` for `com.buildkite.cleanroom.darwin-vz`.
+2. Regenerate and install the matching macOS provisioning profile.
+3. Build the helper as a signed `.app` bundle with the embedded profile.
+
+Known-good local build command:
+
+```bash
+CLEANROOM_DARWIN_VZ_HELPER_ENTITLEMENTS=cmd/cleanroom-darwin-vz/entitlements-vmnet.plist \
+CLEANROOM_DARWIN_VZ_HELPER_SIGN_IDENTITY='Apple Development: <you> (<team>)' \
+CLEANROOM_DARWIN_VZ_HELPER_SIGN_IDENTIFIER='com.buildkite.cleanroom.darwin-vz' \
+CLEANROOM_DARWIN_VZ_HELPER_PROVISION_PROFILE="$HOME/Downloads/Cleanroom_Darwin_VZ_Backend.provisionprofile" \
+scripts/build-darwin-vz-helper.sh dist/cleanroom-darwin-vz
+```
+
+The helper should carry:
+
+- `com.apple.security.virtualization`
+- `com.apple.developer.networking.vmnet`
 
 ### 3. Helper Networking
 
-In vmnet mode, the helper:
+In `vmnet-shared` mode, the helper should:
 
-- creates a vmnet shared-mode logical network
-- applies the requested subnet
-- attaches the VM NIC with `VZVmnetNetworkDeviceAttachment`
-- returns actual network identity in `StartVM` response
+- create a vmnet shared-mode logical network
+- disable vmnet DHCP
+- optionally apply a custom IPv4 subnet only when explicitly requested
+- when applying a custom subnet, pass the host/gateway address rather than the
+  raw network address to `vmnet_network_configuration_set_ipv4_subnet`
+- create the network object
+- query vmnet for the actual subnet after creation
+- attach the NIC using `VZVmnetNetworkDeviceAttachment`
 
-The current NAT attachment remains as the fallback path.
+The current NAT attachment remains the fallback path.
+
+Recommended behavior:
+
+- use the default shared network when no subnet is configured
+- derive the guest IP as the first usable address in the vmnet subnet
+- pass guest IPv4, gateway IPv4, and prefix length to the guest via boot args
 
 ### 4. Guest Networking
 
-The guest should move from DHCP-only startup to explicit boot-arg networking in vmnet mode.
+For `vmnet-shared`, prefer static guest networking driven by helper-provided
+boot args.
 
-Add darwin guest boot args mirroring Firecracker:
+Reason:
 
-- `cleanroom_guest_ip`
-- `cleanroom_guest_gw`
-- `cleanroom_guest_mask`
-- `cleanroom_guest_dns`
+- this matches Apple’s `containerization` implementation strategy
+- it removes guest dependence on vmnet DHCP
+- it works for both the default shared network and explicit RFC1918 subnets on
+  the validated host
 
-This makes guest identity deterministic and avoids depending on guest DHCP behavior for the new mode.
+Guest init should:
 
-### 5. Gateway Integration
+- bring the primary NIC up
+- apply the helper-provided IPv4/prefix
+- install the default route through the helper-provided gateway
+- write `/etc/resolv.conf` with the gateway as the nameserver
+- fall back to DHCP only when the vmnet static boot args are absent
 
-In current NAT mode, gateway scoping relies on scope-token headers because there is no stable guest IP identity.
+### 5. Identity and Host Reachability
 
-In vmnet mode, darwin should move to source-IP sandbox identity similar to Firecracker:
+Do not assume the initial vmnet mode provides a Firecracker-equivalent guest IP
+identity story.
 
-- register sandbox in the gateway by guest IP
-- use host IP as the guest-visible gateway address
-- keep scope-token flow only for NAT fallback mode
+Possible future directions:
 
-### 6. Sandbox Metadata
+- direct host-to-guest reachability using the statically assigned guest IP
+- longer-lived shared-network allocation if Cleanroom wants Apple-style multiple
+  guests on one vmnet network
+- vmnet port forwarding for explicit host ingress
 
-Expose vmnet network identity in sandbox state:
-
-- network mode
-- host IP
-- guest IP
-- subnet
-
-This enables future host-to-guest access patterns and debugging.
+Those should be follow-on slices, not part of the first working vmnet mode.
 
 ## Testing Plan
 
-Add opt-in darwin-vz e2e coverage for vmnet mode:
+### Automated Path
 
-- sandbox gets deterministic guest IP
-- host can connect to a guest-bound TCP port
-- guest still has outbound internet access
-- two sandboxes get distinct subnets
-- terminating a sandbox tears down reachability
-- gateway registration uses guest IP in vmnet mode
+Keep one focused opt-in e2e with two subtests:
 
-Keep existing NAT-mode tests intact.
+- `vmnet-shared` on the default shared network with helper-driven static guest
+  config
+- `vmnet-shared` on a custom RFC1918 subnet, currently `10.233.0.0/16`
+- guest has working outbound egress in both cases
+- host can reach a guest TCP listener on the custom subnet path
+
+The reachability subtest should use an injected one-shot Linux guest test
+binary, not packages expected to exist in the base image.
+
+Run it with a signed helper bundle:
+
+```bash
+CLEANROOM_DARWIN_VZ_HELPER="$PWD/dist/cleanroom-darwin-vz.app" \
+CLEANROOM_DARWIN_VZ_VMNET_E2E=1 \
+mise exec -- go test ./internal/backend/darwinvz -run TestVMNetSharedE2E -v
+```
+
+### Manual Follow-Up Checks
+
+Keep these as manual or follow-up spike items until the automated path is
+stable:
+
+- deterministic guest identity across restarts
 
 ## Risks
 
-- macOS version support split between NAT mode and vmnet mode
-- additional entitlement/signing requirements
-- helper/network cleanup complexity on crash paths
-- vmnet mode improves identity but still does not create a literal Linux TAP device
-- egress allowlist enforcement remains a separate problem even after guest IP identity exists
+- macOS version split between `nat` and `vmnet-shared`
+- Apple-managed capability and provisioning complexity
+- helper crash cleanup for vmnet logical networks
+- vmnet mode improves network behavior but still does not create a Linux TAP
+- egress allowlist enforcement remains separate from vmnet support
+- custom shared subnets may remain OS-version-sensitive even if the API exists
 
 ## Open Questions
 
-- Is vmnet shared-mode direct host-to-guest TCP reachability sufficient, or do we need explicit port-forward rules for the first host-access slice?
-- Do we want one NIC in shared mode, or a later dual-NIC design with one host-only interface and one outbound-NAT interface?
-- Should vmnet mode stay darwin-specific in runtime config, or is it worth defining a backend-neutral "host-reachable guest network" capability first?
+- Is direct host-to-guest TCP reachable on default shared mode reliable enough,
+  or should the first ingress slice use explicit vmnet port forwarding?
+- If Cleanroom eventually wants multiple simultaneous guests on one vmnet
+  network, should it copy Apple’s longer-lived allocator model instead of
+  creating one vmnet logical network per sandbox?
+- Do we need helper-reported vmnet metadata persisted in sandbox state, or is
+  the current boot-arg handoff enough for the next slice?
 
 ## Suggested Slices
 
 ### Slice 0: Spike
 
-- Prove a single `darwin-vz` VM can boot with vmnet shared mode
-- Prove host can reach a guest-bound port
-- Prove guest still has outbound internet access
+Status: complete.
+
+What it proved:
+
+- helper packaging and signing can satisfy VMNet on macOS
+- default `vmnet-shared` works for boot, static guest config, and egress
+- custom `10.233.0.0/16` `vmnet-shared` also works when the helper uses the
+  gateway address for subnet configuration and disables DHCP
+- host-to-guest TCP reachability works on the custom shared subnet path using
+  an injected one-shot guest test binary
+
+What it did not prove:
+
+- guest metadata persistence
 
 ### Slice 1: Experimental Mode
 
-- Add runtime config and helper wiring
-- Add per-sandbox subnet planning
-- Add boot-arg guest IP configuration
-- Persist network metadata
+- keep the current minimal runtime config and helper wiring
+- ship `vmnet-shared` as the default darwin-vz mode with experimental RFC1918
+  subnet override support
+- keep explicit `nat` as an escape hatch
+- keep the focused e2e on the default and custom shared paths
 
-### Slice 2: Gateway Identity
+Exit criteria:
 
-- Switch vmnet mode from scope-token gateway identity to guest-IP identity
-- Keep NAT mode unchanged
+- helper signing path is documented and repeatable
+- tagged release packaging installs a pre-signed vmnet-capable helper bundle
+- doctor surfaces missing vmnet entitlement/profile issues clearly
+- default shared-mode e2e passes on supported macOS 26+ hosts
+- custom shared-subnet e2e passes on supported macOS 26+ hosts
+- host-to-guest reachability e2e passes on supported macOS 26+ hosts
 
-### Slice 3: Hardening
+### Slice 2: Reachability Investigation
 
-- doctor checks for entitlement and vmnet support
-- teardown and crash recovery
-- observability fields for network identity and mode
-- CI strategy for supported macOS workers
+- decide whether product ingress should rely on direct shared-mode routing or
+  vmnet port-forward rules
+- decide whether the current injected test binary is sufficient, or whether a
+  richer guest fixture is needed for future networking tests
+
+Exit criteria:
+
+- one product-ready host-to-guest reachability story
+- one automated or repeatable verification path
+
+### Slice 3: Deterministic Identity
+
+- evaluate deterministic MAC allocation
+- decide whether a longer-lived shared-network allocator is preferable to
+  helper-per-sandbox vmnet networks
+- build on the now-persisted network metadata with a restart-stable identity
+  model
+
+Exit criteria:
+
+- stable guest identity without depending on unsupported subnet behavior
+
+## References
+
+Internal:
+
+- [Darwin VZ Backend](../backend/darwin-vz.md)
+
+Apple:
+
+- [apple/containerization](https://github.com/apple/containerization)
+- [Supported capabilities (macOS)](https://developer.apple.com/help/account/reference/supported-capabilities-macos/)
+- [Provisioning with capabilities](https://developer.apple.com/help/account/reference/provisioning-with-managed-capabilities/)
+- [Diagnosing issues with entitlements](https://developer.apple.com/documentation/bundleresources/diagnosing-issues-with-entitlements)
+- [Technical Note TN2415: Entitlements Troubleshooting](https://developer.apple.com/library/archive/technotes/tn2415/_index.html)
+- [VZVmnetNetworkDeviceAttachment](https://developer.apple.com/documentation/virtualization/vzvmnetnetworkdeviceattachment)
+- [vmnet_network_configuration_set_ipv4_subnet](https://developer.apple.com/documentation/vmnet/vmnet_network_configuration_set_ipv4_subnet)
+
+Apple SDK references used in the spike:
+
+- Xcode 26.0 SDK `VZVmnetNetworkDeviceAttachment.h`
+- Xcode 26.0 SDK `vmnet.h`

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -179,22 +179,24 @@ type RunRequest struct {
 }
 
 type FirecrackerConfig struct {
-	BinaryPath           string
-	KernelImagePath      string
-	RootFSPath           string
-	DockerStartupSeconds int64
-	DockerStorageDriver  string
-	DockerIPTables       bool
-	Snapshots            SnapshotConfig
-	PrivilegedMode       string
-	PrivilegedHelperPath string
-	RunDir               string
-	VCPUs                int64
-	MemoryMiB            int64
-	GuestCID             uint32
-	GuestPort            uint32
-	Launch               bool
-	LaunchSeconds        int64
+	BinaryPath            string
+	KernelImagePath       string
+	RootFSPath            string
+	DarwinVZNetworkMode   string
+	DarwinVZNetworkSubnet string
+	DockerStartupSeconds  int64
+	DockerStorageDriver   string
+	DockerIPTables        bool
+	Snapshots             SnapshotConfig
+	PrivilegedMode        string
+	PrivilegedHelperPath  string
+	RunDir                string
+	VCPUs                 int64
+	MemoryMiB             int64
+	GuestCID              uint32
+	GuestPort             uint32
+	Launch                bool
+	LaunchSeconds         int64
 }
 
 type SnapshotConfig struct {

--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -89,6 +89,7 @@ type sandboxInstance struct {
 	ImageRef            string
 	ImageDigest         string
 	LaunchObservability *darwinVZLaunchObservability
+	NetworkMetadata     *darwinVZNetworkMetadata
 	CommandTimeout      int64
 	Helper              *helperSession
 	VMID                string
@@ -103,28 +104,61 @@ const preparedRuntimeRootFSVersion = "v9-darwin-vz"
 const runObservabilityFile = "run-observability.json"
 
 type darwinVZRunObservation struct {
-	RunID          string           `json:"run_id"`
-	Backend        string           `json:"backend"`
-	LaunchedVM     bool             `json:"launched_vm"`
-	ImageRef       string           `json:"image_ref,omitempty"`
-	ImageDigest    string           `json:"image_digest,omitempty"`
-	PlanPath       string           `json:"plan_path,omitempty"`
-	RunDir         string           `json:"run_dir,omitempty"`
-	ExitCode       int              `json:"exit_code,omitempty"`
-	Error          string           `json:"error,omitempty"`
-	GuestError     string           `json:"guest_error,omitempty"`
-	RootFSCopyMS   int64            `json:"rootfs_copy_ms,omitempty"`
-	VMReadyMS      int64            `json:"vm_ready_ms,omitempty"`
-	HelperTimingMS map[string]int64 `json:"helper_timing_ms,omitempty"`
-	TotalMS        int64            `json:"total_ms,omitempty"`
+	RunID             string           `json:"run_id"`
+	Backend           string           `json:"backend"`
+	LaunchedVM        bool             `json:"launched_vm"`
+	ImageRef          string           `json:"image_ref,omitempty"`
+	ImageDigest       string           `json:"image_digest,omitempty"`
+	PlanPath          string           `json:"plan_path,omitempty"`
+	RunDir            string           `json:"run_dir,omitempty"`
+	ExitCode          int              `json:"exit_code,omitempty"`
+	Error             string           `json:"error,omitempty"`
+	GuestError        string           `json:"guest_error,omitempty"`
+	NetworkMode       string           `json:"network_mode,omitempty"`
+	NetworkSubnetCIDR string           `json:"network_subnet_cidr,omitempty"`
+	NetworkGuestIP    string           `json:"network_guest_ip,omitempty"`
+	NetworkGatewayIP  string           `json:"network_gateway_ip,omitempty"`
+	NetworkPrefixLen  int              `json:"network_prefix_len,omitempty"`
+	RootFSCopyMS      int64            `json:"rootfs_copy_ms,omitempty"`
+	VMReadyMS         int64            `json:"vm_ready_ms,omitempty"`
+	HelperTimingMS    map[string]int64 `json:"helper_timing_ms,omitempty"`
+	TotalMS           int64            `json:"total_ms,omitempty"`
 }
 
 type darwinVZLaunchObservability struct {
 	RootFSCopyMS   int64
 	HelperTimingMS map[string]int64
+	Network        *darwinVZNetworkMetadata
 }
 
-var virtualizationEntitlementPattern = regexp.MustCompile(`(?s)<key>\s*com\.apple\.security\.virtualization\s*</key>\s*<true\s*/?>`)
+type darwinVZNetworkMetadata struct {
+	Mode       string
+	SubnetCIDR string
+	GuestIP    string
+	GatewayIP  string
+	PrefixLen  int
+}
+
+type darwinVZConfigFile struct {
+	Backend           string `json:"backend"`
+	KernelImage       string `json:"kernel_image"`
+	RootFS            string `json:"rootfs"`
+	VCPUs             int64  `json:"vcpus"`
+	MemoryMiB         int64  `json:"memory_mib"`
+	GuestPort         uint32 `json:"guest_port"`
+	LaunchSeconds     int64  `json:"launch_secs"`
+	NetworkMode       string `json:"network_mode,omitempty"`
+	NetworkSubnetCIDR string `json:"network_subnet_cidr,omitempty"`
+	NetworkGuestIP    string `json:"network_guest_ip,omitempty"`
+	NetworkGatewayIP  string `json:"network_gateway_ip,omitempty"`
+	NetworkPrefixLen  int    `json:"network_prefix_len,omitempty"`
+	BootArgs          string `json:"boot_args"`
+}
+
+var (
+	virtualizationEntitlementPattern = regexp.MustCompile(`(?s)<key>\s*com\.apple\.security\.virtualization\s*</key>\s*<true\s*/?>`)
+	vmNetworkingEntitlementPattern   = regexp.MustCompile(`(?s)<key>\s*com\.apple\.developer\.networking\.vmnet\s*</key>\s*<true\s*/?>`)
+)
 
 const (
 	guestInitScriptPathSbin    = "/sbin/cleanroom-init"
@@ -146,6 +180,73 @@ mount -t tmpfs tmpfs /tmp 2>/dev/null || true
 export HOME=/root
 export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/.local/bin
 
+cmdline="$(cat /proc/cmdline 2>/dev/null || true)"
+arg_value() {
+  key="$1"
+  for token in $cmdline; do
+    case "$token" in
+      "$key"=*) echo "${token#*=}"; return 0 ;;
+    esac
+  done
+  return 1
+}
+
+prefix_to_mask() {
+  prefix="$1"
+  remaining="$prefix"
+  octet_index=0
+  mask=""
+  while [ "$octet_index" -lt 4 ]; do
+    if [ "$remaining" -ge 8 ]; then
+      octet=255
+      remaining=$((remaining - 8))
+    elif [ "$remaining" -gt 0 ]; then
+      octet=$((256 - (1 << (8 - remaining))))
+      remaining=0
+    else
+      octet=0
+    fi
+    if [ -z "$mask" ]; then
+      mask="$octet"
+    else
+      mask="$mask.$octet"
+    fi
+    octet_index=$((octet_index + 1))
+  done
+  printf '%s\n' "$mask"
+}
+
+configure_vmnet_static_network() {
+  NET_IFACE="$1"
+  VMNET_GUEST_IPV4="$(arg_value cleanroom_vmnet_guest_ipv4 || true)"
+  VMNET_GATEWAY_IPV4="$(arg_value cleanroom_vmnet_gateway_ipv4 || true)"
+  VMNET_PREFIX_LEN="$(arg_value cleanroom_vmnet_prefix_len || true)"
+
+  if [ -z "$VMNET_GUEST_IPV4" ] || [ -z "$VMNET_GATEWAY_IPV4" ] || [ -z "$VMNET_PREFIX_LEN" ]; then
+    return 1
+  fi
+
+  if command -v ip >/dev/null 2>&1; then
+    ip link set "$NET_IFACE" up 2>/dev/null || true
+    ip addr flush dev "$NET_IFACE" scope global 2>/dev/null || true
+    ip addr add "$VMNET_GUEST_IPV4/$VMNET_PREFIX_LEN" dev "$NET_IFACE"
+    ip route replace default via "$VMNET_GATEWAY_IPV4" dev "$NET_IFACE"
+  elif command -v ifconfig >/dev/null 2>&1; then
+    VMNET_NETMASK="$(prefix_to_mask "$VMNET_PREFIX_LEN")"
+    ifconfig "$NET_IFACE" "$VMNET_GUEST_IPV4" netmask "$VMNET_NETMASK" up
+    if command -v route >/dev/null 2>&1; then
+      route del default >/dev/null 2>&1 || true
+      route add default gw "$VMNET_GATEWAY_IPV4" >/dev/null 2>&1 || true
+    fi
+  else
+    return 1
+  fi
+
+  mkdir -p /etc 2>/dev/null || true
+  printf 'nameserver %s\n' "$VMNET_GATEWAY_IPV4" >/etc/resolv.conf 2>/dev/null || true
+  return 0
+}
+
 setup_guest_network() {
   NET_IFACE=""
   for cand in /sys/class/net/*; do
@@ -157,6 +258,10 @@ setup_guest_network() {
     break
   done
   if [ -z "$NET_IFACE" ]; then
+    return 0
+  fi
+
+  if configure_vmnet_static_network "$NET_IFACE"; then
     return 0
   fi
 
@@ -173,17 +278,6 @@ setup_guest_network() {
   fi
 }
 setup_guest_network
-
-cmdline="$(cat /proc/cmdline 2>/dev/null || true)"
-arg_value() {
-  key="$1"
-  for token in $cmdline; do
-    case "$token" in
-      "$key"=*) echo "${token#*=}"; return 0 ;;
-    esac
-  done
-  return 1
-}
 
 GUEST_PORT="$(arg_value cleanroom_guest_port || true)"
 if [ -z "$GUEST_PORT" ]; then
@@ -349,6 +443,7 @@ func (a *Adapter) RunInSandbox(ctx context.Context, req backend.RunRequest, stre
 		ImageDigest: instance.ImageDigest,
 		PlanPath:    instance.ConfigPath,
 	}
+	applyDarwinVZNetworkMetadata(&observation, instance.NetworkMetadata)
 	a.sandboxMu.Lock()
 	if current, ok := a.sandboxes[sandboxID]; ok && current == instance {
 		applyDarwinVZLaunchObservability(&observation, current.LaunchObservability)
@@ -552,6 +647,15 @@ func (a *Adapter) Doctor(_ context.Context, req backend.DoctorRequest) (*backend
 		appendCheck("os", "fail", fmt.Sprintf("darwin required, current OS is %s", runtime.GOOS))
 	}
 	appendCheck("guest_networking", "warn", guestNetworkUnavailableWarning)
+	networkCfg, networkErr := resolveDarwinVZNetwork(req.FirecrackerConfig)
+	if networkErr != nil {
+		appendCheck("network_mode", "fail", networkErr.Error())
+	} else {
+		appendCheck("network_mode", "pass", fmt.Sprintf("darwin-vz network mode: %s", networkCfg.Mode))
+		if networkCfg.SubnetCIDR != "" {
+			appendCheck("network_subnet", "pass", fmt.Sprintf("darwin-vz vmnet subnet: %s", networkCfg.SubnetCIDR))
+		}
+	}
 
 	if configured := strings.TrimSpace(req.KernelImagePath); configured == "" {
 		if spec, ok := bootassets.LookupManagedKernelForHost(a.Name()); ok {
@@ -670,6 +774,36 @@ func (a *Adapter) Doctor(_ context.Context, req backend.DoctorRequest) (*backend
 				"pass",
 				fmt.Sprintf("%s includes com.apple.security.virtualization entitlement", helperPath),
 			)
+		}
+		if networkErr == nil && networkCfg.Mode == darwinVZNetworkModeVMNetShared {
+			hasVMNetEntitlement, vmnetEntitlementErr := helperHasVMNetworkingEntitlement(helperPath)
+			switch {
+			case vmnetEntitlementErr != nil:
+				appendCheck(
+					"vmnet_entitlement",
+					"warn",
+					fmt.Sprintf(
+						"could not verify com.apple.developer.networking.vmnet entitlement on %s: %v",
+						helperPath,
+						vmnetEntitlementErr,
+					),
+				)
+			case !hasVMNetEntitlement:
+				appendCheck(
+					"vmnet_entitlement",
+					"fail",
+					fmt.Sprintf(
+						"%s is missing com.apple.developer.networking.vmnet entitlement; sign the helper with cmd/cleanroom-darwin-vz/entitlements-vmnet.plist and the matching provisioning profile or identifier",
+						helperPath,
+					),
+				)
+			default:
+				appendCheck(
+					"vmnet_entitlement",
+					"pass",
+					fmt.Sprintf("%s includes com.apple.developer.networking.vmnet entitlement", helperPath),
+				)
+			}
 		}
 	}
 	return report, nil
@@ -817,6 +951,11 @@ func (a *Adapter) run(ctx context.Context, req backend.RunRequest, stream backen
 
 	guestInitPath, guestInitNotice := guestInitExecutableForRootFS(vmRootFSPath)
 	logRunNotice(a.Name(), req.RunID, guestInitNotice)
+	networkCfg, err := resolveDarwinVZNetwork(req.FirecrackerConfig)
+	if err != nil {
+		observation.Error = err.Error()
+		return nil, err
+	}
 	bootArgs := fmt.Sprintf(
 		"console=hvc0 root=/dev/vda rw init=%s cleanroom_guest_port=%d %s",
 		guestInitPath,
@@ -826,16 +965,19 @@ func (a *Adapter) run(ctx context.Context, req backend.RunRequest, stream backen
 	consolePath := filepath.Join(runDir, "vm.console.log")
 
 	vmPlanPath := filepath.Join(runDir, "darwin-vz-config.json")
-	if err := writeJSON(vmPlanPath, map[string]any{
-		"backend":      a.Name(),
-		"kernel_image": kernelPath,
-		"rootfs":       vmRootFSPath,
-		"vcpus":        req.VCPUs,
-		"memory_mib":   req.MemoryMiB,
-		"guest_port":   req.GuestPort,
-		"launch_secs":  req.LaunchSeconds,
-		"boot_args":    bootArgs,
-	}); err != nil {
+	if err := writeDarwinVZConfig(
+		vmPlanPath,
+		a.Name(),
+		kernelPath,
+		vmRootFSPath,
+		bootArgs,
+		req.VCPUs,
+		req.MemoryMiB,
+		req.GuestPort,
+		req.LaunchSeconds,
+		networkCfg,
+		nil,
+	); err != nil {
 		observation.Error = err.Error()
 		return nil, err
 	}
@@ -865,6 +1007,8 @@ func (a *Adapter) run(ctx context.Context, req backend.RunRequest, stream backen
 		KernelPath:      kernelPath,
 		RootFSPath:      vmRootFSPath,
 		BootArgs:        bootArgs,
+		NetworkMode:     networkCfg.Mode,
+		VMNetSubnetCIDR: networkCfg.SubnetCIDR,
 		VCPUs:           req.VCPUs,
 		MemoryMiB:       req.MemoryMiB,
 		GuestPort:       req.GuestPort,
@@ -879,6 +1023,24 @@ func (a *Adapter) run(ctx context.Context, req backend.RunRequest, stream backen
 	}
 	observation.LaunchedVM = true
 	applyDarwinVZHelperTimings(&observation, startRes.TimingMS)
+	networkMetadata := helperResponseNetworkMetadata(networkCfg.Mode, startRes)
+	applyDarwinVZNetworkMetadata(&observation, networkMetadata)
+	if err := writeDarwinVZConfig(
+		vmPlanPath,
+		a.Name(),
+		kernelPath,
+		vmRootFSPath,
+		bootArgs,
+		req.VCPUs,
+		req.MemoryMiB,
+		req.GuestPort,
+		req.LaunchSeconds,
+		networkCfg,
+		networkMetadata,
+	); err != nil {
+		observation.Error = err.Error()
+		return nil, err
+	}
 
 	vmID := strings.TrimSpace(startRes.VMID)
 	if vmID == "" {
@@ -1083,6 +1245,10 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 	rootFSCopyMS := time.Since(copyStart).Milliseconds()
 
 	guestInitPath, _ := guestInitExecutableForRootFS(vmRootFSPath)
+	networkCfg, err := resolveDarwinVZNetwork(cfg)
+	if err != nil {
+		return nil, err
+	}
 	bootArgs := fmt.Sprintf(
 		"console=hvc0 root=/dev/vda rw init=%s cleanroom_guest_port=%d %s",
 		guestInitPath,
@@ -1092,16 +1258,19 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 	consolePath := filepath.Join(runDir, "vm.console.log")
 
 	configPath := filepath.Join(runDir, "darwin-vz-config.json")
-	if err := writeJSON(configPath, map[string]any{
-		"backend":      a.Name(),
-		"kernel_image": kernelPath,
-		"rootfs":       vmRootFSPath,
-		"vcpus":        cfg.VCPUs,
-		"memory_mib":   cfg.MemoryMiB,
-		"guest_port":   cfg.GuestPort,
-		"launch_secs":  cfg.LaunchSeconds,
-		"boot_args":    bootArgs,
-	}); err != nil {
+	if err := writeDarwinVZConfig(
+		configPath,
+		a.Name(),
+		kernelPath,
+		vmRootFSPath,
+		bootArgs,
+		cfg.VCPUs,
+		cfg.MemoryMiB,
+		cfg.GuestPort,
+		cfg.LaunchSeconds,
+		networkCfg,
+		nil,
+	); err != nil {
 		return nil, err
 	}
 
@@ -1129,6 +1298,8 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 		KernelPath:      kernelPath,
 		RootFSPath:      vmRootFSPath,
 		BootArgs:        bootArgs,
+		NetworkMode:     networkCfg.Mode,
+		VMNetSubnetCIDR: networkCfg.SubnetCIDR,
 		VCPUs:           cfg.VCPUs,
 		MemoryMiB:       cfg.MemoryMiB,
 		GuestPort:       cfg.GuestPort,
@@ -1139,6 +1310,22 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 	})
 	if err != nil {
 		return nil, fmt.Errorf("start vm via darwin-vz helper: %w", err)
+	}
+	networkMetadata := helperResponseNetworkMetadata(networkCfg.Mode, startRes)
+	if err := writeDarwinVZConfig(
+		configPath,
+		a.Name(),
+		kernelPath,
+		vmRootFSPath,
+		bootArgs,
+		cfg.VCPUs,
+		cfg.MemoryMiB,
+		cfg.GuestPort,
+		cfg.LaunchSeconds,
+		networkCfg,
+		networkMetadata,
+	); err != nil {
+		return nil, err
 	}
 
 	vmID := strings.TrimSpace(startRes.VMID)
@@ -1167,12 +1354,14 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 		LaunchObservability: &darwinVZLaunchObservability{
 			RootFSCopyMS:   rootFSCopyMS,
 			HelperTimingMS: cloneHelperTimingMS(startRes.TimingMS),
+			Network:        networkMetadata,
 		},
-		CommandTimeout: cfg.LaunchSeconds,
-		Helper:         helper,
-		VMID:           vmID,
-		vmRootFSPath:   vmRootFSPath,
-		exitedCh:       make(chan struct{}),
+		NetworkMetadata: networkMetadata,
+		CommandTimeout:  cfg.LaunchSeconds,
+		Helper:          helper,
+		VMID:            vmID,
+		vmRootFSPath:    vmRootFSPath,
+		exitedCh:        make(chan struct{}),
 	}
 	go func() {
 		err, ok := <-helper.done
@@ -1928,6 +2117,19 @@ func helperHasVirtualizationEntitlement(helperPath string) (bool, error) {
 	return hasVirtualizationEntitlement(string(output)), nil
 }
 
+func helperHasVMNetworkingEntitlement(helperPath string) (bool, error) {
+	cmd := exec.Command("codesign", "-d", "--entitlements", ":-", helperPath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		msg := strings.TrimSpace(string(output))
+		if msg != "" {
+			return false, fmt.Errorf("%w: %s", err, msg)
+		}
+		return false, err
+	}
+	return hasVMNetworkingEntitlement(string(output)), nil
+}
+
 func hasVirtualizationEntitlement(raw string) bool {
 	entitlements := strings.TrimSpace(raw)
 	if entitlements == "" {
@@ -1940,6 +2142,20 @@ func hasVirtualizationEntitlement(raw string) bool {
 		entitlements = entitlements[start:]
 	}
 	return virtualizationEntitlementPattern.MatchString(entitlements)
+}
+
+func hasVMNetworkingEntitlement(raw string) bool {
+	entitlements := strings.TrimSpace(raw)
+	if entitlements == "" {
+		return false
+	}
+
+	if start := strings.Index(entitlements, "<?xml"); start >= 0 {
+		entitlements = entitlements[start:]
+	} else if start := strings.Index(entitlements, "<plist"); start >= 0 {
+		entitlements = entitlements[start:]
+	}
+	return vmNetworkingEntitlementPattern.MatchString(entitlements)
 }
 
 func hashFileSHA256(path string) (string, error) {
@@ -2164,6 +2380,41 @@ func writeJSON(path string, v any) error {
 	return os.WriteFile(path, append(b, '\n'), 0o644)
 }
 
+func writeDarwinVZConfig(
+	path, backendName, kernelPath, rootFSPath, bootArgs string,
+	vcpus int64,
+	memoryMiB int64,
+	guestPort uint32,
+	launchSeconds int64,
+	networkCfg darwinVZNetwork,
+	networkMetadata *darwinVZNetworkMetadata,
+) error {
+	if strings.TrimSpace(path) == "" {
+		return nil
+	}
+	cfg := darwinVZConfigFile{
+		Backend:       backendName,
+		KernelImage:   kernelPath,
+		RootFS:        rootFSPath,
+		VCPUs:         vcpus,
+		MemoryMiB:     memoryMiB,
+		GuestPort:     guestPort,
+		LaunchSeconds: launchSeconds,
+		NetworkMode:   networkCfg.Mode,
+		BootArgs:      bootArgs,
+	}
+	if networkMetadata != nil {
+		cfg.NetworkMode = networkMetadata.Mode
+		cfg.NetworkSubnetCIDR = networkMetadata.SubnetCIDR
+		cfg.NetworkGuestIP = networkMetadata.GuestIP
+		cfg.NetworkGatewayIP = networkMetadata.GatewayIP
+		cfg.NetworkPrefixLen = networkMetadata.PrefixLen
+	} else if networkCfg.SubnetCIDR != "" {
+		cfg.NetworkSubnetCIDR = networkCfg.SubnetCIDR
+	}
+	return writeJSON(path, cfg)
+}
+
 func writeDarwinVZRunObservation(runDir string, observation *darwinVZRunObservation, totalMS int64) error {
 	if strings.TrimSpace(runDir) == "" || observation == nil {
 		return nil
@@ -2186,6 +2437,34 @@ func applyDarwinVZHelperTimings(observation *darwinVZRunObservation, timingMS ma
 	}
 }
 
+func helperResponseNetworkMetadata(mode string, res helperControlResponse) *darwinVZNetworkMetadata {
+	normalizedMode := strings.TrimSpace(mode)
+	subnetCIDR := strings.TrimSpace(res.VMNetSubnetCIDR)
+	guestIP := strings.TrimSpace(res.VMNetGuestIPv4)
+	gatewayIP := strings.TrimSpace(res.VMNetGatewayIPv4)
+	if normalizedMode == "" && subnetCIDR == "" && guestIP == "" && gatewayIP == "" && res.VMNetPrefixLen == 0 {
+		return nil
+	}
+	return &darwinVZNetworkMetadata{
+		Mode:       normalizedMode,
+		SubnetCIDR: subnetCIDR,
+		GuestIP:    guestIP,
+		GatewayIP:  gatewayIP,
+		PrefixLen:  res.VMNetPrefixLen,
+	}
+}
+
+func applyDarwinVZNetworkMetadata(observation *darwinVZRunObservation, metadata *darwinVZNetworkMetadata) {
+	if observation == nil || metadata == nil {
+		return
+	}
+	observation.NetworkMode = metadata.Mode
+	observation.NetworkSubnetCIDR = metadata.SubnetCIDR
+	observation.NetworkGuestIP = metadata.GuestIP
+	observation.NetworkGatewayIP = metadata.GatewayIP
+	observation.NetworkPrefixLen = metadata.PrefixLen
+}
+
 func applyDarwinVZLaunchObservability(observation *darwinVZRunObservation, launch *darwinVZLaunchObservability) {
 	if observation == nil || launch == nil {
 		return
@@ -2193,8 +2472,9 @@ func applyDarwinVZLaunchObservability(observation *darwinVZRunObservation, launc
 	if launch.RootFSCopyMS > 0 {
 		observation.RootFSCopyMS = launch.RootFSCopyMS
 	}
+	applyDarwinVZNetworkMetadata(observation, launch.Network)
 	applyDarwinVZHelperTimings(observation, launch.HelperTimingMS)
-	if launch.RootFSCopyMS > 0 || len(launch.HelperTimingMS) > 0 {
+	if launch.RootFSCopyMS > 0 || len(launch.HelperTimingMS) > 0 || launch.Network != nil {
 		observation.LaunchedVM = true
 	}
 }

--- a/internal/backend/darwinvz/backend_entitlement_test.go
+++ b/internal/backend/darwinvz/backend_entitlement_test.go
@@ -37,3 +37,35 @@ func TestHasVirtualizationEntitlementRejectsMissingOrFalseEntitlement(t *testing
 		t.Fatal("expected false virtualization entitlement to be rejected")
 	}
 }
+
+func TestHasVMNetworkingEntitlementHandlesFormattedXML(t *testing.T) {
+	raw := `Executable=/tmp/helper
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.developer.networking.vmnet</key>
+    <true/>
+  </dict>
+</plist>`
+	if !hasVMNetworkingEntitlement(raw) {
+		t.Fatal("expected vm networking entitlement to be detected")
+	}
+}
+
+func TestHasVMNetworkingEntitlementRejectsMissingOrFalseEntitlement(t *testing.T) {
+	missing := `<?xml version="1.0"?><plist version="1.0"><dict><key>com.apple.security.virtualization</key><true/></dict></plist>`
+	if hasVMNetworkingEntitlement(missing) {
+		t.Fatal("expected missing vm networking entitlement to be rejected")
+	}
+
+	falseValue := `<?xml version="1.0"?><plist version="1.0"><dict><key>com.apple.developer.networking.vmnet</key><false/></dict></plist>`
+	if hasVMNetworkingEntitlement(falseValue) {
+		t.Fatal("expected false vm networking entitlement to be rejected")
+	}
+
+	legacyKey := `<?xml version="1.0"?><plist version="1.0"><dict><key>com.apple.vm.networking</key><true/></dict></plist>`
+	if hasVMNetworkingEntitlement(legacyKey) {
+		t.Fatal("expected legacy vm networking entitlement key to be rejected")
+	}
+}

--- a/internal/backend/darwinvz/guest_init_script_test.go
+++ b/internal/backend/darwinvz/guest_init_script_test.go
@@ -25,8 +25,26 @@ func TestGuestInitScriptBootstrapsNetwork(t *testing.T) {
 	if !strings.Contains(guestInitScriptTemplate, "setup_guest_network") {
 		t.Fatal("expected guest network setup function in init script")
 	}
+	if !strings.Contains(guestInitScriptTemplate, "cleanroom_vmnet_guest_ipv4") {
+		t.Fatal("expected vmnet static guest IPv4 boot arg lookup in init script")
+	}
+	if !strings.Contains(guestInitScriptTemplate, "cleanroom_vmnet_gateway_ipv4") {
+		t.Fatal("expected vmnet static gateway boot arg lookup in init script")
+	}
+	if !strings.Contains(guestInitScriptTemplate, "cleanroom_vmnet_prefix_len") {
+		t.Fatal("expected vmnet static prefix length boot arg lookup in init script")
+	}
+	if !strings.Contains(guestInitScriptTemplate, "ip addr add \"$VMNET_GUEST_IPV4/$VMNET_PREFIX_LEN\" dev \"$NET_IFACE\"") {
+		t.Fatal("expected vmnet static address configuration in init script")
+	}
+	if !strings.Contains(guestInitScriptTemplate, "ip route replace default via \"$VMNET_GATEWAY_IPV4\" dev \"$NET_IFACE\"") {
+		t.Fatal("expected vmnet default route configuration in init script")
+	}
+	if !strings.Contains(guestInitScriptTemplate, "printf 'nameserver %s\\n' \"$VMNET_GATEWAY_IPV4\" >/etc/resolv.conf") {
+		t.Fatal("expected vmnet dns configuration in init script")
+	}
 	if !strings.Contains(guestInitScriptTemplate, "udhcpc -q -n -t 3 -T 3 -i") {
-		t.Fatal("expected udhcpc DHCP bootstrap in init script")
+		t.Fatal("expected udhcpc DHCP fallback in init script")
 	}
 }
 

--- a/internal/backend/darwinvz/helper_client.go
+++ b/internal/backend/darwinvz/helper_client.go
@@ -32,6 +32,8 @@ type helperControlRequest struct {
 	KernelPath      string `json:"kernel_path,omitempty"`
 	RootFSPath      string `json:"rootfs_path,omitempty"`
 	BootArgs        string `json:"boot_args,omitempty"`
+	NetworkMode     string `json:"network_mode,omitempty"`
+	VMNetSubnetCIDR string `json:"vmnet_subnet_cidr,omitempty"`
 	VCPUs           int64  `json:"vcpus,omitempty"`
 	MemoryMiB       int64  `json:"memory_mib,omitempty"`
 	GuestPort       uint32 `json:"guest_port,omitempty"`
@@ -43,11 +45,15 @@ type helperControlRequest struct {
 }
 
 type helperControlResponse struct {
-	OK              bool             `json:"ok"`
-	Error           string           `json:"error,omitempty"`
-	VMID            string           `json:"vm_id,omitempty"`
-	ProxySocketPath string           `json:"proxy_socket_path,omitempty"`
-	TimingMS        map[string]int64 `json:"timing_ms,omitempty"`
+	OK               bool             `json:"ok"`
+	Error            string           `json:"error,omitempty"`
+	VMID             string           `json:"vm_id,omitempty"`
+	ProxySocketPath  string           `json:"proxy_socket_path,omitempty"`
+	VMNetSubnetCIDR  string           `json:"vmnet_subnet_cidr,omitempty"`
+	VMNetGuestIPv4   string           `json:"vmnet_guest_ipv4,omitempty"`
+	VMNetGatewayIPv4 string           `json:"vmnet_gateway_ipv4,omitempty"`
+	VMNetPrefixLen   int              `json:"vmnet_prefix_len,omitempty"`
+	TimingMS         map[string]int64 `json:"timing_ms,omitempty"`
 }
 
 type helperSession struct {
@@ -195,6 +201,9 @@ func (s *helperSession) request(ctx context.Context, req helperControlRequest) (
 		}
 		if strings.Contains(msg, "com.apple.security.virtualization") {
 			msg += "; run `mise run install` to install and sign cleanroom-darwin-vz with the virtualization entitlement"
+		}
+		if strings.Contains(msg, "com.apple.developer.networking.vmnet") {
+			msg += "; sign cleanroom-darwin-vz with cmd/cleanroom-darwin-vz/entitlements-vmnet.plist and a provisioning profile or identifier that grants com.apple.developer.networking.vmnet"
 		}
 		return helperControlResponse{}, s.decorateError(fmt.Errorf("helper %s failed: %s", req.Op, msg))
 	}

--- a/internal/backend/darwinvz/helper_path.go
+++ b/internal/backend/darwinvz/helper_path.go
@@ -38,6 +38,10 @@ func resolveHelperBinaryPathWith(
 		if path, err := resolveHelperCandidatePath(sibling, stat); err == nil {
 			return path, nil
 		}
+		siblingAppBundle := sibling + ".app"
+		if path, err := resolveHelperCandidatePath(siblingAppBundle, stat); err == nil {
+			return path, nil
+		}
 	}
 
 	if getwd != nil {
@@ -79,6 +83,9 @@ func resolvePrebuiltBinaryPathFromWorkdir(startDir, binaryName string, stat func
 		if path, err := resolveHelperCandidatePath(candidate, stat); err == nil {
 			return path, nil
 		}
+		if path, err := resolveHelperCandidatePath(candidate+".app", stat); err == nil {
+			return path, nil
+		}
 		parent := filepath.Dir(dir)
 		if parent == dir {
 			break
@@ -102,7 +109,22 @@ func resolveHelperCandidatePath(path string, stat func(string) (os.FileInfo, err
 		return "", err
 	}
 	if info.IsDir() {
+		if strings.EqualFold(filepath.Ext(absPath), ".app") {
+			return resolveHelperBundleExecutablePath(absPath, stat)
+		}
 		return "", fmt.Errorf("%s is a directory", absPath)
 	}
 	return absPath, nil
+}
+
+func resolveHelperBundleExecutablePath(appPath string, stat func(string) (os.FileInfo, error)) (string, error) {
+	bundleExecutablePath := filepath.Join(appPath, "Contents", "MacOS", helperBinaryName)
+	info, err := stat(bundleExecutablePath)
+	if err != nil {
+		return "", err
+	}
+	if info.IsDir() {
+		return "", fmt.Errorf("%s is a directory", bundleExecutablePath)
+	}
+	return bundleExecutablePath, nil
 }

--- a/internal/backend/darwinvz/helper_path_test.go
+++ b/internal/backend/darwinvz/helper_path_test.go
@@ -3,6 +3,7 @@ package darwinvz
 import (
 	"errors"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -59,6 +60,34 @@ func TestResolveHelperBinaryPathUsesSiblingBeforePath(t *testing.T) {
 	}
 }
 
+func TestResolveHelperBinaryPathUsesAppBundleOverride(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	appBundle := tmp + "/cleanroom-darwin-vz.app"
+	executable := appBundle + "/Contents/MacOS/cleanroom-darwin-vz"
+	if err := os.MkdirAll(filepath.Dir(executable), 0o755); err != nil {
+		t.Fatalf("mkdir app bundle: %v", err)
+	}
+	if err := os.WriteFile(executable, []byte("binary"), 0o755); err != nil {
+		t.Fatalf("write app bundle helper: %v", err)
+	}
+
+	got, err := resolveHelperBinaryPathWith(
+		appBundle,
+		func(string) (string, error) { return "", errors.New("not found") },
+		func() (string, error) { return "", errors.New("no executable") },
+		func() (string, error) { return "", errors.New("no working directory") },
+		os.Stat,
+	)
+	if err != nil {
+		t.Fatalf("resolveHelperBinaryPathWith returned error: %v", err)
+	}
+	if got != executable {
+		t.Fatalf("unexpected helper path: got %q want %q", got, executable)
+	}
+}
+
 func TestResolveHelperBinaryPathUsesAncestorDistBeforePATH(t *testing.T) {
 	t.Parallel()
 
@@ -88,6 +117,39 @@ func TestResolveHelperBinaryPathUsesAncestorDistBeforePATH(t *testing.T) {
 	}
 	if got != prebuilt {
 		t.Fatalf("unexpected helper path: got %q want %q", got, prebuilt)
+	}
+}
+
+func TestResolveHelperBinaryPathUsesAncestorDistAppBundleBeforePATH(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	repoRoot := tmp + "/repo"
+	cwd := repoRoot + "/nested/workdir"
+	appBundle := repoRoot + "/dist/cleanroom-darwin-vz.app"
+	executable := appBundle + "/Contents/MacOS/cleanroom-darwin-vz"
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatalf("mkdir workdir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(executable), 0o755); err != nil {
+		t.Fatalf("mkdir app bundle: %v", err)
+	}
+	if err := os.WriteFile(executable, []byte("binary"), 0o755); err != nil {
+		t.Fatalf("write app bundle helper: %v", err)
+	}
+
+	got, err := resolveHelperBinaryPathWith(
+		"",
+		func(string) (string, error) { return "/usr/local/bin/cleanroom-darwin-vz", nil },
+		func() (string, error) { return "", errors.New("no executable") },
+		func() (string, error) { return cwd, nil },
+		os.Stat,
+	)
+	if err != nil {
+		t.Fatalf("resolveHelperBinaryPathWith returned error: %v", err)
+	}
+	if got != executable {
+		t.Fatalf("unexpected helper path: got %q want %q", got, executable)
 	}
 }
 

--- a/internal/backend/darwinvz/network_vmnet.go
+++ b/internal/backend/darwinvz/network_vmnet.go
@@ -1,0 +1,86 @@
+//go:build darwin
+
+package darwinvz
+
+import (
+	"fmt"
+	"net/netip"
+	"strings"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+)
+
+const (
+	darwinVZNetworkModeNAT         = "nat"
+	darwinVZNetworkModeVMNetShared = "vmnet-shared"
+)
+
+type darwinVZNetwork struct {
+	Mode       string
+	SubnetCIDR string
+}
+
+var darwinVZRFC1918Prefixes = []netip.Prefix{
+	netip.MustParsePrefix("10.0.0.0/8"),
+	netip.MustParsePrefix("172.16.0.0/12"),
+	netip.MustParsePrefix("192.168.0.0/16"),
+}
+
+func resolveDarwinVZNetwork(cfg backend.FirecrackerConfig) (darwinVZNetwork, error) {
+	mode := strings.ToLower(strings.TrimSpace(cfg.DarwinVZNetworkMode))
+	if mode == "" {
+		mode = darwinVZNetworkModeVMNetShared
+	}
+
+	subnet := strings.TrimSpace(cfg.DarwinVZNetworkSubnet)
+	switch mode {
+	case darwinVZNetworkModeNAT:
+		if subnet != "" {
+			return darwinVZNetwork{}, fmt.Errorf("darwin-vz network subnet requires %q mode", darwinVZNetworkModeVMNetShared)
+		}
+		return darwinVZNetwork{Mode: darwinVZNetworkModeNAT}, nil
+	case darwinVZNetworkModeVMNetShared:
+		normalizedSubnet, err := normalizeDarwinVZVMNetSubnet(subnet)
+		if err != nil {
+			return darwinVZNetwork{}, err
+		}
+		return darwinVZNetwork{Mode: darwinVZNetworkModeVMNetShared, SubnetCIDR: normalizedSubnet}, nil
+	default:
+		return darwinVZNetwork{}, fmt.Errorf("unsupported darwin-vz network mode %q", cfg.DarwinVZNetworkMode)
+	}
+}
+
+func normalizeDarwinVZVMNetSubnet(value string) (string, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return "", nil
+	}
+
+	prefix, err := netip.ParsePrefix(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("parse darwin-vz vmnet subnet %q: %w", trimmed, err)
+	}
+	prefix = prefix.Masked()
+	if !prefix.Addr().Is4() {
+		return "", fmt.Errorf("darwin-vz vmnet subnet %q must be an IPv4 CIDR", trimmed)
+	}
+	if prefix.Bits() > 30 {
+		return "", fmt.Errorf("darwin-vz vmnet subnet %q must provide at least four addresses", trimmed)
+	}
+	if !isRFC1918Prefix(prefix) {
+		return "", fmt.Errorf("darwin-vz vmnet subnet %q must be within an RFC1918 private range", trimmed)
+	}
+	return prefix.String(), nil
+}
+
+func isRFC1918Prefix(prefix netip.Prefix) bool {
+	for _, privatePrefix := range darwinVZRFC1918Prefixes {
+		if prefix.Bits() < privatePrefix.Bits() {
+			continue
+		}
+		if privatePrefix.Contains(prefix.Addr()) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/backend/darwinvz/network_vmnet_test.go
+++ b/internal/backend/darwinvz/network_vmnet_test.go
@@ -1,0 +1,91 @@
+//go:build darwin
+
+package darwinvz
+
+import (
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+)
+
+func TestResolveDarwinVZNetworkDefaultsToVMNetShared(t *testing.T) {
+	t.Parallel()
+
+	got, err := resolveDarwinVZNetwork(backend.FirecrackerConfig{})
+	if err != nil {
+		t.Fatalf("resolveDarwinVZNetwork returned error: %v", err)
+	}
+	if got.Mode != darwinVZNetworkModeVMNetShared {
+		t.Fatalf("unexpected network mode: got %q want %q", got.Mode, darwinVZNetworkModeVMNetShared)
+	}
+	if got.SubnetCIDR != "" {
+		t.Fatalf("expected default vmnet-shared mode to omit subnet, got %q", got.SubnetCIDR)
+	}
+}
+
+func TestResolveDarwinVZNetworkAcceptsVMNetSharedWithDefaultSubnet(t *testing.T) {
+	t.Parallel()
+
+	got, err := resolveDarwinVZNetwork(backend.FirecrackerConfig{
+		DarwinVZNetworkMode: darwinVZNetworkModeVMNetShared,
+	})
+	if err != nil {
+		t.Fatalf("resolveDarwinVZNetwork returned error: %v", err)
+	}
+	if got.Mode != darwinVZNetworkModeVMNetShared {
+		t.Fatalf("unexpected network mode: got %q want %q", got.Mode, darwinVZNetworkModeVMNetShared)
+	}
+	if got.SubnetCIDR != "" {
+		t.Fatalf("expected default vmnet-shared subnet to stay empty, got %q", got.SubnetCIDR)
+	}
+}
+
+func TestResolveDarwinVZNetworkAcceptsRFC1918CustomSubnet(t *testing.T) {
+	t.Parallel()
+
+	got, err := resolveDarwinVZNetwork(backend.FirecrackerConfig{
+		DarwinVZNetworkMode:   darwinVZNetworkModeVMNetShared,
+		DarwinVZNetworkSubnet: "10.233.0.0/16",
+	})
+	if err != nil {
+		t.Fatalf("resolveDarwinVZNetwork returned error: %v", err)
+	}
+	if got.SubnetCIDR != "10.233.0.0/16" {
+		t.Fatalf("unexpected subnet: got %q want %q", got.SubnetCIDR, "10.233.0.0/16")
+	}
+}
+
+func TestResolveDarwinVZNetworkRejectsNonRFC1918Subnet(t *testing.T) {
+	t.Parallel()
+
+	_, err := resolveDarwinVZNetwork(backend.FirecrackerConfig{
+		DarwinVZNetworkMode:   darwinVZNetworkModeVMNetShared,
+		DarwinVZNetworkSubnet: "198.19.0.0/16",
+	})
+	if err == nil {
+		t.Fatal("expected non-RFC1918 subnet to fail")
+	}
+}
+
+func TestResolveDarwinVZNetworkRejectsSubnetInNATMode(t *testing.T) {
+	t.Parallel()
+
+	_, err := resolveDarwinVZNetwork(backend.FirecrackerConfig{
+		DarwinVZNetworkMode:   darwinVZNetworkModeNAT,
+		DarwinVZNetworkSubnet: "10.233.0.0/16",
+	})
+	if err == nil {
+		t.Fatal("expected nat mode with subnet to fail")
+	}
+}
+
+func TestResolveDarwinVZNetworkRejectsUnknownMode(t *testing.T) {
+	t.Parallel()
+
+	_, err := resolveDarwinVZNetwork(backend.FirecrackerConfig{
+		DarwinVZNetworkMode: "bridged",
+	})
+	if err == nil {
+		t.Fatal("expected unknown network mode to fail")
+	}
+}

--- a/internal/backend/darwinvz/observability_test.go
+++ b/internal/backend/darwinvz/observability_test.go
@@ -82,6 +82,51 @@ func TestWriteDarwinVZRunObservationIncludesHelperTimings(t *testing.T) {
 	}
 }
 
+func TestWriteDarwinVZRunObservationIncludesNetworkMetadata(t *testing.T) {
+	t.Parallel()
+
+	runDir := t.TempDir()
+	obs := darwinVZRunObservation{
+		RunID:             "run-123",
+		Backend:           "darwin-vz",
+		LaunchedVM:        true,
+		RunDir:            runDir,
+		NetworkMode:       darwinVZNetworkModeVMNetShared,
+		NetworkSubnetCIDR: "10.233.0.0/16",
+		NetworkGuestIP:    "10.233.0.2",
+		NetworkGatewayIP:  "10.233.0.1",
+		NetworkPrefixLen:  16,
+	}
+
+	if err := writeDarwinVZRunObservation(runDir, &obs, 1500); err != nil {
+		t.Fatalf("writeDarwinVZRunObservation returned error: %v", err)
+	}
+
+	b, err := os.ReadFile(filepath.Join(runDir, runObservabilityFile))
+	if err != nil {
+		t.Fatalf("read observability file: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(b, &payload); err != nil {
+		t.Fatalf("parse observability file: %v", err)
+	}
+	if got, want := payload["network_mode"], darwinVZNetworkModeVMNetShared; got != want {
+		t.Fatalf("unexpected network_mode: got %v want %v", got, want)
+	}
+	if got, want := payload["network_subnet_cidr"], "10.233.0.0/16"; got != want {
+		t.Fatalf("unexpected network_subnet_cidr: got %v want %v", got, want)
+	}
+	if got, want := payload["network_guest_ip"], "10.233.0.2"; got != want {
+		t.Fatalf("unexpected network_guest_ip: got %v want %v", got, want)
+	}
+	if got, want := payload["network_gateway_ip"], "10.233.0.1"; got != want {
+		t.Fatalf("unexpected network_gateway_ip: got %v want %v", got, want)
+	}
+	if got, want := payload["network_prefix_len"], float64(16); got != want {
+		t.Fatalf("unexpected network_prefix_len: got %v want %v", got, want)
+	}
+}
+
 func TestRunInSandboxWritesObservabilityWithPendingLaunchTimings(t *testing.T) {
 	t.Parallel()
 
@@ -109,6 +154,13 @@ func TestRunInSandboxWritesObservabilityWithPendingLaunchTimings(t *testing.T) {
 					RootFSCopyMS: 27,
 					HelperTimingMS: map[string]int64{
 						"vm_ready": 321,
+					},
+					Network: &darwinVZNetworkMetadata{
+						Mode:       darwinVZNetworkModeVMNetShared,
+						SubnetCIDR: "10.233.0.0/16",
+						GuestIP:    "10.233.0.2",
+						GatewayIP:  "10.233.0.1",
+						PrefixLen:  16,
 					},
 				},
 			},
@@ -141,6 +193,9 @@ func TestRunInSandboxWritesObservabilityWithPendingLaunchTimings(t *testing.T) {
 	}
 	if got, want := payload["rootfs_copy_ms"], float64(27); got != want {
 		t.Fatalf("unexpected rootfs_copy_ms: got %v want %v", got, want)
+	}
+	if got, want := payload["network_guest_ip"], "10.233.0.2"; got != want {
+		t.Fatalf("unexpected network_guest_ip: got %v want %v", got, want)
 	}
 }
 

--- a/internal/backend/darwinvz/vmnet_e2e_test.go
+++ b/internal/backend/darwinvz/vmnet_e2e_test.go
@@ -1,0 +1,403 @@
+//go:build darwin
+
+package darwinvz
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/netip"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/hosttools"
+	"github.com/buildkite/cleanroom/internal/policy"
+)
+
+const (
+	darwinVZVMNetE2EEnvEnabled = "CLEANROOM_DARWIN_VZ_VMNET_E2E"
+)
+
+func TestVMNetSharedE2E(t *testing.T) {
+	if strings.TrimSpace(os.Getenv(darwinVZVMNetE2EEnvEnabled)) == "" {
+		t.Skipf("set %s=1 to run darwin-vz vmnet e2e", darwinVZVMNetE2EEnvEnabled)
+	}
+	if testing.Short() {
+		t.Skip("skipping darwin-vz vmnet e2e in short mode")
+	}
+
+	helperPath, err := resolveHelperBinaryPath()
+	if err != nil {
+		t.Fatalf("resolve helper binary: %v", err)
+	}
+	hasVirtualizationEntitlement, err := helperHasVirtualizationEntitlement(helperPath)
+	if err != nil {
+		t.Fatalf("verify helper virtualization entitlement: %v", err)
+	}
+	if !hasVirtualizationEntitlement {
+		t.Fatalf("helper %q is missing com.apple.security.virtualization entitlement", helperPath)
+	}
+	hasVMNetEntitlement, err := helperHasVMNetworkingEntitlement(helperPath)
+	if err != nil {
+		t.Fatalf("verify helper vmnet entitlement: %v", err)
+	}
+	if !hasVMNetEntitlement {
+		t.Fatalf("helper %q is missing com.apple.developer.networking.vmnet entitlement", helperPath)
+	}
+	if _, _, err := New().getGuestAgentBinary(); err != nil {
+		t.Fatalf("resolve guest agent binary: %v", err)
+	}
+
+	rootFSOverride := strings.TrimSpace(os.Getenv(darwinVZE2EEnvRootFS))
+	if rootFSOverride == "" {
+		if _, err := hosttools.ResolveE2FSProgsBinary("mkfs.ext4"); err != nil {
+			t.Fatalf("resolve mkfs.ext4: %v", err)
+		}
+		if _, err := hosttools.ResolveE2FSProgsBinary("debugfs"); err != nil {
+			t.Fatalf("resolve debugfs: %v", err)
+		}
+	}
+
+	imageRef := strings.TrimSpace(os.Getenv(darwinVZE2EEnvImageRef))
+	if imageRef == "" {
+		imageRef = defaultDarwinVZE2EImageRef()
+	}
+
+	baseCfg := backend.FirecrackerConfig{
+		KernelImagePath:     strings.TrimSpace(os.Getenv(darwinVZE2EEnvKernelImage)),
+		RootFSPath:          rootFSOverride,
+		DarwinVZNetworkMode: darwinVZNetworkModeVMNetShared,
+		VCPUs:               1,
+		MemoryMiB:           1024,
+		LaunchSeconds:       90,
+	}
+	compiled := &policy.CompiledPolicy{
+		Version:        1,
+		ImageRef:       imageRef,
+		NetworkDefault: "deny",
+	}
+
+	t.Run("default-shared-network-egress", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+
+		adapter := New()
+		sandboxID := fmt.Sprintf("cr-vmnet-default-%d", time.Now().UnixNano())
+		if err := adapter.ProvisionSandbox(ctx, backend.ProvisionRequest{
+			SandboxID:         sandboxID,
+			Policy:            compiled,
+			FirecrackerConfig: baseCfg,
+		}); err != nil {
+			t.Fatalf("ProvisionSandbox returned error: %v", err)
+		}
+		t.Cleanup(func() {
+			_ = adapter.TerminateSandbox(context.Background(), sandboxID)
+		})
+
+		run := sandboxRunner(ctx, adapter, sandboxID, compiled, baseCfg.LaunchSeconds)
+		guestIP := waitForGuestIPv4(t, run)
+		if _, err := netip.ParseAddr(guestIP); err != nil {
+			t.Fatalf("parse guest IPv4 %q: %v", guestIP, err)
+		}
+		waitForGuestEgress(t, run)
+	})
+
+	t.Run("custom-shared-subnet-egress", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+
+		adapter := New()
+		sandboxID := fmt.Sprintf("cr-vmnet-custom-%d", time.Now().UnixNano())
+		cfg := baseCfg
+		cfg.DarwinVZNetworkSubnet = "10.233.0.0/16"
+		if err := adapter.ProvisionSandbox(ctx, backend.ProvisionRequest{
+			SandboxID:         sandboxID,
+			Policy:            compiled,
+			FirecrackerConfig: cfg,
+		}); err != nil {
+			t.Fatalf("ProvisionSandbox returned error: %v", err)
+		}
+		t.Cleanup(func() {
+			_ = adapter.TerminateSandbox(context.Background(), sandboxID)
+		})
+
+		run := sandboxRunner(ctx, adapter, sandboxID, compiled, cfg.LaunchSeconds)
+		guestIP := waitForGuestIPv4(t, run)
+		if got, want := guestIP, "10.233.0.2"; got != want {
+			t.Fatalf("unexpected guest IPv4: got %q want %q", got, want)
+		}
+		waitForGuestEgress(t, run)
+	})
+
+	t.Run("custom-shared-subnet-host-to-guest", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+
+		adapter := New()
+		rootFSPath := prepareVMNetHostIngressRootFS(t, ctx, adapter, rootFSOverride, imageRef)
+		sandboxID := fmt.Sprintf("cr-vmnet-ingress-%d", time.Now().UnixNano())
+		cfg := baseCfg
+		cfg.RootFSPath = rootFSPath
+		cfg.DarwinVZNetworkSubnet = "10.233.0.0/16"
+		if err := adapter.ProvisionSandbox(ctx, backend.ProvisionRequest{
+			SandboxID:         sandboxID,
+			Policy:            compiled,
+			FirecrackerConfig: cfg,
+		}); err != nil {
+			t.Fatalf("ProvisionSandbox returned error: %v", err)
+		}
+		t.Cleanup(func() {
+			_ = adapter.TerminateSandbox(context.Background(), sandboxID)
+		})
+
+		run := sandboxRunner(ctx, adapter, sandboxID, compiled, cfg.LaunchSeconds)
+		guestIP := waitForGuestIPv4(t, run)
+		if got, want := guestIP, "10.233.0.2"; got != want {
+			t.Fatalf("unexpected guest IPv4: got %q want %q", got, want)
+		}
+
+		errCh := make(chan error, 1)
+		go func() {
+			res, err := run("guest-host-ingress-server", "/usr/local/bin/cleanroom-vmnet-echo -listen :18080")
+			if err != nil {
+				errCh <- err
+				return
+			}
+			if res.ExitCode != 0 {
+				errCh <- fmt.Errorf("guest vmnet echo exited %d: stderr=%q stdout=%q", res.ExitCode, res.Stderr, res.Stdout)
+				return
+			}
+			errCh <- nil
+		}()
+
+		waitForHostToGuestEcho(t, guestIP, 18080, "ok\n")
+		select {
+		case err := <-errCh:
+			if err != nil {
+				t.Fatalf("guest vmnet echo failed: %v", err)
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatal("timed out waiting for guest vmnet echo command to exit")
+		}
+	})
+}
+
+func sandboxRunner(
+	ctx context.Context,
+	adapter *Adapter,
+	sandboxID string,
+	compiled *policy.CompiledPolicy,
+	launchSeconds int64,
+) func(runID, shellCommand string) (*backend.RunResult, error) {
+	runCounter := 0
+	return func(runID, shellCommand string) (*backend.RunResult, error) {
+		runCounter++
+		if strings.TrimSpace(runID) == "" {
+			runID = fmt.Sprintf("run-%d", runCounter)
+		}
+		return adapter.RunInSandbox(ctx, backend.RunRequest{
+			SandboxID: sandboxID,
+			RunID:     runID,
+			Command:   []string{"sh", "-lc", shellCommand},
+			Policy:    compiled,
+			FirecrackerConfig: backend.FirecrackerConfig{
+				LaunchSeconds: launchSeconds,
+			},
+		}, backend.OutputStream{})
+	}
+}
+
+func waitForGuestIPv4(t *testing.T, run func(string, string) (*backend.RunResult, error)) string {
+	t.Helper()
+
+	deadline := time.Now().Add(45 * time.Second)
+	var lastStdout string
+	var lastErr string
+	for attempt := 0; time.Now().Before(deadline); attempt++ {
+		res, err := run(fmt.Sprintf("guest-ip-%d", attempt), `set -eu
+iface=""
+for cand in /sys/class/net/*; do
+  name="$(basename "$cand")"
+  if [ "$name" = "lo" ]; then
+    continue
+  fi
+  iface="$name"
+  break
+done
+[ -n "$iface" ]
+ip_addr=""
+if command -v ip >/dev/null 2>&1; then
+  ip_addr="$(ip -4 -o addr show dev "$iface" | awk 'NR == 1 { print $4 }' | cut -d/ -f1)"
+elif command -v ifconfig >/dev/null 2>&1; then
+  ip_addr="$(ifconfig "$iface" | awk '/inet / { print $2; exit }')"
+fi
+[ -n "$ip_addr" ]
+printf '%s\n' "$ip_addr"`)
+		if err != nil {
+			lastErr = err.Error()
+			time.Sleep(1 * time.Second)
+			continue
+		}
+		lastStdout = strings.TrimSpace(res.Stdout)
+		lastErr = strings.TrimSpace(res.Stderr)
+		if res.ExitCode == 0 && lastStdout != "" {
+			return lastStdout
+		}
+		time.Sleep(1 * time.Second)
+	}
+	t.Fatalf("timed out waiting for guest IPv4 (stdout=%q stderr=%q)", lastStdout, lastErr)
+	return ""
+}
+
+func waitForGuestEgress(t *testing.T, run func(string, string) (*backend.RunResult, error)) {
+	t.Helper()
+
+	deadline := time.Now().Add(45 * time.Second)
+	var lastErr string
+	for attempt := 0; time.Now().Before(deadline); attempt++ {
+		res, err := run(fmt.Sprintf("guest-egress-%d", attempt), `set -eu
+if command -v wget >/dev/null 2>&1; then
+  wget -q -T 20 -O /dev/null http://example.com
+elif command -v curl >/dev/null 2>&1; then
+  curl -fsS --max-time 20 http://example.com >/dev/null
+else
+  nc -w 10 example.com 80 </dev/null >/dev/null 2>&1
+fi
+printf 'ok\n'`)
+		if err != nil {
+			lastErr = err.Error()
+			time.Sleep(1 * time.Second)
+			continue
+		}
+		if res.ExitCode == 0 && strings.TrimSpace(res.Stdout) == "ok" {
+			return
+		}
+		lastErr = strings.TrimSpace(res.Stderr)
+		time.Sleep(1 * time.Second)
+	}
+	t.Fatalf("timed out waiting for guest egress (stderr=%q)", lastErr)
+}
+
+var (
+	vmnetHostIngressBinaryOnce sync.Once
+	vmnetHostIngressBinaryPath string
+	vmnetHostIngressBinaryErr  error
+)
+
+func prepareVMNetHostIngressRootFS(t *testing.T, ctx context.Context, adapter *Adapter, rootFSOverride, imageRef string) string {
+	t.Helper()
+
+	if _, err := hosttools.ResolveE2FSProgsBinary("debugfs"); err != nil {
+		t.Fatalf("resolve debugfs for vmnet host-ingress rootfs injection: %v", err)
+	}
+
+	sourceRootFS := strings.TrimSpace(rootFSOverride)
+	if sourceRootFS == "" {
+		prepared, err := adapter.ensurePreparedRuntimeRootFSFromImage(ctx, imageRef)
+		if err != nil {
+			t.Fatalf("prepare runtime rootfs for vmnet host-ingress test: %v", err)
+		}
+		sourceRootFS = prepared.Path
+	}
+
+	rootFSPath := filepath.Join(t.TempDir(), "vmnet-host-ingress.ext4")
+	if err := copyFile(sourceRootFS, rootFSPath); err != nil {
+		t.Fatalf("copy rootfs for vmnet host-ingress test: %v", err)
+	}
+
+	echoBinaryPath := buildGuestVMNetEchoBinary(t)
+	if err := injectFileIntoExt4(rootFSPath, echoBinaryPath, "/usr/local/bin/cleanroom-vmnet-echo", 0o755); err != nil {
+		t.Fatalf("inject guest vmnet echo binary into rootfs image: %v", err)
+	}
+	return rootFSPath
+}
+
+func buildGuestVMNetEchoBinary(t *testing.T) string {
+	t.Helper()
+
+	vmnetHostIngressBinaryOnce.Do(func() {
+		tmpDir, err := os.MkdirTemp("", "cleanroom-vmnet-echo-*")
+		if err != nil {
+			vmnetHostIngressBinaryErr = fmt.Errorf("create vmnet echo temp dir: %w", err)
+			return
+		}
+		vmnetHostIngressBinaryPath = filepath.Join(tmpDir, "cleanroom-vmnet-echo-linux-"+runtime.GOARCH)
+		cmd := exec.Command("go", "build", "-trimpath", "-o", vmnetHostIngressBinaryPath, "./cmd/cleanroom-vmnet-echo")
+		cmd.Dir = repoRoot(t)
+		cmd.Env = append(os.Environ(),
+			"GOOS=linux",
+			"GOARCH="+runtime.GOARCH,
+			"CGO_ENABLED=0",
+		)
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			vmnetHostIngressBinaryErr = fmt.Errorf("build guest vmnet echo binary: %w: %s", err, strings.TrimSpace(string(output)))
+			return
+		}
+	})
+	if vmnetHostIngressBinaryErr != nil {
+		t.Fatal(vmnetHostIngressBinaryErr)
+	}
+	return vmnetHostIngressBinaryPath
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not locate repository root from go.mod")
+		}
+		dir = parent
+	}
+}
+
+func waitForHostToGuestEcho(t *testing.T, guestIP string, port int, want string) {
+	t.Helper()
+
+	deadline := time.Now().Add(20 * time.Second)
+	var lastErr error
+	for attempt := 0; time.Now().Before(deadline); attempt++ {
+		conn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", guestIP, port), 3*time.Second)
+		if err != nil {
+			lastErr = err
+			time.Sleep(500 * time.Millisecond)
+			continue
+		}
+		if err := conn.SetDeadline(time.Now().Add(3 * time.Second)); err != nil {
+			conn.Close()
+			lastErr = err
+			time.Sleep(500 * time.Millisecond)
+			continue
+		}
+		body, readErr := io.ReadAll(conn)
+		conn.Close()
+		if readErr != nil {
+			lastErr = readErr
+			time.Sleep(500 * time.Millisecond)
+			continue
+		}
+		if string(body) == want {
+			return
+		}
+		lastErr = fmt.Errorf("unexpected response body %q", string(body))
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for host-to-guest echo: %v", lastErr)
+}

--- a/internal/runtimeconfig/config.go
+++ b/internal/runtimeconfig/config.go
@@ -39,14 +39,20 @@ type FirecrackerConfig struct {
 }
 
 type DarwinVZConfig struct {
-	KernelImage   string         `yaml:"kernel_image"`
-	RootFS        string         `yaml:"rootfs"`
-	Services      ServicesConfig `yaml:"services"`
-	Snapshots     SnapshotConfig `yaml:"snapshots"`
-	VCPUs         int64          `yaml:"vcpus"`
-	MemoryMiB     int64          `yaml:"memory_mib"`
-	GuestPort     uint32         `yaml:"guest_port"`
-	LaunchSeconds int64          `yaml:"launch_seconds"` // VM boot/guest-agent readiness timeout
+	KernelImage   string                `yaml:"kernel_image"`
+	RootFS        string                `yaml:"rootfs"`
+	Network       DarwinVZNetworkConfig `yaml:"network,omitempty"`
+	Services      ServicesConfig        `yaml:"services"`
+	Snapshots     SnapshotConfig        `yaml:"snapshots"`
+	VCPUs         int64                 `yaml:"vcpus"`
+	MemoryMiB     int64                 `yaml:"memory_mib"`
+	GuestPort     uint32                `yaml:"guest_port"`
+	LaunchSeconds int64                 `yaml:"launch_seconds"` // VM boot/guest-agent readiness timeout
+}
+
+type DarwinVZNetworkConfig struct {
+	Mode   string `yaml:"mode,omitempty"`
+	Subnet string `yaml:"subnet,omitempty"`
 }
 
 type SnapshotConfig struct {
@@ -100,6 +106,8 @@ func MergeBackendConfig(cfg Config, backendName string, launchSeconds int64) bac
 	if backendName == "darwin-vz" {
 		out.KernelImagePath = cfg.Backends.DarwinVZ.KernelImage
 		out.RootFSPath = cfg.Backends.DarwinVZ.RootFS
+		out.DarwinVZNetworkMode = cfg.Backends.DarwinVZ.Network.Mode
+		out.DarwinVZNetworkSubnet = cfg.Backends.DarwinVZ.Network.Subnet
 		out.DockerStartupSeconds = cfg.Backends.DarwinVZ.Services.Docker.StartupTimeoutSeconds
 		out.DockerStorageDriver = cfg.Backends.DarwinVZ.Services.Docker.StorageDriver
 		out.DockerIPTables = cfg.Backends.DarwinVZ.Services.Docker.IPTables
@@ -223,6 +231,7 @@ func Load() (Config, string, error) {
 func darwinVZConfigIsZero(cfg DarwinVZConfig) bool {
 	return strings.TrimSpace(cfg.KernelImage) == "" &&
 		strings.TrimSpace(cfg.RootFS) == "" &&
+		darwinVZNetworkConfigIsZero(cfg.Network) &&
 		cfg.Services.Docker.StartupTimeoutSeconds == 0 &&
 		strings.TrimSpace(cfg.Services.Docker.StorageDriver) == "" &&
 		!cfg.Services.Docker.IPTables &&
@@ -231,6 +240,11 @@ func darwinVZConfigIsZero(cfg DarwinVZConfig) bool {
 		cfg.MemoryMiB == 0 &&
 		cfg.GuestPort == 0 &&
 		cfg.LaunchSeconds == 0
+}
+
+func darwinVZNetworkConfigIsZero(cfg DarwinVZNetworkConfig) bool {
+	return strings.TrimSpace(cfg.Mode) == "" &&
+		strings.TrimSpace(cfg.Subnet) == ""
 }
 
 func snapshotConfigIsZero(cfg SnapshotConfig) bool {

--- a/internal/runtimeconfig/config_test.go
+++ b/internal/runtimeconfig/config_test.go
@@ -23,6 +23,9 @@ backends:
   darwin-vz:
     kernel_image: /tmp/kernel
     rootfs: /tmp/rootfs
+    network:
+      mode: vmnet-shared
+      subnet: 10.233.0.0/16
     services:
       docker:
         startup_timeout_seconds: 25
@@ -43,6 +46,12 @@ backends:
 	}
 	if got, want := cfg.Backends.DarwinVZ.KernelImage, "/tmp/kernel"; got != want {
 		t.Fatalf("unexpected darwin-vz kernel: got %q want %q", got, want)
+	}
+	if got, want := cfg.Backends.DarwinVZ.Network.Mode, "vmnet-shared"; got != want {
+		t.Fatalf("unexpected darwin-vz network mode: got %q want %q", got, want)
+	}
+	if got, want := cfg.Backends.DarwinVZ.Network.Subnet, "10.233.0.0/16"; got != want {
+		t.Fatalf("unexpected darwin-vz network subnet: got %q want %q", got, want)
 	}
 	if got, want := cfg.Backends.DarwinVZ.Services.Docker.StartupTimeoutSeconds, int64(25); got != want {
 		t.Fatalf("unexpected docker startup timeout: got %d want %d", got, want)
@@ -304,6 +313,7 @@ func TestMergeBackendConfig(t *testing.T) {
 			DarwinVZ: DarwinVZConfig{
 				KernelImage:   "/darwin/kernel",
 				RootFS:        "/darwin/rootfs.ext4",
+				Network:       DarwinVZNetworkConfig{Mode: "vmnet-shared", Subnet: "10.233.0.0/16"},
 				Services:      ServicesConfig{Docker: DockerServiceConfig{StartupTimeoutSeconds: 20, StorageDriver: "vzfs", IPTables: false}},
 				Snapshots:     SnapshotConfig{Enabled: false, Driver: "apfs", BaseDir: "/darwin/snapshots", QuiesceTimeoutSeconds: 22},
 				VCPUs:         4,
@@ -334,6 +344,12 @@ func TestMergeBackendConfig(t *testing.T) {
 	}
 	if got, want := darwinCfg.RootFSPath, "/darwin/rootfs.ext4"; got != want {
 		t.Fatalf("unexpected darwin-vz rootfs: got %q want %q", got, want)
+	}
+	if got, want := darwinCfg.DarwinVZNetworkMode, "vmnet-shared"; got != want {
+		t.Fatalf("unexpected darwin-vz network mode: got %q want %q", got, want)
+	}
+	if got, want := darwinCfg.DarwinVZNetworkSubnet, "10.233.0.0/16"; got != want {
+		t.Fatalf("unexpected darwin-vz network subnet: got %q want %q", got, want)
 	}
 	if got, want := darwinCfg.DockerStorageDriver, "vzfs"; got != want {
 		t.Fatalf("unexpected darwin-vz docker storage driver: got %q want %q", got, want)

--- a/scripts/build-darwin-vz-helper.sh
+++ b/scripts/build-darwin-vz-helper.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+OUTPUT_PATH="${1:-${REPO_ROOT}/dist/cleanroom-darwin-vz}"
+SWIFT_TARGET="${CLEANROOM_DARWIN_VZ_HELPER_SWIFT_TARGET:-}"
+ENTITLEMENTS_PATH="${CLEANROOM_DARWIN_VZ_HELPER_ENTITLEMENTS:-${REPO_ROOT}/cmd/cleanroom-darwin-vz/entitlements.plist}"
+SIGN_IDENTITY="${CLEANROOM_DARWIN_VZ_HELPER_SIGN_IDENTITY:--}"
+SIGN_IDENTIFIER="${CLEANROOM_DARWIN_VZ_HELPER_SIGN_IDENTIFIER:-}"
+PROVISION_PROFILE="${CLEANROOM_DARWIN_VZ_HELPER_PROVISION_PROFILE:-}"
+BUNDLE_MODE="${CLEANROOM_DARWIN_VZ_HELPER_BUNDLE:-}"
+
+[[ -f "${REPO_ROOT}/cmd/cleanroom-darwin-vz/main.swift" ]] || {
+  echo "missing helper source: ${REPO_ROOT}/cmd/cleanroom-darwin-vz/main.swift" >&2
+  exit 1
+}
+[[ -f "${ENTITLEMENTS_PATH}" ]] || {
+  echo "missing entitlements plist: ${ENTITLEMENTS_PATH}" >&2
+  exit 1
+}
+if [[ -n "${PROVISION_PROFILE}" && ! -f "${PROVISION_PROFILE}" ]]; then
+  echo "missing provisioning profile: ${PROVISION_PROFILE}" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "${OUTPUT_PATH}")"
+
+swiftc_args=(
+  -O
+  -framework Virtualization
+  -framework vmnet
+)
+if [[ -n "${SWIFT_TARGET}" ]]; then
+  swiftc_args+=(-target "${SWIFT_TARGET}")
+fi
+if [[ -n "${PROVISION_PROFILE}" ]]; then
+  BUNDLE_MODE="1"
+fi
+
+if [[ -n "${BUNDLE_MODE}" ]]; then
+  if [[ -n "${PROVISION_PROFILE}" && -z "${SIGN_IDENTIFIER}" ]]; then
+    echo "CLEANROOM_DARWIN_VZ_HELPER_SIGN_IDENTIFIER is required when embedding a provisioning profile" >&2
+    exit 1
+  fi
+
+  if [[ "${OUTPUT_PATH}" == *.app ]]; then
+    APP_PATH="${OUTPUT_PATH}"
+  else
+    APP_PATH="${OUTPUT_PATH}.app"
+    rm -f "${OUTPUT_PATH}"
+  fi
+  EXECUTABLE_PATH="${APP_PATH}/Contents/MacOS/cleanroom-darwin-vz"
+  INFO_PLIST_PATH="${APP_PATH}/Contents/Info.plist"
+  PROFILE_DEST="${APP_PATH}/Contents/embedded.provisionprofile"
+  BUNDLE_IDENTIFIER="${SIGN_IDENTIFIER:-com.buildkite.cleanroom.darwin-vz}"
+
+  mkdir -p "$(dirname "${EXECUTABLE_PATH}")"
+  cat > "${INFO_PLIST_PATH}" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleExecutable</key>
+  <string>cleanroom-darwin-vz</string>
+  <key>CFBundleIdentifier</key>
+  <string>${BUNDLE_IDENTIFIER}</string>
+  <key>CFBundleName</key>
+  <string>cleanroom-darwin-vz</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>0.0.0</string>
+  <key>CFBundleVersion</key>
+  <string>1</string>
+</dict>
+</plist>
+EOF
+  if [[ -n "${PROVISION_PROFILE}" ]]; then
+    install -m 0644 "${PROVISION_PROFILE}" "${PROFILE_DEST}"
+  else
+    rm -f "${PROFILE_DEST}"
+  fi
+  swiftc_args+=(
+    "${REPO_ROOT}/cmd/cleanroom-darwin-vz/main.swift"
+    -o "${EXECUTABLE_PATH}"
+  )
+  xcrun swiftc "${swiftc_args[@]}"
+
+  codesign_args=(
+    --force
+    --sign "${SIGN_IDENTITY}"
+    --entitlements "${ENTITLEMENTS_PATH}"
+  )
+  if [[ -n "${SIGN_IDENTIFIER}" ]]; then
+    codesign_args+=(-i "${SIGN_IDENTIFIER}")
+  fi
+  codesign_args+=("${APP_PATH}")
+  codesign "${codesign_args[@]}"
+else
+  APP_PATH="${OUTPUT_PATH}.app"
+  EXECUTABLE_PATH="${OUTPUT_PATH}"
+  PROFILE_DEST="${OUTPUT_PATH}.provisionprofile"
+  rm -rf "${APP_PATH}"
+  swiftc_args+=(
+    "${REPO_ROOT}/cmd/cleanroom-darwin-vz/main.swift"
+    -o "${EXECUTABLE_PATH}"
+  )
+  xcrun swiftc "${swiftc_args[@]}"
+
+  codesign_args=(
+    --force
+    --sign "${SIGN_IDENTITY}"
+    --entitlements "${ENTITLEMENTS_PATH}"
+  )
+  if [[ -n "${SIGN_IDENTIFIER}" ]]; then
+    codesign_args+=(-i "${SIGN_IDENTIFIER}")
+  fi
+  codesign_args+=("${EXECUTABLE_PATH}")
+  codesign "${codesign_args[@]}"
+
+  if [[ -n "${PROVISION_PROFILE}" ]]; then
+    install -m 0644 "${PROVISION_PROFILE}" "${PROFILE_DEST}"
+  else
+    rm -f "${PROFILE_DEST}"
+  fi
+fi

--- a/scripts/build-darwin-vz-helper.sh
+++ b/scripts/build-darwin-vz-helper.sh
@@ -11,6 +11,7 @@ SIGN_IDENTITY="${CLEANROOM_DARWIN_VZ_HELPER_SIGN_IDENTITY:--}"
 SIGN_IDENTIFIER="${CLEANROOM_DARWIN_VZ_HELPER_SIGN_IDENTIFIER:-}"
 PROVISION_PROFILE="${CLEANROOM_DARWIN_VZ_HELPER_PROVISION_PROFILE:-}"
 BUNDLE_MODE="${CLEANROOM_DARWIN_VZ_HELPER_BUNDLE:-}"
+SIGN_RUNTIME="${CLEANROOM_DARWIN_VZ_HELPER_SIGN_RUNTIME:-}"
 
 [[ -f "${REPO_ROOT}/cmd/cleanroom-darwin-vz/main.swift" ]] || {
   echo "missing helper source: ${REPO_ROOT}/cmd/cleanroom-darwin-vz/main.swift" >&2
@@ -93,6 +94,9 @@ EOF
     --sign "${SIGN_IDENTITY}"
     --entitlements "${ENTITLEMENTS_PATH}"
   )
+  if [[ -n "${SIGN_RUNTIME}" && "${SIGN_IDENTITY}" != "-" ]]; then
+    codesign_args+=(--options runtime --timestamp)
+  fi
   if [[ -n "${SIGN_IDENTIFIER}" ]]; then
     codesign_args+=(-i "${SIGN_IDENTIFIER}")
   fi
@@ -114,6 +118,9 @@ else
     --sign "${SIGN_IDENTITY}"
     --entitlements "${ENTITLEMENTS_PATH}"
   )
+  if [[ -n "${SIGN_RUNTIME}" && "${SIGN_IDENTITY}" != "-" ]]; then
+    codesign_args+=(--options runtime --timestamp)
+  fi
   if [[ -n "${SIGN_IDENTIFIER}" ]]; then
     codesign_args+=(-i "${SIGN_IDENTIFIER}")
   fi

--- a/scripts/build-macos-release-pkg.sh
+++ b/scripts/build-macos-release-pkg.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+die() {
+  printf '[build-macos-release-pkg] error: %s\n' "$*" >&2
+  exit 1
+}
+
+require_cmd() {
+  local cmd="$1"
+  command -v "$cmd" >/dev/null 2>&1 || die "required command not found: ${cmd}"
+}
+
+usage() {
+  cat <<'USAGE'
+Build a macOS installer package for Cleanroom.
+
+Usage:
+  build-macos-release-pkg.sh <output.pkg>
+
+Required environment:
+  CLEANROOM_MACOS_RELEASE_VERSION                  Package version (for example 0.1.0)
+  CLEANROOM_MACOS_RELEASE_CLEANROOM_BINARY        Path to the signed or unsigned cleanroom macOS binary
+  CLEANROOM_MACOS_RELEASE_GUEST_AGENT_BINARY      Path to the Linux cleanroom-guest-agent binary
+  CLEANROOM_MACOS_RELEASE_HELPER_APP              Path to the cleanroom-darwin-vz.app bundle
+
+Optional environment:
+  CLEANROOM_MACOS_RELEASE_INSTALL_PREFIX          Install prefix inside the package (default: /usr/local/bin)
+  CLEANROOM_MACOS_RELEASE_APPLICATION_SIGN_IDENTITY
+                                                  Developer ID Application identity for cleanroom (default: ad-hoc "-")
+  CLEANROOM_MACOS_RELEASE_INSTALLER_SIGN_IDENTITY Developer ID Installer identity for the package
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+[[ $# -eq 1 ]] || {
+  usage >&2
+  exit 1
+}
+
+OUTPUT_PATH="$1"
+VERSION="${CLEANROOM_MACOS_RELEASE_VERSION:-}"
+CLEANROOM_BINARY="${CLEANROOM_MACOS_RELEASE_CLEANROOM_BINARY:-}"
+GUEST_AGENT_BINARY="${CLEANROOM_MACOS_RELEASE_GUEST_AGENT_BINARY:-}"
+HELPER_APP="${CLEANROOM_MACOS_RELEASE_HELPER_APP:-}"
+INSTALL_PREFIX="${CLEANROOM_MACOS_RELEASE_INSTALL_PREFIX:-/usr/local/bin}"
+APPLICATION_SIGN_IDENTITY="${CLEANROOM_MACOS_RELEASE_APPLICATION_SIGN_IDENTITY:-}"
+INSTALLER_SIGN_IDENTITY="${CLEANROOM_MACOS_RELEASE_INSTALLER_SIGN_IDENTITY:-}"
+if [[ -z "${APPLICATION_SIGN_IDENTITY}" ]]; then
+  APPLICATION_SIGN_IDENTITY="-"
+fi
+
+[[ -n "${VERSION}" ]] || die "CLEANROOM_MACOS_RELEASE_VERSION is required"
+[[ -f "${CLEANROOM_BINARY}" ]] || die "missing cleanroom binary: ${CLEANROOM_BINARY}"
+[[ -f "${GUEST_AGENT_BINARY}" ]] || die "missing cleanroom-guest-agent binary: ${GUEST_AGENT_BINARY}"
+[[ -d "${HELPER_APP}" ]] || die "missing helper app bundle: ${HELPER_APP}"
+[[ "${INSTALL_PREFIX}" = /* ]] || die "install prefix must be absolute: ${INSTALL_PREFIX}"
+
+require_cmd codesign
+require_cmd ditto
+require_cmd install
+require_cmd pkgutil
+require_cmd pkgbuild
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "${WORK_DIR}"' EXIT
+
+PAYLOAD_ROOT="${WORK_DIR}/payload"
+PAYLOAD_BIN_DIR="${PAYLOAD_ROOT}${INSTALL_PREFIX}"
+PAYLOAD_HELPER_DIR="${PAYLOAD_BIN_DIR}/cleanroom-darwin-vz.app"
+PAYLOAD_CLEANROOM_PATH="${PAYLOAD_BIN_DIR}/cleanroom"
+PAYLOAD_GUEST_AGENT_PATH="${PAYLOAD_BIN_DIR}/cleanroom-guest-agent"
+
+mkdir -p "${PAYLOAD_BIN_DIR}" "$(dirname "${OUTPUT_PATH}")"
+install -m 0755 "${CLEANROOM_BINARY}" "${PAYLOAD_CLEANROOM_PATH}"
+install -m 0755 "${GUEST_AGENT_BINARY}" "${PAYLOAD_GUEST_AGENT_PATH}"
+ditto "${HELPER_APP}" "${PAYLOAD_HELPER_DIR}"
+
+codesign_args=(
+  --force
+  --sign "${APPLICATION_SIGN_IDENTITY}"
+)
+if [[ "${APPLICATION_SIGN_IDENTITY}" != "-" ]]; then
+  codesign_args+=(--options runtime --timestamp)
+fi
+codesign_args+=("${PAYLOAD_CLEANROOM_PATH}")
+codesign "${codesign_args[@]}"
+
+codesign --verify --strict --verbose=2 "${PAYLOAD_CLEANROOM_PATH}"
+codesign --verify --deep --strict --verbose=2 "${PAYLOAD_HELPER_DIR}"
+
+pkgbuild_args=(
+  --root "${PAYLOAD_ROOT}"
+  --identifier "com.buildkite.cleanroom"
+  --version "${VERSION}"
+  --install-location /
+)
+if [[ -n "${INSTALLER_SIGN_IDENTITY}" ]]; then
+  pkgbuild_args+=(--sign "${INSTALLER_SIGN_IDENTITY}")
+fi
+pkgbuild_args+=("${OUTPUT_PATH}")
+pkgbuild "${pkgbuild_args[@]}"
+if [[ -n "${INSTALLER_SIGN_IDENTITY}" ]]; then
+  pkgutil --check-signature "${OUTPUT_PATH}"
+fi

--- a/scripts/ci-darwin-vz-e2e.sh
+++ b/scripts/ci-darwin-vz-e2e.sh
@@ -6,9 +6,7 @@ DARWIN_VZ_KERNEL_IMAGE="${CLEANROOM_DARWIN_VZ_KERNEL_IMAGE:-}"
 echo "--- :hammer: Building binaries"
 scripts/build-go.sh
 
-mkdir -p dist
-xcrun swiftc -O -framework Virtualization cmd/cleanroom-darwin-vz/main.swift -o dist/cleanroom-darwin-vz
-codesign --force --sign - --entitlements cmd/cleanroom-darwin-vz/entitlements.plist dist/cleanroom-darwin-vz
+scripts/build-darwin-vz-helper.sh dist/cleanroom-darwin-vz
 
 # `scripts/build-go.sh` produces host binaries in dist/, but darwin-vz doctor also
 # requires a Linux guest agent binary named cleanroom-guest-agent-linux-<arch>.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -31,6 +31,10 @@ Environment variables:
   CLEANROOM_INSTALL_DIR           Install destination (default: /usr/local/bin)
   CLEANROOM_REPO                  GitHub repo in owner/repo format (default: buildkite/cleanroom)
   CLEANROOM_INSTALL_DARWIN_HELPER Set to 0 to skip cleanroom-darwin-vz install on macOS
+  CLEANROOM_DARWIN_VZ_HELPER_ENTITLEMENTS Optional entitlements plist for cleanroom-darwin-vz signing or re-signing
+  CLEANROOM_DARWIN_VZ_HELPER_SIGN_IDENTITY Optional codesign identity for cleanroom-darwin-vz (default: ad-hoc when re-signing)
+  CLEANROOM_DARWIN_VZ_HELPER_SIGN_IDENTIFIER Optional codesign identifier for cleanroom-darwin-vz (default: com.buildkite.cleanroom.darwin-vz when embedding a provisioning profile)
+  CLEANROOM_DARWIN_VZ_HELPER_PROVISION_PROFILE Optional provisioning profile to embed when building or re-signing a helper bundle
 USAGE
 }
 
@@ -139,6 +143,17 @@ install_binary() {
   "${SUDO_CMD[@]}" install -m 0755 "$src" "$dst"
 }
 
+install_app_bundle() {
+  local src="$1"
+  local dst="$2"
+  "${SUDO_CMD[@]}" rm -rf "$dst"
+  if [ "${#SUDO_CMD[@]}" -gt 0 ]; then
+    "${SUDO_CMD[@]}" ditto "$src" "$dst"
+    return
+  fi
+  ditto "$src" "$dst"
+}
+
 HOST_OS_RAW="$(uname -s)"
 HOST_ARCH_RAW="$(uname -m)"
 
@@ -228,21 +243,113 @@ install_binary "${CLEANROOM_EXTRACT_DIR}/cleanroom" "${INSTALL_DIR}/cleanroom"
 install_binary "${CLEANROOM_EXTRACT_DIR}/cleanroom-guest-agent" "${INSTALL_DIR}/cleanroom-guest-agent"
 
 if [ "$HOST_OS" = "Darwin" ] && [ "$INSTALL_DARWIN_HELPER" != "0" ]; then
-  require_cmd codesign
-  [ -f "${CLEANROOM_EXTRACT_DIR}/cleanroom-darwin-vz" ] || die "cleanroom-darwin-vz missing in ${CLEANROOM_ASSET}"
-  [ -f "${CLEANROOM_EXTRACT_DIR}/entitlements.plist" ] || die "entitlements.plist missing in ${CLEANROOM_ASSET}"
+  HELPER_BUNDLE_SRC="${CLEANROOM_EXTRACT_DIR}/cleanroom-darwin-vz.app"
+  HELPER_BINARY_SRC="${CLEANROOM_EXTRACT_DIR}/cleanroom-darwin-vz"
+  HELPER_ENTITLEMENTS_VMNET_PATH="${CLEANROOM_EXTRACT_DIR}/entitlements-vmnet.plist"
+  HELPER_ENTITLEMENTS_DEFAULT_PATH="${CLEANROOM_EXTRACT_DIR}/entitlements.plist"
+  HELPER_SIGN_IDENTITY="${CLEANROOM_DARWIN_VZ_HELPER_SIGN_IDENTITY:-}"
+  HELPER_SIGN_IDENTIFIER="${CLEANROOM_DARWIN_VZ_HELPER_SIGN_IDENTIFIER:-}"
+  HELPER_PROVISION_PROFILE="${CLEANROOM_DARWIN_VZ_HELPER_PROVISION_PROFILE:-}"
+  HELPER_RESIGN_REQUESTED=0
+  if [ "${CLEANROOM_DARWIN_VZ_HELPER_ENTITLEMENTS+x}" = "x" ] || \
+     [ "${CLEANROOM_DARWIN_VZ_HELPER_SIGN_IDENTITY+x}" = "x" ] || \
+     [ "${CLEANROOM_DARWIN_VZ_HELPER_SIGN_IDENTIFIER+x}" = "x" ] || \
+     [ "${CLEANROOM_DARWIN_VZ_HELPER_PROVISION_PROFILE+x}" = "x" ]; then
+    HELPER_RESIGN_REQUESTED=1
+  fi
 
-  install_binary "${CLEANROOM_EXTRACT_DIR}/cleanroom-darwin-vz" "${INSTALL_DIR}/cleanroom-darwin-vz"
-  "${SUDO_CMD[@]}" codesign --force --sign - \
-    --entitlements "${CLEANROOM_EXTRACT_DIR}/entitlements.plist" \
-    "${INSTALL_DIR}/cleanroom-darwin-vz"
-  DARWIN_HELPER_INSTALLED=1
+  HELPER_ENTITLEMENTS_PATH="${CLEANROOM_DARWIN_VZ_HELPER_ENTITLEMENTS:-}"
+  if [ -z "${HELPER_ENTITLEMENTS_PATH}" ]; then
+    if [ -f "${HELPER_ENTITLEMENTS_VMNET_PATH}" ] && { [ -d "${HELPER_BUNDLE_SRC}" ] || [ -n "${HELPER_PROVISION_PROFILE}" ]; }; then
+      HELPER_ENTITLEMENTS_PATH="${HELPER_ENTITLEMENTS_VMNET_PATH}"
+    else
+      HELPER_ENTITLEMENTS_PATH="${HELPER_ENTITLEMENTS_DEFAULT_PATH}"
+    fi
+  fi
+
+  if [ -n "${HELPER_PROVISION_PROFILE}" ] && [ ! -f "${HELPER_PROVISION_PROFILE}" ]; then
+    die "provisioning profile missing: ${HELPER_PROVISION_PROFILE}"
+  fi
+  if [ -n "${HELPER_PROVISION_PROFILE}" ] && [ -z "${HELPER_SIGN_IDENTIFIER}" ]; then
+    HELPER_SIGN_IDENTIFIER="com.buildkite.cleanroom.darwin-vz"
+  fi
+
+  if [ -d "${HELPER_BUNDLE_SRC}" ]; then
+    require_cmd ditto
+    HELPER_BUNDLE_DIR="${INSTALL_DIR}/cleanroom-darwin-vz.app"
+    install_app_bundle "${HELPER_BUNDLE_SRC}" "${HELPER_BUNDLE_DIR}"
+    HELPER_INSTALL_LOG_PATH="${HELPER_BUNDLE_DIR}"
+
+    if [ "${HELPER_RESIGN_REQUESTED}" = "1" ]; then
+      require_cmd codesign
+      [ -f "${HELPER_ENTITLEMENTS_PATH}" ] || die "entitlements plist missing: ${HELPER_ENTITLEMENTS_PATH}"
+      HELPER_SIGN_IDENTITY="${HELPER_SIGN_IDENTITY:--}"
+      if [ -n "${HELPER_PROVISION_PROFILE}" ]; then
+        install_binary "${HELPER_PROVISION_PROFILE}" "${HELPER_BUNDLE_DIR}/Contents/embedded.provisionprofile"
+      fi
+      codesign_cmd=("${SUDO_CMD[@]}" codesign --force --sign "${HELPER_SIGN_IDENTITY}" --entitlements "${HELPER_ENTITLEMENTS_PATH}")
+      if [ -n "${HELPER_SIGN_IDENTIFIER}" ]; then
+        codesign_cmd+=(-i "${HELPER_SIGN_IDENTIFIER}")
+      fi
+      codesign_cmd+=("${HELPER_BUNDLE_DIR}")
+      "${codesign_cmd[@]}"
+    fi
+
+    DARWIN_HELPER_INSTALLED=1
+  else
+    require_cmd codesign
+    [ -f "${HELPER_BINARY_SRC}" ] || die "cleanroom-darwin-vz missing in ${CLEANROOM_ASSET}"
+    [ -f "${HELPER_ENTITLEMENTS_PATH}" ] || die "entitlements plist missing: ${HELPER_ENTITLEMENTS_PATH}"
+
+    HELPER_SIGN_IDENTITY="${HELPER_SIGN_IDENTITY:--}"
+    HELPER_SIGN_TARGET="${INSTALL_DIR}/cleanroom-darwin-vz"
+    HELPER_INSTALL_LOG_PATH="${HELPER_SIGN_TARGET}"
+    if [ -n "${HELPER_PROVISION_PROFILE}" ]; then
+      HELPER_BUNDLE_DIR="${INSTALL_DIR}/cleanroom-darwin-vz.app"
+      HELPER_EXECUTABLE_PATH="${HELPER_BUNDLE_DIR}/Contents/MacOS/cleanroom-darwin-vz"
+      HELPER_INFO_PLIST_PATH="${HELPER_BUNDLE_DIR}/Contents/Info.plist"
+      "${SUDO_CMD[@]}" mkdir -p "$(dirname "${HELPER_EXECUTABLE_PATH}")"
+      "${SUDO_CMD[@]}" sh -c "cat > \"${HELPER_INFO_PLIST_PATH}\" <<'EOF'
+<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
+<plist version=\"1.0\">
+<dict>
+  <key>CFBundleExecutable</key>
+  <string>cleanroom-darwin-vz</string>
+  <key>CFBundleIdentifier</key>
+  <string>${HELPER_SIGN_IDENTIFIER}</string>
+  <key>CFBundleName</key>
+  <string>cleanroom-darwin-vz</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>0.0.0</string>
+  <key>CFBundleVersion</key>
+  <string>1</string>
+</dict>
+</plist>
+EOF"
+      install_binary "${HELPER_BINARY_SRC}" "${HELPER_EXECUTABLE_PATH}"
+      install_binary "${HELPER_PROVISION_PROFILE}" "${HELPER_BUNDLE_DIR}/Contents/embedded.provisionprofile"
+      HELPER_SIGN_TARGET="${HELPER_BUNDLE_DIR}"
+      HELPER_INSTALL_LOG_PATH="${HELPER_BUNDLE_DIR}"
+    else
+      install_binary "${HELPER_BINARY_SRC}" "${INSTALL_DIR}/cleanroom-darwin-vz"
+    fi
+    codesign_cmd=("${SUDO_CMD[@]}" codesign --force --sign "${HELPER_SIGN_IDENTITY}" --entitlements "${HELPER_ENTITLEMENTS_PATH}")
+    if [ -n "${HELPER_SIGN_IDENTIFIER}" ]; then
+      codesign_cmd+=(-i "${HELPER_SIGN_IDENTIFIER}")
+    fi
+    codesign_cmd+=("${HELPER_SIGN_TARGET}")
+    "${codesign_cmd[@]}"
+    DARWIN_HELPER_INSTALLED=1
+  fi
 fi
 
 log "Installed cleanroom to ${INSTALL_DIR}/cleanroom"
 log "Installed cleanroom-guest-agent to ${INSTALL_DIR}/cleanroom-guest-agent"
 if [ "$DARWIN_HELPER_INSTALLED" = "1" ]; then
-  log "Installed cleanroom-darwin-vz to ${INSTALL_DIR}/cleanroom-darwin-vz"
+  log "Installed cleanroom-darwin-vz to ${HELPER_INSTALL_LOG_PATH}"
 fi
 
 case ":${PATH}:" in

--- a/scripts/notarize-macos-package.sh
+++ b/scripts/notarize-macos-package.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+die() {
+  printf '[notarize-macos-package] error: %s\n' "$*" >&2
+  exit 1
+}
+
+require_cmd() {
+  local cmd="$1"
+  command -v "$cmd" >/dev/null 2>&1 || die "required command not found: ${cmd}"
+}
+
+usage() {
+  cat <<'USAGE'
+Submit a signed macOS package for notarization and staple the result.
+
+Usage:
+  notarize-macos-package.sh <package.pkg>
+
+Required environment:
+  CLEANROOM_MACOS_NOTARY_KEY_PATH   Path to an App Store Connect API key (.p8)
+  CLEANROOM_MACOS_NOTARY_KEY_ID     App Store Connect API key ID
+  CLEANROOM_MACOS_NOTARY_ISSUER_ID  App Store Connect issuer ID
+
+Optional environment:
+  CLEANROOM_MACOS_NOTARY_TIMEOUT    notarytool timeout (default: 15m)
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+[[ $# -eq 1 ]] || {
+  usage >&2
+  exit 1
+}
+
+PACKAGE_PATH="$1"
+KEY_PATH="${CLEANROOM_MACOS_NOTARY_KEY_PATH:-}"
+KEY_ID="${CLEANROOM_MACOS_NOTARY_KEY_ID:-}"
+ISSUER_ID="${CLEANROOM_MACOS_NOTARY_ISSUER_ID:-}"
+TIMEOUT="${CLEANROOM_MACOS_NOTARY_TIMEOUT:-15m}"
+
+[[ -f "${PACKAGE_PATH}" ]] || die "missing package: ${PACKAGE_PATH}"
+[[ -f "${KEY_PATH}" ]] || die "missing App Store Connect API key: ${KEY_PATH}"
+[[ -n "${KEY_ID}" ]] || die "CLEANROOM_MACOS_NOTARY_KEY_ID is required"
+[[ -n "${ISSUER_ID}" ]] || die "CLEANROOM_MACOS_NOTARY_ISSUER_ID is required"
+
+require_cmd xcrun
+
+xcrun notarytool submit \
+  "${PACKAGE_PATH}" \
+  --key "${KEY_PATH}" \
+  --key-id "${KEY_ID}" \
+  --issuer "${ISSUER_ID}" \
+  --wait \
+  --timeout "${TIMEOUT}"
+
+xcrun stapler staple -v "${PACKAGE_PATH}"
+xcrun stapler validate -v "${PACKAGE_PATH}"


### PR DESCRIPTION
## Summary
- build signed macOS release packages on the macOS runner
- notarize and staple per-arch `.pkg` artifacts before uploading them to the GitHub release
- keep the existing goreleaser archive flow intact while adding a preferred notarized macOS installer path

## Changes
- add `scripts/build-macos-release-pkg.sh` to assemble and sign the macOS package payload
- add `scripts/notarize-macos-package.sh` to submit, staple, and validate notarized packages
- update the release workflow to import Developer ID application and installer certs, build macOS packages, notarize them, and upload the final `.pkg` artifacts
- extend helper signing to enable hardened runtime and timestamps for Developer ID builds
- update macOS release archives to include the signed helper app bundle and vmnet entitlements
- document the notarized macOS package artifact in the README

## Verification
- `mise exec -- shellcheck scripts/build-darwin-vz-helper.sh scripts/build-macos-release-pkg.sh scripts/notarize-macos-package.sh scripts/install.sh`
- `mise exec -- bash -n scripts/build-darwin-vz-helper.sh scripts/build-macos-release-pkg.sh scripts/notarize-macos-package.sh scripts/install.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); YAML.load_file(".goreleaser.yml"); puts "yaml ok"'`
- local dry run of `scripts/build-macos-release-pkg.sh` producing an unsigned ad-hoc macOS `.pkg`

## Follow-up / Risk
- the Apple service boundary is not fully exercised until a real release workflow submits a signed package to `notarytool`
