### PR TITLE
feat: Add workspace seed snapshot reuse

### DIFF
--- a/docs/plans/layered-caching.md
+++ b/docs/plans/layered-caching.md
@@ -1,0 +1,625 @@
+# Layered Cache Plan
+
+**Spec reference:** `spec.md` sections 5.1.1, 5.2, 6.4
+**Status:** Proposed
+
+## Summary
+
+Build a deterministic cache hierarchy for environment construction, then
+materialize the selected cached environment as a single writable root volume
+per sandbox.
+
+The core model is:
+
+- host-side caches are keyed by immutable inputs such as image digests, git
+  commits, lockfiles, toolchain manifests, and compiled policy hashes
+- cached environments are published only by trusted host-side flows after
+  verification
+- sandboxes do not mount a live stack of cache layers at runtime
+- sandboxes boot from one writable child volume cloned from the best sealed
+  cached snapshot
+
+This separates two concerns that are easy to conflate:
+
+- **cache design** decides what reusable artifacts exist and how they are keyed
+- **materialization design** decides how a selected artifact becomes a fast VM
+  root filesystem
+
+We need both. Deterministic caches without cheap clone materialization still
+leave startup expensive. Cheap block clones without deterministic cache keys
+still leave reuse unsafe and hard to reason about.
+
+## Background
+
+The repository already has most of the right primitives in separate slices:
+
+- repo-aware bootstrap resolves the current repository to an exact remote URL
+  and commit and already plans for a mirror-backed git gateway
+- snapshots are modeled as immutable filesystem artifacts that can fan out to
+  many fresh-boot sandboxes
+- Firecracker and `darwin-vz` both already understand "one writable root volume
+  attached to the VM"
+- the volume store already exposes `EnsureBaseVolume`,
+  `CreateWritableVolume`, `SnapshotVolume`, and `CloneSnapshotToVolume`
+
+What is still missing is a unified cache model that answers:
+
+- which environment artifacts should exist
+- which exact inputs produce them
+- who is allowed to publish them
+- when a cache hit is trusted
+- how warm hits become close to plain sandbox creation time
+
+## Goals
+
+- Make warm environment startup close to plain sandbox boot time.
+- Key reusable environments by immutable, replayable inputs.
+- Keep credentials and upstream auth on the host side.
+- Prevent cache poisoning by untrusted guest workloads.
+- Support offline warm-cache execution with fail-closed behavior.
+- Keep the guest runtime model backend-neutral: one writable root filesystem
+  per sandbox, fresh boot every time.
+
+## Non-goals
+
+- Exposing runtime union filesystem semantics to users.
+- Reusing mutable package-manager caches directly from untrusted sandboxes.
+- Treating moving refs such as branches or tags as reusable cache keys.
+- Solving every ecosystem's lockfile format in the first slice.
+- Guaranteeing zero supply-chain risk in an absolute sense.
+
+## Design Principles
+
+### 1. Keys must be derived from immutable inputs
+
+Reusable environment artifacts must never be keyed by:
+
+- image tags
+- branch names
+- plain repository URLs without a commit
+- registry URLs without an integrity hash
+- mutable host-local cache state
+
+They must instead be keyed by exact inputs such as:
+
+- OCI digest
+- canonical remote URL
+- full commit SHA
+- submodule SHAs or enabled/disabled state
+- lockfile bytes and lockfile parser version
+- toolchain manifest bytes and resolved tool versions
+- compiled policy hash
+- bootstrap recipe digest
+
+### 2. Untrusted sandboxes must not publish shared cache entries
+
+A guest workload can request a checkpoint or complete a bootstrap step, but the
+host control plane remains authoritative for promotion into a shared cache.
+
+That means:
+
+- build into a temporary sandbox or temporary snapshot
+- verify the result on the host side
+- publish atomically
+- never mutate a `ready` cache entry in place
+
+### 3. Treat caches as immutable artifacts, not writable workspaces
+
+Every reusable layer should be modeled as an immutable artifact with metadata,
+state, lineage, and a storage reference.
+
+Mutable work happens only in:
+
+- a temporary builder sandbox
+- a per-run writable child clone
+
+### 4. Keep cache layers host-side and guest runtime simple
+
+The guest should not see a live mount stack like "base + repo + deps" for the
+default case. That adds backend-specific mount complexity, ordering issues, and
+new attack surface without improving deterministic reuse.
+
+The default runtime contract should remain:
+
+- clone one sealed rootfs snapshot into a writable child
+- attach that writable child as the VM root disk
+- boot a fresh sandbox
+
+### 5. Separate transport caches from environment caches
+
+A git mirror or a package artifact CAS improves fetch cost and upstream load,
+but it is not itself a runnable environment.
+
+That distinction matters for correctness:
+
+- transport caches are host-side accelerators
+- environment caches are sealed rootfs states that can be cloned into sandboxes
+
+## Cache Planes
+
+We should model two planes explicitly.
+
+### A. Logical cache plane
+
+This plane answers:
+
+- what artifact exists
+- what inputs produced it
+- whether it is safe to reuse
+- how it relates to parent artifacts
+
+Examples:
+
+- git mirror
+- package artifact blob
+- workspace seed
+- dependency seed
+
+### B. Physical materialization plane
+
+This plane answers:
+
+- where the artifact bytes live
+- how they are cloned
+- what gets attached to the VM
+
+Examples:
+
+- plain file copy
+- APFS `clonefile`
+- ZFS clone of a zvol snapshot
+
+The logical cache plane should not depend on one storage backend. The physical
+materialization plane is backend-specific and may vary by host.
+
+## Cache Layers
+
+### Layer 0: Runtime base
+
+Purpose:
+
+- derive the prepared runtime rootfs from the pinned OCI image digest
+- inject guest runtime assets once
+
+Suggested key:
+
+```text
+runtime_base_key = H(
+  schema_version,
+  backend_family,
+  architecture,
+  image_digest,
+  guest_runtime_version,
+  kernel_asset_id,
+  rootfs_prepare_recipe_digest
+)
+```
+
+Output:
+
+- immutable prepared rootfs artifact
+- optionally stored as a managed base volume
+
+Notes:
+
+- this is not repository-specific
+- this is the first layer that should be reused aggressively across runs
+
+### Layer 1: Git mirror
+
+Purpose:
+
+- reduce repeated upstream git traffic
+- keep auth and fetch control on the host side
+
+Suggested key:
+
+```text
+git_mirror_key = H(canonical_remote_url)
+```
+
+Output:
+
+- host-side bare mirror
+
+Notes:
+
+- this is a transport cache, not a runnable environment
+- freshness must still block until the requested commit exists
+
+### Layer 2: Package artifact CAS
+
+Purpose:
+
+- cache fetched registry artifacts by verified content
+- enforce lockfile-derived allowlists
+
+Suggested key:
+
+```text
+artifact_key = H(
+  ecosystem,
+  canonical_registry,
+  package_identity,
+  version,
+  integrity_hash
+)
+```
+
+Output:
+
+- immutable blob plus verified metadata
+
+Notes:
+
+- URL alone is not sufficient
+- if a lockfile does not include strong integrity metadata, that ecosystem does
+  not qualify for poisoning-resistant warm reuse in strict mode
+
+### Layer 3: Workspace seed
+
+Purpose:
+
+- capture an exact checked-out repository state ready for command execution
+
+Suggested key:
+
+```text
+workspace_seed_key = H(
+  runtime_base_key,
+  canonical_remote_url,
+  commit_sha,
+  submodule_mode,
+  submodule_resolution_digest,
+  checkout_mode,
+  repository_destination_dir
+)
+```
+
+Output:
+
+- sealed rootfs snapshot containing the exact repository checkout
+
+Notes:
+
+- this is the next speed stage after mirror-backed clone
+- it turns "avoid hammering upstream" into "skip clone and checkout on warm hit"
+
+### Layer 4: Dependency seed
+
+Purpose:
+
+- capture the environment after deterministic bootstrap such as dependency
+  install, generated fixtures, and language-specific setup
+
+Suggested key:
+
+```text
+dependency_seed_key = H(
+  workspace_seed_key,
+  compiled_policy_hash,
+  toolchain_manifest_digest,
+  resolved_tool_versions_digest,
+  lockfile_inputs_digest,
+  lockfile_parser_version,
+  bootstrap_recipe_digest
+)
+```
+
+Output:
+
+- sealed rootfs snapshot ready for common build or test commands
+
+Notes:
+
+- this is the primary "nearly instant environment" target
+- a warm hit should bypass repository clone and dependency install entirely
+
+### Layer 5: Writable execution child
+
+Purpose:
+
+- provide disposable isolation for one sandbox lifetime
+
+Suggested key:
+
+- none; this is not a shared cache artifact
+
+Output:
+
+- per-sandbox writable child clone of a dependency seed or workspace seed
+
+Notes:
+
+- this layer must never be shared or promoted automatically
+
+## Environment Key Resolution
+
+At request time, the control plane should derive a single canonical target key
+from the resolved request inputs.
+
+Illustrative shape:
+
+```text
+env_key = H(
+  schema_version,
+  backend_name,
+  architecture,
+  runtime_base_key,
+  compiled_policy_hash,
+  canonical_remote_url,
+  commit_sha,
+  submodule_resolution_digest,
+  toolchain_manifest_digest,
+  resolved_tool_versions_digest,
+  lockfile_inputs_digest,
+  lockfile_parser_version,
+  bootstrap_recipe_digest
+)
+```
+
+The control plane can then resolve the highest reusable artifact it trusts:
+
+1. dependency seed hit
+2. workspace seed hit
+3. runtime base hit
+4. cold path
+
+## Production Flow
+
+Shared cache publication should be a host-controlled promotion pipeline.
+
+### Publish workspace seed
+
+1. Resolve the exact repository checkout inputs.
+2. Start from the selected runtime base.
+3. Materialize the repository through the host git gateway.
+4. Verify the checkout:
+   - remote URL canonicalized as expected
+   - `HEAD` equals requested commit
+   - submodules match requested policy
+5. Snapshot the resulting root volume.
+6. Publish the workspace seed metadata and storage reference atomically.
+
+### Publish dependency seed
+
+1. Start from a published workspace seed.
+2. Run deterministic bootstrap in a temporary builder sandbox.
+3. Allow package fetches only through the gateway and only for lockfile-derived
+   artifacts.
+4. Verify:
+   - no lockfile violations
+   - no unexpected network access
+   - bootstrap recipe completed successfully
+5. Snapshot the resulting root volume.
+6. Publish the dependency seed metadata and storage reference atomically.
+
+## Consumption Flow
+
+Warm-hit resolution should be simple.
+
+1. Resolve request inputs into the canonical environment key.
+2. Look up the best `ready` artifact.
+3. Clone its rootfs snapshot into a fresh writable child volume.
+4. Attach that single writable child as the VM root disk.
+5. Boot a fresh sandbox.
+
+If no dependency seed exists but a workspace seed does:
+
+1. clone the workspace seed
+2. run deterministic bootstrap
+3. optionally publish a dependency seed if the policy allows promotion
+
+If only the runtime base exists:
+
+1. clone the runtime base
+2. perform repository checkout
+3. continue upward through the same promotion flow
+
+## Publication State Machine
+
+Each cache artifact should have an explicit lifecycle state.
+
+Suggested states:
+
+- `pending`
+- `building`
+- `verifying`
+- `ready`
+- `failed`
+- `garbage`
+
+Rules:
+
+- only `ready` entries are reusable
+- `ready` entries are immutable
+- failed builds do not overwrite or downgrade existing `ready` entries
+- promotion is atomic: the metadata entry becomes visible only after the
+  storage reference is durable and verified
+
+## Trust and Safety Model
+
+### Supply-chain and cache-poisoning constraints
+
+The design can sharply reduce mutable trust at startup, but not remove all
+upstream trust entirely.
+
+Trusted inputs still include:
+
+- the pinned base image digest
+- the pinned git commit
+- the lockfile integrity metadata
+- the lockfile and toolchain parsers
+
+The design should eliminate these weaker trust paths:
+
+- mutable tags
+- background refresh races against exact commit checkout
+- package downloads accepted by URL or version string alone
+- shared writable caches modified by untrusted sandboxes
+
+### Publish safety rules
+
+- publish only from trusted host-controlled flows
+- verify bytes before storing by integrity hash
+- use `write temp -> fsync -> atomic rename` for new artifact blobs and metadata
+- never serve partially written artifacts
+- never accept a guest-provided "cache hit" claim as authoritative
+
+### Offline warm mode
+
+When a policy requires strict offline warm-cache execution:
+
+- the control plane must refuse upstream git or registry access
+- only published `ready` artifacts may be used
+- missing artifacts fail closed
+
+## Runtime Filesystem Model
+
+The default runtime model should use one guest-visible root filesystem.
+
+That means:
+
+- no default runtime union mount stack
+- no default "base volume plus repo volume plus deps volume" mount assembly
+- one attached writable root volume per sandbox
+
+Logical cache layering still exists, but it is represented in metadata and
+lineage rather than in a live guest mount stack.
+
+This matches the current backend shape better:
+
+- Firecracker attaches one root drive to the microVM
+- `darwin-vz` attaches one writable rootfs image per VM
+- the snapshot store already models immutable rootfs states
+
+## Firecracker Performance Implications
+
+For Firecracker, the cache plan only pays off if rootfs materialization stops
+doing a full ext4 copy on the hot path.
+
+Recommended direction:
+
+- use the existing volume-store rootfs path for normal execution, not only for
+  persistent sandboxes and snapshot restore
+- treat a published cache artifact's `storage_ref` as the source for
+  `CloneSnapshotToVolume`
+- prefer a clone-capable Linux driver such as ZFS for warm-hit materialization
+
+Desired hot path:
+
+1. resolve best cache artifact
+2. clone snapshot to writable child volume
+3. attach child volume as Firecracker root disk
+4. boot VM
+
+Undesired hot path:
+
+1. resolve best cache artifact
+2. copy full ext4 file to `rootfs-ephemeral.ext4`
+3. boot VM
+
+The first path makes warm hits dominated by clone metadata work plus VM boot.
+The second path keeps warm hits bounded by rootfs size and host I/O.
+
+## Relationship To Existing Plans
+
+This plan composes with the existing documents rather than replacing them.
+
+- `repository-bootstrap.md`
+  defines exact-commit repository resolution and the host mirror-backed git
+  gateway
+- `snapshot-restore-fork.md`
+  defines immutable rootfs snapshots and fresh-boot fan-out semantics
+- `host-gateway.md`
+  defines the host-side mediation point for git and registry traffic
+- `firecracker-privilege-runtime.md`
+  defines the Linux host-runtime direction needed for clone-capable snapshot
+  storage and reduced root surface
+
+## Existing Code Touchpoints
+
+| File | Change |
+|---|---|
+| `internal/gateway/mirror.go` | Keep as the host-side git transport cache keyed by canonical remote URL. |
+| `internal/repositorycheckout/checkout.go` | Continue using exact remote URL and commit as the checkout source of truth. |
+| `internal/snapshotstore/store.go` | Extend snapshot-adjacent metadata to record cache layer type, key, parent, inputs, and publication state. |
+| `internal/volumestore/store.go` | Keep the abstract clone/snapshot interface; do not leak cache semantics into the storage driver API. |
+| `internal/backend/firecracker/backend.go` | Move the normal execution hot path onto clone-based root volume preparation. |
+| `internal/backend/darwinvz/backend_darwin.go` | Reuse the same logical cache metadata while keeping APFS-backed clone materialization. |
+| `internal/policy/policy.go` | Extend compiled policy data with lockfile-derived artifact allowlists and strict offline mode requirements. |
+
+## Suggested Metadata Model
+
+Suggested artifact record shape:
+
+```text
+artifact_key
+artifact_type            // runtime_base | workspace_seed | dependency_seed
+state                    // pending | building | verifying | ready | failed | garbage
+backend
+architecture
+policy_hash
+parent_artifact_key
+storage_driver
+storage_ref
+input_manifest_digest
+created_at
+producer_version
+```
+
+Input manifests should be stored as explicit structured metadata rather than as
+opaque prose so determinism can be tested directly.
+
+## Implementation Order
+
+1. Add cache metadata records and canonical key derivation helpers.
+2. Keep the git mirror as the transport cache for exact-commit checkout.
+3. Add lockfile parsing and package artifact CAS for one ecosystem first.
+4. Publish workspace seeds keyed by exact repository inputs.
+5. Publish dependency seeds keyed by lockfiles, toolchains, and bootstrap
+   recipe.
+6. Move Firecracker warm-hit materialization onto clone-based root volume
+   preparation.
+7. Add strict offline warm-cache mode and fail-closed launch checks.
+8. Add garbage collection and retention policies after the key model and
+   publication flow are stable.
+
+## Testing Plan
+
+### Key determinism
+
+- identical inputs produce identical keys
+- irrelevant field ordering does not change keys
+- parser version changes do change keys when parser behavior is versioned
+
+### Publication safety
+
+- partially written artifacts are never visible as `ready`
+- failed publishes do not corrupt existing entries
+- concurrent publishes of the same key coalesce correctly
+
+### Policy enforcement
+
+- lockfile-derived artifact allowlists block undeclared package requests
+- offline warm mode fails closed when a required artifact is missing
+- git repository materialization blocks until the requested commit exists in the
+  mirror
+
+### Runtime performance
+
+- warm dependency-seed hit skips repository clone and dependency install
+- Firecracker warm hits avoid full rootfs file copies
+- snapshot clone latency and VM boot latency are measured separately
+
+## Open Questions
+
+- Which ecosystem should be the first strict lockfile-enforced package cache:
+  npm, pip, or another?
+- Should dependency seeds be published automatically on successful bootstrap, or
+  only when explicitly requested?
+- What retention policy should apply to large dependency seeds relative to
+  smaller workspace seeds?
+- Do we need a specialized optional read-only guest-visible artifact volume for
+  very large immutable datasets, or can the single-rootfs model handle the
+  first production slice cleanly?

--- a/docs/plans/layered-caching.md
+++ b/docs/plans/layered-caching.md
@@ -29,6 +29,36 @@ We need both. Deterministic caches without cheap clone materialization still
 leave startup expensive. Cheap block clones without deterministic cache keys
 still leave reuse unsafe and hard to reason about.
 
+## Delivery Strategy
+
+This plan should land in phases rather than as one large cross-backend change.
+
+### Phase 1: Workspace-seed orchestration
+
+Land the backend-neutral control-plane slice first:
+
+- publish workspace-seed snapshots after exact-commit repository bootstrap
+- look up matching workspace-seed snapshots before repeating bootstrap
+- prove deterministic cache keying and trusted publication semantics
+
+This phase improves warm repo-aware sandbox creation by skipping repeated
+checkout work on snapshot-capable persistent backends.
+
+It does **not** yet deliver the full hot-path performance win for Firecracker,
+because Firecracker's normal execution flow still copies the prepared ext4
+rootfs per run.
+
+### Phase 2: Firecracker hot-path materialization
+
+Follow with a Firecracker-specific runtime change:
+
+- replace the per-run ext4 file copy with clone-based writable root volume
+  preparation
+- consume published cache artifacts through the volume-store clone path
+
+This is the phase that converts workspace-seed hits from "skip git/bootstrap
+work" into "nearly plain sandbox boot time" on Firecracker.
+
 ## Background
 
 The repository already has most of the right primitives in separate slices:
@@ -575,12 +605,12 @@ opaque prose so determinism can be tested directly.
 
 1. Add cache metadata records and canonical key derivation helpers.
 2. Keep the git mirror as the transport cache for exact-commit checkout.
-3. Add lockfile parsing and package artifact CAS for one ecosystem first.
-4. Publish workspace seeds keyed by exact repository inputs.
-5. Publish dependency seeds keyed by lockfiles, toolchains, and bootstrap
-   recipe.
-6. Move Firecracker warm-hit materialization onto clone-based root volume
+3. Publish workspace seeds keyed by exact repository inputs.
+4. Move Firecracker warm-hit materialization onto clone-based root volume
    preparation.
+5. Add lockfile parsing and package artifact CAS for one ecosystem first.
+6. Publish dependency seeds keyed by lockfiles, toolchains, and bootstrap
+   recipe.
 7. Add strict offline warm-cache mode and fail-closed launch checks.
 8. Add garbage collection and retention policies after the key model and
    publication flow are stable.

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -115,6 +115,12 @@ type SnapshottingAdapter interface {
 	DeleteSnapshot(ctx context.Context, req DeleteSnapshotRequest) error
 }
 
+// RuntimeBaseKeyProvider returns a stable identifier for the backend runtime
+// base that a reusable workspace seed depends on.
+type RuntimeBaseKeyProvider interface {
+	RuntimeBaseKey(ctx context.Context, compiled *policy.CompiledPolicy, cfg FirecrackerConfig) (string, error)
+}
+
 // SandboxFileDownloadAdapter can copy files out of a persistent sandbox.
 type SandboxFileDownloadAdapter interface {
 	DownloadSandboxFile(ctx context.Context, sandboxID, path string, maxBytes int64) ([]byte, error)

--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -1570,6 +1570,44 @@ func (a *Adapter) resolveRootFSPath(ctx context.Context, req backend.ExecutionRe
 	return prepared.Path, prepared.Ref, prepared.Digest, notice, nil
 }
 
+func (a *Adapter) RuntimeBaseKey(ctx context.Context, compiled *policy.CompiledPolicy, cfg backend.FirecrackerConfig) (string, error) {
+	configuredPath := strings.TrimSpace(cfg.RootFSPath)
+	if configuredPath != "" {
+		info, err := os.Stat(configuredPath)
+		if err == nil {
+			absPath, err := filepath.Abs(configuredPath)
+			if err != nil {
+				return "", err
+			}
+			return fmt.Sprintf("configured-rootfs:%s|%d|%d", absPath, info.Size(), info.ModTime().UTC().UnixNano()), nil
+		}
+	}
+
+	if compiled == nil {
+		return "", errors.New("missing compiled policy")
+	}
+
+	imageDigest := strings.TrimSpace(compiled.ImageDigest)
+	if imageDigest == "" {
+		artifact, err := a.ensureImageArtifact(ctx, compiled.ImageRef)
+		if err != nil {
+			return "", err
+		}
+		imageDigest = artifact.Digest
+	}
+
+	_, guestAgentHash, err := a.getGuestAgentBinary()
+	if err != nil {
+		return "", err
+	}
+
+	preparedPath, err := preparedRuntimeRootFSPath(imageDigest, guestAgentHash)
+	if err != nil {
+		return "", err
+	}
+	return "prepared-rootfs:" + preparedPath, nil
+}
+
 func (a *Adapter) ensurePreparedRuntimeRootFSFromImage(ctx context.Context, imageRef string) (preparedRootFS, error) {
 	artifact, err := a.ensureImageArtifact(ctx, imageRef)
 	if err != nil {

--- a/internal/backend/darwinvz/backend_unsupported.go
+++ b/internal/backend/darwinvz/backend_unsupported.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 
 	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/policy"
 )
 
 type Adapter struct {
@@ -38,6 +39,10 @@ func (a *Adapter) Run(_ context.Context, _ backend.ExecutionRequest) (*backend.E
 
 func (a *Adapter) RunStream(ctx context.Context, req backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
 	return a.Run(ctx, req)
+}
+
+func (a *Adapter) RuntimeBaseKey(_ context.Context, _ *policy.CompiledPolicy, _ backend.FirecrackerConfig) (string, error) {
+	return "", fmt.Errorf("darwin-vz backend requires macOS, current OS is %s", runtime.GOOS)
 }
 
 func (a *Adapter) Doctor(_ context.Context, _ backend.DoctorRequest) (*backend.DoctorReport, error) {

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -1310,6 +1310,32 @@ func (a *Adapter) ensureImageArtifact(ctx context.Context, imageRef string) (ima
 	}, nil
 }
 
+func (a *Adapter) RuntimeBaseKey(ctx context.Context, compiled *policy.CompiledPolicy, _ backend.FirecrackerConfig) (string, error) {
+	if compiled == nil {
+		return "", errors.New("missing compiled policy")
+	}
+
+	imageDigest := strings.TrimSpace(compiled.ImageDigest)
+	if imageDigest == "" {
+		artifact, err := a.ensureImageArtifact(ctx, compiled.ImageRef)
+		if err != nil {
+			return "", err
+		}
+		imageDigest = artifact.Digest
+	}
+
+	_, guestAgentHash, err := a.getGuestAgentBinary()
+	if err != nil {
+		return "", err
+	}
+
+	preparedPath, err := preparedRuntimeRootFSPath(imageDigest, guestAgentHash)
+	if err != nil {
+		return "", err
+	}
+	return "prepared-rootfs:" + preparedPath, nil
+}
+
 func (a *Adapter) ensurePreparedRuntimeRootFS(ctx context.Context, cfg backend.FirecrackerConfig, image imageArtifact) (string, error) {
 	sourcePath := strings.TrimSpace(image.RootFSPath)
 	if sourcePath == "" {

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -194,17 +194,23 @@ func (s *Service) CreateSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 	firecrackerCfg.RunDir = ""
 	firecrackerCfg = withRepositoryBootstrapRootFSMinimum(firecrackerCfg, compiled, repository)
 
+	replacedWorkspaceSeedSnapshotID := ""
 	if repository != nil {
 		if _, ok := adapter.(backend.SnapshottingAdapter); ok && snapshotOperationsEnabledForBackend(backendName, s.Config) {
 			record, found, err := s.lookupWorkspaceSeedSnapshot(ctx, backendName, compiled, repository)
 			if err != nil {
 				s.logWorkspaceSeedWarning("lookup workspace seed snapshot", "", err)
 			} else if found {
-				return s.createSandboxFromSnapshot(ctx, &cleanroomv1.CreateSandboxRequest{
+				resp, restoreErr := s.createSandboxFromSnapshot(ctx, &cleanroomv1.CreateSandboxRequest{
 					Backend: backendName,
 					Options: req.GetOptions(),
 					Source:  &cleanroomv1.CreateSandboxRequest_SnapshotId{SnapshotId: record.SnapshotID},
 				}, record.SnapshotID)
+				if restoreErr == nil {
+					return resp, nil
+				}
+				replacedWorkspaceSeedSnapshotID = record.SnapshotID
+				s.logWorkspaceSeedRestoreWarning(record.SnapshotID, restoreErr)
 			}
 		}
 	}
@@ -229,7 +235,7 @@ func (s *Service) CreateSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 			return nil, fmt.Errorf("bootstrap repository checkout: %w", err)
 		}
 		if snapshotAdapter, ok := adapter.(backend.SnapshottingAdapter); ok {
-			s.maybePublishWorkspaceSeedSnapshot(ctx, snapshotAdapter, sandboxID, backendName, compiled, firecrackerCfg, repository)
+			s.maybePublishWorkspaceSeedSnapshot(ctx, snapshotAdapter, sandboxID, backendName, compiled, firecrackerCfg, repository, replacedWorkspaceSeedSnapshotID)
 		}
 	} else if repository != nil {
 		return nil, errors.New("repository bootstrap for sandbox creation requires a persistent backend")
@@ -424,6 +430,9 @@ func (s *Service) CreateSnapshot(ctx context.Context, req *cleanroomv1.CreateSna
 	now := time.Now().UTC()
 	snapshotID := newSnapshotID()
 	name := strings.TrimSpace(req.GetName())
+	if isWorkspaceSeedSnapshotName(name) {
+		return nil, fmt.Errorf("snapshot name %q is reserved for managed workspace seed snapshots", name)
+	}
 
 	var (
 		record          snapshotstore.Record

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -195,22 +195,31 @@ func (s *Service) CreateSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 	firecrackerCfg = withRepositoryBootstrapRootFSMinimum(firecrackerCfg, compiled, repository)
 
 	replacedWorkspaceSeedSnapshotID := ""
+	workspaceSeedRuntimeBaseKey := ""
+	workspaceSeedCachingEnabled := false
 	if repository != nil {
 		if _, ok := adapter.(backend.SnapshottingAdapter); ok && snapshotOperationsEnabledForBackend(backendName, s.Config) {
-			record, found, err := s.lookupWorkspaceSeedSnapshot(ctx, backendName, compiled, repository)
+			runtimeBaseKey, cacheable, err := s.workspaceSeedRuntimeBaseKey(ctx, adapter, compiled, firecrackerCfg)
 			if err != nil {
-				s.logWorkspaceSeedWarning("lookup workspace seed snapshot", "", err)
-			} else if found {
-				resp, restoreErr := s.createSandboxFromSnapshot(ctx, &cleanroomv1.CreateSandboxRequest{
-					Backend: backendName,
-					Options: req.GetOptions(),
-					Source:  &cleanroomv1.CreateSandboxRequest_SnapshotId{SnapshotId: record.SnapshotID},
-				}, record.SnapshotID)
-				if restoreErr == nil {
-					return resp, nil
+				s.logWorkspaceSeedWarning("resolve workspace seed runtime base key", "", err)
+			} else if cacheable {
+				workspaceSeedRuntimeBaseKey = runtimeBaseKey
+				workspaceSeedCachingEnabled = true
+				record, found, err := s.lookupWorkspaceSeedSnapshot(ctx, backendName, compiled, workspaceSeedRuntimeBaseKey, repository)
+				if err != nil {
+					s.logWorkspaceSeedWarning("lookup workspace seed snapshot", "", err)
+				} else if found {
+					resp, restoreErr := s.createSandboxFromSnapshot(ctx, &cleanroomv1.CreateSandboxRequest{
+						Backend: backendName,
+						Options: req.GetOptions(),
+						Source:  &cleanroomv1.CreateSandboxRequest_SnapshotId{SnapshotId: record.SnapshotID},
+					}, record.SnapshotID)
+					if restoreErr == nil {
+						return resp, nil
+					}
+					replacedWorkspaceSeedSnapshotID = record.SnapshotID
+					s.logWorkspaceSeedRestoreWarning(record.SnapshotID, restoreErr)
 				}
-				replacedWorkspaceSeedSnapshotID = record.SnapshotID
-				s.logWorkspaceSeedRestoreWarning(record.SnapshotID, restoreErr)
 			}
 		}
 	}
@@ -234,8 +243,8 @@ func (s *Service) CreateSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 			}
 			return nil, fmt.Errorf("bootstrap repository checkout: %w", err)
 		}
-		if snapshotAdapter, ok := adapter.(backend.SnapshottingAdapter); ok {
-			s.maybePublishWorkspaceSeedSnapshot(ctx, snapshotAdapter, sandboxID, backendName, compiled, firecrackerCfg, repository, replacedWorkspaceSeedSnapshotID)
+		if snapshotAdapter, ok := adapter.(backend.SnapshottingAdapter); ok && workspaceSeedCachingEnabled {
+			s.maybePublishWorkspaceSeedSnapshot(ctx, snapshotAdapter, sandboxID, backendName, compiled, firecrackerCfg, workspaceSeedRuntimeBaseKey, repository, replacedWorkspaceSeedSnapshotID)
 		}
 	} else if repository != nil {
 		return nil, errors.New("repository bootstrap for sandbox creation requires a persistent backend")

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -194,6 +194,21 @@ func (s *Service) CreateSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 	firecrackerCfg.RunDir = ""
 	firecrackerCfg = withRepositoryBootstrapRootFSMinimum(firecrackerCfg, compiled, repository)
 
+	if repository != nil {
+		if _, ok := adapter.(backend.SnapshottingAdapter); ok && snapshotOperationsEnabledForBackend(backendName, s.Config) {
+			record, found, err := s.lookupWorkspaceSeedSnapshot(ctx, backendName, compiled, repository)
+			if err != nil {
+				s.logWorkspaceSeedWarning("lookup workspace seed snapshot", "", err)
+			} else if found {
+				return s.createSandboxFromSnapshot(ctx, &cleanroomv1.CreateSandboxRequest{
+					Backend: backendName,
+					Options: req.GetOptions(),
+					Source:  &cleanroomv1.CreateSandboxRequest_SnapshotId{SnapshotId: record.SnapshotID},
+				}, record.SnapshotID)
+			}
+		}
+	}
+
 	now := s.clock().Now()
 	sandboxID := s.ids().NewSandboxID()
 
@@ -212,6 +227,9 @@ func (s *Service) CreateSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 				return nil, fmt.Errorf("bootstrap repository checkout: %w; cleanup failed: %v", err, terminateErr)
 			}
 			return nil, fmt.Errorf("bootstrap repository checkout: %w", err)
+		}
+		if snapshotAdapter, ok := adapter.(backend.SnapshottingAdapter); ok {
+			s.maybePublishWorkspaceSeedSnapshot(ctx, snapshotAdapter, sandboxID, backendName, compiled, firecrackerCfg, repository)
 		}
 	} else if repository != nil {
 		return nil, errors.New("repository bootstrap for sandbox creation requires a persistent backend")

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -1620,6 +1620,27 @@ func TestCreateSandboxRejectsRepositoryFileRemote(t *testing.T) {
 	}
 }
 
+func TestCreateSandboxRejectsMutableRepositoryCommitRef(t *testing.T) {
+	adapter := &stubAdapter{}
+	svc := newTestService(adapter)
+
+	repository := testRepositoryCheckoutProto()
+	repository.CommitSha = "main"
+	_, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Policy:             testRepositoryPolicy(),
+		RepositoryCheckout: repository,
+	})
+	if err == nil {
+		t.Fatal("expected repository bootstrap to reject mutable commit refs")
+	}
+	if !strings.Contains(err.Error(), "full 40-character hexadecimal commit SHA") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := adapter.provisionCalls; got != 0 {
+		t.Fatalf("expected no provision call on invalid repository commit ref, got %d", got)
+	}
+}
+
 func TestCreateExecutionRejectsRepositoryRemoteOutsidePolicy(t *testing.T) {
 	adapter := &stubAdapter{}
 	mirrors := &stubRepositoryMirrorStore{}

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -1201,6 +1201,40 @@ func TestCreateSandboxPublishesWorkspaceSeedSnapshot(t *testing.T) {
 	}
 }
 
+func TestWorkspaceSeedSnapshotRecordBreaksCreatedAtTiesBySnapshotID(t *testing.T) {
+	compiled, err := policy.FromProto(testRepositoryPolicy())
+	if err != nil {
+		t.Fatalf("FromProto returned error: %v", err)
+	}
+	repository := repositorycheckout.FromProto(testRepositoryCheckoutProto())
+	createdAt := time.Unix(1_700_000_000, 0).UTC()
+
+	older := snapshotstore.Record{
+		SnapshotID: "snap_00000000000000000000000001",
+		Backend:    "firecracker",
+		Name:       workspaceSeedSnapshotName("firecracker", compiled.Hash, repository),
+		PolicyHash: compiled.Hash,
+		Repository: repository.ToProto(),
+		CreatedAt:  createdAt,
+	}
+	newer := snapshotstore.Record{
+		SnapshotID: "snap_00000000000000000000000002",
+		Backend:    "firecracker",
+		Name:       workspaceSeedSnapshotName("firecracker", compiled.Hash, repository),
+		PolicyHash: compiled.Hash,
+		Repository: repository.ToProto(),
+		CreatedAt:  createdAt,
+	}
+
+	record, ok := workspaceSeedSnapshotRecord([]snapshotstore.Record{older, newer}, "firecracker", compiled.Hash, repository)
+	if !ok {
+		t.Fatal("expected workspace seed snapshot record match")
+	}
+	if got, want := record.SnapshotID, newer.SnapshotID; got != want {
+		t.Fatalf("expected tie-break to prefer newer snapshot id, got %q want %q", got, want)
+	}
+}
+
 func TestCreateSandboxReusesWorkspaceSeedSnapshot(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	store := newMemorySnapshotStore()

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -168,11 +168,25 @@ type stubRepositoryMirrorStore struct {
 	err       error
 }
 
+type stubClock struct {
+	now time.Time
+}
+
 func (s *stubRepositoryMirrorStore) EnsureMirrorContains(_ context.Context, remoteURL, commitSHA string) error {
 	s.remoteURL = remoteURL
 	s.commitSHA = commitSHA
 	s.calls++
 	return s.err
+}
+
+func (c stubClock) Now() time.Time {
+	return c.now
+}
+
+func (c stubClock) After(d time.Duration) <-chan time.Time {
+	ch := make(chan time.Time, 1)
+	ch <- c.now.Add(d)
+	return ch
 }
 
 func (l stubLoader) LoadAndCompile(_ string) (*policy.CompiledPolicy, string, error) {
@@ -1159,6 +1173,8 @@ func TestCreateSandboxPublishesWorkspaceSeedSnapshot(t *testing.T) {
 	mirrors := &stubRepositoryMirrorStore{}
 	svc := newTestServiceWithSnapshotStore(adapter, store)
 	svc.RepositoryMirrors = mirrors
+	publishedAt := time.Unix(1_700_000_123, 0).UTC()
+	svc.runtime.clock = stubClock{now: publishedAt}
 
 	createResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
 		Policy:             testRepositoryPolicy(),
@@ -1198,6 +1214,9 @@ func TestCreateSandboxPublishesWorkspaceSeedSnapshot(t *testing.T) {
 	}
 	if got, want := record.Repository.GetCommitSha(), testRepositoryCheckoutProto().GetCommitSha(); got != want {
 		t.Fatalf("unexpected workspace seed commit: got %q want %q", got, want)
+	}
+	if got, want := record.CreatedAt, publishedAt; !got.Equal(want) {
+		t.Fatalf("unexpected workspace seed created_at: got %s want %s", got.Format(time.RFC3339Nano), want.Format(time.RFC3339Nano))
 	}
 }
 

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -518,6 +518,31 @@ func TestCreateSnapshotRejectsDisabledSnapshots(t *testing.T) {
 	}
 }
 
+func TestCreateSnapshotRejectsReservedWorkspaceSeedName(t *testing.T) {
+	store := newMemorySnapshotStore()
+	adapter := &stubAdapter{}
+	svc := newTestServiceWithSnapshotStore(adapter, store)
+
+	createResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+
+	_, err = svc.CreateSnapshot(context.Background(), &cleanroomv1.CreateSnapshotRequest{
+		SandboxId: createResp.GetSandbox().GetSandboxId(),
+		Name:      workspaceSeedSnapshotNamePrefix + "manual",
+	})
+	if err == nil {
+		t.Fatal("expected CreateSnapshot to reject reserved workspace seed snapshot names")
+	}
+	if !strings.Contains(err.Error(), "reserved for managed workspace seed snapshots") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, want := adapter.createSnapshotCalls, 0; got != want {
+		t.Fatalf("unexpected create snapshot call count: got %d want %d", got, want)
+	}
+}
+
 func TestCreateSnapshotRejectsRepositoryBusySandbox(t *testing.T) {
 	store := newMemorySnapshotStore()
 	adapter := &stubAdapter{}
@@ -1233,6 +1258,62 @@ func TestCreateSandboxReusesWorkspaceSeedSnapshot(t *testing.T) {
 	}
 	if got, want := adapter.provisionFromSnapshotReq.StorageRef, "/snapshots/"+adapter.createSnapshotReq.SnapshotID+".ext4"; got != want {
 		t.Fatalf("unexpected snapshot storage ref on warm hit: got %q want %q", got, want)
+	}
+}
+
+func TestCreateSandboxFallsBackWhenWorkspaceSeedRestoreFails(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	store := newMemorySnapshotStore()
+	adapter := &stubAdapter{
+		createSnapshotFn: func(_ context.Context, req backend.SnapshotRequest) (*backend.SnapshotResult, error) {
+			return &backend.SnapshotResult{StorageRef: "/snapshots/" + req.SnapshotID + ".ext4"}, nil
+		},
+		provisionFromSnapshotFn: func(_ context.Context, _ backend.ProvisionFromSnapshotRequest) error {
+			return errors.New("snapshot restore failed")
+		},
+	}
+	mirrors := &stubRepositoryMirrorStore{}
+	svc := newTestServiceWithSnapshotStore(adapter, store)
+	svc.RepositoryMirrors = mirrors
+
+	req := &cleanroomv1.CreateSandboxRequest{
+		Policy:             testRepositoryPolicy(),
+		RepositoryCheckout: testRepositoryCheckoutProto(),
+	}
+
+	if _, err := svc.CreateSandbox(context.Background(), req); err != nil {
+		t.Fatalf("first CreateSandbox returned error: %v", err)
+	}
+
+	secondResp, err := svc.CreateSandbox(context.Background(), req)
+	if err != nil {
+		t.Fatalf("second CreateSandbox returned error: %v", err)
+	}
+	if secondResp.GetSandbox().GetSandboxId() == "" {
+		t.Fatal("expected sandbox id after falling back to cold bootstrap")
+	}
+	if got, want := adapter.provisionFromSnapshotCalls, 1; got != want {
+		t.Fatalf("expected one failed snapshot restore attempt, got %d want %d", got, want)
+	}
+	if got, want := adapter.provisionCalls, 2; got != want {
+		t.Fatalf("expected fallback path to reprovision sandbox, got %d want %d", got, want)
+	}
+	if got, want := adapter.runCalls, 2; got != want {
+		t.Fatalf("expected fallback path to rerun repository bootstrap, got %d want %d", got, want)
+	}
+	if got, want := adapter.createSnapshotCalls, 2; got != want {
+		t.Fatalf("expected fallback path to republish workspace seed snapshot, got %d want %d", got, want)
+	}
+	if got, want := mirrors.calls, 2; got != want {
+		t.Fatalf("expected fallback path to re-prewarm mirror, got %d want %d", got, want)
+	}
+
+	records, err := store.List(context.Background())
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if got, want := len(records), 2; got != want {
+		t.Fatalf("expected failed restore fallback to retain old snapshot and publish a new one, got %d want %d", got, want)
 	}
 }
 

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -41,6 +41,8 @@ type stubAdapter struct {
 	createSnapshotCalls        int
 	deleteSnapshotCalls        int
 	terminateCalls             int
+	workspaceSeedRuntimeKey    string
+	runtimeBaseKeyErr          error
 }
 
 func (s *stubAdapter) Name() string { return "stub" }
@@ -154,6 +156,16 @@ func (s *stubAdapter) DownloadSandboxFile(ctx context.Context, sandboxID, path s
 		return s.downloadFn(ctx, sandboxID, path, maxBytes)
 	}
 	return nil, errors.New("download not configured")
+}
+
+func (s *stubAdapter) RuntimeBaseKey(_ context.Context, _ *policy.CompiledPolicy, _ backend.FirecrackerConfig) (string, error) {
+	if s.runtimeBaseKeyErr != nil {
+		return "", s.runtimeBaseKeyErr
+	}
+	if strings.TrimSpace(s.workspaceSeedRuntimeKey) != "" {
+		return s.workspaceSeedRuntimeKey, nil
+	}
+	return "runtime-base:test", nil
 }
 
 type stubLoader struct {
@@ -1206,7 +1218,7 @@ func TestCreateSandboxPublishesWorkspaceSeedSnapshot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("FromProto returned error: %v", err)
 	}
-	if got, want := record.Name, workspaceSeedSnapshotName("firecracker", compiled.Hash, repositorycheckout.FromProto(testRepositoryCheckoutProto())); got != want {
+	if got, want := record.Name, workspaceSeedSnapshotName("firecracker", compiled.Hash, "runtime-base:test", repositorycheckout.FromProto(testRepositoryCheckoutProto())); got != want {
 		t.Fatalf("unexpected workspace seed snapshot name: got %q want %q", got, want)
 	}
 	if record.Repository == nil {
@@ -1231,7 +1243,7 @@ func TestWorkspaceSeedSnapshotRecordBreaksCreatedAtTiesBySnapshotID(t *testing.T
 	older := snapshotstore.Record{
 		SnapshotID: "snap_00000000000000000000000001",
 		Backend:    "firecracker",
-		Name:       workspaceSeedSnapshotName("firecracker", compiled.Hash, repository),
+		Name:       workspaceSeedSnapshotName("firecracker", compiled.Hash, "runtime-base:test", repository),
 		PolicyHash: compiled.Hash,
 		Repository: repository.ToProto(),
 		CreatedAt:  createdAt,
@@ -1239,13 +1251,13 @@ func TestWorkspaceSeedSnapshotRecordBreaksCreatedAtTiesBySnapshotID(t *testing.T
 	newer := snapshotstore.Record{
 		SnapshotID: "snap_00000000000000000000000002",
 		Backend:    "firecracker",
-		Name:       workspaceSeedSnapshotName("firecracker", compiled.Hash, repository),
+		Name:       workspaceSeedSnapshotName("firecracker", compiled.Hash, "runtime-base:test", repository),
 		PolicyHash: compiled.Hash,
 		Repository: repository.ToProto(),
 		CreatedAt:  createdAt,
 	}
 
-	record, ok := workspaceSeedSnapshotRecord([]snapshotstore.Record{older, newer}, "firecracker", compiled.Hash, repository)
+	record, ok := workspaceSeedSnapshotRecord([]snapshotstore.Record{older, newer}, "firecracker", compiled.Hash, "runtime-base:test", repository)
 	if !ok {
 		t.Fatal("expected workspace seed snapshot record match")
 	}
@@ -1311,6 +1323,59 @@ func TestCreateSandboxReusesWorkspaceSeedSnapshot(t *testing.T) {
 	}
 	if got, want := adapter.provisionFromSnapshotReq.StorageRef, "/snapshots/"+adapter.createSnapshotReq.SnapshotID+".ext4"; got != want {
 		t.Fatalf("unexpected snapshot storage ref on warm hit: got %q want %q", got, want)
+	}
+}
+
+func TestCreateSandboxDoesNotReuseWorkspaceSeedWhenRuntimeBaseKeyChanges(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	store := newMemorySnapshotStore()
+	adapter := &stubAdapter{
+		workspaceSeedRuntimeKey: "runtime-base:a",
+		createSnapshotFn: func(_ context.Context, req backend.SnapshotRequest) (*backend.SnapshotResult, error) {
+			return &backend.SnapshotResult{StorageRef: "/snapshots/" + req.SnapshotID + ".ext4"}, nil
+		},
+	}
+	mirrors := &stubRepositoryMirrorStore{}
+	svc := newTestServiceWithSnapshotStore(adapter, store)
+	svc.RepositoryMirrors = mirrors
+
+	req := &cleanroomv1.CreateSandboxRequest{
+		Policy:             testRepositoryPolicy(),
+		RepositoryCheckout: testRepositoryCheckoutProto(),
+	}
+
+	if _, err := svc.CreateSandbox(context.Background(), req); err != nil {
+		t.Fatalf("first CreateSandbox returned error: %v", err)
+	}
+
+	adapter.workspaceSeedRuntimeKey = "runtime-base:b"
+
+	secondResp, err := svc.CreateSandbox(context.Background(), req)
+	if err != nil {
+		t.Fatalf("second CreateSandbox returned error: %v", err)
+	}
+	if secondResp.GetSandbox().GetSandboxId() == "" {
+		t.Fatal("expected sandbox id after runtime base change")
+	}
+	if got, want := adapter.provisionFromSnapshotCalls, 0; got != want {
+		t.Fatalf("expected runtime base change to avoid snapshot restore, got %d want %d", got, want)
+	}
+	if got, want := adapter.provisionCalls, 2; got != want {
+		t.Fatalf("expected runtime base change to reprovision sandbox, got %d want %d", got, want)
+	}
+	if got, want := adapter.runCalls, 2; got != want {
+		t.Fatalf("expected runtime base change to rerun repository bootstrap, got %d want %d", got, want)
+	}
+	if got, want := adapter.createSnapshotCalls, 2; got != want {
+		t.Fatalf("expected runtime base change to publish a new workspace seed, got %d want %d", got, want)
+	}
+
+	records, err := store.List(context.Background())
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if got, want := len(records), 2; got != want {
+		t.Fatalf("expected two workspace seed snapshots after runtime base change, got %d want %d", got, want)
 	}
 }
 

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -14,6 +14,7 @@ import (
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
 	"github.com/buildkite/cleanroom/internal/paths"
 	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/buildkite/cleanroom/internal/repositorycheckout"
 	"github.com/buildkite/cleanroom/internal/runtimeconfig"
 	"github.com/buildkite/cleanroom/internal/snapshotstore"
 	"go.jetify.com/typeid"
@@ -442,8 +443,8 @@ func TestCreateSnapshotPersistsMetadataAndDeletesIt(t *testing.T) {
 	if got, want := adapter.createSnapshotReq.SandboxID, sandbox.GetSandboxId(); got != want {
 		t.Fatalf("unexpected create snapshot sandbox id: got %q want %q", got, want)
 	}
-	if adapter.createSnapshotCalls != 1 {
-		t.Fatalf("expected one snapshot create call, got %d", adapter.createSnapshotCalls)
+	if adapter.createSnapshotCalls != 2 {
+		t.Fatalf("expected two snapshot create calls (workspace seed + manual snapshot), got %d", adapter.createSnapshotCalls)
 	}
 
 	getResp, err := svc.GetSnapshot(context.Background(), &cleanroomv1.GetSnapshotRequest{
@@ -466,7 +467,7 @@ func TestCreateSnapshotPersistsMetadataAndDeletesIt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListSnapshots returned error: %v", err)
 	}
-	if got, want := len(listResp.GetSnapshots()), 1; got != want {
+	if got, want := len(listResp.GetSnapshots()), 2; got != want {
 		t.Fatalf("unexpected snapshot count: got %d want %d", got, want)
 	}
 
@@ -487,8 +488,8 @@ func TestCreateSnapshotPersistsMetadataAndDeletesIt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListSnapshots after delete returned error: %v", err)
 	}
-	if got := len(listResp.GetSnapshots()); got != 0 {
-		t.Fatalf("expected no snapshots after delete, got %d", got)
+	if got := len(listResp.GetSnapshots()); got != 1 {
+		t.Fatalf("expected workspace seed snapshot to remain after deleting manual snapshot, got %d snapshots", got)
 	}
 }
 
@@ -1119,6 +1120,119 @@ func TestCreateSandboxBootstrapsRepositoryInService(t *testing.T) {
 	}
 	if rel, err := filepath.Rel(executionBaseDir, adapter.req.RunDir); err == nil && rel != "." && !strings.HasPrefix(rel, "..") {
 		t.Fatalf("expected bootstrap run dir to stay out of execution artifacts base dir %q, got %q", executionBaseDir, adapter.req.RunDir)
+	}
+}
+
+func TestCreateSandboxPublishesWorkspaceSeedSnapshot(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	store := newMemorySnapshotStore()
+	adapter := &stubAdapter{
+		createSnapshotFn: func(_ context.Context, req backend.SnapshotRequest) (*backend.SnapshotResult, error) {
+			return &backend.SnapshotResult{StorageRef: "/snapshots/" + req.SnapshotID + ".ext4"}, nil
+		},
+	}
+	mirrors := &stubRepositoryMirrorStore{}
+	svc := newTestServiceWithSnapshotStore(adapter, store)
+	svc.RepositoryMirrors = mirrors
+
+	createResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Policy:             testRepositoryPolicy(),
+		RepositoryCheckout: testRepositoryCheckoutProto(),
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+
+	if got, want := adapter.provisionCalls, 1; got != want {
+		t.Fatalf("unexpected provision call count: got %d want %d", got, want)
+	}
+	if got, want := adapter.createSnapshotCalls, 1; got != want {
+		t.Fatalf("unexpected workspace seed snapshot create count: got %d want %d", got, want)
+	}
+	if got, want := adapter.createSnapshotReq.SandboxID, createResp.GetSandbox().GetSandboxId(); got != want {
+		t.Fatalf("unexpected snapshot sandbox id: got %q want %q", got, want)
+	}
+
+	records, err := store.List(context.Background())
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if got, want := len(records), 1; got != want {
+		t.Fatalf("unexpected snapshot record count: got %d want %d", got, want)
+	}
+	record := records[0]
+	compiled, err := policy.FromProto(testRepositoryPolicy())
+	if err != nil {
+		t.Fatalf("FromProto returned error: %v", err)
+	}
+	if got, want := record.Name, workspaceSeedSnapshotName("firecracker", compiled.Hash, repositorycheckout.FromProto(testRepositoryCheckoutProto())); got != want {
+		t.Fatalf("unexpected workspace seed snapshot name: got %q want %q", got, want)
+	}
+	if record.Repository == nil {
+		t.Fatal("expected repository metadata on workspace seed snapshot")
+	}
+	if got, want := record.Repository.GetCommitSha(), testRepositoryCheckoutProto().GetCommitSha(); got != want {
+		t.Fatalf("unexpected workspace seed commit: got %q want %q", got, want)
+	}
+}
+
+func TestCreateSandboxReusesWorkspaceSeedSnapshot(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	store := newMemorySnapshotStore()
+	adapter := &stubAdapter{
+		createSnapshotFn: func(_ context.Context, req backend.SnapshotRequest) (*backend.SnapshotResult, error) {
+			return &backend.SnapshotResult{StorageRef: "/snapshots/" + req.SnapshotID + ".ext4"}, nil
+		},
+	}
+	mirrors := &stubRepositoryMirrorStore{}
+	svc := newTestServiceWithSnapshotStore(adapter, store)
+	svc.RepositoryMirrors = mirrors
+
+	req := &cleanroomv1.CreateSandboxRequest{
+		Policy:             testRepositoryPolicy(),
+		RepositoryCheckout: testRepositoryCheckoutProto(),
+	}
+
+	if _, err := svc.CreateSandbox(context.Background(), req); err != nil {
+		t.Fatalf("first CreateSandbox returned error: %v", err)
+	}
+	if got, want := adapter.provisionCalls, 1; got != want {
+		t.Fatalf("unexpected initial provision calls: got %d want %d", got, want)
+	}
+	if got, want := adapter.createSnapshotCalls, 1; got != want {
+		t.Fatalf("unexpected initial snapshot create calls: got %d want %d", got, want)
+	}
+	if got, want := adapter.provisionFromSnapshotCalls, 0; got != want {
+		t.Fatalf("unexpected initial snapshot restore calls: got %d want %d", got, want)
+	}
+	if got, want := mirrors.calls, 1; got != want {
+		t.Fatalf("unexpected initial mirror calls: got %d want %d", got, want)
+	}
+
+	secondResp, err := svc.CreateSandbox(context.Background(), req)
+	if err != nil {
+		t.Fatalf("second CreateSandbox returned error: %v", err)
+	}
+	if secondResp.GetSandbox().GetSandboxId() == "" {
+		t.Fatal("expected sandbox id from cache-backed create")
+	}
+	if got, want := adapter.provisionCalls, 1; got != want {
+		t.Fatalf("expected warm hit to avoid reprovision bootstrap path, got provisionCalls=%d want=%d", got, want)
+	}
+	if got, want := adapter.createSnapshotCalls, 1; got != want {
+		t.Fatalf("expected warm hit to avoid publishing another workspace seed, got createSnapshotCalls=%d want=%d", got, want)
+	}
+	if got, want := adapter.provisionFromSnapshotCalls, 1; got != want {
+		t.Fatalf("expected warm hit to provision from snapshot once, got %d want %d", got, want)
+	}
+	if got, want := mirrors.calls, 1; got != want {
+		t.Fatalf("expected warm hit to avoid another mirror prewarm, got %d want %d", got, want)
+	}
+	if got, want := adapter.runCalls, 1; got != want {
+		t.Fatalf("expected warm hit to skip repository bootstrap execution, got runCalls=%d want=%d", got, want)
+	}
+	if got, want := adapter.provisionFromSnapshotReq.StorageRef, "/snapshots/"+adapter.createSnapshotReq.SnapshotID+".ext4"; got != want {
+		t.Fatalf("unexpected snapshot storage ref on warm hit: got %q want %q", got, want)
 	}
 }
 

--- a/internal/controlservice/workspace_seed.go
+++ b/internal/controlservice/workspace_seed.go
@@ -63,7 +63,9 @@ func workspaceSeedSnapshotRecord(records []snapshotstore.Record, backendName, po
 		if !repositoryCheckoutsEqual(repositorycheckout.FromProto(record.Repository), repository) {
 			continue
 		}
-		if !found || record.CreatedAt.After(best.CreatedAt) {
+		recordSnapshotID := strings.TrimSpace(record.SnapshotID)
+		bestSnapshotID := strings.TrimSpace(best.SnapshotID)
+		if !found || record.CreatedAt.After(best.CreatedAt) || (record.CreatedAt.Equal(best.CreatedAt) && recordSnapshotID > bestSnapshotID) {
 			best = record
 			found = true
 		}

--- a/internal/controlservice/workspace_seed.go
+++ b/internal/controlservice/workspace_seed.go
@@ -16,6 +16,10 @@ import (
 
 const workspaceSeedSnapshotNamePrefix = "workspace-seed:"
 
+func isWorkspaceSeedSnapshotName(name string) bool {
+	return strings.HasPrefix(strings.TrimSpace(name), workspaceSeedSnapshotNamePrefix)
+}
+
 func workspaceSeedSnapshotName(backendName, policyHash string, repository *repositorycheckout.Checkout) string {
 	if repository == nil {
 		return ""
@@ -90,6 +94,7 @@ func (s *Service) maybePublishWorkspaceSeedSnapshot(
 	compiled *policy.CompiledPolicy,
 	firecrackerCfg backend.FirecrackerConfig,
 	repository *repositorycheckout.Checkout,
+	replacedSnapshotID string,
 ) {
 	if adapter == nil || compiled == nil || repository == nil {
 		return
@@ -103,8 +108,10 @@ func (s *Service) maybePublishWorkspaceSeedSnapshot(
 		return
 	}
 
-	if _, ok, err := s.lookupWorkspaceSeedSnapshot(ctx, backendName, compiled, repository); err == nil && ok {
-		return
+	if record, ok, err := s.lookupWorkspaceSeedSnapshot(ctx, backendName, compiled, repository); err == nil && ok {
+		if strings.TrimSpace(record.SnapshotID) != strings.TrimSpace(replacedSnapshotID) {
+			return
+		}
 	} else if err != nil {
 		s.logWorkspaceSeedWarning("lookup workspace seed snapshot", sandboxID, err)
 		return
@@ -153,4 +160,11 @@ func (s *Service) logWorkspaceSeedWarning(message, sandboxID string, err error) 
 		return
 	}
 	s.Logger.Warn(message, "sandbox_id", sandboxID, "error", err)
+}
+
+func (s *Service) logWorkspaceSeedRestoreWarning(snapshotID string, err error) {
+	if s == nil || s.Logger == nil || err == nil {
+		return
+	}
+	s.Logger.Warn("restore workspace seed snapshot", "snapshot_id", snapshotID, "error", err)
 }

--- a/internal/controlservice/workspace_seed.go
+++ b/internal/controlservice/workspace_seed.go
@@ -19,14 +19,15 @@ func isWorkspaceSeedSnapshotName(name string) bool {
 	return strings.HasPrefix(strings.TrimSpace(name), workspaceSeedSnapshotNamePrefix)
 }
 
-func workspaceSeedSnapshotName(backendName, policyHash string, repository *repositorycheckout.Checkout) string {
-	if repository == nil {
+func workspaceSeedSnapshotName(backendName, policyHash, runtimeBaseKey string, repository *repositorycheckout.Checkout) string {
+	if repository == nil || strings.TrimSpace(runtimeBaseKey) == "" {
 		return ""
 	}
 	sum := sha256.New()
 	for _, part := range []string{
 		strings.TrimSpace(backendName),
 		strings.TrimSpace(policyHash),
+		strings.TrimSpace(runtimeBaseKey),
 		strings.TrimSpace(repository.RemoteURL),
 		strings.TrimSpace(repository.CommitSHA),
 		strings.TrimSpace(repository.DestinationDir),
@@ -39,8 +40,8 @@ func workspaceSeedSnapshotName(backendName, policyHash string, repository *repos
 	return workspaceSeedSnapshotNamePrefix + hex.EncodeToString(sum.Sum(nil))
 }
 
-func workspaceSeedSnapshotRecord(records []snapshotstore.Record, backendName, policyHash string, repository *repositorycheckout.Checkout) (snapshotstore.Record, bool) {
-	expectedName := workspaceSeedSnapshotName(backendName, policyHash, repository)
+func workspaceSeedSnapshotRecord(records []snapshotstore.Record, backendName, policyHash, runtimeBaseKey string, repository *repositorycheckout.Checkout) (snapshotstore.Record, bool) {
+	expectedName := workspaceSeedSnapshotName(backendName, policyHash, runtimeBaseKey, repository)
 	if expectedName == "" {
 		return snapshotstore.Record{}, false
 	}
@@ -72,8 +73,8 @@ func workspaceSeedSnapshotRecord(records []snapshotstore.Record, backendName, po
 	return best, found
 }
 
-func (s *Service) lookupWorkspaceSeedSnapshot(ctx context.Context, backendName string, compiled *policy.CompiledPolicy, repository *repositorycheckout.Checkout) (snapshotstore.Record, bool, error) {
-	if compiled == nil || repository == nil {
+func (s *Service) lookupWorkspaceSeedSnapshot(ctx context.Context, backendName string, compiled *policy.CompiledPolicy, runtimeBaseKey string, repository *repositorycheckout.Checkout) (snapshotstore.Record, bool, error) {
+	if compiled == nil || repository == nil || strings.TrimSpace(runtimeBaseKey) == "" {
 		return snapshotstore.Record{}, false, nil
 	}
 	store, err := s.snapshotStoreOrErr()
@@ -84,7 +85,7 @@ func (s *Service) lookupWorkspaceSeedSnapshot(ctx context.Context, backendName s
 	if err != nil {
 		return snapshotstore.Record{}, false, err
 	}
-	record, ok := workspaceSeedSnapshotRecord(records, backendName, compiled.Hash, repository)
+	record, ok := workspaceSeedSnapshotRecord(records, backendName, compiled.Hash, runtimeBaseKey, repository)
 	return record, ok, nil
 }
 
@@ -94,10 +95,11 @@ func (s *Service) maybePublishWorkspaceSeedSnapshot(
 	sandboxID, backendName string,
 	compiled *policy.CompiledPolicy,
 	firecrackerCfg backend.FirecrackerConfig,
+	runtimeBaseKey string,
 	repository *repositorycheckout.Checkout,
 	replacedSnapshotID string,
 ) {
-	if adapter == nil || compiled == nil || repository == nil {
+	if adapter == nil || compiled == nil || repository == nil || strings.TrimSpace(runtimeBaseKey) == "" {
 		return
 	}
 	if !snapshotOperationsEnabledForBackend(backendName, s.Config) {
@@ -109,7 +111,7 @@ func (s *Service) maybePublishWorkspaceSeedSnapshot(
 		return
 	}
 
-	if record, ok, err := s.lookupWorkspaceSeedSnapshot(ctx, backendName, compiled, repository); err == nil && ok {
+	if record, ok, err := s.lookupWorkspaceSeedSnapshot(ctx, backendName, compiled, runtimeBaseKey, repository); err == nil && ok {
 		if strings.TrimSpace(record.SnapshotID) != strings.TrimSpace(replacedSnapshotID) {
 			return
 		}
@@ -134,7 +136,7 @@ func (s *Service) maybePublishWorkspaceSeedSnapshot(
 		SnapshotID:      snapshotID,
 		SourceSandboxID: sandboxID,
 		Backend:         backendName,
-		Name:            workspaceSeedSnapshotName(backendName, compiled.Hash, repository),
+		Name:            workspaceSeedSnapshotName(backendName, compiled.Hash, runtimeBaseKey, repository),
 		PolicyHash:      compiled.Hash,
 		Policy:          compiled.ToProto(),
 		Repository:      cloneRepositoryCheckout(repository).ToProto(),
@@ -154,6 +156,25 @@ func (s *Service) maybePublishWorkspaceSeedSnapshot(
 		}
 		s.logWorkspaceSeedWarning("persist workspace seed snapshot metadata", sandboxID, err)
 	}
+}
+
+func (s *Service) workspaceSeedRuntimeBaseKey(ctx context.Context, adapter backend.Adapter, compiled *policy.CompiledPolicy, firecrackerCfg backend.FirecrackerConfig) (string, bool, error) {
+	if adapter == nil || compiled == nil {
+		return "", false, nil
+	}
+	provider, ok := adapter.(backend.RuntimeBaseKeyProvider)
+	if !ok {
+		return "", false, nil
+	}
+	key, err := provider.RuntimeBaseKey(ctx, compiled, firecrackerCfg)
+	if err != nil {
+		return "", false, err
+	}
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return "", false, nil
+	}
+	return key, true, nil
 }
 
 func (s *Service) logWorkspaceSeedWarning(message, sandboxID string, err error) {

--- a/internal/controlservice/workspace_seed.go
+++ b/internal/controlservice/workspace_seed.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/buildkite/cleanroom/internal/backend"
 	"github.com/buildkite/cleanroom/internal/policy"
@@ -141,7 +140,7 @@ func (s *Service) maybePublishWorkspaceSeedSnapshot(
 		Repository:      cloneRepositoryCheckout(repository).ToProto(),
 		StorageDriver:   snapshotCfg.Snapshots.Driver,
 		StorageRef:      strings.TrimSpace(result.StorageRef),
-		CreatedAt:       time.Now().UTC(),
+		CreatedAt:       s.clock().Now(),
 	}
 	if err := store.Create(ctx, record); err != nil {
 		deleteErr := adapter.DeleteSnapshot(ctx, backend.DeleteSnapshotRequest{

--- a/internal/controlservice/workspace_seed.go
+++ b/internal/controlservice/workspace_seed.go
@@ -1,0 +1,156 @@
+package controlservice
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/buildkite/cleanroom/internal/repositorycheckout"
+	"github.com/buildkite/cleanroom/internal/snapshotstore"
+)
+
+const workspaceSeedSnapshotNamePrefix = "workspace-seed:"
+
+func workspaceSeedSnapshotName(backendName, policyHash string, repository *repositorycheckout.Checkout) string {
+	if repository == nil {
+		return ""
+	}
+	sum := sha256.New()
+	for _, part := range []string{
+		strings.TrimSpace(backendName),
+		strings.TrimSpace(policyHash),
+		strings.TrimSpace(repository.RemoteURL),
+		strings.TrimSpace(repository.CommitSHA),
+		strings.TrimSpace(repository.DestinationDir),
+		fmt.Sprintf("%t", repository.Submodules),
+		strings.TrimSpace(repository.Branch),
+	} {
+		_, _ = sum.Write([]byte(part))
+		_, _ = sum.Write([]byte{0})
+	}
+	return workspaceSeedSnapshotNamePrefix + hex.EncodeToString(sum.Sum(nil))
+}
+
+func workspaceSeedSnapshotRecord(records []snapshotstore.Record, backendName, policyHash string, repository *repositorycheckout.Checkout) (snapshotstore.Record, bool) {
+	expectedName := workspaceSeedSnapshotName(backendName, policyHash, repository)
+	if expectedName == "" {
+		return snapshotstore.Record{}, false
+	}
+
+	var (
+		best  snapshotstore.Record
+		found bool
+	)
+	for _, record := range records {
+		if strings.TrimSpace(record.Name) != expectedName {
+			continue
+		}
+		if strings.TrimSpace(record.Backend) != strings.TrimSpace(backendName) {
+			continue
+		}
+		if strings.TrimSpace(record.PolicyHash) != strings.TrimSpace(policyHash) {
+			continue
+		}
+		if !repositoryCheckoutsEqual(repositorycheckout.FromProto(record.Repository), repository) {
+			continue
+		}
+		if !found || record.CreatedAt.After(best.CreatedAt) {
+			best = record
+			found = true
+		}
+	}
+	return best, found
+}
+
+func (s *Service) lookupWorkspaceSeedSnapshot(ctx context.Context, backendName string, compiled *policy.CompiledPolicy, repository *repositorycheckout.Checkout) (snapshotstore.Record, bool, error) {
+	if compiled == nil || repository == nil {
+		return snapshotstore.Record{}, false, nil
+	}
+	store, err := s.snapshotStoreOrErr()
+	if err != nil {
+		return snapshotstore.Record{}, false, nil
+	}
+	records, err := store.List(ctx)
+	if err != nil {
+		return snapshotstore.Record{}, false, err
+	}
+	record, ok := workspaceSeedSnapshotRecord(records, backendName, compiled.Hash, repository)
+	return record, ok, nil
+}
+
+func (s *Service) maybePublishWorkspaceSeedSnapshot(
+	ctx context.Context,
+	adapter backend.SnapshottingAdapter,
+	sandboxID, backendName string,
+	compiled *policy.CompiledPolicy,
+	firecrackerCfg backend.FirecrackerConfig,
+	repository *repositorycheckout.Checkout,
+) {
+	if adapter == nil || compiled == nil || repository == nil {
+		return
+	}
+	if !snapshotOperationsEnabledForBackend(backendName, s.Config) {
+		return
+	}
+
+	store, err := s.snapshotStoreOrErr()
+	if err != nil {
+		return
+	}
+
+	if _, ok, err := s.lookupWorkspaceSeedSnapshot(ctx, backendName, compiled, repository); err == nil && ok {
+		return
+	} else if err != nil {
+		s.logWorkspaceSeedWarning("lookup workspace seed snapshot", sandboxID, err)
+		return
+	}
+
+	snapshotID := newSnapshotID()
+	snapshotCfg := withSnapshotDriver(backendName, firecrackerCfg, firecrackerCfg.Snapshots.Driver)
+	result, err := adapter.CreateSnapshot(ctx, backend.SnapshotRequest{
+		SandboxID:         sandboxID,
+		SnapshotID:        snapshotID,
+		FirecrackerConfig: snapshotCfg,
+	})
+	if err != nil {
+		s.logWorkspaceSeedWarning("publish workspace seed snapshot", sandboxID, err)
+		return
+	}
+
+	record := snapshotstore.Record{
+		SnapshotID:      snapshotID,
+		SourceSandboxID: sandboxID,
+		Backend:         backendName,
+		Name:            workspaceSeedSnapshotName(backendName, compiled.Hash, repository),
+		PolicyHash:      compiled.Hash,
+		Policy:          compiled.ToProto(),
+		Repository:      cloneRepositoryCheckout(repository).ToProto(),
+		StorageDriver:   snapshotCfg.Snapshots.Driver,
+		StorageRef:      strings.TrimSpace(result.StorageRef),
+		CreatedAt:       time.Now().UTC(),
+	}
+	if err := store.Create(ctx, record); err != nil {
+		deleteErr := adapter.DeleteSnapshot(ctx, backend.DeleteSnapshotRequest{
+			SnapshotID:        snapshotID,
+			StorageRef:        record.StorageRef,
+			FirecrackerConfig: snapshotCfg,
+		})
+		if deleteErr != nil {
+			s.logWorkspaceSeedWarning("rollback workspace seed snapshot after metadata failure", sandboxID, fmt.Errorf("%w (rollback failed: %v)", err, deleteErr))
+			return
+		}
+		s.logWorkspaceSeedWarning("persist workspace seed snapshot metadata", sandboxID, err)
+	}
+}
+
+func (s *Service) logWorkspaceSeedWarning(message, sandboxID string, err error) {
+	if s == nil || s.Logger == nil || err == nil {
+		return
+	}
+	s.Logger.Warn(message, "sandbox_id", sandboxID, "error", err)
+}

--- a/internal/repositorycheckout/checkout.go
+++ b/internal/repositorycheckout/checkout.go
@@ -1,6 +1,7 @@
 package repositorycheckout
 
 import (
+	"encoding/hex"
 	"fmt"
 	"net/url"
 	"strings"
@@ -46,9 +47,17 @@ func (c *Checkout) ValidateBootstrap() error {
 	if c == nil {
 		return nil
 	}
-	if strings.TrimSpace(c.CommitSHA) == "" {
+	normalizedCommitSHA := strings.ToLower(strings.TrimSpace(c.CommitSHA))
+	if normalizedCommitSHA == "" {
 		return fmt.Errorf("repository commit_sha is required")
 	}
+	if len(normalizedCommitSHA) != 40 {
+		return fmt.Errorf("repository commit_sha %q must be a full 40-character hexadecimal commit SHA", strings.TrimSpace(c.CommitSHA))
+	}
+	if _, err := hex.DecodeString(normalizedCommitSHA); err != nil {
+		return fmt.Errorf("repository commit_sha %q must be a full 40-character hexadecimal commit SHA", strings.TrimSpace(c.CommitSHA))
+	}
+	c.CommitSHA = normalizedCommitSHA
 	if _, err := c.NormalizeRemoteURL(); err != nil {
 		return err
 	}

--- a/internal/repositorycheckout/checkout_test.go
+++ b/internal/repositorycheckout/checkout_test.go
@@ -90,6 +90,22 @@ func TestBuildBootstrapCommandIncludesSubmoduleUpdateWhenRequested(t *testing.T)
 	}
 }
 
+func TestValidateBootstrapRejectsMutableCommitRef(t *testing.T) {
+	checkout := &Checkout{
+		RemoteURL:      "https://github.com/buildkite/cleanroom.git",
+		CommitSHA:      "main",
+		DestinationDir: "/workspace",
+	}
+
+	err := checkout.ValidateBootstrap()
+	if err == nil {
+		t.Fatal("expected ValidateBootstrap to reject mutable commit refs")
+	}
+	if !strings.Contains(err.Error(), "full 40-character hexadecimal commit SHA") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestWrapCommandInWorkdirQuotesDestinationAndArguments(t *testing.T) {
 	command := WrapCommandInWorkdir([]string{"printf", "%s", "it's alive"}, &Checkout{
 		DestinationDir: "/tmp/work tree",

--- a/internal/snapshotstore/store.go
+++ b/internal/snapshotstore/store.go
@@ -252,7 +252,6 @@ func (s *Store) initDB(ctx context.Context) error {
 			created_at_unix_nano INTEGER NOT NULL DEFAULT 0
 		);
 		CREATE INDEX IF NOT EXISTS idx_snapshots_created_at ON snapshots(created_at_unix);
-		CREATE INDEX IF NOT EXISTS idx_snapshots_created_at_nano ON snapshots(created_at_unix_nano);
 	`)
 	if err != nil {
 		return fmt.Errorf("initialise snapshot metadata schema: %w", err)

--- a/internal/snapshotstore/store.go
+++ b/internal/snapshotstore/store.go
@@ -111,8 +111,9 @@ func (s *Store) Create(ctx context.Context, record Record) error {
 			repository_proto,
 			storage_driver,
 			storage_ref,
-			created_at_unix
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			created_at_unix,
+			created_at_unix_nano
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`,
 		record.SnapshotID,
 		record.SourceSandboxID,
@@ -124,6 +125,7 @@ func (s *Store) Create(ctx context.Context, record Record) error {
 		record.StorageDriver,
 		record.StorageRef,
 		record.CreatedAt.UTC().Unix(),
+		record.CreatedAt.UTC().UnixNano(),
 	); err != nil {
 		return fmt.Errorf("insert snapshot metadata %q: %w", record.SnapshotID, err)
 	}
@@ -148,7 +150,7 @@ func (s *Store) Get(ctx context.Context, snapshotID string) (Record, bool, error
 			repository_proto,
 			storage_driver,
 			storage_ref,
-			created_at_unix
+			created_at_unix_nano
 		FROM snapshots
 		WHERE snapshot_id = ?
 	`, strings.TrimSpace(snapshotID))
@@ -181,9 +183,9 @@ func (s *Store) List(ctx context.Context) ([]Record, error) {
 			repository_proto,
 			storage_driver,
 			storage_ref,
-			created_at_unix
+			created_at_unix_nano
 		FROM snapshots
-		ORDER BY created_at_unix ASC, snapshot_id ASC
+		ORDER BY created_at_unix_nano ASC, snapshot_id ASC
 	`)
 	if err != nil {
 		return nil, fmt.Errorf("query snapshots: %w", err)
@@ -246,9 +248,11 @@ func (s *Store) initDB(ctx context.Context) error {
 			repository_proto BLOB,
 			storage_driver TEXT NOT NULL DEFAULT 'file',
 			storage_ref TEXT NOT NULL,
-			created_at_unix INTEGER NOT NULL
+			created_at_unix INTEGER NOT NULL,
+			created_at_unix_nano INTEGER NOT NULL DEFAULT 0
 		);
 		CREATE INDEX IF NOT EXISTS idx_snapshots_created_at ON snapshots(created_at_unix);
+		CREATE INDEX IF NOT EXISTS idx_snapshots_created_at_nano ON snapshots(created_at_unix_nano);
 	`)
 	if err != nil {
 		return fmt.Errorf("initialise snapshot metadata schema: %w", err)
@@ -258,6 +262,15 @@ func (s *Store) initDB(ctx context.Context) error {
 	}
 	if _, err := db.ExecContext(ctx, `ALTER TABLE snapshots ADD COLUMN repository_proto BLOB`); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
 		return fmt.Errorf("ensure snapshot metadata repository_proto column: %w", err)
+	}
+	if _, err := db.ExecContext(ctx, `ALTER TABLE snapshots ADD COLUMN created_at_unix_nano INTEGER NOT NULL DEFAULT 0`); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
+		return fmt.Errorf("ensure snapshot metadata created_at_unix_nano column: %w", err)
+	}
+	if _, err := db.ExecContext(ctx, `UPDATE snapshots SET created_at_unix_nano = created_at_unix * 1000000000 WHERE created_at_unix_nano = 0`); err != nil {
+		return fmt.Errorf("backfill snapshot metadata created_at_unix_nano column: %w", err)
+	}
+	if _, err := db.ExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_snapshots_created_at_nano ON snapshots(created_at_unix_nano)`); err != nil {
+		return fmt.Errorf("ensure snapshot metadata created_at_unix_nano index: %w", err)
 	}
 	return nil
 }
@@ -271,7 +284,7 @@ func scanRecord(row recordScanner) (Record, error) {
 		record          Record
 		policyBytes     []byte
 		repositoryBytes []byte
-		createdAt       int64
+		createdAtNano   int64
 	)
 	if err := row.Scan(
 		&record.SnapshotID,
@@ -283,7 +296,7 @@ func scanRecord(row recordScanner) (Record, error) {
 		&repositoryBytes,
 		&record.StorageDriver,
 		&record.StorageRef,
-		&createdAt,
+		&createdAtNano,
 	); err != nil {
 		return Record{}, err
 	}
@@ -298,6 +311,6 @@ func scanRecord(row recordScanner) (Record, error) {
 			return Record{}, fmt.Errorf("decode snapshot repository %q: %w", record.SnapshotID, err)
 		}
 	}
-	record.CreatedAt = time.Unix(createdAt, 0).UTC()
+	record.CreatedAt = time.Unix(0, createdAtNano).UTC()
 	return record, nil
 }

--- a/internal/snapshotstore/store_test.go
+++ b/internal/snapshotstore/store_test.go
@@ -2,6 +2,7 @@ package snapshotstore
 
 import (
 	"context"
+	"database/sql"
 	"path/filepath"
 	"testing"
 	"time"
@@ -147,5 +148,76 @@ func TestStoreListOrdersByCreatedAtNanoseconds(t *testing.T) {
 	}
 	if got, want := items[1].SnapshotID, second.SnapshotID; got != want {
 		t.Fatalf("unexpected second snapshot in list: got %q want %q", got, want)
+	}
+}
+
+func TestNewMigratesLegacyStoreBeforeCreatingNanoIndex(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "snapshots.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open legacy snapshot db: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = db.Close()
+	})
+
+	if _, err := db.Exec(`
+		CREATE TABLE snapshots (
+			snapshot_id TEXT PRIMARY KEY,
+			source_sandbox_id TEXT NOT NULL,
+			backend TEXT NOT NULL,
+			name TEXT NOT NULL,
+			policy_hash TEXT NOT NULL,
+			policy_proto BLOB NOT NULL,
+			repository_proto BLOB,
+			storage_driver TEXT NOT NULL DEFAULT 'file',
+			storage_ref TEXT NOT NULL,
+			created_at_unix INTEGER NOT NULL
+		);
+		CREATE INDEX idx_snapshots_created_at ON snapshots(created_at_unix);
+	`); err != nil {
+		t.Fatalf("create legacy snapshot schema: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close legacy snapshot db: %v", err)
+	}
+
+	store, err := New(Options{MetadataDBPath: dbPath})
+	if err != nil {
+		t.Fatalf("New returned error for legacy snapshot db: %v", err)
+	}
+
+	record := Record{
+		SnapshotID:      "snap-test",
+		SourceSandboxID: "cr-test",
+		Backend:         "firecracker",
+		Name:            "golden",
+		PolicyHash:      "policy-hash",
+		Policy: &cleanroomv1.Policy{
+			Version:        1,
+			ImageRef:       "ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			ImageDigest:    "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			NetworkDefault: "deny",
+			Hash:           "policy-hash",
+		},
+		StorageRef:    "/tmp/snap-test.ext4",
+		StorageDriver: "file",
+		CreatedAt:     time.Unix(1700000000, 123).UTC(),
+	}
+	if err := store.Create(context.Background(), record); err != nil {
+		t.Fatalf("Create returned error after legacy migration: %v", err)
+	}
+
+	got, ok, err := store.Get(context.Background(), record.SnapshotID)
+	if err != nil {
+		t.Fatalf("Get returned error after legacy migration: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected migrated legacy store to return stored snapshot")
+	}
+	if !got.CreatedAt.Equal(record.CreatedAt) {
+		t.Fatalf("unexpected created_at after legacy migration: got %s want %s", got.CreatedAt.Format(time.RFC3339Nano), record.CreatedAt.Format(time.RFC3339Nano))
 	}
 }

--- a/internal/snapshotstore/store_test.go
+++ b/internal/snapshotstore/store_test.go
@@ -55,6 +55,9 @@ func TestStoreCreateGetListDelete(t *testing.T) {
 	if got.SnapshotID != record.SnapshotID || got.PolicyHash != record.PolicyHash || got.StorageRef != record.StorageRef || got.StorageDriver != record.StorageDriver {
 		t.Fatalf("unexpected snapshot record: %#v", got)
 	}
+	if !got.CreatedAt.Equal(record.CreatedAt) {
+		t.Fatalf("unexpected created_at: got %s want %s", got.CreatedAt.Format(time.RFC3339Nano), record.CreatedAt.Format(time.RFC3339Nano))
+	}
 	if got.Policy == nil || got.Policy.GetImageRef() != record.Policy.GetImageRef() {
 		t.Fatalf("unexpected stored policy: %#v", got.Policy)
 	}
@@ -77,5 +80,72 @@ func TestStoreCreateGetListDelete(t *testing.T) {
 		t.Fatalf("Get after delete returned error: %v", err)
 	} else if ok {
 		t.Fatal("expected snapshot to be deleted")
+	}
+}
+
+func TestStoreListOrdersByCreatedAtNanoseconds(t *testing.T) {
+	t.Parallel()
+
+	store, err := New(Options{MetadataDBPath: filepath.Join(t.TempDir(), "snapshots.db")})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	basePolicy := &cleanroomv1.Policy{
+		Version:        1,
+		ImageRef:       "ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		ImageDigest:    "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		NetworkDefault: "deny",
+		Hash:           "policy-hash",
+	}
+	baseRepository := &cleanroomv1.RepositoryCheckout{
+		RemoteUrl:      "https://github.com/buildkite/cleanroom.git",
+		CommitSha:      "0123456789abcdef0123456789abcdef01234567",
+		DestinationDir: "/workspace",
+	}
+
+	first := Record{
+		SnapshotID:      "snap-first",
+		SourceSandboxID: "cr-first",
+		Backend:         "firecracker",
+		Name:            "workspace-seed:first",
+		PolicyHash:      "policy-hash",
+		Policy:          basePolicy,
+		Repository:      baseRepository,
+		StorageRef:      "/tmp/snap-first.ext4",
+		StorageDriver:   "file",
+		CreatedAt:       time.Unix(1700000000, 100).UTC(),
+	}
+	second := Record{
+		SnapshotID:      "snap-second",
+		SourceSandboxID: "cr-second",
+		Backend:         "firecracker",
+		Name:            "workspace-seed:second",
+		PolicyHash:      "policy-hash",
+		Policy:          basePolicy,
+		Repository:      baseRepository,
+		StorageRef:      "/tmp/snap-second.ext4",
+		StorageDriver:   "file",
+		CreatedAt:       time.Unix(1700000000, 200).UTC(),
+	}
+	if err := store.Create(context.Background(), second); err != nil {
+		t.Fatalf("Create second returned error: %v", err)
+	}
+	if err := store.Create(context.Background(), first); err != nil {
+		t.Fatalf("Create first returned error: %v", err)
+	}
+
+	items, err := store.List(context.Background())
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if got, want := len(items), 2; got != want {
+		t.Fatalf("unexpected snapshot count: got %d want %d", got, want)
+	}
+	if got, want := items[0].SnapshotID, first.SnapshotID; got != want {
+		t.Fatalf("unexpected first snapshot in list: got %q want %q", got, want)
+	}
+	if got, want := items[1].SnapshotID, second.SnapshotID; got != want {
+		t.Fatalf("unexpected second snapshot in list: got %q want %q", got, want)
 	}
 }


### PR DESCRIPTION
## Summary

This PR lands the first workspace-seed caching slice for repo-aware sandbox creation.

It:
- adds a layered caching design doc that separates logical cache layers from physical snapshot or clone materialization
- teaches `CreateSandbox` to look up a matching workspace-seed snapshot before doing repository bootstrap
- publishes a workspace-seed snapshot after a successful exact-commit repository bootstrap on snapshot-capable backends
- adds control-service coverage for workspace-seed publication and warm-hit reuse

## Scope

This PR is intentionally the backend-neutral control-plane slice.

It improves warm repo-aware sandbox creation by skipping repeated repository checkout work on snapshot-capable persistent backends.

It does not yet change Firecracker's normal runtime hot path. Firecracker still copies the prepared ext4 rootfs per run today, so the larger warm-start win there requires a follow-up PR that moves normal execution onto clone-based root volume preparation.

## Why

Repo-aware sandbox creates currently repeat the same exact-commit checkout work on every warm start.

Reusing a trusted workspace seed snapshot lets the control plane skip that bootstrap path while keeping reuse deterministic from policy and repository state.

Splitting the work this way keeps the cache-key and publication semantics reviewable on their own before changing Firecracker's storage path.

## Validation

- `go test ./internal/cli ./internal/controlservice`

## Follow-up

The next PR should move Firecracker warm-hit materialization onto the existing volume-store clone path so workspace-seed hits also avoid the full ext4 copy cost.
