### PR TITLE
refactor: extract firecracker privileged command runner

### DIFF
--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -130,10 +130,6 @@ var rootFSVolumeStoreDriverFn = rootFSVolumeStoreDriver
 
 var snapshotVolumeStoreDriverFn = snapshotVolumeStoreDriver
 
-var privilegedCommandEUID = os.Geteuid
-
-var directPrivilegedCommandPathResolver = resolveDirectPrivilegedCommandPath
-
 var nflogGroupFromTapNameFn = nflogGroupFromTapName
 
 var newNFLogListenerFn = newNFLogListener
@@ -998,13 +994,8 @@ func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream 
 	vmRootFSPath := writableVolume.AttachmentPath
 
 	networkSetupStart := time.Now()
-	networkRunCommand := func(ctx context.Context, args ...string) error {
-		return runRootCommand(ctx, req.FirecrackerConfig, args...)
-	}
-	networkRunBatch := func(ctx context.Context, commands [][]string) error {
-		return runRootCommandBatch(ctx, req.FirecrackerConfig, commands)
-	}
-	networkCfg, cleanupNetwork, err := setupHostNetwork(ctx, req.ExecutionID, req.Policy.NetworkDefault == "allow", req.Policy.Allow, 0, networkRunCommand, networkRunBatch, nil, nil)
+	runner := newPrivilegedCommandRunner(req.FirecrackerConfig)
+	networkCfg, cleanupNetwork, err := setupHostNetwork(ctx, req.ExecutionID, req.Policy.NetworkDefault == "allow", req.Policy.Allow, 0, runner, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("setup host network: %w", err)
 	}
@@ -1598,12 +1589,7 @@ func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID strin
 	}
 	vmRootFSPath := writableVolume.AttachmentPath
 
-	networkRunCommand := func(ctx context.Context, args ...string) error {
-		return runRootCommand(ctx, cfg, args...)
-	}
-	networkRunBatch := func(ctx context.Context, commands [][]string) error {
-		return runRootCommandBatch(ctx, cfg, commands)
-	}
+	runner := newPrivilegedCommandRunner(cfg)
 	gwPort := 0
 	if a.GatewayRegistry != nil {
 		gwPort = a.GatewayPort
@@ -1628,7 +1614,7 @@ func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID strin
 		}
 	}
 
-	networkCfg, cleanupNetwork, err := setupHostNetwork(ctx, sandboxID, compiled.NetworkDefault == "allow", compiled.Allow, gwPort, networkRunCommand, networkRunBatch, dnsOnDeny, nflogOnBlocked)
+	networkCfg, cleanupNetwork, err := setupHostNetwork(ctx, sandboxID, compiled.NetworkDefault == "allow", compiled.Allow, gwPort, runner, dnsOnDeny, nflogOnBlocked)
 	if err != nil {
 		cleanupVolume()
 		return nil, fmt.Errorf("setup host network: %w", err)
@@ -1862,15 +1848,15 @@ func snapshotStorageBaseDir(cfg backend.FirecrackerConfig) (string, error) {
 }
 
 type rootVolumeCommandRunner struct {
-	cfg backend.FirecrackerConfig
+	runner privilegedCommandRunner
 }
 
 func (r rootVolumeCommandRunner) Run(ctx context.Context, command string, args ...string) error {
-	return runRootCommand(ctx, r.cfg, append([]string{command}, args...)...)
+	return r.runner.Run(ctx, append([]string{command}, args...)...)
 }
 
 func (r rootVolumeCommandRunner) Output(ctx context.Context, command string, args ...string) ([]byte, error) {
-	return runRootCommandOutput(ctx, r.cfg, append([]string{command}, args...)...)
+	return r.runner.Output(ctx, append([]string{command}, args...)...)
 }
 
 func snapshotConfigForStorageRef(cfg backend.FirecrackerConfig, storageRef string) (backend.FirecrackerConfig, error) {
@@ -1904,7 +1890,7 @@ func rootFSVolumeStoreDriver(cfg backend.FirecrackerConfig) (volumestore.Driver,
 	case "zfs":
 		driver, err := volumestore.NewZFSDriver(volumestore.ZFSDriverOptions{
 			DatasetRoot: cfg.Snapshots.ZFSDataset,
-			Runner:      rootVolumeCommandRunner{cfg: cfg},
+			Runner:      rootVolumeCommandRunner{runner: newPrivilegedCommandRunner(cfg)},
 		})
 		if err != nil {
 			return nil, err
@@ -2154,25 +2140,24 @@ type hostNetworkConfig struct {
 
 type ipLookupFunc func(ctx context.Context, host string) ([]net.IP, error)
 type interfaceLookupFunc func(name string) (*net.Interface, error)
-type rootCommandFunc func(ctx context.Context, args ...string) error
 type rootCommandBatchFunc func(ctx context.Context, commands [][]string) error
 
-func setupHostNetwork(ctx context.Context, runID string, allowAll bool, allow []policy.AllowRule, gatewayPort int, runCommand rootCommandFunc, runBatchCommand rootCommandBatchFunc, onDeny func(sandboxID, queryName string), onBlocked func(string)) (hostNetworkConfig, func(), error) {
+func setupHostNetwork(ctx context.Context, runID string, allowAll bool, allow []policy.AllowRule, gatewayPort int, runner privilegedCommandRunner, onDeny func(sandboxID, queryName string), onBlocked func(string)) (hostNetworkConfig, func(), error) {
 	lookup := func(ctx context.Context, host string) ([]net.IP, error) {
 		return net.DefaultResolver.LookupIP(ctx, "ip4", host)
 	}
-	return setupHostNetworkWithDeps(ctx, runID, allowAll, allow, gatewayPort, lookup, runCommand, runBatchCommand, onDeny, onBlocked)
+	return setupHostNetworkWithDeps(ctx, runID, allowAll, allow, gatewayPort, lookup, runner, onDeny, onBlocked)
 }
 
-func setupHostNetworkWithDeps(ctx context.Context, runID string, allowAll bool, allow []policy.AllowRule, gatewayPort int, lookup ipLookupFunc, runCommand rootCommandFunc, runBatchCommand rootCommandBatchFunc, onDeny func(sandboxID, queryName string), onBlocked func(string)) (hostNetworkConfig, func(), error) {
-	return setupHostNetworkWithTrustedDNSFactory(ctx, runID, allowAll, allow, gatewayPort, lookup, net.InterfaceByName, runCommand, runBatchCommand, newTrustedDNSService, onDeny, onBlocked)
+func setupHostNetworkWithDeps(ctx context.Context, runID string, allowAll bool, allow []policy.AllowRule, gatewayPort int, lookup ipLookupFunc, runner privilegedCommandRunner, onDeny func(sandboxID, queryName string), onBlocked func(string)) (hostNetworkConfig, func(), error) {
+	return setupHostNetworkWithTrustedDNSFactory(ctx, runID, allowAll, allow, gatewayPort, lookup, net.InterfaceByName, runner, newTrustedDNSService, onDeny, onBlocked)
 }
 
-func setupHostNetworkWithTapLookup(ctx context.Context, runID string, allowAll bool, allow []policy.AllowRule, gatewayPort int, lookup ipLookupFunc, interfaceByName interfaceLookupFunc, runCommand rootCommandFunc, runBatchCommand rootCommandBatchFunc, onDeny func(sandboxID, queryName string), onBlocked func(string)) (hostNetworkConfig, func(), error) {
-	return setupHostNetworkWithTrustedDNSFactory(ctx, runID, allowAll, allow, gatewayPort, lookup, interfaceByName, runCommand, runBatchCommand, newTrustedDNSService, onDeny, onBlocked)
+func setupHostNetworkWithTapLookup(ctx context.Context, runID string, allowAll bool, allow []policy.AllowRule, gatewayPort int, lookup ipLookupFunc, interfaceByName interfaceLookupFunc, runner privilegedCommandRunner, onDeny func(sandboxID, queryName string), onBlocked func(string)) (hostNetworkConfig, func(), error) {
+	return setupHostNetworkWithTrustedDNSFactory(ctx, runID, allowAll, allow, gatewayPort, lookup, interfaceByName, runner, newTrustedDNSService, onDeny, onBlocked)
 }
 
-func setupHostNetworkWithTrustedDNSFactory(ctx context.Context, runID string, allowAll bool, allow []policy.AllowRule, gatewayPort int, lookup ipLookupFunc, interfaceByName interfaceLookupFunc, runCommand rootCommandFunc, runBatchCommand rootCommandBatchFunc, factory trustedDNSFactory, onDeny func(sandboxID, queryName string), onBlocked func(string)) (hostNetworkConfig, func(), error) {
+func setupHostNetworkWithTrustedDNSFactory(ctx context.Context, runID string, allowAll bool, allow []policy.AllowRule, gatewayPort int, lookup ipLookupFunc, interfaceByName interfaceLookupFunc, runner privilegedCommandRunner, factory trustedDNSFactory, onDeny func(sandboxID, queryName string), onBlocked func(string)) (hostNetworkConfig, func(), error) {
 	_ = lookup
 	if factory == nil {
 		factory = newTrustedDNSService
@@ -2192,7 +2177,7 @@ func setupHostNetworkWithTrustedDNSFactory(ctx context.Context, runID string, al
 	}
 
 	setupRun := func(args ...string) error {
-		return runCommand(ctx, args...)
+		return runner.Run(ctx, args...)
 	}
 	cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), networkCleanupTimeout)
 	cleanupCmds := make([][]string, 0, 16)
@@ -2208,10 +2193,10 @@ func setupHostNetworkWithTrustedDNSFactory(ctx context.Context, runID string, al
 		}
 		for _, args := range reversed {
 			if isTapDeleteCommand(args, tapName) {
-				_ = deleteTapDeviceWithRetry(cleanupCtx, tapName, tapDeleteRetryInterval, interfaceByName, runCommand)
+				_ = deleteTapDeviceWithRetry(cleanupCtx, tapName, tapDeleteRetryInterval, interfaceByName, runner)
 				continue
 			}
-			_ = runCommand(cleanupCtx, args...)
+			_ = runner.Run(cleanupCtx, args...)
 		}
 	}
 	addCleanup := func(args ...string) {
@@ -2219,7 +2204,7 @@ func setupHostNetworkWithTrustedDNSFactory(ctx context.Context, runID string, al
 	}
 	removeNFLogRule := func(tapName, groupStr string) {
 		args := []string{"iptables", "-D", "FORWARD", "-i", tapName, "-j", "NFLOG", "--nflog-group", groupStr}
-		if err := runCommand(cleanupCtx, args...); err != nil {
+		if err := runner.Run(cleanupCtx, args...); err != nil {
 			log.Printf("nflog iptables cleanup failed for %s: %v", tapName, err)
 			addCleanup(args...)
 		}
@@ -2228,7 +2213,7 @@ func setupHostNetworkWithTrustedDNSFactory(ctx context.Context, runID string, al
 	staleTapCleanupCtx, staleTapCleanupCancel := context.WithTimeout(context.Background(), networkCleanupTimeout)
 	defer staleTapCleanupCancel()
 	if _, err := interfaceByName(tapName); err == nil {
-		if err := deleteTapDeviceWithRetry(staleTapCleanupCtx, tapName, tapDeleteRetryInterval, interfaceByName, runCommand); err != nil {
+		if err := deleteTapDeviceWithRetry(staleTapCleanupCtx, tapName, tapDeleteRetryInterval, interfaceByName, runner); err != nil {
 			return hostNetworkConfig{}, func() {}, fmt.Errorf("remove stale tap device %s: %w", tapName, err)
 		}
 	} else if !isNoSuchNetworkInterfaceError(err) {
@@ -2365,7 +2350,7 @@ func setupHostNetworkWithTrustedDNSFactory(ctx context.Context, runID string, al
 		hostIP:       hostAddr,
 		guestIP:      guestAddr,
 		policy:       trustedDNSPolicy(allowAll, allow),
-		runBatch:     runBatchCommand,
+		runBatch:     runner.RunBatch,
 		tcpChainName: tcpChainName,
 		udpChainName: udpChainName,
 		onDeny:       onDeny,
@@ -2427,7 +2412,7 @@ func isTapDeleteCommand(args []string, tapName string) bool {
 	return len(args) == 4 && args[0] == "ip" && args[1] == "link" && args[2] == "del" && args[3] == tapName
 }
 
-func deleteTapDeviceWithRetry(ctx context.Context, tapName string, retryInterval time.Duration, interfaceByName interfaceLookupFunc, runCommand rootCommandFunc) error {
+func deleteTapDeviceWithRetry(ctx context.Context, tapName string, retryInterval time.Duration, interfaceByName interfaceLookupFunc, runner privilegedCommandRunner) error {
 	if strings.TrimSpace(tapName) == "" {
 		return nil
 	}
@@ -2439,7 +2424,7 @@ func deleteTapDeviceWithRetry(ctx context.Context, tapName string, retryInterval
 	defer ticker.Stop()
 
 	for {
-		err := runCommand(ctx, "ip", "link", "del", tapName)
+		err := runner.Run(ctx, "ip", "link", "del", tapName)
 		if err == nil {
 			return nil
 		}
@@ -2565,7 +2550,7 @@ func helperMissingCapabilities(have, required []string) []string {
 }
 
 func helperCapabilities(ctx context.Context, cfg backend.FirecrackerConfig) ([]string, error) {
-	out, err := runHelperCommandOutput(ctx, cfg, "capabilities")
+	out, err := newHelperPrivilegedCommandRunner(cfg).Output(ctx, "capabilities")
 	if err != nil {
 		return nil, err
 	}
@@ -2588,7 +2573,7 @@ func helperCapabilities(ctx context.Context, cfg backend.FirecrackerConfig) ([]s
 }
 
 func helperVersion(ctx context.Context, cfg backend.FirecrackerConfig) (string, error) {
-	out, err := runHelperCommandOutput(ctx, cfg, "version")
+	out, err := newHelperPrivilegedCommandRunner(cfg).Output(ctx, "version")
 	if err != nil {
 		return "", err
 	}
@@ -2622,116 +2607,6 @@ func lookPathWithFallback(binary string, candidates ...string) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("%q not found in PATH or fallback locations", binary)
-}
-
-func resolveTrustedCommandPath(command string, candidates ...string) (string, error) {
-	for _, candidate := range candidates {
-		candidate = strings.TrimSpace(candidate)
-		if candidate == "" {
-			continue
-		}
-		if _, err := os.Stat(candidate); err == nil {
-			return candidate, nil
-		}
-	}
-	return "", fmt.Errorf("%q not found in trusted locations", command)
-}
-
-func resolveDirectPrivilegedCommandPath(command string) (string, error) {
-	switch strings.TrimSpace(command) {
-	case "true":
-		return resolveTrustedCommandPath(command, "/usr/bin/true", "/bin/true")
-	case "dd":
-		return resolveTrustedCommandPath(command, "/usr/bin/dd", "/bin/dd")
-	case "ip":
-		return resolveTrustedCommandPath(command, "/usr/sbin/ip", "/sbin/ip")
-	case "iptables":
-		return resolveTrustedCommandPath(command, "/usr/sbin/iptables", "/sbin/iptables")
-	case "sysctl":
-		return resolveTrustedCommandPath(command, "/usr/sbin/sysctl", "/sbin/sysctl")
-	case "zfs":
-		return resolveTrustedCommandPath(command, "/usr/sbin/zfs", "/sbin/zfs")
-	default:
-		return "", fmt.Errorf("unsupported direct privileged command %q", command)
-	}
-}
-
-func runDirectPrivilegedCommand(ctx context.Context, args ...string) error {
-	if len(args) == 0 {
-		return errors.New("missing privileged command")
-	}
-	binary, err := directPrivilegedCommandPathResolver(args[0])
-	if err != nil {
-		return err
-	}
-	return runCombinedCommand(ctx, append([]string{binary}, args[1:]...), args)
-}
-
-func runDirectPrivilegedCommandOutput(ctx context.Context, args ...string) ([]byte, error) {
-	if len(args) == 0 {
-		return nil, errors.New("missing privileged command")
-	}
-	binary, err := directPrivilegedCommandPathResolver(args[0])
-	if err != nil {
-		return nil, err
-	}
-	return runCombinedCommandOutput(ctx, append([]string{binary}, args[1:]...), args)
-}
-
-func runRootCommand(ctx context.Context, cfg backend.FirecrackerConfig, args ...string) error {
-	if len(args) == 0 {
-		return errors.New("missing privileged command")
-	}
-	if privilegedCommandEUID() == 0 {
-		return runDirectPrivilegedCommand(ctx, args...)
-	}
-	return runHelperCommand(ctx, cfg, args...)
-}
-
-func runHelperCommand(ctx context.Context, cfg backend.FirecrackerConfig, args ...string) error {
-	if len(args) == 0 {
-		return errors.New("missing privileged command")
-	}
-
-	helperPath := resolvePrivilegedHelperPath(cfg)
-	if strings.TrimSpace(helperPath) == "" {
-		return errors.New("missing privileged helper path")
-	}
-	return runCombinedCommand(ctx, append([]string{"sudo", "-n", helperPath}, args...), append([]string{"helper"}, args...))
-}
-
-func runRootCommandOutput(ctx context.Context, cfg backend.FirecrackerConfig, args ...string) ([]byte, error) {
-	if len(args) == 0 {
-		return nil, errors.New("missing privileged command")
-	}
-	if privilegedCommandEUID() == 0 {
-		return runDirectPrivilegedCommandOutput(ctx, args...)
-	}
-	return runHelperCommandOutput(ctx, cfg, args...)
-}
-
-func runHelperCommandOutput(ctx context.Context, cfg backend.FirecrackerConfig, args ...string) ([]byte, error) {
-	if len(args) == 0 {
-		return nil, errors.New("missing privileged command")
-	}
-
-	helperPath := resolvePrivilegedHelperPath(cfg)
-	if strings.TrimSpace(helperPath) == "" {
-		return nil, errors.New("missing privileged helper path")
-	}
-	return runCombinedCommandOutput(ctx, append([]string{"sudo", "-n", helperPath}, args...), append([]string{"helper"}, args...))
-}
-
-func runRootCommandBatch(ctx context.Context, cfg backend.FirecrackerConfig, commands [][]string) error {
-	for _, args := range commands {
-		if len(args) == 0 {
-			continue
-		}
-		if err := runRootCommand(ctx, cfg, args...); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func runCombinedCommand(ctx context.Context, command []string, errorContext []string) error {

--- a/internal/backend/firecracker/gateway_firewall.go
+++ b/internal/backend/firecracker/gateway_firewall.go
@@ -20,33 +20,30 @@ import (
 // Returns a cleanup function that removes the rules. The caller must invoke
 // cleanup on shutdown.
 func SetupGatewayFirewall(ctx context.Context, port int, cfg backend.FirecrackerConfig) (cleanup func(), err error) {
-	run := func(ctx context.Context, args ...string) error {
-		return runRootCommand(ctx, cfg, args...)
-	}
-	return setupGatewayFirewall(ctx, port, run)
+	return setupGatewayFirewall(ctx, port, newPrivilegedCommandRunner(cfg))
 }
 
-func setupGatewayFirewall(ctx context.Context, port int, run rootCommandFunc) (cleanup func(), err error) {
+func setupGatewayFirewall(ctx context.Context, port int, runner privilegedCommandRunner) (cleanup func(), err error) {
 	portStr := strconv.Itoa(port)
 
 	// Allow loopback access to gateway port.
-	if err := run(ctx, "iptables", "-A", "INPUT", "-i", "lo", "-p", "tcp", "--dport", portStr, "-j", "ACCEPT"); err != nil {
+	if err := runner.Run(ctx, "iptables", "-A", "INPUT", "-i", "lo", "-p", "tcp", "--dport", portStr, "-j", "ACCEPT"); err != nil {
 		return nil, fmt.Errorf("install gateway loopback rule: %w", err)
 	}
 
 	// Drop gateway traffic from non-TAP interfaces (eth0, docker0, etc.).
 	// TAP traffic (cr*) is intentionally NOT matched here so it falls through
 	// to the per-TAP anti-spoof rules installed by setupHostNetwork.
-	if err := run(ctx, "iptables", "-A", "INPUT", "!", "-i", "cr+", "-p", "tcp", "--dport", portStr, "-j", "DROP"); err != nil {
-		_ = run(ctx, "iptables", "-D", "INPUT", "-i", "lo", "-p", "tcp", "--dport", portStr, "-j", "ACCEPT")
+	if err := runner.Run(ctx, "iptables", "-A", "INPUT", "!", "-i", "cr+", "-p", "tcp", "--dport", portStr, "-j", "DROP"); err != nil {
+		_ = runner.Run(ctx, "iptables", "-D", "INPUT", "-i", "lo", "-p", "tcp", "--dport", portStr, "-j", "ACCEPT")
 		return nil, fmt.Errorf("install gateway drop rule: %w", err)
 	}
 
 	cleanup = func() {
 		cleanupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		_ = run(cleanupCtx, "iptables", "-D", "INPUT", "!", "-i", "cr+", "-p", "tcp", "--dport", portStr, "-j", "DROP")
-		_ = run(cleanupCtx, "iptables", "-D", "INPUT", "-i", "lo", "-p", "tcp", "--dport", portStr, "-j", "ACCEPT")
+		_ = runner.Run(cleanupCtx, "iptables", "-D", "INPUT", "!", "-i", "cr+", "-p", "tcp", "--dport", portStr, "-j", "DROP")
+		_ = runner.Run(cleanupCtx, "iptables", "-D", "INPUT", "-i", "lo", "-p", "tcp", "--dport", portStr, "-j", "ACCEPT")
 	}
 	return cleanup, nil
 }

--- a/internal/backend/firecracker/gateway_firewall_test.go
+++ b/internal/backend/firecracker/gateway_firewall_test.go
@@ -15,7 +15,7 @@ func TestSetupGatewayFirewall(t *testing.T) {
 		return nil
 	}
 
-	cleanup, err := setupGatewayFirewall(context.Background(), 8170, run)
+	cleanup, err := setupGatewayFirewall(context.Background(), 8170, testPrivilegedCommandRunner{run: run})
 	if err != nil {
 		t.Fatalf("setupGatewayFirewall: %v", err)
 	}

--- a/internal/backend/firecracker/network_test.go
+++ b/internal/backend/firecracker/network_test.go
@@ -118,7 +118,7 @@ func TestSetupHostNetworkWithTrustedDNSFactoryConfiguresDynamicRulesWithoutStati
 	}
 
 	reqCtx, cancel := context.WithCancel(context.Background())
-	cfg, cleanup, err := setupHostNetworkWithTrustedDNSFactory(reqCtx, "run-12345", false, []policy.AllowRule{{Host: "proxy.golang.org", Ports: []int{443}}}, 8170, lookup, net.InterfaceByName, run, runBatch, factory, nil, nil)
+	cfg, cleanup, err := setupHostNetworkWithTrustedDNSFactory(reqCtx, "run-12345", false, []policy.AllowRule{{Host: "proxy.golang.org", Ports: []int{443}}}, 8170, lookup, net.InterfaceByName, testPrivilegedCommandRunner{run: run, runBatch: runBatch}, factory, nil, nil)
 	if err != nil {
 		t.Fatalf("setupHostNetworkWithTrustedDNSFactory: %v", err)
 	}
@@ -192,7 +192,7 @@ func TestSetupHostNetworkWithDepsAddsDenyDefaultAndCleanupIndependentContext(t *
 	}
 
 	reqCtx, cancel := context.WithCancel(context.Background())
-	cfg, cleanup, err := setupHostNetworkWithTrustedDNSFactory(reqCtx, "run-12345", false, []policy.AllowRule{{Host: "proxy.golang.org", Ports: []int{443}}}, 8170, lookup, net.InterfaceByName, run, runBatch, factory, nil, nil)
+	cfg, cleanup, err := setupHostNetworkWithTrustedDNSFactory(reqCtx, "run-12345", false, []policy.AllowRule{{Host: "proxy.golang.org", Ports: []int{443}}}, 8170, lookup, net.InterfaceByName, testPrivilegedCommandRunner{run: run, runBatch: runBatch}, factory, nil, nil)
 	if err != nil {
 		t.Fatalf("setupHostNetworkWithTrustedDNSFactory: %v", err)
 	}
@@ -292,7 +292,7 @@ func TestSetupHostNetworkWithTapLookupDeletesStaleTapBeforeCreate(t *testing.T) 
 	factory := func(_ context.Context, _ trustedDNSConfig) (func(), *dnsproxy.Runtime, error) {
 		return func() {}, nil, nil
 	}
-	_, cleanup, err := setupHostNetworkWithTrustedDNSFactory(context.Background(), runID, false, []policy.AllowRule{{Host: "proxy.golang.org", Ports: []int{443}}}, 0, lookup, interfaceByName, run, nil, factory, nil, nil)
+	_, cleanup, err := setupHostNetworkWithTrustedDNSFactory(context.Background(), runID, false, []policy.AllowRule{{Host: "proxy.golang.org", Ports: []int{443}}}, 0, lookup, interfaceByName, testPrivilegedCommandRunner{run: run}, factory, nil, nil)
 	if err != nil {
 		t.Fatalf("setupHostNetworkWithTrustedDNSFactory: %v", err)
 	}
@@ -331,7 +331,7 @@ func TestSetupHostNetworkWithDepsAddsAllowAllForwardRule(t *testing.T) {
 	factory := func(_ context.Context, _ trustedDNSConfig) (func(), *dnsproxy.Runtime, error) {
 		return func() {}, nil, nil
 	}
-	cfg, cleanup, err := setupHostNetworkWithTrustedDNSFactory(context.Background(), "run-allow-all", true, []policy.AllowRule{{Host: "stale.example.invalid", Ports: []int{443}}}, 0, lookup, net.InterfaceByName, run, runBatch, factory, nil, nil)
+	cfg, cleanup, err := setupHostNetworkWithTrustedDNSFactory(context.Background(), "run-allow-all", true, []policy.AllowRule{{Host: "stale.example.invalid", Ports: []int{443}}}, 0, lookup, net.InterfaceByName, testPrivilegedCommandRunner{run: run, runBatch: runBatch}, factory, nil, nil)
 	if err != nil {
 		t.Fatalf("setupHostNetworkWithTrustedDNSFactory: %v", err)
 	}
@@ -372,7 +372,7 @@ func TestSetupHostNetworkWithTrustedDNSFactoryPreservesDirectIPAllowRules(t *tes
 		return func() {}, nil, nil
 	}
 
-	cfg, cleanup, err := setupHostNetworkWithTrustedDNSFactory(context.Background(), "run-direct-ip", false, []policy.AllowRule{{Host: "203.0.113.10", Ports: []int{443}}}, 0, lookup, net.InterfaceByName, run, runBatch, factory, nil, nil)
+	cfg, cleanup, err := setupHostNetworkWithTrustedDNSFactory(context.Background(), "run-direct-ip", false, []policy.AllowRule{{Host: "203.0.113.10", Ports: []int{443}}}, 0, lookup, net.InterfaceByName, testPrivilegedCommandRunner{run: run, runBatch: runBatch}, factory, nil, nil)
 	if err != nil {
 		t.Fatalf("setupHostNetworkWithTrustedDNSFactory: %v", err)
 	}
@@ -413,7 +413,7 @@ func TestSetupHostNetworkWithTrustedDNSFactoryInsertsNFLogBeforeDrop(t *testing.
 		return func() {}, nil, nil
 	}
 
-	cfg, cleanup, err := setupHostNetworkWithTrustedDNSFactory(context.Background(), "run-nflog", false, []policy.AllowRule{{Host: "example.com", Ports: []int{443}}}, 0, lookup, net.InterfaceByName, run, runBatch, factory, nil, nil)
+	cfg, cleanup, err := setupHostNetworkWithTrustedDNSFactory(context.Background(), "run-nflog", false, []policy.AllowRule{{Host: "example.com", Ports: []int{443}}}, 0, lookup, net.InterfaceByName, testPrivilegedCommandRunner{run: run, runBatch: runBatch}, factory, nil, nil)
 	if err != nil {
 		t.Fatalf("setupHostNetworkWithTrustedDNSFactory: %v", err)
 	}
@@ -475,7 +475,7 @@ func TestSetupHostNetworkWithTrustedDNSFactoryRemovesNFLogRuleWhenListenerStartu
 		return func() {}, dnsproxy.NewRuntime(dnsproxy.RuntimeConfig{}), nil
 	}
 
-	cfg, cleanup, err := setupHostNetworkWithTrustedDNSFactory(context.Background(), "run-nflog-fail", false, []policy.AllowRule{{Host: "example.com", Ports: []int{443}}}, 0, lookup, net.InterfaceByName, run, runBatch, factory, nil, func(string) {})
+	cfg, cleanup, err := setupHostNetworkWithTrustedDNSFactory(context.Background(), "run-nflog-fail", false, []policy.AllowRule{{Host: "example.com", Ports: []int{443}}}, 0, lookup, net.InterfaceByName, testPrivilegedCommandRunner{run: run, runBatch: runBatch}, factory, nil, func(string) {})
 	if err != nil {
 		t.Fatalf("setupHostNetworkWithTrustedDNSFactory: %v", err)
 	}
@@ -544,7 +544,7 @@ func TestSetupHostNetworkWithTrustedDNSFactoryRetriesNFLogRuleCleanupAfterListen
 		return func() {}, dnsproxy.NewRuntime(dnsproxy.RuntimeConfig{}), nil
 	}
 
-	cfg, cleanup, err := setupHostNetworkWithTrustedDNSFactory(context.Background(), "run-nflog-retry-cleanup", false, []policy.AllowRule{{Host: "example.com", Ports: []int{443}}}, 0, lookup, net.InterfaceByName, run, runBatch, factory, nil, func(string) {})
+	cfg, cleanup, err := setupHostNetworkWithTrustedDNSFactory(context.Background(), "run-nflog-retry-cleanup", false, []policy.AllowRule{{Host: "example.com", Ports: []int{443}}}, 0, lookup, net.InterfaceByName, testPrivilegedCommandRunner{run: run, runBatch: runBatch}, factory, nil, func(string) {})
 	if err != nil {
 		t.Fatalf("setupHostNetworkWithTrustedDNSFactory: %v", err)
 	}
@@ -602,7 +602,7 @@ func TestDeleteTapDeviceWithRetryRetriesBusyTapDeletion(t *testing.T) {
 		return nil, errors.New("no such network interface")
 	}
 
-	if err := deleteTapDeviceWithRetry(context.Background(), tapName, time.Millisecond, interfaceByName, run); err != nil {
+	if err := deleteTapDeviceWithRetry(context.Background(), tapName, time.Millisecond, interfaceByName, testPrivilegedCommandRunner{run: run}); err != nil {
 		t.Fatalf("deleteTapDeviceWithRetry: %v", err)
 	}
 	if got, want := attempts, 2; got != want {
@@ -629,7 +629,7 @@ func TestDeleteTapDeviceWithRetryReturnsLookupError(t *testing.T) {
 		return nil, errors.New("permission denied")
 	}
 
-	err := deleteTapDeviceWithRetry(context.Background(), tapName, time.Millisecond, interfaceByName, run)
+	err := deleteTapDeviceWithRetry(context.Background(), tapName, time.Millisecond, interfaceByName, testPrivilegedCommandRunner{run: run})
 	if err == nil {
 		t.Fatal("expected lookup error")
 	}

--- a/internal/backend/firecracker/privileged_runner.go
+++ b/internal/backend/firecracker/privileged_runner.go
@@ -1,0 +1,152 @@
+package firecracker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+)
+
+type privilegedCommandRunner interface {
+	Run(ctx context.Context, args ...string) error
+	Output(ctx context.Context, args ...string) ([]byte, error)
+	RunBatch(ctx context.Context, commands [][]string) error
+}
+
+type directPrivilegedCommandRunner struct{}
+
+type helperPrivilegedCommandRunner struct {
+	cfg backend.FirecrackerConfig
+}
+
+var privilegedCommandEUID = os.Geteuid
+
+var directPrivilegedCommandPathResolver = resolveDirectPrivilegedCommandPath
+
+func newPrivilegedCommandRunner(cfg backend.FirecrackerConfig) privilegedCommandRunner {
+	if privilegedCommandEUID() == 0 {
+		return directPrivilegedCommandRunner{}
+	}
+	return helperPrivilegedCommandRunner{cfg: cfg}
+}
+
+func newHelperPrivilegedCommandRunner(cfg backend.FirecrackerConfig) privilegedCommandRunner {
+	return helperPrivilegedCommandRunner{cfg: cfg}
+}
+
+func resolveTrustedCommandPath(command string, candidates ...string) (string, error) {
+	for _, candidate := range candidates {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" {
+			continue
+		}
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("%q not found in trusted locations", command)
+}
+
+func resolveDirectPrivilegedCommandPath(command string) (string, error) {
+	switch strings.TrimSpace(command) {
+	case "true":
+		return resolveTrustedCommandPath(command, "/usr/bin/true", "/bin/true")
+	case "dd":
+		return resolveTrustedCommandPath(command, "/usr/bin/dd", "/bin/dd")
+	case "ip":
+		return resolveTrustedCommandPath(command, "/usr/sbin/ip", "/sbin/ip")
+	case "iptables":
+		return resolveTrustedCommandPath(command, "/usr/sbin/iptables", "/sbin/iptables")
+	case "sysctl":
+		return resolveTrustedCommandPath(command, "/usr/sbin/sysctl", "/sbin/sysctl")
+	case "zfs":
+		return resolveTrustedCommandPath(command, "/usr/sbin/zfs", "/sbin/zfs")
+	default:
+		return "", fmt.Errorf("unsupported direct privileged command %q", command)
+	}
+}
+
+func (directPrivilegedCommandRunner) Run(ctx context.Context, args ...string) error {
+	if len(args) == 0 {
+		return errors.New("missing privileged command")
+	}
+	binary, err := directPrivilegedCommandPathResolver(args[0])
+	if err != nil {
+		return err
+	}
+	return runCombinedCommand(ctx, append([]string{binary}, args[1:]...), args)
+}
+
+func (directPrivilegedCommandRunner) Output(ctx context.Context, args ...string) ([]byte, error) {
+	if len(args) == 0 {
+		return nil, errors.New("missing privileged command")
+	}
+	binary, err := directPrivilegedCommandPathResolver(args[0])
+	if err != nil {
+		return nil, err
+	}
+	return runCombinedCommandOutput(ctx, append([]string{binary}, args[1:]...), args)
+}
+
+func (r directPrivilegedCommandRunner) RunBatch(ctx context.Context, commands [][]string) error {
+	for _, args := range commands {
+		if len(args) == 0 {
+			continue
+		}
+		if err := r.Run(ctx, args...); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r helperPrivilegedCommandRunner) Run(ctx context.Context, args ...string) error {
+	if len(args) == 0 {
+		return errors.New("missing privileged command")
+	}
+
+	helperPath := resolvePrivilegedHelperPath(r.cfg)
+	if strings.TrimSpace(helperPath) == "" {
+		return errors.New("missing privileged helper path")
+	}
+	return runCombinedCommand(ctx, append([]string{"sudo", "-n", helperPath}, args...), append([]string{"helper"}, args...))
+}
+
+func (r helperPrivilegedCommandRunner) Output(ctx context.Context, args ...string) ([]byte, error) {
+	if len(args) == 0 {
+		return nil, errors.New("missing privileged command")
+	}
+
+	helperPath := resolvePrivilegedHelperPath(r.cfg)
+	if strings.TrimSpace(helperPath) == "" {
+		return nil, errors.New("missing privileged helper path")
+	}
+	return runCombinedCommandOutput(ctx, append([]string{"sudo", "-n", helperPath}, args...), append([]string{"helper"}, args...))
+}
+
+func (r helperPrivilegedCommandRunner) RunBatch(ctx context.Context, commands [][]string) error {
+	for _, args := range commands {
+		if len(args) == 0 {
+			continue
+		}
+		if err := r.Run(ctx, args...); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func runRootCommand(ctx context.Context, cfg backend.FirecrackerConfig, args ...string) error {
+	return newPrivilegedCommandRunner(cfg).Run(ctx, args...)
+}
+
+func runRootCommandOutput(ctx context.Context, cfg backend.FirecrackerConfig, args ...string) ([]byte, error) {
+	return newPrivilegedCommandRunner(cfg).Output(ctx, args...)
+}
+
+func runRootCommandBatch(ctx context.Context, cfg backend.FirecrackerConfig, commands [][]string) error {
+	return newPrivilegedCommandRunner(cfg).RunBatch(ctx, commands)
+}

--- a/internal/backend/firecracker/privileged_test.go
+++ b/internal/backend/firecracker/privileged_test.go
@@ -58,6 +58,33 @@ func stubDirectPrivilegedCommandPathResolver(t *testing.T, fn func(string) (stri
 	})
 }
 
+type testPrivilegedCommandRunner struct {
+	run      func(context.Context, ...string) error
+	output   func(context.Context, ...string) ([]byte, error)
+	runBatch func(context.Context, [][]string) error
+}
+
+func (r testPrivilegedCommandRunner) Run(ctx context.Context, args ...string) error {
+	if r.run == nil {
+		return nil
+	}
+	return r.run(ctx, args...)
+}
+
+func (r testPrivilegedCommandRunner) Output(ctx context.Context, args ...string) ([]byte, error) {
+	if r.output == nil {
+		return nil, nil
+	}
+	return r.output(ctx, args...)
+}
+
+func (r testPrivilegedCommandRunner) RunBatch(ctx context.Context, commands [][]string) error {
+	if r.runBatch == nil {
+		return nil
+	}
+	return r.runBatch(ctx, commands)
+}
+
 func setupFakeSudo(t *testing.T, logPath string) {
 	t.Helper()
 	stubPrivilegedCommandEUID(t, 1000)


### PR DESCRIPTION
## Summary
- extract Firecracker privileged command execution into a small runner seam with direct-root and helper-backed implementations
- thread that runner through host networking, gateway firewall, and ZFS-backed volume operations instead of rebuilding ad hoc command closures
- keep helper capability/version probes explicit while adding test helpers for the injected runner boundary

## Testing
- go test ./internal/backend/firecracker
- go test ./...
