### PR TITLE
fix(cli): restart launchd daemon on install

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -58,6 +58,7 @@ var (
 	serveInstallStat             = os.Stat
 	serveInstallMkdirAll         = os.MkdirAll
 	serveInstallWriteFile        = os.WriteFile
+	serveInstallRename           = os.Rename
 	serveInstallRemoveFile       = os.Remove
 	serveInstallUserHomeDir      = os.UserHomeDir
 	serveInstallExecutablePath   = os.Executable

--- a/internal/cli/daemon_launchd.go
+++ b/internal/cli/daemon_launchd.go
@@ -389,15 +389,24 @@ func launchdServiceTarget(domain string) string {
 
 func installLaunchdDaemonInDomain(stdout io.Writer, executablePath string, args []string, force bool, servicePath, domain string) error {
 	target := launchdServiceTarget(domain)
+	content := renderLaunchdService(executablePath, args)
 	if force {
+		stagedPath, cleanup, err := stageDaemonFile(servicePath, content, 0o644)
+		if err != nil {
+			return err
+		}
+		defer cleanup()
+
 		if err := serveInstallRunCommand("launchctl", "bootout", target); err != nil && !isExitError(err) {
 			return fmt.Errorf("bootout launchd service %s: %w", launchdServiceName, err)
 		}
-	}
-
-	content := renderLaunchdService(executablePath, args)
-	if err := writeDaemonFile(servicePath, content, force, 0o644); err != nil {
-		return err
+		if err := serveInstallRename(stagedPath, servicePath); err != nil {
+			return fmt.Errorf("replace daemon service file %s: %w", servicePath, err)
+		}
+	} else {
+		if err := writeDaemonFile(servicePath, content, force, 0o644); err != nil {
+			return err
+		}
 	}
 	if err := serveInstallRunCommand("launchctl", "enable", target); err != nil {
 		return fmt.Errorf("enable launchd service %s: %w", launchdServiceName, err)
@@ -419,6 +428,32 @@ func installLaunchdDaemonInDomain(stdout io.Writer, executablePath string, args 
 		},
 	}, shouldUseANSI(stdout)))
 	return err
+}
+
+func stageDaemonFile(path, content string, mode os.FileMode) (string, func(), error) {
+	dir := filepath.Dir(path)
+	if err := serveInstallMkdirAll(dir, 0o755); err != nil {
+		return "", nil, fmt.Errorf("create daemon service directory: %w", err)
+	}
+
+	tmpFile, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return "", nil, fmt.Errorf("create staged daemon service file %s: %w", path, err)
+	}
+	tmpPath := tmpFile.Name()
+	if err := tmpFile.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return "", nil, fmt.Errorf("close staged daemon service file %s: %w", path, err)
+	}
+
+	cleanup := func() {
+		_ = serveInstallRemoveFile(tmpPath)
+	}
+	if err := serveInstallWriteFile(tmpPath, []byte(content), mode); err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("stage daemon service file %s: %w", path, err)
+	}
+	return tmpPath, cleanup, nil
 }
 
 func writeDaemonFile(path, content string, force bool, mode os.FileMode) error {

--- a/internal/cli/daemon_launchd.go
+++ b/internal/cli/daemon_launchd.go
@@ -391,6 +391,9 @@ func installLaunchdDaemonInDomain(stdout io.Writer, executablePath string, args 
 	target := launchdServiceTarget(domain)
 	content := renderLaunchdService(executablePath, args)
 	if force {
+		if err := validateDaemonFileTarget(servicePath, true); err != nil {
+			return err
+		}
 		stagedPath, cleanup, err := stageDaemonFile(servicePath, content, 0o644)
 		if err != nil {
 			return err
@@ -430,6 +433,20 @@ func installLaunchdDaemonInDomain(stdout io.Writer, executablePath string, args 
 	return err
 }
 
+func validateDaemonFileTarget(path string, force bool) error {
+	if st, err := serveInstallStat(path); err == nil {
+		if st.IsDir() {
+			return fmt.Errorf("daemon service path %s is a directory", path)
+		}
+		if !force {
+			return fmt.Errorf("%s already exists (use --force to overwrite)", path)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("stat %s: %w", path, err)
+	}
+	return nil
+}
+
 func stageDaemonFile(path, content string, mode os.FileMode) (string, func(), error) {
 	dir := filepath.Dir(path)
 	if err := serveInstallMkdirAll(dir, 0o755); err != nil {
@@ -457,15 +474,8 @@ func stageDaemonFile(path, content string, mode os.FileMode) (string, func(), er
 }
 
 func writeDaemonFile(path, content string, force bool, mode os.FileMode) error {
-	if st, err := serveInstallStat(path); err == nil {
-		if st.IsDir() {
-			return fmt.Errorf("daemon service path %s is a directory", path)
-		}
-		if !force {
-			return fmt.Errorf("%s already exists (use --force to overwrite)", path)
-		}
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("stat %s: %w", path, err)
+	if err := validateDaemonFileTarget(path, force); err != nil {
+		return err
 	}
 
 	if err := serveInstallMkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/internal/cli/daemon_launchd.go
+++ b/internal/cli/daemon_launchd.go
@@ -388,20 +388,25 @@ func launchdServiceTarget(domain string) string {
 }
 
 func installLaunchdDaemonInDomain(stdout io.Writer, executablePath string, args []string, force bool, servicePath, domain string) error {
+	target := launchdServiceTarget(domain)
+	if force {
+		if err := serveInstallRunCommand("launchctl", "bootout", target); err != nil && !isExitError(err) {
+			return fmt.Errorf("bootout launchd service %s: %w", launchdServiceName, err)
+		}
+	}
+
 	content := renderLaunchdService(executablePath, args)
 	if err := writeDaemonFile(servicePath, content, force, 0o644); err != nil {
 		return err
-	}
-
-	target := launchdServiceTarget(domain)
-	if force {
-		_ = serveInstallRunCommand("launchctl", "bootout", target)
 	}
 	if err := serveInstallRunCommand("launchctl", "enable", target); err != nil {
 		return fmt.Errorf("enable launchd service %s: %w", launchdServiceName, err)
 	}
 	if err := serveInstallRunCommand("launchctl", "bootstrap", domain, servicePath); err != nil {
 		return fmt.Errorf("bootstrap launchd service %s: %w", launchdServiceName, err)
+	}
+	if err := serveInstallRunCommand("launchctl", "kickstart", "-k", target); err != nil {
+		return fmt.Errorf("start launchd service %s: %w", launchdServiceName, err)
 	}
 
 	_, err := fmt.Fprint(stdout, renderSummaryBlock(summaryBlock{

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -587,6 +587,52 @@ func TestDaemonInstallDarwinForceDoesNotBootoutWhenStagingPlistFails(t *testing.
 	}
 }
 
+func TestDaemonInstallDarwinForceRejectsDirectoryTargetBeforeBootout(t *testing.T) {
+	tmpDir := t.TempDir()
+	plistPath := filepath.Join(tmpDir, "Library", "LaunchAgents", launchdServiceName+".plist")
+	if err := os.MkdirAll(plistPath, 0o755); err != nil {
+		t.Fatalf("mkdir launchd target dir: %v", err)
+	}
+
+	prevEUID := serveInstallEUID
+	prevUID := serveInstallUID
+	prevGOOS := serveInstallGOOS
+	prevUserHomeDir := serveInstallUserHomeDir
+	prevExecutable := serveInstallExecutablePath
+	prevRunCommand := serveInstallRunCommand
+	serveInstallEUID = func() int { return 501 }
+	serveInstallUID = func() int { return 501 }
+	serveInstallGOOS = "darwin"
+	serveInstallUserHomeDir = func() (string, error) { return tmpDir, nil }
+	serveInstallExecutablePath = func() (string, error) { return "/Users/lachlan/bin/cleanroom", nil }
+	var calls [][]string
+	serveInstallRunCommand = func(name string, args ...string) error {
+		calls = append(calls, append([]string{name}, args...))
+		return nil
+	}
+	t.Cleanup(func() {
+		serveInstallEUID = prevEUID
+		serveInstallUID = prevUID
+		serveInstallGOOS = prevGOOS
+		serveInstallUserHomeDir = prevUserHomeDir
+		serveInstallExecutablePath = prevExecutable
+		serveInstallRunCommand = prevRunCommand
+	})
+
+	stdout, _ := makeStdoutCapture(t)
+	cmd := &DaemonCommand{Action: "install", Force: true}
+	err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout})
+	if err == nil {
+		t.Fatal("expected directory target failure")
+	}
+	if !strings.Contains(err.Error(), "is a directory") {
+		t.Fatalf("expected directory target error context, got: %v", err)
+	}
+	if len(calls) != 0 {
+		t.Fatalf("did not expect launchctl calls when target is invalid, got: %v", calls)
+	}
+}
+
 func TestDaemonInstallDarwinSystemScopeUnsupported(t *testing.T) {
 	prevEUID := serveInstallEUID
 	prevGOOS := serveInstallGOOS

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -397,7 +397,7 @@ func TestDaemonInstallUsesProvidedListenInUnit(t *testing.T) {
 	}
 }
 
-func TestDaemonInstallDarwinEnablesThenBootstrapsUserService(t *testing.T) {
+func TestDaemonInstallDarwinEnablesBootstrapsAndKickstartsUserService(t *testing.T) {
 	tmpDir := t.TempDir()
 	plistPath := filepath.Join(tmpDir, "Library", "LaunchAgents", launchdServiceName+".plist")
 
@@ -435,6 +435,7 @@ func TestDaemonInstallDarwinEnablesThenBootstrapsUserService(t *testing.T) {
 	wantCalls := [][]string{
 		{"launchctl", "enable", "gui/501/" + launchdServiceName},
 		{"launchctl", "bootstrap", "gui/501", plistPath},
+		{"launchctl", "kickstart", "-k", "gui/501/" + launchdServiceName},
 	}
 	if !reflect.DeepEqual(calls, wantCalls) {
 		t.Fatalf("unexpected launchctl commands: got %v want %v", calls, wantCalls)
@@ -448,6 +449,76 @@ func TestDaemonInstallDarwinEnablesThenBootstrapsUserService(t *testing.T) {
 	}
 	if strings.Contains(string(raw), "--listen unix:///var/run/cleanroom/cleanroom.sock") {
 		t.Fatalf("did not expect user launchd plist to use system socket:\n%s", raw)
+	}
+}
+
+func TestDaemonInstallDarwinForceBootsOutBeforeRewritingAndKickstartsUserService(t *testing.T) {
+	tmpDir := t.TempDir()
+	plistPath := filepath.Join(tmpDir, "Library", "LaunchAgents", launchdServiceName+".plist")
+	if err := os.MkdirAll(filepath.Dir(plistPath), 0o755); err != nil {
+		t.Fatalf("mkdir launch agents dir: %v", err)
+	}
+	if err := os.WriteFile(plistPath, []byte("old-plist"), 0o644); err != nil {
+		t.Fatalf("write existing plist: %v", err)
+	}
+
+	prevEUID := serveInstallEUID
+	prevUID := serveInstallUID
+	prevGOOS := serveInstallGOOS
+	prevUserHomeDir := serveInstallUserHomeDir
+	prevExecutable := serveInstallExecutablePath
+	prevRunCommand := serveInstallRunCommand
+	serveInstallEUID = func() int { return 501 }
+	serveInstallUID = func() int { return 501 }
+	serveInstallGOOS = "darwin"
+	serveInstallUserHomeDir = func() (string, error) { return tmpDir, nil }
+	serveInstallExecutablePath = func() (string, error) { return "/Users/lachlan/bin/cleanroom", nil }
+	var calls [][]string
+	serveInstallRunCommand = func(name string, args ...string) error {
+		call := append([]string{name}, args...)
+		calls = append(calls, call)
+		if len(args) > 0 && args[0] == "bootout" {
+			raw, err := os.ReadFile(plistPath)
+			if err != nil {
+				t.Fatalf("read existing plist during bootout: %v", err)
+			}
+			if got := string(raw); got != "old-plist" {
+				t.Fatalf("expected force install to boot out before rewriting plist, got %q", got)
+			}
+		}
+		return nil
+	}
+	t.Cleanup(func() {
+		serveInstallEUID = prevEUID
+		serveInstallUID = prevUID
+		serveInstallGOOS = prevGOOS
+		serveInstallUserHomeDir = prevUserHomeDir
+		serveInstallExecutablePath = prevExecutable
+		serveInstallRunCommand = prevRunCommand
+	})
+
+	stdout, _ := makeStdoutCapture(t)
+	cmd := &DaemonCommand{Action: "install", Force: true}
+	if err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout}); err != nil {
+		t.Fatalf("DaemonCommand.Run returned error: %v", err)
+	}
+
+	wantCalls := [][]string{
+		{"launchctl", "bootout", "gui/501/" + launchdServiceName},
+		{"launchctl", "enable", "gui/501/" + launchdServiceName},
+		{"launchctl", "bootstrap", "gui/501", plistPath},
+		{"launchctl", "kickstart", "-k", "gui/501/" + launchdServiceName},
+	}
+	if !reflect.DeepEqual(calls, wantCalls) {
+		t.Fatalf("unexpected launchctl commands: got %v want %v", calls, wantCalls)
+	}
+
+	raw, err := os.ReadFile(plistPath)
+	if err != nil {
+		t.Fatalf("read rewritten user launchd plist: %v", err)
+	}
+	if !strings.Contains(string(raw), "/Users/lachlan/bin/cleanroom") {
+		t.Fatalf("expected force install to rewrite plist with new executable, got:\n%s", raw)
 	}
 }
 

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -522,6 +522,71 @@ func TestDaemonInstallDarwinForceBootsOutBeforeRewritingAndKickstartsUserService
 	}
 }
 
+func TestDaemonInstallDarwinForceDoesNotBootoutWhenStagingPlistFails(t *testing.T) {
+	tmpDir := t.TempDir()
+	plistPath := filepath.Join(tmpDir, "Library", "LaunchAgents", launchdServiceName+".plist")
+	if err := os.MkdirAll(filepath.Dir(plistPath), 0o755); err != nil {
+		t.Fatalf("mkdir launch agents dir: %v", err)
+	}
+	if err := os.WriteFile(plistPath, []byte("old-plist"), 0o644); err != nil {
+		t.Fatalf("write existing plist: %v", err)
+	}
+
+	prevEUID := serveInstallEUID
+	prevUID := serveInstallUID
+	prevGOOS := serveInstallGOOS
+	prevUserHomeDir := serveInstallUserHomeDir
+	prevExecutable := serveInstallExecutablePath
+	prevRunCommand := serveInstallRunCommand
+	prevWriteFile := serveInstallWriteFile
+	serveInstallEUID = func() int { return 501 }
+	serveInstallUID = func() int { return 501 }
+	serveInstallGOOS = "darwin"
+	serveInstallUserHomeDir = func() (string, error) { return tmpDir, nil }
+	serveInstallExecutablePath = func() (string, error) { return "/Users/lachlan/bin/cleanroom", nil }
+	var calls [][]string
+	serveInstallRunCommand = func(name string, args ...string) error {
+		calls = append(calls, append([]string{name}, args...))
+		return nil
+	}
+	serveInstallWriteFile = func(path string, data []byte, mode os.FileMode) error {
+		if path == plistPath {
+			return os.WriteFile(path, data, mode)
+		}
+		return errors.New("disk full")
+	}
+	t.Cleanup(func() {
+		serveInstallEUID = prevEUID
+		serveInstallUID = prevUID
+		serveInstallGOOS = prevGOOS
+		serveInstallUserHomeDir = prevUserHomeDir
+		serveInstallExecutablePath = prevExecutable
+		serveInstallRunCommand = prevRunCommand
+		serveInstallWriteFile = prevWriteFile
+	})
+
+	stdout, _ := makeStdoutCapture(t)
+	cmd := &DaemonCommand{Action: "install", Force: true}
+	err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout})
+	if err == nil {
+		t.Fatal("expected staged plist write failure")
+	}
+	if !strings.Contains(err.Error(), "stage daemon service file") {
+		t.Fatalf("expected staged plist error context, got: %v", err)
+	}
+	if len(calls) != 0 {
+		t.Fatalf("did not expect launchctl calls when staging plist fails, got: %v", calls)
+	}
+
+	raw, readErr := os.ReadFile(plistPath)
+	if readErr != nil {
+		t.Fatalf("read existing plist after failed force install: %v", readErr)
+	}
+	if got := string(raw); got != "old-plist" {
+		t.Fatalf("expected existing plist to remain unchanged after failed force install, got %q", got)
+	}
+}
+
 func TestDaemonInstallDarwinSystemScopeUnsupported(t *testing.T) {
 	prevEUID := serveInstallEUID
 	prevGOOS := serveInstallGOOS


### PR DESCRIPTION
## Summary
- boot out an existing launchd service before rewriting its plist during `cleanroom daemon install --force`
- kickstart the launchd service after `bootstrap` so `cleanroom daemon install` leaves a live daemon behind
- add regression coverage for fresh install and in-place upgrade flows on macOS

## Testing
- `mise exec -- go test ./internal/cli -run 'TestDaemonInstallDarwin|TestDaemonStartLaunchd|TestDaemonUninstallLaunchd|TestDaemonStatusLaunchd'`
- manual macOS validation of `~/bin/cleanroom daemon install`, `~/bin/cleanroom daemon install --force`, and post-install `exec` calls through the daemon