### PR TITLE
feat: add CLI repository checkout overrides

### DIFF
--- a/internal/cli/console.go
+++ b/internal/cli/console.go
@@ -25,6 +25,7 @@ type ConsoleCommand struct {
 	In             string   `name:"in" aliases:"sandbox-id" help:"Run in an existing sandbox ID instead of creating a new one"`
 	From           string   `name:"from" help:"Create the sandbox from an existing snapshot ID"`
 	Image          string   `help:"Override sandbox image ref for newly created sandboxes (tag, digest, or local Docker image)"`
+	repositoryOverrideFlags
 	Keep           bool     `help:"Keep a newly created sandbox after the console exits"`
 	Env            []string `short:"e" name:"env" help:"Set guest environment variables; use KEY to inherit from the local environment or KEY=VALUE to set an explicit value"`
 	PrintSandboxID bool     `name:"print-sandbox-id" help:"Print resolved sandbox_id=<id> to stderr before attaching"`
@@ -35,7 +36,7 @@ type ConsoleCommand struct {
 }
 
 func (c *ConsoleCommand) Run(ctx *runtimeContext) (runErr error) {
-	if err := validateExecutionSandboxArgs(c.Chdir, c.In, c.From, c.Keep); err != nil {
+	if err := validateExecutionSandboxArgs(c.Chdir, c.In, c.From, c.Keep, c.repositoryOverrideFlags); err != nil {
 		return err
 	}
 
@@ -70,7 +71,7 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) (runErr error) {
 		"env_count", len(executionEnv),
 	)
 	persistentRepositoryBackend := backendSupportsRepositoryPersistence(ctx, host, c.Backend)
-	repository, err := maybeResolveRepositoryCheckout(cwd, ctx.Loader, strings.TrimSpace(c.In), strings.TrimSpace(c.From), !persistentRepositoryBackend)
+	repository, err := maybeResolveRepositoryCheckoutWithOverride(cwd, ctx.Loader, strings.TrimSpace(c.In), strings.TrimSpace(c.From), !persistentRepositoryBackend, c.repositoryOverrideFlags)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -18,6 +18,7 @@ type ExecCommand struct {
 	In             string   `name:"in" aliases:"sandbox-id" help:"Run in an existing sandbox ID instead of creating a new one"`
 	From           string   `name:"from" help:"Create the sandbox from an existing snapshot ID"`
 	Image          string   `help:"Override sandbox image ref for newly created sandboxes (tag, digest, or local Docker image)"`
+	repositoryOverrideFlags
 	Keep           bool     `help:"Keep a newly created sandbox after the command completes"`
 	Env            []string `short:"e" name:"env" help:"Set guest environment variables; use KEY to inherit from the local environment or KEY=VALUE to set an explicit value"`
 	NoStdin        bool     `short:"n" name:"no-stdin" aliases:"stdin-eof" help:"Close stdin immediately instead of attaching it"`
@@ -29,7 +30,7 @@ type ExecCommand struct {
 }
 
 func (e *ExecCommand) Run(ctx *runtimeContext) (runErr error) {
-	if err := validateExecutionSandboxArgs(e.Chdir, e.In, e.From, e.Keep); err != nil {
+	if err := validateExecutionSandboxArgs(e.Chdir, e.In, e.From, e.Keep, e.repositoryOverrideFlags); err != nil {
 		return err
 	}
 
@@ -60,7 +61,7 @@ func (e *ExecCommand) Run(ctx *runtimeContext) (runErr error) {
 		"env_count", len(executionEnv),
 	)
 	persistentRepositoryBackend := backendSupportsRepositoryPersistence(ctx, host, e.Backend)
-	repository, err := maybeResolveRepositoryCheckout(cwd, ctx.Loader, strings.TrimSpace(e.In), strings.TrimSpace(e.From), !persistentRepositoryBackend)
+	repository, err := maybeResolveRepositoryCheckoutWithOverride(cwd, ctx.Loader, strings.TrimSpace(e.In), strings.TrimSpace(e.From), !persistentRepositoryBackend, e.repositoryOverrideFlags)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/execution_shared.go
+++ b/internal/cli/execution_shared.go
@@ -77,10 +77,14 @@ func ensureSandboxID(client *controlclient.Client, loader policyLoader, cwd, hos
 	return sandboxID, true, nil
 }
 
-func validateExecutionSandboxArgs(chdir, existingSandboxID, fromSnapshot string, keep bool) error {
+func validateExecutionSandboxArgs(chdir, existingSandboxID, fromSnapshot string, keep bool, repositoryOverride repositoryOverrideFlags) error {
 	sandboxID := strings.TrimSpace(existingSandboxID)
 	snapshotID := strings.TrimSpace(fromSnapshot)
 	hasChdir := strings.TrimSpace(chdir) != ""
+
+	if _, err := repositoryOverride.resolve(".", nil); err != nil {
+		return err
+	}
 
 	if sandboxID != "" && snapshotID != "" {
 		return errors.New("--from cannot be used with --in")
@@ -93,6 +97,12 @@ func validateExecutionSandboxArgs(chdir, existingSandboxID, fromSnapshot string,
 	}
 	if snapshotID != "" && hasChdir {
 		return errors.New("--chdir cannot be used with --from")
+	}
+	if sandboxID != "" && repositoryOverride.hasRepositoryOverride() {
+		return errors.New("--repo-url cannot be used with --in")
+	}
+	if snapshotID != "" && repositoryOverride.hasRepositoryOverride() {
+		return errors.New("--repo-url cannot be used with --from")
 	}
 
 	return nil

--- a/internal/cli/repository.go
+++ b/internal/cli/repository.go
@@ -23,7 +23,65 @@ type resolvedRepositoryCheckout struct {
 	Dirty          bool
 }
 
+const defaultRepositoryOverridePath = "/workspace"
+
+type repositoryOverrideFlags struct {
+	RepoURL    string `name:"repo-url" help:"Bootstrap this repository URL instead of inheriting the current repository"`
+	RepoCommit string `name:"repo-commit" help:"Bootstrap this exact repository commit SHA; requires --repo-url"`
+}
+
+func (f repositoryOverrideFlags) resolve(cwd string, loader policyLoader) (*resolvedRepositoryCheckout, error) {
+	repoURL := strings.TrimSpace(f.RepoURL)
+	repoCommit := strings.TrimSpace(f.RepoCommit)
+	switch {
+	case repoURL == "" && repoCommit == "":
+		return nil, nil
+	case repoURL == "" || repoCommit == "":
+		return nil, errors.New("--repo-url and --repo-commit must be used together")
+	}
+
+	checkout := &repositorycheckout.Checkout{
+		RemoteURL:      repoURL,
+		CommitSHA:      repoCommit,
+		DestinationDir: defaultRepositoryOverridePath,
+	}
+	if err := checkout.ValidateBootstrap(); err != nil {
+		return nil, err
+	}
+	remoteHost, err := checkout.NormalizeRemoteURL()
+	if err != nil {
+		return nil, err
+	}
+
+	if loader != nil {
+		compiled, _, err := loader.LoadAndCompile(cwd)
+		if err != nil {
+			return nil, err
+		}
+		if compiled != nil && !compiled.Allows(remoteHost, 443) {
+			return nil, fmt.Errorf("repository remote host %q is not allowed by sandbox policy", remoteHost)
+		}
+	}
+
+	return &resolvedRepositoryCheckout{
+		RemoteURL:      checkout.RemoteURL,
+		CommitSHA:      checkout.CommitSHA,
+		DestinationDir: checkout.DestinationDir,
+	}, nil
+}
+
+func (f repositoryOverrideFlags) hasRepositoryOverride() bool {
+	return strings.TrimSpace(f.RepoURL) != "" || strings.TrimSpace(f.RepoCommit) != ""
+}
+
 func resolveRepositoryCheckout(cwd string, loader policyLoader) (*resolvedRepositoryCheckout, error) {
+	return resolveRepositoryCheckoutWithOverride(cwd, loader, repositoryOverrideFlags{})
+}
+
+func resolveRepositoryCheckoutWithOverride(cwd string, loader policyLoader, override repositoryOverrideFlags) (*resolvedRepositoryCheckout, error) {
+	if checkout, err := override.resolve(cwd, loader); err != nil || checkout != nil {
+		return checkout, err
+	}
 	repository, err := loadRepositoryConfig(cwd, loader)
 	if err != nil {
 		if errors.Is(err, errSkipRepositoryCheckout) {
@@ -79,10 +137,14 @@ func resolveRepositoryCheckout(cwd string, loader policyLoader) (*resolvedReposi
 }
 
 func maybeResolveRepositoryCheckout(cwd string, loader policyLoader, existingSandboxID, fromSnapshot string, _ bool) (*resolvedRepositoryCheckout, error) {
+	return maybeResolveRepositoryCheckoutWithOverride(cwd, loader, existingSandboxID, fromSnapshot, false, repositoryOverrideFlags{})
+}
+
+func maybeResolveRepositoryCheckoutWithOverride(cwd string, loader policyLoader, existingSandboxID, fromSnapshot string, _ bool, override repositoryOverrideFlags) (*resolvedRepositoryCheckout, error) {
 	if strings.TrimSpace(existingSandboxID) != "" || strings.TrimSpace(fromSnapshot) != "" {
 		return nil, nil
 	}
-	return resolveRepositoryCheckout(cwd, loader)
+	return resolveRepositoryCheckoutWithOverride(cwd, loader, override)
 }
 
 var errSkipRepositoryCheckout = errors.New("skip repository checkout")

--- a/internal/cli/repository_test.go
+++ b/internal/cli/repository_test.go
@@ -173,6 +173,83 @@ func TestCreateCommandBootstrapsRepositoryForCurrentRepo(t *testing.T) {
 	}
 }
 
+func TestCreateCommandBootstrapsRepositoryForExplicitOverride(t *testing.T) {
+	adapter := &persistentIntegrationAdapter{}
+	host, _ := startIntegrationServer(t, adapter)
+
+	var (
+		mu       sync.Mutex
+		commands [][]string
+	)
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+		mu.Lock()
+		commands = append(commands, append([]string(nil), req.Command...))
+		mu.Unlock()
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+	}
+
+	const wantCommit = "0123456789abcdef0123456789abcdef01234567"
+	outcome := runCreateAliasWithCapture(CreateCommand{
+		clientFlags: clientFlags{Host: host},
+		Chdir:       t.TempDir(),
+		repositoryOverrideFlags: repositoryOverrideFlags{
+			RepoURL:    "https://github.com/buildkite/agent.git",
+			RepoCommit: wantCommit,
+		},
+	}, runtimeContext{
+		CWD: t.TempDir(),
+		Loader: repositoryIntegrationLoader{
+			compiled: &policy.CompiledPolicy{
+				Version:        1,
+				ImageRef:       "ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+				ImageDigest:    "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+				NetworkDefault: "deny",
+				Allow:          []policy.AllowRule{{Host: "github.com", Ports: []int{443}}},
+			},
+		},
+	})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err != nil {
+		t.Fatalf("CreateCommand.Run returned error: %v", outcome.err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(commands) != 1 {
+		t.Fatalf("expected one bootstrap execution, got %d", len(commands))
+	}
+	joined := strings.Join(commands[0], " ")
+	if !strings.Contains(joined, "https://github.com/buildkite/agent.git") {
+		t.Fatalf("expected bootstrap command to include override remote, got %q", joined)
+	}
+	if !strings.Contains(joined, wantCommit) {
+		t.Fatalf("expected bootstrap command to include override commit %q, got %q", wantCommit, joined)
+	}
+	if !strings.Contains(joined, "'/workspace'") {
+		t.Fatalf("expected bootstrap command to use default workspace path, got %q", joined)
+	}
+}
+
+func TestCreateCommandRejectsPartialRepositoryOverride(t *testing.T) {
+	outcome := runCreateAliasWithCapture(CreateCommand{
+		repositoryOverrideFlags: repositoryOverrideFlags{
+			RepoURL:    "https://github.com/buildkite/agent.git",
+			RepoCommit: "",
+		},
+	}, runtimeContext{})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err == nil {
+		t.Fatal("expected create command to reject partial repository override")
+	}
+	if !strings.Contains(outcome.err.Error(), "--repo-url and --repo-commit must be used together") {
+		t.Fatalf("unexpected error: %v", outcome.err)
+	}
+}
+
 func TestCreateCommandBootstrapsRepositoryOnCurrentBranch(t *testing.T) {
 	repoDir := initGitRepository(t, "git@github.com:buildkite/cleanroom.git")
 	checkoutGitBranch(t, repoDir, "feature/console-branch")
@@ -779,6 +856,72 @@ func TestExecCommandInlinesRepositoryBootstrapForNonPersistentBackend(t *testing
 	joined := strings.Join(commands[0], " ")
 	if !strings.Contains(joined, "clone --filter=blob:none --no-checkout") {
 		t.Fatalf("expected inlined repository clone, got %q", joined)
+	}
+	if !strings.Contains(joined, "cd '/workspace' && exec 'echo' 'ok'") {
+		t.Fatalf("expected inlined command to run inside /workspace, got %q", joined)
+	}
+}
+
+func TestExecCommandInlinesExplicitRepositoryOverrideForNonPersistentBackend(t *testing.T) {
+	adapter := &integrationAdapter{}
+	host, _ := startUnixIntegrationServer(t, adapter)
+
+	var (
+		mu       sync.Mutex
+		commands [][]string
+	)
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+		mu.Lock()
+		commands = append(commands, append([]string(nil), req.Command...))
+		mu.Unlock()
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+	}
+
+	const wantCommit = "0123456789abcdef0123456789abcdef01234567"
+	outcome := runExecWithCapture(ExecCommand{
+		clientFlags: clientFlags{Host: host},
+		Chdir:       t.TempDir(),
+		repositoryOverrideFlags: repositoryOverrideFlags{
+			RepoURL:    "https://github.com/buildkite/agent.git",
+			RepoCommit: wantCommit,
+		},
+		Command: []string{"echo", "ok"},
+	}, runtimeContext{
+		CWD: t.TempDir(),
+		Loader: repositoryIntegrationLoader{
+			compiled: &policy.CompiledPolicy{
+				Version:        1,
+				ImageRef:       "ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+				ImageDigest:    "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+				NetworkDefault: "deny",
+				Allow:          []policy.AllowRule{{Host: "github.com", Ports: []int{443}}},
+			},
+		},
+		Config: runtimeconfig.Config{
+			DefaultBackend: "firecracker",
+		},
+		Backends: map[string]backend.Adapter{
+			"firecracker": adapter,
+		},
+	})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err != nil {
+		t.Fatalf("ExecCommand.Run returned error: %v", outcome.err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(commands) != 1 {
+		t.Fatalf("expected one inlined execution, got %d execution(s)", len(commands))
+	}
+	joined := strings.Join(commands[0], " ")
+	if !strings.Contains(joined, "https://github.com/buildkite/agent.git") {
+		t.Fatalf("expected inlined command to include override remote, got %q", joined)
+	}
+	if !strings.Contains(joined, wantCommit) {
+		t.Fatalf("expected inlined command to include override commit %q, got %q", wantCommit, joined)
 	}
 	if !strings.Contains(joined, "cd '/workspace' && exec 'echo' 'ok'") {
 		t.Fatalf("expected inlined command to run inside /workspace, got %q", joined)

--- a/internal/cli/sandbox.go
+++ b/internal/cli/sandbox.go
@@ -55,6 +55,7 @@ type CreateCommand struct {
 	Backend       string `help:"Execution backend (defaults to runtime config or host default)"`
 	From          string `name:"from" help:"Create the sandbox from an existing snapshot ID"`
 	Image         string `help:"Override sandbox image ref (tag, digest, or local Docker image)"`
+	repositoryOverrideFlags
 	LaunchSeconds int64  `help:"VM boot/guest-agent readiness timeout in seconds"`
 	JSON          bool   `help:"Print sandbox as JSON"`
 }
@@ -267,6 +268,9 @@ func (c *SandboxCreateCommand) Run(ctx *runtimeContext) error {
 }
 
 func (c *CreateCommand) Run(ctx *runtimeContext) error {
+	if err := c.validate(); err != nil {
+		return err
+	}
 	if strings.TrimSpace(c.From) != "" {
 		return runSandboxCreate(ctx, c.clientFlags, c.Backend, c.From, c.Image, false, false, c.LaunchSeconds, c.JSON)
 	}
@@ -280,7 +284,7 @@ func (c *CreateCommand) Run(ctx *runtimeContext) error {
 	if err != nil {
 		return err
 	}
-	repository, err := resolveRepositoryCheckout(cwd, ctx.Loader)
+	repository, err := resolveRepositoryCheckoutWithOverride(cwd, ctx.Loader, c.repositoryOverrideFlags)
 	if err != nil {
 		return err
 	}
@@ -300,6 +304,16 @@ func (c *CreateCommand) Run(ctx *runtimeContext) error {
 	}
 	_, err = fmt.Fprintln(ctx.Stdout, sandboxID)
 	return err
+}
+
+func (c *CreateCommand) validate() error {
+	if _, err := c.repositoryOverrideFlags.resolve(".", nil); err != nil {
+		return err
+	}
+	if c.repositoryOverrideFlags.hasRepositoryOverride() && strings.TrimSpace(c.From) != "" {
+		return errors.New("--repo-url cannot be used with --from")
+	}
+	return nil
 }
 
 func createTopLevelSandbox(


### PR DESCRIPTION
## Summary
- add `--repo-url` and `--repo-commit` overrides to `cleanroom create`, `cleanroom exec`, and `cleanroom console`
- resolve explicit repository checkouts through the existing `RepositoryCheckout` path and policy allowlist checks
- cover explicit override bootstrap for persistent and inlined repository bootstrap flows

## Verification
- `mise exec go -- go test ./internal/cli -run 'TestCreateCommandBootstrapsRepositoryForExplicitOverride|TestCreateCommandRejectsPartialRepositoryOverride|TestExecCommandInlinesExplicitRepositoryOverrideForNonPersistentBackend' -count=1`\n- `mise exec go -- go test ./internal/cli -count=1`\n- `mise exec -- scripts/build-go.sh`\n- `mise exec go -- go test ./...`\n- `./dist/cleanroom create --help | rg -n "repo-url|repo-commit"`