### PR TITLE
Route observability export errors through CLI warnings

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/alecthomas/kong"
@@ -169,6 +170,7 @@ func Run(args []string, version string) (runErr error) {
 				Config:         cfg.Observability,
 				ServiceName:    runtimeServiceName(ctx),
 				ServiceVersion: version,
+				ReportError:    newObservabilityErrorReporter(runtimeCtx.stderr()),
 			})
 			if err != nil {
 				return fmt.Errorf("configure observability: %w", err)
@@ -260,7 +262,19 @@ func reportObservabilityShutdown(runErr *error, stderr io.Writer, shutdownErr er
 	}
 
 	if stderr != nil {
-		_, _ = fmt.Fprintf(stderr, "warning: %v\n", wrapped)
+		_ = writeExecutionWarning(stderr, wrapped.Error())
+	}
+}
+
+func newObservabilityErrorReporter(stderr io.Writer) func(error) {
+	var mu sync.Mutex
+	return func(err error) {
+		if err == nil || stderr == nil {
+			return
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		_ = writeExecutionWarning(stderr, err.Error())
 	}
 }
 

--- a/internal/cli/cli_parse_test.go
+++ b/internal/cli/cli_parse_test.go
@@ -558,6 +558,19 @@ func TestReportObservabilityShutdownWarnsWithoutFailingSuccessfulRun(t *testing.
 	}
 }
 
+func TestNewObservabilityErrorReporterWarnsToStderr(t *testing.T) {
+	t.Parallel()
+
+	var stderr bytes.Buffer
+	report := newObservabilityErrorReporter(&stderr)
+
+	report(errors.New("collector unavailable"))
+
+	if got := stderr.String(); !strings.Contains(got, "warning: collector unavailable") {
+		t.Fatalf("expected observability warning in stderr, got %q", got)
+	}
+}
+
 func TestReportObservabilityShutdownAppendsToExistingRunError(t *testing.T) {
 	t.Parallel()
 

--- a/internal/observability/observability.go
+++ b/internal/observability/observability.go
@@ -6,10 +6,13 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"sync"
+	"sync/atomic"
 
 	"connectrpc.com/connect"
 	"connectrpc.com/otelconnect"
 	"github.com/buildkite/cleanroom/internal/runtimeconfig"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
@@ -33,6 +36,7 @@ type Options struct {
 	Config         runtimeconfig.ObservabilityConfig
 	ServiceName    string
 	ServiceVersion string
+	ReportError    func(error)
 }
 
 type Runtime struct {
@@ -61,11 +65,16 @@ func NewWithProviders(tracerProvider trace.TracerProvider, meterProvider metric.
 func Start(ctx context.Context, opts Options) (*Runtime, error) {
 	tracerProvider := trace.TracerProvider(tracenoop.NewTracerProvider())
 	meterProvider := metric.MeterProvider(metricnoop.NewMeterProvider())
-	shutdown := func(context.Context) error { return nil }
+	errorReporter, restoreErrorHandler := installErrorHandler(opts.ReportError)
+	shutdown := func(context.Context) error {
+		restoreErrorHandler()
+		return nil
+	}
 
 	if opts.Config.Enabled {
 		provider, err := newTracerProvider(ctx, opts)
 		if err != nil {
+			restoreErrorHandler()
 			return nil, err
 		}
 		metricsProvider, err := newMeterProvider(ctx, opts)
@@ -73,18 +82,63 @@ func Start(ctx context.Context, opts Options) (*Runtime, error) {
 			shutdownCtx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			_ = provider.Shutdown(shutdownCtx)
+			restoreErrorHandler()
 			return nil, err
 		}
 		tracerProvider = provider
 		meterProvider = metricsProvider
 		shutdown = func(shutdownCtx context.Context) error {
+			if errorReporter != nil {
+				errorReporter.suppress()
+			}
+			defer restoreErrorHandler()
 			metricErr := metricsProvider.Shutdown(shutdownCtx)
 			traceErr := provider.Shutdown(shutdownCtx)
 			return errors.Join(traceErr, metricErr)
 		}
 	}
 
-	return newRuntime(tracerProvider, meterProvider, shutdown)
+	runtime, err := newRuntime(tracerProvider, meterProvider, shutdown)
+	if err != nil {
+		restoreErrorHandler()
+		return nil, err
+	}
+	return runtime, nil
+}
+
+type runtimeErrorReporter struct {
+	mu      sync.Mutex
+	report  func(error)
+	ignored atomic.Bool
+}
+
+func (r *runtimeErrorReporter) Handle(err error) {
+	if r == nil || err == nil || r.ignored.Load() {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.ignored.Load() {
+		return
+	}
+	r.report(err)
+}
+
+func (r *runtimeErrorReporter) suppress() {
+	if r == nil {
+		return
+	}
+	r.ignored.Store(true)
+}
+
+func installErrorHandler(report func(error)) (*runtimeErrorReporter, func()) {
+	if report == nil {
+		return nil, func() {}
+	}
+	previous := otel.GetErrorHandler()
+	reporter := &runtimeErrorReporter{report: report}
+	otel.SetErrorHandler(reporter)
+	return reporter, func() { otel.SetErrorHandler(previous) }
 }
 
 func (r *Runtime) Tracer(name string, options ...trace.TracerOption) trace.Tracer {

--- a/internal/observability/observability.go
+++ b/internal/observability/observability.go
@@ -127,6 +127,8 @@ func (r *runtimeErrorReporter) suppress() {
 	if r == nil {
 		return
 	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.ignored.Store(true)
 }
 

--- a/internal/observability/observability.go
+++ b/internal/observability/observability.go
@@ -65,13 +65,12 @@ func NewWithProviders(tracerProvider trace.TracerProvider, meterProvider metric.
 func Start(ctx context.Context, opts Options) (*Runtime, error) {
 	tracerProvider := trace.TracerProvider(tracenoop.NewTracerProvider())
 	meterProvider := metric.MeterProvider(metricnoop.NewMeterProvider())
-	errorReporter, restoreErrorHandler := installErrorHandler(opts.ReportError)
-	shutdown := func(context.Context) error {
-		restoreErrorHandler()
-		return nil
-	}
+	var errorReporter *runtimeErrorReporter
+	restoreErrorHandler := func() {}
+	shutdown := func(context.Context) error { return nil }
 
 	if opts.Config.Enabled {
+		errorReporter, restoreErrorHandler = installErrorHandler(opts.ReportError)
 		provider, err := newTracerProvider(ctx, opts)
 		if err != nil {
 			restoreErrorHandler()

--- a/internal/observability/observability_test.go
+++ b/internal/observability/observability_test.go
@@ -38,6 +38,49 @@ func TestStartDisabledReturnsRuntime(t *testing.T) {
 	}
 }
 
+func TestStartDisabledLeavesExistingOTelErrorHandlerUntouched(t *testing.T) {
+	original := otel.GetErrorHandler()
+	t.Cleanup(func() { otel.SetErrorHandler(original) })
+
+	previousErrCh := make(chan error, 1)
+	otel.SetErrorHandler(otel.ErrorHandlerFunc(func(err error) {
+		previousErrCh <- err
+	}))
+
+	reportedErrCh := make(chan error, 1)
+	runtime, err := Start(context.Background(), Options{
+		ReportError: func(err error) {
+			reportedErrCh <- err
+		},
+	})
+	if err != nil {
+		t.Fatalf("Start returned error: %v", err)
+	}
+
+	otel.Handle(errors.New("disabled observability"))
+
+	select {
+	case err := <-previousErrCh:
+		if got, want := err.Error(), "disabled observability"; got != want {
+			t.Fatalf("unexpected restored handler error: got %q want %q", got, want)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for existing error handler")
+	}
+
+	select {
+	case err := <-reportedErrCh:
+		t.Fatalf("expected disabled observability not to install report handler, got %v", err)
+	default:
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := runtime.Shutdown(shutdownCtx); err != nil {
+		t.Fatalf("Shutdown returned error: %v", err)
+	}
+}
+
 func TestStartRejectsUnsupportedTraceExporterWhenEnabled(t *testing.T) {
 	_, err := Start(context.Background(), Options{
 		Config: runtimeconfig.ObservabilityConfig{

--- a/internal/observability/observability_test.go
+++ b/internal/observability/observability_test.go
@@ -324,6 +324,53 @@ func TestStartSuppressesConfiguredReporterDuringShutdown(t *testing.T) {
 	}
 }
 
+func TestRuntimeErrorReporterSuppressWaitsForInFlightHandle(t *testing.T) {
+	enteredReport := make(chan struct{})
+	releaseReport := make(chan struct{})
+	reporter := &runtimeErrorReporter{report: func(error) {
+		close(enteredReport)
+		<-releaseReport
+	}}
+
+	handleDone := make(chan struct{})
+	go func() {
+		defer close(handleDone)
+		reporter.Handle(errors.New("collector unavailable"))
+	}()
+
+	select {
+	case <-enteredReport:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for in-flight report")
+	}
+
+	suppressDone := make(chan struct{})
+	go func() {
+		reporter.suppress()
+		close(suppressDone)
+	}()
+
+	select {
+	case <-suppressDone:
+		t.Fatal("expected suppress to wait for in-flight report")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(releaseReport)
+
+	select {
+	case <-suppressDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for suppress to finish")
+	}
+
+	select {
+	case <-handleDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for handle to finish")
+	}
+}
+
 func TestStartExportsOTLPHTTPSpanOnShutdown(t *testing.T) {
 	bodyCh := make(chan []byte, 8)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/observability/observability_test.go
+++ b/internal/observability/observability_test.go
@@ -2,6 +2,7 @@ package observability
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 	"time"
 
 	"github.com/buildkite/cleanroom/internal/runtimeconfig"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	colmetricspb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
@@ -153,6 +155,129 @@ func TestNewSamplerPreservesExplicitZeroRatio(t *testing.T) {
 	)
 	if result.Decision != sdktrace.Drop {
 		t.Fatalf("expected explicit zero ratio to drop, got %v", result.Decision)
+	}
+}
+
+func TestStartRoutesOTelErrorsToConfiguredReporter(t *testing.T) {
+	original := otel.GetErrorHandler()
+	t.Cleanup(func() { otel.SetErrorHandler(original) })
+
+	previousErrCh := make(chan error, 1)
+	otel.SetErrorHandler(otel.ErrorHandlerFunc(func(err error) {
+		previousErrCh <- err
+	}))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/x-protobuf")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte{0x0a, 0x00})
+	}))
+	defer server.Close()
+
+	reportedErrCh := make(chan error, 1)
+	runtime, err := Start(context.Background(), Options{
+		Config: runtimeconfig.ObservabilityConfig{
+			Enabled: true,
+			OTLP: runtimeconfig.OTLPConfig{
+				Endpoint: server.URL,
+				Protocol: "http/protobuf",
+			},
+		},
+		ServiceName: "cleanroom-cli",
+		ReportError: func(err error) {
+			reportedErrCh <- err
+		},
+	})
+	if err != nil {
+		t.Fatalf("Start returned error: %v", err)
+	}
+
+	otel.Handle(errors.New("collector unavailable"))
+
+	select {
+	case err := <-reportedErrCh:
+		if got, want := err.Error(), "collector unavailable"; got != want {
+			t.Fatalf("unexpected reported error: got %q want %q", got, want)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for configured error reporter")
+	}
+
+	select {
+	case err := <-previousErrCh:
+		t.Fatalf("expected configured error reporter to replace previous handler, got %v", err)
+	default:
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := runtime.Shutdown(shutdownCtx); err != nil {
+		t.Fatalf("Shutdown returned error: %v", err)
+	}
+
+	otel.Handle(errors.New("after shutdown"))
+
+	select {
+	case err := <-previousErrCh:
+		if got, want := err.Error(), "after shutdown"; got != want {
+			t.Fatalf("unexpected restored handler error: got %q want %q", got, want)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for restored error handler")
+	}
+}
+
+func TestStartSuppressesConfiguredReporterDuringShutdown(t *testing.T) {
+	original := otel.GetErrorHandler()
+	t.Cleanup(func() { otel.SetErrorHandler(original) })
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	endpoint := listener.Addr().String()
+	if err := listener.Close(); err != nil {
+		t.Fatalf("close listener: %v", err)
+	}
+
+	reportedErrCh := make(chan error, 2)
+	runtime, err := Start(context.Background(), Options{
+		Config: runtimeconfig.ObservabilityConfig{
+			Enabled: true,
+			OTLP: runtimeconfig.OTLPConfig{
+				Endpoint: "http://" + endpoint,
+				Protocol: "http/protobuf",
+			},
+		},
+		ServiceName: "cleanroom-cli",
+		ReportError: func(err error) {
+			reportedErrCh <- err
+		},
+	})
+	if err != nil {
+		t.Fatalf("Start returned error: %v", err)
+	}
+
+	counter, err := runtime.Meter("github.com/buildkite/cleanroom/internal/observability_test").Int64Counter("cleanroom.test.shutdown.metric")
+	if err != nil {
+		t.Fatalf("Int64Counter returned error: %v", err)
+	}
+	counter.Add(context.Background(), 1)
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err = runtime.Shutdown(shutdownCtx)
+	if err == nil {
+		t.Fatal("expected Shutdown to return an export error")
+	}
+	if !strings.Contains(err.Error(), "failed to upload metrics") {
+		t.Fatalf("expected shutdown error to mention metric upload failure, got %v", err)
+	}
+
+	select {
+	case err := <-reportedErrCh:
+		t.Fatalf("expected shutdown errors to be returned, not reported asynchronously, got %v", err)
+	default:
 	}
 }
 

--- a/mise.toml
+++ b/mise.toml
@@ -101,6 +101,14 @@ run = "go run ./cmd/cleanroom doctor"
 description = "Run cleanroom diagnostics as JSON"
 run = "go run ./cmd/cleanroom doctor --json"
 
+[tasks."observability:up"]
+description = "Start the local observability stack"
+run = "docker compose -f examples/observability/docker-compose.yaml up -d"
+
+[tasks."observability:down"]
+description = "Stop the local observability stack"
+run = "docker compose -f examples/observability/docker-compose.yaml down -v"
+
 [tasks.check]
 description = "Run build, test, and lint"
 depends = ["build", "test", "lint-shell"]


### PR DESCRIPTION
## Summary
- route OpenTelemetry exporter errors through the Cleanroom CLI warning renderer instead of the default stdlib logger
- suppress duplicate async exporter warnings during shutdown while preserving the existing shutdown warning path
- add `mise run observability:up` and `mise run observability:down` helpers for the local stack

## Testing
- `mise run check`