### PR TITLE
fix(release): drop stale vmnet entitlements archive

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -47,8 +47,6 @@ archives:
         strip_parent: true
       - src: release-extra/darwin_{{ .Arch }}/cleanroom-darwin-vz.app
         strip_parent: true
-      - src: release-extra/darwin_{{ .Arch }}/entitlements-vmnet.plist
-        strip_parent: true
       - src: release-extra/darwin_{{ .Arch }}/entitlements.plist
         strip_parent: true
 


### PR DESCRIPTION
## Summary
- remove the stale `entitlements-vmnet.plist` Darwin archive entry from `.goreleaser.yml`
- keep the release manifest aligned with the current `ci-macos-release-pkg.sh` output

## Testing
- `mise exec -- goreleaser release --clean --snapshot --verbose` with a synthetic `release-extra` tree matching the Buildkite publisher layout

## Context
Buildkite release build #879 failed during the archive phase because GoReleaser still expected `release-extra/darwin_arm64/entitlements-vmnet.plist`, but the packaging job now only emits `entitlements.plist`.