### PR TITLE
ci: Isolate cleanroom cache in CI

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -114,7 +114,9 @@ go test ./internal/backend/darwinvz -run TestVMNetSharedE2E -v
 The vmnet secrets should stay restricted to the `cleanroom` pipeline and the
 `cleanroom-mac` queue.
 The script also forces a short `XDG_STATE_HOME` so the darwin-vz helper socket
-path stays within the macOS UNIX socket length limit.
+path stays within the macOS UNIX socket length limit, and in Buildkite it uses
+a temporary `XDG_CACHE_HOME` so prepared runtime rootfs cache does not
+accumulate on the host.
 
 ### 3.4 Notarized macOS release pkg step
 
@@ -282,7 +284,7 @@ export CLEANROOM_FIRECRACKER_BINARY="/usr/local/bin/firecracker"
 
 ## 6. Collision Safety
 
-`scripts/ci-cleanroom-e2e.sh` and `scripts/ci-darwin-vz-e2e.sh` isolate CI runtime paths using temporary XDG directories (`XDG_CONFIG_HOME`, `XDG_STATE_HOME`, `XDG_RUNTIME_DIR`, `XDG_DATA_HOME`) and a job-local unix socket.
+`scripts/ci-cleanroom-e2e.sh`, `scripts/ci-darwin-vz-e2e.sh`, and the Buildkite path in `scripts/ci-darwin-vz-vmnet-e2e.sh` isolate CI runtime paths using temporary XDG directories (`XDG_CONFIG_HOME`, `XDG_CACHE_HOME`, `XDG_STATE_HOME`, `XDG_RUNTIME_DIR`, `XDG_DATA_HOME`) and a job-local unix socket.
 
 This prevents collisions with any long-running cleanroom instance on the same host.
 

--- a/scripts/ci-cleanroom-e2e.sh
+++ b/scripts/ci-cleanroom-e2e.sh
@@ -141,11 +141,12 @@ main() {
   trap cleanup EXIT
 
   export XDG_CONFIG_HOME="$tmpdir/config"
+  export XDG_CACHE_HOME="$tmpdir/cache"
   export XDG_STATE_HOME="$tmpdir/state"
   export XDG_RUNTIME_DIR="$tmpdir/runtime"
   export XDG_DATA_HOME="$tmpdir/data"
 
-  mkdir -p "$XDG_CONFIG_HOME" "$XDG_STATE_HOME" "$XDG_RUNTIME_DIR" "$XDG_DATA_HOME"
+  mkdir -p "$XDG_CONFIG_HOME" "$XDG_CACHE_HOME" "$XDG_STATE_HOME" "$XDG_RUNTIME_DIR" "$XDG_DATA_HOME"
   mkdir -p "$XDG_CONFIG_HOME/cleanroom"
   cat > "$XDG_CONFIG_HOME/cleanroom/config.yaml" <<EOF
 default_backend: firecracker

--- a/scripts/ci-darwin-vz-e2e.sh
+++ b/scripts/ci-darwin-vz-e2e.sh
@@ -36,12 +36,13 @@ cleanup() {
 trap cleanup EXIT
 
 export XDG_CONFIG_HOME="$tmpdir/c"
+export XDG_CACHE_HOME="$tmpdir/cache"
 export XDG_STATE_HOME="$tmpdir/s"
 export XDG_RUNTIME_DIR="$tmpdir/r"
 export XDG_DATA_HOME="$tmpdir/d"
 export CLEANROOM_DARWIN_VZ_HELPER="$helper_path"
 
-mkdir -p "$XDG_CONFIG_HOME" "$XDG_STATE_HOME" "$XDG_RUNTIME_DIR" "$XDG_DATA_HOME"
+mkdir -p "$XDG_CONFIG_HOME" "$XDG_CACHE_HOME" "$XDG_STATE_HOME" "$XDG_RUNTIME_DIR" "$XDG_DATA_HOME"
 mkdir -p "$XDG_CONFIG_HOME/cleanroom"
 cat > "$XDG_CONFIG_HOME/cleanroom/config.yaml" <<EOF
 default_backend: darwin-vz

--- a/scripts/ci-darwin-vz-vmnet-e2e.sh
+++ b/scripts/ci-darwin-vz-vmnet-e2e.sh
@@ -139,6 +139,8 @@ setup_local_signing_assets() {
 setup_buildkite_runtime_paths() {
   xdg_state_home_path="/tmp/cleanroom-state-$(openssl rand -hex 4)"
   mkdir -p "$xdg_state_home_path"
+  xdg_cache_home_path="$tmpdir/cache"
+  mkdir -p "$xdg_cache_home_path"
   cleanup_xdg_state_home=1
 }
 
@@ -177,6 +179,7 @@ main() {
   system_keychain_path="/Library/Keychains/System.keychain"
   imported_system_identity_hash=""
   xdg_state_home_path="${XDG_STATE_HOME:-$HOME/.local/state}"
+  xdg_cache_home_path="${XDG_CACHE_HOME:-$HOME/.cache}"
   cleanup_xdg_state_home=0
   sign_identity=""
   sign_keychain=""
@@ -224,6 +227,7 @@ main() {
   run_with_macos_user_home codesign --verify --strict --verbose=2 "$helper_path"
 
   echo "--- :apple: VMNet E2E"
+  XDG_CACHE_HOME="$xdg_cache_home_path" \
   XDG_STATE_HOME="$xdg_state_home_path" \
   CLEANROOM_DARWIN_VZ_HELPER="$helper_path" \
   CLEANROOM_DARWIN_VZ_VMNET_E2E=1 \

--- a/scripts/ci_cleanroom_e2e_test.go
+++ b/scripts/ci_cleanroom_e2e_test.go
@@ -103,3 +103,22 @@ func TestCiCleanroomE2EReusedSandboxExecOmitsChdir(t *testing.T) {
 		t.Fatal("expected ci-cleanroom-e2e.sh not to pass --chdir when reusing a sandbox")
 	}
 }
+
+func TestCiCleanroomE2EIsolatesCacheInTempDir(t *testing.T) {
+	t.Helper()
+
+	content, err := os.ReadFile("ci-cleanroom-e2e.sh")
+	if err != nil {
+		t.Fatalf("read ci-cleanroom-e2e.sh: %v", err)
+	}
+
+	script := string(content)
+	for _, needle := range []string{
+		`export XDG_CACHE_HOME="$tmpdir/cache"`,
+		`mkdir -p "$XDG_CONFIG_HOME" "$XDG_CACHE_HOME" "$XDG_STATE_HOME" "$XDG_RUNTIME_DIR" "$XDG_DATA_HOME"`,
+	} {
+		if !strings.Contains(script, needle) {
+			t.Fatalf("expected ci-cleanroom-e2e.sh to contain %q", needle)
+		}
+	}
+}

--- a/scripts/ci_darwin_vz_e2e_test.go
+++ b/scripts/ci_darwin_vz_e2e_test.go
@@ -34,6 +34,9 @@ func TestCiDarwinVZE2EForcesNATNetworkMode(t *testing.T) {
 	if !strings.Contains(string(content), `helper_path="${CLEANROOM_DARWIN_VZ_HELPER:-$PWD/dist/cleanroom-darwin-vz.app}"`) {
 		t.Fatalf("expected ci-darwin-vz-e2e.sh to default to the prebuilt helper app bundle")
 	}
+	if !strings.Contains(string(content), `export XDG_CACHE_HOME="$tmpdir/cache"`) {
+		t.Fatalf("expected ci-darwin-vz-e2e.sh to isolate cleanroom cache under the job tmpdir")
+	}
 }
 
 func TestBuildDarwinVZHelperUsesSharedPackager(t *testing.T) {
@@ -101,6 +104,8 @@ func TestCiDarwinVZVMNetE2EUsesBuildkiteSecretsAndVMNetEntitlements(t *testing.T
 		`sign_identity="$requested_sign_identity"`,
 		`sign_keychain="$system_keychain_path"`,
 		`xdg_state_home_path="/tmp/cleanroom-state-$(openssl rand -hex 4)"`,
+		`xdg_cache_home_path="$tmpdir/cache"`,
+		`XDG_CACHE_HOME="$xdg_cache_home_path"`,
 		`XDG_STATE_HOME="$xdg_state_home_path"`,
 		"CLEANROOM_DARWIN_VZ_HELPER to a prebuilt signed helper bundle",
 		"CLEANROOM_DARWIN_VZ_HELPER_PROVISION_PROFILE and CLEANROOM_DARWIN_VZ_HELPER_SIGN_IDENTITY",


### PR DESCRIPTION
## What changed

This isolates cleanroom cache directories under job-local temp paths in the self-hosted CI entrypoints instead of letting cache state accumulate under the long-lived Buildkite agent home.

Changes in this PR:
- set `XDG_CACHE_HOME` in `scripts/ci-cleanroom-e2e.sh`
- set `XDG_CACHE_HOME` in `scripts/ci-darwin-vz-e2e.sh`
- set a temporary `XDG_CACHE_HOME` in the Buildkite path of `scripts/ci-darwin-vz-vmnet-e2e.sh`
- update CI docs to describe the cache isolation behavior
- add script tests that lock the new cache wiring in place

## Why

We hit disk exhaustion on the mac CI host because prepared darwin-vz runtime rootfs images were being cached under `/var/lib/buildkite-agent/.cache/cleanroom/darwin-vz/runtime-rootfs` and retained across jobs.

The root cause was that the CI scripts already isolated `XDG_CONFIG_HOME`, `XDG_STATE_HOME`, `XDG_RUNTIME_DIR`, and `XDG_DATA_HOME`, but not `XDG_CACHE_HOME`. That left prepared rootfs cache in the host-global Buildkite home and allowed it to grow unbounded over time.

## Impact

This is a short-term mitigation that trades warm cache reuse for bounded disk usage in CI.

After this change:
- prepared runtime rootfs cache does not persist across CI jobs
- darwin-vz CI jobs rebuild cache state inside their temp workspace as needed
- local non-Buildkite vmnet runs keep their current cache behavior

## Validation

- `mise exec -- go test ./scripts -run 'TestCi(DarwinVZ|CleanroomE2E)'`
- `mise exec -- shellcheck -x scripts/ci-darwin-vz-e2e.sh scripts/ci-cleanroom-e2e.sh scripts/ci-darwin-vz-vmnet-e2e.sh`
