### PR TITLE
refactor: use debugfs for firecracker runtime rootfs prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,8 @@ When `rootfs` is unset, Cleanroom derives one from `sandbox.image.ref` and injec
 - `/dev/kvm` available and writable
 - Firecracker binary installed
 - `mkfs.ext4` for OCI-to-ext4 materialization
-- `sudo -n` access to `/usr/local/sbin/cleanroom-root-helper`
+- `debugfs` for runtime rootfs preparation
+- `sudo -n` access to `/usr/local/sbin/cleanroom-root-helper` for host networking
 
 **macOS ([darwin-vz](docs/backend/darwin-vz.md)):**
 - `cleanroom-darwin-vz` helper signed with `com.apple.security.virtualization` entitlement

--- a/docs/backend/firecracker.md
+++ b/docs/backend/firecracker.md
@@ -51,7 +51,8 @@ Current capability values (visible in `cleanroom doctor --json`):
 - `/dev/kvm` available and writable
 - Firecracker binary installed
 - `mkfs.ext4` for OCI-to-ext4 materialization
-- `sudo -n` access for `ip`, `iptables`, `sysctl`
+- `debugfs` for runtime rootfs preparation
+- `sudo -n` access for privileged host networking (`ip`, `iptables`, `sysctl`)
 
 ## Related
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -127,6 +127,7 @@ The `:fire: E2E (Firecracker)` step runs a real launched Firecracker execution a
 - Readable kernel image for the `buildkite-agent` user (or allow managed kernel auto-download)
 - Internet egress to pull `sandbox.image.ref` from registry on first run
 - `mkfs.ext4` available for OCI-to-ext4 materialization
+- `debugfs` available for runtime rootfs preparation
 - Passwordless sudo for required network setup commands
 
 ### 4.2 Place runtime kernel image
@@ -175,7 +176,9 @@ Task defaults:
 
 ### 4.3 Privileged helper execution
 
-Firecracker always executes privileged host operations through a single root-owned helper.
+Firecracker still uses a single root-owned helper for privileged host networking
+and optional ZFS operations. Runtime rootfs preparation is now unprivileged and
+uses `debugfs` instead.
 
 Runtime config key:
 

--- a/docs/plans/firecracker-privilege-runtime.md
+++ b/docs/plans/firecracker-privilege-runtime.md
@@ -1,0 +1,650 @@
+# Firecracker Privilege Reduction and Host Runtime Plan
+
+**Status:** Proposed
+**Scope:** Linux `firecracker` backend first
+
+## Summary
+
+Cleanroom should stop treating Firecracker privilege as a generic `sudo` escape
+hatch. The current Linux backend already launches the Firecracker process as the
+calling user, but it still relies on a root-owned helper for two different
+classes of work:
+
+1. host networking and gateway firewall changes
+2. loop-mounting ext4 images to inject the guest runtime
+
+Those two classes have different requirements and should not share the same
+mechanism.
+
+This proposal splits the problem into two tracks:
+
+- **Track A: CI-friendly privilege reduction**
+  Remove root from runtime rootfs preparation entirely and make CI use the same
+  Linux host runtime as production.
+- **Track B: production host runtime**
+  Replace ad-hoc privileged operations with a root-owned host daemon that
+  manages
+  network leases, gateway firewall state, optional snapshot backends, and
+  Firecracker `jailer` launches.
+
+The user-facing CLI and API stay backend-neutral. Backend-specific privilege
+details remain in adapter internals and a small Linux host-runtime convention.
+The target is one supported Linux runtime model with good defaults.
+Activation path is a separate concern:
+
+- **persistent activation** via `cleanroom daemon install` on Linux
+- **transient activation** via interactive `cleanroom serve` bootstrapping
+  `hostd` once with sudo when the standard socket is missing
+
+Both paths lead to the same `hostd + jailer` runtime.
+
+## Why change this now
+
+Current state:
+
+- Firecracker itself is launched directly by the backend as the current user.
+- The privileged helper is invoked via `sudo -n`.
+- The helper contract is command-shaped (`ip`, `iptables`, `mount`, `install`,
+  `sysctl`, `zfs`) rather than resource-shaped.
+- CI hosts must install a root-owned helper out of band and keep it in sync
+  with backend expectations.
+- Runtime rootfs preparation still requires loop mounts even though the
+  repository already has an unprivileged ext4 mutation path for `darwin-vz`
+  using `debugfs`.
+
+Problems with the current shape:
+
+- **CI is noisier than it needs to be.** Passwordless sudo is currently needed
+  for both real network privilege and avoidable rootfs mutation.
+- **Helper drift is operationally awkward.** Every new helper capability or
+  argv shape is a host rollout dependency.
+- **The root surface is too low-level.** A shell-style allowlist of raw host
+  commands is harder to reason about than typed operations like "ensure sandbox
+  network" or "ensure gateway firewall."
+- **Production isolation is incomplete.** Running Firecracker as a non-root
+  user is good, but a production host still wants a root-owned control plane
+  for network state, cleanup, and `jailer`-based privilege dropping.
+
+## Goals
+
+- Keep the Firecracker VMM non-root by default.
+- Eliminate root from runtime rootfs preparation.
+- Reduce CI sudo requirements to the smallest practical surface.
+- Provide a production-grade privileged architecture that fits Cleanroom's
+  source-IP identity and gateway model.
+- Keep top-level CLI and control-plane APIs unchanged.
+- Converge CI and production on one supported Linux host runtime model.
+- Prefer convention and fixed install locations over path-heavy runtime config.
+- Keep backend-specific runtime details in adapter internals and host services.
+- Preserve a local-development `cleanroom serve` path that still "just works"
+  without making sudo-per-operation part of the supported runtime design.
+- Make CI use persistent host-runtime installation and avoid interactive sudo in
+  jobs.
+- Make privilege checks and operator expectations visible in `cleanroom doctor`.
+
+## Non-goals
+
+- Adding a rootless Linux backend in this plan.
+- Changing policy semantics, gateway semantics, or snapshot semantics.
+- Introducing backend-specific user-facing commands.
+- Moving Firecracker sandboxes into separate network namespaces in the first
+  production slice. Cleanroom's current host gateway model depends on host-side
+  TAP identity.
+
+## Current privilege surface
+
+| Area | Current mechanism | Root required today | Target |
+|---|---|---:|---|
+| `/dev/kvm` access | delegated device access | no | keep non-root |
+| Firecracker launch | direct process exec | no | `hostd`-managed `jailer` launch |
+| Runtime rootfs injection | loop mount + install | yes | eliminate root |
+| Per-sandbox TAP + policy rules | helper + `ip`/`iptables`/`sysctl` | yes | `hostd`-managed network lease |
+| Gateway firewall | helper + `iptables` | yes | `hostd`-managed gateway firewall |
+| ZFS snapshot plumbing | helper + `zfs` | yes | optional `hostd` storage ops |
+
+## Design principles
+
+### 1. Root should be a host service, not a shell escape
+
+The root boundary should expose typed operations with stable contracts:
+
+- ensure or release sandbox network
+- ensure or release gateway firewall
+- launch or stop jailed microVM
+- perform optional host-native snapshot operations
+
+It should not expose a growing list of raw `iptables`, `mount`, and `install`
+argv patterns.
+
+### 2. Unprivileged work stays unprivileged
+
+If a task can be done by the normal control process, it should be. Runtime
+rootfs preparation is the clearest example: the repository already proves that
+ext4 mutation can be done without root by using `debugfs` on `darwin-vz`.
+
+### 3. Keep the public UX stable
+
+Users should continue using:
+
+- `cleanroom exec`
+- `cleanroom sandbox create`
+- `cleanroom console`
+- `cleanroom serve`
+- `cleanroom doctor`
+
+Linux host-runtime selection should not become a new execution mode exposed
+through every command.
+
+### 4. Keep the host-runtime boundary typed
+
+The Firecracker adapter should depend on an internal host-runtime client
+interface rather than on shell commands or sudo wrappers.
+
+There should be one supported implementation of that interface on Linux:
+
+- a root-owned daemon over a Unix socket
+
+Tests can use fakes. CI and production should use the same runtime.
+
+### 5. Prefer convention over config for host runtime
+
+The Linux host runtime should use fixed defaults unless there is a strong reason
+not to:
+
+- `cleanroom-hostd` Unix socket at `/run/cleanroom/hostd.sock`
+- host-owned runtime state under `/run/cleanroom`
+- host-owned durable state under `/var/lib/cleanroom`
+- `jailer` resolved from `PATH`
+
+If a path exists only to support one installation layout, it should not be a
+stable runtime-config key.
+
+### 6. Separate activation path from runtime design
+
+Linux can support two ways to reach the same runtime without turning them into
+two different privilege modes:
+
+- a persistent host runtime installed once by root
+- a transient host runtime started on demand for interactive local development
+
+The runtime itself remains the same in both cases: `cleanroom-hostd` owns
+privileged operations and Firecracker launches through `jailer`.
+
+## Proposal
+
+## Track A: CI-friendly privilege reduction
+
+### A1. Remove root from runtime rootfs preparation
+
+Firecracker should adopt the same ext4 mutation model already used by
+`darwin-vz`:
+
+- create or derive the ext4 image unprivileged
+- inject `cleanroom-guest-agent`
+- inject `cleanroom-init`
+- create directories and replace files using `debugfs`
+
+Implementation direction:
+
+- Extract the ext4 edit helpers out of `internal/backend/darwinvz` into a
+  shared package such as `internal/ext4runtime` or `internal/ext4edit`.
+- Update the Firecracker backend to use that shared implementation instead of
+  loop-mounting with root.
+- Add a Firecracker `doctor` check for `debugfs`, mirroring the existing
+  `darwin-vz` check.
+
+Benefits:
+
+- Removes `mount`, `umount`, `mkdir`, and `install` from the privileged path.
+- Removes the most awkward repo-artifact-to-rootfs copy path from CI.
+- Shrinks helper churn and host rollout pressure immediately.
+
+### A2. Replace raw helper commands with typed host-runtime operations
+
+After rootfs prep is unprivileged, the remaining privileged Linux work is
+network, optional ZFS, and Firecracker launch. That path should move behind a
+typed internal client backed by `cleanroom-hostd`.
+
+Proposed internal interface:
+
+```go
+type HostRuntime interface {
+    Version(ctx context.Context) (string, error)
+    Capabilities(ctx context.Context) ([]string, error)
+
+    EnsureGatewayFirewall(ctx context.Context, req GatewayFirewallRequest) (Lease, error)
+    EnsureSandboxNetwork(ctx context.Context, req SandboxNetworkRequest) (SandboxNetworkLease, error)
+    ReleaseLease(ctx context.Context, leaseID string) error
+
+    ZFSCreateSnapshot(ctx context.Context, req ZFSCreateSnapshotRequest) error
+    ZFSDestroySnapshot(ctx context.Context, req ZFSDestroySnapshotRequest) error
+
+    LaunchMicroVM(ctx context.Context, req LaunchMicroVMRequest) (MicroVMHandle, error)
+    StopMicroVM(ctx context.Context, handleID string) error
+}
+```
+
+`SandboxNetworkRequest` should be resource-shaped, not command-shaped. It should
+carry:
+
+- sandbox ID
+- tap name
+- host IP / guest IP
+- gateway port
+- resolved allowlist destinations
+- whether IPv6 must be disabled
+
+The request should represent the desired network state. The privileged side owns
+how that becomes iptables or nftables state.
+
+### A3. Remove the helper as a supported runtime component
+
+The helper should not survive this redesign as a supported runtime path.
+
+Consequences:
+
+- no Linux runtime mode for `sudo-helper`
+- no helper path configuration
+- no helper capability matrix in long-term docs
+- no branch-to-host helper drift as an operational concern
+- no repeated `sudo` calls in steady-state operation
+
+CI host expectations become:
+
+- Firecracker binary installed
+- `buildkite-agent` or runtime user in the `kvm` group
+- `mkfs.ext4` and `debugfs` available
+- `cleanroom-hostd` installed and running at the standard socket
+- `jailer` installed and discoverable in `PATH`
+
+`cleanroom doctor` should report:
+
+- privilege runtime
+- host runtime version
+- whether rootfs prep is unprivileged
+- whether `jailer` is available
+- whether the connected host runtime is transient or persistent
+
+### A4. Use two activation paths into the same runtime
+
+Linux should support two operator-facing paths into `hostd`:
+
+1. **Persistent activation**
+   `cleanroom daemon install` installs and enables the standard host runtime.
+2. **Transient activation**
+   `cleanroom serve` can bootstrap `hostd` once with sudo when the standard
+   socket is absent and the terminal is interactive.
+
+Rules:
+
+- both paths use the same socket path and host-runtime contract
+- both paths use the same `hostd` implementation
+- neither path reintroduces raw helper passthrough or per-command sudo
+- transient activation is for local development only
+- non-interactive contexts must not attempt transient bootstrap
+
+## Track B: Production host runtime
+
+### B1. Add a root-owned host daemon
+
+Production should not use repeated `sudo` invocations from the unprivileged
+control service. Instead, introduce a root-owned daemon, `cleanroom-hostd`,
+with a Unix socket transport.
+
+Responsibilities:
+
+- own gateway firewall state
+- own per-sandbox TAP and egress rule state
+- own cleanup and reconciliation after crashes or restarts
+- own optional ZFS-backed snapshot operations
+- launch Firecracker through `jailer` in production mode
+
+Non-responsibilities:
+
+- loading repository policy files
+- compiling policy
+- choosing commands to execute in the guest
+- reading repository checkout state directly
+
+The unprivileged control service remains the policy authority. `hostd` receives
+typed, already-validated requests and executes only host-runtime actions.
+
+`hostd` should be the default and only supported Linux privilege runtime. CI
+and production should use the same host runtime model.
+
+### B2. Reconcile network state as owned resources
+
+`hostd` should manage named owned resources rather than append ad-hoc rules to
+global chains.
+
+Recommended model:
+
+- create dedicated Cleanroom-owned INPUT/FORWARD/NAT chains, or an nftables
+  table with equivalent semantics
+- tag each sandbox network lease with a durable lease ID
+- store lease metadata under `/run/cleanroom` and durable host-owned state
+  under `/var/lib/cleanroom`
+- reconcile owned state on startup and garbage-collect orphaned TAP devices or
+  stale firewall entries
+
+Backend choice:
+
+- For the first daemon slice, reusing the current iptables semantics is
+  acceptable if the daemon owns dedicated chains and can reconcile them.
+- nftables may be a better long-term backend, but it should be an internal
+  daemon detail, not a new user-facing contract.
+
+### B3. Launch Firecracker through `jailer`
+
+Production mode should launch Firecracker through upstream `jailer` rather than
+spawning the VMM directly from the unprivileged Cleanroom service.
+
+Proposed shape:
+
+- `cleanroom serve` runs as an unprivileged service user
+- `hostd` receives a typed launch request
+- `hostd` prepares a jail root under a host-owned base directory
+- `hostd` allocates or derives a per-sandbox uid/gid
+- `hostd` invokes `jailer`
+- `jailer` drops privileges before Firecracker starts executing as the jailed
+  user
+
+Initial production scope should include:
+
+- jailed root directory layout
+- per-sandbox uid/gid allocation
+- cgroup ownership by `hostd`
+- clean teardown when the sandbox is terminated
+
+This improves:
+
+- privilege dropping
+- filesystem containment
+- process ownership clarity
+- host cleanup after control-plane crashes
+
+### B4. Do not add netns in the first production slice
+
+It is tempting to fold network namespaces into the same change. We should not do
+that in the first pass.
+
+Reason:
+
+- Cleanroom's current gateway identity model depends on host-visible TAP and
+  guest source IP identity.
+- Moving interfaces into separate namespaces changes the reachability model for
+  the gateway and complicates the current source-IP-based routing design.
+
+The first production slice should keep the current host namespace model and add:
+
+- a proper network manager
+- owned firewall state
+- `jailer`
+
+That is enough to materially improve production posture without reworking the
+gateway architecture.
+
+## Runtime config and UX
+
+### Public UX
+
+No new top-level user command surface is required.
+
+The main UX changes should be:
+
+- `cleanroom config init` does not write Linux privilege paths or mode toggles
+- `cleanroom doctor` shows the detected Linux privilege runtime and
+  prerequisites
+- `cleanroom serve` logs the detected Linux privilege runtime once at startup
+- `cleanroom daemon install` on Linux installs the host runtime bundle rather
+  than a global long-running control-plane daemon by default
+
+### `serve` ergonomics on Linux
+
+`cleanroom serve` should stay unprivileged on Linux.
+
+Startup flow:
+
+1. attempt to connect to `/run/cleanroom/hostd.sock`
+2. if the socket is available, continue normally
+3. if the socket is missing and the terminal is interactive, offer to start a
+   transient `hostd` with sudo
+4. wait for the socket to become ready, then continue
+5. if the terminal is non-interactive, fail fast with an actionable error
+
+Important invariants:
+
+- `serve` itself does not become root
+- only `hostd` receives elevated privileges
+- transient bootstrap is not attempted in CI or other non-interactive runs
+- all sandbox network, firewall, and jailed Firecracker operations still go
+  through `hostd`
+
+This preserves a local "serve just works" experience without reintroducing the
+old helper architecture.
+
+### `daemon install` semantics on Linux
+
+On Linux, `cleanroom daemon install` should primarily mean "install the host
+runtime bundle", not "install a shared long-running `cleanroom serve` process."
+
+Recommended installed units:
+
+- `cleanroom-hostd.socket`
+- `cleanroom-hostd.service`
+
+Recommended responsibilities of `daemon install`:
+
+- install the systemd units
+- create or validate `/run/cleanroom` and `/var/lib/cleanroom`
+- ensure the service account and permissions are correct
+- enable the socket so `hostd` is available before any unprivileged `serve`
+  process starts
+
+Linux `daemon install` should not, by default, install a global
+`cleanroom.service`. The control plane is better treated as job-local or
+user-local state, while `hostd` is the machine-local privileged runtime.
+
+If operators want a shared long-running `cleanroom serve`, that should be a
+separate advanced deployment choice rather than the default Linux install
+behavior.
+
+### CI model
+
+CI should use the persistent host-runtime path only.
+
+Recommended CI shape:
+
+1. host bootstrap once as root:
+   - install `cleanroom-hostd`
+   - install `firecracker`, `jailer`, `mkfs.ext4`, and `debugfs`
+   - add the CI user to `kvm`
+   - run `cleanroom daemon install`
+2. each job starts its own unprivileged `cleanroom serve`
+3. each job uses isolated XDG runtime, config, data, and state directories
+4. jobs connect to their own local control socket
+5. all privileged work flows to the already-installed `hostd`
+
+Why this shape is preferred:
+
+- no interactive sudo in jobs
+- no helper rollout drift
+- per-job control-plane isolation for config, credentials, and logs
+- one machine-local privileged runtime with restart and cleanup ownership
+
+`cleanroom serve` should refuse transient bootstrap in non-interactive CI runs.
+If `hostd` is unavailable, it should fail with a clear message that the host
+runtime is not installed or not running.
+
+### Runtime config
+
+Recommended new Firecracker-specific runtime config:
+
+```yaml
+backends:
+  firecracker:
+    binary_path: firecracker
+    kernel_image: ""
+```
+
+Notes:
+
+- This can be a breaking config change; the project is early and does not need
+  legacy compatibility unless explicitly requested.
+- `privileged_helper_path` should be removed rather than carried forever.
+- `hostd_socket`, `helper_path`, `jailer_base_dir`, and similar host-runtime
+  paths should not be normal runtime-config keys.
+- `cleanroom-hostd` should own its standard socket and state locations by
+  convention.
+- `jailer` should be on by default for Linux Firecracker once `hostd` launches
+  VMs; lack of `jailer` should be a failing prerequisite, not a preference knob.
+- transient bootstrap should not be a runtime-config mode; it is an interactive
+  `serve` behavior when the standard socket is missing
+
+The long-term design should bias toward:
+
+- no Linux privilege mode setting
+- no path configuration for helper or daemon sockets
+- no runtime flag to disable `jailer` in supported Firecracker deployments
+- no runtime flag to choose between transient and persistent host-runtime
+  activation
+
+### Doctor output
+
+Recommended additional checks:
+
+- `privilege_runtime`
+- `hostd_activation`
+- `debugfs`
+- `hostd_socket`
+- `jailer_binary`
+- `kvm_group_access`
+- `network_backend` (informational)
+
+Recommended warning behavior:
+
+- fail if host runtime version is below the required contract
+- fail if `hostd` is unavailable for supported Linux Firecracker use
+- fail if `jailer` is unavailable once the daemonized launch path lands
+- warn when connected to a transient `hostd` instance
+
+## Architecture fit with the current codebase
+
+This proposal fits the current repository direction:
+
+- backend-neutral CLI and API stay unchanged
+- backend-specific host runtime details remain in the Firecracker backend and
+  host services
+- the existing gateway identity model stays intact
+- `darwin-vz` already provides a working unprivileged ext4 mutation pattern
+  that Firecracker can reuse
+
+Suggested internal package split:
+
+- `internal/ext4runtime` or `internal/ext4edit`
+  Shared ext4 mutation logic used by both `darwin-vz` and Firecracker.
+- `internal/hostruntime`
+  Typed request and response structs plus client interface.
+- `internal/hostruntime/client`
+  Unix-socket client for the supported Linux runtime.
+- `internal/hostd`
+  Root-owned daemon and state reconciliation logic.
+
+The Firecracker adapter should depend on `hostruntime.Client`, not on helper
+paths or raw command wrappers. The adapter should not own path resolution for
+the supported host runtime.
+
+## Implementation slices
+
+### Slice 1: unprivileged rootfs prep
+
+- Extract shared ext4 mutation helpers from `darwin-vz`.
+- Switch Firecracker runtime rootfs preparation to `debugfs`.
+- Remove rootfs-related privileged-runtime assumptions from the Firecracker
+  backend.
+- Update Firecracker doctor checks and docs.
+
+Definition of done:
+
+- Firecracker no longer calls the helper for `mount`, `umount`, `mkdir`, or
+  `install`.
+- Linux Firecracker requires `debugfs` for runtime rootfs preparation.
+
+### Slice 2: typed host-runtime client and daemon
+
+- Add `internal/hostruntime`.
+- Add `internal/hostd`.
+- Replace `runRootCommand`-style call sites with typed requests to `hostd`.
+- Add Unix-socket client wiring to the Firecracker backend.
+
+Definition of done:
+
+- Firecracker adapter does not build raw `iptables`, `ip`, or `sudo` helper
+  argv directly.
+- Linux Firecracker uses `hostd` at the standard socket.
+
+### Slice 3: network and gateway ownership in `hostd`
+
+- Implement gateway firewall and sandbox network lifecycle in the daemon.
+- Add lease persistence and startup reconciliation.
+
+Definition of done:
+
+- Firecracker uses `hostd` for network setup and teardown.
+- Owned network state is reconciled after restarts.
+
+### Slice 4: CLI integration and activation paths
+
+- Update `cleanroom serve` to connect to the standard `hostd` socket.
+- Add interactive transient bootstrap for local Linux `serve` when the socket is
+  missing.
+- Make transient bootstrap unavailable in non-interactive contexts.
+- Change Linux `cleanroom daemon install` to install the `hostd` bundle rather
+  than a global `cleanroom serve` unit.
+- Update `daemon status` to report host-runtime bundle health on Linux.
+
+Definition of done:
+
+- local `cleanroom serve` can bootstrap `hostd` once with sudo when needed
+- CI/non-interactive `cleanroom serve` fails fast instead of prompting
+- Linux `daemon install` manages `cleanroom-hostd.socket` and
+  `cleanroom-hostd.service`
+
+### Slice 5: `jailer` launch path
+
+- Add `hostd` support for jailed Firecracker launches.
+- Make `jailer` the supported Linux Firecracker launch path once `hostd` owns
+  VM launch.
+- Add doctor checks and operator docs for production mode.
+
+Definition of done:
+
+- Supported Linux Firecracker launches through `jailer`.
+- Cleanroom control service does not directly spawn Firecracker in supported
+  Linux runtime mode.
+
+## Recommended rollout
+
+Order matters:
+
+1. Eliminate rootfs privilege first.
+2. Introduce the typed host-runtime interface and `hostd`.
+3. Move network and gateway ownership into `hostd`.
+4. Add `serve`/`daemon install` integration around the standard `hostd`
+   runtime.
+5. Add `jailer` as the default launch path once daemonized launch exists.
+
+This gives immediate CI wins without blocking on the larger production runtime.
+
+## Recommendation
+
+Adopt both tracks, but sequence them deliberately:
+
+- **Near term:** make Firecracker rootfs preparation unprivileged and introduce
+  `hostd` as the Linux host runtime.
+- **Long term:** make `hostd + jailer` the supported Linux Firecracker runtime
+  with no helper-based fallback.
+
+That preserves Cleanroom's existing UX, respects the repository's
+backend-neutral design goals, and gives a practical path from today's CI setup
+to a materially stronger Linux host runtime.

--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/buildkite/cleanroom/internal/backend"
 	"github.com/buildkite/cleanroom/internal/bootassets"
+	"github.com/buildkite/cleanroom/internal/ext4edit"
 	"github.com/buildkite/cleanroom/internal/ext4image"
 	"github.com/buildkite/cleanroom/internal/gateway"
 	"github.com/buildkite/cleanroom/internal/hosttools"
@@ -1671,8 +1672,8 @@ var preparedRuntimeRootFSRequiredPaths = []string{
 
 func validatePreparedRuntimeRootFS(path string) error {
 	for _, requiredPath := range preparedRuntimeRootFSRequiredPaths {
-		if err := runDebugFS(path, false, fmt.Sprintf("stat %s", requiredPath)); err != nil {
-			return fmt.Errorf("required runtime file %q is missing or unreadable: %w", requiredPath, err)
+		if !ext4PathExists(path, requiredPath) {
+			return fmt.Errorf("required runtime file %q is missing or unreadable", requiredPath)
 		}
 	}
 	return validatePreparedRuntimeRootFSInitPathForLayout(
@@ -1683,7 +1684,6 @@ func validatePreparedRuntimeRootFS(path string) error {
 		},
 	)
 }
-
 func preparedRuntimeRootFSPath(imageDigest, guestAgentHash string) (string, error) {
 	cacheBase, err := paths.CacheBaseDir()
 	if err != nil {
@@ -1856,138 +1856,24 @@ func hashFileSHA256(path string) (string, error) {
 }
 
 func injectFileIntoExt4(imagePath, srcPath, dstPath string, mode os.FileMode) error {
-	cleanDst := filepath.Clean(dstPath)
-	if !strings.HasPrefix(cleanDst, "/") {
-		return fmt.Errorf("destination path %q must be absolute", dstPath)
-	}
-	if err := ensureExt4Dir(imagePath, filepath.Dir(cleanDst)); err != nil {
-		return err
-	}
-
-	if ext4PathExists(imagePath, cleanDst) {
-		_ = runDebugFS(imagePath, true, fmt.Sprintf("rm %s", cleanDst))
-	}
-	if err := runDebugFS(imagePath, true, fmt.Sprintf("write %s %s", srcPath, cleanDst)); err != nil {
-		return err
-	}
-	modeValue := fmt.Sprintf("%#o", uint32(0o100000)|uint32(mode.Perm()))
-	return runDebugFS(imagePath, true, fmt.Sprintf("set_inode_field %s mode %s", cleanDst, modeValue))
-}
-
-func ensureExt4Dir(imagePath, dir string) error {
-	cleanDir := filepath.Clean(dir)
-	if cleanDir == "." || cleanDir == "/" {
-		return nil
-	}
-	if !strings.HasPrefix(cleanDir, "/") {
-		cleanDir = "/" + cleanDir
-	}
-	parts := strings.Split(strings.TrimPrefix(cleanDir, "/"), "/")
-	cur := ""
-	for _, part := range parts {
-		if strings.TrimSpace(part) == "" {
-			continue
-		}
-		cur += "/" + part
-		if ext4PathExists(imagePath, cur) {
-			continue
-		}
-		if err := runDebugFS(imagePath, true, fmt.Sprintf("mkdir %s", cur)); err != nil {
-			return err
-		}
-	}
-	return nil
+	return ext4edit.InjectFile(imagePath, srcPath, dstPath, mode)
 }
 
 func ext4PathExists(imagePath, path string) bool {
-	return runDebugFS(imagePath, false, fmt.Sprintf("stat %s", path)) == nil
+	return ext4edit.PathExists(imagePath, path)
 }
 
 func ext4PathType(imagePath, path string) ext4PathKind {
-	output, err := runDebugFSOutput(imagePath, false, fmt.Sprintf("stat %s", path))
-	if err != nil {
+	switch ext4edit.PathType(imagePath, path) {
+	case ext4edit.PathKindDirectory:
+		return ext4PathKindDirectory
+	case ext4edit.PathKindRegular:
+		return ext4PathKindRegular
+	case ext4edit.PathKindSymlink:
+		return ext4PathKindSymlink
+	default:
 		return ext4PathKindUnknown
 	}
-	return debugFSStatType(output)
-}
-
-func runDebugFS(imagePath string, writable bool, command string) error {
-	_, err := runDebugFSOutput(imagePath, writable, command)
-	return err
-}
-
-func runDebugFSOutput(imagePath string, writable bool, command string) (string, error) {
-	debugfsBinary, err := hosttools.ResolveE2FSProgsBinary("debugfs")
-	if err != nil {
-		return "", fmt.Errorf("find debugfs for runtime rootfs preparation: %w", err)
-	}
-
-	args := make([]string, 0, 4)
-	if writable {
-		args = append(args, "-w")
-	}
-	args = append(args, "-R", command, imagePath)
-	cmd := exec.Command(debugfsBinary, args...)
-	output, err := cmd.CombinedOutput()
-	trimmedOutput := strings.TrimSpace(string(output))
-	if err != nil {
-		return "", fmt.Errorf("debugfs command %q failed: %w: %s", command, err, trimmedOutput)
-	}
-	if outputErr := debugFSCommandOutputError(trimmedOutput); outputErr != "" {
-		return "", fmt.Errorf("debugfs command %q reported error: %s", command, outputErr)
-	}
-	return trimmedOutput, nil
-}
-
-func debugFSCommandOutputError(output string) string {
-	trimmed := strings.TrimSpace(output)
-	if trimmed == "" {
-		return ""
-	}
-	for _, line := range strings.Split(trimmed, "\n") {
-		msg := strings.TrimSpace(line)
-		if msg == "" {
-			continue
-		}
-		lower := strings.ToLower(msg)
-		if strings.HasPrefix(lower, "debugfs ") {
-			// Version banner.
-			continue
-		}
-		if strings.Contains(lower, "file not found") ||
-			strings.Contains(lower, "ext2_lookup") ||
-			strings.Contains(lower, "command not found") ||
-			strings.Contains(lower, "no such file or directory") ||
-			strings.Contains(lower, "not a directory") {
-			return msg
-		}
-	}
-	return ""
-}
-
-func debugFSStatType(output string) ext4PathKind {
-	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
-		line = strings.TrimSpace(line)
-		if !strings.Contains(line, "Type:") {
-			continue
-		}
-		rest := line[strings.Index(line, "Type:")+len("Type:"):]
-		fields := strings.Fields(rest)
-		if len(fields) == 0 {
-			return ext4PathKindUnknown
-		}
-		switch strings.ToLower(fields[0]) {
-		case string(ext4PathKindDirectory):
-			return ext4PathKindDirectory
-		case string(ext4PathKindRegular):
-			return ext4PathKindRegular
-		case string(ext4PathKindSymlink):
-			return ext4PathKindSymlink
-		default:
-			return ext4PathKindUnknown
-		}
-	}
-	return ext4PathKindUnknown
 }
 
 func (a *Adapter) resolveKernelPath(ctx context.Context, configuredPath string) (path, notice string, err error) {

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/buildkite/cleanroom/internal/backend"
 	"github.com/buildkite/cleanroom/internal/bootassets"
+	"github.com/buildkite/cleanroom/internal/ext4edit"
 	"github.com/buildkite/cleanroom/internal/ext4image"
 	"github.com/buildkite/cleanroom/internal/gateway"
 	"github.com/buildkite/cleanroom/internal/hosttools"
@@ -98,14 +99,15 @@ type sandboxInstance struct {
 
 const runObservabilityFile = "execution-observability.json"
 const vsockDialRetryInterval = 50 * time.Millisecond
-const preparedRuntimeRootFSVersion = "v1"
+const preparedRuntimeRootFSVersion = "v2-debugfs"
 const defaultPrivilegedHelperPath = "/usr/local/sbin/cleanroom-root-helper"
 const helperCapabilityFirecrackerNetwork = "firecracker-network"
-const helperCapabilityFirecrackerRootFS = "firecracker-rootfs"
 const helperCapabilityFirecrackerZFS = "firecracker-zfs"
 const defaultDownloadMaxBytes int64 = 10 * 1024 * 1024
 const snapshotSyncTimeoutSeconds = 10
 const networkCleanupTimeout = 5 * time.Second
+const guestInitScriptPathSbin = "/sbin/cleanroom-init"
+const guestInitScriptPathUsrSbin = "/usr/sbin/cleanroom-init"
 
 var tapDeleteRetryInterval = 100 * time.Millisecond
 
@@ -733,6 +735,15 @@ func (a *Adapter) Doctor(_ context.Context, req backend.DoctorRequest) (*backend
 	} else {
 		appendCheck("mkfs_ext4", "pass", fmt.Sprintf("found mkfs.ext4 (%s) for OCI rootfs materialisation", mkfsPath))
 	}
+	if debugfsPath, err := hosttools.ResolveE2FSProgsBinary("debugfs"); err != nil {
+		status := "fail"
+		if runtime.GOOS == "darwin" {
+			status = "warn"
+		}
+		appendCheck("debugfs", status, fmt.Sprintf("debugfs not available: %v", err))
+	} else {
+		appendCheck("debugfs", "pass", fmt.Sprintf("found debugfs (%s) for runtime rootfs preparation", debugfsPath))
+	}
 
 	if req.GuestPort == 0 {
 		appendCheck("vsock_port", "pass", fmt.Sprintf("using default guest vsock port %d", vsockexec.DefaultPort))
@@ -1006,7 +1017,7 @@ func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream 
 		BootSource: bootSource{
 			KernelImagePath: kernelPath,
 			BootArgs: fmt.Sprintf(
-				"console=ttyS0 reboot=k panic=1 pci=off init=/sbin/cleanroom-init random.trust_cpu=on cleanroom_guest_ip=%s cleanroom_guest_gw=%s cleanroom_guest_mask=24 cleanroom_guest_dns=1.1.1.1 cleanroom_guest_port=%d %s",
+				"console=ttyS0 reboot=k panic=1 pci=off init=/usr/sbin/cleanroom-init random.trust_cpu=on cleanroom_guest_ip=%s cleanroom_guest_gw=%s cleanroom_guest_mask=24 cleanroom_guest_dns=1.1.1.1 cleanroom_guest_port=%d %s",
 				networkCfg.GuestIP,
 				networkCfg.HostIP,
 				req.GuestPort,
@@ -1334,7 +1345,7 @@ func (a *Adapter) ensurePreparedRuntimeRootFS(ctx context.Context, cfg backend.F
 	if err := copyFile(sourcePath, tmpPath); err != nil {
 		return "", fmt.Errorf("copy rootfs image for runtime preparation: %w", err)
 	}
-	if err := a.installGuestRuntimeIntoRootFS(ctx, cfg, tmpPath, guestAgentPath); err != nil {
+	if err := a.installGuestRuntimeIntoRootFS(tmpPath, guestAgentPath); err != nil {
 		_ = os.Remove(tmpPath)
 		return "", err
 	}
@@ -1362,24 +1373,10 @@ func runtimeRootFSCacheKey(imageDigest, guestAgentHash string) string {
 	return hex.EncodeToString(sum[:])
 }
 
-func (a *Adapter) installGuestRuntimeIntoRootFS(ctx context.Context, cfg backend.FirecrackerConfig, rootFSPath, guestAgentPath string) error {
-	// Keep mount points in /tmp so helper-mode path allowlisting stays stable
-	// regardless of TMPDIR environment overrides.
-	mountDir, err := os.MkdirTemp("/tmp", "cleanroom-firecracker-rootfs-*")
-	if err != nil {
-		return fmt.Errorf("create temporary rootfs mount directory: %w", err)
+func (a *Adapter) installGuestRuntimeIntoRootFS(rootFSPath, guestAgentPath string) error {
+	if _, err := hosttools.ResolveE2FSProgsBinary("debugfs"); err != nil {
+		return fmt.Errorf("find debugfs for runtime rootfs preparation: %w", err)
 	}
-	defer os.RemoveAll(mountDir)
-
-	if err := runRootCommand(ctx, cfg, "mount", "-o", "loop", rootFSPath, mountDir); err != nil {
-		return fmt.Errorf("mount rootfs image for runtime preparation: %w", err)
-	}
-	mounted := true
-	defer func() {
-		if mounted {
-			_ = runRootCommand(context.Background(), cfg, "umount", mountDir)
-		}
-	}()
 
 	initScriptPath, err := createGuestInitScript()
 	if err != nil {
@@ -1387,19 +1384,17 @@ func (a *Adapter) installGuestRuntimeIntoRootFS(ctx context.Context, cfg backend
 	}
 	defer os.Remove(initScriptPath)
 
-	if err := runRootCommand(ctx, cfg, "mkdir", "-p", filepath.Join(mountDir, "usr/local/bin"), filepath.Join(mountDir, "sbin")); err != nil {
-		return fmt.Errorf("prepare runtime directories in mounted rootfs: %w", err)
+	if err := ext4edit.InjectFile(rootFSPath, guestAgentPath, "/usr/local/bin/cleanroom-guest-agent", 0o755); err != nil {
+		return fmt.Errorf("inject guest agent into rootfs image: %w", err)
 	}
-	if err := runRootCommand(ctx, cfg, "install", "-m", "0755", guestAgentPath, filepath.Join(mountDir, "usr/local/bin/cleanroom-guest-agent")); err != nil {
-		return fmt.Errorf("install guest agent into mounted rootfs: %w", err)
+	if err := ext4edit.InjectFile(rootFSPath, initScriptPath, guestInitScriptPathUsrSbin, 0o755); err != nil {
+		return fmt.Errorf("inject cleanroom init into rootfs image (%s): %w", guestInitScriptPathUsrSbin, err)
 	}
-	if err := runRootCommand(ctx, cfg, "install", "-m", "0755", initScriptPath, filepath.Join(mountDir, "sbin/cleanroom-init")); err != nil {
-		return fmt.Errorf("install cleanroom init into mounted rootfs: %w", err)
+	if ext4edit.PathType(rootFSPath, "/sbin") == ext4edit.PathKindDirectory {
+		if err := ext4edit.InjectFile(rootFSPath, initScriptPath, guestInitScriptPathSbin, 0o755); err != nil {
+			return fmt.Errorf("inject cleanroom init into rootfs image (%s): %w", guestInitScriptPathSbin, err)
+		}
 	}
-	if err := runRootCommand(ctx, cfg, "umount", mountDir); err != nil {
-		return fmt.Errorf("unmount prepared rootfs image: %w", err)
-	}
-	mounted = false
 	return nil
 }
 
@@ -1616,7 +1611,7 @@ func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID strin
 		BootSource: bootSource{
 			KernelImagePath: kernelPath,
 			BootArgs: fmt.Sprintf(
-				"console=ttyS0 reboot=k panic=1 pci=off init=/sbin/cleanroom-init random.trust_cpu=on cleanroom_guest_ip=%s cleanroom_guest_gw=%s cleanroom_guest_mask=24 cleanroom_guest_dns=1.1.1.1 cleanroom_guest_port=%d %s",
+				"console=ttyS0 reboot=k panic=1 pci=off init=/usr/sbin/cleanroom-init random.trust_cpu=on cleanroom_guest_ip=%s cleanroom_guest_gw=%s cleanroom_guest_mask=24 cleanroom_guest_dns=1.1.1.1 cleanroom_guest_port=%d %s",
 				networkCfg.GuestIP,
 				networkCfg.HostIP,
 				cfg.GuestPort,
@@ -2352,7 +2347,6 @@ func resolvePrivilegedHelperPath(cfg backend.FirecrackerConfig) string {
 func helperRequiredCapabilities(cfg backend.FirecrackerConfig) []string {
 	required := []string{
 		helperCapabilityFirecrackerNetwork,
-		helperCapabilityFirecrackerRootFS,
 	}
 
 	snapshotDriver := strings.ToLower(strings.TrimSpace(cfg.Snapshots.Driver))

--- a/internal/backend/firecracker/privileged_test.go
+++ b/internal/backend/firecracker/privileged_test.go
@@ -135,7 +135,7 @@ func TestRunRootCommandOutputInvokesHelper(t *testing.T) {
 	helperPath := filepath.Join(tmpDir, "cleanroom-root-helper")
 	setupFakeSudo(t, sudoLogPath)
 
-	helperScript := "#!/bin/sh\nset -eu\nprintf '%s\\n' \"$*\" >> \"$HELPER_LOG_PATH\"\nprintf 'firecracker-network\\nfirecracker-rootfs\\n'\n"
+	helperScript := "#!/bin/sh\nset -eu\nprintf '%s\\n' \"$*\" >> \"$HELPER_LOG_PATH\"\nprintf 'firecracker-network\\n'\n"
 	if err := os.WriteFile(helperPath, []byte(helperScript), 0o755); err != nil {
 		t.Fatalf("write helper script: %v", err)
 	}
@@ -149,7 +149,7 @@ func TestRunRootCommandOutputInvokesHelper(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runRootCommandOutput: %v", err)
 	}
-	if got, want := strings.TrimSpace(string(out)), "firecracker-network\nfirecracker-rootfs"; got != want {
+	if got, want := strings.TrimSpace(string(out)), "firecracker-network"; got != want {
 		t.Fatalf("unexpected helper output: got %q want %q", got, want)
 	}
 
@@ -386,7 +386,6 @@ func TestHelperRequiredCapabilitiesIncludesZFSWhenConfigured(t *testing.T) {
 	got := helperRequiredCapabilities(backend.FirecrackerConfig{})
 	want := []string{
 		helperCapabilityFirecrackerNetwork,
-		helperCapabilityFirecrackerRootFS,
 	}
 	if strings.Join(got, ",") != strings.Join(want, ",") {
 		t.Fatalf("unexpected default helper capabilities: got %v want %v", got, want)
@@ -397,7 +396,6 @@ func TestHelperRequiredCapabilitiesIncludesZFSWhenConfigured(t *testing.T) {
 	})
 	want = []string{
 		helperCapabilityFirecrackerNetwork,
-		helperCapabilityFirecrackerRootFS,
 		helperCapabilityFirecrackerZFS,
 	}
 	if strings.Join(got, ",") != strings.Join(want, ",") {

--- a/internal/ext4edit/ext4edit.go
+++ b/internal/ext4edit/ext4edit.go
@@ -31,23 +31,43 @@ func InjectFile(imagePath, srcPath, dstPath string, mode os.FileMode) error {
 	}
 
 	if PathExists(imagePath, cleanDst) {
-		_ = runDebugFS(imagePath, true, fmt.Sprintf("rm %s", cleanDst))
+		rmCommand, err := debugFSCommand("rm", cleanDst)
+		if err != nil {
+			return err
+		}
+		_ = runDebugFS(imagePath, true, rmCommand)
 	}
-	if err := runDebugFS(imagePath, true, fmt.Sprintf("write %s %s", srcPath, cleanDst)); err != nil {
+	writeCommand, err := debugFSCommand("write", srcPath, cleanDst)
+	if err != nil {
+		return err
+	}
+	if err := runDebugFS(imagePath, true, writeCommand); err != nil {
 		return err
 	}
 	modeValue := fmt.Sprintf("%#o", uint32(0o100000)|uint32(mode.Perm()))
-	return runDebugFS(imagePath, true, fmt.Sprintf("set_inode_field %s mode %s", cleanDst, modeValue))
+	setModeCommand, err := debugFSSetInodeFieldCommand(cleanDst, "mode", modeValue)
+	if err != nil {
+		return err
+	}
+	return runDebugFS(imagePath, true, setModeCommand)
 }
 
 // PathExists reports whether the given path can be resolved inside the ext4 image.
 func PathExists(imagePath, path string) bool {
-	return runDebugFS(imagePath, false, fmt.Sprintf("stat %s", path)) == nil
+	command, err := debugFSCommand("stat", path)
+	if err != nil {
+		return false
+	}
+	return runDebugFS(imagePath, false, command) == nil
 }
 
 // PathType returns the ext4 inode type for the given path.
 func PathType(imagePath, path string) PathKind {
-	output, err := runDebugFSOutput(imagePath, false, fmt.Sprintf("stat %s", path))
+	command, err := debugFSCommand("stat", path)
+	if err != nil {
+		return PathKindUnknown
+	}
+	output, err := runDebugFSOutput(imagePath, false, command)
 	if err != nil {
 		return PathKindUnknown
 	}
@@ -125,11 +145,43 @@ func ensureDir(imagePath, dir string) error {
 		if PathExists(imagePath, cur) {
 			continue
 		}
-		if err := runDebugFS(imagePath, true, fmt.Sprintf("mkdir %s", cur)); err != nil {
+		command, err := debugFSCommand("mkdir", cur)
+		if err != nil {
+			return err
+		}
+		if err := runDebugFS(imagePath, true, command); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func debugFSCommand(name string, args ...string) (string, error) {
+	quotedArgs := make([]string, 0, len(args))
+	for _, arg := range args {
+		quoted, err := debugFSQuoteArg(arg)
+		if err != nil {
+			return "", err
+		}
+		quotedArgs = append(quotedArgs, quoted)
+	}
+	return strings.Join(append([]string{name}, quotedArgs...), " "), nil
+}
+
+func debugFSSetInodeFieldCommand(path, field, value string) (string, error) {
+	quotedPath, err := debugFSQuoteArg(path)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("set_inode_field %s %s %s", quotedPath, field, value), nil
+}
+
+func debugFSQuoteArg(arg string) (string, error) {
+	if strings.ContainsAny(arg, "\x00\r\n") {
+		return "", fmt.Errorf("debugfs argument %q contains an unsupported control character", arg)
+	}
+	escaped := strings.NewReplacer(`\`, `\\`, `"`, `\"`).Replace(arg)
+	return `"` + escaped + `"`, nil
 }
 
 func runDebugFS(imagePath string, writable bool, command string) error {

--- a/internal/ext4edit/ext4edit.go
+++ b/internal/ext4edit/ext4edit.go
@@ -24,6 +24,10 @@ const (
 
 // InjectFile copies a host file into an ext4 image and sets its final mode.
 func InjectFile(imagePath, srcPath, dstPath string, mode os.FileMode) error {
+	if err := ensureOwnerWritable(imagePath); err != nil {
+		return err
+	}
+
 	cleanDst := filepath.Clean(dstPath)
 	if !strings.HasPrefix(cleanDst, "/") {
 		return fmt.Errorf("destination path %q must be absolute", dstPath)
@@ -274,6 +278,21 @@ func isMissingPathError(err error) bool {
 	return strings.Contains(lower, "file not found") ||
 		strings.Contains(lower, "ext2_lookup") ||
 		strings.Contains(lower, "no such file or directory")
+}
+
+func ensureOwnerWritable(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat image %q: %w", path, err)
+	}
+	mode := info.Mode().Perm()
+	if mode&0o200 != 0 {
+		return nil
+	}
+	if err := os.Chmod(path, mode|0o200); err != nil {
+		return fmt.Errorf("make image %q owner-writable: %w", path, err)
+	}
+	return nil
 }
 
 func debugFSCommand(name string, args ...string) (string, error) {

--- a/internal/ext4edit/ext4edit.go
+++ b/internal/ext4edit/ext4edit.go
@@ -2,10 +2,12 @@
 package ext4edit
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/buildkite/cleanroom/internal/hosttools"
@@ -26,18 +28,20 @@ func InjectFile(imagePath, srcPath, dstPath string, mode os.FileMode) error {
 	if !strings.HasPrefix(cleanDst, "/") {
 		return fmt.Errorf("destination path %q must be absolute", dstPath)
 	}
-	if err := ensureDir(imagePath, filepath.Dir(cleanDst)); err != nil {
+	resolvedDir, err := ensureDir(imagePath, filepath.Dir(cleanDst))
+	if err != nil {
 		return err
 	}
+	resolvedDst := filepath.Join(resolvedDir, filepath.Base(cleanDst))
 
-	if PathExists(imagePath, cleanDst) {
-		rmCommand, err := debugFSCommand("rm", cleanDst)
+	if pathExistsDirect(imagePath, resolvedDst) {
+		rmCommand, err := debugFSCommand("rm", resolvedDst)
 		if err != nil {
 			return err
 		}
 		_ = runDebugFS(imagePath, true, rmCommand)
 	}
-	writeCommand, err := debugFSCommand("write", srcPath, cleanDst)
+	writeCommand, err := debugFSCommand("write", srcPath, resolvedDst)
 	if err != nil {
 		return err
 	}
@@ -45,7 +49,7 @@ func InjectFile(imagePath, srcPath, dstPath string, mode os.FileMode) error {
 		return err
 	}
 	modeValue := fmt.Sprintf("%#o", uint32(0o100000)|uint32(mode.Perm()))
-	setModeCommand, err := debugFSSetInodeFieldCommand(cleanDst, "mode", modeValue)
+	setModeCommand, err := debugFSSetInodeFieldCommand(resolvedDst, "mode", modeValue)
 	if err != nil {
 		return err
 	}
@@ -54,20 +58,20 @@ func InjectFile(imagePath, srcPath, dstPath string, mode os.FileMode) error {
 
 // PathExists reports whether the given path can be resolved inside the ext4 image.
 func PathExists(imagePath, path string) bool {
-	command, err := debugFSCommand("stat", path)
+	resolvedPath, err := resolvePath(imagePath, path)
 	if err != nil {
 		return false
 	}
-	return runDebugFS(imagePath, false, command) == nil
+	return pathExistsDirect(imagePath, resolvedPath)
 }
 
 // PathType returns the ext4 inode type for the given path.
 func PathType(imagePath, path string) PathKind {
-	command, err := debugFSCommand("stat", path)
+	resolvedPath, err := resolvePath(imagePath, path)
 	if err != nil {
 		return PathKindUnknown
 	}
-	output, err := runDebugFSOutput(imagePath, false, command)
+	output, err := statPathDirect(imagePath, resolvedPath)
 	if err != nil {
 		return PathKindUnknown
 	}
@@ -127,33 +131,149 @@ func DebugFSStatType(output string) PathKind {
 	return PathKindUnknown
 }
 
-func ensureDir(imagePath, dir string) error {
+// DebugFSStatLinkTarget parses a debugfs `stat` response for a symlink target.
+func DebugFSStatLinkTarget(output string) (string, error) {
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		line = strings.TrimSpace(line)
+		for _, prefix := range []string{"Fast link dest:", "Long link dest:"} {
+			if !strings.HasPrefix(line, prefix) {
+				continue
+			}
+			target := strings.TrimSpace(strings.TrimPrefix(line, prefix))
+			if target == "" {
+				return "", errors.New("debugfs stat did not include a symlink target")
+			}
+			if unquoted, err := strconv.Unquote(target); err == nil {
+				return unquoted, nil
+			}
+			return strings.Trim(target, `"`), nil
+		}
+	}
+	return "", errors.New("debugfs stat did not include a symlink target")
+}
+
+func ensureDir(imagePath, dir string) (string, error) {
 	cleanDir := filepath.Clean(dir)
 	if cleanDir == "." || cleanDir == "/" {
-		return nil
+		return "/", nil
 	}
 	if !strings.HasPrefix(cleanDir, "/") {
 		cleanDir = "/" + cleanDir
 	}
-	parts := strings.Split(strings.TrimPrefix(cleanDir, "/"), "/")
-	cur := ""
-	for _, part := range parts {
+	return resolveDir(imagePath, cleanDir, true)
+}
+
+func resolvePath(imagePath, path string) (string, error) {
+	cleanPath := filepath.Clean(path)
+	if cleanPath == "." || cleanPath == "/" {
+		return "/", nil
+	}
+	if !strings.HasPrefix(cleanPath, "/") {
+		cleanPath = "/" + cleanPath
+	}
+	resolvedDir, err := resolveDir(imagePath, filepath.Dir(cleanPath), false)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(resolvedDir, filepath.Base(cleanPath)), nil
+}
+
+func resolveDir(imagePath, dir string, createMissing bool) (string, error) {
+	cleanDir := filepath.Clean(dir)
+	if cleanDir == "." || cleanDir == "/" {
+		return "/", nil
+	}
+	if !strings.HasPrefix(cleanDir, "/") {
+		cleanDir = "/" + cleanDir
+	}
+
+	cur := "/"
+	remaining := strings.Split(strings.TrimPrefix(cleanDir, "/"), "/")
+	symlinkDepth := 0
+
+	for len(remaining) > 0 {
+		part := remaining[0]
+		remaining = remaining[1:]
 		if strings.TrimSpace(part) == "" {
 			continue
 		}
-		cur += "/" + part
-		if PathExists(imagePath, cur) {
-			continue
-		}
-		command, err := debugFSCommand("mkdir", cur)
+
+		candidate := filepath.Join(cur, part)
+		output, err := statPathDirect(imagePath, candidate)
 		if err != nil {
-			return err
+			if createMissing && isMissingPathError(err) {
+				command, commandErr := debugFSCommand("mkdir", candidate)
+				if commandErr != nil {
+					return "", commandErr
+				}
+				if err := runDebugFS(imagePath, true, command); err != nil {
+					return "", err
+				}
+				cur = candidate
+				continue
+			}
+			return "", err
 		}
-		if err := runDebugFS(imagePath, true, command); err != nil {
-			return err
+
+		switch DebugFSStatType(output) {
+		case PathKindDirectory:
+			cur = candidate
+		case PathKindSymlink:
+			target, err := DebugFSStatLinkTarget(output)
+			if err != nil {
+				return "", fmt.Errorf("resolve symlink %q: %w", candidate, err)
+			}
+			symlinkDepth++
+			if symlinkDepth > 40 {
+				return "", fmt.Errorf("resolve symlink %q: too many nested symlinks", candidate)
+			}
+
+			resolvedTarget := target
+			if !strings.HasPrefix(resolvedTarget, "/") {
+				resolvedTarget = filepath.Join(filepath.Dir(candidate), resolvedTarget)
+			}
+			cur = "/"
+			remaining = append(splitExt4Path(resolvedTarget), remaining...)
+		default:
+			return "", fmt.Errorf("path %q exists but is not a directory", candidate)
 		}
 	}
-	return nil
+
+	return cur, nil
+}
+
+func splitExt4Path(path string) []string {
+	cleanPath := filepath.Clean(path)
+	if cleanPath == "." || cleanPath == "/" {
+		return nil
+	}
+	if !strings.HasPrefix(cleanPath, "/") {
+		cleanPath = "/" + cleanPath
+	}
+	return strings.Split(strings.TrimPrefix(cleanPath, "/"), "/")
+}
+
+func pathExistsDirect(imagePath, path string) bool {
+	_, err := statPathDirect(imagePath, path)
+	return err == nil
+}
+
+func statPathDirect(imagePath, path string) (string, error) {
+	command, err := debugFSCommand("stat", path)
+	if err != nil {
+		return "", err
+	}
+	return runDebugFSOutput(imagePath, false, command)
+}
+
+func isMissingPathError(err error) bool {
+	if err == nil {
+		return false
+	}
+	lower := strings.ToLower(err.Error())
+	return strings.Contains(lower, "file not found") ||
+		strings.Contains(lower, "ext2_lookup") ||
+		strings.Contains(lower, "no such file or directory")
 }
 
 func debugFSCommand(name string, args ...string) (string, error) {

--- a/internal/ext4edit/ext4edit.go
+++ b/internal/ext4edit/ext4edit.go
@@ -1,0 +1,161 @@
+// Package ext4edit mutates ext4 images in place using debugfs.
+package ext4edit
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/buildkite/cleanroom/internal/hosttools"
+)
+
+type PathKind string
+
+const (
+	PathKindUnknown   PathKind = ""
+	PathKindDirectory PathKind = "directory"
+	PathKindRegular   PathKind = "regular"
+	PathKindSymlink   PathKind = "symlink"
+)
+
+// InjectFile copies a host file into an ext4 image and sets its final mode.
+func InjectFile(imagePath, srcPath, dstPath string, mode os.FileMode) error {
+	cleanDst := filepath.Clean(dstPath)
+	if !strings.HasPrefix(cleanDst, "/") {
+		return fmt.Errorf("destination path %q must be absolute", dstPath)
+	}
+	if err := ensureDir(imagePath, filepath.Dir(cleanDst)); err != nil {
+		return err
+	}
+
+	if PathExists(imagePath, cleanDst) {
+		_ = runDebugFS(imagePath, true, fmt.Sprintf("rm %s", cleanDst))
+	}
+	if err := runDebugFS(imagePath, true, fmt.Sprintf("write %s %s", srcPath, cleanDst)); err != nil {
+		return err
+	}
+	modeValue := fmt.Sprintf("%#o", uint32(0o100000)|uint32(mode.Perm()))
+	return runDebugFS(imagePath, true, fmt.Sprintf("set_inode_field %s mode %s", cleanDst, modeValue))
+}
+
+// PathExists reports whether the given path can be resolved inside the ext4 image.
+func PathExists(imagePath, path string) bool {
+	return runDebugFS(imagePath, false, fmt.Sprintf("stat %s", path)) == nil
+}
+
+// PathType returns the ext4 inode type for the given path.
+func PathType(imagePath, path string) PathKind {
+	output, err := runDebugFSOutput(imagePath, false, fmt.Sprintf("stat %s", path))
+	if err != nil {
+		return PathKindUnknown
+	}
+	return DebugFSStatType(output)
+}
+
+// DebugFSCommandOutputError extracts actionable debugfs stderr/stdout error text.
+func DebugFSCommandOutputError(output string) string {
+	trimmed := strings.TrimSpace(output)
+	if trimmed == "" {
+		return ""
+	}
+	for _, line := range strings.Split(trimmed, "\n") {
+		msg := strings.TrimSpace(line)
+		if msg == "" {
+			continue
+		}
+		lower := strings.ToLower(msg)
+		if strings.HasPrefix(lower, "debugfs ") {
+			// Version banner.
+			continue
+		}
+		if strings.Contains(lower, "file not found") ||
+			strings.Contains(lower, "ext2_lookup") ||
+			strings.Contains(lower, "command not found") ||
+			strings.Contains(lower, "no such file or directory") ||
+			strings.Contains(lower, "not a directory") {
+			return msg
+		}
+	}
+	return ""
+}
+
+// DebugFSStatType parses a debugfs `stat` response into a PathKind.
+func DebugFSStatType(output string) PathKind {
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.Contains(line, "Type:") {
+			continue
+		}
+		rest := line[strings.Index(line, "Type:")+len("Type:"):]
+		fields := strings.Fields(rest)
+		if len(fields) == 0 {
+			return PathKindUnknown
+		}
+		switch strings.ToLower(fields[0]) {
+		case string(PathKindDirectory):
+			return PathKindDirectory
+		case string(PathKindRegular):
+			return PathKindRegular
+		case string(PathKindSymlink):
+			return PathKindSymlink
+		default:
+			return PathKindUnknown
+		}
+	}
+	return PathKindUnknown
+}
+
+func ensureDir(imagePath, dir string) error {
+	cleanDir := filepath.Clean(dir)
+	if cleanDir == "." || cleanDir == "/" {
+		return nil
+	}
+	if !strings.HasPrefix(cleanDir, "/") {
+		cleanDir = "/" + cleanDir
+	}
+	parts := strings.Split(strings.TrimPrefix(cleanDir, "/"), "/")
+	cur := ""
+	for _, part := range parts {
+		if strings.TrimSpace(part) == "" {
+			continue
+		}
+		cur += "/" + part
+		if PathExists(imagePath, cur) {
+			continue
+		}
+		if err := runDebugFS(imagePath, true, fmt.Sprintf("mkdir %s", cur)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func runDebugFS(imagePath string, writable bool, command string) error {
+	_, err := runDebugFSOutput(imagePath, writable, command)
+	return err
+}
+
+func runDebugFSOutput(imagePath string, writable bool, command string) (string, error) {
+	debugfsBinary, err := hosttools.ResolveE2FSProgsBinary("debugfs")
+	if err != nil {
+		return "", fmt.Errorf("find debugfs for runtime rootfs preparation: %w", err)
+	}
+
+	args := make([]string, 0, 4)
+	if writable {
+		args = append(args, "-w")
+	}
+	args = append(args, "-R", command, imagePath)
+	cmd := exec.Command(debugfsBinary, args...)
+	output, err := cmd.CombinedOutput()
+	trimmedOutput := strings.TrimSpace(string(output))
+	if err != nil {
+		return "", fmt.Errorf("debugfs command %q failed: %w: %s", command, err, trimmedOutput)
+	}
+	if outputErr := DebugFSCommandOutputError(trimmedOutput); outputErr != "" {
+		return "", fmt.Errorf("debugfs command %q reported error: %s", command, outputErr)
+	}
+	return trimmedOutput, nil
+}

--- a/internal/ext4edit/ext4edit_test.go
+++ b/internal/ext4edit/ext4edit_test.go
@@ -2,6 +2,42 @@ package ext4edit
 
 import "testing"
 
+func TestDebugFSCommandQuotesArguments(t *testing.T) {
+	t.Parallel()
+
+	got, err := debugFSCommand("write", `/tmp/src with "quotes"`, `/dir with space/file\name`)
+	if err != nil {
+		t.Fatalf("debugFSCommand: %v", err)
+	}
+
+	want := `write "/tmp/src with \"quotes\"" "/dir with space/file\\name"`
+	if got != want {
+		t.Fatalf("unexpected command: got %q want %q", got, want)
+	}
+}
+
+func TestDebugFSSetInodeFieldCommandQuotesPath(t *testing.T) {
+	t.Parallel()
+
+	got, err := debugFSSetInodeFieldCommand(`/dir with space/file "quoted"`, "mode", "0100755")
+	if err != nil {
+		t.Fatalf("debugFSSetInodeFieldCommand: %v", err)
+	}
+
+	want := `set_inode_field "/dir with space/file \"quoted\"" mode 0100755`
+	if got != want {
+		t.Fatalf("unexpected command: got %q want %q", got, want)
+	}
+}
+
+func TestDebugFSQuoteArgRejectsControlCharacters(t *testing.T) {
+	t.Parallel()
+
+	if _, err := debugFSQuoteArg("/tmp/path\nwith-newline"); err == nil {
+		t.Fatal("expected control characters to be rejected")
+	}
+}
+
 func TestDebugFSCommandOutputErrorReportsMissingFile(t *testing.T) {
 	t.Parallel()
 

--- a/internal/ext4edit/ext4edit_test.go
+++ b/internal/ext4edit/ext4edit_test.go
@@ -136,6 +136,42 @@ func TestInjectFileFollowsSymlinkedParentDirectories(t *testing.T) {
 	}
 }
 
+func TestInjectFileMakesReadonlyImageOwnerWritable(t *testing.T) {
+	debugfsBinary, mkfsBinary, ok := requireDebugFSTools(t)
+	if !ok {
+		return
+	}
+
+	imagePath := createExt4Image(t, mkfsBinary)
+	createExt4Dir(t, debugfsBinary, imagePath, "/usr")
+	createExt4Dir(t, debugfsBinary, imagePath, "/usr/local")
+	createExt4Dir(t, debugfsBinary, imagePath, "/usr/local/bin")
+
+	if err := os.Chmod(imagePath, 0o444); err != nil {
+		t.Fatalf("chmod readonly image: %v", err)
+	}
+
+	srcPath := filepath.Join(t.TempDir(), "guest-agent")
+	if err := os.WriteFile(srcPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+
+	if err := InjectFile(imagePath, srcPath, "/usr/local/bin/cleanroom-guest-agent", 0o755); err != nil {
+		t.Fatalf("InjectFile: %v", err)
+	}
+
+	info, err := os.Stat(imagePath)
+	if err != nil {
+		t.Fatalf("stat image: %v", err)
+	}
+	if info.Mode().Perm()&0o200 == 0 {
+		t.Fatalf("expected image to become owner-writable, got mode %o", info.Mode().Perm())
+	}
+	if !PathExists(imagePath, "/usr/local/bin/cleanroom-guest-agent") {
+		t.Fatal("expected injected file to exist after mutating a readonly image")
+	}
+}
+
 func requireDebugFSTools(t *testing.T) (debugfsBinary, mkfsBinary string, ok bool) {
 	t.Helper()
 

--- a/internal/ext4edit/ext4edit_test.go
+++ b/internal/ext4edit/ext4edit_test.go
@@ -1,6 +1,4 @@
-//go:build darwin
-
-package darwinvz
+package ext4edit
 
 import "testing"
 
@@ -8,7 +6,7 @@ func TestDebugFSCommandOutputErrorReportsMissingFile(t *testing.T) {
 	t.Parallel()
 
 	output := "debugfs 1.47.3 (8-Jul-2025)\n/sbin: File not found by ext2_lookup while looking up \"/sbin\"\n"
-	got := debugFSCommandOutputError(output)
+	got := DebugFSCommandOutputError(output)
 	if got == "" {
 		t.Fatal("expected missing-file debugfs output to be treated as an error")
 	}
@@ -18,7 +16,7 @@ func TestDebugFSCommandOutputErrorReportsUnknownCommand(t *testing.T) {
 	t.Parallel()
 
 	output := "debugfs 1.47.3 (8-Jul-2025)\ndebugfs: Command not found writee\n"
-	got := debugFSCommandOutputError(output)
+	got := DebugFSCommandOutputError(output)
 	if got == "" {
 		t.Fatal("expected unknown-command debugfs output to be treated as an error")
 	}
@@ -28,7 +26,7 @@ func TestDebugFSCommandOutputErrorIgnoresSuccessfulOutput(t *testing.T) {
 	t.Parallel()
 
 	output := "debugfs 1.47.3 (8-Jul-2025)\nInode: 531   Type: regular    Mode:  0755   Flags: 0x80000\n"
-	if got := debugFSCommandOutputError(output); got != "" {
+	if got := DebugFSCommandOutputError(output); got != "" {
 		t.Fatalf("expected empty error for successful debugfs output, got %q", got)
 	}
 }
@@ -37,7 +35,7 @@ func TestDebugFSStatTypeParsesDirectory(t *testing.T) {
 	t.Parallel()
 
 	output := "debugfs 1.47.3 (8-Jul-2025)\nInode: 261   Type: directory    Mode:  0755   Flags: 0x80000\n"
-	if got, want := debugFSStatType(output), ext4PathKindDirectory; got != want {
+	if got, want := DebugFSStatType(output), PathKindDirectory; got != want {
 		t.Fatalf("unexpected stat type: got %q want %q", got, want)
 	}
 }
@@ -46,7 +44,7 @@ func TestDebugFSStatTypeParsesSymlink(t *testing.T) {
 	t.Parallel()
 
 	output := "debugfs 1.47.3 (8-Jul-2025)\nInode: 82   Type: symlink    Mode:  0755   Flags: 0x0\n"
-	if got, want := debugFSStatType(output), ext4PathKindSymlink; got != want {
+	if got, want := DebugFSStatType(output), PathKindSymlink; got != want {
 		t.Fatalf("unexpected stat type: got %q want %q", got, want)
 	}
 }

--- a/internal/ext4edit/ext4edit_test.go
+++ b/internal/ext4edit/ext4edit_test.go
@@ -1,6 +1,13 @@
 package ext4edit
 
-import "testing"
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/hosttools"
+)
 
 func TestDebugFSCommandQuotesArguments(t *testing.T) {
 	t.Parallel()
@@ -27,6 +34,19 @@ func TestDebugFSSetInodeFieldCommandQuotesPath(t *testing.T) {
 	want := `set_inode_field "/dir with space/file \"quoted\"" mode 0100755`
 	if got != want {
 		t.Fatalf("unexpected command: got %q want %q", got, want)
+	}
+}
+
+func TestDebugFSStatLinkTargetParsesFastLinkDest(t *testing.T) {
+	t.Parallel()
+
+	output := "debugfs 1.47.3 (8-Jul-2025)\nFast link dest: \"/usr/bin\"\n"
+	got, err := DebugFSStatLinkTarget(output)
+	if err != nil {
+		t.Fatalf("DebugFSStatLinkTarget: %v", err)
+	}
+	if got != "/usr/bin" {
+		t.Fatalf("unexpected symlink target: got %q want %q", got, "/usr/bin")
 	}
 }
 
@@ -82,5 +102,102 @@ func TestDebugFSStatTypeParsesSymlink(t *testing.T) {
 	output := "debugfs 1.47.3 (8-Jul-2025)\nInode: 82   Type: symlink    Mode:  0755   Flags: 0x0\n"
 	if got, want := DebugFSStatType(output), PathKindSymlink; got != want {
 		t.Fatalf("unexpected stat type: got %q want %q", got, want)
+	}
+}
+
+func TestInjectFileFollowsSymlinkedParentDirectories(t *testing.T) {
+	debugfsBinary, mkfsBinary, ok := requireDebugFSTools(t)
+	if !ok {
+		return
+	}
+
+	imagePath := createExt4Image(t, mkfsBinary)
+	createExt4Dir(t, debugfsBinary, imagePath, "/usr")
+	createExt4Dir(t, debugfsBinary, imagePath, "/usr/bin")
+	createExt4Symlink(t, debugfsBinary, imagePath, "/usr/sbin", "/usr/bin")
+
+	srcPath := filepath.Join(t.TempDir(), "cleanroom init with spaces.sh")
+	if err := os.WriteFile(srcPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+
+	if err := InjectFile(imagePath, srcPath, "/usr/sbin/cleanroom-init", 0o755); err != nil {
+		t.Fatalf("InjectFile: %v", err)
+	}
+
+	if got, want := PathType(imagePath, "/usr/sbin"), PathKindSymlink; got != want {
+		t.Fatalf("unexpected /usr/sbin type: got %q want %q", got, want)
+	}
+	if !PathExists(imagePath, "/usr/sbin/cleanroom-init") {
+		t.Fatal("expected injected file to be reachable via symlinked /usr/sbin path")
+	}
+	if !PathExists(imagePath, "/usr/bin/cleanroom-init") {
+		t.Fatal("expected injected file to be written to the symlink target directory")
+	}
+}
+
+func requireDebugFSTools(t *testing.T) (debugfsBinary, mkfsBinary string, ok bool) {
+	t.Helper()
+
+	debugfsBinary, err := hosttools.ResolveE2FSProgsBinary("debugfs")
+	if err != nil {
+		t.Skipf("debugfs unavailable: %v", err)
+		return "", "", false
+	}
+	mkfsBinary, err = hosttools.ResolveE2FSProgsBinary("mkfs.ext4")
+	if err != nil {
+		t.Skipf("mkfs.ext4 unavailable: %v", err)
+		return "", "", false
+	}
+	return debugfsBinary, mkfsBinary, true
+}
+
+func createExt4Image(t *testing.T, mkfsBinary string) string {
+	t.Helper()
+
+	imagePath := filepath.Join(t.TempDir(), "test.ext4")
+	f, err := os.Create(imagePath)
+	if err != nil {
+		t.Fatalf("create ext4 image: %v", err)
+	}
+	if err := f.Truncate(16 * 1024 * 1024); err != nil {
+		_ = f.Close()
+		t.Fatalf("size ext4 image: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close ext4 image: %v", err)
+	}
+	if out, err := exec.Command(mkfsBinary, "-q", "-F", imagePath).CombinedOutput(); err != nil {
+		t.Fatalf("mkfs.ext4: %v (%s)", err, string(out))
+	}
+	return imagePath
+}
+
+func createExt4Dir(t *testing.T, debugfsBinary, imagePath, dir string) {
+	t.Helper()
+	runDebugFSCommand(t, debugfsBinary, imagePath, "mkdir", dir)
+}
+
+func createExt4Symlink(t *testing.T, debugfsBinary, imagePath, linkPath, target string) {
+	t.Helper()
+
+	command, err := debugFSCommand("symlink", linkPath, target)
+	if err != nil {
+		t.Fatalf("build symlink command: %v", err)
+	}
+	if out, err := exec.Command(debugfsBinary, "-w", "-R", command, imagePath).CombinedOutput(); err != nil {
+		t.Fatalf("debugfs symlink: %v (%s)", err, string(out))
+	}
+}
+
+func runDebugFSCommand(t *testing.T, debugfsBinary, imagePath, name string, args ...string) {
+	t.Helper()
+
+	command, err := debugFSCommand(name, args...)
+	if err != nil {
+		t.Fatalf("build debugfs command: %v", err)
+	}
+	if out, err := exec.Command(debugfsBinary, "-w", "-R", command, imagePath).CombinedOutput(); err != nil {
+		t.Fatalf("debugfs %s: %v (%s)", name, err, string(out))
 	}
 }

--- a/scripts/ci-cleanroom-e2e.sh
+++ b/scripts/ci-cleanroom-e2e.sh
@@ -7,7 +7,6 @@ PRIVILEGED_HELPER_PATH="${CLEANROOM_PRIVILEGED_HELPER_PATH:-/usr/local/sbin/clea
 
 ROOT_HELPER_REQUIRED_CAPABILITIES=(
   firecracker-network
-  firecracker-rootfs
 )
 
 if [[ -z "$KERNEL_IMAGE" ]]; then
@@ -74,8 +73,8 @@ verify_helper_capabilities() {
 }
 
 # purge_stale_cleanroom_resources removes TAP devices, iptables rules,
-# firecracker processes, and temp mount dirs left over from a previous
-# run that crashed before cleanup.
+# and firecracker processes left over from a previous run that crashed
+# before cleanup.
 purge_stale_cleanroom_resources() {
   # Kill orphaned firecracker processes owned by the current user.
   local stale_pids
@@ -115,14 +114,6 @@ purge_stale_cleanroom_resources() {
     # shellcheck disable=SC2086
     run_privileged iptables -t nat ${rule/-A/-D} 2>/dev/null || true
   done <<< "$nat_rules"
-
-  # Unmount and remove stale rootfs temp dirs.
-  for mnt in /tmp/cleanroom-firecracker-rootfs-*; do
-    [[ -d "$mnt" ]] || continue
-    echo "cleaning stale mount: $mnt"
-    run_privileged umount "$mnt" 2>/dev/null || true
-    rm -rf "$mnt" 2>/dev/null || true
-  done
 }
 
 verify_helper_capabilities

--- a/scripts/cleanroom-root-helper.sh
+++ b/scripts/cleanroom-root-helper.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 # - Helper updates must land on hosts before branches that depend on new capabilities can pass.
 
 helper_contract_version() {
-  echo "2"
+  echo "3"
 }
 
 helper_has_zfs() {
@@ -23,7 +23,6 @@ helper_has_zfs() {
 helper_capabilities() {
   cat <<'EOF'
 firecracker-network
-firecracker-rootfs
 EOF
 
   if helper_has_zfs; then
@@ -42,24 +41,9 @@ require_root() {
   fi
 }
 
-is_tmp_mount_dir() {
-  local p="$1"
-  [[ "$p" == /tmp/cleanroom-firecracker-rootfs-* ]]
-}
-
-is_runtime_rootfs_tmp() {
-  local p="$1"
-  [[ "$p" == /var/lib/buildkite-agent/.cache/cleanroom/firecracker/runtime-rootfs/*.ext4.tmp-* ]]
-}
-
 is_runtime_rootfs_image() {
   local p="$1"
   [[ "$p" == */cleanroom/firecracker/runtime-rootfs/*.ext4 ]]
-}
-
-is_mounted_rootfs_dest() {
-  local p="$1"
-  [[ "$p" == /tmp/cleanroom-firecracker-rootfs-*/usr/local/bin/cleanroom-guest-agent || "$p" == /tmp/cleanroom-firecracker-rootfs-*/sbin/cleanroom-init ]]
 }
 
 is_tap_name() {
@@ -80,11 +64,6 @@ is_ipv4() {
 is_cidr() {
   local v="$1"
   [[ "$v" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}/[0-9]{1,2}$ ]]
-}
-
-is_install_source() {
-  local p="$1"
-  [[ "$p" == /var/lib/buildkite-agent/builds/*/buildkite/cleanroom/dist/cleanroom-guest-agent || "$p" == /tmp/cleanroom-init-* ]]
 }
 
 is_zfs_dataset() {
@@ -281,39 +260,6 @@ run_sysctl() {
   die "sysctl: unsupported arguments"
 }
 
-run_mount() {
-  [[ "$#" -eq 4 ]] || die "mount: expected '-o loop <image> <mount-dir>'"
-  [[ "$1" == "-o" && "$2" == "loop" ]] || die "mount: unsupported flags"
-  is_runtime_rootfs_tmp "$3" || die "mount: unsupported image path"
-  is_tmp_mount_dir "$4" || die "mount: unsupported mount path"
-  exec /usr/bin/mount -o loop "$3" "$4"
-}
-
-run_umount() {
-  [[ "$#" -eq 1 ]] || die "umount: expected '<mount-dir>'"
-  is_tmp_mount_dir "$1" || die "umount: unsupported mount path"
-  exec /usr/bin/umount "$1"
-}
-
-run_mkdir() {
-  [[ "$#" -eq 3 ]] || die "mkdir: expected '-p <path1> <path2>'"
-  [[ "$1" == "-p" ]] || die "mkdir: unsupported arguments"
-  [[ "$2" == /tmp/cleanroom-firecracker-rootfs-*/usr/local/bin ]] || die "mkdir: unsupported path '$2'"
-  [[ "$3" == /tmp/cleanroom-firecracker-rootfs-*/sbin ]] || die "mkdir: unsupported path '$3'"
-  exec /usr/bin/mkdir -p "$2" "$3"
-}
-
-run_install() {
-  [[ "$#" -eq 4 ]] || die "install: expected '-m 0755 <src> <dest>'"
-  [[ "$1" == "-m" && "$2" == "0755" ]] || die "install: unsupported mode"
-  local src="$3"
-  local dst="$4"
-  [[ -f "$src" ]] || die "install: source file not found"
-  is_install_source "$src" || die "install: unsupported source path"
-  is_mounted_rootfs_dest "$dst" || die "install: unsupported destination path"
-  exec /usr/bin/install -m 0755 "$src" "$dst"
-}
-
 run_zfs() {
   [[ "$#" -ge 1 ]] || die "zfs: missing arguments"
   local bin
@@ -409,18 +355,6 @@ main() {
       ;;
     sysctl)
       run_sysctl "$@"
-      ;;
-    mount)
-      run_mount "$@"
-      ;;
-    umount)
-      run_umount "$@"
-      ;;
-    mkdir)
-      run_mkdir "$@"
-      ;;
-    install)
-      run_install "$@"
       ;;
     zfs)
       run_zfs "$@"

--- a/scripts/root_helper_test.go
+++ b/scripts/root_helper_test.go
@@ -20,7 +20,6 @@ func TestCleanroomRootHelperDeclaresCapabilitiesAndZFSSupport(t *testing.T) {
 		"helper_has_zfs()",
 		"helper_capabilities()",
 		"firecracker-network",
-		"firecracker-rootfs",
 		"firecracker-zfs",
 		"    version)",
 		"    capabilities)",


### PR DESCRIPTION
## Summary
- add the Firecracker host-runtime proposal doc for the broader privilege-reduction work
- move ext4 editing into a shared package and switch Firecracker runtime rootfs prep from loop mounts to `debugfs`
- remove the stale rootfs helper capability and helper commands that are no longer needed

## Details
This lands the first implementation slice from the proposal rather than the full `hostd`/`jailer` architecture.

What changed:
- extracted shared ext4 image mutation helpers into `internal/ext4edit`
- updated Firecracker runtime rootfs preparation to inject `cleanroom-guest-agent` and `cleanroom-init` without root
- added a Firecracker `doctor` check for `debugfs`
- bumped the prepared Firecracker runtime rootfs cache key version to invalidate older prepared images
- reduced the root helper surface to privileged networking and optional ZFS operations
- removed stale CI cleanup for loop-mounted Firecracker rootfs temp dirs
- updated Firecracker/CI docs to reflect the new host requirements

## Verification
- `bash -n scripts/cleanroom-root-helper.sh scripts/ci-cleanroom-e2e.sh`
- `mise exec -- go test ./internal/ext4edit ./internal/backend/firecracker ./internal/backend/darwinvz ./scripts/...`
- `mise exec -- go test ./...`
