### PR TITLE
feat: Add portable dependency stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ sandbox:
     command: bundle install
     key:
       files: [Gemfile.lock]
+    # Optional: reuse dependency state across source-only commits when the
+    # dependency outputs survive a checkout refresh.
+    # reuse: portable
   services:
     docker:
       required: true

--- a/docs/plans/layered-caching.md
+++ b/docs/plans/layered-caching.md
@@ -24,13 +24,18 @@ The system-cache pipeline uses stage terminology:
 - workspace stage: runtime rootfs plus exact repository checkout
 - dependency stage: workspace stage plus policy-constrained bootstrap and
   dependencies
+- portable dependency seed: dependency-prepared rootfs that can be restored
+  first and then have the repository checkout refreshed to a different commit
+  when declared dependency inputs still match
 - services stage: dependency stage or workspace stage plus policy-constrained
   service preparation state on disk
 
 Each stage output is a full sealed rootfs snapshot. Higher stages subsume lower
 stages. At runtime we do not mount `runtime + workspace + dependency` as a live
 stack. We clone the best ready stage into one writable child and boot that as
-the only guest root disk.
+the only guest root disk. When a portable dependency seed is used, it is still a
+full rootfs snapshot. Cleanroom restores it into a writable child, refreshes the
+repository checkout inside that child, and only then treats the sandbox as ready.
 
 The core system-cache model is:
 
@@ -58,6 +63,9 @@ This document uses:
 
 - **stage** for the transformation step in the cache pipeline
 - **cache entry** for the immutable stored output of a stage
+- **portable dependency seed** for a dependency-prepared full-rootfs cache entry
+  whose useful dependency state is expected to survive a later repository
+  checkout refresh
 
 Current implementation still uses some "seed" naming for stage outputs,
 especially workspace-stage snapshots. This document uses stage terminology
@@ -124,6 +132,9 @@ This phase now means:
   `sandbox.dependencies.key.files`, which bootstraps a single dependency
   command inside the restored workspace stage and publishes the resulting
   dependency stage
+- add a portable dependency-seed path for dependency state that survives an
+  in-place checkout refresh, so unchanged lockfiles can reuse a dependency
+  snapshot across source-only commits
 - keep distribution/export out of scope until the host-local model is proven
 
 ## Current Progress Snapshot
@@ -149,6 +160,8 @@ This phase now means:
 - dependency-stage caching is starting with a single configured dependency
   bootstrap slice for exact-commit workspaces; toolchain-derived key inputs are
   still pending
+- portable dependency-seed reuse across source-only commits is not implemented
+  yet
 
 Today that means:
 
@@ -173,6 +186,9 @@ Today that means:
 - the initial dependency-stage key intentionally starts from the workspace-stage
   key plus policy hash, dependency bootstrap recipe digest, and declared key
   file digests; richer toolchain inputs are still to come
+- because dependency-stage snapshots are full rootfs snapshots, decoupling them
+  from exact workspace identity requires a checkout refresh and validation step
+  after restore; it is not live layer composition
 
 ## Background
 
@@ -276,6 +292,11 @@ They must instead be keyed by exact inputs such as:
 - compiled policy hash
 - bootstrap recipe digest
 
+Portable dependency seeds are the one deliberate exception to "commit SHA is
+part of every repository cache key": they may omit the exact source commit only
+because they include declared dependency key-file bytes and must refresh and
+verify the checkout before execution.
+
 ### 3. System caches are stage outputs
 
 The cache pipeline should be described as ordered stages:
@@ -287,6 +308,10 @@ The cache pipeline should be described as ordered stages:
 Each stage produces one immutable cached output. Higher stages subsume the
 lower stages logically, even if the runtime only boots from one concrete rootfs
 snapshot.
+
+Portable dependency seeds are dependency-stage entries with different reuse
+semantics. They do not mean Cleanroom can compose independent dependency and
+workspace snapshots at runtime.
 
 ### 4. Each system cache entry is a full rootfs snapshot
 
@@ -342,8 +367,11 @@ This is the host-managed environment cache pipeline:
 - runtime stage cache
 - workspace stage cache
 - dependency stage cache
+- portable dependency seed cache
 
 These are reusable rootfs states that can be cloned into disposable sandboxes.
+Portable dependency seeds are still full rootfs states; their portability comes
+from checkout refresh and validation, not from filesystem layering.
 
 ### B. Transport caches
 
@@ -470,7 +498,9 @@ Purpose:
 - capture the environment after policy-constrained bootstrap such as
   dependency install, generated fixtures, and language-specific setup
 
-Suggested key:
+There are two dependency-cache modes.
+
+The conservative exact dependency stage remains tied to a specific workspace:
 
 ```text
 dependency_stage_key = H(
@@ -484,9 +514,32 @@ dependency_stage_key = H(
 )
 ```
 
+The portable dependency seed is keyed by dependency-relevant inputs rather than
+by the exact workspace snapshot:
+
+```text
+portable_dependency_seed_key = H(
+  runtime_base_key,
+  backend_family,
+  canonical_remote_url,
+  repository_destination_dir,
+  repository_submodule_mode,
+  checkout_refresh_recipe_digest,
+  dependency_policy_hash,
+  dependency_key_files_digest,
+  bootstrap_recipe_digest,
+  dependency_output_mode,
+  producer_version
+)
+```
+
 Output:
 
-- sealed rootfs snapshot ready for common build or test commands
+- exact dependency stage: sealed rootfs snapshot ready for common build or test
+  commands against one exact checkout
+- portable dependency seed: sealed rootfs snapshot that may contain an older
+  checkout, but can be restored first and then refreshed to the requested
+  checkout before execution
 
 Notes:
 
@@ -504,6 +557,22 @@ Notes:
   with the workspace-stage key plus policy hash, the concrete bootstrap recipe
   digest, and declared key-file digests, then grow richer toolchain inputs
   later
+- portable dependency seeds are a separate reuse mode, not a replacement for
+  exact dependency stages
+- a portable seed hit must refresh the repository checkout inside the writable
+  child before user code runs; the restored snapshot's old checkout is never
+  treated as current
+- after checkout refresh and changeset apply, Cleanroom must recompute the
+  declared dependency key-file digest and only skip dependency bootstrap if it
+  still matches the seed's recorded digest
+- if the digest does not match, Cleanroom must discard the restored child and
+  fall back to the normal workspace-stage path before running fresh dependencies
+- the portable mode is suitable for dependency outputs that survive
+  `git reset --hard` and `git clean -ffdx`, such as Go module caches,
+  `mise` installs, system packages, and global package-manager caches
+- repo-local outputs such as `node_modules`, `vendor/bundle`, or generated files
+  under the checkout should stay on the exact dependency-stage path unless
+  explicit preserve/output semantics are added later
 
 ### Stage 3: Writable execution child
 
@@ -593,10 +662,18 @@ The control plane can then resolve the highest reusable stage cache it trusts:
 
 1. services stage hit for the exact checkout plus optional changeset
 2. dependency stage hit for the exact checkout plus optional changeset
-3. workspace stage hit for the exact checkout plus optional changeset
-4. exact-checkout workspace stage hit, followed by verified changeset apply
-5. runtime stage hit
-6. cold path
+3. portable dependency-seed hit for matching dependency inputs, followed by
+   checkout refresh, optional changeset apply, and post-refresh key-file
+   validation
+4. workspace stage hit for the exact checkout plus optional changeset
+5. exact-checkout workspace stage hit, followed by verified changeset apply
+6. runtime stage hit
+7. cold path
+
+Portable dependency-seed lookup should use host-side key-file digest resolution
+when possible so Cleanroom does not restore a candidate that is already known to
+be stale. The post-refresh digest check is still required as defense in depth
+before skipping dependency bootstrap.
 
 ## Production Flow
 
@@ -645,6 +722,24 @@ Shared stage-cache publication should be a host-controlled promotion pipeline.
 5. Snapshot the resulting root volume.
 6. Publish the dependency-stage metadata and storage reference atomically.
 
+### Publish portable dependency seed
+
+1. Start from the same host-controlled dependency bootstrap flow as an exact
+   dependency stage.
+2. Compute the portable dependency seed key from the runtime base, repository
+   identity, checkout-refresh recipe, dependency policy hash, bootstrap recipe
+   digest, and declared dependency key-file digest.
+3. Verify the bootstrap completed successfully and record the key-file digest
+   that made the seed reusable.
+4. Verify that the dependency output mode is portable. The first portable slice
+   should only promote seeds whose useful dependency state lives outside the
+   repository checkout, or whose output paths are explicitly declared by a later
+   policy surface.
+5. Snapshot the resulting root volume.
+6. Publish the portable seed metadata and storage reference atomically. The
+   stored repository checkout is provenance only; later reuse must not treat it
+   as the requested checkout.
+
 ### Publish services stage
 
 1. Start from a published dependency stage when one exists, otherwise from a
@@ -666,6 +761,8 @@ Warm-hit resolution should be simple.
 3. Clone its rootfs snapshot into a fresh writable child volume.
 4. Attach that single writable child as the VM root disk.
 5. Boot a fresh sandbox.
+6. Perform any required trusted post-restore work, such as checkout refresh for
+   portable dependency seeds, before reporting the sandbox as ready.
 
 If no services stage exists but a dependency stage does:
 
@@ -673,7 +770,22 @@ If no services stage exists but a dependency stage does:
 2. run the constrained services-preparation recipe
 3. optionally publish a services stage if the policy allows promotion
 
-If no dependency stage exists but a workspace stage does:
+If no exact dependency stage exists but a portable dependency seed does:
+
+1. clone the portable dependency seed into a writable child
+2. refresh the repository checkout in that child to the requested commit
+3. if a changeset was requested, apply it and verify the resulting tree digest
+4. recompute the declared dependency key-file digest from the refreshed tree
+5. if the digest still matches the seed metadata, skip dependency bootstrap and
+   run from the refreshed child
+6. if the digest differs, discard the child and continue with the normal
+   workspace-stage or cold path
+
+This flow does not compose immutable snapshots. It restores one full snapshot
+and mutates only the disposable writable child.
+
+If no dependency stage or portable dependency seed exists but a workspace stage
+does:
 
 1. clone the workspace stage
 2. if needed, apply and verify the requested changeset
@@ -742,6 +854,10 @@ The design should eliminate these weaker trust paths:
 - use `write temp -> fsync -> atomic rename` for new artifact blobs and metadata
 - never serve partially written artifacts
 - never accept a guest-provided "cache hit" claim as authoritative
+- never treat a portable dependency seed's stored checkout as current; checkout
+  refresh and verification are part of every portable-seed hit
+- if post-refresh dependency key-file validation fails, discard the restored
+  child instead of trying to repair it in place
 
 ### Offline warm mode
 
@@ -750,6 +866,30 @@ When a policy requires strict offline warm-cache execution:
 - the control plane must refuse upstream git or registry access
 - only published `ready` stage caches may be used
 - missing artifacts fail closed
+
+### Portable dependency-seed safety
+
+Portable dependency seeds trade exact checkout identity for faster
+source-iteration when declared dependency inputs are unchanged. The safety rules
+are stricter than a normal exact dependency-stage hit:
+
+- require declared dependency key files; an empty key-file set should remain on
+  the exact workspace-bound path unless a stronger input model exists
+- compute key-file digests from the requested checkout, including post-apply
+  changesets
+- restore the seed only into a fresh writable child
+- refresh the checkout before user code runs
+- verify `HEAD`, submodule behavior, and changeset tree digest after refresh
+- recompute the key-file digest after refresh and compare it with the seed
+  metadata
+- do not promote or reuse portable seeds for dependency outputs under the
+  checkout unless explicit output-preservation semantics define how those paths
+  survive `git clean`
+
+The main correctness risk is under-declared dependency inputs. If the bootstrap
+command reads source files, scripts, generated config, or environment inputs
+that are not represented in the dependency key, cross-commit reuse can be stale.
+The conservative exact dependency stage should remain available for those cases.
 
 ## Runtime Filesystem Model
 
@@ -761,9 +901,15 @@ That means:
 - no default "base volume plus repo volume plus deps volume" mount assembly
 - no separate default `/workspace` guest-visible volume
 - one attached writable root volume per sandbox
+- no live composition of independent workspace and dependency snapshots
 
 Logical cache layering still exists, but it is represented in metadata and
 lineage rather than in a live guest mount stack.
+
+Portable dependency seeds keep the same filesystem model. A seed hit clones one
+full rootfs snapshot into a writable child, then refreshes the checkout inside
+that child. The old checkout inside the sealed seed is an implementation detail,
+not part of the requested sandbox state.
 
 This matches the current backend shape better:
 
@@ -831,9 +977,9 @@ This plan composes with the existing documents rather than replacing them.
 | File | Change |
 |---|---|
 | `internal/gateway/mirror.go` | Already acts as the host-side git transport cache keyed by canonical remote URL. |
-| `internal/repositorycheckout/checkout.go` | Already uses exact remote URL and full commit SHA as the checkout source of truth; `branch` currently affects local checkout mode only. |
+| `internal/repositorycheckout/checkout.go` | Already uses exact remote URL and full commit SHA as the checkout source of truth; `branch` currently affects local checkout mode only. `BuildRefreshCommand` is also the checkout-refresh primitive needed after restoring a portable dependency seed. |
 | `internal/controlservice/workspace_stage.go` | Current workspace-stage orchestration already lives here using dedicated stage-cache metadata. |
-| `internal/controlservice/dependency_stage.go` | Dependency-stage orchestration entry point for policy-controlled bootstrap, declared key-file hashing, post-apply tree keying, and publication. |
+| `internal/controlservice/dependency_stage.go` | Dependency-stage orchestration entry point for policy-controlled bootstrap, declared key-file hashing, post-apply tree keying, exact dependency-stage publication, and the planned portable dependency-seed lookup/validation path. |
 | `internal/snapshotstore/store.go` | Should remain the user snapshot store rather than being expanded into the system-cache store. |
 | `internal/changesetstore/*` | Planned store for explicit local changeset metadata and replay payloads, separate from both snapshots and stage caches. |
 | `internal/volumestore/store.go` | Already provides the backend-neutral clone/snapshot contract shared by both backends. |
@@ -849,6 +995,7 @@ Suggested stage-cache record shape:
 ```text
 cache_key
 stage                    // runtime | workspace | dependency
+reuse_mode               // exact | portable_seed, when stage = dependency
 state                    // ready | failed | garbage
 parent_cache_key
 changeset_digest         // optional, when a workspace/dependency stage includes explicit local changes
@@ -857,6 +1004,8 @@ storage_ref
 policy_hash
 repository
 input_manifest_digest
+dependency_key_files_digest
+checkout_refresh_required
 created_at
 last_used_at
 producer_version
@@ -915,14 +1064,24 @@ stage still needs richer lockfile/toolchain inputs.
    workspaces.
 2. Add post-apply dependency key-file hashing so local lockfile changes affect
    dependency-stage reuse correctly.
-3. Add richer toolchain input digests for dependency-stage keys beyond the
+3. Add portable dependency-seed reuse for cross-commit iteration when declared
+   dependency key files are unchanged:
+   - compute dependency key-file digests for the requested checkout before
+     restore when possible
+   - restore the seed into a writable child
+   - refresh the checkout to the requested commit
+   - validate key files again after refresh
+   - discard the child and fall back if validation fails
+4. Add richer toolchain input digests for dependency-stage keys beyond the
    current workspace-plus-command-plus-key-files slice.
-4. Add additional ecosystems only after the first explicit dependency-stage
+5. Add explicit dependency output/preserve semantics if we want portable reuse
+   for repo-local outputs such as `node_modules` or `vendor/bundle`.
+6. Add additional ecosystems only after the first explicit dependency-stage
    flow is solid.
-5. Add strict offline warm-cache mode and fail-closed launch checks.
-6. Add garbage collection and retention policies after the key model and
+7. Add strict offline warm-cache mode and fail-closed launch checks.
+8. Add garbage collection and retention policies after the key model and
    publication flow are stable.
-7. Revisit cross-host distribution/export only after the local host model is
+9. Revisit cross-host distribution/export only after the local host model is
    proven worthwhile.
 
 ## Testing Plan
@@ -958,10 +1117,17 @@ implemented today as the workspace-seed flow:
   mirror
 - dependency-stage key files resolve from the post-apply tree when a changeset
   is present
+- portable dependency-seed hits refresh the checkout before execution
+- portable dependency-seed hits recompute dependency key-file digests after
+  refresh and skip dependency bootstrap only when they match
+- portable dependency-seed mismatches discard the restored child and fall back
+  to the normal workspace-stage path
 
 ### Runtime performance
 
 - warm dependency-stage hit skips repository clone and dependency install
+- warm portable dependency-seed hit skips dependency install while still doing
+  an incremental checkout refresh through the gateway cache
 - Firecracker warm hits avoid full rootfs file copies
 - snapshot clone latency and VM boot latency are measured separately
 
@@ -971,8 +1137,12 @@ implemented today as the workspace-seed flow:
   npm, pip, or another?
 - Should dependency-stage caches be published automatically on successful
   bootstrap, or only when explicitly requested?
+- Should portable dependency-seed reuse be opt-in, or should it be the default
+  whenever non-empty dependency key files are declared and outputs are portable?
 - What retention policy should apply to large dependency-stage caches relative
   to smaller workspace-stage caches?
+- How should Cleanroom detect or declare whether dependency outputs are
+  portable across `git clean`?
 - Should workspace-stage identity continue to include the local checkout branch,
   or should branch stay outside reusable cache keys once checkout mode is
   modeled separately?

--- a/docs/plans/layered-caching.md
+++ b/docs/plans/layered-caching.md
@@ -160,8 +160,8 @@ This phase now means:
 - dependency-stage caching is starting with a single configured dependency
   bootstrap slice for exact-commit workspaces; toolchain-derived key inputs are
   still pending
-- portable dependency-seed reuse across source-only commits is not implemented
-  yet
+- portable dependency-seed reuse is implemented as an explicit
+  `sandbox.dependencies.reuse: portable` mode for declared key-file inputs
 
 Today that means:
 
@@ -1053,6 +1053,11 @@ This metadata should live in a dedicated `changesetstore`, not in
    `sandbox.dependencies.key.files`, with `go mod download` as the first
    example recipe keyed by workspace stage plus policy, command recipe, and
    declared key-file digests.
+4. Add portable dependency-seed reuse for cross-commit iteration when declared
+   dependency key files are unchanged. The current slice is opt-in through
+   `sandbox.dependencies.reuse: portable`, restores the dependency-prepared
+   rootfs into a writable child, refreshes the checkout to the requested commit,
+   and falls back to normal dependency bootstrap if restore or refresh fails.
 
 These are architecturally landed, but the full performance win still depends on
 clone-capable storage instead of the default `file` driver, and the dependency
@@ -1064,24 +1069,16 @@ stage still needs richer lockfile/toolchain inputs.
    workspaces.
 2. Add post-apply dependency key-file hashing so local lockfile changes affect
    dependency-stage reuse correctly.
-3. Add portable dependency-seed reuse for cross-commit iteration when declared
-   dependency key files are unchanged:
-   - compute dependency key-file digests for the requested checkout before
-     restore when possible
-   - restore the seed into a writable child
-   - refresh the checkout to the requested commit
-   - validate key files again after refresh
-   - discard the child and fall back if validation fails
-4. Add richer toolchain input digests for dependency-stage keys beyond the
+3. Add richer toolchain input digests for dependency-stage keys beyond the
    current workspace-plus-command-plus-key-files slice.
-5. Add explicit dependency output/preserve semantics if we want portable reuse
+4. Add explicit dependency output/preserve semantics if we want portable reuse
    for repo-local outputs such as `node_modules` or `vendor/bundle`.
-6. Add additional ecosystems only after the first explicit dependency-stage
+5. Add additional ecosystems only after the first explicit dependency-stage
    flow is solid.
-7. Add strict offline warm-cache mode and fail-closed launch checks.
-8. Add garbage collection and retention policies after the key model and
+6. Add strict offline warm-cache mode and fail-closed launch checks.
+7. Add garbage collection and retention policies after the key model and
    publication flow are stable.
-9. Revisit cross-host distribution/export only after the local host model is
+8. Revisit cross-host distribution/export only after the local host model is
    proven worthwhile.
 
 ## Testing Plan

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -168,6 +168,7 @@ explicit request-time changeset input.
 - `sandbox.dependencies.command` defaults to unset; when present, Cleanroom runs that command in the repository workdir during sandbox creation and makes the result eligible for dependency-stage caching.
 - `sandbox.dependencies.command` accepts either a YAML string or a YAML sequence; strings execute as `sh -lc <value>`, and strings are the preferred form.
 - `sandbox.dependencies.key.files` defaults to empty; when present, Cleanroom hashes those repository-relative files from the exact committed checkout and includes them in the dependency-stage cache key.
+- `sandbox.dependencies.reuse` defaults to `exact`; `portable` opts into dependency-stage reuse across source-only commits by restoring the dependency snapshot, refreshing the checkout, and reusing it only when declared key files still match.
 - `sandbox.services.command` defaults to unset; when present, Cleanroom runs that command in the repository workdir after dependency bootstrap during sandbox creation and makes the result eligible for services-stage caching.
 - `sandbox.services.command` accepts either a YAML string or a YAML sequence; strings execute as `sh -lc <value>`, and strings are the preferred form.
 - `sandbox.services.key.files` defaults to empty; when present, Cleanroom hashes those repository-relative files from the exact committed checkout and includes them in the services-stage cache key.
@@ -302,6 +303,9 @@ Requirements:
   closed.
 - Dependency bootstrap key resolution must use the post-apply repository tree
   when a changeset is present.
+- Portable dependency reuse requires declared dependency key files and must
+  refresh the checkout before running user code; if key-file validation fails,
+  the restored child is discarded and normal dependency bootstrap is used.
 - Changesets are separate from both user snapshots and system-managed stage
   caches. They are explicit request inputs, not snapshot restore targets.
 

--- a/internal/cachekey/cachekey.go
+++ b/internal/cachekey/cachekey.go
@@ -54,6 +54,22 @@ type ServicesStageInputs struct {
 	BootstrapRecipeDigest string
 }
 
+// PortableDependencyStageInputs are the inputs that define a dependency stage
+// that can be restored before refreshing the checkout to a different commit.
+type PortableDependencyStageInputs struct {
+	Backend                     string
+	RuntimeKey                  string
+	CompiledPolicyHash          string
+	CanonicalRemoteURL          string
+	SubmoduleMode               string
+	DestinationDir              string
+	CheckoutRefreshRecipeDigest string
+	KeyFilesDigest              string
+	BootstrapRecipeDigest       string
+	OutputMode                  string
+	ProducerVersion             string
+}
+
 // RuntimeStageKey returns the canonical cache key for a runtime stage output.
 func RuntimeStageKey(in RuntimeStageInputs) string {
 	return buildStageKey("runtime", []component{
@@ -100,6 +116,25 @@ func ServicesStageKey(in ServicesStageInputs) string {
 		{name: "compiled_policy_hash", value: canonicalDigest(in.CompiledPolicyHash)},
 		{name: "key_files_digest", value: canonicalDigest(in.KeyFilesDigest)},
 		{name: "bootstrap_recipe_digest", value: canonicalDigest(in.BootstrapRecipeDigest)},
+	})
+}
+
+// PortableDependencyStageKey returns the canonical cache key for a portable
+// dependency stage output.
+func PortableDependencyStageKey(in PortableDependencyStageInputs) string {
+	return buildStageKey("dependency", []component{
+		{name: "reuse_mode", value: canonicalIdentifier("portable_seed")},
+		{name: "backend", value: canonicalIdentifier(in.Backend)},
+		{name: "runtime_key", value: canonicalReference(in.RuntimeKey)},
+		{name: "compiled_policy_hash", value: canonicalDigest(in.CompiledPolicyHash)},
+		{name: "canonical_remote_url", value: canonicalRemoteURL(in.CanonicalRemoteURL)},
+		{name: "submodule_mode", value: canonicalIdentifier(in.SubmoduleMode)},
+		{name: "destination_dir", value: canonicalAbsolutePath(in.DestinationDir)},
+		{name: "checkout_refresh_recipe_digest", value: canonicalDigest(in.CheckoutRefreshRecipeDigest)},
+		{name: "key_files_digest", value: canonicalDigest(in.KeyFilesDigest)},
+		{name: "bootstrap_recipe_digest", value: canonicalDigest(in.BootstrapRecipeDigest)},
+		{name: "output_mode", value: canonicalIdentifier(in.OutputMode)},
+		{name: "producer_version", value: canonicalIdentifier(in.ProducerVersion)},
 	})
 }
 

--- a/internal/cachekey/cachekey_test.go
+++ b/internal/cachekey/cachekey_test.go
@@ -91,3 +91,42 @@ func TestDependencyStageKey(t *testing.T) {
 		t.Fatalf("dependency stage key did not change after input mutation: %q", got)
 	}
 }
+
+func TestPortableDependencyStageKey(t *testing.T) {
+	inputs := PortableDependencyStageInputs{
+		Backend:                     "firecracker",
+		RuntimeKey:                  "runtime:v1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		CompiledPolicyHash:          "sha256:7777777777777777777777777777777777777777777777777777777777777777",
+		CanonicalRemoteURL:          "https://github.com/buildkite/cleanroom.git",
+		SubmoduleMode:               "disabled",
+		DestinationDir:              "/workspace",
+		CheckoutRefreshRecipeDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		KeyFilesDigest:              "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		BootstrapRecipeDigest:       "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+		OutputMode:                  "outside-workspace",
+		ProducerVersion:             "cleanroom/portable-dependency-stage-v1",
+	}
+
+	got := PortableDependencyStageKey(inputs)
+	if got == "" {
+		t.Fatal("portable dependency stage key is empty")
+	}
+	if !strings.HasPrefix(got, "dependency:v1:") {
+		t.Fatalf("portable dependency stage key prefix = %q, want %q", got, "dependency:v1:")
+	}
+	if gotAgain := PortableDependencyStageKey(inputs); got != gotAgain {
+		t.Fatalf("portable dependency stage key changed for identical inputs: first %q second %q", got, gotAgain)
+	}
+
+	mutated := inputs
+	mutated.KeyFilesDigest = "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+	if gotMutated := PortableDependencyStageKey(mutated); got == gotMutated {
+		t.Fatalf("portable dependency stage key did not change after key-file mutation: %q", got)
+	}
+
+	mutated = inputs
+	mutated.CanonicalRemoteURL = "https://github.com/buildkite/other.git"
+	if gotMutated := PortableDependencyStageKey(mutated); got == gotMutated {
+		t.Fatalf("portable dependency stage key did not change after repository mutation: %q", got)
+	}
+}

--- a/internal/cachestore/store.go
+++ b/internal/cachestore/store.go
@@ -16,22 +16,25 @@ import (
 )
 
 type Record struct {
-	CacheKey               string
-	Stage                  string
-	State                  string
-	BackingSnapshotID      string
-	Backend                string
-	PolicyHash             string
-	Policy                 *cleanroomv1.Policy
-	Repository             *cleanroomv1.RepositoryCheckout
-	RepositoryHasChangeset bool
-	ParentCacheKey         string
-	StorageDriver          string
-	StorageRef             string
-	InputManifestDigest    string
-	CreatedAt              time.Time
-	LastUsedAt             time.Time
-	ProducerVersion        string
+	CacheKey                 string
+	Stage                    string
+	ReuseMode                string
+	State                    string
+	BackingSnapshotID        string
+	Backend                  string
+	PolicyHash               string
+	Policy                   *cleanroomv1.Policy
+	Repository               *cleanroomv1.RepositoryCheckout
+	RepositoryHasChangeset   bool
+	ParentCacheKey           string
+	StorageDriver            string
+	StorageRef               string
+	InputManifestDigest      string
+	DependencyKeyFilesDigest string
+	CheckoutRefreshRequired  bool
+	CreatedAt                time.Time
+	LastUsedAt               time.Time
+	ProducerVersion          string
 }
 
 type Options struct {
@@ -131,6 +134,7 @@ func (s *Store) persist(ctx context.Context, record Record, replace bool) error 
 		INSERT INTO cache_entries (
 			cache_key,
 			stage,
+			reuse_mode,
 			state,
 			backing_snapshot_id,
 			backend,
@@ -142,10 +146,12 @@ func (s *Store) persist(ctx context.Context, record Record, replace bool) error 
 			storage_driver,
 			storage_ref,
 			input_manifest_digest,
+			dependency_key_files_digest,
+			checkout_refresh_required,
 			created_at_unix_nano,
 			last_used_at_unix_nano,
 			producer_version
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`
 	if replace {
 		verb = "upsert"
@@ -153,6 +159,7 @@ func (s *Store) persist(ctx context.Context, record Record, replace bool) error 
 			INSERT INTO cache_entries (
 				cache_key,
 				stage,
+				reuse_mode,
 				state,
 				backing_snapshot_id,
 				backend,
@@ -164,11 +171,14 @@ func (s *Store) persist(ctx context.Context, record Record, replace bool) error 
 				storage_driver,
 				storage_ref,
 				input_manifest_digest,
+				dependency_key_files_digest,
+				checkout_refresh_required,
 				created_at_unix_nano,
 				last_used_at_unix_nano,
 				producer_version
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 			ON CONFLICT(stage, cache_key) DO UPDATE SET
+				reuse_mode = excluded.reuse_mode,
 				state = excluded.state,
 				backing_snapshot_id = excluded.backing_snapshot_id,
 				backend = excluded.backend,
@@ -180,6 +190,8 @@ func (s *Store) persist(ctx context.Context, record Record, replace bool) error 
 				storage_driver = excluded.storage_driver,
 				storage_ref = excluded.storage_ref,
 				input_manifest_digest = excluded.input_manifest_digest,
+				dependency_key_files_digest = excluded.dependency_key_files_digest,
+				checkout_refresh_required = excluded.checkout_refresh_required,
 				created_at_unix_nano = excluded.created_at_unix_nano,
 				last_used_at_unix_nano = excluded.last_used_at_unix_nano,
 				producer_version = excluded.producer_version
@@ -189,6 +201,7 @@ func (s *Store) persist(ctx context.Context, record Record, replace bool) error 
 	if _, err := db.ExecContext(ctx, statement,
 		record.CacheKey,
 		record.Stage,
+		nullableString(record.ReuseMode),
 		record.State,
 		record.BackingSnapshotID,
 		record.Backend,
@@ -200,6 +213,8 @@ func (s *Store) persist(ctx context.Context, record Record, replace bool) error 
 		record.StorageDriver,
 		record.StorageRef,
 		nullableString(record.InputManifestDigest),
+		nullableString(record.DependencyKeyFilesDigest),
+		boolToInt(record.CheckoutRefreshRequired),
 		record.CreatedAt.UTC().UnixNano(),
 		record.LastUsedAt.UTC().UnixNano(),
 		record.ProducerVersion,
@@ -220,6 +235,7 @@ func (s *Store) GetReady(ctx context.Context, stage, cacheKey string) (Record, b
 		SELECT
 			cache_key,
 			stage,
+			reuse_mode,
 			state,
 			backing_snapshot_id,
 			backend,
@@ -231,6 +247,8 @@ func (s *Store) GetReady(ctx context.Context, stage, cacheKey string) (Record, b
 			storage_driver,
 			storage_ref,
 			input_manifest_digest,
+			dependency_key_files_digest,
+			checkout_refresh_required,
 			created_at_unix_nano,
 			last_used_at_unix_nano,
 			producer_version
@@ -288,6 +306,7 @@ func (s *Store) List(ctx context.Context) ([]Record, error) {
 		SELECT
 			cache_key,
 			stage,
+			reuse_mode,
 			state,
 			backing_snapshot_id,
 			backend,
@@ -299,6 +318,8 @@ func (s *Store) List(ctx context.Context) ([]Record, error) {
 			storage_driver,
 			storage_ref,
 			input_manifest_digest,
+			dependency_key_files_digest,
+			checkout_refresh_required,
 			created_at_unix_nano,
 			last_used_at_unix_nano,
 			producer_version
@@ -362,6 +383,7 @@ func (s *Store) initDB(ctx context.Context) error {
 		CREATE TABLE IF NOT EXISTS cache_entries (
 			cache_key TEXT NOT NULL,
 			stage TEXT NOT NULL,
+			reuse_mode TEXT,
 			state TEXT NOT NULL,
 			backend TEXT NOT NULL,
 			policy_hash TEXT NOT NULL,
@@ -372,6 +394,8 @@ func (s *Store) initDB(ctx context.Context) error {
 			storage_driver TEXT NOT NULL DEFAULT 'file',
 			storage_ref TEXT NOT NULL,
 			input_manifest_digest TEXT,
+			dependency_key_files_digest TEXT,
+			checkout_refresh_required INTEGER NOT NULL DEFAULT 0,
 			created_at_unix_nano INTEGER NOT NULL,
 			last_used_at_unix_nano INTEGER NOT NULL,
 			producer_version TEXT NOT NULL,
@@ -389,6 +413,15 @@ func (s *Store) initDB(ctx context.Context) error {
 	if _, err := db.ExecContext(ctx, `ALTER TABLE cache_entries ADD COLUMN repository_has_changeset INTEGER NOT NULL DEFAULT 0`); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
 		return fmt.Errorf("ensure cache metadata repository_has_changeset column: %w", err)
 	}
+	if _, err := db.ExecContext(ctx, `ALTER TABLE cache_entries ADD COLUMN reuse_mode TEXT`); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
+		return fmt.Errorf("ensure cache metadata reuse_mode column: %w", err)
+	}
+	if _, err := db.ExecContext(ctx, `ALTER TABLE cache_entries ADD COLUMN dependency_key_files_digest TEXT`); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
+		return fmt.Errorf("ensure cache metadata dependency_key_files_digest column: %w", err)
+	}
+	if _, err := db.ExecContext(ctx, `ALTER TABLE cache_entries ADD COLUMN checkout_refresh_required INTEGER NOT NULL DEFAULT 0`); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
+		return fmt.Errorf("ensure cache metadata checkout_refresh_required column: %w", err)
+	}
 	return nil
 }
 
@@ -398,18 +431,22 @@ type recordScanner interface {
 
 func scanRecord(row recordScanner) (Record, error) {
 	var (
-		record                 Record
-		policyBytes            []byte
-		repositoryBytes        []byte
-		repositoryHasChangeset int
-		parentCacheKey         sql.NullString
-		inputDigest            sql.NullString
-		createdAtNano          int64
-		lastUsedAtNano         int64
+		record                   Record
+		policyBytes              []byte
+		repositoryBytes          []byte
+		repositoryHasChangeset   int
+		checkoutRefreshRequired  int
+		reuseMode                sql.NullString
+		parentCacheKey           sql.NullString
+		inputDigest              sql.NullString
+		dependencyKeyFilesDigest sql.NullString
+		createdAtNano            int64
+		lastUsedAtNano           int64
 	)
 	if err := row.Scan(
 		&record.CacheKey,
 		&record.Stage,
+		&reuseMode,
 		&record.State,
 		&record.BackingSnapshotID,
 		&record.Backend,
@@ -421,6 +458,8 @@ func scanRecord(row recordScanner) (Record, error) {
 		&record.StorageDriver,
 		&record.StorageRef,
 		&inputDigest,
+		&dependencyKeyFilesDigest,
+		&checkoutRefreshRequired,
 		&createdAtNano,
 		&lastUsedAtNano,
 		&record.ProducerVersion,
@@ -442,9 +481,16 @@ func scanRecord(row recordScanner) (Record, error) {
 	if parentCacheKey.Valid {
 		record.ParentCacheKey = parentCacheKey.String
 	}
+	if reuseMode.Valid {
+		record.ReuseMode = reuseMode.String
+	}
 	if inputDigest.Valid {
 		record.InputManifestDigest = inputDigest.String
 	}
+	if dependencyKeyFilesDigest.Valid {
+		record.DependencyKeyFilesDigest = dependencyKeyFilesDigest.String
+	}
+	record.CheckoutRefreshRequired = checkoutRefreshRequired != 0
 	record.CreatedAt = time.Unix(0, createdAtNano).UTC()
 	record.LastUsedAt = time.Unix(0, lastUsedAtNano).UTC()
 	return record, nil

--- a/internal/cachestore/store_test.go
+++ b/internal/cachestore/store_test.go
@@ -39,14 +39,17 @@ func TestStoreCreateGetReadyListDelete(t *testing.T) {
 			Submodules:     true,
 			Branch:         "main",
 		},
-		RepositoryHasChangeset: true,
-		ParentCacheKey:         "runtime:test",
-		StorageRef:             "/tmp/workspace-test.ext4",
-		StorageDriver:          "file",
-		InputManifestDigest:    "sha256:manifest",
-		CreatedAt:              time.Unix(1700000000, 123).UTC(),
-		LastUsedAt:             time.Unix(1700000001, 456).UTC(),
-		ProducerVersion:        "cleanroom-test/1",
+		RepositoryHasChangeset:   true,
+		ParentCacheKey:           "runtime:test",
+		ReuseMode:                "portable_seed",
+		StorageRef:               "/tmp/workspace-test.ext4",
+		StorageDriver:            "file",
+		InputManifestDigest:      "sha256:manifest",
+		DependencyKeyFilesDigest: "sha256:dependency-key-files",
+		CheckoutRefreshRequired:  true,
+		CreatedAt:                time.Unix(1700000000, 123).UTC(),
+		LastUsedAt:               time.Unix(1700000001, 456).UTC(),
+		ProducerVersion:          "cleanroom-test/1",
 	}
 	if err := store.Create(context.Background(), record); err != nil {
 		t.Fatalf("Create returned error: %v", err)
@@ -59,7 +62,7 @@ func TestStoreCreateGetReadyListDelete(t *testing.T) {
 	if !ok {
 		t.Fatal("expected stored ready cache")
 	}
-	if got.CacheKey != record.CacheKey || got.Stage != record.Stage || got.State != record.State || got.PolicyHash != record.PolicyHash || got.StorageRef != record.StorageRef || got.StorageDriver != record.StorageDriver || got.ParentCacheKey != record.ParentCacheKey || got.InputManifestDigest != record.InputManifestDigest || got.ProducerVersion != record.ProducerVersion {
+	if got.CacheKey != record.CacheKey || got.Stage != record.Stage || got.State != record.State || got.PolicyHash != record.PolicyHash || got.StorageRef != record.StorageRef || got.StorageDriver != record.StorageDriver || got.ParentCacheKey != record.ParentCacheKey || got.ReuseMode != record.ReuseMode || got.InputManifestDigest != record.InputManifestDigest || got.DependencyKeyFilesDigest != record.DependencyKeyFilesDigest || got.CheckoutRefreshRequired != record.CheckoutRefreshRequired || got.ProducerVersion != record.ProducerVersion {
 		t.Fatalf("unexpected cache record: %#v", got)
 	}
 	if !got.CreatedAt.Equal(record.CreatedAt) {

--- a/internal/controlservice/dependency_stage.go
+++ b/internal/controlservice/dependency_stage.go
@@ -1,6 +1,7 @@
 package controlservice
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -21,17 +22,24 @@ import (
 )
 
 const (
-	dependencyStageName            = "dependency"
-	dependencyStageProducerVersion = "cleanroom/dependency-stage-v1"
+	dependencyStageName                    = "dependency"
+	dependencyStageProducerVersion         = "cleanroom/dependency-stage-v1"
+	portableDependencyStageProducerVersion = "cleanroom/portable-dependency-stage-v1"
+	dependencyStageReuseExact              = "exact"
+	dependencyStageReusePortableSeed       = "portable_seed"
+	portableDependencyOutputMode           = "outside-workspace"
 )
 
 type dependencyStagePlan struct {
 	CacheKey                string
+	PortableCacheKey        string
 	ParentWorkspaceCacheKey string
+	ParentRuntimeCacheKey   string
 	BootstrapCommand        []string
 	BootstrapRecipeDigest   string
 	KeyFiles                []string
 	KeyFilesDigest          string
+	Portable                bool
 }
 
 type stageKeyFileDigest struct {
@@ -55,6 +63,7 @@ func dependencyStagePlanForRepository(compiled *policy.CompiledPolicy, repositor
 		BootstrapCommand:      bootstrapCommand,
 		BootstrapRecipeDigest: bootstrapRecipeDigest,
 		KeyFiles:              append([]string(nil), compiled.Dependencies.KeyFiles...),
+		Portable:              compiled.Dependencies.Reuse == policy.DependencyReusePortable,
 	}, true
 }
 
@@ -63,7 +72,9 @@ func (s *Service) finalizeDependencyStagePlan(
 	compiled *policy.CompiledPolicy,
 	repository *repositorycheckout.Checkout,
 	changeset *repositorychangeset.Changeset,
+	backendName string,
 	workspaceStageKey string,
+	runtimeBaseKey string,
 	plan dependencyStagePlan,
 ) (dependencyStagePlan, bool, error) {
 	if compiled == nil || repository == nil || strings.TrimSpace(workspaceStageKey) == "" {
@@ -87,7 +98,24 @@ func (s *Service) finalizeDependencyStagePlan(
 
 	plan.CacheKey = cacheKey
 	plan.ParentWorkspaceCacheKey = strings.TrimSpace(workspaceStageKey)
+	plan.ParentRuntimeCacheKey = strings.TrimSpace(runtimeBaseKey)
 	plan.KeyFilesDigest = strings.TrimSpace(keyFilesDigest)
+	if plan.Portable && strings.TrimSpace(runtimeBaseKey) != "" && strings.TrimSpace(keyFilesDigest) != "" {
+		normalizedRepository := normalizeRepositoryCheckoutForComparison(repository)
+		plan.PortableCacheKey = cachekey.PortableDependencyStageKey(cachekey.PortableDependencyStageInputs{
+			Backend:                     strings.TrimSpace(backendName),
+			RuntimeKey:                  strings.TrimSpace(runtimeBaseKey),
+			CompiledPolicyHash:          strings.TrimSpace(compiled.Hash),
+			CanonicalRemoteURL:          strings.TrimSpace(normalizedRepository.RemoteURL),
+			SubmoduleMode:               workspaceStageSubmoduleMode(normalizedRepository),
+			DestinationDir:              strings.TrimSpace(normalizedRepository.DestinationDir),
+			CheckoutRefreshRecipeDigest: repositorycheckout.RefreshRecipeDigest(normalizedRepository),
+			KeyFilesDigest:              strings.TrimSpace(keyFilesDigest),
+			BootstrapRecipeDigest:       strings.TrimSpace(plan.BootstrapRecipeDigest),
+			OutputMode:                  portableDependencyOutputMode,
+			ProducerVersion:             portableDependencyStageProducerVersion,
+		})
+	}
 	return plan, true, nil
 }
 
@@ -213,6 +241,9 @@ func (s *Service) lookupDependencyStageCache(ctx context.Context, backendName st
 	if strings.TrimSpace(record.Backend) != strings.TrimSpace(backendName) {
 		return cachestore.Record{}, false, observability.CacheLookupReasonBackendMismatch, nil
 	}
+	if reuseMode := strings.TrimSpace(record.ReuseMode); reuseMode != "" && reuseMode != dependencyStageReuseExact {
+		return cachestore.Record{}, false, observability.CacheLookupReasonRecordNotFound, nil
+	}
 	if strings.TrimSpace(record.PolicyHash) != strings.TrimSpace(compiled.Hash) {
 		return cachestore.Record{}, false, observability.CacheLookupReasonPolicyHashMismatch, nil
 	}
@@ -223,6 +254,215 @@ func (s *Service) lookupDependencyStageCache(ctx context.Context, backendName st
 		return cachestore.Record{}, false, observability.CacheLookupReasonRepositoryChanged, nil
 	}
 	return record, true, "", nil
+}
+
+func (s *Service) lookupPortableDependencyStageCache(ctx context.Context, backendName string, compiled *policy.CompiledPolicy, repository *repositorycheckout.Checkout, plan dependencyStagePlan) (cachestore.Record, bool, string, error) {
+	if compiled == nil || repository == nil || strings.TrimSpace(plan.PortableCacheKey) == "" {
+		return cachestore.Record{}, false, "", nil
+	}
+	store, err := s.cacheStoreOrErr()
+	if err != nil {
+		return cachestore.Record{}, false, "", nil
+	}
+
+	record, ok, err := store.GetReady(ctx, dependencyStageName, plan.PortableCacheKey)
+	if err != nil {
+		return cachestore.Record{}, false, "", err
+	}
+	if !ok {
+		return cachestore.Record{}, false, observability.CacheLookupReasonRecordNotFound, nil
+	}
+	if strings.TrimSpace(record.Backend) != strings.TrimSpace(backendName) {
+		return cachestore.Record{}, false, observability.CacheLookupReasonBackendMismatch, nil
+	}
+	if strings.TrimSpace(record.ReuseMode) != dependencyStageReusePortableSeed {
+		return cachestore.Record{}, false, observability.CacheLookupReasonRecordNotFound, nil
+	}
+	if strings.TrimSpace(record.PolicyHash) != strings.TrimSpace(compiled.Hash) {
+		return cachestore.Record{}, false, observability.CacheLookupReasonPolicyHashMismatch, nil
+	}
+	if strings.TrimSpace(record.ParentCacheKey) != strings.TrimSpace(plan.ParentRuntimeCacheKey) {
+		return cachestore.Record{}, false, observability.CacheLookupReasonWorkspaceParentChanged, nil
+	}
+	if strings.TrimSpace(record.DependencyKeyFilesDigest) != strings.TrimSpace(plan.KeyFilesDigest) {
+		return cachestore.Record{}, false, observability.CacheLookupReasonRecordNotFound, nil
+	}
+	if !portableDependencyRepositoriesCompatible(repositorycheckout.FromProto(record.Repository), repository) {
+		return cachestore.Record{}, false, observability.CacheLookupReasonRepositoryChanged, nil
+	}
+	return record, true, "", nil
+}
+
+func portableDependencyRepositoriesCompatible(left, right *repositorycheckout.Checkout) bool {
+	left = normalizeRepositoryCheckoutForComparison(left)
+	right = normalizeRepositoryCheckoutForComparison(right)
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return strings.TrimSpace(left.RemoteURL) == strings.TrimSpace(right.RemoteURL) &&
+		strings.TrimSpace(left.DestinationDir) == strings.TrimSpace(right.DestinationDir) &&
+		left.Submodules == right.Submodules &&
+		strings.TrimSpace(left.Branch) == strings.TrimSpace(right.Branch)
+}
+
+func (s *Service) restorePortableDependencyStageCache(
+	ctx context.Context,
+	adapter backend.Adapter,
+	backendName string,
+	compiled *policy.CompiledPolicy,
+	firecrackerCfg backend.FirecrackerConfig,
+	repository *repositorycheckout.Checkout,
+	changeset *repositorychangeset.Changeset,
+	options *cleanroomv1.SandboxOptions,
+	record cachestore.Record,
+	reporter CreateSandboxReporter,
+) (*cleanroomv1.CreateSandboxResponse, error) {
+	restoreReq := &cleanroomv1.CreateSandboxRequest{
+		Backend: backendName,
+		Options: options,
+	}
+	restoreResp, err := s.createSandboxFromCacheRecord(ctx, restoreReq, compiled, record, reporter)
+	if err != nil {
+		return nil, err
+	}
+
+	sandboxID := restoreResp.GetSandbox().GetSandboxId()
+	if err := s.bootstrapRepositoryInPersistentSandbox(ctx, adapter, sandboxID, compiled, firecrackerCfg, repository, true, reporter); err != nil {
+		if cleanupErr := s.terminateCreatedSandbox(context.Background(), adapter, sandboxID); cleanupErr != nil {
+			return nil, fmt.Errorf("refresh repository checkout after portable dependency stage restore: %w; cleanup failed: %v", err, cleanupErr)
+		}
+		return nil, fmt.Errorf("refresh repository checkout after portable dependency stage restore: %w", err)
+	}
+	if changeset != nil {
+		if err := s.bootstrapRepositoryChangesetInPersistentSandbox(ctx, adapter, sandboxID, compiled, firecrackerCfg, repository, changeset, reporter); err != nil {
+			if cleanupErr := s.terminateCreatedSandbox(context.Background(), adapter, sandboxID); cleanupErr != nil {
+				return nil, fmt.Errorf("apply repository changeset after portable dependency stage restore: %w; cleanup failed: %v", err, cleanupErr)
+			}
+			return nil, fmt.Errorf("apply repository changeset after portable dependency stage restore: %w", err)
+		}
+	}
+	if err := s.validatePortableDependencyStageKeyFiles(ctx, adapter, sandboxID, compiled, firecrackerCfg, repository, record.DependencyKeyFilesDigest); err != nil {
+		if cleanupErr := s.terminateCreatedSandbox(context.Background(), adapter, sandboxID); cleanupErr != nil {
+			return nil, fmt.Errorf("validate portable dependency stage key files: %w; cleanup failed: %v", err, cleanupErr)
+		}
+		return nil, fmt.Errorf("validate portable dependency stage key files: %w", err)
+	}
+
+	if sandbox := s.markRestoredSandboxRepositoryReady(sandboxID, repository, changeset != nil); sandbox != nil {
+		restoreResp.Sandbox = sandbox
+	}
+	return restoreResp, nil
+}
+
+func (s *Service) markRestoredSandboxRepositoryReady(sandboxID string, repository *repositorycheckout.Checkout, hasChangeset bool) *cleanroomv1.Sandbox {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	sandbox, ok := s.sandboxes[sandboxID]
+	if !ok {
+		return nil
+	}
+	sandbox.Repository = cloneRepositoryCheckout(repository)
+	sandbox.RepositoryHasChangeset = hasChangeset
+	sandbox.RepositoryChangesetPendingExecution = hasChangeset
+	sandbox.UpdatedAt = s.clock().Now()
+	return cloneSandboxLocked(sandbox)
+}
+
+func (s *Service) validatePortableDependencyStageKeyFiles(
+	ctx context.Context,
+	adapter backend.Adapter,
+	sandboxID string,
+	compiled *policy.CompiledPolicy,
+	firecrackerCfg backend.FirecrackerConfig,
+	repository *repositorycheckout.Checkout,
+	expectedDigest string,
+) error {
+	expectedDigest = strings.TrimSpace(expectedDigest)
+	if expectedDigest == "" {
+		return fmt.Errorf("portable dependency stage is missing dependency key-file digest")
+	}
+	command, err := dependencyStageKeyFilesDigestCommand(repository, compiled.Dependencies.KeyFiles)
+	if err != nil {
+		return err
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	result, err := s.runPersistentSandboxCommand(ctx, adapter, sandboxID, compiled, firecrackerCfg, s.ids().NewExecutionID(), command, nil, backend.OutputStream{
+		OnStdout: func(chunk []byte) {
+			_, _ = stdout.Write(chunk)
+		},
+		OnStderr: func(chunk []byte) {
+			_, _ = stderr.Write(chunk)
+		},
+	})
+	if err != nil {
+		message := strings.TrimSpace(stderr.String())
+		if message == "" {
+			message = err.Error()
+		}
+		return fmt.Errorf("%s", message)
+	}
+	if result == nil {
+		return fmt.Errorf("portable dependency key-file validation returned no result")
+	}
+	if result.ExitCode != 0 {
+		message := strings.TrimSpace(stderr.String())
+		if message == "" {
+			message = strings.TrimSpace(stdout.String())
+		}
+		if message == "" {
+			message = fmt.Sprintf("portable dependency key-file validation failed with exit code %d", result.ExitCode)
+		}
+		return fmt.Errorf("%s", message)
+	}
+	actualDigest := strings.TrimSpace(stdout.String())
+	if actualDigest != expectedDigest {
+		return fmt.Errorf("portable dependency key-file digest mismatch: expected %s got %s", expectedDigest, actualDigest)
+	}
+	return nil
+}
+
+func dependencyStageKeyFilesDigestCommand(repository *repositorycheckout.Checkout, files []string) ([]string, error) {
+	if repository == nil {
+		return nil, fmt.Errorf("portable dependency key-file validation requires a repository checkout")
+	}
+	if len(files) == 0 {
+		return nil, fmt.Errorf("portable dependency key-file validation requires dependency key files")
+	}
+	var script strings.Builder
+	script.WriteString("set -eu\n")
+	script.WriteString("dest=" + dependencyStageShellQuote(repository.DestinationDir) + "\n")
+	script.WriteString(`manifest='['` + "\n")
+	script.WriteString(`sep=''` + "\n")
+	for _, file := range files {
+		pathJSON, err := json.Marshal(file)
+		if err != nil {
+			return nil, fmt.Errorf("marshal dependency key-file path: %w", err)
+		}
+		script.WriteString("file=" + dependencyStageShellQuote(file) + "\n")
+		script.WriteString("path_json=" + dependencyStageShellQuote(string(pathJSON)) + "\n")
+		script.WriteString(`path="$dest/$file"` + "\n")
+		script.WriteString(`if [ -L "$path" ]; then` + "\n")
+		script.WriteString(`  target="$(readlink "$path")"` + "\n")
+		script.WriteString(`  hex="$(printf '%s' "$target" | sha256sum | awk '{print $1}')"` + "\n")
+		script.WriteString(`  entry="{\"path\":${path_json},\"sha256\":\"sha256:${hex}\"}"` + "\n")
+		script.WriteString(`elif [ -e "$path" ]; then` + "\n")
+		script.WriteString(`  hex="$(sha256sum "$path" | awk '{print $1}')"` + "\n")
+		script.WriteString(`  entry="{\"path\":${path_json},\"sha256\":\"sha256:${hex}\"}"` + "\n")
+		script.WriteString("else\n")
+		script.WriteString(`  entry="{\"path\":${path_json},\"deleted\":true}"` + "\n")
+		script.WriteString("fi\n")
+		script.WriteString(`manifest="${manifest}${sep}${entry}"` + "\n")
+		script.WriteString(`sep=','` + "\n")
+	}
+	script.WriteString(`manifest="${manifest}]"` + "\n")
+	script.WriteString(`digest="$(printf '%s' "$manifest" | sha256sum | awk '{print $1}')"` + "\n")
+	script.WriteString(`printf 'sha256:%s\n' "$digest"` + "\n")
+	return []string{"sh", "-lc", script.String()}, nil
+}
+
+func dependencyStageShellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", `'"'"'`) + "'"
 }
 
 func (s *Service) maybePublishDependencyStageCache(
@@ -248,13 +488,38 @@ func (s *Service) maybePublishDependencyStageCache(
 		return
 	}
 
+	var exactRecord cachestore.Record
+	exactPublished := false
+	exactReusable := false
 	if record, ok, _, err := s.lookupDependencyStageCache(ctx, backendName, compiled, repository, plan); err == nil && ok {
+		exactRecord = record
+		exactPublished = true
 		if replacedRecord == nil || strings.TrimSpace(record.CacheKey) != strings.TrimSpace(replacedRecord.CacheKey) {
+			exactReusable = true
 			s.logDependencyStageAlreadyPublished(record)
-			return
+			if !plan.Portable || strings.TrimSpace(plan.PortableCacheKey) == "" {
+				return
+			}
+			if portableRecord, ok, _, portableErr := s.lookupPortableDependencyStageCache(ctx, backendName, compiled, repository, plan); portableErr == nil && ok {
+				s.logDependencyStageAlreadyPublished(portableRecord)
+				return
+			} else if portableErr != nil {
+				s.logDependencyStageWarning("lookup portable dependency stage cache", sandboxID, portableErr)
+				return
+			}
 		}
 	} else if err != nil {
 		s.logDependencyStageWarning("lookup dependency stage cache", sandboxID, err)
+		return
+	}
+
+	if exactPublished && exactReusable && strings.TrimSpace(plan.PortableCacheKey) != "" {
+		portableRecord := portableDependencyStageRecordFromExactRecord(exactRecord, compiled, repository, changeset, plan)
+		if err := store.Upsert(ctx, portableRecord); err != nil {
+			s.logDependencyStageWarning("persist portable dependency stage cache metadata", sandboxID, err)
+			return
+		}
+		s.logDependencyStagePublished(portableRecord, sandboxID, false)
 		return
 	}
 
@@ -271,21 +536,23 @@ func (s *Service) maybePublishDependencyStageCache(
 	}
 
 	record := cachestore.Record{
-		CacheKey:               plan.CacheKey,
-		Stage:                  dependencyStageName,
-		State:                  cacheStateReady,
-		BackingSnapshotID:      strings.TrimSpace(snapshotID),
-		Backend:                backendName,
-		PolicyHash:             compiled.Hash,
-		Policy:                 compiled.ToProto(),
-		Repository:             cloneRepositoryCheckout(normalizeRepositoryCheckoutForComparison(repository)).ToProto(),
-		RepositoryHasChangeset: changeset != nil,
-		ParentCacheKey:         plan.ParentWorkspaceCacheKey,
-		StorageDriver:          snapshotCfg.Snapshots.Driver,
-		StorageRef:             strings.TrimSpace(result.StorageRef),
-		CreatedAt:              s.clock().Now(),
-		LastUsedAt:             s.clock().Now(),
-		ProducerVersion:        dependencyStageProducerVersion,
+		CacheKey:                 plan.CacheKey,
+		Stage:                    dependencyStageName,
+		ReuseMode:                dependencyStageReuseExact,
+		State:                    cacheStateReady,
+		BackingSnapshotID:        strings.TrimSpace(snapshotID),
+		Backend:                  backendName,
+		PolicyHash:               compiled.Hash,
+		Policy:                   compiled.ToProto(),
+		Repository:               cloneRepositoryCheckout(normalizeRepositoryCheckoutForComparison(repository)).ToProto(),
+		RepositoryHasChangeset:   changeset != nil,
+		ParentCacheKey:           plan.ParentWorkspaceCacheKey,
+		StorageDriver:            snapshotCfg.Snapshots.Driver,
+		StorageRef:               strings.TrimSpace(result.StorageRef),
+		DependencyKeyFilesDigest: plan.KeyFilesDigest,
+		CreatedAt:                s.clock().Now(),
+		LastUsedAt:               s.clock().Now(),
+		ProducerVersion:          dependencyStageProducerVersion,
 	}
 
 	persist := store.Create
@@ -309,11 +576,42 @@ func (s *Service) maybePublishDependencyStageCache(
 
 	s.logDependencyStagePublished(record, sandboxID, replacedRecord != nil && strings.TrimSpace(replacedRecord.CacheKey) == plan.CacheKey)
 
+	if strings.TrimSpace(plan.PortableCacheKey) != "" {
+		portableRecord := portableDependencyStageRecordFromExactRecord(record, compiled, repository, changeset, plan)
+		if err := store.Upsert(ctx, portableRecord); err != nil {
+			s.logDependencyStageWarning("persist portable dependency stage cache metadata", sandboxID, err)
+		} else {
+			s.logDependencyStagePublished(portableRecord, sandboxID, false)
+		}
+	}
+
 	if replacedRecord != nil && strings.TrimSpace(replacedRecord.CacheKey) == plan.CacheKey {
 		if err := s.deleteWorkspaceStageCacheSnapshot(ctx, adapter, backendName, firecrackerCfg, *replacedRecord); err != nil {
 			s.logDependencyStageWarning("delete replaced dependency stage cache snapshot", sandboxID, err)
 		}
 	}
+}
+
+func portableDependencyStageRecordFromExactRecord(
+	exactRecord cachestore.Record,
+	compiled *policy.CompiledPolicy,
+	repository *repositorycheckout.Checkout,
+	changeset *repositorychangeset.Changeset,
+	plan dependencyStagePlan,
+) cachestore.Record {
+	record := exactRecord
+	record.CacheKey = strings.TrimSpace(plan.PortableCacheKey)
+	record.ReuseMode = dependencyStageReusePortableSeed
+	record.PolicyHash = compiled.Hash
+	record.Policy = compiled.ToProto()
+	record.Repository = cloneRepositoryCheckout(normalizeRepositoryCheckoutForComparison(repository)).ToProto()
+	record.RepositoryHasChangeset = changeset != nil
+	record.ParentCacheKey = strings.TrimSpace(plan.ParentRuntimeCacheKey)
+	record.InputManifestDigest = strings.TrimSpace(plan.KeyFilesDigest)
+	record.DependencyKeyFilesDigest = strings.TrimSpace(plan.KeyFilesDigest)
+	record.CheckoutRefreshRequired = true
+	record.ProducerVersion = portableDependencyStageProducerVersion
+	return record
 }
 
 func (s *Service) bootstrapDependencyStageInPersistentSandbox(

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -356,7 +356,7 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 			workspaceStageCachingEnabled = true
 			workspaceStageKey = workspaceStageCacheKey(backendName, workspaceStageRuntimeBaseKey, compiled.Hash, repository, changeset)
 			if dependencyStageBootstrapEnabled {
-				dependencyStagePlan, dependencyStageCachingEnabled, err = s.finalizeDependencyStagePlan(ctx, compiled, repository, changeset, workspaceStageKey, dependencyStagePlan)
+				dependencyStagePlan, dependencyStageCachingEnabled, err = s.finalizeDependencyStagePlan(ctx, compiled, repository, changeset, backendName, workspaceStageKey, workspaceStageRuntimeBaseKey, dependencyStagePlan)
 				if err != nil {
 					dependencyStageCachingEnabled = false
 					s.logDependencyStageWarning("resolve dependency stage cache key", "", err)
@@ -495,6 +495,60 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 				} else {
 					s.logDependencyStageCacheMiss(backendName, dependencyStagePlan.CacheKey)
 					emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_DEPENDENCY_STAGE_CACHE, "dependency stage cache miss")
+				}
+
+				if strings.TrimSpace(dependencyStagePlan.PortableCacheKey) != "" {
+					emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_DEPENDENCY_STAGE_CACHE, "checking portable dependency stage cache")
+					var portableRecord cachestore.Record
+					var portableFound bool
+					var portableLookupReason string
+					portableLookupErr := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.lookup_portable_dependency_stage_cache", cachePhaseAttributes(
+						observability.CacheStageDependency,
+						observability.CacheOperationLookup,
+						repository,
+						attribute.String(observability.AttrBackend, backendName),
+					), func(ctx context.Context) error {
+						var lookupErr error
+						portableRecord, portableFound, portableLookupReason, lookupErr = s.lookupPortableDependencyStageCache(ctx, backendName, compiled, repository, dependencyStagePlan)
+						setCacheLookupSpanAttributes(ctx, portableFound, portableLookupReason, lookupErr)
+						return lookupErr
+					})
+					if portableLookupErr != nil {
+						s.logDependencyStageWarning("lookup portable dependency stage cache", "", portableLookupErr)
+					} else if portableFound {
+						s.logDependencyStageCacheHit(portableRecord)
+						emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_DEPENDENCY_STAGE_CACHE, "portable dependency stage cache hit")
+						var restoreResp *cleanroomv1.CreateSandboxResponse
+						restoreErr := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.restore_portable_dependency_stage_cache", cachePhaseAttributes(
+							observability.CacheStageDependency,
+							observability.CacheOperationRestore,
+							repository,
+							attribute.String(observability.AttrBackend, backendName),
+						), func(ctx context.Context) error {
+							var err error
+							restoreResp, err = s.restorePortableDependencyStageCache(ctx, adapter, backendName, compiled, firecrackerCfg, repository, changeset, req.GetOptions(), portableRecord, reporter)
+							setCacheResultSpanAttribute(ctx, map[bool]string{true: observability.CacheResultFailed, false: observability.CacheResultRestored}[err != nil])
+							return err
+						})
+						if restoreErr == nil {
+							metricSourceKind = "portable dependency stage cache"
+							if cacheStore, err := s.cacheStoreOrErr(); err == nil {
+								if err := cacheStore.Touch(ctx, portableRecord.Stage, portableRecord.CacheKey); err != nil {
+									s.logDependencyStageWarning("touch portable dependency stage cache", "", err)
+								}
+							}
+							s.logDependencyStageRestore(portableRecord, restoreResp.GetSandbox().GetSandboxId())
+							if !servicesStageBootstrapEnabled {
+								return restoreResp, nil
+							}
+							restoredDependencyResp = restoreResp
+						} else {
+							s.logDependencyStageRestoreWarning(portableRecord, restoreErr)
+						}
+					} else {
+						s.logDependencyStageCacheMiss(backendName, dependencyStagePlan.PortableCacheKey)
+						emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_DEPENDENCY_STAGE_CACHE, "portable dependency stage cache miss")
+					}
 				}
 			}
 

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -320,6 +320,14 @@ func testRepositoryDependencyAndServicesPolicy() *cleanroomv1.Policy {
 			Files: []string{"docker-compose.yml"},
 		},
 	}
+
+	return policyProto
+}
+
+func testRepositoryPortableDependencyPolicy() *cleanroomv1.Policy {
+	policyProto := testRepositoryDependencyPolicy()
+	policyProto.Dependencies.Reuse = policy.DependencyReusePortable
+
 	return policyProto
 }
 
@@ -2834,7 +2842,7 @@ func TestCreateSandboxPublishesDependencyStageCacheForConfiguredDependencies(t *
 	if !ok {
 		t.Fatal("expected configured dependency stage plan to be enabled")
 	}
-	plan, ok, err = svc.finalizeDependencyStagePlan(context.Background(), compiled, repository, nil, workspaceKey, plan)
+	plan, ok, err = svc.finalizeDependencyStagePlan(context.Background(), compiled, repository, nil, "firecracker", workspaceKey, "runtime-base:test", plan)
 	if err != nil {
 		t.Fatalf("finalizeDependencyStagePlan returned error: %v", err)
 	}
@@ -3048,7 +3056,7 @@ func TestCreateSandboxPublishesServicesStageCacheForConfiguredServices(t *testin
 	if !ok {
 		t.Fatal("expected configured dependency stage plan to be enabled")
 	}
-	dependencyPlan, ok, err = svc.finalizeDependencyStagePlan(context.Background(), compiled, repository, nil, workspaceKey, dependencyPlan)
+	dependencyPlan, ok, err = svc.finalizeDependencyStagePlan(context.Background(), compiled, repository, nil, "firecracker", workspaceKey, "runtime-base:test", dependencyPlan)
 	if err != nil {
 		t.Fatalf("finalizeDependencyStagePlan returned error: %v", err)
 	}
@@ -3249,6 +3257,220 @@ func TestCreateSandboxBootstrapsServicesAfterDependencyStageRestoreWithoutServic
 	}
 }
 
+func TestCreateSandboxReusesPortableDependencyStageAfterCheckoutRefresh(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	store := newMemorySnapshotStore()
+	adapter := &stubAdapter{}
+	var snapshotReqs []backend.SnapshotRequest
+	var runCommands [][]string
+	validationDigest := ""
+	adapter.createSnapshotFn = func(_ context.Context, req backend.SnapshotRequest) (*backend.SnapshotResult, error) {
+		snapshotReqs = append(snapshotReqs, req)
+		return &backend.SnapshotResult{StorageRef: "/snapshots/" + req.SnapshotID + ".ext4"}, nil
+	}
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+		runCommands = append(runCommands, append([]string(nil), req.Command...))
+		if strings.Contains(strings.Join(req.Command, "\n"), "sha256sum") && stream.OnStdout != nil {
+			stream.OnStdout([]byte(validationDigest + "\n"))
+		}
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+	}
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"go.mod": "module example.com/test\n\ngo 1.26.2\n",
+		"go.sum": "example.com/test v0.0.0 h1:abc123\n",
+		"app.go": "package main\n\nfunc main() {}\n",
+	})
+	if err := os.WriteFile(filepath.Join(mirrors.mirrorPath, "app.go"), []byte("package main\n\nfunc main() { println(\"changed\") }\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(app.go) returned error: %v", err)
+	}
+	runTestGit(t, mirrors.mirrorPath, "add", ".")
+	runTestGit(t, mirrors.mirrorPath, "commit", "-m", "source-only change")
+	updatedCommit := strings.TrimSpace(runTestGit(t, mirrors.mirrorPath, "rev-parse", "HEAD"))
+	updatedCheckout := *repositoryCheckout
+	updatedCheckout.CommitSha = updatedCommit
+
+	svc := newTestServiceWithSnapshotStore(adapter, store)
+	svc.RepositoryStore = mirrors
+	var err error
+	validationDigest, err = svc.dependencyStageKeyFilesDigest(context.Background(), repositorycheckout.FromProto(&updatedCheckout), nil, []string{"go.mod", "go.sum"})
+	if err != nil {
+		t.Fatalf("dependencyStageKeyFilesDigest returned error: %v", err)
+	}
+
+	if _, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Policy:             testRepositoryPortableDependencyPolicy(),
+		RepositoryCheckout: repositoryCheckout,
+	}); err != nil {
+		t.Fatalf("first CreateSandbox returned error: %v", err)
+	}
+	secondResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Policy:             testRepositoryPortableDependencyPolicy(),
+		RepositoryCheckout: &updatedCheckout,
+	})
+	if err != nil {
+		t.Fatalf("second CreateSandbox returned error: %v", err)
+	}
+	if got, want := secondResp.GetSourceKind(), "portable dependency stage cache"; got != want {
+		t.Fatalf("unexpected response source kind: got %q want %q", got, want)
+	}
+	if got, want := secondResp.GetSandbox().GetSourceKind(), "portable dependency stage cache"; got != want {
+		t.Fatalf("unexpected sandbox source kind: got %q want %q", got, want)
+	}
+	if got, want := adapter.provisionCalls, 1; got != want {
+		t.Fatalf("expected portable dependency-stage hit to avoid second cold provision, got %d want %d", got, want)
+	}
+	if got, want := adapter.provisionFromSnapshotCalls, 1; got != want {
+		t.Fatalf("expected portable dependency-stage hit to restore once, got %d want %d", got, want)
+	}
+	if got, want := adapter.createSnapshotCalls, 2; got != want {
+		t.Fatalf("expected portable metadata to share the dependency snapshot, got %d snapshot creates", got)
+	}
+	if got, want := len(snapshotReqs), 2; got != want {
+		t.Fatalf("expected workspace and dependency snapshot publishes only, got %d want %d", got, want)
+	}
+	if got, want := len(runCommands), 4; got != want {
+		t.Fatalf("expected repository bootstrap, dependency bootstrap, and checkout refresh, got %d commands", got)
+	}
+	refreshCommand := strings.Join(runCommands[2], "\n")
+	if !strings.Contains(refreshCommand, updatedCommit) || !strings.Contains(refreshCommand, `git -C "$dest" fetch --filter=blob:none --progress origin "$commit"`) {
+		t.Fatalf("expected portable hit to refresh checkout to %s, got %q", updatedCommit, refreshCommand)
+	}
+	if dependencyBootstrap := strings.Join(runCommands[1], " "); !repositoryWrappedCommandContains(dependencyBootstrap, `exec 'mise' 'exec' '--' 'go' 'mod' 'download'`) {
+		t.Fatalf("expected first run to bootstrap dependencies, got %q", dependencyBootstrap)
+	}
+	if validationCommand := strings.Join(runCommands[3], "\n"); !strings.Contains(validationCommand, "sha256sum") {
+		t.Fatalf("expected portable hit to validate dependency key files, got %q", validationCommand)
+	}
+
+	cacheStore, ok := svc.CacheStore.(*memoryCacheStore)
+	if !ok {
+		t.Fatalf("expected memory cache store, got %T", svc.CacheStore)
+	}
+	records, err := cacheStore.List(context.Background())
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	var exactRecord, portableRecord *cachestore.Record
+	for i := range records {
+		switch records[i].ReuseMode {
+		case dependencyStageReuseExact:
+			record := records[i]
+			exactRecord = &record
+		case dependencyStageReusePortableSeed:
+			record := records[i]
+			portableRecord = &record
+		}
+	}
+	if exactRecord == nil {
+		t.Fatal("expected exact dependency stage metadata")
+	}
+	if portableRecord == nil {
+		t.Fatal("expected portable dependency stage metadata")
+	}
+	if got, want := portableRecord.BackingSnapshotID, exactRecord.BackingSnapshotID; got != want {
+		t.Fatalf("expected portable record to share exact dependency snapshot: got %q want %q", got, want)
+	}
+	if got, want := portableRecord.ParentCacheKey, "runtime-base:test"; got != want {
+		t.Fatalf("unexpected portable parent cache key: got %q want %q", got, want)
+	}
+	if portableRecord.DependencyKeyFilesDigest == "" {
+		t.Fatal("expected portable dependency key-file digest metadata")
+	}
+
+	svc.mu.Lock()
+	restoredState := svc.sandboxes[secondResp.GetSandbox().GetSandboxId()]
+	svc.mu.Unlock()
+	if restoredState == nil || restoredState.Repository == nil {
+		t.Fatal("expected restored sandbox repository state")
+	}
+	if got, want := restoredState.Repository.CommitSHA, updatedCommit; got != want {
+		t.Fatalf("expected restored sandbox repository to be refreshed: got %q want %q", got, want)
+	}
+}
+
+func TestCreateSandboxBootstrapsServicesAfterPortableDependencyStageRestore(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	store := newMemorySnapshotStore()
+	adapter := &stubAdapter{}
+	var snapshotReqs []backend.SnapshotRequest
+	var runCommands [][]string
+	validationDigest := ""
+	adapter.createSnapshotFn = func(_ context.Context, req backend.SnapshotRequest) (*backend.SnapshotResult, error) {
+		snapshotReqs = append(snapshotReqs, req)
+		return &backend.SnapshotResult{StorageRef: "/snapshots/" + req.SnapshotID + ".ext4"}, nil
+	}
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+		runCommands = append(runCommands, append([]string(nil), req.Command...))
+		if strings.Contains(strings.Join(req.Command, "\n"), "sha256sum") && stream.OnStdout != nil {
+			stream.OnStdout([]byte(validationDigest + "\n"))
+		}
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+	}
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"go.mod":             "module example.com/test\n\ngo 1.26.2\n",
+		"go.sum":             "example.com/test v0.0.0 h1:abc123\n",
+		"docker-compose.yml": "services:\n  postgres:\n    image: postgres:17\n",
+		"app.go":             "package main\n\nfunc main() {}\n",
+	})
+	if err := os.WriteFile(filepath.Join(mirrors.mirrorPath, "app.go"), []byte("package main\n\nfunc main() { println(\"changed\") }\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(app.go) returned error: %v", err)
+	}
+	runTestGit(t, mirrors.mirrorPath, "add", ".")
+	runTestGit(t, mirrors.mirrorPath, "commit", "-m", "source-only change")
+	updatedCommit := strings.TrimSpace(runTestGit(t, mirrors.mirrorPath, "rev-parse", "HEAD"))
+	updatedCheckout := *repositoryCheckout
+	updatedCheckout.CommitSha = updatedCommit
+
+	svc := newTestServiceWithSnapshotStore(adapter, store)
+	svc.RepositoryStore = mirrors
+	var err error
+	validationDigest, err = svc.dependencyStageKeyFilesDigest(context.Background(), repositorycheckout.FromProto(&updatedCheckout), nil, []string{"go.mod", "go.sum"})
+	if err != nil {
+		t.Fatalf("dependencyStageKeyFilesDigest returned error: %v", err)
+	}
+
+	portableServicesPolicy := testRepositoryDependencyAndServicesPolicy()
+	portableServicesPolicy.Dependencies.Reuse = policy.DependencyReusePortable
+	if _, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Policy:             portableServicesPolicy,
+		RepositoryCheckout: repositoryCheckout,
+	}); err != nil {
+		t.Fatalf("first CreateSandbox returned error: %v", err)
+	}
+	secondResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Policy:             portableServicesPolicy,
+		RepositoryCheckout: &updatedCheckout,
+	})
+	if err != nil {
+		t.Fatalf("second CreateSandbox returned error: %v", err)
+	}
+	if got, want := secondResp.GetSourceKind(), "portable dependency stage cache"; got != want {
+		t.Fatalf("unexpected response source kind: got %q want %q", got, want)
+	}
+	if got, want := adapter.provisionCalls, 1; got != want {
+		t.Fatalf("expected portable dependency-stage hit to avoid second cold provision, got %d want %d", got, want)
+	}
+	if got, want := adapter.provisionFromSnapshotCalls, 1; got != want {
+		t.Fatalf("expected portable dependency-stage hit to restore once, got %d want %d", got, want)
+	}
+	if got, want := adapter.createSnapshotCalls, 4; got != want {
+		t.Fatalf("expected first workspace/dependency/services snapshots plus refreshed services snapshot, got %d want %d", got, want)
+	}
+	if got, want := len(snapshotReqs), 4; got != want {
+		t.Fatalf("expected four snapshot publish requests, got %d want %d", got, want)
+	}
+	if got, want := len(runCommands), 6; got != want {
+		t.Fatalf("expected cold bootstraps plus portable refresh, validation, and services bootstrap, got %d want %d", got, want)
+	}
+	if refreshCommand := strings.Join(runCommands[3], "\n"); !strings.Contains(refreshCommand, updatedCommit) {
+		t.Fatalf("expected portable hit to refresh checkout to %s, got %q", updatedCommit, refreshCommand)
+	}
+	servicesBootstrap := strings.Join(runCommands[5], " ")
+	if !repositoryWrappedCommandContains(servicesBootstrap, `exec 'docker' 'compose' 'up' '-d' 'postgres'`) {
+		t.Fatalf("expected services bootstrap after portable restore, got %q", servicesBootstrap)
+	}
+}
+
 func TestDependencyStageKeyFilesDigestDerivesHashesFromRepositoryChangesetPatch(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
@@ -3304,6 +3526,27 @@ func TestDependencyStageKeyFilesDigestDerivesHashesFromRepositoryChangesetPatch(
 	}
 	if got, want := tamperedDigest, changesetDigest; got != want {
 		t.Fatalf("expected dependency key file digest to ignore tampered file hashes: got %q want %q", got, want)
+	}
+}
+
+func TestDependencyStageKeyFilesDigestCommandHashesSymlinkTargets(t *testing.T) {
+	t.Parallel()
+
+	command, err := dependencyStageKeyFilesDigestCommand(&repositorycheckout.Checkout{DestinationDir: "/workspace"}, []string{"Gemfile.lock"})
+	if err != nil {
+		t.Fatalf("dependencyStageKeyFilesDigestCommand returned error: %v", err)
+	}
+	script := strings.Join(command, "\n")
+	for _, want := range []string{
+		`if [ -L "$path" ]; then`,
+		`target="$(readlink "$path")"`,
+		`printf '%s' "$target" | sha256sum`,
+		`elif [ -e "$path" ]; then`,
+		`sha256sum "$path"`,
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("expected validation script to contain %q, got %q", want, script)
+		}
 	}
 }
 

--- a/internal/controlservice/stored_rootfs.go
+++ b/internal/controlservice/stored_rootfs.go
@@ -58,6 +58,9 @@ func storedRootFSRecordFromCacheEntry(record cachestore.Record) (storedRootFSRec
 	} else {
 		sourceKind += " stage cache"
 	}
+	if strings.TrimSpace(record.ReuseMode) == dependencyStageReusePortableSeed {
+		sourceKind = "portable dependency stage cache"
+	}
 	return storedRootFSRecord{
 		ID:                                  strings.TrimSpace(record.CacheKey),
 		Kind:                                sourceKind,
@@ -131,6 +134,8 @@ func (s *Service) createSandboxFromStoredRootFS(ctx context.Context, req *cleanr
 		emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_RESTORE_DEPENDENCY_STAGE_CACHE, "restoring dependency stage cache")
 	case "services stage cache":
 		emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_RESTORE_SERVICES_STAGE_CACHE, "restoring services stage cache")
+	case "portable dependency stage cache":
+		emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_RESTORE_DEPENDENCY_STAGE_CACHE, "restoring portable dependency stage cache")
 	case "workspace stage cache":
 		emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_RESTORE_WORKSPACE_STAGE_CACHE, "restoring workspace stage cache")
 	}

--- a/internal/gen/cleanroom/v1/control.pb.go
+++ b/internal/gen/cleanroom/v1/control.pb.go
@@ -718,6 +718,7 @@ type PolicyDependencies struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Command       []string               `protobuf:"bytes,1,rep,name=command,proto3" json:"command,omitempty"`
 	Key           *PolicyDependencyKey   `protobuf:"bytes,2,opt,name=key,proto3" json:"key,omitempty"`
+	Reuse         string                 `protobuf:"bytes,3,opt,name=reuse,proto3" json:"reuse,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -764,6 +765,13 @@ func (x *PolicyDependencies) GetKey() *PolicyDependencyKey {
 		return x.Key
 	}
 	return nil
+}
+
+func (x *PolicyDependencies) GetReuse() string {
+	if x != nil {
+		return x.Reuse
+	}
+	return ""
 }
 
 type PolicyRun struct {
@@ -3887,10 +3895,11 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\acommand\x18\x02 \x03(\tR\acommand\x123\n" +
 	"\x03key\x18\x03 \x01(\v2!.cleanroom.v1.PolicyDependencyKeyR\x03key\"+\n" +
 	"\x13PolicyDependencyKey\x12\x14\n" +
-	"\x05files\x18\x01 \x03(\tR\x05files\"c\n" +
+	"\x05files\x18\x01 \x03(\tR\x05files\"y\n" +
 	"\x12PolicyDependencies\x12\x18\n" +
 	"\acommand\x18\x01 \x03(\tR\acommand\x123\n" +
-	"\x03key\x18\x02 \x01(\v2!.cleanroom.v1.PolicyDependencyKeyR\x03key\"#\n" +
+	"\x03key\x18\x02 \x01(\v2!.cleanroom.v1.PolicyDependencyKeyR\x03key\x12\x14\n" +
+	"\x05reuse\x18\x03 \x01(\tR\x05reuse\"#\n" +
 	"\tPolicyRun\x12\x16\n" +
 	"\x06before\x18\x01 \x03(\tR\x06before\"\xff\x02\n" +
 	"\x06Policy\x12\x18\n" +

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -60,6 +60,7 @@ type rawDependencyKey struct {
 type rawDependenciesConfig struct {
 	Command rawDependencyCommandSpec `yaml:"command"`
 	Key     rawDependencyKey         `yaml:"key"`
+	Reuse   string                   `yaml:"reuse"`
 }
 
 type rawDependencyCommandSpec []string
@@ -114,6 +115,7 @@ type Services struct {
 type Dependencies struct {
 	Command  []string `json:"command,omitempty"`
 	KeyFiles []string `json:"key_files,omitempty"`
+	Reuse    string   `json:"reuse,omitempty"`
 }
 
 type Run struct {
@@ -322,6 +324,11 @@ func (d Dependencies) Enabled() bool {
 	return len(d.Command) > 0
 }
 
+const (
+	DependencyReuseExact    = "exact"
+	DependencyReusePortable = "portable"
+)
+
 func (r Run) HasBefore() bool {
 	return len(r.Before) > 0
 }
@@ -491,6 +498,7 @@ func (p *CompiledPolicy) ToProto() *cleanroomv1.Policy {
 			Key: &cleanroomv1.PolicyDependencyKey{
 				Files: append([]string(nil), p.Dependencies.KeyFiles...),
 			},
+			Reuse: p.Dependencies.Reuse,
 		},
 		Run: &cleanroomv1.PolicyRun{
 			Before: append([]string(nil), p.Run.Before...),
@@ -606,15 +614,26 @@ func normalizeDependencies(raw rawDependenciesConfig) (Dependencies, error) {
 	if err != nil {
 		return Dependencies{}, err
 	}
+	reuse, err := normalizeDependencyReuse(raw.Reuse, "sandbox.dependencies.reuse")
+	if err != nil {
+		return Dependencies{}, err
+	}
 	if len(command) == 0 {
 		if len(keyFiles) > 0 {
 			return Dependencies{}, errors.New("sandbox.dependencies.key.files requires sandbox.dependencies.command")
 		}
+		if reuse != "" {
+			return Dependencies{}, errors.New("sandbox.dependencies.reuse requires sandbox.dependencies.command")
+		}
 		return Dependencies{}, nil
+	}
+	if reuse == DependencyReusePortable && len(keyFiles) == 0 {
+		return Dependencies{}, errors.New("sandbox.dependencies.reuse=portable requires sandbox.dependencies.key.files")
 	}
 	return Dependencies{
 		Command:  command,
 		KeyFiles: keyFiles,
+		Reuse:    reuse,
 	}, nil
 }
 
@@ -630,15 +649,26 @@ func dependenciesFromProto(pb *cleanroomv1.PolicyDependencies) (Dependencies, er
 	if err != nil {
 		return Dependencies{}, err
 	}
+	reuse, err := normalizeDependencyReuse(pb.GetReuse(), "policy dependencies.reuse")
+	if err != nil {
+		return Dependencies{}, err
+	}
 	if len(command) == 0 {
 		if len(keyFiles) > 0 {
 			return Dependencies{}, errors.New("policy dependencies.key.files requires dependencies.command")
 		}
+		if reuse != "" {
+			return Dependencies{}, errors.New("policy dependencies.reuse requires dependencies.command")
+		}
 		return Dependencies{}, nil
+	}
+	if reuse == DependencyReusePortable && len(keyFiles) == 0 {
+		return Dependencies{}, errors.New("policy dependencies.reuse=portable requires dependencies.key.files")
 	}
 	return Dependencies{
 		Command:  command,
 		KeyFiles: keyFiles,
+		Reuse:    reuse,
 	}, nil
 }
 
@@ -762,6 +792,18 @@ func normalizeBootstrapKeyFiles(raw []string, field string) ([]string, error) {
 	}
 	sort.Strings(files)
 	return files, nil
+}
+
+func normalizeDependencyReuse(raw, field string) (string, error) {
+	trimmed := strings.TrimSpace(strings.ToLower(raw))
+	switch trimmed {
+	case "", DependencyReuseExact:
+		return "", nil
+	case DependencyReusePortable:
+		return DependencyReusePortable, nil
+	default:
+		return "", fmt.Errorf("%s must be %q or %q", field, DependencyReuseExact, DependencyReusePortable)
+	}
 }
 
 func hashPolicy(p *CompiledPolicy) (string, error) {

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -218,6 +218,26 @@ func TestCompileNormalizesDependencyBootstrapConfig(t *testing.T) {
 	if got, want := compiled.Dependencies.KeyFiles, []string{"go.mod", "go.sum"}; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
 		t.Fatalf("unexpected dependency key files: got %v want %v", got, want)
 	}
+	if got := compiled.Dependencies.Reuse; got != "" {
+		t.Fatalf("expected default dependency reuse mode to be empty/exact, got %q", got)
+	}
+}
+
+func TestCompileNormalizesPortableDependencyReuse(t *testing.T) {
+	t.Parallel()
+
+	raw := baseRawPolicy()
+	raw.Sandbox.Dependencies.Command = []string{"go", "mod", "download"}
+	raw.Sandbox.Dependencies.Key.Files = []string{"go.mod", "go.sum"}
+	raw.Sandbox.Dependencies.Reuse = "portable"
+
+	compiled, err := Compile(raw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if got, want := compiled.Dependencies.Reuse, DependencyReusePortable; got != want {
+		t.Fatalf("unexpected dependency reuse mode: got %q want %q", got, want)
+	}
 }
 
 func TestCompileNormalizesServicesBootstrapConfig(t *testing.T) {
@@ -343,6 +363,22 @@ func TestCompileRejectsDependencyKeyFilesWithoutCommand(t *testing.T) {
 		t.Fatal("expected compile to reject dependency key files without a command")
 	}
 	if !strings.Contains(err.Error(), "sandbox.dependencies.key.files") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCompileRejectsPortableDependencyReuseWithoutKeyFiles(t *testing.T) {
+	t.Parallel()
+
+	raw := baseRawPolicy()
+	raw.Sandbox.Dependencies.Command = []string{"go", "mod", "download"}
+	raw.Sandbox.Dependencies.Reuse = "portable"
+
+	_, err := Compile(raw)
+	if err == nil {
+		t.Fatal("expected compile to reject portable dependency reuse without key files")
+	}
+	if !strings.Contains(err.Error(), "sandbox.dependencies.reuse=portable") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -696,6 +732,7 @@ func TestCompiledPolicyProtoRoundTripPreservesDependenciesAndServices(t *testing
 	raw := baseRawPolicy()
 	raw.Sandbox.Dependencies.Command = []string{"go", "mod", "download"}
 	raw.Sandbox.Dependencies.Key.Files = []string{"go.mod", "go.sum"}
+	raw.Sandbox.Dependencies.Reuse = "portable"
 	raw.Sandbox.Services.Docker.Required = true
 	raw.Sandbox.Services.Command = []string{"docker", "compose", "up", "-d", "postgres"}
 	raw.Sandbox.Services.Key.Files = []string{"docker-compose.yml"}
@@ -714,6 +751,9 @@ func TestCompiledPolicyProtoRoundTripPreservesDependenciesAndServices(t *testing
 	}
 	if got, want := strings.Join(roundTripped.Dependencies.KeyFiles, "\x00"), strings.Join(compiled.Dependencies.KeyFiles, "\x00"); got != want {
 		t.Fatalf("unexpected dependency key files after round trip: got %q want %q", got, want)
+	}
+	if got, want := roundTripped.Dependencies.Reuse, compiled.Dependencies.Reuse; got != want {
+		t.Fatalf("unexpected dependency reuse after round trip: got %q want %q", got, want)
 	}
 	if got, want := roundTripped.Services.Docker.Required, compiled.Services.Docker.Required; got != want {
 		t.Fatalf("unexpected docker requirement after round trip: got %t want %t", got, want)

--- a/internal/repositorycheckout/checkout.go
+++ b/internal/repositorycheckout/checkout.go
@@ -205,6 +205,15 @@ func BootstrapRecipeDigest(checkout *Checkout) string {
 	return commandRecipeDigest(BuildBootstrapCommand(checkout))
 }
 
+func RefreshRecipeDigest(checkout *Checkout) string {
+	if checkout == nil {
+		return ""
+	}
+	normalized := *checkout
+	normalized.CommitSHA = ""
+	return commandRecipeDigest(BuildRefreshCommand(&normalized))
+}
+
 func WorkdirRecipeDigest(command []string, checkout *Checkout) string {
 	if checkout == nil {
 		return ""

--- a/proto/cleanroom/v1/control.proto
+++ b/proto/cleanroom/v1/control.proto
@@ -93,6 +93,7 @@ message PolicyDependencyKey {
 message PolicyDependencies {
   repeated string command = 1;
   PolicyDependencyKey key = 2;
+  string reuse = 3;
 }
 
 message PolicyRun {


### PR DESCRIPTION
## Summary

- Adds `sandbox.dependencies.reuse: portable` plus proto, policy, README, spec, and plan documentation for opt-in cross-commit dependency reuse.
- Publishes portable dependency-stage metadata that points at the exact dependency snapshot while keying reuse to the runtime base, repository shape, refresh recipe, dependency key-file digest, and dependency bootstrap recipe.
- On an exact dependency miss, restores the portable seed into a writable child, refreshes the checkout, reapplies the request changeset when present, validates declared key files, and falls back to the normal workspace/dependency path on any restore, refresh, or validation failure.
- Extends cache metadata and tests for portable dependency records, source-kind reporting, and the source-only commit reuse path.

## Validation

- `git diff --check`
- `mise exec -- go test ./internal/cachestore ./internal/controlservice`
- `mise exec -- go test ./...`

Still draft while we review this first implementation slice.
