### PR TITLE
Fix darwin-vz config init defaults

### DIFF
--- a/internal/backend/darwinvz/snapshot_support_darwin.go
+++ b/internal/backend/darwinvz/snapshot_support_darwin.go
@@ -1,0 +1,35 @@
+//go:build darwin
+
+package darwinvz
+
+import "fmt"
+
+type SnapshotSupport struct {
+	Usable  bool
+	Message string
+}
+
+var (
+	detectSnapshotSupportResolveHelperPath = resolveHelperBinaryPath
+	detectSnapshotSupportHasEntitlement    = helperHasVirtualizationEntitlement
+)
+
+func DetectSnapshotSupport() SnapshotSupport {
+	helperPath, err := detectSnapshotSupportResolveHelperPath()
+	if err != nil {
+		return SnapshotSupport{Message: fmt.Sprintf("darwin-vz snapshots remain disabled: helper unavailable: %v", err)}
+	}
+
+	hasEntitlement, err := detectSnapshotSupportHasEntitlement(helperPath)
+	if err != nil {
+		return SnapshotSupport{Message: fmt.Sprintf("darwin-vz snapshots remain disabled: could not verify helper entitlement for %s: %v", helperPath, err)}
+	}
+	if !hasEntitlement {
+		return SnapshotSupport{Message: fmt.Sprintf("darwin-vz snapshots remain disabled: %s is missing com.apple.security.virtualization entitlement", helperPath)}
+	}
+
+	return SnapshotSupport{
+		Usable:  true,
+		Message: fmt.Sprintf("darwin-vz snapshot runtime is usable via %s", helperPath),
+	}
+}

--- a/internal/backend/darwinvz/snapshot_support_unsupported.go
+++ b/internal/backend/darwinvz/snapshot_support_unsupported.go
@@ -1,0 +1,14 @@
+//go:build !darwin
+
+package darwinvz
+
+import "fmt"
+
+type SnapshotSupport struct {
+	Usable  bool
+	Message string
+}
+
+func DetectSnapshotSupport() SnapshotSupport {
+	return SnapshotSupport{Message: fmt.Sprintf("darwin-vz snapshots require macOS")}
+}

--- a/internal/cli/config_init_test.go
+++ b/internal/cli/config_init_test.go
@@ -129,8 +129,8 @@ func TestConfigInitWritesRuntimeConfig(t *testing.T) {
 	if !strings.Contains(string(raw), "snapshots:") {
 		t.Fatalf("expected generated config to include snapshot defaults, got:\n%s", raw)
 	}
-	if runtime.GOOS != "darwin" && !strings.Contains(string(raw), "enabled: false") {
-		t.Fatalf("expected generated config to include disabled snapshot default, got:\n%s", raw)
+	if strings.Contains(string(raw), "enabled: false") {
+		t.Fatalf("expected generated config to omit zero-value snapshot enabled field, got:\n%s", raw)
 	}
 	if runtime.GOOS != "darwin" && !strings.Contains(string(raw), "driver: file") {
 		t.Fatalf("expected generated config to include firecracker snapshot driver default, got:\n%s", raw)

--- a/internal/cli/config_init_test.go
+++ b/internal/cli/config_init_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/buildkite/cleanroom/internal/backend"
+	backenddarwinvz "github.com/buildkite/cleanroom/internal/backend/darwinvz"
 	backendfirecracker "github.com/buildkite/cleanroom/internal/backend/firecracker"
 	"github.com/buildkite/cleanroom/internal/runtimeconfig"
 	"gopkg.in/yaml.v3"
@@ -20,6 +22,9 @@ func TestConfigInitWritesRuntimeConfig(t *testing.T) {
 			SnapshotsUsable: false,
 			SnapshotMessage: "machine bootstrap incomplete",
 		}
+	})
+	stubDarwinVZSnapshotSupport(t, func() backenddarwinvz.SnapshotSupport {
+		return backenddarwinvz.SnapshotSupport{Usable: true, Message: "darwin-vz snapshot runtime is usable"}
 	})
 
 	tmpDir := t.TempDir()
@@ -42,52 +47,98 @@ func TestConfigInitWritesRuntimeConfig(t *testing.T) {
 	if err := yaml.Unmarshal(raw, &cfg); err != nil {
 		t.Fatalf("parse generated yaml: %v", err)
 	}
-	if !strings.Contains(string(raw), "darwin-vz:") {
-		t.Fatalf("expected generated config to use backends.darwin-vz key, got:\n%s", raw)
+	if runtime.GOOS == "darwin" {
+		if !strings.Contains(string(raw), "darwin-vz:") {
+			t.Fatalf("expected generated config to use backends.darwin-vz key, got:\n%s", raw)
+		}
+		if !strings.Contains(string(raw), "backends:\n  darwin-vz:") {
+			t.Fatalf("expected generated config to use 2-space indentation, got:\n%s", raw)
+		}
+	} else {
+		if !strings.Contains(string(raw), "firecracker:") {
+			t.Fatalf("expected generated config to use backends.firecracker key, got:\n%s", raw)
+		}
+		if !strings.Contains(string(raw), "backends:\n  firecracker:") {
+			t.Fatalf("expected generated config to use 2-space indentation, got:\n%s", raw)
+		}
 	}
 	if got := strings.TrimSpace(cfg.DefaultBackend); got == "" {
 		t.Fatal("expected default_backend to be populated")
 	}
-	if got := strings.TrimSpace(cfg.Backends.Firecracker.BinaryPath); got == "" {
-		t.Fatal("expected backends.firecracker.binary_path to be populated")
-	}
-	if got := strings.TrimSpace(cfg.Backends.Firecracker.KernelImage); got != "" {
-		t.Fatalf("expected backends.firecracker.kernel_image to default empty, got %q", got)
-	}
-	if got := strings.TrimSpace(cfg.Backends.DarwinVZ.KernelImage); got != "" {
-		t.Fatalf("expected backends.darwin-vz.kernel_image to default empty, got %q", got)
-	}
-	if got, want := cfg.Backends.Firecracker.Snapshots.Driver, "file"; got != want {
-		t.Fatalf("expected backends.firecracker.snapshots.driver=%q, got %q", want, got)
-	}
-	if cfg.Backends.Firecracker.Snapshots.Enabled {
-		t.Fatal("expected backends.firecracker.snapshots.enabled to default false")
-	}
-	if got, want := cfg.Backends.DarwinVZ.Snapshots.Driver, "apfs"; got != want {
-		t.Fatalf("expected backends.darwin-vz.snapshots.driver=%q, got %q", want, got)
-	}
-	if cfg.Backends.DarwinVZ.Snapshots.Enabled {
-		t.Fatal("expected backends.darwin-vz.snapshots.enabled to default false")
-	}
-	if got, want := cfg.Backends.Firecracker.Services.Docker.StartupTimeoutSeconds, int64(20); got != want {
-		t.Fatalf("expected backends.firecracker.services.docker.startup_timeout_seconds=%d, got %d", want, got)
-	}
-	if got, want := cfg.Backends.Firecracker.Services.Docker.StorageDriver, "vfs"; got != want {
-		t.Fatalf("expected backends.firecracker.services.docker.storage_driver=%q, got %q", want, got)
-	}
-	if cfg.Backends.Firecracker.Services.Docker.IPTables {
-		t.Fatal("expected backends.firecracker.services.docker.iptables to default false")
+	if runtime.GOOS == "darwin" {
+		if strings.Contains(string(raw), "firecracker:") {
+			t.Fatalf("expected generated config to omit firecracker backend on darwin hosts, got:\n%s", raw)
+		}
+		if got := strings.TrimSpace(cfg.Backends.DarwinVZ.KernelImage); got != "" {
+			t.Fatalf("expected backends.darwin-vz.kernel_image to default empty, got %q", got)
+		}
+		if got, want := cfg.Backends.DarwinVZ.Snapshots.Driver, "apfs"; got != want {
+			t.Fatalf("expected backends.darwin-vz.snapshots.driver=%q, got %q", want, got)
+		}
+		if !cfg.Backends.DarwinVZ.Snapshots.Enabled {
+			t.Fatal("expected backends.darwin-vz.snapshots.enabled to default true on darwin")
+		}
+		if got, want := cfg.Backends.DarwinVZ.MemoryMiB, int64(4096); got != want {
+			t.Fatalf("expected backends.darwin-vz.memory_mib=%d, got %d", want, got)
+		}
+		if got, want := int64(cfg.Backends.DarwinVZ.MinimumRootFSBytes), int64(4<<30); got != want {
+			t.Fatalf("expected backends.darwin-vz.minimum_rootfs_bytes=%d, got %d", want, got)
+		}
+		if !strings.Contains(string(raw), "memory_mib: 4096") {
+			t.Fatalf("expected generated config to include memory_mib: 4096, got:\n%s", raw)
+		}
+		if !strings.Contains(string(raw), "minimum_rootfs_bytes: 4GiB") {
+			t.Fatalf("expected generated config to include minimum_rootfs_bytes: 4GiB, got:\n%s", raw)
+		}
+		for _, forbidden := range []string{"kernel_image:", "rootfs:", "iptables:"} {
+			if strings.Contains(string(raw), forbidden) {
+				t.Fatalf("expected generated config to omit zero-value field %q, got:\n%s", forbidden, raw)
+			}
+		}
+	} else {
+		if strings.Contains(string(raw), "darwin-vz:") {
+			t.Fatalf("expected generated config to omit darwin-vz backend on non-darwin hosts, got:\n%s", raw)
+		}
+		if got := strings.TrimSpace(cfg.Backends.Firecracker.BinaryPath); got == "" {
+			t.Fatal("expected backends.firecracker.binary_path to be populated")
+		}
+		if got := strings.TrimSpace(cfg.Backends.Firecracker.KernelImage); got != "" {
+			t.Fatalf("expected backends.firecracker.kernel_image to default empty, got %q", got)
+		}
+		if got, want := cfg.Backends.Firecracker.Snapshots.Driver, "file"; got != want {
+			t.Fatalf("expected backends.firecracker.snapshots.driver=%q, got %q", want, got)
+		}
+		if cfg.Backends.Firecracker.Snapshots.Enabled {
+			t.Fatal("expected backends.firecracker.snapshots.enabled to default false")
+		}
+		if got, want := cfg.Backends.Firecracker.Services.Docker.StartupTimeoutSeconds, int64(20); got != want {
+			t.Fatalf("expected backends.firecracker.services.docker.startup_timeout_seconds=%d, got %d", want, got)
+		}
+		if got, want := cfg.Backends.Firecracker.Services.Docker.StorageDriver, "vfs"; got != want {
+			t.Fatalf("expected backends.firecracker.services.docker.storage_driver=%q, got %q", want, got)
+		}
+		if cfg.Backends.Firecracker.Services.Docker.IPTables {
+			t.Fatal("expected backends.firecracker.services.docker.iptables to default false")
+		}
+		for _, forbidden := range []string{"kernel_image:", "rootfs:", "iptables:"} {
+			if strings.Contains(string(raw), forbidden) {
+				t.Fatalf("expected generated config to omit zero-value field %q, got:\n%s", forbidden, raw)
+			}
+		}
 	}
 	if !strings.Contains(string(raw), "snapshots:") {
 		t.Fatalf("expected generated config to include snapshot defaults, got:\n%s", raw)
 	}
-	if !strings.Contains(string(raw), "enabled: false") {
+	if runtime.GOOS != "darwin" && !strings.Contains(string(raw), "enabled: false") {
 		t.Fatalf("expected generated config to include disabled snapshot default, got:\n%s", raw)
 	}
-	if !strings.Contains(string(raw), "driver: file") {
+	if runtime.GOOS != "darwin" && !strings.Contains(string(raw), "driver: file") {
 		t.Fatalf("expected generated config to include firecracker snapshot driver default, got:\n%s", raw)
 	}
-	if !strings.Contains(string(raw), "driver: apfs") {
+	if runtime.GOOS == "darwin" && (!strings.Contains(string(raw), "enabled: true") || !strings.Contains(string(raw), "driver: apfs")) {
+		t.Fatalf("expected generated config to enable darwin-vz snapshots on darwin hosts, got:\n%s", raw)
+	}
+	if runtime.GOOS == "darwin" && !strings.Contains(string(raw), "driver: apfs") {
 		t.Fatalf("expected generated config to include darwin-vz snapshot driver default, got:\n%s", raw)
 	}
 	if strings.Contains(string(raw), "base_dir:") {
@@ -98,6 +149,70 @@ func TestConfigInitWritesRuntimeConfig(t *testing.T) {
 	}
 	if strings.Contains(string(raw), "quiesce_timeout_seconds:") {
 		t.Fatalf("expected generated config to omit empty snapshot quiesce timeout, got:\n%s", raw)
+	}
+}
+
+func TestConfigInitDisablesDarwinVZSnapshotsWhenSupportUnavailable(t *testing.T) {
+	stubFirecrackerHostSupport(t, func(context.Context, backend.FirecrackerConfig) backendfirecracker.HostSupport {
+		return backendfirecracker.HostSupport{}
+	})
+	stubDarwinVZSnapshotSupport(t, func() backenddarwinvz.SnapshotSupport {
+		return backenddarwinvz.SnapshotSupport{Usable: false, Message: "darwin-vz snapshots remain disabled: helper unavailable"}
+	})
+
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	stdout, _ := makeStdoutCapture(t)
+	stderr, readStderr := makeStdoutCapture(t)
+	cmd := &ConfigInitCommand{DefaultBackend: "darwin-vz"}
+	if err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout, Stderr: stderr}); err != nil {
+		t.Fatalf("ConfigInitCommand.Run returned error: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(tmpDir, "cleanroom", "config.yaml"))
+	if err != nil {
+		t.Fatalf("read generated config: %v", err)
+	}
+
+	var cfg runtimeconfig.Config
+	if err := yaml.Unmarshal(raw, &cfg); err != nil {
+		t.Fatalf("parse generated yaml: %v", err)
+	}
+	if !strings.Contains(string(raw), "darwin-vz:") {
+		t.Fatalf("expected generated config to include darwin-vz backend, got:\n%s", raw)
+	}
+	if !strings.Contains(string(raw), "backends:\n  darwin-vz:") {
+		t.Fatalf("expected generated config to use 2-space indentation, got:\n%s", raw)
+	}
+	if strings.Contains(string(raw), "firecracker:") {
+		t.Fatalf("expected generated config to omit firecracker backend when default backend is darwin-vz, got:\n%s", raw)
+	}
+	if cfg.Backends.DarwinVZ.Snapshots.Enabled {
+		t.Fatal("expected backends.darwin-vz.snapshots.enabled to default false when support is unavailable")
+	}
+	if got, want := cfg.Backends.DarwinVZ.Snapshots.Driver, "apfs"; got != want {
+		t.Fatalf("unexpected darwin-vz snapshot driver: got %q want %q", got, want)
+	}
+	if got, want := cfg.Backends.DarwinVZ.MemoryMiB, int64(4096); got != want {
+		t.Fatalf("expected backends.darwin-vz.memory_mib=%d, got %d", want, got)
+	}
+	if got, want := int64(cfg.Backends.DarwinVZ.MinimumRootFSBytes), int64(4<<30); got != want {
+		t.Fatalf("expected backends.darwin-vz.minimum_rootfs_bytes=%d, got %d", want, got)
+	}
+	if out := readStderr(); !strings.Contains(out, "darwin-vz snapshots remain disabled: helper unavailable") {
+		t.Fatalf("expected darwin-vz snapshot warning, got %q", out)
+	}
+	if !strings.Contains(string(raw), "memory_mib: 4096") {
+		t.Fatalf("expected generated config to include memory_mib: 4096, got:\n%s", raw)
+	}
+	if !strings.Contains(string(raw), "minimum_rootfs_bytes: 4GiB") {
+		t.Fatalf("expected generated config to include minimum_rootfs_bytes: 4GiB, got:\n%s", raw)
+	}
+	for _, forbidden := range []string{"enabled: false", "kernel_image:", "rootfs:", "iptables:"} {
+		if strings.Contains(string(raw), forbidden) {
+			t.Fatalf("expected generated config to omit zero-value field %q, got:\n%s", forbidden, raw)
+		}
 	}
 }
 

--- a/internal/cli/config_init_test.go
+++ b/internal/cli/config_init_test.go
@@ -43,9 +43,9 @@ func TestConfigInitWritesRuntimeConfig(t *testing.T) {
 		t.Fatalf("read generated config: %v", err)
 	}
 
-	var cfg runtimeconfig.Config
-	if err := yaml.Unmarshal(raw, &cfg); err != nil {
-		t.Fatalf("parse generated yaml: %v", err)
+	cfg, _, err := runtimeconfig.LoadPath(configPath)
+	if err != nil {
+		t.Fatalf("load generated config: %v", err)
 	}
 	if runtime.GOOS == "darwin" {
 		if !strings.Contains(string(raw), "darwin-vz:") {
@@ -64,6 +64,9 @@ func TestConfigInitWritesRuntimeConfig(t *testing.T) {
 	}
 	if got := strings.TrimSpace(cfg.DefaultBackend); got == "" {
 		t.Fatal("expected default_backend to be populated")
+	}
+	if strings.Contains(string(raw), "default_backend:") {
+		t.Fatalf("expected generated config to omit default_backend when only one backend is defined, got:\n%s", raw)
 	}
 	if runtime.GOOS == "darwin" {
 		if strings.Contains(string(raw), "firecracker:") {
@@ -170,14 +173,15 @@ func TestConfigInitDisablesDarwinVZSnapshotsWhenSupportUnavailable(t *testing.T)
 		t.Fatalf("ConfigInitCommand.Run returned error: %v", err)
 	}
 
-	raw, err := os.ReadFile(filepath.Join(tmpDir, "cleanroom", "config.yaml"))
+	configPath := filepath.Join(tmpDir, "cleanroom", "config.yaml")
+	raw, err := os.ReadFile(configPath)
 	if err != nil {
 		t.Fatalf("read generated config: %v", err)
 	}
 
-	var cfg runtimeconfig.Config
-	if err := yaml.Unmarshal(raw, &cfg); err != nil {
-		t.Fatalf("parse generated yaml: %v", err)
+	cfg, _, err := runtimeconfig.LoadPath(configPath)
+	if err != nil {
+		t.Fatalf("load generated config: %v", err)
 	}
 	if !strings.Contains(string(raw), "darwin-vz:") {
 		t.Fatalf("expected generated config to include darwin-vz backend, got:\n%s", raw)

--- a/internal/cli/darwinvz_support_test.go
+++ b/internal/cli/darwinvz_support_test.go
@@ -1,0 +1,16 @@
+package cli
+
+import (
+	"testing"
+
+	backenddarwinvz "github.com/buildkite/cleanroom/internal/backend/darwinvz"
+)
+
+func stubDarwinVZSnapshotSupport(t *testing.T, fn func() backenddarwinvz.SnapshotSupport) {
+	t.Helper()
+	prev := detectDarwinVZSnapshotSupport
+	detectDarwinVZSnapshotSupport = fn
+	t.Cleanup(func() {
+		detectDarwinVZSnapshotSupport = prev
+	})
+}

--- a/internal/cli/policy_config.go
+++ b/internal/cli/policy_config.go
@@ -224,7 +224,7 @@ func defaultDarwinVZSnapshotConfig(emitRuntimeWarnings bool) (runtimeconfig.Snap
 }
 
 type runtimeConfigTemplate struct {
-	DefaultBackend string                     `yaml:"default_backend"`
+	DefaultBackend string                     `yaml:"default_backend,omitempty"`
 	Backends       runtimeConfigTemplateNodes `yaml:"backends"`
 }
 
@@ -279,8 +279,7 @@ type runtimeConfigSnapshot struct {
 
 func defaultRuntimeConfig(defaultBackend string, firecrackerSnapshots, darwinVZSnapshots runtimeconfig.SnapshotConfig) runtimeConfigTemplate {
 	tpl := runtimeConfigTemplate{
-		DefaultBackend: defaultBackend,
-		Backends:       runtimeConfigTemplateNodes{},
+		Backends: runtimeConfigTemplateNodes{},
 	}
 
 	switch defaultBackend {

--- a/internal/cli/policy_config.go
+++ b/internal/cli/policy_config.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -9,12 +10,14 @@ import (
 	"strings"
 
 	"github.com/buildkite/cleanroom/internal/backend"
+	backenddarwinvz "github.com/buildkite/cleanroom/internal/backend/darwinvz"
 	backendfirecracker "github.com/buildkite/cleanroom/internal/backend/firecracker"
 	"github.com/buildkite/cleanroom/internal/runtimeconfig"
 	"gopkg.in/yaml.v3"
 )
 
 var detectFirecrackerHostSupport = backendfirecracker.DetectHostSupport
+var detectDarwinVZSnapshotSupport = backenddarwinvz.DetectSnapshotSupport
 
 type PolicyCommand struct {
 	Validate PolicyValidateCommand `cmd:"" help:"Validate policy configuration"`
@@ -100,8 +103,14 @@ func (c *ConfigInitCommand) Run(ctx *runtimeContext) error {
 	}
 
 	firecrackerSnapshots, warnings := defaultFirecrackerSnapshotConfig(context.Background(), defaultBackend == "firecracker" || hostDefaultBackend() == "firecracker")
+	darwinVZSnapshots := runtimeconfig.SnapshotConfig{Enabled: false, Driver: "apfs"}
+	if defaultBackend == "darwin-vz" {
+		var darwinVZWarnings []string
+		darwinVZSnapshots, darwinVZWarnings = defaultDarwinVZSnapshotConfig(true)
+		warnings = append(warnings, darwinVZWarnings...)
+	}
 
-	payload, err := yaml.Marshal(defaultRuntimeConfig(defaultBackend, firecrackerSnapshots))
+	payload, err := marshalRuntimeConfigTemplate(defaultRuntimeConfig(defaultBackend, firecrackerSnapshots, darwinVZSnapshots))
 	if err != nil {
 		return fmt.Errorf("marshal runtime config template: %w", err)
 	}
@@ -195,48 +204,138 @@ func defaultFirecrackerSnapshotConfig(ctx context.Context, emitRuntimeWarnings b
 	return snapshot, []string{"firecracker snapshots default to driver=file: " + support.ZFSMessage}
 }
 
-func defaultRuntimeConfig(defaultBackend string, firecrackerSnapshots runtimeconfig.SnapshotConfig) runtimeconfig.Config {
-	return runtimeconfig.Config{
-		DefaultBackend: defaultBackend,
-		Backends: runtimeconfig.Backends{
-			Firecracker: runtimeconfig.FirecrackerConfig{
-				BinaryPath:  "firecracker",
-				KernelImage: "",
-				RootFS:      "",
-				Services: runtimeconfig.ServicesConfig{
-					Docker: runtimeconfig.DockerServiceConfig{
-						StartupTimeoutSeconds: 20,
-						StorageDriver:         "vfs",
-						IPTables:              false,
-					},
-				},
-				Snapshots:            firecrackerSnapshots,
-				PrivilegedHelperPath: "/usr/local/sbin/cleanroom-root-helper",
-				VCPUs:                2,
-				MemoryMiB:            1024,
-				GuestCID:             3,
-				GuestPort:            10700,
-				LaunchSeconds:        30,
-			},
-			DarwinVZ: runtimeconfig.DarwinVZConfig{
-				KernelImage: "",
-				RootFS:      "",
-				Services: runtimeconfig.ServicesConfig{
-					Docker: runtimeconfig.DockerServiceConfig{
-						StartupTimeoutSeconds: 20,
-						StorageDriver:         "vfs",
-						IPTables:              false,
-					},
-				},
-				Snapshots: runtimeconfig.SnapshotConfig{
-					Enabled: false,
-					Driver:  "apfs",
-				},
-				VCPUs:         2,
-				MemoryMiB:     1024,
-				GuestPort:     10700,
-				LaunchSeconds: 30,
-			},
-		},
+func defaultDarwinVZSnapshotConfig(emitRuntimeWarnings bool) (runtimeconfig.SnapshotConfig, []string) {
+	snapshot := runtimeconfig.SnapshotConfig{Enabled: false, Driver: "apfs"}
+	support := detectDarwinVZSnapshotSupport()
+	if !support.Usable {
+		warnings := []string{}
+		if emitRuntimeWarnings {
+			message := strings.TrimSpace(support.Message)
+			if message == "" {
+				message = "darwin-vz snapshots remain disabled: snapshot runtime is not usable"
+			}
+			warnings = append(warnings, message)
+		}
+		return snapshot, warnings
 	}
+
+	snapshot.Enabled = true
+	return snapshot, nil
+}
+
+type runtimeConfigTemplate struct {
+	DefaultBackend string                     `yaml:"default_backend"`
+	Backends       runtimeConfigTemplateNodes `yaml:"backends"`
+}
+
+type runtimeConfigTemplateNodes struct {
+	Firecracker *runtimeConfigFirecracker `yaml:"firecracker,omitempty"`
+	DarwinVZ    *runtimeConfigDarwinVZ    `yaml:"darwin-vz,omitempty"`
+}
+
+type runtimeConfigFirecracker struct {
+	BinaryPath           string                `yaml:"binary_path,omitempty"`
+	KernelImage          string                `yaml:"kernel_image,omitempty"`
+	RootFS               string                `yaml:"rootfs,omitempty"`
+	Services             runtimeConfigServices `yaml:"services,omitempty"`
+	Snapshots            runtimeConfigSnapshot `yaml:"snapshots,omitempty"`
+	PrivilegedHelperPath string                `yaml:"privileged_helper_path,omitempty"`
+	VCPUs                int64                 `yaml:"vcpus,omitempty"`
+	MemoryMiB            int64                 `yaml:"memory_mib,omitempty"`
+	GuestCID             uint32                `yaml:"guest_cid,omitempty"`
+	GuestPort            uint32                `yaml:"guest_port,omitempty"`
+	LaunchSeconds        int64                 `yaml:"launch_seconds,omitempty"`
+}
+
+type runtimeConfigDarwinVZ struct {
+	KernelImage        string                `yaml:"kernel_image,omitempty"`
+	RootFS             string                `yaml:"rootfs,omitempty"`
+	MinimumRootFSBytes string                `yaml:"minimum_rootfs_bytes,omitempty"`
+	Services           runtimeConfigServices `yaml:"services,omitempty"`
+	Snapshots          runtimeConfigSnapshot `yaml:"snapshots,omitempty"`
+	VCPUs              int64                 `yaml:"vcpus,omitempty"`
+	MemoryMiB          int64                 `yaml:"memory_mib,omitempty"`
+	GuestPort          uint32                `yaml:"guest_port,omitempty"`
+	LaunchSeconds      int64                 `yaml:"launch_seconds,omitempty"`
+}
+
+type runtimeConfigServices struct {
+	Docker runtimeConfigDockerService `yaml:"docker,omitempty"`
+}
+
+type runtimeConfigDockerService struct {
+	StartupTimeoutSeconds int64  `yaml:"startup_timeout_seconds,omitempty"`
+	StorageDriver         string `yaml:"storage_driver,omitempty"`
+	IPTables              bool   `yaml:"iptables,omitempty"`
+}
+
+type runtimeConfigSnapshot struct {
+	Enabled               bool   `yaml:"enabled,omitempty"`
+	Driver                string `yaml:"driver,omitempty"`
+	BaseDir               string `yaml:"base_dir,omitempty"`
+	ZFSDataset            string `yaml:"zfs_dataset,omitempty"`
+	QuiesceTimeoutSeconds int64  `yaml:"quiesce_timeout_seconds,omitempty"`
+}
+
+func defaultRuntimeConfig(defaultBackend string, firecrackerSnapshots, darwinVZSnapshots runtimeconfig.SnapshotConfig) runtimeConfigTemplate {
+	tpl := runtimeConfigTemplate{
+		DefaultBackend: defaultBackend,
+		Backends:       runtimeConfigTemplateNodes{},
+	}
+
+	switch defaultBackend {
+	case "darwin-vz":
+		tpl.Backends.DarwinVZ = &runtimeConfigDarwinVZ{
+			KernelImage:        "",
+			RootFS:             "",
+			MinimumRootFSBytes: "4GiB",
+			Services: runtimeConfigServices{
+				Docker: runtimeConfigDockerService{
+					StartupTimeoutSeconds: 20,
+					StorageDriver:         "vfs",
+					IPTables:              false,
+				},
+			},
+			Snapshots:     runtimeConfigSnapshot(darwinVZSnapshots),
+			VCPUs:         2,
+			MemoryMiB:     4096,
+			GuestPort:     10700,
+			LaunchSeconds: 30,
+		}
+	default:
+		tpl.Backends.Firecracker = &runtimeConfigFirecracker{
+			BinaryPath:  "firecracker",
+			KernelImage: "",
+			RootFS:      "",
+			Services: runtimeConfigServices{
+				Docker: runtimeConfigDockerService{
+					StartupTimeoutSeconds: 20,
+					StorageDriver:         "vfs",
+					IPTables:              false,
+				},
+			},
+			Snapshots:            runtimeConfigSnapshot(firecrackerSnapshots),
+			PrivilegedHelperPath: "/usr/local/sbin/cleanroom-root-helper",
+			VCPUs:                2,
+			MemoryMiB:            1024,
+			GuestCID:             3,
+			GuestPort:            10700,
+			LaunchSeconds:        30,
+		}
+	}
+
+	return tpl
+}
+
+func marshalRuntimeConfigTemplate(cfg runtimeConfigTemplate) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(cfg); err != nil {
+		return nil, err
+	}
+	if err := enc.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }

--- a/internal/runtimeconfig/config.go
+++ b/internal/runtimeconfig/config.go
@@ -387,12 +387,21 @@ func parseConfig(path string, raw []byte) (Config, error) {
 	if err := yaml.Unmarshal(raw, &cfg); err != nil {
 		return Config{}, fmt.Errorf("parse %s: %w", path, err)
 	}
+	backendPresence := struct {
+		Backends struct {
+			Firecracker    *yaml.Node `yaml:"firecracker"`
+			DarwinVZ       *yaml.Node `yaml:"darwin-vz"`
+			LegacyDarwinVZ *yaml.Node `yaml:"darwin_vz"`
+		} `yaml:"backends"`
+	}{}
+	if err := yaml.Unmarshal(raw, &backendPresence); err != nil {
+		return Config{}, fmt.Errorf("parse %s: %w", path, err)
+	}
 	presenceCfg := struct {
 		Backends struct {
 			DarwinVZ struct {
 				MinimumRootFSBytes *ByteSize `yaml:"minimum_rootfs_bytes"`
 			} `yaml:"darwin-vz"`
-			LegacyDarwinVZ *yaml.Node `yaml:"darwin_vz"`
 		} `yaml:"backends"`
 	}{}
 	if err := yaml.Unmarshal(raw, &presenceCfg); err != nil {
@@ -408,7 +417,7 @@ func parseConfig(path string, raw []byte) (Config, error) {
 			} `yaml:"backends"`
 		}{}
 		if err := yaml.Unmarshal(raw, &legacyCfg); err != nil {
-			if presenceCfg.Backends.LegacyDarwinVZ != nil {
+			if backendPresence.Backends.LegacyDarwinVZ != nil {
 				return Config{}, fmt.Errorf("parse %s: %w", path, err)
 			}
 		} else if darwinVZConfigHasValues(legacyCfg.Backends.DarwinVZ) {
@@ -419,17 +428,17 @@ func parseConfig(path string, raw []byte) (Config, error) {
 		cfg.Backends.DarwinVZ.MinimumRootFSBytes = darwinVZMinRootFSBytes
 	}
 
-	cfg = normalizeConfig(cfg)
+	cfg = normalizeConfig(cfg, inferredDefaultBackend(backendPresence.Backends.Firecracker != nil, backendPresence.Backends.DarwinVZ != nil || backendPresence.Backends.LegacyDarwinVZ != nil))
 	if err := validateConfig(cfg); err != nil {
 		return Config{}, err
 	}
 	return cfg, nil
 }
 
-func normalizeConfig(cfg Config) Config {
+func normalizeConfig(cfg Config, inferredDefaultBackend string) Config {
 	cfg.DefaultBackend = strings.TrimSpace(cfg.DefaultBackend)
 	if cfg.DefaultBackend == "" {
-		cfg.DefaultBackend = DefaultBackendForHost()
+		cfg.DefaultBackend = inferredDefaultBackend
 	}
 	cfg.ControlHost = strings.TrimSpace(cfg.ControlHost)
 	cfg.Gateway.Git.CacheHosts = trimStringSlice(cfg.Gateway.Git.CacheHosts)
@@ -442,6 +451,16 @@ func normalizeConfig(cfg Config) Config {
 	cfg.Observability.Traces.Zipkin.Endpoint = strings.TrimSpace(cfg.Observability.Traces.Zipkin.Endpoint)
 	cfg.Observability.Traces.Zipkin.Headers = trimStringMap(cfg.Observability.Traces.Zipkin.Headers)
 	return cfg
+}
+
+func inferredDefaultBackend(hasFirecracker, hasDarwinVZ bool) string {
+	if hasFirecracker == hasDarwinVZ {
+		return DefaultBackendForHost()
+	}
+	if hasFirecracker {
+		return "firecracker"
+	}
+	return "darwin-vz"
 }
 
 func validateConfig(cfg Config) error {

--- a/internal/runtimeconfig/config_test.go
+++ b/internal/runtimeconfig/config_test.go
@@ -616,7 +616,29 @@ backends:
 	}
 }
 
-func TestLoadDefaultsBackendWhenMissing(t *testing.T) {
+func TestLoadDefaultsBackendWhenMissingAndCannotBeInferred(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	configPath := filepath.Join(tmp, "cleanroom", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+
+	content := "backends: {}\n"
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, _, err := Load()
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if got, want := cfg.DefaultBackend, DefaultBackendForHost(); got != want {
+		t.Fatalf("unexpected default backend: got %q want %q", got, want)
+	}
+}
+
+func TestLoadUsesOnlyDefinedBackendWhenDefaultBackendMissing(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)
 	configPath := filepath.Join(tmp, "cleanroom", "config.yaml")
@@ -636,7 +658,7 @@ func TestLoadDefaultsBackendWhenMissing(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load returned error: %v", err)
 	}
-	if got, want := cfg.DefaultBackend, DefaultBackendForHost(); got != want {
+	if got, want := cfg.DefaultBackend, "firecracker"; got != want {
 		t.Fatalf("unexpected default backend: got %q want %q", got, want)
 	}
 }


### PR DESCRIPTION
## Summary
- generate cleaner config-init YAML with 2-space indentation and omitted zero-value fields
- emit only the relevant backend block in generated runtime config
- detect darwin-vz snapshot support before enabling snapshots by default
- raise darwin-vz config-init defaults to 4096 MiB memory and a 4GiB minimum rootfs

## Testing
- go test ./internal/backend/darwinvz ./internal/cli ./internal/runtimeconfig
- go test ./...
