### PR TITLE
feat: Route Go modules and Go SDK downloads through the gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Agent sandboxing tools are [proliferating fast](docs/research.md). Most focus on
 
 **Self-hosted.** Runs on your infrastructure. Your code and data never leave your machines.
 
-**Credentials stay on the host.** A [host-side gateway](docs/gateway.md) rewrites git traffic through Cleanroom-owned routes and keeps upstream credentials on the host side of the boundary. The same gateway now embeds `content-cache` for cache-backed git, OCI, and RubyGems handling.
+**Credentials stay on the host.** A [host-side gateway](docs/gateway.md) rewrites git traffic through Cleanroom-owned routes and keeps upstream credentials on the host side of the boundary. The same gateway now embeds `content-cache` for cache-backed git, OCI, Go module, RubyGems, and immutable download handling.
 
 **Standard OCI images.** Use any OCI image from any registry as your sandbox base. Digest-pinned in policy for reproducibility. No custom VM image format or vendor-specific base images. Same image works across backends.
 

--- a/cmd/cleanroom-guest-agent/main.go
+++ b/cmd/cleanroom-guest-agent/main.go
@@ -300,6 +300,7 @@ func buildCommandEnv(requestEnv []string) ([]string, error) {
 	// Start from the current process environment so caller-provided values can
 	// override, while ensuring we have baseline HOME/PATH defaults for lookups.
 	base := map[string]string{}
+	requestKeys := make(map[string]struct{}, len(requestEnv))
 	for _, entry := range os.Environ() {
 		parts := strings.SplitN(entry, "=", 2)
 		key := parts[0]
@@ -317,13 +318,14 @@ func buildCommandEnv(requestEnv []string) ([]string, error) {
 		if len(parts) == 2 {
 			value = parts[1]
 		}
+		requestKeys[key] = struct{}{}
 		base[key] = value
 	}
 
 	if err := configureBundlerMirror(base); err != nil {
 		return nil, err
 	}
-	configureGatewayGoEnv(base)
+	configureGatewayGoEnv(base, requestKeys)
 
 	if strings.TrimSpace(base["HOME"]) == "" {
 		base["HOME"] = "/root"
@@ -339,20 +341,20 @@ func buildCommandEnv(requestEnv []string) ([]string, error) {
 	return out, nil
 }
 
-func configureGatewayGoEnv(base map[string]string) {
+func configureGatewayGoEnv(base map[string]string, requestKeys map[string]struct{}) {
 	if base == nil {
 		return
 	}
 
 	if defaultProxy, ok := base[gateway.GoProxyDefaultEnvKey]; ok {
-		if _, exists := base["GOPROXY"]; !exists {
+		if _, explicit := requestKeys["GOPROXY"]; !explicit && strings.TrimSpace(base["GOPROXY"]) == "" {
 			base["GOPROXY"] = defaultProxy
 		}
 		delete(base, gateway.GoProxyDefaultEnvKey)
 	}
 
 	if defaultMirror, ok := base[gateway.MiseGoDownloadMirrorDefaultEnvKey]; ok {
-		if _, exists := base["MISE_GO_DOWNLOAD_MIRROR"]; !exists {
+		if _, explicit := requestKeys["MISE_GO_DOWNLOAD_MIRROR"]; !explicit && strings.TrimSpace(base["MISE_GO_DOWNLOAD_MIRROR"]) == "" {
 			base["MISE_GO_DOWNLOAD_MIRROR"] = defaultMirror
 		}
 		delete(base, gateway.MiseGoDownloadMirrorDefaultEnvKey)

--- a/cmd/cleanroom-guest-agent/main.go
+++ b/cmd/cleanroom-guest-agent/main.go
@@ -323,6 +323,7 @@ func buildCommandEnv(requestEnv []string) ([]string, error) {
 	if err := configureBundlerMirror(base); err != nil {
 		return nil, err
 	}
+	configureGatewayGoEnv(base)
 
 	if strings.TrimSpace(base["HOME"]) == "" {
 		base["HOME"] = "/root"
@@ -336,6 +337,26 @@ func buildCommandEnv(requestEnv []string) ([]string, error) {
 		out = append(out, key+"="+value)
 	}
 	return out, nil
+}
+
+func configureGatewayGoEnv(base map[string]string) {
+	if base == nil {
+		return
+	}
+
+	if defaultProxy, ok := base[gateway.GoProxyDefaultEnvKey]; ok {
+		if _, exists := base["GOPROXY"]; !exists {
+			base["GOPROXY"] = defaultProxy
+		}
+		delete(base, gateway.GoProxyDefaultEnvKey)
+	}
+
+	if defaultMirror, ok := base[gateway.MiseGoDownloadMirrorDefaultEnvKey]; ok {
+		if _, exists := base["MISE_GO_DOWNLOAD_MIRROR"]; !exists {
+			base["MISE_GO_DOWNLOAD_MIRROR"] = defaultMirror
+		}
+		delete(base, gateway.MiseGoDownloadMirrorDefaultEnvKey)
+	}
 }
 
 func configureBundlerMirror(base map[string]string) error {

--- a/cmd/cleanroom-guest-agent/main_test.go
+++ b/cmd/cleanroom-guest-agent/main_test.go
@@ -1,0 +1,79 @@
+//go:build linux
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/gateway"
+)
+
+func TestBuildCommandEnvAppliesGatewayDefaultsWhenUnset(t *testing.T) {
+	t.Setenv("GOPROXY", "")
+	t.Setenv("MISE_GO_DOWNLOAD_MIRROR", "")
+
+	env, err := buildCommandEnv([]string{
+		gateway.GoProxyDefaultEnvKey + "=http://gateway.cleanroom.internal:8170/goproxy,direct",
+		gateway.MiseGoDownloadMirrorDefaultEnvKey + "=http://gateway.cleanroom.internal:8170/fetch/dl.google.com/go",
+	})
+	if err != nil {
+		t.Fatalf("buildCommandEnv returned error: %v", err)
+	}
+
+	got := envMap(env)
+	if got["GOPROXY"] != "http://gateway.cleanroom.internal:8170/goproxy,direct" {
+		t.Fatalf("expected GOPROXY default to be applied, got %q", got["GOPROXY"])
+	}
+	if got["MISE_GO_DOWNLOAD_MIRROR"] != "http://gateway.cleanroom.internal:8170/fetch/dl.google.com/go" {
+		t.Fatalf("expected MISE_GO_DOWNLOAD_MIRROR default to be applied, got %q", got["MISE_GO_DOWNLOAD_MIRROR"])
+	}
+	if _, ok := got[gateway.GoProxyDefaultEnvKey]; ok {
+		t.Fatalf("did not expect %s to remain in child env", gateway.GoProxyDefaultEnvKey)
+	}
+	if _, ok := got[gateway.MiseGoDownloadMirrorDefaultEnvKey]; ok {
+		t.Fatalf("did not expect %s to remain in child env", gateway.MiseGoDownloadMirrorDefaultEnvKey)
+	}
+}
+
+func TestBuildCommandEnvPreservesExplicitUserGoEnv(t *testing.T) {
+	t.Setenv("GOPROXY", "")
+	t.Setenv("MISE_GO_DOWNLOAD_MIRROR", "")
+
+	env, err := buildCommandEnv([]string{
+		"GOPROXY=off",
+		"MISE_GO_DOWNLOAD_MIRROR=https://example.test/go",
+		gateway.GoProxyDefaultEnvKey + "=http://gateway.cleanroom.internal:8170/goproxy,direct",
+		gateway.MiseGoDownloadMirrorDefaultEnvKey + "=http://gateway.cleanroom.internal:8170/fetch/dl.google.com/go",
+	})
+	if err != nil {
+		t.Fatalf("buildCommandEnv returned error: %v", err)
+	}
+
+	got := envMap(env)
+	if got["GOPROXY"] != "off" {
+		t.Fatalf("expected explicit GOPROXY to win, got %q", got["GOPROXY"])
+	}
+	if got["MISE_GO_DOWNLOAD_MIRROR"] != "https://example.test/go" {
+		t.Fatalf("expected explicit MISE_GO_DOWNLOAD_MIRROR to win, got %q", got["MISE_GO_DOWNLOAD_MIRROR"])
+	}
+	if _, ok := got[gateway.GoProxyDefaultEnvKey]; ok {
+		t.Fatalf("did not expect %s to remain in child env", gateway.GoProxyDefaultEnvKey)
+	}
+	if _, ok := got[gateway.MiseGoDownloadMirrorDefaultEnvKey]; ok {
+		t.Fatalf("did not expect %s to remain in child env", gateway.MiseGoDownloadMirrorDefaultEnvKey)
+	}
+}
+
+func envMap(entries []string) map[string]string {
+	out := make(map[string]string, len(entries))
+	for _, entry := range entries {
+		key, value, ok := strings.Cut(entry, "=")
+		if !ok {
+			out[entry] = ""
+			continue
+		}
+		out[key] = value
+	}
+	return out
+}

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -3,9 +3,9 @@
 The Cleanroom server runs a shared host gateway that mediates sandbox access to
 selected external services. The current implementation embeds
 `github.com/buildkite/content-cache` behind the gateway for cache-backed Git
-smart-HTTP and OCI registry routes, while keeping sandbox identity, policy
-enforcement, and credential resolution in Cleanroom's own `internal/gateway`
-layer.
+smart-HTTP, OCI registry, Go module proxy, RubyGems, and immutable download
+routes, while keeping sandbox identity, policy enforcement, and credential
+resolution in Cleanroom's own `internal/gateway` layer.
 
 Currently supported on the `firecracker` and `darwin-vz` backends.
 
@@ -18,7 +18,9 @@ Inside sandboxes, the shared gateway is exposed at
 |------|--------|---------|
 | `/git/` | Implemented | Cache-backed Git smart-HTTP route. `.git` remotes use embedded `content-cache`; non-cacheable paths fall back to Cleanroom's mirror-backed proxy. |
 | `/registry/` | Implemented | Cache-backed OCI Distribution route for allowlisted registries. |
+| `/goproxy/` | Implemented | Cache-backed Go module proxy route. Also serves mirrored checksum database requests under `/goproxy/sumdb/`. |
 | `/rubygems/` | Implemented | Cache-backed RubyGems route for Bundler mirror traffic to `rubygems.org`. |
+| `/fetch/` | Implemented | Cache-backed immutable download route for configured upstream hosts such as `dl.google.com`. |
 | `/secrets/` | Reserved | Not implemented yet. |
 | `/meta/` | Reserved | Not implemented yet. |
 
@@ -86,6 +88,28 @@ Not wired yet:
 - lockfile enforcement
 - non-OCI package-manager protocol handling
 
+## Go module proxy route
+
+`/goproxy/` is backed by `content-cache`'s Go module proxy and mirrored checksum
+database handlers. It serves `GOPROXY` requests for `@v/list`, `.info`, `.mod`,
+and `.zip`, while also answering mirrored checksum-database requests under
+`/goproxy/sumdb/`.
+
+Current scope:
+
+- guest-side `GOPROXY` environment injection when `proxy.golang.org` is
+  allowlisted
+- Go module metadata and zip fetches through the shared host gateway
+- mirrored checksum-database requests when `sum.golang.org` is allowlisted
+- host-side redirect validation for proxy redirects such as
+  `storage.googleapis.com`
+
+Not wired yet:
+
+- lockfile-derived Go module allowlists
+- private module or private checksum-database authentication flows
+- non-default upstream Go proxy or sumdb configuration
+
 ## RubyGems route
 
 `/rubygems/` is backed by `content-cache`'s RubyGems handler. It serves the
@@ -105,6 +129,26 @@ Not wired yet:
 - generic `gem sources` rewrites for arbitrary RubyGems registries
 - lockfile enforcement
 - private RubyGems registry authentication flows
+
+## Immutable fetch route
+
+`/fetch/` is backed by `content-cache`'s immutable download handler. Cleanroom
+uses it for guest-side tool downloads that are expressed as direct HTTPS
+artifacts rather than registry APIs.
+
+Current scope:
+
+- guest-side `MISE_GO_DOWNLOAD_MIRROR` injection when `dl.google.com` is
+  allowlisted
+- cache-backed Go SDK downloads from `dl.google.com/go/...`
+- host-side redirect validation and sandbox allowlist enforcement for configured
+  fetch hosts
+
+Not wired yet:
+
+- broader guest-side tool download rewrites beyond the configured fetch hosts
+- lockfile-aware artifact allowlists
+- authenticated private artifact downloads
 
 ## Credentials
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -109,7 +109,8 @@ The current top-level product spans are:
 - `cleanroom.execution.run`
 - `cleanroom.gateway.<service>.request`
 
-`<service>` is one of `git`, `registry`, `rubygems`, `secrets`, or `meta`.
+`<service>` is one of `git`, `registry`, `goproxy`, `sumdb`, `rubygems`,
+`fetch`, `secrets`, or `meta`.
 
 Sandbox creation may emit additional child spans under the
 `cleanroom.sandbox.*` prefix for cache lookup, restore, bootstrap, and publish

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -359,7 +359,7 @@ All runtime launch behavior is initiated by control-plane API calls (for example
 
 ### 6.2 Host gateway
 
-Cleanroom runs a single shared host gateway process that provides mediated access to external services for sandboxes on the host. The current implementation serves Git, OCI registry, and RubyGems routes today, while keeping secret and metadata routes reserved for follow-up work. Sandbox identity is derived from the network transport layer, not bearer tokens.
+Cleanroom runs a single shared host gateway process that provides mediated access to external services for sandboxes on the host. The current implementation serves Git, OCI registry, Go module proxy, RubyGems, and immutable fetch routes today, while keeping secret and metadata routes reserved for follow-up work. Sandbox identity is derived from the network transport layer, not bearer tokens.
 
 #### 6.2.1 Transport and sandbox identity
 
@@ -367,7 +367,7 @@ The gateway uses TAP-network TCP rather than `AF_VSOCK` for guest-to-host servic
 
 Each sandbox is provisioned with a unique TAP device and a unique guest IP. The host gateway identifies the calling sandbox by mapping the source IP of incoming connections to the registered sandbox and its `CompiledPolicy`.
 
-- The gateway listens on a small fixed set of host ports (or a single port with path-prefix routing for `/git/`, `/registry/`, `/rubygems/`, `/secrets/`, `/meta/`).
+- The gateway listens on a small fixed set of host ports (or a single port with path-prefix routing for `/git/`, `/registry/`, `/goproxy/`, `/rubygems/`, `/fetch/`, `/secrets/`, `/meta/`).
 - Sandbox identity is resolved from the connection source IP. No tokens, API keys, or path-embedded credentials are used for sandbox identification.
 - The gateway maintains a registry of `(guestIP → sandboxID → CompiledPolicy)` populated at sandbox creation and removed at teardown.
 - The guest discovers the gateway via its host-side TAP IP on well-known ports, injected into the command environment (for example `GIT_CONFIG_GLOBAL`, `HTTP_PROXY`, or equivalent per-service environment variables).
@@ -403,11 +403,15 @@ These rules are installed during sandbox network setup and torn down during clea
 - The gateway exposes a `/registry/` route backed by embedded `content-cache` OCI handlers.
 - The gateway resolves a registry prefix from the request path, maps it to an upstream registry URL, and applies the sandbox allowlist against the mapped policy host and port before forwarding upstream.
 - Current route scope is OCI pull-style `GET` and `HEAD` traffic.
+- The gateway exposes a `/goproxy/` route backed by embedded `content-cache` Go module proxy handlers, including mirrored sumdb traffic under `/goproxy/sumdb/`.
+- Current Go module scope includes `GOPROXY` metadata requests, module zip downloads, and mirrored checksum-database requests.
 - The gateway also exposes a `/rubygems/` route backed by embedded `content-cache` RubyGems handlers for Bundler mirror traffic to `rubygems.org`.
 - Current RubyGems scope includes Compact Index metadata, legacy specs metadata, and gem downloads.
+- The gateway exposes a `/fetch/` route backed by embedded `content-cache` immutable artifact handlers for configured hosts such as `dl.google.com`.
 - Unsupported registry requests are denied with explicit audit reason (`registry_not_allowed`) or route-specific validation errors.
 - Future work:
   - guest-side package-manager rewrites through `/registry/`
+  - broader guest-side tool download rewrites beyond the current `/fetch/` slice
   - broader guest-side RubyGems source rewrites beyond the default Bundler mirror path
   - lockfile enforcement
   - broader non-OCI package-manager protocol support

--- a/examples/buildkite-agent/README.md
+++ b/examples/buildkite-agent/README.md
@@ -49,9 +49,9 @@ Go module resolution:
 |---|---|
 | `github.com`, `api.github.com` | Git clone and GitHub API |
 | `release-assets.githubusercontent.com` | mise downloads golangci-lint from GitHub releases |
-| `dl.google.com` | mise downloads the Go SDK |
-| `proxy.golang.org`, `sum.golang.org` | Go module proxy and checksum database |
-| `storage.googleapis.com` | Go proxy redirects module payloads here |
+| `dl.google.com` | upstream host validated by the gateway `/fetch/` route for Go SDK downloads |
+| `proxy.golang.org`, `sum.golang.org` | upstream hosts validated by the gateway `/goproxy/` route and mirrored checksum database |
+| `storage.googleapis.com` | Go proxy redirect target validated by the host-side goproxy client |
 | `mise-versions.jdx.dev`, `mise.jdx.dev` | mise tool metadata resolution |
 
 ## Notes
@@ -61,4 +61,7 @@ Go module resolution:
   and keys that stage on `.mise.toml`, `go.mod`, and `go.sum`, so a successful
   first run can publish a reusable dependency stage for later warm hits on the
   same exact commit and policy
+- Cleanroom now injects `GOPROXY` and `MISE_GO_DOWNLOAD_MIRROR` automatically
+  when the relevant upstream hosts are allowlisted, so `go mod download` and
+  `mise use go@...` warm the shared gateway cache instead of fetching directly
 - `go test -p 1` avoids OOM kills on constrained guest memory

--- a/internal/backend/darwinvz/gateway_env_test.go
+++ b/internal/backend/darwinvz/gateway_env_test.go
@@ -198,3 +198,33 @@ func TestGatewayGitProxyEnvVarsSkipsNonFileHandleModes(t *testing.T) {
 		})
 	}
 }
+
+func TestGatewayEnvVarsAddsGoProxyAndMiseMirror(t *testing.T) {
+	t.Parallel()
+
+	p := &policy.CompiledPolicy{
+		Version:        1,
+		NetworkDefault: "deny",
+		Allow: []policy.AllowRule{
+			{Host: "proxy.golang.org", Ports: []int{443}},
+			{Host: "dl.google.com", Ports: []int{443}},
+		},
+	}
+	env := gatewayEnvVars(p, 8170, "token", gateway.ProxyRoutes{GoProxy: true, Fetch: true})
+	foundGoProxy := false
+	foundMiseMirror := false
+	for _, entry := range env {
+		if entry == "GOPROXY=http://"+gateway.GuestGatewayHostname+":8170/goproxy,direct" {
+			foundGoProxy = true
+		}
+		if entry == "MISE_GO_DOWNLOAD_MIRROR=http://"+gateway.GuestGatewayHostname+":8170/fetch/dl.google.com/go" {
+			foundMiseMirror = true
+		}
+	}
+	if !foundGoProxy {
+		t.Fatalf("expected GOPROXY env in %v", env)
+	}
+	if !foundMiseMirror {
+		t.Fatalf("expected MISE_GO_DOWNLOAD_MIRROR env in %v", env)
+	}
+}

--- a/internal/backend/darwinvz/gateway_env_test.go
+++ b/internal/backend/darwinvz/gateway_env_test.go
@@ -214,17 +214,17 @@ func TestGatewayEnvVarsAddsGoProxyAndMiseMirror(t *testing.T) {
 	foundGoProxy := false
 	foundMiseMirror := false
 	for _, entry := range env {
-		if entry == "GOPROXY=http://"+gateway.GuestGatewayHostname+":8170/goproxy,direct" {
+		if entry == gateway.GoProxyDefaultEnvKey+"=http://"+gateway.GuestGatewayHostname+":8170/goproxy,direct" {
 			foundGoProxy = true
 		}
-		if entry == "MISE_GO_DOWNLOAD_MIRROR=http://"+gateway.GuestGatewayHostname+":8170/fetch/dl.google.com/go" {
+		if entry == gateway.MiseGoDownloadMirrorDefaultEnvKey+"=http://"+gateway.GuestGatewayHostname+":8170/fetch/dl.google.com/go" {
 			foundMiseMirror = true
 		}
 	}
 	if !foundGoProxy {
-		t.Fatalf("expected GOPROXY env in %v", env)
+		t.Fatalf("expected %s env in %v", gateway.GoProxyDefaultEnvKey, env)
 	}
 	if !foundMiseMirror {
-		t.Fatalf("expected MISE_GO_DOWNLOAD_MIRROR env in %v", env)
+		t.Fatalf("expected %s env in %v", gateway.MiseGoDownloadMirrorDefaultEnvKey, env)
 	}
 }

--- a/internal/backend/darwinvz/gateway_env_test.go
+++ b/internal/backend/darwinvz/gateway_env_test.go
@@ -207,6 +207,7 @@ func TestGatewayEnvVarsAddsGoProxyAndMiseMirror(t *testing.T) {
 		NetworkDefault: "deny",
 		Allow: []policy.AllowRule{
 			{Host: "proxy.golang.org", Ports: []int{443}},
+			{Host: "sum.golang.org", Ports: []int{443}},
 			{Host: "dl.google.com", Ports: []int{443}},
 		},
 	}

--- a/internal/backend/firecracker/gateway_test.go
+++ b/internal/backend/firecracker/gateway_test.go
@@ -111,17 +111,17 @@ func TestGatewayEnvVarsAddsGoProxyAndMiseMirror(t *testing.T) {
 	foundGoProxy := false
 	foundMiseMirror := false
 	for _, entry := range env {
-		if entry == "GOPROXY=http://"+gateway.GuestGatewayHostname+":8170/goproxy,direct" {
+		if entry == gateway.GoProxyDefaultEnvKey+"=http://"+gateway.GuestGatewayHostname+":8170/goproxy,direct" {
 			foundGoProxy = true
 		}
-		if entry == "MISE_GO_DOWNLOAD_MIRROR=http://"+gateway.GuestGatewayHostname+":8170/fetch/dl.google.com/go" {
+		if entry == gateway.MiseGoDownloadMirrorDefaultEnvKey+"=http://"+gateway.GuestGatewayHostname+":8170/fetch/dl.google.com/go" {
 			foundMiseMirror = true
 		}
 	}
 	if !foundGoProxy {
-		t.Fatalf("expected GOPROXY env in %v", env)
+		t.Fatalf("expected %s env in %v", gateway.GoProxyDefaultEnvKey, env)
 	}
 	if !foundMiseMirror {
-		t.Fatalf("expected MISE_GO_DOWNLOAD_MIRROR env in %v", env)
+		t.Fatalf("expected %s env in %v", gateway.MiseGoDownloadMirrorDefaultEnvKey, env)
 	}
 }

--- a/internal/backend/firecracker/gateway_test.go
+++ b/internal/backend/firecracker/gateway_test.go
@@ -102,6 +102,7 @@ func TestGatewayEnvVarsAddsGoProxyAndMiseMirror(t *testing.T) {
 			NetworkDefault: "deny",
 			Allow: []policy.AllowRule{
 				{Host: "proxy.golang.org", Ports: []int{443}},
+				{Host: "sum.golang.org", Ports: []int{443}},
 				{Host: "dl.google.com", Ports: []int{443}},
 			},
 		},

--- a/internal/backend/firecracker/gateway_test.go
+++ b/internal/backend/firecracker/gateway_test.go
@@ -92,3 +92,36 @@ func TestGatewayEnvVarsSkipsRubyGemsMirrorWithoutLiveRoute(t *testing.T) {
 		}
 	}
 }
+
+func TestGatewayEnvVarsAddsGoProxyAndMiseMirror(t *testing.T) {
+	t.Parallel()
+
+	instance := &sandboxInstance{
+		Policy: &policy.CompiledPolicy{
+			Version:        1,
+			NetworkDefault: "deny",
+			Allow: []policy.AllowRule{
+				{Host: "proxy.golang.org", Ports: []int{443}},
+				{Host: "dl.google.com", Ports: []int{443}},
+			},
+		},
+	}
+
+	env := gatewayEnvVars(instance, 8170, gateway.ProxyRoutes{GoProxy: true, Fetch: true})
+	foundGoProxy := false
+	foundMiseMirror := false
+	for _, entry := range env {
+		if entry == "GOPROXY=http://"+gateway.GuestGatewayHostname+":8170/goproxy,direct" {
+			foundGoProxy = true
+		}
+		if entry == "MISE_GO_DOWNLOAD_MIRROR=http://"+gateway.GuestGatewayHostname+":8170/fetch/dl.google.com/go" {
+			foundMiseMirror = true
+		}
+	}
+	if !foundGoProxy {
+		t.Fatalf("expected GOPROXY env in %v", env)
+	}
+	if !foundMiseMirror {
+		t.Fatalf("expected MISE_GO_DOWNLOAD_MIRROR env in %v", env)
+	}
+}

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -140,8 +140,8 @@ func TestDoctorCommandJSONIncludesCapabilities(t *testing.T) {
 	if payload.Gateway.DefaultPort != 8170 {
 		t.Fatalf("unexpected gateway default port: %d", payload.Gateway.DefaultPort)
 	}
-	if len(payload.Gateway.Routes) != 5 {
-		t.Fatalf("expected 5 gateway routes, got %d (%v)", len(payload.Gateway.Routes), payload.Gateway.Routes)
+	if len(payload.Gateway.Routes) != 7 {
+		t.Fatalf("expected 7 gateway routes, got %d (%v)", len(payload.Gateway.Routes), payload.Gateway.Routes)
 	}
 	foundGitHub := false
 	for _, h := range payload.Gateway.CredentialHosts {

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -45,6 +45,8 @@ var newCacheMetadataStore = cachestore.New
 var gatewayScopeTokenSourcePolicyForGatewayHost = gateway.ScopeTokenSourcePolicyForGatewayHost
 var newGatewayContentCache = gateway.NewContentCache
 
+var defaultGatewayFetchHosts = []string{"dl.google.com"}
+
 func (s *ServeCommand) Run(ctx *runtimeContext) error {
 	return s.runServer(ctx)
 }
@@ -97,9 +99,10 @@ func (s *ServeCommand) runServer(ctx *runtimeContext) error {
 
 	var contentCache *gateway.ContentCache
 	contentCache, err = newGatewayContentCache(gateway.ContentCacheConfig{
-		GitAllowedHosts: ctx.Config.Gateway.Git.CacheHosts,
-		Credentials:     gwCredentials,
-		Logger:          logger.With("subsystem", "content-cache"),
+		GitAllowedHosts:   ctx.Config.Gateway.Git.CacheHosts,
+		FetchAllowedHosts: append([]string(nil), defaultGatewayFetchHosts...),
+		Credentials:       gwCredentials,
+		Logger:            logger.With("subsystem", "content-cache"),
 	})
 	if err != nil {
 		logger.Warn("content cache unavailable; continuing without cache-backed gateway routes", "error", err)
@@ -132,6 +135,8 @@ func (s *ServeCommand) runServer(ctx *runtimeContext) error {
 
 	configureGatewayBackends(ctx.Backends, gwRegistry, gwPort, gwServer.Addr(), darwinGatewayHost, gateway.ProxyRoutes{
 		RubyGems: contentCache != nil && contentCache.HasRubyGemsHandler(),
+		GoProxy:  contentCache != nil && contentCache.HasGoProxyHandler() && contentCache.HasSumDBHandler(),
+		Fetch:    contentCache != nil && contentCache.FetchAllowsHost("dl.google.com"),
 	})
 
 	if fcAdapter, ok := ctx.Backends["firecracker"].(*firecracker.Adapter); ok && fcAdapter.GatewayRegistry != nil {

--- a/internal/cli/serve_lifecycle_test.go
+++ b/internal/cli/serve_lifecycle_test.go
@@ -201,6 +201,9 @@ func TestServeCommandRunServerPassesGatewayGitCacheHostsToContentCache(t *testin
 	if got, want := captured.GitAllowedHosts, []string{"github.com", "gitlab.com"}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
 		t.Fatalf("unexpected git cache hosts: got %v want %v", got, want)
 	}
+	if got, want := captured.FetchAllowedHosts, []string{"dl.google.com"}; len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("unexpected fetch cache hosts: got %v want %v", got, want)
+	}
 	if cancelRun == nil {
 		t.Fatal("expected serveSignalNotifyContext replacement to capture a cancel func")
 	}

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -72,7 +72,7 @@ func TestConfigureGatewayBackendsConfiguresDarwinVZGateway(t *testing.T) {
 		"darwin-vz":   darwinAdapter,
 	}
 
-	configureGatewayBackends(backends, gwRegistry, 8170, "0.0.0.0:8170", "192.168.64.1", gateway.ProxyRoutes{RubyGems: true})
+	configureGatewayBackends(backends, gwRegistry, 8170, "0.0.0.0:8170", "192.168.64.1", gateway.ProxyRoutes{RubyGems: true, GoProxy: true, Fetch: true})
 
 	if fcAdapter.GatewayRegistry == nil {
 		t.Fatal("expected firecracker adapter to use the host gateway registry")
@@ -82,6 +82,12 @@ func TestConfigureGatewayBackendsConfiguresDarwinVZGateway(t *testing.T) {
 	}
 	if !fcAdapter.GatewayRoutes.RubyGems {
 		t.Fatal("expected firecracker adapter to receive live rubygems route state")
+	}
+	if !fcAdapter.GatewayRoutes.GoProxy {
+		t.Fatal("expected firecracker adapter to receive live goproxy route state")
+	}
+	if !fcAdapter.GatewayRoutes.Fetch {
+		t.Fatal("expected firecracker adapter to receive live fetch route state")
 	}
 	if darwinAdapter.GatewayRegistry == nil {
 		t.Fatal("expected darwin-vz adapter to use the host gateway registry")
@@ -94,6 +100,12 @@ func TestConfigureGatewayBackendsConfiguresDarwinVZGateway(t *testing.T) {
 	}
 	if !darwinAdapter.GatewayRoutes.RubyGems {
 		t.Fatal("expected darwin-vz adapter to receive live rubygems route state")
+	}
+	if !darwinAdapter.GatewayRoutes.GoProxy {
+		t.Fatal("expected darwin-vz adapter to receive live goproxy route state")
+	}
+	if !darwinAdapter.GatewayRoutes.Fetch {
+		t.Fatal("expected darwin-vz adapter to receive live fetch route state")
 	}
 }
 

--- a/internal/gateway/contentcache.go
+++ b/internal/gateway/contentcache.go
@@ -224,6 +224,7 @@ func NewContentCache(cfg ContentCacheConfig) (*ContentCache, error) {
 		upstreamHost: goProxyPolicyHost,
 		upstreamPort: goProxyPolicyPort,
 		handlers:     make(map[string]goProxyScopedHandler),
+		maxHandlers:  defaultMaxGoProxyScopedHandlers,
 		buildHandler: func(compiled *policy.CompiledPolicy) (goProxyScopedHandler, error) {
 			goProxyUpstream := ccgoproxy.NewUpstream(
 				ccgoproxy.WithUpstreamURL(goProxyUpstreamURL),

--- a/internal/gateway/contentcache.go
+++ b/internal/gateway/contentcache.go
@@ -22,6 +22,7 @@ import (
 	"github.com/charmbracelet/log"
 
 	"github.com/buildkite/cleanroom/internal/paths"
+	"github.com/buildkite/cleanroom/internal/policy"
 )
 
 var errGitHostNotConfiguredForCaching = errors.New("git host not configured for caching")
@@ -99,7 +100,6 @@ func NewContentCache(cfg ContentCacheConfig) (*ContentCache, error) {
 	// redirects across policy boundaries, while OCI pulls commonly rely on
 	// registry/CDN redirects for blob downloads.
 	gitHTTPClient := newGitContentCacheHTTPClient(cfg.Credentials)
-	goProxyHTTPClient := newGoProxyContentCacheHTTPClient()
 	sumDBHTTPClient := newSumDBContentCacheHTTPClient()
 	ociHTTPClient := newOCIContentCacheHTTPClient(cfg.Credentials)
 	rubyGemsHTTPClient := newRubyGemsContentCacheHTTPClient(cfg.Credentials)
@@ -218,26 +218,30 @@ func NewContentCache(cfg ContentCacheConfig) (*ContentCache, error) {
 		_ = db.Close()
 		return nil, fmt.Errorf("resolve goproxy upstream: %w", err)
 	}
-	goProxyUpstream := ccgoproxy.NewUpstream(
-		ccgoproxy.WithUpstreamURL(goProxyUpstreamURL),
-		ccgoproxy.WithHTTPClient(goProxyHTTPClient),
-	)
-	goProxyHandler := ccgoproxy.NewHandler(
-		goProxyIndex,
-		cafs,
-		ccgoproxy.WithUpstream(goProxyUpstream),
-		ccgoproxy.WithLogger(logger),
-		ccgoproxy.WithDownloader(dl),
-	)
 	cache.goProxy = goProxyHandlerEntry{
-		handler:      goProxyHandler,
 		policyHost:   goProxyPolicyHost,
 		policyPort:   goProxyPolicyPort,
 		upstreamHost: goProxyPolicyHost,
 		upstreamPort: goProxyPolicyPort,
-	}
-	if closer, ok := any(goProxyHandler).(interface{ Close() }); ok {
-		cache.goProxy.closer = closeFunc(closer.Close)
+		handlers:     make(map[string]goProxyScopedHandler),
+		buildHandler: func(compiled *policy.CompiledPolicy) (goProxyScopedHandler, error) {
+			goProxyUpstream := ccgoproxy.NewUpstream(
+				ccgoproxy.WithUpstreamURL(goProxyUpstreamURL),
+				ccgoproxy.WithHTTPClient(newGoProxyContentCacheHTTPClient(compiled)),
+			)
+			handler := ccgoproxy.NewHandler(
+				goProxyIndex,
+				cafs,
+				ccgoproxy.WithUpstream(goProxyUpstream),
+				ccgoproxy.WithLogger(logger),
+				ccgoproxy.WithDownloader(dl),
+			)
+			entry := goProxyScopedHandler{handler: handler}
+			if closer, ok := any(handler).(interface{ Close() }); ok {
+				entry.closer = closeFunc(closer.Close)
+			}
+			return entry, nil
+		},
 	}
 
 	sumDBUpstreamURL := strings.TrimSpace(ccgoproxy.DefaultSumDBURL)

--- a/internal/gateway/contentcache.go
+++ b/internal/gateway/contentcache.go
@@ -12,7 +12,9 @@ import (
 
 	"github.com/buildkite/content-cache/backend"
 	"github.com/buildkite/content-cache/download"
+	ccfetch "github.com/buildkite/content-cache/protocol/fetch"
 	ccgit "github.com/buildkite/content-cache/protocol/git"
+	ccgoproxy "github.com/buildkite/content-cache/protocol/goproxy"
 	ccoci "github.com/buildkite/content-cache/protocol/oci"
 	ccrubygems "github.com/buildkite/content-cache/protocol/rubygems"
 	"github.com/buildkite/content-cache/store"
@@ -52,6 +54,10 @@ type ContentCacheConfig struct {
 
 	// RubyGemsMetadataTTL controls how long RubyGems metadata is cached.
 	RubyGemsMetadataTTL time.Duration
+
+	// FetchAllowedHosts restricts which upstream hosts may be served by the
+	// immutable artifact fetch route.
+	FetchAllowedHosts []string
 
 	Logger *log.Logger
 }
@@ -93,8 +99,11 @@ func NewContentCache(cfg ContentCacheConfig) (*ContentCache, error) {
 	// redirects across policy boundaries, while OCI pulls commonly rely on
 	// registry/CDN redirects for blob downloads.
 	gitHTTPClient := newGitContentCacheHTTPClient(cfg.Credentials)
+	goProxyHTTPClient := newGoProxyContentCacheHTTPClient()
+	sumDBHTTPClient := newSumDBContentCacheHTTPClient()
 	ociHTTPClient := newOCIContentCacheHTTPClient(cfg.Credentials)
 	rubyGemsHTTPClient := newRubyGemsContentCacheHTTPClient(cfg.Credentials)
+	fetchHTTPClient := newFetchContentCacheHTTPClient()
 
 	packIdx, err := metadb.NewEnvelopeIndex(db, "git", "pack", 24*time.Hour)
 	if err != nil {
@@ -115,6 +124,26 @@ func NewContentCache(cfg ContentCacheConfig) (*ContentCache, error) {
 	if err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("create oci image index: %w", err)
+	}
+	goProxyModIdx, err := metadb.NewEnvelopeIndex(db, "goproxy", "mod", 24*time.Hour)
+	if err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("create goproxy mod index: %w", err)
+	}
+	goProxyInfoIdx, err := metadb.NewEnvelopeIndex(db, "goproxy", "info", 24*time.Hour)
+	if err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("create goproxy info index: %w", err)
+	}
+	goProxyListIdx, err := metadb.NewEnvelopeIndex(db, "goproxy", "list", 24*time.Hour)
+	if err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("create goproxy list index: %w", err)
+	}
+	sumDBIdx, err := metadb.NewEnvelopeIndex(db, "sumdb", "cache", 0)
+	if err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("create sumdb cache index: %w", err)
 	}
 	rubyGemsMetadataTTL := cfg.RubyGemsMetadataTTL
 	if rubyGemsMetadataTTL == 0 {
@@ -145,8 +174,15 @@ func NewContentCache(cfg ContentCacheConfig) (*ContentCache, error) {
 		_ = db.Close()
 		return nil, fmt.Errorf("create rubygems gemspec index: %w", err)
 	}
+	fetchResourceIdx, err := metadb.NewEnvelopeIndex(db, "fetch", "resource", 24*time.Hour)
+	if err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("create fetch resource index: %w", err)
+	}
 
 	gitIndex := ccgit.NewIndex(packIdx)
+	goProxyIndex := ccgoproxy.NewIndex(goProxyModIdx, goProxyInfoIdx, goProxyListIdx)
+	sumDBIndex := ccgoproxy.NewSumdbIndex(sumDBIdx)
 	ociIndex := ccoci.NewIndex(imageIdx, manifestIdx, blobIdx)
 	rubyGemsIndex := ccrubygems.NewIndex(
 		rubyGemsVersionsIdx,
@@ -156,7 +192,10 @@ func NewContentCache(cfg ContentCacheConfig) (*ContentCache, error) {
 		rubyGemsGemspecIdx,
 		cafs,
 	)
+	fetchIndex := ccfetch.NewIndex(fetchResourceIdx)
 	allowedGitHosts := normalizeAllowedGitHosts(cfg.GitAllowedHosts)
+	allowedFetchHosts := normalizeAllowedHostList(cfg.FetchAllowedHosts)
+	allowedFetchHostSet := normalizeAllowedGitHosts(allowedFetchHosts)
 	registryMappings, err := normalizeOCIRegistryMappings(cfg.OCIRegistries)
 	if err != nil {
 		_ = db.Close()
@@ -173,6 +212,62 @@ func NewContentCache(cfg ContentCacheConfig) (*ContentCache, error) {
 		gitHandlers: make(map[string]http.Handler),
 		ociHandlers: make(map[string]ociHandlerEntry),
 	}
+	goProxyUpstreamURL := strings.TrimSpace(ccgoproxy.DefaultUpstreamURL)
+	goProxyPolicyHost, goProxyPolicyPort, err := registryHostPort(goProxyUpstreamURL)
+	if err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("resolve goproxy upstream: %w", err)
+	}
+	goProxyUpstream := ccgoproxy.NewUpstream(
+		ccgoproxy.WithUpstreamURL(goProxyUpstreamURL),
+		ccgoproxy.WithHTTPClient(goProxyHTTPClient),
+	)
+	goProxyHandler := ccgoproxy.NewHandler(
+		goProxyIndex,
+		cafs,
+		ccgoproxy.WithUpstream(goProxyUpstream),
+		ccgoproxy.WithLogger(logger),
+		ccgoproxy.WithDownloader(dl),
+	)
+	cache.goProxy = goProxyHandlerEntry{
+		handler:      goProxyHandler,
+		policyHost:   goProxyPolicyHost,
+		policyPort:   goProxyPolicyPort,
+		upstreamHost: goProxyPolicyHost,
+		upstreamPort: goProxyPolicyPort,
+	}
+	if closer, ok := any(goProxyHandler).(interface{ Close() }); ok {
+		cache.goProxy.closer = closeFunc(closer.Close)
+	}
+
+	sumDBUpstreamURL := strings.TrimSpace(ccgoproxy.DefaultSumDBURL)
+	sumDBPolicyHost, sumDBPolicyPort, err := registryHostPort(sumDBUpstreamURL)
+	if err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("resolve sumdb upstream: %w", err)
+	}
+	sumDBUpstream := ccgoproxy.NewSumdbUpstream(
+		ccgoproxy.WithSumdbHTTPClient(sumDBHTTPClient),
+	)
+	sumDBHandler := ccgoproxy.NewSumdbHandler(
+		sumDBIndex,
+		cafs,
+		ccgoproxy.WithSumdbUpstream(sumDBUpstream),
+		ccgoproxy.WithSumdbLogger(logger),
+		ccgoproxy.WithSumdbName(ccgoproxy.DefaultSumDBName),
+	)
+	cache.sumdb = sumDBHandlerEntry{
+		handler:      sumDBHandler,
+		name:         ccgoproxy.DefaultSumDBName,
+		policyHost:   sumDBPolicyHost,
+		policyPort:   sumDBPolicyPort,
+		upstreamHost: sumDBPolicyHost,
+		upstreamPort: sumDBPolicyPort,
+	}
+	if closer, ok := any(sumDBHandler).(interface{ Close() }); ok {
+		cache.sumdb.closer = closeFunc(closer.Close)
+	}
+
 	cache.resolveOCIRoute = func(prefix string) (ociRoute, error) {
 		return resolveOCIRegistryRoute(prefix, registryMappings)
 	}
@@ -268,6 +363,23 @@ func NewContentCache(cfg ContentCacheConfig) (*ContentCache, error) {
 	if closer, ok := any(rubyGemsHandler).(interface{ Close() }); ok {
 		cache.rubyGems.closer = closeFunc(closer.Close)
 	}
+	if len(allowedFetchHosts) > 0 {
+		fetchHandler := ccfetch.NewHandler(
+			fetchIndex,
+			cafs,
+			ccfetch.WithHTTPClient(fetchHTTPClient),
+			ccfetch.WithLogger(logger),
+			ccfetch.WithDownloader(dl),
+			ccfetch.WithAllowedHosts(allowedFetchHosts),
+		)
+		cache.fetch = fetchHandlerEntry{
+			handler:      fetchHandler,
+			allowedHosts: allowedFetchHostSet,
+		}
+		if closer, ok := any(fetchHandler).(interface{ Close() }); ok {
+			cache.fetch.closer = closeFunc(closer.Close)
+		}
+	}
 	return cache, nil
 }
 
@@ -285,12 +397,31 @@ func normalizeAllowedGitHosts(hosts []string) map[string]struct{} {
 		return nil
 	}
 	out := make(map[string]struct{}, len(hosts))
+	for _, host := range normalizeAllowedHostList(hosts) {
+		out[host] = struct{}{}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func normalizeAllowedHostList(hosts []string) []string {
+	if len(hosts) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(hosts))
+	seen := make(map[string]struct{}, len(hosts))
 	for _, host := range hosts {
 		host = strings.ToLower(strings.TrimSpace(host))
 		if host == "" {
 			continue
 		}
-		out[host] = struct{}{}
+		if _, ok := seen[host]; ok {
+			continue
+		}
+		seen[host] = struct{}{}
+		out = append(out, host)
 	}
 	if len(out) == 0 {
 		return nil

--- a/internal/gateway/contentcache_types.go
+++ b/internal/gateway/contentcache_types.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/buildkite/cleanroom/internal/policy"
 )
 
 type gitHandlerFactory func(host string) (http.Handler, error)
@@ -29,13 +31,19 @@ type ociHandlerEntry struct {
 	closer       io.Closer
 }
 
+type goProxyScopedHandler struct {
+	handler http.Handler
+	closer  io.Closer
+}
+
 type goProxyHandlerEntry struct {
-	handler      http.Handler
 	policyHost   string
 	policyPort   int
 	upstreamHost string
 	upstreamPort int
-	closer       io.Closer
+	mu           sync.Mutex
+	handlers     map[string]goProxyScopedHandler
+	buildHandler func(*policy.CompiledPolicy) (goProxyScopedHandler, error)
 }
 
 type sumDBHandlerEntry struct {
@@ -96,9 +104,13 @@ func (c *ContentCache) Close() error {
 		}
 	}
 	c.ociMu.Unlock()
-	if c.goProxy.closer != nil {
-		closers = append(closers, c.goProxy.closer)
+	c.goProxy.mu.Lock()
+	for _, entry := range c.goProxy.handlers {
+		if entry.closer != nil {
+			closers = append(closers, entry.closer)
+		}
 	}
+	c.goProxy.mu.Unlock()
 	if c.sumdb.closer != nil {
 		closers = append(closers, c.sumdb.closer)
 	}
@@ -160,23 +172,49 @@ func (c *ContentCache) HasOCIHandler() bool {
 
 // HasGoProxyHandler reports whether Go module proxy caching is configured.
 func (c *ContentCache) HasGoProxyHandler() bool {
-	return c != nil && c.goProxy.handler != nil
+	return c != nil && c.goProxy.buildHandler != nil
 }
 
 // GoProxyUpstream returns policy/upstream metadata for the configured Go module proxy.
 func (c *ContentCache) GoProxyUpstream() (string, int, string, int, error) {
-	if c == nil || c.goProxy.handler == nil {
+	if c == nil || c.goProxy.buildHandler == nil {
 		return "", 0, "", 0, errors.New("goproxy cache not configured")
 	}
 	return c.goProxy.policyHost, c.goProxy.policyPort, c.goProxy.upstreamHost, c.goProxy.upstreamPort, nil
 }
 
-// GoProxyHandler returns the configured Go module proxy cache handler.
-func (c *ContentCache) GoProxyHandler() (http.Handler, error) {
-	if c == nil || c.goProxy.handler == nil {
+// GoProxyHandlerForPolicy returns a Go module proxy cache handler scoped to
+// the provided compiled policy. The handler caches background fills against the
+// same allowlist that authorized the originating sandbox request.
+func (c *ContentCache) GoProxyHandlerForPolicy(compiled *policy.CompiledPolicy) (http.Handler, error) {
+	if c == nil || c.goProxy.buildHandler == nil {
 		return nil, errors.New("goproxy cache not configured")
 	}
-	return c.goProxy.handler, nil
+	if compiled == nil {
+		return nil, errors.New("goproxy policy is required")
+	}
+
+	key := strings.TrimSpace(compiled.Hash)
+	if key == "" {
+		key = fmt.Sprintf("%p", compiled)
+	}
+
+	c.goProxy.mu.Lock()
+	defer c.goProxy.mu.Unlock()
+
+	if entry, ok := c.goProxy.handlers[key]; ok {
+		return entry.handler, nil
+	}
+
+	entry, err := c.goProxy.buildHandler(compiled)
+	if err != nil {
+		return nil, err
+	}
+	if c.goProxy.handlers == nil {
+		c.goProxy.handlers = make(map[string]goProxyScopedHandler)
+	}
+	c.goProxy.handlers[key] = entry
+	return entry.handler, nil
 }
 
 // HasSumDBHandler reports whether sumdb caching is configured.
@@ -369,9 +407,11 @@ func ociUpstreamPolicyFromContext(ctx context.Context) (ociUpstreamPolicyContext
 	return policy, ok
 }
 
-func validateUpstreamTargetPolicy(req *http.Request) error {
-	scope, ok := ScopeFromContext(req.Context())
-	if !ok || scope == nil || scope.Policy == nil {
+func validateUpstreamTargetPolicy(req *http.Request, compiled *policy.CompiledPolicy) error {
+	if scope, ok := ScopeFromContext(req.Context()); ok && scope != nil && scope.Policy != nil {
+		compiled = scope.Policy
+	}
+	if compiled == nil {
 		return errors.New("sandbox scope is required for upstream policy validation")
 	}
 
@@ -385,7 +425,7 @@ func validateUpstreamTargetPolicy(req *http.Request) error {
 		policyHost = mapped.policyHost
 		policyPort = mapped.policyPort
 	}
-	if !scope.Policy.Allows(policyHost, policyPort) {
+	if !compiled.Allows(policyHost, policyPort) {
 		return fmt.Errorf("upstream target %s:%d is not allowed by sandbox policy", policyHost, policyPort)
 	}
 	return nil
@@ -400,7 +440,8 @@ type credentialInjector struct {
 }
 
 type policyValidatingRoundTripper struct {
-	base http.RoundTripper
+	base   http.RoundTripper
+	policy *policy.CompiledPolicy
 }
 
 func newGitContentCacheHTTPClient(credentials CredentialProvider) *http.Client {
@@ -412,33 +453,33 @@ func newGitContentCacheHTTPClient(credentials CredentialProvider) *http.Client {
 }
 
 func newOCIContentCacheHTTPClient(credentials CredentialProvider) *http.Client {
-	return newPolicyValidatingContentCacheHTTPClient(credentials)
+	return newPolicyValidatingContentCacheHTTPClient(credentials, nil)
 }
 
-func newGoProxyContentCacheHTTPClient() *http.Client {
-	return newPolicyValidatingContentCacheHTTPClient(nil)
+func newGoProxyContentCacheHTTPClient(compiled *policy.CompiledPolicy) *http.Client {
+	return newPolicyValidatingContentCacheHTTPClient(nil, compiled)
 }
 
 func newSumDBContentCacheHTTPClient() *http.Client {
-	return newPolicyValidatingContentCacheHTTPClient(nil)
+	return newPolicyValidatingContentCacheHTTPClient(nil, nil)
 }
 
 func newRubyGemsContentCacheHTTPClient(_ CredentialProvider) *http.Client {
-	return newPolicyValidatingContentCacheHTTPClient(nil)
+	return newPolicyValidatingContentCacheHTTPClient(nil, nil)
 }
 
 func newFetchContentCacheHTTPClient() *http.Client {
-	return newPolicyValidatingContentCacheHTTPClient(nil)
+	return newPolicyValidatingContentCacheHTTPClient(nil, nil)
 }
 
-func newPolicyValidatingContentCacheHTTPClient(credentials CredentialProvider) *http.Client {
+func newPolicyValidatingContentCacheHTTPClient(credentials CredentialProvider, compiled *policy.CompiledPolicy) *http.Client {
 	client := newUpstreamContentCacheHTTPClient(credentials)
-	client.Transport = &policyValidatingRoundTripper{base: client.Transport}
+	client.Transport = &policyValidatingRoundTripper{base: client.Transport, policy: compiled}
 	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
 		if len(via) == 0 {
 			return nil
 		}
-		return validateUpstreamTargetPolicy(req)
+		return validateUpstreamTargetPolicy(req, compiled)
 	}
 	return client
 }
@@ -472,7 +513,7 @@ func (c *credentialInjector) RoundTrip(r *http.Request) (*http.Response, error) 
 }
 
 func (p *policyValidatingRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
-	if err := validateUpstreamTargetPolicy(r); err != nil {
+	if err := validateUpstreamTargetPolicy(r, p.policy); err != nil {
 		return nil, err
 	}
 	return p.base.RoundTrip(r)

--- a/internal/gateway/contentcache_types.go
+++ b/internal/gateway/contentcache_types.go
@@ -16,6 +16,8 @@ import (
 	"github.com/buildkite/cleanroom/internal/policy"
 )
 
+const defaultMaxGoProxyScopedHandlers = 32
+
 type gitHandlerFactory func(host string) (http.Handler, error)
 
 type ociHandlerFactory func(prefix string) (ociHandlerEntry, error)
@@ -43,6 +45,8 @@ type goProxyHandlerEntry struct {
 	upstreamPort int
 	mu           sync.Mutex
 	handlers     map[string]goProxyScopedHandler
+	order        []string
+	maxHandlers  int
 	buildHandler func(*policy.CompiledPolicy) (goProxyScopedHandler, error)
 }
 
@@ -200,21 +204,60 @@ func (c *ContentCache) GoProxyHandlerForPolicy(compiled *policy.CompiledPolicy) 
 	}
 
 	c.goProxy.mu.Lock()
-	defer c.goProxy.mu.Unlock()
 
 	if entry, ok := c.goProxy.handlers[key]; ok {
+		c.goProxy.touchLocked(key)
+		c.goProxy.mu.Unlock()
 		return entry.handler, nil
 	}
 
 	entry, err := c.goProxy.buildHandler(compiled)
 	if err != nil {
+		c.goProxy.mu.Unlock()
 		return nil, err
 	}
 	if c.goProxy.handlers == nil {
 		c.goProxy.handlers = make(map[string]goProxyScopedHandler)
 	}
 	c.goProxy.handlers[key] = entry
+	c.goProxy.touchLocked(key)
+	evicted := c.goProxy.evictLocked()
+	c.goProxy.mu.Unlock()
+	if evicted != nil {
+		_ = evicted.Close()
+	}
 	return entry.handler, nil
+}
+
+func (e *goProxyHandlerEntry) touchLocked(key string) {
+	for i, existing := range e.order {
+		if existing != key {
+			continue
+		}
+		copy(e.order[i:], e.order[i+1:])
+		e.order = e.order[:len(e.order)-1]
+		break
+	}
+	e.order = append(e.order, key)
+}
+
+func (e *goProxyHandlerEntry) evictLocked() io.Closer {
+	maxHandlers := e.maxHandlers
+	if maxHandlers <= 0 {
+		maxHandlers = defaultMaxGoProxyScopedHandlers
+	}
+	if len(e.order) <= maxHandlers {
+		return nil
+	}
+
+	evictedKey := e.order[0]
+	e.order = e.order[1:]
+	entry, ok := e.handlers[evictedKey]
+	if !ok {
+		return nil
+	}
+	delete(e.handlers, evictedKey)
+	return entry.closer
 }
 
 // HasSumDBHandler reports whether sumdb caching is configured.

--- a/internal/gateway/contentcache_types.go
+++ b/internal/gateway/contentcache_types.go
@@ -29,12 +29,37 @@ type ociHandlerEntry struct {
 	closer       io.Closer
 }
 
+type goProxyHandlerEntry struct {
+	handler      http.Handler
+	policyHost   string
+	policyPort   int
+	upstreamHost string
+	upstreamPort int
+	closer       io.Closer
+}
+
+type sumDBHandlerEntry struct {
+	handler      http.Handler
+	policyHost   string
+	policyPort   int
+	upstreamHost string
+	upstreamPort int
+	name         string
+	closer       io.Closer
+}
+
 type rubyGemsHandlerEntry struct {
 	handler      http.Handler
 	policyHost   string
 	policyPort   int
 	upstreamHost string
 	upstreamPort int
+	closer       io.Closer
+}
+
+type fetchHandlerEntry struct {
+	handler      http.Handler
+	allowedHosts map[string]struct{}
 	closer       io.Closer
 }
 
@@ -51,7 +76,10 @@ type ContentCache struct {
 	buildOCIHandler ociHandlerFactory
 	resolveOCIRoute ociRouteResolver
 
+	goProxy  goProxyHandlerEntry
+	sumdb    sumDBHandlerEntry
 	rubyGems rubyGemsHandlerEntry
+	fetch    fetchHandlerEntry
 }
 
 // Close releases resources held by the content cache.
@@ -61,15 +89,24 @@ func (c *ContentCache) Close() error {
 	}
 
 	c.ociMu.Lock()
-	closers := make([]io.Closer, 0, len(c.ociHandlers)+1)
+	closers := make([]io.Closer, 0, len(c.ociHandlers)+4)
 	for _, entry := range c.ociHandlers {
 		if entry.closer != nil {
 			closers = append(closers, entry.closer)
 		}
 	}
 	c.ociMu.Unlock()
+	if c.goProxy.closer != nil {
+		closers = append(closers, c.goProxy.closer)
+	}
+	if c.sumdb.closer != nil {
+		closers = append(closers, c.sumdb.closer)
+	}
 	if c.rubyGems.closer != nil {
 		closers = append(closers, c.rubyGems.closer)
+	}
+	if c.fetch.closer != nil {
+		closers = append(closers, c.fetch.closer)
 	}
 
 	if c.closer != nil {
@@ -121,6 +158,48 @@ func (c *ContentCache) HasOCIHandler() bool {
 	return c != nil && c.buildOCIHandler != nil
 }
 
+// HasGoProxyHandler reports whether Go module proxy caching is configured.
+func (c *ContentCache) HasGoProxyHandler() bool {
+	return c != nil && c.goProxy.handler != nil
+}
+
+// GoProxyUpstream returns policy/upstream metadata for the configured Go module proxy.
+func (c *ContentCache) GoProxyUpstream() (string, int, string, int, error) {
+	if c == nil || c.goProxy.handler == nil {
+		return "", 0, "", 0, errors.New("goproxy cache not configured")
+	}
+	return c.goProxy.policyHost, c.goProxy.policyPort, c.goProxy.upstreamHost, c.goProxy.upstreamPort, nil
+}
+
+// GoProxyHandler returns the configured Go module proxy cache handler.
+func (c *ContentCache) GoProxyHandler() (http.Handler, error) {
+	if c == nil || c.goProxy.handler == nil {
+		return nil, errors.New("goproxy cache not configured")
+	}
+	return c.goProxy.handler, nil
+}
+
+// HasSumDBHandler reports whether sumdb caching is configured.
+func (c *ContentCache) HasSumDBHandler() bool {
+	return c != nil && c.sumdb.handler != nil
+}
+
+// SumDBUpstream returns policy/upstream metadata for the configured checksum database proxy.
+func (c *ContentCache) SumDBUpstream() (string, int, string, int, error) {
+	if c == nil || c.sumdb.handler == nil {
+		return "", 0, "", 0, errors.New("sumdb cache not configured")
+	}
+	return c.sumdb.policyHost, c.sumdb.policyPort, c.sumdb.upstreamHost, c.sumdb.upstreamPort, nil
+}
+
+// SumDBHandler returns the configured checksum database proxy handler.
+func (c *ContentCache) SumDBHandler() (http.Handler, error) {
+	if c == nil || c.sumdb.handler == nil {
+		return nil, errors.New("sumdb cache not configured")
+	}
+	return c.sumdb.handler, nil
+}
+
 // HasRubyGemsHandler reports whether RubyGems caching is configured.
 func (c *ContentCache) HasRubyGemsHandler() bool {
 	return c != nil && c.rubyGems.handler != nil
@@ -141,6 +220,32 @@ func (c *ContentCache) RubyGemsHandler() (http.Handler, error) {
 		return nil, errors.New("rubygems cache not configured")
 	}
 	return c.rubyGems.handler, nil
+}
+
+// HasFetchHandler reports whether immutable artifact fetch caching is configured.
+func (c *ContentCache) HasFetchHandler() bool {
+	return c != nil && c.fetch.handler != nil
+}
+
+// FetchAllowsHost reports whether the immutable artifact fetch route is configured for host.
+func (c *ContentCache) FetchAllowsHost(host string) bool {
+	if c == nil || c.fetch.handler == nil {
+		return false
+	}
+	host = strings.ToLower(strings.TrimSpace(host))
+	if host == "" {
+		return false
+	}
+	_, ok := c.fetch.allowedHosts[host]
+	return ok
+}
+
+// FetchHandler returns the configured immutable artifact fetch cache handler.
+func (c *ContentCache) FetchHandler() (http.Handler, error) {
+	if c == nil || c.fetch.handler == nil {
+		return nil, errors.New("fetch cache not configured")
+	}
+	return c.fetch.handler, nil
 }
 
 // OCIUpstreamForPrefix returns policy/upstream metadata for the requested
@@ -307,19 +412,27 @@ func newGitContentCacheHTTPClient(credentials CredentialProvider) *http.Client {
 }
 
 func newOCIContentCacheHTTPClient(credentials CredentialProvider) *http.Client {
-	client := newUpstreamContentCacheHTTPClient(credentials)
-	client.Transport = &policyValidatingRoundTripper{base: client.Transport}
-	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		if len(via) == 0 {
-			return nil
-		}
-		return validateUpstreamTargetPolicy(req)
-	}
-	return client
+	return newPolicyValidatingContentCacheHTTPClient(credentials)
+}
+
+func newGoProxyContentCacheHTTPClient() *http.Client {
+	return newPolicyValidatingContentCacheHTTPClient(nil)
+}
+
+func newSumDBContentCacheHTTPClient() *http.Client {
+	return newPolicyValidatingContentCacheHTTPClient(nil)
 }
 
 func newRubyGemsContentCacheHTTPClient(_ CredentialProvider) *http.Client {
-	client := newUpstreamContentCacheHTTPClient(nil)
+	return newPolicyValidatingContentCacheHTTPClient(nil)
+}
+
+func newFetchContentCacheHTTPClient() *http.Client {
+	return newPolicyValidatingContentCacheHTTPClient(nil)
+}
+
+func newPolicyValidatingContentCacheHTTPClient(credentials CredentialProvider) *http.Client {
+	client := newUpstreamContentCacheHTTPClient(credentials)
 	client.Transport = &policyValidatingRoundTripper{base: client.Transport}
 	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
 		if len(via) == 0 {

--- a/internal/gateway/contentcache_types_test.go
+++ b/internal/gateway/contentcache_types_test.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"io"
 	"net/http"
+	"slices"
 	"strings"
 	"testing"
 
@@ -14,6 +15,10 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
 	return f(r)
 }
+
+type comparableHandler struct{}
+
+func (comparableHandler) ServeHTTP(http.ResponseWriter, *http.Request) {}
 
 func TestPolicyValidatingRoundTripperUsesPinnedPolicyWithoutScope(t *testing.T) {
 	t.Parallel()
@@ -72,5 +77,63 @@ func TestPolicyValidatingRoundTripperRejectsScopeLessRequestsWithoutPinnedPolicy
 
 	if _, err := rt.RoundTrip(req); err == nil {
 		t.Fatal("expected missing scope validation error")
+	}
+}
+
+func TestGoProxyHandlerForPolicyEvictsLeastRecentlyUsedHandler(t *testing.T) {
+	t.Parallel()
+
+	var closed []string
+	cache := &ContentCache{}
+	cache.goProxy = goProxyHandlerEntry{
+		handlers:    make(map[string]goProxyScopedHandler),
+		maxHandlers: 2,
+		buildHandler: func(compiled *policy.CompiledPolicy) (goProxyScopedHandler, error) {
+			key := compiled.Hash
+			return goProxyScopedHandler{
+				handler: &comparableHandler{},
+				closer: closeFunc(func() {
+					closed = append(closed, key)
+				}),
+			}, nil
+		},
+	}
+
+	policyA := &policy.CompiledPolicy{Hash: "policy-a"}
+	policyB := &policy.CompiledPolicy{Hash: "policy-b"}
+	policyC := &policy.CompiledPolicy{Hash: "policy-c"}
+
+	handlerA, err := cache.GoProxyHandlerForPolicy(policyA)
+	if err != nil {
+		t.Fatalf("handler A: %v", err)
+	}
+	if _, err := cache.GoProxyHandlerForPolicy(policyB); err != nil {
+		t.Fatalf("handler B: %v", err)
+	}
+	reusedA, err := cache.GoProxyHandlerForPolicy(policyA)
+	if err != nil {
+		t.Fatalf("reused handler A: %v", err)
+	}
+	if reusedA != handlerA {
+		t.Fatal("expected policy A handler to be reused before eviction")
+	}
+	if _, err := cache.GoProxyHandlerForPolicy(policyC); err != nil {
+		t.Fatalf("handler C: %v", err)
+	}
+
+	if got, want := len(cache.goProxy.handlers), 2; got != want {
+		t.Fatalf("expected %d cached handlers, got %d", want, got)
+	}
+	if _, ok := cache.goProxy.handlers["policy-a"]; !ok {
+		t.Fatal("expected policy-a to remain cached after recent reuse")
+	}
+	if _, ok := cache.goProxy.handlers["policy-c"]; !ok {
+		t.Fatal("expected policy-c to be cached")
+	}
+	if _, ok := cache.goProxy.handlers["policy-b"]; ok {
+		t.Fatal("expected policy-b to be evicted")
+	}
+	if !slices.Equal(closed, []string{"policy-b"}) {
+		t.Fatalf("expected policy-b closer to run, got %v", closed)
 	}
 }

--- a/internal/gateway/contentcache_types_test.go
+++ b/internal/gateway/contentcache_types_test.go
@@ -1,0 +1,76 @@
+package gateway
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/policy"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+func TestPolicyValidatingRoundTripperUsesPinnedPolicyWithoutScope(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	rt := &policyValidatingRoundTripper{
+		base: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			called = true
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("ok")),
+			}, nil
+		}),
+		policy: &policy.CompiledPolicy{
+			NetworkDefault: "deny",
+			Allow: []policy.AllowRule{{
+				Host:  "storage.googleapis.com",
+				Ports: []int{443},
+			}},
+		},
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "https://storage.googleapis.com/example/module.zip", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("round trip: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if !called {
+		t.Fatal("expected base round tripper to be called")
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestPolicyValidatingRoundTripperRejectsScopeLessRequestsWithoutPinnedPolicy(t *testing.T) {
+	t.Parallel()
+
+	rt := &policyValidatingRoundTripper{
+		base: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			t.Fatal("base round tripper should not be called")
+			return nil, nil
+		}),
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "https://proxy.golang.org/github.com/pkg/errors/@v/list", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	if _, err := rt.RoundTrip(req); err == nil {
+		t.Fatal("expected missing scope validation error")
+	}
+}

--- a/internal/gateway/fetch_cached.go
+++ b/internal/gateway/fetch_cached.go
@@ -1,0 +1,102 @@
+package gateway
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/buildkite/cleanroom/internal/observability"
+	"github.com/charmbracelet/log"
+)
+
+type fetchHandlerProvider interface {
+	FetchAllowsHost(host string) bool
+	FetchHandler() (http.Handler, error)
+}
+
+// cachedFetchHandler wraps content-cache's immutable artifact fetch handler
+// with Cleanroom's identity-based policy enforcement.
+type cachedFetchHandler struct {
+	cache  fetchHandlerProvider
+	logger *log.Logger
+}
+
+func newCachedFetchHandler(cache fetchHandlerProvider, logger *log.Logger) *cachedFetchHandler {
+	return &cachedFetchHandler{cache: cache, logger: logger}
+}
+
+func (h *cachedFetchHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	scope, ok := ScopeFromContext(r.Context())
+	if !ok {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonMethodNotAllowed)
+		writeReasonError(w, http.StatusMethodNotAllowed, reasonMethodNotAllowed, "only GET and HEAD are permitted for fetch")
+		return
+	}
+
+	host, _, err := parseFetchRequestPath(r.URL.Path)
+	if err != nil {
+		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonInvalidRequest)
+		writeReasonError(w, http.StatusBadRequest, reasonInvalidRequest, err.Error())
+		return
+	}
+	if !scope.Policy.Allows(host, 443) {
+		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonHostNotAllowed)
+		h.auditLog(r.Context(), scope.SandboxID, host, gatewayActionDeny, reasonHostNotAllowed)
+		writeReasonError(w, http.StatusForbidden, reasonHostNotAllowed, "upstream fetch host is not allowed by sandbox policy")
+		return
+	}
+	if !h.cache.FetchAllowsHost(host) {
+		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonHostNotAllowed)
+		h.auditLog(r.Context(), scope.SandboxID, host, gatewayActionDeny, reasonHostNotAllowed)
+		writeReasonError(w, http.StatusForbidden, reasonHostNotAllowed, "upstream fetch host is not configured")
+		return
+	}
+
+	handler, err := h.cache.FetchHandler()
+	if err != nil {
+		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonUpstreamError)
+		h.auditLog(r.Context(), scope.SandboxID, "fetch", gatewayActionDeny, reasonUpstreamError)
+		writeReasonError(w, http.StatusBadGateway, reasonUpstreamError, "fetch cache is not configured")
+		return
+	}
+
+	setGatewayRequestDecision(r.Context(), gatewayActionAllow, reasonCached)
+	h.auditLog(r.Context(), scope.SandboxID, host, gatewayActionAllow, reasonCached)
+
+	r = r.Clone(r.Context())
+	r.URL.Path = strings.TrimPrefix(r.URL.Path, "/fetch")
+	r.URL.RawPath = ""
+	if r.URL.Path == "" {
+		r.URL.Path = "/"
+	}
+	handler.ServeHTTP(w, r)
+}
+
+func parseFetchRequestPath(requestPath string) (string, string, error) {
+	trimmed := strings.TrimPrefix(requestPath, "/fetch/")
+	host, remainder, ok := strings.Cut(trimmed, "/")
+	if !ok || host == "" || remainder == "" {
+		return "", "", fmt.Errorf("invalid fetch path")
+	}
+	return strings.ToLower(strings.TrimSpace(host)), "/" + remainder, nil
+}
+
+func (h *cachedFetchHandler) auditLog(ctx context.Context, sandboxID, target, action, reason string) {
+	logger := observability.WithTraceContext(h.logger, ctx)
+	if logger == nil {
+		return
+	}
+	logger.Info("gateway fetch request",
+		observability.LogFieldSandboxID, sandboxID,
+		"service", "fetch",
+		"target", target,
+		"action", action,
+		observability.LogFieldReasonCode, reason,
+	)
+}

--- a/internal/gateway/fetch_cached_test.go
+++ b/internal/gateway/fetch_cached_test.go
@@ -1,0 +1,135 @@
+package gateway
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type stubFetchHandlerProvider struct {
+	handler      http.Handler
+	allowedHosts map[string]struct{}
+	err          error
+}
+
+func (s *stubFetchHandlerProvider) FetchAllowsHost(host string) bool {
+	if s.allowedHosts == nil {
+		return false
+	}
+	_, ok := s.allowedHosts[host]
+	return ok
+}
+
+func (s *stubFetchHandlerProvider) FetchHandler() (http.Handler, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.handler, nil
+}
+
+func TestCachedFetchHandlerStripsPrefixAndDelegates(t *testing.T) {
+	t.Parallel()
+
+	var capturedPath string
+	h := newCachedFetchHandler(&stubFetchHandlerProvider{
+		handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedPath = r.URL.Path
+			w.WriteHeader(http.StatusOK)
+		}),
+		allowedHosts: map[string]struct{}{"dl.google.com": {}},
+	}, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/fetch/dl.google.com/go/go1.26.2.linux-amd64.tar.gz", nil)
+	req = withScope(req, registryTestScope("dl.google.com"))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	if want := "/dl.google.com/go/go1.26.2.linux-amd64.tar.gz"; capturedPath != want {
+		t.Fatalf("expected backend path %q, got %q", want, capturedPath)
+	}
+}
+
+func TestCachedFetchHandlerDeniesHostOutsidePolicy(t *testing.T) {
+	t.Parallel()
+
+	h := newCachedFetchHandler(&stubFetchHandlerProvider{
+		handler:      http.HandlerFunc(func(http.ResponseWriter, *http.Request) { t.Fatal("handler should not run") }),
+		allowedHosts: map[string]struct{}{"dl.google.com": {}},
+	}, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/fetch/dl.google.com/go/go1.26.2.linux-amd64.tar.gz", nil)
+	req = withScope(req, registryTestScope("proxy.golang.org"))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", w.Code)
+	}
+	if got := w.Header().Get(reasonCodeHeader); got != reasonHostNotAllowed {
+		t.Fatalf("expected reason %s, got %q", reasonHostNotAllowed, got)
+	}
+}
+
+func TestCachedFetchHandlerDeniesHostOutsideFetchAllowlist(t *testing.T) {
+	t.Parallel()
+
+	h := newCachedFetchHandler(&stubFetchHandlerProvider{
+		handler:      http.HandlerFunc(func(http.ResponseWriter, *http.Request) { t.Fatal("handler should not run") }),
+		allowedHosts: map[string]struct{}{"objects.githubusercontent.com": {}},
+	}, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/fetch/dl.google.com/go/go1.26.2.linux-amd64.tar.gz", nil)
+	req = withScope(req, registryTestScope("dl.google.com"))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", w.Code)
+	}
+	if got := w.Header().Get(reasonCodeHeader); got != reasonHostNotAllowed {
+		t.Fatalf("expected reason %s, got %q", reasonHostNotAllowed, got)
+	}
+}
+
+func TestCachedFetchHandlerUnavailable(t *testing.T) {
+	t.Parallel()
+
+	h := newCachedFetchHandler(&stubFetchHandlerProvider{
+		err:          errors.New("unavailable"),
+		allowedHosts: map[string]struct{}{"dl.google.com": {}},
+	}, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/fetch/dl.google.com/go/go1.26.2.linux-amd64.tar.gz", nil)
+	req = withScope(req, registryTestScope("dl.google.com"))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("expected 502, got %d", w.Code)
+	}
+}
+
+func TestCachedFetchHandlerRejectsInvalidPath(t *testing.T) {
+	t.Parallel()
+
+	h := newCachedFetchHandler(&stubFetchHandlerProvider{
+		handler:      http.HandlerFunc(func(http.ResponseWriter, *http.Request) { t.Fatal("handler should not run") }),
+		allowedHosts: map[string]struct{}{"dl.google.com": {}},
+	}, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/fetch/dl.google.com", nil)
+	req = withScope(req, registryTestScope("dl.google.com"))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+	if got := w.Header().Get(reasonCodeHeader); got != reasonInvalidRequest {
+		t.Fatalf("expected reason %s, got %q", reasonInvalidRequest, got)
+	}
+}

--- a/internal/gateway/git.go
+++ b/internal/gateway/git.go
@@ -29,6 +29,7 @@ const (
 	reasonCodeHeader            = "X-Cleanroom-Reason-Code"
 	reasonHostNotAllowed        = observability.ReasonHostNotAllowed
 	reasonMethodNotAllowed      = observability.ReasonMethodNotAllowed
+	reasonInvalidRequest        = observability.ReasonInvalidRequest
 	reasonUpstreamError         = observability.ReasonUpstreamError
 	reasonUnknownRegistryPrefix = observability.ReasonUnknownRegistryPrefix
 	reasonProxied               = observability.ReasonProxied
@@ -122,9 +123,15 @@ func (h *gitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	remoteURL, err := canonicalUpstreamRemoteURL(upstreamHost, repoPath)
 	if err != nil {
+		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonInvalidRequest)
 		span.RecordError(err)
+		span.SetAttributes(
+			attribute.String(observability.AttrGatewayAction, gatewayActionDeny),
+			attribute.String(observability.AttrReasonCode, reasonInvalidRequest),
+		)
 		span.SetStatus(codes.Error, err.Error())
-		writeReasonError(w, http.StatusBadRequest, reasonMethodNotAllowed, err.Error())
+		h.auditLog(r.Context(), scope.SandboxID, upstreamHost, repoPath, gatewayActionDeny, reasonInvalidRequest)
+		writeReasonError(w, http.StatusBadRequest, reasonInvalidRequest, err.Error())
 		return
 	}
 

--- a/internal/gateway/git_proxy_env.go
+++ b/internal/gateway/git_proxy_env.go
@@ -24,6 +24,13 @@ const (
 	BundlerAppConfigEnvKey = "BUNDLE_APP_CONFIG"
 	// BundlerAppConfigPath is the guest path used for generated Bundler config.
 	BundlerAppConfigPath = "/tmp/cleanroom-bundle-config"
+	// GoProxyDefaultEnvKey is a shell-safe hint consumed by the guest agent to
+	// set GOPROXY only when the caller has not already defined it.
+	GoProxyDefaultEnvKey = "CLEANROOM_GOPROXY_DEFAULT"
+	// MiseGoDownloadMirrorDefaultEnvKey is a shell-safe hint consumed by the
+	// guest agent to set MISE_GO_DOWNLOAD_MIRROR only when the caller has not
+	// already defined it.
+	MiseGoDownloadMirrorDefaultEnvKey = "CLEANROOM_MISE_GO_DOWNLOAD_MIRROR_DEFAULT"
 )
 
 // ProxyRoutes describes which gateway-backed guest proxy routes are live.
@@ -113,7 +120,7 @@ func GoProxyEnvVars(compiled *policy.CompiledPolicy, gatewayPort int, routes Pro
 	}
 
 	return []string{
-		fmt.Sprintf("GOPROXY=http://%s:%d/goproxy,direct", GuestGatewayHostname, gatewayPort),
+		fmt.Sprintf("%s=http://%s:%d/goproxy,direct", GoProxyDefaultEnvKey, GuestGatewayHostname, gatewayPort),
 	}
 }
 
@@ -126,7 +133,7 @@ func MiseProxyEnvVars(compiled *policy.CompiledPolicy, gatewayPort int, routes P
 	}
 
 	return []string{
-		fmt.Sprintf("MISE_GO_DOWNLOAD_MIRROR=http://%s:%d/fetch/dl.google.com/go", GuestGatewayHostname, gatewayPort),
+		fmt.Sprintf("%s=http://%s:%d/fetch/dl.google.com/go", MiseGoDownloadMirrorDefaultEnvKey, GuestGatewayHostname, gatewayPort),
 	}
 }
 

--- a/internal/gateway/git_proxy_env.go
+++ b/internal/gateway/git_proxy_env.go
@@ -29,6 +29,8 @@ const (
 // ProxyRoutes describes which gateway-backed guest proxy routes are live.
 type ProxyRoutes struct {
 	RubyGems bool
+	GoProxy  bool
+	Fetch    bool
 }
 
 // GitProxyEnvVars returns git config environment variables that rewrite allowed
@@ -103,11 +105,39 @@ func RubyGemsProxyEnvVars(compiled *policy.CompiledPolicy, gatewayPort int, rout
 	}
 }
 
+// GoProxyEnvVars returns environment variables that route Go module downloads
+// through the shared host gateway when proxy.golang.org is policy-allowed.
+func GoProxyEnvVars(compiled *policy.CompiledPolicy, gatewayPort int, routes ProxyRoutes) []string {
+	if !routes.GoProxy || !allowsHTTPSHost(compiled, "proxy.golang.org") || gatewayPort <= 0 {
+		return nil
+	}
+
+	return []string{
+		fmt.Sprintf("GOPROXY=http://%s:%d/goproxy,direct", GuestGatewayHostname, gatewayPort),
+	}
+}
+
+// MiseProxyEnvVars returns environment variables that route immutable mise Go
+// SDK downloads through the shared host gateway when dl.google.com is
+// policy-allowed.
+func MiseProxyEnvVars(compiled *policy.CompiledPolicy, gatewayPort int, routes ProxyRoutes) []string {
+	if !routes.Fetch || !allowsHTTPSHost(compiled, "dl.google.com") || gatewayPort <= 0 {
+		return nil
+	}
+
+	return []string{
+		fmt.Sprintf("MISE_GO_DOWNLOAD_MIRROR=http://%s:%d/fetch/dl.google.com/go", GuestGatewayHostname, gatewayPort),
+	}
+}
+
 // ProxyEnvVars returns gateway-specific environment variables for guest
-// processes, including Git rewrite config and Bundler RubyGems mirroring.
+// processes, including Git rewrite config, Bundler RubyGems mirroring, Go
+// module proxying, and immutable tool download mirroring.
 func ProxyEnvVars(compiled *policy.CompiledPolicy, gatewayPort int, scopeToken string, routes ProxyRoutes) []string {
 	env := GitProxyEnvVars(compiled, gatewayPort, scopeToken)
 	env = append(env, RubyGemsProxyEnvVars(compiled, gatewayPort, routes)...)
+	env = append(env, GoProxyEnvVars(compiled, gatewayPort, routes)...)
+	env = append(env, MiseProxyEnvVars(compiled, gatewayPort, routes)...)
 	if len(env) == 0 {
 		return nil
 	}

--- a/internal/gateway/git_proxy_env.go
+++ b/internal/gateway/git_proxy_env.go
@@ -115,7 +115,7 @@ func RubyGemsProxyEnvVars(compiled *policy.CompiledPolicy, gatewayPort int, rout
 // GoProxyEnvVars returns environment variables that route Go module downloads
 // through the shared host gateway when proxy.golang.org is policy-allowed.
 func GoProxyEnvVars(compiled *policy.CompiledPolicy, gatewayPort int, routes ProxyRoutes) []string {
-	if !routes.GoProxy || !allowsHTTPSHost(compiled, "proxy.golang.org") || gatewayPort <= 0 {
+	if !routes.GoProxy || !allowsHTTPSHost(compiled, "proxy.golang.org") || !allowsHTTPSHost(compiled, "sum.golang.org") || gatewayPort <= 0 {
 		return nil
 	}
 

--- a/internal/gateway/git_proxy_env_test.go
+++ b/internal/gateway/git_proxy_env_test.go
@@ -63,7 +63,10 @@ func TestGoProxyEnvVarsRequiresLiveRoute(t *testing.T) {
 	compiled := &policy.CompiledPolicy{
 		Version:        1,
 		NetworkDefault: "deny",
-		Allow:          []policy.AllowRule{{Host: "proxy.golang.org", Ports: []int{443}}},
+		Allow: []policy.AllowRule{
+			{Host: "proxy.golang.org", Ports: []int{443}},
+			{Host: "sum.golang.org", Ports: []int{443}},
+		},
 	}
 
 	if env := GoProxyEnvVars(compiled, 8170, ProxyRoutes{}); env != nil {
@@ -76,6 +79,20 @@ func TestGoProxyEnvVarsRequiresLiveRoute(t *testing.T) {
 	}
 	if want := GoProxyDefaultEnvKey + "=http://" + GuestGatewayHostname + ":8170/goproxy,direct"; env[0] != want {
 		t.Fatalf("expected %q, got %q", want, env[0])
+	}
+}
+
+func TestGoProxyEnvVarsRequiresSumDBAllowlist(t *testing.T) {
+	t.Parallel()
+
+	compiled := &policy.CompiledPolicy{
+		Version:        1,
+		NetworkDefault: "deny",
+		Allow:          []policy.AllowRule{{Host: "proxy.golang.org", Ports: []int{443}}},
+	}
+
+	if env := GoProxyEnvVars(compiled, 8170, ProxyRoutes{GoProxy: true}); env != nil {
+		t.Fatalf("expected no goproxy env without sumdb allowlist, got %v", env)
 	}
 }
 

--- a/internal/gateway/git_proxy_env_test.go
+++ b/internal/gateway/git_proxy_env_test.go
@@ -56,3 +56,47 @@ func TestProxyEnvVarsStillIncludesGitWhenRubyGemsRouteIsUnavailable(t *testing.T
 		}
 	}
 }
+
+func TestGoProxyEnvVarsRequiresLiveRoute(t *testing.T) {
+	t.Parallel()
+
+	compiled := &policy.CompiledPolicy{
+		Version:        1,
+		NetworkDefault: "deny",
+		Allow:          []policy.AllowRule{{Host: "proxy.golang.org", Ports: []int{443}}},
+	}
+
+	if env := GoProxyEnvVars(compiled, 8170, ProxyRoutes{}); env != nil {
+		t.Fatalf("expected no goproxy env without live route, got %v", env)
+	}
+
+	env := GoProxyEnvVars(compiled, 8170, ProxyRoutes{GoProxy: true})
+	if len(env) != 1 {
+		t.Fatalf("expected 1 goproxy env var with live route, got %d: %v", len(env), env)
+	}
+	if want := "GOPROXY=http://" + GuestGatewayHostname + ":8170/goproxy,direct"; env[0] != want {
+		t.Fatalf("expected %q, got %q", want, env[0])
+	}
+}
+
+func TestMiseProxyEnvVarsRequiresLiveRoute(t *testing.T) {
+	t.Parallel()
+
+	compiled := &policy.CompiledPolicy{
+		Version:        1,
+		NetworkDefault: "deny",
+		Allow:          []policy.AllowRule{{Host: "dl.google.com", Ports: []int{443}}},
+	}
+
+	if env := MiseProxyEnvVars(compiled, 8170, ProxyRoutes{}); env != nil {
+		t.Fatalf("expected no mise fetch env without live route, got %v", env)
+	}
+
+	env := MiseProxyEnvVars(compiled, 8170, ProxyRoutes{Fetch: true})
+	if len(env) != 1 {
+		t.Fatalf("expected 1 mise fetch env var with live route, got %d: %v", len(env), env)
+	}
+	if want := "MISE_GO_DOWNLOAD_MIRROR=http://" + GuestGatewayHostname + ":8170/fetch/dl.google.com/go"; env[0] != want {
+		t.Fatalf("expected %q, got %q", want, env[0])
+	}
+}

--- a/internal/gateway/git_proxy_env_test.go
+++ b/internal/gateway/git_proxy_env_test.go
@@ -74,7 +74,7 @@ func TestGoProxyEnvVarsRequiresLiveRoute(t *testing.T) {
 	if len(env) != 1 {
 		t.Fatalf("expected 1 goproxy env var with live route, got %d: %v", len(env), env)
 	}
-	if want := "GOPROXY=http://" + GuestGatewayHostname + ":8170/goproxy,direct"; env[0] != want {
+	if want := GoProxyDefaultEnvKey + "=http://" + GuestGatewayHostname + ":8170/goproxy,direct"; env[0] != want {
 		t.Fatalf("expected %q, got %q", want, env[0])
 	}
 }
@@ -96,7 +96,7 @@ func TestMiseProxyEnvVarsRequiresLiveRoute(t *testing.T) {
 	if len(env) != 1 {
 		t.Fatalf("expected 1 mise fetch env var with live route, got %d: %v", len(env), env)
 	}
-	if want := "MISE_GO_DOWNLOAD_MIRROR=http://" + GuestGatewayHostname + ":8170/fetch/dl.google.com/go"; env[0] != want {
+	if want := MiseGoDownloadMirrorDefaultEnvKey + "=http://" + GuestGatewayHostname + ":8170/fetch/dl.google.com/go"; env[0] != want {
 		t.Fatalf("expected %q, got %q", want, env[0])
 	}
 }

--- a/internal/gateway/goproxy_cached.go
+++ b/internal/gateway/goproxy_cached.go
@@ -6,12 +6,13 @@ import (
 	"strings"
 
 	"github.com/buildkite/cleanroom/internal/observability"
+	"github.com/buildkite/cleanroom/internal/policy"
 	"github.com/charmbracelet/log"
 )
 
 type goProxyHandlerProvider interface {
 	GoProxyUpstream() (string, int, string, int, error)
-	GoProxyHandler() (http.Handler, error)
+	GoProxyHandlerForPolicy(compiled *policy.CompiledPolicy) (http.Handler, error)
 	SumDBUpstream() (string, int, string, int, error)
 	SumDBHandler() (http.Handler, error)
 }
@@ -34,9 +35,9 @@ func (h *cachedGoProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+	if r.Method != http.MethodGet {
 		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonMethodNotAllowed)
-		writeReasonError(w, http.StatusMethodNotAllowed, reasonMethodNotAllowed, "only GET and HEAD are permitted for goproxy")
+		writeReasonError(w, http.StatusMethodNotAllowed, reasonMethodNotAllowed, "only GET is permitted for goproxy")
 		return
 	}
 
@@ -65,7 +66,7 @@ func (h *cachedGoProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	if service == "sumdb" {
 		handler, err = h.cache.SumDBHandler()
 	} else {
-		handler, err = h.cache.GoProxyHandler()
+		handler, err = h.cache.GoProxyHandlerForPolicy(scope.Policy)
 	}
 	if err != nil {
 		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonUpstreamError)

--- a/internal/gateway/goproxy_cached.go
+++ b/internal/gateway/goproxy_cached.go
@@ -1,0 +1,101 @@
+package gateway
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/buildkite/cleanroom/internal/observability"
+	"github.com/charmbracelet/log"
+)
+
+type goProxyHandlerProvider interface {
+	GoProxyUpstream() (string, int, string, int, error)
+	GoProxyHandler() (http.Handler, error)
+	SumDBUpstream() (string, int, string, int, error)
+	SumDBHandler() (http.Handler, error)
+}
+
+// cachedGoProxyHandler wraps content-cache's goproxy and sumdb handlers with
+// Cleanroom's identity-based policy enforcement.
+type cachedGoProxyHandler struct {
+	cache  goProxyHandlerProvider
+	logger *log.Logger
+}
+
+func newCachedGoProxyHandler(cache goProxyHandlerProvider, logger *log.Logger) *cachedGoProxyHandler {
+	return &cachedGoProxyHandler{cache: cache, logger: logger}
+}
+
+func (h *cachedGoProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	scope, ok := ScopeFromContext(r.Context())
+	if !ok {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonMethodNotAllowed)
+		writeReasonError(w, http.StatusMethodNotAllowed, reasonMethodNotAllowed, "only GET and HEAD are permitted for goproxy")
+		return
+	}
+
+	service := "goproxy"
+	trimPrefix := RouteGoProxy[:len(RouteGoProxy)-1]
+	policyHost, policyPort, upstreamHost, _, err := h.cache.GoProxyUpstream()
+	if strings.HasPrefix(r.URL.Path, "/goproxy/sumdb/") {
+		service = "sumdb"
+		policyHost, policyPort, upstreamHost, _, err = h.cache.SumDBUpstream()
+	}
+	if err != nil {
+		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonUpstreamError)
+		h.auditLog(r.Context(), scope.SandboxID, service, service, gatewayActionDeny, reasonUpstreamError)
+		writeReasonError(w, http.StatusBadGateway, reasonUpstreamError, service+" cache is not configured")
+		return
+	}
+
+	if !scope.Policy.Allows(policyHost, policyPort) {
+		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonHostNotAllowed)
+		h.auditLog(r.Context(), scope.SandboxID, service, policyHost, gatewayActionDeny, reasonHostNotAllowed)
+		writeReasonError(w, http.StatusForbidden, reasonHostNotAllowed, "upstream "+service+" host is not allowed by sandbox policy")
+		return
+	}
+
+	var handler http.Handler
+	if service == "sumdb" {
+		handler, err = h.cache.SumDBHandler()
+	} else {
+		handler, err = h.cache.GoProxyHandler()
+	}
+	if err != nil {
+		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonUpstreamError)
+		h.auditLog(r.Context(), scope.SandboxID, service, service, gatewayActionDeny, reasonUpstreamError)
+		writeReasonError(w, http.StatusBadGateway, reasonUpstreamError, service+" cache is not configured")
+		return
+	}
+
+	setGatewayRequestDecision(r.Context(), gatewayActionAllow, reasonCached)
+	h.auditLog(r.Context(), scope.SandboxID, service, upstreamHost, gatewayActionAllow, reasonCached)
+
+	r = r.Clone(r.Context())
+	r.URL.Path = strings.TrimPrefix(r.URL.Path, trimPrefix)
+	r.URL.RawPath = ""
+	if r.URL.Path == "" {
+		r.URL.Path = "/"
+	}
+	handler.ServeHTTP(w, r)
+}
+
+func (h *cachedGoProxyHandler) auditLog(ctx context.Context, sandboxID, service, target, action, reason string) {
+	logger := observability.WithTraceContext(h.logger, ctx)
+	if logger == nil {
+		return
+	}
+	logger.Info("gateway "+service+" request",
+		observability.LogFieldSandboxID, sandboxID,
+		"service", service,
+		"target", target,
+		"action", action,
+		observability.LogFieldReasonCode, reason,
+	)
+}

--- a/internal/gateway/goproxy_cached_test.go
+++ b/internal/gateway/goproxy_cached_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/buildkite/cleanroom/internal/policy"
 )
 
 type stubGoProxyHandlerProvider struct {
@@ -28,7 +30,7 @@ func (s *stubGoProxyHandlerProvider) GoProxyUpstream() (string, int, string, int
 	return s.goPolicyHost, s.goPolicyPort, s.goUpstreamHost, s.goUpstreamPort, nil
 }
 
-func (s *stubGoProxyHandlerProvider) GoProxyHandler() (http.Handler, error) {
+func (s *stubGoProxyHandlerProvider) GoProxyHandlerForPolicy(*policy.CompiledPolicy) (http.Handler, error) {
 	if s.err != nil {
 		return nil, s.err
 	}
@@ -157,5 +159,34 @@ func TestCachedGoProxyHandlerUnavailable(t *testing.T) {
 
 	if w.Code != http.StatusBadGateway {
 		t.Fatalf("expected 502, got %d", w.Code)
+	}
+}
+
+func TestCachedGoProxyHandlerRejectsHead(t *testing.T) {
+	t.Parallel()
+
+	h := newCachedGoProxyHandler(&stubGoProxyHandlerProvider{
+		goHandler:       http.HandlerFunc(func(http.ResponseWriter, *http.Request) { t.Fatal("handler should not run") }),
+		sumdbHandler:    http.HandlerFunc(func(http.ResponseWriter, *http.Request) { t.Fatal("handler should not run") }),
+		goPolicyHost:    "proxy.golang.org",
+		goPolicyPort:    443,
+		goUpstreamHost:  "proxy.golang.org",
+		goUpstreamPort:  443,
+		sumPolicyHost:   "sum.golang.org",
+		sumPolicyPort:   443,
+		sumUpstreamHost: "sum.golang.org",
+		sumUpstreamPort: 443,
+	}, nil)
+
+	req := httptest.NewRequest(http.MethodHead, "/goproxy/github.com/pkg/errors/@v/list", nil)
+	req = withScope(req, registryTestScope("proxy.golang.org"))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", w.Code)
+	}
+	if got := w.Header().Get(reasonCodeHeader); got != reasonMethodNotAllowed {
+		t.Fatalf("expected reason %s, got %q", reasonMethodNotAllowed, got)
 	}
 }

--- a/internal/gateway/goproxy_cached_test.go
+++ b/internal/gateway/goproxy_cached_test.go
@@ -1,0 +1,161 @@
+package gateway
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type stubGoProxyHandlerProvider struct {
+	goHandler       http.Handler
+	sumdbHandler    http.Handler
+	goPolicyHost    string
+	goPolicyPort    int
+	goUpstreamHost  string
+	goUpstreamPort  int
+	sumPolicyHost   string
+	sumPolicyPort   int
+	sumUpstreamHost string
+	sumUpstreamPort int
+	err             error
+}
+
+func (s *stubGoProxyHandlerProvider) GoProxyUpstream() (string, int, string, int, error) {
+	if s.err != nil {
+		return "", 0, "", 0, s.err
+	}
+	return s.goPolicyHost, s.goPolicyPort, s.goUpstreamHost, s.goUpstreamPort, nil
+}
+
+func (s *stubGoProxyHandlerProvider) GoProxyHandler() (http.Handler, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.goHandler, nil
+}
+
+func (s *stubGoProxyHandlerProvider) SumDBUpstream() (string, int, string, int, error) {
+	if s.err != nil {
+		return "", 0, "", 0, s.err
+	}
+	return s.sumPolicyHost, s.sumPolicyPort, s.sumUpstreamHost, s.sumUpstreamPort, nil
+}
+
+func (s *stubGoProxyHandlerProvider) SumDBHandler() (http.Handler, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.sumdbHandler, nil
+}
+
+func TestCachedGoProxyHandlerStripsPrefixAndDelegates(t *testing.T) {
+	t.Parallel()
+
+	var capturedPath string
+	h := newCachedGoProxyHandler(&stubGoProxyHandlerProvider{
+		goHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedPath = r.URL.Path
+			w.WriteHeader(http.StatusOK)
+		}),
+		goPolicyHost:    "proxy.golang.org",
+		goPolicyPort:    443,
+		goUpstreamHost:  "proxy.golang.org",
+		goUpstreamPort:  443,
+		sumPolicyHost:   "sum.golang.org",
+		sumPolicyPort:   443,
+		sumUpstreamHost: "sum.golang.org",
+		sumUpstreamPort: 443,
+	}, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/goproxy/github.com/pkg/errors/@v/list", nil)
+	req = withScope(req, registryTestScope("proxy.golang.org"))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	if want := "/github.com/pkg/errors/@v/list"; capturedPath != want {
+		t.Fatalf("expected backend path %q, got %q", want, capturedPath)
+	}
+}
+
+func TestCachedGoProxyHandlerDelegatesSumDBPath(t *testing.T) {
+	t.Parallel()
+
+	var capturedPath string
+	h := newCachedGoProxyHandler(&stubGoProxyHandlerProvider{
+		goHandler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			t.Fatal("goproxy handler should not handle sumdb path")
+		}),
+		sumdbHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedPath = r.URL.Path
+			w.WriteHeader(http.StatusOK)
+		}),
+		goPolicyHost:    "proxy.golang.org",
+		goPolicyPort:    443,
+		goUpstreamHost:  "proxy.golang.org",
+		goUpstreamPort:  443,
+		sumPolicyHost:   "sum.golang.org",
+		sumPolicyPort:   443,
+		sumUpstreamHost: "sum.golang.org",
+		sumUpstreamPort: 443,
+	}, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/goproxy/sumdb/sum.golang.org/supported", nil)
+	req = withScope(req, registryTestScope("sum.golang.org"))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	if want := "/sumdb/sum.golang.org/supported"; capturedPath != want {
+		t.Fatalf("expected backend path %q, got %q", want, capturedPath)
+	}
+}
+
+func TestCachedGoProxyHandlerDeniesUnallowedHost(t *testing.T) {
+	t.Parallel()
+
+	h := newCachedGoProxyHandler(&stubGoProxyHandlerProvider{
+		goHandler:       http.HandlerFunc(func(http.ResponseWriter, *http.Request) { t.Fatal("handler should not run") }),
+		sumdbHandler:    http.HandlerFunc(func(http.ResponseWriter, *http.Request) { t.Fatal("handler should not run") }),
+		goPolicyHost:    "proxy.golang.org",
+		goPolicyPort:    443,
+		goUpstreamHost:  "proxy.golang.org",
+		goUpstreamPort:  443,
+		sumPolicyHost:   "sum.golang.org",
+		sumPolicyPort:   443,
+		sumUpstreamHost: "sum.golang.org",
+		sumUpstreamPort: 443,
+	}, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/goproxy/github.com/pkg/errors/@v/list", nil)
+	req = withScope(req, registryTestScope("github.com"))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", w.Code)
+	}
+	if got := w.Header().Get(reasonCodeHeader); got != reasonHostNotAllowed {
+		t.Fatalf("expected reason %s, got %q", reasonHostNotAllowed, got)
+	}
+}
+
+func TestCachedGoProxyHandlerUnavailable(t *testing.T) {
+	t.Parallel()
+
+	h := newCachedGoProxyHandler(&stubGoProxyHandlerProvider{err: errors.New("unavailable")}, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/goproxy/github.com/pkg/errors/@v/list", nil)
+	req = withScope(req, registryTestScope("proxy.golang.org"))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("expected 502, got %d", w.Code)
+	}
+}

--- a/internal/gateway/path_test.go
+++ b/internal/gateway/path_test.go
@@ -13,7 +13,10 @@ func TestCanonicalisePathValid(t *testing.T) {
 		{"/git/github.com/org/repo.git/info/refs", "/git/github.com/org/repo.git/info/refs"},
 		{"/git/github.com/org/repo", "/git/github.com/org/repo"},
 		{"/registry/npmjs.org/pkg", "/registry/npmjs.org/pkg"},
+		{"/goproxy/github.com/pkg/errors/@v/list", "/goproxy/github.com/pkg/errors/@v/list"},
+		{"/goproxy/sumdb/sum.golang.org/supported", "/goproxy/sumdb/sum.golang.org/supported"},
 		{"/rubygems/versions", "/rubygems/versions"},
+		{"/fetch/dl.google.com/go/go1.26.2.linux-amd64.tar.gz", "/fetch/dl.google.com/go/go1.26.2.linux-amd64.tar.gz"},
 		{"/meta/health", "/meta/health"},
 	}
 	for _, tt := range tests {

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -27,7 +27,9 @@ const (
 
 	RouteGit      = "/git/"
 	RouteRegistry = "/registry/"
+	RouteGoProxy  = "/goproxy/"
 	RouteRubyGems = "/rubygems/"
+	RouteFetch    = "/fetch/"
 	RouteSecrets  = "/secrets/"
 	RouteMeta     = "/meta/"
 )
@@ -35,7 +37,9 @@ const (
 var serviceRoutes = []string{
 	RouteGit,
 	RouteRegistry,
+	RouteGoProxy,
 	RouteRubyGems,
+	RouteFetch,
 	RouteSecrets,
 	RouteMeta,
 }
@@ -223,10 +227,22 @@ func NewServer(cfg ServerConfig) *Server {
 		mux.HandleFunc(RouteRegistry, stubHandler("registry"))
 	}
 
+	if cfg.ContentCache != nil && cfg.ContentCache.HasGoProxyHandler() && cfg.ContentCache.HasSumDBHandler() {
+		mux.Handle(RouteGoProxy, newCachedGoProxyHandler(cfg.ContentCache, cfg.Logger))
+	} else {
+		mux.HandleFunc(RouteGoProxy, stubHandler("goproxy"))
+	}
+
 	if cfg.ContentCache != nil && cfg.ContentCache.HasRubyGemsHandler() {
 		mux.Handle(RouteRubyGems, newCachedRubyGemsHandler(cfg.ContentCache, cfg.Logger))
 	} else {
 		mux.HandleFunc(RouteRubyGems, stubHandler("rubygems"))
+	}
+
+	if cfg.ContentCache != nil && cfg.ContentCache.HasFetchHandler() {
+		mux.Handle(RouteFetch, newCachedFetchHandler(cfg.ContentCache, cfg.Logger))
+	} else {
+		mux.HandleFunc(RouteFetch, stubHandler("fetch"))
 	}
 
 	mux.HandleFunc(RouteSecrets, stubHandler("secrets"))
@@ -472,8 +488,14 @@ func gatewayServiceForPath(path string) string {
 		return "git"
 	case strings.HasPrefix(path, RouteRegistry):
 		return "registry"
+	case strings.HasPrefix(path, "/goproxy/sumdb/"):
+		return "sumdb"
+	case strings.HasPrefix(path, RouteGoProxy):
+		return "goproxy"
 	case strings.HasPrefix(path, RouteRubyGems):
 		return "rubygems"
+	case strings.HasPrefix(path, RouteFetch):
+		return "fetch"
 	case strings.HasPrefix(path, RouteSecrets):
 		return "secrets"
 	case strings.HasPrefix(path, RouteMeta):

--- a/internal/gateway/server_test.go
+++ b/internal/gateway/server_test.go
@@ -97,6 +97,30 @@ func TestGatewayServiceForPathClassifiesRubyGems(t *testing.T) {
 	}
 }
 
+func TestGatewayServiceForPathClassifiesGoProxy(t *testing.T) {
+	t.Parallel()
+
+	if got, want := gatewayServiceForPath("/goproxy/github.com/pkg/errors/@v/list"), "goproxy"; got != want {
+		t.Fatalf("unexpected service classification: got %q want %q", got, want)
+	}
+}
+
+func TestGatewayServiceForPathClassifiesSumDB(t *testing.T) {
+	t.Parallel()
+
+	if got, want := gatewayServiceForPath("/goproxy/sumdb/sum.golang.org/supported"), "sumdb"; got != want {
+		t.Fatalf("unexpected service classification: got %q want %q", got, want)
+	}
+}
+
+func TestGatewayServiceForPathClassifiesFetch(t *testing.T) {
+	t.Parallel()
+
+	if got, want := gatewayServiceForPath("/fetch/dl.google.com/go/go1.26.2.linux-amd64.tar.gz"), "fetch"; got != want {
+		t.Fatalf("unexpected service classification: got %q want %q", got, want)
+	}
+}
+
 func TestTracingMiddlewareUsesActiveExecutionTrace(t *testing.T) {
 	t.Parallel()
 

--- a/internal/observability/contract.go
+++ b/internal/observability/contract.go
@@ -78,6 +78,7 @@ const (
 
 	ReasonHostNotAllowed        = "host_not_allowed"
 	ReasonMethodNotAllowed      = "method_not_allowed"
+	ReasonInvalidRequest        = "invalid_request"
 	ReasonUpstreamError         = "upstream_error"
 	ReasonUnknownRegistryPrefix = "unknown_registry_prefix"
 	ReasonProxied               = "proxied"

--- a/internal/observability/observability.go
+++ b/internal/observability/observability.go
@@ -32,6 +32,8 @@ const (
 	defaultTraceName = "github.com/buildkite/cleanroom"
 )
 
+var otelErrorHandlerMu sync.Mutex
+
 type Options struct {
 	Config         runtimeconfig.ObservabilityConfig
 	ServiceName    string
@@ -106,9 +108,10 @@ func Start(ctx context.Context, opts Options) (*Runtime, error) {
 }
 
 type runtimeErrorReporter struct {
-	mu      sync.Mutex
-	report  func(error)
-	ignored atomic.Bool
+	mu       sync.Mutex
+	report   func(error)
+	previous otel.ErrorHandler
+	ignored  atomic.Bool
 }
 
 func (r *runtimeErrorReporter) Handle(err error) {
@@ -136,10 +139,53 @@ func installErrorHandler(report func(error)) (*runtimeErrorReporter, func()) {
 	if report == nil {
 		return nil, func() {}
 	}
+
+	otelErrorHandlerMu.Lock()
 	previous := otel.GetErrorHandler()
-	reporter := &runtimeErrorReporter{report: report}
+	reporter := &runtimeErrorReporter{
+		report:   report,
+		previous: previous,
+	}
 	otel.SetErrorHandler(reporter)
-	return reporter, func() { otel.SetErrorHandler(previous) }
+	otelErrorHandlerMu.Unlock()
+
+	return reporter, func() { restoreErrorHandler(reporter) }
+}
+
+func restoreErrorHandler(reporter *runtimeErrorReporter) {
+	if reporter == nil {
+		return
+	}
+
+	otelErrorHandlerMu.Lock()
+	defer otelErrorHandlerMu.Unlock()
+
+	current := otel.GetErrorHandler()
+	if current == reporter {
+		otel.SetErrorHandler(reporter.previous)
+		return
+	}
+
+	currentReporter, ok := current.(*runtimeErrorReporter)
+	if !ok {
+		return
+	}
+	currentReporter.removeNested(reporter, reporter.previous)
+}
+
+func (r *runtimeErrorReporter) removeNested(target *runtimeErrorReporter, replacement otel.ErrorHandler) bool {
+	if r == nil || target == nil {
+		return false
+	}
+	if r.previous == target {
+		r.previous = replacement
+		return true
+	}
+	next, ok := r.previous.(*runtimeErrorReporter)
+	if !ok {
+		return false
+	}
+	return next.removeNested(target, replacement)
 }
 
 func (r *Runtime) Tracer(name string, options ...trace.TracerOption) trace.Tracer {

--- a/internal/observability/observability_test.go
+++ b/internal/observability/observability_test.go
@@ -324,6 +324,126 @@ func TestStartSuppressesConfiguredReporterDuringShutdown(t *testing.T) {
 	}
 }
 
+func TestStartPreservesNestedOTelErrorHandlersAcrossRuntimeShutdown(t *testing.T) {
+	original := otel.GetErrorHandler()
+	t.Cleanup(func() { otel.SetErrorHandler(original) })
+
+	previousErrCh := make(chan error, 1)
+	otel.SetErrorHandler(otel.ErrorHandlerFunc(func(err error) {
+		previousErrCh <- err
+	}))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/x-protobuf")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte{0x0a, 0x00})
+	}))
+	defer server.Close()
+
+	reportedErrCh1 := make(chan error, 1)
+	runtime1, err := Start(context.Background(), Options{
+		Config: runtimeconfig.ObservabilityConfig{
+			Enabled: true,
+			OTLP: runtimeconfig.OTLPConfig{
+				Endpoint: server.URL,
+				Protocol: "http/protobuf",
+			},
+		},
+		ServiceName: "cleanroom-cli-1",
+		ReportError: func(err error) {
+			reportedErrCh1 <- err
+		},
+	})
+	if err != nil {
+		t.Fatalf("Start returned error: %v", err)
+	}
+
+	reportedErrCh2 := make(chan error, 2)
+	runtime2, err := Start(context.Background(), Options{
+		Config: runtimeconfig.ObservabilityConfig{
+			Enabled: true,
+			OTLP: runtimeconfig.OTLPConfig{
+				Endpoint: server.URL,
+				Protocol: "http/protobuf",
+			},
+		},
+		ServiceName: "cleanroom-cli-2",
+		ReportError: func(err error) {
+			reportedErrCh2 <- err
+		},
+	})
+	if err != nil {
+		t.Fatalf("Start returned error: %v", err)
+	}
+
+	otel.Handle(errors.New("before shutdown"))
+
+	select {
+	case err := <-reportedErrCh2:
+		if got, want := err.Error(), "before shutdown"; got != want {
+			t.Fatalf("unexpected nested reporter error: got %q want %q", got, want)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for nested reporter")
+	}
+
+	select {
+	case err := <-reportedErrCh1:
+		t.Fatalf("expected newer runtime to own otel errors, got %v", err)
+	default:
+	}
+	select {
+	case err := <-previousErrCh:
+		t.Fatalf("expected previous handler to be shadowed, got %v", err)
+	default:
+	}
+
+	shutdownCtx1, cancel1 := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel1()
+	if err := runtime1.Shutdown(shutdownCtx1); err != nil {
+		t.Fatalf("Shutdown returned error: %v", err)
+	}
+
+	otel.Handle(errors.New("after first shutdown"))
+
+	select {
+	case err := <-reportedErrCh2:
+		if got, want := err.Error(), "after first shutdown"; got != want {
+			t.Fatalf("unexpected error after first shutdown: got %q want %q", got, want)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for remaining runtime reporter")
+	}
+
+	select {
+	case err := <-reportedErrCh1:
+		t.Fatalf("expected shutdown runtime not to resume ownership, got %v", err)
+	default:
+	}
+	select {
+	case err := <-previousErrCh:
+		t.Fatalf("expected previous handler to remain shadowed, got %v", err)
+	default:
+	}
+
+	shutdownCtx2, cancel2 := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel2()
+	if err := runtime2.Shutdown(shutdownCtx2); err != nil {
+		t.Fatalf("Shutdown returned error: %v", err)
+	}
+
+	otel.Handle(errors.New("after second shutdown"))
+
+	select {
+	case err := <-previousErrCh:
+		if got, want := err.Error(), "after second shutdown"; got != want {
+			t.Fatalf("unexpected restored handler error: got %q want %q", got, want)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for previous handler restoration")
+	}
+}
+
 func TestRuntimeErrorReporterSuppressWaitsForInFlightHandle(t *testing.T) {
 	enteredReport := make(chan struct{})
 	releaseReport := make(chan struct{})


### PR DESCRIPTION
## Summary
- add cached `/goproxy/` and `/fetch/` gateway routes backed by `content-cache`, including sumdb handling under `/goproxy/sumdb/`
- inject `GOPROXY` and `MISE_GO_DOWNLOAD_MIRROR` when the corresponding upstream hosts are allowlisted so Go modules and Go SDK downloads route through the gateway
- update gateway tests, backend env tests, observability reason codes, and docs/examples to cover the new behavior

## Why
Cleanroom already routed Git, OCI, and RubyGems traffic through the shared gateway, but Go module resolution and `mise` Go SDK downloads still depended on direct guest egress. This change brings those flows under the same host-side gateway and cache path while preserving sandbox policy checks against the source upstream hosts.

## Testing
- `mise exec -- go test ./...`
- `git diff --check`
