### PR TITLE
feat: Add cacheable services stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,10 +111,10 @@ commands become repo-aware: Cleanroom resolves the current git remote and local
 `HEAD`, materializes that checkout in the sandbox, and starts commands in the
 configured guest path. Cleanroom no longer auto-detects or auto-wraps commands
 for `mise`; if you want `mise`, run it explicitly in the command you execute or
-in `sandbox.dependencies.command` so it can participate in dependency-stage
-caching.
+in `sandbox.dependencies.command` or `sandbox.services.command` so it can
+participate in create-time stage caching.
 
-You can also define per-execution setup that runs before each top-level command:
+You can also define create-time and per-execution setup:
 
 ```yaml
 sandbox:
@@ -122,14 +122,28 @@ sandbox:
     command: bundle install
     key:
       files: [Gemfile.lock]
-  run:
-    before: |
+  services:
+    docker:
+      required: true
+    command: |
       docker compose up -d postgres valkey
       bin/rails db:prepare
+      docker compose stop postgres valkey
+    key:
+      files: [docker-compose.yml, db/schema.rb]
+  run:
+    before: docker compose up -d postgres valkey
 ```
 
-`sandbox.dependencies.command` supports either a shell string or an argv sequence.
-Prefer the string form unless you specifically need exact argv semantics.
+Use `sandbox.dependencies.command` for deterministic repo-local bootstrap,
+`sandbox.services.command` for snapshotable on-disk service preparation, and
+`sandbox.run.before` for live startup that must happen before each execution.
+Set `sandbox.services.docker.required: true` when the services bootstrap needs
+the guest Docker daemon.
+
+`sandbox.dependencies.command` and `sandbox.services.command` support either a
+shell string or an argv sequence. Prefer the string form unless you specifically
+need exact argv semantics.
 `sandbox.run.before` always runs through `sh -lc`.
 
 Pre-create a long-running sandbox without running a command:

--- a/docs/api.md
+++ b/docs/api.md
@@ -342,7 +342,8 @@ Behavior contract:
 5. For repo-aware top-level commands, materialize that checkout in the sandbox
    and default the guest working directory to `repository.path`.
    - Cleanroom does not auto-detect or auto-wrap `mise`; call it explicitly in
-     `sandbox.dependencies.command` or the workload command when needed
+     `sandbox.dependencies.command`, `sandbox.services.command`, or the
+     workload command when needed
 6. Create execution with explicit kind, env, and TTY options.
 7. Attach stdio according to command mode:
    - `cleanroom exec` defaults to attached stdin plus separate stdout/stderr

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -196,13 +196,14 @@ The cache-stage values are:
 - `runtime`
 - `workspace`
 - `dependency`
+- `services`
 
 Recommended cache telemetry attributes are:
 
-- `cleanroom.cache.stage=runtime|workspace|dependency`
+- `cleanroom.cache.stage=runtime|workspace|dependency|services`
 - `cleanroom.cache.operation=lookup|restore|publish|invalidate`
 - `cleanroom.cache.result=hit|miss|restored|published|fallback|failed`
-- `cleanroom.cache.lookup_reason=cache_record_not_found|backend_mismatch|policy_hash_mismatch|repository_changed|workspace_parent_changed`
+- `cleanroom.cache.lookup_reason=cache_record_not_found|backend_mismatch|policy_hash_mismatch|repository_changed|parent_stage_changed`
 - `cleanroom.repository.commit_sha=<git commit sha>`
 
 Use these fields in traces and structured logs for cache-specific work. Use

--- a/docs/plans/layered-caching.md
+++ b/docs/plans/layered-caching.md
@@ -24,6 +24,8 @@ The system-cache pipeline uses stage terminology:
 - workspace stage: runtime rootfs plus exact repository checkout
 - dependency stage: workspace stage plus policy-constrained bootstrap and
   dependencies
+- services stage: dependency stage or workspace stage plus policy-constrained
+  service preparation state on disk
 
 Each stage output is a full sealed rootfs snapshot. Higher stages subsume lower
 stages. At runtime we do not mount `runtime + workspace + dependency` as a live
@@ -589,11 +591,12 @@ the resolved request inputs.
 
 The control plane can then resolve the highest reusable stage cache it trusts:
 
-1. dependency stage hit for the exact checkout plus optional changeset
-2. workspace stage hit for the exact checkout plus optional changeset
-3. exact-checkout workspace stage hit, followed by verified changeset apply
-4. runtime stage hit
-5. cold path
+1. services stage hit for the exact checkout plus optional changeset
+2. dependency stage hit for the exact checkout plus optional changeset
+3. workspace stage hit for the exact checkout plus optional changeset
+4. exact-checkout workspace stage hit, followed by verified changeset apply
+5. runtime stage hit
+6. cold path
 
 ## Production Flow
 
@@ -642,6 +645,18 @@ Shared stage-cache publication should be a host-controlled promotion pipeline.
 5. Snapshot the resulting root volume.
 6. Publish the dependency-stage metadata and storage reference atomically.
 
+### Publish services stage
+
+1. Start from a published dependency stage when one exists, otherwise from a
+   published workspace stage.
+2. Run the constrained services-preparation recipe in a temporary builder
+   sandbox.
+3. Stop any long-lived processes before snapshot publication; the cached value
+   is on-disk state, not live process memory.
+4. Verify the services-preparation recipe completed successfully.
+5. Snapshot the resulting root volume.
+6. Publish the services-stage metadata and storage reference atomically.
+
 ## Consumption Flow
 
 Warm-hit resolution should be simple.
@@ -652,12 +667,20 @@ Warm-hit resolution should be simple.
 4. Attach that single writable child as the VM root disk.
 5. Boot a fresh sandbox.
 
+If no services stage exists but a dependency stage does:
+
+1. clone the dependency stage
+2. run the constrained services-preparation recipe
+3. optionally publish a services stage if the policy allows promotion
+
 If no dependency stage exists but a workspace stage does:
 
 1. clone the workspace stage
 2. if needed, apply and verify the requested changeset
 3. run the constrained bootstrap recipe
 4. optionally publish a dependency stage if the policy allows promotion
+5. if needed, run the constrained services-preparation recipe
+6. optionally publish a services stage if the policy allows promotion
 
 If only the runtime stage exists:
 

--- a/docs/plans/repository-bootstrap-acceleration.md
+++ b/docs/plans/repository-bootstrap-acceleration.md
@@ -13,7 +13,7 @@ This plan keeps the existing repository-bootstrap contract:
 
 - Cleanroom resolves an exact remote URL and full commit SHA
 - the sandbox receives an exact committed checkout
-- warm hits continue to come from workspace/dependency stage caches
+- warm hits continue to come from services/dependency/workspace stage caches
 
 The change is in how Cleanroom prepares host-side git state for that exact
 checkout. Today the cold path eagerly creates and refreshes a full bare mirror
@@ -30,8 +30,8 @@ The target model is:
 - first back that abstraction with today’s mirror behavior
 - then add a Git-native partial/promisor backend
 - optionally seed cold hosts with bundle artifacts before talking to origin
-- later distribute workspace-stage caches across hosts to skip Git entirely on
-  a hit
+- later distribute services/dependency/workspace-stage caches across hosts to
+  skip Git entirely on a hit
 
 This plan intentionally leaves any git-aware VFS or lazy worktree mount out of
 scope.
@@ -61,7 +61,7 @@ makes it harder to evolve the transport layer independently.
 - Preserve exact-commit checkout semantics.
 - Keep the implementation backend-agnostic.
 - Keep host-side credentials and origin auth under Cleanroom control.
-- Preserve the current warm path through workspace/dependency stage caches.
+- Preserve the current warm path through services/dependency/workspace stage caches.
 - Create a clean boundary between Cleanroom repository semantics and
   `content-cache` transport artifacts.
 
@@ -82,7 +82,7 @@ Cleanroom owns:
 - canonical remote identity
 - exact commit resolution and verification
 - repository bootstrap policy checks
-- workspace/dependency-stage identity
+- services/dependency/workspace-stage identity
 - sandbox-visible checkout behavior
 
 `content-cache` should not become a Git worktree engine or a repository
@@ -117,9 +117,9 @@ interface should not require a full mirror forever.
 ### 4. Warm speed should still come from stage caches
 
 This plan accelerates the cold path, but it does not replace the layered cache
-model. The largest end-to-end wins still come from reusing workspace and
-dependency stages. Git acceleration reduces the cost of producing those stages
-on cold hosts.
+model. The largest end-to-end wins still come from reusing services,
+dependency, and workspace stages. Git acceleration reduces the cost of
+producing those stages on cold hosts.
 
 ## Proposed Architecture
 
@@ -212,9 +212,10 @@ Cleanroom can then use those artifacts opportunistically:
 This is the most promising Git-native accelerator for brand-new hosts in a
 fleet because it removes repeated full-history bootstrap from origin.
 
-### 5. Later distribute workspace-stage caches in Cleanroom
+### 5. Later distribute stage caches in Cleanroom
 
-Distributed workspace/dependency stages are a separate, higher-level feature.
+Distributed services/workspace/dependency stages are a separate, higher-level
+feature.
 
 They belong in Cleanroom because they are defined by:
 
@@ -240,8 +241,8 @@ Belongs in this repository:
 - dependency-stage key-file reads at exact commits
 - repository bootstrap orchestration
 - checkout-mode decisions such as sparse checkout, if introduced later
-- workspace/dependency-stage identity and cache publication
-- distributed workspace/dependency-stage caches
+- services/dependency/workspace-stage identity and cache publication
+- distributed services/dependency/workspace-stage caches
 
 ### `content-cache`
 
@@ -281,8 +282,9 @@ Work:
 Success criteria:
 
 - no change in bootstrap semantics
-- no change in workspace/dependency-stage cache keys
-- existing repository-bootstrap and dependency-stage tests still pass
+- no change in services/dependency/workspace-stage cache keys
+- existing repository-bootstrap, dependency-stage, and services-stage tests
+  still pass
 
 ### Phase 2: Partial/promisor repository store
 
@@ -315,7 +317,7 @@ Success criteria:
 
 - repo-aware `create`, `exec`, and `console` get faster on cold hosts
 - no user-visible behavior regression
-- warm workspace/dependency-stage hits remain unchanged
+- warm services/dependency/workspace-stage hits remain unchanged
 
 ### Phase 4: Bundle seeding via `content-cache`
 
@@ -339,8 +341,7 @@ Status: not started.
 
 Work:
 
-- export/import workspace-stage caches across hosts
-- later extend the same model to dependency stages
+- export/import services/dependency/workspace-stage caches across hosts
 
 Success criteria:
 
@@ -392,8 +393,10 @@ dependency-stage tests with fixture repositories that assert:
 - warm workspace-stage hits still skip repository bootstrap when expected
 - warm dependency-stage hits still skip both repository bootstrap and
   dependency bootstrap when expected
-- workspace/dependency-stage keys stay stable unless checkout semantics
-  intentionally change
+- warm services-stage hits still skip repository bootstrap plus dependency and
+  services bootstrap when expected
+- services/dependency/workspace-stage keys stay stable unless checkout
+  semantics intentionally change
 
 The same scenarios should be exercised against both repository-store backends
 where practical.
@@ -429,7 +432,7 @@ under a live daemon. That avoids false results from open metadata databases.
 Do not advance a phase unless it shows:
 
 - no correctness regressions in the contract and end-to-end suites
-- no unexpected workspace/dependency-stage cache-key churn
+- no unexpected services/dependency/workspace-stage cache-key churn
 - a measurable cold-host improvement on at least one representative large repo
 - no material warm-path regression relative to the current baseline
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -168,6 +168,9 @@ explicit request-time changeset input.
 - `sandbox.dependencies.command` defaults to unset; when present, Cleanroom runs that command in the repository workdir during sandbox creation and makes the result eligible for dependency-stage caching.
 - `sandbox.dependencies.command` accepts either a YAML string or a YAML sequence; strings execute as `sh -lc <value>`, and strings are the preferred form.
 - `sandbox.dependencies.key.files` defaults to empty; when present, Cleanroom hashes those repository-relative files from the exact committed checkout and includes them in the dependency-stage cache key.
+- `sandbox.services.command` defaults to unset; when present, Cleanroom runs that command in the repository workdir after dependency bootstrap during sandbox creation and makes the result eligible for services-stage caching.
+- `sandbox.services.command` accepts either a YAML string or a YAML sequence; strings execute as `sh -lc <value>`, and strings are the preferred form.
+- `sandbox.services.key.files` defaults to empty; when present, Cleanroom hashes those repository-relative files from the exact committed checkout and includes them in the services-stage cache key.
 - `sandbox.run.before` defaults to unset; when present, each execution runs that shell command in the repository workdir immediately before the requested command.
 - `sandbox.run.before` must be a YAML string or block string and executes as `sh -lc <value>`.
 - Policy schema intentionally has no field for implicit dirty-worktree inclusion; explicit local modifications are a separate request-time changeset input.
@@ -231,9 +234,10 @@ explicit request-time changeset input.
   - they materialize that checkout inside the sandbox before the command runs
   - they start commands in `repository.path`
   - when `sandbox.dependencies.command` is set, sandbox creation runs that dependency bootstrap command after repository bootstrap and may publish a reusable dependency stage for later warm hits
+  - when `sandbox.services.command` is set, sandbox creation runs that services bootstrap command after dependency bootstrap and may publish a reusable services stage for later warm hits
   - when `sandbox.run.before` is set, each execution runs that shell command immediately before the requested command
   - Cleanroom does not auto-detect or auto-wrap `mise`; use explicit commands such as `mise exec -- ...` when needed
-- When explicitly requested, top-level commands may package local modifications against committed `HEAD` into a reproducible changeset, send that changeset as a separate sandbox-creation input, and apply it after repository bootstrap and before dependency bootstrap or workload execution.
+- When explicitly requested, top-level commands may package local modifications against committed `HEAD` into a reproducible changeset, send that changeset as a separate sandbox-creation input, and apply it after repository bootstrap and before dependency bootstrap, services bootstrap, or workload execution.
 - `cleanroom sandbox create` remains the generic low-level surface and does not
   infer repository state from the current working tree or read `cleanroom.yaml`.
 - Without `--from`, `cleanroom sandbox create` synthesizes a repo-agnostic

--- a/internal/cachekey/cachekey.go
+++ b/internal/cachekey/cachekey.go
@@ -46,6 +46,14 @@ type DependencyStageInputs struct {
 	BootstrapRecipeDigest string
 }
 
+// ServicesStageInputs are the inputs that define the reusable services stage.
+type ServicesStageInputs struct {
+	ParentStageKey        string
+	CompiledPolicyHash    string
+	KeyFilesDigest        string
+	BootstrapRecipeDigest string
+}
+
 // RuntimeStageKey returns the canonical cache key for a runtime stage output.
 func RuntimeStageKey(in RuntimeStageInputs) string {
 	return buildStageKey("runtime", []component{
@@ -79,6 +87,16 @@ func WorkspaceStageKey(in WorkspaceStageInputs) string {
 func DependencyStageKey(in DependencyStageInputs) string {
 	return buildStageKey("dependency", []component{
 		{name: "workspace_key", value: canonicalReference(in.WorkspaceKey)},
+		{name: "compiled_policy_hash", value: canonicalDigest(in.CompiledPolicyHash)},
+		{name: "key_files_digest", value: canonicalDigest(in.KeyFilesDigest)},
+		{name: "bootstrap_recipe_digest", value: canonicalDigest(in.BootstrapRecipeDigest)},
+	})
+}
+
+// ServicesStageKey returns the canonical cache key for a services stage output.
+func ServicesStageKey(in ServicesStageInputs) string {
+	return buildStageKey("services", []component{
+		{name: "parent_stage_key", value: canonicalReference(in.ParentStageKey)},
 		{name: "compiled_policy_hash", value: canonicalDigest(in.CompiledPolicyHash)},
 		{name: "key_files_digest", value: canonicalDigest(in.KeyFilesDigest)},
 		{name: "bootstrap_recipe_digest", value: canonicalDigest(in.BootstrapRecipeDigest)},

--- a/internal/controlservice/dependency_stage.go
+++ b/internal/controlservice/dependency_stage.go
@@ -34,7 +34,7 @@ type dependencyStagePlan struct {
 	KeyFilesDigest          string
 }
 
-type dependencyKeyFileDigest struct {
+type stageKeyFileDigest struct {
 	Path    string `json:"path"`
 	SHA256  string `json:"sha256,omitempty"`
 	Deleted bool   `json:"deleted,omitempty"`
@@ -92,20 +92,24 @@ func (s *Service) finalizeDependencyStagePlan(
 }
 
 func (s *Service) dependencyStageKeyFilesDigest(ctx context.Context, repository *repositorycheckout.Checkout, changeset *repositorychangeset.Changeset, files []string) (string, error) {
+	return s.stageKeyFilesDigest(ctx, repository, changeset, files, dependencyStageName)
+}
+
+func (s *Service) stageKeyFilesDigest(ctx context.Context, repository *repositorycheckout.Checkout, changeset *repositorychangeset.Changeset, files []string, stageName string) (string, error) {
 	if len(files) == 0 {
 		return "", nil
 	}
 	if repository == nil {
-		return "", fmt.Errorf("dependency key files require a repository checkout")
+		return "", fmt.Errorf("%s key files require a repository checkout", stageName)
 	}
 	if s.RepositoryStore == nil {
-		return "", fmt.Errorf("dependency key files require repository store")
+		return "", fmt.Errorf("%s key files require repository store", stageName)
 	}
 	if changeset != nil {
 		var digest string
 		err := s.RepositoryStore.WithRepository(ctx, repository.RemoteURL, repository.CommitSHA, repositorystore.FetchHints{}, func(repoDir string) error {
 			var err error
-			digest, err = dependencyStageKeyFilesDigestWithChangeset(repoDir, changeset, files)
+			digest, err = stageKeyFilesDigestWithChangeset(repoDir, changeset, files, stageName)
 			return err
 		})
 		if err != nil {
@@ -116,7 +120,7 @@ func (s *Service) dependencyStageKeyFilesDigest(ctx context.Context, repository 
 	var digest string
 	err := s.RepositoryStore.WithRepository(ctx, repository.RemoteURL, repository.CommitSHA, repositorystore.FetchHints{}, func(repoDir string) error {
 		var err error
-		digest, err = dependencyStageKeyFilesDigestAtCommit(ctx, repoDir, repository.CommitSHA, files)
+		digest, err = stageKeyFilesDigestAtCommit(ctx, repoDir, repository.CommitSHA, files, stageName)
 		return err
 	})
 	if err != nil {
@@ -125,14 +129,14 @@ func (s *Service) dependencyStageKeyFilesDigest(ctx context.Context, repository 
 	return digest, nil
 }
 
-func dependencyStageKeyFilesDigestWithChangeset(repoDir string, changeset *repositorychangeset.Changeset, files []string) (string, error) {
-	manifest := make([]dependencyKeyFileDigest, 0, len(files))
+func stageKeyFilesDigestWithChangeset(repoDir string, changeset *repositorychangeset.Changeset, files []string, stageName string) (string, error) {
+	manifest := make([]stageKeyFileDigest, 0, len(files))
 	digests, err := changeset.DigestPathsFromBase(strings.TrimSpace(repoDir), files)
 	if err != nil {
-		return "", fmt.Errorf("read dependency key files from repository changeset: %w", err)
+		return "", fmt.Errorf("read %s key files from repository changeset: %w", stageName, err)
 	}
 	for _, file := range digests {
-		manifest = append(manifest, dependencyKeyFileDigest{
+		manifest = append(manifest, stageKeyFileDigest{
 			Path:    file.Path,
 			SHA256:  file.SHA256,
 			Deleted: file.Deleted,
@@ -141,26 +145,26 @@ func dependencyStageKeyFilesDigestWithChangeset(repoDir string, changeset *repos
 
 	payload, err := json.Marshal(manifest)
 	if err != nil {
-		return "", fmt.Errorf("marshal dependency key file manifest: %w", err)
+		return "", fmt.Errorf("marshal %s key file manifest: %w", stageName, err)
 	}
 
 	sum := sha256.Sum256(payload)
 	return "sha256:" + hex.EncodeToString(sum[:]), nil
 }
 
-func dependencyStageKeyFilesDigestAtCommit(ctx context.Context, repoDir, commitSHA string, files []string) (string, error) {
+func stageKeyFilesDigestAtCommit(ctx context.Context, repoDir, commitSHA string, files []string, stageName string) (string, error) {
 	trimmedCommitSHA := strings.TrimSpace(commitSHA)
 	if trimmedCommitSHA == "" {
-		return "", fmt.Errorf("dependency key file commit SHA is empty")
+		return "", fmt.Errorf("%s key file commit SHA is empty", stageName)
 	}
 
-	manifest := make([]dependencyKeyFileDigest, 0, len(files))
+	manifest := make([]stageKeyFileDigest, 0, len(files))
 	for _, file := range files {
 		digest, err := gitFileDigestAtCommit(ctx, strings.TrimSpace(repoDir), trimmedCommitSHA, file)
 		if err != nil {
-			return "", fmt.Errorf("read dependency key file %q: %w", file, err)
+			return "", fmt.Errorf("read %s key file %q: %w", stageName, file, err)
 		}
-		manifest = append(manifest, dependencyKeyFileDigest{
+		manifest = append(manifest, stageKeyFileDigest{
 			Path:   file,
 			SHA256: digest,
 		})
@@ -168,7 +172,7 @@ func dependencyStageKeyFilesDigestAtCommit(ctx context.Context, repoDir, commitS
 
 	payload, err := json.Marshal(manifest)
 	if err != nil {
-		return "", fmt.Errorf("marshal dependency key file manifest: %w", err)
+		return "", fmt.Errorf("marshal %s key file manifest: %w", stageName, err)
 	}
 
 	sum := sha256.Sum256(payload)
@@ -213,7 +217,7 @@ func (s *Service) lookupDependencyStageCache(ctx context.Context, backendName st
 		return cachestore.Record{}, false, observability.CacheLookupReasonPolicyHashMismatch, nil
 	}
 	if strings.TrimSpace(record.ParentCacheKey) != strings.TrimSpace(plan.ParentWorkspaceCacheKey) {
-		return cachestore.Record{}, false, observability.CacheLookupReasonWorkspaceParentChanged, nil
+		return cachestore.Record{}, false, observability.CacheLookupReasonParentStageChanged, nil
 	}
 	if !repositoryCheckoutsEqual(repositorycheckout.FromProto(record.Repository), repository) {
 		return cachestore.Record{}, false, observability.CacheLookupReasonRepositoryChanged, nil

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -193,6 +193,8 @@ func sandboxCreateSourceMetricValue(snapshotID, sourceKind string) string {
 		return "workspace_cache"
 	case "dependency stage cache":
 		return "dependency_cache"
+	case "services stage cache":
+		return "services_cache"
 	}
 	if strings.TrimSpace(snapshotID) != "" {
 		return "snapshot"
@@ -328,16 +330,22 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 
 	var replacedWorkspaceStageRecord *cachestore.Record
 	var replacedDependencyStageRecord *cachestore.Record
+	var replacedServicesStageRecord *cachestore.Record
 	workspaceStageRuntimeBaseKey := ""
 	workspaceStageKey := ""
 	workspaceStageCachingEnabled := false
 	dependencyStagePlan := dependencyStagePlan{}
 	dependencyStageBootstrapEnabled := false
 	dependencyStageCachingEnabled := false
+	servicesStagePlan := servicesStagePlan{}
+	servicesStageBootstrapEnabled := false
+	servicesStageCachingEnabled := false
 	var restoredWorkspaceResp *cleanroomv1.CreateSandboxResponse
+	var restoredDependencyResp *cleanroomv1.CreateSandboxResponse
 	snapshotAdapter, snapshotCapable := adapter.(backend.SnapshottingAdapter)
 	if repository != nil {
 		dependencyStagePlan, dependencyStageBootstrapEnabled = dependencyStagePlanForRepository(compiled, repository)
+		servicesStagePlan, servicesStageBootstrapEnabled = servicesStagePlanForRepository(compiled, repository)
 	}
 	if repository != nil && snapshotCapable && snapshotOperationsEnabledForBackend(backendName, s.Config) {
 		runtimeBaseKey, cacheable, err := s.workspaceStageRuntimeBaseKey(ctx, adapter, compiled, firecrackerCfg)
@@ -352,6 +360,80 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 				if err != nil {
 					dependencyStageCachingEnabled = false
 					s.logDependencyStageWarning("resolve dependency stage cache key", "", err)
+				}
+			}
+			if servicesStageBootstrapEnabled {
+				parentStageKey := workspaceStageKey
+				if dependencyStageBootstrapEnabled {
+					if dependencyStageCachingEnabled {
+						parentStageKey = dependencyStagePlan.CacheKey
+					} else {
+						parentStageKey = ""
+					}
+				}
+				if parentStageKey != "" {
+					servicesStagePlan, servicesStageCachingEnabled, err = s.finalizeServicesStagePlan(ctx, compiled, repository, changeset, parentStageKey, servicesStagePlan)
+					if err != nil {
+						servicesStageCachingEnabled = false
+						s.logServicesStageWarning("resolve services stage cache key", "", err)
+					}
+				}
+			}
+
+			if servicesStageCachingEnabled {
+				emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_SERVICES_STAGE_CACHE, "checking services stage cache")
+				var record cachestore.Record
+				var found bool
+				var lookupReason string
+				err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.lookup_services_stage_cache", cachePhaseAttributes(
+					observability.CacheStageServices,
+					observability.CacheOperationLookup,
+					repository,
+					attribute.String(observability.AttrBackend, backendName),
+				), func(ctx context.Context) error {
+					var lookupErr error
+					record, found, lookupReason, lookupErr = s.lookupServicesStageCache(ctx, backendName, compiled, repository, servicesStagePlan)
+					setCacheLookupSpanAttributes(ctx, found, lookupReason, lookupErr)
+					return lookupErr
+				})
+				if err != nil {
+					s.logServicesStageWarning("lookup services stage cache", "", err)
+				} else if found {
+					s.logServicesStageCacheHit(record)
+					emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_SERVICES_STAGE_CACHE, "services stage cache hit")
+					emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_RESTORE_SERVICES_STAGE_CACHE, "restoring services stage cache")
+					restoreReq := &cleanroomv1.CreateSandboxRequest{
+						Backend: backendName,
+						Options: req.GetOptions(),
+					}
+					var restoreResp *cleanroomv1.CreateSandboxResponse
+					restoreErr := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.restore_services_stage_cache", cachePhaseAttributes(
+						observability.CacheStageServices,
+						observability.CacheOperationRestore,
+						repository,
+						attribute.String(observability.AttrBackend, backendName),
+					), func(ctx context.Context) error {
+						var err error
+						restoreResp, err = s.createSandboxFromCacheRecord(ctx, restoreReq, compiled, record, reporter)
+						setCacheResultSpanAttribute(ctx, map[bool]string{true: observability.CacheResultFailed, false: observability.CacheResultRestored}[err != nil])
+						return err
+					})
+					if restoreErr == nil {
+						metricSourceKind = "services stage cache"
+						if cacheStore, err := s.cacheStoreOrErr(); err == nil {
+							if err := cacheStore.Touch(ctx, record.Stage, record.CacheKey); err != nil {
+								s.logServicesStageWarning("touch services stage cache", "", err)
+							}
+						}
+						s.logServicesStageRestore(record, restoreResp.GetSandbox().GetSandboxId())
+						return restoreResp, nil
+					}
+					recordCopy := record
+					replacedServicesStageRecord = &recordCopy
+					s.logServicesStageRestoreWarning(record, restoreErr)
+				} else {
+					s.logServicesStageCacheMiss(backendName, servicesStagePlan.CacheKey)
+					emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_SERVICES_STAGE_CACHE, "services stage cache miss")
 				}
 			}
 
@@ -401,76 +483,114 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 							}
 						}
 						s.logDependencyStageRestore(record, restoreResp.GetSandbox().GetSandboxId())
-						return restoreResp, nil
+						if !servicesStageBootstrapEnabled {
+							return restoreResp, nil
+						}
+						restoredDependencyResp = restoreResp
+					} else {
+						recordCopy := record
+						replacedDependencyStageRecord = &recordCopy
+						s.logDependencyStageRestoreWarning(record, restoreErr)
 					}
-					recordCopy := record
-					replacedDependencyStageRecord = &recordCopy
-					s.logDependencyStageRestoreWarning(record, restoreErr)
 				} else {
 					s.logDependencyStageCacheMiss(backendName, dependencyStagePlan.CacheKey)
 					emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_DEPENDENCY_STAGE_CACHE, "dependency stage cache miss")
 				}
 			}
 
-			emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_WORKSPACE_STAGE_CACHE, "checking workspace stage cache")
-			var record cachestore.Record
-			var found bool
-			var lookupReason string
-			err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.lookup_workspace_stage_cache", cachePhaseAttributes(
-				observability.CacheStageWorkspace,
-				observability.CacheOperationLookup,
-				repository,
-				attribute.String(observability.AttrBackend, backendName),
-			), func(ctx context.Context) error {
-				var lookupErr error
-				record, found, lookupReason, lookupErr = s.lookupWorkspaceStageCache(ctx, backendName, compiled, workspaceStageRuntimeBaseKey, repository, changeset)
-				setCacheLookupSpanAttributes(ctx, found, lookupReason, lookupErr)
-				return lookupErr
-			})
-			if err != nil {
-				s.logWorkspaceStageWarning("lookup workspace stage cache", "", err)
-			} else if found {
-				s.logWorkspaceStageCacheHit(record)
-				emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_WORKSPACE_STAGE_CACHE, "workspace stage cache hit")
-				emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_RESTORE_WORKSPACE_STAGE_CACHE, "restoring workspace stage cache")
-				restoreReq := &cleanroomv1.CreateSandboxRequest{
-					Backend: backendName,
-					Options: req.GetOptions(),
-				}
-				var restoreResp *cleanroomv1.CreateSandboxResponse
-				restoreErr := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.restore_workspace_stage_cache", cachePhaseAttributes(
+			if restoredDependencyResp == nil {
+				emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_WORKSPACE_STAGE_CACHE, "checking workspace stage cache")
+				var record cachestore.Record
+				var found bool
+				var lookupReason string
+				err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.lookup_workspace_stage_cache", cachePhaseAttributes(
 					observability.CacheStageWorkspace,
-					observability.CacheOperationRestore,
+					observability.CacheOperationLookup,
 					repository,
 					attribute.String(observability.AttrBackend, backendName),
 				), func(ctx context.Context) error {
-					var err error
-					restoreResp, err = s.createSandboxFromCacheRecord(ctx, restoreReq, compiled, record, reporter)
-					setCacheResultSpanAttribute(ctx, map[bool]string{true: observability.CacheResultFailed, false: observability.CacheResultRestored}[err != nil])
-					return err
+					var lookupErr error
+					record, found, lookupReason, lookupErr = s.lookupWorkspaceStageCache(ctx, backendName, compiled, workspaceStageRuntimeBaseKey, repository, changeset)
+					setCacheLookupSpanAttributes(ctx, found, lookupReason, lookupErr)
+					return lookupErr
 				})
-				if restoreErr == nil {
-					metricSourceKind = "workspace stage cache"
-					if cacheStore, err := s.cacheStoreOrErr(); err == nil {
-						if err := cacheStore.Touch(ctx, record.Stage, record.CacheKey); err != nil {
-							s.logWorkspaceStageWarning("touch workspace stage cache", "", err)
+				if err != nil {
+					s.logWorkspaceStageWarning("lookup workspace stage cache", "", err)
+				} else if found {
+					s.logWorkspaceStageCacheHit(record)
+					emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_WORKSPACE_STAGE_CACHE, "workspace stage cache hit")
+					emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_RESTORE_WORKSPACE_STAGE_CACHE, "restoring workspace stage cache")
+					restoreReq := &cleanroomv1.CreateSandboxRequest{
+						Backend: backendName,
+						Options: req.GetOptions(),
+					}
+					var restoreResp *cleanroomv1.CreateSandboxResponse
+					restoreErr := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.restore_workspace_stage_cache", cachePhaseAttributes(
+						observability.CacheStageWorkspace,
+						observability.CacheOperationRestore,
+						repository,
+						attribute.String(observability.AttrBackend, backendName),
+					), func(ctx context.Context) error {
+						var err error
+						restoreResp, err = s.createSandboxFromCacheRecord(ctx, restoreReq, compiled, record, reporter)
+						setCacheResultSpanAttribute(ctx, map[bool]string{true: observability.CacheResultFailed, false: observability.CacheResultRestored}[err != nil])
+						return err
+					})
+					if restoreErr == nil {
+						metricSourceKind = "workspace stage cache"
+						if cacheStore, err := s.cacheStoreOrErr(); err == nil {
+							if err := cacheStore.Touch(ctx, record.Stage, record.CacheKey); err != nil {
+								s.logWorkspaceStageWarning("touch workspace stage cache", "", err)
+							}
 						}
+						s.logWorkspaceStageRestore(record, restoreResp.GetSandbox().GetSandboxId())
+						if !dependencyStageBootstrapEnabled && !servicesStageBootstrapEnabled {
+							return restoreResp, nil
+						}
+						restoredWorkspaceResp = restoreResp
+					} else {
+						recordCopy := record
+						replacedWorkspaceStageRecord = &recordCopy
+						s.logWorkspaceStageRestoreWarning(record, restoreErr)
 					}
-					s.logWorkspaceStageRestore(record, restoreResp.GetSandbox().GetSandboxId())
-					if !dependencyStageBootstrapEnabled {
-						return restoreResp, nil
-					}
-					restoredWorkspaceResp = restoreResp
 				} else {
-					recordCopy := record
-					replacedWorkspaceStageRecord = &recordCopy
-					s.logWorkspaceStageRestoreWarning(record, restoreErr)
+					s.logWorkspaceStageCacheMiss(backendName, workspaceStageKey)
+					emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_WORKSPACE_STAGE_CACHE, "workspace stage cache miss")
 				}
-			} else {
-				s.logWorkspaceStageCacheMiss(backendName, workspaceStageKey)
-				emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_WORKSPACE_STAGE_CACHE, "workspace stage cache miss")
 			}
 		}
+	}
+
+	if restoredDependencyResp != nil {
+		sandboxID := restoredDependencyResp.GetSandbox().GetSandboxId()
+		span.SetAttributes(attribute.String("cleanroom.sandbox.id", sandboxID))
+		if servicesStageBootstrapEnabled {
+			bootstrapAttrs := []attribute.KeyValue{
+				attribute.String(observability.AttrBackend, backendName),
+				attribute.String(observability.AttrSandboxID, sandboxID),
+				attribute.Int(observability.AttrCommandArgc, len(servicesStagePlan.BootstrapCommand)),
+			}
+			if repository != nil {
+				if commitSHA := strings.TrimSpace(repository.CommitSHA); commitSHA != "" {
+					bootstrapAttrs = append(bootstrapAttrs, attribute.String(observability.AttrRepositoryCommitSHA, commitSHA))
+				}
+			}
+			emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_SERVICES, "running services bootstrap")
+			if err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.bootstrap_services", bootstrapAttrs, func(ctx context.Context) error {
+				return s.bootstrapServicesStageInPersistentSandbox(ctx, adapter, sandboxID, compiled, firecrackerCfg, servicesStagePlan, reporter)
+			}); err != nil {
+				cleanupErr := s.terminateCreatedSandbox(context.Background(), adapter, sandboxID)
+				if cleanupErr != nil {
+					return nil, fmt.Errorf("bootstrap services stage: %w; cleanup failed: %v", err, cleanupErr)
+				}
+				return nil, fmt.Errorf("bootstrap services stage: %w", err)
+			}
+			if servicesStageCachingEnabled {
+				emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_PUBLISH_SERVICES_STAGE_CACHE, "publishing services stage cache")
+				s.maybePublishServicesStageCache(ctx, snapshotAdapter, sandboxID, backendName, compiled, firecrackerCfg, repository, changeset, servicesStagePlan, replacedServicesStageRecord)
+			}
+		}
+		return restoredDependencyResp, nil
 	}
 
 	if restoredWorkspaceResp != nil {
@@ -500,6 +620,32 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 			if dependencyStageCachingEnabled {
 				emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_PUBLISH_DEPENDENCY_STAGE_CACHE, "publishing dependency stage cache")
 				s.maybePublishDependencyStageCache(ctx, snapshotAdapter, sandboxID, backendName, compiled, firecrackerCfg, repository, changeset, dependencyStagePlan, replacedDependencyStageRecord)
+			}
+		}
+		if servicesStageBootstrapEnabled {
+			bootstrapAttrs := []attribute.KeyValue{
+				attribute.String(observability.AttrBackend, backendName),
+				attribute.String(observability.AttrSandboxID, sandboxID),
+				attribute.Int(observability.AttrCommandArgc, len(servicesStagePlan.BootstrapCommand)),
+			}
+			if repository != nil {
+				if commitSHA := strings.TrimSpace(repository.CommitSHA); commitSHA != "" {
+					bootstrapAttrs = append(bootstrapAttrs, attribute.String(observability.AttrRepositoryCommitSHA, commitSHA))
+				}
+			}
+			emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_SERVICES, "running services bootstrap")
+			if err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.bootstrap_services", bootstrapAttrs, func(ctx context.Context) error {
+				return s.bootstrapServicesStageInPersistentSandbox(ctx, adapter, sandboxID, compiled, firecrackerCfg, servicesStagePlan, reporter)
+			}); err != nil {
+				cleanupErr := s.terminateCreatedSandbox(context.Background(), adapter, sandboxID)
+				if cleanupErr != nil {
+					return nil, fmt.Errorf("bootstrap services stage: %w; cleanup failed: %v", err, cleanupErr)
+				}
+				return nil, fmt.Errorf("bootstrap services stage: %w", err)
+			}
+			if servicesStageCachingEnabled {
+				emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_PUBLISH_SERVICES_STAGE_CACHE, "publishing services stage cache")
+				s.maybePublishServicesStageCache(ctx, snapshotAdapter, sandboxID, backendName, compiled, firecrackerCfg, repository, changeset, servicesStagePlan, replacedServicesStageRecord)
 			}
 		}
 		return restoredWorkspaceResp, nil
@@ -615,6 +761,37 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 				attribute.String("cleanroom.sandbox.id", sandboxID),
 			}, func(ctx context.Context) error {
 				s.maybePublishDependencyStageCache(ctx, snapshotAdapter, sandboxID, backendName, compiled, firecrackerCfg, repository, changeset, dependencyStagePlan, replacedDependencyStageRecord)
+				return nil
+			})
+		}
+	}
+	if servicesStageBootstrapEnabled {
+		bootstrapAttrs := []attribute.KeyValue{
+			attribute.String(observability.AttrBackend, backendName),
+			attribute.String(observability.AttrSandboxID, sandboxID),
+			attribute.Int(observability.AttrCommandArgc, len(servicesStagePlan.BootstrapCommand)),
+		}
+		if repository != nil {
+			if commitSHA := strings.TrimSpace(repository.CommitSHA); commitSHA != "" {
+				bootstrapAttrs = append(bootstrapAttrs, attribute.String(observability.AttrRepositoryCommitSHA, commitSHA))
+			}
+		}
+		emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_SERVICES, "running services bootstrap")
+		if err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.bootstrap_services", bootstrapAttrs, func(ctx context.Context) error {
+			return s.bootstrapServicesStageInPersistentSandbox(ctx, adapter, sandboxID, compiled, firecrackerCfg, servicesStagePlan, reporter)
+		}); err != nil {
+			if terminateErr := s.terminateCreatedSandbox(context.Background(), adapter, sandboxID); terminateErr != nil {
+				return nil, fmt.Errorf("bootstrap services stage: %w; cleanup failed: %v", err, terminateErr)
+			}
+			return nil, fmt.Errorf("bootstrap services stage: %w", err)
+		}
+		if servicesStageCachingEnabled && snapshotCapable {
+			emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_PUBLISH_SERVICES_STAGE_CACHE, "publishing services stage cache")
+			_ = s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.publish_services_stage_cache", []attribute.KeyValue{
+				attribute.String("cleanroom.backend", backendName),
+				attribute.String("cleanroom.sandbox.id", sandboxID),
+			}, func(ctx context.Context) error {
+				s.maybePublishServicesStageCache(ctx, snapshotAdapter, sandboxID, backendName, compiled, firecrackerCfg, repository, changeset, servicesStagePlan, replacedServicesStageRecord)
 				return nil
 			})
 		}

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -311,6 +311,18 @@ func testRepositoryDependencyPolicy() *cleanroomv1.Policy {
 	return policyProto
 }
 
+func testRepositoryDependencyAndServicesPolicy() *cleanroomv1.Policy {
+	policyProto := testRepositoryDependencyPolicy()
+	policyProto.Services = &cleanroomv1.PolicyServices{
+		Docker:  &cleanroomv1.PolicyDockerService{Required: true},
+		Command: []string{"docker", "compose", "up", "-d", "postgres"},
+		Key: &cleanroomv1.PolicyDependencyKey{
+			Files: []string{"docker-compose.yml"},
+		},
+	}
+	return policyProto
+}
+
 func testRepositoryRunBeforePolicy() *cleanroomv1.Policy {
 	policyProto := testRepositoryPolicy()
 	policyProto.Run = &cleanroomv1.PolicyRun{
@@ -669,6 +681,75 @@ func TestCreateSandboxTracesDependencyCacheHitAttributes(t *testing.T) {
 	requireSpanMissingAttribute(t, lookupSpan, observability.AttrCacheLookupReason)
 	requireSpanAttributeValue(t, restoreSpan, observability.AttrRepositoryCommitSHA, repositoryCommitSHA)
 	requireSpanAttributeValue(t, restoreSpan, observability.AttrCacheStage, observability.CacheStageDependency)
+	requireSpanAttributeValue(t, restoreSpan, observability.AttrCacheOperation, observability.CacheOperationRestore)
+	requireSpanAttributeValue(t, restoreSpan, observability.AttrCacheResult, observability.CacheResultRestored)
+}
+
+func TestCreateSandboxTracesServicesCacheHitAttributes(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	store := newMemorySnapshotStore()
+	adapter := &stubAdapter{}
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"go.mod":             "module example.com/test\n\ngo 1.26.2\n",
+		"go.sum":             "example.com/test v0.0.0 h1:abc123\n",
+		"docker-compose.yml": "services:\n  postgres:\n    image: postgres:17\n",
+	})
+	svc := newTestServiceWithSnapshotStore(adapter, store)
+	svc.RepositoryStore = mirrors
+
+	req := &cleanroomv1.CreateSandboxRequest{
+		Policy:             testRepositoryDependencyAndServicesPolicy(),
+		RepositoryCheckout: repositoryCheckout,
+	}
+	if _, err := svc.CreateSandbox(context.Background(), req); err != nil {
+		t.Fatalf("first CreateSandbox returned error: %v", err)
+	}
+	mirrors.err = errors.New("offline")
+
+	recorder := tracetest.NewSpanRecorder()
+	tracerProvider := trace.NewTracerProvider()
+	tracerProvider.RegisterSpanProcessor(recorder)
+	defer func() {
+		_ = tracerProvider.Shutdown(context.Background())
+	}()
+	obs, err := observability.NewWithTracerProvider(tracerProvider)
+	if err != nil {
+		t.Fatalf("NewWithTracerProvider returned error: %v", err)
+	}
+	svc.Observability = obs
+
+	resp, err := svc.CreateSandbox(context.Background(), req)
+	if err != nil {
+		t.Fatalf("second CreateSandbox returned error: %v", err)
+	}
+	if got, want := resp.GetSourceKind(), "services stage cache"; got != want {
+		t.Fatalf("unexpected response source kind: got %q want %q", got, want)
+	}
+
+	spans := recorder.Ended()
+	lookupSpan := findEndedSpanByName(spans, "cleanroom.sandbox.lookup_services_stage_cache")
+	if lookupSpan == nil {
+		t.Fatalf("expected cleanroom.sandbox.lookup_services_stage_cache span, got spans %#v", spans)
+	}
+	restoreSpan := findEndedSpanByName(spans, "cleanroom.sandbox.restore_services_stage_cache")
+	if restoreSpan == nil {
+		t.Fatalf("expected cleanroom.sandbox.restore_services_stage_cache span, got spans %#v", spans)
+	}
+	if dependencyLookupSpan := findEndedSpanByName(spans, "cleanroom.sandbox.lookup_dependency_stage_cache"); dependencyLookupSpan != nil {
+		t.Fatalf("expected services cache hit to skip dependency lookup span, got spans %#v", spans)
+	}
+	if workspaceLookupSpan := findEndedSpanByName(spans, "cleanroom.sandbox.lookup_workspace_stage_cache"); workspaceLookupSpan != nil {
+		t.Fatalf("expected services cache hit to skip workspace lookup span, got spans %#v", spans)
+	}
+
+	repositoryCommitSHA := repositoryCheckout.GetCommitSha()
+	requireSpanAttributeValue(t, lookupSpan, observability.AttrRepositoryCommitSHA, repositoryCommitSHA)
+	requireSpanAttributeValue(t, lookupSpan, observability.AttrCacheStage, observability.CacheStageServices)
+	requireSpanAttributeValue(t, lookupSpan, observability.AttrCacheOperation, observability.CacheOperationLookup)
+	requireSpanAttributeValue(t, lookupSpan, observability.AttrCacheResult, observability.CacheResultHit)
+	requireSpanMissingAttribute(t, lookupSpan, observability.AttrCacheLookupReason)
+	requireSpanAttributeValue(t, restoreSpan, observability.AttrRepositoryCommitSHA, repositoryCommitSHA)
+	requireSpanAttributeValue(t, restoreSpan, observability.AttrCacheStage, observability.CacheStageServices)
 	requireSpanAttributeValue(t, restoreSpan, observability.AttrCacheOperation, observability.CacheOperationRestore)
 	requireSpanAttributeValue(t, restoreSpan, observability.AttrCacheResult, observability.CacheResultRestored)
 }
@@ -2866,6 +2947,305 @@ func TestCreateSandboxReusesDependencyStageCacheForConfiguredDependencies(t *tes
 	}
 	if got, want := adapter.provisionFromSnapshotReq.SnapshotID, snapshotReqs[1].SnapshotID; got != want {
 		t.Fatalf("unexpected dependency stage snapshot id on warm hit: got %q want %q", got, want)
+	}
+}
+
+func TestCreateSandboxPublishesServicesStageCacheForConfiguredServices(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	store := newMemorySnapshotStore()
+	adapter := &stubAdapter{}
+	var (
+		runMu        sync.Mutex
+		runCommands  [][]string
+		snapshotReqs []backend.SnapshotRequest
+	)
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+		runMu.Lock()
+		runCommands = append(runCommands, append([]string(nil), req.Command...))
+		runMu.Unlock()
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+	}
+	adapter.createSnapshotFn = func(_ context.Context, req backend.SnapshotRequest) (*backend.SnapshotResult, error) {
+		snapshotReqs = append(snapshotReqs, req)
+		return &backend.SnapshotResult{StorageRef: "/snapshots/" + req.SnapshotID + ".ext4"}, nil
+	}
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"go.mod":             "module example.com/test\n\ngo 1.26.2\n",
+		"go.sum":             "example.com/test v0.0.0 h1:abc123\n",
+		"docker-compose.yml": "services:\n  postgres:\n    image: postgres:17\n",
+	})
+	svc := newTestServiceWithSnapshotStore(adapter, store)
+	svc.RepositoryStore = mirrors
+
+	if _, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Policy:             testRepositoryDependencyAndServicesPolicy(),
+		RepositoryCheckout: repositoryCheckout,
+	}); err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+
+	if got, want := adapter.provisionCalls, 1; got != want {
+		t.Fatalf("unexpected provision call count: got %d want %d", got, want)
+	}
+	if got, want := adapter.runCalls, 3; got != want {
+		t.Fatalf("expected repository + dependency + services bootstrap executions, got %d want %d", got, want)
+	}
+	if got, want := adapter.createSnapshotCalls, 3; got != want {
+		t.Fatalf("expected workspace + dependency + services stage snapshots, got %d want %d", got, want)
+	}
+	if got, want := len(snapshotReqs), 3; got != want {
+		t.Fatalf("expected three snapshot publish requests, got %d want %d", got, want)
+	}
+
+	cacheStore, ok := svc.CacheStore.(*memoryCacheStore)
+	if !ok {
+		t.Fatalf("expected memory cache store, got %T", svc.CacheStore)
+	}
+	records, err := cacheStore.List(context.Background())
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if got, want := len(records), 3; got != want {
+		t.Fatalf("expected workspace + dependency + services cache records, got %d want %d", got, want)
+	}
+
+	var (
+		workspaceRecord  *cachestore.Record
+		dependencyRecord *cachestore.Record
+		servicesRecord   *cachestore.Record
+	)
+	for i := range records {
+		record := records[i]
+		switch record.Stage {
+		case workspaceStageName:
+			recordCopy := record
+			workspaceRecord = &recordCopy
+		case dependencyStageName:
+			recordCopy := record
+			dependencyRecord = &recordCopy
+		case servicesStageName:
+			recordCopy := record
+			servicesRecord = &recordCopy
+		}
+	}
+	if workspaceRecord == nil {
+		t.Fatal("expected published workspace stage cache record")
+	}
+	if dependencyRecord == nil {
+		t.Fatal("expected published dependency stage cache record")
+	}
+	if servicesRecord == nil {
+		t.Fatal("expected published services stage cache record")
+	}
+
+	compiled, err := policy.FromProto(testRepositoryDependencyAndServicesPolicy())
+	if err != nil {
+		t.Fatalf("FromProto returned error: %v", err)
+	}
+	repository := repositorycheckout.FromProto(repositoryCheckout)
+	workspaceKey := workspaceStageCacheKey("firecracker", "runtime-base:test", compiled.Hash, repository, nil)
+	dependencyPlan, ok := dependencyStagePlanForRepository(compiled, repository)
+	if !ok {
+		t.Fatal("expected configured dependency stage plan to be enabled")
+	}
+	dependencyPlan, ok, err = svc.finalizeDependencyStagePlan(context.Background(), compiled, repository, nil, workspaceKey, dependencyPlan)
+	if err != nil {
+		t.Fatalf("finalizeDependencyStagePlan returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected configured dependency stage cache plan to be enabled")
+	}
+	servicesPlan, ok := servicesStagePlanForRepository(compiled, repository)
+	if !ok {
+		t.Fatal("expected configured services stage plan to be enabled")
+	}
+	servicesPlan, ok, err = svc.finalizeServicesStagePlan(context.Background(), compiled, repository, nil, dependencyPlan.CacheKey, servicesPlan)
+	if err != nil {
+		t.Fatalf("finalizeServicesStagePlan returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected configured services stage cache plan to be enabled")
+	}
+	if got, want := servicesRecord.CacheKey, servicesPlan.CacheKey; got != want {
+		t.Fatalf("unexpected services stage cache key: got %q want %q", got, want)
+	}
+	if got, want := servicesRecord.ParentCacheKey, dependencyPlan.CacheKey; got != want {
+		t.Fatalf("unexpected services stage parent cache key: got %q want %q", got, want)
+	}
+
+	runMu.Lock()
+	defer runMu.Unlock()
+	if got, want := len(runCommands), 3; got != want {
+		t.Fatalf("expected three bootstrap commands, got %d want %d", got, want)
+	}
+	servicesBootstrap := strings.Join(runCommands[2], " ")
+	if !repositoryWrappedCommandContains(servicesBootstrap, `exec 'docker' 'compose' 'up' '-d' 'postgres'`) {
+		t.Fatalf("expected services bootstrap to preserve explicit docker compose command, got %q", servicesBootstrap)
+	}
+}
+
+func TestCreateSandboxReusesServicesStageCacheForConfiguredServices(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	store := newMemorySnapshotStore()
+	adapter := &stubAdapter{}
+	var snapshotReqs []backend.SnapshotRequest
+	adapter.createSnapshotFn = func(_ context.Context, req backend.SnapshotRequest) (*backend.SnapshotResult, error) {
+		snapshotReqs = append(snapshotReqs, req)
+		return &backend.SnapshotResult{StorageRef: "/snapshots/" + req.SnapshotID + ".ext4"}, nil
+	}
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"go.mod":             "module example.com/test\n\ngo 1.26.2\n",
+		"go.sum":             "example.com/test v0.0.0 h1:abc123\n",
+		"docker-compose.yml": "services:\n  postgres:\n    image: postgres:17\n",
+	})
+	svc := newTestServiceWithSnapshotStore(adapter, store)
+	svc.RepositoryStore = mirrors
+
+	req := &cleanroomv1.CreateSandboxRequest{
+		Policy:             testRepositoryDependencyAndServicesPolicy(),
+		RepositoryCheckout: repositoryCheckout,
+	}
+
+	if _, err := svc.CreateSandbox(context.Background(), req); err != nil {
+		t.Fatalf("first CreateSandbox returned error: %v", err)
+	}
+	mirrors.err = errors.New("offline")
+	secondResp, err := svc.CreateSandbox(context.Background(), req)
+	if err != nil {
+		t.Fatalf("second CreateSandbox returned error: %v", err)
+	}
+	if got, want := secondResp.GetSourceKind(), "services stage cache"; got != want {
+		t.Fatalf("unexpected response source kind: got %q want %q", got, want)
+	}
+	if got, want := secondResp.GetSandbox().GetSourceKind(), "services stage cache"; got != want {
+		t.Fatalf("unexpected sandbox source kind: got %q want %q", got, want)
+	}
+	records, err := svc.CacheStore.List(context.Background())
+	if err != nil {
+		t.Fatalf("List cache records returned error: %v", err)
+	}
+	var servicesRecord *cachestore.Record
+	for i := range records {
+		if records[i].Stage == servicesStageName {
+			servicesRecord = &records[i]
+			break
+		}
+	}
+	if servicesRecord == nil {
+		t.Fatal("expected published services stage cache record")
+	}
+	if got, want := secondResp.GetSourceId(), servicesRecord.CacheKey; got != want {
+		t.Fatalf("unexpected response source id: got %q want %q", got, want)
+	}
+	if got, want := secondResp.GetBackingSnapshotId(), servicesRecord.BackingSnapshotID; got != want {
+		t.Fatalf("unexpected response backing snapshot id: got %q want %q", got, want)
+	}
+	if got, want := secondResp.GetSandbox().GetSourceId(), servicesRecord.CacheKey; got != want {
+		t.Fatalf("unexpected sandbox source id: got %q want %q", got, want)
+	}
+	if got, want := secondResp.GetSandbox().GetBackingSnapshotId(), servicesRecord.BackingSnapshotID; got != want {
+		t.Fatalf("unexpected sandbox backing snapshot id: got %q want %q", got, want)
+	}
+
+	if got, want := adapter.provisionCalls, 1; got != want {
+		t.Fatalf("expected warm services-stage hit to avoid reprovision bootstrap path, got %d want %d", got, want)
+	}
+	if got, want := adapter.provisionFromSnapshotCalls, 1; got != want {
+		t.Fatalf("expected warm services-stage hit to restore once, got %d want %d", got, want)
+	}
+	if got, want := adapter.runCalls, 3; got != want {
+		t.Fatalf("expected warm services-stage hit to skip bootstrap executions, got %d want %d", got, want)
+	}
+	if got, want := adapter.createSnapshotCalls, 3; got != want {
+		t.Fatalf("expected warm services-stage hit to avoid republishing stage caches, got %d want %d", got, want)
+	}
+	if got, want := len(snapshotReqs), 3; got != want {
+		t.Fatalf("expected one workspace, one dependency, and one services snapshot publish, got %d want %d", got, want)
+	}
+	if got, want := mirrors.calls, 1; got != want {
+		t.Fatalf("expected only the first repository bootstrap to ensure the exact commit, got %d want %d", got, want)
+	}
+	if got, want := mirrors.mirrorPathCalls, 4; got != want {
+		t.Fatalf("expected dependency and services stage keying to use local mirror paths on both attempts, got %d want %d", got, want)
+	}
+	if got, want := adapter.provisionFromSnapshotReq.StorageRef, "/snapshots/"+snapshotReqs[2].SnapshotID+".ext4"; got != want {
+		t.Fatalf("unexpected services stage storage ref on warm hit: got %q want %q", got, want)
+	}
+	if got, want := adapter.provisionFromSnapshotReq.SnapshotID, snapshotReqs[2].SnapshotID; got != want {
+		t.Fatalf("unexpected services stage snapshot id on warm hit: got %q want %q", got, want)
+	}
+}
+
+func TestCreateSandboxBootstrapsServicesAfterDependencyStageRestoreWithoutServicesStageCache(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	store := newMemorySnapshotStore()
+	adapter := &stubAdapter{}
+	var snapshotReqs []backend.SnapshotRequest
+	adapter.createSnapshotFn = func(_ context.Context, req backend.SnapshotRequest) (*backend.SnapshotResult, error) {
+		snapshotReqs = append(snapshotReqs, req)
+		return &backend.SnapshotResult{StorageRef: "/snapshots/" + req.SnapshotID + ".ext4"}, nil
+	}
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"go.mod":             "module example.com/test\n\ngo 1.26.2\n",
+		"go.sum":             "example.com/test v0.0.0 h1:abc123\n",
+		"docker-compose.yml": "services:\n  postgres:\n    image: postgres:17\n",
+	})
+	svc := newTestServiceWithSnapshotStore(adapter, store)
+	svc.RepositoryStore = mirrors
+
+	req := &cleanroomv1.CreateSandboxRequest{
+		Policy:             testRepositoryDependencyAndServicesPolicy(),
+		RepositoryCheckout: repositoryCheckout,
+	}
+
+	if _, err := svc.CreateSandbox(context.Background(), req); err != nil {
+		t.Fatalf("first CreateSandbox returned error: %v", err)
+	}
+
+	records, err := svc.CacheStore.List(context.Background())
+	if err != nil {
+		t.Fatalf("List cache records returned error: %v", err)
+	}
+	var dependencyRecord *cachestore.Record
+	for _, record := range records {
+		switch record.Stage {
+		case dependencyStageName:
+			recordCopy := record
+			dependencyRecord = &recordCopy
+		case servicesStageName:
+			if err := svc.CacheStore.Delete(context.Background(), record.Stage, record.CacheKey); err != nil {
+				t.Fatalf("Delete services cache record returned error: %v", err)
+			}
+		}
+	}
+	if dependencyRecord == nil {
+		t.Fatal("expected published dependency stage cache record")
+	}
+
+	secondResp, err := svc.CreateSandbox(context.Background(), req)
+	if err != nil {
+		t.Fatalf("second CreateSandbox returned error: %v", err)
+	}
+	if got, want := secondResp.GetSourceKind(), "dependency stage cache"; got != want {
+		t.Fatalf("unexpected response source kind: got %q want %q", got, want)
+	}
+	if got, want := adapter.provisionCalls, 1; got != want {
+		t.Fatalf("expected dependency-stage restore path to avoid cold provision, got %d want %d", got, want)
+	}
+	if got, want := adapter.provisionFromSnapshotCalls, 1; got != want {
+		t.Fatalf("expected exactly one dependency-stage restore, got %d want %d", got, want)
+	}
+	if got, want := adapter.runCalls, 4; got != want {
+		t.Fatalf("expected only one extra services bootstrap after dependency restore, got %d want %d", got, want)
+	}
+	if got, want := adapter.createSnapshotCalls, 4; got != want {
+		t.Fatalf("expected only one extra services-stage snapshot publish, got %d want %d", got, want)
+	}
+	if got, want := adapter.provisionFromSnapshotReq.SnapshotID, dependencyRecord.BackingSnapshotID; got != want {
+		t.Fatalf("unexpected restore snapshot id: got %q want %q", got, want)
+	}
+	if got, want := len(snapshotReqs), 4; got != want {
+		t.Fatalf("expected one replacement services-stage snapshot publish, got %d want %d", got, want)
 	}
 }
 

--- a/internal/controlservice/services_stage.go
+++ b/internal/controlservice/services_stage.go
@@ -1,0 +1,331 @@
+package controlservice
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/cachekey"
+	"github.com/buildkite/cleanroom/internal/cachestore"
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+	"github.com/buildkite/cleanroom/internal/observability"
+	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/buildkite/cleanroom/internal/repositorychangeset"
+	"github.com/buildkite/cleanroom/internal/repositorycheckout"
+)
+
+const (
+	servicesStageName            = "services"
+	servicesStageProducerVersion = "cleanroom/services-stage-v1"
+)
+
+type servicesStagePlan struct {
+	CacheKey              string
+	ParentStageCacheKey   string
+	BootstrapCommand      []string
+	BootstrapRecipeDigest string
+	KeyFiles              []string
+	KeyFilesDigest        string
+}
+
+func servicesStagePlanForRepository(compiled *policy.CompiledPolicy, repository *repositorycheckout.Checkout) (servicesStagePlan, bool) {
+	if compiled == nil || repository == nil || !compiled.Services.BootstrapEnabled() {
+		return servicesStagePlan{}, false
+	}
+
+	bootstrapCommand := repositorycheckout.WrapCommandInWorkdir(compiled.Services.Command, repository)
+	bootstrapRecipeDigest := repositorycheckout.WorkdirRecipeDigest(compiled.Services.Command, repository)
+	if len(bootstrapCommand) == 0 || strings.TrimSpace(bootstrapRecipeDigest) == "" {
+		return servicesStagePlan{}, false
+	}
+
+	return servicesStagePlan{
+		BootstrapCommand:      bootstrapCommand,
+		BootstrapRecipeDigest: bootstrapRecipeDigest,
+		KeyFiles:              append([]string(nil), compiled.Services.KeyFiles...),
+	}, true
+}
+
+func (s *Service) finalizeServicesStagePlan(
+	ctx context.Context,
+	compiled *policy.CompiledPolicy,
+	repository *repositorycheckout.Checkout,
+	changeset *repositorychangeset.Changeset,
+	parentStageKey string,
+	plan servicesStagePlan,
+) (servicesStagePlan, bool, error) {
+	if compiled == nil || repository == nil || strings.TrimSpace(parentStageKey) == "" {
+		return plan, false, nil
+	}
+
+	keyFilesDigest, err := s.stageKeyFilesDigest(ctx, repository, changeset, plan.KeyFiles, servicesStageName)
+	if err != nil {
+		return plan, false, err
+	}
+
+	cacheKey := cachekey.ServicesStageKey(cachekey.ServicesStageInputs{
+		ParentStageKey:        strings.TrimSpace(parentStageKey),
+		CompiledPolicyHash:    strings.TrimSpace(compiled.Hash),
+		KeyFilesDigest:        strings.TrimSpace(keyFilesDigest),
+		BootstrapRecipeDigest: strings.TrimSpace(plan.BootstrapRecipeDigest),
+	})
+	if strings.TrimSpace(cacheKey) == "" {
+		return plan, false, nil
+	}
+
+	plan.CacheKey = cacheKey
+	plan.ParentStageCacheKey = strings.TrimSpace(parentStageKey)
+	plan.KeyFilesDigest = strings.TrimSpace(keyFilesDigest)
+	return plan, true, nil
+}
+
+func (s *Service) lookupServicesStageCache(ctx context.Context, backendName string, compiled *policy.CompiledPolicy, repository *repositorycheckout.Checkout, plan servicesStagePlan) (cachestore.Record, bool, string, error) {
+	if compiled == nil || repository == nil || strings.TrimSpace(plan.CacheKey) == "" {
+		return cachestore.Record{}, false, "", nil
+	}
+	store, err := s.cacheStoreOrErr()
+	if err != nil {
+		return cachestore.Record{}, false, "", nil
+	}
+
+	record, ok, err := store.GetReady(ctx, servicesStageName, plan.CacheKey)
+	if err != nil {
+		return cachestore.Record{}, false, "", err
+	}
+	if !ok {
+		return cachestore.Record{}, false, observability.CacheLookupReasonRecordNotFound, nil
+	}
+	if strings.TrimSpace(record.Backend) != strings.TrimSpace(backendName) {
+		return cachestore.Record{}, false, observability.CacheLookupReasonBackendMismatch, nil
+	}
+	if strings.TrimSpace(record.PolicyHash) != strings.TrimSpace(compiled.Hash) {
+		return cachestore.Record{}, false, observability.CacheLookupReasonPolicyHashMismatch, nil
+	}
+	if strings.TrimSpace(record.ParentCacheKey) != strings.TrimSpace(plan.ParentStageCacheKey) {
+		return cachestore.Record{}, false, observability.CacheLookupReasonParentStageChanged, nil
+	}
+	if !repositoryCheckoutsEqual(repositorycheckout.FromProto(record.Repository), repository) {
+		return cachestore.Record{}, false, observability.CacheLookupReasonRepositoryChanged, nil
+	}
+	return record, true, "", nil
+}
+
+func (s *Service) maybePublishServicesStageCache(
+	ctx context.Context,
+	adapter backend.SnapshottingAdapter,
+	sandboxID, backendName string,
+	compiled *policy.CompiledPolicy,
+	firecrackerCfg backend.FirecrackerConfig,
+	repository *repositorycheckout.Checkout,
+	changeset *repositorychangeset.Changeset,
+	plan servicesStagePlan,
+	replacedRecord *cachestore.Record,
+) {
+	if adapter == nil || compiled == nil || repository == nil || strings.TrimSpace(plan.CacheKey) == "" {
+		return
+	}
+	if !snapshotOperationsEnabledForBackend(backendName, s.Config) {
+		return
+	}
+
+	store, err := s.cacheStoreOrErr()
+	if err != nil {
+		return
+	}
+
+	if record, ok, _, err := s.lookupServicesStageCache(ctx, backendName, compiled, repository, plan); err == nil && ok {
+		if replacedRecord == nil || strings.TrimSpace(record.CacheKey) != strings.TrimSpace(replacedRecord.CacheKey) {
+			s.logServicesStageAlreadyPublished(record)
+			return
+		}
+	} else if err != nil {
+		s.logServicesStageWarning("lookup services stage cache", sandboxID, err)
+		return
+	}
+
+	snapshotID := newSnapshotID()
+	snapshotCfg := withSnapshotDriver(backendName, firecrackerCfg, firecrackerCfg.Snapshots.Driver)
+	result, err := adapter.CreateSnapshot(ctx, backend.SnapshotRequest{
+		SandboxID:         sandboxID,
+		SnapshotID:        snapshotID,
+		FirecrackerConfig: snapshotCfg,
+	})
+	if err != nil {
+		s.logServicesStageWarning("publish services stage cache", sandboxID, err)
+		return
+	}
+
+	record := cachestore.Record{
+		CacheKey:               plan.CacheKey,
+		Stage:                  servicesStageName,
+		State:                  cacheStateReady,
+		BackingSnapshotID:      strings.TrimSpace(snapshotID),
+		Backend:                backendName,
+		PolicyHash:             compiled.Hash,
+		Policy:                 compiled.ToProto(),
+		Repository:             cloneRepositoryCheckout(normalizeRepositoryCheckoutForComparison(repository)).ToProto(),
+		RepositoryHasChangeset: changeset != nil,
+		ParentCacheKey:         plan.ParentStageCacheKey,
+		StorageDriver:          snapshotCfg.Snapshots.Driver,
+		StorageRef:             strings.TrimSpace(result.StorageRef),
+		CreatedAt:              s.clock().Now(),
+		LastUsedAt:             s.clock().Now(),
+		ProducerVersion:        servicesStageProducerVersion,
+	}
+
+	persist := store.Create
+	if replacedRecord != nil && strings.TrimSpace(replacedRecord.CacheKey) == plan.CacheKey {
+		persist = store.Upsert
+	}
+
+	if err := persist(ctx, record); err != nil {
+		deleteErr := adapter.DeleteSnapshot(ctx, backend.DeleteSnapshotRequest{
+			SnapshotID:        snapshotID,
+			StorageRef:        record.StorageRef,
+			FirecrackerConfig: snapshotCfg,
+		})
+		if deleteErr != nil {
+			s.logServicesStageWarning("rollback services stage cache after metadata failure", sandboxID, fmt.Errorf("%w (rollback failed: %v)", err, deleteErr))
+			return
+		}
+		s.logServicesStageWarning("persist services stage cache metadata", sandboxID, err)
+		return
+	}
+
+	s.logServicesStagePublished(record, sandboxID, replacedRecord != nil && strings.TrimSpace(replacedRecord.CacheKey) == plan.CacheKey)
+
+	if replacedRecord != nil && strings.TrimSpace(replacedRecord.CacheKey) == plan.CacheKey {
+		if err := s.deleteWorkspaceStageCacheSnapshot(ctx, adapter, backendName, firecrackerCfg, *replacedRecord); err != nil {
+			s.logServicesStageWarning("delete replaced services stage cache snapshot", sandboxID, err)
+		}
+	}
+}
+
+func (s *Service) bootstrapServicesStageInPersistentSandbox(
+	ctx context.Context,
+	adapter backend.Adapter,
+	sandboxID string,
+	compiled *policy.CompiledPolicy,
+	firecrackerCfg backend.FirecrackerConfig,
+	plan servicesStagePlan,
+	reporter CreateSandboxReporter,
+) error {
+	if adapter == nil || compiled == nil || strings.TrimSpace(sandboxID) == "" || len(plan.BootstrapCommand) == 0 {
+		return nil
+	}
+	if s.Logger != nil {
+		s.Logger.Debug("starting services stage bootstrap",
+			"sandbox_id", sandboxID,
+			"cache_key", strings.TrimSpace(plan.CacheKey),
+		)
+	}
+
+	bootstrapExecutionID, result, stdout, stderr, err := s.runPersistentBootstrapCommand(
+		ctx,
+		adapter,
+		sandboxID,
+		compiled,
+		firecrackerCfg,
+		cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_SERVICES,
+		plan.BootstrapCommand,
+		nil,
+		reporter,
+	)
+	if s.Logger != nil {
+		s.Logger.Debug("services stage bootstrap execution finished",
+			"sandbox_id", sandboxID,
+			"execution_id", bootstrapExecutionID,
+			"exit_code", func() int {
+				if result == nil {
+					return -1
+				}
+				return result.ExitCode
+			}(),
+			"error", err,
+		)
+	}
+	return persistentBootstrapCommandError(result, stdout, stderr, err, "services stage bootstrap returned no result", "services stage bootstrap failed with exit code %d")
+}
+
+func (s *Service) logServicesStageCacheHit(record cachestore.Record) {
+	if s == nil || s.Logger == nil {
+		return
+	}
+	s.Logger.Debug("services stage cache hit",
+		"cache_key", strings.TrimSpace(record.CacheKey),
+		"backing_snapshot_id", strings.TrimSpace(record.BackingSnapshotID),
+		"backend", strings.TrimSpace(record.Backend),
+	)
+}
+
+func (s *Service) logServicesStageCacheMiss(backendName, cacheKey string) {
+	if s == nil || s.Logger == nil {
+		return
+	}
+	s.Logger.Debug("services stage cache miss",
+		"cache_key", strings.TrimSpace(cacheKey),
+		"backend", strings.TrimSpace(backendName),
+	)
+}
+
+func (s *Service) logServicesStageAlreadyPublished(record cachestore.Record) {
+	if s == nil || s.Logger == nil {
+		return
+	}
+	s.Logger.Debug("services stage cache already published",
+		"cache_key", strings.TrimSpace(record.CacheKey),
+		"backing_snapshot_id", strings.TrimSpace(record.BackingSnapshotID),
+		"backend", strings.TrimSpace(record.Backend),
+	)
+}
+
+func (s *Service) logServicesStagePublished(record cachestore.Record, sandboxID string, replaced bool) {
+	if s == nil || s.Logger == nil {
+		return
+	}
+	message := "services stage cache published"
+	if replaced {
+		message = "services stage cache replaced"
+	}
+	s.Logger.Info(message,
+		"sandbox_id", strings.TrimSpace(sandboxID),
+		"cache_key", strings.TrimSpace(record.CacheKey),
+		"backing_snapshot_id", strings.TrimSpace(record.BackingSnapshotID),
+		"backend", strings.TrimSpace(record.Backend),
+	)
+}
+
+func (s *Service) logServicesStageRestore(record cachestore.Record, sandboxID string) {
+	if s == nil || s.Logger == nil {
+		return
+	}
+	s.Logger.Info("services stage cache restored",
+		"sandbox_id", strings.TrimSpace(sandboxID),
+		"cache_key", strings.TrimSpace(record.CacheKey),
+		"backing_snapshot_id", strings.TrimSpace(record.BackingSnapshotID),
+		"backend", strings.TrimSpace(record.Backend),
+	)
+}
+
+func (s *Service) logServicesStageRestoreWarning(record cachestore.Record, err error) {
+	if s == nil || s.Logger == nil {
+		return
+	}
+	s.Logger.Warn("restore services stage cache",
+		"cache_key", strings.TrimSpace(record.CacheKey),
+		"backing_snapshot_id", strings.TrimSpace(record.BackingSnapshotID),
+		"backend", strings.TrimSpace(record.Backend),
+		"error", err,
+	)
+}
+
+func (s *Service) logServicesStageWarning(operation, sandboxID string, err error) {
+	if s == nil || s.Logger == nil || err == nil {
+		return
+	}
+	s.Logger.Warn(operation,
+		"sandbox_id", strings.TrimSpace(sandboxID),
+		"error", err,
+	)
+}

--- a/internal/controlservice/stored_rootfs.go
+++ b/internal/controlservice/stored_rootfs.go
@@ -129,6 +129,8 @@ func (s *Service) createSandboxFromStoredRootFS(ctx context.Context, req *cleanr
 		emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_RESTORE_SNAPSHOT, "restoring snapshot")
 	case "dependency stage cache":
 		emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_RESTORE_DEPENDENCY_STAGE_CACHE, "restoring dependency stage cache")
+	case "services stage cache":
+		emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_RESTORE_SERVICES_STAGE_CACHE, "restoring services stage cache")
 	case "workspace stage cache":
 		emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_RESTORE_WORKSPACE_STAGE_CACHE, "restoring workspace stage cache")
 	}

--- a/internal/gen/cleanroom/v1/control.pb.go
+++ b/internal/gen/cleanroom/v1/control.pb.go
@@ -97,6 +97,10 @@ const (
 	CreateSandboxPhase_CREATE_SANDBOX_PHASE_PUBLISH_DEPENDENCY_STAGE_CACHE CreateSandboxPhase = 10
 	CreateSandboxPhase_CREATE_SANDBOX_PHASE_READY                          CreateSandboxPhase = 11
 	CreateSandboxPhase_CREATE_SANDBOX_PHASE_APPLY_REPOSITORY_CHANGESET     CreateSandboxPhase = 12
+	CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_SERVICES_STAGE_CACHE    CreateSandboxPhase = 13
+	CreateSandboxPhase_CREATE_SANDBOX_PHASE_RESTORE_SERVICES_STAGE_CACHE   CreateSandboxPhase = 14
+	CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_SERVICES             CreateSandboxPhase = 15
+	CreateSandboxPhase_CREATE_SANDBOX_PHASE_PUBLISH_SERVICES_STAGE_CACHE   CreateSandboxPhase = 16
 )
 
 // Enum value maps for CreateSandboxPhase.
@@ -115,6 +119,10 @@ var (
 		10: "CREATE_SANDBOX_PHASE_PUBLISH_DEPENDENCY_STAGE_CACHE",
 		11: "CREATE_SANDBOX_PHASE_READY",
 		12: "CREATE_SANDBOX_PHASE_APPLY_REPOSITORY_CHANGESET",
+		13: "CREATE_SANDBOX_PHASE_LOOKUP_SERVICES_STAGE_CACHE",
+		14: "CREATE_SANDBOX_PHASE_RESTORE_SERVICES_STAGE_CACHE",
+		15: "CREATE_SANDBOX_PHASE_BOOTSTRAP_SERVICES",
+		16: "CREATE_SANDBOX_PHASE_PUBLISH_SERVICES_STAGE_CACHE",
 	}
 	CreateSandboxPhase_value = map[string]int32{
 		"CREATE_SANDBOX_PHASE_UNSPECIFIED":                    0,
@@ -130,6 +138,10 @@ var (
 		"CREATE_SANDBOX_PHASE_PUBLISH_DEPENDENCY_STAGE_CACHE": 10,
 		"CREATE_SANDBOX_PHASE_READY":                          11,
 		"CREATE_SANDBOX_PHASE_APPLY_REPOSITORY_CHANGESET":     12,
+		"CREATE_SANDBOX_PHASE_LOOKUP_SERVICES_STAGE_CACHE":    13,
+		"CREATE_SANDBOX_PHASE_RESTORE_SERVICES_STAGE_CACHE":   14,
+		"CREATE_SANDBOX_PHASE_BOOTSTRAP_SERVICES":             15,
+		"CREATE_SANDBOX_PHASE_PUBLISH_SERVICES_STAGE_CACHE":   16,
 	}
 )
 
@@ -601,6 +613,8 @@ func (x *PolicyDockerService) GetRequired() bool {
 type PolicyServices struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Docker        *PolicyDockerService   `protobuf:"bytes,1,opt,name=docker,proto3" json:"docker,omitempty"`
+	Command       []string               `protobuf:"bytes,2,rep,name=command,proto3" json:"command,omitempty"`
+	Key           *PolicyDependencyKey   `protobuf:"bytes,3,opt,name=key,proto3" json:"key,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -638,6 +652,20 @@ func (*PolicyServices) Descriptor() ([]byte, []int) {
 func (x *PolicyServices) GetDocker() *PolicyDockerService {
 	if x != nil {
 		return x.Docker
+	}
+	return nil
+}
+
+func (x *PolicyServices) GetCommand() []string {
+	if x != nil {
+		return x.Command
+	}
+	return nil
+}
+
+func (x *PolicyServices) GetKey() *PolicyDependencyKey {
+	if x != nil {
+		return x.Key
 	}
 	return nil
 }
@@ -3853,9 +3881,11 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\x04host\x18\x01 \x01(\tR\x04host\x12\x14\n" +
 	"\x05ports\x18\x02 \x03(\x05R\x05ports\"1\n" +
 	"\x13PolicyDockerService\x12\x1a\n" +
-	"\brequired\x18\x01 \x01(\bR\brequired\"K\n" +
+	"\brequired\x18\x01 \x01(\bR\brequired\"\x9a\x01\n" +
 	"\x0ePolicyServices\x129\n" +
-	"\x06docker\x18\x01 \x01(\v2!.cleanroom.v1.PolicyDockerServiceR\x06docker\"+\n" +
+	"\x06docker\x18\x01 \x01(\v2!.cleanroom.v1.PolicyDockerServiceR\x06docker\x12\x18\n" +
+	"\acommand\x18\x02 \x03(\tR\acommand\x123\n" +
+	"\x03key\x18\x03 \x01(\v2!.cleanroom.v1.PolicyDependencyKeyR\x03key\"+\n" +
 	"\x13PolicyDependencyKey\x12\x14\n" +
 	"\x05files\x18\x01 \x03(\tR\x05files\"c\n" +
 	"\x12PolicyDependencies\x12\x18\n" +
@@ -4118,7 +4148,7 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\x14SANDBOX_STATUS_READY\x10\x02\x12\x1b\n" +
 	"\x17SANDBOX_STATUS_STOPPING\x10\x03\x12\x1a\n" +
 	"\x16SANDBOX_STATUS_STOPPED\x10\x04\x12\x19\n" +
-	"\x15SANDBOX_STATUS_FAILED\x10\x05*\x97\x05\n" +
+	"\x15SANDBOX_STATUS_FAILED\x10\x05*\xe8\x06\n" +
 	"\x12CreateSandboxPhase\x12$\n" +
 	" CREATE_SANDBOX_PHASE_UNSPECIFIED\x10\x00\x12)\n" +
 	"%CREATE_SANDBOX_PHASE_RESTORE_SNAPSHOT\x10\x01\x126\n" +
@@ -4133,7 +4163,11 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"3CREATE_SANDBOX_PHASE_PUBLISH_DEPENDENCY_STAGE_CACHE\x10\n" +
 	"\x12\x1e\n" +
 	"\x1aCREATE_SANDBOX_PHASE_READY\x10\v\x123\n" +
-	"/CREATE_SANDBOX_PHASE_APPLY_REPOSITORY_CHANGESET\x10\f*\xea\x01\n" +
+	"/CREATE_SANDBOX_PHASE_APPLY_REPOSITORY_CHANGESET\x10\f\x124\n" +
+	"0CREATE_SANDBOX_PHASE_LOOKUP_SERVICES_STAGE_CACHE\x10\r\x125\n" +
+	"1CREATE_SANDBOX_PHASE_RESTORE_SERVICES_STAGE_CACHE\x10\x0e\x12+\n" +
+	"'CREATE_SANDBOX_PHASE_BOOTSTRAP_SERVICES\x10\x0f\x125\n" +
+	"1CREATE_SANDBOX_PHASE_PUBLISH_SERVICES_STAGE_CACHE\x10\x10*\xea\x01\n" +
 	"\x0fExecutionStatus\x12 \n" +
 	"\x1cEXECUTION_STATUS_UNSPECIFIED\x10\x00\x12\x1b\n" +
 	"\x17EXECUTION_STATUS_QUEUED\x10\x01\x12\x1c\n" +
@@ -4255,90 +4289,91 @@ var file_proto_cleanroom_v1_control_proto_depIdxs = []int32{
 	59, // 3: cleanroom.v1.Snapshot.created_at:type_name -> google.protobuf.Timestamp
 	14, // 4: cleanroom.v1.Snapshot.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
 	7,  // 5: cleanroom.v1.PolicyServices.docker:type_name -> cleanroom.v1.PolicyDockerService
-	9,  // 6: cleanroom.v1.PolicyDependencies.key:type_name -> cleanroom.v1.PolicyDependencyKey
-	6,  // 7: cleanroom.v1.Policy.allow:type_name -> cleanroom.v1.PolicyAllowRule
-	8,  // 8: cleanroom.v1.Policy.services:type_name -> cleanroom.v1.PolicyServices
-	10, // 9: cleanroom.v1.Policy.dependencies:type_name -> cleanroom.v1.PolicyDependencies
-	11, // 10: cleanroom.v1.Policy.run:type_name -> cleanroom.v1.PolicyRun
-	15, // 11: cleanroom.v1.RepositoryChangeset.files:type_name -> cleanroom.v1.RepositoryChangesetFile
-	13, // 12: cleanroom.v1.CreateSandboxRequest.options:type_name -> cleanroom.v1.SandboxOptions
-	12, // 13: cleanroom.v1.CreateSandboxRequest.policy:type_name -> cleanroom.v1.Policy
-	14, // 14: cleanroom.v1.CreateSandboxRequest.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
-	16, // 15: cleanroom.v1.CreateSandboxRequest.repository_changeset:type_name -> cleanroom.v1.RepositoryChangeset
-	4,  // 16: cleanroom.v1.CreateSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
-	1,  // 17: cleanroom.v1.CreateSandboxEvent.phase:type_name -> cleanroom.v1.CreateSandboxPhase
-	18, // 18: cleanroom.v1.CreateSandboxEvent.response:type_name -> cleanroom.v1.CreateSandboxResponse
-	59, // 19: cleanroom.v1.CreateSandboxEvent.occurred_at:type_name -> google.protobuf.Timestamp
-	4,  // 20: cleanroom.v1.GetSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
-	4,  // 21: cleanroom.v1.ListSandboxesResponse.sandboxes:type_name -> cleanroom.v1.Sandbox
-	40, // 22: cleanroom.v1.ListExecutionsResponse.executions:type_name -> cleanroom.v1.Execution
-	0,  // 23: cleanroom.v1.SandboxEvent.status:type_name -> cleanroom.v1.SandboxStatus
-	59, // 24: cleanroom.v1.SandboxEvent.occurred_at:type_name -> google.protobuf.Timestamp
-	5,  // 25: cleanroom.v1.CreateSnapshotResponse.snapshot:type_name -> cleanroom.v1.Snapshot
-	5,  // 26: cleanroom.v1.GetSnapshotResponse.snapshot:type_name -> cleanroom.v1.Snapshot
-	5,  // 27: cleanroom.v1.ListSnapshotsResponse.snapshots:type_name -> cleanroom.v1.Snapshot
-	2,  // 28: cleanroom.v1.Execution.status:type_name -> cleanroom.v1.ExecutionStatus
-	59, // 29: cleanroom.v1.Execution.started_at:type_name -> google.protobuf.Timestamp
-	59, // 30: cleanroom.v1.Execution.finished_at:type_name -> google.protobuf.Timestamp
-	3,  // 31: cleanroom.v1.Execution.kind:type_name -> cleanroom.v1.ExecutionKind
-	41, // 32: cleanroom.v1.CreateExecutionRequest.options:type_name -> cleanroom.v1.ExecutionOptions
-	3,  // 33: cleanroom.v1.CreateExecutionRequest.kind:type_name -> cleanroom.v1.ExecutionKind
-	14, // 34: cleanroom.v1.CreateExecutionRequest.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
-	40, // 35: cleanroom.v1.CreateExecutionResponse.execution:type_name -> cleanroom.v1.Execution
-	59, // 36: cleanroom.v1.AttachExecutionResponse.expires_at:type_name -> google.protobuf.Timestamp
-	40, // 37: cleanroom.v1.GetExecutionResponse.execution:type_name -> cleanroom.v1.Execution
-	40, // 38: cleanroom.v1.InspectExecutionResponse.execution:type_name -> cleanroom.v1.Execution
-	60, // 39: cleanroom.v1.InspectExecutionResponse.observability:type_name -> google.protobuf.Struct
-	2,  // 40: cleanroom.v1.CancelExecutionResponse.status:type_name -> cleanroom.v1.ExecutionStatus
-	2,  // 41: cleanroom.v1.ExecutionExit.status:type_name -> cleanroom.v1.ExecutionStatus
-	2,  // 42: cleanroom.v1.ExecutionStreamEvent.status:type_name -> cleanroom.v1.ExecutionStatus
-	57, // 43: cleanroom.v1.ExecutionStreamEvent.exit:type_name -> cleanroom.v1.ExecutionExit
-	59, // 44: cleanroom.v1.ExecutionStreamEvent.occurred_at:type_name -> google.protobuf.Timestamp
-	17, // 45: cleanroom.v1.SandboxService.CreateSandbox:input_type -> cleanroom.v1.CreateSandboxRequest
-	17, // 46: cleanroom.v1.SandboxService.CreateSandboxStream:input_type -> cleanroom.v1.CreateSandboxRequest
-	20, // 47: cleanroom.v1.SandboxService.GetSandbox:input_type -> cleanroom.v1.GetSandboxRequest
-	22, // 48: cleanroom.v1.SandboxService.ListSandboxes:input_type -> cleanroom.v1.ListSandboxesRequest
-	26, // 49: cleanroom.v1.SandboxService.DownloadSandboxFile:input_type -> cleanroom.v1.DownloadSandboxFileRequest
-	28, // 50: cleanroom.v1.SandboxService.TerminateSandbox:input_type -> cleanroom.v1.TerminateSandboxRequest
-	30, // 51: cleanroom.v1.SandboxService.StreamSandboxEvents:input_type -> cleanroom.v1.StreamSandboxEventsRequest
-	32, // 52: cleanroom.v1.SnapshotService.CreateSnapshot:input_type -> cleanroom.v1.CreateSnapshotRequest
-	34, // 53: cleanroom.v1.SnapshotService.GetSnapshot:input_type -> cleanroom.v1.GetSnapshotRequest
-	36, // 54: cleanroom.v1.SnapshotService.ListSnapshots:input_type -> cleanroom.v1.ListSnapshotsRequest
-	38, // 55: cleanroom.v1.SnapshotService.DeleteSnapshot:input_type -> cleanroom.v1.DeleteSnapshotRequest
-	24, // 56: cleanroom.v1.ExecutionService.ListExecutions:input_type -> cleanroom.v1.ListExecutionsRequest
-	42, // 57: cleanroom.v1.ExecutionService.CreateExecution:input_type -> cleanroom.v1.CreateExecutionRequest
-	44, // 58: cleanroom.v1.ExecutionService.AttachExecution:input_type -> cleanroom.v1.AttachExecutionRequest
-	46, // 59: cleanroom.v1.ExecutionService.GetExecution:input_type -> cleanroom.v1.GetExecutionRequest
-	48, // 60: cleanroom.v1.ExecutionService.InspectExecution:input_type -> cleanroom.v1.InspectExecutionRequest
-	50, // 61: cleanroom.v1.ExecutionService.CancelExecution:input_type -> cleanroom.v1.CancelExecutionRequest
-	52, // 62: cleanroom.v1.ExecutionService.WriteExecutionStdin:input_type -> cleanroom.v1.WriteExecutionStdinRequest
-	54, // 63: cleanroom.v1.ExecutionService.CloseExecutionStdin:input_type -> cleanroom.v1.CloseExecutionStdinRequest
-	56, // 64: cleanroom.v1.ExecutionService.StreamExecution:input_type -> cleanroom.v1.StreamExecutionRequest
-	18, // 65: cleanroom.v1.SandboxService.CreateSandbox:output_type -> cleanroom.v1.CreateSandboxResponse
-	19, // 66: cleanroom.v1.SandboxService.CreateSandboxStream:output_type -> cleanroom.v1.CreateSandboxEvent
-	21, // 67: cleanroom.v1.SandboxService.GetSandbox:output_type -> cleanroom.v1.GetSandboxResponse
-	23, // 68: cleanroom.v1.SandboxService.ListSandboxes:output_type -> cleanroom.v1.ListSandboxesResponse
-	27, // 69: cleanroom.v1.SandboxService.DownloadSandboxFile:output_type -> cleanroom.v1.DownloadSandboxFileResponse
-	29, // 70: cleanroom.v1.SandboxService.TerminateSandbox:output_type -> cleanroom.v1.TerminateSandboxResponse
-	31, // 71: cleanroom.v1.SandboxService.StreamSandboxEvents:output_type -> cleanroom.v1.SandboxEvent
-	33, // 72: cleanroom.v1.SnapshotService.CreateSnapshot:output_type -> cleanroom.v1.CreateSnapshotResponse
-	35, // 73: cleanroom.v1.SnapshotService.GetSnapshot:output_type -> cleanroom.v1.GetSnapshotResponse
-	37, // 74: cleanroom.v1.SnapshotService.ListSnapshots:output_type -> cleanroom.v1.ListSnapshotsResponse
-	39, // 75: cleanroom.v1.SnapshotService.DeleteSnapshot:output_type -> cleanroom.v1.DeleteSnapshotResponse
-	25, // 76: cleanroom.v1.ExecutionService.ListExecutions:output_type -> cleanroom.v1.ListExecutionsResponse
-	43, // 77: cleanroom.v1.ExecutionService.CreateExecution:output_type -> cleanroom.v1.CreateExecutionResponse
-	45, // 78: cleanroom.v1.ExecutionService.AttachExecution:output_type -> cleanroom.v1.AttachExecutionResponse
-	47, // 79: cleanroom.v1.ExecutionService.GetExecution:output_type -> cleanroom.v1.GetExecutionResponse
-	49, // 80: cleanroom.v1.ExecutionService.InspectExecution:output_type -> cleanroom.v1.InspectExecutionResponse
-	51, // 81: cleanroom.v1.ExecutionService.CancelExecution:output_type -> cleanroom.v1.CancelExecutionResponse
-	53, // 82: cleanroom.v1.ExecutionService.WriteExecutionStdin:output_type -> cleanroom.v1.WriteExecutionStdinResponse
-	55, // 83: cleanroom.v1.ExecutionService.CloseExecutionStdin:output_type -> cleanroom.v1.CloseExecutionStdinResponse
-	58, // 84: cleanroom.v1.ExecutionService.StreamExecution:output_type -> cleanroom.v1.ExecutionStreamEvent
-	65, // [65:85] is the sub-list for method output_type
-	45, // [45:65] is the sub-list for method input_type
-	45, // [45:45] is the sub-list for extension type_name
-	45, // [45:45] is the sub-list for extension extendee
-	0,  // [0:45] is the sub-list for field type_name
+	9,  // 6: cleanroom.v1.PolicyServices.key:type_name -> cleanroom.v1.PolicyDependencyKey
+	9,  // 7: cleanroom.v1.PolicyDependencies.key:type_name -> cleanroom.v1.PolicyDependencyKey
+	6,  // 8: cleanroom.v1.Policy.allow:type_name -> cleanroom.v1.PolicyAllowRule
+	8,  // 9: cleanroom.v1.Policy.services:type_name -> cleanroom.v1.PolicyServices
+	10, // 10: cleanroom.v1.Policy.dependencies:type_name -> cleanroom.v1.PolicyDependencies
+	11, // 11: cleanroom.v1.Policy.run:type_name -> cleanroom.v1.PolicyRun
+	15, // 12: cleanroom.v1.RepositoryChangeset.files:type_name -> cleanroom.v1.RepositoryChangesetFile
+	13, // 13: cleanroom.v1.CreateSandboxRequest.options:type_name -> cleanroom.v1.SandboxOptions
+	12, // 14: cleanroom.v1.CreateSandboxRequest.policy:type_name -> cleanroom.v1.Policy
+	14, // 15: cleanroom.v1.CreateSandboxRequest.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
+	16, // 16: cleanroom.v1.CreateSandboxRequest.repository_changeset:type_name -> cleanroom.v1.RepositoryChangeset
+	4,  // 17: cleanroom.v1.CreateSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
+	1,  // 18: cleanroom.v1.CreateSandboxEvent.phase:type_name -> cleanroom.v1.CreateSandboxPhase
+	18, // 19: cleanroom.v1.CreateSandboxEvent.response:type_name -> cleanroom.v1.CreateSandboxResponse
+	59, // 20: cleanroom.v1.CreateSandboxEvent.occurred_at:type_name -> google.protobuf.Timestamp
+	4,  // 21: cleanroom.v1.GetSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
+	4,  // 22: cleanroom.v1.ListSandboxesResponse.sandboxes:type_name -> cleanroom.v1.Sandbox
+	40, // 23: cleanroom.v1.ListExecutionsResponse.executions:type_name -> cleanroom.v1.Execution
+	0,  // 24: cleanroom.v1.SandboxEvent.status:type_name -> cleanroom.v1.SandboxStatus
+	59, // 25: cleanroom.v1.SandboxEvent.occurred_at:type_name -> google.protobuf.Timestamp
+	5,  // 26: cleanroom.v1.CreateSnapshotResponse.snapshot:type_name -> cleanroom.v1.Snapshot
+	5,  // 27: cleanroom.v1.GetSnapshotResponse.snapshot:type_name -> cleanroom.v1.Snapshot
+	5,  // 28: cleanroom.v1.ListSnapshotsResponse.snapshots:type_name -> cleanroom.v1.Snapshot
+	2,  // 29: cleanroom.v1.Execution.status:type_name -> cleanroom.v1.ExecutionStatus
+	59, // 30: cleanroom.v1.Execution.started_at:type_name -> google.protobuf.Timestamp
+	59, // 31: cleanroom.v1.Execution.finished_at:type_name -> google.protobuf.Timestamp
+	3,  // 32: cleanroom.v1.Execution.kind:type_name -> cleanroom.v1.ExecutionKind
+	41, // 33: cleanroom.v1.CreateExecutionRequest.options:type_name -> cleanroom.v1.ExecutionOptions
+	3,  // 34: cleanroom.v1.CreateExecutionRequest.kind:type_name -> cleanroom.v1.ExecutionKind
+	14, // 35: cleanroom.v1.CreateExecutionRequest.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
+	40, // 36: cleanroom.v1.CreateExecutionResponse.execution:type_name -> cleanroom.v1.Execution
+	59, // 37: cleanroom.v1.AttachExecutionResponse.expires_at:type_name -> google.protobuf.Timestamp
+	40, // 38: cleanroom.v1.GetExecutionResponse.execution:type_name -> cleanroom.v1.Execution
+	40, // 39: cleanroom.v1.InspectExecutionResponse.execution:type_name -> cleanroom.v1.Execution
+	60, // 40: cleanroom.v1.InspectExecutionResponse.observability:type_name -> google.protobuf.Struct
+	2,  // 41: cleanroom.v1.CancelExecutionResponse.status:type_name -> cleanroom.v1.ExecutionStatus
+	2,  // 42: cleanroom.v1.ExecutionExit.status:type_name -> cleanroom.v1.ExecutionStatus
+	2,  // 43: cleanroom.v1.ExecutionStreamEvent.status:type_name -> cleanroom.v1.ExecutionStatus
+	57, // 44: cleanroom.v1.ExecutionStreamEvent.exit:type_name -> cleanroom.v1.ExecutionExit
+	59, // 45: cleanroom.v1.ExecutionStreamEvent.occurred_at:type_name -> google.protobuf.Timestamp
+	17, // 46: cleanroom.v1.SandboxService.CreateSandbox:input_type -> cleanroom.v1.CreateSandboxRequest
+	17, // 47: cleanroom.v1.SandboxService.CreateSandboxStream:input_type -> cleanroom.v1.CreateSandboxRequest
+	20, // 48: cleanroom.v1.SandboxService.GetSandbox:input_type -> cleanroom.v1.GetSandboxRequest
+	22, // 49: cleanroom.v1.SandboxService.ListSandboxes:input_type -> cleanroom.v1.ListSandboxesRequest
+	26, // 50: cleanroom.v1.SandboxService.DownloadSandboxFile:input_type -> cleanroom.v1.DownloadSandboxFileRequest
+	28, // 51: cleanroom.v1.SandboxService.TerminateSandbox:input_type -> cleanroom.v1.TerminateSandboxRequest
+	30, // 52: cleanroom.v1.SandboxService.StreamSandboxEvents:input_type -> cleanroom.v1.StreamSandboxEventsRequest
+	32, // 53: cleanroom.v1.SnapshotService.CreateSnapshot:input_type -> cleanroom.v1.CreateSnapshotRequest
+	34, // 54: cleanroom.v1.SnapshotService.GetSnapshot:input_type -> cleanroom.v1.GetSnapshotRequest
+	36, // 55: cleanroom.v1.SnapshotService.ListSnapshots:input_type -> cleanroom.v1.ListSnapshotsRequest
+	38, // 56: cleanroom.v1.SnapshotService.DeleteSnapshot:input_type -> cleanroom.v1.DeleteSnapshotRequest
+	24, // 57: cleanroom.v1.ExecutionService.ListExecutions:input_type -> cleanroom.v1.ListExecutionsRequest
+	42, // 58: cleanroom.v1.ExecutionService.CreateExecution:input_type -> cleanroom.v1.CreateExecutionRequest
+	44, // 59: cleanroom.v1.ExecutionService.AttachExecution:input_type -> cleanroom.v1.AttachExecutionRequest
+	46, // 60: cleanroom.v1.ExecutionService.GetExecution:input_type -> cleanroom.v1.GetExecutionRequest
+	48, // 61: cleanroom.v1.ExecutionService.InspectExecution:input_type -> cleanroom.v1.InspectExecutionRequest
+	50, // 62: cleanroom.v1.ExecutionService.CancelExecution:input_type -> cleanroom.v1.CancelExecutionRequest
+	52, // 63: cleanroom.v1.ExecutionService.WriteExecutionStdin:input_type -> cleanroom.v1.WriteExecutionStdinRequest
+	54, // 64: cleanroom.v1.ExecutionService.CloseExecutionStdin:input_type -> cleanroom.v1.CloseExecutionStdinRequest
+	56, // 65: cleanroom.v1.ExecutionService.StreamExecution:input_type -> cleanroom.v1.StreamExecutionRequest
+	18, // 66: cleanroom.v1.SandboxService.CreateSandbox:output_type -> cleanroom.v1.CreateSandboxResponse
+	19, // 67: cleanroom.v1.SandboxService.CreateSandboxStream:output_type -> cleanroom.v1.CreateSandboxEvent
+	21, // 68: cleanroom.v1.SandboxService.GetSandbox:output_type -> cleanroom.v1.GetSandboxResponse
+	23, // 69: cleanroom.v1.SandboxService.ListSandboxes:output_type -> cleanroom.v1.ListSandboxesResponse
+	27, // 70: cleanroom.v1.SandboxService.DownloadSandboxFile:output_type -> cleanroom.v1.DownloadSandboxFileResponse
+	29, // 71: cleanroom.v1.SandboxService.TerminateSandbox:output_type -> cleanroom.v1.TerminateSandboxResponse
+	31, // 72: cleanroom.v1.SandboxService.StreamSandboxEvents:output_type -> cleanroom.v1.SandboxEvent
+	33, // 73: cleanroom.v1.SnapshotService.CreateSnapshot:output_type -> cleanroom.v1.CreateSnapshotResponse
+	35, // 74: cleanroom.v1.SnapshotService.GetSnapshot:output_type -> cleanroom.v1.GetSnapshotResponse
+	37, // 75: cleanroom.v1.SnapshotService.ListSnapshots:output_type -> cleanroom.v1.ListSnapshotsResponse
+	39, // 76: cleanroom.v1.SnapshotService.DeleteSnapshot:output_type -> cleanroom.v1.DeleteSnapshotResponse
+	25, // 77: cleanroom.v1.ExecutionService.ListExecutions:output_type -> cleanroom.v1.ListExecutionsResponse
+	43, // 78: cleanroom.v1.ExecutionService.CreateExecution:output_type -> cleanroom.v1.CreateExecutionResponse
+	45, // 79: cleanroom.v1.ExecutionService.AttachExecution:output_type -> cleanroom.v1.AttachExecutionResponse
+	47, // 80: cleanroom.v1.ExecutionService.GetExecution:output_type -> cleanroom.v1.GetExecutionResponse
+	49, // 81: cleanroom.v1.ExecutionService.InspectExecution:output_type -> cleanroom.v1.InspectExecutionResponse
+	51, // 82: cleanroom.v1.ExecutionService.CancelExecution:output_type -> cleanroom.v1.CancelExecutionResponse
+	53, // 83: cleanroom.v1.ExecutionService.WriteExecutionStdin:output_type -> cleanroom.v1.WriteExecutionStdinResponse
+	55, // 84: cleanroom.v1.ExecutionService.CloseExecutionStdin:output_type -> cleanroom.v1.CloseExecutionStdinResponse
+	58, // 85: cleanroom.v1.ExecutionService.StreamExecution:output_type -> cleanroom.v1.ExecutionStreamEvent
+	66, // [66:86] is the sub-list for method output_type
+	46, // [46:66] is the sub-list for method input_type
+	46, // [46:46] is the sub-list for extension type_name
+	46, // [46:46] is the sub-list for extension extendee
+	0,  // [0:46] is the sub-list for field type_name
 }
 
 func init() { file_proto_cleanroom_v1_control_proto_init() }

--- a/internal/observability/contract.go
+++ b/internal/observability/contract.go
@@ -95,6 +95,7 @@ const (
 	CacheStageRuntime    = "runtime"
 	CacheStageWorkspace  = "workspace"
 	CacheStageDependency = "dependency"
+	CacheStageServices   = "services"
 
 	CacheOperationLookup     = "lookup"
 	CacheOperationRestore    = "restore"
@@ -112,6 +113,7 @@ const (
 	CacheLookupReasonBackendMismatch        = "backend_mismatch"
 	CacheLookupReasonPolicyHashMismatch     = "policy_hash_mismatch"
 	CacheLookupReasonRepositoryChanged      = "repository_changed"
+	CacheLookupReasonParentStageChanged     = "parent_stage_changed"
 	CacheLookupReasonWorkspaceParentChanged = "workspace_parent_changed"
 )
 

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -71,7 +71,9 @@ type rawRunConfig struct {
 type rawShellCommandSpec []string
 
 type rawServices struct {
-	Docker rawDockerService `yaml:"docker"`
+	Docker  rawDockerService         `yaml:"docker"`
+	Command rawDependencyCommandSpec `yaml:"command"`
+	Key     rawDependencyKey         `yaml:"key"`
 }
 
 type rawDockerService struct {
@@ -104,7 +106,9 @@ type RepositoryConfig struct {
 }
 
 type Services struct {
-	Docker DockerService `json:"docker"`
+	Docker   DockerService `json:"docker"`
+	Command  []string      `json:"command,omitempty"`
+	KeyFiles []string      `json:"key_files,omitempty"`
 }
 
 type Dependencies struct {
@@ -236,20 +240,20 @@ func Compile(raw rawPolicy) (*CompiledPolicy, error) {
 	if err != nil {
 		return nil, err
 	}
+	services, err := normalizeServices(raw.Sandbox.Services)
+	if err != nil {
+		return nil, err
+	}
 	run, err := normalizeRun(raw.Sandbox.Run)
 	if err != nil {
 		return nil, err
 	}
 
 	compiled := &CompiledPolicy{
-		Version:     raw.Version,
-		ImageRef:    parsedRef.Original,
-		ImageDigest: parsedRef.Digest(),
-		Services: Services{
-			Docker: DockerService{
-				Required: raw.Sandbox.Services.Docker.Required,
-			},
-		},
+		Version:        raw.Version,
+		ImageRef:       parsedRef.Original,
+		ImageDigest:    parsedRef.Digest(),
+		Services:       services,
 		NetworkDefault: networkDefault,
 		Allow:          allow,
 		Dependencies:   dependencies,
@@ -308,6 +312,10 @@ func (p *CompiledPolicy) RequiresDockerService() bool {
 		return false
 	}
 	return p.Services.Docker.Required
+}
+
+func (s Services) BootstrapEnabled() bool {
+	return len(s.Command) > 0
 }
 
 func (d Dependencies) Enabled() bool {
@@ -471,6 +479,10 @@ func (p *CompiledPolicy) ToProto() *cleanroomv1.Policy {
 			Docker: &cleanroomv1.PolicyDockerService{
 				Required: p.Services.Docker.Required,
 			},
+			Command: append([]string(nil), p.Services.Command...),
+			Key: &cleanroomv1.PolicyDependencyKey{
+				Files: append([]string(nil), p.Services.KeyFiles...),
+			},
 		},
 		NetworkDefault: p.NetworkDefault,
 		Allow:          allow,
@@ -553,20 +565,20 @@ func FromProto(pb *cleanroomv1.Policy) (*CompiledPolicy, error) {
 	if err != nil {
 		return nil, err
 	}
+	services, err := servicesFromProto(pb.GetServices())
+	if err != nil {
+		return nil, err
+	}
 	run, err := runFromProto(pb.GetRun())
 	if err != nil {
 		return nil, err
 	}
 
 	compiled := &CompiledPolicy{
-		Version:     int(pb.GetVersion()),
-		ImageRef:    parsedRef.Original,
-		ImageDigest: parsedRef.Digest(),
-		Services: Services{
-			Docker: DockerService{
-				Required: pb.GetServices().GetDocker().GetRequired(),
-			},
-		},
+		Version:        int(pb.GetVersion()),
+		ImageRef:       parsedRef.Original,
+		ImageDigest:    parsedRef.Digest(),
+		Services:       services,
 		NetworkDefault: networkDefault,
 		Allow:          allow,
 		Dependencies:   dependencies,
@@ -586,11 +598,11 @@ func FromProto(pb *cleanroomv1.Policy) (*CompiledPolicy, error) {
 }
 
 func normalizeDependencies(raw rawDependenciesConfig) (Dependencies, error) {
-	command, err := normalizeDependencyCommand(raw.Command)
+	command, err := normalizeBootstrapCommand(raw.Command, "sandbox.dependencies.command")
 	if err != nil {
 		return Dependencies{}, err
 	}
-	keyFiles, err := normalizeDependencyKeyFiles(raw.Key.Files)
+	keyFiles, err := normalizeBootstrapKeyFiles(raw.Key.Files, "sandbox.dependencies.key.files")
 	if err != nil {
 		return Dependencies{}, err
 	}
@@ -610,11 +622,11 @@ func dependenciesFromProto(pb *cleanroomv1.PolicyDependencies) (Dependencies, er
 	if pb == nil {
 		return Dependencies{}, nil
 	}
-	command, err := normalizeDependencyCommand(pb.GetCommand())
+	command, err := normalizeBootstrapCommand(pb.GetCommand(), "policy dependencies.command")
 	if err != nil {
 		return Dependencies{}, err
 	}
-	keyFiles, err := normalizeDependencyKeyFiles(pb.GetKey().GetFiles())
+	keyFiles, err := normalizeBootstrapKeyFiles(pb.GetKey().GetFiles(), "policy dependencies.key.files")
 	if err != nil {
 		return Dependencies{}, err
 	}
@@ -625,6 +637,51 @@ func dependenciesFromProto(pb *cleanroomv1.PolicyDependencies) (Dependencies, er
 		return Dependencies{}, nil
 	}
 	return Dependencies{
+		Command:  command,
+		KeyFiles: keyFiles,
+	}, nil
+}
+
+func normalizeServices(raw rawServices) (Services, error) {
+	command, err := normalizeBootstrapCommand(raw.Command, "sandbox.services.command")
+	if err != nil {
+		return Services{}, err
+	}
+	keyFiles, err := normalizeBootstrapKeyFiles(raw.Key.Files, "sandbox.services.key.files")
+	if err != nil {
+		return Services{}, err
+	}
+	if len(command) == 0 && len(keyFiles) > 0 {
+		return Services{}, errors.New("sandbox.services.key.files requires sandbox.services.command")
+	}
+	return Services{
+		Docker: DockerService{
+			Required: raw.Docker.Required,
+		},
+		Command:  command,
+		KeyFiles: keyFiles,
+	}, nil
+}
+
+func servicesFromProto(pb *cleanroomv1.PolicyServices) (Services, error) {
+	if pb == nil {
+		return Services{}, nil
+	}
+	command, err := normalizeBootstrapCommand(pb.GetCommand(), "policy services.command")
+	if err != nil {
+		return Services{}, err
+	}
+	keyFiles, err := normalizeBootstrapKeyFiles(pb.GetKey().GetFiles(), "policy services.key.files")
+	if err != nil {
+		return Services{}, err
+	}
+	if len(command) == 0 && len(keyFiles) > 0 {
+		return Services{}, errors.New("policy services.key.files requires services.command")
+	}
+	return Services{
+		Docker: DockerService{
+			Required: pb.GetDocker().GetRequired(),
+		},
 		Command:  command,
 		KeyFiles: keyFiles,
 	}, nil
@@ -664,7 +721,7 @@ func normalizeShellCommand(raw []string, field string) ([]string, error) {
 	return command, nil
 }
 
-func normalizeDependencyCommand(raw []string) ([]string, error) {
+func normalizeBootstrapCommand(raw []string, field string) ([]string, error) {
 	if len(raw) == 0 {
 		return nil, nil
 	}
@@ -672,14 +729,14 @@ func normalizeDependencyCommand(raw []string) ([]string, error) {
 	for i, arg := range raw {
 		trimmed := strings.TrimSpace(arg)
 		if trimmed == "" {
-			return nil, fmt.Errorf("sandbox.dependencies.command[%d] cannot be empty", i)
+			return nil, fmt.Errorf("%s[%d] cannot be empty", field, i)
 		}
 		command = append(command, trimmed)
 	}
 	return command, nil
 }
 
-func normalizeDependencyKeyFiles(raw []string) ([]string, error) {
+func normalizeBootstrapKeyFiles(raw []string, field string) ([]string, error) {
 	if len(raw) == 0 {
 		return nil, nil
 	}
@@ -688,14 +745,14 @@ func normalizeDependencyKeyFiles(raw []string) ([]string, error) {
 	for i, candidate := range raw {
 		trimmed := strings.TrimSpace(candidate)
 		if trimmed == "" {
-			return nil, fmt.Errorf("sandbox.dependencies.key.files[%d] cannot be empty", i)
+			return nil, fmt.Errorf("%s[%d] cannot be empty", field, i)
 		}
 		if strings.HasPrefix(trimmed, "/") {
-			return nil, fmt.Errorf("sandbox.dependencies.key.files[%d] must be relative", i)
+			return nil, fmt.Errorf("%s[%d] must be relative", field, i)
 		}
 		cleaned := path.Clean(strings.ReplaceAll(trimmed, "\\", "/"))
 		if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "../") {
-			return nil, fmt.Errorf("sandbox.dependencies.key.files[%d] must stay within the repository root", i)
+			return nil, fmt.Errorf("%s[%d] must stay within the repository root", field, i)
 		}
 		if _, ok := seen[cleaned]; ok {
 			continue

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -175,6 +175,19 @@ func TestCompileCapturesDockerServiceRequirement(t *testing.T) {
 	}
 }
 
+func TestCompileDefaultsServicesBootstrapDisabled(t *testing.T) {
+	t.Parallel()
+
+	raw := baseRawPolicy()
+	compiled, err := Compile(raw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if compiled.Services.BootstrapEnabled() {
+		t.Fatal("expected compiled policy to disable services bootstrap by default")
+	}
+}
+
 func TestCompileDefaultsDependenciesDisabled(t *testing.T) {
 	t.Parallel()
 
@@ -204,6 +217,29 @@ func TestCompileNormalizesDependencyBootstrapConfig(t *testing.T) {
 	}
 	if got, want := compiled.Dependencies.KeyFiles, []string{"go.mod", "go.sum"}; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
 		t.Fatalf("unexpected dependency key files: got %v want %v", got, want)
+	}
+}
+
+func TestCompileNormalizesServicesBootstrapConfig(t *testing.T) {
+	t.Parallel()
+
+	raw := baseRawPolicy()
+	raw.Sandbox.Services.Docker.Required = true
+	raw.Sandbox.Services.Command = []string{"docker", "compose", "up", "-d", "postgres"}
+	raw.Sandbox.Services.Key.Files = []string{"./docker-compose.yml", "docker-compose.yml"}
+
+	compiled, err := Compile(raw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if !compiled.Services.Docker.Required {
+		t.Fatal("expected compiled policy to preserve docker service requirement")
+	}
+	if got, want := compiled.Services.Command, []string{"docker", "compose", "up", "-d", "postgres"}; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("unexpected services command: got %v want %v", got, want)
+	}
+	if got, want := compiled.Services.KeyFiles, []string{"docker-compose.yml"}; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("unexpected services key files: got %v want %v", got, want)
 	}
 }
 
@@ -654,12 +690,15 @@ func TestFromProtoAcceptsAllowDefault(t *testing.T) {
 	}
 }
 
-func TestCompiledPolicyProtoRoundTripPreservesDependencies(t *testing.T) {
+func TestCompiledPolicyProtoRoundTripPreservesDependenciesAndServices(t *testing.T) {
 	t.Parallel()
 
 	raw := baseRawPolicy()
 	raw.Sandbox.Dependencies.Command = []string{"go", "mod", "download"}
 	raw.Sandbox.Dependencies.Key.Files = []string{"go.mod", "go.sum"}
+	raw.Sandbox.Services.Docker.Required = true
+	raw.Sandbox.Services.Command = []string{"docker", "compose", "up", "-d", "postgres"}
+	raw.Sandbox.Services.Key.Files = []string{"docker-compose.yml"}
 	raw.Sandbox.Run.Before = rawShellCommandSpec{"sh", "-lc", "bin/rails db:prepare"}
 	compiled, err := Compile(raw)
 	if err != nil {
@@ -675,6 +714,15 @@ func TestCompiledPolicyProtoRoundTripPreservesDependencies(t *testing.T) {
 	}
 	if got, want := strings.Join(roundTripped.Dependencies.KeyFiles, "\x00"), strings.Join(compiled.Dependencies.KeyFiles, "\x00"); got != want {
 		t.Fatalf("unexpected dependency key files after round trip: got %q want %q", got, want)
+	}
+	if got, want := roundTripped.Services.Docker.Required, compiled.Services.Docker.Required; got != want {
+		t.Fatalf("unexpected docker requirement after round trip: got %t want %t", got, want)
+	}
+	if got, want := strings.Join(roundTripped.Services.Command, "\x00"), strings.Join(compiled.Services.Command, "\x00"); got != want {
+		t.Fatalf("unexpected services command after round trip: got %q want %q", got, want)
+	}
+	if got, want := strings.Join(roundTripped.Services.KeyFiles, "\x00"), strings.Join(compiled.Services.KeyFiles, "\x00"); got != want {
+		t.Fatalf("unexpected services key files after round trip: got %q want %q", got, want)
 	}
 	if got, want := strings.Join(roundTripped.Run.Before, "\x00"), strings.Join(compiled.Run.Before, "\x00"); got != want {
 		t.Fatalf("unexpected run.before after round trip: got %q want %q", got, want)

--- a/proto/cleanroom/v1/control.proto
+++ b/proto/cleanroom/v1/control.proto
@@ -82,6 +82,8 @@ message PolicyDockerService {
 
 message PolicyServices {
   PolicyDockerService docker = 1;
+  repeated string command = 2;
+  PolicyDependencyKey key = 3;
 }
 
 message PolicyDependencyKey {
@@ -176,6 +178,10 @@ enum CreateSandboxPhase {
   CREATE_SANDBOX_PHASE_PUBLISH_DEPENDENCY_STAGE_CACHE = 10;
   CREATE_SANDBOX_PHASE_READY = 11;
   CREATE_SANDBOX_PHASE_APPLY_REPOSITORY_CHANGESET = 12;
+  CREATE_SANDBOX_PHASE_LOOKUP_SERVICES_STAGE_CACHE = 13;
+  CREATE_SANDBOX_PHASE_RESTORE_SERVICES_STAGE_CACHE = 14;
+  CREATE_SANDBOX_PHASE_BOOTSTRAP_SERVICES = 15;
+  CREATE_SANDBOX_PHASE_PUBLISH_SERVICES_STAGE_CACHE = 16;
 }
 
 message CreateSandboxEvent {


### PR DESCRIPTION
## Summary
- add a cacheable services stage after dependencies, with policy and proto support for `sandbox.services.command` and `sandbox.services.key.files`
- restore services-stage snapshots before dependency and workspace fallback, while keeping `sandbox.run.before` responsible for starting live services
- add cache observability, docs, and regression coverage for services-stage publish, reuse, and restore ordering

## Review Notes
- fixed a restore-precedence bug found in review where a dependency-stage restore that still needed services bootstrap was incorrectly falling through to workspace-stage lookup
- integrated services-stage cache lookups into the newer cache observability span attributes added on `main`

## Testing
- `mise exec -- go test ./internal/policy ./internal/controlservice`
- `mise exec -- go test ./...`
