### PR TITLE
feat(cli): inspect executions by global id

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,8 +401,8 @@ When `rootfs` is unset, Cleanroom derives one from `sandbox.image.ref` and injec
 cleanroom doctor              # check host prerequisites
 cleanroom doctor --json       # machine-readable with capabilities map
 cleanroom sandbox inspect <sandbox-id>
+cleanroom execution inspect <execution-id>
 cleanroom execution inspect --sandbox-id <sandbox-id> --last
-cleanroom execution inspect --sandbox-id <sandbox-id> <execution-id>
 cleanroom status --last       # browse the newest retained execution artifacts
 cleanroom status --execution-id <execution-id>
 cleanroom version

--- a/docs/api.md
+++ b/docs/api.md
@@ -286,7 +286,7 @@ and `--dangerously-allow-all` cannot be combined with `--from`.
 
 ### 9.3 Execution commands
 
-- `cleanroom execution inspect --sandbox-id <sandbox-id> <execution-id>`
+- `cleanroom execution inspect <execution-id>`
 - `cleanroom execution inspect --sandbox-id <sandbox-id> --last`
 - `cleanroom status --execution-id <execution-id>`
 - `cleanroom status --last`
@@ -355,7 +355,7 @@ Failure UX:
 
 Debugging flow:
 1. Start with `cleanroom sandbox inspect <sandbox-id>` when you need the sandbox state or do not yet know the execution ID.
-2. Use `cleanroom execution inspect --sandbox-id <sandbox-id> <execution-id>` for the canonical execution view.
+2. Use `cleanroom execution inspect <execution-id>` for the canonical execution view.
 3. Use `cleanroom status --execution-id <execution-id>` for retained local artifacts and raw observability files.
 
 ## 10) Suggested Implementation Plan

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -449,7 +449,8 @@ Policy feature mapping:
   - `cleanroom sandbox inspect <sandbox-id>`
   - `cleanroom sandbox ls`
   - `cleanroom sandbox rm <sandbox-id>`
-  - `cleanroom execution inspect --sandbox-id <sandbox-id> <execution-id>|--last`
+  - `cleanroom execution inspect <execution-id>`
+  - `cleanroom execution inspect --sandbox-id <sandbox-id> --last`
   - `cleanroom doctor`
   - `cleanroom status [--execution-id <execution-id>|--last]`
   - `cleanroom image pull|ls|rm|import|bump-ref`

--- a/internal/cli/console_integration_test.go
+++ b/internal/cli/console_integration_test.go
@@ -552,7 +552,7 @@ func TestConsoleIntegrationPrintsExecutionHintsOnFailure(t *testing.T) {
 	if got := parseExecutionID(outcome.stderr); got == "" {
 		t.Fatalf("expected execution_id in failure output, got %q", outcome.stderr)
 	}
-	if !strings.Contains(outcome.stderr, "inspect_command=cleanroom execution inspect --sandbox-id ") {
+	if !strings.Contains(outcome.stderr, "inspect_command=cleanroom execution inspect ") {
 		t.Fatalf("expected inspect_command in failure output, got %q", outcome.stderr)
 	}
 	if !strings.Contains(outcome.stderr, "artifacts_dir=/tmp/console-failed") {

--- a/internal/cli/exec_integration_test.go
+++ b/internal/cli/exec_integration_test.go
@@ -987,7 +987,7 @@ func TestExecIntegrationPropagatesExitAndStderr(t *testing.T) {
 	if got := parseExecutionID(outcome.stderr); got == "" {
 		t.Fatalf("expected execution_id in failure output, got %q", outcome.stderr)
 	}
-	if !strings.Contains(outcome.stderr, "inspect_command=cleanroom execution inspect --sandbox-id ") {
+	if !strings.Contains(outcome.stderr, "inspect_command=cleanroom execution inspect ") {
 		t.Fatalf("expected inspect_command in failure output, got %q", outcome.stderr)
 	}
 	if !strings.Contains(outcome.stderr, "artifacts_dir=/tmp/exec-failed") {

--- a/internal/cli/execution.go
+++ b/internal/cli/execution.go
@@ -16,7 +16,7 @@ type ExecutionCommand struct {
 
 type ExecutionInspectCommand struct {
 	clientFlags
-	SandboxID   string `name:"sandbox-id" help:"Sandbox ID that owns the execution"`
+	SandboxID   string `name:"sandbox-id" help:"Sandbox ID that owns the execution (required with --last)"`
 	ExecutionID string `arg:"" optional:"" help:"Execution ID to inspect"`
 	Last        bool   `help:"Inspect the sandbox's last execution (requires --sandbox-id)"`
 	JSON        bool   `help:"Print execution inspection as JSON"`
@@ -50,9 +50,6 @@ func (c *ExecutionInspectCommand) Run(ctx *runtimeContext) error {
 			return fmt.Errorf("sandbox %q has no recorded executions", sandboxID)
 		}
 	} else {
-		if sandboxID == "" {
-			return errors.New("--sandbox-id is required")
-		}
 		if executionID == "" {
 			return errors.New("missing <execution-id> or use --last")
 		}

--- a/internal/cli/execution_integration_test.go
+++ b/internal/cli/execution_integration_test.go
@@ -160,6 +160,57 @@ func TestExecutionInspectIntegrationSupportsLastAndJSON(t *testing.T) {
 	}
 }
 
+func TestExecutionInspectIntegrationSupportsGlobalExecutionID(t *testing.T) {
+	t.Helper()
+
+	adapter := &integrationAdapter{
+		runFn: func(_ context.Context, req backend.ExecutionRequest) (*backend.ExecutionResult, error) {
+			return &backend.ExecutionResult{
+				ExecutionID: req.ExecutionID,
+				ExitCode:    0,
+				Stdout:      "hello\n",
+				Message:     "done",
+			}, nil
+		},
+	}
+
+	host, svc := startIntegrationServer(t, adapter)
+	client := mustNewControlClient(t, host)
+	sandboxID := mustCreateSandbox(t, client)
+
+	createResp, err := client.CreateExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
+		SandboxId: sandboxID,
+		Command:   []string{"echo", "ok"},
+		Kind:      cleanroomv1.ExecutionKind_EXECUTION_KIND_BATCH,
+	})
+	if err != nil {
+		t.Fatalf("CreateExecution returned error: %v", err)
+	}
+	executionID := createResp.GetExecution().GetExecutionId()
+	if _, err := svc.WaitExecution(context.Background(), sandboxID, executionID); err != nil {
+		t.Fatalf("WaitExecution returned error: %v", err)
+	}
+
+	outcome := runExecutionInspectWithCapture(ExecutionInspectCommand{
+		clientFlags: clientFlags{Host: host},
+		ExecutionID: executionID,
+	}, runtimeContext{CWD: t.TempDir()})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err != nil {
+		t.Fatalf("ExecutionInspectCommand.Run returned error: %v", outcome.err)
+	}
+
+	assertContainsAll(
+		t,
+		outcome.stdout,
+		"execution: "+executionID,
+		"sandbox: "+sandboxID,
+		"status: succeeded",
+	)
+}
+
 func TestExecutionInspectCommandRejectsMutuallyExclusiveFlags(t *testing.T) {
 	t.Helper()
 

--- a/internal/cli/execution_shared.go
+++ b/internal/cli/execution_shared.go
@@ -269,12 +269,11 @@ func writeArtifactsDir(stderr io.Writer, artifactsDir string) error {
 }
 
 func writeExecutionInspectCommand(stderr io.Writer, sandboxID, executionID string) error {
-	sandboxID = strings.TrimSpace(sandboxID)
 	executionID = strings.TrimSpace(executionID)
-	if stderr == nil || sandboxID == "" || executionID == "" {
+	if stderr == nil || executionID == "" {
 		return nil
 	}
-	_, err := fmt.Fprintf(stderr, "inspect_command=cleanroom execution inspect --sandbox-id %s %s\n", sandboxID, executionID)
+	_, err := fmt.Fprintf(stderr, "inspect_command=cleanroom execution inspect %s\n", executionID)
 	return err
 }
 

--- a/internal/cli/sandbox.go
+++ b/internal/cli/sandbox.go
@@ -156,7 +156,7 @@ func (c *SandboxInspectCommand) Run(ctx *runtimeContext) error {
 		if _, err := fmt.Fprintf(ctx.Stdout, "last_execution_id: %s\n", lastExecutionID); err != nil {
 			return err
 		}
-		if _, err := fmt.Fprintf(ctx.Stdout, "inspect_last_execution: cleanroom execution inspect --sandbox-id %s --last\n", sandbox.GetSandboxId()); err != nil {
+		if _, err := fmt.Fprintf(ctx.Stdout, "inspect_last_execution: cleanroom execution inspect %s\n", lastExecutionID); err != nil {
 			return err
 		}
 	}
@@ -164,7 +164,7 @@ func (c *SandboxInspectCommand) Run(ctx *runtimeContext) error {
 		if _, err := fmt.Fprintf(ctx.Stdout, "active_execution_id: %s\n", activeExecutionID); err != nil {
 			return err
 		}
-		if _, err := fmt.Fprintf(ctx.Stdout, "inspect_active_execution: cleanroom execution inspect --sandbox-id %s %s\n", sandbox.GetSandboxId(), activeExecutionID); err != nil {
+		if _, err := fmt.Fprintf(ctx.Stdout, "inspect_active_execution: cleanroom execution inspect %s\n", activeExecutionID); err != nil {
 			return err
 		}
 	}

--- a/internal/cli/sandbox_inspect_integration_test.go
+++ b/internal/cli/sandbox_inspect_integration_test.go
@@ -54,7 +54,7 @@ func TestSandboxInspectIntegrationShowsExecutionPointers(t *testing.T) {
 	if !strings.Contains(outcome.stdout, "last_execution_id: "+executionID) {
 		t.Fatalf("expected last execution id in output, got %q", outcome.stdout)
 	}
-	if !strings.Contains(outcome.stdout, "inspect_last_execution: cleanroom execution inspect --sandbox-id "+sandboxID+" --last") {
+	if !strings.Contains(outcome.stdout, "inspect_last_execution: cleanroom execution inspect "+executionID) {
 		t.Fatalf("expected inspect hint in output, got %q", outcome.stdout)
 	}
 }

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -1024,9 +1024,6 @@ func (s *Service) InspectExecution(_ context.Context, req *cleanroomv1.InspectEx
 	}
 	sandboxID := strings.TrimSpace(req.GetSandboxId())
 	executionID := strings.TrimSpace(req.GetExecutionId())
-	if sandboxID == "" {
-		return nil, errors.New("missing sandbox_id")
-	}
 	if executionID == "" {
 		return nil, errors.New("missing execution_id")
 	}
@@ -1136,18 +1133,15 @@ func (s *Service) GetExecution(_ context.Context, req *cleanroomv1.GetExecutionR
 	}
 	sandboxID := strings.TrimSpace(req.GetSandboxId())
 	executionID := strings.TrimSpace(req.GetExecutionId())
-	if sandboxID == "" {
-		return nil, errors.New("missing sandbox_id")
-	}
 	if executionID == "" {
 		return nil, errors.New("missing execution_id")
 	}
 
 	s.mu.RLock()
-	ex, ok := s.executions[executionKey(sandboxID, executionID)]
-	if !ok {
+	ex, err := s.lookupExecutionLocked(sandboxID, executionID)
+	if err != nil {
 		s.mu.RUnlock()
-		return nil, fmt.Errorf("unknown execution %q in sandbox %q", executionID, sandboxID)
+		return nil, err
 	}
 	resp := &cleanroomv1.GetExecutionResponse{Execution: cloneExecutionLocked(ex)}
 	s.mu.RUnlock()
@@ -1491,9 +1485,9 @@ func (s *Service) WaitExecution(ctx context.Context, sandboxID, executionID stri
 func (s *Service) ExecutionSnapshot(sandboxID, executionID string) (*executionSnapshot, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	ex, ok := s.executions[executionKey(sandboxID, executionID)]
-	if !ok {
-		return nil, fmt.Errorf("unknown execution %q in sandbox %q", executionID, sandboxID)
+	ex, err := s.lookupExecutionLocked(sandboxID, executionID)
+	if err != nil {
+		return nil, err
 	}
 	return &executionSnapshot{
 		Execution:   cloneExecutionLocked(ex),
@@ -1506,6 +1500,31 @@ func (s *Service) ExecutionSnapshot(sandboxID, executionID string) (*executionSn
 		RunDir:      ex.RunDir,
 		Launched:    ex.LaunchedVM,
 	}, nil
+}
+
+func (s *Service) lookupExecutionLocked(sandboxID, executionID string) (*executionState, error) {
+	if strings.TrimSpace(sandboxID) != "" {
+		ex, ok := s.executions[executionKey(sandboxID, executionID)]
+		if !ok {
+			return nil, fmt.Errorf("unknown execution %q in sandbox %q", executionID, sandboxID)
+		}
+		return ex, nil
+	}
+
+	var match *executionState
+	for _, ex := range s.executions {
+		if ex == nil || ex.ID != executionID {
+			continue
+		}
+		if match != nil && match.SandboxID != ex.SandboxID {
+			return nil, fmt.Errorf("execution %q is not globally unique; specify sandbox_id", executionID)
+		}
+		match = ex
+	}
+	if match == nil {
+		return nil, fmt.Errorf("unknown execution %q", executionID)
+	}
+	return match, nil
 }
 
 func (s *Service) runExecution(sandboxID, executionID string) {

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -1999,6 +1999,14 @@ func TestServiceGeneratedIDsUseTypeIDFormat(t *testing.T) {
 		t.Fatalf("unexpected execution id from GetExecution: got %q want %q", got, want)
 	}
 
+	getResp, err = svc.GetExecution(context.Background(), &cleanroomv1.GetExecutionRequest{ExecutionId: executionID})
+	if err != nil {
+		t.Fatalf("GetExecution without sandbox_id returned error: %v", err)
+	}
+	if got, want := getResp.GetExecution().GetSandboxId(), sandboxID; got != want {
+		t.Fatalf("unexpected sandbox id from global GetExecution lookup: got %q want %q", got, want)
+	}
+
 	sandboxResp, err := svc.GetSandbox(context.Background(), &cleanroomv1.GetSandboxRequest{SandboxId: sandboxID})
 	if err != nil {
 		t.Fatalf("GetSandbox returned error: %v", err)


### PR DESCRIPTION
## Summary
- allow execution lookup by `execution_id` without requiring `--sandbox-id`
- update CLI follow-up hints and sandbox inspect output to use the global execution inspect form
- add coverage for global execution lookup and refresh the related docs

## Testing
- `mise exec -- go test ./internal/controlservice -run 'TestServiceGeneratedIDsUseTypeIDFormat' -count=1`
- `mise exec -- go test ./internal/cli -run 'TestExecutionInspectIntegrationShowsExecutionDetails|TestExecutionInspectIntegrationSupportsLastAndJSON|TestExecutionInspectIntegrationSupportsGlobalExecutionID|TestExecutionInspectCommandRejectsMutuallyExclusiveFlags|TestSandboxInspectIntegrationShowsExecutionPointers|TestSandboxInspectIntegrationJSON|TestConsoleIntegrationPrintsExecutionHintsOnFailure|TestExecIntegrationPropagatesExitAndStderr' -count=1`