### PR TITLE
fix: Preserve copy-out file metadata

### DIFF
--- a/docs/plans/sandbox-transfer-invariants.md
+++ b/docs/plans/sandbox-transfer-invariants.md
@@ -77,6 +77,8 @@ after these invariants are stable.
 - Local destination symlink chains are followed with a bounded hop count.
 - Dangling local destination symlinks materialize their target path.
 - Local destination symlink loops fail cleanly.
+- Copying a sandbox file to a local file preserves the sandbox file mode and
+  mtime.
 
 ### CLI copy behavior
 

--- a/internal/cli/copy.go
+++ b/internal/cli/copy.go
@@ -71,6 +71,10 @@ func (c *CopyCommand) copyFromSandbox(ctx *runtimeContext, remote *copyRemotePat
 	if err != nil {
 		return err
 	}
+	sourceInfo, err := sandboxSourceFileInfo(context.Background(), client, remote.sandboxID, remote.path)
+	if err != nil {
+		return fmt.Errorf("stat sandbox source: %w", err)
+	}
 	if err := os.MkdirAll(filepath.Dir(installDestination), 0o755); err != nil {
 		return fmt.Errorf("create local destination parent: %w", err)
 	}
@@ -106,6 +110,9 @@ func (c *CopyCommand) copyFromSandbox(ctx *runtimeContext, remote *copyRemotePat
 	}
 	if err := tmp.Close(); err != nil {
 		return fmt.Errorf("close local temporary file: %w", err)
+	}
+	if err := applyLocalCopyMetadata(tmpPath, sourceInfo); err != nil {
+		return err
 	}
 	if err := os.Rename(tmpPath, installDestination); err != nil {
 		return fmt.Errorf("install local file: %w", err)
@@ -189,6 +196,59 @@ func (c *CopyCommand) copyToSandbox(ctx *runtimeContext, localPath string, remot
 	_, err = stream.CloseAndReceive()
 	if err != nil {
 		return fmt.Errorf("write sandbox file: %w", err)
+	}
+	return nil
+}
+
+func sandboxSourceFileInfo(ctx context.Context, client *controlclient.Client, sandboxID, remotePath string) (*cleanroomv1.SandboxPathInfo, error) {
+	current := remotePath
+	seen := map[string]struct{}{}
+	for range 40 {
+		if _, ok := seen[current]; ok {
+			return nil, fmt.Errorf("remote source symlink cycle at %q", remotePath)
+		}
+		seen[current] = struct{}{}
+		statResp, err := client.StatSandboxPath(ctx, &cleanroomv1.StatSandboxPathRequest{
+			SandboxId: sandboxID,
+			Path:      current,
+		})
+		if err != nil {
+			return nil, err
+		}
+		info := statResp.GetInfo()
+		switch info.GetType() {
+		case cleanroomv1.SandboxPathType_SANDBOX_PATH_TYPE_FILE:
+			return info, nil
+		case cleanroomv1.SandboxPathType_SANDBOX_PATH_TYPE_SYMLINK:
+			target := resolveRemoteSymlinkTarget(current, info.GetSymlinkTarget())
+			if target == "" {
+				return nil, fmt.Errorf("remote source symlink at %q has empty target", current)
+			}
+			current = target
+		case cleanroomv1.SandboxPathType_SANDBOX_PATH_TYPE_DIRECTORY:
+			return nil, fmt.Errorf("remote source %q is a directory; copy supports files", remotePath)
+		default:
+			return nil, fmt.Errorf("remote source %q is not a file", remotePath)
+		}
+	}
+	return nil, fmt.Errorf("remote source symlink chain too deep at %q", remotePath)
+}
+
+func applyLocalCopyMetadata(path string, info *cleanroomv1.SandboxPathInfo) error {
+	if info == nil {
+		return errors.New("missing sandbox source metadata")
+	}
+	if mtime := info.GetMtime(); mtime != nil {
+		if err := mtime.CheckValid(); err != nil {
+			return fmt.Errorf("invalid sandbox source mtime: %w", err)
+		}
+		t := mtime.AsTime()
+		if err := os.Chtimes(path, t, t); err != nil {
+			return fmt.Errorf("apply local file mtime: %w", err)
+		}
+	}
+	if err := os.Chmod(path, os.FileMode(info.GetMode()).Perm()); err != nil {
+		return fmt.Errorf("apply local file mode: %w", err)
 	}
 	return nil
 }

--- a/internal/cli/copy_test.go
+++ b/internal/cli/copy_test.go
@@ -75,6 +75,7 @@ func TestCopyCommandRejectsRemoteToRemote(t *testing.T) {
 func TestCopyFromSandboxWritesLocalFile(t *testing.T) {
 	payload := []byte{0, 1, 'h', 'i', '\n'}
 	adapter := &copyIntegrationAdapter{
+		statFn: copyTestSandboxFileStat(0o644, time.Time{}),
 		readFn: func(_ context.Context, sandboxID, path string, maxBytes int64, emit func([]byte) error) error {
 			if strings.TrimSpace(sandboxID) == "" {
 				t.Fatal("expected sandbox id")
@@ -118,8 +119,117 @@ func TestCopyFromSandboxWritesLocalFile(t *testing.T) {
 	}
 }
 
+func TestCopyFromSandboxPreservesRemoteModeAndMtime(t *testing.T) {
+	payload := []byte("payload")
+	mtime := time.Unix(1700000123, 0)
+	adapter := &copyIntegrationAdapter{
+		statFn: copyTestSandboxFileStat(0o640, mtime),
+		readFn: func(_ context.Context, _ string, _ string, _ int64, emit func([]byte) error) error {
+			return emit(payload)
+		},
+	}
+	host, _ := startIntegrationServer(t, adapter)
+	sandboxID := createCopyTestSandbox(t, host)
+	dest := filepath.Join(t.TempDir(), "artifact.txt")
+	stdout, _ := makeStdoutCapture(t)
+	stderr, _ := makeStdoutCapture(t)
+
+	cmd := CopyCommand{
+		clientFlags: clientFlags{Host: host},
+		Source:      sandboxID + ":/tmp/artifact.txt",
+		Destination: dest,
+	}
+	if err := cmd.Run(&runtimeContext{
+		Config:        runtimeconfig.Config{},
+		Observability: newTestObservability(t),
+		Stdout:        stdout,
+		Stderr:        stderr,
+	}); err != nil {
+		t.Fatalf("CopyCommand.Run returned error: %v", err)
+	}
+
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read copied file: %v", err)
+	}
+	if !bytes.Equal(data, payload) {
+		t.Fatalf("unexpected copied data: got %q want %q", data, payload)
+	}
+	info, err := os.Stat(dest)
+	if err != nil {
+		t.Fatalf("stat copied file: %v", err)
+	}
+	if got, want := info.Mode().Perm(), fs.FileMode(0o640); got != want {
+		t.Fatalf("unexpected copied mode: got %04o want %04o", got, want)
+	}
+	if got, want := info.ModTime().Unix(), mtime.Unix(); got != want {
+		t.Fatalf("unexpected copied mtime: got %d want %d", got, want)
+	}
+}
+
+func TestCopyFromSandboxUsesRemoteSymlinkTargetMetadata(t *testing.T) {
+	payload := []byte("payload")
+	mtime := time.Unix(1700000456, 0)
+	var statPaths []string
+	var readPath string
+	adapter := &copyIntegrationAdapter{
+		statFn: func(_ context.Context, _ string, path string) (*backend.SandboxPathInfo, error) {
+			statPaths = append(statPaths, path)
+			switch path {
+			case "/tmp/link.txt":
+				return &backend.SandboxPathInfo{Path: path, Type: backend.SandboxPathTypeSymlink, SymlinkTarget: "target.txt"}, nil
+			case "/tmp/target.txt":
+				return &backend.SandboxPathInfo{Path: path, Type: backend.SandboxPathTypeFile, Mode: 0o600, MTime: mtime}, nil
+			default:
+				return nil, backend.NewSandboxPathNotFoundError(path)
+			}
+		},
+		readFn: func(_ context.Context, _ string, path string, _ int64, emit func([]byte) error) error {
+			readPath = path
+			return emit(payload)
+		},
+	}
+	host, _ := startIntegrationServer(t, adapter)
+	sandboxID := createCopyTestSandbox(t, host)
+	dest := filepath.Join(t.TempDir(), "artifact.txt")
+	stdout, _ := makeStdoutCapture(t)
+	stderr, _ := makeStdoutCapture(t)
+
+	cmd := CopyCommand{
+		clientFlags: clientFlags{Host: host},
+		Source:      sandboxID + ":/tmp/link.txt",
+		Destination: dest,
+	}
+	if err := cmd.Run(&runtimeContext{
+		Config:        runtimeconfig.Config{},
+		Observability: newTestObservability(t),
+		Stdout:        stdout,
+		Stderr:        stderr,
+	}); err != nil {
+		t.Fatalf("CopyCommand.Run returned error: %v", err)
+	}
+
+	if got, want := strings.Join(statPaths, ","), "/tmp/link.txt,/tmp/target.txt"; got != want {
+		t.Fatalf("unexpected stat paths: got %q want %q", got, want)
+	}
+	if got, want := readPath, "/tmp/link.txt"; got != want {
+		t.Fatalf("unexpected read path: got %q want %q", got, want)
+	}
+	info, err := os.Stat(dest)
+	if err != nil {
+		t.Fatalf("stat copied file: %v", err)
+	}
+	if got, want := info.Mode().Perm(), fs.FileMode(0o600); got != want {
+		t.Fatalf("unexpected copied mode: got %04o want %04o", got, want)
+	}
+	if got, want := info.ModTime().Unix(), mtime.Unix(); got != want {
+		t.Fatalf("unexpected copied mtime: got %d want %d", got, want)
+	}
+}
+
 func TestCopyFromSandboxUsesRemoteBasenameForLocalDirectory(t *testing.T) {
 	adapter := &copyIntegrationAdapter{
+		statFn: copyTestSandboxFileStat(0o644, time.Time{}),
 		readFn: func(_ context.Context, _ string, _ string, _ int64, emit func([]byte) error) error {
 			return emit([]byte("payload"))
 		},
@@ -156,6 +266,7 @@ func TestCopyFromSandboxUsesRemoteBasenameForLocalDirectory(t *testing.T) {
 func TestCopyFromSandboxPreservesLocalDestinationSymlink(t *testing.T) {
 	payload := []byte("payload")
 	adapter := &copyIntegrationAdapter{
+		statFn: copyTestSandboxFileStat(0o644, time.Time{}),
 		readFn: func(_ context.Context, _ string, _ string, _ int64, emit func([]byte) error) error {
 			return emit(payload)
 		},
@@ -207,6 +318,7 @@ func TestCopyFromSandboxPreservesLocalDestinationSymlink(t *testing.T) {
 func TestCopyFromSandboxPreservesLocalDestinationSymlinkChain(t *testing.T) {
 	payload := []byte("payload")
 	adapter := &copyIntegrationAdapter{
+		statFn: copyTestSandboxFileStat(0o644, time.Time{}),
 		readFn: func(_ context.Context, _ string, _ string, _ int64, emit func([]byte) error) error {
 			return emit(payload)
 		},
@@ -264,6 +376,7 @@ func TestCopyFromSandboxPreservesLocalDestinationSymlinkChain(t *testing.T) {
 func TestCopyFromSandboxWritesThroughDanglingLocalDestinationSymlink(t *testing.T) {
 	payload := []byte("payload")
 	adapter := &copyIntegrationAdapter{
+		statFn: copyTestSandboxFileStat(0o644, time.Time{}),
 		readFn: func(_ context.Context, _ string, _ string, _ int64, emit func([]byte) error) error {
 			return emit(payload)
 		},
@@ -777,6 +890,7 @@ func TestCopyToSandboxRejectsSlashSuffixedRemoteSymlinkCycle(t *testing.T) {
 
 func TestCopyFromSandboxReturnsDownloadError(t *testing.T) {
 	adapter := &copyIntegrationAdapter{
+		statFn: copyTestSandboxFileStat(0o644, time.Time{}),
 		readFn: func(context.Context, string, string, int64, func([]byte) error) error {
 			return errors.New("cat: missing")
 		},
@@ -847,6 +961,18 @@ func (a *copyIntegrationAdapter) WriteSandboxFile(ctx context.Context, sandboxID
 		return a.writeFn(ctx, sandboxID, path, r, mode, mtime)
 	}
 	return 0, errors.New("write not configured")
+}
+
+func copyTestSandboxFileStat(mode fs.FileMode, mtime time.Time) func(context.Context, string, string) (*backend.SandboxPathInfo, error) {
+	return func(_ context.Context, _ string, path string) (*backend.SandboxPathInfo, error) {
+		return &backend.SandboxPathInfo{
+			Path:      path,
+			Type:      backend.SandboxPathTypeFile,
+			Mode:      mode,
+			MTime:     mtime,
+			SizeBytes: 7,
+		}, nil
+	}
 }
 
 func createCopyTestSandbox(t *testing.T, host string) string {


### PR DESCRIPTION
## Summary

- preserves remote file mode and mtime when copying from a sandbox to a local file
- follows remote symlink sources to the final file for metadata while still reading the original path
- updates the transfer invariant plan and adds copy-out metadata regression coverage

## Validation

- `mise exec -- go test ./internal/cli -run 'TestCopy'`
- `mise exec -- go test ./internal/cli ./internal/controlservice ./internal/backend`
- `mise exec -- go test ./...`
- built a temporary CLI and manually verified copy-out preserves mode and mtime against the installed daemon on a disposable `darwin-vz` sandbox
