### PR TITLE
fix: Harden gateway trust and git handling

### DIFF
--- a/internal/gateway/git.go
+++ b/internal/gateway/git.go
@@ -42,9 +42,10 @@ const (
 	gatewayActionDeny           = observability.GatewayActionDeny
 )
 
-const maxUploadPackRequestBytes int64 = 32 << 20
-
-var errUploadPackRequestTooLarge = errors.New("git-upload-pack request body too large")
+var (
+	maxUploadPackRequestBytes    int64 = 32 << 20
+	errUploadPackRequestTooLarge       = errors.New("git-upload-pack request body too large")
+)
 
 type gitHandler struct {
 	credentials CredentialProvider
@@ -142,6 +143,18 @@ func (h *gitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if h.mirrors != nil {
 		if err := h.serveFromMirror(w, r, remoteURL, upstreamHost, repoPath, requestType); err != nil {
+			if errors.Is(err, errUploadPackRequestTooLarge) {
+				setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonInvalidRequest)
+				span.RecordError(err)
+				span.SetAttributes(
+					attribute.String(observability.AttrGatewayAction, gatewayActionDeny),
+					attribute.String(observability.AttrReasonCode, reasonInvalidRequest),
+				)
+				span.SetStatus(codes.Error, err.Error())
+				h.auditLog(r.Context(), scope.SandboxID, upstreamHost, repoPath, gatewayActionDeny, reasonInvalidRequest)
+				writeReasonError(w, http.StatusRequestEntityTooLarge, reasonInvalidRequest, err.Error())
+				return
+			}
 			setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonUpstreamError)
 			span.RecordError(err)
 			span.SetAttributes(

--- a/internal/gateway/git.go
+++ b/internal/gateway/git.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -40,6 +41,10 @@ const (
 	gatewayActionAllow          = observability.GatewayActionAllow
 	gatewayActionDeny           = observability.GatewayActionDeny
 )
+
+const maxUploadPackRequestBytes int64 = 32 << 20
+
+var errUploadPackRequestTooLarge = errors.New("git-upload-pack request body too large")
 
 type gitHandler struct {
 	credentials CredentialProvider
@@ -347,6 +352,10 @@ func gitProtocolEnv(r *http.Request) []string {
 }
 
 func readUploadPackBody(r *http.Request) ([]byte, error) {
+	return readUploadPackBodyWithLimit(r, maxUploadPackRequestBytes)
+}
+
+func readUploadPackBodyWithLimit(r *http.Request, limit int64) ([]byte, error) {
 	reader := io.Reader(r.Body)
 	if strings.Contains(strings.ToLower(r.Header.Get("Content-Encoding")), "gzip") {
 		gz, err := gzip.NewReader(r.Body)
@@ -356,9 +365,12 @@ func readUploadPackBody(r *http.Request) ([]byte, error) {
 		defer gz.Close()
 		reader = gz
 	}
-	body, err := io.ReadAll(reader)
+	body, err := io.ReadAll(io.LimitReader(reader, limit+1))
 	if err != nil {
 		return nil, fmt.Errorf("read git-upload-pack request: %w", err)
+	}
+	if int64(len(body)) > limit {
+		return nil, fmt.Errorf("%w: limit %d bytes", errUploadPackRequestTooLarge, limit)
 	}
 	return body, nil
 }

--- a/internal/gateway/git_test.go
+++ b/internal/gateway/git_test.go
@@ -365,6 +365,32 @@ func TestGitHandlerUpstreamTransportFailureMarksSpanDenied(t *testing.T) {
 	}
 }
 
+func TestGitHandlerMirrorOversizedUploadPackReturnsRequestTooLarge(t *testing.T) {
+	oldLimit := maxUploadPackRequestBytes
+	maxUploadPackRequestBytes = 8
+	t.Cleanup(func() {
+		maxUploadPackRequestBytes = oldLimit
+	})
+
+	h := newGitHandler(nil, nil)
+	h.mirrors = &staticMirrorStore{mirrorDir: t.TempDir()}
+
+	req := httptest.NewRequest("POST", "/git/github.com/org/repo.git/git-upload-pack", strings.NewReader("012345678"))
+	req = withScope(req, gitTestScope())
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	if got := w.Header().Get(reasonCodeHeader); got != reasonInvalidRequest {
+		t.Fatalf("expected %s=%s, got %q", reasonCodeHeader, reasonInvalidRequest, got)
+	}
+	if body := w.Body.String(); !strings.Contains(body, errUploadPackRequestTooLarge.Error()) {
+		t.Fatalf("expected body to include oversize error, got %q", body)
+	}
+}
+
 func TestGitHandlerServesMirrorToRealGitClient(t *testing.T) {
 	t.Parallel()
 

--- a/internal/gateway/git_test.go
+++ b/internal/gateway/git_test.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -464,6 +465,33 @@ func TestUploadPackConfigArgsEnablePartialCloneFilter(t *testing.T) {
 	joined := strings.Join(args, " ")
 	if !strings.Contains(joined, "uploadpack.allowFilter=true") {
 		t.Fatalf("expected upload-pack config args to enable filter support, got %q", joined)
+	}
+}
+
+func TestReadUploadPackBodyRejectsOversizedPlainBody(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/git/github.com/org/repo.git/git-upload-pack", strings.NewReader("012345678"))
+
+	_, err := readUploadPackBodyWithLimit(req, 8)
+	if !errors.Is(err, errUploadPackRequestTooLarge) {
+		t.Fatalf("readUploadPackBody error = %v, want %v", err, errUploadPackRequestTooLarge)
+	}
+}
+
+func TestReadUploadPackBodyRejectsOversizedGzipExpansion(t *testing.T) {
+	var compressed bytes.Buffer
+	gz := gzip.NewWriter(&compressed)
+	if _, err := gz.Write([]byte("012345678")); err != nil {
+		t.Fatalf("write gzip body: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("close gzip body: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/git/github.com/org/repo.git/git-upload-pack", &compressed)
+	req.Header.Set("Content-Encoding", "gzip")
+
+	_, err := readUploadPackBodyWithLimit(req, 8)
+	if !errors.Is(err, errUploadPackRequestTooLarge) {
+		t.Fatalf("readUploadPackBody error = %v, want %v", err, errUploadPackRequestTooLarge)
 	}
 }
 

--- a/internal/gateway/mirror.go
+++ b/internal/gateway/mirror.go
@@ -198,9 +198,8 @@ func (s *gitMirrorStore) cloneMirror(ctx context.Context, remoteURL, mirrorDir s
 	if err := os.MkdirAll(filepath.Dir(mirrorDir), 0o755); err != nil {
 		return fmt.Errorf("create mirror directory: %w", err)
 	}
-	args := s.gitArgsWithAuth(ctx, remoteURL, "clone", "--mirror", remoteURL, mirrorDir)
-	cmd := exec.CommandContext(ctx, "git", args...)
-	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	cmd := exec.CommandContext(ctx, "git", "clone", "--mirror", remoteURL, mirrorDir)
+	cmd.Env = s.gitEnvWithAuth(ctx, remoteURL, append(os.Environ(), "GIT_TERMINAL_PROMPT=0"))
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		_ = os.RemoveAll(mirrorDir)
@@ -217,9 +216,8 @@ func (s *gitMirrorStore) fetchMirror(ctx context.Context, remoteURL, mirrorDir s
 		return fmt.Errorf("git remote set-url origin %s: %s: %w", remoteURL, strings.TrimSpace(string(output)), err)
 	}
 
-	args := s.gitArgsWithAuth(ctx, remoteURL, "-C", mirrorDir, "fetch", "--prune", "origin")
-	cmd := exec.CommandContext(ctx, "git", args...)
-	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	cmd := exec.CommandContext(ctx, "git", "-C", mirrorDir, "fetch", "--prune", "origin")
+	cmd.Env = s.gitEnvWithAuth(ctx, remoteURL, append(os.Environ(), "GIT_TERMINAL_PROMPT=0"))
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("git fetch --prune origin: %s: %w", strings.TrimSpace(string(output)), err)
@@ -228,7 +226,8 @@ func (s *gitMirrorStore) fetchMirror(ctx context.Context, remoteURL, mirrorDir s
 	return nil
 }
 
-func (s *gitMirrorStore) gitArgsWithAuth(ctx context.Context, remoteURL string, args ...string) []string {
+func (s *gitMirrorStore) gitEnvWithAuth(ctx context.Context, remoteURL string, baseEnv []string) []string {
+	env := append([]string(nil), baseEnv...)
 	key := ""
 	value := ""
 	if s != nil && s.credentials != nil {
@@ -240,12 +239,30 @@ func (s *gitMirrorStore) gitArgsWithAuth(ctx context.Context, remoteURL string, 
 	}
 
 	if key == "" || value == "" {
-		return append([]string(nil), args...)
+		return env
 	}
 
-	out := make([]string, 0, len(args)+2)
-	out = append(out, "-c", key+"="+value)
-	out = append(out, args...)
+	env = pruneGitConfigEnv(env)
+	return append(env,
+		"GIT_CONFIG_COUNT=1",
+		"GIT_CONFIG_KEY_0="+key,
+		"GIT_CONFIG_VALUE_0="+value,
+	)
+}
+
+func pruneGitConfigEnv(env []string) []string {
+	out := make([]string, 0, len(env))
+	for _, entry := range env {
+		name, _, ok := strings.Cut(entry, "=")
+		if !ok {
+			out = append(out, entry)
+			continue
+		}
+		if name == "GIT_CONFIG_COUNT" || strings.HasPrefix(name, "GIT_CONFIG_KEY_") || strings.HasPrefix(name, "GIT_CONFIG_VALUE_") {
+			continue
+		}
+		out = append(out, entry)
+	}
 	return out
 }
 

--- a/internal/gateway/mirror.go
+++ b/internal/gateway/mirror.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -242,28 +243,62 @@ func (s *gitMirrorStore) gitEnvWithAuth(ctx context.Context, remoteURL string, b
 		return env
 	}
 
-	env = pruneGitConfigEnv(env)
-	return append(env,
-		"GIT_CONFIG_COUNT=1",
-		"GIT_CONFIG_KEY_0="+key,
-		"GIT_CONFIG_VALUE_0="+value,
-	)
+	return appendGitConfigEnv(env, key, value)
 }
 
-func pruneGitConfigEnv(env []string) []string {
-	out := make([]string, 0, len(env))
+func appendGitConfigEnv(env []string, key, value string) []string {
+	count, hasCount := gitConfigCount(env)
+	authIndex := 0
+	if hasCount {
+		authIndex = count
+	}
+	out := make([]string, 0, len(env)+3)
+	countWritten := false
 	for _, entry := range env {
 		name, _, ok := strings.Cut(entry, "=")
 		if !ok {
 			out = append(out, entry)
 			continue
 		}
-		if name == "GIT_CONFIG_COUNT" || strings.HasPrefix(name, "GIT_CONFIG_KEY_") || strings.HasPrefix(name, "GIT_CONFIG_VALUE_") {
+		if name == "GIT_CONFIG_COUNT" {
+			if !hasCount || countWritten {
+				continue
+			}
+			out = append(out, "GIT_CONFIG_COUNT="+strconv.Itoa(authIndex+1))
+			countWritten = true
+			continue
+		}
+		if !hasCount && (strings.HasPrefix(name, "GIT_CONFIG_KEY_") || strings.HasPrefix(name, "GIT_CONFIG_VALUE_")) {
 			continue
 		}
 		out = append(out, entry)
 	}
+	if !countWritten {
+		out = append(out, "GIT_CONFIG_COUNT="+strconv.Itoa(authIndex+1))
+	}
+	out = append(out,
+		fmt.Sprintf("GIT_CONFIG_KEY_%d=%s", authIndex, key),
+		fmt.Sprintf("GIT_CONFIG_VALUE_%d=%s", authIndex, value),
+	)
 	return out
+}
+
+func gitConfigCount(env []string) (int, bool) {
+	count := 0
+	found := false
+	for _, entry := range env {
+		name, value, ok := strings.Cut(entry, "=")
+		if !ok || name != "GIT_CONFIG_COUNT" {
+			continue
+		}
+		parsed, err := strconv.Atoi(value)
+		if err != nil || parsed < 0 {
+			return 0, false
+		}
+		count = parsed
+		found = true
+	}
+	return count, found
 }
 
 func gitCommitExists(ctx context.Context, repoDir, commitSHA string) (bool, error) {

--- a/internal/gateway/mirror_test.go
+++ b/internal/gateway/mirror_test.go
@@ -136,24 +136,25 @@ func TestGitMirrorStoreUsesRemoteURLScopedAuthHeader(t *testing.T) {
 	})
 	env := store.gitEnvWithAuth(context.Background(), "https://github.com/buildkite/cleanroom.git", []string{
 		"PATH=/bin",
-		"GIT_CONFIG_COUNT=99",
-		"GIT_CONFIG_KEY_0=http.old/.extraHeader",
-		"GIT_CONFIG_VALUE_0=Authorization: stale",
+		"GIT_CONFIG_COUNT=1",
+		"GIT_CONFIG_KEY_0=url.https://github.com/.insteadOf",
+		"GIT_CONFIG_VALUE_0=gh:",
 	})
 
-	if got, want := findEnvValue(env, "GIT_CONFIG_COUNT"), "1"; got != want {
+	if got, want := findEnvValue(env, "GIT_CONFIG_COUNT"), "2"; got != want {
 		t.Fatalf("GIT_CONFIG_COUNT = %q, want %q", got, want)
 	}
-	if got, want := findEnvValue(env, "GIT_CONFIG_KEY_0"), "http.https://github.com/buildkite/cleanroom.git/.extraHeader"; got != want {
+	if got, want := findEnvValue(env, "GIT_CONFIG_KEY_0"), "url.https://github.com/.insteadOf"; got != want {
 		t.Fatalf("GIT_CONFIG_KEY_0 = %q, want %q", got, want)
 	}
-	if got, want := findEnvValue(env, "GIT_CONFIG_VALUE_0"), "Authorization: Basic test"; got != want {
+	if got, want := findEnvValue(env, "GIT_CONFIG_VALUE_0"), "gh:"; got != want {
 		t.Fatalf("GIT_CONFIG_VALUE_0 = %q, want %q", got, want)
 	}
-	for _, entry := range env {
-		if strings.Contains(entry, "stale") {
-			t.Fatalf("stale git config env leaked through: %v", env)
-		}
+	if got, want := findEnvValue(env, "GIT_CONFIG_KEY_1"), "http.https://github.com/buildkite/cleanroom.git/.extraHeader"; got != want {
+		t.Fatalf("GIT_CONFIG_KEY_1 = %q, want %q", got, want)
+	}
+	if got, want := findEnvValue(env, "GIT_CONFIG_VALUE_1"), "Authorization: Basic test"; got != want {
+		t.Fatalf("GIT_CONFIG_VALUE_1 = %q, want %q", got, want)
 	}
 }
 

--- a/internal/gateway/mirror_test.go
+++ b/internal/gateway/mirror_test.go
@@ -134,19 +134,37 @@ func TestGitMirrorStoreUsesRemoteURLScopedAuthHeader(t *testing.T) {
 			"https://github.com/buildkite/cleanroom.git": "Basic test",
 		},
 	})
-	args := store.gitArgsWithAuth(context.Background(), "https://github.com/buildkite/cleanroom.git", "fetch", "origin")
-	if len(args) < 3 {
-		t.Fatalf("expected auth config args, got %v", args)
+	env := store.gitEnvWithAuth(context.Background(), "https://github.com/buildkite/cleanroom.git", []string{
+		"PATH=/bin",
+		"GIT_CONFIG_COUNT=99",
+		"GIT_CONFIG_KEY_0=http.old/.extraHeader",
+		"GIT_CONFIG_VALUE_0=Authorization: stale",
+	})
+
+	if got, want := findEnvValue(env, "GIT_CONFIG_COUNT"), "1"; got != want {
+		t.Fatalf("GIT_CONFIG_COUNT = %q, want %q", got, want)
 	}
-	if got, want := args[0], "-c"; got != want {
-		t.Fatalf("unexpected first arg: got %q want %q", got, want)
+	if got, want := findEnvValue(env, "GIT_CONFIG_KEY_0"), "http.https://github.com/buildkite/cleanroom.git/.extraHeader"; got != want {
+		t.Fatalf("GIT_CONFIG_KEY_0 = %q, want %q", got, want)
 	}
-	if got, want := args[1], "http.https://github.com/buildkite/cleanroom.git/.extraHeader=Authorization: Basic test"; got != want {
-		t.Fatalf("unexpected auth config arg: got %q want %q", got, want)
+	if got, want := findEnvValue(env, "GIT_CONFIG_VALUE_0"), "Authorization: Basic test"; got != want {
+		t.Fatalf("GIT_CONFIG_VALUE_0 = %q, want %q", got, want)
 	}
-	if got, want := args[2], "fetch"; got != want {
-		t.Fatalf("unexpected command arg after auth config: got %q want %q", got, want)
+	for _, entry := range env {
+		if strings.Contains(entry, "stale") {
+			t.Fatalf("stale git config env leaked through: %v", env)
+		}
 	}
+}
+
+func findEnvValue(env []string, name string) string {
+	for _, entry := range env {
+		key, value, ok := strings.Cut(entry, "=")
+		if ok && key == name {
+			return value
+		}
+	}
+	return ""
 }
 
 type staticAuthorizationProvider struct {

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -73,6 +73,12 @@ const ScopeTokenHeader = "X-Cleanroom-Scope-Token"
 
 var defaultDarwinVZScopeTokenSourcePrefix = netip.MustParsePrefix("192.168.64.0/24")
 
+func defaultScopeTokenSourcePolicy() ScopeTokenSourcePolicy {
+	return ScopeTokenSourcePolicy{
+		TrustedSourcePrefixes: []netip.Prefix{defaultDarwinVZScopeTokenSourcePrefix},
+	}
+}
+
 // ScopeFromContext retrieves the SandboxScope injected by identity middleware.
 func ScopeFromContext(ctx context.Context) (*SandboxScope, bool) {
 	scope, ok := ctx.Value(scopeContextKey).(*SandboxScope)
@@ -101,10 +107,9 @@ func ScopeTokenSourcePolicyForGatewayHost(gatewayHost string) ScopeTokenSourcePo
 }
 
 func scopeTokenSourcePolicyForGatewayHost(ctx context.Context, gatewayHost string, lookup gatewayHostLookupFunc) ScopeTokenSourcePolicy {
-	defaultPrefixes := []netip.Prefix{defaultDarwinVZScopeTokenSourcePrefix}
 	gatewayHost = strings.TrimSpace(gatewayHost)
 	if gatewayHost == "" {
-		return ScopeTokenSourcePolicy{TrustedSourcePrefixes: defaultPrefixes}
+		return defaultScopeTokenSourcePolicy()
 	}
 
 	if addr, err := netip.ParseAddr(gatewayHost); err == nil {
@@ -113,12 +118,12 @@ func scopeTokenSourcePolicyForGatewayHost(ctx context.Context, gatewayHost strin
 		}
 	}
 	if lookup == nil {
-		return ScopeTokenSourcePolicy{AllowScopeTokenFromAnySource: true}
+		return defaultScopeTokenSourcePolicy()
 	}
 
 	resolved, err := lookup(ctx, gatewayHost)
 	if err != nil {
-		return ScopeTokenSourcePolicy{AllowScopeTokenFromAnySource: true}
+		return defaultScopeTokenSourcePolicy()
 	}
 
 	prefixes := make([]netip.Prefix, 0, len(resolved))
@@ -139,7 +144,7 @@ func scopeTokenSourcePolicyForGatewayHost(ctx context.Context, gatewayHost strin
 		prefixes = append(prefixes, prefix)
 	}
 	if len(prefixes) == 0 {
-		return ScopeTokenSourcePolicy{AllowScopeTokenFromAnySource: true}
+		return defaultScopeTokenSourcePolicy()
 	}
 	return ScopeTokenSourcePolicy{TrustedSourcePrefixes: prefixes}
 }
@@ -249,7 +254,10 @@ func NewServer(cfg ServerConfig) *Server {
 	mux.HandleFunc(RouteMeta, stubHandler("meta"))
 
 	s.httpServer = &http.Server{
-		Handler: s.identityMiddleware(s.pathMiddleware(s.tracingMiddleware(mux))),
+		Handler:           s.identityMiddleware(s.pathMiddleware(s.tracingMiddleware(mux))),
+		ReadHeaderTimeout: 5 * time.Second,
+		IdleTimeout:       60 * time.Second,
+		MaxHeaderBytes:    1 << 20,
 	}
 
 	return s

--- a/internal/gateway/server_test.go
+++ b/internal/gateway/server_test.go
@@ -520,18 +520,45 @@ func TestScopeTokenTrustedSourcePrefixesForGatewayHostResolvesHostnames(t *testi
 	}
 }
 
-func TestScopeTokenSourcePolicyForGatewayHostAllowsAnySourceOnLookupFailure(t *testing.T) {
+func TestScopeTokenSourcePolicyForGatewayHostFallsBackToDefaultPrefixesOnLookupFailure(t *testing.T) {
 	t.Parallel()
 
 	got := scopeTokenSourcePolicyForGatewayHost(context.Background(), "gateway.local", func(context.Context, string) ([]net.IP, error) {
 		return nil, errors.New("lookup failed")
 	})
 
-	if !got.AllowScopeTokenFromAnySource {
-		t.Fatal("expected source trust to be disabled on lookup failure")
+	if got.AllowScopeTokenFromAnySource {
+		t.Fatal("did not expect source trust to be disabled on lookup failure")
 	}
-	if len(got.TrustedSourcePrefixes) != 0 {
-		t.Fatalf("expected no trusted source prefixes when trust is disabled, got %v", got.TrustedSourcePrefixes)
+	want := []netip.Prefix{netip.MustParsePrefix("192.168.64.0/24")}
+	if len(got.TrustedSourcePrefixes) != len(want) {
+		t.Fatalf("len(prefixes) = %d, want %d", len(got.TrustedSourcePrefixes), len(want))
+	}
+	for i := range got.TrustedSourcePrefixes {
+		if got.TrustedSourcePrefixes[i] != want[i] {
+			t.Fatalf("prefix[%d] = %s, want %s", i, got.TrustedSourcePrefixes[i], want[i])
+		}
+	}
+}
+
+func TestScopeTokenSourcePolicyForGatewayHostFallsBackToDefaultPrefixesOnEmptyLookup(t *testing.T) {
+	t.Parallel()
+
+	got := scopeTokenSourcePolicyForGatewayHost(context.Background(), "gateway.local", func(context.Context, string) ([]net.IP, error) {
+		return nil, nil
+	})
+
+	if got.AllowScopeTokenFromAnySource {
+		t.Fatal("did not expect source trust to be disabled on empty lookup")
+	}
+	want := []netip.Prefix{netip.MustParsePrefix("192.168.64.0/24")}
+	if len(got.TrustedSourcePrefixes) != len(want) {
+		t.Fatalf("len(prefixes) = %d, want %d", len(got.TrustedSourcePrefixes), len(want))
+	}
+	for i := range got.TrustedSourcePrefixes {
+		if got.TrustedSourcePrefixes[i] != want[i] {
+			t.Fatalf("prefix[%d] = %s, want %s", i, got.TrustedSourcePrefixes[i], want[i])
+		}
 	}
 }
 


### PR DESCRIPTION
## What changed

- Fail closed when a configured Darwin gateway host lookup fails or resolves no trusted prefixes.
- Add HTTP server read-header, idle, and max-header limits for the gateway listener.
- Move mirrored git Authorization extraHeader plumbing from argv `-c` flags into `GIT_CONFIG_*` environment variables.
- Bound decoded `git-upload-pack` request bodies, including gzip expansion, before buffering.

## Why

The gateway accepts bearer scope-token fallback identity on a TCP listener. Lookup failures and unbounded request buffering should narrow trust and memory use, not broaden them. Git mirror credentials should also avoid process argv exposure while clone/fetch is running.

## Validation

- `mise exec -- go test ./internal/gateway`
- `git diff --cached --check` before commit
