### PR TITLE
feat: add --no-mise flag to exec and console commands

### DIFF
--- a/internal/cli/console.go
+++ b/internal/cli/console.go
@@ -32,6 +32,7 @@ type ConsoleCommand struct {
 	PrintSandboxID bool     `name:"print-sandbox-id" help:"Print resolved sandbox_id=<id> to stderr before attaching"`
 
 	LaunchSeconds int64 `help:"VM boot/guest-agent readiness timeout in seconds"`
+	NoMise        bool  `name:"no-mise" help:"Disable automatic mise tool installation"`
 
 	Command []string `arg:"" passthrough:"partial" optional:"" help:"Command to run in the console (default: sh)"`
 }
@@ -167,6 +168,7 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) (runErr error) {
 		Options: &cleanroomv1.ExecutionOptions{
 			LaunchSeconds: c.LaunchSeconds,
 			Tty:           true,
+			DisableMise:   c.NoMise,
 		},
 	})
 	if err != nil {

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -26,6 +26,7 @@ type ExecCommand struct {
 	PrintSandboxID bool     `name:"print-sandbox-id" help:"Print resolved sandbox_id=<id> to stderr before streaming output"`
 
 	LaunchSeconds int64 `help:"VM boot/guest-agent readiness timeout in seconds"`
+	NoMise        bool  `name:"no-mise" help:"Disable automatic mise tool installation"`
 
 	Command []string `arg:"" passthrough:"partial" required:"" help:"Command to execute"`
 }
@@ -157,6 +158,7 @@ func (e *ExecCommand) Run(ctx *runtimeContext) (runErr error) {
 		RepositoryCheckout: repositoryCheckoutProto(repository),
 		Options: &cleanroomv1.ExecutionOptions{
 			LaunchSeconds: e.LaunchSeconds,
+			DisableMise:   e.NoMise,
 		},
 	})
 	if err != nil {

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -131,6 +131,7 @@ type snapshotMetadataStore interface {
 
 type executionOptions struct {
 	LaunchSeconds int64
+	DisableMise   bool
 }
 
 type executionSnapshot struct {
@@ -871,6 +872,7 @@ func (s *Service) CreateExecution(ctx context.Context, req *cleanroomv1.CreateEx
 	if opts := req.GetOptions(); opts != nil {
 		execOpts = executionOptions{
 			LaunchSeconds: opts.GetLaunchSeconds(),
+			DisableMise:   opts.GetDisableMise(),
 		}
 		tty = opts.GetTty()
 	}
@@ -931,13 +933,13 @@ func (s *Service) CreateExecution(ctx context.Context, req *cleanroomv1.CreateEx
 		if err := validateRepositoryCheckoutForPolicy(sandboxPolicy, repository); err != nil {
 			return nil, err
 		}
-		autoMiseInstall := sandboxPolicy == nil || sandboxPolicy.MiseInstall
+		autoMiseInstall := (sandboxPolicy == nil || sandboxPolicy.MiseInstall) && !execOpts.DisableMise
 		if err := s.preparePersistentSandboxRepository(ctx, sandboxID, sandboxPolicy, firecrackerCfg, adapter, repository); err != nil {
 			return nil, err
 		}
 		command = repositorycheckout.WrapCommandInWorkdir(command, repository, autoMiseInstall)
 	} else if sandboxRepository != nil {
-		autoMiseInstall := sandboxPolicy == nil || sandboxPolicy.MiseInstall
+		autoMiseInstall := (sandboxPolicy == nil || sandboxPolicy.MiseInstall) && !execOpts.DisableMise
 		command = repositorycheckout.WrapCommandInWorkdir(command, sandboxRepository, autoMiseInstall)
 	}
 

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -1616,6 +1616,70 @@ func TestCreateExecutionSkipsMiseBootstrapWhenPolicyDisablesInstall(t *testing.T
 	}
 }
 
+func TestCreateExecutionSkipsMiseWhenExecutionOptionDisablesMise(t *testing.T) {
+	adapter := &stubAdapter{}
+	mirrors := &stubRepositoryMirrorStore{}
+	svc := newTestService(adapter)
+	svc.RepositoryMirrors = mirrors
+
+	var (
+		mu       sync.Mutex
+		commands [][]string
+	)
+	runCalled := make(chan struct{}, 4)
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+		mu.Lock()
+		commands = append(commands, append([]string(nil), req.Command...))
+		mu.Unlock()
+		select {
+		case runCalled <- struct{}{}:
+		default:
+		}
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+	}
+
+	createSandboxResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Policy:             testRepositoryPolicy(),
+		RepositoryCheckout: testRepositoryCheckoutProto(),
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createSandboxResp.GetSandbox().GetSandboxId()
+	select {
+	case <-runCalled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for sandbox bootstrap")
+	}
+
+	_, err = svc.CreateExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
+		SandboxId:          sandboxID,
+		Command:            []string{"sh", "-lc", "pwd"},
+		RepositoryCheckout: testRepositoryCheckoutProto(),
+		Options: &cleanroomv1.ExecutionOptions{
+			DisableMise: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateExecution returned error: %v", err)
+	}
+	select {
+	case <-runCalled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for execution")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if got, want := len(commands), 2; got != want {
+		t.Fatalf("expected create bootstrap + execution, got %d command(s)", got)
+	}
+	joined := strings.Join(commands[1], " ")
+	if strings.Contains(joined, "mise exec --") {
+		t.Fatalf("expected disable_mise option to skip mise exec wrapper, got %q", joined)
+	}
+}
+
 func TestCreateExecutionSkipsBootstrapForSnapshotBackedSandboxWithMatchingRepository(t *testing.T) {
 	adapter := &stubAdapter{
 		createSnapshotFn: func(_ context.Context, req backend.SnapshotRequest) (*backend.SnapshotResult, error) {

--- a/internal/gen/cleanroom/v1/control.pb.go
+++ b/internal/gen/cleanroom/v1/control.pb.go
@@ -1925,6 +1925,7 @@ type ExecutionOptions struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	LaunchSeconds int64                  `protobuf:"varint,5,opt,name=launch_seconds,json=launchSeconds,proto3" json:"launch_seconds,omitempty"`
 	Tty           bool                   `protobuf:"varint,6,opt,name=tty,proto3" json:"tty,omitempty"`
+	DisableMise   bool                   `protobuf:"varint,8,opt,name=disable_mise,json=disableMise,proto3" json:"disable_mise,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1969,6 +1970,13 @@ func (x *ExecutionOptions) GetLaunchSeconds() int64 {
 func (x *ExecutionOptions) GetTty() bool {
 	if x != nil {
 		return x.Tty
+	}
+	return false
+}
+
+func (x *ExecutionOptions) GetDisableMise() bool {
+	if x != nil {
+		return x.DisableMise
 	}
 	return false
 }
@@ -3278,10 +3286,11 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\x03tty\x18\b \x01(\bR\x03tty\x12/\n" +
 	"\x04kind\x18\n" +
 	" \x01(\x0e2\x1b.cleanroom.v1.ExecutionKindR\x04kindJ\x04\b\t\x10\n" +
-	"R\x06run_id\"q\n" +
+	"R\x06run_id\"\x94\x01\n" +
 	"\x10ExecutionOptions\x12%\n" +
 	"\x0elaunch_seconds\x18\x05 \x01(\x03R\rlaunchSeconds\x12\x10\n" +
-	"\x03tty\x18\x06 \x01(\bR\x03ttyJ\x04\b\x02\x10\x03J\x04\b\a\x10\bR\x13read_only_workspaceR\x03cwd\"\xa1\x02\n" +
+	"\x03tty\x18\x06 \x01(\bR\x03tty\x12!\n" +
+	"\fdisable_mise\x18\b \x01(\bR\vdisableMiseJ\x04\b\x02\x10\x03J\x04\b\a\x10\bR\x13read_only_workspaceR\x03cwd\"\xa1\x02\n" +
 	"\x16CreateExecutionRequest\x12\x1d\n" +
 	"\n" +
 	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\x12\x18\n" +

--- a/proto/cleanroom/v1/control.proto
+++ b/proto/cleanroom/v1/control.proto
@@ -242,6 +242,7 @@ message ExecutionOptions {
   reserved "read_only_workspace", "cwd";
   int64 launch_seconds = 5;
   bool tty = 6;
+  bool disable_mise = 8;
 }
 
 message CreateExecutionRequest {


### PR DESCRIPTION
Add `disable_mise` field to `ExecutionOptions` proto and wire it through the control service to skip automatic mise tool installation when creating executions.

This is useful when running in sandboxes where mise would hang or fail trying to resolve tools over blocked network connections.

Both `exec` and `console` CLI commands accept `--no-mise` to opt out of the mise exec wrapper that is normally applied when a repository checkout contains mise configuration files.