### PR TITLE
fix: Harden backend cleanup validation

### DIFF
--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -2114,9 +2114,13 @@ func preparedRuntimeRootFSMarkerStateForPath(path string) (preparedRuntimeRootFS
 	}
 	return preparedRuntimeRootFSMarkerState{
 		size:            stat.Size,
-		modTimeNanos:    stat.Mtim.Nano(),
-		changeTimeNanos: stat.Ctim.Nano(),
+		modTimeNanos:    timespecUnixNano(stat.Mtim),
+		changeTimeNanos: timespecUnixNano(stat.Ctim),
 	}, nil
+}
+
+func timespecUnixNano(ts unix.Timespec) int64 {
+	return time.Unix(ts.Sec, ts.Nsec).UnixNano()
 }
 
 func preparedRuntimeRootFSMarkerMatches(path string) bool {

--- a/internal/backend/darwinvz/rootfs_cache_marker_test.go
+++ b/internal/backend/darwinvz/rootfs_cache_marker_test.go
@@ -4,9 +4,11 @@ package darwinvz
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestPreparedRuntimeRootFSCacheHitUsesValidMarkerWithoutExt4Validation(t *testing.T) {
@@ -116,6 +118,37 @@ func TestPreparedRuntimeRootFSCacheHitRevalidatesWhenContentsChangeWithPreserved
 	}
 	if !preparedRuntimeRootFSMarkerMatches(rootFSPath) {
 		t.Fatal("expected refreshed marker to match mutated rootfs")
+	}
+}
+
+func TestPreparedRuntimeRootFSMarkerRejectsSubsecondOnlyTimestampMatch(t *testing.T) {
+	rootFSPath := writeTestPreparedRootFS(t, "prepared-rootfs")
+	const nsec = int64(123456789)
+	oldModTime := time.Unix(1_700_000_000, nsec)
+	newModTime := time.Unix(1_700_000_001, nsec)
+	if err := os.Chtimes(rootFSPath, oldModTime, oldModTime); err != nil {
+		t.Fatalf("set initial prepared rootfs timestamps: %v", err)
+	}
+	if err := os.Chtimes(rootFSPath, newModTime, newModTime); err != nil {
+		t.Fatalf("preserve prepared rootfs nsec while changing seconds: %v", err)
+	}
+
+	state, err := preparedRuntimeRootFSMarkerStateForPath(rootFSPath)
+	if err != nil {
+		t.Fatalf("stat prepared rootfs marker state: %v", err)
+	}
+	oldStyleContent := fmt.Sprintf("%s\n%d\n%d\n%d\n",
+		preparedRuntimeRootFSMarkerVersion,
+		state.size,
+		nsec,
+		state.changeTimeNanos%int64(time.Second),
+	)
+	if err := os.WriteFile(preparedRuntimeRootFSMarkerPath(rootFSPath), []byte(oldStyleContent), 0o644); err != nil {
+		t.Fatalf("write old-style prepared rootfs marker: %v", err)
+	}
+
+	if preparedRuntimeRootFSMarkerMatches(rootFSPath) {
+		t.Fatal("expected subsecond-only marker to be stale after timestamp seconds changed")
 	}
 }
 

--- a/internal/backend/firecracker/host_network.go
+++ b/internal/backend/firecracker/host_network.go
@@ -80,11 +80,11 @@ func setupHostNetworkWithTrustedDNSFactoryAndLogger(ctx context.Context, runID s
 	setupRun := func(args ...string) error {
 		return runner.Run(ctx, args...)
 	}
-	cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), networkCleanupTimeout)
 	cleanupCmds := make([][]string, 0, 16)
 	trustedDNSCleanup := func() {}
 	nflogCleanupFn := func() {}
 	cleanup := func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), networkCleanupTimeout)
 		defer cleanupCancel()
 		nflogCleanupFn()
 		trustedDNSCleanup()
@@ -104,6 +104,9 @@ func setupHostNetworkWithTrustedDNSFactoryAndLogger(ctx context.Context, runID s
 		cleanupCmds = append(cleanupCmds, append([]string(nil), args...))
 	}
 	removeNFLogRule := func(tapName, groupStr string) {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), networkCleanupTimeout)
+		defer cleanupCancel()
+
 		args := []string{"iptables", "-D", "FORWARD", "-i", tapName, "-j", "NFLOG", "--nflog-group", groupStr}
 		if err := runner.Run(cleanupCtx, args...); err != nil {
 			networkLogger.Warn("nflog iptables cleanup failed", "tap_name", tapName, "error", err)

--- a/internal/backend/firecracker/network_test.go
+++ b/internal/backend/firecracker/network_test.go
@@ -197,6 +197,7 @@ func TestSetupHostNetworkWithDepsAddsDenyDefaultAndCleanupIndependentContext(t *
 		t.Fatalf("setupHostNetworkWithTrustedDNSFactory: %v", err)
 	}
 	cancel()
+	time.Sleep(networkCleanupTimeout + 50*time.Millisecond)
 	cleanup()
 
 	tap := cfg.TapName


### PR DESCRIPTION
## Summary
- create Firecracker network cleanup timeouts when teardown runs, including the NFLOG retry cleanup path
- store full Unix nanosecond mtime and ctime values in Darwin prepared-rootfs validation markers
- add regression coverage for long-lived Firecracker cleanup and subsecond-only Darwin marker matches

## Tests
- `git diff --check`
- `mise exec -- go test ./internal/backend/firecracker ./internal/backend/darwinvz`
- `mise exec -- go test ./...`