### PR TITLE
feat: Persist repository changesets

### DIFF
--- a/docs/plans/layered-caching.md
+++ b/docs/plans/layered-caching.md
@@ -154,6 +154,9 @@ This phase now means:
   and snapshot restore
 - request-scoped `--include-local-changes` packaging and replay after exact
   repository checkout
+- durable host-local `changesetstore` metadata and payload storage for
+  explicit repository changesets, with stage-cache metadata recording the
+  stable changeset ID
 - dependency-stage and services-stage key-file digest resolution from the
   post-apply tree when an explicit changeset is present
 - exact dependency-stage publish, lookup, restore, and republish for one
@@ -170,9 +173,9 @@ This phase now means:
 - dependency-stage keying has the first explicit input model, but richer
   toolchain-derived inputs, lockfile parser inputs, and artifact allowlists are
   still pending
-- explicit local changes are packaged into each create request today, but there
-  is not yet a dedicated `changesetstore` for durable host-local changeset
-  metadata and replay payloads
+- explicit local changes are still supplied through each create request today;
+  the durable `changesetstore` records the replay payload and identity, but a
+  user-facing `--changeset <id>` reuse surface has not been added yet
 
 Today that means:
 
@@ -185,7 +188,6 @@ Today that means:
 
 ### Not started
 
-- dedicated `changesetstore` storage and lifecycle
 - strict offline warm-cache mode
 - garbage collection and retention policy
 - cross-host distribution/export for stage caches
@@ -1030,7 +1032,7 @@ This plan composes with the existing documents rather than replacing them.
 | `internal/controlservice/workspace_stage.go` | Current workspace-stage orchestration already lives here using dedicated stage-cache metadata. |
 | `internal/controlservice/dependency_stage.go` | Dependency-stage orchestration entry point for policy-controlled bootstrap, declared key-file hashing, post-apply tree keying, exact dependency-stage publication, and the portable dependency-stage lookup/validation path. |
 | `internal/snapshotstore/store.go` | Should remain the user snapshot store rather than being expanded into the system-cache store. |
-| `internal/changesetstore/*` | Planned store for explicit local changeset metadata and replay payloads, separate from both snapshots and stage caches. |
+| `internal/changesetstore/*` | Landed store for explicit local changeset metadata and replay payloads, separate from both snapshots and stage caches. |
 | `internal/volumestore/store.go` | Already provides the backend-neutral clone/snapshot contract shared by both backends. |
 | `internal/backend/firecracker/backend.go` | Already routes normal execution and snapshot restore through writable root volume preparation; actual clone behavior depends on the configured driver. |
 | `internal/backend/darwinvz/backend_darwin.go` | Already fits the same one-rootfs model and can use APFS clone materialization. |
@@ -1047,7 +1049,7 @@ stage                    // runtime | workspace | dependency | services
 reuse_mode               // exact | portable, when stage = dependency
 state                    // ready | failed | garbage
 parent_cache_key
-changeset_digest         // optional, when a workspace/dependency stage includes explicit local changes
+changeset_id             // optional, when a workspace/dependency stage includes explicit local changes
 storage_driver
 storage_ref
 policy_hash
@@ -1075,6 +1077,7 @@ changeset_digest
 final_tree_digest
 transport_format
 transport_ref
+payload_digest
 created_at
 ```
 
@@ -1105,6 +1108,9 @@ This metadata should live in a dedicated `changesetstore`, not in
    and falls back to normal dependency bootstrap if restore or refresh fails.
 8. Add services-stage caching on top of the selected workspace or dependency
    stage.
+9. Add a dedicated `changesetstore` for durable host-local changeset metadata
+   and replay payloads, and record the stable changeset ID in system stage-cache
+   metadata when a stage includes explicit local changes.
 
 ### Partial
 
@@ -1114,9 +1120,8 @@ This metadata should live in a dedicated `changesetstore`, not in
    preparation.
 3. Add richer dependency input modeling beyond the current
    workspace-plus-command-plus-key-files slice.
-4. Turn request-scoped changeset payloads into a durable host-local
-   `changesetstore` if changesets need reuse, retention, or operator
-   introspection outside one sandbox create request.
+4. Add a user-facing changeset reuse surface if durable changesets need to be
+   replayed outside the original sandbox create request.
 
 The stage-cache flow is architecturally landed, but the full performance win
 still depends on clone-capable storage instead of the default `file` driver,
@@ -1124,17 +1129,16 @@ and the dependency stage still needs richer lockfile/toolchain inputs.
 
 ### Remaining
 
-1. Add a dedicated `changesetstore` for durable host-local changeset metadata,
-   replay payload lifecycle, and any future changeset reuse outside a single
-   create request.
-2. Add richer toolchain input digests for dependency-stage keys beyond the
+1. Add richer toolchain input digests for dependency-stage keys beyond the
    current workspace-plus-command-plus-key-files slice.
-3. Add lockfile parser inputs and artifact allowlists so dependency-stage keys
+2. Add lockfile parser inputs and artifact allowlists so dependency-stage keys
    can move beyond manually declared key files.
-4. Add explicit dependency output/preserve semantics if we want portable reuse
+3. Add explicit dependency output/preserve semantics if we want portable reuse
    for repo-local outputs such as `node_modules` or `vendor/bundle`.
-5. Add additional ecosystems only after the first explicit dependency-stage
+4. Add additional ecosystems only after the first explicit dependency-stage
    flow is solid.
+5. Add a user-facing `--changeset <id>` or equivalent reuse surface if durable
+   changesets need explicit replay outside the original create request.
 6. Add strict offline warm-cache mode and fail-closed launch checks.
 7. Add garbage collection and retention policies after the key model and
    publication flow are stable.
@@ -1164,6 +1168,9 @@ Current coverage exists for the implemented host-local stage-cache flow:
 - restore failures fall back to cold bootstrap and republish
 - writable-volume preparation cleans up failed clones and uses the configured
   volume-store driver
+- changesetstore round-trips explicit changeset metadata and payloads, dedupes
+  by stable identity, and detects payload corruption
+- sandbox creation persists explicit repository changesets before applying them
 - exact dependency-stage hits skip dependency bootstrap
 - services-stage hits skip dependency and services bootstrap
 - local changeset payloads are replayed after exact repository checkout

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -295,6 +295,9 @@ Requirements:
 - The client may create the changeset from local repository state, but the
   control plane must validate that the base checkout in the request matches the
   changeset metadata before applying it.
+- When a host-local changeset store is available, the control plane should
+  persist the validated changeset identity and replay payload before applying
+  it so cache lineage can refer to a stable changeset ID.
 - The control plane must apply a changeset only after exact repository checkout
   or workspace-stage restore and before dependency bootstrap or workload
   execution.

--- a/internal/cachestore/store.go
+++ b/internal/cachestore/store.go
@@ -26,6 +26,7 @@ type Record struct {
 	Policy                   *cleanroomv1.Policy
 	Repository               *cleanroomv1.RepositoryCheckout
 	RepositoryHasChangeset   bool
+	RepositoryChangesetID    string
 	ParentCacheKey           string
 	StorageDriver            string
 	StorageRef               string
@@ -142,6 +143,7 @@ func (s *Store) persist(ctx context.Context, record Record, replace bool) error 
 			policy_proto,
 			repository_proto,
 			repository_has_changeset,
+			repository_changeset_id,
 			parent_cache_key,
 			storage_driver,
 			storage_ref,
@@ -151,7 +153,7 @@ func (s *Store) persist(ctx context.Context, record Record, replace bool) error 
 			created_at_unix_nano,
 			last_used_at_unix_nano,
 			producer_version
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`
 	if replace {
 		verb = "upsert"
@@ -167,6 +169,7 @@ func (s *Store) persist(ctx context.Context, record Record, replace bool) error 
 				policy_proto,
 				repository_proto,
 				repository_has_changeset,
+				repository_changeset_id,
 				parent_cache_key,
 				storage_driver,
 				storage_ref,
@@ -176,7 +179,7 @@ func (s *Store) persist(ctx context.Context, record Record, replace bool) error 
 				created_at_unix_nano,
 				last_used_at_unix_nano,
 				producer_version
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 			ON CONFLICT(stage, cache_key) DO UPDATE SET
 				reuse_mode = excluded.reuse_mode,
 				state = excluded.state,
@@ -186,6 +189,7 @@ func (s *Store) persist(ctx context.Context, record Record, replace bool) error 
 				policy_proto = excluded.policy_proto,
 				repository_proto = excluded.repository_proto,
 				repository_has_changeset = excluded.repository_has_changeset,
+				repository_changeset_id = excluded.repository_changeset_id,
 				parent_cache_key = excluded.parent_cache_key,
 				storage_driver = excluded.storage_driver,
 				storage_ref = excluded.storage_ref,
@@ -209,6 +213,7 @@ func (s *Store) persist(ctx context.Context, record Record, replace bool) error 
 		policyBytes,
 		repositoryBytes,
 		boolToInt(record.RepositoryHasChangeset),
+		nullableString(record.RepositoryChangesetID),
 		nullableString(record.ParentCacheKey),
 		record.StorageDriver,
 		record.StorageRef,
@@ -243,6 +248,7 @@ func (s *Store) GetReady(ctx context.Context, stage, cacheKey string) (Record, b
 			policy_proto,
 			repository_proto,
 			repository_has_changeset,
+			repository_changeset_id,
 			parent_cache_key,
 			storage_driver,
 			storage_ref,
@@ -314,6 +320,7 @@ func (s *Store) List(ctx context.Context) ([]Record, error) {
 			policy_proto,
 			repository_proto,
 			repository_has_changeset,
+			repository_changeset_id,
 			parent_cache_key,
 			storage_driver,
 			storage_ref,
@@ -390,6 +397,7 @@ func (s *Store) initDB(ctx context.Context) error {
 			policy_proto BLOB NOT NULL,
 			repository_proto BLOB,
 			repository_has_changeset INTEGER NOT NULL DEFAULT 0,
+			repository_changeset_id TEXT,
 			parent_cache_key TEXT,
 			storage_driver TEXT NOT NULL DEFAULT 'file',
 			storage_ref TEXT NOT NULL,
@@ -412,6 +420,9 @@ func (s *Store) initDB(ctx context.Context) error {
 	}
 	if _, err := db.ExecContext(ctx, `ALTER TABLE cache_entries ADD COLUMN repository_has_changeset INTEGER NOT NULL DEFAULT 0`); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
 		return fmt.Errorf("ensure cache metadata repository_has_changeset column: %w", err)
+	}
+	if _, err := db.ExecContext(ctx, `ALTER TABLE cache_entries ADD COLUMN repository_changeset_id TEXT`); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
+		return fmt.Errorf("ensure cache metadata repository_changeset_id column: %w", err)
 	}
 	if _, err := db.ExecContext(ctx, `ALTER TABLE cache_entries ADD COLUMN reuse_mode TEXT`); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
 		return fmt.Errorf("ensure cache metadata reuse_mode column: %w", err)
@@ -437,6 +448,7 @@ func scanRecord(row recordScanner) (Record, error) {
 		repositoryHasChangeset   int
 		checkoutRefreshRequired  int
 		reuseMode                sql.NullString
+		repositoryChangesetID    sql.NullString
 		parentCacheKey           sql.NullString
 		inputDigest              sql.NullString
 		dependencyKeyFilesDigest sql.NullString
@@ -454,6 +466,7 @@ func scanRecord(row recordScanner) (Record, error) {
 		&policyBytes,
 		&repositoryBytes,
 		&repositoryHasChangeset,
+		&repositoryChangesetID,
 		&parentCacheKey,
 		&record.StorageDriver,
 		&record.StorageRef,
@@ -478,6 +491,9 @@ func scanRecord(row recordScanner) (Record, error) {
 		}
 	}
 	record.RepositoryHasChangeset = repositoryHasChangeset != 0
+	if repositoryChangesetID.Valid {
+		record.RepositoryChangesetID = repositoryChangesetID.String
+	}
 	if parentCacheKey.Valid {
 		record.ParentCacheKey = parentCacheKey.String
 	}

--- a/internal/cachestore/store_test.go
+++ b/internal/cachestore/store_test.go
@@ -40,6 +40,7 @@ func TestStoreCreateGetReadyListDelete(t *testing.T) {
 			Branch:         "main",
 		},
 		RepositoryHasChangeset:   true,
+		RepositoryChangesetID:    "changeset:v1:test",
 		ParentCacheKey:           "runtime:test",
 		ReuseMode:                "portable",
 		StorageRef:               "/tmp/workspace-test.ext4",
@@ -62,7 +63,7 @@ func TestStoreCreateGetReadyListDelete(t *testing.T) {
 	if !ok {
 		t.Fatal("expected stored ready cache")
 	}
-	if got.CacheKey != record.CacheKey || got.Stage != record.Stage || got.State != record.State || got.PolicyHash != record.PolicyHash || got.StorageRef != record.StorageRef || got.StorageDriver != record.StorageDriver || got.ParentCacheKey != record.ParentCacheKey || got.ReuseMode != record.ReuseMode || got.InputManifestDigest != record.InputManifestDigest || got.DependencyKeyFilesDigest != record.DependencyKeyFilesDigest || got.CheckoutRefreshRequired != record.CheckoutRefreshRequired || got.ProducerVersion != record.ProducerVersion {
+	if got.CacheKey != record.CacheKey || got.Stage != record.Stage || got.State != record.State || got.PolicyHash != record.PolicyHash || got.StorageRef != record.StorageRef || got.StorageDriver != record.StorageDriver || got.ParentCacheKey != record.ParentCacheKey || got.ReuseMode != record.ReuseMode || got.RepositoryChangesetID != record.RepositoryChangesetID || got.InputManifestDigest != record.InputManifestDigest || got.DependencyKeyFilesDigest != record.DependencyKeyFilesDigest || got.CheckoutRefreshRequired != record.CheckoutRefreshRequired || got.ProducerVersion != record.ProducerVersion {
 		t.Fatalf("unexpected cache record: %#v", got)
 	}
 	if !got.CreatedAt.Equal(record.CreatedAt) {

--- a/internal/changesetstore/store.go
+++ b/internal/changesetstore/store.go
@@ -1,0 +1,529 @@
+// Package changesetstore persists explicit repository changesets separately
+// from user snapshots and system stage caches.
+package changesetstore
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+	"github.com/buildkite/cleanroom/internal/paths"
+	"github.com/buildkite/cleanroom/internal/repositorychangeset"
+	"github.com/buildkite/cleanroom/internal/repositorycheckout"
+	"google.golang.org/protobuf/proto"
+	_ "modernc.org/sqlite"
+)
+
+const (
+	TransportFormatProtoV1 = "repository-changeset-proto-v1"
+	idFormatVersion        = "v1"
+)
+
+type Record struct {
+	ChangesetID        string
+	CanonicalRemoteURL string
+	BaseCommitSHA      string
+	SubmoduleMode      string
+	ChangesetDigest    string
+	FinalTreeDigest    string
+	TransportFormat    string
+	TransportRef       string
+	PayloadDigest      string
+	CreatedAt          time.Time
+	LastUsedAt         time.Time
+}
+
+type Options struct {
+	MetadataDBPath string
+	PayloadDir     string
+}
+
+type Store struct {
+	metadataDBPath string
+	payloadDir     string
+}
+
+func New(opts Options) (*Store, error) {
+	metadataDBPath := strings.TrimSpace(opts.MetadataDBPath)
+	payloadDir := strings.TrimSpace(opts.PayloadDir)
+	if metadataDBPath == "" || payloadDir == "" {
+		defaultMetadataDBPath, defaultPayloadDir, err := defaultPaths()
+		if err != nil {
+			return nil, fmt.Errorf("resolve changeset store paths: %w", err)
+		}
+		if metadataDBPath == "" {
+			metadataDBPath = defaultMetadataDBPath
+		}
+		if payloadDir == "" {
+			payloadDir = defaultPayloadDir
+		}
+	}
+	if err := os.MkdirAll(filepath.Dir(metadataDBPath), 0o755); err != nil {
+		return nil, fmt.Errorf("create changeset metadata directory for %q: %w", metadataDBPath, err)
+	}
+	if err := os.MkdirAll(payloadDir, 0o755); err != nil {
+		return nil, fmt.Errorf("create changeset payload directory for %q: %w", payloadDir, err)
+	}
+
+	store := &Store{
+		metadataDBPath: metadataDBPath,
+		payloadDir:     payloadDir,
+	}
+	if err := store.initDB(context.Background()); err != nil {
+		return nil, err
+	}
+	return store, nil
+}
+
+func (s *Store) Put(ctx context.Context, repository *repositorycheckout.Checkout, changeset *repositorychangeset.Changeset) (Record, error) {
+	record, payload, err := newRecord(repository, changeset)
+	if err != nil {
+		return Record{}, err
+	}
+	if record.CreatedAt.IsZero() {
+		record.CreatedAt = time.Now().UTC()
+	}
+	if record.LastUsedAt.IsZero() {
+		record.LastUsedAt = record.CreatedAt
+	}
+	if err := s.writePayload(record, payload); err != nil {
+		return Record{}, err
+	}
+
+	db, err := s.open(ctx)
+	if err != nil {
+		return Record{}, err
+	}
+	defer db.Close()
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO changesets (
+			changeset_id,
+			canonical_remote_url,
+			base_commit_sha,
+			submodule_mode,
+			changeset_digest,
+			final_tree_digest,
+			transport_format,
+			transport_ref,
+			payload_digest,
+			created_at_unix_nano,
+			last_used_at_unix_nano
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(changeset_id) DO UPDATE SET
+			canonical_remote_url = excluded.canonical_remote_url,
+			base_commit_sha = excluded.base_commit_sha,
+			submodule_mode = excluded.submodule_mode,
+			changeset_digest = excluded.changeset_digest,
+			final_tree_digest = excluded.final_tree_digest,
+			transport_format = excluded.transport_format,
+			transport_ref = excluded.transport_ref,
+			payload_digest = excluded.payload_digest,
+			last_used_at_unix_nano = excluded.last_used_at_unix_nano
+	`, record.ChangesetID,
+		record.CanonicalRemoteURL,
+		record.BaseCommitSHA,
+		record.SubmoduleMode,
+		record.ChangesetDigest,
+		record.FinalTreeDigest,
+		record.TransportFormat,
+		record.TransportRef,
+		record.PayloadDigest,
+		record.CreatedAt.UTC().UnixNano(),
+		record.LastUsedAt.UTC().UnixNano(),
+	); err != nil {
+		return Record{}, fmt.Errorf("persist changeset metadata %q: %w", record.ChangesetID, err)
+	}
+	stored, ok, err := s.getRecord(ctx, record.ChangesetID)
+	if err != nil {
+		return Record{}, err
+	}
+	if !ok {
+		return Record{}, fmt.Errorf("changeset metadata %q was not visible after persist", record.ChangesetID)
+	}
+	return stored, nil
+}
+
+func (s *Store) Get(ctx context.Context, changesetID string) (Record, *repositorychangeset.Changeset, bool, error) {
+	record, ok, err := s.getRecord(ctx, changesetID)
+	if err != nil || !ok {
+		return record, nil, ok, err
+	}
+	changeset, err := s.readPayload(record)
+	if err != nil {
+		return Record{}, nil, false, err
+	}
+	return record, changeset, true, nil
+}
+
+func (s *Store) getRecord(ctx context.Context, changesetID string) (Record, bool, error) {
+	db, err := s.open(ctx)
+	if err != nil {
+		return Record{}, false, err
+	}
+	defer db.Close()
+
+	row := db.QueryRowContext(ctx, `
+		SELECT
+			changeset_id,
+			canonical_remote_url,
+			base_commit_sha,
+			submodule_mode,
+			changeset_digest,
+			final_tree_digest,
+			transport_format,
+			transport_ref,
+			payload_digest,
+			created_at_unix_nano,
+			last_used_at_unix_nano
+		FROM changesets
+		WHERE changeset_id = ?
+	`, strings.TrimSpace(changesetID))
+
+	record, err := scanRecord(row)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return Record{}, false, nil
+		}
+		return Record{}, false, err
+	}
+	return record, true, nil
+}
+
+func (s *Store) List(ctx context.Context) ([]Record, error) {
+	db, err := s.open(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+
+	rows, err := db.QueryContext(ctx, `
+		SELECT
+			changeset_id,
+			canonical_remote_url,
+			base_commit_sha,
+			submodule_mode,
+			changeset_digest,
+			final_tree_digest,
+			transport_format,
+			transport_ref,
+			payload_digest,
+			created_at_unix_nano,
+			last_used_at_unix_nano
+		FROM changesets
+		ORDER BY created_at_unix_nano ASC, changeset_id ASC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("query changesets: %w", err)
+	}
+	defer rows.Close()
+
+	items := make([]Record, 0)
+	for rows.Next() {
+		record, scanErr := scanRecord(rows)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		items = append(items, record)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate changesets: %w", err)
+	}
+	return items, nil
+}
+
+func (s *Store) Delete(ctx context.Context, changesetID string) error {
+	_, ok, err := s.getRecord(ctx, changesetID)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+
+	db, err := s.open(ctx)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	if _, err := db.ExecContext(ctx, `
+		DELETE FROM changesets
+		WHERE changeset_id = ?
+	`, strings.TrimSpace(changesetID)); err != nil {
+		return fmt.Errorf("delete changeset metadata %q: %w", changesetID, err)
+	}
+	return nil
+}
+
+func RecordID(repository *repositorycheckout.Checkout, changeset *repositorychangeset.Changeset) string {
+	if repository == nil || changeset == nil {
+		return ""
+	}
+	remoteURL := strings.TrimSpace(repository.RemoteURL)
+	baseCommitSHA := strings.ToLower(strings.TrimSpace(changeset.BaseCommitSHA))
+	changesetDigest := strings.TrimSpace(changeset.Digest)
+	if remoteURL == "" || baseCommitSHA == "" || changesetDigest == "" {
+		return ""
+	}
+
+	payload := strings.Join([]string{
+		"cleanroom/changesetstore",
+		idFormatVersion,
+		remoteURL,
+		baseCommitSHA,
+		submoduleMode(repository),
+		changesetDigest,
+	}, "\x00")
+	sum := sha256.Sum256([]byte(payload))
+	return "changeset:" + idFormatVersion + ":" + hex.EncodeToString(sum[:])
+}
+
+func newRecord(repository *repositorycheckout.Checkout, changeset *repositorychangeset.Changeset) (Record, []byte, error) {
+	if repository == nil {
+		return Record{}, nil, errors.New("changeset store requires a repository checkout")
+	}
+	if changeset == nil {
+		return Record{}, nil, errors.New("changeset store requires a repository changeset")
+	}
+	if err := changeset.ValidateForCheckout(repository); err != nil {
+		return Record{}, nil, err
+	}
+	if err := changeset.ValidateContent(); err != nil {
+		return Record{}, nil, err
+	}
+
+	protoBytes, err := proto.Marshal(changeset.ToProto())
+	if err != nil {
+		return Record{}, nil, fmt.Errorf("marshal repository changeset payload: %w", err)
+	}
+	payloadDigest := sha256Bytes(protoBytes)
+	transportRef, err := payloadRef(payloadDigest)
+	if err != nil {
+		return Record{}, nil, err
+	}
+	record := Record{
+		ChangesetID:        RecordID(repository, changeset),
+		CanonicalRemoteURL: strings.TrimSpace(repository.RemoteURL),
+		BaseCommitSHA:      strings.ToLower(strings.TrimSpace(changeset.BaseCommitSHA)),
+		SubmoduleMode:      submoduleMode(repository),
+		ChangesetDigest:    strings.TrimSpace(changeset.Digest),
+		FinalTreeDigest:    strings.TrimSpace(changeset.TreeDigest),
+		TransportFormat:    TransportFormatProtoV1,
+		TransportRef:       transportRef,
+		PayloadDigest:      payloadDigest,
+	}
+	if record.ChangesetID == "" {
+		return Record{}, nil, errors.New("changeset store could not derive changeset id")
+	}
+	return record, protoBytes, nil
+}
+
+func (s *Store) writePayload(record Record, payload []byte) error {
+	if strings.TrimSpace(record.PayloadDigest) == "" {
+		return fmt.Errorf("changeset %q missing payload digest", record.ChangesetID)
+	}
+	if got := sha256Bytes(payload); got != strings.TrimSpace(record.PayloadDigest) {
+		return fmt.Errorf("changeset %q payload digest mismatch: got %s want %s", record.ChangesetID, got, record.PayloadDigest)
+	}
+
+	target, err := s.payloadPath(record)
+	if err != nil {
+		return err
+	}
+	if existing, err := os.ReadFile(target); err == nil {
+		if got := sha256Bytes(existing); got != record.PayloadDigest {
+			return fmt.Errorf("changeset payload %q digest mismatch: got %s want %s", target, got, record.PayloadDigest)
+		}
+		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("read changeset payload %q: %w", target, err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		return fmt.Errorf("create changeset payload directory for %q: %w", target, err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(target), ".tmp-changeset-*")
+	if err != nil {
+		return fmt.Errorf("create temporary changeset payload near %q: %w", target, err)
+	}
+	tmpPath := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if _, err := tmp.Write(payload); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temporary changeset payload %q: %w", tmpPath, err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sync temporary changeset payload %q: %w", tmpPath, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temporary changeset payload %q: %w", tmpPath, err)
+	}
+	if err := os.Rename(tmpPath, target); err != nil {
+		return fmt.Errorf("publish changeset payload %q: %w", target, err)
+	}
+	cleanup = false
+	return nil
+}
+
+func (s *Store) readPayload(record Record) (*repositorychangeset.Changeset, error) {
+	payloadPath, err := s.payloadPath(record)
+	if err != nil {
+		return nil, err
+	}
+	payload, err := os.ReadFile(payloadPath)
+	if err != nil {
+		return nil, fmt.Errorf("read changeset payload %q: %w", record.ChangesetID, err)
+	}
+	if got := sha256Bytes(payload); got != strings.TrimSpace(record.PayloadDigest) {
+		return nil, fmt.Errorf("changeset payload %q digest mismatch: got %s want %s", record.ChangesetID, got, record.PayloadDigest)
+	}
+
+	var protoChangeset cleanroomv1.RepositoryChangeset
+	if err := proto.Unmarshal(payload, &protoChangeset); err != nil {
+		return nil, fmt.Errorf("decode changeset payload %q: %w", record.ChangesetID, err)
+	}
+	changeset := repositorychangeset.FromProto(&protoChangeset)
+	if err := changeset.ValidateContent(); err != nil {
+		return nil, fmt.Errorf("validate changeset payload %q: %w", record.ChangesetID, err)
+	}
+	if strings.TrimSpace(changeset.Digest) != strings.TrimSpace(record.ChangesetDigest) {
+		return nil, fmt.Errorf("changeset payload %q digest %q does not match metadata %q", record.ChangesetID, changeset.Digest, record.ChangesetDigest)
+	}
+	if strings.TrimSpace(changeset.TreeDigest) != strings.TrimSpace(record.FinalTreeDigest) {
+		return nil, fmt.Errorf("changeset payload %q tree digest %q does not match metadata %q", record.ChangesetID, changeset.TreeDigest, record.FinalTreeDigest)
+	}
+	return changeset, nil
+}
+
+func (s *Store) payloadPath(record Record) (string, error) {
+	transportRef := strings.TrimSpace(record.TransportRef)
+	if transportRef == "" {
+		return "", fmt.Errorf("changeset %q missing transport ref", record.ChangesetID)
+	}
+	rel := filepath.Clean(filepath.FromSlash(transportRef))
+	if rel == "." || filepath.IsAbs(rel) || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("changeset %q has invalid transport ref %q", record.ChangesetID, record.TransportRef)
+	}
+	return filepath.Join(s.payloadDir, rel), nil
+}
+
+func (s *Store) open(ctx context.Context) (*sql.DB, error) {
+	if err := s.initDB(ctx); err != nil {
+		return nil, err
+	}
+	db, err := sql.Open("sqlite", s.metadataDBPath)
+	if err != nil {
+		return nil, fmt.Errorf("open changeset metadata database %q: %w", s.metadataDBPath, err)
+	}
+	return db, nil
+}
+
+func (s *Store) initDB(ctx context.Context) error {
+	db, err := sql.Open("sqlite", s.metadataDBPath)
+	if err != nil {
+		return fmt.Errorf("open changeset metadata database %q: %w", s.metadataDBPath, err)
+	}
+	defer db.Close()
+
+	_, err = db.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS changesets (
+			changeset_id TEXT PRIMARY KEY,
+			canonical_remote_url TEXT NOT NULL,
+			base_commit_sha TEXT NOT NULL,
+			submodule_mode TEXT NOT NULL,
+			changeset_digest TEXT NOT NULL,
+			final_tree_digest TEXT NOT NULL,
+			transport_format TEXT NOT NULL,
+			transport_ref TEXT NOT NULL,
+			payload_digest TEXT NOT NULL,
+			created_at_unix_nano INTEGER NOT NULL,
+			last_used_at_unix_nano INTEGER NOT NULL
+		);
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_changesets_identity ON changesets(canonical_remote_url, base_commit_sha, submodule_mode, changeset_digest);
+		CREATE INDEX IF NOT EXISTS idx_changesets_created_at ON changesets(created_at_unix_nano);
+		CREATE INDEX IF NOT EXISTS idx_changesets_last_used_at ON changesets(last_used_at_unix_nano);
+	`)
+	if err != nil {
+		return fmt.Errorf("initialise changeset metadata schema: %w", err)
+	}
+	return nil
+}
+
+type recordScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanRecord(row recordScanner) (Record, error) {
+	var (
+		record         Record
+		createdAtNano  int64
+		lastUsedAtNano int64
+	)
+	if err := row.Scan(
+		&record.ChangesetID,
+		&record.CanonicalRemoteURL,
+		&record.BaseCommitSHA,
+		&record.SubmoduleMode,
+		&record.ChangesetDigest,
+		&record.FinalTreeDigest,
+		&record.TransportFormat,
+		&record.TransportRef,
+		&record.PayloadDigest,
+		&createdAtNano,
+		&lastUsedAtNano,
+	); err != nil {
+		return Record{}, err
+	}
+	record.CreatedAt = time.Unix(0, createdAtNano).UTC()
+	record.LastUsedAt = time.Unix(0, lastUsedAtNano).UTC()
+	return record, nil
+}
+
+func payloadRef(digest string) (string, error) {
+	hexDigest, ok := strings.CutPrefix(strings.TrimSpace(digest), "sha256:")
+	if !ok {
+		return "", fmt.Errorf("changeset payload digest %q is not a sha256 digest", digest)
+	}
+	if len(hexDigest) != sha256.Size*2 {
+		return "", fmt.Errorf("changeset payload digest %q has invalid length", digest)
+	}
+	if _, err := hex.DecodeString(hexDigest); err != nil {
+		return "", fmt.Errorf("changeset payload digest %q is invalid: %w", digest, err)
+	}
+	return "sha256/" + hexDigest[:2] + "/" + hexDigest + ".pb", nil
+}
+
+func sha256Bytes(payload []byte) string {
+	sum := sha256.Sum256(payload)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func submoduleMode(repository *repositorycheckout.Checkout) string {
+	if repository != nil && repository.Submodules {
+		return "enabled"
+	}
+	return "disabled"
+}
+
+func defaultPaths() (metadataDBPath, payloadDir string, err error) {
+	base, err := paths.StateBaseDir()
+	if err != nil {
+		return "", "", err
+	}
+	return filepath.Join(base, "changesets", "metadata.db"), filepath.Join(base, "changesets", "payloads"), nil
+}

--- a/internal/changesetstore/store_test.go
+++ b/internal/changesetstore/store_test.go
@@ -1,0 +1,266 @@
+package changesetstore
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/buildkite/cleanroom/internal/repositorychangeset"
+	"github.com/buildkite/cleanroom/internal/repositorycheckout"
+)
+
+func TestStorePutGetListDelete(t *testing.T) {
+	t.Parallel()
+
+	store, err := New(Options{
+		MetadataDBPath: filepath.Join(t.TempDir(), "changesets.db"),
+		PayloadDir:     filepath.Join(t.TempDir(), "payloads"),
+	})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	repository, changeset := testRepositoryChangeset(t)
+
+	record, err := store.Put(context.Background(), repository, changeset)
+	if err != nil {
+		t.Fatalf("Put returned error: %v", err)
+	}
+	if record.ChangesetID == "" {
+		t.Fatal("expected changeset id")
+	}
+	if record.CanonicalRemoteURL != repository.RemoteURL {
+		t.Fatalf("unexpected remote URL: got %q want %q", record.CanonicalRemoteURL, repository.RemoteURL)
+	}
+	if record.BaseCommitSHA != changeset.BaseCommitSHA {
+		t.Fatalf("unexpected base commit: got %q want %q", record.BaseCommitSHA, changeset.BaseCommitSHA)
+	}
+	if record.SubmoduleMode != "enabled" {
+		t.Fatalf("unexpected submodule mode: got %q want enabled", record.SubmoduleMode)
+	}
+	if record.TransportFormat != TransportFormatProtoV1 {
+		t.Fatalf("unexpected transport format: got %q want %q", record.TransportFormat, TransportFormatProtoV1)
+	}
+	if record.TransportRef == "" {
+		t.Fatal("expected transport ref")
+	}
+	if record.PayloadDigest == "" {
+		t.Fatal("expected payload digest")
+	}
+
+	gotRecord, gotChangeset, ok, err := store.Get(context.Background(), record.ChangesetID)
+	if err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected stored changeset")
+	}
+	if gotRecord.ChangesetID != record.ChangesetID || gotRecord.ChangesetDigest != record.ChangesetDigest || gotRecord.FinalTreeDigest != record.FinalTreeDigest {
+		t.Fatalf("unexpected record: %#v", gotRecord)
+	}
+	if gotChangeset.Digest != changeset.Digest || string(gotChangeset.Patch) != string(changeset.Patch) {
+		t.Fatalf("unexpected changeset payload: %#v", gotChangeset)
+	}
+
+	items, err := store.List(context.Background())
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if got, want := len(items), 1; got != want {
+		t.Fatalf("unexpected changeset count: got %d want %d", got, want)
+	}
+
+	if err := store.Delete(context.Background(), record.ChangesetID); err != nil {
+		t.Fatalf("Delete returned error: %v", err)
+	}
+	if _, _, ok, err := store.Get(context.Background(), record.ChangesetID); err != nil {
+		t.Fatalf("Get after delete returned error: %v", err)
+	} else if ok {
+		t.Fatal("expected changeset to be deleted")
+	}
+}
+
+func TestStorePutDeduplicatesByChangesetIdentity(t *testing.T) {
+	t.Parallel()
+
+	store, err := New(Options{
+		MetadataDBPath: filepath.Join(t.TempDir(), "changesets.db"),
+		PayloadDir:     filepath.Join(t.TempDir(), "payloads"),
+	})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	repository, changeset := testRepositoryChangeset(t)
+	first, err := store.Put(context.Background(), repository, changeset)
+	if err != nil {
+		t.Fatalf("first Put returned error: %v", err)
+	}
+	time.Sleep(time.Millisecond)
+	second, err := store.Put(context.Background(), repository, changeset)
+	if err != nil {
+		t.Fatalf("second Put returned error: %v", err)
+	}
+	if second.ChangesetID != first.ChangesetID {
+		t.Fatalf("expected same changeset id, got %q then %q", first.ChangesetID, second.ChangesetID)
+	}
+
+	items, err := store.List(context.Background())
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if got, want := len(items), 1; got != want {
+		t.Fatalf("expected one deduplicated changeset, got %d", got)
+	}
+}
+
+func TestStorePutRejectsBaseCommitMismatch(t *testing.T) {
+	t.Parallel()
+
+	store, err := New(Options{
+		MetadataDBPath: filepath.Join(t.TempDir(), "changesets.db"),
+		PayloadDir:     filepath.Join(t.TempDir(), "payloads"),
+	})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	repository, changeset := testRepositoryChangeset(t)
+	repository.CommitSHA = "ffffffffffffffffffffffffffffffffffffffff"
+	if _, err := store.Put(context.Background(), repository, changeset); err == nil {
+		t.Fatal("expected base commit mismatch error")
+	}
+}
+
+func TestStoreGetDetectsPayloadCorruption(t *testing.T) {
+	t.Parallel()
+
+	store, err := New(Options{
+		MetadataDBPath: filepath.Join(t.TempDir(), "changesets.db"),
+		PayloadDir:     filepath.Join(t.TempDir(), "payloads"),
+	})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	repository, changeset := testRepositoryChangeset(t)
+	record, err := store.Put(context.Background(), repository, changeset)
+	if err != nil {
+		t.Fatalf("Put returned error: %v", err)
+	}
+	payloadPath, err := store.payloadPath(record)
+	if err != nil {
+		t.Fatalf("payloadPath returned error: %v", err)
+	}
+	if err := os.WriteFile(payloadPath, []byte("corrupt"), 0o644); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	if _, _, _, err := store.Get(context.Background(), record.ChangesetID); err == nil {
+		t.Fatal("expected payload corruption error")
+	}
+}
+
+func TestStoreDeleteDoesNotRequireReadablePayload(t *testing.T) {
+	t.Parallel()
+
+	store, err := New(Options{
+		MetadataDBPath: filepath.Join(t.TempDir(), "changesets.db"),
+		PayloadDir:     filepath.Join(t.TempDir(), "payloads"),
+	})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	repository, changeset := testRepositoryChangeset(t)
+	record, err := store.Put(context.Background(), repository, changeset)
+	if err != nil {
+		t.Fatalf("Put returned error: %v", err)
+	}
+	payloadPath, err := store.payloadPath(record)
+	if err != nil {
+		t.Fatalf("payloadPath returned error: %v", err)
+	}
+	if err := os.WriteFile(payloadPath, []byte("corrupt"), 0o644); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+
+	if err := store.Delete(context.Background(), record.ChangesetID); err != nil {
+		t.Fatalf("Delete returned error: %v", err)
+	}
+	if _, _, ok, err := store.Get(context.Background(), record.ChangesetID); err != nil {
+		t.Fatalf("Get after delete returned error: %v", err)
+	} else if ok {
+		t.Fatal("expected changeset metadata to be deleted")
+	}
+}
+
+func TestStoreRejectsInvalidTransportRef(t *testing.T) {
+	t.Parallel()
+
+	store, err := New(Options{
+		MetadataDBPath: filepath.Join(t.TempDir(), "changesets.db"),
+		PayloadDir:     filepath.Join(t.TempDir(), "payloads"),
+	})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	invalidRefs := []string{"", "../escape.pb", "/tmp/escape.pb"}
+	for _, transportRef := range invalidRefs {
+		record := Record{
+			ChangesetID:  "changeset:v1:test",
+			TransportRef: transportRef,
+		}
+		if _, err := store.payloadPath(record); err == nil {
+			t.Fatalf("expected transport ref %q to be rejected", transportRef)
+		}
+	}
+}
+
+func testRepositoryChangeset(t *testing.T) (*repositorycheckout.Checkout, *repositorychangeset.Changeset) {
+	t.Helper()
+
+	repoDir := t.TempDir()
+	runTestGit(t, repoDir, "init", ".")
+	runTestGit(t, repoDir, "config", "user.email", "cleanroom@example.com")
+	runTestGit(t, repoDir, "config", "user.name", "Cleanroom Test")
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(README.md) returned error: %v", err)
+	}
+	runTestGit(t, repoDir, "add", ".")
+	runTestGit(t, repoDir, "commit", "-m", "initial")
+	commitSHA := strings.TrimSpace(runTestGit(t, repoDir, "rev-parse", "HEAD"))
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("hello from changeset\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(README.md) returned error: %v", err)
+	}
+
+	repository := &repositorycheckout.Checkout{
+		RemoteURL:      "https://github.com/buildkite/cleanroom.git",
+		CommitSHA:      commitSHA,
+		DestinationDir: "/workspace",
+		Submodules:     true,
+	}
+	changeset, err := repositorychangeset.BuildFromWorkingTree(repoDir, repository)
+	if err != nil {
+		t.Fatalf("BuildFromWorkingTree returned error: %v", err)
+	}
+	if changeset == nil {
+		t.Fatal("expected repository changeset")
+	}
+	return repository, changeset
+}
+
+func runTestGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s returned error: %v\n%s", strings.Join(args, " "), err, strings.TrimSpace(string(output)))
+	}
+	return string(output)
+}

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -17,6 +17,7 @@ import (
 	"github.com/buildkite/cleanroom/internal/backend/darwinvz"
 	"github.com/buildkite/cleanroom/internal/backend/firecracker"
 	"github.com/buildkite/cleanroom/internal/cachestore"
+	"github.com/buildkite/cleanroom/internal/changesetstore"
 	"github.com/buildkite/cleanroom/internal/controlserver"
 	"github.com/buildkite/cleanroom/internal/controlservice"
 	"github.com/buildkite/cleanroom/internal/endpoint"
@@ -42,6 +43,7 @@ type ServeCommand struct {
 var serveSignalNotifyContext = signal.NotifyContext
 var newSnapshotMetadataStore = snapshotstore.New
 var newCacheMetadataStore = cachestore.New
+var newChangesetMetadataStore = changesetstore.New
 var gatewayScopeTokenSourcePolicyForGatewayHost = gateway.ScopeTokenSourcePolicyForGatewayHost
 var newGatewayContentCache = gateway.NewContentCache
 
@@ -308,6 +310,14 @@ func newControlService(ctx *runtimeContext, logger *log.Logger, mirrors gateway.
 		}
 		cacheMetadataStore = nil
 	}
+	var changesetMetadataStore *changesetstore.Store
+	changesetMetadataStore, err = newChangesetMetadataStore(changesetstore.Options{})
+	if err != nil {
+		if logger != nil {
+			logger.Warn("changeset metadata store unavailable; repository changeset persistence disabled", "error", err)
+		}
+		changesetMetadataStore = nil
+	}
 
 	if ctx == nil {
 		service := &controlservice.Service{
@@ -317,6 +327,9 @@ func newControlService(ctx *runtimeContext, logger *log.Logger, mirrors gateway.
 		}
 		if cacheMetadataStore != nil {
 			service.CacheStore = cacheMetadataStore
+		}
+		if changesetMetadataStore != nil {
+			service.ChangesetStore = changesetMetadataStore
 		}
 		return service, nil
 	}
@@ -331,6 +344,9 @@ func newControlService(ctx *runtimeContext, logger *log.Logger, mirrors gateway.
 	}
 	if cacheMetadataStore != nil {
 		service.CacheStore = cacheMetadataStore
+	}
+	if changesetMetadataStore != nil {
+		service.ChangesetStore = changesetMetadataStore
 	}
 	return service, nil
 }

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/buildkite/cleanroom/internal/backend/darwinvz"
 	"github.com/buildkite/cleanroom/internal/backend/firecracker"
 	"github.com/buildkite/cleanroom/internal/cachestore"
+	"github.com/buildkite/cleanroom/internal/changesetstore"
 	"github.com/buildkite/cleanroom/internal/gateway"
 	"github.com/buildkite/cleanroom/internal/observability"
 	"github.com/buildkite/cleanroom/internal/runtimeconfig"
@@ -260,9 +261,16 @@ func TestGatewayServerConfigUsesDarwinGatewayHostForTrustedPrefixes(t *testing.T
 }
 func TestNewControlServiceWiresRepositoryStore(t *testing.T) {
 	prevSnapshotStoreFactory := newSnapshotMetadataStore
-	t.Cleanup(func() { newSnapshotMetadataStore = prevSnapshotStoreFactory })
+	prevChangesetStoreFactory := newChangesetMetadataStore
+	t.Cleanup(func() {
+		newSnapshotMetadataStore = prevSnapshotStoreFactory
+		newChangesetMetadataStore = prevChangesetStoreFactory
+	})
 	newSnapshotMetadataStore = func(snapshotstore.Options) (*snapshotstore.Store, error) {
 		return &snapshotstore.Store{}, nil
+	}
+	newChangesetMetadataStore = func(changesetstore.Options) (*changesetstore.Store, error) {
+		return &changesetstore.Store{}, nil
 	}
 
 	mirrors := gateway.NewGitMirrorStore(t.TempDir(), 0, nil)
@@ -282,13 +290,23 @@ func TestNewControlServiceWiresRepositoryStore(t *testing.T) {
 	if service.RepositoryStore == nil {
 		t.Fatal("expected control service to configure a repository store")
 	}
+	if service.ChangesetStore == nil {
+		t.Fatal("expected control service to configure a changeset store")
+	}
 }
 
 func TestNewControlServiceWiresSnapshotStore(t *testing.T) {
 	prevSnapshotStoreFactory := newSnapshotMetadataStore
-	t.Cleanup(func() { newSnapshotMetadataStore = prevSnapshotStoreFactory })
+	prevChangesetStoreFactory := newChangesetMetadataStore
+	t.Cleanup(func() {
+		newSnapshotMetadataStore = prevSnapshotStoreFactory
+		newChangesetMetadataStore = prevChangesetStoreFactory
+	})
 	newSnapshotMetadataStore = func(snapshotstore.Options) (*snapshotstore.Store, error) {
 		return &snapshotstore.Store{}, nil
+	}
+	newChangesetMetadataStore = func(changesetstore.Options) (*changesetstore.Store, error) {
+		return &changesetstore.Store{}, nil
 	}
 
 	mirrors := gateway.NewGitMirrorStore(t.TempDir(), 0, nil)
@@ -332,15 +350,20 @@ func TestNewControlServiceReturnsSnapshotStoreError(t *testing.T) {
 func TestNewControlServiceIgnoresCacheStoreError(t *testing.T) {
 	prevSnapshotStoreFactory := newSnapshotMetadataStore
 	prevCacheStoreFactory := newCacheMetadataStore
+	prevChangesetStoreFactory := newChangesetMetadataStore
 	t.Cleanup(func() {
 		newSnapshotMetadataStore = prevSnapshotStoreFactory
 		newCacheMetadataStore = prevCacheStoreFactory
+		newChangesetMetadataStore = prevChangesetStoreFactory
 	})
 	newSnapshotMetadataStore = func(snapshotstore.Options) (*snapshotstore.Store, error) {
 		return &snapshotstore.Store{}, nil
 	}
 	newCacheMetadataStore = func(cachestore.Options) (*cachestore.Store, error) {
 		return nil, errors.New("cache metadata unavailable")
+	}
+	newChangesetMetadataStore = func(changesetstore.Options) (*changesetstore.Store, error) {
+		return &changesetstore.Store{}, nil
 	}
 
 	service, err := newControlService(&runtimeContext{}, log.New(io.Discard), nil)
@@ -355,6 +378,35 @@ func TestNewControlServiceIgnoresCacheStoreError(t *testing.T) {
 	}
 	if service.SnapshotStore == nil {
 		t.Fatal("expected snapshot store to remain configured when cache metadata setup fails")
+	}
+}
+
+func TestNewControlServiceIgnoresChangesetStoreError(t *testing.T) {
+	prevSnapshotStoreFactory := newSnapshotMetadataStore
+	prevChangesetStoreFactory := newChangesetMetadataStore
+	t.Cleanup(func() {
+		newSnapshotMetadataStore = prevSnapshotStoreFactory
+		newChangesetMetadataStore = prevChangesetStoreFactory
+	})
+	newSnapshotMetadataStore = func(snapshotstore.Options) (*snapshotstore.Store, error) {
+		return &snapshotstore.Store{}, nil
+	}
+	newChangesetMetadataStore = func(changesetstore.Options) (*changesetstore.Store, error) {
+		return nil, errors.New("changeset metadata unavailable")
+	}
+
+	service, err := newControlService(&runtimeContext{}, log.New(io.Discard), nil)
+	if err != nil {
+		t.Fatalf("newControlService returned error: %v", err)
+	}
+	if service == nil {
+		t.Fatal("expected non-nil service when changeset metadata store setup fails")
+	}
+	if service.ChangesetStore != nil {
+		t.Fatal("expected changeset store to remain nil when changeset metadata setup fails")
+	}
+	if service.SnapshotStore == nil {
+		t.Fatal("expected snapshot store to remain configured when changeset metadata setup fails")
 	}
 }
 

--- a/internal/controlservice/dependency_stage.go
+++ b/internal/controlservice/dependency_stage.go
@@ -222,7 +222,7 @@ func gitFileDigestAtCommit(ctx context.Context, repoDir, commitSHA, file string)
 	return "sha256:" + hex.EncodeToString(sum[:]), nil
 }
 
-func (s *Service) lookupDependencyStageCache(ctx context.Context, backendName string, compiled *policy.CompiledPolicy, repository *repositorycheckout.Checkout, plan dependencyStagePlan) (cachestore.Record, bool, string, error) {
+func (s *Service) lookupDependencyStageCache(ctx context.Context, backendName string, compiled *policy.CompiledPolicy, repository *repositorycheckout.Checkout, changeset *repositorychangeset.Changeset, plan dependencyStagePlan) (cachestore.Record, bool, string, error) {
 	if compiled == nil || repository == nil || strings.TrimSpace(plan.CacheKey) == "" {
 		return cachestore.Record{}, false, "", nil
 	}
@@ -251,6 +251,9 @@ func (s *Service) lookupDependencyStageCache(ctx context.Context, backendName st
 		return cachestore.Record{}, false, observability.CacheLookupReasonParentStageChanged, nil
 	}
 	if !repositoryCheckoutsEqual(repositorycheckout.FromProto(record.Repository), repository) {
+		return cachestore.Record{}, false, observability.CacheLookupReasonRepositoryChanged, nil
+	}
+	if !cacheRecordChangesetIDMatches(record.RepositoryChangesetID, repository, changeset) {
 		return cachestore.Record{}, false, observability.CacheLookupReasonRepositoryChanged, nil
 	}
 	return record, true, "", nil
@@ -491,7 +494,7 @@ func (s *Service) maybePublishDependencyStageCache(
 	var exactRecord cachestore.Record
 	exactPublished := false
 	exactReusable := false
-	if record, ok, _, err := s.lookupDependencyStageCache(ctx, backendName, compiled, repository, plan); err == nil && ok {
+	if record, ok, _, err := s.lookupDependencyStageCache(ctx, backendName, compiled, repository, changeset, plan); err == nil && ok {
 		exactRecord = record
 		exactPublished = true
 		if replacedRecord == nil || strings.TrimSpace(record.CacheKey) != strings.TrimSpace(replacedRecord.CacheKey) {
@@ -546,6 +549,7 @@ func (s *Service) maybePublishDependencyStageCache(
 		Policy:                   compiled.ToProto(),
 		Repository:               cloneRepositoryCheckout(normalizeRepositoryCheckoutForComparison(repository)).ToProto(),
 		RepositoryHasChangeset:   changeset != nil,
+		RepositoryChangesetID:    repositoryChangesetID(repository, changeset),
 		ParentCacheKey:           plan.ParentWorkspaceCacheKey,
 		StorageDriver:            snapshotCfg.Snapshots.Driver,
 		StorageRef:               strings.TrimSpace(result.StorageRef),
@@ -606,6 +610,7 @@ func portableDependencyStageRecordFromExactRecord(
 	record.Policy = compiled.ToProto()
 	record.Repository = cloneRepositoryCheckout(normalizeRepositoryCheckoutForComparison(repository)).ToProto()
 	record.RepositoryHasChangeset = changeset != nil
+	record.RepositoryChangesetID = repositoryChangesetID(repository, changeset)
 	record.ParentCacheKey = strings.TrimSpace(plan.ParentRuntimeCacheKey)
 	record.InputManifestDigest = strings.TrimSpace(plan.KeyFilesDigest)
 	record.DependencyKeyFilesDigest = strings.TrimSpace(plan.KeyFilesDigest)

--- a/internal/controlservice/repository_changeset.go
+++ b/internal/controlservice/repository_changeset.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/changesetstore"
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
 	"github.com/buildkite/cleanroom/internal/policy"
 	"github.com/buildkite/cleanroom/internal/repositorychangeset"
@@ -31,6 +32,37 @@ func validateRepositoryChangesetForCheckout(repository *repositorycheckout.Check
 		return err
 	}
 	return nil
+}
+
+func repositoryChangesetID(repository *repositorycheckout.Checkout, changeset *repositorychangeset.Changeset) string {
+	return changesetstore.RecordID(repository, changeset)
+}
+
+func cacheRecordChangesetIDMatches(recordChangesetID string, repository *repositorycheckout.Checkout, changeset *repositorychangeset.Changeset) bool {
+	recordChangesetID = strings.TrimSpace(recordChangesetID)
+	expectedChangesetID := repositoryChangesetID(repository, changeset)
+	return recordChangesetID == expectedChangesetID
+}
+
+func (s *Service) persistRepositoryChangeset(ctx context.Context, repository *repositorycheckout.Checkout, changeset *repositorychangeset.Changeset) (changesetstore.Record, error) {
+	if changeset == nil {
+		return changesetstore.Record{}, nil
+	}
+	if s.ChangesetStore == nil {
+		return changesetstore.Record{}, nil
+	}
+	record, err := s.ChangesetStore.Put(ctx, repository, changeset)
+	if err != nil {
+		return changesetstore.Record{}, fmt.Errorf("persist repository changeset: %w", err)
+	}
+	if s.Logger != nil {
+		s.Logger.Debug("repository changeset persisted",
+			"changeset_id", record.ChangesetID,
+			"changeset_digest", record.ChangesetDigest,
+			"tree_digest", record.FinalTreeDigest,
+		)
+	}
+	return record, nil
 }
 
 func persistentBootstrapCommandError(result *backend.ExecutionResult, stdout, stderr string, err error, missingResultMessage, exitCodeMessage string) error {

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -14,10 +14,12 @@ import (
 
 	"github.com/buildkite/cleanroom/internal/backend"
 	"github.com/buildkite/cleanroom/internal/cachestore"
+	"github.com/buildkite/cleanroom/internal/changesetstore"
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
 	"github.com/buildkite/cleanroom/internal/observability"
 	"github.com/buildkite/cleanroom/internal/paths"
 	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/buildkite/cleanroom/internal/repositorychangeset"
 	"github.com/buildkite/cleanroom/internal/repositorycheckout"
 	"github.com/buildkite/cleanroom/internal/repositorystore"
 	"github.com/buildkite/cleanroom/internal/runtimeconfig"
@@ -47,8 +49,9 @@ type Service struct {
 	// adapters, sandbox state, and metadata persistence in one operation chain.
 	// If this grows again, extract a dedicated snapshot manager rather than
 	// adding more snapshot-specific branching here.
-	SnapshotStore snapshotMetadataStore
-	CacheStore    cacheMetadataStore
+	SnapshotStore  snapshotMetadataStore
+	CacheStore     cacheMetadataStore
+	ChangesetStore changesetMetadataStore
 
 	mu                sync.RWMutex
 	sandboxes         map[string]*sandboxState
@@ -150,6 +153,10 @@ type cacheMetadataStore interface {
 	Touch(context.Context, string, string) error
 	List(context.Context) ([]cachestore.Record, error)
 	Delete(context.Context, string, string) error
+}
+
+type changesetMetadataStore interface {
+	Put(context.Context, *repositorycheckout.Checkout, *repositorychangeset.Changeset) (changesetstore.Record, error)
 }
 
 type executionOptions struct {
@@ -320,6 +327,11 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 	if err := validateRepositoryChangesetForCheckout(repository, changeset); err != nil {
 		return nil, err
 	}
+	if changesetRecord, err := s.persistRepositoryChangeset(ctx, repository, changeset); err != nil {
+		return nil, err
+	} else if strings.TrimSpace(changesetRecord.ChangesetID) != "" {
+		span.SetAttributes(attribute.String(observability.AttrRepositoryChangesetID, changesetRecord.ChangesetID))
+	}
 
 	opts := req.GetOptions()
 	execOpts := executionOptions{}
@@ -394,7 +406,7 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 					attribute.String(observability.AttrBackend, backendName),
 				), func(ctx context.Context) error {
 					var lookupErr error
-					record, found, lookupReason, lookupErr = s.lookupServicesStageCache(ctx, backendName, compiled, repository, servicesStagePlan)
+					record, found, lookupReason, lookupErr = s.lookupServicesStageCache(ctx, backendName, compiled, repository, changeset, servicesStagePlan)
 					setCacheLookupSpanAttributes(ctx, found, lookupReason, lookupErr)
 					return lookupErr
 				})
@@ -451,7 +463,7 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 					attribute.String(observability.AttrBackend, backendName),
 				), func(ctx context.Context) error {
 					var lookupErr error
-					record, found, lookupReason, lookupErr = s.lookupDependencyStageCache(ctx, backendName, compiled, repository, dependencyStagePlan)
+					record, found, lookupReason, lookupErr = s.lookupDependencyStageCache(ctx, backendName, compiled, repository, changeset, dependencyStagePlan)
 					setCacheLookupSpanAttributes(ctx, found, lookupReason, lookupErr)
 					return lookupErr
 				})

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/buildkite/cleanroom/internal/backend"
 	"github.com/buildkite/cleanroom/internal/cachestore"
+	"github.com/buildkite/cleanroom/internal/changesetstore"
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
 	"github.com/buildkite/cleanroom/internal/observability"
 	"github.com/buildkite/cleanroom/internal/paths"
@@ -368,9 +369,10 @@ func newTestServiceWithSnapshotStore(adapter backend.Adapter, store snapshotMeta
 				},
 			},
 		},
-		Backends:      map[string]backend.Adapter{"firecracker": adapter},
-		SnapshotStore: store,
-		CacheStore:    newMemoryCacheStore(),
+		Backends:       map[string]backend.Adapter{"firecracker": adapter},
+		SnapshotStore:  store,
+		CacheStore:     newMemoryCacheStore(),
+		ChangesetStore: newMemoryChangesetStore(),
 	}
 }
 
@@ -1170,6 +1172,44 @@ func (s *memoryCacheStore) Delete(_ context.Context, stage, cacheKey string) err
 	defer s.mu.Unlock()
 	delete(s.records, cacheStoreKey(stage, cacheKey))
 	return nil
+}
+
+type memoryChangesetStore struct {
+	mu      sync.Mutex
+	records map[string]changesetstore.Record
+}
+
+func newMemoryChangesetStore() *memoryChangesetStore {
+	return &memoryChangesetStore{records: map[string]changesetstore.Record{}}
+}
+
+func (s *memoryChangesetStore) Put(_ context.Context, repository *repositorycheckout.Checkout, changeset *repositorychangeset.Changeset) (changesetstore.Record, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := time.Now().UTC()
+	record := changesetstore.Record{
+		ChangesetID:        changesetstore.RecordID(repository, changeset),
+		CanonicalRemoteURL: strings.TrimSpace(repository.RemoteURL),
+		BaseCommitSHA:      strings.TrimSpace(changeset.BaseCommitSHA),
+		SubmoduleMode: func() string {
+			if repository.Submodules {
+				return "enabled"
+			}
+			return "disabled"
+		}(),
+		ChangesetDigest: strings.TrimSpace(changeset.Digest),
+		FinalTreeDigest: strings.TrimSpace(changeset.TreeDigest),
+		TransportFormat: changesetstore.TransportFormatProtoV1,
+		TransportRef:    "memory",
+		PayloadDigest:   "memory",
+		CreatedAt:       now,
+		LastUsedAt:      now,
+	}
+	if record.ChangesetID == "" {
+		return changesetstore.Record{}, errors.New("missing changeset id")
+	}
+	s.records[record.ChangesetID] = record
+	return record, nil
 }
 
 func cacheStoreKey(stage, cacheKey string) string {
@@ -4896,6 +4936,54 @@ func TestCreateExecutionRebootstrapsMatchingRepositoryAfterChangesetSnapshotRest
 	}
 	if !repositoryWrappedCommandContains(joined, `exec 'sh' '-lc' 'pwd'`) {
 		t.Fatalf("expected wrapped user command in repository workdir, got %q", joined)
+	}
+}
+
+func TestCreateSandboxPersistsRepositoryChangeset(t *testing.T) {
+	adapter := &stubAdapter{}
+	svc := newTestService(adapter)
+
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"README.md": "hello\n",
+	})
+	svc.RepositoryStore = mirrors
+	repository := repositorycheckout.FromProto(repositoryCheckout)
+	if err := os.WriteFile(filepath.Join(mirrors.mirrorPath, "README.md"), []byte("hello from changeset\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(README.md) returned error: %v", err)
+	}
+	changeset, err := repositorychangeset.BuildFromWorkingTree(mirrors.mirrorPath, repository)
+	if err != nil {
+		t.Fatalf("BuildFromWorkingTree returned error: %v", err)
+	}
+	if changeset == nil {
+		t.Fatal("expected repository changeset")
+	}
+
+	store := newMemoryChangesetStore()
+	svc.ChangesetStore = store
+	_, err = svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Policy:              testRepositoryPolicy(),
+		RepositoryCheckout:  repositoryCheckout,
+		RepositoryChangeset: changeset.ToProto(),
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if got, want := len(store.records), 1; got != want {
+		t.Fatalf("expected one persisted changeset, got %d", got)
+	}
+	record := store.records[changesetstore.RecordID(repository, changeset)]
+	if record.ChangesetID == "" {
+		t.Fatalf("expected persisted changeset id in records: %#v", store.records)
+	}
+	if record.ChangesetDigest != changeset.Digest {
+		t.Fatalf("unexpected persisted changeset digest: got %q want %q", record.ChangesetDigest, changeset.Digest)
+	}
+	if record.FinalTreeDigest != changeset.TreeDigest {
+		t.Fatalf("unexpected persisted tree digest: got %q want %q", record.FinalTreeDigest, changeset.TreeDigest)
 	}
 }
 

--- a/internal/controlservice/services_stage.go
+++ b/internal/controlservice/services_stage.go
@@ -80,7 +80,7 @@ func (s *Service) finalizeServicesStagePlan(
 	return plan, true, nil
 }
 
-func (s *Service) lookupServicesStageCache(ctx context.Context, backendName string, compiled *policy.CompiledPolicy, repository *repositorycheckout.Checkout, plan servicesStagePlan) (cachestore.Record, bool, string, error) {
+func (s *Service) lookupServicesStageCache(ctx context.Context, backendName string, compiled *policy.CompiledPolicy, repository *repositorycheckout.Checkout, changeset *repositorychangeset.Changeset, plan servicesStagePlan) (cachestore.Record, bool, string, error) {
 	if compiled == nil || repository == nil || strings.TrimSpace(plan.CacheKey) == "" {
 		return cachestore.Record{}, false, "", nil
 	}
@@ -106,6 +106,9 @@ func (s *Service) lookupServicesStageCache(ctx context.Context, backendName stri
 		return cachestore.Record{}, false, observability.CacheLookupReasonParentStageChanged, nil
 	}
 	if !repositoryCheckoutsEqual(repositorycheckout.FromProto(record.Repository), repository) {
+		return cachestore.Record{}, false, observability.CacheLookupReasonRepositoryChanged, nil
+	}
+	if !cacheRecordChangesetIDMatches(record.RepositoryChangesetID, repository, changeset) {
 		return cachestore.Record{}, false, observability.CacheLookupReasonRepositoryChanged, nil
 	}
 	return record, true, "", nil
@@ -134,7 +137,7 @@ func (s *Service) maybePublishServicesStageCache(
 		return
 	}
 
-	if record, ok, _, err := s.lookupServicesStageCache(ctx, backendName, compiled, repository, plan); err == nil && ok {
+	if record, ok, _, err := s.lookupServicesStageCache(ctx, backendName, compiled, repository, changeset, plan); err == nil && ok {
 		if replacedRecord == nil || strings.TrimSpace(record.CacheKey) != strings.TrimSpace(replacedRecord.CacheKey) {
 			s.logServicesStageAlreadyPublished(record)
 			return
@@ -166,6 +169,7 @@ func (s *Service) maybePublishServicesStageCache(
 		Policy:                 compiled.ToProto(),
 		Repository:             cloneRepositoryCheckout(normalizeRepositoryCheckoutForComparison(repository)).ToProto(),
 		RepositoryHasChangeset: changeset != nil,
+		RepositoryChangesetID:  repositoryChangesetID(repository, changeset),
 		ParentCacheKey:         plan.ParentStageCacheKey,
 		StorageDriver:          snapshotCfg.Snapshots.Driver,
 		StorageRef:             strings.TrimSpace(result.StorageRef),

--- a/internal/controlservice/workspace_stage.go
+++ b/internal/controlservice/workspace_stage.go
@@ -97,6 +97,9 @@ func (s *Service) lookupWorkspaceStageCache(ctx context.Context, backendName str
 	if !repositoryCheckoutsEqual(repositorycheckout.FromProto(record.Repository), repository) {
 		return cachestore.Record{}, false, observability.CacheLookupReasonRepositoryChanged, nil
 	}
+	if !cacheRecordChangesetIDMatches(record.RepositoryChangesetID, repository, changeset) {
+		return cachestore.Record{}, false, observability.CacheLookupReasonRepositoryChanged, nil
+	}
 	if strings.TrimSpace(record.PolicyHash) != strings.TrimSpace(compiled.Hash) {
 		return cachestore.Record{}, false, observability.CacheLookupReasonPolicyHashMismatch, nil
 	}
@@ -163,6 +166,7 @@ func (s *Service) maybePublishWorkspaceStageCache(
 		Policy:                 compiled.ToProto(),
 		Repository:             cloneRepositoryCheckout(normalizeRepositoryCheckoutForComparison(repository)).ToProto(),
 		RepositoryHasChangeset: changeset != nil,
+		RepositoryChangesetID:  repositoryChangesetID(repository, changeset),
 		ParentCacheKey:         strings.TrimSpace(runtimeBaseKey),
 		StorageDriver:          snapshotCfg.Snapshots.Driver,
 		StorageRef:             strings.TrimSpace(result.StorageRef),

--- a/internal/observability/contract.go
+++ b/internal/observability/contract.go
@@ -56,6 +56,7 @@ const (
 	AttrStdinDisabled         = "cleanroom.stdin.disabled"
 	AttrRepositoryCheckout    = "cleanroom.repository.checkout"
 	AttrRepositoryChangeset   = "cleanroom.repository.changeset"
+	AttrRepositoryChangesetID = "cleanroom.repository.changeset_id"
 	AttrRepositoryCommitSHA   = "cleanroom.repository.commit_sha"
 	AttrCacheStage            = "cleanroom.cache.stage"
 	AttrCacheOperation        = "cleanroom.cache.operation"


### PR DESCRIPTION
## Summary

- Adds a durable host-local `changesetstore` for explicit repository changeset metadata and replay payloads.
- Persists validated repository changesets during sandbox creation while keeping the existing `--include-local-changes` request flow unchanged.
- Records stable changeset IDs in stage-cache metadata and requires matching IDs on changeset-backed cache hits.
- Updates the layered caching plan and spec to reflect the landed storage slice.

## Validation

- `mise exec -- go test ./...`
- `git diff --check`