### PR TITLE
fix: support launchd re-enable and json daemon status

### DIFF
--- a/internal/cli/cli_parse_test.go
+++ b/internal/cli/cli_parse_test.go
@@ -426,6 +426,18 @@ func TestDaemonStatusUserParses(t *testing.T) {
 	}
 }
 
+func TestDaemonStatusJSONParses(t *testing.T) {
+	c := &CLI{}
+	parser := newParserForTest(t, c)
+
+	if _, err := parser.Parse([]string{"daemon", "status", "--json"}); err != nil {
+		t.Fatalf("parse daemon status --json returned error: %v", err)
+	}
+	if !c.Daemon.JSON {
+		t.Fatal("expected --json to set Daemon.JSON")
+	}
+}
+
 func TestDaemonStartSystemParses(t *testing.T) {
 	c := &CLI{}
 	parser := newParserForTest(t, c)

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -18,11 +19,29 @@ type DaemonCommand struct {
 	Force         bool   `help:"Overwrite existing daemon service file (daemon install only)"`
 	User          bool   `help:"Use user daemon scope (launchd only; install/uninstall/status/start/stop actions)"`
 	System        bool   `help:"Use system daemon scope (linux only; install/uninstall/status/start/stop actions)"`
+	JSON          bool   `help:"Print daemon status as JSON (status action only)"`
 	Listen        string `help:"Listen endpoint for control API (defaults to runtime endpoint)"`
 	GatewayListen string `help:"Listen address for the host gateway (default :8170, use :0 for ephemeral port)"`
 	LogLevel      string `help:"Server log level (debug|info|warn|error)"`
 	TLSCert       string `help:"Path to TLS server certificate (auto-discovered from XDG config for https)" env:"CLEANROOM_TLS_CERT"`
 	TLSKey        string `help:"Path to TLS server private key (auto-discovered from XDG config for https)" env:"CLEANROOM_TLS_KEY"`
+}
+
+type daemonStatusPayload struct {
+	Manager   string `json:"manager"`
+	Service   string `json:"service"`
+	Installed bool   `json:"installed"`
+	Active    bool   `json:"active"`
+	Path      string `json:"path"`
+	Enabled   *bool  `json:"enabled,omitempty"`
+	Domain    string `json:"domain,omitempty"`
+	State     string `json:"state,omitempty"`
+	Listen    string `json:"listen,omitempty"`
+}
+
+type daemonStatusResult struct {
+	Report  daemonStatusReport
+	Payload daemonStatusPayload
 }
 
 type daemonScope string
@@ -49,7 +68,12 @@ var (
 )
 
 func (s *DaemonCommand) Run(ctx *runtimeContext) error {
-	switch strings.TrimSpace(strings.ToLower(s.Action)) {
+	action := strings.TrimSpace(strings.ToLower(s.Action))
+	if s.JSON && action != "status" {
+		return errors.New("--json is only supported with daemon status")
+	}
+
+	switch action {
 	case "install":
 		return s.installDaemon(ctx)
 	case "uninstall":
@@ -288,7 +312,7 @@ func (s *DaemonCommand) daemonStatus(ctx *runtimeContext) error {
 		return err
 	}
 
-	var statusFn func(*os.File) error
+	var statusFn func() (daemonStatusResult, error)
 	switch serveInstallGOOS {
 	case "linux":
 		statusFn = systemdDaemonStatus
@@ -302,7 +326,17 @@ func (s *DaemonCommand) daemonStatus(ctx *runtimeContext) error {
 		return fmt.Errorf("daemon status is unsupported on %s (expected linux or darwin)", serveInstallGOOS)
 	}
 
-	return statusFn(ctx.Stdout)
+	result, err := statusFn()
+	if err != nil {
+		return err
+	}
+	if s.JSON {
+		enc := json.NewEncoder(ctx.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(result.Payload)
+	}
+	_, err = fmt.Fprint(ctx.Stdout, renderDaemonStatusReport(result.Report, shouldUseANSI(ctx.Stdout)))
+	return err
 }
 
 func isExitError(err error) bool {

--- a/internal/cli/daemon_launchd.go
+++ b/internal/cli/daemon_launchd.go
@@ -84,6 +84,9 @@ func startLaunchdDaemonInDomain(stdout io.Writer, servicePath, domain string) er
 	}
 
 	target := launchdServiceTarget(domain)
+	if err := serveInstallRunCommand("launchctl", "enable", target); err != nil {
+		return fmt.Errorf("enable launchd service %s: %w", launchdServiceName, err)
+	}
 	loaded, err := launchdServiceLoaded(target)
 	if err != nil {
 		return err
@@ -92,9 +95,6 @@ func startLaunchdDaemonInDomain(stdout io.Writer, servicePath, domain string) er
 		if err := serveInstallRunCommand("launchctl", "bootstrap", domain, servicePath); err != nil {
 			return fmt.Errorf("bootstrap launchd service %s: %w", launchdServiceName, err)
 		}
-	}
-	if err := serveInstallRunCommand("launchctl", "enable", target); err != nil {
-		return fmt.Errorf("enable launchd service %s: %w", launchdServiceName, err)
 	}
 	if err := serveInstallRunCommand("launchctl", "kickstart", "-k", target); err != nil {
 		return fmt.Errorf("start launchd service %s: %w", launchdServiceName, err)
@@ -172,19 +172,19 @@ func stopLaunchdDaemonInDomain(stdout io.Writer, servicePath, domain string) err
 	return err
 }
 
-func launchdDaemonStatus(stdout *os.File) error {
-	return launchdDaemonStatusInDomain(stdout, serveInstallLaunchdPath, "system")
+func launchdDaemonStatus() (daemonStatusResult, error) {
+	return launchdDaemonStatusInDomain(serveInstallLaunchdPath, "system")
 }
 
-func launchdUserDaemonStatus(stdout *os.File) error {
+func launchdUserDaemonStatus() (daemonStatusResult, error) {
 	path, err := launchdUserServicePath()
 	if err != nil {
-		return err
+		return daemonStatusResult{}, err
 	}
-	return launchdDaemonStatusInDomain(stdout, path, launchdUserDomain())
+	return launchdDaemonStatusInDomain(path, launchdUserDomain())
 }
 
-func launchdDaemonStatusInDomain(stdout *os.File, servicePath, domain string) error {
+func launchdDaemonStatusInDomain(servicePath, domain string) (daemonStatusResult, error) {
 	installed := false
 	if _, err := serveInstallStat(servicePath); err == nil {
 		installed = true
@@ -198,7 +198,7 @@ func launchdDaemonStatusInDomain(stdout *os.File, servicePath, domain string) er
 			active = true
 		}
 	} else if !isExitError(err) {
-		return fmt.Errorf("check launchd service state: %w", err)
+		return daemonStatusResult{}, fmt.Errorf("check launchd service state: %w", err)
 	}
 
 	listen := ""
@@ -221,14 +221,25 @@ func launchdDaemonStatusInDomain(stdout *os.File, servicePath, domain string) er
 		fields = append(fields, startupField{Key: "listen", Value: listen})
 	}
 
-	_, err := fmt.Fprint(stdout, renderDaemonStatusReport(daemonStatusReport{
-		Manager:   "launchd",
-		Service:   launchdServiceName,
-		Installed: installed,
-		Active:    active,
-		Fields:    fields,
-	}, shouldUseANSI(stdout)))
-	return err
+	return daemonStatusResult{
+		Report: daemonStatusReport{
+			Manager:   "launchd",
+			Service:   launchdServiceName,
+			Installed: installed,
+			Active:    active,
+			Fields:    fields,
+		},
+		Payload: daemonStatusPayload{
+			Manager:   "launchd",
+			Service:   launchdServiceName,
+			Installed: installed,
+			Active:    active,
+			Path:      servicePath,
+			Domain:    domain,
+			State:     state,
+			Listen:    listen,
+		},
+	}, nil
 }
 
 func launchdServiceState(output string) string {
@@ -386,11 +397,11 @@ func installLaunchdDaemonInDomain(stdout io.Writer, executablePath string, args 
 	if force {
 		_ = serveInstallRunCommand("launchctl", "bootout", target)
 	}
-	if err := serveInstallRunCommand("launchctl", "bootstrap", domain, servicePath); err != nil {
-		return fmt.Errorf("bootstrap launchd service %s: %w", launchdServiceName, err)
-	}
 	if err := serveInstallRunCommand("launchctl", "enable", target); err != nil {
 		return fmt.Errorf("enable launchd service %s: %w", launchdServiceName, err)
+	}
+	if err := serveInstallRunCommand("launchctl", "bootstrap", domain, servicePath); err != nil {
+		return fmt.Errorf("bootstrap launchd service %s: %w", launchdServiceName, err)
 	}
 
 	_, err := fmt.Fprint(stdout, renderSummaryBlock(summaryBlock{

--- a/internal/cli/daemon_systemd.go
+++ b/internal/cli/daemon_systemd.go
@@ -79,7 +79,7 @@ func stopSystemdDaemon(stdout io.Writer) error {
 	return err
 }
 
-func systemdDaemonStatus(stdout *os.File) error {
+func systemdDaemonStatus() (daemonStatusResult, error) {
 	installed := false
 	if _, err := serveInstallStat(serveInstallSystemdUnitPath); err == nil {
 		installed = true
@@ -89,29 +89,38 @@ func systemdDaemonStatus(stdout *os.File) error {
 	if err := serveInstallRunCommand("systemctl", "is-active", "--quiet", systemdServiceName); err == nil {
 		active = true
 	} else if !isExitError(err) {
-		return fmt.Errorf("check systemd service active state: %w", err)
+		return daemonStatusResult{}, fmt.Errorf("check systemd service active state: %w", err)
 	}
 
 	enabled := false
 	if err := serveInstallRunCommand("systemctl", "is-enabled", "--quiet", systemdServiceName); err == nil {
 		enabled = true
 	} else if !isExitError(err) {
-		return fmt.Errorf("check systemd service enabled state: %w", err)
+		return daemonStatusResult{}, fmt.Errorf("check systemd service enabled state: %w", err)
 	}
 
-	_, err := fmt.Fprint(stdout, renderDaemonStatusReport(daemonStatusReport{
-		Manager:   "systemd",
-		Service:   systemdServiceName,
-		Installed: installed,
-		Active:    active,
-		Fields: []startupField{
-			{Key: "install", Value: daemonInstalledLabel(installed)},
-			{Key: "runtime", Value: daemonRuntimeLabel(active)},
-			{Key: "enabled", Value: daemonEnabledLabel(enabled)},
-			{Key: "path", Value: serveInstallSystemdUnitPath},
+	return daemonStatusResult{
+		Report: daemonStatusReport{
+			Manager:   "systemd",
+			Service:   systemdServiceName,
+			Installed: installed,
+			Active:    active,
+			Fields: []startupField{
+				{Key: "install", Value: daemonInstalledLabel(installed)},
+				{Key: "runtime", Value: daemonRuntimeLabel(active)},
+				{Key: "enabled", Value: daemonEnabledLabel(enabled)},
+				{Key: "path", Value: serveInstallSystemdUnitPath},
+			},
 		},
-	}, shouldUseANSI(stdout)))
-	return err
+		Payload: daemonStatusPayload{
+			Manager:   "systemd",
+			Service:   systemdServiceName,
+			Installed: installed,
+			Active:    active,
+			Path:      serveInstallSystemdUnitPath,
+			Enabled:   &enabled,
+		},
+	}, nil
 }
 
 func installSystemdDaemon(stdout io.Writer, executablePath string, args []string, force bool) error {

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"errors"
 	"io"
 	"net/netip"
@@ -396,7 +397,7 @@ func TestDaemonInstallUsesProvidedListenInUnit(t *testing.T) {
 	}
 }
 
-func TestDaemonInstallDarwinDefaultsToUserScopeForNonRoot(t *testing.T) {
+func TestDaemonInstallDarwinEnablesThenBootstrapsUserService(t *testing.T) {
 	tmpDir := t.TempDir()
 	plistPath := filepath.Join(tmpDir, "Library", "LaunchAgents", launchdServiceName+".plist")
 
@@ -431,12 +432,12 @@ func TestDaemonInstallDarwinDefaultsToUserScopeForNonRoot(t *testing.T) {
 		t.Fatalf("DaemonCommand.Run returned error: %v", err)
 	}
 
-	wantDomain := "gui/501"
-	if !containsServeInstallCall(calls, []string{"launchctl", "bootstrap", wantDomain}) {
-		t.Fatalf("expected launchctl bootstrap for user domain %q, calls=%v", wantDomain, calls)
+	wantCalls := [][]string{
+		{"launchctl", "enable", "gui/501/" + launchdServiceName},
+		{"launchctl", "bootstrap", "gui/501", plistPath},
 	}
-	if containsServeInstallCall(calls, []string{"launchctl", "bootstrap", "system"}) {
-		t.Fatalf("did not expect launchctl bootstrap for system domain, calls=%v", calls)
+	if !reflect.DeepEqual(calls, wantCalls) {
+		t.Fatalf("unexpected launchctl commands: got %v want %v", calls, wantCalls)
 	}
 	if _, err := os.Stat(plistPath); err != nil {
 		t.Fatalf("expected user launchd plist to be written at %s: %v", plistPath, err)
@@ -530,6 +531,18 @@ func TestDaemonInstallRejectsUserAndSystemTogether(t *testing.T) {
 		t.Fatal("expected conflicting scope flags error")
 	}
 	if !strings.Contains(err.Error(), "cannot be used together") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDaemonJSONRejectedForNonStatusActions(t *testing.T) {
+	stdout, _ := makeStdoutCapture(t)
+	cmd := &DaemonCommand{Action: "install", JSON: true}
+	err := cmd.Run(&runtimeContext{CWD: t.TempDir(), Stdout: stdout})
+	if err == nil {
+		t.Fatal("expected --json to be rejected for daemon install")
+	}
+	if !strings.Contains(err.Error(), "--json is only supported with daemon status") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -951,7 +964,7 @@ func TestDaemonStopSystemdStopsService(t *testing.T) {
 	}
 }
 
-func TestDaemonStartLaunchdBootstrapsAndKickstartsUserService(t *testing.T) {
+func TestDaemonStartLaunchdEnablesBootstrapsAndKickstartsUserService(t *testing.T) {
 	tmpDir := t.TempDir()
 	plistPath := filepath.Join(tmpDir, "Library", "LaunchAgents", launchdServiceName+".plist")
 	if err := os.MkdirAll(filepath.Dir(plistPath), 0o755); err != nil {
@@ -995,8 +1008,8 @@ func TestDaemonStartLaunchdBootstrapsAndKickstartsUserService(t *testing.T) {
 	}
 
 	wantCalls := [][]string{
-		{"launchctl", "bootstrap", "gui/501", plistPath},
 		{"launchctl", "enable", "gui/501/" + launchdServiceName},
+		{"launchctl", "bootstrap", "gui/501", plistPath},
 		{"launchctl", "kickstart", "-k", "gui/501/" + launchdServiceName},
 	}
 	if !reflect.DeepEqual(calls, wantCalls) {
@@ -1313,6 +1326,64 @@ func TestDaemonStatusSystemdNotInstalled(t *testing.T) {
 	}
 }
 
+func TestDaemonStatusSystemdJSONIncludesEnabled(t *testing.T) {
+	tmpDir := t.TempDir()
+	unitPath := filepath.Join(tmpDir, "cleanroom.service")
+	if err := os.WriteFile(unitPath, []byte("[Unit]\nDescription=cleanroom\n"), 0o644); err != nil {
+		t.Fatalf("write unit file: %v", err)
+	}
+
+	prevGOOS := serveInstallGOOS
+	prevSystemdPath := serveInstallSystemdUnitPath
+	prevRunCommand := serveInstallRunCommand
+	serveInstallGOOS = "linux"
+	serveInstallSystemdUnitPath = unitPath
+	serveInstallRunCommand = func(name string, args ...string) error {
+		return nil
+	}
+	t.Cleanup(func() {
+		serveInstallGOOS = prevGOOS
+		serveInstallSystemdUnitPath = prevSystemdPath
+		serveInstallRunCommand = prevRunCommand
+	})
+
+	stdout, readStdout := makeStdoutCapture(t)
+	cmd := &DaemonCommand{Action: "status", System: true, JSON: true}
+	if err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout}); err != nil {
+		t.Fatalf("DaemonCommand.Run returned error: %v", err)
+	}
+
+	var payload struct {
+		Manager   string `json:"manager"`
+		Service   string `json:"service"`
+		Installed bool   `json:"installed"`
+		Active    bool   `json:"active"`
+		Path      string `json:"path"`
+		Enabled   *bool  `json:"enabled"`
+	}
+	if err := json.Unmarshal([]byte(readStdout()), &payload); err != nil {
+		t.Fatalf("parse daemon status json: %v", err)
+	}
+	if payload.Manager != "systemd" {
+		t.Fatalf("expected systemd manager, got %q", payload.Manager)
+	}
+	if payload.Service != systemdServiceName {
+		t.Fatalf("expected service %q, got %q", systemdServiceName, payload.Service)
+	}
+	if !payload.Installed {
+		t.Fatal("expected installed=true")
+	}
+	if !payload.Active {
+		t.Fatal("expected active=true")
+	}
+	if payload.Path != unitPath {
+		t.Fatalf("expected path %q, got %q", unitPath, payload.Path)
+	}
+	if payload.Enabled == nil || !*payload.Enabled {
+		t.Fatalf("expected enabled=true, got %+v", payload.Enabled)
+	}
+}
+
 func TestDaemonStatusLaunchdNotInstalled(t *testing.T) {
 	tmpDir := t.TempDir()
 
@@ -1472,6 +1543,82 @@ func TestDaemonStatusLaunchdIncludesListenEndpoint(t *testing.T) {
 	}
 	if !strings.Contains(out, "listen: unix:///tmp/custom-cleanroom.sock") {
 		t.Fatalf("expected launchd status to include configured listen endpoint, got: %s", out)
+	}
+}
+
+func TestDaemonStatusLaunchdJSONIncludesListenEndpoint(t *testing.T) {
+	tmpDir := t.TempDir()
+	plistPath := filepath.Join(tmpDir, "Library", "LaunchAgents", launchdServiceName+".plist")
+	content := renderLaunchdService("/usr/local/bin/cleanroom", []string{"serve", "--listen", "unix:///tmp/custom-cleanroom.sock"})
+	if err := os.MkdirAll(filepath.Dir(plistPath), 0o755); err != nil {
+		t.Fatalf("mkdir launch agents dir: %v", err)
+	}
+	if err := os.WriteFile(plistPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write launchd plist: %v", err)
+	}
+
+	prevGOOS := serveInstallGOOS
+	prevEUID := serveInstallEUID
+	prevUID := serveInstallUID
+	prevUserHomeDir := serveInstallUserHomeDir
+	prevRunCommandOutput := serveInstallRunCommandOutput
+	serveInstallGOOS = "darwin"
+	serveInstallEUID = func() int { return 501 }
+	serveInstallUID = func() int { return 501 }
+	serveInstallUserHomeDir = func() (string, error) { return tmpDir, nil }
+	serveInstallRunCommandOutput = func(name string, args ...string) (string, error) {
+		return "state = running\n", nil
+	}
+	t.Cleanup(func() {
+		serveInstallGOOS = prevGOOS
+		serveInstallEUID = prevEUID
+		serveInstallUID = prevUID
+		serveInstallUserHomeDir = prevUserHomeDir
+		serveInstallRunCommandOutput = prevRunCommandOutput
+	})
+
+	stdout, readStdout := makeStdoutCapture(t)
+	cmd := &DaemonCommand{Action: "status", JSON: true}
+	if err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout}); err != nil {
+		t.Fatalf("DaemonCommand.Run returned error: %v", err)
+	}
+
+	var payload struct {
+		Manager   string `json:"manager"`
+		Service   string `json:"service"`
+		Installed bool   `json:"installed"`
+		Active    bool   `json:"active"`
+		Path      string `json:"path"`
+		Domain    string `json:"domain"`
+		State     string `json:"state"`
+		Listen    string `json:"listen"`
+	}
+	if err := json.Unmarshal([]byte(readStdout()), &payload); err != nil {
+		t.Fatalf("parse daemon status json: %v", err)
+	}
+	if payload.Manager != "launchd" {
+		t.Fatalf("expected launchd manager, got %q", payload.Manager)
+	}
+	if payload.Service != launchdServiceName {
+		t.Fatalf("expected service %q, got %q", launchdServiceName, payload.Service)
+	}
+	if !payload.Installed {
+		t.Fatal("expected installed=true")
+	}
+	if !payload.Active {
+		t.Fatal("expected active=true")
+	}
+	if payload.Path != plistPath {
+		t.Fatalf("expected path %q, got %q", plistPath, payload.Path)
+	}
+	if payload.Domain != "gui/501" {
+		t.Fatalf("expected domain gui/501, got %q", payload.Domain)
+	}
+	if payload.State != "running" {
+		t.Fatalf("expected state running, got %q", payload.State)
+	}
+	if payload.Listen != "unix:///tmp/custom-cleanroom.sock" {
+		t.Fatalf("expected listen endpoint, got %q", payload.Listen)
 	}
 }
 


### PR DESCRIPTION
## Summary
- enable launchd labels before bootstrap so disabled user agents can be installed and started again
- add `cleanroom daemon status --json` with machine-readable fields including the listen endpoint
- cover the new launchd ordering and JSON status output with CLI tests

## Testing
- /opt/homebrew/bin/mise exec -- go test ./...