### PR TITLE
Add cache observability attributes for stage cache tracing

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -137,6 +137,7 @@ structured logs where applicable:
 - `cleanroom.sandbox.id`
 - `cleanroom.execution.id`
 - `cleanroom.execution.kind`
+- `cleanroom.repository.commit_sha`
 - `cleanroom.reason_code`
 - `cleanroom.gateway.service`
 - `cleanroom.gateway.action`
@@ -199,6 +200,8 @@ Recommended cache telemetry attributes are:
 - `cleanroom.cache.stage=runtime|workspace|dependency`
 - `cleanroom.cache.operation=lookup|restore|publish|invalidate`
 - `cleanroom.cache.result=hit|miss|restored|published|fallback|failed`
+- `cleanroom.cache.lookup_reason=cache_record_not_found|backend_mismatch|policy_hash_mismatch|repository_changed|workspace_parent_changed`
+- `cleanroom.repository.commit_sha=<git commit sha>`
 
 Use these fields in traces and structured logs for cache-specific work. Use
 them in metrics only for cache-specific series, not for generic execution

--- a/internal/controlservice/cache_observability.go
+++ b/internal/controlservice/cache_observability.go
@@ -1,0 +1,49 @@
+package controlservice
+
+import (
+	"context"
+	"strings"
+
+	"github.com/buildkite/cleanroom/internal/observability"
+	"github.com/buildkite/cleanroom/internal/repositorycheckout"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func cachePhaseAttributes(stage, operation string, repository *repositorycheckout.Checkout, extra ...attribute.KeyValue) []attribute.KeyValue {
+	attrs := make([]attribute.KeyValue, 0, len(extra)+3)
+	attrs = append(attrs,
+		attribute.String(observability.AttrCacheStage, strings.TrimSpace(stage)),
+		attribute.String(observability.AttrCacheOperation, strings.TrimSpace(operation)),
+	)
+	if repository != nil {
+		if commitSHA := strings.TrimSpace(repository.CommitSHA); commitSHA != "" {
+			attrs = append(attrs, attribute.String(observability.AttrRepositoryCommitSHA, commitSHA))
+		}
+	}
+	attrs = append(attrs, extra...)
+	return attrs
+}
+
+func setCacheLookupSpanAttributes(ctx context.Context, hit bool, reason string, err error) {
+	result := observability.CacheResultFailed
+	if err == nil {
+		if hit {
+			result = observability.CacheResultHit
+		} else {
+			result = observability.CacheResultMiss
+		}
+	}
+	attrs := []attribute.KeyValue{attribute.String(observability.AttrCacheResult, result)}
+	if reason = strings.TrimSpace(reason); reason != "" {
+		attrs = append(attrs, attribute.String(observability.AttrCacheLookupReason, reason))
+	}
+	trace.SpanFromContext(ctx).SetAttributes(attrs...)
+}
+
+func setCacheResultSpanAttribute(ctx context.Context, result string) {
+	if result = strings.TrimSpace(result); result == "" {
+		return
+	}
+	trace.SpanFromContext(ctx).SetAttributes(attribute.String(observability.AttrCacheResult, result))
+}

--- a/internal/controlservice/dependency_stage.go
+++ b/internal/controlservice/dependency_stage.go
@@ -13,6 +13,7 @@ import (
 	"github.com/buildkite/cleanroom/internal/cachekey"
 	"github.com/buildkite/cleanroom/internal/cachestore"
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+	"github.com/buildkite/cleanroom/internal/observability"
 	"github.com/buildkite/cleanroom/internal/policy"
 	"github.com/buildkite/cleanroom/internal/repositorychangeset"
 	"github.com/buildkite/cleanroom/internal/repositorycheckout"
@@ -189,35 +190,35 @@ func gitFileDigestAtCommit(ctx context.Context, repoDir, commitSHA, file string)
 	return "sha256:" + hex.EncodeToString(sum[:]), nil
 }
 
-func (s *Service) lookupDependencyStageCache(ctx context.Context, backendName string, compiled *policy.CompiledPolicy, repository *repositorycheckout.Checkout, plan dependencyStagePlan) (cachestore.Record, bool, error) {
+func (s *Service) lookupDependencyStageCache(ctx context.Context, backendName string, compiled *policy.CompiledPolicy, repository *repositorycheckout.Checkout, plan dependencyStagePlan) (cachestore.Record, bool, string, error) {
 	if compiled == nil || repository == nil || strings.TrimSpace(plan.CacheKey) == "" {
-		return cachestore.Record{}, false, nil
+		return cachestore.Record{}, false, "", nil
 	}
 	store, err := s.cacheStoreOrErr()
 	if err != nil {
-		return cachestore.Record{}, false, nil
+		return cachestore.Record{}, false, "", nil
 	}
 
 	record, ok, err := store.GetReady(ctx, dependencyStageName, plan.CacheKey)
 	if err != nil {
-		return cachestore.Record{}, false, err
+		return cachestore.Record{}, false, "", err
 	}
 	if !ok {
-		return cachestore.Record{}, false, nil
+		return cachestore.Record{}, false, observability.CacheLookupReasonRecordNotFound, nil
 	}
 	if strings.TrimSpace(record.Backend) != strings.TrimSpace(backendName) {
-		return cachestore.Record{}, false, nil
+		return cachestore.Record{}, false, observability.CacheLookupReasonBackendMismatch, nil
 	}
 	if strings.TrimSpace(record.PolicyHash) != strings.TrimSpace(compiled.Hash) {
-		return cachestore.Record{}, false, nil
+		return cachestore.Record{}, false, observability.CacheLookupReasonPolicyHashMismatch, nil
 	}
 	if strings.TrimSpace(record.ParentCacheKey) != strings.TrimSpace(plan.ParentWorkspaceCacheKey) {
-		return cachestore.Record{}, false, nil
+		return cachestore.Record{}, false, observability.CacheLookupReasonWorkspaceParentChanged, nil
 	}
 	if !repositoryCheckoutsEqual(repositorycheckout.FromProto(record.Repository), repository) {
-		return cachestore.Record{}, false, nil
+		return cachestore.Record{}, false, observability.CacheLookupReasonRepositoryChanged, nil
 	}
-	return record, true, nil
+	return record, true, "", nil
 }
 
 func (s *Service) maybePublishDependencyStageCache(
@@ -243,7 +244,7 @@ func (s *Service) maybePublishDependencyStageCache(
 		return
 	}
 
-	if record, ok, err := s.lookupDependencyStageCache(ctx, backendName, compiled, repository, plan); err == nil && ok {
+	if record, ok, _, err := s.lookupDependencyStageCache(ctx, backendName, compiled, repository, plan); err == nil && ok {
 		if replacedRecord == nil || strings.TrimSpace(record.CacheKey) != strings.TrimSpace(replacedRecord.CacheKey) {
 			s.logDependencyStageAlreadyPublished(record)
 			return

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -304,6 +304,11 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 	}
 	repository := repositorycheckout.FromProto(req.GetRepositoryCheckout())
 	if repository != nil {
+		if commitSHA := strings.TrimSpace(repository.CommitSHA); commitSHA != "" {
+			span.SetAttributes(attribute.String(observability.AttrRepositoryCommitSHA, commitSHA))
+		}
+	}
+	if repository != nil {
 		if err := validateRepositoryCheckoutForPolicy(compiled, repository); err != nil {
 			return nil, err
 		}
@@ -354,11 +359,16 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 				emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_DEPENDENCY_STAGE_CACHE, "checking dependency stage cache")
 				var record cachestore.Record
 				var found bool
-				err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.lookup_dependency_stage_cache", []attribute.KeyValue{
-					attribute.String("cleanroom.backend", backendName),
-				}, func(ctx context.Context) error {
+				var lookupReason string
+				err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.lookup_dependency_stage_cache", cachePhaseAttributes(
+					observability.CacheStageDependency,
+					observability.CacheOperationLookup,
+					repository,
+					attribute.String(observability.AttrBackend, backendName),
+				), func(ctx context.Context) error {
 					var lookupErr error
-					record, found, lookupErr = s.lookupDependencyStageCache(ctx, backendName, compiled, repository, dependencyStagePlan)
+					record, found, lookupReason, lookupErr = s.lookupDependencyStageCache(ctx, backendName, compiled, repository, dependencyStagePlan)
+					setCacheLookupSpanAttributes(ctx, found, lookupReason, lookupErr)
 					return lookupErr
 				})
 				if err != nil {
@@ -372,11 +382,15 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 						Options: req.GetOptions(),
 					}
 					var restoreResp *cleanroomv1.CreateSandboxResponse
-					restoreErr := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.restore_dependency_stage_cache", []attribute.KeyValue{
-						attribute.String("cleanroom.backend", backendName),
-					}, func(ctx context.Context) error {
+					restoreErr := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.restore_dependency_stage_cache", cachePhaseAttributes(
+						observability.CacheStageDependency,
+						observability.CacheOperationRestore,
+						repository,
+						attribute.String(observability.AttrBackend, backendName),
+					), func(ctx context.Context) error {
 						var err error
 						restoreResp, err = s.createSandboxFromCacheRecord(ctx, restoreReq, compiled, record, reporter)
+						setCacheResultSpanAttribute(ctx, map[bool]string{true: observability.CacheResultFailed, false: observability.CacheResultRestored}[err != nil])
 						return err
 					})
 					if restoreErr == nil {
@@ -401,11 +415,16 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 			emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_WORKSPACE_STAGE_CACHE, "checking workspace stage cache")
 			var record cachestore.Record
 			var found bool
-			err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.lookup_workspace_stage_cache", []attribute.KeyValue{
-				attribute.String("cleanroom.backend", backendName),
-			}, func(ctx context.Context) error {
+			var lookupReason string
+			err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.lookup_workspace_stage_cache", cachePhaseAttributes(
+				observability.CacheStageWorkspace,
+				observability.CacheOperationLookup,
+				repository,
+				attribute.String(observability.AttrBackend, backendName),
+			), func(ctx context.Context) error {
 				var lookupErr error
-				record, found, lookupErr = s.lookupWorkspaceStageCache(ctx, backendName, compiled, workspaceStageRuntimeBaseKey, repository, changeset)
+				record, found, lookupReason, lookupErr = s.lookupWorkspaceStageCache(ctx, backendName, compiled, workspaceStageRuntimeBaseKey, repository, changeset)
+				setCacheLookupSpanAttributes(ctx, found, lookupReason, lookupErr)
 				return lookupErr
 			})
 			if err != nil {
@@ -419,11 +438,15 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 					Options: req.GetOptions(),
 				}
 				var restoreResp *cleanroomv1.CreateSandboxResponse
-				restoreErr := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.restore_workspace_stage_cache", []attribute.KeyValue{
-					attribute.String("cleanroom.backend", backendName),
-				}, func(ctx context.Context) error {
+				restoreErr := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.restore_workspace_stage_cache", cachePhaseAttributes(
+					observability.CacheStageWorkspace,
+					observability.CacheOperationRestore,
+					repository,
+					attribute.String(observability.AttrBackend, backendName),
+				), func(ctx context.Context) error {
 					var err error
 					restoreResp, err = s.createSandboxFromCacheRecord(ctx, restoreReq, compiled, record, reporter)
+					setCacheResultSpanAttribute(ctx, map[bool]string{true: observability.CacheResultFailed, false: observability.CacheResultRestored}[err != nil])
 					return err
 				})
 				if restoreErr == nil {
@@ -454,12 +477,18 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 		sandboxID := restoredWorkspaceResp.GetSandbox().GetSandboxId()
 		span.SetAttributes(attribute.String("cleanroom.sandbox.id", sandboxID))
 		if dependencyStageBootstrapEnabled {
+			bootstrapAttrs := []attribute.KeyValue{
+				attribute.String(observability.AttrBackend, backendName),
+				attribute.String(observability.AttrSandboxID, sandboxID),
+				attribute.Int(observability.AttrCommandArgc, len(dependencyStagePlan.BootstrapCommand)),
+			}
+			if repository != nil {
+				if commitSHA := strings.TrimSpace(repository.CommitSHA); commitSHA != "" {
+					bootstrapAttrs = append(bootstrapAttrs, attribute.String(observability.AttrRepositoryCommitSHA, commitSHA))
+				}
+			}
 			emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_DEPENDENCIES, "running dependency bootstrap")
-			if err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.bootstrap_dependencies", []attribute.KeyValue{
-				attribute.String("cleanroom.backend", backendName),
-				attribute.String("cleanroom.sandbox.id", sandboxID),
-				attribute.Int("cleanroom.command.argc", len(dependencyStagePlan.BootstrapCommand)),
-			}, func(ctx context.Context) error {
+			if err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.bootstrap_dependencies", bootstrapAttrs, func(ctx context.Context) error {
 				return s.bootstrapDependencyStageInPersistentSandbox(ctx, adapter, sandboxID, compiled, firecrackerCfg, dependencyStagePlan, reporter)
 			}); err != nil {
 				cleanupErr := s.terminateCreatedSandbox(context.Background(), adapter, sandboxID)
@@ -511,11 +540,17 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 	if repository != nil {
 		emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_REPOSITORY, "bootstrapping repository checkout")
 	}
-	if err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.bootstrap_repository", []attribute.KeyValue{
-		attribute.String("cleanroom.backend", backendName),
-		attribute.String("cleanroom.sandbox.id", sandboxID),
+	repositoryBootstrapAttrs := []attribute.KeyValue{
+		attribute.String(observability.AttrBackend, backendName),
+		attribute.String(observability.AttrSandboxID, sandboxID),
 		attribute.Bool("cleanroom.repository.refresh_existing", false),
-	}, func(ctx context.Context) error {
+	}
+	if repository != nil {
+		if commitSHA := strings.TrimSpace(repository.CommitSHA); commitSHA != "" {
+			repositoryBootstrapAttrs = append(repositoryBootstrapAttrs, attribute.String(observability.AttrRepositoryCommitSHA, commitSHA))
+		}
+	}
+	if err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.bootstrap_repository", repositoryBootstrapAttrs, func(ctx context.Context) error {
 		return s.bootstrapRepositoryInPersistentSandbox(ctx, adapter, sandboxID, compiled, firecrackerCfg, repository, false, reporter)
 	}); err != nil {
 		if terminateErr := s.terminateCreatedSandbox(context.Background(), adapter, sandboxID); terminateErr != nil {
@@ -524,11 +559,17 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 		return nil, fmt.Errorf("bootstrap repository checkout: %w", err)
 	}
 	if changeset != nil {
+		changesetAttrs := []attribute.KeyValue{
+			attribute.String(observability.AttrBackend, backendName),
+			attribute.String(observability.AttrSandboxID, sandboxID),
+		}
+		if repository != nil {
+			if commitSHA := strings.TrimSpace(repository.CommitSHA); commitSHA != "" {
+				changesetAttrs = append(changesetAttrs, attribute.String(observability.AttrRepositoryCommitSHA, commitSHA))
+			}
+		}
 		emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_APPLY_REPOSITORY_CHANGESET, "applying repository changeset")
-		if err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.apply_repository_changeset", []attribute.KeyValue{
-			attribute.String("cleanroom.backend", backendName),
-			attribute.String("cleanroom.sandbox.id", sandboxID),
-		}, func(ctx context.Context) error {
+		if err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.apply_repository_changeset", changesetAttrs, func(ctx context.Context) error {
 			return s.bootstrapRepositoryChangesetInPersistentSandbox(ctx, adapter, sandboxID, compiled, firecrackerCfg, repository, changeset, reporter)
 		}); err != nil {
 			if terminateErr := s.terminateCreatedSandbox(context.Background(), adapter, sandboxID); terminateErr != nil {
@@ -548,12 +589,18 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 		})
 	}
 	if dependencyStageBootstrapEnabled {
+		bootstrapAttrs := []attribute.KeyValue{
+			attribute.String(observability.AttrBackend, backendName),
+			attribute.String(observability.AttrSandboxID, sandboxID),
+			attribute.Int(observability.AttrCommandArgc, len(dependencyStagePlan.BootstrapCommand)),
+		}
+		if repository != nil {
+			if commitSHA := strings.TrimSpace(repository.CommitSHA); commitSHA != "" {
+				bootstrapAttrs = append(bootstrapAttrs, attribute.String(observability.AttrRepositoryCommitSHA, commitSHA))
+			}
+		}
 		emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_DEPENDENCIES, "running dependency bootstrap")
-		if err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.bootstrap_dependencies", []attribute.KeyValue{
-			attribute.String("cleanroom.backend", backendName),
-			attribute.String("cleanroom.sandbox.id", sandboxID),
-			attribute.Int("cleanroom.command.argc", len(dependencyStagePlan.BootstrapCommand)),
-		}, func(ctx context.Context) error {
+		if err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.bootstrap_dependencies", bootstrapAttrs, func(ctx context.Context) error {
 			return s.bootstrapDependencyStageInPersistentSandbox(ctx, adapter, sandboxID, compiled, firecrackerCfg, dependencyStagePlan, reporter)
 		}); err != nil {
 			if terminateErr := s.terminateCreatedSandbox(context.Background(), adapter, sandboxID); terminateErr != nil {

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -3,6 +3,7 @@ package controlservice
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -362,6 +363,37 @@ func findEndedSpanByName(spans []trace.ReadOnlySpan, name string) trace.ReadOnly
 	return nil
 }
 
+func spanAttributeValue(span trace.ReadOnlySpan, key string) (string, bool) {
+	if span == nil {
+		return "", false
+	}
+	for _, kv := range span.Attributes() {
+		if string(kv.Key) != key {
+			continue
+		}
+		return fmt.Sprint(kv.Value.AsInterface()), true
+	}
+	return "", false
+}
+
+func requireSpanAttributeValue(t *testing.T, span trace.ReadOnlySpan, key, want string) {
+	t.Helper()
+	got, ok := spanAttributeValue(span, key)
+	if !ok {
+		t.Fatalf("expected span %q to include attribute %q", span.Name(), key)
+	}
+	if got != want {
+		t.Fatalf("unexpected span %q attribute %q: got %q want %q", span.Name(), key, got, want)
+	}
+}
+
+func requireSpanMissingAttribute(t *testing.T, span trace.ReadOnlySpan, key string) {
+	t.Helper()
+	if got, ok := spanAttributeValue(span, key); ok {
+		t.Fatalf("expected span %q to omit attribute %q, got %q", span.Name(), key, got)
+	}
+}
+
 func collectResourceMetrics(t *testing.T, reader *sdkmetric.ManualReader) metricdata.ResourceMetrics {
 	t.Helper()
 	var metrics metricdata.ResourceMetrics
@@ -490,7 +522,6 @@ func TestCreateSandboxTracesBootstrapFailure(t *testing.T) {
 		t.Fatalf("NewWithTracerProvider returned error: %v", err)
 	}
 	svc.Observability = obs
-	svc.Config.Backends.Firecracker.Snapshots = runtimeconfig.SnapshotConfig{}
 
 	mirrors, repository := testRepositoryMirror(t, map[string]string{
 		".mise.toml": "[tools]\ngo = '1.25.9'\n",
@@ -521,6 +552,14 @@ func TestCreateSandboxTracesBootstrapFailure(t *testing.T) {
 	if repositorySpan == nil {
 		t.Fatalf("expected cleanroom.sandbox.bootstrap_repository span, got spans %#v", spans)
 	}
+	workspaceLookupSpan := findEndedSpanByName(spans, "cleanroom.sandbox.lookup_workspace_stage_cache")
+	if workspaceLookupSpan == nil {
+		t.Fatalf("expected cleanroom.sandbox.lookup_workspace_stage_cache span, got spans %#v", spans)
+	}
+	dependencyLookupSpan := findEndedSpanByName(spans, "cleanroom.sandbox.lookup_dependency_stage_cache")
+	if dependencyLookupSpan == nil {
+		t.Fatalf("expected cleanroom.sandbox.lookup_dependency_stage_cache span, got spans %#v", spans)
+	}
 	dependencySpan := findEndedSpanByName(spans, "cleanroom.sandbox.bootstrap_dependencies")
 	if dependencySpan == nil {
 		t.Fatalf("expected cleanroom.sandbox.bootstrap_dependencies span, got spans %#v", spans)
@@ -535,6 +574,12 @@ func TestCreateSandboxTracesBootstrapFailure(t *testing.T) {
 	if got, want := repositorySpan.Parent().SpanID(), createSpan.SpanContext().SpanID(); got != want {
 		t.Fatalf("unexpected repository bootstrap parent span id: got %s want %s", got, want)
 	}
+	if got, want := workspaceLookupSpan.Parent().SpanID(), createSpan.SpanContext().SpanID(); got != want {
+		t.Fatalf("unexpected workspace lookup parent span id: got %s want %s", got, want)
+	}
+	if got, want := dependencyLookupSpan.Parent().SpanID(), createSpan.SpanContext().SpanID(); got != want {
+		t.Fatalf("unexpected dependency lookup parent span id: got %s want %s", got, want)
+	}
 	if got, want := dependencySpan.Parent().SpanID(), createSpan.SpanContext().SpanID(); got != want {
 		t.Fatalf("unexpected dependency bootstrap parent span id: got %s want %s", got, want)
 	}
@@ -547,6 +592,85 @@ func TestCreateSandboxTracesBootstrapFailure(t *testing.T) {
 	if got, want := createSpan.Status().Code, codes.Error; got != want {
 		t.Fatalf("unexpected create sandbox span status: got %v want %v", got, want)
 	}
+	repositoryCommitSHA := repository.GetCommitSha()
+	requireSpanAttributeValue(t, createSpan, observability.AttrRepositoryCommitSHA, repositoryCommitSHA)
+	requireSpanAttributeValue(t, repositorySpan, observability.AttrRepositoryCommitSHA, repositoryCommitSHA)
+	requireSpanAttributeValue(t, dependencySpan, observability.AttrRepositoryCommitSHA, repositoryCommitSHA)
+	requireSpanAttributeValue(t, workspaceLookupSpan, observability.AttrRepositoryCommitSHA, repositoryCommitSHA)
+	requireSpanAttributeValue(t, dependencyLookupSpan, observability.AttrRepositoryCommitSHA, repositoryCommitSHA)
+	requireSpanAttributeValue(t, workspaceLookupSpan, observability.AttrCacheStage, observability.CacheStageWorkspace)
+	requireSpanAttributeValue(t, workspaceLookupSpan, observability.AttrCacheOperation, observability.CacheOperationLookup)
+	requireSpanAttributeValue(t, workspaceLookupSpan, observability.AttrCacheResult, observability.CacheResultMiss)
+	requireSpanAttributeValue(t, workspaceLookupSpan, observability.AttrCacheLookupReason, observability.CacheLookupReasonRecordNotFound)
+	requireSpanAttributeValue(t, dependencyLookupSpan, observability.AttrCacheStage, observability.CacheStageDependency)
+	requireSpanAttributeValue(t, dependencyLookupSpan, observability.AttrCacheOperation, observability.CacheOperationLookup)
+	requireSpanAttributeValue(t, dependencyLookupSpan, observability.AttrCacheResult, observability.CacheResultMiss)
+	requireSpanAttributeValue(t, dependencyLookupSpan, observability.AttrCacheLookupReason, observability.CacheLookupReasonRecordNotFound)
+}
+
+func TestCreateSandboxTracesDependencyCacheHitAttributes(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	store := newMemorySnapshotStore()
+	adapter := &stubAdapter{}
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"go.mod": "module example.com/test\n\ngo 1.26.2\n",
+		"go.sum": "example.com/test v0.0.0 h1:abc123\n",
+	})
+	svc := newTestServiceWithSnapshotStore(adapter, store)
+	svc.RepositoryStore = mirrors
+
+	req := &cleanroomv1.CreateSandboxRequest{
+		Policy:             testRepositoryDependencyPolicy(),
+		RepositoryCheckout: repositoryCheckout,
+	}
+	if _, err := svc.CreateSandbox(context.Background(), req); err != nil {
+		t.Fatalf("first CreateSandbox returned error: %v", err)
+	}
+	mirrors.err = errors.New("offline")
+
+	recorder := tracetest.NewSpanRecorder()
+	tracerProvider := trace.NewTracerProvider()
+	tracerProvider.RegisterSpanProcessor(recorder)
+	defer func() {
+		_ = tracerProvider.Shutdown(context.Background())
+	}()
+	obs, err := observability.NewWithTracerProvider(tracerProvider)
+	if err != nil {
+		t.Fatalf("NewWithTracerProvider returned error: %v", err)
+	}
+	svc.Observability = obs
+
+	resp, err := svc.CreateSandbox(context.Background(), req)
+	if err != nil {
+		t.Fatalf("second CreateSandbox returned error: %v", err)
+	}
+	if got, want := resp.GetSourceKind(), "dependency stage cache"; got != want {
+		t.Fatalf("unexpected response source kind: got %q want %q", got, want)
+	}
+
+	spans := recorder.Ended()
+	lookupSpan := findEndedSpanByName(spans, "cleanroom.sandbox.lookup_dependency_stage_cache")
+	if lookupSpan == nil {
+		t.Fatalf("expected cleanroom.sandbox.lookup_dependency_stage_cache span, got spans %#v", spans)
+	}
+	restoreSpan := findEndedSpanByName(spans, "cleanroom.sandbox.restore_dependency_stage_cache")
+	if restoreSpan == nil {
+		t.Fatalf("expected cleanroom.sandbox.restore_dependency_stage_cache span, got spans %#v", spans)
+	}
+	if workspaceLookupSpan := findEndedSpanByName(spans, "cleanroom.sandbox.lookup_workspace_stage_cache"); workspaceLookupSpan != nil {
+		t.Fatalf("expected dependency cache hit to skip workspace lookup span, got spans %#v", spans)
+	}
+
+	repositoryCommitSHA := repositoryCheckout.GetCommitSha()
+	requireSpanAttributeValue(t, lookupSpan, observability.AttrRepositoryCommitSHA, repositoryCommitSHA)
+	requireSpanAttributeValue(t, lookupSpan, observability.AttrCacheStage, observability.CacheStageDependency)
+	requireSpanAttributeValue(t, lookupSpan, observability.AttrCacheOperation, observability.CacheOperationLookup)
+	requireSpanAttributeValue(t, lookupSpan, observability.AttrCacheResult, observability.CacheResultHit)
+	requireSpanMissingAttribute(t, lookupSpan, observability.AttrCacheLookupReason)
+	requireSpanAttributeValue(t, restoreSpan, observability.AttrRepositoryCommitSHA, repositoryCommitSHA)
+	requireSpanAttributeValue(t, restoreSpan, observability.AttrCacheStage, observability.CacheStageDependency)
+	requireSpanAttributeValue(t, restoreSpan, observability.AttrCacheOperation, observability.CacheOperationRestore)
+	requireSpanAttributeValue(t, restoreSpan, observability.AttrCacheResult, observability.CacheResultRestored)
 }
 
 func TestServiceEmitsSandboxAndExecutionMetrics(t *testing.T) {

--- a/internal/controlservice/workspace_stage.go
+++ b/internal/controlservice/workspace_stage.go
@@ -8,6 +8,7 @@ import (
 	"github.com/buildkite/cleanroom/internal/backend"
 	"github.com/buildkite/cleanroom/internal/cachekey"
 	"github.com/buildkite/cleanroom/internal/cachestore"
+	"github.com/buildkite/cleanroom/internal/observability"
 	"github.com/buildkite/cleanroom/internal/policy"
 	"github.com/buildkite/cleanroom/internal/repositorychangeset"
 	"github.com/buildkite/cleanroom/internal/repositorycheckout"
@@ -70,36 +71,36 @@ func workspaceStageMaterializationRecipeDigest(repository *repositorycheckout.Ch
 	return repositorycheckout.BootstrapRecipeDigest(repository)
 }
 
-func (s *Service) lookupWorkspaceStageCache(ctx context.Context, backendName string, compiled *policy.CompiledPolicy, runtimeBaseKey string, repository *repositorycheckout.Checkout, changeset *repositorychangeset.Changeset) (cachestore.Record, bool, error) {
+func (s *Service) lookupWorkspaceStageCache(ctx context.Context, backendName string, compiled *policy.CompiledPolicy, runtimeBaseKey string, repository *repositorycheckout.Checkout, changeset *repositorychangeset.Changeset) (cachestore.Record, bool, string, error) {
 	if compiled == nil || repository == nil || strings.TrimSpace(runtimeBaseKey) == "" {
-		return cachestore.Record{}, false, nil
+		return cachestore.Record{}, false, "", nil
 	}
 	store, err := s.cacheStoreOrErr()
 	if err != nil {
-		return cachestore.Record{}, false, nil
+		return cachestore.Record{}, false, "", nil
 	}
 	cacheKey := workspaceStageCacheKey(backendName, runtimeBaseKey, compiled.Hash, repository, changeset)
 	if cacheKey == "" {
-		return cachestore.Record{}, false, nil
+		return cachestore.Record{}, false, "", nil
 	}
 
 	record, ok, err := store.GetReady(ctx, workspaceStageName, cacheKey)
 	if err != nil {
-		return cachestore.Record{}, false, err
+		return cachestore.Record{}, false, "", err
 	}
 	if !ok {
-		return cachestore.Record{}, false, nil
+		return cachestore.Record{}, false, observability.CacheLookupReasonRecordNotFound, nil
 	}
 	if strings.TrimSpace(record.Backend) != strings.TrimSpace(backendName) {
-		return cachestore.Record{}, false, nil
+		return cachestore.Record{}, false, observability.CacheLookupReasonBackendMismatch, nil
 	}
 	if !repositoryCheckoutsEqual(repositorycheckout.FromProto(record.Repository), repository) {
-		return cachestore.Record{}, false, nil
+		return cachestore.Record{}, false, observability.CacheLookupReasonRepositoryChanged, nil
 	}
 	if strings.TrimSpace(record.PolicyHash) != strings.TrimSpace(compiled.Hash) {
-		return cachestore.Record{}, false, nil
+		return cachestore.Record{}, false, observability.CacheLookupReasonPolicyHashMismatch, nil
 	}
-	return record, true, nil
+	return record, true, "", nil
 }
 
 func (s *Service) maybePublishWorkspaceStageCache(
@@ -130,7 +131,7 @@ func (s *Service) maybePublishWorkspaceStageCache(
 		return
 	}
 
-	if record, ok, err := s.lookupWorkspaceStageCache(ctx, backendName, compiled, runtimeBaseKey, repository, changeset); err == nil && ok {
+	if record, ok, _, err := s.lookupWorkspaceStageCache(ctx, backendName, compiled, runtimeBaseKey, repository, changeset); err == nil && ok {
 		if replacedRecord == nil || strings.TrimSpace(record.CacheKey) != strings.TrimSpace(replacedRecord.CacheKey) {
 			s.logWorkspaceStageAlreadyPublished(record)
 			return

--- a/internal/observability/contract.go
+++ b/internal/observability/contract.go
@@ -56,6 +56,11 @@ const (
 	AttrStdinDisabled         = "cleanroom.stdin.disabled"
 	AttrRepositoryCheckout    = "cleanroom.repository.checkout"
 	AttrRepositoryChangeset   = "cleanroom.repository.changeset"
+	AttrRepositoryCommitSHA   = "cleanroom.repository.commit_sha"
+	AttrCacheStage            = "cleanroom.cache.stage"
+	AttrCacheOperation        = "cleanroom.cache.operation"
+	AttrCacheResult           = "cleanroom.cache.result"
+	AttrCacheLookupReason     = "cleanroom.cache.lookup_reason"
 	AttrVMLaunched            = "cleanroom.vm.launched"
 	AttrExitCode              = "cleanroom.exit_code"
 
@@ -85,6 +90,28 @@ const (
 	ReasonCached                = "cached"
 	ReasonFallback              = "fallback"
 	ReasonRubyGemsUnavailable   = "rubygems_unavailable"
+
+	CacheStageRuntime    = "runtime"
+	CacheStageWorkspace  = "workspace"
+	CacheStageDependency = "dependency"
+
+	CacheOperationLookup     = "lookup"
+	CacheOperationRestore    = "restore"
+	CacheOperationPublish    = "publish"
+	CacheOperationInvalidate = "invalidate"
+
+	CacheResultHit       = "hit"
+	CacheResultMiss      = "miss"
+	CacheResultRestored  = "restored"
+	CacheResultPublished = "published"
+	CacheResultFallback  = "fallback"
+	CacheResultFailed    = "failed"
+
+	CacheLookupReasonRecordNotFound         = "cache_record_not_found"
+	CacheLookupReasonBackendMismatch        = "backend_mismatch"
+	CacheLookupReasonPolicyHashMismatch     = "policy_hash_mismatch"
+	CacheLookupReasonRepositoryChanged      = "repository_changed"
+	CacheLookupReasonWorkspaceParentChanged = "workspace_parent_changed"
 )
 
 func GatewayRequestSpanName(service string) string {


### PR DESCRIPTION
## Summary
- add cache observability contract fields for stage, operation, result, lookup reason, and repository commit SHA
- annotate workspace and dependency cache lookup and restore spans with explicit hit and miss reasons
- add trace regression tests and document the new telemetry fields

## Testing
- go test ./...