### PR TITLE
build: Bump Go to 1.26.2

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,5 @@
 [tools]
-go = "1.23"
+go = "1.26.2"
 terraform = "1.12.2"
 shellcheck = "0.11.0"
 hyperfine = "1.20.0"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/buildkite/cleanroom
 
-go 1.23.1
+go 1.26.2
 
 require (
 	connectrpc.com/connect v1.18.1


### PR DESCRIPTION
## What changed
- bump the module `go` directive in `go.mod` from `1.23.1` to `1.26.2`
- bump the repo toolchain pin in `.mise.toml` from `1.23` to `1.26.2`

## Why
- align the repo with the latest stable Go release
- keep local toolchain setup and the module declaration in sync

## Impact
- developers using `mise` will install and run `go1.26.2`
- module builds and tests now target `go1.26.2`

## Validation
- `go test ./...` run under `go1.26.2`
