### PR TITLE
refactor: centralise observability telemetry contract

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -176,3 +176,33 @@ correlation fields used elsewhere:
 - `reason_code`
 - `component`
 - `subsystem`
+
+### Cache observability
+
+Layered-cache stage names are appropriate in observability because they help
+operators understand cache lookup, restore, publish, and fallback behaviour.
+They should remain telemetry vocabulary, not primary user-facing product nouns.
+
+The cache-stage values are:
+
+- `runtime`
+- `workspace`
+- `dependency`
+
+Recommended cache telemetry attributes are:
+
+- `cleanroom.cache.stage=runtime|workspace|dependency`
+- `cleanroom.cache.operation=lookup|restore|publish|invalidate`
+- `cleanroom.cache.result=hit|miss|restored|published|fallback|failed`
+
+Use these fields in traces and structured logs for cache-specific work. Use
+them in metrics only for cache-specific series, not for generic execution
+metrics.
+
+Recommended cache-specific metric naming is:
+
+- `cleanroom_cache_operation_total{stage,operation,result}`
+- `cleanroom_cache_operation_duration_seconds{stage,operation}`
+
+Do not put cache keys, storage refs, snapshot IDs, execution IDs, sandbox IDs,
+or image digests into metric labels.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -75,3 +75,104 @@ In the local Grafana stack:
   the local Docker Compose stack
 - [docs/api.md](api.md) for execution inspection behaviour
 - [docs/isolation.md](isolation.md) for retained execution observability files
+
+## Telemetry contract
+
+This section is the canonical observability contract for names and fields that
+Cleanroom emits today. When we rename or remove any of these, update the
+emitters and this document in the same change.
+
+### Resource attributes
+
+Every process should emit these stable OpenTelemetry resource attributes:
+
+- `service.namespace=cleanroom`
+- `service.name`
+- `service.version` when available
+- `deployment.environment.name` when configured
+
+### Root spans
+
+The current top-level product spans are:
+
+- `cleanroom.exec`
+- `cleanroom.console`
+- `cleanroom.sandbox.create`
+- `cleanroom.execution.create`
+- `cleanroom.execution.run`
+- `cleanroom.gateway.<service>.request`
+
+`<service>` is one of `git`, `registry`, `rubygems`, `secrets`, or `meta`.
+
+Sandbox creation may emit additional child spans under the
+`cleanroom.sandbox.*` prefix for cache lookup, restore, bootstrap, and publish
+phases.
+
+### Metrics
+
+The current metric names are:
+
+- `cleanroom_sandbox_create_duration_seconds{backend,source,outcome}`
+- `cleanroom_execution_total{backend,kind,outcome}`
+- `cleanroom_execution_duration_seconds{backend,kind,outcome}`
+- `cleanroom_gateway_requests_total{service,action,reason_code,status_class}`
+- `cleanroom_gateway_request_duration_seconds{service,action}`
+- `cleanroom_launch_phase_duration_seconds{backend,phase}`
+
+Metric labels must stay low-cardinality. Execution IDs, sandbox IDs, image
+digests, and host IPs belong in traces, logs, or retained artefacts, not in
+metric labels.
+
+### Common attributes
+
+These attribute keys form the shared contract across traces, metrics, and
+structured logs where applicable:
+
+- `cleanroom.backend`
+- `cleanroom.sandbox.id`
+- `cleanroom.execution.id`
+- `cleanroom.execution.kind`
+- `cleanroom.reason_code`
+- `cleanroom.gateway.service`
+- `cleanroom.gateway.action`
+- `cleanroom.command.argc`
+- `cleanroom.command.name`
+- `cleanroom.command.summary`
+
+### Outcomes and reason codes
+
+Execution and sandbox telemetry should use backend-neutral outcomes:
+
+- `succeeded`
+- `failed`
+- `canceled`
+- `timed_out`
+
+Gateway request telemetry keeps the request decision as a separate axis:
+
+- `action=allow`
+- `action=deny`
+
+Current gateway `reason_code` values include:
+
+- `host_not_allowed`
+- `method_not_allowed`
+- `upstream_error`
+- `unknown_registry_prefix`
+- `proxied`
+- `mirrored`
+- `cached`
+
+### Log correlation
+
+When logs are emitted in structured form, they should carry the same core
+correlation fields used elsewhere:
+
+- `trace_id`
+- `span_id`
+- `execution_id`
+- `sandbox_id`
+- `backend`
+- `reason_code`
+- `component`
+- `subsystem`

--- a/internal/cli/console.go
+++ b/internal/cli/console.go
@@ -15,6 +15,7 @@ import (
 	"github.com/buildkite/cleanroom/internal/endpoint"
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
 	"github.com/buildkite/cleanroom/internal/interactivequic"
+	"github.com/buildkite/cleanroom/internal/observability"
 	"github.com/buildkite/cleanroom/internal/repositorycheckout"
 	"github.com/buildkite/cleanroom/internal/runtimeconfig"
 	"go.opentelemetry.io/otel/attribute"
@@ -54,28 +55,28 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) (runErr error) {
 	}
 	commandArgs := executionCommandArgs(command)
 	rootAttrs := []attribute.KeyValue{
-		attribute.String("cleanroom.backend.requested", strings.TrimSpace(c.Backend)),
-		attribute.Bool("cleanroom.keep_sandbox", c.Keep),
-		attribute.Int("cleanroom.command.argc", len(commandArgs)),
+		attribute.String(observability.AttrBackendRequested, strings.TrimSpace(c.Backend)),
+		attribute.Bool(observability.AttrKeepSandbox, c.Keep),
+		attribute.Int(observability.AttrCommandArgc, len(commandArgs)),
 	}
 	if commandName := executionCommandName(commandArgs); commandName != "" {
 		rootAttrs = append(rootAttrs,
-			attribute.String("cleanroom.command.name", commandName),
-			attribute.String("cleanroom.command.summary", executionCommandSummary(commandArgs)),
+			attribute.String(observability.AttrCommandName, commandName),
+			attribute.String(observability.AttrCommandSummary, executionCommandSummary(commandArgs)),
 		)
 	}
 	rootCtx, rootSpan := ctx.Observability.Tracer("github.com/buildkite/cleanroom/internal/cli").Start(
 		context.Background(),
-		"cleanroom.console",
+		observability.SpanConsole,
 		trace.WithAttributes(rootAttrs...),
 	)
 	traceID := traceIDFromContext(rootCtx)
 	defer func() {
 		if sandboxID != "" {
-			rootSpan.SetAttributes(attribute.String("cleanroom.sandbox.id", sandboxID))
+			rootSpan.SetAttributes(attribute.String(observability.AttrSandboxID, sandboxID))
 		}
 		if executionID != "" {
-			rootSpan.SetAttributes(attribute.String("cleanroom.execution.id", executionID))
+			rootSpan.SetAttributes(attribute.String(observability.AttrExecutionID, executionID))
 		}
 		if runErr != nil {
 			rootSpan.RecordError(runErr)

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+	"github.com/buildkite/cleanroom/internal/observability"
 	"github.com/buildkite/cleanroom/internal/repositorycheckout"
 	"github.com/buildkite/cleanroom/internal/runtimeconfig"
 	"go.opentelemetry.io/otel/attribute"
@@ -45,29 +46,29 @@ func (e *ExecCommand) Run(ctx *runtimeContext) (runErr error) {
 	executionID := ""
 	commandArgs := executionCommandArgs(e.Command)
 	rootAttrs := []attribute.KeyValue{
-		attribute.String("cleanroom.backend.requested", strings.TrimSpace(e.Backend)),
-		attribute.Bool("cleanroom.keep_sandbox", e.Keep),
-		attribute.Bool("cleanroom.stdin.disabled", e.NoStdin),
-		attribute.Int("cleanroom.command.argc", len(commandArgs)),
+		attribute.String(observability.AttrBackendRequested, strings.TrimSpace(e.Backend)),
+		attribute.Bool(observability.AttrKeepSandbox, e.Keep),
+		attribute.Bool(observability.AttrStdinDisabled, e.NoStdin),
+		attribute.Int(observability.AttrCommandArgc, len(commandArgs)),
 	}
 	if commandName := executionCommandName(commandArgs); commandName != "" {
 		rootAttrs = append(rootAttrs,
-			attribute.String("cleanroom.command.name", commandName),
-			attribute.String("cleanroom.command.summary", executionCommandSummary(commandArgs)),
+			attribute.String(observability.AttrCommandName, commandName),
+			attribute.String(observability.AttrCommandSummary, executionCommandSummary(commandArgs)),
 		)
 	}
 	rootCtx, rootSpan := ctx.Observability.Tracer("github.com/buildkite/cleanroom/internal/cli").Start(
 		context.Background(),
-		"cleanroom.exec",
+		observability.SpanExec,
 		trace.WithAttributes(rootAttrs...),
 	)
 	traceID := traceIDFromContext(rootCtx)
 	defer func() {
 		if sandboxID != "" {
-			rootSpan.SetAttributes(attribute.String("cleanroom.sandbox.id", sandboxID))
+			rootSpan.SetAttributes(attribute.String(observability.AttrSandboxID, sandboxID))
 		}
 		if executionID != "" {
-			rootSpan.SetAttributes(attribute.String("cleanroom.execution.id", executionID))
+			rootSpan.SetAttributes(attribute.String(observability.AttrExecutionID, executionID))
 		}
 		if runErr != nil {
 			rootSpan.RecordError(runErr)

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -212,16 +212,7 @@ func executionKindMetricValue(kind cleanroomv1.ExecutionKind) string {
 }
 
 func executionOutcomeMetricValue(status cleanroomv1.ExecutionStatus) string {
-	switch status {
-	case cleanroomv1.ExecutionStatus_EXECUTION_STATUS_SUCCEEDED:
-		return "succeeded"
-	case cleanroomv1.ExecutionStatus_EXECUTION_STATUS_FAILED:
-		return "failed"
-	case cleanroomv1.ExecutionStatus_EXECUTION_STATUS_CANCELED:
-		return "canceled"
-	default:
-		return strings.ToLower(strings.TrimPrefix(status.String(), "EXECUTION_STATUS_"))
-	}
+	return observability.ExecutionOutcome(status)
 }
 
 var (
@@ -248,19 +239,19 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 	backendName := resolveBackendName(strings.TrimSpace(req.GetBackend()), s.Config.DefaultBackend)
 	ctx, span := s.Observability.Tracer("github.com/buildkite/cleanroom/internal/controlservice").Start(
 		ctx,
-		"cleanroom.sandbox.create",
+		observability.SpanSandboxCreate,
 		trace.WithAttributes(
-			attribute.Bool("cleanroom.sandbox.from_snapshot", snapshotID != ""),
-			attribute.Bool("cleanroom.repository.checkout", req.GetRepositoryCheckout() != nil),
-			attribute.Bool("cleanroom.repository.changeset", changeset != nil),
+			attribute.Bool(observability.AttrSandboxFromSnapshot, snapshotID != ""),
+			attribute.Bool(observability.AttrRepositoryCheckout, req.GetRepositoryCheckout() != nil),
+			attribute.Bool(observability.AttrRepositoryChangeset, changeset != nil),
 		),
 	)
 	defer func() {
 		metricBackendName := backendName
 		if resp != nil && resp.GetSandbox() != nil {
 			span.SetAttributes(
-				attribute.String("cleanroom.backend", resp.GetSandbox().GetBackend()),
-				attribute.String("cleanroom.sandbox.id", resp.GetSandbox().GetSandboxId()),
+				attribute.String(observability.AttrBackend, resp.GetSandbox().GetBackend()),
+				attribute.String(observability.AttrSandboxID, resp.GetSandbox().GetSandboxId()),
 			)
 			if resolvedBackend := strings.TrimSpace(resp.GetSandbox().GetBackend()); resolvedBackend != "" {
 				metricBackendName = resolvedBackend
@@ -277,7 +268,7 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 				ctx,
 				metricBackendName,
 				sandboxCreateSourceMetricValue(snapshotID, metricSourceKind),
-				map[bool]string{true: "failed", false: "succeeded"}[err != nil],
+				map[bool]string{true: observability.OutcomeFailed, false: observability.OutcomeSucceeded}[err != nil],
 				s.clock().Now().Sub(createStarted),
 			)
 		}
@@ -305,7 +296,7 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 		return nil, fmt.Errorf("invalid policy: %w", err)
 	}
 
-	span.SetAttributes(attribute.String("cleanroom.backend", backendName))
+	span.SetAttributes(attribute.String(observability.AttrBackend, backendName))
 	adapter, ok := s.Backends[backendName]
 	if !ok {
 		return nil, fmt.Errorf("unknown backend %q", backendName)
@@ -1125,17 +1116,17 @@ func (s *Service) CreateExecution(ctx context.Context, req *cleanroomv1.CreateEx
 	}
 	ctx, span := s.Observability.Tracer("github.com/buildkite/cleanroom/internal/controlservice").Start(
 		ctx,
-		"cleanroom.execution.create",
+		observability.SpanExecutionCreate,
 		trace.WithAttributes(
-			attribute.String("cleanroom.sandbox.id", sandboxID),
-			attribute.Int("cleanroom.command.argc", len(command)),
+			attribute.String(observability.AttrSandboxID, sandboxID),
+			attribute.Int(observability.AttrCommandArgc, len(command)),
 		),
 	)
 	defer func() {
 		if resp != nil && resp.GetExecution() != nil {
 			span.SetAttributes(
-				attribute.String("cleanroom.execution.id", resp.GetExecution().GetExecutionId()),
-				attribute.String("cleanroom.execution.kind", resp.GetExecution().GetKind().String()),
+				attribute.String(observability.AttrExecutionID, resp.GetExecution().GetExecutionId()),
+				attribute.String(observability.AttrExecutionKind, resp.GetExecution().GetKind().String()),
 			)
 		}
 		if err != nil {
@@ -1184,7 +1175,7 @@ func (s *Service) CreateExecution(ctx context.Context, req *cleanroomv1.CreateEx
 		s.mu.Unlock()
 		return nil, fmt.Errorf("unknown sandbox %q", sandboxID)
 	}
-	span.SetAttributes(attribute.String("cleanroom.backend", sandbox.Backend))
+	span.SetAttributes(attribute.String(observability.AttrBackend, sandbox.Backend))
 	if sandbox.Status != cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY {
 		s.mu.Unlock()
 		return nil, fmt.Errorf("sandbox %q is not ready", sandboxID)
@@ -2053,13 +2044,13 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 	}
 	runCtx, span := s.Observability.Tracer("github.com/buildkite/cleanroom/internal/controlservice").Start(
 		runCtx,
-		"cleanroom.execution.run",
+		observability.SpanExecutionRun,
 		trace.WithAttributes(
-			attribute.String("cleanroom.backend", sb.Backend),
-			attribute.String("cleanroom.execution.id", ex.ID),
-			attribute.String("cleanroom.execution.kind", ex.Kind.String()),
-			attribute.String("cleanroom.sandbox.id", sandboxID),
-			attribute.Int("cleanroom.command.argc", len(ex.Command)),
+			attribute.String(observability.AttrBackend, sb.Backend),
+			attribute.String(observability.AttrExecutionID, ex.ID),
+			attribute.String(observability.AttrExecutionKind, ex.Kind.String()),
+			attribute.String(observability.AttrSandboxID, sandboxID),
+			attribute.Int(observability.AttrCommandArgc, len(ex.Command)),
 		),
 	)
 	s.mu.Unlock()
@@ -2225,9 +2216,9 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 		finalStatus = cleanroomv1.ExecutionStatus_EXECUTION_STATUS_SUCCEEDED
 	}
 	span.SetAttributes(
-		attribute.Bool("cleanroom.vm.launched", result.LaunchedVM),
-		attribute.Int("cleanroom.exit_code", result.ExitCode),
-		attribute.String("cleanroom.execution.status", finalStatus.String()),
+		attribute.Bool(observability.AttrVMLaunched, result.LaunchedVM),
+		attribute.Int(observability.AttrExitCode, result.ExitCode),
+		attribute.String(observability.AttrExecutionStatus, finalStatus.String()),
 	)
 	if finalStatus == cleanroomv1.ExecutionStatus_EXECUTION_STATUS_SUCCEEDED {
 		span.SetStatus(codes.Ok, "")

--- a/internal/controlservice/stored_rootfs.go
+++ b/internal/controlservice/stored_rootfs.go
@@ -8,6 +8,7 @@ import (
 	"github.com/buildkite/cleanroom/internal/backend"
 	"github.com/buildkite/cleanroom/internal/cachestore"
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+	"github.com/buildkite/cleanroom/internal/observability"
 	"github.com/buildkite/cleanroom/internal/policy"
 	"github.com/buildkite/cleanroom/internal/repositorycheckout"
 	"github.com/buildkite/cleanroom/internal/runtimeconfig"
@@ -132,8 +133,8 @@ func (s *Service) createSandboxFromStoredRootFS(ctx context.Context, req *cleanr
 		emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_RESTORE_WORKSPACE_STAGE_CACHE, "restoring workspace stage cache")
 	}
 	if err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.restore_snapshot", []attribute.KeyValue{
-		attribute.String("cleanroom.backend", backendName),
-		attribute.String("cleanroom.sandbox.id", sandboxID),
+		attribute.String(observability.AttrBackend, backendName),
+		attribute.String(observability.AttrSandboxID, sandboxID),
 		attribute.String("cleanroom.source_kind", sourceKind),
 	}, func(ctx context.Context) error {
 		return snapshotAdapter.ProvisionSandboxFromSnapshot(ctx, backend.ProvisionFromSnapshotRequest{

--- a/internal/gateway/git.go
+++ b/internal/gateway/git.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/buildkite/cleanroom/internal/observability"
 	"github.com/charmbracelet/log"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -24,10 +25,18 @@ const (
 	gitReceivePackService  = "git-receive-pack"
 	defaultUpstreamTimeout = 30 * time.Second
 
-	reasonCodeHeader       = "X-Cleanroom-Reason-Code"
-	reasonHostNotAllowed   = "host_not_allowed"
-	reasonMethodNotAllowed = "method_not_allowed"
-	reasonUpstreamError    = "upstream_error"
+	reasonCodeHeader            = "X-Cleanroom-Reason-Code"
+	reasonHostNotAllowed        = observability.ReasonHostNotAllowed
+	reasonMethodNotAllowed      = observability.ReasonMethodNotAllowed
+	reasonUpstreamError         = observability.ReasonUpstreamError
+	reasonUnknownRegistryPrefix = observability.ReasonUnknownRegistryPrefix
+	reasonProxied               = observability.ReasonProxied
+	reasonMirrored              = observability.ReasonMirrored
+	reasonCached                = observability.ReasonCached
+	reasonFallback              = observability.ReasonFallback
+	reasonRubyGemsUnavailable   = observability.ReasonRubyGemsUnavailable
+	gatewayActionAllow          = observability.GatewayActionAllow
+	gatewayActionDeny           = observability.GatewayActionDeny
 )
 
 type gitHandler struct {
@@ -79,36 +88,36 @@ func (h *gitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	span.SetAttributes(
-		attribute.String("cleanroom.gateway.target_host", upstreamHost),
-		attribute.String("cleanroom.gateway.repo_path", repoPath),
+		attribute.String(observability.AttrGatewayTargetHost, upstreamHost),
+		attribute.String(observability.AttrGatewayRepoPath, repoPath),
 	)
 
 	if !scope.Policy.Allows(upstreamHost, 443) {
-		setGatewayRequestDecision(r.Context(), "deny", reasonHostNotAllowed)
+		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonHostNotAllowed)
 		span.SetAttributes(
-			attribute.String("cleanroom.gateway.action", "deny"),
-			attribute.String("cleanroom.reason_code", reasonHostNotAllowed),
+			attribute.String(observability.AttrGatewayAction, gatewayActionDeny),
+			attribute.String(observability.AttrReasonCode, reasonHostNotAllowed),
 		)
 		span.SetStatus(codes.Error, "upstream host is not allowed by sandbox policy")
-		h.auditLog(scope.SandboxID, upstreamHost, repoPath, "deny", reasonHostNotAllowed)
+		h.auditLog(scope.SandboxID, upstreamHost, repoPath, gatewayActionDeny, reasonHostNotAllowed)
 		writeReasonError(w, http.StatusForbidden, reasonHostNotAllowed, "upstream host is not allowed by sandbox policy")
 		return
 	}
 
 	requestType, err := h.classifyRequest(r.Method, repoPath, r.URL.RawQuery)
 	if err != nil {
-		setGatewayRequestDecision(r.Context(), "deny", reasonMethodNotAllowed)
+		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonMethodNotAllowed)
 		span.RecordError(err)
 		span.SetAttributes(
-			attribute.String("cleanroom.gateway.action", "deny"),
-			attribute.String("cleanroom.reason_code", reasonMethodNotAllowed),
+			attribute.String(observability.AttrGatewayAction, gatewayActionDeny),
+			attribute.String(observability.AttrReasonCode, reasonMethodNotAllowed),
 		)
 		span.SetStatus(codes.Error, err.Error())
-		h.auditLog(scope.SandboxID, upstreamHost, repoPath, "deny", reasonMethodNotAllowed)
+		h.auditLog(scope.SandboxID, upstreamHost, repoPath, gatewayActionDeny, reasonMethodNotAllowed)
 		writeReasonError(w, http.StatusForbidden, reasonMethodNotAllowed, err.Error())
 		return
 	}
-	span.SetAttributes(attribute.String("cleanroom.gateway.request_type", requestType))
+	span.SetAttributes(attribute.String(observability.AttrGatewayRequestType, requestType))
 
 	remoteURL, err := canonicalUpstreamRemoteURL(upstreamHost, repoPath)
 	if err != nil {
@@ -120,23 +129,23 @@ func (h *gitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if h.mirrors != nil {
 		if err := h.serveFromMirror(w, r, remoteURL, upstreamHost, repoPath, requestType); err != nil {
-			setGatewayRequestDecision(r.Context(), "deny", reasonUpstreamError)
+			setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonUpstreamError)
 			span.RecordError(err)
 			span.SetAttributes(
-				attribute.String("cleanroom.gateway.action", "deny"),
-				attribute.String("cleanroom.reason_code", reasonUpstreamError),
+				attribute.String(observability.AttrGatewayAction, gatewayActionDeny),
+				attribute.String(observability.AttrReasonCode, reasonUpstreamError),
 			)
 			span.SetStatus(codes.Error, err.Error())
-			h.auditLog(scope.SandboxID, upstreamHost, repoPath, "deny", reasonUpstreamError)
+			h.auditLog(scope.SandboxID, upstreamHost, repoPath, gatewayActionDeny, reasonUpstreamError)
 			writeReasonError(w, http.StatusBadGateway, reasonUpstreamError, err.Error())
 			return
 		}
-		setGatewayRequestDecision(r.Context(), "allow", "mirrored")
+		setGatewayRequestDecision(r.Context(), gatewayActionAllow, reasonMirrored)
 		span.SetAttributes(
-			attribute.String("cleanroom.gateway.action", "allow"),
-			attribute.String("cleanroom.reason_code", "mirrored"),
+			attribute.String(observability.AttrGatewayAction, gatewayActionAllow),
+			attribute.String(observability.AttrReasonCode, reasonMirrored),
 		)
-		h.auditLog(scope.SandboxID, upstreamHost, repoPath, "allow", "mirrored")
+		h.auditLog(scope.SandboxID, upstreamHost, repoPath, gatewayActionAllow, reasonMirrored)
 		return
 	}
 
@@ -168,26 +177,26 @@ func (h *gitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	span.SetAttributes(
-		attribute.String("cleanroom.gateway.action", "allow"),
-		attribute.String("cleanroom.reason_code", "proxied"),
+		attribute.String(observability.AttrGatewayAction, gatewayActionAllow),
+		attribute.String(observability.AttrReasonCode, reasonProxied),
 	)
-	setGatewayRequestDecision(r.Context(), "allow", "proxied")
-	h.auditLog(scope.SandboxID, upstreamHost, repoPath, "allow", "proxied")
+	setGatewayRequestDecision(r.Context(), gatewayActionAllow, reasonProxied)
+	h.auditLog(scope.SandboxID, upstreamHost, repoPath, gatewayActionAllow, reasonProxied)
 
 	resp, err := h.client.Do(upstreamReq)
 	if err != nil {
-		setGatewayRequestDecision(r.Context(), "deny", reasonUpstreamError)
+		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonUpstreamError)
 		span.RecordError(err)
 		span.SetAttributes(
-			attribute.String("cleanroom.gateway.action", "deny"),
-			attribute.String("cleanroom.reason_code", reasonUpstreamError),
+			attribute.String(observability.AttrGatewayAction, gatewayActionDeny),
+			attribute.String(observability.AttrReasonCode, reasonUpstreamError),
 		)
 		span.SetStatus(codes.Error, err.Error())
 		writeReasonError(w, http.StatusBadGateway, reasonUpstreamError, "upstream error")
 		return
 	}
 	defer resp.Body.Close()
-	span.SetAttributes(attribute.Int("cleanroom.gateway.upstream_status_code", resp.StatusCode))
+	span.SetAttributes(attribute.Int(observability.AttrGatewayUpstreamStatus, resp.StatusCode))
 
 	for key, vals := range resp.Header {
 		for _, v := range vals {

--- a/internal/gateway/git_cached.go
+++ b/internal/gateway/git_cached.go
@@ -50,14 +50,14 @@ func (h *cachedGitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !scope.Policy.Allows(upstreamHost, 443) {
-		h.auditLog(scope.SandboxID, upstreamHost, repoPath, "deny", reasonHostNotAllowed)
+		h.auditLog(scope.SandboxID, upstreamHost, repoPath, gatewayActionDeny, reasonHostNotAllowed)
 		writeReasonError(w, http.StatusForbidden, reasonHostNotAllowed, "upstream host is not allowed by sandbox policy")
 		return
 	}
 
 	// Classify the request to reject pushes before hitting the cache layer.
 	if _, err := classifyGitRequest(r.Method, repoPath, r.URL.RawQuery); err != nil {
-		h.auditLog(scope.SandboxID, upstreamHost, repoPath, "deny", reasonMethodNotAllowed)
+		h.auditLog(scope.SandboxID, upstreamHost, repoPath, gatewayActionDeny, reasonMethodNotAllowed)
 		writeReasonError(w, http.StatusForbidden, reasonMethodNotAllowed, err.Error())
 		return
 	}
@@ -66,19 +66,19 @@ func (h *cachedGitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		if errors.Is(err, errGitHostNotConfiguredForCaching) {
 			if h.fallback == nil {
-				h.auditLog(scope.SandboxID, upstreamHost, repoPath, "deny", reasonUpstreamError)
+				h.auditLog(scope.SandboxID, upstreamHost, repoPath, gatewayActionDeny, reasonUpstreamError)
 				writeReasonError(w, http.StatusBadGateway, reasonUpstreamError, fmt.Sprintf("git cache fallback is not configured for %s", upstreamHost))
 				return
 			}
-			h.auditLog(scope.SandboxID, upstreamHost, repoPath, "allow", "fallback")
+			h.auditLog(scope.SandboxID, upstreamHost, repoPath, gatewayActionAllow, reasonFallback)
 			h.fallback.ServeHTTP(w, r)
 			return
 		}
-		h.auditLog(scope.SandboxID, upstreamHost, repoPath, "deny", reasonUpstreamError)
+		h.auditLog(scope.SandboxID, upstreamHost, repoPath, gatewayActionDeny, reasonUpstreamError)
 		writeReasonError(w, http.StatusBadGateway, reasonUpstreamError, fmt.Sprintf("git cache handler unavailable for %s: %v", upstreamHost, err))
 		return
 	}
-	h.auditLog(scope.SandboxID, upstreamHost, repoPath, "allow", "cached")
+	h.auditLog(scope.SandboxID, upstreamHost, repoPath, gatewayActionAllow, reasonCached)
 
 	// content-cache's git handler expects paths like /{host}/{repo}.git/...
 	// Strip the /git/ prefix so the cache handler sees the host-rooted path.

--- a/internal/gateway/oci_cached.go
+++ b/internal/gateway/oci_cached.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/buildkite/cleanroom/internal/observability"
 	"github.com/charmbracelet/log"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -43,10 +44,10 @@ func (h *cachedRegistryHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 
 	// Only GET and HEAD are valid OCI Distribution operations for pulls.
 	if r.Method != http.MethodGet && r.Method != http.MethodHead {
-		setGatewayRequestDecision(r.Context(), "deny", reasonMethodNotAllowed)
+		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonMethodNotAllowed)
 		span.SetAttributes(
-			attribute.String("cleanroom.gateway.action", "deny"),
-			attribute.String("cleanroom.reason_code", reasonMethodNotAllowed),
+			attribute.String(observability.AttrGatewayAction, gatewayActionDeny),
+			attribute.String(observability.AttrReasonCode, reasonMethodNotAllowed),
 		)
 		span.SetStatus(codes.Error, "only GET and HEAD are permitted for registry")
 		writeReasonError(w, http.StatusMethodNotAllowed, reasonMethodNotAllowed, "only GET and HEAD are permitted for registry")
@@ -72,52 +73,52 @@ func (h *cachedRegistryHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	normalizedPrefix := strings.ToLower(strings.TrimSpace(prefix))
 	policyHost, policyPort, upstreamHost, upstreamPort, err := h.cache.OCIUpstreamForPrefix(normalizedPrefix)
 	if err != nil {
-		setGatewayRequestDecision(r.Context(), "deny", "unknown_registry_prefix")
+		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonUnknownRegistryPrefix)
 		span.RecordError(err)
 		span.SetAttributes(
-			attribute.String("cleanroom.gateway.action", "deny"),
-			attribute.String("cleanroom.reason_code", "unknown_registry_prefix"),
+			attribute.String(observability.AttrGatewayAction, gatewayActionDeny),
+			attribute.String(observability.AttrReasonCode, reasonUnknownRegistryPrefix),
 		)
 		span.SetStatus(codes.Error, err.Error())
-		h.auditLog(scope.SandboxID, normalizedPrefix, "deny", "unknown_registry_prefix")
-		writeReasonError(w, http.StatusNotFound, "unknown_registry_prefix", fmt.Sprintf("unknown registry prefix %q", prefix))
+		h.auditLog(scope.SandboxID, normalizedPrefix, gatewayActionDeny, reasonUnknownRegistryPrefix)
+		writeReasonError(w, http.StatusNotFound, reasonUnknownRegistryPrefix, fmt.Sprintf("unknown registry prefix %q", prefix))
 		return
 	}
 	span.SetAttributes(
-		attribute.String("cleanroom.gateway.target_host", policyHost),
-		attribute.String("cleanroom.gateway.registry_prefix", normalizedPrefix),
+		attribute.String(observability.AttrGatewayTargetHost, policyHost),
+		attribute.String(observability.AttrGatewayRegistryPrefix, normalizedPrefix),
 	)
 	if !scope.Policy.Allows(policyHost, policyPort) {
-		setGatewayRequestDecision(r.Context(), "deny", reasonHostNotAllowed)
+		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonHostNotAllowed)
 		span.SetAttributes(
-			attribute.String("cleanroom.gateway.action", "deny"),
-			attribute.String("cleanroom.reason_code", reasonHostNotAllowed),
+			attribute.String(observability.AttrGatewayAction, gatewayActionDeny),
+			attribute.String(observability.AttrReasonCode, reasonHostNotAllowed),
 		)
 		span.SetStatus(codes.Error, "upstream registry host is not allowed by sandbox policy")
-		h.auditLog(scope.SandboxID, policyHost, "deny", reasonHostNotAllowed)
+		h.auditLog(scope.SandboxID, policyHost, gatewayActionDeny, reasonHostNotAllowed)
 		writeReasonError(w, http.StatusForbidden, reasonHostNotAllowed, "upstream registry host is not allowed by sandbox policy")
 		return
 	}
 	span.SetAttributes(
-		attribute.String("cleanroom.gateway.action", "allow"),
-		attribute.String("cleanroom.reason_code", "cached"),
-		attribute.Int("cleanroom.gateway.upstream_port", upstreamPort),
-		attribute.String("cleanroom.gateway.upstream_host", upstreamHost),
+		attribute.String(observability.AttrGatewayAction, gatewayActionAllow),
+		attribute.String(observability.AttrReasonCode, reasonCached),
+		attribute.Int(observability.AttrGatewayUpstreamPort, upstreamPort),
+		attribute.String(observability.AttrGatewayUpstreamHost, upstreamHost),
 	)
-	setGatewayRequestDecision(r.Context(), "allow", "cached")
-	h.auditLog(scope.SandboxID, upstreamHost, "allow", "cached")
+	setGatewayRequestDecision(r.Context(), gatewayActionAllow, reasonCached)
+	h.auditLog(scope.SandboxID, upstreamHost, gatewayActionAllow, reasonCached)
 
 	cacheHandler, err := h.cache.OCIHandlerForPrefix(normalizedPrefix)
 	if err != nil {
-		setGatewayRequestDecision(r.Context(), "deny", "unknown_registry_prefix")
+		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonUnknownRegistryPrefix)
 		span.RecordError(err)
 		span.SetAttributes(
-			attribute.String("cleanroom.gateway.action", "deny"),
-			attribute.String("cleanroom.reason_code", "unknown_registry_prefix"),
+			attribute.String(observability.AttrGatewayAction, gatewayActionDeny),
+			attribute.String(observability.AttrReasonCode, reasonUnknownRegistryPrefix),
 		)
 		span.SetStatus(codes.Error, err.Error())
-		h.auditLog(scope.SandboxID, normalizedPrefix, "deny", "unknown_registry_prefix")
-		writeReasonError(w, http.StatusNotFound, "unknown_registry_prefix", fmt.Sprintf("unknown registry prefix %q", prefix))
+		h.auditLog(scope.SandboxID, normalizedPrefix, gatewayActionDeny, reasonUnknownRegistryPrefix)
+		writeReasonError(w, http.StatusNotFound, reasonUnknownRegistryPrefix, fmt.Sprintf("unknown registry prefix %q", prefix))
 		return
 	}
 

--- a/internal/gateway/rubygems_cached.go
+++ b/internal/gateway/rubygems_cached.go
@@ -38,24 +38,24 @@ func (h *cachedRubyGemsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 
 	policyHost, policyPort, upstreamHost, _, err := h.cache.RubyGemsUpstream()
 	if err != nil {
-		h.auditLog(scope.SandboxID, "rubygems", "deny", "rubygems_unavailable")
+		h.auditLog(scope.SandboxID, "rubygems", gatewayActionDeny, reasonRubyGemsUnavailable)
 		writeReasonError(w, http.StatusBadGateway, reasonUpstreamError, "rubygems cache is not configured")
 		return
 	}
 	if !scope.Policy.Allows(policyHost, policyPort) {
-		h.auditLog(scope.SandboxID, policyHost, "deny", reasonHostNotAllowed)
+		h.auditLog(scope.SandboxID, policyHost, gatewayActionDeny, reasonHostNotAllowed)
 		writeReasonError(w, http.StatusForbidden, reasonHostNotAllowed, "upstream rubygems host is not allowed by sandbox policy")
 		return
 	}
 
 	handler, err := h.cache.RubyGemsHandler()
 	if err != nil {
-		h.auditLog(scope.SandboxID, "rubygems", "deny", "rubygems_unavailable")
+		h.auditLog(scope.SandboxID, "rubygems", gatewayActionDeny, reasonRubyGemsUnavailable)
 		writeReasonError(w, http.StatusBadGateway, reasonUpstreamError, "rubygems cache is not configured")
 		return
 	}
 
-	h.auditLog(scope.SandboxID, upstreamHost, "allow", "cached")
+	h.auditLog(scope.SandboxID, upstreamHost, gatewayActionAllow, reasonCached)
 
 	r = r.Clone(r.Context())
 	r.URL.Path = strings.TrimPrefix(r.URL.Path, "/rubygems")

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -366,20 +366,20 @@ func (s *Server) tracingMiddleware(next http.Handler) http.Handler {
 
 		service := gatewayServiceForPath(r.URL.Path)
 		attributes := []attribute.KeyValue{
-			attribute.String("cleanroom.gateway.service", service),
+			attribute.String(observability.AttrGatewayService, service),
 			attribute.String("http.request.method", r.Method),
 			attribute.String("url.path", r.URL.Path),
 		}
 		if scope != nil {
 			if scope.SandboxID != "" {
-				attributes = append(attributes, attribute.String("cleanroom.sandbox.id", scope.SandboxID))
+				attributes = append(attributes, attribute.String(observability.AttrSandboxID, scope.SandboxID))
 			}
 			if scope.ExecutionID != "" {
-				attributes = append(attributes, attribute.String("cleanroom.execution.id", scope.ExecutionID))
+				attributes = append(attributes, attribute.String(observability.AttrExecutionID, scope.ExecutionID))
 			}
 		}
 
-		ctx, span := tracer.Start(ctx, "cleanroom.gateway."+service+".request", trace.WithAttributes(attributes...))
+		ctx, span := tracer.Start(ctx, observability.GatewayRequestSpanName(service), trace.WithAttributes(attributes...))
 		defer span.End()
 
 		status := &gatewayStatusRecorder{ResponseWriter: w, statusCode: http.StatusOK}
@@ -390,7 +390,7 @@ func (s *Server) tracingMiddleware(next http.Handler) http.Handler {
 			reasonCode = strings.TrimSpace(status.Header().Get(reasonCodeHeader))
 		}
 		if reasonCode != "" {
-			span.SetAttributes(attribute.String("cleanroom.reason_code", reasonCode))
+			span.SetAttributes(attribute.String(observability.AttrReasonCode, reasonCode))
 		}
 		if metrics := s.gatewayMetrics(); metrics != nil {
 			metrics.RecordRequest(ctx, service, requestObs.action, reasonCode, status.statusCode, time.Since(startedAt))

--- a/internal/observability/contract.go
+++ b/internal/observability/contract.go
@@ -1,0 +1,98 @@
+package observability
+
+import (
+	"strings"
+
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+)
+
+const (
+	ServiceNamespace = "cleanroom"
+
+	SpanExec            = "cleanroom.exec"
+	SpanConsole         = "cleanroom.console"
+	SpanSandboxCreate   = "cleanroom.sandbox.create"
+	SpanExecutionCreate = "cleanroom.execution.create"
+	SpanExecutionRun    = "cleanroom.execution.run"
+
+	MetricSandboxCreateDurationSeconds = "cleanroom_sandbox_create_duration_seconds"
+	MetricExecutionTotal               = "cleanroom_execution_total"
+	MetricExecutionDurationSeconds     = "cleanroom_execution_duration_seconds"
+	MetricGatewayRequestsTotal         = "cleanroom_gateway_requests_total"
+	MetricGatewayRequestDuration       = "cleanroom_gateway_request_duration_seconds"
+	MetricLaunchPhaseDurationSeconds   = "cleanroom_launch_phase_duration_seconds"
+
+	MetricLabelBackend     = "backend"
+	MetricLabelSource      = "source"
+	MetricLabelOutcome     = "outcome"
+	MetricLabelKind        = "kind"
+	MetricLabelService     = "service"
+	MetricLabelAction      = "action"
+	MetricLabelReasonCode  = "reason_code"
+	MetricLabelStatusClass = "status_class"
+	MetricLabelPhase       = "phase"
+
+	AttrBackend               = "cleanroom.backend"
+	AttrBackendRequested      = "cleanroom.backend.requested"
+	AttrSandboxID             = "cleanroom.sandbox.id"
+	AttrSandboxFromSnapshot   = "cleanroom.sandbox.from_snapshot"
+	AttrExecutionID           = "cleanroom.execution.id"
+	AttrExecutionKind         = "cleanroom.execution.kind"
+	AttrExecutionStatus       = "cleanroom.execution.status"
+	AttrReasonCode            = "cleanroom.reason_code"
+	AttrGatewayService        = "cleanroom.gateway.service"
+	AttrGatewayAction         = "cleanroom.gateway.action"
+	AttrGatewayTargetHost     = "cleanroom.gateway.target_host"
+	AttrGatewayRepoPath       = "cleanroom.gateway.repo_path"
+	AttrGatewayRequestType    = "cleanroom.gateway.request_type"
+	AttrGatewayRegistryPrefix = "cleanroom.gateway.registry_prefix"
+	AttrGatewayUpstreamHost   = "cleanroom.gateway.upstream_host"
+	AttrGatewayUpstreamPort   = "cleanroom.gateway.upstream_port"
+	AttrGatewayUpstreamStatus = "cleanroom.gateway.upstream_status_code"
+	AttrCommandArgc           = "cleanroom.command.argc"
+	AttrCommandName           = "cleanroom.command.name"
+	AttrCommandSummary        = "cleanroom.command.summary"
+	AttrKeepSandbox           = "cleanroom.keep_sandbox"
+	AttrStdinDisabled         = "cleanroom.stdin.disabled"
+	AttrRepositoryCheckout    = "cleanroom.repository.checkout"
+	AttrRepositoryChangeset   = "cleanroom.repository.changeset"
+	AttrVMLaunched            = "cleanroom.vm.launched"
+	AttrExitCode              = "cleanroom.exit_code"
+
+	OutcomeSucceeded = "succeeded"
+	OutcomeFailed    = "failed"
+	OutcomeCanceled  = "canceled"
+	OutcomeTimedOut  = "timed_out"
+
+	GatewayActionAllow = "allow"
+	GatewayActionDeny  = "deny"
+
+	ReasonHostNotAllowed        = "host_not_allowed"
+	ReasonMethodNotAllowed      = "method_not_allowed"
+	ReasonUpstreamError         = "upstream_error"
+	ReasonUnknownRegistryPrefix = "unknown_registry_prefix"
+	ReasonProxied               = "proxied"
+	ReasonMirrored              = "mirrored"
+	ReasonCached                = "cached"
+	ReasonFallback              = "fallback"
+	ReasonRubyGemsUnavailable   = "rubygems_unavailable"
+)
+
+func GatewayRequestSpanName(service string) string {
+	return "cleanroom.gateway." + service + ".request"
+}
+
+func ExecutionOutcome(status cleanroomv1.ExecutionStatus) string {
+	switch status {
+	case cleanroomv1.ExecutionStatus_EXECUTION_STATUS_SUCCEEDED:
+		return OutcomeSucceeded
+	case cleanroomv1.ExecutionStatus_EXECUTION_STATUS_FAILED:
+		return OutcomeFailed
+	case cleanroomv1.ExecutionStatus_EXECUTION_STATUS_CANCELED:
+		return OutcomeCanceled
+	case cleanroomv1.ExecutionStatus_EXECUTION_STATUS_TIMED_OUT:
+		return OutcomeTimedOut
+	default:
+		return strings.ToLower(strings.TrimPrefix(status.String(), "EXECUTION_STATUS_"))
+	}
+}

--- a/internal/observability/contract_test.go
+++ b/internal/observability/contract_test.go
@@ -1,0 +1,40 @@
+package observability
+
+import (
+	"testing"
+
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+)
+
+func TestGatewayRequestSpanName(t *testing.T) {
+	t.Parallel()
+
+	if got, want := GatewayRequestSpanName("git"), "cleanroom.gateway.git.request"; got != want {
+		t.Fatalf("GatewayRequestSpanName returned %q, want %q", got, want)
+	}
+}
+
+func TestExecutionOutcome(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		status cleanroomv1.ExecutionStatus
+		want   string
+	}{
+		{name: "succeeded", status: cleanroomv1.ExecutionStatus_EXECUTION_STATUS_SUCCEEDED, want: OutcomeSucceeded},
+		{name: "failed", status: cleanroomv1.ExecutionStatus_EXECUTION_STATUS_FAILED, want: OutcomeFailed},
+		{name: "canceled", status: cleanroomv1.ExecutionStatus_EXECUTION_STATUS_CANCELED, want: OutcomeCanceled},
+		{name: "timed out", status: cleanroomv1.ExecutionStatus_EXECUTION_STATUS_TIMED_OUT, want: OutcomeTimedOut},
+		{name: "queued falls back to enum name", status: cleanroomv1.ExecutionStatus_EXECUTION_STATUS_QUEUED, want: "queued"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := ExecutionOutcome(tt.status); got != tt.want {
+				t.Fatalf("ExecutionOutcome(%s) = %q, want %q", tt.status, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -20,7 +20,7 @@ type ServiceMetrics struct {
 func NewServiceMetrics(provider metric.MeterProvider) (*ServiceMetrics, error) {
 	meter := meterProviderOrNoop(provider).Meter("github.com/buildkite/cleanroom/internal/controlservice")
 	sandboxCreateDuration, err := meter.Float64Histogram(
-		"cleanroom_sandbox_create_duration_seconds",
+		MetricSandboxCreateDurationSeconds,
 		metric.WithDescription("Time spent creating a sandbox"),
 		metric.WithUnit("s"),
 	)
@@ -28,14 +28,14 @@ func NewServiceMetrics(provider metric.MeterProvider) (*ServiceMetrics, error) {
 		return nil, err
 	}
 	executionTotal, err := meter.Int64Counter(
-		"cleanroom_execution_total",
+		MetricExecutionTotal,
 		metric.WithDescription("Completed executions by backend, kind, and outcome"),
 	)
 	if err != nil {
 		return nil, err
 	}
 	executionDuration, err := meter.Float64Histogram(
-		"cleanroom_execution_duration_seconds",
+		MetricExecutionDurationSeconds,
 		metric.WithDescription("Execution duration by backend, kind, and outcome"),
 		metric.WithUnit("s"),
 	)
@@ -54,9 +54,9 @@ func (m *ServiceMetrics) RecordSandboxCreate(ctx context.Context, backendName, s
 		return
 	}
 	m.sandboxCreateDuration.Record(ctx, duration.Seconds(), metric.WithAttributes(
-		attribute.String("backend", normalizeMetricValue(backendName, "unknown")),
-		attribute.String("source", normalizeMetricValue(source, "unknown")),
-		attribute.String("outcome", normalizeMetricValue(outcome, "unknown")),
+		attribute.String(MetricLabelBackend, normalizeMetricValue(backendName, "unknown")),
+		attribute.String(MetricLabelSource, normalizeMetricValue(source, "unknown")),
+		attribute.String(MetricLabelOutcome, normalizeMetricValue(outcome, "unknown")),
 	))
 }
 
@@ -65,9 +65,9 @@ func (m *ServiceMetrics) RecordExecution(ctx context.Context, backendName, kind,
 		return
 	}
 	attrs := metric.WithAttributes(
-		attribute.String("backend", normalizeMetricValue(backendName, "unknown")),
-		attribute.String("kind", normalizeMetricValue(kind, "unknown")),
-		attribute.String("outcome", normalizeMetricValue(outcome, "unknown")),
+		attribute.String(MetricLabelBackend, normalizeMetricValue(backendName, "unknown")),
+		attribute.String(MetricLabelKind, normalizeMetricValue(kind, "unknown")),
+		attribute.String(MetricLabelOutcome, normalizeMetricValue(outcome, "unknown")),
 	)
 	m.executionTotal.Add(ctx, 1, attrs)
 	m.executionDuration.Record(ctx, duration.Seconds(), attrs)
@@ -81,14 +81,14 @@ type GatewayMetrics struct {
 func NewGatewayMetrics(provider metric.MeterProvider) (*GatewayMetrics, error) {
 	meter := meterProviderOrNoop(provider).Meter("github.com/buildkite/cleanroom/internal/gateway")
 	requestTotal, err := meter.Int64Counter(
-		"cleanroom_gateway_requests_total",
+		MetricGatewayRequestsTotal,
 		metric.WithDescription("Gateway requests by service, action, reason code, and status class"),
 	)
 	if err != nil {
 		return nil, err
 	}
 	requestDuration, err := meter.Float64Histogram(
-		"cleanroom_gateway_request_duration_seconds",
+		MetricGatewayRequestDuration,
 		metric.WithDescription("Gateway request duration by service and action"),
 		metric.WithUnit("s"),
 	)
@@ -106,14 +106,14 @@ func (m *GatewayMetrics) RecordRequest(ctx context.Context, service, action, rea
 	action = normalizeMetricValue(action, "unknown")
 	reasonCode = normalizeMetricValue(reasonCode, "none")
 	m.requestTotal.Add(ctx, 1, metric.WithAttributes(
-		attribute.String("service", service),
-		attribute.String("action", action),
-		attribute.String("reason_code", reasonCode),
-		attribute.String("status_class", statusCodeClass(statusCode)),
+		attribute.String(MetricLabelService, service),
+		attribute.String(MetricLabelAction, action),
+		attribute.String(MetricLabelReasonCode, reasonCode),
+		attribute.String(MetricLabelStatusClass, statusCodeClass(statusCode)),
 	))
 	m.requestDuration.Record(ctx, duration.Seconds(), metric.WithAttributes(
-		attribute.String("service", service),
-		attribute.String("action", action),
+		attribute.String(MetricLabelService, service),
+		attribute.String(MetricLabelAction, action),
 	))
 }
 
@@ -124,7 +124,7 @@ type BackendMetrics struct {
 func NewBackendMetrics(provider metric.MeterProvider, meterName string) (*BackendMetrics, error) {
 	meter := meterProviderOrNoop(provider).Meter(defaultTracerName(meterName))
 	launchPhaseDuration, err := meter.Float64Histogram(
-		"cleanroom_launch_phase_duration_seconds",
+		MetricLaunchPhaseDurationSeconds,
 		metric.WithDescription("Backend launch and guest execution phase duration"),
 		metric.WithUnit("s"),
 	)
@@ -139,8 +139,8 @@ func (m *BackendMetrics) RecordLaunchPhase(ctx context.Context, backendName, pha
 		return
 	}
 	m.launchPhaseDuration.Record(ctx, duration.Seconds(), metric.WithAttributes(
-		attribute.String("backend", normalizeMetricValue(backendName, "unknown")),
-		attribute.String("phase", normalizeMetricValue(phase, "unknown")),
+		attribute.String(MetricLabelBackend, normalizeMetricValue(backendName, "unknown")),
+		attribute.String(MetricLabelPhase, normalizeMetricValue(phase, "unknown")),
 	))
 }
 

--- a/internal/observability/observability.go
+++ b/internal/observability/observability.go
@@ -26,7 +26,6 @@ import (
 )
 
 const (
-	serviceNamespace = "cleanroom"
 	defaultTraceName = "github.com/buildkite/cleanroom"
 )
 
@@ -380,7 +379,7 @@ func newSampler(cfg runtimeconfig.TraceSamplingConfig) (sdktrace.Sampler, error)
 
 func newResource(opts Options) (*sdkresource.Resource, error) {
 	attributes := []attribute.KeyValue{
-		attribute.String("service.namespace", serviceNamespace),
+		attribute.String("service.namespace", ServiceNamespace),
 		attribute.String("service.name", strings.TrimSpace(opts.ServiceName)),
 	}
 	if version := strings.TrimSpace(opts.ServiceVersion); version != "" {


### PR DESCRIPTION
## Summary
- add a canonical observability contract for stable span names, metric names, attributes, outcomes, actions, and reason codes
- update the docs to append a brief telemetry contract to the observability guide
- switch the main CLI, control service, gateway, and metrics emitters to use shared observability contract constants

## Testing
- go test ./internal/observability ./internal/gateway ./internal/controlservice ./internal/cli