### PR TITLE
feat: log blocked network connections in filehandle gateway

### DIFF
--- a/internal/backend/darwinvz/filehandle_gateway.go
+++ b/internal/backend/darwinvz/filehandle_gateway.go
@@ -21,6 +21,7 @@ import (
 	"github.com/buildkite/cleanroom/internal/dnsproxy"
 	"github.com/buildkite/cleanroom/internal/gateway"
 	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/charmbracelet/log"
 	gvtap "github.com/containers/gvisor-tap-vsock/pkg/tap"
 	"github.com/containers/gvisor-tap-vsock/pkg/tcpproxy"
 	gvtransport "github.com/containers/gvisor-tap-vsock/pkg/transport"
@@ -408,6 +409,16 @@ func newFileHandleVirtualNetwork(cfg fileHandleGatewayConfig, dnsUpstreamAddr st
 			Protocol:   dnsproxy.ProtocolTCP,
 		}
 		if dnsRuntime != nil && !dnsRuntime.AllowConnection(conn, time.Now()) {
+			logFields := []interface{}{
+				"sandbox_id", cfg.SandboxID,
+				"dest_ip", destIP.String(),
+				"dest_port", r.ID().LocalPort,
+				"source_ip", sourceIP.String(),
+			}
+			if names := dnsRuntime.NamesForAddress(cfg.SandboxID, sourceIP, destIP, time.Now()); len(names) > 0 {
+				logFields = append(logFields, "dest_host", strings.Join(names, ","))
+			}
+			log.Info("filehandle network connection blocked", logFields...)
 			r.Complete(true)
 			return
 		}

--- a/internal/dnsproxy/runtime.go
+++ b/internal/dnsproxy/runtime.go
@@ -364,6 +364,51 @@ func (r *Runtime) AllowConnection(conn Connection, now time.Time) bool {
 	return false
 }
 
+// NamesForAddress returns the DNS query names that resolved to the given
+// address within a sandbox scope. It is intended for diagnostic logging of
+// blocked connections.
+func (r *Runtime) NamesForAddress(sandboxID string, sourceIP, destIP netip.Addr, now time.Time) []string {
+	sourceIP = normalizeAddr(sourceIP)
+	destIP = normalizeAddr(destIP)
+	if !sourceIP.IsValid() || !destIP.IsValid() {
+		return nil
+	}
+	now = now.UTC()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	state, ok := r.sandboxes[strings.TrimSpace(sandboxID)]
+	if !ok {
+		return nil
+	}
+	scope, ok := state.scopes[sourceIP]
+	if !ok {
+		return nil
+	}
+
+	seen := map[string]struct{}{}
+	var names []string
+	for _, obs := range scope.observations {
+		if !obs.ExpiresAt.After(now) || obs.Address != destIP {
+			continue
+		}
+		name := obs.QueryName
+		if name == "" {
+			name = obs.Name
+		}
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		names = append(names, name)
+	}
+	return names
+}
+
 // ReleaseConnection removes an established flow from the runtime.
 func (r *Runtime) ReleaseConnection(conn Connection) {
 	conn.SourceIP = normalizeAddr(conn.SourceIP)


### PR DESCRIPTION
Add INFO-level logging when the filehandle gateway TCP forwarder blocks a connection that isn't permitted by the sandbox network policy.

Logs include `sandbox_id`, `dest_ip`, `dest_port`, `source_ip`, and `dest_host`.

The `dest_host` field is resolved via a new `NamesForAddress` method on `dnsproxy.Runtime` that reverse-looks up DNS query names from cached observations for the destination IP, making it easy to identify which hostname the guest was trying to reach (e.g. `mise-versions.jdx.dev`).