### PR TITLE
chore: Extract guest execution plumbing

### DIFF
--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/backend/guestexec"
 	"github.com/buildkite/cleanroom/internal/bootassets"
 	"github.com/buildkite/cleanroom/internal/ext4edit"
 	"github.com/buildkite/cleanroom/internal/ext4image"
@@ -1020,15 +1021,9 @@ func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream 
 	}
 	defer conn.Close()
 
-	if dl, ok := ctx.Deadline(); ok {
-		if err := conn.SetDeadline(dl); err != nil {
-			return nil, fmt.Errorf("set proxy socket deadline: %w", err)
-		}
+	if err := guestexec.PrepareConn(ctx, conn, "set proxy socket deadline"); err != nil {
+		return nil, err
 	}
-	go func() {
-		<-ctx.Done()
-		_ = conn.Close()
-	}()
 
 	gatewayScopeToken := ""
 	if a.GatewayRegistry != nil {
@@ -1078,44 +1073,13 @@ func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream 
 	if _, err := cryptorand.Read(entropy); err == nil {
 		guestReq.EntropySeed = entropy
 	}
-	if err := vsockexec.EncodeRequest(conn, guestReq); err != nil {
+	if err := guestexec.SendRequest(conn, guestReq); err != nil {
 		observation.Error = err.Error()
-		return nil, fmt.Errorf("send guest exec request: %w", err)
+		return nil, err
 	}
+	guestexec.AttachStream(conn, stream, darwinVZAttachMetadata(networkProcessPID, startedVM.NetworkMetadata))
 
-	inputSender := &inputFrameSender{w: conn}
-	if stream.OnAttach != nil {
-		var metadata map[string]string
-		if networkProcessPID > 0 || (startedVM.NetworkMetadata != nil && strings.TrimSpace(startedVM.NetworkMetadata.GuestIP) != "") {
-			metadata = map[string]string{}
-			if networkProcessPID > 0 {
-				metadata["network_process_pid"] = strconv.Itoa(networkProcessPID)
-			}
-			if startedVM.NetworkMetadata != nil {
-				if guestIP := strings.TrimSpace(startedVM.NetworkMetadata.GuestIP); guestIP != "" {
-					metadata["network_guest_ip"] = guestIP
-				}
-			}
-		}
-		stream.OnAttach(backend.AttachIO{
-			WriteStdin: func(data []byte) error {
-				return inputSender.Send(vsockexec.ExecInputFrame{Type: "stdin", Data: data})
-			},
-			CloseStdin: func() error {
-				return inputSender.Send(vsockexec.ExecInputFrame{Type: "eof"})
-			},
-			ResizeTTY: func(cols, rows uint32) error {
-				return inputSender.Send(vsockexec.ExecInputFrame{Type: "resize", Cols: cols, Rows: rows})
-			},
-			Metadata: metadata,
-		})
-	}
-
-	guestRes, err := vsockexec.DecodeStreamResponse(conn, vsockexec.StreamCallbacks{
-		OnStdout:                 stream.OnStdout,
-		OnStderr:                 stream.OnStderr,
-		BufferedOutputLimitBytes: stream.BufferedOutputLimitBytes,
-	})
+	guestRes, err := guestexec.DecodeResponse(conn, stream)
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			observation.Error = ctxErr.Error()
@@ -1484,15 +1448,9 @@ func (a *Adapter) executeInSandbox(bootCtx context.Context, runCtx context.Conte
 	}
 	defer conn.Close()
 
-	if dl, ok := runCtx.Deadline(); ok {
-		if err := conn.SetDeadline(dl); err != nil {
-			return nil, fmt.Errorf("set proxy socket deadline: %w", err)
-		}
+	if err := guestexec.PrepareConn(runCtx, conn, "set proxy socket deadline"); err != nil {
+		return nil, err
 	}
-	go func() {
-		<-runCtx.Done()
-		_ = conn.Close()
-	}()
 
 	gatewayScopeToken := ""
 	if a.GatewayRegistry != nil {
@@ -1546,43 +1504,12 @@ func (a *Adapter) executeInSandbox(bootCtx context.Context, runCtx context.Conte
 	if _, err := cryptorand.Read(entropy); err == nil {
 		guestReq.EntropySeed = entropy
 	}
-	if err := vsockexec.EncodeRequest(conn, guestReq); err != nil {
-		return nil, fmt.Errorf("send guest exec request: %w", err)
+	if err := guestexec.SendRequest(conn, guestReq); err != nil {
+		return nil, err
 	}
+	guestexec.AttachStream(conn, stream, darwinVZAttachMetadata(instance.NetworkProcessPID, instance.NetworkMetadata))
 
-	inputSender := &inputFrameSender{w: conn}
-	if stream.OnAttach != nil {
-		var metadata map[string]string
-		if instance.NetworkProcessPID > 0 || (instance.NetworkMetadata != nil && strings.TrimSpace(instance.NetworkMetadata.GuestIP) != "") {
-			metadata = map[string]string{}
-			if instance.NetworkProcessPID > 0 {
-				metadata["network_process_pid"] = strconv.Itoa(instance.NetworkProcessPID)
-			}
-			if instance.NetworkMetadata != nil {
-				if guestIP := strings.TrimSpace(instance.NetworkMetadata.GuestIP); guestIP != "" {
-					metadata["network_guest_ip"] = guestIP
-				}
-			}
-		}
-		stream.OnAttach(backend.AttachIO{
-			WriteStdin: func(data []byte) error {
-				return inputSender.Send(vsockexec.ExecInputFrame{Type: "stdin", Data: data})
-			},
-			CloseStdin: func() error {
-				return inputSender.Send(vsockexec.ExecInputFrame{Type: "eof"})
-			},
-			ResizeTTY: func(cols, rows uint32) error {
-				return inputSender.Send(vsockexec.ExecInputFrame{Type: "resize", Cols: cols, Rows: rows})
-			},
-			Metadata: metadata,
-		})
-	}
-
-	guestRes, err := vsockexec.DecodeStreamResponse(conn, vsockexec.StreamCallbacks{
-		OnStdout:                 stream.OnStdout,
-		OnStderr:                 stream.OnStderr,
-		BufferedOutputLimitBytes: stream.BufferedOutputLimitBytes,
-	})
+	guestRes, err := guestexec.DecodeResponse(conn, stream)
 	if err != nil {
 		if ctxErr := runCtx.Err(); ctxErr != nil {
 			return nil, fmt.Errorf("guest exec canceled while waiting for response: %w", ctxErr)
@@ -2403,15 +2330,20 @@ func (a *Adapter) resolveKernelPath(ctx context.Context, configuredPath string) 
 	return resolved.Path, resolved.Notice, nil
 }
 
-type inputFrameSender struct {
-	w  io.Writer
-	mu sync.Mutex
-}
-
-func (s *inputFrameSender) Send(frame vsockexec.ExecInputFrame) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return vsockexec.EncodeInputFrame(s.w, frame)
+func darwinVZAttachMetadata(networkProcessPID int, networkMetadata *darwinVZNetworkMetadata) map[string]string {
+	if networkProcessPID <= 0 && (networkMetadata == nil || strings.TrimSpace(networkMetadata.GuestIP) == "") {
+		return nil
+	}
+	metadata := map[string]string{}
+	if networkProcessPID > 0 {
+		metadata["network_process_pid"] = strconv.Itoa(networkProcessPID)
+	}
+	if networkMetadata != nil {
+		if guestIP := strings.TrimSpace(networkMetadata.GuestIP); guestIP != "" {
+			metadata["network_guest_ip"] = guestIP
+		}
+	}
+	return metadata
 }
 
 func darwinVZTimingSummary(timingMS map[string]int64) string {

--- a/internal/backend/darwinvz/guestexec_metadata_test.go
+++ b/internal/backend/darwinvz/guestexec_metadata_test.go
@@ -1,0 +1,27 @@
+//go:build darwin
+
+package darwinvz
+
+import "testing"
+
+func TestDarwinVZAttachMetadataIncludesNetworkDetails(t *testing.T) {
+	got := darwinVZAttachMetadata(1234, &darwinVZNetworkMetadata{GuestIP: " 192.0.2.10 "})
+	if got == nil {
+		t.Fatal("expected attach metadata")
+	}
+	if got["network_process_pid"] != "1234" {
+		t.Fatalf("unexpected network_process_pid: %q", got["network_process_pid"])
+	}
+	if got["network_guest_ip"] != "192.0.2.10" {
+		t.Fatalf("unexpected network_guest_ip: %q", got["network_guest_ip"])
+	}
+}
+
+func TestDarwinVZAttachMetadataOmitsEmptyDetails(t *testing.T) {
+	if got := darwinVZAttachMetadata(0, nil); got != nil {
+		t.Fatalf("expected nil metadata, got %#v", got)
+	}
+	if got := darwinVZAttachMetadata(0, &darwinVZNetworkMetadata{GuestIP: " "}); got != nil {
+		t.Fatalf("expected nil metadata for blank guest IP, got %#v", got)
+	}
+}

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/backend/guestexec"
 	"github.com/buildkite/cleanroom/internal/bootassets"
 	"github.com/buildkite/cleanroom/internal/ext4edit"
 	"github.com/buildkite/cleanroom/internal/gateway"
@@ -2248,53 +2249,16 @@ func runGuestCommand(bootCtx context.Context, execCtx context.Context, processEx
 		AgentReadyAt: readyAt,
 	}
 	defer conn.Close()
-	if dl, ok := execCtx.Deadline(); ok {
-		if deadlineConn, ok := conn.(interface{ SetDeadline(time.Time) error }); ok {
-			if err := deadlineConn.SetDeadline(dl); err != nil {
-				return vsockexec.ExecResponse{}, guestExecTiming{}, fmt.Errorf("set vsock deadline: %w", err)
-			}
-		}
+	if err := guestexec.PrepareConn(execCtx, conn, "set vsock deadline"); err != nil {
+		return vsockexec.ExecResponse{}, guestExecTiming{}, err
 	}
-	// Ensure blocked reads/writes are interrupted when context is canceled.
-	go func() {
-		<-execCtx.Done()
-		_ = conn.Close()
-	}()
-
-	if err := vsockexec.EncodeRequest(conn, req); err != nil {
-		return vsockexec.ExecResponse{}, guestExecTiming{}, fmt.Errorf("send guest exec request: %w", err)
+	if err := guestexec.SendRequest(conn, req); err != nil {
+		return vsockexec.ExecResponse{}, guestExecTiming{}, err
 	}
-
-	// Provide stdin/resize handlers so the caller can forward interactive
-	// input to the guest process via the same vsock connection.
-	inputSender := &inputFrameSender{w: conn}
-	if stream.OnAttach != nil {
-		stream.OnAttach(backend.AttachIO{
-			WriteStdin: func(data []byte) error {
-				return inputSender.Send(vsockexec.ExecInputFrame{
-					Type: "stdin",
-					Data: data,
-				})
-			},
-			CloseStdin: func() error {
-				return inputSender.Send(vsockexec.ExecInputFrame{Type: "eof"})
-			},
-			ResizeTTY: func(cols, rows uint32) error {
-				return inputSender.Send(vsockexec.ExecInputFrame{
-					Type: "resize",
-					Cols: cols,
-					Rows: rows,
-				})
-			},
-		})
-	}
+	guestexec.AttachStream(conn, stream, nil)
 
 	commandStart := time.Now()
-	res, err := vsockexec.DecodeStreamResponse(conn, vsockexec.StreamCallbacks{
-		OnStdout:                 stream.OnStdout,
-		OnStderr:                 stream.OnStderr,
-		BufferedOutputLimitBytes: stream.BufferedOutputLimitBytes,
-	})
+	res, err := guestexec.DecodeResponse(conn, stream)
 	if err != nil {
 		if ctxErr := execCtx.Err(); ctxErr != nil {
 			return vsockexec.ExecResponse{}, guestExecTiming{}, fmt.Errorf("guest exec canceled while waiting for response: %w", ctxErr)
@@ -2303,17 +2267,6 @@ func runGuestCommand(bootCtx context.Context, execCtx context.Context, processEx
 	}
 	timing.CommandRun = time.Since(commandStart)
 	return res, timing, nil
-}
-
-type inputFrameSender struct {
-	w  io.Writer
-	mu sync.Mutex
-}
-
-func (s *inputFrameSender) Send(frame vsockexec.ExecInputFrame) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return vsockexec.EncodeInputFrame(s.w, frame)
 }
 
 type callbackWriter struct {

--- a/internal/backend/guestexec/guestexec.go
+++ b/internal/backend/guestexec/guestexec.go
@@ -1,0 +1,95 @@
+package guestexec
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/vsockexec"
+)
+
+type deadlineConn interface {
+	SetDeadline(time.Time) error
+}
+
+// PrepareConn applies the execution deadline when supported and closes conn
+// when ctx is canceled so blocked protocol reads and writes unblock promptly.
+func PrepareConn(ctx context.Context, conn io.Closer, deadlineErr string) error {
+	if conn == nil {
+		return nil
+	}
+	if dl, ok := ctx.Deadline(); ok {
+		if c, ok := conn.(deadlineConn); ok {
+			if err := c.SetDeadline(dl); err != nil {
+				if deadlineErr == "" {
+					deadlineErr = "set guest exec deadline"
+				}
+				return fmt.Errorf("%s: %w", deadlineErr, err)
+			}
+		}
+	}
+	go func() {
+		<-ctx.Done()
+		_ = conn.Close()
+	}()
+	return nil
+}
+
+// SendRequest writes the guest execution request using the vsockexec protocol.
+func SendRequest(w io.Writer, req vsockexec.ExecRequest) error {
+	if err := vsockexec.EncodeRequest(w, req); err != nil {
+		return fmt.Errorf("send guest exec request: %w", err)
+	}
+	return nil
+}
+
+// AttachStream exposes stdin and TTY resize writers for an execution stream.
+func AttachStream(w io.Writer, stream backend.OutputStream, metadata map[string]string) {
+	if stream.OnAttach == nil {
+		return
+	}
+	inputSender := &inputFrameSender{w: w}
+	stream.OnAttach(backend.AttachIO{
+		WriteStdin: func(data []byte) error {
+			return inputSender.Send(vsockexec.ExecInputFrame{
+				Type: "stdin",
+				Data: data,
+			})
+		},
+		CloseStdin: func() error {
+			return inputSender.Send(vsockexec.ExecInputFrame{Type: "eof"})
+		},
+		ResizeTTY: func(cols, rows uint32) error {
+			return inputSender.Send(vsockexec.ExecInputFrame{
+				Type: "resize",
+				Cols: cols,
+				Rows: rows,
+			})
+		},
+		Metadata: metadata,
+	})
+}
+
+// DecodeResponse reads stream frames into an execution response while
+// forwarding stdout and stderr callbacks.
+func DecodeResponse(r io.Reader, stream backend.OutputStream) (vsockexec.ExecResponse, error) {
+	return vsockexec.DecodeStreamResponse(r, vsockexec.StreamCallbacks{
+		OnStdout:                 stream.OnStdout,
+		OnStderr:                 stream.OnStderr,
+		BufferedOutputLimitBytes: stream.BufferedOutputLimitBytes,
+	})
+}
+
+type inputFrameSender struct {
+	w  io.Writer
+	mu sync.Mutex
+}
+
+func (s *inputFrameSender) Send(frame vsockexec.ExecInputFrame) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return vsockexec.EncodeInputFrame(s.w, frame)
+}

--- a/internal/backend/guestexec/guestexec_test.go
+++ b/internal/backend/guestexec/guestexec_test.go
@@ -1,0 +1,155 @@
+package guestexec
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/vsockexec"
+)
+
+func TestPrepareConnSetsDeadlineAndClosesOnCancel(t *testing.T) {
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Hour))
+	defer cancel()
+	conn := &fakeConn{closed: make(chan struct{})}
+
+	if err := PrepareConn(ctx, conn, "set test deadline"); err != nil {
+		t.Fatalf("PrepareConn returned error: %v", err)
+	}
+	if conn.deadline.IsZero() {
+		t.Fatalf("expected deadline to be set")
+	}
+
+	cancel()
+	select {
+	case <-conn.closed:
+	case <-time.After(time.Second):
+		t.Fatal("expected connection to close when context is canceled")
+	}
+}
+
+func TestPrepareConnWrapsDeadlineError(t *testing.T) {
+	conn := &fakeConn{setDeadlineErr: errors.New("boom"), closed: make(chan struct{})}
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Hour))
+	defer cancel()
+
+	err := PrepareConn(ctx, conn, "set proxy socket deadline")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if got, want := err.Error(), "set proxy socket deadline: boom"; got != want {
+		t.Fatalf("unexpected error: got %q want %q", got, want)
+	}
+}
+
+func TestAttachStreamWritesInputFramesAndMetadata(t *testing.T) {
+	var buf bytes.Buffer
+	var attach backend.AttachIO
+	AttachStream(&buf, backend.OutputStream{
+		OnAttach: func(io backend.AttachIO) {
+			attach = io
+		},
+	}, map[string]string{"network_guest_ip": "192.0.2.10"})
+
+	if attach.WriteStdin == nil || attach.CloseStdin == nil || attach.ResizeTTY == nil {
+		t.Fatalf("expected attach IO callbacks to be set")
+	}
+	if got, want := attach.Metadata["network_guest_ip"], "192.0.2.10"; got != want {
+		t.Fatalf("unexpected metadata: got %q want %q", got, want)
+	}
+
+	if err := attach.WriteStdin([]byte("hello")); err != nil {
+		t.Fatalf("WriteStdin returned error: %v", err)
+	}
+	if err := attach.ResizeTTY(120, 40); err != nil {
+		t.Fatalf("ResizeTTY returned error: %v", err)
+	}
+	if err := attach.CloseStdin(); err != nil {
+		t.Fatalf("CloseStdin returned error: %v", err)
+	}
+
+	dec := json.NewDecoder(&buf)
+	first := vsockexec.ExecInputFrame{}
+	if err := dec.Decode(&first); err != nil {
+		t.Fatalf("decode first input frame: %v", err)
+	}
+	if first.Type != "stdin" || string(first.Data) != "hello" {
+		t.Fatalf("unexpected first input frame: %#v", first)
+	}
+	second := vsockexec.ExecInputFrame{}
+	if err := dec.Decode(&second); err != nil {
+		t.Fatalf("decode second input frame: %v", err)
+	}
+	if second.Type != "resize" || second.Cols != 120 || second.Rows != 40 {
+		t.Fatalf("unexpected second input frame: %#v", second)
+	}
+	third := vsockexec.ExecInputFrame{}
+	if err := dec.Decode(&third); err != nil {
+		t.Fatalf("decode third input frame: %v", err)
+	}
+	if third.Type != "eof" {
+		t.Fatalf("unexpected third input frame: %#v", third)
+	}
+}
+
+func TestDecodeResponseForwardsStreamCallbacksAndLimit(t *testing.T) {
+	var frames bytes.Buffer
+	if err := vsockexec.EncodeStreamFrame(&frames, vsockexec.ExecStreamFrame{Type: "stdout", Data: []byte("abcdef")}); err != nil {
+		t.Fatalf("EncodeStreamFrame stdout: %v", err)
+	}
+	if err := vsockexec.EncodeStreamFrame(&frames, vsockexec.ExecStreamFrame{Type: "exit", ExitCode: 7}); err != nil {
+		t.Fatalf("EncodeStreamFrame exit: %v", err)
+	}
+
+	limit := 3
+	var streamed bytes.Buffer
+	res, err := DecodeResponse(&frames, backend.OutputStream{
+		OnStdout:                 func(chunk []byte) { streamed.Write(chunk) },
+		BufferedOutputLimitBytes: &limit,
+	})
+	if err != nil {
+		t.Fatalf("DecodeResponse returned error: %v", err)
+	}
+	if got, want := streamed.String(), "abcdef"; got != want {
+		t.Fatalf("unexpected streamed stdout: got %q want %q", got, want)
+	}
+	if got, want := res.Stdout, "def"; got != want {
+		t.Fatalf("unexpected retained stdout: got %q want %q", got, want)
+	}
+	if got, want := res.ExitCode, 7; got != want {
+		t.Fatalf("unexpected exit code: got %d want %d", got, want)
+	}
+}
+
+type fakeConn struct {
+	deadline       time.Time
+	setDeadlineErr error
+	closed         chan struct{}
+}
+
+func (c *fakeConn) SetDeadline(deadline time.Time) error {
+	c.deadline = deadline
+	return c.setDeadlineErr
+}
+
+func (c *fakeConn) Close() error {
+	select {
+	case <-c.closed:
+	default:
+		close(c.closed)
+	}
+	return nil
+}
+
+func (c *fakeConn) Read([]byte) (int, error) {
+	return 0, io.EOF
+}
+
+func (c *fakeConn) Write(p []byte) (int, error) {
+	return len(p), nil
+}


### PR DESCRIPTION
## Summary

Extract shared host-side guest execution plumbing into `internal/backend/guestexec` and use it from the Firecracker and Darwin VZ adapters.

This keeps backend-specific transport, gateway token handling, warnings, timing, and result mapping in the adapters while consolidating repeated protocol mechanics:

- applying execution deadlines to guest connections
- closing guest connections on context cancellation
- sending `vsockexec` requests
- exposing attach IO for stdin, EOF, and TTY resize frames
- decoding streamed stdout/stderr with the configured buffered-output limit

## Why

The backend adapters had duplicated code for the same request/attach/decode flow. Keeping that logic in one helper reduces drift in cancellation, attach, and output-retention behavior while preserving adapter-specific responsibilities.

## Validation

- `mise exec -- go test ./internal/backend/guestexec ./internal/backend/firecracker ./internal/backend/darwinvz`
- `GOOS=darwin GOARCH=arm64 mise exec -- go test -run '^TestDarwinVZAttachMetadata' ./internal/backend/darwinvz`
- `GOOS=darwin GOARCH=arm64 mise exec -- go test -run '^$' ./internal/backend/firecracker ./internal/backend/darwinvz`
- `GOOS=linux GOARCH=amd64 go test -c ./internal/backend/firecracker ./internal/backend/darwinvz`
- `mise run build:go`
- `mise run test`
- `git diff --check`