### PR TITLE
feat: auto-bootstrap mise for repo-aware commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@ commands become repo-aware: Cleanroom resolves the current git remote and local
 `HEAD`, materializes that checkout in the sandbox, and starts commands in the
 configured guest path. If the checked-out repository contains `.mise.toml`,
 `mise.toml`, `.tool-versions`, or `.mise/config.toml`, Cleanroom also runs
-`mise install` and executes the command through `mise exec -- ...`.
+`mise install` and executes the command through `mise exec -- ...` unless
+`sandbox.mise.enabled: false` or `sandbox.mise.install: false` is set in
+`cleanroom.yaml`.
 
 Pre-create a long-running sandbox without running a command:
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ commands become repo-aware: Cleanroom resolves the current git remote and local
 `HEAD`, materializes that checkout in the sandbox, and starts commands in the
 configured guest path. If the checked-out repository contains `.mise.toml`,
 `mise.toml`, `.tool-versions`, or `.mise/config.toml`, Cleanroom also runs
-`mise install` and executes the command through `mise exec -- ...` unless
+the command through `mise exec -- ...` unless
 `sandbox.mise.enabled: false` or `sandbox.mise.install: false` is set in
 `cleanroom.yaml`.
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,9 @@ cleanroom exec -e OPENAI_API_KEY -- codex app-server
 When `cleanroom.yaml` includes a repository bootstrap block, the top-level
 commands become repo-aware: Cleanroom resolves the current git remote and local
 `HEAD`, materializes that checkout in the sandbox, and starts commands in the
-configured guest path.
+configured guest path. If the checked-out repository contains `.mise.toml`,
+`mise.toml`, `.tool-versions`, or `.mise/config.toml`, Cleanroom also runs
+`mise install` and executes the command through `mise exec -- ...`.
 
 Pre-create a long-running sandbox without running a command:
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -323,7 +323,7 @@ Behavior contract:
 5. For repo-aware top-level commands, materialize that checkout in the sandbox
    and default the guest working directory to `repository.path`.
    - if the checkout contains `.mise.toml`, `mise.toml`, `.tool-versions`, or
-     `.mise/config.toml`, run `mise install` and execute the workload through
+     `.mise/config.toml`, execute the workload through
      `mise exec -- ...`, unless `sandbox.mise.enabled: false` or
      `sandbox.mise.install: false`
 6. Create execution with explicit kind, env, and TTY options.

--- a/docs/api.md
+++ b/docs/api.md
@@ -324,7 +324,8 @@ Behavior contract:
    and default the guest working directory to `repository.path`.
    - if the checkout contains `.mise.toml`, `mise.toml`, `.tool-versions`, or
      `.mise/config.toml`, run `mise install` and execute the workload through
-     `mise exec -- ...`
+     `mise exec -- ...`, unless `sandbox.mise.enabled: false` or
+     `sandbox.mise.install: false`
 6. Create execution with explicit kind, env, and TTY options.
 7. Attach stdio according to command mode:
    - `cleanroom exec` defaults to attached stdin plus separate stdout/stderr

--- a/docs/api.md
+++ b/docs/api.md
@@ -322,6 +322,9 @@ Behavior contract:
    the current git remote and committed `HEAD`.
 5. For repo-aware top-level commands, materialize that checkout in the sandbox
    and default the guest working directory to `repository.path`.
+   - if the checkout contains `.mise.toml`, `mise.toml`, `.tool-versions`, or
+     `.mise/config.toml`, run `mise install` and execute the workload through
+     `mise exec -- ...`
 6. Create execution with explicit kind, env, and TTY options.
 7. Attach stdio according to command mode:
    - `cleanroom exec` defaults to attached stdin plus separate stdout/stderr

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -216,6 +216,7 @@ Meaning:
   - they resolve the local repository remote URL and committed `HEAD`
   - they materialize that checkout inside the sandbox before the command runs
   - they start commands in `repository.path`
+  - when the checkout contains `.mise.toml`, `mise.toml`, `.tool-versions`, or `.mise/config.toml`, they run `mise install` and execute the command through `mise exec -- ...`
 - `cleanroom sandbox create` remains the generic low-level surface and does not
   infer repository state from the current working tree or read `cleanroom.yaml`.
 - Without `--from`, `cleanroom sandbox create` synthesizes a repo-agnostic

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -76,7 +76,7 @@ sandbox:
   ttl_minutes: 60
   mise:
     enabled: true
-    auto_bootstrap: true
+    install: true
     config_files:
       - .mise.toml
       - .mise/config.toml
@@ -216,7 +216,7 @@ Meaning:
   - they resolve the local repository remote URL and committed `HEAD`
   - they materialize that checkout inside the sandbox before the command runs
   - they start commands in `repository.path`
-  - when the checkout contains `.mise.toml`, `mise.toml`, `.tool-versions`, or `.mise/config.toml`, they run `mise install` and execute the command through `mise exec -- ...`
+  - when the checkout contains `.mise.toml`, `mise.toml`, `.tool-versions`, or `.mise/config.toml`, they run `mise install` and execute the command through `mise exec -- ...` unless `sandbox.mise.enabled: false` or `sandbox.mise.install: false`
 - `cleanroom sandbox create` remains the generic low-level surface and does not
   infer repository state from the current working tree or read `cleanroom.yaml`.
 - Without `--from`, `cleanroom sandbox create` synthesizes a repo-agnostic

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -161,7 +161,7 @@ Meaning:
 - `repository.path` defaults to `/workspace` and must be an absolute guest path.
 - `repository.submodules` defaults to `false`.
 - `sandbox.mise.enabled` defaults to `true`; `false` disables Cleanroom-managed `mise` detection and install wrapping.
-- `sandbox.mise.install` defaults to `true`; `false` preserves repo-aware checkout but skips automatic `mise install` and `mise exec -- ...` wrapping.
+- `sandbox.mise.install` defaults to `true`; `false` preserves repo-aware checkout but skips automatic `mise exec -- ...` wrapping.
 - `sandbox.mise.config_files` defaults to `.mise.toml`, `mise.toml`, `.tool-versions`, and `.mise/config.toml`.
 - Host matching supports:
   - exact host (`registry.npmjs.org`)
@@ -221,7 +221,7 @@ Meaning:
   - they resolve the local repository remote URL and committed `HEAD`
   - they materialize that checkout inside the sandbox before the command runs
   - they start commands in `repository.path`
-  - when the checkout contains `.mise.toml`, `mise.toml`, `.tool-versions`, or `.mise/config.toml`, they run `mise install` and execute the command through `mise exec -- ...` unless `sandbox.mise.enabled: false` or `sandbox.mise.install: false`
+  - when the checkout contains `.mise.toml`, `mise.toml`, `.tool-versions`, or `.mise/config.toml`, they execute the command through `mise exec -- ...` unless `sandbox.mise.enabled: false` or `sandbox.mise.install: false`
 - `cleanroom sandbox create` remains the generic low-level surface and does not
   infer repository state from the current working tree or read `cleanroom.yaml`.
 - Without `--from`, `cleanroom sandbox create` synthesizes a repo-agnostic

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -79,6 +79,8 @@ sandbox:
     install: true
     config_files:
       - .mise.toml
+      - mise.toml
+      - .tool-versions
       - .mise/config.toml
   network:
     default: deny
@@ -158,6 +160,9 @@ Meaning:
 - `repository.remote` defaults to `origin`.
 - `repository.path` defaults to `/workspace` and must be an absolute guest path.
 - `repository.submodules` defaults to `false`.
+- `sandbox.mise.enabled` defaults to `true`; `false` disables Cleanroom-managed `mise` detection and install wrapping.
+- `sandbox.mise.install` defaults to `true`; `false` preserves repo-aware checkout but skips automatic `mise install` and `mise exec -- ...` wrapping.
+- `sandbox.mise.config_files` defaults to `.mise.toml`, `mise.toml`, `.tool-versions`, and `.mise/config.toml`.
 - Host matching supports:
   - exact host (`registry.npmjs.org`)
   - wildcard subdomains (`*.example.com`)

--- a/internal/cli/repository_test.go
+++ b/internal/cli/repository_test.go
@@ -402,7 +402,7 @@ func TestExecCommandRunsInsideRepositoryPathForNewSandbox(t *testing.T) {
 		t.Fatalf("expected bootstrap + user execution, got %d execution(s)", len(commands))
 	}
 	joined := strings.Join(commands[1], " ")
-	if !strings.Contains(joined, "cd '/workspace' && exec 'echo' 'ok'") {
+	if !repositoryWrappedCommandContains(joined, `exec 'echo' 'ok'`) {
 		t.Fatalf("expected user command to run inside /workspace, got %q", joined)
 	}
 }
@@ -478,7 +478,7 @@ func TestExecCommandRunsInsideRepositoryPathWhenReusingSandboxID(t *testing.T) {
 		t.Fatalf("expected bootstrap + reused sandbox execution, got %d execution(s)", len(commands))
 	}
 	joined := strings.Join(commands[1], " ")
-	if !strings.Contains(joined, "cd '/workspace' && exec 'echo' 'ok'") {
+	if !repositoryWrappedCommandContains(joined, `exec 'echo' 'ok'`) {
 		t.Fatalf("expected reused sandbox command to run inside /workspace, got %q", joined)
 	}
 }
@@ -857,7 +857,7 @@ func TestExecCommandInlinesRepositoryBootstrapForNonPersistentBackend(t *testing
 	if !strings.Contains(joined, "clone --filter=blob:none --no-checkout") {
 		t.Fatalf("expected inlined repository clone, got %q", joined)
 	}
-	if !strings.Contains(joined, "cd '/workspace' && exec 'echo' 'ok'") {
+	if !repositoryWrappedCommandContains(joined, `exec 'echo' 'ok'`) {
 		t.Fatalf("expected inlined command to run inside /workspace, got %q", joined)
 	}
 }
@@ -923,7 +923,7 @@ func TestExecCommandInlinesExplicitRepositoryOverrideForNonPersistentBackend(t *
 	if !strings.Contains(joined, wantCommit) {
 		t.Fatalf("expected inlined command to include override commit %q, got %q", wantCommit, joined)
 	}
-	if !strings.Contains(joined, "cd '/workspace' && exec 'echo' 'ok'") {
+	if !repositoryWrappedCommandContains(joined, `exec 'echo' 'ok'`) {
 		t.Fatalf("expected inlined command to run inside /workspace, got %q", joined)
 	}
 }
@@ -1072,10 +1072,10 @@ func TestWrapCommandWithRepositoryBootstrapStripsCommandSeparator(t *testing.T) 
 		DestinationDir: "/workspace",
 	})
 	joined := strings.Join(command, " ")
-	if strings.Contains(joined, "exec -- ") {
+	if strings.Contains(joined, `'--'`) {
 		t.Fatalf("expected wrapped command to strip passthrough separator, got %q", joined)
 	}
-	if !strings.Contains(joined, "cd '/workspace' && exec 'sh' '-lc' 'pwd'") {
+	if !repositoryWrappedCommandContains(joined, `exec 'sh' '-lc' 'pwd'`) {
 		t.Fatalf("expected wrapped command to execute normalized command, got %q", joined)
 	}
 }
@@ -1093,4 +1093,10 @@ func TestWrapCommandWithRepositoryBootstrapDoesNotEmbedAuthHeaders(t *testing.T)
 	if strings.Contains(joined, "Authorization:") {
 		t.Fatalf("expected bootstrap command to avoid embedding authorization headers, got %q", joined)
 	}
+}
+
+func repositoryWrappedCommandContains(joined, execSnippet string) bool {
+	return strings.Contains(joined, "dest='/workspace'") &&
+		strings.Contains(joined, `cd "$dest"`) &&
+		strings.Contains(joined, execSnippet)
 }

--- a/internal/cli/repository_test.go
+++ b/internal/cli/repository_test.go
@@ -1070,7 +1070,7 @@ func TestWrapCommandWithRepositoryBootstrapStripsCommandSeparator(t *testing.T) 
 		RemoteURL:      "https://github.com/buildkite/cleanroom.git",
 		CommitSHA:      "0123456789abcdef0123456789abcdef01234567",
 		DestinationDir: "/workspace",
-	})
+	}, true)
 	joined := strings.Join(command, " ")
 	if strings.Contains(joined, `'--'`) {
 		t.Fatalf("expected wrapped command to strip passthrough separator, got %q", joined)
@@ -1085,7 +1085,7 @@ func TestWrapCommandWithRepositoryBootstrapDoesNotEmbedAuthHeaders(t *testing.T)
 		RemoteURL:      "https://github.com/buildkite/cleanroom.git",
 		CommitSHA:      "0123456789abcdef0123456789abcdef01234567",
 		DestinationDir: "/workspace",
-	})
+	}, true)
 	joined := strings.Join(command, " ")
 	if strings.Contains(joined, ".extraHeader") {
 		t.Fatalf("expected bootstrap command to avoid git extra headers, got %q", joined)

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -917,19 +917,21 @@ func (s *Service) CreateExecution(ctx context.Context, req *cleanroomv1.CreateEx
 		if err := validateRepositoryCheckoutForPolicy(sandboxPolicy, repository); err != nil {
 			return nil, err
 		}
+		autoMiseInstall := sandboxPolicy == nil || sandboxPolicy.MiseInstall
 		if persistentAdapter, ok := adapter.(backend.PersistentSandboxAdapter); ok {
 			if err := s.preparePersistentSandboxRepository(ctx, sandboxID, sandboxPolicy, firecrackerCfg, persistentAdapter, repository); err != nil {
 				return nil, err
 			}
-			command = repositorycheckout.WrapCommandInWorkdir(command, repository)
+			command = repositorycheckout.WrapCommandInWorkdir(command, repository, autoMiseInstall)
 		} else {
 			if err := s.ensureRepositoryMirrorContains(ctx, repository); err != nil {
 				return nil, fmt.Errorf("prepare repository checkout: %w", err)
 			}
-			command = repositorycheckout.WrapCommandWithBootstrap(command, repository)
+			command = repositorycheckout.WrapCommandWithBootstrap(command, repository, autoMiseInstall)
 		}
 	} else if sandboxRepository != nil {
-		command = repositorycheckout.WrapCommandInWorkdir(command, sandboxRepository)
+		autoMiseInstall := sandboxPolicy == nil || sandboxPolicy.MiseInstall
+		command = repositorycheckout.WrapCommandInWorkdir(command, sandboxRepository, autoMiseInstall)
 	}
 
 	s.mu.Lock()

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -1576,6 +1576,72 @@ func TestCreateExecutionSkipsBootstrapForMatchingPersistentRepository(t *testing
 	}
 }
 
+func TestCreateExecutionSkipsMiseBootstrapWhenPolicyDisablesInstall(t *testing.T) {
+	adapter := &stubAdapter{}
+	mirrors := &stubRepositoryMirrorStore{}
+	svc := newTestService(adapter)
+	svc.RepositoryMirrors = mirrors
+
+	var (
+		mu       sync.Mutex
+		commands [][]string
+	)
+	runCalled := make(chan struct{}, 4)
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+		mu.Lock()
+		commands = append(commands, append([]string(nil), req.Command...))
+		mu.Unlock()
+		select {
+		case runCalled <- struct{}{}:
+		default:
+		}
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+	}
+
+	policyProto := testRepositoryPolicy()
+	policyProto.MiseInstall = boolPtr(false)
+	createSandboxResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Policy:             policyProto,
+		RepositoryCheckout: testRepositoryCheckoutProto(),
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createSandboxResp.GetSandbox().GetSandboxId()
+	select {
+	case <-runCalled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for sandbox bootstrap")
+	}
+
+	_, err = svc.CreateExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
+		SandboxId:          sandboxID,
+		Command:            []string{"sh", "-lc", "pwd"},
+		RepositoryCheckout: testRepositoryCheckoutProto(),
+	})
+	if err != nil {
+		t.Fatalf("CreateExecution returned error: %v", err)
+	}
+	select {
+	case <-runCalled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for execution")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if got, want := len(commands), 2; got != want {
+		t.Fatalf("expected create bootstrap + execution, got %d command(s)", got)
+	}
+	joined := strings.Join(commands[1], " ")
+	if strings.Contains(joined, "mise install") {
+		t.Fatalf("expected policy-disabled execution to skip mise install, got %q", joined)
+	}
+	if strings.Contains(joined, "mise exec --") {
+		t.Fatalf("expected policy-disabled execution to skip mise exec wrapper, got %q", joined)
+	}
+}
+
 func TestCreateExecutionSkipsBootstrapForSnapshotBackedSandboxWithMatchingRepository(t *testing.T) {
 	adapter := &stubAdapter{
 		createSnapshotFn: func(_ context.Context, req backend.SnapshotRequest) (*backend.SnapshotResult, error) {
@@ -1687,6 +1753,10 @@ func repositoryWrappedCommandContains(joined, execSnippet string) bool {
 	return strings.Contains(joined, "dest='/workspace'") &&
 		strings.Contains(joined, `cd "$dest"`) &&
 		strings.Contains(joined, execSnippet)
+}
+
+func boolPtr(v bool) *bool {
+	return &v
 }
 
 func TestCreateSandboxRejectsRepositoryFileRemote(t *testing.T) {

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -1496,7 +1496,7 @@ func TestCreateExecutionWrapsRepositoryBootstrapInService(t *testing.T) {
 	if strings.Contains(joined, "git clone --filter=blob:none --no-checkout") {
 		t.Fatalf("expected execution command to run after bootstrap, got %q", joined)
 	}
-	if !strings.Contains(joined, "cd '/workspace' && exec 'sh' '-lc' 'pwd'") {
+	if !repositoryWrappedCommandContains(joined, `exec 'sh' '-lc' 'pwd'`) {
 		t.Fatalf("expected wrapped user command in repository workdir, got %q", joined)
 	}
 	if strings.Contains(bootstrap, "Authorization:") || strings.Contains(bootstrap, ".extraHeader") {
@@ -1568,7 +1568,7 @@ func TestCreateExecutionSkipsBootstrapForMatchingPersistentRepository(t *testing
 	if strings.Contains(joined, "git clone --filter=blob:none --no-checkout") {
 		t.Fatalf("expected matching repository execution to reuse existing checkout, got %q", joined)
 	}
-	if !strings.Contains(joined, "cd '/workspace' && exec 'sh' '-lc' 'pwd'") {
+	if !repositoryWrappedCommandContains(joined, `exec 'sh' '-lc' 'pwd'`) {
 		t.Fatalf("expected matching repository execution to run inside repository workdir, got %q", joined)
 	}
 	if got, want := mirrors.calls, 1; got != want {
@@ -1654,7 +1654,7 @@ func TestCreateExecutionSkipsBootstrapForSnapshotBackedSandboxWithMatchingReposi
 	if strings.Contains(joined, "git clone --filter=blob:none --no-checkout") {
 		t.Fatalf("expected snapshot-backed sandbox execution to reuse existing checkout, got %q", joined)
 	}
-	if !strings.Contains(joined, "cd '/workspace' && exec 'sh' '-lc' 'pwd'") {
+	if !repositoryWrappedCommandContains(joined, `exec 'sh' '-lc' 'pwd'`) {
 		t.Fatalf("expected snapshot-backed sandbox execution to run inside repository workdir, got %q", joined)
 	}
 	if got, want := mirrors.calls, 1; got != want {
@@ -1681,6 +1681,12 @@ func TestCreateSandboxRejectsRepositoryRemoteOutsidePolicy(t *testing.T) {
 	if got := adapter.provisionCalls; got != 0 {
 		t.Fatalf("expected no provision call on invalid repository remote, got %d", got)
 	}
+}
+
+func repositoryWrappedCommandContains(joined, execSnippet string) bool {
+	return strings.Contains(joined, "dest='/workspace'") &&
+		strings.Contains(joined, `cd "$dest"`) &&
+		strings.Contains(joined, execSnippet)
 }
 
 func TestCreateSandboxRejectsRepositoryFileRemote(t *testing.T) {

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -1634,9 +1634,6 @@ func TestCreateExecutionSkipsMiseBootstrapWhenPolicyDisablesInstall(t *testing.T
 		t.Fatalf("expected create bootstrap + execution, got %d command(s)", got)
 	}
 	joined := strings.Join(commands[1], " ")
-	if strings.Contains(joined, "mise install") {
-		t.Fatalf("expected policy-disabled execution to skip mise install, got %q", joined)
-	}
 	if strings.Contains(joined, "mise exec --") {
 		t.Fatalf("expected policy-disabled execution to skip mise exec wrapper, got %q", joined)
 	}

--- a/internal/gen/cleanroom/v1/control.pb.go
+++ b/internal/gen/cleanroom/v1/control.pb.go
@@ -548,6 +548,7 @@ type Policy struct {
 	Allow          []*PolicyAllowRule     `protobuf:"bytes,5,rep,name=allow,proto3" json:"allow,omitempty"`
 	Hash           string                 `protobuf:"bytes,6,opt,name=hash,proto3" json:"hash,omitempty"`
 	Services       *PolicyServices        `protobuf:"bytes,7,opt,name=services,proto3" json:"services,omitempty"`
+	MiseInstall    *bool                  `protobuf:"varint,8,opt,name=mise_install,json=miseInstall,proto3,oneof" json:"mise_install,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -629,6 +630,13 @@ func (x *Policy) GetServices() *PolicyServices {
 		return x.Services
 	}
 	return nil
+}
+
+func (x *Policy) GetMiseInstall() bool {
+	if x != nil && x.MiseInstall != nil {
+		return *x.MiseInstall
+	}
+	return false
 }
 
 type SandboxOptions struct {
@@ -3157,7 +3165,7 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\x13PolicyDockerService\x12\x1a\n" +
 	"\brequired\x18\x01 \x01(\bR\brequired\"K\n" +
 	"\x0ePolicyServices\x129\n" +
-	"\x06docker\x18\x01 \x01(\v2!.cleanroom.v1.PolicyDockerServiceR\x06docker\"\x8e\x02\n" +
+	"\x06docker\x18\x01 \x01(\v2!.cleanroom.v1.PolicyDockerServiceR\x06docker\"\xc7\x02\n" +
 	"\x06Policy\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\x05R\aversion\x12\x1b\n" +
 	"\timage_ref\x18\x02 \x01(\tR\bimageRef\x12!\n" +
@@ -3165,7 +3173,9 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\x0fnetwork_default\x18\x04 \x01(\tR\x0enetworkDefault\x123\n" +
 	"\x05allow\x18\x05 \x03(\v2\x1d.cleanroom.v1.PolicyAllowRuleR\x05allow\x12\x12\n" +
 	"\x04hash\x18\x06 \x01(\tR\x04hash\x128\n" +
-	"\bservices\x18\a \x01(\v2\x1c.cleanroom.v1.PolicyServicesR\bservices\"R\n" +
+	"\bservices\x18\a \x01(\v2\x1c.cleanroom.v1.PolicyServicesR\bservices\x12&\n" +
+	"\fmise_install\x18\b \x01(\bH\x00R\vmiseInstall\x88\x01\x01B\x0f\n" +
+	"\r_mise_install\"R\n" +
 	"\x0eSandboxOptions\x12%\n" +
 	"\x0elaunch_seconds\x18\x03 \x01(\x03R\rlaunchSecondsJ\x04\b\x02\x10\x03R\x13read_only_workspace\"\xe1\x01\n" +
 	"\x12RepositoryCheckout\x12\x1d\n" +
@@ -3562,6 +3572,7 @@ func file_proto_cleanroom_v1_control_proto_init() {
 	if File_proto_cleanroom_v1_control_proto != nil {
 		return
 	}
+	file_proto_cleanroom_v1_control_proto_msgTypes[5].OneofWrappers = []any{}
 	file_proto_cleanroom_v1_control_proto_msgTypes[8].OneofWrappers = []any{
 		(*CreateSandboxRequest_SnapshotId)(nil),
 	}

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -32,7 +32,8 @@ type rawPolicy struct {
 		Image struct {
 			Ref string `yaml:"ref"`
 		} `yaml:"image"`
-		Services rawServices `yaml:"services"`
+		Mise     rawMiseConfig `yaml:"mise"`
+		Services rawServices   `yaml:"services"`
 		Network  struct {
 			Default string         `yaml:"default"`
 			Allow   []rawAllowRule `yaml:"allow"`
@@ -46,6 +47,11 @@ type rawRepository struct {
 	Remote     string `yaml:"remote"`
 	Path       string `yaml:"path"`
 	Submodules bool   `yaml:"submodules"`
+}
+
+type rawMiseConfig struct {
+	Enabled *bool `yaml:"enabled"`
+	Install *bool `yaml:"install"`
 }
 
 type rawServices struct {
@@ -68,6 +74,7 @@ type CompiledPolicy struct {
 	Services       Services    `json:"services"`
 	NetworkDefault string      `json:"network_default"`
 	Allow          []AllowRule `json:"allow"`
+	MiseInstall    bool        `json:"mise_install"`
 	Hash           string      `json:"hash"`
 }
 
@@ -210,6 +217,7 @@ func Compile(raw rawPolicy) (*CompiledPolicy, error) {
 		},
 		NetworkDefault: networkDefault,
 		Allow:          allow,
+		MiseInstall:    normalizeMiseInstall(raw.Sandbox.Mise),
 	}
 
 	hash, err := hashPolicy(compiled)
@@ -350,6 +358,7 @@ func (p *CompiledPolicy) ToProto() *cleanroomv1.Policy {
 		},
 		NetworkDefault: p.NetworkDefault,
 		Allow:          allow,
+		MiseInstall:    boolPtr(p.MiseInstall),
 		Hash:           p.Hash,
 	}
 }
@@ -427,6 +436,7 @@ func FromProto(pb *cleanroomv1.Policy) (*CompiledPolicy, error) {
 		},
 		NetworkDefault: networkDefault,
 		Allow:          allow,
+		MiseInstall:    protoBoolOrDefault(pb.MiseInstall, true),
 	}
 
 	hash, err := hashPolicy(compiled)
@@ -439,6 +449,31 @@ func FromProto(pb *cleanroomv1.Policy) (*CompiledPolicy, error) {
 	}
 	compiled.Hash = hash
 	return compiled, nil
+}
+
+func normalizeMiseInstall(raw rawMiseConfig) bool {
+	enabled := true
+	if raw.Enabled != nil {
+		enabled = *raw.Enabled
+	}
+	if !enabled {
+		return false
+	}
+	if raw.Install != nil {
+		return *raw.Install
+	}
+	return true
+}
+
+func protoBoolOrDefault(v *bool, fallback bool) bool {
+	if v == nil {
+		return fallback
+	}
+	return *v
+}
+
+func boolPtr(v bool) *bool {
+	return &v
 }
 
 func hashPolicy(p *CompiledPolicy) (string, error) {

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -174,6 +174,49 @@ func TestCompileCapturesDockerServiceRequirement(t *testing.T) {
 	}
 }
 
+func TestCompileDefaultsMiseInstallEnabled(t *testing.T) {
+	t.Parallel()
+
+	raw := baseRawPolicy()
+	compiled, err := Compile(raw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if !compiled.MiseInstall {
+		t.Fatal("expected compiled policy to enable mise auto-install by default")
+	}
+}
+
+func TestCompileDisablesMiseInstallWhenSandboxMiseDisabled(t *testing.T) {
+	t.Parallel()
+
+	raw := baseRawPolicy()
+	raw.Sandbox.Mise.Enabled = testBoolPtr(false)
+
+	compiled, err := Compile(raw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if compiled.MiseInstall {
+		t.Fatal("expected compiled policy to disable mise auto-install when sandbox.mise.enabled=false")
+	}
+}
+
+func TestCompileDisablesMiseInstallWhenSandboxMiseInstallFalse(t *testing.T) {
+	t.Parallel()
+
+	raw := baseRawPolicy()
+	raw.Sandbox.Mise.Install = testBoolPtr(false)
+
+	compiled, err := Compile(raw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if compiled.MiseInstall {
+		t.Fatal("expected compiled policy to disable mise auto-install when sandbox.mise.install=false")
+	}
+}
+
 func TestLoadPropagatesPrimaryStatError(t *testing.T) {
 	t.Parallel()
 
@@ -396,4 +439,27 @@ func TestFromProtoAcceptsAllowDefault(t *testing.T) {
 	if !compiled.Allows("example.com", 443) {
 		t.Fatal("expected allow-default policy to allow arbitrary host:port")
 	}
+}
+
+func TestCompiledPolicyProtoRoundTripPreservesMiseInstall(t *testing.T) {
+	t.Parallel()
+
+	raw := baseRawPolicy()
+	raw.Sandbox.Mise.Install = testBoolPtr(false)
+	compiled, err := Compile(raw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+
+	roundTripped, err := FromProto(compiled.ToProto())
+	if err != nil {
+		t.Fatalf("FromProto returned error: %v", err)
+	}
+	if roundTripped.MiseInstall {
+		t.Fatal("expected proto round-trip to preserve mise install=false")
+	}
+}
+
+func testBoolPtr(v bool) *bool {
+	return &v
 }

--- a/internal/repositorycheckout/checkout.go
+++ b/internal/repositorycheckout/checkout.go
@@ -213,7 +213,6 @@ func workdirExecutionScript(command []string, checkout *Checkout, autoMiseInstal
 				`  if ! command -v mise >/dev/null 2>&1; then echo "repository declares mise config but 'mise' is not installed in sandbox image" >&2; exit 1; fi`,
 				`  export MISE_YES=1`,
 				`  export MISE_TRUSTED_CONFIG_PATHS="$dest${MISE_TRUSTED_CONFIG_PATHS:+:$MISE_TRUSTED_CONFIG_PATHS}"`,
-				`  mise install`,
 				`  exec mise exec -- `+execCommand,
 				`fi`,
 			)

--- a/internal/repositorycheckout/checkout.go
+++ b/internal/repositorycheckout/checkout.go
@@ -202,6 +202,7 @@ func bootstrapScript(checkout *Checkout) []string {
 func workdirExecutionScript(command []string, checkout *Checkout, autoMiseInstall bool) []string {
 	execCommand := shellJoin(command)
 	script := []string{
+		"set -eu",
 		"dest=" + shellQuote(checkout.DestinationDir),
 		`cd "$dest"`,
 	}

--- a/internal/repositorycheckout/checkout.go
+++ b/internal/repositorycheckout/checkout.go
@@ -17,6 +17,13 @@ type Checkout struct {
 	Branch         string
 }
 
+var miseConfigCandidates = []string{
+	".mise.toml",
+	"mise.toml",
+	".tool-versions",
+	".mise/config.toml",
+}
+
 func FromProto(proto *cleanroomv1.RepositoryCheckout) *Checkout {
 	if proto == nil {
 		return nil
@@ -145,7 +152,7 @@ func WrapCommandWithBootstrap(command []string, checkout *Checkout) []string {
 		return normalized
 	}
 	script := bootstrapScript(checkout)
-	script = append(script, fmt.Sprintf("cd %s && exec %s", shellQuote(checkout.DestinationDir), shellJoin(normalized)))
+	script = append(script, workdirExecutionScript(normalized, checkout)...)
 	return []string{"sh", "-lc", strings.Join(script, "\n")}
 }
 
@@ -154,8 +161,7 @@ func WrapCommandInWorkdir(command []string, checkout *Checkout) []string {
 	if checkout == nil || len(normalized) == 0 {
 		return normalized
 	}
-	script := fmt.Sprintf("cd %s && exec %s", shellQuote(checkout.DestinationDir), shellJoin(normalized))
-	return []string{"sh", "-lc", script}
+	return []string{"sh", "-lc", strings.Join(workdirExecutionScript(normalized, checkout), "\n")}
 }
 
 func NormalizeCommand(command []string) []string {
@@ -191,6 +197,35 @@ func bootstrapScript(checkout *Checkout) []string {
 		script = append(script, submoduleCommand)
 	}
 	return script
+}
+
+func workdirExecutionScript(command []string, checkout *Checkout) []string {
+	execCommand := shellJoin(command)
+	script := []string{
+		"dest=" + shellQuote(checkout.DestinationDir),
+		`cd "$dest"`,
+	}
+	if condition := miseConfigCondition(); condition != "" {
+		script = append(script,
+			"if "+condition+"; then",
+			`  if ! command -v mise >/dev/null 2>&1; then echo "repository declares mise config but 'mise' is not installed in sandbox image" >&2; exit 1; fi`,
+			`  export MISE_YES=1`,
+			`  export MISE_TRUSTED_CONFIG_PATHS="$dest${MISE_TRUSTED_CONFIG_PATHS:+:$MISE_TRUSTED_CONFIG_PATHS}"`,
+			`  mise install`,
+			`  exec mise exec -- `+execCommand,
+			`fi`,
+		)
+	}
+	script = append(script, `exec `+execCommand)
+	return script
+}
+
+func miseConfigCondition() string {
+	conditions := make([]string, 0, len(miseConfigCandidates))
+	for _, candidate := range miseConfigCandidates {
+		conditions = append(conditions, `[ -f `+shellQuote(candidate)+` ]`)
+	}
+	return strings.Join(conditions, " || ")
 }
 
 func shellJoin(args []string) string {

--- a/internal/repositorycheckout/checkout.go
+++ b/internal/repositorycheckout/checkout.go
@@ -146,22 +146,22 @@ func BuildBootstrapCommand(checkout *Checkout) []string {
 	return []string{"sh", "-lc", strings.Join(bootstrapScript(checkout), "\n")}
 }
 
-func WrapCommandWithBootstrap(command []string, checkout *Checkout) []string {
+func WrapCommandWithBootstrap(command []string, checkout *Checkout, autoMiseInstall bool) []string {
 	normalized := NormalizeCommand(command)
 	if checkout == nil || len(normalized) == 0 {
 		return normalized
 	}
 	script := bootstrapScript(checkout)
-	script = append(script, workdirExecutionScript(normalized, checkout)...)
+	script = append(script, workdirExecutionScript(normalized, checkout, autoMiseInstall)...)
 	return []string{"sh", "-lc", strings.Join(script, "\n")}
 }
 
-func WrapCommandInWorkdir(command []string, checkout *Checkout) []string {
+func WrapCommandInWorkdir(command []string, checkout *Checkout, autoMiseInstall bool) []string {
 	normalized := NormalizeCommand(command)
 	if checkout == nil || len(normalized) == 0 {
 		return normalized
 	}
-	return []string{"sh", "-lc", strings.Join(workdirExecutionScript(normalized, checkout), "\n")}
+	return []string{"sh", "-lc", strings.Join(workdirExecutionScript(normalized, checkout, autoMiseInstall), "\n")}
 }
 
 func NormalizeCommand(command []string) []string {
@@ -199,22 +199,24 @@ func bootstrapScript(checkout *Checkout) []string {
 	return script
 }
 
-func workdirExecutionScript(command []string, checkout *Checkout) []string {
+func workdirExecutionScript(command []string, checkout *Checkout, autoMiseInstall bool) []string {
 	execCommand := shellJoin(command)
 	script := []string{
 		"dest=" + shellQuote(checkout.DestinationDir),
 		`cd "$dest"`,
 	}
-	if condition := miseConfigCondition(); condition != "" {
-		script = append(script,
-			"if "+condition+"; then",
-			`  if ! command -v mise >/dev/null 2>&1; then echo "repository declares mise config but 'mise' is not installed in sandbox image" >&2; exit 1; fi`,
-			`  export MISE_YES=1`,
-			`  export MISE_TRUSTED_CONFIG_PATHS="$dest${MISE_TRUSTED_CONFIG_PATHS:+:$MISE_TRUSTED_CONFIG_PATHS}"`,
-			`  mise install`,
-			`  exec mise exec -- `+execCommand,
-			`fi`,
-		)
+	if autoMiseInstall {
+		if condition := miseConfigCondition(); condition != "" {
+			script = append(script,
+				"if "+condition+"; then",
+				`  if ! command -v mise >/dev/null 2>&1; then echo "repository declares mise config but 'mise' is not installed in sandbox image" >&2; exit 1; fi`,
+				`  export MISE_YES=1`,
+				`  export MISE_TRUSTED_CONFIG_PATHS="$dest${MISE_TRUSTED_CONFIG_PATHS:+:$MISE_TRUSTED_CONFIG_PATHS}"`,
+				`  mise install`,
+				`  exec mise exec -- `+execCommand,
+				`fi`,
+			)
+		}
 	}
 	script = append(script, `exec `+execCommand)
 	return script

--- a/internal/repositorycheckout/checkout_test.go
+++ b/internal/repositorycheckout/checkout_test.go
@@ -112,7 +112,7 @@ func TestValidateBootstrapRejectsMutableCommitRef(t *testing.T) {
 func TestWrapCommandInWorkdirQuotesDestinationAndArguments(t *testing.T) {
 	command := WrapCommandInWorkdir([]string{"printf", "%s", "it's alive"}, &Checkout{
 		DestinationDir: "/tmp/work tree",
-	})
+	}, true)
 
 	joined := strings.Join(command, " ")
 	if !strings.Contains(joined, "dest='/tmp/work tree'") {
@@ -136,7 +136,7 @@ func TestWrapCommandInWorkdirBootstrapsMiseWhenConfigPresent(t *testing.T) {
 	outputPath := filepath.Join(logDir, "env")
 	command := WrapCommandInWorkdir([]string{"sh", "-lc", "printf '%s\\n%s\\n%s\\n' \"$PWD\" \"${MISE_TRUSTED_CONFIG_PATHS:-}\" \"${MISE_YES:-}\" > " + shellQuote(outputPath)}, &Checkout{
 		DestinationDir: repoDir,
-	})
+	}, true)
 
 	cmd := exec.Command(command[0], command[1:]...)
 	cmd.Env = envWithout(os.Environ(), "MISE_TRUSTED_CONFIG_PATHS", "MISE_YES")
@@ -173,7 +173,7 @@ func TestWrapCommandInWorkdirSkipsMiseWithoutConfig(t *testing.T) {
 	outputPath := filepath.Join(logDir, "env")
 	command := WrapCommandInWorkdir([]string{"sh", "-lc", "printf '%s\\n%s\\n%s\\n' \"$PWD\" \"${MISE_TRUSTED_CONFIG_PATHS:-}\" \"${MISE_YES:-}\" > " + shellQuote(outputPath)}, &Checkout{
 		DestinationDir: repoDir,
-	})
+	}, true)
 
 	cmd := exec.Command(command[0], command[1:]...)
 	cmd.Env = envWithout(os.Environ(), "MISE_TRUSTED_CONFIG_PATHS", "MISE_YES")
@@ -213,7 +213,7 @@ func TestShellJoinQuotesSingleQuotes(t *testing.T) {
 }
 
 func TestWrapCommandWithBootstrapNormalizesPassthroughWithoutCheckout(t *testing.T) {
-	command := WrapCommandWithBootstrap([]string{"--", "echo", "ok"}, nil)
+	command := WrapCommandWithBootstrap([]string{"--", "echo", "ok"}, nil, true)
 	if got, want := strings.Join(command, " "), "echo ok"; got != want {
 		t.Fatalf("unexpected normalized command: got %q want %q", got, want)
 	}
@@ -224,7 +224,7 @@ func TestWrapCommandWithBootstrapIncludesMiseBootstrapLogic(t *testing.T) {
 		RemoteURL:      "https://github.com/buildkite/cleanroom.git",
 		CommitSHA:      "0123456789abcdef0123456789abcdef01234567",
 		DestinationDir: "/workspace",
-	})
+	}, true)
 
 	joined := strings.Join(command, " ")
 	if !strings.Contains(joined, "if [ -f '.mise.toml' ] || [ -f 'mise.toml' ] || [ -f '.tool-versions' ] || [ -f '.mise/config.toml' ]; then") {
@@ -235,6 +235,20 @@ func TestWrapCommandWithBootstrapIncludesMiseBootstrapLogic(t *testing.T) {
 	}
 	if !strings.Contains(joined, `exec mise exec -- 'sh' '-lc' 'pwd'`) {
 		t.Fatalf("expected bootstrap wrapper to exec through mise, got %q", joined)
+	}
+}
+
+func TestWrapCommandInWorkdirSkipsMiseBootstrapWhenDisabled(t *testing.T) {
+	command := WrapCommandInWorkdir([]string{"sh", "-lc", "pwd"}, &Checkout{
+		DestinationDir: "/workspace",
+	}, false)
+
+	joined := strings.Join(command, " ")
+	if strings.Contains(joined, "mise install") {
+		t.Fatalf("expected mise bootstrap to be skipped when disabled, got %q", joined)
+	}
+	if strings.Contains(joined, "mise exec --") {
+		t.Fatalf("expected mise exec wrapper to be skipped when disabled, got %q", joined)
 	}
 }
 

--- a/internal/repositorycheckout/checkout_test.go
+++ b/internal/repositorycheckout/checkout_test.go
@@ -230,8 +230,8 @@ func TestWrapCommandWithBootstrapIncludesMiseBootstrapLogic(t *testing.T) {
 	if !strings.Contains(joined, "if [ -f '.mise.toml' ] || [ -f 'mise.toml' ] || [ -f '.tool-versions' ] || [ -f '.mise/config.toml' ]; then") {
 		t.Fatalf("expected bootstrap wrapper to detect mise config files, got %q", joined)
 	}
-	if !strings.Contains(joined, `mise install`) {
-		t.Fatalf("expected bootstrap wrapper to run mise install, got %q", joined)
+	if strings.Contains(joined, `mise install`) {
+		t.Fatalf("expected bootstrap wrapper to rely on mise exec auto-install, got %q", joined)
 	}
 	if !strings.Contains(joined, `exec mise exec -- 'sh' '-lc' 'pwd'`) {
 		t.Fatalf("expected bootstrap wrapper to exec through mise, got %q", joined)
@@ -244,9 +244,6 @@ func TestWrapCommandInWorkdirSkipsMiseBootstrapWhenDisabled(t *testing.T) {
 	}, false)
 
 	joined := strings.Join(command, " ")
-	if strings.Contains(joined, "mise install") {
-		t.Fatalf("expected mise bootstrap to be skipped when disabled, got %q", joined)
-	}
 	if strings.Contains(joined, "mise exec --") {
 		t.Fatalf("expected mise exec wrapper to be skipped when disabled, got %q", joined)
 	}

--- a/internal/repositorycheckout/checkout_test.go
+++ b/internal/repositorycheckout/checkout_test.go
@@ -252,6 +252,22 @@ func TestWrapCommandInWorkdirSkipsMiseBootstrapWhenDisabled(t *testing.T) {
 	}
 }
 
+func TestWrapCommandInWorkdirFailsFastWhenWorkdirSetupFails(t *testing.T) {
+	outputPath := filepath.Join(t.TempDir(), "ran")
+	command := WrapCommandInWorkdir([]string{"sh", "-lc", "touch " + shellQuote(outputPath)}, &Checkout{
+		DestinationDir: filepath.Join(t.TempDir(), "missing"),
+	}, false)
+
+	cmd := exec.Command(command[0], command[1:]...)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected wrapped command to fail when cd fails; output=%s", string(out))
+	}
+	if _, statErr := os.Stat(outputPath); !os.IsNotExist(statErr) {
+		t.Fatalf("expected payload not to run when workdir setup fails, stat error=%v", statErr)
+	}
+}
+
 func envWithout(env []string, keys ...string) []string {
 	blocked := make(map[string]struct{}, len(keys))
 	for _, key := range keys {

--- a/internal/repositorycheckout/checkout_test.go
+++ b/internal/repositorycheckout/checkout_test.go
@@ -1,6 +1,9 @@
 package repositorycheckout
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -112,8 +115,83 @@ func TestWrapCommandInWorkdirQuotesDestinationAndArguments(t *testing.T) {
 	})
 
 	joined := strings.Join(command, " ")
-	if !strings.Contains(joined, "cd '/tmp/work tree' && exec 'printf' '%s' 'it'\"'\"'s alive'") {
+	if !strings.Contains(joined, "dest='/tmp/work tree'") {
+		t.Fatalf("expected wrapped workdir command to quote destination, got %q", joined)
+	}
+	if !strings.Contains(joined, `exec 'printf' '%s' 'it'"'"'s alive'`) {
 		t.Fatalf("expected wrapped workdir command to quote args, got %q", joined)
+	}
+}
+
+func TestWrapCommandInWorkdirBootstrapsMiseWhenConfigPresent(t *testing.T) {
+	if _, err := exec.LookPath("mise"); err != nil {
+		t.Skip("mise not installed")
+	}
+	repoDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repoDir, ".mise.toml"), []byte("# test config\n"), 0o644); err != nil {
+		t.Fatalf("write .mise.toml: %v", err)
+	}
+
+	logDir := t.TempDir()
+	outputPath := filepath.Join(logDir, "env")
+	command := WrapCommandInWorkdir([]string{"sh", "-lc", "printf '%s\\n%s\\n%s\\n' \"$PWD\" \"${MISE_TRUSTED_CONFIG_PATHS:-}\" \"${MISE_YES:-}\" > " + shellQuote(outputPath)}, &Checkout{
+		DestinationDir: repoDir,
+	})
+
+	cmd := exec.Command(command[0], command[1:]...)
+	cmd.Env = envWithout(os.Environ(), "MISE_TRUSTED_CONFIG_PATHS", "MISE_YES")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("wrapped command failed: %v\n%s", err, string(out))
+	}
+
+	outputBytes, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(outputBytes)), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 output lines, got %d: %q", len(lines), string(outputBytes))
+	}
+	if got, want := strings.TrimSpace(lines[0]), repoDir; got != want {
+		t.Fatalf("unexpected working directory: got %q want %q", got, want)
+	}
+	if got, want := strings.TrimSpace(lines[1]), repoDir; got != want {
+		t.Fatalf("unexpected trusted config paths: got %q want %q", got, want)
+	}
+	if got, want := strings.TrimSpace(lines[2]), "1"; got != want {
+		t.Fatalf("unexpected MISE_YES value: got %q want %q", got, want)
+	}
+}
+
+func TestWrapCommandInWorkdirSkipsMiseWithoutConfig(t *testing.T) {
+	if _, err := exec.LookPath("mise"); err != nil {
+		t.Skip("mise not installed")
+	}
+	repoDir := t.TempDir()
+	logDir := t.TempDir()
+	outputPath := filepath.Join(logDir, "env")
+	command := WrapCommandInWorkdir([]string{"sh", "-lc", "printf '%s\\n%s\\n%s\\n' \"$PWD\" \"${MISE_TRUSTED_CONFIG_PATHS:-}\" \"${MISE_YES:-}\" > " + shellQuote(outputPath)}, &Checkout{
+		DestinationDir: repoDir,
+	})
+
+	cmd := exec.Command(command[0], command[1:]...)
+	cmd.Env = envWithout(os.Environ(), "MISE_TRUSTED_CONFIG_PATHS", "MISE_YES")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("wrapped command failed: %v\n%s", err, string(out))
+	}
+
+	outputBytes, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(outputBytes)), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected only working-directory output without mise bootstrap, got %q", string(outputBytes))
+	}
+	if got, want := strings.TrimSpace(lines[0]), repoDir; got != want {
+		t.Fatalf("unexpected working directory: got %q want %q", got, want)
 	}
 }
 
@@ -139,4 +217,42 @@ func TestWrapCommandWithBootstrapNormalizesPassthroughWithoutCheckout(t *testing
 	if got, want := strings.Join(command, " "), "echo ok"; got != want {
 		t.Fatalf("unexpected normalized command: got %q want %q", got, want)
 	}
+}
+
+func TestWrapCommandWithBootstrapIncludesMiseBootstrapLogic(t *testing.T) {
+	command := WrapCommandWithBootstrap([]string{"sh", "-lc", "pwd"}, &Checkout{
+		RemoteURL:      "https://github.com/buildkite/cleanroom.git",
+		CommitSHA:      "0123456789abcdef0123456789abcdef01234567",
+		DestinationDir: "/workspace",
+	})
+
+	joined := strings.Join(command, " ")
+	if !strings.Contains(joined, "if [ -f '.mise.toml' ] || [ -f 'mise.toml' ] || [ -f '.tool-versions' ] || [ -f '.mise/config.toml' ]; then") {
+		t.Fatalf("expected bootstrap wrapper to detect mise config files, got %q", joined)
+	}
+	if !strings.Contains(joined, `mise install`) {
+		t.Fatalf("expected bootstrap wrapper to run mise install, got %q", joined)
+	}
+	if !strings.Contains(joined, `exec mise exec -- 'sh' '-lc' 'pwd'`) {
+		t.Fatalf("expected bootstrap wrapper to exec through mise, got %q", joined)
+	}
+}
+
+func envWithout(env []string, keys ...string) []string {
+	blocked := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		blocked[key] = struct{}{}
+	}
+
+	filtered := make([]string, 0, len(env))
+	for _, entry := range env {
+		key, _, ok := strings.Cut(entry, "=")
+		if ok {
+			if _, blockedKey := blocked[key]; blockedKey {
+				continue
+			}
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered
 }

--- a/proto/cleanroom/v1/control.proto
+++ b/proto/cleanroom/v1/control.proto
@@ -87,6 +87,7 @@ message Policy {
   repeated PolicyAllowRule allow = 5;
   string hash = 6;
   PolicyServices services = 7;
+  optional bool mise_install = 8;
 }
 
 message SandboxOptions {


### PR DESCRIPTION
## Summary
- auto-bootstrap repo-local `mise` toolchains for repo-aware commands
- add policy-controlled opt-out with `sandbox.mise.enabled` and `sandbox.mise.install`
- document the new repo-aware behavior and update wrapper expectation tests

## Details
Repo-aware executions now detect these files in the checked-out repository:
- `.mise.toml`
- `mise.toml`
- `.tool-versions`
- `.mise/config.toml`

When `mise` auto-install is enabled, Cleanroom now:
- exports `MISE_YES=1`
- exports `MISE_TRUSTED_CONFIG_PATHS`
- executes the workload through `mise exec -- ...`

`mise exec -- ...` prepares tools automatically from the repository config, so a separate `mise install` step is no longer needed.

This is implemented in the shared repository checkout wrapper, so it applies to both:
- persistent repo-aware executions
- inline repository bootstrap on non-persistent backends

## Policy behavior
Defaults:
- `sandbox.mise.enabled: true`
- `sandbox.mise.install: true`

Opt-out forms:
- `sandbox.mise.enabled: false`
- `sandbox.mise.install: false`

When either opt-out is set, Cleanroom still performs repo-aware checkout and starts commands in `repository.path`, but skips automatic `mise exec -- ...` wrapping.

## Verification
- `MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/auto-mise-bootstrap mise exec go -- go test ./internal/policy ./internal/repositorycheckout ./internal/controlservice ./internal/cli -count=1`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/auto-mise-bootstrap mise exec go -- go test ./...`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/auto-mise-bootstrap mise exec -- scripts/build-go.sh`
