### PR TITLE
chore: Speed pinned TTI benchmark image resolution

### DIFF
--- a/internal/cli/image_override.go
+++ b/internal/cli/image_override.go
@@ -116,7 +116,7 @@ var (
 		return exec.Command("docker", "rm", "-f", containerID).Run()
 	}
 	resolveReferenceForImageOverride = func(ctx context.Context, source string, allowLocal bool) (string, error) {
-		if digestRef, err := ociref.ParseDigestReference(source); err == nil && isRegistryHostPrefix(digestRef.Repository) {
+		if digestRef, err := ociref.ParseDigestReference(source); err == nil && digestReferenceHasExplicitRegistryHost(digestRef) {
 			return digestRef.Original, nil
 		}
 
@@ -160,7 +160,7 @@ func isExplicitRegistryReference(raw string) bool {
 		return false
 	}
 	if parsed, err := ociref.ParseDigestReference(trimmed); err == nil {
-		return isRegistryHostPrefix(parsed.Repository)
+		return digestReferenceHasExplicitRegistryHost(parsed)
 	}
 	namePart := trimmed
 	if at := strings.Index(namePart, "@"); at >= 0 {
@@ -170,6 +170,11 @@ func isExplicitRegistryReference(raw string) bool {
 		namePart = namePart[:colon]
 	}
 	first := strings.TrimSpace(strings.SplitN(namePart, "/", 2)[0])
+	return isRegistryHostPrefix(first)
+}
+
+func digestReferenceHasExplicitRegistryHost(ref ociref.DigestReference) bool {
+	first, _, _ := strings.Cut(ref.Repository, "/")
 	return isRegistryHostPrefix(first)
 }
 

--- a/internal/cli/image_override.go
+++ b/internal/cli/image_override.go
@@ -117,6 +117,11 @@ var (
 	}
 	resolveReferenceForImageOverride = func(ctx context.Context, source string, allowLocal bool) (string, error) {
 		if digestRef, err := ociref.ParseDigestReference(source); err == nil && digestReferenceHasExplicitRegistryHost(digestRef) {
+			if allowLocal {
+				if err := validateImageOverridePlatform(ctx, source, digestRef.Original); err != nil {
+					return "", err
+				}
+			}
 			return digestRef.Original, nil
 		}
 
@@ -132,16 +137,8 @@ var (
 		resolved, err := resolveReferenceForPolicyUpdate(ctx, source)
 		if err == nil {
 			if allowLocal {
-				resolvedRef, parseErr := name.ParseReference(resolved, name.WeakValidation)
-				if parseErr != nil {
-					return "", fmt.Errorf("resolve image digest for %q: %w", source, parseErr)
-				}
-				imageOS, imageArch, platformErr := resolveReferencePlatformConfig(ctx, resolvedRef)
-				if platformErr != nil {
-					return "", fmt.Errorf("resolve image digest for %q: %w", source, platformErr)
-				}
-				if err := imagemgr.ValidateImagePlatformForHost(imageOS, imageArch, runtime.GOARCH); err != nil {
-					return "", fmt.Errorf("resolve image digest for %q: %w", source, err)
+				if err := validateImageOverridePlatform(ctx, source, resolved); err != nil {
+					return "", err
 				}
 			}
 			return resolved, nil
@@ -153,6 +150,21 @@ var (
 		return "", fmt.Errorf("%w; local docker resolution failed: %v", err, localErr)
 	}
 )
+
+func validateImageOverridePlatform(ctx context.Context, source, resolved string) error {
+	resolvedRef, parseErr := name.ParseReference(resolved, name.WeakValidation)
+	if parseErr != nil {
+		return fmt.Errorf("resolve image digest for %q: %w", source, parseErr)
+	}
+	imageOS, imageArch, platformErr := resolveReferencePlatformConfig(ctx, resolvedRef)
+	if platformErr != nil {
+		return fmt.Errorf("resolve image digest for %q: %w", source, platformErr)
+	}
+	if err := imagemgr.ValidateImagePlatformForHost(imageOS, imageArch, runtime.GOARCH); err != nil {
+		return fmt.Errorf("resolve image digest for %q: %w", source, err)
+	}
+	return nil
+}
 
 func isExplicitRegistryReference(raw string) bool {
 	trimmed := strings.TrimSpace(raw)

--- a/internal/cli/image_override.go
+++ b/internal/cli/image_override.go
@@ -116,6 +116,10 @@ var (
 		return exec.Command("docker", "rm", "-f", containerID).Run()
 	}
 	resolveReferenceForImageOverride = func(ctx context.Context, source string, allowLocal bool) (string, error) {
+		if digestRef, err := ociref.ParseDigestReference(source); err == nil && isRegistryHostPrefix(digestRef.Repository) {
+			return digestRef.Original, nil
+		}
+
 		if !allowLocal {
 			return resolveReferenceForPolicyUpdate(ctx, source)
 		}

--- a/internal/cli/image_override_resolution_test.go
+++ b/internal/cli/image_override_resolution_test.go
@@ -137,6 +137,37 @@ func TestResolveReferenceForImageOverrideReturnsRemoteErrorOnlyForExplicitRegist
 	}
 }
 
+func TestResolveReferenceForImageOverrideReturnsExplicitRegistryDigestWithoutResolution(t *testing.T) {
+	localCalls := 0
+	remoteCalls := 0
+	const pinnedRef = "ghcr.io/buildkite/cleanroom-base/alpine@sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+	withImageOverrideResolversForTest(
+		t,
+		func(_ context.Context, _ string) (string, error) {
+			localCalls++
+			return "", errors.New("local resolver should not be called")
+		},
+		func(_ context.Context, _ string) (string, error) {
+			remoteCalls++
+			return "", errors.New("remote resolver should not be called")
+		},
+	)
+
+	got, err := resolveReferenceForImageOverride(context.Background(), pinnedRef, true)
+	if err != nil {
+		t.Fatalf("resolveReferenceForImageOverride returned error: %v", err)
+	}
+	if got != pinnedRef {
+		t.Fatalf("unexpected resolved ref: got %q want %q", got, pinnedRef)
+	}
+	if localCalls != 0 {
+		t.Fatalf("expected local resolver call count 0, got %d", localCalls)
+	}
+	if remoteCalls != 0 {
+		t.Fatalf("expected remote resolver call count 0, got %d", remoteCalls)
+	}
+}
+
 func TestResolveReferenceForImageOverrideSkipsLocalForRemoteEndpoint(t *testing.T) {
 	localCalls := 0
 	remoteCalls := 0

--- a/internal/cli/image_override_resolution_test.go
+++ b/internal/cli/image_override_resolution_test.go
@@ -168,6 +168,51 @@ func TestResolveReferenceForImageOverrideReturnsExplicitRegistryDigestWithoutRes
 	}
 }
 
+func TestResolveReferenceForImageOverrideValidatesExplicitRegistryDigestPlatform(t *testing.T) {
+	localCalls := 0
+	remoteCalls := 0
+	platformCalls := 0
+	const pinnedRef = "ghcr.io/buildkite/cleanroom-base/alpine@sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+	withImageOverrideResolversForTest(
+		t,
+		func(_ context.Context, _ string) (string, error) {
+			localCalls++
+			return "", errors.New("local resolver should not be called")
+		},
+		func(_ context.Context, _ string) (string, error) {
+			remoteCalls++
+			return "", errors.New("remote resolver should not be called")
+		},
+	)
+	resolveReferencePlatformConfig = func(_ context.Context, ref name.Reference) (string, string, error) {
+		platformCalls++
+		if got, want := ref.Name(), pinnedRef; got != want {
+			t.Fatalf("unexpected platform resolver ref: got %q want %q", got, want)
+		}
+		if runtime.GOARCH == "arm64" {
+			return "linux", "amd64", nil
+		}
+		return "linux", "arm64", nil
+	}
+
+	_, err := resolveReferenceForImageOverride(context.Background(), pinnedRef, true)
+	if err == nil {
+		t.Fatal("expected resolveReferenceForImageOverride to reject mismatched platform")
+	}
+	if !strings.Contains(err.Error(), "incompatible") {
+		t.Fatalf("expected platform mismatch error, got %v", err)
+	}
+	if localCalls != 0 {
+		t.Fatalf("expected local resolver call count 0, got %d", localCalls)
+	}
+	if remoteCalls != 0 {
+		t.Fatalf("expected remote resolver call count 0, got %d", remoteCalls)
+	}
+	if platformCalls != 1 {
+		t.Fatalf("expected platform resolver call count 1, got %d", platformCalls)
+	}
+}
+
 func TestResolveReferenceForImageOverrideDoesNotTreatDottedImageNameAsRegistryHost(t *testing.T) {
 	localCalls := 0
 	remoteCalls := 0

--- a/internal/cli/image_override_resolution_test.go
+++ b/internal/cli/image_override_resolution_test.go
@@ -168,6 +168,41 @@ func TestResolveReferenceForImageOverrideReturnsExplicitRegistryDigestWithoutRes
 	}
 }
 
+func TestResolveReferenceForImageOverrideDoesNotTreatDottedImageNameAsRegistryHost(t *testing.T) {
+	localCalls := 0
+	remoteCalls := 0
+	const sourceRef = "myteam/app.v2@sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+	const localRef = "local/docker-image@sha256:1111111111111111111111111111111111111111111111111111111111111111"
+	withImageOverrideResolversForTest(
+		t,
+		func(_ context.Context, source string) (string, error) {
+			localCalls++
+			if got, want := source, sourceRef; got != want {
+				t.Fatalf("unexpected local resolver source: got %q want %q", got, want)
+			}
+			return localRef, nil
+		},
+		func(_ context.Context, _ string) (string, error) {
+			remoteCalls++
+			return "", errors.New("remote resolver should not be called")
+		},
+	)
+
+	got, err := resolveReferenceForImageOverride(context.Background(), sourceRef, true)
+	if err != nil {
+		t.Fatalf("resolveReferenceForImageOverride returned error: %v", err)
+	}
+	if got != localRef {
+		t.Fatalf("unexpected resolved ref: got %q want %q", got, localRef)
+	}
+	if localCalls != 1 {
+		t.Fatalf("expected local resolver call count 1, got %d", localCalls)
+	}
+	if remoteCalls != 0 {
+		t.Fatalf("expected remote resolver call count 0, got %d", remoteCalls)
+	}
+}
+
 func TestResolveReferenceForImageOverrideSkipsLocalForRemoteEndpoint(t *testing.T) {
 	localCalls := 0
 	remoteCalls := 0

--- a/scripts/benchmark-tti.sh
+++ b/scripts/benchmark-tti.sh
@@ -16,13 +16,17 @@ Options:
   -c, --chdir <path>        Repository/policy directory (default: current directory)
   --output-dir <path>       JSON output directory (default: benchmarks/results)
   --cleanroom-bin <path>    cleanroom binary path (default: cleanroom from PATH, then ./dist/cleanroom)
+  --start-server            Start cleanroom serve in the background before benchmarking
+  --build                   Run mise run build before benchmarking
+  --gateway-listen <addr>   Gateway listen address when starting a server (default: :0)
   -h, --help                Show this help
 
 Environment:
   XDG_RUNTIME_DIR           Used to derive the default unix socket endpoint.
 
 Notes:
-  - This script expects the cleanroom server to already be running.
+  - By default this script expects the cleanroom server to already be running.
+  - Use --start-server to self-host cleanroom serve outside the timed section.
   - The measured command is: cleanroom exec ... -- echo benchmark
   - Sandbox termination runs in hyperfine cleanup and is excluded from timing.
 EOF
@@ -41,6 +45,7 @@ elif [[ -x "./dist/cleanroom" ]]; then
 else
   cleanroom_bin="cleanroom"
 fi
+cleanroom_bin_explicit=0
 
 host="$default_host"
 iterations=10
@@ -48,6 +53,12 @@ warmup=1
 backend=""
 chdir="$PWD"
 output_dir="benchmarks/results"
+start_server=0
+build_before=0
+gateway_listen=":0"
+server_pid=""
+server_socket_path=""
+sandbox_id_path=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -77,6 +88,19 @@ while [[ $# -gt 0 ]]; do
       ;;
     --cleanroom-bin)
       cleanroom_bin="$2"
+      cleanroom_bin_explicit=1
+      shift 2
+      ;;
+    --start-server)
+      start_server=1
+      shift
+      ;;
+    --build)
+      build_before=1
+      shift
+      ;;
+    --gateway-listen)
+      gateway_listen="$2"
       shift 2
       ;;
     -h|--help)
@@ -91,6 +115,30 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+cleanup() {
+  if [[ -n "$sandbox_id_path" && -f "$sandbox_id_path" ]]; then
+    sid="$(grep -m1 '^sandbox_id=' "$sandbox_id_path" | cut -d= -f2 || true)"
+    if [[ -n "$sid" ]]; then
+      "$cleanroom_bin" sandbox rm --host "$host" "$sid" >/dev/null 2>&1 || true
+    fi
+    : > "$sandbox_id_path"
+  fi
+
+  if [[ -n "$server_pid" ]]; then
+    kill "$server_pid" >/dev/null 2>&1 || true
+    wait "$server_pid" >/dev/null 2>&1 || true
+  fi
+
+  if [[ -n "$server_socket_path" ]]; then
+    rm -f "$server_socket_path"
+  fi
+
+  if [[ -n "$sandbox_id_path" ]]; then
+    rm -f "$sandbox_id_path"
+  fi
+}
+trap cleanup EXIT
+
 if ! [[ "$iterations" =~ ^[0-9]+$ ]] || [[ "$iterations" -le 0 ]]; then
   echo "iterations must be a positive integer" >&2
   exit 1
@@ -102,6 +150,16 @@ fi
 if ! command -v hyperfine >/dev/null 2>&1; then
   echo "hyperfine is required but not found in PATH" >&2
   exit 1
+fi
+if [[ "$build_before" -eq 1 ]]; then
+  if ! command -v mise >/dev/null 2>&1; then
+    echo "mise is required for --build but not found in PATH" >&2
+    exit 1
+  fi
+  mise run build >/dev/null
+  if [[ "$cleanroom_bin_explicit" -eq 0 && -x "./dist/cleanroom" ]]; then
+    cleanroom_bin="./dist/cleanroom"
+  fi
 fi
 if [[ "$cleanroom_bin" == */* ]]; then
   if [[ ! -x "$cleanroom_bin" ]]; then
@@ -121,12 +179,50 @@ mkdir -p "$output_dir"
 timestamp="$(date -u +%Y-%m-%dT%H-%M-%SZ)"
 output_path="${output_dir}/${timestamp}.json"
 sandbox_id_path="$(mktemp "${output_dir}/.tti-sandbox-id.XXXXXX")"
+server_log_path="${output_dir}/${timestamp}-server.log"
+
+if [[ -z "${CLEANROOM_DARWIN_VZ_HELPER:-}" ]]; then
+  if [[ -d "${PWD}/dist/cleanroom-darwin-vz.app" ]]; then
+    export CLEANROOM_DARWIN_VZ_HELPER="${PWD}/dist/cleanroom-darwin-vz.app"
+  elif [[ -x "${PWD}/dist/cleanroom-darwin-vz" ]]; then
+    export CLEANROOM_DARWIN_VZ_HELPER="${PWD}/dist/cleanroom-darwin-vz"
+  fi
+fi
+
+if [[ "$start_server" -eq 1 ]]; then
+  if [[ "$host" == unix://* ]]; then
+    server_socket_path="${host#unix://}"
+    mkdir -p "$(dirname "$server_socket_path")"
+    rm -f "$server_socket_path"
+  fi
+
+  "$cleanroom_bin" serve --listen "$host" --gateway-listen "$gateway_listen" >"$server_log_path" 2>&1 &
+  server_pid=$!
+
+  for _ in {1..200}; do
+    if ! kill -0 "$server_pid" >/dev/null 2>&1; then
+      echo "cleanroom server exited before it became ready" >&2
+      tail -80 "$server_log_path" >&2 || true
+      exit 1
+    fi
+    if "$cleanroom_bin" sandbox ls --host "$host" >/dev/null 2>&1; then
+      break
+    fi
+    sleep 0.05
+  done
+
+  if ! "$cleanroom_bin" sandbox ls --host "$host" >/dev/null 2>&1; then
+    echo "timed out waiting for cleanroom server readiness on $host" >&2
+    tail -80 "$server_log_path" >&2 || true
+    exit 1
+  fi
+fi
 
 benchmark_cmd=("$cleanroom_bin" exec --host "$host" -c "$chdir")
 if [[ -n "$backend" ]]; then
   benchmark_cmd+=(--backend "$backend")
 fi
-benchmark_cmd+=(--print-sandbox-id -- echo benchmark)
+benchmark_cmd+=(--keep --print-sandbox-id -- echo benchmark)
 
 quoted_benchmark_cmd=""
 for token in "${benchmark_cmd[@]}"; do
@@ -155,6 +251,5 @@ hyperfine \
   "$quoted_benchmark_cmd"
 
 bash -lc "$cleanup_cmd"
-rm -f "$sandbox_id_path"
 
 echo "Results written to ${output_path}"

--- a/scripts/benchmark-tti.sh
+++ b/scripts/benchmark-tti.sh
@@ -250,7 +250,7 @@ for token in "${exec_cmd_prefix[@]}"; do
   quoted_exec_cmd_prefix+="${escaped} "
 done
 printf -v sandbox_id_escaped '%q' "$sandbox_id_path"
-quoted_benchmark_cmd="sid=\$(${quoted_sandbox_create_cmd}2>/dev/null); printf 'sandbox_id=%s\n' \"\${sid}\" > ${sandbox_id_escaped}; ${quoted_exec_cmd_prefix}\"\${sid}\" -- echo benchmark >/dev/null"
+quoted_benchmark_cmd="sid=\$(${quoted_sandbox_create_cmd}2>/dev/null) && [ -n \"\${sid}\" ] && printf 'sandbox_id=%s\n' \"\${sid}\" > ${sandbox_id_escaped} && ${quoted_exec_cmd_prefix}\"\${sid}\" -- echo benchmark >/dev/null"
 
 printf -v cleanroom_bin_escaped '%q' "$cleanroom_bin"
 printf -v host_escaped '%q' "$host"

--- a/scripts/benchmark-tti.sh
+++ b/scripts/benchmark-tti.sh
@@ -48,6 +48,7 @@ else
   cleanroom_bin="cleanroom"
 fi
 cleanroom_bin_explicit=0
+host_explicit=0
 
 host="$default_host"
 iterations=10
@@ -60,6 +61,7 @@ start_server=0
 build_before=0
 gateway_listen=":0"
 server_pid=""
+server_socket_dir=""
 server_socket_path=""
 sandbox_id_path=""
 
@@ -67,6 +69,7 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --host)
       host="$2"
+      host_explicit=1
       shift 2
       ;;
     -n|--iterations)
@@ -139,6 +142,9 @@ cleanup() {
   if [[ -n "$server_socket_path" ]]; then
     rm -f "$server_socket_path"
   fi
+  if [[ -n "$server_socket_dir" ]]; then
+    rmdir "$server_socket_dir" >/dev/null 2>&1 || true
+  fi
 
   if [[ -n "$sandbox_id_path" ]]; then
     rm -f "$sandbox_id_path"
@@ -188,6 +194,12 @@ output_path="${output_dir}/${timestamp}.json"
 sandbox_id_path="$(mktemp "${output_dir}/.tti-sandbox-id.XXXXXX")"
 server_log_path="${output_dir}/${timestamp}-server.log"
 
+if [[ "$start_server" -eq 1 && "$host_explicit" -eq 0 ]]; then
+  server_socket_dir="$(mktemp -d "${output_dir}/.cleanroom-server.XXXXXX")"
+  server_socket_path="${server_socket_dir}/cleanroom.sock"
+  host="unix://${server_socket_path}"
+fi
+
 if [[ -z "${CLEANROOM_DARWIN_VZ_HELPER:-}" ]]; then
   if [[ -d "${PWD}/dist/cleanroom-darwin-vz.app" ]]; then
     export CLEANROOM_DARWIN_VZ_HELPER="${PWD}/dist/cleanroom-darwin-vz.app"
@@ -198,9 +210,16 @@ fi
 
 if [[ "$start_server" -eq 1 ]]; then
   if [[ "$host" == unix://* ]]; then
-    server_socket_path="${host#unix://}"
+    if [[ -z "$server_socket_path" ]]; then
+      requested_socket_path="${host#unix://}"
+      if [[ -e "$requested_socket_path" ]]; then
+        echo "refusing to start cleanroom server because unix socket path already exists: $requested_socket_path" >&2
+        echo "choose a different --host or omit --host to use an isolated benchmark socket" >&2
+        exit 1
+      fi
+      server_socket_path="$requested_socket_path"
+    fi
     mkdir -p "$(dirname "$server_socket_path")"
-    rm -f "$server_socket_path"
   fi
 
   "$cleanroom_bin" serve --listen "$host" --gateway-listen "$gateway_listen" >"$server_log_path" 2>&1 &

--- a/scripts/benchmark-tti.sh
+++ b/scripts/benchmark-tti.sh
@@ -12,8 +12,9 @@ Options:
   --host <endpoint>         Control-plane endpoint (default: unix://$XDG_RUNTIME_DIR/cleanroom/cleanroom.sock, or unix:///tmp/cleanroom/cleanroom.sock)
   -n, --iterations <count>  Number of benchmark runs (default: 10)
   --warmup <count>          Warmup runs before measuring (default: 1)
-  --backend <name>          Optional backend override for cleanroom exec
-  -c, --chdir <path>        Repository/policy directory (default: current directory)
+  --backend <name>          Optional backend override for sandbox create
+  --image <ref>             Image ref for sandbox create (default: pinned cleanroom-base alpine digest)
+  -c, --chdir <path>        Accepted for compatibility; raw sandbox benchmark ignores local policy
   --output-dir <path>       JSON output directory (default: benchmarks/results)
   --cleanroom-bin <path>    cleanroom binary path (default: cleanroom from PATH, then ./dist/cleanroom)
   --start-server            Start cleanroom serve in the background before benchmarking
@@ -27,7 +28,7 @@ Environment:
 Notes:
   - By default this script expects the cleanroom server to already be running.
   - Use --start-server to self-host cleanroom serve outside the timed section.
-  - The measured command is: cleanroom exec ... -- echo benchmark
+  - The measured command is: cleanroom sandbox create ... && cleanroom exec --in ... -- echo benchmark
   - Sandbox termination runs in hyperfine cleanup and is excluded from timing.
 EOF
 }
@@ -37,6 +38,7 @@ if [[ -n "${XDG_RUNTIME_DIR:-}" ]]; then
 else
   default_host="unix:///tmp/cleanroom/cleanroom.sock"
 fi
+default_image="ghcr.io/buildkite/cleanroom-base/alpine@sha256:fe2fbe4950546c0983247d71d5ff5795b064d7e603596efc57e2ea88aaaf3cb1"
 
 if command -v cleanroom >/dev/null 2>&1; then
   cleanroom_bin="$(command -v cleanroom)"
@@ -51,6 +53,7 @@ host="$default_host"
 iterations=10
 warmup=1
 backend=""
+image="$default_image"
 chdir="$PWD"
 output_dir="benchmarks/results"
 start_server=0
@@ -76,6 +79,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --backend)
       backend="$2"
+      shift 2
+      ;;
+    --image)
+      image="$2"
       shift 2
       ;;
     -c|--chdir)
@@ -218,19 +225,32 @@ if [[ "$start_server" -eq 1 ]]; then
   fi
 fi
 
-benchmark_cmd=("$cleanroom_bin" exec --host "$host" -c "$chdir")
-if [[ -n "$backend" ]]; then
-  benchmark_cmd+=(--backend "$backend")
-fi
-benchmark_cmd+=(--keep --print-sandbox-id -- echo benchmark)
+# Keep accepting --chdir for older callers while ensuring this benchmark stays
+# repo-agnostic and never reads local cleanroom.yaml or git state.
+: "$chdir"
 
-quoted_benchmark_cmd=""
-for token in "${benchmark_cmd[@]}"; do
+sandbox_create_cmd=("$cleanroom_bin" sandbox create --host "$host")
+if [[ -n "$backend" ]]; then
+  sandbox_create_cmd+=(--backend "$backend")
+fi
+if [[ -n "$image" ]]; then
+  sandbox_create_cmd+=(--image "$image")
+fi
+
+quoted_sandbox_create_cmd=""
+for token in "${sandbox_create_cmd[@]}"; do
   printf -v escaped '%q' "$token"
-  quoted_benchmark_cmd+="${escaped} "
+  quoted_sandbox_create_cmd+="${escaped} "
+done
+
+exec_cmd_prefix=("$cleanroom_bin" exec --host "$host" --in)
+quoted_exec_cmd_prefix=""
+for token in "${exec_cmd_prefix[@]}"; do
+  printf -v escaped '%q' "$token"
+  quoted_exec_cmd_prefix+="${escaped} "
 done
 printf -v sandbox_id_escaped '%q' "$sandbox_id_path"
-quoted_benchmark_cmd+=" >/dev/null 2>${sandbox_id_escaped}"
+quoted_benchmark_cmd="sid=\$(${quoted_sandbox_create_cmd}2>/dev/null); printf 'sandbox_id=%s\n' \"\${sid}\" > ${sandbox_id_escaped}; ${quoted_exec_cmd_prefix}\"\${sid}\" -- echo benchmark >/dev/null"
 
 printf -v cleanroom_bin_escaped '%q' "$cleanroom_bin"
 printf -v host_escaped '%q' "$host"
@@ -238,6 +258,7 @@ cleanup_cmd="sid=\$(grep -m1 '^sandbox_id=' ${sandbox_id_escaped} | cut -d= -f2 
 
 echo "Benchmarking TTI with hyperfine"
 echo "- endpoint: ${host}"
+echo "- image: ${image}"
 echo "- iterations: ${iterations}"
 echo "- warmup: ${warmup}"
 echo "- output: ${output_path}"

--- a/scripts/benchmark_tti_test.go
+++ b/scripts/benchmark_tti_test.go
@@ -161,3 +161,96 @@ sys.exit(2)
 		t.Fatalf("expected exec --in call, got:\n%s", rawLog)
 	}
 }
+
+func TestBenchmarkTTIStopsWhenSandboxCreateFails(t *testing.T) {
+	tmpDir := t.TempDir()
+	binDir := filepath.Join(tmpDir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+
+	fakeHyperfine := `#!/usr/bin/env bash
+set -euo pipefail
+prepare=
+cleanup=
+command=
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --runs|--warmup|--export-json)
+      shift 2
+      ;;
+    --prepare)
+      prepare=$2
+      shift 2
+      ;;
+    --cleanup)
+      cleanup=$2
+      shift 2
+      ;;
+    *)
+      command=$1
+      shift
+      ;;
+  esac
+done
+if [[ -n "$prepare" ]]; then
+  bash -lc "$prepare"
+fi
+set +e
+bash -lc "$command"
+status=$?
+set -e
+if [[ -n "$cleanup" ]]; then
+  bash -lc "$cleanup"
+fi
+exit "$status"
+`
+	writeLocalExecutable(t, binDir, "hyperfine", fakeHyperfine)
+
+	callLog := filepath.Join(tmpDir, "cleanroom-calls.log")
+	fakeCleanroom := `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$FAKE_CLEANROOM_LOG"
+if [[ "${1:-}" == sandbox && "${2:-}" == create ]]; then
+  echo "create failed" >&2
+  exit 42
+fi
+if [[ "${1:-}" == exec ]]; then
+  echo "exec should not run after create failure" >&2
+  exit 0
+fi
+if [[ "${1:-}" == sandbox && "${2:-}" == rm ]]; then
+  exit 0
+fi
+echo "unexpected args: $*" >&2
+exit 2
+`
+	fakeCleanroomPath := writeLocalExecutable(t, binDir, "cleanroom", fakeCleanroom)
+
+	cmd := exec.Command(
+		"bash",
+		"benchmark-tti.sh",
+		"--cleanroom-bin", fakeCleanroomPath,
+		"--host", "unix://"+filepath.Join(tmpDir, "cleanroom.sock"),
+		"--backend", "darwin-vz",
+		"--iterations", "1",
+		"--warmup", "0",
+		"--output-dir", filepath.Join(tmpDir, "out"),
+	)
+	cmd.Env = append(os.Environ(),
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"FAKE_CLEANROOM_LOG="+callLog,
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected benchmark-tti.sh to fail when sandbox create fails\n%s", out)
+	}
+
+	rawLog, err := os.ReadFile(callLog)
+	if err != nil {
+		t.Fatalf("read call log: %v", err)
+	}
+	if strings.Contains(string(rawLog), "exec ") {
+		t.Fatalf("exec should not run after sandbox create fails, got:\n%s", rawLog)
+	}
+}

--- a/scripts/benchmark_tti_test.go
+++ b/scripts/benchmark_tti_test.go
@@ -1,0 +1,163 @@
+package scripts_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const pinnedDefaultImage = "ghcr.io/buildkite/cleanroom-base/alpine@sha256:fe2fbe4950546c0983247d71d5ff5795b064d7e603596efc57e2ea88aaaf3cb1"
+
+func TestBenchmarkTTIUsesRawSandboxCreateAndExecIn(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not available")
+	}
+
+	tmpDir := t.TempDir()
+	binDir := filepath.Join(tmpDir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+
+	fakeHyperfine := `#!/usr/bin/env python3
+import json
+import pathlib
+import subprocess
+import sys
+
+args = sys.argv[1:]
+prepare = None
+cleanup = None
+export_json = None
+command = None
+i = 0
+while i < len(args):
+    arg = args[i]
+    if arg in ("--runs", "--warmup"):
+        i += 2
+    elif arg == "--prepare":
+        prepare = args[i + 1]
+        i += 2
+    elif arg == "--cleanup":
+        cleanup = args[i + 1]
+        i += 2
+    elif arg == "--export-json":
+        export_json = args[i + 1]
+        i += 2
+    else:
+        command = arg
+        i += 1
+
+if prepare:
+    subprocess.run(prepare, shell=True, check=True)
+subprocess.run(command, shell=True, check=True)
+if cleanup:
+    subprocess.run(cleanup, shell=True, check=True)
+
+pathlib.Path(export_json).write_text(json.dumps({
+    "results": [{
+        "command": command,
+        "mean": 0.001,
+        "stddev": 0.0,
+        "median": 0.001,
+        "min": 0.001,
+        "max": 0.001,
+        "times": [0.001],
+        "exit_codes": [0],
+    }],
+}))
+`
+	writeLocalExecutable(t, binDir, "hyperfine", fakeHyperfine)
+
+	callLog := filepath.Join(tmpDir, "cleanroom-calls.jsonl")
+	fakeCleanroom := `#!/usr/bin/env python3
+import json
+import os
+import signal
+import sys
+import time
+
+log_path = os.environ["FAKE_CLEANROOM_LOG"]
+expected_image = os.environ["EXPECTED_CLEANROOM_IMAGE"]
+argv = sys.argv[1:]
+with open(log_path, "a") as f:
+    f.write(json.dumps(argv) + "\n")
+
+if argv and argv[0] == "serve":
+    signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
+    signal.signal(signal.SIGINT, lambda *_: sys.exit(0))
+    while True:
+        time.sleep(1)
+
+if len(argv) >= 2 and argv[0] == "sandbox" and argv[1] == "ls":
+    print("[]")
+    sys.exit(0)
+
+if len(argv) >= 2 and argv[0] == "sandbox" and argv[1] == "create":
+    if "-c" in argv or "--chdir" in argv:
+        print("sandbox create must not receive local chdir", file=sys.stderr)
+        sys.exit(3)
+    if "--backend" not in argv or "darwin-vz" not in argv:
+        print("sandbox create missing backend", file=sys.stderr)
+        sys.exit(3)
+    if "--image" not in argv or expected_image not in argv:
+        print("sandbox create missing expected pinned image", file=sys.stderr)
+        sys.exit(3)
+    print("cr_raw_001")
+    sys.exit(0)
+
+if len(argv) >= 2 and argv[0] == "sandbox" and argv[1] == "rm":
+    print("sandbox terminated")
+    sys.exit(0)
+
+if argv and argv[0] == "exec":
+    if "--in" not in argv or "cr_raw_001" not in argv:
+        print("exec must reuse raw sandbox via --in", file=sys.stderr)
+        sys.exit(3)
+    if "--backend" in argv or "--keep" in argv or "--print-sandbox-id" in argv:
+        print("exec should not create a top-level sandbox", file=sys.stderr)
+        sys.exit(3)
+    print("benchmark")
+    sys.exit(0)
+
+print("unexpected args: " + " ".join(argv), file=sys.stderr)
+sys.exit(2)
+`
+	fakeCleanroomPath := writeLocalExecutable(t, binDir, "cleanroom", fakeCleanroom)
+
+	outputDir := filepath.Join(tmpDir, "out")
+	cmd := exec.Command(
+		"bash",
+		"benchmark-tti.sh",
+		"--cleanroom-bin", fakeCleanroomPath,
+		"--host", "unix://"+filepath.Join(tmpDir, "cleanroom.sock"),
+		"--start-server",
+		"--backend", "darwin-vz",
+		"--iterations", "1",
+		"--warmup", "0",
+		"--output-dir", outputDir,
+		"--chdir", filepath.Join(tmpDir, "must-not-be-used"),
+	)
+	cmd.Env = append(os.Environ(),
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"FAKE_CLEANROOM_LOG="+callLog,
+		"EXPECTED_CLEANROOM_IMAGE="+pinnedDefaultImage,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("benchmark-tti.sh failed: %v\n%s", err, out)
+	}
+
+	rawLog, err := os.ReadFile(callLog)
+	if err != nil {
+		t.Fatalf("read call log: %v", err)
+	}
+	if !strings.Contains(string(rawLog), `"sandbox", "create"`) {
+		t.Fatalf("expected raw sandbox create call, got:\n%s", rawLog)
+	}
+	if !strings.Contains(string(rawLog), `"exec", "--host"`) || !strings.Contains(string(rawLog), `"--in"`) {
+		t.Fatalf("expected exec --in call, got:\n%s", rawLog)
+	}
+}

--- a/scripts/benchmark_tti_test.go
+++ b/scripts/benchmark_tti_test.go
@@ -254,3 +254,66 @@ exit 2
 		t.Fatalf("exec should not run after sandbox create fails, got:\n%s", rawLog)
 	}
 }
+
+func TestBenchmarkTTIStartServerRefusesExistingUnixSocket(t *testing.T) {
+	tmpDir := t.TempDir()
+	binDir := filepath.Join(tmpDir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+
+	writeLocalExecutable(t, binDir, "hyperfine", "#!/usr/bin/env bash\nexit 0\n")
+
+	callLog := filepath.Join(tmpDir, "cleanroom-calls.log")
+	fakeCleanroom := `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$FAKE_CLEANROOM_LOG"
+if [[ "${1:-}" == serve ]]; then
+  echo "serve should not start with an existing socket" >&2
+  exit 2
+fi
+exit 0
+`
+	fakeCleanroomPath := writeLocalExecutable(t, binDir, "cleanroom", fakeCleanroom)
+
+	socketPath := filepath.Join(tmpDir, "cleanroom.sock")
+	if err := os.WriteFile(socketPath, []byte("existing socket sentinel"), 0o600); err != nil {
+		t.Fatalf("write existing socket sentinel: %v", err)
+	}
+
+	cmd := exec.Command(
+		"bash",
+		"benchmark-tti.sh",
+		"--cleanroom-bin", fakeCleanroomPath,
+		"--host", "unix://"+socketPath,
+		"--start-server",
+		"--iterations", "1",
+		"--warmup", "0",
+		"--output-dir", filepath.Join(tmpDir, "out"),
+	)
+	cmd.Env = append(os.Environ(),
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"FAKE_CLEANROOM_LOG="+callLog,
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected benchmark-tti.sh to fail when start-server socket exists\n%s", out)
+	}
+	if !strings.Contains(string(out), "already exists") {
+		t.Fatalf("expected existing socket error, got:\n%s", out)
+	}
+	contents, err := os.ReadFile(socketPath)
+	if err != nil {
+		t.Fatalf("existing socket path should not be removed: %v", err)
+	}
+	if got, want := string(contents), "existing socket sentinel"; got != want {
+		t.Fatalf("existing socket path was modified: got %q want %q", got, want)
+	}
+	rawLog, err := os.ReadFile(callLog)
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatalf("read call log: %v", err)
+	}
+	if strings.Contains(string(rawLog), "serve") {
+		t.Fatalf("serve should not start with an existing socket, got:\n%s", rawLog)
+	}
+}


### PR DESCRIPTION
## What changed

- Updated `scripts/benchmark-tti.sh` to benchmark the raw sandbox flow (`sandbox create` then `exec --in`) without reading local repository policy.
- Pinned the benchmark script default image to the resolved cleanroom-base alpine digest.
- Added script coverage for the raw sandbox flow and pinned default image.
- Added a fast path for explicit registry digest image overrides so `--image ghcr.io/...@sha256:...` does not try local Docker or remote tag resolution first.

## Why

The TTI benchmark was either reading local cleanroom policy through top-level `exec`, or paying client-side image resolution costs that were outside the server launch timings. Once the script pinned the default via `--image`, local unix control-plane behavior treated it as a local image override candidate, causing pinned runs to slow down to about 2.97s.

The fast path keeps fully qualified digest refs deterministic and cheap, while preserving local Docker override behavior for non-digest/local-style image names.

## Validation

- `go test ./internal/cli -run 'TestResolveReferenceForImageOverride|TestResolveReferenceForPolicyUpdate' -count=1`
- `go test ./internal/cli`
- `go test ./scripts`
- `mise exec -- shellcheck -x scripts/benchmark-tti.sh`
- `scripts/benchmark-tti.sh --build --start-server --backend darwin-vz --iterations 5 --warmup 1`

Pinned benchmark result after the fast path: `658.8 ms ± 22.2 ms` across 5 measured runs.