### PR TITLE
ci: Use setup-go plugin for Go steps

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,7 +15,7 @@ steps:
 
   - label: ":test_tube: Test (Linux)"
     plugins:
-      - github.com/lox/mise-buildkite-plugin#a172963b3d34e98601e2a65c7dd08211fb49b7f0:
+      - github.com/buildkite-plugins/setup-go-buildkite-plugin#daa7af945245588f85b76ba7fe0a9af3d87dbf91:
     command: go test ./...
     cache:
       paths:
@@ -29,7 +29,7 @@ steps:
 
   - label: ":test_tube: Test (macOS)"
     plugins:
-      - github.com/lox/mise-buildkite-plugin#a172963b3d34e98601e2a65c7dd08211fb49b7f0:
+      - github.com/buildkite-plugins/setup-go-buildkite-plugin#daa7af945245588f85b76ba7fe0a9af3d87dbf91:
     command: go test ./...
     cache:
       paths:
@@ -43,7 +43,7 @@ steps:
 
   - label: ":apple: E2E (darwin-vz)"
     plugins:
-      - github.com/lox/mise-buildkite-plugin#a172963b3d34e98601e2a65c7dd08211fb49b7f0:
+      - github.com/buildkite-plugins/setup-go-buildkite-plugin#daa7af945245588f85b76ba7fe0a9af3d87dbf91:
     command: scripts/ci-darwin-vz-e2e.sh
     concurrency: 1
     concurrency_group: cleanroom-darwin-vz-e2e
@@ -52,7 +52,7 @@ steps:
 
   - label: ":apple: E2E (darwin-vz filehandle)"
     plugins:
-      - github.com/lox/mise-buildkite-plugin#a172963b3d34e98601e2a65c7dd08211fb49b7f0:
+      - github.com/buildkite-plugins/setup-go-buildkite-plugin#daa7af945245588f85b76ba7fe0a9af3d87dbf91:
     command: scripts/ci-darwin-vz-filehandle-e2e.sh
     concurrency: 1
     concurrency_group: cleanroom-darwin-vz-e2e
@@ -63,7 +63,7 @@ steps:
     key: macos-release-pkg
     if: build.tag != null || build.branch == "codex/macos-notarized-release-pkg"
     plugins:
-      - github.com/lox/mise-buildkite-plugin#a172963b3d34e98601e2a65c7dd08211fb49b7f0:
+      - github.com/buildkite-plugins/setup-go-buildkite-plugin#daa7af945245588f85b76ba7fe0a9af3d87dbf91:
     command: scripts/ci-macos-release-pkg.sh
     concurrency: 1
     concurrency_group: cleanroom-macos-release-pkg
@@ -75,7 +75,7 @@ steps:
 
   - label: ":fire: E2E (Firecracker)"
     plugins:
-      - github.com/lox/mise-buildkite-plugin#a172963b3d34e98601e2a65c7dd08211fb49b7f0:
+      - github.com/buildkite-plugins/setup-go-buildkite-plugin#daa7af945245588f85b76ba7fe0a9af3d87dbf91:
     command: scripts/ci-cleanroom-e2e.sh
     concurrency: 1
     concurrency_group: cleanroom-e2e

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -25,8 +25,9 @@ For self-hosted macOS capacity, Terraform can provision a private EC2 Mac host a
 
 Notes:
 
-- `mise` is bootstrapped per-step via the pinned `lox/mise-buildkite-plugin` reference in `.buildkite/pipeline.yml`.
-- Self-hosted agents need `curl` and `tar` available so the plugin can install `mise`.
+- Go-oriented steps bootstrap the toolchain via the pinned `buildkite-plugins/setup-go-buildkite-plugin` reference in `.buildkite/pipeline.yml`.
+- The `:shell: Shellcheck` and `:rocket: Publish release` steps still use the pinned `lox/mise-buildkite-plugin` because they need non-Go tools (`shellcheck` and `goreleaser`).
+- Self-hosted agents need `curl` and `tar` available so either plugin can install `mise`.
 - Per-step cache is enabled for `hosted` and `cleanroom-mac` steps.
 - Avoid global pipeline `cache:` blocks if self-hosted queues are present.
 

--- a/scripts/buildkite_pipeline_test.go
+++ b/scripts/buildkite_pipeline_test.go
@@ -8,8 +8,9 @@ import (
 )
 
 const miseBuildkitePluginRef = "github.com/lox/mise-buildkite-plugin#a172963b3d34e98601e2a65c7dd08211fb49b7f0"
+const setupGoBuildkitePluginRef = "github.com/buildkite-plugins/setup-go-buildkite-plugin#daa7af945245588f85b76ba7fe0a9af3d87dbf91"
 
-func TestBuildkitePipelineUsesMisePlugin(t *testing.T) {
+func TestBuildkitePipelineUsesSetupGoForGoSteps(t *testing.T) {
 	t.Parallel()
 
 	content, err := os.ReadFile("../.buildkite/pipeline.yml")
@@ -18,15 +19,52 @@ func TestBuildkitePipelineUsesMisePlugin(t *testing.T) {
 	}
 
 	pipeline := string(content)
-	if !strings.Contains(pipeline, miseBuildkitePluginRef) {
-		t.Fatalf("expected .buildkite/pipeline.yml to use %q", miseBuildkitePluginRef)
-	}
-	if strings.Contains(pipeline, "add_shims_to_path: false") {
-		t.Fatalf("expected .buildkite/pipeline.yml to keep mise shims enabled in CI")
-	}
 	if strings.Contains(pipeline, "command: mise run") {
 		t.Fatalf("expected .buildkite/pipeline.yml to avoid direct `mise run` step commands")
 	}
+
+	for _, snippet := range []string{
+		`- label: ":shell: Shellcheck"
+    plugins:
+      - ` + miseBuildkitePluginRef + `:
+    command: shellcheck`,
+		`- label: ":test_tube: Test (Linux)"
+    plugins:
+      - ` + setupGoBuildkitePluginRef + `:
+    command: go test ./...`,
+		`- label: ":test_tube: Test (macOS)"
+    plugins:
+      - ` + setupGoBuildkitePluginRef + `:
+    command: go test ./...`,
+		`- label: ":apple: E2E (darwin-vz)"
+    plugins:
+      - ` + setupGoBuildkitePluginRef + `:
+    command: scripts/ci-darwin-vz-e2e.sh`,
+		`- label: ":apple: E2E (darwin-vz filehandle)"
+    plugins:
+      - ` + setupGoBuildkitePluginRef + `:
+    command: scripts/ci-darwin-vz-filehandle-e2e.sh`,
+		`- label: ":package: macOS release pkg"
+    key: macos-release-pkg
+    if: build.tag != null || build.branch == "codex/macos-notarized-release-pkg"
+    plugins:
+      - ` + setupGoBuildkitePluginRef + `:
+    command: scripts/ci-macos-release-pkg.sh`,
+		`- label: ":fire: E2E (Firecracker)"
+    plugins:
+      - ` + setupGoBuildkitePluginRef + `:
+    command: scripts/ci-cleanroom-e2e.sh`,
+		`- label: ":rocket: Publish release"
+    if: build.tag != null
+    plugins:
+      - ` + miseBuildkitePluginRef + `:
+    command: scripts/ci-buildkite-release.sh`,
+	} {
+		if !strings.Contains(pipeline, snippet) {
+			t.Fatalf("expected .buildkite/pipeline.yml to contain step snippet:\n%s", snippet)
+		}
+	}
+
 	if !strings.Contains(pipeline, "command: scripts/ci-darwin-vz-filehandle-e2e.sh") {
 		t.Fatalf("expected .buildkite/pipeline.yml to include the darwin-vz filehandle e2e step")
 	}


### PR DESCRIPTION
## Summary
- switch Go-oriented Buildkite steps from the pinned `mise` plugin to `buildkite-plugins/setup-go-buildkite-plugin`
- keep the Shellcheck and release publish steps on the `mise` plugin because they still require non-Go tools
- update the pipeline test and CI docs to assert and document the mixed plugin setup

## Why
The `setup-go` plugin is a better fit for steps that only need the Go toolchain and Go caches. The Shellcheck and release steps still need `shellcheck` and `goreleaser`, so they remain on `mise` until those tools are provisioned another way.

## Validation
- `MISE_TRUSTED_CONFIG_PATHS="$PWD" mise exec -- go test ./scripts/...`
