### PR TITLE
feat: unify gateway hostname

### DIFF
--- a/docs/backend/darwin-vz.md
+++ b/docs/backend/darwin-vz.md
@@ -19,7 +19,7 @@ Implemented:
 - `filehandle` network mode with a Cleanroom-owned guest gateway and stable guest IP
 - TCP allowlist egress filtering for `sandbox.network.allow` in `filehandle` mode
 - hostname-based allow rules currently use observed DNS answers plus destination IP:port, so co-hosted services on the same IP:port are not distinguished
-- guest access to the shared host gateway through the filehandle gateway IP
+- guest access to the shared host gateway through the stable hostname `gateway.cleanroom.internal`
 - managed kernel fallback when `kernel_image` is unset or missing
 - rootfs derivation from `sandbox.image.ref` when `rootfs` is unset or missing
 - persistent sandboxes across multiple executions
@@ -28,7 +28,7 @@ Implemented:
 
 Not implemented:
 
-- host port publishing / stable hostnames such as `*.cleanroom.internal`
+- host port publishing / additional stable hostnames such as `*.cleanroom.internal`
 - general UDP/IPv6 allowlist policy beyond the current DNS + TCP filehandle path
 
 ## Process and Transport Model
@@ -126,7 +126,7 @@ On macOS, cleanroom also probes common Homebrew `e2fsprogs` locations.
   - serves guest DNS from that gateway IP
   - enforces `sandbox.network.allow` for TCP egress in the gateway
   - authorizes hostname rules from observed DNS answers plus destination IP:port rather than HTTP `Host` or TLS SNI
-  - exposes the shared host gateway service to the guest through the same gateway IP
+  - exposes the shared host gateway service to the guest at `gateway.cleanroom.internal`
 
 Compared to Firecracker:
 
@@ -157,7 +157,7 @@ Current `darwin-vz` capability values:
 Git traffic for allowed HTTPS hosts uses the filehandle gateway path:
 
 - `filehandle`
-  - the guest rewrites allowed HTTPS Git remotes through the shared host gateway using the filehandle gateway IP
+  - the guest rewrites allowed HTTPS Git remotes through the shared host gateway using `gateway.cleanroom.internal`
   - the guest does not need direct scope-token headers; the host bridge injects them
 
 ## Entitlements and Signing

--- a/docs/backend/firecracker.md
+++ b/docs/backend/firecracker.md
@@ -23,6 +23,7 @@ Firecracker networking is built around a dedicated per-sandbox TAP device on the
 - each sandbox gets a unique host IP / guest IP pair on that TAP-backed subnet
 - the host can identify the sandbox by guest source IP
 - guest DNS is redirected to a host-side resolver built on `miekg/dns`
+- the shared host gateway is exposed inside the guest as `gateway.cleanroom.internal`
 - DNS answers are observed per sandbox/guest IP and projected into dynamic `ipset`-backed allow rules
 - host-side iptables rules enforce default-deny egress, with established flows surviving DNS TTL expiry
 - gateway access is bound to the sandbox's TAP/IP identity rather than a helper-managed token

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -7,6 +7,9 @@ host-side and injected on the upstream leg, so tokens never enter the sandbox.
 
 Currently supported on the `firecracker` and `darwin-vz` backends.
 
+Inside sandboxes, the shared gateway is exposed at
+`http://gateway.cleanroom.internal:8170` by default.
+
 ## Endpoints
 
 | Path | Purpose |
@@ -27,6 +30,8 @@ cleanroom exec -- git clone https://github.com/org/repo.git
 
 The gateway resolves the target host from the request path, validates it against
 the sandbox's compiled policy, and proxies the git smart-HTTP protocol upstream.
+Guest-side git rewrites target `gateway.cleanroom.internal` rather than backend-specific
+IP addresses.
 
 On `darwin-vz`, sandbox identity is carried with the
 `X-Cleanroom-Scope-Token` request header because guests use shared NAT rather

--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -66,7 +66,6 @@ type Adapter struct {
 
 	GatewayRegistry  gatewayRegistry
 	GatewayPort      int
-	GatewayHost      string
 	GatewayBridgeURL string
 
 	ConfiguredNetworkMode string
@@ -980,13 +979,10 @@ func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream 
 			gwPort = gateway.DefaultPort
 		}
 		networkMode := ""
-		gwHost := ""
 		if startedVM.NetworkMetadata != nil {
 			networkMode = startedVM.NetworkMetadata.Mode
-			gwHost = startedVM.NetworkMetadata.GatewayIP
 		}
-		gwHost = resolveGuestGatewayHost(a.GatewayHost, gwHost)
-		guestReq.Env = append(guestReq.Env, gatewayGitProxyEnvVars(req.Policy, networkMode, gwHost, gwPort, gatewayScopeToken)...)
+		guestReq.Env = append(guestReq.Env, gatewayGitProxyEnvVars(req.Policy, networkMode, gwPort)...)
 	}
 	seed := make([]byte, 64)
 	if _, err := cryptorand.Read(seed); err == nil {
@@ -1446,13 +1442,10 @@ func (a *Adapter) executeInSandbox(bootCtx context.Context, runCtx context.Conte
 			gwPort = gateway.DefaultPort
 		}
 		networkMode := ""
-		gwHost := ""
 		if instance.NetworkMetadata != nil {
 			networkMode = instance.NetworkMetadata.Mode
-			gwHost = instance.NetworkMetadata.GatewayIP
 		}
-		gwHost = resolveGuestGatewayHost(a.GatewayHost, gwHost)
-		guestReq.Env = append(guestReq.Env, gatewayGitProxyEnvVars(policy, networkMode, gwHost, gwPort, gatewayScopeToken)...)
+		guestReq.Env = append(guestReq.Env, gatewayGitProxyEnvVars(policy, networkMode, gwPort)...)
 	}
 	seed := make([]byte, 64)
 	if _, err := cryptorand.Read(seed); err == nil {

--- a/internal/backend/darwinvz/backend_unsupported.go
+++ b/internal/backend/darwinvz/backend_unsupported.go
@@ -14,7 +14,6 @@ import (
 type Adapter struct {
 	GatewayRegistry  gatewayRegistry
 	GatewayPort      int
-	GatewayHost      string
 	GatewayBridgeURL string
 
 	ConfiguredNetworkMode string

--- a/internal/backend/darwinvz/filehandle_gateway.go
+++ b/internal/backend/darwinvz/filehandle_gateway.go
@@ -366,10 +366,18 @@ func newFileHandleVirtualNetwork(cfg fileHandleGatewayConfig, dnsUpstreamAddr st
 		_ = udpConn.Close()
 		return nil, fmt.Errorf("listen dns tcp endpoint: %w", err)
 	}
+	staticGatewayAddrs := make([]netip.Addr, 0, 1)
+	if gatewayAddr, parseErr := netip.ParseAddr(strings.TrimSpace(cfg.GatewayIP)); parseErr == nil && gatewayAddr.IsValid() {
+		staticGatewayAddrs = append(staticGatewayAddrs, gatewayAddr)
+	}
 	dnsForwarder := dnsproxy.NewForwarder(dnsproxy.ForwarderConfig{
 		Runtime:       dnsRuntime,
 		UpstreamAddr:  dnsUpstreamAddr,
 		ScopeResolver: newFileHandleScopeResolver(cfg.SandboxID, cfg.GatewayIP),
+		StaticRecords: []dnsproxy.StaticRecord{{
+			Name:      gateway.GuestGatewayHostname,
+			Addresses: staticGatewayAddrs,
+		}},
 	})
 	dnsUDPServer := &mdns.Server{
 		PacketConn: udpConn,

--- a/internal/backend/darwinvz/gateway_env.go
+++ b/internal/backend/darwinvz/gateway_env.go
@@ -1,14 +1,11 @@
 package darwinvz
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/buildkite/cleanroom/internal/gateway"
 	"github.com/buildkite/cleanroom/internal/policy"
 )
-
-const defaultGatewayHost = "192.168.64.1"
 
 // gatewayRegistry is the subset of gateway.Registry used by the darwin
 // adapter.
@@ -17,84 +14,14 @@ type gatewayRegistry interface {
 	ReleaseScopeToken(scopeToken string)
 }
 
-func resolveGuestGatewayHost(configuredHost, runtimeGatewayIP string) string {
-	configuredHost = strings.TrimSpace(configuredHost)
-	if configuredHost != "" {
-		return configuredHost
-	}
-	runtimeGatewayIP = strings.TrimSpace(runtimeGatewayIP)
-	if runtimeGatewayIP != "" {
-		return runtimeGatewayIP
-	}
-	return defaultGatewayHost
-}
-
-func gatewayGitProxyEnvVars(compiled *policy.CompiledPolicy, networkMode, gatewayHost string, gatewayPort int, scopeToken string) []string {
+func gatewayGitProxyEnvVars(compiled *policy.CompiledPolicy, networkMode string, gatewayPort int) []string {
 	if !strings.EqualFold(strings.TrimSpace(networkMode), darwinVZNetworkModeFileHandle) {
 		// darwin-vz only supports the file-handle guest gateway path.
 		return nil
 	}
-	return gatewayEnvVarsWithScope(compiled, gatewayHost, gatewayPort, "")
+	return gatewayEnvVars(compiled, gatewayPort, "")
 }
 
-func gatewayEnvVars(compiled *policy.CompiledPolicy, gatewayHost string, gatewayPort int, scopeToken string) []string {
-	return gatewayEnvVarsWithScope(compiled, gatewayHost, gatewayPort, scopeToken)
-}
-
-func gatewayEnvVarsWithScope(compiled *policy.CompiledPolicy, gatewayHost string, gatewayPort int, scopeToken string) []string {
-	if compiled == nil {
-		return nil
-	}
-	if gatewayPort <= 0 {
-		return nil
-	}
-	gatewayHost = strings.TrimSpace(gatewayHost)
-	scopeToken = strings.TrimSpace(scopeToken)
-	if gatewayHost == "" {
-		return nil
-	}
-
-	type configEntry struct {
-		key   string
-		value string
-	}
-
-	entries := make([]configEntry, 0, len(compiled.Allow)+1)
-	for _, rule := range compiled.Allow {
-		host := strings.TrimSpace(rule.Host)
-		if host == "" {
-			continue
-		}
-		for _, port := range rule.Ports {
-			if port != 443 {
-				continue
-			}
-			entries = append(entries, configEntry{
-				key:   fmt.Sprintf("url.http://%s:%d/git/%s/.insteadOf", gatewayHost, gatewayPort, host),
-				value: fmt.Sprintf("https://%s/", host),
-			})
-			break
-		}
-	}
-
-	if len(entries) == 0 {
-		return nil
-	}
-
-	scopeToken = strings.TrimSpace(scopeToken)
-	if scopeToken != "" {
-		gatewayAddr := fmt.Sprintf("http://%s:%d", gatewayHost, gatewayPort)
-		entries = append(entries, configEntry{
-			key:   fmt.Sprintf("http.%s/.extraHeader", gatewayAddr),
-			value: fmt.Sprintf("%s: %s", gateway.ScopeTokenHeader, scopeToken),
-		})
-	}
-
-	env := make([]string, 0, 1+len(entries)*2)
-	env = append(env, fmt.Sprintf("GIT_CONFIG_COUNT=%d", len(entries)))
-	for i, entry := range entries {
-		env = append(env, fmt.Sprintf("GIT_CONFIG_KEY_%d=%s", i, entry.key))
-		env = append(env, fmt.Sprintf("GIT_CONFIG_VALUE_%d=%s", i, entry.value))
-	}
-	return env
+func gatewayEnvVars(compiled *policy.CompiledPolicy, gatewayPort int, scopeToken string) []string {
+	return gateway.GitProxyEnvVars(compiled, gatewayPort, scopeToken)
 }

--- a/internal/backend/darwinvz/gateway_env_test.go
+++ b/internal/backend/darwinvz/gateway_env_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestGatewayEnvVarsNilPolicy(t *testing.T) {
 	t.Parallel()
-	env := gatewayEnvVars(nil, defaultGatewayHost, 8170, "token")
+	env := gatewayEnvVars(nil, 8170, "token")
 	if env != nil {
 		t.Fatalf("expected nil env for nil policy, got %v", env)
 	}
@@ -23,7 +23,7 @@ func TestGatewayEnvVarsNoHTTPSHosts(t *testing.T) {
 		NetworkDefault: "deny",
 		Allow:          []policy.AllowRule{{Host: "example.com", Ports: []int{80}}},
 	}
-	env := gatewayEnvVars(p, defaultGatewayHost, 8170, "token")
+	env := gatewayEnvVars(p, 8170, "token")
 	if env != nil {
 		t.Fatalf("expected nil env without port 443 hosts, got %v", env)
 	}
@@ -39,68 +39,31 @@ func TestGatewayEnvVarsGeneratesGitRewriteAndHeader(t *testing.T) {
 			{Host: "gitlab.com", Ports: []int{443}},
 		},
 	}
-	env := gatewayEnvVars(p, "192.168.64.1", 8170, "scope-token")
+	env := gatewayEnvVars(p, 8170, "scope-token")
 	if len(env) != 7 {
 		t.Fatalf("expected 7 env vars (count + 3 key/value entries), got %d: %v", len(env), env)
 	}
 	if env[0] != "GIT_CONFIG_COUNT=3" {
 		t.Fatalf("expected GIT_CONFIG_COUNT=3, got %s", env[0])
 	}
-	if !strings.Contains(env[1], "url.http://192.168.64.1:8170/git/github.com/.insteadOf") {
+	if !strings.Contains(env[1], "url.http://"+gateway.GuestGatewayHostname+":8170/git/github.com/.insteadOf") {
 		t.Fatalf("expected github rewrite key, got %s", env[1])
 	}
 	if env[2] != "GIT_CONFIG_VALUE_0=https://github.com/" {
 		t.Fatalf("expected github rewrite value, got %s", env[2])
 	}
-	if !strings.Contains(env[3], "url.http://192.168.64.1:8170/git/gitlab.com/.insteadOf") {
+	if !strings.Contains(env[3], "url.http://"+gateway.GuestGatewayHostname+":8170/git/gitlab.com/.insteadOf") {
 		t.Fatalf("expected gitlab rewrite key, got %s", env[3])
 	}
 	if env[4] != "GIT_CONFIG_VALUE_1=https://gitlab.com/" {
 		t.Fatalf("expected gitlab rewrite value, got %s", env[4])
 	}
-	if !strings.Contains(env[5], "http.http://192.168.64.1:8170/.extraHeader") {
+	if !strings.Contains(env[5], "http.http://"+gateway.GuestGatewayHostname+":8170/.extraHeader") {
 		t.Fatalf("expected extraHeader key, got %s", env[5])
 	}
 	wantHeader := "GIT_CONFIG_VALUE_2=" + gateway.ScopeTokenHeader + ": scope-token"
 	if env[6] != wantHeader {
 		t.Fatalf("expected %q, got %q", wantHeader, env[6])
-	}
-}
-
-func TestResolveGuestGatewayHost(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name           string
-		configuredHost string
-		runtimeIP      string
-		want           string
-	}{
-		{
-			name:           "prefers explicit configured host",
-			configuredHost: "gateway.cleanroom.internal",
-			runtimeIP:      "10.233.0.1",
-			want:           "gateway.cleanroom.internal",
-		},
-		{
-			name:      "uses runtime gateway ip when config unset",
-			runtimeIP: "10.233.0.1",
-			want:      "10.233.0.1",
-		},
-		{
-			name: "falls back to default gateway host",
-			want: defaultGatewayHost,
-		},
-	}
-
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			if got := resolveGuestGatewayHost(tt.configuredHost, tt.runtimeIP); got != tt.want {
-				t.Fatalf("resolveGuestGatewayHost(%q, %q) = %q, want %q", tt.configuredHost, tt.runtimeIP, got, tt.want)
-			}
-		})
 	}
 }
 
@@ -112,14 +75,14 @@ func TestGatewayGitProxyEnvVarsUsesFileHandleGatewayWithoutHeader(t *testing.T) 
 		NetworkDefault: "deny",
 		Allow:          []policy.AllowRule{{Host: "github.com", Ports: []int{443}}},
 	}
-	env := gatewayGitProxyEnvVars(p, darwinVZNetworkModeFileHandle, "10.233.0.1", 8170, "scope-token")
+	env := gatewayGitProxyEnvVars(p, darwinVZNetworkModeFileHandle, 8170)
 	if len(env) != 3 {
 		t.Fatalf("expected 3 env vars (count + 1 key/value entry), got %d: %v", len(env), env)
 	}
 	if env[0] != "GIT_CONFIG_COUNT=1" {
 		t.Fatalf("expected GIT_CONFIG_COUNT=1, got %s", env[0])
 	}
-	if !strings.Contains(env[1], "url.http://10.233.0.1:8170/git/github.com/.insteadOf") {
+	if !strings.Contains(env[1], "url.http://"+gateway.GuestGatewayHostname+":8170/git/github.com/.insteadOf") {
 		t.Fatalf("expected github rewrite key, got %s", env[1])
 	}
 	if env[2] != "GIT_CONFIG_VALUE_0=https://github.com/" {
@@ -140,7 +103,7 @@ func TestGatewayGitProxyEnvVarsSkipsNonFileHandleModes(t *testing.T) {
 		networkMode := networkMode
 		t.Run(networkMode, func(t *testing.T) {
 			t.Parallel()
-			if env := gatewayGitProxyEnvVars(p, networkMode, "192.168.64.1", 8170, "scope-token"); env != nil {
+			if env := gatewayGitProxyEnvVars(p, networkMode, 8170); env != nil {
 				t.Fatalf("expected no git proxy env for non-filehandle mode %q, got %v", networkMode, env)
 			}
 		})

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -2650,31 +2650,10 @@ func randomGuestCID() uint32 {
 }
 
 func gatewayEnvVars(instance *sandboxInstance, gwPort int) []string {
-	if instance.Policy == nil {
+	if instance == nil {
 		return nil
 	}
-
-	var gitHosts []string
-	for _, rule := range instance.Policy.Allow {
-		for _, port := range rule.Ports {
-			if port == 443 {
-				gitHosts = append(gitHosts, rule.Host)
-				break
-			}
-		}
-	}
-	if len(gitHosts) == 0 {
-		return nil
-	}
-
-	gatewayAddr := fmt.Sprintf("http://%s:%d", instance.HostIP, gwPort)
-	env := make([]string, 0, 1+len(gitHosts)*2)
-	env = append(env, fmt.Sprintf("GIT_CONFIG_COUNT=%d", len(gitHosts)))
-	for i, host := range gitHosts {
-		env = append(env, fmt.Sprintf("GIT_CONFIG_KEY_%d=url.%s/git/%s/.insteadOf", i, gatewayAddr, host))
-		env = append(env, fmt.Sprintf("GIT_CONFIG_VALUE_%d=https://%s/", i, host))
-	}
-	return env
+	return gateway.GitProxyEnvVars(instance.Policy, gwPort, "")
 }
 
 func dockerServiceBootArgs(compiled *policy.CompiledPolicy, cfg backend.FirecrackerConfig) string {

--- a/internal/backend/firecracker/gateway_test.go
+++ b/internal/backend/firecracker/gateway_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/buildkite/cleanroom/internal/gateway"
 	"github.com/buildkite/cleanroom/internal/policy"
 )
 
@@ -11,7 +12,6 @@ func TestGatewayEnvVarsEmptyWhenNoPolicyHosts(t *testing.T) {
 	t.Parallel()
 
 	instance := &sandboxInstance{
-		HostIP: "10.1.1.1",
 		Policy: &policy.CompiledPolicy{
 			Version:        1,
 			NetworkDefault: "deny",
@@ -28,7 +28,6 @@ func TestGatewayEnvVarsGeneratesGitConfig(t *testing.T) {
 	t.Parallel()
 
 	instance := &sandboxInstance{
-		HostIP: "10.1.1.1",
 		Policy: &policy.CompiledPolicy{
 			Version:        1,
 			NetworkDefault: "deny",
@@ -48,13 +47,13 @@ func TestGatewayEnvVarsGeneratesGitConfig(t *testing.T) {
 		t.Fatalf("expected GIT_CONFIG_COUNT=2, got %s", env[0])
 	}
 
-	if !strings.Contains(env[1], "url.http://10.1.1.1:8170/git/github.com/.insteadOf") {
+	if !strings.Contains(env[1], "url.http://"+gateway.GuestGatewayHostname+":8170/git/github.com/.insteadOf") {
 		t.Fatalf("expected github.com insteadOf key, got %s", env[1])
 	}
 	if env[2] != "GIT_CONFIG_VALUE_0=https://github.com/" {
 		t.Fatalf("expected github.com value, got %s", env[2])
 	}
-	if !strings.Contains(env[3], "url.http://10.1.1.1:8170/git/gitlab.com/.insteadOf") {
+	if !strings.Contains(env[3], "url.http://"+gateway.GuestGatewayHostname+":8170/git/gitlab.com/.insteadOf") {
 		t.Fatalf("expected gitlab.com insteadOf key, got %s", env[3])
 	}
 }
@@ -62,7 +61,7 @@ func TestGatewayEnvVarsGeneratesGitConfig(t *testing.T) {
 func TestGatewayEnvVarsNilPolicy(t *testing.T) {
 	t.Parallel()
 
-	instance := &sandboxInstance{HostIP: "10.1.1.1"}
+	instance := &sandboxInstance{}
 	env := gatewayEnvVars(instance, 8170)
 	if env != nil {
 		t.Fatalf("expected nil for nil policy, got %v", env)

--- a/internal/backend/firecracker/persistent_test.go
+++ b/internal/backend/firecracker/persistent_test.go
@@ -27,10 +27,7 @@ func TestProvisionSandboxRejectsConcurrentProvisionForSameID(t *testing.T) {
 			if sandboxID != "cr-test" {
 				t.Fatalf("unexpected sandbox id %q", sandboxID)
 			}
-			select {
-			case started <- struct{}{}:
-			default:
-			}
+			close(started)
 			<-block
 			return &sandboxInstance{SandboxID: sandboxID}, nil
 		},

--- a/internal/backend/firecracker/trusted_dns.go
+++ b/internal/backend/firecracker/trusted_dns.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/buildkite/cleanroom/internal/dnsproxy"
+	"github.com/buildkite/cleanroom/internal/gateway"
 	"github.com/buildkite/cleanroom/internal/policy"
 	"github.com/miekg/dns"
 )
@@ -121,6 +122,10 @@ func newTrustedDNSService(_ context.Context, cfg trustedDNSConfig) (func(), erro
 			chainManager.Trigger()
 		},
 		OnDeny: cfg.onDeny,
+		StaticRecords: []dnsproxy.StaticRecord{{
+			Name:      gateway.GuestGatewayHostname,
+			Addresses: []netip.Addr{cfg.hostIP},
+		}},
 	})
 
 	listenAddr := net.JoinHostPort(cfg.hostIP.String(), strconv.Itoa(trustedDNSListenPort))

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -34,7 +34,6 @@ type ServeCommand struct {
 
 var serveSignalNotifyContext = signal.NotifyContext
 var newSnapshotMetadataStore = snapshotstore.New
-var gatewayScopeTokenSourcePolicyForGatewayHost = gateway.ScopeTokenSourcePolicyForGatewayHost
 
 func (s *ServeCommand) Run(ctx *runtimeContext) error {
 	return s.runServer(ctx)
@@ -79,14 +78,12 @@ func (s *ServeCommand) runServer(ctx *runtimeContext) error {
 	if err != nil {
 		return fmt.Errorf("configure git mirror store: %w", err)
 	}
-	darwinGatewayHost := strings.TrimSpace(os.Getenv("CLEANROOM_DARWIN_GATEWAY_HOST"))
 	gwServer := gateway.NewServer(gatewayServerConfig(
 		s.GatewayListen,
 		gwRegistry,
 		gwCredentials,
 		gwMirrors,
 		logger.With("subsystem", "gateway"),
-		darwinGatewayHost,
 	))
 	if err := gwServer.Start(); err != nil {
 		return fmt.Errorf("start gateway: %w", err)
@@ -99,7 +96,7 @@ func (s *ServeCommand) runServer(ctx *runtimeContext) error {
 		}
 	}
 
-	configureGatewayBackends(ctx.Backends, gwRegistry, gwPort, gwServer.Addr(), darwinGatewayHost)
+	configureGatewayBackends(ctx.Backends, gwRegistry, gwPort, gwServer.Addr())
 
 	if fcAdapter, ok := ctx.Backends["firecracker"].(*firecracker.Adapter); ok && fcAdapter.GatewayRegistry != nil {
 		if shouldInstallGatewayFirewall(runtime.GOOS) {
@@ -154,20 +151,17 @@ func (s *ServeCommand) runServer(ctx *runtimeContext) error {
 	return runErr
 }
 
-func gatewayServerConfig(listen string, registry *gateway.Registry, credentials gateway.CredentialProvider, mirrors gateway.GitMirrorStore, logger *log.Logger, darwinGatewayHost string) gateway.ServerConfig {
-	sourcePolicy := gatewayScopeTokenSourcePolicyForGatewayHost(strings.TrimSpace(darwinGatewayHost))
+func gatewayServerConfig(listen string, registry *gateway.Registry, credentials gateway.CredentialProvider, mirrors gateway.GitMirrorStore, logger *log.Logger) gateway.ServerConfig {
 	return gateway.ServerConfig{
-		ListenAddr:                      listen,
-		Registry:                        registry,
-		Credentials:                     credentials,
-		GitMirrors:                      mirrors,
-		Logger:                          logger,
-		ScopeTokenTrustedSourcePrefixes: sourcePolicy.TrustedSourcePrefixes,
-		AllowScopeTokenFromAnySource:    sourcePolicy.AllowScopeTokenFromAnySource,
+		ListenAddr:  listen,
+		Registry:    registry,
+		Credentials: credentials,
+		GitMirrors:  mirrors,
+		Logger:      logger,
 	}
 }
 
-func configureGatewayBackends(backends map[string]backend.Adapter, gwRegistry *gateway.Registry, gwPort int, gwListenAddr, darwinGatewayHost string) {
+func configureGatewayBackends(backends map[string]backend.Adapter, gwRegistry *gateway.Registry, gwPort int, gwListenAddr string) {
 	if fcAdapter, ok := backends["firecracker"].(*firecracker.Adapter); ok {
 		fcAdapter.GatewayRegistry = gwRegistry
 		fcAdapter.GatewayPort = gwPort
@@ -176,7 +170,6 @@ func configureGatewayBackends(backends map[string]backend.Adapter, gwRegistry *g
 	if darwinAdapter, ok := backends["darwin-vz"].(*darwinvz.Adapter); ok {
 		darwinAdapter.GatewayRegistry = gwRegistry
 		darwinAdapter.GatewayPort = gwPort
-		darwinAdapter.GatewayHost = strings.TrimSpace(darwinGatewayHost)
 		darwinAdapter.GatewayBridgeURL = gatewayBridgeURL(gwPort, gwListenAddr)
 	}
 }

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"net/netip"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -59,7 +58,7 @@ func TestConfigureGatewayBackendsConfiguresDarwinVZGateway(t *testing.T) {
 		"darwin-vz":   darwinAdapter,
 	}
 
-	configureGatewayBackends(backends, gwRegistry, 8170, "0.0.0.0:8170", "192.168.64.1")
+	configureGatewayBackends(backends, gwRegistry, 8170, "0.0.0.0:8170")
 
 	if fcAdapter.GatewayRegistry == nil {
 		t.Fatal("expected firecracker adapter to use the host gateway registry")
@@ -72,9 +71,6 @@ func TestConfigureGatewayBackendsConfiguresDarwinVZGateway(t *testing.T) {
 	}
 	if got, want := darwinAdapter.GatewayPort, 8170; got != want {
 		t.Fatalf("unexpected darwin-vz gateway port: got %d want %d", got, want)
-	}
-	if got, want := darwinAdapter.GatewayHost, "192.168.64.1"; got != want {
-		t.Fatalf("unexpected darwin-vz gateway host: got %q want %q", got, want)
 	}
 	if got, want := darwinAdapter.GatewayBridgeURL, "http://127.0.0.1:8170"; got != want {
 		t.Fatalf("unexpected darwin-vz gateway bridge url: got %q want %q", got, want)
@@ -102,43 +98,6 @@ func TestConfigureBackendRuntimeConfigConfiguresDarwinVZCapabilities(t *testing.
 
 	if got, want := darwinAdapter.ConfiguredNetworkMode, "filehandle"; got != want {
 		t.Fatalf("unexpected configured darwin-vz network mode: got %q want %q", got, want)
-	}
-}
-
-func TestGatewayServerConfigUsesDarwinGatewayHostForTrustedPrefixes(t *testing.T) {
-	t.Parallel()
-
-	prevScopeTokenPolicyResolver := gatewayScopeTokenSourcePolicyForGatewayHost
-	t.Cleanup(func() { gatewayScopeTokenSourcePolicyForGatewayHost = prevScopeTokenPolicyResolver })
-
-	want := []netip.Prefix{
-		netip.MustParsePrefix("10.24.7.0/24"),
-		netip.MustParsePrefix("fd00::/64"),
-	}
-	gatewayScopeTokenSourcePolicyForGatewayHost = func(host string) gateway.ScopeTokenSourcePolicy {
-		if host != "gateway.local" {
-			t.Fatalf("unexpected gateway host: %q", host)
-		}
-		return gateway.ScopeTokenSourcePolicy{
-			TrustedSourcePrefixes:        want,
-			AllowScopeTokenFromAnySource: true,
-		}
-	}
-
-	cfg := gatewayServerConfig(
-		":8170",
-		gateway.NewRegistry(),
-		nil,
-		nil,
-		log.New(io.Discard),
-		"  gateway.local  ",
-	)
-
-	if !reflect.DeepEqual(cfg.ScopeTokenTrustedSourcePrefixes, want) {
-		t.Fatalf("unexpected trusted source prefixes: got %v want %v", cfg.ScopeTokenTrustedSourcePrefixes, want)
-	}
-	if !cfg.AllowScopeTokenFromAnySource {
-		t.Fatal("expected allow-any-source fallback to be preserved in server config")
 	}
 }
 

--- a/internal/dnsproxy/forwarder.go
+++ b/internal/dnsproxy/forwarder.go
@@ -3,6 +3,7 @@ package dnsproxy
 import (
 	"net"
 	"net/netip"
+	"slices"
 	"time"
 
 	"github.com/miekg/dns"
@@ -23,6 +24,13 @@ type ObserveHook func(sandboxID string, sourceIP netip.Addr)
 // sandbox's network allow policy.
 type DenyHook func(sandboxID, queryName string)
 
+// StaticRecord configures a synthetic DNS record served directly by the
+// forwarder without contacting an upstream resolver.
+type StaticRecord struct {
+	Name      string
+	Addresses []netip.Addr
+}
+
 // ForwarderConfig configures a DNS forwarding handler.
 type ForwarderConfig struct {
 	Runtime       *Runtime
@@ -32,6 +40,7 @@ type ForwarderConfig struct {
 	Now           func() time.Time
 	OnObserve     ObserveHook
 	OnDeny        DenyHook
+	StaticRecords []StaticRecord
 }
 
 // Forwarder forwards DNS requests to an upstream resolver and records the
@@ -44,6 +53,7 @@ type Forwarder struct {
 	now           func() time.Time
 	onObserve     ObserveHook
 	onDeny        DenyHook
+	staticRecords map[string][]netip.Addr
 }
 
 // NewForwarder creates a DNS forwarding handler backed by miekg/dns.
@@ -64,12 +74,21 @@ func NewForwarder(cfg ForwarderConfig) *Forwarder {
 		now:           now,
 		onObserve:     cfg.OnObserve,
 		onDeny:        cfg.OnDeny,
+		staticRecords: normalizeStaticRecords(cfg.StaticRecords),
 	}
 }
 
 // ServeDNS implements dns.Handler.
 func (f *Forwarder) ServeDNS(w dns.ResponseWriter, req *dns.Msg) {
-	if req == nil || f.client == nil || f.upstreamAddr == "" {
+	if req == nil {
+		_ = writeServerFailure(w, req)
+		return
+	}
+	if resp, ok := f.staticResponse(req); ok {
+		_ = w.WriteMsg(resp)
+		return
+	}
+	if f.client == nil || f.upstreamAddr == "" {
 		_ = writeServerFailure(w, req)
 		return
 	}
@@ -155,4 +174,105 @@ func writeServerFailure(w dns.ResponseWriter, req *dns.Msg) error {
 		msg.Response = true
 	}
 	return w.WriteMsg(msg)
+}
+
+func normalizeStaticRecords(records []StaticRecord) map[string][]netip.Addr {
+	if len(records) == 0 {
+		return nil
+	}
+
+	out := make(map[string][]netip.Addr, len(records))
+	for _, record := range records {
+		name := normalizeName(record.Name)
+		if name == "" {
+			continue
+		}
+		for _, addr := range record.Addresses {
+			addr = normalizeAddr(addr)
+			if !addr.IsValid() {
+				continue
+			}
+			if slices.Contains(out[name], addr) {
+				continue
+			}
+			out[name] = append(out[name], addr)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func (f *Forwarder) staticResponse(req *dns.Msg) (*dns.Msg, bool) {
+	if req == nil || len(f.staticRecords) == 0 || len(req.Question) == 0 {
+		return nil, false
+	}
+
+	resp := new(dns.Msg)
+	resp.SetReply(req)
+	resp.Authoritative = true
+
+	matched := false
+	for _, question := range req.Question {
+		name := normalizeName(question.Name)
+		addresses := f.staticRecords[name]
+		if len(addresses) == 0 {
+			continue
+		}
+		matched = true
+		for _, addr := range addresses {
+			switch {
+			case question.Qtype == dns.TypeA && addr.Is4():
+				resp.Answer = append(resp.Answer, &dns.A{
+					Hdr: dns.RR_Header{
+						Name:   dns.Fqdn(name),
+						Rrtype: dns.TypeA,
+						Class:  dns.ClassINET,
+						Ttl:    60,
+					},
+					A: net.IP(addr.AsSlice()),
+				})
+			case question.Qtype == dns.TypeAAAA && addr.Is6():
+				resp.Answer = append(resp.Answer, &dns.AAAA{
+					Hdr: dns.RR_Header{
+						Name:   dns.Fqdn(name),
+						Rrtype: dns.TypeAAAA,
+						Class:  dns.ClassINET,
+						Ttl:    60,
+					},
+					AAAA: net.IP(addr.AsSlice()),
+				})
+			case question.Qtype == dns.TypeANY:
+				if addr.Is4() {
+					resp.Answer = append(resp.Answer, &dns.A{
+						Hdr: dns.RR_Header{
+							Name:   dns.Fqdn(name),
+							Rrtype: dns.TypeA,
+							Class:  dns.ClassINET,
+							Ttl:    60,
+						},
+						A: net.IP(addr.AsSlice()),
+					})
+					continue
+				}
+				if addr.Is6() {
+					resp.Answer = append(resp.Answer, &dns.AAAA{
+						Hdr: dns.RR_Header{
+							Name:   dns.Fqdn(name),
+							Rrtype: dns.TypeAAAA,
+							Class:  dns.ClassINET,
+							Ttl:    60,
+						},
+						AAAA: net.IP(addr.AsSlice()),
+					})
+				}
+			}
+		}
+	}
+
+	if !matched {
+		return nil, false
+	}
+	return resp, true
 }

--- a/internal/dnsproxy/runtime_test.go
+++ b/internal/dnsproxy/runtime_test.go
@@ -1109,6 +1109,78 @@ func TestForwarderOnDenyUsesCurrentResponseInsteadOfHistoricalObservation(t *tes
 	}
 }
 
+func TestForwarderServesStaticRecordsWithoutUpstreamObservationOrDeny(t *testing.T) {
+	t.Parallel()
+
+	runtime := NewRuntime(RuntimeConfig{})
+	if err := runtime.RegisterSandbox("sandbox-1", testCompiledPolicy(
+		policy.AllowRule{Host: "github.com", Ports: []int{443}},
+	)); err != nil {
+		t.Fatalf("register sandbox: %v", err)
+	}
+
+	now := time.Date(2026, time.April, 12, 8, 0, 0, 0, time.UTC)
+	sourceIP := netip.MustParseAddr("10.0.0.2")
+	staticIP := netip.MustParseAddr("10.0.0.1")
+
+	upstreamCalls := 0
+	denyCalls := 0
+	forwarder := NewForwarder(ForwarderConfig{
+		Runtime:      runtime,
+		UpstreamAddr: "127.0.0.1:5300",
+		Now:          func() time.Time { return now },
+		ScopeResolver: func(addr netip.Addr) (string, bool) {
+			if addr == sourceIP {
+				return "sandbox-1", true
+			}
+			return "", false
+		},
+		Client: exchangeFunc(func(msg *dns.Msg, _ string) (*dns.Msg, time.Duration, error) {
+			upstreamCalls++
+			return testResponse(msg.Question[0].Name), 0, nil
+		}),
+		OnDeny: func(_, _ string) {
+			denyCalls++
+		},
+		StaticRecords: []StaticRecord{{
+			Name:      "gateway.cleanroom.internal",
+			Addresses: []netip.Addr{staticIP},
+		}},
+	})
+
+	writer := &testResponseWriter{
+		remoteAddr: &net.UDPAddr{IP: net.ParseIP("10.0.0.2"), Port: 53000},
+		localAddr:  &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1053},
+	}
+	request := new(dns.Msg)
+	request.SetQuestion("gateway.cleanroom.internal.", dns.TypeA)
+
+	forwarder.ServeDNS(writer, request)
+
+	if upstreamCalls != 0 {
+		t.Fatalf("expected static record query to skip upstream exchange, got %d calls", upstreamCalls)
+	}
+	if denyCalls != 0 {
+		t.Fatalf("expected static record query to skip deny hooks, got %d calls", denyCalls)
+	}
+	if writer.message == nil {
+		t.Fatal("expected forwarder to write a static response")
+	}
+	if len(writer.message.Answer) != 1 {
+		t.Fatalf("unexpected static answer count: got %d want 1", len(writer.message.Answer))
+	}
+	answer, ok := writer.message.Answer[0].(*dns.A)
+	if !ok {
+		t.Fatalf("expected static A record, got %T", writer.message.Answer[0])
+	}
+	if got, want := answer.A.String(), staticIP.String(); got != want {
+		t.Fatalf("unexpected static record address: got %s want %s", got, want)
+	}
+	if observations := runtime.Observations("sandbox-1", now); len(observations) != 0 {
+		t.Fatalf("did not expect static record query to populate observations: %+v", observations)
+	}
+}
+
 func TestHostAllowedByPolicyReturnsFalseForUnregisteredSandbox(t *testing.T) {
 	t.Parallel()
 

--- a/internal/gateway/git_proxy_env.go
+++ b/internal/gateway/git_proxy_env.go
@@ -1,0 +1,68 @@
+package gateway
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/buildkite/cleanroom/internal/policy"
+)
+
+// GuestGatewayHostname is the canonical guest-visible hostname for the shared
+// Cleanroom host gateway.
+const GuestGatewayHostname = "gateway.cleanroom.internal"
+
+// GitProxyEnvVars returns git config environment variables that rewrite allowed
+// HTTPS remotes through the shared host gateway.
+func GitProxyEnvVars(compiled *policy.CompiledPolicy, gatewayPort int, scopeToken string) []string {
+	if compiled == nil || gatewayPort <= 0 {
+		return nil
+	}
+
+	type configEntry struct {
+		key   string
+		value string
+	}
+
+	gatewayAddr := fmt.Sprintf("http://%s:%d", GuestGatewayHostname, gatewayPort)
+	entries := make([]configEntry, 0, len(compiled.Allow)+1)
+	seenHosts := make(map[string]struct{}, len(compiled.Allow))
+	for _, rule := range compiled.Allow {
+		host := strings.TrimSpace(rule.Host)
+		if host == "" {
+			continue
+		}
+		for _, port := range rule.Ports {
+			if port != 443 {
+				continue
+			}
+			if _, exists := seenHosts[host]; exists {
+				break
+			}
+			seenHosts[host] = struct{}{}
+			entries = append(entries, configEntry{
+				key:   fmt.Sprintf("url.%s/git/%s/.insteadOf", gatewayAddr, host),
+				value: fmt.Sprintf("https://%s/", host),
+			})
+			break
+		}
+	}
+	if len(entries) == 0 {
+		return nil
+	}
+
+	scopeToken = strings.TrimSpace(scopeToken)
+	if scopeToken != "" {
+		entries = append(entries, configEntry{
+			key:   fmt.Sprintf("http.%s/.extraHeader", gatewayAddr),
+			value: fmt.Sprintf("%s: %s", ScopeTokenHeader, scopeToken),
+		})
+	}
+
+	env := make([]string, 0, 1+len(entries)*2)
+	env = append(env, fmt.Sprintf("GIT_CONFIG_COUNT=%d", len(entries)))
+	for i, entry := range entries {
+		env = append(env, fmt.Sprintf("GIT_CONFIG_KEY_%d=%s", i, entry.key))
+		env = append(env, fmt.Sprintf("GIT_CONFIG_VALUE_%d=%s", i, entry.value))
+	}
+	return env
+}


### PR DESCRIPTION
## Summary
- unify guest-facing gateway access around a single canonical hostname: `gateway.cleanroom.internal`
- remove backend-specific gateway host fallback logic and share git rewrite env generation across backends
- serve the gateway hostname directly from the Cleanroom-managed DNS path in both Firecracker and darwin-vz

## Why
The gateway path had drifted into backend-specific behavior and fallback branches. This change keeps the guest-visible address simple and stable, so guests always target the same hostname regardless of backend.

## Impact
- Firecracker and darwin-vz now both advertise the same guest-facing gateway hostname
- git rewrite configuration is generated from shared gateway code instead of backend-local copies
- gateway DNS lookups stay inside Cleanroom-managed resolution rather than depending on external naming

## Validation
- `go test ./internal/dnsproxy ./internal/gateway ./internal/backend/firecracker ./internal/backend/darwinvz ./internal/cli`
