### PR TITLE
feat: Add RubyGems cache support and Rails example

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ Agent sandboxing tools are [proliferating fast](docs/research.md). Most focus on
 
 **Self-hosted.** Runs on your infrastructure. Your code and data never leave your machines.
 
-**Credentials stay on the host.** A [host-side gateway](docs/gateway.md) rewrites git traffic through Cleanroom-owned routes and keeps upstream credentials on the host side of the boundary. The same gateway now embeds `content-cache` for cache-backed git and OCI handling.
+**Credentials stay on the host.** A [host-side gateway](docs/gateway.md) rewrites git traffic through Cleanroom-owned routes and keeps upstream credentials on the host side of the boundary. The same gateway now embeds `content-cache` for cache-backed git, OCI, and RubyGems handling.
 
 **Standard OCI images.** Use any OCI image from any registry as your sandbox base. Digest-pinned in policy for reproducibility. No custom VM image format or vendor-specific base images. Same image works across backends.
 
 **Docker inside the sandbox.** Enable a guest Docker daemon with a single policy flag (`services.docker.required: true`). Build and run containers inside the microVM.
 
-**Coming soon:** guest-side package-manager rewrites with lockfile enforcement, broader Docker pull caching, hermetic offline build flows, and richer audit surfaces. See the [spec](docs/spec.md) for the full roadmap.
+**Coming soon:** broader guest-side package-manager rewrites with lockfile enforcement, broader Docker pull caching, hermetic offline build flows, and richer audit surfaces. See the [spec](docs/spec.md) for the full roadmap.
 
 ## Install
 

--- a/cmd/cleanroom-guest-agent/main.go
+++ b/cmd/cleanroom-guest-agent/main.go
@@ -12,10 +12,12 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 	"unsafe"
 
+	"github.com/buildkite/cleanroom/internal/gateway"
 	"github.com/buildkite/cleanroom/internal/vsockexec"
 	"github.com/creack/pty"
 	"github.com/mdlayher/vsock"
@@ -90,7 +92,11 @@ func handleConnTTY(conn io.ReadWriteCloser, dec *json.Decoder, req vsockexec.Exe
 	if req.Dir != "" {
 		cmd.Dir = req.Dir
 	}
-	env := buildCommandEnv(req.Env)
+	env, err := buildCommandEnv(req.Env)
+	if err != nil {
+		sendErrorResponse(conn, err)
+		return
+	}
 	if !envHasKey(env, "TERM") {
 		env = append(env, "TERM=xterm-256color")
 	}
@@ -120,7 +126,12 @@ func handleConnPipes(conn io.ReadWriteCloser, dec *json.Decoder, req vsockexec.E
 	if req.Dir != "" {
 		cmd.Dir = req.Dir
 	}
-	cmd.Env = buildCommandEnv(req.Env)
+	env, err := buildCommandEnv(req.Env)
+	if err != nil {
+		sendErrorResponse(conn, err)
+		return
+	}
+	cmd.Env = env
 
 	stdinPipe, err := cmd.StdinPipe()
 	if err != nil {
@@ -285,7 +296,7 @@ func (w streamFrameWriter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-func buildCommandEnv(requestEnv []string) []string {
+func buildCommandEnv(requestEnv []string) ([]string, error) {
 	// Start from the current process environment so caller-provided values can
 	// override, while ensuring we have baseline HOME/PATH defaults for lookups.
 	base := map[string]string{}
@@ -309,6 +320,10 @@ func buildCommandEnv(requestEnv []string) []string {
 		base[key] = value
 	}
 
+	if err := configureBundlerMirror(base); err != nil {
+		return nil, err
+	}
+
 	if strings.TrimSpace(base["HOME"]) == "" {
 		base["HOME"] = "/root"
 	}
@@ -320,7 +335,41 @@ func buildCommandEnv(requestEnv []string) []string {
 	for key, value := range base {
 		out = append(out, key+"="+value)
 	}
-	return out
+	return out, nil
+}
+
+func configureBundlerMirror(base map[string]string) error {
+	if base == nil {
+		return nil
+	}
+
+	mirror := strings.TrimSpace(base[gateway.BundlerRubyGemsMirrorEnvKey])
+	if mirror == "" {
+		delete(base, gateway.BundlerRubyGemsMirrorEnvKey)
+		delete(base, gateway.BundlerRubyGemsFallbackTimeoutEnvKey)
+		return nil
+	}
+
+	timeout := strings.TrimSpace(base[gateway.BundlerRubyGemsFallbackTimeoutEnvKey])
+	configDir := strings.TrimSpace(base[gateway.BundlerAppConfigEnvKey])
+	if configDir == "" {
+		configDir = gateway.BundlerAppConfigPath
+		base[gateway.BundlerAppConfigEnvKey] = configDir
+	}
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		return fmt.Errorf("create Bundler config dir: %w", err)
+	}
+	configContent := fmt.Sprintf(
+		"---\nBUNDLE_MIRROR__HTTPS://RUBYGEMS__ORG/: %q\nBUNDLE_MIRROR__HTTPS://RUBYGEMS__ORG/__FALLBACK_TIMEOUT: %q\n",
+		mirror,
+		timeout,
+	)
+	if err := os.WriteFile(filepath.Join(configDir, "config"), []byte(configContent), 0o644); err != nil {
+		return fmt.Errorf("write Bundler config: %w", err)
+	}
+	delete(base, gateway.BundlerRubyGemsMirrorEnvKey)
+	delete(base, gateway.BundlerRubyGemsFallbackTimeoutEnvKey)
+	return nil
 }
 
 func errorsIsClosed(err error) bool {

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -18,6 +18,7 @@ Inside sandboxes, the shared gateway is exposed at
 |------|--------|---------|
 | `/git/` | Implemented | Cache-backed Git smart-HTTP route. `.git` remotes use embedded `content-cache`; non-cacheable paths fall back to Cleanroom's mirror-backed proxy. |
 | `/registry/` | Implemented | Cache-backed OCI Distribution route for allowlisted registries. |
+| `/rubygems/` | Implemented | Cache-backed RubyGems route for Bundler mirror traffic to `rubygems.org`. |
 | `/secrets/` | Reserved | Not implemented yet. |
 | `/meta/` | Reserved | Not implemented yet. |
 
@@ -84,6 +85,26 @@ Not wired yet:
 - guest-wide package-manager rewrites to `/registry/`
 - lockfile enforcement
 - non-OCI package-manager protocol handling
+
+## RubyGems route
+
+`/rubygems/` is backed by `content-cache`'s RubyGems handler. It serves the
+RubyGems Compact Index (`/versions`, `/info/<gem>`, `/names`), legacy specs
+metadata, and gem downloads while applying the sandbox allowlist to the
+upstream `rubygems.org` host before any upstream request is made.
+
+Current scope:
+
+- Bundler mirror traffic for the default `https://rubygems.org` source
+- Compact Index, legacy specs, and gem download requests
+- guest-side Bundler mirror environment injection when `rubygems.org` is
+  allowlisted
+
+Not wired yet:
+
+- generic `gem sources` rewrites for arbitrary RubyGems registries
+- lockfile enforcement
+- private RubyGems registry authentication flows
 
 ## Credentials
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -355,7 +355,7 @@ All runtime launch behavior is initiated by control-plane API calls (for example
 
 ### 6.2 Host gateway
 
-Cleanroom runs a single shared host gateway process that provides mediated access to external services for sandboxes on the host. The current implementation serves Git and OCI registry routes today, while keeping secret and metadata routes reserved for follow-up work. Sandbox identity is derived from the network transport layer, not bearer tokens.
+Cleanroom runs a single shared host gateway process that provides mediated access to external services for sandboxes on the host. The current implementation serves Git, OCI registry, and RubyGems routes today, while keeping secret and metadata routes reserved for follow-up work. Sandbox identity is derived from the network transport layer, not bearer tokens.
 
 #### 6.2.1 Transport and sandbox identity
 
@@ -363,7 +363,7 @@ The gateway uses TAP-network TCP rather than `AF_VSOCK` for guest-to-host servic
 
 Each sandbox is provisioned with a unique TAP device and a unique guest IP. The host gateway identifies the calling sandbox by mapping the source IP of incoming connections to the registered sandbox and its `CompiledPolicy`.
 
-- The gateway listens on a small fixed set of host ports (or a single port with path-prefix routing for `/git/`, `/registry/`, `/secrets/`, `/meta/`).
+- The gateway listens on a small fixed set of host ports (or a single port with path-prefix routing for `/git/`, `/registry/`, `/rubygems/`, `/secrets/`, `/meta/`).
 - Sandbox identity is resolved from the connection source IP. No tokens, API keys, or path-embedded credentials are used for sandbox identification.
 - The gateway maintains a registry of `(guestIP → sandboxID → CompiledPolicy)` populated at sandbox creation and removed at teardown.
 - The guest discovers the gateway via its host-side TAP IP on well-known ports, injected into the command environment (for example `GIT_CONFIG_GLOBAL`, `HTTP_PROXY`, or equivalent per-service environment variables).
@@ -399,9 +399,12 @@ These rules are installed during sandbox network setup and torn down during clea
 - The gateway exposes a `/registry/` route backed by embedded `content-cache` OCI handlers.
 - The gateway resolves a registry prefix from the request path, maps it to an upstream registry URL, and applies the sandbox allowlist against the mapped policy host and port before forwarding upstream.
 - Current route scope is OCI pull-style `GET` and `HEAD` traffic.
+- The gateway also exposes a `/rubygems/` route backed by embedded `content-cache` RubyGems handlers for Bundler mirror traffic to `rubygems.org`.
+- Current RubyGems scope includes Compact Index metadata, legacy specs metadata, and gem downloads.
 - Unsupported registry requests are denied with explicit audit reason (`registry_not_allowed`) or route-specific validation errors.
 - Future work:
   - guest-side package-manager rewrites through `/registry/`
+  - broader guest-side RubyGems source rewrites beyond the default Bundler mirror path
   - lockfile enforcement
   - broader non-OCI package-manager protocol support
   - optional metadata signing/validation hooks
@@ -617,7 +620,7 @@ Minimum v1 codes:
 ## 13) Acceptance criteria (v1)
 1. A repo policy can be checked in and parsed by default.
 2. Running `cleanroom exec [--] <command>` creates a sandbox where unlisted hosts are unreachable.
-3. Gateway-mediated Git and OCI registry fetches work only through cache-backed routes and allowed destinations.
+3. Gateway-mediated Git, OCI registry, and RubyGems fetches work only through cache-backed routes and allowed destinations.
 4. Unsupported destination attempts are denied and logged.
 5. Lockfile-enabled registries block undeclared package artifacts by default.
 6. Git clones are rewritten to cached smart-HTTP endpoints and private clone auth is provided without plaintext exposure.

--- a/examples/rails/README.md
+++ b/examples/rails/README.md
@@ -1,0 +1,76 @@
+# Rails Example
+
+Runs a targeted `rails/rails` component test inside a Cleanroom sandbox with a
+deny-by-default network policy, dependency-stage `bundle install`, and the
+embedded RubyGems content-cache route.
+
+## Prerequisites
+
+Install Cleanroom from this checkout:
+
+```bash
+mise run install
+```
+
+Pull the Debian Ruby base image used by the example:
+
+```bash
+cleanroom image pull ghcr.io/buildkite/cleanroom-base/debian-ruby@sha256:cba9876d67beb8971e791f1bc6af175f0bff47e938f955059813c4dd6914eb53
+```
+
+Give the guest enough memory and disk for the first Rails bundle:
+
+```yaml
+# ~/.config/cleanroom/config.yaml
+backends:
+  darwin-vz:
+    memory_mib: 4096
+    minimum_rootfs_bytes: 14GiB
+```
+
+## Usage
+
+Run from this directory with a `cleanroom serve` instance running:
+
+```bash
+# Validate the policy
+cleanroom policy validate
+
+# Start the control plane if it is not already running
+cleanroom serve &
+
+# Run a small Rails component test
+cleanroom exec \
+  --backend darwin-vz \
+  --repo-url https://github.com/rails/rails.git \
+  --repo-commit cfa4e1b475472c7980a42dd810f237951db5108a \
+  -- sh -lc 'cd activesupport && bin/test test/benchmarkable_test.rb'
+```
+
+## What this exercises
+
+- `sandbox.dependencies.command` fills the remaining guest package gap
+  (`default-libmysqlclient-dev`, `libxml2-dev`) and runs a full `bundle install`
+- Bundler mirror env injection rewrites the default `https://rubygems.org`
+  source through Cleanroom's `/rubygems/` gateway route
+- the dependency stage is keyed on `Gemfile`, `Gemfile.lock`, and the component
+  gemspecs Rails uses from the monorepo
+
+## Network allow list
+
+The example policy allows only the hosts needed for the Rails checkout,
+Debian package bootstrap, and RubyGems resolution:
+
+| Host | Ports | Why |
+|---|---|---|
+| `github.com` | `443` | fetch the `rails/rails` repository |
+| `rubygems.org` | `443` | upstream host validated by the embedded RubyGems cache |
+| `deb.debian.org` | `80` | `apt-get` bootstrap for native gem build dependencies |
+
+## Notes
+
+- The first run is slow because it installs `default-libmysqlclient-dev` and
+  `libxml2-dev`, installs Bundler 4 from the Rails lockfile, and resolves the
+  full Rails bundle
+- The targeted `activesupport` test avoids database services while still
+  proving that bundle install completed successfully

--- a/examples/rails/cleanroom.yaml
+++ b/examples/rails/cleanroom.yaml
@@ -1,0 +1,43 @@
+version: 1
+repository:
+  enabled: false
+sandbox:
+  image:
+    ref: ghcr.io/buildkite/cleanroom-base/debian-ruby@sha256:cba9876d67beb8971e791f1bc6af175f0bff47e938f955059813c4dd6914eb53
+  dependencies:
+    command:
+      - sh
+      - -lc
+      - >-
+        apt-get update &&
+        apt-get install --yes --no-install-recommends
+        default-libmysqlclient-dev
+        libxml2-dev
+        &&
+        bundle install --jobs 4 --retry 1
+    key:
+      files:
+        - Gemfile
+        - Gemfile.lock
+        - rails.gemspec
+        - actioncable/actioncable.gemspec
+        - actionmailbox/actionmailbox.gemspec
+        - actionmailer/actionmailer.gemspec
+        - actionpack/actionpack.gemspec
+        - actiontext/actiontext.gemspec
+        - actionview/actionview.gemspec
+        - activejob/activejob.gemspec
+        - activemodel/activemodel.gemspec
+        - activerecord/activerecord.gemspec
+        - activestorage/activestorage.gemspec
+        - activesupport/activesupport.gemspec
+        - railties/railties.gemspec
+  network:
+    default: deny
+    allow:
+      - host: github.com
+        ports: [443]
+      - host: rubygems.org
+        ports: [443]
+      - host: deb.debian.org
+        ports: [80]

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	connectrpc.com/connect v1.18.1
 	connectrpc.com/otelconnect v0.9.0
 	github.com/alecthomas/kong v1.14.0
-	github.com/buildkite/content-cache v1.2.1-0.20260412020222-74c445fc3ea0
+	github.com/buildkite/content-cache v1.2.1-0.20260419015425-0213634165a8
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/log v0.4.2
 	github.com/containers/gvisor-tap-vsock v0.8.7

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,8 @@ github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx2
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0BsqsP2LwDJ9aOkm/6J86V6lyAXCoQWGw3K50=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
-github.com/buildkite/content-cache v1.2.1-0.20260412020222-74c445fc3ea0 h1:XbOvVYQBz8mpvvow/n72Fir4/JuUV+2qnCRSaHjJZUg=
-github.com/buildkite/content-cache v1.2.1-0.20260412020222-74c445fc3ea0/go.mod h1:d7Lt3s9kd1HNsH8bI3YzpU+23gfZG6wXgU73tyYCfsE=
+github.com/buildkite/content-cache v1.2.1-0.20260419015425-0213634165a8 h1:3aaeREJnohqW0/Tl2J+sdhDYEA5NPimuw0/ymjpP22s=
+github.com/buildkite/content-cache v1.2.1-0.20260419015425-0213634165a8/go.mod h1:d7Lt3s9kd1HNsH8bI3YzpU+23gfZG6wXgU73tyYCfsE=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/images/Dockerfile.base-image-debian-ruby
+++ b/images/Dockerfile.base-image-debian-ruby
@@ -8,6 +8,7 @@ RUN apt-get update \
       build-essential \
       ca-certificates \
       curl \
+      default-libmysqlclient-dev \
       git \
       iproute2 \
       libffi-dev \
@@ -15,6 +16,7 @@ RUN apt-get update \
       libncurses-dev \
       libpq-dev \
       libreadline-dev \
+      libxml2-dev \
       libsqlite3-dev \
       libssl-dev \
       libyaml-dev \

--- a/images/dockerfiles_test.go
+++ b/images/dockerfiles_test.go
@@ -116,6 +116,30 @@ func TestDebianPublishedBaseImagesInstallIPRoute2(t *testing.T) {
 	}
 }
 
+func TestDebianRubyBaseImageInstallsLibXML2Dev(t *testing.T) {
+	t.Parallel()
+
+	raw, err := os.ReadFile(filepath.Join(".", "Dockerfile.base-image-debian-ruby"))
+	if err != nil {
+		t.Fatalf("read Dockerfile.base-image-debian-ruby: %v", err)
+	}
+	if !dockerfileHasTrimmedLine(string(raw), "libxml2-dev \\") {
+		t.Fatal("Dockerfile.base-image-debian-ruby does not install libxml2-dev for native Ruby gem builds")
+	}
+}
+
+func TestDebianRubyBaseImageInstallsDefaultLibMySQLClientDev(t *testing.T) {
+	t.Parallel()
+
+	raw, err := os.ReadFile(filepath.Join(".", "Dockerfile.base-image-debian-ruby"))
+	if err != nil {
+		t.Fatalf("read Dockerfile.base-image-debian-ruby: %v", err)
+	}
+	if !dockerfileHasTrimmedLine(string(raw), "default-libmysqlclient-dev \\") {
+		t.Fatal("Dockerfile.base-image-debian-ruby does not install default-libmysqlclient-dev for mysql2 native gem builds")
+	}
+}
+
 func TestPublishedBaseImagesInstallPinnedMiseRelease(t *testing.T) {
 	t.Parallel()
 

--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -67,6 +67,7 @@ type Adapter struct {
 	GatewayRegistry  gatewayRegistry
 	GatewayPort      int
 	GatewayBridgeURL string
+	GatewayRoutes    gateway.ProxyRoutes
 
 	ConfiguredNetworkMode string
 }
@@ -982,7 +983,7 @@ func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream 
 		if startedVM.NetworkMetadata != nil {
 			networkMode = startedVM.NetworkMetadata.Mode
 		}
-		guestReq.Env = append(guestReq.Env, gatewayGitProxyEnvVars(req.Policy, networkMode, gwPort)...)
+		guestReq.Env = append(guestReq.Env, gatewayGitProxyEnvVars(req.Policy, networkMode, gwPort, a.GatewayRoutes)...)
 	}
 	seed := make([]byte, 64)
 	if _, err := cryptorand.Read(seed); err == nil {
@@ -1445,7 +1446,7 @@ func (a *Adapter) executeInSandbox(bootCtx context.Context, runCtx context.Conte
 		if instance.NetworkMetadata != nil {
 			networkMode = instance.NetworkMetadata.Mode
 		}
-		guestReq.Env = append(guestReq.Env, gatewayGitProxyEnvVars(policy, networkMode, gwPort)...)
+		guestReq.Env = append(guestReq.Env, gatewayGitProxyEnvVars(policy, networkMode, gwPort, a.GatewayRoutes)...)
 	}
 	seed := make([]byte, 64)
 	if _, err := cryptorand.Read(seed); err == nil {

--- a/internal/backend/darwinvz/backend_unsupported.go
+++ b/internal/backend/darwinvz/backend_unsupported.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 
 	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/gateway"
 	"github.com/buildkite/cleanroom/internal/policy"
 )
 
@@ -15,6 +16,7 @@ type Adapter struct {
 	GatewayRegistry  gatewayRegistry
 	GatewayPort      int
 	GatewayBridgeURL string
+	GatewayRoutes    gateway.ProxyRoutes
 
 	ConfiguredNetworkMode string
 }

--- a/internal/backend/darwinvz/gateway_env.go
+++ b/internal/backend/darwinvz/gateway_env.go
@@ -12,14 +12,14 @@ type gatewayRegistry interface {
 	ReleaseScopeToken(scopeToken string)
 }
 
-func gatewayGitProxyEnvVars(compiled *policy.CompiledPolicy, networkMode string, gatewayPort int) []string {
+func gatewayGitProxyEnvVars(compiled *policy.CompiledPolicy, networkMode string, gatewayPort int, routes gateway.ProxyRoutes) []string {
 	if darwinVZConfiguredOrDefaultNetworkMode(networkMode) != darwinVZNetworkModeFileHandle {
 		// darwin-vz only supports the file-handle guest gateway path.
 		return nil
 	}
-	return gatewayEnvVars(compiled, gatewayPort, "")
+	return gatewayEnvVars(compiled, gatewayPort, "", routes)
 }
 
-func gatewayEnvVars(compiled *policy.CompiledPolicy, gatewayPort int, scopeToken string) []string {
-	return gateway.ProxyEnvVars(compiled, gatewayPort, scopeToken)
+func gatewayEnvVars(compiled *policy.CompiledPolicy, gatewayPort int, scopeToken string, routes gateway.ProxyRoutes) []string {
+	return gateway.ProxyEnvVars(compiled, gatewayPort, scopeToken, routes)
 }

--- a/internal/backend/darwinvz/gateway_env.go
+++ b/internal/backend/darwinvz/gateway_env.go
@@ -1,8 +1,6 @@
 package darwinvz
 
 import (
-	"strings"
-
 	"github.com/buildkite/cleanroom/internal/gateway"
 	"github.com/buildkite/cleanroom/internal/policy"
 )
@@ -15,7 +13,7 @@ type gatewayRegistry interface {
 }
 
 func gatewayGitProxyEnvVars(compiled *policy.CompiledPolicy, networkMode string, gatewayPort int) []string {
-	if !strings.EqualFold(strings.TrimSpace(networkMode), darwinVZNetworkModeFileHandle) {
+	if darwinVZConfiguredOrDefaultNetworkMode(networkMode) != darwinVZNetworkModeFileHandle {
 		// darwin-vz only supports the file-handle guest gateway path.
 		return nil
 	}
@@ -23,5 +21,5 @@ func gatewayGitProxyEnvVars(compiled *policy.CompiledPolicy, networkMode string,
 }
 
 func gatewayEnvVars(compiled *policy.CompiledPolicy, gatewayPort int, scopeToken string) []string {
-	return gateway.GitProxyEnvVars(compiled, gatewayPort, scopeToken)
+	return gateway.ProxyEnvVars(compiled, gatewayPort, scopeToken)
 }

--- a/internal/backend/darwinvz/gateway_env_test.go
+++ b/internal/backend/darwinvz/gateway_env_test.go
@@ -29,6 +29,42 @@ func TestGatewayEnvVarsNoHTTPSHosts(t *testing.T) {
 	}
 }
 
+func TestGatewayEnvVarsAddsRubyGemsMirror(t *testing.T) {
+	t.Parallel()
+
+	p := &policy.CompiledPolicy{
+		Version:        1,
+		NetworkDefault: "deny",
+		Allow:          []policy.AllowRule{{Host: "rubygems.org", Ports: []int{443}}},
+	}
+	env := gatewayEnvVars(p, 8170, "token")
+	wantAppConfig := gateway.BundlerAppConfigEnvKey + "=" + gateway.BundlerAppConfigPath
+	wantMirror := gateway.BundlerRubyGemsMirrorEnvKey + "=http://" + gateway.GuestGatewayHostname + ":8170/rubygems/"
+	foundAppConfig := false
+	foundMirror := false
+	foundFallback := false
+	for _, entry := range env {
+		if entry == wantAppConfig {
+			foundAppConfig = true
+		}
+		if entry == wantMirror {
+			foundMirror = true
+		}
+		if entry == gateway.BundlerRubyGemsFallbackTimeoutEnvKey+"=0" {
+			foundFallback = true
+		}
+	}
+	if !foundAppConfig {
+		t.Fatalf("expected Bundler app config env %q in %v", wantAppConfig, env)
+	}
+	if !foundMirror {
+		t.Fatalf("expected rubyGems mirror env %q in %v", wantMirror, env)
+	}
+	if !foundFallback {
+		t.Fatalf("expected RubyGems fallback timeout env in %v", env)
+	}
+}
+
 func TestGatewayEnvVarsGeneratesGitRewriteAndHeader(t *testing.T) {
 	t.Parallel()
 	p := &policy.CompiledPolicy{
@@ -87,6 +123,36 @@ func TestGatewayGitProxyEnvVarsUsesFileHandleGatewayWithoutHeader(t *testing.T) 
 	}
 	if env[2] != "GIT_CONFIG_VALUE_0=https://github.com/" {
 		t.Fatalf("expected github rewrite value, got %s", env[2])
+	}
+}
+
+func TestGatewayGitProxyEnvVarsDefaultsEmptyModeToFileHandle(t *testing.T) {
+	t.Parallel()
+
+	p := &policy.CompiledPolicy{
+		Version:        1,
+		NetworkDefault: "deny",
+		Allow:          []policy.AllowRule{{Host: "rubygems.org", Ports: []int{443}}},
+	}
+	env := gatewayGitProxyEnvVars(p, "", 8170)
+	wantAppConfig := gateway.BundlerAppConfigEnvKey + "=" + gateway.BundlerAppConfigPath
+	wantMirror := gateway.BundlerRubyGemsMirrorEnvKey + "=http://" + gateway.GuestGatewayHostname + ":8170/rubygems/"
+	foundAppConfig := false
+	foundMirror := false
+	for _, entry := range env {
+		if entry == wantAppConfig {
+			foundAppConfig = true
+		}
+		if entry == wantMirror {
+			foundMirror = true
+			break
+		}
+	}
+	if !foundAppConfig {
+		t.Fatalf("expected Bundler app config env %q in %v", wantAppConfig, env)
+	}
+	if !foundMirror {
+		t.Fatalf("expected rubyGems mirror env %q in %v", wantMirror, env)
 	}
 }
 

--- a/internal/backend/darwinvz/gateway_env_test.go
+++ b/internal/backend/darwinvz/gateway_env_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestGatewayEnvVarsNilPolicy(t *testing.T) {
 	t.Parallel()
-	env := gatewayEnvVars(nil, 8170, "token")
+	env := gatewayEnvVars(nil, 8170, "token", gateway.ProxyRoutes{RubyGems: true})
 	if env != nil {
 		t.Fatalf("expected nil env for nil policy, got %v", env)
 	}
@@ -23,7 +23,7 @@ func TestGatewayEnvVarsNoHTTPSHosts(t *testing.T) {
 		NetworkDefault: "deny",
 		Allow:          []policy.AllowRule{{Host: "example.com", Ports: []int{80}}},
 	}
-	env := gatewayEnvVars(p, 8170, "token")
+	env := gatewayEnvVars(p, 8170, "token", gateway.ProxyRoutes{RubyGems: true})
 	if env != nil {
 		t.Fatalf("expected nil env without port 443 hosts, got %v", env)
 	}
@@ -37,7 +37,7 @@ func TestGatewayEnvVarsAddsRubyGemsMirror(t *testing.T) {
 		NetworkDefault: "deny",
 		Allow:          []policy.AllowRule{{Host: "rubygems.org", Ports: []int{443}}},
 	}
-	env := gatewayEnvVars(p, 8170, "token")
+	env := gatewayEnvVars(p, 8170, "token", gateway.ProxyRoutes{RubyGems: true})
 	wantAppConfig := gateway.BundlerAppConfigEnvKey + "=" + gateway.BundlerAppConfigPath
 	wantMirror := gateway.BundlerRubyGemsMirrorEnvKey + "=http://" + gateway.GuestGatewayHostname + ":8170/rubygems/"
 	foundAppConfig := false
@@ -65,6 +65,29 @@ func TestGatewayEnvVarsAddsRubyGemsMirror(t *testing.T) {
 	}
 }
 
+func TestGatewayEnvVarsSkipsRubyGemsMirrorWithoutLiveRoute(t *testing.T) {
+	t.Parallel()
+
+	p := &policy.CompiledPolicy{
+		Version:        1,
+		NetworkDefault: "deny",
+		Allow:          []policy.AllowRule{{Host: "rubygems.org", Ports: []int{443}}},
+	}
+
+	env := gatewayEnvVars(p, 8170, "token", gateway.ProxyRoutes{})
+	for _, entry := range env {
+		if entry == gateway.BundlerAppConfigEnvKey+"="+gateway.BundlerAppConfigPath {
+			t.Fatalf("did not expect bundler app config env without live rubygems route, got %v", env)
+		}
+		if entry == gateway.BundlerRubyGemsFallbackTimeoutEnvKey+"=0" {
+			t.Fatalf("did not expect bundler fallback timeout env without live rubygems route, got %v", env)
+		}
+		if entry == gateway.BundlerRubyGemsMirrorEnvKey+"=http://"+gateway.GuestGatewayHostname+":8170/rubygems/" {
+			t.Fatalf("did not expect rubygems mirror env without live rubygems route, got %v", env)
+		}
+	}
+}
+
 func TestGatewayEnvVarsGeneratesGitRewriteAndHeader(t *testing.T) {
 	t.Parallel()
 	p := &policy.CompiledPolicy{
@@ -75,7 +98,7 @@ func TestGatewayEnvVarsGeneratesGitRewriteAndHeader(t *testing.T) {
 			{Host: "gitlab.com", Ports: []int{443}},
 		},
 	}
-	env := gatewayEnvVars(p, 8170, "scope-token")
+	env := gatewayEnvVars(p, 8170, "scope-token", gateway.ProxyRoutes{})
 	if len(env) != 7 {
 		t.Fatalf("expected 7 env vars (count + 3 key/value entries), got %d: %v", len(env), env)
 	}
@@ -111,7 +134,7 @@ func TestGatewayGitProxyEnvVarsUsesFileHandleGatewayWithoutHeader(t *testing.T) 
 		NetworkDefault: "deny",
 		Allow:          []policy.AllowRule{{Host: "github.com", Ports: []int{443}}},
 	}
-	env := gatewayGitProxyEnvVars(p, darwinVZNetworkModeFileHandle, 8170)
+	env := gatewayGitProxyEnvVars(p, darwinVZNetworkModeFileHandle, 8170, gateway.ProxyRoutes{})
 	if len(env) != 3 {
 		t.Fatalf("expected 3 env vars (count + 1 key/value entry), got %d: %v", len(env), env)
 	}
@@ -134,7 +157,7 @@ func TestGatewayGitProxyEnvVarsDefaultsEmptyModeToFileHandle(t *testing.T) {
 		NetworkDefault: "deny",
 		Allow:          []policy.AllowRule{{Host: "rubygems.org", Ports: []int{443}}},
 	}
-	env := gatewayGitProxyEnvVars(p, "", 8170)
+	env := gatewayGitProxyEnvVars(p, "", 8170, gateway.ProxyRoutes{RubyGems: true})
 	wantAppConfig := gateway.BundlerAppConfigEnvKey + "=" + gateway.BundlerAppConfigPath
 	wantMirror := gateway.BundlerRubyGemsMirrorEnvKey + "=http://" + gateway.GuestGatewayHostname + ":8170/rubygems/"
 	foundAppConfig := false
@@ -169,7 +192,7 @@ func TestGatewayGitProxyEnvVarsSkipsNonFileHandleModes(t *testing.T) {
 		networkMode := networkMode
 		t.Run(networkMode, func(t *testing.T) {
 			t.Parallel()
-			if env := gatewayGitProxyEnvVars(p, networkMode, 8170); env != nil {
+			if env := gatewayGitProxyEnvVars(p, networkMode, 8170, gateway.ProxyRoutes{RubyGems: true}); env != nil {
 				t.Fatalf("expected no git proxy env for non-filehandle mode %q, got %v", networkMode, env)
 			}
 		})

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -65,6 +65,7 @@ type Adapter struct {
 
 	GatewayRegistry gatewayRegistry
 	GatewayPort     int
+	GatewayRoutes   gateway.ProxyRoutes
 }
 
 // gatewayRegistry is the subset of gateway.Registry used by the adapter.
@@ -632,7 +633,7 @@ func (a *Adapter) executeInSandbox(ctx context.Context, instance *sandboxInstanc
 		if gwPort == 0 {
 			gwPort = gateway.DefaultPort
 		}
-		guestReq.Env = append(guestReq.Env, gatewayEnvVars(instance, gwPort)...)
+		guestReq.Env = append(guestReq.Env, gatewayEnvVars(instance, gwPort, a.GatewayRoutes)...)
 	}
 
 	connectSeconds := launchSeconds
@@ -2348,11 +2349,11 @@ func randomGuestCID() uint32 {
 	return cid%(0xFFFFFFFE-3) + 3
 }
 
-func gatewayEnvVars(instance *sandboxInstance, gwPort int) []string {
+func gatewayEnvVars(instance *sandboxInstance, gwPort int, routes gateway.ProxyRoutes) []string {
 	if instance == nil {
 		return nil
 	}
-	return gateway.ProxyEnvVars(instance.Policy, gwPort, "")
+	return gateway.ProxyEnvVars(instance.Policy, gwPort, "", routes)
 }
 
 func dockerServiceBootArgs(compiled *policy.CompiledPolicy, cfg backend.FirecrackerConfig) string {

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -2352,7 +2352,7 @@ func gatewayEnvVars(instance *sandboxInstance, gwPort int) []string {
 	if instance == nil {
 		return nil
 	}
-	return gateway.GitProxyEnvVars(instance.Policy, gwPort, "")
+	return gateway.ProxyEnvVars(instance.Policy, gwPort, "")
 }
 
 func dockerServiceBootArgs(compiled *policy.CompiledPolicy, cfg backend.FirecrackerConfig) string {

--- a/internal/backend/firecracker/gateway_test.go
+++ b/internal/backend/firecracker/gateway_test.go
@@ -18,7 +18,7 @@ func TestGatewayEnvVarsEmptyWhenNoPolicyHosts(t *testing.T) {
 			Allow:          []policy.AllowRule{{Host: "example.com", Ports: []int{80}}},
 		},
 	}
-	env := gatewayEnvVars(instance, 8170)
+	env := gatewayEnvVars(instance, 8170, gateway.ProxyRoutes{RubyGems: true})
 	if len(env) != 0 {
 		t.Fatalf("expected no env vars for host without port 443, got %v", env)
 	}
@@ -38,7 +38,7 @@ func TestGatewayEnvVarsGeneratesGitConfig(t *testing.T) {
 		},
 	}
 
-	env := gatewayEnvVars(instance, 8170)
+	env := gatewayEnvVars(instance, 8170, gateway.ProxyRoutes{})
 	if len(env) != 5 {
 		t.Fatalf("expected 5 env vars (1 count + 2*2 key/value), got %d: %v", len(env), env)
 	}
@@ -62,8 +62,33 @@ func TestGatewayEnvVarsNilPolicy(t *testing.T) {
 	t.Parallel()
 
 	instance := &sandboxInstance{}
-	env := gatewayEnvVars(instance, 8170)
+	env := gatewayEnvVars(instance, 8170, gateway.ProxyRoutes{RubyGems: true})
 	if env != nil {
 		t.Fatalf("expected nil for nil policy, got %v", env)
+	}
+}
+
+func TestGatewayEnvVarsSkipsRubyGemsMirrorWithoutLiveRoute(t *testing.T) {
+	t.Parallel()
+
+	instance := &sandboxInstance{
+		Policy: &policy.CompiledPolicy{
+			Version:        1,
+			NetworkDefault: "deny",
+			Allow:          []policy.AllowRule{{Host: "rubygems.org", Ports: []int{443}}},
+		},
+	}
+
+	env := gatewayEnvVars(instance, 8170, gateway.ProxyRoutes{})
+	for _, entry := range env {
+		if entry == gateway.BundlerAppConfigEnvKey+"="+gateway.BundlerAppConfigPath {
+			t.Fatalf("did not expect bundler app config env without a live rubygems route, got %v", env)
+		}
+		if entry == gateway.BundlerRubyGemsFallbackTimeoutEnvKey+"=0" {
+			t.Fatalf("did not expect bundler fallback timeout env without a live rubygems route, got %v", env)
+		}
+		if entry == gateway.BundlerRubyGemsMirrorEnvKey+"=http://"+gateway.GuestGatewayHostname+":8170/rubygems/" {
+			t.Fatalf("did not expect rubygems mirror env without a live rubygems route, got %v", env)
+		}
 	}
 }

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -140,8 +140,8 @@ func TestDoctorCommandJSONIncludesCapabilities(t *testing.T) {
 	if payload.Gateway.DefaultPort != 8170 {
 		t.Fatalf("unexpected gateway default port: %d", payload.Gateway.DefaultPort)
 	}
-	if len(payload.Gateway.Routes) != 4 {
-		t.Fatalf("expected 4 gateway routes, got %d (%v)", len(payload.Gateway.Routes), payload.Gateway.Routes)
+	if len(payload.Gateway.Routes) != 5 {
+		t.Fatalf("expected 5 gateway routes, got %d (%v)", len(payload.Gateway.Routes), payload.Gateway.Routes)
 	}
 	foundGitHub := false
 	for _, h := range payload.Gateway.CredentialHosts {

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -117,7 +117,9 @@ func (s *ServeCommand) runServer(ctx *runtimeContext) error {
 		}
 	}
 
-	configureGatewayBackends(ctx.Backends, gwRegistry, gwPort, gwServer.Addr(), darwinGatewayHost)
+	configureGatewayBackends(ctx.Backends, gwRegistry, gwPort, gwServer.Addr(), darwinGatewayHost, gateway.ProxyRoutes{
+		RubyGems: contentCache != nil && contentCache.HasRubyGemsHandler(),
+	})
 
 	if fcAdapter, ok := ctx.Backends["firecracker"].(*firecracker.Adapter); ok && fcAdapter.GatewayRegistry != nil {
 		if shouldInstallGatewayFirewall(runtime.GOOS) {
@@ -190,16 +192,18 @@ func gatewayServerConfig(listen string, registry *gateway.Registry, credentials 
 	}
 }
 
-func configureGatewayBackends(backends map[string]backend.Adapter, gwRegistry *gateway.Registry, gwPort int, gwListenAddr, darwinGatewayHost string) {
+func configureGatewayBackends(backends map[string]backend.Adapter, gwRegistry *gateway.Registry, gwPort int, gwListenAddr, darwinGatewayHost string, routes gateway.ProxyRoutes) {
 	if fcAdapter, ok := backends["firecracker"].(*firecracker.Adapter); ok {
 		fcAdapter.GatewayRegistry = gwRegistry
 		fcAdapter.GatewayPort = gwPort
+		fcAdapter.GatewayRoutes = routes
 	}
 
 	if darwinAdapter, ok := backends["darwin-vz"].(*darwinvz.Adapter); ok {
 		darwinAdapter.GatewayRegistry = gwRegistry
 		darwinAdapter.GatewayPort = gwPort
 		darwinAdapter.GatewayBridgeURL = gatewayBridgeURL(gwPort, gwListenAddr)
+		darwinAdapter.GatewayRoutes = routes
 	}
 }
 

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -60,13 +60,16 @@ func TestConfigureGatewayBackendsConfiguresDarwinVZGateway(t *testing.T) {
 		"darwin-vz":   darwinAdapter,
 	}
 
-	configureGatewayBackends(backends, gwRegistry, 8170, "0.0.0.0:8170", "192.168.64.1")
+	configureGatewayBackends(backends, gwRegistry, 8170, "0.0.0.0:8170", "192.168.64.1", gateway.ProxyRoutes{RubyGems: true})
 
 	if fcAdapter.GatewayRegistry == nil {
 		t.Fatal("expected firecracker adapter to use the host gateway registry")
 	}
 	if got, want := fcAdapter.GatewayPort, 8170; got != want {
 		t.Fatalf("unexpected firecracker gateway port: got %d want %d", got, want)
+	}
+	if !fcAdapter.GatewayRoutes.RubyGems {
+		t.Fatal("expected firecracker adapter to receive live rubygems route state")
 	}
 	if darwinAdapter.GatewayRegistry == nil {
 		t.Fatal("expected darwin-vz adapter to use the host gateway registry")
@@ -76,6 +79,9 @@ func TestConfigureGatewayBackendsConfiguresDarwinVZGateway(t *testing.T) {
 	}
 	if got, want := darwinAdapter.GatewayBridgeURL, "http://127.0.0.1:8170"; got != want {
 		t.Fatalf("unexpected darwin-vz gateway bridge url: got %q want %q", got, want)
+	}
+	if !darwinAdapter.GatewayRoutes.RubyGems {
+		t.Fatal("expected darwin-vz adapter to receive live rubygems route state")
 	}
 }
 

--- a/internal/gateway/contentcache.go
+++ b/internal/gateway/contentcache.go
@@ -14,6 +14,7 @@ import (
 	"github.com/buildkite/content-cache/download"
 	ccgit "github.com/buildkite/content-cache/protocol/git"
 	ccoci "github.com/buildkite/content-cache/protocol/oci"
+	ccrubygems "github.com/buildkite/content-cache/protocol/rubygems"
 	"github.com/buildkite/content-cache/store"
 	"github.com/buildkite/content-cache/store/metadb"
 	"github.com/charmbracelet/log"
@@ -44,6 +45,13 @@ type ContentCacheConfig struct {
 
 	// TagTTL controls how long OCI tag→digest mappings are cached.
 	TagTTL time.Duration
+
+	// RubyGemsUpstreamURL overrides the upstream RubyGems registry URL.
+	// Defaults to https://rubygems.org.
+	RubyGemsUpstreamURL string
+
+	// RubyGemsMetadataTTL controls how long RubyGems metadata is cached.
+	RubyGemsMetadataTTL time.Duration
 
 	Logger *log.Logger
 }
@@ -86,6 +94,7 @@ func NewContentCache(cfg ContentCacheConfig) (*ContentCache, error) {
 	// registry/CDN redirects for blob downloads.
 	gitHTTPClient := newGitContentCacheHTTPClient(cfg.Credentials)
 	ociHTTPClient := newOCIContentCacheHTTPClient(cfg.Credentials)
+	rubyGemsHTTPClient := newRubyGemsContentCacheHTTPClient(cfg.Credentials)
 
 	packIdx, err := metadb.NewEnvelopeIndex(db, "git", "pack", 24*time.Hour)
 	if err != nil {
@@ -107,9 +116,46 @@ func NewContentCache(cfg ContentCacheConfig) (*ContentCache, error) {
 		_ = db.Close()
 		return nil, fmt.Errorf("create oci image index: %w", err)
 	}
+	rubyGemsMetadataTTL := cfg.RubyGemsMetadataTTL
+	if rubyGemsMetadataTTL == 0 {
+		rubyGemsMetadataTTL = 5 * time.Minute
+	}
+	rubyGemsVersionsIdx, err := metadb.NewEnvelopeIndex(db, "rubygems", "versions", rubyGemsMetadataTTL)
+	if err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("create rubygems versions index: %w", err)
+	}
+	rubyGemsInfoIdx, err := metadb.NewEnvelopeIndex(db, "rubygems", "info", rubyGemsMetadataTTL)
+	if err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("create rubygems info index: %w", err)
+	}
+	rubyGemsSpecsIdx, err := metadb.NewEnvelopeIndex(db, "rubygems", "specs", rubyGemsMetadataTTL)
+	if err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("create rubygems specs index: %w", err)
+	}
+	rubyGemsGemIdx, err := metadb.NewEnvelopeIndex(db, "rubygems", "gem", 24*time.Hour)
+	if err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("create rubygems gem index: %w", err)
+	}
+	rubyGemsGemspecIdx, err := metadb.NewEnvelopeIndex(db, "rubygems", "gemspec", 24*time.Hour)
+	if err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("create rubygems gemspec index: %w", err)
+	}
 
 	gitIndex := ccgit.NewIndex(packIdx)
 	ociIndex := ccoci.NewIndex(imageIdx, manifestIdx, blobIdx)
+	rubyGemsIndex := ccrubygems.NewIndex(
+		rubyGemsVersionsIdx,
+		rubyGemsInfoIdx,
+		rubyGemsSpecsIdx,
+		rubyGemsGemIdx,
+		rubyGemsGemspecIdx,
+		cafs,
+	)
 	allowedGitHosts := normalizeAllowedGitHosts(cfg.GitAllowedHosts)
 	registryMappings, err := normalizeOCIRegistryMappings(cfg.OCIRegistries)
 	if err != nil {
@@ -189,6 +235,38 @@ func NewContentCache(cfg ContentCacheConfig) (*ContentCache, error) {
 			entry.closer = closeFunc(closer.Close)
 		}
 		return entry, nil
+	}
+
+	rubyGemsUpstreamURL := strings.TrimSpace(cfg.RubyGemsUpstreamURL)
+	if rubyGemsUpstreamURL == "" {
+		rubyGemsUpstreamURL = ccrubygems.DefaultUpstreamURL
+	}
+	rubyGemsPolicyHost, rubyGemsPolicyPort, err := registryHostPort(rubyGemsUpstreamURL)
+	if err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("resolve rubygems upstream: %w", err)
+	}
+	rubyGemsUpstream := ccrubygems.NewUpstream(
+		ccrubygems.WithRegistryURL(rubyGemsUpstreamURL),
+		ccrubygems.WithHTTPClient(rubyGemsHTTPClient),
+	)
+	rubyGemsHandler := ccrubygems.NewHandler(
+		rubyGemsIndex,
+		cafs,
+		ccrubygems.WithUpstream(rubyGemsUpstream),
+		ccrubygems.WithLogger(logger),
+		ccrubygems.WithDownloader(dl),
+		ccrubygems.WithMetadataTTL(rubyGemsMetadataTTL),
+	)
+	cache.rubyGems = rubyGemsHandlerEntry{
+		handler:      rubyGemsHandler,
+		policyHost:   rubyGemsPolicyHost,
+		policyPort:   rubyGemsPolicyPort,
+		upstreamHost: rubyGemsPolicyHost,
+		upstreamPort: rubyGemsPolicyPort,
+	}
+	if closer, ok := any(rubyGemsHandler).(interface{ Close() }); ok {
+		cache.rubyGems.closer = closeFunc(closer.Close)
 	}
 	return cache, nil
 }

--- a/internal/gateway/contentcache_types.go
+++ b/internal/gateway/contentcache_types.go
@@ -29,6 +29,15 @@ type ociHandlerEntry struct {
 	closer       io.Closer
 }
 
+type rubyGemsHandlerEntry struct {
+	handler      http.Handler
+	policyHost   string
+	policyPort   int
+	upstreamHost string
+	upstreamPort int
+	closer       io.Closer
+}
+
 // ContentCache holds the shared storage and protocol handlers.
 type ContentCache struct {
 	closer io.Closer
@@ -41,6 +50,8 @@ type ContentCache struct {
 	ociHandlers     map[string]ociHandlerEntry
 	buildOCIHandler ociHandlerFactory
 	resolveOCIRoute ociRouteResolver
+
+	rubyGems rubyGemsHandlerEntry
 }
 
 // Close releases resources held by the content cache.
@@ -57,6 +68,9 @@ func (c *ContentCache) Close() error {
 		}
 	}
 	c.ociMu.Unlock()
+	if c.rubyGems.closer != nil {
+		closers = append(closers, c.rubyGems.closer)
+	}
 
 	if c.closer != nil {
 		closers = append(closers, c.closer)
@@ -105,6 +119,28 @@ func (c *ContentCache) GitHandlerForHost(host string) (http.Handler, error) {
 // HasOCIHandler reports whether OCI caching is configured.
 func (c *ContentCache) HasOCIHandler() bool {
 	return c != nil && c.buildOCIHandler != nil
+}
+
+// HasRubyGemsHandler reports whether RubyGems caching is configured.
+func (c *ContentCache) HasRubyGemsHandler() bool {
+	return c != nil && c.rubyGems.handler != nil
+}
+
+// RubyGemsUpstream returns policy/upstream metadata for the configured
+// RubyGems upstream.
+func (c *ContentCache) RubyGemsUpstream() (string, int, string, int, error) {
+	if c == nil || c.rubyGems.handler == nil {
+		return "", 0, "", 0, errors.New("rubygems cache not configured")
+	}
+	return c.rubyGems.policyHost, c.rubyGems.policyPort, c.rubyGems.upstreamHost, c.rubyGems.upstreamPort, nil
+}
+
+// RubyGemsHandler returns the configured RubyGems cache handler.
+func (c *ContentCache) RubyGemsHandler() (http.Handler, error) {
+	if c == nil || c.rubyGems.handler == nil {
+		return nil, errors.New("rubygems cache not configured")
+	}
+	return c.rubyGems.handler, nil
 }
 
 // OCIUpstreamForPrefix returns policy/upstream metadata for the requested
@@ -272,6 +308,18 @@ func newGitContentCacheHTTPClient(credentials CredentialProvider) *http.Client {
 
 func newOCIContentCacheHTTPClient(credentials CredentialProvider) *http.Client {
 	client := newUpstreamContentCacheHTTPClient(credentials)
+	client.Transport = &policyValidatingRoundTripper{base: client.Transport}
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if len(via) == 0 {
+			return nil
+		}
+		return validateUpstreamTargetPolicy(req)
+	}
+	return client
+}
+
+func newRubyGemsContentCacheHTTPClient(_ CredentialProvider) *http.Client {
+	client := newUpstreamContentCacheHTTPClient(nil)
 	client.Transport = &policyValidatingRoundTripper{base: client.Transport}
 	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
 		if len(via) == 0 {

--- a/internal/gateway/git_proxy_env.go
+++ b/internal/gateway/git_proxy_env.go
@@ -26,6 +26,11 @@ const (
 	BundlerAppConfigPath = "/tmp/cleanroom-bundle-config"
 )
 
+// ProxyRoutes describes which gateway-backed guest proxy routes are live.
+type ProxyRoutes struct {
+	RubyGems bool
+}
+
 // GitProxyEnvVars returns git config environment variables that rewrite allowed
 // HTTPS remotes through the shared host gateway.
 func GitProxyEnvVars(compiled *policy.CompiledPolicy, gatewayPort int, scopeToken string) []string {
@@ -85,8 +90,8 @@ func GitProxyEnvVars(compiled *policy.CompiledPolicy, gatewayPort int, scopeToke
 // RubyGemsProxyEnvVars returns Bundler config environment variables that mirror
 // RubyGems traffic through the shared host gateway when rubygems.org is
 // policy-allowed.
-func RubyGemsProxyEnvVars(compiled *policy.CompiledPolicy, gatewayPort int) []string {
-	if !allowsHTTPSHost(compiled, "rubygems.org") || gatewayPort <= 0 {
+func RubyGemsProxyEnvVars(compiled *policy.CompiledPolicy, gatewayPort int, routes ProxyRoutes) []string {
+	if !routes.RubyGems || !allowsHTTPSHost(compiled, "rubygems.org") || gatewayPort <= 0 {
 		return nil
 	}
 
@@ -100,9 +105,9 @@ func RubyGemsProxyEnvVars(compiled *policy.CompiledPolicy, gatewayPort int) []st
 
 // ProxyEnvVars returns gateway-specific environment variables for guest
 // processes, including Git rewrite config and Bundler RubyGems mirroring.
-func ProxyEnvVars(compiled *policy.CompiledPolicy, gatewayPort int, scopeToken string) []string {
+func ProxyEnvVars(compiled *policy.CompiledPolicy, gatewayPort int, scopeToken string, routes ProxyRoutes) []string {
 	env := GitProxyEnvVars(compiled, gatewayPort, scopeToken)
-	env = append(env, RubyGemsProxyEnvVars(compiled, gatewayPort)...)
+	env = append(env, RubyGemsProxyEnvVars(compiled, gatewayPort, routes)...)
 	if len(env) == 0 {
 		return nil
 	}

--- a/internal/gateway/git_proxy_env.go
+++ b/internal/gateway/git_proxy_env.go
@@ -11,6 +11,21 @@ import (
 // Cleanroom host gateway.
 const GuestGatewayHostname = "gateway.cleanroom.internal"
 
+const (
+	// BundlerRubyGemsMirrorEnvKey is a shell-safe hint consumed by the guest
+	// agent, which expands it into Bundler's mirror config env keys before
+	// launching the requested process.
+	BundlerRubyGemsMirrorEnvKey = "CLEANROOM_BUNDLER_RUBYGEMS_MIRROR"
+	// BundlerRubyGemsFallbackTimeoutEnvKey carries Bundler's mirror fallback
+	// timeout setting through the control plane using a shell-safe key.
+	BundlerRubyGemsFallbackTimeoutEnvKey = "CLEANROOM_BUNDLER_RUBYGEMS_FALLBACK_TIMEOUT"
+	// BundlerAppConfigEnvKey points Bundler at a shell-safe config directory we
+	// control inside the guest.
+	BundlerAppConfigEnvKey = "BUNDLE_APP_CONFIG"
+	// BundlerAppConfigPath is the guest path used for generated Bundler config.
+	BundlerAppConfigPath = "/tmp/cleanroom-bundle-config"
+)
+
 // GitProxyEnvVars returns git config environment variables that rewrite allowed
 // HTTPS remotes through the shared host gateway.
 func GitProxyEnvVars(compiled *policy.CompiledPolicy, gatewayPort int, scopeToken string) []string {
@@ -65,4 +80,35 @@ func GitProxyEnvVars(compiled *policy.CompiledPolicy, gatewayPort int, scopeToke
 		env = append(env, fmt.Sprintf("GIT_CONFIG_VALUE_%d=%s", i, entry.value))
 	}
 	return env
+}
+
+// RubyGemsProxyEnvVars returns Bundler config environment variables that mirror
+// RubyGems traffic through the shared host gateway when rubygems.org is
+// policy-allowed.
+func RubyGemsProxyEnvVars(compiled *policy.CompiledPolicy, gatewayPort int) []string {
+	if !allowsHTTPSHost(compiled, "rubygems.org") || gatewayPort <= 0 {
+		return nil
+	}
+
+	gatewayAddr := fmt.Sprintf("http://%s:%d", GuestGatewayHostname, gatewayPort)
+	return []string{
+		fmt.Sprintf("%s=%s", BundlerAppConfigEnvKey, BundlerAppConfigPath),
+		fmt.Sprintf("%s=%s/rubygems/", BundlerRubyGemsMirrorEnvKey, gatewayAddr),
+		BundlerRubyGemsFallbackTimeoutEnvKey + "=0",
+	}
+}
+
+// ProxyEnvVars returns gateway-specific environment variables for guest
+// processes, including Git rewrite config and Bundler RubyGems mirroring.
+func ProxyEnvVars(compiled *policy.CompiledPolicy, gatewayPort int, scopeToken string) []string {
+	env := GitProxyEnvVars(compiled, gatewayPort, scopeToken)
+	env = append(env, RubyGemsProxyEnvVars(compiled, gatewayPort)...)
+	if len(env) == 0 {
+		return nil
+	}
+	return env
+}
+
+func allowsHTTPSHost(compiled *policy.CompiledPolicy, host string) bool {
+	return compiled != nil && compiled.Allows(strings.TrimSpace(host), 443)
 }

--- a/internal/gateway/git_proxy_env_test.go
+++ b/internal/gateway/git_proxy_env_test.go
@@ -1,0 +1,58 @@
+package gateway
+
+import (
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/policy"
+)
+
+func TestRubyGemsProxyEnvVarsRequiresLiveRoute(t *testing.T) {
+	t.Parallel()
+
+	compiled := &policy.CompiledPolicy{
+		Version:        1,
+		NetworkDefault: "deny",
+		Allow:          []policy.AllowRule{{Host: "rubygems.org", Ports: []int{443}}},
+	}
+
+	if env := RubyGemsProxyEnvVars(compiled, 8170, ProxyRoutes{}); env != nil {
+		t.Fatalf("expected no rubygems proxy env without live route, got %v", env)
+	}
+
+	env := RubyGemsProxyEnvVars(compiled, 8170, ProxyRoutes{RubyGems: true})
+	if len(env) != 3 {
+		t.Fatalf("expected 3 env vars with live route, got %d: %v", len(env), env)
+	}
+}
+
+func TestProxyEnvVarsStillIncludesGitWhenRubyGemsRouteIsUnavailable(t *testing.T) {
+	t.Parallel()
+
+	compiled := &policy.CompiledPolicy{
+		Version:        1,
+		NetworkDefault: "deny",
+		Allow: []policy.AllowRule{
+			{Host: "github.com", Ports: []int{443}},
+			{Host: "rubygems.org", Ports: []int{443}},
+		},
+	}
+
+	env := ProxyEnvVars(compiled, 8170, "", ProxyRoutes{})
+	if len(env) != 5 {
+		t.Fatalf("expected only git env vars when rubygems route is unavailable, got %d: %v", len(env), env)
+	}
+	if env[0] != "GIT_CONFIG_COUNT=2" {
+		t.Fatalf("expected git config count only, got %q", env[0])
+	}
+	for _, entry := range env {
+		if entry == BundlerAppConfigEnvKey+"="+BundlerAppConfigPath {
+			t.Fatalf("did not expect bundler app config env when rubygems route is unavailable: %v", env)
+		}
+		if entry == BundlerRubyGemsFallbackTimeoutEnvKey+"=0" {
+			t.Fatalf("did not expect bundler fallback timeout env when rubygems route is unavailable: %v", env)
+		}
+		if entry == BundlerRubyGemsMirrorEnvKey+"=http://"+GuestGatewayHostname+":8170/rubygems/" {
+			t.Fatalf("did not expect rubygems mirror env when rubygems route is unavailable: %v", env)
+		}
+	}
+}

--- a/internal/gateway/path_test.go
+++ b/internal/gateway/path_test.go
@@ -13,6 +13,7 @@ func TestCanonicalisePathValid(t *testing.T) {
 		{"/git/github.com/org/repo.git/info/refs", "/git/github.com/org/repo.git/info/refs"},
 		{"/git/github.com/org/repo", "/git/github.com/org/repo"},
 		{"/registry/npmjs.org/pkg", "/registry/npmjs.org/pkg"},
+		{"/rubygems/versions", "/rubygems/versions"},
 		{"/meta/health", "/meta/health"},
 	}
 	for _, tt := range tests {

--- a/internal/gateway/rubygems_cached.go
+++ b/internal/gateway/rubygems_cached.go
@@ -1,0 +1,80 @@
+package gateway
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/charmbracelet/log"
+)
+
+type rubyGemsHandlerProvider interface {
+	RubyGemsUpstream() (string, int, string, int, error)
+	RubyGemsHandler() (http.Handler, error)
+}
+
+// cachedRubyGemsHandler wraps a content-cache RubyGems handler with Cleanroom's
+// identity-based policy enforcement and strips the gateway route prefix before
+// delegating to the embedded content-cache handler.
+type cachedRubyGemsHandler struct {
+	cache  rubyGemsHandlerProvider
+	logger *log.Logger
+}
+
+func newCachedRubyGemsHandler(cache rubyGemsHandlerProvider, logger *log.Logger) *cachedRubyGemsHandler {
+	return &cachedRubyGemsHandler{cache: cache, logger: logger}
+}
+
+func (h *cachedRubyGemsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	scope, ok := ScopeFromContext(r.Context())
+	if !ok {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		writeReasonError(w, http.StatusMethodNotAllowed, reasonMethodNotAllowed, "only GET and HEAD are permitted for rubygems")
+		return
+	}
+
+	policyHost, policyPort, upstreamHost, _, err := h.cache.RubyGemsUpstream()
+	if err != nil {
+		h.auditLog(scope.SandboxID, "rubygems", "deny", "rubygems_unavailable")
+		writeReasonError(w, http.StatusBadGateway, reasonUpstreamError, "rubygems cache is not configured")
+		return
+	}
+	if !scope.Policy.Allows(policyHost, policyPort) {
+		h.auditLog(scope.SandboxID, policyHost, "deny", reasonHostNotAllowed)
+		writeReasonError(w, http.StatusForbidden, reasonHostNotAllowed, "upstream rubygems host is not allowed by sandbox policy")
+		return
+	}
+
+	handler, err := h.cache.RubyGemsHandler()
+	if err != nil {
+		h.auditLog(scope.SandboxID, "rubygems", "deny", "rubygems_unavailable")
+		writeReasonError(w, http.StatusBadGateway, reasonUpstreamError, "rubygems cache is not configured")
+		return
+	}
+
+	h.auditLog(scope.SandboxID, upstreamHost, "allow", "cached")
+
+	r = r.Clone(r.Context())
+	r.URL.Path = strings.TrimPrefix(r.URL.Path, "/rubygems")
+	r.URL.RawPath = ""
+	if r.URL.Path == "" {
+		r.URL.Path = "/"
+	}
+	handler.ServeHTTP(w, r)
+}
+
+func (h *cachedRubyGemsHandler) auditLog(sandboxID, target, action, reason string) {
+	if h.logger == nil {
+		return
+	}
+	h.logger.Info("gateway rubygems request",
+		"sandbox_id", sandboxID,
+		"service", "rubygems",
+		"target", target,
+		"action", action,
+		"reason_code", reason,
+	)
+}

--- a/internal/gateway/rubygems_cached_test.go
+++ b/internal/gateway/rubygems_cached_test.go
@@ -1,0 +1,147 @@
+package gateway
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type stubRubyGemsHandlerProvider struct {
+	handler      http.Handler
+	policyHost   string
+	policyPort   int
+	upstreamHost string
+	upstreamPort int
+	err          error
+}
+
+func (s *stubRubyGemsHandlerProvider) RubyGemsUpstream() (string, int, string, int, error) {
+	if s.err != nil {
+		return "", 0, "", 0, s.err
+	}
+	return s.policyHost, s.policyPort, s.upstreamHost, s.upstreamPort, nil
+}
+
+func (s *stubRubyGemsHandlerProvider) RubyGemsHandler() (http.Handler, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.handler, nil
+}
+
+func TestCachedRubyGemsHandlerStripsPrefixAndDelegates(t *testing.T) {
+	t.Parallel()
+
+	var capturedPath string
+	provider := &stubRubyGemsHandlerProvider{
+		handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedPath = r.URL.Path
+			w.WriteHeader(http.StatusOK)
+		}),
+		policyHost:   "rubygems.org",
+		policyPort:   443,
+		upstreamHost: "rubygems.org",
+		upstreamPort: 443,
+	}
+	h := newCachedRubyGemsHandler(provider, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/rubygems/versions", nil)
+	req = withScope(req, registryTestScope("rubygems.org"))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	if want := "/versions"; capturedPath != want {
+		t.Fatalf("expected backend path %q, got %q", want, capturedPath)
+	}
+}
+
+func TestCachedRubyGemsHandlerDeniesUnallowedHost(t *testing.T) {
+	t.Parallel()
+
+	provider := &stubRubyGemsHandlerProvider{
+		handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			t.Fatal("handler should not run for denied host")
+		}),
+		policyHost:   "rubygems.org",
+		policyPort:   443,
+		upstreamHost: "rubygems.org",
+		upstreamPort: 443,
+	}
+	h := newCachedRubyGemsHandler(provider, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/rubygems/versions", nil)
+	req = withScope(req, registryTestScope("github.com"))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", w.Code)
+	}
+	if got := w.Header().Get(reasonCodeHeader); got != reasonHostNotAllowed {
+		t.Fatalf("expected reason %s, got %q", reasonHostNotAllowed, got)
+	}
+}
+
+func TestCachedRubyGemsHandlerRejectsPost(t *testing.T) {
+	t.Parallel()
+
+	h := newCachedRubyGemsHandler(&stubRubyGemsHandlerProvider{
+		handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			t.Fatal("handler should not run for POST")
+		}),
+		policyHost:   "rubygems.org",
+		policyPort:   443,
+		upstreamHost: "rubygems.org",
+		upstreamPort: 443,
+	}, nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/rubygems/versions", nil)
+	req = withScope(req, registryTestScope("rubygems.org"))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestCachedRubyGemsHandlerNoScope(t *testing.T) {
+	t.Parallel()
+
+	h := newCachedRubyGemsHandler(&stubRubyGemsHandlerProvider{
+		handler:      http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}),
+		policyHost:   "rubygems.org",
+		policyPort:   443,
+		upstreamHost: "rubygems.org",
+		upstreamPort: 443,
+	}, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/rubygems/versions", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", w.Code)
+	}
+}
+
+func TestCachedRubyGemsHandlerUnavailable(t *testing.T) {
+	t.Parallel()
+
+	h := newCachedRubyGemsHandler(&stubRubyGemsHandlerProvider{
+		err: errors.New("unavailable"),
+	}, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/rubygems/versions", nil)
+	req = withScope(req, registryTestScope("rubygems.org"))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("expected 502, got %d", w.Code)
+	}
+}

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -19,6 +19,7 @@ const (
 
 	RouteGit      = "/git/"
 	RouteRegistry = "/registry/"
+	RouteRubyGems = "/rubygems/"
 	RouteSecrets  = "/secrets/"
 	RouteMeta     = "/meta/"
 )
@@ -26,6 +27,7 @@ const (
 var serviceRoutes = []string{
 	RouteGit,
 	RouteRegistry,
+	RouteRubyGems,
 	RouteSecrets,
 	RouteMeta,
 }
@@ -190,6 +192,12 @@ func NewServer(cfg ServerConfig) *Server {
 		mux.Handle(RouteRegistry, newCachedRegistryHandler(cfg.ContentCache, cfg.Logger))
 	} else {
 		mux.HandleFunc(RouteRegistry, stubHandler("registry"))
+	}
+
+	if cfg.ContentCache != nil && cfg.ContentCache.HasRubyGemsHandler() {
+		mux.Handle(RouteRubyGems, newCachedRubyGemsHandler(cfg.ContentCache, cfg.Logger))
+	} else {
+		mux.HandleFunc(RouteRubyGems, stubHandler("rubygems"))
 	}
 
 	mux.HandleFunc(RouteSecrets, stubHandler("secrets"))


### PR DESCRIPTION
## Summary
- add a cache-backed `/rubygems/` gateway route and guest-side Bundler mirror wiring so RubyGems traffic stays on the host side of the sandbox boundary
- update the Debian Ruby base image and runtime tests for the native dependencies Rails needs during `bundle install`
- add a `examples/rails` example plus docs updates, and switch Cleanroom to the merged upstream `content-cache` RubyGems fix

## Testing
- `PATH=/Users/lachlan/.local/share/mise/installs/go/1.26.2/bin:$PATH go test ./internal/gateway ./internal/backend/darwinvz ./internal/backend/firecracker ./internal/cli ./images`
- `/tmp/cleanroom-rails-e2e-bin exec --host http://127.0.0.1:18195 --log-level debug --no-stdin --backend darwin-vz --repo-url https://github.com/rails/rails.git --repo-commit cfa4e1b475472c7980a42dd810f237951db5108a -- sh -lc 'cd activesupport && bin/test'`
  - result: `5860 runs, 18788 assertions, 0 failures, 0 errors, 1049 skips`
  - skips are the expected service-dependent `memcached` and `redis` cases in the current sandbox
