### PR TITLE
feat: Add sandbox resource requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,10 @@ version: 1
 sandbox:
   image:
     ref: ghcr.io/buildkite/cleanroom-base/debian@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+  resources:
+    vcpus: 4
+    memory: 8GiB
+    disk: 16GiB
   network:
     default: deny
     allow:
@@ -223,6 +227,12 @@ sandbox:
       - host: registry.npmjs.org
         ports: [443]
 ```
+
+`sandbox.resources` is optional and declares backend-neutral minimum workload
+requirements. `vcpus` is a positive integer, while `memory` and `disk` accept
+raw bytes or human-friendly sizes such as `4096MiB`, `8GiB`, or `16GiB`.
+Cleanroom raises the selected backend runtime config to meet these minimums,
+but does not lower larger host defaults.
 
 Enable Docker as a guest service:
 

--- a/client/types.go
+++ b/client/types.go
@@ -16,6 +16,7 @@ const (
 )
 
 type PolicyAllowRule = cleanroomv1.PolicyAllowRule
+type PolicyResources = cleanroomv1.PolicyResources
 type Policy = cleanroomv1.Policy
 type Snapshot = cleanroomv1.Snapshot
 type SandboxOptions = cleanroomv1.SandboxOptions

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -75,6 +75,10 @@ project:
 
 sandbox:
   ttl_minutes: 60
+  resources:
+    vcpus: 4
+    memory: 8GiB
+    disk: 16GiB
   dependencies:
     command: mise exec -- go mod download
     key:
@@ -165,6 +169,10 @@ explicit request-time changeset input.
 - `repository.remote` defaults to `origin`.
 - `repository.path` defaults to `/workspace` and must be an absolute guest path.
 - `repository.submodules` defaults to `false`.
+- `sandbox.resources` defaults to unset. When present, it declares backend-neutral minimum workload requirements.
+- `sandbox.resources.vcpus` must be a positive integer.
+- `sandbox.resources.memory` and `sandbox.resources.disk` must be positive byte sizes. They accept raw bytes or size strings such as `4096MiB`, `8GiB`, or `16GiB`.
+- Resource requirements raise the effective backend runtime settings when the host runtime config is lower; they do not lower larger host defaults.
 - `sandbox.dependencies.command` defaults to unset; when present, Cleanroom runs that command in the repository workdir during sandbox creation and makes the result eligible for dependency-stage caching.
 - `sandbox.dependencies.command` accepts either a YAML string or a YAML sequence; strings execute as `sh -lc <value>`, and strings are the preferred form.
 - `sandbox.dependencies.key.files` defaults to empty; when present, Cleanroom hashes those repository-relative files from the exact committed checkout and includes them in the dependency-stage cache key.
@@ -330,6 +338,10 @@ Minimum required fields:
   - `default_action`
   - `allow_rules[]` (normalized host/IP, ports, protocol defaults)
   - `deny_rules[]` (normalized host/IP, ports optional)
+- `resources`
+  - `vcpus`
+  - `memory_bytes`
+  - `disk_bytes`
 - `registries`
   - manager key (`npm`, `pip`, and so on)
   - `enabled`

--- a/examples/buildkite-agent/README.md
+++ b/examples/buildkite-agent/README.md
@@ -6,15 +6,14 @@ dependency bootstrap, Go module resolution, and dependency-stage warmup.
 
 ## Prerequisites
 
-Install cleanroom (`mise run install` from repository root) and ensure
-your runtime config has enough resources for a large Go build:
+Install cleanroom (`mise run install` from repository root). The example policy
+declares enough guest resources for a large Go build:
 
 ```yaml
-# ~/.config/cleanroom/config.yaml
-backends:
-  darwin-vz:
-    memory_mib: 12288
-    minimum_rootfs_bytes: 12GiB
+sandbox:
+  resources:
+    memory: 12GiB
+    disk: 12GiB
 ```
 
 ## Usage
@@ -67,7 +66,7 @@ Go module resolution:
 - First run is slow: git clone, mise tool install, and Go module download
 - The example now targets the current `buildkite/agent` `HEAD` commit at the time of this update: `9eba5c5b83807b9aaaaffef6225be1f62c8d7d6c`
 - The example policy uses the current multi-arch Debian base image digest `ghcr.io/buildkite/cleanroom-base/debian@sha256:28c3f638fabe1ed780f87b82cfb0c6dda2549c86b9e4edbe519e8250243411c5`
-- Guest memory still comes from `~/.config/cleanroom/config.yaml`; `cleanroom.yaml` does not carry backend runtime sizing
+- Guest resource minimums are declared in `cleanroom.yaml`; larger host runtime defaults still win
 - The policy sets:
 
   ```sh

--- a/examples/buildkite-agent/cleanroom.yaml
+++ b/examples/buildkite-agent/cleanroom.yaml
@@ -2,6 +2,9 @@ version: 1
 sandbox:
   image:
     ref: ghcr.io/buildkite/cleanroom-base/debian@sha256:28c3f638fabe1ed780f87b82cfb0c6dda2549c86b9e4edbe519e8250243411c5
+  resources:
+    memory: 12GiB
+    disk: 12GiB
   dependencies:
     command: |
       mise settings ruby.compile=false

--- a/examples/rails/README.md
+++ b/examples/rails/README.md
@@ -18,14 +18,13 @@ Pull the Debian Ruby base image used by the example:
 cleanroom image pull ghcr.io/buildkite/cleanroom-base/debian-ruby@sha256:cba9876d67beb8971e791f1bc6af175f0bff47e938f955059813c4dd6914eb53
 ```
 
-Give the guest enough memory and disk for the first Rails bundle:
+The example policy declares enough guest memory and disk for the first Rails bundle:
 
 ```yaml
-# ~/.config/cleanroom/config.yaml
-backends:
-  darwin-vz:
-    memory_mib: 4096
-    minimum_rootfs_bytes: 14GiB
+sandbox:
+  resources:
+    memory: 4GiB
+    disk: 14GiB
 ```
 
 ## Usage

--- a/examples/rails/cleanroom.yaml
+++ b/examples/rails/cleanroom.yaml
@@ -4,6 +4,9 @@ repository:
 sandbox:
   image:
     ref: ghcr.io/buildkite/cleanroom-base/debian-ruby@sha256:cba9876d67beb8971e791f1bc6af175f0bff47e938f955059813c4dd6914eb53
+  resources:
+    memory: 4GiB
+    disk: 14GiB
   dependencies:
     command:
       - sh

--- a/internal/bytesize/bytesize.go
+++ b/internal/bytesize/bytesize.go
@@ -1,0 +1,110 @@
+package bytesize
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"gopkg.in/yaml.v3"
+)
+
+type Size int64
+
+func (s *Size) UnmarshalYAML(node *yaml.Node) error {
+	if node.Kind != yaml.ScalarNode {
+		return fmt.Errorf("invalid byte size node kind %v", node.Kind)
+	}
+
+	value, err := Parse(node.Value)
+	if err != nil {
+		return fmt.Errorf("invalid byte size %q: %w", node.Value, err)
+	}
+	*s = Size(value)
+	return nil
+}
+
+func Parse(input string) (int64, error) {
+	s := strings.TrimSpace(input)
+	if s == "" {
+		return 0, errors.New("value is empty")
+	}
+
+	if value, err := strconv.ParseInt(s, 10, 64); err == nil {
+		if value < 0 {
+			return 0, errors.New("value must be non-negative")
+		}
+		return value, nil
+	}
+
+	numberEnd := strings.IndexFunc(s, func(r rune) bool {
+		return !(unicode.IsDigit(r) || r == '.')
+	})
+	if numberEnd <= 0 {
+		return 0, errors.New("missing numeric value")
+	}
+
+	numberPart := strings.TrimSpace(s[:numberEnd])
+	unitPart := strings.ToLower(strings.TrimSpace(s[numberEnd:]))
+	if numberPart == "" || unitPart == "" {
+		return 0, errors.New("size must include a number and unit")
+	}
+
+	numberValue, err := strconv.ParseFloat(numberPart, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse numeric value: %w", err)
+	}
+	if numberValue < 0 {
+		return 0, errors.New("value must be non-negative")
+	}
+
+	multiplier, ok := byteSizeMultipliers[unitPart]
+	if !ok {
+		return 0, fmt.Errorf("unsupported unit %q", unitPart)
+	}
+
+	if !strings.Contains(numberPart, ".") {
+		numberValue, err := strconv.ParseInt(numberPart, 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("parse numeric value: %w", err)
+		}
+		if numberValue < 0 {
+			return 0, errors.New("value must be non-negative")
+		}
+		if multiplier != 0 && numberValue > math.MaxInt64/multiplier {
+			return 0, errors.New("size overflows int64")
+		}
+		return numberValue * multiplier, nil
+	}
+
+	value := numberValue * float64(multiplier)
+	rounded := math.Round(value)
+	if math.Abs(value-rounded) > 1e-9 {
+		return 0, errors.New("size resolves to fractional bytes")
+	}
+	if rounded > math.MaxInt64 {
+		return 0, errors.New("size overflows int64")
+	}
+	return int64(rounded), nil
+}
+
+var byteSizeMultipliers = map[string]int64{
+	"b":   1,
+	"k":   1 << 10,
+	"kb":  1000,
+	"kib": 1 << 10,
+	"m":   1 << 20,
+	"mb":  1000 * 1000,
+	"mib": 1 << 20,
+	"g":   1 << 30,
+	"gb":  1000 * 1000 * 1000,
+	"gib": 1 << 30,
+	"t":   1 << 40,
+	"tb":  1000 * 1000 * 1000 * 1000,
+	"tib": 1 << 40,
+	"p":   1 << 50,
+	"pb":  1000 * 1000 * 1000 * 1000 * 1000,
+	"pib": 1 << 50,
+}

--- a/internal/controlservice/resource_requirements.go
+++ b/internal/controlservice/resource_requirements.go
@@ -1,0 +1,31 @@
+package controlservice
+
+import (
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/policy"
+)
+
+const mibBytes int64 = 1 << 20
+
+func withPolicyResourceRequirements(cfg backend.FirecrackerConfig, resources *policy.Resources) backend.FirecrackerConfig {
+	if resources == nil {
+		return cfg
+	}
+	if resources.VCPUs > cfg.VCPUs {
+		cfg.VCPUs = resources.VCPUs
+	}
+	if memoryMiB := bytesToMiBCeil(resources.MemoryBytes); memoryMiB > cfg.MemoryMiB {
+		cfg.MemoryMiB = memoryMiB
+	}
+	if resources.DiskBytes > cfg.MinimumRootFSBytes {
+		cfg.MinimumRootFSBytes = resources.DiskBytes
+	}
+	return cfg
+}
+
+func bytesToMiBCeil(value int64) int64 {
+	if value <= 0 {
+		return 0
+	}
+	return 1 + (value-1)/mibBytes
+}

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -340,6 +340,7 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 	}
 	firecrackerCfg := runtimeconfig.MergeBackendConfig(s.Config, backendName, execOpts.LaunchSeconds)
 	firecrackerCfg.RunDir = ""
+	firecrackerCfg = withPolicyResourceRequirements(firecrackerCfg, compiled.Resources)
 	firecrackerCfg = withRepositoryBootstrapRootFSMinimum(firecrackerCfg, compiled, repository)
 
 	var replacedWorkspaceStageRecord *cachestore.Record

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -5205,6 +5205,48 @@ func TestCreateSandboxMergesDarwinVZConfig(t *testing.T) {
 	}
 }
 
+func TestCreateSandboxAppliesPolicyResourceMinimums(t *testing.T) {
+	adapter := &stubAdapter{}
+	svc := &Service{
+		Config: runtimeconfig.Config{
+			DefaultBackend: "darwin-vz",
+			Backends: runtimeconfig.Backends{
+				DarwinVZ: runtimeconfig.DarwinVZConfig{
+					VCPUs:              2,
+					MemoryMiB:          1024,
+					MinimumRootFSBytes: runtimeconfig.ByteSize(8 << 30),
+				},
+			},
+		},
+		Backends: map[string]backend.Adapter{"darwin-vz": adapter},
+	}
+
+	policyProto := testPolicy()
+	policyProto.Resources = &cleanroomv1.PolicyResources{
+		Vcpus:       4,
+		MemoryBytes: (3 << 30) + 1,
+		DiskBytes:   16 << 30,
+	}
+
+	_, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Policy: policyProto,
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+
+	gotCfg := adapter.provisionReq.FirecrackerConfig
+	if got, want := gotCfg.VCPUs, int64(4); got != want {
+		t.Fatalf("unexpected vcpus: got %d want %d", got, want)
+	}
+	if got, want := gotCfg.MemoryMiB, int64(3073); got != want {
+		t.Fatalf("unexpected memory_mib: got %d want %d", got, want)
+	}
+	if got, want := gotCfg.MinimumRootFSBytes, int64(16<<30); got != want {
+		t.Fatalf("unexpected minimum_rootfs_bytes: got %d want %d", got, want)
+	}
+}
+
 func TestCreateSandboxMergesFirecrackerSnapshotConfig(t *testing.T) {
 	adapter := &stubAdapter{}
 	svc := &Service{

--- a/internal/controlservice/stored_rootfs.go
+++ b/internal/controlservice/stored_rootfs.go
@@ -110,6 +110,7 @@ func (s *Service) createSandboxFromStoredRootFS(ctx context.Context, req *cleanr
 	}
 	firecrackerCfg := runtimeconfig.MergeBackendConfig(s.Config, backendName, execOpts.LaunchSeconds)
 	firecrackerCfg.RunDir = ""
+	firecrackerCfg = withPolicyResourceRequirements(firecrackerCfg, effectivePolicy.Resources)
 	firecrackerCfg = withSnapshotDriver(backendName, firecrackerCfg, record.StorageDriver)
 
 	now := s.clock().Now()

--- a/internal/gen/cleanroom/v1/control.pb.go
+++ b/internal/gen/cleanroom/v1/control.pb.go
@@ -818,6 +818,66 @@ func (x *PolicyRun) GetBefore() []string {
 	return nil
 }
 
+type PolicyResources struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Vcpus         int64                  `protobuf:"varint,1,opt,name=vcpus,proto3" json:"vcpus,omitempty"`
+	MemoryBytes   int64                  `protobuf:"varint,2,opt,name=memory_bytes,json=memoryBytes,proto3" json:"memory_bytes,omitempty"`
+	DiskBytes     int64                  `protobuf:"varint,3,opt,name=disk_bytes,json=diskBytes,proto3" json:"disk_bytes,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PolicyResources) Reset() {
+	*x = PolicyResources{}
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PolicyResources) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PolicyResources) ProtoMessage() {}
+
+func (x *PolicyResources) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PolicyResources.ProtoReflect.Descriptor instead.
+func (*PolicyResources) Descriptor() ([]byte, []int) {
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *PolicyResources) GetVcpus() int64 {
+	if x != nil {
+		return x.Vcpus
+	}
+	return 0
+}
+
+func (x *PolicyResources) GetMemoryBytes() int64 {
+	if x != nil {
+		return x.MemoryBytes
+	}
+	return 0
+}
+
+func (x *PolicyResources) GetDiskBytes() int64 {
+	if x != nil {
+		return x.DiskBytes
+	}
+	return 0
+}
+
 type Policy struct {
 	state          protoimpl.MessageState `protogen:"open.v1"`
 	Version        int32                  `protobuf:"varint,1,opt,name=version,proto3" json:"version,omitempty"`
@@ -829,13 +889,14 @@ type Policy struct {
 	Services       *PolicyServices        `protobuf:"bytes,7,opt,name=services,proto3" json:"services,omitempty"`
 	Dependencies   *PolicyDependencies    `protobuf:"bytes,9,opt,name=dependencies,proto3" json:"dependencies,omitempty"`
 	Run            *PolicyRun             `protobuf:"bytes,10,opt,name=run,proto3" json:"run,omitempty"`
+	Resources      *PolicyResources       `protobuf:"bytes,11,opt,name=resources,proto3" json:"resources,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
 
 func (x *Policy) Reset() {
 	*x = Policy{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[8]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -847,7 +908,7 @@ func (x *Policy) String() string {
 func (*Policy) ProtoMessage() {}
 
 func (x *Policy) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[8]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -860,7 +921,7 @@ func (x *Policy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Policy.ProtoReflect.Descriptor instead.
 func (*Policy) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{8}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *Policy) GetVersion() int32 {
@@ -926,6 +987,13 @@ func (x *Policy) GetRun() *PolicyRun {
 	return nil
 }
 
+func (x *Policy) GetResources() *PolicyResources {
+	if x != nil {
+		return x.Resources
+	}
+	return nil
+}
+
 type SandboxOptions struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	LaunchSeconds int64                  `protobuf:"varint,3,opt,name=launch_seconds,json=launchSeconds,proto3" json:"launch_seconds,omitempty"`
@@ -935,7 +1003,7 @@ type SandboxOptions struct {
 
 func (x *SandboxOptions) Reset() {
 	*x = SandboxOptions{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[9]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -947,7 +1015,7 @@ func (x *SandboxOptions) String() string {
 func (*SandboxOptions) ProtoMessage() {}
 
 func (x *SandboxOptions) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[9]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -960,7 +1028,7 @@ func (x *SandboxOptions) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxOptions.ProtoReflect.Descriptor instead.
 func (*SandboxOptions) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{9}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *SandboxOptions) GetLaunchSeconds() int64 {
@@ -983,7 +1051,7 @@ type RepositoryCheckout struct {
 
 func (x *RepositoryCheckout) Reset() {
 	*x = RepositoryCheckout{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[10]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -995,7 +1063,7 @@ func (x *RepositoryCheckout) String() string {
 func (*RepositoryCheckout) ProtoMessage() {}
 
 func (x *RepositoryCheckout) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[10]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1008,7 +1076,7 @@ func (x *RepositoryCheckout) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RepositoryCheckout.ProtoReflect.Descriptor instead.
 func (*RepositoryCheckout) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{10}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *RepositoryCheckout) GetRemoteUrl() string {
@@ -1057,7 +1125,7 @@ type RepositoryChangesetFile struct {
 
 func (x *RepositoryChangesetFile) Reset() {
 	*x = RepositoryChangesetFile{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[11]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1069,7 +1137,7 @@ func (x *RepositoryChangesetFile) String() string {
 func (*RepositoryChangesetFile) ProtoMessage() {}
 
 func (x *RepositoryChangesetFile) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[11]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1082,7 +1150,7 @@ func (x *RepositoryChangesetFile) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RepositoryChangesetFile.ProtoReflect.Descriptor instead.
 func (*RepositoryChangesetFile) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{11}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *RepositoryChangesetFile) GetPath() string {
@@ -1120,7 +1188,7 @@ type RepositoryChangeset struct {
 
 func (x *RepositoryChangeset) Reset() {
 	*x = RepositoryChangeset{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[12]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1132,7 +1200,7 @@ func (x *RepositoryChangeset) String() string {
 func (*RepositoryChangeset) ProtoMessage() {}
 
 func (x *RepositoryChangeset) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[12]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1145,7 +1213,7 @@ func (x *RepositoryChangeset) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RepositoryChangeset.ProtoReflect.Descriptor instead.
 func (*RepositoryChangeset) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{12}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *RepositoryChangeset) GetFormat() string {
@@ -1207,7 +1275,7 @@ type CreateSandboxRequest struct {
 
 func (x *CreateSandboxRequest) Reset() {
 	*x = CreateSandboxRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[13]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1219,7 +1287,7 @@ func (x *CreateSandboxRequest) String() string {
 func (*CreateSandboxRequest) ProtoMessage() {}
 
 func (x *CreateSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[13]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1232,7 +1300,7 @@ func (x *CreateSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSandboxRequest.ProtoReflect.Descriptor instead.
 func (*CreateSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{13}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *CreateSandboxRequest) GetBackend() string {
@@ -1310,7 +1378,7 @@ type CreateSandboxResponse struct {
 
 func (x *CreateSandboxResponse) Reset() {
 	*x = CreateSandboxResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[14]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1322,7 +1390,7 @@ func (x *CreateSandboxResponse) String() string {
 func (*CreateSandboxResponse) ProtoMessage() {}
 
 func (x *CreateSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[14]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1335,7 +1403,7 @@ func (x *CreateSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSandboxResponse.ProtoReflect.Descriptor instead.
 func (*CreateSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{14}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *CreateSandboxResponse) GetSandbox() *Sandbox {
@@ -1398,7 +1466,7 @@ type CreateSandboxEvent struct {
 
 func (x *CreateSandboxEvent) Reset() {
 	*x = CreateSandboxEvent{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[15]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1410,7 +1478,7 @@ func (x *CreateSandboxEvent) String() string {
 func (*CreateSandboxEvent) ProtoMessage() {}
 
 func (x *CreateSandboxEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[15]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1423,7 +1491,7 @@ func (x *CreateSandboxEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSandboxEvent.ProtoReflect.Descriptor instead.
 func (*CreateSandboxEvent) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{15}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *CreateSandboxEvent) GetPhase() CreateSandboxPhase {
@@ -1535,7 +1603,7 @@ type GetSandboxRequest struct {
 
 func (x *GetSandboxRequest) Reset() {
 	*x = GetSandboxRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[16]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1547,7 +1615,7 @@ func (x *GetSandboxRequest) String() string {
 func (*GetSandboxRequest) ProtoMessage() {}
 
 func (x *GetSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[16]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1560,7 +1628,7 @@ func (x *GetSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSandboxRequest.ProtoReflect.Descriptor instead.
 func (*GetSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{16}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *GetSandboxRequest) GetSandboxId() string {
@@ -1579,7 +1647,7 @@ type GetSandboxResponse struct {
 
 func (x *GetSandboxResponse) Reset() {
 	*x = GetSandboxResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[17]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1591,7 +1659,7 @@ func (x *GetSandboxResponse) String() string {
 func (*GetSandboxResponse) ProtoMessage() {}
 
 func (x *GetSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[17]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1604,7 +1672,7 @@ func (x *GetSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSandboxResponse.ProtoReflect.Descriptor instead.
 func (*GetSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{17}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *GetSandboxResponse) GetSandbox() *Sandbox {
@@ -1622,7 +1690,7 @@ type ListSandboxesRequest struct {
 
 func (x *ListSandboxesRequest) Reset() {
 	*x = ListSandboxesRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[18]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1634,7 +1702,7 @@ func (x *ListSandboxesRequest) String() string {
 func (*ListSandboxesRequest) ProtoMessage() {}
 
 func (x *ListSandboxesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[18]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1647,7 +1715,7 @@ func (x *ListSandboxesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSandboxesRequest.ProtoReflect.Descriptor instead.
 func (*ListSandboxesRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{18}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{19}
 }
 
 type ListSandboxesResponse struct {
@@ -1659,7 +1727,7 @@ type ListSandboxesResponse struct {
 
 func (x *ListSandboxesResponse) Reset() {
 	*x = ListSandboxesResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[19]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1671,7 +1739,7 @@ func (x *ListSandboxesResponse) String() string {
 func (*ListSandboxesResponse) ProtoMessage() {}
 
 func (x *ListSandboxesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[19]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1684,7 +1752,7 @@ func (x *ListSandboxesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSandboxesResponse.ProtoReflect.Descriptor instead.
 func (*ListSandboxesResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{19}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *ListSandboxesResponse) GetSandboxes() []*Sandbox {
@@ -1704,7 +1772,7 @@ type ListExecutionsRequest struct {
 
 func (x *ListExecutionsRequest) Reset() {
 	*x = ListExecutionsRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[20]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1716,7 +1784,7 @@ func (x *ListExecutionsRequest) String() string {
 func (*ListExecutionsRequest) ProtoMessage() {}
 
 func (x *ListExecutionsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[20]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1729,7 +1797,7 @@ func (x *ListExecutionsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListExecutionsRequest.ProtoReflect.Descriptor instead.
 func (*ListExecutionsRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{20}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *ListExecutionsRequest) GetSandboxId() string {
@@ -1755,7 +1823,7 @@ type ListExecutionsResponse struct {
 
 func (x *ListExecutionsResponse) Reset() {
 	*x = ListExecutionsResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[21]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1767,7 +1835,7 @@ func (x *ListExecutionsResponse) String() string {
 func (*ListExecutionsResponse) ProtoMessage() {}
 
 func (x *ListExecutionsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[21]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1780,7 +1848,7 @@ func (x *ListExecutionsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListExecutionsResponse.ProtoReflect.Descriptor instead.
 func (*ListExecutionsResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{21}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *ListExecutionsResponse) GetExecutions() []*Execution {
@@ -1801,7 +1869,7 @@ type DownloadSandboxFileRequest struct {
 
 func (x *DownloadSandboxFileRequest) Reset() {
 	*x = DownloadSandboxFileRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[22]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1813,7 +1881,7 @@ func (x *DownloadSandboxFileRequest) String() string {
 func (*DownloadSandboxFileRequest) ProtoMessage() {}
 
 func (x *DownloadSandboxFileRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[22]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1826,7 +1894,7 @@ func (x *DownloadSandboxFileRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DownloadSandboxFileRequest.ProtoReflect.Descriptor instead.
 func (*DownloadSandboxFileRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{22}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *DownloadSandboxFileRequest) GetSandboxId() string {
@@ -1862,7 +1930,7 @@ type DownloadSandboxFileResponse struct {
 
 func (x *DownloadSandboxFileResponse) Reset() {
 	*x = DownloadSandboxFileResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[23]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1874,7 +1942,7 @@ func (x *DownloadSandboxFileResponse) String() string {
 func (*DownloadSandboxFileResponse) ProtoMessage() {}
 
 func (x *DownloadSandboxFileResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[23]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1887,7 +1955,7 @@ func (x *DownloadSandboxFileResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DownloadSandboxFileResponse.ProtoReflect.Descriptor instead.
 func (*DownloadSandboxFileResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{23}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *DownloadSandboxFileResponse) GetSandboxId() string {
@@ -1927,7 +1995,7 @@ type TerminateSandboxRequest struct {
 
 func (x *TerminateSandboxRequest) Reset() {
 	*x = TerminateSandboxRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[24]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1939,7 +2007,7 @@ func (x *TerminateSandboxRequest) String() string {
 func (*TerminateSandboxRequest) ProtoMessage() {}
 
 func (x *TerminateSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[24]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1952,7 +2020,7 @@ func (x *TerminateSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TerminateSandboxRequest.ProtoReflect.Descriptor instead.
 func (*TerminateSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{24}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *TerminateSandboxRequest) GetSandboxId() string {
@@ -1973,7 +2041,7 @@ type TerminateSandboxResponse struct {
 
 func (x *TerminateSandboxResponse) Reset() {
 	*x = TerminateSandboxResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[25]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1985,7 +2053,7 @@ func (x *TerminateSandboxResponse) String() string {
 func (*TerminateSandboxResponse) ProtoMessage() {}
 
 func (x *TerminateSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[25]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1998,7 +2066,7 @@ func (x *TerminateSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TerminateSandboxResponse.ProtoReflect.Descriptor instead.
 func (*TerminateSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{25}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *TerminateSandboxResponse) GetSandboxId() string {
@@ -2032,7 +2100,7 @@ type StreamSandboxEventsRequest struct {
 
 func (x *StreamSandboxEventsRequest) Reset() {
 	*x = StreamSandboxEventsRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[26]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2044,7 +2112,7 @@ func (x *StreamSandboxEventsRequest) String() string {
 func (*StreamSandboxEventsRequest) ProtoMessage() {}
 
 func (x *StreamSandboxEventsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[26]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2057,7 +2125,7 @@ func (x *StreamSandboxEventsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamSandboxEventsRequest.ProtoReflect.Descriptor instead.
 func (*StreamSandboxEventsRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{26}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *StreamSandboxEventsRequest) GetSandboxId() string {
@@ -2086,7 +2154,7 @@ type SandboxEvent struct {
 
 func (x *SandboxEvent) Reset() {
 	*x = SandboxEvent{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[27]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2098,7 +2166,7 @@ func (x *SandboxEvent) String() string {
 func (*SandboxEvent) ProtoMessage() {}
 
 func (x *SandboxEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[27]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2111,7 +2179,7 @@ func (x *SandboxEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxEvent.ProtoReflect.Descriptor instead.
 func (*SandboxEvent) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{27}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *SandboxEvent) GetSandboxId() string {
@@ -2152,7 +2220,7 @@ type CreateSnapshotRequest struct {
 
 func (x *CreateSnapshotRequest) Reset() {
 	*x = CreateSnapshotRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[28]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2164,7 +2232,7 @@ func (x *CreateSnapshotRequest) String() string {
 func (*CreateSnapshotRequest) ProtoMessage() {}
 
 func (x *CreateSnapshotRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[28]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2177,7 +2245,7 @@ func (x *CreateSnapshotRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSnapshotRequest.ProtoReflect.Descriptor instead.
 func (*CreateSnapshotRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{28}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *CreateSnapshotRequest) GetSandboxId() string {
@@ -2204,7 +2272,7 @@ type CreateSnapshotResponse struct {
 
 func (x *CreateSnapshotResponse) Reset() {
 	*x = CreateSnapshotResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[29]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2216,7 +2284,7 @@ func (x *CreateSnapshotResponse) String() string {
 func (*CreateSnapshotResponse) ProtoMessage() {}
 
 func (x *CreateSnapshotResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[29]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2229,7 +2297,7 @@ func (x *CreateSnapshotResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSnapshotResponse.ProtoReflect.Descriptor instead.
 func (*CreateSnapshotResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{29}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *CreateSnapshotResponse) GetSnapshot() *Snapshot {
@@ -2255,7 +2323,7 @@ type GetSnapshotRequest struct {
 
 func (x *GetSnapshotRequest) Reset() {
 	*x = GetSnapshotRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[30]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2267,7 +2335,7 @@ func (x *GetSnapshotRequest) String() string {
 func (*GetSnapshotRequest) ProtoMessage() {}
 
 func (x *GetSnapshotRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[30]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2280,7 +2348,7 @@ func (x *GetSnapshotRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSnapshotRequest.ProtoReflect.Descriptor instead.
 func (*GetSnapshotRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{30}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *GetSnapshotRequest) GetSnapshotId() string {
@@ -2299,7 +2367,7 @@ type GetSnapshotResponse struct {
 
 func (x *GetSnapshotResponse) Reset() {
 	*x = GetSnapshotResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[31]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2311,7 +2379,7 @@ func (x *GetSnapshotResponse) String() string {
 func (*GetSnapshotResponse) ProtoMessage() {}
 
 func (x *GetSnapshotResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[31]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2324,7 +2392,7 @@ func (x *GetSnapshotResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSnapshotResponse.ProtoReflect.Descriptor instead.
 func (*GetSnapshotResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{31}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *GetSnapshotResponse) GetSnapshot() *Snapshot {
@@ -2342,7 +2410,7 @@ type ListSnapshotsRequest struct {
 
 func (x *ListSnapshotsRequest) Reset() {
 	*x = ListSnapshotsRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[32]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2354,7 +2422,7 @@ func (x *ListSnapshotsRequest) String() string {
 func (*ListSnapshotsRequest) ProtoMessage() {}
 
 func (x *ListSnapshotsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[32]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2367,7 +2435,7 @@ func (x *ListSnapshotsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSnapshotsRequest.ProtoReflect.Descriptor instead.
 func (*ListSnapshotsRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{32}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{33}
 }
 
 type ListSnapshotsResponse struct {
@@ -2379,7 +2447,7 @@ type ListSnapshotsResponse struct {
 
 func (x *ListSnapshotsResponse) Reset() {
 	*x = ListSnapshotsResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[33]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2391,7 +2459,7 @@ func (x *ListSnapshotsResponse) String() string {
 func (*ListSnapshotsResponse) ProtoMessage() {}
 
 func (x *ListSnapshotsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[33]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2404,7 +2472,7 @@ func (x *ListSnapshotsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSnapshotsResponse.ProtoReflect.Descriptor instead.
 func (*ListSnapshotsResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{33}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *ListSnapshotsResponse) GetSnapshots() []*Snapshot {
@@ -2423,7 +2491,7 @@ type DeleteSnapshotRequest struct {
 
 func (x *DeleteSnapshotRequest) Reset() {
 	*x = DeleteSnapshotRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[34]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2435,7 +2503,7 @@ func (x *DeleteSnapshotRequest) String() string {
 func (*DeleteSnapshotRequest) ProtoMessage() {}
 
 func (x *DeleteSnapshotRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[34]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2448,7 +2516,7 @@ func (x *DeleteSnapshotRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSnapshotRequest.ProtoReflect.Descriptor instead.
 func (*DeleteSnapshotRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{34}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *DeleteSnapshotRequest) GetSnapshotId() string {
@@ -2469,7 +2537,7 @@ type DeleteSnapshotResponse struct {
 
 func (x *DeleteSnapshotResponse) Reset() {
 	*x = DeleteSnapshotResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[35]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2481,7 +2549,7 @@ func (x *DeleteSnapshotResponse) String() string {
 func (*DeleteSnapshotResponse) ProtoMessage() {}
 
 func (x *DeleteSnapshotResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[35]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2494,7 +2562,7 @@ func (x *DeleteSnapshotResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSnapshotResponse.ProtoReflect.Descriptor instead.
 func (*DeleteSnapshotResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{35}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *DeleteSnapshotResponse) GetSnapshotId() string {
@@ -2535,7 +2603,7 @@ type Execution struct {
 
 func (x *Execution) Reset() {
 	*x = Execution{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[36]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2547,7 +2615,7 @@ func (x *Execution) String() string {
 func (*Execution) ProtoMessage() {}
 
 func (x *Execution) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[36]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2560,7 +2628,7 @@ func (x *Execution) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Execution.ProtoReflect.Descriptor instead.
 func (*Execution) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{36}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *Execution) GetExecutionId() string {
@@ -2636,7 +2704,7 @@ type ExecutionOptions struct {
 
 func (x *ExecutionOptions) Reset() {
 	*x = ExecutionOptions{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[37]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2648,7 +2716,7 @@ func (x *ExecutionOptions) String() string {
 func (*ExecutionOptions) ProtoMessage() {}
 
 func (x *ExecutionOptions) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[37]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2661,7 +2729,7 @@ func (x *ExecutionOptions) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionOptions.ProtoReflect.Descriptor instead.
 func (*ExecutionOptions) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{37}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *ExecutionOptions) GetLaunchSeconds() int64 {
@@ -2692,7 +2760,7 @@ type CreateExecutionRequest struct {
 
 func (x *CreateExecutionRequest) Reset() {
 	*x = CreateExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[38]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2704,7 +2772,7 @@ func (x *CreateExecutionRequest) String() string {
 func (*CreateExecutionRequest) ProtoMessage() {}
 
 func (x *CreateExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[38]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2717,7 +2785,7 @@ func (x *CreateExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateExecutionRequest.ProtoReflect.Descriptor instead.
 func (*CreateExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{38}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *CreateExecutionRequest) GetSandboxId() string {
@@ -2771,7 +2839,7 @@ type CreateExecutionResponse struct {
 
 func (x *CreateExecutionResponse) Reset() {
 	*x = CreateExecutionResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[39]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2783,7 +2851,7 @@ func (x *CreateExecutionResponse) String() string {
 func (*CreateExecutionResponse) ProtoMessage() {}
 
 func (x *CreateExecutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[39]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2796,7 +2864,7 @@ func (x *CreateExecutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateExecutionResponse.ProtoReflect.Descriptor instead.
 func (*CreateExecutionResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{39}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *CreateExecutionResponse) GetExecution() *Execution {
@@ -2818,7 +2886,7 @@ type AttachExecutionRequest struct {
 
 func (x *AttachExecutionRequest) Reset() {
 	*x = AttachExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[40]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2830,7 +2898,7 @@ func (x *AttachExecutionRequest) String() string {
 func (*AttachExecutionRequest) ProtoMessage() {}
 
 func (x *AttachExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[40]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2843,7 +2911,7 @@ func (x *AttachExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachExecutionRequest.ProtoReflect.Descriptor instead.
 func (*AttachExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{40}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *AttachExecutionRequest) GetSandboxId() string {
@@ -2888,7 +2956,7 @@ type AttachExecutionResponse struct {
 
 func (x *AttachExecutionResponse) Reset() {
 	*x = AttachExecutionResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[41]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2900,7 +2968,7 @@ func (x *AttachExecutionResponse) String() string {
 func (*AttachExecutionResponse) ProtoMessage() {}
 
 func (x *AttachExecutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[41]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2913,7 +2981,7 @@ func (x *AttachExecutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachExecutionResponse.ProtoReflect.Descriptor instead.
 func (*AttachExecutionResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{41}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *AttachExecutionResponse) GetSessionId() string {
@@ -2968,7 +3036,7 @@ type GetExecutionRequest struct {
 
 func (x *GetExecutionRequest) Reset() {
 	*x = GetExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[42]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2980,7 +3048,7 @@ func (x *GetExecutionRequest) String() string {
 func (*GetExecutionRequest) ProtoMessage() {}
 
 func (x *GetExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[42]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2993,7 +3061,7 @@ func (x *GetExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetExecutionRequest.ProtoReflect.Descriptor instead.
 func (*GetExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{42}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *GetExecutionRequest) GetSandboxId() string {
@@ -3019,7 +3087,7 @@ type GetExecutionResponse struct {
 
 func (x *GetExecutionResponse) Reset() {
 	*x = GetExecutionResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[43]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3031,7 +3099,7 @@ func (x *GetExecutionResponse) String() string {
 func (*GetExecutionResponse) ProtoMessage() {}
 
 func (x *GetExecutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[43]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3044,7 +3112,7 @@ func (x *GetExecutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetExecutionResponse.ProtoReflect.Descriptor instead.
 func (*GetExecutionResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{43}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *GetExecutionResponse) GetExecution() *Execution {
@@ -3064,7 +3132,7 @@ type InspectExecutionRequest struct {
 
 func (x *InspectExecutionRequest) Reset() {
 	*x = InspectExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[44]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3076,7 +3144,7 @@ func (x *InspectExecutionRequest) String() string {
 func (*InspectExecutionRequest) ProtoMessage() {}
 
 func (x *InspectExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[44]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3089,7 +3157,7 @@ func (x *InspectExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectExecutionRequest.ProtoReflect.Descriptor instead.
 func (*InspectExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{44}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *InspectExecutionRequest) GetSandboxId() string {
@@ -3126,7 +3194,7 @@ type InspectExecutionResponse struct {
 
 func (x *InspectExecutionResponse) Reset() {
 	*x = InspectExecutionResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[45]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3138,7 +3206,7 @@ func (x *InspectExecutionResponse) String() string {
 func (*InspectExecutionResponse) ProtoMessage() {}
 
 func (x *InspectExecutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[45]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3151,7 +3219,7 @@ func (x *InspectExecutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectExecutionResponse.ProtoReflect.Descriptor instead.
 func (*InspectExecutionResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{45}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *InspectExecutionResponse) GetExecution() *Execution {
@@ -3249,7 +3317,7 @@ type CancelExecutionRequest struct {
 
 func (x *CancelExecutionRequest) Reset() {
 	*x = CancelExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[46]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3261,7 +3329,7 @@ func (x *CancelExecutionRequest) String() string {
 func (*CancelExecutionRequest) ProtoMessage() {}
 
 func (x *CancelExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[46]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3274,7 +3342,7 @@ func (x *CancelExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelExecutionRequest.ProtoReflect.Descriptor instead.
 func (*CancelExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{46}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *CancelExecutionRequest) GetSandboxId() string {
@@ -3310,7 +3378,7 @@ type CancelExecutionResponse struct {
 
 func (x *CancelExecutionResponse) Reset() {
 	*x = CancelExecutionResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[47]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3322,7 +3390,7 @@ func (x *CancelExecutionResponse) String() string {
 func (*CancelExecutionResponse) ProtoMessage() {}
 
 func (x *CancelExecutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[47]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3335,7 +3403,7 @@ func (x *CancelExecutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelExecutionResponse.ProtoReflect.Descriptor instead.
 func (*CancelExecutionResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{47}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *CancelExecutionResponse) GetSandboxId() string {
@@ -3377,7 +3445,7 @@ type WriteExecutionStdinRequest struct {
 
 func (x *WriteExecutionStdinRequest) Reset() {
 	*x = WriteExecutionStdinRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[48]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3389,7 +3457,7 @@ func (x *WriteExecutionStdinRequest) String() string {
 func (*WriteExecutionStdinRequest) ProtoMessage() {}
 
 func (x *WriteExecutionStdinRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[48]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3402,7 +3470,7 @@ func (x *WriteExecutionStdinRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WriteExecutionStdinRequest.ProtoReflect.Descriptor instead.
 func (*WriteExecutionStdinRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{48}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *WriteExecutionStdinRequest) GetSandboxId() string {
@@ -3434,7 +3502,7 @@ type WriteExecutionStdinResponse struct {
 
 func (x *WriteExecutionStdinResponse) Reset() {
 	*x = WriteExecutionStdinResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[49]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3446,7 +3514,7 @@ func (x *WriteExecutionStdinResponse) String() string {
 func (*WriteExecutionStdinResponse) ProtoMessage() {}
 
 func (x *WriteExecutionStdinResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[49]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3459,7 +3527,7 @@ func (x *WriteExecutionStdinResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WriteExecutionStdinResponse.ProtoReflect.Descriptor instead.
 func (*WriteExecutionStdinResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{49}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{50}
 }
 
 type CloseExecutionStdinRequest struct {
@@ -3472,7 +3540,7 @@ type CloseExecutionStdinRequest struct {
 
 func (x *CloseExecutionStdinRequest) Reset() {
 	*x = CloseExecutionStdinRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[50]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3484,7 +3552,7 @@ func (x *CloseExecutionStdinRequest) String() string {
 func (*CloseExecutionStdinRequest) ProtoMessage() {}
 
 func (x *CloseExecutionStdinRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[50]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3497,7 +3565,7 @@ func (x *CloseExecutionStdinRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CloseExecutionStdinRequest.ProtoReflect.Descriptor instead.
 func (*CloseExecutionStdinRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{50}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *CloseExecutionStdinRequest) GetSandboxId() string {
@@ -3522,7 +3590,7 @@ type CloseExecutionStdinResponse struct {
 
 func (x *CloseExecutionStdinResponse) Reset() {
 	*x = CloseExecutionStdinResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[51]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3534,7 +3602,7 @@ func (x *CloseExecutionStdinResponse) String() string {
 func (*CloseExecutionStdinResponse) ProtoMessage() {}
 
 func (x *CloseExecutionStdinResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[51]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3547,7 +3615,7 @@ func (x *CloseExecutionStdinResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CloseExecutionStdinResponse.ProtoReflect.Descriptor instead.
 func (*CloseExecutionStdinResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{51}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{52}
 }
 
 type StreamExecutionRequest struct {
@@ -3561,7 +3629,7 @@ type StreamExecutionRequest struct {
 
 func (x *StreamExecutionRequest) Reset() {
 	*x = StreamExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[52]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3573,7 +3641,7 @@ func (x *StreamExecutionRequest) String() string {
 func (*StreamExecutionRequest) ProtoMessage() {}
 
 func (x *StreamExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[52]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3586,7 +3654,7 @@ func (x *StreamExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamExecutionRequest.ProtoReflect.Descriptor instead.
 func (*StreamExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{52}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *StreamExecutionRequest) GetSandboxId() string {
@@ -3621,7 +3689,7 @@ type ExecutionExit struct {
 
 func (x *ExecutionExit) Reset() {
 	*x = ExecutionExit{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[53]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3633,7 +3701,7 @@ func (x *ExecutionExit) String() string {
 func (*ExecutionExit) ProtoMessage() {}
 
 func (x *ExecutionExit) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[53]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3646,7 +3714,7 @@ func (x *ExecutionExit) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionExit.ProtoReflect.Descriptor instead.
 func (*ExecutionExit) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{53}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *ExecutionExit) GetExitCode() int32 {
@@ -3692,7 +3760,7 @@ type ExecutionStreamEvent struct {
 
 func (x *ExecutionStreamEvent) Reset() {
 	*x = ExecutionStreamEvent{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[54]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3704,7 +3772,7 @@ func (x *ExecutionStreamEvent) String() string {
 func (*ExecutionStreamEvent) ProtoMessage() {}
 
 func (x *ExecutionStreamEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[54]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3717,7 +3785,7 @@ func (x *ExecutionStreamEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionStreamEvent.ProtoReflect.Descriptor instead.
 func (*ExecutionStreamEvent) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{54}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *ExecutionStreamEvent) GetSandboxId() string {
@@ -3901,7 +3969,12 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\x03key\x18\x02 \x01(\v2!.cleanroom.v1.PolicyDependencyKeyR\x03key\x12\x14\n" +
 	"\x05reuse\x18\x03 \x01(\tR\x05reuse\"#\n" +
 	"\tPolicyRun\x12\x16\n" +
-	"\x06before\x18\x01 \x03(\tR\x06before\"\xff\x02\n" +
+	"\x06before\x18\x01 \x03(\tR\x06before\"i\n" +
+	"\x0fPolicyResources\x12\x14\n" +
+	"\x05vcpus\x18\x01 \x01(\x03R\x05vcpus\x12!\n" +
+	"\fmemory_bytes\x18\x02 \x01(\x03R\vmemoryBytes\x12\x1d\n" +
+	"\n" +
+	"disk_bytes\x18\x03 \x01(\x03R\tdiskBytes\"\xbc\x03\n" +
 	"\x06Policy\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\x05R\aversion\x12\x1b\n" +
 	"\timage_ref\x18\x02 \x01(\tR\bimageRef\x12!\n" +
@@ -3912,7 +3985,8 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\bservices\x18\a \x01(\v2\x1c.cleanroom.v1.PolicyServicesR\bservices\x12D\n" +
 	"\fdependencies\x18\t \x01(\v2 .cleanroom.v1.PolicyDependenciesR\fdependencies\x12)\n" +
 	"\x03run\x18\n" +
-	" \x01(\v2\x17.cleanroom.v1.PolicyRunR\x03run\"R\n" +
+	" \x01(\v2\x17.cleanroom.v1.PolicyRunR\x03run\x12;\n" +
+	"\tresources\x18\v \x01(\v2\x1d.cleanroom.v1.PolicyResourcesR\tresources\"R\n" +
 	"\x0eSandboxOptions\x12%\n" +
 	"\x0elaunch_seconds\x18\x03 \x01(\x03R\rlaunchSecondsJ\x04\b\x02\x10\x03R\x13read_only_workspace\"\xe1\x01\n" +
 	"\x12RepositoryCheckout\x12\x1d\n" +
@@ -4227,7 +4301,7 @@ func file_proto_cleanroom_v1_control_proto_rawDescGZIP() []byte {
 }
 
 var file_proto_cleanroom_v1_control_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_proto_cleanroom_v1_control_proto_msgTypes = make([]protoimpl.MessageInfo, 55)
+var file_proto_cleanroom_v1_control_proto_msgTypes = make([]protoimpl.MessageInfo, 56)
 var file_proto_cleanroom_v1_control_proto_goTypes = []any{
 	(SandboxStatus)(0),                  // 0: cleanroom.v1.SandboxStatus
 	(CreateSandboxPhase)(0),             // 1: cleanroom.v1.CreateSandboxPhase
@@ -4241,62 +4315,63 @@ var file_proto_cleanroom_v1_control_proto_goTypes = []any{
 	(*PolicyDependencyKey)(nil),         // 9: cleanroom.v1.PolicyDependencyKey
 	(*PolicyDependencies)(nil),          // 10: cleanroom.v1.PolicyDependencies
 	(*PolicyRun)(nil),                   // 11: cleanroom.v1.PolicyRun
-	(*Policy)(nil),                      // 12: cleanroom.v1.Policy
-	(*SandboxOptions)(nil),              // 13: cleanroom.v1.SandboxOptions
-	(*RepositoryCheckout)(nil),          // 14: cleanroom.v1.RepositoryCheckout
-	(*RepositoryChangesetFile)(nil),     // 15: cleanroom.v1.RepositoryChangesetFile
-	(*RepositoryChangeset)(nil),         // 16: cleanroom.v1.RepositoryChangeset
-	(*CreateSandboxRequest)(nil),        // 17: cleanroom.v1.CreateSandboxRequest
-	(*CreateSandboxResponse)(nil),       // 18: cleanroom.v1.CreateSandboxResponse
-	(*CreateSandboxEvent)(nil),          // 19: cleanroom.v1.CreateSandboxEvent
-	(*GetSandboxRequest)(nil),           // 20: cleanroom.v1.GetSandboxRequest
-	(*GetSandboxResponse)(nil),          // 21: cleanroom.v1.GetSandboxResponse
-	(*ListSandboxesRequest)(nil),        // 22: cleanroom.v1.ListSandboxesRequest
-	(*ListSandboxesResponse)(nil),       // 23: cleanroom.v1.ListSandboxesResponse
-	(*ListExecutionsRequest)(nil),       // 24: cleanroom.v1.ListExecutionsRequest
-	(*ListExecutionsResponse)(nil),      // 25: cleanroom.v1.ListExecutionsResponse
-	(*DownloadSandboxFileRequest)(nil),  // 26: cleanroom.v1.DownloadSandboxFileRequest
-	(*DownloadSandboxFileResponse)(nil), // 27: cleanroom.v1.DownloadSandboxFileResponse
-	(*TerminateSandboxRequest)(nil),     // 28: cleanroom.v1.TerminateSandboxRequest
-	(*TerminateSandboxResponse)(nil),    // 29: cleanroom.v1.TerminateSandboxResponse
-	(*StreamSandboxEventsRequest)(nil),  // 30: cleanroom.v1.StreamSandboxEventsRequest
-	(*SandboxEvent)(nil),                // 31: cleanroom.v1.SandboxEvent
-	(*CreateSnapshotRequest)(nil),       // 32: cleanroom.v1.CreateSnapshotRequest
-	(*CreateSnapshotResponse)(nil),      // 33: cleanroom.v1.CreateSnapshotResponse
-	(*GetSnapshotRequest)(nil),          // 34: cleanroom.v1.GetSnapshotRequest
-	(*GetSnapshotResponse)(nil),         // 35: cleanroom.v1.GetSnapshotResponse
-	(*ListSnapshotsRequest)(nil),        // 36: cleanroom.v1.ListSnapshotsRequest
-	(*ListSnapshotsResponse)(nil),       // 37: cleanroom.v1.ListSnapshotsResponse
-	(*DeleteSnapshotRequest)(nil),       // 38: cleanroom.v1.DeleteSnapshotRequest
-	(*DeleteSnapshotResponse)(nil),      // 39: cleanroom.v1.DeleteSnapshotResponse
-	(*Execution)(nil),                   // 40: cleanroom.v1.Execution
-	(*ExecutionOptions)(nil),            // 41: cleanroom.v1.ExecutionOptions
-	(*CreateExecutionRequest)(nil),      // 42: cleanroom.v1.CreateExecutionRequest
-	(*CreateExecutionResponse)(nil),     // 43: cleanroom.v1.CreateExecutionResponse
-	(*AttachExecutionRequest)(nil),      // 44: cleanroom.v1.AttachExecutionRequest
-	(*AttachExecutionResponse)(nil),     // 45: cleanroom.v1.AttachExecutionResponse
-	(*GetExecutionRequest)(nil),         // 46: cleanroom.v1.GetExecutionRequest
-	(*GetExecutionResponse)(nil),        // 47: cleanroom.v1.GetExecutionResponse
-	(*InspectExecutionRequest)(nil),     // 48: cleanroom.v1.InspectExecutionRequest
-	(*InspectExecutionResponse)(nil),    // 49: cleanroom.v1.InspectExecutionResponse
-	(*CancelExecutionRequest)(nil),      // 50: cleanroom.v1.CancelExecutionRequest
-	(*CancelExecutionResponse)(nil),     // 51: cleanroom.v1.CancelExecutionResponse
-	(*WriteExecutionStdinRequest)(nil),  // 52: cleanroom.v1.WriteExecutionStdinRequest
-	(*WriteExecutionStdinResponse)(nil), // 53: cleanroom.v1.WriteExecutionStdinResponse
-	(*CloseExecutionStdinRequest)(nil),  // 54: cleanroom.v1.CloseExecutionStdinRequest
-	(*CloseExecutionStdinResponse)(nil), // 55: cleanroom.v1.CloseExecutionStdinResponse
-	(*StreamExecutionRequest)(nil),      // 56: cleanroom.v1.StreamExecutionRequest
-	(*ExecutionExit)(nil),               // 57: cleanroom.v1.ExecutionExit
-	(*ExecutionStreamEvent)(nil),        // 58: cleanroom.v1.ExecutionStreamEvent
-	(*timestamppb.Timestamp)(nil),       // 59: google.protobuf.Timestamp
-	(*structpb.Struct)(nil),             // 60: google.protobuf.Struct
+	(*PolicyResources)(nil),             // 12: cleanroom.v1.PolicyResources
+	(*Policy)(nil),                      // 13: cleanroom.v1.Policy
+	(*SandboxOptions)(nil),              // 14: cleanroom.v1.SandboxOptions
+	(*RepositoryCheckout)(nil),          // 15: cleanroom.v1.RepositoryCheckout
+	(*RepositoryChangesetFile)(nil),     // 16: cleanroom.v1.RepositoryChangesetFile
+	(*RepositoryChangeset)(nil),         // 17: cleanroom.v1.RepositoryChangeset
+	(*CreateSandboxRequest)(nil),        // 18: cleanroom.v1.CreateSandboxRequest
+	(*CreateSandboxResponse)(nil),       // 19: cleanroom.v1.CreateSandboxResponse
+	(*CreateSandboxEvent)(nil),          // 20: cleanroom.v1.CreateSandboxEvent
+	(*GetSandboxRequest)(nil),           // 21: cleanroom.v1.GetSandboxRequest
+	(*GetSandboxResponse)(nil),          // 22: cleanroom.v1.GetSandboxResponse
+	(*ListSandboxesRequest)(nil),        // 23: cleanroom.v1.ListSandboxesRequest
+	(*ListSandboxesResponse)(nil),       // 24: cleanroom.v1.ListSandboxesResponse
+	(*ListExecutionsRequest)(nil),       // 25: cleanroom.v1.ListExecutionsRequest
+	(*ListExecutionsResponse)(nil),      // 26: cleanroom.v1.ListExecutionsResponse
+	(*DownloadSandboxFileRequest)(nil),  // 27: cleanroom.v1.DownloadSandboxFileRequest
+	(*DownloadSandboxFileResponse)(nil), // 28: cleanroom.v1.DownloadSandboxFileResponse
+	(*TerminateSandboxRequest)(nil),     // 29: cleanroom.v1.TerminateSandboxRequest
+	(*TerminateSandboxResponse)(nil),    // 30: cleanroom.v1.TerminateSandboxResponse
+	(*StreamSandboxEventsRequest)(nil),  // 31: cleanroom.v1.StreamSandboxEventsRequest
+	(*SandboxEvent)(nil),                // 32: cleanroom.v1.SandboxEvent
+	(*CreateSnapshotRequest)(nil),       // 33: cleanroom.v1.CreateSnapshotRequest
+	(*CreateSnapshotResponse)(nil),      // 34: cleanroom.v1.CreateSnapshotResponse
+	(*GetSnapshotRequest)(nil),          // 35: cleanroom.v1.GetSnapshotRequest
+	(*GetSnapshotResponse)(nil),         // 36: cleanroom.v1.GetSnapshotResponse
+	(*ListSnapshotsRequest)(nil),        // 37: cleanroom.v1.ListSnapshotsRequest
+	(*ListSnapshotsResponse)(nil),       // 38: cleanroom.v1.ListSnapshotsResponse
+	(*DeleteSnapshotRequest)(nil),       // 39: cleanroom.v1.DeleteSnapshotRequest
+	(*DeleteSnapshotResponse)(nil),      // 40: cleanroom.v1.DeleteSnapshotResponse
+	(*Execution)(nil),                   // 41: cleanroom.v1.Execution
+	(*ExecutionOptions)(nil),            // 42: cleanroom.v1.ExecutionOptions
+	(*CreateExecutionRequest)(nil),      // 43: cleanroom.v1.CreateExecutionRequest
+	(*CreateExecutionResponse)(nil),     // 44: cleanroom.v1.CreateExecutionResponse
+	(*AttachExecutionRequest)(nil),      // 45: cleanroom.v1.AttachExecutionRequest
+	(*AttachExecutionResponse)(nil),     // 46: cleanroom.v1.AttachExecutionResponse
+	(*GetExecutionRequest)(nil),         // 47: cleanroom.v1.GetExecutionRequest
+	(*GetExecutionResponse)(nil),        // 48: cleanroom.v1.GetExecutionResponse
+	(*InspectExecutionRequest)(nil),     // 49: cleanroom.v1.InspectExecutionRequest
+	(*InspectExecutionResponse)(nil),    // 50: cleanroom.v1.InspectExecutionResponse
+	(*CancelExecutionRequest)(nil),      // 51: cleanroom.v1.CancelExecutionRequest
+	(*CancelExecutionResponse)(nil),     // 52: cleanroom.v1.CancelExecutionResponse
+	(*WriteExecutionStdinRequest)(nil),  // 53: cleanroom.v1.WriteExecutionStdinRequest
+	(*WriteExecutionStdinResponse)(nil), // 54: cleanroom.v1.WriteExecutionStdinResponse
+	(*CloseExecutionStdinRequest)(nil),  // 55: cleanroom.v1.CloseExecutionStdinRequest
+	(*CloseExecutionStdinResponse)(nil), // 56: cleanroom.v1.CloseExecutionStdinResponse
+	(*StreamExecutionRequest)(nil),      // 57: cleanroom.v1.StreamExecutionRequest
+	(*ExecutionExit)(nil),               // 58: cleanroom.v1.ExecutionExit
+	(*ExecutionStreamEvent)(nil),        // 59: cleanroom.v1.ExecutionStreamEvent
+	(*timestamppb.Timestamp)(nil),       // 60: google.protobuf.Timestamp
+	(*structpb.Struct)(nil),             // 61: google.protobuf.Struct
 }
 var file_proto_cleanroom_v1_control_proto_depIdxs = []int32{
 	0,  // 0: cleanroom.v1.Sandbox.status:type_name -> cleanroom.v1.SandboxStatus
-	59, // 1: cleanroom.v1.Sandbox.created_at:type_name -> google.protobuf.Timestamp
-	59, // 2: cleanroom.v1.Sandbox.updated_at:type_name -> google.protobuf.Timestamp
-	59, // 3: cleanroom.v1.Snapshot.created_at:type_name -> google.protobuf.Timestamp
-	14, // 4: cleanroom.v1.Snapshot.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
+	60, // 1: cleanroom.v1.Sandbox.created_at:type_name -> google.protobuf.Timestamp
+	60, // 2: cleanroom.v1.Sandbox.updated_at:type_name -> google.protobuf.Timestamp
+	60, // 3: cleanroom.v1.Snapshot.created_at:type_name -> google.protobuf.Timestamp
+	15, // 4: cleanroom.v1.Snapshot.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
 	7,  // 5: cleanroom.v1.PolicyServices.docker:type_name -> cleanroom.v1.PolicyDockerService
 	9,  // 6: cleanroom.v1.PolicyServices.key:type_name -> cleanroom.v1.PolicyDependencyKey
 	9,  // 7: cleanroom.v1.PolicyDependencies.key:type_name -> cleanroom.v1.PolicyDependencyKey
@@ -4304,85 +4379,86 @@ var file_proto_cleanroom_v1_control_proto_depIdxs = []int32{
 	8,  // 9: cleanroom.v1.Policy.services:type_name -> cleanroom.v1.PolicyServices
 	10, // 10: cleanroom.v1.Policy.dependencies:type_name -> cleanroom.v1.PolicyDependencies
 	11, // 11: cleanroom.v1.Policy.run:type_name -> cleanroom.v1.PolicyRun
-	15, // 12: cleanroom.v1.RepositoryChangeset.files:type_name -> cleanroom.v1.RepositoryChangesetFile
-	13, // 13: cleanroom.v1.CreateSandboxRequest.options:type_name -> cleanroom.v1.SandboxOptions
-	12, // 14: cleanroom.v1.CreateSandboxRequest.policy:type_name -> cleanroom.v1.Policy
-	14, // 15: cleanroom.v1.CreateSandboxRequest.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
-	16, // 16: cleanroom.v1.CreateSandboxRequest.repository_changeset:type_name -> cleanroom.v1.RepositoryChangeset
-	4,  // 17: cleanroom.v1.CreateSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
-	1,  // 18: cleanroom.v1.CreateSandboxEvent.phase:type_name -> cleanroom.v1.CreateSandboxPhase
-	18, // 19: cleanroom.v1.CreateSandboxEvent.response:type_name -> cleanroom.v1.CreateSandboxResponse
-	59, // 20: cleanroom.v1.CreateSandboxEvent.occurred_at:type_name -> google.protobuf.Timestamp
-	4,  // 21: cleanroom.v1.GetSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
-	4,  // 22: cleanroom.v1.ListSandboxesResponse.sandboxes:type_name -> cleanroom.v1.Sandbox
-	40, // 23: cleanroom.v1.ListExecutionsResponse.executions:type_name -> cleanroom.v1.Execution
-	0,  // 24: cleanroom.v1.SandboxEvent.status:type_name -> cleanroom.v1.SandboxStatus
-	59, // 25: cleanroom.v1.SandboxEvent.occurred_at:type_name -> google.protobuf.Timestamp
-	5,  // 26: cleanroom.v1.CreateSnapshotResponse.snapshot:type_name -> cleanroom.v1.Snapshot
-	5,  // 27: cleanroom.v1.GetSnapshotResponse.snapshot:type_name -> cleanroom.v1.Snapshot
-	5,  // 28: cleanroom.v1.ListSnapshotsResponse.snapshots:type_name -> cleanroom.v1.Snapshot
-	2,  // 29: cleanroom.v1.Execution.status:type_name -> cleanroom.v1.ExecutionStatus
-	59, // 30: cleanroom.v1.Execution.started_at:type_name -> google.protobuf.Timestamp
-	59, // 31: cleanroom.v1.Execution.finished_at:type_name -> google.protobuf.Timestamp
-	3,  // 32: cleanroom.v1.Execution.kind:type_name -> cleanroom.v1.ExecutionKind
-	41, // 33: cleanroom.v1.CreateExecutionRequest.options:type_name -> cleanroom.v1.ExecutionOptions
-	3,  // 34: cleanroom.v1.CreateExecutionRequest.kind:type_name -> cleanroom.v1.ExecutionKind
-	14, // 35: cleanroom.v1.CreateExecutionRequest.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
-	40, // 36: cleanroom.v1.CreateExecutionResponse.execution:type_name -> cleanroom.v1.Execution
-	59, // 37: cleanroom.v1.AttachExecutionResponse.expires_at:type_name -> google.protobuf.Timestamp
-	40, // 38: cleanroom.v1.GetExecutionResponse.execution:type_name -> cleanroom.v1.Execution
-	40, // 39: cleanroom.v1.InspectExecutionResponse.execution:type_name -> cleanroom.v1.Execution
-	60, // 40: cleanroom.v1.InspectExecutionResponse.observability:type_name -> google.protobuf.Struct
-	2,  // 41: cleanroom.v1.CancelExecutionResponse.status:type_name -> cleanroom.v1.ExecutionStatus
-	2,  // 42: cleanroom.v1.ExecutionExit.status:type_name -> cleanroom.v1.ExecutionStatus
-	2,  // 43: cleanroom.v1.ExecutionStreamEvent.status:type_name -> cleanroom.v1.ExecutionStatus
-	57, // 44: cleanroom.v1.ExecutionStreamEvent.exit:type_name -> cleanroom.v1.ExecutionExit
-	59, // 45: cleanroom.v1.ExecutionStreamEvent.occurred_at:type_name -> google.protobuf.Timestamp
-	17, // 46: cleanroom.v1.SandboxService.CreateSandbox:input_type -> cleanroom.v1.CreateSandboxRequest
-	17, // 47: cleanroom.v1.SandboxService.CreateSandboxStream:input_type -> cleanroom.v1.CreateSandboxRequest
-	20, // 48: cleanroom.v1.SandboxService.GetSandbox:input_type -> cleanroom.v1.GetSandboxRequest
-	22, // 49: cleanroom.v1.SandboxService.ListSandboxes:input_type -> cleanroom.v1.ListSandboxesRequest
-	26, // 50: cleanroom.v1.SandboxService.DownloadSandboxFile:input_type -> cleanroom.v1.DownloadSandboxFileRequest
-	28, // 51: cleanroom.v1.SandboxService.TerminateSandbox:input_type -> cleanroom.v1.TerminateSandboxRequest
-	30, // 52: cleanroom.v1.SandboxService.StreamSandboxEvents:input_type -> cleanroom.v1.StreamSandboxEventsRequest
-	32, // 53: cleanroom.v1.SnapshotService.CreateSnapshot:input_type -> cleanroom.v1.CreateSnapshotRequest
-	34, // 54: cleanroom.v1.SnapshotService.GetSnapshot:input_type -> cleanroom.v1.GetSnapshotRequest
-	36, // 55: cleanroom.v1.SnapshotService.ListSnapshots:input_type -> cleanroom.v1.ListSnapshotsRequest
-	38, // 56: cleanroom.v1.SnapshotService.DeleteSnapshot:input_type -> cleanroom.v1.DeleteSnapshotRequest
-	24, // 57: cleanroom.v1.ExecutionService.ListExecutions:input_type -> cleanroom.v1.ListExecutionsRequest
-	42, // 58: cleanroom.v1.ExecutionService.CreateExecution:input_type -> cleanroom.v1.CreateExecutionRequest
-	44, // 59: cleanroom.v1.ExecutionService.AttachExecution:input_type -> cleanroom.v1.AttachExecutionRequest
-	46, // 60: cleanroom.v1.ExecutionService.GetExecution:input_type -> cleanroom.v1.GetExecutionRequest
-	48, // 61: cleanroom.v1.ExecutionService.InspectExecution:input_type -> cleanroom.v1.InspectExecutionRequest
-	50, // 62: cleanroom.v1.ExecutionService.CancelExecution:input_type -> cleanroom.v1.CancelExecutionRequest
-	52, // 63: cleanroom.v1.ExecutionService.WriteExecutionStdin:input_type -> cleanroom.v1.WriteExecutionStdinRequest
-	54, // 64: cleanroom.v1.ExecutionService.CloseExecutionStdin:input_type -> cleanroom.v1.CloseExecutionStdinRequest
-	56, // 65: cleanroom.v1.ExecutionService.StreamExecution:input_type -> cleanroom.v1.StreamExecutionRequest
-	18, // 66: cleanroom.v1.SandboxService.CreateSandbox:output_type -> cleanroom.v1.CreateSandboxResponse
-	19, // 67: cleanroom.v1.SandboxService.CreateSandboxStream:output_type -> cleanroom.v1.CreateSandboxEvent
-	21, // 68: cleanroom.v1.SandboxService.GetSandbox:output_type -> cleanroom.v1.GetSandboxResponse
-	23, // 69: cleanroom.v1.SandboxService.ListSandboxes:output_type -> cleanroom.v1.ListSandboxesResponse
-	27, // 70: cleanroom.v1.SandboxService.DownloadSandboxFile:output_type -> cleanroom.v1.DownloadSandboxFileResponse
-	29, // 71: cleanroom.v1.SandboxService.TerminateSandbox:output_type -> cleanroom.v1.TerminateSandboxResponse
-	31, // 72: cleanroom.v1.SandboxService.StreamSandboxEvents:output_type -> cleanroom.v1.SandboxEvent
-	33, // 73: cleanroom.v1.SnapshotService.CreateSnapshot:output_type -> cleanroom.v1.CreateSnapshotResponse
-	35, // 74: cleanroom.v1.SnapshotService.GetSnapshot:output_type -> cleanroom.v1.GetSnapshotResponse
-	37, // 75: cleanroom.v1.SnapshotService.ListSnapshots:output_type -> cleanroom.v1.ListSnapshotsResponse
-	39, // 76: cleanroom.v1.SnapshotService.DeleteSnapshot:output_type -> cleanroom.v1.DeleteSnapshotResponse
-	25, // 77: cleanroom.v1.ExecutionService.ListExecutions:output_type -> cleanroom.v1.ListExecutionsResponse
-	43, // 78: cleanroom.v1.ExecutionService.CreateExecution:output_type -> cleanroom.v1.CreateExecutionResponse
-	45, // 79: cleanroom.v1.ExecutionService.AttachExecution:output_type -> cleanroom.v1.AttachExecutionResponse
-	47, // 80: cleanroom.v1.ExecutionService.GetExecution:output_type -> cleanroom.v1.GetExecutionResponse
-	49, // 81: cleanroom.v1.ExecutionService.InspectExecution:output_type -> cleanroom.v1.InspectExecutionResponse
-	51, // 82: cleanroom.v1.ExecutionService.CancelExecution:output_type -> cleanroom.v1.CancelExecutionResponse
-	53, // 83: cleanroom.v1.ExecutionService.WriteExecutionStdin:output_type -> cleanroom.v1.WriteExecutionStdinResponse
-	55, // 84: cleanroom.v1.ExecutionService.CloseExecutionStdin:output_type -> cleanroom.v1.CloseExecutionStdinResponse
-	58, // 85: cleanroom.v1.ExecutionService.StreamExecution:output_type -> cleanroom.v1.ExecutionStreamEvent
-	66, // [66:86] is the sub-list for method output_type
-	46, // [46:66] is the sub-list for method input_type
-	46, // [46:46] is the sub-list for extension type_name
-	46, // [46:46] is the sub-list for extension extendee
-	0,  // [0:46] is the sub-list for field type_name
+	12, // 12: cleanroom.v1.Policy.resources:type_name -> cleanroom.v1.PolicyResources
+	16, // 13: cleanroom.v1.RepositoryChangeset.files:type_name -> cleanroom.v1.RepositoryChangesetFile
+	14, // 14: cleanroom.v1.CreateSandboxRequest.options:type_name -> cleanroom.v1.SandboxOptions
+	13, // 15: cleanroom.v1.CreateSandboxRequest.policy:type_name -> cleanroom.v1.Policy
+	15, // 16: cleanroom.v1.CreateSandboxRequest.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
+	17, // 17: cleanroom.v1.CreateSandboxRequest.repository_changeset:type_name -> cleanroom.v1.RepositoryChangeset
+	4,  // 18: cleanroom.v1.CreateSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
+	1,  // 19: cleanroom.v1.CreateSandboxEvent.phase:type_name -> cleanroom.v1.CreateSandboxPhase
+	19, // 20: cleanroom.v1.CreateSandboxEvent.response:type_name -> cleanroom.v1.CreateSandboxResponse
+	60, // 21: cleanroom.v1.CreateSandboxEvent.occurred_at:type_name -> google.protobuf.Timestamp
+	4,  // 22: cleanroom.v1.GetSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
+	4,  // 23: cleanroom.v1.ListSandboxesResponse.sandboxes:type_name -> cleanroom.v1.Sandbox
+	41, // 24: cleanroom.v1.ListExecutionsResponse.executions:type_name -> cleanroom.v1.Execution
+	0,  // 25: cleanroom.v1.SandboxEvent.status:type_name -> cleanroom.v1.SandboxStatus
+	60, // 26: cleanroom.v1.SandboxEvent.occurred_at:type_name -> google.protobuf.Timestamp
+	5,  // 27: cleanroom.v1.CreateSnapshotResponse.snapshot:type_name -> cleanroom.v1.Snapshot
+	5,  // 28: cleanroom.v1.GetSnapshotResponse.snapshot:type_name -> cleanroom.v1.Snapshot
+	5,  // 29: cleanroom.v1.ListSnapshotsResponse.snapshots:type_name -> cleanroom.v1.Snapshot
+	2,  // 30: cleanroom.v1.Execution.status:type_name -> cleanroom.v1.ExecutionStatus
+	60, // 31: cleanroom.v1.Execution.started_at:type_name -> google.protobuf.Timestamp
+	60, // 32: cleanroom.v1.Execution.finished_at:type_name -> google.protobuf.Timestamp
+	3,  // 33: cleanroom.v1.Execution.kind:type_name -> cleanroom.v1.ExecutionKind
+	42, // 34: cleanroom.v1.CreateExecutionRequest.options:type_name -> cleanroom.v1.ExecutionOptions
+	3,  // 35: cleanroom.v1.CreateExecutionRequest.kind:type_name -> cleanroom.v1.ExecutionKind
+	15, // 36: cleanroom.v1.CreateExecutionRequest.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
+	41, // 37: cleanroom.v1.CreateExecutionResponse.execution:type_name -> cleanroom.v1.Execution
+	60, // 38: cleanroom.v1.AttachExecutionResponse.expires_at:type_name -> google.protobuf.Timestamp
+	41, // 39: cleanroom.v1.GetExecutionResponse.execution:type_name -> cleanroom.v1.Execution
+	41, // 40: cleanroom.v1.InspectExecutionResponse.execution:type_name -> cleanroom.v1.Execution
+	61, // 41: cleanroom.v1.InspectExecutionResponse.observability:type_name -> google.protobuf.Struct
+	2,  // 42: cleanroom.v1.CancelExecutionResponse.status:type_name -> cleanroom.v1.ExecutionStatus
+	2,  // 43: cleanroom.v1.ExecutionExit.status:type_name -> cleanroom.v1.ExecutionStatus
+	2,  // 44: cleanroom.v1.ExecutionStreamEvent.status:type_name -> cleanroom.v1.ExecutionStatus
+	58, // 45: cleanroom.v1.ExecutionStreamEvent.exit:type_name -> cleanroom.v1.ExecutionExit
+	60, // 46: cleanroom.v1.ExecutionStreamEvent.occurred_at:type_name -> google.protobuf.Timestamp
+	18, // 47: cleanroom.v1.SandboxService.CreateSandbox:input_type -> cleanroom.v1.CreateSandboxRequest
+	18, // 48: cleanroom.v1.SandboxService.CreateSandboxStream:input_type -> cleanroom.v1.CreateSandboxRequest
+	21, // 49: cleanroom.v1.SandboxService.GetSandbox:input_type -> cleanroom.v1.GetSandboxRequest
+	23, // 50: cleanroom.v1.SandboxService.ListSandboxes:input_type -> cleanroom.v1.ListSandboxesRequest
+	27, // 51: cleanroom.v1.SandboxService.DownloadSandboxFile:input_type -> cleanroom.v1.DownloadSandboxFileRequest
+	29, // 52: cleanroom.v1.SandboxService.TerminateSandbox:input_type -> cleanroom.v1.TerminateSandboxRequest
+	31, // 53: cleanroom.v1.SandboxService.StreamSandboxEvents:input_type -> cleanroom.v1.StreamSandboxEventsRequest
+	33, // 54: cleanroom.v1.SnapshotService.CreateSnapshot:input_type -> cleanroom.v1.CreateSnapshotRequest
+	35, // 55: cleanroom.v1.SnapshotService.GetSnapshot:input_type -> cleanroom.v1.GetSnapshotRequest
+	37, // 56: cleanroom.v1.SnapshotService.ListSnapshots:input_type -> cleanroom.v1.ListSnapshotsRequest
+	39, // 57: cleanroom.v1.SnapshotService.DeleteSnapshot:input_type -> cleanroom.v1.DeleteSnapshotRequest
+	25, // 58: cleanroom.v1.ExecutionService.ListExecutions:input_type -> cleanroom.v1.ListExecutionsRequest
+	43, // 59: cleanroom.v1.ExecutionService.CreateExecution:input_type -> cleanroom.v1.CreateExecutionRequest
+	45, // 60: cleanroom.v1.ExecutionService.AttachExecution:input_type -> cleanroom.v1.AttachExecutionRequest
+	47, // 61: cleanroom.v1.ExecutionService.GetExecution:input_type -> cleanroom.v1.GetExecutionRequest
+	49, // 62: cleanroom.v1.ExecutionService.InspectExecution:input_type -> cleanroom.v1.InspectExecutionRequest
+	51, // 63: cleanroom.v1.ExecutionService.CancelExecution:input_type -> cleanroom.v1.CancelExecutionRequest
+	53, // 64: cleanroom.v1.ExecutionService.WriteExecutionStdin:input_type -> cleanroom.v1.WriteExecutionStdinRequest
+	55, // 65: cleanroom.v1.ExecutionService.CloseExecutionStdin:input_type -> cleanroom.v1.CloseExecutionStdinRequest
+	57, // 66: cleanroom.v1.ExecutionService.StreamExecution:input_type -> cleanroom.v1.StreamExecutionRequest
+	19, // 67: cleanroom.v1.SandboxService.CreateSandbox:output_type -> cleanroom.v1.CreateSandboxResponse
+	20, // 68: cleanroom.v1.SandboxService.CreateSandboxStream:output_type -> cleanroom.v1.CreateSandboxEvent
+	22, // 69: cleanroom.v1.SandboxService.GetSandbox:output_type -> cleanroom.v1.GetSandboxResponse
+	24, // 70: cleanroom.v1.SandboxService.ListSandboxes:output_type -> cleanroom.v1.ListSandboxesResponse
+	28, // 71: cleanroom.v1.SandboxService.DownloadSandboxFile:output_type -> cleanroom.v1.DownloadSandboxFileResponse
+	30, // 72: cleanroom.v1.SandboxService.TerminateSandbox:output_type -> cleanroom.v1.TerminateSandboxResponse
+	32, // 73: cleanroom.v1.SandboxService.StreamSandboxEvents:output_type -> cleanroom.v1.SandboxEvent
+	34, // 74: cleanroom.v1.SnapshotService.CreateSnapshot:output_type -> cleanroom.v1.CreateSnapshotResponse
+	36, // 75: cleanroom.v1.SnapshotService.GetSnapshot:output_type -> cleanroom.v1.GetSnapshotResponse
+	38, // 76: cleanroom.v1.SnapshotService.ListSnapshots:output_type -> cleanroom.v1.ListSnapshotsResponse
+	40, // 77: cleanroom.v1.SnapshotService.DeleteSnapshot:output_type -> cleanroom.v1.DeleteSnapshotResponse
+	26, // 78: cleanroom.v1.ExecutionService.ListExecutions:output_type -> cleanroom.v1.ListExecutionsResponse
+	44, // 79: cleanroom.v1.ExecutionService.CreateExecution:output_type -> cleanroom.v1.CreateExecutionResponse
+	46, // 80: cleanroom.v1.ExecutionService.AttachExecution:output_type -> cleanroom.v1.AttachExecutionResponse
+	48, // 81: cleanroom.v1.ExecutionService.GetExecution:output_type -> cleanroom.v1.GetExecutionResponse
+	50, // 82: cleanroom.v1.ExecutionService.InspectExecution:output_type -> cleanroom.v1.InspectExecutionResponse
+	52, // 83: cleanroom.v1.ExecutionService.CancelExecution:output_type -> cleanroom.v1.CancelExecutionResponse
+	54, // 84: cleanroom.v1.ExecutionService.WriteExecutionStdin:output_type -> cleanroom.v1.WriteExecutionStdinResponse
+	56, // 85: cleanroom.v1.ExecutionService.CloseExecutionStdin:output_type -> cleanroom.v1.CloseExecutionStdinResponse
+	59, // 86: cleanroom.v1.ExecutionService.StreamExecution:output_type -> cleanroom.v1.ExecutionStreamEvent
+	67, // [67:87] is the sub-list for method output_type
+	47, // [47:67] is the sub-list for method input_type
+	47, // [47:47] is the sub-list for extension type_name
+	47, // [47:47] is the sub-list for extension extendee
+	0,  // [0:47] is the sub-list for field type_name
 }
 
 func init() { file_proto_cleanroom_v1_control_proto_init() }
@@ -4390,17 +4466,17 @@ func file_proto_cleanroom_v1_control_proto_init() {
 	if File_proto_cleanroom_v1_control_proto != nil {
 		return
 	}
-	file_proto_cleanroom_v1_control_proto_msgTypes[13].OneofWrappers = []any{
+	file_proto_cleanroom_v1_control_proto_msgTypes[14].OneofWrappers = []any{
 		(*CreateSandboxRequest_SnapshotId)(nil),
 	}
-	file_proto_cleanroom_v1_control_proto_msgTypes[15].OneofWrappers = []any{
+	file_proto_cleanroom_v1_control_proto_msgTypes[16].OneofWrappers = []any{
 		(*CreateSandboxEvent_Message)(nil),
 		(*CreateSandboxEvent_Stdout)(nil),
 		(*CreateSandboxEvent_Stderr)(nil),
 		(*CreateSandboxEvent_Warning)(nil),
 		(*CreateSandboxEvent_Response)(nil),
 	}
-	file_proto_cleanroom_v1_control_proto_msgTypes[54].OneofWrappers = []any{
+	file_proto_cleanroom_v1_control_proto_msgTypes[55].OneofWrappers = []any{
 		(*ExecutionStreamEvent_Stdout)(nil),
 		(*ExecutionStreamEvent_Stderr)(nil),
 		(*ExecutionStreamEvent_Exit)(nil),
@@ -4413,7 +4489,7 @@ func file_proto_cleanroom_v1_control_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proto_cleanroom_v1_control_proto_rawDesc), len(file_proto_cleanroom_v1_control_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   55,
+			NumMessages:   56,
 			NumExtensions: 0,
 			NumServices:   3,
 		},

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -14,6 +14,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/buildkite/cleanroom/internal/bytesize"
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
 	"github.com/buildkite/cleanroom/internal/ociref"
 	"gopkg.in/yaml.v3"
@@ -38,6 +39,7 @@ type rawPolicy struct {
 		Dependencies rawDependenciesConfig `yaml:"dependencies"`
 		Run          rawRunConfig          `yaml:"run"`
 		Services     rawServices           `yaml:"services"`
+		Resources    rawResources          `yaml:"resources"`
 		Network      struct {
 			Default string         `yaml:"default"`
 			Allow   []rawAllowRule `yaml:"allow"`
@@ -81,6 +83,12 @@ type rawDockerService struct {
 	Required bool `yaml:"required"`
 }
 
+type rawResources struct {
+	VCPUs  *int64         `yaml:"vcpus"`
+	Memory *bytesize.Size `yaml:"memory"`
+	Disk   *bytesize.Size `yaml:"disk"`
+}
+
 type rawAllowRule struct {
 	Host  string `yaml:"host"`
 	Ports []int  `yaml:"ports"`
@@ -95,6 +103,7 @@ type CompiledPolicy struct {
 	Allow          []AllowRule  `json:"allow"`
 	Dependencies   Dependencies `json:"dependencies"`
 	Run            Run          `json:"run"`
+	Resources      *Resources   `json:"resources,omitempty"`
 	Hash           string       `json:"hash"`
 }
 
@@ -124,6 +133,16 @@ type Run struct {
 
 type DockerService struct {
 	Required bool `json:"required"`
+}
+
+type Resources struct {
+	VCPUs       int64 `json:"vcpus,omitempty"`
+	MemoryBytes int64 `json:"memory_bytes,omitempty"`
+	DiskBytes   int64 `json:"disk_bytes,omitempty"`
+}
+
+func (r Resources) IsZero() bool {
+	return r.VCPUs == 0 && r.MemoryBytes == 0 && r.DiskBytes == 0
 }
 
 type AllowRule struct {
@@ -250,6 +269,10 @@ func Compile(raw rawPolicy) (*CompiledPolicy, error) {
 	if err != nil {
 		return nil, err
 	}
+	resources, err := normalizeResources(raw.Sandbox.Resources, "sandbox.resources")
+	if err != nil {
+		return nil, err
+	}
 
 	compiled := &CompiledPolicy{
 		Version:        raw.Version,
@@ -260,6 +283,7 @@ func Compile(raw rawPolicy) (*CompiledPolicy, error) {
 		Allow:          allow,
 		Dependencies:   dependencies,
 		Run:            run,
+		Resources:      resources,
 	}
 
 	hash, err := hashPolicy(compiled)
@@ -478,6 +502,14 @@ func (p *CompiledPolicy) ToProto() *cleanroomv1.Policy {
 			Ports: ports,
 		})
 	}
+	var resources *cleanroomv1.PolicyResources
+	if p.Resources != nil && !p.Resources.IsZero() {
+		resources = &cleanroomv1.PolicyResources{
+			Vcpus:       p.Resources.VCPUs,
+			MemoryBytes: p.Resources.MemoryBytes,
+			DiskBytes:   p.Resources.DiskBytes,
+		}
+	}
 	return &cleanroomv1.Policy{
 		Version:     int32(p.Version),
 		ImageRef:    p.ImageRef,
@@ -503,7 +535,8 @@ func (p *CompiledPolicy) ToProto() *cleanroomv1.Policy {
 		Run: &cleanroomv1.PolicyRun{
 			Before: append([]string(nil), p.Run.Before...),
 		},
-		Hash: p.Hash,
+		Resources: resources,
+		Hash:      p.Hash,
 	}
 }
 
@@ -581,6 +614,10 @@ func FromProto(pb *cleanroomv1.Policy) (*CompiledPolicy, error) {
 	if err != nil {
 		return nil, err
 	}
+	resources, err := resourcesFromProto(pb.GetResources())
+	if err != nil {
+		return nil, err
+	}
 
 	compiled := &CompiledPolicy{
 		Version:        int(pb.GetVersion()),
@@ -591,6 +628,7 @@ func FromProto(pb *cleanroomv1.Policy) (*CompiledPolicy, error) {
 		Allow:          allow,
 		Dependencies:   dependencies,
 		Run:            run,
+		Resources:      resources,
 	}
 
 	hash, err := hashPolicy(compiled)
@@ -734,6 +772,56 @@ func runFromProto(pb *cleanroomv1.PolicyRun) (Run, error) {
 		return Run{}, err
 	}
 	return Run{Before: before}, nil
+}
+
+func normalizeResources(raw rawResources, field string) (*Resources, error) {
+	var resources Resources
+	if raw.VCPUs != nil {
+		if *raw.VCPUs <= 0 {
+			return nil, fmt.Errorf("%s.vcpus must be positive", field)
+		}
+		resources.VCPUs = *raw.VCPUs
+	}
+	if raw.Memory != nil {
+		if *raw.Memory <= 0 {
+			return nil, fmt.Errorf("%s.memory must be positive", field)
+		}
+		resources.MemoryBytes = int64(*raw.Memory)
+	}
+	if raw.Disk != nil {
+		if *raw.Disk <= 0 {
+			return nil, fmt.Errorf("%s.disk must be positive", field)
+		}
+		resources.DiskBytes = int64(*raw.Disk)
+	}
+	if resources.IsZero() {
+		return nil, nil
+	}
+	return &resources, nil
+}
+
+func resourcesFromProto(pb *cleanroomv1.PolicyResources) (*Resources, error) {
+	if pb == nil {
+		return nil, nil
+	}
+	resources := Resources{
+		VCPUs:       pb.GetVcpus(),
+		MemoryBytes: pb.GetMemoryBytes(),
+		DiskBytes:   pb.GetDiskBytes(),
+	}
+	if resources.VCPUs < 0 {
+		return nil, errors.New("policy resources.vcpus must be non-negative")
+	}
+	if resources.MemoryBytes < 0 {
+		return nil, errors.New("policy resources.memory_bytes must be non-negative")
+	}
+	if resources.DiskBytes < 0 {
+		return nil, errors.New("policy resources.disk_bytes must be non-negative")
+	}
+	if resources.IsZero() {
+		return nil, nil
+	}
+	return &resources, nil
 }
 
 func normalizeShellCommand(raw []string, field string) ([]string, error) {

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/buildkite/cleanroom/internal/bytesize"
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
 	"gopkg.in/yaml.v3"
 )
@@ -172,6 +173,59 @@ func TestCompileCapturesDockerServiceRequirement(t *testing.T) {
 	}
 	if !compiled.Services.Docker.Required {
 		t.Fatal("expected compiled policy to require docker service")
+	}
+}
+
+func TestCompileNormalizesResourceRequirements(t *testing.T) {
+	t.Parallel()
+
+	var raw rawPolicy
+	if err := yaml.Unmarshal([]byte(`
+version: 1
+sandbox:
+  image:
+    ref: ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+  resources:
+    vcpus: 4
+    memory: 12GiB
+    disk: 16GiB
+  network:
+    default: deny
+`), &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	compiled, err := Compile(raw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if compiled.Resources == nil {
+		t.Fatal("expected resource requirements")
+	}
+	if got, want := compiled.Resources.VCPUs, int64(4); got != want {
+		t.Fatalf("unexpected vcpus: got %d want %d", got, want)
+	}
+	if got, want := compiled.Resources.MemoryBytes, int64(12<<30); got != want {
+		t.Fatalf("unexpected memory bytes: got %d want %d", got, want)
+	}
+	if got, want := compiled.Resources.DiskBytes, int64(16<<30); got != want {
+		t.Fatalf("unexpected disk bytes: got %d want %d", got, want)
+	}
+}
+
+func TestCompileRejectsNonPositiveResourceRequirements(t *testing.T) {
+	t.Parallel()
+
+	raw := baseRawPolicy()
+	vcpus := int64(0)
+	raw.Sandbox.Resources.VCPUs = &vcpus
+
+	_, err := Compile(raw)
+	if err == nil {
+		t.Fatal("expected compile to reject zero vcpus")
+	}
+	if !strings.Contains(err.Error(), "sandbox.resources.vcpus") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
@@ -737,6 +791,12 @@ func TestCompiledPolicyProtoRoundTripPreservesDependenciesAndServices(t *testing
 	raw.Sandbox.Services.Command = []string{"docker", "compose", "up", "-d", "postgres"}
 	raw.Sandbox.Services.Key.Files = []string{"docker-compose.yml"}
 	raw.Sandbox.Run.Before = rawShellCommandSpec{"sh", "-lc", "bin/rails db:prepare"}
+	vcpus := int64(6)
+	memory := bytesize.Size(12 << 30)
+	disk := bytesize.Size(18 << 30)
+	raw.Sandbox.Resources.VCPUs = &vcpus
+	raw.Sandbox.Resources.Memory = &memory
+	raw.Sandbox.Resources.Disk = &disk
 	compiled, err := Compile(raw)
 	if err != nil {
 		t.Fatalf("compile: %v", err)
@@ -766,5 +826,30 @@ func TestCompiledPolicyProtoRoundTripPreservesDependenciesAndServices(t *testing
 	}
 	if got, want := strings.Join(roundTripped.Run.Before, "\x00"), strings.Join(compiled.Run.Before, "\x00"); got != want {
 		t.Fatalf("unexpected run.before after round trip: got %q want %q", got, want)
+	}
+	if roundTripped.Resources == nil {
+		t.Fatal("expected resources after round trip")
+	}
+	if got, want := *roundTripped.Resources, *compiled.Resources; got != want {
+		t.Fatalf("unexpected resources after round trip: got %#v want %#v", got, want)
+	}
+}
+
+func TestFromProtoRejectsNegativeResourceRequirements(t *testing.T) {
+	t.Parallel()
+
+	_, err := FromProto(&cleanroomv1.Policy{
+		Version:        1,
+		ImageRef:       validImageRef,
+		NetworkDefault: "deny",
+		Resources: &cleanroomv1.PolicyResources{
+			MemoryBytes: -1,
+		},
+	})
+	if err == nil {
+		t.Fatal("expected FromProto to reject negative resource requirement")
+	}
+	if !strings.Contains(err.Error(), "resources.memory_bytes") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/internal/runtimeconfig/config.go
+++ b/internal/runtimeconfig/config.go
@@ -5,17 +5,15 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math"
 	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"strings"
 	"text/template"
-	"unicode"
 
 	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/bytesize"
 	"github.com/buildkite/cleanroom/internal/endpoint"
 	"gopkg.in/yaml.v3"
 )
@@ -240,103 +238,7 @@ type DockerServiceConfig struct {
 	IPTables              bool   `yaml:"iptables"`
 }
 
-type ByteSize int64
-
-func (s *ByteSize) UnmarshalYAML(node *yaml.Node) error {
-	if node.Kind != yaml.ScalarNode {
-		return fmt.Errorf("invalid byte size node kind %v", node.Kind)
-	}
-
-	value, err := parseByteSize(node.Value)
-	if err != nil {
-		return fmt.Errorf("invalid byte size %q: %w", node.Value, err)
-	}
-	*s = ByteSize(value)
-	return nil
-}
-
-func parseByteSize(input string) (int64, error) {
-	s := strings.TrimSpace(input)
-	if s == "" {
-		return 0, errors.New("value is empty")
-	}
-
-	if value, err := strconv.ParseInt(s, 10, 64); err == nil {
-		if value < 0 {
-			return 0, errors.New("value must be non-negative")
-		}
-		return value, nil
-	}
-
-	numberEnd := strings.IndexFunc(s, func(r rune) bool {
-		return !(unicode.IsDigit(r) || r == '.')
-	})
-	if numberEnd <= 0 {
-		return 0, errors.New("missing numeric value")
-	}
-
-	numberPart := strings.TrimSpace(s[:numberEnd])
-	unitPart := strings.ToLower(strings.TrimSpace(s[numberEnd:]))
-	if numberPart == "" || unitPart == "" {
-		return 0, errors.New("size must include a number and unit")
-	}
-
-	numberValue, err := strconv.ParseFloat(numberPart, 64)
-	if err != nil {
-		return 0, fmt.Errorf("parse numeric value: %w", err)
-	}
-	if numberValue < 0 {
-		return 0, errors.New("value must be non-negative")
-	}
-
-	multiplier, ok := byteSizeMultipliers[unitPart]
-	if !ok {
-		return 0, fmt.Errorf("unsupported unit %q", unitPart)
-	}
-
-	if !strings.Contains(numberPart, ".") {
-		numberValue, err := strconv.ParseInt(numberPart, 10, 64)
-		if err != nil {
-			return 0, fmt.Errorf("parse numeric value: %w", err)
-		}
-		if numberValue < 0 {
-			return 0, errors.New("value must be non-negative")
-		}
-		if multiplier != 0 && numberValue > math.MaxInt64/multiplier {
-			return 0, errors.New("size overflows int64")
-		}
-		return numberValue * multiplier, nil
-	}
-
-	value := numberValue * float64(multiplier)
-	rounded := math.Round(value)
-	if math.Abs(value-rounded) > 1e-9 {
-		return 0, errors.New("size resolves to fractional bytes")
-	}
-	if rounded > math.MaxInt64 {
-		return 0, errors.New("size overflows int64")
-	}
-	return int64(rounded), nil
-}
-
-var byteSizeMultipliers = map[string]int64{
-	"b":   1,
-	"k":   1 << 10,
-	"kb":  1000,
-	"kib": 1 << 10,
-	"m":   1 << 20,
-	"mb":  1000 * 1000,
-	"mib": 1 << 20,
-	"g":   1 << 30,
-	"gb":  1000 * 1000 * 1000,
-	"gib": 1 << 30,
-	"t":   1 << 40,
-	"tb":  1000 * 1000 * 1000 * 1000,
-	"tib": 1 << 40,
-	"p":   1 << 50,
-	"pb":  1000 * 1000 * 1000 * 1000 * 1000,
-	"pib": 1 << 50,
-}
+type ByteSize = bytesize.Size
 
 var (
 	runtimeconfigUserHomeDir = os.UserHomeDir

--- a/proto/cleanroom/v1/control.proto
+++ b/proto/cleanroom/v1/control.proto
@@ -100,6 +100,12 @@ message PolicyRun {
   repeated string before = 1;
 }
 
+message PolicyResources {
+  int64 vcpus = 1;
+  int64 memory_bytes = 2;
+  int64 disk_bytes = 3;
+}
+
 message Policy {
   int32 version = 1;
   string image_ref = 2;
@@ -110,6 +116,7 @@ message Policy {
   PolicyServices services = 7;
   PolicyDependencies dependencies = 9;
   PolicyRun run = 10;
+  PolicyResources resources = 11;
 }
 
 message SandboxOptions {


### PR DESCRIPTION
## Summary

- Add backend-neutral `sandbox.resources` policy config for required `vcpus`, `memory`, and `disk` values in `cleanroom.yaml`.
- Compile resource requirements through policy/proto/client types and apply them when creating sandboxes or restoring stored rootfs sandboxes.
- Share byte-size parsing with runtime config and update README, spec docs, and examples.

## Validation

- `mise exec -- buf generate`
- `mise exec -- go test ./...`
- `mise exec -- go run ./cmd/cleanroom policy validate -c examples/basic`
- `mise exec -- go run ./cmd/cleanroom policy validate -c examples/docker`
- `mise exec -- go run ./cmd/cleanroom policy validate -c examples/rails`
- `mise exec -- go run ./cmd/cleanroom policy validate -c examples/buildkite-agent`
- `git diff --check`

Note: `mise exec -- buf lint` still reports existing repo-wide proto lint issues around package directory layout and RPC request/response naming.