### PR TITLE
fix: harden Firecracker ZFS snapshot lifecycle

### DIFF
--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -509,9 +509,6 @@ func (a *Adapter) CreateSnapshot(ctx context.Context, req backend.SnapshotReques
 	if err := pauseSandboxProcess(instance); err != nil {
 		return nil, err
 	}
-	if err := flushSnapshotHostFilesystem(ctx, driverCfg.Snapshots.Driver); err != nil {
-		return nil, err
-	}
 	snapshotStorageRef := ""
 	paused := true
 	defer func() {
@@ -533,6 +530,9 @@ func (a *Adapter) CreateSnapshot(ctx context.Context, req backend.SnapshotReques
 			retErr = fmt.Errorf("resume firecracker sandbox after snapshot: %w", err)
 		}
 	}()
+	if err := flushSnapshotHostFilesystem(ctx, driverCfg.Snapshots.Driver); err != nil {
+		return nil, err
+	}
 
 	snapshot, err := driver.SnapshotVolume(ctx, volumestore.SnapshotVolumeRequest{
 		SnapshotID: snapshotID,

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -118,6 +118,10 @@ var sendProcessSignal = func(proc *os.Process, sig syscall.Signal) error {
 	return proc.Signal(sig)
 }
 
+var syncHostFilesystem = defaultSyncHostFilesystem
+
+var snapshotVolumeStoreDriverFn = snapshotVolumeStoreDriver
+
 const guestInitScriptTemplate = `#!/bin/sh
 set -eu
 
@@ -498,11 +502,14 @@ func (a *Adapter) CreateSnapshot(ctx context.Context, req backend.SnapshotReques
 	if err != nil {
 		return nil, err
 	}
-	driver, err := snapshotVolumeStoreDriver(driverCfg)
+	driver, err := snapshotVolumeStoreDriverFn(driverCfg)
 	if err != nil {
 		return nil, err
 	}
 	if err := pauseSandboxProcess(instance); err != nil {
+		return nil, err
+	}
+	if err := flushSnapshotHostFilesystem(ctx, driverCfg.Snapshots.Driver); err != nil {
 		return nil, err
 	}
 	snapshotStorageRef := ""
@@ -1861,6 +1868,26 @@ func snapshotVolumeStoreDriver(cfg backend.FirecrackerConfig) (volumestore.Drive
 		return nil, errors.New("firecracker snapshots are not enabled")
 	}
 	return rootFSVolumeStoreDriver(cfg)
+}
+
+func defaultSyncHostFilesystem(ctx context.Context) error {
+	return runCombinedCommand(ctx, []string{"sync"}, []string{"host", "sync"})
+}
+
+func flushSnapshotHostFilesystem(ctx context.Context, driverName string) error {
+	if !snapshotDriverNeedsHostSync(driverName) {
+		return nil
+	}
+	// ZFS snapshots persist pool state, not the current host page cache.
+	// Flush after the guest is paused so the snapshot captures its latest writes.
+	if err := syncHostFilesystem(ctx); err != nil {
+		return fmt.Errorf("sync host filesystem before snapshot: %w", err)
+	}
+	return nil
+}
+
+func snapshotDriverNeedsHostSync(driverName string) bool {
+	return strings.EqualFold(strings.TrimSpace(driverName), "zfs")
 }
 
 func pauseSandboxProcess(instance *sandboxInstance) error {

--- a/internal/backend/firecracker/snapshot_test.go
+++ b/internal/backend/firecracker/snapshot_test.go
@@ -228,6 +228,82 @@ func TestCreateSnapshotFlushesHostFilesystemForZFSSnapshots(t *testing.T) {
 	}
 }
 
+func TestCreateSnapshotResumesSandboxWhenHostSyncFails(t *testing.T) {
+	prevSync := syncHostFilesystem
+	prevSnapshotDriver := snapshotVolumeStoreDriverFn
+	prevSignal := sendProcessSignal
+	t.Cleanup(func() {
+		syncHostFilesystem = prevSync
+		snapshotVolumeStoreDriverFn = prevSnapshotDriver
+		sendProcessSignal = prevSignal
+	})
+
+	var signals []syscall.Signal
+	sendProcessSignal = func(_ *os.Process, sig syscall.Signal) error {
+		signals = append(signals, sig)
+		return nil
+	}
+
+	syncHostFilesystem = func(context.Context) error {
+		return errors.New("host sync failed")
+	}
+	snapshotVolumeStoreDriverFn = func(cfg backend.FirecrackerConfig) (volumestore.Driver, error) {
+		if got, want := cfg.Snapshots.Driver, "zfs"; got != want {
+			t.Fatalf("unexpected snapshot driver: got %q want %q", got, want)
+		}
+		return testVolumeDriver{
+			snapshotVolumeFn: func(context.Context, volumestore.SnapshotVolumeRequest) (volumestore.Snapshot, error) {
+				t.Fatal("snapshot should not run after host sync failure")
+				return volumestore.Snapshot{}, nil
+			},
+		}, nil
+	}
+
+	adapter := &Adapter{
+		runGuestCommandFn: func(_ context.Context, _ context.Context, _ <-chan struct{}, _ func() error, _ string, _ uint32, req vsockexec.ExecRequest, _ backend.OutputStream) (vsockexec.ExecResponse, guestExecTiming, error) {
+			if len(req.Command) != 1 || req.Command[0] != "sync" {
+				t.Fatalf("unexpected command: %v", req.Command)
+			}
+			return vsockexec.ExecResponse{ExitCode: 0}, guestExecTiming{}, nil
+		},
+		sandboxes: map[string]*sandboxInstance{
+			"cr-test": {
+				SandboxID:    "cr-test",
+				VsockPath:    "/tmp/fake.sock",
+				GuestPort:    10700,
+				fcCmd:        &exec.Cmd{Process: &os.Process{Pid: 42}},
+				exitedCh:     make(chan struct{}),
+				vmRootFSPath: "/dev/zvol/tank/cleanroom/sandboxes/cr-test",
+				volumeRef:    "tank/cleanroom/sandboxes/cr-test",
+			},
+		},
+	}
+
+	result, err := adapter.CreateSnapshot(context.Background(), backend.SnapshotRequest{
+		SandboxID:  "cr-test",
+		SnapshotID: "snap-test",
+		FirecrackerConfig: backend.FirecrackerConfig{
+			Snapshots: backend.SnapshotConfig{
+				Enabled:    true,
+				Driver:     "zfs",
+				ZFSDataset: "tank/cleanroom",
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected CreateSnapshot to fail when host sync fails")
+	}
+	if result != nil {
+		t.Fatalf("expected nil snapshot result, got %#v", result)
+	}
+	if !strings.Contains(err.Error(), "host sync failed") {
+		t.Fatalf("expected host sync error, got %v", err)
+	}
+	if got, want := signals, []syscall.Signal{syscall.SIGSTOP, syscall.SIGCONT}; strings.Join(signalStrings(got), ",") != strings.Join(signalStrings(want), ",") {
+		t.Fatalf("unexpected signals: got %v want %v", got, want)
+	}
+}
+
 func TestCreateSnapshotReturnsErrorWhenGuestSyncExitsNonZero(t *testing.T) {
 	stateHome := t.TempDir()
 	t.Setenv("XDG_STATE_HOME", stateHome)
@@ -452,6 +528,14 @@ func TestCreateSnapshotReturnsErrorWhenSandboxResumeFails(t *testing.T) {
 	if _, statErr := os.Stat(snapshotPath); !os.IsNotExist(statErr) {
 		t.Fatalf("expected failed snapshot to be cleaned up, stat error = %v", statErr)
 	}
+}
+
+func signalStrings(signals []syscall.Signal) []string {
+	out := make([]string, 0, len(signals))
+	for _, sig := range signals {
+		out = append(out, sig.String())
+	}
+	return out
 }
 
 func TestProvisionSandboxFromSnapshotUsesSnapshotRootFS(t *testing.T) {

--- a/internal/backend/firecracker/snapshot_test.go
+++ b/internal/backend/firecracker/snapshot_test.go
@@ -151,6 +151,83 @@ func TestCreateSnapshotSyncsPausesAndClonesRootFS(t *testing.T) {
 	}
 }
 
+func TestCreateSnapshotFlushesHostFilesystemForZFSSnapshots(t *testing.T) {
+	prevSignal := sendProcessSignal
+	sendProcessSignal = func(_ *os.Process, _ syscall.Signal) error { return nil }
+	t.Cleanup(func() { sendProcessSignal = prevSignal })
+
+	prevSync := syncHostFilesystem
+	prevSnapshotDriver := snapshotVolumeStoreDriverFn
+	t.Cleanup(func() {
+		syncHostFilesystem = prevSync
+		snapshotVolumeStoreDriverFn = prevSnapshotDriver
+	})
+
+	var calls []string
+	syncHostFilesystem = func(context.Context) error {
+		calls = append(calls, "host-sync")
+		return nil
+	}
+	snapshotVolumeStoreDriverFn = func(cfg backend.FirecrackerConfig) (volumestore.Driver, error) {
+		if got, want := cfg.Snapshots.Driver, "zfs"; got != want {
+			t.Fatalf("unexpected snapshot driver: got %q want %q", got, want)
+		}
+		return testVolumeDriver{
+			snapshotVolumeFn: func(_ context.Context, req volumestore.SnapshotVolumeRequest) (volumestore.Snapshot, error) {
+				if got, want := calls, []string{"host-sync"}; strings.Join(got, ",") != strings.Join(want, ",") {
+					t.Fatalf("expected host sync before snapshot, got %v", got)
+				}
+				if got, want := req.VolumeRef, "tank/cleanroom/sandboxes/cr-test"; got != want {
+					t.Fatalf("unexpected volume ref: got %q want %q", got, want)
+				}
+				calls = append(calls, "snapshot")
+				return volumestore.Snapshot{StorageRef: "tank/cleanroom/snapshots/snap-test@seed"}, nil
+			},
+		}, nil
+	}
+
+	adapter := &Adapter{
+		runGuestCommandFn: func(_ context.Context, _ context.Context, _ <-chan struct{}, _ func() error, _ string, _ uint32, req vsockexec.ExecRequest, _ backend.OutputStream) (vsockexec.ExecResponse, guestExecTiming, error) {
+			if len(req.Command) != 1 || req.Command[0] != "sync" {
+				t.Fatalf("unexpected command: %v", req.Command)
+			}
+			return vsockexec.ExecResponse{ExitCode: 0}, guestExecTiming{}, nil
+		},
+		sandboxes: map[string]*sandboxInstance{
+			"cr-test": {
+				SandboxID:    "cr-test",
+				VsockPath:    "/tmp/fake.sock",
+				GuestPort:    10700,
+				fcCmd:        &exec.Cmd{Process: &os.Process{Pid: 42}},
+				exitedCh:     make(chan struct{}),
+				vmRootFSPath: "/dev/zvol/tank/cleanroom/sandboxes/cr-test",
+				volumeRef:    "tank/cleanroom/sandboxes/cr-test",
+			},
+		},
+	}
+
+	result, err := adapter.CreateSnapshot(context.Background(), backend.SnapshotRequest{
+		SandboxID:  "cr-test",
+		SnapshotID: "snap-test",
+		FirecrackerConfig: backend.FirecrackerConfig{
+			Snapshots: backend.SnapshotConfig{
+				Enabled:    true,
+				Driver:     "zfs",
+				ZFSDataset: "tank/cleanroom",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateSnapshot returned error: %v", err)
+	}
+	if got, want := result.StorageRef, "tank/cleanroom/snapshots/snap-test@seed"; got != want {
+		t.Fatalf("unexpected snapshot storage ref: got %q want %q", got, want)
+	}
+	if got, want := calls, []string{"host-sync", "snapshot"}; strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("unexpected call order: got %v want %v", got, want)
+	}
+}
+
 func TestCreateSnapshotReturnsErrorWhenGuestSyncExitsNonZero(t *testing.T) {
 	stateHome := t.TempDir()
 	t.Setenv("XDG_STATE_HOME", stateHome)
@@ -192,6 +269,31 @@ func TestCreateSnapshotReturnsErrorWhenGuestSyncExitsNonZero(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected CreateSnapshot to fail when guest sync exits non-zero")
+	}
+}
+
+func TestSnapshotDriverNeedsHostSync(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		driverName string
+		want       bool
+	}{
+		{name: "zfs", driverName: "zfs", want: true},
+		{name: "trimmed zfs", driverName: " ZFS ", want: true},
+		{name: "file", driverName: "file", want: false},
+		{name: "empty", driverName: "", want: false},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := snapshotDriverNeedsHostSync(tc.driverName); got != tc.want {
+				t.Fatalf("snapshotDriverNeedsHostSync(%q) = %t, want %t", tc.driverName, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -183,8 +183,7 @@ func (e *ExecCommand) Run(ctx *runtimeContext) (runErr error) {
 		return fmt.Errorf("stream execution: %w", err)
 	}
 
-	stdinErrCh := startExecutionStdinForwarder(client, sandboxID, executionID, e.NoStdin)
-	stdinErrCh = monitorExecutionStdinErr(streamCtx, streamCancel, stdinErrCh)
+	stdinErrCh := startExecutionStdinForwarder(client, sandboxID, executionID, e.NoStdin, streamCancel)
 
 	signalCh := newSignalChannel()
 	notifySignals(signalCh, os.Interrupt, syscall.SIGTERM)

--- a/internal/cli/execution_shared.go
+++ b/internal/cli/execution_shared.go
@@ -116,6 +116,7 @@ func startExecutionStdinForwarder(
 	client *controlclient.Client,
 	sandboxID, executionID string,
 	closeImmediately bool,
+	cancel context.CancelFunc,
 ) <-chan error {
 	errCh := make(chan error, 1)
 	go func() {
@@ -124,9 +125,19 @@ func startExecutionStdinForwarder(
 			return
 		}
 
+		reportErr := func(err error) {
+			if err == nil {
+				return
+			}
+			errCh <- err
+			if cancel != nil {
+				cancel()
+			}
+		}
+
 		if closeImmediately {
 			if err := closeExecutionStdin(client, sandboxID, executionID); err != nil {
-				errCh <- err
+				reportErr(err)
 			}
 			return
 		}
@@ -148,14 +159,14 @@ func startExecutionStdinForwarder(
 					if isBenignExecutionStdinErr(err) {
 						return
 					}
-					errCh <- fmt.Errorf("write execution stdin: %w", err)
+					reportErr(fmt.Errorf("write execution stdin: %w", err))
 					return
 				}
 			}
 			if readErr != nil {
 				if err := closeExecutionStdin(client, sandboxID, executionID); err != nil &&
 					!(isExecutionStdinUnsupportedErr(err) && !sentInput) {
-					errCh <- err
+					reportErr(err)
 				}
 				return
 			}
@@ -206,35 +217,6 @@ func closeExecutionStdin(client *controlclient.Client, sandboxID, executionID st
 		return fmt.Errorf("close execution stdin: %w", err)
 	}
 	return nil
-}
-
-func monitorExecutionStdinErr(
-	ctx context.Context,
-	cancel context.CancelFunc,
-	errCh <-chan error,
-) <-chan error {
-	if errCh == nil {
-		return nil
-	}
-
-	monitoredErrCh := make(chan error, 1)
-	go func() {
-		defer close(monitoredErrCh)
-
-		select {
-		case err, ok := <-errCh:
-			if !ok || err == nil {
-				return
-			}
-			monitoredErrCh <- err
-			if cancel != nil {
-				cancel()
-			}
-		case <-ctx.Done():
-		}
-	}()
-
-	return monitoredErrCh
 }
 
 func pollExecutionStdinErr(errCh <-chan error) error {

--- a/scripts/cleanroom-root-helper.sh
+++ b/scripts/cleanroom-root-helper.sh
@@ -111,6 +111,26 @@ is_zvol_device_path() {
   is_cleanroom_zfs_dataset "${p#/dev/zvol/}"
 }
 
+zvol_device_path_for_dataset() {
+  local dataset="$1"
+  printf '/dev/zvol/%s\n' "${dataset#/}"
+}
+
+wait_for_zvol_device_path() {
+  local dataset="$1"
+  local path
+  local attempt
+
+  path="$(zvol_device_path_for_dataset "$dataset")"
+  for attempt in {1..50}; do
+    if [[ -e "$path" ]]; then
+      return 0
+    fi
+    sleep 0.1
+  done
+  die "zfs: timed out waiting for zvol device '$path'"
+}
+
 zfs_bin() {
   if [[ -x /usr/sbin/zfs ]]; then
     echo /usr/sbin/zfs
@@ -270,10 +290,17 @@ run_zfs() {
     exec "$bin" "$@"
   fi
 
+  if [[ "$#" -eq 7 && "$1" == "list" && "$2" == "-H" && "$3" == "-d" && "$4" == "0" && "$5" == "-o" && "$6" == "name" ]]; then
+    is_cleanroom_zfs_dataset "$7" || die "zfs list -d 0: unsupported dataset '$7'"
+    exec "$bin" "$@"
+  fi
+
   if [[ "$#" -eq 5 && "$1" == "create" && "$2" == "-p" && "$3" == "-V" ]]; then
     is_numeric "$4" || die "zfs create: invalid size '$4'"
     is_cleanroom_zfs_dataset "$5" || die "zfs create: unsupported dataset '$5'"
-    exec "$bin" "$@"
+    "$bin" "$@"
+    wait_for_zvol_device_path "$5"
+    return
   fi
 
   if [[ "$#" -eq 2 && "$1" == "snapshot" ]]; then
@@ -284,7 +311,9 @@ run_zfs() {
   if [[ "$#" -eq 4 && "$1" == "clone" && "$2" == "-p" ]]; then
     is_cleanroom_zfs_snapshot_ref "$3" || die "zfs clone: unsupported snapshot '$3'"
     is_cleanroom_zfs_dataset "$4" || die "zfs clone: unsupported dataset '$4'"
-    exec "$bin" "$@"
+    "$bin" "$@"
+    wait_for_zvol_device_path "$4"
+    return
   fi
 
   if [[ "$#" -eq 3 && "$1" == "set" && "$2" == volsize=* ]]; then

--- a/scripts/cleanroom-root-helper.sh
+++ b/scripts/cleanroom-root-helper.sh
@@ -119,10 +119,9 @@ zvol_device_path_for_dataset() {
 wait_for_zvol_device_path() {
   local dataset="$1"
   local path
-  local attempt
 
   path="$(zvol_device_path_for_dataset "$dataset")"
-  for attempt in {1..50}; do
+  for _ in {1..50}; do
     if [[ -e "$path" ]]; then
       return 0
     fi


### PR DESCRIPTION
## Summary
- flush host-side buffered writes before taking Firecracker ZFS snapshots so restored sandboxes see the latest rootfs state
- keep the root helper aligned with the ZFS runtime by allowing the dataset-access doctor probe and waiting for cloned zvol device nodes to appear
- add Firecracker snapshot regression coverage for the ZFS host-sync path

## Root cause
ZFS snapshots were being taken after the guest ran `sync`, but before the host had flushed buffered writes for the zvol. That meant the stored snapshot could capture an older rootfs state than the live sandbox, which showed up as restored sandboxes missing `/workspace` after repo bootstrap.

## Impact
- snapshot-backed Firecracker sandboxes on ZFS restore the expected workspace contents again
- ZFS doctor checks and clone/create flows work reliably with the privileged helper

## Validation
- `mise exec -- go test ./internal/backend/firecracker ./internal/volumestore ./scripts -run 'Test(CreateSnapshot|SnapshotDriverNeedsHostSync|ZFSDriver|RootHelper|Helper)'`
- `bash -n scripts/cleanroom-root-helper.sh`
- remote validation on `cleanroom-prod-apse2-linux-i-0b35e6770b45a7db1` (`100.127.229.48`): repo-aware create, ZFS snapshot create, create-from-snapshot, exec from `/workspace`, interactive `console`, cleanup, and `cleanroom doctor` (`summary: 34 pass, 3 warn, 0 fail`)

## Notes
During validation I cleaned up one leftover test snapshot dataset directly after the listener had already dropped sandbox state. The restore regression itself is fixed by this change, but that cleanup edge may still be worth a separate follow-up if it reproduces consistently.