### PR TITLE
fix: pin direct firecracker root commands to trusted paths

### DIFF
--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -132,6 +132,8 @@ var snapshotVolumeStoreDriverFn = snapshotVolumeStoreDriver
 
 var privilegedCommandEUID = os.Geteuid
 
+var directPrivilegedCommandPathResolver = resolveDirectPrivilegedCommandPath
+
 var nflogGroupFromTapNameFn = nflogGroupFromTapName
 
 var newNFLogListenerFn = newNFLogListener
@@ -2622,12 +2624,35 @@ func lookPathWithFallback(binary string, candidates ...string) (string, error) {
 	return "", fmt.Errorf("%q not found in PATH or fallback locations", binary)
 }
 
+func resolveTrustedCommandPath(command string, candidates ...string) (string, error) {
+	for _, candidate := range candidates {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" {
+			continue
+		}
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("%q not found in trusted locations", command)
+}
+
 func resolveDirectPrivilegedCommandPath(command string) (string, error) {
 	switch strings.TrimSpace(command) {
+	case "true":
+		return resolveTrustedCommandPath(command, "/usr/bin/true", "/bin/true")
+	case "dd":
+		return resolveTrustedCommandPath(command, "/usr/bin/dd", "/bin/dd")
+	case "ip":
+		return resolveTrustedCommandPath(command, "/usr/sbin/ip", "/sbin/ip")
+	case "iptables":
+		return resolveTrustedCommandPath(command, "/usr/sbin/iptables", "/sbin/iptables")
+	case "sysctl":
+		return resolveTrustedCommandPath(command, "/usr/sbin/sysctl", "/sbin/sysctl")
 	case "zfs":
-		return lookPathWithFallback(command, "/usr/sbin/zfs", "/sbin/zfs")
+		return resolveTrustedCommandPath(command, "/usr/sbin/zfs", "/sbin/zfs")
 	default:
-		return hostSupportResolveCommand(command)
+		return "", fmt.Errorf("unsupported direct privileged command %q", command)
 	}
 }
 
@@ -2635,7 +2660,7 @@ func runDirectPrivilegedCommand(ctx context.Context, args ...string) error {
 	if len(args) == 0 {
 		return errors.New("missing privileged command")
 	}
-	binary, err := resolveDirectPrivilegedCommandPath(args[0])
+	binary, err := directPrivilegedCommandPathResolver(args[0])
 	if err != nil {
 		return err
 	}
@@ -2646,7 +2671,7 @@ func runDirectPrivilegedCommandOutput(ctx context.Context, args ...string) ([]by
 	if len(args) == 0 {
 		return nil, errors.New("missing privileged command")
 	}
-	binary, err := resolveDirectPrivilegedCommandPath(args[0])
+	binary, err := directPrivilegedCommandPathResolver(args[0])
 	if err != nil {
 		return nil, err
 	}

--- a/internal/backend/firecracker/privileged_test.go
+++ b/internal/backend/firecracker/privileged_test.go
@@ -48,6 +48,16 @@ func stubPrivilegedCommandEUID(t *testing.T, uid int) {
 	})
 }
 
+func stubDirectPrivilegedCommandPathResolver(t *testing.T, fn func(string) (string, error)) {
+	t.Helper()
+
+	prev := directPrivilegedCommandPathResolver
+	directPrivilegedCommandPathResolver = fn
+	t.Cleanup(func() {
+		directPrivilegedCommandPathResolver = prev
+	})
+}
+
 func setupFakeSudo(t *testing.T, logPath string) {
 	t.Helper()
 	stubPrivilegedCommandEUID(t, 1000)
@@ -106,9 +116,14 @@ func TestRunRootCommandExecutesDirectlyWhenRoot(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	logPath := filepath.Join(tmpDir, "ip.log")
-	writeExecutable(t, tmpDir, "ip", "#!/bin/sh\nset -eu\nprintf '%s\\n' \"$*\" >> \"$IP_LOG_PATH\"\n")
+	ipPath := writeExecutable(t, tmpDir, "ip", "#!/bin/sh\nset -eu\nprintf '%s\\n' \"$*\" >> \"$IP_LOG_PATH\"\n")
 	t.Setenv("IP_LOG_PATH", logPath)
-	t.Setenv("PATH", tmpDir+":"+os.Getenv("PATH"))
+	stubDirectPrivilegedCommandPathResolver(t, func(command string) (string, error) {
+		if command == "ip" {
+			return ipPath, nil
+		}
+		return resolveDirectPrivilegedCommandPath(command)
+	})
 
 	cfg := backend.FirecrackerConfig{
 		PrivilegedHelperPath: filepath.Join(tmpDir, "missing-helper"),
@@ -127,24 +142,40 @@ func TestRunRootCommandExecutesDirectlyWhenRoot(t *testing.T) {
 	}
 }
 
-func TestRunRootCommandUsesResolvedCommandPathWhenRoot(t *testing.T) {
+func TestRunRootCommandDoesNotUsePATHShadowedBinaryWhenRoot(t *testing.T) {
 	stubPrivilegedCommandEUID(t, 0)
 
-	prevResolveCommand := hostSupportResolveCommand
-	t.Cleanup(func() {
-		hostSupportResolveCommand = prevResolveCommand
-	})
+	tmpDir := t.TempDir()
+	shadowLogPath := filepath.Join(tmpDir, "shadow.log")
+	writeExecutable(t, tmpDir, "true", "#!/bin/sh\nset -eu\nprintf 'shadowed true executed\\n' >> \"$SHADOW_LOG_PATH\"\nexit 23\n")
+	t.Setenv("SHADOW_LOG_PATH", shadowLogPath)
+	t.Setenv("PATH", tmpDir+":"+os.Getenv("PATH"))
+
+	cfg := backend.FirecrackerConfig{
+		PrivilegedHelperPath: filepath.Join(tmpDir, "missing-helper"),
+	}
+
+	if err := runRootCommand(context.Background(), cfg, "true"); err != nil {
+		t.Fatalf("runRootCommand: %v", err)
+	}
+	if _, err := os.Stat(shadowLogPath); !os.IsNotExist(err) {
+		t.Fatalf("expected shadowed PATH binary to be ignored, got stat err=%v", err)
+	}
+}
+
+func TestRunRootCommandUsesResolvedCommandPathWhenRoot(t *testing.T) {
+	stubPrivilegedCommandEUID(t, 0)
 
 	tmpDir := t.TempDir()
 	logPath := filepath.Join(tmpDir, "ip.log")
 	ipPath := writeExecutable(t, tmpDir, "ip-root", "#!/bin/sh\nset -eu\nprintf '%s\\n' \"$*\" >> \"$IP_LOG_PATH\"\n")
 	t.Setenv("IP_LOG_PATH", logPath)
-	hostSupportResolveCommand = func(command string) (string, error) {
+	stubDirectPrivilegedCommandPathResolver(t, func(command string) (string, error) {
 		if command == "ip" {
 			return ipPath, nil
 		}
-		return prevResolveCommand(command)
-	}
+		return resolveDirectPrivilegedCommandPath(command)
+	})
 
 	cfg := backend.FirecrackerConfig{
 		PrivilegedHelperPath: filepath.Join(tmpDir, "missing-helper"),
@@ -167,8 +198,13 @@ func TestRunRootCommandOutputExecutesDirectlyWhenRoot(t *testing.T) {
 	stubPrivilegedCommandEUID(t, 0)
 
 	tmpDir := t.TempDir()
-	writeExecutable(t, tmpDir, "zfs", "#!/bin/sh\nset -eu\nprintf 'tank/cleanroom\\n'\n")
-	t.Setenv("PATH", tmpDir+":"+os.Getenv("PATH"))
+	zfsPath := writeExecutable(t, tmpDir, "zfs", "#!/bin/sh\nset -eu\nprintf 'tank/cleanroom\\n'\n")
+	stubDirectPrivilegedCommandPathResolver(t, func(command string) (string, error) {
+		if command == "zfs" {
+			return zfsPath, nil
+		}
+		return resolveDirectPrivilegedCommandPath(command)
+	})
 
 	cfg := backend.FirecrackerConfig{
 		PrivilegedHelperPath: filepath.Join(tmpDir, "missing-helper"),


### PR DESCRIPTION
## Summary
- pin the direct-root firecracker privileged command path to trusted absolute binaries instead of resolving through PATH
- keep the direct resolver injectable in tests so root-path behaviour stays portable without weakening production resolution
- add a regression that proves a PATH-shadowed `true` binary is ignored when the runtime is already root

## Testing
- go test ./internal/backend/firecracker
- go test ./...
