### PR TITLE
docs: Note DNS-derived allowlist limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Agent sandboxing tools are [proliferating fast](docs/research.md). Most focus on
 
 ## Why Cleanroom?
 
-**Deny-by-default egress.** A `cleanroom.yaml` policy file in your repo controls exactly which hosts the sandbox can reach. Everything else is blocked.
+**Deny-by-default egress.** A `cleanroom.yaml` policy file in your repo controls which hosts the sandbox may reach. Current hostname-based rules are enforced from observed DNS answers plus destination IP:port, so co-hosted services on the same IP:port are not distinguished. Everything else is blocked.
 
 **MicroVM isolation.** Each sandbox is a hardware-virtualized microVM (Firecracker on Linux, Virtualization.framework on macOS), not a container. A VM boundary is stronger than namespaces, seccomp, or gVisor -- a kernel vulnerability in the guest doesn't compromise the host.
 

--- a/docs/backend/darwin-vz.md
+++ b/docs/backend/darwin-vz.md
@@ -18,6 +18,7 @@ Implemented:
 - helper-managed VM lifecycle (`StartVM` / `StopVM` / `PauseVM` / `ResumeVM`)
 - `filehandle` network mode with a Cleanroom-owned guest gateway and stable guest IP
 - TCP allowlist egress filtering for `sandbox.network.allow` in `filehandle` mode
+- hostname-based allow rules currently use observed DNS answers plus destination IP:port, so co-hosted services on the same IP:port are not distinguished
 - guest access to the shared host gateway through the filehandle gateway IP
 - managed kernel fallback when `kernel_image` is unset or missing
 - rootfs derivation from `sandbox.image.ref` when `rootfs` is unset or missing
@@ -124,6 +125,7 @@ On macOS, cleanroom also probes common Homebrew `e2fsprogs` locations.
   - runs a Cleanroom-owned guest gateway on the gateway IP, typically `10.233.0.1`
   - serves guest DNS from that gateway IP
   - enforces `sandbox.network.allow` for TCP egress in the gateway
+  - authorizes hostname rules from observed DNS answers plus destination IP:port rather than HTTP `Host` or TLS SNI
   - exposes the shared host gateway service to the guest through the same gateway IP
 
 Compared to Firecracker:

--- a/docs/backend/firecracker.md
+++ b/docs/backend/firecracker.md
@@ -12,7 +12,7 @@ Firecracker is purpose-built for secure multi-tenant workloads with a minimal de
 
 - Linux-only local backend using Firecracker + KVM.
 - Enforce `CompiledPolicy` only (no runtime repo policy reload).
-- Deny-by-default egress with explicit host/port allowlist.
+- Deny-by-default egress with explicit allow rules.
 - Route package and git egress through `content-cache`.
 - Keep secret values out of guest env and policy files.
 
@@ -27,12 +27,16 @@ Firecracker networking is built around a dedicated per-sandbox TAP device on the
 - host-side iptables rules enforce default-deny egress, with established flows surviving DNS TTL expiry
 - gateway access is bound to the sandbox's TAP/IP identity rather than a helper-managed token
 
+Current hostname-based allow rules are enforced from observed DNS answers plus
+destination IP:port. Firecracker does not currently distinguish co-hosted
+services that share the same IP:port.
+
 This is materially different from the current `darwin-vz` backend, which uses helper-managed NAT networking and does not expose a host-visible per-sandbox guest IP. See [darwin-vz.md](darwin-vz.md) for the current macOS model.
 
 ## Implementation slices
 
 1. Slice A: minimal Firecracker runner -- create backend adapter package and run lifecycle. Boot VM, run command over vsock, collect exit code/stdout/stderr.
-2. Slice B: deterministic networking -- add TAP/subnet allocator + nftables setup/teardown. Enforce default deny and exact host/port allowlist (no registries yet).
+2. Slice B: deterministic networking -- add TAP/subnet allocator + nftables setup/teardown. Enforce default deny and host/port allowlist (no registries yet).
 3. Slice C: registry and git mediation -- start/attach `content-cache`. Rewrite package/git traffic through cache endpoint and emit deny reasons for bypass attempts.
 4. Slice D: secret proxy -- add tokenizer-style host-scoped injection path. Enforce `secret_scope_violation` and keep secret values out of guest-visible env/args.
 5. Slice E: conformance and hardening -- implement backend capability handshake. Add conformance suite from spec.md section 14 before backend marked supported.

--- a/docs/isolation.md
+++ b/docs/isolation.md
@@ -5,7 +5,7 @@ Workloads run in a Linux microVM (`firecracker` on Linux, `darwin-vz` on macOS).
 ## Network model and enforcement
 
 - `firecracker` creates a dedicated TAP interface and host/guest IP pair per sandbox. It enforces policy egress allowlists with host-side iptables rules, and the host can identify a sandbox by its guest IP on that TAP-backed network.
-- `firecracker` learns allowed destinations from observed DNS answers and then authorizes destination IP:port pairs. Current hostname-based rules therefore do not distinguish co-hosted services that share the same IP:port.
+- `firecracker` learns hostname-based allowed destinations from observed DNS answers and then authorizes destination IP:port pairs. Literal IPv4 allow rules are installed directly. Current hostname-based rules therefore do not distinguish co-hosted services that share the same IP:port.
 - `darwin-vz` uses `filehandle` networking with a Cleanroom-owned guest gateway for TCP egress filtering. The host does not get a Firecracker-style per-sandbox TAP device or host-visible guest IP identity.
 - `darwin-vz` also learns allowed destinations from observed DNS answers and then authorizes destination IP:port pairs in the filehandle gateway. Current hostname-based rules therefore do not distinguish co-hosted services that share the same IP:port.
 

--- a/docs/isolation.md
+++ b/docs/isolation.md
@@ -5,9 +5,9 @@ Workloads run in a Linux microVM (`firecracker` on Linux, `darwin-vz` on macOS).
 ## Network model and enforcement
 
 - `firecracker` creates a dedicated TAP interface and host/guest IP pair per sandbox. It enforces policy egress allowlists with host-side iptables rules, and the host can identify a sandbox by its guest IP on that TAP-backed network.
-- `darwin-vz` currently attaches a NAT-backed virtual NIC through `Virtualization.framework`. Guests get outbound networking and can reach the host gateway through the NAT host address, but the host does not get a Firecracker-style per-sandbox TAP device or host-visible guest IP identity.
-- `darwin-vz` currently requires `network.default: deny`, ignores `network.allow` entries, and provides no host-side egress allowlist enforcement. A warning is printed during execution.
-- Planned work for vmnet-backed `darwin-vz` networking is tracked in [plans/darwin-vz-vmnet-mode.md](plans/darwin-vz-vmnet-mode.md).
+- `firecracker` learns allowed destinations from observed DNS answers and then authorizes destination IP:port pairs. Current hostname-based rules therefore do not distinguish co-hosted services that share the same IP:port.
+- `darwin-vz` uses `filehandle` networking with a Cleanroom-owned guest gateway for TCP egress filtering. The host does not get a Firecracker-style per-sandbox TAP device or host-visible guest IP identity.
+- `darwin-vz` also learns allowed destinations from observed DNS answers and then authorizes destination IP:port pairs in the filehandle gateway. Current hostname-based rules therefore do not distinguish co-hosted services that share the same IP:port.
 
 ## Filesystem persistence
 


### PR DESCRIPTION
## Summary

Document the current limitation of hostname-based egress allow rules across Firecracker and darwin-vz.

## What changed

- clarify the top-level README claim about deny-by-default egress
- note in the Firecracker backend docs that hostname rules are enforced from observed DNS answers plus destination IP:port
- note the same limitation in the darwin-vz filehandle docs
- refresh `docs/isolation.md` so it matches the current darwin-vz model and documents the same caveat

## Why

Current policy enforcement does not distinguish co-hosted services that share the same IP:port after DNS resolution. This PR makes that behavior explicit in the public docs instead of implying exact hostname identity enforcement.

## Validation

- docs-only change
- reviewed rendered diff locally
