### PR TITLE
feat: Pin latest mise in base images

### DIFF
--- a/images/Dockerfile.base-image
+++ b/images/Dockerfile.base-image
@@ -1,11 +1,15 @@
 FROM alpine:3.22
 
+ARG MISE_VERSION=v2026.4.5
+
 RUN apk add --no-cache \
   bash \
+  curl \
   git \
   openssh-client-default \
-  strace \
-  mise
+  strace
+
+RUN curl -fsSL https://mise.run | MISE_VERSION="${MISE_VERSION}" MISE_INSTALL_HELP=0 MISE_INSTALL_PATH=/usr/local/bin/mise sh
 
 # Cleanroom checks out repositories into /workspace, so trust repo-local mise
 # configs there and expose shims on PATH for guest commands.

--- a/images/Dockerfile.base-image-agents
+++ b/images/Dockerfile.base-image-agents
@@ -1,5 +1,6 @@
 FROM alpine:3.22
 
+ARG MISE_VERSION=v2026.4.5
 ARG CODEX_VERSION=0.106.0
 ARG CLAUDE_CODE_VERSION=2.1.63
 ARG GEMINI_CLI_VERSION=0.31.0
@@ -8,6 +9,7 @@ ARG GEMINI_CLI_VERSION=0.31.0
 RUN apk add --no-cache \
   bash \
   coreutils \
+  curl \
   g++ \
   git \
   make \
@@ -15,8 +17,9 @@ RUN apk add --no-cache \
   npm \
   openssh-client-default \
   python3 \
-  strace \
-  mise
+  strace
+
+RUN curl -fsSL https://mise.run | MISE_VERSION="${MISE_VERSION}" MISE_INSTALL_HELP=0 MISE_INSTALL_PATH=/usr/local/bin/mise sh
 
 # Keep repo-local mise configs under /workspace usable in agent containers too.
 RUN mise settings add trusted_config_paths /workspace

--- a/images/Dockerfile.base-image-docker
+++ b/images/Dockerfile.base-image-docker
@@ -1,12 +1,16 @@
 FROM alpine:3.22
 
+ARG MISE_VERSION=v2026.4.5
+
 RUN apk add --no-cache \
   bash \
+  curl \
   docker \
   git \
   openssh-client-default \
-  strace \
-  mise
+  strace
+
+RUN curl -fsSL https://mise.run | MISE_VERSION="${MISE_VERSION}" MISE_INSTALL_HELP=0 MISE_INSTALL_PATH=/usr/local/bin/mise sh
 
 # Cleanroom checks out repositories into /workspace, so trust repo-local mise
 # configs there and expose shims on PATH for guest commands.

--- a/images/dockerfiles_test.go
+++ b/images/dockerfiles_test.go
@@ -7,14 +7,20 @@ import (
 	"testing"
 )
 
-func TestPublishedBaseImagesInstallBash(t *testing.T) {
-	t.Parallel()
+const expectedMiseVersion = "v2026.4.5"
 
-	for _, relPath := range []string{
+func publishedBaseDockerfiles() []string {
+	return []string{
 		"Dockerfile.base-image",
 		"Dockerfile.base-image-docker",
 		"Dockerfile.base-image-agents",
-	} {
+	}
+}
+
+func TestPublishedBaseImagesInstallBash(t *testing.T) {
+	t.Parallel()
+
+	for _, relPath := range publishedBaseDockerfiles() {
 		relPath := relPath
 		t.Run(relPath, func(t *testing.T) {
 			t.Parallel()
@@ -33,11 +39,7 @@ func TestPublishedBaseImagesInstallBash(t *testing.T) {
 func TestPublishedBaseImagesInstallOpenSSHClientDefault(t *testing.T) {
 	t.Parallel()
 
-	for _, relPath := range []string{
-		"Dockerfile.base-image",
-		"Dockerfile.base-image-docker",
-		"Dockerfile.base-image-agents",
-	} {
+	for _, relPath := range publishedBaseDockerfiles() {
 		relPath := relPath
 		t.Run(relPath, func(t *testing.T) {
 			t.Parallel()
@@ -53,14 +55,44 @@ func TestPublishedBaseImagesInstallOpenSSHClientDefault(t *testing.T) {
 	}
 }
 
+func TestPublishedBaseImagesInstallPinnedMiseRelease(t *testing.T) {
+	t.Parallel()
+
+	for _, relPath := range publishedBaseDockerfiles() {
+		relPath := relPath
+		t.Run(relPath, func(t *testing.T) {
+			t.Parallel()
+
+			raw, err := os.ReadFile(filepath.Join(".", relPath))
+			if err != nil {
+				t.Fatalf("read %s: %v", relPath, err)
+			}
+
+			dockerfile := string(raw)
+			if !strings.Contains(dockerfile, "ARG MISE_VERSION="+expectedMiseVersion) {
+				t.Fatalf("%s does not pin mise to %s", relPath, expectedMiseVersion)
+			}
+			if !strings.Contains(dockerfile, "\n  curl") {
+				t.Fatalf("%s does not install curl for pinned mise bootstrap", relPath)
+			}
+			if !strings.Contains(dockerfile, "curl -fsSL https://mise.run |") {
+				t.Fatalf("%s does not install mise via the official installer", relPath)
+			}
+
+			for _, line := range strings.Split(dockerfile, "\n") {
+				trimmed := strings.TrimSpace(line)
+				if trimmed == "mise" || trimmed == "mise \\" {
+					t.Fatalf("%s still installs mise from apk", relPath)
+				}
+			}
+		})
+	}
+}
+
 func TestPublishedBaseImagesExposeMiseShimsOnPATH(t *testing.T) {
 	t.Parallel()
 
-	for _, relPath := range []string{
-		"Dockerfile.base-image",
-		"Dockerfile.base-image-docker",
-		"Dockerfile.base-image-agents",
-	} {
+	for _, relPath := range publishedBaseDockerfiles() {
 		relPath := relPath
 		t.Run(relPath, func(t *testing.T) {
 			t.Parallel()
@@ -79,11 +111,7 @@ func TestPublishedBaseImagesExposeMiseShimsOnPATH(t *testing.T) {
 func TestPublishedBaseImagesTrustWorkspaceMiseConfig(t *testing.T) {
 	t.Parallel()
 
-	for _, relPath := range []string{
-		"Dockerfile.base-image",
-		"Dockerfile.base-image-docker",
-		"Dockerfile.base-image-agents",
-	} {
+	for _, relPath := range publishedBaseDockerfiles() {
 		relPath := relPath
 		t.Run(relPath, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
## Summary
- pin `mise` in all published base image Dockerfiles to upstream release `v2026.4.5`
- install `mise` via the official installer with a pinned version instead of Alpine's `apk` package
- extend the Dockerfile tests to assert the pinned release install path stays in place

## Why
The base images were installing `mise` from Alpine packages, which can lag upstream releases. This change makes the published images install the latest upstream `mise` release available as of April 6, 2026 (`v2026.4.5`) while keeping builds reproducible with an explicit version pin.

## Validation
- `go test ./images`
- `docker build -f images/Dockerfile.base-image -t cleanroom-base:alpine .`
- `docker build -f images/Dockerfile.base-image-docker -t cleanroom-base:alpine-docker .`
- `docker build -f images/Dockerfile.base-image-agents -t cleanroom-base:alpine-agents .`
