### PR TITLE
fix: Disable automatic mise bootstrap by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,11 @@ When `cleanroom.yaml` includes a repository bootstrap block, the top-level
 commands become repo-aware: Cleanroom resolves the current git remote and local
 `HEAD`, materializes that checkout in the sandbox, and starts commands in the
 configured guest path. If the checked-out repository contains `.mise.toml`,
-`mise.toml`, `.tool-versions`, or `.mise/config.toml`, Cleanroom also runs
-the command through `mise exec -- ...` unless
-`sandbox.mise.enabled: false` or `sandbox.mise.install: false` is set in
-`cleanroom.yaml`. Use `cleanroom exec --no-mise -- ...` or
-`cleanroom console --no-mise` to skip that wrapper for a single execution.
+`mise.toml`, `.tool-versions`, or `.mise/config.toml`, Cleanroom only runs the
+command through `mise exec -- ...` when `sandbox.mise.install: true` is set in
+`cleanroom.yaml` and `sandbox.mise.enabled` is not `false`. Use
+`cleanroom exec --no-mise -- ...` or `cleanroom console --no-mise` to skip
+that wrapper for a single execution.
 
 Pre-create a long-running sandbox without running a command:
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -324,8 +324,8 @@ Behavior contract:
    and default the guest working directory to `repository.path`.
    - if the checkout contains `.mise.toml`, `mise.toml`, `.tool-versions`, or
      `.mise/config.toml`, execute the workload through
-     `mise exec -- ...`, unless `sandbox.mise.enabled: false` or
-     `sandbox.mise.install: false`
+     `mise exec -- ...` only when `sandbox.mise.install: true` and
+     `sandbox.mise.enabled` is not `false`
    - `cleanroom exec --no-mise` and `cleanroom console --no-mise` set
      `ExecutionOptions.disable_mise` for that execution
 6. Create execution with explicit kind, env, and TTY options.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -161,7 +161,7 @@ Meaning:
 - `repository.path` defaults to `/workspace` and must be an absolute guest path.
 - `repository.submodules` defaults to `false`.
 - `sandbox.mise.enabled` defaults to `true`; `false` disables Cleanroom-managed `mise` detection and install wrapping.
-- `sandbox.mise.install` defaults to `true`; `false` preserves repo-aware checkout but skips automatic `mise exec -- ...` wrapping.
+- `sandbox.mise.install` defaults to `false`; `true` preserves repo-aware checkout and enables automatic `mise exec -- ...` wrapping.
 - `sandbox.mise.config_files` defaults to `.mise.toml`, `mise.toml`, `.tool-versions`, and `.mise/config.toml`.
 - Host matching supports:
   - exact host (`registry.npmjs.org`)
@@ -221,7 +221,7 @@ Meaning:
   - they resolve the local repository remote URL and committed `HEAD`
   - they materialize that checkout inside the sandbox before the command runs
   - they start commands in `repository.path`
-  - when the checkout contains `.mise.toml`, `mise.toml`, `.tool-versions`, or `.mise/config.toml`, they execute the command through `mise exec -- ...` unless `sandbox.mise.enabled: false` or `sandbox.mise.install: false`
+  - when the checkout contains `.mise.toml`, `mise.toml`, `.tool-versions`, or `.mise/config.toml`, they execute the command through `mise exec -- ...` only when `sandbox.mise.install: true` and `sandbox.mise.enabled` is not `false`
   - `cleanroom exec --no-mise` and `cleanroom console --no-mise` disable that automatic wrapping for a single execution
 - `cleanroom sandbox create` remains the generic low-level surface and does not
   infer repository state from the current working tree or read `cleanroom.yaml`.

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -933,13 +933,13 @@ func (s *Service) CreateExecution(ctx context.Context, req *cleanroomv1.CreateEx
 		if err := validateRepositoryCheckoutForPolicy(sandboxPolicy, repository); err != nil {
 			return nil, err
 		}
-		autoMiseInstall := (sandboxPolicy == nil || sandboxPolicy.MiseInstall) && !execOpts.DisableMise
+		autoMiseInstall := sandboxPolicy != nil && sandboxPolicy.MiseInstall && !execOpts.DisableMise
 		if err := s.preparePersistentSandboxRepository(ctx, sandboxID, sandboxPolicy, firecrackerCfg, adapter, repository); err != nil {
 			return nil, err
 		}
 		command = repositorycheckout.WrapCommandInWorkdir(command, repository, autoMiseInstall)
 	} else if sandboxRepository != nil {
-		autoMiseInstall := (sandboxPolicy == nil || sandboxPolicy.MiseInstall) && !execOpts.DisableMise
+		autoMiseInstall := sandboxPolicy != nil && sandboxPolicy.MiseInstall && !execOpts.DisableMise
 		command = repositorycheckout.WrapCommandInWorkdir(command, sandboxRepository, autoMiseInstall)
 	}
 

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -1616,6 +1616,130 @@ func TestCreateExecutionSkipsMiseBootstrapWhenPolicyDisablesInstall(t *testing.T
 	}
 }
 
+func TestCreateExecutionSkipsMiseBootstrapByDefault(t *testing.T) {
+	adapter := &stubAdapter{}
+	mirrors := &stubRepositoryMirrorStore{}
+	svc := newTestService(adapter)
+	svc.RepositoryMirrors = mirrors
+
+	var (
+		mu       sync.Mutex
+		commands [][]string
+	)
+	runCalled := make(chan struct{}, 4)
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+		mu.Lock()
+		commands = append(commands, append([]string(nil), req.Command...))
+		mu.Unlock()
+		select {
+		case runCalled <- struct{}{}:
+		default:
+		}
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+	}
+
+	createSandboxResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Policy:             testRepositoryPolicy(),
+		RepositoryCheckout: testRepositoryCheckoutProto(),
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createSandboxResp.GetSandbox().GetSandboxId()
+	select {
+	case <-runCalled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for sandbox bootstrap")
+	}
+
+	_, err = svc.CreateExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
+		SandboxId:          sandboxID,
+		Command:            []string{"sh", "-lc", "pwd"},
+		RepositoryCheckout: testRepositoryCheckoutProto(),
+	})
+	if err != nil {
+		t.Fatalf("CreateExecution returned error: %v", err)
+	}
+	select {
+	case <-runCalled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for execution")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if got, want := len(commands), 2; got != want {
+		t.Fatalf("expected create bootstrap + execution, got %d command(s)", got)
+	}
+	joined := strings.Join(commands[1], " ")
+	if strings.Contains(joined, "mise exec --") {
+		t.Fatalf("expected default execution to skip mise exec wrapper, got %q", joined)
+	}
+}
+
+func TestCreateExecutionWrapsInMiseWhenPolicyEnablesInstall(t *testing.T) {
+	adapter := &stubAdapter{}
+	mirrors := &stubRepositoryMirrorStore{}
+	svc := newTestService(adapter)
+	svc.RepositoryMirrors = mirrors
+
+	var (
+		mu       sync.Mutex
+		commands [][]string
+	)
+	runCalled := make(chan struct{}, 4)
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+		mu.Lock()
+		commands = append(commands, append([]string(nil), req.Command...))
+		mu.Unlock()
+		select {
+		case runCalled <- struct{}{}:
+		default:
+		}
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+	}
+
+	policyProto := testRepositoryPolicy()
+	policyProto.MiseInstall = boolPtr(true)
+	createSandboxResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Policy:             policyProto,
+		RepositoryCheckout: testRepositoryCheckoutProto(),
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createSandboxResp.GetSandbox().GetSandboxId()
+	select {
+	case <-runCalled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for sandbox bootstrap")
+	}
+
+	_, err = svc.CreateExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
+		SandboxId:          sandboxID,
+		Command:            []string{"sh", "-lc", "pwd"},
+		RepositoryCheckout: testRepositoryCheckoutProto(),
+	})
+	if err != nil {
+		t.Fatalf("CreateExecution returned error: %v", err)
+	}
+	select {
+	case <-runCalled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for execution")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if got, want := len(commands), 2; got != want {
+		t.Fatalf("expected create bootstrap + execution, got %d command(s)", got)
+	}
+	joined := strings.Join(commands[1], " ")
+	if !strings.Contains(joined, "mise exec --") {
+		t.Fatalf("expected policy-enabled execution to wrap with mise exec, got %q", joined)
+	}
+}
+
 func TestCreateExecutionSkipsMiseWhenExecutionOptionDisablesMise(t *testing.T) {
 	adapter := &stubAdapter{}
 	mirrors := &stubRepositoryMirrorStore{}

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -453,7 +453,7 @@ func FromProto(pb *cleanroomv1.Policy) (*CompiledPolicy, error) {
 		},
 		NetworkDefault: networkDefault,
 		Allow:          allow,
-		MiseInstall:    protoBoolOrDefault(pb.MiseInstall, true),
+		MiseInstall:    protoBoolOrDefault(pb.MiseInstall, false),
 	}
 
 	hash, err := hashPolicy(compiled)
@@ -479,7 +479,7 @@ func normalizeMiseInstall(raw rawMiseConfig) bool {
 	if raw.Install != nil {
 		return *raw.Install
 	}
-	return true
+	return false
 }
 
 func protoBoolOrDefault(v *bool, fallback bool) bool {

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -174,7 +174,7 @@ func TestCompileCapturesDockerServiceRequirement(t *testing.T) {
 	}
 }
 
-func TestCompileDefaultsMiseInstallEnabled(t *testing.T) {
+func TestCompileDefaultsMiseInstallDisabled(t *testing.T) {
 	t.Parallel()
 
 	raw := baseRawPolicy()
@@ -182,8 +182,23 @@ func TestCompileDefaultsMiseInstallEnabled(t *testing.T) {
 	if err != nil {
 		t.Fatalf("compile: %v", err)
 	}
+	if compiled.MiseInstall {
+		t.Fatal("expected compiled policy to disable mise auto-install by default")
+	}
+}
+
+func TestCompileEnablesMiseInstallWhenSandboxMiseInstallTrue(t *testing.T) {
+	t.Parallel()
+
+	raw := baseRawPolicy()
+	raw.Sandbox.Mise.Install = testBoolPtr(true)
+
+	compiled, err := Compile(raw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
 	if !compiled.MiseInstall {
-		t.Fatal("expected compiled policy to enable mise auto-install by default")
+		t.Fatal("expected compiled policy to enable mise auto-install when sandbox.mise.install=true")
 	}
 }
 


### PR DESCRIPTION
## Summary

This flips Cleanroom's repository `mise` integration from opt-out to opt-in.

## What Changed

- change the compiled policy default so `sandbox.mise.install` is `false` when omitted
- change policy proto decoding to preserve the new default when the field is unset
- stop execution-time repository wrapping from enabling `mise exec -- ...` unless the compiled policy explicitly opted in
- add tests for the new default-disabled behavior and the explicit opt-in path
- update README, spec, and API docs to describe `mise` wrapping as opt-in

## Why

The current default is surprising and fragile:

- a plain repo-scoped `cleanroom exec` can silently become `mise exec -- ...`
- that silently expands the sandbox's required network surface
- it introduces hidden startup latency and failure modes into commands that do not need tool bootstrap

Recent CI failures made this concrete. Buildkite build [#857](https://buildkite.com/buildkite/cleanroom/builds/857) stalled in Firecracker e2e after trying to reach `mise-versions.jdx.dev` from an otherwise simple repo-scoped command. That is the wrong default for a product whose main value is explicit runtime and network behavior.

## Impact

Repositories that want automatic `mise` toolchain activation now need to opt in with:

```yaml
sandbox:
  mise:
    install: true
```

Existing `--no-mise` behavior is unchanged and still overrides the policy when needed.

## Validation

- `MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/559c/cleanroom mise exec -- go test ./internal/policy ./internal/controlservice ./scripts`
