### PR TITLE
feat(cli): add top-level inspect command

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@ When `rootfs` is unset, Cleanroom derives one from `sandbox.image.ref` and injec
 ```bash
 cleanroom doctor              # check host prerequisites
 cleanroom doctor --json       # machine-readable with capabilities map
+cleanroom inspect <typeid>
 cleanroom sandbox inspect <sandbox-id>
 cleanroom execution inspect <execution-id>
 cleanroom execution inspect --sandbox-id <sandbox-id> --last

--- a/docs/api.md
+++ b/docs/api.md
@@ -286,6 +286,7 @@ and `--dangerously-allow-all` cannot be combined with `--from`.
 
 ### 9.3 Execution commands
 
+- `cleanroom inspect <typeid>`
 - `cleanroom execution inspect <execution-id>`
 - `cleanroom execution inspect --sandbox-id <sandbox-id> --last`
 - `cleanroom status --execution-id <execution-id>`

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -446,6 +446,7 @@ Policy feature mapping:
   - `cleanroom policy validate`
   - `cleanroom exec [--] <command>`
   - `cleanroom console [--] <command>`
+  - `cleanroom inspect <typeid>`
   - `cleanroom sandbox inspect <sandbox-id>`
   - `cleanroom sandbox ls`
   - `cleanroom sandbox rm <sandbox-id>`

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -47,6 +47,7 @@ type CLI struct {
 	Policy    PolicyCommand    `cmd:"" help:"Policy commands"`
 	Config    ConfigCommand    `cmd:"" help:"Runtime config commands"`
 	Image     ImageCommand     `cmd:"" help:"Manage OCI image cache artifacts"`
+	Inspect   InspectCommand   `cmd:"" help:"Inspect a sandbox, execution, or snapshot by ID"`
 	Snapshot  SnapshotCommand  `cmd:"" help:"Manage snapshots"`
 	Create    CreateCommand    `cmd:"" help:"Create a sandbox using repo policy"`
 	Exec      ExecCommand      `cmd:"" help:"Execute a command in a sandbox"`

--- a/internal/cli/cli_parse_test.go
+++ b/internal/cli/cli_parse_test.go
@@ -105,6 +105,21 @@ func TestSnapshotInspectParses(t *testing.T) {
 	}
 }
 
+func TestTopLevelInspectParses(t *testing.T) {
+	c := &CLI{}
+	parser := newParserForTest(t, c)
+
+	if _, err := parser.Parse([]string{"inspect", "exec_123", "--json"}); err != nil {
+		t.Fatalf("parse inspect returned error: %v", err)
+	}
+	if got, want := c.Inspect.ID, "exec_123"; got != want {
+		t.Fatalf("unexpected inspect id: got %q want %q", got, want)
+	}
+	if !c.Inspect.JSON {
+		t.Fatal("expected inspect --json flag to be set")
+	}
+}
+
 func TestSandboxCreateParses(t *testing.T) {
 	c := &CLI{}
 	parser := newParserForTest(t, c)

--- a/internal/cli/inspect.go
+++ b/internal/cli/inspect.go
@@ -1,0 +1,77 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"go.jetify.com/typeid"
+)
+
+type InspectCommand struct {
+	clientFlags
+	ID   string `arg:"" required:"" help:"Sandbox, execution, or snapshot ID to inspect"`
+	JSON bool   `help:"Print inspection as JSON"`
+}
+
+func (c *InspectCommand) Run(ctx *runtimeContext) error {
+	targetID := strings.TrimSpace(c.ID)
+	kind, err := inspectTargetKind(targetID)
+	if err != nil {
+		return err
+	}
+
+	switch kind {
+	case "sandbox":
+		return (&SandboxInspectCommand{
+			clientFlags: c.clientFlags,
+			SandboxID:   targetID,
+			JSON:        c.JSON,
+		}).Run(ctx)
+	case "execution":
+		return (&ExecutionInspectCommand{
+			clientFlags: c.clientFlags,
+			ExecutionID: targetID,
+			JSON:        c.JSON,
+		}).Run(ctx)
+	case "snapshot":
+		return (&SnapshotInspectCommand{
+			clientFlags: c.clientFlags,
+			SnapshotID:  targetID,
+			JSON:        c.JSON,
+		}).Run(ctx)
+	default:
+		return fmt.Errorf("unsupported inspect target %q", targetID)
+	}
+}
+
+func inspectTargetKind(id string) (string, error) {
+	targetID := strings.TrimSpace(id)
+	if targetID == "" {
+		return "", fmt.Errorf("missing inspect target id")
+	}
+
+	parsed, err := typeid.FromString(targetID)
+	if err == nil {
+		switch parsed.Prefix() {
+		case "cr":
+			return "sandbox", nil
+		case "exec":
+			return "execution", nil
+		case "snap":
+			return "snapshot", nil
+		default:
+			return "", fmt.Errorf("unsupported inspect target prefix %q", parsed.Prefix())
+		}
+	}
+
+	switch {
+	case strings.HasPrefix(targetID, "cr-"):
+		return "sandbox", nil
+	case strings.HasPrefix(targetID, "exec-"):
+		return "execution", nil
+	case strings.HasPrefix(targetID, "snap-"):
+		return "snapshot", nil
+	default:
+		return "", fmt.Errorf("unrecognized inspect target %q: expected sandbox, execution, or snapshot id", targetID)
+	}
+}

--- a/internal/cli/inspect_integration_test.go
+++ b/internal/cli/inspect_integration_test.go
@@ -1,0 +1,126 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+)
+
+func runInspectWithCapture(cmd InspectCommand, ctx runtimeContext) execOutcome {
+	return runWithCapture(func(runCtx *runtimeContext) error {
+		return cmd.Run(runCtx)
+	}, nil, ctx)
+}
+
+func TestInspectIntegrationDispatchesSandboxID(t *testing.T) {
+	host, _ := startIntegrationServer(t, &integrationAdapter{})
+	cwd := t.TempDir()
+
+	client := mustNewControlClient(t, host)
+	sandboxID := mustCreateSandbox(t, client)
+
+	outcome := runInspectWithCapture(InspectCommand{
+		clientFlags: clientFlags{Host: host},
+		ID:          sandboxID,
+	}, runtimeContext{CWD: cwd})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err != nil {
+		t.Fatalf("InspectCommand.Run returned error: %v", outcome.err)
+	}
+	assertContainsAll(t, outcome.stdout, "sandbox: "+sandboxID, "status: ready")
+}
+
+func TestInspectIntegrationDispatchesExecutionID(t *testing.T) {
+	host, svc := startIntegrationServer(t, &integrationAdapter{})
+	cwd := t.TempDir()
+
+	client := mustNewControlClient(t, host)
+	sandboxID := mustCreateSandbox(t, client)
+
+	createExecutionResp, err := client.CreateExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
+		SandboxId: sandboxID,
+		Command:   []string{"echo", "ok"},
+		Kind:      cleanroomv1.ExecutionKind_EXECUTION_KIND_BATCH,
+	})
+	if err != nil {
+		t.Fatalf("CreateExecution returned error: %v", err)
+	}
+	executionID := createExecutionResp.GetExecution().GetExecutionId()
+	if _, err := svc.WaitExecution(context.Background(), sandboxID, executionID); err != nil {
+		t.Fatalf("WaitExecution returned error: %v", err)
+	}
+
+	outcome := runInspectWithCapture(InspectCommand{
+		clientFlags: clientFlags{Host: host},
+		ID:          executionID,
+	}, runtimeContext{CWD: cwd})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err != nil {
+		t.Fatalf("InspectCommand.Run returned error: %v", outcome.err)
+	}
+	assertContainsAll(t, outcome.stdout, "execution: "+executionID, "sandbox: "+sandboxID, "status: succeeded")
+}
+
+func TestInspectIntegrationDispatchesSnapshotID(t *testing.T) {
+	adapter := &snapshotIntegrationAdapter{}
+	host, _ := startIntegrationServer(t, adapter)
+	cwd := t.TempDir()
+
+	client := mustNewControlClient(t, host)
+	sandboxID := mustCreateSandbox(t, client)
+
+	createOutcome := runSnapshotCreateWithCapture(SnapshotCreateCommand{
+		clientFlags: clientFlags{Host: host},
+		SandboxID:   sandboxID,
+		Name:        "golden",
+	}, runtimeContext{CWD: cwd})
+	if createOutcome.cause != nil {
+		t.Fatalf("capture failure: %v", createOutcome.cause)
+	}
+	if createOutcome.err != nil {
+		t.Fatalf("SnapshotCreateCommand.Run returned error: %v", createOutcome.err)
+	}
+	snapshotID := strings.TrimSpace(createOutcome.stdout)
+
+	outcome := runInspectWithCapture(InspectCommand{
+		clientFlags: clientFlags{Host: host},
+		ID:          snapshotID,
+		JSON:        true,
+	}, runtimeContext{CWD: cwd})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err != nil {
+		t.Fatalf("InspectCommand.Run returned error: %v", outcome.err)
+	}
+
+	var snapshot cleanroomv1.Snapshot
+	if err := json.Unmarshal([]byte(outcome.stdout), &snapshot); err != nil {
+		t.Fatalf("parse snapshot json: %v", err)
+	}
+	if got, want := snapshot.GetSnapshotId(), snapshotID; got != want {
+		t.Fatalf("unexpected snapshot id: got %q want %q", got, want)
+	}
+}
+
+func TestInspectCommandRejectsUnknownIDKind(t *testing.T) {
+	outcome := runInspectWithCapture(InspectCommand{
+		ID: "weird_123",
+	}, runtimeContext{CWD: t.TempDir()})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err == nil {
+		t.Fatal("expected validation error")
+	}
+	if !strings.Contains(outcome.err.Error(), "unrecognized inspect target") {
+		t.Fatalf("unexpected validation error: %v", outcome.err)
+	}
+}


### PR DESCRIPTION
## Summary
- add `cleanroom inspect <typeid>` as a top-level dispatcher for sandbox, execution, and snapshot inspection
- route by TypeID prefix so existing inspect subcommands stay the canonical implementation
- add parser and integration coverage for sandbox, execution, snapshot, and invalid IDs

## Testing
- `mise exec -- go test ./internal/cli -run 'TestTopLevelInspectParses|TestInspectIntegrationDispatchesSandboxID|TestInspectIntegrationDispatchesExecutionID|TestInspectIntegrationDispatchesSnapshotID|TestInspectCommandRejectsUnknownIDKind|TestExecutionInspectIntegrationSupportsGlobalExecutionID|TestSandboxInspectIntegrationShowsExecutionPointers|TestSnapshotCommandsIntegrationLifecycle' -count=1`