### PR TITLE
[codex] bump prod cleanroom to v0.4.0

### DIFF
--- a/infra/terraform/envs/prod/prod.ap-southeast-2.tfvars
+++ b/infra/terraform/envs/prod/prod.ap-southeast-2.tfvars
@@ -15,7 +15,7 @@ git_deploy_key_parameter_name     = "/buildkite/cleanroom/deploy-key"
 repo_url                     = "git@github.com:buildkite/cleanroom.git"
 repo_ref                     = "main"
 setup_script_path            = "scripts/bootstrap-cleanroom-host.sh"
-cleanroom_version            = "v0.3.0"
+cleanroom_version            = "v0.4.0"
 cleanroom_install_script_ref = "main"
 
 tailscale_hostname_prefix = "cleanroom-prod-apse2-linux"

--- a/infra/terraform/envs/prod/prod.us-west-2.tfvars
+++ b/infra/terraform/envs/prod/prod.us-west-2.tfvars
@@ -15,7 +15,7 @@ git_deploy_key_parameter_name     = "/buildkite/cleanroom/deploy-key"
 repo_url                     = "git@github.com:buildkite/cleanroom.git"
 repo_ref                     = "main"
 setup_script_path            = "scripts/bootstrap-cleanroom-host.sh"
-cleanroom_version            = "v0.3.0"
+cleanroom_version            = "v0.4.0"
 cleanroom_install_script_ref = "main"
 
 tailscale_hostname_prefix = "cleanroom-prod-usw2-linux"

--- a/infra/terraform/envs/prod/terraform.tfvars.example
+++ b/infra/terraform/envs/prod/terraform.tfvars.example
@@ -15,7 +15,7 @@ git_deploy_key_parameter_name     = "/buildkite/cleanroom/deploy-key"
 repo_url          = "git@github.com:buildkite/cleanroom.git"
 repo_ref          = "main"
 setup_script_path = "scripts/bootstrap-cleanroom-host.sh"
-cleanroom_version = "v0.3.0"
+cleanroom_version = "v0.4.0"
 # cleanroom_release_repo = "buildkite/cleanroom"
 
 tailscale_hostname_prefix = "cleanroom-prod-apse2-linux"


### PR DESCRIPTION
## What changed

Bump the prod Terraform release pins from `v0.3.0` to `v0.4.0` in the checked-in prod var-files and example config.

## Why

The Sydney prod host was upgraded to `cleanroom v0.4.0` directly on-host. Keeping the prod bootstrap tfvars at `v0.3.0` would let a future bootstrap or reprovision drift the host back to the older release.

## Impact

Future prod bootstrap runs and new prod hosts will install `v0.4.0` instead of reverting to `v0.3.0`.

## Validation

- `terraform fmt -check infra/terraform/envs/prod/prod.ap-southeast-2.tfvars infra/terraform/envs/prod/prod.us-west-2.tfvars`
- `git diff --check`
