### PR TITLE
fix: Classify portable dependency cache metrics

### DIFF
--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -193,6 +193,8 @@ func sandboxCreateSourceMetricValue(snapshotID, sourceKind string) string {
 		return "workspace_cache"
 	case "dependency stage cache":
 		return "dependency_cache"
+	case "portable dependency stage cache":
+		return "dependency_cache"
 	case "services stage cache":
 		return "services_cache"
 	}

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -978,6 +978,33 @@ func TestServiceSandboxCreateMetricsUseSnapshotBackend(t *testing.T) {
 	}, 1)
 }
 
+func TestSandboxCreateSourceMetricValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		snapshotID string
+		sourceKind string
+		want       string
+	}{
+		{name: "fresh", want: "fresh"},
+		{name: "snapshot source kind", sourceKind: "snapshot", want: "snapshot"},
+		{name: "snapshot id fallback", snapshotID: "snap-1", want: "snapshot"},
+		{name: "workspace cache", sourceKind: "workspace stage cache", want: "workspace_cache"},
+		{name: "dependency cache", sourceKind: "dependency stage cache", want: "dependency_cache"},
+		{name: "portable dependency cache", sourceKind: "portable dependency stage cache", want: "dependency_cache"},
+		{name: "services cache", sourceKind: "services stage cache", want: "services_cache"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := sandboxCreateSourceMetricValue(tt.snapshotID, tt.sourceKind); got != tt.want {
+				t.Fatalf("sandboxCreateSourceMetricValue(%q, %q) = %q, want %q", tt.snapshotID, tt.sourceKind, got, tt.want)
+			}
+		})
+	}
+}
+
 func testRepositoryMirror(t *testing.T, files map[string]string) (*stubRepositoryMirrorStore, *cleanroomv1.RepositoryCheckout) {
 	t.Helper()
 


### PR DESCRIPTION
Fixes missed review feedback from #233.\n\nPortable dependency-stage restores now report as dependency cache hits in sandbox create metrics instead of falling back to snapshot. Adds a direct mapping test for create source metric values.\n\nValidation:\n- mise exec -- go test ./internal/controlservice