### PR TITLE
fix: add gateway git cache host controls

### DIFF
--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -45,6 +45,10 @@ For `.git` smart-HTTP routes, the request is handed to embedded
 mirror-backed proxy. Guest-side git rewrites target
 `gateway.cleanroom.internal` rather than backend-specific IP addresses.
 
+When you want to restrict which Git hosts use the cache layer without denying
+other policy-allowed Git traffic, set `gateway.git.cache_hosts` in runtime
+config. Hosts outside that list fall back to the mirror-backed proxy.
+
 On `darwin-vz`, sandbox identity is carried with the
 `X-Cleanroom-Scope-Token` request header because guests use shared NAT rather
 than unique source IPs.

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -86,8 +86,9 @@ func (s *ServeCommand) runServer(ctx *runtimeContext) error {
 
 	var contentCache *gateway.ContentCache
 	contentCache, err = newGatewayContentCache(gateway.ContentCacheConfig{
-		Credentials: gwCredentials,
-		Logger:      logger.With("subsystem", "content-cache"),
+		GitAllowedHosts: ctx.Config.Gateway.Git.CacheHosts,
+		Credentials:     gwCredentials,
+		Logger:          logger.With("subsystem", "content-cache"),
 	})
 	if err != nil {
 		logger.Warn("content cache unavailable; continuing without cache-backed gateway routes", "error", err)

--- a/internal/cli/serve_lifecycle_test.go
+++ b/internal/cli/serve_lifecycle_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/buildkite/cleanroom/internal/backend"
 	"github.com/buildkite/cleanroom/internal/gateway"
+	"github.com/buildkite/cleanroom/internal/runtimeconfig"
 )
 
 func reserveLocalTCPAddr(t *testing.T) string {
@@ -140,6 +141,66 @@ func TestServeCommandRunServerStartsWithoutContentCache(t *testing.T) {
 	}()
 
 	waitForHTTPHealthz(t, fmt.Sprintf("http://%s/healthz", listenAddr), 5*time.Second)
+	if cancelRun == nil {
+		t.Fatal("expected serveSignalNotifyContext replacement to capture a cancel func")
+	}
+	cancelRun()
+
+	waitCtx, cancel := context.WithTimeoutCause(context.Background(), 5*time.Second, fmt.Errorf("timed out waiting for ServeCommand.Run to exit after cancellation"))
+	defer cancel()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("ServeCommand.Run returned error: %v", err)
+		}
+	case <-waitCtx.Done():
+		t.Fatal(context.Cause(waitCtx))
+	}
+}
+
+func TestServeCommandRunServerPassesGatewayGitCacheHostsToContentCache(t *testing.T) {
+	listenAddr := reserveLocalTCPAddr(t)
+	var cancelRun context.CancelFunc
+	stubServeNotifyContext(t, func(parent context.Context, _ ...os.Signal) (context.Context, context.CancelFunc) {
+		runCtx, cancel := context.WithCancel(parent)
+		cancelRun = cancel
+		return runCtx, cancel
+	})
+
+	var captured gateway.ContentCacheConfig
+	prevNewGatewayContentCache := newGatewayContentCache
+	newGatewayContentCache = func(cfg gateway.ContentCacheConfig) (*gateway.ContentCache, error) {
+		captured = cfg
+		return nil, errors.New("cache dir unavailable")
+	}
+	t.Cleanup(func() {
+		newGatewayContentCache = prevNewGatewayContentCache
+	})
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- (&ServeCommand{
+			Listen:        "http://" + listenAddr,
+			GatewayListen: "127.0.0.1:0",
+		}).Run(&runtimeContext{
+			CWD:        t.TempDir(),
+			ConfigPath: "/tmp/cleanroom-config.yaml",
+			Config: runtimeconfig.Config{
+				Gateway: runtimeconfig.GatewayConfig{
+					Git: runtimeconfig.GatewayGitConfig{
+						CacheHosts: []string{"github.com", "gitlab.com"},
+					},
+				},
+			},
+			Backends: map[string]backend.Adapter{},
+		})
+	}()
+
+	waitForHTTPHealthz(t, fmt.Sprintf("http://%s/healthz", listenAddr), 5*time.Second)
+	if got, want := captured.GitAllowedHosts, []string{"github.com", "gitlab.com"}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("unexpected git cache hosts: got %v want %v", got, want)
+	}
 	if cancelRun == nil {
 		t.Fatal("expected serveSignalNotifyContext replacement to capture a cancel func")
 	}

--- a/internal/gateway/contentcache.go
+++ b/internal/gateway/contentcache.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -19,6 +20,8 @@ import (
 
 	"github.com/buildkite/cleanroom/internal/paths"
 )
+
+var errGitHostNotConfiguredForCaching = errors.New("git host not configured for caching")
 
 // ContentCacheConfig configures the embedded content-cache layer.
 type ContentCacheConfig struct {
@@ -134,7 +137,7 @@ func NewContentCache(cfg ContentCacheConfig) (*ContentCache, error) {
 		}
 		if len(allowedGitHosts) > 0 {
 			if _, ok := allowedGitHosts[host]; !ok {
-				return nil, fmt.Errorf("git host %q is not configured for caching", host)
+				return nil, fmt.Errorf("%w: %s", errGitHostNotConfiguredForCaching, host)
 			}
 		}
 		return ccgit.NewHandler(

--- a/internal/gateway/git_cached.go
+++ b/internal/gateway/git_cached.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -61,14 +62,23 @@ func (h *cachedGitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.auditLog(scope.SandboxID, upstreamHost, repoPath, "allow", "cached")
-
 	cacheHandler, err := h.cache.GitHandlerForHost(upstreamHost)
 	if err != nil {
-		h.auditLog(scope.SandboxID, upstreamHost, repoPath, "deny", reasonHostNotAllowed)
-		writeReasonError(w, http.StatusForbidden, reasonHostNotAllowed, fmt.Sprintf("git cache is not configured for %s", upstreamHost))
+		if errors.Is(err, errGitHostNotConfiguredForCaching) {
+			if h.fallback == nil {
+				h.auditLog(scope.SandboxID, upstreamHost, repoPath, "deny", reasonUpstreamError)
+				writeReasonError(w, http.StatusBadGateway, reasonUpstreamError, fmt.Sprintf("git cache fallback is not configured for %s", upstreamHost))
+				return
+			}
+			h.auditLog(scope.SandboxID, upstreamHost, repoPath, "allow", "fallback")
+			h.fallback.ServeHTTP(w, r)
+			return
+		}
+		h.auditLog(scope.SandboxID, upstreamHost, repoPath, "deny", reasonUpstreamError)
+		writeReasonError(w, http.StatusBadGateway, reasonUpstreamError, fmt.Sprintf("git cache handler unavailable for %s: %v", upstreamHost, err))
 		return
 	}
+	h.auditLog(scope.SandboxID, upstreamHost, repoPath, "allow", "cached")
 
 	// content-cache's git handler expects paths like /{host}/{repo}.git/...
 	// Strip the /git/ prefix so the cache handler sees the host-rooted path.

--- a/internal/gateway/git_cached_test.go
+++ b/internal/gateway/git_cached_test.go
@@ -1,7 +1,7 @@
 package gateway
 
 import (
-	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -151,13 +151,19 @@ func TestCachedGitHandlerUploadPackDelegates(t *testing.T) {
 	}
 }
 
-func TestCachedGitHandlerRejectsUnconfiguredCacheHost(t *testing.T) {
+func TestCachedGitHandlerFallsBackForUnconfiguredCacheHost(t *testing.T) {
 	t.Parallel()
 
+	var capturedPath, capturedQuery string
+	fallback := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		capturedQuery = r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+	})
 	provider := &stubGitHostHandlerProvider{
-		err: errors.New("not configured"),
+		err: fmt.Errorf("%w: github.enterprise.test", errGitHostNotConfiguredForCaching),
 	}
-	h := newCachedGitHandler(provider, nil, nil)
+	h := newCachedGitHandler(provider, fallback, nil)
 
 	req := httptest.NewRequest("GET", "/git/github.enterprise.test/org/repo.git/info/refs?service=git-upload-pack", nil)
 	req = withScope(req, &SandboxScope{
@@ -174,11 +180,17 @@ func TestCachedGitHandlerRejectsUnconfiguredCacheHost(t *testing.T) {
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("expected 403, got %d", w.Code)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
 	}
-	if got := w.Header().Get(reasonCodeHeader); got != reasonHostNotAllowed {
-		t.Fatalf("expected reason %s, got %q", reasonHostNotAllowed, got)
+	if want := "/git/github.enterprise.test/org/repo.git/info/refs"; capturedPath != want {
+		t.Fatalf("expected fallback path %q, got %q", want, capturedPath)
+	}
+	if want := "service=git-upload-pack"; capturedQuery != want {
+		t.Fatalf("expected fallback query %q, got %q", want, capturedQuery)
+	}
+	if provider.host != "github.enterprise.test" {
+		t.Fatalf("expected cache host lookup for github.enterprise.test, got %q", provider.host)
 	}
 }
 

--- a/internal/runtimeconfig/config.go
+++ b/internal/runtimeconfig/config.go
@@ -18,8 +18,17 @@ import (
 type Config struct {
 	DefaultBackend string              `yaml:"default_backend"`
 	ControlHost    string              `yaml:"control_host,omitempty"`
+	Gateway        GatewayConfig       `yaml:"gateway,omitempty"`
 	Observability  ObservabilityConfig `yaml:"observability,omitempty"`
 	Backends       Backends            `yaml:"backends"`
+}
+
+type GatewayConfig struct {
+	Git GatewayGitConfig `yaml:"git,omitempty"`
+}
+
+type GatewayGitConfig struct {
+	CacheHosts []string `yaml:"cache_hosts,omitempty"`
 }
 
 type ObservabilityConfig struct {
@@ -397,6 +406,7 @@ func Load() (Config, string, error) {
 		cfg.DefaultBackend = DefaultBackendForHost()
 	}
 	cfg.ControlHost = strings.TrimSpace(cfg.ControlHost)
+	cfg.Gateway.Git.CacheHosts = trimStringSlice(cfg.Gateway.Git.CacheHosts)
 	cfg.Observability.DeploymentEnvironment = strings.TrimSpace(cfg.Observability.DeploymentEnvironment)
 	cfg.Observability.OTLP.Endpoint = strings.TrimSpace(cfg.Observability.OTLP.Endpoint)
 	cfg.Observability.OTLP.Protocol = strings.TrimSpace(cfg.Observability.OTLP.Protocol)
@@ -451,6 +461,25 @@ func trimStringMap(input map[string]string) map[string]string {
 			continue
 		}
 		out[trimmedKey] = strings.TrimSpace(value)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func trimStringSlice(input []string) []string {
+	if len(input) == 0 {
+		return nil
+	}
+
+	out := make([]string, 0, len(input))
+	for _, value := range input {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		out = append(out, trimmed)
 	}
 	if len(out) == 0 {
 		return nil

--- a/internal/runtimeconfig/config_test.go
+++ b/internal/runtimeconfig/config_test.go
@@ -348,6 +348,40 @@ func TestLoadTrimsObservabilityConfig(t *testing.T) {
 	}
 }
 
+func TestLoadTrimsGatewayGitCacheHosts(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	configPath := filepath.Join(tmp, "cleanroom", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+
+	content := `gateway:
+  git:
+    cache_hosts:
+      - " github.com "
+      - ""
+      - " gitlab.com "
+`
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, _, err := Load()
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if got, want := len(cfg.Gateway.Git.CacheHosts), 2; got != want {
+		t.Fatalf("unexpected cache host count: got %d want %d", got, want)
+	}
+	if got, want := cfg.Gateway.Git.CacheHosts[0], "github.com"; got != want {
+		t.Fatalf("unexpected first cache host: got %q want %q", got, want)
+	}
+	if got, want := cfg.Gateway.Git.CacheHosts[1], "gitlab.com"; got != want {
+		t.Fatalf("unexpected second cache host: got %q want %q", got, want)
+	}
+}
+
 func TestLoadObservabilitySupportsZeroSamplingRatio(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)


### PR DESCRIPTION
## Summary
- add runtime config support for `gateway.git.cache_hosts`
- pass configured cache hosts into the embedded gateway content-cache
- fall back to the mirror-backed git proxy when a policy-allowed host is not cache-enabled

## Testing
- go test ./...