### PR TITLE
feat: use trusted dns policy in firecracker

### DIFF
--- a/docs/backend/firecracker.md
+++ b/docs/backend/firecracker.md
@@ -4,7 +4,7 @@
 
 ## Summary
 
-Cleanroom's primary Linux backend uses [Firecracker](https://github.com/firecracker-microvm/firecracker) microVMs with per-sandbox TAP networking and host iptables enforcement. Each sandbox gets a dedicated TAP interface, generated machine JSON, and a vsock guest-agent for command execution.
+Cleanroom's primary Linux backend uses [Firecracker](https://github.com/firecracker-microvm/firecracker) microVMs with per-sandbox TAP networking, a host-side trusted DNS forwarder, and host firewall enforcement. Each sandbox gets a dedicated TAP interface, generated machine JSON, and a vsock guest-agent for command execution.
 
 Firecracker is purpose-built for secure multi-tenant workloads with a minimal device model. Its network model (TAP + host firewall) maps directly to Cleanroom's deny-by-default enforcement.
 
@@ -22,7 +22,9 @@ Firecracker networking is built around a dedicated per-sandbox TAP device on the
 
 - each sandbox gets a unique host IP / guest IP pair on that TAP-backed subnet
 - the host can identify the sandbox by guest source IP
-- host-side iptables rules enforce default-deny egress and exact allowlist exceptions
+- guest DNS is redirected to a host-side resolver built on `miekg/dns`
+- DNS answers are observed per sandbox/guest IP and projected into dynamic `ipset`-backed allow rules
+- host-side iptables rules enforce default-deny egress, with established flows surviving DNS TTL expiry
 - gateway access is bound to the sandbox's TAP/IP identity rather than a helper-managed token
 
 This is materially different from the current `darwin-vz` backend, which uses helper-managed NAT networking and does not expose a host-visible per-sandbox guest IP. See [darwin-vz.md](darwin-vz.md) for the current macOS model.
@@ -44,6 +46,7 @@ Current capability values (visible in `cleanroom doctor --json`):
 - `sandbox.file_download=true`
 - `network.default_deny=true`
 - `network.allowlist_egress=true`
+- `dns_control_or_equivalent=true`
 - `network.guest_interface=true`
 
 ## Host requirements
@@ -52,7 +55,7 @@ Current capability values (visible in `cleanroom doctor --json`):
 - Firecracker binary installed
 - `mkfs.ext4` for OCI-to-ext4 materialization
 - `debugfs` for runtime rootfs preparation
-- `sudo -n` access for privileged host networking (`ip`, `iptables`, `sysctl`)
+- `sudo -n` access for privileged host networking (`ip`, `ipset`, `iptables`, `sysctl`)
 
 ## Related
 

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -15,6 +15,7 @@ const (
 	CapabilitySandboxFileDownload    = "sandbox.file_download"
 	CapabilityNetworkDefaultDeny     = "network.default_deny"
 	CapabilityNetworkAllowlistEgress = "network.allowlist_egress"
+	CapabilityDNSControlOrEquivalent = "dns_control_or_equivalent"
 	CapabilityNetworkGuestInterface  = "network.guest_interface"
 )
 
@@ -25,6 +26,7 @@ var knownCapabilityKeys = []string{
 	CapabilitySandboxFileDownload,
 	CapabilityNetworkDefaultDeny,
 	CapabilityNetworkAllowlistEgress,
+	CapabilityDNSControlOrEquivalent,
 	CapabilityNetworkGuestInterface,
 }
 

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -103,6 +103,7 @@ const vsockDialRetryInterval = 50 * time.Millisecond
 const preparedRuntimeRootFSVersion = "v2-debugfs"
 const defaultPrivilegedHelperPath = "/usr/local/sbin/cleanroom-root-helper"
 const helperCapabilityFirecrackerNetwork = "firecracker-network"
+const helperCapabilityFirecrackerTrustedDNS = "firecracker-trusted-dns"
 const helperCapabilityFirecrackerZFS = "firecracker-zfs"
 const defaultDownloadMaxBytes int64 = 10 * 1024 * 1024
 const snapshotSyncTimeoutSeconds = 10
@@ -771,7 +772,7 @@ func (a *Adapter) Doctor(_ context.Context, req backend.DoctorRequest) (*backend
 
 	privilegedHelperPath := resolvePrivilegedHelperPath(req.FirecrackerConfig)
 
-	requiredCommands := []string{"ip", "ipset", "iptables", "sysctl", "sudo"}
+	requiredCommands := []string{"ip", "iptables", "sysctl", "sudo"}
 	for _, cmd := range requiredCommands {
 		if _, err := exec.LookPath(cmd); err != nil {
 			appendCheck("network_cmd_"+cmd, "fail", fmt.Sprintf("missing required host command %q", cmd))
@@ -2251,22 +2252,24 @@ func setupHostNetworkWithTrustedDNSFactory(ctx context.Context, runID string, al
 	}
 	addCleanup(returnPathCleanup...)
 
-	tcpSetName := ""
-	udpSetName := ""
+	tcpChainName := ""
+	udpChainName := ""
 	if !allowAll {
-		tcpSetName = trustedDNSTCPSetName(tapName)
-		udpSetName = trustedDNSUDPSetName(tapName)
+		tcpChainName = trustedDNSTCPChainName(tapName)
+		udpChainName = trustedDNSUDPChainName(tapName)
 
-		if err := setupRun("ipset", "create", tcpSetName, "hash:ip,port", "family", "inet", "timeout", "1"); err != nil {
+		if err := setupRun("iptables", "-N", tcpChainName); err != nil {
 			cleanup()
-			return hostNetworkConfig{}, func() {}, fmt.Errorf("create trusted dns tcp set for %s: %w", tapName, err)
+			return hostNetworkConfig{}, func() {}, fmt.Errorf("create trusted dns tcp chain for %s: %w", tapName, err)
 		}
-		addCleanup("ipset", "destroy", tcpSetName)
-		if err := setupRun("ipset", "create", udpSetName, "hash:ip,port", "family", "inet", "timeout", "1"); err != nil {
+		addCleanup("iptables", "-X", tcpChainName)
+		addCleanup("iptables", "-F", tcpChainName)
+		if err := setupRun("iptables", "-N", udpChainName); err != nil {
 			cleanup()
-			return hostNetworkConfig{}, func() {}, fmt.Errorf("create trusted dns udp set for %s: %w", tapName, err)
+			return hostNetworkConfig{}, func() {}, fmt.Errorf("create trusted dns udp chain for %s: %w", tapName, err)
 		}
-		addCleanup("ipset", "destroy", udpSetName)
+		addCleanup("iptables", "-X", udpChainName)
+		addCleanup("iptables", "-F", udpChainName)
 
 		establishedCleanup, err := installForwardEstablishedEgressRule(setupRun, tapName)
 		if err != nil {
@@ -2275,26 +2278,26 @@ func setupHostNetworkWithTrustedDNSFactory(ctx context.Context, runID string, al
 		}
 		addCleanup(establishedCleanup...)
 
-		if err := setupRun("iptables", "-A", "FORWARD", "-i", tapName, "-p", "tcp", "-m", "set", "--match-set", tcpSetName, "dst,dst", "-j", "ACCEPT"); err != nil {
+		if err := setupRun("iptables", "-A", "FORWARD", "-i", tapName, "-p", "tcp", "-j", tcpChainName); err != nil {
 			cleanup()
-			return hostNetworkConfig{}, func() {}, fmt.Errorf("install trusted dns tcp allow rule for %s: %w", tapName, err)
+			return hostNetworkConfig{}, func() {}, fmt.Errorf("install trusted dns tcp chain jump for %s: %w", tapName, err)
 		}
-		addCleanup("iptables", "-D", "FORWARD", "-i", tapName, "-p", "tcp", "-m", "set", "--match-set", tcpSetName, "dst,dst", "-j", "ACCEPT")
-		if err := setupRun("iptables", "-A", "FORWARD", "-i", tapName, "-p", "udp", "-m", "set", "--match-set", udpSetName, "dst,dst", "-j", "ACCEPT"); err != nil {
+		addCleanup("iptables", "-D", "FORWARD", "-i", tapName, "-p", "tcp", "-j", tcpChainName)
+		if err := setupRun("iptables", "-A", "FORWARD", "-i", tapName, "-p", "udp", "-j", udpChainName); err != nil {
 			cleanup()
-			return hostNetworkConfig{}, func() {}, fmt.Errorf("install trusted dns udp allow rule for %s: %w", tapName, err)
+			return hostNetworkConfig{}, func() {}, fmt.Errorf("install trusted dns udp chain jump for %s: %w", tapName, err)
 		}
-		addCleanup("iptables", "-D", "FORWARD", "-i", tapName, "-p", "udp", "-m", "set", "--match-set", udpSetName, "dst,dst", "-j", "ACCEPT")
+		addCleanup("iptables", "-D", "FORWARD", "-i", tapName, "-p", "udp", "-j", udpChainName)
 	}
 
 	trustedDNSCleanup, err = factory(ctx, trustedDNSConfig{
-		sandboxID:  runID,
-		hostIP:     hostAddr,
-		guestIP:    guestAddr,
-		policy:     trustedDNSPolicy(allow),
-		runBatch:   runBatchCommand,
-		tcpSetName: tcpSetName,
-		udpSetName: udpSetName,
+		sandboxID:    runID,
+		hostIP:       hostAddr,
+		guestIP:      guestAddr,
+		policy:       trustedDNSPolicy(allow),
+		runBatch:     runBatchCommand,
+		tcpChainName: tcpChainName,
+		udpChainName: udpChainName,
 	})
 	if err != nil {
 		cleanup()
@@ -2417,6 +2420,7 @@ func resolvePrivilegedHelperPath(cfg backend.FirecrackerConfig) string {
 func helperRequiredCapabilities(cfg backend.FirecrackerConfig) []string {
 	required := []string{
 		helperCapabilityFirecrackerNetwork,
+		helperCapabilityFirecrackerTrustedDNS,
 	}
 
 	snapshotDriver := strings.ToLower(strings.TrimSpace(cfg.Snapshots.Driver))

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -14,6 +14,7 @@ import (
 	"log"
 	"math"
 	"net"
+	"net/netip"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -235,6 +236,7 @@ func (a *Adapter) Capabilities() map[string]bool {
 	return map[string]bool{
 		backend.CapabilityNetworkDefaultDeny:     true,
 		backend.CapabilityNetworkAllowlistEgress: true,
+		backend.CapabilityDNSControlOrEquivalent: true,
 		backend.CapabilityNetworkGuestInterface:  true,
 	}
 }
@@ -769,7 +771,7 @@ func (a *Adapter) Doctor(_ context.Context, req backend.DoctorRequest) (*backend
 
 	privilegedHelperPath := resolvePrivilegedHelperPath(req.FirecrackerConfig)
 
-	requiredCommands := []string{"ip", "iptables", "sysctl", "sudo"}
+	requiredCommands := []string{"ip", "ipset", "iptables", "sysctl", "sudo"}
 	for _, cmd := range requiredCommands {
 		if _, err := exec.LookPath(cmd); err != nil {
 			appendCheck("network_cmd_"+cmd, "fail", fmt.Sprintf("missing required host command %q", cmd))
@@ -1024,9 +1026,10 @@ func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream 
 		BootSource: bootSource{
 			KernelImagePath: kernelPath,
 			BootArgs: fmt.Sprintf(
-				"console=ttyS0 reboot=k panic=1 pci=off init=/usr/sbin/cleanroom-init random.trust_cpu=on cleanroom_guest_ip=%s cleanroom_guest_gw=%s cleanroom_guest_mask=24 cleanroom_guest_dns=1.1.1.1 cleanroom_guest_port=%d %s",
+				"console=ttyS0 reboot=k panic=1 pci=off init=/usr/sbin/cleanroom-init random.trust_cpu=on cleanroom_guest_ip=%s cleanroom_guest_gw=%s cleanroom_guest_mask=24 cleanroom_guest_dns=%s cleanroom_guest_port=%d %s",
 				networkCfg.GuestIP,
 				networkCfg.HostIP,
+				networkCfg.GuestDNS,
 				req.GuestPort,
 				dockerBootArgs,
 			),
@@ -1618,9 +1621,10 @@ func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID strin
 		BootSource: bootSource{
 			KernelImagePath: kernelPath,
 			BootArgs: fmt.Sprintf(
-				"console=ttyS0 reboot=k panic=1 pci=off init=/usr/sbin/cleanroom-init random.trust_cpu=on cleanroom_guest_ip=%s cleanroom_guest_gw=%s cleanroom_guest_mask=24 cleanroom_guest_dns=1.1.1.1 cleanroom_guest_port=%d %s",
+				"console=ttyS0 reboot=k panic=1 pci=off init=/usr/sbin/cleanroom-init random.trust_cpu=on cleanroom_guest_ip=%s cleanroom_guest_gw=%s cleanroom_guest_mask=24 cleanroom_guest_dns=%s cleanroom_guest_port=%d %s",
 				networkCfg.GuestIP,
 				networkCfg.HostIP,
+				networkCfg.GuestDNS,
 				cfg.GuestPort,
 				dockerBootArgs,
 			),
@@ -2096,13 +2100,8 @@ type hostNetworkConfig struct {
 	TapName         string
 	HostIP          string
 	GuestIP         string
+	GuestDNS        string
 	PolicyResolveMS int64
-}
-
-type iptablesForwardRule struct {
-	Protocol string
-	DestIP   string
-	DestPort int
 }
 
 type ipLookupFunc func(ctx context.Context, host string) ([]net.IP, error)
@@ -2118,28 +2117,30 @@ func setupHostNetwork(ctx context.Context, runID string, allowAll bool, allow []
 }
 
 func setupHostNetworkWithDeps(ctx context.Context, runID string, allowAll bool, allow []policy.AllowRule, gatewayPort int, lookup ipLookupFunc, runCommand rootCommandFunc, runBatchCommand rootCommandBatchFunc) (hostNetworkConfig, func(), error) {
-	return setupHostNetworkWithTapLookup(ctx, runID, allowAll, allow, gatewayPort, lookup, net.InterfaceByName, runCommand, runBatchCommand)
+	return setupHostNetworkWithTrustedDNSFactory(ctx, runID, allowAll, allow, gatewayPort, lookup, net.InterfaceByName, runCommand, runBatchCommand, newTrustedDNSService)
 }
 
 func setupHostNetworkWithTapLookup(ctx context.Context, runID string, allowAll bool, allow []policy.AllowRule, gatewayPort int, lookup ipLookupFunc, interfaceByName interfaceLookupFunc, runCommand rootCommandFunc, runBatchCommand rootCommandBatchFunc) (hostNetworkConfig, func(), error) {
+	return setupHostNetworkWithTrustedDNSFactory(ctx, runID, allowAll, allow, gatewayPort, lookup, interfaceByName, runCommand, runBatchCommand, newTrustedDNSService)
+}
+
+func setupHostNetworkWithTrustedDNSFactory(ctx context.Context, runID string, allowAll bool, allow []policy.AllowRule, gatewayPort int, lookup ipLookupFunc, interfaceByName interfaceLookupFunc, runCommand rootCommandFunc, runBatchCommand rootCommandBatchFunc, factory trustedDNSFactory) (hostNetworkConfig, func(), error) {
+	_ = lookup
+	if factory == nil {
+		factory = newTrustedDNSService
+	}
+
 	tapName := tapNameFromExecutionID(runID)
 	hostIP, guestIP := hostGuestIPs(runID)
 	hostCIDR := hostIP + "/24"
 	guestCIDR := guestIP + "/32"
-	const dnsServer = "1.1.1.1"
-
-	var (
-		forwardRules    []iptablesForwardRule
-		policyResolveMS int64
-		err             error
-	)
-	if !allowAll {
-		policyResolveStart := time.Now()
-		forwardRules, err = resolveForwardRulesWithLookup(ctx, allow, lookup)
-		policyResolveMS = durationMillisCeil(time.Since(policyResolveStart))
-		if err != nil {
-			return hostNetworkConfig{}, func() {}, err
-		}
+	hostAddr, err := netip.ParseAddr(hostIP)
+	if err != nil {
+		return hostNetworkConfig{}, func() {}, fmt.Errorf("parse host ip %q: %w", hostIP, err)
+	}
+	guestAddr, err := netip.ParseAddr(guestIP)
+	if err != nil {
+		return hostNetworkConfig{}, func() {}, fmt.Errorf("parse guest ip %q: %w", guestIP, err)
 	}
 
 	setupRun := func(args ...string) error {
@@ -2147,8 +2148,10 @@ func setupHostNetworkWithTapLookup(ctx context.Context, runID string, allowAll b
 	}
 	cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), networkCleanupTimeout)
 	cleanupCmds := make([][]string, 0, 16)
+	trustedDNSCleanup := func() {}
 	cleanup := func() {
 		defer cleanupCancel()
+		trustedDNSCleanup()
 		reversed := make([][]string, 0, len(cleanupCmds))
 		for i := len(cleanupCmds) - 1; i >= 0; i-- {
 			reversed = append(reversed, cleanupCmds[i])
@@ -2198,14 +2201,12 @@ func setupHostNetworkWithTapLookup(ctx context.Context, runID string, allowAll b
 		return hostNetworkConfig{}, func() {}, fmt.Errorf("disable ipv6 on %s: %w", tapName, err)
 	}
 
-	// Anti-spoof: drop anything from this TAP not sourced from assigned guest IP.
 	if err := setupRun("iptables", "-A", "INPUT", "-i", tapName, "!", "-s", guestIP, "-j", "DROP"); err != nil {
 		cleanup()
 		return hostNetworkConfig{}, func() {}, fmt.Errorf("install anti-spoof rule for %s: %w", tapName, err)
 	}
 	addCleanup("iptables", "-D", "INPUT", "-i", tapName, "!", "-s", guestIP, "-j", "DROP")
 
-	// Allow guest to reach gateway port on host.
 	if gatewayPort > 0 {
 		port := strconv.Itoa(gatewayPort)
 		if err := setupRun("iptables", "-A", "INPUT", "-i", tapName, "-s", guestIP, "-p", "tcp", "--dport", port, "-j", "ACCEPT"); err != nil {
@@ -2215,7 +2216,14 @@ func setupHostNetworkWithTapLookup(ctx context.Context, runID string, allowAll b
 		addCleanup("iptables", "-D", "INPUT", "-i", tapName, "-s", guestIP, "-p", "tcp", "--dport", port, "-j", "ACCEPT")
 	}
 
-	// Drop all other host INPUT from this TAP.
+	for _, proto := range []string{"udp", "tcp"} {
+		if err := setupRun("iptables", "-A", "INPUT", "-i", tapName, "-s", guestIP, "-p", proto, "--dport", strconv.Itoa(trustedDNSListenPort), "-j", "ACCEPT"); err != nil {
+			cleanup()
+			return hostNetworkConfig{}, func() {}, fmt.Errorf("install trusted dns %s accept rule for %s: %w", proto, tapName, err)
+		}
+		addCleanup("iptables", "-D", "INPUT", "-i", tapName, "-s", guestIP, "-p", proto, "--dport", strconv.Itoa(trustedDNSListenPort), "-j", "ACCEPT")
+	}
+
 	if err := setupRun("iptables", "-A", "INPUT", "-i", tapName, "-j", "DROP"); err != nil {
 		cleanup()
 		return hostNetworkConfig{}, func() {}, fmt.Errorf("install input deny rule for %s: %w", tapName, err)
@@ -2227,6 +2235,15 @@ func setupHostNetworkWithTapLookup(ctx context.Context, runID string, allowAll b
 		return hostNetworkConfig{}, func() {}, fmt.Errorf("install nat rule for %s: %w", guestCIDR, err)
 	}
 	addCleanup("iptables", "-t", "nat", "-D", "POSTROUTING", "-s", guestCIDR, "-j", "MASQUERADE")
+
+	for _, proto := range []string{"udp", "tcp"} {
+		if err := setupRun("iptables", "-t", "nat", "-A", "PREROUTING", "-i", tapName, "-p", proto, "--dport", "53", "-j", "REDIRECT", "--to-ports", strconv.Itoa(trustedDNSListenPort)); err != nil {
+			cleanup()
+			return hostNetworkConfig{}, func() {}, fmt.Errorf("install trusted dns %s redirect for %s: %w", proto, tapName, err)
+		}
+		addCleanup("iptables", "-t", "nat", "-D", "PREROUTING", "-i", tapName, "-p", proto, "--dport", "53", "-j", "REDIRECT", "--to-ports", strconv.Itoa(trustedDNSListenPort))
+	}
+
 	returnPathCleanup, err := installForwardReturnPathRule(setupRun, tapName)
 	if err != nil {
 		cleanup()
@@ -2234,26 +2251,56 @@ func setupHostNetworkWithTapLookup(ctx context.Context, runID string, allowAll b
 	}
 	addCleanup(returnPathCleanup...)
 
-	// Allow guest DNS to the configured resolver so host-based policy entries remain usable.
-	if err := setupRun("iptables", "-A", "FORWARD", "-i", tapName, "-p", "udp", "-d", dnsServer, "--dport", "53", "-j", "ACCEPT"); err != nil {
-		cleanup()
-		return hostNetworkConfig{}, func() {}, fmt.Errorf("install dns udp rule for %s: %w", tapName, err)
-	}
-	addCleanup("iptables", "-D", "FORWARD", "-i", tapName, "-p", "udp", "-d", dnsServer, "--dport", "53", "-j", "ACCEPT")
-	if err := setupRun("iptables", "-A", "FORWARD", "-i", tapName, "-p", "tcp", "-d", dnsServer, "--dport", "53", "-j", "ACCEPT"); err != nil {
-		cleanup()
-		return hostNetworkConfig{}, func() {}, fmt.Errorf("install dns tcp rule for %s: %w", tapName, err)
-	}
-	addCleanup("iptables", "-D", "FORWARD", "-i", tapName, "-p", "tcp", "-d", dnsServer, "--dport", "53", "-j", "ACCEPT")
+	tcpSetName := ""
+	udpSetName := ""
+	if !allowAll {
+		tcpSetName = trustedDNSTCPSetName(tapName)
+		udpSetName = trustedDNSUDPSetName(tapName)
 
-	for _, rule := range forwardRules {
-		port := strconv.Itoa(rule.DestPort)
-		if err := setupRun("iptables", "-A", "FORWARD", "-i", tapName, "-p", rule.Protocol, "-d", rule.DestIP, "--dport", port, "-j", "ACCEPT"); err != nil {
+		if err := setupRun("ipset", "create", tcpSetName, "hash:ip,port", "family", "inet", "timeout", "1"); err != nil {
 			cleanup()
-			return hostNetworkConfig{}, func() {}, fmt.Errorf("install allow rule %s %s:%d: %w", rule.Protocol, rule.DestIP, rule.DestPort, err)
+			return hostNetworkConfig{}, func() {}, fmt.Errorf("create trusted dns tcp set for %s: %w", tapName, err)
 		}
-		addCleanup("iptables", "-D", "FORWARD", "-i", tapName, "-p", rule.Protocol, "-d", rule.DestIP, "--dport", port, "-j", "ACCEPT")
+		addCleanup("ipset", "destroy", tcpSetName)
+		if err := setupRun("ipset", "create", udpSetName, "hash:ip,port", "family", "inet", "timeout", "1"); err != nil {
+			cleanup()
+			return hostNetworkConfig{}, func() {}, fmt.Errorf("create trusted dns udp set for %s: %w", tapName, err)
+		}
+		addCleanup("ipset", "destroy", udpSetName)
+
+		establishedCleanup, err := installForwardEstablishedEgressRule(setupRun, tapName)
+		if err != nil {
+			cleanup()
+			return hostNetworkConfig{}, func() {}, fmt.Errorf("install forward established egress rule for %s: %w", tapName, err)
+		}
+		addCleanup(establishedCleanup...)
+
+		if err := setupRun("iptables", "-A", "FORWARD", "-i", tapName, "-p", "tcp", "-m", "set", "--match-set", tcpSetName, "dst,dst", "-j", "ACCEPT"); err != nil {
+			cleanup()
+			return hostNetworkConfig{}, func() {}, fmt.Errorf("install trusted dns tcp allow rule for %s: %w", tapName, err)
+		}
+		addCleanup("iptables", "-D", "FORWARD", "-i", tapName, "-p", "tcp", "-m", "set", "--match-set", tcpSetName, "dst,dst", "-j", "ACCEPT")
+		if err := setupRun("iptables", "-A", "FORWARD", "-i", tapName, "-p", "udp", "-m", "set", "--match-set", udpSetName, "dst,dst", "-j", "ACCEPT"); err != nil {
+			cleanup()
+			return hostNetworkConfig{}, func() {}, fmt.Errorf("install trusted dns udp allow rule for %s: %w", tapName, err)
+		}
+		addCleanup("iptables", "-D", "FORWARD", "-i", tapName, "-p", "udp", "-m", "set", "--match-set", udpSetName, "dst,dst", "-j", "ACCEPT")
 	}
+
+	trustedDNSCleanup, err = factory(ctx, trustedDNSConfig{
+		sandboxID:  runID,
+		hostIP:     hostAddr,
+		guestIP:    guestAddr,
+		policy:     trustedDNSPolicy(allow),
+		runBatch:   runBatchCommand,
+		tcpSetName: tcpSetName,
+		udpSetName: udpSetName,
+	})
+	if err != nil {
+		cleanup()
+		return hostNetworkConfig{}, func() {}, fmt.Errorf("start trusted dns service: %w", err)
+	}
+
 	if allowAll {
 		if err := setupRun("iptables", "-A", "FORWARD", "-i", tapName, "-j", "ACCEPT"); err != nil {
 			cleanup()
@@ -2272,7 +2319,8 @@ func setupHostNetworkWithTapLookup(ctx context.Context, runID string, allowAll b
 		TapName:         tapName,
 		HostIP:          hostIP,
 		GuestIP:         guestIP,
-		PolicyResolveMS: policyResolveMS,
+		GuestDNS:        hostIP,
+		PolicyResolveMS: 0,
 	}, cleanup, nil
 }
 
@@ -2323,59 +2371,39 @@ func isNoSuchNetworkInterfaceError(err error) bool {
 }
 
 func installForwardReturnPathRule(setupRun func(args ...string) error, tapName string) ([]string, error) {
-	conntrackAdd := []string{"iptables", "-A", "FORWARD", "-o", tapName, "-m", "conntrack", "--ctstate", "RELATED,ESTABLISHED", "-j", "ACCEPT"}
+	return installForwardEstablishedRule(setupRun, "-o", tapName)
+}
+
+func installForwardEstablishedEgressRule(setupRun func(args ...string) error, tapName string) ([]string, error) {
+	return installForwardEstablishedRule(setupRun, "-i", tapName)
+}
+
+func installForwardEstablishedRule(setupRun func(args ...string) error, directionFlag, tapName string) ([]string, error) {
+	conntrackAdd := []string{"iptables", "-A", "FORWARD", directionFlag, tapName, "-m", "conntrack", "--ctstate", "RELATED,ESTABLISHED", "-j", "ACCEPT"}
 	if err := setupRun(conntrackAdd...); err == nil {
-		return []string{"iptables", "-D", "FORWARD", "-o", tapName, "-m", "conntrack", "--ctstate", "RELATED,ESTABLISHED", "-j", "ACCEPT"}, nil
+		return []string{"iptables", "-D", "FORWARD", directionFlag, tapName, "-m", "conntrack", "--ctstate", "RELATED,ESTABLISHED", "-j", "ACCEPT"}, nil
 	}
 
-	stateAdd := []string{"iptables", "-A", "FORWARD", "-o", tapName, "-m", "state", "--state", "RELATED,ESTABLISHED", "-j", "ACCEPT"}
+	stateAdd := []string{"iptables", "-A", "FORWARD", directionFlag, tapName, "-m", "state", "--state", "RELATED,ESTABLISHED", "-j", "ACCEPT"}
 	if err := setupRun(stateAdd...); err != nil {
 		return nil, err
 	}
-	return []string{"iptables", "-D", "FORWARD", "-o", tapName, "-m", "state", "--state", "RELATED,ESTABLISHED", "-j", "ACCEPT"}, nil
+	return []string{"iptables", "-D", "FORWARD", directionFlag, tapName, "-m", "state", "--state", "RELATED,ESTABLISHED", "-j", "ACCEPT"}, nil
 }
 
-func resolveForwardRules(ctx context.Context, allow []policy.AllowRule) ([]iptablesForwardRule, error) {
-	lookup := func(ctx context.Context, host string) ([]net.IP, error) {
-		return net.DefaultResolver.LookupIP(ctx, "ip4", host)
+func trustedDNSPolicy(allow []policy.AllowRule) *policy.CompiledPolicy {
+	copied := make([]policy.AllowRule, 0, len(allow))
+	for _, rule := range allow {
+		copied = append(copied, policy.AllowRule{
+			Host:  rule.Host,
+			Ports: append([]int(nil), rule.Ports...),
+		})
 	}
-	return resolveForwardRulesWithLookup(ctx, allow, lookup)
-}
-
-func resolveForwardRulesWithLookup(ctx context.Context, allow []policy.AllowRule, lookup ipLookupFunc) ([]iptablesForwardRule, error) {
-	rules := make([]iptablesForwardRule, 0, len(allow)*2)
-	seen := map[string]struct{}{}
-	for _, entry := range allow {
-		ips, err := lookup(ctx, entry.Host)
-		if err != nil {
-			return nil, fmt.Errorf("resolve policy host %q: %w", entry.Host, err)
-		}
-		if len(ips) == 0 {
-			return nil, fmt.Errorf("resolve policy host %q: no ipv4 addresses", entry.Host)
-		}
-		for _, ip := range ips {
-			ipv4 := ip.To4()
-			if ipv4 == nil {
-				continue
-			}
-			ipStr := ipv4.String()
-			for _, port := range entry.Ports {
-				for _, proto := range []string{"tcp", "udp"} {
-					key := fmt.Sprintf("%s|%s|%d", proto, ipStr, port)
-					if _, ok := seen[key]; ok {
-						continue
-					}
-					seen[key] = struct{}{}
-					rules = append(rules, iptablesForwardRule{
-						Protocol: proto,
-						DestIP:   ipStr,
-						DestPort: port,
-					})
-				}
-			}
-		}
+	return &policy.CompiledPolicy{
+		Version:        1,
+		NetworkDefault: "deny",
+		Allow:          copied,
 	}
-	return rules, nil
 }
 
 func resolvePrivilegedHelperPath(cfg backend.FirecrackerConfig) string {

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -2288,6 +2288,19 @@ func setupHostNetworkWithTrustedDNSFactory(ctx context.Context, runID string, al
 			return hostNetworkConfig{}, func() {}, fmt.Errorf("install trusted dns udp chain jump for %s: %w", tapName, err)
 		}
 		addCleanup("iptables", "-D", "FORWARD", "-i", tapName, "-p", "udp", "-j", udpChainName)
+
+		for _, rule := range literalIPv4AllowRules(allow) {
+			for _, proto := range []string{"tcp", "udp"} {
+				for _, port := range rule.Ports {
+					portText := strconv.Itoa(port)
+					if err := setupRun("iptables", "-A", "FORWARD", "-i", tapName, "-d", rule.Host, "-p", proto, "--dport", portText, "-j", "ACCEPT"); err != nil {
+						cleanup()
+						return hostNetworkConfig{}, func() {}, fmt.Errorf("install direct-ip %s allow rule for %s: %w", proto, rule.Host, err)
+					}
+					addCleanup("iptables", "-D", "FORWARD", "-i", tapName, "-d", rule.Host, "-p", proto, "--dport", portText, "-j", "ACCEPT")
+				}
+			}
+		}
 	}
 
 	trustedDNSCleanup, err = factory(ctx, trustedDNSConfig{
@@ -2407,6 +2420,21 @@ func trustedDNSPolicy(allow []policy.AllowRule) *policy.CompiledPolicy {
 		NetworkDefault: "deny",
 		Allow:          copied,
 	}
+}
+
+func literalIPv4AllowRules(allow []policy.AllowRule) []policy.AllowRule {
+	out := make([]policy.AllowRule, 0, len(allow))
+	for _, rule := range allow {
+		addr, err := netip.ParseAddr(strings.TrimSpace(rule.Host))
+		if err != nil || !addr.Is4() {
+			continue
+		}
+		out = append(out, policy.AllowRule{
+			Host:  addr.String(),
+			Ports: append([]int(nil), rule.Ports...),
+		})
+	}
+	return out
 }
 
 func resolvePrivilegedHelperPath(cfg backend.FirecrackerConfig) string {

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -2538,7 +2538,9 @@ func runRootCommandBatch(ctx context.Context, cfg backend.FirecrackerConfig, com
 		if len(args) == 0 {
 			continue
 		}
-		_ = runRootCommand(ctx, cfg, args...)
+		if err := runRootCommand(ctx, cfg, args...); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/backend/firecracker/capabilities_test.go
+++ b/internal/backend/firecracker/capabilities_test.go
@@ -15,6 +15,9 @@ func TestCapabilitiesDeclareNetworkSupport(t *testing.T) {
 	if !caps[backend.CapabilityNetworkAllowlistEgress] {
 		t.Fatalf("expected %s=true", backend.CapabilityNetworkAllowlistEgress)
 	}
+	if !caps[backend.CapabilityDNSControlOrEquivalent] {
+		t.Fatalf("expected %s=true", backend.CapabilityDNSControlOrEquivalent)
+	}
 	if !caps[backend.CapabilityNetworkGuestInterface] {
 		t.Fatalf("expected %s=true", backend.CapabilityNetworkGuestInterface)
 	}

--- a/internal/backend/firecracker/network_test.go
+++ b/internal/backend/firecracker/network_test.go
@@ -4,55 +4,162 @@ import (
 	"context"
 	"errors"
 	"net"
+	"net/netip"
 	"os"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/buildkite/cleanroom/internal/dnsproxy"
 	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/miekg/dns"
 )
 
-func TestResolveForwardRulesWithLookupDeduplicates(t *testing.T) {
+func TestTrustedDNSSetSyncerSyncsRuntimeObservationsToIPSets(t *testing.T) {
 	t.Parallel()
 
-	allow := []policy.AllowRule{
-		{Host: "registry.npmjs.org", Ports: []int{443, 443}},
-	}
-	lookup := func(_ context.Context, host string) ([]net.IP, error) {
-		if host != "registry.npmjs.org" {
-			t.Fatalf("unexpected host lookup %q", host)
-		}
-		return []net.IP{net.ParseIP("203.0.113.7"), net.ParseIP("203.0.113.7")}, nil
+	runtime := dnsproxy.NewRuntime(dnsproxy.RuntimeConfig{
+		MaxObservationsPerScope:  8,
+		MaxConnectionsPerSandbox: 8,
+	})
+	if err := runtime.RegisterSandbox("sandbox-1", &policy.CompiledPolicy{
+		Version:        1,
+		NetworkDefault: "deny",
+		Allow: []policy.AllowRule{
+			{Host: "service.example", Ports: []int{443}},
+			{Host: "cdn.example", Ports: []int{8443}},
+		},
+	}); err != nil {
+		t.Fatalf("register sandbox: %v", err)
 	}
 
-	rules, err := resolveForwardRulesWithLookup(context.Background(), allow, lookup)
-	if err != nil {
-		t.Fatalf("resolve rules: %v", err)
+	now := time.Date(2026, time.April, 6, 10, 0, 0, 0, time.UTC)
+	sourceIP := netip.MustParseAddr("10.0.0.2")
+	if err := runtime.ObserveResponse("sandbox-1", sourceIP, testDNSResponse("service.example.",
+		&dns.CNAME{
+			Hdr:    dns.RR_Header{Name: "service.example.", Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 5},
+			Target: "cdn.example.",
+		},
+		&dns.A{
+			Hdr: dns.RR_Header{Name: "cdn.example.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 30},
+			A:   net.ParseIP("203.0.113.60"),
+		},
+	), now); err != nil {
+		t.Fatalf("observe response: %v", err)
 	}
-	if len(rules) != 2 {
-		t.Fatalf("expected 2 unique rules (tcp+udp), got %d", len(rules))
+
+	var calls []string
+	runBatch := func(_ context.Context, commands [][]string) error {
+		for _, command := range commands {
+			calls = append(calls, strings.Join(command, " "))
+		}
+		return nil
 	}
-	seen := map[string]struct{}{}
-	for _, r := range rules {
-		seen[r.Protocol+"|"+r.DestIP+"|"+strconv.Itoa(r.DestPort)] = struct{}{}
+
+	syncer := trustedDNSSetSyncer{
+		sandboxID:  "sandbox-1",
+		sourceIP:   sourceIP,
+		runtime:    runtime,
+		tcpSetName: trustedDNSTCPSetName("crrun12345"),
+		udpSetName: trustedDNSUDPSetName("crrun12345"),
+		runBatch:   runBatch,
+		now:        func() time.Time { return now },
 	}
-	for _, k := range []string{"tcp|203.0.113.7|443", "udp|203.0.113.7|443"} {
-		if _, ok := seen[k]; !ok {
-			t.Fatalf("missing rule %s", k)
+
+	if err := syncer.Sync(context.Background()); err != nil {
+		t.Fatalf("sync trusted dns sets: %v", err)
+	}
+
+	joined := strings.Join(calls, "\n")
+	for _, line := range []string{
+		"ipset flush " + trustedDNSTCPSetName("crrun12345"),
+		"ipset flush " + trustedDNSUDPSetName("crrun12345"),
+		"ipset add " + trustedDNSTCPSetName("crrun12345") + " 203.0.113.60,tcp:443 timeout 5",
+		"ipset add " + trustedDNSUDPSetName("crrun12345") + " 203.0.113.60,udp:443 timeout 5",
+		"ipset add " + trustedDNSTCPSetName("crrun12345") + " 203.0.113.60,tcp:8443 timeout 5",
+		"ipset add " + trustedDNSUDPSetName("crrun12345") + " 203.0.113.60,udp:8443 timeout 5",
+	} {
+		if !strings.Contains(joined, line) {
+			t.Fatalf("missing sync command %q\ncommands:\n%s", line, joined)
 		}
 	}
 }
 
-func TestResolveForwardRulesWithLookupReturnsLookupError(t *testing.T) {
+func TestSetupHostNetworkWithTrustedDNSFactoryConfiguresDynamicRulesWithoutStaticResolution(t *testing.T) {
 	t.Parallel()
 
-	lookup := func(_ context.Context, _ string) ([]net.IP, error) {
-		return nil, errors.New("dns down")
+	type call struct {
+		ctxCanceled bool
+		args        []string
 	}
-	_, err := resolveForwardRulesWithLookup(context.Background(), []policy.AllowRule{{Host: "example.com", Ports: []int{443}}}, lookup)
-	if err == nil || !strings.Contains(err.Error(), "dns down") {
-		t.Fatalf("expected dns error, got %v", err)
+	var calls []call
+	run := func(ctx context.Context, args ...string) error {
+		copied := append([]string(nil), args...)
+		calls = append(calls, call{ctxCanceled: ctx.Err() != nil, args: copied})
+		return nil
+	}
+	runBatch := func(ctx context.Context, commands [][]string) error {
+		for _, args := range commands {
+			copied := append([]string(nil), args...)
+			calls = append(calls, call{ctxCanceled: ctx.Err() != nil, args: copied})
+		}
+		return nil
+	}
+	lookup := func(_ context.Context, host string) ([]net.IP, error) {
+		t.Fatalf("trusted dns setup should not resolve policy host %q during network setup", host)
+		return nil, nil
+	}
+
+	var dnsCfg trustedDNSConfig
+	factory := func(_ context.Context, cfg trustedDNSConfig) (func(), error) {
+		dnsCfg = cfg
+		return func() {}, nil
+	}
+
+	reqCtx, cancel := context.WithCancel(context.Background())
+	cfg, cleanup, err := setupHostNetworkWithTrustedDNSFactory(reqCtx, "run-12345", false, []policy.AllowRule{{Host: "proxy.golang.org", Ports: []int{443}}}, 8170, lookup, net.InterfaceByName, run, runBatch, factory)
+	if err != nil {
+		t.Fatalf("setupHostNetworkWithTrustedDNSFactory: %v", err)
+	}
+	cancel()
+	cleanup()
+
+	tap := cfg.TapName
+	if got, want := cfg.GuestDNS, cfg.HostIP; got != want {
+		t.Fatalf("unexpected guest dns target: got %q want %q", got, want)
+	}
+	if got, want := dnsCfg.sandboxID, "run-12345"; got != want {
+		t.Fatalf("unexpected trusted dns sandbox id: got %q want %q", got, want)
+	}
+	if got, want := dnsCfg.hostIP, netip.MustParseAddr(cfg.HostIP); got != want {
+		t.Fatalf("unexpected trusted dns host ip: got %s want %s", got, want)
+	}
+	if got, want := dnsCfg.guestIP, netip.MustParseAddr(cfg.GuestIP); got != want {
+		t.Fatalf("unexpected trusted dns guest ip: got %s want %s", got, want)
+	}
+
+	joinedLines := make([]string, 0, len(calls))
+	for _, call := range calls {
+		joinedLines = append(joinedLines, strings.Join(call.args, " "))
+	}
+	joined := strings.Join(joinedLines, "\n")
+
+	for _, expected := range []string{
+		"ipset create " + trustedDNSTCPSetName(tap) + " hash:ip,port family inet timeout 1",
+		"ipset create " + trustedDNSUDPSetName(tap) + " hash:ip,port family inet timeout 1",
+		"iptables -t nat -A PREROUTING -i " + tap + " -p udp --dport 53 -j REDIRECT --to-ports " + strconv.Itoa(trustedDNSListenPort),
+		"iptables -t nat -A PREROUTING -i " + tap + " -p tcp --dport 53 -j REDIRECT --to-ports " + strconv.Itoa(trustedDNSListenPort),
+		"iptables -A FORWARD -i " + tap + " -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT",
+		"iptables -A FORWARD -i " + tap + " -p tcp -m set --match-set " + trustedDNSTCPSetName(tap) + " dst,dst -j ACCEPT",
+		"iptables -A FORWARD -i " + tap + " -p udp -m set --match-set " + trustedDNSUDPSetName(tap) + " dst,dst -j ACCEPT",
+	} {
+		if !strings.Contains(joined, expected) {
+			t.Fatalf("missing command %q\ncalls:\n%s", expected, joined)
+		}
+	}
+	if strings.Contains(joined, "proxy.golang.org") || strings.Contains(joined, "142.251.") {
+		t.Fatalf("did not expect static host resolution in setup commands\ncalls:\n%s", joined)
 	}
 }
 
@@ -77,17 +184,17 @@ func TestSetupHostNetworkWithDepsAddsDenyDefaultAndCleanupIndependentContext(t *
 		return nil
 	}
 	lookup := func(_ context.Context, host string) ([]net.IP, error) {
-		if host != "proxy.golang.org" {
-			t.Fatalf("unexpected host %q", host)
-		}
-		time.Sleep(2 * time.Millisecond)
-		return []net.IP{net.ParseIP("142.251.41.17")}, nil
+		t.Fatalf("trusted dns setup should not resolve policy host %q during network setup", host)
+		return nil, nil
+	}
+	factory := func(_ context.Context, _ trustedDNSConfig) (func(), error) {
+		return func() {}, nil
 	}
 
 	reqCtx, cancel := context.WithCancel(context.Background())
-	cfg, cleanup, err := setupHostNetworkWithDeps(reqCtx, "run-12345", false, []policy.AllowRule{{Host: "proxy.golang.org", Ports: []int{443}}}, 8170, lookup, run, runBatch)
+	cfg, cleanup, err := setupHostNetworkWithTrustedDNSFactory(reqCtx, "run-12345", false, []policy.AllowRule{{Host: "proxy.golang.org", Ports: []int{443}}}, 8170, lookup, net.InterfaceByName, run, runBatch, factory)
 	if err != nil {
-		t.Fatalf("setupHostNetworkWithDeps: %v", err)
+		t.Fatalf("setupHostNetworkWithTrustedDNSFactory: %v", err)
 	}
 	cancel()
 	cleanup()
@@ -96,8 +203,8 @@ func TestSetupHostNetworkWithDepsAddsDenyDefaultAndCleanupIndependentContext(t *
 	if tap == "" {
 		t.Fatal("expected non-empty tap name")
 	}
-	if cfg.PolicyResolveMS <= 0 {
-		t.Fatalf("expected positive policy resolve timing, got %d", cfg.PolicyResolveMS)
+	if cfg.PolicyResolveMS != 0 {
+		t.Fatalf("expected trusted dns networking to avoid setup-time resolution, got %d", cfg.PolicyResolveMS)
 	}
 	haystack := make([]string, 0, len(calls))
 	for _, c := range calls {
@@ -110,11 +217,14 @@ func TestSetupHostNetworkWithDepsAddsDenyDefaultAndCleanupIndependentContext(t *
 	if strings.Contains(joined, "iptables -A FORWARD -i "+tap+" -j ACCEPT") {
 		t.Fatalf("unexpected blanket ACCEPT FORWARD rule for tap %s\ncalls:\n%s", tap, joined)
 	}
-	if !strings.Contains(joined, "iptables -A FORWARD -i "+tap+" -p tcp -d 142.251.41.17 --dport 443 -j ACCEPT") {
-		t.Fatalf("expected tcp allow rule for policy host\ncalls:\n%s", joined)
+	if !strings.Contains(joined, "iptables -A FORWARD -i "+tap+" -p tcp -m set --match-set "+trustedDNSTCPSetName(tap)+" dst,dst -j ACCEPT") {
+		t.Fatalf("expected dynamic tcp set rule for policy host\ncalls:\n%s", joined)
 	}
-	if !strings.Contains(joined, "iptables -A FORWARD -i "+tap+" -p udp -d 142.251.41.17 --dport 443 -j ACCEPT") {
-		t.Fatalf("expected udp allow rule for policy host\ncalls:\n%s", joined)
+	if !strings.Contains(joined, "iptables -A FORWARD -i "+tap+" -p udp -m set --match-set "+trustedDNSUDPSetName(tap)+" dst,dst -j ACCEPT") {
+		t.Fatalf("expected dynamic udp set rule for policy host\ncalls:\n%s", joined)
+	}
+	if strings.Contains(joined, "142.251.41.17") {
+		t.Fatalf("did not expect static resolved ip rules in setup\ncalls:\n%s", joined)
 	}
 
 	// Verify anti-spoof INPUT rules.
@@ -166,10 +276,8 @@ func TestSetupHostNetworkWithTapLookupDeletesStaleTapBeforeCreate(t *testing.T) 
 		return nil
 	}
 	lookup := func(_ context.Context, host string) ([]net.IP, error) {
-		if host != "proxy.golang.org" {
-			t.Fatalf("unexpected host %q", host)
-		}
-		return []net.IP{net.ParseIP("142.251.41.17")}, nil
+		t.Fatalf("trusted dns setup should not resolve policy host %q during network setup", host)
+		return nil, nil
 	}
 	interfaceByName := func(name string) (*net.Interface, error) {
 		if name != tapName {
@@ -181,9 +289,12 @@ func TestSetupHostNetworkWithTapLookupDeletesStaleTapBeforeCreate(t *testing.T) 
 		return nil, errors.New("no such network interface")
 	}
 
-	_, cleanup, err := setupHostNetworkWithTapLookup(context.Background(), runID, false, []policy.AllowRule{{Host: "proxy.golang.org", Ports: []int{443}}}, 0, lookup, interfaceByName, run, nil)
+	factory := func(_ context.Context, _ trustedDNSConfig) (func(), error) {
+		return func() {}, nil
+	}
+	_, cleanup, err := setupHostNetworkWithTrustedDNSFactory(context.Background(), runID, false, []policy.AllowRule{{Host: "proxy.golang.org", Ports: []int{443}}}, 0, lookup, interfaceByName, run, nil, factory)
 	if err != nil {
-		t.Fatalf("setupHostNetworkWithTapLookup: %v", err)
+		t.Fatalf("setupHostNetworkWithTrustedDNSFactory: %v", err)
 	}
 	defer cleanup()
 
@@ -217,9 +328,12 @@ func TestSetupHostNetworkWithDepsAddsAllowAllForwardRule(t *testing.T) {
 		return nil, nil
 	}
 
-	cfg, cleanup, err := setupHostNetworkWithDeps(context.Background(), "run-allow-all", true, []policy.AllowRule{{Host: "stale.example.invalid", Ports: []int{443}}}, 0, lookup, run, runBatch)
+	factory := func(_ context.Context, _ trustedDNSConfig) (func(), error) {
+		return func() {}, nil
+	}
+	cfg, cleanup, err := setupHostNetworkWithTrustedDNSFactory(context.Background(), "run-allow-all", true, []policy.AllowRule{{Host: "stale.example.invalid", Ports: []int{443}}}, 0, lookup, net.InterfaceByName, run, runBatch, factory)
 	if err != nil {
-		t.Fatalf("setupHostNetworkWithDeps: %v", err)
+		t.Fatalf("setupHostNetworkWithTrustedDNSFactory: %v", err)
 	}
 	defer cleanup()
 
@@ -234,6 +348,14 @@ func TestSetupHostNetworkWithDepsAddsAllowAllForwardRule(t *testing.T) {
 	if cfg.PolicyResolveMS != 0 {
 		t.Fatalf("expected allow-all networking to skip policy resolution timing, got %d", cfg.PolicyResolveMS)
 	}
+}
+
+func testDNSResponse(query string, answers ...dns.RR) *dns.Msg {
+	msg := new(dns.Msg)
+	msg.SetQuestion(query, dns.TypeA)
+	msg.Response = true
+	msg.Answer = append(msg.Answer, answers...)
+	return msg
 }
 
 func TestDeleteTapDeviceWithRetryRetriesBusyTapDeletion(t *testing.T) {

--- a/internal/backend/firecracker/network_test.go
+++ b/internal/backend/firecracker/network_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/miekg/dns"
 )
 
-func TestTrustedDNSSetSyncerSyncsRuntimeObservationsToIPSets(t *testing.T) {
+func TestTrustedDNSChainSyncerSyncsRuntimeObservationsToIPTablesChains(t *testing.T) {
 	t.Parallel()
 
 	runtime := dnsproxy.NewRuntime(dnsproxy.RuntimeConfig{
@@ -57,28 +57,28 @@ func TestTrustedDNSSetSyncerSyncsRuntimeObservationsToIPSets(t *testing.T) {
 		return nil
 	}
 
-	syncer := trustedDNSSetSyncer{
-		sandboxID:  "sandbox-1",
-		sourceIP:   sourceIP,
-		runtime:    runtime,
-		tcpSetName: trustedDNSTCPSetName("crrun12345"),
-		udpSetName: trustedDNSUDPSetName("crrun12345"),
-		runBatch:   runBatch,
-		now:        func() time.Time { return now },
+	syncer := trustedDNSChainSyncer{
+		sandboxID:    "sandbox-1",
+		sourceIP:     sourceIP,
+		runtime:      runtime,
+		tcpChainName: trustedDNSTCPChainName("crrun12345"),
+		udpChainName: trustedDNSUDPChainName("crrun12345"),
+		runBatch:     runBatch,
+		now:          func() time.Time { return now },
 	}
 
-	if err := syncer.Sync(context.Background()); err != nil {
+	if _, _, err := syncer.Sync(context.Background()); err != nil {
 		t.Fatalf("sync trusted dns sets: %v", err)
 	}
 
 	joined := strings.Join(calls, "\n")
 	for _, line := range []string{
-		"ipset flush " + trustedDNSTCPSetName("crrun12345"),
-		"ipset flush " + trustedDNSUDPSetName("crrun12345"),
-		"ipset add " + trustedDNSTCPSetName("crrun12345") + " 203.0.113.60,tcp:443 timeout 5",
-		"ipset add " + trustedDNSUDPSetName("crrun12345") + " 203.0.113.60,udp:443 timeout 5",
-		"ipset add " + trustedDNSTCPSetName("crrun12345") + " 203.0.113.60,tcp:8443 timeout 5",
-		"ipset add " + trustedDNSUDPSetName("crrun12345") + " 203.0.113.60,udp:8443 timeout 5",
+		"iptables -F " + trustedDNSTCPChainName("crrun12345"),
+		"iptables -F " + trustedDNSUDPChainName("crrun12345"),
+		"iptables -A " + trustedDNSTCPChainName("crrun12345") + " -d 203.0.113.60 -p tcp --dport 443 -j ACCEPT",
+		"iptables -A " + trustedDNSUDPChainName("crrun12345") + " -d 203.0.113.60 -p udp --dport 443 -j ACCEPT",
+		"iptables -A " + trustedDNSTCPChainName("crrun12345") + " -d 203.0.113.60 -p tcp --dport 8443 -j ACCEPT",
+		"iptables -A " + trustedDNSUDPChainName("crrun12345") + " -d 203.0.113.60 -p udp --dport 8443 -j ACCEPT",
 	} {
 		if !strings.Contains(joined, line) {
 			t.Fatalf("missing sync command %q\ncommands:\n%s", line, joined)
@@ -146,13 +146,13 @@ func TestSetupHostNetworkWithTrustedDNSFactoryConfiguresDynamicRulesWithoutStati
 	joined := strings.Join(joinedLines, "\n")
 
 	for _, expected := range []string{
-		"ipset create " + trustedDNSTCPSetName(tap) + " hash:ip,port family inet timeout 1",
-		"ipset create " + trustedDNSUDPSetName(tap) + " hash:ip,port family inet timeout 1",
+		"iptables -N " + trustedDNSTCPChainName(tap),
+		"iptables -N " + trustedDNSUDPChainName(tap),
 		"iptables -t nat -A PREROUTING -i " + tap + " -p udp --dport 53 -j REDIRECT --to-ports " + strconv.Itoa(trustedDNSListenPort),
 		"iptables -t nat -A PREROUTING -i " + tap + " -p tcp --dport 53 -j REDIRECT --to-ports " + strconv.Itoa(trustedDNSListenPort),
 		"iptables -A FORWARD -i " + tap + " -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT",
-		"iptables -A FORWARD -i " + tap + " -p tcp -m set --match-set " + trustedDNSTCPSetName(tap) + " dst,dst -j ACCEPT",
-		"iptables -A FORWARD -i " + tap + " -p udp -m set --match-set " + trustedDNSUDPSetName(tap) + " dst,dst -j ACCEPT",
+		"iptables -A FORWARD -i " + tap + " -p tcp -j " + trustedDNSTCPChainName(tap),
+		"iptables -A FORWARD -i " + tap + " -p udp -j " + trustedDNSUDPChainName(tap),
 	} {
 		if !strings.Contains(joined, expected) {
 			t.Fatalf("missing command %q\ncalls:\n%s", expected, joined)
@@ -217,11 +217,11 @@ func TestSetupHostNetworkWithDepsAddsDenyDefaultAndCleanupIndependentContext(t *
 	if strings.Contains(joined, "iptables -A FORWARD -i "+tap+" -j ACCEPT") {
 		t.Fatalf("unexpected blanket ACCEPT FORWARD rule for tap %s\ncalls:\n%s", tap, joined)
 	}
-	if !strings.Contains(joined, "iptables -A FORWARD -i "+tap+" -p tcp -m set --match-set "+trustedDNSTCPSetName(tap)+" dst,dst -j ACCEPT") {
-		t.Fatalf("expected dynamic tcp set rule for policy host\ncalls:\n%s", joined)
+	if !strings.Contains(joined, "iptables -A FORWARD -i "+tap+" -p tcp -j "+trustedDNSTCPChainName(tap)) {
+		t.Fatalf("expected dynamic tcp chain jump for policy host\ncalls:\n%s", joined)
 	}
-	if !strings.Contains(joined, "iptables -A FORWARD -i "+tap+" -p udp -m set --match-set "+trustedDNSUDPSetName(tap)+" dst,dst -j ACCEPT") {
-		t.Fatalf("expected dynamic udp set rule for policy host\ncalls:\n%s", joined)
+	if !strings.Contains(joined, "iptables -A FORWARD -i "+tap+" -p udp -j "+trustedDNSUDPChainName(tap)) {
+		t.Fatalf("expected dynamic udp chain jump for policy host\ncalls:\n%s", joined)
 	}
 	if strings.Contains(joined, "142.251.41.17") {
 		t.Fatalf("did not expect static resolved ip rules in setup\ncalls:\n%s", joined)

--- a/internal/backend/firecracker/network_test.go
+++ b/internal/backend/firecracker/network_test.go
@@ -350,6 +350,47 @@ func TestSetupHostNetworkWithDepsAddsAllowAllForwardRule(t *testing.T) {
 	}
 }
 
+func TestSetupHostNetworkWithTrustedDNSFactoryPreservesDirectIPAllowRules(t *testing.T) {
+	t.Parallel()
+
+	var calls []string
+	run := func(_ context.Context, args ...string) error {
+		calls = append(calls, strings.Join(args, " "))
+		return nil
+	}
+	runBatch := func(_ context.Context, commands [][]string) error {
+		for _, args := range commands {
+			calls = append(calls, strings.Join(args, " "))
+		}
+		return nil
+	}
+	lookup := func(_ context.Context, host string) ([]net.IP, error) {
+		t.Fatalf("direct ip allow rules should not trigger setup-time lookup for %q", host)
+		return nil, nil
+	}
+	factory := func(_ context.Context, _ trustedDNSConfig) (func(), error) {
+		return func() {}, nil
+	}
+
+	cfg, cleanup, err := setupHostNetworkWithTrustedDNSFactory(context.Background(), "run-direct-ip", false, []policy.AllowRule{{Host: "203.0.113.10", Ports: []int{443}}}, 0, lookup, net.InterfaceByName, run, runBatch, factory)
+	if err != nil {
+		t.Fatalf("setupHostNetworkWithTrustedDNSFactory: %v", err)
+	}
+	defer cleanup()
+
+	joined := strings.Join(calls, "\n")
+	tap := cfg.TapName
+	for _, expected := range []string{
+		"iptables -A FORWARD -i " + tap + " -d 203.0.113.10 -p tcp --dport 443 -j ACCEPT",
+		"iptables -A FORWARD -i " + tap + " -d 203.0.113.10 -p udp --dport 443 -j ACCEPT",
+		"iptables -A FORWARD -i " + tap + " -j DROP",
+	} {
+		if !strings.Contains(joined, expected) {
+			t.Fatalf("missing command %q\ncalls:\n%s", expected, joined)
+		}
+	}
+}
+
 func testDNSResponse(query string, answers ...dns.RR) *dns.Msg {
 	msg := new(dns.Msg)
 	msg.SetQuestion(query, dns.TypeA)

--- a/internal/backend/firecracker/privileged_test.go
+++ b/internal/backend/firecracker/privileged_test.go
@@ -29,6 +29,15 @@ func doctorCheck(report *backend.DoctorReport, name string) backend.DoctorCheck 
 	return backend.DoctorCheck{}
 }
 
+func doctorHasCheck(report *backend.DoctorReport, name string) bool {
+	for _, check := range report.Checks {
+		if check.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
 func setupFakeSudo(t *testing.T, logPath string) {
 	t.Helper()
 
@@ -211,14 +220,13 @@ func TestDoctorReportsZFSChecks(t *testing.T) {
 	writeExecutable(t, binDir, "firecracker", "#!/bin/sh\nexit 0\n")
 	writeExecutable(t, binDir, "cleanroom-guest-agent", "#!/bin/sh\nexit 0\n")
 	writeExecutable(t, binDir, "mkfs.ext4", "#!/bin/sh\nexit 0\n")
-	writeExecutable(t, binDir, "ipset", "#!/bin/sh\nexit 0\n")
 	writeExecutable(t, binDir, "iptables", "#!/bin/sh\nexit 0\n")
 	writeExecutable(t, binDir, "sysctl", "#!/bin/sh\nexit 0\n")
 	writeExecutable(t, binDir, "true", "#!/bin/sh\nexit 0\n")
 	writeExecutable(t, binDir, "ip", "#!/bin/sh\nif [ \"$1\" = \"link\" ] && [ \"$2\" = \"show\" ]; then exit 0; fi\nexit 0\n")
 	writeExecutable(t, binDir, "zfs", "#!/bin/sh\nif [ \"$1\" = \"list\" ] && [ \"$2\" = \"-H\" ] && [ \"$3\" = \"-d\" ] && [ \"$4\" = \"0\" ] && [ \"$5\" = \"-o\" ] && [ \"$6\" = \"name\" ]; then printf '%s\\n' \"$7\"; exit 0; fi\nif [ \"$1\" = \"list\" ] && [ \"$2\" = \"-H\" ] && [ \"$3\" = \"-o\" ] && [ \"$4\" = \"name\" ]; then printf '%s\\n%s/child\\n' \"$5\" \"$5\"; exit 0; fi\nexit 0\n")
 	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
-	helperPath := writeExecutable(t, tmpDir, "cleanroom-root-helper", "#!/bin/sh\nset -eu\nprintf '%s\\n' \"$*\" >> \"$HELPER_LOG_PATH\"\ncase \"$1\" in\n  version)\n    printf 'test-helper\\n'\n    ;;\n  capabilities)\n    printf 'firecracker-network\\nfirecracker-rootfs\\nfirecracker-zfs\\n'\n    ;;\n  true)\n    exec \"$@\"\n    ;;\n  zfs)\n    if [ \"$2\" = \"list\" ] && [ \"$3\" = \"-H\" ] && [ \"$4\" = \"-d\" ] && [ \"$5\" = \"0\" ] && [ \"$6\" = \"-o\" ] && [ \"$7\" = \"name\" ]; then\n      printf '%s\\n' \"$8\"\n      exit 0\n    fi\n    echo 'unexpected helper zfs args' >&2\n    exit 2\n    ;;\n  *)\n    exec \"$@\"\n    ;;\n esac\n")
+	helperPath := writeExecutable(t, tmpDir, "cleanroom-root-helper", "#!/bin/sh\nset -eu\nprintf '%s\\n' \"$*\" >> \"$HELPER_LOG_PATH\"\ncase \"$1\" in\n  version)\n    printf 'test-helper\\n'\n    ;;\n  capabilities)\n    printf 'firecracker-network\\nfirecracker-trusted-dns\\nfirecracker-rootfs\\nfirecracker-zfs\\n'\n    ;;\n  true)\n    exec \"$@\"\n    ;;\n  zfs)\n    if [ \"$2\" = \"list\" ] && [ \"$3\" = \"-H\" ] && [ \"$4\" = \"-d\" ] && [ \"$5\" = \"0\" ] && [ \"$6\" = \"-o\" ] && [ \"$7\" = \"name\" ]; then\n      printf '%s\\n' \"$8\"\n      exit 0\n    fi\n    echo 'unexpected helper zfs args' >&2\n    exit 2\n    ;;\n  *)\n    exec \"$@\"\n    ;;\n esac\n")
 
 	kernelPath := filepath.Join(tmpDir, "vmlinux")
 	if err := os.WriteFile(kernelPath, []byte("kernel"), 0o644); err != nil {
@@ -251,6 +259,9 @@ func TestDoctorReportsZFSChecks(t *testing.T) {
 	}
 	if got := doctorCheck(report, "snapshot_zfs_dataset_access"); got.Status != "pass" {
 		t.Fatalf("unexpected snapshot_zfs_dataset_access check: %+v", got)
+	}
+	if doctorHasCheck(report, "network_cmd_ipset") {
+		t.Fatalf("doctor unexpectedly requires ipset: %+v", doctorCheck(report, "network_cmd_ipset"))
 	}
 
 	logBytes, err := os.ReadFile(logPath)
@@ -387,6 +398,7 @@ func TestHelperRequiredCapabilitiesIncludesZFSWhenConfigured(t *testing.T) {
 	got := helperRequiredCapabilities(backend.FirecrackerConfig{})
 	want := []string{
 		helperCapabilityFirecrackerNetwork,
+		helperCapabilityFirecrackerTrustedDNS,
 	}
 	if strings.Join(got, ",") != strings.Join(want, ",") {
 		t.Fatalf("unexpected default helper capabilities: got %v want %v", got, want)
@@ -397,6 +409,7 @@ func TestHelperRequiredCapabilitiesIncludesZFSWhenConfigured(t *testing.T) {
 	})
 	want = []string{
 		helperCapabilityFirecrackerNetwork,
+		helperCapabilityFirecrackerTrustedDNS,
 		helperCapabilityFirecrackerZFS,
 	}
 	if strings.Join(got, ",") != strings.Join(want, ",") {

--- a/internal/backend/firecracker/privileged_test.go
+++ b/internal/backend/firecracker/privileged_test.go
@@ -211,6 +211,7 @@ func TestDoctorReportsZFSChecks(t *testing.T) {
 	writeExecutable(t, binDir, "firecracker", "#!/bin/sh\nexit 0\n")
 	writeExecutable(t, binDir, "cleanroom-guest-agent", "#!/bin/sh\nexit 0\n")
 	writeExecutable(t, binDir, "mkfs.ext4", "#!/bin/sh\nexit 0\n")
+	writeExecutable(t, binDir, "ipset", "#!/bin/sh\nexit 0\n")
 	writeExecutable(t, binDir, "iptables", "#!/bin/sh\nexit 0\n")
 	writeExecutable(t, binDir, "sysctl", "#!/bin/sh\nexit 0\n")
 	writeExecutable(t, binDir, "true", "#!/bin/sh\nexit 0\n")

--- a/internal/backend/firecracker/privileged_test.go
+++ b/internal/backend/firecracker/privileged_test.go
@@ -137,6 +137,49 @@ func TestRunRootCommandBatchInvokesHelperPerCommand(t *testing.T) {
 	}
 }
 
+func TestRunRootCommandBatchPropagatesHelperErrors(t *testing.T) {
+	tmpDir := t.TempDir()
+	sudoLogPath := filepath.Join(tmpDir, "sudo.log")
+	logPath := filepath.Join(tmpDir, "helper.log")
+	helperPath := filepath.Join(tmpDir, "cleanroom-root-helper")
+	setupFakeSudo(t, sudoLogPath)
+
+	helperScript := "#!/bin/sh\nset -eu\nprintf '%s\\n' \"$*\" >> \"$HELPER_LOG_PATH\"\nif [ \"$1\" = \"iptables\" ]; then\n  echo 'iptables failed' >&2\n  exit 23\nfi\n"
+	if err := os.WriteFile(helperPath, []byte(helperScript), 0o755); err != nil {
+		t.Fatalf("write helper script: %v", err)
+	}
+	t.Setenv("HELPER_LOG_PATH", logPath)
+
+	cfg := backend.FirecrackerConfig{
+		PrivilegedHelperPath: helperPath,
+	}
+
+	commands := [][]string{
+		{"ip", "link", "del", "tap0"},
+		{"iptables", "-D", "FORWARD", "-j", "DROP"},
+		{"ip", "link", "show"},
+	}
+	err := runRootCommandBatch(context.Background(), cfg, commands)
+	if err == nil {
+		t.Fatal("expected runRootCommandBatch to fail")
+	}
+	if !strings.Contains(err.Error(), "iptables failed") {
+		t.Fatalf("expected helper stderr in error, got %v", err)
+	}
+
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read helper log: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(logBytes)), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected batch execution to stop at the failing command, got %d invocations (%q)", len(lines), string(logBytes))
+	}
+	if got, want := lines[1], "iptables -D FORWARD -j DROP"; got != want {
+		t.Fatalf("unexpected failing helper invocation: got %q want %q", got, want)
+	}
+}
+
 func TestRunRootCommandOutputInvokesHelper(t *testing.T) {
 	tmpDir := t.TempDir()
 	sudoLogPath := filepath.Join(tmpDir, "sudo.log")

--- a/internal/backend/firecracker/trusted_dns.go
+++ b/internal/backend/firecracker/trusted_dns.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"math"
 	"net"
 	"net/netip"
 	"strconv"
@@ -19,35 +18,43 @@ import (
 )
 
 const trustedDNSListenPort = 1053
+const trustedDNSSyncRetryDelay = time.Second
 
 type trustedDNSFactory func(context.Context, trustedDNSConfig) (func(), error)
 
 type trustedDNSConfig struct {
-	sandboxID  string
-	hostIP     netip.Addr
-	guestIP    netip.Addr
-	policy     *policy.CompiledPolicy
-	runBatch   rootCommandBatchFunc
-	tcpSetName string
-	udpSetName string
-	now        func() time.Time
+	sandboxID    string
+	hostIP       netip.Addr
+	guestIP      netip.Addr
+	policy       *policy.CompiledPolicy
+	runBatch     rootCommandBatchFunc
+	tcpChainName string
+	udpChainName string
+	now          func() time.Time
 }
 
-type trustedDNSSetSyncer struct {
-	sandboxID  string
-	sourceIP   netip.Addr
-	runtime    *dnsproxy.Runtime
-	tcpSetName string
-	udpSetName string
-	runBatch   rootCommandBatchFunc
-	now        func() time.Time
+type trustedDNSChainSyncer struct {
+	sandboxID    string
+	sourceIP     netip.Addr
+	runtime      *dnsproxy.Runtime
+	tcpChainName string
+	udpChainName string
+	runBatch     rootCommandBatchFunc
+	now          func() time.Time
 }
 
-func trustedDNSTCPSetName(tapName string) string {
+type trustedDNSChainManager struct {
+	sandboxID string
+	syncer    *trustedDNSChainSyncer
+	trigger   chan struct{}
+	done      chan struct{}
+}
+
+func trustedDNSTCPChainName(tapName string) string {
 	return "crdns-tcp-" + tapName
 }
 
-func trustedDNSUDPSetName(tapName string) string {
+func trustedDNSUDPChainName(tapName string) string {
 	return "crdns-udp-" + tapName
 }
 
@@ -76,21 +83,21 @@ func newTrustedDNSService(_ context.Context, cfg trustedDNSConfig) (func(), erro
 		return nil, err
 	}
 
-	var syncer *trustedDNSSetSyncer
-	if cfg.tcpSetName != "" || cfg.udpSetName != "" {
+	var chainManager *trustedDNSChainManager
+	if cfg.tcpChainName != "" || cfg.udpChainName != "" {
 		if cfg.runBatch == nil {
 			runtime.ClearSandbox(cfg.sandboxID)
 			return nil, errors.New("trusted dns batch runner is required")
 		}
-		syncer = &trustedDNSSetSyncer{
-			sandboxID:  cfg.sandboxID,
-			sourceIP:   cfg.guestIP,
-			runtime:    runtime,
-			tcpSetName: cfg.tcpSetName,
-			udpSetName: cfg.udpSetName,
-			runBatch:   cfg.runBatch,
-			now:        cfg.now,
-		}
+		chainManager = newTrustedDNSChainManager(cfg.sandboxID, &trustedDNSChainSyncer{
+			sandboxID:    cfg.sandboxID,
+			sourceIP:     cfg.guestIP,
+			runtime:      runtime,
+			tcpChainName: cfg.tcpChainName,
+			udpChainName: cfg.udpChainName,
+			runBatch:     cfg.runBatch,
+			now:          cfg.now,
+		})
 	}
 
 	forwarder := dnsproxy.NewForwarder(dnsproxy.ForwarderConfig{
@@ -103,14 +110,10 @@ func newTrustedDNSService(_ context.Context, cfg trustedDNSConfig) (func(), erro
 			return "", false
 		},
 		OnObserve: func(string, netip.Addr) {
-			if syncer == nil {
+			if chainManager == nil {
 				return
 			}
-			syncCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
-			if err := syncer.Sync(syncCtx); err != nil {
-				log.Printf("trusted dns sync failed for %s: %v", cfg.sandboxID, err)
-			}
+			chainManager.Trigger()
 		},
 	})
 
@@ -130,6 +133,11 @@ func newTrustedDNSService(_ context.Context, cfg trustedDNSConfig) (func(), erro
 	udpServer := &dns.Server{PacketConn: udpConn, Handler: forwarder}
 	tcpServer := &dns.Server{Listener: tcpListener, Handler: forwarder}
 
+	stopChainManager := func() {}
+	if chainManager != nil {
+		stopChainManager = chainManager.Start()
+	}
+
 	go func() {
 		if err := udpServer.ActivateAndServe(); err != nil && !isTrustedDNSServerClosedError(err) {
 			log.Printf("trusted dns udp server failed for %s: %v", cfg.sandboxID, err)
@@ -144,6 +152,7 @@ func newTrustedDNSService(_ context.Context, cfg trustedDNSConfig) (func(), erro
 	var once sync.Once
 	cleanup := func() {
 		once.Do(func() {
+			stopChainManager()
 			_ = udpServer.Shutdown()
 			_ = tcpServer.Shutdown()
 			runtime.ClearSandbox(cfg.sandboxID)
@@ -172,12 +181,95 @@ func trustedDNSUpstreamAddr() (string, error) {
 	return net.JoinHostPort(server, port), nil
 }
 
-func (s trustedDNSSetSyncer) Sync(ctx context.Context) error {
+func newTrustedDNSChainManager(sandboxID string, syncer *trustedDNSChainSyncer) *trustedDNSChainManager {
+	return &trustedDNSChainManager{
+		sandboxID: sandboxID,
+		syncer:    syncer,
+		trigger:   make(chan struct{}, 1),
+		done:      make(chan struct{}),
+	}
+}
+
+func (m *trustedDNSChainManager) Start() func() {
+	ctx, cancel := context.WithCancel(context.Background())
+	go m.run(ctx)
+
+	return func() {
+		cancel()
+		<-m.done
+	}
+}
+
+func (m *trustedDNSChainManager) Trigger() {
+	select {
+	case m.trigger <- struct{}{}:
+	default:
+	}
+}
+
+func (m *trustedDNSChainManager) run(ctx context.Context) {
+	defer close(m.done)
+
+	var timer *time.Timer
+	var timerCh <-chan time.Time
+
+	for {
+		select {
+		case <-ctx.Done():
+			stopTrustedDNSTimer(timer)
+			return
+		case <-m.trigger:
+		case <-timerCh:
+		}
+
+		nextSync, hasNextSync, err := m.syncOnce()
+		if err != nil {
+			log.Printf("trusted dns sync failed for %s: %v", m.sandboxID, err)
+			nextSync = time.Now().Add(trustedDNSSyncRetryDelay)
+			hasNextSync = true
+		}
+
+		stopTrustedDNSTimer(timer)
+		timer = nil
+		timerCh = nil
+
+		if !hasNextSync {
+			continue
+		}
+
+		delay := time.Until(nextSync)
+		if delay < 0 {
+			delay = 0
+		}
+		timer = time.NewTimer(delay)
+		timerCh = timer.C
+	}
+}
+
+func (m *trustedDNSChainManager) syncOnce() (time.Time, bool, error) {
+	syncCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	return m.syncer.Sync(syncCtx)
+}
+
+func stopTrustedDNSTimer(timer *time.Timer) {
+	if timer == nil {
+		return
+	}
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+}
+
+func (s trustedDNSChainSyncer) Sync(ctx context.Context) (time.Time, bool, error) {
 	if s.runtime == nil {
-		return errors.New("trusted dns runtime is required")
+		return time.Time{}, false, errors.New("trusted dns runtime is required")
 	}
 	if s.runBatch == nil {
-		return errors.New("trusted dns batch runner is required")
+		return time.Time{}, false, errors.New("trusted dns batch runner is required")
 	}
 
 	now := time.Now().UTC()
@@ -185,49 +277,59 @@ func (s trustedDNSSetSyncer) Sync(ctx context.Context) error {
 		now = s.now().UTC()
 	}
 
-	commands := [][]string{
-		{"ipset", "flush", s.tcpSetName},
-		{"ipset", "flush", s.udpSetName},
+	commands := make([][]string, 0, 2)
+	if s.tcpChainName != "" {
+		commands = append(commands, []string{"iptables", "-F", s.tcpChainName})
 	}
+	if s.udpChainName != "" {
+		commands = append(commands, []string{"iptables", "-F", s.udpChainName})
+	}
+
+	var nextSync time.Time
+	hasNextSync := false
 	for _, destination := range s.runtime.AllowedDestinations(s.sandboxID, s.sourceIP, now) {
 		if !destination.Address.Is4() {
 			continue
 		}
-		timeout := trustedDNSDestinationTimeoutSeconds(now, destination.ExpiresAt)
-		if timeout <= 0 {
-			continue
+		if !hasNextSync || destination.ExpiresAt.Before(nextSync) {
+			nextSync = destination.ExpiresAt
+			hasNextSync = true
 		}
 
-		setName := s.tcpSetName
+		chainName := s.tcpChainName
 		switch destination.Protocol {
 		case dnsproxy.ProtocolUDP:
-			setName = s.udpSetName
+			chainName = s.udpChainName
 		case dnsproxy.ProtocolTCP:
-			setName = s.tcpSetName
+			chainName = s.tcpChainName
 		default:
 			continue
 		}
-		if setName == "" {
+		if chainName == "" {
 			continue
 		}
 
 		commands = append(commands, []string{
-			"ipset",
-			"add",
-			setName,
-			destination.Address.String() + "," + destination.Protocol + ":" + destination.Port,
-			"timeout",
-			strconv.FormatInt(timeout, 10),
+			"iptables",
+			"-A",
+			chainName,
+			"-d",
+			destination.Address.String(),
+			"-p",
+			destination.Protocol,
+			"--dport",
+			destination.Port,
+			"-j",
+			"ACCEPT",
 		})
 	}
-	if err := s.runBatch(ctx, commands); err != nil {
-		return fmt.Errorf("sync trusted dns ipsets: %w", err)
+	if len(commands) == 0 {
+		return nextSync, hasNextSync, nil
 	}
-	return nil
-}
-
-func trustedDNSDestinationTimeoutSeconds(now, expiresAt time.Time) int64 {
-	return int64(math.Ceil(expiresAt.Sub(now).Seconds()))
+	if err := s.runBatch(ctx, commands); err != nil {
+		return time.Time{}, false, fmt.Errorf("sync trusted dns chains: %w", err)
+	}
+	return nextSync, hasNextSync, nil
 }
 
 func isTrustedDNSServerClosedError(err error) bool {

--- a/internal/backend/firecracker/trusted_dns.go
+++ b/internal/backend/firecracker/trusted_dns.go
@@ -1,0 +1,239 @@
+package firecracker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"math"
+	"net"
+	"net/netip"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/buildkite/cleanroom/internal/dnsproxy"
+	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/miekg/dns"
+)
+
+const trustedDNSListenPort = 1053
+
+type trustedDNSFactory func(context.Context, trustedDNSConfig) (func(), error)
+
+type trustedDNSConfig struct {
+	sandboxID  string
+	hostIP     netip.Addr
+	guestIP    netip.Addr
+	policy     *policy.CompiledPolicy
+	runBatch   rootCommandBatchFunc
+	tcpSetName string
+	udpSetName string
+	now        func() time.Time
+}
+
+type trustedDNSSetSyncer struct {
+	sandboxID  string
+	sourceIP   netip.Addr
+	runtime    *dnsproxy.Runtime
+	tcpSetName string
+	udpSetName string
+	runBatch   rootCommandBatchFunc
+	now        func() time.Time
+}
+
+func trustedDNSTCPSetName(tapName string) string {
+	return "crdns-tcp-" + tapName
+}
+
+func trustedDNSUDPSetName(tapName string) string {
+	return "crdns-udp-" + tapName
+}
+
+func newTrustedDNSService(_ context.Context, cfg trustedDNSConfig) (func(), error) {
+	if strings.TrimSpace(cfg.sandboxID) == "" {
+		return nil, errors.New("trusted dns sandbox id is required")
+	}
+	if !cfg.hostIP.IsValid() {
+		return nil, errors.New("trusted dns host ip must be valid")
+	}
+	if !cfg.guestIP.IsValid() {
+		return nil, errors.New("trusted dns guest ip must be valid")
+	}
+	if cfg.policy == nil {
+		return nil, errors.New("trusted dns policy is required")
+	}
+
+	runtime := dnsproxy.NewRuntime(dnsproxy.RuntimeConfig{})
+	if err := runtime.RegisterSandbox(cfg.sandboxID, cfg.policy); err != nil {
+		return nil, fmt.Errorf("register trusted dns sandbox: %w", err)
+	}
+
+	upstreamAddr, err := trustedDNSUpstreamAddr()
+	if err != nil {
+		runtime.ClearSandbox(cfg.sandboxID)
+		return nil, err
+	}
+
+	var syncer *trustedDNSSetSyncer
+	if cfg.tcpSetName != "" || cfg.udpSetName != "" {
+		if cfg.runBatch == nil {
+			runtime.ClearSandbox(cfg.sandboxID)
+			return nil, errors.New("trusted dns batch runner is required")
+		}
+		syncer = &trustedDNSSetSyncer{
+			sandboxID:  cfg.sandboxID,
+			sourceIP:   cfg.guestIP,
+			runtime:    runtime,
+			tcpSetName: cfg.tcpSetName,
+			udpSetName: cfg.udpSetName,
+			runBatch:   cfg.runBatch,
+			now:        cfg.now,
+		}
+	}
+
+	forwarder := dnsproxy.NewForwarder(dnsproxy.ForwarderConfig{
+		Runtime:      runtime,
+		UpstreamAddr: upstreamAddr,
+		ScopeResolver: func(sourceIP netip.Addr) (string, bool) {
+			if sourceIP == cfg.guestIP {
+				return cfg.sandboxID, true
+			}
+			return "", false
+		},
+		OnObserve: func(string, netip.Addr) {
+			if syncer == nil {
+				return
+			}
+			syncCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if err := syncer.Sync(syncCtx); err != nil {
+				log.Printf("trusted dns sync failed for %s: %v", cfg.sandboxID, err)
+			}
+		},
+	})
+
+	listenAddr := net.JoinHostPort(cfg.hostIP.String(), strconv.Itoa(trustedDNSListenPort))
+	udpConn, err := net.ListenPacket("udp4", listenAddr)
+	if err != nil {
+		runtime.ClearSandbox(cfg.sandboxID)
+		return nil, fmt.Errorf("listen for trusted dns udp on %s: %w", listenAddr, err)
+	}
+	tcpListener, err := net.Listen("tcp4", listenAddr)
+	if err != nil {
+		_ = udpConn.Close()
+		runtime.ClearSandbox(cfg.sandboxID)
+		return nil, fmt.Errorf("listen for trusted dns tcp on %s: %w", listenAddr, err)
+	}
+
+	udpServer := &dns.Server{PacketConn: udpConn, Handler: forwarder}
+	tcpServer := &dns.Server{Listener: tcpListener, Handler: forwarder}
+
+	go func() {
+		if err := udpServer.ActivateAndServe(); err != nil && !isTrustedDNSServerClosedError(err) {
+			log.Printf("trusted dns udp server failed for %s: %v", cfg.sandboxID, err)
+		}
+	}()
+	go func() {
+		if err := tcpServer.ActivateAndServe(); err != nil && !isTrustedDNSServerClosedError(err) {
+			log.Printf("trusted dns tcp server failed for %s: %v", cfg.sandboxID, err)
+		}
+	}()
+
+	var once sync.Once
+	cleanup := func() {
+		once.Do(func() {
+			_ = udpServer.Shutdown()
+			_ = tcpServer.Shutdown()
+			runtime.ClearSandbox(cfg.sandboxID)
+		})
+	}
+	return cleanup, nil
+}
+
+func trustedDNSUpstreamAddr() (string, error) {
+	clientCfg, err := dns.ClientConfigFromFile("/etc/resolv.conf")
+	if err != nil {
+		return "", fmt.Errorf("read host dns resolver config: %w", err)
+	}
+	if len(clientCfg.Servers) == 0 {
+		return "", errors.New("read host dns resolver config: no nameservers configured")
+	}
+
+	server := strings.TrimSpace(clientCfg.Servers[0])
+	if server == "" {
+		return "", errors.New("read host dns resolver config: first nameserver is empty")
+	}
+	port := strings.TrimSpace(clientCfg.Port)
+	if port == "" {
+		port = "53"
+	}
+	return net.JoinHostPort(server, port), nil
+}
+
+func (s trustedDNSSetSyncer) Sync(ctx context.Context) error {
+	if s.runtime == nil {
+		return errors.New("trusted dns runtime is required")
+	}
+	if s.runBatch == nil {
+		return errors.New("trusted dns batch runner is required")
+	}
+
+	now := time.Now().UTC()
+	if s.now != nil {
+		now = s.now().UTC()
+	}
+
+	commands := [][]string{
+		{"ipset", "flush", s.tcpSetName},
+		{"ipset", "flush", s.udpSetName},
+	}
+	for _, destination := range s.runtime.AllowedDestinations(s.sandboxID, s.sourceIP, now) {
+		if !destination.Address.Is4() {
+			continue
+		}
+		timeout := trustedDNSDestinationTimeoutSeconds(now, destination.ExpiresAt)
+		if timeout <= 0 {
+			continue
+		}
+
+		setName := s.tcpSetName
+		switch destination.Protocol {
+		case dnsproxy.ProtocolUDP:
+			setName = s.udpSetName
+		case dnsproxy.ProtocolTCP:
+			setName = s.tcpSetName
+		default:
+			continue
+		}
+		if setName == "" {
+			continue
+		}
+
+		commands = append(commands, []string{
+			"ipset",
+			"add",
+			setName,
+			destination.Address.String() + "," + destination.Protocol + ":" + destination.Port,
+			"timeout",
+			strconv.FormatInt(timeout, 10),
+		})
+	}
+	if err := s.runBatch(ctx, commands); err != nil {
+		return fmt.Errorf("sync trusted dns ipsets: %w", err)
+	}
+	return nil
+}
+
+func trustedDNSDestinationTimeoutSeconds(now, expiresAt time.Time) int64 {
+	return int64(math.Ceil(expiresAt.Sub(now).Seconds()))
+}
+
+func isTrustedDNSServerClosedError(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "server shutdown") || strings.Contains(message, "server closed")
+}

--- a/internal/backend/firecracker/trusted_dns.go
+++ b/internal/backend/firecracker/trusted_dns.go
@@ -77,7 +77,7 @@ func newTrustedDNSService(_ context.Context, cfg trustedDNSConfig) (func(), erro
 		return nil, fmt.Errorf("register trusted dns sandbox: %w", err)
 	}
 
-	upstreamAddr, err := trustedDNSUpstreamAddr()
+	upstreamAddrs, err := trustedDNSUpstreamAddrs()
 	if err != nil {
 		runtime.ClearSandbox(cfg.sandboxID)
 		return nil, err
@@ -102,7 +102,11 @@ func newTrustedDNSService(_ context.Context, cfg trustedDNSConfig) (func(), erro
 
 	forwarder := dnsproxy.NewForwarder(dnsproxy.ForwarderConfig{
 		Runtime:      runtime,
-		UpstreamAddr: upstreamAddr,
+		UpstreamAddr: upstreamAddrs[0],
+		Client: trustedDNSMultiUpstreamClient{
+			upstreamAddrs: upstreamAddrs,
+			client:        &dns.Client{},
+		},
 		ScopeResolver: func(sourceIP netip.Addr) (string, bool) {
 			if sourceIP == cfg.guestIP {
 				return cfg.sandboxID, true
@@ -161,24 +165,36 @@ func newTrustedDNSService(_ context.Context, cfg trustedDNSConfig) (func(), erro
 	return cleanup, nil
 }
 
-func trustedDNSUpstreamAddr() (string, error) {
+func trustedDNSUpstreamAddrs() ([]string, error) {
 	clientCfg, err := dns.ClientConfigFromFile("/etc/resolv.conf")
 	if err != nil {
-		return "", fmt.Errorf("read host dns resolver config: %w", err)
+		return nil, fmt.Errorf("read host dns resolver config: %w", err)
 	}
-	if len(clientCfg.Servers) == 0 {
-		return "", errors.New("read host dns resolver config: no nameservers configured")
+	return trustedDNSUpstreamAddrsFromConfig(clientCfg)
+}
+
+func trustedDNSUpstreamAddrsFromConfig(clientCfg *dns.ClientConfig) ([]string, error) {
+	if clientCfg == nil {
+		return nil, errors.New("read host dns resolver config: no nameservers configured")
 	}
 
-	server := strings.TrimSpace(clientCfg.Servers[0])
-	if server == "" {
-		return "", errors.New("read host dns resolver config: first nameserver is empty")
-	}
 	port := strings.TrimSpace(clientCfg.Port)
 	if port == "" {
 		port = "53"
 	}
-	return net.JoinHostPort(server, port), nil
+
+	upstreamAddrs := make([]string, 0, len(clientCfg.Servers))
+	for _, server := range clientCfg.Servers {
+		server = strings.TrimSpace(server)
+		if server == "" {
+			continue
+		}
+		upstreamAddrs = append(upstreamAddrs, net.JoinHostPort(server, port))
+	}
+	if len(upstreamAddrs) == 0 {
+		return nil, errors.New("read host dns resolver config: no nameservers configured")
+	}
+	return upstreamAddrs, nil
 }
 
 func newTrustedDNSChainManager(sandboxID string, syncer *trustedDNSChainSyncer) *trustedDNSChainManager {
@@ -338,4 +354,39 @@ func isTrustedDNSServerClosedError(err error) bool {
 	}
 	message := strings.ToLower(err.Error())
 	return strings.Contains(message, "server shutdown") || strings.Contains(message, "server closed")
+}
+
+type trustedDNSMultiUpstreamClient struct {
+	upstreamAddrs []string
+	client        dnsproxy.DNSClient
+}
+
+func (c trustedDNSMultiUpstreamClient) Exchange(msg *dns.Msg, _ string) (*dns.Msg, time.Duration, error) {
+	if len(c.upstreamAddrs) == 0 {
+		return nil, 0, errors.New("trusted dns upstream resolvers are required")
+	}
+	if c.client == nil {
+		return nil, 0, errors.New("trusted dns client is required")
+	}
+
+	var failures []string
+	for _, upstreamAddr := range c.upstreamAddrs {
+		req := msg
+		if msg != nil {
+			req = msg.Copy()
+		}
+
+		resp, rtt, err := c.client.Exchange(req, upstreamAddr)
+		if err == nil && resp != nil {
+			return resp, rtt, nil
+		}
+
+		if err != nil {
+			failures = append(failures, fmt.Sprintf("%s: %v", upstreamAddr, err))
+			continue
+		}
+		failures = append(failures, fmt.Sprintf("%s: nil response", upstreamAddr))
+	}
+
+	return nil, 0, fmt.Errorf("exchange with trusted dns upstream resolvers: %s", strings.Join(failures, "; "))
 }

--- a/internal/backend/firecracker/trusted_dns_test.go
+++ b/internal/backend/firecracker/trusted_dns_test.go
@@ -1,0 +1,71 @@
+package firecracker
+
+import (
+	"errors"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+type testTrustedDNSExchangeFunc func(*dns.Msg, string) (*dns.Msg, time.Duration, error)
+
+func (f testTrustedDNSExchangeFunc) Exchange(msg *dns.Msg, addr string) (*dns.Msg, time.Duration, error) {
+	return f(msg, addr)
+}
+
+func TestTrustedDNSUpstreamAddrsFromConfigUsesAllConfiguredResolvers(t *testing.T) {
+	t.Parallel()
+
+	upstreamAddrs, err := trustedDNSUpstreamAddrsFromConfig(&dns.ClientConfig{
+		Servers: []string{"1.1.1.1", " ", "8.8.8.8"},
+		Port:    "53",
+	})
+	if err != nil {
+		t.Fatalf("trustedDNSUpstreamAddrsFromConfig: %v", err)
+	}
+
+	if got, want := strings.Join(upstreamAddrs, ","), "1.1.1.1:53,8.8.8.8:53"; got != want {
+		t.Fatalf("unexpected upstream addrs: got %q want %q", got, want)
+	}
+}
+
+func TestTrustedDNSMultiUpstreamClientFallsBackToLaterResolver(t *testing.T) {
+	t.Parallel()
+
+	var calls []string
+	client := trustedDNSMultiUpstreamClient{
+		upstreamAddrs: []string{"1.1.1.1:53", "8.8.8.8:53"},
+		client: testTrustedDNSExchangeFunc(func(msg *dns.Msg, addr string) (*dns.Msg, time.Duration, error) {
+			calls = append(calls, addr)
+			if addr == "1.1.1.1:53" {
+				return nil, 0, errors.New("dial udp 1.1.1.1:53: i/o timeout")
+			}
+			if msg == nil || len(msg.Question) != 1 || msg.Question[0].Name != "api.example.com." {
+				t.Fatalf("unexpected forwarded question: %+v", msg)
+			}
+			return testDNSResponse("api.example.com.",
+				&dns.A{
+					Hdr: dns.RR_Header{Name: "api.example.com.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 30},
+					A:   net.ParseIP("203.0.113.44"),
+				},
+			), 5 * time.Millisecond, nil
+		}),
+	}
+
+	req := new(dns.Msg)
+	req.SetQuestion("api.example.com.", dns.TypeA)
+
+	resp, _, err := client.Exchange(req, "ignored")
+	if err != nil {
+		t.Fatalf("Exchange: %v", err)
+	}
+	if resp == nil || len(resp.Answer) != 1 {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+	if got, want := strings.Join(calls, ","), "1.1.1.1:53,8.8.8.8:53"; got != want {
+		t.Fatalf("unexpected upstream attempts: got %q want %q", got, want)
+	}
+}

--- a/internal/dnsproxy/forwarder.go
+++ b/internal/dnsproxy/forwarder.go
@@ -16,6 +16,9 @@ type DNSClient interface {
 // ScopeResolver maps an inbound source IP to a sandbox identity.
 type ScopeResolver func(sourceIP netip.Addr) (sandboxID string, ok bool)
 
+// ObserveHook runs after a scoped response has been recorded in the runtime.
+type ObserveHook func(sandboxID string, sourceIP netip.Addr)
+
 // ForwarderConfig configures a DNS forwarding handler.
 type ForwarderConfig struct {
 	Runtime       *Runtime
@@ -23,6 +26,7 @@ type ForwarderConfig struct {
 	ScopeResolver ScopeResolver
 	Client        DNSClient
 	Now           func() time.Time
+	OnObserve     ObserveHook
 }
 
 // Forwarder forwards DNS requests to an upstream resolver and records the
@@ -33,6 +37,7 @@ type Forwarder struct {
 	scopeResolver ScopeResolver
 	client        DNSClient
 	now           func() time.Time
+	onObserve     ObserveHook
 }
 
 // NewForwarder creates a DNS forwarding handler backed by miekg/dns.
@@ -51,6 +56,7 @@ func NewForwarder(cfg ForwarderConfig) *Forwarder {
 		scopeResolver: cfg.ScopeResolver,
 		client:        client,
 		now:           now,
+		onObserve:     cfg.OnObserve,
 	}
 }
 
@@ -85,7 +91,12 @@ func (f *Forwarder) observeScopedResponse(remoteAddr net.Addr, resp *dns.Msg) {
 	if !ok {
 		return
 	}
-	_ = f.runtime.ObserveResponse(sandboxID, sourceIP, resp.Copy(), f.now().UTC())
+	if err := f.runtime.ObserveResponse(sandboxID, sourceIP, resp.Copy(), f.now().UTC()); err != nil {
+		return
+	}
+	if f.onObserve != nil {
+		f.onObserve(sandboxID, sourceIP)
+	}
 }
 
 func addrFromNetAddr(addr net.Addr) (netip.Addr, bool) {

--- a/internal/dnsproxy/runtime.go
+++ b/internal/dnsproxy/runtime.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/netip"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -54,6 +55,15 @@ type Observation struct {
 	TTL        time.Duration
 	ObservedAt time.Time
 	ExpiresAt  time.Time
+}
+
+// AllowedDestination is a concrete transport destination derived from current
+// DNS observations plus sandbox allowlist policy.
+type AllowedDestination struct {
+	Protocol  string
+	Address   netip.Addr
+	Port      string
+	ExpiresAt time.Time
 }
 
 // Connection identifies a network flow that is being authorised.
@@ -223,6 +233,83 @@ func (r *Runtime) Observations(sandboxID string, now time.Time) []Observation {
 	return out
 }
 
+// AllowedDestinations returns the currently permitted transport destinations
+// for a sandbox/source pair after applying DNS observation TTLs and policy
+// ports. The result is suitable for backend-specific firewall programming.
+func (r *Runtime) AllowedDestinations(sandboxID string, sourceIP netip.Addr, now time.Time) []AllowedDestination {
+	sourceIP = normalizeAddr(sourceIP)
+	if !sourceIP.IsValid() {
+		return nil
+	}
+
+	now = now.UTC()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	state, ok := r.sandboxes[strings.TrimSpace(sandboxID)]
+	if !ok {
+		return nil
+	}
+
+	scope, ok := state.scopes[sourceIP]
+	if !ok {
+		return nil
+	}
+	scope.pruneExpired(now)
+
+	type destinationKey struct {
+		protocol string
+		address  netip.Addr
+		port     string
+	}
+
+	destinations := make(map[destinationKey]AllowedDestination)
+	for _, observation := range scope.observations {
+		if !observation.ExpiresAt.After(now) || !observation.Address.IsValid() {
+			continue
+		}
+		for _, port := range state.observationAllowedPorts(observation) {
+			portStr := strconv.Itoa(port)
+			for _, protocol := range []string{ProtocolTCP, ProtocolUDP} {
+				key := destinationKey{
+					protocol: protocol,
+					address:  observation.Address,
+					port:     portStr,
+				}
+				candidate := AllowedDestination{
+					Protocol:  protocol,
+					Address:   observation.Address,
+					Port:      portStr,
+					ExpiresAt: observation.ExpiresAt,
+				}
+				existing, exists := destinations[key]
+				if !exists || existing.ExpiresAt.Before(candidate.ExpiresAt) {
+					destinations[key] = candidate
+				}
+			}
+		}
+	}
+
+	out := make([]AllowedDestination, 0, len(destinations))
+	for _, destination := range destinations {
+		out = append(out, destination)
+	}
+	slices.SortFunc(out, func(a, b AllowedDestination) int {
+		if cmp := compareAddr(a.Address, b.Address); cmp != 0 {
+			return cmp
+		}
+		if cmp := strings.Compare(a.Protocol, b.Protocol); cmp != 0 {
+			return cmp
+		}
+		if cmp := strings.Compare(a.Port, b.Port); cmp != 0 {
+			return cmp
+		}
+		return a.ExpiresAt.Compare(b.ExpiresAt)
+	})
+	return out
+}
+
 // AllowConnection permits an already-established flow or authorises a new flow
 // when there is a still-valid DNS observation that matches sandbox policy.
 func (r *Runtime) AllowConnection(conn Connection, now time.Time) bool {
@@ -329,6 +416,29 @@ func (s *sandboxState) observationAllowsPort(observation Observation, port int) 
 		return true
 	}
 	return false
+}
+
+func (s *sandboxState) observationAllowedPorts(observation Observation) []int {
+	if s.policy == nil {
+		return nil
+	}
+
+	ports := make([]int, 0)
+	seen := make(map[int]struct{})
+	for _, rule := range s.policy.Allow {
+		for _, port := range rule.Ports {
+			if _, exists := seen[port]; exists {
+				continue
+			}
+			if !s.observationAllowsPort(observation, port) {
+				continue
+			}
+			seen[port] = struct{}{}
+			ports = append(ports, port)
+		}
+	}
+	slices.Sort(ports)
+	return ports
 }
 
 func (s *sandboxState) recordConnection(key connectionKey, limit int) {

--- a/internal/dnsproxy/runtime_test.go
+++ b/internal/dnsproxy/runtime_test.go
@@ -617,6 +617,73 @@ func TestForwarderDoesNotRecordScopedAnswersWhenWriteFails(t *testing.T) {
 	}
 }
 
+func TestRuntimeAllowedDestinationsExpandsObservedPortsAndProtocols(t *testing.T) {
+	t.Parallel()
+
+	runtime := NewRuntime(RuntimeConfig{
+		MaxObservationsPerScope:  8,
+		MaxConnectionsPerSandbox: 8,
+	})
+	if err := runtime.RegisterSandbox("sandbox-1", testCompiledPolicy(
+		policy.AllowRule{Host: "service.example", Ports: []int{443}},
+		policy.AllowRule{Host: "cdn.example", Ports: []int{8443}},
+	)); err != nil {
+		t.Fatalf("register sandbox: %v", err)
+	}
+
+	now := time.Date(2026, time.April, 6, 10, 0, 0, 0, time.UTC)
+	sourceIP := netip.MustParseAddr("10.0.0.2")
+	destIP := netip.MustParseAddr("203.0.113.55")
+
+	if err := runtime.ObserveResponse("sandbox-1", sourceIP, testResponse("service.example.",
+		&dns.CNAME{
+			Hdr:    dns.RR_Header{Name: "service.example.", Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 5},
+			Target: "cdn.example.",
+		},
+		&dns.A{
+			Hdr: dns.RR_Header{Name: "cdn.example.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 60},
+			A:   net.ParseIP("203.0.113.55"),
+		},
+	), now); err != nil {
+		t.Fatalf("observe response: %v", err)
+	}
+
+	destinations := runtime.AllowedDestinations("sandbox-1", sourceIP, now)
+	if len(destinations) != 4 {
+		t.Fatalf("unexpected destination count: got %d want 4", len(destinations))
+	}
+
+	seen := map[string]time.Time{}
+	for _, destination := range destinations {
+		seen[destination.Protocol+"|"+destination.Address.String()+"|"+destination.Port] = destination.ExpiresAt
+	}
+	for _, key := range []string{
+		ProtocolTCP + "|203.0.113.55|443",
+		ProtocolUDP + "|203.0.113.55|443",
+		ProtocolTCP + "|203.0.113.55|8443",
+		ProtocolUDP + "|203.0.113.55|8443",
+	} {
+		expiresAt, ok := seen[key]
+		if !ok {
+			t.Fatalf("missing allowed destination %s", key)
+		}
+		if got, want := expiresAt, now.Add(5*time.Second); !got.Equal(want) {
+			t.Fatalf("unexpected expiry for %s: got %s want %s", key, got, want)
+		}
+	}
+
+	if !runtime.AllowConnection(Connection{
+		SandboxID:  "sandbox-1",
+		SourceIP:   sourceIP,
+		SourcePort: 44000,
+		DestIP:     destIP,
+		DestPort:   8443,
+		Protocol:   ProtocolUDP,
+	}, now) {
+		t.Fatal("expected expanded allowed destination to permit connection")
+	}
+}
+
 func TestAddrFromNetAddrHandlesNilValues(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/bootstrap-cleanroom-host.sh
+++ b/scripts/bootstrap-cleanroom-host.sh
@@ -671,7 +671,7 @@ CLEANROOM_VERSION="$(normalize_version "$CLEANROOM_VERSION")"
 configure_apt_ipv4
 export DEBIAN_FRONTEND=noninteractive
 retry 5 10 apt-get update -y
-retry 5 10 apt-get install -y e2fsprogs iproute2 iptables
+retry 5 10 apt-get install -y e2fsprogs iproute2 ipset iptables
 
 if [ "$INSTALL_FIRECRACKER" = "true" ]; then
   log "installing firecracker ${FIRECRACKER_VERSION}"

--- a/scripts/ci-cleanroom-e2e.sh
+++ b/scripts/ci-cleanroom-e2e.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT_HELPER_REQUIRED_CAPABILITIES=(
   firecracker-network
+  firecracker-trusted-dns
 )
 
 # run_privileged executes a privileged command via the installed root helper.
@@ -94,6 +95,10 @@ purge_stale_cleanroom_resources() {
         run_privileged iptables ${rule/-A/-D} 2>/dev/null || true
       done <<< "$rules"
     done
+    run_privileged iptables -F "crdns-tcp-${tap}" 2>/dev/null || true
+    run_privileged iptables -X "crdns-tcp-${tap}" 2>/dev/null || true
+    run_privileged iptables -F "crdns-udp-${tap}" 2>/dev/null || true
+    run_privileged iptables -X "crdns-udp-${tap}" 2>/dev/null || true
     run_privileged ip link del "$tap" 2>/dev/null || true
   done
 

--- a/scripts/cleanroom-root-helper.sh
+++ b/scripts/cleanroom-root-helper.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 # - Helper updates must land on hosts before branches that depend on new capabilities can pass.
 
 helper_contract_version() {
-  echo "4"
+  echo "5"
 }
 
 helper_has_zfs() {
@@ -23,6 +23,7 @@ helper_has_zfs() {
 helper_capabilities() {
   cat <<'EOF'
 firecracker-network
+firecracker-trusted-dns
 EOF
 
   if helper_has_zfs; then
@@ -67,6 +68,11 @@ is_cidr() {
 }
 
 is_trusted_dns_set_name() {
+  local v="$1"
+  [[ "$v" =~ ^crdns-(tcp|udp)-cr[a-z0-9]{1,13}$ ]]
+}
+
+is_trusted_dns_chain_name() {
   local v="$1"
   [[ "$v" =~ ^crdns-(tcp|udp)-cr[a-z0-9]{1,13}$ ]]
 }
@@ -261,6 +267,29 @@ run_iptables() {
   if [[ "$#" -eq 13 && ( "$1" == "-A" || "$1" == "-D" ) && "$2" == "FORWARD" && "$3" == "-i" && "$5" == "-p" && ( "$6" == "tcp" || "$6" == "udp" ) && "$7" == "-m" && "$8" == "set" && "$9" == "--match-set" && "${11}" == "dst,dst" && "${12}" == "-j" && "${13}" == "ACCEPT" ]]; then
     is_tap_name "$4" || die "iptables FORWARD set allow: unsupported interface '$4'"
     is_trusted_dns_set_name "${10}" || die "iptables FORWARD set allow: unsupported set '${10}'"
+    exec /usr/sbin/iptables "$@"
+  fi
+
+  if [[ "$#" -eq 2 && "$1" == "-N" ]]; then
+    is_trusted_dns_chain_name "$2" || die "iptables chain create: unsupported chain '$2'"
+    exec /usr/sbin/iptables "$@"
+  fi
+
+  if [[ "$#" -eq 2 && ( "$1" == "-F" || "$1" == "-X" ) ]]; then
+    is_trusted_dns_chain_name "$2" || die "iptables chain $1: unsupported chain '$2'"
+    exec /usr/sbin/iptables "$@"
+  fi
+
+  if [[ "$#" -eq 8 && ( "$1" == "-A" || "$1" == "-D" ) && "$2" == "FORWARD" && "$3" == "-i" && "$5" == "-p" && ( "$6" == "tcp" || "$6" == "udp" ) && "$7" == "-j" ]]; then
+    is_tap_name "$4" || die "iptables FORWARD chain jump: unsupported interface '$4'"
+    is_trusted_dns_chain_name "$8" || die "iptables FORWARD chain jump: unsupported chain '$8'"
+    exec /usr/sbin/iptables "$@"
+  fi
+
+  if [[ "$#" -eq 10 && ( "$1" == "-A" || "$1" == "-D" ) && "$3" == "-d" && "$5" == "-p" && ( "$6" == "tcp" || "$6" == "udp" ) && "$7" == "--dport" && "$9" == "-j" && "${10}" == "ACCEPT" ]]; then
+    is_trusted_dns_chain_name "$2" || die "iptables trusted dns allow: unsupported chain '$2'"
+    is_ipv4 "$4" || die "iptables trusted dns allow: invalid destination ip '$4'"
+    is_numeric "$8" || die "iptables trusted dns allow: invalid port '$8'"
     exec /usr/sbin/iptables "$@"
   fi
 

--- a/scripts/cleanroom-root-helper.sh
+++ b/scripts/cleanroom-root-helper.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 # - Helper updates must land on hosts before branches that depend on new capabilities can pass.
 
 helper_contract_version() {
-  echo "3"
+  echo "4"
 }
 
 helper_has_zfs() {
@@ -64,6 +64,16 @@ is_ipv4() {
 is_cidr() {
   local v="$1"
   [[ "$v" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}/[0-9]{1,2}$ ]]
+}
+
+is_trusted_dns_set_name() {
+  local v="$1"
+  [[ "$v" =~ ^crdns-(tcp|udp)-cr[a-z0-9]{1,13}$ ]]
+}
+
+is_ipset_entry() {
+  local v="$1"
+  [[ "$v" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3},(tcp|udp):[0-9]+$ ]]
 }
 
 is_zfs_dataset() {
@@ -154,6 +164,18 @@ dd_bin() {
   command -v dd || die "dd: binary not found"
 }
 
+ipset_bin() {
+  if [[ -x /usr/sbin/ipset ]]; then
+    echo /usr/sbin/ipset
+    return
+  fi
+  if [[ -x /sbin/ipset ]]; then
+    echo /sbin/ipset
+    return
+  fi
+  command -v ipset || die "ipset: binary not found"
+}
+
 run_ip() {
   [[ "$#" -ge 1 ]] || die "ip: missing arguments"
   case "$1" in
@@ -215,8 +237,14 @@ run_iptables() {
     exec /usr/sbin/iptables "$@"
   fi
 
-  if [[ "$#" -eq 10 && ( "$1" == "-A" || "$1" == "-D" ) && "$2" == "FORWARD" && "$3" == "-o" && "$5" == "-m" && "$9" == "-j" && "${10}" == "ACCEPT" ]]; then
-    is_tap_name "$4" || die "iptables FORWARD -o: unsupported interface '$4'"
+  if [[ "$#" -eq 14 && "$1" == "-t" && "$2" == "nat" && ( "$3" == "-A" || "$3" == "-D" ) && "$4" == "PREROUTING" && "$5" == "-i" && "$7" == "-p" && ( "$8" == "tcp" || "$8" == "udp" ) && "$9" == "--dport" && "${10}" == "53" && "${11}" == "-j" && "${12}" == "REDIRECT" && "${13}" == "--to-ports" ]]; then
+    is_tap_name "$6" || die "iptables PREROUTING redirect: unsupported interface '$6'"
+    is_numeric "${14}" || die "iptables PREROUTING redirect: invalid port '${14}'"
+    exec /usr/sbin/iptables "$@"
+  fi
+
+  if [[ "$#" -eq 10 && ( "$1" == "-A" || "$1" == "-D" ) && "$2" == "FORWARD" && ( "$3" == "-o" || "$3" == "-i" ) && "$5" == "-m" && "$9" == "-j" && "${10}" == "ACCEPT" ]]; then
+    is_tap_name "$4" || die "iptables FORWARD ${3}: unsupported interface '$4'"
     if [[ "$6" == "state" && "$7" == "--state" && "$8" == "RELATED,ESTABLISHED" ]]; then
       exec /usr/sbin/iptables "$@"
     fi
@@ -227,6 +255,12 @@ run_iptables() {
 
   if [[ "$#" -eq 6 && ( "$1" == "-A" || "$1" == "-D" ) && ( "$2" == "FORWARD" || "$2" == "INPUT" ) && "$3" == "-i" && "$5" == "-j" && "$6" == "DROP" ]]; then
     is_tap_name "$4" || die "iptables $2 drop: unsupported interface '$4'"
+    exec /usr/sbin/iptables "$@"
+  fi
+
+  if [[ "$#" -eq 13 && ( "$1" == "-A" || "$1" == "-D" ) && "$2" == "FORWARD" && "$3" == "-i" && "$5" == "-p" && ( "$6" == "tcp" || "$6" == "udp" ) && "$7" == "-m" && "$8" == "set" && "$9" == "--match-set" && "${11}" == "dst,dst" && "${12}" == "-j" && "${13}" == "ACCEPT" ]]; then
+    is_tap_name "$4" || die "iptables FORWARD set allow: unsupported interface '$4'"
+    is_trusted_dns_set_name "${10}" || die "iptables FORWARD set allow: unsupported set '${10}'"
     exec /usr/sbin/iptables "$@"
   fi
 
@@ -244,8 +278,8 @@ run_iptables() {
     exec /usr/sbin/iptables "$@"
   fi
 
-  # Gateway accept: iptables -A INPUT -i <tap> -s <IP> -p tcp --dport <port> -j ACCEPT
-  if [[ "$#" -eq 12 && ( "$1" == "-A" || "$1" == "-D" ) && "$2" == "INPUT" && "$3" == "-i" && "$5" == "-s" && "$7" == "-p" && "$8" == "tcp" && "$9" == "--dport" && "${11}" == "-j" && "${12}" == "ACCEPT" ]]; then
+  # Gateway/trusted-DNS accept: iptables -A INPUT -i <tap> -s <IP> -p tcp|udp --dport <port> -j ACCEPT
+  if [[ "$#" -eq 12 && ( "$1" == "-A" || "$1" == "-D" ) && "$2" == "INPUT" && "$3" == "-i" && "$5" == "-s" && "$7" == "-p" && ( "$8" == "tcp" || "$8" == "udp" ) && "$9" == "--dport" && "${11}" == "-j" && "${12}" == "ACCEPT" ]]; then
     is_tap_name "$4" || die "iptables INPUT accept: unsupported interface '$4'"
     is_ipv4 "$6" || die "iptables INPUT accept: invalid ip '$6'"
     is_numeric "${10}" || die "iptables INPUT accept: invalid port '${10}'"
@@ -265,6 +299,32 @@ run_iptables() {
   fi
 
   die "iptables: unsupported arguments"
+}
+
+run_ipset() {
+  [[ "$#" -ge 1 ]] || die "ipset: missing arguments"
+  local bin
+  bin="$(ipset_bin)"
+
+  if [[ "$#" -eq 7 && "$1" == "create" && "$3" == "hash:ip,port" && "$4" == "family" && "$5" == "inet" && "$6" == "timeout" ]]; then
+    is_trusted_dns_set_name "$2" || die "ipset create: unsupported set '$2'"
+    is_numeric "$7" || die "ipset create: invalid timeout '$7'"
+    exec "$bin" "$@"
+  fi
+
+  if [[ "$#" -eq 2 && ( "$1" == "destroy" || "$1" == "flush" ) ]]; then
+    is_trusted_dns_set_name "$2" || die "ipset $1: unsupported set '$2'"
+    exec "$bin" "$@"
+  fi
+
+  if [[ "$#" -eq 5 && "$1" == "add" && "$4" == "timeout" ]]; then
+    is_trusted_dns_set_name "$2" || die "ipset add: unsupported set '$2'"
+    is_ipset_entry "$3" || die "ipset add: unsupported entry '$3'"
+    is_numeric "$5" || die "ipset add: invalid timeout '$5'"
+    exec "$bin" "$@"
+  fi
+
+  die "ipset: unsupported arguments"
 }
 
 run_sysctl() {
@@ -377,6 +437,9 @@ main() {
       ;;
     ip)
       run_ip "$@"
+      ;;
+    ipset)
+      run_ipset "$@"
       ;;
     iptables)
       run_iptables "$@"

--- a/scripts/root_helper_test.go
+++ b/scripts/root_helper_test.go
@@ -20,6 +20,7 @@ func TestCleanroomRootHelperDeclaresCapabilitiesAndZFSSupport(t *testing.T) {
 		"helper_has_zfs()",
 		"helper_capabilities()",
 		"firecracker-network",
+		"firecracker-trusted-dns",
 		"firecracker-zfs",
 		"    version)",
 		"    capabilities)",


### PR DESCRIPTION
## Summary
- point Firecracker guests at a host-side trusted DNS forwarder instead of hard-coding `1.1.1.1`
- replace setup-time policy host resolution with dynamic `ipset`-backed FORWARD rules driven by DNS observations
- advertise `dns_control_or_equivalent=true` for Firecracker and update the helper/bootstrap/docs surfaces required by the Linux path

## Why
This makes the Linux backend actually consume the trusted DNS runtime from the previous PR instead of leaving `dns_control_or_equivalent` aspirational. New egress is gated by current DNS observations, CNAME/TTL semantics are preserved, and established flows survive TTL expiry through conntrack/state rules.

## Validation
- `go test ./internal/backend ./internal/dnsproxy ./internal/backend/firecracker ./internal/gateway`
- `go test ./...`
- `bash -n scripts/cleanroom-root-helper.sh scripts/bootstrap-cleanroom-host.sh`

## Stack
- base branch: `codex/add-trusted-dns-policy-runtime`
- stacked on top of PR #148
