### PR TITLE
fix: seed localhost hosts entries in guests

### DIFF
--- a/internal/backend/darwinvz/guest_init_script.go
+++ b/internal/backend/darwinvz/guest_init_script.go
@@ -31,10 +31,13 @@ export HOME=/root
 export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/.local/bin
 
 mkdir -p /etc 2>/dev/null || true
-cat >/etc/hosts <<'EOF'
-127.0.0.1 localhost
-::1 localhost ip6-localhost ip6-loopback
-EOF
+touch /etc/hosts 2>/dev/null || true
+if ! grep -Eq '^[[:space:]]*127\.0\.0\.1([[:space:]]|$).*localhost([[:space:]]|$)' /etc/hosts 2>/dev/null; then
+  printf '127.0.0.1 localhost\n' >>/etc/hosts
+fi
+if ! grep -Eq '^[[:space:]]*::1([[:space:]]|$).*localhost([[:space:]]|$)' /etc/hosts 2>/dev/null; then
+  printf '::1 localhost ip6-localhost ip6-loopback\n' >>/etc/hosts
+fi
 
 cmdline="$(cat /proc/cmdline 2>/dev/null || true)"
 arg_value() {

--- a/internal/backend/darwinvz/guest_init_script.go
+++ b/internal/backend/darwinvz/guest_init_script.go
@@ -30,6 +30,12 @@ mount -t tmpfs tmpfs /tmp 2>/dev/null || true
 export HOME=/root
 export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/.local/bin
 
+mkdir -p /etc 2>/dev/null || true
+cat >/etc/hosts <<'EOF'
+127.0.0.1 localhost
+::1 localhost ip6-localhost ip6-loopback
+EOF
+
 cmdline="$(cat /proc/cmdline 2>/dev/null || true)"
 arg_value() {
   key="$1"

--- a/internal/backend/darwinvz/guest_init_script.go
+++ b/internal/backend/darwinvz/guest_init_script.go
@@ -33,10 +33,10 @@ export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/.
 mkdir -p /etc 2>/dev/null || true
 touch /etc/hosts 2>/dev/null || true
 if ! grep -Eq '^[[:space:]]*127\.0\.0\.1([[:space:]]|$).*localhost([[:space:]]|$)' /etc/hosts 2>/dev/null; then
-  printf '127.0.0.1 localhost\n' >>/etc/hosts
+  printf '127.0.0.1 localhost\n' >>/etc/hosts 2>/dev/null || true
 fi
 if ! grep -Eq '^[[:space:]]*::1([[:space:]]|$).*localhost([[:space:]]|$)' /etc/hosts 2>/dev/null; then
-  printf '::1 localhost ip6-localhost ip6-loopback\n' >>/etc/hosts
+  printf '::1 localhost ip6-localhost ip6-loopback\n' >>/etc/hosts 2>/dev/null || true
 fi
 
 cmdline="$(cat /proc/cmdline 2>/dev/null || true)"

--- a/internal/backend/darwinvz/guest_init_script.go
+++ b/internal/backend/darwinvz/guest_init_script.go
@@ -32,12 +32,19 @@ export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/.
 
 mkdir -p /etc 2>/dev/null || true
 touch /etc/hosts 2>/dev/null || true
-if ! grep -Eq '^[[:space:]]*127\.0\.0\.1([[:space:]]|$).*localhost([[:space:]]|$)' /etc/hosts 2>/dev/null; then
-  printf '127.0.0.1 localhost\n' >>/etc/hosts 2>/dev/null || true
-fi
-if ! grep -Eq '^[[:space:]]*::1([[:space:]]|$).*localhost([[:space:]]|$)' /etc/hosts 2>/dev/null; then
-  printf '::1 localhost ip6-localhost ip6-loopback\n' >>/etc/hosts 2>/dev/null || true
-fi
+append_hosts_line_if_missing() {
+  pattern="$1"
+  line="$2"
+  if grep -Eq "$pattern" /etc/hosts 2>/dev/null; then
+    return 0
+  fi
+  if [ -s /etc/hosts ] && [ -n "$(tail -c 1 /etc/hosts 2>/dev/null || true)" ]; then
+    printf '\n' >>/etc/hosts 2>/dev/null || true
+  fi
+  printf '%s\n' "$line" >>/etc/hosts 2>/dev/null || true
+}
+append_hosts_line_if_missing '^[[:space:]]*127\.0\.0\.1([[:space:]]|$).*localhost([[:space:]]|$)' '127.0.0.1 localhost'
+append_hosts_line_if_missing '^[[:space:]]*::1([[:space:]]|$).*localhost([[:space:]]|$)' '::1 localhost ip6-localhost ip6-loopback'
 
 cmdline="$(cat /proc/cmdline 2>/dev/null || true)"
 arg_value() {

--- a/internal/backend/darwinvz/guest_init_script_test.go
+++ b/internal/backend/darwinvz/guest_init_script_test.go
@@ -31,6 +31,12 @@ func TestGuestInitScriptBootstrapsNetwork(t *testing.T) {
 	if !strings.Contains(guestInitScriptTemplate, "::1 localhost ip6-localhost ip6-loopback") {
 		t.Fatal("expected localhost IPv6 hosts entry in init script")
 	}
+	if strings.Contains(guestInitScriptTemplate, "cat >/etc/hosts") {
+		t.Fatal("expected init script to preserve existing hosts entries")
+	}
+	if !strings.Contains(guestInitScriptTemplate, ">>/etc/hosts") {
+		t.Fatal("expected init script to append missing localhost hosts entries")
+	}
 	if !strings.Contains(guestInitScriptTemplate, "ip link set lo up") {
 		t.Fatal("expected loopback interface setup in init script")
 	}

--- a/internal/backend/darwinvz/guest_init_script_test.go
+++ b/internal/backend/darwinvz/guest_init_script_test.go
@@ -34,11 +34,17 @@ func TestGuestInitScriptBootstrapsNetwork(t *testing.T) {
 	if strings.Contains(guestInitScriptTemplate, "cat >/etc/hosts") {
 		t.Fatal("expected init script to preserve existing hosts entries")
 	}
-	if !strings.Contains(guestInitScriptTemplate, ">>/etc/hosts") {
-		t.Fatal("expected init script to append missing localhost hosts entries")
+	if !strings.Contains(guestInitScriptTemplate, "append_hosts_line_if_missing()") {
+		t.Fatal("expected init script to use helper for missing localhost hosts entries")
 	}
-	if !strings.Contains(guestInitScriptTemplate, ">>/etc/hosts 2>/dev/null || true") {
-		t.Fatal("expected localhost hosts entry append to be best-effort")
+	if !strings.Contains(guestInitScriptTemplate, "tail -c 1 /etc/hosts") {
+		t.Fatal("expected localhost hosts entry helper to detect missing trailing newline")
+	}
+	if !strings.Contains(guestInitScriptTemplate, "printf '\\n' >>/etc/hosts 2>/dev/null || true") {
+		t.Fatal("expected localhost hosts entry helper to insert a separator newline when needed")
+	}
+	if !strings.Contains(guestInitScriptTemplate, "printf '%s\\n' \"$line\" >>/etc/hosts 2>/dev/null || true") {
+		t.Fatal("expected localhost hosts entry helper to append lines best-effort")
 	}
 	if !strings.Contains(guestInitScriptTemplate, "ip link set lo up") {
 		t.Fatal("expected loopback interface setup in init script")

--- a/internal/backend/darwinvz/guest_init_script_test.go
+++ b/internal/backend/darwinvz/guest_init_script_test.go
@@ -25,6 +25,12 @@ func TestGuestInitScriptBootstrapsNetwork(t *testing.T) {
 	if !strings.Contains(guestInitScriptTemplate, "setup_guest_network") {
 		t.Fatal("expected guest network setup function in init script")
 	}
+	if !strings.Contains(guestInitScriptTemplate, "127.0.0.1 localhost") {
+		t.Fatal("expected localhost IPv4 hosts entry in init script")
+	}
+	if !strings.Contains(guestInitScriptTemplate, "::1 localhost ip6-localhost ip6-loopback") {
+		t.Fatal("expected localhost IPv6 hosts entry in init script")
+	}
 	if !strings.Contains(guestInitScriptTemplate, "ip link set lo up") {
 		t.Fatal("expected loopback interface setup in init script")
 	}

--- a/internal/backend/darwinvz/guest_init_script_test.go
+++ b/internal/backend/darwinvz/guest_init_script_test.go
@@ -37,6 +37,9 @@ func TestGuestInitScriptBootstrapsNetwork(t *testing.T) {
 	if !strings.Contains(guestInitScriptTemplate, ">>/etc/hosts") {
 		t.Fatal("expected init script to append missing localhost hosts entries")
 	}
+	if !strings.Contains(guestInitScriptTemplate, ">>/etc/hosts 2>/dev/null || true") {
+		t.Fatal("expected localhost hosts entry append to be best-effort")
+	}
 	if !strings.Contains(guestInitScriptTemplate, "ip link set lo up") {
 		t.Fatal("expected loopback interface setup in init script")
 	}

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -160,12 +160,19 @@ export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/.
 
 mkdir -p /etc 2>/dev/null || true
 touch /etc/hosts 2>/dev/null || true
-if ! grep -Eq '^[[:space:]]*127\.0\.0\.1([[:space:]]|$).*localhost([[:space:]]|$)' /etc/hosts 2>/dev/null; then
-  printf '127.0.0.1 localhost\n' >>/etc/hosts 2>/dev/null || true
-fi
-if ! grep -Eq '^[[:space:]]*::1([[:space:]]|$).*localhost([[:space:]]|$)' /etc/hosts 2>/dev/null; then
-  printf '::1 localhost ip6-localhost ip6-loopback\n' >>/etc/hosts 2>/dev/null || true
-fi
+append_hosts_line_if_missing() {
+  pattern="$1"
+  line="$2"
+  if grep -Eq "$pattern" /etc/hosts 2>/dev/null; then
+    return 0
+  fi
+  if [ -s /etc/hosts ] && [ -n "$(tail -c 1 /etc/hosts 2>/dev/null || true)" ]; then
+    printf '\n' >>/etc/hosts 2>/dev/null || true
+  fi
+  printf '%s\n' "$line" >>/etc/hosts 2>/dev/null || true
+}
+append_hosts_line_if_missing '^[[:space:]]*127\.0\.0\.1([[:space:]]|$).*localhost([[:space:]]|$)' '127.0.0.1 localhost'
+append_hosts_line_if_missing '^[[:space:]]*::1([[:space:]]|$).*localhost([[:space:]]|$)' '::1 localhost ip6-localhost ip6-loopback'
 
 cmdline="$(cat /proc/cmdline 2>/dev/null || true)"
 arg_value() {

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -159,10 +159,13 @@ export HOME=/root
 export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/.local/bin
 
 mkdir -p /etc 2>/dev/null || true
-cat >/etc/hosts <<'EOF'
-127.0.0.1 localhost
-::1 localhost ip6-localhost ip6-loopback
-EOF
+touch /etc/hosts 2>/dev/null || true
+if ! grep -Eq '^[[:space:]]*127\.0\.0\.1([[:space:]]|$).*localhost([[:space:]]|$)' /etc/hosts 2>/dev/null; then
+  printf '127.0.0.1 localhost\n' >>/etc/hosts
+fi
+if ! grep -Eq '^[[:space:]]*::1([[:space:]]|$).*localhost([[:space:]]|$)' /etc/hosts 2>/dev/null; then
+  printf '::1 localhost ip6-localhost ip6-loopback\n' >>/etc/hosts
+fi
 
 cmdline="$(cat /proc/cmdline 2>/dev/null || true)"
 arg_value() {

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -158,6 +158,12 @@ mount -t tmpfs tmpfs /tmp 2>/dev/null || true
 export HOME=/root
 export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/.local/bin
 
+mkdir -p /etc 2>/dev/null || true
+cat >/etc/hosts <<'EOF'
+127.0.0.1 localhost
+::1 localhost ip6-localhost ip6-loopback
+EOF
+
 cmdline="$(cat /proc/cmdline 2>/dev/null || true)"
 arg_value() {
   key="$1"

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -161,10 +161,10 @@ export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/.
 mkdir -p /etc 2>/dev/null || true
 touch /etc/hosts 2>/dev/null || true
 if ! grep -Eq '^[[:space:]]*127\.0\.0\.1([[:space:]]|$).*localhost([[:space:]]|$)' /etc/hosts 2>/dev/null; then
-  printf '127.0.0.1 localhost\n' >>/etc/hosts
+  printf '127.0.0.1 localhost\n' >>/etc/hosts 2>/dev/null || true
 fi
 if ! grep -Eq '^[[:space:]]*::1([[:space:]]|$).*localhost([[:space:]]|$)' /etc/hosts 2>/dev/null; then
-  printf '::1 localhost ip6-localhost ip6-loopback\n' >>/etc/hosts
+  printf '::1 localhost ip6-localhost ip6-loopback\n' >>/etc/hosts 2>/dev/null || true
 fi
 
 cmdline="$(cat /proc/cmdline 2>/dev/null || true)"

--- a/internal/backend/firecracker/guest_init_script_test.go
+++ b/internal/backend/firecracker/guest_init_script_test.go
@@ -22,3 +22,12 @@ func TestGuestInitScriptAutostartsDockerWhenAvailable(t *testing.T) {
 		t.Fatal("expected init script to wait for dockerd API readiness")
 	}
 }
+
+func TestGuestInitScriptSeedsLocalhostHostsEntries(t *testing.T) {
+	if !strings.Contains(guestInitScriptTemplate, "127.0.0.1 localhost") {
+		t.Fatal("expected localhost IPv4 hosts entry in init script")
+	}
+	if !strings.Contains(guestInitScriptTemplate, "::1 localhost ip6-localhost ip6-loopback") {
+		t.Fatal("expected localhost IPv6 hosts entry in init script")
+	}
+}

--- a/internal/backend/firecracker/guest_init_script_test.go
+++ b/internal/backend/firecracker/guest_init_script_test.go
@@ -33,10 +33,16 @@ func TestGuestInitScriptSeedsLocalhostHostsEntries(t *testing.T) {
 	if strings.Contains(guestInitScriptTemplate, "cat >/etc/hosts") {
 		t.Fatal("expected init script to preserve existing hosts entries")
 	}
-	if !strings.Contains(guestInitScriptTemplate, ">>/etc/hosts") {
-		t.Fatal("expected init script to append missing localhost hosts entries")
+	if !strings.Contains(guestInitScriptTemplate, "append_hosts_line_if_missing()") {
+		t.Fatal("expected init script to use helper for missing localhost hosts entries")
 	}
-	if !strings.Contains(guestInitScriptTemplate, ">>/etc/hosts 2>/dev/null || true") {
-		t.Fatal("expected localhost hosts entry append to be best-effort")
+	if !strings.Contains(guestInitScriptTemplate, "tail -c 1 /etc/hosts") {
+		t.Fatal("expected localhost hosts entry helper to detect missing trailing newline")
+	}
+	if !strings.Contains(guestInitScriptTemplate, "printf '\\n' >>/etc/hosts 2>/dev/null || true") {
+		t.Fatal("expected localhost hosts entry helper to insert a separator newline when needed")
+	}
+	if !strings.Contains(guestInitScriptTemplate, "printf '%s\\n' \"$line\" >>/etc/hosts 2>/dev/null || true") {
+		t.Fatal("expected localhost hosts entry helper to append lines best-effort")
 	}
 }

--- a/internal/backend/firecracker/guest_init_script_test.go
+++ b/internal/backend/firecracker/guest_init_script_test.go
@@ -30,4 +30,10 @@ func TestGuestInitScriptSeedsLocalhostHostsEntries(t *testing.T) {
 	if !strings.Contains(guestInitScriptTemplate, "::1 localhost ip6-localhost ip6-loopback") {
 		t.Fatal("expected localhost IPv6 hosts entry in init script")
 	}
+	if strings.Contains(guestInitScriptTemplate, "cat >/etc/hosts") {
+		t.Fatal("expected init script to preserve existing hosts entries")
+	}
+	if !strings.Contains(guestInitScriptTemplate, ">>/etc/hosts") {
+		t.Fatal("expected init script to append missing localhost hosts entries")
+	}
 }

--- a/internal/backend/firecracker/guest_init_script_test.go
+++ b/internal/backend/firecracker/guest_init_script_test.go
@@ -36,4 +36,7 @@ func TestGuestInitScriptSeedsLocalhostHostsEntries(t *testing.T) {
 	if !strings.Contains(guestInitScriptTemplate, ">>/etc/hosts") {
 		t.Fatal("expected init script to append missing localhost hosts entries")
 	}
+	if !strings.Contains(guestInitScriptTemplate, ">>/etc/hosts 2>/dev/null || true") {
+		t.Fatal("expected localhost hosts entry append to be best-effort")
+	}
 }


### PR DESCRIPTION
## Summary
- seed `/etc/hosts` in both guest init paths with standard localhost entries
- add regression checks for the generated guest init scripts

## Problem
Some workloads resolve `localhost` through the system resolver rather than hard-coding `127.0.0.1`. Our guests brought loopback up, but they did not populate `/etc/hosts`, so `localhost` lookups could fall through to DNS and fail.

That showed up when running the buildkite-agent example as:

```text
listen tcp: lookup localhost on 10.233.0.1:53: no such host
```

## Testing
- `go test ./internal/backend/darwinvz ./internal/backend/firecracker -run 'TestGuestInitScript(BootstrapsNetwork|SeedsLocalhostHostsEntries|AutostartsDockerWhenAvailable)'`
- `cleanroom exec --repo-url https://github.com/buildkite/agent.git --repo-commit 9eba5c5b83807b9aaaaffef6225be1f62c8d7d6c -- mise x -- go test ./internal/job -run TestAddingToKnownHosts -count=1`
