### PR TITLE
fix: Wait for launchd bootout before bootstrap

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/buildkite/cleanroom/internal/backend"
 	"github.com/buildkite/cleanroom/internal/backend/darwinvz"
@@ -78,6 +79,9 @@ var (
 	serveInstallRunCommandOutput = runServeInstallCommandOutput
 	serveInstallSystemdUnitPath  = "/etc/systemd/system/" + systemdServiceName
 	serveInstallLaunchdPath      = "/Library/LaunchDaemons/" + launchdServiceName + ".plist"
+	serveInstallSleep            = time.Sleep
+	serveInstallWaitAttempts     = 50
+	serveInstallWaitPollInterval = 100 * time.Millisecond
 )
 
 func (s *DaemonCommand) Run(ctx *runtimeContext) error {

--- a/internal/cli/daemon_launchd.go
+++ b/internal/cli/daemon_launchd.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/buildkite/cleanroom/internal/endpoint"
 )
 
 func uninstallLaunchdDaemon(stdout io.Writer) error {
@@ -204,6 +206,9 @@ func restartLaunchdDaemonInDomain(stdout io.Writer, servicePath, domain string, 
 		if err := serveInstallRunCommand("launchctl", "bootout", target); err != nil && !isExitError(err) {
 			return fmt.Errorf("bootout launchd service %s: %w", launchdServiceName, err)
 		}
+		if err := waitForLaunchdBootout(target, servicePath); err != nil {
+			return err
+		}
 	}
 	if err := serveInstallRunCommand("launchctl", "enable", target); err != nil {
 		return fmt.Errorf("enable launchd service %s: %w", launchdServiceName, err)
@@ -335,6 +340,49 @@ func launchdConfiguredListenEndpoint(plistPath string) (string, error) {
 		}
 	}
 	return "", nil
+}
+
+func waitForLaunchdBootout(target, servicePath string) error {
+	socketPath := launchdConfiguredUnixSocketPath(servicePath)
+	for attempt := 0; attempt < serveInstallWaitAttempts; attempt++ {
+		loaded, _, err := launchdServiceStatus(target)
+		if err != nil {
+			return err
+		}
+
+		socketPresent := false
+		if socketPath != "" {
+			if _, err := serveInstallStat(socketPath); err == nil {
+				socketPresent = true
+			} else if !errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("stat launchd listen socket %s: %w", socketPath, err)
+			}
+		}
+
+		if !loaded && !socketPresent {
+			return nil
+		}
+		if attempt+1 < serveInstallWaitAttempts {
+			serveInstallSleep(serveInstallWaitPollInterval)
+		}
+	}
+
+	if socketPath != "" {
+		return fmt.Errorf("timed out waiting for launchd service %s to stop and release %s", launchdServiceName, socketPath)
+	}
+	return fmt.Errorf("timed out waiting for launchd service %s to stop", launchdServiceName)
+}
+
+func launchdConfiguredUnixSocketPath(servicePath string) string {
+	value, err := launchdConfiguredListenEndpoint(servicePath)
+	if err != nil {
+		return ""
+	}
+	ep, err := endpoint.ResolveListen(value)
+	if err != nil || ep.Scheme != "unix" {
+		return ""
+	}
+	return ep.Address
 }
 
 func launchdProgramArguments(plistContent []byte) ([]string, error) {
@@ -496,6 +544,9 @@ func installLaunchdDaemonInDomain(stdout io.Writer, executablePath string, args 
 	if loaded {
 		if err := serveInstallRunCommand("launchctl", "bootout", target); err != nil && !isExitError(err) {
 			return fmt.Errorf("bootout launchd service %s: %w", launchdServiceName, err)
+		}
+		if err := waitForLaunchdBootout(target, servicePath); err != nil {
+			return err
 		}
 	}
 	if err := serveInstallRunCommand("launchctl", "enable", target); err != nil {

--- a/internal/cli/daemon_launchd.go
+++ b/internal/cli/daemon_launchd.go
@@ -6,9 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/buildkite/cleanroom/internal/endpoint"
 )
@@ -350,16 +352,7 @@ func waitForLaunchdBootout(target, servicePath string) error {
 			return err
 		}
 
-		socketPresent := false
-		if socketPath != "" {
-			if _, err := serveInstallStat(socketPath); err == nil {
-				socketPresent = true
-			} else if !errors.Is(err, os.ErrNotExist) {
-				return fmt.Errorf("stat launchd listen socket %s: %w", socketPath, err)
-			}
-		}
-
-		if !loaded && !socketPresent {
+		if !loaded && !launchdSocketAcceptsConnections(socketPath) {
 			return nil
 		}
 		if attempt+1 < serveInstallWaitAttempts {
@@ -371,6 +364,19 @@ func waitForLaunchdBootout(target, servicePath string) error {
 		return fmt.Errorf("timed out waiting for launchd service %s to stop and release %s", launchdServiceName, socketPath)
 	}
 	return fmt.Errorf("timed out waiting for launchd service %s to stop", launchdServiceName)
+}
+
+func launchdSocketAcceptsConnections(socketPath string) bool {
+	if strings.TrimSpace(socketPath) == "" {
+		return false
+	}
+
+	conn, err := net.DialTimeout("unix", socketPath, 25*time.Millisecond)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
 }
 
 func launchdConfiguredUnixSocketPath(servicePath string) string {

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -11,6 +11,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/buildkite/cleanroom/internal/backend"
 	"github.com/buildkite/cleanroom/internal/backend/darwinvz"
@@ -366,7 +367,11 @@ func TestDaemonInstallRestartRestartsRunningSystemdService(t *testing.T) {
 	})
 
 	stdout, _ := makeStdoutCapture(t)
-	cmd := &DaemonCommand{Action: "install", Restart: true}
+	cmd := &DaemonCommand{
+		Action:  "install",
+		Restart: true,
+		Listen:  "unix://" + filepath.Join(tmpDir, "cleanroom.sock"),
+	}
 	if err := cmd.Run(daemonInstallContext(tmpDir, stdout)); err != nil {
 		t.Fatalf("DaemonCommand.Run returned error: %v", err)
 	}
@@ -550,11 +555,21 @@ func TestDaemonInstallDarwinUpdatesRunningUserServiceWithoutRestart(t *testing.T
 	serveInstallGOOS = "darwin"
 	serveInstallUserHomeDir = func() (string, error) { return tmpDir, nil }
 	serveInstallExecutablePath = func() (string, error) { return "/Users/lachlan/bin/cleanroom", nil }
+	loaded := true
 	serveInstallRunCommandOutput = func(name string, args ...string) (string, error) {
+		if !loaded {
+			return "", &exec.ExitError{ProcessState: &os.ProcessState{}}
+		}
 		return "state = running\n", nil
 	}
 	var calls [][]string
 	serveInstallRunCommand = func(name string, args ...string) error {
+		if len(args) > 0 && args[0] == "bootout" {
+			loaded = false
+		}
+		if len(args) > 0 && args[0] == "bootstrap" {
+			loaded = true
+		}
 		calls = append(calls, append([]string{name}, args...))
 		return nil
 	}
@@ -612,11 +627,21 @@ func TestDaemonInstallDarwinRestartBootsOutAndKickstartsRunningUserService(t *te
 	serveInstallGOOS = "darwin"
 	serveInstallUserHomeDir = func() (string, error) { return tmpDir, nil }
 	serveInstallExecutablePath = func() (string, error) { return "/Users/lachlan/bin/cleanroom", nil }
+	loaded := true
 	serveInstallRunCommandOutput = func(name string, args ...string) (string, error) {
+		if !loaded {
+			return "", &exec.ExitError{ProcessState: &os.ProcessState{}}
+		}
 		return "state = running\n", nil
 	}
 	var calls [][]string
 	serveInstallRunCommand = func(name string, args ...string) error {
+		if len(args) > 0 && args[0] == "bootout" {
+			loaded = false
+		}
+		if len(args) > 0 && args[0] == "bootstrap" {
+			loaded = true
+		}
 		calls = append(calls, append([]string{name}, args...))
 		return nil
 	}
@@ -631,7 +656,11 @@ func TestDaemonInstallDarwinRestartBootsOutAndKickstartsRunningUserService(t *te
 	})
 
 	stdout, _ := makeStdoutCapture(t)
-	cmd := &DaemonCommand{Action: "install", Restart: true}
+	cmd := &DaemonCommand{
+		Action:  "install",
+		Restart: true,
+		Listen:  "unix://" + filepath.Join(tmpDir, "cleanroom.sock"),
+	}
 	if err := cmd.Run(daemonInstallContext(tmpDir, stdout)); err != nil {
 		t.Fatalf("DaemonCommand.Run returned error: %v", err)
 	}
@@ -1461,11 +1490,21 @@ func TestDaemonRestartLaunchdRebootstrapsRunningUserService(t *testing.T) {
 	serveInstallEUID = func() int { return 501 }
 	serveInstallUID = func() int { return 501 }
 	serveInstallUserHomeDir = func() (string, error) { return tmpDir, nil }
+	loaded := true
 	serveInstallRunCommandOutput = func(name string, args ...string) (string, error) {
+		if !loaded {
+			return "", &exec.ExitError{ProcessState: &os.ProcessState{}}
+		}
 		return "state = running\n", nil
 	}
 	var calls [][]string
 	serveInstallRunCommand = func(name string, args ...string) error {
+		if len(args) > 0 && args[0] == "bootout" {
+			loaded = false
+		}
+		if len(args) > 0 && args[0] == "bootstrap" {
+			loaded = true
+		}
 		calls = append(calls, append([]string{name}, args...))
 		return nil
 	}
@@ -1561,6 +1600,48 @@ func TestDaemonRestartLaunchdForceBootstrapsStoppedUserService(t *testing.T) {
 	}
 	if !strings.Contains(out, "manager=launchd") {
 		t.Fatalf("expected manager=launchd, got: %s", out)
+	}
+}
+
+func TestWaitForLaunchdBootoutWaitsForSocketRemoval(t *testing.T) {
+	tmpDir := t.TempDir()
+	plistPath := filepath.Join(tmpDir, "cleanroom.plist")
+	socketPath := filepath.Join(tmpDir, "cleanroom.sock")
+	if err := os.WriteFile(plistPath, []byte(renderLaunchdService("/usr/local/bin/cleanroom", []string{"serve", "--listen", "unix://" + socketPath})), 0o644); err != nil {
+		t.Fatalf("write plist: %v", err)
+	}
+	if err := os.WriteFile(socketPath, []byte(""), 0o644); err != nil {
+		t.Fatalf("write socket placeholder: %v", err)
+	}
+
+	prevRunCommandOutput := serveInstallRunCommandOutput
+	prevSleep := serveInstallSleep
+	prevAttempts := serveInstallWaitAttempts
+	prevPollInterval := serveInstallWaitPollInterval
+	serveInstallRunCommandOutput = func(name string, args ...string) (string, error) {
+		return "", &exec.ExitError{ProcessState: &os.ProcessState{}}
+	}
+	sleepCalls := 0
+	serveInstallSleep = func(time.Duration) {
+		sleepCalls++
+		if err := os.Remove(socketPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("remove socket placeholder: %v", err)
+		}
+	}
+	serveInstallWaitAttempts = 3
+	serveInstallWaitPollInterval = 0
+	t.Cleanup(func() {
+		serveInstallRunCommandOutput = prevRunCommandOutput
+		serveInstallSleep = prevSleep
+		serveInstallWaitAttempts = prevAttempts
+		serveInstallWaitPollInterval = prevPollInterval
+	})
+
+	if err := waitForLaunchdBootout("gui/501/"+launchdServiceName, plistPath); err != nil {
+		t.Fatalf("waitForLaunchdBootout returned error: %v", err)
+	}
+	if sleepCalls == 0 {
+		t.Fatal("expected waitForLaunchdBootout to wait for socket removal")
 	}
 }
 

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"net"
 	"net/netip"
 	"os"
 	"os/exec"
@@ -1604,16 +1605,26 @@ func TestDaemonRestartLaunchdForceBootstrapsStoppedUserService(t *testing.T) {
 	}
 }
 
-func TestWaitForLaunchdBootoutWaitsForSocketRemoval(t *testing.T) {
-	tmpDir := t.TempDir()
+func TestWaitForLaunchdBootoutWaitsForActiveSocketToClose(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("/tmp", "cleanroom-launchd-*")
+	if err != nil {
+		t.Fatalf("mktemp short dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
 	plistPath := filepath.Join(tmpDir, "cleanroom.plist")
 	socketPath := filepath.Join(tmpDir, "cleanroom.sock")
 	if err := os.WriteFile(plistPath, []byte(renderLaunchdService("/usr/local/bin/cleanroom", []string{"serve", "--listen", "unix://" + socketPath})), 0o644); err != nil {
 		t.Fatalf("write plist: %v", err)
 	}
-	if err := os.WriteFile(socketPath, []byte(""), 0o644); err != nil {
-		t.Fatalf("write socket placeholder: %v", err)
+
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen on socket: %v", err)
 	}
+	t.Cleanup(func() {
+		_ = listener.Close()
+		_ = os.Remove(socketPath)
+	})
 
 	prevRunCommandOutput := serveInstallRunCommandOutput
 	prevSleep := serveInstallSleep
@@ -1625,8 +1636,8 @@ func TestWaitForLaunchdBootoutWaitsForSocketRemoval(t *testing.T) {
 	sleepCalls := 0
 	serveInstallSleep = func(time.Duration) {
 		sleepCalls++
-		if err := os.Remove(socketPath); err != nil && !errors.Is(err, os.ErrNotExist) {
-			t.Fatalf("remove socket placeholder: %v", err)
+		if err := listener.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
+			t.Fatalf("close socket listener: %v", err)
 		}
 	}
 	serveInstallWaitAttempts = 3
@@ -1642,7 +1653,54 @@ func TestWaitForLaunchdBootoutWaitsForSocketRemoval(t *testing.T) {
 		t.Fatalf("waitForLaunchdBootout returned error: %v", err)
 	}
 	if sleepCalls == 0 {
-		t.Fatal("expected waitForLaunchdBootout to wait for socket removal")
+		t.Fatal("expected waitForLaunchdBootout to wait for active socket shutdown")
+	}
+}
+
+func TestWaitForLaunchdBootoutIgnoresStaleSocketFile(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("/tmp", "cleanroom-launchd-*")
+	if err != nil {
+		t.Fatalf("mktemp short dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+	plistPath := filepath.Join(tmpDir, "cleanroom.plist")
+	socketPath := filepath.Join(tmpDir, "cleanroom.sock")
+	if err := os.WriteFile(plistPath, []byte(renderLaunchdService("/usr/local/bin/cleanroom", []string{"serve", "--listen", "unix://" + socketPath})), 0o644); err != nil {
+		t.Fatalf("write plist: %v", err)
+	}
+
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen on socket: %v", err)
+	}
+	if err := listener.Close(); err != nil {
+		t.Fatalf("close socket listener: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(socketPath) })
+
+	prevRunCommandOutput := serveInstallRunCommandOutput
+	prevSleep := serveInstallSleep
+	prevAttempts := serveInstallWaitAttempts
+	prevPollInterval := serveInstallWaitPollInterval
+	serveInstallRunCommandOutput = func(name string, args ...string) (string, error) {
+		return "", &exec.ExitError{ProcessState: &os.ProcessState{}}
+	}
+	sleepCalls := 0
+	serveInstallSleep = func(time.Duration) { sleepCalls++ }
+	serveInstallWaitAttempts = 2
+	serveInstallWaitPollInterval = 0
+	t.Cleanup(func() {
+		serveInstallRunCommandOutput = prevRunCommandOutput
+		serveInstallSleep = prevSleep
+		serveInstallWaitAttempts = prevAttempts
+		serveInstallWaitPollInterval = prevPollInterval
+	})
+
+	if err := waitForLaunchdBootout("gui/501/"+launchdServiceName, plistPath); err != nil {
+		t.Fatalf("waitForLaunchdBootout returned error: %v", err)
+	}
+	if sleepCalls != 0 {
+		t.Fatal("expected stale socket file not to block launchd bootout wait")
 	}
 }
 

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -367,10 +367,11 @@ func TestDaemonInstallRestartRestartsRunningSystemdService(t *testing.T) {
 	})
 
 	stdout, _ := makeStdoutCapture(t)
+	listen := "unix://" + filepath.Join(tmpDir, "cleanroom.sock")
 	cmd := &DaemonCommand{
 		Action:  "install",
 		Restart: true,
-		Listen:  "unix://" + filepath.Join(tmpDir, "cleanroom.sock"),
+		Listen:  listen,
 	}
 	if err := cmd.Run(daemonInstallContext(tmpDir, stdout)); err != nil {
 		t.Fatalf("DaemonCommand.Run returned error: %v", err)
@@ -390,8 +391,8 @@ func TestDaemonInstallRestartRestartsRunningSystemdService(t *testing.T) {
 	if !strings.Contains(content, "Environment=XDG_CONFIG_HOME=/root/.config") {
 		t.Fatalf("expected XDG_CONFIG_HOME environment in systemd unit, got:\n%s", content)
 	}
-	if !strings.Contains(content, "--listen unix:///var/run/cleanroom/cleanroom.sock") {
-		t.Fatalf("expected explicit default --listen in unit, got:\n%s", content)
+	if !strings.Contains(content, "--listen "+listen) {
+		t.Fatalf("expected configured --listen in unit, got:\n%s", content)
 	}
 	if strings.Contains(content, "serve install") {
 		t.Fatalf("unit should run server mode, not install mode:\n%s", content)


### PR DESCRIPTION
## Summary
- wait for launchd jobs to fully disappear after `bootout` before re-running `bootstrap` during launchd restart/install rebootstrap paths
- treat the configured unix listen socket as part of that shutdown check so we do not re-bootstrap while the old daemon still holds the socket
- add launchd tests covering the wait path and the socket-removal race

## Why
On macOS, `cleanroom daemon restart` and `cleanroom daemon install --restart` could re-bootstrap too quickly after `launchctl bootout`. The old Cleanroom process was sometimes still exiting and still owned the unix socket, so launchd reported `bootstrap ... exit status 5 (Input/output error)` even though the plist itself was valid.

## Validation
- `mise exec -- go test ./internal/cli -run 'TestDaemonInstallDarwin|TestDaemonRestartLaunchd|TestWaitForLaunchdBootoutWaitsForSocketRemoval'`
- `mise exec -- go run ./cmd/cleanroom daemon restart --user`