### PR TITLE
refactor: introduce firecracker host runtime interface

### DIFF
--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -778,6 +778,7 @@ func (a *Adapter) Doctor(_ context.Context, req backend.DoctorRequest) (*backend
 	appendCheck("network_policy_rules", policyRulesStatus, policyRulesMessage)
 
 	privilegedHelperPath := resolvePrivilegedHelperPath(req.FirecrackerConfig)
+	hostRuntime := hostRuntimeForConfig(req.FirecrackerConfig)
 
 	requiredCommands := []string{"ip", "iptables", "sysctl", "sudo"}
 	for _, cmd := range requiredCommands {
@@ -839,7 +840,7 @@ func (a *Adapter) Doctor(_ context.Context, req backend.DoctorRequest) (*backend
 			if zfsBinary == "" {
 				appendCheck("snapshot_zfs_dataset_access", "fail", fmt.Sprintf("unable to access zfs dataset %q: zfs command not available", dataset))
 			} else {
-				if err := validateZFSDatasetRoot(context.Background(), req.FirecrackerConfig, dataset); err != nil {
+				if err := hostRuntime.ValidateZFSDatasetRoot(context.Background(), dataset); err != nil {
 					appendCheck("snapshot_zfs_dataset_access", "fail", err.Error())
 				} else {
 					appendCheck("snapshot_zfs_dataset_access", "pass", fmt.Sprintf("zfs dataset root %q is accessible", dataset))
@@ -850,12 +851,12 @@ func (a *Adapter) Doctor(_ context.Context, req backend.DoctorRequest) (*backend
 		appendCheck("snapshot_driver", "fail", fmt.Sprintf("unsupported snapshot driver %q", req.FirecrackerConfig.Snapshots.Driver))
 	}
 
-	if err := runRootCommand(context.Background(), req.FirecrackerConfig, "true"); err != nil {
+	if err := hostRuntime.CheckAccess(context.Background()); err != nil {
 		appendCheck("network_privileged_probe", "warn", fmt.Sprintf("privileged command probe failed: %v", err))
 	} else {
 		appendCheck("network_privileged_probe", "pass", "privileged command probe succeeded")
 	}
-	if err := runRootCommand(context.Background(), req.FirecrackerConfig, "ip", "link", "show"); err != nil {
+	if err := hostRuntime.CheckNetworking(context.Background()); err != nil {
 		appendCheck("network_privileged_ip", "warn", fmt.Sprintf("privileged ip link show failed: %v", err))
 	} else {
 		appendCheck("network_privileged_ip", "pass", "privileged ip command execution succeeded")
@@ -994,8 +995,12 @@ func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream 
 	vmRootFSPath := writableVolume.AttachmentPath
 
 	networkSetupStart := time.Now()
-	runner := newPrivilegedCommandRunner(req.FirecrackerConfig)
-	networkCfg, cleanupNetwork, err := setupHostNetwork(ctx, req.ExecutionID, req.Policy.NetworkDefault == "allow", req.Policy.Allow, 0, runner, nil, nil)
+	hostRuntime := hostRuntimeForConfig(req.FirecrackerConfig)
+	networkCfg, cleanupNetwork, err := hostRuntime.SetupSandboxNetwork(ctx, sandboxNetworkRequest{
+		SandboxID: req.ExecutionID,
+		AllowAll:  req.Policy.NetworkDefault == "allow",
+		Allow:     req.Policy.Allow,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("setup host network: %w", err)
 	}
@@ -1589,7 +1594,7 @@ func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID strin
 	}
 	vmRootFSPath := writableVolume.AttachmentPath
 
-	runner := newPrivilegedCommandRunner(cfg)
+	hostRuntime := hostRuntimeForConfig(cfg)
 	gwPort := 0
 	if a.GatewayRegistry != nil {
 		gwPort = a.GatewayPort
@@ -1614,7 +1619,14 @@ func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID strin
 		}
 	}
 
-	networkCfg, cleanupNetwork, err := setupHostNetwork(ctx, sandboxID, compiled.NetworkDefault == "allow", compiled.Allow, gwPort, runner, dnsOnDeny, nflogOnBlocked)
+	networkCfg, cleanupNetwork, err := hostRuntime.SetupSandboxNetwork(ctx, sandboxNetworkRequest{
+		SandboxID:   sandboxID,
+		AllowAll:    compiled.NetworkDefault == "allow",
+		Allow:       compiled.Allow,
+		GatewayPort: gwPort,
+		OnDeny:      dnsOnDeny,
+		OnBlocked:   nflogOnBlocked,
+	})
 	if err != nil {
 		cleanupVolume()
 		return nil, fmt.Errorf("setup host network: %w", err)
@@ -1847,18 +1859,6 @@ func snapshotStorageBaseDir(cfg backend.FirecrackerConfig) (string, error) {
 	return paths.SnapshotDir()
 }
 
-type rootVolumeCommandRunner struct {
-	runner privilegedCommandRunner
-}
-
-func (r rootVolumeCommandRunner) Run(ctx context.Context, command string, args ...string) error {
-	return r.runner.Run(ctx, append([]string{command}, args...)...)
-}
-
-func (r rootVolumeCommandRunner) Output(ctx context.Context, command string, args ...string) ([]byte, error) {
-	return r.runner.Output(ctx, append([]string{command}, args...)...)
-}
-
 func snapshotConfigForStorageRef(cfg backend.FirecrackerConfig, storageRef string) (backend.FirecrackerConfig, error) {
 	if datasetRoot, ok := volumestore.ZFSDatasetRootFromManagedRef(storageRef); ok {
 		driverName := strings.ToLower(strings.TrimSpace(cfg.Snapshots.Driver))
@@ -1888,10 +1888,7 @@ func rootFSVolumeStoreDriver(cfg backend.FirecrackerConfig) (volumestore.Driver,
 		}
 		return driver, nil
 	case "zfs":
-		driver, err := volumestore.NewZFSDriver(volumestore.ZFSDriverOptions{
-			DatasetRoot: cfg.Snapshots.ZFSDataset,
-			Runner:      rootVolumeCommandRunner{runner: newPrivilegedCommandRunner(cfg)},
-		})
+		driver, err := hostRuntimeForConfig(cfg).OpenZFSVolumeStore(cfg.Snapshots.ZFSDataset)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/backend/firecracker/gateway_firewall.go
+++ b/internal/backend/firecracker/gateway_firewall.go
@@ -20,10 +20,14 @@ import (
 // Returns a cleanup function that removes the rules. The caller must invoke
 // cleanup on shutdown.
 func SetupGatewayFirewall(ctx context.Context, port int, cfg backend.FirecrackerConfig) (cleanup func(), err error) {
-	return setupGatewayFirewall(ctx, port, newPrivilegedCommandRunner(cfg))
+	return setupGatewayFirewall(ctx, port, hostRuntimeForConfig(cfg))
 }
 
-func setupGatewayFirewall(ctx context.Context, port int, runner privilegedCommandRunner) (cleanup func(), err error) {
+func setupGatewayFirewall(ctx context.Context, port int, runtime hostRuntime) (cleanup func(), err error) {
+	return runtime.SetupGatewayFirewall(ctx, gatewayFirewallRequest{Port: port})
+}
+
+func setupGatewayFirewallWithRunner(ctx context.Context, port int, runner privilegedCommandRunner) (cleanup func(), err error) {
 	portStr := strconv.Itoa(port)
 
 	// Allow loopback access to gateway port.

--- a/internal/backend/firecracker/gateway_firewall_test.go
+++ b/internal/backend/firecracker/gateway_firewall_test.go
@@ -15,7 +15,7 @@ func TestSetupGatewayFirewall(t *testing.T) {
 		return nil
 	}
 
-	cleanup, err := setupGatewayFirewall(context.Background(), 8170, testPrivilegedCommandRunner{run: run})
+	cleanup, err := setupGatewayFirewallWithRunner(context.Background(), 8170, testPrivilegedCommandRunner{run: run})
 	if err != nil {
 		t.Fatalf("setupGatewayFirewall: %v", err)
 	}

--- a/internal/backend/firecracker/host_runtime.go
+++ b/internal/backend/firecracker/host_runtime.go
@@ -1,0 +1,113 @@
+package firecracker
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/buildkite/cleanroom/internal/volumestore"
+)
+
+type hostRuntime interface {
+	CheckAccess(context.Context) error
+	CheckNetworking(context.Context) error
+	SetupSandboxNetwork(context.Context, sandboxNetworkRequest) (hostNetworkConfig, func(), error)
+	SetupGatewayFirewall(context.Context, gatewayFirewallRequest) (func(), error)
+	ValidateZFSDatasetRoot(context.Context, string) error
+	OpenZFSVolumeStore(string) (volumestore.Driver, error)
+}
+
+type hostRuntimeFactory func(backend.FirecrackerConfig) hostRuntime
+
+type sandboxNetworkRequest struct {
+	SandboxID   string
+	AllowAll    bool
+	Allow       []policy.AllowRule
+	GatewayPort int
+	OnDeny      func(sandboxID, queryName string)
+	OnBlocked   func(string)
+}
+
+type gatewayFirewallRequest struct {
+	Port int
+}
+
+type runnerBackedHostRuntime struct {
+	cfg    backend.FirecrackerConfig
+	runner privilegedCommandRunner
+}
+
+type hostRuntimeVolumeCommandRunner struct {
+	runner privilegedCommandRunner
+}
+
+var newHostRuntimeFn hostRuntimeFactory = newRunnerBackedHostRuntime
+
+func hostRuntimeForConfig(cfg backend.FirecrackerConfig) hostRuntime {
+	if newHostRuntimeFn == nil {
+		return newRunnerBackedHostRuntime(cfg)
+	}
+	return newHostRuntimeFn(cfg)
+}
+
+func newRunnerBackedHostRuntime(cfg backend.FirecrackerConfig) hostRuntime {
+	return runnerBackedHostRuntime{
+		cfg:    cfg,
+		runner: newPrivilegedCommandRunner(cfg),
+	}
+}
+
+func (r runnerBackedHostRuntime) CheckAccess(ctx context.Context) error {
+	return r.runner.Run(ctx, "true")
+}
+
+func (r runnerBackedHostRuntime) CheckNetworking(ctx context.Context) error {
+	return r.runner.Run(ctx, "ip", "link", "show")
+}
+
+func (r runnerBackedHostRuntime) SetupSandboxNetwork(ctx context.Context, req sandboxNetworkRequest) (hostNetworkConfig, func(), error) {
+	return setupHostNetwork(ctx, req.SandboxID, req.AllowAll, req.Allow, req.GatewayPort, r.runner, req.OnDeny, req.OnBlocked)
+}
+
+func (r runnerBackedHostRuntime) SetupGatewayFirewall(ctx context.Context, req gatewayFirewallRequest) (func(), error) {
+	return setupGatewayFirewallWithRunner(ctx, req.Port, r.runner)
+}
+
+func (r runnerBackedHostRuntime) ValidateZFSDatasetRoot(ctx context.Context, dataset string) error {
+	return validateZFSDatasetRootWithRunner(ctx, r.runner, dataset)
+}
+
+func (r runnerBackedHostRuntime) OpenZFSVolumeStore(datasetRoot string) (volumestore.Driver, error) {
+	return volumestore.NewZFSDriver(volumestore.ZFSDriverOptions{
+		DatasetRoot: datasetRoot,
+		Runner:      hostRuntimeVolumeCommandRunner{runner: r.runner},
+	})
+}
+
+func (r hostRuntimeVolumeCommandRunner) Run(ctx context.Context, command string, args ...string) error {
+	return r.runner.Run(ctx, append([]string{command}, args...)...)
+}
+
+func (r hostRuntimeVolumeCommandRunner) Output(ctx context.Context, command string, args ...string) ([]byte, error) {
+	return r.runner.Output(ctx, append([]string{command}, args...)...)
+}
+
+func validateZFSDatasetRootWithRunner(ctx context.Context, runner privilegedCommandRunner, dataset string) error {
+	dataset = strings.TrimSpace(dataset)
+	if dataset == "" {
+		return fmt.Errorf("zfs dataset root is empty")
+	}
+	if !isCleanroomZFSDatasetRoot(dataset) {
+		return fmt.Errorf("zfs dataset root %q must be cleanroom or */cleanroom", dataset)
+	}
+	out, err := runner.Output(ctx, "zfs", "list", "-H", "-d", "0", "-o", "name", dataset)
+	if err != nil {
+		return fmt.Errorf("unable to access zfs dataset root %q: %v", dataset, err)
+	}
+	if strings.TrimSpace(string(out)) != dataset {
+		return fmt.Errorf("zfs dataset probe for %q returned %q", dataset, strings.TrimSpace(string(out)))
+	}
+	return nil
+}

--- a/internal/backend/firecracker/host_runtime_test.go
+++ b/internal/backend/firecracker/host_runtime_test.go
@@ -1,0 +1,122 @@
+package firecracker
+
+import (
+	"context"
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/volumestore"
+)
+
+type testHostRuntime struct {
+	checkAccessFn            func(context.Context) error
+	checkNetworkingFn        func(context.Context) error
+	setupSandboxNetworkFn    func(context.Context, sandboxNetworkRequest) (hostNetworkConfig, func(), error)
+	setupGatewayFirewallFn   func(context.Context, gatewayFirewallRequest) (func(), error)
+	validateZFSDatasetRootFn func(context.Context, string) error
+	openZFSVolumeStoreFn     func(string) (volumestore.Driver, error)
+}
+
+func (r testHostRuntime) CheckAccess(ctx context.Context) error {
+	if r.checkAccessFn == nil {
+		return nil
+	}
+	return r.checkAccessFn(ctx)
+}
+
+func (r testHostRuntime) CheckNetworking(ctx context.Context) error {
+	if r.checkNetworkingFn == nil {
+		return nil
+	}
+	return r.checkNetworkingFn(ctx)
+}
+
+func (r testHostRuntime) SetupSandboxNetwork(ctx context.Context, req sandboxNetworkRequest) (hostNetworkConfig, func(), error) {
+	if r.setupSandboxNetworkFn == nil {
+		return hostNetworkConfig{}, func() {}, nil
+	}
+	return r.setupSandboxNetworkFn(ctx, req)
+}
+
+func (r testHostRuntime) SetupGatewayFirewall(ctx context.Context, req gatewayFirewallRequest) (func(), error) {
+	if r.setupGatewayFirewallFn == nil {
+		return func() {}, nil
+	}
+	return r.setupGatewayFirewallFn(ctx, req)
+}
+
+func (r testHostRuntime) ValidateZFSDatasetRoot(ctx context.Context, dataset string) error {
+	if r.validateZFSDatasetRootFn == nil {
+		return nil
+	}
+	return r.validateZFSDatasetRootFn(ctx, dataset)
+}
+
+func (r testHostRuntime) OpenZFSVolumeStore(datasetRoot string) (volumestore.Driver, error) {
+	if r.openZFSVolumeStoreFn == nil {
+		return nil, nil
+	}
+	return r.openZFSVolumeStoreFn(datasetRoot)
+}
+
+func TestSetupGatewayFirewallUsesHostRuntime(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	cleanedUp := false
+
+	cleanup, err := setupGatewayFirewall(context.Background(), 8170, testHostRuntime{
+		setupGatewayFirewallFn: func(_ context.Context, req gatewayFirewallRequest) (func(), error) {
+			called = true
+			if got, want := req.Port, 8170; got != want {
+				t.Fatalf("unexpected gateway firewall port: got %d want %d", got, want)
+			}
+			return func() { cleanedUp = true }, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("setupGatewayFirewall returned error: %v", err)
+	}
+	if !called {
+		t.Fatal("expected host runtime gateway firewall setup to be called")
+	}
+
+	cleanup()
+	if !cleanedUp {
+		t.Fatal("expected host runtime cleanup to run")
+	}
+}
+
+func TestRootFSVolumeStoreDriverUsesHostRuntimeForZFS(t *testing.T) {
+	prevHostRuntimeFn := newHostRuntimeFn
+	t.Cleanup(func() { newHostRuntimeFn = prevHostRuntimeFn })
+
+	var gotDatasetRoot string
+	newHostRuntimeFn = func(cfg backend.FirecrackerConfig) hostRuntime {
+		if got, want := cfg.Snapshots.Driver, "zfs"; got != want {
+			t.Fatalf("unexpected snapshot driver: got %q want %q", got, want)
+		}
+		return testHostRuntime{
+			openZFSVolumeStoreFn: func(datasetRoot string) (volumestore.Driver, error) {
+				gotDatasetRoot = datasetRoot
+				return testVolumeDriver{}, nil
+			},
+		}
+	}
+
+	driver, err := rootFSVolumeStoreDriver(backend.FirecrackerConfig{
+		Snapshots: backend.SnapshotConfig{
+			Driver:     "zfs",
+			ZFSDataset: "tank/cleanroom",
+		},
+	})
+	if err != nil {
+		t.Fatalf("rootFSVolumeStoreDriver returned error: %v", err)
+	}
+	if got, want := gotDatasetRoot, "tank/cleanroom"; got != want {
+		t.Fatalf("unexpected zfs dataset root: got %q want %q", got, want)
+	}
+	if _, ok := driver.(testVolumeDriver); !ok {
+		t.Fatalf("unexpected zfs driver type: %T", driver)
+	}
+}

--- a/internal/backend/firecracker/host_support.go
+++ b/internal/backend/firecracker/host_support.go
@@ -190,21 +190,7 @@ func discoverCleanroomZFSDatasetRoots(ctx context.Context, zfsPath string) ([]st
 }
 
 func validateZFSDatasetRoot(ctx context.Context, cfg backend.FirecrackerConfig, dataset string) error {
-	dataset = strings.TrimSpace(dataset)
-	if dataset == "" {
-		return fmt.Errorf("zfs dataset root is empty")
-	}
-	if !isCleanroomZFSDatasetRoot(dataset) {
-		return fmt.Errorf("zfs dataset root %q must be cleanroom or */cleanroom", dataset)
-	}
-	out, err := runRootCommandOutput(ctx, cfg, "zfs", "list", "-H", "-d", "0", "-o", "name", dataset)
-	if err != nil {
-		return fmt.Errorf("unable to access zfs dataset root %q: %v", dataset, err)
-	}
-	if strings.TrimSpace(string(out)) != dataset {
-		return fmt.Errorf("zfs dataset probe for %q returned %q", dataset, strings.TrimSpace(string(out)))
-	}
-	return nil
+	return validateZFSDatasetRootWithRunner(ctx, newPrivilegedCommandRunner(cfg), dataset)
 }
 
 func isCleanroomZFSDatasetRoot(dataset string) bool {


### PR DESCRIPTION
## Summary
- add a small internal `hostRuntime` abstraction for Firecracker host operations with a runner-backed implementation
- route execution, persistent sandbox networking, gateway firewall setup, and ZFS volume-store wiring through that interface instead of constructing privileged argv in adapter paths
- keep helper version and capability probes explicit while sharing the runner-backed ZFS dataset validation path and add focused seam tests

## Testing
- go test ./internal/backend/firecracker
- go test ./...