### PR TITLE
fix: recover dependency stage keying when mirror path is missing

### DIFF
--- a/internal/controlservice/dependency_stage.go
+++ b/internal/controlservice/dependency_stage.go
@@ -98,7 +98,10 @@ func (s *Service) dependencyStageKeyFilesDigest(ctx context.Context, repository 
 	}
 	mirrorPath, err := s.RepositoryMirrors.MirrorPath(repository.RemoteURL)
 	if err != nil {
-		return "", err
+		mirrorPath, err = s.RepositoryMirrors.EnsureMirror(ctx, repository.RemoteURL)
+		if err != nil {
+			return "", err
+		}
 	}
 	digest, err := dependencyStageKeyFilesDigestFromMirror(ctx, mirrorPath, repository.CommitSHA, files)
 	if err == nil {

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -2174,10 +2174,15 @@ func TestCreateSandboxReusesDependencyStageCacheForConfiguredDependencies(t *tes
 	}
 }
 
-func TestCreateSandboxBootstrapsDependenciesAfterWorkspaceStageRestoreWithoutDependencyStageCache(t *testing.T) {
+func TestCreateSandboxPublishesDependencyStageCacheAfterWorkspaceStageRestoreWhenMirrorPathIsMissing(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	store := newMemorySnapshotStore()
 	adapter := &stubAdapter{}
+	var snapshotReqs []backend.SnapshotRequest
+	adapter.createSnapshotFn = func(_ context.Context, req backend.SnapshotRequest) (*backend.SnapshotResult, error) {
+		snapshotReqs = append(snapshotReqs, req)
+		return &backend.SnapshotResult{StorageRef: "/snapshots/" + req.SnapshotID + ".ext4"}, nil
+	}
 	var runCommands [][]string
 	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 		runCommands = append(runCommands, append([]string(nil), req.Command...))
@@ -2237,17 +2242,33 @@ func TestCreateSandboxBootstrapsDependenciesAfterWorkspaceStageRestoreWithoutDep
 	if got, want := adapter.runCalls, 1; got != want {
 		t.Fatalf("expected dependency bootstrap to run once after workspace restore, got %d want %d", got, want)
 	}
-	if got, want := adapter.createSnapshotCalls, 0; got != want {
-		t.Fatalf("expected dependency cache publish to stay disabled after key resolution failure, got %d want %d", got, want)
+	if got, want := adapter.createSnapshotCalls, 1; got != want {
+		t.Fatalf("expected dependency cache publish after mirror creation, got %d want %d", got, want)
 	}
 	if got, want := mirrors.calls, 0; got != want {
-		t.Fatalf("expected dependency-stage key resolution to avoid remote mirror refresh, got %d want %d", got, want)
+		t.Fatalf("expected dependency-stage key resolution to avoid an extra ensure-contains refresh after creating the mirror, got %d want %d", got, want)
 	}
 	if got, want := mirrors.mirrorPathCalls, 1; got != want {
 		t.Fatalf("expected one local mirror path lookup while resolving dependency cache key, got %d want %d", got, want)
 	}
-	if got, want := mirrors.ensureMirrorCalls, 0; got != want {
-		t.Fatalf("expected dependency-stage key resolution to avoid EnsureMirror, got %d want %d", got, want)
+	if got, want := mirrors.ensureMirrorCalls, 1; got != want {
+		t.Fatalf("expected dependency-stage key resolution to create a local mirror, got %d want %d", got, want)
+	}
+	if got, want := len(snapshotReqs), 1; got != want {
+		t.Fatalf("expected one dependency-stage snapshot publish, got %d want %d", got, want)
+	}
+	records, err := cacheStore.List(context.Background())
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	dependencyRecords := 0
+	for _, record := range records {
+		if record.Stage == dependencyStageName {
+			dependencyRecords++
+		}
+	}
+	if got, want := dependencyRecords, 1; got != want {
+		t.Fatalf("expected one published dependency-stage cache record, got %d want %d", got, want)
 	}
 	if got, want := len(runCommands), 1; got != want {
 		t.Fatalf("expected one dependency bootstrap command, got %d want %d", got, want)


### PR DESCRIPTION
## Summary
- recover dependency-stage key-file hashing when `MirrorPath()` reports that no local mirror path is available yet
- create the local mirror via `EnsureMirror()` before digesting key files
- add regression coverage for publishing a dependency-stage cache after workspace restore when the mirror path is initially missing

## Testing
- go test ./internal/controlservice
- go test ./...