### PR TITLE
feat: Cache darwin-vz rootfs validation

### DIFF
--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -1980,7 +1980,7 @@ func (a *Adapter) ensurePreparedRuntimeRootFSFromImage(ctx context.Context, imag
 		return preparedRootFS{}, err
 	}
 	if _, err := os.Stat(preparedPath); err == nil {
-		if validateErr := validatePreparedRuntimeRootFS(preparedPath); validateErr == nil {
+		if preparedRuntimeRootFSCacheHitIsValid(preparedPath) {
 			return preparedRootFS{
 				Ref:    artifact.Ref,
 				Digest: artifact.Digest,
@@ -1989,6 +1989,7 @@ func (a *Adapter) ensurePreparedRuntimeRootFSFromImage(ctx context.Context, imag
 			}, nil
 		}
 		// Stale/incomplete cache entries should be rebuilt instead of reused.
+		_ = os.Remove(preparedRuntimeRootFSMarkerPath(preparedPath))
 		_ = os.Remove(preparedPath)
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return preparedRootFS{}, fmt.Errorf("inspect prepared runtime rootfs %q: %w", preparedPath, err)
@@ -1998,7 +1999,7 @@ func (a *Adapter) ensurePreparedRuntimeRootFSFromImage(ctx context.Context, imag
 	defer a.runtimeImageMu.Unlock()
 
 	if _, err := os.Stat(preparedPath); err == nil {
-		if validateErr := validatePreparedRuntimeRootFS(preparedPath); validateErr == nil {
+		if preparedRuntimeRootFSCacheHitIsValid(preparedPath) {
 			return preparedRootFS{
 				Ref:    artifact.Ref,
 				Digest: artifact.Digest,
@@ -2006,6 +2007,7 @@ func (a *Adapter) ensurePreparedRuntimeRootFSFromImage(ctx context.Context, imag
 				Hit:    true,
 			}, nil
 		}
+		_ = os.Remove(preparedRuntimeRootFSMarkerPath(preparedPath))
 		if removeErr := os.Remove(preparedPath); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
 			return preparedRootFS{}, fmt.Errorf("remove invalid prepared runtime rootfs %q: %w", preparedPath, removeErr)
 		}
@@ -2034,6 +2036,7 @@ func (a *Adapter) ensurePreparedRuntimeRootFSFromImage(ctx context.Context, imag
 		_ = os.Remove(tmpPath)
 		if _, statErr := os.Stat(preparedPath); statErr == nil {
 			if validateErr := validatePreparedRuntimeRootFS(preparedPath); validateErr == nil {
+				_ = writePreparedRuntimeRootFSMarker(preparedPath)
 				return preparedRootFS{
 					Ref:    artifact.Ref,
 					Digest: artifact.Digest,
@@ -2045,6 +2048,7 @@ func (a *Adapter) ensurePreparedRuntimeRootFSFromImage(ctx context.Context, imag
 		}
 		return preparedRootFS{}, fmt.Errorf("store prepared runtime rootfs %q: %w", preparedPath, err)
 	}
+	_ = writePreparedRuntimeRootFSMarker(preparedPath)
 
 	return preparedRootFS{
 		Ref:    artifact.Ref,
@@ -2057,6 +2061,8 @@ func (a *Adapter) ensurePreparedRuntimeRootFSFromImage(ctx context.Context, imag
 var preparedRuntimeRootFSRequiredPaths = []string{
 	guestAgentPath,
 }
+
+var validatePreparedRuntimeRootFSFn = validatePreparedRuntimeRootFS
 
 func validatePreparedRuntimeRootFS(path string) error {
 	for _, requiredPath := range preparedRuntimeRootFSRequiredPaths {
@@ -2072,6 +2078,67 @@ func validatePreparedRuntimeRootFS(path string) error {
 		},
 	)
 }
+
+const preparedRuntimeRootFSMarkerVersion = "v1"
+
+func preparedRuntimeRootFSCacheHitIsValid(path string) bool {
+	if preparedRuntimeRootFSMarkerMatches(path) {
+		return true
+	}
+	if err := validatePreparedRuntimeRootFSFn(path); err != nil {
+		return false
+	}
+	_ = writePreparedRuntimeRootFSMarker(path)
+	return true
+}
+
+func preparedRuntimeRootFSMarkerPath(path string) string {
+	return path + ".validated"
+}
+
+func preparedRuntimeRootFSMarkerMatches(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	raw, err := os.ReadFile(preparedRuntimeRootFSMarkerPath(path))
+	if err != nil {
+		return false
+	}
+	fields := strings.Fields(string(raw))
+	if len(fields) != 3 || fields[0] != preparedRuntimeRootFSMarkerVersion {
+		return false
+	}
+	size, err := strconv.ParseInt(fields[1], 10, 64)
+	if err != nil || size != info.Size() {
+		return false
+	}
+	modTimeNanos, err := strconv.ParseInt(fields[2], 10, 64)
+	if err != nil || modTimeNanos != info.ModTime().UTC().UnixNano() {
+		return false
+	}
+	return true
+}
+
+func writePreparedRuntimeRootFSMarker(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	markerPath := preparedRuntimeRootFSMarkerPath(path)
+	tmpPath := markerPath + fmt.Sprintf(".tmp-%d", time.Now().UnixNano())
+	content := fmt.Sprintf("%s\n%d\n%d\n", preparedRuntimeRootFSMarkerVersion, info.Size(), info.ModTime().UTC().UnixNano())
+	if err := os.WriteFile(tmpPath, []byte(content), 0o644); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if err := os.Rename(tmpPath, markerPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	return nil
+}
+
 func preparedRuntimeRootFSPath(imageDigest, guestAgentHash string) (string, error) {
 	cacheBase, err := paths.CacheBaseDir()
 	if err != nil {

--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -2079,7 +2079,13 @@ func validatePreparedRuntimeRootFS(path string) error {
 	)
 }
 
-const preparedRuntimeRootFSMarkerVersion = "v1"
+const preparedRuntimeRootFSMarkerVersion = "v2"
+
+type preparedRuntimeRootFSMarkerState struct {
+	size            int64
+	modTimeNanos    int64
+	changeTimeNanos int64
+}
 
 func preparedRuntimeRootFSCacheHitIsValid(path string) bool {
 	if preparedRuntimeRootFSMarkerMatches(path) {
@@ -2096,8 +2102,20 @@ func preparedRuntimeRootFSMarkerPath(path string) string {
 	return path + ".validated"
 }
 
+func preparedRuntimeRootFSMarkerStateForPath(path string) (preparedRuntimeRootFSMarkerState, error) {
+	var stat unix.Stat_t
+	if err := unix.Stat(path, &stat); err != nil {
+		return preparedRuntimeRootFSMarkerState{}, err
+	}
+	return preparedRuntimeRootFSMarkerState{
+		size:            stat.Size,
+		modTimeNanos:    stat.Mtim.Nano(),
+		changeTimeNanos: stat.Ctim.Nano(),
+	}, nil
+}
+
 func preparedRuntimeRootFSMarkerMatches(path string) bool {
-	info, err := os.Stat(path)
+	state, err := preparedRuntimeRootFSMarkerStateForPath(path)
 	if err != nil {
 		return false
 	}
@@ -2106,28 +2124,32 @@ func preparedRuntimeRootFSMarkerMatches(path string) bool {
 		return false
 	}
 	fields := strings.Fields(string(raw))
-	if len(fields) != 3 || fields[0] != preparedRuntimeRootFSMarkerVersion {
+	if len(fields) != 4 || fields[0] != preparedRuntimeRootFSMarkerVersion {
 		return false
 	}
 	size, err := strconv.ParseInt(fields[1], 10, 64)
-	if err != nil || size != info.Size() {
+	if err != nil || size != state.size {
 		return false
 	}
 	modTimeNanos, err := strconv.ParseInt(fields[2], 10, 64)
-	if err != nil || modTimeNanos != info.ModTime().UTC().UnixNano() {
+	if err != nil || modTimeNanos != state.modTimeNanos {
+		return false
+	}
+	changeTimeNanos, err := strconv.ParseInt(fields[3], 10, 64)
+	if err != nil || changeTimeNanos != state.changeTimeNanos {
 		return false
 	}
 	return true
 }
 
 func writePreparedRuntimeRootFSMarker(path string) error {
-	info, err := os.Stat(path)
+	state, err := preparedRuntimeRootFSMarkerStateForPath(path)
 	if err != nil {
 		return err
 	}
 	markerPath := preparedRuntimeRootFSMarkerPath(path)
 	tmpPath := markerPath + fmt.Sprintf(".tmp-%d", time.Now().UnixNano())
-	content := fmt.Sprintf("%s\n%d\n%d\n", preparedRuntimeRootFSMarkerVersion, info.Size(), info.ModTime().UTC().UnixNano())
+	content := fmt.Sprintf("%s\n%d\n%d\n%d\n", preparedRuntimeRootFSMarkerVersion, state.size, state.modTimeNanos, state.changeTimeNanos)
 	if err := os.WriteFile(tmpPath, []byte(content), 0o644); err != nil {
 		_ = os.Remove(tmpPath)
 		return err

--- a/internal/backend/darwinvz/rootfs_cache_marker_test.go
+++ b/internal/backend/darwinvz/rootfs_cache_marker_test.go
@@ -1,0 +1,127 @@
+//go:build darwin
+
+package darwinvz
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPreparedRuntimeRootFSCacheHitUsesValidMarkerWithoutExt4Validation(t *testing.T) {
+	rootFSPath := writeTestPreparedRootFS(t, "prepared-rootfs")
+	if err := writePreparedRuntimeRootFSMarker(rootFSPath); err != nil {
+		t.Fatalf("write prepared rootfs marker: %v", err)
+	}
+
+	validateCalls := 0
+	restore := stubPreparedRuntimeRootFSValidator(t, func(string) error {
+		validateCalls++
+		return errors.New("validator should not be called")
+	})
+	defer restore()
+
+	if !preparedRuntimeRootFSCacheHitIsValid(rootFSPath) {
+		t.Fatal("expected prepared rootfs cache hit to be valid")
+	}
+	if validateCalls != 0 {
+		t.Fatalf("expected validation to be skipped, got %d calls", validateCalls)
+	}
+}
+
+func TestPreparedRuntimeRootFSCacheHitValidatesAndMarksWhenMarkerMissing(t *testing.T) {
+	rootFSPath := writeTestPreparedRootFS(t, "prepared-rootfs")
+
+	validateCalls := 0
+	restore := stubPreparedRuntimeRootFSValidator(t, func(string) error {
+		validateCalls++
+		return nil
+	})
+	defer restore()
+
+	if !preparedRuntimeRootFSCacheHitIsValid(rootFSPath) {
+		t.Fatal("expected prepared rootfs cache hit to be valid after validation")
+	}
+	if validateCalls != 1 {
+		t.Fatalf("expected one validation call, got %d", validateCalls)
+	}
+	if _, err := os.Stat(preparedRuntimeRootFSMarkerPath(rootFSPath)); err != nil {
+		t.Fatalf("expected prepared rootfs marker to be written: %v", err)
+	}
+
+	if !preparedRuntimeRootFSCacheHitIsValid(rootFSPath) {
+		t.Fatal("expected marked prepared rootfs cache hit to remain valid")
+	}
+	if validateCalls != 1 {
+		t.Fatalf("expected marker to skip second validation, got %d calls", validateCalls)
+	}
+}
+
+func TestPreparedRuntimeRootFSCacheHitRevalidatesStaleMarker(t *testing.T) {
+	rootFSPath := writeTestPreparedRootFS(t, "prepared-rootfs")
+	if err := writePreparedRuntimeRootFSMarker(rootFSPath); err != nil {
+		t.Fatalf("write prepared rootfs marker: %v", err)
+	}
+	if err := os.WriteFile(rootFSPath, []byte("prepared-rootfs-mutated"), 0o644); err != nil {
+		t.Fatalf("mutate prepared rootfs: %v", err)
+	}
+
+	validateCalls := 0
+	restore := stubPreparedRuntimeRootFSValidator(t, func(string) error {
+		validateCalls++
+		return nil
+	})
+	defer restore()
+
+	if !preparedRuntimeRootFSCacheHitIsValid(rootFSPath) {
+		t.Fatal("expected stale marker to be refreshed after validation")
+	}
+	if validateCalls != 1 {
+		t.Fatalf("expected stale marker to force validation once, got %d calls", validateCalls)
+	}
+	if !preparedRuntimeRootFSMarkerMatches(rootFSPath) {
+		t.Fatal("expected refreshed marker to match mutated rootfs")
+	}
+}
+
+func TestPreparedRuntimeRootFSCacheHitRejectsInvalidPreparedRootFS(t *testing.T) {
+	rootFSPath := writeTestPreparedRootFS(t, "prepared-rootfs")
+
+	validateCalls := 0
+	restore := stubPreparedRuntimeRootFSValidator(t, func(string) error {
+		validateCalls++
+		return errors.New("missing guest runtime")
+	})
+	defer restore()
+
+	if preparedRuntimeRootFSCacheHitIsValid(rootFSPath) {
+		t.Fatal("expected invalid prepared rootfs cache hit to be rejected")
+	}
+	if validateCalls != 1 {
+		t.Fatalf("expected one validation call, got %d", validateCalls)
+	}
+	if _, err := os.Stat(preparedRuntimeRootFSMarkerPath(rootFSPath)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected marker not to be written, got err=%v", err)
+	}
+}
+
+func writeTestPreparedRootFS(t *testing.T, contents string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "rootfs.ext4")
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write prepared rootfs: %v", err)
+	}
+	return path
+}
+
+func stubPreparedRuntimeRootFSValidator(t *testing.T, fn func(string) error) func() {
+	t.Helper()
+
+	prev := validatePreparedRuntimeRootFSFn
+	validatePreparedRuntimeRootFSFn = fn
+	return func() {
+		validatePreparedRuntimeRootFSFn = prev
+	}
+}

--- a/internal/backend/darwinvz/rootfs_cache_marker_test.go
+++ b/internal/backend/darwinvz/rootfs_cache_marker_test.go
@@ -85,6 +85,40 @@ func TestPreparedRuntimeRootFSCacheHitRevalidatesStaleMarker(t *testing.T) {
 	}
 }
 
+func TestPreparedRuntimeRootFSCacheHitRevalidatesWhenContentsChangeWithPreservedSizeAndModTime(t *testing.T) {
+	rootFSPath := writeTestPreparedRootFS(t, "prepared-rootfs")
+	info, err := os.Stat(rootFSPath)
+	if err != nil {
+		t.Fatalf("stat prepared rootfs: %v", err)
+	}
+	if err := writePreparedRuntimeRootFSMarker(rootFSPath); err != nil {
+		t.Fatalf("write prepared rootfs marker: %v", err)
+	}
+	if err := os.WriteFile(rootFSPath, []byte("corrupted-rootf"), 0o644); err != nil {
+		t.Fatalf("mutate prepared rootfs: %v", err)
+	}
+	if err := os.Chtimes(rootFSPath, info.ModTime(), info.ModTime()); err != nil {
+		t.Fatalf("restore prepared rootfs mtime: %v", err)
+	}
+
+	validateCalls := 0
+	restore := stubPreparedRuntimeRootFSValidator(t, func(string) error {
+		validateCalls++
+		return nil
+	})
+	defer restore()
+
+	if !preparedRuntimeRootFSCacheHitIsValid(rootFSPath) {
+		t.Fatal("expected marker with changed contents to be refreshed after validation")
+	}
+	if validateCalls != 1 {
+		t.Fatalf("expected content change with preserved size and mtime to force validation once, got %d calls", validateCalls)
+	}
+	if !preparedRuntimeRootFSMarkerMatches(rootFSPath) {
+		t.Fatal("expected refreshed marker to match mutated rootfs")
+	}
+}
+
 func TestPreparedRuntimeRootFSCacheHitRejectsInvalidPreparedRootFS(t *testing.T) {
 	rootFSPath := writeTestPreparedRootFS(t, "prepared-rootfs")
 


### PR DESCRIPTION
## What changed

- Added a validated sidecar marker for prepared darwin-vz runtime rootfs cache entries.
- Prepared rootfs cache hits now trust matching markers instead of reopening the ext4 image for validation on every sandbox launch.
- Missing or stale markers still force the existing ext4 validation path, and invalid prepared rootfs files are removed and rebuilt.

## Why

The TTI experiments showed the prepared rootfs cache-hit validation path accounts for roughly 45-50 ms of warm darwin-vz sandbox creation. Since prepared rootfs filenames are already keyed by image digest, guest-agent hash, init template, architecture, and prepared-rootfs version, validating once and recording a marker preserves stale-cache recovery without paying the ext4/debugfs probe every launch.

In the experiment, skipping repeated prepared-rootfs validation moved TTI from about `658.9 ms ± 25.5 ms` to `612.2 ms ± 4.7 ms`, and `go_resolve_rootfs` dropped from about `47 ms` to about `1 ms`.

## Validation

- `go test ./internal/backend/darwinvz -run 'TestPreparedRuntimeRootFSCacheHit|TestValidatePreparedRuntimeRootFS|TestResolveRootFSPath' -count=1`
- `go test ./internal/backend/darwinvz`
- `scripts/build-go.sh`
