### PR TITLE
fix: Reject unknown config fields

### DIFF
--- a/internal/controlservice/runtime_config_helpers.go
+++ b/internal/controlservice/runtime_config_helpers.go
@@ -1,7 +1,6 @@
 package controlservice
 
 import (
-	"github.com/buildkite/cleanroom/internal/backend"
 	"github.com/buildkite/cleanroom/internal/runtimeconfig"
 )
 
@@ -13,38 +12,4 @@ func resolveBackendName(requested, configuredDefault string) string {
 		return configuredDefault
 	}
 	return runtimeconfig.DefaultBackendForHost()
-}
-
-func mergeBackendConfig(backendName string, opts executionOptions, cfg runtimeconfig.Config) backend.FirecrackerConfig {
-	out := backend.FirecrackerConfig{
-		BinaryPath:           cfg.Backends.Firecracker.BinaryPath,
-		KernelImagePath:      cfg.Backends.Firecracker.KernelImage,
-		RootFSPath:           cfg.Backends.Firecracker.RootFS,
-		DockerStartupSeconds: cfg.Backends.Firecracker.Services.Docker.StartupTimeoutSeconds,
-		DockerStorageDriver:  cfg.Backends.Firecracker.Services.Docker.StorageDriver,
-		DockerIPTables:       cfg.Backends.Firecracker.Services.Docker.IPTables,
-		PrivilegedHelperPath: cfg.Backends.Firecracker.PrivilegedHelperPath,
-		VCPUs:                cfg.Backends.Firecracker.VCPUs,
-		MemoryMiB:            cfg.Backends.Firecracker.MemoryMiB,
-		GuestCID:             cfg.Backends.Firecracker.GuestCID,
-		GuestPort:            cfg.Backends.Firecracker.GuestPort,
-		LaunchSeconds:        cfg.Backends.Firecracker.LaunchSeconds,
-	}
-	if backendName == "darwin-vz" {
-		out.KernelImagePath = cfg.Backends.DarwinVZ.KernelImage
-		out.RootFSPath = cfg.Backends.DarwinVZ.RootFS
-		out.DockerStartupSeconds = cfg.Backends.DarwinVZ.Services.Docker.StartupTimeoutSeconds
-		out.DockerStorageDriver = cfg.Backends.DarwinVZ.Services.Docker.StorageDriver
-		out.DockerIPTables = cfg.Backends.DarwinVZ.Services.Docker.IPTables
-		out.VCPUs = cfg.Backends.DarwinVZ.VCPUs
-		out.MemoryMiB = cfg.Backends.DarwinVZ.MemoryMiB
-		out.GuestPort = cfg.Backends.DarwinVZ.GuestPort
-		out.LaunchSeconds = cfg.Backends.DarwinVZ.LaunchSeconds
-	}
-
-	out.Launch = true
-	if opts.LaunchSeconds != 0 {
-		out.LaunchSeconds = opts.LaunchSeconds
-	}
-	return out
 }

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -1,11 +1,13 @@
 package policy
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -423,8 +425,12 @@ func readPolicy(path string) (rawPolicy, error) {
 	}
 
 	var raw rawPolicy
-	if err := yaml.Unmarshal(b, &raw); err != nil {
-		return rawPolicy{}, fmt.Errorf("parse %s: %w", path, err)
+	dec := yaml.NewDecoder(bytes.NewReader(b))
+	dec.KnownFields(true)
+	if err := dec.Decode(&raw); err != nil {
+		if !errors.Is(err, io.EOF) {
+			return rawPolicy{}, fmt.Errorf("parse %s: %w", path, err)
+		}
 	}
 
 	return raw, nil

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -418,6 +418,31 @@ func TestLoadPropagatesPrimaryStatError(t *testing.T) {
 	}
 }
 
+func TestReadPolicyRejectsUnknownFields(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), PrimaryPolicyPath)
+	if err := os.WriteFile(path, []byte(`
+version: 1
+unknown_top_level: true
+sandbox:
+  image:
+    ref: ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+  network:
+    default: deny
+`), 0o644); err != nil {
+		t.Fatalf("write policy: %v", err)
+	}
+
+	_, err := readPolicy(path)
+	if err == nil {
+		t.Fatal("expected unknown policy field to be rejected")
+	}
+	if !strings.Contains(err.Error(), "unknown_top_level") {
+		t.Fatalf("expected error to name unknown field, got %v", err)
+	}
+}
+
 func TestLoadRepositoryDefaultsCurrentRepoSettings(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtimeconfig/config.go
+++ b/internal/runtimeconfig/config.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"math"
 	"net/url"
 	"os"
@@ -63,6 +64,34 @@ type TraceConfig struct {
 type TraceSamplingConfig struct {
 	Mode  string   `yaml:"mode,omitempty"`
 	Ratio *float64 `yaml:"ratio,omitempty"`
+}
+
+type configFile struct {
+	DefaultBackend string              `yaml:"default_backend"`
+	ControlHost    string              `yaml:"control_host,omitempty"`
+	Gateway        GatewayConfig       `yaml:"gateway,omitempty"`
+	Observability  ObservabilityConfig `yaml:"observability,omitempty"`
+	Backends       backendsFile        `yaml:"backends"`
+}
+
+type backendsFile struct {
+	Firecracker    FirecrackerConfig `yaml:"firecracker"`
+	DarwinVZ       DarwinVZConfig    `yaml:"darwin-vz"`
+	DarwinVZLegacy DarwinVZConfig    `yaml:"darwin_vz"`
+}
+
+func (f configFile) config() Config {
+	cfg := Config{
+		DefaultBackend: f.DefaultBackend,
+		ControlHost:    f.ControlHost,
+		Gateway:        f.Gateway,
+		Observability:  f.Observability,
+		Backends: Backends{
+			Firecracker: f.Backends.Firecracker,
+			DarwinVZ:    f.Backends.DarwinVZ,
+		},
+	}
+	return cfg
 }
 
 type Backends struct {
@@ -386,10 +415,16 @@ func LoadPath(path string) (Config, string, error) {
 }
 
 func parseConfig(path string, raw []byte) (Config, error) {
-	cfg := Config{}
-	if err := yaml.Unmarshal(raw, &cfg); err != nil {
-		return Config{}, fmt.Errorf("parse %s: %w", path, err)
+	rawCfg := configFile{}
+	dec := yaml.NewDecoder(bytes.NewReader(raw))
+	dec.KnownFields(true)
+	if err := dec.Decode(&rawCfg); err != nil {
+		if !errors.Is(err, io.EOF) {
+			return Config{}, fmt.Errorf("parse %s: %w", path, err)
+		}
 	}
+	cfg := rawCfg.config()
+
 	backendPresence := struct {
 		Backends struct {
 			Firecracker    *yaml.Node `yaml:"firecracker"`
@@ -414,17 +449,8 @@ func parseConfig(path string, raw []byte) (Config, error) {
 	darwinVZMinRootFSBytes := cfg.Backends.DarwinVZ.MinimumRootFSBytes
 	darwinVZMinRootFSBytesSet := presenceCfg.Backends.DarwinVZ.MinimumRootFSBytes != nil
 	if darwinVZConfigIsZero(cfg.Backends.DarwinVZ) {
-		legacyCfg := struct {
-			Backends struct {
-				DarwinVZ DarwinVZConfig `yaml:"darwin_vz"`
-			} `yaml:"backends"`
-		}{}
-		if err := yaml.Unmarshal(raw, &legacyCfg); err != nil {
-			if backendPresence.Backends.LegacyDarwinVZ != nil {
-				return Config{}, fmt.Errorf("parse %s: %w", path, err)
-			}
-		} else if darwinVZConfigHasValues(legacyCfg.Backends.DarwinVZ) {
-			cfg.Backends.DarwinVZ = legacyCfg.Backends.DarwinVZ
+		if darwinVZConfigHasValues(rawCfg.Backends.DarwinVZLegacy) {
+			cfg.Backends.DarwinVZ = rawCfg.Backends.DarwinVZLegacy
 		}
 	}
 	if darwinVZMinRootFSBytesSet {

--- a/internal/runtimeconfig/config_test.go
+++ b/internal/runtimeconfig/config_test.go
@@ -960,6 +960,32 @@ backends:
 	}
 }
 
+func TestLoadRejectsUnknownConfigFields(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	configPath := filepath.Join(tmp, "cleanroom", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+
+	content := `default_backend: firecracker
+backends:
+  firecracker:
+    memory_mb: 1024
+`
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, _, err := Load()
+	if err == nil {
+		t.Fatal("expected unknown config field to be rejected")
+	}
+	if !strings.Contains(err.Error(), "memory_mb") {
+		t.Fatalf("expected error to name unknown field, got %v", err)
+	}
+}
+
 func TestLoadTrimsControlHost(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)


### PR DESCRIPTION
## What changed

- Decode policy YAML with `KnownFields(true)` so typos and unknown fields fail fast.
- Decode runtime config YAML strictly while preserving the supported legacy `backends.darwin_vz` key.
- Keep newer runtime config behavior for inferred backend defaults, observability config, gateway config, and Darwin rootfs sizing.
- Remove the unused stale `controlservice.mergeBackendConfig` helper.

## Why

Unknown fields in security-sensitive policy and runtime config can silently fall back to defaults. Strict decoding makes configuration mistakes visible, while deleting the stale helper avoids future confusion around backend config merging.

## Validation

- `mise exec -- go test ./internal/policy ./internal/runtimeconfig ./internal/controlservice`
- `mise exec -- go test ./...`
- `mise run build:go`
- `git diff --check`

Note: `mise exec -- go vet ./...` currently fails on an unrelated existing warning in `internal/backend/darwinvz/filehandle_gateway.go` about IPv6 address formatting.
