### PR TITLE
docs: add buildkite-agent example

### DIFF
--- a/examples/buildkite-agent/README.md
+++ b/examples/buildkite-agent/README.md
@@ -1,0 +1,59 @@
+# Buildkite Agent Example
+
+Runs the [buildkite/agent](https://github.com/buildkite/agent) test suite
+inside a cleanroom sandbox with deny-by-default egress, mise toolchain
+bootstrap, and Go module resolution.
+
+## Prerequisites
+
+Install cleanroom (`mise run install` from repository root) and ensure
+your runtime config has enough resources for a large Go build:
+
+```yaml
+# ~/.config/cleanroom/config.yaml
+backends:
+  darwin-vz:
+    memory_mib: 4096
+    minimum_rootfs_bytes: 12GiB
+```
+
+## Usage
+
+Run from this directory with a `cleanroom serve` instance running:
+
+```bash
+# Validate the policy
+cleanroom policy validate
+
+# Open an interactive shell in the checkout
+cleanroom console \
+  --backend darwin-vz \
+  --repo-url https://github.com/buildkite/agent.git \
+  --repo-commit 704a7e24737231681395b58604ca5174d2335712
+
+# Run the test suite
+cleanroom exec \
+  --backend darwin-vz \
+  --repo-url https://github.com/buildkite/agent.git \
+  --repo-commit 704a7e24737231681395b58604ca5174d2335712 \
+  -- go test -p 1 ./...
+```
+
+## Network allow list
+
+The `cleanroom.yaml` policy allows egress to the minimum set of hosts
+needed for mise tool installation and Go module resolution:
+
+| Host | Why |
+|---|---|
+| `github.com`, `api.github.com` | Git clone and GitHub API |
+| `release-assets.githubusercontent.com` | mise downloads golangci-lint from GitHub releases |
+| `dl.google.com` | mise downloads the Go SDK |
+| `proxy.golang.org`, `sum.golang.org` | Go module proxy and checksum database |
+| `storage.googleapis.com` | Go proxy redirects module payloads here |
+| `mise-versions.jdx.dev`, `mise.jdx.dev` | mise tool metadata resolution |
+
+## Notes
+
+- First run is slow: git clone, mise tool install, and Go module download
+- `go test -p 1` avoids OOM kills on constrained guest memory

--- a/examples/buildkite-agent/cleanroom.yaml
+++ b/examples/buildkite-agent/cleanroom.yaml
@@ -1,0 +1,30 @@
+version: 1
+repository:
+  enabled: false
+sandbox:
+  image:
+    ref: ghcr.io/buildkite/cleanroom-base/alpine@sha256:8eb2c1bc27af65d828ab6d93738a1adb1b62ef5b74417a273cedf3e7cec5f18b
+  network:
+    default: deny
+    allow:
+      - host: github.com
+        ports: [443]
+      - host: api.github.com
+        ports: [443]
+      - host: release-assets.githubusercontent.com
+        ports: [443]
+      - host: dl.google.com
+        ports: [443]
+      - host: proxy.golang.org
+        ports: [443]
+      - host: sum.golang.org
+        ports: [443]
+      - host: storage.googleapis.com
+        ports: [443]
+      - host: mise-versions.jdx.dev
+        ports: [443]
+      - host: mise.jdx.dev
+        ports: [443]
+      - host: tuf-repo-cdn.sigstore.dev
+        ports: [443]
+


### PR DESCRIPTION
Adds an example that runs the [buildkite/agent](https://github.com/buildkite/agent) test suite inside a cleanroom sandbox with:

- Deny-by-default egress policy with minimum allowlist for mise, Go modules, and GitHub
- Automatic mise toolchain bootstrap (Go SDK + golangci-lint)
- Repository checkout via `--repo-url` / `--repo-commit`

Includes a `cleanroom.yaml` policy and a concise README with usage instructions and a network allowlist reference table.