### PR TITLE
refactor: Remove direct mise integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,12 +99,10 @@ cleanroom exec -e OPENAI_API_KEY -- codex app-server
 When `cleanroom.yaml` includes a repository bootstrap block, the top-level
 commands become repo-aware: Cleanroom resolves the current git remote and local
 `HEAD`, materializes that checkout in the sandbox, and starts commands in the
-configured guest path. If the checked-out repository contains `mise.toml`,
-`.mise.toml`, `.tool-versions`, or `.mise/config.toml`, Cleanroom only runs the
-command through `mise exec -- ...` when `sandbox.mise.install: true` is set in
-`cleanroom.yaml` and `sandbox.mise.enabled` is not `false`. Use
-`cleanroom exec --no-mise -- ...` or `cleanroom console --no-mise` to skip
-that wrapper for a single execution.
+configured guest path. Cleanroom no longer auto-detects or auto-wraps commands
+for `mise`; if you want `mise`, run it explicitly in the command you execute or
+in `sandbox.dependencies.command` so it can participate in dependency-stage
+caching.
 
 Pre-create a long-running sandbox without running a command:
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -322,12 +322,8 @@ Behavior contract:
    the current git remote and committed `HEAD`.
 5. For repo-aware top-level commands, materialize that checkout in the sandbox
    and default the guest working directory to `repository.path`.
-   - if the checkout contains `mise.toml`, `.mise.toml`, `.tool-versions`, or
-     `.mise/config.toml`, execute the workload through
-     `mise exec -- ...` only when `sandbox.mise.install: true` and
-     `sandbox.mise.enabled` is not `false`
-   - `cleanroom exec --no-mise` and `cleanroom console --no-mise` set
-     `ExecutionOptions.disable_mise` for that execution
+   - Cleanroom does not auto-detect or auto-wrap `mise`; call it explicitly in
+     `sandbox.dependencies.command` or the workload command when needed
 6. Create execution with explicit kind, env, and TTY options.
 7. Attach stdio according to command mode:
    - `cleanroom exec` defaults to attached stdin plus separate stdout/stderr

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -57,7 +57,7 @@ Deferred past MVP:
 - As a developer, I can run a command that executes my existing test commands inside a compliant sandbox.
 - As a security reviewer, I can see exactly which hosts and registries were allowed for each sandbox execution.
 - As an SRE, I can configure backend selection and runtime options independently of repository policy.
-- As a developer, I can run repository-defined toolchains (for example via `mise`) inside the sandbox with the same command patterns as local tooling.
+- As a developer, I can preinstall repository-defined toolchains (for example via `mise`) with an explicit dependency bootstrap command inside the sandbox.
 
 ## 5) Policy model
 ### 5.1 Repository config
@@ -74,14 +74,13 @@ project:
 
 sandbox:
   ttl_minutes: 60
-  mise:
-    enabled: true
-    install: true
-    config_files:
-      - mise.toml
-      - .mise.toml
-      - .tool-versions
-      - .mise/config.toml
+  dependencies:
+    command: [mise, exec, --, go, mod, download]
+    key:
+      files:
+        - .mise.toml
+        - go.mod
+        - go.sum
   network:
     default: deny
     allow:
@@ -160,11 +159,9 @@ Meaning:
 - `repository.remote` defaults to `origin`.
 - `repository.path` defaults to `/workspace` and must be an absolute guest path.
 - `repository.submodules` defaults to `false`.
-- `sandbox.mise.enabled` defaults to `true`; `false` disables Cleanroom-managed `mise` detection and install wrapping.
-- `sandbox.mise.install` defaults to `false`; `true` preserves repo-aware checkout and enables automatic `mise exec -- ...` wrapping.
 - `sandbox.dependencies.command` defaults to unset; when present, Cleanroom runs that command in the repository workdir during sandbox creation and makes the result eligible for dependency-stage caching.
 - `sandbox.dependencies.key.files` defaults to empty; when present, Cleanroom hashes those repository-relative files from the exact committed checkout and includes them in the dependency-stage cache key.
-- `sandbox.mise.config_files` defaults to `mise.toml`, `.mise.toml`, `.tool-versions`, and `.mise/config.toml`.
+- `sandbox.mise` has been removed. If you want to use `mise`, call it explicitly from `sandbox.dependencies.command` or the workload command itself.
 - Host matching supports:
   - exact host (`registry.npmjs.org`)
   - wildcard subdomains (`*.example.com`)
@@ -223,9 +220,8 @@ Meaning:
   - they resolve the local repository remote URL and committed `HEAD`
   - they materialize that checkout inside the sandbox before the command runs
   - they start commands in `repository.path`
-  - when the checkout contains `mise.toml`, `.mise.toml`, `.tool-versions`, or `.mise/config.toml`, they execute the command through `mise exec -- ...` only when `sandbox.mise.install: true` and `sandbox.mise.enabled` is not `false`
   - when `sandbox.dependencies.command` is set, sandbox creation runs that dependency bootstrap command after repository bootstrap and may publish a reusable dependency stage for later warm hits
-  - `cleanroom exec --no-mise` and `cleanroom console --no-mise` disable that automatic wrapping for a single execution
+  - Cleanroom does not auto-detect or auto-wrap `mise`; use explicit commands such as `mise exec -- ...` when needed
 - `cleanroom sandbox create` remains the generic low-level surface and does not
   infer repository state from the current working tree or read `cleanroom.yaml`.
 - Without `--from`, `cleanroom sandbox create` synthesizes a repo-agnostic
@@ -251,7 +247,6 @@ Meaning:
 - `--keep` preserves a newly created sandbox after execution completes.
 - Reuse an existing sandbox with `--in <id>`.
 - Create a new sandbox from a snapshot with `--from <snapshot-id>`.
-- `--no-mise` disables per-execution automatic `mise exec -- ...` wrapping even when policy-level `sandbox.mise.*` settings allow it.
 - Interactive executions must use `AttachExecution` bootstrap plus the dedicated QUIC interactive transport.
 - Non-interactive mode must use server-streaming semantics.
 - First interrupt signal should request execution cancel; second interrupt may detach client stream immediately.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -161,7 +161,6 @@ Meaning:
 - `repository.submodules` defaults to `false`.
 - `sandbox.dependencies.command` defaults to unset; when present, Cleanroom runs that command in the repository workdir during sandbox creation and makes the result eligible for dependency-stage caching.
 - `sandbox.dependencies.key.files` defaults to empty; when present, Cleanroom hashes those repository-relative files from the exact committed checkout and includes them in the dependency-stage cache key.
-- `sandbox.mise` has been removed. If you want to use `mise`, call it explicitly from `sandbox.dependencies.command` or the workload command itself.
 - Host matching supports:
   - exact host (`registry.npmjs.org`)
   - wildcard subdomains (`*.example.com`)

--- a/examples/buildkite-agent/README.md
+++ b/examples/buildkite-agent/README.md
@@ -1,8 +1,8 @@
 # Buildkite Agent Example
 
 Runs the [buildkite/agent](https://github.com/buildkite/agent) test suite
-inside a cleanroom sandbox with deny-by-default egress, mise toolchain
-bootstrap, Go module resolution, and dependency-stage warmup.
+inside a cleanroom sandbox with deny-by-default egress, explicit `mise`
+dependency bootstrap, Go module resolution, and dependency-stage warmup.
 
 ## Prerequisites
 
@@ -42,7 +42,8 @@ cleanroom exec \
 ## Network allow list
 
 The `cleanroom.yaml` policy allows egress to the minimum set of hosts
-needed for mise tool installation and Go module resolution:
+needed for the explicit `mise exec -- go mod download` dependency bootstrap and
+Go module resolution:
 
 | Host | Why |
 |---|---|
@@ -56,8 +57,8 @@ needed for mise tool installation and Go module resolution:
 ## Notes
 
 - First run is slow: git clone, mise tool install, and Go module download
-- The example policy sets `sandbox.dependencies.command: [go, mod, download]`
-  with `sandbox.dependencies.key.files: [go.mod, go.sum]`, so a successful
+- The example policy sets `sandbox.dependencies.command: [mise, exec, --, go, mod, download]`
+  and keys that stage on `.mise.toml`, `go.mod`, and `go.sum`, so a successful
   first run can publish a reusable dependency stage for later warm hits on the
   same exact commit and policy
 - `go test -p 1` avoids OOM kills on constrained guest memory

--- a/examples/buildkite-agent/cleanroom.yaml
+++ b/examples/buildkite-agent/cleanroom.yaml
@@ -4,12 +4,11 @@ repository:
 sandbox:
   image:
     ref: ghcr.io/buildkite/cleanroom-base/alpine@sha256:8eb2c1bc27af65d828ab6d93738a1adb1b62ef5b74417a273cedf3e7cec5f18b
-  mise:
-    install: true
   dependencies:
-    command: [go, mod, download]
+    command: [mise, exec, --, go, mod, download]
     key:
       files:
+        - .mise.toml
         - go.mod
         - go.sum
   network:

--- a/internal/cli/console.go
+++ b/internal/cli/console.go
@@ -32,7 +32,6 @@ type ConsoleCommand struct {
 	PrintSandboxID bool     `name:"print-sandbox-id" help:"Print resolved sandbox_id=<id> to stderr before attaching"`
 
 	LaunchSeconds int64 `help:"VM boot/guest-agent readiness timeout in seconds"`
-	NoMise        bool  `name:"no-mise" help:"Disable automatic mise tool installation"`
 
 	Command []string `arg:"" passthrough:"partial" optional:"" help:"Command to run in the console (default: sh)"`
 }
@@ -168,7 +167,6 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) (runErr error) {
 		Options: &cleanroomv1.ExecutionOptions{
 			LaunchSeconds: c.LaunchSeconds,
 			Tty:           true,
-			DisableMise:   c.NoMise,
 		},
 	})
 	if err != nil {

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -26,7 +26,6 @@ type ExecCommand struct {
 	PrintSandboxID bool     `name:"print-sandbox-id" help:"Print resolved sandbox_id=<id> to stderr before streaming output"`
 
 	LaunchSeconds int64 `help:"VM boot/guest-agent readiness timeout in seconds"`
-	NoMise        bool  `name:"no-mise" help:"Disable automatic mise tool installation"`
 
 	Command []string `arg:"" passthrough:"partial" required:"" help:"Command to execute"`
 }
@@ -158,7 +157,6 @@ func (e *ExecCommand) Run(ctx *runtimeContext) (runErr error) {
 		RepositoryCheckout: repositoryCheckoutProto(repository),
 		Options: &cleanroomv1.ExecutionOptions{
 			LaunchSeconds: e.LaunchSeconds,
-			DisableMise:   e.NoMise,
 		},
 	})
 	if err != nil {

--- a/internal/cli/repository_test.go
+++ b/internal/cli/repository_test.go
@@ -961,7 +961,7 @@ func TestWrapCommandWithRepositoryBootstrapStripsCommandSeparator(t *testing.T) 
 		RemoteURL:      "https://github.com/buildkite/cleanroom.git",
 		CommitSHA:      "0123456789abcdef0123456789abcdef01234567",
 		DestinationDir: "/workspace",
-	}, true)
+	})
 	joined := strings.Join(command, " ")
 	if strings.Contains(joined, `'--'`) {
 		t.Fatalf("expected wrapped command to strip passthrough separator, got %q", joined)
@@ -976,7 +976,7 @@ func TestWrapCommandWithRepositoryBootstrapDoesNotEmbedAuthHeaders(t *testing.T)
 		RemoteURL:      "https://github.com/buildkite/cleanroom.git",
 		CommitSHA:      "0123456789abcdef0123456789abcdef01234567",
 		DestinationDir: "/workspace",
-	}, true)
+	})
 	joined := strings.Join(command, " ")
 	if strings.Contains(joined, ".extraHeader") {
 		t.Fatalf("expected bootstrap command to avoid git extra headers, got %q", joined)

--- a/internal/controlservice/dependency_stage.go
+++ b/internal/controlservice/dependency_stage.go
@@ -41,8 +41,8 @@ func dependencyStagePlanForRepository(compiled *policy.CompiledPolicy, repositor
 		return dependencyStagePlan{}, false
 	}
 
-	bootstrapCommand := repositorycheckout.WrapCommandInWorkdir(compiled.Dependencies.Command, repository, compiled.MiseInstall)
-	bootstrapRecipeDigest := repositorycheckout.WorkdirRecipeDigest(compiled.Dependencies.Command, repository, compiled.MiseInstall)
+	bootstrapCommand := repositorycheckout.WrapCommandInWorkdir(compiled.Dependencies.Command, repository)
+	bootstrapRecipeDigest := repositorycheckout.WorkdirRecipeDigest(compiled.Dependencies.Command, repository)
 	if len(bootstrapCommand) == 0 || strings.TrimSpace(bootstrapRecipeDigest) == "" {
 		return dependencyStagePlan{}, false
 	}

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -144,7 +144,6 @@ type cacheMetadataStore interface {
 
 type executionOptions struct {
 	LaunchSeconds int64
-	DisableMise   bool
 }
 
 type executionSnapshot struct {
@@ -899,7 +898,6 @@ func (s *Service) CreateExecution(ctx context.Context, req *cleanroomv1.CreateEx
 	if opts := req.GetOptions(); opts != nil {
 		execOpts = executionOptions{
 			LaunchSeconds: opts.GetLaunchSeconds(),
-			DisableMise:   opts.GetDisableMise(),
 		}
 		tty = opts.GetTty()
 	}
@@ -960,14 +958,12 @@ func (s *Service) CreateExecution(ctx context.Context, req *cleanroomv1.CreateEx
 		if err := validateRepositoryCheckoutForPolicy(sandboxPolicy, repository); err != nil {
 			return nil, err
 		}
-		autoMiseInstall := sandboxPolicy != nil && sandboxPolicy.MiseInstall && !execOpts.DisableMise
 		if err := s.preparePersistentSandboxRepository(ctx, sandboxID, sandboxPolicy, firecrackerCfg, adapter, repository); err != nil {
 			return nil, err
 		}
-		command = repositorycheckout.WrapCommandInWorkdir(command, repository, autoMiseInstall)
+		command = repositorycheckout.WrapCommandInWorkdir(command, repository)
 	} else if sandboxRepository != nil {
-		autoMiseInstall := sandboxPolicy != nil && sandboxPolicy.MiseInstall && !execOpts.DisableMise
-		command = repositorycheckout.WrapCommandInWorkdir(command, sandboxRepository, autoMiseInstall)
+		command = repositorycheckout.WrapCommandInWorkdir(command, sandboxRepository)
 	}
 
 	s.mu.Lock()

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -236,9 +236,8 @@ func testRepositoryPolicy() *cleanroomv1.Policy {
 
 func testRepositoryDependencyPolicy() *cleanroomv1.Policy {
 	policyProto := testRepositoryPolicy()
-	policyProto.MiseInstall = boolPtr(true)
 	policyProto.Dependencies = &cleanroomv1.PolicyDependencies{
-		Command: []string{"go", "mod", "download"},
+		Command: []string{"mise", "exec", "--", "go", "mod", "download"},
 		Key: &cleanroomv1.PolicyDependencyKey{
 			Files: []string{"go.mod", "go.sum"},
 		},
@@ -2046,8 +2045,8 @@ func TestCreateSandboxPublishesDependencyStageCacheForConfiguredDependencies(t *
 		t.Fatalf("expected two bootstrap commands, got %d want %d", got, want)
 	}
 	dependencyBootstrap := strings.Join(runCommands[1], " ")
-	if !repositoryWrappedCommandContains(dependencyBootstrap, `exec mise exec -- 'go' 'mod' 'download'`) {
-		t.Fatalf("expected configured dependency bootstrap to run go mod download via mise exec, got %q", dependencyBootstrap)
+	if !repositoryWrappedCommandContains(dependencyBootstrap, `exec 'mise' 'exec' '--' 'go' 'mod' 'download'`) {
+		t.Fatalf("expected configured dependency bootstrap to preserve explicit mise command, got %q", dependencyBootstrap)
 	}
 }
 
@@ -2188,8 +2187,8 @@ func TestCreateSandboxBootstrapsDependenciesAfterWorkspaceStageRestoreWithoutDep
 		t.Fatalf("expected one dependency bootstrap command, got %d want %d", got, want)
 	}
 	dependencyBootstrap := strings.Join(runCommands[0], " ")
-	if !repositoryWrappedCommandContains(dependencyBootstrap, `exec mise exec -- 'go' 'mod' 'download'`) {
-		t.Fatalf("expected dependency bootstrap to run go mod download via mise exec, got %q", dependencyBootstrap)
+	if !repositoryWrappedCommandContains(dependencyBootstrap, `exec 'mise' 'exec' '--' 'go' 'mod' 'download'`) {
+		t.Fatalf("expected dependency bootstrap to preserve explicit mise command, got %q", dependencyBootstrap)
 	}
 }
 
@@ -2471,257 +2470,6 @@ func TestCreateExecutionSkipsBootstrapForMatchingPersistentRepository(t *testing
 	}
 }
 
-func TestCreateExecutionSkipsMiseBootstrapWhenPolicyDisablesInstall(t *testing.T) {
-	adapter := &stubAdapter{}
-	mirrors := &stubRepositoryMirrorStore{}
-	svc := newTestService(adapter)
-	svc.RepositoryMirrors = mirrors
-
-	var (
-		mu       sync.Mutex
-		commands [][]string
-	)
-	runCalled := make(chan struct{}, 4)
-	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
-		mu.Lock()
-		commands = append(commands, append([]string(nil), req.Command...))
-		mu.Unlock()
-		select {
-		case runCalled <- struct{}{}:
-		default:
-		}
-		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
-	}
-
-	policyProto := testRepositoryPolicy()
-	policyProto.MiseInstall = boolPtr(false)
-	createSandboxResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
-		Policy:             policyProto,
-		RepositoryCheckout: testRepositoryCheckoutProto(),
-	})
-	if err != nil {
-		t.Fatalf("CreateSandbox returned error: %v", err)
-	}
-	sandboxID := createSandboxResp.GetSandbox().GetSandboxId()
-	select {
-	case <-runCalled:
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for sandbox bootstrap")
-	}
-
-	_, err = svc.CreateExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
-		SandboxId:          sandboxID,
-		Command:            []string{"sh", "-lc", "pwd"},
-		RepositoryCheckout: testRepositoryCheckoutProto(),
-	})
-	if err != nil {
-		t.Fatalf("CreateExecution returned error: %v", err)
-	}
-	select {
-	case <-runCalled:
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for execution")
-	}
-
-	mu.Lock()
-	defer mu.Unlock()
-	if got, want := len(commands), 2; got != want {
-		t.Fatalf("expected create bootstrap + execution, got %d command(s)", got)
-	}
-	joined := strings.Join(commands[1], " ")
-	if strings.Contains(joined, "mise exec --") {
-		t.Fatalf("expected policy-disabled execution to skip mise exec wrapper, got %q", joined)
-	}
-}
-
-func TestCreateExecutionSkipsMiseBootstrapByDefault(t *testing.T) {
-	adapter := &stubAdapter{}
-	mirrors := &stubRepositoryMirrorStore{}
-	svc := newTestService(adapter)
-	svc.RepositoryMirrors = mirrors
-
-	var (
-		mu       sync.Mutex
-		commands [][]string
-	)
-	runCalled := make(chan struct{}, 4)
-	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
-		mu.Lock()
-		commands = append(commands, append([]string(nil), req.Command...))
-		mu.Unlock()
-		select {
-		case runCalled <- struct{}{}:
-		default:
-		}
-		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
-	}
-
-	createSandboxResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
-		Policy:             testRepositoryPolicy(),
-		RepositoryCheckout: testRepositoryCheckoutProto(),
-	})
-	if err != nil {
-		t.Fatalf("CreateSandbox returned error: %v", err)
-	}
-	sandboxID := createSandboxResp.GetSandbox().GetSandboxId()
-	select {
-	case <-runCalled:
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for sandbox bootstrap")
-	}
-
-	_, err = svc.CreateExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
-		SandboxId:          sandboxID,
-		Command:            []string{"sh", "-lc", "pwd"},
-		RepositoryCheckout: testRepositoryCheckoutProto(),
-	})
-	if err != nil {
-		t.Fatalf("CreateExecution returned error: %v", err)
-	}
-	select {
-	case <-runCalled:
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for execution")
-	}
-
-	mu.Lock()
-	defer mu.Unlock()
-	if got, want := len(commands), 2; got != want {
-		t.Fatalf("expected create bootstrap + execution, got %d command(s)", got)
-	}
-	joined := strings.Join(commands[1], " ")
-	if strings.Contains(joined, "mise exec --") {
-		t.Fatalf("expected default execution to skip mise exec wrapper, got %q", joined)
-	}
-}
-
-func TestCreateExecutionWrapsInMiseWhenPolicyEnablesInstall(t *testing.T) {
-	adapter := &stubAdapter{}
-	mirrors := &stubRepositoryMirrorStore{}
-	svc := newTestService(adapter)
-	svc.RepositoryMirrors = mirrors
-
-	var (
-		mu       sync.Mutex
-		commands [][]string
-	)
-	runCalled := make(chan struct{}, 4)
-	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
-		mu.Lock()
-		commands = append(commands, append([]string(nil), req.Command...))
-		mu.Unlock()
-		select {
-		case runCalled <- struct{}{}:
-		default:
-		}
-		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
-	}
-
-	policyProto := testRepositoryPolicy()
-	policyProto.MiseInstall = boolPtr(true)
-	createSandboxResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
-		Policy:             policyProto,
-		RepositoryCheckout: testRepositoryCheckoutProto(),
-	})
-	if err != nil {
-		t.Fatalf("CreateSandbox returned error: %v", err)
-	}
-	sandboxID := createSandboxResp.GetSandbox().GetSandboxId()
-	select {
-	case <-runCalled:
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for sandbox bootstrap")
-	}
-
-	_, err = svc.CreateExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
-		SandboxId:          sandboxID,
-		Command:            []string{"sh", "-lc", "pwd"},
-		RepositoryCheckout: testRepositoryCheckoutProto(),
-	})
-	if err != nil {
-		t.Fatalf("CreateExecution returned error: %v", err)
-	}
-	select {
-	case <-runCalled:
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for execution")
-	}
-
-	mu.Lock()
-	defer mu.Unlock()
-	if got, want := len(commands), 2; got != want {
-		t.Fatalf("expected create bootstrap + execution, got %d command(s)", got)
-	}
-	joined := strings.Join(commands[1], " ")
-	if !strings.Contains(joined, "mise exec --") {
-		t.Fatalf("expected policy-enabled execution to wrap with mise exec, got %q", joined)
-	}
-}
-
-func TestCreateExecutionSkipsMiseWhenExecutionOptionDisablesMise(t *testing.T) {
-	adapter := &stubAdapter{}
-	mirrors := &stubRepositoryMirrorStore{}
-	svc := newTestService(adapter)
-	svc.RepositoryMirrors = mirrors
-
-	var (
-		mu       sync.Mutex
-		commands [][]string
-	)
-	runCalled := make(chan struct{}, 4)
-	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
-		mu.Lock()
-		commands = append(commands, append([]string(nil), req.Command...))
-		mu.Unlock()
-		select {
-		case runCalled <- struct{}{}:
-		default:
-		}
-		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
-	}
-
-	createSandboxResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
-		Policy:             testRepositoryPolicy(),
-		RepositoryCheckout: testRepositoryCheckoutProto(),
-	})
-	if err != nil {
-		t.Fatalf("CreateSandbox returned error: %v", err)
-	}
-	sandboxID := createSandboxResp.GetSandbox().GetSandboxId()
-	select {
-	case <-runCalled:
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for sandbox bootstrap")
-	}
-
-	_, err = svc.CreateExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
-		SandboxId:          sandboxID,
-		Command:            []string{"sh", "-lc", "pwd"},
-		RepositoryCheckout: testRepositoryCheckoutProto(),
-		Options: &cleanroomv1.ExecutionOptions{
-			DisableMise: true,
-		},
-	})
-	if err != nil {
-		t.Fatalf("CreateExecution returned error: %v", err)
-	}
-	select {
-	case <-runCalled:
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for execution")
-	}
-
-	mu.Lock()
-	defer mu.Unlock()
-	if got, want := len(commands), 2; got != want {
-		t.Fatalf("expected create bootstrap + execution, got %d command(s)", got)
-	}
-	joined := strings.Join(commands[1], " ")
-	if strings.Contains(joined, "mise exec --") {
-		t.Fatalf("expected disable_mise option to skip mise exec wrapper, got %q", joined)
-	}
-}
-
 func TestCreateExecutionSkipsBootstrapForSnapshotBackedSandboxWithMatchingRepository(t *testing.T) {
 	adapter := &stubAdapter{
 		createSnapshotFn: func(_ context.Context, req backend.SnapshotRequest) (*backend.SnapshotResult, error) {
@@ -2833,10 +2581,6 @@ func repositoryWrappedCommandContains(joined, execSnippet string) bool {
 	return strings.Contains(joined, "dest='/workspace'") &&
 		strings.Contains(joined, `cd "$dest"`) &&
 		strings.Contains(joined, execSnippet)
-}
-
-func boolPtr(v bool) *bool {
-	return &v
 }
 
 func TestCreateSandboxRejectsRepositoryFileRemote(t *testing.T) {

--- a/internal/gen/cleanroom/v1/control.pb.go
+++ b/internal/gen/cleanroom/v1/control.pb.go
@@ -3266,7 +3266,7 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\x05files\x18\x01 \x03(\tR\x05files\"c\n" +
 	"\x12PolicyDependencies\x12\x18\n" +
 	"\acommand\x18\x01 \x03(\tR\acommand\x123\n" +
-	"\x03key\x18\x02 \x01(\v2!.cleanroom.v1.PolicyDependencyKeyR\x03key\"\xe8\x02\n" +
+	"\x03key\x18\x02 \x01(\v2!.cleanroom.v1.PolicyDependencyKeyR\x03key\"\xd4\x02\n" +
 	"\x06Policy\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\x05R\aversion\x12\x1b\n" +
 	"\timage_ref\x18\x02 \x01(\tR\bimageRef\x12!\n" +
@@ -3275,7 +3275,7 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\x05allow\x18\x05 \x03(\v2\x1d.cleanroom.v1.PolicyAllowRuleR\x05allow\x12\x12\n" +
 	"\x04hash\x18\x06 \x01(\tR\x04hash\x128\n" +
 	"\bservices\x18\a \x01(\v2\x1c.cleanroom.v1.PolicyServicesR\bservices\x12D\n" +
-	"\fdependencies\x18\t \x01(\v2 .cleanroom.v1.PolicyDependenciesR\fdependenciesJ\x04\b\b\x10\tR\fmise_install\"R\n" +
+	"\fdependencies\x18\t \x01(\v2 .cleanroom.v1.PolicyDependenciesR\fdependencies\"R\n" +
 	"\x0eSandboxOptions\x12%\n" +
 	"\x0elaunch_seconds\x18\x03 \x01(\x03R\rlaunchSecondsJ\x04\b\x02\x10\x03R\x13read_only_workspace\"\xe1\x01\n" +
 	"\x12RepositoryCheckout\x12\x1d\n" +
@@ -3378,10 +3378,10 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\x03tty\x18\b \x01(\bR\x03tty\x12/\n" +
 	"\x04kind\x18\n" +
 	" \x01(\x0e2\x1b.cleanroom.v1.ExecutionKindR\x04kindJ\x04\b\t\x10\n" +
-	"R\x06run_id\"\x85\x01\n" +
+	"R\x06run_id\"q\n" +
 	"\x10ExecutionOptions\x12%\n" +
 	"\x0elaunch_seconds\x18\x05 \x01(\x03R\rlaunchSeconds\x12\x10\n" +
-	"\x03tty\x18\x06 \x01(\bR\x03ttyJ\x04\b\x02\x10\x03J\x04\b\a\x10\bJ\x04\b\b\x10\tR\x13read_only_workspaceR\x03cwdR\fdisable_mise\"\xa1\x02\n" +
+	"\x03tty\x18\x06 \x01(\bR\x03ttyJ\x04\b\x02\x10\x03J\x04\b\a\x10\bR\x13read_only_workspaceR\x03cwd\"\xa1\x02\n" +
 	"\x16CreateExecutionRequest\x12\x1d\n" +
 	"\n" +
 	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\x12\x18\n" +

--- a/internal/gen/cleanroom/v1/control.pb.go
+++ b/internal/gen/cleanroom/v1/control.pb.go
@@ -644,7 +644,6 @@ type Policy struct {
 	Allow          []*PolicyAllowRule     `protobuf:"bytes,5,rep,name=allow,proto3" json:"allow,omitempty"`
 	Hash           string                 `protobuf:"bytes,6,opt,name=hash,proto3" json:"hash,omitempty"`
 	Services       *PolicyServices        `protobuf:"bytes,7,opt,name=services,proto3" json:"services,omitempty"`
-	MiseInstall    *bool                  `protobuf:"varint,8,opt,name=mise_install,json=miseInstall,proto3,oneof" json:"mise_install,omitempty"`
 	Dependencies   *PolicyDependencies    `protobuf:"bytes,9,opt,name=dependencies,proto3" json:"dependencies,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
@@ -727,13 +726,6 @@ func (x *Policy) GetServices() *PolicyServices {
 		return x.Services
 	}
 	return nil
-}
-
-func (x *Policy) GetMiseInstall() bool {
-	if x != nil && x.MiseInstall != nil {
-		return *x.MiseInstall
-	}
-	return false
 }
 
 func (x *Policy) GetDependencies() *PolicyDependencies {
@@ -2029,7 +2021,6 @@ type ExecutionOptions struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	LaunchSeconds int64                  `protobuf:"varint,5,opt,name=launch_seconds,json=launchSeconds,proto3" json:"launch_seconds,omitempty"`
 	Tty           bool                   `protobuf:"varint,6,opt,name=tty,proto3" json:"tty,omitempty"`
-	DisableMise   bool                   `protobuf:"varint,8,opt,name=disable_mise,json=disableMise,proto3" json:"disable_mise,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2074,13 +2065,6 @@ func (x *ExecutionOptions) GetLaunchSeconds() int64 {
 func (x *ExecutionOptions) GetTty() bool {
 	if x != nil {
 		return x.Tty
-	}
-	return false
-}
-
-func (x *ExecutionOptions) GetDisableMise() bool {
-	if x != nil {
-		return x.DisableMise
 	}
 	return false
 }
@@ -3282,7 +3266,7 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\x05files\x18\x01 \x03(\tR\x05files\"c\n" +
 	"\x12PolicyDependencies\x12\x18\n" +
 	"\acommand\x18\x01 \x03(\tR\acommand\x123\n" +
-	"\x03key\x18\x02 \x01(\v2!.cleanroom.v1.PolicyDependencyKeyR\x03key\"\x8d\x03\n" +
+	"\x03key\x18\x02 \x01(\v2!.cleanroom.v1.PolicyDependencyKeyR\x03key\"\xe8\x02\n" +
 	"\x06Policy\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\x05R\aversion\x12\x1b\n" +
 	"\timage_ref\x18\x02 \x01(\tR\bimageRef\x12!\n" +
@@ -3290,10 +3274,8 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\x0fnetwork_default\x18\x04 \x01(\tR\x0enetworkDefault\x123\n" +
 	"\x05allow\x18\x05 \x03(\v2\x1d.cleanroom.v1.PolicyAllowRuleR\x05allow\x12\x12\n" +
 	"\x04hash\x18\x06 \x01(\tR\x04hash\x128\n" +
-	"\bservices\x18\a \x01(\v2\x1c.cleanroom.v1.PolicyServicesR\bservices\x12&\n" +
-	"\fmise_install\x18\b \x01(\bH\x00R\vmiseInstall\x88\x01\x01\x12D\n" +
-	"\fdependencies\x18\t \x01(\v2 .cleanroom.v1.PolicyDependenciesR\fdependenciesB\x0f\n" +
-	"\r_mise_install\"R\n" +
+	"\bservices\x18\a \x01(\v2\x1c.cleanroom.v1.PolicyServicesR\bservices\x12D\n" +
+	"\fdependencies\x18\t \x01(\v2 .cleanroom.v1.PolicyDependenciesR\fdependenciesJ\x04\b\b\x10\tR\fmise_install\"R\n" +
 	"\x0eSandboxOptions\x12%\n" +
 	"\x0elaunch_seconds\x18\x03 \x01(\x03R\rlaunchSecondsJ\x04\b\x02\x10\x03R\x13read_only_workspace\"\xe1\x01\n" +
 	"\x12RepositoryCheckout\x12\x1d\n" +
@@ -3396,11 +3378,10 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\x03tty\x18\b \x01(\bR\x03tty\x12/\n" +
 	"\x04kind\x18\n" +
 	" \x01(\x0e2\x1b.cleanroom.v1.ExecutionKindR\x04kindJ\x04\b\t\x10\n" +
-	"R\x06run_id\"\x94\x01\n" +
+	"R\x06run_id\"\x85\x01\n" +
 	"\x10ExecutionOptions\x12%\n" +
 	"\x0elaunch_seconds\x18\x05 \x01(\x03R\rlaunchSeconds\x12\x10\n" +
-	"\x03tty\x18\x06 \x01(\bR\x03tty\x12!\n" +
-	"\fdisable_mise\x18\b \x01(\bR\vdisableMiseJ\x04\b\x02\x10\x03J\x04\b\a\x10\bR\x13read_only_workspaceR\x03cwd\"\xa1\x02\n" +
+	"\x03tty\x18\x06 \x01(\bR\x03ttyJ\x04\b\x02\x10\x03J\x04\b\a\x10\bJ\x04\b\b\x10\tR\x13read_only_workspaceR\x03cwdR\fdisable_mise\"\xa1\x02\n" +
 	"\x16CreateExecutionRequest\x12\x1d\n" +
 	"\n" +
 	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\x12\x18\n" +
@@ -3695,7 +3676,6 @@ func file_proto_cleanroom_v1_control_proto_init() {
 	if File_proto_cleanroom_v1_control_proto != nil {
 		return
 	}
-	file_proto_cleanroom_v1_control_proto_msgTypes[7].OneofWrappers = []any{}
 	file_proto_cleanroom_v1_control_proto_msgTypes[10].OneofWrappers = []any{
 		(*CreateSandboxRequest_SnapshotId)(nil),
 	}

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -33,8 +33,8 @@ type rawPolicy struct {
 		Image struct {
 			Ref string `yaml:"ref"`
 		} `yaml:"image"`
-		Mise         rawMiseConfig         `yaml:"mise"`
 		Dependencies rawDependenciesConfig `yaml:"dependencies"`
+		Mise         rawMiseConfig         `yaml:"mise"`
 		Services     rawServices           `yaml:"services"`
 		Network      struct {
 			Default string         `yaml:"default"`
@@ -52,8 +52,9 @@ type rawRepository struct {
 }
 
 type rawMiseConfig struct {
-	Enabled *bool `yaml:"enabled"`
-	Install *bool `yaml:"install"`
+	Enabled     *bool    `yaml:"enabled"`
+	Install     *bool    `yaml:"install"`
+	ConfigFiles []string `yaml:"config_files"`
 }
 
 type rawDependencyKey struct {
@@ -85,7 +86,6 @@ type CompiledPolicy struct {
 	Services       Services     `json:"services"`
 	NetworkDefault string       `json:"network_default"`
 	Allow          []AllowRule  `json:"allow"`
-	MiseInstall    bool         `json:"mise_install"`
 	Dependencies   Dependencies `json:"dependencies"`
 	Hash           string       `json:"hash"`
 }
@@ -227,6 +227,9 @@ func Compile(raw rawPolicy) (*CompiledPolicy, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err := validateRemovedMiseConfig(raw.Sandbox.Mise); err != nil {
+		return nil, err
+	}
 
 	compiled := &CompiledPolicy{
 		Version:     raw.Version,
@@ -239,7 +242,6 @@ func Compile(raw rawPolicy) (*CompiledPolicy, error) {
 		},
 		NetworkDefault: networkDefault,
 		Allow:          allow,
-		MiseInstall:    normalizeMiseInstall(raw.Sandbox.Mise),
 		Dependencies:   dependencies,
 	}
 
@@ -402,7 +404,6 @@ func (p *CompiledPolicy) ToProto() *cleanroomv1.Policy {
 		},
 		NetworkDefault: p.NetworkDefault,
 		Allow:          allow,
-		MiseInstall:    boolPtr(p.MiseInstall),
 		Dependencies: &cleanroomv1.PolicyDependencies{
 			Command: append([]string(nil), p.Dependencies.Command...),
 			Key: &cleanroomv1.PolicyDependencyKey{
@@ -491,7 +492,6 @@ func FromProto(pb *cleanroomv1.Policy) (*CompiledPolicy, error) {
 		},
 		NetworkDefault: networkDefault,
 		Allow:          allow,
-		MiseInstall:    protoBoolOrDefault(pb.MiseInstall, false),
 		Dependencies:   dependencies,
 	}
 
@@ -507,18 +507,11 @@ func FromProto(pb *cleanroomv1.Policy) (*CompiledPolicy, error) {
 	return compiled, nil
 }
 
-func normalizeMiseInstall(raw rawMiseConfig) bool {
-	enabled := true
-	if raw.Enabled != nil {
-		enabled = *raw.Enabled
+func validateRemovedMiseConfig(raw rawMiseConfig) error {
+	if raw.Enabled == nil && raw.Install == nil && len(raw.ConfigFiles) == 0 {
+		return nil
 	}
-	if !enabled {
-		return false
-	}
-	if raw.Install != nil {
-		return *raw.Install
-	}
-	return false
+	return errors.New("sandbox.mise has been removed; use sandbox.dependencies.command to run mise explicitly when needed")
 }
 
 func normalizeDependencies(raw rawDependenciesConfig) (Dependencies, error) {
@@ -607,17 +600,6 @@ func normalizeDependencyKeyFiles(raw []string) ([]string, error) {
 	}
 	sort.Strings(files)
 	return files, nil
-}
-
-func protoBoolOrDefault(v *bool, fallback bool) bool {
-	if v == nil {
-		return fallback
-	}
-	return *v
-}
-
-func boolPtr(v bool) *bool {
-	return &v
 }
 
 func hashPolicy(p *CompiledPolicy) (string, error) {

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -34,7 +34,6 @@ type rawPolicy struct {
 			Ref string `yaml:"ref"`
 		} `yaml:"image"`
 		Dependencies rawDependenciesConfig `yaml:"dependencies"`
-		Mise         rawMiseConfig         `yaml:"mise"`
 		Services     rawServices           `yaml:"services"`
 		Network      struct {
 			Default string         `yaml:"default"`
@@ -49,12 +48,6 @@ type rawRepository struct {
 	Remote     string `yaml:"remote"`
 	Path       string `yaml:"path"`
 	Submodules bool   `yaml:"submodules"`
-}
-
-type rawMiseConfig struct {
-	Enabled     *bool    `yaml:"enabled"`
-	Install     *bool    `yaml:"install"`
-	ConfigFiles []string `yaml:"config_files"`
 }
 
 type rawDependencyKey struct {
@@ -225,9 +218,6 @@ func Compile(raw rawPolicy) (*CompiledPolicy, error) {
 
 	dependencies, err := normalizeDependencies(raw.Sandbox.Dependencies)
 	if err != nil {
-		return nil, err
-	}
-	if err := validateRemovedMiseConfig(raw.Sandbox.Mise); err != nil {
 		return nil, err
 	}
 
@@ -505,13 +495,6 @@ func FromProto(pb *cleanroomv1.Policy) (*CompiledPolicy, error) {
 	}
 	compiled.Hash = hash
 	return compiled, nil
-}
-
-func validateRemovedMiseConfig(raw rawMiseConfig) error {
-	if raw.Enabled == nil && raw.Install == nil && len(raw.ConfigFiles) == 0 {
-		return nil
-	}
-	return errors.New("sandbox.mise has been removed; use sandbox.dependencies.command to run mise explicitly when needed")
 }
 
 func normalizeDependencies(raw rawDependenciesConfig) (Dependencies, error) {

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -174,21 +174,6 @@ func TestCompileCapturesDockerServiceRequirement(t *testing.T) {
 	}
 }
 
-func TestCompileRejectsRemovedSandboxMiseConfig(t *testing.T) {
-	t.Parallel()
-
-	raw := baseRawPolicy()
-	raw.Sandbox.Mise.Install = testBoolPtr(false)
-
-	_, err := Compile(raw)
-	if err == nil {
-		t.Fatal("expected compile to reject sandbox.mise")
-	}
-	if !strings.Contains(err.Error(), "sandbox.mise has been removed") {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
 func TestCompileDefaultsDependenciesDisabled(t *testing.T) {
 	t.Parallel()
 
@@ -481,8 +466,4 @@ func TestCompiledPolicyProtoRoundTripPreservesDependencies(t *testing.T) {
 	if got, want := strings.Join(roundTripped.Dependencies.KeyFiles, "\x00"), strings.Join(compiled.Dependencies.KeyFiles, "\x00"); got != want {
 		t.Fatalf("unexpected dependency key files after round trip: got %q want %q", got, want)
 	}
-}
-
-func testBoolPtr(v bool) *bool {
-	return &v
 }

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -174,61 +174,18 @@ func TestCompileCapturesDockerServiceRequirement(t *testing.T) {
 	}
 }
 
-func TestCompileDefaultsMiseInstallDisabled(t *testing.T) {
-	t.Parallel()
-
-	raw := baseRawPolicy()
-	compiled, err := Compile(raw)
-	if err != nil {
-		t.Fatalf("compile: %v", err)
-	}
-	if compiled.MiseInstall {
-		t.Fatal("expected compiled policy to disable mise auto-install by default")
-	}
-}
-
-func TestCompileEnablesMiseInstallWhenSandboxMiseInstallTrue(t *testing.T) {
-	t.Parallel()
-
-	raw := baseRawPolicy()
-	raw.Sandbox.Mise.Install = testBoolPtr(true)
-
-	compiled, err := Compile(raw)
-	if err != nil {
-		t.Fatalf("compile: %v", err)
-	}
-	if !compiled.MiseInstall {
-		t.Fatal("expected compiled policy to enable mise auto-install when sandbox.mise.install=true")
-	}
-}
-
-func TestCompileDisablesMiseInstallWhenSandboxMiseDisabled(t *testing.T) {
-	t.Parallel()
-
-	raw := baseRawPolicy()
-	raw.Sandbox.Mise.Enabled = testBoolPtr(false)
-
-	compiled, err := Compile(raw)
-	if err != nil {
-		t.Fatalf("compile: %v", err)
-	}
-	if compiled.MiseInstall {
-		t.Fatal("expected compiled policy to disable mise auto-install when sandbox.mise.enabled=false")
-	}
-}
-
-func TestCompileDisablesMiseInstallWhenSandboxMiseInstallFalse(t *testing.T) {
+func TestCompileRejectsRemovedSandboxMiseConfig(t *testing.T) {
 	t.Parallel()
 
 	raw := baseRawPolicy()
 	raw.Sandbox.Mise.Install = testBoolPtr(false)
 
-	compiled, err := Compile(raw)
-	if err != nil {
-		t.Fatalf("compile: %v", err)
+	_, err := Compile(raw)
+	if err == nil {
+		t.Fatal("expected compile to reject sandbox.mise")
 	}
-	if compiled.MiseInstall {
-		t.Fatal("expected compiled policy to disable mise auto-install when sandbox.mise.install=false")
+	if !strings.Contains(err.Error(), "sandbox.mise has been removed") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
@@ -500,25 +457,6 @@ func TestFromProtoAcceptsAllowDefault(t *testing.T) {
 	}
 	if !compiled.Allows("example.com", 443) {
 		t.Fatal("expected allow-default policy to allow arbitrary host:port")
-	}
-}
-
-func TestCompiledPolicyProtoRoundTripPreservesMiseInstall(t *testing.T) {
-	t.Parallel()
-
-	raw := baseRawPolicy()
-	raw.Sandbox.Mise.Install = testBoolPtr(false)
-	compiled, err := Compile(raw)
-	if err != nil {
-		t.Fatalf("compile: %v", err)
-	}
-
-	roundTripped, err := FromProto(compiled.ToProto())
-	if err != nil {
-		t.Fatalf("FromProto returned error: %v", err)
-	}
-	if roundTripped.MiseInstall {
-		t.Fatal("expected proto round-trip to preserve mise install=false")
 	}
 }
 

--- a/internal/repositorycheckout/checkout.go
+++ b/internal/repositorycheckout/checkout.go
@@ -18,13 +18,6 @@ type Checkout struct {
 	Branch         string
 }
 
-var miseConfigCandidates = []string{
-	"mise.toml",
-	".mise.toml",
-	".tool-versions",
-	".mise/config.toml",
-}
-
 func FromProto(proto *cleanroomv1.RepositoryCheckout) *Checkout {
 	if proto == nil {
 		return nil
@@ -205,29 +198,29 @@ func BootstrapRecipeDigest(checkout *Checkout) string {
 	return commandRecipeDigest(BuildBootstrapCommand(checkout))
 }
 
-func WorkdirRecipeDigest(command []string, checkout *Checkout, autoMiseInstall bool) string {
+func WorkdirRecipeDigest(command []string, checkout *Checkout) string {
 	if checkout == nil {
 		return ""
 	}
-	return commandRecipeDigest(WrapCommandInWorkdir(command, checkout, autoMiseInstall))
+	return commandRecipeDigest(WrapCommandInWorkdir(command, checkout))
 }
 
-func WrapCommandWithBootstrap(command []string, checkout *Checkout, autoMiseInstall bool) []string {
+func WrapCommandWithBootstrap(command []string, checkout *Checkout) []string {
 	normalized := NormalizeCommand(command)
 	if checkout == nil || len(normalized) == 0 {
 		return normalized
 	}
 	script := bootstrapScript(checkout)
-	script = append(script, workdirExecutionScript(normalized, checkout, autoMiseInstall)...)
+	script = append(script, workdirExecutionScript(normalized, checkout)...)
 	return []string{"sh", "-lc", strings.Join(script, "\n")}
 }
 
-func WrapCommandInWorkdir(command []string, checkout *Checkout, autoMiseInstall bool) []string {
+func WrapCommandInWorkdir(command []string, checkout *Checkout) []string {
 	normalized := NormalizeCommand(command)
 	if checkout == nil || len(normalized) == 0 {
 		return normalized
 	}
-	return []string{"sh", "-lc", strings.Join(workdirExecutionScript(normalized, checkout, autoMiseInstall), "\n")}
+	return []string{"sh", "-lc", strings.Join(workdirExecutionScript(normalized, checkout), "\n")}
 }
 
 func NormalizeCommand(command []string) []string {
@@ -265,35 +258,15 @@ func bootstrapScript(checkout *Checkout) []string {
 	return script
 }
 
-func workdirExecutionScript(command []string, checkout *Checkout, autoMiseInstall bool) []string {
+func workdirExecutionScript(command []string, checkout *Checkout) []string {
 	execCommand := shellJoin(command)
 	script := []string{
 		"set -eu",
 		"dest=" + shellQuote(checkout.DestinationDir),
 		`cd "$dest"`,
 	}
-	if autoMiseInstall {
-		if condition := miseConfigCondition(); condition != "" {
-			script = append(script,
-				"if "+condition+"; then",
-				`  if ! command -v mise >/dev/null 2>&1; then echo "repository declares mise config but 'mise' is not installed in sandbox image" >&2; exit 1; fi`,
-				`  export MISE_YES=1`,
-				`  export MISE_TRUSTED_CONFIG_PATHS="$dest${MISE_TRUSTED_CONFIG_PATHS:+:$MISE_TRUSTED_CONFIG_PATHS}"`,
-				`  exec mise exec -- `+execCommand,
-				`fi`,
-			)
-		}
-	}
 	script = append(script, `exec `+execCommand)
 	return script
-}
-
-func miseConfigCondition() string {
-	conditions := make([]string, 0, len(miseConfigCandidates))
-	for _, candidate := range miseConfigCandidates {
-		conditions = append(conditions, `[ -f `+shellQuote(candidate)+` ]`)
-	}
-	return strings.Join(conditions, " || ")
 }
 
 func shellJoin(args []string) string {

--- a/internal/repositorycheckout/checkout.go
+++ b/internal/repositorycheckout/checkout.go
@@ -264,6 +264,8 @@ func workdirExecutionScript(command []string, checkout *Checkout) []string {
 		"set -eu",
 		"dest=" + shellQuote(checkout.DestinationDir),
 		`cd "$dest"`,
+		`export MISE_TRUSTED_CONFIG_PATHS="$dest${MISE_TRUSTED_CONFIG_PATHS:+:$MISE_TRUSTED_CONFIG_PATHS}"`,
+		`export MISE_YES="${MISE_YES:-1}"`,
 	}
 	script = append(script, `exec `+execCommand)
 	return script

--- a/internal/repositorycheckout/checkout.go
+++ b/internal/repositorycheckout/checkout.go
@@ -264,8 +264,6 @@ func workdirExecutionScript(command []string, checkout *Checkout) []string {
 		"set -eu",
 		"dest=" + shellQuote(checkout.DestinationDir),
 		`cd "$dest"`,
-		`export MISE_TRUSTED_CONFIG_PATHS="$dest${MISE_TRUSTED_CONFIG_PATHS:+:$MISE_TRUSTED_CONFIG_PATHS}"`,
-		`export MISE_YES="${MISE_YES:-1}"`,
 	}
 	script = append(script, `exec `+execCommand)
 	return script

--- a/internal/repositorycheckout/checkout_test.go
+++ b/internal/repositorycheckout/checkout_test.go
@@ -205,13 +205,12 @@ func TestWrapCommandInWorkdirQuotesDestinationAndArguments(t *testing.T) {
 
 func TestWrapCommandInWorkdirRunsInRepositoryDirectory(t *testing.T) {
 	repoDir := t.TempDir()
-	outputPath := filepath.Join(t.TempDir(), "env")
-	command := WrapCommandInWorkdir([]string{"sh", "-lc", "printf '%s\\n%s\\n%s\\n' \"$PWD\" \"$MISE_TRUSTED_CONFIG_PATHS\" \"$MISE_YES\" > " + shellQuote(outputPath)}, &Checkout{
+	outputPath := filepath.Join(t.TempDir(), "pwd")
+	command := WrapCommandInWorkdir([]string{"sh", "-lc", "pwd > " + shellQuote(outputPath)}, &Checkout{
 		DestinationDir: repoDir,
 	})
 
 	cmd := exec.Command(command[0], command[1:]...)
-	cmd.Env = envWithout(os.Environ(), "MISE_TRUSTED_CONFIG_PATHS", "MISE_YES")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("wrapped command failed: %v\n%s", err, string(out))
@@ -221,18 +220,8 @@ func TestWrapCommandInWorkdirRunsInRepositoryDirectory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read output: %v", err)
 	}
-	lines := strings.Split(strings.TrimSpace(string(outputBytes)), "\n")
-	if got, want := len(lines), 3; got != want {
-		t.Fatalf("unexpected output line count: got %d want %d (%q)", got, want, string(outputBytes))
-	}
-	if got, want := strings.TrimSpace(lines[0]), repoDir; got != want {
+	if got, want := strings.TrimSpace(string(outputBytes)), repoDir; got != want {
 		t.Fatalf("unexpected working directory: got %q want %q", got, want)
-	}
-	if got, want := strings.TrimSpace(lines[1]), repoDir; got != want {
-		t.Fatalf("unexpected trusted config paths: got %q want %q", got, want)
-	}
-	if got, want := strings.TrimSpace(lines[2]), "1"; got != want {
-		t.Fatalf("unexpected MISE_YES default: got %q want %q", got, want)
 	}
 }
 
@@ -290,23 +279,4 @@ func TestWrapCommandInWorkdirFailsFastWhenWorkdirSetupFails(t *testing.T) {
 	if _, statErr := os.Stat(outputPath); !os.IsNotExist(statErr) {
 		t.Fatalf("expected payload not to run when workdir setup fails, stat error=%v", statErr)
 	}
-}
-
-func envWithout(env []string, keys ...string) []string {
-	blocked := make(map[string]struct{}, len(keys))
-	for _, key := range keys {
-		blocked[key] = struct{}{}
-	}
-
-	filtered := make([]string, 0, len(env))
-	for _, entry := range env {
-		key, _, ok := strings.Cut(entry, "=")
-		if ok {
-			if _, blockedKey := blocked[key]; blockedKey {
-				continue
-			}
-		}
-		filtered = append(filtered, entry)
-	}
-	return filtered
 }

--- a/internal/repositorycheckout/checkout_test.go
+++ b/internal/repositorycheckout/checkout_test.go
@@ -205,12 +205,13 @@ func TestWrapCommandInWorkdirQuotesDestinationAndArguments(t *testing.T) {
 
 func TestWrapCommandInWorkdirRunsInRepositoryDirectory(t *testing.T) {
 	repoDir := t.TempDir()
-	outputPath := filepath.Join(t.TempDir(), "pwd")
-	command := WrapCommandInWorkdir([]string{"sh", "-lc", "pwd > " + shellQuote(outputPath)}, &Checkout{
+	outputPath := filepath.Join(t.TempDir(), "env")
+	command := WrapCommandInWorkdir([]string{"sh", "-lc", "printf '%s\\n%s\\n%s\\n' \"$PWD\" \"$MISE_TRUSTED_CONFIG_PATHS\" \"$MISE_YES\" > " + shellQuote(outputPath)}, &Checkout{
 		DestinationDir: repoDir,
 	})
 
 	cmd := exec.Command(command[0], command[1:]...)
+	cmd.Env = envWithout(os.Environ(), "MISE_TRUSTED_CONFIG_PATHS", "MISE_YES")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("wrapped command failed: %v\n%s", err, string(out))
@@ -220,8 +221,18 @@ func TestWrapCommandInWorkdirRunsInRepositoryDirectory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read output: %v", err)
 	}
-	if got, want := strings.TrimSpace(string(outputBytes)), repoDir; got != want {
+	lines := strings.Split(strings.TrimSpace(string(outputBytes)), "\n")
+	if got, want := len(lines), 3; got != want {
+		t.Fatalf("unexpected output line count: got %d want %d (%q)", got, want, string(outputBytes))
+	}
+	if got, want := strings.TrimSpace(lines[0]), repoDir; got != want {
 		t.Fatalf("unexpected working directory: got %q want %q", got, want)
+	}
+	if got, want := strings.TrimSpace(lines[1]), repoDir; got != want {
+		t.Fatalf("unexpected trusted config paths: got %q want %q", got, want)
+	}
+	if got, want := strings.TrimSpace(lines[2]), "1"; got != want {
+		t.Fatalf("unexpected MISE_YES default: got %q want %q", got, want)
 	}
 }
 
@@ -279,4 +290,23 @@ func TestWrapCommandInWorkdirFailsFastWhenWorkdirSetupFails(t *testing.T) {
 	if _, statErr := os.Stat(outputPath); !os.IsNotExist(statErr) {
 		t.Fatalf("expected payload not to run when workdir setup fails, stat error=%v", statErr)
 	}
+}
+
+func envWithout(env []string, keys ...string) []string {
+	blocked := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		blocked[key] = struct{}{}
+	}
+
+	filtered := make([]string, 0, len(env))
+	for _, entry := range env {
+		key, _, ok := strings.Cut(entry, "=")
+		if ok {
+			if _, blockedKey := blocked[key]; blockedKey {
+				continue
+			}
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered
 }

--- a/internal/repositorycheckout/checkout_test.go
+++ b/internal/repositorycheckout/checkout_test.go
@@ -192,7 +192,7 @@ func TestValidateBootstrapRejectsMutableCommitRef(t *testing.T) {
 func TestWrapCommandInWorkdirQuotesDestinationAndArguments(t *testing.T) {
 	command := WrapCommandInWorkdir([]string{"printf", "%s", "it's alive"}, &Checkout{
 		DestinationDir: "/tmp/work tree",
-	}, true)
+	})
 
 	joined := strings.Join(command, " ")
 	if !strings.Contains(joined, "dest='/tmp/work tree'") {
@@ -203,23 +203,14 @@ func TestWrapCommandInWorkdirQuotesDestinationAndArguments(t *testing.T) {
 	}
 }
 
-func TestWrapCommandInWorkdirBootstrapsMiseWhenConfigPresent(t *testing.T) {
-	if _, err := exec.LookPath("mise"); err != nil {
-		t.Skip("mise not installed")
-	}
+func TestWrapCommandInWorkdirRunsInRepositoryDirectory(t *testing.T) {
 	repoDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(repoDir, "mise.toml"), []byte("# test config\n"), 0o644); err != nil {
-		t.Fatalf("write mise.toml: %v", err)
-	}
-
-	logDir := t.TempDir()
-	outputPath := filepath.Join(logDir, "env")
-	command := WrapCommandInWorkdir([]string{"sh", "-lc", "printf '%s\\n%s\\n%s\\n' \"$PWD\" \"${MISE_TRUSTED_CONFIG_PATHS:-}\" \"${MISE_YES:-}\" > " + shellQuote(outputPath)}, &Checkout{
+	outputPath := filepath.Join(t.TempDir(), "pwd")
+	command := WrapCommandInWorkdir([]string{"sh", "-lc", "pwd > " + shellQuote(outputPath)}, &Checkout{
 		DestinationDir: repoDir,
-	}, true)
+	})
 
 	cmd := exec.Command(command[0], command[1:]...)
-	cmd.Env = envWithout(os.Environ(), "MISE_TRUSTED_CONFIG_PATHS", "MISE_YES")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("wrapped command failed: %v\n%s", err, string(out))
@@ -229,48 +220,7 @@ func TestWrapCommandInWorkdirBootstrapsMiseWhenConfigPresent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read output: %v", err)
 	}
-	lines := strings.Split(strings.TrimSpace(string(outputBytes)), "\n")
-	if len(lines) != 3 {
-		t.Fatalf("expected 3 output lines, got %d: %q", len(lines), string(outputBytes))
-	}
-	if got, want := strings.TrimSpace(lines[0]), repoDir; got != want {
-		t.Fatalf("unexpected working directory: got %q want %q", got, want)
-	}
-	if got, want := strings.TrimSpace(lines[1]), repoDir; got != want {
-		t.Fatalf("unexpected trusted config paths: got %q want %q", got, want)
-	}
-	if got, want := strings.TrimSpace(lines[2]), "1"; got != want {
-		t.Fatalf("unexpected MISE_YES value: got %q want %q", got, want)
-	}
-}
-
-func TestWrapCommandInWorkdirSkipsMiseWithoutConfig(t *testing.T) {
-	if _, err := exec.LookPath("mise"); err != nil {
-		t.Skip("mise not installed")
-	}
-	repoDir := t.TempDir()
-	logDir := t.TempDir()
-	outputPath := filepath.Join(logDir, "env")
-	command := WrapCommandInWorkdir([]string{"sh", "-lc", "printf '%s\\n%s\\n%s\\n' \"$PWD\" \"${MISE_TRUSTED_CONFIG_PATHS:-}\" \"${MISE_YES:-}\" > " + shellQuote(outputPath)}, &Checkout{
-		DestinationDir: repoDir,
-	}, true)
-
-	cmd := exec.Command(command[0], command[1:]...)
-	cmd.Env = envWithout(os.Environ(), "MISE_TRUSTED_CONFIG_PATHS", "MISE_YES")
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("wrapped command failed: %v\n%s", err, string(out))
-	}
-
-	outputBytes, err := os.ReadFile(outputPath)
-	if err != nil {
-		t.Fatalf("read output: %v", err)
-	}
-	lines := strings.Split(strings.TrimSpace(string(outputBytes)), "\n")
-	if len(lines) != 1 {
-		t.Fatalf("expected only working-directory output without mise bootstrap, got %q", string(outputBytes))
-	}
-	if got, want := strings.TrimSpace(lines[0]), repoDir; got != want {
+	if got, want := strings.TrimSpace(string(outputBytes)), repoDir; got != want {
 		t.Fatalf("unexpected working directory: got %q want %q", got, want)
 	}
 }
@@ -293,39 +243,25 @@ func TestShellJoinQuotesSingleQuotes(t *testing.T) {
 }
 
 func TestWrapCommandWithBootstrapNormalizesPassthroughWithoutCheckout(t *testing.T) {
-	command := WrapCommandWithBootstrap([]string{"--", "echo", "ok"}, nil, true)
+	command := WrapCommandWithBootstrap([]string{"--", "echo", "ok"}, nil)
 	if got, want := strings.Join(command, " "), "echo ok"; got != want {
 		t.Fatalf("unexpected normalized command: got %q want %q", got, want)
 	}
 }
 
-func TestWrapCommandWithBootstrapIncludesMiseBootstrapLogic(t *testing.T) {
+func TestWrapCommandWithBootstrapIncludesRepositoryWorkdirExecution(t *testing.T) {
 	command := WrapCommandWithBootstrap([]string{"sh", "-lc", "pwd"}, &Checkout{
 		RemoteURL:      "https://github.com/buildkite/cleanroom.git",
 		CommitSHA:      "0123456789abcdef0123456789abcdef01234567",
 		DestinationDir: "/workspace",
-	}, true)
+	})
 
 	joined := strings.Join(command, " ")
-	if !strings.Contains(joined, "if [ -f 'mise.toml' ] || [ -f '.mise.toml' ] || [ -f '.tool-versions' ] || [ -f '.mise/config.toml' ]; then") {
-		t.Fatalf("expected bootstrap wrapper to detect mise config files, got %q", joined)
+	if !strings.Contains(joined, `cd "$dest"`) {
+		t.Fatalf("expected bootstrap wrapper to enter repository workdir, got %q", joined)
 	}
-	if strings.Contains(joined, `mise install`) {
-		t.Fatalf("expected bootstrap wrapper to rely on mise exec auto-install, got %q", joined)
-	}
-	if !strings.Contains(joined, `exec mise exec -- 'sh' '-lc' 'pwd'`) {
-		t.Fatalf("expected bootstrap wrapper to exec through mise, got %q", joined)
-	}
-}
-
-func TestWrapCommandInWorkdirSkipsMiseBootstrapWhenDisabled(t *testing.T) {
-	command := WrapCommandInWorkdir([]string{"sh", "-lc", "pwd"}, &Checkout{
-		DestinationDir: "/workspace",
-	}, false)
-
-	joined := strings.Join(command, " ")
-	if strings.Contains(joined, "mise exec --") {
-		t.Fatalf("expected mise exec wrapper to be skipped when disabled, got %q", joined)
+	if !strings.Contains(joined, `exec 'sh' '-lc' 'pwd'`) {
+		t.Fatalf("expected bootstrap wrapper to execute the requested command, got %q", joined)
 	}
 }
 
@@ -333,7 +269,7 @@ func TestWrapCommandInWorkdirFailsFastWhenWorkdirSetupFails(t *testing.T) {
 	outputPath := filepath.Join(t.TempDir(), "ran")
 	command := WrapCommandInWorkdir([]string{"sh", "-lc", "touch " + shellQuote(outputPath)}, &Checkout{
 		DestinationDir: filepath.Join(t.TempDir(), "missing"),
-	}, false)
+	})
 
 	cmd := exec.Command(command[0], command[1:]...)
 	out, err := cmd.CombinedOutput()
@@ -343,23 +279,4 @@ func TestWrapCommandInWorkdirFailsFastWhenWorkdirSetupFails(t *testing.T) {
 	if _, statErr := os.Stat(outputPath); !os.IsNotExist(statErr) {
 		t.Fatalf("expected payload not to run when workdir setup fails, stat error=%v", statErr)
 	}
-}
-
-func envWithout(env []string, keys ...string) []string {
-	blocked := make(map[string]struct{}, len(keys))
-	for _, key := range keys {
-		blocked[key] = struct{}{}
-	}
-
-	filtered := make([]string, 0, len(env))
-	for _, entry := range env {
-		key, _, ok := strings.Cut(entry, "=")
-		if ok {
-			if _, blockedKey := blocked[key]; blockedKey {
-				continue
-			}
-		}
-		filtered = append(filtered, entry)
-	}
-	return filtered
 }

--- a/proto/cleanroom/v1/control.proto
+++ b/proto/cleanroom/v1/control.proto
@@ -96,8 +96,9 @@ message Policy {
   repeated PolicyAllowRule allow = 5;
   string hash = 6;
   PolicyServices services = 7;
-  optional bool mise_install = 8;
   PolicyDependencies dependencies = 9;
+  reserved 8;
+  reserved "mise_install";
 }
 
 message SandboxOptions {
@@ -248,11 +249,10 @@ enum ExecutionKind {
 }
 
 message ExecutionOptions {
-  reserved 2, 7;
-  reserved "read_only_workspace", "cwd";
+  reserved 2, 7, 8;
+  reserved "read_only_workspace", "cwd", "disable_mise";
   int64 launch_seconds = 5;
   bool tty = 6;
-  bool disable_mise = 8;
 }
 
 message CreateExecutionRequest {

--- a/proto/cleanroom/v1/control.proto
+++ b/proto/cleanroom/v1/control.proto
@@ -97,8 +97,6 @@ message Policy {
   string hash = 6;
   PolicyServices services = 7;
   PolicyDependencies dependencies = 9;
-  reserved 8;
-  reserved "mise_install";
 }
 
 message SandboxOptions {
@@ -249,8 +247,8 @@ enum ExecutionKind {
 }
 
 message ExecutionOptions {
-  reserved 2, 7, 8;
-  reserved "read_only_workspace", "cwd", "disable_mise";
+  reserved 2, 7;
+  reserved "read_only_workspace", "cwd";
   int64 launch_seconds = 5;
   bool tty = 6;
 }

--- a/scripts/ci-cleanroom-e2e.sh
+++ b/scripts/ci-cleanroom-e2e.sh
@@ -219,7 +219,7 @@ smoke_attempt=1
 smoke_max_attempts=3
 while true; do
   set +e
-  ./dist/cleanroom exec --host "$listen_endpoint" --no-mise -c "$PWD" -- sh -lc 'echo cleanroom-e2e' >"$tmpdir/exec.out" 2>"$tmpdir/exec.err"
+  ./dist/cleanroom exec --host "$listen_endpoint" -c "$PWD" -- sh -lc 'echo cleanroom-e2e' >"$tmpdir/exec.out" 2>"$tmpdir/exec.err"
   smoke_status=$?
   set -e
 
@@ -252,8 +252,8 @@ if [[ -z "$sandbox_id" ]]; then
 fi
 echo "sandbox id: $sandbox_id"
 
-./dist/cleanroom exec --host "$listen_endpoint" --no-mise --in "$sandbox_id" -- sh -lc 'printf persisted-data >/tmp/persist.txt'
-./dist/cleanroom exec --host "$listen_endpoint" --no-mise --in "$sandbox_id" -- sh -lc 'cat /tmp/persist.txt' | tee "$tmpdir/persist-read.out"
+./dist/cleanroom exec --host "$listen_endpoint" --in "$sandbox_id" -- sh -lc 'printf persisted-data >/tmp/persist.txt'
+./dist/cleanroom exec --host "$listen_endpoint" --in "$sandbox_id" -- sh -lc 'cat /tmp/persist.txt' | tee "$tmpdir/persist-read.out"
 if ! grep -q '^persisted-data$' "$tmpdir/persist-read.out"; then
   echo "expected persisted sandbox file contents from second execution" >&2
   exit 1
@@ -279,7 +279,7 @@ if ! grep -q 'sandbox terminated' "$tmpdir/sandbox-rm.out"; then
 fi
 
 set +e
-./dist/cleanroom exec --host "$listen_endpoint" --no-mise --in "$sandbox_id" -- sh -lc 'echo should-not-run' >"$tmpdir/terminated.out" 2>"$tmpdir/terminated.err"
+./dist/cleanroom exec --host "$listen_endpoint" --in "$sandbox_id" -- sh -lc 'echo should-not-run' >"$tmpdir/terminated.out" 2>"$tmpdir/terminated.err"
 terminated_status=$?
 set -e
 if [[ "$terminated_status" -eq 0 ]]; then
@@ -298,7 +298,7 @@ git_gateway_max_attempts=3
 while true; do
   set +e
   # shellcheck disable=SC2016
-  ./dist/cleanroom exec --host "$listen_endpoint" --no-mise -c "$PWD" -- sh -lc '
+  ./dist/cleanroom exec --host "$listen_endpoint" -c "$PWD" -- sh -lc '
   set -eu
 
   key="$(env | awk -F= '"'"'/^GIT_CONFIG_KEY_[0-9]+=url\.http:\/\/.+\/git\/github\.com\/\.insteadOf$/ {print $2; exit}'"'"')"

--- a/scripts/ci_cleanroom_e2e_test.go
+++ b/scripts/ci_cleanroom_e2e_test.go
@@ -90,9 +90,9 @@ func TestCiCleanroomE2EReusedSandboxExecOmitsChdir(t *testing.T) {
 
 	script := string(content)
 	for _, needle := range []string{
-		"./dist/cleanroom exec --host \"$listen_endpoint\" --no-mise --in \"$sandbox_id\" -- sh -lc 'printf persisted-data >/tmp/persist.txt'",
-		"./dist/cleanroom exec --host \"$listen_endpoint\" --no-mise --in \"$sandbox_id\" -- sh -lc 'cat /tmp/persist.txt' | tee \"$tmpdir/persist-read.out\"",
-		"./dist/cleanroom exec --host \"$listen_endpoint\" --no-mise --in \"$sandbox_id\" -- sh -lc 'echo should-not-run' >\"$tmpdir/terminated.out\" 2>\"$tmpdir/terminated.err\"",
+		"./dist/cleanroom exec --host \"$listen_endpoint\" --in \"$sandbox_id\" -- sh -lc 'printf persisted-data >/tmp/persist.txt'",
+		"./dist/cleanroom exec --host \"$listen_endpoint\" --in \"$sandbox_id\" -- sh -lc 'cat /tmp/persist.txt' | tee \"$tmpdir/persist-read.out\"",
+		"./dist/cleanroom exec --host \"$listen_endpoint\" --in \"$sandbox_id\" -- sh -lc 'echo should-not-run' >\"$tmpdir/terminated.out\" 2>\"$tmpdir/terminated.err\"",
 	} {
 		if !strings.Contains(script, needle) {
 			t.Fatalf("expected ci-cleanroom-e2e.sh to contain %q", needle)
@@ -116,8 +116,8 @@ func TestCiCleanroomE2EIsolatesCacheInTempDir(t *testing.T) {
 	for _, needle := range []string{
 		`export XDG_CACHE_HOME="$tmpdir/cache"`,
 		`mkdir -p "$XDG_CONFIG_HOME" "$XDG_CACHE_HOME" "$XDG_STATE_HOME" "$XDG_RUNTIME_DIR" "$XDG_DATA_HOME"`,
-		`./dist/cleanroom exec --host "$listen_endpoint" --no-mise -c "$PWD" -- sh -lc 'echo cleanroom-e2e'`,
-		`./dist/cleanroom exec --host "$listen_endpoint" --no-mise -c "$PWD" -- sh -lc '`,
+		`./dist/cleanroom exec --host "$listen_endpoint" -c "$PWD" -- sh -lc 'echo cleanroom-e2e'`,
+		`./dist/cleanroom exec --host "$listen_endpoint" -c "$PWD" -- sh -lc '`,
 	} {
 		if !strings.Contains(script, needle) {
 			t.Fatalf("expected ci-cleanroom-e2e.sh to contain %q", needle)


### PR DESCRIPTION
## Summary

Remove Cleanroom's first-class `mise` integration from policy, CLI, and runtime execution wrapping while keeping explicit `mise` usage available through generic dependency bootstrapping.

## What Changed

- removed policy and execution API support for automatic `mise` wrapping
- stopped repository-aware executions from auto-detecting `mise` config and injecting `mise exec -- ...`
- kept dependency-stage caching intact and updated examples to use explicit `sandbox.dependencies.command: [mise, exec, --, ...]`
- updated docs to describe the new explicit migration path
- left base images unchanged so the `mise` binary remains installed

## Why

The direct integration was redundant with the generic dependency snapshotting flow and made `mise` a special case in policy and execution behavior. Explicit dependency bootstrap commands keep the behavior backend-agnostic while still supporting `mise` when users want it.

## Validation

- `MISE_TRUSTED_CONFIG_PATHS="$PWD" mise exec -- go test ./internal/policy ./internal/repositorycheckout ./internal/controlservice ./internal/cli ./scripts/...`
- `MISE_TRUSTED_CONFIG_PATHS="$PWD" mise exec -- go test -run '^$' ./...`
