### PR TITLE
feat: warn on DNS queries for disallowed hosts in firecracker

### DIFF
--- a/internal/backend/darwinvz/filehandle_gateway.go
+++ b/internal/backend/darwinvz/filehandle_gateway.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/buildkite/cleanroom/internal/backend"
 	"github.com/buildkite/cleanroom/internal/dnsproxy"
 	"github.com/buildkite/cleanroom/internal/gateway"
 	"github.com/buildkite/cleanroom/internal/policy"
@@ -73,9 +74,7 @@ type fileHandleVirtualNetwork struct {
 	gatewayHTTPLn     net.Listener
 	gatewayHTTPServer *http.Server
 
-	warningMu      sync.RWMutex
-	warningHandler func(string)
-	warnedDests    map[string]struct{}
+	warnings backend.WarningEmitter
 }
 
 type fileHandleGateway struct {
@@ -240,10 +239,7 @@ func (g *fileHandleGateway) SetWarningHandler(handler func(string)) {
 	if g == nil || g.network == nil {
 		return
 	}
-	g.network.warningMu.Lock()
-	g.network.warningHandler = handler
-	g.network.warnedDests = make(map[string]struct{})
-	g.network.warningMu.Unlock()
+	g.network.warnings.SetHandler(handler)
 }
 
 func newFileHandleDNSRuntime(sandboxID string, compiled *policy.CompiledPolicy) (*dnsproxy.Runtime, error) {
@@ -440,18 +436,9 @@ func newFileHandleVirtualNetwork(cfg fileHandleGatewayConfig, dnsUpstreamAddr st
 				dest = strings.Join(names, ",")
 			}
 			msg := fmt.Sprintf("network connection blocked: %s:%d", dest, r.ID().LocalPort)
-			network.warningMu.Lock()
-			handler := network.warningHandler
-			_, alreadyWarned := network.warnedDests[msg]
-			if handler != nil && !alreadyWarned {
-				network.warnedDests[msg] = struct{}{}
-			}
-			network.warningMu.Unlock()
-			if handler != nil && !alreadyWarned {
-				handler(msg)
-			}
+			network.warnings.Emit(msg)
 			logFn := log.Info
-			if handler != nil {
+			if network.warnings.HasHandler() {
 				logFn = log.Debug
 			}
 			logFn("filehandle network connection blocked",

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -2340,7 +2340,7 @@ func setupHostNetworkWithTrustedDNSFactory(ctx context.Context, runID string, al
 		sandboxID:    runID,
 		hostIP:       hostAddr,
 		guestIP:      guestAddr,
-		policy:       trustedDNSPolicy(allow),
+		policy:       trustedDNSPolicy(allowAll, allow),
 		runBatch:     runBatchCommand,
 		tcpChainName: tcpChainName,
 		udpChainName: udpChainName,
@@ -2441,7 +2441,7 @@ func installForwardEstablishedRule(setupRun func(args ...string) error, directio
 	return []string{"iptables", "-D", "FORWARD", directionFlag, tapName, "-m", "state", "--state", "RELATED,ESTABLISHED", "-j", "ACCEPT"}, nil
 }
 
-func trustedDNSPolicy(allow []policy.AllowRule) *policy.CompiledPolicy {
+func trustedDNSPolicy(allowAll bool, allow []policy.AllowRule) *policy.CompiledPolicy {
 	copied := make([]policy.AllowRule, 0, len(allow))
 	for _, rule := range allow {
 		copied = append(copied, policy.AllowRule{
@@ -2449,9 +2449,13 @@ func trustedDNSPolicy(allow []policy.AllowRule) *policy.CompiledPolicy {
 			Ports: append([]int(nil), rule.Ports...),
 		})
 	}
+	networkDefault := "deny"
+	if allowAll {
+		networkDefault = "allow"
+	}
 	return &policy.CompiledPolicy{
 		Version:        1,
-		NetworkDefault: "deny",
+		NetworkDefault: networkDefault,
 		Allow:          copied,
 	}
 }

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -95,6 +96,8 @@ type sandboxInstance struct {
 	cleanupVolume  func()
 	vmRootFSPath   string
 	volumeRef      string
+
+	warnings backend.WarningEmitter
 }
 
 const runObservabilityFile = "execution-observability.json"
@@ -345,6 +348,11 @@ func (a *Adapter) RunInSandbox(ctx context.Context, req backend.ExecutionRequest
 		if err := os.MkdirAll(runDir, 0o755); err != nil {
 			return nil, fmt.Errorf("create run directory: %w", err)
 		}
+	}
+
+	if stream.OnWarning != nil {
+		instance.warnings.SetHandler(stream.OnWarning)
+		defer instance.warnings.SetHandler(nil)
 	}
 
 	guestResult, timing, err := a.executeInSandbox(ctx, instance, req.LaunchSeconds, req.Command, req.Env, req.TTY, stream)
@@ -989,7 +997,7 @@ func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream 
 	networkRunBatch := func(ctx context.Context, commands [][]string) error {
 		return runRootCommandBatch(ctx, req.FirecrackerConfig, commands)
 	}
-	networkCfg, cleanupNetwork, err := setupHostNetwork(ctx, req.ExecutionID, req.Policy.NetworkDefault == "allow", req.Policy.Allow, 0, networkRunCommand, networkRunBatch)
+	networkCfg, cleanupNetwork, err := setupHostNetwork(ctx, req.ExecutionID, req.Policy.NetworkDefault == "allow", req.Policy.Allow, 0, networkRunCommand, networkRunBatch, nil)
 	if err != nil {
 		return nil, fmt.Errorf("setup host network: %w", err)
 	}
@@ -1596,7 +1604,17 @@ func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID strin
 			gwPort = gateway.DefaultPort
 		}
 	}
-	networkCfg, cleanupNetwork, err := setupHostNetwork(ctx, sandboxID, compiled.NetworkDefault == "allow", compiled.Allow, gwPort, networkRunCommand, networkRunBatch)
+	// The DNS deny callback is routed through an atomic pointer to the sandbox
+	// instance which is created after network setup. The instance sets a
+	// concrete warning handler when RunInSandbox is called.
+	var instanceRef atomic.Pointer[sandboxInstance]
+	dnsOnDeny := func(_, queryName string) {
+		if inst := instanceRef.Load(); inst != nil {
+			inst.warnings.Emit(fmt.Sprintf("dns query for disallowed host: %s", queryName))
+		}
+	}
+
+	networkCfg, cleanupNetwork, err := setupHostNetwork(ctx, sandboxID, compiled.NetworkDefault == "allow", compiled.Allow, gwPort, networkRunCommand, networkRunBatch, dnsOnDeny)
 	if err != nil {
 		cleanupVolume()
 		return nil, fmt.Errorf("setup host network: %w", err)
@@ -1705,6 +1723,7 @@ func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID strin
 		vmRootFSPath:   vmRootFSPath,
 		volumeRef:      writableVolume.Ref,
 	}
+	instanceRef.Store(instance)
 	go func() {
 		err := fcCmd.Wait()
 		instance.setExited(err)
@@ -2124,22 +2143,22 @@ type interfaceLookupFunc func(name string) (*net.Interface, error)
 type rootCommandFunc func(ctx context.Context, args ...string) error
 type rootCommandBatchFunc func(ctx context.Context, commands [][]string) error
 
-func setupHostNetwork(ctx context.Context, runID string, allowAll bool, allow []policy.AllowRule, gatewayPort int, runCommand rootCommandFunc, runBatchCommand rootCommandBatchFunc) (hostNetworkConfig, func(), error) {
+func setupHostNetwork(ctx context.Context, runID string, allowAll bool, allow []policy.AllowRule, gatewayPort int, runCommand rootCommandFunc, runBatchCommand rootCommandBatchFunc, onDeny func(sandboxID, queryName string)) (hostNetworkConfig, func(), error) {
 	lookup := func(ctx context.Context, host string) ([]net.IP, error) {
 		return net.DefaultResolver.LookupIP(ctx, "ip4", host)
 	}
-	return setupHostNetworkWithDeps(ctx, runID, allowAll, allow, gatewayPort, lookup, runCommand, runBatchCommand)
+	return setupHostNetworkWithDeps(ctx, runID, allowAll, allow, gatewayPort, lookup, runCommand, runBatchCommand, onDeny)
 }
 
-func setupHostNetworkWithDeps(ctx context.Context, runID string, allowAll bool, allow []policy.AllowRule, gatewayPort int, lookup ipLookupFunc, runCommand rootCommandFunc, runBatchCommand rootCommandBatchFunc) (hostNetworkConfig, func(), error) {
-	return setupHostNetworkWithTrustedDNSFactory(ctx, runID, allowAll, allow, gatewayPort, lookup, net.InterfaceByName, runCommand, runBatchCommand, newTrustedDNSService)
+func setupHostNetworkWithDeps(ctx context.Context, runID string, allowAll bool, allow []policy.AllowRule, gatewayPort int, lookup ipLookupFunc, runCommand rootCommandFunc, runBatchCommand rootCommandBatchFunc, onDeny func(sandboxID, queryName string)) (hostNetworkConfig, func(), error) {
+	return setupHostNetworkWithTrustedDNSFactory(ctx, runID, allowAll, allow, gatewayPort, lookup, net.InterfaceByName, runCommand, runBatchCommand, newTrustedDNSService, onDeny)
 }
 
-func setupHostNetworkWithTapLookup(ctx context.Context, runID string, allowAll bool, allow []policy.AllowRule, gatewayPort int, lookup ipLookupFunc, interfaceByName interfaceLookupFunc, runCommand rootCommandFunc, runBatchCommand rootCommandBatchFunc) (hostNetworkConfig, func(), error) {
-	return setupHostNetworkWithTrustedDNSFactory(ctx, runID, allowAll, allow, gatewayPort, lookup, interfaceByName, runCommand, runBatchCommand, newTrustedDNSService)
+func setupHostNetworkWithTapLookup(ctx context.Context, runID string, allowAll bool, allow []policy.AllowRule, gatewayPort int, lookup ipLookupFunc, interfaceByName interfaceLookupFunc, runCommand rootCommandFunc, runBatchCommand rootCommandBatchFunc, onDeny func(sandboxID, queryName string)) (hostNetworkConfig, func(), error) {
+	return setupHostNetworkWithTrustedDNSFactory(ctx, runID, allowAll, allow, gatewayPort, lookup, interfaceByName, runCommand, runBatchCommand, newTrustedDNSService, onDeny)
 }
 
-func setupHostNetworkWithTrustedDNSFactory(ctx context.Context, runID string, allowAll bool, allow []policy.AllowRule, gatewayPort int, lookup ipLookupFunc, interfaceByName interfaceLookupFunc, runCommand rootCommandFunc, runBatchCommand rootCommandBatchFunc, factory trustedDNSFactory) (hostNetworkConfig, func(), error) {
+func setupHostNetworkWithTrustedDNSFactory(ctx context.Context, runID string, allowAll bool, allow []policy.AllowRule, gatewayPort int, lookup ipLookupFunc, interfaceByName interfaceLookupFunc, runCommand rootCommandFunc, runBatchCommand rootCommandBatchFunc, factory trustedDNSFactory, onDeny func(sandboxID, queryName string)) (hostNetworkConfig, func(), error) {
 	_ = lookup
 	if factory == nil {
 		factory = newTrustedDNSService
@@ -2325,6 +2344,7 @@ func setupHostNetworkWithTrustedDNSFactory(ctx context.Context, runID string, al
 		runBatch:     runBatchCommand,
 		tcpChainName: tcpChainName,
 		udpChainName: udpChainName,
+		onDeny:       onDeny,
 	})
 	if err != nil {
 		cleanup()

--- a/internal/backend/firecracker/network_test.go
+++ b/internal/backend/firecracker/network_test.go
@@ -118,7 +118,7 @@ func TestSetupHostNetworkWithTrustedDNSFactoryConfiguresDynamicRulesWithoutStati
 	}
 
 	reqCtx, cancel := context.WithCancel(context.Background())
-	cfg, cleanup, err := setupHostNetworkWithTrustedDNSFactory(reqCtx, "run-12345", false, []policy.AllowRule{{Host: "proxy.golang.org", Ports: []int{443}}}, 8170, lookup, net.InterfaceByName, run, runBatch, factory)
+	cfg, cleanup, err := setupHostNetworkWithTrustedDNSFactory(reqCtx, "run-12345", false, []policy.AllowRule{{Host: "proxy.golang.org", Ports: []int{443}}}, 8170, lookup, net.InterfaceByName, run, runBatch, factory, nil)
 	if err != nil {
 		t.Fatalf("setupHostNetworkWithTrustedDNSFactory: %v", err)
 	}
@@ -192,7 +192,7 @@ func TestSetupHostNetworkWithDepsAddsDenyDefaultAndCleanupIndependentContext(t *
 	}
 
 	reqCtx, cancel := context.WithCancel(context.Background())
-	cfg, cleanup, err := setupHostNetworkWithTrustedDNSFactory(reqCtx, "run-12345", false, []policy.AllowRule{{Host: "proxy.golang.org", Ports: []int{443}}}, 8170, lookup, net.InterfaceByName, run, runBatch, factory)
+	cfg, cleanup, err := setupHostNetworkWithTrustedDNSFactory(reqCtx, "run-12345", false, []policy.AllowRule{{Host: "proxy.golang.org", Ports: []int{443}}}, 8170, lookup, net.InterfaceByName, run, runBatch, factory, nil)
 	if err != nil {
 		t.Fatalf("setupHostNetworkWithTrustedDNSFactory: %v", err)
 	}
@@ -292,7 +292,7 @@ func TestSetupHostNetworkWithTapLookupDeletesStaleTapBeforeCreate(t *testing.T) 
 	factory := func(_ context.Context, _ trustedDNSConfig) (func(), error) {
 		return func() {}, nil
 	}
-	_, cleanup, err := setupHostNetworkWithTrustedDNSFactory(context.Background(), runID, false, []policy.AllowRule{{Host: "proxy.golang.org", Ports: []int{443}}}, 0, lookup, interfaceByName, run, nil, factory)
+	_, cleanup, err := setupHostNetworkWithTrustedDNSFactory(context.Background(), runID, false, []policy.AllowRule{{Host: "proxy.golang.org", Ports: []int{443}}}, 0, lookup, interfaceByName, run, nil, factory, nil)
 	if err != nil {
 		t.Fatalf("setupHostNetworkWithTrustedDNSFactory: %v", err)
 	}
@@ -331,7 +331,7 @@ func TestSetupHostNetworkWithDepsAddsAllowAllForwardRule(t *testing.T) {
 	factory := func(_ context.Context, _ trustedDNSConfig) (func(), error) {
 		return func() {}, nil
 	}
-	cfg, cleanup, err := setupHostNetworkWithTrustedDNSFactory(context.Background(), "run-allow-all", true, []policy.AllowRule{{Host: "stale.example.invalid", Ports: []int{443}}}, 0, lookup, net.InterfaceByName, run, runBatch, factory)
+	cfg, cleanup, err := setupHostNetworkWithTrustedDNSFactory(context.Background(), "run-allow-all", true, []policy.AllowRule{{Host: "stale.example.invalid", Ports: []int{443}}}, 0, lookup, net.InterfaceByName, run, runBatch, factory, nil)
 	if err != nil {
 		t.Fatalf("setupHostNetworkWithTrustedDNSFactory: %v", err)
 	}
@@ -372,7 +372,7 @@ func TestSetupHostNetworkWithTrustedDNSFactoryPreservesDirectIPAllowRules(t *tes
 		return func() {}, nil
 	}
 
-	cfg, cleanup, err := setupHostNetworkWithTrustedDNSFactory(context.Background(), "run-direct-ip", false, []policy.AllowRule{{Host: "203.0.113.10", Ports: []int{443}}}, 0, lookup, net.InterfaceByName, run, runBatch, factory)
+	cfg, cleanup, err := setupHostNetworkWithTrustedDNSFactory(context.Background(), "run-direct-ip", false, []policy.AllowRule{{Host: "203.0.113.10", Ports: []int{443}}}, 0, lookup, net.InterfaceByName, run, runBatch, factory, nil)
 	if err != nil {
 		t.Fatalf("setupHostNetworkWithTrustedDNSFactory: %v", err)
 	}

--- a/internal/backend/firecracker/network_test.go
+++ b/internal/backend/firecracker/network_test.go
@@ -313,6 +313,7 @@ func TestSetupHostNetworkWithDepsAddsAllowAllForwardRule(t *testing.T) {
 	t.Parallel()
 
 	var calls []string
+	var dnsCfg trustedDNSConfig
 	run := func(_ context.Context, args ...string) error {
 		calls = append(calls, strings.Join(args, " "))
 		return nil
@@ -328,7 +329,8 @@ func TestSetupHostNetworkWithDepsAddsAllowAllForwardRule(t *testing.T) {
 		return nil, nil
 	}
 
-	factory := func(_ context.Context, _ trustedDNSConfig) (func(), error) {
+	factory := func(_ context.Context, cfg trustedDNSConfig) (func(), error) {
+		dnsCfg = cfg
 		return func() {}, nil
 	}
 	cfg, cleanup, err := setupHostNetworkWithTrustedDNSFactory(context.Background(), "run-allow-all", true, []policy.AllowRule{{Host: "stale.example.invalid", Ports: []int{443}}}, 0, lookup, net.InterfaceByName, run, runBatch, factory, nil)
@@ -347,6 +349,12 @@ func TestSetupHostNetworkWithDepsAddsAllowAllForwardRule(t *testing.T) {
 	}
 	if cfg.PolicyResolveMS != 0 {
 		t.Fatalf("expected allow-all networking to skip policy resolution timing, got %d", cfg.PolicyResolveMS)
+	}
+	if dnsCfg.policy == nil {
+		t.Fatal("expected trusted dns policy to be configured")
+	}
+	if got, want := dnsCfg.policy.NetworkDefault, "allow"; got != want {
+		t.Fatalf("unexpected trusted dns network default: got %q want %q", got, want)
 	}
 }
 

--- a/internal/backend/firecracker/trusted_dns.go
+++ b/internal/backend/firecracker/trusted_dns.go
@@ -31,6 +31,7 @@ type trustedDNSConfig struct {
 	tcpChainName string
 	udpChainName string
 	now          func() time.Time
+	onDeny       func(sandboxID, queryName string)
 }
 
 type trustedDNSChainSyncer struct {
@@ -119,6 +120,7 @@ func newTrustedDNSService(_ context.Context, cfg trustedDNSConfig) (func(), erro
 			}
 			chainManager.Trigger()
 		},
+		OnDeny: cfg.onDeny,
 	})
 
 	listenAddr := net.JoinHostPort(cfg.hostIP.String(), strconv.Itoa(trustedDNSListenPort))

--- a/internal/backend/warning.go
+++ b/internal/backend/warning.go
@@ -1,0 +1,44 @@
+package backend
+
+import "sync"
+
+// WarningEmitter deduplicates and dispatches execution warnings. It is
+// safe for concurrent use and is shared between the firecracker and
+// darwin-vz backends.
+type WarningEmitter struct {
+	mu      sync.Mutex
+	handler func(string)
+	seen    map[string]struct{}
+}
+
+// SetHandler replaces the warning handler and resets the deduplication set.
+func (w *WarningEmitter) SetHandler(handler func(string)) {
+	w.mu.Lock()
+	w.handler = handler
+	w.seen = make(map[string]struct{})
+	w.mu.Unlock()
+}
+
+// HasHandler reports whether a warning handler is currently set.
+func (w *WarningEmitter) HasHandler() bool {
+	w.mu.Lock()
+	has := w.handler != nil
+	w.mu.Unlock()
+	return has
+}
+
+// Emit sends a warning message to the handler if one is set and the message
+// has not already been emitted during this handler's lifetime. The handler
+// is called under the lock to prevent races with SetHandler(nil).
+func (w *WarningEmitter) Emit(msg string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.handler == nil {
+		return
+	}
+	if _, alreadyWarned := w.seen[msg]; alreadyWarned {
+		return
+	}
+	w.seen[msg] = struct{}{}
+	w.handler(msg)
+}

--- a/internal/dnsproxy/forwarder.go
+++ b/internal/dnsproxy/forwarder.go
@@ -108,7 +108,7 @@ func (f *Forwarder) observeScopedResponse(remoteAddr net.Addr, resp *dns.Msg) {
 	if f.onDeny != nil {
 		for _, question := range resp.Question {
 			name := normalizeName(question.Name)
-			if name != "" && !f.runtime.queryAllowedByPolicy(sandboxID, sourceIP, name, now) {
+			if name != "" && !f.runtime.queryAllowedByPolicy(sandboxID, sourceIP, resp, name, now) {
 				f.onDeny(sandboxID, name)
 			}
 		}

--- a/internal/dnsproxy/forwarder.go
+++ b/internal/dnsproxy/forwarder.go
@@ -98,7 +98,8 @@ func (f *Forwarder) observeScopedResponse(remoteAddr net.Addr, resp *dns.Msg) {
 	if !ok {
 		return
 	}
-	if err := f.runtime.ObserveResponse(sandboxID, sourceIP, resp.Copy(), f.now().UTC()); err != nil {
+	now := f.now().UTC()
+	if err := f.runtime.ObserveResponse(sandboxID, sourceIP, resp.Copy(), now); err != nil {
 		return
 	}
 	if f.onObserve != nil {
@@ -107,7 +108,7 @@ func (f *Forwarder) observeScopedResponse(remoteAddr net.Addr, resp *dns.Msg) {
 	if f.onDeny != nil {
 		for _, question := range resp.Question {
 			name := normalizeName(question.Name)
-			if name != "" && !f.runtime.HostAllowedByPolicy(sandboxID, name) {
+			if name != "" && !f.runtime.queryAllowedByPolicy(sandboxID, sourceIP, name, now) {
 				f.onDeny(sandboxID, name)
 			}
 		}

--- a/internal/dnsproxy/forwarder.go
+++ b/internal/dnsproxy/forwarder.go
@@ -19,6 +19,10 @@ type ScopeResolver func(sourceIP netip.Addr) (sandboxID string, ok bool)
 // ObserveHook runs after a scoped response has been recorded in the runtime.
 type ObserveHook func(sandboxID string, sourceIP netip.Addr)
 
+// DenyHook runs when a DNS response is observed for a host that is not in the
+// sandbox's network allow policy.
+type DenyHook func(sandboxID, queryName string)
+
 // ForwarderConfig configures a DNS forwarding handler.
 type ForwarderConfig struct {
 	Runtime       *Runtime
@@ -27,6 +31,7 @@ type ForwarderConfig struct {
 	Client        DNSClient
 	Now           func() time.Time
 	OnObserve     ObserveHook
+	OnDeny        DenyHook
 }
 
 // Forwarder forwards DNS requests to an upstream resolver and records the
@@ -38,6 +43,7 @@ type Forwarder struct {
 	client        DNSClient
 	now           func() time.Time
 	onObserve     ObserveHook
+	onDeny        DenyHook
 }
 
 // NewForwarder creates a DNS forwarding handler backed by miekg/dns.
@@ -57,6 +63,7 @@ func NewForwarder(cfg ForwarderConfig) *Forwarder {
 		client:        client,
 		now:           now,
 		onObserve:     cfg.OnObserve,
+		onDeny:        cfg.OnDeny,
 	}
 }
 
@@ -96,6 +103,14 @@ func (f *Forwarder) observeScopedResponse(remoteAddr net.Addr, resp *dns.Msg) {
 	}
 	if f.onObserve != nil {
 		f.onObserve(sandboxID, sourceIP)
+	}
+	if f.onDeny != nil {
+		for _, question := range resp.Question {
+			name := normalizeName(question.Name)
+			if name != "" && !f.runtime.HostAllowedByPolicy(sandboxID, name) {
+				f.onDeny(sandboxID, name)
+			}
+		}
 	}
 }
 

--- a/internal/dnsproxy/runtime.go
+++ b/internal/dnsproxy/runtime.go
@@ -409,6 +409,19 @@ func (r *Runtime) NamesForAddress(sandboxID string, sourceIP, destIP netip.Addr,
 	return names
 }
 
+// HostAllowedByPolicy checks whether the given host is in the network allow
+// list for the sandbox.
+func (r *Runtime) HostAllowedByPolicy(sandboxID, host string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	state, ok := r.sandboxes[strings.TrimSpace(sandboxID)]
+	if !ok {
+		return false
+	}
+	return state.policy.HostAllowed(host)
+}
+
 // ReleaseConnection removes an established flow from the runtime.
 func (r *Runtime) ReleaseConnection(conn Connection) {
 	conn.SourceIP = normalizeAddr(conn.SourceIP)

--- a/internal/dnsproxy/runtime.go
+++ b/internal/dnsproxy/runtime.go
@@ -422,7 +422,7 @@ func (r *Runtime) HostAllowedByPolicy(sandboxID, host string) bool {
 	return state.policy.HostAllowed(host)
 }
 
-func (r *Runtime) queryAllowedByPolicy(sandboxID string, sourceIP netip.Addr, queryName string, now time.Time) bool {
+func (r *Runtime) queryAllowedByPolicy(sandboxID string, sourceIP netip.Addr, resp *dns.Msg, queryName string, now time.Time) bool {
 	sourceIP = normalizeAddr(sourceIP)
 	queryName = normalizeName(queryName)
 	if !sourceIP.IsValid() || queryName == "" {
@@ -431,32 +431,30 @@ func (r *Runtime) queryAllowedByPolicy(sandboxID string, sourceIP netip.Addr, qu
 	now = now.UTC()
 
 	r.mu.Lock()
-	defer r.mu.Unlock()
-
 	state, ok := r.sandboxes[strings.TrimSpace(sandboxID)]
-	if !ok || state.policy == nil {
+	var compiled *policy.CompiledPolicy
+	if ok {
+		compiled = state.policy
+	}
+	r.mu.Unlock()
+
+	if compiled == nil {
 		return false
 	}
-	if state.policy.HostAllowed(queryName) {
+	if compiled.HostAllowed(queryName) {
 		return true
 	}
 
-	scope, ok := state.scopes[sourceIP]
-	if !ok {
-		return false
-	}
-	scope.pruneExpired(now)
-
-	for _, observation := range scope.observations {
-		if !observation.ExpiresAt.After(now) || observation.QueryName != queryName {
+	for _, observation := range observationsFromResponse(sandboxID, sourceIP, resp, now) {
+		if observation.QueryName != queryName {
 			continue
 		}
 		for _, name := range observation.Names {
-			if state.policy.HostAllowed(name) {
+			if compiled.HostAllowed(name) {
 				return true
 			}
 		}
-		if observation.Name != "" && state.policy.HostAllowed(observation.Name) {
+		if observation.Name != "" && compiled.HostAllowed(observation.Name) {
 			return true
 		}
 	}

--- a/internal/dnsproxy/runtime.go
+++ b/internal/dnsproxy/runtime.go
@@ -422,6 +422,48 @@ func (r *Runtime) HostAllowedByPolicy(sandboxID, host string) bool {
 	return state.policy.HostAllowed(host)
 }
 
+func (r *Runtime) queryAllowedByPolicy(sandboxID string, sourceIP netip.Addr, queryName string, now time.Time) bool {
+	sourceIP = normalizeAddr(sourceIP)
+	queryName = normalizeName(queryName)
+	if !sourceIP.IsValid() || queryName == "" {
+		return false
+	}
+	now = now.UTC()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	state, ok := r.sandboxes[strings.TrimSpace(sandboxID)]
+	if !ok || state.policy == nil {
+		return false
+	}
+	if state.policy.HostAllowed(queryName) {
+		return true
+	}
+
+	scope, ok := state.scopes[sourceIP]
+	if !ok {
+		return false
+	}
+	scope.pruneExpired(now)
+
+	for _, observation := range scope.observations {
+		if !observation.ExpiresAt.After(now) || observation.QueryName != queryName {
+			continue
+		}
+		for _, name := range observation.Names {
+			if state.policy.HostAllowed(name) {
+				return true
+			}
+		}
+		if observation.Name != "" && state.policy.HostAllowed(observation.Name) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // ReleaseConnection removes an established flow from the runtime.
 func (r *Runtime) ReleaseConnection(conn Connection) {
 	conn.SourceIP = normalizeAddr(conn.SourceIP)

--- a/internal/dnsproxy/runtime_test.go
+++ b/internal/dnsproxy/runtime_test.go
@@ -765,6 +765,113 @@ func TestForwarderOnDenyCalledForDisallowedHost(t *testing.T) {
 	}
 }
 
+func TestForwarderOnDenySkipsAllowedCNAMEPath(t *testing.T) {
+	t.Parallel()
+
+	runtime := NewRuntime(RuntimeConfig{})
+	if err := runtime.RegisterSandbox("sandbox-1", testCompiledPolicy(
+		policy.AllowRule{Host: "cdn.example.com", Ports: []int{443}},
+	)); err != nil {
+		t.Fatalf("register sandbox: %v", err)
+	}
+
+	now := time.Date(2026, time.April, 10, 12, 0, 0, 0, time.UTC)
+	sourceIP := netip.MustParseAddr("10.0.0.2")
+
+	var denied []string
+	forwarder := NewForwarder(ForwarderConfig{
+		Runtime:      runtime,
+		UpstreamAddr: "127.0.0.1:5300",
+		Now:          func() time.Time { return now },
+		ScopeResolver: func(addr netip.Addr) (string, bool) {
+			if addr == sourceIP {
+				return "sandbox-1", true
+			}
+			return "", false
+		},
+		Client: exchangeFunc(func(msg *dns.Msg, _ string) (*dns.Msg, time.Duration, error) {
+			return testResponse(msg.Question[0].Name,
+				&dns.CNAME{
+					Hdr:    dns.RR_Header{Name: msg.Question[0].Name, Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 30},
+					Target: "cdn.example.com.",
+				},
+				&dns.A{
+					Hdr: dns.RR_Header{Name: "cdn.example.com.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 30},
+					A:   net.ParseIP("203.0.113.10"),
+				},
+			), 0, nil
+		}),
+		OnDeny: func(_, queryName string) {
+			denied = append(denied, queryName)
+		},
+	})
+
+	writer := &testResponseWriter{
+		remoteAddr: &net.UDPAddr{IP: net.ParseIP("10.0.0.2"), Port: 53000},
+		localAddr:  &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1053},
+	}
+
+	request := new(dns.Msg)
+	request.SetQuestion("service.example.com.", dns.TypeA)
+	forwarder.ServeDNS(writer, request)
+
+	if len(denied) != 0 {
+		t.Fatalf("expected no OnDeny for CNAME path resolved via allowed host, got %v", denied)
+	}
+}
+
+func TestForwarderOnDenySkippedWhenPolicyDefaultAllowsAll(t *testing.T) {
+	t.Parallel()
+
+	runtime := NewRuntime(RuntimeConfig{})
+	if err := runtime.RegisterSandbox("sandbox-1", &policy.CompiledPolicy{
+		Version:        1,
+		NetworkDefault: "allow",
+	}); err != nil {
+		t.Fatalf("register sandbox: %v", err)
+	}
+
+	now := time.Date(2026, time.April, 10, 12, 0, 0, 0, time.UTC)
+	sourceIP := netip.MustParseAddr("10.0.0.2")
+
+	var denied []string
+	forwarder := NewForwarder(ForwarderConfig{
+		Runtime:      runtime,
+		UpstreamAddr: "127.0.0.1:5300",
+		Now:          func() time.Time { return now },
+		ScopeResolver: func(addr netip.Addr) (string, bool) {
+			if addr == sourceIP {
+				return "sandbox-1", true
+			}
+			return "", false
+		},
+		Client: exchangeFunc(func(msg *dns.Msg, _ string) (*dns.Msg, time.Duration, error) {
+			return testResponse(msg.Question[0].Name,
+				&dns.A{
+					Hdr: dns.RR_Header{Name: msg.Question[0].Name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 30},
+					A:   net.ParseIP("93.184.216.34"),
+				},
+			), 0, nil
+		}),
+		OnDeny: func(_, queryName string) {
+			denied = append(denied, queryName)
+		},
+	})
+
+	writer := &testResponseWriter{
+		remoteAddr: &net.UDPAddr{IP: net.ParseIP("10.0.0.2"), Port: 53000},
+		localAddr:  &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1053},
+	}
+
+	request := new(dns.Msg)
+	request.SetQuestion("example.com.", dns.TypeA)
+	forwarder.ServeDNS(writer, request)
+
+	if len(denied) != 0 {
+		t.Fatalf("expected no OnDeny for allow-default policy, got %v", denied)
+	}
+}
+
 func TestHostAllowedByPolicyReturnsFalseForUnregisteredSandbox(t *testing.T) {
 	t.Parallel()
 

--- a/internal/dnsproxy/runtime_test.go
+++ b/internal/dnsproxy/runtime_test.go
@@ -703,6 +703,77 @@ func TestAddrFromNetAddrHandlesNilValues(t *testing.T) {
 	}
 }
 
+func TestForwarderOnDenyCalledForDisallowedHost(t *testing.T) {
+	t.Parallel()
+
+	runtime := NewRuntime(RuntimeConfig{})
+	if err := runtime.RegisterSandbox("sandbox-1", testCompiledPolicy(
+		policy.AllowRule{Host: "api.example.com", Ports: []int{443}},
+	)); err != nil {
+		t.Fatalf("register sandbox: %v", err)
+	}
+
+	now := time.Date(2026, time.April, 10, 12, 0, 0, 0, time.UTC)
+	sourceIP := netip.MustParseAddr("10.0.0.2")
+
+	var denied []string
+	forwarder := NewForwarder(ForwarderConfig{
+		Runtime:      runtime,
+		UpstreamAddr: "127.0.0.1:5300",
+		Now:          func() time.Time { return now },
+		ScopeResolver: func(addr netip.Addr) (string, bool) {
+			if addr == sourceIP {
+				return "sandbox-1", true
+			}
+			return "", false
+		},
+		Client: exchangeFunc(func(msg *dns.Msg, _ string) (*dns.Msg, time.Duration, error) {
+			return testResponse(msg.Question[0].Name,
+				&dns.A{
+					Hdr: dns.RR_Header{Name: msg.Question[0].Name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 30},
+					A:   net.ParseIP("93.184.216.34"),
+				},
+			), 0, nil
+		}),
+		OnDeny: func(_, queryName string) {
+			denied = append(denied, queryName)
+		},
+	})
+
+	writer := &testResponseWriter{
+		remoteAddr: &net.UDPAddr{IP: net.ParseIP("10.0.0.2"), Port: 53000},
+		localAddr:  &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1053},
+	}
+
+	// Query for a disallowed host should trigger OnDeny.
+	request := new(dns.Msg)
+	request.SetQuestion("example.com.", dns.TypeA)
+	forwarder.ServeDNS(writer, request)
+
+	if len(denied) != 1 || denied[0] != "example.com" {
+		t.Fatalf("expected OnDeny for example.com, got %v", denied)
+	}
+
+	// Query for an allowed host should not trigger OnDeny.
+	denied = nil
+	request2 := new(dns.Msg)
+	request2.SetQuestion("api.example.com.", dns.TypeA)
+	forwarder.ServeDNS(writer, request2)
+
+	if len(denied) != 0 {
+		t.Fatalf("expected no OnDeny for allowed host, got %v", denied)
+	}
+}
+
+func TestHostAllowedByPolicyReturnsFalseForUnregisteredSandbox(t *testing.T) {
+	t.Parallel()
+
+	runtime := NewRuntime(RuntimeConfig{})
+	if runtime.HostAllowedByPolicy("unknown", "example.com") {
+		t.Fatal("expected false for unregistered sandbox")
+	}
+}
+
 func testCompiledPolicy(allow ...policy.AllowRule) *policy.CompiledPolicy {
 	return &policy.CompiledPolicy{
 		Version:        1,

--- a/internal/dnsproxy/runtime_test.go
+++ b/internal/dnsproxy/runtime_test.go
@@ -872,6 +872,75 @@ func TestForwarderOnDenySkippedWhenPolicyDefaultAllowsAll(t *testing.T) {
 	}
 }
 
+func TestForwarderOnDenyUsesCurrentResponseInsteadOfHistoricalObservation(t *testing.T) {
+	t.Parallel()
+
+	runtime := NewRuntime(RuntimeConfig{})
+	if err := runtime.RegisterSandbox("sandbox-1", testCompiledPolicy(
+		policy.AllowRule{Host: "cdn.example.com", Ports: []int{443}},
+	)); err != nil {
+		t.Fatalf("register sandbox: %v", err)
+	}
+
+	now := time.Date(2026, time.April, 10, 12, 0, 0, 0, time.UTC)
+	sourceIP := netip.MustParseAddr("10.0.0.2")
+
+	call := 0
+	var denied []string
+	forwarder := NewForwarder(ForwarderConfig{
+		Runtime:      runtime,
+		UpstreamAddr: "127.0.0.1:5300",
+		Now:          func() time.Time { return now },
+		ScopeResolver: func(addr netip.Addr) (string, bool) {
+			if addr == sourceIP {
+				return "sandbox-1", true
+			}
+			return "", false
+		},
+		Client: exchangeFunc(func(msg *dns.Msg, _ string) (*dns.Msg, time.Duration, error) {
+			call++
+			if call == 1 {
+				return testResponse(msg.Question[0].Name,
+					&dns.CNAME{
+						Hdr:    dns.RR_Header{Name: msg.Question[0].Name, Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 30},
+						Target: "cdn.example.com.",
+					},
+					&dns.A{
+						Hdr: dns.RR_Header{Name: "cdn.example.com.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 30},
+						A:   net.ParseIP("203.0.113.10"),
+					},
+				), 0, nil
+			}
+			return testResponse(msg.Question[0].Name,
+				&dns.A{
+					Hdr: dns.RR_Header{Name: msg.Question[0].Name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 30},
+					A:   net.ParseIP("198.51.100.7"),
+				},
+			), 0, nil
+		}),
+		OnDeny: func(_, queryName string) {
+			denied = append(denied, queryName)
+		},
+	})
+
+	writer := &testResponseWriter{
+		remoteAddr: &net.UDPAddr{IP: net.ParseIP("10.0.0.2"), Port: 53000},
+		localAddr:  &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1053},
+	}
+
+	request := new(dns.Msg)
+	request.SetQuestion("service.example.com.", dns.TypeA)
+	forwarder.ServeDNS(writer, request)
+	if len(denied) != 0 {
+		t.Fatalf("expected first response to be allowed via CNAME path, got %v", denied)
+	}
+
+	forwarder.ServeDNS(writer, request)
+	if len(denied) != 1 || denied[0] != "service.example.com" {
+		t.Fatalf("expected second response to trigger OnDeny despite historical allowed observation, got %v", denied)
+	}
+}
+
 func TestHostAllowedByPolicyReturnsFalseForUnregisteredSandbox(t *testing.T) {
 	t.Parallel()
 

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -250,6 +250,23 @@ func (p *CompiledPolicy) Allows(host string, port int) bool {
 	return false
 }
 
+// HostAllowed returns true when at least one allow rule references the host,
+// regardless of port.
+func (p *CompiledPolicy) HostAllowed(host string) bool {
+	if p == nil {
+		return false
+	}
+	if p.NetworkDefault == "allow" {
+		return true
+	}
+	for _, rule := range p.Allow {
+		if rule.Host == host {
+			return true
+		}
+	}
+	return false
+}
+
 func (p *CompiledPolicy) RequiresDockerService() bool {
 	if p == nil {
 		return false


### PR DESCRIPTION
## Summary

Adds DNS-layer blocked connection detection to the firecracker backend. When a guest resolves a hostname that isn't in the network allow policy, a warning is streamed to the client immediately — before the connection times out against iptables DROP rules.

### Example output

```
$ cleanroom exec -- sh -lc 'wget http://example.com'
warning: dns query for disallowed host: example.com
wget: download timed out
```

Allowed hosts produce no warning.

### How it works

1. `policy.HostAllowed(host)` — checks if a host is in the allowlist for any port
2. `dnsproxy.Runtime.HostAllowedByPolicy()` — exposes policy check from runtime
3. `dnsproxy.ForwarderConfig.OnDeny` — callback fires when DNS resolves a disallowed host
4. Firecracker's trusted DNS service wires `OnDeny` through to `stream.OnWarning` via the sandbox instance

### Unification

Extracts the duplicated warning deduplication pattern from both firecracker (`sandboxInstance`) and darwin-vz (`fileHandleVirtualNetwork`) into a shared `backend.WarningEmitter` type.

### Scope

Covers hostname-based connections (99%+ of real traffic). Literal IP connections still rely on iptables DROP with no client-side warning — NFLOG-based detection for that case is a potential follow-up.

### Testing

- Unit tests for `OnDeny` callback and `HostAllowedByPolicy`
- Full test suite passes
- Tested E2E on prod firecracker instance via Tailscale