### PR TITLE
fix: Remove sandbox ready output

### DIFF
--- a/internal/cli/progress.go
+++ b/internal/cli/progress.go
@@ -87,6 +87,9 @@ func (p *sandboxProgress) complete(success bool, elapsed time.Duration) {
 	if (!p.shown && !p.suppressed) || p.stderr == nil {
 		return
 	}
+	if success && p.suppressed {
+		return
+	}
 	if p.useANSI {
 		writeSandboxProgressComplete(p.stderr, success, elapsed)
 		return

--- a/internal/cli/progress.go
+++ b/internal/cli/progress.go
@@ -165,22 +165,21 @@ func writeSandboxProgressComplete(stderr *os.File, success bool, elapsed time.Du
 	if stderr == nil {
 		return
 	}
-	message := "Sandbox ready"
-	if !success {
-		message = "Sandbox creation failed"
+	if success {
+		_, _ = fmt.Fprint(stderr, "\r\033[2K")
+		return
 	}
-	_, _ = fmt.Fprintf(stderr, "\r\033[2K%s in %s\n", message, formatSandboxProgressDuration(elapsed))
+	_, _ = fmt.Fprintf(stderr, "\r\033[2KSandbox creation failed in %s\n", formatSandboxProgressDuration(elapsed))
 }
 
 func writeSandboxProgressCompletePlain(stderr *os.File, success bool, elapsed time.Duration) {
 	if stderr == nil {
 		return
 	}
-	message := "Sandbox ready"
-	if !success {
-		message = "Sandbox creation failed"
+	if success {
+		return
 	}
-	_, _ = fmt.Fprintf(stderr, "%s in %s\n", message, formatSandboxProgressDuration(elapsed))
+	_, _ = fmt.Fprintf(stderr, "Sandbox creation failed in %s\n", formatSandboxProgressDuration(elapsed))
 }
 
 func formatSandboxProgressDuration(elapsed time.Duration) string {

--- a/internal/cli/progress_test.go
+++ b/internal/cli/progress_test.go
@@ -153,6 +153,33 @@ func TestWithSandboxProgressSuccessClearsSpinnerWithoutCompletionMessage(t *test
 	}
 }
 
+func TestWithSandboxProgressSuppressAfterSpinnerKeepsStreamedOutput(t *testing.T) {
+	forceSandboxProgressTTY(t)
+	t.Setenv("CLICOLOR_FORCE", "1")
+
+	output, err := captureSandboxProgressOutput(t, func(stderr *os.File) error {
+		return withSandboxProgress(stderr, func(progress *sandboxProgress) error {
+			time.Sleep(20 * time.Millisecond)
+			progress.suppress()
+			if _, err := stderr.WriteString("stream fragment"); err != nil {
+				return err
+			}
+			time.Sleep(10 * time.Millisecond)
+			return nil
+		})
+	})
+	if err != nil {
+		t.Fatalf("withSandboxProgress returned error: %v", err)
+	}
+	idx := strings.Index(output, "stream fragment")
+	if idx == -1 {
+		t.Fatalf("expected streamed output, got %q", output)
+	}
+	if strings.Contains(output[idx:], "\r\x1b[2K") {
+		t.Fatalf("did not expect line clearing after streamed output, got %q", output)
+	}
+}
+
 func TestWriteSandboxProgressFrameClearsTheLine(t *testing.T) {
 	tmpDir := t.TempDir()
 	stderrPath := filepath.Join(tmpDir, "stderr.log")

--- a/internal/cli/progress_test.go
+++ b/internal/cli/progress_test.go
@@ -88,8 +88,8 @@ func TestWithSandboxProgressNoColorAvoidsANSIControlSequences(t *testing.T) {
 	if !strings.Contains(output, "Preparing sandbox (first use may take a bit)...") {
 		t.Fatalf("expected plain progress start output, got %q", output)
 	}
-	if !strings.Contains(output, "Sandbox ready in") {
-		t.Fatalf("expected plain progress completion output, got %q", output)
+	if strings.Contains(output, "Sandbox ready in") {
+		t.Fatalf("did not expect success progress completion output, got %q", output)
 	}
 	if strings.Contains(output, "\x1b[") {
 		t.Fatalf("did not expect ANSI escapes in no-color mode, got %q", output)
@@ -127,8 +127,29 @@ func TestWithSandboxProgressSuppressStopsFramesBeforeStreamingOutput(t *testing.
 	if strings.Contains(output[idx:], "Preparing sandbox") {
 		t.Fatalf("did not expect spinner frames after streamed output starts, got %q", output)
 	}
-	if !strings.Contains(output, "Sandbox ready in") {
-		t.Fatalf("expected completion message, got %q", output)
+	if strings.Contains(output, "Sandbox ready in") {
+		t.Fatalf("did not expect success completion message, got %q", output)
+	}
+}
+
+func TestWithSandboxProgressSuccessClearsSpinnerWithoutCompletionMessage(t *testing.T) {
+	forceSandboxProgressTTY(t)
+	t.Setenv("CLICOLOR_FORCE", "1")
+
+	output, err := captureSandboxProgressOutput(t, func(stderr *os.File) error {
+		return withSandboxProgress(stderr, func(_ *sandboxProgress) error {
+			time.Sleep(25 * time.Millisecond)
+			return nil
+		})
+	})
+	if err != nil {
+		t.Fatalf("withSandboxProgress returned error: %v", err)
+	}
+	if strings.Contains(output, "Sandbox ready in") {
+		t.Fatalf("did not expect success completion output, got %q", output)
+	}
+	if !strings.Contains(output, "\r\x1b[2K") {
+		t.Fatalf("expected spinner line clearing output, got %q", output)
 	}
 }
 

--- a/internal/cli/repository_test.go
+++ b/internal/cli/repository_test.go
@@ -212,7 +212,6 @@ func TestCreateCommandShowsDependencyBootstrapOutputDuringSandboxCreate(t *testi
 	assertContainsAll(t, outcome.stderr,
 		"repo bootstrap output",
 		"dependency bootstrap output",
-		"Sandbox ready in",
 	)
 	if strings.Contains(outcome.stderr, "bootstrapping repository checkout") {
 		t.Fatalf("expected repository bootstrap phase chatter to be hidden, got %q", outcome.stderr)

--- a/internal/cli/sandbox_progress_integration_test.go
+++ b/internal/cli/sandbox_progress_integration_test.go
@@ -91,8 +91,8 @@ func TestSandboxCreateIntegrationShowsProgressWhileProvisioning(t *testing.T) {
 	if strings.Contains(outcome.stderr, "component=client") {
 		t.Fatalf("expected structured client logs to be hidden, got %q", outcome.stderr)
 	}
-	if !strings.Contains(outcome.stderr, "Sandbox ready in") {
-		t.Fatalf("expected completion message in stderr, got %q", outcome.stderr)
+	if strings.Contains(outcome.stderr, "Sandbox ready in") {
+		t.Fatalf("did not expect success completion message in stderr, got %q", outcome.stderr)
 	}
 }
 
@@ -135,7 +135,7 @@ func TestExecIntegrationShowsProgressWhenCreatingSandbox(t *testing.T) {
 	if strings.Contains(outcome.stderr, "component=client") {
 		t.Fatalf("expected structured client logs to be hidden, got %q", outcome.stderr)
 	}
-	if !strings.Contains(outcome.stderr, "Sandbox ready in") {
-		t.Fatalf("expected completion message in stderr, got %q", outcome.stderr)
+	if strings.Contains(outcome.stderr, "Sandbox ready in") {
+		t.Fatalf("did not expect success completion message in stderr, got %q", outcome.stderr)
 	}
 }


### PR DESCRIPTION
## Summary
- stop printing `Sandbox ready in ...` after successful sandbox creation
- keep failure completion output when sandbox creation fails
- update progress and integration tests to assert silent success completion

## Why
Sandbox progress currently emits a success completion line even when the command output follows immediately, which adds extra noise to `cleanroom exec` output.

## Impact
Sandbox creation still shows progress while provisioning, but successful runs no longer print an extra completion line. Failure cases still report sandbox creation timing.

## Validation
- `mise exec -- go test ./internal/cli -run 'TestWithSandboxProgress|TestSandboxCreateIntegrationShowsProgressWhileProvisioning|TestExecIntegrationShowsProgressWhenCreatingSandbox|TestCreateCommandBootstrapsRepository'`