### PR TITLE
Center observability on executions

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,10 +382,20 @@ When `rootfs` is unset, Cleanroom derives one from `sandbox.image.ref` and injec
 ```bash
 cleanroom doctor              # check host prerequisites
 cleanroom doctor --json       # machine-readable with capabilities map
-cleanroom status --last-run   # inspect most recent run
-cleanroom status --run-id <id>
+cleanroom sandbox inspect <sandbox-id>
+cleanroom execution inspect --sandbox-id <sandbox-id> --last
+cleanroom execution inspect --sandbox-id <sandbox-id> <execution-id>
+cleanroom status --last       # browse the newest retained execution artifacts
+cleanroom status --execution-id <execution-id>
 cleanroom version
 ```
+
+Failure flow:
+
+- `cleanroom exec` and `cleanroom console` print `sandbox_id` and `execution_id` on failure when available.
+- `cleanroom sandbox inspect <sandbox-id>` shows sandbox state plus `last_execution_id` and `active_execution_id`.
+- `cleanroom execution inspect ...` is the control-plane view for execution status, retained stdout/stderr, image metadata, and observability.
+- `cleanroom status ...` is the local artifact view under `$XDG_STATE_HOME/cleanroom/executions`.
 
 ## Further reading
 

--- a/client/client.go
+++ b/client/client.go
@@ -162,11 +162,11 @@ func (c *Client) CreateExecution(ctx context.Context, req *CreateExecutionReques
 	return c.inner.CreateExecution(ctx, req)
 }
 
-func (c *Client) OpenInteractiveExecution(ctx context.Context, req *OpenInteractiveExecutionRequest) (*OpenInteractiveExecutionResponse, error) {
+func (c *Client) AttachExecution(ctx context.Context, req *AttachExecutionRequest) (*AttachExecutionResponse, error) {
 	if c == nil || c.inner == nil {
 		return nil, errors.New("nil client")
 	}
-	return c.inner.OpenInteractiveExecution(ctx, req)
+	return c.inner.AttachExecution(ctx, req)
 }
 
 func (c *Client) GetExecution(ctx context.Context, req *GetExecutionRequest) (*GetExecutionResponse, error) {
@@ -174,6 +174,13 @@ func (c *Client) GetExecution(ctx context.Context, req *GetExecutionRequest) (*G
 		return nil, errors.New("nil client")
 	}
 	return c.inner.GetExecution(ctx, req)
+}
+
+func (c *Client) InspectExecution(ctx context.Context, req *InspectExecutionRequest) (*InspectExecutionResponse, error) {
+	if c == nil || c.inner == nil {
+		return nil, errors.New("nil client")
+	}
+	return c.inner.InspectExecution(ctx, req)
 }
 
 func (c *Client) CancelExecution(ctx context.Context, req *CancelExecutionRequest) (*CancelExecutionResponse, error) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -19,16 +19,16 @@ type integrationAdapter struct{}
 
 func (integrationAdapter) Name() string { return "firecracker" }
 
-func (integrationAdapter) Run(_ context.Context, req backend.RunRequest) (*backend.RunResult, error) {
-	return &backend.RunResult{
-		RunID:    req.RunID,
-		ExitCode: 0,
-		Stdout:   "hello from cleanroom\n",
-		Message:  "ok",
+func (integrationAdapter) Run(_ context.Context, req backend.ExecutionRequest) (*backend.ExecutionResult, error) {
+	return &backend.ExecutionResult{
+		ExecutionID: req.ExecutionID,
+		ExitCode:    0,
+		Stdout:      "hello from cleanroom\n",
+		Message:     "ok",
 	}, nil
 }
 
-func (a integrationAdapter) RunStream(ctx context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+func (a integrationAdapter) RunStream(ctx context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 	result, err := a.Run(ctx, req)
 	if err != nil {
 		return nil, err
@@ -47,7 +47,7 @@ func (snapshotIntegrationAdapter) ProvisionSandbox(context.Context, backend.Prov
 	return nil
 }
 
-func (a snapshotIntegrationAdapter) RunInSandbox(ctx context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+func (a snapshotIntegrationAdapter) RunInSandbox(ctx context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 	return a.RunStream(ctx, req, stream)
 }
 

--- a/client/ergonomics_test.go
+++ b/client/ergonomics_test.go
@@ -41,7 +41,7 @@ func (a *blockingPersistentAdapter) ProvisionSandbox(context.Context, backend.Pr
 	return nil
 }
 
-func (a *blockingPersistentAdapter) RunInSandbox(ctx context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+func (a *blockingPersistentAdapter) RunInSandbox(ctx context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 	return a.RunStream(ctx, req, stream)
 }
 
@@ -61,7 +61,7 @@ type cancelAwareStreamingAdapter struct {
 	runCanceled chan struct{}
 }
 
-func (a *cancelAwareStreamingAdapter) RunStream(ctx context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+func (a *cancelAwareStreamingAdapter) RunStream(ctx context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 	if a.runEntered != nil {
 		a.runEntered <- struct{}{}
 	}
@@ -76,8 +76,8 @@ type immediateStreamingAdapter struct {
 	integrationAdapter
 }
 
-func (a *immediateStreamingAdapter) RunStream(context.Context, backend.RunRequest, backend.OutputStream) (*backend.RunResult, error) {
-	return &backend.RunResult{
+func (a *immediateStreamingAdapter) RunStream(context.Context, backend.ExecutionRequest, backend.OutputStream) (*backend.ExecutionResult, error) {
+	return &backend.ExecutionResult{
 		ExitCode: 0,
 		Message:  "done",
 	}, nil
@@ -88,18 +88,18 @@ type warningStreamingAdapter struct {
 	warning string
 }
 
-func (a *warningStreamingAdapter) RunStream(_ context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+func (a *warningStreamingAdapter) RunStream(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 	if stream.OnWarning != nil {
 		stream.OnWarning(a.warning)
 	}
 	if stream.OnStdout != nil {
 		stream.OnStdout([]byte("hello from cleanroom\n"))
 	}
-	return &backend.RunResult{
-		RunID:    req.RunID,
-		ExitCode: 0,
-		Stdout:   "hello from cleanroom\n",
-		Message:  "done",
+	return &backend.ExecutionResult{
+		ExecutionID: req.ExecutionID,
+		ExitCode:    0,
+		Stdout:      "hello from cleanroom\n",
+		Message:     "done",
 	}, nil
 }
 

--- a/client/types.go
+++ b/client/types.go
@@ -65,10 +65,12 @@ const (
 type ExecutionOptions = cleanroomv1.ExecutionOptions
 type CreateExecutionRequest = cleanroomv1.CreateExecutionRequest
 type CreateExecutionResponse = cleanroomv1.CreateExecutionResponse
-type OpenInteractiveExecutionRequest = cleanroomv1.OpenInteractiveExecutionRequest
-type OpenInteractiveExecutionResponse = cleanroomv1.OpenInteractiveExecutionResponse
+type AttachExecutionRequest = cleanroomv1.AttachExecutionRequest
+type AttachExecutionResponse = cleanroomv1.AttachExecutionResponse
 type GetExecutionRequest = cleanroomv1.GetExecutionRequest
 type GetExecutionResponse = cleanroomv1.GetExecutionResponse
+type InspectExecutionRequest = cleanroomv1.InspectExecutionRequest
+type InspectExecutionResponse = cleanroomv1.InspectExecutionResponse
 type CancelExecutionRequest = cleanroomv1.CancelExecutionRequest
 type CancelExecutionResponse = cleanroomv1.CancelExecutionResponse
 type WriteExecutionStdinRequest = cleanroomv1.WriteExecutionStdinRequest

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,7 +2,7 @@
 
 ## 1) Goal
 
-Define a minimal, functional API for creating and managing Cleanroom sandboxes with streaming execution support.
+Define a minimal, functional control API for creating and managing Cleanroom sandboxes with durable execution streaming and interactive execution bootstrap.
 
 This document is intentionally small-scope:
 - management plane for sandbox lifecycle
@@ -14,7 +14,7 @@ This document is intentionally small-scope:
 - `Execution`: A single command invocation inside a sandbox.
 - `Event`: Structured runtime and policy events emitted during sandbox/execution lifecycle.
 
-`sandbox` is the top-level API noun. `run_id` remains an internal/audit identifier.
+`sandbox` is the top-level lifecycle noun. `execution_id` is the canonical identifier for a command invocation.
 
 ## 3) Transport Choice
 
@@ -22,11 +22,12 @@ Use ConnectRPC with HTTP/2 enabled in server deployments.
 
 Why:
 - unary RPCs for lifecycle operations
-- server-streaming for event/log tails
-- bidirectional stream for interactive exec (`stdin` -> guest, `stdout/stderr/events` <- guest)
+- server-streaming for durable batch execution output and event tails
+- unary interactive bootstrap via `AttachExecution`, with QUIC carrying interactive PTY bytes and control frames after bootstrap
 
 Non-goal for v1:
 - REST endpoint support.
+- ConnectRPC bidirectional streaming for interactive terminal traffic.
 
 ## 3.1 Process Model (Canonical)
 
@@ -79,12 +80,17 @@ Two services are sufficient.
 ### 4.2 ExecutionService
 
 1. `CreateExecution(CreateExecutionRequest) returns (CreateExecutionResponse)` (unary)
-2. `GetExecution(GetExecutionRequest) returns (GetExecutionResponse)` (unary)
-3. `CancelExecution(CancelExecutionRequest) returns (CancelExecutionResponse)` (unary)
-4. `StreamExecution(StreamExecutionRequest) returns (stream ExecutionStreamEvent)` (server-streaming)
-5. `AttachExecution(stream ExecutionAttachFrame) returns (stream ExecutionAttachFrame)` (bidirectional)
+2. `AttachExecution(AttachExecutionRequest) returns (AttachExecutionResponse)` (unary)
+3. `GetExecution(GetExecutionRequest) returns (GetExecutionResponse)` (unary)
+4. `InspectExecution(InspectExecutionRequest) returns (InspectExecutionResponse)` (unary)
+5. `CancelExecution(CancelExecutionRequest) returns (CancelExecutionResponse)` (unary)
+6. `WriteExecutionStdin(WriteExecutionStdinRequest) returns (WriteExecutionStdinResponse)` (unary)
+7. `CloseExecutionStdin(CloseExecutionStdinRequest) returns (CloseExecutionStdinResponse)` (unary)
+8. `StreamExecution(StreamExecutionRequest) returns (stream ExecutionStreamEvent)` (server-streaming)
 
-`AttachExecution` is for interactive sessions and signaling (stdin, resize, heartbeat, close, stdout/stderr, exit).
+`AttachExecution` is a bootstrap RPC for interactive executions. It returns a session token plus QUIC connection parameters. Interactive PTY bytes and control frames do not flow through ConnectRPC after bootstrap.
+
+`StreamExecution` is the durable batch-oriented output stream. `InspectExecution` is the richer diagnostics surface for retained stdout/stderr, message, image metadata, artifacts dir, and observability payload.
 
 ## 5) Resource and State Model
 
@@ -145,6 +151,7 @@ syntax = "proto3";
 
 package cleanroom.v1;
 
+import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 
 service SandboxService {
@@ -158,8 +165,9 @@ service SandboxService {
 
 service ExecutionService {
   rpc CreateExecution(CreateExecutionRequest) returns (CreateExecutionResponse);
-  rpc OpenInteractiveExecution(OpenInteractiveExecutionRequest) returns (OpenInteractiveExecutionResponse);
+  rpc AttachExecution(AttachExecutionRequest) returns (AttachExecutionResponse);
   rpc GetExecution(GetExecutionRequest) returns (GetExecutionResponse);
+  rpc InspectExecution(InspectExecutionRequest) returns (InspectExecutionResponse);
   rpc CancelExecution(CancelExecutionRequest) returns (CancelExecutionResponse);
   rpc WriteExecutionStdin(WriteExecutionStdinRequest) returns (WriteExecutionStdinResponse);
   rpc CloseExecutionStdin(CloseExecutionStdinRequest) returns (CloseExecutionStdinResponse);
@@ -173,6 +181,8 @@ message Sandbox {
   string policy_hash = 4;
   google.protobuf.Timestamp created_at = 5;
   google.protobuf.Timestamp updated_at = 6;
+  string last_execution_id = 7;
+  string active_execution_id = 8;
 }
 
 enum SandboxStatus {
@@ -193,7 +203,41 @@ message Execution {
   google.protobuf.Timestamp started_at = 6;
   google.protobuf.Timestamp finished_at = 7;
   bool tty = 8;
-  string run_id = 9;
+  ExecutionKind kind = 10;
+}
+
+message AttachExecutionRequest {
+  string sandbox_id = 1;
+  string execution_id = 2;
+  uint32 initial_cols = 3;
+  uint32 initial_rows = 4;
+}
+
+message AttachExecutionResponse {
+  string session_id = 1;
+  string session_token = 2;
+  google.protobuf.Timestamp expires_at = 3;
+  string quic_endpoint = 4;
+  string alpn = 5;
+  string server_cert_pin_sha256 = 6;
+}
+
+message InspectExecutionRequest {
+  string sandbox_id = 1;
+  string execution_id = 2;
+}
+
+message InspectExecutionResponse {
+  Execution execution = 1;
+  string message = 2;
+  string stdout = 3;
+  string stderr = 4;
+  string image_ref = 5;
+  string image_digest = 6;
+  string artifacts_dir = 7;
+  string plan_path = 8;
+  bool launched_vm = 9;
+  google.protobuf.Struct observability = 10;
 }
 
 enum ExecutionStatus {
@@ -204,6 +248,12 @@ enum ExecutionStatus {
   EXECUTION_STATUS_FAILED = 4;
   EXECUTION_STATUS_CANCELED = 5;
   EXECUTION_STATUS_TIMED_OUT = 6;
+}
+
+enum ExecutionKind {
+  EXECUTION_KIND_UNSPECIFIED = 0;
+  EXECUTION_KIND_BATCH = 1;
+  EXECUTION_KIND_INTERACTIVE = 2;
 }
 ```
 
@@ -220,16 +270,24 @@ Expose a server mode and API-driven commands in the same binary.
 ### 9.2 Sandbox commands
 
 - `cleanroom sandbox create`
+- `cleanroom sandbox inspect <sandbox-id>`
 - `cleanroom sandbox ls`
 - `cleanroom sandbox rm <sandbox-id>`
 
+`sandbox inspect` is the primary way to discover a sandbox's `last_execution_id` and `active_execution_id`.
+
 ### 9.3 Execution commands
 
-- `cleanroom executions create <sandbox-id> -- "npm test"`
-- `cleanroom executions get <sandbox-id> <execution-id>`
-- `cleanroom executions cancel <sandbox-id> <execution-id>`
-- `cleanroom executions stream <sandbox-id> <execution-id>`
-- `cleanroom executions attach <sandbox-id> <execution-id>` (PTY-oriented attach/bootstrap)
+- `cleanroom execution inspect --sandbox-id <sandbox-id> <execution-id>`
+- `cleanroom execution inspect --sandbox-id <sandbox-id> --last`
+- `cleanroom status --execution-id <execution-id>`
+- `cleanroom status --last`
+
+Notes:
+- `sandbox inspect` is the lookup surface when you only know a sandbox ID.
+- `execution inspect` is the live control-plane inspection surface.
+- `status` is the local retained-artifacts browser under `$XDG_STATE_HOME/cleanroom/executions`.
+- There are no first-class low-level `execution create/get/cancel/stream` CLI verbs; those are API/SDK operations.
 
 ### 9.4 Local UX
 
@@ -255,12 +313,12 @@ Behavior contract:
    - otherwise create a sandbox from policy
 5. For repo-aware top-level commands, materialize that checkout in the sandbox
    and default the guest working directory to `repository.path`.
-6. Create execution with command and TTY options.
+6. Create execution with explicit kind and TTY options.
 7. Attach stdio according to command mode:
    - `cleanroom exec` defaults to attached stdin plus separate stdout/stderr
      using `StreamExecution`, `WriteExecutionStdin`, and `CloseExecutionStdin`
    - `cleanroom exec -n` closes stdin immediately so the command observes EOF
-   - `cleanroom console` uses `OpenInteractiveExecution` for PTY-oriented
+   - `cleanroom console` uses `AttachExecution` for PTY-oriented
      interactive sessions
 8. Return the command exit code.
 9. Newly created `exec` and `console` sandboxes are terminated after the command
@@ -280,7 +338,13 @@ Signal behavior:
 
 Failure UX:
 - Always print `sandbox_id` and `execution_id` when available.
-- On policy/runtime deny, print stable reason code and a follow-up command to inspect events.
+- On `exec` or `console` failure, also print a ready-to-run `cleanroom execution inspect ...` follow-up command and `artifacts_dir` when available.
+- On policy/runtime deny, print stable reason code and a follow-up command to inspect sandbox or execution state.
+
+Debugging flow:
+1. Start with `cleanroom sandbox inspect <sandbox-id>` when you need the sandbox state or do not yet know the execution ID.
+2. Use `cleanroom execution inspect --sandbox-id <sandbox-id> <execution-id>` for the canonical execution view.
+3. Use `cleanroom status --execution-id <execution-id>` for retained local artifacts and raw observability files.
 
 ## 10) Suggested Implementation Plan
 
@@ -288,7 +352,7 @@ Failure UX:
 2. Implement `cleanroom serve` with in-process adapter wiring.
 3. Implement unary RPCs first (`Create/Get/List/Terminate`, `Create/Get/Cancel`).
 4. Add `StreamExecution` and `StreamSandboxEvents`.
-5. Add `OpenInteractiveExecution` plus stdin attach/close RPCs.
+5. Add `AttachExecution`, `InspectExecution`, and stdin attach/close RPCs.
 6. Implement `cleanroom exec` as an RPC wrapper (`CreateSandbox` ->
    `CreateExecution` -> optional stdin attach/close -> stream -> optional
    `TerminateSandbox`).

--- a/docs/backend/darwin-vz.md
+++ b/docs/backend/darwin-vz.md
@@ -98,7 +98,7 @@ Snapshot/rootfs volume drivers:
 - omitted `snapshots.driver` defaults to `apfs` for `darwin-vz`
 - `snapshots.driver: file` copies ext4 images with standard file I/O
 - `snapshots.driver: apfs` uses macOS `clonefile(2)` for same-filesystem APFS copy-on-write clones and falls back to standard file copies when `clonefile(2)` is unavailable for the selected source/destination
-- the selected driver is used for snapshot capture, snapshot-backed sandbox creation, and writable per-run/per-sandbox rootfs preparation
+- the selected driver is used for snapshot capture, snapshot-backed sandbox creation, and writable per-execution/per-sandbox rootfs preparation
 
 Host tools required for derivation/injection:
 

--- a/docs/isolation.md
+++ b/docs/isolation.md
@@ -16,7 +16,7 @@ Workloads run in a Linux microVM (`firecracker` on Linux, `darwin-vz` on macOS).
 
 ## Observability
 
-Per-run timing metrics are written to `run-observability.json`:
+Per-execution timing metrics are written to `execution-observability.json`:
 - rootfs prep
 - network setup
 - VM ready

--- a/docs/plans/interactive-tty-streaming.md
+++ b/docs/plans/interactive-tty-streaming.md
@@ -17,7 +17,7 @@ Keep Connect RPC for control-plane operations and move interactive bytes to a de
 This work lands in a single umbrella PR, using phased commits:
 
 1. phase 0 (done): remove built-in Tailscale listener modes (`tsnet://`, `tssvc://`) and mTLS management/auth paths; keep plain HTTPS + server-auth TLS.
-2. phase 1 (done): add explicit execution kinds + `OpenInteractiveExecution` bootstrap RPC.
+2. phase 1 (done): add explicit execution kinds + `AttachExecution` bootstrap RPC.
 3. phase 2 (done): add server-side QUIC interactive transport and session registry.
 4. phase 3 (in progress): migrate CLI interactive commands to QUIC path (`console` done; `agent codex` pending command implementation in this repo).
 5. phase 4 (done): remove legacy attach stream path; finalize docs/tests/observability follow-ups.
@@ -105,7 +105,7 @@ Current CLI note:
 Use Connect RPC to open interactive sessions, then pivot to QUIC:
 
 1. `CreateExecution(kind=INTERACTIVE, ...)`.
-2. `OpenInteractiveExecution(execution_id, sandbox_id, initial_tty)` returns:
+2. `AttachExecution(execution_id, sandbox_id, initial_tty)` returns:
    - `session_id`
    - `quic_endpoint` (host:port)
    - `alpn` (`cleanroom-interactive-v1`)
@@ -138,7 +138,7 @@ No JSON, no base64, no per-frame event envelopes in the hot byte path.
 
 1. ALPN: `cleanroom-interactive-v1`.
 2. for remote HTTPS deployments: reuse configured server-auth TLS trust chain.
-3. for local unix/http deployments: use certificate pin returned by `OpenInteractiveExecution`.
+3. for local unix/http deployments: use certificate pin returned by `AttachExecution`.
 4. client verifies either PKI trust or pin before sending token.
 
 ### 4.5 `quic-go` defaults for v1
@@ -178,9 +178,9 @@ Client maps these to stable CLI errors.
 ## API changes (breaking, intentional)
 
 1. `CreateExecutionRequest` takes `kind` instead of inferring from `tty`.
-2. add unary `OpenInteractiveExecution`.
+2. add unary `AttachExecution`.
 3. `StreamExecution` remains batch-only durable stream.
-4. remove `AttachExecution` (done in this branch).
+4. remove the legacy interactive attach stream path; keep `AttachExecution` as the live bootstrap RPC (done in this branch).
 
 CLI/API UX expectation:
 
@@ -213,7 +213,7 @@ Adapters keep backend-specific runtime details internal.
 ### Slice 0: API/schema split
 
 1. add `ExecutionKind`.
-2. add `OpenInteractiveExecution` RPC/messages.
+2. add `AttachExecution` RPC/messages.
 3. keep old `tty` field only as temporary shim in the active migration branch.
 
 Definition of done:
@@ -224,7 +224,7 @@ Definition of done:
 
 1. track interactive session metadata (`session_id`, token hash, owner, ttl, execution binding).
 2. enforce single attach owner.
-3. expose `OpenInteractiveExecution` from service layer.
+3. expose `AttachExecution` from service layer.
 
 Definition of done:
 
@@ -245,7 +245,7 @@ Definition of done:
 
 1. add client-side dialer in `internal/controlclient/client.go`.
 2. in `internal/cli/cli.go` console/agent flows:
-   - call `OpenInteractiveExecution`
+   - call `AttachExecution`
    - dial QUIC
    - map local raw terminal to QUIC streams
 3. keep batch path unchanged.
@@ -256,7 +256,7 @@ Definition of done:
 
 ### Slice 4: remove legacy interactive stream (done)
 
-1. delete `AttachExecution` internals and proto fields once cutover is complete.
+1. delete legacy interactive attach-stream internals and compatibility shims once cutover is complete.
 2. keep only batch stream semantics in `StreamExecution`.
 3. update docs (`docs/api.md`, CLI help).
 

--- a/docs/research.md
+++ b/docs/research.md
@@ -96,7 +96,7 @@ The tools above use different isolation technologies. This section covers each b
 
 [Firecracker](https://github.com/firecracker-microvm/firecracker) is a microVM monitor purpose-built for secure multi-tenant workloads. Minimal device model, fast boot, strong isolation boundary. Network model uses per-VM TAP interfaces and host firewall rules, which maps directly to deny-by-default enforcement.
 
-Cleanroom uses Firecracker as the primary Linux backend. The backend is built around per-run TAP interfaces, host iptables FORWARD rules, generated machine JSON, and vsock guest-agent RPC.
+Cleanroom uses Firecracker as the primary Linux backend. The backend is built around per-execution TAP interfaces, host iptables FORWARD rules, generated machine JSON, and vsock guest-agent RPC.
 
 Used by: E2B, Sprites, Matchlock, Cleanroom.
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -34,9 +34,9 @@ Initial execution backend:
 - Remote execution backends and multi-cloud scheduler federation.
 
 ### 3.1 Responsibility split (v1)
-Cleanroom specifies the normative security contract for a run:
+Cleanroom specifies the normative security contract for a sandbox and its executions:
 - Policy semantics and match behavior (`allow`/`deny`, precedence, defaults).
-- Runtime invariants (policy load timing, immutability during run lifetime).
+- Runtime invariants (policy load timing, immutability during sandbox lifetime).
 - Enforcement outcomes (what must be blocked/allowed for a given effective policy).
 - Required audit event schema and deny reason codes.
 - Backend capability requirements and fail-closed behavior.
@@ -206,7 +206,7 @@ Meaning:
 - Unless an explicit vector command form is added later, `cleanroom exec` defaults to shell execution (e.g., `/bin/sh -lc`) so commands like `cleanroom exec "npm test"` work directly.
 - Cleanroom uses a client/server architecture:
   - `cleanroom` CLI resolves and compiles policy from repository files.
-  - `cleanroom serve` validates compiled policy and executes runs via backend adapters.
+  - `cleanroom serve` validates compiled policy and manages sandbox and execution lifecycle via backend adapters.
   - all CLI commands, including `cleanroom exec`, call the server API.
   - "local execution" means local backend selected by the server, not a direct non-API code path.
 - Filesystem writes persist across executions within a sandbox and are discarded on sandbox termination.
@@ -234,14 +234,14 @@ Meaning:
 - `--keep` preserves a newly created sandbox after execution completes.
 - Reuse an existing sandbox with `--in <id>`.
 - Create a new sandbox from a snapshot with `--from <snapshot-id>`.
-- Interactive mode (`-it`) must use bidirectional stream semantics.
+- Interactive executions must use `AttachExecution` bootstrap plus the dedicated QUIC interactive transport.
 - Non-interactive mode must use server-streaming semantics.
 - First interrupt signal should request execution cancel; second interrupt may detach client stream immediately.
 - If the local repository is dirty, Cleanroom should warn and continue using
   committed `HEAD`; uncommitted changes must not be copied into the sandbox.
 
 ### 5.5 Compiled policy payload (normative)
-Cleanroom compiles repository policy into an immutable `CompiledPolicy` payload for run creation. This payload is the only policy input to backend adapters.
+Cleanroom compiles repository policy into an immutable `CompiledPolicy` payload for sandbox creation. That payload is then reused for every execution in the sandbox. It is the only policy input to backend adapters.
 
 Minimum required fields:
 - `policy_hash` (digest of full compiled payload)
@@ -286,9 +286,9 @@ All runtime launch behavior is initiated by control-plane API calls (for example
 ### 6.1.1 Policy load and immutability
 - Policy is loaded and compiled by the client, then provided to the control plane at sandbox creation.
 - Backend adapters receive a compiled immutable policy payload; they must not receive repository file paths for policy re-resolution.
-- Active runs do not support runtime policy mutation.
-- Backend adapters must not re-read repository policy files after run creation.
-- Guest workloads cannot mutate control-plane policy inputs for the active run.
+- Active sandboxes do not support runtime policy mutation.
+- Backend adapters must not re-read repository policy files after sandbox creation.
+- Guest workloads cannot mutate control-plane policy inputs for the active sandbox.
 
 ### 6.2 Host gateway
 
@@ -385,13 +385,13 @@ Cleanroom provides a Go adapter interface for backend implementations:
 
 - `Adapter`
   - `Name() string`
-  - `Run(ctx, RunRequest) (*RunResult, error)`
+  - `Run(ctx, ExecutionRequest) (*ExecutionResult, error)`
 - `PersistentSandboxAdapter` (extends `Adapter`)
   - `ProvisionSandbox(ctx, ProvisionRequest) error`
-  - `RunInSandbox(ctx, RunRequest, OutputStream) (*RunResult, error)`
+  - `RunInSandbox(ctx, ExecutionRequest, OutputStream) (*ExecutionResult, error)`
   - `TerminateSandbox(ctx, sandboxID) error`
 - `StreamingAdapter` (extends `Adapter`)
-  - `RunStream(ctx, RunRequest, OutputStream) (*RunResult, error)`
+  - `RunStream(ctx, ExecutionRequest, OutputStream) (*ExecutionResult, error)`
 
 ### 7.1 Backend capability contract (required for launch)
 Each backend must publish a capability map consumed by launch-time validation. Capabilities describe enforcement outcomes, not implementation details.
@@ -400,8 +400,8 @@ Required capabilities:
 - `network_default_deny`: backend can enforce deny-by-default outbound network behavior.
 - `network_host_port_filtering`: backend can enforce host/port allow/deny outcomes from compiled policy.
 - `dns_control_or_equivalent`: backend can prevent bypass of policy via unmanaged resolver paths.
-- `policy_immutability`: backend runs against immutable compiled policy payload for the run lifetime.
-- `audit_event_emission`: backend can emit required allow/deny and violation events with run identifiers.
+- `policy_immutability`: backend executes against immutable compiled policy payload for the sandbox lifetime.
+- `audit_event_emission`: backend can emit required allow/deny and violation events with execution identifiers.
 - `secret_isolation`: backend can satisfy secret exposure constraints defined in this spec.
 
 Optional capabilities (may be added by policy requirements later):
@@ -429,7 +429,7 @@ Policy feature mapping:
 - Any unmet requirement results in `backend_capability_mismatch`.
 
 #### Local backend (firecracker)
-- Firecracker microVM with per-run TAP networking and iptables enforcement.
+- Firecracker microVM with per-execution TAP networking and iptables enforcement.
 - Primary use: developer workflows and lightweight local CI.
 - Controls at runtime via host iptables rules + managed DNS from compiled policy.
 
@@ -439,32 +439,39 @@ Policy feature mapping:
   - `cleanroom policy validate`
   - `cleanroom exec [--] <command>`
   - `cleanroom console [--] <command>`
+  - `cleanroom sandbox inspect <sandbox-id>`
+  - `cleanroom sandbox ls`
+  - `cleanroom sandbox rm <sandbox-id>`
+  - `cleanroom execution inspect --sandbox-id <sandbox-id> <execution-id>|--last`
   - `cleanroom doctor`
-  - `cleanroom status`
+  - `cleanroom status [--execution-id <execution-id>|--last]`
   - `cleanroom image pull|ls|rm|import|bump-ref`
 - CI integration:
   - `cleanroom exec --` wrapper for existing and local automation
   - machine-readable output (`--json`) for pipeline tooling
 - API/SDK (v1):
   - ConnectRPC `SandboxService` (`CreateSandbox`, `GetSandbox`, `ListSandboxes`, `DownloadSandboxFile`, `TerminateSandbox`, `StreamSandboxEvents`)
-  - ConnectRPC `ExecutionService` (`CreateExecution`, `GetExecution`, `CancelExecution`, `StreamExecution`, `AttachExecution`)
+  - ConnectRPC `ExecutionService` (`CreateExecution`, `AttachExecution`, `GetExecution`, `InspectExecution`, `CancelExecution`, `WriteExecutionStdin`, `CloseExecutionStdin`, `StreamExecution`)
 
 ### 8.1 CLI and API failure contract (normative)
 CLI:
 - Validation failures (`cleanroom policy validate`, pre-launch compile errors) return non-zero and print structured error details.
 - Launch failures (including `backend_capability_mismatch`) return non-zero before workload execution starts.
 - Runtime policy denies do not change process semantics unless deny prevents command completion; deny events must still be emitted.
+- Non-zero `cleanroom exec` and `cleanroom console` exits print `sandbox_id`, `execution_id`, and a follow-up `cleanroom execution inspect` command when available.
 
 API:
 - `SandboxService.CreateSandbox` returns client error for invalid policy input and conflict/error response for unsatisfied backend requirements.
-- `SandboxService.GetSandbox` and `ExecutionService.GetExecution` must expose terminal status, exit code, and normalized failure reason (if any).
+- `SandboxService.GetSandbox` must expose terminal sandbox status plus `last_execution_id` and `active_execution_id`.
+- `ExecutionService.GetExecution` must expose execution status and exit code.
+- `ExecutionService.InspectExecution` must expose richer diagnostics including message, retained stdout/stderr, artifacts location, and observability payload when available.
 - ConnectRPC errors must include stable application `code` and human-readable `message`.
-- `ExecutionService.StreamExecution` and `ExecutionService.AttachExecution` must terminate cleanly with final exit status signaling.
+- `ExecutionService.StreamExecution` and interactive sessions bootstrapped by `ExecutionService.AttachExecution` must terminate cleanly with final exit status signaling.
 - If an HTTP/JSON gateway is exposed, it must preserve the same stable error codes and reason semantics.
 
 ## 9) Audit and observability
 - Emit structured logs per sandbox with:
-  - `run_id`
+  - `execution_id`
   - `actor`
   - `backend`
   - `timestamp`
@@ -524,7 +531,7 @@ Minimum v1 codes:
 - Core policy compiler to normalized allowlist + registry map
 - Local backend (Firecracker) implementation
 - content-cache wrapper integration for npm and one additional manager
-- `cleanroom serve` foreground server plus `cleanroom daemon` lifecycle management and CLI client command set (`exec`, `sandboxes`, `executions`)
+- `cleanroom serve` foreground server plus `cleanroom daemon` lifecycle management and CLI client command set (`exec`, `console`, `sandbox inspect`, `execution inspect`)
 - `cleanroom exec` RPC wrapper flow
 
 ### Phase 2
@@ -547,9 +554,9 @@ Minimum v1 codes:
 6. Git clones are rewritten to cached smart-HTTP endpoints and private clone auth is provided without plaintext exposure.
 7. Secrets can be used via tokenizer-style proxy flow with host-scoped allowlist and no plaintext secrets in guest/runtime-visible config.
 8. Launch fails when selected backend cannot satisfy required policy capabilities.
-9. Audit logs include `run_id`, `actor`, `backend`, and `policy_hash` for every run.
+9. Audit logs include `execution_id`, `actor`, `backend`, and `policy_hash` for every execution.
 10. Backend adapters must pass the Cleanroom conformance suite for required capabilities before being considered supported.
-11. All CLI execution paths (`exec`, `sandboxes`, `executions`) are routed through the control-plane API; no direct non-API execution path is supported.
+11. All CLI execution paths (`exec`, `console`, `sandbox inspect`, `execution inspect`) are routed through the control-plane API; no direct non-API execution path is supported.
 
 ## 14) Conformance test matrix (required for supported backends)
 Cleanroom must provide a backend-agnostic conformance suite that validates equivalent enforcement outcomes for the same `CompiledPolicy`.

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -30,7 +30,7 @@ var knownCapabilityKeys = []string{
 
 type Adapter interface {
 	Name() string
-	Run(ctx context.Context, req RunRequest) (*RunResult, error)
+	Run(ctx context.Context, req ExecutionRequest) (*ExecutionResult, error)
 }
 
 // CapabilityReporter allows backend adapters to publish backend-specific
@@ -102,7 +102,7 @@ func CloneCapabilities(caps map[string]bool) map[string]bool {
 type PersistentSandboxAdapter interface {
 	Adapter
 	ProvisionSandbox(ctx context.Context, req ProvisionRequest) error
-	RunInSandbox(ctx context.Context, req RunRequest, stream OutputStream) (*RunResult, error)
+	RunInSandbox(ctx context.Context, req ExecutionRequest, stream OutputStream) (*ExecutionResult, error)
 	TerminateSandbox(ctx context.Context, sandboxID string) error
 }
 
@@ -167,15 +167,15 @@ type OutputStream struct {
 // Adapters that don't implement this continue to work via Run.
 type StreamingAdapter interface {
 	Adapter
-	RunStream(ctx context.Context, req RunRequest, stream OutputStream) (*RunResult, error)
+	RunStream(ctx context.Context, req ExecutionRequest, stream OutputStream) (*ExecutionResult, error)
 }
 
-type RunRequest struct {
-	SandboxID string
-	RunID     string
-	Command   []string
-	TTY       bool
-	Policy    *policy.CompiledPolicy
+type ExecutionRequest struct {
+	SandboxID   string
+	ExecutionID string
+	Command     []string
+	TTY         bool
+	Policy      *policy.CompiledPolicy
 	FirecrackerConfig
 }
 
@@ -205,8 +205,8 @@ type SnapshotConfig struct {
 	QuiesceTimeoutSeconds int64
 }
 
-type RunResult struct {
-	RunID       string
+type ExecutionResult struct {
+	ExecutionID string
 	ExitCode    int
 	LaunchedVM  bool
 	PlanPath    string

--- a/internal/backend/capabilities_test.go
+++ b/internal/backend/capabilities_test.go
@@ -9,22 +9,22 @@ type testAdapter struct{}
 
 func (testAdapter) Name() string { return "test" }
 
-func (testAdapter) Run(context.Context, RunRequest) (*RunResult, error) {
-	return &RunResult{}, nil
+func (testAdapter) Run(context.Context, ExecutionRequest) (*ExecutionResult, error) {
+	return &ExecutionResult{}, nil
 }
 
 type testStreamingAdapter struct{ testAdapter }
 
-func (testStreamingAdapter) RunStream(context.Context, RunRequest, OutputStream) (*RunResult, error) {
-	return &RunResult{}, nil
+func (testStreamingAdapter) RunStream(context.Context, ExecutionRequest, OutputStream) (*ExecutionResult, error) {
+	return &ExecutionResult{}, nil
 }
 
 type testPersistentAdapter struct{ testStreamingAdapter }
 
 func (testPersistentAdapter) ProvisionSandbox(context.Context, ProvisionRequest) error { return nil }
 
-func (testPersistentAdapter) RunInSandbox(context.Context, RunRequest, OutputStream) (*RunResult, error) {
-	return &RunResult{}, nil
+func (testPersistentAdapter) RunInSandbox(context.Context, ExecutionRequest, OutputStream) (*ExecutionResult, error) {
+	return &ExecutionResult{}, nil
 }
 
 func (testPersistentAdapter) TerminateSandbox(context.Context, string) error { return nil }

--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -58,7 +58,7 @@ type Adapter struct {
 	sandboxes          map[string]*sandboxInstance
 	provisioning       map[string]struct{}
 	launchSandboxVMFn  func(context.Context, string, *policy.CompiledPolicy, backend.FirecrackerConfig) (*sandboxInstance, error)
-	executeInSandboxFn func(context.Context, context.Context, *sandboxInstance, backend.RunRequest, backend.OutputStream) (*backend.RunResult, error)
+	executeInSandboxFn func(context.Context, context.Context, *sandboxInstance, backend.ExecutionRequest, backend.OutputStream) (*backend.ExecutionResult, error)
 	helperRequestFn    func(context.Context, *helperSession, helperControlRequest) (helperControlResponse, error)
 
 	ensurePreparedRootFSFn func(context.Context, string) (preparedRootFS, error)
@@ -102,10 +102,10 @@ type sandboxInstance struct {
 }
 
 const preparedRuntimeRootFSVersion = "v9-darwin-vz"
-const runObservabilityFile = "run-observability.json"
+const runObservabilityFile = "execution-observability.json"
 
 type darwinVZRunObservation struct {
-	RunID          string           `json:"run_id"`
+	ExecutionID    string           `json:"execution_id"`
 	Backend        string           `json:"backend"`
 	LaunchedVM     bool             `json:"launched_vm"`
 	ImageRef       string           `json:"image_ref,omitempty"`
@@ -280,11 +280,11 @@ func (a *Adapter) Capabilities() map[string]bool {
 	}
 }
 
-func (a *Adapter) Run(ctx context.Context, req backend.RunRequest) (*backend.RunResult, error) {
+func (a *Adapter) Run(ctx context.Context, req backend.ExecutionRequest) (*backend.ExecutionResult, error) {
 	return a.run(ctx, req, backend.OutputStream{})
 }
 
-func (a *Adapter) RunStream(ctx context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+func (a *Adapter) RunStream(ctx context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 	return a.run(ctx, req, stream)
 }
 
@@ -299,7 +299,7 @@ func (a *Adapter) ProvisionSandbox(ctx context.Context, req backend.ProvisionReq
 	return a.provisionSandbox(ctx, sandboxID, req.Policy, req.FirecrackerConfig)
 }
 
-func (a *Adapter) RunInSandbox(ctx context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+func (a *Adapter) RunInSandbox(ctx context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 	sandboxID := strings.TrimSpace(req.SandboxID)
 	if sandboxID == "" {
 		return nil, errors.New("missing sandbox_id")
@@ -307,8 +307,8 @@ func (a *Adapter) RunInSandbox(ctx context.Context, req backend.RunRequest, stre
 	if len(req.Command) == 0 {
 		return nil, errors.New("missing command")
 	}
-	if strings.TrimSpace(req.RunID) == "" {
-		return nil, errors.New("missing run_id")
+	if strings.TrimSpace(req.ExecutionID) == "" {
+		return nil, errors.New("missing execution_id")
 	}
 
 	a.sandboxMu.Lock()
@@ -333,8 +333,8 @@ func (a *Adapter) RunInSandbox(ctx context.Context, req backend.RunRequest, stre
 
 	runDir := strings.TrimSpace(req.RunDir)
 	if runDir == "" {
-		if baseDir, err := paths.RunBaseDir(); err == nil {
-			runDir = filepath.Join(baseDir, req.RunID)
+		if baseDir, err := paths.ExecutionBaseDir(); err == nil {
+			runDir = filepath.Join(baseDir, req.ExecutionID)
 		}
 	}
 	if runDir != "" {
@@ -344,7 +344,7 @@ func (a *Adapter) RunInSandbox(ctx context.Context, req backend.RunRequest, stre
 	}
 	req.RunDir = runDir
 	observation := darwinVZRunObservation{
-		RunID:       req.RunID,
+		ExecutionID: req.ExecutionID,
 		Backend:     a.Name(),
 		RunDir:      runDir,
 		ImageRef:    instance.ImageRef,
@@ -360,7 +360,7 @@ func (a *Adapter) RunInSandbox(ctx context.Context, req backend.RunRequest, stre
 	runStart := time.Now()
 	defer func() {
 		if err := writeDarwinVZRunObservation(runDir, &observation, time.Since(runStart).Milliseconds()); err != nil {
-			log.Warn("write darwin-vz run observability failed", "run_id", req.RunID, "error", err)
+			log.Warn("write darwin-vz run observability failed", "execution_id", req.ExecutionID, "error", err)
 		}
 	}()
 
@@ -453,7 +453,7 @@ func (a *Adapter) CreateSnapshot(ctx context.Context, req backend.SnapshotReques
 	}
 	syncCtx, cancel := context.WithTimeout(ctx, time.Duration(connectSeconds)*time.Second)
 	defer cancel()
-	if _, err := executeInSandbox(syncCtx, ctx, instance, backend.RunRequest{
+	if _, err := executeInSandbox(syncCtx, ctx, instance, backend.ExecutionRequest{
 		SandboxID: sandboxID,
 		Command:   []string{"sync"},
 		Policy:    instance.Policy,
@@ -677,7 +677,7 @@ func (a *Adapter) Doctor(_ context.Context, req backend.DoctorRequest) (*backend
 	return report, nil
 }
 
-func (a *Adapter) run(ctx context.Context, req backend.RunRequest, stream backend.OutputStream) (result *backend.RunResult, err error) {
+func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (result *backend.ExecutionResult, err error) {
 	runStart := time.Now()
 
 	if req.Policy == nil {
@@ -696,17 +696,17 @@ func (a *Adapter) run(ctx context.Context, req backend.RunRequest, stream backen
 
 	runDir := req.RunDir
 	if runDir == "" {
-		baseDir, err := paths.RunBaseDir()
+		baseDir, err := paths.ExecutionBaseDir()
 		if err != nil {
 			return nil, fmt.Errorf("resolve run base directory: %w", err)
 		}
-		runDir = filepath.Join(baseDir, req.RunID)
+		runDir = filepath.Join(baseDir, req.ExecutionID)
 	}
 	if err := os.MkdirAll(runDir, 0o755); err != nil {
 		return nil, fmt.Errorf("create run directory: %w", err)
 	}
 	observation := darwinVZRunObservation{
-		RunID:       req.RunID,
+		ExecutionID: req.ExecutionID,
 		Backend:     a.Name(),
 		RunDir:      runDir,
 		ImageRef:    req.Policy.ImageRef,
@@ -717,7 +717,7 @@ func (a *Adapter) run(ctx context.Context, req backend.RunRequest, stream backen
 			observation.Error = err.Error()
 		}
 		if err := writeDarwinVZRunObservation(runDir, &observation, time.Since(runStart).Milliseconds()); err != nil {
-			log.Warn("write darwin-vz run observability failed", "run_id", req.RunID, "error", err)
+			log.Warn("write darwin-vz run observability failed", "execution_id", req.ExecutionID, "error", err)
 		}
 	}()
 
@@ -761,8 +761,8 @@ func (a *Adapter) run(ctx context.Context, req backend.RunRequest, stream backen
 			return nil, err
 		}
 		observation.PlanPath = planPath
-		return &backend.RunResult{
-			RunID:       req.RunID,
+		return &backend.ExecutionResult{
+			ExecutionID: req.ExecutionID,
 			ExitCode:    0,
 			LaunchedVM:  false,
 			PlanPath:    planPath,
@@ -779,14 +779,14 @@ func (a *Adapter) run(ctx context.Context, req backend.RunRequest, stream backen
 		observation.Error = err.Error()
 		return nil, err
 	}
-	logRunNotice(a.Name(), req.RunID, kernelNotice)
+	logExecutionNotice(a.Name(), req.ExecutionID, kernelNotice)
 
 	rootFSPath, imageRef, imageDigest, rootFSNotice, err := a.resolveRootFSPath(ctx, req)
 	if err != nil {
 		observation.Error = err.Error()
 		return nil, err
 	}
-	logRunNotice(a.Name(), req.RunID, rootFSNotice)
+	logExecutionNotice(a.Name(), req.ExecutionID, rootFSNotice)
 	if strings.TrimSpace(imageRef) != "" {
 		resolvedImageRef = imageRef
 	}
@@ -820,7 +820,7 @@ func (a *Adapter) run(ctx context.Context, req backend.RunRequest, stream backen
 	vmRootFSPath := filepath.Join(runDir, "rootfs-ephemeral.ext4")
 	copyStart := time.Now()
 	writableVolume, err := driver.CreateWritableVolume(ctx, volumestore.CreateWritableVolumeRequest{
-		VolumeID:       req.RunID,
+		VolumeID:       req.ExecutionID,
 		BaseRef:        baseVolume.Ref,
 		AttachmentPath: vmRootFSPath,
 	})
@@ -839,7 +839,7 @@ func (a *Adapter) run(ctx context.Context, req backend.RunRequest, stream backen
 	}()
 
 	guestInitPath, guestInitNotice := guestInitExecutableForRootFS(vmRootFSPath)
-	logRunNotice(a.Name(), req.RunID, guestInitNotice)
+	logExecutionNotice(a.Name(), req.ExecutionID, guestInitNotice)
 	bootArgs := fmt.Sprintf(
 		"console=hvc0 root=/dev/vda rw init=%s cleanroom_guest_port=%d %s",
 		guestInitPath,
@@ -954,7 +954,7 @@ func (a *Adapter) run(ctx context.Context, req backend.RunRequest, stream backen
 		}
 		scopeSandboxID := strings.TrimSpace(req.SandboxID)
 		if scopeSandboxID == "" {
-			scopeSandboxID = strings.TrimSpace(req.RunID)
+			scopeSandboxID = strings.TrimSpace(req.ExecutionID)
 		}
 		if scopeSandboxID == "" {
 			scopeSandboxID = vmID
@@ -1025,8 +1025,8 @@ func (a *Adapter) run(ctx context.Context, req backend.RunRequest, stream backen
 	observation.ExitCode = guestRes.ExitCode
 	observation.GuestError = guestRes.Error
 
-	return &backend.RunResult{
-		RunID:       req.RunID,
+	return &backend.ExecutionResult{
+		ExecutionID: req.ExecutionID,
 		ExitCode:    guestRes.ExitCode,
 		LaunchedVM:  true,
 		PlanPath:    vmPlanPath,
@@ -1067,7 +1067,7 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 	if err != nil {
 		return nil, err
 	}
-	rootFSPath, imageRef, imageDigest, _, err := a.resolveRootFSPath(ctx, backend.RunRequest{
+	rootFSPath, imageRef, imageDigest, _, err := a.resolveRootFSPath(ctx, backend.ExecutionRequest{
 		Policy:            compiled,
 		FirecrackerConfig: cfg,
 	})
@@ -1288,7 +1288,7 @@ func (a *Adapter) launchSandbox(ctx context.Context, sandboxID string, compiled 
 	return launch(ctx, sandboxID, compiled, cfg)
 }
 
-func (a *Adapter) executeInSandbox(bootCtx context.Context, runCtx context.Context, instance *sandboxInstance, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+func (a *Adapter) executeInSandbox(bootCtx context.Context, runCtx context.Context, instance *sandboxInstance, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 	if instance == nil {
 		return nil, errors.New("nil sandbox instance")
 	}
@@ -1353,7 +1353,7 @@ func (a *Adapter) executeInSandbox(bootCtx context.Context, runCtx context.Conte
 			scopeSandboxID = strings.TrimSpace(instance.SandboxID)
 		}
 		if scopeSandboxID == "" {
-			scopeSandboxID = strings.TrimSpace(req.RunID)
+			scopeSandboxID = strings.TrimSpace(req.ExecutionID)
 		}
 		if err := a.GatewayRegistry.RegisterScopeToken(token, scopeSandboxID, policy); err != nil {
 			return nil, fmt.Errorf("register sandbox in gateway: %w", err)
@@ -1408,8 +1408,8 @@ func (a *Adapter) executeInSandbox(bootCtx context.Context, runCtx context.Conte
 		return nil, helper.decorateError(fmt.Errorf("decode guest exec response over darwin-vz proxy: %w", err))
 	}
 
-	return &backend.RunResult{
-		RunID:       req.RunID,
+	return &backend.ExecutionResult{
+		ExecutionID: req.ExecutionID,
 		ExitCode:    guestRes.ExitCode,
 		LaunchedVM:  false,
 		PlanPath:    instance.ConfigPath,
@@ -1704,7 +1704,7 @@ type imageArtifact struct {
 	CacheHit   bool
 }
 
-func (a *Adapter) resolveRootFSPath(ctx context.Context, req backend.RunRequest) (path, imageRef, imageDigest, notice string, err error) {
+func (a *Adapter) resolveRootFSPath(ctx context.Context, req backend.ExecutionRequest) (path, imageRef, imageDigest, notice string, err error) {
 	configuredPath := strings.TrimSpace(req.RootFSPath)
 	if configuredPath != "" {
 		if _, statErr := os.Stat(configuredPath); statErr == nil {
@@ -2388,7 +2388,7 @@ func copyFile(src, dst string) error {
 	return out.Sync()
 }
 
-func logRunNotice(backendName, runID, notice string) {
+func logExecutionNotice(backendName, runID, notice string) {
 	msg := strings.TrimSpace(notice)
 	if msg == "" {
 		return
@@ -2396,7 +2396,7 @@ func logRunNotice(backendName, runID, notice string) {
 	fields := []any{"backend", strings.TrimSpace(backendName)}
 	id := strings.TrimSpace(runID)
 	if id != "" {
-		fields = append(fields, "run_id", id)
+		fields = append(fields, "execution_id", id)
 	}
 	log.Info(msg, fields...)
 }

--- a/internal/backend/darwinvz/backend_message_test.go
+++ b/internal/backend/darwinvz/backend_message_test.go
@@ -63,7 +63,7 @@ func TestLogRunNoticeUsesCharmLogger(t *testing.T) {
 	})
 	log.SetDefault(logger)
 
-	logRunNotice("darwin-vz", "run-123", "using managed kernel asset my-kernel (cache hit)")
+	logExecutionNotice("darwin-vz", "run-123", "using managed kernel asset my-kernel (cache hit)")
 
 	out := buf.String()
 	if !strings.Contains(out, "using managed kernel asset my-kernel (cache hit)") {
@@ -72,7 +72,7 @@ func TestLogRunNoticeUsesCharmLogger(t *testing.T) {
 	if !strings.Contains(out, "backend=darwin-vz") {
 		t.Fatalf("expected backend field in logger output, got %q", out)
 	}
-	if !strings.Contains(out, "run_id=run-123") {
-		t.Fatalf("expected run_id field in logger output, got %q", out)
+	if !strings.Contains(out, "execution_id=run-123") {
+		t.Fatalf("expected execution_id field in logger output, got %q", out)
 	}
 }

--- a/internal/backend/darwinvz/backend_unsupported.go
+++ b/internal/backend/darwinvz/backend_unsupported.go
@@ -32,11 +32,11 @@ func (a *Adapter) Capabilities() map[string]bool {
 	}
 }
 
-func (a *Adapter) Run(_ context.Context, _ backend.RunRequest) (*backend.RunResult, error) {
+func (a *Adapter) Run(_ context.Context, _ backend.ExecutionRequest) (*backend.ExecutionResult, error) {
 	return nil, fmt.Errorf("darwin-vz backend requires macOS, current OS is %s", runtime.GOOS)
 }
 
-func (a *Adapter) RunStream(ctx context.Context, req backend.RunRequest, _ backend.OutputStream) (*backend.RunResult, error) {
+func (a *Adapter) RunStream(ctx context.Context, req backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
 	return a.Run(ctx, req)
 }
 

--- a/internal/backend/darwinvz/observability_test.go
+++ b/internal/backend/darwinvz/observability_test.go
@@ -32,7 +32,7 @@ func TestWriteDarwinVZRunObservationIncludesHelperTimings(t *testing.T) {
 
 	runDir := t.TempDir()
 	obs := darwinVZRunObservation{
-		RunID:        "run-123",
+		ExecutionID:  "run-123",
 		Backend:      "darwin-vz",
 		LaunchedVM:   true,
 		RunDir:       runDir,
@@ -57,8 +57,8 @@ func TestWriteDarwinVZRunObservationIncludesHelperTimings(t *testing.T) {
 		t.Fatalf("parse observability file: %v", err)
 	}
 
-	if got, want := payload["run_id"], "run-123"; got != want {
-		t.Fatalf("unexpected run_id: got %v want %v", got, want)
+	if got, want := payload["execution_id"], "run-123"; got != want {
+		t.Fatalf("unexpected execution_id: got %v want %v", got, want)
 	}
 	if got, want := payload["vm_ready_ms"], float64(321); got != want {
 		t.Fatalf("unexpected vm_ready_ms: got %v want %v", got, want)
@@ -87,12 +87,12 @@ func TestRunInSandboxWritesObservabilityWithPendingLaunchTimings(t *testing.T) {
 
 	runDir := t.TempDir()
 	adapter := &Adapter{
-		executeInSandboxFn: func(_ context.Context, _ context.Context, instance *sandboxInstance, req backend.RunRequest, _ backend.OutputStream) (*backend.RunResult, error) {
+		executeInSandboxFn: func(_ context.Context, _ context.Context, instance *sandboxInstance, req backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
 			if instance == nil || instance.SandboxID != "cr-test" {
 				t.Fatalf("unexpected sandbox instance: %#v", instance)
 			}
-			return &backend.RunResult{
-				RunID:       req.RunID,
+			return &backend.ExecutionResult{
+				ExecutionID: req.ExecutionID,
 				ExitCode:    0,
 				LaunchedVM:  false,
 				PlanPath:    "/tmp/fake-plan.json",
@@ -115,11 +115,11 @@ func TestRunInSandboxWritesObservabilityWithPendingLaunchTimings(t *testing.T) {
 		},
 	}
 
-	_, err := adapter.RunInSandbox(context.Background(), backend.RunRequest{
-		SandboxID: "cr-test",
-		RunID:     "run-123",
-		Command:   []string{"echo", "hello"},
-		Policy:    &policy.CompiledPolicy{NetworkDefault: "deny"},
+	_, err := adapter.RunInSandbox(context.Background(), backend.ExecutionRequest{
+		SandboxID:   "cr-test",
+		ExecutionID: "run-123",
+		Command:     []string{"echo", "hello"},
+		Policy:      &policy.CompiledPolicy{NetworkDefault: "deny"},
 		FirecrackerConfig: backend.FirecrackerConfig{
 			RunDir: runDir,
 		},
@@ -153,10 +153,10 @@ func TestRunWritesObservabilityErrorWhenRequestedCommandWriteFails(t *testing.T)
 	}
 
 	adapter := &Adapter{}
-	_, err := adapter.run(context.Background(), backend.RunRequest{
-		RunID:   "run-write-fail",
-		Command: []string{"echo", "hello"},
-		Policy:  &policy.CompiledPolicy{NetworkDefault: "deny"},
+	_, err := adapter.run(context.Background(), backend.ExecutionRequest{
+		ExecutionID: "run-write-fail",
+		Command:     []string{"echo", "hello"},
+		Policy:      &policy.CompiledPolicy{NetworkDefault: "deny"},
 		FirecrackerConfig: backend.FirecrackerConfig{
 			RunDir: runDir,
 			Launch: false,

--- a/internal/backend/darwinvz/persistent_e2e_test.go
+++ b/internal/backend/darwinvz/persistent_e2e_test.go
@@ -112,9 +112,9 @@ func TestPersistentSandboxE2E(t *testing.T) {
 	markerValue := "darwin-vz-persisted-state"
 
 	run1Dir := filepath.Join(t.TempDir(), "run-1")
-	first, err := adapter.RunInSandbox(ctx, backend.RunRequest{
-		SandboxID: sandboxID,
-		RunID:     "run-1",
+	first, err := adapter.RunInSandbox(ctx, backend.ExecutionRequest{
+		SandboxID:   sandboxID,
+		ExecutionID: "run-1",
 		Command: []string{
 			"sh", "-lc", fmt.Sprintf("printf %s > %s", markerValue, markerPath),
 		},
@@ -135,11 +135,11 @@ func TestPersistentSandboxE2E(t *testing.T) {
 	}
 
 	run2Dir := filepath.Join(t.TempDir(), "run-2")
-	second, err := adapter.RunInSandbox(ctx, backend.RunRequest{
-		SandboxID: sandboxID,
-		RunID:     "run-2",
-		Command:   []string{"sh", "-lc", "cat " + markerPath},
-		Policy:    compiled,
+	second, err := adapter.RunInSandbox(ctx, backend.ExecutionRequest{
+		SandboxID:   sandboxID,
+		ExecutionID: "run-2",
+		Command:     []string{"sh", "-lc", "cat " + markerPath},
+		Policy:      compiled,
 		FirecrackerConfig: backend.FirecrackerConfig{
 			RunDir:        run2Dir,
 			LaunchSeconds: cfg.LaunchSeconds,
@@ -169,11 +169,11 @@ func TestPersistentSandboxE2E(t *testing.T) {
 	if _, err := os.Stat(sandboxRunDir); !os.IsNotExist(err) {
 		t.Fatalf("expected sandbox runtime dir to be removed, got err=%v", err)
 	}
-	if _, err := adapter.RunInSandbox(context.Background(), backend.RunRequest{
-		SandboxID: sandboxID,
-		RunID:     "run-after-terminate",
-		Command:   []string{"true"},
-		Policy:    compiled,
+	if _, err := adapter.RunInSandbox(context.Background(), backend.ExecutionRequest{
+		SandboxID:   sandboxID,
+		ExecutionID: "run-after-terminate",
+		Command:     []string{"true"},
+		Policy:      compiled,
 	}, backend.OutputStream{}); err == nil || !strings.Contains(err.Error(), "unknown sandbox") {
 		t.Fatalf("expected run after terminate to fail with unknown sandbox, got %v", err)
 	}
@@ -251,11 +251,11 @@ func TestPersistentSandboxE2EExecStreamingDoesNotHang(t *testing.T) {
 	// A quick warm-up run that exercises the readiness/proxy path before we
 	// assert repeated non-interactive executions complete promptly.
 	warmupCtx, warmupCancel := context.WithTimeout(ctx, 60*time.Second)
-	warmup, err := adapter.RunInSandbox(warmupCtx, backend.RunRequest{
-		SandboxID: sandboxID,
-		RunID:     "run-warmup",
-		Command:   []string{"sh", "-lc", "echo warmup"},
-		Policy:    compiled,
+	warmup, err := adapter.RunInSandbox(warmupCtx, backend.ExecutionRequest{
+		SandboxID:   sandboxID,
+		ExecutionID: "run-warmup",
+		Command:     []string{"sh", "-lc", "echo warmup"},
+		Policy:      compiled,
 		FirecrackerConfig: backend.FirecrackerConfig{
 			LaunchSeconds: cfg.LaunchSeconds,
 		},
@@ -272,11 +272,11 @@ func TestPersistentSandboxE2EExecStreamingDoesNotHang(t *testing.T) {
 		runID := fmt.Sprintf("run-stream-%d", i)
 		want := fmt.Sprintf("stream-%d", i)
 		runCtx, runCancel := context.WithTimeout(ctx, 30*time.Second)
-		res, err := adapter.RunInSandbox(runCtx, backend.RunRequest{
-			SandboxID: sandboxID,
-			RunID:     runID,
-			Command:   []string{"sh", "-lc", "echo " + want},
-			Policy:    compiled,
+		res, err := adapter.RunInSandbox(runCtx, backend.ExecutionRequest{
+			SandboxID:   sandboxID,
+			ExecutionID: runID,
+			Command:     []string{"sh", "-lc", "echo " + want},
+			Policy:      compiled,
 			FirecrackerConfig: backend.FirecrackerConfig{
 				LaunchSeconds: cfg.LaunchSeconds,
 			},

--- a/internal/backend/darwinvz/persistent_test.go
+++ b/internal/backend/darwinvz/persistent_test.go
@@ -91,7 +91,7 @@ func TestRunInSandboxUsesRequestLaunchSecondsOverride(t *testing.T) {
 	block := make(chan struct{})
 	defer close(block)
 	adapter := &Adapter{}
-	adapter.executeInSandboxFn = func(bootCtx context.Context, _ context.Context, instance *sandboxInstance, req backend.RunRequest, _ backend.OutputStream) (*backend.RunResult, error) {
+	adapter.executeInSandboxFn = func(bootCtx context.Context, _ context.Context, instance *sandboxInstance, req backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
 		if instance == nil || instance.SandboxID != "cr-test" {
 			t.Fatalf("unexpected sandbox instance: %#v", instance)
 		}
@@ -110,10 +110,10 @@ func TestRunInSandboxUsesRequestLaunchSecondsOverride(t *testing.T) {
 	}
 
 	start := time.Now()
-	_, err := adapter.RunInSandbox(context.Background(), backend.RunRequest{
-		SandboxID: "cr-test",
-		RunID:     "run-timeout",
-		Command:   []string{"echo", "hello"},
+	_, err := adapter.RunInSandbox(context.Background(), backend.ExecutionRequest{
+		SandboxID:   "cr-test",
+		ExecutionID: "run-timeout",
+		Command:     []string{"echo", "hello"},
 		Policy: &policy.CompiledPolicy{
 			NetworkDefault: "deny",
 		},
@@ -142,11 +142,11 @@ func TestRunInSandboxRejectsExitedSandbox(t *testing.T) {
 		},
 	}
 
-	_, err := adapter.RunInSandbox(context.Background(), backend.RunRequest{
-		SandboxID: "cr-test",
-		RunID:     "run-dead",
-		Command:   []string{"true"},
-		Policy:    &policy.CompiledPolicy{NetworkDefault: "deny"},
+	_, err := adapter.RunInSandbox(context.Background(), backend.ExecutionRequest{
+		SandboxID:   "cr-test",
+		ExecutionID: "run-dead",
+		Command:     []string{"true"},
+		Policy:      &policy.CompiledPolicy{NetworkDefault: "deny"},
 	}, backend.OutputStream{})
 	if err == nil {
 		t.Fatal("expected dead sandbox run to fail")

--- a/internal/backend/darwinvz/rootfs_test.go
+++ b/internal/backend/darwinvz/rootfs_test.go
@@ -21,7 +21,7 @@ func TestResolveRootFSPathUsesConfiguredRootFS(t *testing.T) {
 	}
 
 	adapter := New()
-	req := backend.RunRequest{
+	req := backend.ExecutionRequest{
 		Policy: &policy.CompiledPolicy{
 			ImageRef:    "ghcr.io/buildkite/cleanroom-base/alpine@sha256:abc",
 			ImageDigest: "sha256:abc",
@@ -65,7 +65,7 @@ func TestResolveRootFSPathDerivesFromPolicyImageRef(t *testing.T) {
 		}, nil
 	}
 
-	req := backend.RunRequest{
+	req := backend.ExecutionRequest{
 		Policy: &policy.CompiledPolicy{
 			ImageRef: "ghcr.io/buildkite/cleanroom-base/alpine@sha256:def",
 		},
@@ -93,7 +93,7 @@ func TestResolveRootFSPathRequiresImageRefWhenRootFSUnset(t *testing.T) {
 	t.Parallel()
 
 	adapter := New()
-	req := backend.RunRequest{
+	req := backend.ExecutionRequest{
 		Policy: &policy.CompiledPolicy{},
 	}
 	_, _, _, _, err := adapter.resolveRootFSPath(context.Background(), req)
@@ -115,7 +115,7 @@ func TestResolveRootFSPathFallsBackWhenConfiguredRootFSMissing(t *testing.T) {
 		}, nil
 	}
 
-	req := backend.RunRequest{
+	req := backend.ExecutionRequest{
 		Policy: &policy.CompiledPolicy{
 			ImageRef: "ghcr.io/buildkite/cleanroom-base/alpine@sha256:xyz",
 		},

--- a/internal/backend/darwinvz/snapshot_e2e_test.go
+++ b/internal/backend/darwinvz/snapshot_e2e_test.go
@@ -75,11 +75,11 @@ func TestSnapshotLifecycleE2E(t *testing.T) {
 	runCommand := func(ctx context.Context, adapter *Adapter, sandboxID, runID string, command ...string) string {
 		t.Helper()
 
-		result, err := adapter.RunInSandbox(ctx, backend.RunRequest{
-			SandboxID: sandboxID,
-			RunID:     runID,
-			Command:   command,
-			Policy:    compiled,
+		result, err := adapter.RunInSandbox(ctx, backend.ExecutionRequest{
+			SandboxID:   sandboxID,
+			ExecutionID: runID,
+			Command:     command,
+			Policy:      compiled,
 			FirecrackerConfig: backend.FirecrackerConfig{
 				LaunchSeconds: cfg.LaunchSeconds,
 			},

--- a/internal/backend/darwinvz/snapshot_test.go
+++ b/internal/backend/darwinvz/snapshot_test.go
@@ -27,14 +27,14 @@ func TestCreateSnapshotSyncsPausesAndClonesRootFS(t *testing.T) {
 
 	var helperOps []string
 	adapter := &Adapter{
-		executeInSandboxFn: func(_ context.Context, _ context.Context, instance *sandboxInstance, req backend.RunRequest, _ backend.OutputStream) (*backend.RunResult, error) {
+		executeInSandboxFn: func(_ context.Context, _ context.Context, instance *sandboxInstance, req backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
 			if instance == nil || instance.SandboxID != "cr-test" {
 				t.Fatalf("unexpected sandbox instance: %#v", instance)
 			}
 			if len(req.Command) != 1 || req.Command[0] != "sync" {
 				t.Fatalf("unexpected command: %v", req.Command)
 			}
-			return &backend.RunResult{ExitCode: 0}, nil
+			return &backend.ExecutionResult{ExitCode: 0}, nil
 		},
 		helperRequestFn: func(_ context.Context, helper *helperSession, req helperControlRequest) (helperControlResponse, error) {
 			if helper == nil {

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -94,7 +94,7 @@ type sandboxInstance struct {
 	vmRootFSPath   string
 }
 
-const runObservabilityFile = "run-observability.json"
+const runObservabilityFile = "execution-observability.json"
 const vsockDialRetryInterval = 50 * time.Millisecond
 const preparedRuntimeRootFSVersion = "v1"
 const defaultPrivilegedHelperPath = "/usr/local/sbin/cleanroom-root-helper"
@@ -231,11 +231,11 @@ func (a *Adapter) Capabilities() map[string]bool {
 	}
 }
 
-func (a *Adapter) Run(ctx context.Context, req backend.RunRequest) (*backend.RunResult, error) {
+func (a *Adapter) Run(ctx context.Context, req backend.ExecutionRequest) (*backend.ExecutionResult, error) {
 	return a.run(ctx, req, backend.OutputStream{})
 }
 
-func (a *Adapter) RunStream(ctx context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+func (a *Adapter) RunStream(ctx context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 	return a.run(ctx, req, stream)
 }
 
@@ -290,7 +290,7 @@ func (a *Adapter) ProvisionSandbox(ctx context.Context, req backend.ProvisionReq
 	return nil
 }
 
-func (a *Adapter) RunInSandbox(ctx context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+func (a *Adapter) RunInSandbox(ctx context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 	sandboxID := strings.TrimSpace(req.SandboxID)
 	if sandboxID == "" {
 		return nil, errors.New("missing sandbox_id")
@@ -298,8 +298,8 @@ func (a *Adapter) RunInSandbox(ctx context.Context, req backend.RunRequest, stre
 	if len(req.Command) == 0 {
 		return nil, errors.New("missing command")
 	}
-	if strings.TrimSpace(req.RunID) == "" {
-		return nil, errors.New("missing run_id")
+	if strings.TrimSpace(req.ExecutionID) == "" {
+		return nil, errors.New("missing execution_id")
 	}
 
 	a.sandboxMu.Lock()
@@ -315,12 +315,12 @@ func (a *Adapter) RunInSandbox(ctx context.Context, req backend.RunRequest, stre
 	runStart := time.Now()
 	runDir := strings.TrimSpace(req.RunDir)
 	if runDir == "" {
-		if baseDir, err := paths.RunBaseDir(); err == nil {
-			runDir = filepath.Join(baseDir, req.RunID)
+		if baseDir, err := paths.ExecutionBaseDir(); err == nil {
+			runDir = filepath.Join(baseDir, req.ExecutionID)
 		}
 	}
 	observation := firecrackerRunObservation{
-		RunID:       req.RunID,
+		ExecutionID: req.ExecutionID,
 		Backend:     a.Name(),
 		LaunchedVM:  false,
 		ImageRef:    instance.ImageRef,
@@ -359,8 +359,8 @@ func (a *Adapter) RunInSandbox(ctx context.Context, req backend.RunRequest, stre
 		message = runResultMessage("guest command execution completed with guest-side error detail: " + guestResult.Error)
 	}
 
-	return &backend.RunResult{
-		RunID:       req.RunID,
+	return &backend.ExecutionResult{
+		ExecutionID: req.ExecutionID,
 		ExitCode:    guestResult.ExitCode,
 		LaunchedVM:  false,
 		PlanPath:    instance.ConfigPath,
@@ -782,13 +782,13 @@ func (a *Adapter) Doctor(_ context.Context, req backend.DoctorRequest) (*backend
 	return report, nil
 }
 
-func (a *Adapter) run(ctx context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 	runStart := time.Now()
 	observation := firecrackerRunObservation{
-		RunID:      req.RunID,
-		Backend:    a.Name(),
-		LaunchedVM: req.Launch,
-		ExitCode:   1,
+		ExecutionID: req.ExecutionID,
+		Backend:     a.Name(),
+		LaunchedVM:  req.Launch,
+		ExitCode:    1,
 	}
 
 	if req.Policy == nil {
@@ -808,11 +808,11 @@ func (a *Adapter) run(ctx context.Context, req backend.RunRequest, stream backen
 
 	runDir := req.RunDir
 	if runDir == "" {
-		baseDir, err := paths.RunBaseDir()
+		baseDir, err := paths.ExecutionBaseDir()
 		if err != nil {
 			return nil, fmt.Errorf("resolve run base directory: %w", err)
 		}
-		runDir = filepath.Join(baseDir, req.RunID)
+		runDir = filepath.Join(baseDir, req.ExecutionID)
 	}
 	if err := os.MkdirAll(runDir, 0o755); err != nil {
 		return nil, err
@@ -858,8 +858,8 @@ func (a *Adapter) run(ctx context.Context, req backend.RunRequest, stream backen
 
 		observation.PlanPath = planPath
 		observation.RunDir = runDir
-		return &backend.RunResult{
-			RunID:       req.RunID,
+		return &backend.ExecutionResult{
+			ExecutionID: req.ExecutionID,
 			ExitCode:    0,
 			LaunchedVM:  false,
 			PlanPath:    planPath,
@@ -884,7 +884,7 @@ func (a *Adapter) run(ctx context.Context, req backend.RunRequest, stream backen
 	if err != nil {
 		return nil, err
 	}
-	logRunNotice(a.Name(), req.RunID, kernelNotice)
+	logExecutionNotice(a.Name(), req.ExecutionID, kernelNotice)
 
 	imageArtifact, err := a.ensureImageArtifact(ctx, req.Policy.ImageRef)
 	if err != nil {
@@ -927,7 +927,7 @@ func (a *Adapter) run(ctx context.Context, req backend.RunRequest, stream backen
 	networkRunBatch := func(ctx context.Context, commands [][]string) error {
 		return runRootCommandBatch(ctx, req.FirecrackerConfig, commands)
 	}
-	networkCfg, cleanupNetwork, err := setupHostNetwork(ctx, req.RunID, req.Policy.Allow, 0, networkRunCommand, networkRunBatch)
+	networkCfg, cleanupNetwork, err := setupHostNetwork(ctx, req.ExecutionID, req.Policy.Allow, 0, networkRunCommand, networkRunBatch)
 	if err != nil {
 		return nil, fmt.Errorf("setup host network: %w", err)
 	}
@@ -978,7 +978,7 @@ func (a *Adapter) run(ctx context.Context, req backend.RunRequest, stream backen
 			{
 				IfaceID:     "eth0",
 				HostDevName: networkCfg.TapName,
-				GuestMac:    guestMACFromRunID(req.RunID),
+				GuestMac:    guestMACFromExecutionID(req.ExecutionID),
 			},
 		},
 		Entropy: &entropyConfig{},
@@ -1080,8 +1080,8 @@ func (a *Adapter) run(ctx context.Context, req backend.RunRequest, stream backen
 
 	timingSummary := fmt.Sprintf("timings boot=%s vsock_wait=%s exec=%s", vmReady, guestTiming.WaitForAgent, guestTiming.CommandRun)
 
-	return &backend.RunResult{
-		RunID:       req.RunID,
+	return &backend.ExecutionResult{
+		ExecutionID: req.ExecutionID,
 		ExitCode:    guestResult.ExitCode,
 		LaunchedVM:  true,
 		PlanPath:    cfgPath,
@@ -1095,7 +1095,7 @@ func (a *Adapter) run(ctx context.Context, req backend.RunRequest, stream backen
 }
 
 type firecrackerRunObservation struct {
-	RunID              string `json:"run_id"`
+	ExecutionID        string `json:"execution_id"`
 	Backend            string `json:"backend"`
 	LaunchedVM         bool   `json:"launched_vm"`
 	ImageRef           string `json:"image_ref,omitempty"`
@@ -1604,7 +1604,7 @@ func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID strin
 		NetworkInterfaces: []networkInterface{{
 			IfaceID:     "eth0",
 			HostDevName: networkCfg.TapName,
-			GuestMac:    guestMACFromRunID(sandboxID),
+			GuestMac:    guestMACFromExecutionID(sandboxID),
 		}},
 		Entropy: &entropyConfig{},
 	}
@@ -1955,7 +1955,7 @@ func setupHostNetworkWithDeps(ctx context.Context, runID string, allow []policy.
 }
 
 func setupHostNetworkWithTapLookup(ctx context.Context, runID string, allow []policy.AllowRule, gatewayPort int, lookup ipLookupFunc, interfaceByName interfaceLookupFunc, runCommand rootCommandFunc, runBatchCommand rootCommandBatchFunc) (hostNetworkConfig, func(), error) {
-	tapName := tapNameFromRunID(runID)
+	tapName := tapNameFromExecutionID(runID)
 	hostIP, guestIP := hostGuestIPs(runID)
 	hostCIDR := hostIP + "/24"
 	guestCIDR := guestIP + "/32"
@@ -2267,7 +2267,7 @@ func helperVersion(ctx context.Context, cfg backend.FirecrackerConfig) (string, 
 	return strings.TrimSpace(string(out)), nil
 }
 
-func logRunNotice(backendName, runID, notice string) {
+func logExecutionNotice(backendName, runID, notice string) {
 	msg := strings.TrimSpace(notice)
 	if msg == "" {
 		return
@@ -2277,7 +2277,7 @@ func logRunNotice(backendName, runID, notice string) {
 		log.Printf("%s: %s", backendName, msg)
 		return
 	}
-	log.Printf("%s run_id=%s: %s", backendName, id, msg)
+	log.Printf("%s execution_id=%s: %s", backendName, id, msg)
 }
 
 func runRootCommand(ctx context.Context, cfg backend.FirecrackerConfig, args ...string) error {
@@ -2421,7 +2421,7 @@ func sanitizeKernelArgValue(value string) string {
 	return b.String()
 }
 
-func tapNameFromRunID(runID string) string {
+func tapNameFromExecutionID(runID string) string {
 	filtered := strings.Map(func(r rune) rune {
 		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
 			return r
@@ -2453,7 +2453,7 @@ func hostGuestIPs(runID string) (string, string) {
 	return hostIP, guestIP
 }
 
-func guestMACFromRunID(runID string) string {
+func guestMACFromExecutionID(runID string) string {
 	sum := sha1.Sum([]byte(runID))
 	return fmt.Sprintf("02:fc:%02x:%02x:%02x:%02x", sum[0], sum[1], sum[2], sum[3])
 }

--- a/internal/backend/firecracker/network_test.go
+++ b/internal/backend/firecracker/network_test.go
@@ -154,7 +154,7 @@ func TestSetupHostNetworkWithTapLookupDeletesStaleTapBeforeCreate(t *testing.T) 
 	t.Parallel()
 
 	runID := "run-12345"
-	tapName := tapNameFromRunID(runID)
+	tapName := tapNameFromExecutionID(runID)
 	staleTapExists := true
 
 	var calls [][]string

--- a/internal/backend/firecracker/persistent_test.go
+++ b/internal/backend/firecracker/persistent_test.go
@@ -100,9 +100,9 @@ func TestRunInSandboxUsesRequestLaunchSecondsOverride(t *testing.T) {
 	}
 
 	start := time.Now()
-	_, err := adapter.RunInSandbox(context.Background(), backend.RunRequest{
+	_, err := adapter.RunInSandbox(context.Background(), backend.ExecutionRequest{
 		SandboxID:         "cr-test",
-		RunID:             "run-timeout",
+		ExecutionID:       "run-timeout",
 		Command:           []string{"echo", "hello"},
 		FirecrackerConfig: backend.FirecrackerConfig{LaunchSeconds: 3},
 	}, backend.OutputStream{})
@@ -139,10 +139,10 @@ func TestRunInSandboxWritesRunObservabilityForStatusCommand(t *testing.T) {
 		},
 	}
 
-	result, err := adapter.RunInSandbox(context.Background(), backend.RunRequest{
-		SandboxID: "cr-test",
-		RunID:     "run-123",
-		Command:   []string{"echo", "hello"},
+	result, err := adapter.RunInSandbox(context.Background(), backend.ExecutionRequest{
+		SandboxID:   "cr-test",
+		ExecutionID: "run-123",
+		Command:     []string{"echo", "hello"},
 		FirecrackerConfig: backend.FirecrackerConfig{
 			RunDir: runDir,
 		},
@@ -163,8 +163,8 @@ func TestRunInSandboxWritesRunObservabilityForStatusCommand(t *testing.T) {
 	if err := json.Unmarshal(b, &obs); err != nil {
 		t.Fatalf("parse observability json: %v", err)
 	}
-	if got, want := obs["run_id"], "run-123"; got != want {
-		t.Fatalf("unexpected run_id: got %v want %v", got, want)
+	if got, want := obs["execution_id"], "run-123"; got != want {
+		t.Fatalf("unexpected execution_id: got %v want %v", got, want)
 	}
 }
 
@@ -187,10 +187,10 @@ func TestRunInSandboxWritesRunObservabilityOnError(t *testing.T) {
 		},
 	}
 
-	_, err := adapter.RunInSandbox(context.Background(), backend.RunRequest{
-		SandboxID: "cr-test",
-		RunID:     "run-err",
-		Command:   []string{"echo", "hello"},
+	_, err := adapter.RunInSandbox(context.Background(), backend.ExecutionRequest{
+		SandboxID:   "cr-test",
+		ExecutionID: "run-err",
+		Command:     []string{"echo", "hello"},
 		FirecrackerConfig: backend.FirecrackerConfig{
 			RunDir: runDir,
 		},
@@ -208,8 +208,8 @@ func TestRunInSandboxWritesRunObservabilityOnError(t *testing.T) {
 	if err := json.Unmarshal(b, &obs); err != nil {
 		t.Fatalf("parse observability json: %v", err)
 	}
-	if got, want := obs["run_id"], "run-err"; got != want {
-		t.Fatalf("unexpected run_id: got %v want %v", got, want)
+	if got, want := obs["execution_id"], "run-err"; got != want {
+		t.Fatalf("unexpected execution_id: got %v want %v", got, want)
 	}
 	if got := obs["guest_error"]; got == nil || got == "" {
 		t.Fatalf("expected guest_error to be recorded, got %v", got)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -44,19 +44,20 @@ type runtimeContext struct {
 }
 
 type CLI struct {
-	Policy   PolicyCommand   `cmd:"" help:"Policy commands"`
-	Config   ConfigCommand   `cmd:"" help:"Runtime config commands"`
-	Image    ImageCommand    `cmd:"" help:"Manage OCI image cache artifacts"`
-	Snapshot SnapshotCommand `cmd:"" help:"Manage snapshots"`
-	Create   CreateCommand   `cmd:"" help:"Create a sandbox"`
-	Exec     ExecCommand     `cmd:"" help:"Execute a command in a cleanroom backend"`
-	Console  ConsoleCommand  `cmd:"" help:"Attach an interactive console to a cleanroom execution"`
-	Serve    ServeCommand    `cmd:"" help:"Run the cleanroom control-plane server in the foreground"`
-	Daemon   DaemonCommand   `cmd:"" help:"Manage daemon/service lifecycle"`
-	Doctor   DoctorCommand   `cmd:"" help:"Run environment and backend diagnostics"`
-	Status   StatusCommand   `cmd:"" help:"Inspect run artifacts"`
-	Sandbox  SandboxCommand  `cmd:"" help:"Manage sandboxes"`
-	Version  VersionCommand  `cmd:"" help:"Print version information"`
+	Policy    PolicyCommand    `cmd:"" help:"Policy commands"`
+	Config    ConfigCommand    `cmd:"" help:"Runtime config commands"`
+	Image     ImageCommand     `cmd:"" help:"Manage OCI image cache artifacts"`
+	Snapshot  SnapshotCommand  `cmd:"" help:"Manage snapshots"`
+	Create    CreateCommand    `cmd:"" help:"Create a sandbox"`
+	Exec      ExecCommand      `cmd:"" help:"Execute a command in a sandbox"`
+	Console   ConsoleCommand   `cmd:"" help:"Open an interactive console in a sandbox"`
+	Serve     ServeCommand     `cmd:"" help:"Run the cleanroom control-plane server in the foreground"`
+	Daemon    DaemonCommand    `cmd:"" help:"Manage daemon/service lifecycle"`
+	Doctor    DoctorCommand    `cmd:"" help:"Run environment and backend diagnostics"`
+	Execution ExecutionCommand `cmd:"" help:"Inspect command executions and diagnostics"`
+	Status    StatusCommand    `cmd:"" help:"Browse retained execution artifacts"`
+	Sandbox   SandboxCommand   `cmd:"" help:"Manage sandboxes"`
+	Version   VersionCommand   `cmd:"" help:"Print version information"`
 }
 
 type VersionCommand struct {

--- a/internal/cli/console.go
+++ b/internal/cli/console.go
@@ -91,6 +91,18 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) (runErr error) {
 		printedSandboxID = true
 		return nil
 	}
+	executionID := ""
+	printedExecutionID := false
+	printExecutionID := func() error {
+		if printedExecutionID {
+			return nil
+		}
+		if err := writeExecutionID(os.Stderr, executionID); err != nil {
+			return err
+		}
+		printedExecutionID = true
+		return nil
+	}
 	defer func() {
 		if !createdSandbox || !c.Keep {
 			return
@@ -101,6 +113,35 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) (runErr error) {
 				return
 			}
 			runErr = errors.Join(runErr, err)
+		}
+	}()
+	defer func() {
+		if runErr == nil {
+			return
+		}
+		var extraErr error
+		if err := printSandboxID(); err != nil {
+			extraErr = errors.Join(extraErr, err)
+		}
+		if err := printExecutionID(); err != nil {
+			extraErr = errors.Join(extraErr, err)
+		}
+		if sandboxID != "" && executionID != "" {
+			if err := writeExecutionInspectCommand(os.Stderr, sandboxID, executionID); err != nil {
+				extraErr = errors.Join(extraErr, err)
+			}
+			resp, err := client.InspectExecution(context.Background(), &cleanroomv1.InspectExecutionRequest{
+				SandboxId:   sandboxID,
+				ExecutionId: executionID,
+			})
+			if err == nil {
+				if err := writeArtifactsDir(os.Stderr, resp.GetArtifactsDir()); err != nil {
+					extraErr = errors.Join(extraErr, err)
+				}
+			}
+		}
+		if extraErr != nil {
+			runErr = errors.Join(runErr, extraErr)
 		}
 	}()
 	if c.PrintSandboxID {
@@ -129,12 +170,12 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) (runErr error) {
 	if err != nil {
 		return fmt.Errorf("create execution: %w", err)
 	}
-	executionID := createExecutionResp.GetExecution().GetExecutionId()
+	executionID = createExecutionResp.GetExecution().GetExecutionId()
 	logger.Debug("console execution started", "sandbox_id", sandboxID, "execution_id", executionID)
 
 	stdinFD := int(os.Stdin.Fd())
 	initialCols, initialRows := attachTTYSize(stdinFD)
-	openResp, err := client.OpenInteractiveExecution(context.Background(), &cleanroomv1.OpenInteractiveExecutionRequest{
+	openResp, err := client.AttachExecution(context.Background(), &cleanroomv1.AttachExecutionRequest{
 		SandboxId:   sandboxID,
 		ExecutionId: executionID,
 		InitialCols: initialCols,
@@ -144,7 +185,7 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) (runErr error) {
 		if isExecutionNoLongerActiveErr(err) {
 			exitCode, haveExitCode, replayErr := replayExecutionHistory(client, sandboxID, executionID, ctx.Stdout, os.Stderr)
 			if replayErr != nil {
-				return fmt.Errorf("open interactive execution: %w", err)
+				return fmt.Errorf("attach interactive console: %w", err)
 			}
 			if !haveExitCode {
 				if fetchedExitCode, ok := getFinalExecutionExitCode(client, sandboxID, executionID); ok {
@@ -160,7 +201,7 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) (runErr error) {
 			}
 			return nil
 		}
-		return fmt.Errorf("open interactive execution: %w", err)
+		return fmt.Errorf("attach interactive console: %w", err)
 	}
 	controlEndpoint, err := endpoint.Resolve(host)
 	if err != nil {

--- a/internal/cli/console_integration_test.go
+++ b/internal/cli/console_integration_test.go
@@ -23,7 +23,7 @@ func TestConsoleIntegrationForwardsStdinAndStreamsOutput(t *testing.T) {
 	started := make(chan struct{}, 1)
 	var captured bytes.Buffer
 	adapter := &integrationAdapter{
-		runStreamFn: func(ctx context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+		runStreamFn: func(ctx context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 			if !req.TTY {
 				return nil, errors.New("expected tty execution")
 			}
@@ -57,11 +57,11 @@ func TestConsoleIntegrationForwardsStdinAndStreamsOutput(t *testing.T) {
 			case <-ctx.Done():
 				return nil, ctx.Err()
 			}
-			return &backend.RunResult{
-				RunID:    req.RunID,
-				ExitCode: 0,
-				Stdout:   captured.String(),
-				Message:  "ok",
+			return &backend.ExecutionResult{
+				ExecutionID: req.ExecutionID,
+				ExitCode:    0,
+				Stdout:      captured.String(),
+				Message:     "ok",
 			}, nil
 		},
 	}
@@ -96,7 +96,7 @@ func TestConsoleIntegrationForwardsStdinAndStreamsOutput(t *testing.T) {
 func TestConsoleIntegrationInterruptCancelsExecution(t *testing.T) {
 	started := make(chan struct{}, 1)
 	adapter := &integrationAdapter{
-		runStreamFn: func(ctx context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+		runStreamFn: func(ctx context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 			if stream.OnAttach != nil {
 				stream.OnAttach(backend.AttachIO{
 					WriteStdin: func(_ []byte) error { return nil },
@@ -148,7 +148,7 @@ func TestConsoleIntegrationSecondInterruptForcesLocalExitWhenExecutionIgnoresCan
 		close(releaseRun)
 	})
 	adapter := &integrationAdapter{
-		runStreamFn: func(_ context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+		runStreamFn: func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 			if stream.OnAttach != nil {
 				stream.OnAttach(backend.AttachIO{
 					WriteStdin: func(_ []byte) error { return nil },
@@ -159,7 +159,7 @@ func TestConsoleIntegrationSecondInterruptForcesLocalExitWhenExecutionIgnoresCan
 			default:
 			}
 			<-releaseRun
-			return &backend.RunResult{RunID: req.RunID, ExitCode: 0, Message: "released"}, nil
+			return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "released"}, nil
 		},
 	}
 
@@ -198,7 +198,7 @@ func TestConsoleIntegrationSecondInterruptAfterWindowDoesNotForceLocalExit(t *te
 	started := make(chan struct{}, 1)
 	releaseRun := make(chan struct{})
 	adapter := &integrationAdapter{
-		runStreamFn: func(_ context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+		runStreamFn: func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 			if stream.OnAttach != nil {
 				stream.OnAttach(backend.AttachIO{WriteStdin: func(_ []byte) error { return nil }})
 			}
@@ -207,7 +207,7 @@ func TestConsoleIntegrationSecondInterruptAfterWindowDoesNotForceLocalExit(t *te
 			default:
 			}
 			<-releaseRun
-			return &backend.RunResult{RunID: req.RunID, ExitCode: 0, Message: "released"}, nil
+			return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "released"}, nil
 		},
 	}
 
@@ -266,8 +266,8 @@ func TestConsoleRejectsUnsupportedHostScheme(t *testing.T) {
 
 func TestConsoleIntegrationDefaultTerminatesCreatedSandbox(t *testing.T) {
 	host, _ := startIntegrationServer(t, &integrationAdapter{
-		runStreamFn: func(_ context.Context, req backend.RunRequest, _ backend.OutputStream) (*backend.RunResult, error) {
-			return &backend.RunResult{RunID: req.RunID, ExitCode: 0, Stdout: "ok\n", Message: "ok"}, nil
+		runStreamFn: func(_ context.Context, req backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
+			return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Stdout: "ok\n", Message: "ok"}, nil
 		},
 	})
 
@@ -297,8 +297,8 @@ func TestConsoleIntegrationDefaultTerminatesCreatedSandbox(t *testing.T) {
 
 func TestConsoleIntegrationKeepPreservesCreatedSandbox(t *testing.T) {
 	host, _ := startIntegrationServer(t, &integrationAdapter{
-		runStreamFn: func(_ context.Context, req backend.RunRequest, _ backend.OutputStream) (*backend.RunResult, error) {
-			return &backend.RunResult{RunID: req.RunID, ExitCode: 0, Stdout: "ok\n", Message: "ok"}, nil
+		runStreamFn: func(_ context.Context, req backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
+			return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Stdout: "ok\n", Message: "ok"}, nil
 		},
 	})
 
@@ -328,8 +328,8 @@ func TestConsoleIntegrationKeepPreservesCreatedSandbox(t *testing.T) {
 
 func TestConsoleIntegrationKeepWithPrintSandboxIDPrintsOnce(t *testing.T) {
 	host, _ := startIntegrationServer(t, &integrationAdapter{
-		runStreamFn: func(_ context.Context, req backend.RunRequest, _ backend.OutputStream) (*backend.RunResult, error) {
-			return &backend.RunResult{RunID: req.RunID, ExitCode: 0, Stdout: "ok\n", Message: "ok"}, nil
+		runStreamFn: func(_ context.Context, req backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
+			return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Stdout: "ok\n", Message: "ok"}, nil
 		},
 	})
 
@@ -356,7 +356,7 @@ func TestConsoleIntegrationKeepWithPrintSandboxIDPrintsOnce(t *testing.T) {
 func TestConsoleIntegrationReuseSandboxSkipsPolicyCompile(t *testing.T) {
 	started := make(chan struct{}, 1)
 	host, _ := startIntegrationServer(t, &integrationAdapter{
-		runStreamFn: func(_ context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+		runStreamFn: func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 			done := make(chan struct{})
 			if stream.OnAttach != nil {
 				stream.OnAttach(backend.AttachIO{
@@ -380,7 +380,7 @@ func TestConsoleIntegrationReuseSandboxSkipsPolicyCompile(t *testing.T) {
 			default:
 			}
 			<-done
-			return &backend.RunResult{RunID: req.RunID, ExitCode: 0, Stdout: "ok\n", Message: "ok"}, nil
+			return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Stdout: "ok\n", Message: "ok"}, nil
 		},
 	})
 	client := mustNewControlClient(t, host)
@@ -408,8 +408,8 @@ func TestConsoleIntegrationReuseSandboxSkipsPolicyCompile(t *testing.T) {
 
 func TestConsoleIntegrationRejectsKeepWhenReusingSandbox(t *testing.T) {
 	host, _ := startIntegrationServer(t, &integrationAdapter{
-		runStreamFn: func(_ context.Context, req backend.RunRequest, _ backend.OutputStream) (*backend.RunResult, error) {
-			return &backend.RunResult{RunID: req.RunID, ExitCode: 0, Stdout: "ok\n", Message: "ok"}, nil
+		runStreamFn: func(_ context.Context, req backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
+			return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Stdout: "ok\n", Message: "ok"}, nil
 		},
 	})
 	client := mustNewControlClient(t, host)
@@ -437,7 +437,7 @@ func TestConsoleIntegrationRejectsKeepWhenReusingSandbox(t *testing.T) {
 
 func TestConsoleIntegrationRoutesBackendWarningsToStderr(t *testing.T) {
 	host, _ := startIntegrationServer(t, &integrationAdapter{
-		runStreamFn: func(_ context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+		runStreamFn: func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 			if stream.OnAttach != nil {
 				stream.OnAttach(backend.AttachIO{
 					WriteStdin: func([]byte) error { return nil },
@@ -449,11 +449,11 @@ func TestConsoleIntegrationRoutesBackendWarningsToStderr(t *testing.T) {
 			if stream.OnStdout != nil {
 				stream.OnStdout([]byte("/ # "))
 			}
-			return &backend.RunResult{
-				RunID:    req.RunID,
-				ExitCode: 0,
-				Stdout:   "/ # ",
-				Stderr:   "warning: backend warning\n",
+			return &backend.ExecutionResult{
+				ExecutionID: req.ExecutionID,
+				ExitCode:    0,
+				Stdout:      "/ # ",
+				Stderr:      "warning: backend warning\n",
 			}, nil
 		},
 	})
@@ -476,5 +476,47 @@ func TestConsoleIntegrationRoutesBackendWarningsToStderr(t *testing.T) {
 	}
 	if strings.Contains(outcome.stdout, "warning: backend warning\n") {
 		t.Fatalf("unexpected warning in stdout: %q", outcome.stdout)
+	}
+}
+
+func TestConsoleIntegrationPrintsExecutionHintsOnFailure(t *testing.T) {
+	host, _ := startIntegrationServer(t, &integrationAdapter{
+		runStreamFn: func(_ context.Context, req backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
+			return &backend.ExecutionResult{
+				ExecutionID: req.ExecutionID,
+				ExitCode:    7,
+				Message:     "failed",
+				RunDir:      "/tmp/console-failed",
+			}, nil
+		},
+	})
+
+	outcome := runConsoleWithCapture(ConsoleCommand{
+		clientFlags: clientFlags{Host: host},
+		Command:     []string{"sh"},
+	}, "", runtimeContext{
+		CWD:    t.TempDir(),
+		Loader: integrationLoader{},
+	})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err == nil {
+		t.Fatal("expected non-zero exit from failed console execution")
+	}
+	if got, want := ExitCode(outcome.err), 7; got != want {
+		t.Fatalf("unexpected console exit code: got %d want %d (err=%v)", got, want, outcome.err)
+	}
+	if got := parseSandboxID(outcome.stderr); got == "" {
+		t.Fatalf("expected sandbox_id in failure output, got %q", outcome.stderr)
+	}
+	if got := parseExecutionID(outcome.stderr); got == "" {
+		t.Fatalf("expected execution_id in failure output, got %q", outcome.stderr)
+	}
+	if !strings.Contains(outcome.stderr, "inspect_command=cleanroom execution inspect --sandbox-id ") {
+		t.Fatalf("expected inspect_command in failure output, got %q", outcome.stderr)
+	}
+	if !strings.Contains(outcome.stderr, "artifacts_dir=/tmp/console-failed") {
+		t.Fatalf("expected artifacts_dir in failure output, got %q", outcome.stderr)
 	}
 }

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -18,8 +18,8 @@ type doctorTestAdapter struct{}
 
 func (doctorTestAdapter) Name() string { return "doctor-test" }
 
-func (doctorTestAdapter) Run(context.Context, backend.RunRequest) (*backend.RunResult, error) {
-	return &backend.RunResult{Message: "ok"}, nil
+func (doctorTestAdapter) Run(context.Context, backend.ExecutionRequest) (*backend.ExecutionResult, error) {
+	return &backend.ExecutionResult{Message: "ok"}, nil
 }
 
 func (doctorTestAdapter) Doctor(context.Context, backend.DoctorRequest) (*backend.DoctorReport, error) {
@@ -45,8 +45,8 @@ func (doctorSnapshotAdapter) ProvisionSandbox(context.Context, backend.Provision
 	return nil
 }
 
-func (doctorSnapshotAdapter) RunInSandbox(context.Context, backend.RunRequest, backend.OutputStream) (*backend.RunResult, error) {
-	return &backend.RunResult{Message: "ok"}, nil
+func (doctorSnapshotAdapter) RunInSandbox(context.Context, backend.ExecutionRequest, backend.OutputStream) (*backend.ExecutionResult, error) {
+	return &backend.ExecutionResult{Message: "ok"}, nil
 }
 
 func (doctorSnapshotAdapter) TerminateSandbox(context.Context, string) error {

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -70,6 +70,7 @@ func (e *ExecCommand) Run(ctx *runtimeContext) (runErr error) {
 		}
 		return err
 	}
+	executionID := ""
 	printedSandboxID := false
 	printSandboxID := func() error {
 		if printedSandboxID {
@@ -79,6 +80,17 @@ func (e *ExecCommand) Run(ctx *runtimeContext) (runErr error) {
 			return err
 		}
 		printedSandboxID = true
+		return nil
+	}
+	printedExecutionID := false
+	printExecutionID := func() error {
+		if printedExecutionID {
+			return nil
+		}
+		if err := writeExecutionID(os.Stderr, executionID); err != nil {
+			return err
+		}
+		printedExecutionID = true
 		return nil
 	}
 	defer func() {
@@ -91,6 +103,35 @@ func (e *ExecCommand) Run(ctx *runtimeContext) (runErr error) {
 				return
 			}
 			runErr = errors.Join(runErr, err)
+		}
+	}()
+	defer func() {
+		if runErr == nil {
+			return
+		}
+		var extraErr error
+		if err := printSandboxID(); err != nil {
+			extraErr = errors.Join(extraErr, err)
+		}
+		if err := printExecutionID(); err != nil {
+			extraErr = errors.Join(extraErr, err)
+		}
+		if sandboxID != "" && executionID != "" {
+			if err := writeExecutionInspectCommand(os.Stderr, sandboxID, executionID); err != nil {
+				extraErr = errors.Join(extraErr, err)
+			}
+			resp, err := client.InspectExecution(context.Background(), &cleanroomv1.InspectExecutionRequest{
+				SandboxId:   sandboxID,
+				ExecutionId: executionID,
+			})
+			if err == nil {
+				if err := writeArtifactsDir(os.Stderr, resp.GetArtifactsDir()); err != nil {
+					extraErr = errors.Join(extraErr, err)
+				}
+			}
+		}
+		if extraErr != nil {
+			runErr = errors.Join(runErr, extraErr)
 		}
 	}()
 	if e.PrintSandboxID {
@@ -119,7 +160,7 @@ func (e *ExecCommand) Run(ctx *runtimeContext) (runErr error) {
 	if err != nil {
 		return fmt.Errorf("create execution: %w", err)
 	}
-	executionID := createExecutionResp.GetExecution().GetExecutionId()
+	executionID = createExecutionResp.GetExecution().GetExecutionId()
 
 	logger.Debug("execution started", "sandbox_id", sandboxID, "execution_id", executionID)
 

--- a/internal/cli/exec_integration_test.go
+++ b/internal/cli/exec_integration_test.go
@@ -31,8 +31,8 @@ import (
 type integrationAdapter struct {
 	mu sync.Mutex
 
-	runFn                    func(context.Context, backend.RunRequest) (*backend.RunResult, error)
-	runStreamFn              func(context.Context, backend.RunRequest, backend.OutputStream) (*backend.RunResult, error)
+	runFn                    func(context.Context, backend.ExecutionRequest) (*backend.ExecutionResult, error)
+	runStreamFn              func(context.Context, backend.ExecutionRequest, backend.OutputStream) (*backend.ExecutionResult, error)
 	provisionFn              func(context.Context, backend.ProvisionRequest) error
 	provisionFromSnapshotFn  func(context.Context, backend.ProvisionFromSnapshotRequest) error
 	createSnapshotFn         func(context.Context, backend.SnapshotRequest) (*backend.SnapshotResult, error)
@@ -46,17 +46,17 @@ type integrationAdapter struct {
 
 func (a *integrationAdapter) Name() string { return "firecracker" }
 
-func (a *integrationAdapter) Run(ctx context.Context, req backend.RunRequest) (*backend.RunResult, error) {
+func (a *integrationAdapter) Run(ctx context.Context, req backend.ExecutionRequest) (*backend.ExecutionResult, error) {
 	a.mu.Lock()
 	fn := a.runFn
 	a.mu.Unlock()
 	if fn != nil {
 		return fn(ctx, req)
 	}
-	return &backend.RunResult{RunID: req.RunID, ExitCode: 0, Message: "ok"}, nil
+	return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
 }
 
-func (a *integrationAdapter) RunStream(ctx context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+func (a *integrationAdapter) RunStream(ctx context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 	a.mu.Lock()
 	fn := a.runStreamFn
 	a.mu.Unlock()
@@ -91,7 +91,7 @@ func (a *snapshotIntegrationAdapter) ProvisionSandbox(ctx context.Context, req b
 	return nil
 }
 
-func (a *snapshotIntegrationAdapter) RunInSandbox(ctx context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+func (a *snapshotIntegrationAdapter) RunInSandbox(ctx context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 	return a.RunStream(ctx, req, stream)
 }
 
@@ -406,6 +406,14 @@ func parseSandboxID(stderr string) string {
 	return strings.TrimSpace(match[1])
 }
 
+func parseExecutionID(stderr string) string {
+	match := regexp.MustCompile(`execution_id="?([^"\s]+)"?`).FindStringSubmatch(stderr)
+	if len(match) < 2 {
+		return ""
+	}
+	return strings.TrimSpace(match[1])
+}
+
 func mustNewControlClient(t *testing.T, host string) *controlclient.Client {
 	t.Helper()
 
@@ -452,7 +460,7 @@ func requireSandboxStatus(t *testing.T, client *controlclient.Client, sandboxID 
 
 func TestExecIntegrationStreamsOutput(t *testing.T) {
 	adapter := &integrationAdapter{
-		runStreamFn: func(_ context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+		runStreamFn: func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 			if stream.OnStdout != nil {
 				stream.OnStdout([]byte("one\n"))
 			}
@@ -460,11 +468,11 @@ func TestExecIntegrationStreamsOutput(t *testing.T) {
 			if stream.OnStdout != nil {
 				stream.OnStdout([]byte("two\n"))
 			}
-			return &backend.RunResult{
-				RunID:    req.RunID,
-				ExitCode: 0,
-				Stdout:   "one\ntwo\n",
-				Message:  "ok",
+			return &backend.ExecutionResult{
+				ExecutionID: req.ExecutionID,
+				ExitCode:    0,
+				Stdout:      "one\ntwo\n",
+				Message:     "ok",
 			}, nil
 		},
 	}
@@ -501,7 +509,7 @@ func TestExecIntegrationForwardsStdinByDefault(t *testing.T) {
 	)
 	stdinClosed := make(chan struct{}, 1)
 	adapter := &integrationAdapter{
-		runStreamFn: func(_ context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+		runStreamFn: func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 			if stream.OnAttach != nil {
 				stream.OnAttach(backend.AttachIO{
 					WriteStdin: func(data []byte) error {
@@ -532,11 +540,11 @@ func TestExecIntegrationForwardsStdinByDefault(t *testing.T) {
 			if stream.OnStdout != nil {
 				stream.OnStdout([]byte(output))
 			}
-			return &backend.RunResult{
-				RunID:    req.RunID,
-				ExitCode: 0,
-				Stdout:   output,
-				Message:  "ok",
+			return &backend.ExecutionResult{
+				ExecutionID: req.ExecutionID,
+				ExitCode:    0,
+				Stdout:      output,
+				Message:     "ok",
 			}, nil
 		},
 	}
@@ -581,7 +589,7 @@ func TestExecIntegrationIgnoresLateBenignStdinWriteFailures(t *testing.T) {
 		stdinCalls int
 	)
 	adapter := &integrationAdapter{
-		runStreamFn: func(_ context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+		runStreamFn: func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 			if stream.OnAttach != nil {
 				stream.OnAttach(backend.AttachIO{
 					WriteStdin: func(data []byte) error {
@@ -620,11 +628,11 @@ func TestExecIntegrationIgnoresLateBenignStdinWriteFailures(t *testing.T) {
 			if stream.OnStdout != nil {
 				stream.OnStdout([]byte("done\n"))
 			}
-			return &backend.RunResult{
-				RunID:    req.RunID,
-				ExitCode: 0,
-				Stdout:   "done\n",
-				Message:  "ok",
+			return &backend.ExecutionResult{
+				ExecutionID: req.ExecutionID,
+				ExitCode:    0,
+				Stdout:      "done\n",
+				Message:     "ok",
 			}, nil
 		},
 	}
@@ -665,7 +673,7 @@ func TestExecIntegrationNoStdinClosesImmediately(t *testing.T) {
 	stdinWrites := make(chan string, 1)
 	stdinClosed := make(chan struct{}, 1)
 	adapter := &integrationAdapter{
-		runStreamFn: func(_ context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+		runStreamFn: func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 			if stream.OnAttach != nil {
 				stream.OnAttach(backend.AttachIO{
 					WriteStdin: func(data []byte) error {
@@ -692,11 +700,11 @@ func TestExecIntegrationNoStdinClosesImmediately(t *testing.T) {
 			if stream.OnStdout != nil {
 				stream.OnStdout([]byte("closed\n"))
 			}
-			return &backend.RunResult{
-				RunID:    req.RunID,
-				ExitCode: 0,
-				Stdout:   "closed\n",
-				Message:  "ok",
+			return &backend.ExecutionResult{
+				ExecutionID: req.ExecutionID,
+				ExitCode:    0,
+				Stdout:      "closed\n",
+				Message:     "ok",
 			}, nil
 		},
 	}
@@ -732,7 +740,7 @@ func TestExecIntegrationNoStdinClosesImmediately(t *testing.T) {
 func TestExecIntegrationNoStdinFailureDoesNotHangWhileStreamBlocked(t *testing.T) {
 	started := make(chan struct{}, 1)
 	adapter := &integrationAdapter{
-		runFn: func(ctx context.Context, _ backend.RunRequest) (*backend.RunResult, error) {
+		runFn: func(ctx context.Context, _ backend.ExecutionRequest) (*backend.ExecutionResult, error) {
 			select {
 			case started <- struct{}{}:
 			default:
@@ -774,13 +782,14 @@ func TestExecIntegrationNoStdinFailureDoesNotHangWhileStreamBlocked(t *testing.T
 
 func TestExecIntegrationPropagatesExitAndStderr(t *testing.T) {
 	adapter := &integrationAdapter{
-		runFn: func(_ context.Context, req backend.RunRequest) (*backend.RunResult, error) {
-			return &backend.RunResult{
-				RunID:    req.RunID,
-				ExitCode: 7,
-				Stdout:   "out\n",
-				Stderr:   "err\n",
-				Message:  "failed",
+		runFn: func(_ context.Context, req backend.ExecutionRequest) (*backend.ExecutionResult, error) {
+			return &backend.ExecutionResult{
+				ExecutionID: req.ExecutionID,
+				ExitCode:    7,
+				Stdout:      "out\n",
+				Stderr:      "err\n",
+				RunDir:      "/tmp/exec-failed",
+				Message:     "failed",
 			}, nil
 		},
 	}
@@ -811,6 +820,18 @@ func TestExecIntegrationPropagatesExitAndStderr(t *testing.T) {
 	if !strings.Contains(outcome.stderr, "err\n") {
 		t.Fatalf("expected stderr in stream output, got %q", outcome.stderr)
 	}
+	if got := parseSandboxID(outcome.stderr); got == "" {
+		t.Fatalf("expected sandbox_id in failure output, got %q", outcome.stderr)
+	}
+	if got := parseExecutionID(outcome.stderr); got == "" {
+		t.Fatalf("expected execution_id in failure output, got %q", outcome.stderr)
+	}
+	if !strings.Contains(outcome.stderr, "inspect_command=cleanroom execution inspect --sandbox-id ") {
+		t.Fatalf("expected inspect_command in failure output, got %q", outcome.stderr)
+	}
+	if !strings.Contains(outcome.stderr, "artifacts_dir=/tmp/exec-failed") {
+		t.Fatalf("expected artifacts_dir in failure output, got %q", outcome.stderr)
+	}
 }
 
 func TestExecIntegrationRendersStructuredWarnings(t *testing.T) {
@@ -819,18 +840,18 @@ func TestExecIntegrationRendersStructuredWarnings(t *testing.T) {
 	const warningText = "darwin-vz guest networking is enabled without host-side egress filtering"
 
 	adapter := &integrationAdapter{
-		runStreamFn: func(_ context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+		runStreamFn: func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 			if stream.OnWarning != nil {
 				stream.OnWarning(warningText)
 			}
 			if stream.OnStdout != nil {
 				stream.OnStdout([]byte("hello world\n"))
 			}
-			return &backend.RunResult{
-				RunID:    req.RunID,
-				ExitCode: 0,
-				Stdout:   "hello world\n",
-				Message:  "ok",
+			return &backend.ExecutionResult{
+				ExecutionID: req.ExecutionID,
+				ExitCode:    0,
+				Stdout:      "hello world\n",
+				Message:     "ok",
 			}, nil
 		},
 	}
@@ -869,7 +890,7 @@ func TestExecIntegrationRendersStructuredWarnings(t *testing.T) {
 func TestExecIntegrationFirstInterruptCancelsExecution(t *testing.T) {
 	started := make(chan struct{}, 1)
 	adapter := &integrationAdapter{
-		runFn: func(ctx context.Context, _ backend.RunRequest) (*backend.RunResult, error) {
+		runFn: func(ctx context.Context, _ backend.ExecutionRequest) (*backend.ExecutionResult, error) {
 			select {
 			case started <- struct{}{}:
 			default:
@@ -922,7 +943,7 @@ func TestExecIntegrationSecondInterruptTerminatesSandboxWithRemove(t *testing.T)
 	}
 	t.Cleanup(release)
 	adapter := &integrationAdapter{
-		runFn: func(ctx context.Context, _ backend.RunRequest) (*backend.RunResult, error) {
+		runFn: func(ctx context.Context, _ backend.ExecutionRequest) (*backend.ExecutionResult, error) {
 			defer close(runReturned)
 			select {
 			case started <- struct{}{}:
@@ -932,7 +953,7 @@ func TestExecIntegrationSecondInterruptTerminatesSandboxWithRemove(t *testing.T)
 			if ctx.Err() != nil {
 				return nil, ctx.Err()
 			}
-			return &backend.RunResult{ExitCode: 0, Message: "unexpected success"}, nil
+			return &backend.ExecutionResult{ExitCode: 0, Message: "unexpected success"}, nil
 		},
 	}
 
@@ -993,7 +1014,7 @@ func TestExecIntegrationSecondInterruptKeepsSuppliedSandboxWithoutRemove(t *test
 	t.Cleanup(release)
 
 	adapter := &integrationAdapter{
-		runFn: func(ctx context.Context, _ backend.RunRequest) (*backend.RunResult, error) {
+		runFn: func(ctx context.Context, _ backend.ExecutionRequest) (*backend.ExecutionResult, error) {
 			defer close(runReturned)
 			select {
 			case started <- struct{}{}:
@@ -1003,7 +1024,7 @@ func TestExecIntegrationSecondInterruptKeepsSuppliedSandboxWithoutRemove(t *test
 			if ctx.Err() != nil {
 				return nil, ctx.Err()
 			}
-			return &backend.RunResult{ExitCode: 0, Message: "unexpected success"}, nil
+			return &backend.ExecutionResult{ExitCode: 0, Message: "unexpected success"}, nil
 		},
 	}
 
@@ -1049,15 +1070,15 @@ func TestExecIntegrationSecondInterruptKeepsSuppliedSandboxWithoutRemove(t *test
 
 func TestExecIntegrationVmPathUsesShForGuestCompatibility(t *testing.T) {
 	adapter := &integrationAdapter{
-		runFn: func(_ context.Context, req backend.RunRequest) (*backend.RunResult, error) {
+		runFn: func(_ context.Context, req backend.ExecutionRequest) (*backend.ExecutionResult, error) {
 			if len(req.Command) >= 1 && req.Command[0] == "bash" {
 				return nil, errors.New(`exec: "bash": executable file not found in $PATH`)
 			}
-			return &backend.RunResult{
-				RunID:    req.RunID,
-				ExitCode: 0,
-				Stdout:   "guest-ok\n",
-				Message:  "ok",
+			return &backend.ExecutionResult{
+				ExecutionID: req.ExecutionID,
+				ExitCode:    0,
+				Stdout:      "guest-ok\n",
+				Message:     "ok",
 			}, nil
 		},
 	}
@@ -1094,6 +1115,20 @@ func TestParseSandboxID(t *testing.T) {
 	}
 	if got := parseSandboxID("no id here"); got != "" {
 		t.Fatalf("expected empty sandbox id for invalid input, got %q", got)
+	}
+}
+
+func TestParseExecutionID(t *testing.T) {
+	in := "DEBU execution started component=client sandbox_id=cr-123 execution_id=exec-456\n"
+	if got, want := parseExecutionID(in), "exec-456"; got != want {
+		t.Fatalf("unexpected execution id: got %q want %q", got, want)
+	}
+	in = "execution_id=exec_456\n"
+	if got, want := parseExecutionID(in), "exec_456"; got != want {
+		t.Fatalf("unexpected execution id from print output: got %q want %q", got, want)
+	}
+	if got := parseExecutionID("no id here"); got != "" {
+		t.Fatalf("expected empty execution id for invalid input, got %q", got)
 	}
 }
 

--- a/internal/cli/execution.go
+++ b/internal/cli/execution.go
@@ -1,0 +1,183 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+)
+
+type ExecutionCommand struct {
+	Inspect ExecutionInspectCommand `name:"inspect" aliases:"show" cmd:"" help:"Inspect an execution and its diagnostics"`
+}
+
+type ExecutionInspectCommand struct {
+	clientFlags
+	SandboxID   string `name:"sandbox-id" help:"Sandbox ID that owns the execution"`
+	ExecutionID string `arg:"" optional:"" help:"Execution ID to inspect"`
+	Last        bool   `help:"Inspect the sandbox's last execution (requires --sandbox-id)"`
+	JSON        bool   `help:"Print execution inspection as JSON"`
+}
+
+func (c *ExecutionInspectCommand) Run(ctx *runtimeContext) error {
+	client, err := c.connect(ctx)
+	if err != nil {
+		return err
+	}
+
+	sandboxID := strings.TrimSpace(c.SandboxID)
+	executionID := strings.TrimSpace(c.ExecutionID)
+	if c.Last {
+		if executionID != "" {
+			return errors.New("choose either <execution-id> or --last")
+		}
+		if sandboxID == "" {
+			return errors.New("--sandbox-id is required with --last")
+		}
+		sbResp, err := client.GetSandbox(context.Background(), &cleanroomv1.GetSandboxRequest{SandboxId: sandboxID})
+		if err != nil {
+			return fmt.Errorf("get sandbox: %w", err)
+		}
+		sandbox := sbResp.GetSandbox()
+		if sandbox == nil {
+			return fmt.Errorf("sandbox %q not found", sandboxID)
+		}
+		executionID = strings.TrimSpace(sandbox.GetLastExecutionId())
+		if executionID == "" {
+			return fmt.Errorf("sandbox %q has no recorded executions", sandboxID)
+		}
+	} else {
+		if sandboxID == "" {
+			return errors.New("--sandbox-id is required")
+		}
+		if executionID == "" {
+			return errors.New("missing <execution-id> or use --last")
+		}
+	}
+
+	resp, err := client.InspectExecution(context.Background(), &cleanroomv1.InspectExecutionRequest{
+		SandboxId:   sandboxID,
+		ExecutionId: executionID,
+	})
+	if err != nil {
+		return fmt.Errorf("inspect execution: %w", err)
+	}
+
+	if c.JSON {
+		enc := json.NewEncoder(ctx.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(resp)
+	}
+
+	execution := resp.GetExecution()
+	if execution == nil {
+		return errors.New("inspect execution returned no execution")
+	}
+
+	if _, err := fmt.Fprintf(ctx.Stdout, "execution: %s\n", execution.GetExecutionId()); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(ctx.Stdout, "sandbox: %s\n", execution.GetSandboxId()); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(ctx.Stdout, "status: %s\n", executionStatusString(execution.GetStatus())); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(ctx.Stdout, "kind: %s\n", executionKindString(execution.GetKind())); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(ctx.Stdout, "exit_code: %d\n", execution.GetExitCode()); err != nil {
+		return err
+	}
+	if started := execution.GetStartedAt(); started != nil {
+		if _, err := fmt.Fprintf(ctx.Stdout, "started_at: %s\n", started.AsTime().Format(timeFormat)); err != nil {
+			return err
+		}
+	}
+	if finished := execution.GetFinishedAt(); finished != nil {
+		if _, err := fmt.Fprintf(ctx.Stdout, "finished_at: %s\n", finished.AsTime().Format(timeFormat)); err != nil {
+			return err
+		}
+	}
+	if msg := strings.TrimSpace(resp.GetMessage()); msg != "" {
+		if _, err := fmt.Fprintf(ctx.Stdout, "message: %s\n", msg); err != nil {
+			return err
+		}
+	}
+	if dir := strings.TrimSpace(resp.GetArtifactsDir()); dir != "" {
+		if _, err := fmt.Fprintf(ctx.Stdout, "artifacts_dir: %s\n", dir); err != nil {
+			return err
+		}
+	}
+	if planPath := strings.TrimSpace(resp.GetPlanPath()); planPath != "" {
+		if _, err := fmt.Fprintf(ctx.Stdout, "plan_path: %s\n", planPath); err != nil {
+			return err
+		}
+	}
+	if imageRef := strings.TrimSpace(resp.GetImageRef()); imageRef != "" {
+		if _, err := fmt.Fprintf(ctx.Stdout, "image_ref: %s\n", imageRef); err != nil {
+			return err
+		}
+	}
+	if imageDigest := strings.TrimSpace(resp.GetImageDigest()); imageDigest != "" {
+		if _, err := fmt.Fprintf(ctx.Stdout, "image_digest: %s\n", imageDigest); err != nil {
+			return err
+		}
+	}
+
+	if stderr := strings.TrimSpace(resp.GetStderr()); stderr != "" {
+		if _, err := fmt.Fprint(ctx.Stdout, "\nstderr:\n"+stderr+"\n"); err != nil {
+			return err
+		}
+	}
+	if stdout := strings.TrimSpace(resp.GetStdout()); stdout != "" {
+		if _, err := fmt.Fprint(ctx.Stdout, "\nstdout:\n"+stdout+"\n"); err != nil {
+			return err
+		}
+	}
+	if obs := resp.GetObservability(); obs != nil {
+		formatted, err := json.MarshalIndent(obs.AsMap(), "", "  ")
+		if err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(ctx.Stdout, "\nobservability:\n%s\n", formatted); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+const timeFormat = "2006-01-02T15:04:05Z07:00"
+
+func executionStatusString(status cleanroomv1.ExecutionStatus) string {
+	switch status {
+	case cleanroomv1.ExecutionStatus_EXECUTION_STATUS_QUEUED:
+		return "queued"
+	case cleanroomv1.ExecutionStatus_EXECUTION_STATUS_RUNNING:
+		return "running"
+	case cleanroomv1.ExecutionStatus_EXECUTION_STATUS_SUCCEEDED:
+		return "succeeded"
+	case cleanroomv1.ExecutionStatus_EXECUTION_STATUS_FAILED:
+		return "failed"
+	case cleanroomv1.ExecutionStatus_EXECUTION_STATUS_CANCELED:
+		return "canceled"
+	case cleanroomv1.ExecutionStatus_EXECUTION_STATUS_TIMED_OUT:
+		return "timed_out"
+	default:
+		return "unknown"
+	}
+}
+
+func executionKindString(kind cleanroomv1.ExecutionKind) string {
+	switch kind {
+	case cleanroomv1.ExecutionKind_EXECUTION_KIND_BATCH:
+		return "batch"
+	case cleanroomv1.ExecutionKind_EXECUTION_KIND_INTERACTIVE:
+		return "interactive"
+	default:
+		return "unknown"
+	}
+}

--- a/internal/cli/execution_shared.go
+++ b/internal/cli/execution_shared.go
@@ -220,6 +220,34 @@ func writeSandboxID(stderr io.Writer, sandboxID string) error {
 	return err
 }
 
+func writeExecutionID(stderr io.Writer, executionID string) error {
+	executionID = strings.TrimSpace(executionID)
+	if stderr == nil || executionID == "" {
+		return nil
+	}
+	_, err := fmt.Fprintf(stderr, "execution_id=%s\n", executionID)
+	return err
+}
+
+func writeArtifactsDir(stderr io.Writer, artifactsDir string) error {
+	artifactsDir = strings.TrimSpace(artifactsDir)
+	if stderr == nil || artifactsDir == "" {
+		return nil
+	}
+	_, err := fmt.Fprintf(stderr, "artifacts_dir=%s\n", artifactsDir)
+	return err
+}
+
+func writeExecutionInspectCommand(stderr io.Writer, sandboxID, executionID string) error {
+	sandboxID = strings.TrimSpace(sandboxID)
+	executionID = strings.TrimSpace(executionID)
+	if stderr == nil || sandboxID == "" || executionID == "" {
+		return nil
+	}
+	_, err := fmt.Fprintf(stderr, "inspect_command=cleanroom execution inspect --sandbox-id %s %s\n", sandboxID, executionID)
+	return err
+}
+
 func replayExecutionHistory(client *controlclient.Client, sandboxID, executionID string, stdout, stderr io.Writer) (int, bool, error) {
 	stream, err := client.StreamExecution(context.Background(), &cleanroomv1.StreamExecutionRequest{
 		SandboxId:   sandboxID,

--- a/internal/cli/image_override_integration_test.go
+++ b/internal/cli/image_override_integration_test.go
@@ -38,12 +38,12 @@ func TestSandboxCreateIntegrationOverridesImageRefForNewSandbox(t *testing.T) {
 
 	imageRefCh := make(chan string, 1)
 	adapter := &integrationAdapter{
-		runFn: func(_ context.Context, req backend.RunRequest) (*backend.RunResult, error) {
+		runFn: func(_ context.Context, req backend.ExecutionRequest) (*backend.ExecutionResult, error) {
 			if req.Policy == nil {
 				return nil, errors.New("expected policy on run request")
 			}
 			imageRefCh <- req.Policy.ImageRef
-			return &backend.RunResult{RunID: req.RunID, ExitCode: 0, Message: "ok"}, nil
+			return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
 		},
 	}
 
@@ -105,12 +105,12 @@ func TestExecIntegrationOverridesImageRefForCreatedSandbox(t *testing.T) {
 
 	imageRefCh := make(chan string, 1)
 	adapter := &integrationAdapter{
-		runFn: func(_ context.Context, req backend.RunRequest) (*backend.RunResult, error) {
+		runFn: func(_ context.Context, req backend.ExecutionRequest) (*backend.ExecutionResult, error) {
 			if req.Policy == nil {
 				return nil, errors.New("expected policy on run request")
 			}
 			imageRefCh <- req.Policy.ImageRef
-			return &backend.RunResult{RunID: req.RunID, ExitCode: 0, Message: "ok"}, nil
+			return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
 		},
 	}
 
@@ -152,12 +152,12 @@ func TestConsoleIntegrationOverridesImageRefForCreatedSandbox(t *testing.T) {
 
 	imageRefCh := make(chan string, 1)
 	adapter := &integrationAdapter{
-		runStreamFn: func(_ context.Context, req backend.RunRequest, _ backend.OutputStream) (*backend.RunResult, error) {
+		runStreamFn: func(_ context.Context, req backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
 			if req.Policy == nil {
 				return nil, errors.New("expected policy on run request")
 			}
 			imageRefCh <- req.Policy.ImageRef
-			return &backend.RunResult{RunID: req.RunID, ExitCode: 0, Message: "ok"}, nil
+			return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
 		},
 	}
 
@@ -212,8 +212,8 @@ func TestExecIntegrationRejectsImageOverrideWhenSandboxProvided(t *testing.T) {
 
 func TestConsoleIntegrationRejectsImageOverrideWhenSandboxProvided(t *testing.T) {
 	host, _ := startIntegrationServer(t, &integrationAdapter{
-		runStreamFn: func(_ context.Context, req backend.RunRequest, _ backend.OutputStream) (*backend.RunResult, error) {
-			return &backend.RunResult{RunID: req.RunID, ExitCode: 0, Message: "ok"}, nil
+		runStreamFn: func(_ context.Context, req backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
+			return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
 		},
 	})
 	client := mustNewControlClient(t, host)

--- a/internal/cli/repository_test.go
+++ b/internal/cli/repository_test.go
@@ -32,7 +32,7 @@ func (a *persistentIntegrationAdapter) ProvisionSandbox(context.Context, backend
 	return nil
 }
 
-func (a *persistentIntegrationAdapter) RunInSandbox(ctx context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+func (a *persistentIntegrationAdapter) RunInSandbox(ctx context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 	return a.RunStream(ctx, req, stream)
 }
 
@@ -119,11 +119,11 @@ func TestCreateCommandBootstrapsRepositoryForCurrentRepo(t *testing.T) {
 		mu       sync.Mutex
 		commands [][]string
 	)
-	adapter.runStreamFn = func(_ context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 		mu.Lock()
 		commands = append(commands, append([]string(nil), req.Command...))
 		mu.Unlock()
-		return &backend.RunResult{RunID: req.RunID, ExitCode: 0, Message: "ok"}, nil
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
 	}
 
 	outcome := runCreateAliasWithCapture(CreateCommand{
@@ -184,11 +184,11 @@ func TestCreateCommandBootstrapsRepositoryOnCurrentBranch(t *testing.T) {
 		mu       sync.Mutex
 		commands [][]string
 	)
-	adapter.runStreamFn = func(_ context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 		mu.Lock()
 		commands = append(commands, append([]string(nil), req.Command...))
 		mu.Unlock()
-		return &backend.RunResult{RunID: req.RunID, ExitCode: 0, Message: "ok"}, nil
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
 	}
 
 	outcome := runCreateAliasWithCapture(CreateCommand{
@@ -241,11 +241,11 @@ func TestSandboxCreateCommandRemainsGenericWithRepositoryConfig(t *testing.T) {
 		mu       sync.Mutex
 		commands [][]string
 	)
-	adapter.runStreamFn = func(_ context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 		mu.Lock()
 		commands = append(commands, append([]string(nil), req.Command...))
 		mu.Unlock()
-		return &backend.RunResult{RunID: req.RunID, ExitCode: 0, Message: "ok"}, nil
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
 	}
 
 	outcome := runSandboxCreateWithCapture(SandboxCreateCommand{
@@ -291,11 +291,11 @@ func TestExecCommandRunsInsideRepositoryPathForNewSandbox(t *testing.T) {
 		mu       sync.Mutex
 		commands [][]string
 	)
-	adapter.runStreamFn = func(_ context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 		mu.Lock()
 		commands = append(commands, append([]string(nil), req.Command...))
 		mu.Unlock()
-		return &backend.RunResult{RunID: req.RunID, ExitCode: 0, Message: "ok"}, nil
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
 	}
 
 	outcome := runExecWithCapture(ExecCommand{
@@ -347,11 +347,11 @@ func TestExecCommandRunsInsideRepositoryPathWhenReusingSandboxID(t *testing.T) {
 		mu       sync.Mutex
 		commands [][]string
 	)
-	adapter.runStreamFn = func(_ context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 		mu.Lock()
 		commands = append(commands, append([]string(nil), req.Command...))
 		mu.Unlock()
-		return &backend.RunResult{RunID: req.RunID, ExitCode: 0, Message: "ok"}, nil
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
 	}
 
 	loader := repositoryIntegrationLoader{
@@ -443,11 +443,11 @@ func TestExecCommandSkipsRepositoryBootstrapForExistingSandboxID(t *testing.T) {
 		mu       sync.Mutex
 		commands [][]string
 	)
-	adapter.runStreamFn = func(_ context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 		mu.Lock()
 		commands = append(commands, append([]string(nil), req.Command...))
 		mu.Unlock()
-		return &backend.RunResult{RunID: req.RunID, ExitCode: 0, Message: "ok"}, nil
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
 	}
 
 	loader := repositoryIntegrationLoader{
@@ -566,11 +566,11 @@ func TestExecCommandWithSandboxIDAllowsMissingPolicyInCurrentDirectory(t *testin
 		mu       sync.Mutex
 		commands [][]string
 	)
-	adapter.runStreamFn = func(_ context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 		mu.Lock()
 		commands = append(commands, append([]string(nil), req.Command...))
 		mu.Unlock()
-		return &backend.RunResult{RunID: req.RunID, ExitCode: 0, Message: "ok"}, nil
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
 	}
 
 	outcome := runExecWithCapture(ExecCommand{
@@ -607,8 +607,8 @@ func TestCreateCommandWarnsWhenRepositoryIsDirty(t *testing.T) {
 
 	adapter := &persistentIntegrationAdapter{}
 	host, _ := startIntegrationServer(t, adapter)
-	adapter.runStreamFn = func(_ context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
-		return &backend.RunResult{RunID: req.RunID, ExitCode: 0, Message: "ok"}, nil
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
 	}
 
 	outcome := runCreateAliasWithCapture(CreateCommand{
@@ -652,8 +652,8 @@ func TestCreateCommandWarnsWhenRepositoryIsDirtyUsesANSIWhenForced(t *testing.T)
 
 	adapter := &persistentIntegrationAdapter{}
 	host, _ := startIntegrationServer(t, adapter)
-	adapter.runStreamFn = func(_ context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
-		return &backend.RunResult{RunID: req.RunID, ExitCode: 0, Message: "ok"}, nil
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
 	}
 
 	outcome := runCreateAliasWithCapture(CreateCommand{
@@ -740,11 +740,11 @@ func TestExecCommandInlinesRepositoryBootstrapForNonPersistentBackend(t *testing
 		mu       sync.Mutex
 		commands [][]string
 	)
-	adapter.runStreamFn = func(_ context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 		mu.Lock()
 		commands = append(commands, append([]string(nil), req.Command...))
 		mu.Unlock()
-		return &backend.RunResult{RunID: req.RunID, ExitCode: 0, Message: "ok"}, nil
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
 	}
 
 	outcome := runExecWithCapture(ExecCommand{
@@ -823,11 +823,11 @@ func TestExecCommandSkipsRepositoryBootstrapForExistingSandboxOnNonPersistentBac
 		mu       sync.Mutex
 		commands [][]string
 	)
-	adapter.runStreamFn = func(_ context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 		mu.Lock()
 		commands = append(commands, append([]string(nil), req.Command...))
 		mu.Unlock()
-		return &backend.RunResult{RunID: req.RunID, ExitCode: 0, Message: "ok"}, nil
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
 	}
 
 	outcome := runExecWithCapture(ExecCommand{

--- a/internal/cli/sandbox.go
+++ b/internal/cli/sandbox.go
@@ -15,6 +15,7 @@ import (
 
 type SandboxCommand struct {
 	Create    SandboxCreateCommand    `cmd:"" help:"Create a sandbox"`
+	Inspect   SandboxInspectCommand   `name:"inspect" aliases:"show" cmd:"" help:"Inspect sandbox state and related execution IDs"`
 	List      SandboxListCommand      `name:"ls" aliases:"list" cmd:"" help:"List active sandboxes"`
 	Terminate SandboxTerminateCommand `name:"rm" aliases:"terminate" cmd:"" help:"Terminate a sandbox"`
 }
@@ -33,6 +34,12 @@ type SandboxListCommand struct {
 	clientFlags
 	All  bool `help:"Include stopped sandboxes"`
 	JSON bool `help:"Print sandboxes as JSON"`
+}
+
+type SandboxInspectCommand struct {
+	clientFlags
+	SandboxID string `arg:"" required:"" help:"Sandbox ID to inspect"`
+	JSON      bool   `help:"Print sandbox as JSON"`
 }
 
 type SandboxTerminateCommand struct {
@@ -92,6 +99,74 @@ func (c *SandboxListCommand) Run(ctx *runtimeContext) error {
 		}
 	}
 	return tw.Flush()
+}
+
+func (c *SandboxInspectCommand) Run(ctx *runtimeContext) error {
+	client, err := c.connect(ctx)
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.GetSandbox(context.Background(), &cleanroomv1.GetSandboxRequest{
+		SandboxId: c.SandboxID,
+	})
+	if err != nil {
+		return err
+	}
+	sandbox := resp.GetSandbox()
+	if sandbox == nil {
+		return fmt.Errorf("sandbox %q not found", c.SandboxID)
+	}
+
+	if c.JSON {
+		enc := json.NewEncoder(ctx.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(sandbox)
+	}
+
+	if _, err := fmt.Fprintf(ctx.Stdout, "sandbox: %s\n", sandbox.GetSandboxId()); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(ctx.Stdout, "status: %s\n", sandboxStatusString(sandbox.GetStatus())); err != nil {
+		return err
+	}
+	if backend := strings.TrimSpace(sandbox.GetBackend()); backend != "" {
+		if _, err := fmt.Fprintf(ctx.Stdout, "backend: %s\n", backend); err != nil {
+			return err
+		}
+	}
+	if policyHash := strings.TrimSpace(sandbox.GetPolicyHash()); policyHash != "" {
+		if _, err := fmt.Fprintf(ctx.Stdout, "policy_hash: %s\n", policyHash); err != nil {
+			return err
+		}
+	}
+	if created := sandbox.GetCreatedAt(); created != nil {
+		if _, err := fmt.Fprintf(ctx.Stdout, "created_at: %s\n", created.AsTime().Format(time.RFC3339)); err != nil {
+			return err
+		}
+	}
+	if updated := sandbox.GetUpdatedAt(); updated != nil {
+		if _, err := fmt.Fprintf(ctx.Stdout, "updated_at: %s\n", updated.AsTime().Format(time.RFC3339)); err != nil {
+			return err
+		}
+	}
+	if lastExecutionID := strings.TrimSpace(sandbox.GetLastExecutionId()); lastExecutionID != "" {
+		if _, err := fmt.Fprintf(ctx.Stdout, "last_execution_id: %s\n", lastExecutionID); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(ctx.Stdout, "inspect_last_execution: cleanroom execution inspect --sandbox-id %s --last\n", sandbox.GetSandboxId()); err != nil {
+			return err
+		}
+	}
+	if activeExecutionID := strings.TrimSpace(sandbox.GetActiveExecutionId()); activeExecutionID != "" {
+		if _, err := fmt.Fprintf(ctx.Stdout, "active_execution_id: %s\n", activeExecutionID); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(ctx.Stdout, "inspect_active_execution: cleanroom execution inspect --sandbox-id %s %s\n", sandbox.GetSandboxId(), activeExecutionID); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func filterSandboxList(sandboxes []*cleanroomv1.Sandbox, includeStopped bool) []*cleanroomv1.Sandbox {

--- a/internal/cli/sandbox_inspect_integration_test.go
+++ b/internal/cli/sandbox_inspect_integration_test.go
@@ -1,0 +1,88 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+)
+
+func runSandboxInspectWithCapture(cmd SandboxInspectCommand, ctx runtimeContext) execOutcome {
+	return runWithCapture(func(runCtx *runtimeContext) error {
+		return cmd.Run(runCtx)
+	}, nil, ctx)
+}
+
+func TestSandboxInspectIntegrationShowsExecutionPointers(t *testing.T) {
+	host, svc := startIntegrationServer(t, &integrationAdapter{})
+	cwd := t.TempDir()
+
+	client := mustNewControlClient(t, host)
+	sandboxID := mustCreateSandbox(t, client)
+
+	createExecutionResp, err := client.CreateExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
+		SandboxId: sandboxID,
+		Command:   []string{"echo", "ok"},
+		Kind:      cleanroomv1.ExecutionKind_EXECUTION_KIND_BATCH,
+	})
+	if err != nil {
+		t.Fatalf("CreateExecution returned error: %v", err)
+	}
+	executionID := createExecutionResp.GetExecution().GetExecutionId()
+	if _, err := svc.WaitExecution(context.Background(), sandboxID, executionID); err != nil {
+		t.Fatalf("WaitExecution returned error: %v", err)
+	}
+
+	outcome := runSandboxInspectWithCapture(SandboxInspectCommand{
+		clientFlags: clientFlags{Host: host},
+		SandboxID:   sandboxID,
+	}, runtimeContext{CWD: cwd})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err != nil {
+		t.Fatalf("SandboxInspectCommand.Run returned error: %v", outcome.err)
+	}
+	if !strings.Contains(outcome.stdout, "sandbox: "+sandboxID) {
+		t.Fatalf("expected sandbox id in output, got %q", outcome.stdout)
+	}
+	if !strings.Contains(outcome.stdout, "status: ready") {
+		t.Fatalf("expected sandbox status in output, got %q", outcome.stdout)
+	}
+	if !strings.Contains(outcome.stdout, "last_execution_id: "+executionID) {
+		t.Fatalf("expected last execution id in output, got %q", outcome.stdout)
+	}
+	if !strings.Contains(outcome.stdout, "inspect_last_execution: cleanroom execution inspect --sandbox-id "+sandboxID+" --last") {
+		t.Fatalf("expected inspect hint in output, got %q", outcome.stdout)
+	}
+}
+
+func TestSandboxInspectIntegrationJSON(t *testing.T) {
+	host, _ := startIntegrationServer(t, &integrationAdapter{})
+	cwd := t.TempDir()
+
+	client := mustNewControlClient(t, host)
+	sandboxID := mustCreateSandbox(t, client)
+
+	outcome := runSandboxInspectWithCapture(SandboxInspectCommand{
+		clientFlags: clientFlags{Host: host},
+		SandboxID:   sandboxID,
+		JSON:        true,
+	}, runtimeContext{CWD: cwd})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err != nil {
+		t.Fatalf("SandboxInspectCommand.Run returned error: %v", outcome.err)
+	}
+
+	var sandbox cleanroomv1.Sandbox
+	if err := json.Unmarshal([]byte(outcome.stdout), &sandbox); err != nil {
+		t.Fatalf("parse sandbox json: %v", err)
+	}
+	if got, want := sandbox.GetSandboxId(), sandboxID; got != want {
+		t.Fatalf("unexpected sandbox id: got %q want %q", got, want)
+	}
+}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -6,99 +6,78 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"text/tabwriter"
 	"time"
 
 	"github.com/buildkite/cleanroom/internal/paths"
 )
 
 type StatusCommand struct {
-	RunID   string `help:"Run ID to inspect"`
-	LastRun bool   `help:"Inspect the most recent run"`
+	ExecutionID string `name:"execution-id" help:"Execution ID to inspect"`
+	Last        bool   `help:"Inspect the most recent retained execution artifacts"`
+}
+
+type retainedExecutionEntry struct {
+	ID         string
+	ModifiedAt time.Time
 }
 
 func (s *StatusCommand) Run(ctx *runtimeContext) error {
-	baseDir, err := paths.RunBaseDir()
+	baseDir, err := paths.ExecutionBaseDir()
 	if err != nil {
-		return fmt.Errorf("resolve run base directory: %w", err)
+		return fmt.Errorf("resolve execution artifacts base directory: %w", err)
 	}
-	if s.RunID != "" && s.LastRun {
-		return errors.New("choose either --run-id or --last-run")
+	if s.ExecutionID != "" && s.Last {
+		return errors.New("choose either --execution-id or --last")
 	}
-	if s.RunID != "" {
-		return inspectRun(ctx.Stdout, baseDir, s.RunID)
+	if s.ExecutionID != "" {
+		return inspectExecutionArtifacts(ctx.Stdout, baseDir, s.ExecutionID)
 	}
-	if s.LastRun {
-		entries, err := os.ReadDir(baseDir)
-		if err != nil {
-			if errors.Is(err, os.ErrNotExist) {
-				_, werr := fmt.Fprintf(ctx.Stdout, "no runs found (%s does not exist)\n", baseDir)
-				return werr
-			}
-			return err
-		}
-		var newest string
-		var newestTime time.Time
-		for _, entry := range entries {
-			if !entry.IsDir() {
-				continue
-			}
-			info, err := entry.Info()
-			if err != nil {
-				return err
-			}
-			if newest == "" || info.ModTime().After(newestTime) {
-				newest = entry.Name()
-				newestTime = info.ModTime()
-			}
-		}
-		if newest == "" {
-			_, err := fmt.Fprintf(ctx.Stdout, "no runs found in %s\n", baseDir)
-			return err
-		}
-		return inspectRun(ctx.Stdout, baseDir, newest)
-	}
-
-	entries, err := os.ReadDir(baseDir)
+	entries, err := listRetainedExecutions(baseDir)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			_, werr := fmt.Fprintf(ctx.Stdout, "no runs found (%s does not exist)\n", baseDir)
+			_, werr := fmt.Fprintf(ctx.Stdout, "no retained executions found (%s does not exist)\n", baseDir)
 			return werr
 		}
 		return err
 	}
-
 	if len(entries) == 0 {
-		_, err := fmt.Fprintf(ctx.Stdout, "no runs found in %s\n", baseDir)
+		_, err := fmt.Fprintf(ctx.Stdout, "no retained executions found in %s\n", baseDir)
 		return err
 	}
+	if s.Last {
+		return inspectExecutionArtifacts(ctx.Stdout, baseDir, entries[0].ID)
+	}
 
-	_, err = fmt.Fprintf(ctx.Stdout, "runs in %s:\n", baseDir)
+	_, err = fmt.Fprintf(ctx.Stdout, "retained executions in %s:\n", baseDir)
 	if err != nil {
 		return err
 	}
+	tw := tabwriter.NewWriter(ctx.Stdout, 0, 2, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "ID\tMODIFIED"); err != nil {
+		return err
+	}
 	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		if _, err := fmt.Fprintf(ctx.Stdout, "- %s\n", entry.Name()); err != nil {
+		if _, err := fmt.Fprintf(tw, "%s\t%s\n", entry.ID, entry.ModifiedAt.Format(time.RFC3339)); err != nil {
 			return err
 		}
 	}
-	return nil
+	return tw.Flush()
 }
 
-func inspectRun(stdout *os.File, baseDir, runID string) error {
-	runDir := filepath.Join(baseDir, runID)
-	if _, err := os.Stat(runDir); err != nil {
+func inspectExecutionArtifacts(stdout *os.File, baseDir, executionID string) error {
+	artifactsDir := filepath.Join(baseDir, executionID)
+	if _, err := os.Stat(artifactsDir); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("run %q not found in %s", runID, baseDir)
+			return fmt.Errorf("execution %q not found in %s", executionID, baseDir)
 		}
 		return err
 	}
-	if _, err := fmt.Fprintf(stdout, "run: %s\n", runDir); err != nil {
+	if _, err := fmt.Fprintf(stdout, "execution artifacts: %s\n", artifactsDir); err != nil {
 		return err
 	}
-	obsPath := filepath.Join(runDir, "run-observability.json")
+	obsPath := filepath.Join(artifactsDir, "execution-observability.json")
 	b, err := os.ReadFile(obsPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -117,4 +96,34 @@ func inspectRun(stdout *os.File, baseDir, runID string) error {
 	}
 	_, err = fmt.Fprintf(stdout, "observability (%s):\n%s\n", obsPath, out)
 	return err
+}
+
+func listRetainedExecutions(baseDir string) ([]retainedExecutionEntry, error) {
+	entries, err := os.ReadDir(baseDir)
+	if err != nil {
+		return nil, err
+	}
+
+	retained := make([]retainedExecutionEntry, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return nil, err
+		}
+		retained = append(retained, retainedExecutionEntry{
+			ID:         entry.Name(),
+			ModifiedAt: info.ModTime(),
+		})
+	}
+
+	sort.Slice(retained, func(i, j int) bool {
+		if retained[i].ModifiedAt.Equal(retained[j].ModifiedAt) {
+			return retained[i].ID < retained[j].ID
+		}
+		return retained[i].ModifiedAt.After(retained[j].ModifiedAt)
+	})
+	return retained, nil
 }

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -13,36 +13,36 @@ import (
 
 var statusTestBaseTime = time.Date(2026, time.March, 14, 10, 0, 0, 0, time.UTC)
 
-func writeRunObservability(t *testing.T, baseDir, runID string, observed map[string]any, modTime time.Time) string {
+func writeExecutionObservability(t *testing.T, baseDir, executionID string, observed map[string]any, modTime time.Time) string {
 	t.Helper()
 
-	runDir := filepath.Join(baseDir, runID)
-	if err := os.MkdirAll(runDir, 0o755); err != nil {
-		t.Fatalf("create run dir: %v", err)
+	artifactsDir := filepath.Join(baseDir, executionID)
+	if err := os.MkdirAll(artifactsDir, 0o755); err != nil {
+		t.Fatalf("create execution artifacts dir: %v", err)
 	}
 	payload, err := json.Marshal(observed)
 	if err != nil {
 		t.Fatalf("marshal observability payload: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(runDir, "run-observability.json"), payload, 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(artifactsDir, "execution-observability.json"), payload, 0o644); err != nil {
 		t.Fatalf("write observability payload: %v", err)
 	}
-	if err := os.Chtimes(runDir, modTime, modTime); err != nil {
-		t.Fatalf("set run dir modtime: %v", err)
+	if err := os.Chtimes(artifactsDir, modTime, modTime); err != nil {
+		t.Fatalf("set execution artifacts dir modtime: %v", err)
 	}
-	return runDir
+	return artifactsDir
 }
 
-func TestStatusCommandRunListsRuns(t *testing.T) {
+func TestStatusCommandRunListsExecutionsNewestFirst(t *testing.T) {
 	stateHome := t.TempDir()
 	t.Setenv("XDG_STATE_HOME", stateHome)
 
-	baseDir, err := paths.RunBaseDir()
+	baseDir, err := paths.ExecutionBaseDir()
 	if err != nil {
-		t.Fatalf("resolve run base dir: %v", err)
+		t.Fatalf("resolve execution base dir: %v", err)
 	}
-	writeRunObservability(t, baseDir, "run-a", map[string]any{"exit_code": 0}, statusTestBaseTime.Add(-time.Hour))
-	writeRunObservability(t, baseDir, "run-b", map[string]any{"exit_code": 1}, statusTestBaseTime)
+	writeExecutionObservability(t, baseDir, "exec-a", map[string]any{"exit_code": 0}, statusTestBaseTime.Add(-time.Hour))
+	writeExecutionObservability(t, baseDir, "exec-b", map[string]any{"exit_code": 1}, statusTestBaseTime)
 
 	stdout, readStdout := makeStdoutCapture(t)
 	t.Cleanup(func() { _ = stdout.Close() })
@@ -53,18 +53,21 @@ func TestStatusCommandRunListsRuns(t *testing.T) {
 	}
 
 	output := readStdout()
-	assertContainsAll(t, output, "runs in "+baseDir+":", "- run-a", "- run-b")
+	assertContainsAll(t, output, "retained executions in "+baseDir+":", "ID", "MODIFIED", "exec-a", "exec-b")
+	if strings.Index(output, "exec-b") > strings.Index(output, "exec-a") {
+		t.Fatalf("expected newest execution first, got %q", output)
+	}
 }
 
-func TestStatusCommandRunInspectsRequestedRun(t *testing.T) {
+func TestStatusCommandRunInspectsRequestedExecution(t *testing.T) {
 	stateHome := t.TempDir()
 	t.Setenv("XDG_STATE_HOME", stateHome)
 
-	baseDir, err := paths.RunBaseDir()
+	baseDir, err := paths.ExecutionBaseDir()
 	if err != nil {
-		t.Fatalf("resolve run base dir: %v", err)
+		t.Fatalf("resolve execution base dir: %v", err)
 	}
-	runDir := writeRunObservability(t, baseDir, "run-inspect", map[string]any{
+	artifactsDir := writeExecutionObservability(t, baseDir, "exec-inspect", map[string]any{
 		"exit_code": 0,
 		"message":   "ok",
 	}, statusTestBaseTime)
@@ -72,44 +75,44 @@ func TestStatusCommandRunInspectsRequestedRun(t *testing.T) {
 	stdout, readStdout := makeStdoutCapture(t)
 	t.Cleanup(func() { _ = stdout.Close() })
 
-	err = (&StatusCommand{RunID: "run-inspect"}).Run(&runtimeContext{Stdout: stdout})
+	err = (&StatusCommand{ExecutionID: "exec-inspect"}).Run(&runtimeContext{Stdout: stdout})
 	if err != nil {
 		t.Fatalf("StatusCommand.Run returned error: %v", err)
 	}
 
 	output := readStdout()
 	assertContainsAll(t, output,
-		"run: "+runDir,
-		"observability ("+filepath.Join(runDir, "run-observability.json")+"):",
+		"execution artifacts: "+artifactsDir,
+		"observability ("+filepath.Join(artifactsDir, "execution-observability.json")+"):",
 		"\"exit_code\": 0",
 		"\"message\": \"ok\"",
 	)
 }
 
-func TestStatusCommandRunLastRunChoosesNewest(t *testing.T) {
+func TestStatusCommandRunLastExecutionChoosesNewest(t *testing.T) {
 	stateHome := t.TempDir()
 	t.Setenv("XDG_STATE_HOME", stateHome)
 
-	baseDir, err := paths.RunBaseDir()
+	baseDir, err := paths.ExecutionBaseDir()
 	if err != nil {
-		t.Fatalf("resolve run base dir: %v", err)
+		t.Fatalf("resolve execution base dir: %v", err)
 	}
-	oldDir := writeRunObservability(t, baseDir, "run-old", map[string]any{"exit_code": 1}, statusTestBaseTime.Add(-2*time.Hour))
-	newDir := writeRunObservability(t, baseDir, "run-new", map[string]any{"exit_code": 0}, statusTestBaseTime)
+	oldDir := writeExecutionObservability(t, baseDir, "exec-old", map[string]any{"exit_code": 1}, statusTestBaseTime.Add(-2*time.Hour))
+	newDir := writeExecutionObservability(t, baseDir, "exec-new", map[string]any{"exit_code": 0}, statusTestBaseTime)
 
 	stdout, readStdout := makeStdoutCapture(t)
 	t.Cleanup(func() { _ = stdout.Close() })
 
-	err = (&StatusCommand{LastRun: true}).Run(&runtimeContext{Stdout: stdout})
+	err = (&StatusCommand{Last: true}).Run(&runtimeContext{Stdout: stdout})
 	if err != nil {
 		t.Fatalf("StatusCommand.Run returned error: %v", err)
 	}
 
 	output := readStdout()
-	if !strings.Contains(output, "run: "+newDir) {
-		t.Fatalf("expected output to inspect newest run %q, got %q", newDir, output)
+	if !strings.Contains(output, "execution artifacts: "+newDir) {
+		t.Fatalf("expected output to inspect newest execution artifacts %q, got %q", newDir, output)
 	}
-	if strings.Contains(output, "run: "+oldDir) {
-		t.Fatalf("expected output to avoid older run %q, got %q", oldDir, output)
+	if strings.Contains(output, "execution artifacts: "+oldDir) {
+		t.Fatalf("expected output to avoid older execution artifacts %q, got %q", oldDir, output)
 	}
 }

--- a/internal/controlclient/client.go
+++ b/internal/controlclient/client.go
@@ -183,8 +183,8 @@ func (c *Client) CreateExecution(ctx context.Context, req *cleanroomv1.CreateExe
 	return resp.Msg, nil
 }
 
-func (c *Client) OpenInteractiveExecution(ctx context.Context, req *cleanroomv1.OpenInteractiveExecutionRequest) (*cleanroomv1.OpenInteractiveExecutionResponse, error) {
-	resp, err := c.executionClient.OpenInteractiveExecution(ctx, connect.NewRequest(req))
+func (c *Client) AttachExecution(ctx context.Context, req *cleanroomv1.AttachExecutionRequest) (*cleanroomv1.AttachExecutionResponse, error) {
+	resp, err := c.executionClient.AttachExecution(ctx, connect.NewRequest(req))
 	if err != nil {
 		return nil, err
 	}
@@ -193,6 +193,14 @@ func (c *Client) OpenInteractiveExecution(ctx context.Context, req *cleanroomv1.
 
 func (c *Client) GetExecution(ctx context.Context, req *cleanroomv1.GetExecutionRequest) (*cleanroomv1.GetExecutionResponse, error) {
 	resp, err := c.executionClient.GetExecution(ctx, connect.NewRequest(req))
+	if err != nil {
+		return nil, err
+	}
+	return resp.Msg, nil
+}
+
+func (c *Client) InspectExecution(ctx context.Context, req *cleanroomv1.InspectExecutionRequest) (*cleanroomv1.InspectExecutionResponse, error) {
+	resp, err := c.executionClient.InspectExecution(ctx, connect.NewRequest(req))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controlclient/client_tls_integration_test.go
+++ b/internal/controlclient/client_tls_integration_test.go
@@ -28,8 +28,8 @@ type tlsTestAdapter struct{}
 
 func (tlsTestAdapter) Name() string { return "firecracker" }
 
-func (tlsTestAdapter) Run(_ context.Context, req backend.RunRequest) (*backend.RunResult, error) {
-	return &backend.RunResult{RunID: req.RunID, ExitCode: 0, Message: "ok"}, nil
+func (tlsTestAdapter) Run(_ context.Context, req backend.ExecutionRequest) (*backend.ExecutionResult, error) {
+	return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
 }
 
 func TestHTTPSControlPlaneDiscoversTLSMaterial(t *testing.T) {

--- a/internal/controlserver/server.go
+++ b/internal/controlserver/server.go
@@ -170,8 +170,8 @@ func (s *Server) CreateExecution(ctx context.Context, req *connect.Request[clean
 	return connect.NewResponse(resp), nil
 }
 
-func (s *Server) OpenInteractiveExecution(ctx context.Context, req *connect.Request[cleanroomv1.OpenInteractiveExecutionRequest]) (*connect.Response[cleanroomv1.OpenInteractiveExecutionResponse], error) {
-	resp, err := s.service.OpenInteractiveExecution(ctx, req.Msg)
+func (s *Server) AttachExecution(ctx context.Context, req *connect.Request[cleanroomv1.AttachExecutionRequest]) (*connect.Response[cleanroomv1.AttachExecutionResponse], error) {
+	resp, err := s.service.AttachExecution(ctx, req.Msg)
 	if err != nil {
 		return nil, toConnectError(err)
 	}
@@ -180,6 +180,14 @@ func (s *Server) OpenInteractiveExecution(ctx context.Context, req *connect.Requ
 
 func (s *Server) GetExecution(ctx context.Context, req *connect.Request[cleanroomv1.GetExecutionRequest]) (*connect.Response[cleanroomv1.GetExecutionResponse], error) {
 	resp, err := s.service.GetExecution(ctx, req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (s *Server) InspectExecution(ctx context.Context, req *connect.Request[cleanroomv1.InspectExecutionRequest]) (*connect.Response[cleanroomv1.InspectExecutionResponse], error) {
+	resp, err := s.service.InspectExecution(ctx, req.Msg)
 	if err != nil {
 		return nil, toConnectError(err)
 	}

--- a/internal/controlserver/server_handler_test.go
+++ b/internal/controlserver/server_handler_test.go
@@ -33,11 +33,11 @@ func newHandlerTestAdapter() *handlerTestAdapter {
 
 func (a *handlerTestAdapter) Name() string { return "firecracker" }
 
-func (a *handlerTestAdapter) Run(ctx context.Context, req backend.RunRequest) (*backend.RunResult, error) {
+func (a *handlerTestAdapter) Run(ctx context.Context, req backend.ExecutionRequest) (*backend.ExecutionResult, error) {
 	return a.RunStream(ctx, req, backend.OutputStream{})
 }
 
-func (a *handlerTestAdapter) RunStream(ctx context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+func (a *handlerTestAdapter) RunStream(ctx context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 	select {
 	case a.started <- struct{}{}:
 	default:
@@ -57,10 +57,10 @@ func (a *handlerTestAdapter) RunStream(ctx context.Context, req backend.RunReque
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	}
-	return &backend.RunResult{
-		RunID:    req.RunID,
-		ExitCode: 0,
-		Message:  "ok",
+	return &backend.ExecutionResult{
+		ExecutionID: req.ExecutionID,
+		ExitCode:    0,
+		Message:     "ok",
 	}, nil
 }
 
@@ -68,7 +68,7 @@ func (a *handlerTestAdapter) ProvisionSandbox(context.Context, backend.Provision
 	return nil
 }
 
-func (a *handlerTestAdapter) RunInSandbox(ctx context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+func (a *handlerTestAdapter) RunInSandbox(ctx context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 	return a.RunStream(ctx, req, stream)
 }
 

--- a/internal/controlservice/ids.go
+++ b/internal/controlservice/ids.go
@@ -28,10 +28,6 @@ func newSnapshotID() string {
 	return newID("snap")
 }
 
-func newRunID() string {
-	return newID("run")
-}
-
 func newInteractiveSessionID() string {
 	return newID("isess")
 }

--- a/internal/controlservice/runtime.go
+++ b/internal/controlservice/runtime.go
@@ -21,7 +21,6 @@ type serviceIDSource interface {
 	NewSandboxID() string
 	NewExecutionID() string
 	NewInteractiveSessionID() string
-	NewRunID() string
 	NewSessionToken() (string, error)
 }
 
@@ -30,7 +29,6 @@ type defaultServiceIDSource struct{}
 func (defaultServiceIDSource) NewSandboxID() string            { return newSandboxID() }
 func (defaultServiceIDSource) NewExecutionID() string          { return newExecutionID() }
 func (defaultServiceIDSource) NewInteractiveSessionID() string { return newInteractiveSessionID() }
-func (defaultServiceIDSource) NewRunID() string                { return newRunID() }
 func (defaultServiceIDSource) NewSessionToken() (string, error) {
 	return newSessionToken()
 }

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -3,8 +3,10 @@ package controlservice
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -20,6 +22,7 @@ import (
 	"github.com/buildkite/cleanroom/internal/snapshotstore"
 	"github.com/charmbracelet/log"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -65,7 +68,6 @@ type sandboxState struct {
 type executionState struct {
 	ID               string
 	SandboxID        string
-	RunID            string
 	ImageRef         string
 	ImageDigest      string
 	Command          []string
@@ -962,7 +964,7 @@ func (s *Service) CreateExecution(ctx context.Context, req *cleanroomv1.CreateEx
 	return resp, nil
 }
 
-func (s *Service) OpenInteractiveExecution(_ context.Context, req *cleanroomv1.OpenInteractiveExecutionRequest) (*cleanroomv1.OpenInteractiveExecutionResponse, error) {
+func (s *Service) AttachExecution(_ context.Context, req *cleanroomv1.AttachExecutionRequest) (*cleanroomv1.AttachExecutionResponse, error) {
 	if req == nil {
 		return nil, errors.New("missing request")
 	}
@@ -1000,7 +1002,7 @@ func (s *Service) OpenInteractiveExecution(_ context.Context, req *cleanroomv1.O
 		return nil, err
 	}
 
-	return &cleanroomv1.OpenInteractiveExecutionResponse{
+	return &cleanroomv1.AttachExecutionResponse{
 		SessionId:           grant.SessionID,
 		SessionToken:        grant.SessionToken,
 		ExpiresAt:           timestamppb.New(grant.ExpiresAt),
@@ -1010,10 +1012,72 @@ func (s *Service) OpenInteractiveExecution(_ context.Context, req *cleanroomv1.O
 	}, nil
 }
 
+func (s *Service) InspectExecution(_ context.Context, req *cleanroomv1.InspectExecutionRequest) (*cleanroomv1.InspectExecutionResponse, error) {
+	if req == nil {
+		return nil, errors.New("missing request")
+	}
+	sandboxID := strings.TrimSpace(req.GetSandboxId())
+	executionID := strings.TrimSpace(req.GetExecutionId())
+	if sandboxID == "" {
+		return nil, errors.New("missing sandbox_id")
+	}
+	if executionID == "" {
+		return nil, errors.New("missing execution_id")
+	}
+
+	snapshot, err := s.ExecutionSnapshot(sandboxID, executionID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := &cleanroomv1.InspectExecutionResponse{
+		Execution:    snapshot.Execution,
+		Message:      snapshot.Message,
+		Stdout:       snapshot.Stdout,
+		Stderr:       snapshot.Stderr,
+		ImageRef:     snapshot.ImageRef,
+		ImageDigest:  snapshot.ImageDigest,
+		ArtifactsDir: snapshot.RunDir,
+		PlanPath:     snapshot.PlanPath,
+		LaunchedVm:   snapshot.Launched,
+	}
+
+	if obs, err := loadExecutionObservability(snapshot.RunDir); err != nil {
+		return nil, err
+	} else if obs != nil {
+		resp.Observability = obs
+	}
+
+	return resp, nil
+}
+
 func (s *Service) ConfigureInteractiveTransport(endpoint, alpn, certPinSHA256 string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.interactive.configureTransport(endpoint, alpn, certPinSHA256)
+}
+
+func loadExecutionObservability(artifactsDir string) (*structpb.Struct, error) {
+	if strings.TrimSpace(artifactsDir) == "" {
+		return nil, nil
+	}
+	obsPath := filepath.Join(strings.TrimSpace(artifactsDir), "execution-observability.json")
+	b, err := os.ReadFile(obsPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read %s: %w", obsPath, err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(b, &payload); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", obsPath, err)
+	}
+	obs, err := structpb.NewStruct(payload)
+	if err != nil {
+		return nil, fmt.Errorf("convert %s to protobuf struct: %w", obsPath, err)
+	}
+	return obs, nil
 }
 
 func (s *Service) ConsumeInteractiveSession(sessionID, token string) (*InteractiveSession, error) {
@@ -1492,7 +1556,6 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 	started := s.clock().Now()
 	ex.StartedAt = &started
 	ex.Status = cleanroomv1.ExecutionStatus_EXECUTION_STATUS_RUNNING
-	ex.RunID = s.ids().NewRunID()
 	if sb.Policy != nil {
 		ex.ImageRef = sb.Policy.ImageRef
 		ex.ImageDigest = sb.Policy.ImageDigest
@@ -1507,17 +1570,17 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 
 	firecrackerCfg := sb.Firecracker
 	if strings.TrimSpace(firecrackerCfg.RunDir) == "" {
-		if runBaseDir, err := paths.RunBaseDir(); err == nil {
-			firecrackerCfg.RunDir = filepath.Join(runBaseDir, ex.RunID)
+		if executionBaseDir, err := paths.ExecutionBaseDir(); err == nil {
+			firecrackerCfg.RunDir = filepath.Join(executionBaseDir, ex.ID)
 		}
 	}
 	if ex.Options.LaunchSeconds != 0 {
 		firecrackerCfg.LaunchSeconds = ex.Options.LaunchSeconds
 	}
 
-	runReq := backend.RunRequest{
+	executionReq := backend.ExecutionRequest{
 		SandboxID:         sandboxID,
-		RunID:             ex.RunID,
+		ExecutionID:       ex.ID,
 		Command:           append([]string(nil), ex.Command...),
 		TTY:               ex.TTY,
 		Policy:            sb.Policy,
@@ -1525,7 +1588,7 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 	}
 	s.mu.Unlock()
 
-	result, usedStreaming, err := s.runAdapterExecution(runCtx, adapter, runReq, key)
+	result, usedStreaming, err := s.runAdapterExecution(runCtx, adapter, executionReq, key)
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -1554,7 +1617,6 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 			s.Logger.Warn("execution failed",
 				"sandbox_id", ex.SandboxID,
 				"execution_id", ex.ID,
-				"run_id", ex.RunID,
 				"image_ref", ex.ImageRef,
 				"image_digest", ex.ImageDigest,
 				"status", ex.Status.String(),
@@ -1564,7 +1626,6 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 		return
 	}
 
-	ex.RunID = result.RunID
 	ex.LaunchedVM = result.LaunchedVM
 	ex.PlanPath = result.PlanPath
 	ex.RunDir = result.RunDir
@@ -1597,7 +1658,6 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 		s.Logger.Info("execution completed",
 			"sandbox_id", ex.SandboxID,
 			"execution_id", ex.ID,
-			"run_id", ex.RunID,
 			"image_ref", ex.ImageRef,
 			"image_digest", ex.ImageDigest,
 			"exit_code", ex.ExitCode,
@@ -1606,17 +1666,17 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 	}
 }
 
-func (s *Service) runAdapterExecution(runCtx context.Context, adapter backend.Adapter, runReq backend.RunRequest, key string) (*backend.RunResult, bool, error) {
+func (s *Service) runAdapterExecution(runCtx context.Context, adapter backend.Adapter, executionReq backend.ExecutionRequest, key string) (*backend.ExecutionResult, bool, error) {
 	if persistentAdapter, ok := adapter.(backend.PersistentSandboxAdapter); ok {
-		result, err := persistentAdapter.RunInSandbox(runCtx, runReq, s.executionOutputStream(key))
+		result, err := persistentAdapter.RunInSandbox(runCtx, executionReq, s.executionOutputStream(key))
 		return result, true, err
 	}
 	if streamAdapter, ok := adapter.(backend.StreamingAdapter); ok {
-		result, err := streamAdapter.RunStream(runCtx, runReq, s.executionOutputStream(key))
+		result, err := streamAdapter.RunStream(runCtx, executionReq, s.executionOutputStream(key))
 		return result, true, err
 	}
 
-	result, err := adapter.Run(runCtx, runReq)
+	result, err := adapter.Run(runCtx, executionReq)
 	return result, false, err
 }
 
@@ -1726,9 +1786,9 @@ func (s *Service) bootstrapRepositoryInPersistentSandbox(
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	result, err := adapter.RunInSandbox(ctx, backend.RunRequest{
+	result, err := adapter.RunInSandbox(ctx, backend.ExecutionRequest{
 		SandboxID:         sandboxID,
-		RunID:             s.ids().NewRunID(),
+		ExecutionID:       s.ids().NewExecutionID(),
 		Command:           repositorycheckout.BuildBootstrapCommand(repository),
 		Policy:            compiled,
 		FirecrackerConfig: firecrackerCfg,
@@ -1822,7 +1882,7 @@ func (s *Service) finishSnapshotDelete(snapshotID string) {
 	delete(s.snapshotDeletions, snapshotID)
 }
 
-func (s *Service) mergeBufferedResultOutputLocked(ex *executionState, result *backend.RunResult, usedStreaming bool) {
+func (s *Service) mergeBufferedResultOutputLocked(ex *executionState, result *backend.ExecutionResult, usedStreaming bool) {
 	if ex == nil || result == nil {
 		return
 	}

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -1080,6 +1080,19 @@ func loadExecutionObservability(artifactsDir string) (*structpb.Struct, error) {
 	return obs, nil
 }
 
+func internalBootstrapArtifactsDir(sandboxID, executionID string) string {
+	baseDir, err := paths.StateBaseDir()
+	if err != nil {
+		baseDir = filepath.Join(os.TempDir(), "cleanroom")
+	}
+	return filepath.Join(baseDir, "internal", "bootstrap-executions", sandboxID, executionID)
+}
+
+func withRunDir(cfg backend.FirecrackerConfig, runDir string) backend.FirecrackerConfig {
+	cfg.RunDir = runDir
+	return cfg
+}
+
 func (s *Service) ConsumeInteractiveSession(sessionID, token string) (*InteractiveSession, error) {
 	id := strings.TrimSpace(sessionID)
 	tok := strings.TrimSpace(token)
@@ -1786,12 +1799,13 @@ func (s *Service) bootstrapRepositoryInPersistentSandbox(
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
+	bootstrapExecutionID := s.ids().NewExecutionID()
 	result, err := adapter.RunInSandbox(ctx, backend.ExecutionRequest{
 		SandboxID:         sandboxID,
-		ExecutionID:       s.ids().NewExecutionID(),
+		ExecutionID:       bootstrapExecutionID,
 		Command:           repositorycheckout.BuildBootstrapCommand(repository),
 		Policy:            compiled,
-		FirecrackerConfig: firecrackerCfg,
+		FirecrackerConfig: withRunDir(firecrackerCfg, internalBootstrapArtifactsDir(sandboxID, bootstrapExecutionID)),
 	}, backend.OutputStream{
 		OnStdout: func(chunk []byte) {
 			_, _ = stdout.Write(chunk)
@@ -2058,6 +2072,7 @@ func (s *Service) dropExecutionLocked(key string, ex *executionState) {
 	closeExecutionDoneLocked(ex)
 	s.interactive.clearExecution(key)
 	delete(s.executions, key)
+	s.refreshSandboxExecutionPointersLocked(ex.SandboxID)
 }
 
 func (s *Service) hasActiveExecutionLocked(sandboxID string) bool {
@@ -2067,6 +2082,62 @@ func (s *Service) hasActiveExecutionLocked(sandboxID string) bool {
 		}
 	}
 	return false
+}
+
+func (s *Service) refreshSandboxExecutionPointersLocked(sandboxID string) {
+	sb, ok := s.sandboxes[sandboxID]
+	if !ok || sb == nil {
+		return
+	}
+
+	var latestActive *executionState
+	var latestFinished *executionState
+	for _, ex := range s.executions {
+		if ex == nil || ex.SandboxID != sandboxID {
+			continue
+		}
+		if !isFinalExecutionStatus(ex.Status) {
+			if latestActive == nil || ex.ID > latestActive.ID {
+				latestActive = ex
+			}
+			continue
+		}
+		if latestFinished == nil || newerExecutionState(ex, latestFinished) {
+			latestFinished = ex
+		}
+	}
+
+	if latestActive != nil {
+		sb.ActiveExecutionID = latestActive.ID
+		sb.LastExecutionID = latestActive.ID
+		return
+	}
+
+	sb.ActiveExecutionID = ""
+	if latestFinished != nil {
+		sb.LastExecutionID = latestFinished.ID
+		return
+	}
+	sb.LastExecutionID = ""
+}
+
+func newerExecutionState(left, right *executionState) bool {
+	if left == nil {
+		return false
+	}
+	if right == nil {
+		return true
+	}
+	leftTime := executionTerminalTime(left)
+	rightTime := executionTerminalTime(right)
+	switch {
+	case leftTime.After(rightTime):
+		return true
+	case rightTime.After(leftTime):
+		return false
+	default:
+		return left.ID > right.ID
+	}
 }
 
 func (s *Service) pruneStateLocked(now time.Time) {

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -3,6 +3,7 @@ package controlservice
 import (
 	"context"
 	"errors"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/buildkite/cleanroom/internal/backend"
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+	"github.com/buildkite/cleanroom/internal/paths"
 	"github.com/buildkite/cleanroom/internal/policy"
 	"github.com/buildkite/cleanroom/internal/runtimeconfig"
 	"github.com/buildkite/cleanroom/internal/snapshotstore"
@@ -1049,6 +1051,7 @@ func TestCreateSandboxProvisionsPersistentBackend(t *testing.T) {
 }
 
 func TestCreateSandboxBootstrapsRepositoryInService(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	adapter := &stubAdapter{}
 	mirrors := &stubRepositoryMirrorStore{}
 	svc := newTestService(adapter)
@@ -1082,6 +1085,17 @@ func TestCreateSandboxBootstrapsRepositoryInService(t *testing.T) {
 	}
 	if strings.Contains(joined, "Authorization:") || strings.Contains(joined, ".extraHeader") {
 		t.Fatalf("expected bootstrap command to avoid embedded auth, got %q", joined)
+	}
+	wantRunDir := internalBootstrapArtifactsDir(createResp.GetSandbox().GetSandboxId(), adapter.req.ExecutionID)
+	if got := adapter.req.RunDir; got != wantRunDir {
+		t.Fatalf("unexpected bootstrap run dir: got %q want %q", got, wantRunDir)
+	}
+	executionBaseDir, err := paths.ExecutionBaseDir()
+	if err != nil {
+		t.Fatalf("ExecutionBaseDir returned error: %v", err)
+	}
+	if rel, err := filepath.Rel(executionBaseDir, adapter.req.RunDir); err == nil && rel != "." && !strings.HasPrefix(rel, "..") {
+		t.Fatalf("expected bootstrap run dir to stay out of execution artifacts base dir %q, got %q", executionBaseDir, adapter.req.RunDir)
 	}
 }
 
@@ -2387,6 +2401,50 @@ func TestFinalizeExecutionWithoutPruneSkipsImmediateStatePruning(t *testing.T) {
 		t.Fatal("execution should be pruned once explicit prune runs")
 	}
 	svc.mu.Unlock()
+}
+
+func TestPruneFinishedExecutionClearsSandboxExecutionPointers(t *testing.T) {
+	svc := newTestService(&stubAdapter{})
+
+	createSandboxResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createSandboxResp.GetSandbox().GetSandboxId()
+
+	createExecutionResp, err := svc.CreateExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
+		SandboxId: sandboxID,
+		Command:   []string{"echo", "ok"},
+	})
+	if err != nil {
+		t.Fatalf("CreateExecution returned error: %v", err)
+	}
+	executionID := createExecutionResp.GetExecution().GetExecutionId()
+	if _, err := svc.WaitExecution(context.Background(), sandboxID, executionID); err != nil {
+		t.Fatalf("WaitExecution returned error: %v", err)
+	}
+
+	retention := testRetentionPolicy()
+	retention.maxRetainedFinishedExecutions = 0
+	svc.runtime.retention = retention
+
+	svc.mu.Lock()
+	svc.pruneStateLocked(time.Now().UTC())
+	svc.mu.Unlock()
+
+	getSandboxResp, err := svc.GetSandbox(context.Background(), &cleanroomv1.GetSandboxRequest{SandboxId: sandboxID})
+	if err != nil {
+		t.Fatalf("GetSandbox returned error: %v", err)
+	}
+	if got := getSandboxResp.GetSandbox().GetLastExecutionId(); got != "" {
+		t.Fatalf("expected last_execution_id to clear after pruning, got %q", got)
+	}
+	if got := getSandboxResp.GetSandbox().GetActiveExecutionId(); got != "" {
+		t.Fatalf("expected active_execution_id to remain empty after pruning, got %q", got)
+	}
+	if _, err := svc.ExecutionSnapshot(sandboxID, executionID); err == nil {
+		t.Fatal("expected pruned execution snapshot lookup to fail")
+	}
 }
 
 func TestBufferedResultDeltaModes(t *testing.T) {

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -3,7 +3,6 @@ package controlservice
 import (
 	"context"
 	"errors"
-	"regexp"
 	"strings"
 	"sync"
 	"testing"
@@ -19,16 +18,16 @@ import (
 )
 
 type stubAdapter struct {
-	result                     *backend.RunResult
-	runFn                      func(context.Context, backend.RunRequest) (*backend.RunResult, error)
-	runStreamFn                func(context.Context, backend.RunRequest, backend.OutputStream) (*backend.RunResult, error)
+	result                     *backend.ExecutionResult
+	runFn                      func(context.Context, backend.ExecutionRequest) (*backend.ExecutionResult, error)
+	runStreamFn                func(context.Context, backend.ExecutionRequest, backend.OutputStream) (*backend.ExecutionResult, error)
 	provisionFn                func(context.Context, backend.ProvisionRequest) error
 	provisionFromSnapshotFn    func(context.Context, backend.ProvisionFromSnapshotRequest) error
 	createSnapshotFn           func(context.Context, backend.SnapshotRequest) (*backend.SnapshotResult, error)
 	deleteSnapshotFn           func(context.Context, backend.DeleteSnapshotRequest) error
 	terminateFn                func(context.Context, string) error
 	downloadFn                 func(context.Context, string, string, int64) ([]byte, error)
-	req                        backend.RunRequest
+	req                        backend.ExecutionRequest
 	provisionReq               backend.ProvisionRequest
 	provisionFromSnapshotReq   backend.ProvisionFromSnapshotRequest
 	createSnapshotReq          backend.SnapshotRequest
@@ -43,7 +42,7 @@ type stubAdapter struct {
 
 func (s *stubAdapter) Name() string { return "stub" }
 
-func (s *stubAdapter) Run(ctx context.Context, req backend.RunRequest) (*backend.RunResult, error) {
+func (s *stubAdapter) Run(ctx context.Context, req backend.ExecutionRequest) (*backend.ExecutionResult, error) {
 	s.req = req
 	s.runCalls++
 	if s.runFn != nil {
@@ -52,24 +51,24 @@ func (s *stubAdapter) Run(ctx context.Context, req backend.RunRequest) (*backend
 	if s.result != nil {
 		return s.result, nil
 	}
-	return &backend.RunResult{
-		RunID:      req.RunID,
-		ExitCode:   0,
-		LaunchedVM: true,
-		PlanPath:   "/tmp/plan",
-		RunDir:     "/tmp/run",
-		Message:    "ok",
+	return &backend.ExecutionResult{
+		ExecutionID: req.ExecutionID,
+		ExitCode:    0,
+		LaunchedVM:  true,
+		PlanPath:    "/tmp/plan",
+		RunDir:      "/tmp/run",
+		Message:     "ok",
 	}, nil
 }
 
-func (s *stubAdapter) RunStream(ctx context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+func (s *stubAdapter) RunStream(ctx context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 	s.req = req
 	s.runCalls++
 	if s.runStreamFn != nil {
 		return s.runStreamFn(ctx, req, stream)
 	}
 	var (
-		result *backend.RunResult
+		result *backend.ExecutionResult
 		err    error
 	)
 	if s.runFn != nil {
@@ -81,13 +80,13 @@ func (s *stubAdapter) RunStream(ctx context.Context, req backend.RunRequest, str
 		result = s.result
 	}
 	if result == nil {
-		result = &backend.RunResult{
-			RunID:      req.RunID,
-			ExitCode:   0,
-			LaunchedVM: true,
-			PlanPath:   "/tmp/plan",
-			RunDir:     "/tmp/run",
-			Message:    "ok",
+		result = &backend.ExecutionResult{
+			ExecutionID: req.ExecutionID,
+			ExitCode:    0,
+			LaunchedVM:  true,
+			PlanPath:    "/tmp/plan",
+			RunDir:      "/tmp/run",
+			Message:     "ok",
 		}
 	}
 	if stream.OnStdout != nil && result.Stdout != "" {
@@ -108,7 +107,7 @@ func (s *stubAdapter) ProvisionSandbox(ctx context.Context, req backend.Provisio
 	return nil
 }
 
-func (s *stubAdapter) RunInSandbox(ctx context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+func (s *stubAdapter) RunInSandbox(ctx context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 	return s.RunStream(ctx, req, stream)
 }
 
@@ -288,9 +287,9 @@ func (s *memorySnapshotStore) Delete(_ context.Context, snapshotID string) error
 
 func TestExecutionStreamIncludesExitEvent(t *testing.T) {
 	adapter := &stubAdapter{
-		runFn: func(_ context.Context, req backend.RunRequest) (*backend.RunResult, error) {
-			return &backend.RunResult{
-				RunID:       req.RunID,
+		runFn: func(_ context.Context, req backend.ExecutionRequest) (*backend.ExecutionResult, error) {
+			return &backend.ExecutionResult{
+				ExecutionID: req.ExecutionID,
 				ExitCode:    7,
 				LaunchedVM:  true,
 				PlanPath:    "/tmp/plan",
@@ -870,18 +869,18 @@ func TestExecutionStreamIncludesStructuredWarnings(t *testing.T) {
 	const warningText = "darwin-vz guest networking is enabled without host-side egress filtering"
 
 	adapter := &stubAdapter{
-		runStreamFn: func(_ context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+		runStreamFn: func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 			if stream.OnWarning != nil {
 				stream.OnWarning(warningText)
 			}
 			if stream.OnStdout != nil {
 				stream.OnStdout([]byte("hello stdout\n"))
 			}
-			return &backend.RunResult{
-				RunID:    req.RunID,
-				ExitCode: 0,
-				Stdout:   "hello stdout\n",
-				Message:  "done",
+			return &backend.ExecutionResult{
+				ExecutionID: req.ExecutionID,
+				ExitCode:    0,
+				Stdout:      "hello stdout\n",
+				Message:     "done",
 			}, nil
 		},
 	}
@@ -934,7 +933,7 @@ func TestExecutionStreamIncludesStructuredWarnings(t *testing.T) {
 func TestCancelExecutionTransitionsToCanceled(t *testing.T) {
 	started := make(chan struct{}, 1)
 	adapter := &stubAdapter{
-		runFn: func(ctx context.Context, _ backend.RunRequest) (*backend.RunResult, error) {
+		runFn: func(ctx context.Context, _ backend.ExecutionRequest) (*backend.ExecutionResult, error) {
 			select {
 			case started <- struct{}{}:
 			default:
@@ -1096,7 +1095,7 @@ func TestCreateExecutionWrapsRepositoryBootstrapInService(t *testing.T) {
 		mu       sync.Mutex
 		commands [][]string
 	)
-	adapter.runStreamFn = func(_ context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 		mu.Lock()
 		commands = append(commands, append([]string(nil), req.Command...))
 		mu.Unlock()
@@ -1104,7 +1103,7 @@ func TestCreateExecutionWrapsRepositoryBootstrapInService(t *testing.T) {
 		case runCalled <- struct{}{}:
 		default:
 		}
-		return &backend.RunResult{RunID: req.RunID, ExitCode: 0, Message: "ok"}, nil
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
 	}
 
 	createSandboxResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testRepositoryPolicy()})
@@ -1172,7 +1171,7 @@ func TestCreateExecutionSkipsBootstrapForMatchingPersistentRepository(t *testing
 		commands [][]string
 	)
 	runCalled := make(chan struct{}, 4)
-	adapter.runStreamFn = func(_ context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 		mu.Lock()
 		commands = append(commands, append([]string(nil), req.Command...))
 		mu.Unlock()
@@ -1180,7 +1179,7 @@ func TestCreateExecutionSkipsBootstrapForMatchingPersistentRepository(t *testing
 		case runCalled <- struct{}{}:
 		default:
 		}
-		return &backend.RunResult{RunID: req.RunID, ExitCode: 0, Message: "ok"}, nil
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
 	}
 
 	createSandboxResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
@@ -1243,7 +1242,7 @@ func TestCreateExecutionSkipsBootstrapForSnapshotBackedSandboxWithMatchingReposi
 		commands [][]string
 	)
 	runCalled := make(chan struct{}, 8)
-	adapter.runStreamFn = func(_ context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 		mu.Lock()
 		commands = append(commands, append([]string(nil), req.Command...))
 		mu.Unlock()
@@ -1251,7 +1250,7 @@ func TestCreateExecutionSkipsBootstrapForSnapshotBackedSandboxWithMatchingReposi
 		case runCalled <- struct{}{}:
 		default:
 		}
-		return &backend.RunResult{RunID: req.RunID, ExitCode: 0, Message: "ok"}, nil
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
 	}
 
 	sourceResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
@@ -1388,7 +1387,7 @@ func TestCreateExecutionRejectsRepositoryRemoteOutsidePolicy(t *testing.T) {
 func TestCreateSandboxBootstrapCleanupUsesFreshContext(t *testing.T) {
 	adapter := &stubAdapter{}
 	svc := newTestService(adapter)
-	adapter.runStreamFn = func(ctx context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+	adapter.runStreamFn = func(ctx context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 		return nil, ctx.Err()
 	}
 	adapter.terminateFn = func(ctx context.Context, sandboxID string) error {
@@ -1583,7 +1582,7 @@ func TestCreateSandboxSetsRepositoryBootstrapRootFSMinimum(t *testing.T) {
 func TestCreateExecutionRejectsWhenSandboxBusy(t *testing.T) {
 	started := make(chan struct{}, 1)
 	adapter := &stubAdapter{
-		runFn: func(ctx context.Context, req backend.RunRequest) (*backend.RunResult, error) {
+		runFn: func(ctx context.Context, req backend.ExecutionRequest) (*backend.ExecutionResult, error) {
 			select {
 			case started <- struct{}{}:
 			default:
@@ -1681,7 +1680,7 @@ func TestDownloadSandboxFileReturnsData(t *testing.T) {
 func TestDownloadSandboxFileRejectsWhenSandboxBusy(t *testing.T) {
 	started := make(chan struct{}, 1)
 	adapter := &stubAdapter{
-		runFn: func(ctx context.Context, req backend.RunRequest) (*backend.RunResult, error) {
+		runFn: func(ctx context.Context, req backend.ExecutionRequest) (*backend.ExecutionResult, error) {
 			select {
 			case started <- struct{}{}:
 			default:
@@ -1959,16 +1958,19 @@ func TestServiceGeneratedIDsUseTypeIDFormat(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetExecution returned error: %v", err)
 	}
-	runID := getResp.GetExecution().GetRunId()
-	parsedRunID, err := typeid.FromString(runID)
+	if got, want := getResp.GetExecution().GetExecutionId(), executionID; got != want {
+		t.Fatalf("unexpected execution id from GetExecution: got %q want %q", got, want)
+	}
+
+	sandboxResp, err := svc.GetSandbox(context.Background(), &cleanroomv1.GetSandboxRequest{SandboxId: sandboxID})
 	if err != nil {
-		t.Fatalf("expected typeid-formatted run id, got %q: %v", runID, err)
+		t.Fatalf("GetSandbox returned error: %v", err)
 	}
-	if got, want := parsedRunID.Prefix(), "run"; got != want {
-		t.Fatalf("unexpected run id prefix: got %q want %q", got, want)
+	if got, want := sandboxResp.GetSandbox().GetLastExecutionId(), executionID; got != want {
+		t.Fatalf("unexpected last execution id: got %q want %q", got, want)
 	}
-	if !regexp.MustCompile(`^run_[0-9a-z]{26}$`).MatchString(runID) {
-		t.Fatalf("unexpected run id shape: %q", runID)
+	if got := sandboxResp.GetSandbox().GetActiveExecutionId(); got != "" {
+		t.Fatalf("expected no active execution after completion, got %q", got)
 	}
 }
 
@@ -1978,7 +1980,7 @@ func TestExecutionAttachIOForwarding(t *testing.T) {
 	stdinClosed := make(chan struct{}, 1)
 	resizes := make(chan [2]uint32, 1)
 	adapter := &stubAdapter{
-		runStreamFn: func(ctx context.Context, _ backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+		runStreamFn: func(ctx context.Context, _ backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 			if stream.OnAttach != nil {
 				stream.OnAttach(backend.AttachIO{
 					WriteStdin: func(data []byte) error {
@@ -2084,7 +2086,7 @@ func TestExecutionAttachIOWaitsForDelayedAttachRegistration(t *testing.T) {
 	stdinClosed := make(chan struct{}, 1)
 	resizes := make(chan [2]uint32, 1)
 	adapter := &stubAdapter{
-		runStreamFn: func(ctx context.Context, _ backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+		runStreamFn: func(ctx context.Context, _ backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 			select {
 			case started <- struct{}{}:
 			default:
@@ -2192,7 +2194,7 @@ func TestExecutionAttachIOWaitsForDelayedAttachRegistration(t *testing.T) {
 func TestExecutionAttachIOUnsupportedWhenBackendDoesNotExposeHandlers(t *testing.T) {
 	started := make(chan struct{}, 1)
 	adapter := &stubAdapter{
-		runStreamFn: func(ctx context.Context, _ backend.RunRequest, _ backend.OutputStream) (*backend.RunResult, error) {
+		runStreamFn: func(ctx context.Context, _ backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
 			select {
 			case started <- struct{}{}:
 			default:
@@ -2409,7 +2411,7 @@ func TestMergeBufferedResultOutputReplacesMissingStreamPrefix(t *testing.T) {
 		events:    newEventFeed[*cleanroomv1.ExecutionStreamEvent](defaultRetentionPolicy.maxRetainedExecutionEvents),
 	}
 
-	svc.mergeBufferedResultOutputLocked(ex, &backend.RunResult{
+	svc.mergeBufferedResultOutputLocked(ex, &backend.ExecutionResult{
 		Stdout: "head-tail",
 	}, true)
 
@@ -2508,7 +2510,7 @@ func TestStatePruningBoundsRetainedTerminalState(t *testing.T) {
 
 func TestExecutionRetentionBoundsOutput(t *testing.T) {
 	adapter := &stubAdapter{
-		runStreamFn: func(_ context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+		runStreamFn: func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 			for _, chunk := range []string{"1234", "5678", "90"} {
 				if stream.OnStdout != nil {
 					stream.OnStdout([]byte(chunk))
@@ -2519,15 +2521,15 @@ func TestExecutionRetentionBoundsOutput(t *testing.T) {
 					stream.OnStderr([]byte(chunk))
 				}
 			}
-			return &backend.RunResult{
-				RunID:      req.RunID,
-				ExitCode:   0,
-				LaunchedVM: false,
-				PlanPath:   "/tmp/plan",
-				RunDir:     "/tmp/run",
-				Message:    "ok",
-				Stdout:     "1234567890",
-				Stderr:     "abcdefghij",
+			return &backend.ExecutionResult{
+				ExecutionID: req.ExecutionID,
+				ExitCode:    0,
+				LaunchedVM:  false,
+				PlanPath:    "/tmp/plan",
+				RunDir:      "/tmp/run",
+				Message:     "ok",
+				Stdout:      "1234567890",
+				Stderr:      "abcdefghij",
 			}, nil
 		},
 	}
@@ -2569,20 +2571,20 @@ func TestExecutionRetentionBoundsOutput(t *testing.T) {
 
 func TestExecutionRetentionBoundsEventHistory(t *testing.T) {
 	adapter := &stubAdapter{
-		runStreamFn: func(_ context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+		runStreamFn: func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 			for _, chunk := range []string{"1", "2", "3", "4"} {
 				if stream.OnStdout != nil {
 					stream.OnStdout([]byte(chunk))
 				}
 			}
-			return &backend.RunResult{
-				RunID:      req.RunID,
-				ExitCode:   0,
-				LaunchedVM: false,
-				PlanPath:   "/tmp/plan",
-				RunDir:     "/tmp/run",
-				Message:    "ok",
-				Stdout:     "1234",
+			return &backend.ExecutionResult{
+				ExecutionID: req.ExecutionID,
+				ExitCode:    0,
+				LaunchedVM:  false,
+				PlanPath:    "/tmp/plan",
+				RunDir:      "/tmp/run",
+				Message:     "ok",
+				Stdout:      "1234",
 			}, nil
 		},
 	}
@@ -2670,7 +2672,7 @@ func TestSandboxRetentionBoundsEventHistory(t *testing.T) {
 
 func TestStreamedOutputArrivesBeforeExecutionExit(t *testing.T) {
 	adapter := &stubAdapter{
-		runStreamFn: func(ctx context.Context, req backend.RunRequest, stream backend.OutputStream) (*backend.RunResult, error) {
+		runStreamFn: func(ctx context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 			if stream.OnStdout != nil {
 				stream.OnStdout([]byte("chunk-1\n"))
 			}
@@ -2683,14 +2685,14 @@ func TestStreamedOutputArrivesBeforeExecutionExit(t *testing.T) {
 				return nil, ctx.Err()
 			default:
 			}
-			return &backend.RunResult{
-				RunID:      req.RunID,
-				ExitCode:   0,
-				LaunchedVM: false,
-				PlanPath:   "/tmp/plan",
-				RunDir:     "/tmp/run",
-				Message:    "ok",
-				Stdout:     "chunk-1\nchunk-2\n",
+			return &backend.ExecutionResult{
+				ExecutionID: req.ExecutionID,
+				ExitCode:    0,
+				LaunchedVM:  false,
+				PlanPath:    "/tmp/plan",
+				RunDir:      "/tmp/run",
+				Message:     "ok",
+				Stdout:      "chunk-1\nchunk-2\n",
 			}, nil
 		},
 	}
@@ -2776,22 +2778,22 @@ func TestCreateExecutionDerivesKindFromTTY(t *testing.T) {
 	}
 }
 
-func TestOpenInteractiveExecutionRejectsBatchExecution(t *testing.T) {
+func TestAttachExecutionRejectsBatchExecution(t *testing.T) {
 	release := make(chan struct{})
 	adapter := &stubAdapter{
-		runFn: func(ctx context.Context, req backend.RunRequest) (*backend.RunResult, error) {
+		runFn: func(ctx context.Context, req backend.ExecutionRequest) (*backend.ExecutionResult, error) {
 			select {
 			case <-release:
 			case <-ctx.Done():
 				return nil, ctx.Err()
 			}
-			return &backend.RunResult{
-				RunID:      req.RunID,
-				ExitCode:   0,
-				LaunchedVM: false,
-				PlanPath:   "/tmp/plan",
-				RunDir:     "/tmp/run",
-				Message:    "ok",
+			return &backend.ExecutionResult{
+				ExecutionID: req.ExecutionID,
+				ExitCode:    0,
+				LaunchedVM:  false,
+				PlanPath:    "/tmp/plan",
+				RunDir:      "/tmp/run",
+				Message:     "ok",
 			}, nil
 		},
 	}
@@ -2813,12 +2815,12 @@ func TestOpenInteractiveExecutionRejectsBatchExecution(t *testing.T) {
 		t.Fatalf("CreateExecution returned error: %v", err)
 	}
 
-	_, err = svc.OpenInteractiveExecution(context.Background(), &cleanroomv1.OpenInteractiveExecutionRequest{
+	_, err = svc.AttachExecution(context.Background(), &cleanroomv1.AttachExecutionRequest{
 		SandboxId:   sandboxID,
 		ExecutionId: execResp.GetExecution().GetExecutionId(),
 	})
 	if err == nil {
-		t.Fatal("expected OpenInteractiveExecution to fail for batch execution")
+		t.Fatal("expected AttachExecution to fail for batch execution")
 	}
 	if !strings.Contains(err.Error(), "not interactive") {
 		t.Fatalf("expected not interactive error, got %v", err)
@@ -2827,22 +2829,22 @@ func TestOpenInteractiveExecutionRejectsBatchExecution(t *testing.T) {
 	close(release)
 }
 
-func TestOpenInteractiveExecutionReturnsSessionToken(t *testing.T) {
+func TestAttachExecutionReturnsSessionToken(t *testing.T) {
 	release := make(chan struct{})
 	adapter := &stubAdapter{
-		runFn: func(ctx context.Context, req backend.RunRequest) (*backend.RunResult, error) {
+		runFn: func(ctx context.Context, req backend.ExecutionRequest) (*backend.ExecutionResult, error) {
 			select {
 			case <-release:
 			case <-ctx.Done():
 				return nil, ctx.Err()
 			}
-			return &backend.RunResult{
-				RunID:      req.RunID,
-				ExitCode:   0,
-				LaunchedVM: false,
-				PlanPath:   "/tmp/plan",
-				RunDir:     "/tmp/run",
-				Message:    "ok",
+			return &backend.ExecutionResult{
+				ExecutionID: req.ExecutionID,
+				ExitCode:    0,
+				LaunchedVM:  false,
+				PlanPath:    "/tmp/plan",
+				RunDir:      "/tmp/run",
+				Message:     "ok",
 			}, nil
 		},
 	}
@@ -2868,14 +2870,14 @@ func TestOpenInteractiveExecutionReturnsSessionToken(t *testing.T) {
 	}
 	executionID := execResp.GetExecution().GetExecutionId()
 
-	openResp, err := svc.OpenInteractiveExecution(context.Background(), &cleanroomv1.OpenInteractiveExecutionRequest{
+	openResp, err := svc.AttachExecution(context.Background(), &cleanroomv1.AttachExecutionRequest{
 		SandboxId:   sandboxID,
 		ExecutionId: executionID,
 		InitialCols: 120,
 		InitialRows: 42,
 	})
 	if err != nil {
-		t.Fatalf("OpenInteractiveExecution returned error: %v", err)
+		t.Fatalf("AttachExecution returned error: %v", err)
 	}
 	if openResp.GetSessionId() == "" {
 		t.Fatal("expected session_id")
@@ -2908,19 +2910,19 @@ func TestOpenInteractiveExecutionReturnsSessionToken(t *testing.T) {
 func TestConsumeInteractiveSessionIsSingleUse(t *testing.T) {
 	release := make(chan struct{})
 	adapter := &stubAdapter{
-		runFn: func(ctx context.Context, req backend.RunRequest) (*backend.RunResult, error) {
+		runFn: func(ctx context.Context, req backend.ExecutionRequest) (*backend.ExecutionResult, error) {
 			select {
 			case <-release:
 			case <-ctx.Done():
 				return nil, ctx.Err()
 			}
-			return &backend.RunResult{
-				RunID:      req.RunID,
-				ExitCode:   0,
-				LaunchedVM: false,
-				PlanPath:   "/tmp/plan",
-				RunDir:     "/tmp/run",
-				Message:    "ok",
+			return &backend.ExecutionResult{
+				ExecutionID: req.ExecutionID,
+				ExitCode:    0,
+				LaunchedVM:  false,
+				PlanPath:    "/tmp/plan",
+				RunDir:      "/tmp/run",
+				Message:     "ok",
 			}, nil
 		},
 	}
@@ -2945,12 +2947,12 @@ func TestConsumeInteractiveSessionIsSingleUse(t *testing.T) {
 		t.Fatalf("CreateExecution returned error: %v", err)
 	}
 
-	openResp, err := svc.OpenInteractiveExecution(context.Background(), &cleanroomv1.OpenInteractiveExecutionRequest{
+	openResp, err := svc.AttachExecution(context.Background(), &cleanroomv1.AttachExecutionRequest{
 		SandboxId:   sandboxID,
 		ExecutionId: execResp.GetExecution().GetExecutionId(),
 	})
 	if err != nil {
-		t.Fatalf("OpenInteractiveExecution returned error: %v", err)
+		t.Fatalf("AttachExecution returned error: %v", err)
 	}
 
 	session, err := svc.ConsumeInteractiveSession(openResp.GetSessionId(), openResp.GetSessionToken())
@@ -2971,22 +2973,22 @@ func TestConsumeInteractiveSessionIsSingleUse(t *testing.T) {
 	}
 }
 
-func TestOpenInteractiveExecutionEnforcesSingleActiveAttach(t *testing.T) {
+func TestAttachExecutionEnforcesSingleActiveAttach(t *testing.T) {
 	release := make(chan struct{})
 	adapter := &stubAdapter{
-		runFn: func(ctx context.Context, req backend.RunRequest) (*backend.RunResult, error) {
+		runFn: func(ctx context.Context, req backend.ExecutionRequest) (*backend.ExecutionResult, error) {
 			select {
 			case <-release:
 			case <-ctx.Done():
 				return nil, ctx.Err()
 			}
-			return &backend.RunResult{
-				RunID:      req.RunID,
-				ExitCode:   0,
-				LaunchedVM: false,
-				PlanPath:   "/tmp/plan",
-				RunDir:     "/tmp/run",
-				Message:    "ok",
+			return &backend.ExecutionResult{
+				ExecutionID: req.ExecutionID,
+				ExitCode:    0,
+				LaunchedVM:  false,
+				PlanPath:    "/tmp/plan",
+				RunDir:      "/tmp/run",
+				Message:     "ok",
 			}, nil
 		},
 	}
@@ -3012,15 +3014,15 @@ func TestOpenInteractiveExecutionEnforcesSingleActiveAttach(t *testing.T) {
 	}
 	executionID := createExecutionResp.GetExecution().GetExecutionId()
 
-	firstOpenResp, err := svc.OpenInteractiveExecution(context.Background(), &cleanroomv1.OpenInteractiveExecutionRequest{
+	firstOpenResp, err := svc.AttachExecution(context.Background(), &cleanroomv1.AttachExecutionRequest{
 		SandboxId:   sandboxID,
 		ExecutionId: executionID,
 	})
 	if err != nil {
-		t.Fatalf("first OpenInteractiveExecution returned error: %v", err)
+		t.Fatalf("first AttachExecution returned error: %v", err)
 	}
 
-	if _, err := svc.OpenInteractiveExecution(context.Background(), &cleanroomv1.OpenInteractiveExecutionRequest{
+	if _, err := svc.AttachExecution(context.Background(), &cleanroomv1.AttachExecutionRequest{
 		SandboxId:   sandboxID,
 		ExecutionId: executionID,
 	}); err == nil || !strings.Contains(err.Error(), "pending interactive session") {
@@ -3031,7 +3033,7 @@ func TestOpenInteractiveExecutionEnforcesSingleActiveAttach(t *testing.T) {
 		t.Fatalf("ConsumeInteractiveSession returned error: %v", err)
 	}
 
-	if _, err := svc.OpenInteractiveExecution(context.Background(), &cleanroomv1.OpenInteractiveExecutionRequest{
+	if _, err := svc.AttachExecution(context.Background(), &cleanroomv1.AttachExecutionRequest{
 		SandboxId:   sandboxID,
 		ExecutionId: executionID,
 	}); err == nil || !strings.Contains(err.Error(), "active interactive session") {
@@ -3040,7 +3042,7 @@ func TestOpenInteractiveExecutionEnforcesSingleActiveAttach(t *testing.T) {
 
 	svc.ReleaseInteractiveExecution(sandboxID, executionID)
 
-	if _, err := svc.OpenInteractiveExecution(context.Background(), &cleanroomv1.OpenInteractiveExecutionRequest{
+	if _, err := svc.AttachExecution(context.Background(), &cleanroomv1.AttachExecutionRequest{
 		SandboxId:   sandboxID,
 		ExecutionId: executionID,
 	}); err != nil {

--- a/internal/controlservice/state_helpers.go
+++ b/internal/controlservice/state_helpers.go
@@ -114,12 +114,14 @@ func cloneSandboxLocked(state *sandboxState) *cleanroomv1.Sandbox {
 		policyHash = state.Policy.Hash
 	}
 	return &cleanroomv1.Sandbox{
-		SandboxId:  state.ID,
-		Status:     state.Status,
-		Backend:    state.Backend,
-		PolicyHash: policyHash,
-		CreatedAt:  timestamppb.New(state.CreatedAt),
-		UpdatedAt:  timestamppb.New(state.UpdatedAt),
+		SandboxId:         state.ID,
+		Status:            state.Status,
+		Backend:           state.Backend,
+		PolicyHash:        policyHash,
+		CreatedAt:         timestamppb.New(state.CreatedAt),
+		UpdatedAt:         timestamppb.New(state.UpdatedAt),
+		LastExecutionId:   state.LastExecutionID,
+		ActiveExecutionId: state.ActiveExecutionID,
 	}
 }
 
@@ -134,7 +136,6 @@ func cloneExecutionLocked(state *executionState) *cleanroomv1.Execution {
 		Command:     append([]string(nil), state.Command...),
 		ExitCode:    state.ExitCode,
 		Tty:         state.TTY,
-		RunId:       state.RunID,
 		Kind:        state.Kind,
 	}
 	if state.StartedAt != nil {

--- a/internal/gen/cleanroom/v1/cleanroomv1connect/control.connect.go
+++ b/internal/gen/cleanroom/v1/cleanroomv1connect/control.connect.go
@@ -70,12 +70,15 @@ const (
 	// ExecutionServiceCreateExecutionProcedure is the fully-qualified name of the ExecutionService's
 	// CreateExecution RPC.
 	ExecutionServiceCreateExecutionProcedure = "/cleanroom.v1.ExecutionService/CreateExecution"
-	// ExecutionServiceOpenInteractiveExecutionProcedure is the fully-qualified name of the
-	// ExecutionService's OpenInteractiveExecution RPC.
-	ExecutionServiceOpenInteractiveExecutionProcedure = "/cleanroom.v1.ExecutionService/OpenInteractiveExecution"
+	// ExecutionServiceAttachExecutionProcedure is the fully-qualified name of the ExecutionService's
+	// AttachExecution RPC.
+	ExecutionServiceAttachExecutionProcedure = "/cleanroom.v1.ExecutionService/AttachExecution"
 	// ExecutionServiceGetExecutionProcedure is the fully-qualified name of the ExecutionService's
 	// GetExecution RPC.
 	ExecutionServiceGetExecutionProcedure = "/cleanroom.v1.ExecutionService/GetExecution"
+	// ExecutionServiceInspectExecutionProcedure is the fully-qualified name of the ExecutionService's
+	// InspectExecution RPC.
+	ExecutionServiceInspectExecutionProcedure = "/cleanroom.v1.ExecutionService/InspectExecution"
 	// ExecutionServiceCancelExecutionProcedure is the fully-qualified name of the ExecutionService's
 	// CancelExecution RPC.
 	ExecutionServiceCancelExecutionProcedure = "/cleanroom.v1.ExecutionService/CancelExecution"
@@ -441,8 +444,9 @@ func (UnimplementedSnapshotServiceHandler) DeleteSnapshot(context.Context, *conn
 // ExecutionServiceClient is a client for the cleanroom.v1.ExecutionService service.
 type ExecutionServiceClient interface {
 	CreateExecution(context.Context, *connect.Request[v1.CreateExecutionRequest]) (*connect.Response[v1.CreateExecutionResponse], error)
-	OpenInteractiveExecution(context.Context, *connect.Request[v1.OpenInteractiveExecutionRequest]) (*connect.Response[v1.OpenInteractiveExecutionResponse], error)
+	AttachExecution(context.Context, *connect.Request[v1.AttachExecutionRequest]) (*connect.Response[v1.AttachExecutionResponse], error)
 	GetExecution(context.Context, *connect.Request[v1.GetExecutionRequest]) (*connect.Response[v1.GetExecutionResponse], error)
+	InspectExecution(context.Context, *connect.Request[v1.InspectExecutionRequest]) (*connect.Response[v1.InspectExecutionResponse], error)
 	CancelExecution(context.Context, *connect.Request[v1.CancelExecutionRequest]) (*connect.Response[v1.CancelExecutionResponse], error)
 	WriteExecutionStdin(context.Context, *connect.Request[v1.WriteExecutionStdinRequest]) (*connect.Response[v1.WriteExecutionStdinResponse], error)
 	CloseExecutionStdin(context.Context, *connect.Request[v1.CloseExecutionStdinRequest]) (*connect.Response[v1.CloseExecutionStdinResponse], error)
@@ -466,16 +470,22 @@ func NewExecutionServiceClient(httpClient connect.HTTPClient, baseURL string, op
 			connect.WithSchema(executionServiceMethods.ByName("CreateExecution")),
 			connect.WithClientOptions(opts...),
 		),
-		openInteractiveExecution: connect.NewClient[v1.OpenInteractiveExecutionRequest, v1.OpenInteractiveExecutionResponse](
+		attachExecution: connect.NewClient[v1.AttachExecutionRequest, v1.AttachExecutionResponse](
 			httpClient,
-			baseURL+ExecutionServiceOpenInteractiveExecutionProcedure,
-			connect.WithSchema(executionServiceMethods.ByName("OpenInteractiveExecution")),
+			baseURL+ExecutionServiceAttachExecutionProcedure,
+			connect.WithSchema(executionServiceMethods.ByName("AttachExecution")),
 			connect.WithClientOptions(opts...),
 		),
 		getExecution: connect.NewClient[v1.GetExecutionRequest, v1.GetExecutionResponse](
 			httpClient,
 			baseURL+ExecutionServiceGetExecutionProcedure,
 			connect.WithSchema(executionServiceMethods.ByName("GetExecution")),
+			connect.WithClientOptions(opts...),
+		),
+		inspectExecution: connect.NewClient[v1.InspectExecutionRequest, v1.InspectExecutionResponse](
+			httpClient,
+			baseURL+ExecutionServiceInspectExecutionProcedure,
+			connect.WithSchema(executionServiceMethods.ByName("InspectExecution")),
 			connect.WithClientOptions(opts...),
 		),
 		cancelExecution: connect.NewClient[v1.CancelExecutionRequest, v1.CancelExecutionResponse](
@@ -507,13 +517,14 @@ func NewExecutionServiceClient(httpClient connect.HTTPClient, baseURL string, op
 
 // executionServiceClient implements ExecutionServiceClient.
 type executionServiceClient struct {
-	createExecution          *connect.Client[v1.CreateExecutionRequest, v1.CreateExecutionResponse]
-	openInteractiveExecution *connect.Client[v1.OpenInteractiveExecutionRequest, v1.OpenInteractiveExecutionResponse]
-	getExecution             *connect.Client[v1.GetExecutionRequest, v1.GetExecutionResponse]
-	cancelExecution          *connect.Client[v1.CancelExecutionRequest, v1.CancelExecutionResponse]
-	writeExecutionStdin      *connect.Client[v1.WriteExecutionStdinRequest, v1.WriteExecutionStdinResponse]
-	closeExecutionStdin      *connect.Client[v1.CloseExecutionStdinRequest, v1.CloseExecutionStdinResponse]
-	streamExecution          *connect.Client[v1.StreamExecutionRequest, v1.ExecutionStreamEvent]
+	createExecution     *connect.Client[v1.CreateExecutionRequest, v1.CreateExecutionResponse]
+	attachExecution     *connect.Client[v1.AttachExecutionRequest, v1.AttachExecutionResponse]
+	getExecution        *connect.Client[v1.GetExecutionRequest, v1.GetExecutionResponse]
+	inspectExecution    *connect.Client[v1.InspectExecutionRequest, v1.InspectExecutionResponse]
+	cancelExecution     *connect.Client[v1.CancelExecutionRequest, v1.CancelExecutionResponse]
+	writeExecutionStdin *connect.Client[v1.WriteExecutionStdinRequest, v1.WriteExecutionStdinResponse]
+	closeExecutionStdin *connect.Client[v1.CloseExecutionStdinRequest, v1.CloseExecutionStdinResponse]
+	streamExecution     *connect.Client[v1.StreamExecutionRequest, v1.ExecutionStreamEvent]
 }
 
 // CreateExecution calls cleanroom.v1.ExecutionService.CreateExecution.
@@ -521,14 +532,19 @@ func (c *executionServiceClient) CreateExecution(ctx context.Context, req *conne
 	return c.createExecution.CallUnary(ctx, req)
 }
 
-// OpenInteractiveExecution calls cleanroom.v1.ExecutionService.OpenInteractiveExecution.
-func (c *executionServiceClient) OpenInteractiveExecution(ctx context.Context, req *connect.Request[v1.OpenInteractiveExecutionRequest]) (*connect.Response[v1.OpenInteractiveExecutionResponse], error) {
-	return c.openInteractiveExecution.CallUnary(ctx, req)
+// AttachExecution calls cleanroom.v1.ExecutionService.AttachExecution.
+func (c *executionServiceClient) AttachExecution(ctx context.Context, req *connect.Request[v1.AttachExecutionRequest]) (*connect.Response[v1.AttachExecutionResponse], error) {
+	return c.attachExecution.CallUnary(ctx, req)
 }
 
 // GetExecution calls cleanroom.v1.ExecutionService.GetExecution.
 func (c *executionServiceClient) GetExecution(ctx context.Context, req *connect.Request[v1.GetExecutionRequest]) (*connect.Response[v1.GetExecutionResponse], error) {
 	return c.getExecution.CallUnary(ctx, req)
+}
+
+// InspectExecution calls cleanroom.v1.ExecutionService.InspectExecution.
+func (c *executionServiceClient) InspectExecution(ctx context.Context, req *connect.Request[v1.InspectExecutionRequest]) (*connect.Response[v1.InspectExecutionResponse], error) {
+	return c.inspectExecution.CallUnary(ctx, req)
 }
 
 // CancelExecution calls cleanroom.v1.ExecutionService.CancelExecution.
@@ -554,8 +570,9 @@ func (c *executionServiceClient) StreamExecution(ctx context.Context, req *conne
 // ExecutionServiceHandler is an implementation of the cleanroom.v1.ExecutionService service.
 type ExecutionServiceHandler interface {
 	CreateExecution(context.Context, *connect.Request[v1.CreateExecutionRequest]) (*connect.Response[v1.CreateExecutionResponse], error)
-	OpenInteractiveExecution(context.Context, *connect.Request[v1.OpenInteractiveExecutionRequest]) (*connect.Response[v1.OpenInteractiveExecutionResponse], error)
+	AttachExecution(context.Context, *connect.Request[v1.AttachExecutionRequest]) (*connect.Response[v1.AttachExecutionResponse], error)
 	GetExecution(context.Context, *connect.Request[v1.GetExecutionRequest]) (*connect.Response[v1.GetExecutionResponse], error)
+	InspectExecution(context.Context, *connect.Request[v1.InspectExecutionRequest]) (*connect.Response[v1.InspectExecutionResponse], error)
 	CancelExecution(context.Context, *connect.Request[v1.CancelExecutionRequest]) (*connect.Response[v1.CancelExecutionResponse], error)
 	WriteExecutionStdin(context.Context, *connect.Request[v1.WriteExecutionStdinRequest]) (*connect.Response[v1.WriteExecutionStdinResponse], error)
 	CloseExecutionStdin(context.Context, *connect.Request[v1.CloseExecutionStdinRequest]) (*connect.Response[v1.CloseExecutionStdinResponse], error)
@@ -575,16 +592,22 @@ func NewExecutionServiceHandler(svc ExecutionServiceHandler, opts ...connect.Han
 		connect.WithSchema(executionServiceMethods.ByName("CreateExecution")),
 		connect.WithHandlerOptions(opts...),
 	)
-	executionServiceOpenInteractiveExecutionHandler := connect.NewUnaryHandler(
-		ExecutionServiceOpenInteractiveExecutionProcedure,
-		svc.OpenInteractiveExecution,
-		connect.WithSchema(executionServiceMethods.ByName("OpenInteractiveExecution")),
+	executionServiceAttachExecutionHandler := connect.NewUnaryHandler(
+		ExecutionServiceAttachExecutionProcedure,
+		svc.AttachExecution,
+		connect.WithSchema(executionServiceMethods.ByName("AttachExecution")),
 		connect.WithHandlerOptions(opts...),
 	)
 	executionServiceGetExecutionHandler := connect.NewUnaryHandler(
 		ExecutionServiceGetExecutionProcedure,
 		svc.GetExecution,
 		connect.WithSchema(executionServiceMethods.ByName("GetExecution")),
+		connect.WithHandlerOptions(opts...),
+	)
+	executionServiceInspectExecutionHandler := connect.NewUnaryHandler(
+		ExecutionServiceInspectExecutionProcedure,
+		svc.InspectExecution,
+		connect.WithSchema(executionServiceMethods.ByName("InspectExecution")),
 		connect.WithHandlerOptions(opts...),
 	)
 	executionServiceCancelExecutionHandler := connect.NewUnaryHandler(
@@ -615,10 +638,12 @@ func NewExecutionServiceHandler(svc ExecutionServiceHandler, opts ...connect.Han
 		switch r.URL.Path {
 		case ExecutionServiceCreateExecutionProcedure:
 			executionServiceCreateExecutionHandler.ServeHTTP(w, r)
-		case ExecutionServiceOpenInteractiveExecutionProcedure:
-			executionServiceOpenInteractiveExecutionHandler.ServeHTTP(w, r)
+		case ExecutionServiceAttachExecutionProcedure:
+			executionServiceAttachExecutionHandler.ServeHTTP(w, r)
 		case ExecutionServiceGetExecutionProcedure:
 			executionServiceGetExecutionHandler.ServeHTTP(w, r)
+		case ExecutionServiceInspectExecutionProcedure:
+			executionServiceInspectExecutionHandler.ServeHTTP(w, r)
 		case ExecutionServiceCancelExecutionProcedure:
 			executionServiceCancelExecutionHandler.ServeHTTP(w, r)
 		case ExecutionServiceWriteExecutionStdinProcedure:
@@ -640,12 +665,16 @@ func (UnimplementedExecutionServiceHandler) CreateExecution(context.Context, *co
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cleanroom.v1.ExecutionService.CreateExecution is not implemented"))
 }
 
-func (UnimplementedExecutionServiceHandler) OpenInteractiveExecution(context.Context, *connect.Request[v1.OpenInteractiveExecutionRequest]) (*connect.Response[v1.OpenInteractiveExecutionResponse], error) {
-	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cleanroom.v1.ExecutionService.OpenInteractiveExecution is not implemented"))
+func (UnimplementedExecutionServiceHandler) AttachExecution(context.Context, *connect.Request[v1.AttachExecutionRequest]) (*connect.Response[v1.AttachExecutionResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cleanroom.v1.ExecutionService.AttachExecution is not implemented"))
 }
 
 func (UnimplementedExecutionServiceHandler) GetExecution(context.Context, *connect.Request[v1.GetExecutionRequest]) (*connect.Response[v1.GetExecutionResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cleanroom.v1.ExecutionService.GetExecution is not implemented"))
+}
+
+func (UnimplementedExecutionServiceHandler) InspectExecution(context.Context, *connect.Request[v1.InspectExecutionRequest]) (*connect.Response[v1.InspectExecutionResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cleanroom.v1.ExecutionService.InspectExecution is not implemented"))
 }
 
 func (UnimplementedExecutionServiceHandler) CancelExecution(context.Context, *connect.Request[v1.CancelExecutionRequest]) (*connect.Response[v1.CancelExecutionResponse], error) {

--- a/internal/gen/cleanroom/v1/control.pb.go
+++ b/internal/gen/cleanroom/v1/control.pb.go
@@ -9,6 +9,7 @@ package cleanroomv1
 import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	structpb "google.golang.org/protobuf/types/known/structpb"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	sync "sync"
@@ -191,15 +192,17 @@ func (ExecutionKind) EnumDescriptor() ([]byte, []int) {
 }
 
 type Sandbox struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	SandboxId     string                 `protobuf:"bytes,1,opt,name=sandbox_id,json=sandboxId,proto3" json:"sandbox_id,omitempty"`
-	Status        SandboxStatus          `protobuf:"varint,2,opt,name=status,proto3,enum=cleanroom.v1.SandboxStatus" json:"status,omitempty"`
-	Backend       string                 `protobuf:"bytes,3,opt,name=backend,proto3" json:"backend,omitempty"`
-	PolicyHash    string                 `protobuf:"bytes,4,opt,name=policy_hash,json=policyHash,proto3" json:"policy_hash,omitempty"`
-	CreatedAt     *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
-	UpdatedAt     *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=updated_at,json=updatedAt,proto3" json:"updated_at,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	SandboxId         string                 `protobuf:"bytes,1,opt,name=sandbox_id,json=sandboxId,proto3" json:"sandbox_id,omitempty"`
+	Status            SandboxStatus          `protobuf:"varint,2,opt,name=status,proto3,enum=cleanroom.v1.SandboxStatus" json:"status,omitempty"`
+	Backend           string                 `protobuf:"bytes,3,opt,name=backend,proto3" json:"backend,omitempty"`
+	PolicyHash        string                 `protobuf:"bytes,4,opt,name=policy_hash,json=policyHash,proto3" json:"policy_hash,omitempty"`
+	CreatedAt         *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	UpdatedAt         *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=updated_at,json=updatedAt,proto3" json:"updated_at,omitempty"`
+	LastExecutionId   string                 `protobuf:"bytes,7,opt,name=last_execution_id,json=lastExecutionId,proto3" json:"last_execution_id,omitempty"`
+	ActiveExecutionId string                 `protobuf:"bytes,8,opt,name=active_execution_id,json=activeExecutionId,proto3" json:"active_execution_id,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *Sandbox) Reset() {
@@ -272,6 +275,20 @@ func (x *Sandbox) GetUpdatedAt() *timestamppb.Timestamp {
 		return x.UpdatedAt
 	}
 	return nil
+}
+
+func (x *Sandbox) GetLastExecutionId() string {
+	if x != nil {
+		return x.LastExecutionId
+	}
+	return ""
+}
+
+func (x *Sandbox) GetActiveExecutionId() string {
+	if x != nil {
+		return x.ActiveExecutionId
+	}
+	return ""
 }
 
 type Snapshot struct {
@@ -1798,7 +1815,6 @@ type Execution struct {
 	StartedAt     *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=started_at,json=startedAt,proto3" json:"started_at,omitempty"`
 	FinishedAt    *timestamppb.Timestamp `protobuf:"bytes,7,opt,name=finished_at,json=finishedAt,proto3" json:"finished_at,omitempty"`
 	Tty           bool                   `protobuf:"varint,8,opt,name=tty,proto3" json:"tty,omitempty"`
-	RunId         string                 `protobuf:"bytes,9,opt,name=run_id,json=runId,proto3" json:"run_id,omitempty"`
 	Kind          ExecutionKind          `protobuf:"varint,10,opt,name=kind,proto3,enum=cleanroom.v1.ExecutionKind" json:"kind,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -1888,13 +1904,6 @@ func (x *Execution) GetTty() bool {
 		return x.Tty
 	}
 	return false
-}
-
-func (x *Execution) GetRunId() string {
-	if x != nil {
-		return x.RunId
-	}
-	return ""
 }
 
 func (x *Execution) GetKind() ExecutionKind {
@@ -2076,7 +2085,7 @@ func (x *CreateExecutionResponse) GetExecution() *Execution {
 	return nil
 }
 
-type OpenInteractiveExecutionRequest struct {
+type AttachExecutionRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	SandboxId     string                 `protobuf:"bytes,1,opt,name=sandbox_id,json=sandboxId,proto3" json:"sandbox_id,omitempty"`
 	ExecutionId   string                 `protobuf:"bytes,2,opt,name=execution_id,json=executionId,proto3" json:"execution_id,omitempty"`
@@ -2086,20 +2095,20 @@ type OpenInteractiveExecutionRequest struct {
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *OpenInteractiveExecutionRequest) Reset() {
-	*x = OpenInteractiveExecutionRequest{}
+func (x *AttachExecutionRequest) Reset() {
+	*x = AttachExecutionRequest{}
 	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *OpenInteractiveExecutionRequest) String() string {
+func (x *AttachExecutionRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*OpenInteractiveExecutionRequest) ProtoMessage() {}
+func (*AttachExecutionRequest) ProtoMessage() {}
 
-func (x *OpenInteractiveExecutionRequest) ProtoReflect() protoreflect.Message {
+func (x *AttachExecutionRequest) ProtoReflect() protoreflect.Message {
 	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -2111,40 +2120,40 @@ func (x *OpenInteractiveExecutionRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use OpenInteractiveExecutionRequest.ProtoReflect.Descriptor instead.
-func (*OpenInteractiveExecutionRequest) Descriptor() ([]byte, []int) {
+// Deprecated: Use AttachExecutionRequest.ProtoReflect.Descriptor instead.
+func (*AttachExecutionRequest) Descriptor() ([]byte, []int) {
 	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{32}
 }
 
-func (x *OpenInteractiveExecutionRequest) GetSandboxId() string {
+func (x *AttachExecutionRequest) GetSandboxId() string {
 	if x != nil {
 		return x.SandboxId
 	}
 	return ""
 }
 
-func (x *OpenInteractiveExecutionRequest) GetExecutionId() string {
+func (x *AttachExecutionRequest) GetExecutionId() string {
 	if x != nil {
 		return x.ExecutionId
 	}
 	return ""
 }
 
-func (x *OpenInteractiveExecutionRequest) GetInitialCols() uint32 {
+func (x *AttachExecutionRequest) GetInitialCols() uint32 {
 	if x != nil {
 		return x.InitialCols
 	}
 	return 0
 }
 
-func (x *OpenInteractiveExecutionRequest) GetInitialRows() uint32 {
+func (x *AttachExecutionRequest) GetInitialRows() uint32 {
 	if x != nil {
 		return x.InitialRows
 	}
 	return 0
 }
 
-type OpenInteractiveExecutionResponse struct {
+type AttachExecutionResponse struct {
 	state               protoimpl.MessageState `protogen:"open.v1"`
 	SessionId           string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
 	SessionToken        string                 `protobuf:"bytes,2,opt,name=session_token,json=sessionToken,proto3" json:"session_token,omitempty"`
@@ -2156,20 +2165,20 @@ type OpenInteractiveExecutionResponse struct {
 	sizeCache           protoimpl.SizeCache
 }
 
-func (x *OpenInteractiveExecutionResponse) Reset() {
-	*x = OpenInteractiveExecutionResponse{}
+func (x *AttachExecutionResponse) Reset() {
+	*x = AttachExecutionResponse{}
 	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *OpenInteractiveExecutionResponse) String() string {
+func (x *AttachExecutionResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*OpenInteractiveExecutionResponse) ProtoMessage() {}
+func (*AttachExecutionResponse) ProtoMessage() {}
 
-func (x *OpenInteractiveExecutionResponse) ProtoReflect() protoreflect.Message {
+func (x *AttachExecutionResponse) ProtoReflect() protoreflect.Message {
 	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -2181,47 +2190,47 @@ func (x *OpenInteractiveExecutionResponse) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use OpenInteractiveExecutionResponse.ProtoReflect.Descriptor instead.
-func (*OpenInteractiveExecutionResponse) Descriptor() ([]byte, []int) {
+// Deprecated: Use AttachExecutionResponse.ProtoReflect.Descriptor instead.
+func (*AttachExecutionResponse) Descriptor() ([]byte, []int) {
 	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{33}
 }
 
-func (x *OpenInteractiveExecutionResponse) GetSessionId() string {
+func (x *AttachExecutionResponse) GetSessionId() string {
 	if x != nil {
 		return x.SessionId
 	}
 	return ""
 }
 
-func (x *OpenInteractiveExecutionResponse) GetSessionToken() string {
+func (x *AttachExecutionResponse) GetSessionToken() string {
 	if x != nil {
 		return x.SessionToken
 	}
 	return ""
 }
 
-func (x *OpenInteractiveExecutionResponse) GetExpiresAt() *timestamppb.Timestamp {
+func (x *AttachExecutionResponse) GetExpiresAt() *timestamppb.Timestamp {
 	if x != nil {
 		return x.ExpiresAt
 	}
 	return nil
 }
 
-func (x *OpenInteractiveExecutionResponse) GetQuicEndpoint() string {
+func (x *AttachExecutionResponse) GetQuicEndpoint() string {
 	if x != nil {
 		return x.QuicEndpoint
 	}
 	return ""
 }
 
-func (x *OpenInteractiveExecutionResponse) GetAlpn() string {
+func (x *AttachExecutionResponse) GetAlpn() string {
 	if x != nil {
 		return x.Alpn
 	}
 	return ""
 }
 
-func (x *OpenInteractiveExecutionResponse) GetServerCertPinSha256() string {
+func (x *AttachExecutionResponse) GetServerCertPinSha256() string {
 	if x != nil {
 		return x.ServerCertPinSha256
 	}
@@ -2324,6 +2333,174 @@ func (x *GetExecutionResponse) GetExecution() *Execution {
 	return nil
 }
 
+type InspectExecutionRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SandboxId     string                 `protobuf:"bytes,1,opt,name=sandbox_id,json=sandboxId,proto3" json:"sandbox_id,omitempty"`
+	ExecutionId   string                 `protobuf:"bytes,2,opt,name=execution_id,json=executionId,proto3" json:"execution_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *InspectExecutionRequest) Reset() {
+	*x = InspectExecutionRequest{}
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[36]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *InspectExecutionRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InspectExecutionRequest) ProtoMessage() {}
+
+func (x *InspectExecutionRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[36]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InspectExecutionRequest.ProtoReflect.Descriptor instead.
+func (*InspectExecutionRequest) Descriptor() ([]byte, []int) {
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{36}
+}
+
+func (x *InspectExecutionRequest) GetSandboxId() string {
+	if x != nil {
+		return x.SandboxId
+	}
+	return ""
+}
+
+func (x *InspectExecutionRequest) GetExecutionId() string {
+	if x != nil {
+		return x.ExecutionId
+	}
+	return ""
+}
+
+type InspectExecutionResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Execution     *Execution             `protobuf:"bytes,1,opt,name=execution,proto3" json:"execution,omitempty"`
+	Message       string                 `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
+	Stdout        string                 `protobuf:"bytes,3,opt,name=stdout,proto3" json:"stdout,omitempty"`
+	Stderr        string                 `protobuf:"bytes,4,opt,name=stderr,proto3" json:"stderr,omitempty"`
+	ImageRef      string                 `protobuf:"bytes,5,opt,name=image_ref,json=imageRef,proto3" json:"image_ref,omitempty"`
+	ImageDigest   string                 `protobuf:"bytes,6,opt,name=image_digest,json=imageDigest,proto3" json:"image_digest,omitempty"`
+	ArtifactsDir  string                 `protobuf:"bytes,7,opt,name=artifacts_dir,json=artifactsDir,proto3" json:"artifacts_dir,omitempty"`
+	PlanPath      string                 `protobuf:"bytes,8,opt,name=plan_path,json=planPath,proto3" json:"plan_path,omitempty"`
+	LaunchedVm    bool                   `protobuf:"varint,9,opt,name=launched_vm,json=launchedVm,proto3" json:"launched_vm,omitempty"`
+	Observability *structpb.Struct       `protobuf:"bytes,10,opt,name=observability,proto3" json:"observability,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *InspectExecutionResponse) Reset() {
+	*x = InspectExecutionResponse{}
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[37]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *InspectExecutionResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InspectExecutionResponse) ProtoMessage() {}
+
+func (x *InspectExecutionResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[37]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InspectExecutionResponse.ProtoReflect.Descriptor instead.
+func (*InspectExecutionResponse) Descriptor() ([]byte, []int) {
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{37}
+}
+
+func (x *InspectExecutionResponse) GetExecution() *Execution {
+	if x != nil {
+		return x.Execution
+	}
+	return nil
+}
+
+func (x *InspectExecutionResponse) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+func (x *InspectExecutionResponse) GetStdout() string {
+	if x != nil {
+		return x.Stdout
+	}
+	return ""
+}
+
+func (x *InspectExecutionResponse) GetStderr() string {
+	if x != nil {
+		return x.Stderr
+	}
+	return ""
+}
+
+func (x *InspectExecutionResponse) GetImageRef() string {
+	if x != nil {
+		return x.ImageRef
+	}
+	return ""
+}
+
+func (x *InspectExecutionResponse) GetImageDigest() string {
+	if x != nil {
+		return x.ImageDigest
+	}
+	return ""
+}
+
+func (x *InspectExecutionResponse) GetArtifactsDir() string {
+	if x != nil {
+		return x.ArtifactsDir
+	}
+	return ""
+}
+
+func (x *InspectExecutionResponse) GetPlanPath() string {
+	if x != nil {
+		return x.PlanPath
+	}
+	return ""
+}
+
+func (x *InspectExecutionResponse) GetLaunchedVm() bool {
+	if x != nil {
+		return x.LaunchedVm
+	}
+	return false
+}
+
+func (x *InspectExecutionResponse) GetObservability() *structpb.Struct {
+	if x != nil {
+		return x.Observability
+	}
+	return nil
+}
+
 type CancelExecutionRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	SandboxId     string                 `protobuf:"bytes,1,opt,name=sandbox_id,json=sandboxId,proto3" json:"sandbox_id,omitempty"`
@@ -2335,7 +2512,7 @@ type CancelExecutionRequest struct {
 
 func (x *CancelExecutionRequest) Reset() {
 	*x = CancelExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[36]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2347,7 +2524,7 @@ func (x *CancelExecutionRequest) String() string {
 func (*CancelExecutionRequest) ProtoMessage() {}
 
 func (x *CancelExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[36]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2360,7 +2537,7 @@ func (x *CancelExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelExecutionRequest.ProtoReflect.Descriptor instead.
 func (*CancelExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{36}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *CancelExecutionRequest) GetSandboxId() string {
@@ -2396,7 +2573,7 @@ type CancelExecutionResponse struct {
 
 func (x *CancelExecutionResponse) Reset() {
 	*x = CancelExecutionResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[37]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2408,7 +2585,7 @@ func (x *CancelExecutionResponse) String() string {
 func (*CancelExecutionResponse) ProtoMessage() {}
 
 func (x *CancelExecutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[37]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2421,7 +2598,7 @@ func (x *CancelExecutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelExecutionResponse.ProtoReflect.Descriptor instead.
 func (*CancelExecutionResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{37}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *CancelExecutionResponse) GetSandboxId() string {
@@ -2463,7 +2640,7 @@ type WriteExecutionStdinRequest struct {
 
 func (x *WriteExecutionStdinRequest) Reset() {
 	*x = WriteExecutionStdinRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[38]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2475,7 +2652,7 @@ func (x *WriteExecutionStdinRequest) String() string {
 func (*WriteExecutionStdinRequest) ProtoMessage() {}
 
 func (x *WriteExecutionStdinRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[38]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2488,7 +2665,7 @@ func (x *WriteExecutionStdinRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WriteExecutionStdinRequest.ProtoReflect.Descriptor instead.
 func (*WriteExecutionStdinRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{38}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *WriteExecutionStdinRequest) GetSandboxId() string {
@@ -2520,7 +2697,7 @@ type WriteExecutionStdinResponse struct {
 
 func (x *WriteExecutionStdinResponse) Reset() {
 	*x = WriteExecutionStdinResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[39]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2532,7 +2709,7 @@ func (x *WriteExecutionStdinResponse) String() string {
 func (*WriteExecutionStdinResponse) ProtoMessage() {}
 
 func (x *WriteExecutionStdinResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[39]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2545,7 +2722,7 @@ func (x *WriteExecutionStdinResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WriteExecutionStdinResponse.ProtoReflect.Descriptor instead.
 func (*WriteExecutionStdinResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{39}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{41}
 }
 
 type CloseExecutionStdinRequest struct {
@@ -2558,7 +2735,7 @@ type CloseExecutionStdinRequest struct {
 
 func (x *CloseExecutionStdinRequest) Reset() {
 	*x = CloseExecutionStdinRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[40]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2570,7 +2747,7 @@ func (x *CloseExecutionStdinRequest) String() string {
 func (*CloseExecutionStdinRequest) ProtoMessage() {}
 
 func (x *CloseExecutionStdinRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[40]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2583,7 +2760,7 @@ func (x *CloseExecutionStdinRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CloseExecutionStdinRequest.ProtoReflect.Descriptor instead.
 func (*CloseExecutionStdinRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{40}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *CloseExecutionStdinRequest) GetSandboxId() string {
@@ -2608,7 +2785,7 @@ type CloseExecutionStdinResponse struct {
 
 func (x *CloseExecutionStdinResponse) Reset() {
 	*x = CloseExecutionStdinResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[41]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2620,7 +2797,7 @@ func (x *CloseExecutionStdinResponse) String() string {
 func (*CloseExecutionStdinResponse) ProtoMessage() {}
 
 func (x *CloseExecutionStdinResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[41]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2633,7 +2810,7 @@ func (x *CloseExecutionStdinResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CloseExecutionStdinResponse.ProtoReflect.Descriptor instead.
 func (*CloseExecutionStdinResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{41}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{43}
 }
 
 type StreamExecutionRequest struct {
@@ -2647,7 +2824,7 @@ type StreamExecutionRequest struct {
 
 func (x *StreamExecutionRequest) Reset() {
 	*x = StreamExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[42]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2659,7 +2836,7 @@ func (x *StreamExecutionRequest) String() string {
 func (*StreamExecutionRequest) ProtoMessage() {}
 
 func (x *StreamExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[42]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2672,7 +2849,7 @@ func (x *StreamExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamExecutionRequest.ProtoReflect.Descriptor instead.
 func (*StreamExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{42}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *StreamExecutionRequest) GetSandboxId() string {
@@ -2707,7 +2884,7 @@ type ExecutionExit struct {
 
 func (x *ExecutionExit) Reset() {
 	*x = ExecutionExit{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[43]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2719,7 +2896,7 @@ func (x *ExecutionExit) String() string {
 func (*ExecutionExit) ProtoMessage() {}
 
 func (x *ExecutionExit) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[43]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2732,7 +2909,7 @@ func (x *ExecutionExit) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionExit.ProtoReflect.Descriptor instead.
 func (*ExecutionExit) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{43}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *ExecutionExit) GetExitCode() int32 {
@@ -2778,7 +2955,7 @@ type ExecutionStreamEvent struct {
 
 func (x *ExecutionStreamEvent) Reset() {
 	*x = ExecutionStreamEvent{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[44]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2790,7 +2967,7 @@ func (x *ExecutionStreamEvent) String() string {
 func (*ExecutionStreamEvent) ProtoMessage() {}
 
 func (x *ExecutionStreamEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[44]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2803,7 +2980,7 @@ func (x *ExecutionStreamEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionStreamEvent.ProtoReflect.Descriptor instead.
 func (*ExecutionStreamEvent) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{44}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *ExecutionStreamEvent) GetSandboxId() string {
@@ -2938,7 +3115,7 @@ var File_proto_cleanroom_v1_control_proto protoreflect.FileDescriptor
 
 const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\n" +
-	" proto/cleanroom/v1/control.proto\x12\fcleanroom.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\x8e\x02\n" +
+	" proto/cleanroom/v1/control.proto\x12\fcleanroom.v1\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xea\x02\n" +
 	"\aSandbox\x12\x1d\n" +
 	"\n" +
 	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\x123\n" +
@@ -2949,7 +3126,9 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\n" +
 	"created_at\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x129\n" +
 	"\n" +
-	"updated_at\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\tupdatedAt\"\xfc\x02\n" +
+	"updated_at\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\tupdatedAt\x12*\n" +
+	"\x11last_execution_id\x18\a \x01(\tR\x0flastExecutionId\x12.\n" +
+	"\x13active_execution_id\x18\b \x01(\tR\x11activeExecutionId\"\xfc\x02\n" +
 	"\bSnapshot\x12\x1f\n" +
 	"\vsnapshot_id\x18\x01 \x01(\tR\n" +
 	"snapshotId\x12*\n" +
@@ -3066,7 +3245,7 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\vsnapshot_id\x18\x01 \x01(\tR\n" +
 	"snapshotId\x12\x18\n" +
 	"\adeleted\x18\x02 \x01(\bR\adeleted\x12\x18\n" +
-	"\amessage\x18\x03 \x01(\tR\amessage\"\x8d\x03\n" +
+	"\amessage\x18\x03 \x01(\tR\amessage\"\x84\x03\n" +
 	"\tExecution\x12!\n" +
 	"\fexecution_id\x18\x01 \x01(\tR\vexecutionId\x12\x1d\n" +
 	"\n" +
@@ -3078,10 +3257,10 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"started_at\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\tstartedAt\x12;\n" +
 	"\vfinished_at\x18\a \x01(\v2\x1a.google.protobuf.TimestampR\n" +
 	"finishedAt\x12\x10\n" +
-	"\x03tty\x18\b \x01(\bR\x03tty\x12\x15\n" +
-	"\x06run_id\x18\t \x01(\tR\x05runId\x12/\n" +
+	"\x03tty\x18\b \x01(\bR\x03tty\x12/\n" +
 	"\x04kind\x18\n" +
-	" \x01(\x0e2\x1b.cleanroom.v1.ExecutionKindR\x04kind\"q\n" +
+	" \x01(\x0e2\x1b.cleanroom.v1.ExecutionKindR\x04kindJ\x04\b\t\x10\n" +
+	"R\x06run_id\"q\n" +
 	"\x10ExecutionOptions\x12%\n" +
 	"\x0elaunch_seconds\x18\x05 \x01(\x03R\rlaunchSeconds\x12\x10\n" +
 	"\x03tty\x18\x06 \x01(\bR\x03ttyJ\x04\b\x02\x10\x03J\x04\b\a\x10\bR\x13read_only_workspaceR\x03cwd\"\x8f\x02\n" +
@@ -3093,14 +3272,14 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\x04kind\x18\x04 \x01(\x0e2\x1b.cleanroom.v1.ExecutionKindR\x04kind\x12Q\n" +
 	"\x13repository_checkout\x18\x05 \x01(\v2 .cleanroom.v1.RepositoryCheckoutR\x12repositoryCheckout\"P\n" +
 	"\x17CreateExecutionResponse\x125\n" +
-	"\texecution\x18\x01 \x01(\v2\x17.cleanroom.v1.ExecutionR\texecution\"\xa9\x01\n" +
-	"\x1fOpenInteractiveExecutionRequest\x12\x1d\n" +
+	"\texecution\x18\x01 \x01(\v2\x17.cleanroom.v1.ExecutionR\texecution\"\xa0\x01\n" +
+	"\x16AttachExecutionRequest\x12\x1d\n" +
 	"\n" +
 	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\x12!\n" +
 	"\fexecution_id\x18\x02 \x01(\tR\vexecutionId\x12!\n" +
 	"\finitial_cols\x18\x03 \x01(\rR\vinitialCols\x12!\n" +
-	"\finitial_rows\x18\x04 \x01(\rR\vinitialRows\"\x8f\x02\n" +
-	" OpenInteractiveExecutionResponse\x12\x1d\n" +
+	"\finitial_rows\x18\x04 \x01(\rR\vinitialRows\"\x86\x02\n" +
+	"\x17AttachExecutionResponse\x12\x1d\n" +
 	"\n" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\x12#\n" +
 	"\rsession_token\x18\x02 \x01(\tR\fsessionToken\x129\n" +
@@ -3114,7 +3293,24 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\x12!\n" +
 	"\fexecution_id\x18\x02 \x01(\tR\vexecutionId\"M\n" +
 	"\x14GetExecutionResponse\x125\n" +
-	"\texecution\x18\x01 \x01(\v2\x17.cleanroom.v1.ExecutionR\texecution\"r\n" +
+	"\texecution\x18\x01 \x01(\v2\x17.cleanroom.v1.ExecutionR\texecution\"[\n" +
+	"\x17InspectExecutionRequest\x12\x1d\n" +
+	"\n" +
+	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\x12!\n" +
+	"\fexecution_id\x18\x02 \x01(\tR\vexecutionId\"\xfd\x02\n" +
+	"\x18InspectExecutionResponse\x125\n" +
+	"\texecution\x18\x01 \x01(\v2\x17.cleanroom.v1.ExecutionR\texecution\x12\x18\n" +
+	"\amessage\x18\x02 \x01(\tR\amessage\x12\x16\n" +
+	"\x06stdout\x18\x03 \x01(\tR\x06stdout\x12\x16\n" +
+	"\x06stderr\x18\x04 \x01(\tR\x06stderr\x12\x1b\n" +
+	"\timage_ref\x18\x05 \x01(\tR\bimageRef\x12!\n" +
+	"\fimage_digest\x18\x06 \x01(\tR\vimageDigest\x12#\n" +
+	"\rartifacts_dir\x18\a \x01(\tR\fartifactsDir\x12\x1b\n" +
+	"\tplan_path\x18\b \x01(\tR\bplanPath\x12\x1f\n" +
+	"\vlaunched_vm\x18\t \x01(\bR\n" +
+	"launchedVm\x12=\n" +
+	"\robservability\x18\n" +
+	" \x01(\v2\x17.google.protobuf.StructR\robservability\"r\n" +
 	"\x16CancelExecutionRequest\x12\x1d\n" +
 	"\n" +
 	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\x12!\n" +
@@ -3193,11 +3389,12 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\x0eCreateSnapshot\x12#.cleanroom.v1.CreateSnapshotRequest\x1a$.cleanroom.v1.CreateSnapshotResponse\x12R\n" +
 	"\vGetSnapshot\x12 .cleanroom.v1.GetSnapshotRequest\x1a!.cleanroom.v1.GetSnapshotResponse\x12X\n" +
 	"\rListSnapshots\x12\".cleanroom.v1.ListSnapshotsRequest\x1a#.cleanroom.v1.ListSnapshotsResponse\x12[\n" +
-	"\x0eDeleteSnapshot\x12#.cleanroom.v1.DeleteSnapshotRequest\x1a$.cleanroom.v1.DeleteSnapshotResponse2\xdb\x05\n" +
+	"\x0eDeleteSnapshot\x12#.cleanroom.v1.DeleteSnapshotRequest\x1a$.cleanroom.v1.DeleteSnapshotResponse2\xa3\x06\n" +
 	"\x10ExecutionService\x12^\n" +
-	"\x0fCreateExecution\x12$.cleanroom.v1.CreateExecutionRequest\x1a%.cleanroom.v1.CreateExecutionResponse\x12y\n" +
-	"\x18OpenInteractiveExecution\x12-.cleanroom.v1.OpenInteractiveExecutionRequest\x1a..cleanroom.v1.OpenInteractiveExecutionResponse\x12U\n" +
-	"\fGetExecution\x12!.cleanroom.v1.GetExecutionRequest\x1a\".cleanroom.v1.GetExecutionResponse\x12^\n" +
+	"\x0fCreateExecution\x12$.cleanroom.v1.CreateExecutionRequest\x1a%.cleanroom.v1.CreateExecutionResponse\x12^\n" +
+	"\x0fAttachExecution\x12$.cleanroom.v1.AttachExecutionRequest\x1a%.cleanroom.v1.AttachExecutionResponse\x12U\n" +
+	"\fGetExecution\x12!.cleanroom.v1.GetExecutionRequest\x1a\".cleanroom.v1.GetExecutionResponse\x12a\n" +
+	"\x10InspectExecution\x12%.cleanroom.v1.InspectExecutionRequest\x1a&.cleanroom.v1.InspectExecutionResponse\x12^\n" +
 	"\x0fCancelExecution\x12$.cleanroom.v1.CancelExecutionRequest\x1a%.cleanroom.v1.CancelExecutionResponse\x12j\n" +
 	"\x13WriteExecutionStdin\x12(.cleanroom.v1.WriteExecutionStdinRequest\x1a).cleanroom.v1.WriteExecutionStdinResponse\x12j\n" +
 	"\x13CloseExecutionStdin\x12(.cleanroom.v1.CloseExecutionStdinRequest\x1a).cleanroom.v1.CloseExecutionStdinResponse\x12]\n" +
@@ -3216,63 +3413,66 @@ func file_proto_cleanroom_v1_control_proto_rawDescGZIP() []byte {
 }
 
 var file_proto_cleanroom_v1_control_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_proto_cleanroom_v1_control_proto_msgTypes = make([]protoimpl.MessageInfo, 45)
+var file_proto_cleanroom_v1_control_proto_msgTypes = make([]protoimpl.MessageInfo, 47)
 var file_proto_cleanroom_v1_control_proto_goTypes = []any{
-	(SandboxStatus)(0),                       // 0: cleanroom.v1.SandboxStatus
-	(ExecutionStatus)(0),                     // 1: cleanroom.v1.ExecutionStatus
-	(ExecutionKind)(0),                       // 2: cleanroom.v1.ExecutionKind
-	(*Sandbox)(nil),                          // 3: cleanroom.v1.Sandbox
-	(*Snapshot)(nil),                         // 4: cleanroom.v1.Snapshot
-	(*PolicyAllowRule)(nil),                  // 5: cleanroom.v1.PolicyAllowRule
-	(*PolicyDockerService)(nil),              // 6: cleanroom.v1.PolicyDockerService
-	(*PolicyServices)(nil),                   // 7: cleanroom.v1.PolicyServices
-	(*Policy)(nil),                           // 8: cleanroom.v1.Policy
-	(*SandboxOptions)(nil),                   // 9: cleanroom.v1.SandboxOptions
-	(*RepositoryCheckout)(nil),               // 10: cleanroom.v1.RepositoryCheckout
-	(*CreateSandboxRequest)(nil),             // 11: cleanroom.v1.CreateSandboxRequest
-	(*CreateSandboxResponse)(nil),            // 12: cleanroom.v1.CreateSandboxResponse
-	(*GetSandboxRequest)(nil),                // 13: cleanroom.v1.GetSandboxRequest
-	(*GetSandboxResponse)(nil),               // 14: cleanroom.v1.GetSandboxResponse
-	(*ListSandboxesRequest)(nil),             // 15: cleanroom.v1.ListSandboxesRequest
-	(*ListSandboxesResponse)(nil),            // 16: cleanroom.v1.ListSandboxesResponse
-	(*DownloadSandboxFileRequest)(nil),       // 17: cleanroom.v1.DownloadSandboxFileRequest
-	(*DownloadSandboxFileResponse)(nil),      // 18: cleanroom.v1.DownloadSandboxFileResponse
-	(*TerminateSandboxRequest)(nil),          // 19: cleanroom.v1.TerminateSandboxRequest
-	(*TerminateSandboxResponse)(nil),         // 20: cleanroom.v1.TerminateSandboxResponse
-	(*StreamSandboxEventsRequest)(nil),       // 21: cleanroom.v1.StreamSandboxEventsRequest
-	(*SandboxEvent)(nil),                     // 22: cleanroom.v1.SandboxEvent
-	(*CreateSnapshotRequest)(nil),            // 23: cleanroom.v1.CreateSnapshotRequest
-	(*CreateSnapshotResponse)(nil),           // 24: cleanroom.v1.CreateSnapshotResponse
-	(*GetSnapshotRequest)(nil),               // 25: cleanroom.v1.GetSnapshotRequest
-	(*GetSnapshotResponse)(nil),              // 26: cleanroom.v1.GetSnapshotResponse
-	(*ListSnapshotsRequest)(nil),             // 27: cleanroom.v1.ListSnapshotsRequest
-	(*ListSnapshotsResponse)(nil),            // 28: cleanroom.v1.ListSnapshotsResponse
-	(*DeleteSnapshotRequest)(nil),            // 29: cleanroom.v1.DeleteSnapshotRequest
-	(*DeleteSnapshotResponse)(nil),           // 30: cleanroom.v1.DeleteSnapshotResponse
-	(*Execution)(nil),                        // 31: cleanroom.v1.Execution
-	(*ExecutionOptions)(nil),                 // 32: cleanroom.v1.ExecutionOptions
-	(*CreateExecutionRequest)(nil),           // 33: cleanroom.v1.CreateExecutionRequest
-	(*CreateExecutionResponse)(nil),          // 34: cleanroom.v1.CreateExecutionResponse
-	(*OpenInteractiveExecutionRequest)(nil),  // 35: cleanroom.v1.OpenInteractiveExecutionRequest
-	(*OpenInteractiveExecutionResponse)(nil), // 36: cleanroom.v1.OpenInteractiveExecutionResponse
-	(*GetExecutionRequest)(nil),              // 37: cleanroom.v1.GetExecutionRequest
-	(*GetExecutionResponse)(nil),             // 38: cleanroom.v1.GetExecutionResponse
-	(*CancelExecutionRequest)(nil),           // 39: cleanroom.v1.CancelExecutionRequest
-	(*CancelExecutionResponse)(nil),          // 40: cleanroom.v1.CancelExecutionResponse
-	(*WriteExecutionStdinRequest)(nil),       // 41: cleanroom.v1.WriteExecutionStdinRequest
-	(*WriteExecutionStdinResponse)(nil),      // 42: cleanroom.v1.WriteExecutionStdinResponse
-	(*CloseExecutionStdinRequest)(nil),       // 43: cleanroom.v1.CloseExecutionStdinRequest
-	(*CloseExecutionStdinResponse)(nil),      // 44: cleanroom.v1.CloseExecutionStdinResponse
-	(*StreamExecutionRequest)(nil),           // 45: cleanroom.v1.StreamExecutionRequest
-	(*ExecutionExit)(nil),                    // 46: cleanroom.v1.ExecutionExit
-	(*ExecutionStreamEvent)(nil),             // 47: cleanroom.v1.ExecutionStreamEvent
-	(*timestamppb.Timestamp)(nil),            // 48: google.protobuf.Timestamp
+	(SandboxStatus)(0),                  // 0: cleanroom.v1.SandboxStatus
+	(ExecutionStatus)(0),                // 1: cleanroom.v1.ExecutionStatus
+	(ExecutionKind)(0),                  // 2: cleanroom.v1.ExecutionKind
+	(*Sandbox)(nil),                     // 3: cleanroom.v1.Sandbox
+	(*Snapshot)(nil),                    // 4: cleanroom.v1.Snapshot
+	(*PolicyAllowRule)(nil),             // 5: cleanroom.v1.PolicyAllowRule
+	(*PolicyDockerService)(nil),         // 6: cleanroom.v1.PolicyDockerService
+	(*PolicyServices)(nil),              // 7: cleanroom.v1.PolicyServices
+	(*Policy)(nil),                      // 8: cleanroom.v1.Policy
+	(*SandboxOptions)(nil),              // 9: cleanroom.v1.SandboxOptions
+	(*RepositoryCheckout)(nil),          // 10: cleanroom.v1.RepositoryCheckout
+	(*CreateSandboxRequest)(nil),        // 11: cleanroom.v1.CreateSandboxRequest
+	(*CreateSandboxResponse)(nil),       // 12: cleanroom.v1.CreateSandboxResponse
+	(*GetSandboxRequest)(nil),           // 13: cleanroom.v1.GetSandboxRequest
+	(*GetSandboxResponse)(nil),          // 14: cleanroom.v1.GetSandboxResponse
+	(*ListSandboxesRequest)(nil),        // 15: cleanroom.v1.ListSandboxesRequest
+	(*ListSandboxesResponse)(nil),       // 16: cleanroom.v1.ListSandboxesResponse
+	(*DownloadSandboxFileRequest)(nil),  // 17: cleanroom.v1.DownloadSandboxFileRequest
+	(*DownloadSandboxFileResponse)(nil), // 18: cleanroom.v1.DownloadSandboxFileResponse
+	(*TerminateSandboxRequest)(nil),     // 19: cleanroom.v1.TerminateSandboxRequest
+	(*TerminateSandboxResponse)(nil),    // 20: cleanroom.v1.TerminateSandboxResponse
+	(*StreamSandboxEventsRequest)(nil),  // 21: cleanroom.v1.StreamSandboxEventsRequest
+	(*SandboxEvent)(nil),                // 22: cleanroom.v1.SandboxEvent
+	(*CreateSnapshotRequest)(nil),       // 23: cleanroom.v1.CreateSnapshotRequest
+	(*CreateSnapshotResponse)(nil),      // 24: cleanroom.v1.CreateSnapshotResponse
+	(*GetSnapshotRequest)(nil),          // 25: cleanroom.v1.GetSnapshotRequest
+	(*GetSnapshotResponse)(nil),         // 26: cleanroom.v1.GetSnapshotResponse
+	(*ListSnapshotsRequest)(nil),        // 27: cleanroom.v1.ListSnapshotsRequest
+	(*ListSnapshotsResponse)(nil),       // 28: cleanroom.v1.ListSnapshotsResponse
+	(*DeleteSnapshotRequest)(nil),       // 29: cleanroom.v1.DeleteSnapshotRequest
+	(*DeleteSnapshotResponse)(nil),      // 30: cleanroom.v1.DeleteSnapshotResponse
+	(*Execution)(nil),                   // 31: cleanroom.v1.Execution
+	(*ExecutionOptions)(nil),            // 32: cleanroom.v1.ExecutionOptions
+	(*CreateExecutionRequest)(nil),      // 33: cleanroom.v1.CreateExecutionRequest
+	(*CreateExecutionResponse)(nil),     // 34: cleanroom.v1.CreateExecutionResponse
+	(*AttachExecutionRequest)(nil),      // 35: cleanroom.v1.AttachExecutionRequest
+	(*AttachExecutionResponse)(nil),     // 36: cleanroom.v1.AttachExecutionResponse
+	(*GetExecutionRequest)(nil),         // 37: cleanroom.v1.GetExecutionRequest
+	(*GetExecutionResponse)(nil),        // 38: cleanroom.v1.GetExecutionResponse
+	(*InspectExecutionRequest)(nil),     // 39: cleanroom.v1.InspectExecutionRequest
+	(*InspectExecutionResponse)(nil),    // 40: cleanroom.v1.InspectExecutionResponse
+	(*CancelExecutionRequest)(nil),      // 41: cleanroom.v1.CancelExecutionRequest
+	(*CancelExecutionResponse)(nil),     // 42: cleanroom.v1.CancelExecutionResponse
+	(*WriteExecutionStdinRequest)(nil),  // 43: cleanroom.v1.WriteExecutionStdinRequest
+	(*WriteExecutionStdinResponse)(nil), // 44: cleanroom.v1.WriteExecutionStdinResponse
+	(*CloseExecutionStdinRequest)(nil),  // 45: cleanroom.v1.CloseExecutionStdinRequest
+	(*CloseExecutionStdinResponse)(nil), // 46: cleanroom.v1.CloseExecutionStdinResponse
+	(*StreamExecutionRequest)(nil),      // 47: cleanroom.v1.StreamExecutionRequest
+	(*ExecutionExit)(nil),               // 48: cleanroom.v1.ExecutionExit
+	(*ExecutionStreamEvent)(nil),        // 49: cleanroom.v1.ExecutionStreamEvent
+	(*timestamppb.Timestamp)(nil),       // 50: google.protobuf.Timestamp
+	(*structpb.Struct)(nil),             // 51: google.protobuf.Struct
 }
 var file_proto_cleanroom_v1_control_proto_depIdxs = []int32{
 	0,  // 0: cleanroom.v1.Sandbox.status:type_name -> cleanroom.v1.SandboxStatus
-	48, // 1: cleanroom.v1.Sandbox.created_at:type_name -> google.protobuf.Timestamp
-	48, // 2: cleanroom.v1.Sandbox.updated_at:type_name -> google.protobuf.Timestamp
-	48, // 3: cleanroom.v1.Snapshot.created_at:type_name -> google.protobuf.Timestamp
+	50, // 1: cleanroom.v1.Sandbox.created_at:type_name -> google.protobuf.Timestamp
+	50, // 2: cleanroom.v1.Sandbox.updated_at:type_name -> google.protobuf.Timestamp
+	50, // 3: cleanroom.v1.Snapshot.created_at:type_name -> google.protobuf.Timestamp
 	10, // 4: cleanroom.v1.Snapshot.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
 	6,  // 5: cleanroom.v1.PolicyServices.docker:type_name -> cleanroom.v1.PolicyDockerService
 	5,  // 6: cleanroom.v1.Policy.allow:type_name -> cleanroom.v1.PolicyAllowRule
@@ -3284,64 +3484,68 @@ var file_proto_cleanroom_v1_control_proto_depIdxs = []int32{
 	3,  // 12: cleanroom.v1.GetSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
 	3,  // 13: cleanroom.v1.ListSandboxesResponse.sandboxes:type_name -> cleanroom.v1.Sandbox
 	0,  // 14: cleanroom.v1.SandboxEvent.status:type_name -> cleanroom.v1.SandboxStatus
-	48, // 15: cleanroom.v1.SandboxEvent.occurred_at:type_name -> google.protobuf.Timestamp
+	50, // 15: cleanroom.v1.SandboxEvent.occurred_at:type_name -> google.protobuf.Timestamp
 	4,  // 16: cleanroom.v1.CreateSnapshotResponse.snapshot:type_name -> cleanroom.v1.Snapshot
 	4,  // 17: cleanroom.v1.GetSnapshotResponse.snapshot:type_name -> cleanroom.v1.Snapshot
 	4,  // 18: cleanroom.v1.ListSnapshotsResponse.snapshots:type_name -> cleanroom.v1.Snapshot
 	1,  // 19: cleanroom.v1.Execution.status:type_name -> cleanroom.v1.ExecutionStatus
-	48, // 20: cleanroom.v1.Execution.started_at:type_name -> google.protobuf.Timestamp
-	48, // 21: cleanroom.v1.Execution.finished_at:type_name -> google.protobuf.Timestamp
+	50, // 20: cleanroom.v1.Execution.started_at:type_name -> google.protobuf.Timestamp
+	50, // 21: cleanroom.v1.Execution.finished_at:type_name -> google.protobuf.Timestamp
 	2,  // 22: cleanroom.v1.Execution.kind:type_name -> cleanroom.v1.ExecutionKind
 	32, // 23: cleanroom.v1.CreateExecutionRequest.options:type_name -> cleanroom.v1.ExecutionOptions
 	2,  // 24: cleanroom.v1.CreateExecutionRequest.kind:type_name -> cleanroom.v1.ExecutionKind
 	10, // 25: cleanroom.v1.CreateExecutionRequest.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
 	31, // 26: cleanroom.v1.CreateExecutionResponse.execution:type_name -> cleanroom.v1.Execution
-	48, // 27: cleanroom.v1.OpenInteractiveExecutionResponse.expires_at:type_name -> google.protobuf.Timestamp
+	50, // 27: cleanroom.v1.AttachExecutionResponse.expires_at:type_name -> google.protobuf.Timestamp
 	31, // 28: cleanroom.v1.GetExecutionResponse.execution:type_name -> cleanroom.v1.Execution
-	1,  // 29: cleanroom.v1.CancelExecutionResponse.status:type_name -> cleanroom.v1.ExecutionStatus
-	1,  // 30: cleanroom.v1.ExecutionExit.status:type_name -> cleanroom.v1.ExecutionStatus
-	1,  // 31: cleanroom.v1.ExecutionStreamEvent.status:type_name -> cleanroom.v1.ExecutionStatus
-	46, // 32: cleanroom.v1.ExecutionStreamEvent.exit:type_name -> cleanroom.v1.ExecutionExit
-	48, // 33: cleanroom.v1.ExecutionStreamEvent.occurred_at:type_name -> google.protobuf.Timestamp
-	11, // 34: cleanroom.v1.SandboxService.CreateSandbox:input_type -> cleanroom.v1.CreateSandboxRequest
-	13, // 35: cleanroom.v1.SandboxService.GetSandbox:input_type -> cleanroom.v1.GetSandboxRequest
-	15, // 36: cleanroom.v1.SandboxService.ListSandboxes:input_type -> cleanroom.v1.ListSandboxesRequest
-	17, // 37: cleanroom.v1.SandboxService.DownloadSandboxFile:input_type -> cleanroom.v1.DownloadSandboxFileRequest
-	19, // 38: cleanroom.v1.SandboxService.TerminateSandbox:input_type -> cleanroom.v1.TerminateSandboxRequest
-	21, // 39: cleanroom.v1.SandboxService.StreamSandboxEvents:input_type -> cleanroom.v1.StreamSandboxEventsRequest
-	23, // 40: cleanroom.v1.SnapshotService.CreateSnapshot:input_type -> cleanroom.v1.CreateSnapshotRequest
-	25, // 41: cleanroom.v1.SnapshotService.GetSnapshot:input_type -> cleanroom.v1.GetSnapshotRequest
-	27, // 42: cleanroom.v1.SnapshotService.ListSnapshots:input_type -> cleanroom.v1.ListSnapshotsRequest
-	29, // 43: cleanroom.v1.SnapshotService.DeleteSnapshot:input_type -> cleanroom.v1.DeleteSnapshotRequest
-	33, // 44: cleanroom.v1.ExecutionService.CreateExecution:input_type -> cleanroom.v1.CreateExecutionRequest
-	35, // 45: cleanroom.v1.ExecutionService.OpenInteractiveExecution:input_type -> cleanroom.v1.OpenInteractiveExecutionRequest
-	37, // 46: cleanroom.v1.ExecutionService.GetExecution:input_type -> cleanroom.v1.GetExecutionRequest
-	39, // 47: cleanroom.v1.ExecutionService.CancelExecution:input_type -> cleanroom.v1.CancelExecutionRequest
-	41, // 48: cleanroom.v1.ExecutionService.WriteExecutionStdin:input_type -> cleanroom.v1.WriteExecutionStdinRequest
-	43, // 49: cleanroom.v1.ExecutionService.CloseExecutionStdin:input_type -> cleanroom.v1.CloseExecutionStdinRequest
-	45, // 50: cleanroom.v1.ExecutionService.StreamExecution:input_type -> cleanroom.v1.StreamExecutionRequest
-	12, // 51: cleanroom.v1.SandboxService.CreateSandbox:output_type -> cleanroom.v1.CreateSandboxResponse
-	14, // 52: cleanroom.v1.SandboxService.GetSandbox:output_type -> cleanroom.v1.GetSandboxResponse
-	16, // 53: cleanroom.v1.SandboxService.ListSandboxes:output_type -> cleanroom.v1.ListSandboxesResponse
-	18, // 54: cleanroom.v1.SandboxService.DownloadSandboxFile:output_type -> cleanroom.v1.DownloadSandboxFileResponse
-	20, // 55: cleanroom.v1.SandboxService.TerminateSandbox:output_type -> cleanroom.v1.TerminateSandboxResponse
-	22, // 56: cleanroom.v1.SandboxService.StreamSandboxEvents:output_type -> cleanroom.v1.SandboxEvent
-	24, // 57: cleanroom.v1.SnapshotService.CreateSnapshot:output_type -> cleanroom.v1.CreateSnapshotResponse
-	26, // 58: cleanroom.v1.SnapshotService.GetSnapshot:output_type -> cleanroom.v1.GetSnapshotResponse
-	28, // 59: cleanroom.v1.SnapshotService.ListSnapshots:output_type -> cleanroom.v1.ListSnapshotsResponse
-	30, // 60: cleanroom.v1.SnapshotService.DeleteSnapshot:output_type -> cleanroom.v1.DeleteSnapshotResponse
-	34, // 61: cleanroom.v1.ExecutionService.CreateExecution:output_type -> cleanroom.v1.CreateExecutionResponse
-	36, // 62: cleanroom.v1.ExecutionService.OpenInteractiveExecution:output_type -> cleanroom.v1.OpenInteractiveExecutionResponse
-	38, // 63: cleanroom.v1.ExecutionService.GetExecution:output_type -> cleanroom.v1.GetExecutionResponse
-	40, // 64: cleanroom.v1.ExecutionService.CancelExecution:output_type -> cleanroom.v1.CancelExecutionResponse
-	42, // 65: cleanroom.v1.ExecutionService.WriteExecutionStdin:output_type -> cleanroom.v1.WriteExecutionStdinResponse
-	44, // 66: cleanroom.v1.ExecutionService.CloseExecutionStdin:output_type -> cleanroom.v1.CloseExecutionStdinResponse
-	47, // 67: cleanroom.v1.ExecutionService.StreamExecution:output_type -> cleanroom.v1.ExecutionStreamEvent
-	51, // [51:68] is the sub-list for method output_type
-	34, // [34:51] is the sub-list for method input_type
-	34, // [34:34] is the sub-list for extension type_name
-	34, // [34:34] is the sub-list for extension extendee
-	0,  // [0:34] is the sub-list for field type_name
+	31, // 29: cleanroom.v1.InspectExecutionResponse.execution:type_name -> cleanroom.v1.Execution
+	51, // 30: cleanroom.v1.InspectExecutionResponse.observability:type_name -> google.protobuf.Struct
+	1,  // 31: cleanroom.v1.CancelExecutionResponse.status:type_name -> cleanroom.v1.ExecutionStatus
+	1,  // 32: cleanroom.v1.ExecutionExit.status:type_name -> cleanroom.v1.ExecutionStatus
+	1,  // 33: cleanroom.v1.ExecutionStreamEvent.status:type_name -> cleanroom.v1.ExecutionStatus
+	48, // 34: cleanroom.v1.ExecutionStreamEvent.exit:type_name -> cleanroom.v1.ExecutionExit
+	50, // 35: cleanroom.v1.ExecutionStreamEvent.occurred_at:type_name -> google.protobuf.Timestamp
+	11, // 36: cleanroom.v1.SandboxService.CreateSandbox:input_type -> cleanroom.v1.CreateSandboxRequest
+	13, // 37: cleanroom.v1.SandboxService.GetSandbox:input_type -> cleanroom.v1.GetSandboxRequest
+	15, // 38: cleanroom.v1.SandboxService.ListSandboxes:input_type -> cleanroom.v1.ListSandboxesRequest
+	17, // 39: cleanroom.v1.SandboxService.DownloadSandboxFile:input_type -> cleanroom.v1.DownloadSandboxFileRequest
+	19, // 40: cleanroom.v1.SandboxService.TerminateSandbox:input_type -> cleanroom.v1.TerminateSandboxRequest
+	21, // 41: cleanroom.v1.SandboxService.StreamSandboxEvents:input_type -> cleanroom.v1.StreamSandboxEventsRequest
+	23, // 42: cleanroom.v1.SnapshotService.CreateSnapshot:input_type -> cleanroom.v1.CreateSnapshotRequest
+	25, // 43: cleanroom.v1.SnapshotService.GetSnapshot:input_type -> cleanroom.v1.GetSnapshotRequest
+	27, // 44: cleanroom.v1.SnapshotService.ListSnapshots:input_type -> cleanroom.v1.ListSnapshotsRequest
+	29, // 45: cleanroom.v1.SnapshotService.DeleteSnapshot:input_type -> cleanroom.v1.DeleteSnapshotRequest
+	33, // 46: cleanroom.v1.ExecutionService.CreateExecution:input_type -> cleanroom.v1.CreateExecutionRequest
+	35, // 47: cleanroom.v1.ExecutionService.AttachExecution:input_type -> cleanroom.v1.AttachExecutionRequest
+	37, // 48: cleanroom.v1.ExecutionService.GetExecution:input_type -> cleanroom.v1.GetExecutionRequest
+	39, // 49: cleanroom.v1.ExecutionService.InspectExecution:input_type -> cleanroom.v1.InspectExecutionRequest
+	41, // 50: cleanroom.v1.ExecutionService.CancelExecution:input_type -> cleanroom.v1.CancelExecutionRequest
+	43, // 51: cleanroom.v1.ExecutionService.WriteExecutionStdin:input_type -> cleanroom.v1.WriteExecutionStdinRequest
+	45, // 52: cleanroom.v1.ExecutionService.CloseExecutionStdin:input_type -> cleanroom.v1.CloseExecutionStdinRequest
+	47, // 53: cleanroom.v1.ExecutionService.StreamExecution:input_type -> cleanroom.v1.StreamExecutionRequest
+	12, // 54: cleanroom.v1.SandboxService.CreateSandbox:output_type -> cleanroom.v1.CreateSandboxResponse
+	14, // 55: cleanroom.v1.SandboxService.GetSandbox:output_type -> cleanroom.v1.GetSandboxResponse
+	16, // 56: cleanroom.v1.SandboxService.ListSandboxes:output_type -> cleanroom.v1.ListSandboxesResponse
+	18, // 57: cleanroom.v1.SandboxService.DownloadSandboxFile:output_type -> cleanroom.v1.DownloadSandboxFileResponse
+	20, // 58: cleanroom.v1.SandboxService.TerminateSandbox:output_type -> cleanroom.v1.TerminateSandboxResponse
+	22, // 59: cleanroom.v1.SandboxService.StreamSandboxEvents:output_type -> cleanroom.v1.SandboxEvent
+	24, // 60: cleanroom.v1.SnapshotService.CreateSnapshot:output_type -> cleanroom.v1.CreateSnapshotResponse
+	26, // 61: cleanroom.v1.SnapshotService.GetSnapshot:output_type -> cleanroom.v1.GetSnapshotResponse
+	28, // 62: cleanroom.v1.SnapshotService.ListSnapshots:output_type -> cleanroom.v1.ListSnapshotsResponse
+	30, // 63: cleanroom.v1.SnapshotService.DeleteSnapshot:output_type -> cleanroom.v1.DeleteSnapshotResponse
+	34, // 64: cleanroom.v1.ExecutionService.CreateExecution:output_type -> cleanroom.v1.CreateExecutionResponse
+	36, // 65: cleanroom.v1.ExecutionService.AttachExecution:output_type -> cleanroom.v1.AttachExecutionResponse
+	38, // 66: cleanroom.v1.ExecutionService.GetExecution:output_type -> cleanroom.v1.GetExecutionResponse
+	40, // 67: cleanroom.v1.ExecutionService.InspectExecution:output_type -> cleanroom.v1.InspectExecutionResponse
+	42, // 68: cleanroom.v1.ExecutionService.CancelExecution:output_type -> cleanroom.v1.CancelExecutionResponse
+	44, // 69: cleanroom.v1.ExecutionService.WriteExecutionStdin:output_type -> cleanroom.v1.WriteExecutionStdinResponse
+	46, // 70: cleanroom.v1.ExecutionService.CloseExecutionStdin:output_type -> cleanroom.v1.CloseExecutionStdinResponse
+	49, // 71: cleanroom.v1.ExecutionService.StreamExecution:output_type -> cleanroom.v1.ExecutionStreamEvent
+	54, // [54:72] is the sub-list for method output_type
+	36, // [36:54] is the sub-list for method input_type
+	36, // [36:36] is the sub-list for extension type_name
+	36, // [36:36] is the sub-list for extension extendee
+	0,  // [0:36] is the sub-list for field type_name
 }
 
 func init() { file_proto_cleanroom_v1_control_proto_init() }
@@ -3352,7 +3556,7 @@ func file_proto_cleanroom_v1_control_proto_init() {
 	file_proto_cleanroom_v1_control_proto_msgTypes[8].OneofWrappers = []any{
 		(*CreateSandboxRequest_SnapshotId)(nil),
 	}
-	file_proto_cleanroom_v1_control_proto_msgTypes[44].OneofWrappers = []any{
+	file_proto_cleanroom_v1_control_proto_msgTypes[46].OneofWrappers = []any{
 		(*ExecutionStreamEvent_Stdout)(nil),
 		(*ExecutionStreamEvent_Stderr)(nil),
 		(*ExecutionStreamEvent_Exit)(nil),
@@ -3365,7 +3569,7 @@ func file_proto_cleanroom_v1_control_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proto_cleanroom_v1_control_proto_rawDesc), len(file_proto_cleanroom_v1_control_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   45,
+			NumMessages:   47,
 			NumExtensions: 0,
 			NumServices:   3,
 		},

--- a/internal/paths/run_dir.go
+++ b/internal/paths/run_dir.go
@@ -4,15 +4,15 @@ import (
 	"path/filepath"
 )
 
-// RunBaseDir resolves the default base directory for run artifacts.
+// ExecutionBaseDir resolves the default base directory for execution artifacts.
 // Preference order:
-// 1. $XDG_STATE_HOME/cleanroom/runs
-// 2. ~/.local/state/cleanroom/runs
-// 3. $XDG_RUNTIME_DIR/cleanroom/runs
-func RunBaseDir() (string, error) {
+// 1. $XDG_STATE_HOME/cleanroom/executions
+// 2. ~/.local/state/cleanroom/executions
+// 3. $XDG_RUNTIME_DIR/cleanroom/executions
+func ExecutionBaseDir() (string, error) {
 	base, err := StateBaseDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(base, "runs"), nil
+	return filepath.Join(base, "executions"), nil
 }

--- a/proto/cleanroom/v1/control.proto
+++ b/proto/cleanroom/v1/control.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package cleanroom.v1;
 
+import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 
 option go_package = "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1;cleanroomv1";
@@ -24,8 +25,9 @@ service SnapshotService {
 
 service ExecutionService {
   rpc CreateExecution(CreateExecutionRequest) returns (CreateExecutionResponse);
-  rpc OpenInteractiveExecution(OpenInteractiveExecutionRequest) returns (OpenInteractiveExecutionResponse);
+  rpc AttachExecution(AttachExecutionRequest) returns (AttachExecutionResponse);
   rpc GetExecution(GetExecutionRequest) returns (GetExecutionResponse);
+  rpc InspectExecution(InspectExecutionRequest) returns (InspectExecutionResponse);
   rpc CancelExecution(CancelExecutionRequest) returns (CancelExecutionResponse);
   rpc WriteExecutionStdin(WriteExecutionStdinRequest) returns (WriteExecutionStdinResponse);
   rpc CloseExecutionStdin(CloseExecutionStdinRequest) returns (CloseExecutionStdinResponse);
@@ -39,6 +41,8 @@ message Sandbox {
   string policy_hash = 4;
   google.protobuf.Timestamp created_at = 5;
   google.protobuf.Timestamp updated_at = 6;
+  string last_execution_id = 7;
+  string active_execution_id = 8;
 }
 
 message Snapshot {
@@ -211,8 +215,9 @@ message Execution {
   google.protobuf.Timestamp started_at = 6;
   google.protobuf.Timestamp finished_at = 7;
   bool tty = 8;
-  string run_id = 9;
   ExecutionKind kind = 10;
+  reserved 9;
+  reserved "run_id";
 }
 
 enum ExecutionStatus {
@@ -250,14 +255,14 @@ message CreateExecutionResponse {
   Execution execution = 1;
 }
 
-message OpenInteractiveExecutionRequest {
+message AttachExecutionRequest {
   string sandbox_id = 1;
   string execution_id = 2;
   uint32 initial_cols = 3;
   uint32 initial_rows = 4;
 }
 
-message OpenInteractiveExecutionResponse {
+message AttachExecutionResponse {
   string session_id = 1;
   string session_token = 2;
   google.protobuf.Timestamp expires_at = 3;
@@ -273,6 +278,24 @@ message GetExecutionRequest {
 
 message GetExecutionResponse {
   Execution execution = 1;
+}
+
+message InspectExecutionRequest {
+  string sandbox_id = 1;
+  string execution_id = 2;
+}
+
+message InspectExecutionResponse {
+  Execution execution = 1;
+  string message = 2;
+  string stdout = 3;
+  string stderr = 4;
+  string image_ref = 5;
+  string image_digest = 6;
+  string artifacts_dir = 7;
+  string plan_path = 8;
+  bool launched_vm = 9;
+  google.protobuf.Struct observability = 10;
 }
 
 message CancelExecutionRequest {

--- a/scripts/ci-cleanroom-e2e.sh
+++ b/scripts/ci-cleanroom-e2e.sh
@@ -491,15 +491,15 @@ else
   echo "gateway server not started (no log entry found) — skipping reachability test"
 fi
 
-echo "--- :bar_chart: Run observability present"
-./dist/cleanroom status --last-run | tee "$tmpdir/status.out"
-if ! grep -q 'run-observability.json' "$tmpdir/status.out"; then
-  echo "expected run-observability.json reference in status output" >&2
+echo "--- :bar_chart: Execution observability present"
+./dist/cleanroom status --last | tee "$tmpdir/status.out"
+if ! grep -q 'execution-observability.json' "$tmpdir/status.out"; then
+  echo "expected execution-observability.json reference in status output" >&2
   exit 1
 fi
 
 obs_file="$(
-  find "$XDG_STATE_HOME"/cleanroom/runs -name run-observability.json -type f -print 2>/dev/null \
+  find "$XDG_STATE_HOME"/cleanroom/executions -name execution-observability.json -type f -print 2>/dev/null \
     | while IFS= read -r path; do
         stat -c '%Y %n' "$path"
       done \
@@ -519,7 +519,7 @@ if [[ -n "$obs_file" && -f "$obs_file" ]]; then
     sed -nE "s/.*\"${key}\"[[:space:]]*:[[:space:]]*\"([^\"]+)\".*/\1/p" "$file" | head -n 1
   }
 
-  run_id="$(extract_json_string run_id "$obs_file")"
+  execution_id="$(extract_json_string execution_id "$obs_file")"
   total_ms="$(extract_json_number total_ms "$obs_file")"
   policy_resolve_ms="$(extract_json_number policy_resolve_ms "$obs_file")"
   rootfs_copy_ms="$(extract_json_number rootfs_copy_ms "$obs_file")"
@@ -535,7 +535,7 @@ if [[ -n "$obs_file" && -f "$obs_file" ]]; then
     cat > "$annotation_file" <<EOF
 ### Firecracker E2E Observability
 
-- run id: ${run_id:-n/a}
+- execution id: ${execution_id:-n/a}
 
 | Metric | Value (ms) |
 | --- | ---: |


### PR DESCRIPTION
## Summary
- make `execution` the primary control-plane and observability noun across the API, client types, retained artifacts, and backend request/result models
- add a coherent debugging UX with `sandbox inspect`, `execution inspect`, execution-keyed local artifacts, and matching failure hints from both `exec` and `console`
- update docs, generated protobufs, tests, and CI/e2e scripts to reflect the new execution-centric design

## Testing
- `/opt/homebrew/bin/mise exec -- go test ./internal/cli ./internal/controlservice ./client ./internal/controlclient ./internal/controlserver ./internal/interactivequic`
- `/opt/homebrew/bin/mise exec -- go test ./...`