### PR TITLE
feat: pass env through exec and console

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Run a command in a sandbox:
 
 ```bash
 cleanroom exec -- npm test
+cleanroom exec -e OPENAI_API_KEY -- codex app-server
 ```
 
 When `cleanroom.yaml` includes a repository bootstrap block, the top-level
@@ -111,6 +112,7 @@ Override the sandbox image per command (remote tag/digest or local Docker image 
 cleanroom sandbox create --image ghcr.io/buildkite/cleanroom-base/alpine:latest
 cleanroom exec --image ghcr.io/buildkite/cleanroom-base/alpine:latest -- npm test
 cleanroom console --image my-local-image:dev -- sh
+cleanroom exec -e OPENAI_API_KEY -e CODEX_HOME=/workspace/.codex -- codex app-server
 ```
 
 Equivalent namespaced command:

--- a/docs/api.md
+++ b/docs/api.md
@@ -313,10 +313,12 @@ Behavior contract:
    - otherwise create a sandbox from policy
 5. For repo-aware top-level commands, materialize that checkout in the sandbox
    and default the guest working directory to `repository.path`.
-6. Create execution with explicit kind and TTY options.
+6. Create execution with explicit kind, env, and TTY options.
 7. Attach stdio according to command mode:
    - `cleanroom exec` defaults to attached stdin plus separate stdout/stderr
      using `StreamExecution`, `WriteExecutionStdin`, and `CloseExecutionStdin`
+   - `cleanroom exec --env KEY` inherits `KEY` from the local client
+   - `cleanroom exec --env KEY=VALUE` sends an explicit guest env assignment
    - `cleanroom exec -n` closes stdin immediately so the command observes EOF
    - `cleanroom console` uses `AttachExecution` for PTY-oriented
      interactive sessions

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -174,6 +174,7 @@ type ExecutionRequest struct {
 	SandboxID   string
 	ExecutionID string
 	Command     []string
+	Env         []string
 	TTY         bool
 	Policy      *policy.CompiledPolicy
 	FirecrackerConfig

--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -966,7 +966,11 @@ func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream 
 		defer a.GatewayRegistry.ReleaseScopeToken(gatewayScopeToken)
 	}
 
-	guestReq := vsockexec.ExecRequest{Command: append([]string(nil), req.Command...), TTY: req.TTY}
+	guestReq := vsockexec.ExecRequest{
+		Command: append([]string(nil), req.Command...),
+		Env:     append([]string(nil), req.Env...),
+		TTY:     req.TTY,
+	}
 	if a.GatewayRegistry != nil && gatewayScopeToken != "" {
 		gwPort := a.GatewayPort
 		if gwPort <= 0 {
@@ -1362,7 +1366,11 @@ func (a *Adapter) executeInSandbox(bootCtx context.Context, runCtx context.Conte
 		defer a.GatewayRegistry.ReleaseScopeToken(gatewayScopeToken)
 	}
 
-	guestReq := vsockexec.ExecRequest{Command: append([]string(nil), req.Command...), TTY: req.TTY}
+	guestReq := vsockexec.ExecRequest{
+		Command: append([]string(nil), req.Command...),
+		Env:     append([]string(nil), req.Env...),
+		TTY:     req.TTY,
+	}
 	if a.GatewayRegistry != nil && gatewayScopeToken != "" {
 		gwPort := a.GatewayPort
 		if gwPort <= 0 {

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -345,7 +345,7 @@ func (a *Adapter) RunInSandbox(ctx context.Context, req backend.ExecutionRequest
 		}
 	}
 
-	guestResult, timing, err := a.executeInSandbox(ctx, instance, req.LaunchSeconds, req.Command, req.TTY, stream)
+	guestResult, timing, err := a.executeInSandbox(ctx, instance, req.LaunchSeconds, req.Command, req.Env, req.TTY, stream)
 	if err != nil {
 		observation.ExitCode = 1
 		observation.GuestError = err.Error()
@@ -406,7 +406,7 @@ func (a *Adapter) DownloadSandboxFile(ctx context.Context, sandboxID, path strin
 		limit = maxBytes
 	}
 	cmd := []string{"head", "-c", strconv.FormatInt(limit, 10), "--", path}
-	result, _, err := a.executeInSandbox(ctx, instance, 0, cmd, false, backend.OutputStream{OnStdout: func(chunk []byte) {
+	result, _, err := a.executeInSandbox(ctx, instance, 0, cmd, nil, false, backend.OutputStream{OnStdout: func(chunk []byte) {
 		_, _ = stdout.Write(chunk)
 	}})
 	if err != nil {
@@ -476,7 +476,7 @@ func (a *Adapter) CreateSnapshot(ctx context.Context, req backend.SnapshotReques
 		return nil, fmt.Errorf("sandbox %q is not running: %w", sandboxID, err)
 	}
 
-	syncResp, _, err := a.executeInSandbox(ctx, instance, snapshotSyncTimeoutSeconds, []string{"sync"}, false, backend.OutputStream{})
+	syncResp, _, err := a.executeInSandbox(ctx, instance, snapshotSyncTimeoutSeconds, []string{"sync"}, nil, false, backend.OutputStream{})
 	if err != nil {
 		return nil, fmt.Errorf("sync sandbox filesystem before snapshot: %w", err)
 	}
@@ -612,8 +612,12 @@ func (a *Adapter) DeleteSnapshot(ctx context.Context, req backend.DeleteSnapshot
 	return nil
 }
 
-func (a *Adapter) executeInSandbox(ctx context.Context, instance *sandboxInstance, launchSeconds int64, command []string, tty bool, stream backend.OutputStream) (vsockexec.ExecResponse, guestExecTiming, error) {
-	guestReq := vsockexec.ExecRequest{Command: append([]string(nil), command...), TTY: tty}
+func (a *Adapter) executeInSandbox(ctx context.Context, instance *sandboxInstance, launchSeconds int64, command, env []string, tty bool, stream backend.OutputStream) (vsockexec.ExecResponse, guestExecTiming, error) {
+	guestReq := vsockexec.ExecRequest{
+		Command: append([]string(nil), command...),
+		Env:     append([]string(nil), env...),
+		TTY:     tty,
+	}
 	seed := make([]byte, 64)
 	if _, err := cryptorand.Read(seed); err == nil {
 		guestReq.EntropySeed = seed

--- a/internal/backend/firecracker/snapshot_zfs_e2e_test.go
+++ b/internal/backend/firecracker/snapshot_zfs_e2e_test.go
@@ -134,15 +134,15 @@ func TestSnapshotLifecycleZFSE2E(t *testing.T) {
 	runCommand := func(ctx context.Context, sandboxID, runID string, command ...string) string {
 		t.Helper()
 
-		result, err := adapter.RunInSandbox(ctx, backend.RunRequest{
-			SandboxID: sandboxID,
-			RunID:     runID,
-			Command:   command,
-			Policy:    compiled,
-			FirecrackerConfig: backend.FirecrackerConfig{
-				LaunchSeconds: cfg.LaunchSeconds,
-			},
-		}, backend.OutputStream{})
+	result, err := adapter.RunInSandbox(ctx, backend.ExecutionRequest{
+		SandboxID:   sandboxID,
+		ExecutionID: runID,
+		Command:     command,
+		Policy:      compiled,
+		FirecrackerConfig: backend.FirecrackerConfig{
+			LaunchSeconds: cfg.LaunchSeconds,
+		},
+	}, backend.OutputStream{})
 		if err != nil {
 			t.Fatalf("%s returned error: %v", runID, err)
 		}

--- a/internal/cli/cli_parse_test.go
+++ b/internal/cli/cli_parse_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
@@ -221,6 +222,18 @@ func TestExecParsesInFromAndKeep(t *testing.T) {
 	}
 }
 
+func TestExecParsesRepeatedEnvFlags(t *testing.T) {
+	c := &CLI{}
+	parser := newParserForTest(t, c)
+
+	if _, err := parser.Parse([]string{"exec", "--env", "OPENAI_API_KEY", "--env", "DEBUG=1", "--", "echo", "ok"}); err != nil {
+		t.Fatalf("parse exec --env returned error: %v", err)
+	}
+	if got, want := c.Exec.Env, []string{"OPENAI_API_KEY", "DEBUG=1"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected exec env flags: got %v want %v", got, want)
+	}
+}
+
 func TestExecParsesLegacySandboxIDFlag(t *testing.T) {
 	c := &CLI{}
 	parser := newParserForTest(t, c)
@@ -243,6 +256,18 @@ func TestConsoleParsesImageOverride(t *testing.T) {
 	}
 	if got, want := c.Console.Image, imageRef; got != want {
 		t.Fatalf("unexpected console image override: got %q want %q", got, want)
+	}
+}
+
+func TestConsoleParsesRepeatedEnvFlags(t *testing.T) {
+	c := &CLI{}
+	parser := newParserForTest(t, c)
+
+	if _, err := parser.Parse([]string{"console", "--env", "OPENAI_API_KEY", "--env", "DEBUG=1", "--", "sh"}); err != nil {
+		t.Fatalf("parse console --env returned error: %v", err)
+	}
+	if got, want := c.Console.Env, []string{"OPENAI_API_KEY", "DEBUG=1"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected console env flags: got %v want %v", got, want)
 	}
 }
 

--- a/internal/cli/console.go
+++ b/internal/cli/console.go
@@ -20,13 +20,14 @@ import (
 
 type ConsoleCommand struct {
 	clientFlags
-	Chdir          string `short:"c" help:"Change to this directory before running commands"`
-	Backend        string `help:"Execution backend (defaults to runtime config or host default)"`
-	In             string `name:"in" aliases:"sandbox-id" help:"Run in an existing sandbox ID instead of creating a new one"`
-	From           string `name:"from" help:"Create the sandbox from an existing snapshot ID"`
-	Image          string `help:"Override sandbox image ref for newly created sandboxes (tag, digest, or local Docker image)"`
-	Keep           bool   `help:"Keep a newly created sandbox after the console exits"`
-	PrintSandboxID bool   `name:"print-sandbox-id" help:"Print resolved sandbox_id=<id> to stderr before attaching"`
+	Chdir          string   `short:"c" help:"Change to this directory before running commands"`
+	Backend        string   `help:"Execution backend (defaults to runtime config or host default)"`
+	In             string   `name:"in" aliases:"sandbox-id" help:"Run in an existing sandbox ID instead of creating a new one"`
+	From           string   `name:"from" help:"Create the sandbox from an existing snapshot ID"`
+	Image          string   `help:"Override sandbox image ref for newly created sandboxes (tag, digest, or local Docker image)"`
+	Keep           bool     `help:"Keep a newly created sandbox after the console exits"`
+	Env            []string `short:"e" name:"env" help:"Set guest environment variables; use KEY to inherit from the local environment or KEY=VALUE to set an explicit value"`
+	PrintSandboxID bool     `name:"print-sandbox-id" help:"Print resolved sandbox_id=<id> to stderr before attaching"`
 
 	LaunchSeconds int64 `help:"VM boot/guest-agent readiness timeout in seconds"`
 
@@ -48,6 +49,10 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) (runErr error) {
 	if err != nil {
 		return err
 	}
+	executionEnv, err := resolveExecutionEnv(c.Env)
+	if err != nil {
+		return err
+	}
 
 	command := append([]string(nil), c.Command...)
 	if len(command) == 0 {
@@ -58,6 +63,7 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) (runErr error) {
 		"backend", c.Backend,
 		"sandbox_id", strings.TrimSpace(c.In),
 		"command_argc", len(command),
+		"env_count", len(executionEnv),
 	)
 	persistentRepositoryBackend := backendSupportsRepositoryPersistence(ctx, host, c.Backend)
 	repository, err := maybeResolveRepositoryCheckout(cwd, ctx.Loader, strings.TrimSpace(c.In), strings.TrimSpace(c.From), !persistentRepositoryBackend)
@@ -160,6 +166,7 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) (runErr error) {
 	createExecutionResp, err := client.CreateExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
 		SandboxId:          sandboxID,
 		Command:            repositoryExecutionCommand(command, repository, inlineRepositoryBootstrap),
+		Env:                executionEnv,
 		Kind:               cleanroomv1.ExecutionKind_EXECUTION_KIND_INTERACTIVE,
 		RepositoryCheckout: repositoryExecutionCheckout(repository, inlineRepositoryBootstrap),
 		Options: &cleanroomv1.ExecutionOptions{

--- a/internal/cli/console_integration_test.go
+++ b/internal/cli/console_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -91,6 +92,44 @@ func TestConsoleIntegrationForwardsStdinAndStreamsOutput(t *testing.T) {
 		t.Fatalf("expected streamed output to include echoed stdin, got %q", outcome.stdout)
 	}
 	_ = mustReceiveWithin(t, started, 2*time.Second, "timed out waiting for console execution to start")
+}
+
+func TestConsoleIntegrationPassesResolvedEnv(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "host-secret")
+
+	var captured backend.ExecutionRequest
+	adapter := &integrationAdapter{
+		runStreamFn: func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+			captured = req
+			return &backend.ExecutionResult{
+				ExecutionID: req.ExecutionID,
+				ExitCode:    0,
+				Message:     "ok",
+			}, nil
+		},
+	}
+
+	host, _ := startIntegrationServer(t, adapter)
+	cwd := t.TempDir()
+	outcome := runConsoleWithCapture(ConsoleCommand{
+		clientFlags: clientFlags{Host: host},
+		Chdir:       cwd,
+		Env:         []string{"OPENAI_API_KEY", "DEBUG=1", "EMPTY="},
+		Command:     []string{"sh"},
+	}, "", runtimeContext{
+		CWD:    cwd,
+		Loader: integrationLoader{},
+	})
+
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err != nil {
+		t.Fatalf("ConsoleCommand.Run returned error: %v", outcome.err)
+	}
+	if got, want := captured.Env, []string{"OPENAI_API_KEY=host-secret", "DEBUG=1", "EMPTY="}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected console env: got %v want %v", got, want)
+	}
 }
 
 func TestConsoleIntegrationInterruptCancelsExecution(t *testing.T) {

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -13,14 +13,15 @@ import (
 
 type ExecCommand struct {
 	clientFlags
-	Chdir          string `short:"c" help:"Change to this directory before running commands"`
-	Backend        string `help:"Execution backend (defaults to runtime config or host default)"`
-	In             string `name:"in" aliases:"sandbox-id" help:"Run in an existing sandbox ID instead of creating a new one"`
-	From           string `name:"from" help:"Create the sandbox from an existing snapshot ID"`
-	Image          string `help:"Override sandbox image ref for newly created sandboxes (tag, digest, or local Docker image)"`
-	Keep           bool   `help:"Keep a newly created sandbox after the command completes"`
-	NoStdin        bool   `short:"n" name:"no-stdin" aliases:"stdin-eof" help:"Close stdin immediately instead of attaching it"`
-	PrintSandboxID bool   `name:"print-sandbox-id" help:"Print resolved sandbox_id=<id> to stderr before streaming output"`
+	Chdir          string   `short:"c" help:"Change to this directory before running commands"`
+	Backend        string   `help:"Execution backend (defaults to runtime config or host default)"`
+	In             string   `name:"in" aliases:"sandbox-id" help:"Run in an existing sandbox ID instead of creating a new one"`
+	From           string   `name:"from" help:"Create the sandbox from an existing snapshot ID"`
+	Image          string   `help:"Override sandbox image ref for newly created sandboxes (tag, digest, or local Docker image)"`
+	Keep           bool     `help:"Keep a newly created sandbox after the command completes"`
+	Env            []string `short:"e" name:"env" help:"Set guest environment variables; use KEY to inherit from the local environment or KEY=VALUE to set an explicit value"`
+	NoStdin        bool     `short:"n" name:"no-stdin" aliases:"stdin-eof" help:"Close stdin immediately instead of attaching it"`
+	PrintSandboxID bool     `name:"print-sandbox-id" help:"Print resolved sandbox_id=<id> to stderr before streaming output"`
 
 	LaunchSeconds int64 `help:"VM boot/guest-agent readiness timeout in seconds"`
 
@@ -42,12 +43,17 @@ func (e *ExecCommand) Run(ctx *runtimeContext) (runErr error) {
 	if err != nil {
 		return err
 	}
+	executionEnv, err := resolveExecutionEnv(e.Env)
+	if err != nil {
+		return err
+	}
 
 	logger.Debug("sending execution request",
 		"host", host,
 		"backend", e.Backend,
 		"sandbox_id", strings.TrimSpace(e.In),
 		"command_argc", len(e.Command),
+		"env_count", len(executionEnv),
 	)
 	persistentRepositoryBackend := backendSupportsRepositoryPersistence(ctx, host, e.Backend)
 	repository, err := maybeResolveRepositoryCheckout(cwd, ctx.Loader, strings.TrimSpace(e.In), strings.TrimSpace(e.From), !persistentRepositoryBackend)
@@ -151,6 +157,7 @@ func (e *ExecCommand) Run(ctx *runtimeContext) (runErr error) {
 	createExecutionResp, err := client.CreateExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
 		SandboxId:          sandboxID,
 		Command:            repositoryExecutionCommand(e.Command, repository, inlineRepositoryBootstrap),
+		Env:                executionEnv,
 		Kind:               cleanroomv1.ExecutionKind_EXECUTION_KIND_BATCH,
 		RepositoryCheckout: repositoryExecutionCheckout(repository, inlineRepositoryBootstrap),
 		Options: &cleanroomv1.ExecutionOptions{

--- a/internal/cli/exec_integration_test.go
+++ b/internal/cli/exec_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"strings"
 	"sync"
@@ -578,6 +579,44 @@ func TestExecIntegrationForwardsStdinByDefault(t *testing.T) {
 	mu.Unlock()
 	if gotStdin != stdinData {
 		t.Fatalf("unexpected stdin forwarded to backend: got %q want %q", gotStdin, stdinData)
+	}
+}
+
+func TestExecIntegrationPassesResolvedEnv(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "host-secret")
+
+	var captured backend.ExecutionRequest
+	adapter := &integrationAdapter{
+		runFn: func(_ context.Context, req backend.ExecutionRequest) (*backend.ExecutionResult, error) {
+			captured = req
+			return &backend.ExecutionResult{
+				ExecutionID: req.ExecutionID,
+				ExitCode:    0,
+				Message:     "ok",
+			}, nil
+		},
+	}
+
+	host, _ := startIntegrationServer(t, adapter)
+	cwd := t.TempDir()
+	outcome := runExecWithCapture(ExecCommand{
+		clientFlags: clientFlags{Host: host},
+		Chdir:       cwd,
+		Env:         []string{"OPENAI_API_KEY", "DEBUG=1", "EMPTY="},
+		Command:     []string{"echo", "ok"},
+	}, runtimeContext{
+		CWD:    cwd,
+		Loader: integrationLoader{},
+	})
+
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err != nil {
+		t.Fatalf("ExecCommand.Run returned error: %v", outcome.err)
+	}
+	if got, want := captured.Env, []string{"OPENAI_API_KEY=host-secret", "DEBUG=1", "EMPTY="}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected exec env: got %v want %v", got, want)
 	}
 }
 

--- a/internal/cli/execution_shared.go
+++ b/internal/cli/execution_shared.go
@@ -143,6 +143,36 @@ func startExecutionStdinForwarder(
 	return errCh
 }
 
+func resolveExecutionEnv(specs []string) ([]string, error) {
+	if len(specs) == 0 {
+		return nil, nil
+	}
+
+	out := make([]string, 0, len(specs))
+	for _, spec := range specs {
+		if strings.Contains(spec, "\x00") {
+			return nil, fmt.Errorf("invalid --env %q: contains NUL", spec)
+		}
+		if key, _, ok := strings.Cut(spec, "="); ok {
+			if key == "" {
+				return nil, fmt.Errorf("invalid --env %q: missing variable name", spec)
+			}
+			out = append(out, spec)
+			continue
+		}
+
+		if spec == "" {
+			return nil, errors.New("invalid --env \"\": missing variable name")
+		}
+		value, ok := os.LookupEnv(spec)
+		if !ok {
+			return nil, fmt.Errorf("environment variable %q is not set", spec)
+		}
+		out = append(out, spec+"="+value)
+	}
+	return out, nil
+}
+
 func closeExecutionStdin(client *controlclient.Client, sandboxID, executionID string) error {
 	_, err := client.CloseExecutionStdin(context.Background(), &cleanroomv1.CloseExecutionStdinRequest{
 		SandboxId:   sandboxID,

--- a/internal/cli/execution_shared_test.go
+++ b/internal/cli/execution_shared_test.go
@@ -1,0 +1,41 @@
+package cli
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestResolveExecutionEnv(t *testing.T) {
+	t.Setenv("INHERITED_ENV", "from-host")
+
+	got, err := resolveExecutionEnv([]string{"INHERITED_ENV", "EXPLICIT=value", "EMPTY="})
+	if err != nil {
+		t.Fatalf("resolveExecutionEnv returned error: %v", err)
+	}
+
+	want := []string{"INHERITED_ENV=from-host", "EXPLICIT=value", "EMPTY="}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected resolved env: got %v want %v", got, want)
+	}
+}
+
+func TestResolveExecutionEnvRejectsUnsetInheritedVar(t *testing.T) {
+	_, err := resolveExecutionEnv([]string{"UNSET_ENV_FOR_TEST"})
+	if err == nil {
+		t.Fatal("expected resolveExecutionEnv to fail for unset inherited variable")
+	}
+	if !strings.Contains(err.Error(), "UNSET_ENV_FOR_TEST") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestResolveExecutionEnvRejectsMissingExplicitKey(t *testing.T) {
+	_, err := resolveExecutionEnv([]string{"=value"})
+	if err == nil {
+		t.Fatal("expected resolveExecutionEnv to fail for missing key")
+	}
+	if !strings.Contains(err.Error(), "missing variable name") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -71,6 +71,7 @@ type executionState struct {
 	ImageRef         string
 	ImageDigest      string
 	Command          []string
+	Env              []string
 	Options          executionOptions
 	TTY              bool
 	Kind             cleanroomv1.ExecutionKind
@@ -804,6 +805,10 @@ func (s *Service) CreateExecution(ctx context.Context, req *cleanroomv1.CreateEx
 	if len(command) == 0 {
 		return nil, errors.New("missing command")
 	}
+	executionEnv, err := normalizeExecutionEnv(req.GetEnv())
+	if err != nil {
+		return nil, err
+	}
 	repository := repositorycheckout.FromProto(req.GetRepositoryCheckout())
 	if repository != nil {
 		if err := repository.ValidateBootstrap(); err != nil {
@@ -927,6 +932,7 @@ func (s *Service) CreateExecution(ctx context.Context, req *cleanroomv1.CreateEx
 		ImageRef:    imageRef,
 		ImageDigest: imageDigest,
 		Command:     append([]string(nil), command...),
+		Env:         executionEnv,
 		Options:     execOpts,
 		TTY:         tty,
 		Kind:        kind,
@@ -1595,6 +1601,7 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 		SandboxID:         sandboxID,
 		ExecutionID:       ex.ID,
 		Command:           append([]string(nil), ex.Command...),
+		Env:               append([]string(nil), ex.Env...),
 		TTY:               ex.TTY,
 		Policy:            sb.Policy,
 		FirecrackerConfig: firecrackerCfg,

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -365,6 +365,29 @@ func TestExecutionStreamIncludesExitEvent(t *testing.T) {
 	}
 }
 
+func TestCreateExecutionRejectsEnvWithoutAssignment(t *testing.T) {
+	adapter := &stubAdapter{}
+	svc := newTestService(adapter)
+
+	createSandboxResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createSandboxResp.GetSandbox().GetSandboxId()
+
+	_, err = svc.CreateExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
+		SandboxId: sandboxID,
+		Command:   []string{"echo", "hi"},
+		Env:       []string{"OPENAI_API_KEY"},
+	})
+	if err == nil {
+		t.Fatal("expected CreateExecution to reject env entries without KEY=VALUE")
+	}
+	if !strings.Contains(err.Error(), "KEY=VALUE") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestCreateSnapshotPersistsMetadataAndDeletesIt(t *testing.T) {
 	store := newMemorySnapshotStore()
 	adapter := &stubAdapter{

--- a/internal/controlservice/state_helpers.go
+++ b/internal/controlservice/state_helpers.go
@@ -179,6 +179,28 @@ func normalizeCommand(command []string) []string {
 	return command
 }
 
+func normalizeExecutionEnv(env []string) ([]string, error) {
+	if len(env) == 0 {
+		return nil, nil
+	}
+
+	out := make([]string, 0, len(env))
+	for _, entry := range env {
+		if strings.Contains(entry, "\x00") {
+			return nil, fmt.Errorf("invalid env entry %q: contains NUL", entry)
+		}
+		key, _, ok := strings.Cut(entry, "=")
+		if !ok {
+			return nil, fmt.Errorf("invalid env entry %q: expected KEY=VALUE", entry)
+		}
+		if key == "" {
+			return nil, fmt.Errorf("invalid env entry %q: missing variable name", entry)
+		}
+		out = append(out, entry)
+	}
+	return out, nil
+}
+
 func bufferedResultDelta(retained, buffered string, retentionLimit int) (string, bool) {
 	if buffered == "" {
 		return "", false

--- a/internal/gen/cleanroom/v1/control.pb.go
+++ b/internal/gen/cleanroom/v1/control.pb.go
@@ -1972,6 +1972,7 @@ type CreateExecutionRequest struct {
 	Options            *ExecutionOptions      `protobuf:"bytes,3,opt,name=options,proto3" json:"options,omitempty"`
 	Kind               ExecutionKind          `protobuf:"varint,4,opt,name=kind,proto3,enum=cleanroom.v1.ExecutionKind" json:"kind,omitempty"`
 	RepositoryCheckout *RepositoryCheckout    `protobuf:"bytes,5,opt,name=repository_checkout,json=repositoryCheckout,proto3" json:"repository_checkout,omitempty"`
+	Env                []string               `protobuf:"bytes,6,rep,name=env,proto3" json:"env,omitempty"`
 	unknownFields      protoimpl.UnknownFields
 	sizeCache          protoimpl.SizeCache
 }
@@ -2037,6 +2038,13 @@ func (x *CreateExecutionRequest) GetKind() ExecutionKind {
 func (x *CreateExecutionRequest) GetRepositoryCheckout() *RepositoryCheckout {
 	if x != nil {
 		return x.RepositoryCheckout
+	}
+	return nil
+}
+
+func (x *CreateExecutionRequest) GetEnv() []string {
+	if x != nil {
+		return x.Env
 	}
 	return nil
 }
@@ -3263,14 +3271,15 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"R\x06run_id\"q\n" +
 	"\x10ExecutionOptions\x12%\n" +
 	"\x0elaunch_seconds\x18\x05 \x01(\x03R\rlaunchSeconds\x12\x10\n" +
-	"\x03tty\x18\x06 \x01(\bR\x03ttyJ\x04\b\x02\x10\x03J\x04\b\a\x10\bR\x13read_only_workspaceR\x03cwd\"\x8f\x02\n" +
+	"\x03tty\x18\x06 \x01(\bR\x03ttyJ\x04\b\x02\x10\x03J\x04\b\a\x10\bR\x13read_only_workspaceR\x03cwd\"\xa1\x02\n" +
 	"\x16CreateExecutionRequest\x12\x1d\n" +
 	"\n" +
 	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\x12\x18\n" +
 	"\acommand\x18\x02 \x03(\tR\acommand\x128\n" +
 	"\aoptions\x18\x03 \x01(\v2\x1e.cleanroom.v1.ExecutionOptionsR\aoptions\x12/\n" +
 	"\x04kind\x18\x04 \x01(\x0e2\x1b.cleanroom.v1.ExecutionKindR\x04kind\x12Q\n" +
-	"\x13repository_checkout\x18\x05 \x01(\v2 .cleanroom.v1.RepositoryCheckoutR\x12repositoryCheckout\"P\n" +
+	"\x13repository_checkout\x18\x05 \x01(\v2 .cleanroom.v1.RepositoryCheckoutR\x12repositoryCheckout\x12\x10\n" +
+	"\x03env\x18\x06 \x03(\tR\x03env\"P\n" +
 	"\x17CreateExecutionResponse\x125\n" +
 	"\texecution\x18\x01 \x01(\v2\x17.cleanroom.v1.ExecutionR\texecution\"\xa0\x01\n" +
 	"\x16AttachExecutionRequest\x12\x1d\n" +

--- a/proto/cleanroom/v1/control.proto
+++ b/proto/cleanroom/v1/control.proto
@@ -249,6 +249,7 @@ message CreateExecutionRequest {
   ExecutionOptions options = 3;
   ExecutionKind kind = 4;
   RepositoryCheckout repository_checkout = 5;
+  repeated string env = 6;
 }
 
 message CreateExecutionResponse {


### PR DESCRIPTION
## Summary
- add a repeatable --env/-e flag to cleanroom exec and cleanroom console
- resolve bare KEY values from the local client environment and send concrete KEY=VALUE assignments over the execution API
- pass execution env through the control service and both backends, with CLI, service, and integration test coverage

## Testing
- mise exec -- go test ./internal/cli ./internal/controlservice
- mise exec -- go test ./internal/backend/firecracker ./internal/backend/darwinvz
- mise exec -- go test ./...