### PR TITLE
test: harden release readiness coverage

### DIFF
--- a/cmd/cleanroom-vmnet-echo/main.go
+++ b/cmd/cleanroom-vmnet-echo/main.go
@@ -9,26 +9,41 @@ import (
 )
 
 func main() {
-	listenAddr := flag.String("listen", ":18080", "tcp listen address")
-	response := flag.String("response", "ok\n", "response written to the first client")
-	flag.Parse()
+	os.Exit(run(os.Args[1:], os.Stderr))
+}
+
+func run(args []string, stderr io.Writer) int {
+	flags := flag.NewFlagSet("cleanroom-vmnet-echo", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+
+	listenAddr := flags.String("listen", ":18080", "tcp listen address")
+	response := flags.String("response", "ok\n", "response written to the first client")
+	if err := flags.Parse(args); err != nil {
+		return 2
+	}
 
 	listener, err := net.Listen("tcp", *listenAddr)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "listen %q: %v\n", *listenAddr, err)
-		os.Exit(1)
+		fmt.Fprintf(stderr, "listen %q: %v\n", *listenAddr, err)
+		return 1
 	}
-	defer listener.Close()
+	if err := serve(listener, *response); err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	return 0
+}
 
+func serve(listener net.Listener, response string) error {
+	defer listener.Close()
 	conn, err := listener.Accept()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "accept %q: %v\n", *listenAddr, err)
-		os.Exit(1)
+		return fmt.Errorf("accept %q: %w", listener.Addr().String(), err)
 	}
 	defer conn.Close()
 
-	if _, err := io.WriteString(conn, *response); err != nil {
-		fmt.Fprintf(os.Stderr, "write response: %v\n", err)
-		os.Exit(1)
+	if _, err := io.WriteString(conn, response); err != nil {
+		return fmt.Errorf("write response: %w", err)
 	}
+	return nil
 }

--- a/cmd/cleanroom-vmnet-echo/main_test.go
+++ b/cmd/cleanroom-vmnet-echo/main_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"strings"
+	"testing"
+)
+
+func TestServeWritesConfiguredResponse(t *testing.T) {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen returned error: %v", err)
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- serve(listener, "pong\n")
+	}()
+
+	conn, err := net.Dial("tcp", listener.Addr().String())
+	if err != nil {
+		t.Fatalf("Dial returned error: %v", err)
+	}
+	defer conn.Close()
+
+	body, err := io.ReadAll(conn)
+	if err != nil {
+		t.Fatalf("ReadAll returned error: %v", err)
+	}
+	if got, want := string(body), "pong\n"; got != want {
+		t.Fatalf("unexpected response body: got %q want %q", got, want)
+	}
+
+	if err := <-errCh; err != nil {
+		t.Fatalf("serve returned error: %v", err)
+	}
+}
+
+func TestRunRejectsUnknownFlags(t *testing.T) {
+	t.Helper()
+
+	var stderr bytes.Buffer
+	if got, want := run([]string{"--unknown-flag"}, &stderr), 2; got != want {
+		t.Fatalf("unexpected exit code: got %d want %d", got, want)
+	}
+	if !strings.Contains(stderr.String(), "flag provided but not defined") {
+		t.Fatalf("expected flag parse error, got %q", stderr.String())
+	}
+}
+
+func TestRunReportsListenFailures(t *testing.T) {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen returned error: %v", err)
+	}
+	defer listener.Close()
+
+	var stderr bytes.Buffer
+	if got, want := run([]string{"--listen", listener.Addr().String()}, &stderr), 1; got != want {
+		t.Fatalf("unexpected exit code: got %d want %d", got, want)
+	}
+	if !strings.Contains(stderr.String(), "listen") {
+		t.Fatalf("expected listen error in stderr, got %q", stderr.String())
+	}
+}

--- a/internal/cli/execution_integration_test.go
+++ b/internal/cli/execution_integration_test.go
@@ -1,0 +1,180 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+)
+
+func runExecutionInspectWithCapture(cmd ExecutionInspectCommand, ctx runtimeContext) execOutcome {
+	return runWithCapture(func(runCtx *runtimeContext) error {
+		return cmd.Run(runCtx)
+	}, nil, ctx)
+}
+
+func TestExecutionInspectIntegrationShowsExecutionDetails(t *testing.T) {
+	t.Helper()
+
+	runDir := filepath.Join(t.TempDir(), "artifacts")
+	if err := os.MkdirAll(runDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll returned error: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(runDir, "execution-observability.json"),
+		[]byte(`{"total_ms":12,"guest_exec_ms":7}`),
+		0o644,
+	); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+
+	adapter := &integrationAdapter{
+		runFn: func(_ context.Context, req backend.ExecutionRequest) (*backend.ExecutionResult, error) {
+			return &backend.ExecutionResult{
+				ExecutionID: req.ExecutionID,
+				ExitCode:    0,
+				Stdout:      "hello\n",
+				Stderr:      "warn\n",
+				RunDir:      runDir,
+				PlanPath:    "/tmp/plan.json",
+				ImageRef:    "ghcr.io/buildkite/cleanroom-base/alpine@sha256:abc",
+				ImageDigest: "sha256:abc",
+				Message:     "command completed",
+			}, nil
+		},
+	}
+
+	host, svc := startIntegrationServer(t, adapter)
+	client := mustNewControlClient(t, host)
+	sandboxID := mustCreateSandbox(t, client)
+
+	createResp, err := client.CreateExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
+		SandboxId: sandboxID,
+		Command:   []string{"echo", "ok"},
+		Kind:      cleanroomv1.ExecutionKind_EXECUTION_KIND_BATCH,
+	})
+	if err != nil {
+		t.Fatalf("CreateExecution returned error: %v", err)
+	}
+	executionID := createResp.GetExecution().GetExecutionId()
+	if _, err := svc.WaitExecution(context.Background(), sandboxID, executionID); err != nil {
+		t.Fatalf("WaitExecution returned error: %v", err)
+	}
+
+	outcome := runExecutionInspectWithCapture(ExecutionInspectCommand{
+		clientFlags: clientFlags{Host: host},
+		SandboxID:   sandboxID,
+		ExecutionID: executionID,
+	}, runtimeContext{CWD: t.TempDir()})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err != nil {
+		t.Fatalf("ExecutionInspectCommand.Run returned error: %v", outcome.err)
+	}
+
+	assertContainsAll(
+		t,
+		outcome.stdout,
+		"execution: "+executionID,
+		"sandbox: "+sandboxID,
+		"status: succeeded",
+		"kind: batch",
+		"exit_code: 0",
+		"message: command completed",
+		"artifacts_dir: "+runDir,
+		"plan_path: /tmp/plan.json",
+		"image_ref: ghcr.io/buildkite/cleanroom-base/alpine@sha256:abc",
+		"image_digest: sha256:abc",
+		"\nstderr:\nwarn\n",
+		"\nstdout:\nhello\n",
+		"\nobservability:\n",
+		`"total_ms": 12`,
+		`"guest_exec_ms": 7`,
+	)
+}
+
+func TestExecutionInspectIntegrationSupportsLastAndJSON(t *testing.T) {
+	t.Helper()
+
+	adapter := &integrationAdapter{
+		runFn: func(_ context.Context, req backend.ExecutionRequest) (*backend.ExecutionResult, error) {
+			return &backend.ExecutionResult{
+				ExecutionID: req.ExecutionID,
+				ExitCode:    0,
+				Stdout:      "hello\n",
+				Message:     "done",
+			}, nil
+		},
+	}
+
+	host, svc := startIntegrationServer(t, adapter)
+	client := mustNewControlClient(t, host)
+	sandboxID := mustCreateSandbox(t, client)
+
+	createResp, err := client.CreateExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
+		SandboxId: sandboxID,
+		Command:   []string{"echo", "ok"},
+		Kind:      cleanroomv1.ExecutionKind_EXECUTION_KIND_BATCH,
+	})
+	if err != nil {
+		t.Fatalf("CreateExecution returned error: %v", err)
+	}
+	executionID := createResp.GetExecution().GetExecutionId()
+	if _, err := svc.WaitExecution(context.Background(), sandboxID, executionID); err != nil {
+		t.Fatalf("WaitExecution returned error: %v", err)
+	}
+
+	outcome := runExecutionInspectWithCapture(ExecutionInspectCommand{
+		clientFlags: clientFlags{Host: host},
+		SandboxID:   sandboxID,
+		Last:        true,
+		JSON:        true,
+	}, runtimeContext{CWD: t.TempDir()})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err != nil {
+		t.Fatalf("ExecutionInspectCommand.Run returned error: %v", outcome.err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(outcome.stdout), &payload); err != nil {
+		t.Fatalf("Unmarshal returned error: %v", err)
+	}
+
+	execution, ok := payload["execution"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected execution object, got %#v", payload["execution"])
+	}
+	if got, want := strings.TrimSpace(execution["execution_id"].(string)), executionID; got != want {
+		t.Fatalf("unexpected execution id: got %q want %q", got, want)
+	}
+	if got, want := strings.TrimSpace(execution["sandbox_id"].(string)), sandboxID; got != want {
+		t.Fatalf("unexpected sandbox id: got %q want %q", got, want)
+	}
+}
+
+func TestExecutionInspectCommandRejectsMutuallyExclusiveFlags(t *testing.T) {
+	t.Helper()
+
+	outcome := runExecutionInspectWithCapture(ExecutionInspectCommand{
+		SandboxID:   "sbx_123",
+		ExecutionID: "exe_123",
+		Last:        true,
+	}, runtimeContext{CWD: t.TempDir()})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err == nil {
+		t.Fatal("expected validation error")
+	}
+	if !strings.Contains(outcome.err.Error(), "choose either <execution-id> or --last") {
+		t.Fatalf("unexpected validation error: %v", outcome.err)
+	}
+}

--- a/internal/controlclient/client_test.go
+++ b/internal/controlclient/client_test.go
@@ -1,0 +1,75 @@
+package controlclient
+
+import (
+	"crypto/tls"
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/endpoint"
+	"github.com/buildkite/cleanroom/internal/tlsconfig"
+	"golang.org/x/net/http2"
+)
+
+func TestBuildTransportHTTPSLoadsDiscoveredCA(t *testing.T) {
+	t.Helper()
+
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	writeTLSMaterial(t, configHome, net.ParseIP("127.0.0.1"))
+
+	rt, err := buildTransport(endpoint.Endpoint{Scheme: "https"}, "https://127.0.0.1:8443", tlsconfig.Options{})
+	if err != nil {
+		t.Fatalf("buildTransport returned error: %v", err)
+	}
+
+	transport, ok := rt.(*http.Transport)
+	if !ok {
+		t.Fatalf("expected *http.Transport, got %T", rt)
+	}
+	if got, want := transport.TLSClientConfig.MinVersion, uint16(tls.VersionTLS13); got != want {
+		t.Fatalf("unexpected min TLS version: got %d want %d", got, want)
+	}
+	if transport.TLSClientConfig.RootCAs == nil {
+		t.Fatal("expected discovered client CA pool")
+	}
+}
+
+func TestBuildTransportUnixUsesHTTP2Transport(t *testing.T) {
+	t.Helper()
+
+	rt, err := buildTransport(endpoint.Endpoint{
+		Scheme:  "unix",
+		Address: "/tmp/cleanroom.sock",
+	}, "http://unix", tlsconfig.Options{})
+	if err != nil {
+		t.Fatalf("buildTransport returned error: %v", err)
+	}
+	if _, ok := rt.(*http2.Transport); !ok {
+		t.Fatalf("expected *http2.Transport, got %T", rt)
+	}
+}
+
+func TestBuildTransportHTTPUsesHTTP2Transport(t *testing.T) {
+	t.Helper()
+
+	rt, err := buildTransport(endpoint.Endpoint{Scheme: "http"}, "http://127.0.0.1:8080", tlsconfig.Options{})
+	if err != nil {
+		t.Fatalf("buildTransport returned error: %v", err)
+	}
+	if _, ok := rt.(*http2.Transport); !ok {
+		t.Fatalf("expected *http2.Transport, got %T", rt)
+	}
+}
+
+func TestBuildTransportFallsBackToHTTPTransportOnInvalidBaseURL(t *testing.T) {
+	t.Helper()
+
+	rt, err := buildTransport(endpoint.Endpoint{Scheme: "http"}, "://not-a-url", tlsconfig.Options{})
+	if err != nil {
+		t.Fatalf("buildTransport returned error: %v", err)
+	}
+	if _, ok := rt.(*http.Transport); !ok {
+		t.Fatalf("expected *http.Transport, got %T", rt)
+	}
+}

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -1,0 +1,148 @@
+package paths
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestBaseDirsPreferExplicitXDGHomes(t *testing.T) {
+	t.Helper()
+
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CACHE_HOME", "/xdg/cache")
+	t.Setenv("XDG_STATE_HOME", "/xdg/state")
+	t.Setenv("XDG_DATA_HOME", "/xdg/data")
+	t.Setenv("XDG_CONFIG_HOME", "/xdg/config")
+
+	cacheDir, err := CacheBaseDir()
+	if err != nil {
+		t.Fatalf("CacheBaseDir returned error: %v", err)
+	}
+	if got, want := cacheDir, "/xdg/cache/cleanroom"; got != want {
+		t.Fatalf("unexpected cache dir: got %q want %q", got, want)
+	}
+
+	stateDir, err := StateBaseDir()
+	if err != nil {
+		t.Fatalf("StateBaseDir returned error: %v", err)
+	}
+	if got, want := stateDir, "/xdg/state/cleanroom"; got != want {
+		t.Fatalf("unexpected state dir: got %q want %q", got, want)
+	}
+
+	dataDir, err := DataBaseDir()
+	if err != nil {
+		t.Fatalf("DataBaseDir returned error: %v", err)
+	}
+	if got, want := dataDir, "/xdg/data/cleanroom"; got != want {
+		t.Fatalf("unexpected data dir: got %q want %q", got, want)
+	}
+
+	tlsDir, err := TLSDir()
+	if err != nil {
+		t.Fatalf("TLSDir returned error: %v", err)
+	}
+	if got, want := tlsDir, "/xdg/config/cleanroom/tls"; got != want {
+		t.Fatalf("unexpected tls dir: got %q want %q", got, want)
+	}
+}
+
+func TestBaseDirsFallBackToHomeDirectories(t *testing.T) {
+	t.Helper()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CACHE_HOME", "")
+	t.Setenv("XDG_STATE_HOME", "")
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	cacheDir, err := CacheBaseDir()
+	if err != nil {
+		t.Fatalf("CacheBaseDir returned error: %v", err)
+	}
+	if got, want := cacheDir, filepath.Join(home, ".cache", "cleanroom"); got != want {
+		t.Fatalf("unexpected cache dir: got %q want %q", got, want)
+	}
+
+	stateDir, err := StateBaseDir()
+	if err != nil {
+		t.Fatalf("StateBaseDir returned error: %v", err)
+	}
+	if got, want := stateDir, filepath.Join(home, ".local", "state", "cleanroom"); got != want {
+		t.Fatalf("unexpected state dir: got %q want %q", got, want)
+	}
+
+	dataDir, err := DataBaseDir()
+	if err != nil {
+		t.Fatalf("DataBaseDir returned error: %v", err)
+	}
+	if got, want := dataDir, filepath.Join(home, ".local", "share", "cleanroom"); got != want {
+		t.Fatalf("unexpected data dir: got %q want %q", got, want)
+	}
+
+	tlsDir, err := TLSDir()
+	if err != nil {
+		t.Fatalf("TLSDir returned error: %v", err)
+	}
+	if got, want := tlsDir, filepath.Join(home, ".config", "cleanroom", "tls"); got != want {
+		t.Fatalf("unexpected tls dir: got %q want %q", got, want)
+	}
+}
+
+func TestDerivedPathsUseResolvedBaseDirectories(t *testing.T) {
+	t.Helper()
+
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CACHE_HOME", "/xdg/cache")
+	t.Setenv("XDG_STATE_HOME", "/xdg/state")
+	t.Setenv("XDG_DATA_HOME", "/xdg/data")
+
+	imageCacheDir, err := ImageCacheDir()
+	if err != nil {
+		t.Fatalf("ImageCacheDir returned error: %v", err)
+	}
+	if got, want := imageCacheDir, "/xdg/cache/cleanroom/images"; got != want {
+		t.Fatalf("unexpected image cache dir: got %q want %q", got, want)
+	}
+
+	imageMetadataDBPath, err := ImageMetadataDBPath()
+	if err != nil {
+		t.Fatalf("ImageMetadataDBPath returned error: %v", err)
+	}
+	if got, want := imageMetadataDBPath, "/xdg/state/cleanroom/images/metadata.db"; got != want {
+		t.Fatalf("unexpected image metadata db path: got %q want %q", got, want)
+	}
+
+	executionBaseDir, err := ExecutionBaseDir()
+	if err != nil {
+		t.Fatalf("ExecutionBaseDir returned error: %v", err)
+	}
+	if got, want := executionBaseDir, "/xdg/state/cleanroom/executions"; got != want {
+		t.Fatalf("unexpected execution base dir: got %q want %q", got, want)
+	}
+
+	snapshotDir, err := SnapshotDir()
+	if err != nil {
+		t.Fatalf("SnapshotDir returned error: %v", err)
+	}
+	if got, want := snapshotDir, "/xdg/state/cleanroom/snapshots"; got != want {
+		t.Fatalf("unexpected snapshot dir: got %q want %q", got, want)
+	}
+
+	snapshotMetadataDBPath, err := SnapshotMetadataDBPath()
+	if err != nil {
+		t.Fatalf("SnapshotMetadataDBPath returned error: %v", err)
+	}
+	if got, want := snapshotMetadataDBPath, "/xdg/state/cleanroom/snapshots/metadata.db"; got != want {
+		t.Fatalf("unexpected snapshot metadata db path: got %q want %q", got, want)
+	}
+
+	assetsDir, err := AssetsDir()
+	if err != nil {
+		t.Fatalf("AssetsDir returned error: %v", err)
+	}
+	if got, want := assetsDir, "/xdg/data/cleanroom/assets"; got != want {
+		t.Fatalf("unexpected assets dir: got %q want %q", got, want)
+	}
+}

--- a/internal/repositorycheckout/checkout_test.go
+++ b/internal/repositorycheckout/checkout_test.go
@@ -75,3 +75,52 @@ func TestNormalizeRemoteURLPreservesIPv6Brackets(t *testing.T) {
 		t.Fatalf("unexpected normalized URL: got %q want %q", got, want)
 	}
 }
+
+func TestBuildBootstrapCommandIncludesSubmoduleUpdateWhenRequested(t *testing.T) {
+	command := BuildBootstrapCommand(&Checkout{
+		RemoteURL:      "https://github.com/buildkite/cleanroom.git",
+		CommitSHA:      "0123456789abcdef0123456789abcdef01234567",
+		DestinationDir: "/workspace",
+		Submodules:     true,
+	})
+
+	joined := strings.Join(command, " ")
+	if !strings.Contains(joined, `git -C "$dest" submodule update --init --recursive`) {
+		t.Fatalf("expected bootstrap command to update submodules, got %q", joined)
+	}
+}
+
+func TestWrapCommandInWorkdirQuotesDestinationAndArguments(t *testing.T) {
+	command := WrapCommandInWorkdir([]string{"printf", "%s", "it's alive"}, &Checkout{
+		DestinationDir: "/tmp/work tree",
+	})
+
+	joined := strings.Join(command, " ")
+	if !strings.Contains(joined, "cd '/tmp/work tree' && exec 'printf' '%s' 'it'\"'\"'s alive'") {
+		t.Fatalf("expected wrapped workdir command to quote args, got %q", joined)
+	}
+}
+
+func TestNormalizeCommandReturnsDetachedCopyWithoutSeparator(t *testing.T) {
+	original := []string{"--", "sh", "-lc", "pwd"}
+	normalized := NormalizeCommand(original)
+	original[1] = "mutated"
+
+	if got, want := strings.Join(normalized, " "), "sh -lc pwd"; got != want {
+		t.Fatalf("unexpected normalized command: got %q want %q", got, want)
+	}
+}
+
+func TestShellJoinQuotesSingleQuotes(t *testing.T) {
+	got := shellJoin([]string{"echo", "it's"})
+	if want := `'echo' 'it'"'"'s'`; got != want {
+		t.Fatalf("unexpected shell join: got %q want %q", got, want)
+	}
+}
+
+func TestWrapCommandWithBootstrapNormalizesPassthroughWithoutCheckout(t *testing.T) {
+	command := WrapCommandWithBootstrap([]string{"--", "echo", "ok"}, nil)
+	if got, want := strings.Join(command, " "), "echo ok"; got != want {
+		t.Fatalf("unexpected normalized command: got %q want %q", got, want)
+	}
+}

--- a/internal/tlsconfig/tlsconfig_test.go
+++ b/internal/tlsconfig/tlsconfig_test.go
@@ -1,0 +1,191 @@
+package tlsconfig
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestResolveServerReturnsNilWithoutCompletePair(t *testing.T) {
+	t.Helper()
+
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+
+	tlsDir := filepath.Join(configHome, "cleanroom", "tls")
+	if err := os.MkdirAll(tlsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll returned error: %v", err)
+	}
+	writePEMFile(t, filepath.Join(tlsDir, "server.pem"), "CERTIFICATE", []byte("not-a-cert"))
+
+	cfg, err := ResolveServer(Options{})
+	if err != nil {
+		t.Fatalf("ResolveServer returned error: %v", err)
+	}
+	if cfg != nil {
+		t.Fatalf("expected nil server config when key pair is incomplete, got %#v", cfg)
+	}
+}
+
+func TestResolveServerDiscoversCertificatePair(t *testing.T) {
+	t.Helper()
+
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+
+	writeServerTLSMaterial(t, configHome, net.ParseIP("127.0.0.1"))
+
+	cfg, err := ResolveServer(Options{})
+	if err != nil {
+		t.Fatalf("ResolveServer returned error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected discovered server TLS config")
+	}
+	if got, want := len(cfg.Certificates), 1; got != want {
+		t.Fatalf("unexpected certificate count: got %d want %d", got, want)
+	}
+}
+
+func TestResolveClientRejectsClientCertificates(t *testing.T) {
+	t.Helper()
+
+	_, err := ResolveClient(Options{CertPath: "/tmp/client.pem"})
+	if err == nil {
+		t.Fatal("expected client certificate rejection")
+	}
+	if !strings.Contains(err.Error(), "client certificates are not supported") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestResolveClientLoadsExplicitCA(t *testing.T) {
+	t.Helper()
+
+	caPath := filepath.Join(t.TempDir(), "ca.pem")
+	writeCACertificate(t, caPath)
+
+	cfg, err := ResolveClient(Options{CAPath: caPath})
+	if err != nil {
+		t.Fatalf("ResolveClient returned error: %v", err)
+	}
+	if cfg == nil || cfg.RootCAs == nil {
+		t.Fatalf("expected client RootCAs, got %#v", cfg)
+	}
+}
+
+func TestResolveClientDiscoversCAFromXDGConfig(t *testing.T) {
+	t.Helper()
+
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+
+	tlsDir := filepath.Join(configHome, "cleanroom", "tls")
+	if err := os.MkdirAll(tlsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll returned error: %v", err)
+	}
+	writeCACertificate(t, filepath.Join(tlsDir, "ca.pem"))
+
+	cfg, err := ResolveClient(Options{})
+	if err != nil {
+		t.Fatalf("ResolveClient returned error: %v", err)
+	}
+	if cfg == nil || cfg.RootCAs == nil {
+		t.Fatalf("expected discovered client RootCAs, got %#v", cfg)
+	}
+}
+
+func TestResolveClientRejectsInvalidCAFile(t *testing.T) {
+	t.Helper()
+
+	caPath := filepath.Join(t.TempDir(), "ca.pem")
+	if err := os.WriteFile(caPath, []byte("not-a-certificate"), 0o600); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+
+	_, err := ResolveClient(Options{CAPath: caPath})
+	if err == nil {
+		t.Fatal("expected invalid CA error")
+	}
+	if !strings.Contains(err.Error(), "no valid certificates") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func writeServerTLSMaterial(t *testing.T, configHome string, ip net.IP) {
+	t.Helper()
+
+	tlsDir := filepath.Join(configHome, "cleanroom", "tls")
+	if err := os.MkdirAll(tlsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll returned error: %v", err)
+	}
+
+	now := time.Now().UTC()
+	serverKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey returned error: %v", err)
+	}
+	serverTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "127.0.0.1"},
+		NotBefore:    now.Add(-1 * time.Minute),
+		NotAfter:     now.Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{ip},
+		DNSNames:     []string{"localhost"},
+	}
+	serverDER, err := x509.CreateCertificate(rand.Reader, serverTemplate, serverTemplate, &serverKey.PublicKey, serverKey)
+	if err != nil {
+		t.Fatalf("CreateCertificate returned error: %v", err)
+	}
+	serverKeyDER, err := x509.MarshalECPrivateKey(serverKey)
+	if err != nil {
+		t.Fatalf("MarshalECPrivateKey returned error: %v", err)
+	}
+
+	writePEMFile(t, filepath.Join(tlsDir, "server.pem"), "CERTIFICATE", serverDER)
+	writePEMFile(t, filepath.Join(tlsDir, "server.key"), "EC PRIVATE KEY", serverKeyDER)
+}
+
+func writeCACertificate(t *testing.T, path string) {
+	t.Helper()
+
+	now := time.Now().UTC()
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey returned error: %v", err)
+	}
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "cleanroom-test-ca"},
+		NotBefore:             now.Add(-1 * time.Minute),
+		NotAfter:              now.Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("CreateCertificate returned error: %v", err)
+	}
+	writePEMFile(t, path, "CERTIFICATE", caDER)
+}
+
+func writePEMFile(t *testing.T, path, blockType string, der []byte) {
+	t.Helper()
+
+	if err := os.WriteFile(path, pem.EncodeToMemory(&pem.Block{Type: blockType, Bytes: der}), 0o600); err != nil {
+		t.Fatalf("WriteFile(%s) returned error: %v", path, err)
+	}
+}

--- a/scripts/ci-cleanroom-e2e.sh
+++ b/scripts/ci-cleanroom-e2e.sh
@@ -1,19 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-KERNEL_IMAGE="${CLEANROOM_KERNEL_IMAGE:-}"
-FIRECRACKER_BINARY="${CLEANROOM_FIRECRACKER_BINARY:-firecracker}"
-PRIVILEGED_HELPER_PATH="${CLEANROOM_PRIVILEGED_HELPER_PATH:-/usr/local/sbin/cleanroom-root-helper}"
-
 ROOT_HELPER_REQUIRED_CAPABILITIES=(
   firecracker-network
   firecracker-rootfs
 )
-
-if [[ -z "$KERNEL_IMAGE" ]]; then
-  echo "CLEANROOM_KERNEL_IMAGE is required for Firecracker e2e CI" >&2
-  exit 1
-fi
 
 # run_privileged executes a privileged command via the installed root helper.
 run_privileged() {
@@ -125,15 +116,6 @@ purge_stale_cleanroom_resources() {
   done
 }
 
-verify_helper_capabilities
-
-echo "--- :broom: Pre-build cleanup"
-purge_stale_cleanroom_resources
-
-echo "--- :hammer: Building binaries"
-scripts/build-go.sh
-
-tmpdir="$(mktemp -d)"
 cleanup() {
   if [[ -n "${srv_pid:-}" ]]; then
     kill "$srv_pid" >/dev/null 2>&1 || true
@@ -145,16 +127,36 @@ cleanup() {
   purge_stale_cleanroom_resources 2>/dev/null || true
   rm -rf "$tmpdir"
 }
-trap cleanup EXIT
 
-export XDG_CONFIG_HOME="$tmpdir/config"
-export XDG_STATE_HOME="$tmpdir/state"
-export XDG_RUNTIME_DIR="$tmpdir/runtime"
-export XDG_DATA_HOME="$tmpdir/data"
+main() {
+  KERNEL_IMAGE="${CLEANROOM_KERNEL_IMAGE:-}"
+  FIRECRACKER_BINARY="${CLEANROOM_FIRECRACKER_BINARY:-firecracker}"
+  PRIVILEGED_HELPER_PATH="${CLEANROOM_PRIVILEGED_HELPER_PATH:-/usr/local/sbin/cleanroom-root-helper}"
 
-mkdir -p "$XDG_CONFIG_HOME" "$XDG_STATE_HOME" "$XDG_RUNTIME_DIR" "$XDG_DATA_HOME"
-mkdir -p "$XDG_CONFIG_HOME/cleanroom"
-cat > "$XDG_CONFIG_HOME/cleanroom/config.yaml" <<EOF
+  if [[ -z "$KERNEL_IMAGE" ]]; then
+    echo "CLEANROOM_KERNEL_IMAGE is required for Firecracker e2e CI" >&2
+    exit 1
+  fi
+
+  verify_helper_capabilities
+
+  echo "--- :broom: Pre-build cleanup"
+  purge_stale_cleanroom_resources
+
+  echo "--- :hammer: Building binaries"
+  scripts/build-go.sh
+
+  tmpdir="$(mktemp -d)"
+  trap cleanup EXIT
+
+  export XDG_CONFIG_HOME="$tmpdir/config"
+  export XDG_STATE_HOME="$tmpdir/state"
+  export XDG_RUNTIME_DIR="$tmpdir/runtime"
+  export XDG_DATA_HOME="$tmpdir/data"
+
+  mkdir -p "$XDG_CONFIG_HOME" "$XDG_STATE_HOME" "$XDG_RUNTIME_DIR" "$XDG_DATA_HOME"
+  mkdir -p "$XDG_CONFIG_HOME/cleanroom"
+  cat > "$XDG_CONFIG_HOME/cleanroom/config.yaml" <<EOF
 default_backend: firecracker
 backends:
   firecracker:
@@ -165,17 +167,17 @@ backends:
     launch_seconds: 90
 EOF
 
-echo "    privileged_helper_path: $PRIVILEGED_HELPER_PATH" >> "$XDG_CONFIG_HOME/cleanroom/config.yaml"
+  echo "    privileged_helper_path: $PRIVILEGED_HELPER_PATH" >> "$XDG_CONFIG_HOME/cleanroom/config.yaml"
 
-echo "--- :stethoscope: Doctor"
-./dist/cleanroom doctor --json | tee "$tmpdir/doctor.json"
-if grep -q '"status": "fail"' "$tmpdir/doctor.json"; then
-  echo "doctor checks reported failures" >&2
-  exit 1
-fi
+  echo "--- :stethoscope: Doctor"
+  ./dist/cleanroom doctor --json | tee "$tmpdir/doctor.json"
+  if grep -q '"status": "fail"' "$tmpdir/doctor.json"; then
+    echo "doctor checks reported failures" >&2
+    exit 1
+  fi
 
-socket_path="$tmpdir/cleanroom.sock"
-listen_endpoint="unix://$socket_path"
+  socket_path="$tmpdir/cleanroom.sock"
+  listen_endpoint="unix://$socket_path"
 
 dump_runtime_diagnostics() {
   local server_lines="${1:-40}"
@@ -198,22 +200,22 @@ dump_runtime_diagnostics() {
   fi
 }
 
-echo "--- :rocket: Start cleanroom control-plane"
-./dist/cleanroom serve --listen "$listen_endpoint" --gateway-listen ":0" >"$tmpdir/server.log" 2>&1 &
-srv_pid=$!
+  echo "--- :rocket: Start cleanroom control-plane"
+  ./dist/cleanroom serve --listen "$listen_endpoint" --gateway-listen ":0" >"$tmpdir/server.log" 2>&1 &
+  srv_pid=$!
 
-for _ in $(seq 1 40); do
-  if [[ -S "$socket_path" ]]; then
-    break
+  for _ in $(seq 1 40); do
+    if [[ -S "$socket_path" ]]; then
+      break
+    fi
+    sleep 0.25
+  done
+  if [[ ! -S "$socket_path" ]]; then
+    echo "cleanroom server did not create unix socket: $socket_path" >&2
+    echo "server log:" >&2
+    cat "$tmpdir/server.log" >&2
+    exit 1
   fi
-  sleep 0.25
-done
-if [[ ! -S "$socket_path" ]]; then
-  echo "cleanroom server did not create unix socket: $socket_path" >&2
-  echo "server log:" >&2
-  cat "$tmpdir/server.log" >&2
-  exit 1
-fi
 
 echo "--- :white_check_mark: Launched execution smoke test"
 smoke_attempt=1
@@ -555,4 +557,9 @@ EOF
   fi
 fi
 
-echo "Firecracker e2e checks passed"
+  echo "Firecracker e2e checks passed"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/scripts/ci-darwin-vz-vmnet-e2e.sh
+++ b/scripts/ci-darwin-vz-vmnet-e2e.sh
@@ -155,75 +155,81 @@ cleanup() {
   rm -rf "${tmpdir:-}"
 }
 
-require_command security
-require_command curl
-require_command openssl
-require_command codesign
-require_command sudo
+main() {
+  require_command security
+  require_command curl
+  require_command openssl
+  require_command codesign
+  require_command sudo
 
-tmpdir="$(mktemp -d /tmp/cleanroom-dvz-vmnet-e2e.XXXXXX)"
-trap cleanup EXIT
+  tmpdir="$(mktemp -d /tmp/cleanroom-dvz-vmnet-e2e.XXXXXX)"
+  trap cleanup EXIT
 
-macos_user_name="$(resolve_macos_user_name)"
-macos_user_home="$(resolve_macos_user_home)"
+  macos_user_name="$(resolve_macos_user_name)"
+  macos_user_home="$(resolve_macos_user_home)"
 
-p12_path="$tmpdir/helper-cert.p12"
-profile_path="$tmpdir/helper.provisionprofile"
-decoded_profile_path="$tmpdir/helper.provisionprofile.plist"
-wwdr_path="$tmpdir/AppleWWDRCAG3.cer"
-wwdr_fingerprint=""
-wwdr_added_to_system_keychain=0
-system_keychain_path="/Library/Keychains/System.keychain"
-imported_system_identity_hash=""
-xdg_state_home_path="${XDG_STATE_HOME:-$HOME/.local/state}"
-cleanup_xdg_state_home=0
-sign_identity=""
-sign_keychain=""
-p12_password=""
-helper_path="$(resolve_local_helper_path)"
+  p12_path="$tmpdir/helper-cert.p12"
+  profile_path="$tmpdir/helper.provisionprofile"
+  decoded_profile_path="$tmpdir/helper.provisionprofile.plist"
+  wwdr_path="$tmpdir/AppleWWDRCAG3.cer"
+  wwdr_fingerprint=""
+  wwdr_added_to_system_keychain=0
+  system_keychain_path="/Library/Keychains/System.keychain"
+  imported_system_identity_hash=""
+  xdg_state_home_path="${XDG_STATE_HOME:-$HOME/.local/state}"
+  cleanup_xdg_state_home=0
+  sign_identity=""
+  sign_keychain=""
+  p12_password=""
+  helper_path="$(resolve_local_helper_path)"
 
-if [[ -z "${BUILDKITE:-}" ]]; then
-  setup_local_signing_assets
-else
-  setup_buildkite_runtime_paths
-  setup_buildkite_signing_assets
-fi
-assert_profile_allows_current_device
+  if [[ -z "${BUILDKITE:-}" ]]; then
+    setup_local_signing_assets
+  else
+    setup_buildkite_runtime_paths
+    setup_buildkite_signing_assets
+  fi
+  assert_profile_allows_current_device
 
-echo "--- :hammer: Building binaries"
-cd "$REPO_ROOT"
-scripts/build-go.sh
+  echo "--- :hammer: Building binaries"
+  cd "$REPO_ROOT"
+  scripts/build-go.sh
 
-if [[ ! -d "$helper_path" ]]; then
-  [[ -n "$profile_path" ]] || {
-    echo "vmnet helper bundle is missing: $helper_path" >&2
-    echo "Set CLEANROOM_DARWIN_VZ_HELPER to a prebuilt signed helper bundle or provide CLEANROOM_DARWIN_VZ_HELPER_PROVISION_PROFILE and CLEANROOM_DARWIN_VZ_HELPER_SIGN_IDENTITY." >&2
+  if [[ ! -d "$helper_path" ]]; then
+    [[ -n "$profile_path" ]] || {
+      echo "vmnet helper bundle is missing: $helper_path" >&2
+      echo "Set CLEANROOM_DARWIN_VZ_HELPER to a prebuilt signed helper bundle or provide CLEANROOM_DARWIN_VZ_HELPER_PROVISION_PROFILE and CLEANROOM_DARWIN_VZ_HELPER_SIGN_IDENTITY." >&2
+      exit 1
+    }
+    [[ -n "$sign_identity" ]] || {
+      echo "CLEANROOM_DARWIN_VZ_HELPER_SIGN_IDENTITY is required to build a local vmnet helper" >&2
+      exit 1
+    }
+
+    echo "--- :key: Building vmnet-signed helper"
+    run_with_macos_user_home env \
+      CLEANROOM_DARWIN_VZ_HELPER_ENTITLEMENTS=cmd/cleanroom-darwin-vz/entitlements-vmnet.plist \
+      CLEANROOM_DARWIN_VZ_HELPER_SIGN_IDENTITY="$sign_identity" \
+      CLEANROOM_DARWIN_VZ_HELPER_SIGN_KEYCHAIN="$sign_keychain" \
+      CLEANROOM_DARWIN_VZ_HELPER_SIGN_IDENTIFIER="${CLEANROOM_DARWIN_VZ_HELPER_SIGN_IDENTIFIER:-com.buildkite.cleanroom.darwin-vz}" \
+      CLEANROOM_DARWIN_VZ_HELPER_PROVISION_PROFILE="$profile_path" \
+      CLEANROOM_DARWIN_VZ_HELPER_BUNDLE=1 \
+      scripts/build-darwin-vz-helper.sh dist/cleanroom-darwin-vz.app
+  fi
+
+  if [[ ! -d "$helper_path" ]]; then
+    echo "darwin-vz helper bundle is missing: $helper_path" >&2
     exit 1
-  }
-  [[ -n "$sign_identity" ]] || {
-    echo "CLEANROOM_DARWIN_VZ_HELPER_SIGN_IDENTITY is required to build a local vmnet helper" >&2
-    exit 1
-  }
+  fi
+  run_with_macos_user_home codesign --verify --strict --verbose=2 "$helper_path"
 
-  echo "--- :key: Building vmnet-signed helper"
-  run_with_macos_user_home env \
-    CLEANROOM_DARWIN_VZ_HELPER_ENTITLEMENTS=cmd/cleanroom-darwin-vz/entitlements-vmnet.plist \
-    CLEANROOM_DARWIN_VZ_HELPER_SIGN_IDENTITY="$sign_identity" \
-    CLEANROOM_DARWIN_VZ_HELPER_SIGN_KEYCHAIN="$sign_keychain" \
-    CLEANROOM_DARWIN_VZ_HELPER_SIGN_IDENTIFIER="${CLEANROOM_DARWIN_VZ_HELPER_SIGN_IDENTIFIER:-com.buildkite.cleanroom.darwin-vz}" \
-    CLEANROOM_DARWIN_VZ_HELPER_PROVISION_PROFILE="$profile_path" \
-    CLEANROOM_DARWIN_VZ_HELPER_BUNDLE=1 \
-    scripts/build-darwin-vz-helper.sh dist/cleanroom-darwin-vz.app
+  echo "--- :apple: VMNet E2E"
+  XDG_STATE_HOME="$xdg_state_home_path" \
+  CLEANROOM_DARWIN_VZ_HELPER="$helper_path" \
+  CLEANROOM_DARWIN_VZ_VMNET_E2E=1 \
+  go test ./internal/backend/darwinvz -run TestVMNetSharedE2E -v
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
 fi
-
-if [[ ! -d "$helper_path" ]]; then
-  echo "darwin-vz helper bundle is missing: $helper_path" >&2
-  exit 1
-fi
-run_with_macos_user_home codesign --verify --strict --verbose=2 "$helper_path"
-
-echo "--- :apple: VMNet E2E"
-XDG_STATE_HOME="$xdg_state_home_path" \
-CLEANROOM_DARWIN_VZ_HELPER="$helper_path" \
-CLEANROOM_DARWIN_VZ_VMNET_E2E=1 \
-go test ./internal/backend/darwinvz -run TestVMNetSharedE2E -v

--- a/scripts/ci_cleanroom_e2e_behavior_test.go
+++ b/scripts/ci_cleanroom_e2e_behavior_test.go
@@ -1,0 +1,202 @@
+package scripts_test
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestCiCleanroomE2ERunPrivilegedUsesConfiguredHelper(t *testing.T) {
+	t.Helper()
+
+	workDir := t.TempDir()
+	binDir := filepath.Join(workDir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll returned error: %v", err)
+	}
+
+	argsPath := filepath.Join(workDir, "helper-args.txt")
+	helperPath := filepath.Join(workDir, "helper.sh")
+	writeExecutable(t, helperPath, "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >\"$HELPER_ARGS_PATH\"\n")
+	writeExecutable(t, filepath.Join(binDir, "sudo"), "#!/usr/bin/env bash\n[[ \"$1\" == \"-n\" ]] && shift\nexec \"$@\"\n")
+
+	scriptPath := scriptAbsPath(t, "ci-cleanroom-e2e.sh")
+	_, stderr, err := runShellSnippet(t, `
+source "$SCRIPT_PATH"
+PRIVILEGED_HELPER_PATH="$HELPER_PATH"
+run_privileged capabilities
+`, map[string]string{
+		"PATH":             binDir + ":" + os.Getenv("PATH"),
+		"SCRIPT_PATH":      scriptPath,
+		"HELPER_PATH":      helperPath,
+		"HELPER_ARGS_PATH": argsPath,
+	})
+	if err != nil {
+		t.Fatalf("runShellSnippet returned error: %v (stderr=%q)", err, stderr)
+	}
+
+	got, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatalf("ReadFile returned error: %v", err)
+	}
+	if got, want := strings.TrimSpace(string(got)), "capabilities"; got != want {
+		t.Fatalf("unexpected helper args: got %q want %q", got, want)
+	}
+}
+
+func TestCiCleanroomE2EVerifyHelperCapabilitiesDetectsMissingCapabilities(t *testing.T) {
+	t.Helper()
+
+	workDir := t.TempDir()
+	binDir := filepath.Join(workDir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll returned error: %v", err)
+	}
+
+	annotationPath := filepath.Join(workDir, "annotation.md")
+	helperPath := filepath.Join(workDir, "helper.sh")
+	writeExecutable(t, helperPath, "#!/usr/bin/env bash\nprintf 'firecracker-network\\n'\n")
+	writeExecutable(t, filepath.Join(binDir, "sudo"), "#!/usr/bin/env bash\n[[ \"$1\" == \"-n\" ]] && shift\nexec \"$@\"\n")
+	writeExecutable(t, filepath.Join(binDir, "buildkite-agent"), "#!/usr/bin/env bash\ncat >\"$ANNOTATION_FILE\"\n")
+
+	scriptPath := scriptAbsPath(t, "ci-cleanroom-e2e.sh")
+	_, stderr, err := runShellSnippet(t, `
+source "$SCRIPT_PATH"
+PRIVILEGED_HELPER_PATH="$HELPER_PATH"
+if verify_helper_capabilities; then
+  echo "expected capability verification to fail" >&2
+  exit 1
+fi
+`, map[string]string{
+		"PATH":            binDir + ":" + os.Getenv("PATH"),
+		"SCRIPT_PATH":     scriptPath,
+		"HELPER_PATH":     helperPath,
+		"ANNOTATION_FILE": annotationPath,
+	})
+	if err != nil {
+		t.Fatalf("runShellSnippet returned error: %v (stderr=%q)", err, stderr)
+	}
+	if !strings.Contains(stderr, "missing required capabilities") {
+		t.Fatalf("expected missing capabilities in stderr, got %q", stderr)
+	}
+	if !strings.Contains(stderr, "firecracker-rootfs") {
+		t.Fatalf("expected missing capability name in stderr, got %q", stderr)
+	}
+
+	annotation, err := os.ReadFile(annotationPath)
+	if err != nil {
+		t.Fatalf("ReadFile returned error: %v", err)
+	}
+	if !strings.Contains(string(annotation), "Root helper is missing required capabilities") {
+		t.Fatalf("expected annotation to mention missing capabilities, got %q", string(annotation))
+	}
+}
+
+func TestCiCleanroomE2EVerifyHelperCapabilitiesReportsProbeFailures(t *testing.T) {
+	t.Helper()
+
+	workDir := t.TempDir()
+	binDir := filepath.Join(workDir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll returned error: %v", err)
+	}
+
+	annotationPath := filepath.Join(workDir, "annotation.md")
+	helperPath := filepath.Join(workDir, "helper.sh")
+	writeExecutable(t, helperPath, "#!/usr/bin/env bash\necho 'probe failed' >&2\nexit 23\n")
+	writeExecutable(t, filepath.Join(binDir, "sudo"), "#!/usr/bin/env bash\n[[ \"$1\" == \"-n\" ]] && shift\nexec \"$@\"\n")
+	writeExecutable(t, filepath.Join(binDir, "buildkite-agent"), "#!/usr/bin/env bash\ncat >\"$ANNOTATION_FILE\"\n")
+
+	scriptPath := scriptAbsPath(t, "ci-cleanroom-e2e.sh")
+	_, stderr, err := runShellSnippet(t, `
+source "$SCRIPT_PATH"
+PRIVILEGED_HELPER_PATH="$HELPER_PATH"
+if verify_helper_capabilities; then
+  echo "expected capability verification to fail" >&2
+  exit 1
+fi
+`, map[string]string{
+		"PATH":            binDir + ":" + os.Getenv("PATH"),
+		"SCRIPT_PATH":     scriptPath,
+		"HELPER_PATH":     helperPath,
+		"ANNOTATION_FILE": annotationPath,
+	})
+	if err != nil {
+		t.Fatalf("runShellSnippet returned error: %v (stderr=%q)", err, stderr)
+	}
+	if !strings.Contains(stderr, "Root helper capability probe failed") {
+		t.Fatalf("expected probe failure in stderr, got %q", stderr)
+	}
+
+	annotation, err := os.ReadFile(annotationPath)
+	if err != nil {
+		t.Fatalf("ReadFile returned error: %v", err)
+	}
+	if !strings.Contains(string(annotation), "Root helper capability probe failed") {
+		t.Fatalf("expected annotation to mention probe failure, got %q", string(annotation))
+	}
+}
+
+func runShellSnippet(t *testing.T, snippet string, env map[string]string) (string, string, error) {
+	t.Helper()
+
+	cmd := exec.Command("bash", "-c", snippet)
+	cmd.Env = envSlice(env)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	return stdout.String(), stderr.String(), err
+}
+
+func scriptAbsPath(t *testing.T, name string) string {
+	t.Helper()
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd returned error: %v", err)
+	}
+	return filepath.Join(cwd, name)
+}
+
+func writeExecutable(t *testing.T, path, content string) {
+	t.Helper()
+
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+		t.Fatalf("WriteFile(%s) returned error: %v", path, err)
+	}
+}
+
+func envSlice(overrides map[string]string) []string {
+	envMap := make(map[string]string)
+	for _, entry := range os.Environ() {
+		parts := strings.SplitN(entry, "=", 2)
+		value := ""
+		if len(parts) == 2 {
+			value = parts[1]
+		}
+		envMap[parts[0]] = value
+	}
+	for key, value := range overrides {
+		envMap[key] = value
+	}
+
+	keys := make([]string, 0, len(envMap))
+	for key := range envMap {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	env := make([]string, 0, len(keys))
+	for _, key := range keys {
+		env = append(env, key+"="+envMap[key])
+	}
+	return env
+}

--- a/scripts/ci_darwin_vz_vmnet_behavior_test.go
+++ b/scripts/ci_darwin_vz_vmnet_behavior_test.go
@@ -1,0 +1,67 @@
+package scripts_test
+
+import (
+	"os"
+	"testing"
+)
+
+func TestCiDarwinVZVMNetNormalizeSecretValueRemovesCarriageReturns(t *testing.T) {
+	t.Helper()
+
+	scriptPath := scriptAbsPath(t, "ci-darwin-vz-vmnet-e2e.sh")
+	stdout, stderr, err := runShellSnippet(t, `
+source "$SCRIPT_PATH"
+normalize_secret_value $'line1\r\nline2\r'
+`, map[string]string{
+		"SCRIPT_PATH": scriptPath,
+	})
+	if err != nil {
+		t.Fatalf("runShellSnippet returned error: %v (stderr=%q)", err, stderr)
+	}
+	if got, want := stdout, "line1\nline2"; got != want {
+		t.Fatalf("unexpected normalized secret: got %q want %q", got, want)
+	}
+}
+
+func TestCiDarwinVZVMNetResolveLocalHelperPathPrefersEnv(t *testing.T) {
+	t.Helper()
+
+	scriptPath := scriptAbsPath(t, "ci-darwin-vz-vmnet-e2e.sh")
+	stdout, stderr, err := runShellSnippet(t, `
+source "$SCRIPT_PATH"
+resolve_local_helper_path
+`, map[string]string{
+		"SCRIPT_PATH":                scriptPath,
+		"CLEANROOM_DARWIN_VZ_HELPER": "/tmp/custom-helper.app",
+	})
+	if err != nil {
+		t.Fatalf("runShellSnippet returned error: %v (stderr=%q)", err, stderr)
+	}
+	if got, want := stdout, "/tmp/custom-helper.app\n"; got != want {
+		t.Fatalf("unexpected helper path: got %q want %q", got, want)
+	}
+}
+
+func TestEnvSliceAppliesOverridesLast(t *testing.T) {
+	t.Helper()
+
+	env := envSlice(map[string]string{"PATH": "/tmp/bin", "TEST_KEY": "value"})
+	var (
+		foundPATH bool
+		foundKey  bool
+	)
+	for _, entry := range env {
+		if entry == "PATH=/tmp/bin" {
+			foundPATH = true
+		}
+		if entry == "TEST_KEY=value" {
+			foundKey = true
+		}
+	}
+	if !foundPATH || !foundKey {
+		t.Fatalf("expected env overrides to be present, got %v", env)
+	}
+	if _, ok := os.LookupEnv("PATH"); !ok {
+		t.Fatal("expected PATH to exist in process environment")
+	}
+}

--- a/scripts/download_sandbox_file/main.go
+++ b/scripts/download_sandbox_file/main.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"time"
@@ -18,6 +19,10 @@ import (
 const defaultRequestTimeout = 45 * time.Second
 
 func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+func run(args []string, stdout, stderr io.Writer) int {
 	var (
 		host      string
 		tlsCA     string
@@ -27,36 +32,40 @@ func main() {
 		timeout   time.Duration
 	)
 
-	flag.StringVar(&host, "host", "", "Control-plane endpoint")
-	flag.StringVar(&tlsCA, "tls-ca", "", "Path to CA certificate for HTTPS hosts")
-	flag.StringVar(&sandboxID, "sandbox-id", "", "Sandbox ID")
-	flag.StringVar(&path, "path", "", "Absolute guest path to download")
-	flag.Int64Var(&maxBytes, "max-bytes", 10*1024*1024, "Maximum bytes to download")
-	flag.DurationVar(&timeout, "timeout", defaultRequestTimeout, "Request timeout (0 disables timeout)")
-	flag.Parse()
+	flags := flag.NewFlagSet("download-sandbox-file", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	flags.StringVar(&host, "host", "", "Control-plane endpoint")
+	flags.StringVar(&tlsCA, "tls-ca", "", "Path to CA certificate for HTTPS hosts")
+	flags.StringVar(&sandboxID, "sandbox-id", "", "Sandbox ID")
+	flags.StringVar(&path, "path", "", "Absolute guest path to download")
+	flags.Int64Var(&maxBytes, "max-bytes", 10*1024*1024, "Maximum bytes to download")
+	flags.DurationVar(&timeout, "timeout", defaultRequestTimeout, "Request timeout (0 disables timeout)")
+	if err := flags.Parse(args); err != nil {
+		return 2
+	}
 
 	if strings.TrimSpace(host) == "" {
-		fail("missing --host")
+		return failf(stderr, "missing --host")
 	}
 	if strings.TrimSpace(sandboxID) == "" {
-		fail("missing --sandbox-id")
+		return failf(stderr, "missing --sandbox-id")
 	}
 	if strings.TrimSpace(path) == "" {
-		fail("missing --path")
+		return failf(stderr, "missing --path")
 	}
 	if timeout < 0 {
-		fail("invalid --timeout: must be >= 0")
+		return failf(stderr, "invalid --timeout: must be >= 0")
 	}
 
 	ep, err := endpoint.Resolve(host)
 	if err != nil {
-		fail("resolve host: %v", err)
+		return failf(stderr, "resolve host: %v", err)
 	}
 	client, err := controlclient.New(ep, controlclient.WithTLS(tlsconfig.Options{
 		CAPath: tlsCA,
 	}))
 	if err != nil {
-		fail("create control client: %v", err)
+		return failf(stderr, "create control client: %v", err)
 	}
 
 	ctx, cancel := requestContext(timeout)
@@ -69,13 +78,14 @@ func main() {
 	})
 	if err != nil {
 		if timeout > 0 && errors.Is(err, context.DeadlineExceeded) {
-			fail("download sandbox file timed out after %s: %v", timeout, err)
+			return failf(stderr, "download sandbox file timed out after %s: %v", timeout, err)
 		}
-		fail("download sandbox file: %v", err)
+		return failf(stderr, "download sandbox file: %v", err)
 	}
-	if _, err := os.Stdout.Write(resp.GetData()); err != nil {
-		fail("write download payload: %v", err)
+	if _, err := stdout.Write(resp.GetData()); err != nil {
+		return failf(stderr, "write download payload: %v", err)
 	}
+	return 0
 }
 
 func requestContext(timeout time.Duration) (context.Context, context.CancelFunc) {
@@ -85,7 +95,7 @@ func requestContext(timeout time.Duration) (context.Context, context.CancelFunc)
 	return context.WithTimeout(context.Background(), timeout)
 }
 
-func fail(format string, args ...any) {
-	fmt.Fprintf(os.Stderr, format+"\n", args...)
-	os.Exit(1)
+func failf(w io.Writer, format string, args ...any) int {
+	fmt.Fprintf(w, format+"\n", args...)
+	return 1
 }

--- a/scripts/download_sandbox_file/main_test.go
+++ b/scripts/download_sandbox_file/main_test.go
@@ -1,9 +1,74 @@
 package main
 
 import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/controlclient"
+	"github.com/buildkite/cleanroom/internal/controlserver"
+	"github.com/buildkite/cleanroom/internal/controlservice"
+	"github.com/buildkite/cleanroom/internal/endpoint"
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/buildkite/cleanroom/internal/runtimeconfig"
 )
+
+type downloadTestAdapter struct {
+	downloadedSandboxID string
+	downloadedPath      string
+	downloadedMaxBytes  int64
+	downloadErr         error
+	downloadData        []byte
+}
+
+func (a *downloadTestAdapter) Name() string { return "firecracker" }
+
+func (a *downloadTestAdapter) Run(_ context.Context, req backend.ExecutionRequest) (*backend.ExecutionResult, error) {
+	return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0}, nil
+}
+
+func (a *downloadTestAdapter) ProvisionSandbox(context.Context, backend.ProvisionRequest) error {
+	return nil
+}
+
+func (a *downloadTestAdapter) RunInSandbox(ctx context.Context, req backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
+	return a.Run(ctx, req)
+}
+
+func (a *downloadTestAdapter) TerminateSandbox(context.Context, string) error {
+	return nil
+}
+
+func (a *downloadTestAdapter) DownloadSandboxFile(_ context.Context, sandboxID, path string, maxBytes int64) ([]byte, error) {
+	a.downloadedSandboxID = sandboxID
+	a.downloadedPath = path
+	a.downloadedMaxBytes = maxBytes
+	if a.downloadErr != nil {
+		return nil, a.downloadErr
+	}
+	return append([]byte(nil), a.downloadData...), nil
+}
+
+type downloadTestLoader struct{}
+
+func (downloadTestLoader) LoadAndCompile(_ string) (*policy.CompiledPolicy, string, error) {
+	return &policy.CompiledPolicy{
+		Version:        1,
+		ImageRef:       "ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		ImageDigest:    "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		NetworkDefault: "deny",
+	}, "/repo/cleanroom.yaml", nil
+}
+
+func (downloadTestLoader) LoadRepository(_ string) (policy.RepositoryConfig, string, error) {
+	return policy.RepositoryConfig{}, "/repo/cleanroom.yaml", nil
+}
 
 func TestRequestContextAddsDeadlineWhenTimeoutPositive(t *testing.T) {
 	t.Helper()
@@ -35,4 +100,138 @@ func TestRequestContextDisablesDeadlineWhenTimeoutZero(t *testing.T) {
 	if _, ok := ctx.Deadline(); ok {
 		t.Fatalf("expected timeout=0 to disable request deadline")
 	}
+}
+
+func TestRunRejectsMissingHost(t *testing.T) {
+	t.Helper()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := run([]string{"--sandbox-id", "sbx_123", "--path", "/tmp/test.txt"}, &stdout, &stderr)
+	if got, want := code, 1; got != want {
+		t.Fatalf("unexpected exit code: got %d want %d", got, want)
+	}
+	if !strings.Contains(stderr.String(), "missing --host") {
+		t.Fatalf("expected missing host error, got %q", stderr.String())
+	}
+}
+
+func TestRunRejectsNegativeTimeout(t *testing.T) {
+	t.Helper()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := run([]string{
+		"--host", "http://127.0.0.1:8080",
+		"--sandbox-id", "sbx_123",
+		"--path", "/tmp/test.txt",
+		"--timeout", "-1s",
+	}, &stdout, &stderr)
+	if got, want := code, 1; got != want {
+		t.Fatalf("unexpected exit code: got %d want %d", got, want)
+	}
+	if !strings.Contains(stderr.String(), "invalid --timeout") {
+		t.Fatalf("expected invalid timeout error, got %q", stderr.String())
+	}
+}
+
+func TestRunDownloadsSandboxFile(t *testing.T) {
+	t.Helper()
+
+	adapter := &downloadTestAdapter{downloadData: []byte("payload\n")}
+	host := startDownloadSandboxServer(t, adapter)
+	sandboxID := mustCreateDownloadTestSandbox(t, host)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := run([]string{
+		"--host", host,
+		"--sandbox-id", sandboxID,
+		"--path", "/tmp/persist.txt",
+		"--max-bytes", "4096",
+	}, &stdout, &stderr)
+	if got, want := code, 0; got != want {
+		t.Fatalf("unexpected exit code: got %d want %d (stderr=%q)", got, want, stderr.String())
+	}
+	if got, want := stdout.String(), "payload\n"; got != want {
+		t.Fatalf("unexpected stdout: got %q want %q", got, want)
+	}
+	if got, want := adapter.downloadedSandboxID, sandboxID; got != want {
+		t.Fatalf("unexpected sandbox id: got %q want %q", got, want)
+	}
+	if got, want := adapter.downloadedPath, "/tmp/persist.txt"; got != want {
+		t.Fatalf("unexpected download path: got %q want %q", got, want)
+	}
+	if got, want := adapter.downloadedMaxBytes, int64(4096); got != want {
+		t.Fatalf("unexpected max bytes: got %d want %d", got, want)
+	}
+}
+
+func TestRunReportsDownloadErrors(t *testing.T) {
+	t.Helper()
+
+	adapter := &downloadTestAdapter{downloadErr: errors.New("boom")}
+	host := startDownloadSandboxServer(t, adapter)
+	sandboxID := mustCreateDownloadTestSandbox(t, host)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := run([]string{
+		"--host", host,
+		"--sandbox-id", sandboxID,
+		"--path", "/tmp/persist.txt",
+	}, &stdout, &stderr)
+	if got, want := code, 1; got != want {
+		t.Fatalf("unexpected exit code: got %d want %d", got, want)
+	}
+	if !strings.Contains(stderr.String(), "download sandbox file:") {
+		t.Fatalf("expected download error, got %q", stderr.String())
+	}
+}
+
+func startDownloadSandboxServer(t *testing.T, adapter backend.Adapter) string {
+	t.Helper()
+
+	svc := &controlservice.Service{
+		Loader: downloadTestLoader{},
+		Config: runtimeconfig.Config{DefaultBackend: "firecracker"},
+		Backends: map[string]backend.Adapter{
+			"firecracker": adapter,
+		},
+	}
+
+	server := httptest.NewServer(controlserver.New(svc, nil).Handler())
+	t.Cleanup(server.Close)
+	return server.URL
+}
+
+func mustCreateDownloadTestSandbox(t *testing.T, host string) string {
+	t.Helper()
+
+	ep, err := endpoint.Resolve(host)
+	if err != nil {
+		t.Fatalf("Resolve returned error: %v", err)
+	}
+	client, err := controlclient.New(ep)
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	resp, err := client.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Backend: "firecracker",
+		Policy: &cleanroomv1.Policy{
+			Version:        1,
+			ImageRef:       "ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			ImageDigest:    "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			NetworkDefault: "deny",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := resp.GetSandbox().GetSandboxId()
+	if sandboxID == "" {
+		t.Fatal("expected sandbox id")
+	}
+	return sandboxID
 }


### PR DESCRIPTION
## Summary
- add direct integration coverage for `cleanroom execution inspect` and broaden repository bootstrap/path/TLS/client transport tests
- make the small helper CLIs testable and add real behavior tests for `download-sandbox-file` and `cleanroom-vmnet-echo`
- wrap the Firecracker and darwin-vz vmnet CI scripts in guarded `main` entrypoints so shell behavior tests can exercise helper capability and vmnet helper logic without running the full e2e flows

## Testing
- `mise exec -- go test ./...`