### PR TITLE
fix(cli): reject --chdir for reused sandboxes

### DIFF
--- a/internal/cli/console.go
+++ b/internal/cli/console.go
@@ -35,6 +35,10 @@ type ConsoleCommand struct {
 }
 
 func (c *ConsoleCommand) Run(ctx *runtimeContext) (runErr error) {
+	if err := validateExecutionSandboxArgs(c.Chdir, c.In, c.From, c.Keep); err != nil {
+		return err
+	}
+
 	logger, err := newLogger(c.LogLevel, "client")
 	if err != nil {
 		return err
@@ -75,9 +79,6 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) (runErr error) {
 	repositoryForCreate := repository
 	if inlineRepositoryBootstrap {
 		repositoryForCreate = nil
-	}
-	if strings.TrimSpace(c.In) != "" && c.Keep {
-		return errors.New("--keep cannot be used with --in")
 	}
 	sandboxID, createdSandbox, err := ensureSandboxID(client, ctx.Loader, cwd, host, c.Backend, strings.TrimSpace(c.In), strings.TrimSpace(c.From), c.Image, c.LaunchSeconds, repositoryForCreate)
 	if err != nil {

--- a/internal/cli/console_integration_test.go
+++ b/internal/cli/console_integration_test.go
@@ -474,6 +474,50 @@ func TestConsoleIntegrationRejectsKeepWhenReusingSandbox(t *testing.T) {
 	}
 }
 
+func TestConsoleIntegrationRejectsChdirWhenReusingSandbox(t *testing.T) {
+	cwd := t.TempDir()
+	outcome := runConsoleWithCapture(ConsoleCommand{
+		clientFlags: clientFlags{Host: "tssvc://cleanroom"},
+		Chdir:       cwd,
+		In:          "cr_123",
+		Command:     []string{"sh"},
+	}, "", runtimeContext{
+		CWD:    cwd,
+		Loader: failingLoader{},
+	})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err == nil {
+		t.Fatal("expected ConsoleCommand.Run to reject --chdir with --in")
+	}
+	if got, want := outcome.err.Error(), "--chdir cannot be used with --in"; !strings.Contains(got, want) {
+		t.Fatalf("expected error to contain %q, got %q", want, got)
+	}
+}
+
+func TestConsoleIntegrationRejectsChdirWhenCreatingFromSnapshot(t *testing.T) {
+	cwd := t.TempDir()
+	outcome := runConsoleWithCapture(ConsoleCommand{
+		clientFlags: clientFlags{Host: "tssvc://cleanroom"},
+		Chdir:       cwd,
+		From:        "snap_123",
+		Command:     []string{"sh"},
+	}, "", runtimeContext{
+		CWD:    cwd,
+		Loader: failingLoader{},
+	})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err == nil {
+		t.Fatal("expected ConsoleCommand.Run to reject --chdir with --from")
+	}
+	if got, want := outcome.err.Error(), "--chdir cannot be used with --from"; !strings.Contains(got, want) {
+		t.Fatalf("expected error to contain %q, got %q", want, got)
+	}
+}
+
 func TestConsoleIntegrationRoutesBackendWarningsToStderr(t *testing.T) {
 	host, _ := startIntegrationServer(t, &integrationAdapter{
 		runStreamFn: func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -29,6 +29,10 @@ type ExecCommand struct {
 }
 
 func (e *ExecCommand) Run(ctx *runtimeContext) (runErr error) {
+	if err := validateExecutionSandboxArgs(e.Chdir, e.In, e.From, e.Keep); err != nil {
+		return err
+	}
+
 	logger, err := newLogger(e.LogLevel, "client")
 	if err != nil {
 		return err
@@ -65,9 +69,6 @@ func (e *ExecCommand) Run(ctx *runtimeContext) (runErr error) {
 	repositoryForCreate := repository
 	if inlineRepositoryBootstrap {
 		repositoryForCreate = nil
-	}
-	if strings.TrimSpace(e.In) != "" && e.Keep {
-		return errors.New("--keep cannot be used with --in")
 	}
 	sandboxID, createdSandbox, err := ensureSandboxID(client, ctx.Loader, cwd, host, e.Backend, strings.TrimSpace(e.In), strings.TrimSpace(e.From), e.Image, e.LaunchSeconds, repositoryForCreate)
 	if err != nil {

--- a/internal/cli/exec_integration_test.go
+++ b/internal/cli/exec_integration_test.go
@@ -1199,7 +1199,6 @@ func TestExecIntegrationSecondInterruptKeepsSuppliedSandboxWithoutRemove(t *test
 	go func() {
 		done <- runExecWithCapture(ExecCommand{
 			clientFlags: clientFlags{Host: host, LogLevel: "debug"},
-			Chdir:       cwd,
 			In:          sandboxID,
 			Command:     []string{"sleep", "300"},
 		}, runtimeContext{
@@ -1408,7 +1407,6 @@ func TestExecIntegrationRejectsKeepWhenReusingSandbox(t *testing.T) {
 	cwd := t.TempDir()
 	outcome := runExecWithCapture(ExecCommand{
 		clientFlags: clientFlags{Host: host},
-		Chdir:       cwd,
 		In:          sandboxID,
 		Keep:        true,
 		Command:     []string{"echo", "ok"},
@@ -1423,6 +1421,50 @@ func TestExecIntegrationRejectsKeepWhenReusingSandbox(t *testing.T) {
 		t.Fatal("expected ExecCommand.Run to reject --keep with --in")
 	}
 	if got, want := outcome.err.Error(), "--keep cannot be used with --in"; !strings.Contains(got, want) {
+		t.Fatalf("expected error to contain %q, got %q", want, got)
+	}
+}
+
+func TestExecIntegrationRejectsChdirWhenReusingSandbox(t *testing.T) {
+	cwd := t.TempDir()
+	outcome := runExecWithCapture(ExecCommand{
+		clientFlags: clientFlags{Host: "tssvc://cleanroom"},
+		Chdir:       cwd,
+		In:          "cr_123",
+		Command:     []string{"echo", "ok"},
+	}, runtimeContext{
+		CWD:    cwd,
+		Loader: failingLoader{},
+	})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err == nil {
+		t.Fatal("expected ExecCommand.Run to reject --chdir with --in")
+	}
+	if got, want := outcome.err.Error(), "--chdir cannot be used with --in"; !strings.Contains(got, want) {
+		t.Fatalf("expected error to contain %q, got %q", want, got)
+	}
+}
+
+func TestExecIntegrationRejectsChdirWhenCreatingFromSnapshot(t *testing.T) {
+	cwd := t.TempDir()
+	outcome := runExecWithCapture(ExecCommand{
+		clientFlags: clientFlags{Host: "tssvc://cleanroom"},
+		Chdir:       cwd,
+		From:        "snap_123",
+		Command:     []string{"echo", "ok"},
+	}, runtimeContext{
+		CWD:    cwd,
+		Loader: failingLoader{},
+	})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err == nil {
+		t.Fatal("expected ExecCommand.Run to reject --chdir with --from")
+	}
+	if got, want := outcome.err.Error(), "--chdir cannot be used with --from"; !strings.Contains(got, want) {
 		t.Fatalf("expected error to contain %q, got %q", want, got)
 	}
 }

--- a/internal/cli/execution_shared.go
+++ b/internal/cli/execution_shared.go
@@ -76,6 +76,27 @@ func ensureSandboxID(client *controlclient.Client, loader policyLoader, cwd, hos
 	return sandboxID, true, nil
 }
 
+func validateExecutionSandboxArgs(chdir, existingSandboxID, fromSnapshot string, keep bool) error {
+	sandboxID := strings.TrimSpace(existingSandboxID)
+	snapshotID := strings.TrimSpace(fromSnapshot)
+	hasChdir := strings.TrimSpace(chdir) != ""
+
+	if sandboxID != "" && snapshotID != "" {
+		return errors.New("--from cannot be used with --in")
+	}
+	if sandboxID != "" && keep {
+		return errors.New("--keep cannot be used with --in")
+	}
+	if sandboxID != "" && hasChdir {
+		return errors.New("--chdir cannot be used with --in")
+	}
+	if snapshotID != "" && hasChdir {
+		return errors.New("--chdir cannot be used with --from")
+	}
+
+	return nil
+}
+
 func getFinalExecutionExitCode(client *controlclient.Client, sandboxID, executionID string) (int, bool) {
 	getResp, err := client.GetExecution(context.Background(), &cleanroomv1.GetExecutionRequest{
 		SandboxId:   sandboxID,

--- a/internal/cli/image_override_integration_test.go
+++ b/internal/cli/image_override_integration_test.go
@@ -70,7 +70,6 @@ func TestSandboxCreateIntegrationOverridesImageRefForNewSandbox(t *testing.T) {
 
 	execOutcome := runExecWithCapture(ExecCommand{
 		clientFlags: clientFlags{Host: host},
-		Chdir:       cwd,
 		In:          sandboxID,
 		Command:     []string{"echo", "ok"},
 	}, runtimeContext{

--- a/internal/cli/repository_test.go
+++ b/internal/cli/repository_test.go
@@ -382,7 +382,6 @@ func TestExecCommandRunsInsideRepositoryPathWhenReusingSandboxID(t *testing.T) {
 
 	outcome := runExecWithCapture(ExecCommand{
 		clientFlags: clientFlags{Host: host},
-		Chdir:       repoDir,
 		In:          sandboxID,
 		Command:     []string{"echo", "ok"},
 	}, runtimeContext{
@@ -460,7 +459,6 @@ func TestExecCommandSkipsRepositoryBootstrapForExistingSandboxID(t *testing.T) {
 
 	outcome := runExecWithCapture(ExecCommand{
 		clientFlags: clientFlags{Host: host},
-		Chdir:       repoDir,
 		In:          sandboxID,
 		Command:     []string{"echo", "ok"},
 	}, runtimeContext{
@@ -569,7 +567,6 @@ func TestExecCommandWithSandboxIDAllowsMissingPolicyInCurrentDirectory(t *testin
 	outcome := runExecWithCapture(ExecCommand{
 		clientFlags: clientFlags{Host: host},
 		In:          sandboxID,
-		Chdir:       t.TempDir(),
 		Command:     []string{"echo", "ok"},
 	}, runtimeContext{
 		CWD:    t.TempDir(),
@@ -825,7 +822,6 @@ func TestExecCommandSkipsRepositoryBootstrapForExistingSandboxOnNonPersistentBac
 
 	outcome := runExecWithCapture(ExecCommand{
 		clientFlags: clientFlags{Host: host},
-		Chdir:       repoDir,
 		In:          sandboxID,
 		Command:     []string{"echo", "ok"},
 	}, runtimeContext{

--- a/scripts/ci-cleanroom-e2e.sh
+++ b/scripts/ci-cleanroom-e2e.sh
@@ -246,8 +246,8 @@ if [[ -z "$sandbox_id" ]]; then
 fi
 echo "sandbox id: $sandbox_id"
 
-./dist/cleanroom exec --host "$listen_endpoint" -c "$PWD" --in "$sandbox_id" -- sh -lc 'printf persisted-data >/tmp/persist.txt'
-./dist/cleanroom exec --host "$listen_endpoint" -c "$PWD" --in "$sandbox_id" -- sh -lc 'cat /tmp/persist.txt' | tee "$tmpdir/persist-read.out"
+./dist/cleanroom exec --host "$listen_endpoint" --in "$sandbox_id" -- sh -lc 'printf persisted-data >/tmp/persist.txt'
+./dist/cleanroom exec --host "$listen_endpoint" --in "$sandbox_id" -- sh -lc 'cat /tmp/persist.txt' | tee "$tmpdir/persist-read.out"
 if ! grep -q '^persisted-data$' "$tmpdir/persist-read.out"; then
   echo "expected persisted sandbox file contents from second execution" >&2
   exit 1
@@ -273,7 +273,7 @@ if ! grep -q 'sandbox terminated' "$tmpdir/sandbox-rm.out"; then
 fi
 
 set +e
-./dist/cleanroom exec --host "$listen_endpoint" -c "$PWD" --in "$sandbox_id" -- sh -lc 'echo should-not-run' >"$tmpdir/terminated.out" 2>"$tmpdir/terminated.err"
+./dist/cleanroom exec --host "$listen_endpoint" --in "$sandbox_id" -- sh -lc 'echo should-not-run' >"$tmpdir/terminated.out" 2>"$tmpdir/terminated.err"
 terminated_status=$?
 set -e
 if [[ "$terminated_status" -eq 0 ]]; then

--- a/scripts/ci_cleanroom_e2e_behavior_test.go
+++ b/scripts/ci_cleanroom_e2e_behavior_test.go
@@ -59,7 +59,7 @@ func TestCiCleanroomE2EVerifyHelperCapabilitiesDetectsMissingCapabilities(t *tes
 
 	annotationPath := filepath.Join(workDir, "annotation.md")
 	helperPath := filepath.Join(workDir, "helper.sh")
-	writeExecutable(t, helperPath, "#!/usr/bin/env bash\nprintf 'firecracker-network\\n'\n")
+	writeExecutable(t, helperPath, "#!/usr/bin/env bash\nprintf 'unrelated-capability\\n'\n")
 	writeExecutable(t, filepath.Join(binDir, "sudo"), "#!/usr/bin/env bash\n[[ \"$1\" == \"-n\" ]] && shift\nexec \"$@\"\n")
 	writeExecutable(t, filepath.Join(binDir, "buildkite-agent"), "#!/usr/bin/env bash\ncat >\"$ANNOTATION_FILE\"\n")
 
@@ -83,7 +83,7 @@ fi
 	if !strings.Contains(stderr, "missing required capabilities") {
 		t.Fatalf("expected missing capabilities in stderr, got %q", stderr)
 	}
-	if !strings.Contains(stderr, "firecracker-rootfs") {
+	if !strings.Contains(stderr, "firecracker-network") {
 		t.Fatalf("expected missing capability name in stderr, got %q", stderr)
 	}
 

--- a/scripts/ci_cleanroom_e2e_test.go
+++ b/scripts/ci_cleanroom_e2e_test.go
@@ -79,3 +79,27 @@ func TestCiCleanroomE2EProbesHelperCapabilitiesInsteadOfHelperDrift(t *testing.T
 		}
 	}
 }
+
+func TestCiCleanroomE2EReusedSandboxExecOmitsChdir(t *testing.T) {
+	t.Helper()
+
+	content, err := os.ReadFile("ci-cleanroom-e2e.sh")
+	if err != nil {
+		t.Fatalf("read ci-cleanroom-e2e.sh: %v", err)
+	}
+
+	script := string(content)
+	for _, needle := range []string{
+		"./dist/cleanroom exec --host \"$listen_endpoint\" --in \"$sandbox_id\" -- sh -lc 'printf persisted-data >/tmp/persist.txt'",
+		"./dist/cleanroom exec --host \"$listen_endpoint\" --in \"$sandbox_id\" -- sh -lc 'cat /tmp/persist.txt' | tee \"$tmpdir/persist-read.out\"",
+		"./dist/cleanroom exec --host \"$listen_endpoint\" --in \"$sandbox_id\" -- sh -lc 'echo should-not-run' >\"$tmpdir/terminated.out\" 2>\"$tmpdir/terminated.err\"",
+	} {
+		if !strings.Contains(script, needle) {
+			t.Fatalf("expected ci-cleanroom-e2e.sh to contain %q", needle)
+		}
+	}
+
+	if strings.Contains(script, "./dist/cleanroom exec --host \"$listen_endpoint\" -c \"$PWD\" --in \"$sandbox_id\"") {
+		t.Fatal("expected ci-cleanroom-e2e.sh not to pass --chdir when reusing a sandbox")
+	}
+}


### PR DESCRIPTION
## Summary
- reject `--chdir` for `cleanroom exec` and `cleanroom console` when paired with `--in` or `--from`
- centralize the validation for execution-style sandbox arguments
- update integration tests to cover the new errors and remove old no-op `--chdir` usage from sandbox-reuse cases

## Testing
- `mise exec -- go test ./internal/cli`