### PR TITLE
refactor: add firecracker host runtime leases

### DIFF
--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -13,8 +13,6 @@ import (
 	"io"
 	"log"
 	"math"
-	"net"
-	"net/netip"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -28,7 +26,6 @@ import (
 
 	"github.com/buildkite/cleanroom/internal/backend"
 	"github.com/buildkite/cleanroom/internal/bootassets"
-	"github.com/buildkite/cleanroom/internal/dnsproxy"
 	"github.com/buildkite/cleanroom/internal/ext4edit"
 	"github.com/buildkite/cleanroom/internal/gateway"
 	"github.com/buildkite/cleanroom/internal/hosttools"
@@ -996,7 +993,7 @@ func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream 
 
 	networkSetupStart := time.Now()
 	hostRuntime := hostRuntimeForConfig(req.FirecrackerConfig)
-	networkCfg, cleanupNetwork, err := hostRuntime.SetupSandboxNetwork(ctx, sandboxNetworkRequest{
+	networkLease, err := hostRuntime.SetupSandboxNetwork(ctx, sandboxNetworkRequest{
 		SandboxID: req.ExecutionID,
 		AllowAll:  req.Policy.NetworkDefault == "allow",
 		Allow:     req.Policy.Allow,
@@ -1004,6 +1001,7 @@ func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream 
 	if err != nil {
 		return nil, fmt.Errorf("setup host network: %w", err)
 	}
+	networkCfg := networkLease.Config
 	observation.NetworkSetupMS = time.Since(networkSetupStart).Milliseconds()
 	observation.PolicyResolveMS = networkCfg.PolicyResolveMS
 	observation.NetworkTap = networkCfg.TapName
@@ -1011,7 +1009,7 @@ func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream 
 	observation.NetworkHostIP = networkCfg.HostIP
 	cleanupMeasured := func() {
 		cleanupStart := time.Now()
-		cleanupNetwork()
+		_ = networkLease.Release(context.Background())
 		observation.CleanupMS = time.Since(cleanupStart).Milliseconds()
 	}
 	defer cleanupMeasured()
@@ -1619,7 +1617,7 @@ func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID strin
 		}
 	}
 
-	networkCfg, cleanupNetwork, err := hostRuntime.SetupSandboxNetwork(ctx, sandboxNetworkRequest{
+	networkLease, err := hostRuntime.SetupSandboxNetwork(ctx, sandboxNetworkRequest{
 		SandboxID:   sandboxID,
 		AllowAll:    compiled.NetworkDefault == "allow",
 		Allow:       compiled.Allow,
@@ -1630,6 +1628,10 @@ func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID strin
 	if err != nil {
 		cleanupVolume()
 		return nil, fmt.Errorf("setup host network: %w", err)
+	}
+	networkCfg := networkLease.Config
+	cleanupNetwork := func() {
+		_ = networkLease.Release(context.Background())
 	}
 
 	if a.GatewayRegistry != nil {
@@ -2125,385 +2127,6 @@ func stopVM(fcCmd *exec.Cmd, processExited <-chan struct{}) {
 	case <-processExited:
 	case <-time.After(2 * time.Second):
 	}
-}
-
-type hostNetworkConfig struct {
-	TapName         string
-	HostIP          string
-	GuestIP         string
-	GuestDNS        string
-	PolicyResolveMS int64
-}
-
-type ipLookupFunc func(ctx context.Context, host string) ([]net.IP, error)
-type interfaceLookupFunc func(name string) (*net.Interface, error)
-type rootCommandBatchFunc func(ctx context.Context, commands [][]string) error
-
-func setupHostNetwork(ctx context.Context, runID string, allowAll bool, allow []policy.AllowRule, gatewayPort int, runner privilegedCommandRunner, onDeny func(sandboxID, queryName string), onBlocked func(string)) (hostNetworkConfig, func(), error) {
-	lookup := func(ctx context.Context, host string) ([]net.IP, error) {
-		return net.DefaultResolver.LookupIP(ctx, "ip4", host)
-	}
-	return setupHostNetworkWithDeps(ctx, runID, allowAll, allow, gatewayPort, lookup, runner, onDeny, onBlocked)
-}
-
-func setupHostNetworkWithDeps(ctx context.Context, runID string, allowAll bool, allow []policy.AllowRule, gatewayPort int, lookup ipLookupFunc, runner privilegedCommandRunner, onDeny func(sandboxID, queryName string), onBlocked func(string)) (hostNetworkConfig, func(), error) {
-	return setupHostNetworkWithTrustedDNSFactory(ctx, runID, allowAll, allow, gatewayPort, lookup, net.InterfaceByName, runner, newTrustedDNSService, onDeny, onBlocked)
-}
-
-func setupHostNetworkWithTapLookup(ctx context.Context, runID string, allowAll bool, allow []policy.AllowRule, gatewayPort int, lookup ipLookupFunc, interfaceByName interfaceLookupFunc, runner privilegedCommandRunner, onDeny func(sandboxID, queryName string), onBlocked func(string)) (hostNetworkConfig, func(), error) {
-	return setupHostNetworkWithTrustedDNSFactory(ctx, runID, allowAll, allow, gatewayPort, lookup, interfaceByName, runner, newTrustedDNSService, onDeny, onBlocked)
-}
-
-func setupHostNetworkWithTrustedDNSFactory(ctx context.Context, runID string, allowAll bool, allow []policy.AllowRule, gatewayPort int, lookup ipLookupFunc, interfaceByName interfaceLookupFunc, runner privilegedCommandRunner, factory trustedDNSFactory, onDeny func(sandboxID, queryName string), onBlocked func(string)) (hostNetworkConfig, func(), error) {
-	_ = lookup
-	if factory == nil {
-		factory = newTrustedDNSService
-	}
-
-	tapName := tapNameFromExecutionID(runID)
-	hostIP, guestIP := hostGuestIPs(runID)
-	hostCIDR := hostIP + "/24"
-	guestCIDR := guestIP + "/32"
-	hostAddr, err := netip.ParseAddr(hostIP)
-	if err != nil {
-		return hostNetworkConfig{}, func() {}, fmt.Errorf("parse host ip %q: %w", hostIP, err)
-	}
-	guestAddr, err := netip.ParseAddr(guestIP)
-	if err != nil {
-		return hostNetworkConfig{}, func() {}, fmt.Errorf("parse guest ip %q: %w", guestIP, err)
-	}
-
-	setupRun := func(args ...string) error {
-		return runner.Run(ctx, args...)
-	}
-	cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), networkCleanupTimeout)
-	cleanupCmds := make([][]string, 0, 16)
-	trustedDNSCleanup := func() {}
-	nflogCleanupFn := func() {}
-	cleanup := func() {
-		defer cleanupCancel()
-		nflogCleanupFn()
-		trustedDNSCleanup()
-		reversed := make([][]string, 0, len(cleanupCmds))
-		for i := len(cleanupCmds) - 1; i >= 0; i-- {
-			reversed = append(reversed, cleanupCmds[i])
-		}
-		for _, args := range reversed {
-			if isTapDeleteCommand(args, tapName) {
-				_ = deleteTapDeviceWithRetry(cleanupCtx, tapName, tapDeleteRetryInterval, interfaceByName, runner)
-				continue
-			}
-			_ = runner.Run(cleanupCtx, args...)
-		}
-	}
-	addCleanup := func(args ...string) {
-		cleanupCmds = append(cleanupCmds, append([]string(nil), args...))
-	}
-	removeNFLogRule := func(tapName, groupStr string) {
-		args := []string{"iptables", "-D", "FORWARD", "-i", tapName, "-j", "NFLOG", "--nflog-group", groupStr}
-		if err := runner.Run(cleanupCtx, args...); err != nil {
-			log.Printf("nflog iptables cleanup failed for %s: %v", tapName, err)
-			addCleanup(args...)
-		}
-	}
-
-	staleTapCleanupCtx, staleTapCleanupCancel := context.WithTimeout(context.Background(), networkCleanupTimeout)
-	defer staleTapCleanupCancel()
-	if _, err := interfaceByName(tapName); err == nil {
-		if err := deleteTapDeviceWithRetry(staleTapCleanupCtx, tapName, tapDeleteRetryInterval, interfaceByName, runner); err != nil {
-			return hostNetworkConfig{}, func() {}, fmt.Errorf("remove stale tap device %s: %w", tapName, err)
-		}
-	} else if !isNoSuchNetworkInterfaceError(err) {
-		return hostNetworkConfig{}, func() {}, fmt.Errorf("lookup tap device %s: %w", tapName, err)
-	}
-
-	if err := setupRun("ip", "tuntap", "add", "dev", tapName, "mode", "tap", "user", strconv.Itoa(os.Getuid())); err != nil {
-		return hostNetworkConfig{}, func() {}, fmt.Errorf("create tap device %s: %w", tapName, err)
-	}
-	addCleanup("ip", "link", "del", tapName)
-	if err := setupRun("ip", "addr", "add", hostCIDR, "dev", tapName); err != nil {
-		cleanup()
-		return hostNetworkConfig{}, func() {}, fmt.Errorf("assign host ip to %s: %w", tapName, err)
-	}
-	if err := setupRun("ip", "link", "set", "dev", tapName, "up"); err != nil {
-		cleanup()
-		return hostNetworkConfig{}, func() {}, fmt.Errorf("bring tap %s up: %w", tapName, err)
-	}
-	if err := setupRun("sysctl", "-w", "net.ipv4.ip_forward=1"); err != nil {
-		cleanup()
-		return hostNetworkConfig{}, func() {}, fmt.Errorf("enable ipv4 forwarding: %w", err)
-	}
-
-	// Disable IPv6 on TAP to prevent bypass of IPv4-only policy controls.
-	if err := setupRun("sysctl", "-w", fmt.Sprintf("net.ipv6.conf.%s.disable_ipv6=1", tapName)); err != nil {
-		cleanup()
-		return hostNetworkConfig{}, func() {}, fmt.Errorf("disable ipv6 on %s: %w", tapName, err)
-	}
-
-	if err := setupRun("iptables", "-A", "INPUT", "-i", tapName, "!", "-s", guestIP, "-j", "DROP"); err != nil {
-		cleanup()
-		return hostNetworkConfig{}, func() {}, fmt.Errorf("install anti-spoof rule for %s: %w", tapName, err)
-	}
-	addCleanup("iptables", "-D", "INPUT", "-i", tapName, "!", "-s", guestIP, "-j", "DROP")
-
-	if gatewayPort > 0 {
-		port := strconv.Itoa(gatewayPort)
-		if err := setupRun("iptables", "-A", "INPUT", "-i", tapName, "-s", guestIP, "-p", "tcp", "--dport", port, "-j", "ACCEPT"); err != nil {
-			cleanup()
-			return hostNetworkConfig{}, func() {}, fmt.Errorf("install gateway accept rule for %s: %w", tapName, err)
-		}
-		addCleanup("iptables", "-D", "INPUT", "-i", tapName, "-s", guestIP, "-p", "tcp", "--dport", port, "-j", "ACCEPT")
-	}
-
-	for _, proto := range []string{"udp", "tcp"} {
-		if err := setupRun("iptables", "-A", "INPUT", "-i", tapName, "-s", guestIP, "-p", proto, "--dport", strconv.Itoa(trustedDNSListenPort), "-j", "ACCEPT"); err != nil {
-			cleanup()
-			return hostNetworkConfig{}, func() {}, fmt.Errorf("install trusted dns %s accept rule for %s: %w", proto, tapName, err)
-		}
-		addCleanup("iptables", "-D", "INPUT", "-i", tapName, "-s", guestIP, "-p", proto, "--dport", strconv.Itoa(trustedDNSListenPort), "-j", "ACCEPT")
-	}
-
-	if err := setupRun("iptables", "-A", "INPUT", "-i", tapName, "-j", "DROP"); err != nil {
-		cleanup()
-		return hostNetworkConfig{}, func() {}, fmt.Errorf("install input deny rule for %s: %w", tapName, err)
-	}
-	addCleanup("iptables", "-D", "INPUT", "-i", tapName, "-j", "DROP")
-
-	if err := setupRun("iptables", "-t", "nat", "-A", "POSTROUTING", "-s", guestCIDR, "-j", "MASQUERADE"); err != nil {
-		cleanup()
-		return hostNetworkConfig{}, func() {}, fmt.Errorf("install nat rule for %s: %w", guestCIDR, err)
-	}
-	addCleanup("iptables", "-t", "nat", "-D", "POSTROUTING", "-s", guestCIDR, "-j", "MASQUERADE")
-
-	for _, proto := range []string{"udp", "tcp"} {
-		if err := setupRun("iptables", "-t", "nat", "-A", "PREROUTING", "-i", tapName, "-p", proto, "--dport", "53", "-j", "REDIRECT", "--to-ports", strconv.Itoa(trustedDNSListenPort)); err != nil {
-			cleanup()
-			return hostNetworkConfig{}, func() {}, fmt.Errorf("install trusted dns %s redirect for %s: %w", proto, tapName, err)
-		}
-		addCleanup("iptables", "-t", "nat", "-D", "PREROUTING", "-i", tapName, "-p", proto, "--dport", "53", "-j", "REDIRECT", "--to-ports", strconv.Itoa(trustedDNSListenPort))
-	}
-
-	returnPathCleanup, err := installForwardReturnPathRule(setupRun, tapName)
-	if err != nil {
-		cleanup()
-		return hostNetworkConfig{}, func() {}, fmt.Errorf("install forward return-path rule for %s: %w", tapName, err)
-	}
-	addCleanup(returnPathCleanup...)
-
-	tcpChainName := ""
-	udpChainName := ""
-	if !allowAll {
-		tcpChainName = trustedDNSTCPChainName(tapName)
-		udpChainName = trustedDNSUDPChainName(tapName)
-
-		if err := setupRun("iptables", "-N", tcpChainName); err != nil {
-			cleanup()
-			return hostNetworkConfig{}, func() {}, fmt.Errorf("create trusted dns tcp chain for %s: %w", tapName, err)
-		}
-		addCleanup("iptables", "-X", tcpChainName)
-		addCleanup("iptables", "-F", tcpChainName)
-		if err := setupRun("iptables", "-N", udpChainName); err != nil {
-			cleanup()
-			return hostNetworkConfig{}, func() {}, fmt.Errorf("create trusted dns udp chain for %s: %w", tapName, err)
-		}
-		addCleanup("iptables", "-X", udpChainName)
-		addCleanup("iptables", "-F", udpChainName)
-
-		establishedCleanup, err := installForwardEstablishedEgressRule(setupRun, tapName)
-		if err != nil {
-			cleanup()
-			return hostNetworkConfig{}, func() {}, fmt.Errorf("install forward established egress rule for %s: %w", tapName, err)
-		}
-		addCleanup(establishedCleanup...)
-
-		if err := setupRun("iptables", "-A", "FORWARD", "-i", tapName, "-p", "tcp", "-j", tcpChainName); err != nil {
-			cleanup()
-			return hostNetworkConfig{}, func() {}, fmt.Errorf("install trusted dns tcp chain jump for %s: %w", tapName, err)
-		}
-		addCleanup("iptables", "-D", "FORWARD", "-i", tapName, "-p", "tcp", "-j", tcpChainName)
-		if err := setupRun("iptables", "-A", "FORWARD", "-i", tapName, "-p", "udp", "-j", udpChainName); err != nil {
-			cleanup()
-			return hostNetworkConfig{}, func() {}, fmt.Errorf("install trusted dns udp chain jump for %s: %w", tapName, err)
-		}
-		addCleanup("iptables", "-D", "FORWARD", "-i", tapName, "-p", "udp", "-j", udpChainName)
-
-		for _, rule := range literalIPv4AllowRules(allow) {
-			for _, proto := range []string{"tcp", "udp"} {
-				for _, port := range rule.Ports {
-					portText := strconv.Itoa(port)
-					if err := setupRun("iptables", "-A", "FORWARD", "-i", tapName, "-d", rule.Host, "-p", proto, "--dport", portText, "-j", "ACCEPT"); err != nil {
-						cleanup()
-						return hostNetworkConfig{}, func() {}, fmt.Errorf("install direct-ip %s allow rule for %s: %w", proto, rule.Host, err)
-					}
-					addCleanup("iptables", "-D", "FORWARD", "-i", tapName, "-d", rule.Host, "-p", proto, "--dport", portText, "-j", "ACCEPT")
-				}
-			}
-		}
-	}
-
-	var dnsRuntime *dnsproxy.Runtime
-	trustedDNSCleanup, dnsRuntime, err = factory(ctx, trustedDNSConfig{
-		sandboxID:    runID,
-		hostIP:       hostAddr,
-		guestIP:      guestAddr,
-		policy:       trustedDNSPolicy(allowAll, allow),
-		runBatch:     runner.RunBatch,
-		tcpChainName: tcpChainName,
-		udpChainName: udpChainName,
-		onDeny:       onDeny,
-	})
-	if err != nil {
-		cleanup()
-		return hostNetworkConfig{}, func() {}, fmt.Errorf("start trusted dns service: %w", err)
-	}
-
-	if allowAll {
-		if err := setupRun("iptables", "-A", "FORWARD", "-i", tapName, "-j", "ACCEPT"); err != nil {
-			cleanup()
-			return hostNetworkConfig{}, func() {}, fmt.Errorf("install allow-all forward rule for %s: %w", tapName, err)
-		}
-		addCleanup("iptables", "-D", "FORWARD", "-i", tapName, "-j", "ACCEPT")
-	} else {
-		nflogGroup := nflogGroupFromTapNameFn(tapName)
-		if nflogGroup > 0 && onBlocked != nil && dnsRuntime != nil {
-			groupStr := strconv.Itoa(int(nflogGroup))
-			if err := setupRun("iptables", "-A", "FORWARD", "-i", tapName, "-j", "NFLOG", "--nflog-group", groupStr); err != nil {
-				log.Printf("nflog iptables rule unavailable for %s: %v", tapName, err)
-			} else {
-				listener, nflogErr := newNFLogListenerFn(nflogListenerConfig{
-					group:     nflogGroup,
-					sandboxID: runID,
-					guestIP:   guestAddr,
-					runtime:   dnsRuntime,
-					onBlocked: onBlocked,
-				})
-				if nflogErr != nil {
-					log.Printf("nflog listener unavailable for %s: %v", runID, nflogErr)
-					removeNFLogRule(tapName, groupStr)
-				} else if listener == nil {
-					removeNFLogRule(tapName, groupStr)
-				} else if listener != nil {
-					addCleanup("iptables", "-D", "FORWARD", "-i", tapName, "-j", "NFLOG", "--nflog-group", groupStr)
-					nflogCleanupFn = func() { _ = listener.Close() }
-				}
-			}
-		}
-
-		if err := setupRun("iptables", "-A", "FORWARD", "-i", tapName, "-j", "DROP"); err != nil {
-			cleanup()
-			return hostNetworkConfig{}, func() {}, fmt.Errorf("install default deny forward rule for %s: %w", tapName, err)
-		}
-		addCleanup("iptables", "-D", "FORWARD", "-i", tapName, "-j", "DROP")
-	}
-
-	return hostNetworkConfig{
-		TapName:         tapName,
-		HostIP:          hostIP,
-		GuestIP:         guestIP,
-		GuestDNS:        hostIP,
-		PolicyResolveMS: 0,
-	}, cleanup, nil
-}
-
-func isTapDeleteCommand(args []string, tapName string) bool {
-	return len(args) == 4 && args[0] == "ip" && args[1] == "link" && args[2] == "del" && args[3] == tapName
-}
-
-func deleteTapDeviceWithRetry(ctx context.Context, tapName string, retryInterval time.Duration, interfaceByName interfaceLookupFunc, runner privilegedCommandRunner) error {
-	if strings.TrimSpace(tapName) == "" {
-		return nil
-	}
-	if retryInterval <= 0 {
-		retryInterval = time.Millisecond
-	}
-
-	ticker := time.NewTicker(retryInterval)
-	defer ticker.Stop()
-
-	for {
-		err := runner.Run(ctx, "ip", "link", "del", tapName)
-		if err == nil {
-			return nil
-		}
-		if _, lookupErr := interfaceByName(tapName); lookupErr != nil {
-			if isNoSuchNetworkInterfaceError(lookupErr) {
-				return nil
-			}
-			return fmt.Errorf("lookup tap device %s after delete failure (%v): %w", tapName, err, lookupErr)
-		}
-
-		select {
-		case <-ctx.Done():
-			return fmt.Errorf("delete tap device %s: %w", tapName, err)
-		case <-ticker.C:
-		}
-	}
-}
-
-func isNoSuchNetworkInterfaceError(err error) bool {
-	if err == nil {
-		return false
-	}
-	var opErr *net.OpError
-	if errors.As(err, &opErr) && opErr.Err != nil {
-		return strings.Contains(opErr.Err.Error(), "no such network interface")
-	}
-	return strings.Contains(err.Error(), "no such network interface")
-}
-
-func installForwardReturnPathRule(setupRun func(args ...string) error, tapName string) ([]string, error) {
-	return installForwardEstablishedRule(setupRun, "-o", tapName)
-}
-
-func installForwardEstablishedEgressRule(setupRun func(args ...string) error, tapName string) ([]string, error) {
-	return installForwardEstablishedRule(setupRun, "-i", tapName)
-}
-
-func installForwardEstablishedRule(setupRun func(args ...string) error, directionFlag, tapName string) ([]string, error) {
-	conntrackAdd := []string{"iptables", "-A", "FORWARD", directionFlag, tapName, "-m", "conntrack", "--ctstate", "RELATED,ESTABLISHED", "-j", "ACCEPT"}
-	if err := setupRun(conntrackAdd...); err == nil {
-		return []string{"iptables", "-D", "FORWARD", directionFlag, tapName, "-m", "conntrack", "--ctstate", "RELATED,ESTABLISHED", "-j", "ACCEPT"}, nil
-	}
-
-	stateAdd := []string{"iptables", "-A", "FORWARD", directionFlag, tapName, "-m", "state", "--state", "RELATED,ESTABLISHED", "-j", "ACCEPT"}
-	if err := setupRun(stateAdd...); err != nil {
-		return nil, err
-	}
-	return []string{"iptables", "-D", "FORWARD", directionFlag, tapName, "-m", "state", "--state", "RELATED,ESTABLISHED", "-j", "ACCEPT"}, nil
-}
-
-func trustedDNSPolicy(allowAll bool, allow []policy.AllowRule) *policy.CompiledPolicy {
-	copied := make([]policy.AllowRule, 0, len(allow))
-	for _, rule := range allow {
-		copied = append(copied, policy.AllowRule{
-			Host:  rule.Host,
-			Ports: append([]int(nil), rule.Ports...),
-		})
-	}
-	networkDefault := "deny"
-	if allowAll {
-		networkDefault = "allow"
-	}
-	return &policy.CompiledPolicy{
-		Version:        1,
-		NetworkDefault: networkDefault,
-		Allow:          copied,
-	}
-}
-
-func literalIPv4AllowRules(allow []policy.AllowRule) []policy.AllowRule {
-	out := make([]policy.AllowRule, 0, len(allow))
-	for _, rule := range allow {
-		addr, err := netip.ParseAddr(strings.TrimSpace(rule.Host))
-		if err != nil || !addr.Is4() {
-			continue
-		}
-		out = append(out, policy.AllowRule{
-			Host:  addr.String(),
-			Ports: append([]int(nil), rule.Ports...),
-		})
-	}
-	return out
 }
 
 func resolvePrivilegedHelperPath(cfg backend.FirecrackerConfig) string {

--- a/internal/backend/firecracker/gateway_firewall.go
+++ b/internal/backend/firecracker/gateway_firewall.go
@@ -24,7 +24,13 @@ func SetupGatewayFirewall(ctx context.Context, port int, cfg backend.Firecracker
 }
 
 func setupGatewayFirewall(ctx context.Context, port int, runtime hostRuntime) (cleanup func(), err error) {
-	return runtime.SetupGatewayFirewall(ctx, gatewayFirewallRequest{Port: port})
+	lease, err := runtime.SetupGatewayFirewall(ctx, gatewayFirewallRequest{Port: port})
+	if err != nil {
+		return nil, err
+	}
+	return func() {
+		_ = lease.Release(context.Background())
+	}, nil
 }
 
 func setupGatewayFirewallWithRunner(ctx context.Context, port int, runner privilegedCommandRunner) (cleanup func(), err error) {

--- a/internal/backend/firecracker/host_network.go
+++ b/internal/backend/firecracker/host_network.go
@@ -1,0 +1,398 @@
+package firecracker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"net/netip"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/buildkite/cleanroom/internal/dnsproxy"
+	"github.com/buildkite/cleanroom/internal/policy"
+)
+
+type hostNetworkConfig struct {
+	TapName         string
+	HostIP          string
+	GuestIP         string
+	GuestDNS        string
+	PolicyResolveMS int64
+}
+
+type ipLookupFunc func(ctx context.Context, host string) ([]net.IP, error)
+type interfaceLookupFunc func(name string) (*net.Interface, error)
+type rootCommandBatchFunc func(ctx context.Context, commands [][]string) error
+
+func setupHostNetwork(ctx context.Context, runID string, allowAll bool, allow []policy.AllowRule, gatewayPort int, runner privilegedCommandRunner, onDeny func(sandboxID, queryName string), onBlocked func(string)) (hostNetworkConfig, func(), error) {
+	lookup := func(ctx context.Context, host string) ([]net.IP, error) {
+		return net.DefaultResolver.LookupIP(ctx, "ip4", host)
+	}
+	return setupHostNetworkWithDeps(ctx, runID, allowAll, allow, gatewayPort, lookup, runner, onDeny, onBlocked)
+}
+
+func setupHostNetworkWithDeps(ctx context.Context, runID string, allowAll bool, allow []policy.AllowRule, gatewayPort int, lookup ipLookupFunc, runner privilegedCommandRunner, onDeny func(sandboxID, queryName string), onBlocked func(string)) (hostNetworkConfig, func(), error) {
+	return setupHostNetworkWithTrustedDNSFactory(ctx, runID, allowAll, allow, gatewayPort, lookup, net.InterfaceByName, runner, newTrustedDNSService, onDeny, onBlocked)
+}
+
+func setupHostNetworkWithTapLookup(ctx context.Context, runID string, allowAll bool, allow []policy.AllowRule, gatewayPort int, lookup ipLookupFunc, interfaceByName interfaceLookupFunc, runner privilegedCommandRunner, onDeny func(sandboxID, queryName string), onBlocked func(string)) (hostNetworkConfig, func(), error) {
+	return setupHostNetworkWithTrustedDNSFactory(ctx, runID, allowAll, allow, gatewayPort, lookup, interfaceByName, runner, newTrustedDNSService, onDeny, onBlocked)
+}
+
+func setupHostNetworkWithTrustedDNSFactory(ctx context.Context, runID string, allowAll bool, allow []policy.AllowRule, gatewayPort int, lookup ipLookupFunc, interfaceByName interfaceLookupFunc, runner privilegedCommandRunner, factory trustedDNSFactory, onDeny func(sandboxID, queryName string), onBlocked func(string)) (hostNetworkConfig, func(), error) {
+	_ = lookup
+	if factory == nil {
+		factory = newTrustedDNSService
+	}
+
+	tapName := tapNameFromExecutionID(runID)
+	hostIP, guestIP := hostGuestIPs(runID)
+	hostCIDR := hostIP + "/24"
+	guestCIDR := guestIP + "/32"
+	hostAddr, err := netip.ParseAddr(hostIP)
+	if err != nil {
+		return hostNetworkConfig{}, func() {}, fmt.Errorf("parse host ip %q: %w", hostIP, err)
+	}
+	guestAddr, err := netip.ParseAddr(guestIP)
+	if err != nil {
+		return hostNetworkConfig{}, func() {}, fmt.Errorf("parse guest ip %q: %w", guestIP, err)
+	}
+
+	setupRun := func(args ...string) error {
+		return runner.Run(ctx, args...)
+	}
+	cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), networkCleanupTimeout)
+	cleanupCmds := make([][]string, 0, 16)
+	trustedDNSCleanup := func() {}
+	nflogCleanupFn := func() {}
+	cleanup := func() {
+		defer cleanupCancel()
+		nflogCleanupFn()
+		trustedDNSCleanup()
+		reversed := make([][]string, 0, len(cleanupCmds))
+		for i := len(cleanupCmds) - 1; i >= 0; i-- {
+			reversed = append(reversed, cleanupCmds[i])
+		}
+		for _, args := range reversed {
+			if isTapDeleteCommand(args, tapName) {
+				_ = deleteTapDeviceWithRetry(cleanupCtx, tapName, tapDeleteRetryInterval, interfaceByName, runner)
+				continue
+			}
+			_ = runner.Run(cleanupCtx, args...)
+		}
+	}
+	addCleanup := func(args ...string) {
+		cleanupCmds = append(cleanupCmds, append([]string(nil), args...))
+	}
+	removeNFLogRule := func(tapName, groupStr string) {
+		args := []string{"iptables", "-D", "FORWARD", "-i", tapName, "-j", "NFLOG", "--nflog-group", groupStr}
+		if err := runner.Run(cleanupCtx, args...); err != nil {
+			log.Printf("nflog iptables cleanup failed for %s: %v", tapName, err)
+			addCleanup(args...)
+		}
+	}
+
+	staleTapCleanupCtx, staleTapCleanupCancel := context.WithTimeout(context.Background(), networkCleanupTimeout)
+	defer staleTapCleanupCancel()
+	if _, err := interfaceByName(tapName); err == nil {
+		if err := deleteTapDeviceWithRetry(staleTapCleanupCtx, tapName, tapDeleteRetryInterval, interfaceByName, runner); err != nil {
+			return hostNetworkConfig{}, func() {}, fmt.Errorf("remove stale tap device %s: %w", tapName, err)
+		}
+	} else if !isNoSuchNetworkInterfaceError(err) {
+		return hostNetworkConfig{}, func() {}, fmt.Errorf("lookup tap device %s: %w", tapName, err)
+	}
+
+	if err := setupRun("ip", "tuntap", "add", "dev", tapName, "mode", "tap", "user", strconv.Itoa(os.Getuid())); err != nil {
+		return hostNetworkConfig{}, func() {}, fmt.Errorf("create tap device %s: %w", tapName, err)
+	}
+	addCleanup("ip", "link", "del", tapName)
+	if err := setupRun("ip", "addr", "add", hostCIDR, "dev", tapName); err != nil {
+		cleanup()
+		return hostNetworkConfig{}, func() {}, fmt.Errorf("assign host ip to %s: %w", tapName, err)
+	}
+	if err := setupRun("ip", "link", "set", "dev", tapName, "up"); err != nil {
+		cleanup()
+		return hostNetworkConfig{}, func() {}, fmt.Errorf("bring tap %s up: %w", tapName, err)
+	}
+	if err := setupRun("sysctl", "-w", "net.ipv4.ip_forward=1"); err != nil {
+		cleanup()
+		return hostNetworkConfig{}, func() {}, fmt.Errorf("enable ipv4 forwarding: %w", err)
+	}
+
+	// Disable IPv6 on TAP to prevent bypass of IPv4-only policy controls.
+	if err := setupRun("sysctl", "-w", fmt.Sprintf("net.ipv6.conf.%s.disable_ipv6=1", tapName)); err != nil {
+		cleanup()
+		return hostNetworkConfig{}, func() {}, fmt.Errorf("disable ipv6 on %s: %w", tapName, err)
+	}
+
+	if err := setupRun("iptables", "-A", "INPUT", "-i", tapName, "!", "-s", guestIP, "-j", "DROP"); err != nil {
+		cleanup()
+		return hostNetworkConfig{}, func() {}, fmt.Errorf("install anti-spoof rule for %s: %w", tapName, err)
+	}
+	addCleanup("iptables", "-D", "INPUT", "-i", tapName, "!", "-s", guestIP, "-j", "DROP")
+
+	if gatewayPort > 0 {
+		port := strconv.Itoa(gatewayPort)
+		if err := setupRun("iptables", "-A", "INPUT", "-i", tapName, "-s", guestIP, "-p", "tcp", "--dport", port, "-j", "ACCEPT"); err != nil {
+			cleanup()
+			return hostNetworkConfig{}, func() {}, fmt.Errorf("install gateway accept rule for %s: %w", tapName, err)
+		}
+		addCleanup("iptables", "-D", "INPUT", "-i", tapName, "-s", guestIP, "-p", "tcp", "--dport", port, "-j", "ACCEPT")
+	}
+
+	for _, proto := range []string{"udp", "tcp"} {
+		if err := setupRun("iptables", "-A", "INPUT", "-i", tapName, "-s", guestIP, "-p", proto, "--dport", strconv.Itoa(trustedDNSListenPort), "-j", "ACCEPT"); err != nil {
+			cleanup()
+			return hostNetworkConfig{}, func() {}, fmt.Errorf("install trusted dns %s accept rule for %s: %w", proto, tapName, err)
+		}
+		addCleanup("iptables", "-D", "INPUT", "-i", tapName, "-s", guestIP, "-p", proto, "--dport", strconv.Itoa(trustedDNSListenPort), "-j", "ACCEPT")
+	}
+
+	if err := setupRun("iptables", "-A", "INPUT", "-i", tapName, "-j", "DROP"); err != nil {
+		cleanup()
+		return hostNetworkConfig{}, func() {}, fmt.Errorf("install input deny rule for %s: %w", tapName, err)
+	}
+	addCleanup("iptables", "-D", "INPUT", "-i", tapName, "-j", "DROP")
+
+	if err := setupRun("iptables", "-t", "nat", "-A", "POSTROUTING", "-s", guestCIDR, "-j", "MASQUERADE"); err != nil {
+		cleanup()
+		return hostNetworkConfig{}, func() {}, fmt.Errorf("install nat rule for %s: %w", guestCIDR, err)
+	}
+	addCleanup("iptables", "-t", "nat", "-D", "POSTROUTING", "-s", guestCIDR, "-j", "MASQUERADE")
+
+	for _, proto := range []string{"udp", "tcp"} {
+		if err := setupRun("iptables", "-t", "nat", "-A", "PREROUTING", "-i", tapName, "-p", proto, "--dport", "53", "-j", "REDIRECT", "--to-ports", strconv.Itoa(trustedDNSListenPort)); err != nil {
+			cleanup()
+			return hostNetworkConfig{}, func() {}, fmt.Errorf("install trusted dns %s redirect for %s: %w", proto, tapName, err)
+		}
+		addCleanup("iptables", "-t", "nat", "-D", "PREROUTING", "-i", tapName, "-p", proto, "--dport", "53", "-j", "REDIRECT", "--to-ports", strconv.Itoa(trustedDNSListenPort))
+	}
+
+	returnPathCleanup, err := installForwardReturnPathRule(setupRun, tapName)
+	if err != nil {
+		cleanup()
+		return hostNetworkConfig{}, func() {}, fmt.Errorf("install forward return-path rule for %s: %w", tapName, err)
+	}
+	addCleanup(returnPathCleanup...)
+
+	tcpChainName := ""
+	udpChainName := ""
+	if !allowAll {
+		tcpChainName = trustedDNSTCPChainName(tapName)
+		udpChainName = trustedDNSUDPChainName(tapName)
+
+		if err := setupRun("iptables", "-N", tcpChainName); err != nil {
+			cleanup()
+			return hostNetworkConfig{}, func() {}, fmt.Errorf("create trusted dns tcp chain for %s: %w", tapName, err)
+		}
+		addCleanup("iptables", "-X", tcpChainName)
+		addCleanup("iptables", "-F", tcpChainName)
+		if err := setupRun("iptables", "-N", udpChainName); err != nil {
+			cleanup()
+			return hostNetworkConfig{}, func() {}, fmt.Errorf("create trusted dns udp chain for %s: %w", tapName, err)
+		}
+		addCleanup("iptables", "-X", udpChainName)
+		addCleanup("iptables", "-F", udpChainName)
+
+		establishedCleanup, err := installForwardEstablishedEgressRule(setupRun, tapName)
+		if err != nil {
+			cleanup()
+			return hostNetworkConfig{}, func() {}, fmt.Errorf("install forward established egress rule for %s: %w", tapName, err)
+		}
+		addCleanup(establishedCleanup...)
+
+		if err := setupRun("iptables", "-A", "FORWARD", "-i", tapName, "-p", "tcp", "-j", tcpChainName); err != nil {
+			cleanup()
+			return hostNetworkConfig{}, func() {}, fmt.Errorf("install trusted dns tcp chain jump for %s: %w", tapName, err)
+		}
+		addCleanup("iptables", "-D", "FORWARD", "-i", tapName, "-p", "tcp", "-j", tcpChainName)
+		if err := setupRun("iptables", "-A", "FORWARD", "-i", tapName, "-p", "udp", "-j", udpChainName); err != nil {
+			cleanup()
+			return hostNetworkConfig{}, func() {}, fmt.Errorf("install trusted dns udp chain jump for %s: %w", tapName, err)
+		}
+		addCleanup("iptables", "-D", "FORWARD", "-i", tapName, "-p", "udp", "-j", udpChainName)
+
+		for _, rule := range literalIPv4AllowRules(allow) {
+			for _, proto := range []string{"tcp", "udp"} {
+				for _, port := range rule.Ports {
+					portText := strconv.Itoa(port)
+					if err := setupRun("iptables", "-A", "FORWARD", "-i", tapName, "-d", rule.Host, "-p", proto, "--dport", portText, "-j", "ACCEPT"); err != nil {
+						cleanup()
+						return hostNetworkConfig{}, func() {}, fmt.Errorf("install direct-ip %s allow rule for %s: %w", proto, rule.Host, err)
+					}
+					addCleanup("iptables", "-D", "FORWARD", "-i", tapName, "-d", rule.Host, "-p", proto, "--dport", portText, "-j", "ACCEPT")
+				}
+			}
+		}
+	}
+
+	var dnsRuntime *dnsproxy.Runtime
+	trustedDNSCleanup, dnsRuntime, err = factory(ctx, trustedDNSConfig{
+		sandboxID:    runID,
+		hostIP:       hostAddr,
+		guestIP:      guestAddr,
+		policy:       trustedDNSPolicy(allowAll, allow),
+		runBatch:     runner.RunBatch,
+		tcpChainName: tcpChainName,
+		udpChainName: udpChainName,
+		onDeny:       onDeny,
+	})
+	if err != nil {
+		cleanup()
+		return hostNetworkConfig{}, func() {}, fmt.Errorf("start trusted dns service: %w", err)
+	}
+
+	if allowAll {
+		if err := setupRun("iptables", "-A", "FORWARD", "-i", tapName, "-j", "ACCEPT"); err != nil {
+			cleanup()
+			return hostNetworkConfig{}, func() {}, fmt.Errorf("install allow-all forward rule for %s: %w", tapName, err)
+		}
+		addCleanup("iptables", "-D", "FORWARD", "-i", tapName, "-j", "ACCEPT")
+	} else {
+		nflogGroup := nflogGroupFromTapNameFn(tapName)
+		if nflogGroup > 0 && onBlocked != nil && dnsRuntime != nil {
+			groupStr := strconv.Itoa(int(nflogGroup))
+			if err := setupRun("iptables", "-A", "FORWARD", "-i", tapName, "-j", "NFLOG", "--nflog-group", groupStr); err != nil {
+				log.Printf("nflog iptables rule unavailable for %s: %v", tapName, err)
+			} else {
+				listener, nflogErr := newNFLogListenerFn(nflogListenerConfig{
+					group:     nflogGroup,
+					sandboxID: runID,
+					guestIP:   guestAddr,
+					runtime:   dnsRuntime,
+					onBlocked: onBlocked,
+				})
+				if nflogErr != nil {
+					log.Printf("nflog listener unavailable for %s: %v", runID, nflogErr)
+					removeNFLogRule(tapName, groupStr)
+				} else if listener == nil {
+					removeNFLogRule(tapName, groupStr)
+				} else {
+					addCleanup("iptables", "-D", "FORWARD", "-i", tapName, "-j", "NFLOG", "--nflog-group", groupStr)
+					nflogCleanupFn = func() { _ = listener.Close() }
+				}
+			}
+		}
+
+		if err := setupRun("iptables", "-A", "FORWARD", "-i", tapName, "-j", "DROP"); err != nil {
+			cleanup()
+			return hostNetworkConfig{}, func() {}, fmt.Errorf("install default deny forward rule for %s: %w", tapName, err)
+		}
+		addCleanup("iptables", "-D", "FORWARD", "-i", tapName, "-j", "DROP")
+	}
+
+	return hostNetworkConfig{
+		TapName:         tapName,
+		HostIP:          hostIP,
+		GuestIP:         guestIP,
+		GuestDNS:        hostIP,
+		PolicyResolveMS: 0,
+	}, cleanup, nil
+}
+
+func isTapDeleteCommand(args []string, tapName string) bool {
+	return len(args) == 4 && args[0] == "ip" && args[1] == "link" && args[2] == "del" && args[3] == tapName
+}
+
+func deleteTapDeviceWithRetry(ctx context.Context, tapName string, retryInterval time.Duration, interfaceByName interfaceLookupFunc, runner privilegedCommandRunner) error {
+	if strings.TrimSpace(tapName) == "" {
+		return nil
+	}
+	if retryInterval <= 0 {
+		retryInterval = time.Millisecond
+	}
+
+	ticker := time.NewTicker(retryInterval)
+	defer ticker.Stop()
+
+	for {
+		err := runner.Run(ctx, "ip", "link", "del", tapName)
+		if err == nil {
+			return nil
+		}
+		if _, lookupErr := interfaceByName(tapName); lookupErr != nil {
+			if isNoSuchNetworkInterfaceError(lookupErr) {
+				return nil
+			}
+			return fmt.Errorf("lookup tap device %s after delete failure (%v): %w", tapName, err, lookupErr)
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("delete tap device %s: %w", tapName, err)
+		case <-ticker.C:
+		}
+	}
+}
+
+func isNoSuchNetworkInterfaceError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var opErr *net.OpError
+	if errors.As(err, &opErr) && opErr.Err != nil {
+		err = opErr.Err
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "no such network interface") || strings.Contains(msg, "not found")
+}
+
+func installForwardReturnPathRule(setupRun func(args ...string) error, tapName string) ([]string, error) {
+	return installForwardEstablishedRule(setupRun, "-o", tapName)
+}
+
+func installForwardEstablishedEgressRule(setupRun func(args ...string) error, tapName string) ([]string, error) {
+	return installForwardEstablishedRule(setupRun, "-i", tapName)
+}
+
+func installForwardEstablishedRule(setupRun func(args ...string) error, directionFlag, tapName string) ([]string, error) {
+	conntrackRule := []string{"iptables", "-A", "FORWARD", directionFlag, tapName, "-m", "conntrack", "--ctstate", "RELATED,ESTABLISHED", "-j", "ACCEPT"}
+	if err := setupRun(conntrackRule...); err == nil {
+		cleanup := append([]string{"iptables", "-D", "FORWARD", directionFlag, tapName}, conntrackRule[5:]...)
+		return cleanup, nil
+	}
+	stateRule := []string{"iptables", "-A", "FORWARD", directionFlag, tapName, "-m", "state", "--state", "RELATED,ESTABLISHED", "-j", "ACCEPT"}
+	if err := setupRun(stateRule...); err != nil {
+		return nil, err
+	}
+	cleanup := append([]string{"iptables", "-D", "FORWARD", directionFlag, tapName}, stateRule[5:]...)
+	return cleanup, nil
+}
+
+func trustedDNSPolicy(allowAll bool, allow []policy.AllowRule) *policy.CompiledPolicy {
+	copied := make([]policy.AllowRule, 0, len(allow))
+	for _, rule := range allow {
+		copied = append(copied, policy.AllowRule{
+			Host:  rule.Host,
+			Ports: append([]int(nil), rule.Ports...),
+		})
+	}
+	networkDefault := "deny"
+	if allowAll {
+		networkDefault = "allow"
+	}
+	return &policy.CompiledPolicy{
+		Version:        1,
+		NetworkDefault: networkDefault,
+		Allow:          copied,
+	}
+}
+
+func literalIPv4AllowRules(allow []policy.AllowRule) []policy.AllowRule {
+	out := make([]policy.AllowRule, 0, len(allow))
+	for _, rule := range allow {
+		addr, err := netip.ParseAddr(strings.TrimSpace(rule.Host))
+		if err != nil || !addr.Is4() {
+			continue
+		}
+		out = append(out, policy.AllowRule{
+			Host:  addr.String(),
+			Ports: append([]int(nil), rule.Ports...),
+		})
+	}
+	return out
+}

--- a/internal/backend/firecracker/host_runtime.go
+++ b/internal/backend/firecracker/host_runtime.go
@@ -13,8 +13,8 @@ import (
 type hostRuntime interface {
 	CheckAccess(context.Context) error
 	CheckNetworking(context.Context) error
-	SetupSandboxNetwork(context.Context, sandboxNetworkRequest) (hostNetworkConfig, func(), error)
-	SetupGatewayFirewall(context.Context, gatewayFirewallRequest) (func(), error)
+	SetupSandboxNetwork(context.Context, sandboxNetworkRequest) (sandboxNetworkLease, error)
+	SetupGatewayFirewall(context.Context, gatewayFirewallRequest) (gatewayFirewallLease, error)
 	ValidateZFSDatasetRoot(context.Context, string) error
 	OpenZFSVolumeStore(string) (volumestore.Driver, error)
 }
@@ -32,6 +32,15 @@ type sandboxNetworkRequest struct {
 
 type gatewayFirewallRequest struct {
 	Port int
+}
+
+type sandboxNetworkLease struct {
+	Config  hostNetworkConfig
+	release func(context.Context) error
+}
+
+type gatewayFirewallLease struct {
+	release func(context.Context) error
 }
 
 type runnerBackedHostRuntime struct {
@@ -67,12 +76,45 @@ func (r runnerBackedHostRuntime) CheckNetworking(ctx context.Context) error {
 	return r.runner.Run(ctx, "ip", "link", "show")
 }
 
-func (r runnerBackedHostRuntime) SetupSandboxNetwork(ctx context.Context, req sandboxNetworkRequest) (hostNetworkConfig, func(), error) {
-	return setupHostNetwork(ctx, req.SandboxID, req.AllowAll, req.Allow, req.GatewayPort, r.runner, req.OnDeny, req.OnBlocked)
+func (l sandboxNetworkLease) Release(ctx context.Context) error {
+	if l.release == nil {
+		return nil
+	}
+	return l.release(ctx)
 }
 
-func (r runnerBackedHostRuntime) SetupGatewayFirewall(ctx context.Context, req gatewayFirewallRequest) (func(), error) {
-	return setupGatewayFirewallWithRunner(ctx, req.Port, r.runner)
+func (l gatewayFirewallLease) Release(ctx context.Context) error {
+	if l.release == nil {
+		return nil
+	}
+	return l.release(ctx)
+}
+
+func (r runnerBackedHostRuntime) SetupSandboxNetwork(ctx context.Context, req sandboxNetworkRequest) (sandboxNetworkLease, error) {
+	config, cleanup, err := setupHostNetwork(ctx, req.SandboxID, req.AllowAll, req.Allow, req.GatewayPort, r.runner, req.OnDeny, req.OnBlocked)
+	if err != nil {
+		return sandboxNetworkLease{}, err
+	}
+	return sandboxNetworkLease{
+		Config: config,
+		release: func(context.Context) error {
+			cleanup()
+			return nil
+		},
+	}, nil
+}
+
+func (r runnerBackedHostRuntime) SetupGatewayFirewall(ctx context.Context, req gatewayFirewallRequest) (gatewayFirewallLease, error) {
+	cleanup, err := setupGatewayFirewallWithRunner(ctx, req.Port, r.runner)
+	if err != nil {
+		return gatewayFirewallLease{}, err
+	}
+	return gatewayFirewallLease{
+		release: func(context.Context) error {
+			cleanup()
+			return nil
+		},
+	}, nil
 }
 
 func (r runnerBackedHostRuntime) ValidateZFSDatasetRoot(ctx context.Context, dataset string) error {

--- a/internal/backend/firecracker/host_runtime_test.go
+++ b/internal/backend/firecracker/host_runtime_test.go
@@ -11,8 +11,8 @@ import (
 type testHostRuntime struct {
 	checkAccessFn            func(context.Context) error
 	checkNetworkingFn        func(context.Context) error
-	setupSandboxNetworkFn    func(context.Context, sandboxNetworkRequest) (hostNetworkConfig, func(), error)
-	setupGatewayFirewallFn   func(context.Context, gatewayFirewallRequest) (func(), error)
+	setupSandboxNetworkFn    func(context.Context, sandboxNetworkRequest) (sandboxNetworkLease, error)
+	setupGatewayFirewallFn   func(context.Context, gatewayFirewallRequest) (gatewayFirewallLease, error)
 	validateZFSDatasetRootFn func(context.Context, string) error
 	openZFSVolumeStoreFn     func(string) (volumestore.Driver, error)
 }
@@ -31,16 +31,16 @@ func (r testHostRuntime) CheckNetworking(ctx context.Context) error {
 	return r.checkNetworkingFn(ctx)
 }
 
-func (r testHostRuntime) SetupSandboxNetwork(ctx context.Context, req sandboxNetworkRequest) (hostNetworkConfig, func(), error) {
+func (r testHostRuntime) SetupSandboxNetwork(ctx context.Context, req sandboxNetworkRequest) (sandboxNetworkLease, error) {
 	if r.setupSandboxNetworkFn == nil {
-		return hostNetworkConfig{}, func() {}, nil
+		return sandboxNetworkLease{}, nil
 	}
 	return r.setupSandboxNetworkFn(ctx, req)
 }
 
-func (r testHostRuntime) SetupGatewayFirewall(ctx context.Context, req gatewayFirewallRequest) (func(), error) {
+func (r testHostRuntime) SetupGatewayFirewall(ctx context.Context, req gatewayFirewallRequest) (gatewayFirewallLease, error) {
 	if r.setupGatewayFirewallFn == nil {
-		return func() {}, nil
+		return gatewayFirewallLease{}, nil
 	}
 	return r.setupGatewayFirewallFn(ctx, req)
 }
@@ -66,12 +66,15 @@ func TestSetupGatewayFirewallUsesHostRuntime(t *testing.T) {
 	cleanedUp := false
 
 	cleanup, err := setupGatewayFirewall(context.Background(), 8170, testHostRuntime{
-		setupGatewayFirewallFn: func(_ context.Context, req gatewayFirewallRequest) (func(), error) {
+		setupGatewayFirewallFn: func(_ context.Context, req gatewayFirewallRequest) (gatewayFirewallLease, error) {
 			called = true
 			if got, want := req.Port, 8170; got != want {
 				t.Fatalf("unexpected gateway firewall port: got %d want %d", got, want)
 			}
-			return func() { cleanedUp = true }, nil
+			return gatewayFirewallLease{release: func(context.Context) error {
+				cleanedUp = true
+				return nil
+			}}, nil
 		},
 	})
 	if err != nil {
@@ -118,5 +121,24 @@ func TestRootFSVolumeStoreDriverUsesHostRuntimeForZFS(t *testing.T) {
 	}
 	if _, ok := driver.(testVolumeDriver); !ok {
 		t.Fatalf("unexpected zfs driver type: %T", driver)
+	}
+}
+
+func TestSandboxNetworkLeaseReleaseRunsCleanup(t *testing.T) {
+	t.Parallel()
+
+	released := false
+	lease := sandboxNetworkLease{
+		release: func(context.Context) error {
+			released = true
+			return nil
+		},
+	}
+
+	if err := lease.Release(context.Background()); err != nil {
+		t.Fatalf("Release returned error: %v", err)
+	}
+	if !released {
+		t.Fatal("expected sandbox network lease release to invoke cleanup")
 	}
 }


### PR DESCRIPTION
## Summary
- change the Firecracker host-runtime seam from raw cleanup closures to typed network and gateway firewall leases
- update the adapter call sites to depend on lease config and release semantics instead of raw cleanup funcs
- move the runner-backed host networking implementation into its own file so `backend.go` no longer owns those mechanics

## Testing
- go test ./internal/backend/firecracker
- go test ./...