### PR TITLE
fix(images): Install iproute2 in Debian base images

### DIFF
--- a/images/Dockerfile.base-image-debian
+++ b/images/Dockerfile.base-image-debian
@@ -8,6 +8,7 @@ RUN apt-get update \
       ca-certificates \
       curl \
       git \
+      iproute2 \
       openssh-client \
       strace \
     && rm -rf /var/lib/apt/lists/*

--- a/images/Dockerfile.base-image-debian-agents
+++ b/images/Dockerfile.base-image-debian-agents
@@ -12,6 +12,7 @@ RUN apt-get update \
       ca-certificates \
       curl \
       git \
+      iproute2 \
       openssh-client \
       python3 \
       strace \

--- a/images/Dockerfile.base-image-debian-docker
+++ b/images/Dockerfile.base-image-debian-docker
@@ -9,6 +9,7 @@ RUN apt-get update \
       curl \
       docker.io \
       git \
+      iproute2 \
       openssh-client \
       strace \
     && rm -rf /var/lib/apt/lists/*

--- a/images/Dockerfile.base-image-debian-ruby
+++ b/images/Dockerfile.base-image-debian-ruby
@@ -9,6 +9,7 @@ RUN apt-get update \
       ca-certificates \
       curl \
       git \
+      iproute2 \
       libffi-dev \
       libgdbm-dev \
       libncurses-dev \

--- a/images/dockerfiles_test.go
+++ b/images/dockerfiles_test.go
@@ -97,6 +97,25 @@ func TestDebianPublishedBaseImagesInstallOpenSSHClient(t *testing.T) {
 	}
 }
 
+func TestDebianPublishedBaseImagesInstallIPRoute2(t *testing.T) {
+	t.Parallel()
+
+	for _, relPath := range debianPublishedBaseDockerfiles() {
+		relPath := relPath
+		t.Run(relPath, func(t *testing.T) {
+			t.Parallel()
+
+			raw, err := os.ReadFile(filepath.Join(".", relPath))
+			if err != nil {
+				t.Fatalf("read %s: %v", relPath, err)
+			}
+			if !dockerfileHasTrimmedLine(string(raw), "iproute2 \\") {
+				t.Fatalf("%s does not install iproute2 for darwin-vz guest routing", relPath)
+			}
+		})
+	}
+}
+
 func TestPublishedBaseImagesInstallPinnedMiseRelease(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- install `iproute2` in every published Debian base image variant
- add a Dockerfile test that enforces `iproute2` in the Debian image family
- cover the darwin-vz/filehandle guest-routing regression introduced by the recent Debian images

## Why
The darwin-vz guest init path configures static networking with `ip` when it is available, and falls back to `ifconfig` otherwise. The recent Debian base images shipped without either tool, so filehandle guests could boot without a default route and fail to reach the host gateway at `10.233.0.1`.

Adding `iproute2` restores the required guest-side tooling across the Debian base image family.

## Validation
- `MISE_TRUSTED_CONFIG_PATHS=$PWD mise exec -- go test ./images`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD mise run build:image:debian`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD mise run build:image:debian-docker`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD mise run build:image:debian-agents`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD mise run build:image:debian-ruby`
