### PR TITLE
feat: add darwin-vz rootfs sizing override

### DIFF
--- a/docs/backend/darwin-vz.md
+++ b/docs/backend/darwin-vz.md
@@ -93,6 +93,10 @@ Rootfs:
 - otherwise derive rootfs from `sandbox.image.ref` using image manager
 - inject guest runtime (`cleanroom-guest-agent` and `/usr/sbin/cleanroom-init`) into a prepared cached rootfs image
 - create a per-sandbox copy (`rootfs-persistent.ext4`) and attach it read-write to the VM
+- `/workspace` is not a separate volume on `darwin-vz`; it lives on the guest rootfs
+- `backends.darwin-vz.minimum_rootfs_bytes` lets the runtime grow the guest rootfs copy before boot for non-trivial workloads that need more writable space
+- `minimum_rootfs_bytes` accepts either raw bytes (`2147483648`) or human-friendly sizes (`2GiB`, `700MiB`, `"2147483648"`)
+- the same setting is also honored under the legacy underscore config key: `backends.darwin_vz.minimum_rootfs_bytes`
 
 Snapshot/rootfs volume drivers:
 

--- a/internal/runtimeconfig/config.go
+++ b/internal/runtimeconfig/config.go
@@ -305,7 +305,19 @@ func Load() (Config, string, error) {
 	if err := yaml.Unmarshal(b, &cfg); err != nil {
 		return Config{}, path, fmt.Errorf("parse %s: %w", path, err)
 	}
+	presenceCfg := struct {
+		Backends struct {
+			DarwinVZ struct {
+				MinimumRootFSBytes *ByteSize `yaml:"minimum_rootfs_bytes"`
+			} `yaml:"darwin-vz"`
+		} `yaml:"backends"`
+	}{}
+	if err := yaml.Unmarshal(b, &presenceCfg); err != nil {
+		return Config{}, path, fmt.Errorf("parse %s: %w", path, err)
+	}
+
 	darwinVZMinRootFSBytes := cfg.Backends.DarwinVZ.MinimumRootFSBytes
+	darwinVZMinRootFSBytesSet := presenceCfg.Backends.DarwinVZ.MinimumRootFSBytes != nil
 	if darwinVZConfigIsZero(cfg.Backends.DarwinVZ) {
 		legacyCfg := struct {
 			Backends struct {
@@ -316,7 +328,7 @@ func Load() (Config, string, error) {
 			cfg.Backends.DarwinVZ = legacyCfg.Backends.DarwinVZ
 		}
 	}
-	if darwinVZMinRootFSBytes > 0 {
+	if darwinVZMinRootFSBytesSet {
 		cfg.Backends.DarwinVZ.MinimumRootFSBytes = darwinVZMinRootFSBytes
 	}
 

--- a/internal/runtimeconfig/config.go
+++ b/internal/runtimeconfig/config.go
@@ -38,15 +38,16 @@ type FirecrackerConfig struct {
 }
 
 type DarwinVZConfig struct {
-	KernelImage   string                `yaml:"kernel_image"`
-	RootFS        string                `yaml:"rootfs"`
-	Network       DarwinVZNetworkConfig `yaml:"network,omitempty"`
-	Services      ServicesConfig        `yaml:"services"`
-	Snapshots     SnapshotConfig        `yaml:"snapshots"`
-	VCPUs         int64                 `yaml:"vcpus"`
-	MemoryMiB     int64                 `yaml:"memory_mib"`
-	GuestPort     uint32                `yaml:"guest_port"`
-	LaunchSeconds int64                 `yaml:"launch_seconds"` // VM boot/guest-agent readiness timeout
+	KernelImage        string                `yaml:"kernel_image"`
+	RootFS             string                `yaml:"rootfs"`
+	MinimumRootFSBytes int64                 `yaml:"minimum_rootfs_bytes"`
+	Network            DarwinVZNetworkConfig `yaml:"network,omitempty"`
+	Services           ServicesConfig        `yaml:"services"`
+	Snapshots          SnapshotConfig        `yaml:"snapshots"`
+	VCPUs              int64                 `yaml:"vcpus"`
+	MemoryMiB          int64                 `yaml:"memory_mib"`
+	GuestPort          uint32                `yaml:"guest_port"`
+	LaunchSeconds      int64                 `yaml:"launch_seconds"` // VM boot/guest-agent readiness timeout
 }
 
 type DarwinVZNetworkConfig struct {
@@ -112,6 +113,7 @@ func MergeBackendConfig(cfg Config, backendName string, launchSeconds int64) bac
 	if backendName == "darwin-vz" {
 		out.KernelImagePath = cfg.Backends.DarwinVZ.KernelImage
 		out.RootFSPath = cfg.Backends.DarwinVZ.RootFS
+		out.MinimumRootFSBytes = cfg.Backends.DarwinVZ.MinimumRootFSBytes
 		out.DarwinVZNetworkMode = cfg.Backends.DarwinVZ.Network.Mode
 		out.DarwinVZNetworkSubnet = cfg.Backends.DarwinVZ.Network.Subnet
 		out.DockerStartupSeconds = cfg.Backends.DarwinVZ.Services.Docker.StartupTimeoutSeconds
@@ -238,6 +240,7 @@ func Load() (Config, string, error) {
 func darwinVZConfigIsZero(cfg DarwinVZConfig) bool {
 	return strings.TrimSpace(cfg.KernelImage) == "" &&
 		strings.TrimSpace(cfg.RootFS) == "" &&
+		cfg.MinimumRootFSBytes == 0 &&
 		darwinVZNetworkConfigIsZero(cfg.Network) &&
 		cfg.Services.Docker.StartupTimeoutSeconds == 0 &&
 		strings.TrimSpace(cfg.Services.Docker.StorageDriver) == "" &&

--- a/internal/runtimeconfig/config.go
+++ b/internal/runtimeconfig/config.go
@@ -3,10 +3,13 @@ package runtimeconfig
 import (
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/buildkite/cleanroom/internal/backend"
 	"gopkg.in/yaml.v3"
@@ -40,7 +43,7 @@ type FirecrackerConfig struct {
 type DarwinVZConfig struct {
 	KernelImage        string                `yaml:"kernel_image"`
 	RootFS             string                `yaml:"rootfs"`
-	MinimumRootFSBytes int64                 `yaml:"minimum_rootfs_bytes"`
+	MinimumRootFSBytes ByteSize              `yaml:"minimum_rootfs_bytes"`
 	Network            DarwinVZNetworkConfig `yaml:"network,omitempty"`
 	Services           ServicesConfig        `yaml:"services"`
 	Snapshots          SnapshotConfig        `yaml:"snapshots"`
@@ -113,7 +116,7 @@ func MergeBackendConfig(cfg Config, backendName string, launchSeconds int64) bac
 	if backendName == "darwin-vz" {
 		out.KernelImagePath = cfg.Backends.DarwinVZ.KernelImage
 		out.RootFSPath = cfg.Backends.DarwinVZ.RootFS
-		out.MinimumRootFSBytes = cfg.Backends.DarwinVZ.MinimumRootFSBytes
+		out.MinimumRootFSBytes = int64(cfg.Backends.DarwinVZ.MinimumRootFSBytes)
 		out.DarwinVZNetworkMode = cfg.Backends.DarwinVZ.Network.Mode
 		out.DarwinVZNetworkSubnet = cfg.Backends.DarwinVZ.Network.Subnet
 		out.DockerStartupSeconds = cfg.Backends.DarwinVZ.Services.Docker.StartupTimeoutSeconds
@@ -147,6 +150,90 @@ type DockerServiceConfig struct {
 	StartupTimeoutSeconds int64  `yaml:"startup_timeout_seconds"`
 	StorageDriver         string `yaml:"storage_driver"`
 	IPTables              bool   `yaml:"iptables"`
+}
+
+type ByteSize int64
+
+func (s *ByteSize) UnmarshalYAML(node *yaml.Node) error {
+	if node.Kind != yaml.ScalarNode {
+		return fmt.Errorf("invalid byte size node kind %v", node.Kind)
+	}
+
+	value, err := parseByteSize(node.Value)
+	if err != nil {
+		return fmt.Errorf("invalid byte size %q: %w", node.Value, err)
+	}
+	*s = ByteSize(value)
+	return nil
+}
+
+func parseByteSize(input string) (int64, error) {
+	s := strings.TrimSpace(input)
+	if s == "" {
+		return 0, errors.New("value is empty")
+	}
+
+	if value, err := strconv.ParseInt(s, 10, 64); err == nil {
+		if value < 0 {
+			return 0, errors.New("value must be non-negative")
+		}
+		return value, nil
+	}
+
+	numberEnd := strings.IndexFunc(s, func(r rune) bool {
+		return !(unicode.IsDigit(r) || r == '.')
+	})
+	if numberEnd <= 0 {
+		return 0, errors.New("missing numeric value")
+	}
+
+	numberPart := strings.TrimSpace(s[:numberEnd])
+	unitPart := strings.ToLower(strings.TrimSpace(s[numberEnd:]))
+	if numberPart == "" || unitPart == "" {
+		return 0, errors.New("size must include a number and unit")
+	}
+
+	numberValue, err := strconv.ParseFloat(numberPart, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse numeric value: %w", err)
+	}
+	if numberValue < 0 {
+		return 0, errors.New("value must be non-negative")
+	}
+
+	multiplier, ok := byteSizeMultipliers[unitPart]
+	if !ok {
+		return 0, fmt.Errorf("unsupported unit %q", unitPart)
+	}
+
+	value := numberValue * float64(multiplier)
+	rounded := math.Round(value)
+	if math.Abs(value-rounded) > 1e-9 {
+		return 0, errors.New("size resolves to fractional bytes")
+	}
+	if rounded > math.MaxInt64 {
+		return 0, errors.New("size overflows int64")
+	}
+	return int64(rounded), nil
+}
+
+var byteSizeMultipliers = map[string]int64{
+	"b":   1,
+	"k":   1 << 10,
+	"kb":  1000,
+	"kib": 1 << 10,
+	"m":   1 << 20,
+	"mb":  1000 * 1000,
+	"mib": 1 << 20,
+	"g":   1 << 30,
+	"gb":  1000 * 1000 * 1000,
+	"gib": 1 << 30,
+	"t":   1 << 40,
+	"tb":  1000 * 1000 * 1000 * 1000,
+	"tib": 1 << 40,
+	"p":   1 << 50,
+	"pb":  1000 * 1000 * 1000 * 1000 * 1000,
+	"pib": 1 << 50,
 }
 
 var (

--- a/internal/runtimeconfig/config.go
+++ b/internal/runtimeconfig/config.go
@@ -218,6 +218,7 @@ func Load() (Config, string, error) {
 	if err := yaml.Unmarshal(b, &cfg); err != nil {
 		return Config{}, path, fmt.Errorf("parse %s: %w", path, err)
 	}
+	darwinVZMinRootFSBytes := cfg.Backends.DarwinVZ.MinimumRootFSBytes
 	if darwinVZConfigIsZero(cfg.Backends.DarwinVZ) {
 		legacyCfg := struct {
 			Backends struct {
@@ -227,6 +228,9 @@ func Load() (Config, string, error) {
 		if err := yaml.Unmarshal(b, &legacyCfg); err == nil && !darwinVZConfigIsZero(legacyCfg.Backends.DarwinVZ) {
 			cfg.Backends.DarwinVZ = legacyCfg.Backends.DarwinVZ
 		}
+	}
+	if darwinVZMinRootFSBytes > 0 {
+		cfg.Backends.DarwinVZ.MinimumRootFSBytes = darwinVZMinRootFSBytes
 	}
 
 	cfg.DefaultBackend = strings.TrimSpace(cfg.DefaultBackend)
@@ -240,7 +244,6 @@ func Load() (Config, string, error) {
 func darwinVZConfigIsZero(cfg DarwinVZConfig) bool {
 	return strings.TrimSpace(cfg.KernelImage) == "" &&
 		strings.TrimSpace(cfg.RootFS) == "" &&
-		cfg.MinimumRootFSBytes == 0 &&
 		darwinVZNetworkConfigIsZero(cfg.Network) &&
 		cfg.Services.Docker.StartupTimeoutSeconds == 0 &&
 		strings.TrimSpace(cfg.Services.Docker.StorageDriver) == "" &&

--- a/internal/runtimeconfig/config.go
+++ b/internal/runtimeconfig/config.go
@@ -312,7 +312,7 @@ func Load() (Config, string, error) {
 				DarwinVZ DarwinVZConfig `yaml:"darwin_vz"`
 			} `yaml:"backends"`
 		}{}
-		if err := yaml.Unmarshal(b, &legacyCfg); err == nil && !darwinVZConfigIsZero(legacyCfg.Backends.DarwinVZ) {
+		if err := yaml.Unmarshal(b, &legacyCfg); err == nil && darwinVZConfigHasValues(legacyCfg.Backends.DarwinVZ) {
 			cfg.Backends.DarwinVZ = legacyCfg.Backends.DarwinVZ
 		}
 	}
@@ -340,6 +340,10 @@ func darwinVZConfigIsZero(cfg DarwinVZConfig) bool {
 		cfg.MemoryMiB == 0 &&
 		cfg.GuestPort == 0 &&
 		cfg.LaunchSeconds == 0
+}
+
+func darwinVZConfigHasValues(cfg DarwinVZConfig) bool {
+	return !darwinVZConfigIsZero(cfg) || cfg.MinimumRootFSBytes > 0
 }
 
 func darwinVZNetworkConfigIsZero(cfg DarwinVZNetworkConfig) bool {

--- a/internal/runtimeconfig/config.go
+++ b/internal/runtimeconfig/config.go
@@ -310,6 +310,7 @@ func Load() (Config, string, error) {
 			DarwinVZ struct {
 				MinimumRootFSBytes *ByteSize `yaml:"minimum_rootfs_bytes"`
 			} `yaml:"darwin-vz"`
+			LegacyDarwinVZ *yaml.Node `yaml:"darwin_vz"`
 		} `yaml:"backends"`
 	}{}
 	if err := yaml.Unmarshal(b, &presenceCfg); err != nil {
@@ -324,7 +325,11 @@ func Load() (Config, string, error) {
 				DarwinVZ DarwinVZConfig `yaml:"darwin_vz"`
 			} `yaml:"backends"`
 		}{}
-		if err := yaml.Unmarshal(b, &legacyCfg); err == nil && darwinVZConfigHasValues(legacyCfg.Backends.DarwinVZ) {
+		if err := yaml.Unmarshal(b, &legacyCfg); err != nil {
+			if presenceCfg.Backends.LegacyDarwinVZ != nil {
+				return Config{}, path, fmt.Errorf("parse %s: %w", path, err)
+			}
+		} else if darwinVZConfigHasValues(legacyCfg.Backends.DarwinVZ) {
 			cfg.Backends.DarwinVZ = legacyCfg.Backends.DarwinVZ
 		}
 	}

--- a/internal/runtimeconfig/config.go
+++ b/internal/runtimeconfig/config.go
@@ -206,6 +206,20 @@ func parseByteSize(input string) (int64, error) {
 		return 0, fmt.Errorf("unsupported unit %q", unitPart)
 	}
 
+	if !strings.Contains(numberPart, ".") {
+		numberValue, err := strconv.ParseInt(numberPart, 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("parse numeric value: %w", err)
+		}
+		if numberValue < 0 {
+			return 0, errors.New("value must be non-negative")
+		}
+		if multiplier != 0 && numberValue > math.MaxInt64/multiplier {
+			return 0, errors.New("size overflows int64")
+		}
+		return numberValue * multiplier, nil
+	}
+
 	value := numberValue * float64(multiplier)
 	rounded := math.Round(value)
 	if math.Abs(value-rounded) > 1e-9 {

--- a/internal/runtimeconfig/config_test.go
+++ b/internal/runtimeconfig/config_test.go
@@ -293,6 +293,58 @@ backends:
 	}
 }
 
+func TestLoadSupportsLargeExactDarwinVZMinimumRootFSBytes(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	configPath := filepath.Join(tmp, "cleanroom", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+
+	content := `default_backend: darwin-vz
+backends:
+  darwin-vz:
+    minimum_rootfs_bytes: 9007199254740993b
+`
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, _, err := Load()
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if got, want := int64(cfg.Backends.DarwinVZ.MinimumRootFSBytes), int64(9007199254740993); got != want {
+		t.Fatalf("unexpected darwin-vz minimum rootfs bytes: got %d want %d", got, want)
+	}
+}
+
+func TestLoadSupportsMaxInt64DarwinVZMinimumRootFSBytes(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	configPath := filepath.Join(tmp, "cleanroom", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+
+	content := `default_backend: darwin-vz
+backends:
+  darwin-vz:
+    minimum_rootfs_bytes: 9223372036854775807b
+`
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, _, err := Load()
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if got, want := int64(cfg.Backends.DarwinVZ.MinimumRootFSBytes), int64(9223372036854775807); got != want {
+		t.Fatalf("unexpected darwin-vz minimum rootfs bytes: got %d want %d", got, want)
+	}
+}
+
 func TestLoadSupportsLegacyDarwinVZUnderscoreKey(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)

--- a/internal/runtimeconfig/config_test.go
+++ b/internal/runtimeconfig/config_test.go
@@ -210,6 +210,33 @@ backends:
 		t.Fatalf("unexpected darwin-vz minimum rootfs bytes: got %d want %d", got, want)
 	}
 }
+
+func TestLoadSupportsLegacyDarwinVZMinimumRootFSBytesOnly(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	configPath := filepath.Join(tmp, "cleanroom", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+
+	content := `default_backend: darwin-vz
+backends:
+  darwin_vz:
+    minimum_rootfs_bytes: 2GiB
+`
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, _, err := Load()
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if got, want := int64(cfg.Backends.DarwinVZ.MinimumRootFSBytes), int64(2<<30); got != want {
+		t.Fatalf("unexpected darwin-vz minimum rootfs bytes: got %d want %d", got, want)
+	}
+}
+
 func TestLoadSupportsLegacyDarwinVZUnderscoreKey(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)

--- a/internal/runtimeconfig/config_test.go
+++ b/internal/runtimeconfig/config_test.go
@@ -211,6 +211,36 @@ backends:
 	}
 }
 
+func TestLoadAllowsExplicitZeroDarwinVZMinimumRootFSBytesOverride(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	configPath := filepath.Join(tmp, "cleanroom", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+
+	content := `default_backend: darwin-vz
+backends:
+  darwin-vz:
+    minimum_rootfs_bytes: 0
+  darwin_vz:
+    kernel_image: /tmp/legacy-kernel
+    rootfs: /tmp/legacy-rootfs
+    minimum_rootfs_bytes: 2GiB
+`
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, _, err := Load()
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if got, want := int64(cfg.Backends.DarwinVZ.MinimumRootFSBytes), int64(0); got != want {
+		t.Fatalf("unexpected darwin-vz minimum rootfs bytes: got %d want %d", got, want)
+	}
+}
+
 func TestLoadSupportsLegacyDarwinVZMinimumRootFSBytesOnly(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)

--- a/internal/runtimeconfig/config_test.go
+++ b/internal/runtimeconfig/config_test.go
@@ -86,8 +86,89 @@ backends:
 	if err != nil {
 		t.Fatalf("Load returned error: %v", err)
 	}
-	if got, want := cfg.Backends.DarwinVZ.MinimumRootFSBytes, int64(2147483648); got != want {
+	if got, want := int64(cfg.Backends.DarwinVZ.MinimumRootFSBytes), int64(2147483648); got != want {
 		t.Fatalf("unexpected darwin-vz minimum rootfs bytes: got %d want %d", got, want)
+	}
+}
+
+func TestLoadSupportsDarwinVZMinimumRootFSBytesHumanString(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	configPath := filepath.Join(tmp, "cleanroom", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+
+	content := `default_backend: darwin-vz
+backends:
+  darwin-vz:
+    rootfs: /tmp/rootfs
+    minimum_rootfs_bytes: 2GiB
+`
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, _, err := Load()
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if got, want := int64(cfg.Backends.DarwinVZ.MinimumRootFSBytes), int64(2<<30); got != want {
+		t.Fatalf("unexpected darwin-vz minimum rootfs bytes: got %d want %d", got, want)
+	}
+}
+
+func TestLoadSupportsDarwinVZMinimumRootFSBytesQuotedNumericString(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	configPath := filepath.Join(tmp, "cleanroom", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+
+	content := `default_backend: darwin-vz
+backends:
+  darwin-vz:
+    rootfs: /tmp/rootfs
+    minimum_rootfs_bytes: "2147483648"
+`
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, _, err := Load()
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if got, want := int64(cfg.Backends.DarwinVZ.MinimumRootFSBytes), int64(2147483648); got != want {
+		t.Fatalf("unexpected darwin-vz minimum rootfs bytes: got %d want %d", got, want)
+	}
+}
+
+func TestLoadRejectsInvalidDarwinVZMinimumRootFSBytes(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	configPath := filepath.Join(tmp, "cleanroom", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+
+	content := `default_backend: darwin-vz
+backends:
+  darwin-vz:
+    rootfs: /tmp/rootfs
+    minimum_rootfs_bytes: giant
+`
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, _, err := Load()
+	if err == nil {
+		t.Fatal("expected Load to reject invalid minimum_rootfs_bytes")
+	}
+	if !strings.Contains(err.Error(), "invalid byte size") {
+		t.Fatalf("expected error to mention invalid byte size, got %v", err)
 	}
 }
 
@@ -125,7 +206,7 @@ backends:
 	if got, want := cfg.Backends.DarwinVZ.RootFS, "/tmp/legacy-rootfs"; got != want {
 		t.Fatalf("unexpected darwin-vz rootfs: got %q want %q", got, want)
 	}
-	if got, want := cfg.Backends.DarwinVZ.MinimumRootFSBytes, int64(2147483648); got != want {
+	if got, want := int64(cfg.Backends.DarwinVZ.MinimumRootFSBytes), int64(2147483648); got != want {
 		t.Fatalf("unexpected darwin-vz minimum rootfs bytes: got %d want %d", got, want)
 	}
 }
@@ -386,12 +467,12 @@ func TestMergeBackendConfig(t *testing.T) {
 				RootFS:             "/darwin/rootfs.ext4",
 				MinimumRootFSBytes: 2147483648,
 				Network:            DarwinVZNetworkConfig{Mode: "vmnet-shared", Subnet: "10.233.0.0/16"},
-				Services:      ServicesConfig{Docker: DockerServiceConfig{StartupTimeoutSeconds: 20, StorageDriver: "vzfs", IPTables: false}},
-				Snapshots:     SnapshotConfig{Enabled: false, Driver: "apfs", BaseDir: "/darwin/snapshots", QuiesceTimeoutSeconds: 22},
-				VCPUs:         4,
-				MemoryMiB:     2048,
-				GuestPort:     10701,
-				LaunchSeconds: 45,
+				Services:           ServicesConfig{Docker: DockerServiceConfig{StartupTimeoutSeconds: 20, StorageDriver: "vzfs", IPTables: false}},
+				Snapshots:          SnapshotConfig{Enabled: false, Driver: "apfs", BaseDir: "/darwin/snapshots", QuiesceTimeoutSeconds: 22},
+				VCPUs:              4,
+				MemoryMiB:          2048,
+				GuestPort:          10701,
+				LaunchSeconds:      45,
 			},
 		},
 	}

--- a/internal/runtimeconfig/config_test.go
+++ b/internal/runtimeconfig/config_test.go
@@ -64,6 +64,32 @@ backends:
 	}
 }
 
+func TestLoadSupportsDarwinVZMinimumRootFSBytes(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	configPath := filepath.Join(tmp, "cleanroom", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+
+	content := `default_backend: darwin-vz
+backends:
+  darwin-vz:
+    rootfs: /tmp/rootfs
+    minimum_rootfs_bytes: 2147483648
+`
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, _, err := Load()
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if got, want := cfg.Backends.DarwinVZ.MinimumRootFSBytes, int64(2147483648); got != want {
+		t.Fatalf("unexpected darwin-vz minimum rootfs bytes: got %d want %d", got, want)
+	}
+}
 func TestLoadSupportsLegacyDarwinVZUnderscoreKey(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)
@@ -317,9 +343,10 @@ func TestMergeBackendConfig(t *testing.T) {
 				LaunchSeconds:        30,
 			},
 			DarwinVZ: DarwinVZConfig{
-				KernelImage:   "/darwin/kernel",
-				RootFS:        "/darwin/rootfs.ext4",
-				Network:       DarwinVZNetworkConfig{Mode: "vmnet-shared", Subnet: "10.233.0.0/16"},
+				KernelImage:        "/darwin/kernel",
+				RootFS:             "/darwin/rootfs.ext4",
+				MinimumRootFSBytes: 2147483648,
+				Network:            DarwinVZNetworkConfig{Mode: "vmnet-shared", Subnet: "10.233.0.0/16"},
 				Services:      ServicesConfig{Docker: DockerServiceConfig{StartupTimeoutSeconds: 20, StorageDriver: "vzfs", IPTables: false}},
 				Snapshots:     SnapshotConfig{Enabled: false, Driver: "apfs", BaseDir: "/darwin/snapshots", QuiesceTimeoutSeconds: 22},
 				VCPUs:         4,
@@ -350,6 +377,9 @@ func TestMergeBackendConfig(t *testing.T) {
 	}
 	if got, want := darwinCfg.RootFSPath, "/darwin/rootfs.ext4"; got != want {
 		t.Fatalf("unexpected darwin-vz rootfs: got %q want %q", got, want)
+	}
+	if got, want := darwinCfg.MinimumRootFSBytes, int64(2147483648); got != want {
+		t.Fatalf("unexpected darwin-vz minimum rootfs bytes: got %d want %d", got, want)
 	}
 	if got, want := darwinCfg.DarwinVZNetworkMode, "vmnet-shared"; got != want {
 		t.Fatalf("unexpected darwin-vz network mode: got %q want %q", got, want)

--- a/internal/runtimeconfig/config_test.go
+++ b/internal/runtimeconfig/config_test.go
@@ -267,6 +267,32 @@ backends:
 	}
 }
 
+func TestLoadRejectsInvalidLegacyDarwinVZMinimumRootFSBytes(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	configPath := filepath.Join(tmp, "cleanroom", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+
+	content := `default_backend: darwin-vz
+backends:
+  darwin_vz:
+    minimum_rootfs_bytes: 2GIBB
+`
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, _, err := Load()
+	if err == nil {
+		t.Fatal("expected Load to reject invalid legacy minimum_rootfs_bytes")
+	}
+	if !strings.Contains(err.Error(), "invalid byte size") {
+		t.Fatalf("expected error to mention invalid byte size, got %v", err)
+	}
+}
+
 func TestLoadSupportsLegacyDarwinVZUnderscoreKey(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)

--- a/internal/runtimeconfig/config_test.go
+++ b/internal/runtimeconfig/config_test.go
@@ -90,6 +90,45 @@ backends:
 		t.Fatalf("unexpected darwin-vz minimum rootfs bytes: got %d want %d", got, want)
 	}
 }
+
+func TestLoadPreservesLegacyDarwinVZFallbackWhenOnlyMinRootFSIsSet(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	configPath := filepath.Join(tmp, "cleanroom", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+
+	content := `default_backend: darwin-vz
+backends:
+  darwin-vz:
+    minimum_rootfs_bytes: 2147483648
+  darwin_vz:
+    kernel_image: /tmp/legacy-kernel
+    rootfs: /tmp/legacy-rootfs
+    vcpus: 4
+    memory_mib: 2048
+    guest_port: 10701
+    launch_seconds: 45
+`
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, _, err := Load()
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if got, want := cfg.Backends.DarwinVZ.KernelImage, "/tmp/legacy-kernel"; got != want {
+		t.Fatalf("unexpected darwin-vz kernel: got %q want %q", got, want)
+	}
+	if got, want := cfg.Backends.DarwinVZ.RootFS, "/tmp/legacy-rootfs"; got != want {
+		t.Fatalf("unexpected darwin-vz rootfs: got %q want %q", got, want)
+	}
+	if got, want := cfg.Backends.DarwinVZ.MinimumRootFSBytes, int64(2147483648); got != want {
+		t.Fatalf("unexpected darwin-vz minimum rootfs bytes: got %d want %d", got, want)
+	}
+}
 func TestLoadSupportsLegacyDarwinVZUnderscoreKey(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)


### PR DESCRIPTION
## Summary
- add a `backends.darwin-vz.minimum_rootfs_bytes` runtime config knob
- allow that knob to be set as raw bytes or human-friendly sizes such as `2GiB` and `700MiB`
- preserve both hyphenated `backends.darwin-vz` and legacy underscore `backends.darwin_vz` config parsing for the new setting
- propagate the new setting through backend config merging for darwin-vz
- document the new sizing behavior and cover parsing/merge behavior with tests

## Why
Heavy darwin-vz workloads currently rely on implicit repository bootstrap sizing to grow the guest rootfs. This makes non-repository workloads brittle, because `/workspace` is just a path on the guest rootfs, not a separate volume. This change adds an explicit sizing override for darwin-vz so large workloads can request more guest storage directly without relying on repository bootstrap side effects.

## Notes
- `minimum_rootfs_bytes` accepts `2147483648`, `"2147483648"`, `2GiB`, and similar `KiB`/`MiB`/`GiB` forms
- the override is preserved when loading legacy `backends.darwin_vz` configs, including cases where it is the only legacy darwin-vz field present

## Verification
- `go test ./...`
- live darwin-vz check with `minimum_rootfs_bytes: 2147483648`, verifying the guest rootfs grew to `2.0G` and a `700 MiB` write under `/workspace` succeeded
