### PR TITLE
feat: add stage cache foundation

### DIFF
--- a/internal/cachekey/cachekey.go
+++ b/internal/cachekey/cachekey.go
@@ -25,6 +25,7 @@ type RuntimeStageInputs struct {
 
 // WorkspaceStageInputs are the inputs that define the reusable workspace stage.
 type WorkspaceStageInputs struct {
+	Backend                     string
 	RuntimeKey                  string
 	CompiledPolicyHash          string
 	CanonicalRemoteURL          string
@@ -62,6 +63,7 @@ func RuntimeStageKey(in RuntimeStageInputs) string {
 // WorkspaceStageKey returns the canonical cache key for a workspace stage output.
 func WorkspaceStageKey(in WorkspaceStageInputs) string {
 	return buildStageKey("workspace", []component{
+		{name: "backend", value: canonicalIdentifier(in.Backend)},
 		{name: "runtime_key", value: canonicalReference(in.RuntimeKey)},
 		{name: "compiled_policy_hash", value: canonicalDigest(in.CompiledPolicyHash)},
 		{name: "canonical_remote_url", value: canonicalRemoteURL(in.CanonicalRemoteURL)},

--- a/internal/cachekey/cachekey.go
+++ b/internal/cachekey/cachekey.go
@@ -26,6 +26,7 @@ type RuntimeStageInputs struct {
 // WorkspaceStageInputs are the inputs that define the reusable workspace stage.
 type WorkspaceStageInputs struct {
 	RuntimeKey                  string
+	CompiledPolicyHash          string
 	CanonicalRemoteURL          string
 	CommitSHA                   string
 	SubmoduleMode               string
@@ -62,6 +63,7 @@ func RuntimeStageKey(in RuntimeStageInputs) string {
 func WorkspaceStageKey(in WorkspaceStageInputs) string {
 	return buildStageKey("workspace", []component{
 		{name: "runtime_key", value: canonicalReference(in.RuntimeKey)},
+		{name: "compiled_policy_hash", value: canonicalDigest(in.CompiledPolicyHash)},
 		{name: "canonical_remote_url", value: canonicalRemoteURL(in.CanonicalRemoteURL)},
 		{name: "commit_sha", value: canonicalDigest(in.CommitSHA)},
 		{name: "submodule_mode", value: canonicalIdentifier(in.SubmoduleMode)},

--- a/internal/cachekey/cachekey.go
+++ b/internal/cachekey/cachekey.go
@@ -1,0 +1,142 @@
+package cachekey
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"path"
+	"strings"
+)
+
+const formatVersion = "v1"
+
+const keyNamespace = "cleanroom/cachekey"
+
+// RuntimeStageInputs are the inputs that define the reusable runtime stage.
+type RuntimeStageInputs struct {
+	Backend                       string
+	Architecture                  string
+	ImageDigest                   string
+	GuestAgentHash                string
+	PreparedRuntimeRootFSVersion  string
+	GuestInitScriptTemplateDigest string
+}
+
+// WorkspaceStageInputs are the inputs that define the reusable workspace stage.
+type WorkspaceStageInputs struct {
+	RuntimeKey                  string
+	CanonicalRemoteURL          string
+	CommitSHA                   string
+	SubmoduleMode               string
+	SubmoduleResolutionDigest   string
+	CheckoutMode                string
+	DestinationDir              string
+	MaterializationRecipeDigest string
+}
+
+// DependencyStageInputs are the inputs that define the reusable dependency stage.
+type DependencyStageInputs struct {
+	WorkspaceKey               string
+	CompiledPolicyHash         string
+	ToolchainManifestDigest    string
+	ResolvedToolVersionsDigest string
+	LockfileInputsDigest       string
+	LockfileParserVersion      string
+	BootstrapRecipeDigest      string
+}
+
+// RuntimeStageKey returns the canonical cache key for a runtime stage output.
+func RuntimeStageKey(in RuntimeStageInputs) string {
+	return buildStageKey("runtime", []component{
+		{name: "backend", value: canonicalIdentifier(in.Backend)},
+		{name: "architecture", value: canonicalIdentifier(in.Architecture)},
+		{name: "image_digest", value: canonicalDigest(in.ImageDigest)},
+		{name: "guest_agent_hash", value: canonicalDigest(in.GuestAgentHash)},
+		{name: "prepared_runtime_rootfs_version", value: canonicalIdentifier(in.PreparedRuntimeRootFSVersion)},
+		{name: "guest_init_script_template_digest", value: canonicalDigest(in.GuestInitScriptTemplateDigest)},
+	})
+}
+
+// WorkspaceStageKey returns the canonical cache key for a workspace stage output.
+func WorkspaceStageKey(in WorkspaceStageInputs) string {
+	return buildStageKey("workspace", []component{
+		{name: "runtime_key", value: canonicalReference(in.RuntimeKey)},
+		{name: "canonical_remote_url", value: canonicalRemoteURL(in.CanonicalRemoteURL)},
+		{name: "commit_sha", value: canonicalDigest(in.CommitSHA)},
+		{name: "submodule_mode", value: canonicalIdentifier(in.SubmoduleMode)},
+		{name: "submodule_resolution_digest", value: canonicalDigest(in.SubmoduleResolutionDigest)},
+		{name: "checkout_mode", value: canonicalIdentifier(in.CheckoutMode)},
+		{name: "destination_dir", value: canonicalAbsolutePath(in.DestinationDir)},
+		{name: "materialization_recipe_digest", value: canonicalDigest(in.MaterializationRecipeDigest)},
+	})
+}
+
+// DependencyStageKey returns the canonical cache key for a dependency stage output.
+func DependencyStageKey(in DependencyStageInputs) string {
+	return buildStageKey("dependency", []component{
+		{name: "workspace_key", value: canonicalReference(in.WorkspaceKey)},
+		{name: "compiled_policy_hash", value: canonicalDigest(in.CompiledPolicyHash)},
+		{name: "toolchain_manifest_digest", value: canonicalDigest(in.ToolchainManifestDigest)},
+		{name: "resolved_tool_versions_digest", value: canonicalDigest(in.ResolvedToolVersionsDigest)},
+		{name: "lockfile_inputs_digest", value: canonicalDigest(in.LockfileInputsDigest)},
+		{name: "lockfile_parser_version", value: canonicalIdentifier(in.LockfileParserVersion)},
+		{name: "bootstrap_recipe_digest", value: canonicalDigest(in.BootstrapRecipeDigest)},
+	})
+}
+
+type component struct {
+	name  string
+	value string
+}
+
+func buildStageKey(stage string, components []component) string {
+	sum := sha256.Sum256(encodeStagePayload(stage, components))
+	return stage + ":" + formatVersion + ":" + hex.EncodeToString(sum[:])
+}
+
+func encodeStagePayload(stage string, components []component) []byte {
+	var buf bytes.Buffer
+	writeComponent(&buf, keyNamespace)
+	writeComponent(&buf, formatVersion)
+	writeComponent(&buf, stage)
+	for _, c := range components {
+		writeComponent(&buf, c.name)
+		writeComponent(&buf, c.value)
+	}
+	return buf.Bytes()
+}
+
+func writeComponent(buf *bytes.Buffer, value string) {
+	var lenBuf [8]byte
+	binary.BigEndian.PutUint64(lenBuf[:], uint64(len(value)))
+	_, _ = buf.Write(lenBuf[:])
+	_, _ = buf.WriteString(value)
+}
+
+func canonicalDigest(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func canonicalIdentifier(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func canonicalReference(value string) string {
+	return strings.TrimSpace(value)
+}
+
+func canonicalRemoteURL(value string) string {
+	return strings.TrimSpace(value)
+}
+
+func canonicalAbsolutePath(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return ""
+	}
+	if strings.HasPrefix(trimmed, "/") {
+		return path.Clean(trimmed)
+	}
+	return trimmed
+}

--- a/internal/cachekey/cachekey_test.go
+++ b/internal/cachekey/cachekey_test.go
@@ -35,6 +35,7 @@ func TestRuntimeStageKey(t *testing.T) {
 
 func TestWorkspaceStageKey(t *testing.T) {
 	inputs := WorkspaceStageInputs{
+		Backend:                     "firecracker",
 		RuntimeKey:                  "runtime:v1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 		CompiledPolicyHash:          "sha256:1111111111111111111111111111111111111111111111111111111111111111",
 		CanonicalRemoteURL:          "https://github.com/buildkite/cleanroom.git",
@@ -58,7 +59,7 @@ func TestWorkspaceStageKey(t *testing.T) {
 	}
 
 	mutated := inputs
-	mutated.CompiledPolicyHash = "sha256:6666666666666666666666666666666666666666666666666666666666666666"
+	mutated.Backend = "darwin-vz"
 	if gotMutated := WorkspaceStageKey(mutated); got == gotMutated {
 		t.Fatalf("workspace stage key did not change after input mutation: %q", got)
 	}

--- a/internal/cachekey/cachekey_test.go
+++ b/internal/cachekey/cachekey_test.go
@@ -1,0 +1,93 @@
+package cachekey
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRuntimeStageKey(t *testing.T) {
+	inputs := RuntimeStageInputs{
+		Backend:                       "firecracker",
+		Architecture:                  "amd64",
+		ImageDigest:                   "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+		GuestAgentHash:                "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+		PreparedRuntimeRootFSVersion:  "v1",
+		GuestInitScriptTemplateDigest: "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+	}
+
+	got := RuntimeStageKey(inputs)
+	if got == "" {
+		t.Fatal("runtime stage key is empty")
+	}
+	if !strings.HasPrefix(got, "runtime:v1:") {
+		t.Fatalf("runtime stage key prefix = %q, want %q", got, "runtime:v1:")
+	}
+	if gotAgain := RuntimeStageKey(inputs); got != gotAgain {
+		t.Fatalf("runtime stage key changed for identical inputs: first %q second %q", got, gotAgain)
+	}
+
+	mutated := inputs
+	mutated.ImageDigest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	if gotMutated := RuntimeStageKey(mutated); got == gotMutated {
+		t.Fatalf("runtime stage key did not change after input mutation: %q", got)
+	}
+}
+
+func TestWorkspaceStageKey(t *testing.T) {
+	inputs := WorkspaceStageInputs{
+		RuntimeKey:                  "runtime:v1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		CanonicalRemoteURL:          "https://github.com/buildkite/cleanroom.git",
+		CommitSHA:                   "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		SubmoduleMode:               "recursive",
+		SubmoduleResolutionDigest:   "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+		CheckoutMode:                "detached",
+		DestinationDir:              "/workspace",
+		MaterializationRecipeDigest: "sha256:5555555555555555555555555555555555555555555555555555555555555555",
+	}
+
+	got := WorkspaceStageKey(inputs)
+	if got == "" {
+		t.Fatal("workspace stage key is empty")
+	}
+	if !strings.HasPrefix(got, "workspace:v1:") {
+		t.Fatalf("workspace stage key prefix = %q, want %q", got, "workspace:v1:")
+	}
+	if gotAgain := WorkspaceStageKey(inputs); got != gotAgain {
+		t.Fatalf("workspace stage key changed for identical inputs: first %q second %q", got, gotAgain)
+	}
+
+	mutated := inputs
+	mutated.MaterializationRecipeDigest = "sha256:6666666666666666666666666666666666666666666666666666666666666666"
+	if gotMutated := WorkspaceStageKey(mutated); got == gotMutated {
+		t.Fatalf("workspace stage key did not change after input mutation: %q", got)
+	}
+}
+
+func TestDependencyStageKey(t *testing.T) {
+	inputs := DependencyStageInputs{
+		WorkspaceKey:               "workspace:v1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		CompiledPolicyHash:         "sha256:7777777777777777777777777777777777777777777777777777777777777777",
+		ToolchainManifestDigest:    "sha256:8888888888888888888888888888888888888888888888888888888888888888",
+		ResolvedToolVersionsDigest: "sha256:9999999999999999999999999999999999999999999999999999999999999999",
+		LockfileInputsDigest:       "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		LockfileParserVersion:      "v1",
+		BootstrapRecipeDigest:      "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+	}
+
+	got := DependencyStageKey(inputs)
+	if got == "" {
+		t.Fatal("dependency stage key is empty")
+	}
+	if !strings.HasPrefix(got, "dependency:v1:") {
+		t.Fatalf("dependency stage key prefix = %q, want %q", got, "dependency:v1:")
+	}
+	if gotAgain := DependencyStageKey(inputs); got != gotAgain {
+		t.Fatalf("dependency stage key changed for identical inputs: first %q second %q", got, gotAgain)
+	}
+
+	mutated := inputs
+	mutated.LockfileParserVersion = "v2"
+	if gotMutated := DependencyStageKey(mutated); got == gotMutated {
+		t.Fatalf("dependency stage key did not change after input mutation: %q", got)
+	}
+}

--- a/internal/cachekey/cachekey_test.go
+++ b/internal/cachekey/cachekey_test.go
@@ -36,6 +36,7 @@ func TestRuntimeStageKey(t *testing.T) {
 func TestWorkspaceStageKey(t *testing.T) {
 	inputs := WorkspaceStageInputs{
 		RuntimeKey:                  "runtime:v1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		CompiledPolicyHash:          "sha256:1111111111111111111111111111111111111111111111111111111111111111",
 		CanonicalRemoteURL:          "https://github.com/buildkite/cleanroom.git",
 		CommitSHA:                   "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
 		SubmoduleMode:               "recursive",
@@ -57,7 +58,7 @@ func TestWorkspaceStageKey(t *testing.T) {
 	}
 
 	mutated := inputs
-	mutated.MaterializationRecipeDigest = "sha256:6666666666666666666666666666666666666666666666666666666666666666"
+	mutated.CompiledPolicyHash = "sha256:6666666666666666666666666666666666666666666666666666666666666666"
 	if gotMutated := WorkspaceStageKey(mutated); got == gotMutated {
 		t.Fatalf("workspace stage key did not change after input mutation: %q", got)
 	}

--- a/internal/cachestore/store.go
+++ b/internal/cachestore/store.go
@@ -19,6 +19,7 @@ type Record struct {
 	CacheKey            string
 	Stage               string
 	State               string
+	BackingSnapshotID   string
 	Backend             string
 	PolicyHash          string
 	Policy              *cleanroomv1.Policy
@@ -61,6 +62,14 @@ func New(opts Options) (*Store, error) {
 }
 
 func (s *Store) Create(ctx context.Context, record Record) error {
+	return s.persist(ctx, record, false)
+}
+
+func (s *Store) Upsert(ctx context.Context, record Record) error {
+	return s.persist(ctx, record, true)
+}
+
+func (s *Store) persist(ctx context.Context, record Record, replace bool) error {
 	if strings.TrimSpace(record.CacheKey) == "" {
 		return fmt.Errorf("cache record missing cache key")
 	}
@@ -72,6 +81,9 @@ func (s *Store) Create(ctx context.Context, record Record) error {
 	}
 	if strings.TrimSpace(record.Backend) == "" {
 		return fmt.Errorf("cache record %q missing backend", record.CacheKey)
+	}
+	if strings.TrimSpace(record.BackingSnapshotID) == "" {
+		return fmt.Errorf("cache record %q missing backing snapshot id", record.CacheKey)
 	}
 	if strings.TrimSpace(record.PolicyHash) == "" {
 		return fmt.Errorf("cache record %q missing policy hash", record.CacheKey)
@@ -113,11 +125,13 @@ func (s *Store) Create(ctx context.Context, record Record) error {
 	}
 	defer db.Close()
 
-	if _, err := db.ExecContext(ctx, `
+	verb := "insert"
+	statement := `
 		INSERT INTO cache_entries (
 			cache_key,
 			stage,
 			state,
+			backing_snapshot_id,
 			backend,
 			policy_hash,
 			policy_proto,
@@ -129,11 +143,50 @@ func (s *Store) Create(ctx context.Context, record Record) error {
 			created_at_unix_nano,
 			last_used_at_unix_nano,
 			producer_version
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-	`,
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`
+	if replace {
+		verb = "upsert"
+		statement = `
+			INSERT INTO cache_entries (
+				cache_key,
+				stage,
+				state,
+				backing_snapshot_id,
+				backend,
+				policy_hash,
+				policy_proto,
+				repository_proto,
+				parent_cache_key,
+				storage_driver,
+				storage_ref,
+				input_manifest_digest,
+				created_at_unix_nano,
+				last_used_at_unix_nano,
+				producer_version
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			ON CONFLICT(stage, cache_key) DO UPDATE SET
+				state = excluded.state,
+				backing_snapshot_id = excluded.backing_snapshot_id,
+				backend = excluded.backend,
+				policy_hash = excluded.policy_hash,
+				policy_proto = excluded.policy_proto,
+				repository_proto = excluded.repository_proto,
+				parent_cache_key = excluded.parent_cache_key,
+				storage_driver = excluded.storage_driver,
+				storage_ref = excluded.storage_ref,
+				input_manifest_digest = excluded.input_manifest_digest,
+				created_at_unix_nano = excluded.created_at_unix_nano,
+				last_used_at_unix_nano = excluded.last_used_at_unix_nano,
+				producer_version = excluded.producer_version
+		`
+	}
+
+	if _, err := db.ExecContext(ctx, statement,
 		record.CacheKey,
 		record.Stage,
 		record.State,
+		record.BackingSnapshotID,
 		record.Backend,
 		record.PolicyHash,
 		policyBytes,
@@ -146,7 +199,7 @@ func (s *Store) Create(ctx context.Context, record Record) error {
 		record.LastUsedAt.UTC().UnixNano(),
 		record.ProducerVersion,
 	); err != nil {
-		return fmt.Errorf("insert cache metadata %q/%q: %w", record.Stage, record.CacheKey, err)
+		return fmt.Errorf("%s cache metadata %q/%q: %w", verb, record.Stage, record.CacheKey, err)
 	}
 	return nil
 }
@@ -163,6 +216,7 @@ func (s *Store) GetReady(ctx context.Context, stage, cacheKey string) (Record, b
 			cache_key,
 			stage,
 			state,
+			backing_snapshot_id,
 			backend,
 			policy_hash,
 			policy_proto,
@@ -229,6 +283,7 @@ func (s *Store) List(ctx context.Context) ([]Record, error) {
 			cache_key,
 			stage,
 			state,
+			backing_snapshot_id,
 			backend,
 			policy_hash,
 			policy_proto,
@@ -320,6 +375,9 @@ func (s *Store) initDB(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("initialise cache metadata schema: %w", err)
 	}
+	if _, err := db.ExecContext(ctx, `ALTER TABLE cache_entries ADD COLUMN backing_snapshot_id TEXT NOT NULL DEFAULT ''`); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
+		return fmt.Errorf("ensure cache metadata backing_snapshot_id column: %w", err)
+	}
 	return nil
 }
 
@@ -341,6 +399,7 @@ func scanRecord(row recordScanner) (Record, error) {
 		&record.CacheKey,
 		&record.Stage,
 		&record.State,
+		&record.BackingSnapshotID,
 		&record.Backend,
 		&record.PolicyHash,
 		&policyBytes,

--- a/internal/cachestore/store.go
+++ b/internal/cachestore/store.go
@@ -1,0 +1,393 @@
+package cachestore
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+	"github.com/buildkite/cleanroom/internal/paths"
+	"google.golang.org/protobuf/proto"
+	_ "modernc.org/sqlite"
+)
+
+type Record struct {
+	CacheKey            string
+	Stage               string
+	State               string
+	Backend             string
+	PolicyHash          string
+	Policy              *cleanroomv1.Policy
+	Repository          *cleanroomv1.RepositoryCheckout
+	ParentCacheKey      string
+	StorageDriver       string
+	StorageRef          string
+	InputManifestDigest string
+	CreatedAt           time.Time
+	LastUsedAt          time.Time
+	ProducerVersion     string
+}
+
+type Options struct {
+	MetadataDBPath string
+}
+
+type Store struct {
+	metadataDBPath string
+}
+
+func New(opts Options) (*Store, error) {
+	metadataDBPath := strings.TrimSpace(opts.MetadataDBPath)
+	if metadataDBPath == "" {
+		var err error
+		metadataDBPath, err = defaultMetadataDBPath()
+		if err != nil {
+			return nil, fmt.Errorf("resolve cache metadata database path: %w", err)
+		}
+	}
+	if err := os.MkdirAll(filepath.Dir(metadataDBPath), 0o755); err != nil {
+		return nil, fmt.Errorf("create cache metadata directory for %q: %w", metadataDBPath, err)
+	}
+
+	store := &Store{metadataDBPath: metadataDBPath}
+	if err := store.initDB(context.Background()); err != nil {
+		return nil, err
+	}
+	return store, nil
+}
+
+func (s *Store) Create(ctx context.Context, record Record) error {
+	if strings.TrimSpace(record.CacheKey) == "" {
+		return fmt.Errorf("cache record missing cache key")
+	}
+	if strings.TrimSpace(record.Stage) == "" {
+		return fmt.Errorf("cache record %q missing stage", record.CacheKey)
+	}
+	if strings.TrimSpace(record.State) == "" {
+		return fmt.Errorf("cache record %q missing state", record.CacheKey)
+	}
+	if strings.TrimSpace(record.Backend) == "" {
+		return fmt.Errorf("cache record %q missing backend", record.CacheKey)
+	}
+	if strings.TrimSpace(record.PolicyHash) == "" {
+		return fmt.Errorf("cache record %q missing policy hash", record.CacheKey)
+	}
+	if record.Policy == nil {
+		return fmt.Errorf("cache record %q missing policy", record.CacheKey)
+	}
+	if strings.TrimSpace(record.StorageRef) == "" {
+		return fmt.Errorf("cache record %q missing storage ref", record.CacheKey)
+	}
+	if strings.TrimSpace(record.StorageDriver) == "" {
+		return fmt.Errorf("cache record %q missing storage driver", record.CacheKey)
+	}
+	if strings.TrimSpace(record.ProducerVersion) == "" {
+		return fmt.Errorf("cache record %q missing producer version", record.CacheKey)
+	}
+	if record.CreatedAt.IsZero() {
+		record.CreatedAt = time.Now().UTC()
+	}
+	if record.LastUsedAt.IsZero() {
+		record.LastUsedAt = record.CreatedAt
+	}
+
+	policyBytes, err := proto.Marshal(record.Policy)
+	if err != nil {
+		return fmt.Errorf("marshal cache policy %q: %w", record.CacheKey, err)
+	}
+	var repositoryBytes []byte
+	if record.Repository != nil {
+		repositoryBytes, err = proto.Marshal(record.Repository)
+		if err != nil {
+			return fmt.Errorf("marshal cache repository %q: %w", record.CacheKey, err)
+		}
+	}
+
+	db, err := s.open(ctx)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO cache_entries (
+			cache_key,
+			stage,
+			state,
+			backend,
+			policy_hash,
+			policy_proto,
+			repository_proto,
+			parent_cache_key,
+			storage_driver,
+			storage_ref,
+			input_manifest_digest,
+			created_at_unix_nano,
+			last_used_at_unix_nano,
+			producer_version
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`,
+		record.CacheKey,
+		record.Stage,
+		record.State,
+		record.Backend,
+		record.PolicyHash,
+		policyBytes,
+		repositoryBytes,
+		nullableString(record.ParentCacheKey),
+		record.StorageDriver,
+		record.StorageRef,
+		nullableString(record.InputManifestDigest),
+		record.CreatedAt.UTC().UnixNano(),
+		record.LastUsedAt.UTC().UnixNano(),
+		record.ProducerVersion,
+	); err != nil {
+		return fmt.Errorf("insert cache metadata %q/%q: %w", record.Stage, record.CacheKey, err)
+	}
+	return nil
+}
+
+func (s *Store) GetReady(ctx context.Context, stage, cacheKey string) (Record, bool, error) {
+	db, err := s.open(ctx)
+	if err != nil {
+		return Record{}, false, err
+	}
+	defer db.Close()
+
+	row := db.QueryRowContext(ctx, `
+		SELECT
+			cache_key,
+			stage,
+			state,
+			backend,
+			policy_hash,
+			policy_proto,
+			repository_proto,
+			parent_cache_key,
+			storage_driver,
+			storage_ref,
+			input_manifest_digest,
+			created_at_unix_nano,
+			last_used_at_unix_nano,
+			producer_version
+		FROM cache_entries
+		WHERE stage = ? AND cache_key = ? AND state = 'ready'
+	`, strings.TrimSpace(stage), strings.TrimSpace(cacheKey))
+
+	record, err := scanRecord(row)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return Record{}, false, nil
+		}
+		return Record{}, false, err
+	}
+	return record, true, nil
+}
+
+func (s *Store) UpdateLastUsedAt(ctx context.Context, stage, cacheKey string, lastUsedAt time.Time) error {
+	if lastUsedAt.IsZero() {
+		lastUsedAt = time.Now().UTC()
+	}
+
+	db, err := s.open(ctx)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	result, err := db.ExecContext(ctx, `
+		UPDATE cache_entries
+		SET last_used_at_unix_nano = ?
+		WHERE stage = ? AND cache_key = ?
+	`, lastUsedAt.UTC().UnixNano(), strings.TrimSpace(stage), strings.TrimSpace(cacheKey))
+	if err != nil {
+		return fmt.Errorf("update cache last used time %q/%q: %w", stage, cacheKey, err)
+	}
+	if rows, _ := result.RowsAffected(); rows == 0 {
+		return fmt.Errorf("cache metadata %q/%q not found", stage, cacheKey)
+	}
+	return nil
+}
+
+func (s *Store) Touch(ctx context.Context, stage, cacheKey string) error {
+	return s.UpdateLastUsedAt(ctx, stage, cacheKey, time.Now().UTC())
+}
+
+func (s *Store) List(ctx context.Context) ([]Record, error) {
+	db, err := s.open(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+
+	rows, err := db.QueryContext(ctx, `
+		SELECT
+			cache_key,
+			stage,
+			state,
+			backend,
+			policy_hash,
+			policy_proto,
+			repository_proto,
+			parent_cache_key,
+			storage_driver,
+			storage_ref,
+			input_manifest_digest,
+			created_at_unix_nano,
+			last_used_at_unix_nano,
+			producer_version
+		FROM cache_entries
+		ORDER BY created_at_unix_nano ASC, cache_key ASC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("query cache metadata: %w", err)
+	}
+	defer rows.Close()
+
+	items := make([]Record, 0)
+	for rows.Next() {
+		record, scanErr := scanRecord(rows)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		items = append(items, record)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate cache metadata: %w", err)
+	}
+	return items, nil
+}
+
+func (s *Store) Delete(ctx context.Context, stage, cacheKey string) error {
+	db, err := s.open(ctx)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	if _, err := db.ExecContext(ctx, `
+		DELETE FROM cache_entries
+		WHERE stage = ? AND cache_key = ?
+	`, strings.TrimSpace(stage), strings.TrimSpace(cacheKey)); err != nil {
+		return fmt.Errorf("delete cache metadata %q/%q: %w", stage, cacheKey, err)
+	}
+	return nil
+}
+
+func (s *Store) open(ctx context.Context) (*sql.DB, error) {
+	if err := s.initDB(ctx); err != nil {
+		return nil, err
+	}
+	db, err := sql.Open("sqlite", s.metadataDBPath)
+	if err != nil {
+		return nil, fmt.Errorf("open cache metadata database %q: %w", s.metadataDBPath, err)
+	}
+	return db, nil
+}
+
+func (s *Store) initDB(ctx context.Context) error {
+	db, err := sql.Open("sqlite", s.metadataDBPath)
+	if err != nil {
+		return fmt.Errorf("open cache metadata database %q: %w", s.metadataDBPath, err)
+	}
+	defer db.Close()
+
+	_, err = db.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS cache_entries (
+			cache_key TEXT NOT NULL,
+			stage TEXT NOT NULL,
+			state TEXT NOT NULL,
+			backend TEXT NOT NULL,
+			policy_hash TEXT NOT NULL,
+			policy_proto BLOB NOT NULL,
+			repository_proto BLOB,
+			parent_cache_key TEXT,
+			storage_driver TEXT NOT NULL DEFAULT 'file',
+			storage_ref TEXT NOT NULL,
+			input_manifest_digest TEXT,
+			created_at_unix_nano INTEGER NOT NULL,
+			last_used_at_unix_nano INTEGER NOT NULL,
+			producer_version TEXT NOT NULL,
+			PRIMARY KEY (stage, cache_key)
+		);
+		CREATE INDEX IF NOT EXISTS idx_cache_entries_state_created_at ON cache_entries(state, created_at_unix_nano);
+		CREATE INDEX IF NOT EXISTS idx_cache_entries_last_used_at ON cache_entries(last_used_at_unix_nano);
+	`)
+	if err != nil {
+		return fmt.Errorf("initialise cache metadata schema: %w", err)
+	}
+	return nil
+}
+
+type recordScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanRecord(row recordScanner) (Record, error) {
+	var (
+		record          Record
+		policyBytes     []byte
+		repositoryBytes []byte
+		parentCacheKey  sql.NullString
+		inputDigest     sql.NullString
+		createdAtNano   int64
+		lastUsedAtNano  int64
+	)
+	if err := row.Scan(
+		&record.CacheKey,
+		&record.Stage,
+		&record.State,
+		&record.Backend,
+		&record.PolicyHash,
+		&policyBytes,
+		&repositoryBytes,
+		&parentCacheKey,
+		&record.StorageDriver,
+		&record.StorageRef,
+		&inputDigest,
+		&createdAtNano,
+		&lastUsedAtNano,
+		&record.ProducerVersion,
+	); err != nil {
+		return Record{}, err
+	}
+
+	record.Policy = &cleanroomv1.Policy{}
+	if err := proto.Unmarshal(policyBytes, record.Policy); err != nil {
+		return Record{}, fmt.Errorf("decode cache policy %q/%q: %w", record.Stage, record.CacheKey, err)
+	}
+	if len(repositoryBytes) > 0 {
+		record.Repository = &cleanroomv1.RepositoryCheckout{}
+		if err := proto.Unmarshal(repositoryBytes, record.Repository); err != nil {
+			return Record{}, fmt.Errorf("decode cache repository %q/%q: %w", record.Stage, record.CacheKey, err)
+		}
+	}
+	if parentCacheKey.Valid {
+		record.ParentCacheKey = parentCacheKey.String
+	}
+	if inputDigest.Valid {
+		record.InputManifestDigest = inputDigest.String
+	}
+	record.CreatedAt = time.Unix(0, createdAtNano).UTC()
+	record.LastUsedAt = time.Unix(0, lastUsedAtNano).UTC()
+	return record, nil
+}
+
+func nullableString(value string) any {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	return value
+}
+
+func defaultMetadataDBPath() (string, error) {
+	base, err := paths.CacheBaseDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, "stage-caches", "metadata.db"), nil
+}

--- a/internal/cachestore/store_test.go
+++ b/internal/cachestore/store_test.go
@@ -1,0 +1,282 @@
+package cachestore
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+)
+
+func TestStoreCreateGetReadyListDelete(t *testing.T) {
+	t.Parallel()
+
+	store, err := New(Options{MetadataDBPath: filepath.Join(t.TempDir(), "caches.db")})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	record := Record{
+		CacheKey:   "workspace-seed:test",
+		Stage:      "workspace",
+		State:      "ready",
+		Backend:    "firecracker",
+		PolicyHash: "policy-hash",
+		Policy: &cleanroomv1.Policy{
+			Version:        1,
+			ImageRef:       "ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			ImageDigest:    "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			NetworkDefault: "deny",
+			Hash:           "policy-hash",
+		},
+		Repository: &cleanroomv1.RepositoryCheckout{
+			RemoteUrl:      "https://github.com/buildkite/cleanroom.git",
+			CommitSha:      "0123456789abcdef0123456789abcdef01234567",
+			DestinationDir: "/workspace",
+			Submodules:     true,
+			Branch:         "main",
+		},
+		ParentCacheKey:      "runtime:test",
+		StorageRef:          "/tmp/workspace-test.ext4",
+		StorageDriver:       "file",
+		InputManifestDigest: "sha256:manifest",
+		CreatedAt:           time.Unix(1700000000, 123).UTC(),
+		LastUsedAt:          time.Unix(1700000001, 456).UTC(),
+		ProducerVersion:     "cleanroom-test/1",
+	}
+	if err := store.Create(context.Background(), record); err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+
+	got, ok, err := store.GetReady(context.Background(), record.Stage, record.CacheKey)
+	if err != nil {
+		t.Fatalf("GetReady returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected stored ready cache")
+	}
+	if got.CacheKey != record.CacheKey || got.Stage != record.Stage || got.State != record.State || got.PolicyHash != record.PolicyHash || got.StorageRef != record.StorageRef || got.StorageDriver != record.StorageDriver || got.ParentCacheKey != record.ParentCacheKey || got.InputManifestDigest != record.InputManifestDigest || got.ProducerVersion != record.ProducerVersion {
+		t.Fatalf("unexpected cache record: %#v", got)
+	}
+	if !got.CreatedAt.Equal(record.CreatedAt) {
+		t.Fatalf("unexpected created_at: got %s want %s", got.CreatedAt.Format(time.RFC3339Nano), record.CreatedAt.Format(time.RFC3339Nano))
+	}
+	if !got.LastUsedAt.Equal(record.LastUsedAt) {
+		t.Fatalf("unexpected last_used_at: got %s want %s", got.LastUsedAt.Format(time.RFC3339Nano), record.LastUsedAt.Format(time.RFC3339Nano))
+	}
+	if got.Policy == nil || got.Policy.GetImageRef() != record.Policy.GetImageRef() {
+		t.Fatalf("unexpected stored policy: %#v", got.Policy)
+	}
+	if got.Repository == nil || got.Repository.GetDestinationDir() != record.Repository.GetDestinationDir() || got.Repository.GetCommitSha() != record.Repository.GetCommitSha() {
+		t.Fatalf("unexpected stored repository: %#v", got.Repository)
+	}
+
+	items, err := store.List(context.Background())
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if got, want := len(items), 1; got != want {
+		t.Fatalf("unexpected cache count: got %d want %d", got, want)
+	}
+
+	if err := store.Delete(context.Background(), record.Stage, record.CacheKey); err != nil {
+		t.Fatalf("Delete returned error: %v", err)
+	}
+	if _, ok, err := store.GetReady(context.Background(), record.Stage, record.CacheKey); err != nil {
+		t.Fatalf("GetReady after delete returned error: %v", err)
+	} else if ok {
+		t.Fatal("expected cache to be deleted")
+	}
+}
+
+func TestStoreGetReadyFiltersNonReadyStates(t *testing.T) {
+	t.Parallel()
+
+	store, err := New(Options{MetadataDBPath: filepath.Join(t.TempDir(), "caches.db")})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	record := Record{
+		CacheKey:        "dependency-seed:test",
+		Stage:           "dependency",
+		State:           "failed",
+		Backend:         "firecracker",
+		PolicyHash:      "policy-hash",
+		Policy:          testPolicy(),
+		StorageRef:      "/tmp/dependency-test.ext4",
+		StorageDriver:   "file",
+		ProducerVersion: "cleanroom-test/1",
+	}
+	if err := store.Create(context.Background(), record); err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+
+	if _, ok, err := store.GetReady(context.Background(), record.Stage, record.CacheKey); err != nil {
+		t.Fatalf("GetReady returned error: %v", err)
+	} else if ok {
+		t.Fatal("expected non-ready cache to be hidden from GetReady")
+	}
+}
+
+func TestStoreUpdateLastUsedAtAndTouch(t *testing.T) {
+	t.Parallel()
+
+	store, err := New(Options{MetadataDBPath: filepath.Join(t.TempDir(), "caches.db")})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	record := Record{
+		CacheKey:        "runtime:test",
+		Stage:           "runtime",
+		State:           "ready",
+		Backend:         "firecracker",
+		PolicyHash:      "policy-hash",
+		Policy:          testPolicy(),
+		StorageRef:      "/tmp/runtime-test.ext4",
+		StorageDriver:   "file",
+		ProducerVersion: "cleanroom-test/1",
+		CreatedAt:       time.Unix(1700000000, 0).UTC(),
+		LastUsedAt:      time.Unix(1700000000, 0).UTC(),
+	}
+	if err := store.Create(context.Background(), record); err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+
+	next := time.Unix(1700000100, 789).UTC()
+	if err := store.UpdateLastUsedAt(context.Background(), record.Stage, record.CacheKey, next); err != nil {
+		t.Fatalf("UpdateLastUsedAt returned error: %v", err)
+	}
+
+	got, ok, err := store.GetReady(context.Background(), record.Stage, record.CacheKey)
+	if err != nil {
+		t.Fatalf("GetReady returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected stored cache")
+	}
+	if !got.LastUsedAt.Equal(next) {
+		t.Fatalf("unexpected last_used_at after update: got %s want %s", got.LastUsedAt.Format(time.RFC3339Nano), next.Format(time.RFC3339Nano))
+	}
+
+	if err := store.Touch(context.Background(), record.Stage, record.CacheKey); err != nil {
+		t.Fatalf("Touch returned error: %v", err)
+	}
+	touched, ok, err := store.GetReady(context.Background(), record.Stage, record.CacheKey)
+	if err != nil {
+		t.Fatalf("GetReady after touch returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected stored cache after touch")
+	}
+	if !touched.LastUsedAt.After(next) {
+		t.Fatalf("expected touched last_used_at to move forward, got %s want after %s", touched.LastUsedAt.Format(time.RFC3339Nano), next.Format(time.RFC3339Nano))
+	}
+}
+
+func TestStoreListOrdersByCreatedAtNanoseconds(t *testing.T) {
+	t.Parallel()
+
+	store, err := New(Options{MetadataDBPath: filepath.Join(t.TempDir(), "caches.db")})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	first := Record{
+		CacheKey:        "workspace-seed:first",
+		Stage:           "workspace",
+		State:           "ready",
+		Backend:         "firecracker",
+		PolicyHash:      "policy-hash",
+		Policy:          testPolicy(),
+		StorageRef:      "/tmp/workspace-first.ext4",
+		StorageDriver:   "file",
+		CreatedAt:       time.Unix(1700000000, 100).UTC(),
+		LastUsedAt:      time.Unix(1700000000, 100).UTC(),
+		ProducerVersion: "cleanroom-test/1",
+	}
+	second := Record{
+		CacheKey:        "workspace-seed:second",
+		Stage:           "workspace",
+		State:           "ready",
+		Backend:         "firecracker",
+		PolicyHash:      "policy-hash",
+		Policy:          testPolicy(),
+		StorageRef:      "/tmp/workspace-second.ext4",
+		StorageDriver:   "file",
+		CreatedAt:       time.Unix(1700000000, 200).UTC(),
+		LastUsedAt:      time.Unix(1700000000, 200).UTC(),
+		ProducerVersion: "cleanroom-test/1",
+	}
+	if err := store.Create(context.Background(), second); err != nil {
+		t.Fatalf("Create second returned error: %v", err)
+	}
+	if err := store.Create(context.Background(), first); err != nil {
+		t.Fatalf("Create first returned error: %v", err)
+	}
+
+	items, err := store.List(context.Background())
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if got, want := len(items), 2; got != want {
+		t.Fatalf("unexpected cache count: got %d want %d", got, want)
+	}
+	if got, want := items[0].CacheKey, first.CacheKey; got != want {
+		t.Fatalf("unexpected first cache in list: got %q want %q", got, want)
+	}
+	if got, want := items[1].CacheKey, second.CacheKey; got != want {
+		t.Fatalf("unexpected second cache in list: got %q want %q", got, want)
+	}
+}
+
+func TestNewMigratesLegacySchemalessDatabase(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "caches.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open legacy cache db: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = db.Close()
+	})
+	if err := db.Close(); err != nil {
+		t.Fatalf("close legacy cache db: %v", err)
+	}
+
+	store, err := New(Options{MetadataDBPath: dbPath})
+	if err != nil {
+		t.Fatalf("New returned error for legacy cache db: %v", err)
+	}
+
+	record := Record{
+		CacheKey:        "runtime:test",
+		Stage:           "runtime",
+		State:           "ready",
+		Backend:         "firecracker",
+		PolicyHash:      "policy-hash",
+		Policy:          testPolicy(),
+		StorageRef:      "/tmp/runtime-test.ext4",
+		StorageDriver:   "file",
+		CreatedAt:       time.Unix(1700000000, 123).UTC(),
+		LastUsedAt:      time.Unix(1700000000, 456).UTC(),
+		ProducerVersion: "cleanroom-test/1",
+	}
+	if err := store.Create(context.Background(), record); err != nil {
+		t.Fatalf("Create returned error after legacy init: %v", err)
+	}
+}
+
+func testPolicy() *cleanroomv1.Policy {
+	return &cleanroomv1.Policy{
+		Version:        1,
+		ImageRef:       "ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		ImageDigest:    "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		NetworkDefault: "deny",
+		Hash:           "policy-hash",
+	}
+}

--- a/internal/cachestore/store_test.go
+++ b/internal/cachestore/store_test.go
@@ -19,11 +19,12 @@ func TestStoreCreateGetReadyListDelete(t *testing.T) {
 	}
 
 	record := Record{
-		CacheKey:   "workspace-seed:test",
-		Stage:      "workspace",
-		State:      "ready",
-		Backend:    "firecracker",
-		PolicyHash: "policy-hash",
+		CacheKey:          "workspace-seed:test",
+		Stage:             "workspace",
+		State:             "ready",
+		BackingSnapshotID: "snapshot-workspace-test",
+		Backend:           "firecracker",
+		PolicyHash:        "policy-hash",
 		Policy: &cleanroomv1.Policy{
 			Version:        1,
 			ImageRef:       "ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
@@ -100,15 +101,16 @@ func TestStoreGetReadyFiltersNonReadyStates(t *testing.T) {
 	}
 
 	record := Record{
-		CacheKey:        "dependency-seed:test",
-		Stage:           "dependency",
-		State:           "failed",
-		Backend:         "firecracker",
-		PolicyHash:      "policy-hash",
-		Policy:          testPolicy(),
-		StorageRef:      "/tmp/dependency-test.ext4",
-		StorageDriver:   "file",
-		ProducerVersion: "cleanroom-test/1",
+		CacheKey:          "dependency-seed:test",
+		Stage:             "dependency",
+		State:             "failed",
+		BackingSnapshotID: "snapshot-dependency-test",
+		Backend:           "firecracker",
+		PolicyHash:        "policy-hash",
+		Policy:            testPolicy(),
+		StorageRef:        "/tmp/dependency-test.ext4",
+		StorageDriver:     "file",
+		ProducerVersion:   "cleanroom-test/1",
 	}
 	if err := store.Create(context.Background(), record); err != nil {
 		t.Fatalf("Create returned error: %v", err)
@@ -130,17 +132,18 @@ func TestStoreUpdateLastUsedAtAndTouch(t *testing.T) {
 	}
 
 	record := Record{
-		CacheKey:        "runtime:test",
-		Stage:           "runtime",
-		State:           "ready",
-		Backend:         "firecracker",
-		PolicyHash:      "policy-hash",
-		Policy:          testPolicy(),
-		StorageRef:      "/tmp/runtime-test.ext4",
-		StorageDriver:   "file",
-		ProducerVersion: "cleanroom-test/1",
-		CreatedAt:       time.Unix(1700000000, 0).UTC(),
-		LastUsedAt:      time.Unix(1700000000, 0).UTC(),
+		CacheKey:          "runtime:test",
+		Stage:             "runtime",
+		State:             "ready",
+		BackingSnapshotID: "snapshot-runtime-test",
+		Backend:           "firecracker",
+		PolicyHash:        "policy-hash",
+		Policy:            testPolicy(),
+		StorageRef:        "/tmp/runtime-test.ext4",
+		StorageDriver:     "file",
+		ProducerVersion:   "cleanroom-test/1",
+		CreatedAt:         time.Unix(1700000000, 0).UTC(),
+		LastUsedAt:        time.Unix(1700000000, 0).UTC(),
 	}
 	if err := store.Create(context.Background(), record); err != nil {
 		t.Fatalf("Create returned error: %v", err)
@@ -186,30 +189,32 @@ func TestStoreListOrdersByCreatedAtNanoseconds(t *testing.T) {
 	}
 
 	first := Record{
-		CacheKey:        "workspace-seed:first",
-		Stage:           "workspace",
-		State:           "ready",
-		Backend:         "firecracker",
-		PolicyHash:      "policy-hash",
-		Policy:          testPolicy(),
-		StorageRef:      "/tmp/workspace-first.ext4",
-		StorageDriver:   "file",
-		CreatedAt:       time.Unix(1700000000, 100).UTC(),
-		LastUsedAt:      time.Unix(1700000000, 100).UTC(),
-		ProducerVersion: "cleanroom-test/1",
+		CacheKey:          "workspace-seed:first",
+		Stage:             "workspace",
+		State:             "ready",
+		BackingSnapshotID: "snapshot-workspace-first",
+		Backend:           "firecracker",
+		PolicyHash:        "policy-hash",
+		Policy:            testPolicy(),
+		StorageRef:        "/tmp/workspace-first.ext4",
+		StorageDriver:     "file",
+		CreatedAt:         time.Unix(1700000000, 100).UTC(),
+		LastUsedAt:        time.Unix(1700000000, 100).UTC(),
+		ProducerVersion:   "cleanroom-test/1",
 	}
 	second := Record{
-		CacheKey:        "workspace-seed:second",
-		Stage:           "workspace",
-		State:           "ready",
-		Backend:         "firecracker",
-		PolicyHash:      "policy-hash",
-		Policy:          testPolicy(),
-		StorageRef:      "/tmp/workspace-second.ext4",
-		StorageDriver:   "file",
-		CreatedAt:       time.Unix(1700000000, 200).UTC(),
-		LastUsedAt:      time.Unix(1700000000, 200).UTC(),
-		ProducerVersion: "cleanroom-test/1",
+		CacheKey:          "workspace-seed:second",
+		Stage:             "workspace",
+		State:             "ready",
+		BackingSnapshotID: "snapshot-workspace-second",
+		Backend:           "firecracker",
+		PolicyHash:        "policy-hash",
+		Policy:            testPolicy(),
+		StorageRef:        "/tmp/workspace-second.ext4",
+		StorageDriver:     "file",
+		CreatedAt:         time.Unix(1700000000, 200).UTC(),
+		LastUsedAt:        time.Unix(1700000000, 200).UTC(),
+		ProducerVersion:   "cleanroom-test/1",
 	}
 	if err := store.Create(context.Background(), second); err != nil {
 		t.Fatalf("Create second returned error: %v", err)
@@ -230,6 +235,42 @@ func TestStoreListOrdersByCreatedAtNanoseconds(t *testing.T) {
 	}
 	if got, want := items[1].CacheKey, second.CacheKey; got != want {
 		t.Fatalf("unexpected second cache in list: got %q want %q", got, want)
+	}
+}
+
+func TestStoreCreateRejectsDuplicateStageCacheKey(t *testing.T) {
+	t.Parallel()
+
+	store, err := New(Options{MetadataDBPath: filepath.Join(t.TempDir(), "caches.db")})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	record := Record{
+		CacheKey:          "workspace-seed:test",
+		Stage:             "workspace",
+		State:             "ready",
+		BackingSnapshotID: "snapshot-workspace-test",
+		Backend:           "firecracker",
+		PolicyHash:        "policy-hash",
+		Policy:            testPolicy(),
+		StorageRef:        "/tmp/workspace-test.ext4",
+		StorageDriver:     "file",
+		ProducerVersion:   "cleanroom-test/1",
+	}
+	if err := store.Create(context.Background(), record); err != nil {
+		t.Fatalf("first Create returned error: %v", err)
+	}
+	if err := store.Create(context.Background(), record); err == nil {
+		t.Fatal("expected duplicate cache insert to fail")
+	}
+
+	items, err := store.List(context.Background())
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if got, want := len(items), 1; got != want {
+		t.Fatalf("expected duplicate cache insert to keep one record, got %d want %d", got, want)
 	}
 }
 
@@ -254,17 +295,18 @@ func TestNewMigratesLegacySchemalessDatabase(t *testing.T) {
 	}
 
 	record := Record{
-		CacheKey:        "runtime:test",
-		Stage:           "runtime",
-		State:           "ready",
-		Backend:         "firecracker",
-		PolicyHash:      "policy-hash",
-		Policy:          testPolicy(),
-		StorageRef:      "/tmp/runtime-test.ext4",
-		StorageDriver:   "file",
-		CreatedAt:       time.Unix(1700000000, 123).UTC(),
-		LastUsedAt:      time.Unix(1700000000, 456).UTC(),
-		ProducerVersion: "cleanroom-test/1",
+		CacheKey:          "runtime:test",
+		Stage:             "runtime",
+		State:             "ready",
+		BackingSnapshotID: "snapshot-runtime-test",
+		Backend:           "firecracker",
+		PolicyHash:        "policy-hash",
+		Policy:            testPolicy(),
+		StorageRef:        "/tmp/runtime-test.ext4",
+		StorageDriver:     "file",
+		CreatedAt:         time.Unix(1700000000, 123).UTC(),
+		LastUsedAt:        time.Unix(1700000000, 456).UTC(),
+		ProducerVersion:   "cleanroom-test/1",
 	}
 	if err := store.Create(context.Background(), record); err != nil {
 		t.Fatalf("Create returned error after legacy init: %v", err)

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -15,6 +15,7 @@ import (
 	"github.com/buildkite/cleanroom/internal/backend"
 	"github.com/buildkite/cleanroom/internal/backend/darwinvz"
 	"github.com/buildkite/cleanroom/internal/backend/firecracker"
+	"github.com/buildkite/cleanroom/internal/cachestore"
 	"github.com/buildkite/cleanroom/internal/controlserver"
 	"github.com/buildkite/cleanroom/internal/controlservice"
 	"github.com/buildkite/cleanroom/internal/endpoint"
@@ -34,6 +35,8 @@ type ServeCommand struct {
 
 var serveSignalNotifyContext = signal.NotifyContext
 var newSnapshotMetadataStore = snapshotstore.New
+var newCacheMetadataStore = cachestore.New
+var gatewayScopeTokenSourcePolicyForGatewayHost = gateway.ScopeTokenSourcePolicyForGatewayHost
 
 func (s *ServeCommand) Run(ctx *runtimeContext) error {
 	return s.runServer(ctx)
@@ -195,12 +198,17 @@ func newControlService(ctx *runtimeContext, logger *log.Logger, mirrors gateway.
 	if err != nil {
 		return nil, fmt.Errorf("configure snapshot metadata store: %w", err)
 	}
+	cacheMetadataStore, err := newCacheMetadataStore(cachestore.Options{})
+	if err != nil {
+		return nil, fmt.Errorf("configure cache metadata store: %w", err)
+	}
 
 	if ctx == nil {
 		return &controlservice.Service{
 			Logger:            logger,
 			RepositoryMirrors: mirrors,
 			SnapshotStore:     snapshotMetadataStore,
+			CacheStore:        cacheMetadataStore,
 		}, nil
 	}
 	return &controlservice.Service{
@@ -210,6 +218,7 @@ func newControlService(ctx *runtimeContext, logger *log.Logger, mirrors gateway.
 		Logger:            logger,
 		RepositoryMirrors: mirrors,
 		SnapshotStore:     snapshotMetadataStore,
+		CacheStore:        cacheMetadataStore,
 	}, nil
 }
 

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -198,28 +198,38 @@ func newControlService(ctx *runtimeContext, logger *log.Logger, mirrors gateway.
 	if err != nil {
 		return nil, fmt.Errorf("configure snapshot metadata store: %w", err)
 	}
-	cacheMetadataStore, err := newCacheMetadataStore(cachestore.Options{})
+	var cacheMetadataStore *cachestore.Store
+	cacheMetadataStore, err = newCacheMetadataStore(cachestore.Options{})
 	if err != nil {
-		return nil, fmt.Errorf("configure cache metadata store: %w", err)
+		if logger != nil {
+			logger.Warn("cache metadata store unavailable; stage caches disabled", "error", err)
+		}
+		cacheMetadataStore = nil
 	}
 
 	if ctx == nil {
-		return &controlservice.Service{
+		service := &controlservice.Service{
 			Logger:            logger,
 			RepositoryMirrors: mirrors,
 			SnapshotStore:     snapshotMetadataStore,
-			CacheStore:        cacheMetadataStore,
-		}, nil
+		}
+		if cacheMetadataStore != nil {
+			service.CacheStore = cacheMetadataStore
+		}
+		return service, nil
 	}
-	return &controlservice.Service{
+	service := &controlservice.Service{
 		Loader:            ctx.Loader,
 		Config:            ctx.Config,
 		Backends:          ctx.Backends,
 		Logger:            logger,
 		RepositoryMirrors: mirrors,
 		SnapshotStore:     snapshotMetadataStore,
-		CacheStore:        cacheMetadataStore,
-	}, nil
+	}
+	if cacheMetadataStore != nil {
+		service.CacheStore = cacheMetadataStore
+	}
+	return service, nil
 }
 
 func shouldInstallGatewayFirewall(goos string) bool {

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/buildkite/cleanroom/internal/backend"
 	"github.com/buildkite/cleanroom/internal/backend/darwinvz"
 	"github.com/buildkite/cleanroom/internal/backend/firecracker"
+	"github.com/buildkite/cleanroom/internal/cachestore"
 	"github.com/buildkite/cleanroom/internal/gateway"
 	"github.com/buildkite/cleanroom/internal/runtimeconfig"
 	"github.com/buildkite/cleanroom/internal/snapshotstore"
@@ -169,6 +170,35 @@ func TestNewControlServiceReturnsSnapshotStoreError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "configure snapshot metadata store") {
 		t.Fatalf("expected snapshot metadata store context in error, got: %v", err)
+	}
+}
+
+func TestNewControlServiceIgnoresCacheStoreError(t *testing.T) {
+	prevSnapshotStoreFactory := newSnapshotMetadataStore
+	prevCacheStoreFactory := newCacheMetadataStore
+	t.Cleanup(func() {
+		newSnapshotMetadataStore = prevSnapshotStoreFactory
+		newCacheMetadataStore = prevCacheStoreFactory
+	})
+	newSnapshotMetadataStore = func(snapshotstore.Options) (*snapshotstore.Store, error) {
+		return &snapshotstore.Store{}, nil
+	}
+	newCacheMetadataStore = func(cachestore.Options) (*cachestore.Store, error) {
+		return nil, errors.New("cache metadata unavailable")
+	}
+
+	service, err := newControlService(&runtimeContext{}, log.New(io.Discard), nil)
+	if err != nil {
+		t.Fatalf("newControlService returned error: %v", err)
+	}
+	if service == nil {
+		t.Fatal("expected non-nil service when cache metadata store setup fails")
+	}
+	if service.CacheStore != nil {
+		t.Fatal("expected cache store to remain nil when cache metadata setup fails")
+	}
+	if service.SnapshotStore == nil {
+		t.Fatal("expected snapshot store to remain configured when cache metadata setup fails")
 	}
 }
 

--- a/internal/controlservice/repository_helpers.go
+++ b/internal/controlservice/repository_helpers.go
@@ -3,6 +3,8 @@ package controlservice
 import (
 	"errors"
 	"fmt"
+	"path"
+	"strings"
 
 	"github.com/buildkite/cleanroom/internal/policy"
 	"github.com/buildkite/cleanroom/internal/repositorycheckout"
@@ -26,12 +28,40 @@ func repositoryCheckoutsEqual(a, b *repositorycheckout.Checkout) bool {
 	case a == nil || b == nil:
 		return a == nil && b == nil
 	default:
+		a = normalizeRepositoryCheckoutForComparison(a)
+		b = normalizeRepositoryCheckoutForComparison(b)
 		return a.RemoteURL == b.RemoteURL &&
 			a.CommitSHA == b.CommitSHA &&
 			a.DestinationDir == b.DestinationDir &&
 			a.Submodules == b.Submodules &&
 			a.Branch == b.Branch
 	}
+}
+
+func normalizeRepositoryCheckoutForComparison(repository *repositorycheckout.Checkout) *repositorycheckout.Checkout {
+	if repository == nil {
+		return nil
+	}
+	normalized := cloneRepositoryCheckout(repository)
+	normalized.RemoteURL = strings.TrimSpace(normalized.RemoteURL)
+	if normalizedURL, _, err := repositorycheckout.CanonicalizeRemoteURL(normalized.RemoteURL); err == nil {
+		normalized.RemoteURL = normalizedURL
+	}
+	normalized.CommitSHA = strings.ToLower(strings.TrimSpace(normalized.CommitSHA))
+	normalized.DestinationDir = normalizeRepositoryDestinationDir(normalized.DestinationDir)
+	normalized.Branch = strings.TrimSpace(normalized.Branch)
+	return normalized
+}
+
+func normalizeRepositoryDestinationDir(destinationDir string) string {
+	trimmed := strings.TrimSpace(destinationDir)
+	if trimmed == "" {
+		return ""
+	}
+	if strings.HasPrefix(trimmed, "/") {
+		return path.Clean(trimmed)
+	}
+	return trimmed
 }
 
 func validateRepositoryCheckoutForPolicy(compiled *policy.CompiledPolicy, repository *repositorycheckout.Checkout) error {

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/cachestore"
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
 	"github.com/buildkite/cleanroom/internal/paths"
 	"github.com/buildkite/cleanroom/internal/policy"
@@ -39,6 +40,7 @@ type Service struct {
 	// If this grows again, extract a dedicated snapshot manager rather than
 	// adding more snapshot-specific branching here.
 	SnapshotStore snapshotMetadataStore
+	CacheStore    cacheMetadataStore
 
 	mu                sync.RWMutex
 	sandboxes         map[string]*sandboxState
@@ -129,6 +131,14 @@ type snapshotMetadataStore interface {
 	Delete(context.Context, string) error
 }
 
+type cacheMetadataStore interface {
+	Create(context.Context, cachestore.Record) error
+	GetReady(context.Context, string, string) (cachestore.Record, bool, error)
+	Touch(context.Context, string, string) error
+	List(context.Context) ([]cachestore.Record, error)
+	Delete(context.Context, string, string) error
+}
+
 type executionOptions struct {
 	LaunchSeconds int64
 	DisableMise   bool
@@ -195,7 +205,7 @@ func (s *Service) CreateSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 	firecrackerCfg.RunDir = ""
 	firecrackerCfg = withRepositoryBootstrapRootFSMinimum(firecrackerCfg, compiled, repository)
 
-	replacedWorkspaceSeedSnapshotID := ""
+	var replacedWorkspaceSeedRecord *cachestore.Record
 	workspaceSeedRuntimeBaseKey := ""
 	workspaceSeedCachingEnabled := false
 	if repository != nil {
@@ -210,16 +220,20 @@ func (s *Service) CreateSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 				if err != nil {
 					s.logWorkspaceSeedWarning("lookup workspace seed snapshot", "", err)
 				} else if found {
-					resp, restoreErr := s.createSandboxFromSnapshot(ctx, &cleanroomv1.CreateSandboxRequest{
+					restoreReq := &cleanroomv1.CreateSandboxRequest{
 						Backend: backendName,
 						Options: req.GetOptions(),
-						Source:  &cleanroomv1.CreateSandboxRequest_SnapshotId{SnapshotId: record.SnapshotID},
-					}, record.SnapshotID)
+					}
+					resp, restoreErr := s.createSandboxFromCacheRecord(ctx, restoreReq, compiled, record)
 					if restoreErr == nil {
+						if cacheStore, err := s.cacheStoreOrErr(); err == nil {
+							_ = cacheStore.Touch(ctx, record.Stage, record.CacheKey)
+						}
 						return resp, nil
 					}
-					replacedWorkspaceSeedSnapshotID = record.SnapshotID
-					s.logWorkspaceSeedRestoreWarning(record.SnapshotID, restoreErr)
+					recordCopy := record
+					replacedWorkspaceSeedRecord = &recordCopy
+					s.logWorkspaceSeedRestoreWarning(record, restoreErr)
 				}
 			}
 		}
@@ -264,7 +278,7 @@ func (s *Service) CreateSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 		return nil, fmt.Errorf("bootstrap repository checkout: %w", err)
 	}
 	if snapshotAdapter, ok := adapter.(backend.SnapshottingAdapter); ok && workspaceSeedCachingEnabled {
-		s.maybePublishWorkspaceSeedSnapshot(ctx, snapshotAdapter, sandboxID, backendName, compiled, firecrackerCfg, workspaceSeedRuntimeBaseKey, repository, replacedWorkspaceSeedSnapshotID)
+		s.maybePublishWorkspaceSeedSnapshot(ctx, snapshotAdapter, sandboxID, backendName, compiled, firecrackerCfg, workspaceSeedRuntimeBaseKey, repository, replacedWorkspaceSeedRecord)
 	}
 
 	state := &sandboxState{
@@ -308,15 +322,6 @@ func (s *Service) createSandboxFromSnapshot(ctx context.Context, req *cleanroomv
 		return nil, err
 	}
 
-	s.mu.Lock()
-	s.ensureMapsLocked()
-	if err := s.beginSnapshotUseLocked(snapshotID); err != nil {
-		s.mu.Unlock()
-		return nil, err
-	}
-	s.mu.Unlock()
-	defer s.finishSnapshotUse(snapshotID)
-
 	record, ok, err := store.Get(ctx, snapshotID)
 	if err != nil {
 		return nil, fmt.Errorf("load snapshot %q: %w", snapshotID, err)
@@ -324,84 +329,24 @@ func (s *Service) createSandboxFromSnapshot(ctx context.Context, req *cleanroomv
 	if !ok {
 		return nil, fmt.Errorf("unknown snapshot %q", snapshotID)
 	}
+	return s.createSandboxFromSnapshotRecord(ctx, req, record)
+}
 
-	backendName := record.Backend
-	if requested := strings.TrimSpace(req.GetBackend()); requested != "" && requested != backendName {
-		return nil, fmt.Errorf("snapshot %q requires backend %q, got %q", snapshotID, backendName, requested)
+func (s *Service) createSandboxFromSnapshotRecord(ctx context.Context, req *cleanroomv1.CreateSandboxRequest, record snapshotstore.Record) (*cleanroomv1.CreateSandboxResponse, error) {
+	snapshotID := strings.TrimSpace(record.SnapshotID)
+	if snapshotID == "" {
+		return nil, errors.New("missing snapshot_id")
 	}
+	if err := s.beginSnapshotUse(snapshotID); err != nil {
+		return nil, err
+	}
+	defer s.finishSnapshotUse(snapshotID)
 
-	adapter, ok := s.Backends[backendName]
-	if !ok {
-		return nil, fmt.Errorf("unknown backend %q", backendName)
-	}
-	snapshotAdapter, ok := adapter.(backend.SnapshottingAdapter)
-	if !ok {
-		return nil, fmt.Errorf("backend %q does not support snapshot-backed sandbox creation", backendName)
-	}
-	if !snapshotOperationsEnabledForBackend(backendName, s.Config) {
-		return nil, fmt.Errorf("snapshots are not enabled for backend %q", backendName)
-	}
-
-	compiled, err := policy.FromProto(record.Policy)
+	source, err := storedRootFSRecordFromSnapshot(record)
 	if err != nil {
-		return nil, fmt.Errorf("invalid snapshot policy %q: %w", snapshotID, err)
+		return nil, err
 	}
-
-	opts := req.GetOptions()
-	execOpts := executionOptions{}
-	if opts != nil {
-		execOpts.LaunchSeconds = opts.GetLaunchSeconds()
-	}
-	firecrackerCfg := runtimeconfig.MergeBackendConfig(s.Config, backendName, execOpts.LaunchSeconds)
-	firecrackerCfg.RunDir = ""
-	firecrackerCfg = withSnapshotDriver(backendName, firecrackerCfg, record.StorageDriver)
-
-	now := s.clock().Now()
-	sandboxID := s.ids().NewSandboxID()
-	if err := snapshotAdapter.ProvisionSandboxFromSnapshot(ctx, backend.ProvisionFromSnapshotRequest{
-		SandboxID:         sandboxID,
-		SnapshotID:        record.SnapshotID,
-		StorageRef:        record.StorageRef,
-		Policy:            compiled,
-		FirecrackerConfig: firecrackerCfg,
-	}); err != nil {
-		return nil, fmt.Errorf("provision sandbox from snapshot: %w", err)
-	}
-
-	state := &sandboxState{
-		ID:          sandboxID,
-		Backend:     backendName,
-		Policy:      compiled,
-		Firecracker: firecrackerCfg,
-		Repository:  repositorycheckout.FromProto(record.Repository),
-		CreatedAt:   now,
-		UpdatedAt:   now,
-		Status:      cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY,
-		events:      newEventFeed[*cleanroomv1.SandboxEvent](s.retention().maxRetainedSandboxEvents),
-		Done:        make(chan struct{}),
-	}
-
-	s.mu.Lock()
-	s.ensureMapsLocked()
-	s.sandboxes[sandboxID] = state
-	s.recordSandboxEventLocked(state, cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY, fmt.Sprintf("sandbox created from snapshot %s and ready", snapshotID))
-	s.pruneStateLocked(now)
-	resp := &cleanroomv1.CreateSandboxResponse{
-		Sandbox: cloneSandboxLocked(state),
-		Message: "sandbox created from snapshot and ready",
-	}
-	s.mu.Unlock()
-
-	if s.Logger != nil {
-		s.Logger.Info("sandbox created from snapshot",
-			"sandbox_id", sandboxID,
-			"snapshot_id", snapshotID,
-			"backend", backendName,
-			"policy_hash", compiled.Hash,
-		)
-	}
-
-	return resp, nil
+	return s.createSandboxFromStoredRootFS(ctx, req, source, nil)
 }
 
 func (s *Service) GetSandbox(_ context.Context, req *cleanroomv1.GetSandboxRequest) (*cleanroomv1.GetSandboxResponse, error) {
@@ -456,9 +401,6 @@ func (s *Service) CreateSnapshot(ctx context.Context, req *cleanroomv1.CreateSna
 	now := time.Now().UTC()
 	snapshotID := newSnapshotID()
 	name := strings.TrimSpace(req.GetName())
-	if isWorkspaceSeedSnapshotName(name) {
-		return nil, fmt.Errorf("snapshot name %q is reserved for managed workspace seed snapshots", name)
-	}
 
 	var (
 		record          snapshotstore.Record
@@ -1960,6 +1902,13 @@ func (s *Service) beginSnapshotUseLocked(snapshotID string) error {
 	return nil
 }
 
+func (s *Service) beginSnapshotUse(snapshotID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ensureMapsLocked()
+	return s.beginSnapshotUseLocked(strings.TrimSpace(snapshotID))
+}
+
 func (s *Service) finishSnapshotUse(snapshotID string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -2383,6 +2332,13 @@ func (s *Service) snapshotStoreOrErr() (snapshotMetadataStore, error) {
 		return nil, errors.New("snapshot metadata store is not configured")
 	}
 	return s.SnapshotStore, nil
+}
+
+func (s *Service) cacheStoreOrErr() (cacheMetadataStore, error) {
+	if s.CacheStore == nil {
+		return nil, errors.New("cache metadata store is not configured")
+	}
+	return s.CacheStore, nil
 }
 
 func cloneSnapshotRecord(record snapshotstore.Record) *cleanroomv1.Snapshot {

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -133,6 +133,7 @@ type snapshotMetadataStore interface {
 
 type cacheMetadataStore interface {
 	Create(context.Context, cachestore.Record) error
+	Upsert(context.Context, cachestore.Record) error
 	GetReady(context.Context, string, string) (cachestore.Record, bool, error)
 	Touch(context.Context, string, string) error
 	List(context.Context) ([]cachestore.Record, error)

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -558,13 +558,9 @@ func (s *Service) DeleteSnapshot(ctx context.Context, req *cleanroomv1.DeleteSna
 	}
 	snapshotID := strings.TrimSpace(req.GetSnapshotId())
 
-	s.mu.Lock()
-	s.ensureMapsLocked()
-	if err := s.beginSnapshotDeleteLocked(snapshotID); err != nil {
-		s.mu.Unlock()
+	if err := s.beginSnapshotDelete(snapshotID); err != nil {
 		return nil, err
 	}
-	s.mu.Unlock()
 	defer s.finishSnapshotDelete(snapshotID)
 
 	store, err := s.snapshotStoreOrErr()
@@ -1934,6 +1930,13 @@ func (s *Service) beginSnapshotDeleteLocked(snapshotID string) error {
 	}
 	s.snapshotDeletions[snapshotID] = struct{}{}
 	return nil
+}
+
+func (s *Service) beginSnapshotDelete(snapshotID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ensureMapsLocked()
+	return s.beginSnapshotDeleteLocked(strings.TrimSpace(snapshotID))
 }
 
 func (s *Service) finishSnapshotDelete(snapshotID string) {

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -318,6 +318,15 @@ func (s *Service) CreateSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 }
 
 func (s *Service) createSandboxFromSnapshot(ctx context.Context, req *cleanroomv1.CreateSandboxRequest, snapshotID string) (*cleanroomv1.CreateSandboxResponse, error) {
+	snapshotID = strings.TrimSpace(snapshotID)
+	if snapshotID == "" {
+		return nil, errors.New("missing snapshot_id")
+	}
+	if err := s.beginSnapshotUse(snapshotID); err != nil {
+		return nil, err
+	}
+	defer s.finishSnapshotUse(snapshotID)
+
 	store, err := s.snapshotStoreOrErr()
 	if err != nil {
 		return nil, err
@@ -338,10 +347,6 @@ func (s *Service) createSandboxFromSnapshotRecord(ctx context.Context, req *clea
 	if snapshotID == "" {
 		return nil, errors.New("missing snapshot_id")
 	}
-	if err := s.beginSnapshotUse(snapshotID); err != nil {
-		return nil, err
-	}
-	defer s.finishSnapshotUse(snapshotID)
 
 	source, err := storedRootFSRecordFromSnapshot(record)
 	if err != nil {

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -11,6 +11,7 @@ import (
 	"unsafe"
 
 	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/cachestore"
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
 	"github.com/buildkite/cleanroom/internal/paths"
 	"github.com/buildkite/cleanroom/internal/policy"
@@ -208,6 +209,9 @@ func newTestService(adapter backend.Adapter) *Service {
 }
 
 func newTestServiceWithSnapshotStore(adapter backend.Adapter, store snapshotMetadataStore) *Service {
+	if store == nil {
+		store = newMemorySnapshotStore()
+	}
 	return &Service{
 		Loader: stubLoader{
 			compiled: &policy.CompiledPolicy{
@@ -231,6 +235,7 @@ func newTestServiceWithSnapshotStore(adapter backend.Adapter, store snapshotMeta
 		},
 		Backends:      map[string]backend.Adapter{"firecracker": adapter},
 		SnapshotStore: store,
+		CacheStore:    newMemoryCacheStore(),
 	}
 }
 
@@ -288,6 +293,62 @@ func (s *memorySnapshotStore) Delete(_ context.Context, snapshotID string) error
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	delete(s.records, snapshotID)
+	return nil
+}
+
+type memoryCacheStore struct {
+	mu      sync.Mutex
+	records map[string]cachestore.Record
+}
+
+func newMemoryCacheStore() *memoryCacheStore {
+	return &memoryCacheStore{records: map[string]cachestore.Record{}}
+}
+
+func (s *memoryCacheStore) Create(_ context.Context, record cachestore.Record) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.records[record.Stage+"\x00"+record.CacheKey] = record
+	return nil
+}
+
+func (s *memoryCacheStore) GetReady(_ context.Context, stage, cacheKey string) (cachestore.Record, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	record, ok := s.records[stage+"\x00"+cacheKey]
+	if !ok || record.State != cacheStateReady {
+		return cachestore.Record{}, false, nil
+	}
+	return record, true, nil
+}
+
+func (s *memoryCacheStore) Touch(_ context.Context, stage, cacheKey string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := stage + "\x00" + cacheKey
+	record, ok := s.records[key]
+	if !ok {
+		return errors.New("cache record not found")
+	}
+	record.LastUsedAt = time.Now().UTC()
+	s.records[key] = record
+	return nil
+}
+
+func (s *memoryCacheStore) List(_ context.Context) ([]cachestore.Record, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	items := make([]cachestore.Record, 0, len(s.records))
+	for _, record := range s.records {
+		items = append(items, record)
+	}
+	return items, nil
+}
+
+func (s *memoryCacheStore) Delete(_ context.Context, stage, cacheKey string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.records, stage+"\x00"+cacheKey)
 	return nil
 }
 
@@ -470,7 +531,7 @@ func TestCreateSnapshotPersistsMetadataAndDeletesIt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListSnapshots returned error: %v", err)
 	}
-	if got, want := len(listResp.GetSnapshots()), 2; got != want {
+	if got, want := len(listResp.GetSnapshots()), 1; got != want {
 		t.Fatalf("unexpected snapshot count: got %d want %d", got, want)
 	}
 
@@ -491,8 +552,8 @@ func TestCreateSnapshotPersistsMetadataAndDeletesIt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListSnapshots after delete returned error: %v", err)
 	}
-	if got := len(listResp.GetSnapshots()); got != 1 {
-		t.Fatalf("expected workspace seed snapshot to remain after deleting manual snapshot, got %d snapshots", got)
+	if got := len(listResp.GetSnapshots()); got != 0 {
+		t.Fatalf("expected only the manual snapshot to be deleted from snapshot metadata, got %d snapshots", got)
 	}
 }
 
@@ -521,7 +582,7 @@ func TestCreateSnapshotRejectsDisabledSnapshots(t *testing.T) {
 	}
 }
 
-func TestCreateSnapshotRejectsReservedWorkspaceSeedName(t *testing.T) {
+func TestCreateSnapshotAllowsWorkspaceSeedLikeNames(t *testing.T) {
 	store := newMemorySnapshotStore()
 	adapter := &stubAdapter{}
 	svc := newTestServiceWithSnapshotStore(adapter, store)
@@ -531,17 +592,17 @@ func TestCreateSnapshotRejectsReservedWorkspaceSeedName(t *testing.T) {
 		t.Fatalf("CreateSandbox returned error: %v", err)
 	}
 
-	_, err = svc.CreateSnapshot(context.Background(), &cleanroomv1.CreateSnapshotRequest{
+	resp, err := svc.CreateSnapshot(context.Background(), &cleanroomv1.CreateSnapshotRequest{
 		SandboxId: createResp.GetSandbox().GetSandboxId(),
-		Name:      workspaceSeedSnapshotNamePrefix + "manual",
+		Name:      "workspace-seed:manual",
 	})
-	if err == nil {
-		t.Fatal("expected CreateSnapshot to reject reserved workspace seed snapshot names")
+	if err != nil {
+		t.Fatalf("CreateSnapshot returned error: %v", err)
 	}
-	if !strings.Contains(err.Error(), "reserved for managed workspace seed snapshots") {
-		t.Fatalf("unexpected error: %v", err)
+	if got, want := resp.GetSnapshot().GetName(), "workspace-seed:manual"; got != want {
+		t.Fatalf("unexpected snapshot name: got %q want %q", got, want)
 	}
-	if got, want := adapter.createSnapshotCalls, 0; got != want {
+	if got, want := adapter.createSnapshotCalls, 1; got != want {
 		t.Fatalf("unexpected create snapshot call count: got %d want %d", got, want)
 	}
 }
@@ -1183,63 +1244,45 @@ func TestCreateSandboxPublishesWorkspaceSeedSnapshot(t *testing.T) {
 		t.Fatalf("unexpected snapshot sandbox id: got %q want %q", got, want)
 	}
 
-	records, err := store.List(context.Background())
+	cacheStore, ok := svc.CacheStore.(*memoryCacheStore)
+	if !ok {
+		t.Fatalf("expected memory cache store, got %T", svc.CacheStore)
+	}
+	records, err := cacheStore.List(context.Background())
 	if err != nil {
 		t.Fatalf("List returned error: %v", err)
 	}
 	if got, want := len(records), 1; got != want {
-		t.Fatalf("unexpected snapshot record count: got %d want %d", got, want)
+		t.Fatalf("unexpected workspace cache record count: got %d want %d", got, want)
 	}
 	record := records[0]
 	compiled, err := policy.FromProto(testRepositoryPolicy())
 	if err != nil {
 		t.Fatalf("FromProto returned error: %v", err)
 	}
-	if got, want := record.Name, workspaceSeedSnapshotName("firecracker", compiled.Hash, "runtime-base:test", repositorycheckout.FromProto(testRepositoryCheckoutProto())); got != want {
-		t.Fatalf("unexpected workspace seed snapshot name: got %q want %q", got, want)
+	if got, want := record.CacheKey, workspaceStageCacheKey("runtime-base:test", repositorycheckout.FromProto(testRepositoryCheckoutProto())); got != want {
+		t.Fatalf("unexpected workspace cache key: got %q want %q", got, want)
+	}
+	if got, want := record.Stage, workspaceStageName; got != want {
+		t.Fatalf("unexpected workspace cache stage: got %q want %q", got, want)
+	}
+	if got, want := record.State, cacheStateReady; got != want {
+		t.Fatalf("unexpected workspace cache state: got %q want %q", got, want)
+	}
+	if got, want := record.ParentCacheKey, "runtime-base:test"; got != want {
+		t.Fatalf("unexpected parent cache key: got %q want %q", got, want)
+	}
+	if got, want := record.PolicyHash, compiled.Hash; got != want {
+		t.Fatalf("unexpected policy hash: got %q want %q", got, want)
 	}
 	if record.Repository == nil {
-		t.Fatal("expected repository metadata on workspace seed snapshot")
+		t.Fatal("expected repository metadata on workspace stage cache")
 	}
 	if got, want := record.Repository.GetCommitSha(), testRepositoryCheckoutProto().GetCommitSha(); got != want {
-		t.Fatalf("unexpected workspace seed commit: got %q want %q", got, want)
+		t.Fatalf("unexpected workspace stage commit: got %q want %q", got, want)
 	}
 	if got, want := record.CreatedAt, publishedAt; !got.Equal(want) {
-		t.Fatalf("unexpected workspace seed created_at: got %s want %s", got.Format(time.RFC3339Nano), want.Format(time.RFC3339Nano))
-	}
-}
-
-func TestWorkspaceSeedSnapshotRecordBreaksCreatedAtTiesBySnapshotID(t *testing.T) {
-	compiled, err := policy.FromProto(testRepositoryPolicy())
-	if err != nil {
-		t.Fatalf("FromProto returned error: %v", err)
-	}
-	repository := repositorycheckout.FromProto(testRepositoryCheckoutProto())
-	createdAt := time.Unix(1_700_000_000, 0).UTC()
-
-	older := snapshotstore.Record{
-		SnapshotID: "snap_00000000000000000000000001",
-		Backend:    "firecracker",
-		Name:       workspaceSeedSnapshotName("firecracker", compiled.Hash, "runtime-base:test", repository),
-		PolicyHash: compiled.Hash,
-		Repository: repository.ToProto(),
-		CreatedAt:  createdAt,
-	}
-	newer := snapshotstore.Record{
-		SnapshotID: "snap_00000000000000000000000002",
-		Backend:    "firecracker",
-		Name:       workspaceSeedSnapshotName("firecracker", compiled.Hash, "runtime-base:test", repository),
-		PolicyHash: compiled.Hash,
-		Repository: repository.ToProto(),
-		CreatedAt:  createdAt,
-	}
-
-	record, ok := workspaceSeedSnapshotRecord([]snapshotstore.Record{older, newer}, "firecracker", compiled.Hash, "runtime-base:test", repository)
-	if !ok {
-		t.Fatal("expected workspace seed snapshot record match")
-	}
-	if got, want := record.SnapshotID, newer.SnapshotID; got != want {
-		t.Fatalf("expected tie-break to prefer newer snapshot id, got %q want %q", got, want)
+		t.Fatalf("unexpected workspace stage created_at: got %s want %s", got.Format(time.RFC3339Nano), want.Format(time.RFC3339Nano))
 	}
 }
 
@@ -1347,12 +1390,16 @@ func TestCreateSandboxDoesNotReuseWorkspaceSeedWhenRuntimeBaseKeyChanges(t *test
 		t.Fatalf("expected runtime base change to publish a new workspace seed, got %d want %d", got, want)
 	}
 
-	records, err := store.List(context.Background())
+	cacheStore, ok := svc.CacheStore.(*memoryCacheStore)
+	if !ok {
+		t.Fatalf("expected memory cache store, got %T", svc.CacheStore)
+	}
+	records, err := cacheStore.List(context.Background())
 	if err != nil {
 		t.Fatalf("List returned error: %v", err)
 	}
 	if got, want := len(records), 2; got != want {
-		t.Fatalf("expected two workspace seed snapshots after runtime base change, got %d want %d", got, want)
+		t.Fatalf("expected two workspace stage cache records after runtime base change, got %d want %d", got, want)
 	}
 }
 
@@ -1402,13 +1449,24 @@ func TestCreateSandboxFallsBackWhenWorkspaceSeedRestoreFails(t *testing.T) {
 	if got, want := mirrors.calls, 2; got != want {
 		t.Fatalf("expected fallback path to re-prewarm mirror, got %d want %d", got, want)
 	}
-
-	records, err := store.List(context.Background())
+	cacheStore, ok := svc.CacheStore.(*memoryCacheStore)
+	if !ok {
+		t.Fatalf("expected memory cache store, got %T", svc.CacheStore)
+	}
+	records, err := cacheStore.List(context.Background())
 	if err != nil {
 		t.Fatalf("List returned error: %v", err)
 	}
-	if got, want := len(records), 2; got != want {
-		t.Fatalf("expected failed restore fallback to retain old snapshot and publish a new one, got %d want %d", got, want)
+	if got, want := len(records), 1; got != want {
+		t.Fatalf("expected failed restore replacement to leave one workspace stage cache record, got %d want %d", got, want)
+	}
+
+	snapshotRecords, err := store.List(context.Background())
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if got, want := len(snapshotRecords), 0; got != want {
+		t.Fatalf("expected workspace stage snapshots to stay out of snapshot metadata, got %d want %d", got, want)
 	}
 }
 

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -308,14 +309,25 @@ func newMemoryCacheStore() *memoryCacheStore {
 func (s *memoryCacheStore) Create(_ context.Context, record cachestore.Record) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.records[record.Stage+"\x00"+record.CacheKey] = record
+	key := cacheStoreKey(record.Stage, record.CacheKey)
+	if _, exists := s.records[key]; exists {
+		return errors.New("cache record already exists")
+	}
+	s.records[key] = record
+	return nil
+}
+
+func (s *memoryCacheStore) Upsert(_ context.Context, record cachestore.Record) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.records[cacheStoreKey(record.Stage, record.CacheKey)] = record
 	return nil
 }
 
 func (s *memoryCacheStore) GetReady(_ context.Context, stage, cacheKey string) (cachestore.Record, bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	record, ok := s.records[stage+"\x00"+cacheKey]
+	record, ok := s.records[cacheStoreKey(stage, cacheKey)]
 	if !ok || record.State != cacheStateReady {
 		return cachestore.Record{}, false, nil
 	}
@@ -325,7 +337,7 @@ func (s *memoryCacheStore) GetReady(_ context.Context, stage, cacheKey string) (
 func (s *memoryCacheStore) Touch(_ context.Context, stage, cacheKey string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	key := stage + "\x00" + cacheKey
+	key := cacheStoreKey(stage, cacheKey)
 	record, ok := s.records[key]
 	if !ok {
 		return errors.New("cache record not found")
@@ -348,8 +360,23 @@ func (s *memoryCacheStore) List(_ context.Context) ([]cachestore.Record, error) 
 func (s *memoryCacheStore) Delete(_ context.Context, stage, cacheKey string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	delete(s.records, stage+"\x00"+cacheKey)
+	delete(s.records, cacheStoreKey(stage, cacheKey))
 	return nil
+}
+
+func cacheStoreKey(stage, cacheKey string) string {
+	return strings.TrimSpace(stage) + "\x00" + strings.TrimSpace(cacheKey)
+}
+
+func cacheRecordBackingSnapshotID(record cachestore.Record) (string, bool) {
+	value := reflect.ValueOf(record)
+	for _, fieldName := range []string{"BackingSnapshotID", "SnapshotID", "BackingSnapshotIdentity"} {
+		field := value.FieldByName(fieldName)
+		if field.IsValid() && field.Kind() == reflect.String {
+			return field.String(), true
+		}
+	}
+	return "", false
 }
 
 func TestExecutionStreamIncludesExitEvent(t *testing.T) {
@@ -1212,7 +1239,7 @@ func TestCreateSandboxBootstrapsRepositoryInService(t *testing.T) {
 	}
 }
 
-func TestCreateSandboxPublishesWorkspaceSeedSnapshot(t *testing.T) {
+func TestCreateSandboxPublishesWorkspaceStageCache(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	store := newMemorySnapshotStore()
 	adapter := &stubAdapter{
@@ -1281,12 +1308,19 @@ func TestCreateSandboxPublishesWorkspaceSeedSnapshot(t *testing.T) {
 	if got, want := record.Repository.GetCommitSha(), testRepositoryCheckoutProto().GetCommitSha(); got != want {
 		t.Fatalf("unexpected workspace stage commit: got %q want %q", got, want)
 	}
+	backingSnapshotID, ok := cacheRecordBackingSnapshotID(record)
+	if !ok {
+		t.Fatal("expected workspace stage cache to include backing snapshot identity")
+	}
+	if got, want := backingSnapshotID, adapter.createSnapshotReq.SnapshotID; got != want {
+		t.Fatalf("unexpected workspace stage backing snapshot identity: got %q want %q", got, want)
+	}
 	if got, want := record.CreatedAt, publishedAt; !got.Equal(want) {
 		t.Fatalf("unexpected workspace stage created_at: got %s want %s", got.Format(time.RFC3339Nano), want.Format(time.RFC3339Nano))
 	}
 }
 
-func TestCreateSandboxReusesWorkspaceSeedSnapshot(t *testing.T) {
+func TestCreateSandboxReusesWorkspaceStageCache(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	store := newMemorySnapshotStore()
 	adapter := &stubAdapter{
@@ -1403,7 +1437,7 @@ func TestCreateSandboxDoesNotReuseWorkspaceSeedWhenRuntimeBaseKeyChanges(t *test
 	}
 }
 
-func TestCreateSandboxFallsBackWhenWorkspaceSeedRestoreFails(t *testing.T) {
+func TestCreateSandboxFallsBackWhenWorkspaceStageRestoreFails(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	store := newMemorySnapshotStore()
 	adapter := &stubAdapter{
@@ -1426,6 +1460,7 @@ func TestCreateSandboxFallsBackWhenWorkspaceSeedRestoreFails(t *testing.T) {
 	if _, err := svc.CreateSandbox(context.Background(), req); err != nil {
 		t.Fatalf("first CreateSandbox returned error: %v", err)
 	}
+	firstSnapshotID := adapter.createSnapshotReq.SnapshotID
 
 	secondResp, err := svc.CreateSandbox(context.Background(), req)
 	if err != nil {
@@ -1449,6 +1484,12 @@ func TestCreateSandboxFallsBackWhenWorkspaceSeedRestoreFails(t *testing.T) {
 	if got, want := mirrors.calls, 2; got != want {
 		t.Fatalf("expected fallback path to re-prewarm mirror, got %d want %d", got, want)
 	}
+	if got, want := adapter.deleteSnapshotCalls, 1; got != want {
+		t.Fatalf("expected fallback replacement cleanup to delete stale snapshot once, got %d want %d", got, want)
+	}
+	if got, want := adapter.deleteSnapshotReq.SnapshotID, firstSnapshotID; got != want {
+		t.Fatalf("unexpected stale snapshot cleanup target: got %q want %q", got, want)
+	}
 	cacheStore, ok := svc.CacheStore.(*memoryCacheStore)
 	if !ok {
 		t.Fatalf("expected memory cache store, got %T", svc.CacheStore)
@@ -1460,6 +1501,13 @@ func TestCreateSandboxFallsBackWhenWorkspaceSeedRestoreFails(t *testing.T) {
 	if got, want := len(records), 1; got != want {
 		t.Fatalf("expected failed restore replacement to leave one workspace stage cache record, got %d want %d", got, want)
 	}
+	backingSnapshotID, ok := cacheRecordBackingSnapshotID(records[0])
+	if !ok {
+		t.Fatal("expected workspace stage cache to include backing snapshot identity")
+	}
+	if got, want := backingSnapshotID, adapter.createSnapshotReq.SnapshotID; got != want {
+		t.Fatalf("unexpected workspace stage backing snapshot identity after replacement: got %q want %q", got, want)
+	}
 
 	snapshotRecords, err := store.List(context.Background())
 	if err != nil {
@@ -1467,6 +1515,38 @@ func TestCreateSandboxFallsBackWhenWorkspaceSeedRestoreFails(t *testing.T) {
 	}
 	if got, want := len(snapshotRecords), 0; got != want {
 		t.Fatalf("expected workspace stage snapshots to stay out of snapshot metadata, got %d want %d", got, want)
+	}
+}
+
+func TestMemoryCacheStoreRejectsDuplicateStageCacheKey(t *testing.T) {
+	t.Parallel()
+
+	store := newMemoryCacheStore()
+	record := cachestore.Record{
+		CacheKey:        "workspace:test",
+		Stage:           workspaceStageName,
+		State:           cacheStateReady,
+		Backend:         "firecracker",
+		PolicyHash:      "policy-hash",
+		Policy:          testRepositoryPolicy(),
+		StorageRef:      "/tmp/workspace-test.ext4",
+		StorageDriver:   "file",
+		ProducerVersion: workspaceStageProducerVersion,
+	}
+
+	if err := store.Create(context.Background(), record); err != nil {
+		t.Fatalf("first Create returned error: %v", err)
+	}
+	if err := store.Create(context.Background(), record); err == nil {
+		t.Fatal("expected duplicate cache insert to fail")
+	}
+
+	items, err := store.List(context.Background())
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if got, want := len(items), 1; got != want {
+		t.Fatalf("expected duplicate cache insert to keep one record, got %d want %d", got, want)
 	}
 }
 

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -1287,7 +1287,7 @@ func TestCreateSandboxPublishesWorkspaceStageCache(t *testing.T) {
 	if err != nil {
 		t.Fatalf("FromProto returned error: %v", err)
 	}
-	if got, want := record.CacheKey, workspaceStageCacheKey("runtime-base:test", repositorycheckout.FromProto(testRepositoryCheckoutProto())); got != want {
+	if got, want := record.CacheKey, workspaceStageCacheKey("runtime-base:test", compiled.Hash, repositorycheckout.FromProto(testRepositoryCheckoutProto())); got != want {
 		t.Fatalf("unexpected workspace cache key: got %q want %q", got, want)
 	}
 	if got, want := record.Stage, workspaceStageName; got != want {
@@ -1377,6 +1377,78 @@ func TestCreateSandboxReusesWorkspaceStageCache(t *testing.T) {
 	}
 	if got, want := adapter.provisionFromSnapshotReq.StorageRef, "/snapshots/"+adapter.createSnapshotReq.SnapshotID+".ext4"; got != want {
 		t.Fatalf("unexpected snapshot storage ref on warm hit: got %q want %q", got, want)
+	}
+}
+
+func TestCreateSandboxDoesNotReuseWorkspaceStageCacheAcrossPolicies(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	store := newMemorySnapshotStore()
+	adapter := &stubAdapter{
+		createSnapshotFn: func(_ context.Context, req backend.SnapshotRequest) (*backend.SnapshotResult, error) {
+			return &backend.SnapshotResult{StorageRef: "/snapshots/" + req.SnapshotID + ".ext4"}, nil
+		},
+	}
+	mirrors := &stubRepositoryMirrorStore{}
+	svc := newTestServiceWithSnapshotStore(adapter, store)
+	svc.RepositoryMirrors = mirrors
+
+	firstPolicy := testRepositoryPolicy()
+	if _, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Policy:             firstPolicy,
+		RepositoryCheckout: testRepositoryCheckoutProto(),
+	}); err != nil {
+		t.Fatalf("first CreateSandbox returned error: %v", err)
+	}
+
+	secondPolicy := testRepositoryPolicy()
+	secondPolicy.Allow = append(secondPolicy.Allow, &cleanroomv1.PolicyAllowRule{
+		Host:  "pkg.buildkite.test",
+		Ports: []int32{443},
+	})
+	if _, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Policy:             secondPolicy,
+		RepositoryCheckout: testRepositoryCheckoutProto(),
+	}); err != nil {
+		t.Fatalf("second CreateSandbox returned error: %v", err)
+	}
+
+	if got, want := adapter.provisionCalls, 2; got != want {
+		t.Fatalf("expected both sandboxes to provision from scratch, got %d want %d", got, want)
+	}
+	if got, want := adapter.provisionFromSnapshotCalls, 0; got != want {
+		t.Fatalf("expected no snapshot restores across policy changes, got %d want %d", got, want)
+	}
+	if got, want := adapter.createSnapshotCalls, 2; got != want {
+		t.Fatalf("expected each policy variant to publish its own workspace stage cache, got %d want %d", got, want)
+	}
+
+	cacheStore, ok := svc.CacheStore.(*memoryCacheStore)
+	if !ok {
+		t.Fatalf("expected memory cache store, got %T", svc.CacheStore)
+	}
+	records, err := cacheStore.List(context.Background())
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if got, want := len(records), 2; got != want {
+		t.Fatalf("expected one workspace stage cache per policy, got %d want %d", got, want)
+	}
+
+	firstCompiled, err := policy.FromProto(firstPolicy)
+	if err != nil {
+		t.Fatalf("FromProto(firstPolicy) returned error: %v", err)
+	}
+	secondCompiled, err := policy.FromProto(secondPolicy)
+	if err != nil {
+		t.Fatalf("FromProto(secondPolicy) returned error: %v", err)
+	}
+	if firstCompiled.Hash == secondCompiled.Hash {
+		t.Fatalf("expected distinct compiled policy hashes, got %q", firstCompiled.Hash)
+	}
+	firstKey := workspaceStageCacheKey("runtime-base:test", firstCompiled.Hash, repositorycheckout.FromProto(testRepositoryCheckoutProto()))
+	secondKey := workspaceStageCacheKey("runtime-base:test", secondCompiled.Hash, repositorycheckout.FromProto(testRepositoryCheckoutProto()))
+	if firstKey == secondKey {
+		t.Fatalf("expected workspace stage cache keys to differ across policies, got %q", firstKey)
 	}
 }
 

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -297,6 +297,25 @@ func (s *memorySnapshotStore) Delete(_ context.Context, snapshotID string) error
 	return nil
 }
 
+type blockingSnapshotStore struct {
+	*memorySnapshotStore
+	getStarted chan struct{}
+	getRelease chan struct{}
+}
+
+func (s *blockingSnapshotStore) Get(ctx context.Context, snapshotID string) (snapshotstore.Record, bool, error) {
+	select {
+	case s.getStarted <- struct{}{}:
+	default:
+	}
+	select {
+	case <-s.getRelease:
+	case <-ctx.Done():
+		return snapshotstore.Record{}, false, ctx.Err()
+	}
+	return s.memorySnapshotStore.Get(ctx, snapshotID)
+}
+
 type memoryCacheStore struct {
 	mu      sync.Mutex
 	records map[string]cachestore.Record
@@ -925,6 +944,65 @@ func TestDeleteSnapshotRejectsSnapshotWithInFlightProvisionFromSnapshot(t *testi
 	}
 
 	close(provisionRelease)
+	select {
+	case createErr := <-createDone:
+		if createErr != nil {
+			t.Fatalf("CreateSandbox from snapshot returned error: %v", createErr)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected create-from-snapshot to finish")
+	}
+}
+
+func TestDeleteSnapshotRejectsSnapshotWithMetadataLoadInFlight(t *testing.T) {
+	baseStore := newMemorySnapshotStore()
+	store := &blockingSnapshotStore{
+		memorySnapshotStore: baseStore,
+		getStarted:          make(chan struct{}, 1),
+		getRelease:          make(chan struct{}),
+	}
+	adapter := &stubAdapter{
+		createSnapshotFn: func(_ context.Context, req backend.SnapshotRequest) (*backend.SnapshotResult, error) {
+			return &backend.SnapshotResult{StorageRef: "/snapshots/" + req.SnapshotID + ".ext4"}, nil
+		},
+	}
+	svc := newTestServiceWithSnapshotStore(adapter, store)
+
+	sourceResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	snapshotResp, err := svc.CreateSnapshot(context.Background(), &cleanroomv1.CreateSnapshotRequest{
+		SandboxId: sourceResp.GetSandbox().GetSandboxId(),
+	})
+	if err != nil {
+		t.Fatalf("CreateSnapshot returned error: %v", err)
+	}
+	snapshotID := snapshotResp.GetSnapshot().GetSnapshotId()
+
+	createDone := make(chan error, 1)
+	go func() {
+		_, createErr := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+			Source: &cleanroomv1.CreateSandboxRequest_SnapshotId{SnapshotId: snapshotID},
+		})
+		createDone <- createErr
+	}()
+
+	select {
+	case <-store.getStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected create-from-snapshot metadata load to start")
+	}
+
+	_, err = svc.DeleteSnapshot(context.Background(), &cleanroomv1.DeleteSnapshotRequest{SnapshotId: snapshotID})
+	if err == nil {
+		t.Fatal("expected delete snapshot to fail while metadata load is in flight")
+	}
+	if !strings.Contains(err.Error(), "snapshot_busy") || !strings.Contains(err.Error(), "another operation") {
+		t.Fatalf("unexpected delete snapshot error: %v", err)
+	}
+
+	close(store.getRelease)
 	select {
 	case createErr := <-createDone:
 		if createErr != nil {

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -1458,6 +1458,44 @@ func TestCreateSandboxReusesWorkspaceStageCache(t *testing.T) {
 	}
 }
 
+func TestCreateSandboxReusesWorkspaceStageCacheForNormalizedDestinationDir(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	store := newMemorySnapshotStore()
+	adapter := &stubAdapter{
+		createSnapshotFn: func(_ context.Context, req backend.SnapshotRequest) (*backend.SnapshotResult, error) {
+			return &backend.SnapshotResult{StorageRef: "/snapshots/" + req.SnapshotID + ".ext4"}, nil
+		},
+	}
+	mirrors := &stubRepositoryMirrorStore{}
+	svc := newTestServiceWithSnapshotStore(adapter, store)
+	svc.RepositoryMirrors = mirrors
+
+	firstRepo := testRepositoryCheckoutProto()
+	firstRepo.DestinationDir = "/workspace/"
+	secondRepo := testRepositoryCheckoutProto()
+	secondRepo.DestinationDir = "/workspace"
+
+	if _, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Policy:             testRepositoryPolicy(),
+		RepositoryCheckout: firstRepo,
+	}); err != nil {
+		t.Fatalf("first CreateSandbox returned error: %v", err)
+	}
+	if _, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Policy:             testRepositoryPolicy(),
+		RepositoryCheckout: secondRepo,
+	}); err != nil {
+		t.Fatalf("second CreateSandbox returned error: %v", err)
+	}
+
+	if got, want := adapter.createSnapshotCalls, 1; got != want {
+		t.Fatalf("expected normalized destination dir to reuse existing workspace stage cache, got createSnapshotCalls=%d want=%d", got, want)
+	}
+	if got, want := adapter.provisionFromSnapshotCalls, 1; got != want {
+		t.Fatalf("expected normalized destination dir to warm-hit the workspace stage cache, got provisionFromSnapshotCalls=%d want=%d", got, want)
+	}
+}
+
 func TestCreateSandboxDoesNotReuseWorkspaceStageCacheAcrossPolicies(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	store := newMemorySnapshotStore()

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -1774,6 +1774,88 @@ func TestCreateSandboxFallsBackWhenWorkspaceStageRestoreFails(t *testing.T) {
 	}
 }
 
+func TestDeleteWorkspaceStageCacheSnapshotRejectsInFlightRestore(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	store := newMemorySnapshotStore()
+	provisionStarted := make(chan struct{}, 1)
+	provisionRelease := make(chan struct{})
+	adapter := &stubAdapter{
+		provisionFromSnapshotFn: func(_ context.Context, _ backend.ProvisionFromSnapshotRequest) error {
+			select {
+			case provisionStarted <- struct{}{}:
+			default:
+			}
+			<-provisionRelease
+			return nil
+		},
+	}
+	svc := newTestServiceWithSnapshotStore(adapter, store)
+
+	compiled, err := policy.FromProto(testRepositoryPolicy())
+	if err != nil {
+		t.Fatalf("FromProto returned error: %v", err)
+	}
+	repository := repositorycheckout.FromProto(testRepositoryCheckoutProto())
+	record := cachestore.Record{
+		CacheKey:          workspaceStageCacheKey("firecracker", "runtime-base:test", compiled.Hash, repository),
+		Stage:             workspaceStageName,
+		State:             cacheStateReady,
+		BackingSnapshotID: "workspace-stage-backing-snapshot",
+		Backend:           "firecracker",
+		PolicyHash:        compiled.Hash,
+		Policy:            compiled.ToProto(),
+		Repository:        cloneRepositoryCheckout(normalizeRepositoryCheckoutForComparison(repository)).ToProto(),
+		ParentCacheKey:    "runtime-base:test",
+		StorageDriver:     "file",
+		StorageRef:        "/snapshots/workspace-stage-backing-snapshot.ext4",
+		ProducerVersion:   workspaceStageProducerVersion,
+	}
+	cacheStore, ok := svc.CacheStore.(*memoryCacheStore)
+	if !ok {
+		t.Fatalf("expected memory cache store, got %T", svc.CacheStore)
+	}
+	if err := cacheStore.Create(context.Background(), record); err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+
+	createDone := make(chan error, 1)
+	go func() {
+		_, createErr := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+			Policy:             testRepositoryPolicy(),
+			RepositoryCheckout: testRepositoryCheckoutProto(),
+		})
+		createDone <- createErr
+	}()
+
+	select {
+	case <-provisionStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected workspace stage restore to start")
+	}
+
+	firecrackerCfg := runtimeconfig.MergeBackendConfig(svc.Config, "firecracker", 0)
+	err = svc.deleteWorkspaceStageCacheSnapshot(context.Background(), adapter, "firecracker", firecrackerCfg, record)
+	if err == nil {
+		t.Fatal("expected stale workspace stage cleanup to fail while restore is in flight")
+	}
+	if !strings.Contains(err.Error(), "snapshot_busy") || !strings.Contains(err.Error(), "another operation") {
+		t.Fatalf("unexpected stale workspace stage cleanup error: %v", err)
+	}
+	if got, want := adapter.deleteSnapshotCalls, 0; got != want {
+		t.Fatalf("expected no backend delete while restore is in flight, got %d want %d", got, want)
+	}
+
+	close(provisionRelease)
+	select {
+	case createErr := <-createDone:
+		if createErr != nil {
+			t.Fatalf("CreateSandbox returned error: %v", createErr)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected workspace stage restore to finish")
+	}
+}
+
 func TestMemoryCacheStoreRejectsDuplicateStageCacheKey(t *testing.T) {
 	t.Parallel()
 

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -1365,7 +1365,7 @@ func TestCreateSandboxPublishesWorkspaceStageCache(t *testing.T) {
 	if err != nil {
 		t.Fatalf("FromProto returned error: %v", err)
 	}
-	if got, want := record.CacheKey, workspaceStageCacheKey("runtime-base:test", compiled.Hash, repositorycheckout.FromProto(testRepositoryCheckoutProto())); got != want {
+	if got, want := record.CacheKey, workspaceStageCacheKey("firecracker", "runtime-base:test", compiled.Hash, repositorycheckout.FromProto(testRepositoryCheckoutProto())); got != want {
 		t.Fatalf("unexpected workspace cache key: got %q want %q", got, want)
 	}
 	if got, want := record.Stage, workspaceStageName; got != want {
@@ -1523,10 +1523,78 @@ func TestCreateSandboxDoesNotReuseWorkspaceStageCacheAcrossPolicies(t *testing.T
 	if firstCompiled.Hash == secondCompiled.Hash {
 		t.Fatalf("expected distinct compiled policy hashes, got %q", firstCompiled.Hash)
 	}
-	firstKey := workspaceStageCacheKey("runtime-base:test", firstCompiled.Hash, repositorycheckout.FromProto(testRepositoryCheckoutProto()))
-	secondKey := workspaceStageCacheKey("runtime-base:test", secondCompiled.Hash, repositorycheckout.FromProto(testRepositoryCheckoutProto()))
+	firstKey := workspaceStageCacheKey("firecracker", "runtime-base:test", firstCompiled.Hash, repositorycheckout.FromProto(testRepositoryCheckoutProto()))
+	secondKey := workspaceStageCacheKey("firecracker", "runtime-base:test", secondCompiled.Hash, repositorycheckout.FromProto(testRepositoryCheckoutProto()))
 	if firstKey == secondKey {
 		t.Fatalf("expected workspace stage cache keys to differ across policies, got %q", firstKey)
+	}
+}
+
+func TestCreateSandboxPublishesWorkspaceStageCachePerBackend(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	store := newMemorySnapshotStore()
+	firecrackerAdapter := &stubAdapter{
+		createSnapshotFn: func(_ context.Context, req backend.SnapshotRequest) (*backend.SnapshotResult, error) {
+			return &backend.SnapshotResult{StorageRef: "/snapshots/firecracker/" + req.SnapshotID + ".ext4"}, nil
+		},
+	}
+	darwinAdapter := &stubAdapter{
+		createSnapshotFn: func(_ context.Context, req backend.SnapshotRequest) (*backend.SnapshotResult, error) {
+			return &backend.SnapshotResult{StorageRef: "/snapshots/darwin-vz/" + req.SnapshotID + ".img"}, nil
+		},
+	}
+	mirrors := &stubRepositoryMirrorStore{}
+	svc := newTestServiceWithSnapshotStore(firecrackerAdapter, store)
+	svc.RepositoryMirrors = mirrors
+	svc.Backends["darwin-vz"] = darwinAdapter
+	svc.Config.Backends.DarwinVZ.Snapshots.Enabled = true
+	svc.Config.Backends.DarwinVZ.Snapshots.Driver = "apfs"
+
+	req := &cleanroomv1.CreateSandboxRequest{
+		Policy:             testRepositoryPolicy(),
+		RepositoryCheckout: testRepositoryCheckoutProto(),
+	}
+	if _, err := svc.CreateSandbox(context.Background(), req); err != nil {
+		t.Fatalf("CreateSandbox firecracker returned error: %v", err)
+	}
+	if _, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Backend:            "darwin-vz",
+		Policy:             testRepositoryPolicy(),
+		RepositoryCheckout: testRepositoryCheckoutProto(),
+	}); err != nil {
+		t.Fatalf("CreateSandbox darwin-vz returned error: %v", err)
+	}
+
+	if got, want := firecrackerAdapter.createSnapshotCalls, 1; got != want {
+		t.Fatalf("expected one firecracker workspace stage publish, got %d want %d", got, want)
+	}
+	if got, want := darwinAdapter.createSnapshotCalls, 1; got != want {
+		t.Fatalf("expected one darwin-vz workspace stage publish, got %d want %d", got, want)
+	}
+	if got := firecrackerAdapter.deleteSnapshotCalls + darwinAdapter.deleteSnapshotCalls; got != 0 {
+		t.Fatalf("expected no snapshot rollback deletes across backends, got %d", got)
+	}
+
+	cacheStore, ok := svc.CacheStore.(*memoryCacheStore)
+	if !ok {
+		t.Fatalf("expected memory cache store, got %T", svc.CacheStore)
+	}
+	records, err := cacheStore.List(context.Background())
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if got, want := len(records), 2; got != want {
+		t.Fatalf("expected one workspace stage cache per backend, got %d want %d", got, want)
+	}
+
+	compiled, err := policy.FromProto(testRepositoryPolicy())
+	if err != nil {
+		t.Fatalf("FromProto returned error: %v", err)
+	}
+	firecrackerKey := workspaceStageCacheKey("firecracker", "runtime-base:test", compiled.Hash, repositorycheckout.FromProto(testRepositoryCheckoutProto()))
+	darwinKey := workspaceStageCacheKey("darwin-vz", "runtime-base:test", compiled.Hash, repositorycheckout.FromProto(testRepositoryCheckoutProto()))
+	if firecrackerKey == darwinKey {
+		t.Fatalf("expected backend-specific workspace stage cache keys, got %q", firecrackerKey)
 	}
 }
 

--- a/internal/controlservice/stored_rootfs.go
+++ b/internal/controlservice/stored_rootfs.go
@@ -17,6 +17,7 @@ import (
 type storedRootFSRecord struct {
 	ID            string
 	Kind          string
+	SnapshotID    string
 	Backend       string
 	Policy        *policy.CompiledPolicy
 	Repository    *repositorycheckout.Checkout
@@ -32,6 +33,7 @@ func storedRootFSRecordFromSnapshot(record snapshotstore.Record) (storedRootFSRe
 	return storedRootFSRecord{
 		ID:            strings.TrimSpace(record.SnapshotID),
 		Kind:          "snapshot",
+		SnapshotID:    strings.TrimSpace(record.SnapshotID),
 		Backend:       strings.TrimSpace(record.Backend),
 		Policy:        compiled,
 		Repository:    repositorycheckout.FromProto(record.Repository),
@@ -54,6 +56,7 @@ func storedRootFSRecordFromCacheEntry(record cachestore.Record) (storedRootFSRec
 	return storedRootFSRecord{
 		ID:            strings.TrimSpace(record.CacheKey),
 		Kind:          sourceKind,
+		SnapshotID:    strings.TrimSpace(record.BackingSnapshotID),
 		Backend:       strings.TrimSpace(record.Backend),
 		Policy:        compiled,
 		Repository:    repositorycheckout.FromProto(record.Repository),
@@ -101,9 +104,13 @@ func (s *Service) createSandboxFromStoredRootFS(ctx context.Context, req *cleanr
 
 	now := s.clock().Now()
 	sandboxID := s.ids().NewSandboxID()
+	provisionSnapshotID := strings.TrimSpace(record.SnapshotID)
+	if provisionSnapshotID == "" {
+		provisionSnapshotID = strings.TrimSpace(record.ID)
+	}
 	if err := snapshotAdapter.ProvisionSandboxFromSnapshot(ctx, backend.ProvisionFromSnapshotRequest{
 		SandboxID:         sandboxID,
-		SnapshotID:        record.ID,
+		SnapshotID:        provisionSnapshotID,
 		StorageRef:        record.StorageRef,
 		Policy:            effectivePolicy,
 		FirecrackerConfig: firecrackerCfg,

--- a/internal/controlservice/stored_rootfs.go
+++ b/internal/controlservice/stored_rootfs.go
@@ -1,0 +1,164 @@
+package controlservice
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/cachestore"
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/buildkite/cleanroom/internal/repositorycheckout"
+	"github.com/buildkite/cleanroom/internal/runtimeconfig"
+	"github.com/buildkite/cleanroom/internal/snapshotstore"
+)
+
+type storedRootFSRecord struct {
+	ID            string
+	Kind          string
+	Backend       string
+	Policy        *policy.CompiledPolicy
+	Repository    *repositorycheckout.Checkout
+	StorageDriver string
+	StorageRef    string
+}
+
+func storedRootFSRecordFromSnapshot(record snapshotstore.Record) (storedRootFSRecord, error) {
+	compiled, err := policy.FromProto(record.Policy)
+	if err != nil {
+		return storedRootFSRecord{}, fmt.Errorf("invalid snapshot policy %q: %w", record.SnapshotID, err)
+	}
+	return storedRootFSRecord{
+		ID:            strings.TrimSpace(record.SnapshotID),
+		Kind:          "snapshot",
+		Backend:       strings.TrimSpace(record.Backend),
+		Policy:        compiled,
+		Repository:    repositorycheckout.FromProto(record.Repository),
+		StorageDriver: strings.TrimSpace(record.StorageDriver),
+		StorageRef:    strings.TrimSpace(record.StorageRef),
+	}, nil
+}
+
+func storedRootFSRecordFromCacheEntry(record cachestore.Record) (storedRootFSRecord, error) {
+	compiled, err := policy.FromProto(record.Policy)
+	if err != nil {
+		return storedRootFSRecord{}, fmt.Errorf("invalid cache policy %q/%q: %w", record.Stage, record.CacheKey, err)
+	}
+	sourceKind := strings.TrimSpace(record.Stage)
+	if sourceKind == "" {
+		sourceKind = "stage cache"
+	} else {
+		sourceKind += " stage cache"
+	}
+	return storedRootFSRecord{
+		ID:            strings.TrimSpace(record.CacheKey),
+		Kind:          sourceKind,
+		Backend:       strings.TrimSpace(record.Backend),
+		Policy:        compiled,
+		Repository:    repositorycheckout.FromProto(record.Repository),
+		StorageDriver: strings.TrimSpace(record.StorageDriver),
+		StorageRef:    strings.TrimSpace(record.StorageRef),
+	}, nil
+}
+
+func (s *Service) createSandboxFromStoredRootFS(ctx context.Context, req *cleanroomv1.CreateSandboxRequest, record storedRootFSRecord, overridePolicy *policy.CompiledPolicy) (*cleanroomv1.CreateSandboxResponse, error) {
+	backendName := record.Backend
+	if backendName == "" {
+		return nil, fmt.Errorf("stored rootfs record %q missing backend", record.ID)
+	}
+	if requested := strings.TrimSpace(req.GetBackend()); requested != "" && requested != backendName {
+		return nil, fmt.Errorf("%s %q requires backend %q, got %q", record.Kind, record.ID, backendName, requested)
+	}
+	effectivePolicy := record.Policy
+	if overridePolicy != nil {
+		effectivePolicy = overridePolicy
+	}
+	if effectivePolicy == nil {
+		return nil, fmt.Errorf("stored rootfs record %q missing compiled policy", record.ID)
+	}
+
+	adapter, ok := s.Backends[backendName]
+	if !ok {
+		return nil, fmt.Errorf("unknown backend %q", backendName)
+	}
+	snapshotAdapter, ok := adapter.(backend.SnapshottingAdapter)
+	if !ok {
+		return nil, fmt.Errorf("backend %q does not support snapshot-backed sandbox creation", backendName)
+	}
+	if !snapshotOperationsEnabledForBackend(backendName, s.Config) {
+		return nil, fmt.Errorf("snapshots are not enabled for backend %q", backendName)
+	}
+
+	opts := req.GetOptions()
+	execOpts := executionOptions{}
+	if opts != nil {
+		execOpts.LaunchSeconds = opts.GetLaunchSeconds()
+	}
+	firecrackerCfg := runtimeconfig.MergeBackendConfig(s.Config, backendName, execOpts.LaunchSeconds)
+	firecrackerCfg.RunDir = ""
+	firecrackerCfg = withSnapshotDriver(backendName, firecrackerCfg, record.StorageDriver)
+
+	now := s.clock().Now()
+	sandboxID := s.ids().NewSandboxID()
+	if err := snapshotAdapter.ProvisionSandboxFromSnapshot(ctx, backend.ProvisionFromSnapshotRequest{
+		SandboxID:         sandboxID,
+		SnapshotID:        record.ID,
+		StorageRef:        record.StorageRef,
+		Policy:            effectivePolicy,
+		FirecrackerConfig: firecrackerCfg,
+	}); err != nil {
+		return nil, fmt.Errorf("provision sandbox from snapshot: %w", err)
+	}
+
+	state := &sandboxState{
+		ID:          sandboxID,
+		Backend:     backendName,
+		Policy:      effectivePolicy,
+		Firecracker: firecrackerCfg,
+		Repository:  cloneRepositoryCheckout(record.Repository),
+		CreatedAt:   now,
+		UpdatedAt:   now,
+		Status:      cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY,
+		events:      newEventFeed[*cleanroomv1.SandboxEvent](s.retention().maxRetainedSandboxEvents),
+		Done:        make(chan struct{}),
+	}
+
+	sourceKind := strings.TrimSpace(record.Kind)
+	if sourceKind == "" {
+		sourceKind = "stored rootfs"
+	}
+	eventMessage := fmt.Sprintf("sandbox created from %s %s and ready", sourceKind, record.ID)
+	responseMessage := fmt.Sprintf("sandbox created from %s and ready", sourceKind)
+
+	s.mu.Lock()
+	s.ensureMapsLocked()
+	s.sandboxes[sandboxID] = state
+	s.recordSandboxEventLocked(state, cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY, eventMessage)
+	s.pruneStateLocked(now)
+	resp := &cleanroomv1.CreateSandboxResponse{
+		Sandbox: cloneSandboxLocked(state),
+		Message: responseMessage,
+	}
+	s.mu.Unlock()
+
+	if s.Logger != nil {
+		s.Logger.Info("sandbox created from stored rootfs",
+			"sandbox_id", sandboxID,
+			"source_id", record.ID,
+			"source_kind", sourceKind,
+			"backend", backendName,
+			"policy_hash", effectivePolicy.Hash,
+		)
+	}
+
+	return resp, nil
+}
+
+func (s *Service) createSandboxFromCacheRecord(ctx context.Context, req *cleanroomv1.CreateSandboxRequest, compiled *policy.CompiledPolicy, record cachestore.Record) (*cleanroomv1.CreateSandboxResponse, error) {
+	source, err := storedRootFSRecordFromCacheEntry(record)
+	if err != nil {
+		return nil, err
+	}
+	return s.createSandboxFromStoredRootFS(ctx, req, source, compiled)
+}

--- a/internal/controlservice/stored_rootfs.go
+++ b/internal/controlservice/stored_rootfs.go
@@ -167,5 +167,15 @@ func (s *Service) createSandboxFromCacheRecord(ctx context.Context, req *cleanro
 	if err != nil {
 		return nil, err
 	}
+	backingSnapshotID := strings.TrimSpace(source.SnapshotID)
+	if backingSnapshotID == "" {
+		backingSnapshotID = strings.TrimSpace(source.ID)
+	}
+	if backingSnapshotID != "" {
+		if err := s.beginSnapshotUse(backingSnapshotID); err != nil {
+			return nil, err
+		}
+		defer s.finishSnapshotUse(backingSnapshotID)
+	}
 	return s.createSandboxFromStoredRootFS(ctx, req, source, compiled)
 }

--- a/internal/controlservice/workspace_seed.go
+++ b/internal/controlservice/workspace_seed.go
@@ -18,11 +18,12 @@ const (
 	workspaceStageProducerVersion = "cleanroom/workspace-stage-v1"
 )
 
-func workspaceStageCacheKey(runtimeBaseKey, compiledPolicyHash string, repository *repositorycheckout.Checkout) string {
-	if repository == nil || strings.TrimSpace(runtimeBaseKey) == "" || strings.TrimSpace(compiledPolicyHash) == "" {
+func workspaceStageCacheKey(backendName, runtimeBaseKey, compiledPolicyHash string, repository *repositorycheckout.Checkout) string {
+	if repository == nil || strings.TrimSpace(backendName) == "" || strings.TrimSpace(runtimeBaseKey) == "" || strings.TrimSpace(compiledPolicyHash) == "" {
 		return ""
 	}
 	return cachekey.WorkspaceStageKey(cachekey.WorkspaceStageInputs{
+		Backend:                     strings.TrimSpace(backendName),
 		RuntimeKey:                  strings.TrimSpace(runtimeBaseKey),
 		CompiledPolicyHash:          strings.TrimSpace(compiledPolicyHash),
 		CanonicalRemoteURL:          strings.TrimSpace(repository.RemoteURL),
@@ -67,7 +68,7 @@ func (s *Service) lookupWorkspaceSeedSnapshot(ctx context.Context, backendName s
 	if err != nil {
 		return cachestore.Record{}, false, nil
 	}
-	cacheKey := workspaceStageCacheKey(runtimeBaseKey, compiled.Hash, repository)
+	cacheKey := workspaceStageCacheKey(backendName, runtimeBaseKey, compiled.Hash, repository)
 	if cacheKey == "" {
 		return cachestore.Record{}, false, nil
 	}
@@ -113,7 +114,7 @@ func (s *Service) maybePublishWorkspaceSeedSnapshot(
 		return
 	}
 
-	cacheKey := workspaceStageCacheKey(runtimeBaseKey, compiled.Hash, repository)
+	cacheKey := workspaceStageCacheKey(backendName, runtimeBaseKey, compiled.Hash, repository)
 	if cacheKey == "" {
 		return
 	}

--- a/internal/controlservice/workspace_seed.go
+++ b/internal/controlservice/workspace_seed.go
@@ -8,85 +8,87 @@ import (
 	"strings"
 
 	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/cachekey"
+	"github.com/buildkite/cleanroom/internal/cachestore"
 	"github.com/buildkite/cleanroom/internal/policy"
 	"github.com/buildkite/cleanroom/internal/repositorycheckout"
-	"github.com/buildkite/cleanroom/internal/snapshotstore"
 )
 
-const workspaceSeedSnapshotNamePrefix = "workspace-seed:"
+const (
+	workspaceStageName                = "workspace"
+	cacheStateReady                   = "ready"
+	workspaceStageMaterializationSpec = "workspace-bootstrap:v1"
+	workspaceStageProducerVersion     = "cleanroom/workspace-stage-v1"
+)
 
-func isWorkspaceSeedSnapshotName(name string) bool {
-	return strings.HasPrefix(strings.TrimSpace(name), workspaceSeedSnapshotNamePrefix)
-}
-
-func workspaceSeedSnapshotName(backendName, policyHash, runtimeBaseKey string, repository *repositorycheckout.Checkout) string {
+func workspaceStageCacheKey(runtimeBaseKey string, repository *repositorycheckout.Checkout) string {
 	if repository == nil || strings.TrimSpace(runtimeBaseKey) == "" {
 		return ""
 	}
-	sum := sha256.New()
-	for _, part := range []string{
-		strings.TrimSpace(backendName),
-		strings.TrimSpace(policyHash),
-		strings.TrimSpace(runtimeBaseKey),
-		strings.TrimSpace(repository.RemoteURL),
-		strings.TrimSpace(repository.CommitSHA),
-		strings.TrimSpace(repository.DestinationDir),
-		fmt.Sprintf("%t", repository.Submodules),
-		strings.TrimSpace(repository.Branch),
-	} {
-		_, _ = sum.Write([]byte(part))
-		_, _ = sum.Write([]byte{0})
-	}
-	return workspaceSeedSnapshotNamePrefix + hex.EncodeToString(sum.Sum(nil))
+	return cachekey.WorkspaceStageKey(cachekey.WorkspaceStageInputs{
+		RuntimeKey:                  strings.TrimSpace(runtimeBaseKey),
+		CanonicalRemoteURL:          strings.TrimSpace(repository.RemoteURL),
+		CommitSHA:                   strings.TrimSpace(repository.CommitSHA),
+		SubmoduleMode:               workspaceStageSubmoduleMode(repository),
+		SubmoduleResolutionDigest:   "",
+		CheckoutMode:                workspaceStageCheckoutMode(repository),
+		DestinationDir:              strings.TrimSpace(repository.DestinationDir),
+		MaterializationRecipeDigest: workspaceStageMaterializationRecipeDigest(),
+	})
 }
 
-func workspaceSeedSnapshotRecord(records []snapshotstore.Record, backendName, policyHash, runtimeBaseKey string, repository *repositorycheckout.Checkout) (snapshotstore.Record, bool) {
-	expectedName := workspaceSeedSnapshotName(backendName, policyHash, runtimeBaseKey, repository)
-	if expectedName == "" {
-		return snapshotstore.Record{}, false
+func workspaceStageCheckoutMode(repository *repositorycheckout.Checkout) string {
+	if repository == nil {
+		return ""
 	}
-
-	var (
-		best  snapshotstore.Record
-		found bool
-	)
-	for _, record := range records {
-		if strings.TrimSpace(record.Name) != expectedName {
-			continue
-		}
-		if strings.TrimSpace(record.Backend) != strings.TrimSpace(backendName) {
-			continue
-		}
-		if strings.TrimSpace(record.PolicyHash) != strings.TrimSpace(policyHash) {
-			continue
-		}
-		if !repositoryCheckoutsEqual(repositorycheckout.FromProto(record.Repository), repository) {
-			continue
-		}
-		recordSnapshotID := strings.TrimSpace(record.SnapshotID)
-		bestSnapshotID := strings.TrimSpace(best.SnapshotID)
-		if !found || record.CreatedAt.After(best.CreatedAt) || (record.CreatedAt.Equal(best.CreatedAt) && recordSnapshotID > bestSnapshotID) {
-			best = record
-			found = true
-		}
+	if branch := strings.TrimSpace(repository.Branch); branch != "" {
+		return "branch:" + branch
 	}
-	return best, found
+	return "detached"
 }
 
-func (s *Service) lookupWorkspaceSeedSnapshot(ctx context.Context, backendName string, compiled *policy.CompiledPolicy, runtimeBaseKey string, repository *repositorycheckout.Checkout) (snapshotstore.Record, bool, error) {
+func workspaceStageSubmoduleMode(repository *repositorycheckout.Checkout) string {
+	if repository == nil {
+		return ""
+	}
+	if repository.Submodules {
+		return "enabled"
+	}
+	return "disabled"
+}
+
+func workspaceStageMaterializationRecipeDigest() string {
+	sum := sha256.Sum256([]byte(workspaceStageMaterializationSpec))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func (s *Service) lookupWorkspaceSeedSnapshot(ctx context.Context, backendName string, compiled *policy.CompiledPolicy, runtimeBaseKey string, repository *repositorycheckout.Checkout) (cachestore.Record, bool, error) {
 	if compiled == nil || repository == nil || strings.TrimSpace(runtimeBaseKey) == "" {
-		return snapshotstore.Record{}, false, nil
+		return cachestore.Record{}, false, nil
 	}
-	store, err := s.snapshotStoreOrErr()
+	store, err := s.cacheStoreOrErr()
 	if err != nil {
-		return snapshotstore.Record{}, false, nil
+		return cachestore.Record{}, false, nil
 	}
-	records, err := store.List(ctx)
+	cacheKey := workspaceStageCacheKey(runtimeBaseKey, repository)
+	if cacheKey == "" {
+		return cachestore.Record{}, false, nil
+	}
+
+	record, ok, err := store.GetReady(ctx, workspaceStageName, cacheKey)
 	if err != nil {
-		return snapshotstore.Record{}, false, err
+		return cachestore.Record{}, false, err
 	}
-	record, ok := workspaceSeedSnapshotRecord(records, backendName, compiled.Hash, runtimeBaseKey, repository)
-	return record, ok, nil
+	if !ok {
+		return cachestore.Record{}, false, nil
+	}
+	if strings.TrimSpace(record.Backend) != strings.TrimSpace(backendName) {
+		return cachestore.Record{}, false, nil
+	}
+	if !repositoryCheckoutsEqual(repositorycheckout.FromProto(record.Repository), repository) {
+		return cachestore.Record{}, false, nil
+	}
+	return record, true, nil
 }
 
 func (s *Service) maybePublishWorkspaceSeedSnapshot(
@@ -97,7 +99,7 @@ func (s *Service) maybePublishWorkspaceSeedSnapshot(
 	firecrackerCfg backend.FirecrackerConfig,
 	runtimeBaseKey string,
 	repository *repositorycheckout.Checkout,
-	replacedSnapshotID string,
+	replacedRecord *cachestore.Record,
 ) {
 	if adapter == nil || compiled == nil || repository == nil || strings.TrimSpace(runtimeBaseKey) == "" {
 		return
@@ -106,17 +108,22 @@ func (s *Service) maybePublishWorkspaceSeedSnapshot(
 		return
 	}
 
-	store, err := s.snapshotStoreOrErr()
+	store, err := s.cacheStoreOrErr()
 	if err != nil {
 		return
 	}
 
+	cacheKey := workspaceStageCacheKey(runtimeBaseKey, repository)
+	if cacheKey == "" {
+		return
+	}
+
 	if record, ok, err := s.lookupWorkspaceSeedSnapshot(ctx, backendName, compiled, runtimeBaseKey, repository); err == nil && ok {
-		if strings.TrimSpace(record.SnapshotID) != strings.TrimSpace(replacedSnapshotID) {
+		if replacedRecord == nil || strings.TrimSpace(record.CacheKey) != strings.TrimSpace(replacedRecord.CacheKey) {
 			return
 		}
 	} else if err != nil {
-		s.logWorkspaceSeedWarning("lookup workspace seed snapshot", sandboxID, err)
+		s.logWorkspaceSeedWarning("lookup workspace stage cache", sandboxID, err)
 		return
 	}
 
@@ -128,22 +135,42 @@ func (s *Service) maybePublishWorkspaceSeedSnapshot(
 		FirecrackerConfig: snapshotCfg,
 	})
 	if err != nil {
-		s.logWorkspaceSeedWarning("publish workspace seed snapshot", sandboxID, err)
+		s.logWorkspaceSeedWarning("publish workspace stage cache", sandboxID, err)
 		return
 	}
 
-	record := snapshotstore.Record{
-		SnapshotID:      snapshotID,
-		SourceSandboxID: sandboxID,
+	record := cachestore.Record{
+		CacheKey:        cacheKey,
+		Stage:           workspaceStageName,
+		State:           cacheStateReady,
 		Backend:         backendName,
-		Name:            workspaceSeedSnapshotName(backendName, compiled.Hash, runtimeBaseKey, repository),
 		PolicyHash:      compiled.Hash,
 		Policy:          compiled.ToProto(),
 		Repository:      cloneRepositoryCheckout(repository).ToProto(),
+		ParentCacheKey:  strings.TrimSpace(runtimeBaseKey),
 		StorageDriver:   snapshotCfg.Snapshots.Driver,
 		StorageRef:      strings.TrimSpace(result.StorageRef),
 		CreatedAt:       s.clock().Now(),
+		LastUsedAt:      s.clock().Now(),
+		ProducerVersion: workspaceStageProducerVersion,
 	}
+
+	if replacedRecord != nil && strings.TrimSpace(replacedRecord.CacheKey) == cacheKey {
+		if err := store.Delete(ctx, workspaceStageName, cacheKey); err != nil {
+			deleteErr := adapter.DeleteSnapshot(ctx, backend.DeleteSnapshotRequest{
+				SnapshotID:        snapshotID,
+				StorageRef:        record.StorageRef,
+				FirecrackerConfig: snapshotCfg,
+			})
+			if deleteErr != nil {
+				s.logWorkspaceSeedWarning("rollback workspace stage cache after stale cache delete failure", sandboxID, fmt.Errorf("%w (rollback failed: %v)", err, deleteErr))
+				return
+			}
+			s.logWorkspaceSeedWarning("delete stale workspace stage cache metadata", sandboxID, err)
+			return
+		}
+	}
+
 	if err := store.Create(ctx, record); err != nil {
 		deleteErr := adapter.DeleteSnapshot(ctx, backend.DeleteSnapshotRequest{
 			SnapshotID:        snapshotID,
@@ -151,10 +178,10 @@ func (s *Service) maybePublishWorkspaceSeedSnapshot(
 			FirecrackerConfig: snapshotCfg,
 		})
 		if deleteErr != nil {
-			s.logWorkspaceSeedWarning("rollback workspace seed snapshot after metadata failure", sandboxID, fmt.Errorf("%w (rollback failed: %v)", err, deleteErr))
+			s.logWorkspaceSeedWarning("rollback workspace stage cache after metadata failure", sandboxID, fmt.Errorf("%w (rollback failed: %v)", err, deleteErr))
 			return
 		}
-		s.logWorkspaceSeedWarning("persist workspace seed snapshot metadata", sandboxID, err)
+		s.logWorkspaceSeedWarning("persist workspace stage cache metadata", sandboxID, err)
 	}
 }
 
@@ -184,9 +211,13 @@ func (s *Service) logWorkspaceSeedWarning(message, sandboxID string, err error) 
 	s.Logger.Warn(message, "sandbox_id", sandboxID, "error", err)
 }
 
-func (s *Service) logWorkspaceSeedRestoreWarning(snapshotID string, err error) {
+func (s *Service) logWorkspaceSeedRestoreWarning(record cachestore.Record, err error) {
 	if s == nil || s.Logger == nil || err == nil {
 		return
 	}
-	s.Logger.Warn("restore workspace seed snapshot", "snapshot_id", snapshotID, "error", err)
+	s.Logger.Warn("restore workspace stage cache",
+		"cache_key", strings.TrimSpace(record.CacheKey),
+		"storage_ref", strings.TrimSpace(record.StorageRef),
+		"error", err,
+	)
 }

--- a/internal/controlservice/workspace_seed.go
+++ b/internal/controlservice/workspace_seed.go
@@ -2,8 +2,6 @@ package controlservice
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"strings"
 
@@ -15,10 +13,9 @@ import (
 )
 
 const (
-	workspaceStageName                = "workspace"
-	cacheStateReady                   = "ready"
-	workspaceStageMaterializationSpec = "workspace-bootstrap:v1"
-	workspaceStageProducerVersion     = "cleanroom/workspace-stage-v1"
+	workspaceStageName            = "workspace"
+	cacheStateReady               = "ready"
+	workspaceStageProducerVersion = "cleanroom/workspace-stage-v1"
 )
 
 func workspaceStageCacheKey(runtimeBaseKey string, repository *repositorycheckout.Checkout) string {
@@ -33,7 +30,7 @@ func workspaceStageCacheKey(runtimeBaseKey string, repository *repositorycheckou
 		SubmoduleResolutionDigest:   "",
 		CheckoutMode:                workspaceStageCheckoutMode(repository),
 		DestinationDir:              strings.TrimSpace(repository.DestinationDir),
-		MaterializationRecipeDigest: workspaceStageMaterializationRecipeDigest(),
+		MaterializationRecipeDigest: workspaceStageMaterializationRecipeDigest(repository),
 	})
 }
 
@@ -57,9 +54,8 @@ func workspaceStageSubmoduleMode(repository *repositorycheckout.Checkout) string
 	return "disabled"
 }
 
-func workspaceStageMaterializationRecipeDigest() string {
-	sum := sha256.Sum256([]byte(workspaceStageMaterializationSpec))
-	return "sha256:" + hex.EncodeToString(sum[:])
+func workspaceStageMaterializationRecipeDigest(repository *repositorycheckout.Checkout) string {
+	return repositorycheckout.BootstrapRecipeDigest(repository)
 }
 
 func (s *Service) lookupWorkspaceSeedSnapshot(ctx context.Context, backendName string, compiled *policy.CompiledPolicy, runtimeBaseKey string, repository *repositorycheckout.Checkout) (cachestore.Record, bool, error) {
@@ -140,38 +136,28 @@ func (s *Service) maybePublishWorkspaceSeedSnapshot(
 	}
 
 	record := cachestore.Record{
-		CacheKey:        cacheKey,
-		Stage:           workspaceStageName,
-		State:           cacheStateReady,
-		Backend:         backendName,
-		PolicyHash:      compiled.Hash,
-		Policy:          compiled.ToProto(),
-		Repository:      cloneRepositoryCheckout(repository).ToProto(),
-		ParentCacheKey:  strings.TrimSpace(runtimeBaseKey),
-		StorageDriver:   snapshotCfg.Snapshots.Driver,
-		StorageRef:      strings.TrimSpace(result.StorageRef),
-		CreatedAt:       s.clock().Now(),
-		LastUsedAt:      s.clock().Now(),
-		ProducerVersion: workspaceStageProducerVersion,
+		CacheKey:          cacheKey,
+		Stage:             workspaceStageName,
+		State:             cacheStateReady,
+		BackingSnapshotID: strings.TrimSpace(snapshotID),
+		Backend:           backendName,
+		PolicyHash:        compiled.Hash,
+		Policy:            compiled.ToProto(),
+		Repository:        cloneRepositoryCheckout(repository).ToProto(),
+		ParentCacheKey:    strings.TrimSpace(runtimeBaseKey),
+		StorageDriver:     snapshotCfg.Snapshots.Driver,
+		StorageRef:        strings.TrimSpace(result.StorageRef),
+		CreatedAt:         s.clock().Now(),
+		LastUsedAt:        s.clock().Now(),
+		ProducerVersion:   workspaceStageProducerVersion,
 	}
 
+	persist := store.Create
 	if replacedRecord != nil && strings.TrimSpace(replacedRecord.CacheKey) == cacheKey {
-		if err := store.Delete(ctx, workspaceStageName, cacheKey); err != nil {
-			deleteErr := adapter.DeleteSnapshot(ctx, backend.DeleteSnapshotRequest{
-				SnapshotID:        snapshotID,
-				StorageRef:        record.StorageRef,
-				FirecrackerConfig: snapshotCfg,
-			})
-			if deleteErr != nil {
-				s.logWorkspaceSeedWarning("rollback workspace stage cache after stale cache delete failure", sandboxID, fmt.Errorf("%w (rollback failed: %v)", err, deleteErr))
-				return
-			}
-			s.logWorkspaceSeedWarning("delete stale workspace stage cache metadata", sandboxID, err)
-			return
-		}
+		persist = store.Upsert
 	}
 
-	if err := store.Create(ctx, record); err != nil {
+	if err := persist(ctx, record); err != nil {
 		deleteErr := adapter.DeleteSnapshot(ctx, backend.DeleteSnapshotRequest{
 			SnapshotID:        snapshotID,
 			StorageRef:        record.StorageRef,
@@ -182,7 +168,34 @@ func (s *Service) maybePublishWorkspaceSeedSnapshot(
 			return
 		}
 		s.logWorkspaceSeedWarning("persist workspace stage cache metadata", sandboxID, err)
+		return
 	}
+
+	if replacedRecord != nil && strings.TrimSpace(replacedRecord.CacheKey) == cacheKey {
+		if err := deleteWorkspaceStageCacheSnapshot(ctx, adapter, backendName, firecrackerCfg, *replacedRecord); err != nil {
+			s.logWorkspaceSeedWarning("delete replaced workspace stage cache snapshot", sandboxID, err)
+		}
+	}
+}
+
+func deleteWorkspaceStageCacheSnapshot(ctx context.Context, adapter backend.SnapshottingAdapter, backendName string, firecrackerCfg backend.FirecrackerConfig, record cachestore.Record) error {
+	if adapter == nil {
+		return nil
+	}
+	storageRef := strings.TrimSpace(record.StorageRef)
+	if storageRef == "" {
+		return nil
+	}
+	snapshotID := strings.TrimSpace(record.BackingSnapshotID)
+	if snapshotID == "" {
+		snapshotID = strings.TrimSpace(record.CacheKey)
+	}
+	deleteCfg := withSnapshotDriver(backendName, firecrackerCfg, record.StorageDriver)
+	return adapter.DeleteSnapshot(ctx, backend.DeleteSnapshotRequest{
+		SnapshotID:        snapshotID,
+		StorageRef:        storageRef,
+		FirecrackerConfig: deleteCfg,
+	})
 }
 
 func (s *Service) workspaceSeedRuntimeBaseKey(ctx context.Context, adapter backend.Adapter, compiled *policy.CompiledPolicy, firecrackerCfg backend.FirecrackerConfig) (string, bool, error) {

--- a/internal/controlservice/workspace_seed.go
+++ b/internal/controlservice/workspace_seed.go
@@ -19,20 +19,21 @@ const (
 )
 
 func workspaceStageCacheKey(backendName, runtimeBaseKey, compiledPolicyHash string, repository *repositorycheckout.Checkout) string {
-	if repository == nil || strings.TrimSpace(backendName) == "" || strings.TrimSpace(runtimeBaseKey) == "" || strings.TrimSpace(compiledPolicyHash) == "" {
+	normalizedRepository := normalizeRepositoryCheckoutForComparison(repository)
+	if normalizedRepository == nil || strings.TrimSpace(backendName) == "" || strings.TrimSpace(runtimeBaseKey) == "" || strings.TrimSpace(compiledPolicyHash) == "" {
 		return ""
 	}
 	return cachekey.WorkspaceStageKey(cachekey.WorkspaceStageInputs{
 		Backend:                     strings.TrimSpace(backendName),
 		RuntimeKey:                  strings.TrimSpace(runtimeBaseKey),
 		CompiledPolicyHash:          strings.TrimSpace(compiledPolicyHash),
-		CanonicalRemoteURL:          strings.TrimSpace(repository.RemoteURL),
-		CommitSHA:                   strings.TrimSpace(repository.CommitSHA),
-		SubmoduleMode:               workspaceStageSubmoduleMode(repository),
+		CanonicalRemoteURL:          strings.TrimSpace(normalizedRepository.RemoteURL),
+		CommitSHA:                   strings.TrimSpace(normalizedRepository.CommitSHA),
+		SubmoduleMode:               workspaceStageSubmoduleMode(normalizedRepository),
 		SubmoduleResolutionDigest:   "",
-		CheckoutMode:                workspaceStageCheckoutMode(repository),
-		DestinationDir:              strings.TrimSpace(repository.DestinationDir),
-		MaterializationRecipeDigest: workspaceStageMaterializationRecipeDigest(repository),
+		CheckoutMode:                workspaceStageCheckoutMode(normalizedRepository),
+		DestinationDir:              strings.TrimSpace(normalizedRepository.DestinationDir),
+		MaterializationRecipeDigest: workspaceStageMaterializationRecipeDigest(normalizedRepository),
 	})
 }
 
@@ -148,7 +149,7 @@ func (s *Service) maybePublishWorkspaceSeedSnapshot(
 		Backend:           backendName,
 		PolicyHash:        compiled.Hash,
 		Policy:            compiled.ToProto(),
-		Repository:        cloneRepositoryCheckout(repository).ToProto(),
+		Repository:        cloneRepositoryCheckout(normalizeRepositoryCheckoutForComparison(repository)).ToProto(),
 		ParentCacheKey:    strings.TrimSpace(runtimeBaseKey),
 		StorageDriver:     snapshotCfg.Snapshots.Driver,
 		StorageRef:        strings.TrimSpace(result.StorageRef),

--- a/internal/controlservice/workspace_seed.go
+++ b/internal/controlservice/workspace_seed.go
@@ -178,13 +178,13 @@ func (s *Service) maybePublishWorkspaceSeedSnapshot(
 	}
 
 	if replacedRecord != nil && strings.TrimSpace(replacedRecord.CacheKey) == cacheKey {
-		if err := deleteWorkspaceStageCacheSnapshot(ctx, adapter, backendName, firecrackerCfg, *replacedRecord); err != nil {
+		if err := s.deleteWorkspaceStageCacheSnapshot(ctx, adapter, backendName, firecrackerCfg, *replacedRecord); err != nil {
 			s.logWorkspaceSeedWarning("delete replaced workspace stage cache snapshot", sandboxID, err)
 		}
 	}
 }
 
-func deleteWorkspaceStageCacheSnapshot(ctx context.Context, adapter backend.SnapshottingAdapter, backendName string, firecrackerCfg backend.FirecrackerConfig, record cachestore.Record) error {
+func (s *Service) deleteWorkspaceStageCacheSnapshot(ctx context.Context, adapter backend.SnapshottingAdapter, backendName string, firecrackerCfg backend.FirecrackerConfig, record cachestore.Record) error {
 	if adapter == nil {
 		return nil
 	}
@@ -195,6 +195,12 @@ func deleteWorkspaceStageCacheSnapshot(ctx context.Context, adapter backend.Snap
 	snapshotID := strings.TrimSpace(record.BackingSnapshotID)
 	if snapshotID == "" {
 		snapshotID = strings.TrimSpace(record.CacheKey)
+	}
+	if snapshotID != "" {
+		if err := s.beginSnapshotDelete(snapshotID); err != nil {
+			return err
+		}
+		defer s.finishSnapshotDelete(snapshotID)
 	}
 	deleteCfg := withSnapshotDriver(backendName, firecrackerCfg, record.StorageDriver)
 	return adapter.DeleteSnapshot(ctx, backend.DeleteSnapshotRequest{

--- a/internal/controlservice/workspace_seed.go
+++ b/internal/controlservice/workspace_seed.go
@@ -18,12 +18,13 @@ const (
 	workspaceStageProducerVersion = "cleanroom/workspace-stage-v1"
 )
 
-func workspaceStageCacheKey(runtimeBaseKey string, repository *repositorycheckout.Checkout) string {
-	if repository == nil || strings.TrimSpace(runtimeBaseKey) == "" {
+func workspaceStageCacheKey(runtimeBaseKey, compiledPolicyHash string, repository *repositorycheckout.Checkout) string {
+	if repository == nil || strings.TrimSpace(runtimeBaseKey) == "" || strings.TrimSpace(compiledPolicyHash) == "" {
 		return ""
 	}
 	return cachekey.WorkspaceStageKey(cachekey.WorkspaceStageInputs{
 		RuntimeKey:                  strings.TrimSpace(runtimeBaseKey),
+		CompiledPolicyHash:          strings.TrimSpace(compiledPolicyHash),
 		CanonicalRemoteURL:          strings.TrimSpace(repository.RemoteURL),
 		CommitSHA:                   strings.TrimSpace(repository.CommitSHA),
 		SubmoduleMode:               workspaceStageSubmoduleMode(repository),
@@ -66,7 +67,7 @@ func (s *Service) lookupWorkspaceSeedSnapshot(ctx context.Context, backendName s
 	if err != nil {
 		return cachestore.Record{}, false, nil
 	}
-	cacheKey := workspaceStageCacheKey(runtimeBaseKey, repository)
+	cacheKey := workspaceStageCacheKey(runtimeBaseKey, compiled.Hash, repository)
 	if cacheKey == "" {
 		return cachestore.Record{}, false, nil
 	}
@@ -82,6 +83,9 @@ func (s *Service) lookupWorkspaceSeedSnapshot(ctx context.Context, backendName s
 		return cachestore.Record{}, false, nil
 	}
 	if !repositoryCheckoutsEqual(repositorycheckout.FromProto(record.Repository), repository) {
+		return cachestore.Record{}, false, nil
+	}
+	if strings.TrimSpace(record.PolicyHash) != strings.TrimSpace(compiled.Hash) {
 		return cachestore.Record{}, false, nil
 	}
 	return record, true, nil
@@ -109,7 +113,7 @@ func (s *Service) maybePublishWorkspaceSeedSnapshot(
 		return
 	}
 
-	cacheKey := workspaceStageCacheKey(runtimeBaseKey, repository)
+	cacheKey := workspaceStageCacheKey(runtimeBaseKey, compiled.Hash, repository)
 	if cacheKey == "" {
 		return
 	}

--- a/internal/repositorycheckout/checkout.go
+++ b/internal/repositorycheckout/checkout.go
@@ -1,6 +1,7 @@
 package repositorycheckout
 
 import (
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"net/url"
@@ -195,6 +196,18 @@ func BuildBootstrapCommand(checkout *Checkout) []string {
 		return nil
 	}
 	return []string{"sh", "-lc", strings.Join(bootstrapScript(checkout), "\n")}
+}
+
+func BootstrapRecipeDigest(checkout *Checkout) string {
+	if checkout == nil {
+		return ""
+	}
+	sum := sha256.New()
+	for _, part := range BuildBootstrapCommand(checkout) {
+		_, _ = sum.Write([]byte(part))
+		_, _ = sum.Write([]byte{0})
+	}
+	return "sha256:" + hex.EncodeToString(sum.Sum(nil))
 }
 
 func WrapCommandWithBootstrap(command []string, checkout *Checkout, autoMiseInstall bool) []string {

--- a/internal/repositorycheckout/checkout_test.go
+++ b/internal/repositorycheckout/checkout_test.go
@@ -142,6 +142,37 @@ func TestBuildBootstrapCommandIncludesSubmoduleUpdateWhenRequested(t *testing.T)
 	}
 }
 
+func TestBootstrapRecipeDigestTracksCheckoutBehavior(t *testing.T) {
+	base := &Checkout{
+		RemoteURL:      "https://github.com/buildkite/cleanroom.git",
+		CommitSHA:      "0123456789abcdef0123456789abcdef01234567",
+		DestinationDir: "/workspace",
+	}
+	if got := BootstrapRecipeDigest(base); got == "" {
+		t.Fatal("expected non-empty bootstrap recipe digest")
+	}
+
+	withBranch := &Checkout{
+		RemoteURL:      base.RemoteURL,
+		CommitSHA:      base.CommitSHA,
+		DestinationDir: base.DestinationDir,
+		Branch:         "feature/cache-stage",
+	}
+	if BootstrapRecipeDigest(withBranch) == BootstrapRecipeDigest(base) {
+		t.Fatal("expected bootstrap recipe digest to change when checkout mode changes")
+	}
+
+	withSubmodules := &Checkout{
+		RemoteURL:      base.RemoteURL,
+		CommitSHA:      base.CommitSHA,
+		DestinationDir: base.DestinationDir,
+		Submodules:     true,
+	}
+	if BootstrapRecipeDigest(withSubmodules) == BootstrapRecipeDigest(base) {
+		t.Fatal("expected bootstrap recipe digest to change when submodule bootstrap changes")
+	}
+}
+
 func TestValidateBootstrapRejectsMutableCommitRef(t *testing.T) {
 	checkout := &Checkout{
 		RemoteURL:      "https://github.com/buildkite/cleanroom.git",


### PR DESCRIPTION
## Summary
- add a dedicated `cachestore` for system-managed stage cache metadata
- add canonical stage key builders for runtime, workspace, and dependency cache stages
- extract a shared stored-rootfs restore path so user snapshots and stage caches can restore without sharing metadata stores
- migrate workspace-stage lookup and publish flow off reserved snapshot names and onto `cachestore`
- keep `snapshotstore` user-facing only and update tests accordingly

## Validation
- `mise exec -- go test ./internal/cachekey ./internal/cachestore ./internal/controlservice ./internal/cli`
- `mise exec -- go test ./...`

## Follow-up
- dependency-stage publication and policy surface are still a separate slice
- cache GC and cleanup of replaced backing snapshots remain follow-up work
