### PR TITLE
fix: darwin-vz guest loopback bring-up

### DIFF
--- a/internal/backend/darwinvz/guest_init_script.go
+++ b/internal/backend/darwinvz/guest_init_script.go
@@ -97,7 +97,20 @@ configure_vmnet_static_network() {
   return 0
 }
 
+setup_loopback() {
+  if command -v ip >/dev/null 2>&1; then
+    ip link set lo up 2>/dev/null || true
+    ip addr add 127.0.0.1/8 dev lo 2>/dev/null || true
+    ip -6 addr add ::1/128 dev lo 2>/dev/null || true
+  elif command -v ifconfig >/dev/null 2>&1; then
+    ifconfig lo 127.0.0.1 up 2>/dev/null || true
+    ifconfig lo inet6 add ::1/128 2>/dev/null || true
+  fi
+}
+
 setup_guest_network() {
+  setup_loopback
+
   NET_IFACE=""
   for cand in /sys/class/net/*; do
     name="$(basename "$cand")"

--- a/internal/backend/darwinvz/guest_init_script_test.go
+++ b/internal/backend/darwinvz/guest_init_script_test.go
@@ -25,6 +25,15 @@ func TestGuestInitScriptBootstrapsNetwork(t *testing.T) {
 	if !strings.Contains(guestInitScriptTemplate, "setup_guest_network") {
 		t.Fatal("expected guest network setup function in init script")
 	}
+	if !strings.Contains(guestInitScriptTemplate, "ip link set lo up") {
+		t.Fatal("expected loopback interface setup in init script")
+	}
+	if !strings.Contains(guestInitScriptTemplate, "ip addr add 127.0.0.1/8 dev lo") {
+		t.Fatal("expected IPv4 loopback address setup in init script")
+	}
+	if !strings.Contains(guestInitScriptTemplate, "ip -6 addr add ::1/128 dev lo") {
+		t.Fatal("expected IPv6 loopback address setup in init script")
+	}
 	if !strings.Contains(guestInitScriptTemplate, "cleanroom_vmnet_guest_ipv4") {
 		t.Fatal("expected vmnet static guest IPv4 boot arg lookup in init script")
 	}


### PR DESCRIPTION
## Summary
- bring `lo` up during darwin-vz guest init before configuring the primary network interface
- assign `127.0.0.1/8` and `::1/128` on a best-effort basis for guests that use `ip` or `ifconfig`
- add a regression test that locks the guest init script to configuring loopback addresses

## Why
Buildkite Agent and other real workloads expect loopback to exist by default. In darwin-vz guests, `lo` was booting down, which broke tests and localhost listeners unless callers manually configured loopback inside the guest.

## Validation
- `mise exec go -- go test ./internal/backend/darwinvz -run TestGuestInitScriptBootstrapsNetwork -count=1`
- `mise exec go -- go test ./internal/backend/darwinvz -count=1`
- `mise exec -- scripts/build-go.sh`
