### PR TITLE
feat: improve execution inspection commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,8 +427,11 @@ When `rootfs` is unset, Cleanroom derives one from `sandbox.image.ref` and injec
 cleanroom doctor              # check host prerequisites
 cleanroom doctor --json       # machine-readable with capabilities map
 cleanroom sandbox inspect <sandbox-id>
+cleanroom sandbox inspect --last
+cleanroom execution ls        # list active executions
+cleanroom execution inspect --last
 cleanroom execution inspect --sandbox-id <sandbox-id> --last
-cleanroom execution inspect --sandbox-id <sandbox-id> <execution-id>
+cleanroom execution inspect <execution-id>
 cleanroom status --last       # browse the newest retained execution artifacts
 cleanroom status --execution-id <execution-id>
 cleanroom version
@@ -439,7 +442,8 @@ Failure flow:
 - `cleanroom exec` and `cleanroom console` keep failure stderr focused on streamed guest output; they do not append `sandbox_id`, `execution_id`, `trace_id`, or `trace_url` footers automatically.
 - Use `--print-sandbox-id` when you need to correlate a kept or reused sandbox, and use `cleanroom status --last` or `cleanroom execution inspect ...` for retained diagnostics.
 - Attached `cleanroom exec` and `cleanroom console` streams may print warning notices on stderr for policy observations such as blocked connections or disallowed DNS lookups.
-- `cleanroom sandbox inspect <sandbox-id>` shows sandbox state plus `last_execution_id` and `active_execution_id`.
+- `cleanroom sandbox inspect <sandbox-id>` and `cleanroom sandbox inspect --last` show sandbox state plus `last_execution_id` and `active_execution_id`.
+- `cleanroom execution ls` lists active executions by default; add `--all` to include finished executions that are still known to the control plane.
 - `cleanroom execution inspect ...` is the control-plane view for execution status, retained stdout/stderr, image metadata, `trace_id`, optional `trace_url`, and observability.
 - `cleanroom status ...` is the local artifact view under `$XDG_STATE_HOME/cleanroom/executions`.
 

--- a/client/client.go
+++ b/client/client.go
@@ -162,6 +162,13 @@ func (c *Client) DeleteSnapshot(ctx context.Context, req *DeleteSnapshotRequest)
 	return c.inner.DeleteSnapshot(ctx, req)
 }
 
+func (c *Client) ListExecutions(ctx context.Context, req *ListExecutionsRequest) (*ListExecutionsResponse, error) {
+	if c == nil || c.inner == nil {
+		return nil, errors.New("nil client")
+	}
+	return c.inner.ListExecutions(ctx, req)
+}
+
 func (c *Client) CreateExecution(ctx context.Context, req *CreateExecutionRequest) (*CreateExecutionResponse, error) {
 	if c == nil || c.inner == nil {
 		return nil, errors.New("nil client")

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -201,6 +201,24 @@ func TestClientLifecycle(t *testing.T) {
 		t.Fatalf("unexpected execution status: %v", got)
 	}
 
+	listExecutionsResp, err := client.ListExecutions(ctx, &ListExecutionsRequest{All: true})
+	if err != nil {
+		t.Fatalf("ListExecutions returned error: %v", err)
+	}
+	foundExecution := false
+	for _, execution := range listExecutionsResp.GetExecutions() {
+		if execution.GetExecutionId() != executionID {
+			continue
+		}
+		foundExecution = true
+		if got := execution.GetSandboxId(); got != sandboxID {
+			t.Fatalf("ListExecutions sandbox id mismatch: got %q want %q", got, sandboxID)
+		}
+	}
+	if !foundExecution {
+		t.Fatalf("expected ListExecutions to include %q", executionID)
+	}
+
 	terminateResp, err := client.TerminateSandbox(ctx, &TerminateSandboxRequest{SandboxId: sandboxID})
 	if err != nil {
 		t.Fatalf("TerminateSandbox returned error: %v", err)

--- a/client/types.go
+++ b/client/types.go
@@ -65,6 +65,8 @@ const (
 )
 
 type ExecutionOptions = cleanroomv1.ExecutionOptions
+type ListExecutionsRequest = cleanroomv1.ListExecutionsRequest
+type ListExecutionsResponse = cleanroomv1.ListExecutionsResponse
 type CreateExecutionRequest = cleanroomv1.CreateExecutionRequest
 type CreateExecutionResponse = cleanroomv1.CreateExecutionResponse
 type AttachExecutionRequest = cleanroomv1.AttachExecutionRequest

--- a/docs/api.md
+++ b/docs/api.md
@@ -79,14 +79,15 @@ Two services are sufficient.
 
 ### 4.2 ExecutionService
 
-1. `CreateExecution(CreateExecutionRequest) returns (CreateExecutionResponse)` (unary)
-2. `AttachExecution(AttachExecutionRequest) returns (AttachExecutionResponse)` (unary)
-3. `GetExecution(GetExecutionRequest) returns (GetExecutionResponse)` (unary)
-4. `InspectExecution(InspectExecutionRequest) returns (InspectExecutionResponse)` (unary)
-5. `CancelExecution(CancelExecutionRequest) returns (CancelExecutionResponse)` (unary)
-6. `WriteExecutionStdin(WriteExecutionStdinRequest) returns (WriteExecutionStdinResponse)` (unary)
-7. `CloseExecutionStdin(CloseExecutionStdinRequest) returns (CloseExecutionStdinResponse)` (unary)
-8. `StreamExecution(StreamExecutionRequest) returns (stream ExecutionStreamEvent)` (server-streaming)
+1. `ListExecutions(ListExecutionsRequest) returns (ListExecutionsResponse)` (unary)
+2. `CreateExecution(CreateExecutionRequest) returns (CreateExecutionResponse)` (unary)
+3. `AttachExecution(AttachExecutionRequest) returns (AttachExecutionResponse)` (unary)
+4. `GetExecution(GetExecutionRequest) returns (GetExecutionResponse)` (unary)
+5. `InspectExecution(InspectExecutionRequest) returns (InspectExecutionResponse)` (unary)
+6. `CancelExecution(CancelExecutionRequest) returns (CancelExecutionResponse)` (unary)
+7. `WriteExecutionStdin(WriteExecutionStdinRequest) returns (WriteExecutionStdinResponse)` (unary)
+8. `CloseExecutionStdin(CloseExecutionStdinRequest) returns (CloseExecutionStdinResponse)` (unary)
+9. `StreamExecution(StreamExecutionRequest) returns (stream ExecutionStreamEvent)` (server-streaming)
 
 `AttachExecution` is a bootstrap RPC for interactive executions. It returns a session token plus QUIC connection parameters. Interactive PTY bytes and control frames do not flow through ConnectRPC after bootstrap.
 
@@ -164,6 +165,7 @@ service SandboxService {
 }
 
 service ExecutionService {
+  rpc ListExecutions(ListExecutionsRequest) returns (ListExecutionsResponse);
   rpc CreateExecution(CreateExecutionRequest) returns (CreateExecutionResponse);
   rpc AttachExecution(AttachExecutionRequest) returns (AttachExecutionResponse);
   rpc GetExecution(GetExecutionRequest) returns (GetExecutionResponse);
@@ -204,6 +206,15 @@ message Execution {
   google.protobuf.Timestamp finished_at = 7;
   bool tty = 8;
   ExecutionKind kind = 10;
+}
+
+message ListExecutionsRequest {
+  string sandbox_id = 1;
+  bool all = 2;
+}
+
+message ListExecutionsResponse {
+  repeated Execution executions = 1;
 }
 
 message AttachExecutionRequest {
@@ -274,6 +285,7 @@ Expose a server mode and API-driven commands in the same binary.
 - `cleanroom sandbox create`
 - `cleanroom sandbox create --from <snapshot-id>`
 - `cleanroom sandbox inspect <sandbox-id>`
+- `cleanroom sandbox inspect --last`
 - `cleanroom sandbox ls`
 - `cleanroom sandbox rm <sandbox-id>`
 
@@ -289,13 +301,17 @@ and `--dangerously-allow-all` cannot be combined with `--from`.
 ### 9.3 Execution commands
 
 - `cleanroom inspect <typeid>`
+- `cleanroom execution ls`
+- `cleanroom execution ls --all`
 - `cleanroom execution inspect <execution-id>`
+- `cleanroom execution inspect --last`
 - `cleanroom execution inspect --sandbox-id <sandbox-id> --last`
 - `cleanroom status --execution-id <execution-id>`
 - `cleanroom status --last`
 
 Notes:
-- `sandbox inspect` is the lookup surface when you only know a sandbox ID.
+- `sandbox inspect` is the lookup surface when you only know a sandbox ID, and `--last` resolves the most recently updated sandbox.
+- `execution ls` is the discovery surface for active executions; add `--all` to include finished executions still retained in control-plane memory.
 - `execution inspect` is the live control-plane inspection surface and includes
   trace metadata when available.
 - `status` is the local retained-artifacts browser under `$XDG_STATE_HOME/cleanroom/executions`.
@@ -363,7 +379,7 @@ Failure UX:
 - On policy/runtime deny, print stable reason code and a follow-up command to inspect sandbox or execution state.
 
 Debugging flow:
-1. Start with `cleanroom status --last` when you only need the newest retained execution, or `cleanroom sandbox inspect <sandbox-id>` when you already know the sandbox ID.
+1. Start with `cleanroom execution ls` when you need to find an active run, `cleanroom execution inspect --last` when you want the newest known execution, or `cleanroom sandbox inspect <sandbox-id>` when you already know the sandbox ID.
 2. Use `cleanroom execution inspect <execution-id>` for the canonical execution view, including `trace_id`, optional `trace_url`, and retained observability payload.
 3. Use `cleanroom status --execution-id <execution-id>` for retained local artifacts and raw observability files.
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -519,9 +519,12 @@ Policy feature mapping:
   - `cleanroom console [--] <command>`
   - `cleanroom inspect <typeid>`
   - `cleanroom sandbox inspect <sandbox-id>`
+  - `cleanroom sandbox inspect --last`
   - `cleanroom sandbox ls`
   - `cleanroom sandbox rm <sandbox-id>`
+  - `cleanroom execution ls`
   - `cleanroom execution inspect <execution-id>`
+  - `cleanroom execution inspect --last`
   - `cleanroom execution inspect --sandbox-id <sandbox-id> --last`
   - `cleanroom doctor`
   - `cleanroom status [--execution-id <execution-id>|--last]`
@@ -531,7 +534,7 @@ Policy feature mapping:
   - machine-readable output (`--json`) for pipeline tooling
 - API/SDK (v1):
   - ConnectRPC `SandboxService` (`CreateSandbox`, `GetSandbox`, `ListSandboxes`, `DownloadSandboxFile`, `TerminateSandbox`, `StreamSandboxEvents`)
-  - ConnectRPC `ExecutionService` (`CreateExecution`, `AttachExecution`, `GetExecution`, `InspectExecution`, `CancelExecution`, `WriteExecutionStdin`, `CloseExecutionStdin`, `StreamExecution`)
+  - ConnectRPC `ExecutionService` (`ListExecutions`, `CreateExecution`, `AttachExecution`, `GetExecution`, `InspectExecution`, `CancelExecution`, `WriteExecutionStdin`, `CloseExecutionStdin`, `StreamExecution`)
 
 ### 8.1 CLI and API failure contract (normative)
 CLI:
@@ -544,6 +547,7 @@ CLI:
 API:
 - `SandboxService.CreateSandbox` returns client error for invalid policy input and conflict/error response for unsatisfied backend requirements.
 - `SandboxService.GetSandbox` must expose terminal sandbox status plus `last_execution_id` and `active_execution_id`.
+- `ExecutionService.ListExecutions` must list active executions by default, include finished executions when explicitly requested, and return newest executions first.
 - `ExecutionService.GetExecution` must expose execution status and exit code.
 - `ExecutionService.InspectExecution` must expose richer diagnostics including message, retained stdout/stderr, artifacts location, `trace_id`, optional `trace_url`, and observability payload when available.
 - ConnectRPC errors must include stable application `code` and human-readable `message`.

--- a/examples/buildkite-agent/README.md
+++ b/examples/buildkite-agent/README.md
@@ -13,7 +13,7 @@ your runtime config has enough resources for a large Go build:
 # ~/.config/cleanroom/config.yaml
 backends:
   darwin-vz:
-    memory_mib: 4096
+    memory_mib: 12288
     minimum_rootfs_bytes: 12GiB
 ```
 
@@ -29,14 +29,21 @@ cleanroom policy validate
 cleanroom console \
   --backend darwin-vz \
   --repo-url https://github.com/buildkite/agent.git \
-  --repo-commit 704a7e24737231681395b58604ca5174d2335712
+  --repo-commit 9eba5c5b83807b9aaaaffef6225be1f62c8d7d6c
 
 # Run the test suite
 cleanroom exec \
   --backend darwin-vz \
   --repo-url https://github.com/buildkite/agent.git \
-  --repo-commit 704a7e24737231681395b58604ca5174d2335712 \
-  -- go test -p 1 ./...
+  --repo-commit 9eba5c5b83807b9aaaaffef6225be1f62c8d7d6c \
+  -- mise x -- go test -p 1 ./...
+
+# Match the host-side gotestsum flow
+cleanroom exec \
+  --backend darwin-vz \
+  --repo-url https://github.com/buildkite/agent.git \
+  --repo-commit 9eba5c5b83807b9aaaaffef6225be1f62c8d7d6c \
+  -- mise x -- go run gotest.tools/gotestsum@latest ./... -- -fastfail
 ```
 
 ## Network allow list
@@ -48,20 +55,33 @@ Go module resolution:
 | Host | Why |
 |---|---|
 | `github.com`, `api.github.com` | Git clone and GitHub API |
-| `release-assets.githubusercontent.com` | mise downloads golangci-lint from GitHub releases |
+| `release-assets.githubusercontent.com` | mise downloads release assets for managed tools |
 | `dl.google.com` | upstream host validated by the gateway `/fetch/` route for Go SDK downloads |
 | `proxy.golang.org`, `sum.golang.org` | upstream hosts validated by the gateway `/goproxy/` route and mirrored checksum database |
 | `storage.googleapis.com` | Go proxy redirect target validated by the host-side goproxy client |
 | `mise-versions.jdx.dev`, `mise.jdx.dev` | mise tool metadata resolution |
+| `tuf-repo-cdn.sigstore.dev` | mise verifies GitHub artifact attestations |
 
 ## Notes
 
 - First run is slow: git clone, mise tool install, and Go module download
-- The example policy sets `sandbox.dependencies.command: [mise, exec, --, go, mod, download]`
+- The example now targets the current `buildkite/agent` `HEAD` commit at the time of this update: `9eba5c5b83807b9aaaaffef6225be1f62c8d7d6c`
+- The example policy uses the current multi-arch Debian base image digest `ghcr.io/buildkite/cleanroom-base/debian@sha256:28c3f638fabe1ed780f87b82cfb0c6dda2549c86b9e4edbe519e8250243411c5`
+- Guest memory still comes from `~/.config/cleanroom/config.yaml`; `cleanroom.yaml` does not carry backend runtime sizing
+- The policy sets:
+
+  ```sh
+  mise settings ruby.compile=false
+  mise install
+  mise exec -- go mod download
+  ```
+
   and keys that stage on `.mise.toml`, `go.mod`, and `go.sum`, so a successful
   first run can publish a reusable dependency stage for later warm hits on the
   same exact commit and policy
 - Cleanroom now injects `GOPROXY` and `MISE_GO_DOWNLOAD_MIRROR` automatically
   when the relevant upstream hosts are allowlisted, so `go mod download` and
   `mise use go@...` warm the shared gateway cache instead of fetching directly
+- `ruby.compile=false` avoids source-building Ruby during the dependency stage while still allowing `mise install` to satisfy the repo's current tool declarations
+- Use `mise x -- go ...` for execution commands so the installed Go toolchain is placed on `PATH`
 - `go test -p 1` avoids OOM kills on constrained guest memory

--- a/examples/buildkite-agent/cleanroom.yaml
+++ b/examples/buildkite-agent/cleanroom.yaml
@@ -1,11 +1,12 @@
 version: 1
-repository:
-  enabled: false
 sandbox:
   image:
-    ref: ghcr.io/buildkite/cleanroom-base/alpine@sha256:8eb2c1bc27af65d828ab6d93738a1adb1b62ef5b74417a273cedf3e7cec5f18b
+    ref: ghcr.io/buildkite/cleanroom-base/debian@sha256:28c3f638fabe1ed780f87b82cfb0c6dda2549c86b9e4edbe519e8250243411c5
   dependencies:
-    command: [mise, exec, --, go, mod, download]
+    command: |
+      mise settings ruby.compile=false
+      mise install
+      mise exec -- go mod download
     key:
       files:
         - .mise.toml
@@ -18,8 +19,6 @@ sandbox:
         ports: [443]
       - host: api.github.com
         ports: [443]
-      - host: release-assets.githubusercontent.com
-        ports: [443]
       - host: dl.google.com
         ports: [443]
       - host: proxy.golang.org
@@ -31,6 +30,8 @@ sandbox:
       - host: mise-versions.jdx.dev
         ports: [443]
       - host: mise.jdx.dev
+        ports: [443]
+      - host: release-assets.githubusercontent.com
         ports: [443]
       - host: tuf-repo-cdn.sigstore.dev
         ports: [443]

--- a/internal/cli/cli_parse_test.go
+++ b/internal/cli/cli_parse_test.go
@@ -171,6 +171,42 @@ func TestSandboxListParsesAllFlag(t *testing.T) {
 	}
 }
 
+func TestSandboxInspectParsesLastFlag(t *testing.T) {
+	c := &CLI{}
+	parser := newParserForTest(t, c)
+
+	if _, err := parser.Parse([]string{"sandbox", "inspect", "--last"}); err != nil {
+		t.Fatalf("parse sandbox inspect --last returned error: %v", err)
+	}
+	if !c.Sandbox.Inspect.Last {
+		t.Fatal("expected sandbox inspect last flag to be set")
+	}
+}
+
+func TestExecutionListParsesAllFlag(t *testing.T) {
+	c := &CLI{}
+	parser := newParserForTest(t, c)
+
+	if _, err := parser.Parse([]string{"execution", "ls", "--all"}); err != nil {
+		t.Fatalf("parse execution ls --all returned error: %v", err)
+	}
+	if !c.Execution.List.All {
+		t.Fatal("expected execution list all flag to be set")
+	}
+}
+
+func TestExecutionInspectParsesLastWithoutSandboxID(t *testing.T) {
+	c := &CLI{}
+	parser := newParserForTest(t, c)
+
+	if _, err := parser.Parse([]string{"execution", "inspect", "--last"}); err != nil {
+		t.Fatalf("parse execution inspect --last returned error: %v", err)
+	}
+	if !c.Execution.Inspect.Last {
+		t.Fatal("expected execution inspect last flag to be set")
+	}
+}
+
 func TestSandboxCreateParsesImageOverride(t *testing.T) {
 	c := &CLI{}
 	parser := newParserForTest(t, c)

--- a/internal/cli/execution.go
+++ b/internal/cli/execution.go
@@ -6,21 +6,88 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"text/tabwriter"
 
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
 	"github.com/buildkite/cleanroom/internal/runtimeconfig"
 )
 
 type ExecutionCommand struct {
+	List    ExecutionListCommand    `name:"ls" aliases:"list" cmd:"" help:"List known executions"`
 	Inspect ExecutionInspectCommand `name:"inspect" aliases:"show" cmd:"" help:"Inspect an execution and its diagnostics"`
+}
+
+type ExecutionListCommand struct {
+	clientFlags
+	SandboxID string `name:"sandbox-id" help:"Only list executions for this sandbox"`
+	All       bool   `help:"Include finished executions"`
+	JSON      bool   `help:"Print executions as JSON"`
 }
 
 type ExecutionInspectCommand struct {
 	clientFlags
-	SandboxID   string `name:"sandbox-id" help:"Sandbox ID that owns the execution (required with --last)"`
+	SandboxID   string `name:"sandbox-id" help:"Sandbox ID that owns or scopes the execution"`
 	ExecutionID string `arg:"" optional:"" help:"Execution ID to inspect"`
-	Last        bool   `help:"Inspect the sandbox's last execution (requires --sandbox-id)"`
+	Last        bool   `help:"Inspect the most recent execution globally or within --sandbox-id"`
 	JSON        bool   `help:"Print execution inspection as JSON"`
+}
+
+func (c *ExecutionListCommand) Run(ctx *runtimeContext) error {
+	client, err := c.connect(ctx)
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.ListExecutions(context.Background(), &cleanroomv1.ListExecutionsRequest{
+		SandboxId: strings.TrimSpace(c.SandboxID),
+		All:       c.All,
+	})
+	if err != nil {
+		return fmt.Errorf("list executions: %w", err)
+	}
+
+	if c.JSON {
+		enc := json.NewEncoder(ctx.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(resp.GetExecutions())
+	}
+
+	executions := resp.GetExecutions()
+	if len(executions) == 0 {
+		_, err := fmt.Fprintln(ctx.Stdout, executionListEmptyMessage(c.All, strings.TrimSpace(c.SandboxID)))
+		return err
+	}
+
+	tw := tabwriter.NewWriter(ctx.Stdout, 0, 2, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "ID\tSTATUS\tKIND\tSANDBOX\tSTARTED\tFINISHED"); err != nil {
+		return err
+	}
+	for _, execution := range executions {
+		if execution == nil {
+			continue
+		}
+		started := ""
+		if startedAt := execution.GetStartedAt(); startedAt != nil {
+			started = startedAt.AsTime().Format(timeFormat)
+		}
+		finished := ""
+		if finishedAt := execution.GetFinishedAt(); finishedAt != nil {
+			finished = finishedAt.AsTime().Format(timeFormat)
+		}
+		if _, err := fmt.Fprintf(
+			tw,
+			"%s\t%s\t%s\t%s\t%s\t%s\n",
+			execution.GetExecutionId(),
+			executionStatusString(execution.GetStatus()),
+			executionKindString(execution.GetKind()),
+			execution.GetSandboxId(),
+			started,
+			finished,
+		); err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
 }
 
 func (c *ExecutionInspectCommand) Run(ctx *runtimeContext) error {
@@ -35,20 +102,27 @@ func (c *ExecutionInspectCommand) Run(ctx *runtimeContext) error {
 		if executionID != "" {
 			return errors.New("choose either <execution-id> or --last")
 		}
-		if sandboxID == "" {
-			return errors.New("--sandbox-id is required with --last")
-		}
-		sbResp, err := client.GetSandbox(context.Background(), &cleanroomv1.GetSandboxRequest{SandboxId: sandboxID})
+		listResp, err := client.ListExecutions(context.Background(), &cleanroomv1.ListExecutionsRequest{
+			SandboxId: sandboxID,
+			All:       true,
+		})
 		if err != nil {
-			return fmt.Errorf("get sandbox: %w", err)
+			return fmt.Errorf("list executions: %w", err)
 		}
-		sandbox := sbResp.GetSandbox()
-		if sandbox == nil {
-			return fmt.Errorf("sandbox %q not found", sandboxID)
+		for _, execution := range listResp.GetExecutions() {
+			if execution == nil {
+				continue
+			}
+			executionID = strings.TrimSpace(execution.GetExecutionId())
+			if executionID != "" {
+				break
+			}
 		}
-		executionID = strings.TrimSpace(sandbox.GetLastExecutionId())
 		if executionID == "" {
-			return fmt.Errorf("sandbox %q has no recorded executions", sandboxID)
+			if sandboxID != "" {
+				return fmt.Errorf("sandbox %q has no recorded executions", sandboxID)
+			}
+			return errors.New("no recorded executions")
 		}
 	} else {
 		if executionID == "" {
@@ -169,6 +243,17 @@ func (c *ExecutionInspectCommand) Run(ctx *runtimeContext) error {
 }
 
 const timeFormat = "2006-01-02T15:04:05Z07:00"
+
+func executionListEmptyMessage(includeFinished bool, sandboxID string) string {
+	scope := ""
+	if strings.TrimSpace(sandboxID) != "" {
+		scope = " for sandbox " + strings.TrimSpace(sandboxID)
+	}
+	if includeFinished {
+		return "no recorded executions" + scope
+	}
+	return "no active executions" + scope
+}
 
 func executionStatusString(status cleanroomv1.ExecutionStatus) string {
 	switch status {

--- a/internal/cli/execution.go
+++ b/internal/cli/execution.go
@@ -114,7 +114,11 @@ func (c *ExecutionInspectCommand) Run(ctx *runtimeContext) error {
 				continue
 			}
 			executionID = strings.TrimSpace(execution.GetExecutionId())
+			selectedSandboxID := strings.TrimSpace(execution.GetSandboxId())
 			if executionID != "" {
+				if sandboxID == "" && selectedSandboxID != "" {
+					sandboxID = selectedSandboxID
+				}
 				break
 			}
 		}

--- a/internal/cli/execution_integration_test.go
+++ b/internal/cli/execution_integration_test.go
@@ -161,6 +161,70 @@ func TestExecutionInspectIntegrationSupportsLastAndJSON(t *testing.T) {
 	}
 }
 
+func TestExecutionInspectIntegrationSupportsGlobalLast(t *testing.T) {
+	t.Helper()
+
+	adapter := &integrationAdapter{
+		runFn: func(_ context.Context, req backend.ExecutionRequest) (*backend.ExecutionResult, error) {
+			return &backend.ExecutionResult{
+				ExecutionID: req.ExecutionID,
+				ExitCode:    0,
+				Stdout:      "hello\n",
+				Message:     "done",
+			}, nil
+		},
+	}
+
+	host, svc := startIntegrationServer(t, adapter)
+	client := mustNewControlClient(t, host)
+	firstSandboxID := mustCreateSandbox(t, client)
+	secondSandboxID := mustCreateSandbox(t, client)
+
+	firstResp, err := client.CreateExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
+		SandboxId: firstSandboxID,
+		Command:   []string{"echo", "first"},
+		Kind:      cleanroomv1.ExecutionKind_EXECUTION_KIND_BATCH,
+	})
+	if err != nil {
+		t.Fatalf("CreateExecution first returned error: %v", err)
+	}
+	if _, err := svc.WaitExecution(context.Background(), firstSandboxID, firstResp.GetExecution().GetExecutionId()); err != nil {
+		t.Fatalf("WaitExecution first returned error: %v", err)
+	}
+
+	secondResp, err := client.CreateExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
+		SandboxId: secondSandboxID,
+		Command:   []string{"echo", "second"},
+		Kind:      cleanroomv1.ExecutionKind_EXECUTION_KIND_BATCH,
+	})
+	if err != nil {
+		t.Fatalf("CreateExecution second returned error: %v", err)
+	}
+	secondExecutionID := secondResp.GetExecution().GetExecutionId()
+	if _, err := svc.WaitExecution(context.Background(), secondSandboxID, secondExecutionID); err != nil {
+		t.Fatalf("WaitExecution second returned error: %v", err)
+	}
+
+	outcome := runExecutionInspectWithCapture(ExecutionInspectCommand{
+		clientFlags: clientFlags{Host: host},
+		Last:        true,
+	}, runtimeContext{CWD: t.TempDir()})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err != nil {
+		t.Fatalf("ExecutionInspectCommand.Run returned error: %v", outcome.err)
+	}
+
+	assertContainsAll(
+		t,
+		outcome.stdout,
+		"execution: "+secondExecutionID,
+		"sandbox: "+secondSandboxID,
+		"status: succeeded",
+	)
+}
+
 func TestExecutionInspectIntegrationSupportsGlobalExecutionID(t *testing.T) {
 	t.Helper()
 

--- a/internal/cli/execution_last_integration_test.go
+++ b/internal/cli/execution_last_integration_test.go
@@ -1,0 +1,110 @@
+package cli
+
+import (
+	"context"
+	"reflect"
+	"sync"
+	"testing"
+	"unsafe"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/controlservice"
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+)
+
+func TestExecutionInspectGlobalLastUsesSelectedSandboxID(t *testing.T) {
+	adapter := &integrationAdapter{
+		runFn: func(_ context.Context, req backend.ExecutionRequest) (*backend.ExecutionResult, error) {
+			return &backend.ExecutionResult{
+				ExecutionID: req.ExecutionID,
+				ExitCode:    0,
+				Message:     "done",
+			}, nil
+		},
+	}
+
+	host, svc := startIntegrationServer(t, adapter)
+	client := mustNewControlClient(t, host)
+	firstSandboxID := mustCreateSandbox(t, client)
+	secondSandboxID := mustCreateSandbox(t, client)
+
+	firstResp, err := client.CreateExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
+		SandboxId: firstSandboxID,
+		Command:   []string{"echo", "first"},
+		Kind:      cleanroomv1.ExecutionKind_EXECUTION_KIND_BATCH,
+	})
+	if err != nil {
+		t.Fatalf("CreateExecution first returned error: %v", err)
+	}
+	firstExecutionID := firstResp.GetExecution().GetExecutionId()
+	if _, err := svc.WaitExecution(context.Background(), firstSandboxID, firstExecutionID); err != nil {
+		t.Fatalf("WaitExecution first returned error: %v", err)
+	}
+
+	secondResp, err := client.CreateExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
+		SandboxId: secondSandboxID,
+		Command:   []string{"echo", "second"},
+		Kind:      cleanroomv1.ExecutionKind_EXECUTION_KIND_BATCH,
+	})
+	if err != nil {
+		t.Fatalf("CreateExecution second returned error: %v", err)
+	}
+	secondExecutionID := secondResp.GetExecution().GetExecutionId()
+	if _, err := svc.WaitExecution(context.Background(), secondSandboxID, secondExecutionID); err != nil {
+		t.Fatalf("WaitExecution second returned error: %v", err)
+	}
+
+	forceExecutionID(t, svc, secondSandboxID, secondExecutionID, firstExecutionID)
+
+	outcome := runExecutionInspectWithCapture(ExecutionInspectCommand{
+		clientFlags: clientFlags{Host: host},
+		Last:        true,
+	}, runtimeContext{CWD: t.TempDir()})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err != nil {
+		t.Fatalf("ExecutionInspectCommand.Run returned error: %v", outcome.err)
+	}
+
+	assertContainsAll(
+		t,
+		outcome.stdout,
+		"execution: "+firstExecutionID,
+		"sandbox: "+secondSandboxID,
+		"status: succeeded",
+	)
+}
+
+func forceExecutionID(t *testing.T, svc *controlservice.Service, sandboxID, fromExecutionID, toExecutionID string) {
+	t.Helper()
+
+	mu := rwMutexField(t, svc, "mu")
+	mu.Lock()
+	defer mu.Unlock()
+
+	executionsField := reflect.ValueOf(svc).Elem().FieldByName("executions")
+	executionsValue := reflect.NewAt(executionsField.Type(), unsafe.Pointer(executionsField.UnsafeAddr())).Elem()
+	oldKey := reflect.ValueOf(sandboxID + "/" + fromExecutionID)
+	newKey := reflect.ValueOf(sandboxID + "/" + toExecutionID)
+	entry := executionsValue.MapIndex(oldKey)
+	if !entry.IsValid() || entry.IsNil() {
+		t.Fatalf("execution entry %q missing", sandboxID+"/"+fromExecutionID)
+	}
+
+	executionValue := reflect.NewAt(entry.Elem().Type(), unsafe.Pointer(entry.Pointer())).Elem()
+	idField := executionValue.FieldByName("ID")
+	reflect.NewAt(idField.Type(), unsafe.Pointer(idField.UnsafeAddr())).Elem().SetString(toExecutionID)
+	executionsValue.SetMapIndex(newKey, entry)
+	executionsValue.SetMapIndex(oldKey, reflect.Value{})
+}
+
+func rwMutexField(t *testing.T, svc *controlservice.Service, name string) *sync.RWMutex {
+	t.Helper()
+
+	field := reflect.ValueOf(svc).Elem().FieldByName(name)
+	if !field.IsValid() {
+		t.Fatalf("service field %q missing", name)
+	}
+	return (*sync.RWMutex)(unsafe.Pointer(field.UnsafeAddr()))
+}

--- a/internal/cli/execution_list_integration_test.go
+++ b/internal/cli/execution_list_integration_test.go
@@ -1,0 +1,112 @@
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+)
+
+func runExecutionListWithCapture(cmd ExecutionListCommand, ctx runtimeContext) execOutcome {
+	return runWithCapture(func(runCtx *runtimeContext) error {
+		return cmd.Run(runCtx)
+	}, nil, ctx)
+}
+
+func TestExecutionListIntegrationShowsActiveExecutionsByDefault(t *testing.T) {
+	blockExecution := make(chan struct{})
+	adapter := &integrationAdapter{
+		runFn: func(_ context.Context, req backend.ExecutionRequest) (*backend.ExecutionResult, error) {
+			<-blockExecution
+			return &backend.ExecutionResult{
+				ExecutionID: req.ExecutionID,
+				ExitCode:    0,
+			}, nil
+		},
+	}
+
+	host, svc := startIntegrationServer(t, adapter)
+	client := mustNewControlClient(t, host)
+	sandboxID := mustCreateSandbox(t, client)
+
+	createResp, err := client.CreateExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
+		SandboxId: sandboxID,
+		Command:   []string{"sleep", "1"},
+		Kind:      cleanroomv1.ExecutionKind_EXECUTION_KIND_BATCH,
+	})
+	if err != nil {
+		t.Fatalf("CreateExecution returned error: %v", err)
+	}
+	executionID := createResp.GetExecution().GetExecutionId()
+
+	outcome := runExecutionListWithCapture(ExecutionListCommand{
+		clientFlags: clientFlags{Host: host},
+	}, runtimeContext{CWD: t.TempDir()})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err != nil {
+		t.Fatalf("ExecutionListCommand.Run returned error: %v", outcome.err)
+	}
+	assertContainsAll(t, outcome.stdout, "ID", executionID, sandboxID)
+
+	close(blockExecution)
+	if _, err := svc.WaitExecution(context.Background(), sandboxID, executionID); err != nil {
+		t.Fatalf("WaitExecution returned error: %v", err)
+	}
+}
+
+func TestExecutionListIntegrationIncludesFinishedExecutionsWithAll(t *testing.T) {
+	adapter := &integrationAdapter{
+		runFn: func(_ context.Context, req backend.ExecutionRequest) (*backend.ExecutionResult, error) {
+			return &backend.ExecutionResult{
+				ExecutionID: req.ExecutionID,
+				ExitCode:    0,
+			}, nil
+		},
+	}
+
+	host, svc := startIntegrationServer(t, adapter)
+	client := mustNewControlClient(t, host)
+	sandboxID := mustCreateSandbox(t, client)
+
+	createResp, err := client.CreateExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
+		SandboxId: sandboxID,
+		Command:   []string{"echo", "ok"},
+		Kind:      cleanroomv1.ExecutionKind_EXECUTION_KIND_BATCH,
+	})
+	if err != nil {
+		t.Fatalf("CreateExecution returned error: %v", err)
+	}
+	executionID := createResp.GetExecution().GetExecutionId()
+	if _, err := svc.WaitExecution(context.Background(), sandboxID, executionID); err != nil {
+		t.Fatalf("WaitExecution returned error: %v", err)
+	}
+
+	defaultOutcome := runExecutionListWithCapture(ExecutionListCommand{
+		clientFlags: clientFlags{Host: host},
+	}, runtimeContext{CWD: t.TempDir()})
+	if defaultOutcome.cause != nil {
+		t.Fatalf("capture failure: %v", defaultOutcome.cause)
+	}
+	if defaultOutcome.err != nil {
+		t.Fatalf("ExecutionListCommand.Run returned error: %v", defaultOutcome.err)
+	}
+	if !strings.Contains(defaultOutcome.stdout, "no active executions") {
+		t.Fatalf("expected default list to hide finished executions, got %q", defaultOutcome.stdout)
+	}
+
+	allOutcome := runExecutionListWithCapture(ExecutionListCommand{
+		clientFlags: clientFlags{Host: host},
+		All:         true,
+	}, runtimeContext{CWD: t.TempDir()})
+	if allOutcome.cause != nil {
+		t.Fatalf("capture failure: %v", allOutcome.cause)
+	}
+	if allOutcome.err != nil {
+		t.Fatalf("ExecutionListCommand.Run with --all returned error: %v", allOutcome.err)
+	}
+	assertContainsAll(t, allOutcome.stdout, "ID", executionID, sandboxID, "succeeded")
+}

--- a/internal/cli/sandbox.go
+++ b/internal/cli/sandbox.go
@@ -41,7 +41,8 @@ type SandboxListCommand struct {
 
 type SandboxInspectCommand struct {
 	clientFlags
-	SandboxID string `arg:"" required:"" help:"Sandbox ID to inspect"`
+	SandboxID string `arg:"" optional:"" help:"Sandbox ID to inspect"`
+	Last      bool   `help:"Inspect the most recent sandbox"`
 	JSON      bool   `help:"Print sandbox as JSON"`
 }
 
@@ -112,15 +113,40 @@ func (c *SandboxInspectCommand) Run(ctx *runtimeContext) error {
 		return err
 	}
 
+	sandboxID := strings.TrimSpace(c.SandboxID)
+	if c.Last {
+		if sandboxID != "" {
+			return errors.New("choose either <sandbox-id> or --last")
+		}
+		listResp, err := client.ListSandboxes(context.Background(), &cleanroomv1.ListSandboxesRequest{})
+		if err != nil {
+			return fmt.Errorf("list sandboxes: %w", err)
+		}
+		for _, sandbox := range listResp.GetSandboxes() {
+			if sandbox == nil {
+				continue
+			}
+			sandboxID = strings.TrimSpace(sandbox.GetSandboxId())
+			if sandboxID != "" {
+				break
+			}
+		}
+		if sandboxID == "" {
+			return errors.New("no sandboxes available")
+		}
+	} else if sandboxID == "" {
+		return errors.New("missing <sandbox-id> or use --last")
+	}
+
 	resp, err := client.GetSandbox(context.Background(), &cleanroomv1.GetSandboxRequest{
-		SandboxId: c.SandboxID,
+		SandboxId: sandboxID,
 	})
 	if err != nil {
 		return err
 	}
 	sandbox := resp.GetSandbox()
 	if sandbox == nil {
-		return fmt.Errorf("sandbox %q not found", c.SandboxID)
+		return fmt.Errorf("sandbox %q not found", sandboxID)
 	}
 
 	if c.JSON {

--- a/internal/cli/sandbox_inspect_integration_test.go
+++ b/internal/cli/sandbox_inspect_integration_test.go
@@ -87,6 +87,29 @@ func TestSandboxInspectIntegrationJSON(t *testing.T) {
 	}
 }
 
+func TestSandboxInspectIntegrationSupportsLast(t *testing.T) {
+	host, _ := startIntegrationServer(t, &integrationAdapter{})
+	cwd := t.TempDir()
+
+	client := mustNewControlClient(t, host)
+	_ = mustCreateSandbox(t, client)
+	latestSandboxID := mustCreateSandbox(t, client)
+
+	outcome := runSandboxInspectWithCapture(SandboxInspectCommand{
+		clientFlags: clientFlags{Host: host},
+		Last:        true,
+	}, runtimeContext{CWD: cwd})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err != nil {
+		t.Fatalf("SandboxInspectCommand.Run returned error: %v", outcome.err)
+	}
+	if !strings.Contains(outcome.stdout, "sandbox: "+latestSandboxID) {
+		t.Fatalf("expected latest sandbox id in output, got %q", outcome.stdout)
+	}
+}
+
 func TestSandboxInspectIntegrationShowsProvenance(t *testing.T) {
 	host, _ := startIntegrationServer(t, &snapshotIntegrationAdapter{})
 	cwd := t.TempDir()

--- a/internal/controlclient/client.go
+++ b/internal/controlclient/client.go
@@ -195,6 +195,14 @@ func (c *Client) DeleteSnapshot(ctx context.Context, req *cleanroomv1.DeleteSnap
 	return resp.Msg, nil
 }
 
+func (c *Client) ListExecutions(ctx context.Context, req *cleanroomv1.ListExecutionsRequest) (*cleanroomv1.ListExecutionsResponse, error) {
+	resp, err := c.executionClient.ListExecutions(ctx, connect.NewRequest(req))
+	if err != nil {
+		return nil, err
+	}
+	return resp.Msg, nil
+}
+
 func (c *Client) CreateExecution(ctx context.Context, req *cleanroomv1.CreateExecutionRequest) (*cleanroomv1.CreateExecutionResponse, error) {
 	resp, err := c.executionClient.CreateExecution(ctx, connect.NewRequest(req))
 	if err != nil {

--- a/internal/controlserver/server.go
+++ b/internal/controlserver/server.go
@@ -22,9 +22,9 @@ import (
 	"github.com/buildkite/cleanroom/internal/gen/cleanroom/v1/cleanroomv1connect"
 	"github.com/buildkite/cleanroom/internal/tlsconfig"
 	"github.com/charmbracelet/log"
-	"google.golang.org/protobuf/types/known/timestamppb"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // TLSOptions holds explicit TLS paths for the server.
@@ -192,6 +192,14 @@ func (s *Server) ListSnapshots(ctx context.Context, req *connect.Request[cleanro
 
 func (s *Server) DeleteSnapshot(ctx context.Context, req *connect.Request[cleanroomv1.DeleteSnapshotRequest]) (*connect.Response[cleanroomv1.DeleteSnapshotResponse], error) {
 	resp, err := s.service.DeleteSnapshot(ctx, req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (s *Server) ListExecutions(ctx context.Context, req *connect.Request[cleanroomv1.ListExecutionsRequest]) (*connect.Response[cleanroomv1.ListExecutionsResponse], error) {
+	resp, err := s.service.ListExecutions(ctx, req.Msg)
 	if err != nil {
 		return nil, toConnectError(err)
 	}

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -734,24 +734,31 @@ func (s *Service) GetSandbox(_ context.Context, req *cleanroomv1.GetSandboxReque
 
 func (s *Service) ListSandboxes(_ context.Context, _ *cleanroomv1.ListSandboxesRequest) (*cleanroomv1.ListSandboxesResponse, error) {
 	s.mu.RLock()
-	items := make([]*sandboxState, 0, len(s.sandboxes))
+	type sandboxListItem struct {
+		sandbox  *cleanroomv1.Sandbox
+		sortTime time.Time
+	}
+	items := make([]sandboxListItem, 0, len(s.sandboxes))
 	for _, sb := range s.sandboxes {
-		items = append(items, sb)
+		items = append(items, sandboxListItem{
+			sandbox:  cloneSandboxLocked(sb),
+			sortTime: sandboxTerminalTime(sb),
+		})
 	}
 	s.mu.RUnlock()
 
 	sort.Slice(items, func(i, j int) bool {
-		left := sandboxTerminalTime(items[i])
-		right := sandboxTerminalTime(items[j])
+		left := items[i].sortTime
+		right := items[j].sortTime
 		if left.Equal(right) {
-			return items[i].ID < items[j].ID
+			return items[i].sandbox.GetSandboxId() < items[j].sandbox.GetSandboxId()
 		}
 		return left.After(right)
 	})
 
 	resp := &cleanroomv1.ListSandboxesResponse{Sandboxes: make([]*cleanroomv1.Sandbox, 0, len(items))}
-	for _, sb := range items {
-		resp.Sandboxes = append(resp.Sandboxes, cloneSandboxLocked(sb))
+	for _, item := range items {
+		resp.Sandboxes = append(resp.Sandboxes, item.sandbox)
 	}
 	return resp, nil
 }

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -741,12 +741,67 @@ func (s *Service) ListSandboxes(_ context.Context, _ *cleanroomv1.ListSandboxesR
 	s.mu.RUnlock()
 
 	sort.Slice(items, func(i, j int) bool {
-		return items[i].CreatedAt.Before(items[j].CreatedAt)
+		left := sandboxTerminalTime(items[i])
+		right := sandboxTerminalTime(items[j])
+		if left.Equal(right) {
+			return items[i].ID < items[j].ID
+		}
+		return left.After(right)
 	})
 
 	resp := &cleanroomv1.ListSandboxesResponse{Sandboxes: make([]*cleanroomv1.Sandbox, 0, len(items))}
 	for _, sb := range items {
 		resp.Sandboxes = append(resp.Sandboxes, cloneSandboxLocked(sb))
+	}
+	return resp, nil
+}
+
+func (s *Service) ListExecutions(_ context.Context, req *cleanroomv1.ListExecutionsRequest) (*cleanroomv1.ListExecutionsResponse, error) {
+	if req == nil {
+		req = &cleanroomv1.ListExecutionsRequest{}
+	}
+	sandboxID := strings.TrimSpace(req.GetSandboxId())
+	includeFinal := req.GetAll()
+
+	type executionListItem struct {
+		execution *cleanroomv1.Execution
+		sortTime  time.Time
+	}
+
+	s.mu.RLock()
+	items := make([]executionListItem, 0, len(s.executions))
+	for _, ex := range s.executions {
+		if ex == nil {
+			continue
+		}
+		if sandboxID != "" && ex.SandboxID != sandboxID {
+			continue
+		}
+		if !includeFinal && isFinalExecutionStatus(ex.Status) {
+			continue
+		}
+		items = append(items, executionListItem{
+			execution: cloneExecutionLocked(ex),
+			sortTime:  executionSortTime(ex, s.sandboxes[ex.SandboxID]),
+		})
+	}
+	s.mu.RUnlock()
+
+	sort.Slice(items, func(i, j int) bool {
+		left := items[i].sortTime
+		right := items[j].sortTime
+		if left.Equal(right) {
+			if items[i].execution.GetSandboxId() == items[j].execution.GetSandboxId() {
+				return items[i].execution.GetExecutionId() < items[j].execution.GetExecutionId()
+			}
+			return items[i].execution.GetSandboxId() < items[j].execution.GetSandboxId()
+		}
+		return left.After(right)
+	})
+
+	resp := &cleanroomv1.ListExecutionsResponse{Executions: make([]*cleanroomv1.Execution, 0, len(items))}
+	for _, item := range items {
+		resp.Executions = append(resp.Executions, item.execution)
 	}
 	return resp, nil
 }

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -5537,6 +5537,61 @@ func TestStatePruningBoundsRetainedTerminalState(t *testing.T) {
 	}
 }
 
+func TestListExecutionsSupportsRetainedExecutionFromPrunedSandbox(t *testing.T) {
+	svc := newTestService(&stubAdapter{})
+	retention := testRetentionPolicy()
+	retention.maxRetainedStoppedSandboxes = 1
+	retention.maxRetainedFinishedExecutions = 2
+	retention.retainedStateMaxAge = 24 * time.Hour
+	svc.runtime.retention = retention
+
+	runOnce := func() (string, string) {
+		createSandboxResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+		if err != nil {
+			t.Fatalf("CreateSandbox returned error: %v", err)
+		}
+		sandboxID := createSandboxResp.GetSandbox().GetSandboxId()
+
+		createExecutionResp, err := svc.CreateExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
+			SandboxId: sandboxID,
+			Command:   []string{"echo", "ok"},
+		})
+		if err != nil {
+			t.Fatalf("CreateExecution returned error: %v", err)
+		}
+		executionID := createExecutionResp.GetExecution().GetExecutionId()
+
+		if _, err := svc.WaitExecution(context.Background(), sandboxID, executionID); err != nil {
+			t.Fatalf("WaitExecution returned error: %v", err)
+		}
+		if _, err := svc.TerminateSandbox(context.Background(), &cleanroomv1.TerminateSandboxRequest{SandboxId: sandboxID}); err != nil {
+			t.Fatalf("TerminateSandbox returned error: %v", err)
+		}
+		return sandboxID, executionID
+	}
+
+	_, _ = runOnce()
+	prunedSandboxID, retainedExecutionID := runOnce()
+	_, _ = runOnce()
+
+	resp, err := svc.ListExecutions(context.Background(), &cleanroomv1.ListExecutionsRequest{
+		SandboxId: prunedSandboxID,
+		All:       true,
+	})
+	if err != nil {
+		t.Fatalf("ListExecutions returned error: %v", err)
+	}
+	if got, want := len(resp.GetExecutions()), 1; got != want {
+		t.Fatalf("unexpected execution count: got %d want %d", got, want)
+	}
+	if got, want := resp.GetExecutions()[0].GetExecutionId(), retainedExecutionID; got != want {
+		t.Fatalf("unexpected execution id: got %q want %q", got, want)
+	}
+	if got, want := resp.GetExecutions()[0].GetSandboxId(), prunedSandboxID; got != want {
+		t.Fatalf("unexpected sandbox id: got %q want %q", got, want)
+	}
+}
+
 func TestExecutionRetentionBoundsOutput(t *testing.T) {
 	adapter := &stubAdapter{
 		runStreamFn: func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -5592,6 +5592,51 @@ func TestListExecutionsSupportsRetainedExecutionFromPrunedSandbox(t *testing.T) 
 	}
 }
 
+func TestListSandboxesReturnsNewestSnapshotFirst(t *testing.T) {
+	svc := newTestService(&stubAdapter{})
+	first := &sandboxState{
+		ID:        "sandbox_first",
+		Status:    cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY,
+		CreatedAt: time.Unix(1_700_000_000, 0).UTC(),
+		UpdatedAt: time.Unix(1_700_000_010, 0).UTC(),
+		events:    newEventFeed[*cleanroomv1.SandboxEvent](0),
+		Done:      make(chan struct{}),
+	}
+	second := &sandboxState{
+		ID:        "sandbox_second",
+		Status:    cleanroomv1.SandboxStatus_SANDBOX_STATUS_STOPPED,
+		CreatedAt: time.Unix(1_700_000_100, 0).UTC(),
+		UpdatedAt: time.Unix(1_700_000_200, 0).UTC(),
+		events:    newEventFeed[*cleanroomv1.SandboxEvent](0),
+		Done:      make(chan struct{}),
+	}
+
+	svc.mu.Lock()
+	svc.ensureMapsLocked()
+	svc.sandboxes[first.ID] = first
+	svc.sandboxes[second.ID] = second
+	svc.mu.Unlock()
+
+	resp, err := svc.ListSandboxes(context.Background(), &cleanroomv1.ListSandboxesRequest{})
+	if err != nil {
+		t.Fatalf("ListSandboxes returned error: %v", err)
+	}
+
+	sandboxes := resp.GetSandboxes()
+	if got, want := len(sandboxes), 2; got != want {
+		t.Fatalf("unexpected sandbox count: got %d want %d", got, want)
+	}
+	if got, want := sandboxes[0].GetSandboxId(), second.ID; got != want {
+		t.Fatalf("unexpected first sandbox id: got %q want %q", got, want)
+	}
+	if got, want := sandboxes[0].GetUpdatedAt().AsTime(), second.UpdatedAt; !got.Equal(want) {
+		t.Fatalf("unexpected first sandbox updated_at: got %v want %v", got, want)
+	}
+	if got, want := sandboxes[1].GetSandboxId(), first.ID; got != want {
+		t.Fatalf("unexpected second sandbox id: got %q want %q", got, want)
+	}
+}
+
 func TestExecutionRetentionBoundsOutput(t *testing.T) {
 	adapter := &stubAdapter{
 		runStreamFn: func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {

--- a/internal/controlservice/state_helpers.go
+++ b/internal/controlservice/state_helpers.go
@@ -80,6 +80,13 @@ func executionTerminalTime(ex *executionState) time.Time {
 	return time.Time{}
 }
 
+func executionSortTime(ex *executionState, sb *sandboxState) time.Time {
+	if when := executionTerminalTime(ex); !when.IsZero() {
+		return when
+	}
+	return sandboxTerminalTime(sb)
+}
+
 func sandboxTerminalTime(sb *sandboxState) time.Time {
 	if sb == nil {
 		return time.Time{}

--- a/internal/gen/cleanroom/v1/cleanroomv1connect/control.connect.go
+++ b/internal/gen/cleanroom/v1/cleanroomv1connect/control.connect.go
@@ -70,6 +70,9 @@ const (
 	// SnapshotServiceDeleteSnapshotProcedure is the fully-qualified name of the SnapshotService's
 	// DeleteSnapshot RPC.
 	SnapshotServiceDeleteSnapshotProcedure = "/cleanroom.v1.SnapshotService/DeleteSnapshot"
+	// ExecutionServiceListExecutionsProcedure is the fully-qualified name of the ExecutionService's
+	// ListExecutions RPC.
+	ExecutionServiceListExecutionsProcedure = "/cleanroom.v1.ExecutionService/ListExecutions"
 	// ExecutionServiceCreateExecutionProcedure is the fully-qualified name of the ExecutionService's
 	// CreateExecution RPC.
 	ExecutionServiceCreateExecutionProcedure = "/cleanroom.v1.ExecutionService/CreateExecution"
@@ -472,6 +475,7 @@ func (UnimplementedSnapshotServiceHandler) DeleteSnapshot(context.Context, *conn
 
 // ExecutionServiceClient is a client for the cleanroom.v1.ExecutionService service.
 type ExecutionServiceClient interface {
+	ListExecutions(context.Context, *connect.Request[v1.ListExecutionsRequest]) (*connect.Response[v1.ListExecutionsResponse], error)
 	CreateExecution(context.Context, *connect.Request[v1.CreateExecutionRequest]) (*connect.Response[v1.CreateExecutionResponse], error)
 	AttachExecution(context.Context, *connect.Request[v1.AttachExecutionRequest]) (*connect.Response[v1.AttachExecutionResponse], error)
 	GetExecution(context.Context, *connect.Request[v1.GetExecutionRequest]) (*connect.Response[v1.GetExecutionResponse], error)
@@ -493,6 +497,12 @@ func NewExecutionServiceClient(httpClient connect.HTTPClient, baseURL string, op
 	baseURL = strings.TrimRight(baseURL, "/")
 	executionServiceMethods := v1.File_proto_cleanroom_v1_control_proto.Services().ByName("ExecutionService").Methods()
 	return &executionServiceClient{
+		listExecutions: connect.NewClient[v1.ListExecutionsRequest, v1.ListExecutionsResponse](
+			httpClient,
+			baseURL+ExecutionServiceListExecutionsProcedure,
+			connect.WithSchema(executionServiceMethods.ByName("ListExecutions")),
+			connect.WithClientOptions(opts...),
+		),
 		createExecution: connect.NewClient[v1.CreateExecutionRequest, v1.CreateExecutionResponse](
 			httpClient,
 			baseURL+ExecutionServiceCreateExecutionProcedure,
@@ -546,6 +556,7 @@ func NewExecutionServiceClient(httpClient connect.HTTPClient, baseURL string, op
 
 // executionServiceClient implements ExecutionServiceClient.
 type executionServiceClient struct {
+	listExecutions      *connect.Client[v1.ListExecutionsRequest, v1.ListExecutionsResponse]
 	createExecution     *connect.Client[v1.CreateExecutionRequest, v1.CreateExecutionResponse]
 	attachExecution     *connect.Client[v1.AttachExecutionRequest, v1.AttachExecutionResponse]
 	getExecution        *connect.Client[v1.GetExecutionRequest, v1.GetExecutionResponse]
@@ -554,6 +565,11 @@ type executionServiceClient struct {
 	writeExecutionStdin *connect.Client[v1.WriteExecutionStdinRequest, v1.WriteExecutionStdinResponse]
 	closeExecutionStdin *connect.Client[v1.CloseExecutionStdinRequest, v1.CloseExecutionStdinResponse]
 	streamExecution     *connect.Client[v1.StreamExecutionRequest, v1.ExecutionStreamEvent]
+}
+
+// ListExecutions calls cleanroom.v1.ExecutionService.ListExecutions.
+func (c *executionServiceClient) ListExecutions(ctx context.Context, req *connect.Request[v1.ListExecutionsRequest]) (*connect.Response[v1.ListExecutionsResponse], error) {
+	return c.listExecutions.CallUnary(ctx, req)
 }
 
 // CreateExecution calls cleanroom.v1.ExecutionService.CreateExecution.
@@ -598,6 +614,7 @@ func (c *executionServiceClient) StreamExecution(ctx context.Context, req *conne
 
 // ExecutionServiceHandler is an implementation of the cleanroom.v1.ExecutionService service.
 type ExecutionServiceHandler interface {
+	ListExecutions(context.Context, *connect.Request[v1.ListExecutionsRequest]) (*connect.Response[v1.ListExecutionsResponse], error)
 	CreateExecution(context.Context, *connect.Request[v1.CreateExecutionRequest]) (*connect.Response[v1.CreateExecutionResponse], error)
 	AttachExecution(context.Context, *connect.Request[v1.AttachExecutionRequest]) (*connect.Response[v1.AttachExecutionResponse], error)
 	GetExecution(context.Context, *connect.Request[v1.GetExecutionRequest]) (*connect.Response[v1.GetExecutionResponse], error)
@@ -615,6 +632,12 @@ type ExecutionServiceHandler interface {
 // and JSON codecs. They also support gzip compression.
 func NewExecutionServiceHandler(svc ExecutionServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
 	executionServiceMethods := v1.File_proto_cleanroom_v1_control_proto.Services().ByName("ExecutionService").Methods()
+	executionServiceListExecutionsHandler := connect.NewUnaryHandler(
+		ExecutionServiceListExecutionsProcedure,
+		svc.ListExecutions,
+		connect.WithSchema(executionServiceMethods.ByName("ListExecutions")),
+		connect.WithHandlerOptions(opts...),
+	)
 	executionServiceCreateExecutionHandler := connect.NewUnaryHandler(
 		ExecutionServiceCreateExecutionProcedure,
 		svc.CreateExecution,
@@ -665,6 +688,8 @@ func NewExecutionServiceHandler(svc ExecutionServiceHandler, opts ...connect.Han
 	)
 	return "/cleanroom.v1.ExecutionService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
+		case ExecutionServiceListExecutionsProcedure:
+			executionServiceListExecutionsHandler.ServeHTTP(w, r)
 		case ExecutionServiceCreateExecutionProcedure:
 			executionServiceCreateExecutionHandler.ServeHTTP(w, r)
 		case ExecutionServiceAttachExecutionProcedure:
@@ -689,6 +714,10 @@ func NewExecutionServiceHandler(svc ExecutionServiceHandler, opts ...connect.Han
 
 // UnimplementedExecutionServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedExecutionServiceHandler struct{}
+
+func (UnimplementedExecutionServiceHandler) ListExecutions(context.Context, *connect.Request[v1.ListExecutionsRequest]) (*connect.Response[v1.ListExecutionsResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cleanroom.v1.ExecutionService.ListExecutions is not implemented"))
+}
 
 func (UnimplementedExecutionServiceHandler) CreateExecution(context.Context, *connect.Request[v1.CreateExecutionRequest]) (*connect.Response[v1.CreateExecutionResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cleanroom.v1.ExecutionService.CreateExecution is not implemented"))

--- a/internal/gen/cleanroom/v1/control.pb.go
+++ b/internal/gen/cleanroom/v1/control.pb.go
@@ -1658,6 +1658,102 @@ func (x *ListSandboxesResponse) GetSandboxes() []*Sandbox {
 	return nil
 }
 
+type ListExecutionsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SandboxId     string                 `protobuf:"bytes,1,opt,name=sandbox_id,json=sandboxId,proto3" json:"sandbox_id,omitempty"`
+	All           bool                   `protobuf:"varint,2,opt,name=all,proto3" json:"all,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListExecutionsRequest) Reset() {
+	*x = ListExecutionsRequest{}
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListExecutionsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListExecutionsRequest) ProtoMessage() {}
+
+func (x *ListExecutionsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListExecutionsRequest.ProtoReflect.Descriptor instead.
+func (*ListExecutionsRequest) Descriptor() ([]byte, []int) {
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *ListExecutionsRequest) GetSandboxId() string {
+	if x != nil {
+		return x.SandboxId
+	}
+	return ""
+}
+
+func (x *ListExecutionsRequest) GetAll() bool {
+	if x != nil {
+		return x.All
+	}
+	return false
+}
+
+type ListExecutionsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Executions    []*Execution           `protobuf:"bytes,1,rep,name=executions,proto3" json:"executions,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListExecutionsResponse) Reset() {
+	*x = ListExecutionsResponse{}
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[21]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListExecutionsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListExecutionsResponse) ProtoMessage() {}
+
+func (x *ListExecutionsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[21]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListExecutionsResponse.ProtoReflect.Descriptor instead.
+func (*ListExecutionsResponse) Descriptor() ([]byte, []int) {
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{21}
+}
+
+func (x *ListExecutionsResponse) GetExecutions() []*Execution {
+	if x != nil {
+		return x.Executions
+	}
+	return nil
+}
+
 type DownloadSandboxFileRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	SandboxId     string                 `protobuf:"bytes,1,opt,name=sandbox_id,json=sandboxId,proto3" json:"sandbox_id,omitempty"`
@@ -1669,7 +1765,7 @@ type DownloadSandboxFileRequest struct {
 
 func (x *DownloadSandboxFileRequest) Reset() {
 	*x = DownloadSandboxFileRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[20]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1681,7 +1777,7 @@ func (x *DownloadSandboxFileRequest) String() string {
 func (*DownloadSandboxFileRequest) ProtoMessage() {}
 
 func (x *DownloadSandboxFileRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[20]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1694,7 +1790,7 @@ func (x *DownloadSandboxFileRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DownloadSandboxFileRequest.ProtoReflect.Descriptor instead.
 func (*DownloadSandboxFileRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{20}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *DownloadSandboxFileRequest) GetSandboxId() string {
@@ -1730,7 +1826,7 @@ type DownloadSandboxFileResponse struct {
 
 func (x *DownloadSandboxFileResponse) Reset() {
 	*x = DownloadSandboxFileResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[21]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1742,7 +1838,7 @@ func (x *DownloadSandboxFileResponse) String() string {
 func (*DownloadSandboxFileResponse) ProtoMessage() {}
 
 func (x *DownloadSandboxFileResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[21]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1755,7 +1851,7 @@ func (x *DownloadSandboxFileResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DownloadSandboxFileResponse.ProtoReflect.Descriptor instead.
 func (*DownloadSandboxFileResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{21}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *DownloadSandboxFileResponse) GetSandboxId() string {
@@ -1795,7 +1891,7 @@ type TerminateSandboxRequest struct {
 
 func (x *TerminateSandboxRequest) Reset() {
 	*x = TerminateSandboxRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[22]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1807,7 +1903,7 @@ func (x *TerminateSandboxRequest) String() string {
 func (*TerminateSandboxRequest) ProtoMessage() {}
 
 func (x *TerminateSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[22]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1820,7 +1916,7 @@ func (x *TerminateSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TerminateSandboxRequest.ProtoReflect.Descriptor instead.
 func (*TerminateSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{22}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *TerminateSandboxRequest) GetSandboxId() string {
@@ -1841,7 +1937,7 @@ type TerminateSandboxResponse struct {
 
 func (x *TerminateSandboxResponse) Reset() {
 	*x = TerminateSandboxResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[23]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1853,7 +1949,7 @@ func (x *TerminateSandboxResponse) String() string {
 func (*TerminateSandboxResponse) ProtoMessage() {}
 
 func (x *TerminateSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[23]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1866,7 +1962,7 @@ func (x *TerminateSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TerminateSandboxResponse.ProtoReflect.Descriptor instead.
 func (*TerminateSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{23}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *TerminateSandboxResponse) GetSandboxId() string {
@@ -1900,7 +1996,7 @@ type StreamSandboxEventsRequest struct {
 
 func (x *StreamSandboxEventsRequest) Reset() {
 	*x = StreamSandboxEventsRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[24]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1912,7 +2008,7 @@ func (x *StreamSandboxEventsRequest) String() string {
 func (*StreamSandboxEventsRequest) ProtoMessage() {}
 
 func (x *StreamSandboxEventsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[24]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1925,7 +2021,7 @@ func (x *StreamSandboxEventsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamSandboxEventsRequest.ProtoReflect.Descriptor instead.
 func (*StreamSandboxEventsRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{24}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *StreamSandboxEventsRequest) GetSandboxId() string {
@@ -1954,7 +2050,7 @@ type SandboxEvent struct {
 
 func (x *SandboxEvent) Reset() {
 	*x = SandboxEvent{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[25]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1966,7 +2062,7 @@ func (x *SandboxEvent) String() string {
 func (*SandboxEvent) ProtoMessage() {}
 
 func (x *SandboxEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[25]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1979,7 +2075,7 @@ func (x *SandboxEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxEvent.ProtoReflect.Descriptor instead.
 func (*SandboxEvent) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{25}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *SandboxEvent) GetSandboxId() string {
@@ -2020,7 +2116,7 @@ type CreateSnapshotRequest struct {
 
 func (x *CreateSnapshotRequest) Reset() {
 	*x = CreateSnapshotRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[26]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2032,7 +2128,7 @@ func (x *CreateSnapshotRequest) String() string {
 func (*CreateSnapshotRequest) ProtoMessage() {}
 
 func (x *CreateSnapshotRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[26]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2045,7 +2141,7 @@ func (x *CreateSnapshotRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSnapshotRequest.ProtoReflect.Descriptor instead.
 func (*CreateSnapshotRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{26}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *CreateSnapshotRequest) GetSandboxId() string {
@@ -2072,7 +2168,7 @@ type CreateSnapshotResponse struct {
 
 func (x *CreateSnapshotResponse) Reset() {
 	*x = CreateSnapshotResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[27]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2084,7 +2180,7 @@ func (x *CreateSnapshotResponse) String() string {
 func (*CreateSnapshotResponse) ProtoMessage() {}
 
 func (x *CreateSnapshotResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[27]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2097,7 +2193,7 @@ func (x *CreateSnapshotResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSnapshotResponse.ProtoReflect.Descriptor instead.
 func (*CreateSnapshotResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{27}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *CreateSnapshotResponse) GetSnapshot() *Snapshot {
@@ -2123,7 +2219,7 @@ type GetSnapshotRequest struct {
 
 func (x *GetSnapshotRequest) Reset() {
 	*x = GetSnapshotRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[28]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2135,7 +2231,7 @@ func (x *GetSnapshotRequest) String() string {
 func (*GetSnapshotRequest) ProtoMessage() {}
 
 func (x *GetSnapshotRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[28]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2148,7 +2244,7 @@ func (x *GetSnapshotRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSnapshotRequest.ProtoReflect.Descriptor instead.
 func (*GetSnapshotRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{28}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *GetSnapshotRequest) GetSnapshotId() string {
@@ -2167,7 +2263,7 @@ type GetSnapshotResponse struct {
 
 func (x *GetSnapshotResponse) Reset() {
 	*x = GetSnapshotResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[29]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2179,7 +2275,7 @@ func (x *GetSnapshotResponse) String() string {
 func (*GetSnapshotResponse) ProtoMessage() {}
 
 func (x *GetSnapshotResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[29]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2192,7 +2288,7 @@ func (x *GetSnapshotResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSnapshotResponse.ProtoReflect.Descriptor instead.
 func (*GetSnapshotResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{29}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *GetSnapshotResponse) GetSnapshot() *Snapshot {
@@ -2210,7 +2306,7 @@ type ListSnapshotsRequest struct {
 
 func (x *ListSnapshotsRequest) Reset() {
 	*x = ListSnapshotsRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[30]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2222,7 +2318,7 @@ func (x *ListSnapshotsRequest) String() string {
 func (*ListSnapshotsRequest) ProtoMessage() {}
 
 func (x *ListSnapshotsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[30]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2235,7 +2331,7 @@ func (x *ListSnapshotsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSnapshotsRequest.ProtoReflect.Descriptor instead.
 func (*ListSnapshotsRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{30}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{32}
 }
 
 type ListSnapshotsResponse struct {
@@ -2247,7 +2343,7 @@ type ListSnapshotsResponse struct {
 
 func (x *ListSnapshotsResponse) Reset() {
 	*x = ListSnapshotsResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[31]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2259,7 +2355,7 @@ func (x *ListSnapshotsResponse) String() string {
 func (*ListSnapshotsResponse) ProtoMessage() {}
 
 func (x *ListSnapshotsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[31]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2272,7 +2368,7 @@ func (x *ListSnapshotsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSnapshotsResponse.ProtoReflect.Descriptor instead.
 func (*ListSnapshotsResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{31}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *ListSnapshotsResponse) GetSnapshots() []*Snapshot {
@@ -2291,7 +2387,7 @@ type DeleteSnapshotRequest struct {
 
 func (x *DeleteSnapshotRequest) Reset() {
 	*x = DeleteSnapshotRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[32]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2303,7 +2399,7 @@ func (x *DeleteSnapshotRequest) String() string {
 func (*DeleteSnapshotRequest) ProtoMessage() {}
 
 func (x *DeleteSnapshotRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[32]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2316,7 +2412,7 @@ func (x *DeleteSnapshotRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSnapshotRequest.ProtoReflect.Descriptor instead.
 func (*DeleteSnapshotRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{32}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *DeleteSnapshotRequest) GetSnapshotId() string {
@@ -2337,7 +2433,7 @@ type DeleteSnapshotResponse struct {
 
 func (x *DeleteSnapshotResponse) Reset() {
 	*x = DeleteSnapshotResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[33]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2349,7 +2445,7 @@ func (x *DeleteSnapshotResponse) String() string {
 func (*DeleteSnapshotResponse) ProtoMessage() {}
 
 func (x *DeleteSnapshotResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[33]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2362,7 +2458,7 @@ func (x *DeleteSnapshotResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSnapshotResponse.ProtoReflect.Descriptor instead.
 func (*DeleteSnapshotResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{33}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *DeleteSnapshotResponse) GetSnapshotId() string {
@@ -2403,7 +2499,7 @@ type Execution struct {
 
 func (x *Execution) Reset() {
 	*x = Execution{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[34]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2415,7 +2511,7 @@ func (x *Execution) String() string {
 func (*Execution) ProtoMessage() {}
 
 func (x *Execution) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[34]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2428,7 +2524,7 @@ func (x *Execution) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Execution.ProtoReflect.Descriptor instead.
 func (*Execution) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{34}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *Execution) GetExecutionId() string {
@@ -2504,7 +2600,7 @@ type ExecutionOptions struct {
 
 func (x *ExecutionOptions) Reset() {
 	*x = ExecutionOptions{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[35]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2516,7 +2612,7 @@ func (x *ExecutionOptions) String() string {
 func (*ExecutionOptions) ProtoMessage() {}
 
 func (x *ExecutionOptions) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[35]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2529,7 +2625,7 @@ func (x *ExecutionOptions) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionOptions.ProtoReflect.Descriptor instead.
 func (*ExecutionOptions) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{35}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *ExecutionOptions) GetLaunchSeconds() int64 {
@@ -2560,7 +2656,7 @@ type CreateExecutionRequest struct {
 
 func (x *CreateExecutionRequest) Reset() {
 	*x = CreateExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[36]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2572,7 +2668,7 @@ func (x *CreateExecutionRequest) String() string {
 func (*CreateExecutionRequest) ProtoMessage() {}
 
 func (x *CreateExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[36]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2585,7 +2681,7 @@ func (x *CreateExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateExecutionRequest.ProtoReflect.Descriptor instead.
 func (*CreateExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{36}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *CreateExecutionRequest) GetSandboxId() string {
@@ -2639,7 +2735,7 @@ type CreateExecutionResponse struct {
 
 func (x *CreateExecutionResponse) Reset() {
 	*x = CreateExecutionResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[37]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2651,7 +2747,7 @@ func (x *CreateExecutionResponse) String() string {
 func (*CreateExecutionResponse) ProtoMessage() {}
 
 func (x *CreateExecutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[37]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2664,7 +2760,7 @@ func (x *CreateExecutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateExecutionResponse.ProtoReflect.Descriptor instead.
 func (*CreateExecutionResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{37}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *CreateExecutionResponse) GetExecution() *Execution {
@@ -2686,7 +2782,7 @@ type AttachExecutionRequest struct {
 
 func (x *AttachExecutionRequest) Reset() {
 	*x = AttachExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[38]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2698,7 +2794,7 @@ func (x *AttachExecutionRequest) String() string {
 func (*AttachExecutionRequest) ProtoMessage() {}
 
 func (x *AttachExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[38]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2711,7 +2807,7 @@ func (x *AttachExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachExecutionRequest.ProtoReflect.Descriptor instead.
 func (*AttachExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{38}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *AttachExecutionRequest) GetSandboxId() string {
@@ -2756,7 +2852,7 @@ type AttachExecutionResponse struct {
 
 func (x *AttachExecutionResponse) Reset() {
 	*x = AttachExecutionResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[39]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2768,7 +2864,7 @@ func (x *AttachExecutionResponse) String() string {
 func (*AttachExecutionResponse) ProtoMessage() {}
 
 func (x *AttachExecutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[39]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2781,7 +2877,7 @@ func (x *AttachExecutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachExecutionResponse.ProtoReflect.Descriptor instead.
 func (*AttachExecutionResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{39}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *AttachExecutionResponse) GetSessionId() string {
@@ -2836,7 +2932,7 @@ type GetExecutionRequest struct {
 
 func (x *GetExecutionRequest) Reset() {
 	*x = GetExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[40]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2848,7 +2944,7 @@ func (x *GetExecutionRequest) String() string {
 func (*GetExecutionRequest) ProtoMessage() {}
 
 func (x *GetExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[40]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2861,7 +2957,7 @@ func (x *GetExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetExecutionRequest.ProtoReflect.Descriptor instead.
 func (*GetExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{40}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *GetExecutionRequest) GetSandboxId() string {
@@ -2887,7 +2983,7 @@ type GetExecutionResponse struct {
 
 func (x *GetExecutionResponse) Reset() {
 	*x = GetExecutionResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[41]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2899,7 +2995,7 @@ func (x *GetExecutionResponse) String() string {
 func (*GetExecutionResponse) ProtoMessage() {}
 
 func (x *GetExecutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[41]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2912,7 +3008,7 @@ func (x *GetExecutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetExecutionResponse.ProtoReflect.Descriptor instead.
 func (*GetExecutionResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{41}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *GetExecutionResponse) GetExecution() *Execution {
@@ -2932,7 +3028,7 @@ type InspectExecutionRequest struct {
 
 func (x *InspectExecutionRequest) Reset() {
 	*x = InspectExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[42]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2944,7 +3040,7 @@ func (x *InspectExecutionRequest) String() string {
 func (*InspectExecutionRequest) ProtoMessage() {}
 
 func (x *InspectExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[42]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2957,7 +3053,7 @@ func (x *InspectExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectExecutionRequest.ProtoReflect.Descriptor instead.
 func (*InspectExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{42}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *InspectExecutionRequest) GetSandboxId() string {
@@ -2994,7 +3090,7 @@ type InspectExecutionResponse struct {
 
 func (x *InspectExecutionResponse) Reset() {
 	*x = InspectExecutionResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[43]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3006,7 +3102,7 @@ func (x *InspectExecutionResponse) String() string {
 func (*InspectExecutionResponse) ProtoMessage() {}
 
 func (x *InspectExecutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[43]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3019,7 +3115,7 @@ func (x *InspectExecutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectExecutionResponse.ProtoReflect.Descriptor instead.
 func (*InspectExecutionResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{43}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *InspectExecutionResponse) GetExecution() *Execution {
@@ -3117,7 +3213,7 @@ type CancelExecutionRequest struct {
 
 func (x *CancelExecutionRequest) Reset() {
 	*x = CancelExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[44]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3129,7 +3225,7 @@ func (x *CancelExecutionRequest) String() string {
 func (*CancelExecutionRequest) ProtoMessage() {}
 
 func (x *CancelExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[44]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3142,7 +3238,7 @@ func (x *CancelExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelExecutionRequest.ProtoReflect.Descriptor instead.
 func (*CancelExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{44}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *CancelExecutionRequest) GetSandboxId() string {
@@ -3178,7 +3274,7 @@ type CancelExecutionResponse struct {
 
 func (x *CancelExecutionResponse) Reset() {
 	*x = CancelExecutionResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[45]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3190,7 +3286,7 @@ func (x *CancelExecutionResponse) String() string {
 func (*CancelExecutionResponse) ProtoMessage() {}
 
 func (x *CancelExecutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[45]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3203,7 +3299,7 @@ func (x *CancelExecutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelExecutionResponse.ProtoReflect.Descriptor instead.
 func (*CancelExecutionResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{45}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *CancelExecutionResponse) GetSandboxId() string {
@@ -3245,7 +3341,7 @@ type WriteExecutionStdinRequest struct {
 
 func (x *WriteExecutionStdinRequest) Reset() {
 	*x = WriteExecutionStdinRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[46]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3257,7 +3353,7 @@ func (x *WriteExecutionStdinRequest) String() string {
 func (*WriteExecutionStdinRequest) ProtoMessage() {}
 
 func (x *WriteExecutionStdinRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[46]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3270,7 +3366,7 @@ func (x *WriteExecutionStdinRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WriteExecutionStdinRequest.ProtoReflect.Descriptor instead.
 func (*WriteExecutionStdinRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{46}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *WriteExecutionStdinRequest) GetSandboxId() string {
@@ -3302,7 +3398,7 @@ type WriteExecutionStdinResponse struct {
 
 func (x *WriteExecutionStdinResponse) Reset() {
 	*x = WriteExecutionStdinResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[47]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3314,7 +3410,7 @@ func (x *WriteExecutionStdinResponse) String() string {
 func (*WriteExecutionStdinResponse) ProtoMessage() {}
 
 func (x *WriteExecutionStdinResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[47]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3327,7 +3423,7 @@ func (x *WriteExecutionStdinResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WriteExecutionStdinResponse.ProtoReflect.Descriptor instead.
 func (*WriteExecutionStdinResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{47}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{49}
 }
 
 type CloseExecutionStdinRequest struct {
@@ -3340,7 +3436,7 @@ type CloseExecutionStdinRequest struct {
 
 func (x *CloseExecutionStdinRequest) Reset() {
 	*x = CloseExecutionStdinRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[48]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3352,7 +3448,7 @@ func (x *CloseExecutionStdinRequest) String() string {
 func (*CloseExecutionStdinRequest) ProtoMessage() {}
 
 func (x *CloseExecutionStdinRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[48]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3365,7 +3461,7 @@ func (x *CloseExecutionStdinRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CloseExecutionStdinRequest.ProtoReflect.Descriptor instead.
 func (*CloseExecutionStdinRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{48}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *CloseExecutionStdinRequest) GetSandboxId() string {
@@ -3390,7 +3486,7 @@ type CloseExecutionStdinResponse struct {
 
 func (x *CloseExecutionStdinResponse) Reset() {
 	*x = CloseExecutionStdinResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[49]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3402,7 +3498,7 @@ func (x *CloseExecutionStdinResponse) String() string {
 func (*CloseExecutionStdinResponse) ProtoMessage() {}
 
 func (x *CloseExecutionStdinResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[49]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3415,7 +3511,7 @@ func (x *CloseExecutionStdinResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CloseExecutionStdinResponse.ProtoReflect.Descriptor instead.
 func (*CloseExecutionStdinResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{49}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{51}
 }
 
 type StreamExecutionRequest struct {
@@ -3429,7 +3525,7 @@ type StreamExecutionRequest struct {
 
 func (x *StreamExecutionRequest) Reset() {
 	*x = StreamExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[50]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3441,7 +3537,7 @@ func (x *StreamExecutionRequest) String() string {
 func (*StreamExecutionRequest) ProtoMessage() {}
 
 func (x *StreamExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[50]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3454,7 +3550,7 @@ func (x *StreamExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamExecutionRequest.ProtoReflect.Descriptor instead.
 func (*StreamExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{50}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *StreamExecutionRequest) GetSandboxId() string {
@@ -3489,7 +3585,7 @@ type ExecutionExit struct {
 
 func (x *ExecutionExit) Reset() {
 	*x = ExecutionExit{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[51]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3501,7 +3597,7 @@ func (x *ExecutionExit) String() string {
 func (*ExecutionExit) ProtoMessage() {}
 
 func (x *ExecutionExit) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[51]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3514,7 +3610,7 @@ func (x *ExecutionExit) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionExit.ProtoReflect.Descriptor instead.
 func (*ExecutionExit) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{51}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *ExecutionExit) GetExitCode() int32 {
@@ -3560,7 +3656,7 @@ type ExecutionStreamEvent struct {
 
 func (x *ExecutionStreamEvent) Reset() {
 	*x = ExecutionStreamEvent{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[52]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3572,7 +3668,7 @@ func (x *ExecutionStreamEvent) String() string {
 func (*ExecutionStreamEvent) ProtoMessage() {}
 
 func (x *ExecutionStreamEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[52]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3585,7 +3681,7 @@ func (x *ExecutionStreamEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionStreamEvent.ProtoReflect.Descriptor instead.
 func (*ExecutionStreamEvent) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{52}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *ExecutionStreamEvent) GetSandboxId() string {
@@ -3836,7 +3932,15 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\asandbox\x18\x01 \x01(\v2\x15.cleanroom.v1.SandboxR\asandbox\"\x16\n" +
 	"\x14ListSandboxesRequest\"L\n" +
 	"\x15ListSandboxesResponse\x123\n" +
-	"\tsandboxes\x18\x01 \x03(\v2\x15.cleanroom.v1.SandboxR\tsandboxes\"l\n" +
+	"\tsandboxes\x18\x01 \x03(\v2\x15.cleanroom.v1.SandboxR\tsandboxes\"H\n" +
+	"\x15ListExecutionsRequest\x12\x1d\n" +
+	"\n" +
+	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\x12\x10\n" +
+	"\x03all\x18\x02 \x01(\bR\x03all\"Q\n" +
+	"\x16ListExecutionsResponse\x127\n" +
+	"\n" +
+	"executions\x18\x01 \x03(\v2\x17.cleanroom.v1.ExecutionR\n" +
+	"executions\"l\n" +
 	"\x1aDownloadSandboxFileRequest\x12\x1d\n" +
 	"\n" +
 	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\x12\x12\n" +
@@ -4055,8 +4159,9 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\x0eCreateSnapshot\x12#.cleanroom.v1.CreateSnapshotRequest\x1a$.cleanroom.v1.CreateSnapshotResponse\x12R\n" +
 	"\vGetSnapshot\x12 .cleanroom.v1.GetSnapshotRequest\x1a!.cleanroom.v1.GetSnapshotResponse\x12X\n" +
 	"\rListSnapshots\x12\".cleanroom.v1.ListSnapshotsRequest\x1a#.cleanroom.v1.ListSnapshotsResponse\x12[\n" +
-	"\x0eDeleteSnapshot\x12#.cleanroom.v1.DeleteSnapshotRequest\x1a$.cleanroom.v1.DeleteSnapshotResponse2\xa3\x06\n" +
-	"\x10ExecutionService\x12^\n" +
+	"\x0eDeleteSnapshot\x12#.cleanroom.v1.DeleteSnapshotRequest\x1a$.cleanroom.v1.DeleteSnapshotResponse2\x80\a\n" +
+	"\x10ExecutionService\x12[\n" +
+	"\x0eListExecutions\x12#.cleanroom.v1.ListExecutionsRequest\x1a$.cleanroom.v1.ListExecutionsResponse\x12^\n" +
 	"\x0fCreateExecution\x12$.cleanroom.v1.CreateExecutionRequest\x1a%.cleanroom.v1.CreateExecutionResponse\x12^\n" +
 	"\x0fAttachExecution\x12$.cleanroom.v1.AttachExecutionRequest\x1a%.cleanroom.v1.AttachExecutionResponse\x12U\n" +
 	"\fGetExecution\x12!.cleanroom.v1.GetExecutionRequest\x1a\".cleanroom.v1.GetExecutionResponse\x12a\n" +
@@ -4079,7 +4184,7 @@ func file_proto_cleanroom_v1_control_proto_rawDescGZIP() []byte {
 }
 
 var file_proto_cleanroom_v1_control_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_proto_cleanroom_v1_control_proto_msgTypes = make([]protoimpl.MessageInfo, 53)
+var file_proto_cleanroom_v1_control_proto_msgTypes = make([]protoimpl.MessageInfo, 55)
 var file_proto_cleanroom_v1_control_proto_goTypes = []any{
 	(SandboxStatus)(0),                  // 0: cleanroom.v1.SandboxStatus
 	(CreateSandboxPhase)(0),             // 1: cleanroom.v1.CreateSandboxPhase
@@ -4105,47 +4210,49 @@ var file_proto_cleanroom_v1_control_proto_goTypes = []any{
 	(*GetSandboxResponse)(nil),          // 21: cleanroom.v1.GetSandboxResponse
 	(*ListSandboxesRequest)(nil),        // 22: cleanroom.v1.ListSandboxesRequest
 	(*ListSandboxesResponse)(nil),       // 23: cleanroom.v1.ListSandboxesResponse
-	(*DownloadSandboxFileRequest)(nil),  // 24: cleanroom.v1.DownloadSandboxFileRequest
-	(*DownloadSandboxFileResponse)(nil), // 25: cleanroom.v1.DownloadSandboxFileResponse
-	(*TerminateSandboxRequest)(nil),     // 26: cleanroom.v1.TerminateSandboxRequest
-	(*TerminateSandboxResponse)(nil),    // 27: cleanroom.v1.TerminateSandboxResponse
-	(*StreamSandboxEventsRequest)(nil),  // 28: cleanroom.v1.StreamSandboxEventsRequest
-	(*SandboxEvent)(nil),                // 29: cleanroom.v1.SandboxEvent
-	(*CreateSnapshotRequest)(nil),       // 30: cleanroom.v1.CreateSnapshotRequest
-	(*CreateSnapshotResponse)(nil),      // 31: cleanroom.v1.CreateSnapshotResponse
-	(*GetSnapshotRequest)(nil),          // 32: cleanroom.v1.GetSnapshotRequest
-	(*GetSnapshotResponse)(nil),         // 33: cleanroom.v1.GetSnapshotResponse
-	(*ListSnapshotsRequest)(nil),        // 34: cleanroom.v1.ListSnapshotsRequest
-	(*ListSnapshotsResponse)(nil),       // 35: cleanroom.v1.ListSnapshotsResponse
-	(*DeleteSnapshotRequest)(nil),       // 36: cleanroom.v1.DeleteSnapshotRequest
-	(*DeleteSnapshotResponse)(nil),      // 37: cleanroom.v1.DeleteSnapshotResponse
-	(*Execution)(nil),                   // 38: cleanroom.v1.Execution
-	(*ExecutionOptions)(nil),            // 39: cleanroom.v1.ExecutionOptions
-	(*CreateExecutionRequest)(nil),      // 40: cleanroom.v1.CreateExecutionRequest
-	(*CreateExecutionResponse)(nil),     // 41: cleanroom.v1.CreateExecutionResponse
-	(*AttachExecutionRequest)(nil),      // 42: cleanroom.v1.AttachExecutionRequest
-	(*AttachExecutionResponse)(nil),     // 43: cleanroom.v1.AttachExecutionResponse
-	(*GetExecutionRequest)(nil),         // 44: cleanroom.v1.GetExecutionRequest
-	(*GetExecutionResponse)(nil),        // 45: cleanroom.v1.GetExecutionResponse
-	(*InspectExecutionRequest)(nil),     // 46: cleanroom.v1.InspectExecutionRequest
-	(*InspectExecutionResponse)(nil),    // 47: cleanroom.v1.InspectExecutionResponse
-	(*CancelExecutionRequest)(nil),      // 48: cleanroom.v1.CancelExecutionRequest
-	(*CancelExecutionResponse)(nil),     // 49: cleanroom.v1.CancelExecutionResponse
-	(*WriteExecutionStdinRequest)(nil),  // 50: cleanroom.v1.WriteExecutionStdinRequest
-	(*WriteExecutionStdinResponse)(nil), // 51: cleanroom.v1.WriteExecutionStdinResponse
-	(*CloseExecutionStdinRequest)(nil),  // 52: cleanroom.v1.CloseExecutionStdinRequest
-	(*CloseExecutionStdinResponse)(nil), // 53: cleanroom.v1.CloseExecutionStdinResponse
-	(*StreamExecutionRequest)(nil),      // 54: cleanroom.v1.StreamExecutionRequest
-	(*ExecutionExit)(nil),               // 55: cleanroom.v1.ExecutionExit
-	(*ExecutionStreamEvent)(nil),        // 56: cleanroom.v1.ExecutionStreamEvent
-	(*timestamppb.Timestamp)(nil),       // 57: google.protobuf.Timestamp
-	(*structpb.Struct)(nil),             // 58: google.protobuf.Struct
+	(*ListExecutionsRequest)(nil),       // 24: cleanroom.v1.ListExecutionsRequest
+	(*ListExecutionsResponse)(nil),      // 25: cleanroom.v1.ListExecutionsResponse
+	(*DownloadSandboxFileRequest)(nil),  // 26: cleanroom.v1.DownloadSandboxFileRequest
+	(*DownloadSandboxFileResponse)(nil), // 27: cleanroom.v1.DownloadSandboxFileResponse
+	(*TerminateSandboxRequest)(nil),     // 28: cleanroom.v1.TerminateSandboxRequest
+	(*TerminateSandboxResponse)(nil),    // 29: cleanroom.v1.TerminateSandboxResponse
+	(*StreamSandboxEventsRequest)(nil),  // 30: cleanroom.v1.StreamSandboxEventsRequest
+	(*SandboxEvent)(nil),                // 31: cleanroom.v1.SandboxEvent
+	(*CreateSnapshotRequest)(nil),       // 32: cleanroom.v1.CreateSnapshotRequest
+	(*CreateSnapshotResponse)(nil),      // 33: cleanroom.v1.CreateSnapshotResponse
+	(*GetSnapshotRequest)(nil),          // 34: cleanroom.v1.GetSnapshotRequest
+	(*GetSnapshotResponse)(nil),         // 35: cleanroom.v1.GetSnapshotResponse
+	(*ListSnapshotsRequest)(nil),        // 36: cleanroom.v1.ListSnapshotsRequest
+	(*ListSnapshotsResponse)(nil),       // 37: cleanroom.v1.ListSnapshotsResponse
+	(*DeleteSnapshotRequest)(nil),       // 38: cleanroom.v1.DeleteSnapshotRequest
+	(*DeleteSnapshotResponse)(nil),      // 39: cleanroom.v1.DeleteSnapshotResponse
+	(*Execution)(nil),                   // 40: cleanroom.v1.Execution
+	(*ExecutionOptions)(nil),            // 41: cleanroom.v1.ExecutionOptions
+	(*CreateExecutionRequest)(nil),      // 42: cleanroom.v1.CreateExecutionRequest
+	(*CreateExecutionResponse)(nil),     // 43: cleanroom.v1.CreateExecutionResponse
+	(*AttachExecutionRequest)(nil),      // 44: cleanroom.v1.AttachExecutionRequest
+	(*AttachExecutionResponse)(nil),     // 45: cleanroom.v1.AttachExecutionResponse
+	(*GetExecutionRequest)(nil),         // 46: cleanroom.v1.GetExecutionRequest
+	(*GetExecutionResponse)(nil),        // 47: cleanroom.v1.GetExecutionResponse
+	(*InspectExecutionRequest)(nil),     // 48: cleanroom.v1.InspectExecutionRequest
+	(*InspectExecutionResponse)(nil),    // 49: cleanroom.v1.InspectExecutionResponse
+	(*CancelExecutionRequest)(nil),      // 50: cleanroom.v1.CancelExecutionRequest
+	(*CancelExecutionResponse)(nil),     // 51: cleanroom.v1.CancelExecutionResponse
+	(*WriteExecutionStdinRequest)(nil),  // 52: cleanroom.v1.WriteExecutionStdinRequest
+	(*WriteExecutionStdinResponse)(nil), // 53: cleanroom.v1.WriteExecutionStdinResponse
+	(*CloseExecutionStdinRequest)(nil),  // 54: cleanroom.v1.CloseExecutionStdinRequest
+	(*CloseExecutionStdinResponse)(nil), // 55: cleanroom.v1.CloseExecutionStdinResponse
+	(*StreamExecutionRequest)(nil),      // 56: cleanroom.v1.StreamExecutionRequest
+	(*ExecutionExit)(nil),               // 57: cleanroom.v1.ExecutionExit
+	(*ExecutionStreamEvent)(nil),        // 58: cleanroom.v1.ExecutionStreamEvent
+	(*timestamppb.Timestamp)(nil),       // 59: google.protobuf.Timestamp
+	(*structpb.Struct)(nil),             // 60: google.protobuf.Struct
 }
 var file_proto_cleanroom_v1_control_proto_depIdxs = []int32{
 	0,  // 0: cleanroom.v1.Sandbox.status:type_name -> cleanroom.v1.SandboxStatus
-	57, // 1: cleanroom.v1.Sandbox.created_at:type_name -> google.protobuf.Timestamp
-	57, // 2: cleanroom.v1.Sandbox.updated_at:type_name -> google.protobuf.Timestamp
-	57, // 3: cleanroom.v1.Snapshot.created_at:type_name -> google.protobuf.Timestamp
+	59, // 1: cleanroom.v1.Sandbox.created_at:type_name -> google.protobuf.Timestamp
+	59, // 2: cleanroom.v1.Sandbox.updated_at:type_name -> google.protobuf.Timestamp
+	59, // 3: cleanroom.v1.Snapshot.created_at:type_name -> google.protobuf.Timestamp
 	14, // 4: cleanroom.v1.Snapshot.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
 	7,  // 5: cleanroom.v1.PolicyServices.docker:type_name -> cleanroom.v1.PolicyDockerService
 	9,  // 6: cleanroom.v1.PolicyDependencies.key:type_name -> cleanroom.v1.PolicyDependencyKey
@@ -4161,74 +4268,77 @@ var file_proto_cleanroom_v1_control_proto_depIdxs = []int32{
 	4,  // 16: cleanroom.v1.CreateSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
 	1,  // 17: cleanroom.v1.CreateSandboxEvent.phase:type_name -> cleanroom.v1.CreateSandboxPhase
 	18, // 18: cleanroom.v1.CreateSandboxEvent.response:type_name -> cleanroom.v1.CreateSandboxResponse
-	57, // 19: cleanroom.v1.CreateSandboxEvent.occurred_at:type_name -> google.protobuf.Timestamp
+	59, // 19: cleanroom.v1.CreateSandboxEvent.occurred_at:type_name -> google.protobuf.Timestamp
 	4,  // 20: cleanroom.v1.GetSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
 	4,  // 21: cleanroom.v1.ListSandboxesResponse.sandboxes:type_name -> cleanroom.v1.Sandbox
-	0,  // 22: cleanroom.v1.SandboxEvent.status:type_name -> cleanroom.v1.SandboxStatus
-	57, // 23: cleanroom.v1.SandboxEvent.occurred_at:type_name -> google.protobuf.Timestamp
-	5,  // 24: cleanroom.v1.CreateSnapshotResponse.snapshot:type_name -> cleanroom.v1.Snapshot
-	5,  // 25: cleanroom.v1.GetSnapshotResponse.snapshot:type_name -> cleanroom.v1.Snapshot
-	5,  // 26: cleanroom.v1.ListSnapshotsResponse.snapshots:type_name -> cleanroom.v1.Snapshot
-	2,  // 27: cleanroom.v1.Execution.status:type_name -> cleanroom.v1.ExecutionStatus
-	57, // 28: cleanroom.v1.Execution.started_at:type_name -> google.protobuf.Timestamp
-	57, // 29: cleanroom.v1.Execution.finished_at:type_name -> google.protobuf.Timestamp
-	3,  // 30: cleanroom.v1.Execution.kind:type_name -> cleanroom.v1.ExecutionKind
-	39, // 31: cleanroom.v1.CreateExecutionRequest.options:type_name -> cleanroom.v1.ExecutionOptions
-	3,  // 32: cleanroom.v1.CreateExecutionRequest.kind:type_name -> cleanroom.v1.ExecutionKind
-	14, // 33: cleanroom.v1.CreateExecutionRequest.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
-	38, // 34: cleanroom.v1.CreateExecutionResponse.execution:type_name -> cleanroom.v1.Execution
-	57, // 35: cleanroom.v1.AttachExecutionResponse.expires_at:type_name -> google.protobuf.Timestamp
-	38, // 36: cleanroom.v1.GetExecutionResponse.execution:type_name -> cleanroom.v1.Execution
-	38, // 37: cleanroom.v1.InspectExecutionResponse.execution:type_name -> cleanroom.v1.Execution
-	58, // 38: cleanroom.v1.InspectExecutionResponse.observability:type_name -> google.protobuf.Struct
-	2,  // 39: cleanroom.v1.CancelExecutionResponse.status:type_name -> cleanroom.v1.ExecutionStatus
-	2,  // 40: cleanroom.v1.ExecutionExit.status:type_name -> cleanroom.v1.ExecutionStatus
-	2,  // 41: cleanroom.v1.ExecutionStreamEvent.status:type_name -> cleanroom.v1.ExecutionStatus
-	55, // 42: cleanroom.v1.ExecutionStreamEvent.exit:type_name -> cleanroom.v1.ExecutionExit
-	57, // 43: cleanroom.v1.ExecutionStreamEvent.occurred_at:type_name -> google.protobuf.Timestamp
-	17, // 44: cleanroom.v1.SandboxService.CreateSandbox:input_type -> cleanroom.v1.CreateSandboxRequest
-	17, // 45: cleanroom.v1.SandboxService.CreateSandboxStream:input_type -> cleanroom.v1.CreateSandboxRequest
-	20, // 46: cleanroom.v1.SandboxService.GetSandbox:input_type -> cleanroom.v1.GetSandboxRequest
-	22, // 47: cleanroom.v1.SandboxService.ListSandboxes:input_type -> cleanroom.v1.ListSandboxesRequest
-	24, // 48: cleanroom.v1.SandboxService.DownloadSandboxFile:input_type -> cleanroom.v1.DownloadSandboxFileRequest
-	26, // 49: cleanroom.v1.SandboxService.TerminateSandbox:input_type -> cleanroom.v1.TerminateSandboxRequest
-	28, // 50: cleanroom.v1.SandboxService.StreamSandboxEvents:input_type -> cleanroom.v1.StreamSandboxEventsRequest
-	30, // 51: cleanroom.v1.SnapshotService.CreateSnapshot:input_type -> cleanroom.v1.CreateSnapshotRequest
-	32, // 52: cleanroom.v1.SnapshotService.GetSnapshot:input_type -> cleanroom.v1.GetSnapshotRequest
-	34, // 53: cleanroom.v1.SnapshotService.ListSnapshots:input_type -> cleanroom.v1.ListSnapshotsRequest
-	36, // 54: cleanroom.v1.SnapshotService.DeleteSnapshot:input_type -> cleanroom.v1.DeleteSnapshotRequest
-	40, // 55: cleanroom.v1.ExecutionService.CreateExecution:input_type -> cleanroom.v1.CreateExecutionRequest
-	42, // 56: cleanroom.v1.ExecutionService.AttachExecution:input_type -> cleanroom.v1.AttachExecutionRequest
-	44, // 57: cleanroom.v1.ExecutionService.GetExecution:input_type -> cleanroom.v1.GetExecutionRequest
-	46, // 58: cleanroom.v1.ExecutionService.InspectExecution:input_type -> cleanroom.v1.InspectExecutionRequest
-	48, // 59: cleanroom.v1.ExecutionService.CancelExecution:input_type -> cleanroom.v1.CancelExecutionRequest
-	50, // 60: cleanroom.v1.ExecutionService.WriteExecutionStdin:input_type -> cleanroom.v1.WriteExecutionStdinRequest
-	52, // 61: cleanroom.v1.ExecutionService.CloseExecutionStdin:input_type -> cleanroom.v1.CloseExecutionStdinRequest
-	54, // 62: cleanroom.v1.ExecutionService.StreamExecution:input_type -> cleanroom.v1.StreamExecutionRequest
-	18, // 63: cleanroom.v1.SandboxService.CreateSandbox:output_type -> cleanroom.v1.CreateSandboxResponse
-	19, // 64: cleanroom.v1.SandboxService.CreateSandboxStream:output_type -> cleanroom.v1.CreateSandboxEvent
-	21, // 65: cleanroom.v1.SandboxService.GetSandbox:output_type -> cleanroom.v1.GetSandboxResponse
-	23, // 66: cleanroom.v1.SandboxService.ListSandboxes:output_type -> cleanroom.v1.ListSandboxesResponse
-	25, // 67: cleanroom.v1.SandboxService.DownloadSandboxFile:output_type -> cleanroom.v1.DownloadSandboxFileResponse
-	27, // 68: cleanroom.v1.SandboxService.TerminateSandbox:output_type -> cleanroom.v1.TerminateSandboxResponse
-	29, // 69: cleanroom.v1.SandboxService.StreamSandboxEvents:output_type -> cleanroom.v1.SandboxEvent
-	31, // 70: cleanroom.v1.SnapshotService.CreateSnapshot:output_type -> cleanroom.v1.CreateSnapshotResponse
-	33, // 71: cleanroom.v1.SnapshotService.GetSnapshot:output_type -> cleanroom.v1.GetSnapshotResponse
-	35, // 72: cleanroom.v1.SnapshotService.ListSnapshots:output_type -> cleanroom.v1.ListSnapshotsResponse
-	37, // 73: cleanroom.v1.SnapshotService.DeleteSnapshot:output_type -> cleanroom.v1.DeleteSnapshotResponse
-	41, // 74: cleanroom.v1.ExecutionService.CreateExecution:output_type -> cleanroom.v1.CreateExecutionResponse
-	43, // 75: cleanroom.v1.ExecutionService.AttachExecution:output_type -> cleanroom.v1.AttachExecutionResponse
-	45, // 76: cleanroom.v1.ExecutionService.GetExecution:output_type -> cleanroom.v1.GetExecutionResponse
-	47, // 77: cleanroom.v1.ExecutionService.InspectExecution:output_type -> cleanroom.v1.InspectExecutionResponse
-	49, // 78: cleanroom.v1.ExecutionService.CancelExecution:output_type -> cleanroom.v1.CancelExecutionResponse
-	51, // 79: cleanroom.v1.ExecutionService.WriteExecutionStdin:output_type -> cleanroom.v1.WriteExecutionStdinResponse
-	53, // 80: cleanroom.v1.ExecutionService.CloseExecutionStdin:output_type -> cleanroom.v1.CloseExecutionStdinResponse
-	56, // 81: cleanroom.v1.ExecutionService.StreamExecution:output_type -> cleanroom.v1.ExecutionStreamEvent
-	63, // [63:82] is the sub-list for method output_type
-	44, // [44:63] is the sub-list for method input_type
-	44, // [44:44] is the sub-list for extension type_name
-	44, // [44:44] is the sub-list for extension extendee
-	0,  // [0:44] is the sub-list for field type_name
+	40, // 22: cleanroom.v1.ListExecutionsResponse.executions:type_name -> cleanroom.v1.Execution
+	0,  // 23: cleanroom.v1.SandboxEvent.status:type_name -> cleanroom.v1.SandboxStatus
+	59, // 24: cleanroom.v1.SandboxEvent.occurred_at:type_name -> google.protobuf.Timestamp
+	5,  // 25: cleanroom.v1.CreateSnapshotResponse.snapshot:type_name -> cleanroom.v1.Snapshot
+	5,  // 26: cleanroom.v1.GetSnapshotResponse.snapshot:type_name -> cleanroom.v1.Snapshot
+	5,  // 27: cleanroom.v1.ListSnapshotsResponse.snapshots:type_name -> cleanroom.v1.Snapshot
+	2,  // 28: cleanroom.v1.Execution.status:type_name -> cleanroom.v1.ExecutionStatus
+	59, // 29: cleanroom.v1.Execution.started_at:type_name -> google.protobuf.Timestamp
+	59, // 30: cleanroom.v1.Execution.finished_at:type_name -> google.protobuf.Timestamp
+	3,  // 31: cleanroom.v1.Execution.kind:type_name -> cleanroom.v1.ExecutionKind
+	41, // 32: cleanroom.v1.CreateExecutionRequest.options:type_name -> cleanroom.v1.ExecutionOptions
+	3,  // 33: cleanroom.v1.CreateExecutionRequest.kind:type_name -> cleanroom.v1.ExecutionKind
+	14, // 34: cleanroom.v1.CreateExecutionRequest.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
+	40, // 35: cleanroom.v1.CreateExecutionResponse.execution:type_name -> cleanroom.v1.Execution
+	59, // 36: cleanroom.v1.AttachExecutionResponse.expires_at:type_name -> google.protobuf.Timestamp
+	40, // 37: cleanroom.v1.GetExecutionResponse.execution:type_name -> cleanroom.v1.Execution
+	40, // 38: cleanroom.v1.InspectExecutionResponse.execution:type_name -> cleanroom.v1.Execution
+	60, // 39: cleanroom.v1.InspectExecutionResponse.observability:type_name -> google.protobuf.Struct
+	2,  // 40: cleanroom.v1.CancelExecutionResponse.status:type_name -> cleanroom.v1.ExecutionStatus
+	2,  // 41: cleanroom.v1.ExecutionExit.status:type_name -> cleanroom.v1.ExecutionStatus
+	2,  // 42: cleanroom.v1.ExecutionStreamEvent.status:type_name -> cleanroom.v1.ExecutionStatus
+	57, // 43: cleanroom.v1.ExecutionStreamEvent.exit:type_name -> cleanroom.v1.ExecutionExit
+	59, // 44: cleanroom.v1.ExecutionStreamEvent.occurred_at:type_name -> google.protobuf.Timestamp
+	17, // 45: cleanroom.v1.SandboxService.CreateSandbox:input_type -> cleanroom.v1.CreateSandboxRequest
+	17, // 46: cleanroom.v1.SandboxService.CreateSandboxStream:input_type -> cleanroom.v1.CreateSandboxRequest
+	20, // 47: cleanroom.v1.SandboxService.GetSandbox:input_type -> cleanroom.v1.GetSandboxRequest
+	22, // 48: cleanroom.v1.SandboxService.ListSandboxes:input_type -> cleanroom.v1.ListSandboxesRequest
+	26, // 49: cleanroom.v1.SandboxService.DownloadSandboxFile:input_type -> cleanroom.v1.DownloadSandboxFileRequest
+	28, // 50: cleanroom.v1.SandboxService.TerminateSandbox:input_type -> cleanroom.v1.TerminateSandboxRequest
+	30, // 51: cleanroom.v1.SandboxService.StreamSandboxEvents:input_type -> cleanroom.v1.StreamSandboxEventsRequest
+	32, // 52: cleanroom.v1.SnapshotService.CreateSnapshot:input_type -> cleanroom.v1.CreateSnapshotRequest
+	34, // 53: cleanroom.v1.SnapshotService.GetSnapshot:input_type -> cleanroom.v1.GetSnapshotRequest
+	36, // 54: cleanroom.v1.SnapshotService.ListSnapshots:input_type -> cleanroom.v1.ListSnapshotsRequest
+	38, // 55: cleanroom.v1.SnapshotService.DeleteSnapshot:input_type -> cleanroom.v1.DeleteSnapshotRequest
+	24, // 56: cleanroom.v1.ExecutionService.ListExecutions:input_type -> cleanroom.v1.ListExecutionsRequest
+	42, // 57: cleanroom.v1.ExecutionService.CreateExecution:input_type -> cleanroom.v1.CreateExecutionRequest
+	44, // 58: cleanroom.v1.ExecutionService.AttachExecution:input_type -> cleanroom.v1.AttachExecutionRequest
+	46, // 59: cleanroom.v1.ExecutionService.GetExecution:input_type -> cleanroom.v1.GetExecutionRequest
+	48, // 60: cleanroom.v1.ExecutionService.InspectExecution:input_type -> cleanroom.v1.InspectExecutionRequest
+	50, // 61: cleanroom.v1.ExecutionService.CancelExecution:input_type -> cleanroom.v1.CancelExecutionRequest
+	52, // 62: cleanroom.v1.ExecutionService.WriteExecutionStdin:input_type -> cleanroom.v1.WriteExecutionStdinRequest
+	54, // 63: cleanroom.v1.ExecutionService.CloseExecutionStdin:input_type -> cleanroom.v1.CloseExecutionStdinRequest
+	56, // 64: cleanroom.v1.ExecutionService.StreamExecution:input_type -> cleanroom.v1.StreamExecutionRequest
+	18, // 65: cleanroom.v1.SandboxService.CreateSandbox:output_type -> cleanroom.v1.CreateSandboxResponse
+	19, // 66: cleanroom.v1.SandboxService.CreateSandboxStream:output_type -> cleanroom.v1.CreateSandboxEvent
+	21, // 67: cleanroom.v1.SandboxService.GetSandbox:output_type -> cleanroom.v1.GetSandboxResponse
+	23, // 68: cleanroom.v1.SandboxService.ListSandboxes:output_type -> cleanroom.v1.ListSandboxesResponse
+	27, // 69: cleanroom.v1.SandboxService.DownloadSandboxFile:output_type -> cleanroom.v1.DownloadSandboxFileResponse
+	29, // 70: cleanroom.v1.SandboxService.TerminateSandbox:output_type -> cleanroom.v1.TerminateSandboxResponse
+	31, // 71: cleanroom.v1.SandboxService.StreamSandboxEvents:output_type -> cleanroom.v1.SandboxEvent
+	33, // 72: cleanroom.v1.SnapshotService.CreateSnapshot:output_type -> cleanroom.v1.CreateSnapshotResponse
+	35, // 73: cleanroom.v1.SnapshotService.GetSnapshot:output_type -> cleanroom.v1.GetSnapshotResponse
+	37, // 74: cleanroom.v1.SnapshotService.ListSnapshots:output_type -> cleanroom.v1.ListSnapshotsResponse
+	39, // 75: cleanroom.v1.SnapshotService.DeleteSnapshot:output_type -> cleanroom.v1.DeleteSnapshotResponse
+	25, // 76: cleanroom.v1.ExecutionService.ListExecutions:output_type -> cleanroom.v1.ListExecutionsResponse
+	43, // 77: cleanroom.v1.ExecutionService.CreateExecution:output_type -> cleanroom.v1.CreateExecutionResponse
+	45, // 78: cleanroom.v1.ExecutionService.AttachExecution:output_type -> cleanroom.v1.AttachExecutionResponse
+	47, // 79: cleanroom.v1.ExecutionService.GetExecution:output_type -> cleanroom.v1.GetExecutionResponse
+	49, // 80: cleanroom.v1.ExecutionService.InspectExecution:output_type -> cleanroom.v1.InspectExecutionResponse
+	51, // 81: cleanroom.v1.ExecutionService.CancelExecution:output_type -> cleanroom.v1.CancelExecutionResponse
+	53, // 82: cleanroom.v1.ExecutionService.WriteExecutionStdin:output_type -> cleanroom.v1.WriteExecutionStdinResponse
+	55, // 83: cleanroom.v1.ExecutionService.CloseExecutionStdin:output_type -> cleanroom.v1.CloseExecutionStdinResponse
+	58, // 84: cleanroom.v1.ExecutionService.StreamExecution:output_type -> cleanroom.v1.ExecutionStreamEvent
+	65, // [65:85] is the sub-list for method output_type
+	45, // [45:65] is the sub-list for method input_type
+	45, // [45:45] is the sub-list for extension type_name
+	45, // [45:45] is the sub-list for extension extendee
+	0,  // [0:45] is the sub-list for field type_name
 }
 
 func init() { file_proto_cleanroom_v1_control_proto_init() }
@@ -4246,7 +4356,7 @@ func file_proto_cleanroom_v1_control_proto_init() {
 		(*CreateSandboxEvent_Warning)(nil),
 		(*CreateSandboxEvent_Response)(nil),
 	}
-	file_proto_cleanroom_v1_control_proto_msgTypes[52].OneofWrappers = []any{
+	file_proto_cleanroom_v1_control_proto_msgTypes[54].OneofWrappers = []any{
 		(*ExecutionStreamEvent_Stdout)(nil),
 		(*ExecutionStreamEvent_Stderr)(nil),
 		(*ExecutionStreamEvent_Exit)(nil),
@@ -4259,7 +4369,7 @@ func file_proto_cleanroom_v1_control_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proto_cleanroom_v1_control_proto_rawDesc), len(file_proto_cleanroom_v1_control_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   53,
+			NumMessages:   55,
 			NumExtensions: 0,
 			NumServices:   3,
 		},

--- a/proto/cleanroom/v1/control.proto
+++ b/proto/cleanroom/v1/control.proto
@@ -25,6 +25,7 @@ service SnapshotService {
 }
 
 service ExecutionService {
+  rpc ListExecutions(ListExecutionsRequest) returns (ListExecutionsResponse);
   rpc CreateExecution(CreateExecutionRequest) returns (CreateExecutionResponse);
   rpc AttachExecution(AttachExecutionRequest) returns (AttachExecutionResponse);
   rpc GetExecution(GetExecutionRequest) returns (GetExecutionResponse);
@@ -203,6 +204,15 @@ message ListSandboxesRequest {}
 
 message ListSandboxesResponse {
   repeated Sandbox sandboxes = 1;
+}
+
+message ListExecutionsRequest {
+  string sandbox_id = 1;
+  bool all = 2;
+}
+
+message ListExecutionsResponse {
+  repeated Execution executions = 1;
 }
 
 message DownloadSandboxFileRequest {


### PR DESCRIPTION
## Summary
- add `cleanroom execution ls` and make `execution inspect --last` and `sandbox inspect --last` consistent for live execution inspection
- snapshot execution state under lock and allow sandbox-scoped execution lookup after sandbox pruning
- remove the no-op backend memory setting from the Buildkite agent example and document where runtime sizing actually lives

## Validation
- `mise exec -- go test ./...`
- `mise exec -- go test -race ./internal/controlservice`
- `mise exec -- go run ./cmd/cleanroom policy validate -c examples/buildkite-agent`
