### PR TITLE
ci: Reconcile CI Terraform with live mac hosts

### DIFF
--- a/infra/terraform/envs/ci/README.md
+++ b/infra/terraform/envs/ci/README.md
@@ -10,11 +10,11 @@ Default AMI behaviour:
 
 - defaults to `us-west-2` for `aws_region`
 - uses latest Ubuntu 24.04 AMI from SSM public parameter
-- set `ami_id` in `terraform.tfvars` if you want to pin an explicit AMI
+- set `ami_id` in your selected var-file if you want to pin an explicit AMI
 - set `enable_macos_ci = true` to enable the macOS host
 - set `enable_macos_signer_ci = true` to enable a second dedicated macOS signer host
 - macOS defaults to the latest Tahoe AMI from the public SSM parameter that matches `mac_instance_type`
-- set `mac_ami_id` in `terraform.tfvars` if you want to pin an explicit macOS AMI
+- set `mac_ami_id` in your selected var-file if you want to pin an explicit macOS AMI
 - set `mac_ami_ssm_parameter_name` if you want a different public SSM parameter than the Tahoe default
 
 Network behaviour:
@@ -48,11 +48,19 @@ macOS dedicated host lifecycle:
 
 ```bash
 cd infra/terraform/envs/ci
-cp terraform.tfvars.example terraform.tfvars
 mise x -- terraform init
-mise x -- terraform plan
-mise x -- terraform apply
+terraform workspace select -or-create ap-southeast-2
+mise x -- terraform plan -var-file=ci.ap-southeast-2.tfvars
+mise x -- terraform apply -var-file=ci.ap-southeast-2.tfvars
 ```
+
+Available checked-in var-files:
+
+- `ci.ap-southeast-2.tfvars` for the Sydney CI environment
+
+`terraform.tfvars` remains ignored for local-only overrides and ad hoc envs. The
+checked-in regional var-files are the shared source of truth for long-lived CI
+workspaces.
 
 ## Access
 

--- a/infra/terraform/envs/ci/bootstrap_defaults_test.go
+++ b/infra/terraform/envs/ci/bootstrap_defaults_test.go
@@ -269,6 +269,7 @@ func TestExampleRegionIsSydney(t *testing.T) {
 	t.Helper()
 
 	requireContains(t, "terraform.tfvars.example", "aws_region  = \"ap-southeast-2\"")
+	requireContains(t, "ci.ap-southeast-2.tfvars", "aws_region  = \"ap-southeast-2\"")
 }
 
 func TestBootstrapConfiguresZfsSnapshots(t *testing.T) {
@@ -342,6 +343,25 @@ func TestEnvSupportsAvailabilityZoneOverride(t *testing.T) {
 	requireContains(t, "variables.tf", "variable \"availability_zone\"")
 	requireContains(t, "main.tf", "availability_zone   = var.availability_zone")
 	requireContains(t, "terraform.tfvars.example", "# availability_zone = \"ap-southeast-2b\"")
+	requireContains(t, "ci.ap-southeast-2.tfvars", "availability_zone = \"ap-southeast-2b\"")
+}
+
+func TestReadmeUsesCheckedInSydneyVarFile(t *testing.T) {
+	t.Helper()
+
+	requireContains(t, "README.md", "terraform workspace select -or-create ap-southeast-2")
+	requireContains(t, "README.md", "terraform plan -var-file=ci.ap-southeast-2.tfvars")
+	requireContains(t, "README.md", "terraform apply -var-file=ci.ap-southeast-2.tfvars")
+	requireContains(t, "README.md", "Available checked-in var-files:")
+	requireContains(t, "README.md", "`ci.ap-southeast-2.tfvars` for the Sydney CI environment")
+}
+
+func TestSydneyCiVarFileReflectsSignerLayout(t *testing.T) {
+	t.Helper()
+
+	requireContains(t, "ci.ap-southeast-2.tfvars", "enable_macos_signer_ci           = true")
+	requireContains(t, "ci.ap-southeast-2.tfvars", "mac_instance_type                = \"mac2-m2pro.metal\"")
+	requireContains(t, "ci.ap-southeast-2.tfvars", "mac_signer_root_volume_encrypted = false")
 }
 
 func TestGitDeployKeyIsRequired(t *testing.T) {

--- a/infra/terraform/envs/ci/ci.ap-southeast-2.tfvars
+++ b/infra/terraform/envs/ci/ci.ap-southeast-2.tfvars
@@ -1,0 +1,38 @@
+aws_region  = "ap-southeast-2"
+name_prefix = "cleanroom-ci-apse2"
+
+# Pin Sydney CI to the AZ where Mac capacity landed.
+availability_zone = "ap-southeast-2b"
+
+# Pin current live AMIs to avoid churn while the shared workspace stays aligned
+# with the provisioned CI hosts.
+ami_id        = "ami-0c33c6bd24cee108b"
+instance_type = "m8i.large"
+
+enable_macos_ci                  = true
+enable_macos_signer_ci           = true
+mac_ami_id                       = "ami-03410f84a69ea2482"
+mac_instance_type                = "mac2-m2pro.metal"
+mac_signer_ami_id                = "ami-03410f84a69ea2482"
+mac_signer_root_volume_encrypted = false
+
+buildkite_token_parameter_name    = "/buildkite/agent-token"
+tailscale_auth_key_parameter_name = "/tailscale/authkey/ci"
+git_deploy_key_parameter_name     = "/buildkite/cleanroom/deploy-key"
+
+repo_url              = "git@github.com:buildkite/cleanroom.git"
+repo_ref              = "main"
+setup_script_path     = "scripts/bootstrap-buildkite-agent.sh"
+mac_setup_script_path = "scripts/bootstrap-buildkite-agent-macos.sh"
+mac_buildkite_queue   = "cleanroom-mac"
+
+tailscale_hostname_prefix = "cleanroom-ci-apse2-linux"
+tailscale_advertise_tags  = ""
+tailscale_enable_ssh      = true
+tailscale_accept_routes   = false
+
+tags = {
+  env    = "ci"
+  team   = "platform"
+  region = "ap-southeast-2"
+}

--- a/infra/terraform/envs/ci/main.tf
+++ b/infra/terraform/envs/ci/main.tf
@@ -66,6 +66,7 @@ module "linux_ci" {
   ami_id                            = local.selected_ami_id
   instance_type                     = var.instance_type
   root_volume_size_gib              = var.root_volume_size_gib
+  user_data_replace_on_change       = false
   buildkite_token_parameter_name    = var.buildkite_token_parameter_name
   tailscale_auth_key_parameter_name = var.tailscale_auth_key_parameter_name
   git_deploy_key_parameter_name     = var.git_deploy_key_parameter_name
@@ -91,6 +92,7 @@ module "mac_ci" {
   ami_id                            = local.selected_mac_ami_id
   instance_type                     = var.mac_instance_type
   root_volume_size_gib              = var.mac_root_volume_size_gib
+  root_volume_encrypted             = var.mac_root_volume_encrypted
   buildkite_queue                   = var.mac_buildkite_queue
   buildkite_token_parameter_name    = var.buildkite_token_parameter_name
   autologin_password_parameter_name = ""
@@ -118,6 +120,7 @@ module "mac_signer" {
   ami_id                            = local.selected_mac_signer_ami_id
   instance_type                     = local.selected_mac_signer_instance_type
   root_volume_size_gib              = local.selected_mac_signer_root_volume_size_gib
+  root_volume_encrypted             = var.mac_signer_root_volume_encrypted
   buildkite_queue                   = var.mac_signer_buildkite_queue
   buildkite_token_parameter_name    = var.buildkite_token_parameter_name
   autologin_password_parameter_name = local.selected_mac_signer_autologin_password_parameter_name

--- a/infra/terraform/envs/ci/variables.tf
+++ b/infra/terraform/envs/ci/variables.tf
@@ -75,6 +75,12 @@ variable "mac_root_volume_size_gib" {
   default     = 200
 }
 
+variable "mac_root_volume_encrypted" {
+  description = "Whether the macOS CI host root EBS volume is encrypted."
+  type        = bool
+  default     = true
+}
+
 variable "mac_buildkite_queue" {
   description = "Buildkite queue tag used by the macOS agent."
   type        = string
@@ -132,6 +138,12 @@ variable "mac_signer_root_volume_size_gib" {
   description = "Optional root EBS volume size in GiB for the macOS signer host. Use 0 to reuse mac_root_volume_size_gib."
   type        = number
   default     = 0
+}
+
+variable "mac_signer_root_volume_encrypted" {
+  description = "Whether the macOS signer host root EBS volume is encrypted."
+  type        = bool
+  default     = true
 }
 
 variable "mac_signer_buildkite_queue" {

--- a/infra/terraform/modules/macos-ci/main.tf
+++ b/infra/terraform/modules/macos-ci/main.tf
@@ -137,7 +137,7 @@ resource "aws_instance" "host" {
   root_block_device {
     volume_type = "gp3"
     volume_size = var.root_volume_size_gib
-    encrypted   = true
+    encrypted   = var.root_volume_encrypted
   }
 
   user_data = templatefile("${path.module}/templates/user_data.sh.tftpl", {

--- a/infra/terraform/modules/macos-ci/variables.tf
+++ b/infra/terraform/modules/macos-ci/variables.tf
@@ -47,6 +47,12 @@ variable "root_volume_size_gib" {
   default     = 200
 }
 
+variable "root_volume_encrypted" {
+  description = "Whether the macOS root EBS volume is encrypted."
+  type        = bool
+  default     = true
+}
+
 variable "buildkite_queue" {
   description = "Buildkite queue tag for this macOS host."
   type        = string


### PR DESCRIPTION
## Summary

This reconciles the Sydney CI Terraform config with the live CI runner layout.

It adds first-class support for the current mac signer host shape, including a configurable mac root volume encryption flag, and checks in a tracked `ci.ap-southeast-2.tfvars` so the shared CI workspace no longer depends on an ignored local `terraform.tfvars`.

## Why

The live `ap-southeast-2` CI environment had drifted away from the checked-in configuration:

- Terraform only modeled the main mac runner, while a separate signer runner existed live
- the signer runner's unencrypted root volume did not match the module defaults
- the CI env relied on an ignored local var file, which made the live workspace shape effectively machine-local

That made the workspace hard to reason about and created replacement churn in plan output.

## Impact

After importing the live signer resources and applying this config:

- `terraform plan -var-file=ci.ap-southeast-2.tfvars` is now a no-op for the Sydney CI workspace
- the signer runner is represented explicitly in Terraform
- the checked-in CI docs now follow the same explicit regional var-file pattern as prod
- the main mac runner cache was pruned and validated after the earlier `XDG_CACHE_HOME` change

## Validation

- `mise exec -- go test ./infra/terraform/envs/ci`
- `terraform -chdir=infra/terraform/envs/ci plan -no-color -var-file=ci.ap-southeast-2.tfvars`
- Buildkite build `757` on `main` passed the mac and darwin-vz paths after cleanup and reconciliation
