### PR TITLE
feat: accept string sandbox.dependencies.command

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ You can also define per-execution setup that runs before each top-level command:
 ```yaml
 sandbox:
   dependencies:
-    command: [bundle, install]
+    command: bundle install
     key:
       files: [Gemfile.lock]
   run:
@@ -121,6 +121,8 @@ sandbox:
       bin/rails db:prepare
 ```
 
+`sandbox.dependencies.command` supports either a shell string or an argv sequence.
+Prefer the string form unless you specifically need exact argv semantics.
 `sandbox.run.before` always runs through `sh -lc`.
 
 Pre-create a long-running sandbox without running a command:

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -76,7 +76,7 @@ project:
 sandbox:
   ttl_minutes: 60
   dependencies:
-    command: [mise, exec, --, go, mod, download]
+    command: mise exec -- go mod download
     key:
       files:
         - .mise.toml
@@ -166,6 +166,7 @@ explicit request-time changeset input.
 - `repository.path` defaults to `/workspace` and must be an absolute guest path.
 - `repository.submodules` defaults to `false`.
 - `sandbox.dependencies.command` defaults to unset; when present, Cleanroom runs that command in the repository workdir during sandbox creation and makes the result eligible for dependency-stage caching.
+- `sandbox.dependencies.command` accepts either a YAML string or a YAML sequence; strings execute as `sh -lc <value>`, and strings are the preferred form.
 - `sandbox.dependencies.key.files` defaults to empty; when present, Cleanroom hashes those repository-relative files from the exact committed checkout and includes them in the dependency-stage cache key.
 - `sandbox.run.before` defaults to unset; when present, each execution runs that shell command in the repository workdir immediately before the requested command.
 - `sandbox.run.before` must be a YAML string or block string and executes as `sh -lc <value>`.

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -340,6 +340,10 @@ func (c *rawDependencyCommandSpec) UnmarshalYAML(node *yaml.Node) error {
 	}
 	switch node.Kind {
 	case yaml.ScalarNode:
+		if node.ShortTag() == "!!null" {
+			*c = nil
+			return nil
+		}
 		if node.ShortTag() != "!!str" {
 			return fmt.Errorf("command must be a string or sequence")
 		}

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -325,6 +325,7 @@ func (c *rawShellCommandSpec) UnmarshalYAML(node *yaml.Node) error {
 		*c = nil
 		return nil
 	}
+	node = dereferenceYAMLAlias(node)
 	if node.Kind != yaml.ScalarNode || node.ShortTag() != "!!str" {
 		return fmt.Errorf("command must be a string")
 	}
@@ -338,6 +339,7 @@ func (c *rawDependencyCommandSpec) UnmarshalYAML(node *yaml.Node) error {
 		*c = nil
 		return nil
 	}
+	node = dereferenceYAMLAlias(node)
 	switch node.Kind {
 	case yaml.ScalarNode:
 		if node.ShortTag() == "!!null" {
@@ -360,6 +362,13 @@ func (c *rawDependencyCommandSpec) UnmarshalYAML(node *yaml.Node) error {
 	default:
 		return fmt.Errorf("command must be a string or sequence")
 	}
+}
+
+func dereferenceYAMLAlias(node *yaml.Node) *yaml.Node {
+	for node != nil && node.Kind == yaml.AliasNode {
+		node = node.Alias
+	}
+	return node
 }
 
 func normalizeRepositoryConfig(raw *rawRepository) (RepositoryConfig, error) {

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -56,9 +56,11 @@ type rawDependencyKey struct {
 }
 
 type rawDependenciesConfig struct {
-	Command []string         `yaml:"command"`
-	Key     rawDependencyKey `yaml:"key"`
+	Command rawDependencyCommandSpec `yaml:"command"`
+	Key     rawDependencyKey         `yaml:"key"`
 }
+
+type rawDependencyCommandSpec []string
 
 type rawRunConfig struct {
 	Before rawShellCommandSpec `yaml:"before"`
@@ -329,6 +331,31 @@ func (c *rawShellCommandSpec) UnmarshalYAML(node *yaml.Node) error {
 	script := strings.TrimSpace(node.Value)
 	*c = rawShellCommandSpec{"sh", "-lc", script}
 	return nil
+}
+
+func (c *rawDependencyCommandSpec) UnmarshalYAML(node *yaml.Node) error {
+	if node == nil {
+		*c = nil
+		return nil
+	}
+	switch node.Kind {
+	case yaml.ScalarNode:
+		if node.ShortTag() != "!!str" {
+			return fmt.Errorf("command must be a string or sequence")
+		}
+		script := strings.TrimSpace(node.Value)
+		*c = rawDependencyCommandSpec{"sh", "-lc", script}
+		return nil
+	case yaml.SequenceNode:
+		var command []string
+		if err := node.Decode(&command); err != nil {
+			return err
+		}
+		*c = rawDependencyCommandSpec(command)
+		return nil
+	default:
+		return fmt.Errorf("command must be a string or sequence")
+	}
 }
 
 func normalizeRepositoryConfig(raw *rawRepository) (RepositoryConfig, error) {

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -267,6 +267,35 @@ sandbox:
 	}
 }
 
+func TestCompileAcceptsAliasedDependencyCommandSequence(t *testing.T) {
+	t.Parallel()
+
+	var raw rawPolicy
+	if err := yaml.Unmarshal([]byte(`
+version: 1
+common_cmd: &deps [mise, exec, --, go, mod, download]
+sandbox:
+  image:
+    ref: ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+  dependencies:
+    command: *deps
+    key:
+      files: [go.mod, go.sum]
+  network:
+    default: deny
+`), &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	compiled, err := Compile(raw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if got, want := compiled.Dependencies.Command, []string{"mise", "exec", "--", "go", "mod", "download"}; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("unexpected dependency command: got %v want %v", got, want)
+	}
+}
+
 func TestCompileRejectsDependencyKeyFilesWithoutCommand(t *testing.T) {
 	t.Parallel()
 

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -238,6 +238,35 @@ sandbox:
 	}
 }
 
+func TestCompileTreatsNullDependencyCommandAsUnset(t *testing.T) {
+	t.Parallel()
+
+	var raw rawPolicy
+	if err := yaml.Unmarshal([]byte(`
+version: 1
+sandbox:
+  image:
+    ref: ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+  dependencies:
+    command: null
+  network:
+    default: deny
+`), &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	compiled, err := Compile(raw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if compiled.Dependencies.Enabled() {
+		t.Fatal("expected null dependency command to disable dependency bootstrap")
+	}
+	if len(compiled.Dependencies.Command) != 0 {
+		t.Fatalf("expected null dependency command to normalize to empty, got %v", compiled.Dependencies.Command)
+	}
+}
+
 func TestCompileRejectsDependencyKeyFilesWithoutCommand(t *testing.T) {
 	t.Parallel()
 

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -207,6 +207,37 @@ func TestCompileNormalizesDependencyBootstrapConfig(t *testing.T) {
 	}
 }
 
+func TestCompileNormalizesDependencyCommandString(t *testing.T) {
+	t.Parallel()
+
+	var raw rawPolicy
+	if err := yaml.Unmarshal([]byte(`
+version: 1
+sandbox:
+  image:
+    ref: ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+  dependencies:
+    command: bundle install
+    key:
+      files: [Gemfile.lock]
+  network:
+    default: deny
+`), &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	compiled, err := Compile(raw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if got, want := compiled.Dependencies.Command, []string{"sh", "-lc", "bundle install"}; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("unexpected dependency command: got %v want %v", got, want)
+	}
+	if got, want := compiled.Dependencies.KeyFiles, []string{"Gemfile.lock"}; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("unexpected dependency key files: got %v want %v", got, want)
+	}
+}
+
 func TestCompileRejectsDependencyKeyFilesWithoutCommand(t *testing.T) {
 	t.Parallel()
 
@@ -218,6 +249,28 @@ func TestCompileRejectsDependencyKeyFilesWithoutCommand(t *testing.T) {
 		t.Fatal("expected compile to reject dependency key files without a command")
 	}
 	if !strings.Contains(err.Error(), "sandbox.dependencies.key.files") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestUnmarshalRejectsNonStringOrSequenceDependencyCommand(t *testing.T) {
+	t.Parallel()
+
+	var raw rawPolicy
+	err := yaml.Unmarshal([]byte(`
+version: 1
+sandbox:
+  image:
+    ref: ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+  dependencies:
+    command: false
+  network:
+    default: deny
+`), &raw)
+	if err == nil {
+		t.Fatal("expected unmarshal to reject non-string dependency command")
+	}
+	if !strings.Contains(err.Error(), "command must be a string or sequence") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- accept shell-string `sandbox.dependencies.command` values while preserving argv-sequence support
- switch the docs and examples to the string form as the preferred syntax
- keep the compiled and proto representation unchanged as argv

## Testing
- mise exec -- go test ./...
