### PR TITLE
refactor: introduce repository store abstraction

### DIFF
--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -22,6 +22,7 @@ import (
 	"github.com/buildkite/cleanroom/internal/endpoint"
 	"github.com/buildkite/cleanroom/internal/gateway"
 	"github.com/buildkite/cleanroom/internal/interactivequic"
+	"github.com/buildkite/cleanroom/internal/repositorystore"
 	"github.com/buildkite/cleanroom/internal/snapshotstore"
 	"github.com/charmbracelet/log"
 )
@@ -235,9 +236,9 @@ func newControlService(ctx *runtimeContext, logger *log.Logger, mirrors gateway.
 
 	if ctx == nil {
 		service := &controlservice.Service{
-			Logger:            logger,
-			RepositoryMirrors: mirrors,
-			SnapshotStore:     snapshotMetadataStore,
+			Logger:          logger,
+			RepositoryStore: repositorystore.NewMirrorBacked(mirrors),
+			SnapshotStore:   snapshotMetadataStore,
 		}
 		if cacheMetadataStore != nil {
 			service.CacheStore = cacheMetadataStore
@@ -245,13 +246,13 @@ func newControlService(ctx *runtimeContext, logger *log.Logger, mirrors gateway.
 		return service, nil
 	}
 	service := &controlservice.Service{
-		Loader:            ctx.Loader,
-		Config:            ctx.Config,
-		Backends:          ctx.Backends,
-		Logger:            logger,
-		Observability:     ctx.Observability,
-		RepositoryMirrors: mirrors,
-		SnapshotStore:     snapshotMetadataStore,
+		Loader:          ctx.Loader,
+		Config:          ctx.Config,
+		Backends:        ctx.Backends,
+		Logger:          logger,
+		Observability:   ctx.Observability,
+		RepositoryStore: repositorystore.NewMirrorBacked(mirrors),
+		SnapshotStore:   snapshotMetadataStore,
 	}
 	if cacheMetadataStore != nil {
 		service.CacheStore = cacheMetadataStore

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -140,7 +140,7 @@ func TestGatewayServerConfigUsesDarwinGatewayHostForTrustedPrefixes(t *testing.T
 		t.Fatal("expected allow-any-source fallback to be preserved in server config")
 	}
 }
-func TestNewControlServiceWiresRepositoryMirrors(t *testing.T) {
+func TestNewControlServiceWiresRepositoryStore(t *testing.T) {
 	prevSnapshotStoreFactory := newSnapshotMetadataStore
 	t.Cleanup(func() { newSnapshotMetadataStore = prevSnapshotStoreFactory })
 	newSnapshotMetadataStore = func(snapshotstore.Options) (*snapshotstore.Store, error) {
@@ -161,8 +161,8 @@ func TestNewControlServiceWiresRepositoryMirrors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newControlService returned error: %v", err)
 	}
-	if service.RepositoryMirrors != mirrors {
-		t.Fatal("expected control service to use the gateway mirror store")
+	if service.RepositoryStore == nil {
+		t.Fatal("expected control service to configure a repository store")
 	}
 }
 

--- a/internal/controlservice/dependency_stage.go
+++ b/internal/controlservice/dependency_stage.go
@@ -16,6 +16,7 @@ import (
 	"github.com/buildkite/cleanroom/internal/policy"
 	"github.com/buildkite/cleanroom/internal/repositorychangeset"
 	"github.com/buildkite/cleanroom/internal/repositorycheckout"
+	"github.com/buildkite/cleanroom/internal/repositorystore"
 )
 
 const (
@@ -96,63 +97,65 @@ func (s *Service) dependencyStageKeyFilesDigest(ctx context.Context, repository 
 	if repository == nil {
 		return "", fmt.Errorf("dependency key files require a repository checkout")
 	}
-	if s.RepositoryMirrors == nil {
-		return "", fmt.Errorf("dependency key files require repository mirrors")
+	if s.RepositoryStore == nil {
+		return "", fmt.Errorf("dependency key files require repository store")
 	}
-	mirrorPath, err := s.RepositoryMirrors.MirrorPath(repository.RemoteURL)
-	if err != nil {
-		mirrorPath, err = s.RepositoryMirrors.EnsureMirror(ctx, repository.RemoteURL)
+	if changeset != nil {
+		var digest string
+		err := s.RepositoryStore.WithRepository(ctx, repository.RemoteURL, repository.CommitSHA, repositorystore.FetchHints{}, func(repoDir string) error {
+			var err error
+			digest, err = dependencyStageKeyFilesDigestWithChangeset(repoDir, changeset, files)
+			return err
+		})
 		if err != nil {
 			return "", err
 		}
-	}
-	digest, err := dependencyStageKeyFilesDigestFromMirror(ctx, mirrorPath, repository.CommitSHA, changeset, files)
-	if err == nil {
 		return digest, nil
 	}
-	if ensureErr := s.RepositoryMirrors.EnsureMirrorContains(ctx, repository.RemoteURL, repository.CommitSHA); ensureErr != nil {
-		return "", ensureErr
-	}
-	mirrorPath, err = s.RepositoryMirrors.MirrorPath(repository.RemoteURL)
+	var digest string
+	err := s.RepositoryStore.WithRepository(ctx, repository.RemoteURL, repository.CommitSHA, repositorystore.FetchHints{}, func(repoDir string) error {
+		var err error
+		digest, err = dependencyStageKeyFilesDigestAtCommit(ctx, repoDir, repository.CommitSHA, files)
+		return err
+	})
 	if err != nil {
 		return "", err
 	}
-	return dependencyStageKeyFilesDigestFromMirror(ctx, mirrorPath, repository.CommitSHA, changeset, files)
+	return digest, nil
 }
 
-func dependencyStageKeyFilesDigestFromMirror(ctx context.Context, mirrorPath, commitSHA string, changeset *repositorychangeset.Changeset, files []string) (string, error) {
-	trimmedMirrorPath := strings.TrimSpace(mirrorPath)
+func dependencyStageKeyFilesDigestWithChangeset(repoDir string, changeset *repositorychangeset.Changeset, files []string) (string, error) {
+	manifest := make([]dependencyKeyFileDigest, 0, len(files))
+	digests, err := changeset.DigestPathsFromBase(strings.TrimSpace(repoDir), files)
+	if err != nil {
+		return "", fmt.Errorf("read dependency key files from repository changeset: %w", err)
+	}
+	for _, file := range digests {
+		manifest = append(manifest, dependencyKeyFileDigest{
+			Path:    file.Path,
+			SHA256:  file.SHA256,
+			Deleted: file.Deleted,
+		})
+	}
+
+	payload, err := json.Marshal(manifest)
+	if err != nil {
+		return "", fmt.Errorf("marshal dependency key file manifest: %w", err)
+	}
+
+	sum := sha256.Sum256(payload)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
+func dependencyStageKeyFilesDigestAtCommit(ctx context.Context, repoDir, commitSHA string, files []string) (string, error) {
 	trimmedCommitSHA := strings.TrimSpace(commitSHA)
 	if trimmedCommitSHA == "" {
 		return "", fmt.Errorf("dependency key file commit SHA is empty")
 	}
 
 	manifest := make([]dependencyKeyFileDigest, 0, len(files))
-	if changeset != nil {
-		digests, err := changeset.DigestPathsFromBase(trimmedMirrorPath, files)
-		if err != nil {
-			return "", fmt.Errorf("read dependency key files from repository changeset: %w", err)
-		}
-		for _, file := range digests {
-			manifest = append(manifest, dependencyKeyFileDigest{
-				Path:    file.Path,
-				SHA256:  file.SHA256,
-				Deleted: file.Deleted,
-			})
-		}
-		payload, err := json.Marshal(manifest)
-		if err != nil {
-			return "", fmt.Errorf("marshal dependency key file manifest: %w", err)
-		}
-
-		sum := sha256.Sum256(payload)
-		return "sha256:" + hex.EncodeToString(sum[:]), nil
-	}
 	for _, file := range files {
-		if trimmedMirrorPath == "" {
-			return "", fmt.Errorf("dependency key file mirror path is empty")
-		}
-		digest, err := gitFileDigestAtCommit(ctx, trimmedMirrorPath, trimmedCommitSHA, file)
+		digest, err := gitFileDigestAtCommit(ctx, strings.TrimSpace(repoDir), trimmedCommitSHA, file)
 		if err != nil {
 			return "", fmt.Errorf("read dependency key file %q: %w", file, err)
 		}
@@ -171,8 +174,8 @@ func dependencyStageKeyFilesDigestFromMirror(ctx context.Context, mirrorPath, co
 	return "sha256:" + hex.EncodeToString(sum[:]), nil
 }
 
-func gitFileDigestAtCommit(ctx context.Context, repoPath, commitSHA, file string) (string, error) {
-	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "show", commitSHA+":"+file)
+func gitFileDigestAtCommit(ctx context.Context, repoDir, commitSHA, file string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", "-C", repoDir, "show", commitSHA+":"+file)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		message := strings.TrimSpace(string(output))

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -19,6 +19,7 @@ import (
 	"github.com/buildkite/cleanroom/internal/paths"
 	"github.com/buildkite/cleanroom/internal/policy"
 	"github.com/buildkite/cleanroom/internal/repositorycheckout"
+	"github.com/buildkite/cleanroom/internal/repositorystore"
 	"github.com/buildkite/cleanroom/internal/runtimeconfig"
 	"github.com/buildkite/cleanroom/internal/snapshotstore"
 	"github.com/charmbracelet/log"
@@ -31,14 +32,14 @@ import (
 )
 
 type Service struct {
-	Loader            loader
-	Config            runtimeconfig.Config
-	Backends          map[string]backend.Adapter
-	Logger            *log.Logger
-	Observability     *observability.Runtime
-	RepositoryMirrors repositoryMirrorStore
-	runtime           serviceRuntime
-	interactive       interactiveSessionBroker
+	Loader          loader
+	Config          runtimeconfig.Config
+	Backends        map[string]backend.Adapter
+	Logger          *log.Logger
+	Observability   *observability.Runtime
+	RepositoryStore repositorystore.RepositoryStore
+	runtime         serviceRuntime
+	interactive     interactiveSessionBroker
 	// Snapshot lifecycle still lives on Service because it coordinates backend
 	// adapters, sandbox state, and metadata persistence in one operation chain.
 	// If this grows again, extract a dedicated snapshot manager rather than
@@ -128,12 +129,6 @@ type InteractiveSession struct {
 
 type loader interface {
 	LoadAndCompile(cwd string) (*policy.CompiledPolicy, string, error)
-}
-
-type repositoryMirrorStore interface {
-	MirrorPath(remoteURL string) (string, error)
-	EnsureMirror(ctx context.Context, remoteURL string) (string, error)
-	EnsureMirrorContains(ctx context.Context, remoteURL, commitSHA string) error
 }
 
 type snapshotMetadataStore interface {
@@ -1905,11 +1900,11 @@ func (s *Service) executionOutputStream(key string) backend.OutputStream {
 	}
 }
 
-func (s *Service) ensureRepositoryMirrorContains(ctx context.Context, repository *repositorycheckout.Checkout) error {
-	if repository == nil || s.RepositoryMirrors == nil {
+func (s *Service) ensureRepositoryCommitAvailable(ctx context.Context, repository *repositorycheckout.Checkout) error {
+	if repository == nil || s.RepositoryStore == nil {
 		return nil
 	}
-	return s.RepositoryMirrors.EnsureMirrorContains(ctx, repository.RemoteURL, repository.CommitSHA)
+	return s.RepositoryStore.EnsureCommit(ctx, repository.RemoteURL, repository.CommitSHA, repositorystore.FetchHints{})
 }
 
 func (s *Service) preparePersistentSandboxRepository(
@@ -2005,7 +2000,7 @@ func (s *Service) bootstrapRepositoryInPersistentSandbox(
 			"destination_dir", repository.DestinationDir,
 		)
 	}
-	if err := s.ensureRepositoryMirrorContains(ctx, repository); err != nil {
+	if err := s.ensureRepositoryCommitAvailable(ctx, repository); err != nil {
 		return err
 	}
 	if s.Logger != nil {

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/buildkite/cleanroom/internal/policy"
 	"github.com/buildkite/cleanroom/internal/repositorychangeset"
 	"github.com/buildkite/cleanroom/internal/repositorycheckout"
+	"github.com/buildkite/cleanroom/internal/repositorystore"
 	"github.com/buildkite/cleanroom/internal/runtimeconfig"
 	"github.com/buildkite/cleanroom/internal/snapshotstore"
 	"go.jetify.com/typeid"
@@ -172,7 +173,7 @@ type stubClock struct {
 	now time.Time
 }
 
-func (s *stubRepositoryMirrorStore) EnsureMirrorContains(_ context.Context, remoteURL, commitSHA string) error {
+func (s *stubRepositoryMirrorStore) EnsureCommit(_ context.Context, remoteURL, commitSHA string, _ repositorystore.FetchHints) error {
 	s.remoteURL = remoteURL
 	s.commitSHA = commitSHA
 	s.calls++
@@ -180,6 +181,10 @@ func (s *stubRepositoryMirrorStore) EnsureMirrorContains(_ context.Context, remo
 		return s.ensureContainsFn(remoteURL, commitSHA)
 	}
 	return s.err
+}
+
+func (s *stubRepositoryMirrorStore) EnsureMirrorContains(ctx context.Context, remoteURL, commitSHA string) error {
+	return s.EnsureCommit(ctx, remoteURL, commitSHA, repositorystore.FetchHints{})
 }
 
 func (s *stubRepositoryMirrorStore) MirrorPath(remoteURL string) (string, error) {
@@ -198,6 +203,58 @@ func (s *stubRepositoryMirrorStore) EnsureMirror(_ context.Context, remoteURL st
 		return "", s.ensureMirrorErr
 	}
 	return s.mirrorPath, nil
+}
+
+func (s *stubRepositoryMirrorStore) ReadFileAtCommit(ctx context.Context, remoteURL, commitSHA, path string) ([]byte, error) {
+	var content []byte
+	err := s.WithRepository(ctx, remoteURL, commitSHA, repositorystore.FetchHints{}, func(repoDir string) error {
+		cmd := exec.CommandContext(ctx, "git", "-C", repoDir, "show", commitSHA+":"+path)
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			message := strings.TrimSpace(string(output))
+			if message == "" {
+				message = err.Error()
+			}
+			return errors.New(message)
+		}
+		content = output
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return content, nil
+}
+
+func (s *stubRepositoryMirrorStore) WithRepository(ctx context.Context, remoteURL, commitSHA string, _ repositorystore.FetchHints, fn func(repoDir string) error) error {
+	if fn == nil {
+		return errors.New("repository callback is nil")
+	}
+	repoDir, err := s.MirrorPath(remoteURL)
+	if err != nil {
+		repoDir, err = s.EnsureMirror(ctx, remoteURL)
+		if err != nil {
+			return err
+		}
+	}
+	if err := fn(repoDir); err == nil || strings.TrimSpace(commitSHA) == "" {
+		return err
+	}
+	if err := s.EnsureCommit(ctx, remoteURL, commitSHA, repositorystore.FetchHints{}); err != nil {
+		return err
+	}
+	repoDir, err = s.MirrorPath(remoteURL)
+	if err != nil {
+		repoDir, err = s.EnsureMirror(ctx, remoteURL)
+		if err != nil {
+			return err
+		}
+	}
+	return fn(repoDir)
+}
+
+func (s *stubRepositoryMirrorStore) TransportHints(context.Context, string, string, repositorystore.FetchHints) (repositorystore.TransportHints, error) {
+	return repositorystore.TransportHints{}, nil
 }
 
 func (c stubClock) Now() time.Time {
@@ -1385,7 +1442,7 @@ func TestCreateSandboxBootstrapsRepositoryInService(t *testing.T) {
 	adapter := &stubAdapter{}
 	mirrors := &stubRepositoryMirrorStore{}
 	svc := newTestService(adapter)
-	svc.RepositoryMirrors = mirrors
+	svc.RepositoryStore = mirrors
 
 	createResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
 		Policy:             testRepositoryPolicy(),
@@ -1439,7 +1496,7 @@ func TestCreateSandboxPublishesWorkspaceStageCache(t *testing.T) {
 	}
 	mirrors := &stubRepositoryMirrorStore{}
 	svc := newTestServiceWithSnapshotStore(adapter, store)
-	svc.RepositoryMirrors = mirrors
+	svc.RepositoryStore = mirrors
 	publishedAt := time.Unix(1_700_000_123, 0).UTC()
 	svc.runtime.clock = stubClock{now: publishedAt}
 
@@ -1520,7 +1577,7 @@ func TestCreateSandboxReusesWorkspaceStageCache(t *testing.T) {
 	}
 	mirrors := &stubRepositoryMirrorStore{}
 	svc := newTestServiceWithSnapshotStore(adapter, store)
-	svc.RepositoryMirrors = mirrors
+	svc.RepositoryStore = mirrors
 
 	req := &cleanroomv1.CreateSandboxRequest{
 		Policy:             testRepositoryPolicy(),
@@ -1582,7 +1639,7 @@ func TestCreateExecutionPreservesFirstMatchingRepositoryAfterChangesetWorkspaceS
 		"README.md": "hello\n",
 	})
 	svc := newTestServiceWithSnapshotStore(adapter, store)
-	svc.RepositoryMirrors = mirrors
+	svc.RepositoryStore = mirrors
 
 	repository := repositorycheckout.FromProto(repositoryCheckout)
 	if err := os.WriteFile(filepath.Join(mirrors.mirrorPath, "README.md"), []byte("hello from changeset\n"), 0o644); err != nil {
@@ -1680,7 +1737,7 @@ func TestCreateSandboxReusesWorkspaceStageCacheForNormalizedDestinationDir(t *te
 	}
 	mirrors := &stubRepositoryMirrorStore{}
 	svc := newTestServiceWithSnapshotStore(adapter, store)
-	svc.RepositoryMirrors = mirrors
+	svc.RepositoryStore = mirrors
 
 	firstRepo := testRepositoryCheckoutProto()
 	firstRepo.DestinationDir = "/workspace/"
@@ -1718,7 +1775,7 @@ func TestCreateSandboxDoesNotReuseWorkspaceStageCacheAcrossPolicies(t *testing.T
 	}
 	mirrors := &stubRepositoryMirrorStore{}
 	svc := newTestServiceWithSnapshotStore(adapter, store)
-	svc.RepositoryMirrors = mirrors
+	svc.RepositoryStore = mirrors
 
 	firstPolicy := testRepositoryPolicy()
 	if _, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
@@ -1795,7 +1852,7 @@ func TestCreateSandboxPublishesWorkspaceStageCachePerBackend(t *testing.T) {
 	}
 	mirrors := &stubRepositoryMirrorStore{}
 	svc := newTestServiceWithSnapshotStore(firecrackerAdapter, store)
-	svc.RepositoryMirrors = mirrors
+	svc.RepositoryStore = mirrors
 	svc.Backends["darwin-vz"] = darwinAdapter
 	svc.Config.Backends.DarwinVZ.Snapshots.Enabled = true
 	svc.Config.Backends.DarwinVZ.Snapshots.Driver = "apfs"
@@ -1859,7 +1916,7 @@ func TestCreateSandboxDoesNotReuseWorkspaceStageWhenRuntimeBaseKeyChanges(t *tes
 	}
 	mirrors := &stubRepositoryMirrorStore{}
 	svc := newTestServiceWithSnapshotStore(adapter, store)
-	svc.RepositoryMirrors = mirrors
+	svc.RepositoryStore = mirrors
 
 	req := &cleanroomv1.CreateSandboxRequest{
 		Policy:             testRepositoryPolicy(),
@@ -1918,7 +1975,7 @@ func TestCreateSandboxFallsBackWhenWorkspaceStageRestoreFails(t *testing.T) {
 	}
 	mirrors := &stubRepositoryMirrorStore{}
 	svc := newTestServiceWithSnapshotStore(adapter, store)
-	svc.RepositoryMirrors = mirrors
+	svc.RepositoryStore = mirrors
 
 	req := &cleanroomv1.CreateSandboxRequest{
 		Policy:             testRepositoryPolicy(),
@@ -2093,7 +2150,7 @@ func TestCreateSandboxPublishesDependencyStageCacheForConfiguredDependencies(t *
 		"README": "ignored\n",
 	})
 	svc := newTestServiceWithSnapshotStore(adapter, store)
-	svc.RepositoryMirrors = mirrors
+	svc.RepositoryStore = mirrors
 
 	if _, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
 		Policy:             testRepositoryDependencyPolicy(),
@@ -2198,7 +2255,7 @@ func TestCreateSandboxReusesDependencyStageCacheForConfiguredDependencies(t *tes
 		"go.sum": "example.com/test v0.0.0 h1:abc123\n",
 	})
 	svc := newTestServiceWithSnapshotStore(adapter, store)
-	svc.RepositoryMirrors = mirrors
+	svc.RepositoryStore = mirrors
 
 	req := &cleanroomv1.CreateSandboxRequest{
 		Policy:             testRepositoryDependencyPolicy(),
@@ -2298,7 +2355,7 @@ func TestDependencyStageKeyFilesDigestDerivesHashesFromRepositoryChangesetPatch(
 	}
 
 	svc := newTestService(&stubAdapter{})
-	svc.RepositoryMirrors = mirrors
+	svc.RepositoryStore = mirrors
 
 	baseDigest, err := svc.dependencyStageKeyFilesDigest(context.Background(), repository, nil, []string{"go.mod", "go.sum"})
 	if err != nil {
@@ -2353,7 +2410,7 @@ func TestCreateSandboxBootstrapsDependenciesAfterWorkspaceStageRestoreWithoutDep
 	})
 	mirrors.mirrorPathErr = errors.New("mirror path unavailable")
 	svc := newTestServiceWithSnapshotStore(adapter, store)
-	svc.RepositoryMirrors = mirrors
+	svc.RepositoryStore = mirrors
 
 	compiled, err := policy.FromProto(testRepositoryDependencyPolicy())
 	if err != nil {
@@ -2460,7 +2517,7 @@ func TestCreateSandboxPublishesDependencyStageCacheWhenLocalMirrorStartsEmpty(t 
 	}
 
 	svc := newTestServiceWithSnapshotStore(adapter, store)
-	svc.RepositoryMirrors = mirrors
+	svc.RepositoryStore = mirrors
 
 	if _, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
 		Policy:             testRepositoryDependencyPolicy(),
@@ -2579,7 +2636,7 @@ func TestCreateExecutionWrapsRepositoryBootstrapInService(t *testing.T) {
 	adapter := &stubAdapter{}
 	mirrors := &stubRepositoryMirrorStore{}
 	svc := newTestService(adapter)
-	svc.RepositoryMirrors = mirrors
+	svc.RepositoryStore = mirrors
 	runCalled := make(chan struct{}, 4)
 	var (
 		mu       sync.Mutex
@@ -2654,7 +2711,7 @@ func TestCreateExecutionSkipsBootstrapForMatchingPersistentRepository(t *testing
 	adapter := &stubAdapter{}
 	mirrors := &stubRepositoryMirrorStore{}
 	svc := newTestService(adapter)
-	svc.RepositoryMirrors = mirrors
+	svc.RepositoryStore = mirrors
 
 	var (
 		mu       sync.Mutex
@@ -2723,7 +2780,7 @@ func TestCreateExecutionPreservesFirstMatchingRepositoryAfterChangesetSandboxCre
 	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
 		"README.md": "hello\n",
 	})
-	svc.RepositoryMirrors = mirrors
+	svc.RepositoryStore = mirrors
 	repository := repositorycheckout.FromProto(repositoryCheckout)
 	if err := os.WriteFile(filepath.Join(mirrors.mirrorPath, "README.md"), []byte("hello from changeset\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile(README.md) returned error: %v", err)
@@ -2804,7 +2861,7 @@ func TestCreateExecutionRebootstrapsSecondMatchingRepositoryAfterChangesetSandbo
 	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
 		"README.md": "hello\n",
 	})
-	svc.RepositoryMirrors = mirrors
+	svc.RepositoryStore = mirrors
 	repository := repositorycheckout.FromProto(repositoryCheckout)
 	if err := os.WriteFile(filepath.Join(mirrors.mirrorPath, "README.md"), []byte("hello from changeset\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile(README.md) returned error: %v", err)
@@ -2907,7 +2964,7 @@ func TestCreateExecutionSkipsBootstrapForSnapshotBackedSandboxWithMatchingReposi
 	mirrors := &stubRepositoryMirrorStore{}
 	store := newMemorySnapshotStore()
 	svc := newTestServiceWithSnapshotStore(adapter, store)
-	svc.RepositoryMirrors = mirrors
+	svc.RepositoryStore = mirrors
 
 	var (
 		mu       sync.Mutex
@@ -2996,7 +3053,7 @@ func TestCreateExecutionRebootstrapsMatchingRepositoryAfterChangesetSnapshotRest
 	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
 		"README.md": "hello\n",
 	})
-	svc.RepositoryMirrors = mirrors
+	svc.RepositoryStore = mirrors
 	repository := repositorycheckout.FromProto(repositoryCheckout)
 	if err := os.WriteFile(filepath.Join(mirrors.mirrorPath, "README.md"), []byte("hello from changeset\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile(README.md) returned error: %v", err)
@@ -3172,7 +3229,7 @@ func TestCreateExecutionRejectsRepositoryRemoteOutsidePolicy(t *testing.T) {
 	adapter := &stubAdapter{}
 	mirrors := &stubRepositoryMirrorStore{}
 	svc := newTestService(adapter)
-	svc.RepositoryMirrors = mirrors
+	svc.RepositoryStore = mirrors
 
 	createSandboxResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testRepositoryPolicy()})
 	if err != nil {

--- a/internal/repositorystore/store.go
+++ b/internal/repositorystore/store.go
@@ -1,0 +1,115 @@
+package repositorystore
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type FetchHints struct {
+	Branches []string
+	Refs     []string
+}
+
+type TransportHints struct {
+	BundleListURL string
+}
+
+type RepositoryStore interface {
+	EnsureCommit(ctx context.Context, remoteURL, commitSHA string, hints FetchHints) error
+	ReadFileAtCommit(ctx context.Context, remoteURL, commitSHA, path string) ([]byte, error)
+	WithRepository(ctx context.Context, remoteURL, commitSHA string, hints FetchHints, fn func(repoDir string) error) error
+	TransportHints(ctx context.Context, remoteURL, commitSHA string, hints FetchHints) (TransportHints, error)
+}
+
+type mirrorSource interface {
+	MirrorPath(remoteURL string) (string, error)
+	EnsureMirror(ctx context.Context, remoteURL string) (string, error)
+	EnsureMirrorContains(ctx context.Context, remoteURL, commitSHA string) error
+}
+
+type mirrorBackedRepositoryStore struct {
+	mirrors mirrorSource
+}
+
+func NewMirrorBacked(mirrors mirrorSource) RepositoryStore {
+	if mirrors == nil {
+		return nil
+	}
+	return &mirrorBackedRepositoryStore{mirrors: mirrors}
+}
+
+func (s *mirrorBackedRepositoryStore) EnsureCommit(ctx context.Context, remoteURL, commitSHA string, _ FetchHints) error {
+	if s == nil || s.mirrors == nil {
+		return fmt.Errorf("repository store is nil")
+	}
+	return s.mirrors.EnsureMirrorContains(ctx, remoteURL, commitSHA)
+}
+
+func (s *mirrorBackedRepositoryStore) ReadFileAtCommit(ctx context.Context, remoteURL, commitSHA, path string) ([]byte, error) {
+	var content []byte
+	err := s.WithRepository(ctx, remoteURL, commitSHA, FetchHints{}, func(repoDir string) error {
+		output, err := gitShowFileAtCommit(ctx, repoDir, commitSHA, path)
+		if err != nil {
+			return err
+		}
+		content = output
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return content, nil
+}
+
+func (s *mirrorBackedRepositoryStore) WithRepository(ctx context.Context, remoteURL, commitSHA string, hints FetchHints, fn func(repoDir string) error) error {
+	if s == nil || s.mirrors == nil {
+		return fmt.Errorf("repository store is nil")
+	}
+	if fn == nil {
+		return fmt.Errorf("repository callback is nil")
+	}
+	repoDir, err := s.repositoryPath(ctx, remoteURL)
+	if err != nil {
+		return err
+	}
+	if err := fn(repoDir); err == nil || strings.TrimSpace(commitSHA) == "" {
+		return err
+	}
+	if err := s.EnsureCommit(ctx, remoteURL, commitSHA, hints); err != nil {
+		return err
+	}
+	repoDir, err = s.repositoryPath(ctx, remoteURL)
+	if err != nil {
+		return err
+	}
+	return fn(repoDir)
+}
+
+func (s *mirrorBackedRepositoryStore) TransportHints(context.Context, string, string, FetchHints) (TransportHints, error) {
+	return TransportHints{}, nil
+}
+
+func (s *mirrorBackedRepositoryStore) repositoryPath(ctx context.Context, remoteURL string) (string, error) {
+	repoDir, err := s.mirrors.MirrorPath(remoteURL)
+	if err == nil {
+		return repoDir, nil
+	}
+	return s.mirrors.EnsureMirror(ctx, remoteURL)
+}
+
+func gitShowFileAtCommit(ctx context.Context, repoDir, commitSHA, path string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "git", "-C", repoDir, "show", strings.TrimSpace(commitSHA)+":"+path)
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		message := strings.TrimSpace(string(output))
+		if message == "" {
+			message = err.Error()
+		}
+		return nil, fmt.Errorf("git show %s:%s: %s", strings.TrimSpace(commitSHA), path, message)
+	}
+	return output, nil
+}

--- a/internal/repositorystore/store_test.go
+++ b/internal/repositorystore/store_test.go
@@ -1,0 +1,103 @@
+package repositorystore
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/buildkite/cleanroom/internal/gateway"
+)
+
+func TestMirrorBackedRepositoryStoreEnsureCommitFetchesRequestedCommit(t *testing.T) {
+	t.Parallel()
+
+	workDir := t.TempDir()
+	originDir := filepath.Join(t.TempDir(), "origin.git")
+
+	runGitCommand(t, "", "init", "--bare", originDir)
+	runGitCommand(t, workDir, "init")
+	runGitCommand(t, workDir, "config", "user.email", "test@example.com")
+	runGitCommand(t, workDir, "config", "user.name", "Test")
+	runGitCommand(t, workDir, "branch", "-M", "main")
+	if err := os.WriteFile(filepath.Join(workDir, "README.md"), []byte("one\n"), 0o644); err != nil {
+		t.Fatalf("write README.md: %v", err)
+	}
+	runGitCommand(t, workDir, "add", "README.md")
+	runGitCommand(t, workDir, "commit", "-m", "initial")
+	runGitCommand(t, workDir, "remote", "add", "origin", originDir)
+	runGitCommand(t, workDir, "push", "-u", "origin", "main")
+
+	mirrors := gateway.NewGitMirrorStore(t.TempDir(), time.Hour, nil)
+	store := NewMirrorBacked(mirrors)
+
+	if err := os.WriteFile(filepath.Join(workDir, "README.md"), []byte("two\n"), 0o644); err != nil {
+		t.Fatalf("write README.md: %v", err)
+	}
+	runGitCommand(t, workDir, "add", "README.md")
+	runGitCommand(t, workDir, "commit", "-m", "second")
+	runGitCommand(t, workDir, "push", "origin", "main")
+	head := strings.TrimSpace(runGitCommand(t, workDir, "rev-parse", "HEAD"))
+
+	if err := store.EnsureCommit(context.Background(), "file://"+originDir, head, FetchHints{}); err != nil {
+		t.Fatalf("ensure commit: %v", err)
+	}
+
+	if err := store.WithRepository(context.Background(), "file://"+originDir, head, FetchHints{}, func(repoDir string) error {
+		got := strings.TrimSpace(runGitCommand(t, repoDir, "rev-parse", "refs/heads/main"))
+		if got != head {
+			t.Fatalf("unexpected mirror head: got %q want %q", got, head)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("with repository: %v", err)
+	}
+}
+
+func TestMirrorBackedRepositoryStoreReadFileAtCommit(t *testing.T) {
+	t.Parallel()
+
+	workDir := t.TempDir()
+	originDir := filepath.Join(t.TempDir(), "origin.git")
+
+	runGitCommand(t, "", "init", "--bare", originDir)
+	runGitCommand(t, workDir, "init")
+	runGitCommand(t, workDir, "config", "user.email", "test@example.com")
+	runGitCommand(t, workDir, "config", "user.name", "Test")
+	runGitCommand(t, workDir, "branch", "-M", "main")
+	if err := os.WriteFile(filepath.Join(workDir, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("write README.md: %v", err)
+	}
+	runGitCommand(t, workDir, "add", "README.md")
+	runGitCommand(t, workDir, "commit", "-m", "initial")
+	runGitCommand(t, workDir, "remote", "add", "origin", originDir)
+	runGitCommand(t, workDir, "push", "-u", "origin", "main")
+	head := strings.TrimSpace(runGitCommand(t, workDir, "rev-parse", "HEAD"))
+
+	store := NewMirrorBacked(gateway.NewGitMirrorStore(t.TempDir(), 0, nil))
+	content, err := store.ReadFileAtCommit(context.Background(), "file://"+originDir, head, "README.md")
+	if err != nil {
+		t.Fatalf("read file at commit: %v", err)
+	}
+	if got, want := string(content), "hello\n"; got != want {
+		t.Fatalf("unexpected file content: got %q want %q", got, want)
+	}
+}
+
+func runGitCommand(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+
+	cmd := exec.Command("git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return string(out)
+}


### PR DESCRIPTION
## Summary
- introduce a `RepositoryStore` abstraction in controlservice and back it with the existing mirror store
- move dependency-stage key file resolution onto `RepositoryStore` while keeping the current optimistic local-repo behavior
- add repository-store tests and update service wiring tests for the new abstraction
