### PR TITLE
fix(ci): stabilize cleanroom e2e jobs

### DIFF
--- a/scripts/ci-cleanroom-e2e.sh
+++ b/scripts/ci-cleanroom-e2e.sh
@@ -219,7 +219,7 @@ smoke_attempt=1
 smoke_max_attempts=3
 while true; do
   set +e
-  ./dist/cleanroom exec --host "$listen_endpoint" -c "$PWD" -- sh -lc 'echo cleanroom-e2e' >"$tmpdir/exec.out" 2>"$tmpdir/exec.err"
+  ./dist/cleanroom exec --host "$listen_endpoint" --no-mise -c "$PWD" -- sh -lc 'echo cleanroom-e2e' >"$tmpdir/exec.out" 2>"$tmpdir/exec.err"
   smoke_status=$?
   set -e
 
@@ -252,8 +252,8 @@ if [[ -z "$sandbox_id" ]]; then
 fi
 echo "sandbox id: $sandbox_id"
 
-./dist/cleanroom exec --host "$listen_endpoint" --in "$sandbox_id" -- sh -lc 'printf persisted-data >/tmp/persist.txt'
-./dist/cleanroom exec --host "$listen_endpoint" --in "$sandbox_id" -- sh -lc 'cat /tmp/persist.txt' | tee "$tmpdir/persist-read.out"
+./dist/cleanroom exec --host "$listen_endpoint" --no-mise --in "$sandbox_id" -- sh -lc 'printf persisted-data >/tmp/persist.txt'
+./dist/cleanroom exec --host "$listen_endpoint" --no-mise --in "$sandbox_id" -- sh -lc 'cat /tmp/persist.txt' | tee "$tmpdir/persist-read.out"
 if ! grep -q '^persisted-data$' "$tmpdir/persist-read.out"; then
   echo "expected persisted sandbox file contents from second execution" >&2
   exit 1
@@ -279,7 +279,7 @@ if ! grep -q 'sandbox terminated' "$tmpdir/sandbox-rm.out"; then
 fi
 
 set +e
-./dist/cleanroom exec --host "$listen_endpoint" --in "$sandbox_id" -- sh -lc 'echo should-not-run' >"$tmpdir/terminated.out" 2>"$tmpdir/terminated.err"
+./dist/cleanroom exec --host "$listen_endpoint" --no-mise --in "$sandbox_id" -- sh -lc 'echo should-not-run' >"$tmpdir/terminated.out" 2>"$tmpdir/terminated.err"
 terminated_status=$?
 set -e
 if [[ "$terminated_status" -eq 0 ]]; then
@@ -298,7 +298,7 @@ git_gateway_max_attempts=3
 while true; do
   set +e
   # shellcheck disable=SC2016
-  ./dist/cleanroom exec --host "$listen_endpoint" -c "$PWD" -- sh -lc '
+  ./dist/cleanroom exec --host "$listen_endpoint" --no-mise -c "$PWD" -- sh -lc '
   set -eu
 
   key="$(env | awk -F= '"'"'/^GIT_CONFIG_KEY_[0-9]+=url\.http:\/\/.+\/git\/github\.com\/\.insteadOf$/ {print $2; exit}'"'"')"

--- a/scripts/ci-darwin-vz-filehandle-e2e.sh
+++ b/scripts/ci-darwin-vz-filehandle-e2e.sh
@@ -152,11 +152,40 @@ echo "--- :white_check_mark: Guest gateway bridge smoke test"
 ./dist/cleanroom exec --host "$listen_endpoint" --backend darwin-vz -c "$smoke_policy_dir" -- sh -lc "wget -T 20 -S -O - http://10.233.0.1:${gateway_port}/meta/health >/dev/null 2>/tmp/meta.err || true; grep -q 'HTTP/1.1 501 Not Implemented' /tmp/meta.err"
 
 echo "--- :white_check_mark: Allowlisted egress test"
-./dist/cleanroom exec --host "$listen_endpoint" --backend darwin-vz -c "$allowlist_policy_dir" -- sh -lc 'wget -T 20 -q -O /dev/null https://github.com'
+# Probe the file-handle egress path directly instead of any ambient proxy
+# configuration inherited by the guest image, then retry transient upstream
+# failures from the live GitHub endpoint.
+allow_attempt=1
+allow_max_attempts=3
+allow_status=1
+while [[ "$allow_attempt" -le "$allow_max_attempts" ]]; do
+  set +e
+  ./dist/cleanroom exec --host "$listen_endpoint" --backend darwin-vz -c "$allowlist_policy_dir" -- sh -lc 'http_proxy= https_proxy= HTTP_PROXY= HTTPS_PROXY= ALL_PROXY= all_proxy= NO_PROXY= no_proxy= wget -T 20 -q -O /dev/null https://github.com' >"$tmpdir/allow.out" 2>"$tmpdir/allow.err"
+  allow_status=$?
+  set -e
+  if [[ "$allow_status" -eq 0 ]]; then
+    break
+  fi
+  if [[ "$allow_attempt" -lt "$allow_max_attempts" ]]; then
+    echo "allowlisted host probe failed (attempt $allow_attempt/$allow_max_attempts); retrying"
+    sleep "$allow_attempt"
+  fi
+  allow_attempt=$((allow_attempt + 1))
+done
+if [[ "$allow_status" -ne 0 ]]; then
+  echo "allowlisted host probe failed in filehandle mode" >&2
+  echo "stdout:" >&2
+  cat "$tmpdir/allow.out" >&2 || true
+  echo "stderr:" >&2
+  cat "$tmpdir/allow.err" >&2 || true
+  echo "server log (last 30 lines):" >&2
+  tail -n 30 "$tmpdir/server.log" >&2 || true
+  exit 1
+fi
 
 echo "--- :no_entry: Denied egress test"
 set +e
-./dist/cleanroom exec --host "$listen_endpoint" --backend darwin-vz -c "$allowlist_policy_dir" -- sh -lc 'wget -T 20 -q -O /dev/null https://buildkite.com' >"$tmpdir/deny.out" 2>"$tmpdir/deny.err"
+./dist/cleanroom exec --host "$listen_endpoint" --backend darwin-vz -c "$allowlist_policy_dir" -- sh -lc 'http_proxy= https_proxy= HTTP_PROXY= HTTPS_PROXY= ALL_PROXY= all_proxy= NO_PROXY= no_proxy= wget -T 20 -q -O /dev/null https://buildkite.com' >"$tmpdir/deny.out" 2>"$tmpdir/deny.err"
 deny_status=$?
 set -e
 if [[ "$deny_status" -eq 0 ]]; then

--- a/scripts/ci_cleanroom_e2e_test.go
+++ b/scripts/ci_cleanroom_e2e_test.go
@@ -90,9 +90,9 @@ func TestCiCleanroomE2EReusedSandboxExecOmitsChdir(t *testing.T) {
 
 	script := string(content)
 	for _, needle := range []string{
-		"./dist/cleanroom exec --host \"$listen_endpoint\" --in \"$sandbox_id\" -- sh -lc 'printf persisted-data >/tmp/persist.txt'",
-		"./dist/cleanroom exec --host \"$listen_endpoint\" --in \"$sandbox_id\" -- sh -lc 'cat /tmp/persist.txt' | tee \"$tmpdir/persist-read.out\"",
-		"./dist/cleanroom exec --host \"$listen_endpoint\" --in \"$sandbox_id\" -- sh -lc 'echo should-not-run' >\"$tmpdir/terminated.out\" 2>\"$tmpdir/terminated.err\"",
+		"./dist/cleanroom exec --host \"$listen_endpoint\" --no-mise --in \"$sandbox_id\" -- sh -lc 'printf persisted-data >/tmp/persist.txt'",
+		"./dist/cleanroom exec --host \"$listen_endpoint\" --no-mise --in \"$sandbox_id\" -- sh -lc 'cat /tmp/persist.txt' | tee \"$tmpdir/persist-read.out\"",
+		"./dist/cleanroom exec --host \"$listen_endpoint\" --no-mise --in \"$sandbox_id\" -- sh -lc 'echo should-not-run' >\"$tmpdir/terminated.out\" 2>\"$tmpdir/terminated.err\"",
 	} {
 		if !strings.Contains(script, needle) {
 			t.Fatalf("expected ci-cleanroom-e2e.sh to contain %q", needle)
@@ -116,6 +116,8 @@ func TestCiCleanroomE2EIsolatesCacheInTempDir(t *testing.T) {
 	for _, needle := range []string{
 		`export XDG_CACHE_HOME="$tmpdir/cache"`,
 		`mkdir -p "$XDG_CONFIG_HOME" "$XDG_CACHE_HOME" "$XDG_STATE_HOME" "$XDG_RUNTIME_DIR" "$XDG_DATA_HOME"`,
+		`./dist/cleanroom exec --host "$listen_endpoint" --no-mise -c "$PWD" -- sh -lc 'echo cleanroom-e2e'`,
+		`./dist/cleanroom exec --host "$listen_endpoint" --no-mise -c "$PWD" -- sh -lc '`,
 	} {
 		if !strings.Contains(script, needle) {
 			t.Fatalf("expected ci-cleanroom-e2e.sh to contain %q", needle)

--- a/scripts/ci_darwin_vz_e2e_test.go
+++ b/scripts/ci_darwin_vz_e2e_test.go
@@ -66,8 +66,11 @@ func TestCiDarwinVZFileHandleE2EUsesAllowlistPolicy(t *testing.T) {
 		`./dist/cleanroom exec --host "$listen_endpoint" --backend darwin-vz -c "$smoke_policy_dir" -- sh -lc "wget -T 20 -S -O - http://10.233.0.1:${gateway_port}/meta/health >/dev/null 2>/tmp/meta.err || true; grep -q 'HTTP/1.1 501 Not Implemented' /tmp/meta.err"`,
 		`- host: github.com`,
 		`ports: [443]`,
-		`./dist/cleanroom exec --host "$listen_endpoint" --backend darwin-vz -c "$allowlist_policy_dir" -- sh -lc 'wget -T 20 -q -O /dev/null https://github.com'`,
-		`./dist/cleanroom exec --host "$listen_endpoint" --backend darwin-vz -c "$allowlist_policy_dir" -- sh -lc 'wget -T 20 -q -O /dev/null https://buildkite.com'`,
+		`allow_attempt=1`,
+		`allow_max_attempts=3`,
+		`allowlisted host probe failed in filehandle mode`,
+		`./dist/cleanroom exec --host "$listen_endpoint" --backend darwin-vz -c "$allowlist_policy_dir" -- sh -lc 'http_proxy= https_proxy= HTTP_PROXY= HTTPS_PROXY= ALL_PROXY= all_proxy= NO_PROXY= no_proxy= wget -T 20 -q -O /dev/null https://github.com'`,
+		`./dist/cleanroom exec --host "$listen_endpoint" --backend darwin-vz -c "$allowlist_policy_dir" -- sh -lc 'http_proxy= https_proxy= HTTP_PROXY= HTTPS_PROXY= ALL_PROXY= all_proxy= NO_PROXY= no_proxy= wget -T 20 -q -O /dev/null https://buildkite.com'`,
 		`expected non-allowlisted egress to fail in filehandle mode`,
 	} {
 		if !strings.Contains(script, needle) {


### PR DESCRIPTION
## Summary

This stabilizes two flaky cleanroom e2e jobs in CI.

## What Changed

- clear ambient proxy environment variables before the darwin-vz filehandle guest `wget` allow/deny probes
- retry the darwin-vz allowlisted `github.com` probe up to 3 times and dump diagnostics on final failure
- disable automatic `mise` bootstrap for the Firecracker e2e smoke, persistent-sandbox, and git-gateway exec probes
- update the script tests to assert both changes

## Root Causes

### darwin-vz filehandle flake

Buildkite build [#858](https://buildkite.com/buildkite/cleanroom/builds/858) failed in `:apple: E2E (darwin-vz filehandle)` during the allowlisted egress check with:

`wget: server returned error: HTTP/1.1 502 Bad Gateway or Proxy Error`

That probe was a single-shot live fetch to `https://github.com`, so it could fail even when the filehandle network path and allowlist behavior were otherwise correct. Clearing inherited proxy vars also makes the probe exercise the intended filehandle path directly instead of any ambient proxy configuration from the guest image.

### Firecracker e2e hang

Buildkite build [#857](https://buildkite.com/buildkite/cleanroom/builds/857) stalled in `:fire: E2E (Firecracker)` after entering `Persistent sandbox lifecycle test` and logging:

`warning: dns query for disallowed host: mise-versions.jdx.dev`

The repo-scoped CI execs were being wrapped with `mise exec --` by default because the checkout contains `.mise.toml`. In the sandbox policy, `mise-versions.jdx.dev` is not allowlisted, so those probes could block on tool-bootstrap network access that the test does not actually need. The e2e script now opts out with `--no-mise` for those commands.

## Impact

These changes keep the CI jobs focused on cleanroom's own persistence, gateway, and egress behavior instead of external proxy/upstream flakiness or unnecessary tool bootstrap inside the guest.

## Validation

- `bash -n scripts/ci-darwin-vz-filehandle-e2e.sh`
- `bash -n scripts/ci-cleanroom-e2e.sh`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/559c/cleanroom mise exec -- go test ./scripts`
