### PR TITLE
fix: default darwin-vz networking to filehandle

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,15 +247,15 @@ sandbox:
 | Host OS | Backend | Status | Notes |
 |---------|---------|--------|-------|
 | Linux | `firecracker` | Full support | Persistent sandboxes, per-sandbox TAP + guest IP identity, file download, egress allowlist enforcement |
-| macOS | `darwin-vz` | Supported with gaps | Persistent sandboxes, `vmnet-shared` by default on macOS 26+, experimental custom subnet host reachability, no file download, no egress filtering, no TAP parity |
+| macOS | `darwin-vz` | Supported with gaps | Persistent sandboxes, `filehandle` by default with allowlist egress filtering, experimental `vmnet-shared` custom subnet host reachability, no file download, no TAP parity |
 
 Backend capabilities are exposed in `cleanroom doctor --json` under `capabilities`. See [isolation model](docs/isolation.md) for enforcement and persistence details.
 
 Network model differs significantly by backend:
 
 - `firecracker` creates a dedicated TAP interface and host/guest IP pair per sandbox, which enables host-side identity and firewall enforcement.
-- `darwin-vz` now defaults to `vmnet-shared` on supported macOS 26+ hosts. It is still NAT-backed for outbound access, but the helper owns an explicit vmnet logical network and can provide guest IP metadata.
-- `darwin-vz` still does not expose Firecracker-style TAP devices or host firewall enforcement semantics. Explicit `nat` remains available as a fallback mode.
+- `darwin-vz` now defaults to `filehandle` on macOS so deny-by-default policies can use the Cleanroom-owned gateway path for allowlisted egress.
+- `darwin-vz` still does not expose Firecracker-style TAP devices or host firewall enforcement semantics. Explicit `vmnet-shared` and `nat` remain available as compatibility and debugging fallbacks.
 - Current vmnet work and remaining gaps are tracked in [docs/plans/darwin-vz-vmnet-mode.md](docs/plans/darwin-vz-vmnet-mode.md).
 
 Select a backend explicitly:
@@ -366,7 +366,7 @@ backends:
     kernel_image: ""    # auto-managed when unset
     rootfs: ""          # derived from sandbox.image.ref when unset
     network:
-      mode: nat         # optional fallback; default is vmnet-shared on macOS 26+
+      mode: nat         # optional fallback; default is filehandle on macOS
     vcpus: 2
     memory_mib: 1024
     launch_seconds: 30
@@ -386,7 +386,7 @@ When `rootfs` is unset, Cleanroom derives one from `sandbox.image.ref` and injec
 
 **macOS ([darwin-vz](docs/backend/darwin-vz.md)):**
 - `cleanroom-darwin-vz` helper signed with `com.apple.security.virtualization` entitlement
-- `vmnet-shared` additionally needs `com.apple.developer.networking.vmnet` and a matching provisioning profile
+- optional `vmnet-shared` additionally needs `com.apple.developer.networking.vmnet` and a matching provisioning profile
 - explicit `nat` remains available as a compatibility fallback
 - `mkfs.ext4` and `debugfs` (`brew install e2fsprogs`)
 

--- a/docs/backend/darwin-vz.md
+++ b/docs/backend/darwin-vz.md
@@ -143,10 +143,10 @@ Experimental runtime config:
 - `backends.darwin-vz.network.subnet: 10.233.0.0/16` for custom vmnet shared-mode IPv4 ranges
 - `backends.darwin-vz.network.subnet: 10.233.0.0/24` for custom filehandle private ranges
 
-`vmnet-shared` is now the default only when the host supports it and the
-resolved helper declares the vmnet entitlement. Otherwise the implicit default
-falls back to `nat`. Use explicit `vmnet-shared` only when you want an
-unsupported host or unsigned helper to fail fast instead of degrading to `nat`.
+`filehandle` is now the default on macOS because it is the only `darwin-vz`
+network mode that matches Cleanroom's allowlisted egress semantics. Use
+explicit `vmnet-shared` when you want helper-managed shared networking and
+guest IP metadata, or explicit `nat` as a compatibility fallback.
 `vmnet-shared` accepts only RFC1918 IPv4 CIDRs. For `vmnet-shared`, the helper
 now mirrors the Apple `containerization` pattern: create the vmnet shared
 network in-helper, disable vmnet DHCP, derive the actual subnet from vmnet, and
@@ -172,12 +172,11 @@ In `nat` and `vmnet-shared` modes, `network.allowlist_egress` remains `false`.
 Git traffic for allowed HTTPS hosts now uses two different paths:
 
 - `filehandle`
-  - the guest talks to the shared host gateway through the filehandle gateway IP
+  - the guest rewrites allowed HTTPS Git remotes through the shared host gateway using the filehandle gateway IP
   - the guest does not need direct scope-token headers; the host bridge injects them
 - `nat` / `vmnet-shared`
-  - Git traffic uses the NAT host address
-  - `CLEANROOM_DARWIN_GATEWAY_HOST` can override the default host address for unusual setups
-  - gateway scoping still relies on helper-managed scope-token headers because these modes do not provide stable guest identity at the host firewall boundary
+  - Git traffic goes directly to the original remote; Cleanroom does not inject Git rewrite env in these modes
+  - this avoids rewriting bootstrap clones to a host gateway path that the guest cannot reliably reach outside `filehandle`
 
 ## Entitlements and Signing
 
@@ -185,7 +184,7 @@ Git traffic for allowed HTTPS hosts now uses two different paths:
 
 - `com.apple.security.virtualization`
 
-The default `vmnet-shared` path additionally requires:
+The optional `vmnet-shared` path additionally requires:
 
 - `com.apple.developer.networking.vmnet`
 - a matching provisioning profile for the helper identifier

--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -245,13 +245,14 @@ func (a *Adapter) Name() string {
 }
 
 func (a *Adapter) Capabilities() map[string]bool {
+	configuredMode := darwinVZConfiguredOrDefaultNetworkMode(a.ConfiguredNetworkMode)
 	allowlistSupported, _, _, err := allowlistSupportForConfig(backend.FirecrackerConfig{
-		DarwinVZNetworkMode: strings.TrimSpace(a.ConfiguredNetworkMode),
+		DarwinVZNetworkMode: configuredMode,
 	})
 	if err != nil {
 		allowlistSupported = false
 	}
-	dnsControlSupported := strings.TrimSpace(a.ConfiguredNetworkMode) == darwinVZNetworkModeFileHandle
+	dnsControlSupported := configuredMode == darwinVZNetworkModeFileHandle
 	return map[string]bool{
 		backend.CapabilityNetworkDefaultDeny:     true,
 		backend.CapabilityNetworkAllowlistEgress: allowlistSupported,
@@ -1097,11 +1098,19 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 	if cfg.LaunchSeconds <= 0 {
 		cfg.LaunchSeconds = 30
 	}
+	log.Debug("darwin-vz launch sandbox vm: resolving kernel",
+		"sandbox_id", sandboxID,
+		"configured_kernel_path", strings.TrimSpace(cfg.KernelImagePath),
+	)
 
 	kernelPath, _, err := a.resolveKernelPath(ctx, cfg.KernelImagePath)
 	if err != nil {
 		return nil, err
 	}
+	log.Debug("darwin-vz launch sandbox vm: resolving rootfs",
+		"sandbox_id", sandboxID,
+		"image_ref", strings.TrimSpace(compiled.ImageRef),
+	)
 	rootFSPath, imageRef, imageDigest, _, err := a.resolveRootFSPath(ctx, backend.ExecutionRequest{
 		Policy:            compiled,
 		FirecrackerConfig: cfg,
@@ -1137,6 +1146,12 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 	if err != nil {
 		return nil, err
 	}
+	log.Debug("darwin-vz launch sandbox vm: preparing writable rootfs",
+		"sandbox_id", sandboxID,
+		"rootfs_path", rootFSPath,
+		"image_ref", imageRef,
+		"image_digest", imageDigest,
+	)
 	baseVolume, err := driver.EnsureBaseVolume(ctx, volumestore.EnsureBaseVolumeRequest{
 		BaseID:     strings.TrimSuffix(filepath.Base(rootFSPath), filepath.Ext(rootFSPath)),
 		SourcePath: rootFSPath,
@@ -1179,6 +1194,10 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 	if err != nil {
 		return nil, fmt.Errorf("start darwin-vz helper: %w", err)
 	}
+	log.Debug("darwin-vz launch sandbox vm: helper session ready",
+		"sandbox_id", sandboxID,
+		"run_dir", runDir,
+	)
 	helperNeedsClose := true
 	defer func() {
 		if helperNeedsClose {
@@ -1186,6 +1205,11 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 		}
 	}()
 
+	log.Debug("darwin-vz launch sandbox vm: starting helper-managed vm",
+		"sandbox_id", sandboxID,
+		"network_mode", strings.TrimSpace(networkCfg.Mode),
+		"launch_seconds", cfg.LaunchSeconds,
+	)
 	startedVM, err := startDarwinVZHelperVM(ctx, helper, darwinVZVMStartRequest{
 		SandboxID:      sandboxID,
 		ConfigPath:     configPath,
@@ -1207,6 +1231,11 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 	if err != nil {
 		return nil, err
 	}
+	log.Debug("darwin-vz launch sandbox vm: vm started",
+		"sandbox_id", sandboxID,
+		"vm_id", startedVM.VMID,
+		"proxy_socket_path", startedVM.ProxySocketPath,
+	)
 	fileHandleGatewayNeedsClose := startedVM.FileHandleGW != nil
 	defer func() {
 		if fileHandleGatewayNeedsClose {

--- a/internal/backend/darwinvz/capabilities_test.go
+++ b/internal/backend/darwinvz/capabilities_test.go
@@ -7,19 +7,27 @@ import (
 	"github.com/buildkite/cleanroom/internal/backend"
 )
 
-func TestCapabilitiesDeclareGuestNetworkInterfaceWithoutAllowlistFilteringByDefault(t *testing.T) {
+func TestCapabilitiesMatchImplicitDefaultNetworkMode(t *testing.T) {
 	caps := New().Capabilities()
 
 	if !caps[backend.CapabilityNetworkDefaultDeny] {
 		t.Fatalf("expected %s=true", backend.CapabilityNetworkDefaultDeny)
 	}
-	if caps[backend.CapabilityNetworkAllowlistEgress] {
+	if runtime.GOOS == "darwin" {
+		if !caps[backend.CapabilityNetworkAllowlistEgress] {
+			t.Fatalf("expected %s=true on darwin", backend.CapabilityNetworkAllowlistEgress)
+		}
+	} else if caps[backend.CapabilityNetworkAllowlistEgress] {
 		t.Fatalf("expected %s=false", backend.CapabilityNetworkAllowlistEgress)
 	}
 	if !caps[backend.CapabilityNetworkGuestInterface] {
 		t.Fatalf("expected %s=true", backend.CapabilityNetworkGuestInterface)
 	}
-	if caps[backend.CapabilityDNSControlOrEquivalent] {
+	if runtime.GOOS == "darwin" {
+		if !caps[backend.CapabilityDNSControlOrEquivalent] {
+			t.Fatalf("expected %s=true on darwin", backend.CapabilityDNSControlOrEquivalent)
+		}
+	} else if caps[backend.CapabilityDNSControlOrEquivalent] {
 		t.Fatalf("expected %s=false", backend.CapabilityDNSControlOrEquivalent)
 	}
 }

--- a/internal/backend/darwinvz/gateway_env.go
+++ b/internal/backend/darwinvz/gateway_env.go
@@ -30,10 +30,10 @@ func resolveGuestGatewayHost(configuredHost, runtimeGatewayIP string) string {
 }
 
 func gatewayGitProxyEnvVars(compiled *policy.CompiledPolicy, networkMode, gatewayHost string, gatewayPort int, scopeToken string) []string {
-	if strings.EqualFold(strings.TrimSpace(networkMode), darwinVZNetworkModeFileHandle) {
-		return gatewayEnvVarsWithScope(compiled, gatewayHost, gatewayPort, "")
+	if !strings.EqualFold(strings.TrimSpace(networkMode), darwinVZNetworkModeFileHandle) {
+		return nil
 	}
-	return gatewayEnvVarsWithScope(compiled, gatewayHost, gatewayPort, scopeToken)
+	return gatewayEnvVarsWithScope(compiled, gatewayHost, gatewayPort, "")
 }
 
 func gatewayEnvVars(compiled *policy.CompiledPolicy, gatewayHost string, gatewayPort int, scopeToken string) []string {

--- a/internal/backend/darwinvz/gateway_env.go
+++ b/internal/backend/darwinvz/gateway_env.go
@@ -31,6 +31,9 @@ func resolveGuestGatewayHost(configuredHost, runtimeGatewayIP string) string {
 
 func gatewayGitProxyEnvVars(compiled *policy.CompiledPolicy, networkMode, gatewayHost string, gatewayPort int, scopeToken string) []string {
 	if !strings.EqualFold(strings.TrimSpace(networkMode), darwinVZNetworkModeFileHandle) {
+		// nat and vmnet-shared do not provide a reachable guest path to the
+		// Cleanroom git gateway, so rewriting HTTPS remotes through it breaks
+		// repository bootstrap instead of helping.
 		return nil
 	}
 	return gatewayEnvVarsWithScope(compiled, gatewayHost, gatewayPort, "")

--- a/internal/backend/darwinvz/gateway_env_test.go
+++ b/internal/backend/darwinvz/gateway_env_test.go
@@ -126,3 +126,23 @@ func TestGatewayGitProxyEnvVarsUsesFileHandleGatewayWithoutHeader(t *testing.T) 
 		t.Fatalf("expected github rewrite value, got %s", env[2])
 	}
 }
+
+func TestGatewayGitProxyEnvVarsSkipsUnsupportedNetworkModes(t *testing.T) {
+	t.Parallel()
+
+	p := &policy.CompiledPolicy{
+		Version:        1,
+		NetworkDefault: "deny",
+		Allow:          []policy.AllowRule{{Host: "github.com", Ports: []int{443}}},
+	}
+
+	for _, networkMode := range []string{darwinVZNetworkModeNAT, darwinVZNetworkModeVMNetShared} {
+		networkMode := networkMode
+		t.Run(networkMode, func(t *testing.T) {
+			t.Parallel()
+			if env := gatewayGitProxyEnvVars(p, networkMode, "192.168.64.1", 8170, "scope-token"); env != nil {
+				t.Fatalf("expected no git proxy env for unsupported mode %q, got %v", networkMode, env)
+			}
+		})
+	}
+}

--- a/internal/backend/darwinvz/network_modes.go
+++ b/internal/backend/darwinvz/network_modes.go
@@ -1,7 +1,17 @@
 package darwinvz
 
+import "strings"
+
 const (
 	darwinVZNetworkModeNAT         = "nat"
 	darwinVZNetworkModeFileHandle  = "filehandle"
 	darwinVZNetworkModeVMNetShared = "vmnet-shared"
 )
+
+func darwinVZConfiguredOrDefaultNetworkMode(mode string) string {
+	normalized := strings.ToLower(strings.TrimSpace(mode))
+	if normalized == "" {
+		return darwinVZNetworkModeFileHandle
+	}
+	return normalized
+}

--- a/internal/backend/darwinvz/network_vmnet.go
+++ b/internal/backend/darwinvz/network_vmnet.go
@@ -31,9 +31,7 @@ var darwinVZRFC1918Prefixes = []netip.Prefix{
 }
 
 var (
-	darwinVZVMNetSharedSupported                  = hostSupportsVMNetShared
-	resolveDarwinVZNetworkHelperPath              = resolveHelperBinaryPath
-	helperHasVMNetworkingEntitlementForNetworking = helperHasVMNetworkingEntitlement
+	darwinVZVMNetSharedSupported = hostSupportsVMNetShared
 )
 
 func hostSupportsVMNetShared() bool {
@@ -49,28 +47,8 @@ func hostSupportsVMNetShared() bool {
 	return major >= 26
 }
 
-func darwinVZDefaultNetworkMode() string {
-	if !darwinVZVMNetSharedSupported() {
-		return darwinVZNetworkModeNAT
-	}
-
-	helperPath, err := resolveDarwinVZNetworkHelperPath()
-	if err != nil {
-		return darwinVZNetworkModeNAT
-	}
-	hasVMNetEntitlement, err := helperHasVMNetworkingEntitlementForNetworking(helperPath)
-	if err != nil || !hasVMNetEntitlement {
-		return darwinVZNetworkModeNAT
-	}
-
-	return darwinVZNetworkModeVMNetShared
-}
-
 func resolveDarwinVZNetwork(cfg backend.FirecrackerConfig) (darwinVZNetwork, error) {
-	mode := strings.ToLower(strings.TrimSpace(cfg.DarwinVZNetworkMode))
-	if mode == "" {
-		mode = darwinVZDefaultNetworkMode()
-	}
+	mode := darwinVZConfiguredOrDefaultNetworkMode(cfg.DarwinVZNetworkMode)
 
 	subnet := strings.TrimSpace(cfg.DarwinVZNetworkSubnet)
 	externalInterface := strings.TrimSpace(cfg.DarwinVZNetworkExternalInterface)

--- a/internal/backend/darwinvz/network_vmnet_test.go
+++ b/internal/backend/darwinvz/network_vmnet_test.go
@@ -8,32 +8,26 @@ import (
 	"github.com/buildkite/cleanroom/internal/backend"
 )
 
-func TestResolveDarwinVZNetworkDefaultsToVMNetShared(t *testing.T) {
+func TestResolveDarwinVZNetworkDefaultsToFileHandle(t *testing.T) {
 	prevSupported := darwinVZVMNetSharedSupported
-	prevResolveHelper := resolveDarwinVZNetworkHelperPath
-	prevHasVMNetEntitlement := helperHasVMNetworkingEntitlementForNetworking
 	darwinVZVMNetSharedSupported = func() bool { return true }
-	resolveDarwinVZNetworkHelperPath = func() (string, error) { return "/tmp/helper", nil }
-	helperHasVMNetworkingEntitlementForNetworking = func(string) (bool, error) { return true, nil }
 	t.Cleanup(func() {
 		darwinVZVMNetSharedSupported = prevSupported
-		resolveDarwinVZNetworkHelperPath = prevResolveHelper
-		helperHasVMNetworkingEntitlementForNetworking = prevHasVMNetEntitlement
 	})
 
 	got, err := resolveDarwinVZNetwork(backend.FirecrackerConfig{})
 	if err != nil {
 		t.Fatalf("resolveDarwinVZNetwork returned error: %v", err)
 	}
-	if got.Mode != darwinVZNetworkModeVMNetShared {
-		t.Fatalf("unexpected network mode: got %q want %q", got.Mode, darwinVZNetworkModeVMNetShared)
+	if got.Mode != darwinVZNetworkModeFileHandle {
+		t.Fatalf("unexpected network mode: got %q want %q", got.Mode, darwinVZNetworkModeFileHandle)
 	}
-	if got.SubnetCIDR != "" {
-		t.Fatalf("expected default vmnet-shared mode to omit subnet, got %q", got.SubnetCIDR)
+	if got.SubnetCIDR != darwinVZFileHandleDefaultSubnetCIDR {
+		t.Fatalf("unexpected default file-handle subnet: got %q want %q", got.SubnetCIDR, darwinVZFileHandleDefaultSubnetCIDR)
 	}
 }
 
-func TestResolveDarwinVZNetworkDefaultsToNATWhenVMNetSharedUnsupported(t *testing.T) {
+func TestResolveDarwinVZNetworkDefaultsToFileHandleWhenVMNetSharedUnsupported(t *testing.T) {
 	prevSupported := darwinVZVMNetSharedSupported
 	darwinVZVMNetSharedSupported = func() bool { return false }
 	t.Cleanup(func() {
@@ -44,33 +38,11 @@ func TestResolveDarwinVZNetworkDefaultsToNATWhenVMNetSharedUnsupported(t *testin
 	if err != nil {
 		t.Fatalf("resolveDarwinVZNetwork returned error: %v", err)
 	}
-	if got.Mode != darwinVZNetworkModeNAT {
-		t.Fatalf("unexpected network mode: got %q want %q", got.Mode, darwinVZNetworkModeNAT)
+	if got.Mode != darwinVZNetworkModeFileHandle {
+		t.Fatalf("unexpected network mode: got %q want %q", got.Mode, darwinVZNetworkModeFileHandle)
 	}
-	if got.SubnetCIDR != "" {
-		t.Fatalf("expected default nat mode to omit subnet, got %q", got.SubnetCIDR)
-	}
-}
-
-func TestResolveDarwinVZNetworkDefaultsToNATWhenHelperLacksVMNetEntitlement(t *testing.T) {
-	prevSupported := darwinVZVMNetSharedSupported
-	prevResolveHelper := resolveDarwinVZNetworkHelperPath
-	prevHasVMNetEntitlement := helperHasVMNetworkingEntitlementForNetworking
-	darwinVZVMNetSharedSupported = func() bool { return true }
-	resolveDarwinVZNetworkHelperPath = func() (string, error) { return "/tmp/helper", nil }
-	helperHasVMNetworkingEntitlementForNetworking = func(string) (bool, error) { return false, nil }
-	t.Cleanup(func() {
-		darwinVZVMNetSharedSupported = prevSupported
-		resolveDarwinVZNetworkHelperPath = prevResolveHelper
-		helperHasVMNetworkingEntitlementForNetworking = prevHasVMNetEntitlement
-	})
-
-	got, err := resolveDarwinVZNetwork(backend.FirecrackerConfig{})
-	if err != nil {
-		t.Fatalf("resolveDarwinVZNetwork returned error: %v", err)
-	}
-	if got.Mode != darwinVZNetworkModeNAT {
-		t.Fatalf("unexpected network mode: got %q want %q", got.Mode, darwinVZNetworkModeNAT)
+	if got.SubnetCIDR != darwinVZFileHandleDefaultSubnetCIDR {
+		t.Fatalf("unexpected default file-handle subnet: got %q want %q", got.SubnetCIDR, darwinVZFileHandleDefaultSubnetCIDR)
 	}
 }
 

--- a/internal/backend/darwinvz/policy.go
+++ b/internal/backend/darwinvz/policy.go
@@ -7,8 +7,7 @@ import (
 	"github.com/buildkite/cleanroom/internal/backend"
 )
 
-const allowRulesIgnoredWarning = "darwin-vz ignores sandbox.network.allow entries; allowlist egress filtering is not implemented"
-const allowRulesRequireFilterError = "darwin-vz requires host-side egress filtering for sandbox.network.allow entries; enable the Cleanroom network filter"
+const allowRulesIgnoredWarning = "darwin-vz cannot enforce sandbox.network.allow entries in this network mode; use backends.darwin-vz.network.mode=filehandle for allowlist egress filtering"
 const guestNetworkUnavailableWarning = "darwin-vz guest networking is enabled without host-side egress filtering"
 const guestNetworkProtectedMessage = "darwin-vz guest networking is protected by host-side egress filtering"
 const guestNetworkProtectedByFileHandleMessage = "darwin-vz guest networking is protected by file-handle gateway filtering"
@@ -22,20 +21,18 @@ func evaluateNetworkPolicyForRun(networkDefault string, allowCount int, allowlis
 }
 
 func evaluateNetworkPolicy(networkDefault string, allowCount int, allowlistSupported, requireAllowlistEnforcement bool) (string, error) {
+	_ = requireAllowlistEnforcement
 	if strings.TrimSpace(networkDefault) != "deny" {
 		return "", fmt.Errorf("darwin-vz backend requires deny-by-default policy, got %q", networkDefault)
 	}
 	if allowCount > 0 && !allowlistSupported {
-		if requireAllowlistEnforcement {
-			return "", fmt.Errorf("%s", allowRulesRequireFilterError)
-		}
 		return allowRulesIgnoredWarning, nil
 	}
 	return "", nil
 }
 
 func allowlistSupportForConfig(cfg backend.FirecrackerConfig) (supported bool, detail, protectionMessage string, err error) {
-	if strings.EqualFold(strings.TrimSpace(cfg.DarwinVZNetworkMode), darwinVZNetworkModeFileHandle) {
+	if darwinVZConfiguredOrDefaultNetworkMode(cfg.DarwinVZNetworkMode) == darwinVZNetworkModeFileHandle {
 		return true, "", guestNetworkProtectedByFileHandleMessage, nil
 	}
 	return false, "", "", nil

--- a/internal/backend/darwinvz/policy_test.go
+++ b/internal/backend/darwinvz/policy_test.go
@@ -25,21 +25,18 @@ func TestEvaluateNetworkPolicyForDoctorWarnsWhenAllowEntriesPresentWithoutHostFi
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(warn, "ignores sandbox.network.allow") {
+	if !strings.Contains(warn, "network.mode=filehandle") {
 		t.Fatalf("unexpected warning: %q", warn)
 	}
 }
 
-func TestEvaluateNetworkPolicyForRunFailsWhenAllowEntriesPresentWithoutHostFilter(t *testing.T) {
+func TestEvaluateNetworkPolicyForRunWarnsWhenAllowEntriesPresentWithoutHostFilter(t *testing.T) {
 	warn, err := evaluateNetworkPolicyForRun("deny", 2, false)
-	if err == nil {
-		t.Fatal("expected error when allow entries are present without host filter")
-	}
-	if warn != "" {
-		t.Fatalf("expected no warning, got %q", warn)
-	}
-	if !strings.Contains(err.Error(), "requires host-side egress filtering") {
+	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(warn, "network.mode=filehandle") {
+		t.Fatalf("unexpected warning: %q", warn)
 	}
 }
 
@@ -74,6 +71,24 @@ func TestAllowlistSupportForConfigTreatsFileHandleModeAsSupported(t *testing.T) 
 	}
 	if !supported {
 		t.Fatal("expected filehandle mode to support allowlists")
+	}
+	if detail != "" {
+		t.Fatalf("expected empty detail, got %q", detail)
+	}
+	if got, want := protectionMessage, guestNetworkProtectedByFileHandleMessage; got != want {
+		t.Fatalf("unexpected protection message: got %q want %q", got, want)
+	}
+}
+
+func TestAllowlistSupportForConfigTreatsImplicitDefaultAsSupported(t *testing.T) {
+	t.Parallel()
+
+	supported, detail, protectionMessage, err := allowlistSupportForConfig(backend.FirecrackerConfig{})
+	if err != nil {
+		t.Fatalf("allowlistSupportForConfig returned error: %v", err)
+	}
+	if !supported {
+		t.Fatal("expected implicit darwin-vz default to support allowlists")
 	}
 	if detail != "" {
 		t.Fatalf("expected empty detail, got %q", detail)

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -226,13 +226,33 @@ func (s *Service) CreateSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 
 	now := s.clock().Now()
 	sandboxID := s.ids().NewSandboxID()
+	if s.Logger != nil {
+		s.Logger.Debug("create sandbox requested",
+			"sandbox_id", sandboxID,
+			"backend", backendName,
+			"policy_hash", compiled.Hash,
+			"repository_checkout", repository != nil,
+		)
+	}
 
+	if s.Logger != nil {
+		s.Logger.Debug("provisioning sandbox",
+			"sandbox_id", sandboxID,
+			"backend", backendName,
+		)
+	}
 	if err := adapter.ProvisionSandbox(ctx, backend.ProvisionRequest{
 		SandboxID:         sandboxID,
 		Policy:            compiled,
 		FirecrackerConfig: firecrackerCfg,
 	}); err != nil {
 		return nil, fmt.Errorf("provision sandbox: %w", err)
+	}
+	if s.Logger != nil {
+		s.Logger.Debug("sandbox provisioned",
+			"sandbox_id", sandboxID,
+			"backend", backendName,
+		)
 	}
 	if err := s.bootstrapRepositoryInPersistentSandbox(ctx, adapter, sandboxID, compiled, firecrackerCfg, repository); err != nil {
 		cleanupCtx, cancel := context.WithTimeout(context.Background(), s.timeouts().bootstrapCleanupTimeout)
@@ -1834,8 +1854,23 @@ func (s *Service) bootstrapRepositoryInPersistentSandbox(
 	if repository == nil {
 		return nil
 	}
+	if s.Logger != nil {
+		s.Logger.Debug("starting repository bootstrap",
+			"sandbox_id", sandboxID,
+			"remote_url", repository.RemoteURL,
+			"commit_sha", repository.CommitSHA,
+			"destination_dir", repository.DestinationDir,
+		)
+	}
 	if err := s.ensureRepositoryMirrorContains(ctx, repository); err != nil {
 		return err
+	}
+	if s.Logger != nil {
+		s.Logger.Debug("repository mirror ready",
+			"sandbox_id", sandboxID,
+			"remote_url", repository.RemoteURL,
+			"commit_sha", repository.CommitSHA,
+		)
 	}
 
 	var stdout bytes.Buffer
@@ -1855,6 +1890,19 @@ func (s *Service) bootstrapRepositoryInPersistentSandbox(
 			_, _ = stderr.Write(chunk)
 		},
 	})
+	if s.Logger != nil {
+		s.Logger.Debug("repository bootstrap execution finished",
+			"sandbox_id", sandboxID,
+			"execution_id", bootstrapExecutionID,
+			"exit_code", func() int {
+				if result == nil {
+					return -1
+				}
+				return result.ExitCode
+			}(),
+			"error", err,
+		)
+	}
 	if err != nil {
 		msg := strings.TrimSpace(stderr.String())
 		if msg == "" {


### PR DESCRIPTION
## Summary
- make darwin-vz resolve its implicit macOS network mode to filehandle so the default runtime behaviour matches Cleanroom's allowlist model
- keep the bootstrap git gateway rewrite scoped to filehandle mode and cover nat/vmnet-shared with regression tests
- carry over the bootstrap and VM launch debug logging that helped diagnose the repository bootstrap failure, and update the darwin-vz docs to match the new default

## Testing
- go test ./internal/backend/darwinvz
- go test ./internal/controlservice -run TestDoesNotExist