### PR TITLE
fix: Bound exec output retention

### DIFF
--- a/cmd/cleanroom-guest-agent/bounded_buffer.go
+++ b/cmd/cleanroom-guest-agent/bounded_buffer.go
@@ -1,0 +1,33 @@
+package main
+
+const maxExecResponseOutputBytes = 1 << 20
+
+type boundedOutputBuffer struct {
+	limit int
+	data  []byte
+}
+
+func newBoundedOutputBuffer(limit int) *boundedOutputBuffer {
+	return &boundedOutputBuffer{limit: limit}
+}
+
+func (b *boundedOutputBuffer) Write(p []byte) (int, error) {
+	written := len(p)
+	if len(p) == 0 || b.limit <= 0 {
+		return written, nil
+	}
+	if len(p) >= b.limit {
+		b.data = append(b.data[:0], p[len(p)-b.limit:]...)
+		return written, nil
+	}
+	b.data = append(b.data, p...)
+	if len(b.data) > b.limit {
+		copy(b.data, b.data[len(b.data)-b.limit:])
+		b.data = b.data[:b.limit]
+	}
+	return written, nil
+}
+
+func (b *boundedOutputBuffer) String() string {
+	return string(b.data)
+}

--- a/cmd/cleanroom-guest-agent/bounded_buffer_test.go
+++ b/cmd/cleanroom-guest-agent/bounded_buffer_test.go
@@ -1,0 +1,21 @@
+package main
+
+import "testing"
+
+func TestBoundedOutputBufferRetainsTail(t *testing.T) {
+	buf := newBoundedOutputBuffer(5)
+
+	if n, err := buf.Write([]byte("hello")); err != nil || n != 5 {
+		t.Fatalf("first write = %d, %v; want 5, nil", n, err)
+	}
+	if got, want := buf.String(), "hello"; got != want {
+		t.Fatalf("buffer after first write = %q, want %q", got, want)
+	}
+
+	if n, err := buf.Write([]byte(" world")); err != nil || n != 6 {
+		t.Fatalf("second write = %d, %v; want 6, nil", n, err)
+	}
+	if got, want := buf.String(), "world"; got != want {
+		t.Fatalf("buffer after second write = %q, want %q", got, want)
+	}
+}

--- a/cmd/cleanroom-guest-agent/main.go
+++ b/cmd/cleanroom-guest-agent/main.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"bytes"
 	"encoding/binary"
 	"encoding/json"
 	"errors"
@@ -158,17 +157,17 @@ func handleConnPipes(conn io.ReadWriteCloser, dec *json.Decoder, req vsockexec.E
 
 	go readInputFrames(dec, stdinPipe, func() { _ = stdinPipe.Close() }, nil)
 
-	var stdoutBuf bytes.Buffer
-	var stderrBuf bytes.Buffer
+	stdoutBuf := newBoundedOutputBuffer(maxExecResponseOutputBytes)
+	stderrBuf := newBoundedOutputBuffer(maxExecResponseOutputBytes)
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		_, _ = io.Copy(io.MultiWriter(&stdoutBuf, streamFrameWriter{send: sender.Send, kind: "stdout"}), stdout)
+		_, _ = io.Copy(io.MultiWriter(stdoutBuf, streamFrameWriter{send: sender.Send, kind: "stdout"}), stdout)
 	}()
 	go func() {
 		defer wg.Done()
-		_, _ = io.Copy(io.MultiWriter(&stderrBuf, streamFrameWriter{send: sender.Send, kind: "stderr"}), stderr)
+		_, _ = io.Copy(io.MultiWriter(stderrBuf, streamFrameWriter{send: sender.Send, kind: "stderr"}), stderr)
 	}()
 
 	wg.Wait()

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -154,11 +154,13 @@ type AttachIO struct {
 }
 
 type OutputStream struct {
-	OnStdout                 func([]byte)
-	OnStderr                 func([]byte)
-	OnWarning                func(string)
-	OnAttach                 func(AttachIO)
-	BufferedOutputLimitBytes int
+	OnStdout  func([]byte)
+	OnStderr  func([]byte)
+	OnWarning func(string)
+	OnAttach  func(AttachIO)
+	// BufferedOutputLimitBytes caps stdout/stderr accumulated in the backend
+	// result. Nil keeps the backend default; zero disables accumulation.
+	BufferedOutputLimitBytes *int
 }
 
 type ExecutionRequest struct {

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -154,10 +154,11 @@ type AttachIO struct {
 }
 
 type OutputStream struct {
-	OnStdout  func([]byte)
-	OnStderr  func([]byte)
-	OnWarning func(string)
-	OnAttach  func(AttachIO)
+	OnStdout                 func([]byte)
+	OnStderr                 func([]byte)
+	OnWarning                func(string)
+	OnAttach                 func(AttachIO)
+	BufferedOutputLimitBytes int
 }
 
 type ExecutionRequest struct {

--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -1112,8 +1112,9 @@ func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream 
 	}
 
 	guestRes, err := vsockexec.DecodeStreamResponse(conn, vsockexec.StreamCallbacks{
-		OnStdout: stream.OnStdout,
-		OnStderr: stream.OnStderr,
+		OnStdout:                 stream.OnStdout,
+		OnStderr:                 stream.OnStderr,
+		BufferedOutputLimitBytes: stream.BufferedOutputLimitBytes,
 	})
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
@@ -1578,8 +1579,9 @@ func (a *Adapter) executeInSandbox(bootCtx context.Context, runCtx context.Conte
 	}
 
 	guestRes, err := vsockexec.DecodeStreamResponse(conn, vsockexec.StreamCallbacks{
-		OnStdout: stream.OnStdout,
-		OnStderr: stream.OnStderr,
+		OnStdout:                 stream.OnStdout,
+		OnStderr:                 stream.OnStderr,
+		BufferedOutputLimitBytes: stream.BufferedOutputLimitBytes,
 	})
 	if err != nil {
 		if ctxErr := runCtx.Err(); ctxErr != nil {

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -2282,8 +2282,9 @@ func runGuestCommand(bootCtx context.Context, execCtx context.Context, processEx
 
 	commandStart := time.Now()
 	res, err := vsockexec.DecodeStreamResponse(conn, vsockexec.StreamCallbacks{
-		OnStdout: stream.OnStdout,
-		OnStderr: stream.OnStderr,
+		OnStdout:                 stream.OnStdout,
+		OnStderr:                 stream.OnStderr,
+		BufferedOutputLimitBytes: stream.BufferedOutputLimitBytes,
 	})
 	if err != nil {
 		if ctxErr := execCtx.Err(); ctxErr != nil {

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -2377,8 +2377,9 @@ func (s *Service) applyExecutionResultMetadataLocked(ex *executionState, result 
 }
 
 func (s *Service) executionOutputStream(key string, stdoutCapture, stderrCapture *retainedOutputCapture) backend.OutputStream {
+	bufferedOutputLimit := s.retention().maxRetainedExecutionOutputBytes
 	return backend.OutputStream{
-		BufferedOutputLimitBytes: s.retention().maxRetainedExecutionOutputBytes,
+		BufferedOutputLimitBytes: &bufferedOutputLimit,
 		OnStdout: func(chunk []byte) {
 			if stdoutCapture != nil {
 				_, _ = stdoutCapture.Write(chunk)
@@ -2401,8 +2402,9 @@ func (s *Service) executionOutputStream(key string, stdoutCapture, stderrCapture
 }
 
 func (s *Service) executionAuxOutputStream(key string) backend.OutputStream {
+	bufferedOutputLimit := s.retention().maxRetainedExecutionOutputBytes
 	return backend.OutputStream{
-		BufferedOutputLimitBytes: s.retention().maxRetainedExecutionOutputBytes,
+		BufferedOutputLimitBytes: &bufferedOutputLimit,
 		OnStdout: func(chunk []byte) {
 			s.recordExecutionOutputChunk(key, true, chunk)
 		},

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -2378,6 +2378,7 @@ func (s *Service) applyExecutionResultMetadataLocked(ex *executionState, result 
 
 func (s *Service) executionOutputStream(key string, stdoutCapture, stderrCapture *retainedOutputCapture) backend.OutputStream {
 	return backend.OutputStream{
+		BufferedOutputLimitBytes: s.retention().maxRetainedExecutionOutputBytes,
 		OnStdout: func(chunk []byte) {
 			if stdoutCapture != nil {
 				_, _ = stdoutCapture.Write(chunk)
@@ -2401,6 +2402,7 @@ func (s *Service) executionOutputStream(key string, stdoutCapture, stderrCapture
 
 func (s *Service) executionAuxOutputStream(key string) backend.OutputStream {
 	return backend.OutputStream{
+		BufferedOutputLimitBytes: s.retention().maxRetainedExecutionOutputBytes,
 		OnStdout: func(chunk []byte) {
 			s.recordExecutionOutputChunk(key, true, chunk)
 		},

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -5638,8 +5638,10 @@ func TestListSandboxesReturnsNewestSnapshotFirst(t *testing.T) {
 }
 
 func TestExecutionRetentionBoundsOutput(t *testing.T) {
+	gotStreamLimit := 0
 	adapter := &stubAdapter{
 		runStreamFn: func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+			gotStreamLimit = stream.BufferedOutputLimitBytes
 			for _, chunk := range []string{"1234", "5678", "90"} {
 				if stream.OnStdout != nil {
 					stream.OnStdout([]byte(chunk))
@@ -5695,6 +5697,9 @@ func TestExecutionRetentionBoundsOutput(t *testing.T) {
 	}
 	if got, want := snapshot.Stderr, "cdefghij"; got != want {
 		t.Fatalf("unexpected retained stderr: got %q want %q", got, want)
+	}
+	if got, want := gotStreamLimit, 8; got != want {
+		t.Fatalf("unexpected stream buffered output limit: got %d want %d", got, want)
 	}
 }
 

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -5638,10 +5638,13 @@ func TestListSandboxesReturnsNewestSnapshotFirst(t *testing.T) {
 }
 
 func TestExecutionRetentionBoundsOutput(t *testing.T) {
-	gotStreamLimit := 0
+	var gotStreamLimit *int
 	adapter := &stubAdapter{
 		runStreamFn: func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
-			gotStreamLimit = stream.BufferedOutputLimitBytes
+			if stream.BufferedOutputLimitBytes != nil {
+				limit := *stream.BufferedOutputLimitBytes
+				gotStreamLimit = &limit
+			}
 			for _, chunk := range []string{"1234", "5678", "90"} {
 				if stream.OnStdout != nil {
 					stream.OnStdout([]byte(chunk))
@@ -5698,8 +5701,56 @@ func TestExecutionRetentionBoundsOutput(t *testing.T) {
 	if got, want := snapshot.Stderr, "cdefghij"; got != want {
 		t.Fatalf("unexpected retained stderr: got %q want %q", got, want)
 	}
-	if got, want := gotStreamLimit, 8; got != want {
+	if gotStreamLimit == nil {
+		t.Fatalf("expected stream buffered output limit to be set")
+	}
+	if got, want := *gotStreamLimit, 8; got != want {
 		t.Fatalf("unexpected stream buffered output limit: got %d want %d", got, want)
+	}
+}
+
+func TestExecutionRetentionSetsZeroStreamOutputLimit(t *testing.T) {
+	var gotStreamLimit *int
+	adapter := &stubAdapter{
+		runStreamFn: func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+			if stream.BufferedOutputLimitBytes != nil {
+				limit := *stream.BufferedOutputLimitBytes
+				gotStreamLimit = &limit
+			}
+			return &backend.ExecutionResult{
+				ExecutionID: req.ExecutionID,
+				ExitCode:    0,
+			}, nil
+		},
+	}
+	svc := newTestService(adapter)
+	retention := testRetentionPolicy()
+	retention.maxRetainedExecutionOutputBytes = 0
+	svc.runtime.retention = retention
+
+	createSandboxResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createSandboxResp.GetSandbox().GetSandboxId()
+
+	createExecutionResp, err := svc.CreateExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
+		SandboxId: sandboxID,
+		Command:   []string{"echo", "disabled"},
+	})
+	if err != nil {
+		t.Fatalf("CreateExecution returned error: %v", err)
+	}
+	executionID := createExecutionResp.GetExecution().GetExecutionId()
+
+	if _, err := svc.WaitExecution(context.Background(), sandboxID, executionID); err != nil {
+		t.Fatalf("WaitExecution returned error: %v", err)
+	}
+	if gotStreamLimit == nil {
+		t.Fatalf("expected stream buffered output limit to be set")
+	}
+	if got := *gotStreamLimit; got != 0 {
+		t.Fatalf("unexpected stream buffered output limit: got %d want 0", got)
 	}
 }
 

--- a/internal/vsockexec/protocol.go
+++ b/internal/vsockexec/protocol.go
@@ -9,7 +9,11 @@ import (
 	"strings"
 )
 
-const DefaultPort uint32 = 10700
+const (
+	DefaultPort uint32 = 10700
+
+	defaultStreamResponseOutputLimit = 1 << 20
+)
 
 type ExecRequest struct {
 	Command     []string `json:"command"`
@@ -134,12 +138,12 @@ func DecodeStreamResponse(r io.Reader, callbacks StreamCallbacks) (ExecResponse,
 				continue
 			}
 			if kind == "stdout" {
-				out.Stdout += string(chunk)
+				out.Stdout = appendBoundedString(out.Stdout, chunk, defaultStreamResponseOutputLimit)
 				if callbacks.OnStdout != nil {
 					callbacks.OnStdout(append([]byte(nil), chunk...))
 				}
 			} else {
-				out.Stderr += string(chunk)
+				out.Stderr = appendBoundedString(out.Stderr, chunk, defaultStreamResponseOutputLimit)
 				if callbacks.OnStderr != nil {
 					callbacks.OnStderr(append([]byte(nil), chunk...))
 				}
@@ -160,6 +164,23 @@ func DecodeStreamResponse(r io.Reader, callbacks StreamCallbacks) (ExecResponse,
 			return ExecResponse{}, fmt.Errorf("unknown stream frame type %q", kind)
 		}
 	}
+}
+
+func appendBoundedString(current string, chunk []byte, limit int) string {
+	if len(chunk) == 0 || limit <= 0 {
+		return current
+	}
+	if len(chunk) >= limit {
+		return string(chunk[len(chunk)-limit:])
+	}
+	if len(current)+len(chunk) <= limit {
+		return current + string(chunk)
+	}
+	keep := limit - len(chunk)
+	if keep < 0 {
+		keep = 0
+	}
+	return current[len(current)-keep:] + string(chunk)
 }
 
 func decodeFrameData(raw json.RawMessage) ([]byte, error) {

--- a/internal/vsockexec/protocol.go
+++ b/internal/vsockexec/protocol.go
@@ -95,9 +95,11 @@ func DecodeInputFrame(r io.Reader) (ExecInputFrame, error) {
 }
 
 type StreamCallbacks struct {
-	OnStdout                 func([]byte)
-	OnStderr                 func([]byte)
-	BufferedOutputLimitBytes int
+	OnStdout func([]byte)
+	OnStderr func([]byte)
+	// BufferedOutputLimitBytes caps stdout/stderr accumulated in the final
+	// response. Nil uses the default limit; zero disables accumulation.
+	BufferedOutputLimitBytes *int
 }
 
 func DecodeStreamResponse(r io.Reader, callbacks StreamCallbacks) (ExecResponse, error) {
@@ -169,8 +171,8 @@ func DecodeStreamResponse(r io.Reader, callbacks StreamCallbacks) (ExecResponse,
 }
 
 func (callbacks StreamCallbacks) bufferedOutputLimitBytes() int {
-	if callbacks.BufferedOutputLimitBytes > 0 {
-		return callbacks.BufferedOutputLimitBytes
+	if callbacks.BufferedOutputLimitBytes != nil {
+		return *callbacks.BufferedOutputLimitBytes
 	}
 	return defaultStreamResponseOutputLimit
 }

--- a/internal/vsockexec/protocol.go
+++ b/internal/vsockexec/protocol.go
@@ -95,12 +95,14 @@ func DecodeInputFrame(r io.Reader) (ExecInputFrame, error) {
 }
 
 type StreamCallbacks struct {
-	OnStdout func([]byte)
-	OnStderr func([]byte)
+	OnStdout                 func([]byte)
+	OnStderr                 func([]byte)
+	BufferedOutputLimitBytes int
 }
 
 func DecodeStreamResponse(r io.Reader, callbacks StreamCallbacks) (ExecResponse, error) {
 	dec := json.NewDecoder(r)
+	bufferedOutputLimit := callbacks.bufferedOutputLimitBytes()
 	out := ExecResponse{}
 	for {
 		raw := map[string]json.RawMessage{}
@@ -138,12 +140,12 @@ func DecodeStreamResponse(r io.Reader, callbacks StreamCallbacks) (ExecResponse,
 				continue
 			}
 			if kind == "stdout" {
-				out.Stdout = appendBoundedString(out.Stdout, chunk, defaultStreamResponseOutputLimit)
+				out.Stdout = appendBoundedString(out.Stdout, chunk, bufferedOutputLimit)
 				if callbacks.OnStdout != nil {
 					callbacks.OnStdout(append([]byte(nil), chunk...))
 				}
 			} else {
-				out.Stderr = appendBoundedString(out.Stderr, chunk, defaultStreamResponseOutputLimit)
+				out.Stderr = appendBoundedString(out.Stderr, chunk, bufferedOutputLimit)
 				if callbacks.OnStderr != nil {
 					callbacks.OnStderr(append([]byte(nil), chunk...))
 				}
@@ -164,6 +166,13 @@ func DecodeStreamResponse(r io.Reader, callbacks StreamCallbacks) (ExecResponse,
 			return ExecResponse{}, fmt.Errorf("unknown stream frame type %q", kind)
 		}
 	}
+}
+
+func (callbacks StreamCallbacks) bufferedOutputLimitBytes() int {
+	if callbacks.BufferedOutputLimitBytes > 0 {
+		return callbacks.BufferedOutputLimitBytes
+	}
+	return defaultStreamResponseOutputLimit
 }
 
 func appendBoundedString(current string, chunk []byte, limit int) string {

--- a/internal/vsockexec/protocol_test.go
+++ b/internal/vsockexec/protocol_test.go
@@ -177,6 +177,34 @@ func TestProtocolRoundTripStdinEcho(t *testing.T) {
 	}
 }
 
+func TestDecodeStreamResponseRetainsBoundedOutputTail(t *testing.T) {
+	var buf bytes.Buffer
+	fullStdout := strings.Repeat("a", defaultStreamResponseOutputLimit) + "bc"
+	if err := EncodeStreamFrame(&buf, ExecStreamFrame{Type: "stdout", Data: []byte(fullStdout)}); err != nil {
+		t.Fatalf("EncodeStreamFrame stdout: %v", err)
+	}
+	if err := EncodeStreamFrame(&buf, ExecStreamFrame{Type: "exit", ExitCode: 0}); err != nil {
+		t.Fatalf("EncodeStreamFrame exit: %v", err)
+	}
+
+	var streamed bytes.Buffer
+	res, err := DecodeStreamResponse(&buf, StreamCallbacks{
+		OnStdout: func(data []byte) { streamed.Write(data) },
+	})
+	if err != nil {
+		t.Fatalf("DecodeStreamResponse: %v", err)
+	}
+	if got, want := streamed.String(), fullStdout; got != want {
+		t.Fatalf("streamed stdout length = %d, want %d", len(got), len(want))
+	}
+	if got, want := len(res.Stdout), defaultStreamResponseOutputLimit; got != want {
+		t.Fatalf("retained stdout length = %d, want %d", got, want)
+	}
+	if !strings.HasSuffix(fullStdout, res.Stdout) {
+		t.Fatalf("retained stdout does not match tail of streamed output")
+	}
+}
+
 // TestProtocolRoundTripResizeFrame verifies that resize frames are correctly
 // transmitted alongside stdin data.
 func TestProtocolRoundTripResizeFrame(t *testing.T) {

--- a/internal/vsockexec/protocol_test.go
+++ b/internal/vsockexec/protocol_test.go
@@ -179,7 +179,7 @@ func TestProtocolRoundTripStdinEcho(t *testing.T) {
 
 func TestDecodeStreamResponseRetainsBoundedOutputTail(t *testing.T) {
 	var buf bytes.Buffer
-	const limit = 8
+	limit := 8
 	fullStdout := "0123456789"
 	if err := EncodeStreamFrame(&buf, ExecStreamFrame{Type: "stdout", Data: []byte(fullStdout)}); err != nil {
 		t.Fatalf("EncodeStreamFrame stdout: %v", err)
@@ -191,7 +191,7 @@ func TestDecodeStreamResponseRetainsBoundedOutputTail(t *testing.T) {
 	var streamed bytes.Buffer
 	res, err := DecodeStreamResponse(&buf, StreamCallbacks{
 		OnStdout:                 func(data []byte) { streamed.Write(data) },
-		BufferedOutputLimitBytes: limit,
+		BufferedOutputLimitBytes: &limit,
 	})
 	if err != nil {
 		t.Fatalf("DecodeStreamResponse: %v", err)
@@ -204,6 +204,39 @@ func TestDecodeStreamResponseRetainsBoundedOutputTail(t *testing.T) {
 	}
 	if !strings.HasSuffix(fullStdout, res.Stdout) {
 		t.Fatalf("retained stdout does not match tail of streamed output")
+	}
+}
+
+func TestDecodeStreamResponseHonorsZeroBufferedOutputLimit(t *testing.T) {
+	var buf bytes.Buffer
+	if err := EncodeStreamFrame(&buf, ExecStreamFrame{Type: "stdout", Data: []byte("stdout")}); err != nil {
+		t.Fatalf("EncodeStreamFrame stdout: %v", err)
+	}
+	if err := EncodeStreamFrame(&buf, ExecStreamFrame{Type: "stderr", Data: []byte("stderr")}); err != nil {
+		t.Fatalf("EncodeStreamFrame stderr: %v", err)
+	}
+	if err := EncodeStreamFrame(&buf, ExecStreamFrame{Type: "exit", ExitCode: 0}); err != nil {
+		t.Fatalf("EncodeStreamFrame exit: %v", err)
+	}
+
+	limit := 0
+	var streamedStdout, streamedStderr bytes.Buffer
+	res, err := DecodeStreamResponse(&buf, StreamCallbacks{
+		OnStdout:                 func(data []byte) { streamedStdout.Write(data) },
+		OnStderr:                 func(data []byte) { streamedStderr.Write(data) },
+		BufferedOutputLimitBytes: &limit,
+	})
+	if err != nil {
+		t.Fatalf("DecodeStreamResponse: %v", err)
+	}
+	if got, want := streamedStdout.String(), "stdout"; got != want {
+		t.Fatalf("streamed stdout: got %q want %q", got, want)
+	}
+	if got, want := streamedStderr.String(), "stderr"; got != want {
+		t.Fatalf("streamed stderr: got %q want %q", got, want)
+	}
+	if res.Stdout != "" || res.Stderr != "" {
+		t.Fatalf("retained output with zero limit: stdout %q stderr %q", res.Stdout, res.Stderr)
 	}
 }
 

--- a/internal/vsockexec/protocol_test.go
+++ b/internal/vsockexec/protocol_test.go
@@ -179,7 +179,8 @@ func TestProtocolRoundTripStdinEcho(t *testing.T) {
 
 func TestDecodeStreamResponseRetainsBoundedOutputTail(t *testing.T) {
 	var buf bytes.Buffer
-	fullStdout := strings.Repeat("a", defaultStreamResponseOutputLimit) + "bc"
+	const limit = 8
+	fullStdout := "0123456789"
 	if err := EncodeStreamFrame(&buf, ExecStreamFrame{Type: "stdout", Data: []byte(fullStdout)}); err != nil {
 		t.Fatalf("EncodeStreamFrame stdout: %v", err)
 	}
@@ -189,7 +190,8 @@ func TestDecodeStreamResponseRetainsBoundedOutputTail(t *testing.T) {
 
 	var streamed bytes.Buffer
 	res, err := DecodeStreamResponse(&buf, StreamCallbacks{
-		OnStdout: func(data []byte) { streamed.Write(data) },
+		OnStdout:                 func(data []byte) { streamed.Write(data) },
+		BufferedOutputLimitBytes: limit,
 	})
 	if err != nil {
 		t.Fatalf("DecodeStreamResponse: %v", err)
@@ -197,7 +199,7 @@ func TestDecodeStreamResponseRetainsBoundedOutputTail(t *testing.T) {
 	if got, want := streamed.String(), fullStdout; got != want {
 		t.Fatalf("streamed stdout length = %d, want %d", len(got), len(want))
 	}
-	if got, want := len(res.Stdout), defaultStreamResponseOutputLimit; got != want {
+	if got, want := len(res.Stdout), limit; got != want {
 		t.Fatalf("retained stdout length = %d, want %d", got, want)
 	}
 	if !strings.HasSuffix(fullStdout, res.Stdout) {


### PR DESCRIPTION
## What changed

- Bound host-side retained stdout/stderr for streamed exec responses to a 1 MiB tail.
- Preserve full streaming callback delivery while limiting the final `ExecResponse` strings.
- Add a bounded output buffer for the guest-agent non-TTY fallback response path.
- Add tests for host retention and guest fallback buffering.

## Why

A command can stream output indefinitely. The host decoder and guest fallback path previously retained all stdout/stderr in memory even when the data was already being streamed onward, allowing an untrusted command to exhaust memory.

## Validation

- `mise exec -- go test ./internal/vsockexec`
- `mise exec -- go test ./cmd/cleanroom-guest-agent`
- `mise run build:go`
- `git diff --check`
