### PR TITLE
feat: Wire gateway Docker Hub mirror and OCI registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Agent sandboxing tools are [proliferating fast](docs/research.md). Most focus on
 
 **Standard OCI images.** Use any OCI image from any registry as your sandbox base. Digest-pinned in policy for reproducibility. No custom VM image format or vendor-specific base images. Same image works across backends.
 
-**Docker inside the sandbox.** Enable a guest Docker daemon with a single policy flag (`services.docker.required: true`). Build and run containers inside the microVM.
+**Docker inside the sandbox.** Enable a guest Docker daemon with a single policy flag (`services.docker.required: true`). Docker Hub pulls are mirrored through the host gateway cache, and you can build and run containers inside the microVM.
 
-**Coming soon:** broader guest-side package-manager rewrites with lockfile enforcement, broader Docker pull caching, hermetic offline build flows, and richer audit surfaces. See the [spec](docs/spec.md) for the full roadmap.
+**Coming soon:** broader guest-side package-manager rewrites with lockfile enforcement, broader non-Docker-Hub registry caching, hermetic offline build flows, and richer audit surfaces. See the [spec](docs/spec.md) for the full roadmap.
 
 ## Install
 

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -16,6 +16,7 @@ Inside sandboxes, the shared gateway is exposed at
 
 | Path | Status | Purpose |
 |------|--------|---------|
+| `/v2/` | Implemented | Docker Hub-compatible pull-through mirror endpoint for guest `dockerd`. |
 | `/git/` | Implemented | Cache-backed Git smart-HTTP route. `.git` remotes use embedded `content-cache`; non-cacheable paths fall back to Cleanroom's mirror-backed proxy. |
 | `/registry/` | Implemented | Cache-backed OCI Distribution route for allowlisted registries. |
 | `/goproxy/` | Implemented | Cache-backed Go module proxy route. Also serves mirrored checksum database requests under `/goproxy/sumdb/`. |
@@ -80,13 +81,44 @@ Current scope:
 - OCI pull-style `GET` and `HEAD` requests
 - built-in prefix mapping for Docker Hub (`docker.io` ->
   `https://registry-1.docker.io`)
-- additional registry-prefix mappings configured inside the gateway
+- additional registry-prefix mappings configured via
+  `gateway.oci.registries` in runtime config
+- custom registry keys must be real registry hosts, not arbitrary aliases
+
+Example runtime config:
+
+```yaml
+gateway:
+  oci:
+    registries:
+      ghcr.io: https://ghcr.io
+      registry.internal:5000: https://registry.internal:5000
+```
 
 Not wired yet:
 
 - guest-wide package-manager rewrites to `/registry/`
 - lockfile enforcement
 - non-OCI package-manager protocol handling
+
+## Docker Hub mirror
+
+`/v2/` exposes a Docker Hub-compatible mirror endpoint backed by the same
+embedded OCI cache. When guest Docker service support is enabled and the OCI
+cache route is live, Cleanroom starts `dockerd` with this gateway endpoint as a
+Docker Hub registry mirror.
+
+Current scope:
+
+- guest `dockerd` pull-through caching for Docker Hub images
+- pull-style `GET` and `HEAD` requests only
+- mirror traffic routed to the same `docker.io` -> `registry-1.docker.io`
+  upstream mapping used by `/registry/`
+
+Not wired yet:
+
+- guest daemon rewrites for non-Docker-Hub registries
+- Docker push or other write operations through the mirror
 
 ## Go module proxy route
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -403,6 +403,8 @@ These rules are installed during sandbox network setup and torn down during clea
 - The gateway exposes a `/registry/` route backed by embedded `content-cache` OCI handlers.
 - The gateway resolves a registry prefix from the request path, maps it to an upstream registry URL, and applies the sandbox allowlist against the mapped policy host and port before forwarding upstream.
 - Current route scope is OCI pull-style `GET` and `HEAD` traffic.
+- The gateway also exposes a Docker Hub-compatible `/v2/` mirror endpoint backed by the same OCI cache so guest `dockerd` can use the shared gateway as a Docker Hub registry mirror.
+- Current Docker mirror scope is Docker Hub pull-style `GET` and `HEAD` traffic.
 - The gateway exposes a `/goproxy/` route backed by embedded `content-cache` Go module proxy handlers, including mirrored sumdb traffic under `/goproxy/sumdb/`.
 - Current Go module scope includes `GOPROXY` metadata requests, module zip downloads, and mirrored checksum-database requests.
 - The gateway also exposes a `/rubygems/` route backed by embedded `content-cache` RubyGems handlers for Bundler mirror traffic to `rubygems.org`.

--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -12,7 +12,7 @@ mise run install
 
 ## Files
 
-- `cleanroom.yaml`: digest-pinned Docker image ref, `sandbox.services.docker.required: true`, and a deny-by-default network allowlist for Docker Hub pull endpoints.
+- `cleanroom.yaml`: digest-pinned Docker image ref, `sandbox.services.docker.required: true`, and a deny-by-default network allowlist for the upstream Docker Hub endpoints that the host gateway validates and fetches against.
 
 ## Quick test flow
 
@@ -33,6 +33,10 @@ Confirm daemon + client are wired:
 ```bash
 mise exec -- cleanroom exec --backend darwin-vz -- docker version
 ```
+
+With the gateway server running, guest `dockerd` automatically uses
+`gateway.cleanroom.internal` as its Docker Hub mirror, backed by the embedded
+OCI cache.
 
 Run a container pull + execution smoke test:
 

--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -950,7 +950,7 @@ func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream 
 		"console=hvc0 root=/dev/vda rw init=%s cleanroom_guest_port=%d %s",
 		guestInitPath,
 		req.GuestPort,
-		dockerServiceBootArgs(req.Policy, req.FirecrackerConfig),
+		dockerServiceBootArgs(req.Policy, req.FirecrackerConfig, a.GatewayPort, a.GatewayRoutes),
 	)
 	consolePath := filepath.Join(runDir, "vm.console.log")
 
@@ -1264,7 +1264,7 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 		"console=hvc0 root=/dev/vda rw init=%s cleanroom_guest_port=%d %s",
 		guestInitPath,
 		cfg.GuestPort,
-		dockerServiceBootArgs(compiled, cfg),
+		dockerServiceBootArgs(compiled, cfg, a.GatewayPort, a.GatewayRoutes),
 	)
 	consolePath := filepath.Join(runDir, "vm.console.log")
 

--- a/internal/backend/darwinvz/docker_bootargs.go
+++ b/internal/backend/darwinvz/docker_bootargs.go
@@ -5,10 +5,11 @@ import (
 	"strings"
 
 	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/gateway"
 	"github.com/buildkite/cleanroom/internal/policy"
 )
 
-func dockerServiceBootArgs(compiled *policy.CompiledPolicy, cfg backend.FirecrackerConfig) string {
+func dockerServiceBootArgs(compiled *policy.CompiledPolicy, cfg backend.FirecrackerConfig, gatewayPort int, routes gateway.ProxyRoutes) string {
 	if compiled == nil || !compiled.RequiresDockerService() {
 		return "cleanroom_service_docker_required=0"
 	}
@@ -28,12 +29,23 @@ func dockerServiceBootArgs(compiled *policy.CompiledPolicy, cfg backend.Firecrac
 		iptables = 1
 	}
 
-	return fmt.Sprintf(
+	args := fmt.Sprintf(
 		"cleanroom_service_docker_required=1 cleanroom_service_docker_startup_timeout=%d cleanroom_service_docker_storage_driver=%s cleanroom_service_docker_iptables=%d",
 		startupSeconds,
 		storageDriver,
 		iptables,
 	)
+	if routes.DockerHubMirror && gatewayPort > 0 {
+		host := sanitizeKernelArgValue(gateway.GuestGatewayHostname)
+		if host != "" {
+			args += fmt.Sprintf(
+				" cleanroom_service_docker_registry_mirror_host=%s cleanroom_service_docker_registry_mirror_port=%d",
+				host,
+				gatewayPort,
+			)
+		}
+	}
+	return args
 }
 
 func sanitizeKernelArgValue(value string) string {

--- a/internal/backend/darwinvz/docker_bootargs_test.go
+++ b/internal/backend/darwinvz/docker_bootargs_test.go
@@ -7,11 +7,12 @@ import (
 	"testing"
 
 	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/gateway"
 	"github.com/buildkite/cleanroom/internal/policy"
 )
 
 func TestDockerServiceBootArgsDisabledByDefault(t *testing.T) {
-	got := dockerServiceBootArgs(nil, backend.FirecrackerConfig{})
+	got := dockerServiceBootArgs(nil, backend.FirecrackerConfig{}, 0, gateway.ProxyRoutes{})
 	if got != "cleanroom_service_docker_required=0" {
 		t.Fatalf("unexpected docker boot args: %q", got)
 	}
@@ -29,15 +30,33 @@ func TestDockerServiceBootArgsUsesPolicyAndRuntimeSettings(t *testing.T) {
 		DockerIPTables:       true,
 	}
 
-	got := dockerServiceBootArgs(compiled, cfg)
+	got := dockerServiceBootArgs(compiled, cfg, 8170, gateway.ProxyRoutes{DockerHubMirror: true})
 	for _, want := range []string{
 		"cleanroom_service_docker_required=1",
 		"cleanroom_service_docker_startup_timeout=45",
 		"cleanroom_service_docker_storage_driver=overlay2",
 		"cleanroom_service_docker_iptables=1",
+		"cleanroom_service_docker_registry_mirror_host=gateway.cleanroom.internal",
+		"cleanroom_service_docker_registry_mirror_port=8170",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("expected %q in docker boot args %q", want, got)
 		}
+	}
+}
+
+func TestDockerServiceBootArgsSkipsMirrorWithoutLiveRoute(t *testing.T) {
+	compiled := &policy.CompiledPolicy{
+		Services: policy.Services{
+			Docker: policy.DockerService{Required: true},
+		},
+	}
+
+	got := dockerServiceBootArgs(compiled, backend.FirecrackerConfig{}, 8170, gateway.ProxyRoutes{})
+	if strings.Contains(got, "cleanroom_service_docker_registry_mirror_host") {
+		t.Fatalf("did not expect docker mirror host in boot args %q", got)
+	}
+	if strings.Contains(got, "cleanroom_service_docker_registry_mirror_port") {
+		t.Fatalf("did not expect docker mirror port in boot args %q", got)
 	}
 }

--- a/internal/backend/darwinvz/guest_init_script.go
+++ b/internal/backend/darwinvz/guest_init_script.go
@@ -178,10 +178,19 @@ if [ "$DOCKER_REQUIRED" = "1" ] && command -v dockerd >/dev/null 2>&1; then
     DOCKER_STORAGE_DRIVER="vfs"
   fi
   DOCKER_IPTABLES="$(arg_value cleanroom_service_docker_iptables || true)"
+  DOCKER_MIRROR_HOST="$(arg_value cleanroom_service_docker_registry_mirror_host || true)"
+  DOCKER_MIRROR_PORT="$(arg_value cleanroom_service_docker_registry_mirror_port || true)"
+  case "$DOCKER_MIRROR_PORT" in
+    ''|*[!0-9]*) DOCKER_MIRROR_PORT="" ;;
+  esac
 
   DOCKER_ARGS="--host=unix:///var/run/docker.sock --storage-driver=$DOCKER_STORAGE_DRIVER"
   if [ "$DOCKER_IPTABLES" = "0" ] || [ "$DOCKER_IPTABLES" = "false" ]; then
     DOCKER_ARGS="$DOCKER_ARGS --iptables=false"
+  fi
+  if [ -n "$DOCKER_MIRROR_HOST" ] && [ -n "$DOCKER_MIRROR_PORT" ]; then
+    DOCKER_ARGS="$DOCKER_ARGS --registry-mirror=http://$DOCKER_MIRROR_HOST:$DOCKER_MIRROR_PORT"
+    DOCKER_ARGS="$DOCKER_ARGS --insecure-registry=$DOCKER_MIRROR_HOST:$DOCKER_MIRROR_PORT"
   fi
 
   mkdir -p /var/log /var/lib/docker /etc/docker /var/run /sys/fs/cgroup

--- a/internal/backend/darwinvz/guest_init_script_test.go
+++ b/internal/backend/darwinvz/guest_init_script_test.go
@@ -94,6 +94,18 @@ func TestGuestInitScriptAutostartsDockerWhenAvailable(t *testing.T) {
 	if !strings.Contains(guestInitScriptTemplate, "DOCKER_IPTABLES=\"$(arg_value cleanroom_service_docker_iptables || true)\"") {
 		t.Fatal("expected docker iptables boot arg lookup in init script")
 	}
+	if !strings.Contains(guestInitScriptTemplate, "DOCKER_MIRROR_HOST=\"$(arg_value cleanroom_service_docker_registry_mirror_host || true)\"") {
+		t.Fatal("expected docker registry mirror host boot arg lookup in init script")
+	}
+	if !strings.Contains(guestInitScriptTemplate, "DOCKER_MIRROR_PORT=\"$(arg_value cleanroom_service_docker_registry_mirror_port || true)\"") {
+		t.Fatal("expected docker registry mirror port boot arg lookup in init script")
+	}
+	if !strings.Contains(guestInitScriptTemplate, "--registry-mirror=http://$DOCKER_MIRROR_HOST:$DOCKER_MIRROR_PORT") {
+		t.Fatal("expected init script to configure dockerd registry mirror when provided")
+	}
+	if !strings.Contains(guestInitScriptTemplate, "--insecure-registry=$DOCKER_MIRROR_HOST:$DOCKER_MIRROR_PORT") {
+		t.Fatal("expected init script to mark the dockerd mirror as insecure for guest HTTP access")
+	}
 
 	if !strings.Contains(guestInitScriptTemplate, "docker version >/dev/null 2>&1") {
 		t.Fatal("expected init script to wait for dockerd API readiness")

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -223,10 +223,19 @@ if [ "$DOCKER_REQUIRED" = "1" ] && command -v dockerd >/dev/null 2>&1; then
     DOCKER_STORAGE_DRIVER="vfs"
   fi
   DOCKER_IPTABLES="$(arg_value cleanroom_service_docker_iptables || true)"
+  DOCKER_MIRROR_HOST="$(arg_value cleanroom_service_docker_registry_mirror_host || true)"
+  DOCKER_MIRROR_PORT="$(arg_value cleanroom_service_docker_registry_mirror_port || true)"
+  case "$DOCKER_MIRROR_PORT" in
+    ''|*[!0-9]*) DOCKER_MIRROR_PORT="" ;;
+  esac
 
   DOCKER_ARGS="--host=unix:///var/run/docker.sock --storage-driver=$DOCKER_STORAGE_DRIVER"
   if [ "$DOCKER_IPTABLES" = "0" ] || [ "$DOCKER_IPTABLES" = "false" ]; then
     DOCKER_ARGS="$DOCKER_ARGS --iptables=false"
+  fi
+  if [ -n "$DOCKER_MIRROR_HOST" ] && [ -n "$DOCKER_MIRROR_PORT" ]; then
+    DOCKER_ARGS="$DOCKER_ARGS --registry-mirror=http://$DOCKER_MIRROR_HOST:$DOCKER_MIRROR_PORT"
+    DOCKER_ARGS="$DOCKER_ARGS --insecure-registry=$DOCKER_MIRROR_HOST:$DOCKER_MIRROR_PORT"
   fi
 
   mkdir -p /var/log /var/lib/docker /etc/docker /var/run /sys/fs/cgroup
@@ -1135,7 +1144,7 @@ func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream 
 	defer cleanupMeasured()
 
 	vsockPath := filepath.Join(runDir, "vsock.sock")
-	dockerBootArgs := dockerServiceBootArgs(req.Policy, req.FirecrackerConfig)
+	dockerBootArgs := dockerServiceBootArgs(req.Policy, req.FirecrackerConfig, a.GatewayPort, a.GatewayRoutes)
 	fcCfg := firecrackerConfig{
 		BootSource: bootSource{
 			KernelImagePath: kernelPath,
@@ -1787,7 +1796,7 @@ func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID strin
 	}
 
 	vsockPath := filepath.Join(runDir, "vsock.sock")
-	dockerBootArgs := dockerServiceBootArgs(compiled, cfg)
+	dockerBootArgs := dockerServiceBootArgs(compiled, cfg, a.GatewayPort, a.GatewayRoutes)
 	fcCfg := firecrackerConfig{
 		BootSource: bootSource{
 			KernelImagePath: kernelPath,
@@ -2489,7 +2498,7 @@ func gatewayEnvVars(instance *sandboxInstance, gwPort int, routes gateway.ProxyR
 	return gateway.ProxyEnvVars(instance.Policy, gwPort, "", routes)
 }
 
-func dockerServiceBootArgs(compiled *policy.CompiledPolicy, cfg backend.FirecrackerConfig) string {
+func dockerServiceBootArgs(compiled *policy.CompiledPolicy, cfg backend.FirecrackerConfig, gatewayPort int, routes gateway.ProxyRoutes) string {
 	if compiled == nil || !compiled.RequiresDockerService() {
 		return "cleanroom_service_docker_required=0"
 	}
@@ -2509,12 +2518,23 @@ func dockerServiceBootArgs(compiled *policy.CompiledPolicy, cfg backend.Firecrac
 		iptables = 1
 	}
 
-	return fmt.Sprintf(
+	args := fmt.Sprintf(
 		"cleanroom_service_docker_required=1 cleanroom_service_docker_startup_timeout=%d cleanroom_service_docker_storage_driver=%s cleanroom_service_docker_iptables=%d",
 		startupSeconds,
 		storageDriver,
 		iptables,
 	)
+	if routes.DockerHubMirror && gatewayPort > 0 {
+		host := sanitizeKernelArgValue(gateway.GuestGatewayHostname)
+		if host != "" {
+			args += fmt.Sprintf(
+				" cleanroom_service_docker_registry_mirror_host=%s cleanroom_service_docker_registry_mirror_port=%d",
+				host,
+				gatewayPort,
+			)
+		}
+	}
+	return args
 }
 
 func sanitizeKernelArgValue(value string) string {

--- a/internal/backend/firecracker/docker_bootargs_test.go
+++ b/internal/backend/firecracker/docker_bootargs_test.go
@@ -5,11 +5,12 @@ import (
 	"testing"
 
 	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/gateway"
 	"github.com/buildkite/cleanroom/internal/policy"
 )
 
 func TestDockerServiceBootArgsDisabledByDefault(t *testing.T) {
-	got := dockerServiceBootArgs(nil, backend.FirecrackerConfig{})
+	got := dockerServiceBootArgs(nil, backend.FirecrackerConfig{}, 0, gateway.ProxyRoutes{})
 	if got != "cleanroom_service_docker_required=0" {
 		t.Fatalf("unexpected docker boot args: %q", got)
 	}
@@ -27,12 +28,14 @@ func TestDockerServiceBootArgsUsesPolicyAndRuntimeSettings(t *testing.T) {
 		DockerIPTables:       true,
 	}
 
-	got := dockerServiceBootArgs(compiled, cfg)
+	got := dockerServiceBootArgs(compiled, cfg, 8170, gateway.ProxyRoutes{DockerHubMirror: true})
 	for _, want := range []string{
 		"cleanroom_service_docker_required=1",
 		"cleanroom_service_docker_startup_timeout=45",
 		"cleanroom_service_docker_storage_driver=overlay2",
 		"cleanroom_service_docker_iptables=1",
+		"cleanroom_service_docker_registry_mirror_host=gateway.cleanroom.internal",
+		"cleanroom_service_docker_registry_mirror_port=8170",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("expected %q in docker boot args %q", want, got)
@@ -46,7 +49,7 @@ func TestDockerServiceBootArgsUsesSafeDefaults(t *testing.T) {
 			Docker: policy.DockerService{Required: true},
 		},
 	}
-	got := dockerServiceBootArgs(compiled, backend.FirecrackerConfig{})
+	got := dockerServiceBootArgs(compiled, backend.FirecrackerConfig{}, 0, gateway.ProxyRoutes{})
 	for _, want := range []string{
 		"cleanroom_service_docker_startup_timeout=20",
 		"cleanroom_service_docker_storage_driver=vfs",
@@ -55,5 +58,21 @@ func TestDockerServiceBootArgsUsesSafeDefaults(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Fatalf("expected %q in docker boot args %q", want, got)
 		}
+	}
+}
+
+func TestDockerServiceBootArgsSkipsMirrorWithoutLiveRoute(t *testing.T) {
+	compiled := &policy.CompiledPolicy{
+		Services: policy.Services{
+			Docker: policy.DockerService{Required: true},
+		},
+	}
+
+	got := dockerServiceBootArgs(compiled, backend.FirecrackerConfig{}, 8170, gateway.ProxyRoutes{})
+	if strings.Contains(got, "cleanroom_service_docker_registry_mirror_host") {
+		t.Fatalf("did not expect docker mirror host in boot args %q", got)
+	}
+	if strings.Contains(got, "cleanroom_service_docker_registry_mirror_port") {
+		t.Fatalf("did not expect docker mirror port in boot args %q", got)
 	}
 }

--- a/internal/backend/firecracker/guest_init_script_test.go
+++ b/internal/backend/firecracker/guest_init_script_test.go
@@ -18,6 +18,18 @@ func TestGuestInitScriptAutostartsDockerWhenAvailable(t *testing.T) {
 	if !strings.Contains(guestInitScriptTemplate, "DOCKER_IPTABLES=\"$(arg_value cleanroom_service_docker_iptables || true)\"") {
 		t.Fatal("expected docker iptables boot arg lookup in init script")
 	}
+	if !strings.Contains(guestInitScriptTemplate, "DOCKER_MIRROR_HOST=\"$(arg_value cleanroom_service_docker_registry_mirror_host || true)\"") {
+		t.Fatal("expected docker registry mirror host boot arg lookup in init script")
+	}
+	if !strings.Contains(guestInitScriptTemplate, "DOCKER_MIRROR_PORT=\"$(arg_value cleanroom_service_docker_registry_mirror_port || true)\"") {
+		t.Fatal("expected docker registry mirror port boot arg lookup in init script")
+	}
+	if !strings.Contains(guestInitScriptTemplate, "--registry-mirror=http://$DOCKER_MIRROR_HOST:$DOCKER_MIRROR_PORT") {
+		t.Fatal("expected init script to configure dockerd registry mirror when provided")
+	}
+	if !strings.Contains(guestInitScriptTemplate, "--insecure-registry=$DOCKER_MIRROR_HOST:$DOCKER_MIRROR_PORT") {
+		t.Fatal("expected init script to mark the dockerd mirror as insecure for guest HTTP access")
+	}
 	if !strings.Contains(guestInitScriptTemplate, "docker version >/dev/null 2>&1") {
 		t.Fatal("expected init script to wait for dockerd API readiness")
 	}

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/buildkite/cleanroom/internal/backend"
 	backendfirecracker "github.com/buildkite/cleanroom/internal/backend/firecracker"
+	"github.com/buildkite/cleanroom/internal/gateway"
 	"github.com/buildkite/cleanroom/internal/policy"
 	"github.com/buildkite/cleanroom/internal/runtimeconfig"
 )
@@ -140,8 +141,8 @@ func TestDoctorCommandJSONIncludesCapabilities(t *testing.T) {
 	if payload.Gateway.DefaultPort != 8170 {
 		t.Fatalf("unexpected gateway default port: %d", payload.Gateway.DefaultPort)
 	}
-	if len(payload.Gateway.Routes) != 7 {
-		t.Fatalf("expected 7 gateway routes, got %d (%v)", len(payload.Gateway.Routes), payload.Gateway.Routes)
+	if len(payload.Gateway.Routes) != len(gateway.Routes()) {
+		t.Fatalf("expected %d gateway routes, got %d (%v)", len(gateway.Routes()), len(payload.Gateway.Routes), payload.Gateway.Routes)
 	}
 	foundGitHub := false
 	for _, h := range payload.Gateway.CredentialHosts {

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -100,6 +100,7 @@ func (s *ServeCommand) runServer(ctx *runtimeContext) error {
 	var contentCache *gateway.ContentCache
 	contentCache, err = newGatewayContentCache(gateway.ContentCacheConfig{
 		GitAllowedHosts:   ctx.Config.Gateway.Git.CacheHosts,
+		OCIRegistries:     ctx.Config.Gateway.OCI.Registries,
 		FetchAllowedHosts: append([]string(nil), defaultGatewayFetchHosts...),
 		Credentials:       gwCredentials,
 		Logger:            logger.With("subsystem", "content-cache"),
@@ -134,9 +135,10 @@ func (s *ServeCommand) runServer(ctx *runtimeContext) error {
 	}
 
 	configureGatewayBackends(ctx.Backends, gwRegistry, gwPort, gwServer.Addr(), darwinGatewayHost, gateway.ProxyRoutes{
-		RubyGems: contentCache != nil && contentCache.HasRubyGemsHandler(),
-		GoProxy:  contentCache != nil && contentCache.HasGoProxyHandler() && contentCache.HasSumDBHandler(),
-		Fetch:    contentCache != nil && contentCache.FetchAllowsHost("dl.google.com"),
+		DockerHubMirror: contentCache != nil && contentCache.HasOCIHandler(),
+		RubyGems:        contentCache != nil && contentCache.HasRubyGemsHandler(),
+		GoProxy:         contentCache != nil && contentCache.HasGoProxyHandler() && contentCache.HasSumDBHandler(),
+		Fetch:           contentCache != nil && contentCache.FetchAllowsHost("dl.google.com"),
 	})
 
 	if fcAdapter, ok := ctx.Backends["firecracker"].(*firecracker.Adapter); ok && fcAdapter.GatewayRegistry != nil {

--- a/internal/cli/serve_lifecycle_test.go
+++ b/internal/cli/serve_lifecycle_test.go
@@ -159,7 +159,7 @@ func TestServeCommandRunServerStartsWithoutContentCache(t *testing.T) {
 	}
 }
 
-func TestServeCommandRunServerPassesGatewayGitCacheHostsToContentCache(t *testing.T) {
+func TestServeCommandRunServerPassesGatewayCacheConfigToContentCache(t *testing.T) {
 	listenAddr := reserveLocalTCPAddr(t)
 	var cancelRun context.CancelFunc
 	stubServeNotifyContext(t, func(parent context.Context, _ ...os.Signal) (context.Context, context.CancelFunc) {
@@ -191,6 +191,11 @@ func TestServeCommandRunServerPassesGatewayGitCacheHostsToContentCache(t *testin
 					Git: runtimeconfig.GatewayGitConfig{
 						CacheHosts: []string{"github.com", "gitlab.com"},
 					},
+					OCI: runtimeconfig.GatewayOCIConfig{
+						Registries: map[string]string{
+							"ghcr.io": "https://ghcr.io",
+						},
+					},
 				},
 			},
 			Backends: map[string]backend.Adapter{},
@@ -200,6 +205,9 @@ func TestServeCommandRunServerPassesGatewayGitCacheHostsToContentCache(t *testin
 	waitForHTTPHealthz(t, fmt.Sprintf("http://%s/healthz", listenAddr), 5*time.Second)
 	if got, want := captured.GitAllowedHosts, []string{"github.com", "gitlab.com"}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
 		t.Fatalf("unexpected git cache hosts: got %v want %v", got, want)
+	}
+	if got, want := captured.OCIRegistries["ghcr.io"], "https://ghcr.io"; got != want {
+		t.Fatalf("unexpected OCI registry mapping: got %q want %q", got, want)
 	}
 	if got, want := captured.FetchAllowedHosts, []string{"dl.google.com"}; len(got) != len(want) || got[0] != want[0] {
 		t.Fatalf("unexpected fetch cache hosts: got %v want %v", got, want)

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -72,13 +72,16 @@ func TestConfigureGatewayBackendsConfiguresDarwinVZGateway(t *testing.T) {
 		"darwin-vz":   darwinAdapter,
 	}
 
-	configureGatewayBackends(backends, gwRegistry, 8170, "0.0.0.0:8170", "192.168.64.1", gateway.ProxyRoutes{RubyGems: true, GoProxy: true, Fetch: true})
+	configureGatewayBackends(backends, gwRegistry, 8170, "0.0.0.0:8170", "192.168.64.1", gateway.ProxyRoutes{DockerHubMirror: true, RubyGems: true, GoProxy: true, Fetch: true})
 
 	if fcAdapter.GatewayRegistry == nil {
 		t.Fatal("expected firecracker adapter to use the host gateway registry")
 	}
 	if got, want := fcAdapter.GatewayPort, 8170; got != want {
 		t.Fatalf("unexpected firecracker gateway port: got %d want %d", got, want)
+	}
+	if !fcAdapter.GatewayRoutes.DockerHubMirror {
+		t.Fatal("expected firecracker adapter to receive live docker hub mirror state")
 	}
 	if !fcAdapter.GatewayRoutes.RubyGems {
 		t.Fatal("expected firecracker adapter to receive live rubygems route state")
@@ -97,6 +100,9 @@ func TestConfigureGatewayBackendsConfiguresDarwinVZGateway(t *testing.T) {
 	}
 	if got, want := darwinAdapter.GatewayBridgeURL, "http://127.0.0.1:8170"; got != want {
 		t.Fatalf("unexpected darwin-vz gateway bridge url: got %q want %q", got, want)
+	}
+	if !darwinAdapter.GatewayRoutes.DockerHubMirror {
+		t.Fatal("expected darwin-vz adapter to receive live docker hub mirror state")
 	}
 	if !darwinAdapter.GatewayRoutes.RubyGems {
 		t.Fatal("expected darwin-vz adapter to receive live rubygems route state")

--- a/internal/gateway/contentcache.go
+++ b/internal/gateway/contentcache.go
@@ -41,9 +41,10 @@ type ContentCacheConfig struct {
 	// policy-allowed host.
 	GitAllowedHosts []string
 
-	// OCIRegistries maps a request prefix to an upstream registry URL. Entries
-	// augment the built-in defaults and are useful for aliases such as
-	// {"docker.io": "https://registry-1.docker.io"} or custom symbolic prefixes.
+	// OCIRegistries maps a registry host-style prefix to an upstream registry
+	// URL. Entries augment the built-in defaults and are useful for host-based
+	// remaps such as {"docker.io": "https://registry-1.docker.io"} or
+	// {"registry.internal:5000": "https://registry.internal"}.
 	OCIRegistries map[string]string
 
 	// TagTTL controls how long OCI tag→digest mappings are cached.
@@ -446,6 +447,9 @@ func normalizeOCIRegistryMappings(registries map[string]string) (map[string]stri
 		normalizedURL := strings.TrimRight(strings.TrimSpace(registryURL), "/")
 		if normalizedPrefix == "" || normalizedURL == "" {
 			continue
+		}
+		if !isRegistryHostPrefix(normalizedPrefix) {
+			return nil, fmt.Errorf("registry mapping key %q must be a registry host", prefix)
 		}
 		if !strings.Contains(normalizedURL, "://") {
 			normalizedURL = "https://" + normalizedURL

--- a/internal/gateway/dockerhub_cached.go
+++ b/internal/gateway/dockerhub_cached.go
@@ -1,0 +1,132 @@
+package gateway
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/buildkite/cleanroom/internal/observability"
+	"github.com/charmbracelet/log"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const dockerHubMirrorPrefix = "docker.io"
+
+// dockerHubMirrorHandler exposes a Docker Hub-compatible pull-through mirror at
+// /v2/ so guest dockerd can use the shared gateway as a registry mirror.
+type dockerHubMirrorHandler struct {
+	cache  registryPrefixHandlerProvider
+	logger *log.Logger
+}
+
+func newDockerHubMirrorHandler(cache registryPrefixHandlerProvider, logger *log.Logger) *dockerHubMirrorHandler {
+	return &dockerHubMirrorHandler{
+		cache:  cache,
+		logger: logger,
+	}
+}
+
+func (h *dockerHubMirrorHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	scope, ok := ScopeFromContext(r.Context())
+	if !ok {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+	span := trace.SpanFromContext(r.Context())
+
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonMethodNotAllowed)
+		span.SetAttributes(
+			attribute.String(observability.AttrGatewayAction, gatewayActionDeny),
+			attribute.String(observability.AttrReasonCode, reasonMethodNotAllowed),
+		)
+		span.SetStatus(codes.Error, "only GET and HEAD are permitted for docker hub mirror")
+		writeReasonError(w, http.StatusMethodNotAllowed, reasonMethodNotAllowed, "only GET and HEAD are permitted for docker hub mirror")
+		return
+	}
+
+	policyHost, policyPort, upstreamHost, upstreamPort, err := h.cache.OCIUpstreamForPrefix(dockerHubMirrorPrefix)
+	if err != nil {
+		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonUnknownRegistryPrefix)
+		span.RecordError(err)
+		span.SetAttributes(
+			attribute.String(observability.AttrGatewayAction, gatewayActionDeny),
+			attribute.String(observability.AttrReasonCode, reasonUnknownRegistryPrefix),
+			attribute.String(observability.AttrGatewayRegistryPrefix, dockerHubMirrorPrefix),
+		)
+		span.SetStatus(codes.Error, err.Error())
+		h.auditLog(r.Context(), scope.SandboxID, dockerHubMirrorPrefix, gatewayActionDeny, reasonUnknownRegistryPrefix)
+		writeReasonError(w, http.StatusNotFound, reasonUnknownRegistryPrefix, "docker hub mirror is not configured")
+		return
+	}
+
+	span.SetAttributes(
+		attribute.String(observability.AttrGatewayRegistryPrefix, dockerHubMirrorPrefix),
+		attribute.String(observability.AttrGatewayTargetHost, policyHost),
+	)
+	if !scope.Policy.Allows(policyHost, policyPort) {
+		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonHostNotAllowed)
+		span.SetAttributes(
+			attribute.String(observability.AttrGatewayAction, gatewayActionDeny),
+			attribute.String(observability.AttrReasonCode, reasonHostNotAllowed),
+		)
+		span.SetStatus(codes.Error, "upstream registry host is not allowed by sandbox policy")
+		h.auditLog(r.Context(), scope.SandboxID, policyHost, gatewayActionDeny, reasonHostNotAllowed)
+		writeReasonError(w, http.StatusForbidden, reasonHostNotAllowed, "upstream registry host is not allowed by sandbox policy")
+		return
+	}
+
+	cacheHandler, err := h.cache.OCIHandlerForPrefix(dockerHubMirrorPrefix)
+	if err != nil {
+		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonUnknownRegistryPrefix)
+		span.RecordError(err)
+		span.SetAttributes(
+			attribute.String(observability.AttrGatewayAction, gatewayActionDeny),
+			attribute.String(observability.AttrReasonCode, reasonUnknownRegistryPrefix),
+			attribute.String(observability.AttrGatewayRegistryPrefix, dockerHubMirrorPrefix),
+		)
+		span.SetStatus(codes.Error, err.Error())
+		h.auditLog(r.Context(), scope.SandboxID, dockerHubMirrorPrefix, gatewayActionDeny, reasonUnknownRegistryPrefix)
+		writeReasonError(w, http.StatusNotFound, reasonUnknownRegistryPrefix, "docker hub mirror is not configured")
+		return
+	}
+
+	span.SetAttributes(
+		attribute.String(observability.AttrGatewayAction, gatewayActionAllow),
+		attribute.String(observability.AttrReasonCode, reasonCached),
+		attribute.Int(observability.AttrGatewayUpstreamPort, upstreamPort),
+		attribute.String(observability.AttrGatewayUpstreamHost, upstreamHost),
+	)
+	setGatewayRequestDecision(r.Context(), gatewayActionAllow, reasonCached)
+	h.auditLog(r.Context(), scope.SandboxID, upstreamHost, gatewayActionAllow, reasonCached)
+
+	r = r.Clone(withOCIUpstreamPolicy(r.Context(), policyHost, policyPort, upstreamHost, upstreamPort))
+	r.URL.Path = rewriteDockerHubMirrorPath(r.URL.Path)
+	r.URL.RawPath = ""
+	cacheHandler.ServeHTTP(w, r)
+}
+
+func rewriteDockerHubMirrorPath(path string) string {
+	switch path {
+	case "/v2", "/v2/":
+		return "/v2/"
+	}
+	remainder := strings.TrimPrefix(path, "/v2/")
+	return "/v2/" + dockerHubMirrorPrefix + "/" + remainder
+}
+
+func (h *dockerHubMirrorHandler) auditLog(ctx context.Context, sandboxID, target, action, reason string) {
+	logger := observability.WithTraceContext(h.logger, ctx)
+	if logger == nil {
+		return
+	}
+	logger.Info("gateway docker hub mirror request",
+		observability.LogFieldSandboxID, sandboxID,
+		"service", "registry",
+		"target", target,
+		"action", action,
+		observability.LogFieldReasonCode, reason,
+	)
+}

--- a/internal/gateway/dockerhub_cached_test.go
+++ b/internal/gateway/dockerhub_cached_test.go
@@ -1,0 +1,138 @@
+package gateway
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestDockerHubMirrorHandlerRewritesManifestPath(t *testing.T) {
+	t.Parallel()
+
+	var capturedPath string
+	backend := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	})
+	provider := &stubRegistryPrefixHandlerProvider{
+		handler:      backend,
+		policyHost:   "docker.io",
+		policyPort:   443,
+		upstreamHost: "registry-1.docker.io",
+		upstreamPort: 443,
+	}
+	h := newDockerHubMirrorHandler(provider, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/v2/library/alpine/manifests/latest", nil)
+	req = withScope(req, registryTestScope("docker.io"))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	if want := "/v2/docker.io/library/alpine/manifests/latest"; capturedPath != want {
+		t.Fatalf("expected backend path %q, got %q", want, capturedPath)
+	}
+	if got := provider.prefix; got != dockerHubMirrorPrefix {
+		t.Fatalf("expected prefix %q, got %q", dockerHubMirrorPrefix, got)
+	}
+}
+
+func TestDockerHubMirrorHandlerRewritesVersionProbe(t *testing.T) {
+	t.Parallel()
+
+	var capturedPath string
+	backend := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	})
+	provider := &stubRegistryPrefixHandlerProvider{
+		handler:      backend,
+		policyHost:   "docker.io",
+		policyPort:   443,
+		upstreamHost: "registry-1.docker.io",
+		upstreamPort: 443,
+	}
+	h := newDockerHubMirrorHandler(provider, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/v2/", nil)
+	req = withScope(req, registryTestScope("docker.io"))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	if want := "/v2/"; capturedPath != want {
+		t.Fatalf("expected backend path %q, got %q", want, capturedPath)
+	}
+}
+
+func TestDockerHubMirrorHandlerDeniesPolicyMiss(t *testing.T) {
+	t.Parallel()
+
+	backend := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Fatal("backend should not be called for denied host")
+	})
+	provider := &stubRegistryPrefixHandlerProvider{
+		handler:      backend,
+		policyHost:   "docker.io",
+		policyPort:   443,
+		upstreamHost: "registry-1.docker.io",
+		upstreamPort: 443,
+	}
+	h := newDockerHubMirrorHandler(provider, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/v2/library/alpine/manifests/latest", nil)
+	req = withScope(req, registryTestScope("ghcr.io"))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", w.Code)
+	}
+	if got := w.Header().Get(reasonCodeHeader); got != reasonHostNotAllowed {
+		t.Fatalf("expected reason %s, got %q", reasonHostNotAllowed, got)
+	}
+}
+
+func TestDockerHubMirrorHandlerRejectsPost(t *testing.T) {
+	t.Parallel()
+
+	backend := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Fatal("backend should not be called for POST")
+	})
+	h := newDockerHubMirrorHandler(&stubRegistryPrefixHandlerProvider{handler: backend}, nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/v2/library/alpine/manifests/latest", nil)
+	req = withScope(req, registryTestScope("docker.io"))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestDockerHubMirrorHandlerRequiresConfiguredOCI(t *testing.T) {
+	t.Parallel()
+
+	backend := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Fatal("backend should not be called when docker hub mirror is unavailable")
+	})
+	h := newDockerHubMirrorHandler(&stubRegistryPrefixHandlerProvider{
+		handler: backend,
+		err:     errors.New("unknown prefix"),
+	}, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/v2/library/alpine/manifests/latest", nil)
+	req = withScope(req, registryTestScope("docker.io"))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}

--- a/internal/gateway/git_proxy_env.go
+++ b/internal/gateway/git_proxy_env.go
@@ -35,9 +35,10 @@ const (
 
 // ProxyRoutes describes which gateway-backed guest proxy routes are live.
 type ProxyRoutes struct {
-	RubyGems bool
-	GoProxy  bool
-	Fetch    bool
+	DockerHubMirror bool
+	RubyGems        bool
+	GoProxy         bool
+	Fetch           bool
 }
 
 // GitProxyEnvVars returns git config environment variables that rewrite allowed

--- a/internal/gateway/oci_cached_test.go
+++ b/internal/gateway/oci_cached_test.go
@@ -435,28 +435,17 @@ func TestResolveOCIRegistryRouteUsesDockerHubAlias(t *testing.T) {
 	}
 }
 
-func TestResolveOCIRegistryRoutePreservesConfiguredPortForSymbolicPrefix(t *testing.T) {
+func TestNormalizeOCIRegistryMappingsRejectsSymbolicPrefix(t *testing.T) {
 	t.Parallel()
 
-	routes, err := normalizeOCIRegistryMappings(map[string]string{
+	_, err := normalizeOCIRegistryMappings(map[string]string{
 		"registry-cache": "https://registry.internal:5000",
 	})
-	if err != nil {
-		t.Fatalf("normalizeOCIRegistryMappings returned error: %v", err)
+	if err == nil {
+		t.Fatal("expected symbolic registry prefix to be rejected")
 	}
-
-	route, err := resolveOCIRegistryRoute("registry-cache", routes)
-	if err != nil {
-		t.Fatalf("resolveOCIRegistryRoute returned error: %v", err)
-	}
-	if route.policyHost != "registry.internal" {
-		t.Fatalf("expected registry.internal policy host, got %q", route.policyHost)
-	}
-	if route.policyPort != 5000 {
-		t.Fatalf("expected registry.internal policy port 5000, got %d", route.policyPort)
-	}
-	if route.upstreamHost != "registry.internal" {
-		t.Fatalf("expected registry.internal upstream host, got %q", route.upstreamHost)
+	if got, want := err.Error(), `registry mapping key "registry-cache" must be a registry host`; got != want {
+		t.Fatalf("unexpected error: got %q want %q", got, want)
 	}
 }
 

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -22,8 +22,9 @@ import (
 
 // DefaultPort is the default gateway listen port.
 const (
-	DefaultPort       = 8170
-	DefaultListenAddr = ":8170"
+	DefaultPort          = 8170
+	DefaultListenAddr    = ":8170"
+	RouteDockerHubMirror = "/v2/"
 
 	RouteGit      = "/git/"
 	RouteRegistry = "/registry/"
@@ -35,6 +36,7 @@ const (
 )
 
 var serviceRoutes = []string{
+	RouteDockerHubMirror,
 	RouteGit,
 	RouteRegistry,
 	RouteGoProxy,
@@ -222,8 +224,13 @@ func NewServer(cfg ServerConfig) *Server {
 
 	// Registry: prefer content-cache OCI handler, fall back to stub.
 	if cfg.ContentCache != nil && cfg.ContentCache.HasOCIHandler() {
+		dockerHubMirror := newDockerHubMirrorHandler(cfg.ContentCache, cfg.Logger)
+		mux.Handle("/v2", dockerHubMirror)
+		mux.Handle(RouteDockerHubMirror, dockerHubMirror)
 		mux.Handle(RouteRegistry, newCachedRegistryHandler(cfg.ContentCache, cfg.Logger))
 	} else {
+		mux.HandleFunc("/v2", stubHandler("dockerhub mirror"))
+		mux.HandleFunc(RouteDockerHubMirror, stubHandler("dockerhub mirror"))
 		mux.HandleFunc(RouteRegistry, stubHandler("registry"))
 	}
 
@@ -484,6 +491,8 @@ func (r *gatewayStatusRecorder) Write(p []byte) (int, error) {
 
 func gatewayServiceForPath(path string) string {
 	switch {
+	case path == "/v2" || strings.HasPrefix(path, RouteDockerHubMirror):
+		return "registry"
 	case strings.HasPrefix(path, RouteGit):
 		return "git"
 	case strings.HasPrefix(path, RouteRegistry):

--- a/internal/gateway/server_test.go
+++ b/internal/gateway/server_test.go
@@ -105,6 +105,16 @@ func TestGatewayServiceForPathClassifiesGoProxy(t *testing.T) {
 	}
 }
 
+func TestGatewayServiceForPathClassifiesDockerHubMirror(t *testing.T) {
+	t.Parallel()
+
+	for _, path := range []string{"/v2", "/v2/library/alpine/manifests/latest"} {
+		if got, want := gatewayServiceForPath(path), "registry"; got != want {
+			t.Fatalf("unexpected service classification for %q: got %q want %q", path, got, want)
+		}
+	}
+}
+
 func TestGatewayServiceForPathClassifiesSumDB(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtimeconfig/config.go
+++ b/internal/runtimeconfig/config.go
@@ -29,10 +29,15 @@ type Config struct {
 
 type GatewayConfig struct {
 	Git GatewayGitConfig `yaml:"git,omitempty"`
+	OCI GatewayOCIConfig `yaml:"oci,omitempty"`
 }
 
 type GatewayGitConfig struct {
 	CacheHosts []string `yaml:"cache_hosts,omitempty"`
+}
+
+type GatewayOCIConfig struct {
+	Registries map[string]string `yaml:"registries,omitempty"`
 }
 
 type ObservabilityConfig struct {
@@ -445,6 +450,7 @@ func normalizeConfig(cfg Config, inferredDefaultBackend string) Config {
 	}
 	cfg.ControlHost = strings.TrimSpace(cfg.ControlHost)
 	cfg.Gateway.Git.CacheHosts = trimStringSlice(cfg.Gateway.Git.CacheHosts)
+	cfg.Gateway.OCI.Registries = trimStringMap(cfg.Gateway.OCI.Registries)
 	cfg.Observability.DeploymentEnvironment = strings.TrimSpace(cfg.Observability.DeploymentEnvironment)
 	cfg.Observability.Logs.Format = strings.ToLower(strings.TrimSpace(cfg.Observability.Logs.Format))
 	if cfg.Observability.Logs.Format == "" {

--- a/internal/runtimeconfig/config_test.go
+++ b/internal/runtimeconfig/config_test.go
@@ -720,6 +720,40 @@ func TestLoadTrimsGatewayGitCacheHosts(t *testing.T) {
 	}
 }
 
+func TestLoadTrimsGatewayOCIRegistries(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	configPath := filepath.Join(tmp, "cleanroom", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+
+	content := `gateway:
+  oci:
+    registries:
+      " ghcr.io ": " https://ghcr.io/ "
+      "": "https://example.invalid"
+      " registry.internal:5000 ": " registry.internal:5000 "
+`
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, _, err := Load()
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if got, want := len(cfg.Gateway.OCI.Registries), 2; got != want {
+		t.Fatalf("unexpected registry mapping count: got %d want %d", got, want)
+	}
+	if got, want := cfg.Gateway.OCI.Registries["ghcr.io"], "https://ghcr.io/"; got != want {
+		t.Fatalf("unexpected ghcr registry mapping: got %q want %q", got, want)
+	}
+	if got, want := cfg.Gateway.OCI.Registries["registry.internal:5000"], "registry.internal:5000"; got != want {
+		t.Fatalf("unexpected internal registry mapping: got %q want %q", got, want)
+	}
+}
+
 func TestLoadObservabilitySupportsZeroSamplingRatio(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)


### PR DESCRIPTION
## Summary
- expose a Docker Hub-compatible `/v2/` gateway mirror and wire guest `dockerd` to use it on both backends
- add `gateway.oci.registries` runtime config and pass the configured host mappings into the embedded OCI cache
- require custom OCI registry keys to be real registry hosts instead of symbolic aliases, and update the tests and docs to match

## Why
- let guest Docker Hub pulls use the cache-backed gateway path instead of fetching upstream directly
- make OCI registry routing/config align with the host-based policy model and avoid ambiguous alias keys

## Testing
- `mise exec -- go test ./...`
