### PR TITLE
feat: add sandbox.run.before

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ You can also define per-execution setup that runs before each top-level command:
 ```yaml
 sandbox:
   dependencies:
-    command: [bundle, install]
+    command: bundle install
     key:
       files: [Gemfile.lock]
   run:
@@ -121,6 +121,8 @@ sandbox:
       bin/rails db:prepare
 ```
 
+`sandbox.dependencies.command` supports either a shell string or an argv sequence.
+Prefer the string form unless you specifically need exact argv semantics.
 `sandbox.run.before` always runs through `sh -lc`.
 
 Pre-create a long-running sandbox without running a command:

--- a/README.md
+++ b/README.md
@@ -107,6 +107,22 @@ for `mise`; if you want `mise`, run it explicitly in the command you execute or
 in `sandbox.dependencies.command` so it can participate in dependency-stage
 caching.
 
+You can also define per-execution setup that runs before each top-level command:
+
+```yaml
+sandbox:
+  dependencies:
+    command: [bundle, install]
+    key:
+      files: [Gemfile.lock]
+  run:
+    before: |
+      docker compose up -d postgres valkey
+      bin/rails db:prepare
+```
+
+`sandbox.run.before` always runs through `sh -lc`.
+
 Pre-create a long-running sandbox without running a command:
 
 ```bash

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -167,6 +167,8 @@ explicit request-time changeset input.
 - `repository.submodules` defaults to `false`.
 - `sandbox.dependencies.command` defaults to unset; when present, Cleanroom runs that command in the repository workdir during sandbox creation and makes the result eligible for dependency-stage caching.
 - `sandbox.dependencies.key.files` defaults to empty; when present, Cleanroom hashes those repository-relative files from the exact committed checkout and includes them in the dependency-stage cache key.
+- `sandbox.run.before` defaults to unset; when present, each execution runs that shell command in the repository workdir immediately before the requested command.
+- `sandbox.run.before` must be a YAML string or block string and executes as `sh -lc <value>`.
 - Policy schema intentionally has no field for implicit dirty-worktree inclusion; explicit local modifications are a separate request-time changeset input.
 - Host matching supports:
   - exact host (`registry.npmjs.org`)
@@ -228,6 +230,7 @@ explicit request-time changeset input.
   - they materialize that checkout inside the sandbox before the command runs
   - they start commands in `repository.path`
   - when `sandbox.dependencies.command` is set, sandbox creation runs that dependency bootstrap command after repository bootstrap and may publish a reusable dependency stage for later warm hits
+  - when `sandbox.run.before` is set, each execution runs that shell command immediately before the requested command
   - Cleanroom does not auto-detect or auto-wrap `mise`; use explicit commands such as `mise exec -- ...` when needed
 - When explicitly requested, top-level commands may package local modifications against committed `HEAD` into a reproducible changeset, send that changeset as a separate sandbox-creation input, and apply it after repository bootstrap and before dependency bootstrap or workload execution.
 - `cleanroom sandbox create` remains the generic low-level surface and does not

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -76,7 +76,7 @@ project:
 sandbox:
   ttl_minutes: 60
   dependencies:
-    command: [mise, exec, --, go, mod, download]
+    command: mise exec -- go mod download
     key:
       files:
         - .mise.toml
@@ -166,6 +166,7 @@ explicit request-time changeset input.
 - `repository.path` defaults to `/workspace` and must be an absolute guest path.
 - `repository.submodules` defaults to `false`.
 - `sandbox.dependencies.command` defaults to unset; when present, Cleanroom runs that command in the repository workdir during sandbox creation and makes the result eligible for dependency-stage caching.
+- `sandbox.dependencies.command` accepts either a YAML string or a YAML sequence; strings execute as `sh -lc <value>`, and strings are the preferred form.
 - `sandbox.dependencies.key.files` defaults to empty; when present, Cleanroom hashes those repository-relative files from the exact committed checkout and includes them in the dependency-stage cache key.
 - `sandbox.run.before` defaults to unset; when present, each execution runs that shell command in the repository workdir immediately before the requested command.
 - `sandbox.run.before` must be a YAML string or block string and executes as `sh -lc <value>`.

--- a/internal/controlservice/bootstrap_runner.go
+++ b/internal/controlservice/bootstrap_runner.go
@@ -10,6 +10,25 @@ import (
 	"github.com/buildkite/cleanroom/internal/policy"
 )
 
+func (s *Service) runPersistentSandboxCommand(
+	ctx context.Context,
+	adapter backend.Adapter,
+	sandboxID string,
+	compiled *policy.CompiledPolicy,
+	firecrackerCfg backend.FirecrackerConfig,
+	executionID string,
+	command []string,
+	stream backend.OutputStream,
+) (*backend.ExecutionResult, error) {
+	return adapter.RunInSandbox(ctx, backend.ExecutionRequest{
+		SandboxID:         sandboxID,
+		ExecutionID:       executionID,
+		Command:           append([]string(nil), command...),
+		Policy:            compiled,
+		FirecrackerConfig: withRunDir(firecrackerCfg, internalBootstrapArtifactsDir(sandboxID, executionID)),
+	}, stream)
+}
+
 func (s *Service) runPersistentBootstrapCommand(
 	ctx context.Context,
 	adapter backend.Adapter,
@@ -25,13 +44,7 @@ func (s *Service) runPersistentBootstrapCommand(
 	var stderr bytes.Buffer
 	var attachErr error
 	bootstrapExecutionID := s.ids().NewExecutionID()
-	result, err := adapter.RunInSandbox(ctx, backend.ExecutionRequest{
-		SandboxID:         sandboxID,
-		ExecutionID:       bootstrapExecutionID,
-		Command:           append([]string(nil), command...),
-		Policy:            compiled,
-		FirecrackerConfig: withRunDir(firecrackerCfg, internalBootstrapArtifactsDir(sandboxID, bootstrapExecutionID)),
-	}, backend.OutputStream{
+	result, err := s.runPersistentSandboxCommand(ctx, adapter, sandboxID, compiled, firecrackerCfg, bootstrapExecutionID, command, backend.OutputStream{
 		OnStdout: func(chunk []byte) {
 			_, _ = stdout.Write(chunk)
 			emitCreateSandboxStdout(reporter, phase, chunk)

--- a/internal/controlservice/bootstrap_runner.go
+++ b/internal/controlservice/bootstrap_runner.go
@@ -18,12 +18,14 @@ func (s *Service) runPersistentSandboxCommand(
 	firecrackerCfg backend.FirecrackerConfig,
 	executionID string,
 	command []string,
+	env []string,
 	stream backend.OutputStream,
 ) (*backend.ExecutionResult, error) {
 	return adapter.RunInSandbox(ctx, backend.ExecutionRequest{
 		SandboxID:         sandboxID,
 		ExecutionID:       executionID,
 		Command:           append([]string(nil), command...),
+		Env:               append([]string(nil), env...),
 		Policy:            compiled,
 		FirecrackerConfig: withRunDir(firecrackerCfg, internalBootstrapArtifactsDir(sandboxID, executionID)),
 	}, stream)
@@ -44,7 +46,7 @@ func (s *Service) runPersistentBootstrapCommand(
 	var stderr bytes.Buffer
 	var attachErr error
 	bootstrapExecutionID := s.ids().NewExecutionID()
-	result, err := s.runPersistentSandboxCommand(ctx, adapter, sandboxID, compiled, firecrackerCfg, bootstrapExecutionID, command, backend.OutputStream{
+	result, err := s.runPersistentSandboxCommand(ctx, adapter, sandboxID, compiled, firecrackerCfg, bootstrapExecutionID, command, nil, backend.OutputStream{
 		OnStdout: func(chunk []byte) {
 			_, _ = stdout.Write(chunk)
 			emitCreateSandboxStdout(reporter, phase, chunk)

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -82,6 +82,7 @@ type executionState struct {
 	ImageRef          string
 	ImageDigest       string
 	Command           []string
+	PreRunBefore      []string
 	Env               []string
 	Options           executionOptions
 	TTY               bool
@@ -1022,6 +1023,17 @@ func (s *Service) CreateExecution(ctx context.Context, req *cleanroomv1.CreateEx
 	} else if sandboxRepository != nil {
 		command = repositorycheckout.WrapCommandInWorkdir(command, sandboxRepository)
 	}
+	runRepository := repository
+	if runRepository == nil {
+		runRepository = sandboxRepository
+	}
+	var preRunBefore []string
+	if sandboxPolicy != nil && sandboxPolicy.Run.HasBefore() {
+		preRunBefore = append([]string(nil), sandboxPolicy.Run.Before...)
+		if runRepository != nil {
+			preRunBefore = repositorycheckout.WrapCommandInWorkdir(preRunBefore, runRepository)
+		}
+	}
 
 	s.mu.Lock()
 	s.ensureMapsLocked()
@@ -1062,6 +1074,7 @@ func (s *Service) CreateExecution(ctx context.Context, req *cleanroomv1.CreateEx
 		ImageRef:          imageRef,
 		ImageDigest:       imageDigest,
 		Command:           append([]string(nil), command...),
+		PreRunBefore:      preRunBefore,
 		Env:               executionEnv,
 		Options:           execOpts,
 		TTY:               tty,
@@ -1770,6 +1783,16 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 	if ex.Options.LaunchSeconds != 0 {
 		firecrackerCfg.LaunchSeconds = ex.Options.LaunchSeconds
 	}
+	preRunBefore := append([]string(nil), ex.PreRunBefore...)
+	if len(preRunBefore) > 0 {
+		s.recordExecutionEventLocked(ex, &cleanroomv1.ExecutionStreamEvent{
+			SandboxId:   sandboxID,
+			ExecutionId: executionID,
+			Status:      ex.Status,
+			Payload:     &cleanroomv1.ExecutionStreamEvent_Message{Message: "running sandbox.run.before"},
+			OccurredAt:  timestamppb.New(s.clock().Now()),
+		})
+	}
 
 	executionReq := backend.ExecutionRequest{
 		SandboxID:         sandboxID,
@@ -1793,6 +1816,83 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 	)
 	s.mu.Unlock()
 	defer span.End()
+
+	if len(preRunBefore) > 0 {
+		preRunExecutionID := s.ids().NewExecutionID()
+		preRunResult, preRunErr := s.runPersistentSandboxCommand(runCtx, adapter, sandboxID, sb.Policy, firecrackerCfg, preRunExecutionID, preRunBefore, s.executionAuxOutputStream(key))
+
+		s.mu.Lock()
+		ex, ok = s.executions[key]
+		if !ok {
+			s.mu.Unlock()
+			return
+		}
+		if preRunErr != nil {
+			span.RecordError(preRunErr)
+			span.SetStatus(codes.Error, preRunErr.Error())
+			finalStatus, exitCode := executionRunErrorStatus(ex, runCtx)
+			if strings.TrimSpace(preRunErr.Error()) != "" {
+				s.appendExecutionStderrLocked(ex, finalStatus, []byte(preRunErr.Error()+"\n"))
+			}
+			finished := s.clock().Now()
+			s.finalizeExecutionLocked(ex, finalStatus, exitCode, preRunErr.Error(), "", finished)
+			if sb, ok := s.sandboxes[sandboxID]; ok && sb.ActiveExecutionID == executionID {
+				sb.ActiveExecutionID = ""
+				sb.UpdatedAt = s.clock().Now()
+			}
+			s.mu.Unlock()
+			return
+		}
+		if preRunResult == nil {
+			finished := s.clock().Now()
+			s.finalizeExecutionLocked(ex, cleanroomv1.ExecutionStatus_EXECUTION_STATUS_FAILED, 1, "sandbox.run.before returned no result", "", finished)
+			if sb, ok := s.sandboxes[sandboxID]; ok && sb.ActiveExecutionID == executionID {
+				sb.ActiveExecutionID = ""
+				sb.UpdatedAt = s.clock().Now()
+			}
+			s.mu.Unlock()
+			return
+		}
+		s.mergeBufferedResultOutputLocked(ex, preRunResult, true)
+		if preRunResult.ExitCode != 0 {
+			msg := strings.TrimSpace(preRunResult.Message)
+			if msg == "" {
+				if ex.CancelRequested {
+					msg = "execution canceled before command start"
+				} else {
+					msg = fmt.Sprintf("sandbox.run.before failed with exit code %d", preRunResult.ExitCode)
+				}
+			}
+			if msg != "" && !strings.Contains(ex.Stderr, msg) {
+				s.appendExecutionStderrLocked(ex, cleanroomv1.ExecutionStatus_EXECUTION_STATUS_RUNNING, []byte(msg+"\n"))
+			}
+			finished := s.clock().Now()
+			finalStatus := cleanroomv1.ExecutionStatus_EXECUTION_STATUS_FAILED
+			finalExitCode := int32(preRunResult.ExitCode)
+			if ex.CancelRequested {
+				finalStatus = cleanroomv1.ExecutionStatus_EXECUTION_STATUS_CANCELED
+				finalExitCode = cancelExitCode(ex.CancelSignal)
+			}
+			s.finalizeExecutionLocked(ex, finalStatus, finalExitCode, msg, "", finished)
+			if sb, ok := s.sandboxes[sandboxID]; ok && sb.ActiveExecutionID == executionID {
+				sb.ActiveExecutionID = ""
+				sb.UpdatedAt = s.clock().Now()
+			}
+			s.mu.Unlock()
+			return
+		}
+		if ex.CancelRequested {
+			finished := s.clock().Now()
+			s.finalizeExecutionLocked(ex, cleanroomv1.ExecutionStatus_EXECUTION_STATUS_CANCELED, cancelExitCode(ex.CancelSignal), ex.Message, "execution canceled before command start", finished)
+			if sb, ok := s.sandboxes[sandboxID]; ok && sb.ActiveExecutionID == executionID {
+				sb.ActiveExecutionID = ""
+				sb.UpdatedAt = s.clock().Now()
+			}
+			s.mu.Unlock()
+			return
+		}
+		s.mu.Unlock()
+	}
 
 	result, err := s.runAdapterExecution(runCtx, adapter, executionReq, key)
 
@@ -1901,6 +2001,20 @@ func (s *Service) executionOutputStream(key string) backend.OutputStream {
 		},
 		OnAttach: func(io backend.AttachIO) {
 			s.setExecutionAttachIO(key, io)
+		},
+	}
+}
+
+func (s *Service) executionAuxOutputStream(key string) backend.OutputStream {
+	return backend.OutputStream{
+		OnStdout: func(chunk []byte) {
+			s.recordExecutionOutputChunk(key, true, chunk)
+		},
+		OnStderr: func(chunk []byte) {
+			s.recordExecutionOutputChunk(key, false, chunk)
+		},
+		OnWarning: func(message string) {
+			s.recordExecutionWarning(key, message)
 		},
 	}
 }

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -1842,6 +1842,7 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 			if strings.TrimSpace(preRunErr.Error()) != "" {
 				s.appendExecutionStderrLocked(ex, finalStatus, []byte(preRunErr.Error()+"\n"))
 			}
+			clearExecutionRuntimeHandlesLocked(ex)
 			finished := s.clock().Now()
 			s.finalizeExecutionLocked(ex, finalStatus, exitCode, preRunErr.Error(), "", finished)
 			if sb, ok := s.sandboxes[sandboxID]; ok && sb.ActiveExecutionID == executionID {
@@ -1852,6 +1853,7 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 			return
 		}
 		if preRunResult == nil {
+			clearExecutionRuntimeHandlesLocked(ex)
 			finished := s.clock().Now()
 			s.finalizeExecutionLocked(ex, cleanroomv1.ExecutionStatus_EXECUTION_STATUS_FAILED, 1, "sandbox.run.before returned no result", "", finished)
 			if sb, ok := s.sandboxes[sandboxID]; ok && sb.ActiveExecutionID == executionID {
@@ -1881,6 +1883,7 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 				finalStatus = cleanroomv1.ExecutionStatus_EXECUTION_STATUS_CANCELED
 				finalExitCode = cancelExitCode(ex.CancelSignal)
 			}
+			clearExecutionRuntimeHandlesLocked(ex)
 			s.finalizeExecutionLocked(ex, finalStatus, finalExitCode, msg, "", finished)
 			if sb, ok := s.sandboxes[sandboxID]; ok && sb.ActiveExecutionID == executionID {
 				sb.ActiveExecutionID = ""
@@ -1890,6 +1893,7 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 			return
 		}
 		if ex.CancelRequested {
+			clearExecutionRuntimeHandlesLocked(ex)
 			finished := s.clock().Now()
 			s.finalizeExecutionLocked(ex, cleanroomv1.ExecutionStatus_EXECUTION_STATUS_CANCELED, cancelExitCode(ex.CancelSignal), ex.Message, "execution canceled before command start", finished)
 			if sb, ok := s.sandboxes[sandboxID]; ok && sb.ActiveExecutionID == executionID {
@@ -1927,10 +1931,7 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 		sb.UpdatedAt = s.clock().Now()
 	}
 
-	if ex.Cancel != nil {
-		ex.Cancel = nil
-	}
-	clearExecutionAttachIOLocked(ex)
+	clearExecutionRuntimeHandlesLocked(ex)
 
 	if err != nil {
 		span.RecordError(err)

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -1433,8 +1433,8 @@ func (s *Service) WriteExecutionStdin(sandboxID, executionID string, data []byte
 			s.mu.RUnlock()
 			return errors.New("execution is not running")
 		}
-		if !ex.PreRunActive && deadline.IsZero() {
-			deadline = clock.Now().Add(s.executionAttachStdinWaitLocked(sandboxID, ex))
+		if deadline.IsZero() {
+			deadline = clock.Now().Add(s.executionAttachStdinTotalWaitLocked(sandboxID, ex))
 		}
 		writeFn = ex.AttachStdin
 		done = ex.Done
@@ -1480,8 +1480,8 @@ func (s *Service) CloseExecutionStdin(sandboxID, executionID string) error {
 			s.mu.RUnlock()
 			return errors.New("execution is not running")
 		}
-		if !ex.PreRunActive && deadline.IsZero() {
-			deadline = clock.Now().Add(s.executionAttachStdinWaitLocked(sandboxID, ex))
+		if deadline.IsZero() {
+			deadline = clock.Now().Add(s.executionAttachStdinTotalWaitLocked(sandboxID, ex))
 		}
 		closeFn = ex.AttachCloseStdin
 		done = ex.Done
@@ -1518,6 +1518,22 @@ func (s *Service) executionAttachStdinWaitLocked(sandboxID string, ex *execution
 	return wait
 }
 
+func (s *Service) executionAttachStdinTotalWaitLocked(sandboxID string, ex *executionState) time.Duration {
+	wait := s.executionAttachStdinWaitLocked(sandboxID, ex)
+	if ex != nil && ex.PreRunActive {
+		return wait + s.executionAttachStdinWaitLocked(sandboxID, ex)
+	}
+	return wait
+}
+
+func (s *Service) executionAttachResizeTotalWaitLocked(sandboxID string, ex *executionState) time.Duration {
+	wait := s.timeouts().attachResizeRegistrationWait
+	if ex != nil && ex.PreRunActive {
+		return wait + s.executionAttachStdinWaitLocked(sandboxID, ex)
+	}
+	return wait
+}
+
 func (s *Service) ResizeExecutionTTY(sandboxID, executionID string, cols, rows uint32) error {
 	sandboxID = strings.TrimSpace(sandboxID)
 	executionID = strings.TrimSpace(executionID)
@@ -1545,8 +1561,8 @@ func (s *Service) ResizeExecutionTTY(sandboxID, executionID string, cols, rows u
 			s.mu.RUnlock()
 			return errors.New("execution is not running")
 		}
-		if !ex.PreRunActive && deadline.IsZero() {
-			deadline = clock.Now().Add(s.timeouts().attachResizeRegistrationWait)
+		if deadline.IsZero() {
+			deadline = clock.Now().Add(s.executionAttachResizeTotalWaitLocked(sandboxID, ex))
 		}
 		resizeFn = ex.AttachResize
 		done = ex.Done

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -1834,6 +1834,7 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 			return
 		}
 		ex.PreRunActive = false
+		s.applyExecutionResultMetadataLocked(ex, preRunResult)
 		if preRunErr != nil {
 			span.RecordError(preRunErr)
 			span.SetStatus(codes.Error, preRunErr.Error())
@@ -1953,15 +1954,7 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 		return
 	}
 
-	ex.LaunchedVM = result.LaunchedVM
-	ex.PlanPath = result.PlanPath
-	ex.RunDir = result.RunDir
-	if strings.TrimSpace(result.ImageRef) != "" {
-		ex.ImageRef = result.ImageRef
-	}
-	if strings.TrimSpace(result.ImageDigest) != "" {
-		ex.ImageDigest = result.ImageDigest
-	}
+	s.applyExecutionResultMetadataLocked(ex, result)
 	ex.Message = result.Message
 	s.mergeBufferedResultOutputFromStreamLocked(ex, result, commandOutputPrefixStdout, commandOutputPrefixStderr, commandStreamStdout.String(), commandStreamStderr.String())
 
@@ -2005,6 +1998,21 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 
 func (s *Service) runAdapterExecution(runCtx context.Context, adapter backend.Adapter, executionReq backend.ExecutionRequest, key string, stdoutCapture, stderrCapture *retainedOutputCapture) (*backend.ExecutionResult, error) {
 	return adapter.RunInSandbox(runCtx, executionReq, s.executionOutputStream(key, stdoutCapture, stderrCapture))
+}
+
+func (s *Service) applyExecutionResultMetadataLocked(ex *executionState, result *backend.ExecutionResult) {
+	if ex == nil || result == nil {
+		return
+	}
+	ex.LaunchedVM = result.LaunchedVM
+	ex.PlanPath = result.PlanPath
+	ex.RunDir = result.RunDir
+	if strings.TrimSpace(result.ImageRef) != "" {
+		ex.ImageRef = result.ImageRef
+	}
+	if strings.TrimSpace(result.ImageDigest) != "" {
+		ex.ImageDigest = result.ImageDigest
+	}
 }
 
 func (s *Service) executionOutputStream(key string, stdoutCapture, stderrCapture *retainedOutputCapture) backend.OutputStream {

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -1,7 +1,6 @@
 package controlservice
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -98,6 +97,7 @@ type executionState struct {
 	LaunchedVM        bool
 	PlanPath          string
 	RunDir            string
+	PreRunActive      bool
 	CancelRequested   bool
 	CancelSignal      int32
 	Cancel            context.CancelFunc
@@ -1081,6 +1081,7 @@ func (s *Service) CreateExecution(ctx context.Context, req *cleanroomv1.CreateEx
 		TTY:               tty,
 		Kind:              kind,
 		Status:            cleanroomv1.ExecutionStatus_EXECUTION_STATUS_QUEUED,
+		PreRunActive:      len(preRunBefore) > 0,
 		ParentSpanContext: trace.SpanContextFromContext(ctx),
 		events:            newEventFeed[*cleanroomv1.ExecutionStreamEvent](s.retention().maxRetainedExecutionEvents),
 		Done:              make(chan struct{}),
@@ -1432,7 +1433,7 @@ func (s *Service) WriteExecutionStdin(sandboxID, executionID string, data []byte
 			s.mu.RUnlock()
 			return errors.New("execution is not running")
 		}
-		if deadline.IsZero() {
+		if !ex.PreRunActive && deadline.IsZero() {
 			deadline = clock.Now().Add(s.executionAttachStdinWaitLocked(sandboxID, ex))
 		}
 		writeFn = ex.AttachStdin
@@ -1442,7 +1443,7 @@ func (s *Service) WriteExecutionStdin(sandboxID, executionID string, data []byte
 		if writeFn != nil {
 			return writeFn(payload)
 		}
-		if clock.Now().After(deadline) {
+		if !deadline.IsZero() && clock.Now().After(deadline) {
 			return ErrExecutionStdinUnsupported
 		}
 		select {
@@ -1479,7 +1480,7 @@ func (s *Service) CloseExecutionStdin(sandboxID, executionID string) error {
 			s.mu.RUnlock()
 			return errors.New("execution is not running")
 		}
-		if deadline.IsZero() {
+		if !ex.PreRunActive && deadline.IsZero() {
 			deadline = clock.Now().Add(s.executionAttachStdinWaitLocked(sandboxID, ex))
 		}
 		closeFn = ex.AttachCloseStdin
@@ -1489,7 +1490,7 @@ func (s *Service) CloseExecutionStdin(sandboxID, executionID string) error {
 		if closeFn != nil {
 			return closeFn()
 		}
-		if clock.Now().After(deadline) {
+		if !deadline.IsZero() && clock.Now().After(deadline) {
 			return ErrExecutionStdinUnsupported
 		}
 		select {
@@ -1528,7 +1529,7 @@ func (s *Service) ResizeExecutionTTY(sandboxID, executionID string, cols, rows u
 	}
 
 	clock := s.clock()
-	deadline := clock.Now().Add(s.timeouts().attachResizeRegistrationWait)
+	var deadline time.Time
 	for {
 		var (
 			resizeFn func(cols, rows uint32) error
@@ -1544,6 +1545,9 @@ func (s *Service) ResizeExecutionTTY(sandboxID, executionID string, cols, rows u
 			s.mu.RUnlock()
 			return errors.New("execution is not running")
 		}
+		if !ex.PreRunActive && deadline.IsZero() {
+			deadline = clock.Now().Add(s.timeouts().attachResizeRegistrationWait)
+		}
 		resizeFn = ex.AttachResize
 		done = ex.Done
 		s.mu.RUnlock()
@@ -1551,7 +1555,7 @@ func (s *Service) ResizeExecutionTTY(sandboxID, executionID string, cols, rows u
 		if resizeFn != nil {
 			return resizeFn(cols, rows)
 		}
-		if clock.Now().After(deadline) {
+		if !deadline.IsZero() && clock.Now().After(deadline) {
 			return ErrExecutionResizeUnsupported
 		}
 		select {
@@ -1786,6 +1790,7 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 	}
 	preRunBefore := append([]string(nil), ex.PreRunBefore...)
 	if len(preRunBefore) > 0 {
+		ex.PreRunActive = true
 		s.recordExecutionEventLocked(ex, &cleanroomv1.ExecutionStreamEvent{
 			SandboxId:   sandboxID,
 			ExecutionId: executionID,
@@ -1828,6 +1833,7 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 			s.mu.Unlock()
 			return
 		}
+		ex.PreRunActive = false
 		if preRunErr != nil {
 			span.RecordError(preRunErr)
 			span.SetStatus(codes.Error, preRunErr.Error())
@@ -1897,8 +1903,8 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 
 	commandOutputPrefixStdout := ""
 	commandOutputPrefixStderr := ""
-	commandStreamStdout := &bytes.Buffer{}
-	commandStreamStderr := &bytes.Buffer{}
+	commandStreamStdout := newRetainedOutputCapture(s.retention().maxRetainedExecutionOutputBytes)
+	commandStreamStderr := newRetainedOutputCapture(s.retention().maxRetainedExecutionOutputBytes)
 
 	s.mu.Lock()
 	if ex, ok := s.executions[key]; ok {
@@ -1997,11 +2003,11 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 	}
 }
 
-func (s *Service) runAdapterExecution(runCtx context.Context, adapter backend.Adapter, executionReq backend.ExecutionRequest, key string, stdoutCapture, stderrCapture *bytes.Buffer) (*backend.ExecutionResult, error) {
+func (s *Service) runAdapterExecution(runCtx context.Context, adapter backend.Adapter, executionReq backend.ExecutionRequest, key string, stdoutCapture, stderrCapture *retainedOutputCapture) (*backend.ExecutionResult, error) {
 	return adapter.RunInSandbox(runCtx, executionReq, s.executionOutputStream(key, stdoutCapture, stderrCapture))
 }
 
-func (s *Service) executionOutputStream(key string, stdoutCapture, stderrCapture *bytes.Buffer) backend.OutputStream {
+func (s *Service) executionOutputStream(key string, stdoutCapture, stderrCapture *retainedOutputCapture) backend.OutputStream {
 	return backend.OutputStream{
 		OnStdout: func(chunk []byte) {
 			if stdoutCapture != nil {

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -1819,7 +1819,7 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 
 	if len(preRunBefore) > 0 {
 		preRunExecutionID := s.ids().NewExecutionID()
-		preRunResult, preRunErr := s.runPersistentSandboxCommand(runCtx, adapter, sandboxID, sb.Policy, firecrackerCfg, preRunExecutionID, preRunBefore, s.executionAuxOutputStream(key))
+		preRunResult, preRunErr := s.runPersistentSandboxCommand(runCtx, adapter, sandboxID, sb.Policy, firecrackerCfg, preRunExecutionID, preRunBefore, ex.Env, s.executionAuxOutputStream(key))
 
 		s.mu.Lock()
 		ex, ok = s.executions[key]

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -1,6 +1,7 @@
 package controlservice
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -1894,7 +1895,19 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 		s.mu.Unlock()
 	}
 
-	result, err := s.runAdapterExecution(runCtx, adapter, executionReq, key)
+	commandOutputPrefixStdout := ""
+	commandOutputPrefixStderr := ""
+	commandStreamStdout := &bytes.Buffer{}
+	commandStreamStderr := &bytes.Buffer{}
+
+	s.mu.Lock()
+	if ex, ok := s.executions[key]; ok {
+		commandOutputPrefixStdout = ex.Stdout
+		commandOutputPrefixStderr = ex.Stderr
+	}
+	s.mu.Unlock()
+
+	result, err := s.runAdapterExecution(runCtx, adapter, executionReq, key, commandStreamStdout, commandStreamStderr)
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -1944,7 +1957,7 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 		ex.ImageDigest = result.ImageDigest
 	}
 	ex.Message = result.Message
-	s.mergeBufferedResultOutputLocked(ex, result, true)
+	s.mergeBufferedResultOutputFromStreamLocked(ex, result, commandOutputPrefixStdout, commandOutputPrefixStderr, commandStreamStdout.String(), commandStreamStderr.String())
 
 	if result.ExitCode != 0 && strings.TrimSpace(result.Message) != "" && !strings.Contains(ex.Stderr, result.Message) {
 		msg := result.Message + "\n"
@@ -1984,16 +1997,22 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 	}
 }
 
-func (s *Service) runAdapterExecution(runCtx context.Context, adapter backend.Adapter, executionReq backend.ExecutionRequest, key string) (*backend.ExecutionResult, error) {
-	return adapter.RunInSandbox(runCtx, executionReq, s.executionOutputStream(key))
+func (s *Service) runAdapterExecution(runCtx context.Context, adapter backend.Adapter, executionReq backend.ExecutionRequest, key string, stdoutCapture, stderrCapture *bytes.Buffer) (*backend.ExecutionResult, error) {
+	return adapter.RunInSandbox(runCtx, executionReq, s.executionOutputStream(key, stdoutCapture, stderrCapture))
 }
 
-func (s *Service) executionOutputStream(key string) backend.OutputStream {
+func (s *Service) executionOutputStream(key string, stdoutCapture, stderrCapture *bytes.Buffer) backend.OutputStream {
 	return backend.OutputStream{
 		OnStdout: func(chunk []byte) {
+			if stdoutCapture != nil {
+				_, _ = stdoutCapture.Write(chunk)
+			}
 			s.recordExecutionOutputChunk(key, true, chunk)
 		},
 		OnStderr: func(chunk []byte) {
+			if stderrCapture != nil {
+				_, _ = stderrCapture.Write(chunk)
+			}
 			s.recordExecutionOutputChunk(key, false, chunk)
 		},
 		OnWarning: func(message string) {
@@ -2256,6 +2275,26 @@ func (s *Service) mergeBufferedResultOutputLocked(ex *executionState, result *ba
 	}
 }
 
+func (s *Service) mergeBufferedResultOutputFromStreamLocked(ex *executionState, result *backend.ExecutionResult, prefixStdout, prefixStderr, streamedStdout, streamedStderr string) {
+	if ex == nil || result == nil {
+		return
+	}
+
+	appendStdout, replaceStdout := bufferedResultDelta(streamedStdout, result.Stdout, s.retention().maxRetainedExecutionOutputBytes)
+	appendStderr, replaceStderr := bufferedResultDelta(streamedStderr, result.Stderr, s.retention().maxRetainedExecutionOutputBytes)
+
+	if replaceStdout {
+		s.replaceExecutionStdoutFromBufferedWithPrefixLocked(ex, cleanroomv1.ExecutionStatus_EXECUTION_STATUS_RUNNING, prefixStdout, appendStdout)
+	} else {
+		s.appendExecutionStdoutLocked(ex, cleanroomv1.ExecutionStatus_EXECUTION_STATUS_RUNNING, []byte(appendStdout))
+	}
+	if replaceStderr {
+		s.replaceExecutionStderrFromBufferedWithPrefixLocked(ex, cleanroomv1.ExecutionStatus_EXECUTION_STATUS_RUNNING, prefixStderr, appendStderr)
+	} else {
+		s.appendExecutionStderrLocked(ex, cleanroomv1.ExecutionStatus_EXECUTION_STATUS_RUNNING, []byte(appendStderr))
+	}
+}
+
 func (s *Service) recordExecutionOutputChunk(key string, isStdout bool, chunk []byte) {
 	if len(chunk) == 0 {
 		return
@@ -2351,11 +2390,39 @@ func (s *Service) replaceExecutionStdoutFromBufferedLocked(ex *executionState, s
 	})
 }
 
+func (s *Service) replaceExecutionStdoutFromBufferedWithPrefixLocked(ex *executionState, status cleanroomv1.ExecutionStatus, prefix, output string) {
+	if ex == nil || output == "" {
+		return
+	}
+	ex.Stdout = appendRetainedOutput(prefix, output, s.retention().maxRetainedExecutionOutputBytes)
+	s.recordExecutionEventLocked(ex, &cleanroomv1.ExecutionStreamEvent{
+		SandboxId:   ex.SandboxID,
+		ExecutionId: ex.ID,
+		Status:      status,
+		Payload:     &cleanroomv1.ExecutionStreamEvent_Stdout{Stdout: []byte(output)},
+		OccurredAt:  timestamppb.New(s.clock().Now()),
+	})
+}
+
 func (s *Service) replaceExecutionStderrFromBufferedLocked(ex *executionState, status cleanroomv1.ExecutionStatus, output string) {
 	if ex == nil || output == "" {
 		return
 	}
 	ex.Stderr = appendRetainedOutput("", output, s.retention().maxRetainedExecutionOutputBytes)
+	s.recordExecutionEventLocked(ex, &cleanroomv1.ExecutionStreamEvent{
+		SandboxId:   ex.SandboxID,
+		ExecutionId: ex.ID,
+		Status:      status,
+		Payload:     &cleanroomv1.ExecutionStreamEvent_Stderr{Stderr: []byte(output)},
+		OccurredAt:  timestamppb.New(s.clock().Now()),
+	})
+}
+
+func (s *Service) replaceExecutionStderrFromBufferedWithPrefixLocked(ex *executionState, status cleanroomv1.ExecutionStatus, prefix, output string) {
+	if ex == nil || output == "" {
+		return
+	}
+	ex.Stderr = appendRetainedOutput(prefix, output, s.retention().maxRetainedExecutionOutputBytes)
 	s.recordExecutionEventLocked(ex, &cleanroomv1.ExecutionStreamEvent{
 		SandboxId:   ex.SandboxID,
 		ExecutionId: ex.ID,

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -246,6 +246,14 @@ func testRepositoryDependencyPolicy() *cleanroomv1.Policy {
 	return policyProto
 }
 
+func testRepositoryRunBeforePolicy() *cleanroomv1.Policy {
+	policyProto := testRepositoryPolicy()
+	policyProto.Run = &cleanroomv1.PolicyRun{
+		Before: []string{"sh", "-lc", "echo pre-run"},
+	}
+	return policyProto
+}
+
 func newTestService(adapter backend.Adapter) *Service {
 	return newTestServiceWithSnapshotStore(adapter, nil)
 }
@@ -2713,6 +2721,172 @@ func TestCreateExecutionSkipsBootstrapForMatchingPersistentRepository(t *testing
 	}
 	if got, want := mirrors.calls, 1; got != want {
 		t.Fatalf("expected mirror prewarm only during sandbox create, got %d call(s)", got)
+	}
+}
+
+func TestCreateExecutionRunsRunBeforeBeforeUserCommand(t *testing.T) {
+	adapter := &stubAdapter{}
+	svc := newTestService(adapter)
+
+	var (
+		mu       sync.Mutex
+		commands [][]string
+	)
+	runCalled := make(chan struct{}, 4)
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+		mu.Lock()
+		commands = append(commands, append([]string(nil), req.Command...))
+		mu.Unlock()
+		select {
+		case runCalled <- struct{}{}:
+		default:
+		}
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+	}
+
+	createSandboxResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Policy:             testRepositoryRunBeforePolicy(),
+		RepositoryCheckout: testRepositoryCheckoutProto(),
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createSandboxResp.GetSandbox().GetSandboxId()
+	select {
+	case <-runCalled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for sandbox bootstrap")
+	}
+
+	createExecutionResp, err := svc.CreateExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
+		SandboxId: sandboxID,
+		Command:   []string{"sh", "-lc", "pwd"},
+	})
+	if err != nil {
+		t.Fatalf("CreateExecution returned error: %v", err)
+	}
+	if createExecutionResp.GetExecution().GetExecutionId() == "" {
+		t.Fatal("expected execution id")
+	}
+	for i := 0; i < 2; i++ {
+		select {
+		case <-runCalled:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for run.before + user execution")
+		}
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if got, want := len(commands), 3; got != want {
+		t.Fatalf("expected create bootstrap, run.before, and user execution, got %d command(s)", got)
+	}
+	if runBefore := strings.Join(commands[1], " "); !repositoryWrappedCommandContains(runBefore, `exec 'sh' '-lc' 'echo pre-run'`) {
+		t.Fatalf("expected wrapped run.before command, got %q", runBefore)
+	}
+	if joined := strings.Join(commands[2], " "); !repositoryWrappedCommandContains(joined, `exec 'sh' '-lc' 'pwd'`) {
+		t.Fatalf("expected wrapped user command, got %q", joined)
+	}
+}
+
+func TestCancelExecutionDuringRunBeforeTransitionsToCanceled(t *testing.T) {
+	started := make(chan struct{}, 1)
+	adapter := &stubAdapter{
+		runStreamFn: func(ctx context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+			if strings.Join(req.Command, " ") == "sh -lc echo pre-run" {
+				select {
+				case started <- struct{}{}:
+				default:
+				}
+				<-ctx.Done()
+				return &backend.ExecutionResult{
+					ExecutionID: req.ExecutionID,
+					ExitCode:    1,
+					Message:     "terminated",
+				}, nil
+			}
+			t.Fatalf("expected user command not to run after run.before cancel, got %v", req.Command)
+			return nil, nil
+		},
+	}
+	svc := newTestService(adapter)
+
+	policyProto := testPolicy()
+	policyProto.Run = &cleanroomv1.PolicyRun{
+		Before: []string{"sh", "-lc", "echo pre-run"},
+	}
+
+	createSandboxResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: policyProto})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createSandboxResp.GetSandbox().GetSandboxId()
+
+	createExecutionResp, err := svc.CreateExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
+		SandboxId: sandboxID,
+		Command:   []string{"sleep", "10"},
+	})
+	if err != nil {
+		t.Fatalf("CreateExecution returned error: %v", err)
+	}
+	executionID := createExecutionResp.GetExecution().GetExecutionId()
+
+	history, updates, done, unsubscribe, err := svc.SubscribeExecutionEvents(sandboxID, executionID)
+	if err != nil {
+		t.Fatalf("SubscribeExecutionEvents returned error: %v", err)
+	}
+	defer unsubscribe()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for run.before to start")
+	}
+
+	cancelResp, err := svc.CancelExecution(context.Background(), &cleanroomv1.CancelExecutionRequest{
+		SandboxId:   sandboxID,
+		ExecutionId: executionID,
+		Signal:      15,
+	})
+	if err != nil {
+		t.Fatalf("CancelExecution returned error: %v", err)
+	}
+	if !cancelResp.GetAccepted() {
+		t.Fatal("expected cancel request to be accepted")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for canceled execution to finish")
+	}
+
+	getResp, err := svc.GetExecution(context.Background(), &cleanroomv1.GetExecutionRequest{
+		SandboxId:   sandboxID,
+		ExecutionId: executionID,
+	})
+	if err != nil {
+		t.Fatalf("GetExecution returned error: %v", err)
+	}
+	if got, want := getResp.GetExecution().GetStatus(), cleanroomv1.ExecutionStatus_EXECUTION_STATUS_CANCELED; got != want {
+		t.Fatalf("unexpected execution status: got %v want %v", got, want)
+	}
+
+	events := collectExecutionEvents(t, history, updates, done)
+	var exit *cleanroomv1.ExecutionExit
+	for _, event := range events {
+		if payload, ok := event.Payload.(*cleanroomv1.ExecutionStreamEvent_Exit); ok {
+			exit = payload.Exit
+		}
+	}
+	if exit == nil {
+		t.Fatalf("expected exit event after cancel, events=%d", len(events))
+	}
+	if got, want := exit.GetStatus(), cleanroomv1.ExecutionStatus_EXECUTION_STATUS_CANCELED; got != want {
+		t.Fatalf("unexpected exit status: got %v want %v", got, want)
+	}
+	if got, want := exit.GetExitCode(), int32(143); got != want {
+		t.Fatalf("unexpected exit code: got %d want %d", got, want)
 	}
 }
 

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -2851,6 +2851,96 @@ func TestCreateExecutionPassesEnvToRunBefore(t *testing.T) {
 	}
 }
 
+func TestWriteExecutionStdinWaitsForRunBeforeToComplete(t *testing.T) {
+	preRunStarted := make(chan struct{}, 1)
+	stdinChunks := make(chan string, 1)
+	adapter := &stubAdapter{
+		runStreamFn: func(ctx context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+			switch strings.Join(req.Command, " ") {
+			case "sh -lc echo pre-run":
+				select {
+				case preRunStarted <- struct{}{}:
+				default:
+				}
+				time.Sleep(250 * time.Millisecond)
+				return &backend.ExecutionResult{
+					ExecutionID: req.ExecutionID,
+					ExitCode:    0,
+					Message:     "ok",
+				}, nil
+			case "sh":
+				if stream.OnAttach != nil {
+					stream.OnAttach(backend.AttachIO{
+						WriteStdin: func(data []byte) error {
+							stdinChunks <- string(data)
+							return nil
+						},
+					})
+				}
+				<-ctx.Done()
+				return nil, ctx.Err()
+			default:
+				t.Fatalf("unexpected command: %v", req.Command)
+				return nil, nil
+			}
+		},
+	}
+	svc := newTestService(adapter)
+	timeouts := defaultServiceTimeouts
+	timeouts.attachStdinRegistrationWait = 100 * time.Millisecond
+	svc.runtime.timeouts = &timeouts
+
+	policyProto := testPolicy()
+	policyProto.Run = &cleanroomv1.PolicyRun{
+		Before: []string{"sh", "-lc", "echo pre-run"},
+	}
+
+	createSandboxResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: policyProto})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createSandboxResp.GetSandbox().GetSandboxId()
+
+	createExecutionResp, err := svc.CreateExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
+		SandboxId: sandboxID,
+		Command:   []string{"sh"},
+	})
+	if err != nil {
+		t.Fatalf("CreateExecution returned error: %v", err)
+	}
+	executionID := createExecutionResp.GetExecution().GetExecutionId()
+
+	select {
+	case <-preRunStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for run.before to start")
+	}
+
+	if err := svc.WriteExecutionStdin(sandboxID, executionID, []byte("hello\n")); err != nil {
+		t.Fatalf("WriteExecutionStdin returned error: %v", err)
+	}
+
+	select {
+	case got := <-stdinChunks:
+		if got != "hello\n" {
+			t.Fatalf("unexpected stdin payload: got %q want %q", got, "hello\n")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for stdin after run.before")
+	}
+
+	if _, err := svc.CancelExecution(context.Background(), &cleanroomv1.CancelExecutionRequest{
+		SandboxId:   sandboxID,
+		ExecutionId: executionID,
+		Signal:      2,
+	}); err != nil {
+		t.Fatalf("CancelExecution returned error: %v", err)
+	}
+	if _, err := svc.WaitExecution(context.Background(), sandboxID, executionID); err != nil {
+		t.Fatalf("WaitExecution returned error: %v", err)
+	}
+}
+
 func TestCreateExecutionPreservesRunBeforeOutputInFinalSnapshot(t *testing.T) {
 	adapter := &stubAdapter{
 		runStreamFn: func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
@@ -4594,6 +4684,19 @@ func TestAppendRetainedOutputClonesTailSlice(t *testing.T) {
 	}
 	if unsafe.StringData(got) == unsafe.StringData(tail) {
 		t.Fatal("expected retained tail to be copied, but it reuses source backing storage")
+	}
+}
+
+func TestRetainedOutputCaptureBoundsStoredSuffix(t *testing.T) {
+	capture := newRetainedOutputCapture(8)
+	if _, err := capture.Write([]byte("hello")); err != nil {
+		t.Fatalf("Write returned error: %v", err)
+	}
+	if _, err := capture.Write([]byte("-world")); err != nil {
+		t.Fatalf("Write returned error: %v", err)
+	}
+	if got, want := capture.String(), "lo-world"; got != want {
+		t.Fatalf("unexpected retained capture suffix: got %q want %q", got, want)
 	}
 }
 

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -3061,6 +3061,59 @@ func TestCreateExecutionRetainsRunBeforeFailureArtifacts(t *testing.T) {
 	}
 }
 
+func TestCreateExecutionRunBeforeFailureClearsRuntimeHandles(t *testing.T) {
+	adapter := &stubAdapter{
+		runStreamFn: func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+			switch strings.Join(req.Command, " ") {
+			case "sh -lc echo pre-run":
+				return &backend.ExecutionResult{
+					ExecutionID: req.ExecutionID,
+					ExitCode:    23,
+					Message:     "pre-run failed",
+				}, nil
+			default:
+				t.Fatalf("unexpected command: %v", req.Command)
+				return nil, nil
+			}
+		},
+	}
+	svc := newTestService(adapter)
+
+	createSandboxResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Policy: testRepositoryRunBeforePolicy(),
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createSandboxResp.GetSandbox().GetSandboxId()
+
+	createExecutionResp, err := svc.CreateExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
+		SandboxId: sandboxID,
+		Command:   []string{"sh", "-lc", "pwd"},
+	})
+	if err != nil {
+		t.Fatalf("CreateExecution returned error: %v", err)
+	}
+	executionID := createExecutionResp.GetExecution().GetExecutionId()
+
+	if _, err := svc.WaitExecution(context.Background(), sandboxID, executionID); err != nil {
+		t.Fatalf("WaitExecution returned error: %v", err)
+	}
+
+	svc.mu.RLock()
+	defer svc.mu.RUnlock()
+	ex, ok := svc.executions[executionKey(sandboxID, executionID)]
+	if !ok {
+		t.Fatalf("expected execution %q to remain available", executionID)
+	}
+	if ex.Cancel != nil {
+		t.Fatal("expected run.before failure to clear retained cancel handler")
+	}
+	if ex.AttachStdin != nil || ex.AttachCloseStdin != nil || ex.AttachResize != nil {
+		t.Fatal("expected run.before failure to clear retained attach handlers")
+	}
+}
+
 func TestCancelExecutionDuringRunBeforeTransitionsToCanceled(t *testing.T) {
 	started := make(chan struct{}, 1)
 	adapter := &stubAdapter{

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -2997,6 +2997,70 @@ func TestCreateExecutionPreservesRunBeforeOutputInFinalSnapshot(t *testing.T) {
 	}
 }
 
+func TestCreateExecutionRetainsRunBeforeFailureArtifacts(t *testing.T) {
+	adapter := &stubAdapter{
+		runStreamFn: func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+			switch strings.Join(req.Command, " ") {
+			case "sh -lc echo pre-run":
+				return &backend.ExecutionResult{
+					ExecutionID: req.ExecutionID,
+					ExitCode:    23,
+					LaunchedVM:  true,
+					PlanPath:    "/tmp/pre-run-plan",
+					RunDir:      "/tmp/pre-run-run",
+					Message:     "pre-run failed",
+					Stdout:      "pre-run output\n",
+				}, nil
+			default:
+				t.Fatalf("unexpected command: %v", req.Command)
+				return nil, nil
+			}
+		},
+	}
+	svc := newTestService(adapter)
+
+	createSandboxResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Policy: testRepositoryRunBeforePolicy(),
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createSandboxResp.GetSandbox().GetSandboxId()
+
+	createExecutionResp, err := svc.CreateExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
+		SandboxId: sandboxID,
+		Command:   []string{"sh", "-lc", "pwd"},
+	})
+	if err != nil {
+		t.Fatalf("CreateExecution returned error: %v", err)
+	}
+	executionID := createExecutionResp.GetExecution().GetExecutionId()
+
+	if _, err := svc.WaitExecution(context.Background(), sandboxID, executionID); err != nil {
+		t.Fatalf("WaitExecution returned error: %v", err)
+	}
+
+	snapshot, err := svc.ExecutionSnapshot(sandboxID, executionID)
+	if err != nil {
+		t.Fatalf("ExecutionSnapshot returned error: %v", err)
+	}
+	if got, want := snapshot.RunDir, "/tmp/pre-run-run"; got != want {
+		t.Fatalf("unexpected run dir: got %q want %q", got, want)
+	}
+	if got, want := snapshot.PlanPath, "/tmp/pre-run-plan"; got != want {
+		t.Fatalf("unexpected plan path: got %q want %q", got, want)
+	}
+	if got, want := snapshot.Launched, true; got != want {
+		t.Fatalf("unexpected launched flag: got %t want %t", got, want)
+	}
+	if got, want := snapshot.Stdout, "pre-run output\n"; got != want {
+		t.Fatalf("unexpected retained stdout: got %q want %q", got, want)
+	}
+	if got, want := snapshot.Execution.GetExitCode(), int32(23); got != want {
+		t.Fatalf("unexpected exit code: got %d want %d", got, want)
+	}
+}
+
 func TestCancelExecutionDuringRunBeforeTransitionsToCanceled(t *testing.T) {
 	started := make(chan struct{}, 1)
 	adapter := &stubAdapter{

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -2851,6 +2851,62 @@ func TestCreateExecutionPassesEnvToRunBefore(t *testing.T) {
 	}
 }
 
+func TestCreateExecutionPreservesRunBeforeOutputInFinalSnapshot(t *testing.T) {
+	adapter := &stubAdapter{
+		runStreamFn: func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+			switch strings.Join(req.Command, " ") {
+			case "sh -lc echo pre-run":
+				return &backend.ExecutionResult{
+					ExecutionID: req.ExecutionID,
+					ExitCode:    0,
+					Message:     "ok",
+					Stdout:      "pre-run output\n",
+				}, nil
+			case "sh -lc pwd":
+				return &backend.ExecutionResult{
+					ExecutionID: req.ExecutionID,
+					ExitCode:    0,
+					Message:     "ok",
+					Stdout:      "user output\n",
+				}, nil
+			default:
+				t.Fatalf("unexpected command: %v", req.Command)
+				return nil, nil
+			}
+		},
+	}
+	svc := newTestService(adapter)
+
+	createSandboxResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Policy: testRepositoryRunBeforePolicy(),
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createSandboxResp.GetSandbox().GetSandboxId()
+
+	createExecutionResp, err := svc.CreateExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
+		SandboxId: sandboxID,
+		Command:   []string{"sh", "-lc", "pwd"},
+	})
+	if err != nil {
+		t.Fatalf("CreateExecution returned error: %v", err)
+	}
+	executionID := createExecutionResp.GetExecution().GetExecutionId()
+
+	if _, err := svc.WaitExecution(context.Background(), sandboxID, executionID); err != nil {
+		t.Fatalf("WaitExecution returned error: %v", err)
+	}
+
+	snapshot, err := svc.ExecutionSnapshot(sandboxID, executionID)
+	if err != nil {
+		t.Fatalf("ExecutionSnapshot returned error: %v", err)
+	}
+	if got, want := snapshot.Stdout, "pre-run output\nuser output\n"; got != want {
+		t.Fatalf("unexpected retained stdout: got %q want %q", got, want)
+	}
+}
+
 func TestCancelExecutionDuringRunBeforeTransitionsToCanceled(t *testing.T) {
 	started := make(chan struct{}, 1)
 	adapter := &stubAdapter{

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -2789,6 +2789,68 @@ func TestCreateExecutionRunsRunBeforeBeforeUserCommand(t *testing.T) {
 	}
 }
 
+func TestCreateExecutionPassesEnvToRunBefore(t *testing.T) {
+	adapter := &stubAdapter{}
+	svc := newTestService(adapter)
+
+	var (
+		mu   sync.Mutex
+		envs [][]string
+	)
+	runCalled := make(chan struct{}, 4)
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+		mu.Lock()
+		envs = append(envs, append([]string(nil), req.Env...))
+		mu.Unlock()
+		select {
+		case runCalled <- struct{}{}:
+		default:
+		}
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+	}
+
+	createSandboxResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Policy:             testRepositoryRunBeforePolicy(),
+		RepositoryCheckout: testRepositoryCheckoutProto(),
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createSandboxResp.GetSandbox().GetSandboxId()
+	select {
+	case <-runCalled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for sandbox bootstrap")
+	}
+
+	_, err = svc.CreateExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
+		SandboxId: sandboxID,
+		Command:   []string{"sh", "-lc", "pwd"},
+		Env:       []string{"DATABASE_URL=postgres://example", "REDIS_URL=redis://example"},
+	})
+	if err != nil {
+		t.Fatalf("CreateExecution returned error: %v", err)
+	}
+	for i := 0; i < 2; i++ {
+		select {
+		case <-runCalled:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for run.before + user execution")
+		}
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if got, want := len(envs), 3; got != want {
+		t.Fatalf("expected create bootstrap, run.before, and user execution env captures, got %d", got)
+	}
+	for i, got := range envs[1:] {
+		if want := []string{"DATABASE_URL=postgres://example", "REDIS_URL=redis://example"}; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+			t.Fatalf("unexpected env on command #%d: got %v want %v", i+2, got, want)
+		}
+	}
+}
+
 func TestCancelExecutionDuringRunBeforeTransitionsToCanceled(t *testing.T) {
 	started := make(chan struct{}, 1)
 	adapter := &stubAdapter{

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -2862,7 +2862,7 @@ func TestWriteExecutionStdinWaitsForRunBeforeToComplete(t *testing.T) {
 				case preRunStarted <- struct{}{}:
 				default:
 				}
-				time.Sleep(250 * time.Millisecond)
+				time.Sleep(150 * time.Millisecond)
 				return &backend.ExecutionResult{
 					ExecutionID: req.ExecutionID,
 					ExitCode:    0,
@@ -3111,6 +3111,71 @@ func TestCreateExecutionRunBeforeFailureClearsRuntimeHandles(t *testing.T) {
 	}
 	if ex.AttachStdin != nil || ex.AttachCloseStdin != nil || ex.AttachResize != nil {
 		t.Fatal("expected run.before failure to clear retained attach handlers")
+	}
+}
+
+func TestWriteExecutionStdinTimesOutWhenRunBeforeNeverCompletes(t *testing.T) {
+	preRunStarted := make(chan struct{}, 1)
+	adapter := &stubAdapter{
+		runStreamFn: func(ctx context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+			switch strings.Join(req.Command, " ") {
+			case "sh -lc echo pre-run":
+				select {
+				case preRunStarted <- struct{}{}:
+				default:
+				}
+				<-ctx.Done()
+				return nil, ctx.Err()
+			default:
+				t.Fatalf("unexpected command: %v", req.Command)
+				return nil, nil
+			}
+		},
+	}
+	svc := newTestService(adapter)
+	timeouts := defaultServiceTimeouts
+	timeouts.attachStdinRegistrationWait = 100 * time.Millisecond
+	svc.runtime.timeouts = &timeouts
+
+	policyProto := testPolicy()
+	policyProto.Run = &cleanroomv1.PolicyRun{
+		Before: []string{"sh", "-lc", "echo pre-run"},
+	}
+
+	createSandboxResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: policyProto})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createSandboxResp.GetSandbox().GetSandboxId()
+
+	createExecutionResp, err := svc.CreateExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
+		SandboxId: sandboxID,
+		Command:   []string{"sh"},
+	})
+	if err != nil {
+		t.Fatalf("CreateExecution returned error: %v", err)
+	}
+	executionID := createExecutionResp.GetExecution().GetExecutionId()
+
+	select {
+	case <-preRunStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for run.before to start")
+	}
+
+	if err := svc.WriteExecutionStdin(sandboxID, executionID, []byte("hello\n")); !errors.Is(err, ErrExecutionStdinUnsupported) {
+		t.Fatalf("expected ErrExecutionStdinUnsupported, got %v", err)
+	}
+
+	if _, err := svc.CancelExecution(context.Background(), &cleanroomv1.CancelExecutionRequest{
+		SandboxId:   sandboxID,
+		ExecutionId: executionID,
+		Signal:      2,
+	}); err != nil {
+		t.Fatalf("CancelExecution returned error: %v", err)
+	}
+	if _, err := svc.WaitExecution(context.Background(), sandboxID, executionID); err != nil {
+		t.Fatalf("WaitExecution returned error: %v", err)
 	}
 }
 

--- a/internal/controlservice/state_helpers.go
+++ b/internal/controlservice/state_helpers.go
@@ -51,6 +51,14 @@ func clearExecutionAttachIOLocked(ex *executionState) {
 	ex.AttachResize = nil
 }
 
+func clearExecutionRuntimeHandlesLocked(ex *executionState) {
+	if ex == nil {
+		return
+	}
+	ex.Cancel = nil
+	clearExecutionAttachIOLocked(ex)
+}
+
 func closeSandboxSubscribersLocked(sb *sandboxState) {
 	sb.events.closeSubscribers()
 }

--- a/internal/controlservice/state_helpers.go
+++ b/internal/controlservice/state_helpers.go
@@ -250,6 +250,30 @@ func appendRetainedOutput(existing, chunk string, limit int) string {
 	return existing + chunk
 }
 
+type retainedOutputCapture struct {
+	limit int
+	value string
+}
+
+func newRetainedOutputCapture(limit int) *retainedOutputCapture {
+	return &retainedOutputCapture{limit: limit}
+}
+
+func (c *retainedOutputCapture) Write(p []byte) (int, error) {
+	if c == nil {
+		return len(p), nil
+	}
+	c.value = appendRetainedOutput(c.value, string(p), c.limit)
+	return len(p), nil
+}
+
+func (c *retainedOutputCapture) String() string {
+	if c == nil {
+		return ""
+	}
+	return c.value
+}
+
 func appendBounded[T any](history []T, item T, limit int) []T {
 	if limit <= 0 {
 		return nil

--- a/internal/gen/cleanroom/v1/control.pb.go
+++ b/internal/gen/cleanroom/v1/control.pb.go
@@ -738,6 +738,50 @@ func (x *PolicyDependencies) GetKey() *PolicyDependencyKey {
 	return nil
 }
 
+type PolicyRun struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Before        []string               `protobuf:"bytes,1,rep,name=before,proto3" json:"before,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PolicyRun) Reset() {
+	*x = PolicyRun{}
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PolicyRun) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PolicyRun) ProtoMessage() {}
+
+func (x *PolicyRun) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PolicyRun.ProtoReflect.Descriptor instead.
+func (*PolicyRun) Descriptor() ([]byte, []int) {
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *PolicyRun) GetBefore() []string {
+	if x != nil {
+		return x.Before
+	}
+	return nil
+}
+
 type Policy struct {
 	state          protoimpl.MessageState `protogen:"open.v1"`
 	Version        int32                  `protobuf:"varint,1,opt,name=version,proto3" json:"version,omitempty"`
@@ -748,13 +792,14 @@ type Policy struct {
 	Hash           string                 `protobuf:"bytes,6,opt,name=hash,proto3" json:"hash,omitempty"`
 	Services       *PolicyServices        `protobuf:"bytes,7,opt,name=services,proto3" json:"services,omitempty"`
 	Dependencies   *PolicyDependencies    `protobuf:"bytes,9,opt,name=dependencies,proto3" json:"dependencies,omitempty"`
+	Run            *PolicyRun             `protobuf:"bytes,10,opt,name=run,proto3" json:"run,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
 
 func (x *Policy) Reset() {
 	*x = Policy{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[7]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -766,7 +811,7 @@ func (x *Policy) String() string {
 func (*Policy) ProtoMessage() {}
 
 func (x *Policy) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[7]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -779,7 +824,7 @@ func (x *Policy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Policy.ProtoReflect.Descriptor instead.
 func (*Policy) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{7}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *Policy) GetVersion() int32 {
@@ -838,6 +883,13 @@ func (x *Policy) GetDependencies() *PolicyDependencies {
 	return nil
 }
 
+func (x *Policy) GetRun() *PolicyRun {
+	if x != nil {
+		return x.Run
+	}
+	return nil
+}
+
 type SandboxOptions struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	LaunchSeconds int64                  `protobuf:"varint,3,opt,name=launch_seconds,json=launchSeconds,proto3" json:"launch_seconds,omitempty"`
@@ -847,7 +899,7 @@ type SandboxOptions struct {
 
 func (x *SandboxOptions) Reset() {
 	*x = SandboxOptions{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[8]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -859,7 +911,7 @@ func (x *SandboxOptions) String() string {
 func (*SandboxOptions) ProtoMessage() {}
 
 func (x *SandboxOptions) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[8]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -872,7 +924,7 @@ func (x *SandboxOptions) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxOptions.ProtoReflect.Descriptor instead.
 func (*SandboxOptions) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{8}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *SandboxOptions) GetLaunchSeconds() int64 {
@@ -895,7 +947,7 @@ type RepositoryCheckout struct {
 
 func (x *RepositoryCheckout) Reset() {
 	*x = RepositoryCheckout{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[9]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -907,7 +959,7 @@ func (x *RepositoryCheckout) String() string {
 func (*RepositoryCheckout) ProtoMessage() {}
 
 func (x *RepositoryCheckout) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[9]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -920,7 +972,7 @@ func (x *RepositoryCheckout) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RepositoryCheckout.ProtoReflect.Descriptor instead.
 func (*RepositoryCheckout) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{9}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *RepositoryCheckout) GetRemoteUrl() string {
@@ -969,7 +1021,7 @@ type RepositoryChangesetFile struct {
 
 func (x *RepositoryChangesetFile) Reset() {
 	*x = RepositoryChangesetFile{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[10]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -981,7 +1033,7 @@ func (x *RepositoryChangesetFile) String() string {
 func (*RepositoryChangesetFile) ProtoMessage() {}
 
 func (x *RepositoryChangesetFile) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[10]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -994,7 +1046,7 @@ func (x *RepositoryChangesetFile) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RepositoryChangesetFile.ProtoReflect.Descriptor instead.
 func (*RepositoryChangesetFile) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{10}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *RepositoryChangesetFile) GetPath() string {
@@ -1032,7 +1084,7 @@ type RepositoryChangeset struct {
 
 func (x *RepositoryChangeset) Reset() {
 	*x = RepositoryChangeset{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[11]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1044,7 +1096,7 @@ func (x *RepositoryChangeset) String() string {
 func (*RepositoryChangeset) ProtoMessage() {}
 
 func (x *RepositoryChangeset) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[11]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1057,7 +1109,7 @@ func (x *RepositoryChangeset) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RepositoryChangeset.ProtoReflect.Descriptor instead.
 func (*RepositoryChangeset) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{11}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *RepositoryChangeset) GetFormat() string {
@@ -1119,7 +1171,7 @@ type CreateSandboxRequest struct {
 
 func (x *CreateSandboxRequest) Reset() {
 	*x = CreateSandboxRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[12]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1131,7 +1183,7 @@ func (x *CreateSandboxRequest) String() string {
 func (*CreateSandboxRequest) ProtoMessage() {}
 
 func (x *CreateSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[12]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1144,7 +1196,7 @@ func (x *CreateSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSandboxRequest.ProtoReflect.Descriptor instead.
 func (*CreateSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{12}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *CreateSandboxRequest) GetBackend() string {
@@ -1222,7 +1274,7 @@ type CreateSandboxResponse struct {
 
 func (x *CreateSandboxResponse) Reset() {
 	*x = CreateSandboxResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[13]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1234,7 +1286,7 @@ func (x *CreateSandboxResponse) String() string {
 func (*CreateSandboxResponse) ProtoMessage() {}
 
 func (x *CreateSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[13]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1247,7 +1299,7 @@ func (x *CreateSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSandboxResponse.ProtoReflect.Descriptor instead.
 func (*CreateSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{13}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *CreateSandboxResponse) GetSandbox() *Sandbox {
@@ -1310,7 +1362,7 @@ type CreateSandboxEvent struct {
 
 func (x *CreateSandboxEvent) Reset() {
 	*x = CreateSandboxEvent{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[14]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1322,7 +1374,7 @@ func (x *CreateSandboxEvent) String() string {
 func (*CreateSandboxEvent) ProtoMessage() {}
 
 func (x *CreateSandboxEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[14]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1335,7 +1387,7 @@ func (x *CreateSandboxEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSandboxEvent.ProtoReflect.Descriptor instead.
 func (*CreateSandboxEvent) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{14}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *CreateSandboxEvent) GetPhase() CreateSandboxPhase {
@@ -1447,7 +1499,7 @@ type GetSandboxRequest struct {
 
 func (x *GetSandboxRequest) Reset() {
 	*x = GetSandboxRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[15]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1459,7 +1511,7 @@ func (x *GetSandboxRequest) String() string {
 func (*GetSandboxRequest) ProtoMessage() {}
 
 func (x *GetSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[15]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1472,7 +1524,7 @@ func (x *GetSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSandboxRequest.ProtoReflect.Descriptor instead.
 func (*GetSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{15}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *GetSandboxRequest) GetSandboxId() string {
@@ -1491,7 +1543,7 @@ type GetSandboxResponse struct {
 
 func (x *GetSandboxResponse) Reset() {
 	*x = GetSandboxResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[16]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1503,7 +1555,7 @@ func (x *GetSandboxResponse) String() string {
 func (*GetSandboxResponse) ProtoMessage() {}
 
 func (x *GetSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[16]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1516,7 +1568,7 @@ func (x *GetSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSandboxResponse.ProtoReflect.Descriptor instead.
 func (*GetSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{16}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *GetSandboxResponse) GetSandbox() *Sandbox {
@@ -1534,7 +1586,7 @@ type ListSandboxesRequest struct {
 
 func (x *ListSandboxesRequest) Reset() {
 	*x = ListSandboxesRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[17]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1546,7 +1598,7 @@ func (x *ListSandboxesRequest) String() string {
 func (*ListSandboxesRequest) ProtoMessage() {}
 
 func (x *ListSandboxesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[17]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1559,7 +1611,7 @@ func (x *ListSandboxesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSandboxesRequest.ProtoReflect.Descriptor instead.
 func (*ListSandboxesRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{17}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{18}
 }
 
 type ListSandboxesResponse struct {
@@ -1571,7 +1623,7 @@ type ListSandboxesResponse struct {
 
 func (x *ListSandboxesResponse) Reset() {
 	*x = ListSandboxesResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[18]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1583,7 +1635,7 @@ func (x *ListSandboxesResponse) String() string {
 func (*ListSandboxesResponse) ProtoMessage() {}
 
 func (x *ListSandboxesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[18]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1596,7 +1648,7 @@ func (x *ListSandboxesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSandboxesResponse.ProtoReflect.Descriptor instead.
 func (*ListSandboxesResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{18}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *ListSandboxesResponse) GetSandboxes() []*Sandbox {
@@ -1617,7 +1669,7 @@ type DownloadSandboxFileRequest struct {
 
 func (x *DownloadSandboxFileRequest) Reset() {
 	*x = DownloadSandboxFileRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[19]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1629,7 +1681,7 @@ func (x *DownloadSandboxFileRequest) String() string {
 func (*DownloadSandboxFileRequest) ProtoMessage() {}
 
 func (x *DownloadSandboxFileRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[19]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1642,7 +1694,7 @@ func (x *DownloadSandboxFileRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DownloadSandboxFileRequest.ProtoReflect.Descriptor instead.
 func (*DownloadSandboxFileRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{19}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *DownloadSandboxFileRequest) GetSandboxId() string {
@@ -1678,7 +1730,7 @@ type DownloadSandboxFileResponse struct {
 
 func (x *DownloadSandboxFileResponse) Reset() {
 	*x = DownloadSandboxFileResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[20]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1690,7 +1742,7 @@ func (x *DownloadSandboxFileResponse) String() string {
 func (*DownloadSandboxFileResponse) ProtoMessage() {}
 
 func (x *DownloadSandboxFileResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[20]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1703,7 +1755,7 @@ func (x *DownloadSandboxFileResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DownloadSandboxFileResponse.ProtoReflect.Descriptor instead.
 func (*DownloadSandboxFileResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{20}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *DownloadSandboxFileResponse) GetSandboxId() string {
@@ -1743,7 +1795,7 @@ type TerminateSandboxRequest struct {
 
 func (x *TerminateSandboxRequest) Reset() {
 	*x = TerminateSandboxRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[21]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1755,7 +1807,7 @@ func (x *TerminateSandboxRequest) String() string {
 func (*TerminateSandboxRequest) ProtoMessage() {}
 
 func (x *TerminateSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[21]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1768,7 +1820,7 @@ func (x *TerminateSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TerminateSandboxRequest.ProtoReflect.Descriptor instead.
 func (*TerminateSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{21}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *TerminateSandboxRequest) GetSandboxId() string {
@@ -1789,7 +1841,7 @@ type TerminateSandboxResponse struct {
 
 func (x *TerminateSandboxResponse) Reset() {
 	*x = TerminateSandboxResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[22]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1801,7 +1853,7 @@ func (x *TerminateSandboxResponse) String() string {
 func (*TerminateSandboxResponse) ProtoMessage() {}
 
 func (x *TerminateSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[22]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1814,7 +1866,7 @@ func (x *TerminateSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TerminateSandboxResponse.ProtoReflect.Descriptor instead.
 func (*TerminateSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{22}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *TerminateSandboxResponse) GetSandboxId() string {
@@ -1848,7 +1900,7 @@ type StreamSandboxEventsRequest struct {
 
 func (x *StreamSandboxEventsRequest) Reset() {
 	*x = StreamSandboxEventsRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[23]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1860,7 +1912,7 @@ func (x *StreamSandboxEventsRequest) String() string {
 func (*StreamSandboxEventsRequest) ProtoMessage() {}
 
 func (x *StreamSandboxEventsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[23]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1873,7 +1925,7 @@ func (x *StreamSandboxEventsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamSandboxEventsRequest.ProtoReflect.Descriptor instead.
 func (*StreamSandboxEventsRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{23}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *StreamSandboxEventsRequest) GetSandboxId() string {
@@ -1902,7 +1954,7 @@ type SandboxEvent struct {
 
 func (x *SandboxEvent) Reset() {
 	*x = SandboxEvent{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[24]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1914,7 +1966,7 @@ func (x *SandboxEvent) String() string {
 func (*SandboxEvent) ProtoMessage() {}
 
 func (x *SandboxEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[24]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1927,7 +1979,7 @@ func (x *SandboxEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxEvent.ProtoReflect.Descriptor instead.
 func (*SandboxEvent) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{24}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *SandboxEvent) GetSandboxId() string {
@@ -1968,7 +2020,7 @@ type CreateSnapshotRequest struct {
 
 func (x *CreateSnapshotRequest) Reset() {
 	*x = CreateSnapshotRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[25]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1980,7 +2032,7 @@ func (x *CreateSnapshotRequest) String() string {
 func (*CreateSnapshotRequest) ProtoMessage() {}
 
 func (x *CreateSnapshotRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[25]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1993,7 +2045,7 @@ func (x *CreateSnapshotRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSnapshotRequest.ProtoReflect.Descriptor instead.
 func (*CreateSnapshotRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{25}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *CreateSnapshotRequest) GetSandboxId() string {
@@ -2020,7 +2072,7 @@ type CreateSnapshotResponse struct {
 
 func (x *CreateSnapshotResponse) Reset() {
 	*x = CreateSnapshotResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[26]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2032,7 +2084,7 @@ func (x *CreateSnapshotResponse) String() string {
 func (*CreateSnapshotResponse) ProtoMessage() {}
 
 func (x *CreateSnapshotResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[26]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2045,7 +2097,7 @@ func (x *CreateSnapshotResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSnapshotResponse.ProtoReflect.Descriptor instead.
 func (*CreateSnapshotResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{26}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *CreateSnapshotResponse) GetSnapshot() *Snapshot {
@@ -2071,7 +2123,7 @@ type GetSnapshotRequest struct {
 
 func (x *GetSnapshotRequest) Reset() {
 	*x = GetSnapshotRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[27]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2083,7 +2135,7 @@ func (x *GetSnapshotRequest) String() string {
 func (*GetSnapshotRequest) ProtoMessage() {}
 
 func (x *GetSnapshotRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[27]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2096,7 +2148,7 @@ func (x *GetSnapshotRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSnapshotRequest.ProtoReflect.Descriptor instead.
 func (*GetSnapshotRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{27}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *GetSnapshotRequest) GetSnapshotId() string {
@@ -2115,7 +2167,7 @@ type GetSnapshotResponse struct {
 
 func (x *GetSnapshotResponse) Reset() {
 	*x = GetSnapshotResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[28]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2127,7 +2179,7 @@ func (x *GetSnapshotResponse) String() string {
 func (*GetSnapshotResponse) ProtoMessage() {}
 
 func (x *GetSnapshotResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[28]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2140,7 +2192,7 @@ func (x *GetSnapshotResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSnapshotResponse.ProtoReflect.Descriptor instead.
 func (*GetSnapshotResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{28}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *GetSnapshotResponse) GetSnapshot() *Snapshot {
@@ -2158,7 +2210,7 @@ type ListSnapshotsRequest struct {
 
 func (x *ListSnapshotsRequest) Reset() {
 	*x = ListSnapshotsRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[29]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2170,7 +2222,7 @@ func (x *ListSnapshotsRequest) String() string {
 func (*ListSnapshotsRequest) ProtoMessage() {}
 
 func (x *ListSnapshotsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[29]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2183,7 +2235,7 @@ func (x *ListSnapshotsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSnapshotsRequest.ProtoReflect.Descriptor instead.
 func (*ListSnapshotsRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{29}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{30}
 }
 
 type ListSnapshotsResponse struct {
@@ -2195,7 +2247,7 @@ type ListSnapshotsResponse struct {
 
 func (x *ListSnapshotsResponse) Reset() {
 	*x = ListSnapshotsResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[30]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2207,7 +2259,7 @@ func (x *ListSnapshotsResponse) String() string {
 func (*ListSnapshotsResponse) ProtoMessage() {}
 
 func (x *ListSnapshotsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[30]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2220,7 +2272,7 @@ func (x *ListSnapshotsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSnapshotsResponse.ProtoReflect.Descriptor instead.
 func (*ListSnapshotsResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{30}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *ListSnapshotsResponse) GetSnapshots() []*Snapshot {
@@ -2239,7 +2291,7 @@ type DeleteSnapshotRequest struct {
 
 func (x *DeleteSnapshotRequest) Reset() {
 	*x = DeleteSnapshotRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[31]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2251,7 +2303,7 @@ func (x *DeleteSnapshotRequest) String() string {
 func (*DeleteSnapshotRequest) ProtoMessage() {}
 
 func (x *DeleteSnapshotRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[31]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2264,7 +2316,7 @@ func (x *DeleteSnapshotRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSnapshotRequest.ProtoReflect.Descriptor instead.
 func (*DeleteSnapshotRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{31}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *DeleteSnapshotRequest) GetSnapshotId() string {
@@ -2285,7 +2337,7 @@ type DeleteSnapshotResponse struct {
 
 func (x *DeleteSnapshotResponse) Reset() {
 	*x = DeleteSnapshotResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[32]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2297,7 +2349,7 @@ func (x *DeleteSnapshotResponse) String() string {
 func (*DeleteSnapshotResponse) ProtoMessage() {}
 
 func (x *DeleteSnapshotResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[32]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2310,7 +2362,7 @@ func (x *DeleteSnapshotResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSnapshotResponse.ProtoReflect.Descriptor instead.
 func (*DeleteSnapshotResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{32}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *DeleteSnapshotResponse) GetSnapshotId() string {
@@ -2351,7 +2403,7 @@ type Execution struct {
 
 func (x *Execution) Reset() {
 	*x = Execution{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[33]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2363,7 +2415,7 @@ func (x *Execution) String() string {
 func (*Execution) ProtoMessage() {}
 
 func (x *Execution) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[33]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2376,7 +2428,7 @@ func (x *Execution) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Execution.ProtoReflect.Descriptor instead.
 func (*Execution) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{33}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *Execution) GetExecutionId() string {
@@ -2452,7 +2504,7 @@ type ExecutionOptions struct {
 
 func (x *ExecutionOptions) Reset() {
 	*x = ExecutionOptions{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[34]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2464,7 +2516,7 @@ func (x *ExecutionOptions) String() string {
 func (*ExecutionOptions) ProtoMessage() {}
 
 func (x *ExecutionOptions) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[34]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2477,7 +2529,7 @@ func (x *ExecutionOptions) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionOptions.ProtoReflect.Descriptor instead.
 func (*ExecutionOptions) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{34}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *ExecutionOptions) GetLaunchSeconds() int64 {
@@ -2508,7 +2560,7 @@ type CreateExecutionRequest struct {
 
 func (x *CreateExecutionRequest) Reset() {
 	*x = CreateExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[35]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2520,7 +2572,7 @@ func (x *CreateExecutionRequest) String() string {
 func (*CreateExecutionRequest) ProtoMessage() {}
 
 func (x *CreateExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[35]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2533,7 +2585,7 @@ func (x *CreateExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateExecutionRequest.ProtoReflect.Descriptor instead.
 func (*CreateExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{35}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *CreateExecutionRequest) GetSandboxId() string {
@@ -2587,7 +2639,7 @@ type CreateExecutionResponse struct {
 
 func (x *CreateExecutionResponse) Reset() {
 	*x = CreateExecutionResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[36]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2599,7 +2651,7 @@ func (x *CreateExecutionResponse) String() string {
 func (*CreateExecutionResponse) ProtoMessage() {}
 
 func (x *CreateExecutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[36]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2612,7 +2664,7 @@ func (x *CreateExecutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateExecutionResponse.ProtoReflect.Descriptor instead.
 func (*CreateExecutionResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{36}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *CreateExecutionResponse) GetExecution() *Execution {
@@ -2634,7 +2686,7 @@ type AttachExecutionRequest struct {
 
 func (x *AttachExecutionRequest) Reset() {
 	*x = AttachExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[37]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2646,7 +2698,7 @@ func (x *AttachExecutionRequest) String() string {
 func (*AttachExecutionRequest) ProtoMessage() {}
 
 func (x *AttachExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[37]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2659,7 +2711,7 @@ func (x *AttachExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachExecutionRequest.ProtoReflect.Descriptor instead.
 func (*AttachExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{37}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *AttachExecutionRequest) GetSandboxId() string {
@@ -2704,7 +2756,7 @@ type AttachExecutionResponse struct {
 
 func (x *AttachExecutionResponse) Reset() {
 	*x = AttachExecutionResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[38]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2716,7 +2768,7 @@ func (x *AttachExecutionResponse) String() string {
 func (*AttachExecutionResponse) ProtoMessage() {}
 
 func (x *AttachExecutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[38]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2729,7 +2781,7 @@ func (x *AttachExecutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachExecutionResponse.ProtoReflect.Descriptor instead.
 func (*AttachExecutionResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{38}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *AttachExecutionResponse) GetSessionId() string {
@@ -2784,7 +2836,7 @@ type GetExecutionRequest struct {
 
 func (x *GetExecutionRequest) Reset() {
 	*x = GetExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[39]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2796,7 +2848,7 @@ func (x *GetExecutionRequest) String() string {
 func (*GetExecutionRequest) ProtoMessage() {}
 
 func (x *GetExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[39]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2809,7 +2861,7 @@ func (x *GetExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetExecutionRequest.ProtoReflect.Descriptor instead.
 func (*GetExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{39}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *GetExecutionRequest) GetSandboxId() string {
@@ -2835,7 +2887,7 @@ type GetExecutionResponse struct {
 
 func (x *GetExecutionResponse) Reset() {
 	*x = GetExecutionResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[40]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2847,7 +2899,7 @@ func (x *GetExecutionResponse) String() string {
 func (*GetExecutionResponse) ProtoMessage() {}
 
 func (x *GetExecutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[40]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2860,7 +2912,7 @@ func (x *GetExecutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetExecutionResponse.ProtoReflect.Descriptor instead.
 func (*GetExecutionResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{40}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *GetExecutionResponse) GetExecution() *Execution {
@@ -2880,7 +2932,7 @@ type InspectExecutionRequest struct {
 
 func (x *InspectExecutionRequest) Reset() {
 	*x = InspectExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[41]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2892,7 +2944,7 @@ func (x *InspectExecutionRequest) String() string {
 func (*InspectExecutionRequest) ProtoMessage() {}
 
 func (x *InspectExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[41]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2905,7 +2957,7 @@ func (x *InspectExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectExecutionRequest.ProtoReflect.Descriptor instead.
 func (*InspectExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{41}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *InspectExecutionRequest) GetSandboxId() string {
@@ -2940,7 +2992,7 @@ type InspectExecutionResponse struct {
 
 func (x *InspectExecutionResponse) Reset() {
 	*x = InspectExecutionResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[42]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2952,7 +3004,7 @@ func (x *InspectExecutionResponse) String() string {
 func (*InspectExecutionResponse) ProtoMessage() {}
 
 func (x *InspectExecutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[42]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2965,7 +3017,7 @@ func (x *InspectExecutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectExecutionResponse.ProtoReflect.Descriptor instead.
 func (*InspectExecutionResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{42}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *InspectExecutionResponse) GetExecution() *Execution {
@@ -3049,7 +3101,7 @@ type CancelExecutionRequest struct {
 
 func (x *CancelExecutionRequest) Reset() {
 	*x = CancelExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[43]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3061,7 +3113,7 @@ func (x *CancelExecutionRequest) String() string {
 func (*CancelExecutionRequest) ProtoMessage() {}
 
 func (x *CancelExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[43]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3074,7 +3126,7 @@ func (x *CancelExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelExecutionRequest.ProtoReflect.Descriptor instead.
 func (*CancelExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{43}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *CancelExecutionRequest) GetSandboxId() string {
@@ -3110,7 +3162,7 @@ type CancelExecutionResponse struct {
 
 func (x *CancelExecutionResponse) Reset() {
 	*x = CancelExecutionResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[44]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3122,7 +3174,7 @@ func (x *CancelExecutionResponse) String() string {
 func (*CancelExecutionResponse) ProtoMessage() {}
 
 func (x *CancelExecutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[44]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3135,7 +3187,7 @@ func (x *CancelExecutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelExecutionResponse.ProtoReflect.Descriptor instead.
 func (*CancelExecutionResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{44}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *CancelExecutionResponse) GetSandboxId() string {
@@ -3177,7 +3229,7 @@ type WriteExecutionStdinRequest struct {
 
 func (x *WriteExecutionStdinRequest) Reset() {
 	*x = WriteExecutionStdinRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[45]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3189,7 +3241,7 @@ func (x *WriteExecutionStdinRequest) String() string {
 func (*WriteExecutionStdinRequest) ProtoMessage() {}
 
 func (x *WriteExecutionStdinRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[45]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3202,7 +3254,7 @@ func (x *WriteExecutionStdinRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WriteExecutionStdinRequest.ProtoReflect.Descriptor instead.
 func (*WriteExecutionStdinRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{45}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *WriteExecutionStdinRequest) GetSandboxId() string {
@@ -3234,7 +3286,7 @@ type WriteExecutionStdinResponse struct {
 
 func (x *WriteExecutionStdinResponse) Reset() {
 	*x = WriteExecutionStdinResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[46]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3246,7 +3298,7 @@ func (x *WriteExecutionStdinResponse) String() string {
 func (*WriteExecutionStdinResponse) ProtoMessage() {}
 
 func (x *WriteExecutionStdinResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[46]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3259,7 +3311,7 @@ func (x *WriteExecutionStdinResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WriteExecutionStdinResponse.ProtoReflect.Descriptor instead.
 func (*WriteExecutionStdinResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{46}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{47}
 }
 
 type CloseExecutionStdinRequest struct {
@@ -3272,7 +3324,7 @@ type CloseExecutionStdinRequest struct {
 
 func (x *CloseExecutionStdinRequest) Reset() {
 	*x = CloseExecutionStdinRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[47]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3284,7 +3336,7 @@ func (x *CloseExecutionStdinRequest) String() string {
 func (*CloseExecutionStdinRequest) ProtoMessage() {}
 
 func (x *CloseExecutionStdinRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[47]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3297,7 +3349,7 @@ func (x *CloseExecutionStdinRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CloseExecutionStdinRequest.ProtoReflect.Descriptor instead.
 func (*CloseExecutionStdinRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{47}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *CloseExecutionStdinRequest) GetSandboxId() string {
@@ -3322,7 +3374,7 @@ type CloseExecutionStdinResponse struct {
 
 func (x *CloseExecutionStdinResponse) Reset() {
 	*x = CloseExecutionStdinResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[48]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3334,7 +3386,7 @@ func (x *CloseExecutionStdinResponse) String() string {
 func (*CloseExecutionStdinResponse) ProtoMessage() {}
 
 func (x *CloseExecutionStdinResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[48]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3347,7 +3399,7 @@ func (x *CloseExecutionStdinResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CloseExecutionStdinResponse.ProtoReflect.Descriptor instead.
 func (*CloseExecutionStdinResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{48}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{49}
 }
 
 type StreamExecutionRequest struct {
@@ -3361,7 +3413,7 @@ type StreamExecutionRequest struct {
 
 func (x *StreamExecutionRequest) Reset() {
 	*x = StreamExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[49]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3373,7 +3425,7 @@ func (x *StreamExecutionRequest) String() string {
 func (*StreamExecutionRequest) ProtoMessage() {}
 
 func (x *StreamExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[49]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3386,7 +3438,7 @@ func (x *StreamExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamExecutionRequest.ProtoReflect.Descriptor instead.
 func (*StreamExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{49}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *StreamExecutionRequest) GetSandboxId() string {
@@ -3421,7 +3473,7 @@ type ExecutionExit struct {
 
 func (x *ExecutionExit) Reset() {
 	*x = ExecutionExit{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[50]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3433,7 +3485,7 @@ func (x *ExecutionExit) String() string {
 func (*ExecutionExit) ProtoMessage() {}
 
 func (x *ExecutionExit) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[50]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3446,7 +3498,7 @@ func (x *ExecutionExit) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionExit.ProtoReflect.Descriptor instead.
 func (*ExecutionExit) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{50}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *ExecutionExit) GetExitCode() int32 {
@@ -3492,7 +3544,7 @@ type ExecutionStreamEvent struct {
 
 func (x *ExecutionStreamEvent) Reset() {
 	*x = ExecutionStreamEvent{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[51]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3504,7 +3556,7 @@ func (x *ExecutionStreamEvent) String() string {
 func (*ExecutionStreamEvent) ProtoMessage() {}
 
 func (x *ExecutionStreamEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[51]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3517,7 +3569,7 @@ func (x *ExecutionStreamEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionStreamEvent.ProtoReflect.Descriptor instead.
 func (*ExecutionStreamEvent) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{51}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *ExecutionStreamEvent) GetSandboxId() string {
@@ -3696,7 +3748,9 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\x05files\x18\x01 \x03(\tR\x05files\"c\n" +
 	"\x12PolicyDependencies\x12\x18\n" +
 	"\acommand\x18\x01 \x03(\tR\acommand\x123\n" +
-	"\x03key\x18\x02 \x01(\v2!.cleanroom.v1.PolicyDependencyKeyR\x03key\"\xd4\x02\n" +
+	"\x03key\x18\x02 \x01(\v2!.cleanroom.v1.PolicyDependencyKeyR\x03key\"#\n" +
+	"\tPolicyRun\x12\x16\n" +
+	"\x06before\x18\x01 \x03(\tR\x06before\"\xff\x02\n" +
 	"\x06Policy\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\x05R\aversion\x12\x1b\n" +
 	"\timage_ref\x18\x02 \x01(\tR\bimageRef\x12!\n" +
@@ -3705,7 +3759,9 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\x05allow\x18\x05 \x03(\v2\x1d.cleanroom.v1.PolicyAllowRuleR\x05allow\x12\x12\n" +
 	"\x04hash\x18\x06 \x01(\tR\x04hash\x128\n" +
 	"\bservices\x18\a \x01(\v2\x1c.cleanroom.v1.PolicyServicesR\bservices\x12D\n" +
-	"\fdependencies\x18\t \x01(\v2 .cleanroom.v1.PolicyDependenciesR\fdependencies\"R\n" +
+	"\fdependencies\x18\t \x01(\v2 .cleanroom.v1.PolicyDependenciesR\fdependencies\x12)\n" +
+	"\x03run\x18\n" +
+	" \x01(\v2\x17.cleanroom.v1.PolicyRunR\x03run\"R\n" +
 	"\x0eSandboxOptions\x12%\n" +
 	"\x0elaunch_seconds\x18\x03 \x01(\x03R\rlaunchSecondsJ\x04\b\x02\x10\x03R\x13read_only_workspace\"\xe1\x01\n" +
 	"\x12RepositoryCheckout\x12\x1d\n" +
@@ -4005,7 +4061,7 @@ func file_proto_cleanroom_v1_control_proto_rawDescGZIP() []byte {
 }
 
 var file_proto_cleanroom_v1_control_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_proto_cleanroom_v1_control_proto_msgTypes = make([]protoimpl.MessageInfo, 52)
+var file_proto_cleanroom_v1_control_proto_msgTypes = make([]protoimpl.MessageInfo, 53)
 var file_proto_cleanroom_v1_control_proto_goTypes = []any{
 	(SandboxStatus)(0),                  // 0: cleanroom.v1.SandboxStatus
 	(CreateSandboxPhase)(0),             // 1: cleanroom.v1.CreateSandboxPhase
@@ -4018,141 +4074,143 @@ var file_proto_cleanroom_v1_control_proto_goTypes = []any{
 	(*PolicyServices)(nil),              // 8: cleanroom.v1.PolicyServices
 	(*PolicyDependencyKey)(nil),         // 9: cleanroom.v1.PolicyDependencyKey
 	(*PolicyDependencies)(nil),          // 10: cleanroom.v1.PolicyDependencies
-	(*Policy)(nil),                      // 11: cleanroom.v1.Policy
-	(*SandboxOptions)(nil),              // 12: cleanroom.v1.SandboxOptions
-	(*RepositoryCheckout)(nil),          // 13: cleanroom.v1.RepositoryCheckout
-	(*RepositoryChangesetFile)(nil),     // 14: cleanroom.v1.RepositoryChangesetFile
-	(*RepositoryChangeset)(nil),         // 15: cleanroom.v1.RepositoryChangeset
-	(*CreateSandboxRequest)(nil),        // 16: cleanroom.v1.CreateSandboxRequest
-	(*CreateSandboxResponse)(nil),       // 17: cleanroom.v1.CreateSandboxResponse
-	(*CreateSandboxEvent)(nil),          // 18: cleanroom.v1.CreateSandboxEvent
-	(*GetSandboxRequest)(nil),           // 19: cleanroom.v1.GetSandboxRequest
-	(*GetSandboxResponse)(nil),          // 20: cleanroom.v1.GetSandboxResponse
-	(*ListSandboxesRequest)(nil),        // 21: cleanroom.v1.ListSandboxesRequest
-	(*ListSandboxesResponse)(nil),       // 22: cleanroom.v1.ListSandboxesResponse
-	(*DownloadSandboxFileRequest)(nil),  // 23: cleanroom.v1.DownloadSandboxFileRequest
-	(*DownloadSandboxFileResponse)(nil), // 24: cleanroom.v1.DownloadSandboxFileResponse
-	(*TerminateSandboxRequest)(nil),     // 25: cleanroom.v1.TerminateSandboxRequest
-	(*TerminateSandboxResponse)(nil),    // 26: cleanroom.v1.TerminateSandboxResponse
-	(*StreamSandboxEventsRequest)(nil),  // 27: cleanroom.v1.StreamSandboxEventsRequest
-	(*SandboxEvent)(nil),                // 28: cleanroom.v1.SandboxEvent
-	(*CreateSnapshotRequest)(nil),       // 29: cleanroom.v1.CreateSnapshotRequest
-	(*CreateSnapshotResponse)(nil),      // 30: cleanroom.v1.CreateSnapshotResponse
-	(*GetSnapshotRequest)(nil),          // 31: cleanroom.v1.GetSnapshotRequest
-	(*GetSnapshotResponse)(nil),         // 32: cleanroom.v1.GetSnapshotResponse
-	(*ListSnapshotsRequest)(nil),        // 33: cleanroom.v1.ListSnapshotsRequest
-	(*ListSnapshotsResponse)(nil),       // 34: cleanroom.v1.ListSnapshotsResponse
-	(*DeleteSnapshotRequest)(nil),       // 35: cleanroom.v1.DeleteSnapshotRequest
-	(*DeleteSnapshotResponse)(nil),      // 36: cleanroom.v1.DeleteSnapshotResponse
-	(*Execution)(nil),                   // 37: cleanroom.v1.Execution
-	(*ExecutionOptions)(nil),            // 38: cleanroom.v1.ExecutionOptions
-	(*CreateExecutionRequest)(nil),      // 39: cleanroom.v1.CreateExecutionRequest
-	(*CreateExecutionResponse)(nil),     // 40: cleanroom.v1.CreateExecutionResponse
-	(*AttachExecutionRequest)(nil),      // 41: cleanroom.v1.AttachExecutionRequest
-	(*AttachExecutionResponse)(nil),     // 42: cleanroom.v1.AttachExecutionResponse
-	(*GetExecutionRequest)(nil),         // 43: cleanroom.v1.GetExecutionRequest
-	(*GetExecutionResponse)(nil),        // 44: cleanroom.v1.GetExecutionResponse
-	(*InspectExecutionRequest)(nil),     // 45: cleanroom.v1.InspectExecutionRequest
-	(*InspectExecutionResponse)(nil),    // 46: cleanroom.v1.InspectExecutionResponse
-	(*CancelExecutionRequest)(nil),      // 47: cleanroom.v1.CancelExecutionRequest
-	(*CancelExecutionResponse)(nil),     // 48: cleanroom.v1.CancelExecutionResponse
-	(*WriteExecutionStdinRequest)(nil),  // 49: cleanroom.v1.WriteExecutionStdinRequest
-	(*WriteExecutionStdinResponse)(nil), // 50: cleanroom.v1.WriteExecutionStdinResponse
-	(*CloseExecutionStdinRequest)(nil),  // 51: cleanroom.v1.CloseExecutionStdinRequest
-	(*CloseExecutionStdinResponse)(nil), // 52: cleanroom.v1.CloseExecutionStdinResponse
-	(*StreamExecutionRequest)(nil),      // 53: cleanroom.v1.StreamExecutionRequest
-	(*ExecutionExit)(nil),               // 54: cleanroom.v1.ExecutionExit
-	(*ExecutionStreamEvent)(nil),        // 55: cleanroom.v1.ExecutionStreamEvent
-	(*timestamppb.Timestamp)(nil),       // 56: google.protobuf.Timestamp
-	(*structpb.Struct)(nil),             // 57: google.protobuf.Struct
+	(*PolicyRun)(nil),                   // 11: cleanroom.v1.PolicyRun
+	(*Policy)(nil),                      // 12: cleanroom.v1.Policy
+	(*SandboxOptions)(nil),              // 13: cleanroom.v1.SandboxOptions
+	(*RepositoryCheckout)(nil),          // 14: cleanroom.v1.RepositoryCheckout
+	(*RepositoryChangesetFile)(nil),     // 15: cleanroom.v1.RepositoryChangesetFile
+	(*RepositoryChangeset)(nil),         // 16: cleanroom.v1.RepositoryChangeset
+	(*CreateSandboxRequest)(nil),        // 17: cleanroom.v1.CreateSandboxRequest
+	(*CreateSandboxResponse)(nil),       // 18: cleanroom.v1.CreateSandboxResponse
+	(*CreateSandboxEvent)(nil),          // 19: cleanroom.v1.CreateSandboxEvent
+	(*GetSandboxRequest)(nil),           // 20: cleanroom.v1.GetSandboxRequest
+	(*GetSandboxResponse)(nil),          // 21: cleanroom.v1.GetSandboxResponse
+	(*ListSandboxesRequest)(nil),        // 22: cleanroom.v1.ListSandboxesRequest
+	(*ListSandboxesResponse)(nil),       // 23: cleanroom.v1.ListSandboxesResponse
+	(*DownloadSandboxFileRequest)(nil),  // 24: cleanroom.v1.DownloadSandboxFileRequest
+	(*DownloadSandboxFileResponse)(nil), // 25: cleanroom.v1.DownloadSandboxFileResponse
+	(*TerminateSandboxRequest)(nil),     // 26: cleanroom.v1.TerminateSandboxRequest
+	(*TerminateSandboxResponse)(nil),    // 27: cleanroom.v1.TerminateSandboxResponse
+	(*StreamSandboxEventsRequest)(nil),  // 28: cleanroom.v1.StreamSandboxEventsRequest
+	(*SandboxEvent)(nil),                // 29: cleanroom.v1.SandboxEvent
+	(*CreateSnapshotRequest)(nil),       // 30: cleanroom.v1.CreateSnapshotRequest
+	(*CreateSnapshotResponse)(nil),      // 31: cleanroom.v1.CreateSnapshotResponse
+	(*GetSnapshotRequest)(nil),          // 32: cleanroom.v1.GetSnapshotRequest
+	(*GetSnapshotResponse)(nil),         // 33: cleanroom.v1.GetSnapshotResponse
+	(*ListSnapshotsRequest)(nil),        // 34: cleanroom.v1.ListSnapshotsRequest
+	(*ListSnapshotsResponse)(nil),       // 35: cleanroom.v1.ListSnapshotsResponse
+	(*DeleteSnapshotRequest)(nil),       // 36: cleanroom.v1.DeleteSnapshotRequest
+	(*DeleteSnapshotResponse)(nil),      // 37: cleanroom.v1.DeleteSnapshotResponse
+	(*Execution)(nil),                   // 38: cleanroom.v1.Execution
+	(*ExecutionOptions)(nil),            // 39: cleanroom.v1.ExecutionOptions
+	(*CreateExecutionRequest)(nil),      // 40: cleanroom.v1.CreateExecutionRequest
+	(*CreateExecutionResponse)(nil),     // 41: cleanroom.v1.CreateExecutionResponse
+	(*AttachExecutionRequest)(nil),      // 42: cleanroom.v1.AttachExecutionRequest
+	(*AttachExecutionResponse)(nil),     // 43: cleanroom.v1.AttachExecutionResponse
+	(*GetExecutionRequest)(nil),         // 44: cleanroom.v1.GetExecutionRequest
+	(*GetExecutionResponse)(nil),        // 45: cleanroom.v1.GetExecutionResponse
+	(*InspectExecutionRequest)(nil),     // 46: cleanroom.v1.InspectExecutionRequest
+	(*InspectExecutionResponse)(nil),    // 47: cleanroom.v1.InspectExecutionResponse
+	(*CancelExecutionRequest)(nil),      // 48: cleanroom.v1.CancelExecutionRequest
+	(*CancelExecutionResponse)(nil),     // 49: cleanroom.v1.CancelExecutionResponse
+	(*WriteExecutionStdinRequest)(nil),  // 50: cleanroom.v1.WriteExecutionStdinRequest
+	(*WriteExecutionStdinResponse)(nil), // 51: cleanroom.v1.WriteExecutionStdinResponse
+	(*CloseExecutionStdinRequest)(nil),  // 52: cleanroom.v1.CloseExecutionStdinRequest
+	(*CloseExecutionStdinResponse)(nil), // 53: cleanroom.v1.CloseExecutionStdinResponse
+	(*StreamExecutionRequest)(nil),      // 54: cleanroom.v1.StreamExecutionRequest
+	(*ExecutionExit)(nil),               // 55: cleanroom.v1.ExecutionExit
+	(*ExecutionStreamEvent)(nil),        // 56: cleanroom.v1.ExecutionStreamEvent
+	(*timestamppb.Timestamp)(nil),       // 57: google.protobuf.Timestamp
+	(*structpb.Struct)(nil),             // 58: google.protobuf.Struct
 }
 var file_proto_cleanroom_v1_control_proto_depIdxs = []int32{
 	0,  // 0: cleanroom.v1.Sandbox.status:type_name -> cleanroom.v1.SandboxStatus
-	56, // 1: cleanroom.v1.Sandbox.created_at:type_name -> google.protobuf.Timestamp
-	56, // 2: cleanroom.v1.Sandbox.updated_at:type_name -> google.protobuf.Timestamp
-	56, // 3: cleanroom.v1.Snapshot.created_at:type_name -> google.protobuf.Timestamp
-	13, // 4: cleanroom.v1.Snapshot.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
+	57, // 1: cleanroom.v1.Sandbox.created_at:type_name -> google.protobuf.Timestamp
+	57, // 2: cleanroom.v1.Sandbox.updated_at:type_name -> google.protobuf.Timestamp
+	57, // 3: cleanroom.v1.Snapshot.created_at:type_name -> google.protobuf.Timestamp
+	14, // 4: cleanroom.v1.Snapshot.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
 	7,  // 5: cleanroom.v1.PolicyServices.docker:type_name -> cleanroom.v1.PolicyDockerService
 	9,  // 6: cleanroom.v1.PolicyDependencies.key:type_name -> cleanroom.v1.PolicyDependencyKey
 	6,  // 7: cleanroom.v1.Policy.allow:type_name -> cleanroom.v1.PolicyAllowRule
 	8,  // 8: cleanroom.v1.Policy.services:type_name -> cleanroom.v1.PolicyServices
 	10, // 9: cleanroom.v1.Policy.dependencies:type_name -> cleanroom.v1.PolicyDependencies
-	14, // 10: cleanroom.v1.RepositoryChangeset.files:type_name -> cleanroom.v1.RepositoryChangesetFile
-	12, // 11: cleanroom.v1.CreateSandboxRequest.options:type_name -> cleanroom.v1.SandboxOptions
-	11, // 12: cleanroom.v1.CreateSandboxRequest.policy:type_name -> cleanroom.v1.Policy
-	13, // 13: cleanroom.v1.CreateSandboxRequest.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
-	15, // 14: cleanroom.v1.CreateSandboxRequest.repository_changeset:type_name -> cleanroom.v1.RepositoryChangeset
-	4,  // 15: cleanroom.v1.CreateSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
-	1,  // 16: cleanroom.v1.CreateSandboxEvent.phase:type_name -> cleanroom.v1.CreateSandboxPhase
-	17, // 17: cleanroom.v1.CreateSandboxEvent.response:type_name -> cleanroom.v1.CreateSandboxResponse
-	56, // 18: cleanroom.v1.CreateSandboxEvent.occurred_at:type_name -> google.protobuf.Timestamp
-	4,  // 19: cleanroom.v1.GetSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
-	4,  // 20: cleanroom.v1.ListSandboxesResponse.sandboxes:type_name -> cleanroom.v1.Sandbox
-	0,  // 21: cleanroom.v1.SandboxEvent.status:type_name -> cleanroom.v1.SandboxStatus
-	56, // 22: cleanroom.v1.SandboxEvent.occurred_at:type_name -> google.protobuf.Timestamp
-	5,  // 23: cleanroom.v1.CreateSnapshotResponse.snapshot:type_name -> cleanroom.v1.Snapshot
-	5,  // 24: cleanroom.v1.GetSnapshotResponse.snapshot:type_name -> cleanroom.v1.Snapshot
-	5,  // 25: cleanroom.v1.ListSnapshotsResponse.snapshots:type_name -> cleanroom.v1.Snapshot
-	2,  // 26: cleanroom.v1.Execution.status:type_name -> cleanroom.v1.ExecutionStatus
-	56, // 27: cleanroom.v1.Execution.started_at:type_name -> google.protobuf.Timestamp
-	56, // 28: cleanroom.v1.Execution.finished_at:type_name -> google.protobuf.Timestamp
-	3,  // 29: cleanroom.v1.Execution.kind:type_name -> cleanroom.v1.ExecutionKind
-	38, // 30: cleanroom.v1.CreateExecutionRequest.options:type_name -> cleanroom.v1.ExecutionOptions
-	3,  // 31: cleanroom.v1.CreateExecutionRequest.kind:type_name -> cleanroom.v1.ExecutionKind
-	13, // 32: cleanroom.v1.CreateExecutionRequest.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
-	37, // 33: cleanroom.v1.CreateExecutionResponse.execution:type_name -> cleanroom.v1.Execution
-	56, // 34: cleanroom.v1.AttachExecutionResponse.expires_at:type_name -> google.protobuf.Timestamp
-	37, // 35: cleanroom.v1.GetExecutionResponse.execution:type_name -> cleanroom.v1.Execution
-	37, // 36: cleanroom.v1.InspectExecutionResponse.execution:type_name -> cleanroom.v1.Execution
-	57, // 37: cleanroom.v1.InspectExecutionResponse.observability:type_name -> google.protobuf.Struct
-	2,  // 38: cleanroom.v1.CancelExecutionResponse.status:type_name -> cleanroom.v1.ExecutionStatus
-	2,  // 39: cleanroom.v1.ExecutionExit.status:type_name -> cleanroom.v1.ExecutionStatus
-	2,  // 40: cleanroom.v1.ExecutionStreamEvent.status:type_name -> cleanroom.v1.ExecutionStatus
-	54, // 41: cleanroom.v1.ExecutionStreamEvent.exit:type_name -> cleanroom.v1.ExecutionExit
-	56, // 42: cleanroom.v1.ExecutionStreamEvent.occurred_at:type_name -> google.protobuf.Timestamp
-	16, // 43: cleanroom.v1.SandboxService.CreateSandbox:input_type -> cleanroom.v1.CreateSandboxRequest
-	16, // 44: cleanroom.v1.SandboxService.CreateSandboxStream:input_type -> cleanroom.v1.CreateSandboxRequest
-	19, // 45: cleanroom.v1.SandboxService.GetSandbox:input_type -> cleanroom.v1.GetSandboxRequest
-	21, // 46: cleanroom.v1.SandboxService.ListSandboxes:input_type -> cleanroom.v1.ListSandboxesRequest
-	23, // 47: cleanroom.v1.SandboxService.DownloadSandboxFile:input_type -> cleanroom.v1.DownloadSandboxFileRequest
-	25, // 48: cleanroom.v1.SandboxService.TerminateSandbox:input_type -> cleanroom.v1.TerminateSandboxRequest
-	27, // 49: cleanroom.v1.SandboxService.StreamSandboxEvents:input_type -> cleanroom.v1.StreamSandboxEventsRequest
-	29, // 50: cleanroom.v1.SnapshotService.CreateSnapshot:input_type -> cleanroom.v1.CreateSnapshotRequest
-	31, // 51: cleanroom.v1.SnapshotService.GetSnapshot:input_type -> cleanroom.v1.GetSnapshotRequest
-	33, // 52: cleanroom.v1.SnapshotService.ListSnapshots:input_type -> cleanroom.v1.ListSnapshotsRequest
-	35, // 53: cleanroom.v1.SnapshotService.DeleteSnapshot:input_type -> cleanroom.v1.DeleteSnapshotRequest
-	39, // 54: cleanroom.v1.ExecutionService.CreateExecution:input_type -> cleanroom.v1.CreateExecutionRequest
-	41, // 55: cleanroom.v1.ExecutionService.AttachExecution:input_type -> cleanroom.v1.AttachExecutionRequest
-	43, // 56: cleanroom.v1.ExecutionService.GetExecution:input_type -> cleanroom.v1.GetExecutionRequest
-	45, // 57: cleanroom.v1.ExecutionService.InspectExecution:input_type -> cleanroom.v1.InspectExecutionRequest
-	47, // 58: cleanroom.v1.ExecutionService.CancelExecution:input_type -> cleanroom.v1.CancelExecutionRequest
-	49, // 59: cleanroom.v1.ExecutionService.WriteExecutionStdin:input_type -> cleanroom.v1.WriteExecutionStdinRequest
-	51, // 60: cleanroom.v1.ExecutionService.CloseExecutionStdin:input_type -> cleanroom.v1.CloseExecutionStdinRequest
-	53, // 61: cleanroom.v1.ExecutionService.StreamExecution:input_type -> cleanroom.v1.StreamExecutionRequest
-	17, // 62: cleanroom.v1.SandboxService.CreateSandbox:output_type -> cleanroom.v1.CreateSandboxResponse
-	18, // 63: cleanroom.v1.SandboxService.CreateSandboxStream:output_type -> cleanroom.v1.CreateSandboxEvent
-	20, // 64: cleanroom.v1.SandboxService.GetSandbox:output_type -> cleanroom.v1.GetSandboxResponse
-	22, // 65: cleanroom.v1.SandboxService.ListSandboxes:output_type -> cleanroom.v1.ListSandboxesResponse
-	24, // 66: cleanroom.v1.SandboxService.DownloadSandboxFile:output_type -> cleanroom.v1.DownloadSandboxFileResponse
-	26, // 67: cleanroom.v1.SandboxService.TerminateSandbox:output_type -> cleanroom.v1.TerminateSandboxResponse
-	28, // 68: cleanroom.v1.SandboxService.StreamSandboxEvents:output_type -> cleanroom.v1.SandboxEvent
-	30, // 69: cleanroom.v1.SnapshotService.CreateSnapshot:output_type -> cleanroom.v1.CreateSnapshotResponse
-	32, // 70: cleanroom.v1.SnapshotService.GetSnapshot:output_type -> cleanroom.v1.GetSnapshotResponse
-	34, // 71: cleanroom.v1.SnapshotService.ListSnapshots:output_type -> cleanroom.v1.ListSnapshotsResponse
-	36, // 72: cleanroom.v1.SnapshotService.DeleteSnapshot:output_type -> cleanroom.v1.DeleteSnapshotResponse
-	40, // 73: cleanroom.v1.ExecutionService.CreateExecution:output_type -> cleanroom.v1.CreateExecutionResponse
-	42, // 74: cleanroom.v1.ExecutionService.AttachExecution:output_type -> cleanroom.v1.AttachExecutionResponse
-	44, // 75: cleanroom.v1.ExecutionService.GetExecution:output_type -> cleanroom.v1.GetExecutionResponse
-	46, // 76: cleanroom.v1.ExecutionService.InspectExecution:output_type -> cleanroom.v1.InspectExecutionResponse
-	48, // 77: cleanroom.v1.ExecutionService.CancelExecution:output_type -> cleanroom.v1.CancelExecutionResponse
-	50, // 78: cleanroom.v1.ExecutionService.WriteExecutionStdin:output_type -> cleanroom.v1.WriteExecutionStdinResponse
-	52, // 79: cleanroom.v1.ExecutionService.CloseExecutionStdin:output_type -> cleanroom.v1.CloseExecutionStdinResponse
-	55, // 80: cleanroom.v1.ExecutionService.StreamExecution:output_type -> cleanroom.v1.ExecutionStreamEvent
-	62, // [62:81] is the sub-list for method output_type
-	43, // [43:62] is the sub-list for method input_type
-	43, // [43:43] is the sub-list for extension type_name
-	43, // [43:43] is the sub-list for extension extendee
-	0,  // [0:43] is the sub-list for field type_name
+	11, // 10: cleanroom.v1.Policy.run:type_name -> cleanroom.v1.PolicyRun
+	15, // 11: cleanroom.v1.RepositoryChangeset.files:type_name -> cleanroom.v1.RepositoryChangesetFile
+	13, // 12: cleanroom.v1.CreateSandboxRequest.options:type_name -> cleanroom.v1.SandboxOptions
+	12, // 13: cleanroom.v1.CreateSandboxRequest.policy:type_name -> cleanroom.v1.Policy
+	14, // 14: cleanroom.v1.CreateSandboxRequest.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
+	16, // 15: cleanroom.v1.CreateSandboxRequest.repository_changeset:type_name -> cleanroom.v1.RepositoryChangeset
+	4,  // 16: cleanroom.v1.CreateSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
+	1,  // 17: cleanroom.v1.CreateSandboxEvent.phase:type_name -> cleanroom.v1.CreateSandboxPhase
+	18, // 18: cleanroom.v1.CreateSandboxEvent.response:type_name -> cleanroom.v1.CreateSandboxResponse
+	57, // 19: cleanroom.v1.CreateSandboxEvent.occurred_at:type_name -> google.protobuf.Timestamp
+	4,  // 20: cleanroom.v1.GetSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
+	4,  // 21: cleanroom.v1.ListSandboxesResponse.sandboxes:type_name -> cleanroom.v1.Sandbox
+	0,  // 22: cleanroom.v1.SandboxEvent.status:type_name -> cleanroom.v1.SandboxStatus
+	57, // 23: cleanroom.v1.SandboxEvent.occurred_at:type_name -> google.protobuf.Timestamp
+	5,  // 24: cleanroom.v1.CreateSnapshotResponse.snapshot:type_name -> cleanroom.v1.Snapshot
+	5,  // 25: cleanroom.v1.GetSnapshotResponse.snapshot:type_name -> cleanroom.v1.Snapshot
+	5,  // 26: cleanroom.v1.ListSnapshotsResponse.snapshots:type_name -> cleanroom.v1.Snapshot
+	2,  // 27: cleanroom.v1.Execution.status:type_name -> cleanroom.v1.ExecutionStatus
+	57, // 28: cleanroom.v1.Execution.started_at:type_name -> google.protobuf.Timestamp
+	57, // 29: cleanroom.v1.Execution.finished_at:type_name -> google.protobuf.Timestamp
+	3,  // 30: cleanroom.v1.Execution.kind:type_name -> cleanroom.v1.ExecutionKind
+	39, // 31: cleanroom.v1.CreateExecutionRequest.options:type_name -> cleanroom.v1.ExecutionOptions
+	3,  // 32: cleanroom.v1.CreateExecutionRequest.kind:type_name -> cleanroom.v1.ExecutionKind
+	14, // 33: cleanroom.v1.CreateExecutionRequest.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
+	38, // 34: cleanroom.v1.CreateExecutionResponse.execution:type_name -> cleanroom.v1.Execution
+	57, // 35: cleanroom.v1.AttachExecutionResponse.expires_at:type_name -> google.protobuf.Timestamp
+	38, // 36: cleanroom.v1.GetExecutionResponse.execution:type_name -> cleanroom.v1.Execution
+	38, // 37: cleanroom.v1.InspectExecutionResponse.execution:type_name -> cleanroom.v1.Execution
+	58, // 38: cleanroom.v1.InspectExecutionResponse.observability:type_name -> google.protobuf.Struct
+	2,  // 39: cleanroom.v1.CancelExecutionResponse.status:type_name -> cleanroom.v1.ExecutionStatus
+	2,  // 40: cleanroom.v1.ExecutionExit.status:type_name -> cleanroom.v1.ExecutionStatus
+	2,  // 41: cleanroom.v1.ExecutionStreamEvent.status:type_name -> cleanroom.v1.ExecutionStatus
+	55, // 42: cleanroom.v1.ExecutionStreamEvent.exit:type_name -> cleanroom.v1.ExecutionExit
+	57, // 43: cleanroom.v1.ExecutionStreamEvent.occurred_at:type_name -> google.protobuf.Timestamp
+	17, // 44: cleanroom.v1.SandboxService.CreateSandbox:input_type -> cleanroom.v1.CreateSandboxRequest
+	17, // 45: cleanroom.v1.SandboxService.CreateSandboxStream:input_type -> cleanroom.v1.CreateSandboxRequest
+	20, // 46: cleanroom.v1.SandboxService.GetSandbox:input_type -> cleanroom.v1.GetSandboxRequest
+	22, // 47: cleanroom.v1.SandboxService.ListSandboxes:input_type -> cleanroom.v1.ListSandboxesRequest
+	24, // 48: cleanroom.v1.SandboxService.DownloadSandboxFile:input_type -> cleanroom.v1.DownloadSandboxFileRequest
+	26, // 49: cleanroom.v1.SandboxService.TerminateSandbox:input_type -> cleanroom.v1.TerminateSandboxRequest
+	28, // 50: cleanroom.v1.SandboxService.StreamSandboxEvents:input_type -> cleanroom.v1.StreamSandboxEventsRequest
+	30, // 51: cleanroom.v1.SnapshotService.CreateSnapshot:input_type -> cleanroom.v1.CreateSnapshotRequest
+	32, // 52: cleanroom.v1.SnapshotService.GetSnapshot:input_type -> cleanroom.v1.GetSnapshotRequest
+	34, // 53: cleanroom.v1.SnapshotService.ListSnapshots:input_type -> cleanroom.v1.ListSnapshotsRequest
+	36, // 54: cleanroom.v1.SnapshotService.DeleteSnapshot:input_type -> cleanroom.v1.DeleteSnapshotRequest
+	40, // 55: cleanroom.v1.ExecutionService.CreateExecution:input_type -> cleanroom.v1.CreateExecutionRequest
+	42, // 56: cleanroom.v1.ExecutionService.AttachExecution:input_type -> cleanroom.v1.AttachExecutionRequest
+	44, // 57: cleanroom.v1.ExecutionService.GetExecution:input_type -> cleanroom.v1.GetExecutionRequest
+	46, // 58: cleanroom.v1.ExecutionService.InspectExecution:input_type -> cleanroom.v1.InspectExecutionRequest
+	48, // 59: cleanroom.v1.ExecutionService.CancelExecution:input_type -> cleanroom.v1.CancelExecutionRequest
+	50, // 60: cleanroom.v1.ExecutionService.WriteExecutionStdin:input_type -> cleanroom.v1.WriteExecutionStdinRequest
+	52, // 61: cleanroom.v1.ExecutionService.CloseExecutionStdin:input_type -> cleanroom.v1.CloseExecutionStdinRequest
+	54, // 62: cleanroom.v1.ExecutionService.StreamExecution:input_type -> cleanroom.v1.StreamExecutionRequest
+	18, // 63: cleanroom.v1.SandboxService.CreateSandbox:output_type -> cleanroom.v1.CreateSandboxResponse
+	19, // 64: cleanroom.v1.SandboxService.CreateSandboxStream:output_type -> cleanroom.v1.CreateSandboxEvent
+	21, // 65: cleanroom.v1.SandboxService.GetSandbox:output_type -> cleanroom.v1.GetSandboxResponse
+	23, // 66: cleanroom.v1.SandboxService.ListSandboxes:output_type -> cleanroom.v1.ListSandboxesResponse
+	25, // 67: cleanroom.v1.SandboxService.DownloadSandboxFile:output_type -> cleanroom.v1.DownloadSandboxFileResponse
+	27, // 68: cleanroom.v1.SandboxService.TerminateSandbox:output_type -> cleanroom.v1.TerminateSandboxResponse
+	29, // 69: cleanroom.v1.SandboxService.StreamSandboxEvents:output_type -> cleanroom.v1.SandboxEvent
+	31, // 70: cleanroom.v1.SnapshotService.CreateSnapshot:output_type -> cleanroom.v1.CreateSnapshotResponse
+	33, // 71: cleanroom.v1.SnapshotService.GetSnapshot:output_type -> cleanroom.v1.GetSnapshotResponse
+	35, // 72: cleanroom.v1.SnapshotService.ListSnapshots:output_type -> cleanroom.v1.ListSnapshotsResponse
+	37, // 73: cleanroom.v1.SnapshotService.DeleteSnapshot:output_type -> cleanroom.v1.DeleteSnapshotResponse
+	41, // 74: cleanroom.v1.ExecutionService.CreateExecution:output_type -> cleanroom.v1.CreateExecutionResponse
+	43, // 75: cleanroom.v1.ExecutionService.AttachExecution:output_type -> cleanroom.v1.AttachExecutionResponse
+	45, // 76: cleanroom.v1.ExecutionService.GetExecution:output_type -> cleanroom.v1.GetExecutionResponse
+	47, // 77: cleanroom.v1.ExecutionService.InspectExecution:output_type -> cleanroom.v1.InspectExecutionResponse
+	49, // 78: cleanroom.v1.ExecutionService.CancelExecution:output_type -> cleanroom.v1.CancelExecutionResponse
+	51, // 79: cleanroom.v1.ExecutionService.WriteExecutionStdin:output_type -> cleanroom.v1.WriteExecutionStdinResponse
+	53, // 80: cleanroom.v1.ExecutionService.CloseExecutionStdin:output_type -> cleanroom.v1.CloseExecutionStdinResponse
+	56, // 81: cleanroom.v1.ExecutionService.StreamExecution:output_type -> cleanroom.v1.ExecutionStreamEvent
+	63, // [63:82] is the sub-list for method output_type
+	44, // [44:63] is the sub-list for method input_type
+	44, // [44:44] is the sub-list for extension type_name
+	44, // [44:44] is the sub-list for extension extendee
+	0,  // [0:44] is the sub-list for field type_name
 }
 
 func init() { file_proto_cleanroom_v1_control_proto_init() }
@@ -4160,17 +4218,17 @@ func file_proto_cleanroom_v1_control_proto_init() {
 	if File_proto_cleanroom_v1_control_proto != nil {
 		return
 	}
-	file_proto_cleanroom_v1_control_proto_msgTypes[12].OneofWrappers = []any{
+	file_proto_cleanroom_v1_control_proto_msgTypes[13].OneofWrappers = []any{
 		(*CreateSandboxRequest_SnapshotId)(nil),
 	}
-	file_proto_cleanroom_v1_control_proto_msgTypes[14].OneofWrappers = []any{
+	file_proto_cleanroom_v1_control_proto_msgTypes[15].OneofWrappers = []any{
 		(*CreateSandboxEvent_Message)(nil),
 		(*CreateSandboxEvent_Stdout)(nil),
 		(*CreateSandboxEvent_Stderr)(nil),
 		(*CreateSandboxEvent_Warning)(nil),
 		(*CreateSandboxEvent_Response)(nil),
 	}
-	file_proto_cleanroom_v1_control_proto_msgTypes[51].OneofWrappers = []any{
+	file_proto_cleanroom_v1_control_proto_msgTypes[52].OneofWrappers = []any{
 		(*ExecutionStreamEvent_Stdout)(nil),
 		(*ExecutionStreamEvent_Stderr)(nil),
 		(*ExecutionStreamEvent_Exit)(nil),
@@ -4183,7 +4241,7 @@ func file_proto_cleanroom_v1_control_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proto_cleanroom_v1_control_proto_rawDesc), len(file_proto_cleanroom_v1_control_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   52,
+			NumMessages:   53,
 			NumExtensions: 0,
 			NumServices:   3,
 		},

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -56,9 +56,11 @@ type rawDependencyKey struct {
 }
 
 type rawDependenciesConfig struct {
-	Command []string         `yaml:"command"`
-	Key     rawDependencyKey `yaml:"key"`
+	Command rawDependencyCommandSpec `yaml:"command"`
+	Key     rawDependencyKey         `yaml:"key"`
 }
+
+type rawDependencyCommandSpec []string
 
 type rawRunConfig struct {
 	Before rawShellCommandSpec `yaml:"before"`
@@ -323,12 +325,50 @@ func (c *rawShellCommandSpec) UnmarshalYAML(node *yaml.Node) error {
 		*c = nil
 		return nil
 	}
+	node = dereferenceYAMLAlias(node)
 	if node.Kind != yaml.ScalarNode || node.ShortTag() != "!!str" {
 		return fmt.Errorf("command must be a string")
 	}
 	script := strings.TrimSpace(node.Value)
 	*c = rawShellCommandSpec{"sh", "-lc", script}
 	return nil
+}
+
+func (c *rawDependencyCommandSpec) UnmarshalYAML(node *yaml.Node) error {
+	if node == nil {
+		*c = nil
+		return nil
+	}
+	node = dereferenceYAMLAlias(node)
+	switch node.Kind {
+	case yaml.ScalarNode:
+		if node.ShortTag() == "!!null" {
+			*c = nil
+			return nil
+		}
+		if node.ShortTag() != "!!str" {
+			return fmt.Errorf("command must be a string or sequence")
+		}
+		script := strings.TrimSpace(node.Value)
+		*c = rawDependencyCommandSpec{"sh", "-lc", script}
+		return nil
+	case yaml.SequenceNode:
+		var command []string
+		if err := node.Decode(&command); err != nil {
+			return err
+		}
+		*c = rawDependencyCommandSpec(command)
+		return nil
+	default:
+		return fmt.Errorf("command must be a string or sequence")
+	}
+}
+
+func dereferenceYAMLAlias(node *yaml.Node) *yaml.Node {
+	for node != nil && node.Kind == yaml.AliasNode {
+		node = node.Alias
+	}
+	return node
 }
 
 func normalizeRepositoryConfig(raw *rawRepository) (RepositoryConfig, error) {

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -34,6 +34,7 @@ type rawPolicy struct {
 			Ref string `yaml:"ref"`
 		} `yaml:"image"`
 		Dependencies rawDependenciesConfig `yaml:"dependencies"`
+		Run          rawRunConfig          `yaml:"run"`
 		Services     rawServices           `yaml:"services"`
 		Network      struct {
 			Default string         `yaml:"default"`
@@ -59,6 +60,12 @@ type rawDependenciesConfig struct {
 	Key     rawDependencyKey `yaml:"key"`
 }
 
+type rawRunConfig struct {
+	Before rawShellCommandSpec `yaml:"before"`
+}
+
+type rawShellCommandSpec []string
+
 type rawServices struct {
 	Docker rawDockerService `yaml:"docker"`
 }
@@ -80,6 +87,7 @@ type CompiledPolicy struct {
 	NetworkDefault string       `json:"network_default"`
 	Allow          []AllowRule  `json:"allow"`
 	Dependencies   Dependencies `json:"dependencies"`
+	Run            Run          `json:"run"`
 	Hash           string       `json:"hash"`
 }
 
@@ -98,6 +106,10 @@ type Services struct {
 type Dependencies struct {
 	Command  []string `json:"command,omitempty"`
 	KeyFiles []string `json:"key_files,omitempty"`
+}
+
+type Run struct {
+	Before []string `json:"before,omitempty"`
 }
 
 type DockerService struct {
@@ -220,6 +232,10 @@ func Compile(raw rawPolicy) (*CompiledPolicy, error) {
 	if err != nil {
 		return nil, err
 	}
+	run, err := normalizeRun(raw.Sandbox.Run)
+	if err != nil {
+		return nil, err
+	}
 
 	compiled := &CompiledPolicy{
 		Version:     raw.Version,
@@ -233,6 +249,7 @@ func Compile(raw rawPolicy) (*CompiledPolicy, error) {
 		NetworkDefault: networkDefault,
 		Allow:          allow,
 		Dependencies:   dependencies,
+		Run:            run,
 	}
 
 	hash, err := hashPolicy(compiled)
@@ -293,8 +310,25 @@ func (d Dependencies) Enabled() bool {
 	return len(d.Command) > 0
 }
 
+func (r Run) HasBefore() bool {
+	return len(r.Before) > 0
+}
+
 func (c RepositoryConfig) Enabled() bool {
 	return strings.TrimSpace(strings.ToLower(c.Mode)) != "" && strings.TrimSpace(strings.ToLower(c.Mode)) != "none"
+}
+
+func (c *rawShellCommandSpec) UnmarshalYAML(node *yaml.Node) error {
+	if node == nil {
+		*c = nil
+		return nil
+	}
+	if node.Kind != yaml.ScalarNode || node.ShortTag() != "!!str" {
+		return fmt.Errorf("command must be a string")
+	}
+	script := strings.TrimSpace(node.Value)
+	*c = rawShellCommandSpec{"sh", "-lc", script}
+	return nil
 }
 
 func normalizeRepositoryConfig(raw *rawRepository) (RepositoryConfig, error) {
@@ -400,6 +434,9 @@ func (p *CompiledPolicy) ToProto() *cleanroomv1.Policy {
 				Files: append([]string(nil), p.Dependencies.KeyFiles...),
 			},
 		},
+		Run: &cleanroomv1.PolicyRun{
+			Before: append([]string(nil), p.Run.Before...),
+		},
 		Hash: p.Hash,
 	}
 }
@@ -470,6 +507,10 @@ func FromProto(pb *cleanroomv1.Policy) (*CompiledPolicy, error) {
 	if err != nil {
 		return nil, err
 	}
+	run, err := runFromProto(pb.GetRun())
+	if err != nil {
+		return nil, err
+	}
 
 	compiled := &CompiledPolicy{
 		Version:     int(pb.GetVersion()),
@@ -483,6 +524,7 @@ func FromProto(pb *cleanroomv1.Policy) (*CompiledPolicy, error) {
 		NetworkDefault: networkDefault,
 		Allow:          allow,
 		Dependencies:   dependencies,
+		Run:            run,
 	}
 
 	hash, err := hashPolicy(compiled)
@@ -540,6 +582,40 @@ func dependenciesFromProto(pb *cleanroomv1.PolicyDependencies) (Dependencies, er
 		Command:  command,
 		KeyFiles: keyFiles,
 	}, nil
+}
+
+func normalizeRun(raw rawRunConfig) (Run, error) {
+	before, err := normalizeShellCommand(raw.Before, "sandbox.run.before")
+	if err != nil {
+		return Run{}, err
+	}
+	return Run{Before: before}, nil
+}
+
+func runFromProto(pb *cleanroomv1.PolicyRun) (Run, error) {
+	if pb == nil {
+		return Run{}, nil
+	}
+	before, err := normalizeShellCommand(pb.GetBefore(), "policy run.before")
+	if err != nil {
+		return Run{}, err
+	}
+	return Run{Before: before}, nil
+}
+
+func normalizeShellCommand(raw []string, field string) ([]string, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	command := make([]string, 0, len(raw))
+	for i, arg := range raw {
+		trimmed := strings.TrimSpace(arg)
+		if trimmed == "" {
+			return nil, fmt.Errorf("%s[%d] cannot be empty", field, i)
+		}
+		command = append(command, trimmed)
+	}
+	return command, nil
 }
 
 func normalizeDependencyCommand(raw []string) ([]string, error) {

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+	"gopkg.in/yaml.v3"
 )
 
 const validImageRef = "ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
@@ -217,6 +218,78 @@ func TestCompileRejectsDependencyKeyFilesWithoutCommand(t *testing.T) {
 		t.Fatal("expected compile to reject dependency key files without a command")
 	}
 	if !strings.Contains(err.Error(), "sandbox.dependencies.key.files") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCompileNormalizesRunBeforeCommand(t *testing.T) {
+	t.Parallel()
+
+	var raw rawPolicy
+	if err := yaml.Unmarshal([]byte(`
+version: 1
+sandbox:
+  image:
+    ref: ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+  run:
+    before: |
+      docker compose up -d postgres valkey
+      bin/rails db:prepare
+  network:
+    default: deny
+`), &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	compiled, err := Compile(raw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if got, want := compiled.Run.Before, []string{"sh", "-lc", "docker compose up -d postgres valkey\nbin/rails db:prepare"}; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("unexpected run.before command: got %v want %v", got, want)
+	}
+}
+
+func TestUnmarshalRejectsNonStringRunBefore(t *testing.T) {
+	t.Parallel()
+
+	var raw rawPolicy
+	err := yaml.Unmarshal([]byte(`
+version: 1
+sandbox:
+  image:
+    ref: ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+  run:
+    before: false
+  network:
+    default: deny
+`), &raw)
+	if err == nil {
+		t.Fatal("expected unmarshal to reject non-string run.before")
+	}
+	if !strings.Contains(err.Error(), "command must be a string") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestUnmarshalRejectsSequenceRunBefore(t *testing.T) {
+	t.Parallel()
+
+	var raw rawPolicy
+	err := yaml.Unmarshal([]byte(`
+version: 1
+sandbox:
+  image:
+    ref: ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+  run:
+    before: [bin/rails, db:prepare]
+  network:
+    default: deny
+`), &raw)
+	if err == nil {
+		t.Fatal("expected unmarshal to reject sequence run.before")
+	}
+	if !strings.Contains(err.Error(), "command must be a string") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -451,6 +524,7 @@ func TestCompiledPolicyProtoRoundTripPreservesDependencies(t *testing.T) {
 	raw := baseRawPolicy()
 	raw.Sandbox.Dependencies.Command = []string{"go", "mod", "download"}
 	raw.Sandbox.Dependencies.Key.Files = []string{"go.mod", "go.sum"}
+	raw.Sandbox.Run.Before = rawShellCommandSpec{"sh", "-lc", "bin/rails db:prepare"}
 	compiled, err := Compile(raw)
 	if err != nil {
 		t.Fatalf("compile: %v", err)
@@ -465,5 +539,8 @@ func TestCompiledPolicyProtoRoundTripPreservesDependencies(t *testing.T) {
 	}
 	if got, want := strings.Join(roundTripped.Dependencies.KeyFiles, "\x00"), strings.Join(compiled.Dependencies.KeyFiles, "\x00"); got != want {
 		t.Fatalf("unexpected dependency key files after round trip: got %q want %q", got, want)
+	}
+	if got, want := strings.Join(roundTripped.Run.Before, "\x00"), strings.Join(compiled.Run.Before, "\x00"); got != want {
+		t.Fatalf("unexpected run.before after round trip: got %q want %q", got, want)
 	}
 }

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -207,6 +207,95 @@ func TestCompileNormalizesDependencyBootstrapConfig(t *testing.T) {
 	}
 }
 
+func TestCompileNormalizesDependencyCommandString(t *testing.T) {
+	t.Parallel()
+
+	var raw rawPolicy
+	if err := yaml.Unmarshal([]byte(`
+version: 1
+sandbox:
+  image:
+    ref: ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+  dependencies:
+    command: bundle install
+    key:
+      files: [Gemfile.lock]
+  network:
+    default: deny
+`), &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	compiled, err := Compile(raw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if got, want := compiled.Dependencies.Command, []string{"sh", "-lc", "bundle install"}; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("unexpected dependency command: got %v want %v", got, want)
+	}
+	if got, want := compiled.Dependencies.KeyFiles, []string{"Gemfile.lock"}; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("unexpected dependency key files: got %v want %v", got, want)
+	}
+}
+
+func TestCompileTreatsNullDependencyCommandAsUnset(t *testing.T) {
+	t.Parallel()
+
+	var raw rawPolicy
+	if err := yaml.Unmarshal([]byte(`
+version: 1
+sandbox:
+  image:
+    ref: ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+  dependencies:
+    command: null
+  network:
+    default: deny
+`), &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	compiled, err := Compile(raw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if compiled.Dependencies.Enabled() {
+		t.Fatal("expected null dependency command to disable dependency bootstrap")
+	}
+	if len(compiled.Dependencies.Command) != 0 {
+		t.Fatalf("expected null dependency command to normalize to empty, got %v", compiled.Dependencies.Command)
+	}
+}
+
+func TestCompileAcceptsAliasedDependencyCommandSequence(t *testing.T) {
+	t.Parallel()
+
+	var raw rawPolicy
+	if err := yaml.Unmarshal([]byte(`
+version: 1
+common_cmd: &deps [mise, exec, --, go, mod, download]
+sandbox:
+  image:
+    ref: ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+  dependencies:
+    command: *deps
+    key:
+      files: [go.mod, go.sum]
+  network:
+    default: deny
+`), &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	compiled, err := Compile(raw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if got, want := compiled.Dependencies.Command, []string{"mise", "exec", "--", "go", "mod", "download"}; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("unexpected dependency command: got %v want %v", got, want)
+	}
+}
+
 func TestCompileRejectsDependencyKeyFilesWithoutCommand(t *testing.T) {
 	t.Parallel()
 
@@ -218,6 +307,28 @@ func TestCompileRejectsDependencyKeyFilesWithoutCommand(t *testing.T) {
 		t.Fatal("expected compile to reject dependency key files without a command")
 	}
 	if !strings.Contains(err.Error(), "sandbox.dependencies.key.files") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestUnmarshalRejectsNonStringOrSequenceDependencyCommand(t *testing.T) {
+	t.Parallel()
+
+	var raw rawPolicy
+	err := yaml.Unmarshal([]byte(`
+version: 1
+sandbox:
+  image:
+    ref: ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+  dependencies:
+    command: false
+  network:
+    default: deny
+`), &raw)
+	if err == nil {
+		t.Fatal("expected unmarshal to reject non-string dependency command")
+	}
+	if !strings.Contains(err.Error(), "command must be a string or sequence") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/proto/cleanroom/v1/control.proto
+++ b/proto/cleanroom/v1/control.proto
@@ -92,6 +92,10 @@ message PolicyDependencies {
   PolicyDependencyKey key = 2;
 }
 
+message PolicyRun {
+  repeated string before = 1;
+}
+
 message Policy {
   int32 version = 1;
   string image_ref = 2;
@@ -101,6 +105,7 @@ message Policy {
   string hash = 6;
   PolicyServices services = 7;
   PolicyDependencies dependencies = 9;
+  PolicyRun run = 10;
 }
 
 message SandboxOptions {


### PR DESCRIPTION
## Summary
- add a minimal `sandbox.run.before` policy surface for per-execution setup
- run that command before each top-level execution, in the repository workdir when repo bootstrap is active
- document the new YAML shape and add focused policy/controlservice coverage

## Testing
- mise exec -- go test ./...
