### PR TITLE
feat: Default guest Docker to overlay2

### DIFF
--- a/examples/docker/cleanroom.yaml
+++ b/examples/docker/cleanroom.yaml
@@ -14,3 +14,5 @@ sandbox:
         ports: [443]
       - host: production.cloudflare.docker.com
         ports: [443]
+      - host: docker-images-prod.6aa30f8b08e16409b46e0173d6de2f56.r2.cloudflarestorage.com
+        ports: [443]

--- a/internal/backend/darwinvz/docker_bootargs.go
+++ b/internal/backend/darwinvz/docker_bootargs.go
@@ -21,7 +21,7 @@ func dockerServiceBootArgs(compiled *policy.CompiledPolicy, cfg backend.Firecrac
 
 	storageDriver := sanitizeKernelArgValue(strings.TrimSpace(cfg.DockerStorageDriver))
 	if storageDriver == "" {
-		storageDriver = "vfs"
+		storageDriver = "overlay2"
 	}
 
 	iptables := 0

--- a/internal/backend/darwinvz/guest_init_script.go
+++ b/internal/backend/darwinvz/guest_init_script.go
@@ -175,7 +175,7 @@ if [ "$DOCKER_REQUIRED" = "1" ] && command -v dockerd >/dev/null 2>&1; then
   fi
   DOCKER_STORAGE_DRIVER="$(arg_value cleanroom_service_docker_storage_driver || true)"
   if [ -z "$DOCKER_STORAGE_DRIVER" ]; then
-    DOCKER_STORAGE_DRIVER="vfs"
+    DOCKER_STORAGE_DRIVER="overlay2"
   fi
   DOCKER_IPTABLES="$(arg_value cleanroom_service_docker_iptables || true)"
   DOCKER_MIRROR_HOST="$(arg_value cleanroom_service_docker_registry_mirror_host || true)"

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -220,7 +220,7 @@ if [ "$DOCKER_REQUIRED" = "1" ] && command -v dockerd >/dev/null 2>&1; then
   fi
   DOCKER_STORAGE_DRIVER="$(arg_value cleanroom_service_docker_storage_driver || true)"
   if [ -z "$DOCKER_STORAGE_DRIVER" ]; then
-    DOCKER_STORAGE_DRIVER="vfs"
+    DOCKER_STORAGE_DRIVER="overlay2"
   fi
   DOCKER_IPTABLES="$(arg_value cleanroom_service_docker_iptables || true)"
   DOCKER_MIRROR_HOST="$(arg_value cleanroom_service_docker_registry_mirror_host || true)"
@@ -2511,7 +2511,7 @@ func dockerServiceBootArgs(compiled *policy.CompiledPolicy, cfg backend.Firecrac
 
 	storageDriver := sanitizeKernelArgValue(strings.TrimSpace(cfg.DockerStorageDriver))
 	if storageDriver == "" {
-		storageDriver = "vfs"
+		storageDriver = "overlay2"
 	}
 
 	iptables := 0

--- a/internal/backend/firecracker/docker_bootargs_test.go
+++ b/internal/backend/firecracker/docker_bootargs_test.go
@@ -52,7 +52,7 @@ func TestDockerServiceBootArgsUsesSafeDefaults(t *testing.T) {
 	got := dockerServiceBootArgs(compiled, backend.FirecrackerConfig{}, 0, gateway.ProxyRoutes{})
 	for _, want := range []string{
 		"cleanroom_service_docker_startup_timeout=20",
-		"cleanroom_service_docker_storage_driver=vfs",
+		"cleanroom_service_docker_storage_driver=overlay2",
 		"cleanroom_service_docker_iptables=0",
 	} {
 		if !strings.Contains(got, want) {

--- a/internal/cli/config_init_test.go
+++ b/internal/cli/config_init_test.go
@@ -87,6 +87,9 @@ func TestConfigInitWritesRuntimeConfig(t *testing.T) {
 		if got, want := int64(cfg.Backends.DarwinVZ.MinimumRootFSBytes), int64(4<<30); got != want {
 			t.Fatalf("expected backends.darwin-vz.minimum_rootfs_bytes=%d, got %d", want, got)
 		}
+		if got, want := cfg.Backends.DarwinVZ.Services.Docker.StorageDriver, "overlay2"; got != want {
+			t.Fatalf("expected backends.darwin-vz.services.docker.storage_driver=%q, got %q", want, got)
+		}
 		if !strings.Contains(string(raw), "memory_mib: 4096") {
 			t.Fatalf("expected generated config to include memory_mib: 4096, got:\n%s", raw)
 		}
@@ -117,7 +120,7 @@ func TestConfigInitWritesRuntimeConfig(t *testing.T) {
 		if got, want := cfg.Backends.Firecracker.Services.Docker.StartupTimeoutSeconds, int64(20); got != want {
 			t.Fatalf("expected backends.firecracker.services.docker.startup_timeout_seconds=%d, got %d", want, got)
 		}
-		if got, want := cfg.Backends.Firecracker.Services.Docker.StorageDriver, "vfs"; got != want {
+		if got, want := cfg.Backends.Firecracker.Services.Docker.StorageDriver, "overlay2"; got != want {
 			t.Fatalf("expected backends.firecracker.services.docker.storage_driver=%q, got %q", want, got)
 		}
 		if cfg.Backends.Firecracker.Services.Docker.IPTables {

--- a/internal/cli/policy_config.go
+++ b/internal/cli/policy_config.go
@@ -291,7 +291,7 @@ func defaultRuntimeConfig(defaultBackend string, firecrackerSnapshots, darwinVZS
 			Services: runtimeConfigServices{
 				Docker: runtimeConfigDockerService{
 					StartupTimeoutSeconds: 20,
-					StorageDriver:         "vfs",
+					StorageDriver:         "overlay2",
 					IPTables:              false,
 				},
 			},
@@ -309,7 +309,7 @@ func defaultRuntimeConfig(defaultBackend string, firecrackerSnapshots, darwinVZS
 			Services: runtimeConfigServices{
 				Docker: runtimeConfigDockerService{
 					StartupTimeoutSeconds: 20,
-					StorageDriver:         "vfs",
+					StorageDriver:         "overlay2",
 					IPTables:              false,
 				},
 			},


### PR DESCRIPTION
## Summary
- default guest Docker storage-driver selection to `overlay2` when it is unspecified
- update the Docker example allowlist with the observed Docker Hub R2 blob host used by anonymous/personal pulls
- adjust config-generation and backend bootarg tests to match the new default

## Testing
- `mise exec -- go test ./internal/cli -run TestConfigInitWritesRuntimeConfig`
- `mise exec -- go test ./internal/backend/firecracker -run 'TestDockerServiceBootArgsUsesPolicyAndRuntimeSettings|TestDockerServiceBootArgsUsesSafeDefaults|TestGuestInitScriptAutostartsDockerWhenAvailable'`
- `mise exec -- go test ./internal/backend/darwinvz -run 'TestDockerServiceBootArgsUsesPolicyAndRuntimeSettings|TestGuestInitScriptAutostartsDockerWhenAvailable'`
- `mise exec -- cleanroom policy validate`
