### PR TITLE
docs: Align content-cache docs with gateway implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ Agent sandboxing tools are [proliferating fast](docs/research.md). Most focus on
 
 **Self-hosted.** Runs on your infrastructure. Your code and data never leave your machines.
 
-**Credentials stay on the host.** A [host-side gateway](docs/gateway.md) proxies git clones and package fetches, injecting credentials on the upstream leg. Tokens never enter the sandbox.
+**Credentials stay on the host.** A [host-side gateway](docs/gateway.md) rewrites git traffic through Cleanroom-owned routes and keeps upstream credentials on the host side of the boundary. The same gateway now embeds `content-cache` for cache-backed git and OCI handling.
 
 **Standard OCI images.** Use any OCI image from any registry as your sandbox base. Digest-pinned in policy for reproducibility. No custom VM image format or vendor-specific base images. Same image works across backends.
 
 **Docker inside the sandbox.** Enable a guest Docker daemon with a single policy flag (`services.docker.required: true`). Build and run containers inside the microVM.
 
-**Coming soon:** package registry proxy with lockfile enforcement, Docker pull caching, content caching for hermetic offline builds, and structured audit logging. See the [spec](docs/spec.md) for the full roadmap.
+**Coming soon:** guest-side package-manager rewrites with lockfile enforcement, broader Docker pull caching, hermetic offline build flows, and richer audit surfaces. See the [spec](docs/spec.md) for the full roadmap.
 
 ## Install
 

--- a/docs/backend/firecracker.md
+++ b/docs/backend/firecracker.md
@@ -13,7 +13,8 @@ Firecracker is purpose-built for secure multi-tenant workloads with a minimal de
 - Linux-only local backend using Firecracker + KVM.
 - Enforce `CompiledPolicy` only (no runtime repo policy reload).
 - Deny-by-default egress with explicit allow rules.
-- Route package and git egress through `content-cache`.
+- Route git egress through the shared host gateway, with embedded
+  `content-cache` for Git and OCI transport caching.
 - Keep secret values out of guest env and policy files.
 
 ## Network Model
@@ -38,7 +39,10 @@ This is materially different from the current `darwin-vz` backend, which uses he
 
 1. Slice A: minimal Firecracker runner -- create backend adapter package and run lifecycle. Boot VM, run command over vsock, collect exit code/stdout/stderr.
 2. Slice B: deterministic networking -- add TAP/subnet allocator + nftables setup/teardown. Enforce default deny and host/port allowlist (no registries yet).
-3. Slice C: registry and git mediation -- start/attach `content-cache`. Rewrite package/git traffic through cache endpoint and emit deny reasons for bypass attempts.
+3. Slice C: registry and git mediation -- start/attach embedded
+   `content-cache`. Rewrite git traffic through cache-backed gateway routes,
+   serve OCI registry pulls through the same cache layer, and emit deny reasons
+   for bypass attempts. Broader package-manager rewrites remain follow-up work.
 4. Slice D: secret proxy -- add tokenizer-style host-scoped injection path. Enforce `secret_scope_violation` and keep secret values out of guest-visible env/args.
 5. Slice E: conformance and hardening -- implement backend capability handshake. Add conformance suite from spec.md section 14 before backend marked supported.
 

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -25,8 +25,9 @@ Inside sandboxes, the shared gateway is exposed at
 
 On `firecracker`, the gateway identifies the sandbox from the guest source IP.
 On `darwin-vz`, guests share NAT, so requests use the
-`X-Cleanroom-Scope-Token` header and the gateway only trusts that header from
-configured gateway-source prefixes.
+`X-Cleanroom-Scope-Token` header. The gateway normally restricts that header to
+configured gateway-source prefixes, but falls back to allowing it from any
+source if gateway-host resolution is unavailable.
 
 ## Git proxy
 

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -1,23 +1,32 @@
 # Host gateway
 
-The Cleanroom server runs a host gateway that provides mediated access to
-external services for sandboxes. The gateway handles git clones, package
-registry requests, secret injection, and metadata. Credentials are held
-host-side and injected on the upstream leg, so tokens never enter the sandbox.
+The Cleanroom server runs a shared host gateway that mediates sandbox access to
+selected external services. The current implementation embeds
+`github.com/buildkite/content-cache` behind the gateway for cache-backed Git
+smart-HTTP and OCI registry routes, while keeping sandbox identity, policy
+enforcement, and credential resolution in Cleanroom's own `internal/gateway`
+layer.
 
 Currently supported on the `firecracker` and `darwin-vz` backends.
 
 Inside sandboxes, the shared gateway is exposed at
 `http://gateway.cleanroom.internal:8170` by default.
 
-## Endpoints
+## Route status
 
-| Path | Purpose |
-|------|---------|
-| `/git/` | Git smart-HTTP proxy with policy-scoped URL rewrites |
-| `/registry/` | Package registry proxy |
-| `/secrets/` | Secret injection endpoint |
-| `/meta/` | Sandbox metadata |
+| Path | Status | Purpose |
+|------|--------|---------|
+| `/git/` | Implemented | Cache-backed Git smart-HTTP route. `.git` remotes use embedded `content-cache`; non-cacheable paths fall back to Cleanroom's mirror-backed proxy. |
+| `/registry/` | Implemented | Cache-backed OCI Distribution route for allowlisted registries. |
+| `/secrets/` | Reserved | Not implemented yet. |
+| `/meta/` | Reserved | Not implemented yet. |
+
+## Sandbox identity
+
+On `firecracker`, the gateway identifies the sandbox from the guest source IP.
+On `darwin-vz`, guests share NAT, so requests use the
+`X-Cleanroom-Scope-Token` header and the gateway only trusts that header from
+configured gateway-source prefixes.
 
 ## Git proxy
 
@@ -30,8 +39,10 @@ cleanroom exec -- git clone https://github.com/org/repo.git
 
 The gateway resolves the target host from the request path, validates it against
 the sandbox's compiled policy, and proxies the git smart-HTTP protocol upstream.
-Guest-side git rewrites target `gateway.cleanroom.internal` rather than backend-specific
-IP addresses.
+For `.git` smart-HTTP routes, the request is handed to embedded
+`content-cache`; for non-`.git` paths, the gateway falls back to Cleanroom's
+mirror-backed proxy. Guest-side git rewrites target
+`gateway.cleanroom.internal` rather than backend-specific IP addresses.
 
 On `darwin-vz`, sandbox identity is carried with the
 `X-Cleanroom-Scope-Token` request header because guests use shared NAT rather
@@ -49,6 +60,26 @@ Denied host example (not in `sandbox.network.allow`):
 cleanroom exec -- git ls-remote https://gitlab.com/gitlab-org/gitlab.git HEAD
 ```
 
+## Registry route
+
+`/registry/` is backed by `content-cache`'s OCI handlers rather than a generic
+HTTP forward proxy. Cleanroom resolves the registry prefix from the request
+path, maps it to an upstream registry, checks the mapped host and port against
+the sandbox policy, and only then allows the upstream fetch.
+
+Current scope:
+
+- OCI pull-style `GET` and `HEAD` requests
+- built-in prefix mapping for Docker Hub (`docker.io` ->
+  `https://registry-1.docker.io`)
+- additional registry-prefix mappings configured inside the gateway
+
+Not wired yet:
+
+- guest-wide package-manager rewrites to `/registry/`
+- lockfile enforcement
+- non-OCI package-manager protocol handling
+
 ## Credentials
 
 Host-side credentials are provided via environment variables:
@@ -59,7 +90,8 @@ Host-side credentials are provided via environment variables:
 | `CLEANROOM_GITLAB_TOKEN` | GitLab authentication |
 
 Credentials are injected into upstream requests by the gateway. They are never
-exposed to the guest environment.
+exposed to the guest environment. The same host-side credential provider chain
+is used by the embedded `content-cache` upstream clients.
 
 ## Configuration
 

--- a/docs/plans/host-gateway.md
+++ b/docs/plans/host-gateway.md
@@ -228,24 +228,34 @@ type CredentialProvider interface {
 
 ---
 
-### Slice 5: Registry proxy (stub)
+### Slice 5: Registry route
 
-**`internal/gateway/registry.go`** — Handler for `/registry/...`
+**`internal/gateway/oci_cached.go`** — Handler for `/registry/...`
 
-Initial implementation is a passthrough HTTP proxy with policy enforcement:
+The original passthrough-proxy sketch is now superseded by the merged
+`content-cache` integration. The current implementation mounts `/registry/` on
+top of cache-backed OCI handlers and wraps them with Cleanroom policy
+enforcement.
 
-1. Extract upstream registry host from request path.
-2. Validate against sandbox's compiled policy registry allowlist.
-3. Proxy request upstream, injecting credentials if configured.
-4. Return `registry_not_allowed` on deny.
+Current behavior:
 
-This is where content-cache integration can plug in later — the gateway either handles proxying directly or forwards to a content-cache instance for caching and lockfile enforcement.
+1. Extract a registry prefix from the request path.
+2. Resolve that prefix to an upstream registry URL.
+3. Validate the mapped policy host and port against the sandbox policy.
+4. Serve OCI pull traffic through embedded `content-cache`.
+5. Return `host_not_allowed` or `unknown_registry_prefix` on deny.
+
+Follow-up work remains for:
+
+1. guest-side package-manager rewrites through `/registry/`
+2. lockfile enforcement
+3. broader non-OCI package-manager protocol support
 
 **Tests:**
 
 - Policy enforcement: allowed registry host proxied, disallowed host denied with correct reason code.
 
-**Definition of done:** Package manager requests routed through `/registry/` are policy-enforced and proxied upstream.
+**Definition of done:** OCI registry requests routed through `/registry/` are policy-enforced and cache-backed. Broader package-manager proxying is a later slice.
 
 ---
 

--- a/docs/plans/layered-caching.md
+++ b/docs/plans/layered-caching.md
@@ -313,8 +313,8 @@ These reduce upstream fetch cost but are not runnable environments:
 - gateway OCI/blob cache
 
 The existing git mirror is already in-tree. The gateway Git/OCI content-cache
-work proposed in PR #138 fits here as a transport-cache plane, not as a system
-stage cache.
+layer now lives under `internal/gateway` and fits here as a transport-cache
+plane, not as a system stage cache.
 
 ### C. Runtime materialization
 
@@ -473,7 +473,7 @@ Output:
 Notes:
 
 - the existing git mirror is the current transport cache
-- the gateway git caching work proposed in PR #138 belongs in this plane
+- the merged gateway git/content-cache layer belongs in this plane
 - freshness must still block until the requested commit exists
 
 ### Registry/package transport cache
@@ -504,7 +504,7 @@ Output:
 Notes:
 
 - URL alone is not sufficient
-- the gateway OCI/content-cache work proposed in PR #138 belongs in this plane
+- the merged gateway OCI/content-cache transport layer belongs in this plane
 - if a lockfile does not include strong integrity metadata, that ecosystem does
   not qualify for poisoning-resistant warm reuse in strict mode
 
@@ -704,8 +704,8 @@ This plan composes with the existing documents rather than replacing them.
 - `firecracker-privilege-runtime.md`
   defines the Linux host-runtime direction needed for clone-capable snapshot
   storage and reduced root surface
-- PR #138
-  proposes the gateway Git/OCI content-cache transport plane that should remain
+- `internal/gateway/contentcache.go`
+  implements the gateway Git/OCI transport-cache plane that should remain
   separate from system stage caches
 
 ## Code Touchpoints and Planned Additions

--- a/docs/research.md
+++ b/docs/research.md
@@ -170,15 +170,16 @@ Implication for Cleanroom architecture:
 
 ### content-cache
 
-[content-cache](https://github.com/wolfeidau/content-cache) is relevant prior art
-for host-side mediation of package and git traffic. The important takeaway for
-Cleanroom is architectural, not dependency choice: keep mediation, caching, and
-credential handling on the host so the sandbox never talks directly to upstream
-with its own secrets.
+`content-cache` is now part of Cleanroom's implementation, not just prior art.
+Cleanroom embeds `github.com/buildkite/content-cache` inside the host gateway
+for Git smart-HTTP and OCI registry caching, while keeping sandbox identity,
+policy enforcement, credential resolution, and route shaping in Cleanroom's own
+`internal/gateway` layer.
 
-Cleanroom is not currently adopting `content-cache` as a direct dependency.
-The active direction is to grow the in-tree Cleanroom gateway so it can enforce
-policy, inject host-side credentials, and eventually cache upstream content.
+The architectural takeaway remains the same: keep mediation, caching, and
+credential handling on the host so the sandbox never talks directly to upstream
+with its own secrets. Cleanroom is not exposing `content-cache` as a separate
+user-facing surface; it is using it as an internal transport-cache component.
 
 ### git-proxy-cache
 
@@ -216,8 +217,9 @@ Key properties of this model:
 
 1. Use Firecracker as the local sandbox backend (inspired by Matchlock patterns). See [backend/firecracker.md](backend/firecracker.md) for implementation details.
 2. Use an in-tree host gateway as the package/registry and git mediation layer,
-   borrowing ideas from tools like `content-cache` and `git-proxy-cache` rather
-   than depending on them directly.
+   embedding `content-cache` for Git/OCI transport caching while keeping the
+   user-facing control surface, policy model, and credential handling in
+   Cleanroom.
 3. Use a tokenizer-like secret-injection model with host-scoped policy and no
    plaintext propagation.
 4. Keep CLI first: `cleanroom exec` as primary entrypoint and command pattern.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -307,7 +307,7 @@ All runtime launch behavior is initiated by control-plane API calls (for example
 
 ### 6.2 Host gateway
 
-Cleanroom runs a single shared host gateway process that provides mediated access to external services (git, package registries, secrets, metadata) for all sandboxes on the host. Sandbox identity is derived from the network transport layer, not bearer tokens.
+Cleanroom runs a single shared host gateway process that provides mediated access to external services for sandboxes on the host. The current implementation serves Git and OCI registry routes today, while keeping secret and metadata routes reserved for follow-up work. Sandbox identity is derived from the network transport layer, not bearer tokens.
 
 #### 6.2.1 Transport and sandbox identity
 
@@ -343,16 +343,20 @@ These rules are installed during sandbox network setup and torn down during clea
 - Enforcement:
   - deny by default except policy-allowed git hosts.
   - credential injection scoped by upstream host prefix.
-  - gateway may serve as a transparent cache with offline fallback for warm entries (future extension).
+  - `.git` smart-HTTP routes are served through embedded `content-cache`, with Cleanroom policy enforcement wrapped around the cache handler.
+  - gateway may later add offline fallback for warm entries.
 
 #### 6.2.4 Package registry proxy
 
-- All package manager egress is redirected through the host gateway's registry endpoint.
-- The gateway applies the sandbox's registry allowlist before forwarding upstream.
-- Unsupported registry requests are denied with explicit audit reason (`registry_not_allowed`).
-- Cache layer (future extension):
-  - positive cache (hit/miss) for registry metadata and tarballs.
-  - optional metadata signing/validation hooks.
+- The gateway exposes a `/registry/` route backed by embedded `content-cache` OCI handlers.
+- The gateway resolves a registry prefix from the request path, maps it to an upstream registry URL, and applies the sandbox allowlist against the mapped policy host and port before forwarding upstream.
+- Current route scope is OCI pull-style `GET` and `HEAD` traffic.
+- Unsupported registry requests are denied with explicit audit reason (`registry_not_allowed`) or route-specific validation errors.
+- Future work:
+  - guest-side package-manager rewrites through `/registry/`
+  - lockfile enforcement
+  - broader non-OCI package-manager protocol support
+  - optional metadata signing/validation hooks
 
 #### 6.2.5 Secret injection
 
@@ -547,7 +551,7 @@ Minimum v1 codes:
 - Spec schema + validator (`cleanroom.yaml` parser with `.buildkite/cleanroom.yaml` fallback)
 - Core policy compiler to normalized allowlist + registry map
 - Local backend (Firecracker) implementation
-- content-cache wrapper integration for npm and one additional manager
+- embed `content-cache` behind gateway Git and OCI routes
 - `cleanroom serve` foreground server plus `cleanroom daemon` lifecycle management and CLI client command set (`exec`, `console`, `sandbox inspect`, `execution inspect`)
 - `cleanroom exec` RPC wrapper flow
 
@@ -565,7 +569,7 @@ Minimum v1 codes:
 ## 13) Acceptance criteria (v1)
 1. A repo policy can be checked in and parsed by default.
 2. Running `cleanroom exec [--] <command>` creates a sandbox where unlisted hosts are unreachable.
-3. Package fetches work only through content-cache and allowed registries.
+3. Gateway-mediated Git and OCI registry fetches work only through cache-backed routes and allowed destinations.
 4. Unsupported destination attempts are denied and logged.
 5. Lockfile-enabled registries block undeclared package artifacts by default.
 6. Git clones are rewritten to cached smart-HTTP endpoints and private clone auth is provided without plaintext exposure.


### PR DESCRIPTION
## Summary
- update the research and architecture docs to reflect that Cleanroom now embeds `github.com/buildkite/content-cache` behind the host gateway
- document the current gateway surface more precisely, including cache-backed `/git/` and `/registry/` routes and the still-reserved `/secrets/` and `/meta/` routes
- clean up README and planning docs to remove stale references that described `content-cache` as future work

## Why
The merged gateway cache work changed the implementation, but several docs still described `content-cache` as prior art or future integration. Other docs implied broader package-manager support than is wired today. This PR brings the docs back in line with the actual code paths.

## Impact
Readers now get an accurate description of what is implemented today versus what is still planned, especially around gateway routing, OCI registry handling, and follow-up work like lockfile enforcement and guest-side package-manager rewrites.

## Validation
- reviewed the staged diff manually
- attempted to run `markdownlint`, but it is not installed in this environment
