### PR TITLE
cli: Remove automatic failure footers

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,8 +436,8 @@ cleanroom version
 
 Failure flow:
 
-- `cleanroom exec` and `cleanroom console` print `sandbox_id`, `execution_id`, and `trace_id` on failure when available.
-- When `observability.traces.url_template` is configured, failure footers also print `trace_url`.
+- `cleanroom exec` and `cleanroom console` keep failure stderr focused on streamed guest output; they do not append `sandbox_id`, `execution_id`, `trace_id`, or `trace_url` footers automatically.
+- Use `--print-sandbox-id` when you need to correlate a kept or reused sandbox, and use `cleanroom status --last` or `cleanroom execution inspect ...` for retained diagnostics.
 - Attached `cleanroom exec` and `cleanroom console` streams may print warning notices on stderr for policy observations such as blocked connections or disallowed DNS lookups.
 - `cleanroom sandbox inspect <sandbox-id>` shows sandbox state plus `last_execution_id` and `active_execution_id`.
 - `cleanroom execution inspect ...` is the control-plane view for execution status, retained stdout/stderr, image metadata, `trace_id`, optional `trace_url`, and observability.

--- a/docs/api.md
+++ b/docs/api.md
@@ -357,13 +357,13 @@ Signal behavior:
 2. Second `Ctrl-C`: force detach client stream and return immediately.
 
 Failure UX:
-- Always print `sandbox_id`, `execution_id`, and `trace_id` when available.
-- When `observability.traces.url_template` is configured, also print `trace_url`.
-- On `exec` or `console` failure, also print a ready-to-run `cleanroom execution inspect ...` follow-up command and `artifacts_dir` when available.
+- `exec` and `console` failures preserve streamed guest stdout/stderr and return the guest exit code without appending a diagnostic footer.
+- `cleanroom exec --print-sandbox-id` remains the explicit opt-in for printing the resolved sandbox ID before streaming begins.
+- `cleanroom exec --print-trace-id` remains the explicit opt-in for printing `trace_id` after a successful execution.
 - On policy/runtime deny, print stable reason code and a follow-up command to inspect sandbox or execution state.
 
 Debugging flow:
-1. Start with `cleanroom sandbox inspect <sandbox-id>` when you need the sandbox state or do not yet know the execution ID.
+1. Start with `cleanroom status --last` when you only need the newest retained execution, or `cleanroom sandbox inspect <sandbox-id>` when you already know the sandbox ID.
 2. Use `cleanroom execution inspect <execution-id>` for the canonical execution view, including `trace_id`, optional `trace_url`, and retained observability payload.
 3. Use `cleanroom status --execution-id <execution-id>` for retained local artifacts and raw observability files.
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -31,9 +31,8 @@ instead.
 structured logs with stable correlation fields such as `trace_id`, `span_id`,
 `execution_id`, `sandbox_id`, `backend`, and `reason_code`.
 
-`observability.traces.url_template` is optional. When set, Cleanroom prints
-`trace_url=...` in failure footers and exposes the same URL from
-`cleanroom execution inspect`.
+`observability.traces.url_template` is optional. When set, Cleanroom exposes
+`trace_url` from `cleanroom execution inspect`.
 
 ## Local stack
 
@@ -59,11 +58,10 @@ under the `Cleanroom` folder.
 Use the local stack or your configured OTLP backend to inspect traces and
 execution diagnostics.
 
-- `cleanroom exec` and `cleanroom console` print `sandbox_id`, `execution_id`,
-  and `trace_id` on failure when available.
+- `cleanroom exec` and `cleanroom console` leave failure stderr focused on
+  streamed guest output instead of appending diagnostic footers.
 - `cleanroom exec --print-trace-id` also prints `trace_id` after a successful
   execution when available.
-- When `url_template` is configured, failure footers also print `trace_url`.
 - `cleanroom execution inspect <execution-id>` shows execution status,
   retained stdout and stderr, `trace_id`, optional `trace_url`, and retained
   observability payload.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -534,8 +534,8 @@ CLI:
 - Validation failures (`cleanroom policy validate`, pre-launch compile errors) return non-zero and print structured error details.
 - Launch failures (including `backend_capability_mismatch`) return non-zero before workload execution starts.
 - Runtime policy denies do not change process semantics unless deny prevents command completion; deny events must still be emitted.
-- Non-zero `cleanroom exec` and `cleanroom console` exits print `sandbox_id`, `execution_id`, `trace_id`, and a follow-up `cleanroom execution inspect` command when available.
-- When a trace URL template is configured, those failure footers also print `trace_url`.
+- Non-zero `cleanroom exec` and `cleanroom console` exits preserve streamed stdout/stderr and do not append automatic diagnostic footers.
+- `cleanroom exec --print-sandbox-id` and `cleanroom exec --print-trace-id` remain the explicit opt-in surfaces for correlation identifiers.
 
 API:
 - `SandboxService.CreateSandbox` returns client error for invalid policy input and conflict/error response for unsatisfied backend requirements.

--- a/internal/cli/console.go
+++ b/internal/cli/console.go
@@ -17,7 +17,6 @@ import (
 	"github.com/buildkite/cleanroom/internal/interactivequic"
 	"github.com/buildkite/cleanroom/internal/observability"
 	"github.com/buildkite/cleanroom/internal/repositorycheckout"
-	"github.com/buildkite/cleanroom/internal/runtimeconfig"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
@@ -70,7 +69,6 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) (runErr error) {
 		observability.SpanConsole,
 		trace.WithAttributes(rootAttrs...),
 	)
-	traceID := traceIDFromContext(rootCtx)
 	defer func() {
 		if sandboxID != "" {
 			rootSpan.SetAttributes(attribute.String(observability.AttrSandboxID, sandboxID))
@@ -124,45 +122,6 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) (runErr error) {
 		printedSandboxID = true
 		return nil
 	}
-	printedExecutionID := false
-	printExecutionID := func() error {
-		if printedExecutionID {
-			return nil
-		}
-		if err := writeExecutionID(os.Stderr, executionID); err != nil {
-			return err
-		}
-		printedExecutionID = true
-		return nil
-	}
-	printedTraceID := false
-	printTraceID := func() error {
-		if printedTraceID {
-			return nil
-		}
-		if err := writeTraceID(os.Stderr, traceID); err != nil {
-			return err
-		}
-		printedTraceID = true
-		return nil
-	}
-	printedTraceURL := false
-	printTraceURL := func() error {
-		if printedTraceURL {
-			return nil
-		}
-		traceURL, err := runtimeconfig.RenderTraceURL(ctx.Config.Observability, traceID, executionID, sandboxID)
-		if err != nil {
-			return err
-		}
-		if err := writeTraceURL(os.Stderr, traceURL); err != nil {
-			return err
-		}
-		if strings.TrimSpace(traceURL) != "" {
-			printedTraceURL = true
-		}
-		return nil
-	}
 	defer func() {
 		if !createdSandbox || !c.Keep {
 			return
@@ -179,36 +138,7 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) (runErr error) {
 		if runErr == nil {
 			return
 		}
-		var extraErr error
-		if err := printSandboxID(); err != nil {
-			extraErr = errors.Join(extraErr, err)
-		}
-		if err := printExecutionID(); err != nil {
-			extraErr = errors.Join(extraErr, err)
-		}
-		if err := printTraceID(); err != nil {
-			extraErr = errors.Join(extraErr, err)
-		}
-		if err := printTraceURL(); err != nil {
-			extraErr = errors.Join(extraErr, err)
-		}
-		if sandboxID != "" && executionID != "" {
-			if err := writeExecutionInspectCommand(os.Stderr, sandboxID, executionID); err != nil {
-				extraErr = errors.Join(extraErr, err)
-			}
-			resp, err := client.InspectExecution(rootCtx, &cleanroomv1.InspectExecutionRequest{
-				SandboxId:   sandboxID,
-				ExecutionId: executionID,
-			})
-			if err == nil {
-				if err := writeArtifactsDir(os.Stderr, resp.GetArtifactsDir()); err != nil {
-					extraErr = errors.Join(extraErr, err)
-				}
-			}
-		}
-		if extraErr != nil {
-			runErr = errors.Join(runErr, extraErr)
-		}
+		// Non-zero exits should leave stderr focused on the streamed command output.
 	}()
 	if c.PrintSandboxID {
 		if err := printSandboxID(); err != nil {

--- a/internal/cli/console_integration_test.go
+++ b/internal/cli/console_integration_test.go
@@ -562,7 +562,7 @@ func TestConsoleIntegrationRoutesBackendWarningsToStderr(t *testing.T) {
 	}
 }
 
-func TestConsoleIntegrationPrintsExecutionHintsOnFailure(t *testing.T) {
+func TestConsoleIntegrationOmitsFailureFooter(t *testing.T) {
 	host, _ := startIntegrationServer(t, &integrationAdapter{
 		runStreamFn: func(_ context.Context, req backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
 			return &backend.ExecutionResult{
@@ -590,16 +590,16 @@ func TestConsoleIntegrationPrintsExecutionHintsOnFailure(t *testing.T) {
 	if got, want := ExitCode(outcome.err), 7; got != want {
 		t.Fatalf("unexpected console exit code: got %d want %d (err=%v)", got, want, outcome.err)
 	}
-	if got := parseSandboxID(outcome.stderr); got == "" {
-		t.Fatalf("expected sandbox_id in failure output, got %q", outcome.stderr)
+	if strings.Contains(outcome.stderr, "sandbox_id=") {
+		t.Fatalf("did not expect sandbox_id footer in failure output, got %q", outcome.stderr)
 	}
-	if got := parseExecutionID(outcome.stderr); got == "" {
-		t.Fatalf("expected execution_id in failure output, got %q", outcome.stderr)
+	if strings.Contains(outcome.stderr, "execution_id=") {
+		t.Fatalf("did not expect execution_id footer in failure output, got %q", outcome.stderr)
 	}
-	if !strings.Contains(outcome.stderr, "inspect_command=cleanroom execution inspect ") {
-		t.Fatalf("expected inspect_command in failure output, got %q", outcome.stderr)
+	if strings.Contains(outcome.stderr, "inspect_command=cleanroom execution inspect ") {
+		t.Fatalf("did not expect inspect_command footer in failure output, got %q", outcome.stderr)
 	}
-	if !strings.Contains(outcome.stderr, "artifacts_dir=/tmp/console-failed") {
-		t.Fatalf("expected artifacts_dir in failure output, got %q", outcome.stderr)
+	if strings.Contains(outcome.stderr, "artifacts_dir=/tmp/console-failed") {
+		t.Fatalf("did not expect artifacts_dir footer in failure output, got %q", outcome.stderr)
 	}
 }

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -11,7 +11,6 @@ import (
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
 	"github.com/buildkite/cleanroom/internal/observability"
 	"github.com/buildkite/cleanroom/internal/repositorycheckout"
-	"github.com/buildkite/cleanroom/internal/runtimeconfig"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
@@ -116,17 +115,6 @@ func (e *ExecCommand) Run(ctx *runtimeContext) (runErr error) {
 		printedSandboxID = true
 		return nil
 	}
-	printedExecutionID := false
-	printExecutionID := func() error {
-		if printedExecutionID {
-			return nil
-		}
-		if err := writeExecutionID(os.Stderr, executionID); err != nil {
-			return err
-		}
-		printedExecutionID = true
-		return nil
-	}
 	printedTraceID := false
 	printTraceID := func() error {
 		if printedTraceID {
@@ -136,23 +124,6 @@ func (e *ExecCommand) Run(ctx *runtimeContext) (runErr error) {
 			return err
 		}
 		printedTraceID = true
-		return nil
-	}
-	printedTraceURL := false
-	printTraceURL := func() error {
-		if printedTraceURL {
-			return nil
-		}
-		traceURL, err := runtimeconfig.RenderTraceURL(ctx.Config.Observability, traceID, executionID, sandboxID)
-		if err != nil {
-			return err
-		}
-		if err := writeTraceURL(os.Stderr, traceURL); err != nil {
-			return err
-		}
-		if strings.TrimSpace(traceURL) != "" {
-			printedTraceURL = true
-		}
 		return nil
 	}
 	defer func() {
@@ -183,36 +154,7 @@ func (e *ExecCommand) Run(ctx *runtimeContext) (runErr error) {
 		if runErr == nil {
 			return
 		}
-		var extraErr error
-		if err := printSandboxID(); err != nil {
-			extraErr = errors.Join(extraErr, err)
-		}
-		if err := printExecutionID(); err != nil {
-			extraErr = errors.Join(extraErr, err)
-		}
-		if err := printTraceID(); err != nil {
-			extraErr = errors.Join(extraErr, err)
-		}
-		if err := printTraceURL(); err != nil {
-			extraErr = errors.Join(extraErr, err)
-		}
-		if sandboxID != "" && executionID != "" {
-			if err := writeExecutionInspectCommand(os.Stderr, sandboxID, executionID); err != nil {
-				extraErr = errors.Join(extraErr, err)
-			}
-			resp, err := client.InspectExecution(rootCtx, &cleanroomv1.InspectExecutionRequest{
-				SandboxId:   sandboxID,
-				ExecutionId: executionID,
-			})
-			if err == nil {
-				if err := writeArtifactsDir(os.Stderr, resp.GetArtifactsDir()); err != nil {
-					extraErr = errors.Join(extraErr, err)
-				}
-			}
-		}
-		if extraErr != nil {
-			runErr = errors.Join(runErr, extraErr)
-		}
+		// Non-zero exits should leave stderr focused on the streamed command output.
 	}()
 	if e.PrintSandboxID {
 		if err := printSandboxID(); err != nil {

--- a/internal/cli/exec_integration_test.go
+++ b/internal/cli/exec_integration_test.go
@@ -968,7 +968,7 @@ func TestExecIntegrationNoStdinFailureDoesNotHangWhileStreamBlocked(t *testing.T
 	}
 }
 
-func TestExecIntegrationPropagatesExitAndStderr(t *testing.T) {
+func TestExecIntegrationPropagatesExitWithoutFailureFooter(t *testing.T) {
 	adapter := &integrationAdapter{
 		runFn: func(_ context.Context, req backend.ExecutionRequest) (*backend.ExecutionResult, error) {
 			return &backend.ExecutionResult{
@@ -1008,17 +1008,17 @@ func TestExecIntegrationPropagatesExitAndStderr(t *testing.T) {
 	if !strings.Contains(outcome.stderr, "err\n") {
 		t.Fatalf("expected stderr in stream output, got %q", outcome.stderr)
 	}
-	if got := parseSandboxID(outcome.stderr); got == "" {
-		t.Fatalf("expected sandbox_id in failure output, got %q", outcome.stderr)
+	if strings.Contains(outcome.stderr, "sandbox_id=") {
+		t.Fatalf("did not expect sandbox_id footer in failure output, got %q", outcome.stderr)
 	}
-	if got := parseExecutionID(outcome.stderr); got == "" {
-		t.Fatalf("expected execution_id in failure output, got %q", outcome.stderr)
+	if strings.Contains(outcome.stderr, "execution_id=") {
+		t.Fatalf("did not expect execution_id footer in failure output, got %q", outcome.stderr)
 	}
-	if !strings.Contains(outcome.stderr, "inspect_command=cleanroom execution inspect ") {
-		t.Fatalf("expected inspect_command in failure output, got %q", outcome.stderr)
+	if strings.Contains(outcome.stderr, "inspect_command=cleanroom execution inspect ") {
+		t.Fatalf("did not expect inspect_command footer in failure output, got %q", outcome.stderr)
 	}
-	if !strings.Contains(outcome.stderr, "artifacts_dir=/tmp/exec-failed") {
-		t.Fatalf("expected artifacts_dir in failure output, got %q", outcome.stderr)
+	if strings.Contains(outcome.stderr, "artifacts_dir=/tmp/exec-failed") {
+		t.Fatalf("did not expect artifacts_dir footer in failure output, got %q", outcome.stderr)
 	}
 }
 

--- a/internal/cli/execution_shared.go
+++ b/internal/cli/execution_shared.go
@@ -405,48 +405,12 @@ func writeSandboxID(stderr io.Writer, sandboxID string) error {
 	return err
 }
 
-func writeExecutionID(stderr io.Writer, executionID string) error {
-	executionID = strings.TrimSpace(executionID)
-	if stderr == nil || executionID == "" {
-		return nil
-	}
-	_, err := fmt.Fprintf(stderr, "execution_id=%s\n", executionID)
-	return err
-}
-
 func writeTraceID(stderr io.Writer, traceID string) error {
 	traceID = strings.TrimSpace(traceID)
 	if stderr == nil || traceID == "" {
 		return nil
 	}
 	_, err := fmt.Fprintf(stderr, "trace_id=%s\n", traceID)
-	return err
-}
-
-func writeTraceURL(stderr io.Writer, traceURL string) error {
-	traceURL = strings.TrimSpace(traceURL)
-	if stderr == nil || traceURL == "" {
-		return nil
-	}
-	_, err := fmt.Fprintf(stderr, "trace_url=%s\n", traceURL)
-	return err
-}
-
-func writeArtifactsDir(stderr io.Writer, artifactsDir string) error {
-	artifactsDir = strings.TrimSpace(artifactsDir)
-	if stderr == nil || artifactsDir == "" {
-		return nil
-	}
-	_, err := fmt.Fprintf(stderr, "artifacts_dir=%s\n", artifactsDir)
-	return err
-}
-
-func writeExecutionInspectCommand(stderr io.Writer, sandboxID, executionID string) error {
-	executionID = strings.TrimSpace(executionID)
-	if stderr == nil || executionID == "" {
-		return nil
-	}
-	_, err := fmt.Fprintf(stderr, "inspect_command=cleanroom execution inspect %s\n", executionID)
 	return err
 }
 

--- a/internal/cli/execution_shared_test.go
+++ b/internal/cli/execution_shared_test.go
@@ -196,15 +196,3 @@ func TestWriteTraceID(t *testing.T) {
 		t.Fatalf("unexpected trace id output: got %q want %q", got, want)
 	}
 }
-
-func TestWriteTraceURL(t *testing.T) {
-	var stderr bytes.Buffer
-
-	if err := writeTraceURL(&stderr, " https://jaeger.example.test/trace/0123456789abcdef0123456789abcdef "); err != nil {
-		t.Fatalf("writeTraceURL returned error: %v", err)
-	}
-
-	if got, want := stderr.String(), "trace_url=https://jaeger.example.test/trace/0123456789abcdef0123456789abcdef\n"; got != want {
-		t.Fatalf("unexpected trace url output: got %q want %q", got, want)
-	}
-}


### PR DESCRIPTION
## Summary

- remove the automatic `cleanroom exec` and `cleanroom console` failure footer so non-zero exits stay focused on streamed guest output
- keep explicit `--print-sandbox-id` and `--print-trace-id` correlation paths intact
- update the README and current docs/spec text to match the new failure UX

## Why

Commands that fail should primarily show the command failure. The extra footer metadata made common failures noisy, and the retained inspection surfaces already cover deeper debugging when needed.

## Validation

- `mise exec -- go test ./internal/cli`
