### PR TITLE
fix: validate zipkin-only observability config

### DIFF
--- a/internal/runtimeconfig/config.go
+++ b/internal/runtimeconfig/config.go
@@ -415,7 +415,33 @@ func Load() (Config, string, error) {
 	cfg.Observability.Traces.Sampling.Mode = strings.TrimSpace(cfg.Observability.Traces.Sampling.Mode)
 	cfg.Observability.Traces.Zipkin.Endpoint = strings.TrimSpace(cfg.Observability.Traces.Zipkin.Endpoint)
 	cfg.Observability.Traces.Zipkin.Headers = trimStringMap(cfg.Observability.Traces.Zipkin.Headers)
+	if err := validateObservabilityConfig(cfg.Observability); err != nil {
+		return Config{}, path, err
+	}
 	return cfg, path, nil
+}
+
+func validateObservabilityConfig(cfg ObservabilityConfig) error {
+	exporter := strings.ToLower(strings.TrimSpace(cfg.Traces.Exporter))
+	if hasUnsupportedOTLPConfig(cfg.OTLP) {
+		return errors.New("observability.otlp is not supported in this build; use observability.traces.exporter=zipkin and observability.traces.zipkin")
+	}
+
+	switch exporter {
+	case "", "zipkin":
+		return nil
+	case "otlp", "otlp_http", "otlp/http", "http", "http/protobuf", "grpc":
+		return fmt.Errorf("trace exporter %q is not supported in this build; use observability.traces.exporter=zipkin", exporter)
+	default:
+		return fmt.Errorf("unsupported observability.traces.exporter %q", cfg.Traces.Exporter)
+	}
+}
+
+func hasUnsupportedOTLPConfig(cfg OTLPConfig) bool {
+	return strings.TrimSpace(cfg.Endpoint) != "" ||
+		strings.TrimSpace(cfg.Protocol) != "" ||
+		cfg.Insecure ||
+		len(cfg.Headers) > 0
 }
 
 func darwinVZConfigIsZero(cfg DarwinVZConfig) bool {

--- a/internal/runtimeconfig/config.go
+++ b/internal/runtimeconfig/config.go
@@ -422,6 +422,10 @@ func Load() (Config, string, error) {
 }
 
 func validateObservabilityConfig(cfg ObservabilityConfig) error {
+	if !cfg.Enabled {
+		return nil
+	}
+
 	exporter := strings.ToLower(strings.TrimSpace(cfg.Traces.Exporter))
 	if hasUnsupportedOTLPConfig(cfg.OTLP) {
 		return errors.New("observability.otlp is not supported in this build; use observability.traces.exporter=zipkin and observability.traces.zipkin")

--- a/internal/runtimeconfig/config_test.go
+++ b/internal/runtimeconfig/config_test.go
@@ -285,12 +285,6 @@ func TestLoadTrimsObservabilityConfig(t *testing.T) {
 	content := `observability:
   enabled: true
   deployment_environment: " ci "
-  otlp:
-    endpoint: " localhost:4317 "
-    protocol: " grpc "
-    headers:
-      " authorization ": " Bearer token "
-      "": ignored
   traces:
     exporter: " zipkin "
     sampling:
@@ -315,12 +309,6 @@ func TestLoadTrimsObservabilityConfig(t *testing.T) {
 	if got, want := cfg.Observability.DeploymentEnvironment, "ci"; got != want {
 		t.Fatalf("unexpected deployment environment: got %q want %q", got, want)
 	}
-	if got, want := cfg.Observability.OTLP.Endpoint, "localhost:4317"; got != want {
-		t.Fatalf("unexpected OTLP endpoint: got %q want %q", got, want)
-	}
-	if got, want := cfg.Observability.OTLP.Protocol, "grpc"; got != want {
-		t.Fatalf("unexpected OTLP protocol: got %q want %q", got, want)
-	}
 	if got, want := cfg.Observability.Traces.Exporter, "zipkin"; got != want {
 		t.Fatalf("unexpected trace exporter: got %q want %q", got, want)
 	}
@@ -333,18 +321,63 @@ func TestLoadTrimsObservabilityConfig(t *testing.T) {
 	if got, want := *cfg.Observability.Traces.Sampling.Ratio, 0.5; got != want {
 		t.Fatalf("unexpected sampling ratio: got %v want %v", got, want)
 	}
-	headers := cfg.Observability.OTLP.Headers
-	if len(headers) != 1 {
-		t.Fatalf("unexpected header count: got %d want 1", len(headers))
-	}
-	if got, want := headers["authorization"], "Bearer token"; got != want {
-		t.Fatalf("unexpected authorization header: got %q want %q", got, want)
-	}
 	if got, want := cfg.Observability.Traces.Zipkin.Endpoint, "http://localhost:9411/api/v2/spans"; got != want {
 		t.Fatalf("unexpected zipkin endpoint: got %q want %q", got, want)
 	}
 	if got, want := cfg.Observability.Traces.Zipkin.Headers["x-dev-mode"], "true"; got != want {
 		t.Fatalf("unexpected zipkin header: got %q want %q", got, want)
+	}
+}
+
+func TestLoadRejectsUnsupportedObservabilityOTLPConfig(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	configPath := filepath.Join(tmp, "cleanroom", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+
+	content := `observability:
+  enabled: true
+  otlp:
+    endpoint: "localhost:4317"
+`
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, _, err := Load()
+	if err == nil {
+		t.Fatal("expected Load to reject unsupported observability.otlp config")
+	}
+	if !strings.Contains(err.Error(), "observability.otlp") {
+		t.Fatalf("expected error to mention observability.otlp, got %v", err)
+	}
+}
+
+func TestLoadRejectsUnsupportedObservabilityTraceExporter(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	configPath := filepath.Join(tmp, "cleanroom", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+
+	content := `observability:
+  enabled: true
+  traces:
+    exporter: otlp
+`
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, _, err := Load()
+	if err == nil {
+		t.Fatal("expected Load to reject unsupported observability trace exporter")
+	}
+	if !strings.Contains(err.Error(), "not supported in this build") {
+		t.Fatalf("expected error to mention unsupported build-time exporter, got %v", err)
 	}
 }
 

--- a/internal/runtimeconfig/config_test.go
+++ b/internal/runtimeconfig/config_test.go
@@ -381,6 +381,40 @@ func TestLoadRejectsUnsupportedObservabilityTraceExporter(t *testing.T) {
 	}
 }
 
+func TestLoadAllowsUnsupportedObservabilityConfigWhenDisabled(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	configPath := filepath.Join(tmp, "cleanroom", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+
+	content := `observability:
+  enabled: false
+  otlp:
+    endpoint: " localhost:4317 "
+  traces:
+    exporter: " otlp "
+`
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, _, err := Load()
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if cfg.Observability.Enabled {
+		t.Fatal("expected observability to remain disabled")
+	}
+	if got, want := cfg.Observability.OTLP.Endpoint, "localhost:4317"; got != want {
+		t.Fatalf("unexpected trimmed otlp endpoint: got %q want %q", got, want)
+	}
+	if got, want := cfg.Observability.Traces.Exporter, "otlp"; got != want {
+		t.Fatalf("unexpected trimmed trace exporter: got %q want %q", got, want)
+	}
+}
+
 func TestLoadTrimsGatewayGitCacheHosts(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)


### PR DESCRIPTION
## Summary
- reject unsupported `observability.otlp` settings during runtime config load
- reject unsupported OTLP trace exporter values before observability startup
- keep the supported config path explicitly Zipkin-only in this build

## Testing
- go test ./internal/runtimeconfig ./internal/observability
- go test ./...