### PR TITLE
feat: add correlated structured server logging

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,8 +1,9 @@
 # Observability
 
-Cleanroom observability is OTLP-only. When enabled, `cleanroom serve` prints
-startup status for trace export, sampling, and whether direct trace links are
-configured.
+Cleanroom observability is OTLP-only for traces and metrics. Server-side
+operational logs stay local to the process and can be emitted as text or JSON.
+When enabled, `cleanroom serve` prints startup status for log format, trace
+export, sampling, and whether direct trace links are configured.
 
 ## Runtime config
 
@@ -12,6 +13,8 @@ Configure observability in `~/.config/cleanroom/config.yaml`:
 observability:
   enabled: true
   deployment_environment: local
+  logs:
+    format: json
   otlp:
     endpoint: http://localhost:14318
     protocol: http/protobuf
@@ -23,6 +26,10 @@ observability:
 
 If you prefer OTLP gRPC, set `endpoint: localhost:14317` and `protocol: grpc`
 instead.
+
+`observability.logs.format` defaults to `text`. Set it to `json` when you want
+structured logs with stable correlation fields such as `trace_id`, `span_id`,
+`execution_id`, `sandbox_id`, `backend`, and `reason_code`.
 
 `observability.traces.url_template` is optional. When set, Cleanroom prints
 `trace_url=...` in failure footers and exposes the same URL from

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"math"
 	"os"
 	"os/exec"
@@ -35,6 +34,7 @@ import (
 	"github.com/buildkite/cleanroom/internal/policy"
 	"github.com/buildkite/cleanroom/internal/volumestore"
 	"github.com/buildkite/cleanroom/internal/vsockexec"
+	charmlog "github.com/charmbracelet/log"
 	fcvsock "github.com/firecracker-microvm/firecracker-go-sdk/vsock"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -71,6 +71,7 @@ type Adapter struct {
 	GatewayRegistry gatewayRegistry
 	GatewayPort     int
 	GatewayRoutes   gateway.ProxyRoutes
+	Logger          *charmlog.Logger
 	MeterProvider   metric.MeterProvider
 	metricsOnce     sync.Once
 	metrics         *observability.BackendMetrics
@@ -255,7 +256,7 @@ func (a *Adapter) backendMetrics() *observability.BackendMetrics {
 	a.metricsOnce.Do(func() {
 		a.metrics, a.metricsErr = observability.NewBackendMetrics(a.MeterProvider, "github.com/buildkite/cleanroom/internal/backend/firecracker")
 		if a.metricsErr != nil {
-			log.Printf("firecracker backend metrics unavailable: %v", a.metricsErr)
+			baseFirecrackerLogger(a.Logger).Warn("backend metrics unavailable", "error", a.metricsErr)
 		}
 	})
 	return a.metrics
@@ -1058,7 +1059,7 @@ func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream 
 	if err != nil {
 		return nil, err
 	}
-	logExecutionNotice(a.Name(), req.ExecutionID, kernelNotice)
+	logExecutionNotice(observability.WithTraceContext(baseFirecrackerLogger(a.Logger), ctx), req.ExecutionID, kernelNotice)
 
 	imageArtifact, err := a.ensureImageArtifact(ctx, req.Policy.ImageRef)
 	if err != nil {
@@ -1074,7 +1075,14 @@ func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream 
 	}
 
 	rootfsCopyStart := time.Now()
-	writableVolume, cleanupVolume, err := prepareWritableRootVolume(ctx, req.FirecrackerConfig, req.ExecutionID, runDir, preparedRootFSPath)
+	writableVolume, cleanupVolume, err := prepareWritableRootVolumeWithLogger(
+		ctx,
+		observability.WithLoggerFields(observability.WithTraceContext(baseFirecrackerLogger(a.Logger), ctx), observability.LogFieldExecutionID, req.ExecutionID),
+		req.FirecrackerConfig,
+		req.ExecutionID,
+		runDir,
+		preparedRootFSPath,
+	)
 	if err != nil {
 		observation.RootFSCopyMS = durationMillisCeil(time.Since(rootfsCopyStart))
 		return nil, fmt.Errorf("prepare per-run rootfs: %w", err)
@@ -1688,7 +1696,14 @@ func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID strin
 		return nil, err
 	}
 
-	writableVolume, cleanupVolume, err := prepareWritableRootVolume(ctx, cfg, sandboxID, runDir, sourceRootFSPath)
+	writableVolume, cleanupVolume, err := prepareWritableRootVolumeWithLogger(
+		ctx,
+		observability.WithLoggerFields(observability.WithTraceContext(baseFirecrackerLogger(a.Logger), ctx), observability.LogFieldSandboxID, sandboxID),
+		cfg,
+		sandboxID,
+		runDir,
+		sourceRootFSPath,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("prepare persistent rootfs: %w", err)
 	}
@@ -1876,6 +1891,10 @@ func sandboxRuntimeBaseDir() (string, error) {
 }
 
 func preparePersistentWritableVolume(ctx context.Context, driver volumestore.Driver, sandboxID, runDir, sourceRef string, minimumBytes int64) (volumestore.WritableVolume, func(), error) {
+	return preparePersistentWritableVolumeWithLogger(ctx, nil, driver, sandboxID, runDir, sourceRef, minimumBytes)
+}
+
+func preparePersistentWritableVolumeWithLogger(ctx context.Context, logger *charmlog.Logger, driver volumestore.Driver, sandboxID, runDir, sourceRef string, minimumBytes int64) (volumestore.WritableVolume, func(), error) {
 	sourceRef = strings.TrimSpace(sourceRef)
 	if sourceRef == "" {
 		return volumestore.WritableVolume{}, nil, errors.New("missing persistent rootfs source")
@@ -1885,7 +1904,7 @@ func preparePersistentWritableVolume(ctx context.Context, driver volumestore.Dri
 	resizeVolume := func(volume volumestore.WritableVolume) (volumestore.WritableVolume, func(), error) {
 		cleanupVolume := func() {
 			if err := driver.DestroyVolume(context.Background(), volumestore.DestroyVolumeRequest{VolumeRef: volume.Ref}); err != nil {
-				log.Printf("firecracker: cleanup persistent volume %q: %v", volume.Ref, err)
+				logPersistentVolumeCleanup(logger, volume.Ref, err)
 			}
 		}
 		if err := volumestore.EnsureWritableVolumeMinimumSize(ctx, driver, volume, minimumBytes); err != nil {
@@ -1935,12 +1954,16 @@ func preparePersistentWritableVolume(ctx context.Context, driver volumestore.Dri
 }
 
 func prepareWritableRootVolume(ctx context.Context, cfg backend.FirecrackerConfig, volumeID, runDir, sourceRef string) (volumestore.WritableVolume, func(), error) {
+	return prepareWritableRootVolumeWithLogger(ctx, nil, cfg, volumeID, runDir, sourceRef)
+}
+
+func prepareWritableRootVolumeWithLogger(ctx context.Context, logger *charmlog.Logger, cfg backend.FirecrackerConfig, volumeID, runDir, sourceRef string) (volumestore.WritableVolume, func(), error) {
 	driverCfg, err := snapshotConfigForStorageRef(cfg, sourceRef)
 	if err != nil {
 		return volumestore.WritableVolume{}, nil, err
 	}
 	if strings.EqualFold(strings.TrimSpace(driverCfg.Snapshots.Driver), "zfs") {
-		hostRuntime := hostRuntimeForConfig(driverCfg)
+		hostRuntime := hostRuntimeForConfigWithLogger(driverCfg, logger)
 		zfsReq := zfsWritableVolumeRequest{
 			VolumeID:     volumeID,
 			MinimumBytes: cfg.MinimumRootFSBytes,
@@ -1956,7 +1979,7 @@ func prepareWritableRootVolume(ctx context.Context, cfg backend.FirecrackerConfi
 		}
 		cleanupVolume := func() {
 			if err := hostRuntime.DestroyZFSVolume(context.Background(), volume.Ref); err != nil {
-				log.Printf("firecracker: cleanup persistent volume %q: %v", volume.Ref, err)
+				logPersistentVolumeCleanup(logger, volume.Ref, err)
 			}
 		}
 		return volumestore.WritableVolume{
@@ -1968,7 +1991,7 @@ func prepareWritableRootVolume(ctx context.Context, cfg backend.FirecrackerConfi
 	if err != nil {
 		return volumestore.WritableVolume{}, nil, err
 	}
-	return preparePersistentWritableVolume(ctx, driver, volumeID, runDir, sourceRef, cfg.MinimumRootFSBytes)
+	return preparePersistentWritableVolumeWithLogger(ctx, logger, driver, volumeID, runDir, sourceRef, cfg.MinimumRootFSBytes)
 }
 
 func snapshotVolumeRef(instance *sandboxInstance) string {
@@ -2384,19 +2407,6 @@ func helperVersion(ctx context.Context, cfg backend.FirecrackerConfig) (string, 
 		return "", err
 	}
 	return strings.TrimSpace(string(out)), nil
-}
-
-func logExecutionNotice(backendName, runID, notice string) {
-	msg := strings.TrimSpace(notice)
-	if msg == "" {
-		return
-	}
-	id := strings.TrimSpace(runID)
-	if id == "" {
-		log.Printf("%s: %s", backendName, msg)
-		return
-	}
-	log.Printf("%s execution_id=%s: %s", backendName, id, msg)
 }
 
 func lookPathWithFallback(binary string, candidates ...string) (string, error) {

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -614,6 +614,7 @@ func (a *Adapter) CreateSnapshot(ctx context.Context, req backend.SnapshotReques
 	if err := pauseSandboxProcess(instance); err != nil {
 		return nil, err
 	}
+	snapshotLogger := observability.WithLoggerFields(observability.WithTraceContext(baseFirecrackerLogger(a.Logger), ctx), observability.LogFieldSandboxID, sandboxID)
 	snapshotStorageRef := ""
 	paused := true
 	defer func() {
@@ -623,7 +624,7 @@ func (a *Adapter) CreateSnapshot(ctx context.Context, req backend.SnapshotReques
 		if err := resumeSandboxProcess(instance); err != nil && retErr == nil {
 			if strings.TrimSpace(snapshotStorageRef) != "" {
 				cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-				cleanupErr := destroySnapshotStorage(cleanupCtx, driverCfg, snapshotStorageRef)
+				cleanupErr := destroySnapshotStorage(cleanupCtx, snapshotLogger, driverCfg, snapshotStorageRef)
 				cancel()
 				if cleanupErr != nil {
 					result = nil
@@ -638,7 +639,7 @@ func (a *Adapter) CreateSnapshot(ctx context.Context, req backend.SnapshotReques
 	if err := flushSnapshotHostFilesystem(ctx, driverName); err != nil {
 		return nil, err
 	}
-	snapshotStorageRef, err = createSnapshotStorage(ctx, driverCfg, snapshotID, volumeRef)
+	snapshotStorageRef, err = createSnapshotStorage(ctx, snapshotLogger, driverCfg, snapshotID, volumeRef)
 	if err != nil {
 		return nil, fmt.Errorf("persist snapshot rootfs: %w", err)
 	}
@@ -709,7 +710,7 @@ func (a *Adapter) DeleteSnapshot(ctx context.Context, req backend.DeleteSnapshot
 	if err != nil {
 		return err
 	}
-	if err := destroySnapshotStorage(ctx, driverCfg, storageRef); err != nil {
+	if err := destroySnapshotStorage(ctx, observability.WithTraceContext(baseFirecrackerLogger(a.Logger), ctx), driverCfg, storageRef); err != nil {
 		return fmt.Errorf("remove snapshot rootfs %q: %w", storageRef, err)
 	}
 	return nil
@@ -751,7 +752,7 @@ func (a *Adapter) executeInSandbox(ctx context.Context, instance *sandboxInstanc
 	return runGuestCommandFn(bootCtx, ctx, instance.exitedCh, instance.exitedErrOrNil, instance.VsockPath, instance.GuestPort, guestReq, stream)
 }
 
-func (a *Adapter) Doctor(_ context.Context, req backend.DoctorRequest) (*backend.DoctorReport, error) {
+func (a *Adapter) Doctor(ctx context.Context, req backend.DoctorRequest) (*backend.DoctorReport, error) {
 	report := &backend.DoctorReport{
 		Backend: a.Name(),
 	}
@@ -862,7 +863,7 @@ func (a *Adapter) Doctor(_ context.Context, req backend.DoctorRequest) (*backend
 	appendCheck("network_policy_rules", policyRulesStatus, policyRulesMessage)
 
 	privilegedHelperPath := resolvePrivilegedHelperPath(req.FirecrackerConfig)
-	hostRuntime := hostRuntimeForConfig(req.FirecrackerConfig)
+	hostRuntime := hostRuntimeForConfigWithLogger(req.FirecrackerConfig, observability.WithTraceContext(baseFirecrackerLogger(a.Logger), ctx))
 	directRuntime := privilegedCommandsRunDirectly()
 
 	requiredCommands := []string{"ip", "iptables", "sysctl"}
@@ -1094,7 +1095,8 @@ func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream 
 	vmRootFSPath := writableVolume.AttachmentPath
 
 	networkSetupStart := time.Now()
-	hostRuntime := hostRuntimeForConfig(req.FirecrackerConfig)
+	executionLogger := observability.WithLoggerFields(observability.WithTraceContext(baseFirecrackerLogger(a.Logger), ctx), observability.LogFieldExecutionID, req.ExecutionID)
+	hostRuntime := hostRuntimeForConfigWithLogger(req.FirecrackerConfig, executionLogger)
 	networkLease, err := hostRuntime.SetupSandboxNetwork(ctx, sandboxNetworkRequest{
 		SandboxID: req.ExecutionID,
 		AllowAll:  req.Policy.NetworkDefault == "allow",
@@ -1709,7 +1711,8 @@ func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID strin
 	}
 	vmRootFSPath := writableVolume.AttachmentPath
 
-	hostRuntime := hostRuntimeForConfig(cfg)
+	sandboxLogger := observability.WithLoggerFields(observability.WithTraceContext(baseFirecrackerLogger(a.Logger), ctx), observability.LogFieldSandboxID, sandboxID)
+	hostRuntime := hostRuntimeForConfigWithLogger(cfg, sandboxLogger)
 	gwPort := 0
 	if a.GatewayRegistry != nil {
 		gwPort = a.GatewayPort
@@ -2071,12 +2074,12 @@ func snapshotDriverNeedsHostSync(driverName string) bool {
 	return strings.EqualFold(strings.TrimSpace(driverName), "zfs")
 }
 
-func createSnapshotStorage(ctx context.Context, cfg backend.FirecrackerConfig, snapshotID, volumeRef string) (string, error) {
+func createSnapshotStorage(ctx context.Context, logger *charmlog.Logger, cfg backend.FirecrackerConfig, snapshotID, volumeRef string) (string, error) {
 	if err := validateSnapshotsEnabled(cfg); err != nil {
 		return "", err
 	}
 	if strings.EqualFold(strings.TrimSpace(cfg.Snapshots.Driver), "zfs") {
-		snapshot, err := hostRuntimeForConfig(cfg).CreateZFSSnapshot(ctx, zfsSnapshotRequest{
+		snapshot, err := hostRuntimeForConfigWithLogger(cfg, logger).CreateZFSSnapshot(ctx, zfsSnapshotRequest{
 			SnapshotID: snapshotID,
 			VolumeRef:  volumeRef,
 		})
@@ -2100,12 +2103,12 @@ func createSnapshotStorage(ctx context.Context, cfg backend.FirecrackerConfig, s
 	return snapshot.StorageRef, nil
 }
 
-func destroySnapshotStorage(ctx context.Context, cfg backend.FirecrackerConfig, storageRef string) error {
+func destroySnapshotStorage(ctx context.Context, logger *charmlog.Logger, cfg backend.FirecrackerConfig, storageRef string) error {
 	if err := validateSnapshotsEnabled(cfg); err != nil {
 		return err
 	}
 	if strings.EqualFold(strings.TrimSpace(cfg.Snapshots.Driver), "zfs") {
-		return hostRuntimeForConfig(cfg).DestroyZFSSnapshot(ctx, storageRef)
+		return hostRuntimeForConfigWithLogger(cfg, logger).DestroyZFSSnapshot(ctx, storageRef)
 	}
 
 	driver, err := snapshotVolumeStoreDriverFn(cfg)

--- a/internal/backend/firecracker/gateway_firewall.go
+++ b/internal/backend/firecracker/gateway_firewall.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/buildkite/cleanroom/internal/backend"
+	charmlog "github.com/charmbracelet/log"
 )
 
 // SetupGatewayFirewall installs global iptables rules that restrict access to
@@ -19,8 +20,8 @@ import (
 //
 // Returns a cleanup function that removes the rules. The caller must invoke
 // cleanup on shutdown.
-func SetupGatewayFirewall(ctx context.Context, port int, cfg backend.FirecrackerConfig) (cleanup func(), err error) {
-	return setupGatewayFirewall(ctx, port, hostRuntimeForConfig(cfg))
+func SetupGatewayFirewall(ctx context.Context, port int, cfg backend.FirecrackerConfig, logger *charmlog.Logger) (cleanup func(), err error) {
+	return setupGatewayFirewall(ctx, port, hostRuntimeForConfigWithLogger(cfg, logger))
 }
 
 func setupGatewayFirewall(ctx context.Context, port int, runtime hostRuntime) (cleanup func(), err error) {

--- a/internal/backend/firecracker/gateway_firewall_test.go
+++ b/internal/backend/firecracker/gateway_firewall_test.go
@@ -2,8 +2,12 @@ package firecracker
 
 import (
 	"context"
+	"io"
 	"strings"
 	"testing"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	charmlog "github.com/charmbracelet/log"
 )
 
 func TestSetupGatewayFirewall(t *testing.T) {
@@ -47,4 +51,30 @@ func TestSetupGatewayFirewall(t *testing.T) {
 			t.Errorf("cleanup call %d:\n  got:  %s\n  want: %s", i, calls[i], w)
 		}
 	}
+}
+
+func TestSetupGatewayFirewallPassesLoggerToHostRuntime(t *testing.T) {
+	prevHostRuntimeFn := newHostRuntimeFn
+	t.Cleanup(func() { newHostRuntimeFn = prevHostRuntimeFn })
+
+	logger := charmlog.New(io.Discard)
+	runtime := &testLoggerAwareHostRuntime{}
+	runtime.testHostRuntime.setupGatewayFirewallFn = func(_ context.Context, req gatewayFirewallRequest) (gatewayFirewallLease, error) {
+		if got, want := req.Port, 8170; got != want {
+			t.Fatalf("unexpected gateway firewall port: got %d want %d", got, want)
+		}
+		if runtime.logger != logger {
+			t.Fatal("expected SetupGatewayFirewall to pass the logger into the host runtime")
+		}
+		return gatewayFirewallLease{}, nil
+	}
+	newHostRuntimeFn = func(backend.FirecrackerConfig) hostRuntime {
+		return runtime
+	}
+
+	cleanup, err := SetupGatewayFirewall(context.Background(), 8170, backend.FirecrackerConfig{}, logger)
+	if err != nil {
+		t.Fatalf("SetupGatewayFirewall returned error: %v", err)
+	}
+	cleanup()
 }

--- a/internal/backend/firecracker/host_network.go
+++ b/internal/backend/firecracker/host_network.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"net"
 	"net/netip"
 	"os"
@@ -13,7 +12,9 @@ import (
 	"time"
 
 	"github.com/buildkite/cleanroom/internal/dnsproxy"
+	"github.com/buildkite/cleanroom/internal/observability"
 	"github.com/buildkite/cleanroom/internal/policy"
+	charmlog "github.com/charmbracelet/log"
 )
 
 type hostNetworkConfig struct {
@@ -29,25 +30,39 @@ type interfaceLookupFunc func(name string) (*net.Interface, error)
 type rootCommandBatchFunc func(ctx context.Context, commands [][]string) error
 
 func setupHostNetwork(ctx context.Context, runID string, allowAll bool, allow []policy.AllowRule, gatewayPort int, runner privilegedCommandRunner, onDeny func(sandboxID, queryName string), onBlocked func(string)) (hostNetworkConfig, func(), error) {
+	return setupHostNetworkWithLogger(ctx, runID, allowAll, allow, gatewayPort, nil, runner, onDeny, onBlocked)
+}
+
+func setupHostNetworkWithLogger(ctx context.Context, runID string, allowAll bool, allow []policy.AllowRule, gatewayPort int, logger *charmlog.Logger, runner privilegedCommandRunner, onDeny func(sandboxID, queryName string), onBlocked func(string)) (hostNetworkConfig, func(), error) {
 	lookup := func(ctx context.Context, host string) ([]net.IP, error) {
 		return net.DefaultResolver.LookupIP(ctx, "ip4", host)
 	}
-	return setupHostNetworkWithDeps(ctx, runID, allowAll, allow, gatewayPort, lookup, runner, onDeny, onBlocked)
+	return setupHostNetworkWithDepsAndLogger(ctx, runID, allowAll, allow, gatewayPort, lookup, logger, runner, onDeny, onBlocked)
 }
 
 func setupHostNetworkWithDeps(ctx context.Context, runID string, allowAll bool, allow []policy.AllowRule, gatewayPort int, lookup ipLookupFunc, runner privilegedCommandRunner, onDeny func(sandboxID, queryName string), onBlocked func(string)) (hostNetworkConfig, func(), error) {
-	return setupHostNetworkWithTrustedDNSFactory(ctx, runID, allowAll, allow, gatewayPort, lookup, net.InterfaceByName, runner, newTrustedDNSService, onDeny, onBlocked)
+	return setupHostNetworkWithDepsAndLogger(ctx, runID, allowAll, allow, gatewayPort, lookup, nil, runner, onDeny, onBlocked)
+}
+
+func setupHostNetworkWithDepsAndLogger(ctx context.Context, runID string, allowAll bool, allow []policy.AllowRule, gatewayPort int, lookup ipLookupFunc, logger *charmlog.Logger, runner privilegedCommandRunner, onDeny func(sandboxID, queryName string), onBlocked func(string)) (hostNetworkConfig, func(), error) {
+	return setupHostNetworkWithTrustedDNSFactoryAndLogger(ctx, runID, allowAll, allow, gatewayPort, lookup, net.InterfaceByName, logger, runner, newTrustedDNSService, onDeny, onBlocked)
 }
 
 func setupHostNetworkWithTapLookup(ctx context.Context, runID string, allowAll bool, allow []policy.AllowRule, gatewayPort int, lookup ipLookupFunc, interfaceByName interfaceLookupFunc, runner privilegedCommandRunner, onDeny func(sandboxID, queryName string), onBlocked func(string)) (hostNetworkConfig, func(), error) {
-	return setupHostNetworkWithTrustedDNSFactory(ctx, runID, allowAll, allow, gatewayPort, lookup, interfaceByName, runner, newTrustedDNSService, onDeny, onBlocked)
+	return setupHostNetworkWithTrustedDNSFactoryAndLogger(ctx, runID, allowAll, allow, gatewayPort, lookup, interfaceByName, nil, runner, newTrustedDNSService, onDeny, onBlocked)
 }
 
 func setupHostNetworkWithTrustedDNSFactory(ctx context.Context, runID string, allowAll bool, allow []policy.AllowRule, gatewayPort int, lookup ipLookupFunc, interfaceByName interfaceLookupFunc, runner privilegedCommandRunner, factory trustedDNSFactory, onDeny func(sandboxID, queryName string), onBlocked func(string)) (hostNetworkConfig, func(), error) {
+	return setupHostNetworkWithTrustedDNSFactoryAndLogger(ctx, runID, allowAll, allow, gatewayPort, lookup, interfaceByName, nil, runner, factory, onDeny, onBlocked)
+}
+
+func setupHostNetworkWithTrustedDNSFactoryAndLogger(ctx context.Context, runID string, allowAll bool, allow []policy.AllowRule, gatewayPort int, lookup ipLookupFunc, interfaceByName interfaceLookupFunc, logger *charmlog.Logger, runner privilegedCommandRunner, factory trustedDNSFactory, onDeny func(sandboxID, queryName string), onBlocked func(string)) (hostNetworkConfig, func(), error) {
 	_ = lookup
 	if factory == nil {
 		factory = newTrustedDNSService
 	}
+
+	networkLogger := observability.WithLoggerFields(baseFirecrackerLogger(logger), observability.LogFieldSandboxID, runID)
 
 	tapName := tapNameFromExecutionID(runID)
 	hostIP, guestIP := hostGuestIPs(runID)
@@ -91,7 +106,7 @@ func setupHostNetworkWithTrustedDNSFactory(ctx context.Context, runID string, al
 	removeNFLogRule := func(tapName, groupStr string) {
 		args := []string{"iptables", "-D", "FORWARD", "-i", tapName, "-j", "NFLOG", "--nflog-group", groupStr}
 		if err := runner.Run(cleanupCtx, args...); err != nil {
-			log.Printf("nflog iptables cleanup failed for %s: %v", tapName, err)
+			networkLogger.Warn("nflog iptables cleanup failed", "tap_name", tapName, "error", err)
 			addCleanup(args...)
 		}
 	}
@@ -239,6 +254,7 @@ func setupHostNetworkWithTrustedDNSFactory(ctx context.Context, runID string, al
 		runBatch:     runner.RunBatch,
 		tcpChainName: tcpChainName,
 		udpChainName: udpChainName,
+		logger:       networkLogger,
 		onDeny:       onDeny,
 	})
 	if err != nil {
@@ -257,17 +273,18 @@ func setupHostNetworkWithTrustedDNSFactory(ctx context.Context, runID string, al
 		if nflogGroup > 0 && onBlocked != nil && dnsRuntime != nil {
 			groupStr := strconv.Itoa(int(nflogGroup))
 			if err := setupRun("iptables", "-A", "FORWARD", "-i", tapName, "-j", "NFLOG", "--nflog-group", groupStr); err != nil {
-				log.Printf("nflog iptables rule unavailable for %s: %v", tapName, err)
+				networkLogger.Warn("nflog iptables rule unavailable", "tap_name", tapName, "error", err)
 			} else {
 				listener, nflogErr := newNFLogListenerFn(nflogListenerConfig{
 					group:     nflogGroup,
 					sandboxID: runID,
 					guestIP:   guestAddr,
 					runtime:   dnsRuntime,
+					logger:    networkLogger,
 					onBlocked: onBlocked,
 				})
 				if nflogErr != nil {
-					log.Printf("nflog listener unavailable for %s: %v", runID, nflogErr)
+					networkLogger.Warn("nflog listener unavailable", "error", nflogErr)
 					removeNFLogRule(tapName, groupStr)
 				} else if listener == nil {
 					removeNFLogRule(tapName, groupStr)

--- a/internal/backend/firecracker/host_runtime.go
+++ b/internal/backend/firecracker/host_runtime.go
@@ -3,14 +3,15 @@ package firecracker
 import (
 	"context"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/observability"
 	"github.com/buildkite/cleanroom/internal/policy"
 	"github.com/buildkite/cleanroom/internal/volumestore"
+	charmlog "github.com/charmbracelet/log"
 )
 
 type hostRuntime interface {
@@ -73,6 +74,7 @@ type zfsSnapshot struct {
 type runnerBackedHostRuntime struct {
 	cfg    backend.FirecrackerConfig
 	runner privilegedCommandRunner
+	logger *charmlog.Logger
 }
 
 type hostRuntimeVolumeCommandRunner struct {
@@ -88,18 +90,30 @@ func hostRuntimeForConfig(cfg backend.FirecrackerConfig) hostRuntime {
 	return newHostRuntimeFn(cfg)
 }
 
+func hostRuntimeForConfigWithLogger(cfg backend.FirecrackerConfig, logger *charmlog.Logger) hostRuntime {
+	runtime := hostRuntimeForConfig(cfg)
+	if setter, ok := runtime.(interface{ setLogger(*charmlog.Logger) }); ok {
+		setter.setLogger(logger)
+	}
+	return runtime
+}
+
 func newRunnerBackedHostRuntime(cfg backend.FirecrackerConfig) hostRuntime {
-	return runnerBackedHostRuntime{
+	return &runnerBackedHostRuntime{
 		cfg:    cfg,
 		runner: newPrivilegedCommandRunner(cfg),
 	}
 }
 
-func (r runnerBackedHostRuntime) CheckAccess(ctx context.Context) error {
+func (r *runnerBackedHostRuntime) setLogger(logger *charmlog.Logger) {
+	r.logger = logger
+}
+
+func (r *runnerBackedHostRuntime) CheckAccess(ctx context.Context) error {
 	return r.runner.Run(ctx, "true")
 }
 
-func (r runnerBackedHostRuntime) CheckNetworking(ctx context.Context) error {
+func (r *runnerBackedHostRuntime) CheckNetworking(ctx context.Context) error {
 	return r.runner.Run(ctx, "ip", "link", "show")
 }
 
@@ -117,8 +131,8 @@ func (l gatewayFirewallLease) Release(ctx context.Context) error {
 	return l.release(ctx)
 }
 
-func (r runnerBackedHostRuntime) SetupSandboxNetwork(ctx context.Context, req sandboxNetworkRequest) (sandboxNetworkLease, error) {
-	config, cleanup, err := setupHostNetwork(ctx, req.SandboxID, req.AllowAll, req.Allow, req.GatewayPort, r.runner, req.OnDeny, req.OnBlocked)
+func (r *runnerBackedHostRuntime) SetupSandboxNetwork(ctx context.Context, req sandboxNetworkRequest) (sandboxNetworkLease, error) {
+	config, cleanup, err := setupHostNetworkWithLogger(ctx, req.SandboxID, req.AllowAll, req.Allow, req.GatewayPort, observability.WithTraceContext(r.logger, ctx), r.runner, req.OnDeny, req.OnBlocked)
 	if err != nil {
 		return sandboxNetworkLease{}, err
 	}
@@ -131,7 +145,7 @@ func (r runnerBackedHostRuntime) SetupSandboxNetwork(ctx context.Context, req sa
 	}, nil
 }
 
-func (r runnerBackedHostRuntime) SetupGatewayFirewall(ctx context.Context, req gatewayFirewallRequest) (gatewayFirewallLease, error) {
+func (r *runnerBackedHostRuntime) SetupGatewayFirewall(ctx context.Context, req gatewayFirewallRequest) (gatewayFirewallLease, error) {
 	cleanup, err := setupGatewayFirewallWithRunner(ctx, req.Port, r.runner)
 	if err != nil {
 		return gatewayFirewallLease{}, err
@@ -144,11 +158,11 @@ func (r runnerBackedHostRuntime) SetupGatewayFirewall(ctx context.Context, req g
 	}, nil
 }
 
-func (r runnerBackedHostRuntime) ValidateZFSDatasetRoot(ctx context.Context, dataset string) error {
+func (r *runnerBackedHostRuntime) ValidateZFSDatasetRoot(ctx context.Context, dataset string) error {
 	return validateZFSDatasetRootWithRunner(ctx, r.runner, dataset)
 }
 
-func (r runnerBackedHostRuntime) PrepareZFSWritableVolume(ctx context.Context, req zfsWritableVolumeRequest) (zfsWritableVolume, error) {
+func (r *runnerBackedHostRuntime) PrepareZFSWritableVolume(ctx context.Context, req zfsWritableVolumeRequest) (zfsWritableVolume, error) {
 	driver, err := r.openZFSVolumeStore(r.cfg.Snapshots.ZFSDataset)
 	if err != nil {
 		return zfsWritableVolume{}, err
@@ -162,7 +176,7 @@ func (r runnerBackedHostRuntime) PrepareZFSWritableVolume(ctx context.Context, r
 
 	cleanupVolume := func(ref string) {
 		if err := driver.DestroyVolume(context.Background(), volumestore.DestroyVolumeRequest{VolumeRef: ref}); err != nil {
-			log.Printf("firecracker: cleanup persistent volume %q: %v", ref, err)
+			logPersistentVolumeCleanup(r.logger, ref, err)
 		}
 	}
 	resizeVolume := func(volume volumestore.WritableVolume) (zfsWritableVolume, error) {
@@ -210,7 +224,7 @@ func (r runnerBackedHostRuntime) PrepareZFSWritableVolume(ctx context.Context, r
 	return resizeVolume(volume)
 }
 
-func (r runnerBackedHostRuntime) CreateZFSSnapshot(ctx context.Context, req zfsSnapshotRequest) (zfsSnapshot, error) {
+func (r *runnerBackedHostRuntime) CreateZFSSnapshot(ctx context.Context, req zfsSnapshotRequest) (zfsSnapshot, error) {
 	driver, err := r.openZFSVolumeStore(r.cfg.Snapshots.ZFSDataset)
 	if err != nil {
 		return zfsSnapshot{}, err
@@ -225,7 +239,7 @@ func (r runnerBackedHostRuntime) CreateZFSSnapshot(ctx context.Context, req zfsS
 	return zfsSnapshot{StorageRef: snapshot.StorageRef}, nil
 }
 
-func (r runnerBackedHostRuntime) DestroyZFSVolume(ctx context.Context, volumeRef string) error {
+func (r *runnerBackedHostRuntime) DestroyZFSVolume(ctx context.Context, volumeRef string) error {
 	driver, err := r.openZFSVolumeStore(r.cfg.Snapshots.ZFSDataset)
 	if err != nil {
 		return err
@@ -233,7 +247,7 @@ func (r runnerBackedHostRuntime) DestroyZFSVolume(ctx context.Context, volumeRef
 	return driver.DestroyVolume(ctx, volumestore.DestroyVolumeRequest{VolumeRef: volumeRef})
 }
 
-func (r runnerBackedHostRuntime) DestroyZFSSnapshot(ctx context.Context, snapshotRef string) error {
+func (r *runnerBackedHostRuntime) DestroyZFSSnapshot(ctx context.Context, snapshotRef string) error {
 	driver, err := r.openZFSVolumeStore(r.cfg.Snapshots.ZFSDataset)
 	if err != nil {
 		return err
@@ -241,7 +255,7 @@ func (r runnerBackedHostRuntime) DestroyZFSSnapshot(ctx context.Context, snapsho
 	return driver.DestroySnapshot(ctx, volumestore.DestroySnapshotRequest{SnapshotRef: snapshotRef})
 }
 
-func (r runnerBackedHostRuntime) openZFSVolumeStore(datasetRoot string) (*volumestore.ZFSDriver, error) {
+func (r *runnerBackedHostRuntime) openZFSVolumeStore(datasetRoot string) (*volumestore.ZFSDriver, error) {
 	return volumestore.NewZFSDriver(volumestore.ZFSDriverOptions{
 		DatasetRoot: datasetRoot,
 		Runner:      hostRuntimeVolumeCommandRunner{runner: r.runner},

--- a/internal/backend/firecracker/host_runtime_test.go
+++ b/internal/backend/firecracker/host_runtime_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/buildkite/cleanroom/internal/backend"
+	charmlog "github.com/charmbracelet/log"
 )
 
 type testHostRuntime struct {
@@ -17,6 +18,15 @@ type testHostRuntime struct {
 	createZFSSnapshotFn        func(context.Context, zfsSnapshotRequest) (zfsSnapshot, error)
 	destroyZFSVolumeFn         func(context.Context, string) error
 	destroyZFSSnapshotFn       func(context.Context, string) error
+}
+
+type testLoggerAwareHostRuntime struct {
+	testHostRuntime
+	logger *charmlog.Logger
+}
+
+func (r *testLoggerAwareHostRuntime) setLogger(logger *charmlog.Logger) {
+	r.logger = logger
 }
 
 func (r testHostRuntime) CheckAccess(ctx context.Context) error {

--- a/internal/backend/firecracker/logging.go
+++ b/internal/backend/firecracker/logging.go
@@ -1,0 +1,34 @@
+package firecracker
+
+import (
+	"strings"
+
+	"github.com/buildkite/cleanroom/internal/observability"
+	charmlog "github.com/charmbracelet/log"
+)
+
+func baseFirecrackerLogger(logger *charmlog.Logger) *charmlog.Logger {
+	if logger != nil {
+		return logger
+	}
+	return charmlog.Default().With(observability.LogFieldBackend, "firecracker")
+}
+
+func logPersistentVolumeCleanup(logger *charmlog.Logger, volumeRef string, err error) {
+	if err == nil {
+		return
+	}
+	observability.WithLoggerFields(baseFirecrackerLogger(logger), "volume_ref", strings.TrimSpace(volumeRef)).Warn("cleanup persistent volume", "error", err)
+}
+
+func logExecutionNotice(logger *charmlog.Logger, runID, notice string) {
+	msg := strings.TrimSpace(notice)
+	if msg == "" {
+		return
+	}
+	entry := baseFirecrackerLogger(logger)
+	if id := strings.TrimSpace(runID); id != "" {
+		entry = entry.With(observability.LogFieldExecutionID, id)
+	}
+	entry.Info(msg)
+}

--- a/internal/backend/firecracker/nflog_listener.go
+++ b/internal/backend/firecracker/nflog_listener.go
@@ -6,12 +6,12 @@ import (
 	"context"
 	"fmt"
 	"hash/fnv"
-	"log"
 	"net/netip"
 	"strings"
 	"time"
 
 	"github.com/buildkite/cleanroom/internal/dnsproxy"
+	charmlog "github.com/charmbracelet/log"
 	nflog "github.com/florianl/go-nflog/v2"
 	"github.com/mdlayher/netlink"
 )
@@ -29,6 +29,7 @@ type nflogListenerConfig struct {
 	sandboxID string
 	guestIP   netip.Addr
 	runtime   *dnsproxy.Runtime
+	logger    *charmlog.Logger
 	onBlocked func(string)
 }
 
@@ -87,7 +88,7 @@ func newNFLogListener(cfg nflogListenerConfig) (*nflogListener, error) {
 		if ctx.Err() != nil {
 			return 1
 		}
-		log.Printf("[ERROR] nflog group %d: %v", cfg.group, e)
+		baseFirecrackerLogger(cfg.logger).Warn("nflog listener error", "nflog_group", cfg.group, "error", e)
 		return 0
 	}
 

--- a/internal/backend/firecracker/nflog_listener_stub.go
+++ b/internal/backend/firecracker/nflog_listener_stub.go
@@ -6,6 +6,7 @@ import (
 	"net/netip"
 
 	"github.com/buildkite/cleanroom/internal/dnsproxy"
+	charmlog "github.com/charmbracelet/log"
 )
 
 type nflogListenerConfig struct {
@@ -13,6 +14,7 @@ type nflogListenerConfig struct {
 	sandboxID string
 	guestIP   netip.Addr
 	runtime   *dnsproxy.Runtime
+	logger    *charmlog.Logger
 	onBlocked func(string)
 }
 

--- a/internal/backend/firecracker/snapshot_test.go
+++ b/internal/backend/firecracker/snapshot_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -534,6 +535,60 @@ func TestCreateSnapshotRejectsDisabledZFSSnapshots(t *testing.T) {
 	}
 	if len(signals) != 0 {
 		t.Fatalf("expected snapshots-disabled validation to fail before pausing sandbox, got signals %v", signals)
+	}
+}
+
+func TestSnapshotStorageHelpersPassLoggerToHostRuntime(t *testing.T) {
+	prevHostRuntimeFn := newHostRuntimeFn
+	t.Cleanup(func() { newHostRuntimeFn = prevHostRuntimeFn })
+
+	logger := log.New(io.Discard)
+	runtime := &testLoggerAwareHostRuntime{}
+	runtime.testHostRuntime.createZFSSnapshotFn = func(_ context.Context, req zfsSnapshotRequest) (zfsSnapshot, error) {
+		if runtime.logger != logger {
+			t.Fatal("expected createSnapshotStorage to pass the logger into the host runtime")
+		}
+		if got, want := req.SnapshotID, "snap-test"; got != want {
+			t.Fatalf("unexpected snapshot id: got %q want %q", got, want)
+		}
+		if got, want := req.VolumeRef, "tank/cleanroom/sandboxes/cr-test"; got != want {
+			t.Fatalf("unexpected volume ref: got %q want %q", got, want)
+		}
+		return zfsSnapshot{StorageRef: "tank/cleanroom/snapshots/snap-test@seed"}, nil
+	}
+	runtime.testHostRuntime.destroyZFSSnapshotFn = func(_ context.Context, snapshotRef string) error {
+		if runtime.logger != logger {
+			t.Fatal("expected destroySnapshotStorage to pass the logger into the host runtime")
+		}
+		if got, want := snapshotRef, "tank/cleanroom/snapshots/snap-test@seed"; got != want {
+			t.Fatalf("unexpected snapshot ref: got %q want %q", got, want)
+		}
+		return nil
+	}
+	newHostRuntimeFn = func(cfg backend.FirecrackerConfig) hostRuntime {
+		if got, want := cfg.Snapshots.Driver, "zfs"; got != want {
+			t.Fatalf("unexpected snapshot driver: got %q want %q", got, want)
+		}
+		return runtime
+	}
+
+	cfg := backend.FirecrackerConfig{
+		Snapshots: backend.SnapshotConfig{
+			Enabled:    true,
+			Driver:     "zfs",
+			ZFSDataset: "tank/cleanroom",
+		},
+	}
+
+	storageRef, err := createSnapshotStorage(context.Background(), logger, cfg, "snap-test", "tank/cleanroom/sandboxes/cr-test")
+	if err != nil {
+		t.Fatalf("createSnapshotStorage returned error: %v", err)
+	}
+	if got, want := storageRef, "tank/cleanroom/snapshots/snap-test@seed"; got != want {
+		t.Fatalf("unexpected storage ref: got %q want %q", got, want)
+	}
+	if err := destroySnapshotStorage(context.Background(), logger, cfg, storageRef); err != nil {
+		t.Fatalf("destroySnapshotStorage returned error: %v", err)
 	}
 }
 

--- a/internal/backend/firecracker/snapshot_test.go
+++ b/internal/backend/firecracker/snapshot_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -16,6 +15,7 @@ import (
 	"github.com/buildkite/cleanroom/internal/policy"
 	"github.com/buildkite/cleanroom/internal/volumestore"
 	"github.com/buildkite/cleanroom/internal/vsockexec"
+	"github.com/charmbracelet/log"
 )
 
 type testVolumeDriver struct {
@@ -75,16 +75,10 @@ func captureFirecrackerLogOutput(t *testing.T) *bytes.Buffer {
 	t.Helper()
 
 	var buf bytes.Buffer
-	prevWriter := log.Writer()
-	prevFlags := log.Flags()
-	prevPrefix := log.Prefix()
-	log.SetOutput(&buf)
-	log.SetFlags(0)
-	log.SetPrefix("")
+	prevLogger := log.Default()
+	log.SetDefault(log.NewWithOptions(&buf, log.Options{Formatter: log.TextFormatter}))
 	t.Cleanup(func() {
-		log.SetOutput(prevWriter)
-		log.SetFlags(prevFlags)
-		log.SetPrefix(prevPrefix)
+		log.SetDefault(prevLogger)
 	})
 	return &buf
 }
@@ -950,7 +944,7 @@ func TestPreparePersistentWritableVolumeLogsDestroyFailure(t *testing.T) {
 
 	cleanupVolume()
 
-	if got := logOutput.String(); !strings.Contains(got, "firecracker: cleanup persistent volume \"tank/cleanroom/sandboxes/sandbox-1\": destroy failed") {
+	if got := logOutput.String(); !strings.Contains(got, "cleanup persistent volume") || !strings.Contains(got, "volume_ref=tank/cleanroom/sandboxes/sandbox-1") || !strings.Contains(got, "destroy failed") {
 		t.Fatalf("expected destroy error to be logged, got %q", got)
 	}
 }

--- a/internal/backend/firecracker/trusted_dns.go
+++ b/internal/backend/firecracker/trusted_dns.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"net"
 	"net/netip"
 	"strconv"
@@ -15,6 +14,7 @@ import (
 	"github.com/buildkite/cleanroom/internal/dnsproxy"
 	"github.com/buildkite/cleanroom/internal/gateway"
 	"github.com/buildkite/cleanroom/internal/policy"
+	charmlog "github.com/charmbracelet/log"
 	"github.com/miekg/dns"
 )
 
@@ -32,6 +32,7 @@ type trustedDNSConfig struct {
 	tcpChainName string
 	udpChainName string
 	now          func() time.Time
+	logger       *charmlog.Logger
 	onDeny       func(sandboxID, queryName string)
 }
 
@@ -43,6 +44,7 @@ type trustedDNSChainSyncer struct {
 	udpChainName string
 	runBatch     rootCommandBatchFunc
 	now          func() time.Time
+	logger       *charmlog.Logger
 }
 
 type trustedDNSChainManager struct {
@@ -99,6 +101,7 @@ func newTrustedDNSService(_ context.Context, cfg trustedDNSConfig) (func(), *dns
 			udpChainName: cfg.udpChainName,
 			runBatch:     cfg.runBatch,
 			now:          cfg.now,
+			logger:       cfg.logger,
 		})
 	}
 
@@ -151,12 +154,12 @@ func newTrustedDNSService(_ context.Context, cfg trustedDNSConfig) (func(), *dns
 
 	go func() {
 		if err := udpServer.ActivateAndServe(); err != nil && !isTrustedDNSServerClosedError(err) {
-			log.Printf("trusted dns udp server failed for %s: %v", cfg.sandboxID, err)
+			baseFirecrackerLogger(cfg.logger).Error("trusted dns udp server failed", "error", err)
 		}
 	}()
 	go func() {
 		if err := tcpServer.ActivateAndServe(); err != nil && !isTrustedDNSServerClosedError(err) {
-			log.Printf("trusted dns tcp server failed for %s: %v", cfg.sandboxID, err)
+			baseFirecrackerLogger(cfg.logger).Error("trusted dns tcp server failed", "error", err)
 		}
 	}()
 
@@ -247,7 +250,7 @@ func (m *trustedDNSChainManager) run(ctx context.Context) {
 
 		nextSync, hasNextSync, err := m.syncOnce()
 		if err != nil {
-			log.Printf("trusted dns sync failed for %s: %v", m.sandboxID, err)
+			baseFirecrackerLogger(m.syncer.logger).Warn("trusted dns sync failed", "error", err)
 			nextSync = time.Now().Add(trustedDNSSyncRetryDelay)
 			hasNextSync = true
 		}

--- a/internal/cli/logging.go
+++ b/internal/cli/logging.go
@@ -4,23 +4,21 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/buildkite/cleanroom/internal/observability"
+	"github.com/buildkite/cleanroom/internal/runtimeconfig"
 	"github.com/charmbracelet/log"
 )
 
-func newLogger(rawLevel, component string) (*log.Logger, error) {
+func newLogger(rawLevel string, cfg runtimeconfig.ObservabilityConfig, component string) (*log.Logger, error) {
 	levelName := effectiveLogLevel(rawLevel)
-	level, err := log.ParseLevel(levelName)
+	logger, err := observability.NewLogger(os.Stderr, levelName, cfg, observability.LogFieldComponent, component)
 	if err != nil {
 		return nil, fmt.Errorf("invalid --log-level %q: %w", rawLevel, err)
 	}
-	logger := log.NewWithOptions(os.Stderr, log.Options{
-		Level:     level,
-		Formatter: log.TextFormatter,
-	})
-	return logger.With("component", component), nil
+	return logger, nil
 }
 
 func newClientLogger() *log.Logger {
-	logger, _ := newLogger("warn", "client")
+	logger, _ := newLogger("warn", runtimeconfig.ObservabilityConfig{}, "client")
 	return logger
 }

--- a/internal/cli/logging.go
+++ b/internal/cli/logging.go
@@ -11,9 +11,12 @@ import (
 
 func newLogger(rawLevel string, cfg runtimeconfig.ObservabilityConfig, component string) (*log.Logger, error) {
 	levelName := effectiveLogLevel(rawLevel)
+	if _, err := log.ParseLevel(levelName); err != nil {
+		return nil, fmt.Errorf("invalid --log-level %q: %w", rawLevel, err)
+	}
 	logger, err := observability.NewLogger(os.Stderr, levelName, cfg, observability.LogFieldComponent, component)
 	if err != nil {
-		return nil, fmt.Errorf("invalid --log-level %q: %w", rawLevel, err)
+		return nil, err
 	}
 	return logger, nil
 }

--- a/internal/cli/logging_test.go
+++ b/internal/cli/logging_test.go
@@ -1,0 +1,25 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/runtimeconfig"
+)
+
+func TestNewLoggerReturnsLogFormatError(t *testing.T) {
+	t.Parallel()
+
+	_, err := newLogger("info", runtimeconfig.ObservabilityConfig{
+		Logs: runtimeconfig.LogConfig{Format: "logfmt"},
+	}, "server")
+	if err == nil {
+		t.Fatal("expected newLogger to fail for unsupported log format")
+	}
+	if strings.Contains(err.Error(), "invalid --log-level") {
+		t.Fatalf("expected non-log-level error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "unsupported observability.logs.format") {
+		t.Fatalf("expected observability log format error, got %v", err)
+	}
+}

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -139,7 +139,7 @@ func (s *ServeCommand) runServer(ctx *runtimeContext) error {
 			fwCfg := backend.FirecrackerConfig{
 				PrivilegedHelperPath: ctx.Config.Backends.Firecracker.PrivilegedHelperPath,
 			}
-			fwCleanup, err := firecracker.SetupGatewayFirewall(context.Background(), gwPort, fwCfg)
+			fwCleanup, err := firecracker.SetupGatewayFirewall(context.Background(), gwPort, fwCfg, logger.With("subsystem", "gateway"))
 			if err != nil {
 				logger.Warn("failed to install gateway firewall rules", "error", err)
 			} else {

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -22,6 +22,7 @@ import (
 	"github.com/buildkite/cleanroom/internal/endpoint"
 	"github.com/buildkite/cleanroom/internal/gateway"
 	"github.com/buildkite/cleanroom/internal/interactivequic"
+	"github.com/buildkite/cleanroom/internal/observability"
 	"github.com/buildkite/cleanroom/internal/repositorystore"
 	"github.com/buildkite/cleanroom/internal/runtimeconfig"
 	"github.com/buildkite/cleanroom/internal/snapshotstore"
@@ -74,11 +75,15 @@ func (s *ServeCommand) runServer(ctx *runtimeContext) error {
 		}
 	}
 
-	logger, err := newLogger(s.LogLevel, "server")
+	logger, err := newLogger(s.LogLevel, ctx.Config.Observability, "server")
 	if err != nil {
 		return err
 	}
 	log.SetDefault(logger)
+	configureBackendLogging(ctx.Backends, logger)
+	serviceLogger := logger.With("subsystem", "service")
+	httpLogger := logger.With("subsystem", "http")
+	interactiveLogger := logger.With("subsystem", "interactive-quic")
 
 	gwRegistry := gateway.NewRegistry()
 	gwCredentials := gateway.NewChainCredentialProvider(
@@ -151,7 +156,7 @@ func (s *ServeCommand) runServer(ctx *runtimeContext) error {
 		}
 	}
 
-	service, err := newControlService(ctx, logger.With("subsystem", "service"), gwMirrors)
+	service, err := newControlService(ctx, serviceLogger, gwMirrors)
 	if err != nil {
 		return err
 	}
@@ -159,12 +164,12 @@ func (s *ServeCommand) runServer(ctx *runtimeContext) error {
 	if interceptor := ctx.Observability.ConnectInterceptor(); interceptor != nil {
 		serverInterceptors = append(serverInterceptors, interceptor)
 	}
-	server := controlserver.New(service, logger.With("subsystem", "http"), serverInterceptors...)
+	server := controlserver.New(service, httpLogger, serverInterceptors...)
 
 	runCtx, cancel := serveSignalNotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 	interactiveListen, interactiveHost := resolveInteractiveQUICEndpoint(ep)
-	interactiveServer, err := interactivequic.Start(runCtx, interactiveListen, service, logger.With("subsystem", "interactive-quic"))
+	interactiveServer, err := interactivequic.Start(runCtx, interactiveListen, service, interactiveLogger)
 	if err != nil {
 		return fmt.Errorf("start interactive quic server: %w", err)
 	}
@@ -172,14 +177,14 @@ func (s *ServeCommand) runServer(ctx *runtimeContext) error {
 
 	interactiveEndpoint := interactiveAdvertiseEndpoint(interactiveServer.Addr(), interactiveHost)
 	service.ConfigureInteractiveTransport(interactiveEndpoint, interactiveServer.ALPN(), interactiveServer.CertPinSHA256())
-	logger.Info(
+	interactiveLogger.Info(
 		"interactive QUIC server ready",
 		"listen", interactiveServer.Addr().String(),
 		"endpoint", interactiveEndpoint,
 		"alpn", interactiveServer.ALPN(),
 	)
 
-	runErr := controlserver.Serve(runCtx, ep, server.Handler(), logger, serverTLS)
+	runErr := controlserver.Serve(runCtx, ep, server.Handler(), httpLogger, serverTLS)
 	gwStopCtx, gwStopCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer gwStopCancel()
 	_ = gwServer.Stop(gwStopCtx)
@@ -203,8 +208,15 @@ func gatewayServerConfig(listen string, registry *gateway.Registry, credentials 
 }
 
 func observabilityStartupFields(cfg runtimeconfig.ObservabilityConfig) []startupField {
+	format, err := runtimeconfig.ResolveObservabilityLogFormat(cfg)
+	if err != nil {
+		return []startupField{{Key: "observability", Value: "invalid"}}
+	}
 	if !cfg.Enabled {
-		return []startupField{{Key: "observability", Value: "disabled"}}
+		return []startupField{
+			{Key: "observability", Value: "disabled"},
+			{Key: "log_format", Value: format},
+		}
 	}
 
 	protocol, err := runtimeconfig.ResolveOTLPTraceProtocol(cfg)
@@ -212,6 +224,7 @@ func observabilityStartupFields(cfg runtimeconfig.ObservabilityConfig) []startup
 		return []startupField{{Key: "observability", Value: "invalid"}}
 	}
 	fields := []startupField{{Key: "observability", Value: "enabled"}}
+	fields = append(fields, startupField{Key: "log_format", Value: format})
 	fields = append(fields, startupField{Key: "trace_export", Value: fmt.Sprintf("otlp/%s -> %s", protocol, strings.TrimSpace(cfg.OTLP.Endpoint))})
 	fields = append(fields, startupField{Key: "trace_sampling", Value: formatTraceSampling(cfg.Traces.Sampling)})
 	if strings.TrimSpace(cfg.Traces.URLTemplate) != "" {
@@ -229,6 +242,19 @@ func formatTraceSampling(cfg runtimeconfig.TraceSamplingConfig) string {
 		return mode
 	}
 	return fmt.Sprintf("%s ratio=%g", mode, *cfg.Ratio)
+}
+
+func configureBackendLogging(backends map[string]backend.Adapter, logger *log.Logger) {
+	if logger == nil {
+		return
+	}
+	if fcAdapter, ok := backends["firecracker"].(*firecracker.Adapter); ok {
+		fcAdapter.Logger = observability.WithLoggerFields(
+			logger,
+			observability.LogFieldSubsystem, "firecracker",
+			observability.LogFieldBackend, "firecracker",
+		)
+	}
 }
 
 func configureGatewayBackends(backends map[string]backend.Adapter, gwRegistry *gateway.Registry, gwPort int, gwListenAddr, darwinGatewayHost string, routes gateway.ProxyRoutes) {

--- a/internal/cli/serve_observability_test.go
+++ b/internal/cli/serve_observability_test.go
@@ -11,7 +11,10 @@ func TestObservabilityStartupFieldsDisabled(t *testing.T) {
 	t.Parallel()
 
 	got := observabilityStartupFields(runtimeconfig.ObservabilityConfig{})
-	want := []startupField{{Key: "observability", Value: "disabled"}}
+	want := []startupField{
+		{Key: "observability", Value: "disabled"},
+		{Key: "log_format", Value: "text"},
+	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("unexpected observability startup fields: got %#v want %#v", got, want)
 	}
@@ -23,6 +26,9 @@ func TestObservabilityStartupFieldsOTLP(t *testing.T) {
 	ratio := 0.5
 	got := observabilityStartupFields(runtimeconfig.ObservabilityConfig{
 		Enabled: true,
+		Logs: runtimeconfig.LogConfig{
+			Format: "json",
+		},
 		OTLP: runtimeconfig.OTLPConfig{
 			Endpoint: "https://otel.example.test:4317",
 			Protocol: "grpc",
@@ -37,6 +43,7 @@ func TestObservabilityStartupFieldsOTLP(t *testing.T) {
 	})
 	want := []startupField{
 		{Key: "observability", Value: "enabled"},
+		{Key: "log_format", Value: "json"},
 		{Key: "trace_export", Value: "otlp/grpc -> https://otel.example.test:4317"},
 		{Key: "trace_sampling", Value: "parentbased_traceidratio ratio=0.5"},
 		{Key: "trace_links", Value: "enabled"},

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"io"
@@ -142,6 +143,61 @@ func TestConfigureBackendObservabilityConfiguresSupportedBackends(t *testing.T) 
 	}
 	if darwinAdapter.MeterProvider == nil {
 		t.Fatal("expected darwin-vz adapter meter provider to be configured")
+	}
+}
+
+func TestConfigureBackendLoggingConfiguresFirecrackerLogger(t *testing.T) {
+	t.Parallel()
+
+	fcAdapter := &firecracker.Adapter{}
+	backends := map[string]backend.Adapter{"firecracker": fcAdapter}
+
+	configureBackendLogging(backends, log.New(io.Discard))
+
+	if fcAdapter.Logger == nil {
+		t.Fatal("expected firecracker adapter logger to be configured")
+	}
+}
+
+func TestServeSubsystemLoggersIncludeSubsystem(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger, err := observability.NewLogger(&buf, "info", runtimeconfig.ObservabilityConfig{
+		Logs: runtimeconfig.LogConfig{Format: "json"},
+	}, observability.LogFieldComponent, "server")
+	if err != nil {
+		t.Fatalf("NewLogger returned error: %v", err)
+	}
+
+	logger.With(observability.LogFieldSubsystem, "interactive-quic").Info("interactive QUIC server ready")
+	logger.With(observability.LogFieldSubsystem, "http").Info("serving cleanroom control API")
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if got, want := len(lines), 2; got != want {
+		t.Fatalf("unexpected log line count: got %d want %d\noutput=%s", got, want, buf.String())
+	}
+
+	var first map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &first); err != nil {
+		t.Fatalf("unmarshal first log line: %v", err)
+	}
+	if got, want := first[observability.LogFieldComponent], "server"; got != want {
+		t.Fatalf("unexpected component: got %#v want %#v", got, want)
+	}
+	if got, want := first[observability.LogFieldSubsystem], "interactive-quic"; got != want {
+		t.Fatalf("unexpected first subsystem: got %#v want %#v", got, want)
+	}
+
+	var second map[string]any
+	if err := json.Unmarshal([]byte(lines[1]), &second); err != nil {
+		t.Fatalf("unmarshal second log line: %v", err)
+	}
+	if got, want := second[observability.LogFieldComponent], "server"; got != want {
+		t.Fatalf("unexpected component: got %#v want %#v", got, want)
+	}
+	if got, want := second[observability.LogFieldSubsystem], "http"; got != want {
+		t.Fatalf("unexpected second subsystem: got %#v want %#v", got, want)
 	}
 }
 

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -246,6 +246,7 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 			attribute.Bool(observability.AttrRepositoryChangeset, changeset != nil),
 		),
 	)
+	logger := observability.WithTraceContext(s.Logger, ctx)
 	defer func() {
 		metricBackendName := backendName
 		if resp != nil && resp.GetSandbox() != nil {
@@ -478,19 +479,19 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 	now := s.clock().Now()
 	sandboxID := s.ids().NewSandboxID()
 	span.SetAttributes(attribute.String("cleanroom.sandbox.id", sandboxID))
-	if s.Logger != nil {
-		s.Logger.Debug("create sandbox requested",
-			"sandbox_id", sandboxID,
-			"backend", backendName,
+	if logger != nil {
+		logger.Debug("create sandbox requested",
+			observability.LogFieldSandboxID, sandboxID,
+			observability.LogFieldBackend, backendName,
 			"policy_hash", compiled.Hash,
 			"repository_checkout", repository != nil,
 		)
 	}
 
-	if s.Logger != nil {
-		s.Logger.Debug("provisioning sandbox",
-			"sandbox_id", sandboxID,
-			"backend", backendName,
+	if logger != nil {
+		logger.Debug("provisioning sandbox",
+			observability.LogFieldSandboxID, sandboxID,
+			observability.LogFieldBackend, backendName,
 		)
 	}
 	emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_PROVISION_SANDBOX, "provisioning sandbox")
@@ -501,10 +502,10 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 	}); err != nil {
 		return nil, fmt.Errorf("provision sandbox: %w", err)
 	}
-	if s.Logger != nil {
-		s.Logger.Debug("sandbox provisioned",
-			"sandbox_id", sandboxID,
-			"backend", backendName,
+	if logger != nil {
+		logger.Debug("sandbox provisioned",
+			observability.LogFieldSandboxID, sandboxID,
+			observability.LogFieldBackend, backendName,
 		)
 	}
 	if repository != nil {
@@ -601,10 +602,10 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 	}
 	s.mu.Unlock()
 
-	if s.Logger != nil {
-		s.Logger.Info("sandbox created",
-			"sandbox_id", sandboxID,
-			"backend", backendName,
+	if logger != nil {
+		logger.Info("sandbox created",
+			observability.LogFieldSandboxID, sandboxID,
+			observability.LogFieldBackend, backendName,
 			"policy_hash", compiled.Hash,
 		)
 	}
@@ -1122,6 +1123,7 @@ func (s *Service) CreateExecution(ctx context.Context, req *cleanroomv1.CreateEx
 			attribute.Int(observability.AttrCommandArgc, len(command)),
 		),
 	)
+	logger := observability.WithTraceContext(s.Logger, ctx)
 	defer func() {
 		if resp != nil && resp.GetExecution() != nil {
 			span.SetAttributes(
@@ -1185,6 +1187,7 @@ func (s *Service) CreateExecution(ctx context.Context, req *cleanroomv1.CreateEx
 		s.mu.Unlock()
 		return nil, fmt.Errorf("unknown backend %q", sandbox.Backend)
 	}
+	sandboxBackend := sandbox.Backend
 	if strings.TrimSpace(sandbox.ActiveExecutionID) != "" {
 		if activeExecution, ok := s.executions[executionKey(sandboxID, sandbox.ActiveExecutionID)]; ok && !isFinalExecutionStatus(activeExecution.Status) {
 			s.mu.Unlock()
@@ -1301,10 +1304,11 @@ func (s *Service) CreateExecution(ctx context.Context, req *cleanroomv1.CreateEx
 
 	go s.runExecution(sandboxID, executionID)
 
-	if s.Logger != nil {
-		s.Logger.Info("execution created",
-			"sandbox_id", sandboxID,
-			"execution_id", executionID,
+	if logger != nil {
+		logger.Info("execution created",
+			observability.LogFieldSandboxID, sandboxID,
+			observability.LogFieldExecutionID, executionID,
+			observability.LogFieldBackend, sandboxBackend,
 			"command_argc", len(command),
 			"tty", tty,
 			"kind", kind.String(),
@@ -2053,6 +2057,7 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 			attribute.Int(observability.AttrCommandArgc, len(ex.Command)),
 		),
 	)
+	runLogger := observability.WithTraceContext(s.Logger, runCtx)
 	s.mu.Unlock()
 	defer span.End()
 	recordExecutionMetrics := func(status cleanroomv1.ExecutionStatus, finished time.Time) {
@@ -2185,10 +2190,11 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 		finished := s.clock().Now()
 		recordExecutionMetrics(finalStatus, finished)
 		s.finalizeExecutionLocked(ex, finalStatus, exitCode, err.Error(), "", finished)
-		if s.Logger != nil {
-			s.Logger.Warn("execution failed",
-				"sandbox_id", ex.SandboxID,
-				"execution_id", ex.ID,
+		if runLogger != nil {
+			runLogger.Warn("execution failed",
+				observability.LogFieldSandboxID, ex.SandboxID,
+				observability.LogFieldExecutionID, ex.ID,
+				observability.LogFieldBackend, sb.Backend,
 				"image_ref", ex.ImageRef,
 				"image_digest", ex.ImageDigest,
 				"status", ex.Status.String(),
@@ -2229,10 +2235,11 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 	recordExecutionMetrics(finalStatus, finished)
 	s.finalizeExecutionLocked(ex, finalStatus, finalExitCode, ex.Message, "", finished)
 
-	if s.Logger != nil {
-		s.Logger.Info("execution completed",
-			"sandbox_id", ex.SandboxID,
-			"execution_id", ex.ID,
+	if runLogger != nil {
+		runLogger.Info("execution completed",
+			observability.LogFieldSandboxID, ex.SandboxID,
+			observability.LogFieldExecutionID, ex.ID,
+			observability.LogFieldBackend, sb.Backend,
 			"image_ref", ex.ImageRef,
 			"image_digest", ex.ImageDigest,
 			"exit_code", ex.ExitCode,

--- a/internal/gateway/git.go
+++ b/internal/gateway/git.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"bytes"
 	"compress/gzip"
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -99,7 +100,7 @@ func (h *gitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			attribute.String(observability.AttrReasonCode, reasonHostNotAllowed),
 		)
 		span.SetStatus(codes.Error, "upstream host is not allowed by sandbox policy")
-		h.auditLog(scope.SandboxID, upstreamHost, repoPath, gatewayActionDeny, reasonHostNotAllowed)
+		h.auditLog(r.Context(), scope.SandboxID, upstreamHost, repoPath, gatewayActionDeny, reasonHostNotAllowed)
 		writeReasonError(w, http.StatusForbidden, reasonHostNotAllowed, "upstream host is not allowed by sandbox policy")
 		return
 	}
@@ -113,7 +114,7 @@ func (h *gitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			attribute.String(observability.AttrReasonCode, reasonMethodNotAllowed),
 		)
 		span.SetStatus(codes.Error, err.Error())
-		h.auditLog(scope.SandboxID, upstreamHost, repoPath, gatewayActionDeny, reasonMethodNotAllowed)
+		h.auditLog(r.Context(), scope.SandboxID, upstreamHost, repoPath, gatewayActionDeny, reasonMethodNotAllowed)
 		writeReasonError(w, http.StatusForbidden, reasonMethodNotAllowed, err.Error())
 		return
 	}
@@ -136,7 +137,7 @@ func (h *gitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				attribute.String(observability.AttrReasonCode, reasonUpstreamError),
 			)
 			span.SetStatus(codes.Error, err.Error())
-			h.auditLog(scope.SandboxID, upstreamHost, repoPath, gatewayActionDeny, reasonUpstreamError)
+			h.auditLog(r.Context(), scope.SandboxID, upstreamHost, repoPath, gatewayActionDeny, reasonUpstreamError)
 			writeReasonError(w, http.StatusBadGateway, reasonUpstreamError, err.Error())
 			return
 		}
@@ -145,7 +146,7 @@ func (h *gitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			attribute.String(observability.AttrGatewayAction, gatewayActionAllow),
 			attribute.String(observability.AttrReasonCode, reasonMirrored),
 		)
-		h.auditLog(scope.SandboxID, upstreamHost, repoPath, gatewayActionAllow, reasonMirrored)
+		h.auditLog(r.Context(), scope.SandboxID, upstreamHost, repoPath, gatewayActionAllow, reasonMirrored)
 		return
 	}
 
@@ -181,7 +182,7 @@ func (h *gitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		attribute.String(observability.AttrReasonCode, reasonProxied),
 	)
 	setGatewayRequestDecision(r.Context(), gatewayActionAllow, reasonProxied)
-	h.auditLog(scope.SandboxID, upstreamHost, repoPath, gatewayActionAllow, reasonProxied)
+	h.auditLog(r.Context(), scope.SandboxID, upstreamHost, repoPath, gatewayActionAllow, reasonProxied)
 
 	resp, err := h.client.Do(upstreamReq)
 	if err != nil {
@@ -423,17 +424,18 @@ func (h *gitHandler) classifyRequest(method, repoPath, query string) (string, er
 	}
 }
 
-func (h *gitHandler) auditLog(sandboxID, upstreamHost, repoPath, action, reason string) {
-	if h.logger == nil {
+func (h *gitHandler) auditLog(ctx context.Context, sandboxID, upstreamHost, repoPath, action, reason string) {
+	logger := observability.WithTraceContext(h.logger, ctx)
+	if logger == nil {
 		return
 	}
-	h.logger.Info("gateway git request",
-		"sandbox_id", sandboxID,
+	logger.Info("gateway git request",
+		observability.LogFieldSandboxID, sandboxID,
 		"service", "git",
 		"upstream_host", upstreamHost,
 		"repo_path", repoPath,
 		"action", action,
-		"reason_code", reason,
+		observability.LogFieldReasonCode, reason,
 	)
 }
 

--- a/internal/gateway/git_cached.go
+++ b/internal/gateway/git_cached.go
@@ -1,11 +1,13 @@
 package gateway
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
 	"strings"
 
+	"github.com/buildkite/cleanroom/internal/observability"
 	"github.com/charmbracelet/log"
 )
 
@@ -50,14 +52,14 @@ func (h *cachedGitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !scope.Policy.Allows(upstreamHost, 443) {
-		h.auditLog(scope.SandboxID, upstreamHost, repoPath, gatewayActionDeny, reasonHostNotAllowed)
+		h.auditLog(r.Context(), scope.SandboxID, upstreamHost, repoPath, gatewayActionDeny, reasonHostNotAllowed)
 		writeReasonError(w, http.StatusForbidden, reasonHostNotAllowed, "upstream host is not allowed by sandbox policy")
 		return
 	}
 
 	// Classify the request to reject pushes before hitting the cache layer.
 	if _, err := classifyGitRequest(r.Method, repoPath, r.URL.RawQuery); err != nil {
-		h.auditLog(scope.SandboxID, upstreamHost, repoPath, gatewayActionDeny, reasonMethodNotAllowed)
+		h.auditLog(r.Context(), scope.SandboxID, upstreamHost, repoPath, gatewayActionDeny, reasonMethodNotAllowed)
 		writeReasonError(w, http.StatusForbidden, reasonMethodNotAllowed, err.Error())
 		return
 	}
@@ -66,19 +68,19 @@ func (h *cachedGitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		if errors.Is(err, errGitHostNotConfiguredForCaching) {
 			if h.fallback == nil {
-				h.auditLog(scope.SandboxID, upstreamHost, repoPath, gatewayActionDeny, reasonUpstreamError)
+				h.auditLog(r.Context(), scope.SandboxID, upstreamHost, repoPath, gatewayActionDeny, reasonUpstreamError)
 				writeReasonError(w, http.StatusBadGateway, reasonUpstreamError, fmt.Sprintf("git cache fallback is not configured for %s", upstreamHost))
 				return
 			}
-			h.auditLog(scope.SandboxID, upstreamHost, repoPath, gatewayActionAllow, reasonFallback)
+			h.auditLog(r.Context(), scope.SandboxID, upstreamHost, repoPath, gatewayActionAllow, reasonFallback)
 			h.fallback.ServeHTTP(w, r)
 			return
 		}
-		h.auditLog(scope.SandboxID, upstreamHost, repoPath, gatewayActionDeny, reasonUpstreamError)
+		h.auditLog(r.Context(), scope.SandboxID, upstreamHost, repoPath, gatewayActionDeny, reasonUpstreamError)
 		writeReasonError(w, http.StatusBadGateway, reasonUpstreamError, fmt.Sprintf("git cache handler unavailable for %s: %v", upstreamHost, err))
 		return
 	}
-	h.auditLog(scope.SandboxID, upstreamHost, repoPath, gatewayActionAllow, reasonCached)
+	h.auditLog(r.Context(), scope.SandboxID, upstreamHost, repoPath, gatewayActionAllow, reasonCached)
 
 	// content-cache's git handler expects paths like /{host}/{repo}.git/...
 	// Strip the /git/ prefix so the cache handler sees the host-rooted path.
@@ -88,17 +90,18 @@ func (h *cachedGitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	cacheHandler.ServeHTTP(w, r)
 }
 
-func (h *cachedGitHandler) auditLog(sandboxID, upstreamHost, repoPath, action, reason string) {
-	if h.logger == nil {
+func (h *cachedGitHandler) auditLog(ctx context.Context, sandboxID, upstreamHost, repoPath, action, reason string) {
+	logger := observability.WithTraceContext(h.logger, ctx)
+	if logger == nil {
 		return
 	}
-	h.logger.Info("gateway git request",
-		"sandbox_id", sandboxID,
+	logger.Info("gateway git request",
+		observability.LogFieldSandboxID, sandboxID,
 		"service", "git",
 		"upstream_host", upstreamHost,
 		"repo_path", repoPath,
 		"action", action,
-		"reason_code", reason,
+		observability.LogFieldReasonCode, reason,
 	)
 }
 

--- a/internal/gateway/git_test.go
+++ b/internal/gateway/git_test.go
@@ -1,7 +1,9 @@
 package gateway
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -12,7 +14,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/buildkite/cleanroom/internal/observability"
 	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/charmbracelet/log"
 	"go.opentelemetry.io/otel/attribute"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	tracetest "go.opentelemetry.io/otel/sdk/trace/tracetest"
@@ -168,6 +172,54 @@ func TestGitHandlerProxiesUpstream(t *testing.T) {
 	body, _ := io.ReadAll(w.Body)
 	if string(body) != "git-refs-data" {
 		t.Fatalf("unexpected body: %q", string(body))
+	}
+}
+
+func TestGitHandlerAuditLogIncludesTraceCorrelation(t *testing.T) {
+	t.Parallel()
+
+	var logBuf bytes.Buffer
+	logger := log.NewWithOptions(&logBuf, log.Options{Formatter: log.JSONFormatter})
+	recorder := tracetest.NewSpanRecorder()
+	tracerProvider := sdktrace.NewTracerProvider()
+	tracerProvider.RegisterSpanProcessor(recorder)
+	defer func() {
+		_ = tracerProvider.Shutdown(context.Background())
+	}()
+
+	srv := &Server{tracerProvider: tracerProvider}
+	h := newGitHandler(nil, logger)
+	handler := srv.tracingMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h.ServeHTTP(w, r)
+	}))
+
+	req := httptest.NewRequest("GET", "/git/evil.com/org/repo.git/info/refs?service=git-upload-pack", nil)
+	req = withScope(req, gitTestScope())
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", w.Code)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(logBuf.Bytes()), &payload); err != nil {
+		t.Fatalf("expected json gateway log, got error: %v\noutput=%s", err, logBuf.String())
+	}
+	if got, want := payload["action"], gatewayActionDeny; got != want {
+		t.Fatalf("unexpected action: got %#v want %#v", got, want)
+	}
+	if got, want := payload["reason_code"], reasonHostNotAllowed; got != want {
+		t.Fatalf("unexpected reason_code: got %#v want %#v", got, want)
+	}
+	if got, want := payload[observability.LogFieldSandboxID], "sandbox-test"; got != want {
+		t.Fatalf("unexpected sandbox_id: got %#v want %#v", got, want)
+	}
+	if _, ok := payload[observability.LogFieldTraceID]; !ok {
+		t.Fatalf("expected trace_id in log payload: %#v", payload)
+	}
+	if _, ok := payload[observability.LogFieldSpanID]; !ok {
+		t.Fatalf("expected span_id in log payload: %#v", payload)
 	}
 }
 

--- a/internal/gateway/oci_cached.go
+++ b/internal/gateway/oci_cached.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -80,7 +81,7 @@ func (h *cachedRegistryHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 			attribute.String(observability.AttrReasonCode, reasonUnknownRegistryPrefix),
 		)
 		span.SetStatus(codes.Error, err.Error())
-		h.auditLog(scope.SandboxID, normalizedPrefix, gatewayActionDeny, reasonUnknownRegistryPrefix)
+		h.auditLog(r.Context(), scope.SandboxID, normalizedPrefix, gatewayActionDeny, reasonUnknownRegistryPrefix)
 		writeReasonError(w, http.StatusNotFound, reasonUnknownRegistryPrefix, fmt.Sprintf("unknown registry prefix %q", prefix))
 		return
 	}
@@ -95,7 +96,7 @@ func (h *cachedRegistryHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 			attribute.String(observability.AttrReasonCode, reasonHostNotAllowed),
 		)
 		span.SetStatus(codes.Error, "upstream registry host is not allowed by sandbox policy")
-		h.auditLog(scope.SandboxID, policyHost, gatewayActionDeny, reasonHostNotAllowed)
+		h.auditLog(r.Context(), scope.SandboxID, policyHost, gatewayActionDeny, reasonHostNotAllowed)
 		writeReasonError(w, http.StatusForbidden, reasonHostNotAllowed, "upstream registry host is not allowed by sandbox policy")
 		return
 	}
@@ -106,7 +107,7 @@ func (h *cachedRegistryHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		attribute.String(observability.AttrGatewayUpstreamHost, upstreamHost),
 	)
 	setGatewayRequestDecision(r.Context(), gatewayActionAllow, reasonCached)
-	h.auditLog(scope.SandboxID, upstreamHost, gatewayActionAllow, reasonCached)
+	h.auditLog(r.Context(), scope.SandboxID, upstreamHost, gatewayActionAllow, reasonCached)
 
 	cacheHandler, err := h.cache.OCIHandlerForPrefix(normalizedPrefix)
 	if err != nil {
@@ -117,7 +118,7 @@ func (h *cachedRegistryHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 			attribute.String(observability.AttrReasonCode, reasonUnknownRegistryPrefix),
 		)
 		span.SetStatus(codes.Error, err.Error())
-		h.auditLog(scope.SandboxID, normalizedPrefix, gatewayActionDeny, reasonUnknownRegistryPrefix)
+		h.auditLog(r.Context(), scope.SandboxID, normalizedPrefix, gatewayActionDeny, reasonUnknownRegistryPrefix)
 		writeReasonError(w, http.StatusNotFound, reasonUnknownRegistryPrefix, fmt.Sprintf("unknown registry prefix %q", prefix))
 		return
 	}
@@ -137,15 +138,16 @@ func rewriteOCICachePath(prefix, rest string) string {
 	return "/v2/" + prefix + "/" + rest
 }
 
-func (h *cachedRegistryHandler) auditLog(sandboxID, target, action, reason string) {
-	if h.logger == nil {
+func (h *cachedRegistryHandler) auditLog(ctx context.Context, sandboxID, target, action, reason string) {
+	logger := observability.WithTraceContext(h.logger, ctx)
+	if logger == nil {
 		return
 	}
-	h.logger.Info("gateway registry request",
-		"sandbox_id", sandboxID,
+	logger.Info("gateway registry request",
+		observability.LogFieldSandboxID, sandboxID,
 		"service", "registry",
 		"target", target,
 		"action", action,
-		"reason_code", reason,
+		observability.LogFieldReasonCode, reason,
 	)
 }

--- a/internal/gateway/rubygems_cached.go
+++ b/internal/gateway/rubygems_cached.go
@@ -1,9 +1,11 @@
 package gateway
 
 import (
+	"context"
 	"net/http"
 	"strings"
 
+	"github.com/buildkite/cleanroom/internal/observability"
 	"github.com/charmbracelet/log"
 )
 
@@ -38,24 +40,24 @@ func (h *cachedRubyGemsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 
 	policyHost, policyPort, upstreamHost, _, err := h.cache.RubyGemsUpstream()
 	if err != nil {
-		h.auditLog(scope.SandboxID, "rubygems", gatewayActionDeny, reasonRubyGemsUnavailable)
+		h.auditLog(r.Context(), scope.SandboxID, "rubygems", gatewayActionDeny, reasonRubyGemsUnavailable)
 		writeReasonError(w, http.StatusBadGateway, reasonUpstreamError, "rubygems cache is not configured")
 		return
 	}
 	if !scope.Policy.Allows(policyHost, policyPort) {
-		h.auditLog(scope.SandboxID, policyHost, gatewayActionDeny, reasonHostNotAllowed)
+		h.auditLog(r.Context(), scope.SandboxID, policyHost, gatewayActionDeny, reasonHostNotAllowed)
 		writeReasonError(w, http.StatusForbidden, reasonHostNotAllowed, "upstream rubygems host is not allowed by sandbox policy")
 		return
 	}
 
 	handler, err := h.cache.RubyGemsHandler()
 	if err != nil {
-		h.auditLog(scope.SandboxID, "rubygems", gatewayActionDeny, reasonRubyGemsUnavailable)
+		h.auditLog(r.Context(), scope.SandboxID, "rubygems", gatewayActionDeny, reasonRubyGemsUnavailable)
 		writeReasonError(w, http.StatusBadGateway, reasonUpstreamError, "rubygems cache is not configured")
 		return
 	}
 
-	h.auditLog(scope.SandboxID, upstreamHost, gatewayActionAllow, reasonCached)
+	h.auditLog(r.Context(), scope.SandboxID, upstreamHost, gatewayActionAllow, reasonCached)
 
 	r = r.Clone(r.Context())
 	r.URL.Path = strings.TrimPrefix(r.URL.Path, "/rubygems")
@@ -66,15 +68,16 @@ func (h *cachedRubyGemsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	handler.ServeHTTP(w, r)
 }
 
-func (h *cachedRubyGemsHandler) auditLog(sandboxID, target, action, reason string) {
-	if h.logger == nil {
+func (h *cachedRubyGemsHandler) auditLog(ctx context.Context, sandboxID, target, action, reason string) {
+	logger := observability.WithTraceContext(h.logger, ctx)
+	if logger == nil {
 		return
 	}
-	h.logger.Info("gateway rubygems request",
-		"sandbox_id", sandboxID,
+	logger.Info("gateway rubygems request",
+		observability.LogFieldSandboxID, sandboxID,
 		"service", "rubygems",
 		"target", target,
 		"action", action,
-		"reason_code", reason,
+		observability.LogFieldReasonCode, reason,
 	)
 }

--- a/internal/observability/contract.go
+++ b/internal/observability/contract.go
@@ -59,6 +59,15 @@ const (
 	AttrVMLaunched            = "cleanroom.vm.launched"
 	AttrExitCode              = "cleanroom.exit_code"
 
+	LogFieldTraceID     = "trace_id"
+	LogFieldSpanID      = "span_id"
+	LogFieldExecutionID = "execution_id"
+	LogFieldSandboxID   = "sandbox_id"
+	LogFieldBackend     = "backend"
+	LogFieldReasonCode  = "reason_code"
+	LogFieldComponent   = "component"
+	LogFieldSubsystem   = "subsystem"
+
 	OutcomeSucceeded = "succeeded"
 	OutcomeFailed    = "failed"
 	OutcomeCanceled  = "canceled"

--- a/internal/observability/logging.go
+++ b/internal/observability/logging.go
@@ -1,0 +1,73 @@
+package observability
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/buildkite/cleanroom/internal/runtimeconfig"
+	"github.com/charmbracelet/log"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func NewLogger(w io.Writer, level string, cfg runtimeconfig.ObservabilityConfig, fields ...any) (*log.Logger, error) {
+	formatter, err := resolveFormatter(cfg)
+	if err != nil {
+		return nil, err
+	}
+	parsedLevel, err := log.ParseLevel(strings.TrimSpace(level))
+	if err != nil {
+		return nil, err
+	}
+	logger := log.NewWithOptions(w, log.Options{
+		Level:     parsedLevel,
+		Formatter: formatter,
+	})
+	if len(fields) == 0 {
+		return logger, nil
+	}
+	return logger.With(fields...), nil
+}
+
+func WithLoggerFields(logger *log.Logger, keyvals ...any) *log.Logger {
+	if logger == nil {
+		return nil
+	}
+	if len(keyvals) == 0 {
+		return logger
+	}
+	return logger.With(keyvals...)
+}
+
+func WithTraceContext(logger *log.Logger, ctx context.Context) *log.Logger {
+	if logger == nil {
+		return nil
+	}
+	if ctx == nil {
+		return logger
+	}
+	spanContext := trace.SpanContextFromContext(ctx)
+	if !spanContext.IsValid() {
+		return logger
+	}
+	return logger.With(
+		LogFieldTraceID, spanContext.TraceID().String(),
+		LogFieldSpanID, spanContext.SpanID().String(),
+	)
+}
+
+func resolveFormatter(cfg runtimeconfig.ObservabilityConfig) (log.Formatter, error) {
+	format, err := runtimeconfig.ResolveObservabilityLogFormat(cfg)
+	if err != nil {
+		return log.TextFormatter, err
+	}
+	switch format {
+	case "json":
+		return log.JSONFormatter, nil
+	case "text":
+		return log.TextFormatter, nil
+	default:
+		return log.TextFormatter, fmt.Errorf("unsupported log format %q", format)
+	}
+}

--- a/internal/observability/logging_test.go
+++ b/internal/observability/logging_test.go
@@ -1,0 +1,69 @@
+package observability
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/runtimeconfig"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+func TestNewLoggerUsesConfiguredJSONFormat(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger, err := NewLogger(&buf, "info", runtimeconfig.ObservabilityConfig{
+		Logs: runtimeconfig.LogConfig{Format: "json"},
+	}, LogFieldComponent, "server")
+	if err != nil {
+		t.Fatalf("NewLogger returned error: %v", err)
+	}
+
+	logger.Info("hello", LogFieldSubsystem, "gateway")
+
+	var payload map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &payload); err != nil {
+		t.Fatalf("expected json log output, got error: %v\noutput=%s", err, buf.String())
+	}
+	if got, want := payload[LogFieldComponent], "server"; got != want {
+		t.Fatalf("unexpected component: got %#v want %#v", got, want)
+	}
+	if got, want := payload[LogFieldSubsystem], "gateway"; got != want {
+		t.Fatalf("unexpected subsystem: got %#v want %#v", got, want)
+	}
+}
+
+func TestWithTraceContextAddsTraceCorrelationFields(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger, err := NewLogger(&buf, "info", runtimeconfig.ObservabilityConfig{
+		Logs: runtimeconfig.LogConfig{Format: "json"},
+	})
+	if err != nil {
+		t.Fatalf("NewLogger returned error: %v", err)
+	}
+
+	provider := sdktrace.NewTracerProvider()
+	t.Cleanup(func() {
+		_ = provider.Shutdown(context.Background())
+	})
+
+	ctx, span := provider.Tracer("test").Start(context.Background(), "span")
+	defer span.End()
+
+	WithTraceContext(logger, ctx).Info("hello")
+
+	var payload map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &payload); err != nil {
+		t.Fatalf("expected json log output, got error: %v\noutput=%s", err, buf.String())
+	}
+	if got, want := payload[LogFieldTraceID], span.SpanContext().TraceID().String(); got != want {
+		t.Fatalf("unexpected trace_id: got %#v want %#v", got, want)
+	}
+	if got, want := payload[LogFieldSpanID], span.SpanContext().SpanID().String(); got != want {
+		t.Fatalf("unexpected span_id: got %#v want %#v", got, want)
+	}
+}

--- a/internal/runtimeconfig/config.go
+++ b/internal/runtimeconfig/config.go
@@ -38,8 +38,13 @@ type GatewayGitConfig struct {
 type ObservabilityConfig struct {
 	Enabled               bool        `yaml:"enabled,omitempty"`
 	DeploymentEnvironment string      `yaml:"deployment_environment,omitempty"`
+	Logs                  LogConfig   `yaml:"logs,omitempty"`
 	OTLP                  OTLPConfig  `yaml:"otlp,omitempty"`
 	Traces                TraceConfig `yaml:"traces,omitempty"`
+}
+
+type LogConfig struct {
+	Format string `yaml:"format,omitempty"`
 }
 
 type OTLPConfig struct {
@@ -441,6 +446,10 @@ func normalizeConfig(cfg Config, inferredDefaultBackend string) Config {
 	cfg.ControlHost = strings.TrimSpace(cfg.ControlHost)
 	cfg.Gateway.Git.CacheHosts = trimStringSlice(cfg.Gateway.Git.CacheHosts)
 	cfg.Observability.DeploymentEnvironment = strings.TrimSpace(cfg.Observability.DeploymentEnvironment)
+	cfg.Observability.Logs.Format = strings.ToLower(strings.TrimSpace(cfg.Observability.Logs.Format))
+	if cfg.Observability.Logs.Format == "" {
+		cfg.Observability.Logs.Format = "text"
+	}
 	cfg.Observability.OTLP.Endpoint = strings.TrimSpace(cfg.Observability.OTLP.Endpoint)
 	cfg.Observability.OTLP.Protocol = strings.TrimSpace(cfg.Observability.OTLP.Protocol)
 	cfg.Observability.OTLP.Headers = trimStringMap(cfg.Observability.OTLP.Headers)
@@ -481,6 +490,9 @@ func validateConfig(cfg Config) error {
 }
 
 func validateObservabilityConfig(cfg ObservabilityConfig) error {
+	if _, err := ResolveObservabilityLogFormat(cfg); err != nil {
+		return err
+	}
 	if !cfg.Enabled {
 		return nil
 	}
@@ -503,6 +515,17 @@ func validateObservabilityConfig(cfg ObservabilityConfig) error {
 		return err
 	}
 	return nil
+}
+
+func ResolveObservabilityLogFormat(cfg ObservabilityConfig) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(cfg.Logs.Format)) {
+	case "", "text":
+		return "text", nil
+	case "json":
+		return "json", nil
+	default:
+		return "", fmt.Errorf("unsupported observability.logs.format %q", cfg.Logs.Format)
+	}
 }
 
 func validateTraceExporter(exporter string) error {

--- a/internal/runtimeconfig/config_test.go
+++ b/internal/runtimeconfig/config_test.go
@@ -285,6 +285,8 @@ func TestLoadTrimsObservabilityConfig(t *testing.T) {
 	content := `observability:
   enabled: true
   deployment_environment: " ci "
+  logs:
+    format: " JSON "
   otlp:
     endpoint: " https://otel.example.test:4318 "
     protocol: " http/protobuf "
@@ -309,6 +311,9 @@ func TestLoadTrimsObservabilityConfig(t *testing.T) {
 	}
 	if got, want := cfg.Observability.DeploymentEnvironment, "ci"; got != want {
 		t.Fatalf("unexpected deployment environment: got %q want %q", got, want)
+	}
+	if got, want := cfg.Observability.Logs.Format, "json"; got != want {
+		t.Fatalf("unexpected log format: got %q want %q", got, want)
 	}
 	if got, want := cfg.Observability.OTLP.Endpoint, "https://otel.example.test:4318"; got != want {
 		t.Fatalf("unexpected otlp endpoint: got %q want %q", got, want)
@@ -368,6 +373,55 @@ func TestLoadSupportsOTLPObservabilityConfig(t *testing.T) {
 	}
 	if got, want := cfg.Observability.OTLP.Headers["x-otlp-token"], "secret"; got != want {
 		t.Fatalf("unexpected otlp header: got %q want %q", got, want)
+	}
+}
+
+func TestLoadDefaultsObservabilityLogFormatToText(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	configPath := filepath.Join(tmp, "cleanroom", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+
+	content := `observability:
+  logs: {}
+`
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, _, err := Load()
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if got, want := cfg.Observability.Logs.Format, "text"; got != want {
+		t.Fatalf("unexpected log format: got %q want %q", got, want)
+	}
+}
+
+func TestLoadRejectsUnsupportedObservabilityLogFormat(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	configPath := filepath.Join(tmp, "cleanroom", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+
+	content := `observability:
+  logs:
+    format: logfmt
+`
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, _, err := Load()
+	if err == nil {
+		t.Fatal("expected Load to reject unsupported log format")
+	}
+	if !strings.Contains(err.Error(), "observability.logs.format") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add backend-neutral `observability.logs.format` runtime config with normalisation, defaulting, and validation
- add a shared observability logger builder plus trace-correlation helper and wire it through `cleanroom serve`, control service, and gateway
- convert Firecracker runtime logging off stdlib `log.Printf` while preserving existing human-facing CLI output boundaries

## Testing
- go test ./internal/runtimeconfig ./internal/observability ./internal/cli ./internal/gateway ./internal/controlservice ./internal/backend/firecracker
- go test ./...
