### PR TITLE
chore: Reconcile cache stage nomenclature

### DIFF
--- a/cmd/cleanroom-guest-agent/main.go
+++ b/cmd/cleanroom-guest-agent/main.go
@@ -405,13 +405,13 @@ func listenVsock(port uint32) (net.Listener, error) {
 	return vsock.Listen(port, nil)
 }
 
-func injectEntropy(seed []byte) error {
-	if len(seed) == 0 {
+func injectEntropy(entropy []byte) error {
+	if len(entropy) == 0 {
 		return nil
 	}
 
-	// Best effort fallback: mix seed into urandom even if entropy credit ioctl is unavailable.
-	if err := os.WriteFile("/dev/urandom", seed, 0o000); err != nil {
+	// Best effort fallback: mix caller-provided entropy into urandom even if entropy credit ioctl is unavailable.
+	if err := os.WriteFile("/dev/urandom", entropy, 0o000); err != nil {
 		_ = err
 	}
 
@@ -423,10 +423,10 @@ func injectEntropy(seed []byte) error {
 
 	// Linux rand_pool_info:
 	// struct rand_pool_info { int entropy_count; int buf_size; __u32 buf[0]; };
-	payload := make([]byte, 8+len(seed))
-	binary.LittleEndian.PutUint32(payload[0:4], uint32(len(seed)*8))
-	binary.LittleEndian.PutUint32(payload[4:8], uint32(len(seed)))
-	copy(payload[8:], seed)
+	payload := make([]byte, 8+len(entropy))
+	binary.LittleEndian.PutUint32(payload[0:4], uint32(len(entropy)*8))
+	binary.LittleEndian.PutUint32(payload[4:8], uint32(len(entropy)))
+	copy(payload[8:], entropy)
 
 	_, _, errno := unix.Syscall(unix.SYS_IOCTL, f.Fd(), uintptr(unix.RNDADDENTROPY), uintptr(unsafe.Pointer(&payload[0])))
 	if errno != 0 {

--- a/docs/plans/layered-caching.md
+++ b/docs/plans/layered-caching.md
@@ -24,18 +24,19 @@ The system-cache pipeline uses stage terminology:
 - workspace stage: runtime rootfs plus exact repository checkout
 - dependency stage: workspace stage plus policy-constrained bootstrap and
   dependencies
-- portable dependency seed: dependency-prepared rootfs that can be restored
+- portable dependency stage: dependency-prepared rootfs that can be restored
   first and then have the repository checkout refreshed to a different commit
   when declared dependency inputs still match
 - services stage: dependency stage or workspace stage plus policy-constrained
   service preparation state on disk
 
 Each stage output is a full sealed rootfs snapshot. Higher stages subsume lower
-stages. At runtime we do not mount `runtime + workspace + dependency` as a live
-stack. We clone the best ready stage into one writable child and boot that as
-the only guest root disk. When a portable dependency seed is used, it is still a
-full rootfs snapshot. Cleanroom restores it into a writable child, refreshes the
-repository checkout inside that child, and only then treats the sandbox as ready.
+stages. At runtime we do not mount separate runtime, workspace, dependency, and
+services layers as a live stack. We clone the best ready stage into one writable
+child and boot that as the only guest root disk. When a portable dependency
+stage is used, it is still a full rootfs snapshot. Cleanroom restores it into a
+writable child, refreshes the repository checkout inside that child, and only
+then treats the sandbox as ready.
 
 The core system-cache model is:
 
@@ -63,13 +64,13 @@ This document uses:
 
 - **stage** for the transformation step in the cache pipeline
 - **cache entry** for the immutable stored output of a stage
-- **portable dependency seed** for a dependency-prepared full-rootfs cache entry
+- **portable dependency stage** for a dependency-prepared full-rootfs cache entry
   whose useful dependency state is expected to survive a later repository
   checkout refresh
 
-Current implementation still uses some "seed" naming for stage outputs,
-especially workspace-stage snapshots. This document uses stage terminology
-going forward because it maps more clearly to how the cache pipeline is built.
+This document and the current implementation use stage terminology for system
+caches. The dependency-stage `reuse_mode` value `portable` is metadata for the
+portable dependency stage rather than a separate user-facing cache type.
 
 ## Delivery Strategy
 
@@ -77,8 +78,7 @@ This plan should land in phases rather than as one large cross-backend change.
 
 ### Phase 1: Workspace-stage orchestration
 
-Status: largely landed for snapshot-capable backends. Current implementation
-names this the workspace-seed flow.
+Status: largely landed for snapshot-capable backends.
 
 The backend-neutral control-plane slice is now in place:
 
@@ -132,7 +132,7 @@ This phase now means:
   `sandbox.dependencies.key.files`, which bootstraps a single dependency
   command inside the restored workspace stage and publishes the resulting
   dependency stage
-- add a portable dependency-seed path for dependency state that survives an
+- add a portable dependency-stage path for dependency state that survives an
   in-place checkout refresh, so unchanged lockfiles can reuse a dependency
   snapshot across source-only commits
 - keep distribution/export out of scope until the host-local model is proven
@@ -160,7 +160,7 @@ This phase now means:
 - dependency-stage caching is starting with a single configured dependency
   bootstrap slice for exact-commit workspaces; toolchain-derived key inputs are
   still pending
-- portable dependency-seed reuse is implemented as an explicit
+- portable dependency-stage reuse is implemented as an explicit
   `sandbox.dependencies.reuse: portable` mode for declared key-file inputs
 
 Today that means:
@@ -292,7 +292,7 @@ They must instead be keyed by exact inputs such as:
 - compiled policy hash
 - bootstrap recipe digest
 
-Portable dependency seeds are the one deliberate exception to "commit SHA is
+Portable dependency stages are the one deliberate exception to "commit SHA is
 part of every repository cache key": they may omit the exact source commit only
 because they include declared dependency key-file bytes and must refresh and
 verify the checkout before execution.
@@ -304,14 +304,15 @@ The cache pipeline should be described as ordered stages:
 - runtime
 - workspace
 - dependency
+- services
 
 Each stage produces one immutable cached output. Higher stages subsume the
 lower stages logically, even if the runtime only boots from one concrete rootfs
 snapshot.
 
-Portable dependency seeds are dependency-stage entries with different reuse
-semantics. They do not mean Cleanroom can compose independent dependency and
-workspace snapshots at runtime.
+Portable dependency stages are dependency-stage entries with different reuse
+semantics. They do not mean Cleanroom can compose independent workspace,
+dependency, and services snapshots at runtime.
 
 ### 4. Each system cache entry is a full rootfs snapshot
 
@@ -367,11 +368,13 @@ This is the host-managed environment cache pipeline:
 - runtime stage cache
 - workspace stage cache
 - dependency stage cache
-- portable dependency seed cache
+  - including portable dependency-stage entries with `reuse_mode: portable`
+- services stage cache
 
 These are reusable rootfs states that can be cloned into disposable sandboxes.
-Portable dependency seeds are still full rootfs states; their portability comes
-from checkout refresh and validation, not from filesystem layering.
+Portable dependency-stage entries are still full rootfs states; their
+portability comes from checkout refresh and validation, not from filesystem
+layering.
 
 ### B. Transport caches
 
@@ -489,7 +492,7 @@ Notes:
 - workspace-stage identity must also capture repository provenance and checkout
   behavior such as submodule resolution, destination path, and any explicit
   materialization recipe details such as sparse checkout or LFS hydration
-- current implementation calls this the workspace-seed flow
+- current implementation uses the workspace-stage flow
 
 ### Stage 2: Dependency
 
@@ -514,11 +517,11 @@ dependency_stage_key = H(
 )
 ```
 
-The portable dependency seed is keyed by dependency-relevant inputs rather than
+The portable dependency stage is keyed by dependency-relevant inputs rather than
 by the exact workspace snapshot:
 
 ```text
-portable_dependency_seed_key = H(
+portable_dependency_stage_key = H(
   runtime_base_key,
   backend_family,
   canonical_remote_url,
@@ -537,7 +540,7 @@ Output:
 
 - exact dependency stage: sealed rootfs snapshot ready for common build or test
   commands against one exact checkout
-- portable dependency seed: sealed rootfs snapshot that may contain an older
+- portable dependency stage: sealed rootfs snapshot that may contain an older
   checkout, but can be restored first and then refreshed to the requested
   checkout before execution
 
@@ -557,14 +560,14 @@ Notes:
   with the workspace-stage key plus policy hash, the concrete bootstrap recipe
   digest, and declared key-file digests, then grow richer toolchain inputs
   later
-- portable dependency seeds are a separate reuse mode, not a replacement for
+- portable dependency stages are a separate reuse mode, not a replacement for
   exact dependency stages
-- a portable seed hit must refresh the repository checkout inside the writable
-  child before user code runs; the restored snapshot's old checkout is never
-  treated as current
+- a portable dependency-stage hit must refresh the repository checkout inside
+  the writable child before user code runs; the restored snapshot's old
+  checkout is never treated as current
 - after checkout refresh and changeset apply, Cleanroom must recompute the
   declared dependency key-file digest and only skip dependency bootstrap if it
-  still matches the seed's recorded digest
+  still matches the stage entry's recorded digest
 - if the digest does not match, Cleanroom must discard the restored child and
   fall back to the normal workspace-stage path before running fresh dependencies
 - the portable mode is suitable for dependency outputs that survive
@@ -574,7 +577,39 @@ Notes:
   under the checkout should stay on the exact dependency-stage path unless
   explicit preserve/output semantics are added later
 
-### Stage 3: Writable execution child
+### Stage 3: Services
+
+Purpose:
+
+- capture policy-constrained services-preparation state after dependency
+  bootstrap
+- keep reusable on-disk service setup separate from per-execution process
+  startup
+
+Suggested key:
+
+```text
+services_stage_key = H(
+  parent_stage_key,
+  compiled_policy_hash,
+  services_key_files_digest,
+  services_bootstrap_recipe_digest
+)
+```
+
+Output:
+
+- sealed rootfs snapshot containing prepared service state on top of the
+  selected dependency stage or workspace stage
+
+Notes:
+
+- this stage stores on-disk state only, not live processes or memory
+- if no dependency stage is configured, it can start from a workspace stage
+- services-stage identity must include the exact parent stage key so service
+  preparation is tied to the dependency or workspace state it was built from
+
+### Materialization: Writable execution child
 
 Purpose:
 
@@ -586,7 +621,8 @@ Suggested key:
 
 Output:
 
-- per-sandbox writable child clone of a dependency stage or workspace stage
+- per-sandbox writable child clone of a services stage, dependency stage, or
+  workspace stage
 
 Notes:
 
@@ -662,7 +698,7 @@ The control plane can then resolve the highest reusable stage cache it trusts:
 
 1. services stage hit for the exact checkout plus optional changeset
 2. dependency stage hit for the exact checkout plus optional changeset
-3. portable dependency-seed hit for matching dependency inputs, followed by
+3. portable dependency-stage hit for matching dependency inputs, followed by
    checkout refresh, optional changeset apply, and post-refresh key-file
    validation
 4. workspace stage hit for the exact checkout plus optional changeset
@@ -670,7 +706,7 @@ The control plane can then resolve the highest reusable stage cache it trusts:
 6. runtime stage hit
 7. cold path
 
-Portable dependency-seed lookup should use host-side key-file digest resolution
+Portable dependency-stage lookup should use host-side key-file digest resolution
 when possible so Cleanroom does not restore a candidate that is already known to
 be stale. The post-refresh digest check is still required as defense in depth
 before skipping dependency bootstrap.
@@ -722,21 +758,21 @@ Shared stage-cache publication should be a host-controlled promotion pipeline.
 5. Snapshot the resulting root volume.
 6. Publish the dependency-stage metadata and storage reference atomically.
 
-### Publish portable dependency seed
+### Publish portable dependency stage
 
 1. Start from the same host-controlled dependency bootstrap flow as an exact
    dependency stage.
-2. Compute the portable dependency seed key from the runtime base, repository
+2. Compute the portable dependency stage key from the runtime base, repository
    identity, checkout-refresh recipe, dependency policy hash, bootstrap recipe
    digest, and declared dependency key-file digest.
 3. Verify the bootstrap completed successfully and record the key-file digest
-   that made the seed reusable.
+   that made the stage reusable.
 4. Verify that the dependency output mode is portable. The first portable slice
-   should only promote seeds whose useful dependency state lives outside the
-   repository checkout, or whose output paths are explicitly declared by a later
-   policy surface.
+   should only promote stage entries whose useful dependency state lives outside
+   the repository checkout, or whose output paths are explicitly declared by a
+   later policy surface.
 5. Snapshot the resulting root volume.
-6. Publish the portable seed metadata and storage reference atomically. The
+6. Publish the portable stage metadata and storage reference atomically. The
    stored repository checkout is provenance only; later reuse must not treat it
    as the requested checkout.
 
@@ -762,7 +798,7 @@ Warm-hit resolution should be simple.
 4. Attach that single writable child as the VM root disk.
 5. Boot a fresh sandbox.
 6. Perform any required trusted post-restore work, such as checkout refresh for
-   portable dependency seeds, before reporting the sandbox as ready.
+   portable dependency stages, before reporting the sandbox as ready.
 
 If no services stage exists but a dependency stage does:
 
@@ -770,21 +806,21 @@ If no services stage exists but a dependency stage does:
 2. run the constrained services-preparation recipe
 3. optionally publish a services stage if the policy allows promotion
 
-If no exact dependency stage exists but a portable dependency seed does:
+If no exact dependency stage exists but a portable dependency stage does:
 
-1. clone the portable dependency seed into a writable child
+1. clone the portable dependency stage into a writable child
 2. refresh the repository checkout in that child to the requested commit
 3. if a changeset was requested, apply it and verify the resulting tree digest
 4. recompute the declared dependency key-file digest from the refreshed tree
-5. if the digest still matches the seed metadata, skip dependency bootstrap and
-   run from the refreshed child
+5. if the digest still matches the stage metadata, skip dependency bootstrap
+   and run from the refreshed child
 6. if the digest differs, discard the child and continue with the normal
    workspace-stage or cold path
 
 This flow does not compose immutable snapshots. It restores one full snapshot
 and mutates only the disposable writable child.
 
-If no dependency stage or portable dependency seed exists but a workspace stage
+If no dependency stage or portable dependency stage exists but a workspace stage
 does:
 
 1. clone the workspace stage
@@ -854,8 +890,8 @@ The design should eliminate these weaker trust paths:
 - use `write temp -> fsync -> atomic rename` for new artifact blobs and metadata
 - never serve partially written artifacts
 - never accept a guest-provided "cache hit" claim as authoritative
-- never treat a portable dependency seed's stored checkout as current; checkout
-  refresh and verification are part of every portable-seed hit
+- never treat a portable dependency stage's stored checkout as current; checkout
+  refresh and verification are part of every portable dependency-stage hit
 - if post-refresh dependency key-file validation fails, discard the restored
   child instead of trying to repair it in place
 
@@ -867,9 +903,9 @@ When a policy requires strict offline warm-cache execution:
 - only published `ready` stage caches may be used
 - missing artifacts fail closed
 
-### Portable dependency-seed safety
+### Portable Dependency-Stage Safety
 
-Portable dependency seeds trade exact checkout identity for faster
+Portable dependency stages trade exact checkout identity for faster
 source-iteration when declared dependency inputs are unchanged. The safety rules
 are stricter than a normal exact dependency-stage hit:
 
@@ -877,14 +913,14 @@ are stricter than a normal exact dependency-stage hit:
   the exact workspace-bound path unless a stronger input model exists
 - compute key-file digests from the requested checkout, including post-apply
   changesets
-- restore the seed only into a fresh writable child
+- restore the stage only into a fresh writable child
 - refresh the checkout before user code runs
 - verify `HEAD`, submodule behavior, and changeset tree digest after refresh
-- recompute the key-file digest after refresh and compare it with the seed
+- recompute the key-file digest after refresh and compare it with the stage
   metadata
-- do not promote or reuse portable seeds for dependency outputs under the
-  checkout unless explicit output-preservation semantics define how those paths
-  survive `git clean`
+- do not promote or reuse portable dependency stages for dependency outputs
+  under the checkout unless explicit output-preservation semantics define how
+  those paths survive `git clean`
 
 The main correctness risk is under-declared dependency inputs. If the bootstrap
 command reads source files, scripts, generated config, or environment inputs
@@ -901,15 +937,16 @@ That means:
 - no default "base volume plus repo volume plus deps volume" mount assembly
 - no separate default `/workspace` guest-visible volume
 - one attached writable root volume per sandbox
-- no live composition of independent workspace and dependency snapshots
+- no live composition of independent workspace, dependency, and services
+  snapshots
 
 Logical cache layering still exists, but it is represented in metadata and
 lineage rather than in a live guest mount stack.
 
-Portable dependency seeds keep the same filesystem model. A seed hit clones one
-full rootfs snapshot into a writable child, then refreshes the checkout inside
-that child. The old checkout inside the sealed seed is an implementation detail,
-not part of the requested sandbox state.
+Portable dependency stages keep the same filesystem model. A portable hit clones
+one full rootfs snapshot into a writable child, then refreshes the checkout
+inside that child. The old checkout inside the sealed stage is an implementation
+detail, not part of the requested sandbox state.
 
 This matches the current backend shape better:
 
@@ -977,9 +1014,9 @@ This plan composes with the existing documents rather than replacing them.
 | File | Change |
 |---|---|
 | `internal/gateway/mirror.go` | Already acts as the host-side git transport cache keyed by canonical remote URL. |
-| `internal/repositorycheckout/checkout.go` | Already uses exact remote URL and full commit SHA as the checkout source of truth; `branch` currently affects local checkout mode only. `BuildRefreshCommand` is also the checkout-refresh primitive needed after restoring a portable dependency seed. |
+| `internal/repositorycheckout/checkout.go` | Already uses exact remote URL and full commit SHA as the checkout source of truth; `branch` currently affects local checkout mode only. `BuildRefreshCommand` is also the checkout-refresh primitive needed after restoring a portable dependency stage. |
 | `internal/controlservice/workspace_stage.go` | Current workspace-stage orchestration already lives here using dedicated stage-cache metadata. |
-| `internal/controlservice/dependency_stage.go` | Dependency-stage orchestration entry point for policy-controlled bootstrap, declared key-file hashing, post-apply tree keying, exact dependency-stage publication, and the planned portable dependency-seed lookup/validation path. |
+| `internal/controlservice/dependency_stage.go` | Dependency-stage orchestration entry point for policy-controlled bootstrap, declared key-file hashing, post-apply tree keying, exact dependency-stage publication, and the portable dependency-stage lookup/validation path. |
 | `internal/snapshotstore/store.go` | Should remain the user snapshot store rather than being expanded into the system-cache store. |
 | `internal/changesetstore/*` | Planned store for explicit local changeset metadata and replay payloads, separate from both snapshots and stage caches. |
 | `internal/volumestore/store.go` | Already provides the backend-neutral clone/snapshot contract shared by both backends. |
@@ -994,8 +1031,8 @@ Suggested stage-cache record shape:
 
 ```text
 cache_key
-stage                    // runtime | workspace | dependency
-reuse_mode               // exact | portable_seed, when stage = dependency
+stage                    // runtime | workspace | dependency | services
+reuse_mode               // exact | portable, when stage = dependency
 state                    // ready | failed | garbage
 parent_cache_key
 changeset_digest         // optional, when a workspace/dependency stage includes explicit local changes
@@ -1053,7 +1090,7 @@ This metadata should live in a dedicated `changesetstore`, not in
    `sandbox.dependencies.key.files`, with `go mod download` as the first
    example recipe keyed by workspace stage plus policy, command recipe, and
    declared key-file digests.
-4. Add portable dependency-seed reuse for cross-commit iteration when declared
+4. Add portable dependency-stage reuse for cross-commit iteration when declared
    dependency key files are unchanged. The current slice is opt-in through
    `sandbox.dependencies.reuse: portable`, restores the dependency-prepared
    rootfs into a writable child, refreshes the checkout to the requested commit,
@@ -1097,8 +1134,7 @@ stage still needs richer lockfile/toolchain inputs.
 - failed publishes do not corrupt existing entries
 - concurrent publishes of the same key coalesce correctly
 
-Current coverage already exists for the narrower workspace-stage flow, which is
-implemented today as the workspace-seed flow:
+Current coverage already exists for the narrower workspace-stage flow:
 
 - warm workspace-stage hits reuse snapshot-backed sandbox creation
 - runtime-base changes invalidate workspace-stage reuse
@@ -1114,16 +1150,16 @@ implemented today as the workspace-seed flow:
   mirror
 - dependency-stage key files resolve from the post-apply tree when a changeset
   is present
-- portable dependency-seed hits refresh the checkout before execution
-- portable dependency-seed hits recompute dependency key-file digests after
+- portable dependency-stage hits refresh the checkout before execution
+- portable dependency-stage hits recompute dependency key-file digests after
   refresh and skip dependency bootstrap only when they match
-- portable dependency-seed mismatches discard the restored child and fall back
+- portable dependency-stage mismatches discard the restored child and fall back
   to the normal workspace-stage path
 
 ### Runtime performance
 
 - warm dependency-stage hit skips repository clone and dependency install
-- warm portable dependency-seed hit skips dependency install while still doing
+- warm portable dependency-stage hit skips dependency install while still doing
   an incremental checkout refresh through the gateway cache
 - Firecracker warm hits avoid full rootfs file copies
 - snapshot clone latency and VM boot latency are measured separately
@@ -1134,7 +1170,7 @@ implemented today as the workspace-seed flow:
   npm, pip, or another?
 - Should dependency-stage caches be published automatically on successful
   bootstrap, or only when explicitly requested?
-- Should portable dependency-seed reuse be opt-in, or should it be the default
+- Should portable dependency-stage reuse be opt-in, or should it be the default
   whenever non-empty dependency key files are declared and outputs are portable?
 - What retention policy should apply to large dependency-stage caches relative
   to smaller workspace-stage caches?

--- a/docs/plans/repository-bootstrap-acceleration.md
+++ b/docs/plans/repository-bootstrap-acceleration.md
@@ -29,7 +29,7 @@ The target model is:
   repository-store abstraction
 - first back that abstraction with today’s mirror behavior
 - then add a Git-native partial/promisor backend
-- optionally seed cold hosts with bundle artifacts before talking to origin
+- optionally hydrate cold hosts from bundle artifacts before talking to origin
 - later distribute services/dependency/workspace-stage caches across hosts to
   skip Git entirely on a hit
 
@@ -190,7 +190,7 @@ That means:
 This keeps correctness and cache identity stable while the host-side transport
 layer evolves.
 
-### 4. Add bundle seeding through `content-cache`
+### 4. Add bundle hydration through `content-cache`
 
 Once Cleanroom can consume repository transport hints, add generic Git bundle
 support to `content-cache`.
@@ -205,7 +205,7 @@ This should cover:
 
 Cleanroom can then use those artifacts opportunistically:
 
-- if a bundle seed is available, hydrate the repository store from it first
+- if a bundle artifact is available, hydrate the repository store from it first
 - then fetch only the delta needed to reach the exact target commit
 - if no bundle is available, continue with direct origin access
 
@@ -319,7 +319,7 @@ Success criteria:
 - no user-visible behavior regression
 - warm services/dependency/workspace-stage hits remain unchanged
 
-### Phase 4: Bundle seeding via `content-cache`
+### Phase 4: Bundle hydration via `content-cache`
 
 Status: not started.
 
@@ -355,7 +355,7 @@ Success criteria:
   optimization.
 - Partial/promisor mode should be gated behind explicit runtime configuration
   until proven on supported hosts and remotes.
-- Bundle seeding should be opportunistic rather than mandatory.
+- Bundle hydration should be opportunistic rather than mandatory.
 
 ## Verification
 
@@ -448,7 +448,7 @@ Add metrics and debug logs for:
 - repo-aware bootstrap duration by phase
 
 These measurements are necessary to decide whether later slices, especially
-bundle seeding and cross-host stage distribution, are worth their complexity.
+bundle hydration and cross-host stage distribution, are worth their complexity.
 
 ## Open Questions
 

--- a/docs/plans/repository-bootstrap.md
+++ b/docs/plans/repository-bootstrap.md
@@ -315,7 +315,7 @@ Start with a simple correctness-first flow:
 5. optionally materialize submodules
 
 This keeps the semantics obvious, prefers blobless transfer over sparse
-checkout, and avoids backend-specific file seeding.
+checkout, and avoids backend-specific file injection.
 
 ## Efficient upstream strategy
 
@@ -473,12 +473,12 @@ Useful future optimizations:
 ## Next speed stage
 
 If the mirror-backed gateway is still not fast enough, the next stage should be
-commit-addressed workspace seeds.
+commit-addressed workspace-stage snapshots.
 
 That means:
 
-- prepare a host-side checkout seed for `(remote, commit, submodules, mode)`
-- clone or copy that seed into new sandboxes
+- prepare a host-side workspace stage for `(remote, commit, submodules, mode)`
+- clone or copy that stage output into new sandboxes
 - keep `origin` pointed at the gateway
 
 That is the step that turns "avoid hammering GitHub" into "new sandboxes start
@@ -566,8 +566,8 @@ This is clearer than pretending the checkout is a normal user execution.
 9. Move checkout orchestration into the control service for persistent
    sandboxes.
 10. Add generic explicit `sandbox create` git flags.
-11. If needed, add commit-addressed workspace seeds as a second-stage startup
-    optimization.
+11. If needed, add commit-addressed workspace-stage snapshots as a second-stage
+    startup optimization.
 
 ## Bottom line
 
@@ -580,5 +580,5 @@ The most useful model is:
 - the control plane owns checkout orchestration
 - the guest still clones through the gateway
 - the gateway owns auth and is backed by a host mirror cache
-- later, if needed, workspace seeds can make repeated sandbox creation much
-  cheaper than recloning every time
+- later, if needed, workspace-stage snapshots can make repeated sandbox
+  creation much cheaper than recloning every time

--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -1074,9 +1074,9 @@ func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream 
 		}
 		guestReq.Env = append(guestReq.Env, gatewayGitProxyEnvVars(req.Policy, networkMode, gwPort, a.GatewayRoutes)...)
 	}
-	seed := make([]byte, 64)
-	if _, err := cryptorand.Read(seed); err == nil {
-		guestReq.EntropySeed = seed
+	entropy := make([]byte, 64)
+	if _, err := cryptorand.Read(entropy); err == nil {
+		guestReq.EntropySeed = entropy
 	}
 	if err := vsockexec.EncodeRequest(conn, guestReq); err != nil {
 		observation.Error = err.Error()
@@ -1542,9 +1542,9 @@ func (a *Adapter) executeInSandbox(bootCtx context.Context, runCtx context.Conte
 		}
 		guestReq.Env = append(guestReq.Env, gatewayGitProxyEnvVars(policy, networkMode, gwPort, a.GatewayRoutes)...)
 	}
-	seed := make([]byte, 64)
-	if _, err := cryptorand.Read(seed); err == nil {
-		guestReq.EntropySeed = seed
+	entropy := make([]byte, 64)
+	if _, err := cryptorand.Read(entropy); err == nil {
+		guestReq.EntropySeed = entropy
 	}
 	if err := vsockexec.EncodeRequest(conn, guestReq); err != nil {
 		return nil, fmt.Errorf("send guest exec request: %w", err)

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -747,9 +747,9 @@ func (a *Adapter) executeInSandbox(ctx context.Context, instance *sandboxInstanc
 		Env:     append([]string(nil), env...),
 		TTY:     tty,
 	}
-	seed := make([]byte, 64)
-	if _, err := cryptorand.Read(seed); err == nil {
-		guestReq.EntropySeed = seed
+	entropy := make([]byte, 64)
+	if _, err := cryptorand.Read(entropy); err == nil {
+		guestReq.EntropySeed = entropy
 	}
 	if a.GatewayRegistry != nil && instance.HostIP != "" {
 		gwPort := a.GatewayPort
@@ -1250,9 +1250,9 @@ func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream 
 		Command: req.Command,
 		TTY:     req.TTY,
 	}
-	seed := make([]byte, 64)
-	if _, err := cryptorand.Read(seed); err == nil {
-		guestReq.EntropySeed = seed
+	entropy := make([]byte, 64)
+	if _, err := cryptorand.Read(entropy); err == nil {
+		guestReq.EntropySeed = entropy
 	}
 	guestResult, guestTiming, err := runGuestCommand(bootCtx, ctx, processExited, processExitErrFn, vsockPath, req.GuestPort, guestReq, stream)
 	if err != nil {

--- a/internal/backend/firecracker/guest_init_script_test.go
+++ b/internal/backend/firecracker/guest_init_script_test.go
@@ -35,7 +35,7 @@ func TestGuestInitScriptAutostartsDockerWhenAvailable(t *testing.T) {
 	}
 }
 
-func TestGuestInitScriptSeedsLocalhostHostsEntries(t *testing.T) {
+func TestGuestInitScriptAddsLocalhostHostsEntries(t *testing.T) {
 	if !strings.Contains(guestInitScriptTemplate, "127.0.0.1 localhost") {
 		t.Fatal("expected localhost IPv4 hosts entry in init script")
 	}

--- a/internal/backend/firecracker/privileged_test.go
+++ b/internal/backend/firecracker/privileged_test.go
@@ -482,7 +482,7 @@ func TestDeleteSnapshotDerivesZFSDatasetFromStorageRef(t *testing.T) {
 	t.Setenv("HELPER_LOG_PATH", logPath)
 
 	err := (&Adapter{}).DeleteSnapshot(context.Background(), backend.DeleteSnapshotRequest{
-		StorageRef: "tank/cleanroom/snapshots/snap-test@seed",
+		StorageRef: "tank/cleanroom/snapshots/snap-test@base",
 		FirecrackerConfig: backend.FirecrackerConfig{
 			PrivilegedHelperPath: helperPath,
 			Snapshots: backend.SnapshotConfig{
@@ -514,7 +514,7 @@ func TestDeleteSnapshotInfersZFSDriverFromStorageRef(t *testing.T) {
 	t.Setenv("HELPER_LOG_PATH", logPath)
 
 	err := (&Adapter{}).DeleteSnapshot(context.Background(), backend.DeleteSnapshotRequest{
-		StorageRef: "tank/cleanroom/snapshots/snap-test@seed",
+		StorageRef: "tank/cleanroom/snapshots/snap-test@base",
 		FirecrackerConfig: backend.FirecrackerConfig{
 			PrivilegedHelperPath: helperPath,
 			Snapshots: backend.SnapshotConfig{

--- a/internal/backend/firecracker/snapshot_test.go
+++ b/internal/backend/firecracker/snapshot_test.go
@@ -179,7 +179,7 @@ func TestCreateSnapshotFlushesHostFilesystemForZFSSnapshots(t *testing.T) {
 					t.Fatalf("unexpected snapshot id: got %q want %q", got, want)
 				}
 				calls = append(calls, "snapshot")
-				return zfsSnapshot{StorageRef: "tank/cleanroom/snapshots/snap-test@seed"}, nil
+				return zfsSnapshot{StorageRef: "tank/cleanroom/snapshots/snap-test@base"}, nil
 			},
 		}
 	}
@@ -218,7 +218,7 @@ func TestCreateSnapshotFlushesHostFilesystemForZFSSnapshots(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateSnapshot returned error: %v", err)
 	}
-	if got, want := result.StorageRef, "tank/cleanroom/snapshots/snap-test@seed"; got != want {
+	if got, want := result.StorageRef, "tank/cleanroom/snapshots/snap-test@base"; got != want {
 		t.Fatalf("unexpected snapshot storage ref: got %q want %q", got, want)
 	}
 	if got, want := calls, []string{"host-sync", "snapshot"}; strings.Join(got, ",") != strings.Join(want, ",") {
@@ -554,13 +554,13 @@ func TestSnapshotStorageHelpersPassLoggerToHostRuntime(t *testing.T) {
 		if got, want := req.VolumeRef, "tank/cleanroom/sandboxes/cr-test"; got != want {
 			t.Fatalf("unexpected volume ref: got %q want %q", got, want)
 		}
-		return zfsSnapshot{StorageRef: "tank/cleanroom/snapshots/snap-test@seed"}, nil
+		return zfsSnapshot{StorageRef: "tank/cleanroom/snapshots/snap-test@base"}, nil
 	}
 	runtime.testHostRuntime.destroyZFSSnapshotFn = func(_ context.Context, snapshotRef string) error {
 		if runtime.logger != logger {
 			t.Fatal("expected destroySnapshotStorage to pass the logger into the host runtime")
 		}
-		if got, want := snapshotRef, "tank/cleanroom/snapshots/snap-test@seed"; got != want {
+		if got, want := snapshotRef, "tank/cleanroom/snapshots/snap-test@base"; got != want {
 			t.Fatalf("unexpected snapshot ref: got %q want %q", got, want)
 		}
 		return nil
@@ -584,7 +584,7 @@ func TestSnapshotStorageHelpersPassLoggerToHostRuntime(t *testing.T) {
 	if err != nil {
 		t.Fatalf("createSnapshotStorage returned error: %v", err)
 	}
-	if got, want := storageRef, "tank/cleanroom/snapshots/snap-test@seed"; got != want {
+	if got, want := storageRef, "tank/cleanroom/snapshots/snap-test@base"; got != want {
 		t.Fatalf("unexpected storage ref: got %q want %q", got, want)
 	}
 	if err := destroySnapshotStorage(context.Background(), logger, cfg, storageRef); err != nil {
@@ -712,7 +712,7 @@ func TestSnapshotConfigForStorageRefUsesStoredZFSDataset(t *testing.T) {
 			Driver:     "zfs",
 			ZFSDataset: "tank/other",
 		},
-	}, "tank/cleanroom/snapshots/snap-test@seed")
+	}, "tank/cleanroom/snapshots/snap-test@base")
 	if err != nil {
 		t.Fatalf("snapshotConfigForStorageRef returned error: %v", err)
 	}
@@ -741,7 +741,7 @@ func TestSnapshotConfigForStorageRefLeavesConfiguredDatasetForNonStoredRef(t *te
 func TestSnapshotConfigForStorageRefInfersZFSDriverFromStoredRef(t *testing.T) {
 	t.Parallel()
 
-	cfg, err := snapshotConfigForStorageRef(backend.FirecrackerConfig{}, "tank/cleanroom/snapshots/snap-test@seed")
+	cfg, err := snapshotConfigForStorageRef(backend.FirecrackerConfig{}, "tank/cleanroom/snapshots/snap-test@base")
 	if err != nil {
 		t.Fatalf("snapshotConfigForStorageRef returned error: %v", err)
 	}
@@ -773,7 +773,7 @@ func TestSnapshotConfigForStorageRefRejectsDriverMismatch(t *testing.T) {
 
 	_, err := snapshotConfigForStorageRef(backend.FirecrackerConfig{
 		Snapshots: backend.SnapshotConfig{Driver: "file"},
-	}, "tank/cleanroom/snapshots/snap-test@seed")
+	}, "tank/cleanroom/snapshots/snap-test@base")
 	if err == nil {
 		t.Fatal("expected snapshotConfigForStorageRef to reject driver mismatch")
 	}

--- a/internal/cachekey/cachekey.go
+++ b/internal/cachekey/cachekey.go
@@ -123,7 +123,7 @@ func ServicesStageKey(in ServicesStageInputs) string {
 // dependency stage output.
 func PortableDependencyStageKey(in PortableDependencyStageInputs) string {
 	return buildStageKey("dependency", []component{
-		{name: "reuse_mode", value: canonicalIdentifier("portable_seed")},
+		{name: "reuse_mode", value: canonicalIdentifier("portable")},
 		{name: "backend", value: canonicalIdentifier(in.Backend)},
 		{name: "runtime_key", value: canonicalReference(in.RuntimeKey)},
 		{name: "compiled_policy_hash", value: canonicalDigest(in.CompiledPolicyHash)},

--- a/internal/cachestore/store_test.go
+++ b/internal/cachestore/store_test.go
@@ -41,7 +41,7 @@ func TestStoreCreateGetReadyListDelete(t *testing.T) {
 		},
 		RepositoryHasChangeset:   true,
 		ParentCacheKey:           "runtime:test",
-		ReuseMode:                "portable_seed",
+		ReuseMode:                "portable",
 		StorageRef:               "/tmp/workspace-test.ext4",
 		StorageDriver:            "file",
 		InputManifestDigest:      "sha256:manifest",
@@ -108,7 +108,7 @@ func TestStoreGetReadyFiltersNonReadyStates(t *testing.T) {
 	}
 
 	record := Record{
-		CacheKey:          "dependency-seed:test",
+		CacheKey:          "dependency-stage:test",
 		Stage:             "dependency",
 		State:             "failed",
 		BackingSnapshotID: "snapshot-dependency-test",

--- a/internal/controlservice/dependency_stage.go
+++ b/internal/controlservice/dependency_stage.go
@@ -26,7 +26,7 @@ const (
 	dependencyStageProducerVersion         = "cleanroom/dependency-stage-v1"
 	portableDependencyStageProducerVersion = "cleanroom/portable-dependency-stage-v1"
 	dependencyStageReuseExact              = "exact"
-	dependencyStageReusePortableSeed       = "portable_seed"
+	dependencyStageReusePortable           = "portable"
 	portableDependencyOutputMode           = "outside-workspace"
 )
 
@@ -275,7 +275,7 @@ func (s *Service) lookupPortableDependencyStageCache(ctx context.Context, backen
 	if strings.TrimSpace(record.Backend) != strings.TrimSpace(backendName) {
 		return cachestore.Record{}, false, observability.CacheLookupReasonBackendMismatch, nil
 	}
-	if strings.TrimSpace(record.ReuseMode) != dependencyStageReusePortableSeed {
+	if strings.TrimSpace(record.ReuseMode) != dependencyStageReusePortable {
 		return cachestore.Record{}, false, observability.CacheLookupReasonRecordNotFound, nil
 	}
 	if strings.TrimSpace(record.PolicyHash) != strings.TrimSpace(compiled.Hash) {
@@ -601,7 +601,7 @@ func portableDependencyStageRecordFromExactRecord(
 ) cachestore.Record {
 	record := exactRecord
 	record.CacheKey = strings.TrimSpace(plan.PortableCacheKey)
-	record.ReuseMode = dependencyStageReusePortableSeed
+	record.ReuseMode = dependencyStageReusePortable
 	record.PolicyHash = compiled.Hash
 	record.Policy = compiled.ToProto()
 	record.Repository = cloneRepositoryCheckout(normalizeRepositoryCheckoutForComparison(repository)).ToProto()

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -3383,7 +3383,7 @@ func TestCreateSandboxReusesPortableDependencyStageAfterCheckoutRefresh(t *testi
 		case dependencyStageReuseExact:
 			record := records[i]
 			exactRecord = &record
-		case dependencyStageReusePortableSeed:
+		case dependencyStageReusePortable:
 			record := records[i]
 			portableRecord = &record
 		}

--- a/internal/controlservice/stored_rootfs.go
+++ b/internal/controlservice/stored_rootfs.go
@@ -58,7 +58,7 @@ func storedRootFSRecordFromCacheEntry(record cachestore.Record) (storedRootFSRec
 	} else {
 		sourceKind += " stage cache"
 	}
-	if strings.TrimSpace(record.ReuseMode) == dependencyStageReusePortableSeed {
+	if strings.TrimSpace(record.ReuseMode) == dependencyStageReusePortable {
 		sourceKind = "portable dependency stage cache"
 	}
 	return storedRootFSRecord{

--- a/internal/imagemgr/imagemgr_test.go
+++ b/internal/imagemgr/imagemgr_test.go
@@ -234,7 +234,7 @@ func TestRemoveKeepsMetadataWhenRootFSDeleteFails(t *testing.T) {
 		t.Fatalf("create rootfs directory: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(rootfsDir, "keep"), []byte("x"), 0o644); err != nil {
-		t.Fatalf("seed rootfs directory: %v", err)
+		t.Fatalf("populate rootfs directory: %v", err)
 	}
 
 	record := Record{

--- a/internal/repositorychangeset/changeset.go
+++ b/internal/repositorychangeset/changeset.go
@@ -62,7 +62,7 @@ func BuildFromWorkingTree(repoRoot string, checkout *repositorycheckout.Checkout
 
 	env := append(os.Environ(), "GIT_INDEX_FILE="+indexPath)
 	if _, err := gitOutput(repoRoot, env, "read-tree", baseCommitSHA); err != nil {
-		return nil, fmt.Errorf("seed temporary git index: %w", err)
+		return nil, fmt.Errorf("initialize temporary git index: %w", err)
 	}
 	if _, err := gitOutput(repoRoot, env, "add", "-A", "--all", "."); err != nil {
 		return nil, fmt.Errorf("stage working tree into temporary git index: %w", err)
@@ -152,7 +152,7 @@ func (c *Changeset) DigestPathsFromBase(repoRoot string, paths []string) ([]File
 
 	env := append(os.Environ(), "GIT_INDEX_FILE="+indexPath)
 	if _, err := gitOutput(repoRoot, env, "read-tree", baseCommitSHA); err != nil {
-		return nil, fmt.Errorf("seed temporary git index: %w", err)
+		return nil, fmt.Errorf("initialize temporary git index: %w", err)
 	}
 	if _, err := gitOutput(repoRoot, env, "apply", "--cached", "--binary", "--whitespace=nowarn", patchPath); err != nil {
 		return nil, fmt.Errorf("apply repository changeset patch to temporary git index: %w", err)

--- a/internal/repositorycheckout/checkout_test.go
+++ b/internal/repositorycheckout/checkout_test.go
@@ -107,26 +107,26 @@ func TestBuildRefreshCommandResetsWorkingTreeToExactCommit(t *testing.T) {
 	remoteDir := filepath.Join(t.TempDir(), "remote.git")
 	runGit(t, "", "init", "--bare", remoteDir)
 
-	seedDir := filepath.Join(t.TempDir(), "seed")
-	runGit(t, "", "clone", remoteDir, seedDir)
-	runGit(t, seedDir, "config", "user.name", "Test User")
-	runGit(t, seedDir, "config", "user.email", "test@example.com")
+	sourceDir := filepath.Join(t.TempDir(), "source")
+	runGit(t, "", "clone", remoteDir, sourceDir)
+	runGit(t, sourceDir, "config", "user.name", "Test User")
+	runGit(t, sourceDir, "config", "user.email", "test@example.com")
 
-	readmePath := filepath.Join(seedDir, "README.md")
+	readmePath := filepath.Join(sourceDir, "README.md")
 	if err := os.WriteFile(readmePath, []byte("first\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile(README.md) returned error: %v", err)
 	}
-	runGit(t, seedDir, "add", "README.md")
-	runGit(t, seedDir, "commit", "-m", "first")
-	runGit(t, seedDir, "push", "origin", "HEAD")
-	firstCommit := strings.TrimSpace(runGit(t, seedDir, "rev-parse", "HEAD"))
+	runGit(t, sourceDir, "add", "README.md")
+	runGit(t, sourceDir, "commit", "-m", "first")
+	runGit(t, sourceDir, "push", "origin", "HEAD")
+	firstCommit := strings.TrimSpace(runGit(t, sourceDir, "rev-parse", "HEAD"))
 
 	if err := os.WriteFile(readmePath, []byte("second\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile(README.md) returned error: %v", err)
 	}
-	runGit(t, seedDir, "commit", "-am", "second")
-	runGit(t, seedDir, "push", "origin", "HEAD")
-	secondCommit := strings.TrimSpace(runGit(t, seedDir, "rev-parse", "HEAD"))
+	runGit(t, sourceDir, "commit", "-am", "second")
+	runGit(t, sourceDir, "push", "origin", "HEAD")
+	secondCommit := strings.TrimSpace(runGit(t, sourceDir, "rev-parse", "HEAD"))
 
 	checkoutDir := filepath.Join(t.TempDir(), "checkout")
 	runGit(t, "", "clone", remoteDir, checkoutDir)

--- a/internal/volumestore/zfs.go
+++ b/internal/volumestore/zfs.go
@@ -11,7 +11,7 @@ import (
 	"unicode"
 )
 
-const zfsBaseSnapshotName = "seed"
+const zfsManagedSnapshotName = "base"
 const zfsBaseNamespace = "base"
 const zfsSandboxNamespace = "sandboxes"
 const zfsSnapshotNamespace = "snapshots"
@@ -70,7 +70,7 @@ func (d *ZFSDriver) EnsureBaseVolume(ctx context.Context, req EnsureBaseVolumeRe
 	}
 
 	baseDataset := d.baseDataset(req.BaseID, req.MinimumBytes)
-	baseSnapshot := d.snapshotRef(baseDataset, zfsBaseSnapshotName)
+	baseSnapshot := d.snapshotRef(baseDataset, zfsManagedSnapshotName)
 	volumeSize := info.Size()
 	if req.MinimumBytes > volumeSize {
 		volumeSize = req.MinimumBytes
@@ -86,7 +86,7 @@ func (d *ZFSDriver) EnsureBaseVolume(ctx context.Context, req EnsureBaseVolumeRe
 		}
 		if err := d.runner.Run(ctx, "dd", "if="+sourcePath, "of="+zvolDevicePath(baseDataset), "bs=4M", "conv=fsync", "status=none"); err != nil {
 			_ = d.runner.Run(context.Background(), "zfs", "destroy", "-r", baseDataset)
-			return BaseVolume{}, fmt.Errorf("seed zfs base volume %q: %w", baseDataset, err)
+			return BaseVolume{}, fmt.Errorf("initialize zfs base volume %q: %w", baseDataset, err)
 		}
 	}
 
@@ -129,7 +129,7 @@ func (d *ZFSDriver) SnapshotVolume(ctx context.Context, req SnapshotVolumeReques
 
 	sourceSnapshotRef := d.snapshotRef(volumeRef, "snap-"+snapshotID)
 	storedDataset := d.datasetPath(zfsSnapshotNamespace, snapshotID)
-	storedSnapshotRef := d.snapshotRef(storedDataset, zfsBaseSnapshotName)
+	storedSnapshotRef := d.snapshotRef(storedDataset, zfsManagedSnapshotName)
 
 	exists, err := d.refExists(ctx, storedDataset)
 	if err != nil {

--- a/internal/volumestore/zfs_test.go
+++ b/internal/volumestore/zfs_test.go
@@ -110,7 +110,7 @@ func TestZFSDriverEnsureBaseVolumeAndCloneLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EnsureBaseVolume returned error: %v", err)
 	}
-	if got, want := base.Ref, "tank/cleanroom/base/runtime-key@seed"; got != want {
+	if got, want := base.Ref, "tank/cleanroom/base/runtime-key@base"; got != want {
 		t.Fatalf("unexpected base ref: got %q want %q", got, want)
 	}
 
@@ -132,10 +132,10 @@ func TestZFSDriverEnsureBaseVolumeAndCloneLifecycle(t *testing.T) {
 		"zfs list -H -o name tank/cleanroom/base/runtime-key",
 		"zfs create -p -V 10 tank/cleanroom/base/runtime-key",
 		"dd if=" + sourcePath + " of=/dev/zvol/tank/cleanroom/base/runtime-key bs=4M conv=fsync status=none",
-		"zfs list -H -o name tank/cleanroom/base/runtime-key@seed",
-		"zfs snapshot tank/cleanroom/base/runtime-key@seed",
+		"zfs list -H -o name tank/cleanroom/base/runtime-key@base",
+		"zfs snapshot tank/cleanroom/base/runtime-key@base",
 		"zfs list -H -o name tank/cleanroom/sandboxes/sandbox-1",
-		"zfs clone -p tank/cleanroom/base/runtime-key@seed tank/cleanroom/sandboxes/sandbox-1",
+		"zfs clone -p tank/cleanroom/base/runtime-key@base tank/cleanroom/sandboxes/sandbox-1",
 	}
 	if got, want := runner.commands, wantCommands; strings.Join(got, "\n") != strings.Join(want, "\n") {
 		t.Fatalf("unexpected zfs commands:\n got: %v\nwant: %v", got, want)
@@ -163,7 +163,7 @@ func TestZFSDriverSnapshotSurvivesSourceVolumeDestroy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SnapshotVolume returned error: %v", err)
 	}
-	if got, want := snapshot.Ref, "tank/cleanroom/snapshots/golden@seed"; got != want {
+	if got, want := snapshot.Ref, "tank/cleanroom/snapshots/golden@base"; got != want {
 		t.Fatalf("unexpected snapshot ref: got %q want %q", got, want)
 	}
 
@@ -195,11 +195,11 @@ func TestZFSDriverSnapshotSurvivesSourceVolumeDestroy(t *testing.T) {
 		"zfs list -H -o name tank/cleanroom/snapshots/golden",
 		"zfs clone -p tank/cleanroom/sandboxes/sandbox-1@snap-golden tank/cleanroom/snapshots/golden",
 		"zfs promote tank/cleanroom/snapshots/golden",
-		"zfs snapshot tank/cleanroom/snapshots/golden@seed",
+		"zfs snapshot tank/cleanroom/snapshots/golden@base",
 		"zfs destroy tank/cleanroom/sandboxes/sandbox-1@snap-golden",
 		"zfs destroy -r tank/cleanroom/sandboxes/sandbox-1",
 		"zfs list -H -o name tank/cleanroom/sandboxes/sandbox-2",
-		"zfs clone -p tank/cleanroom/snapshots/golden@seed tank/cleanroom/sandboxes/sandbox-2",
+		"zfs clone -p tank/cleanroom/snapshots/golden@base tank/cleanroom/sandboxes/sandbox-2",
 		"zfs destroy -r tank/cleanroom/sandboxes/sandbox-2",
 		"zfs destroy -r tank/cleanroom/snapshots/golden",
 	}
@@ -231,7 +231,7 @@ func TestZFSDriverEnsureBaseVolumeUsesMinimumBytesNamespace(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EnsureBaseVolume returned error: %v", err)
 	}
-	if got, want := base.Ref, "tank/cleanroom/base/runtime-key-min-8388608@seed"; got != want {
+	if got, want := base.Ref, "tank/cleanroom/base/runtime-key-min-8388608@base"; got != want {
 		t.Fatalf("unexpected base ref: got %q want %q", got, want)
 	}
 
@@ -239,8 +239,8 @@ func TestZFSDriverEnsureBaseVolumeUsesMinimumBytesNamespace(t *testing.T) {
 		"zfs list -H -o name tank/cleanroom/base/runtime-key-min-8388608",
 		"zfs create -p -V 8388608 tank/cleanroom/base/runtime-key-min-8388608",
 		"dd if=" + sourcePath + " of=/dev/zvol/tank/cleanroom/base/runtime-key-min-8388608 bs=4M conv=fsync status=none",
-		"zfs list -H -o name tank/cleanroom/base/runtime-key-min-8388608@seed",
-		"zfs snapshot tank/cleanroom/base/runtime-key-min-8388608@seed",
+		"zfs list -H -o name tank/cleanroom/base/runtime-key-min-8388608@base",
+		"zfs snapshot tank/cleanroom/base/runtime-key-min-8388608@base",
 	}
 	if got, want := runner.commands, wantCommands; strings.Join(got, "\n") != strings.Join(want, "\n") {
 		t.Fatalf("unexpected zfs commands:\n got: %v\nwant: %v", got, want)
@@ -257,7 +257,7 @@ func TestZFSDriverRequiresDatasetRoot(t *testing.T) {
 func TestZFSDatasetRootFromStoredSnapshotRef(t *testing.T) {
 	t.Parallel()
 
-	if got, ok := ZFSDatasetRootFromStoredSnapshotRef("tank/cleanroom/snapshots/golden@seed"); !ok || got != "tank/cleanroom" {
+	if got, ok := ZFSDatasetRootFromStoredSnapshotRef("tank/cleanroom/snapshots/golden@base"); !ok || got != "tank/cleanroom" {
 		t.Fatalf("unexpected dataset root: got %q ok=%t", got, ok)
 	}
 	if _, ok := ZFSDatasetRootFromStoredSnapshotRef("tank/cleanroom/sandboxes/sandbox-1@snap-golden"); ok {
@@ -269,12 +269,12 @@ func TestZFSDatasetRootFromManagedRef(t *testing.T) {
 	t.Parallel()
 
 	cases := map[string]string{
-		"tank/cleanroom/base/runtime-key@seed":                  "tank/cleanroom",
+		"tank/cleanroom/base/runtime-key@base":                  "tank/cleanroom",
 		"tank/cleanroom/sandboxes/sandbox-1":                    "tank/cleanroom",
-		"tank/cleanroom/snapshots/golden@seed":                  "tank/cleanroom",
+		"tank/cleanroom/snapshots/golden@base":                  "tank/cleanroom",
 		"tank/cleanroom/sandboxes/source@snap-golden":           "tank/cleanroom",
 		"tank/snapshots/cleanroom/sandboxes/sandbox-1":          "tank/snapshots/cleanroom",
-		"tank/base/cleanroom/snapshots/golden@seed":             "tank/base/cleanroom",
+		"tank/base/cleanroom/snapshots/golden@base":             "tank/base/cleanroom",
 		"tank/sandboxes/cleanroom/base/runtime-key-min-8388608": "tank/sandboxes/cleanroom",
 	}
 	for ref, want := range cases {

--- a/scripts/benchmark_repository_bootstrap/main.go
+++ b/scripts/benchmark_repository_bootstrap/main.go
@@ -86,7 +86,7 @@ type payload struct {
 	Platform     any         `json:"platform"`
 	TempRoot     string      `json:"temp_root"`
 	TempRootKept bool        `json:"temp_root_kept"`
-	Seed         *runResult  `json:"seed"`
+	CacheWarmup  *runResult  `json:"cache_warmup"`
 	WarmupRuns   []runResult `json:"warmup_runs"`
 	Runs         []runResult `json:"runs"`
 	Summary      summary     `json:"summary"`
@@ -150,13 +150,13 @@ func run(args []string, stdout, stderr io.Writer) (runErr error) {
 	fmt.Fprintf(stdout, "- output: %s\n", runner.outputPath)
 	fmt.Fprintf(stdout, "- temp root: %s\n", runner.tmpRoot)
 
-	seed, err := runner.seedRun()
+	cacheWarmup, err := runner.cacheWarmupRun()
 	if err != nil {
 		runner.keepTempDir = true
 		return err
 	}
-	if seed != nil {
-		fmt.Fprintln(stdout, "- seed: performed")
+	if cacheWarmup != nil {
+		fmt.Fprintln(stdout, "- cache warmup: performed")
 	}
 
 	if runner.cfg.Warmup > 0 {
@@ -205,7 +205,7 @@ func run(args []string, stdout, stderr io.Writer) (runErr error) {
 		},
 		TempRoot:     runner.tmpRoot,
 		TempRootKept: runner.keepTempDir,
-		Seed:         seed,
+		CacheWarmup:  cacheWarmup,
 		WarmupRuns:   warmupRuns,
 		Runs:         runs,
 		Summary:      computeSummary(elapsed),
@@ -253,7 +253,7 @@ Options:
   -h, --help                Show this help
 
 Notes:
-  - This tool starts its own cleanroom server for each seed/run sequence.
+  - This tool starts its own cleanroom server for each cache-warmup/run sequence.
   - It isolates XDG cache/state/data/runtime directories per scenario while
     preserving the caller's runtime config discovery.
   - The measured command is: cleanroom create --json
@@ -376,13 +376,13 @@ func (r *benchmarkRunner) cleanup() error {
 	return nil
 }
 
-func (r *benchmarkRunner) seedRun() (*runResult, error) {
+func (r *benchmarkRunner) cacheWarmupRun() (*runResult, error) {
 	sharedEnvRoot := filepath.Join(r.tmpRoot, "shared")
 	switch r.cfg.Scenario {
 	case scenarioWarmRepositoryStore:
 		r.resetStageState(sharedEnvRoot)
 		r.resetTransportState(sharedEnvRoot)
-		result, err := r.runCreateIteration(sharedEnvRoot, "seed", 0)
+		result, err := r.runCreateIteration(sharedEnvRoot, "cache-warmup", 0)
 		if err != nil {
 			return nil, err
 		}
@@ -391,7 +391,7 @@ func (r *benchmarkRunner) seedRun() (*runResult, error) {
 	case scenarioWarmWorkspaceStage:
 		r.resetStageState(sharedEnvRoot)
 		r.resetTransportState(sharedEnvRoot)
-		result, err := r.runCreateIteration(sharedEnvRoot, "seed", 0)
+		result, err := r.runCreateIteration(sharedEnvRoot, "cache-warmup", 0)
 		if err != nil {
 			return nil, err
 		}

--- a/scripts/benchmark_repository_bootstrap_test.go
+++ b/scripts/benchmark_repository_bootstrap_test.go
@@ -18,12 +18,12 @@ func TestBenchmarkRepositoryBootstrapTool(t *testing.T) {
 	}
 
 	scenarios := []struct {
-		name       string
-		hasSeedRun bool
+		name           string
+		hasCacheWarmup bool
 	}{
-		{name: "cold-host", hasSeedRun: false},
-		{name: "warm-repository-store", hasSeedRun: true},
-		{name: "warm-workspace-stage", hasSeedRun: true},
+		{name: "cold-host", hasCacheWarmup: false},
+		{name: "warm-repository-store", hasCacheWarmup: true},
+		{name: "warm-workspace-stage", hasCacheWarmup: true},
 	}
 
 	for _, scenario := range scenarios {
@@ -132,9 +132,9 @@ raise SystemExit(2)
 					Warmup     int    `json:"warmup"`
 					Backend    string `json:"backend"`
 				} `json:"config"`
-				Seed       *map[string]any  `json:"seed"`
-				WarmupRuns []map[string]any `json:"warmup_runs"`
-				Runs       []struct {
+				CacheWarmup *map[string]any  `json:"cache_warmup"`
+				WarmupRuns  []map[string]any `json:"warmup_runs"`
+				Runs        []struct {
 					Label   string  `json:"label"`
 					Backend string  `json:"backend"`
 					Elapsed float64 `json:"elapsed_seconds"`
@@ -168,11 +168,11 @@ raise SystemExit(2)
 			if got, want := len(payload.Runs), 2; got != want {
 				t.Fatalf("unexpected measured run count: got %d want %d", got, want)
 			}
-			if scenario.hasSeedRun && payload.Seed == nil {
-				t.Fatal("expected seed run metadata")
+			if scenario.hasCacheWarmup && payload.CacheWarmup == nil {
+				t.Fatal("expected cache warmup run metadata")
 			}
-			if !scenario.hasSeedRun && payload.Seed != nil {
-				t.Fatalf("expected no seed metadata, got %+v", payload.Seed)
+			if !scenario.hasCacheWarmup && payload.CacheWarmup != nil {
+				t.Fatalf("expected no cache warmup metadata, got %+v", payload.CacheWarmup)
 			}
 			for _, run := range payload.Runs {
 				if run.Label == "" {


### PR DESCRIPTION
## Summary

- Reconciles stage-cache terminology so the layered caching plan, code, tests, and benchmark tooling use stage/base/cache-warmup language instead of old seed wording.
- Aligns portable dependency-stage metadata with the policy value by using `reuse_mode: portable` in the dependency-stage cache key and persisted records.
- Renames ZFS managed snapshot refs from `@seed` to `@base` and updates affected tests.
- Leaves the public `entropy_seed` protocol field intact because that is separate random-entropy terminology.

## Review

- Reviewed the layered caching plan against the current workspace, dependency, portable dependency, services, cache-store, cache-key, and ZFS volume-store code paths.
- Ran an additional Codex peer-review pass over the uncommitted diff; it reported no discrete findings.
- Verified the repository no longer has whole-word `seed` cache/stage terminology outside the entropy protocol surface.

## Validation

- `git diff --check`
- `mise exec -- go test ./...`