### PR TITLE
fix(cli): ignore benign stdin close races

### DIFF
--- a/internal/cli/exec_integration_test.go
+++ b/internal/cli/exec_integration_test.go
@@ -776,6 +776,67 @@ func TestExecIntegrationNoStdinClosesImmediately(t *testing.T) {
 	}
 }
 
+func TestExecIntegrationIgnoresBenignStdinCloseFailures(t *testing.T) {
+	stdinClosed := make(chan struct{}, 1)
+	adapter := &integrationAdapter{
+		runStreamFn: func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+			if stream.OnAttach != nil {
+				stream.OnAttach(backend.AttachIO{
+					WriteStdin: func(data []byte) error {
+						return nil
+					},
+					CloseStdin: func() error {
+						select {
+						case stdinClosed <- struct{}{}:
+						default:
+						}
+						return errors.New("use of closed network connection")
+					},
+				})
+			}
+			select {
+			case <-stdinClosed:
+			case <-time.After(2 * time.Second):
+				return nil, errors.New("timed out waiting for stdin close")
+			}
+			if stream.OnStdout != nil {
+				stream.OnStdout([]byte("done\n"))
+			}
+			return &backend.ExecutionResult{
+				ExecutionID: req.ExecutionID,
+				ExitCode:    0,
+				Stdout:      "done\n",
+				Message:     "ok",
+			}, nil
+		},
+	}
+
+	host, _ := startIntegrationServer(t, adapter)
+	cwd := t.TempDir()
+	stdinData := ""
+	cmd := ExecCommand{
+		clientFlags: clientFlags{Host: host},
+		Chdir:       cwd,
+		Command:     []string{"cat"},
+	}
+	outcome := runWithCapture(func(runCtx *runtimeContext) error {
+		return cmd.Run(runCtx)
+	}, &stdinData, runtimeContext{
+		CWD:    cwd,
+		Loader: integrationLoader{},
+	})
+
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err != nil {
+		t.Fatalf("ExecCommand.Run returned error: %v", outcome.err)
+	}
+	if got := outcome.stdout; got != "done\n" {
+		t.Fatalf("unexpected stdout: got %q want %q", got, "done\n")
+	}
+}
+
 func TestExecIntegrationNoStdinFailureDoesNotHangWhileStreamBlocked(t *testing.T) {
 	started := make(chan struct{}, 1)
 	adapter := &integrationAdapter{

--- a/internal/cli/exec_integration_test.go
+++ b/internal/cli/exec_integration_test.go
@@ -837,6 +837,67 @@ func TestExecIntegrationIgnoresBenignStdinCloseFailures(t *testing.T) {
 	}
 }
 
+func TestExecIntegrationPropagatesStdinWriteClosedConnectionFailures(t *testing.T) {
+	firstWrite := make(chan struct{}, 1)
+	adapter := &integrationAdapter{
+		runStreamFn: func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+			if stream.OnAttach != nil {
+				stream.OnAttach(backend.AttachIO{
+					WriteStdin: func(data []byte) error {
+						select {
+						case firstWrite <- struct{}{}:
+						default:
+						}
+						return errors.New("use of closed network connection")
+					},
+					CloseStdin: func() error {
+						return nil
+					},
+				})
+			}
+			select {
+			case <-firstWrite:
+			case <-time.After(2 * time.Second):
+				return nil, errors.New("timed out waiting for stdin write")
+			}
+			if stream.OnStdout != nil {
+				stream.OnStdout([]byte("done\n"))
+			}
+			return &backend.ExecutionResult{
+				ExecutionID: req.ExecutionID,
+				ExitCode:    0,
+				Stdout:      "done\n",
+				Message:     "ok",
+			}, nil
+		},
+	}
+
+	host, _ := startIntegrationServer(t, adapter)
+	cwd := t.TempDir()
+	stdinData := "input\n"
+	cmd := ExecCommand{
+		clientFlags: clientFlags{Host: host},
+		Chdir:       cwd,
+		Command:     []string{"cat"},
+	}
+	outcome := runWithCapture(func(runCtx *runtimeContext) error {
+		return cmd.Run(runCtx)
+	}, &stdinData, runtimeContext{
+		CWD:    cwd,
+		Loader: integrationLoader{},
+	})
+
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err == nil {
+		t.Fatal("expected stdin write error")
+	}
+	if !strings.Contains(outcome.err.Error(), "write execution stdin") {
+		t.Fatalf("expected stdin write error, got %v", outcome.err)
+	}
+}
+
 func TestExecIntegrationNoStdinFailureDoesNotHangWhileStreamBlocked(t *testing.T) {
 	started := make(chan struct{}, 1)
 	adapter := &integrationAdapter{

--- a/internal/cli/execution_shared.go
+++ b/internal/cli/execution_shared.go
@@ -362,6 +362,16 @@ func isExecutionNotRunningErr(err error) bool {
 	return strings.Contains(strings.ToLower(err.Error()), "execution is not running")
 }
 
+func isClosedNetworkConnectionErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, net.ErrClosed) {
+		return true
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "closed network connection")
+}
+
 func isExecutionStdinUnsupportedErr(err error) bool {
 	if err == nil {
 		return false
@@ -370,7 +380,11 @@ func isExecutionStdinUnsupportedErr(err error) bool {
 }
 
 func isBenignExecutionStdinErr(err error) bool {
-	return err == nil || isCanceledStreamErr(err) || isExecutionNoLongerActiveErr(err) || isExecutionNotRunningErr(err)
+	return err == nil ||
+		isCanceledStreamErr(err) ||
+		isExecutionNoLongerActiveErr(err) ||
+		isExecutionNotRunningErr(err) ||
+		isClosedNetworkConnectionErr(err)
 }
 
 func isInteractiveStreamClosedErr(err error) bool {

--- a/internal/cli/execution_shared.go
+++ b/internal/cli/execution_shared.go
@@ -178,7 +178,7 @@ func closeExecutionStdin(client *controlclient.Client, sandboxID, executionID st
 		SandboxId:   sandboxID,
 		ExecutionId: executionID,
 	})
-	if isBenignExecutionStdinErr(err) {
+	if isBenignExecutionStdinErr(err) || isClosedNetworkConnectionErr(err) {
 		return nil
 	}
 	if err != nil {
@@ -383,8 +383,7 @@ func isBenignExecutionStdinErr(err error) bool {
 	return err == nil ||
 		isCanceledStreamErr(err) ||
 		isExecutionNoLongerActiveErr(err) ||
-		isExecutionNotRunningErr(err) ||
-		isClosedNetworkConnectionErr(err)
+		isExecutionNotRunningErr(err)
 }
 
 func isInteractiveStreamClosedErr(err error) bool {


### PR DESCRIPTION
## Summary
- treat transport-level closed-network-connection errors as benign for execution stdin teardown
- add an exec integration regression that simulates `CloseStdin` returning `use of closed network connection`
- keep fast-finishing batch execs from surfacing a client-side failure after the execution already succeeded

## Testing
- `mise exec -- go test ./internal/cli -run 'TestExecIntegration(IgnoresBenignStdinCloseFailures|IgnoresLateBenignStdinWriteFailures|NoStdinClosesImmediately|NoStdinFailureDoesNotHangWhileStreamBlocked)'`
- manual smoke: refresh `~/bin/cleanroom`, restart the launchd daemon with `~/bin/cleanroom daemon install --force`, then run `~/bin/cleanroom exec --keep --print-sandbox-id -- sh -lc 'echo smoke-manual'` and confirm it exits 0 without the previous `close execution stdin` error