### PR TITLE
feat: detect firecracker host support in config init and doctor

### DIFF
--- a/docs/backend/firecracker.md
+++ b/docs/backend/firecracker.md
@@ -8,6 +8,12 @@ Cleanroom's primary Linux backend uses [Firecracker](https://github.com/firecrac
 
 Firecracker is purpose-built for secure multi-tenant workloads with a minimal device model. Its network model (TAP + host firewall) maps directly to Cleanroom's deny-by-default enforcement.
 
+Today this backend is still a machine-bootstrap model rather than a pure
+unprivileged runtime. The user-facing CLI and runtime config remain
+unprivileged, but Linux hosts must be prepared with the Firecracker helper,
+sudoers access, KVM access, and optionally a dedicated ZFS dataset root for the
+supported layered-cache path.
+
 ## Scope
 
 - Linux-only local backend using Firecracker + KVM.
@@ -63,7 +69,45 @@ Current capability values (visible in `cleanroom doctor --json`):
 - Firecracker binary installed
 - `mkfs.ext4` for OCI-to-ext4 materialization
 - `debugfs` for runtime rootfs preparation
-- `sudo -n` access for privileged host networking (`ip`, `ipset`, `iptables`, `sysctl`)
+- root-owned `cleanroom-root-helper` installed at the configured helper path
+- `sudo -n` access for privileged host networking (`ip`, `ipset`, `iptables`, `sysctl`) through that helper
+- optional existing ZFS dataset root named `cleanroom` or matching
+  `*/cleanroom` for supported
+  Firecracker layered-cache restores
+
+## Machine Bootstrap vs User Config
+
+There are two separate layers to keep in mind on Linux:
+
+- machine bootstrap supplies the host prerequisites: helper install, sudoers,
+  KVM access, host commands, and optional ZFS dataset provisioning
+- user config selects how Cleanroom should use that machine state, including
+  whether Firecracker snapshots are enabled and whether they are file-backed or
+  ZFS-backed
+
+`cleanroom doctor` is the source of truth for the effective support tier on the
+current machine. It reports whether the helper-based Firecracker host runtime is
+usable at all, whether snapshotting is available, and whether the current state
+is on the supported ZFS-backed path or a degraded file-backed path.
+
+`cleanroom config init` uses feature detection, not profiles. On Linux it will:
+
+- enable Firecracker snapshots with `driver: zfs` when it finds one existing,
+  unambiguous Cleanroom dataset root
+- fall back to `driver: file` with a warning when the snapshot runtime is
+  usable but no usable ZFS dataset can be selected conservatively
+- leave snapshots disabled when the helper-based Firecracker snapshot runtime is
+  not usable yet
+
+## Layered Cache Support
+
+The currently supported Linux layered-cache path for Firecracker is ZFS-backed
+snapshot materialisation. That path gives clone-capable warm restores.
+
+File-backed Firecracker snapshots remain functional, but they are degraded for
+warm restores because writable volumes still copy ext4 bytes instead of cloning
+them. Release language should treat ZFS-backed Firecracker as the supported path
+and file-backed Firecracker as a fallback with slower restore behaviour.
 
 ## Related
 

--- a/docs/plans/firecracker-privilege-runtime.md
+++ b/docs/plans/firecracker-privilege-runtime.md
@@ -27,6 +27,18 @@ This proposal splits the problem into two tracks:
   network leases, gateway firewall state, optional snapshot backends, and
   Firecracker `jailer` launches.
 
+Near-term release work is intentionally narrower than this full plan. The
+current supported Linux story still uses the helper-based machine bootstrap.
+That means:
+
+- the helper, sudoers, KVM access, and related host commands are machine-level
+  prerequisites
+- runtime config remains a user-level choice layered on top of that bootstrap
+- ZFS-backed Firecracker is the supported layered-cache path
+- file-backed Firecracker remains functional but degraded for warm restores
+- `cleanroom doctor` is the source of truth for the current support tier on a
+  host while the broader `hostd` plan remains future work
+
 The user-facing CLI and API stay backend-neutral. Backend-specific privilege
 details remain in adapter internals and a small Linux host-runtime convention.
 The target is one supported Linux runtime model with good defaults.

--- a/docs/plans/layered-caching.md
+++ b/docs/plans/layered-caching.md
@@ -97,6 +97,12 @@ The remaining gap is deployment/runtime-dependent rather than architectural:
 the default Firecracker `file` driver still copies ext4 bytes, so the "nearly
 plain sandbox boot time" win only happens on clone-capable storage such as ZFS.
 
+For release framing, Linux CI and local Linux should be described with the same
+model: machine bootstrap plus unprivileged user workflow. The difference is not
+"CI mode" versus "local mode". The difference is whether the host has already
+been prepared with the Firecracker helper, sudoers access, KVM access, and an
+optional Cleanroom ZFS dataset root.
+
 ### Phase 3: Dedicated cache store and dependency stage
 
 Status: started.
@@ -140,6 +146,15 @@ This phase now means:
 - dependency-stage caching is starting with a single configured dependency
   bootstrap slice for exact-commit workspaces; toolchain-derived key inputs are
   still pending
+
+Today that means:
+
+- ZFS-backed Firecracker is the supported Linux layered-cache path
+- file-backed Firecracker remains functional, but warm restores are degraded
+  because they still materialise writable root volumes by copying bytes
+- `cleanroom doctor` should be treated as the source of truth for whether a
+  given Linux host is in the supported, degraded, or unavailable Firecracker
+  state
 
 ### Not started
 

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -839,13 +839,10 @@ func (a *Adapter) Doctor(_ context.Context, req backend.DoctorRequest) (*backend
 			if zfsBinary == "" {
 				appendCheck("snapshot_zfs_dataset_access", "fail", fmt.Sprintf("unable to access zfs dataset %q: zfs command not available", dataset))
 			} else {
-				out, err := runRootCommandOutput(context.Background(), req.FirecrackerConfig, "zfs", "list", "-H", "-d", "0", "-o", "name", dataset)
-				if err != nil {
-					appendCheck("snapshot_zfs_dataset_access", "fail", fmt.Sprintf("unable to access zfs dataset %q: %v", dataset, err))
-				} else if strings.TrimSpace(string(out)) != dataset {
-					appendCheck("snapshot_zfs_dataset_access", "fail", fmt.Sprintf("zfs dataset probe for %q returned %q", dataset, strings.TrimSpace(string(out))))
+				if err := validateZFSDatasetRoot(context.Background(), zfsBinary, dataset); err != nil {
+					appendCheck("snapshot_zfs_dataset_access", "fail", err.Error())
 				} else {
-					appendCheck("snapshot_zfs_dataset_access", "pass", fmt.Sprintf("zfs dataset %q is accessible", dataset))
+					appendCheck("snapshot_zfs_dataset_access", "pass", fmt.Sprintf("zfs dataset root %q is accessible", dataset))
 				}
 			}
 		}

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -839,7 +839,7 @@ func (a *Adapter) Doctor(_ context.Context, req backend.DoctorRequest) (*backend
 			if zfsBinary == "" {
 				appendCheck("snapshot_zfs_dataset_access", "fail", fmt.Sprintf("unable to access zfs dataset %q: zfs command not available", dataset))
 			} else {
-				if err := validateZFSDatasetRoot(context.Background(), zfsBinary, dataset); err != nil {
+				if err := validateZFSDatasetRoot(context.Background(), req.FirecrackerConfig, dataset); err != nil {
 					appendCheck("snapshot_zfs_dataset_access", "fail", err.Error())
 				} else {
 					appendCheck("snapshot_zfs_dataset_access", "pass", fmt.Sprintf("zfs dataset root %q is accessible", dataset))

--- a/internal/backend/firecracker/host_support.go
+++ b/internal/backend/firecracker/host_support.go
@@ -130,7 +130,7 @@ func DetectHostSupport(ctx context.Context, cfg backend.FirecrackerConfig) HostS
 
 	requestedDataset := strings.TrimSpace(cfg.Snapshots.ZFSDataset)
 	if requestedDataset != "" {
-		if err := validateZFSDatasetRoot(ctx, zfsPath, requestedDataset); err != nil {
+		if err := validateZFSDatasetRoot(ctx, cfg, requestedDataset); err != nil {
 			result.ZFSMessage = err.Error()
 			return result
 		}
@@ -152,7 +152,7 @@ func DetectHostSupport(ctx context.Context, cfg backend.FirecrackerConfig) HostS
 		result.ZFSMessage = "no existing Cleanroom ZFS dataset root matched cleanroom or */cleanroom"
 		return result
 	case 1:
-		if err := validateZFSDatasetRoot(ctx, zfsPath, candidates[0]); err != nil {
+		if err := validateZFSDatasetRoot(ctx, cfg, candidates[0]); err != nil {
 			result.ZFSMessage = err.Error()
 			return result
 		}
@@ -189,7 +189,7 @@ func discoverCleanroomZFSDatasetRoots(ctx context.Context, zfsPath string) ([]st
 	return candidates, nil
 }
 
-func validateZFSDatasetRoot(ctx context.Context, zfsPath, dataset string) error {
+func validateZFSDatasetRoot(ctx context.Context, cfg backend.FirecrackerConfig, dataset string) error {
 	dataset = strings.TrimSpace(dataset)
 	if dataset == "" {
 		return fmt.Errorf("zfs dataset root is empty")
@@ -197,7 +197,7 @@ func validateZFSDatasetRoot(ctx context.Context, zfsPath, dataset string) error 
 	if !isCleanroomZFSDatasetRoot(dataset) {
 		return fmt.Errorf("zfs dataset root %q must be cleanroom or */cleanroom", dataset)
 	}
-	out, err := hostSupportCommandOutput(ctx, zfsPath, "list", "-H", "-d", "0", "-o", "name", dataset)
+	out, err := runRootCommandOutput(ctx, cfg, "zfs", "list", "-H", "-d", "0", "-o", "name", dataset)
 	if err != nil {
 		return fmt.Errorf("unable to access zfs dataset root %q: %v", dataset, err)
 	}

--- a/internal/backend/firecracker/host_support.go
+++ b/internal/backend/firecracker/host_support.go
@@ -1,0 +1,216 @@
+package firecracker
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"slices"
+	"strings"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+)
+
+type HostSupport struct {
+	RuntimeUsable    bool
+	SnapshotsUsable  bool
+	ZFSUsable        bool
+	ZFSDatasetRoot   string
+	RuntimeMessage   string
+	SnapshotMessage  string
+	ZFSMessage       string
+	ZFSCandidates    []string
+	HelperPath       string
+	HelperVersion    string
+	HelperCaps       []string
+	RequiredCommands []string
+}
+
+var hostSupportLookPath = exec.LookPath
+
+var hostSupportCommandOutput = func(ctx context.Context, binary string, args ...string) ([]byte, error) {
+	return runCombinedCommandOutput(ctx, append([]string{binary}, args...), append([]string{binary}, args...))
+}
+
+func DetectHostSupport(ctx context.Context, cfg backend.FirecrackerConfig) HostSupport {
+	result := HostSupport{
+		HelperPath:       resolvePrivilegedHelperPath(cfg),
+		RequiredCommands: []string{"sudo", "ip", "iptables", "sysctl"},
+	}
+
+	if runtime.GOOS != "linux" {
+		result.RuntimeMessage = fmt.Sprintf("firecracker host runtime bootstrap is only available on linux (current host: %s)", runtime.GOOS)
+		result.SnapshotMessage = result.RuntimeMessage
+		result.ZFSMessage = result.RuntimeMessage
+		return result
+	}
+
+	missingCommands := make([]string, 0, len(result.RequiredCommands))
+	for _, command := range result.RequiredCommands {
+		if _, err := hostSupportLookPath(command); err != nil {
+			missingCommands = append(missingCommands, command)
+		}
+	}
+	if len(missingCommands) > 0 {
+		result.RuntimeMessage = fmt.Sprintf("missing required host commands: %s", strings.Join(missingCommands, ", "))
+		result.SnapshotMessage = result.RuntimeMessage
+		result.ZFSMessage = result.RuntimeMessage
+		return result
+	}
+
+	if _, err := os.Stat(result.HelperPath); err != nil {
+		result.RuntimeMessage = fmt.Sprintf("privileged helper %q is not accessible: %v", result.HelperPath, err)
+		result.SnapshotMessage = result.RuntimeMessage
+		result.ZFSMessage = result.RuntimeMessage
+		return result
+	}
+
+	version, err := helperVersion(ctx, cfg)
+	if err != nil {
+		result.RuntimeMessage = fmt.Sprintf("privileged helper version probe failed: %v", err)
+		result.SnapshotMessage = result.RuntimeMessage
+		result.ZFSMessage = result.RuntimeMessage
+		return result
+	}
+	result.HelperVersion = version
+
+	caps, err := helperCapabilities(ctx, cfg)
+	if err != nil {
+		result.RuntimeMessage = fmt.Sprintf("privileged helper capability probe failed: %v", err)
+		result.SnapshotMessage = result.RuntimeMessage
+		result.ZFSMessage = result.RuntimeMessage
+		return result
+	}
+	result.HelperCaps = append(result.HelperCaps, caps...)
+
+	runtimeMissingCaps := helperMissingCapabilities(caps, []string{
+		helperCapabilityFirecrackerNetwork,
+		helperCapabilityFirecrackerTrustedDNS,
+	})
+	if len(runtimeMissingCaps) > 0 {
+		result.RuntimeMessage = fmt.Sprintf("privileged helper is missing required capabilities: %s", strings.Join(runtimeMissingCaps, ", "))
+		result.SnapshotMessage = result.RuntimeMessage
+		result.ZFSMessage = result.RuntimeMessage
+		return result
+	}
+
+	if err := runRootCommand(ctx, cfg, "true"); err != nil {
+		result.RuntimeMessage = fmt.Sprintf("privileged command probe failed: %v", err)
+		result.SnapshotMessage = result.RuntimeMessage
+		result.ZFSMessage = result.RuntimeMessage
+		return result
+	}
+	if err := runRootCommand(ctx, cfg, "ip", "link", "show"); err != nil {
+		result.RuntimeMessage = fmt.Sprintf("privileged ip probe failed: %v", err)
+		result.SnapshotMessage = result.RuntimeMessage
+		result.ZFSMessage = result.RuntimeMessage
+		return result
+	}
+
+	result.RuntimeUsable = true
+	result.SnapshotsUsable = true
+	result.RuntimeMessage = fmt.Sprintf("helper-based firecracker host runtime is usable via %s (helper contract version %s)", result.HelperPath, result.HelperVersion)
+	result.SnapshotMessage = "firecracker snapshot runtime is usable"
+
+	if missingCaps := helperMissingCapabilities(caps, []string{helperCapabilityFirecrackerZFS}); len(missingCaps) > 0 {
+		result.ZFSMessage = fmt.Sprintf("privileged helper is missing required capabilities: %s", strings.Join(missingCaps, ", "))
+		return result
+	}
+
+	zfsPath, err := lookPathWithFallback("zfs", "/usr/sbin/zfs", "/sbin/zfs")
+	if err != nil {
+		result.ZFSMessage = fmt.Sprintf("zfs command not available: %v", err)
+		return result
+	}
+
+	requestedDataset := strings.TrimSpace(cfg.Snapshots.ZFSDataset)
+	if requestedDataset != "" {
+		if err := validateZFSDatasetRoot(ctx, zfsPath, requestedDataset); err != nil {
+			result.ZFSMessage = err.Error()
+			return result
+		}
+		result.ZFSUsable = true
+		result.ZFSDatasetRoot = requestedDataset
+		result.ZFSMessage = fmt.Sprintf("configured Cleanroom ZFS dataset root %q is usable", requestedDataset)
+		return result
+	}
+
+	candidates, err := discoverCleanroomZFSDatasetRoots(ctx, zfsPath)
+	if err != nil {
+		result.ZFSMessage = fmt.Sprintf("unable to enumerate ZFS datasets: %v", err)
+		return result
+	}
+	result.ZFSCandidates = append(result.ZFSCandidates, candidates...)
+
+	switch len(candidates) {
+	case 0:
+		result.ZFSMessage = "no existing Cleanroom ZFS dataset root matched cleanroom or */cleanroom"
+		return result
+	case 1:
+		if err := validateZFSDatasetRoot(ctx, zfsPath, candidates[0]); err != nil {
+			result.ZFSMessage = err.Error()
+			return result
+		}
+		result.ZFSUsable = true
+		result.ZFSDatasetRoot = candidates[0]
+		result.ZFSMessage = fmt.Sprintf("auto-detected Cleanroom ZFS dataset root %q", candidates[0])
+		return result
+	default:
+		result.ZFSMessage = fmt.Sprintf("multiple Cleanroom ZFS dataset roots detected: %s", strings.Join(candidates, ", "))
+		return result
+	}
+}
+
+func discoverCleanroomZFSDatasetRoots(ctx context.Context, zfsPath string) ([]string, error) {
+	out, err := hostSupportCommandOutput(ctx, zfsPath, "list", "-H", "-o", "name")
+	if err != nil {
+		return nil, err
+	}
+
+	seen := make(map[string]struct{})
+	var candidates []string
+	for _, line := range strings.Split(string(out), "\n") {
+		candidate := strings.TrimSpace(line)
+		if !isCleanroomZFSDatasetRoot(candidate) {
+			continue
+		}
+		if _, ok := seen[candidate]; ok {
+			continue
+		}
+		seen[candidate] = struct{}{}
+		candidates = append(candidates, candidate)
+	}
+	slices.Sort(candidates)
+	return candidates, nil
+}
+
+func validateZFSDatasetRoot(ctx context.Context, zfsPath, dataset string) error {
+	dataset = strings.TrimSpace(dataset)
+	if dataset == "" {
+		return fmt.Errorf("zfs dataset root is empty")
+	}
+	if !isCleanroomZFSDatasetRoot(dataset) {
+		return fmt.Errorf("zfs dataset root %q must be cleanroom or */cleanroom", dataset)
+	}
+	out, err := hostSupportCommandOutput(ctx, zfsPath, "list", "-H", "-d", "0", "-o", "name", dataset)
+	if err != nil {
+		return fmt.Errorf("unable to access zfs dataset root %q: %v", dataset, err)
+	}
+	if strings.TrimSpace(string(out)) != dataset {
+		return fmt.Errorf("zfs dataset probe for %q returned %q", dataset, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+func isCleanroomZFSDatasetRoot(dataset string) bool {
+	dataset = strings.Trim(strings.TrimSpace(dataset), "/")
+	if dataset == "" {
+		return false
+	}
+	if dataset == "cleanroom" {
+		return true
+	}
+	parts := strings.Split(dataset, "/")
+	return parts[len(parts)-1] == "cleanroom"
+}

--- a/internal/backend/firecracker/host_support.go
+++ b/internal/backend/firecracker/host_support.go
@@ -29,6 +29,10 @@ type HostSupport struct {
 
 var hostSupportLookPath = exec.LookPath
 
+var hostSupportResolveCommand = resolveHostSupportCommandPath
+
+var hostSupportGOOS = runtime.GOOS
+
 var hostSupportCommandOutput = func(ctx context.Context, binary string, args ...string) ([]byte, error) {
 	return runCombinedCommandOutput(ctx, append([]string{binary}, args...), append([]string{binary}, args...))
 }
@@ -39,8 +43,8 @@ func DetectHostSupport(ctx context.Context, cfg backend.FirecrackerConfig) HostS
 		RequiredCommands: []string{"sudo", "ip", "iptables", "sysctl"},
 	}
 
-	if runtime.GOOS != "linux" {
-		result.RuntimeMessage = fmt.Sprintf("firecracker host runtime bootstrap is only available on linux (current host: %s)", runtime.GOOS)
+	if hostSupportGOOS != "linux" {
+		result.RuntimeMessage = fmt.Sprintf("firecracker host runtime bootstrap is only available on linux (current host: %s)", hostSupportGOOS)
 		result.SnapshotMessage = result.RuntimeMessage
 		result.ZFSMessage = result.RuntimeMessage
 		return result
@@ -48,7 +52,7 @@ func DetectHostSupport(ctx context.Context, cfg backend.FirecrackerConfig) HostS
 
 	missingCommands := make([]string, 0, len(result.RequiredCommands))
 	for _, command := range result.RequiredCommands {
-		if _, err := hostSupportLookPath(command); err != nil {
+		if _, err := hostSupportResolveCommand(command); err != nil {
 			missingCommands = append(missingCommands, command)
 		}
 	}
@@ -213,4 +217,19 @@ func isCleanroomZFSDatasetRoot(dataset string) bool {
 	}
 	parts := strings.Split(dataset, "/")
 	return parts[len(parts)-1] == "cleanroom"
+}
+
+func resolveHostSupportCommandPath(command string) (string, error) {
+	switch strings.TrimSpace(command) {
+	case "sudo":
+		return lookPathWithFallback(command, "/usr/bin/sudo", "/bin/sudo")
+	case "ip":
+		return lookPathWithFallback(command, "/usr/sbin/ip", "/sbin/ip")
+	case "iptables":
+		return lookPathWithFallback(command, "/usr/sbin/iptables", "/sbin/iptables")
+	case "sysctl":
+		return lookPathWithFallback(command, "/usr/sbin/sysctl", "/sbin/sysctl")
+	default:
+		return hostSupportLookPath(command)
+	}
 }

--- a/internal/backend/firecracker/host_support_test.go
+++ b/internal/backend/firecracker/host_support_test.go
@@ -92,3 +92,70 @@ esac
 		t.Fatalf("expected runtime usable with fallback command resolution, got %+v", support)
 	}
 }
+
+func TestDetectHostSupportUsesHelperForZFSDatasetValidation(t *testing.T) {
+	prevResolveCommand := hostSupportResolveCommand
+	prevGOOS := hostSupportGOOS
+	t.Cleanup(func() {
+		hostSupportResolveCommand = prevResolveCommand
+		hostSupportGOOS = prevGOOS
+	})
+
+	hostSupportGOOS = "linux"
+	hostSupportResolveCommand = func(command string) (string, error) {
+		switch command {
+		case "sudo", "ip", "iptables", "sysctl":
+			return "/fallback/" + command, nil
+		default:
+			return "", nil
+		}
+	}
+
+	tmpDir := t.TempDir()
+	setupFakeSudo(t, filepath.Join(tmpDir, "sudo.log"))
+	zfsPath := writeExecutable(t, tmpDir, "zfs", "#!/bin/sh\nset -eu\necho 'direct zfs access should not be used for dataset validation' >&2\nexit 23\n")
+	t.Setenv("PATH", tmpDir+":"+os.Getenv("PATH"))
+	helperPath := writeExecutable(t, tmpDir, "cleanroom-root-helper", `#!/bin/sh
+set -eu
+case "$1" in
+  version) printf '6
+' ;;
+  capabilities) printf 'firecracker-network
+firecracker-trusted-dns
+firecracker-zfs
+' ;;
+  true) exit 0 ;;
+  ip) exit 0 ;;
+  zfs)
+    if [ "$2" = "list" ] && [ "$3" = "-H" ] && [ "$4" = "-d" ] && [ "$5" = "0" ] && [ "$6" = "-o" ] && [ "$7" = "name" ]; then
+      printf '%s
+' "$8"
+      exit 0
+    fi
+    echo 'unexpected helper zfs args' >&2
+    exit 2
+    ;;
+  *) exit 0 ;;
+esac
+`)
+	if _, err := os.Stat(helperPath); err != nil {
+		t.Fatalf("stat helper path: %v", err)
+	}
+	if _, err := os.Stat(zfsPath); err != nil {
+		t.Fatalf("stat zfs path: %v", err)
+	}
+
+	support := DetectHostSupport(context.Background(), backend.FirecrackerConfig{
+		PrivilegedHelperPath: helperPath,
+		Snapshots: backend.SnapshotConfig{
+			Driver:     "zfs",
+			ZFSDataset: "cleanroom",
+		},
+	})
+	if !support.ZFSUsable {
+		t.Fatalf("expected zfs usable when helper can validate dataset, got %+v", support)
+	}
+	if got, want := support.ZFSDatasetRoot, "cleanroom"; got != want {
+		t.Fatalf("unexpected zfs dataset root: got %q want %q", got, want)
+	}
+}

--- a/internal/backend/firecracker/host_support_test.go
+++ b/internal/backend/firecracker/host_support_test.go
@@ -2,8 +2,12 @@ package firecracker
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
+
+	"github.com/buildkite/cleanroom/internal/backend"
 )
 
 func TestDiscoverCleanroomZFSDatasetRootsAcceptsDedicatedCleanroomPool(t *testing.T) {
@@ -43,5 +47,48 @@ func TestIsCleanroomZFSDatasetRoot(t *testing.T) {
 				t.Fatalf("isCleanroomZFSDatasetRoot(%q) = %t, want %t", tt.dataset, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestDetectHostSupportUsesHelperCompatibleCommandFallbacks(t *testing.T) {
+	prevResolveCommand := hostSupportResolveCommand
+	prevGOOS := hostSupportGOOS
+	t.Cleanup(func() {
+		hostSupportResolveCommand = prevResolveCommand
+		hostSupportGOOS = prevGOOS
+	})
+
+	hostSupportGOOS = "linux"
+	hostSupportResolveCommand = func(command string) (string, error) {
+		switch command {
+		case "sudo", "ip", "iptables", "sysctl":
+			return "/fallback/" + command, nil
+		default:
+			return "", nil
+		}
+	}
+
+	tmpDir := t.TempDir()
+	setupFakeSudo(t, filepath.Join(tmpDir, "sudo.log"))
+	helperPath := writeExecutable(t, tmpDir, "cleanroom-root-helper", `#!/bin/sh
+set -eu
+case "$1" in
+  version) printf '6
+' ;;
+  capabilities) printf 'firecracker-network
+firecracker-trusted-dns
+' ;;
+  true) exit 0 ;;
+  ip) exit 0 ;;
+  *) exit 0 ;;
+esac
+`)
+	if _, err := os.Stat(helperPath); err != nil {
+		t.Fatalf("stat helper path: %v", err)
+	}
+
+	support := DetectHostSupport(context.Background(), backend.FirecrackerConfig{PrivilegedHelperPath: helperPath})
+	if !support.RuntimeUsable {
+		t.Fatalf("expected runtime usable with fallback command resolution, got %+v", support)
 	}
 }

--- a/internal/backend/firecracker/host_support_test.go
+++ b/internal/backend/firecracker/host_support_test.go
@@ -1,0 +1,47 @@
+package firecracker
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+func TestDiscoverCleanroomZFSDatasetRootsAcceptsDedicatedCleanroomPool(t *testing.T) {
+	prev := hostSupportCommandOutput
+	hostSupportCommandOutput = func(context.Context, string, ...string) ([]byte, error) {
+		return []byte("cleanroom\ncleanroom/data\ncleanroom/data/snapshots\n"), nil
+	}
+	t.Cleanup(func() {
+		hostSupportCommandOutput = prev
+	})
+
+	got, err := discoverCleanroomZFSDatasetRoots(context.Background(), "/usr/sbin/zfs")
+	if err != nil {
+		t.Fatalf("discoverCleanroomZFSDatasetRoots returned error: %v", err)
+	}
+	if want := []string{"cleanroom"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected dataset roots: got %v want %v", got, want)
+	}
+}
+
+func TestIsCleanroomZFSDatasetRoot(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		dataset string
+		want    bool
+	}{
+		{name: "dedicated cleanroom pool", dataset: "cleanroom", want: true},
+		{name: "nested cleanroom dataset", dataset: "tank/cleanroom", want: true},
+		{name: "cleanroom child dataset", dataset: "cleanroom/data", want: false},
+		{name: "non cleanroom dataset", dataset: "tank/data", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isCleanroomZFSDatasetRoot(tt.dataset); got != tt.want {
+				t.Fatalf("isCleanroomZFSDatasetRoot(%q) = %t, want %t", tt.dataset, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/backend/firecracker/privileged_test.go
+++ b/internal/backend/firecracker/privileged_test.go
@@ -311,8 +311,8 @@ func TestDoctorReportsZFSChecks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read helper log: %v", err)
 	}
-	if strings.Contains(string(logBytes), "zfs list -H -d 0 -o name tank/cleanroom") {
-		t.Fatalf("expected zfs dataset root probe to avoid the privileged helper, got log %q", string(logBytes))
+	if !strings.Contains(string(logBytes), "zfs list -H -d 0 -o name tank/cleanroom") {
+		t.Fatalf("expected zfs dataset root probe to use the privileged helper, got log %q", string(logBytes))
 	}
 }
 

--- a/internal/backend/firecracker/privileged_test.go
+++ b/internal/backend/firecracker/privileged_test.go
@@ -311,8 +311,8 @@ func TestDoctorReportsZFSChecks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read helper log: %v", err)
 	}
-	if !strings.Contains(string(logBytes), "zfs list -H -d 0 -o name tank/cleanroom") {
-		t.Fatalf("expected helper-mediated zfs probe, got log %q", string(logBytes))
+	if strings.Contains(string(logBytes), "zfs list -H -d 0 -o name tank/cleanroom") {
+		t.Fatalf("expected zfs dataset root probe to avoid the privileged helper, got log %q", string(logBytes))
 	}
 }
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -37,6 +37,7 @@ type policyLoader interface {
 type runtimeContext struct {
 	CWD        string
 	Stdout     *os.File
+	Stderr     *os.File
 	Loader     policyLoader
 	Config     runtimeconfig.Config
 	ConfigPath string
@@ -118,6 +119,7 @@ func Run(args []string, version string) error {
 
 	runtimeCtx := &runtimeContext{
 		Stdout:     os.Stdout,
+		Stderr:     os.Stderr,
 		Loader:     policy.Loader{},
 		Config:     cfg,
 		ConfigPath: cfgPath,
@@ -175,4 +177,11 @@ func resolveCWD(base, chdir string) (string, error) {
 		return filepath.Clean(chdir), nil
 	}
 	return filepath.Join(base, chdir), nil
+}
+
+func (ctx *runtimeContext) stderr() *os.File {
+	if ctx != nil && ctx.Stderr != nil {
+		return ctx.Stderr
+	}
+	return os.Stderr
 }

--- a/internal/cli/config_init_test.go
+++ b/internal/cli/config_init_test.go
@@ -1,22 +1,34 @@
 package cli
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/buildkite/cleanroom/internal/backend"
+	backendfirecracker "github.com/buildkite/cleanroom/internal/backend/firecracker"
 	"github.com/buildkite/cleanroom/internal/runtimeconfig"
 	"gopkg.in/yaml.v3"
 )
 
 func TestConfigInitWritesRuntimeConfig(t *testing.T) {
+	stubFirecrackerHostSupport(t, func(context.Context, backend.FirecrackerConfig) backendfirecracker.HostSupport {
+		return backendfirecracker.HostSupport{
+			RuntimeUsable:   false,
+			SnapshotsUsable: false,
+			SnapshotMessage: "machine bootstrap incomplete",
+		}
+	})
+
 	tmpDir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmpDir)
 
 	stdout, _ := makeStdoutCapture(t)
+	stderr, _ := makeStdoutCapture(t)
 	cmd := &ConfigInitCommand{}
-	if err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout}); err != nil {
+	if err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout, Stderr: stderr}); err != nil {
 		t.Fatalf("ConfigInitCommand.Run returned error: %v", err)
 	}
 
@@ -90,6 +102,10 @@ func TestConfigInitWritesRuntimeConfig(t *testing.T) {
 }
 
 func TestConfigInitRefusesOverwriteWithoutForce(t *testing.T) {
+	stubFirecrackerHostSupport(t, func(context.Context, backend.FirecrackerConfig) backendfirecracker.HostSupport {
+		return backendfirecracker.HostSupport{}
+	})
+
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "cleanroom", "config.yaml")
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
@@ -120,6 +136,10 @@ func TestConfigInitRefusesOverwriteWithoutForce(t *testing.T) {
 }
 
 func TestConfigInitForceOverwritesExistingFile(t *testing.T) {
+	stubFirecrackerHostSupport(t, func(context.Context, backend.FirecrackerConfig) backendfirecracker.HostSupport {
+		return backendfirecracker.HostSupport{}
+	})
+
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "runtime", "cleanroom.yaml")
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
@@ -144,5 +164,132 @@ func TestConfigInitForceOverwritesExistingFile(t *testing.T) {
 	}
 	if strings.Contains(string(raw), "existing: true") {
 		t.Fatalf("expected config to be overwritten, got:\n%s", raw)
+	}
+}
+
+func TestConfigInitUsesFileSnapshotsWhenZFSUnavailable(t *testing.T) {
+	stubFirecrackerHostSupport(t, func(context.Context, backend.FirecrackerConfig) backendfirecracker.HostSupport {
+		return backendfirecracker.HostSupport{
+			RuntimeUsable:   true,
+			SnapshotsUsable: true,
+			ZFSUsable:       false,
+			ZFSMessage:      "no existing Cleanroom ZFS dataset root matched cleanroom or */cleanroom",
+		}
+	})
+
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	stdout, _ := makeStdoutCapture(t)
+	stderr, readStderr := makeStdoutCapture(t)
+	cmd := &ConfigInitCommand{DefaultBackend: "firecracker"}
+	if err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout, Stderr: stderr}); err != nil {
+		t.Fatalf("ConfigInitCommand.Run returned error: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(tmpDir, "cleanroom", "config.yaml"))
+	if err != nil {
+		t.Fatalf("read generated config: %v", err)
+	}
+
+	var cfg runtimeconfig.Config
+	if err := yaml.Unmarshal(raw, &cfg); err != nil {
+		t.Fatalf("parse generated yaml: %v", err)
+	}
+	if !cfg.Backends.Firecracker.Snapshots.Enabled {
+		t.Fatal("expected firecracker snapshots to default enabled when snapshot runtime is usable")
+	}
+	if got, want := cfg.Backends.Firecracker.Snapshots.Driver, "file"; got != want {
+		t.Fatalf("unexpected firecracker snapshot driver: got %q want %q", got, want)
+	}
+	if cfg.Backends.Firecracker.Snapshots.ZFSDataset != "" {
+		t.Fatalf("expected firecracker zfs dataset to be omitted, got %q", cfg.Backends.Firecracker.Snapshots.ZFSDataset)
+	}
+	if out := readStderr(); !strings.Contains(out, "driver=file") || !strings.Contains(out, "no existing Cleanroom ZFS dataset root matched cleanroom or */cleanroom") {
+		t.Fatalf("expected file-driver warning, got %q", out)
+	}
+}
+
+func TestConfigInitUsesZFSWhenCleanroomDatasetDetected(t *testing.T) {
+	stubFirecrackerHostSupport(t, func(context.Context, backend.FirecrackerConfig) backendfirecracker.HostSupport {
+		return backendfirecracker.HostSupport{
+			RuntimeUsable:   true,
+			SnapshotsUsable: true,
+			ZFSUsable:       true,
+			ZFSDatasetRoot:  "cleanroom",
+			ZFSMessage:      "auto-detected Cleanroom ZFS dataset root \"cleanroom\"",
+		}
+	})
+
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	stdout, _ := makeStdoutCapture(t)
+	stderr, readStderr := makeStdoutCapture(t)
+	cmd := &ConfigInitCommand{DefaultBackend: "firecracker"}
+	if err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout, Stderr: stderr}); err != nil {
+		t.Fatalf("ConfigInitCommand.Run returned error: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(tmpDir, "cleanroom", "config.yaml"))
+	if err != nil {
+		t.Fatalf("read generated config: %v", err)
+	}
+
+	var cfg runtimeconfig.Config
+	if err := yaml.Unmarshal(raw, &cfg); err != nil {
+		t.Fatalf("parse generated yaml: %v", err)
+	}
+	if !cfg.Backends.Firecracker.Snapshots.Enabled {
+		t.Fatal("expected firecracker snapshots enabled for zfs-capable host runtime")
+	}
+	if got, want := cfg.Backends.Firecracker.Snapshots.Driver, "zfs"; got != want {
+		t.Fatalf("unexpected firecracker snapshot driver: got %q want %q", got, want)
+	}
+	if got, want := cfg.Backends.Firecracker.Snapshots.ZFSDataset, "cleanroom"; got != want {
+		t.Fatalf("unexpected firecracker zfs dataset: got %q want %q", got, want)
+	}
+	if out := strings.TrimSpace(readStderr()); out != "" {
+		t.Fatalf("expected no warning output, got %q", out)
+	}
+}
+
+func TestConfigInitWarnsWhenZFSDatasetDetectionIsAmbiguous(t *testing.T) {
+	stubFirecrackerHostSupport(t, func(context.Context, backend.FirecrackerConfig) backendfirecracker.HostSupport {
+		return backendfirecracker.HostSupport{
+			RuntimeUsable:   true,
+			SnapshotsUsable: true,
+			ZFSUsable:       false,
+			ZFSMessage:      "multiple Cleanroom ZFS dataset roots detected: tank/ci/cleanroom, tank/dev/cleanroom",
+		}
+	})
+
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	stdout, _ := makeStdoutCapture(t)
+	stderr, readStderr := makeStdoutCapture(t)
+	cmd := &ConfigInitCommand{DefaultBackend: "firecracker"}
+	if err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout, Stderr: stderr}); err != nil {
+		t.Fatalf("ConfigInitCommand.Run returned error: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(tmpDir, "cleanroom", "config.yaml"))
+	if err != nil {
+		t.Fatalf("read generated config: %v", err)
+	}
+
+	var cfg runtimeconfig.Config
+	if err := yaml.Unmarshal(raw, &cfg); err != nil {
+		t.Fatalf("parse generated yaml: %v", err)
+	}
+	if got, want := cfg.Backends.Firecracker.Snapshots.Driver, "file"; got != want {
+		t.Fatalf("unexpected firecracker snapshot driver: got %q want %q", got, want)
+	}
+	if !cfg.Backends.Firecracker.Snapshots.Enabled {
+		t.Fatal("expected firecracker snapshots enabled with file fallback when zfs detection is ambiguous")
+	}
+	if out := readStderr(); !strings.Contains(out, "multiple Cleanroom ZFS dataset roots detected") || !strings.Contains(out, "tank/ci/cleanroom") {
+		t.Fatalf("expected ambiguous zfs warning, got %q", out)
 	}
 }

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/buildkite/cleanroom/internal/backend"
+	backendfirecracker "github.com/buildkite/cleanroom/internal/backend/firecracker"
 	"github.com/buildkite/cleanroom/internal/gateway"
 	"github.com/buildkite/cleanroom/internal/paths"
 	"github.com/buildkite/cleanroom/internal/runtimeconfig"
@@ -24,6 +25,15 @@ type snapshotDoctorConfig struct {
 	Driver    string `json:"driver"`
 	BaseDir   string `json:"base_dir"`
 	Defaulted bool   `json:"defaulted"`
+}
+
+type doctorSupportSummary struct {
+	Tier              string `json:"tier"`
+	Message           string `json:"message"`
+	HostRuntimeUsable bool   `json:"host_runtime_usable"`
+	SnapshotsUsable   bool   `json:"snapshots_usable"`
+	ZFSUsable         bool   `json:"zfs_usable"`
+	ZFSDatasetRoot    string `json:"zfs_dataset_root,omitempty"`
 }
 
 func (d *DoctorCommand) Run(ctx *runtimeContext) error {
@@ -47,10 +57,16 @@ func (d *DoctorCommand) Run(ctx *runtimeContext) error {
 	}
 	routeSummary := strings.Join(gwRoutes, ", ")
 	snapshotCfg, snapshotCheck, hasSnapshotCfg := snapshotDoctorConfigForBackend(backendName, ctx.Config)
+	var supportSummary *doctorSupportSummary
 
 	checks := []backend.DoctorCheck{
 		{Name: "runtime_config", Status: "pass", Message: fmt.Sprintf("using runtime config path %s", ctx.ConfigPath)},
 		{Name: "backend", Status: "pass", Message: fmt.Sprintf("selected backend %s", backendName)},
+	}
+	if backendName == "firecracker" {
+		summary, check := firecrackerDoctorSupportSummary(detectFirecrackerHostSupport(context.Background(), runtimeconfig.MergeBackendConfig(ctx.Config, backendName, 0)), ctx.Config.Backends.Firecracker.Snapshots)
+		supportSummary = &summary
+		checks = append(checks, check)
 	}
 	if hasSnapshotCfg {
 		checks = append(checks, snapshotCheck)
@@ -137,6 +153,9 @@ func (d *DoctorCommand) Run(ctx *runtimeContext) error {
 		}
 		if hasSnapshotCfg {
 			payload["snapshot"] = snapshotCfg
+		}
+		if supportSummary != nil {
+			payload["support"] = supportSummary
 		}
 		enc := json.NewEncoder(ctx.Stdout)
 		enc.SetIndent("", "  ")
@@ -246,5 +265,73 @@ func snapshotConfigEnableHint(backendName string) string {
 		return "backends.firecracker.snapshots.enabled: true"
 	default:
 		return "backends.<backend>.snapshots.enabled: true"
+	}
+}
+
+func firecrackerDoctorSupportSummary(support backendfirecracker.HostSupport, snapshotCfg runtimeconfig.SnapshotConfig) (doctorSupportSummary, backend.DoctorCheck) {
+	summary := doctorSupportSummary{
+		HostRuntimeUsable: support.RuntimeUsable,
+		SnapshotsUsable:   support.SnapshotsUsable,
+		ZFSUsable:         support.ZFSUsable,
+		ZFSDatasetRoot:    support.ZFSDatasetRoot,
+	}
+
+	check := backend.DoctorCheck{Name: "support_tier"}
+	driver := runtimeconfig.SnapshotDriverOrDefault("firecracker", snapshotCfg.Driver)
+
+	if !support.RuntimeUsable {
+		summary.Tier = "unsupported"
+		summary.Message = "unsupported: machine bootstrap incomplete for firecracker host runtime: " + support.RuntimeMessage
+		check.Status = "fail"
+		check.Message = summary.Message
+		return summary, check
+	}
+
+	if !snapshotCfg.Enabled {
+		summary.Tier = "disabled"
+		summary.Message = "disabled: firecracker snapshot runtime is available, but snapshots are disabled in runtime config"
+		check.Status = "warn"
+		check.Message = summary.Message
+		return summary, check
+	}
+
+	switch driver {
+	case "zfs":
+		dataset := strings.TrimSpace(snapshotCfg.ZFSDataset)
+		if !support.ZFSUsable {
+			summary.Tier = "unsupported"
+			summary.Message = "unsupported: firecracker zfs-backed snapshots are configured, but host support is not usable: " + support.ZFSMessage
+			check.Status = "fail"
+			check.Message = summary.Message
+			return summary, check
+		}
+		if dataset == "" {
+			summary.Tier = "unsupported"
+			summary.Message = "unsupported: firecracker zfs-backed snapshots require backends.firecracker.snapshots.zfs_dataset"
+			check.Status = "fail"
+			check.Message = summary.Message
+			return summary, check
+		}
+		summary.Tier = "supported"
+		summary.ZFSDatasetRoot = dataset
+		summary.Message = fmt.Sprintf("supported: zfs-backed firecracker layered caching is available via dataset root %s", dataset)
+		check.Status = "pass"
+		check.Message = summary.Message
+		return summary, check
+	case "file":
+		summary.Tier = "degraded"
+		summary.Message = "degraded: firecracker layered caching is file-backed; warm restores still copy bytes"
+		if support.ZFSUsable && support.ZFSDatasetRoot != "" {
+			summary.Message += fmt.Sprintf(" (machine bootstrap can support zfs via %s)", support.ZFSDatasetRoot)
+		}
+		check.Status = "warn"
+		check.Message = summary.Message
+		return summary, check
+	default:
+		summary.Tier = "unsupported"
+		summary.Message = fmt.Sprintf("unsupported: firecracker snapshot driver %q is not recognised", snapshotCfg.Driver)
+		check.Status = "fail"
+		check.Message = summary.Message
+		return summary, check
 	}
 }

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/buildkite/cleanroom/internal/backend"
+	backendfirecracker "github.com/buildkite/cleanroom/internal/backend/firecracker"
 	"github.com/buildkite/cleanroom/internal/policy"
 	"github.com/buildkite/cleanroom/internal/runtimeconfig"
 )
@@ -397,5 +398,156 @@ func TestDoctorCommandTextIncludesEffectiveSnapshotConfig(t *testing.T) {
 	}
 	if !strings.Contains(out, filepath.Join(tmpDir, "state", "cleanroom", "snapshots")) {
 		t.Fatalf("expected snapshot base dir in doctor output, got: %q", out)
+	}
+}
+
+func TestDoctorCommandReportsSupportedFirecrackerTierInJSON(t *testing.T) {
+	stubFirecrackerHostSupport(t, func(context.Context, backend.FirecrackerConfig) backendfirecracker.HostSupport {
+		return backendfirecracker.HostSupport{
+			RuntimeUsable:   true,
+			SnapshotsUsable: true,
+			ZFSUsable:       true,
+			ZFSDatasetRoot:  "tank/cleanroom",
+		}
+	})
+
+	tmpDir := t.TempDir()
+	stdoutPath := filepath.Join(tmpDir, "doctor.json")
+	stdout, err := os.Create(stdoutPath)
+	if err != nil {
+		t.Fatalf("create stdout file: %v", err)
+	}
+
+	cmd := DoctorCommand{Backend: "firecracker", JSON: true}
+	err = cmd.Run(&runtimeContext{
+		CWD:    tmpDir,
+		Stdout: stdout,
+		Loader: doctorFailingLoader{},
+		Config: runtimeconfig.Config{
+			Backends: runtimeconfig.Backends{
+				Firecracker: runtimeconfig.FirecrackerConfig{
+					Snapshots: runtimeconfig.SnapshotConfig{Enabled: true, Driver: "zfs", ZFSDataset: "tank/cleanroom"},
+				},
+			},
+		},
+		ConfigPath: filepath.Join(tmpDir, "config.yaml"),
+		Backends: map[string]backend.Adapter{
+			"firecracker": doctorSnapshotAdapter{},
+		},
+	})
+	if closeErr := stdout.Close(); closeErr != nil {
+		t.Fatalf("close stdout file: %v", closeErr)
+	}
+	if err != nil {
+		t.Fatalf("DoctorCommand.Run returned error: %v", err)
+	}
+
+	raw, err := os.ReadFile(stdoutPath)
+	if err != nil {
+		t.Fatalf("read doctor output: %v", err)
+	}
+
+	var payload struct {
+		Support struct {
+			Tier              string `json:"tier"`
+			Message           string `json:"message"`
+			HostRuntimeUsable bool   `json:"host_runtime_usable"`
+			SnapshotsUsable   bool   `json:"snapshots_usable"`
+			ZFSUsable         bool   `json:"zfs_usable"`
+			ZFSDatasetRoot    string `json:"zfs_dataset_root"`
+		} `json:"support"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("unmarshal doctor JSON: %v", err)
+	}
+	if got, want := payload.Support.Tier, "supported"; got != want {
+		t.Fatalf("unexpected support tier: got %q want %q", got, want)
+	}
+	if !payload.Support.HostRuntimeUsable || !payload.Support.SnapshotsUsable || !payload.Support.ZFSUsable {
+		t.Fatalf("expected support booleans to be true, got %+v", payload.Support)
+	}
+	if got, want := payload.Support.ZFSDatasetRoot, "tank/cleanroom"; got != want {
+		t.Fatalf("unexpected support dataset root: got %q want %q", got, want)
+	}
+	if !strings.Contains(payload.Support.Message, "supported: zfs-backed firecracker layered caching") {
+		t.Fatalf("unexpected support summary message: %q", payload.Support.Message)
+	}
+}
+
+func TestDoctorCommandReportsDegradedFirecrackerTierInText(t *testing.T) {
+	stubFirecrackerHostSupport(t, func(context.Context, backend.FirecrackerConfig) backendfirecracker.HostSupport {
+		return backendfirecracker.HostSupport{
+			RuntimeUsable:   true,
+			SnapshotsUsable: true,
+			ZFSUsable:       true,
+			ZFSDatasetRoot:  "tank/cleanroom",
+		}
+	})
+
+	tmpDir := t.TempDir()
+	stdout, readStdout := makeStdoutCapture(t)
+
+	cmd := DoctorCommand{Backend: "firecracker"}
+	err := cmd.Run(&runtimeContext{
+		CWD:    tmpDir,
+		Stdout: stdout,
+		Loader: doctorFailingLoader{},
+		Config: runtimeconfig.Config{
+			Backends: runtimeconfig.Backends{
+				Firecracker: runtimeconfig.FirecrackerConfig{
+					Snapshots: runtimeconfig.SnapshotConfig{Enabled: true, Driver: "file"},
+				},
+			},
+		},
+		ConfigPath: filepath.Join(tmpDir, "config.yaml"),
+		Backends: map[string]backend.Adapter{
+			"firecracker": doctorSnapshotAdapter{},
+		},
+	})
+	if err != nil {
+		t.Fatalf("DoctorCommand.Run returned error: %v", err)
+	}
+
+	out := readStdout()
+	if !strings.Contains(out, "support_tier: degraded: firecracker layered caching is file-backed; warm restores still copy bytes") {
+		t.Fatalf("expected degraded support tier line, got %q", out)
+	}
+	if !strings.Contains(out, "machine bootstrap can support zfs via tank/cleanroom") {
+		t.Fatalf("expected degraded support tier hint, got %q", out)
+	}
+}
+
+func TestDoctorCommandReportsUnsupportedFirecrackerTierWhenRuntimeMissing(t *testing.T) {
+	stubFirecrackerHostSupport(t, func(context.Context, backend.FirecrackerConfig) backendfirecracker.HostSupport {
+		return backendfirecracker.HostSupport{
+			RuntimeUsable:   false,
+			SnapshotsUsable: false,
+			RuntimeMessage:  "missing required host commands: sudo",
+			SnapshotMessage: "missing required host commands: sudo",
+			ZFSMessage:      "missing required host commands: sudo",
+		}
+	})
+
+	tmpDir := t.TempDir()
+	stdout, readStdout := makeStdoutCapture(t)
+
+	cmd := DoctorCommand{Backend: "firecracker"}
+	err := cmd.Run(&runtimeContext{
+		CWD:        tmpDir,
+		Stdout:     stdout,
+		Loader:     doctorFailingLoader{},
+		Config:     runtimeconfig.Config{},
+		ConfigPath: filepath.Join(tmpDir, "config.yaml"),
+		Backends: map[string]backend.Adapter{
+			"firecracker": doctorSnapshotAdapter{},
+		},
+	})
+	if err != nil {
+		t.Fatalf("DoctorCommand.Run returned error: %v", err)
+	}
+
+	out := readStdout()
+	if !strings.Contains(out, "✗ [fail] support_tier: unsupported: machine bootstrap incomplete for firecracker host runtime: missing required host commands: sudo") {
+		t.Fatalf("expected unsupported support tier line, got %q", out)
 	}
 }

--- a/internal/cli/firecracker_support_test.go
+++ b/internal/cli/firecracker_support_test.go
@@ -1,0 +1,18 @@
+package cli
+
+import (
+	"context"
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	backendfirecracker "github.com/buildkite/cleanroom/internal/backend/firecracker"
+)
+
+func stubFirecrackerHostSupport(t *testing.T, fn func(context.Context, backend.FirecrackerConfig) backendfirecracker.HostSupport) {
+	t.Helper()
+	prev := detectFirecrackerHostSupport
+	detectFirecrackerHostSupport = fn
+	t.Cleanup(func() {
+		detectFirecrackerHostSupport = prev
+	})
+}

--- a/internal/cli/policy_config.go
+++ b/internal/cli/policy_config.go
@@ -1,15 +1,20 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/buildkite/cleanroom/internal/backend"
+	backendfirecracker "github.com/buildkite/cleanroom/internal/backend/firecracker"
 	"github.com/buildkite/cleanroom/internal/runtimeconfig"
 	"gopkg.in/yaml.v3"
 )
+
+var detectFirecrackerHostSupport = backendfirecracker.DetectHostSupport
 
 type PolicyCommand struct {
 	Validate PolicyValidateCommand `cmd:"" help:"Validate policy configuration"`
@@ -94,12 +99,19 @@ func (c *ConfigInitCommand) Run(ctx *runtimeContext) error {
 		return fmt.Errorf("create config directory: %w", err)
 	}
 
-	payload, err := yaml.Marshal(defaultRuntimeConfig(defaultBackend))
+	firecrackerSnapshots, warnings := defaultFirecrackerSnapshotConfig(context.Background(), defaultBackend == "firecracker" || hostDefaultBackend() == "firecracker")
+
+	payload, err := yaml.Marshal(defaultRuntimeConfig(defaultBackend, firecrackerSnapshots))
 	if err != nil {
 		return fmt.Errorf("marshal runtime config template: %w", err)
 	}
 	if err := os.WriteFile(path, payload, 0o644); err != nil {
 		return fmt.Errorf("write runtime config %s: %w", path, err)
+	}
+	for _, warning := range warnings {
+		if _, err := fmt.Fprint(ctx.stderr(), renderNoticeLine("warning", warning, defaultTerminalPalette().warn, shouldUseANSI(ctx.stderr()))); err != nil {
+			return err
+		}
 	}
 
 	_, err = fmt.Fprintln(ctx.Stdout, renderStatusValueLine("runtime config written", path, defaultTerminalPalette().info, shouldUseANSI(ctx.Stdout)))
@@ -110,7 +122,29 @@ func hostDefaultBackend() string {
 	return runtimeconfig.DefaultBackendForHost()
 }
 
-func defaultRuntimeConfig(defaultBackend string) runtimeconfig.Config {
+func defaultFirecrackerSnapshotConfig(ctx context.Context, emitRuntimeWarnings bool) (runtimeconfig.SnapshotConfig, []string) {
+	support := detectFirecrackerHostSupport(ctx, backend.FirecrackerConfig{})
+	snapshot := runtimeconfig.SnapshotConfig{Enabled: false, Driver: "file"}
+
+	if !support.SnapshotsUsable {
+		warnings := []string{}
+		if emitRuntimeWarnings {
+			warnings = append(warnings, "firecracker snapshots remain disabled: "+support.SnapshotMessage)
+		}
+		return snapshot, warnings
+	}
+
+	snapshot.Enabled = true
+	if support.ZFSUsable {
+		snapshot.Driver = "zfs"
+		snapshot.ZFSDataset = support.ZFSDatasetRoot
+		return snapshot, nil
+	}
+
+	return snapshot, []string{"firecracker snapshots default to driver=file: " + support.ZFSMessage}
+}
+
+func defaultRuntimeConfig(defaultBackend string, firecrackerSnapshots runtimeconfig.SnapshotConfig) runtimeconfig.Config {
 	return runtimeconfig.Config{
 		DefaultBackend: defaultBackend,
 		Backends: runtimeconfig.Backends{
@@ -125,10 +159,7 @@ func defaultRuntimeConfig(defaultBackend string) runtimeconfig.Config {
 						IPTables:              false,
 					},
 				},
-				Snapshots: runtimeconfig.SnapshotConfig{
-					Enabled: false,
-					Driver:  "file",
-				},
+				Snapshots:            firecrackerSnapshots,
 				PrivilegedHelperPath: "/usr/local/sbin/cleanroom-root-helper",
 				VCPUs:                2,
 				MemoryMiB:            1024,


### PR DESCRIPTION
## Summary

This adds shared Firecracker host support detection and uses it in `cleanroom config init` and `cleanroom doctor`.

It does three main things:
- adds a shared Firecracker host probe for helper, snapshot runtime, and ZFS dataset-root detection
- makes `cleanroom config init` pick `zfs` when an existing usable Cleanroom dataset root is detected, otherwise fall back to `file` or disabled snapshots with a warning
- adds a Firecracker support-tier summary to `cleanroom doctor`, so the CLI can distinguish supported ZFS-backed hosts from degraded file-backed hosts and missing bootstrap state

The docs now frame Linux Firecracker as machine bootstrap plus unprivileged user config, with ZFS-backed Firecracker as the supported layered-cache path.

## Testing

- `go test ./...`
- read-only SSM checks on prod host `i-0b35e6770b45a7db1`

## Prod host note

The prod host test surfaced one useful edge case: its usable ZFS root is a dedicated `cleanroom` pool root, not only `*/cleanroom`. This PR includes that fix, so the host detector now accepts both shapes.

The same host is currently configured for file-backed Firecracker snapshots, so under this PR it would be classified as degraded rather than unsupported. It is already machine-bootstrap capable of the ZFS-backed path.
