### PR TITLE
feat: Add daemon restart command

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,10 @@ cleanroom daemon install
 sudo cleanroom daemon install
 ```
 
-Use `--force` to overwrite an existing service file. On macOS, `--system`
-is unsupported; `--user` is accepted for explicitness.
+Use `cleanroom daemon install --force` to overwrite an existing service file.
+Use `cleanroom daemon restart --force` to start the daemon again if it is
+currently stopped. On macOS, `--system` is unsupported; `--user` is accepted
+for explicitness.
 
 Manage the daemon lifecycle:
 
@@ -81,6 +83,7 @@ Manage the daemon lifecycle:
 cleanroom daemon status
 cleanroom daemon start
 cleanroom daemon stop
+cleanroom daemon restart
 cleanroom daemon uninstall
 ```
 

--- a/internal/cli/cli_parse_test.go
+++ b/internal/cli/cli_parse_test.go
@@ -526,3 +526,18 @@ func TestDaemonStartSystemParses(t *testing.T) {
 		t.Fatal("expected --system to set Daemon.System")
 	}
 }
+
+func TestDaemonRestartForceParses(t *testing.T) {
+	c := &CLI{}
+	parser := newParserForTest(t, c)
+
+	if _, err := parser.Parse([]string{"daemon", "restart", "--force"}); err != nil {
+		t.Fatalf("parse daemon restart --force returned error: %v", err)
+	}
+	if got := c.Daemon.Action; got != "restart" {
+		t.Fatalf("expected daemon action restart, got %q", got)
+	}
+	if !c.Daemon.Force {
+		t.Fatal("expected --force to set Daemon.Force")
+	}
+}

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -15,10 +15,10 @@ import (
 )
 
 type DaemonCommand struct {
-	Action        string `arg:"" required:"" help:"Daemon action (install, uninstall, status, start, stop)"`
-	Force         bool   `help:"Overwrite existing daemon service file (daemon install only)"`
-	User          bool   `help:"Use user daemon scope (launchd only; install/uninstall/status/start/stop actions)"`
-	System        bool   `help:"Use system daemon scope (linux only; install/uninstall/status/start/stop actions)"`
+	Action        string `arg:"" required:"" help:"Daemon action (install, uninstall, status, start, stop, restart)"`
+	Force         bool   `help:"Overwrite an existing daemon service file (daemon install) or start a stopped daemon during restart (daemon restart)"`
+	User          bool   `help:"Use user daemon scope (launchd only; install/uninstall/status/start/stop/restart actions)"`
+	System        bool   `help:"Use system daemon scope (linux only; install/uninstall/status/start/stop/restart actions)"`
 	JSON          bool   `help:"Print daemon status as JSON (status action only)"`
 	Listen        string `help:"Listen endpoint for control API (defaults to runtime endpoint)"`
 	GatewayListen string `help:"Listen address for the host gateway (default :8170, use :0 for ephemeral port)"`
@@ -85,6 +85,8 @@ func (s *DaemonCommand) Run(ctx *runtimeContext) error {
 		return s.startDaemon(ctx)
 	case "stop":
 		return s.stopDaemon(ctx)
+	case "restart":
+		return s.restartDaemon(ctx)
 	default:
 		return fmt.Errorf("unsupported daemon action %q", s.Action)
 	}
@@ -305,6 +307,33 @@ func (s *DaemonCommand) stopDaemon(ctx *runtimeContext) error {
 	}
 
 	return stopFn(ctx.Stdout)
+}
+
+func (s *DaemonCommand) restartDaemon(ctx *runtimeContext) error {
+	scope, err := s.effectiveDaemonScope()
+	if err != nil {
+		return err
+	}
+
+	var restartFn func(io.Writer, bool) error
+	switch serveInstallGOOS {
+	case "linux":
+		restartFn = restartSystemdDaemon
+	case "darwin":
+		if scope == daemonScopeUser {
+			restartFn = restartLaunchdUserDaemon
+		} else {
+			restartFn = restartLaunchdDaemon
+		}
+	default:
+		return fmt.Errorf("daemon restart is unsupported on %s (expected linux or darwin)", serveInstallGOOS)
+	}
+
+	if scope == daemonScopeSystem && serveInstallEUID() != 0 {
+		return errors.New("daemon restart requires root privileges (use sudo cleanroom daemon restart)")
+	}
+
+	return restartFn(ctx.Stdout, s.Force)
 }
 
 func (s *DaemonCommand) daemonStatus(ctx *runtimeContext) error {

--- a/internal/cli/daemon_launchd.go
+++ b/internal/cli/daemon_launchd.go
@@ -172,6 +172,57 @@ func stopLaunchdDaemonInDomain(stdout io.Writer, servicePath, domain string) err
 	return err
 }
 
+func restartLaunchdDaemon(stdout io.Writer, force bool) error {
+	return restartLaunchdDaemonInDomain(stdout, serveInstallLaunchdPath, "system", force)
+}
+
+func restartLaunchdUserDaemon(stdout io.Writer, force bool) error {
+	path, err := launchdUserServicePath()
+	if err != nil {
+		return err
+	}
+	return restartLaunchdDaemonInDomain(stdout, path, launchdUserDomain(), force)
+}
+
+func restartLaunchdDaemonInDomain(stdout io.Writer, servicePath, domain string, force bool) error {
+	if _, err := serveInstallStat(servicePath); errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("service file %s does not exist", servicePath)
+	} else if err != nil {
+		return fmt.Errorf("stat service file %s: %w", servicePath, err)
+	}
+
+	target := launchdServiceTarget(domain)
+	loaded, state, err := launchdServiceStatus(target)
+	if err != nil {
+		return err
+	}
+	if state != "running" && !force {
+		return errors.New("daemon is not running (use cleanroom daemon restart --force to start it)")
+	}
+
+	if err := serveInstallRunCommand("launchctl", "enable", target); err != nil {
+		return fmt.Errorf("enable launchd service %s: %w", launchdServiceName, err)
+	}
+	if !loaded {
+		if err := serveInstallRunCommand("launchctl", "bootstrap", domain, servicePath); err != nil {
+			return fmt.Errorf("bootstrap launchd service %s: %w", launchdServiceName, err)
+		}
+	}
+	if err := serveInstallRunCommand("launchctl", "kickstart", "-k", target); err != nil {
+		return fmt.Errorf("restart launchd service %s: %w", launchdServiceName, err)
+	}
+
+	_, err = fmt.Fprint(stdout, renderSummaryBlock(summaryBlock{
+		Title:      "daemon restarted",
+		TitleStyle: defaultTerminalPalette().info,
+		Fields: []startupField{
+			{Key: "manager", Value: "launchd"},
+			{Key: "service", Value: launchdServiceName},
+		},
+	}, shouldUseANSI(stdout)))
+	return err
+}
+
 func launchdDaemonStatus() (daemonStatusResult, error) {
 	return launchdDaemonStatusInDomain(serveInstallLaunchdPath, "system")
 }
@@ -190,16 +241,11 @@ func launchdDaemonStatusInDomain(servicePath, domain string) (daemonStatusResult
 		installed = true
 	}
 
-	active := false
-	state := ""
-	if output, err := serveInstallRunCommandOutput("launchctl", "print", launchdServiceTarget(domain)); err == nil {
-		state = launchdServiceState(output)
-		if state == "running" {
-			active = true
-		}
-	} else if !isExitError(err) {
-		return daemonStatusResult{}, fmt.Errorf("check launchd service state: %w", err)
+	_, state, err := launchdServiceStatus(launchdServiceTarget(domain))
+	if err != nil {
+		return daemonStatusResult{}, err
 	}
+	active := state == "running"
 
 	listen := ""
 	if installed {
@@ -254,13 +300,19 @@ func launchdServiceState(output string) string {
 }
 
 func launchdServiceLoaded(target string) (bool, error) {
-	if _, err := serveInstallRunCommandOutput("launchctl", "print", target); err == nil {
-		return true, nil
-	} else if isExitError(err) {
-		return false, nil
-	} else {
-		return false, fmt.Errorf("check launchd service %s: %w", target, err)
+	loaded, _, err := launchdServiceStatus(target)
+	return loaded, err
+}
+
+func launchdServiceStatus(target string) (bool, string, error) {
+	output, err := serveInstallRunCommandOutput("launchctl", "print", target)
+	if err == nil {
+		return true, launchdServiceState(output), nil
 	}
+	if isExitError(err) {
+		return false, "", nil
+	}
+	return false, "", fmt.Errorf("check launchd service %s: %w", target, err)
 }
 
 func launchdConfiguredListenEndpoint(plistPath string) (string, error) {

--- a/internal/cli/daemon_systemd.go
+++ b/internal/cli/daemon_systemd.go
@@ -79,24 +79,48 @@ func stopSystemdDaemon(stdout io.Writer) error {
 	return err
 }
 
+func restartSystemdDaemon(stdout io.Writer, force bool) error {
+	if _, err := serveInstallStat(serveInstallSystemdUnitPath); errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("service file %s does not exist", serveInstallSystemdUnitPath)
+	}
+
+	active, err := systemdServiceActive()
+	if err != nil {
+		return err
+	}
+	if !active && !force {
+		return errors.New("daemon is not running (use cleanroom daemon restart --force to start it)")
+	}
+
+	if err := serveInstallRunCommand("systemctl", "restart", systemdServiceName); err != nil {
+		return fmt.Errorf("restart systemd service %s: %w", systemdServiceName, err)
+	}
+
+	_, err = fmt.Fprint(stdout, renderSummaryBlock(summaryBlock{
+		Title:      "daemon restarted",
+		TitleStyle: defaultTerminalPalette().info,
+		Fields: []startupField{
+			{Key: "manager", Value: "systemd"},
+			{Key: "service", Value: systemdServiceName},
+		},
+	}, shouldUseANSI(stdout)))
+	return err
+}
+
 func systemdDaemonStatus() (daemonStatusResult, error) {
 	installed := false
 	if _, err := serveInstallStat(serveInstallSystemdUnitPath); err == nil {
 		installed = true
 	}
 
-	active := false
-	if err := serveInstallRunCommand("systemctl", "is-active", "--quiet", systemdServiceName); err == nil {
-		active = true
-	} else if !isExitError(err) {
-		return daemonStatusResult{}, fmt.Errorf("check systemd service active state: %w", err)
+	active, err := systemdServiceActive()
+	if err != nil {
+		return daemonStatusResult{}, err
 	}
 
-	enabled := false
-	if err := serveInstallRunCommand("systemctl", "is-enabled", "--quiet", systemdServiceName); err == nil {
-		enabled = true
-	} else if !isExitError(err) {
-		return daemonStatusResult{}, fmt.Errorf("check systemd service enabled state: %w", err)
+	enabled, err := systemdServiceEnabled()
+	if err != nil {
+		return daemonStatusResult{}, err
 	}
 
 	return daemonStatusResult{
@@ -121,6 +145,26 @@ func systemdDaemonStatus() (daemonStatusResult, error) {
 			Enabled:   &enabled,
 		},
 	}, nil
+}
+
+func systemdServiceActive() (bool, error) {
+	if err := serveInstallRunCommand("systemctl", "is-active", "--quiet", systemdServiceName); err == nil {
+		return true, nil
+	} else if isExitError(err) {
+		return false, nil
+	} else {
+		return false, fmt.Errorf("check systemd service active state: %w", err)
+	}
+}
+
+func systemdServiceEnabled() (bool, error) {
+	if err := serveInstallRunCommand("systemctl", "is-enabled", "--quiet", systemdServiceName); err == nil {
+		return true, nil
+	} else if isExitError(err) {
+		return false, nil
+	} else {
+		return false, fmt.Errorf("check systemd service enabled state: %w", err)
+	}
 }
 
 func installSystemdDaemon(stdout io.Writer, executablePath string, args []string, force bool) error {

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -1200,6 +1200,102 @@ func TestDaemonStopSystemdStopsService(t *testing.T) {
 	}
 }
 
+func TestDaemonRestartSystemdRestartsRunningService(t *testing.T) {
+	tmpDir := t.TempDir()
+	unitPath := filepath.Join(tmpDir, "cleanroom.service")
+	if err := os.WriteFile(unitPath, []byte("existing-unit"), 0o644); err != nil {
+		t.Fatalf("write existing unit: %v", err)
+	}
+
+	prevEUID := serveInstallEUID
+	prevGOOS := serveInstallGOOS
+	prevSystemdPath := serveInstallSystemdUnitPath
+	prevRunCommand := serveInstallRunCommand
+	serveInstallEUID = func() int { return 0 }
+	serveInstallGOOS = "linux"
+	serveInstallSystemdUnitPath = unitPath
+	var calls [][]string
+	serveInstallRunCommand = func(name string, args ...string) error {
+		calls = append(calls, append([]string{name}, args...))
+		return nil
+	}
+	t.Cleanup(func() {
+		serveInstallEUID = prevEUID
+		serveInstallGOOS = prevGOOS
+		serveInstallSystemdUnitPath = prevSystemdPath
+		serveInstallRunCommand = prevRunCommand
+	})
+
+	stdout, readStdout := makeStdoutCapture(t)
+	cmd := &DaemonCommand{Action: "restart"}
+	if err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout}); err != nil {
+		t.Fatalf("DaemonCommand.Run returned error: %v", err)
+	}
+
+	wantCalls := [][]string{
+		{"systemctl", "is-active", "--quiet", "cleanroom.service"},
+		{"systemctl", "restart", "cleanroom.service"},
+	}
+	if !reflect.DeepEqual(calls, wantCalls) {
+		t.Fatalf("unexpected systemctl commands: got %v want %v", calls, wantCalls)
+	}
+
+	out := readStdout()
+	if !strings.Contains(out, "daemon restarted") {
+		t.Fatalf("expected restarted message, got: %s", out)
+	}
+	if !strings.Contains(out, "manager=systemd") {
+		t.Fatalf("expected manager=systemd, got: %s", out)
+	}
+}
+
+func TestDaemonRestartSystemdRequiresForceWhenStopped(t *testing.T) {
+	tmpDir := t.TempDir()
+	unitPath := filepath.Join(tmpDir, "cleanroom.service")
+	if err := os.WriteFile(unitPath, []byte("existing-unit"), 0o644); err != nil {
+		t.Fatalf("write existing unit: %v", err)
+	}
+
+	prevEUID := serveInstallEUID
+	prevGOOS := serveInstallGOOS
+	prevSystemdPath := serveInstallSystemdUnitPath
+	prevRunCommand := serveInstallRunCommand
+	serveInstallEUID = func() int { return 0 }
+	serveInstallGOOS = "linux"
+	serveInstallSystemdUnitPath = unitPath
+	var calls [][]string
+	serveInstallRunCommand = func(name string, args ...string) error {
+		calls = append(calls, append([]string{name}, args...))
+		if len(args) > 0 && args[0] == "is-active" {
+			return &exec.ExitError{ProcessState: &os.ProcessState{}}
+		}
+		return nil
+	}
+	t.Cleanup(func() {
+		serveInstallEUID = prevEUID
+		serveInstallGOOS = prevGOOS
+		serveInstallSystemdUnitPath = prevSystemdPath
+		serveInstallRunCommand = prevRunCommand
+	})
+
+	stdout, _ := makeStdoutCapture(t)
+	cmd := &DaemonCommand{Action: "restart"}
+	err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout})
+	if err == nil {
+		t.Fatal("expected restart to require --force when daemon is stopped")
+	}
+	if !strings.Contains(err.Error(), "--force") {
+		t.Fatalf("expected --force guidance, got: %v", err)
+	}
+
+	wantCalls := [][]string{
+		{"systemctl", "is-active", "--quiet", "cleanroom.service"},
+	}
+	if !reflect.DeepEqual(calls, wantCalls) {
+		t.Fatalf("unexpected systemctl commands: got %v want %v", calls, wantCalls)
+	}
+}
+
 func TestDaemonStartLaunchdEnablesBootstrapsAndKickstartsUserService(t *testing.T) {
 	tmpDir := t.TempDir()
 	plistPath := filepath.Join(tmpDir, "Library", "LaunchAgents", launchdServiceName+".plist")
@@ -1255,6 +1351,127 @@ func TestDaemonStartLaunchdEnablesBootstrapsAndKickstartsUserService(t *testing.
 	out := readStdout()
 	if !strings.Contains(out, "daemon started") {
 		t.Fatalf("expected started message, got: %s", out)
+	}
+	if !strings.Contains(out, "manager=launchd") {
+		t.Fatalf("expected manager=launchd, got: %s", out)
+	}
+}
+
+func TestDaemonRestartLaunchdKickstartsRunningUserService(t *testing.T) {
+	tmpDir := t.TempDir()
+	plistPath := filepath.Join(tmpDir, "Library", "LaunchAgents", launchdServiceName+".plist")
+	if err := os.MkdirAll(filepath.Dir(plistPath), 0o755); err != nil {
+		t.Fatalf("mkdir launch agents dir: %v", err)
+	}
+	if err := os.WriteFile(plistPath, []byte("existing-plist"), 0o644); err != nil {
+		t.Fatalf("write existing plist: %v", err)
+	}
+
+	prevGOOS := serveInstallGOOS
+	prevEUID := serveInstallEUID
+	prevUID := serveInstallUID
+	prevUserHomeDir := serveInstallUserHomeDir
+	prevRunCommand := serveInstallRunCommand
+	prevRunCommandOutput := serveInstallRunCommandOutput
+	serveInstallGOOS = "darwin"
+	serveInstallEUID = func() int { return 501 }
+	serveInstallUID = func() int { return 501 }
+	serveInstallUserHomeDir = func() (string, error) { return tmpDir, nil }
+	serveInstallRunCommandOutput = func(name string, args ...string) (string, error) {
+		return "state = running\n", nil
+	}
+	var calls [][]string
+	serveInstallRunCommand = func(name string, args ...string) error {
+		calls = append(calls, append([]string{name}, args...))
+		return nil
+	}
+	t.Cleanup(func() {
+		serveInstallGOOS = prevGOOS
+		serveInstallEUID = prevEUID
+		serveInstallUID = prevUID
+		serveInstallUserHomeDir = prevUserHomeDir
+		serveInstallRunCommand = prevRunCommand
+		serveInstallRunCommandOutput = prevRunCommandOutput
+	})
+
+	stdout, readStdout := makeStdoutCapture(t)
+	cmd := &DaemonCommand{Action: "restart"}
+	if err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout}); err != nil {
+		t.Fatalf("DaemonCommand.Run returned error: %v", err)
+	}
+
+	wantCalls := [][]string{
+		{"launchctl", "enable", "gui/501/" + launchdServiceName},
+		{"launchctl", "kickstart", "-k", "gui/501/" + launchdServiceName},
+	}
+	if !reflect.DeepEqual(calls, wantCalls) {
+		t.Fatalf("unexpected launchctl commands: got %v want %v", calls, wantCalls)
+	}
+
+	out := readStdout()
+	if !strings.Contains(out, "daemon restarted") {
+		t.Fatalf("expected restarted message, got: %s", out)
+	}
+	if !strings.Contains(out, "manager=launchd") {
+		t.Fatalf("expected manager=launchd, got: %s", out)
+	}
+}
+
+func TestDaemonRestartLaunchdForceBootstrapsStoppedUserService(t *testing.T) {
+	tmpDir := t.TempDir()
+	plistPath := filepath.Join(tmpDir, "Library", "LaunchAgents", launchdServiceName+".plist")
+	if err := os.MkdirAll(filepath.Dir(plistPath), 0o755); err != nil {
+		t.Fatalf("mkdir launch agents dir: %v", err)
+	}
+	if err := os.WriteFile(plistPath, []byte("existing-plist"), 0o644); err != nil {
+		t.Fatalf("write existing plist: %v", err)
+	}
+
+	prevGOOS := serveInstallGOOS
+	prevEUID := serveInstallEUID
+	prevUID := serveInstallUID
+	prevUserHomeDir := serveInstallUserHomeDir
+	prevRunCommand := serveInstallRunCommand
+	prevRunCommandOutput := serveInstallRunCommandOutput
+	serveInstallGOOS = "darwin"
+	serveInstallEUID = func() int { return 501 }
+	serveInstallUID = func() int { return 501 }
+	serveInstallUserHomeDir = func() (string, error) { return tmpDir, nil }
+	serveInstallRunCommandOutput = func(name string, args ...string) (string, error) {
+		return "", &exec.ExitError{ProcessState: &os.ProcessState{}}
+	}
+	var calls [][]string
+	serveInstallRunCommand = func(name string, args ...string) error {
+		calls = append(calls, append([]string{name}, args...))
+		return nil
+	}
+	t.Cleanup(func() {
+		serveInstallGOOS = prevGOOS
+		serveInstallEUID = prevEUID
+		serveInstallUID = prevUID
+		serveInstallUserHomeDir = prevUserHomeDir
+		serveInstallRunCommand = prevRunCommand
+		serveInstallRunCommandOutput = prevRunCommandOutput
+	})
+
+	stdout, readStdout := makeStdoutCapture(t)
+	cmd := &DaemonCommand{Action: "restart", Force: true}
+	if err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout}); err != nil {
+		t.Fatalf("DaemonCommand.Run returned error: %v", err)
+	}
+
+	wantCalls := [][]string{
+		{"launchctl", "enable", "gui/501/" + launchdServiceName},
+		{"launchctl", "bootstrap", "gui/501", plistPath},
+		{"launchctl", "kickstart", "-k", "gui/501/" + launchdServiceName},
+	}
+	if !reflect.DeepEqual(calls, wantCalls) {
+		t.Fatalf("unexpected launchctl commands: got %v want %v", calls, wantCalls)
+	}
+
+	out := readStdout()
+	if !strings.Contains(out, "daemon restarted") {
+		t.Fatalf("expected restarted message, got: %s", out)
 	}
 	if !strings.Contains(out, "manager=launchd") {
 		t.Fatalf("expected manager=launchd, got: %s", out)


### PR DESCRIPTION
## Summary
- add a `cleanroom daemon restart` action to the CLI
- support `--force` during restart so a stopped daemon can be started again
- cover restart behavior for both systemd and launchd, and document the new command in the README

## Why
Managing the daemon lifecycle required separate stop/start calls. This change adds a dedicated restart path with explicit behavior when the daemon is not already running.

## Impact
Users can now restart daemon-managed cleanroom services directly. On a stopped daemon, `cleanroom daemon restart` fails with guidance, while `cleanroom daemon restart --force` starts it again.

## Validation
- `go test ./internal/cli`
