### PR TITLE
feat: make mise ready in base images

### DIFF
--- a/images/Dockerfile.base-image
+++ b/images/Dockerfile.base-image
@@ -3,6 +3,7 @@ FROM alpine:3.22
 RUN apk add --no-cache \
   bash \
   git \
+  openssh-client-default \
   strace \
   mise
 

--- a/images/Dockerfile.base-image
+++ b/images/Dockerfile.base-image
@@ -6,6 +6,12 @@ RUN apk add --no-cache \
   strace \
   mise
 
+# Cleanroom checks out repositories into /workspace, so trust repo-local mise
+# configs there and expose shims on PATH for guest commands.
+RUN mise settings add trusted_config_paths /workspace
+
+ENV PATH="/root/.local/share/mise/shims:${PATH}"
+
 RUN mise --version
 
 CMD ["/bin/sh"]

--- a/images/Dockerfile.base-image-agents
+++ b/images/Dockerfile.base-image-agents
@@ -17,6 +17,9 @@ RUN apk add --no-cache \
   strace \
   mise
 
+# Keep repo-local mise configs under /workspace usable in agent containers too.
+RUN mise settings add trusted_config_paths /workspace
+
 # Install common agent CLIs with pinned versions for reproducible builds.
 RUN mise use -g --pin \
   npm:@openai/codex@"${CODEX_VERSION}" \

--- a/images/Dockerfile.base-image-agents
+++ b/images/Dockerfile.base-image-agents
@@ -13,6 +13,7 @@ RUN apk add --no-cache \
   make \
   nodejs \
   npm \
+  openssh-client-default \
   python3 \
   strace \
   mise

--- a/images/Dockerfile.base-image-docker
+++ b/images/Dockerfile.base-image-docker
@@ -7,6 +7,12 @@ RUN apk add --no-cache \
   strace \
   mise
 
+# Cleanroom checks out repositories into /workspace, so trust repo-local mise
+# configs there and expose shims on PATH for guest commands.
+RUN mise settings add trusted_config_paths /workspace
+
+ENV PATH="/root/.local/share/mise/shims:${PATH}"
+
 RUN docker --version && mise --version
 
 CMD ["/bin/sh"]

--- a/images/Dockerfile.base-image-docker
+++ b/images/Dockerfile.base-image-docker
@@ -4,6 +4,7 @@ RUN apk add --no-cache \
   bash \
   docker \
   git \
+  openssh-client-default \
   strace \
   mise
 

--- a/images/dockerfiles_test.go
+++ b/images/dockerfiles_test.go
@@ -29,3 +29,49 @@ func TestPublishedBaseImagesInstallBash(t *testing.T) {
 		})
 	}
 }
+
+func TestPublishedBaseImagesExposeMiseShimsOnPATH(t *testing.T) {
+	t.Parallel()
+
+	for _, relPath := range []string{
+		"Dockerfile.base-image",
+		"Dockerfile.base-image-docker",
+		"Dockerfile.base-image-agents",
+	} {
+		relPath := relPath
+		t.Run(relPath, func(t *testing.T) {
+			t.Parallel()
+
+			raw, err := os.ReadFile(filepath.Join(".", relPath))
+			if err != nil {
+				t.Fatalf("read %s: %v", relPath, err)
+			}
+			if !strings.Contains(string(raw), `ENV PATH="/root/.local/share/mise/shims:${PATH}"`) {
+				t.Fatalf("%s does not add mise shims to PATH", relPath)
+			}
+		})
+	}
+}
+
+func TestPublishedBaseImagesTrustWorkspaceMiseConfig(t *testing.T) {
+	t.Parallel()
+
+	for _, relPath := range []string{
+		"Dockerfile.base-image",
+		"Dockerfile.base-image-docker",
+		"Dockerfile.base-image-agents",
+	} {
+		relPath := relPath
+		t.Run(relPath, func(t *testing.T) {
+			t.Parallel()
+
+			raw, err := os.ReadFile(filepath.Join(".", relPath))
+			if err != nil {
+				t.Fatalf("read %s: %v", relPath, err)
+			}
+			if !strings.Contains(string(raw), "mise settings add trusted_config_paths /workspace") {
+				t.Fatalf("%s does not trust /workspace for repo-local mise config", relPath)
+			}
+		})
+	}
+}

--- a/images/dockerfiles_test.go
+++ b/images/dockerfiles_test.go
@@ -30,6 +30,29 @@ func TestPublishedBaseImagesInstallBash(t *testing.T) {
 	}
 }
 
+func TestPublishedBaseImagesInstallOpenSSHClientDefault(t *testing.T) {
+	t.Parallel()
+
+	for _, relPath := range []string{
+		"Dockerfile.base-image",
+		"Dockerfile.base-image-docker",
+		"Dockerfile.base-image-agents",
+	} {
+		relPath := relPath
+		t.Run(relPath, func(t *testing.T) {
+			t.Parallel()
+
+			raw, err := os.ReadFile(filepath.Join(".", relPath))
+			if err != nil {
+				t.Fatalf("read %s: %v", relPath, err)
+			}
+			if !strings.Contains(string(raw), "\n  openssh-client-default \\\n") {
+				t.Fatalf("%s does not install openssh-client-default", relPath)
+			}
+		})
+	}
+}
+
 func TestPublishedBaseImagesExposeMiseShimsOnPATH(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- trust repo-local mise config under `/workspace` in the published base images
- expose the mise shims directory on `PATH` in the non-agent base images
- add image tests that lock those defaults in place

## What this fixes
- repo-local `.mise.toml` files under `/workspace` no longer require a manual `mise trust` step
- `mise exec ...` works out of the box in the base image against a checked-out repo in `/workspace`

## Notes
- plain `sh -lc 'mise install && go version'` still does not work in the same shell because `ash` caches command lookups before the shim exists\n- `mise exec go -- go version` works after this change and is the reliable shell-agnostic flow\n\n## Verification\n- `mise exec go -- go test ./images -count=1`\n- `mise exec go -- go test ./...`\n- `docker build -f images/Dockerfile.base-image -t cleanroom-base:alpine-mise-oob .`\n- `docker build -f images/Dockerfile.base-image-docker -t cleanroom-base:alpine-docker-mise-oob .`\n- `docker run --rm cleanroom-base:alpine-mise-oob sh -lc 'set -eu\nmkdir -p /workspace/repo\ncat > /workspace/repo/.mise.toml <<"EOF"\n[tools]\ngo = "1.25.8"\nEOF\ncd /workspace/repo\nmise exec go -- go version\n'`