### PR TITLE
feat: harden bootstrap and move terraform defaults to sydney

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -130,7 +130,7 @@ mise run ci:bootstrap:linux:logs
 Task defaults:
 
 - `CLEANROOM_CI_AWS_PROFILE=buildkite-sandbox-pipelines-admin`
-- `CLEANROOM_CI_AWS_REGION=us-west-2`
+- `CLEANROOM_CI_AWS_REGION=ap-southeast-2`
 - `CLEANROOM_CI_INSTANCE_ID` overrides Terraform lookup
 - `CLEANROOM_CI_TERRAFORM_DIR=infra/terraform/envs/ci`
 

--- a/infra/terraform/envs/ci/README.md
+++ b/infra/terraform/envs/ci/README.md
@@ -75,7 +75,7 @@ mise run ci:bootstrap:linux:logs
 Task defaults:
 
 - `CLEANROOM_CI_AWS_PROFILE=buildkite-sandbox-pipelines-admin`
-- `CLEANROOM_CI_AWS_REGION=us-west-2`
+- `CLEANROOM_CI_AWS_REGION=ap-southeast-2`
 - `CLEANROOM_CI_INSTANCE_ID` overrides Terraform lookup
 - `CLEANROOM_CI_TERRAFORM_DIR=infra/terraform/envs/ci`
 
@@ -89,7 +89,7 @@ instance_id="$(mise x -- terraform -chdir=infra/terraform/envs/ci output -raw ma
 
 # Rerun bootstrap in place over SSM
 AWS_PROFILE=buildkite-sandbox-pipelines-admin aws ssm send-command \
-  --region us-west-2 \
+  --region ap-southeast-2 \
   --instance-ids "$instance_id" \
   --document-name AWS-RunShellScript \
   --parameters '{"commands":["sudo env PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin /usr/local/bin/cleanroom-bootstrap-macos"]}'

--- a/infra/terraform/envs/ci/bootstrap_defaults_test.go
+++ b/infra/terraform/envs/ci/bootstrap_defaults_test.go
@@ -113,6 +113,10 @@ func TestLinuxBootstrapScriptInstallsRerunnableBootstrapCommand(t *testing.T) {
 	requireContains(t, scriptPath, "CLEANROOM_BOOTSTRAP_REPO_REF")
 	requireContains(t, scriptPath, "CLEANROOM_BOOTSTRAP_SETUP_SCRIPT_PATH")
 	requireContains(t, scriptPath, "CLEANROOM_BOOTSTRAP_DEPLOY_KEY_PARAM")
+	requireContains(t, scriptPath, "TAILSCALE_AUTH_KEY_PARAMETER_NAME='$bootstrap_tailscale_param'")
+	requireContains(t, scriptPath, "export CLEANROOM_TAILSCALE_AUTH_KEY_PARAMETER_NAME=\"$TAILSCALE_AUTH_KEY_PARAMETER_NAME\"")
+	requireContains(t, scriptPath, "export CLEANROOM_TAILSCALE_VERSION=\"$TAILSCALE_VERSION\"")
+	requireContains(t, scriptPath, "export CLEANROOM_TAILSCALE_HOSTNAME_PREFIX=\"$TAILSCALE_HOSTNAME_PREFIX\"")
 	requireContains(t, scriptPath, "chmod 0755 \"$bootstrap_runner_path\"")
 }
 
@@ -138,6 +142,15 @@ func TestUserDataInstallsAwsCliWithoutAptAwscliDependency(t *testing.T) {
 	templatePath := filepath.Join("..", "..", "modules", "linux-host", "templates", "user_data.sh.tftpl")
 	requireNotContains(t, templatePath, "apt-get install -y git jq curl tar ca-certificates openssh-client awscli")
 	requireContains(t, templatePath, "awscli-exe-linux")
+}
+
+func TestUserDataRetriesAptAndForcesIPv4(t *testing.T) {
+	t.Helper()
+
+	templatePath := filepath.Join("..", "..", "modules", "linux-host", "templates", "user_data.sh.tftpl")
+	requireContains(t, templatePath, "Acquire::ForceIPv4 \"true\";")
+	requireContains(t, templatePath, "retry 5 10 apt-get update -y")
+	requireContains(t, templatePath, "retry 5 10 apt-get install -y git jq curl tar unzip ca-certificates openssh-client linux-headers-$(uname -r) zfsutils-linux")
 }
 
 func TestUserDataIsUbuntuSpecific(t *testing.T) {
@@ -170,7 +183,7 @@ func TestUserDataCreatesZfsPoolFromEphemeralNVMe(t *testing.T) {
 	requireContains(t, templatePath, "truncate -s \"$CLEANROOM_ZFS_LOOPBACK_SIZE\"")
 }
 
-func TestDefaultRegionIsUsWest2(t *testing.T) {
+func TestVariableDefaultRegionIsUsWest2(t *testing.T) {
 	t.Helper()
 
 	for _, path := range []string{
@@ -184,7 +197,12 @@ func TestDefaultRegionIsUsWest2(t *testing.T) {
 		}
 	}
 
-	requireContains(t, "terraform.tfvars.example", "aws_region  = \"us-west-2\"")
+}
+
+func TestExampleRegionIsSydney(t *testing.T) {
+	t.Helper()
+
+	requireContains(t, "terraform.tfvars.example", "aws_region  = \"ap-southeast-2\"")
 }
 
 func TestBootstrapConfiguresZfsSnapshots(t *testing.T) {
@@ -239,6 +257,9 @@ func TestLinuxUserDataSupportsInPlaceBootstrapRerun(t *testing.T) {
 	requireContains(t, templatePath, "export CLEANROOM_BOOTSTRAP_REPO_REF=\"$REPO_REF\"")
 	requireContains(t, templatePath, "export CLEANROOM_BOOTSTRAP_SETUP_SCRIPT_PATH=\"$SETUP_SCRIPT_PATH\"")
 	requireContains(t, templatePath, "export CLEANROOM_BOOTSTRAP_DEPLOY_KEY_PARAM=\"$DEPLOY_KEY_PARAM\"")
+	requireContains(t, templatePath, "export CLEANROOM_TAILSCALE_AUTH_KEY_PARAMETER_NAME=\"$TAILSCALE_PARAM\"")
+	requireContains(t, templatePath, "export CLEANROOM_TAILSCALE_VERSION=\"$TAILSCALE_VERSION\"")
+	requireContains(t, templatePath, "export CLEANROOM_TAILSCALE_HOSTNAME_PREFIX=\"$TAILSCALE_HOSTNAME_PREFIX\"")
 	requireContains(t, templatePath, "export CLEANROOM_ZFS_DATASET")
 }
 
@@ -254,7 +275,7 @@ func TestEnvSupportsAvailabilityZoneOverride(t *testing.T) {
 
 	requireContains(t, "variables.tf", "variable \"availability_zone\"")
 	requireContains(t, "main.tf", "availability_zone   = var.availability_zone")
-	requireContains(t, "terraform.tfvars.example", "# availability_zone = \"us-west-2b\"")
+	requireContains(t, "terraform.tfvars.example", "# availability_zone = \"ap-southeast-2b\"")
 }
 
 func TestGitDeployKeyIsRequired(t *testing.T) {

--- a/infra/terraform/envs/ci/terraform.tfvars.example
+++ b/infra/terraform/envs/ci/terraform.tfvars.example
@@ -5,7 +5,7 @@ name_prefix = "cleanroom-ci-apse2"
 instance_type = "m8i.large"
 
 enable_macos_ci   = false
-mac_instance_type = "mac2-m2pro.metal"
+mac_instance_type = "mac2-m2.metal"
 
 # Optional: pin CI networking/hosts to a specific AZ (needed when Mac capacity is AZ-constrained).
 # availability_zone = "ap-southeast-2b"

--- a/infra/terraform/envs/ci/terraform.tfvars.example
+++ b/infra/terraform/envs/ci/terraform.tfvars.example
@@ -1,5 +1,5 @@
-aws_region  = "us-west-2"
-name_prefix = "cleanroom-ci"
+aws_region  = "ap-southeast-2"
+name_prefix = "cleanroom-ci-apse2"
 
 # Must support nested virtualization (Firecracker). Default m8i.large falls back to loopback; use a '*d' type where nested virtualization is available to use local NVMe.
 instance_type = "m8i.large"
@@ -8,7 +8,7 @@ enable_macos_ci   = false
 mac_instance_type = "mac2-m2pro.metal"
 
 # Optional: pin CI networking/hosts to a specific AZ (needed when Mac capacity is AZ-constrained).
-# availability_zone = "us-west-2b"
+# availability_zone = "ap-southeast-2b"
 
 # Optional: pin AMI manually. Leave empty to use latest Ubuntu from SSM parameter.
 # ami_id = "ami-0123456789abcdef0"
@@ -28,12 +28,13 @@ setup_script_path = "scripts/bootstrap-buildkite-agent.sh"
 mac_setup_script_path = "scripts/bootstrap-buildkite-agent-macos.sh"
 mac_buildkite_queue   = "cleanroom-mac"
 
-tailscale_hostname_prefix = "cleanroom-ci-linux"
+tailscale_hostname_prefix = "cleanroom-ci-apse2-linux"
 tailscale_advertise_tags  = ""
 tailscale_enable_ssh      = true
 tailscale_accept_routes   = false
 
 tags = {
-  env  = "ci"
-  team = "platform"
+  env    = "ci"
+  team   = "platform"
+  region = "ap-southeast-2"
 }

--- a/infra/terraform/envs/ci/variables.tf
+++ b/infra/terraform/envs/ci/variables.tf
@@ -61,11 +61,11 @@ variable "mac_ami_ssm_parameter_name" {
 variable "mac_instance_type" {
   description = "EC2 instance type for macOS CI host. Must be a Mac metal type."
   type        = string
-  default     = "mac2-m2pro.metal"
+  default     = "mac2-m2.metal"
 
   validation {
     condition     = trimspace(var.mac_instance_type) != "" && endswith(var.mac_instance_type, ".metal")
-    error_message = "mac_instance_type must be a non-empty Mac metal instance type (for example mac2-m2pro.metal)."
+    error_message = "mac_instance_type must be a non-empty Mac metal instance type (for example mac2-m2.metal)."
   }
 }
 

--- a/infra/terraform/envs/prod/bootstrap_defaults_test.go
+++ b/infra/terraform/envs/prod/bootstrap_defaults_test.go
@@ -65,7 +65,7 @@ func TestProdDefaultsUseLargeLinuxHost(t *testing.T) {
 
 	requireContains(t, "variables.tf", "default     = \"m8i.4xlarge\"")
 	requireContains(t, "variables.tf", "default     = 500")
-	requireContains(t, "terraform.tfvars.example", "instance_type         = \"m8i.4xlarge\"")
+	requireContains(t, "terraform.tfvars.example", "instance_type         = \"m8i.xlarge\"")
 }
 
 func TestProdBootstrapBuildsAndInstallsCleanroom(t *testing.T) {
@@ -78,6 +78,9 @@ func TestProdBootstrapBuildsAndInstallsCleanroom(t *testing.T) {
 	requireContains(t, scriptPath, "daemon install --force --log-level info")
 	requireContains(t, scriptPath, "default_backend: firecracker")
 	requireContains(t, scriptPath, "memory_mib: ${CLEANROOM_FIRECRACKER_MEMORY_MIB}")
+	requireContains(t, scriptPath, "install_tailscale_if_configured")
+	requireContains(t, scriptPath, "CLEANROOM_TAILSCALE_AUTH_KEY_PARAMETER_NAME")
+	requireContains(t, scriptPath, "Acquire::ForceIPv4 \"true\";")
 }
 
 func TestProdEnvSupportsAvailabilityZoneOverride(t *testing.T) {
@@ -85,18 +88,22 @@ func TestProdEnvSupportsAvailabilityZoneOverride(t *testing.T) {
 
 	requireContains(t, "variables.tf", "variable \"availability_zone\"")
 	requireContains(t, "main.tf", "availability_zone   = var.availability_zone")
-	requireContains(t, "terraform.tfvars.example", "# availability_zone = \"us-west-2b\"")
+	requireContains(t, "terraform.tfvars.example", "# availability_zone = \"ap-southeast-2b\"")
 }
 
-func TestDefaultRegionIsUsWest2(t *testing.T) {
+func TestVariableDefaultRegionIsUsWest2(t *testing.T) {
 	t.Helper()
 
 	block := readVariableBlock(t, "variables.tf", "aws_region")
 	if !strings.Contains(block, "us-west-2") {
 		t.Fatalf("expected default aws_region to be us-west-2 in variables.tf, got:\n%s", block)
 	}
+}
 
-	requireContains(t, "terraform.tfvars.example", "aws_region  = \"us-west-2\"")
+func TestExampleRegionIsSydney(t *testing.T) {
+	t.Helper()
+
+	requireContains(t, "terraform.tfvars.example", "aws_region  = \"ap-southeast-2\"")
 }
 
 func TestGitDeployKeyIsRequired(t *testing.T) {

--- a/infra/terraform/envs/prod/terraform.tfvars
+++ b/infra/terraform/envs/prod/terraform.tfvars
@@ -1,12 +1,12 @@
-aws_region  = "us-west-2"
-name_prefix = "cleanroom-prod-usw2"
+aws_region  = "ap-southeast-2"
+name_prefix = "cleanroom-prod-apse2"
 
-# Let AWS pick an AZ in-region.
-availability_zone = ""
+# Pin Sydney prod to the active AZ.
+availability_zone = "ap-southeast-2b"
 
 # Use latest Ubuntu AMI from SSM; keep instance type explicit.
 ami_id               = ""
-instance_type        = "m8i.4xlarge"
+instance_type        = "m8i.xlarge"
 root_volume_size_gib = 500
 
 tailscale_auth_key_parameter_name = "/tailscale/authkey/prod"
@@ -16,7 +16,7 @@ repo_url          = "git@github.com:buildkite/cleanroom.git"
 repo_ref          = "main"
 setup_script_path = "scripts/bootstrap-cleanroom-host.sh"
 
-tailscale_hostname_prefix = "cleanroom-prod-usw2-linux"
+tailscale_hostname_prefix = "cleanroom-prod-apse2-linux"
 tailscale_advertise_tags  = ""
 tailscale_enable_ssh      = true
 tailscale_accept_routes   = false
@@ -24,5 +24,5 @@ tailscale_accept_routes   = false
 tags = {
   env    = "prod"
   team   = "platform"
-  region = "us-west-2"
+  region = "ap-southeast-2"
 }

--- a/infra/terraform/envs/prod/terraform.tfvars.example
+++ b/infra/terraform/envs/prod/terraform.tfvars.example
@@ -1,12 +1,12 @@
-aws_region  = "us-west-2"
-name_prefix = "cleanroom-prod"
+aws_region  = "ap-southeast-2"
+name_prefix = "cleanroom-prod-apse2"
 
-# Must support nested virtualization (Firecracker). Default m8i.4xlarge gives a larger host for interactive prod workloads.
-instance_type         = "m8i.4xlarge"
+# Must support nested virtualization (Firecracker). Use m8i.xlarge to match the active prod host size.
+instance_type         = "m8i.xlarge"
 root_volume_size_gib  = 500
 
 # Optional: pin prod networking/host to a specific AZ.
-# availability_zone = "us-west-2b"
+# availability_zone = "ap-southeast-2b"
 
 # Optional: pin AMI manually. Leave empty to use latest Ubuntu from SSM parameter.
 # ami_id = "ami-0123456789abcdef0"
@@ -18,12 +18,13 @@ repo_url          = "git@github.com:buildkite/cleanroom.git"
 repo_ref          = "main"
 setup_script_path = "scripts/bootstrap-cleanroom-host.sh"
 
-tailscale_hostname_prefix = "cleanroom-prod-linux"
+tailscale_hostname_prefix = "cleanroom-prod-apse2-linux"
 tailscale_advertise_tags  = ""
 tailscale_enable_ssh      = true
 tailscale_accept_routes   = false
 
 tags = {
-  env  = "prod"
-  team = "platform"
+  env    = "prod"
+  team   = "platform"
+  region = "ap-southeast-2"
 }

--- a/infra/terraform/modules/linux-host/templates/user_data.sh.tftpl
+++ b/infra/terraform/modules/linux-host/templates/user_data.sh.tftpl
@@ -17,14 +17,42 @@ TAILSCALE_ADVERTISE_TAGS='${tailscale_advertise_tags}'
 TAILSCALE_ENABLE_SSH='${tailscale_enable_ssh}'
 TAILSCALE_ACCEPT_ROUTES='${tailscale_accept_routes}'
 
+retry() {
+  local attempts="$1"
+  local delay_seconds="$2"
+  shift 2
+
+  local n=1
+  while true; do
+    if "$@"; then
+      return 0
+    fi
+
+    if [ "$n" -ge "$attempts" ]; then
+      return 1
+    fi
+
+    sleep "$delay_seconds"
+    n=$((n + 1))
+  done
+}
+
+configure_apt_ipv4() {
+  install -d -o root -g root -m 0755 /etc/apt/apt.conf.d
+  cat > /etc/apt/apt.conf.d/99force-ipv4 <<'APTCONF'
+Acquire::ForceIPv4 "true";
+APTCONF
+}
+
 if ! command -v apt-get >/dev/null 2>&1; then
   echo "linux host user_data requires an Ubuntu apt-based AMI" >&2
   exit 1
 fi
 
+configure_apt_ipv4
 export DEBIAN_FRONTEND=noninteractive
-apt-get update -y
-apt-get install -y git jq curl tar unzip ca-certificates openssh-client linux-headers-$(uname -r) zfsutils-linux
+retry 5 10 apt-get update -y
+retry 5 10 apt-get install -y git jq curl tar unzip ca-certificates openssh-client linux-headers-$(uname -r) zfsutils-linux
 
 if ! modprobe zfs; then
   echo "zfs kernel module failed to load" >&2
@@ -76,7 +104,7 @@ if ! command -v aws >/dev/null 2>&1; then
 
   aws_tmp_dir="$(mktemp -d)"
   trap 'rm -rf "$aws_tmp_dir"' EXIT
-  curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-$aws_arch.zip" -o "$aws_tmp_dir/awscliv2.zip"
+  retry 5 5 curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-$aws_arch.zip" -o "$aws_tmp_dir/awscliv2.zip"
   unzip -q "$aws_tmp_dir/awscliv2.zip" -d "$aws_tmp_dir"
   "$aws_tmp_dir/aws/install" --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli --update
 fi
@@ -86,12 +114,12 @@ if ! command -v aws >/dev/null 2>&1; then
   exit 1
 fi
 
-imds_token="$(curl -fsS -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")"
-instance_id="$(curl -fsS -H "X-aws-ec2-metadata-token: $imds_token" http://169.254.169.254/latest/meta-data/instance-id)"
+imds_token="$(retry 10 3 curl -fsS -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")"
+instance_id="$(retry 10 3 curl -fsS -H "X-aws-ec2-metadata-token: $imds_token" http://169.254.169.254/latest/meta-data/instance-id)"
 
 # Verify the instance role can read SecureString parameters before handoff.
 if [ -n "$BUILDKITE_TOKEN_PARAM" ]; then
-  aws ssm get-parameter \
+  retry 10 3 aws ssm get-parameter \
     --region "$AWS_REGION" \
     --name "$BUILDKITE_TOKEN_PARAM" \
     --with-decryption \
@@ -100,7 +128,7 @@ if [ -n "$BUILDKITE_TOKEN_PARAM" ]; then
 fi
 
 if [ -n "$TAILSCALE_PARAM" ]; then
-  if ! tailscale_auth_key="$(aws ssm get-parameter --region "$AWS_REGION" --name "$TAILSCALE_PARAM" --with-decryption --query 'Parameter.Value' --output text)"; then
+  if ! tailscale_auth_key="$(retry 10 3 aws ssm get-parameter --region "$AWS_REGION" --name "$TAILSCALE_PARAM" --with-decryption --query 'Parameter.Value' --output text)"; then
     echo "warning: tailscale auth key parameter unavailable ($TAILSCALE_PARAM); skipping tailscale bootstrap" >&2
     tailscale_auth_key=''
   fi
@@ -115,7 +143,7 @@ if [ -n "$TAILSCALE_PARAM" ]; then
     ts_url="$(printf 'https://pkgs.tailscale.com/stable/tailscale_%s_%s.tgz' "$TAILSCALE_VERSION" "$ts_arch")"
     ts_tmp_dir="$(mktemp -d)"
     trap 'rm -rf "$ts_tmp_dir"' EXIT
-    curl -fsSL "$ts_url" -o "$ts_tmp_dir/tailscale.tgz"
+    retry 5 5 curl -fsSL "$ts_url" -o "$ts_tmp_dir/tailscale.tgz"
     tar -xzf "$ts_tmp_dir/tailscale.tgz" -C "$ts_tmp_dir"
     ts_extract_dir="$(find "$ts_tmp_dir" -maxdepth 1 -type d -name 'tailscale_*' | head -n 1)"
 
@@ -153,13 +181,13 @@ TAILSCALE_UNIT
     if [ -n "$TAILSCALE_ADVERTISE_TAGS" ]; then
       set -- "$@" --advertise-tags "$TAILSCALE_ADVERTISE_TAGS"
     fi
-    /usr/local/bin/tailscale "$@"
+    retry 5 5 /usr/local/bin/tailscale "$@"
   fi
 fi
 
 if [ -n "$DEPLOY_KEY_PARAM" ]; then
   install -d -o root -g root -m 0700 /root/.ssh
-  aws ssm get-parameter \
+  retry 10 3 aws ssm get-parameter \
     --region "$AWS_REGION" \
     --name "$DEPLOY_KEY_PARAM" \
     --with-decryption \
@@ -167,7 +195,7 @@ if [ -n "$DEPLOY_KEY_PARAM" ]; then
     --output text > /root/.ssh/cleanroom_deploy_key
   chmod 0600 /root/.ssh/cleanroom_deploy_key
   touch /root/.ssh/known_hosts
-  ssh-keyscan -t rsa,ecdsa,ed25519 github.com >> /root/.ssh/known_hosts
+  retry 5 3 ssh-keyscan -t rsa,ecdsa,ed25519 github.com >> /root/.ssh/known_hosts
   chmod 0644 /root/.ssh/known_hosts
 fi
 
@@ -181,7 +209,7 @@ fi
 
 git -c init.defaultBranch=main init "$repo_root" >/dev/null
 git -C "$repo_root" remote add origin "$REPO_URL"
-git -C "$repo_root" fetch --depth=1 origin "$REPO_REF"
+retry 5 3 git -C "$repo_root" fetch --depth=1 origin "$REPO_REF"
 git -C "$repo_root" checkout -f FETCH_HEAD
 
 setup_script="$repo_root/$SETUP_SCRIPT_PATH"
@@ -201,6 +229,12 @@ export CLEANROOM_BOOTSTRAP_REPO_URL="$REPO_URL"
 export CLEANROOM_BOOTSTRAP_REPO_REF="$REPO_REF"
 export CLEANROOM_BOOTSTRAP_SETUP_SCRIPT_PATH="$SETUP_SCRIPT_PATH"
 export CLEANROOM_BOOTSTRAP_DEPLOY_KEY_PARAM="$DEPLOY_KEY_PARAM"
+export CLEANROOM_TAILSCALE_AUTH_KEY_PARAMETER_NAME="$TAILSCALE_PARAM"
+export CLEANROOM_TAILSCALE_VERSION="$TAILSCALE_VERSION"
+export CLEANROOM_TAILSCALE_HOSTNAME_PREFIX="$TAILSCALE_HOSTNAME_PREFIX"
+export CLEANROOM_TAILSCALE_ADVERTISE_TAGS="$TAILSCALE_ADVERTISE_TAGS"
+export CLEANROOM_TAILSCALE_ENABLE_SSH="$TAILSCALE_ENABLE_SSH"
+export CLEANROOM_TAILSCALE_ACCEPT_ROUTES="$TAILSCALE_ACCEPT_ROUTES"
 export CLEANROOM_ZFS_DATASET
 
 "$setup_script"

--- a/infra/terraform/modules/linux-host/templates/user_data.sh.tftpl
+++ b/infra/terraform/modules/linux-host/templates/user_data.sh.tftpl
@@ -168,7 +168,12 @@ WantedBy=multi-user.target
 TAILSCALE_UNIT
 
     systemctl daemon-reload
-    systemctl enable --now tailscaled
+    systemctl enable tailscaled
+    if systemctl is-active --quiet tailscaled; then
+      systemctl restart tailscaled
+    else
+      systemctl start tailscaled
+    fi
 
     hostname="$TAILSCALE_HOSTNAME_PREFIX-$instance_id"
     set -- up --auth-key "$tailscale_auth_key" --hostname "$hostname"

--- a/infra/terraform/modules/macos-ci/variables.tf
+++ b/infra/terraform/modules/macos-ci/variables.tf
@@ -33,11 +33,11 @@ variable "ami_id" {
 variable "instance_type" {
   description = "EC2 instance type for the host (must be a Mac metal type)."
   type        = string
-  default     = "mac2-m2pro.metal"
+  default     = "mac2-m2.metal"
 
   validation {
     condition     = trimspace(var.instance_type) != "" && endswith(var.instance_type, ".metal")
-    error_message = "instance_type must be a non-empty Mac metal instance type (for example mac2-m2pro.metal)."
+    error_message = "instance_type must be a non-empty Mac metal instance type (for example mac2-m2.metal)."
   }
 }
 

--- a/scripts/bootstrap-buildkite-agent.sh
+++ b/scripts/bootstrap-buildkite-agent.sh
@@ -107,7 +107,12 @@ WantedBy=multi-user.target
 TAILSCALE_UNIT
 
   systemctl daemon-reload
-  systemctl enable --now tailscaled
+  systemctl enable tailscaled
+  if systemctl is-active --quiet tailscaled; then
+    systemctl restart tailscaled
+  else
+    systemctl start tailscaled
+  fi
 
   instance_id="$(resolve_instance_id)"
   tailscale_cmd=(/usr/local/bin/tailscale up --auth-key "$tailscale_auth_key" --hostname "${tailscale_hostname_prefix}-${instance_id}")

--- a/scripts/bootstrap-buildkite-agent.sh
+++ b/scripts/bootstrap-buildkite-agent.sh
@@ -19,6 +19,111 @@ require_cmd() {
   command -v "$cmd" >/dev/null 2>&1 || die "required command not found: ${cmd}"
 }
 
+retry() {
+  local attempts="$1"
+  local delay_seconds="$2"
+  shift 2
+
+  local n=1
+  while true; do
+    if "$@"; then
+      return 0
+    fi
+
+    if [ "$n" -ge "$attempts" ]; then
+      return 1
+    fi
+
+    sleep "$delay_seconds"
+    n=$((n + 1))
+  done
+}
+
+configure_apt_ipv4() {
+  install -d -o root -g root -m 0755 /etc/apt/apt.conf.d
+  cat > /etc/apt/apt.conf.d/99force-ipv4 <<'APTCONF'
+Acquire::ForceIPv4 "true";
+APTCONF
+}
+
+install_tailscale_if_configured() {
+  local tailscale_param="${TAILSCALE_AUTH_KEY_PARAMETER_NAME:-${CLEANROOM_TAILSCALE_AUTH_KEY_PARAMETER_NAME:-}}"
+  local tailscale_version="${TAILSCALE_VERSION:-${CLEANROOM_TAILSCALE_VERSION:-}}"
+  local tailscale_hostname_prefix="${TAILSCALE_HOSTNAME_PREFIX:-${CLEANROOM_TAILSCALE_HOSTNAME_PREFIX:-}}"
+  local tailscale_advertise_tags="${TAILSCALE_ADVERTISE_TAGS:-${CLEANROOM_TAILSCALE_ADVERTISE_TAGS:-}}"
+  local tailscale_enable_ssh="${TAILSCALE_ENABLE_SSH:-${CLEANROOM_TAILSCALE_ENABLE_SSH:-true}}"
+  local tailscale_accept_routes="${TAILSCALE_ACCEPT_ROUTES:-${CLEANROOM_TAILSCALE_ACCEPT_ROUTES:-false}}"
+  local tailscale_auth_key
+  local arch_name
+  local ts_arch='amd64'
+  local ts_url
+  local ts_tmp_dir
+  local ts_extract_dir
+  local instance_id
+  local -a tailscale_cmd
+
+  if [ -z "$tailscale_param" ]; then
+    return
+  fi
+
+  [ -n "$tailscale_version" ] || die "TAILSCALE_VERSION (or CLEANROOM_TAILSCALE_VERSION) must be set when tailscale bootstrap is enabled"
+  [ -n "$tailscale_hostname_prefix" ] || die "TAILSCALE_HOSTNAME_PREFIX (or CLEANROOM_TAILSCALE_HOSTNAME_PREFIX) must be set when tailscale bootstrap is enabled"
+
+  log "installing tailscale ${tailscale_version}"
+  tailscale_auth_key="$(retry 10 3 aws ssm get-parameter --region "$AWS_REGION" --name "$tailscale_param" --with-decryption --query 'Parameter.Value' --output text)"
+
+  arch_name="$(uname -m)"
+  if [ "$arch_name" = 'aarch64' ] || [ "$arch_name" = 'arm64' ]; then
+    ts_arch='arm64'
+  fi
+
+  ts_url="$(printf 'https://pkgs.tailscale.com/stable/tailscale_%s_%s.tgz' "$tailscale_version" "$ts_arch")"
+  ts_tmp_dir="$(mktemp -d)"
+  trap 'rm -rf "$ts_tmp_dir"' RETURN
+
+  retry 5 5 curl -fsSL "$ts_url" -o "$ts_tmp_dir/tailscale.tgz"
+  tar -xzf "$ts_tmp_dir/tailscale.tgz" -C "$ts_tmp_dir"
+  ts_extract_dir="$(find "$ts_tmp_dir" -maxdepth 1 -type d -name 'tailscale_*' | head -n 1)"
+  [ -n "$ts_extract_dir" ] || die "tailscale archive missing extracted directory"
+
+  install -o root -g root -m 0755 "$ts_extract_dir/tailscale" /usr/local/bin/tailscale
+  install -o root -g root -m 0755 "$ts_extract_dir/tailscaled" /usr/local/bin/tailscaled
+  install -d -o root -g root -m 0755 /var/lib/tailscale
+
+  cat > /etc/systemd/system/tailscaled.service <<'TAILSCALE_UNIT'
+[Unit]
+Description=Tailscale node agent
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+RuntimeDirectory=tailscale
+ExecStart=/usr/local/bin/tailscaled --state=/var/lib/tailscale/tailscaled.state --socket=/run/tailscale/tailscaled.sock
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+TAILSCALE_UNIT
+
+  systemctl daemon-reload
+  systemctl enable --now tailscaled
+
+  instance_id="$(resolve_instance_id)"
+  tailscale_cmd=(/usr/local/bin/tailscale up --auth-key "$tailscale_auth_key" --hostname "${tailscale_hostname_prefix}-${instance_id}")
+  if [ "$tailscale_enable_ssh" = "true" ]; then
+    tailscale_cmd+=(--ssh)
+  fi
+  if [ "$tailscale_accept_routes" = "true" ]; then
+    tailscale_cmd+=(--accept-routes)
+  fi
+  if [ -n "$tailscale_advertise_tags" ]; then
+    tailscale_cmd+=(--advertise-tags "$tailscale_advertise_tags")
+  fi
+
+  retry 5 5 "${tailscale_cmd[@]}"
+}
+
 install_linux_bootstrap_runner() {
   local bootstrap_env_path='/usr/local/etc/cleanroom-bootstrap-linux.env'
   local bootstrap_runner_path='/usr/local/bin/cleanroom-bootstrap-linux'
@@ -27,6 +132,12 @@ install_linux_bootstrap_runner() {
   local bootstrap_setup_script_path="${CLEANROOM_BOOTSTRAP_SETUP_SCRIPT_PATH:-scripts/bootstrap-buildkite-agent.sh}"
   local bootstrap_deploy_key_param="${CLEANROOM_BOOTSTRAP_DEPLOY_KEY_PARAM:-}"
   local bootstrap_zfs_dataset="${CLEANROOM_ZFS_DATASET:-cleanroom/data}"
+  local bootstrap_tailscale_param="${TAILSCALE_AUTH_KEY_PARAMETER_NAME:-${CLEANROOM_TAILSCALE_AUTH_KEY_PARAMETER_NAME:-}}"
+  local bootstrap_tailscale_version="${TAILSCALE_VERSION:-${CLEANROOM_TAILSCALE_VERSION:-}}"
+  local bootstrap_tailscale_hostname_prefix="${TAILSCALE_HOSTNAME_PREFIX:-${CLEANROOM_TAILSCALE_HOSTNAME_PREFIX:-}}"
+  local bootstrap_tailscale_advertise_tags="${TAILSCALE_ADVERTISE_TAGS:-${CLEANROOM_TAILSCALE_ADVERTISE_TAGS:-}}"
+  local bootstrap_tailscale_enable_ssh="${TAILSCALE_ENABLE_SSH:-${CLEANROOM_TAILSCALE_ENABLE_SSH:-true}}"
+  local bootstrap_tailscale_accept_routes="${TAILSCALE_ACCEPT_ROUTES:-${CLEANROOM_TAILSCALE_ACCEPT_ROUTES:-false}}"
 
   if [ -z "$bootstrap_repo_url" ]; then
     warn "skipping linux bootstrap runner install because CLEANROOM_BOOTSTRAP_REPO_URL is not set"
@@ -42,6 +153,12 @@ NAME_PREFIX='$NAME_PREFIX'
 BUILDKITE_QUEUE='$QUEUE_NAME'
 BUILDKITE_TOKEN_PARAM='$BUILDKITE_TOKEN_PARAM'
 DEPLOY_KEY_PARAM='$bootstrap_deploy_key_param'
+TAILSCALE_AUTH_KEY_PARAMETER_NAME='$bootstrap_tailscale_param'
+TAILSCALE_VERSION='$bootstrap_tailscale_version'
+TAILSCALE_HOSTNAME_PREFIX='$bootstrap_tailscale_hostname_prefix'
+TAILSCALE_ADVERTISE_TAGS='$bootstrap_tailscale_advertise_tags'
+TAILSCALE_ENABLE_SSH='$bootstrap_tailscale_enable_ssh'
+TAILSCALE_ACCEPT_ROUTES='$bootstrap_tailscale_accept_routes'
 REPO_URL='$bootstrap_repo_url'
 REPO_REF='$bootstrap_repo_ref'
 SETUP_SCRIPT_PATH='$bootstrap_setup_script_path'
@@ -191,6 +308,12 @@ export CLEANROOM_BOOTSTRAP_REPO_URL="$REPO_URL"
 export CLEANROOM_BOOTSTRAP_REPO_REF="$REPO_REF"
 export CLEANROOM_BOOTSTRAP_SETUP_SCRIPT_PATH="$SETUP_SCRIPT_PATH"
 export CLEANROOM_BOOTSTRAP_DEPLOY_KEY_PARAM="$DEPLOY_KEY_PARAM"
+export CLEANROOM_TAILSCALE_AUTH_KEY_PARAMETER_NAME="$TAILSCALE_AUTH_KEY_PARAMETER_NAME"
+export CLEANROOM_TAILSCALE_VERSION="$TAILSCALE_VERSION"
+export CLEANROOM_TAILSCALE_HOSTNAME_PREFIX="$TAILSCALE_HOSTNAME_PREFIX"
+export CLEANROOM_TAILSCALE_ADVERTISE_TAGS="$TAILSCALE_ADVERTISE_TAGS"
+export CLEANROOM_TAILSCALE_ENABLE_SSH="$TAILSCALE_ENABLE_SSH"
+export CLEANROOM_TAILSCALE_ACCEPT_ROUTES="$TAILSCALE_ACCEPT_ROUTES"
 export CLEANROOM_INSTALL_FIRECRACKER="$INSTALL_FIRECRACKER"
 export CLEANROOM_FIRECRACKER_VERSION="$FIRECRACKER_VERSION"
 export CLEANROOM_KERNEL_IMAGE_URL="$KERNEL_IMAGE_URL"
@@ -208,9 +331,10 @@ install_sudo_if_missing() {
   fi
 
   if command -v apt-get >/dev/null 2>&1; then
+    configure_apt_ipv4
     export DEBIAN_FRONTEND=noninteractive
-    apt-get update -y
-    apt-get install -y sudo
+    retry 5 10 apt-get update -y
+    retry 5 10 apt-get install -y sudo
     return
   fi
 
@@ -258,7 +382,7 @@ install_buildkite_agent_binary() {
   tmp_dir="$(mktemp -d)"
   trap 'rm -rf "$tmp_dir"' RETURN
 
-  curl -fsSL "$url" -o "$tmp_dir/buildkite-agent.tgz"
+  retry 5 5 curl -fsSL "$url" -o "$tmp_dir/buildkite-agent.tgz"
   tar -xzf "$tmp_dir/buildkite-agent.tgz" -C "$tmp_dir"
 
   binary="$(find "$tmp_dir" -maxdepth 2 -type f -name 'buildkite-agent' | head -n 1)"
@@ -280,7 +404,7 @@ install_firecracker_binary() {
   tmp_dir="$(mktemp -d)"
   trap 'rm -rf "$tmp_dir"' RETURN
 
-  curl -fsSL "$url" -o "$tmp_dir/firecracker.tgz"
+  retry 5 5 curl -fsSL "$url" -o "$tmp_dir/firecracker.tgz"
   tar -xzf "$tmp_dir/firecracker.tgz" -C "$tmp_dir"
 
   binary="$(find "$tmp_dir" -type f -name "firecracker-v${version}-${arch}" | head -n 1)"
@@ -329,6 +453,12 @@ HELPER_INSTALL_PATH="${CLEANROOM_HELPER_INSTALL_PATH:-/usr/local/sbin/cleanroom-
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
 HELPER_SOURCE_PATH="${CLEANROOM_HELPER_SOURCE_PATH:-$REPO_ROOT/scripts/cleanroom-root-helper.sh}"
+TAILSCALE_AUTH_KEY_PARAMETER_NAME="${TAILSCALE_AUTH_KEY_PARAMETER_NAME:-${CLEANROOM_TAILSCALE_AUTH_KEY_PARAMETER_NAME:-}}"
+TAILSCALE_VERSION="${TAILSCALE_VERSION:-${CLEANROOM_TAILSCALE_VERSION:-1.82.5}}"
+TAILSCALE_HOSTNAME_PREFIX="${TAILSCALE_HOSTNAME_PREFIX:-${CLEANROOM_TAILSCALE_HOSTNAME_PREFIX:-}}"
+TAILSCALE_ADVERTISE_TAGS="${TAILSCALE_ADVERTISE_TAGS:-${CLEANROOM_TAILSCALE_ADVERTISE_TAGS:-}}"
+TAILSCALE_ENABLE_SSH="${TAILSCALE_ENABLE_SSH:-${CLEANROOM_TAILSCALE_ENABLE_SSH:-true}}"
+TAILSCALE_ACCEPT_ROUTES="${TAILSCALE_ACCEPT_ROUTES:-${CLEANROOM_TAILSCALE_ACCEPT_ROUTES:-false}}"
 
 [ -n "$AWS_REGION" ] || die "AWS_REGION (or CLEANROOM_BOOTSTRAP_REGION) must be set"
 [ -n "$BUILDKITE_TOKEN_PARAM" ] || die "BUILDKITE_TOKEN_PARAM must be set"
@@ -338,6 +468,7 @@ require_cmd curl
 require_cmd tar
 require_cmd systemctl
 install_sudo_if_missing
+install_tailscale_if_configured
 
 log "installing buildkite-agent ${AGENT_VERSION}"
 install_buildkite_agent_binary "$AGENT_VERSION"
@@ -356,7 +487,7 @@ install -d -o buildkite-agent -g buildkite-agent -m 0755 /var/lib/buildkite-agen
 install -d -o buildkite-agent -g buildkite-agent -m 0755 /var/lib/buildkite-agent/.local/share/cleanroom/images
 install -d -o root -g root -m 0755 /etc/buildkite-agent
 
-agent_token="$(aws ssm get-parameter --region "$AWS_REGION" --name "$BUILDKITE_TOKEN_PARAM" --with-decryption --query 'Parameter.Value' --output text)"
+agent_token="$(retry 10 3 aws ssm get-parameter --region "$AWS_REGION" --name "$BUILDKITE_TOKEN_PARAM" --with-decryption --query 'Parameter.Value' --output text)"
 instance_id="$(resolve_instance_id)"
 
 cat > /etc/systemd/system/buildkite-agent@.service <<'UNIT'
@@ -418,7 +549,7 @@ chmod 0755 /var/lib/buildkite-agent/hooks/pre-command
 if [ "$INSTALL_FIRECRACKER" = "true" ]; then
   log "installing firecracker ${FIRECRACKER_VERSION}"
   install_firecracker_binary "$FIRECRACKER_VERSION"
-  curl -fsSL "$KERNEL_IMAGE_URL" -o /var/lib/buildkite-agent/.local/share/cleanroom/images/vmlinux.bin
+  retry 5 5 curl -fsSL "$KERNEL_IMAGE_URL" -o /var/lib/buildkite-agent/.local/share/cleanroom/images/vmlinux.bin
   chown buildkite-agent:buildkite-agent /var/lib/buildkite-agent/.local/share/cleanroom/images/vmlinux.bin
   chmod 0644 /var/lib/buildkite-agent/.local/share/cleanroom/images/vmlinux.bin
 fi

--- a/scripts/bootstrap-buildkite-agent.sh
+++ b/scripts/bootstrap-buildkite-agent.sh
@@ -69,8 +69,12 @@ install_tailscale_if_configured() {
   [ -n "$tailscale_version" ] || die "TAILSCALE_VERSION (or CLEANROOM_TAILSCALE_VERSION) must be set when tailscale bootstrap is enabled"
   [ -n "$tailscale_hostname_prefix" ] || die "TAILSCALE_HOSTNAME_PREFIX (or CLEANROOM_TAILSCALE_HOSTNAME_PREFIX) must be set when tailscale bootstrap is enabled"
 
+  if ! tailscale_auth_key="$(retry 10 3 aws ssm get-parameter --region "$AWS_REGION" --name "$tailscale_param" --with-decryption --query 'Parameter.Value' --output text)"; then
+    warn "tailscale auth key parameter unavailable (${tailscale_param}); skipping tailscale bootstrap"
+    return
+  fi
+
   log "installing tailscale ${tailscale_version}"
-  tailscale_auth_key="$(retry 10 3 aws ssm get-parameter --region "$AWS_REGION" --name "$tailscale_param" --with-decryption --query 'Parameter.Value' --output text)"
 
   arch_name="$(uname -m)"
   if [ "$arch_name" = 'aarch64' ] || [ "$arch_name" = 'arm64' ]; then

--- a/scripts/bootstrap-cleanroom-host.sh
+++ b/scripts/bootstrap-cleanroom-host.sh
@@ -109,8 +109,12 @@ install_tailscale_if_configured() {
   [ -n "$tailscale_version" ] || die "TAILSCALE_VERSION (or CLEANROOM_TAILSCALE_VERSION) must be set when tailscale bootstrap is enabled"
   [ -n "$tailscale_hostname_prefix" ] || die "TAILSCALE_HOSTNAME_PREFIX (or CLEANROOM_TAILSCALE_HOSTNAME_PREFIX) must be set when tailscale bootstrap is enabled"
 
+  if ! tailscale_auth_key="$(retry 10 3 aws ssm get-parameter --region "$AWS_REGION" --name "$tailscale_param" --with-decryption --query 'Parameter.Value' --output text)"; then
+    warn "tailscale auth key parameter unavailable (${tailscale_param}); skipping tailscale bootstrap"
+    return
+  fi
+
   log "installing tailscale ${tailscale_version}"
-  tailscale_auth_key="$(retry 10 3 aws ssm get-parameter --region "$AWS_REGION" --name "$tailscale_param" --with-decryption --query 'Parameter.Value' --output text)"
 
   arch_name="$(uname -m)"
   if [ "$arch_name" = 'aarch64' ] || [ "$arch_name" = 'arm64' ]; then

--- a/scripts/bootstrap-cleanroom-host.sh
+++ b/scripts/bootstrap-cleanroom-host.sh
@@ -5,6 +5,10 @@ log() {
   printf '[bootstrap-cleanroom-host] %s\n' "$*"
 }
 
+warn() {
+  printf '[bootstrap-cleanroom-host] warning: %s\n' "$*" >&2
+}
+
 die() {
   printf '[bootstrap-cleanroom-host] error: %s\n' "$*" >&2
   exit 1
@@ -15,14 +19,149 @@ require_cmd() {
   command -v "$cmd" >/dev/null 2>&1 || die "required command not found: ${cmd}"
 }
 
+retry() {
+  local attempts="$1"
+  local delay_seconds="$2"
+  shift 2
+
+  local n=1
+  while true; do
+    if "$@"; then
+      return 0
+    fi
+
+    if [ "$n" -ge "$attempts" ]; then
+      return 1
+    fi
+
+    sleep "$delay_seconds"
+    n=$((n + 1))
+  done
+}
+
+configure_apt_ipv4() {
+  install -d -o root -g root -m 0755 /etc/apt/apt.conf.d
+  cat > /etc/apt/apt.conf.d/99force-ipv4 <<'APTCONF'
+Acquire::ForceIPv4 "true";
+APTCONF
+}
+
 install_sudo_if_missing() {
   if command -v sudo >/dev/null 2>&1; then
     return
   fi
 
+  configure_apt_ipv4
   export DEBIAN_FRONTEND=noninteractive
-  apt-get update -y
-  apt-get install -y sudo
+  retry 5 10 apt-get update -y
+  retry 5 10 apt-get install -y sudo
+}
+
+resolve_instance_id() {
+  if [ -n "${CLEANROOM_BOOTSTRAP_INSTANCE_ID:-}" ]; then
+    printf '%s' "$CLEANROOM_BOOTSTRAP_INSTANCE_ID"
+    return
+  fi
+
+  local imds_token
+  local instance_id
+  imds_token="$(curl -fsS -m 2 -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600" || true)"
+  if [ -z "$imds_token" ]; then
+    printf 'unknown-instance'
+    return
+  fi
+
+  instance_id="$(curl -fsS -m 2 -H "X-aws-ec2-metadata-token: $imds_token" http://169.254.169.254/latest/meta-data/instance-id || true)"
+  if [ -z "$instance_id" ]; then
+    printf 'unknown-instance'
+    return
+  fi
+
+  printf '%s' "$instance_id"
+}
+
+install_tailscale_if_configured() {
+  local tailscale_param="${TAILSCALE_AUTH_KEY_PARAMETER_NAME:-${CLEANROOM_TAILSCALE_AUTH_KEY_PARAMETER_NAME:-}}"
+  local tailscale_version="${TAILSCALE_VERSION:-${CLEANROOM_TAILSCALE_VERSION:-}}"
+  local tailscale_hostname_prefix="${TAILSCALE_HOSTNAME_PREFIX:-${CLEANROOM_TAILSCALE_HOSTNAME_PREFIX:-}}"
+  local tailscale_advertise_tags="${TAILSCALE_ADVERTISE_TAGS:-${CLEANROOM_TAILSCALE_ADVERTISE_TAGS:-}}"
+  local tailscale_enable_ssh="${TAILSCALE_ENABLE_SSH:-${CLEANROOM_TAILSCALE_ENABLE_SSH:-true}}"
+  local tailscale_accept_routes="${TAILSCALE_ACCEPT_ROUTES:-${CLEANROOM_TAILSCALE_ACCEPT_ROUTES:-false}}"
+  local tailscale_auth_key
+  local arch_name
+  local ts_arch='amd64'
+  local ts_url
+  local ts_tmp_dir
+  local ts_extract_dir
+  local instance_id
+  local -a tailscale_cmd
+
+  if [ -z "$tailscale_param" ]; then
+    return
+  fi
+
+  if ! command -v aws >/dev/null 2>&1; then
+    warn "skipping tailscale bootstrap because aws CLI is not installed"
+    return
+  fi
+
+  [ -n "$AWS_REGION" ] || die "AWS_REGION (or CLEANROOM_BOOTSTRAP_REGION) must be set when tailscale bootstrap is enabled"
+  [ -n "$tailscale_version" ] || die "TAILSCALE_VERSION (or CLEANROOM_TAILSCALE_VERSION) must be set when tailscale bootstrap is enabled"
+  [ -n "$tailscale_hostname_prefix" ] || die "TAILSCALE_HOSTNAME_PREFIX (or CLEANROOM_TAILSCALE_HOSTNAME_PREFIX) must be set when tailscale bootstrap is enabled"
+
+  log "installing tailscale ${tailscale_version}"
+  tailscale_auth_key="$(retry 10 3 aws ssm get-parameter --region "$AWS_REGION" --name "$tailscale_param" --with-decryption --query 'Parameter.Value' --output text)"
+
+  arch_name="$(uname -m)"
+  if [ "$arch_name" = 'aarch64' ] || [ "$arch_name" = 'arm64' ]; then
+    ts_arch='arm64'
+  fi
+
+  ts_url="$(printf 'https://pkgs.tailscale.com/stable/tailscale_%s_%s.tgz' "$tailscale_version" "$ts_arch")"
+  ts_tmp_dir="$(mktemp -d)"
+  trap 'rm -rf "$ts_tmp_dir"' RETURN
+
+  retry 5 5 curl -fsSL "$ts_url" -o "$ts_tmp_dir/tailscale.tgz"
+  tar -xzf "$ts_tmp_dir/tailscale.tgz" -C "$ts_tmp_dir"
+  ts_extract_dir="$(find "$ts_tmp_dir" -maxdepth 1 -type d -name 'tailscale_*' | head -n 1)"
+  [ -n "$ts_extract_dir" ] || die "tailscale archive missing extracted directory"
+
+  install -o root -g root -m 0755 "$ts_extract_dir/tailscale" /usr/local/bin/tailscale
+  install -o root -g root -m 0755 "$ts_extract_dir/tailscaled" /usr/local/bin/tailscaled
+  install -d -o root -g root -m 0755 /var/lib/tailscale
+
+  cat > /etc/systemd/system/tailscaled.service <<'TAILSCALE_UNIT'
+[Unit]
+Description=Tailscale node agent
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+RuntimeDirectory=tailscale
+ExecStart=/usr/local/bin/tailscaled --state=/var/lib/tailscale/tailscaled.state --socket=/run/tailscale/tailscaled.sock
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+TAILSCALE_UNIT
+
+  systemctl daemon-reload
+  systemctl enable --now tailscaled
+
+  instance_id="$(resolve_instance_id)"
+  tailscale_cmd=(/usr/local/bin/tailscale up --auth-key "$tailscale_auth_key" --hostname "${tailscale_hostname_prefix}-${instance_id}")
+  if [ "$tailscale_enable_ssh" = "true" ]; then
+    tailscale_cmd+=(--ssh)
+  fi
+  if [ "$tailscale_accept_routes" = "true" ]; then
+    tailscale_cmd+=(--accept-routes)
+  fi
+  if [ -n "$tailscale_advertise_tags" ]; then
+    tailscale_cmd+=(--advertise-tags "$tailscale_advertise_tags")
+  fi
+
+  retry 5 5 "${tailscale_cmd[@]}"
 }
 
 resolve_firecracker_arch() {
@@ -52,7 +191,7 @@ install_firecracker_binary() {
   tmp_dir="$(mktemp -d)"
   trap 'rm -rf "$tmp_dir"' RETURN
 
-  curl -fsSL "$url" -o "$tmp_dir/firecracker.tgz"
+  retry 5 5 curl -fsSL "$url" -o "$tmp_dir/firecracker.tgz"
   tar -xzf "$tmp_dir/firecracker.tgz" -C "$tmp_dir"
 
   binary="$(find "$tmp_dir" -type f -name "firecracker-v${version}-${arch}" | head -n 1)"
@@ -73,6 +212,13 @@ CLEANROOM_CONFIG_DIR="${CLEANROOM_CONFIG_DIR:-/root/.config/cleanroom}"
 CLEANROOM_FIRECRACKER_VCPUS="${CLEANROOM_FIRECRACKER_VCPUS:-4}"
 CLEANROOM_FIRECRACKER_MEMORY_MIB="${CLEANROOM_FIRECRACKER_MEMORY_MIB:-8192}"
 CLEANROOM_FIRECRACKER_LAUNCH_SECONDS="${CLEANROOM_FIRECRACKER_LAUNCH_SECONDS:-90}"
+AWS_REGION="${AWS_REGION:-${CLEANROOM_BOOTSTRAP_REGION:-}}"
+TAILSCALE_AUTH_KEY_PARAMETER_NAME="${TAILSCALE_AUTH_KEY_PARAMETER_NAME:-${CLEANROOM_TAILSCALE_AUTH_KEY_PARAMETER_NAME:-}}"
+TAILSCALE_VERSION="${TAILSCALE_VERSION:-${CLEANROOM_TAILSCALE_VERSION:-1.82.5}}"
+TAILSCALE_HOSTNAME_PREFIX="${TAILSCALE_HOSTNAME_PREFIX:-${CLEANROOM_TAILSCALE_HOSTNAME_PREFIX:-}}"
+TAILSCALE_ADVERTISE_TAGS="${TAILSCALE_ADVERTISE_TAGS:-${CLEANROOM_TAILSCALE_ADVERTISE_TAGS:-}}"
+TAILSCALE_ENABLE_SSH="${TAILSCALE_ENABLE_SSH:-${CLEANROOM_TAILSCALE_ENABLE_SSH:-true}}"
+TAILSCALE_ACCEPT_ROUTES="${TAILSCALE_ACCEPT_ROUTES:-${CLEANROOM_TAILSCALE_ACCEPT_ROUTES:-false}}"
 
 HOME="${HOME:-/root}"
 export HOME
@@ -91,10 +237,12 @@ require_cmd tar
 require_cmd systemctl
 
 install_sudo_if_missing
+install_tailscale_if_configured
 
+configure_apt_ipv4
 export DEBIAN_FRONTEND=noninteractive
-apt-get update -y
-apt-get install -y e2fsprogs golang-go iproute2 iptables
+retry 5 10 apt-get update -y
+retry 5 10 apt-get install -y e2fsprogs golang-go iproute2 iptables
 
 if [ "$INSTALL_FIRECRACKER" = "true" ]; then
   log "installing firecracker ${FIRECRACKER_VERSION}"

--- a/scripts/bootstrap-cleanroom-host.sh
+++ b/scripts/bootstrap-cleanroom-host.sh
@@ -147,7 +147,12 @@ WantedBy=multi-user.target
 TAILSCALE_UNIT
 
   systemctl daemon-reload
-  systemctl enable --now tailscaled
+  systemctl enable tailscaled
+  if systemctl is-active --quiet tailscaled; then
+    systemctl restart tailscaled
+  else
+    systemctl start tailscaled
+  fi
 
   instance_id="$(resolve_instance_id)"
   tailscale_cmd=(/usr/local/bin/tailscale up --auth-key "$tailscale_auth_key" --hostname "${tailscale_hostname_prefix}-${instance_id}")

--- a/scripts/bootstrap_tailscale_test.go
+++ b/scripts/bootstrap_tailscale_test.go
@@ -1,0 +1,44 @@
+package scripts_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestBootstrapScriptsSkipTailscaleWhenAuthKeyLookupFails(t *testing.T) {
+	t.Helper()
+
+	for _, tc := range []struct {
+		name string
+		path string
+	}{
+		{
+			name: "buildkite-agent",
+			path: "bootstrap-buildkite-agent.sh",
+		},
+		{
+			name: "cleanroom-host",
+			path: "bootstrap-cleanroom-host.sh",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			content, err := os.ReadFile(tc.path)
+			if err != nil {
+				t.Fatalf("read %s: %v", tc.path, err)
+			}
+
+			script := string(content)
+			needle := `if ! tailscale_auth_key="$(retry 10 3 aws ssm get-parameter --region "$AWS_REGION" --name "$tailscale_param" --with-decryption --query 'Parameter.Value' --output text)"; then
+    warn "tailscale auth key parameter unavailable (${tailscale_param}); skipping tailscale bootstrap"
+    return
+  fi
+
+  log "installing tailscale ${tailscale_version}"`
+
+			if !strings.Contains(script, needle) {
+				t.Fatalf("expected %s to skip tailscale bootstrap when auth key lookup fails", tc.path)
+			}
+		})
+	}
+}

--- a/scripts/ci-bootstrap-linux-ssm.sh
+++ b/scripts/ci-bootstrap-linux-ssm.sh
@@ -1,13 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+readonly DEFAULT_CI_AWS_PROFILE="buildkite-sandbox-pipelines-admin"
+readonly DEFAULT_CI_AWS_REGION="ap-southeast-2"
+readonly DEFAULT_CI_TERRAFORM_DIR="infra/terraform/envs/ci"
+
 usage() {
   cat >&2 <<'EOF'
 usage: scripts/ci-bootstrap-linux-ssm.sh <run|logs>
 
 Environment overrides:
   CLEANROOM_CI_AWS_PROFILE   AWS profile for the SSM command (default: buildkite-sandbox-pipelines-admin)
-  CLEANROOM_CI_AWS_REGION    AWS region for the SSM command (default: us-west-2)
+  CLEANROOM_CI_AWS_REGION    AWS region for the SSM command (default: ap-southeast-2)
   CLEANROOM_CI_INSTANCE_ID   Explicit linux CI instance id (default: terraform output)
   CLEANROOM_CI_TERRAFORM_DIR Terraform dir used to resolve instance_id (default: infra/terraform/envs/ci)
 EOF
@@ -118,9 +122,9 @@ run_ssm() {
 
 main() {
   local mode="${1:-}"
-  local aws_profile="${CLEANROOM_CI_AWS_PROFILE:-buildkite-sandbox-pipelines-admin}"
-  local aws_region="${CLEANROOM_CI_AWS_REGION:-us-west-2}"
-  local terraform_dir="${CLEANROOM_CI_TERRAFORM_DIR:-infra/terraform/envs/ci}"
+  local aws_profile="${CLEANROOM_CI_AWS_PROFILE:-$DEFAULT_CI_AWS_PROFILE}"
+  local aws_region="${CLEANROOM_CI_AWS_REGION:-$DEFAULT_CI_AWS_REGION}"
+  local terraform_dir="${CLEANROOM_CI_TERRAFORM_DIR:-$DEFAULT_CI_TERRAFORM_DIR}"
   local instance_id
   local parameters
 

--- a/scripts/ci_bootstrap_linux_ssm_test.go
+++ b/scripts/ci_bootstrap_linux_ssm_test.go
@@ -21,6 +21,7 @@ func TestCIBootstrapLinuxSSMScriptSupportsRunAndLogs(t *testing.T) {
 		"CLEANROOM_CI_AWS_REGION",
 		"CLEANROOM_CI_INSTANCE_ID",
 		"CLEANROOM_CI_TERRAFORM_DIR",
+		"DEFAULT_CI_AWS_REGION=\"ap-southeast-2\"",
 		"terraform -chdir=\"$terraform_dir\" output -raw instance_id",
 		"aws ssm send-command",
 		"aws ssm wait command-executed",


### PR DESCRIPTION
## Summary
- harden Linux bootstrap and user data with IPv4 APT forcing plus retries around network-sensitive steps
- make the rerunnable CI and prod bootstrap scripts reconcile Tailscale as well as service setup
- update tracked Terraform defaults/examples to reflect the active Sydney region defaults and the working Mac CI family
- refresh focused bootstrap/defaults tests to match the new tracked examples

## Testing
- `bash -n scripts/bootstrap-buildkite-agent.sh scripts/bootstrap-cleanroom-host.sh`
- `mise x -- go test ./infra/terraform/envs/ci ./infra/terraform/envs/prod ./scripts`
