### PR TITLE
feat: make sandbox create repo-agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ commands become repo-aware: Cleanroom resolves the current git remote and local
 `HEAD`, materializes that checkout in the sandbox, and starts commands in the
 configured guest path.
 
-Pre-create a long-running sandbox without running a command:
+Pre-create a long-running sandbox using repo policy:
 
 ```bash
 SANDBOX_ID="$(cleanroom create)"
@@ -113,14 +113,20 @@ cleanroom exec --image ghcr.io/buildkite/cleanroom-base/alpine:latest -- npm tes
 cleanroom console --image my-local-image:dev -- sh
 ```
 
-Equivalent namespaced command:
+Pre-create a repo-agnostic sandbox without reading `cleanroom.yaml`:
 
 ```bash
 cleanroom sandbox create
 ```
 
 `cleanroom sandbox create` stays generic. It does not inspect the local git
-repository or infer a checkout from `cleanroom.yaml`.
+repository or read `cleanroom.yaml`. It creates a sandbox with a built-in
+deny-by-default policy and resolves
+`ghcr.io/buildkite/cleanroom-base/alpine:latest` to a digest unless `--image`
+is provided.
+
+To disable egress filtering for a repo-agnostic sandbox, pass
+`--dangerously-allow-all`.
 
 `cleanroom exec` and `cleanroom console` create ephemeral sandboxes by default.
 Reuse an existing sandbox with `--in`, or keep a newly created sandbox with
@@ -155,7 +161,10 @@ cleanroom console -- bash
 
 ## Policy file
 
-A `cleanroom.yaml` in your repo defines the sandbox policy. Cleanroom also checks `.buildkite/cleanroom.yaml` as a fallback.
+A `cleanroom.yaml` in your repo defines the sandbox policy for policy-aware
+commands such as `cleanroom create`, `cleanroom exec`, and `cleanroom console`.
+Cleanroom also checks `.buildkite/cleanroom.yaml` as a fallback.
+`cleanroom sandbox create` does not read either path.
 
 ```yaml
 version: 1
@@ -216,11 +225,11 @@ repository:
 
 With the default behavior:
 
-- `cleanroom create` creates a sandbox with the current repo checked out at local `HEAD`
+- `cleanroom create` reads repo policy and creates a sandbox with the current repo checked out at local `HEAD`
 - `cleanroom exec -- <cmd>` checks out the repo, runs `<cmd>` from `/workspace`, and tears the sandbox down unless `--keep` is set
 - `cleanroom console -- bash` opens a shell in `/workspace` and tears the sandbox down unless `--keep` is set
 - dirty working trees print a warning and use committed `HEAD`; uncommitted changes are not copied in
-- `cleanroom sandbox create` remains explicit and repo-agnostic
+- `cleanroom sandbox create` remains explicit and repo-agnostic, using a built-in policy instead of repo policy (deny-by-default unless `--dangerously-allow-all` is set)
 
 Repository bootstrap needs the remote host in `sandbox.network.allow`, for
 example:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Agent sandboxing tools are [proliferating fast](docs/research.md). Most focus on
 
 **Standard OCI images.** Use any OCI image from any registry as your sandbox base. Digest-pinned in policy for reproducibility. No custom VM image format or vendor-specific base images. Same image works across backends.
 
-**Docker inside the sandbox.** Enable a guest Docker daemon with a single policy flag (`services.docker.required: true`). Build and run containers inside the microVM.
+**Docker inside the sandbox.** Enable a guest Docker daemon with a policy flag (`services.docker.required: true`) or explicitly for a repo-agnostic sandbox with `cleanroom sandbox create --docker`. Build and run containers inside the microVM.
 
 **Coming soon:** package registry proxy with lockfile enforcement, Docker pull caching, content caching for hermetic offline builds, and structured audit logging. See the [spec](docs/spec.md) for the full roadmap.
 
@@ -125,6 +125,8 @@ deny-by-default policy and resolves
 `ghcr.io/buildkite/cleanroom-base/alpine:latest` to a digest unless `--image`
 is provided.
 
+To start the guest Docker service for a repo-agnostic sandbox, pass `--docker`.
+
 To disable egress filtering for a repo-agnostic sandbox, pass
 `--dangerously-allow-all`.
 
@@ -229,7 +231,7 @@ With the default behavior:
 - `cleanroom exec -- <cmd>` checks out the repo, runs `<cmd>` from `/workspace`, and tears the sandbox down unless `--keep` is set
 - `cleanroom console -- bash` opens a shell in `/workspace` and tears the sandbox down unless `--keep` is set
 - dirty working trees print a warning and use committed `HEAD`; uncommitted changes are not copied in
-- `cleanroom sandbox create` remains explicit and repo-agnostic, using a built-in policy instead of repo policy (deny-by-default unless `--dangerously-allow-all` is set)
+- `cleanroom sandbox create` remains explicit and repo-agnostic, using a built-in policy instead of repo policy (default image, deny-by-default networking unless `--dangerously-allow-all` is set, optional guest Docker via `--docker`)
 
 Repository bootstrap needs the remote host in `sandbox.network.allow`, for
 example:

--- a/docs/api.md
+++ b/docs/api.md
@@ -270,11 +270,19 @@ Expose a server mode and API-driven commands in the same binary.
 ### 9.2 Sandbox commands
 
 - `cleanroom sandbox create`
+- `cleanroom sandbox create --from <snapshot-id>`
 - `cleanroom sandbox inspect <sandbox-id>`
 - `cleanroom sandbox ls`
 - `cleanroom sandbox rm <sandbox-id>`
 
 `sandbox inspect` is the primary way to discover a sandbox's `last_execution_id` and `active_execution_id`.
+
+`cleanroom sandbox create` is repo-agnostic. Without `--from`, it does not
+inspect the local git repository or read `cleanroom.yaml`; it synthesizes a
+built-in policy from the selected image ref, uses deny-by-default networking by
+default, enables the guest Docker service with `--docker`, and disables egress
+filtering only when `--dangerously-allow-all` is set. `--image`, `--docker`,
+and `--dangerously-allow-all` cannot be combined with `--from`.
 
 ### 9.3 Execution commands
 
@@ -304,13 +312,13 @@ Additional command forms:
 
 Behavior contract:
 1. Resolve server endpoint (`--host`, `CLEANROOM_HOST`, context, default unix socket).
-2. Resolve and compile repository policy.
-3. If repo-aware bootstrap is enabled, resolve the current git remote and
-   committed `HEAD`.
-4. Select sandbox mode:
+2. Select sandbox mode:
    - `--in <id>` reuses an existing sandbox
    - `--from <snapshot-id>` creates a sandbox from a snapshot
    - otherwise create a sandbox from policy
+3. When creating a sandbox from policy, resolve and compile repository policy.
+4. If repo-aware bootstrap is enabled for that policy-created sandbox, resolve
+   the current git remote and committed `HEAD`.
 5. For repo-aware top-level commands, materialize that checkout in the sandbox
    and default the guest working directory to `repository.path`.
 6. Create execution with explicit kind and TTY options.
@@ -326,9 +334,11 @@ Behavior contract:
 
 Notes:
 - `cleanroom create`, `cleanroom exec`, and `cleanroom console` are the
-  repo-aware UX layer.
+  repo-aware UX layer by default.
+- `cleanroom create --from <snapshot-id>` follows the snapshot path and does
+  not read repository policy.
 - `cleanroom sandbox create` stays generic and does not inspect the local git
-  repository.
+  repository or read `cleanroom.yaml`.
 - Dirty working trees warn and use committed `HEAD`; uncommitted changes are
   not copied into the sandbox.
 

--- a/docs/backend/darwin-vz.md
+++ b/docs/backend/darwin-vz.md
@@ -109,10 +109,10 @@ On macOS, cleanroom also probes common Homebrew `e2fsprogs` locations.
 
 ## Networking Semantics
 
-`darwin-vz` currently enforces only deny-by-default policy shape:
+`darwin-vz` currently supports only two policy shapes:
 
-- `network.default` must be `deny`
-- `network.allow` entries are ignored and produce a warning
+- `network.default: deny` keeps the existing policy shape; `network.allow` entries are ignored and produce a warning
+- `network.default: allow` disables egress filtering entirely and produces a warning
 - a virtual NIC is attached with `Virtualization.framework` NAT networking, so guest outbound networking is available
 
 The backend currently has no allowlist egress enforcement equivalent to Linux Firecracker iptables rules.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -217,7 +217,14 @@ Meaning:
   - they materialize that checkout inside the sandbox before the command runs
   - they start commands in `repository.path`
 - `cleanroom sandbox create` remains the generic low-level surface and does not
-  infer repository state from the current working tree.
+  infer repository state from the current working tree or read `cleanroom.yaml`.
+- Without `--from`, `cleanroom sandbox create` synthesizes a repo-agnostic
+  policy using the selected image ref, deny-by-default networking by default,
+  optional guest Docker service enablement via `--docker`, and optional
+  unrestricted outbound networking via `--dangerously-allow-all`.
+- With `--from <snapshot-id>`, `cleanroom sandbox create` restores a sandbox
+  from the snapshot and does not accept create-time policy override flags such
+  as `--image`, `--docker`, or `--dangerously-allow-all`.
 
 ### 5.4.1 `cleanroom exec` behavior contract (normative)
 - `cleanroom exec` must:

--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -596,7 +596,7 @@ func (a *Adapter) Doctor(_ context.Context, req backend.DoctorRequest) (*backend
 		if policyErr != nil {
 			appendCheck("policy_network_default", "fail", policyErr.Error())
 		} else {
-			appendCheck("policy_network_default", "pass", "deny-by-default policy")
+			appendCheck("policy_network_default", "pass", fmt.Sprintf("network.default=%s", strings.TrimSpace(req.Policy.NetworkDefault)))
 			if policyWarn != "" {
 				appendCheck("policy_network_allow", "warn", policyWarn)
 			} else {

--- a/internal/backend/darwinvz/policy.go
+++ b/internal/backend/darwinvz/policy.go
@@ -7,13 +7,21 @@ import (
 
 const allowRulesIgnoredWarning = "darwin-vz ignores sandbox.network.allow entries; allowlist egress filtering is not implemented"
 const guestNetworkUnavailableWarning = "darwin-vz guest networking is enabled without host-side egress filtering"
+const allowAllPolicyWarning = "darwin-vz allows outbound networking for network.default=allow; host-side egress filtering is disabled"
 
 func evaluateNetworkPolicy(networkDefault string, allowCount int) (string, error) {
-	if strings.TrimSpace(networkDefault) != "deny" {
-		return "", fmt.Errorf("darwin-vz backend requires deny-by-default policy, got %q", networkDefault)
+	switch strings.TrimSpace(networkDefault) {
+	case "deny":
+		if allowCount > 0 {
+			return allowRulesIgnoredWarning, nil
+		}
+		return "", nil
+	case "allow":
+		if allowCount > 0 {
+			return allowAllPolicyWarning + "; sandbox.network.allow entries are ignored", nil
+		}
+		return allowAllPolicyWarning, nil
+	default:
+		return "", fmt.Errorf("darwin-vz backend requires network.default=deny or allow, got %q", networkDefault)
 	}
-	if allowCount > 0 {
-		return allowRulesIgnoredWarning, nil
-	}
-	return "", nil
 }

--- a/internal/backend/darwinvz/policy_test.go
+++ b/internal/backend/darwinvz/policy_test.go
@@ -5,16 +5,13 @@ import (
 	"testing"
 )
 
-func TestEvaluateNetworkPolicyRequiresDenyDefault(t *testing.T) {
+func TestEvaluateNetworkPolicyAllowsAllowDefaultWithWarning(t *testing.T) {
 	warn, err := evaluateNetworkPolicy("allow", 0)
-	if err == nil {
-		t.Fatal("expected error for non-deny network default")
+	if err != nil {
+		t.Fatalf("unexpected error for allow network default: %v", err)
 	}
-	if warn != "" {
-		t.Fatalf("expected empty warning when validation fails, got %q", warn)
-	}
-	if !strings.Contains(err.Error(), "deny-by-default") {
-		t.Fatalf("unexpected error: %v", err)
+	if !strings.Contains(warn, "network.default=allow") {
+		t.Fatalf("unexpected warning: %q", warn)
 	}
 }
 
@@ -35,5 +32,15 @@ func TestEvaluateNetworkPolicyAcceptsDenyWithNoAllowEntries(t *testing.T) {
 	}
 	if warn != "" {
 		t.Fatalf("expected no warning, got %q", warn)
+	}
+}
+
+func TestEvaluateNetworkPolicyRejectsUnsupportedDefault(t *testing.T) {
+	warn, err := evaluateNetworkPolicy("bogus", 0)
+	if err == nil {
+		t.Fatal("expected error for unsupported network default")
+	}
+	if warn != "" {
+		t.Fatalf("expected empty warning when validation fails, got %q", warn)
 	}
 }

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -2102,11 +2102,18 @@ func setupHostNetworkWithTapLookup(ctx context.Context, runID string, allowAll b
 	guestCIDR := guestIP + "/32"
 	const dnsServer = "1.1.1.1"
 
-	policyResolveStart := time.Now()
-	forwardRules, err := resolveForwardRulesWithLookup(ctx, allow, lookup)
-	policyResolveMS := durationMillisCeil(time.Since(policyResolveStart))
-	if err != nil {
-		return hostNetworkConfig{}, func() {}, err
+	var (
+		forwardRules    []iptablesForwardRule
+		policyResolveMS int64
+		err             error
+	)
+	if !allowAll {
+		policyResolveStart := time.Now()
+		forwardRules, err = resolveForwardRulesWithLookup(ctx, allow, lookup)
+		policyResolveMS = durationMillisCeil(time.Since(policyResolveStart))
+		if err != nil {
+			return hostNetworkConfig{}, func() {}, err
+		}
 	}
 
 	setupRun := func(args ...string) error {

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -849,8 +849,8 @@ func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream 
 	}
 	observation.ImageRef = req.Policy.ImageRef
 	observation.ImageDigest = req.Policy.ImageDigest
-	if req.Policy.NetworkDefault != "deny" {
-		return nil, fmt.Errorf("firecracker backend requires deny-by-default policy, got %q", req.Policy.NetworkDefault)
+	if req.Policy.NetworkDefault != "deny" && req.Policy.NetworkDefault != "allow" {
+		return nil, fmt.Errorf("firecracker backend requires network.default=deny or allow, got %q", req.Policy.NetworkDefault)
 	}
 	if len(req.Command) == 0 {
 		return nil, errors.New("missing command")
@@ -980,7 +980,7 @@ func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream 
 	networkRunBatch := func(ctx context.Context, commands [][]string) error {
 		return runRootCommandBatch(ctx, req.FirecrackerConfig, commands)
 	}
-	networkCfg, cleanupNetwork, err := setupHostNetwork(ctx, req.ExecutionID, req.Policy.Allow, 0, networkRunCommand, networkRunBatch)
+	networkCfg, cleanupNetwork, err := setupHostNetwork(ctx, req.ExecutionID, req.Policy.NetworkDefault == "allow", req.Policy.Allow, 0, networkRunCommand, networkRunBatch)
 	if err != nil {
 		return nil, fmt.Errorf("setup host network: %w", err)
 	}
@@ -1507,8 +1507,8 @@ func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID strin
 	if compiled == nil {
 		return nil, errors.New("missing compiled policy")
 	}
-	if compiled.NetworkDefault != "deny" {
-		return nil, fmt.Errorf("firecracker backend requires deny-by-default policy, got %q", compiled.NetworkDefault)
+	if compiled.NetworkDefault != "deny" && compiled.NetworkDefault != "allow" {
+		return nil, fmt.Errorf("firecracker backend requires network.default=deny or allow, got %q", compiled.NetworkDefault)
 	}
 	if runtime.GOOS != "linux" {
 		return nil, fmt.Errorf("firecracker backend is linux-only, current OS is %s", runtime.GOOS)
@@ -1584,7 +1584,7 @@ func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID strin
 			gwPort = gateway.DefaultPort
 		}
 	}
-	networkCfg, cleanupNetwork, err := setupHostNetwork(ctx, sandboxID, compiled.Allow, gwPort, networkRunCommand, networkRunBatch)
+	networkCfg, cleanupNetwork, err := setupHostNetwork(ctx, sandboxID, compiled.NetworkDefault == "allow", compiled.Allow, gwPort, networkRunCommand, networkRunBatch)
 	if err != nil {
 		cleanupVolume()
 		return nil, fmt.Errorf("setup host network: %w", err)
@@ -2084,18 +2084,18 @@ type interfaceLookupFunc func(name string) (*net.Interface, error)
 type rootCommandFunc func(ctx context.Context, args ...string) error
 type rootCommandBatchFunc func(ctx context.Context, commands [][]string) error
 
-func setupHostNetwork(ctx context.Context, runID string, allow []policy.AllowRule, gatewayPort int, runCommand rootCommandFunc, runBatchCommand rootCommandBatchFunc) (hostNetworkConfig, func(), error) {
+func setupHostNetwork(ctx context.Context, runID string, allowAll bool, allow []policy.AllowRule, gatewayPort int, runCommand rootCommandFunc, runBatchCommand rootCommandBatchFunc) (hostNetworkConfig, func(), error) {
 	lookup := func(ctx context.Context, host string) ([]net.IP, error) {
 		return net.DefaultResolver.LookupIP(ctx, "ip4", host)
 	}
-	return setupHostNetworkWithDeps(ctx, runID, allow, gatewayPort, lookup, runCommand, runBatchCommand)
+	return setupHostNetworkWithDeps(ctx, runID, allowAll, allow, gatewayPort, lookup, runCommand, runBatchCommand)
 }
 
-func setupHostNetworkWithDeps(ctx context.Context, runID string, allow []policy.AllowRule, gatewayPort int, lookup ipLookupFunc, runCommand rootCommandFunc, runBatchCommand rootCommandBatchFunc) (hostNetworkConfig, func(), error) {
-	return setupHostNetworkWithTapLookup(ctx, runID, allow, gatewayPort, lookup, net.InterfaceByName, runCommand, runBatchCommand)
+func setupHostNetworkWithDeps(ctx context.Context, runID string, allowAll bool, allow []policy.AllowRule, gatewayPort int, lookup ipLookupFunc, runCommand rootCommandFunc, runBatchCommand rootCommandBatchFunc) (hostNetworkConfig, func(), error) {
+	return setupHostNetworkWithTapLookup(ctx, runID, allowAll, allow, gatewayPort, lookup, net.InterfaceByName, runCommand, runBatchCommand)
 }
 
-func setupHostNetworkWithTapLookup(ctx context.Context, runID string, allow []policy.AllowRule, gatewayPort int, lookup ipLookupFunc, interfaceByName interfaceLookupFunc, runCommand rootCommandFunc, runBatchCommand rootCommandBatchFunc) (hostNetworkConfig, func(), error) {
+func setupHostNetworkWithTapLookup(ctx context.Context, runID string, allowAll bool, allow []policy.AllowRule, gatewayPort int, lookup ipLookupFunc, interfaceByName interfaceLookupFunc, runCommand rootCommandFunc, runBatchCommand rootCommandBatchFunc) (hostNetworkConfig, func(), error) {
 	tapName := tapNameFromExecutionID(runID)
 	hostIP, guestIP := hostGuestIPs(runID)
 	hostCIDR := hostIP + "/24"
@@ -2221,11 +2221,19 @@ func setupHostNetworkWithTapLookup(ctx context.Context, runID string, allow []po
 		}
 		addCleanup("iptables", "-D", "FORWARD", "-i", tapName, "-p", rule.Protocol, "-d", rule.DestIP, "--dport", port, "-j", "ACCEPT")
 	}
-	if err := setupRun("iptables", "-A", "FORWARD", "-i", tapName, "-j", "DROP"); err != nil {
-		cleanup()
-		return hostNetworkConfig{}, func() {}, fmt.Errorf("install default deny forward rule for %s: %w", tapName, err)
+	if allowAll {
+		if err := setupRun("iptables", "-A", "FORWARD", "-i", tapName, "-j", "ACCEPT"); err != nil {
+			cleanup()
+			return hostNetworkConfig{}, func() {}, fmt.Errorf("install allow-all forward rule for %s: %w", tapName, err)
+		}
+		addCleanup("iptables", "-D", "FORWARD", "-i", tapName, "-j", "ACCEPT")
+	} else {
+		if err := setupRun("iptables", "-A", "FORWARD", "-i", tapName, "-j", "DROP"); err != nil {
+			cleanup()
+			return hostNetworkConfig{}, func() {}, fmt.Errorf("install default deny forward rule for %s: %w", tapName, err)
+		}
+		addCleanup("iptables", "-D", "FORWARD", "-i", tapName, "-j", "DROP")
 	}
-	addCleanup("iptables", "-D", "FORWARD", "-i", tapName, "-j", "DROP")
 
 	return hostNetworkConfig{
 		TapName:         tapName,

--- a/internal/backend/firecracker/network_test.go
+++ b/internal/backend/firecracker/network_test.go
@@ -85,7 +85,7 @@ func TestSetupHostNetworkWithDepsAddsDenyDefaultAndCleanupIndependentContext(t *
 	}
 
 	reqCtx, cancel := context.WithCancel(context.Background())
-	cfg, cleanup, err := setupHostNetworkWithDeps(reqCtx, "run-12345", []policy.AllowRule{{Host: "proxy.golang.org", Ports: []int{443}}}, 8170, lookup, run, runBatch)
+	cfg, cleanup, err := setupHostNetworkWithDeps(reqCtx, "run-12345", false, []policy.AllowRule{{Host: "proxy.golang.org", Ports: []int{443}}}, 8170, lookup, run, runBatch)
 	if err != nil {
 		t.Fatalf("setupHostNetworkWithDeps: %v", err)
 	}
@@ -181,7 +181,7 @@ func TestSetupHostNetworkWithTapLookupDeletesStaleTapBeforeCreate(t *testing.T) 
 		return nil, errors.New("no such network interface")
 	}
 
-	_, cleanup, err := setupHostNetworkWithTapLookup(context.Background(), runID, []policy.AllowRule{{Host: "proxy.golang.org", Ports: []int{443}}}, 0, lookup, interfaceByName, run, nil)
+	_, cleanup, err := setupHostNetworkWithTapLookup(context.Background(), runID, false, []policy.AllowRule{{Host: "proxy.golang.org", Ports: []int{443}}}, 0, lookup, interfaceByName, run, nil)
 	if err != nil {
 		t.Fatalf("setupHostNetworkWithTapLookup: %v", err)
 	}
@@ -195,6 +195,43 @@ func TestSetupHostNetworkWithTapLookupDeletesStaleTapBeforeCreate(t *testing.T) 
 	}
 	if got, want := strings.Join(calls[1], " "), "ip tuntap add dev "+tapName+" mode tap user "+strconv.Itoa(os.Getuid()); got != want {
 		t.Fatalf("unexpected second command: got %q want %q", got, want)
+	}
+}
+
+func TestSetupHostNetworkWithDepsAddsAllowAllForwardRule(t *testing.T) {
+	t.Parallel()
+
+	var calls []string
+	run := func(_ context.Context, args ...string) error {
+		calls = append(calls, strings.Join(args, " "))
+		return nil
+	}
+	runBatch := func(_ context.Context, commands [][]string) error {
+		for _, args := range commands {
+			calls = append(calls, strings.Join(args, " "))
+		}
+		return nil
+	}
+	lookup := func(_ context.Context, host string) ([]net.IP, error) {
+		if host != "proxy.golang.org" {
+			t.Fatalf("unexpected host %q", host)
+		}
+		return []net.IP{net.ParseIP("142.251.41.17")}, nil
+	}
+
+	cfg, cleanup, err := setupHostNetworkWithDeps(context.Background(), "run-allow-all", true, []policy.AllowRule{{Host: "proxy.golang.org", Ports: []int{443}}}, 0, lookup, run, runBatch)
+	if err != nil {
+		t.Fatalf("setupHostNetworkWithDeps: %v", err)
+	}
+	defer cleanup()
+
+	joined := strings.Join(calls, "\n")
+	tap := cfg.TapName
+	if !strings.Contains(joined, "iptables -A FORWARD -i "+tap+" -j ACCEPT") {
+		t.Fatalf("expected blanket ACCEPT FORWARD rule for tap %s\ncalls:\n%s", tap, joined)
+	}
+	if strings.Contains(joined, "iptables -A FORWARD -i "+tap+" -j DROP") {
+		t.Fatalf("unexpected default DROP FORWARD rule for tap %s\ncalls:\n%s", tap, joined)
 	}
 }
 

--- a/internal/backend/firecracker/network_test.go
+++ b/internal/backend/firecracker/network_test.go
@@ -213,13 +213,11 @@ func TestSetupHostNetworkWithDepsAddsAllowAllForwardRule(t *testing.T) {
 		return nil
 	}
 	lookup := func(_ context.Context, host string) ([]net.IP, error) {
-		if host != "proxy.golang.org" {
-			t.Fatalf("unexpected host %q", host)
-		}
-		return []net.IP{net.ParseIP("142.251.41.17")}, nil
+		t.Fatalf("allow-all networking should not resolve policy host %q", host)
+		return nil, nil
 	}
 
-	cfg, cleanup, err := setupHostNetworkWithDeps(context.Background(), "run-allow-all", true, []policy.AllowRule{{Host: "proxy.golang.org", Ports: []int{443}}}, 0, lookup, run, runBatch)
+	cfg, cleanup, err := setupHostNetworkWithDeps(context.Background(), "run-allow-all", true, []policy.AllowRule{{Host: "stale.example.invalid", Ports: []int{443}}}, 0, lookup, run, runBatch)
 	if err != nil {
 		t.Fatalf("setupHostNetworkWithDeps: %v", err)
 	}
@@ -232,6 +230,9 @@ func TestSetupHostNetworkWithDepsAddsAllowAllForwardRule(t *testing.T) {
 	}
 	if strings.Contains(joined, "iptables -A FORWARD -i "+tap+" -j DROP") {
 		t.Fatalf("unexpected default DROP FORWARD rule for tap %s\ncalls:\n%s", tap, joined)
+	}
+	if cfg.PolicyResolveMS != 0 {
+		t.Fatalf("expected allow-all networking to skip policy resolution timing, got %d", cfg.PolicyResolveMS)
 	}
 }
 

--- a/internal/backend/firecracker/snapshot_zfs_e2e_test.go
+++ b/internal/backend/firecracker/snapshot_zfs_e2e_test.go
@@ -134,11 +134,11 @@ func TestSnapshotLifecycleZFSE2E(t *testing.T) {
 	runCommand := func(ctx context.Context, sandboxID, runID string, command ...string) string {
 		t.Helper()
 
-		result, err := adapter.RunInSandbox(ctx, backend.RunRequest{
-			SandboxID: sandboxID,
-			RunID:     runID,
-			Command:   command,
-			Policy:    compiled,
+		result, err := adapter.RunInSandbox(ctx, backend.ExecutionRequest{
+			SandboxID:   sandboxID,
+			ExecutionID: runID,
+			Command:     command,
+			Policy:      compiled,
 			FirecrackerConfig: backend.FirecrackerConfig{
 				LaunchSeconds: cfg.LaunchSeconds,
 			},

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -48,7 +48,7 @@ type CLI struct {
 	Config    ConfigCommand    `cmd:"" help:"Runtime config commands"`
 	Image     ImageCommand     `cmd:"" help:"Manage OCI image cache artifacts"`
 	Snapshot  SnapshotCommand  `cmd:"" help:"Manage snapshots"`
-	Create    CreateCommand    `cmd:"" help:"Create a sandbox"`
+	Create    CreateCommand    `cmd:"" help:"Create a sandbox using repo policy"`
 	Exec      ExecCommand      `cmd:"" help:"Execute a command in a sandbox"`
 	Console   ConsoleCommand   `cmd:"" help:"Open an interactive console in a sandbox"`
 	Serve     ServeCommand     `cmd:"" help:"Run the cleanroom control-plane server in the foreground"`

--- a/internal/cli/cli_parse_test.go
+++ b/internal/cli/cli_parse_test.go
@@ -150,6 +150,31 @@ func TestSandboxCreateParsesFromSnapshot(t *testing.T) {
 	}
 }
 
+func TestSandboxCreateParsesDangerouslyAllowAll(t *testing.T) {
+	c := &CLI{}
+	parser := newParserForTest(t, c)
+
+	if _, err := parser.Parse([]string{"sandbox", "create", "--dangerously-allow-all"}); err != nil {
+		t.Fatalf("parse sandbox create --dangerously-allow-all returned error: %v", err)
+	}
+	if !c.Sandbox.Create.DangerouslyAllowAll {
+		t.Fatal("expected sandbox create dangerously-allow-all flag to be set")
+	}
+}
+
+func TestSandboxCreateRejectsChdirFlag(t *testing.T) {
+	c := &CLI{}
+	parser := newParserForTest(t, c)
+
+	_, err := parser.Parse([]string{"sandbox", "create", "--chdir", "."})
+	if err == nil {
+		t.Fatal("expected sandbox create --chdir to be rejected")
+	}
+	if !strings.Contains(err.Error(), "--chdir") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestTopLevelCreateParses(t *testing.T) {
 	c := &CLI{}
 	parser := newParserForTest(t, c)

--- a/internal/cli/cli_parse_test.go
+++ b/internal/cli/cli_parse_test.go
@@ -162,6 +162,18 @@ func TestSandboxCreateParsesDangerouslyAllowAll(t *testing.T) {
 	}
 }
 
+func TestSandboxCreateParsesDocker(t *testing.T) {
+	c := &CLI{}
+	parser := newParserForTest(t, c)
+
+	if _, err := parser.Parse([]string{"sandbox", "create", "--docker"}); err != nil {
+		t.Fatalf("parse sandbox create --docker returned error: %v", err)
+	}
+	if !c.Sandbox.Create.Docker {
+		t.Fatal("expected sandbox create docker flag to be set")
+	}
+}
+
 func TestSandboxCreateRejectsChdirFlag(t *testing.T) {
 	c := &CLI{}
 	parser := newParserForTest(t, c)

--- a/internal/cli/image_override_integration_test.go
+++ b/internal/cli/image_override_integration_test.go
@@ -52,11 +52,10 @@ func TestSandboxCreateIntegrationOverridesImageRefForNewSandbox(t *testing.T) {
 
 	createOutcome := runSandboxCreateWithCapture(SandboxCreateCommand{
 		clientFlags: clientFlags{Host: host},
-		Chdir:       cwd,
 		Image:       testImageOverrideTag,
 	}, runtimeContext{
 		CWD:    cwd,
-		Loader: integrationLoader{},
+		Loader: failingLoader{},
 	})
 	if createOutcome.cause != nil {
 		t.Fatalf("capture failure: %v", createOutcome.cause)

--- a/internal/cli/repository_test.go
+++ b/internal/cli/repository_test.go
@@ -236,6 +236,13 @@ func TestSandboxCreateCommandRemainsGenericWithRepositoryConfig(t *testing.T) {
 	adapter := &persistentIntegrationAdapter{}
 	host, _ := startIntegrationServer(t, adapter)
 	repoDir := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
+	restore := stubPolicyUpdateResolver(t, func(_ context.Context, source string) (string, error) {
+		if got, want := source, defaultBumpRefSource; got != want {
+			t.Fatalf("unexpected default sandbox image source: got %q want %q", got, want)
+		}
+		return testImageOverrideRef, nil
+	})
+	defer restore()
 
 	var (
 		mu       sync.Mutex
@@ -250,23 +257,9 @@ func TestSandboxCreateCommandRemainsGenericWithRepositoryConfig(t *testing.T) {
 
 	outcome := runSandboxCreateWithCapture(SandboxCreateCommand{
 		clientFlags: clientFlags{Host: host},
-		Chdir:       repoDir,
 	}, runtimeContext{
-		CWD: repoDir,
-		Loader: repositoryIntegrationLoader{
-			compiled: &policy.CompiledPolicy{
-				Version:        1,
-				ImageRef:       "ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-				ImageDigest:    "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-				NetworkDefault: "deny",
-				Allow:          []policy.AllowRule{{Host: "github.com", Ports: []int{443}}},
-			},
-			repository: policy.RepositoryConfig{
-				Mode:   "current-repo",
-				Remote: "origin",
-				Path:   "/workspace",
-			},
-		},
+		CWD:    repoDir,
+		Loader: failingLoader{},
 	})
 	if outcome.cause != nil {
 		t.Fatalf("capture failure: %v", outcome.cause)

--- a/internal/cli/sandbox.go
+++ b/internal/cli/sandbox.go
@@ -11,10 +11,11 @@ import (
 
 	"github.com/buildkite/cleanroom/internal/controlclient"
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+	"github.com/buildkite/cleanroom/internal/policy"
 )
 
 type SandboxCommand struct {
-	Create    SandboxCreateCommand    `cmd:"" help:"Create a sandbox"`
+	Create    SandboxCreateCommand    `cmd:"" help:"Create a repo-agnostic sandbox"`
 	Inspect   SandboxInspectCommand   `name:"inspect" aliases:"show" cmd:"" help:"Inspect sandbox state and related execution IDs"`
 	List      SandboxListCommand      `name:"ls" aliases:"list" cmd:"" help:"List active sandboxes"`
 	Terminate SandboxTerminateCommand `name:"rm" aliases:"terminate" cmd:"" help:"Terminate a sandbox"`
@@ -22,12 +23,12 @@ type SandboxCommand struct {
 
 type SandboxCreateCommand struct {
 	clientFlags
-	Chdir         string `short:"c" help:"Change to this directory before running commands"`
-	Backend       string `help:"Execution backend (defaults to runtime config or host default)"`
-	From          string `name:"from" help:"Create the sandbox from an existing snapshot ID"`
-	Image         string `help:"Override sandbox image ref (tag, digest, or local Docker image)"`
-	LaunchSeconds int64  `help:"VM boot/guest-agent readiness timeout in seconds"`
-	JSON          bool   `help:"Print sandbox as JSON"`
+	Backend             string `help:"Execution backend (defaults to runtime config or host default)"`
+	From                string `name:"from" help:"Create the sandbox from an existing snapshot ID"`
+	Image               string `help:"Override sandbox image ref (tag, digest, or local Docker image)"`
+	DangerouslyAllowAll bool   `name:"dangerously-allow-all" help:"Disable network egress filtering for this repo-agnostic sandbox"`
+	LaunchSeconds       int64  `help:"VM boot/guest-agent readiness timeout in seconds"`
+	JSON                bool   `help:"Print sandbox as JSON"`
 }
 
 type SandboxListCommand struct {
@@ -200,20 +201,15 @@ func (c *SandboxTerminateCommand) Run(ctx *runtimeContext) error {
 	return err
 }
 
-func runSandboxCreate(ctx *runtimeContext, connectFlags clientFlags, chdir, backend, from, imageRefOverride string, launchSeconds int64, outputJSON bool) error {
+func runSandboxCreate(ctx *runtimeContext, connectFlags clientFlags, backend, from, imageRefOverride string, dangerouslyAllowAll bool, launchSeconds int64, outputJSON bool) error {
 	resolvedHost := connectFlags.resolvedHost(ctx.Config)
 	client, err := connectFlags.connect(ctx)
 	if err != nil {
 		return err
 	}
 
-	createReq := &cleanroomv1.CreateSandboxRequest{
-		Backend: backend,
-		Options: &cleanroomv1.SandboxOptions{
-			LaunchSeconds: launchSeconds,
-		},
-	}
 	from = strings.TrimSpace(from)
+	var sandbox *cleanroomv1.Sandbox
 	if from != "" {
 		if strings.TrimSpace(imageRefOverride) != "" {
 			return errors.New("--image cannot be used with --from")
@@ -221,36 +217,32 @@ func runSandboxCreate(ctx *runtimeContext, connectFlags clientFlags, chdir, back
 		if strings.TrimSpace(backend) != "" {
 			return errors.New("--backend cannot be used with --from")
 		}
-		createReq.Source = &cleanroomv1.CreateSandboxRequest_SnapshotId{SnapshotId: from}
-	} else {
-		cwd, err := resolveCWD(ctx.CWD, chdir)
-		if err != nil {
-			return err
+		if dangerouslyAllowAll {
+			return errors.New("--dangerously-allow-all cannot be used with --from")
 		}
-		compiled, _, err := ctx.Loader.LoadAndCompile(cwd)
-		if err != nil {
-			return err
-		}
-		allowLocalImageOverride, err := isLocalControlPlaneEndpoint(resolvedHost)
-		if err != nil {
-			return err
-		}
-		compiled, err = overrideCompiledPolicyImage(compiled, imageRefOverride, allowLocalImageOverride)
-		if err != nil {
-			return err
-		}
-		createReq.Policy = compiled.ToProto()
-	}
 
-	resp, err := client.CreateSandbox(context.Background(), createReq)
-	if err != nil {
-		if from != "" {
+		resp, err := client.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+			Options: &cleanroomv1.SandboxOptions{
+				LaunchSeconds: launchSeconds,
+			},
+			Source: &cleanroomv1.CreateSandboxRequest_SnapshotId{SnapshotId: from},
+		})
+		if err != nil {
 			err = explainSnapshotRuntimeDisabledError(err, ctx)
+			return fmt.Errorf("create sandbox: %w", err)
 		}
-		return fmt.Errorf("create sandbox: %w", err)
+		sandbox = resp.GetSandbox()
+	} else {
+		compiled, err := defaultSandboxCreatePolicy(resolvedHost, imageRefOverride, dangerouslyAllowAll)
+		if err != nil {
+			return err
+		}
+		_, sandbox, err = createSandboxWithPolicy(client, compiled, backend, launchSeconds, nil)
+		if err != nil {
+			return err
+		}
 	}
 
-	sandbox := resp.GetSandbox()
 	sandboxID := strings.TrimSpace(sandbox.GetSandboxId())
 	if sandboxID == "" {
 		return errors.New("create sandbox: response missing sandbox id")
@@ -267,12 +259,12 @@ func runSandboxCreate(ctx *runtimeContext, connectFlags clientFlags, chdir, back
 }
 
 func (c *SandboxCreateCommand) Run(ctx *runtimeContext) error {
-	return runSandboxCreate(ctx, c.clientFlags, c.Chdir, c.Backend, c.From, c.Image, c.LaunchSeconds, c.JSON)
+	return runSandboxCreate(ctx, c.clientFlags, c.Backend, c.From, c.Image, c.DangerouslyAllowAll, c.LaunchSeconds, c.JSON)
 }
 
 func (c *CreateCommand) Run(ctx *runtimeContext) error {
 	if strings.TrimSpace(c.From) != "" {
-		return runSandboxCreate(ctx, c.clientFlags, c.Chdir, c.Backend, c.From, c.Image, c.LaunchSeconds, c.JSON)
+		return runSandboxCreate(ctx, c.clientFlags, c.Backend, c.From, c.Image, false, c.LaunchSeconds, c.JSON)
 	}
 	host := c.resolvedHost(ctx.Config)
 	client, err := c.connect(ctx)
@@ -326,6 +318,20 @@ func createTopLevelSandbox(
 		return "", nil, err
 	}
 
+	return createSandboxWithPolicy(client, compiled, backendName, launchSeconds, repository)
+}
+
+func createSandboxWithPolicy(
+	client *controlclient.Client,
+	compiled *policy.CompiledPolicy,
+	backendName string,
+	launchSeconds int64,
+	repository *resolvedRepositoryCheckout,
+) (string, *cleanroomv1.Sandbox, error) {
+	if compiled == nil {
+		return "", nil, errors.New("create sandbox: missing compiled policy")
+	}
+
 	createSandboxResp, err := client.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
 		Backend: backendName,
 		Options: &cleanroomv1.SandboxOptions{
@@ -345,6 +351,43 @@ func createTopLevelSandbox(
 	}
 
 	return sandboxID, sandbox, nil
+}
+
+func defaultSandboxCreatePolicy(host, imageRefOverride string, dangerouslyAllowAll bool) (*policy.CompiledPolicy, error) {
+	imageRefOverride = strings.TrimSpace(imageRefOverride)
+	resolvedRef := ""
+	if imageRefOverride == "" {
+		ref, err := resolveReferenceForPolicyUpdate(context.Background(), defaultBumpRefSource)
+		if err != nil {
+			return nil, fmt.Errorf("resolve default sandbox image %q: %w", defaultBumpRefSource, err)
+		}
+		resolvedRef = ref
+	} else {
+		allowLocalImageOverride, err := isLocalControlPlaneEndpoint(host)
+		if err != nil {
+			return nil, err
+		}
+		ref, err := resolveReferenceForImageOverride(context.Background(), imageRefOverride, allowLocalImageOverride)
+		if err != nil {
+			return nil, fmt.Errorf("invalid --image value: %w", err)
+		}
+		resolvedRef = ref
+	}
+
+	networkDefault := "deny"
+	if dangerouslyAllowAll {
+		networkDefault = "allow"
+	}
+
+	compiled, err := policy.FromProto(&cleanroomv1.Policy{
+		Version:        1,
+		ImageRef:       resolvedRef,
+		NetworkDefault: networkDefault,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("build sandbox policy: %w", err)
+	}
+	return compiled, nil
 }
 
 func sandboxStatusString(s cleanroomv1.SandboxStatus) string {

--- a/internal/cli/sandbox.go
+++ b/internal/cli/sandbox.go
@@ -26,6 +26,7 @@ type SandboxCreateCommand struct {
 	Backend             string `help:"Execution backend (defaults to runtime config or host default)"`
 	From                string `name:"from" help:"Create the sandbox from an existing snapshot ID"`
 	Image               string `help:"Override sandbox image ref (tag, digest, or local Docker image)"`
+	Docker              bool   `help:"Enable the guest Docker service for this repo-agnostic sandbox"`
 	DangerouslyAllowAll bool   `name:"dangerously-allow-all" help:"Disable network egress filtering for this repo-agnostic sandbox"`
 	LaunchSeconds       int64  `help:"VM boot/guest-agent readiness timeout in seconds"`
 	JSON                bool   `help:"Print sandbox as JSON"`
@@ -201,7 +202,7 @@ func (c *SandboxTerminateCommand) Run(ctx *runtimeContext) error {
 	return err
 }
 
-func runSandboxCreate(ctx *runtimeContext, connectFlags clientFlags, backend, from, imageRefOverride string, dangerouslyAllowAll bool, launchSeconds int64, outputJSON bool) error {
+func runSandboxCreate(ctx *runtimeContext, connectFlags clientFlags, backend, from, imageRefOverride string, requireDockerService, dangerouslyAllowAll bool, launchSeconds int64, outputJSON bool) error {
 	resolvedHost := connectFlags.resolvedHost(ctx.Config)
 	client, err := connectFlags.connect(ctx)
 	if err != nil {
@@ -216,6 +217,9 @@ func runSandboxCreate(ctx *runtimeContext, connectFlags clientFlags, backend, fr
 		}
 		if strings.TrimSpace(backend) != "" {
 			return errors.New("--backend cannot be used with --from")
+		}
+		if requireDockerService {
+			return errors.New("--docker cannot be used with --from")
 		}
 		if dangerouslyAllowAll {
 			return errors.New("--dangerously-allow-all cannot be used with --from")
@@ -233,7 +237,7 @@ func runSandboxCreate(ctx *runtimeContext, connectFlags clientFlags, backend, fr
 		}
 		sandbox = resp.GetSandbox()
 	} else {
-		compiled, err := defaultSandboxCreatePolicy(resolvedHost, imageRefOverride, dangerouslyAllowAll)
+		compiled, err := defaultSandboxCreatePolicy(resolvedHost, imageRefOverride, requireDockerService, dangerouslyAllowAll)
 		if err != nil {
 			return err
 		}
@@ -259,12 +263,12 @@ func runSandboxCreate(ctx *runtimeContext, connectFlags clientFlags, backend, fr
 }
 
 func (c *SandboxCreateCommand) Run(ctx *runtimeContext) error {
-	return runSandboxCreate(ctx, c.clientFlags, c.Backend, c.From, c.Image, c.DangerouslyAllowAll, c.LaunchSeconds, c.JSON)
+	return runSandboxCreate(ctx, c.clientFlags, c.Backend, c.From, c.Image, c.Docker, c.DangerouslyAllowAll, c.LaunchSeconds, c.JSON)
 }
 
 func (c *CreateCommand) Run(ctx *runtimeContext) error {
 	if strings.TrimSpace(c.From) != "" {
-		return runSandboxCreate(ctx, c.clientFlags, c.Backend, c.From, c.Image, false, c.LaunchSeconds, c.JSON)
+		return runSandboxCreate(ctx, c.clientFlags, c.Backend, c.From, c.Image, false, false, c.LaunchSeconds, c.JSON)
 	}
 	host := c.resolvedHost(ctx.Config)
 	client, err := c.connect(ctx)
@@ -353,7 +357,7 @@ func createSandboxWithPolicy(
 	return sandboxID, sandbox, nil
 }
 
-func defaultSandboxCreatePolicy(host, imageRefOverride string, dangerouslyAllowAll bool) (*policy.CompiledPolicy, error) {
+func defaultSandboxCreatePolicy(host, imageRefOverride string, requireDockerService, dangerouslyAllowAll bool) (*policy.CompiledPolicy, error) {
 	imageRefOverride = strings.TrimSpace(imageRefOverride)
 	resolvedRef := ""
 	if imageRefOverride == "" {
@@ -383,6 +387,11 @@ func defaultSandboxCreatePolicy(host, imageRefOverride string, dangerouslyAllowA
 		Version:        1,
 		ImageRef:       resolvedRef,
 		NetworkDefault: networkDefault,
+		Services: &cleanroomv1.PolicyServices{
+			Docker: &cleanroomv1.PolicyDockerService{
+				Required: requireDockerService,
+			},
+		},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("build sandbox policy: %w", err)

--- a/internal/cli/sandbox_create_integration_test.go
+++ b/internal/cli/sandbox_create_integration_test.go
@@ -1,12 +1,22 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
 	"strings"
 	"testing"
 
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
 )
+
+func stubPolicyUpdateResolver(t *testing.T, fn func(context.Context, string) (string, error)) func() {
+	t.Helper()
+	prev := resolveReferenceForPolicyUpdate
+	resolveReferenceForPolicyUpdate = fn
+	return func() {
+		resolveReferenceForPolicyUpdate = prev
+	}
+}
 
 func runSandboxCreateWithCapture(cmd SandboxCreateCommand, ctx runtimeContext) execOutcome {
 	return runWithCapture(func(runCtx *runtimeContext) error {
@@ -21,15 +31,22 @@ func runCreateAliasWithCapture(cmd CreateCommand, ctx runtimeContext) execOutcom
 }
 
 func TestSandboxCreateIntegrationPrintsSandboxID(t *testing.T) {
+	restore := stubPolicyUpdateResolver(t, func(_ context.Context, source string) (string, error) {
+		if got, want := source, defaultBumpRefSource; got != want {
+			t.Fatalf("unexpected default sandbox image source: got %q want %q", got, want)
+		}
+		return testImageOverrideRef, nil
+	})
+	defer restore()
+
 	host, _ := startIntegrationServer(t, &integrationAdapter{})
 	cwd := t.TempDir()
 
 	outcome := runSandboxCreateWithCapture(SandboxCreateCommand{
 		clientFlags: clientFlags{Host: host},
-		Chdir:       cwd,
 	}, runtimeContext{
 		CWD:    cwd,
-		Loader: integrationLoader{},
+		Loader: failingLoader{},
 	})
 	if outcome.cause != nil {
 		t.Fatalf("capture failure: %v", outcome.cause)
@@ -48,16 +65,23 @@ func TestSandboxCreateIntegrationPrintsSandboxID(t *testing.T) {
 }
 
 func TestSandboxCreateIntegrationJSONOutput(t *testing.T) {
+	restore := stubPolicyUpdateResolver(t, func(_ context.Context, source string) (string, error) {
+		if got, want := source, defaultBumpRefSource; got != want {
+			t.Fatalf("unexpected default sandbox image source: got %q want %q", got, want)
+		}
+		return testImageOverrideRef, nil
+	})
+	defer restore()
+
 	host, _ := startIntegrationServer(t, &integrationAdapter{})
 	cwd := t.TempDir()
 
 	outcome := runSandboxCreateWithCapture(SandboxCreateCommand{
 		clientFlags: clientFlags{Host: host},
-		Chdir:       cwd,
 		JSON:        true,
 	}, runtimeContext{
 		CWD:    cwd,
-		Loader: integrationLoader{},
+		Loader: failingLoader{},
 	})
 	if outcome.cause != nil {
 		t.Fatalf("capture failure: %v", outcome.cause)
@@ -73,6 +97,58 @@ func TestSandboxCreateIntegrationJSONOutput(t *testing.T) {
 	rawID, ok := payload["sandbox_id"].(string)
 	if !ok || strings.TrimSpace(rawID) == "" {
 		t.Fatalf("expected sandbox_id in JSON output, got %v", payload)
+	}
+}
+
+func TestSandboxCreateIntegrationDangerouslyAllowAllSetsAllowNetworkDefault(t *testing.T) {
+	restore := stubPolicyUpdateResolver(t, func(_ context.Context, source string) (string, error) {
+		if got, want := source, defaultBumpRefSource; got != want {
+			t.Fatalf("unexpected default sandbox image source: got %q want %q", got, want)
+		}
+		return testImageOverrideRef, nil
+	})
+	defer restore()
+
+	adapter := &snapshotIntegrationAdapter{}
+	host, _ := startIntegrationServer(t, adapter)
+
+	outcome := runSandboxCreateWithCapture(SandboxCreateCommand{
+		clientFlags:         clientFlags{Host: host},
+		DangerouslyAllowAll: true,
+	}, runtimeContext{
+		CWD:    t.TempDir(),
+		Loader: failingLoader{},
+	})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err != nil {
+		t.Fatalf("SandboxCreateCommand.Run returned error: %v", outcome.err)
+	}
+	if got := strings.TrimSpace(outcome.stdout); got == "" {
+		t.Fatalf("expected sandbox id output, got %q", outcome.stdout)
+	}
+	if got, want := adapter.provisionReq.Policy.NetworkDefault, "allow"; got != want {
+		t.Fatalf("unexpected provisioned network default: got %q want %q", got, want)
+	}
+}
+
+func TestSandboxCreateIntegrationRejectsDangerouslyAllowAllWithSnapshot(t *testing.T) {
+	outcome := runSandboxCreateWithCapture(SandboxCreateCommand{
+		From:                "snap_123",
+		DangerouslyAllowAll: true,
+	}, runtimeContext{
+		CWD:    t.TempDir(),
+		Loader: failingLoader{},
+	})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err == nil {
+		t.Fatal("expected SandboxCreateCommand.Run to fail when both --from and --dangerously-allow-all are set")
+	}
+	if got, want := outcome.err.Error(), "--dangerously-allow-all cannot be used with --from"; !strings.Contains(got, want) {
+		t.Fatalf("expected error to contain %q, got %q", want, got)
 	}
 }
 

--- a/internal/cli/sandbox_create_integration_test.go
+++ b/internal/cli/sandbox_create_integration_test.go
@@ -133,6 +133,42 @@ func TestSandboxCreateIntegrationDangerouslyAllowAllSetsAllowNetworkDefault(t *t
 	}
 }
 
+func TestSandboxCreateIntegrationDockerRequiresGuestService(t *testing.T) {
+	restore := stubPolicyUpdateResolver(t, func(_ context.Context, source string) (string, error) {
+		if got, want := source, defaultBumpRefSource; got != want {
+			t.Fatalf("unexpected default sandbox image source: got %q want %q", got, want)
+		}
+		return testImageOverrideRef, nil
+	})
+	defer restore()
+
+	adapter := &snapshotIntegrationAdapter{}
+	host, _ := startIntegrationServer(t, adapter)
+
+	outcome := runSandboxCreateWithCapture(SandboxCreateCommand{
+		clientFlags: clientFlags{Host: host},
+		Docker:      true,
+	}, runtimeContext{
+		CWD:    t.TempDir(),
+		Loader: failingLoader{},
+	})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err != nil {
+		t.Fatalf("SandboxCreateCommand.Run returned error: %v", outcome.err)
+	}
+	if got := strings.TrimSpace(outcome.stdout); got == "" {
+		t.Fatalf("expected sandbox id output, got %q", outcome.stdout)
+	}
+	if adapter.provisionReq.Policy == nil {
+		t.Fatal("expected provisioned policy")
+	}
+	if !adapter.provisionReq.Policy.Services.Docker.Required {
+		t.Fatal("expected provisioned docker service to be required")
+	}
+}
+
 func TestSandboxCreateIntegrationRejectsDangerouslyAllowAllWithSnapshot(t *testing.T) {
 	outcome := runSandboxCreateWithCapture(SandboxCreateCommand{
 		From:                "snap_123",
@@ -148,6 +184,25 @@ func TestSandboxCreateIntegrationRejectsDangerouslyAllowAllWithSnapshot(t *testi
 		t.Fatal("expected SandboxCreateCommand.Run to fail when both --from and --dangerously-allow-all are set")
 	}
 	if got, want := outcome.err.Error(), "--dangerously-allow-all cannot be used with --from"; !strings.Contains(got, want) {
+		t.Fatalf("expected error to contain %q, got %q", want, got)
+	}
+}
+
+func TestSandboxCreateIntegrationRejectsDockerWithSnapshot(t *testing.T) {
+	outcome := runSandboxCreateWithCapture(SandboxCreateCommand{
+		From:   "snap_123",
+		Docker: true,
+	}, runtimeContext{
+		CWD:    t.TempDir(),
+		Loader: failingLoader{},
+	})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err == nil {
+		t.Fatal("expected SandboxCreateCommand.Run to fail when both --from and --docker are set")
+	}
+	if got, want := outcome.err.Error(), "--docker cannot be used with --from"; !strings.Contains(got, want) {
 		t.Fatalf("expected error to contain %q, got %q", want, got)
 	}
 }

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -222,6 +222,12 @@ func Compile(raw rawPolicy) (*CompiledPolicy, error) {
 }
 
 func (p *CompiledPolicy) Allows(host string, port int) bool {
+	if p == nil {
+		return false
+	}
+	if strings.TrimSpace(strings.ToLower(p.NetworkDefault)) == "allow" {
+		return true
+	}
 	host = strings.TrimSpace(strings.ToLower(host))
 	for _, rule := range p.Allow {
 		if rule.Host != host {
@@ -374,8 +380,10 @@ func FromProto(pb *cleanroomv1.Policy) (*CompiledPolicy, error) {
 	if networkDefault == "" {
 		networkDefault = "deny"
 	}
-	if networkDefault != "deny" {
-		return nil, fmt.Errorf("unsupported policy network_default %q: cleanroom requires deny-by-default", networkDefault)
+	switch networkDefault {
+	case "deny", "allow":
+	default:
+		return nil, fmt.Errorf("unsupported policy network_default %q: expected deny or allow", networkDefault)
 	}
 
 	allow := make([]AllowRule, 0, len(pb.GetAllow()))

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -378,3 +378,22 @@ func TestFromProtoPropagatesDockerServiceRequirement(t *testing.T) {
 		t.Fatal("expected docker service requirement from proto policy")
 	}
 }
+
+func TestFromProtoAcceptsAllowDefault(t *testing.T) {
+	t.Parallel()
+
+	compiled, err := FromProto(&cleanroomv1.Policy{
+		Version:        1,
+		ImageRef:       validImageRef,
+		NetworkDefault: "allow",
+	})
+	if err != nil {
+		t.Fatalf("FromProto returned error: %v", err)
+	}
+	if got, want := compiled.NetworkDefault, "allow"; got != want {
+		t.Fatalf("unexpected network default: got %q want %q", got, want)
+	}
+	if !compiled.Allows("example.com", 443) {
+		t.Fatal("expected allow-default policy to allow arbitrary host:port")
+	}
+}

--- a/scripts/buildkite_pipeline_test.go
+++ b/scripts/buildkite_pipeline_test.go
@@ -3,6 +3,7 @@ package scripts_test
 import (
 	"errors"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -81,6 +82,21 @@ func TestBuildkiteCIScriptsDoNotInvokeMiseDirectly(t *testing.T) {
 				t.Fatalf("expected %s to use the prebuilt download helper instead of `go run`", path)
 			}
 		})
+	}
+}
+
+func TestFirecrackerE2ESandboxCreateDoesNotUseChdir(t *testing.T) {
+	t.Parallel()
+
+	content, err := os.ReadFile("ci-cleanroom-e2e.sh")
+	if err != nil {
+		t.Fatalf("read ci-cleanroom-e2e.sh: %v", err)
+	}
+
+	script := string(content)
+	pattern := regexp.MustCompile(`sandbox create[^\n]*(?:^|[[:space:]])(?:-c|--chdir)(?:[[:space:]]|=)`)
+	if pattern.MatchString(script) {
+		t.Fatal("expected ci-cleanroom-e2e.sh to avoid passing --chdir/-c to sandbox create")
 	}
 }
 

--- a/scripts/ci-cleanroom-e2e.sh
+++ b/scripts/ci-cleanroom-e2e.sh
@@ -246,14 +246,9 @@ while true; do
 done
 
 echo "--- :recycle: Persistent sandbox lifecycle test"
-sandbox_image_ref="$(awk '/^[[:space:]]*ref:[[:space:]]*/ { print $2; exit }' cleanroom.yaml)"
-if [[ -z "$sandbox_image_ref" ]]; then
-  echo "failed to resolve sandbox image ref from cleanroom.yaml" >&2
-  exit 1
-fi
-sandbox_id="$(./dist/cleanroom sandbox create --host "$listen_endpoint" --image "$sandbox_image_ref" | tr -d '\n')"
+sandbox_id="$(./dist/cleanroom create --host "$listen_endpoint" -c "$PWD" | tr -d '\n')"
 if [[ -z "$sandbox_id" ]]; then
-  echo "sandbox create did not return an id" >&2
+  echo "cleanroom create did not return an id" >&2
   exit 1
 fi
 echo "sandbox id: $sandbox_id"

--- a/scripts/ci-cleanroom-e2e.sh
+++ b/scripts/ci-cleanroom-e2e.sh
@@ -246,7 +246,7 @@ while true; do
 done
 
 echo "--- :recycle: Persistent sandbox lifecycle test"
-sandbox_id="$(./dist/cleanroom sandbox create --host "$listen_endpoint" -c "$PWD" | tr -d '\n')"
+sandbox_id="$(./dist/cleanroom sandbox create --host "$listen_endpoint" | tr -d '\n')"
 if [[ -z "$sandbox_id" ]]; then
   echo "sandbox create did not return an id" >&2
   exit 1

--- a/scripts/ci-cleanroom-e2e.sh
+++ b/scripts/ci-cleanroom-e2e.sh
@@ -246,7 +246,12 @@ while true; do
 done
 
 echo "--- :recycle: Persistent sandbox lifecycle test"
-sandbox_id="$(./dist/cleanroom sandbox create --host "$listen_endpoint" | tr -d '\n')"
+sandbox_image_ref="$(awk '/^[[:space:]]*ref:[[:space:]]*/ { print $2; exit }' cleanroom.yaml)"
+if [[ -z "$sandbox_image_ref" ]]; then
+  echo "failed to resolve sandbox image ref from cleanroom.yaml" >&2
+  exit 1
+fi
+sandbox_id="$(./dist/cleanroom sandbox create --host "$listen_endpoint" --image "$sandbox_image_ref" | tr -d '\n')"
 if [[ -z "$sandbox_id" ]]; then
   echo "sandbox create did not return an id" >&2
   exit 1


### PR DESCRIPTION
## Summary
- make `cleanroom sandbox create` repo-agnostic and stop requiring `cleanroom.yaml` or local repo inspection
- add explicit repo-agnostic overrides for guest Docker (`--docker`) and unrestricted egress (`--dangerously-allow-all`)
- document the split between policy-aware top-level commands and generic sandbox creation, and add coverage for the new CLI behavior

## Testing
- `mise exec -C /tmp go@1.23.1 -- /bin/zsh -lc 'cd /Users/lachlan/.codex/worktrees/aac0/cleanroom && go test ./internal/cli ./internal/policy ./internal/backend/firecracker ./internal/backend/darwinvz ./internal/gateway'`
- `mise exec -C /tmp go@1.23.1 -- /bin/zsh -lc 'cd /Users/lachlan/.codex/worktrees/aac0/cleanroom && go test ./internal/cli'`
