### PR TITLE
fix: Allow darwin-vz allow-all sandboxes

### DIFF
--- a/docs/backend/darwin-vz.md
+++ b/docs/backend/darwin-vz.md
@@ -18,6 +18,7 @@ Implemented:
 - helper-managed VM lifecycle (`StartVM` / `StopVM` / `PauseVM` / `ResumeVM`)
 - `filehandle` network mode with a Cleanroom-owned guest gateway and stable guest IP
 - TCP allowlist egress filtering for `sandbox.network.allow` in `filehandle` mode
+- allow-all egress for repo-agnostic sandboxes created with `cleanroom sandbox create --dangerously-allow-all`
 - hostname-based allow rules currently use observed DNS answers plus destination IP:port, so co-hosted services on the same IP:port are not distinguished
 - guest access to the shared host gateway through the stable hostname `gateway.cleanroom.internal`
 - managed kernel fallback when `kernel_image` is unset or missing
@@ -125,6 +126,7 @@ On macOS, cleanroom also probes common Homebrew `e2fsprogs` locations.
   - runs a Cleanroom-owned guest gateway on the gateway IP, typically `10.233.0.1`
   - serves guest DNS from that gateway IP
   - enforces `sandbox.network.allow` for TCP egress in the gateway
+  - bypasses egress filtering when the compiled policy uses `network.default=allow`
   - authorizes hostname rules from observed DNS answers plus destination IP:port rather than HTTP `Host` or TLS SNI
   - exposes the shared host gateway service to the guest at `gateway.cleanroom.internal`
 

--- a/internal/backend/darwinvz/filehandle_gateway.go
+++ b/internal/backend/darwinvz/filehandle_gateway.go
@@ -246,8 +246,8 @@ func newFileHandleDNSRuntime(sandboxID string, compiled *policy.CompiledPolicy) 
 	if compiled == nil {
 		return nil, nil
 	}
-	if strings.TrimSpace(compiled.NetworkDefault) != "deny" {
-		return nil, fmt.Errorf("darwin-vz backend requires deny-by-default policy, got %q", compiled.NetworkDefault)
+	if _, err := evaluateNetworkPolicyForRun(compiled.NetworkDefault, len(compiled.Allow), true); err != nil {
+		return nil, err
 	}
 	sandboxID = strings.TrimSpace(sandboxID)
 	if sandboxID == "" {

--- a/internal/backend/darwinvz/filehandle_gateway_test.go
+++ b/internal/backend/darwinvz/filehandle_gateway_test.go
@@ -137,6 +137,20 @@ func TestNewFileHandleDNSRuntimeRequiresSandboxIDWhenPolicyPresent(t *testing.T)
 	}
 }
 
+func TestNewFileHandleDNSRuntimeAcceptsAllowDefaultPolicy(t *testing.T) {
+	t.Parallel()
+
+	runtime, err := newFileHandleDNSRuntime("sandbox-1", &policy.CompiledPolicy{
+		NetworkDefault: "allow",
+	})
+	if err != nil {
+		t.Fatalf("newFileHandleDNSRuntime returned error: %v", err)
+	}
+	if !runtime.HostAllowedByPolicy("sandbox-1", "example.com") {
+		t.Fatal("expected allow-default policy to allow arbitrary hosts")
+	}
+}
+
 func TestResolveFileHandleDNSUpstreamAddrUsesConfiguredValue(t *testing.T) {
 	t.Parallel()
 

--- a/internal/backend/darwinvz/policy.go
+++ b/internal/backend/darwinvz/policy.go
@@ -21,10 +21,14 @@ func evaluateNetworkPolicyForRun(networkDefault string, allowCount int, allowlis
 
 func evaluateNetworkPolicy(networkDefault string, allowCount int, allowlistSupported, requireAllowlistEnforcement bool) (string, error) {
 	_, _ = allowCount, requireAllowlistEnforcement
-	if strings.TrimSpace(networkDefault) != "deny" {
-		return "", fmt.Errorf("darwin-vz backend requires deny-by-default policy, got %q", networkDefault)
+	switch strings.TrimSpace(strings.ToLower(networkDefault)) {
+	case "deny":
+		return "", nil
+	case "allow":
+		return guestNetworkUnavailableWarning, nil
+	default:
+		return "", fmt.Errorf("darwin-vz backend requires network.default=deny or allow, got %q", networkDefault)
 	}
-	return "", nil
 }
 
 func allowlistSupportForConfig(cfg backend.FirecrackerConfig) (supported bool, detail, protectionMessage string, err error) {

--- a/internal/backend/darwinvz/policy_test.go
+++ b/internal/backend/darwinvz/policy_test.go
@@ -7,16 +7,13 @@ import (
 	"github.com/buildkite/cleanroom/internal/backend"
 )
 
-func TestEvaluateNetworkPolicyRequiresDenyDefault(t *testing.T) {
+func TestEvaluateNetworkPolicyAllowsAllowDefaultWithWarning(t *testing.T) {
 	warn, err := evaluateNetworkPolicyForRun("allow", 0, false)
-	if err == nil {
-		t.Fatal("expected error for non-deny network default")
+	if err != nil {
+		t.Fatalf("unexpected error for allow network default: %v", err)
 	}
-	if !strings.Contains(err.Error(), "deny-by-default") {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if warn != "" {
-		t.Fatalf("expected empty warning, got %q", warn)
+	if !strings.Contains(warn, "without host-side egress filtering") {
+		t.Fatalf("expected allow-default warning, got %q", warn)
 	}
 }
 

--- a/internal/dnsproxy/runtime.go
+++ b/internal/dnsproxy/runtime.go
@@ -330,6 +330,9 @@ func (r *Runtime) AllowConnection(conn Connection, now time.Time) bool {
 	if !ok {
 		return false
 	}
+	if state.allowsAllConnections() {
+		return true
+	}
 
 	key := connectionKey{
 		sourceIP:   conn.SourceIP,
@@ -516,6 +519,10 @@ func (s *sandboxState) observationAllowsPort(observation Observation, port int) 
 		return true
 	}
 	return false
+}
+
+func (s *sandboxState) allowsAllConnections() bool {
+	return s != nil && s.policy != nil && strings.TrimSpace(strings.ToLower(s.policy.NetworkDefault)) == "allow"
 }
 
 func (s *sandboxState) observationAllowedPorts(observation Observation) []int {

--- a/internal/dnsproxy/runtime_test.go
+++ b/internal/dnsproxy/runtime_test.go
@@ -103,6 +103,29 @@ func TestRuntimeAllowsConnectionFromObservedAllowedAddress(t *testing.T) {
 	}
 }
 
+func TestRuntimeAllowDefaultPermitsConnectionWithoutDNSObservation(t *testing.T) {
+	t.Parallel()
+
+	runtime := NewRuntime(RuntimeConfig{})
+	if err := runtime.RegisterSandbox("sandbox-1", &policy.CompiledPolicy{
+		Version:        1,
+		NetworkDefault: "allow",
+	}); err != nil {
+		t.Fatalf("register sandbox: %v", err)
+	}
+
+	if !runtime.AllowConnection(Connection{
+		SandboxID:  "sandbox-1",
+		SourceIP:   netip.MustParseAddr("10.0.0.2"),
+		SourcePort: 40000,
+		DestIP:     netip.MustParseAddr("93.184.216.34"),
+		DestPort:   443,
+		Protocol:   ProtocolTCP,
+	}, time.Date(2026, time.April, 27, 10, 0, 0, 0, time.UTC)) {
+		t.Fatal("expected allow-default policy to permit arbitrary connection")
+	}
+}
+
 func TestRuntimeHonoursMinimumTTLAcrossCNAMEChainAndKeepsEstablishedConnections(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Allow the `darwin-vz` backend to accept compiled `network.default=allow` policies.
- Teach the filehandle DNS/TCP runtime to permit allow-default connections without requiring prior DNS observations.
- Document the darwin-vz allow-all behavior and cover it with backend/runtime tests.

## Root cause

`cleanroom sandbox create --dangerously-allow-all` correctly synthesizes a repo-agnostic policy with `network.default=allow`, but `darwin-vz` still rejected non-deny policies before provisioning. Even if accepted, its DNS/TCP runtime only authorized connections from observed allowlist DNS entries, so allow-default needed an explicit bypass.

## Validation

```sh
GOTOOLCHAIN=local /Users/lachlan/.local/share/mise/installs/go/1.26.2/bin/go test ./...
```