### PR TITLE
docs: Simplify layered cache design

### DIFF
--- a/docs/plans/layered-caching.md
+++ b/docs/plans/layered-caching.md
@@ -6,7 +6,8 @@
 
 ## Summary
 
-Build a deterministic, host-local cache pipeline for environment construction,
+Build an input-addressed, host-local cache pipeline for environment
+construction,
 then
 materialize the selected cached environment as a single writable root volume
 per sandbox.
@@ -20,7 +21,8 @@ The system-cache pipeline uses stage terminology:
 
 - runtime stage: prepared runtime rootfs
 - workspace stage: runtime rootfs plus exact repository checkout
-- dependency stage: workspace stage plus deterministic bootstrap/dependencies
+- dependency stage: workspace stage plus policy-constrained bootstrap and
+  dependencies
 
 Each stage output is a full sealed rootfs snapshot. Higher stages subsume lower
 stages. At runtime we do not mount `runtime + workspace + dependency` as a live
@@ -43,9 +45,9 @@ This separates two concerns that are easy to conflate:
 - **materialization design** decides how a selected artifact becomes a fast VM
   root filesystem
 
-We need both. Deterministic caches without cheap clone materialization still
-leave startup expensive. Cheap block clones without deterministic cache keys
-still leave reuse unsafe and hard to reason about.
+We need both. Input-addressed caches without cheap clone materialization still
+leave startup expensive. Cheap block clones without deterministic key
+derivation still leave reuse unsafe and hard to reason about.
 
 ## Terminology
 
@@ -194,7 +196,8 @@ User snapshots and system caches may use the same low-level clone/snapshot
 mechanisms, but they are different products:
 
 - user snapshots are addressed by snapshot ID and user intent
-- system caches are addressed by `(stage, key)` and deterministic inputs
+- system caches are addressed by `(stage, key)` and immutable, replayable
+  inputs
 - user snapshots are explicit and durable
 - system caches are implicit and eligible for automatic garbage collection
 
@@ -381,8 +384,8 @@ Notes:
 
 Purpose:
 
-- capture the environment after deterministic bootstrap such as dependency
-  install, generated fixtures, and language-specific setup
+- capture the environment after policy-constrained bootstrap such as
+  dependency install, generated fixtures, and language-specific setup
 
 Suggested key:
 
@@ -406,6 +409,9 @@ Notes:
 
 - this is the primary "nearly instant environment" target
 - a warm hit should bypass repository clone and dependency install entirely
+- this stage is only reproducible to the extent that the selected ecosystem,
+  toolchain, and bootstrap recipe are actually constrained enough to produce
+  stable outputs
 
 ### Stage 3: Writable execution child
 
@@ -517,7 +523,7 @@ Shared stage-cache publication should be a host-controlled promotion pipeline.
 ### Publish dependency stage
 
 1. Start from a published workspace stage.
-2. Run deterministic bootstrap in a temporary builder sandbox.
+2. Run the constrained bootstrap recipe in a temporary builder sandbox.
 3. Allow package fetches only through the gateway and only for lockfile-derived
    artifacts.
 4. Verify:
@@ -540,7 +546,7 @@ Warm-hit resolution should be simple.
 If no dependency stage exists but a workspace stage does:
 
 1. clone the workspace stage
-2. run deterministic bootstrap
+2. run the constrained bootstrap recipe
 3. optionally publish a dependency stage if the policy allows promotion
 
 If only the runtime stage exists:

--- a/docs/plans/layered-caching.md
+++ b/docs/plans/layered-caching.md
@@ -186,6 +186,8 @@ identity, lifecycle, and API semantics.
 - Treating moving refs such as branches or tags as reusable cache keys.
 - Solving every ecosystem's lockfile format in the first slice.
 - Unifying user snapshots and system caches into one metadata/API surface.
+- Making system stage caches user-addressable through the normal snapshot
+  restore surface such as `--from`.
 - Guaranteeing zero supply-chain risk in an absolute sense.
 
 ## Design Principles
@@ -203,6 +205,14 @@ mechanisms, but they are different products:
 
 `snapshotstore` should remain the user snapshot store. System-managed stage
 outputs should move into a dedicated `cachestore`.
+
+The user-facing restore/fork surface should remain snapshot-oriented:
+
+- `--from` should refer to user snapshots, not system stage caches
+- normal sandbox creation should resolve system stage caches automatically from
+  request inputs
+- if direct stage-cache selection is ever exposed, it should use a separate
+  operator/debug surface rather than sharing snapshot semantics
 
 ### 2. Keys must be derived from immutable inputs
 
@@ -560,6 +570,10 @@ If only the runtime stage exists:
 1. clone the runtime stage
 2. perform repository checkout
 3. continue upward through the same promotion flow
+
+This stage-cache resolution should remain an internal control-plane behavior for
+normal users. User-facing restore/fork flows should continue to target explicit
+snapshots rather than arbitrary stage-cache entries.
 
 ## Publication State Machine
 

--- a/docs/plans/layered-caching.md
+++ b/docs/plans/layered-caching.md
@@ -6,11 +6,28 @@
 
 ## Summary
 
-Build a deterministic cache hierarchy for environment construction, then
+Build a deterministic, host-local cache pipeline for environment construction,
+then
 materialize the selected cached environment as a single writable root volume
 per sandbox.
 
-The core model is:
+This plan intentionally keeps two systems separate:
+
+- user snapshots are explicit, user-facing savepoints
+- system caches are implicit, host-managed stage outputs
+
+The system-cache pipeline uses stage terminology:
+
+- runtime stage: prepared runtime rootfs
+- workspace stage: runtime rootfs plus exact repository checkout
+- dependency stage: workspace stage plus deterministic bootstrap/dependencies
+
+Each stage output is a full sealed rootfs snapshot. Higher stages subsume lower
+stages. At runtime we do not mount `runtime + workspace + dependency` as a live
+stack. We clone the best ready stage into one writable child and boot that as
+the only guest root disk.
+
+The core system-cache model is:
 
 - host-side caches are keyed by immutable inputs such as image digests, git
   commits, lockfiles, toolchain manifests, and compiled policy hashes
@@ -30,19 +47,31 @@ We need both. Deterministic caches without cheap clone materialization still
 leave startup expensive. Cheap block clones without deterministic cache keys
 still leave reuse unsafe and hard to reason about.
 
+## Terminology
+
+This document uses:
+
+- **stage** for the transformation step in the cache pipeline
+- **cache entry** for the immutable stored output of a stage
+
+Current implementation still uses some "seed" naming for stage outputs,
+especially workspace-stage snapshots. This document uses stage terminology
+going forward because it maps more clearly to how the cache pipeline is built.
+
 ## Delivery Strategy
 
 This plan should land in phases rather than as one large cross-backend change.
 
-### Phase 1: Workspace-seed orchestration
+### Phase 1: Workspace-stage orchestration
 
-Status: largely landed for snapshot-capable backends.
+Status: largely landed for snapshot-capable backends. Current implementation
+names this the workspace-seed flow.
 
 The backend-neutral control-plane slice is now in place:
 
-- publish workspace-seed snapshots after exact-commit repository bootstrap
-- look up matching workspace-seed snapshots before repeating bootstrap
-- restore matching workspace-seed snapshots before cold bootstrap
+- publish workspace-stage snapshots after exact-commit repository bootstrap
+- look up matching workspace-stage snapshots before repeating bootstrap
+- restore matching workspace-stage snapshots before cold bootstrap
 - republish after runtime-base changes or restore failure fallbacks
 
 This phase improves warm repo-aware sandbox creation by skipping repeated
@@ -59,12 +88,24 @@ Status: partially landed.
 The Firecracker runtime plumbing now exists:
 
 - route normal execution through writable root volume preparation
-- consume published cache artifacts through the volume-store clone path
+- consume published stage caches through the volume-store clone path
 - allow clone-capable drivers such as ZFS to materialize writable child volumes
 
 The remaining gap is deployment/runtime-dependent rather than architectural:
 the default Firecracker `file` driver still copies ext4 bytes, so the "nearly
 plain sandbox boot time" win only happens on clone-capable storage such as ZFS.
+
+### Phase 3: Dedicated cache store and dependency stage
+
+Status: not started.
+
+The next simplification step should be:
+
+- add a dedicated `cachestore` for system-managed stage outputs
+- keep `snapshotstore` as the user snapshot store
+- move workspace-stage metadata out of reserved snapshot naming
+- add one strict dependency stage for a single ecosystem first
+- keep distribution/export out of scope until the host-local model is proven
 
 ## Current Progress Snapshot
 
@@ -73,7 +114,7 @@ plain sandbox boot time" win only happens on clone-capable storage such as ZFS.
 - host-side git mirror transport cache keyed by canonical remote URL
 - exact-commit repository bootstrap through the host-controlled flow
 - runtime-base-key derivation for `firecracker` and `darwin-vz`
-- workspace-seed publish, lookup, restore, and fallback republish in the
+- workspace-stage publish, lookup, restore, and fallback republish in the
   control service
 - one writable-root-volume preparation path for Firecracker normal execution
   and snapshot restore
@@ -85,17 +126,18 @@ plain sandbox boot time" win only happens on clone-capable storage such as ZFS.
 
 ### Not started
 
-- dependency-seed artifacts
-- package artifact CAS and lockfile-keyed environment caching
-- first-class artifact metadata with publication states and lineage
+- dedicated `cachestore` for system-managed stage outputs
+- dependency-stage caches
+- lockfile-keyed dependency stage publication for any ecosystem
 - strict offline warm-cache mode
 - garbage collection and retention policy
+- cross-host distribution/export for stage caches
 
 ### Current caveats
 
-- workspace-seed identity is currently stored as a managed snapshot name, not a
-  first-class cache artifact record
-- workspace-seed keying currently includes the local checkout branch because
+- workspace-stage identity is currently stored as a managed snapshot name, not
+  a first-class cache entry record
+- workspace-stage keying currently includes the local checkout branch because
   repository bootstrap can create either a detached checkout or a named local
   branch
 
@@ -112,13 +154,18 @@ The repository already has most of the right primitives in separate slices:
 - the volume store already exposes `EnsureBaseVolume`,
   `CreateWritableVolume`, `SnapshotVolume`, and `CloneSnapshotToVolume`
 
-What is still missing is a unified cache model that answers:
+What is still missing is a dedicated system-cache model that answers:
 
-- which environment artifacts should exist
+- which stage outputs should exist
 - which exact inputs produce them
 - who is allowed to publish them
 - when a cache hit is trusted
 - how warm hits become close to plain sandbox creation time
+
+The important simplification is to avoid over-unifying this with user
+snapshots. User snapshots and system caches can share low-level storage
+mechanisms, but they should remain separate top-level features with different
+identity, lifecycle, and API semantics.
 
 ## Goals
 
@@ -136,13 +183,27 @@ What is still missing is a unified cache model that answers:
 - Reusing mutable package-manager caches directly from untrusted sandboxes.
 - Treating moving refs such as branches or tags as reusable cache keys.
 - Solving every ecosystem's lockfile format in the first slice.
+- Unifying user snapshots and system caches into one metadata/API surface.
 - Guaranteeing zero supply-chain risk in an absolute sense.
 
 ## Design Principles
 
-### 1. Keys must be derived from immutable inputs
+### 1. Keep user snapshots and system caches separate
 
-Reusable environment artifacts must never be keyed by:
+User snapshots and system caches may use the same low-level clone/snapshot
+mechanisms, but they are different products:
+
+- user snapshots are addressed by snapshot ID and user intent
+- system caches are addressed by `(stage, key)` and deterministic inputs
+- user snapshots are explicit and durable
+- system caches are implicit and eligible for automatic garbage collection
+
+`snapshotstore` should remain the user snapshot store. System-managed stage
+outputs should move into a dedicated `cachestore`.
+
+### 2. Keys must be derived from immutable inputs
+
+Reusable stage caches must never be keyed by:
 
 - image tags
 - branch names
@@ -161,7 +222,31 @@ They must instead be keyed by exact inputs such as:
 - compiled policy hash
 - bootstrap recipe digest
 
-### 2. Untrusted sandboxes must not publish shared cache entries
+### 3. System caches are stage outputs
+
+The cache pipeline should be described as ordered stages:
+
+- runtime
+- workspace
+- dependency
+
+Each stage produces one immutable cached output. Higher stages subsume the
+lower stages logically, even if the runtime only boots from one concrete rootfs
+snapshot.
+
+### 4. Each system cache entry is a full rootfs snapshot
+
+We should not assemble a live guest-visible mount stack like "base + workspace
++ dependency" for the default path. Each stage cache entry should be one sealed
+rootfs snapshot that already contains the lower stages' contents.
+
+That means:
+
+- `/workspace` stays part of the main rootfs, not its own default volume
+- boot always attaches one writable child root disk
+- runtime layering exists in metadata and lineage, not in guest mounts
+
+### 5. Untrusted sandboxes must not publish shared cache entries
 
 A guest workload can request a checkpoint or complete a bootstrap step, but the
 host control plane remains authoritative for promotion into a shared cache.
@@ -173,29 +258,7 @@ That means:
 - publish atomically
 - never mutate a `ready` cache entry in place
 
-### 3. Treat caches as immutable artifacts, not writable workspaces
-
-Every reusable layer should be modeled as an immutable artifact with metadata,
-state, lineage, and a storage reference.
-
-Mutable work happens only in:
-
-- a temporary builder sandbox
-- a per-run writable child clone
-
-### 4. Keep cache layers host-side and guest runtime simple
-
-The guest should not see a live mount stack like "base + repo + deps" for the
-default case. That adds backend-specific mount complexity, ordering issues, and
-new attack surface without improving deterministic reuse.
-
-The default runtime contract should remain:
-
-- clone one sealed rootfs snapshot into a writable child
-- attach that writable child as the VM root disk
-- boot a fresh sandbox
-
-### 5. Separate transport caches from environment caches
+### 6. Separate transport caches from environment caches
 
 A git mirror or a package artifact CAS improves fetch cost and upstream load,
 but it is not itself a runnable environment.
@@ -205,46 +268,55 @@ That distinction matters for correctness:
 - transport caches are host-side accelerators
 - environment caches are sealed rootfs states that can be cloned into sandboxes
 
-## Cache Planes
+### 7. Keep the API/backend model simple and host-local first
 
-We should model two planes explicitly.
+The first slice should stay backend-neutral at the API surface and host-local
+in storage behavior:
 
-### A. Logical cache plane
+- keep stage keys and stage selection backend-agnostic
+- keep storage-driver differences inside runtime config and adapter internals
+- do not design cross-host distribution into the local metadata model yet
 
-This plane answers:
+## Cache Types
 
-- what artifact exists
-- what inputs produced it
-- whether it is safe to reuse
-- how it relates to parent artifacts
+We should model three distinct things explicitly.
 
-Examples:
+### A. System stage caches
 
-- git mirror
-- package artifact blob
-- workspace seed
-- dependency seed
+This is the host-managed environment cache pipeline:
 
-### B. Physical materialization plane
+- runtime stage cache
+- workspace stage cache
+- dependency stage cache
 
-This plane answers:
+These are reusable rootfs states that can be cloned into disposable sandboxes.
 
-- where the artifact bytes live
-- how they are cloned
-- what gets attached to the VM
+### B. Transport caches
 
-Examples:
+These reduce upstream fetch cost but are not runnable environments:
+
+- git mirror transport cache
+- gateway git response cache
+- gateway OCI/blob cache
+
+The existing git mirror is already in-tree. The gateway Git/OCI content-cache
+work proposed in PR #138 fits here as a transport-cache plane, not as a system
+stage cache.
+
+### C. Runtime materialization
+
+This is how a selected stage cache becomes one writable VM root disk:
 
 - plain file copy
 - APFS `clonefile`
-- ZFS clone of a zvol snapshot
+- ZFS snapshot/clone
 
-The logical cache plane should not depend on one storage backend. The physical
-materialization plane is backend-specific and may vary by host.
+Stage cache selection is backend-neutral. Materialization remains
+backend-specific.
 
-## Cache Layers
+## System Cache Stages
 
-### Layer 0: Runtime base
+### Stage 0: Runtime
 
 Purpose:
 
@@ -267,7 +339,7 @@ runtime_base_key = H(
 
 Output:
 
-- immutable prepared rootfs artifact
+- immutable prepared runtime rootfs stage cache
 - optionally stored as a managed base volume
 
 Notes:
@@ -275,58 +347,7 @@ Notes:
 - this is not repository-specific
 - this is the first layer that should be reused aggressively across runs
 
-### Layer 1: Git mirror
-
-Purpose:
-
-- reduce repeated upstream git traffic
-- keep auth and fetch control on the host side
-
-Suggested key:
-
-```text
-git_mirror_key = H(canonical_remote_url)
-```
-
-Output:
-
-- host-side bare mirror
-
-Notes:
-
-- this is a transport cache, not a runnable environment
-- freshness must still block until the requested commit exists
-
-### Layer 2: Package artifact CAS
-
-Purpose:
-
-- cache fetched registry artifacts by verified content
-- enforce lockfile-derived allowlists
-
-Suggested key:
-
-```text
-artifact_key = H(
-  ecosystem,
-  canonical_registry,
-  package_identity,
-  version,
-  integrity_hash
-)
-```
-
-Output:
-
-- immutable blob plus verified metadata
-
-Notes:
-
-- URL alone is not sufficient
-- if a lockfile does not include strong integrity metadata, that ecosystem does
-  not qualify for poisoning-resistant warm reuse in strict mode
-
-### Layer 3: Workspace seed
+### Stage 1: Workspace
 
 Purpose:
 
@@ -335,7 +356,7 @@ Purpose:
 Suggested key:
 
 ```text
-workspace_seed_key = H(
+workspace_stage_key = H(
   runtime_base_key,
   canonical_remote_url,
   commit_sha,
@@ -354,8 +375,9 @@ Notes:
 
 - this is the next speed stage after mirror-backed clone
 - it turns "avoid hammering upstream" into "skip clone and checkout on warm hit"
+- current implementation calls this the workspace-seed flow
 
-### Layer 4: Dependency seed
+### Stage 2: Dependency
 
 Purpose:
 
@@ -365,8 +387,8 @@ Purpose:
 Suggested key:
 
 ```text
-dependency_seed_key = H(
-  workspace_seed_key,
+dependency_stage_key = H(
+  workspace_stage_key,
   compiled_policy_hash,
   toolchain_manifest_digest,
   resolved_tool_versions_digest,
@@ -385,7 +407,7 @@ Notes:
 - this is the primary "nearly instant environment" target
 - a warm hit should bypass repository clone and dependency install entirely
 
-### Layer 5: Writable execution child
+### Stage 3: Writable execution child
 
 Purpose:
 
@@ -393,67 +415,108 @@ Purpose:
 
 Suggested key:
 
-- none; this is not a shared cache artifact
+- none; this is not a shared stage cache
 
 Output:
 
-- per-sandbox writable child clone of a dependency seed or workspace seed
+- per-sandbox writable child clone of a dependency stage or workspace stage
 
 Notes:
 
-- this layer must never be shared or promoted automatically
+- this stage must never be shared or promoted automatically
 
-## Environment Key Resolution
+## Transport Caches
 
-At request time, the control plane should derive a single canonical target key
-from the resolved request inputs.
+Transport caches accelerate repository and registry access but are not
+themselves runnable environments.
 
-Illustrative shape:
+### Git transport cache
+
+Purpose:
+
+- reduce repeated upstream git traffic
+- keep auth and fetch control on the host side
+
+Suggested key:
 
 ```text
-env_key = H(
-  schema_version,
-  backend_name,
-  architecture,
-  runtime_base_key,
-  compiled_policy_hash,
-  canonical_remote_url,
-  commit_sha,
-  submodule_resolution_digest,
-  toolchain_manifest_digest,
-  resolved_tool_versions_digest,
-  lockfile_inputs_digest,
-  lockfile_parser_version,
-  bootstrap_recipe_digest
+git_mirror_key = H(canonical_remote_url)
+```
+
+Output:
+
+- host-side bare mirror
+- optionally, a host-side protocol/content cache for repeated git fetch traffic
+
+Notes:
+
+- the existing git mirror is the current transport cache
+- the gateway git caching work proposed in PR #138 belongs in this plane
+- freshness must still block until the requested commit exists
+
+### Registry/package transport cache
+
+Purpose:
+
+- cache fetched registry artifacts by verified content
+- reduce repeated OCI/blob/tag traffic
+- support future lockfile-derived allowlists without making the registry cache
+  itself a runnable environment
+
+Suggested key:
+
+```text
+registry_artifact_key = H(
+  ecosystem,
+  canonical_registry,
+  package_identity,
+  version,
+  integrity_hash
 )
 ```
 
-The control plane can then resolve the highest reusable artifact it trusts:
+Output:
 
-1. dependency seed hit
-2. workspace seed hit
-3. runtime base hit
+- immutable blob plus verified metadata
+
+Notes:
+
+- URL alone is not sufficient
+- the gateway OCI/content-cache work proposed in PR #138 belongs in this plane
+- if a lockfile does not include strong integrity metadata, that ecosystem does
+  not qualify for poisoning-resistant warm reuse in strict mode
+
+## Stage Key Resolution
+
+At request time, the control plane should derive the canonical stage keys from
+the resolved request inputs.
+
+The control plane can then resolve the highest reusable stage cache it trusts:
+
+1. dependency stage hit
+2. workspace stage hit
+3. runtime stage hit
 4. cold path
 
 ## Production Flow
 
-Shared cache publication should be a host-controlled promotion pipeline.
+Shared stage-cache publication should be a host-controlled promotion pipeline.
 
-### Publish workspace seed
+### Publish workspace stage
 
 1. Resolve the exact repository checkout inputs.
-2. Start from the selected runtime base.
+2. Start from the selected runtime stage.
 3. Materialize the repository through the host git gateway.
 4. Verify the checkout:
    - remote URL canonicalized as expected
    - `HEAD` equals requested commit
    - submodules match requested policy
 5. Snapshot the resulting root volume.
-6. Publish the workspace seed metadata and storage reference atomically.
+6. Publish the workspace-stage metadata and storage reference atomically.
 
-### Publish dependency seed
+### Publish dependency stage
 
-1. Start from a published workspace seed.
+1. Start from a published workspace stage.
 2. Run deterministic bootstrap in a temporary builder sandbox.
 3. Allow package fetches only through the gateway and only for lockfile-derived
    artifacts.
@@ -462,39 +525,36 @@ Shared cache publication should be a host-controlled promotion pipeline.
    - no unexpected network access
    - bootstrap recipe completed successfully
 5. Snapshot the resulting root volume.
-6. Publish the dependency seed metadata and storage reference atomically.
+6. Publish the dependency-stage metadata and storage reference atomically.
 
 ## Consumption Flow
 
 Warm-hit resolution should be simple.
 
-1. Resolve request inputs into the canonical environment key.
-2. Look up the best `ready` artifact.
+1. Resolve request inputs into the canonical stage keys.
+2. Look up the best `ready` stage cache.
 3. Clone its rootfs snapshot into a fresh writable child volume.
 4. Attach that single writable child as the VM root disk.
 5. Boot a fresh sandbox.
 
-If no dependency seed exists but a workspace seed does:
+If no dependency stage exists but a workspace stage does:
 
-1. clone the workspace seed
+1. clone the workspace stage
 2. run deterministic bootstrap
-3. optionally publish a dependency seed if the policy allows promotion
+3. optionally publish a dependency stage if the policy allows promotion
 
-If only the runtime base exists:
+If only the runtime stage exists:
 
-1. clone the runtime base
+1. clone the runtime stage
 2. perform repository checkout
 3. continue upward through the same promotion flow
 
 ## Publication State Machine
 
-Each cache artifact should have an explicit lifecycle state.
+Each stage cache entry should have an explicit lifecycle state.
 
-Suggested states:
+For the first slice, keep the durable states minimal:
 
-- `pending`
-- `building`
-- `verifying`
 - `ready`
 - `failed`
 - `garbage`
@@ -506,6 +566,9 @@ Rules:
 - failed builds do not overwrite or downgrade existing `ready` entries
 - promotion is atomic: the metadata entry becomes visible only after the
   storage reference is durable and verified
+
+In-flight build coordination can stay outside the durable metadata record at
+first if that keeps the implementation simpler.
 
 ## Trust and Safety Model
 
@@ -541,7 +604,7 @@ The design should eliminate these weaker trust paths:
 When a policy requires strict offline warm-cache execution:
 
 - the control plane must refuse upstream git or registry access
-- only published `ready` artifacts may be used
+- only published `ready` stage caches may be used
 - missing artifacts fail closed
 
 ## Runtime Filesystem Model
@@ -552,6 +615,7 @@ That means:
 
 - no default runtime union mount stack
 - no default "base volume plus repo volume plus deps volume" mount assembly
+- no separate default `/workspace` guest-visible volume
 - one attached writable root volume per sandbox
 
 Logical cache layering still exists, but it is represented in metadata and
@@ -586,14 +650,14 @@ Recommended direction from here:
 
 Desired hot path:
 
-1. resolve best cache artifact
+1. resolve best stage cache
 2. clone snapshot to writable child volume
 3. attach child volume as Firecracker root disk
 4. boot VM
 
 Undesired hot path:
 
-1. resolve best cache artifact
+1. resolve best stage cache
 2. copy full ext4 file to `rootfs-ephemeral.ext4`
 3. boot VM
 
@@ -614,38 +678,44 @@ This plan composes with the existing documents rather than replacing them.
 - `firecracker-privilege-runtime.md`
   defines the Linux host-runtime direction needed for clone-capable snapshot
   storage and reduced root surface
+- PR #138
+  proposes the gateway Git/OCI content-cache transport plane that should remain
+  separate from system stage caches
 
-## Existing Code Touchpoints
+## Code Touchpoints and Planned Additions
 
 | File | Change |
 |---|---|
 | `internal/gateway/mirror.go` | Already acts as the host-side git transport cache keyed by canonical remote URL. |
 | `internal/repositorycheckout/checkout.go` | Already uses exact remote URL and full commit SHA as the checkout source of truth; `branch` currently affects local checkout mode only. |
-| `internal/snapshotstore/store.go` | Currently stores snapshot metadata only; it still needs expansion for cache artifact type, key, lineage, inputs, and publication state. |
+| `internal/controlservice/workspace_seed.go` | Current workspace-stage orchestration lives here under workspace-seed naming; this should migrate to dedicated stage-cache metadata. |
+| `internal/snapshotstore/store.go` | Should remain the user snapshot store rather than being expanded into the system-cache store. |
 | `internal/volumestore/store.go` | Already provides the backend-neutral clone/snapshot contract shared by both backends. |
 | `internal/backend/firecracker/backend.go` | Already routes normal execution and snapshot restore through writable root volume preparation; actual clone behavior depends on the configured driver. |
 | `internal/backend/darwinvz/backend_darwin.go` | Already fits the same one-rootfs model and can use APFS clone materialization. |
 | `internal/policy/policy.go` | Still needs lockfile-derived artifact allowlists and strict offline warm-cache requirements. |
+| `internal/cachestore/*` | Planned new package for system-managed stage-cache metadata, separate from user snapshots. |
 
-## Suggested Metadata Model
+## Suggested Cache Metadata Model
 
-Suggested artifact record shape:
+Suggested stage-cache record shape:
 
 ```text
-artifact_key
-artifact_type            // runtime_base | workspace_seed | dependency_seed
-state                    // pending | building | verifying | ready | failed | garbage
-backend
-architecture
-policy_hash
-parent_artifact_key
+cache_key
+stage                    // runtime | workspace | dependency
+state                    // ready | failed | garbage
+parent_cache_key
 storage_driver
 storage_ref
+policy_hash
+repository
 input_manifest_digest
 created_at
+last_used_at
 producer_version
 ```
 
+This metadata should live in a dedicated `cachestore`, not in `snapshotstore`.
 Input manifests should be stored as explicit structured metadata rather than as
 opaque prose so determinism can be tested directly.
 
@@ -654,7 +724,8 @@ opaque prose so determinism can be tested directly.
 ### Done
 
 1. Keep the git mirror as the transport cache for exact-commit checkout.
-2. Publish workspace seeds keyed by runtime base plus exact repository inputs.
+2. Publish workspace-stage caches keyed by runtime stage plus exact repository
+   inputs.
 
 ### Partial
 
@@ -668,13 +739,17 @@ clone-capable storage instead of the default `file` driver.
 
 ### Remaining
 
-1. Add first-class cache metadata records and canonical key derivation helpers.
-2. Add lockfile parsing and package artifact CAS for one ecosystem first.
-3. Publish dependency seeds keyed by lockfiles, toolchains, and bootstrap
-   recipe.
+1. Add a dedicated `cachestore` for system-managed stage caches and canonical
+   key derivation helpers.
+2. Move workspace-stage metadata off reserved snapshot names and into
+   `cachestore`.
+3. Add lockfile parsing and one strict dependency stage for a single ecosystem
+   first.
 4. Add strict offline warm-cache mode and fail-closed launch checks.
 5. Add garbage collection and retention policies after the key model and
    publication flow are stable.
+6. Revisit cross-host distribution/export only after the local host model is
+   proven worthwhile.
 
 ## Testing Plan
 
@@ -686,14 +761,15 @@ clone-capable storage instead of the default `file` driver.
 
 ### Publication safety
 
-- partially written artifacts are never visible as `ready`
+- partially written stage-cache entries are never visible as `ready`
 - failed publishes do not corrupt existing entries
 - concurrent publishes of the same key coalesce correctly
 
-Current coverage already exists for the narrower workspace-seed flow:
+Current coverage already exists for the narrower workspace-stage flow, which is
+implemented today as the workspace-seed flow:
 
-- warm workspace-seed hits reuse snapshot-backed sandbox creation
-- runtime-base changes invalidate workspace-seed reuse
+- warm workspace-stage hits reuse snapshot-backed sandbox creation
+- runtime-base changes invalidate workspace-stage reuse
 - restore failures fall back to cold bootstrap and republish
 - writable-volume preparation cleans up failed clones and uses the configured
   volume-store driver
@@ -707,7 +783,7 @@ Current coverage already exists for the narrower workspace-seed flow:
 
 ### Runtime performance
 
-- warm dependency-seed hit skips repository clone and dependency install
+- warm dependency-stage hit skips repository clone and dependency install
 - Firecracker warm hits avoid full rootfs file copies
 - snapshot clone latency and VM boot latency are measured separately
 
@@ -715,13 +791,15 @@ Current coverage already exists for the narrower workspace-seed flow:
 
 - Which ecosystem should be the first strict lockfile-enforced package cache:
   npm, pip, or another?
-- Should dependency seeds be published automatically on successful bootstrap, or
-  only when explicitly requested?
-- What retention policy should apply to large dependency seeds relative to
-  smaller workspace seeds?
-- Should workspace-seed identity continue to include the local checkout branch,
+- Should dependency-stage caches be published automatically on successful
+  bootstrap, or only when explicitly requested?
+- What retention policy should apply to large dependency-stage caches relative
+  to smaller workspace-stage caches?
+- Should workspace-stage identity continue to include the local checkout branch,
   or should branch stay outside reusable cache keys once checkout mode is
   modeled separately?
 - Do we need a specialized optional read-only guest-visible artifact volume for
   very large immutable datasets, or can the single-rootfs model handle the
   first production slice cleanly?
+- When we later revisit cross-host distribution, should exported stage caches be
+  rebuilt from transport caches or exported as separate portable artifacts?

--- a/docs/plans/layered-caching.md
+++ b/docs/plans/layered-caching.md
@@ -366,7 +366,8 @@ workspace_stage_key = H(
   submodule_mode,
   submodule_resolution_digest,
   checkout_mode,
-  repository_destination_dir
+  repository_destination_dir,
+  materialization_recipe_digest
 )
 ```
 
@@ -378,6 +379,11 @@ Notes:
 
 - this is the next speed stage after mirror-backed clone
 - it turns "avoid hammering upstream" into "skip clone and checkout on warm hit"
+- `commit_sha` identifies the repo tree, but it is not enough to identify the
+  full workspace stage by itself
+- workspace-stage identity must also capture repository provenance and checkout
+  behavior such as submodule resolution, destination path, and any explicit
+  materialization recipe details such as sparse checkout or LFS hydration
 - current implementation calls this the workspace-seed flow
 
 ### Stage 2: Dependency


### PR DESCRIPTION
## What changed
Rewrites `docs/plans/layered-caching.md` around the simpler cache model we want to build:

- keep user snapshots and system caches separate
- use stage language for system-managed caches (`runtime`, `workspace`, `dependency`)
- treat each stage cache as a full rootfs snapshot
- keep transport caches separate from environment caches
- defer cross-host distribution until the host-local model is solid

It also folds in the transport-cache context from PR #138 without treating that work as part of the stage-cache model.

## Why
The earlier doc still leaned on the older `*_seed` / artifact framing and blurred user snapshots with managed caches. This update makes the intended shape simpler and closer to the direction we discussed.

## Impact
The plan now gives a cleaner next step:

- introduce a dedicated `cachestore`
- move current workspace-stage metadata out of reserved snapshot names
- add one strict dependency stage after that

## Validation
- `git diff --check -- docs/plans/layered-caching.md`
- docs-only change; no runtime tests run