### PR TITLE
refactor: bypass firecracker helper bridge when already root

### DIFF
--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -130,6 +130,8 @@ var rootFSVolumeStoreDriverFn = rootFSVolumeStoreDriver
 
 var snapshotVolumeStoreDriverFn = snapshotVolumeStoreDriver
 
+var privilegedCommandEUID = os.Geteuid
+
 var nflogGroupFromTapNameFn = nflogGroupFromTapName
 
 var newNFLogListenerFn = newNFLogListener
@@ -2561,7 +2563,7 @@ func helperMissingCapabilities(have, required []string) []string {
 }
 
 func helperCapabilities(ctx context.Context, cfg backend.FirecrackerConfig) ([]string, error) {
-	out, err := runRootCommandOutput(ctx, cfg, "capabilities")
+	out, err := runHelperCommandOutput(ctx, cfg, "capabilities")
 	if err != nil {
 		return nil, err
 	}
@@ -2584,7 +2586,7 @@ func helperCapabilities(ctx context.Context, cfg backend.FirecrackerConfig) ([]s
 }
 
 func helperVersion(ctx context.Context, cfg backend.FirecrackerConfig) (string, error) {
-	out, err := runRootCommandOutput(ctx, cfg, "version")
+	out, err := runHelperCommandOutput(ctx, cfg, "version")
 	if err != nil {
 		return "", err
 	}
@@ -2620,7 +2622,48 @@ func lookPathWithFallback(binary string, candidates ...string) (string, error) {
 	return "", fmt.Errorf("%q not found in PATH or fallback locations", binary)
 }
 
+func resolveDirectPrivilegedCommandPath(command string) (string, error) {
+	switch strings.TrimSpace(command) {
+	case "zfs":
+		return lookPathWithFallback(command, "/usr/sbin/zfs", "/sbin/zfs")
+	default:
+		return hostSupportResolveCommand(command)
+	}
+}
+
+func runDirectPrivilegedCommand(ctx context.Context, args ...string) error {
+	if len(args) == 0 {
+		return errors.New("missing privileged command")
+	}
+	binary, err := resolveDirectPrivilegedCommandPath(args[0])
+	if err != nil {
+		return err
+	}
+	return runCombinedCommand(ctx, append([]string{binary}, args[1:]...), args)
+}
+
+func runDirectPrivilegedCommandOutput(ctx context.Context, args ...string) ([]byte, error) {
+	if len(args) == 0 {
+		return nil, errors.New("missing privileged command")
+	}
+	binary, err := resolveDirectPrivilegedCommandPath(args[0])
+	if err != nil {
+		return nil, err
+	}
+	return runCombinedCommandOutput(ctx, append([]string{binary}, args[1:]...), args)
+}
+
 func runRootCommand(ctx context.Context, cfg backend.FirecrackerConfig, args ...string) error {
+	if len(args) == 0 {
+		return errors.New("missing privileged command")
+	}
+	if privilegedCommandEUID() == 0 {
+		return runDirectPrivilegedCommand(ctx, args...)
+	}
+	return runHelperCommand(ctx, cfg, args...)
+}
+
+func runHelperCommand(ctx context.Context, cfg backend.FirecrackerConfig, args ...string) error {
 	if len(args) == 0 {
 		return errors.New("missing privileged command")
 	}
@@ -2633,6 +2676,16 @@ func runRootCommand(ctx context.Context, cfg backend.FirecrackerConfig, args ...
 }
 
 func runRootCommandOutput(ctx context.Context, cfg backend.FirecrackerConfig, args ...string) ([]byte, error) {
+	if len(args) == 0 {
+		return nil, errors.New("missing privileged command")
+	}
+	if privilegedCommandEUID() == 0 {
+		return runDirectPrivilegedCommandOutput(ctx, args...)
+	}
+	return runHelperCommandOutput(ctx, cfg, args...)
+}
+
+func runHelperCommandOutput(ctx context.Context, cfg backend.FirecrackerConfig, args ...string) ([]byte, error) {
 	if len(args) == 0 {
 		return nil, errors.New("missing privileged command")
 	}

--- a/internal/backend/firecracker/privileged_test.go
+++ b/internal/backend/firecracker/privileged_test.go
@@ -38,8 +38,19 @@ func doctorHasCheck(report *backend.DoctorReport, name string) bool {
 	return false
 }
 
+func stubPrivilegedCommandEUID(t *testing.T, uid int) {
+	t.Helper()
+
+	prev := privilegedCommandEUID
+	privilegedCommandEUID = func() int { return uid }
+	t.Cleanup(func() {
+		privilegedCommandEUID = prev
+	})
+}
+
 func setupFakeSudo(t *testing.T, logPath string) {
 	t.Helper()
+	stubPrivilegedCommandEUID(t, 1000)
 
 	tmpDir := t.TempDir()
 	fakeSudoPath := filepath.Join(tmpDir, "sudo")
@@ -87,6 +98,88 @@ func TestRunRootCommandInvokesHelper(t *testing.T) {
 	}
 	if got := strings.TrimSpace(string(sudoLogBytes)); !strings.HasPrefix(got, "-n "+helperPath+" ") {
 		t.Fatalf("expected helper invocation via sudo, got %q", got)
+	}
+}
+
+func TestRunRootCommandExecutesDirectlyWhenRoot(t *testing.T) {
+	stubPrivilegedCommandEUID(t, 0)
+
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "ip.log")
+	writeExecutable(t, tmpDir, "ip", "#!/bin/sh\nset -eu\nprintf '%s\\n' \"$*\" >> \"$IP_LOG_PATH\"\n")
+	t.Setenv("IP_LOG_PATH", logPath)
+	t.Setenv("PATH", tmpDir+":"+os.Getenv("PATH"))
+
+	cfg := backend.FirecrackerConfig{
+		PrivilegedHelperPath: filepath.Join(tmpDir, "missing-helper"),
+	}
+
+	if err := runRootCommand(context.Background(), cfg, "ip", "link", "show"); err != nil {
+		t.Fatalf("runRootCommand: %v", err)
+	}
+
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read direct command log: %v", err)
+	}
+	if got, want := strings.TrimSpace(string(logBytes)), "link show"; got != want {
+		t.Fatalf("unexpected direct command invocation: got %q want %q", got, want)
+	}
+}
+
+func TestRunRootCommandUsesResolvedCommandPathWhenRoot(t *testing.T) {
+	stubPrivilegedCommandEUID(t, 0)
+
+	prevResolveCommand := hostSupportResolveCommand
+	t.Cleanup(func() {
+		hostSupportResolveCommand = prevResolveCommand
+	})
+
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "ip.log")
+	ipPath := writeExecutable(t, tmpDir, "ip-root", "#!/bin/sh\nset -eu\nprintf '%s\\n' \"$*\" >> \"$IP_LOG_PATH\"\n")
+	t.Setenv("IP_LOG_PATH", logPath)
+	hostSupportResolveCommand = func(command string) (string, error) {
+		if command == "ip" {
+			return ipPath, nil
+		}
+		return prevResolveCommand(command)
+	}
+
+	cfg := backend.FirecrackerConfig{
+		PrivilegedHelperPath: filepath.Join(tmpDir, "missing-helper"),
+	}
+
+	if err := runRootCommand(context.Background(), cfg, "ip", "link", "show"); err != nil {
+		t.Fatalf("runRootCommand: %v", err)
+	}
+
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read resolved command log: %v", err)
+	}
+	if got, want := strings.TrimSpace(string(logBytes)), "link show"; got != want {
+		t.Fatalf("unexpected resolved command invocation: got %q want %q", got, want)
+	}
+}
+
+func TestRunRootCommandOutputExecutesDirectlyWhenRoot(t *testing.T) {
+	stubPrivilegedCommandEUID(t, 0)
+
+	tmpDir := t.TempDir()
+	writeExecutable(t, tmpDir, "zfs", "#!/bin/sh\nset -eu\nprintf 'tank/cleanroom\\n'\n")
+	t.Setenv("PATH", tmpDir+":"+os.Getenv("PATH"))
+
+	cfg := backend.FirecrackerConfig{
+		PrivilegedHelperPath: filepath.Join(tmpDir, "missing-helper"),
+	}
+
+	out, err := runRootCommandOutput(context.Background(), cfg, "zfs", "list", "-H", "-d", "0", "-o", "name", "tank/cleanroom")
+	if err != nil {
+		t.Fatalf("runRootCommandOutput: %v", err)
+	}
+	if got, want := strings.TrimSpace(string(out)), "tank/cleanroom"; got != want {
+		t.Fatalf("unexpected direct command output: got %q want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- execute privileged firecracker runtime commands directly when the process already runs as root
- keep helper version/capability probes on the helper bridge so machine-bootstrap detection stays unchanged
- add regression coverage for both the non-root sudo/helper path and the direct root path, including shared command-path resolution

## Testing
- go test ./...
