### PR TITLE
fix: honour root mode in firecracker diagnostics

### DIFF
--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -765,8 +765,12 @@ func (a *Adapter) Doctor(_ context.Context, req backend.DoctorRequest) (*backend
 
 	privilegedHelperPath := resolvePrivilegedHelperPath(req.FirecrackerConfig)
 	hostRuntime := hostRuntimeForConfig(req.FirecrackerConfig)
+	directRuntime := privilegedCommandsRunDirectly()
 
-	requiredCommands := []string{"ip", "iptables", "sysctl", "sudo"}
+	requiredCommands := []string{"ip", "iptables", "sysctl"}
+	if !directRuntime {
+		requiredCommands = append(requiredCommands, "sudo")
+	}
 	for _, cmd := range requiredCommands {
 		if _, err := exec.LookPath(cmd); err != nil {
 			appendCheck("network_cmd_"+cmd, "fail", fmt.Sprintf("missing required host command %q", cmd))
@@ -775,28 +779,32 @@ func (a *Adapter) Doctor(_ context.Context, req backend.DoctorRequest) (*backend
 		}
 	}
 
-	if _, err := os.Stat(privilegedHelperPath); err != nil {
-		appendCheck("network_helper", "fail", fmt.Sprintf("privileged helper %q is not accessible: %v", privilegedHelperPath, err))
+	if directRuntime {
+		appendCheck("network_runtime", "pass", "running as root; using direct privileged commands")
 	} else {
-		appendCheck("network_helper", "pass", fmt.Sprintf("using privileged helper %q", privilegedHelperPath))
-
-		version, err := helperVersion(context.Background(), req.FirecrackerConfig)
-		if err != nil {
-			appendCheck("network_helper_version", "warn", fmt.Sprintf("privileged helper version probe failed: %v", err))
+		if _, err := os.Stat(privilegedHelperPath); err != nil {
+			appendCheck("network_helper", "fail", fmt.Sprintf("privileged helper %q is not accessible: %v", privilegedHelperPath, err))
 		} else {
-			appendCheck("network_helper_version", "pass", fmt.Sprintf("helper contract version %s", version))
-		}
+			appendCheck("network_helper", "pass", fmt.Sprintf("using privileged helper %q", privilegedHelperPath))
 
-		caps, err := helperCapabilities(context.Background(), req.FirecrackerConfig)
-		if err != nil {
-			appendCheck("network_helper_capabilities", "fail", fmt.Sprintf("privileged helper capability probe failed: %v", err))
-		} else {
-			requiredCaps := helperRequiredCapabilities(req.FirecrackerConfig)
-			missingCaps := helperMissingCapabilities(caps, requiredCaps)
-			if len(missingCaps) > 0 {
-				appendCheck("network_helper_capabilities", "fail", fmt.Sprintf("helper is missing required capabilities: %s (have: %s)", strings.Join(missingCaps, ", "), strings.Join(caps, ", ")))
+			version, err := helperVersion(context.Background(), req.FirecrackerConfig)
+			if err != nil {
+				appendCheck("network_helper_version", "warn", fmt.Sprintf("privileged helper version probe failed: %v", err))
 			} else {
-				appendCheck("network_helper_capabilities", "pass", fmt.Sprintf("helper capabilities: %s", strings.Join(caps, ", ")))
+				appendCheck("network_helper_version", "pass", fmt.Sprintf("helper contract version %s", version))
+			}
+
+			caps, err := helperCapabilities(context.Background(), req.FirecrackerConfig)
+			if err != nil {
+				appendCheck("network_helper_capabilities", "fail", fmt.Sprintf("privileged helper capability probe failed: %v", err))
+			} else {
+				requiredCaps := helperRequiredCapabilities(req.FirecrackerConfig)
+				missingCaps := helperMissingCapabilities(caps, requiredCaps)
+				if len(missingCaps) > 0 {
+					appendCheck("network_helper_capabilities", "fail", fmt.Sprintf("helper is missing required capabilities: %s (have: %s)", strings.Join(missingCaps, ", "), strings.Join(caps, ", ")))
+				} else {
+					appendCheck("network_helper_capabilities", "pass", fmt.Sprintf("helper capabilities: %s", strings.Join(caps, ", ")))
+				}
 			}
 		}
 	}

--- a/internal/backend/firecracker/host_support.go
+++ b/internal/backend/firecracker/host_support.go
@@ -38,9 +38,14 @@ var hostSupportCommandOutput = func(ctx context.Context, binary string, args ...
 }
 
 func DetectHostSupport(ctx context.Context, cfg backend.FirecrackerConfig) HostSupport {
+	directRuntime := privilegedCommandsRunDirectly()
+	requiredCommands := []string{"ip", "iptables", "sysctl"}
+	if !directRuntime {
+		requiredCommands = append(requiredCommands, "sudo")
+	}
 	result := HostSupport{
 		HelperPath:       resolvePrivilegedHelperPath(cfg),
-		RequiredCommands: []string{"sudo", "ip", "iptables", "sysctl"},
+		RequiredCommands: requiredCommands,
 	}
 
 	if hostSupportGOOS != "linux" {
@@ -63,40 +68,43 @@ func DetectHostSupport(ctx context.Context, cfg backend.FirecrackerConfig) HostS
 		return result
 	}
 
-	if _, err := os.Stat(result.HelperPath); err != nil {
-		result.RuntimeMessage = fmt.Sprintf("privileged helper %q is not accessible: %v", result.HelperPath, err)
-		result.SnapshotMessage = result.RuntimeMessage
-		result.ZFSMessage = result.RuntimeMessage
-		return result
-	}
+	var caps []string
+	if !directRuntime {
+		if _, err := os.Stat(result.HelperPath); err != nil {
+			result.RuntimeMessage = fmt.Sprintf("privileged helper %q is not accessible: %v", result.HelperPath, err)
+			result.SnapshotMessage = result.RuntimeMessage
+			result.ZFSMessage = result.RuntimeMessage
+			return result
+		}
 
-	version, err := helperVersion(ctx, cfg)
-	if err != nil {
-		result.RuntimeMessage = fmt.Sprintf("privileged helper version probe failed: %v", err)
-		result.SnapshotMessage = result.RuntimeMessage
-		result.ZFSMessage = result.RuntimeMessage
-		return result
-	}
-	result.HelperVersion = version
+		version, err := helperVersion(ctx, cfg)
+		if err != nil {
+			result.RuntimeMessage = fmt.Sprintf("privileged helper version probe failed: %v", err)
+			result.SnapshotMessage = result.RuntimeMessage
+			result.ZFSMessage = result.RuntimeMessage
+			return result
+		}
+		result.HelperVersion = version
 
-	caps, err := helperCapabilities(ctx, cfg)
-	if err != nil {
-		result.RuntimeMessage = fmt.Sprintf("privileged helper capability probe failed: %v", err)
-		result.SnapshotMessage = result.RuntimeMessage
-		result.ZFSMessage = result.RuntimeMessage
-		return result
-	}
-	result.HelperCaps = append(result.HelperCaps, caps...)
+		caps, err = helperCapabilities(ctx, cfg)
+		if err != nil {
+			result.RuntimeMessage = fmt.Sprintf("privileged helper capability probe failed: %v", err)
+			result.SnapshotMessage = result.RuntimeMessage
+			result.ZFSMessage = result.RuntimeMessage
+			return result
+		}
+		result.HelperCaps = append(result.HelperCaps, caps...)
 
-	runtimeMissingCaps := helperMissingCapabilities(caps, []string{
-		helperCapabilityFirecrackerNetwork,
-		helperCapabilityFirecrackerTrustedDNS,
-	})
-	if len(runtimeMissingCaps) > 0 {
-		result.RuntimeMessage = fmt.Sprintf("privileged helper is missing required capabilities: %s", strings.Join(runtimeMissingCaps, ", "))
-		result.SnapshotMessage = result.RuntimeMessage
-		result.ZFSMessage = result.RuntimeMessage
-		return result
+		runtimeMissingCaps := helperMissingCapabilities(caps, []string{
+			helperCapabilityFirecrackerNetwork,
+			helperCapabilityFirecrackerTrustedDNS,
+		})
+		if len(runtimeMissingCaps) > 0 {
+			result.RuntimeMessage = fmt.Sprintf("privileged helper is missing required capabilities: %s", strings.Join(runtimeMissingCaps, ", "))
+			result.SnapshotMessage = result.RuntimeMessage
+			result.ZFSMessage = result.RuntimeMessage
+			return result
+		}
 	}
 
 	if err := runRootCommand(ctx, cfg, "true"); err != nil {
@@ -114,12 +122,18 @@ func DetectHostSupport(ctx context.Context, cfg backend.FirecrackerConfig) HostS
 
 	result.RuntimeUsable = true
 	result.SnapshotsUsable = true
-	result.RuntimeMessage = fmt.Sprintf("helper-based firecracker host runtime is usable via %s (helper contract version %s)", result.HelperPath, result.HelperVersion)
+	if directRuntime {
+		result.RuntimeMessage = "direct firecracker host runtime is usable as root"
+	} else {
+		result.RuntimeMessage = fmt.Sprintf("helper-based firecracker host runtime is usable via %s (helper contract version %s)", result.HelperPath, result.HelperVersion)
+	}
 	result.SnapshotMessage = "firecracker snapshot runtime is usable"
 
-	if missingCaps := helperMissingCapabilities(caps, []string{helperCapabilityFirecrackerZFS}); len(missingCaps) > 0 {
-		result.ZFSMessage = fmt.Sprintf("privileged helper is missing required capabilities: %s", strings.Join(missingCaps, ", "))
-		return result
+	if !directRuntime {
+		if missingCaps := helperMissingCapabilities(caps, []string{helperCapabilityFirecrackerZFS}); len(missingCaps) > 0 {
+			result.ZFSMessage = fmt.Sprintf("privileged helper is missing required capabilities: %s", strings.Join(missingCaps, ", "))
+			return result
+		}
 	}
 
 	zfsPath, err := lookPathWithFallback("zfs", "/usr/sbin/zfs", "/sbin/zfs")

--- a/internal/backend/firecracker/host_support_test.go
+++ b/internal/backend/firecracker/host_support_test.go
@@ -2,9 +2,11 @@ package firecracker
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/buildkite/cleanroom/internal/backend"
@@ -157,5 +159,59 @@ esac
 	}
 	if got, want := support.ZFSDatasetRoot, "cleanroom"; got != want {
 		t.Fatalf("unexpected zfs dataset root: got %q want %q", got, want)
+	}
+}
+
+func TestDetectHostSupportWhenRootDoesNotRequireSudoOrHelper(t *testing.T) {
+	prevResolveCommand := hostSupportResolveCommand
+	prevGOOS := hostSupportGOOS
+	t.Cleanup(func() {
+		hostSupportResolveCommand = prevResolveCommand
+		hostSupportGOOS = prevGOOS
+	})
+
+	hostSupportGOOS = "linux"
+	stubPrivilegedCommandEUID(t, 0)
+
+	tmpDir := t.TempDir()
+	truePath := writeExecutable(t, tmpDir, "true-root", "#!/bin/sh\nset -eu\nexit 0\n")
+	ipPath := writeExecutable(t, tmpDir, "ip-root", "#!/bin/sh\nset -eu\nif [ \"$1\" = \"link\" ] && [ \"$2\" = \"show\" ]; then exit 0; fi\nexit 0\n")
+	stubDirectPrivilegedCommandPathResolver(t, func(command string) (string, error) {
+		switch command {
+		case "true":
+			return truePath, nil
+		case "ip":
+			return ipPath, nil
+		default:
+			return resolveDirectPrivilegedCommandPath(command)
+		}
+	})
+	hostSupportResolveCommand = func(command string) (string, error) {
+		switch command {
+		case "ip", "iptables", "sysctl":
+			return "/fallback/" + command, nil
+		case "sudo":
+			return "", errors.New("sudo not installed")
+		default:
+			return "", errors.New("unexpected command")
+		}
+	}
+
+	support := DetectHostSupport(context.Background(), backend.FirecrackerConfig{
+		PrivilegedHelperPath: filepath.Join(tmpDir, "missing-helper"),
+	})
+	if !support.RuntimeUsable {
+		t.Fatalf("expected runtime usable when running as root, got %+v", support)
+	}
+	if !support.SnapshotsUsable {
+		t.Fatalf("expected snapshots usable when running as root, got %+v", support)
+	}
+	if strings.Contains(strings.ToLower(support.RuntimeMessage), "helper") {
+		t.Fatalf("expected root runtime message without helper dependency, got %q", support.RuntimeMessage)
+	}
+	for _, command := range support.RequiredCommands {
+		if command == "sudo" {
+			t.Fatalf("did not expect sudo in required commands when running as root: %v", support.RequiredCommands)
+		}
 	}
 }

--- a/internal/backend/firecracker/privileged_runner.go
+++ b/internal/backend/firecracker/privileged_runner.go
@@ -26,8 +26,12 @@ var privilegedCommandEUID = os.Geteuid
 
 var directPrivilegedCommandPathResolver = resolveDirectPrivilegedCommandPath
 
+func privilegedCommandsRunDirectly() bool {
+	return privilegedCommandEUID() == 0
+}
+
 func newPrivilegedCommandRunner(cfg backend.FirecrackerConfig) privilegedCommandRunner {
-	if privilegedCommandEUID() == 0 {
+	if privilegedCommandsRunDirectly() {
 		return directPrivilegedCommandRunner{}
 	}
 	return helperPrivilegedCommandRunner{cfg: cfg}

--- a/internal/backend/firecracker/privileged_test.go
+++ b/internal/backend/firecracker/privileged_test.go
@@ -535,6 +535,71 @@ func TestDeleteSnapshotInfersZFSDriverFromStorageRef(t *testing.T) {
 	}
 }
 
+func TestDoctorWhenRootDoesNotRequireSudoOrHelper(t *testing.T) {
+	stubPrivilegedCommandEUID(t, 0)
+
+	tmpDir := t.TempDir()
+	binDir := filepath.Join(tmpDir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin dir: %v", err)
+	}
+	writeExecutable(t, binDir, "firecracker", "#!/bin/sh\nexit 0\n")
+	writeExecutable(t, binDir, "cleanroom-guest-agent", "#!/bin/sh\nexit 0\n")
+	writeExecutable(t, binDir, "mkfs.ext4", "#!/bin/sh\nexit 0\n")
+	writeExecutable(t, binDir, "debugfs", "#!/bin/sh\nexit 0\n")
+	writeExecutable(t, binDir, "iptables", "#!/bin/sh\nexit 0\n")
+	writeExecutable(t, binDir, "sysctl", "#!/bin/sh\nexit 0\n")
+	writeExecutable(t, binDir, "ip", "#!/bin/sh\nif [ \"$1\" = \"link\" ] && [ \"$2\" = \"show\" ]; then exit 0; fi\nexit 0\n")
+	t.Setenv("PATH", binDir)
+
+	truePath := writeExecutable(t, tmpDir, "true-root", "#!/bin/sh\nset -eu\nexit 0\n")
+	ipPath := writeExecutable(t, tmpDir, "ip-root", "#!/bin/sh\nset -eu\nif [ \"$1\" = \"link\" ] && [ \"$2\" = \"show\" ]; then exit 0; fi\nexit 0\n")
+	stubDirectPrivilegedCommandPathResolver(t, func(command string) (string, error) {
+		switch command {
+		case "true":
+			return truePath, nil
+		case "ip":
+			return ipPath, nil
+		default:
+			return resolveDirectPrivilegedCommandPath(command)
+		}
+	})
+
+	kernelPath := filepath.Join(tmpDir, "vmlinux")
+	if err := os.WriteFile(kernelPath, []byte("kernel"), 0o644); err != nil {
+		t.Fatalf("write kernel image: %v", err)
+	}
+
+	report, err := (&Adapter{}).Doctor(context.Background(), backend.DoctorRequest{
+		FirecrackerConfig: backend.FirecrackerConfig{
+			BinaryPath:           "firecracker",
+			KernelImagePath:      kernelPath,
+			PrivilegedHelperPath: filepath.Join(tmpDir, "missing-helper"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Doctor returned error: %v", err)
+	}
+	if doctorHasCheck(report, "network_cmd_sudo") {
+		t.Fatalf("doctor unexpectedly requires sudo when running as root: %+v", doctorCheck(report, "network_cmd_sudo"))
+	}
+	if doctorHasCheck(report, "network_helper") {
+		t.Fatalf("doctor unexpectedly requires helper when running as root: %+v", doctorCheck(report, "network_helper"))
+	}
+	if doctorHasCheck(report, "network_helper_version") {
+		t.Fatalf("doctor unexpectedly probes helper version when running as root: %+v", doctorCheck(report, "network_helper_version"))
+	}
+	if doctorHasCheck(report, "network_helper_capabilities") {
+		t.Fatalf("doctor unexpectedly probes helper capabilities when running as root: %+v", doctorCheck(report, "network_helper_capabilities"))
+	}
+	if got := doctorCheck(report, "network_privileged_probe"); got.Status != "pass" {
+		t.Fatalf("unexpected network_privileged_probe check: %+v", got)
+	}
+	if got := doctorCheck(report, "network_privileged_ip"); got.Status != "pass" {
+		t.Fatalf("unexpected network_privileged_ip check: %+v", got)
+	}
+}
+
 func TestHelperCapabilitiesReturnsProbeError(t *testing.T) {
 	tmpDir := t.TempDir()
 	sudoLogPath := filepath.Join(tmpDir, "sudo.log")


### PR DESCRIPTION
## Summary
- make firecracker host support detection honour direct root mode
- stop doctor from requiring `sudo` or the privileged helper when already running as root
- add regression coverage for root-mode support and doctor checks

## Testing
- go test ./...