### PR TITLE
build: Add Debian base image family

### DIFF
--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -90,6 +90,7 @@ jobs:
     name: merge (${{ matrix.image.name }})
     runs-on: ubuntu-24.04
     needs: build
+    if: ${{ always() }}
     strategy:
       fail-fast: false
       matrix:
@@ -128,6 +129,7 @@ jobs:
           pattern: digests__${{ matrix.image.name }}__*
           path: ${{ runner.temp }}/digests
           merge-multiple: true
+          if-no-files-found: ignore
 
       - uses: docker/setup-buildx-action@v3
 
@@ -141,13 +143,14 @@ jobs:
         working-directory: ${{ runner.temp }}/digests
         env:
           BASE_TAG: ${{ steps.meta.outputs.base_tag }}
+          EXPECTED_DIGEST_COUNT: "2"
           REPOSITORY: ${{ matrix.image.repository }}
         run: |
           set -euo pipefail
           shopt -s nullglob
           digests=(*)
-          if [[ ${#digests[@]} -eq 0 ]]; then
-            echo "no digests downloaded" >&2
+          if [[ ${#digests[@]} -ne ${EXPECTED_DIGEST_COUNT} ]]; then
+            echo "expected ${EXPECTED_DIGEST_COUNT} platform digests for ${REPOSITORY}, found ${#digests[@]}" >&2
             exit 1
           fi
           refs=()

--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -4,9 +4,7 @@ on:
   push:
     branches: [main]
     paths:
-      - images/Dockerfile.base-image
-      - images/Dockerfile.base-image-docker
-      - images/Dockerfile.base-image-agents
+      - images/Dockerfile.base-image*
       - scripts/base-image-tag.sh
       - .github/workflows/base-image.yml
   workflow_dispatch:
@@ -16,17 +14,32 @@ permissions:
   packages: write
 
 jobs:
-  build-alpine:
-    name: build (alpine, ${{ matrix.platform }})
-    runs-on: ${{ matrix.runner }}
-    env:
-      IMAGE_NAME: alpine
-      DOCKERFILE: images/Dockerfile.base-image
-      REPOSITORY: ghcr.io/buildkite/cleanroom-base/alpine
+  build:
+    name: build (${{ matrix.image.name }}, ${{ matrix.platform.platform }})
+    runs-on: ${{ matrix.platform.runner }}
     strategy:
       fail-fast: false
       matrix:
-        include:
+        image:
+          - name: debian
+            dockerfile: images/Dockerfile.base-image-debian
+            repository: ghcr.io/buildkite/cleanroom-base/debian
+          - name: debian-docker
+            dockerfile: images/Dockerfile.base-image-debian-docker
+            repository: ghcr.io/buildkite/cleanroom-base/debian-docker
+          - name: debian-agents
+            dockerfile: images/Dockerfile.base-image-debian-agents
+            repository: ghcr.io/buildkite/cleanroom-base/debian-agents
+          - name: alpine
+            dockerfile: images/Dockerfile.base-image
+            repository: ghcr.io/buildkite/cleanroom-base/alpine
+          - name: alpine-docker
+            dockerfile: images/Dockerfile.base-image-docker
+            repository: ghcr.io/buildkite/cleanroom-base/alpine-docker
+          - name: alpine-agents
+            dockerfile: images/Dockerfile.base-image-agents
+            repository: ghcr.io/buildkite/cleanroom-base/alpine-agents
+        platform:
           - platform: linux/amd64
             platform_key: linux-amd64
             runner: ubuntu-24.04
@@ -48,9 +61,9 @@ jobs:
         id: build
         with:
           context: .
-          file: ${{ env.DOCKERFILE }}
-          platforms: ${{ matrix.platform }}
-          outputs: type=image,name=${{ env.REPOSITORY }},push-by-digest=true,name-canonical=true,push=true
+          file: ${{ matrix.image.dockerfile }}
+          platforms: ${{ matrix.platform.platform }}
+          outputs: type=image,name=${{ matrix.image.repository }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export image digest
         run: |
@@ -65,139 +78,48 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: digests__${{ env.IMAGE_NAME }}__${{ matrix.platform_key }}
+          name: digests__${{ matrix.image.name }}__${{ matrix.platform.platform_key }}
           path: ${{ runner.temp }}/digests/*
           if-no-files-found: error
           retention-days: 1
 
-  merge-alpine:
-    name: merge (alpine)
+  merge:
+    name: merge (${{ matrix.image.name }})
     runs-on: ubuntu-24.04
-    needs: build-alpine
-    env:
-      IMAGE_NAME: alpine
-      DOCKERFILE: images/Dockerfile.base-image
-      REPOSITORY: ghcr.io/buildkite/cleanroom-base/alpine
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Compute base image tag
-        id: meta
-        run: |
-          echo "base_tag=$(scripts/base-image-tag.sh '${{ env.IMAGE_NAME }}' '${{ env.DOCKERFILE }}')" >> "$GITHUB_OUTPUT"
-
-      - uses: actions/download-artifact@v4
-        with:
-          pattern: digests__${{ env.IMAGE_NAME }}__*
-          path: ${{ runner.temp }}/digests
-          merge-multiple: true
-
-      - uses: docker/setup-buildx-action@v3
-
-      - uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create manifest list
-        working-directory: ${{ runner.temp }}/digests
-        env:
-          BASE_TAG: ${{ steps.meta.outputs.base_tag }}
-        run: |
-          set -euo pipefail
-          shopt -s nullglob
-          digests=(*)
-          if [[ ${#digests[@]} -eq 0 ]]; then
-            echo "no digests downloaded" >&2
-            exit 1
-          fi
-          refs=()
-          for digest in "${digests[@]}"; do
-            refs+=("${REPOSITORY}@sha256:${digest}")
-          done
-          docker buildx imagetools create \
-            -t "${REPOSITORY}:latest" \
-            -t "${REPOSITORY}:${BASE_TAG}" \
-            -t "${REPOSITORY}:${GITHUB_SHA}" \
-            "${refs[@]}"
-
-      - name: Inspect manifest list
-        run: docker buildx imagetools inspect "${REPOSITORY}:latest"
-
-  build-alpine-docker:
-    name: build (alpine-docker, ${{ matrix.platform }})
-    runs-on: ${{ matrix.runner }}
-    env:
-      IMAGE_NAME: alpine-docker
-      DOCKERFILE: images/Dockerfile.base-image-docker
-      REPOSITORY: ghcr.io/buildkite/cleanroom-base/alpine-docker
+    needs: build
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - platform: linux/amd64
-            platform_key: linux-amd64
-            runner: ubuntu-24.04
-          - platform: linux/arm64
-            platform_key: linux-arm64
-            runner: ubuntu-24.04-arm
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: docker/setup-buildx-action@v3
-
-      - uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: docker/build-push-action@v6
-        id: build
-        with:
-          context: .
-          file: ${{ env.DOCKERFILE }}
-          platforms: ${{ matrix.platform }}
-          outputs: type=image,name=${{ env.REPOSITORY }},push-by-digest=true,name-canonical=true,push=true
-
-      - name: Export image digest
-        run: |
-          set -euo pipefail
-          mkdir -p "$RUNNER_TEMP/digests"
-          digest="${{ steps.build.outputs.digest }}"
-          if [[ -z "$digest" ]]; then
-            echo "build digest missing" >&2
-            exit 1
-          fi
-          touch "$RUNNER_TEMP/digests/${digest#sha256:}"
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: digests__${{ env.IMAGE_NAME }}__${{ matrix.platform_key }}
-          path: ${{ runner.temp }}/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-  merge-alpine-docker:
-    name: merge (alpine-docker)
-    runs-on: ubuntu-24.04
-    needs: build-alpine-docker
-    env:
-      IMAGE_NAME: alpine-docker
-      DOCKERFILE: images/Dockerfile.base-image-docker
-      REPOSITORY: ghcr.io/buildkite/cleanroom-base/alpine-docker
+        image:
+          - name: debian
+            dockerfile: images/Dockerfile.base-image-debian
+            repository: ghcr.io/buildkite/cleanroom-base/debian
+          - name: debian-docker
+            dockerfile: images/Dockerfile.base-image-debian-docker
+            repository: ghcr.io/buildkite/cleanroom-base/debian-docker
+          - name: debian-agents
+            dockerfile: images/Dockerfile.base-image-debian-agents
+            repository: ghcr.io/buildkite/cleanroom-base/debian-agents
+          - name: alpine
+            dockerfile: images/Dockerfile.base-image
+            repository: ghcr.io/buildkite/cleanroom-base/alpine
+          - name: alpine-docker
+            dockerfile: images/Dockerfile.base-image-docker
+            repository: ghcr.io/buildkite/cleanroom-base/alpine-docker
+          - name: alpine-agents
+            dockerfile: images/Dockerfile.base-image-agents
+            repository: ghcr.io/buildkite/cleanroom-base/alpine-agents
     steps:
       - uses: actions/checkout@v4
 
       - name: Compute base image tag
         id: meta
         run: |
-          echo "base_tag=$(scripts/base-image-tag.sh '${{ env.IMAGE_NAME }}' '${{ env.DOCKERFILE }}')" >> "$GITHUB_OUTPUT"
+          echo "base_tag=$(scripts/base-image-tag.sh '${{ matrix.image.name }}' '${{ matrix.image.dockerfile }}')" >> "$GITHUB_OUTPUT"
 
       - uses: actions/download-artifact@v4
         with:
-          pattern: digests__${{ env.IMAGE_NAME }}__*
+          pattern: digests__${{ matrix.image.name }}__*
           path: ${{ runner.temp }}/digests
           merge-multiple: true
 
@@ -213,6 +135,7 @@ jobs:
         working-directory: ${{ runner.temp }}/digests
         env:
           BASE_TAG: ${{ steps.meta.outputs.base_tag }}
+          REPOSITORY: ${{ matrix.image.repository }}
         run: |
           set -euo pipefail
           shopt -s nullglob
@@ -232,113 +155,4 @@ jobs:
             "${refs[@]}"
 
       - name: Inspect manifest list
-        run: docker buildx imagetools inspect "${REPOSITORY}:latest"
-
-  build-alpine-agents:
-    name: build (alpine-agents, ${{ matrix.platform }})
-    runs-on: ${{ matrix.runner }}
-    env:
-      IMAGE_NAME: alpine-agents
-      DOCKERFILE: images/Dockerfile.base-image-agents
-      REPOSITORY: ghcr.io/buildkite/cleanroom-base/alpine-agents
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: linux/amd64
-            platform_key: linux-amd64
-            runner: ubuntu-24.04
-          - platform: linux/arm64
-            platform_key: linux-arm64
-            runner: ubuntu-24.04-arm
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: docker/setup-buildx-action@v3
-
-      - uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: docker/build-push-action@v6
-        id: build
-        with:
-          context: .
-          file: ${{ env.DOCKERFILE }}
-          platforms: ${{ matrix.platform }}
-          outputs: type=image,name=${{ env.REPOSITORY }},push-by-digest=true,name-canonical=true,push=true
-
-      - name: Export image digest
-        run: |
-          set -euo pipefail
-          mkdir -p "$RUNNER_TEMP/digests"
-          digest="${{ steps.build.outputs.digest }}"
-          if [[ -z "$digest" ]]; then
-            echo "build digest missing" >&2
-            exit 1
-          fi
-          touch "$RUNNER_TEMP/digests/${digest#sha256:}"
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: digests__${{ env.IMAGE_NAME }}__${{ matrix.platform_key }}
-          path: ${{ runner.temp }}/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-  merge-alpine-agents:
-    name: merge (alpine-agents)
-    runs-on: ubuntu-24.04
-    needs: build-alpine-agents
-    env:
-      IMAGE_NAME: alpine-agents
-      DOCKERFILE: images/Dockerfile.base-image-agents
-      REPOSITORY: ghcr.io/buildkite/cleanroom-base/alpine-agents
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Compute base image tag
-        id: meta
-        run: |
-          echo "base_tag=$(scripts/base-image-tag.sh '${{ env.IMAGE_NAME }}' '${{ env.DOCKERFILE }}')" >> "$GITHUB_OUTPUT"
-
-      - uses: actions/download-artifact@v4
-        with:
-          pattern: digests__${{ env.IMAGE_NAME }}__*
-          path: ${{ runner.temp }}/digests
-          merge-multiple: true
-
-      - uses: docker/setup-buildx-action@v3
-
-      - uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create manifest list
-        working-directory: ${{ runner.temp }}/digests
-        env:
-          BASE_TAG: ${{ steps.meta.outputs.base_tag }}
-        run: |
-          set -euo pipefail
-          shopt -s nullglob
-          digests=(*)
-          if [[ ${#digests[@]} -eq 0 ]]; then
-            echo "no digests downloaded" >&2
-            exit 1
-          fi
-          refs=()
-          for digest in "${digests[@]}"; do
-            refs+=("${REPOSITORY}@sha256:${digest}")
-          done
-          docker buildx imagetools create \
-            -t "${REPOSITORY}:latest" \
-            -t "${REPOSITORY}:${BASE_TAG}" \
-            -t "${REPOSITORY}:${GITHUB_SHA}" \
-            "${refs[@]}"
-
-      - name: Inspect manifest list
-        run: docker buildx imagetools inspect "${REPOSITORY}:latest"
+        run: docker buildx imagetools inspect "${{ matrix.image.repository }}:latest"

--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -24,6 +24,9 @@ jobs:
           - name: debian
             dockerfile: images/Dockerfile.base-image-debian
             repository: ghcr.io/buildkite/cleanroom-base/debian
+          - name: debian-ruby
+            dockerfile: images/Dockerfile.base-image-debian-ruby
+            repository: ghcr.io/buildkite/cleanroom-base/debian-ruby
           - name: debian-docker
             dockerfile: images/Dockerfile.base-image-debian-docker
             repository: ghcr.io/buildkite/cleanroom-base/debian-docker
@@ -94,6 +97,9 @@ jobs:
           - name: debian
             dockerfile: images/Dockerfile.base-image-debian
             repository: ghcr.io/buildkite/cleanroom-base/debian
+          - name: debian-ruby
+            dockerfile: images/Dockerfile.base-image-debian-ruby
+            repository: ghcr.io/buildkite/cleanroom-base/debian-ruby
           - name: debian-docker
             dockerfile: images/Dockerfile.base-image-debian-docker
             repository: ghcr.io/buildkite/cleanroom-base/debian-docker

--- a/.mise.toml
+++ b/.mise.toml
@@ -45,6 +45,10 @@ run = "docker build -f images/Dockerfile.base-image-agents -t cleanroom-base:alp
 description = "Build local debian base image"
 run = "docker build -f images/Dockerfile.base-image-debian -t cleanroom-base:debian ."
 
+[tasks."build:image:debian-ruby"]
+description = "Build local debian-ruby base image"
+run = "docker build -f images/Dockerfile.base-image-debian-ruby -t cleanroom-base:debian-ruby ."
+
 [tasks."build:image:debian-docker"]
 description = "Build local debian-docker base image"
 run = "docker build -f images/Dockerfile.base-image-debian-docker -t cleanroom-base:debian-docker ."
@@ -57,6 +61,7 @@ run = "docker build -f images/Dockerfile.base-image-debian-agents -t cleanroom-b
 description = "Build all local base images"
 depends = [
   "build:image:debian",
+  "build:image:debian-ruby",
   "build:image:debian-docker",
   "build:image:debian-agents",
   "build:image:alpine",

--- a/.mise.toml
+++ b/.mise.toml
@@ -41,9 +41,28 @@ run = "docker build -f images/Dockerfile.base-image-docker -t cleanroom-base:alp
 description = "Build local alpine-agents base image"
 run = "docker build -f images/Dockerfile.base-image-agents -t cleanroom-base:alpine-agents ."
 
+[tasks."build:image:debian"]
+description = "Build local debian base image"
+run = "docker build -f images/Dockerfile.base-image-debian -t cleanroom-base:debian ."
+
+[tasks."build:image:debian-docker"]
+description = "Build local debian-docker base image"
+run = "docker build -f images/Dockerfile.base-image-debian-docker -t cleanroom-base:debian-docker ."
+
+[tasks."build:image:debian-agents"]
+description = "Build local debian-agents base image"
+run = "docker build -f images/Dockerfile.base-image-debian-agents -t cleanroom-base:debian-agents ."
+
 [tasks."build:images"]
 description = "Build all local base images"
-depends = ["build:image:alpine", "build:image:alpine-docker", "build:image:alpine-agents"]
+depends = [
+  "build:image:debian",
+  "build:image:debian-docker",
+  "build:image:debian-agents",
+  "build:image:alpine",
+  "build:image:alpine-docker",
+  "build:image:alpine-agents",
+]
 run = "true"
 
 [tasks.build]

--- a/README.md
+++ b/README.md
@@ -322,7 +322,8 @@ cleanroom image pull ghcr.io/buildkite/cleanroom-base/debian@sha256:...
 cleanroom image ls
 cleanroom image rm sha256:...
 cleanroom image import ghcr.io/buildkite/cleanroom-base/debian@sha256:... ./rootfs.tar.gz
-cleanroom image bump-ref    # resolve :latest tag to digest and update cleanroom.yaml
+cleanroom image bump-ref ghcr.io/buildkite/cleanroom-base/debian:latest
+                           # resolve :latest tag to digest and update cleanroom.yaml
 ```
 
 Recommended defaults are the Debian-based images: `ghcr.io/buildkite/cleanroom-base/debian`, `ghcr.io/buildkite/cleanroom-base/debian-ruby`, `ghcr.io/buildkite/cleanroom-base/debian-docker`, and `ghcr.io/buildkite/cleanroom-base/debian-agents`.

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ cleanroom image import ghcr.io/buildkite/cleanroom-base/debian@sha256:... ./root
 cleanroom image bump-ref    # resolve :latest tag to digest and update cleanroom.yaml
 ```
 
-Recommended defaults are the Debian-based images: `ghcr.io/buildkite/cleanroom-base/debian`, `ghcr.io/buildkite/cleanroom-base/debian-docker`, and `ghcr.io/buildkite/cleanroom-base/debian-agents`.
+Recommended defaults are the Debian-based images: `ghcr.io/buildkite/cleanroom-base/debian`, `ghcr.io/buildkite/cleanroom-base/debian-ruby`, `ghcr.io/buildkite/cleanroom-base/debian-docker`, and `ghcr.io/buildkite/cleanroom-base/debian-agents`.
 The Alpine variants remain available as smaller musl-based alternatives: `ghcr.io/buildkite/cleanroom-base/alpine`, `ghcr.io/buildkite/cleanroom-base/alpine-docker`, and `ghcr.io/buildkite/cleanroom-base/alpine-agents`.
 
 Build these locally with `mise`:
@@ -334,6 +334,7 @@ Build these locally with `mise`:
 mise run build:images
 # or individually:
 mise run build:image:debian
+mise run build:image:debian-ruby
 mise run build:image:debian-docker
 mise run build:image:debian-agents
 mise run build:image:alpine

--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ cleanroom exec --in "$SANDBOX_ID" -- npm run lint
 Override the sandbox image per command (remote tag/digest or local Docker image name):
 
 ```bash
-cleanroom sandbox create --image ghcr.io/buildkite/cleanroom-base/alpine:latest
-cleanroom exec --image ghcr.io/buildkite/cleanroom-base/alpine:latest -- npm test
+cleanroom sandbox create --image ghcr.io/buildkite/cleanroom-base/debian:latest
+cleanroom exec --image ghcr.io/buildkite/cleanroom-base/debian:latest -- npm test
 cleanroom console --image my-local-image:dev -- sh
 cleanroom exec -e OPENAI_API_KEY -e CODEX_HOME=/workspace/.codex -- codex app-server
 ```
@@ -169,7 +169,7 @@ A `cleanroom.yaml` in your repo defines the sandbox policy. Cleanroom also check
 version: 1
 sandbox:
   image:
-    ref: ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+    ref: ghcr.io/buildkite/cleanroom-base/debian@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
   network:
     default: deny
     allow:
@@ -289,7 +289,7 @@ func example() error {
   sb, err := c.EnsureSandbox(context.Background(), "thread:abc123", client.EnsureSandboxOptions{
     Backend: "firecracker",
     Policy: client.PolicyFromAllowlist(
-      "ghcr.io/buildkite/cleanroom-base/alpine@sha256:...",
+      "ghcr.io/buildkite/cleanroom-base/debian@sha256:...",
       "sha256:...",
       client.Allow("api.github.com", 443),
       client.Allow("registry.npmjs.org", 443),
@@ -318,20 +318,24 @@ func example() error {
 Cleanroom uses digest-pinned OCI images as sandbox bases. Images are pulled from any OCI registry and materialized into ext4 rootfs files for the VM backend.
 
 ```bash
-cleanroom image pull ghcr.io/buildkite/cleanroom-base/alpine@sha256:...
+cleanroom image pull ghcr.io/buildkite/cleanroom-base/debian@sha256:...
 cleanroom image ls
 cleanroom image rm sha256:...
-cleanroom image import ghcr.io/buildkite/cleanroom-base/alpine@sha256:... ./rootfs.tar.gz
+cleanroom image import ghcr.io/buildkite/cleanroom-base/debian@sha256:... ./rootfs.tar.gz
 cleanroom image bump-ref    # resolve :latest tag to digest and update cleanroom.yaml
 ```
 
-`ghcr.io/buildkite/cleanroom-base/alpine`, `ghcr.io/buildkite/cleanroom-base/alpine-docker`, and `ghcr.io/buildkite/cleanroom-base/alpine-agents` are published from this repo on pushes to `main`.
+Recommended defaults are the Debian-based images: `ghcr.io/buildkite/cleanroom-base/debian`, `ghcr.io/buildkite/cleanroom-base/debian-docker`, and `ghcr.io/buildkite/cleanroom-base/debian-agents`.
+The Alpine variants remain available as smaller musl-based alternatives: `ghcr.io/buildkite/cleanroom-base/alpine`, `ghcr.io/buildkite/cleanroom-base/alpine-docker`, and `ghcr.io/buildkite/cleanroom-base/alpine-agents`.
 
 Build these locally with `mise`:
 
 ```bash
 mise run build:images
 # or individually:
+mise run build:image:debian
+mise run build:image:debian-docker
+mise run build:image:debian-agents
 mise run build:image:alpine
 mise run build:image:alpine-docker
 mise run build:image:alpine-agents

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -44,7 +44,7 @@ basic-example-ok
 Optional second check:
 
 ```bash
-mise exec -- cleanroom exec --backend darwin-vz -- sh -lc 'cat /etc/alpine-release || cat /etc/os-release'
+mise exec -- cleanroom exec --backend darwin-vz -- sh -lc 'cat /etc/os-release'
 ```
 
 When finished:

--- a/images/Dockerfile.base-image-debian
+++ b/images/Dockerfile.base-image-debian
@@ -1,0 +1,25 @@
+FROM debian:bookworm-slim
+
+ARG MISE_VERSION=v2026.4.5
+
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends \
+      bash \
+      ca-certificates \
+      curl \
+      git \
+      openssh-client \
+      strace \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://mise.run | MISE_VERSION="${MISE_VERSION}" MISE_INSTALL_HELP=0 MISE_INSTALL_PATH=/usr/local/bin/mise sh
+
+# Cleanroom checks out repositories into /workspace, so trust repo-local mise
+# configs there and expose shims on PATH for guest commands.
+RUN mise settings add trusted_config_paths /workspace
+
+ENV PATH="/root/.local/share/mise/shims:${PATH}"
+
+RUN mise --version
+
+CMD ["/bin/sh"]

--- a/images/Dockerfile.base-image-debian-agents
+++ b/images/Dockerfile.base-image-debian-agents
@@ -1,0 +1,44 @@
+FROM node:22-bookworm-slim
+
+ARG MISE_VERSION=v2026.4.5
+ARG CODEX_VERSION=0.106.0
+ARG CLAUDE_CODE_VERSION=2.1.63
+ARG GEMINI_CLI_VERSION=0.31.0
+
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends \
+      bash \
+      build-essential \
+      ca-certificates \
+      curl \
+      git \
+      openssh-client \
+      python3 \
+      strace \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://mise.run | MISE_VERSION="${MISE_VERSION}" MISE_INSTALL_HELP=0 MISE_INSTALL_PATH=/usr/local/bin/mise sh
+
+# Keep repo-local mise configs under /workspace usable in agent containers too.
+RUN mise settings add trusted_config_paths /workspace
+
+# Install common agent CLIs with pinned versions for reproducible builds.
+RUN mise use -g --pin \
+  npm:@openai/codex@"${CODEX_VERSION}" \
+  npm:@anthropic-ai/claude-code@"${CLAUDE_CODE_VERSION}" \
+  npm:@google/gemini-cli@"${GEMINI_CLI_VERSION}"
+
+# Ensure agent binaries are available on the default PATH even when OCI env
+# metadata is not propagated.
+RUN ln -sf /root/.local/share/mise/shims/codex /usr/local/bin/codex \
+  && ln -sf /root/.local/share/mise/shims/claude /usr/local/bin/claude \
+  && ln -sf /root/.local/share/mise/shims/gemini /usr/local/bin/gemini
+
+ENV PATH="/root/.local/share/mise/shims:${PATH}"
+
+RUN mise --version && node --version && npm --version && python3 --version \
+  && PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" codex --version \
+  && PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" claude --version \
+  && PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" gemini --version
+
+CMD ["/bin/sh"]

--- a/images/Dockerfile.base-image-debian-docker
+++ b/images/Dockerfile.base-image-debian-docker
@@ -1,0 +1,26 @@
+FROM debian:bookworm-slim
+
+ARG MISE_VERSION=v2026.4.5
+
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends \
+      bash \
+      ca-certificates \
+      curl \
+      docker.io \
+      git \
+      openssh-client \
+      strace \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://mise.run | MISE_VERSION="${MISE_VERSION}" MISE_INSTALL_HELP=0 MISE_INSTALL_PATH=/usr/local/bin/mise sh
+
+# Cleanroom checks out repositories into /workspace, so trust repo-local mise
+# configs there and expose shims on PATH for guest commands.
+RUN mise settings add trusted_config_paths /workspace
+
+ENV PATH="/root/.local/share/mise/shims:${PATH}"
+
+RUN docker --version && mise --version
+
+CMD ["/bin/sh"]

--- a/images/Dockerfile.base-image-debian-ruby
+++ b/images/Dockerfile.base-image-debian-ruby
@@ -1,0 +1,28 @@
+FROM ruby:3.4.9-slim-bookworm
+
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends \
+      bash \
+      build-essential \
+      ca-certificates \
+      curl \
+      git \
+      libffi-dev \
+      libgdbm-dev \
+      libncurses-dev \
+      libpq-dev \
+      libreadline-dev \
+      libsqlite3-dev \
+      libssl-dev \
+      libyaml-dev \
+      openssh-client \
+      patch \
+      pkg-config \
+      strace \
+      xz-utils \
+      zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN ruby --version && gem --version && bundle --version
+
+CMD ["/bin/sh"]

--- a/images/Dockerfile.base-image-debian-ruby
+++ b/images/Dockerfile.base-image-debian-ruby
@@ -1,5 +1,7 @@
 FROM ruby:3.4.9-slim-bookworm
 
+ARG MISE_VERSION=v2026.4.5
+
 RUN apt-get update \
     && apt-get install --yes --no-install-recommends \
       bash \
@@ -23,6 +25,14 @@ RUN apt-get update \
       zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
 
-RUN ruby --version && gem --version && bundle --version
+RUN curl -fsSL https://mise.run | MISE_VERSION="${MISE_VERSION}" MISE_INSTALL_HELP=0 MISE_INSTALL_PATH=/usr/local/bin/mise sh
+
+# Cleanroom checks out repositories into /workspace, so trust repo-local mise
+# configs there and expose shims on PATH for guest commands.
+RUN mise settings add trusted_config_paths /workspace
+
+ENV PATH="/root/.local/share/mise/shims:${PATH}"
+
+RUN ruby --version && gem --version && bundle --version && mise --version
 
 CMD ["/bin/sh"]

--- a/images/dockerfiles_test.go
+++ b/images/dockerfiles_test.go
@@ -17,10 +17,33 @@ func publishedBaseDockerfiles() []string {
 	}
 }
 
+func debianPublishedBaseDockerfiles() []string {
+	return []string{
+		"Dockerfile.base-image-debian",
+		"Dockerfile.base-image-debian-docker",
+		"Dockerfile.base-image-debian-agents",
+		"Dockerfile.base-image-debian-ruby",
+	}
+}
+
+func allPublishedBaseDockerfiles() []string {
+	paths := publishedBaseDockerfiles()
+	return append(paths, debianPublishedBaseDockerfiles()...)
+}
+
+func dockerfileHasTrimmedLine(dockerfile, want string) bool {
+	for _, line := range strings.Split(dockerfile, "\n") {
+		if strings.TrimSpace(line) == want {
+			return true
+		}
+	}
+	return false
+}
+
 func TestPublishedBaseImagesInstallBash(t *testing.T) {
 	t.Parallel()
 
-	for _, relPath := range publishedBaseDockerfiles() {
+	for _, relPath := range allPublishedBaseDockerfiles() {
 		relPath := relPath
 		t.Run(relPath, func(t *testing.T) {
 			t.Parallel()
@@ -29,7 +52,7 @@ func TestPublishedBaseImagesInstallBash(t *testing.T) {
 			if err != nil {
 				t.Fatalf("read %s: %v", relPath, err)
 			}
-			if !strings.Contains(string(raw), "\n  bash \\\n") {
+			if !dockerfileHasTrimmedLine(string(raw), "bash \\") {
 				t.Fatalf("%s does not install bash", relPath)
 			}
 		})
@@ -48,8 +71,27 @@ func TestPublishedBaseImagesInstallOpenSSHClientDefault(t *testing.T) {
 			if err != nil {
 				t.Fatalf("read %s: %v", relPath, err)
 			}
-			if !strings.Contains(string(raw), "\n  openssh-client-default \\\n") {
+			if !dockerfileHasTrimmedLine(string(raw), "openssh-client-default \\") {
 				t.Fatalf("%s does not install openssh-client-default", relPath)
+			}
+		})
+	}
+}
+
+func TestDebianPublishedBaseImagesInstallOpenSSHClient(t *testing.T) {
+	t.Parallel()
+
+	for _, relPath := range debianPublishedBaseDockerfiles() {
+		relPath := relPath
+		t.Run(relPath, func(t *testing.T) {
+			t.Parallel()
+
+			raw, err := os.ReadFile(filepath.Join(".", relPath))
+			if err != nil {
+				t.Fatalf("read %s: %v", relPath, err)
+			}
+			if !dockerfileHasTrimmedLine(string(raw), "openssh-client \\") {
+				t.Fatalf("%s does not install openssh-client", relPath)
 			}
 		})
 	}
@@ -58,7 +100,7 @@ func TestPublishedBaseImagesInstallOpenSSHClientDefault(t *testing.T) {
 func TestPublishedBaseImagesInstallPinnedMiseRelease(t *testing.T) {
 	t.Parallel()
 
-	for _, relPath := range publishedBaseDockerfiles() {
+	for _, relPath := range allPublishedBaseDockerfiles() {
 		relPath := relPath
 		t.Run(relPath, func(t *testing.T) {
 			t.Parallel()
@@ -72,7 +114,7 @@ func TestPublishedBaseImagesInstallPinnedMiseRelease(t *testing.T) {
 			if !strings.Contains(dockerfile, "ARG MISE_VERSION="+expectedMiseVersion) {
 				t.Fatalf("%s does not pin mise to %s", relPath, expectedMiseVersion)
 			}
-			if !strings.Contains(dockerfile, "\n  curl") {
+			if !dockerfileHasTrimmedLine(dockerfile, "curl \\") {
 				t.Fatalf("%s does not install curl for pinned mise bootstrap", relPath)
 			}
 			if !strings.Contains(dockerfile, "curl -fsSL https://mise.run |") {
@@ -92,7 +134,7 @@ func TestPublishedBaseImagesInstallPinnedMiseRelease(t *testing.T) {
 func TestPublishedBaseImagesExposeMiseShimsOnPATH(t *testing.T) {
 	t.Parallel()
 
-	for _, relPath := range publishedBaseDockerfiles() {
+	for _, relPath := range allPublishedBaseDockerfiles() {
 		relPath := relPath
 		t.Run(relPath, func(t *testing.T) {
 			t.Parallel()
@@ -111,7 +153,7 @@ func TestPublishedBaseImagesExposeMiseShimsOnPATH(t *testing.T) {
 func TestPublishedBaseImagesTrustWorkspaceMiseConfig(t *testing.T) {
 	t.Parallel()
 
-	for _, relPath := range publishedBaseDockerfiles() {
+	for _, relPath := range allPublishedBaseDockerfiles() {
 		relPath := relPath
 		t.Run(relPath, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
## Summary

Add a Debian-based cleanroom base image family alongside the existing Alpine images and switch the default documentation examples to Debian.

## What Changed

- added `ghcr.io/buildkite/cleanroom-base/debian`
- added `ghcr.io/buildkite/cleanroom-base/debian-ruby`
- added `ghcr.io/buildkite/cleanroom-base/debian-docker`
- added `ghcr.io/buildkite/cleanroom-base/debian-agents`
- added local `mise` tasks to build the Debian images
- refactored the base-image GitHub Actions workflow into a matrix so Alpine and Debian variants share the same publish path
- updated README examples and image docs to recommend Debian as the default family
- kept the runnable pinned example policies on Alpine for now, since the Debian digests do not exist until the new workflow publishes them

## Why

Debian gives cleaner defaults for general developer workloads than Alpine, especially for Ruby, Node, Python, and native extensions. The new `debian-ruby` image covers the common Bundler and native-gem toolchain without forcing every Ruby repo to carry a custom cleanroom image.

## Impact

- consumers can pin Debian-based cleanroom images directly once the workflow publishes them
- Ruby repos can start from `debian-ruby` instead of rebuilding the usual compiler and header package set
- Alpine remains available as a smaller musl-based option
- the base-image workflow is simpler to extend for future image families

## Validation

- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/base-image.yml'); puts 'workflow yaml ok'"`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD mise run build:image:debian`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD mise run build:image:debian-ruby`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD mise run build:image:debian-docker`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD mise run build:image:debian-agents`
