### PR TITLE
fix: Observe HTTPS and SVCB address hints

### DIFF
--- a/internal/dnsproxy/runtime.go
+++ b/internal/dnsproxy/runtime.go
@@ -658,17 +658,9 @@ func serviceBindingHintObservations(
 		return nil
 	}
 
-	serviceName := owner
-	if target != "" && target != "." {
-		serviceName = target
-	}
-
 	observations := make([]Observation, 0, len(paths))
 	for _, path := range paths {
 		names := append([]string(nil), path.names...)
-		if target != "" && target != "." && target != owner && !slices.Contains(names, target) {
-			names = append(names, target)
-		}
 
 		effectiveTTL := answerTTL
 		if len(path.names) > 1 {
@@ -683,9 +675,10 @@ func serviceBindingHintObservations(
 				SandboxID:  sandboxID,
 				SourceIP:   sourceIP,
 				QueryName:  path.query,
-				Name:       serviceName,
+				Name:       owner,
 				Type:       recordType,
 				Address:    addr,
+				Target:     target,
 				Names:      append([]string(nil), names...),
 				TTL:        effectiveTTL,
 				ObservedAt: now,

--- a/internal/dnsproxy/runtime.go
+++ b/internal/dnsproxy/runtime.go
@@ -28,6 +28,8 @@ const (
 	RecordTypeA     RecordType = "A"
 	RecordTypeAAAA  RecordType = "AAAA"
 	RecordTypeCNAME RecordType = "CNAME"
+	RecordTypeHTTPS RecordType = "HTTPS"
+	RecordTypeSVCB  RecordType = "SVCB"
 )
 
 // Protocol values describe the transport attached to a connection decision.
@@ -575,6 +577,32 @@ func observationsFromResponse(sandboxID string, sourceIP netip.Addr, msg *dns.Ms
 				addr = addr.Unmap()
 			}
 			observations = append(observations, addressObservations(sandboxID, sourceIP, questions, cnames, normalizeName(record.Hdr.Name), RecordTypeAAAA, addr, ttlSeconds(record.Hdr.Ttl), now)...)
+		case *dns.HTTPS:
+			observations = append(observations, serviceBindingHintObservations(
+				sandboxID,
+				sourceIP,
+				questions,
+				cnames,
+				normalizeName(record.Hdr.Name),
+				normalizeName(record.Target),
+				record.Value,
+				RecordTypeHTTPS,
+				ttlSeconds(record.Hdr.Ttl),
+				now,
+			)...)
+		case *dns.SVCB:
+			observations = append(observations, serviceBindingHintObservations(
+				sandboxID,
+				sourceIP,
+				questions,
+				cnames,
+				normalizeName(record.Hdr.Name),
+				normalizeName(record.Target),
+				record.Value,
+				RecordTypeSVCB,
+				ttlSeconds(record.Hdr.Ttl),
+				now,
+			)...)
 		}
 	}
 
@@ -606,6 +634,88 @@ func addressObservations(sandboxID string, sourceIP netip.Addr, questions []stri
 			ExpiresAt:  now.Add(effectiveTTL),
 		})
 	}
+	return observations
+}
+
+func serviceBindingHintObservations(
+	sandboxID string,
+	sourceIP netip.Addr,
+	questions []string,
+	cnames map[string]cnameRecord,
+	owner string,
+	target string,
+	values []dns.SVCBKeyValue,
+	recordType RecordType,
+	answerTTL time.Duration,
+	now time.Time,
+) []Observation {
+	if owner == "" || len(values) == 0 {
+		return nil
+	}
+
+	paths := queryPaths(owner, questions, cnames)
+	if len(paths) == 0 {
+		return nil
+	}
+
+	serviceName := owner
+	if target != "" && target != "." {
+		serviceName = target
+	}
+
+	observations := make([]Observation, 0, len(paths))
+	for _, path := range paths {
+		names := append([]string(nil), path.names...)
+		if target != "" && target != "." && target != owner && !slices.Contains(names, target) {
+			names = append(names, target)
+		}
+
+		effectiveTTL := answerTTL
+		if len(path.names) > 1 {
+			effectiveTTL = minTTL(answerTTL, path.cnameTTL)
+		}
+
+		appendObservation := func(addr netip.Addr) {
+			if !addr.IsValid() {
+				return
+			}
+			observations = append(observations, Observation{
+				SandboxID:  sandboxID,
+				SourceIP:   sourceIP,
+				QueryName:  path.query,
+				Name:       serviceName,
+				Type:       recordType,
+				Address:    addr,
+				Names:      append([]string(nil), names...),
+				TTL:        effectiveTTL,
+				ObservedAt: now,
+				ExpiresAt:  now.Add(effectiveTTL),
+			})
+		}
+
+		for _, value := range values {
+			switch hint := value.(type) {
+			case *dns.SVCBIPv4Hint:
+				for _, ip := range hint.Hint {
+					addr, ok := netip.AddrFromSlice(ip.To4())
+					if ok {
+						appendObservation(addr)
+					}
+				}
+			case *dns.SVCBIPv6Hint:
+				for _, ip := range hint.Hint {
+					addr, ok := netip.AddrFromSlice(ip)
+					if ok {
+						if addr.Is4In6() {
+							addr = addr.Unmap()
+						}
+						appendObservation(addr)
+					}
+				}
+			}
+		}
+	}
+
 	return observations
 }
 

--- a/internal/dnsproxy/runtime_test.go
+++ b/internal/dnsproxy/runtime_test.go
@@ -341,10 +341,13 @@ func TestRuntimeAllowsConnectionFromObservedHTTPSAliasIPv4Hint(t *testing.T) {
 	if len(observations) != 1 {
 		t.Fatalf("unexpected observation count: got %d want 1", len(observations))
 	}
-	if got, want := observations[0].Name, "yarnpkg.netlify.com"; got != want {
+	if got, want := observations[0].Name, "classic.yarnpkg.com"; got != want {
 		t.Fatalf("unexpected observation name: got %q want %q", got, want)
 	}
-	if got, want := observations[0].Names, []string{"classic.yarnpkg.com", "yarnpkg.netlify.com"}; !reflect.DeepEqual(got, want) {
+	if got, want := observations[0].Target, "yarnpkg.netlify.com"; got != want {
+		t.Fatalf("unexpected observation target: got %q want %q", got, want)
+	}
+	if got, want := observations[0].Names, []string{"classic.yarnpkg.com"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("unexpected observation names: got %v want %v", got, want)
 	}
 
@@ -361,6 +364,50 @@ func TestRuntimeAllowsConnectionFromObservedHTTPSAliasIPv4Hint(t *testing.T) {
 
 	if got, want := runtime.NamesForAddress("sandbox-1", sourceIP, destIP, now), []string{"classic.yarnpkg.com"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("unexpected names for address: got %v want %v", got, want)
+	}
+}
+
+func TestRuntimeRejectsObservedHTTPSAliasHintsForUnallowlistedOwner(t *testing.T) {
+	t.Parallel()
+
+	runtime := NewRuntime(RuntimeConfig{
+		MaxObservationsPerScope:  8,
+		MaxConnectionsPerSandbox: 8,
+	})
+	if err := runtime.RegisterSandbox("sandbox-1", testCompiledPolicy(
+		policy.AllowRule{Host: "yarnpkg.netlify.com", Ports: []int{443}},
+	)); err != nil {
+		t.Fatalf("register sandbox: %v", err)
+	}
+
+	now := time.Date(2026, time.April, 6, 10, 0, 0, 0, time.UTC)
+	sourceIP := netip.MustParseAddr("10.0.0.2")
+	destIP := netip.MustParseAddr("54.253.94.210")
+
+	if err := runtime.ObserveResponse("sandbox-1", sourceIP, testResponse("classic.yarnpkg.com.",
+		&dns.HTTPS{
+			SVCB: dns.SVCB{
+				Hdr:      dns.RR_Header{Name: "classic.yarnpkg.com.", Rrtype: dns.TypeHTTPS, Class: dns.ClassINET, Ttl: 30},
+				Priority: 0,
+				Target:   "yarnpkg.netlify.com.",
+				Value: []dns.SVCBKeyValue{
+					&dns.SVCBIPv4Hint{Hint: []net.IP{net.ParseIP("54.253.94.210").To4()}},
+				},
+			},
+		},
+	), now); err != nil {
+		t.Fatalf("observe response: %v", err)
+	}
+
+	if runtime.AllowConnection(Connection{
+		SandboxID:  "sandbox-1",
+		SourceIP:   sourceIP,
+		SourcePort: 41022,
+		DestIP:     destIP,
+		DestPort:   443,
+		Protocol:   ProtocolTCP,
+	}, now) {
+		t.Fatal("expected unallowlisted https owner to remain unauthorized")
 	}
 }
 

--- a/internal/dnsproxy/runtime_test.go
+++ b/internal/dnsproxy/runtime_test.go
@@ -243,6 +243,127 @@ func TestRuntimeTreatsZeroAnswerTTLAsImmediateExpiry(t *testing.T) {
 	}
 }
 
+func TestRuntimeAllowsConnectionFromObservedHTTPSIPv4Hint(t *testing.T) {
+	t.Parallel()
+
+	runtime := NewRuntime(RuntimeConfig{
+		MaxObservationsPerScope:  8,
+		MaxConnectionsPerSandbox: 8,
+	})
+	if err := runtime.RegisterSandbox("sandbox-1", testCompiledPolicy(
+		policy.AllowRule{Host: "github.com", Ports: []int{443}},
+	)); err != nil {
+		t.Fatalf("register sandbox: %v", err)
+	}
+
+	now := time.Date(2026, time.April, 6, 10, 0, 0, 0, time.UTC)
+	sourceIP := netip.MustParseAddr("10.0.0.2")
+	destIP := netip.MustParseAddr("4.237.22.38")
+
+	if err := runtime.ObserveResponse("sandbox-1", sourceIP, testResponse("github.com.",
+		&dns.HTTPS{
+			SVCB: dns.SVCB{
+				Hdr:      dns.RR_Header{Name: "github.com.", Rrtype: dns.TypeHTTPS, Class: dns.ClassINET, Ttl: 30},
+				Priority: 1,
+				Target:   ".",
+				Value: []dns.SVCBKeyValue{
+					&dns.SVCBIPv4Hint{Hint: []net.IP{net.ParseIP("4.237.22.38").To4()}},
+				},
+			},
+		},
+	), now); err != nil {
+		t.Fatalf("observe response: %v", err)
+	}
+
+	observations := runtime.Observations("sandbox-1", now)
+	if len(observations) != 1 {
+		t.Fatalf("unexpected observation count: got %d want 1", len(observations))
+	}
+	if got, want := observations[0].Type, RecordTypeHTTPS; got != want {
+		t.Fatalf("unexpected observation type: got %q want %q", got, want)
+	}
+	if got, want := observations[0].Address, destIP; got != want {
+		t.Fatalf("unexpected observation address: got %s want %s", got, want)
+	}
+	if got, want := observations[0].Names, []string{"github.com"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected observation names: got %v want %v", got, want)
+	}
+
+	if !runtime.AllowConnection(Connection{
+		SandboxID:  "sandbox-1",
+		SourceIP:   sourceIP,
+		SourcePort: 41020,
+		DestIP:     destIP,
+		DestPort:   443,
+		Protocol:   ProtocolTCP,
+	}, now) {
+		t.Fatal("expected https ipv4hint observation to authorize a connection")
+	}
+
+	if got, want := runtime.NamesForAddress("sandbox-1", sourceIP, destIP, now), []string{"github.com"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected names for address: got %v want %v", got, want)
+	}
+}
+
+func TestRuntimeAllowsConnectionFromObservedHTTPSAliasIPv4Hint(t *testing.T) {
+	t.Parallel()
+
+	runtime := NewRuntime(RuntimeConfig{
+		MaxObservationsPerScope:  8,
+		MaxConnectionsPerSandbox: 8,
+	})
+	if err := runtime.RegisterSandbox("sandbox-1", testCompiledPolicy(
+		policy.AllowRule{Host: "classic.yarnpkg.com", Ports: []int{443}},
+	)); err != nil {
+		t.Fatalf("register sandbox: %v", err)
+	}
+
+	now := time.Date(2026, time.April, 6, 10, 0, 0, 0, time.UTC)
+	sourceIP := netip.MustParseAddr("10.0.0.2")
+	destIP := netip.MustParseAddr("54.253.94.210")
+
+	if err := runtime.ObserveResponse("sandbox-1", sourceIP, testResponse("classic.yarnpkg.com.",
+		&dns.HTTPS{
+			SVCB: dns.SVCB{
+				Hdr:      dns.RR_Header{Name: "classic.yarnpkg.com.", Rrtype: dns.TypeHTTPS, Class: dns.ClassINET, Ttl: 30},
+				Priority: 0,
+				Target:   "yarnpkg.netlify.com.",
+				Value: []dns.SVCBKeyValue{
+					&dns.SVCBIPv4Hint{Hint: []net.IP{net.ParseIP("54.253.94.210").To4()}},
+				},
+			},
+		},
+	), now); err != nil {
+		t.Fatalf("observe response: %v", err)
+	}
+
+	observations := runtime.Observations("sandbox-1", now)
+	if len(observations) != 1 {
+		t.Fatalf("unexpected observation count: got %d want 1", len(observations))
+	}
+	if got, want := observations[0].Name, "yarnpkg.netlify.com"; got != want {
+		t.Fatalf("unexpected observation name: got %q want %q", got, want)
+	}
+	if got, want := observations[0].Names, []string{"classic.yarnpkg.com", "yarnpkg.netlify.com"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected observation names: got %v want %v", got, want)
+	}
+
+	if !runtime.AllowConnection(Connection{
+		SandboxID:  "sandbox-1",
+		SourceIP:   sourceIP,
+		SourcePort: 41021,
+		DestIP:     destIP,
+		DestPort:   443,
+		Protocol:   ProtocolTCP,
+	}, now) {
+		t.Fatal("expected https alias ipv4hint observation to authorize a connection")
+	}
+
+	if got, want := runtime.NamesForAddress("sandbox-1", sourceIP, destIP, now), []string{"classic.yarnpkg.com"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected names for address: got %v want %v", got, want)
+	}
+}
+
 func TestRuntimeIgnoresUnmatchedAnswerOwnersWhenQuestionPresent(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- observe `HTTPS` and `SVCB` answers alongside `A`/`AAAA`/`CNAME`
- turn `ipv4hint` and `ipv6hint` values into connection observations for the original queried host
- preserve alias-form service bindings by recording the target name while still authorizing the queried allowlisted host

## Testing
- `export MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/7e7f/cleanroom${MISE_TRUSTED_CONFIG_PATHS:+:$MISE_TRUSTED_CONFIG_PATHS}; mise exec -- go test ./internal/dnsproxy`