### PR TITLE
refactor: lift firecracker zfs storage ops into host runtime

### DIFF
--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -509,6 +509,9 @@ func (a *Adapter) CreateSnapshot(ctx context.Context, req backend.SnapshotReques
 	if err != nil {
 		return nil, err
 	}
+	if err := validateSnapshotStorageConfig(driverCfg); err != nil {
+		return nil, err
+	}
 	driverName := strings.ToLower(strings.TrimSpace(driverCfg.Snapshots.Driver))
 	if err := pauseSandboxProcess(instance); err != nil {
 		return nil, err
@@ -1981,6 +1984,20 @@ func validateSnapshotsEnabled(cfg backend.FirecrackerConfig) error {
 		return errors.New("firecracker snapshots are not enabled")
 	}
 	return nil
+}
+
+func validateSnapshotStorageConfig(cfg backend.FirecrackerConfig) error {
+	if err := validateSnapshotsEnabled(cfg); err != nil {
+		return err
+	}
+	if strings.EqualFold(strings.TrimSpace(cfg.Snapshots.Driver), "zfs") {
+		if strings.TrimSpace(cfg.Snapshots.ZFSDataset) == "" {
+			return errors.New("zfs volume driver requires dataset root")
+		}
+		return nil
+	}
+	_, err := snapshotVolumeStoreDriverFn(cfg)
+	return err
 }
 
 func pauseSandboxProcess(instance *sandboxInstance) error {

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -509,10 +509,7 @@ func (a *Adapter) CreateSnapshot(ctx context.Context, req backend.SnapshotReques
 	if err != nil {
 		return nil, err
 	}
-	driver, err := snapshotVolumeStoreDriverFn(driverCfg)
-	if err != nil {
-		return nil, err
-	}
+	driverName := strings.ToLower(strings.TrimSpace(driverCfg.Snapshots.Driver))
 	if err := pauseSandboxProcess(instance); err != nil {
 		return nil, err
 	}
@@ -525,7 +522,7 @@ func (a *Adapter) CreateSnapshot(ctx context.Context, req backend.SnapshotReques
 		if err := resumeSandboxProcess(instance); err != nil && retErr == nil {
 			if strings.TrimSpace(snapshotStorageRef) != "" {
 				cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-				cleanupErr := driver.DestroySnapshot(cleanupCtx, volumestore.DestroySnapshotRequest{SnapshotRef: snapshotStorageRef})
+				cleanupErr := destroySnapshotStorage(cleanupCtx, driverCfg, snapshotStorageRef)
 				cancel()
 				if cleanupErr != nil {
 					result = nil
@@ -537,20 +534,15 @@ func (a *Adapter) CreateSnapshot(ctx context.Context, req backend.SnapshotReques
 			retErr = fmt.Errorf("resume firecracker sandbox after snapshot: %w", err)
 		}
 	}()
-	if err := flushSnapshotHostFilesystem(ctx, driverCfg.Snapshots.Driver); err != nil {
+	if err := flushSnapshotHostFilesystem(ctx, driverName); err != nil {
 		return nil, err
 	}
-
-	snapshot, err := driver.SnapshotVolume(ctx, volumestore.SnapshotVolumeRequest{
-		SnapshotID: snapshotID,
-		VolumeRef:  volumeRef,
-	})
+	snapshotStorageRef, err = createSnapshotStorage(ctx, driverCfg, snapshotID, volumeRef)
 	if err != nil {
 		return nil, fmt.Errorf("persist snapshot rootfs: %w", err)
 	}
-	snapshotStorageRef = snapshot.StorageRef
 
-	return &backend.SnapshotResult{StorageRef: snapshot.StorageRef}, nil
+	return &backend.SnapshotResult{StorageRef: snapshotStorageRef}, nil
 }
 
 func (a *Adapter) ProvisionSandboxFromSnapshot(ctx context.Context, req backend.ProvisionFromSnapshotRequest) error {
@@ -616,13 +608,7 @@ func (a *Adapter) DeleteSnapshot(ctx context.Context, req backend.DeleteSnapshot
 	if err != nil {
 		return err
 	}
-	driver, err := snapshotVolumeStoreDriver(driverCfg)
-	if err != nil {
-		return err
-	}
-	if err := driver.DestroySnapshot(ctx, volumestore.DestroySnapshotRequest{
-		SnapshotRef: storageRef,
-	}); err != nil {
+	if err := destroySnapshotStorage(ctx, driverCfg, storageRef); err != nil {
 		return fmt.Errorf("remove snapshot rootfs %q: %w", storageRef, err)
 	}
 	return nil
@@ -1837,6 +1823,31 @@ func prepareWritableRootVolume(ctx context.Context, cfg backend.FirecrackerConfi
 	if err != nil {
 		return volumestore.WritableVolume{}, nil, err
 	}
+	if strings.EqualFold(strings.TrimSpace(driverCfg.Snapshots.Driver), "zfs") {
+		hostRuntime := hostRuntimeForConfig(driverCfg)
+		zfsReq := zfsWritableVolumeRequest{
+			VolumeID:     volumeID,
+			MinimumBytes: cfg.MinimumRootFSBytes,
+		}
+		if filepath.IsAbs(strings.TrimSpace(sourceRef)) {
+			zfsReq.SourcePath = sourceRef
+		} else {
+			zfsReq.SnapshotRef = sourceRef
+		}
+		volume, err := hostRuntime.PrepareZFSWritableVolume(ctx, zfsReq)
+		if err != nil {
+			return volumestore.WritableVolume{}, nil, err
+		}
+		cleanupVolume := func() {
+			if err := hostRuntime.DestroyZFSVolume(context.Background(), volume.Ref); err != nil {
+				log.Printf("firecracker: cleanup persistent volume %q: %v", volume.Ref, err)
+			}
+		}
+		return volumestore.WritableVolume{
+			Ref:            volume.Ref,
+			AttachmentPath: volume.AttachmentPath,
+		}, cleanupVolume, nil
+	}
 	driver, err := rootFSVolumeStoreDriverFn(driverCfg)
 	if err != nil {
 		return volumestore.WritableVolume{}, nil, err
@@ -1889,12 +1900,6 @@ func rootFSVolumeStoreDriver(cfg backend.FirecrackerConfig) (volumestore.Driver,
 			return nil, err
 		}
 		return driver, nil
-	case "zfs":
-		driver, err := hostRuntimeForConfig(cfg).OpenZFSVolumeStore(cfg.Snapshots.ZFSDataset)
-		if err != nil {
-			return nil, err
-		}
-		return driver, nil
 	default:
 		return nil, fmt.Errorf("unsupported firecracker snapshot driver %q", cfg.Snapshots.Driver)
 	}
@@ -1925,6 +1930,44 @@ func flushSnapshotHostFilesystem(ctx context.Context, driverName string) error {
 
 func snapshotDriverNeedsHostSync(driverName string) bool {
 	return strings.EqualFold(strings.TrimSpace(driverName), "zfs")
+}
+
+func createSnapshotStorage(ctx context.Context, cfg backend.FirecrackerConfig, snapshotID, volumeRef string) (string, error) {
+	if strings.EqualFold(strings.TrimSpace(cfg.Snapshots.Driver), "zfs") {
+		snapshot, err := hostRuntimeForConfig(cfg).CreateZFSSnapshot(ctx, zfsSnapshotRequest{
+			SnapshotID: snapshotID,
+			VolumeRef:  volumeRef,
+		})
+		if err != nil {
+			return "", err
+		}
+		return snapshot.StorageRef, nil
+	}
+
+	driver, err := snapshotVolumeStoreDriverFn(cfg)
+	if err != nil {
+		return "", err
+	}
+	snapshot, err := driver.SnapshotVolume(ctx, volumestore.SnapshotVolumeRequest{
+		SnapshotID: snapshotID,
+		VolumeRef:  volumeRef,
+	})
+	if err != nil {
+		return "", err
+	}
+	return snapshot.StorageRef, nil
+}
+
+func destroySnapshotStorage(ctx context.Context, cfg backend.FirecrackerConfig, storageRef string) error {
+	if strings.EqualFold(strings.TrimSpace(cfg.Snapshots.Driver), "zfs") {
+		return hostRuntimeForConfig(cfg).DestroyZFSSnapshot(ctx, storageRef)
+	}
+
+	driver, err := snapshotVolumeStoreDriverFn(cfg)
+	if err != nil {
+		return err
+	}
+	return driver.DestroySnapshot(ctx, volumestore.DestroySnapshotRequest{SnapshotRef: storageRef})
 }
 
 func pauseSandboxProcess(instance *sandboxInstance) error {

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -1906,8 +1906,8 @@ func rootFSVolumeStoreDriver(cfg backend.FirecrackerConfig) (volumestore.Driver,
 }
 
 func snapshotVolumeStoreDriver(cfg backend.FirecrackerConfig) (volumestore.Driver, error) {
-	if !cfg.Snapshots.Enabled {
-		return nil, errors.New("firecracker snapshots are not enabled")
+	if err := validateSnapshotsEnabled(cfg); err != nil {
+		return nil, err
 	}
 	return rootFSVolumeStoreDriver(cfg)
 }
@@ -1933,6 +1933,9 @@ func snapshotDriverNeedsHostSync(driverName string) bool {
 }
 
 func createSnapshotStorage(ctx context.Context, cfg backend.FirecrackerConfig, snapshotID, volumeRef string) (string, error) {
+	if err := validateSnapshotsEnabled(cfg); err != nil {
+		return "", err
+	}
 	if strings.EqualFold(strings.TrimSpace(cfg.Snapshots.Driver), "zfs") {
 		snapshot, err := hostRuntimeForConfig(cfg).CreateZFSSnapshot(ctx, zfsSnapshotRequest{
 			SnapshotID: snapshotID,
@@ -1959,6 +1962,9 @@ func createSnapshotStorage(ctx context.Context, cfg backend.FirecrackerConfig, s
 }
 
 func destroySnapshotStorage(ctx context.Context, cfg backend.FirecrackerConfig, storageRef string) error {
+	if err := validateSnapshotsEnabled(cfg); err != nil {
+		return err
+	}
 	if strings.EqualFold(strings.TrimSpace(cfg.Snapshots.Driver), "zfs") {
 		return hostRuntimeForConfig(cfg).DestroyZFSSnapshot(ctx, storageRef)
 	}
@@ -1968,6 +1974,13 @@ func destroySnapshotStorage(ctx context.Context, cfg backend.FirecrackerConfig, 
 		return err
 	}
 	return driver.DestroySnapshot(ctx, volumestore.DestroySnapshotRequest{SnapshotRef: storageRef})
+}
+
+func validateSnapshotsEnabled(cfg backend.FirecrackerConfig) error {
+	if !cfg.Snapshots.Enabled {
+		return errors.New("firecracker snapshots are not enabled")
+	}
+	return nil
 }
 
 func pauseSandboxProcess(instance *sandboxInstance) error {

--- a/internal/backend/firecracker/host_runtime.go
+++ b/internal/backend/firecracker/host_runtime.go
@@ -3,6 +3,9 @@ package firecracker
 import (
 	"context"
 	"fmt"
+	"log"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/buildkite/cleanroom/internal/backend"
@@ -16,7 +19,10 @@ type hostRuntime interface {
 	SetupSandboxNetwork(context.Context, sandboxNetworkRequest) (sandboxNetworkLease, error)
 	SetupGatewayFirewall(context.Context, gatewayFirewallRequest) (gatewayFirewallLease, error)
 	ValidateZFSDatasetRoot(context.Context, string) error
-	OpenZFSVolumeStore(string) (volumestore.Driver, error)
+	PrepareZFSWritableVolume(context.Context, zfsWritableVolumeRequest) (zfsWritableVolume, error)
+	CreateZFSSnapshot(context.Context, zfsSnapshotRequest) (zfsSnapshot, error)
+	DestroyZFSVolume(context.Context, string) error
+	DestroyZFSSnapshot(context.Context, string) error
 }
 
 type hostRuntimeFactory func(backend.FirecrackerConfig) hostRuntime
@@ -41,6 +47,27 @@ type sandboxNetworkLease struct {
 
 type gatewayFirewallLease struct {
 	release func(context.Context) error
+}
+
+type zfsWritableVolumeRequest struct {
+	VolumeID     string
+	SourcePath   string
+	SnapshotRef  string
+	MinimumBytes int64
+}
+
+type zfsWritableVolume struct {
+	Ref            string
+	AttachmentPath string
+}
+
+type zfsSnapshotRequest struct {
+	SnapshotID string
+	VolumeRef  string
+}
+
+type zfsSnapshot struct {
+	StorageRef string
 }
 
 type runnerBackedHostRuntime struct {
@@ -121,7 +148,100 @@ func (r runnerBackedHostRuntime) ValidateZFSDatasetRoot(ctx context.Context, dat
 	return validateZFSDatasetRootWithRunner(ctx, r.runner, dataset)
 }
 
-func (r runnerBackedHostRuntime) OpenZFSVolumeStore(datasetRoot string) (volumestore.Driver, error) {
+func (r runnerBackedHostRuntime) PrepareZFSWritableVolume(ctx context.Context, req zfsWritableVolumeRequest) (zfsWritableVolume, error) {
+	driver, err := r.openZFSVolumeStore(r.cfg.Snapshots.ZFSDataset)
+	if err != nil {
+		return zfsWritableVolume{}, err
+	}
+
+	sourcePath := strings.TrimSpace(req.SourcePath)
+	snapshotRef := strings.TrimSpace(req.SnapshotRef)
+	if (sourcePath == "") == (snapshotRef == "") {
+		return zfsWritableVolume{}, fmt.Errorf("zfs writable volume requires exactly one of source path or snapshot ref")
+	}
+
+	cleanupVolume := func(ref string) {
+		if err := driver.DestroyVolume(context.Background(), volumestore.DestroyVolumeRequest{VolumeRef: ref}); err != nil {
+			log.Printf("firecracker: cleanup persistent volume %q: %v", ref, err)
+		}
+	}
+	resizeVolume := func(volume volumestore.WritableVolume) (zfsWritableVolume, error) {
+		if err := volumestore.EnsureWritableVolumeMinimumSize(ctx, driver, volume, req.MinimumBytes); err != nil {
+			cleanupVolume(volume.Ref)
+			return zfsWritableVolume{}, fmt.Errorf("resize persistent rootfs: %w", err)
+		}
+		return zfsWritableVolume{Ref: volume.Ref, AttachmentPath: volume.AttachmentPath}, nil
+	}
+
+	if sourcePath != "" {
+		rootfsPath, err := filepath.Abs(sourcePath)
+		if err != nil {
+			return zfsWritableVolume{}, err
+		}
+		if _, err := os.Stat(rootfsPath); err != nil {
+			return zfsWritableVolume{}, fmt.Errorf("rootfs %s: %w", rootfsPath, err)
+		}
+
+		baseVolume, err := driver.EnsureBaseVolume(ctx, volumestore.EnsureBaseVolumeRequest{
+			BaseID:       strings.TrimSuffix(filepath.Base(rootfsPath), filepath.Ext(rootfsPath)),
+			SourcePath:   rootfsPath,
+			MinimumBytes: req.MinimumBytes,
+		})
+		if err != nil {
+			return zfsWritableVolume{}, fmt.Errorf("prepare base volume: %w", err)
+		}
+		volume, err := driver.CreateWritableVolume(ctx, volumestore.CreateWritableVolumeRequest{
+			VolumeID: req.VolumeID,
+			BaseRef:  baseVolume.Ref,
+		})
+		if err != nil {
+			return zfsWritableVolume{}, err
+		}
+		return resizeVolume(volume)
+	}
+
+	volume, err := driver.CloneSnapshotToVolume(ctx, volumestore.CloneSnapshotToVolumeRequest{
+		VolumeID:    req.VolumeID,
+		SnapshotRef: snapshotRef,
+	})
+	if err != nil {
+		return zfsWritableVolume{}, err
+	}
+	return resizeVolume(volume)
+}
+
+func (r runnerBackedHostRuntime) CreateZFSSnapshot(ctx context.Context, req zfsSnapshotRequest) (zfsSnapshot, error) {
+	driver, err := r.openZFSVolumeStore(r.cfg.Snapshots.ZFSDataset)
+	if err != nil {
+		return zfsSnapshot{}, err
+	}
+	snapshot, err := driver.SnapshotVolume(ctx, volumestore.SnapshotVolumeRequest{
+		SnapshotID: req.SnapshotID,
+		VolumeRef:  req.VolumeRef,
+	})
+	if err != nil {
+		return zfsSnapshot{}, err
+	}
+	return zfsSnapshot{StorageRef: snapshot.StorageRef}, nil
+}
+
+func (r runnerBackedHostRuntime) DestroyZFSVolume(ctx context.Context, volumeRef string) error {
+	driver, err := r.openZFSVolumeStore(r.cfg.Snapshots.ZFSDataset)
+	if err != nil {
+		return err
+	}
+	return driver.DestroyVolume(ctx, volumestore.DestroyVolumeRequest{VolumeRef: volumeRef})
+}
+
+func (r runnerBackedHostRuntime) DestroyZFSSnapshot(ctx context.Context, snapshotRef string) error {
+	driver, err := r.openZFSVolumeStore(r.cfg.Snapshots.ZFSDataset)
+	if err != nil {
+		return err
+	}
+	return driver.DestroySnapshot(ctx, volumestore.DestroySnapshotRequest{SnapshotRef: snapshotRef})
+}
+
+func (r runnerBackedHostRuntime) openZFSVolumeStore(datasetRoot string) (*volumestore.ZFSDriver, error) {
 	return volumestore.NewZFSDriver(volumestore.ZFSDriverOptions{
 		DatasetRoot: datasetRoot,
 		Runner:      hostRuntimeVolumeCommandRunner{runner: r.runner},

--- a/internal/backend/firecracker/host_runtime_test.go
+++ b/internal/backend/firecracker/host_runtime_test.go
@@ -5,16 +5,18 @@ import (
 	"testing"
 
 	"github.com/buildkite/cleanroom/internal/backend"
-	"github.com/buildkite/cleanroom/internal/volumestore"
 )
 
 type testHostRuntime struct {
-	checkAccessFn            func(context.Context) error
-	checkNetworkingFn        func(context.Context) error
-	setupSandboxNetworkFn    func(context.Context, sandboxNetworkRequest) (sandboxNetworkLease, error)
-	setupGatewayFirewallFn   func(context.Context, gatewayFirewallRequest) (gatewayFirewallLease, error)
-	validateZFSDatasetRootFn func(context.Context, string) error
-	openZFSVolumeStoreFn     func(string) (volumestore.Driver, error)
+	checkAccessFn              func(context.Context) error
+	checkNetworkingFn          func(context.Context) error
+	setupSandboxNetworkFn      func(context.Context, sandboxNetworkRequest) (sandboxNetworkLease, error)
+	setupGatewayFirewallFn     func(context.Context, gatewayFirewallRequest) (gatewayFirewallLease, error)
+	validateZFSDatasetRootFn   func(context.Context, string) error
+	prepareZFSWritableVolumeFn func(context.Context, zfsWritableVolumeRequest) (zfsWritableVolume, error)
+	createZFSSnapshotFn        func(context.Context, zfsSnapshotRequest) (zfsSnapshot, error)
+	destroyZFSVolumeFn         func(context.Context, string) error
+	destroyZFSSnapshotFn       func(context.Context, string) error
 }
 
 func (r testHostRuntime) CheckAccess(ctx context.Context) error {
@@ -52,11 +54,32 @@ func (r testHostRuntime) ValidateZFSDatasetRoot(ctx context.Context, dataset str
 	return r.validateZFSDatasetRootFn(ctx, dataset)
 }
 
-func (r testHostRuntime) OpenZFSVolumeStore(datasetRoot string) (volumestore.Driver, error) {
-	if r.openZFSVolumeStoreFn == nil {
-		return nil, nil
+func (r testHostRuntime) PrepareZFSWritableVolume(ctx context.Context, req zfsWritableVolumeRequest) (zfsWritableVolume, error) {
+	if r.prepareZFSWritableVolumeFn == nil {
+		return zfsWritableVolume{}, nil
 	}
-	return r.openZFSVolumeStoreFn(datasetRoot)
+	return r.prepareZFSWritableVolumeFn(ctx, req)
+}
+
+func (r testHostRuntime) CreateZFSSnapshot(ctx context.Context, req zfsSnapshotRequest) (zfsSnapshot, error) {
+	if r.createZFSSnapshotFn == nil {
+		return zfsSnapshot{}, nil
+	}
+	return r.createZFSSnapshotFn(ctx, req)
+}
+
+func (r testHostRuntime) DestroyZFSVolume(ctx context.Context, volumeRef string) error {
+	if r.destroyZFSVolumeFn == nil {
+		return nil
+	}
+	return r.destroyZFSVolumeFn(ctx, volumeRef)
+}
+
+func (r testHostRuntime) DestroyZFSSnapshot(ctx context.Context, snapshotRef string) error {
+	if r.destroyZFSSnapshotFn == nil {
+		return nil
+	}
+	return r.destroyZFSSnapshotFn(ctx, snapshotRef)
 }
 
 func TestSetupGatewayFirewallUsesHostRuntime(t *testing.T) {
@@ -90,37 +113,58 @@ func TestSetupGatewayFirewallUsesHostRuntime(t *testing.T) {
 	}
 }
 
-func TestRootFSVolumeStoreDriverUsesHostRuntimeForZFS(t *testing.T) {
+func TestPrepareWritableRootVolumeUsesHostRuntimeForZFS(t *testing.T) {
 	prevHostRuntimeFn := newHostRuntimeFn
 	t.Cleanup(func() { newHostRuntimeFn = prevHostRuntimeFn })
 
-	var gotDatasetRoot string
+	var gotReq zfsWritableVolumeRequest
+	destroyedVolume := ""
 	newHostRuntimeFn = func(cfg backend.FirecrackerConfig) hostRuntime {
 		if got, want := cfg.Snapshots.Driver, "zfs"; got != want {
 			t.Fatalf("unexpected snapshot driver: got %q want %q", got, want)
 		}
 		return testHostRuntime{
-			openZFSVolumeStoreFn: func(datasetRoot string) (volumestore.Driver, error) {
-				gotDatasetRoot = datasetRoot
-				return testVolumeDriver{}, nil
+			prepareZFSWritableVolumeFn: func(_ context.Context, req zfsWritableVolumeRequest) (zfsWritableVolume, error) {
+				gotReq = req
+				return zfsWritableVolume{
+					Ref:            "tank/cleanroom/sandboxes/exec-1",
+					AttachmentPath: "/dev/zvol/tank/cleanroom/sandboxes/exec-1",
+				}, nil
+			},
+			destroyZFSVolumeFn: func(_ context.Context, volumeRef string) error {
+				destroyedVolume = volumeRef
+				return nil
 			},
 		}
 	}
 
-	driver, err := rootFSVolumeStoreDriver(backend.FirecrackerConfig{
+	volume, cleanupVolume, err := prepareWritableRootVolume(context.Background(), backend.FirecrackerConfig{
+		MinimumRootFSBytes: 8 << 20,
 		Snapshots: backend.SnapshotConfig{
 			Driver:     "zfs",
 			ZFSDataset: "tank/cleanroom",
 		},
-	})
+	}, "exec-1", t.TempDir(), "/tmp/runtime-rootfs.ext4")
 	if err != nil {
-		t.Fatalf("rootFSVolumeStoreDriver returned error: %v", err)
+		t.Fatalf("prepareWritableRootVolume returned error: %v", err)
 	}
-	if got, want := gotDatasetRoot, "tank/cleanroom"; got != want {
-		t.Fatalf("unexpected zfs dataset root: got %q want %q", got, want)
+	if cleanupVolume == nil {
+		t.Fatal("expected cleanup function")
 	}
-	if _, ok := driver.(testVolumeDriver); !ok {
-		t.Fatalf("unexpected zfs driver type: %T", driver)
+	if got, want := gotReq, (zfsWritableVolumeRequest{
+		VolumeID:     "exec-1",
+		SourcePath:   "/tmp/runtime-rootfs.ext4",
+		MinimumBytes: 8 << 20,
+	}); got != want {
+		t.Fatalf("unexpected zfs writable volume request: got %+v want %+v", got, want)
+	}
+	if got, want := volume.Ref, "tank/cleanroom/sandboxes/exec-1"; got != want {
+		t.Fatalf("unexpected volume ref: got %q want %q", got, want)
+	}
+
+	cleanupVolume()
+	if got, want := destroyedVolume, "tank/cleanroom/sandboxes/exec-1"; got != want {
+		t.Fatalf("unexpected destroyed zfs volume ref: got %q want %q", got, want)
 	}
 }
 

--- a/internal/backend/firecracker/snapshot_test.go
+++ b/internal/backend/firecracker/snapshot_test.go
@@ -474,6 +474,68 @@ func TestCreateSnapshotUsesManagedVolumeRef(t *testing.T) {
 	}
 }
 
+func TestCreateSnapshotRejectsDisabledZFSSnapshots(t *testing.T) {
+	prevSignal := sendProcessSignal
+	prevHostRuntimeFn := newHostRuntimeFn
+	sendProcessSignal = func(_ *os.Process, _ syscall.Signal) error { return nil }
+	t.Cleanup(func() {
+		sendProcessSignal = prevSignal
+		newHostRuntimeFn = prevHostRuntimeFn
+	})
+
+	newHostRuntimeFn = func(cfg backend.FirecrackerConfig) hostRuntime {
+		if got, want := cfg.Snapshots.Driver, "zfs"; got != want {
+			t.Fatalf("unexpected snapshot driver: got %q want %q", got, want)
+		}
+		return testHostRuntime{
+			createZFSSnapshotFn: func(context.Context, zfsSnapshotRequest) (zfsSnapshot, error) {
+				t.Fatal("zfs snapshot creation should not run when snapshots are disabled")
+				return zfsSnapshot{}, nil
+			},
+		}
+	}
+
+	adapter := &Adapter{
+		runGuestCommandFn: func(_ context.Context, _ context.Context, _ <-chan struct{}, _ func() error, _ string, _ uint32, req vsockexec.ExecRequest, _ backend.OutputStream) (vsockexec.ExecResponse, guestExecTiming, error) {
+			if len(req.Command) != 1 || req.Command[0] != "sync" {
+				t.Fatalf("unexpected command: %v", req.Command)
+			}
+			return vsockexec.ExecResponse{ExitCode: 0}, guestExecTiming{}, nil
+		},
+		sandboxes: map[string]*sandboxInstance{
+			"cr-test": {
+				SandboxID:    "cr-test",
+				VsockPath:    "/tmp/fake.sock",
+				GuestPort:    10700,
+				fcCmd:        &exec.Cmd{Process: &os.Process{Pid: 42}},
+				exitedCh:     make(chan struct{}),
+				vmRootFSPath: "/dev/zvol/tank/cleanroom/sandboxes/cr-test",
+				volumeRef:    "tank/cleanroom/sandboxes/cr-test",
+			},
+		},
+	}
+
+	result, err := adapter.CreateSnapshot(context.Background(), backend.SnapshotRequest{
+		SandboxID:  "cr-test",
+		SnapshotID: "snap-test",
+		FirecrackerConfig: backend.FirecrackerConfig{
+			Snapshots: backend.SnapshotConfig{
+				Driver:     "zfs",
+				ZFSDataset: "tank/cleanroom",
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected CreateSnapshot to reject disabled zfs snapshots")
+	}
+	if result != nil {
+		t.Fatalf("expected nil snapshot result, got %#v", result)
+	}
+	if got := err.Error(); !strings.Contains(got, "not enabled") {
+		t.Fatalf("expected snapshots disabled error, got %v", err)
+	}
+}
+
 func TestCreateSnapshotReturnsErrorWhenSandboxResumeFails(t *testing.T) {
 	stateHome := t.TempDir()
 	t.Setenv("XDG_STATE_HOME", stateHome)

--- a/internal/backend/firecracker/snapshot_test.go
+++ b/internal/backend/firecracker/snapshot_test.go
@@ -157,10 +157,10 @@ func TestCreateSnapshotFlushesHostFilesystemForZFSSnapshots(t *testing.T) {
 	t.Cleanup(func() { sendProcessSignal = prevSignal })
 
 	prevSync := syncHostFilesystem
-	prevSnapshotDriver := snapshotVolumeStoreDriverFn
+	prevHostRuntimeFn := newHostRuntimeFn
 	t.Cleanup(func() {
 		syncHostFilesystem = prevSync
-		snapshotVolumeStoreDriverFn = prevSnapshotDriver
+		newHostRuntimeFn = prevHostRuntimeFn
 	})
 
 	var calls []string
@@ -168,22 +168,25 @@ func TestCreateSnapshotFlushesHostFilesystemForZFSSnapshots(t *testing.T) {
 		calls = append(calls, "host-sync")
 		return nil
 	}
-	snapshotVolumeStoreDriverFn = func(cfg backend.FirecrackerConfig) (volumestore.Driver, error) {
+	newHostRuntimeFn = func(cfg backend.FirecrackerConfig) hostRuntime {
 		if got, want := cfg.Snapshots.Driver, "zfs"; got != want {
 			t.Fatalf("unexpected snapshot driver: got %q want %q", got, want)
 		}
-		return testVolumeDriver{
-			snapshotVolumeFn: func(_ context.Context, req volumestore.SnapshotVolumeRequest) (volumestore.Snapshot, error) {
+		return testHostRuntime{
+			createZFSSnapshotFn: func(_ context.Context, req zfsSnapshotRequest) (zfsSnapshot, error) {
 				if got, want := calls, []string{"host-sync"}; strings.Join(got, ",") != strings.Join(want, ",") {
 					t.Fatalf("expected host sync before snapshot, got %v", got)
 				}
 				if got, want := req.VolumeRef, "tank/cleanroom/sandboxes/cr-test"; got != want {
 					t.Fatalf("unexpected volume ref: got %q want %q", got, want)
 				}
+				if got, want := req.SnapshotID, "snap-test"; got != want {
+					t.Fatalf("unexpected snapshot id: got %q want %q", got, want)
+				}
 				calls = append(calls, "snapshot")
-				return volumestore.Snapshot{StorageRef: "tank/cleanroom/snapshots/snap-test@seed"}, nil
+				return zfsSnapshot{StorageRef: "tank/cleanroom/snapshots/snap-test@seed"}, nil
 			},
-		}, nil
+		}
 	}
 
 	adapter := &Adapter{
@@ -230,11 +233,11 @@ func TestCreateSnapshotFlushesHostFilesystemForZFSSnapshots(t *testing.T) {
 
 func TestCreateSnapshotResumesSandboxWhenHostSyncFails(t *testing.T) {
 	prevSync := syncHostFilesystem
-	prevSnapshotDriver := snapshotVolumeStoreDriverFn
+	prevHostRuntimeFn := newHostRuntimeFn
 	prevSignal := sendProcessSignal
 	t.Cleanup(func() {
 		syncHostFilesystem = prevSync
-		snapshotVolumeStoreDriverFn = prevSnapshotDriver
+		newHostRuntimeFn = prevHostRuntimeFn
 		sendProcessSignal = prevSignal
 	})
 
@@ -247,16 +250,16 @@ func TestCreateSnapshotResumesSandboxWhenHostSyncFails(t *testing.T) {
 	syncHostFilesystem = func(context.Context) error {
 		return errors.New("host sync failed")
 	}
-	snapshotVolumeStoreDriverFn = func(cfg backend.FirecrackerConfig) (volumestore.Driver, error) {
+	newHostRuntimeFn = func(cfg backend.FirecrackerConfig) hostRuntime {
 		if got, want := cfg.Snapshots.Driver, "zfs"; got != want {
 			t.Fatalf("unexpected snapshot driver: got %q want %q", got, want)
 		}
-		return testVolumeDriver{
-			snapshotVolumeFn: func(context.Context, volumestore.SnapshotVolumeRequest) (volumestore.Snapshot, error) {
+		return testHostRuntime{
+			createZFSSnapshotFn: func(context.Context, zfsSnapshotRequest) (zfsSnapshot, error) {
 				t.Fatal("snapshot should not run after host sync failure")
-				return volumestore.Snapshot{}, nil
+				return zfsSnapshot{}, nil
 			},
-		}, nil
+		}
 	}
 
 	adapter := &Adapter{
@@ -938,20 +941,22 @@ func TestPrepareWritableRootVolumeUsesRootFSVolumeStoreDriver(t *testing.T) {
 }
 
 func TestPrepareWritableRootVolumeNormalizesManagedZFSStorageRefs(t *testing.T) {
-	prevDriverFn := rootFSVolumeStoreDriverFn
-	t.Cleanup(func() { rootFSVolumeStoreDriverFn = prevDriverFn })
+	prevHostRuntimeFn := newHostRuntimeFn
+	t.Cleanup(func() { newHostRuntimeFn = prevHostRuntimeFn })
 
 	var gotDriverCfg backend.FirecrackerConfig
-	rootFSVolumeStoreDriverFn = func(cfg backend.FirecrackerConfig) (volumestore.Driver, error) {
+	var gotReq zfsWritableVolumeRequest
+	newHostRuntimeFn = func(cfg backend.FirecrackerConfig) hostRuntime {
 		gotDriverCfg = cfg
-		return testVolumeDriver{
-			cloneSnapshotToVolumeFn: func(_ context.Context, req volumestore.CloneSnapshotToVolumeRequest) (volumestore.WritableVolume, error) {
-				return volumestore.WritableVolume{Ref: "tank/cleanroom/sandboxes/exec-1", AttachmentPath: req.AttachmentPath}, nil
+		return testHostRuntime{
+			prepareZFSWritableVolumeFn: func(_ context.Context, req zfsWritableVolumeRequest) (zfsWritableVolume, error) {
+				gotReq = req
+				return zfsWritableVolume{Ref: "tank/cleanroom/sandboxes/exec-1", AttachmentPath: "/dev/zvol/tank/cleanroom/sandboxes/exec-1"}, nil
 			},
-		}, nil
+		}
 	}
 
-	_, cleanupVolume, err := prepareWritableRootVolume(
+	volume, cleanupVolume, err := prepareWritableRootVolume(
 		context.Background(),
 		backend.FirecrackerConfig{},
 		"exec-1",
@@ -969,5 +974,11 @@ func TestPrepareWritableRootVolumeNormalizesManagedZFSStorageRefs(t *testing.T) 
 	}
 	if got, want := gotDriverCfg.Snapshots.ZFSDataset, "tank/cleanroom"; got != want {
 		t.Fatalf("unexpected zfs dataset: got %q want %q", got, want)
+	}
+	if got, want := gotReq, (zfsWritableVolumeRequest{VolumeID: "exec-1", SnapshotRef: "tank/cleanroom/sandboxes/source@snap-golden"}); got != want {
+		t.Fatalf("unexpected zfs writable volume request: got %+v want %+v", got, want)
+	}
+	if got, want := volume.AttachmentPath, "/dev/zvol/tank/cleanroom/sandboxes/exec-1"; got != want {
+		t.Fatalf("unexpected attachment path: got %q want %q", got, want)
 	}
 }

--- a/internal/backend/firecracker/snapshot_test.go
+++ b/internal/backend/firecracker/snapshot_test.go
@@ -477,7 +477,11 @@ func TestCreateSnapshotUsesManagedVolumeRef(t *testing.T) {
 func TestCreateSnapshotRejectsDisabledZFSSnapshots(t *testing.T) {
 	prevSignal := sendProcessSignal
 	prevHostRuntimeFn := newHostRuntimeFn
-	sendProcessSignal = func(_ *os.Process, _ syscall.Signal) error { return nil }
+	var signals []syscall.Signal
+	sendProcessSignal = func(_ *os.Process, sig syscall.Signal) error {
+		signals = append(signals, sig)
+		return nil
+	}
 	t.Cleanup(func() {
 		sendProcessSignal = prevSignal
 		newHostRuntimeFn = prevHostRuntimeFn
@@ -533,6 +537,9 @@ func TestCreateSnapshotRejectsDisabledZFSSnapshots(t *testing.T) {
 	}
 	if got := err.Error(); !strings.Contains(got, "not enabled") {
 		t.Fatalf("expected snapshots disabled error, got %v", err)
+	}
+	if len(signals) != 0 {
+		t.Fatalf("expected snapshots-disabled validation to fail before pausing sandbox, got signals %v", signals)
 	}
 }
 


### PR DESCRIPTION
## Summary
- replace `hostRuntime.OpenZFSVolumeStore` with typed ZFS host-runtime operations for writable volume prep, snapshot creation, and cleanup
- route Firecracker ZFS rootfs and snapshot flows through those semantic runtime operations so `volumestore.Driver` no longer crosses the adapter boundary
- keep file-backed storage on the existing `volumestore` path and update Firecracker tests to fake the runtime boundary instead of a leaked ZFS driver

## Testing
- `go test ./internal/backend/firecracker`
- `go test ./...`
