### PR TITLE
feat: Add workspace copy-in command

### DIFF
--- a/docs/plans/layered-caching.md
+++ b/docs/plans/layered-caching.md
@@ -152,7 +152,7 @@ This phase now means:
   `cachestore`
 - one writable-root-volume preparation path for Firecracker normal execution
   and snapshot restore
-- request-scoped `--include-local-changes` packaging and replay after exact
+- request-scoped `--copy-in` packaging and replay after exact
   repository checkout
 - durable host-local `changesetstore` metadata and payload storage for
   explicit repository changesets, with stage-cache metadata recording the
@@ -279,7 +279,7 @@ The user-facing restore/fork surface should remain snapshot-oriented:
 - normal sandbox creation should resolve system stage caches automatically from
   request inputs
 - explicit local changes should use a separate changeset surface such as
-  `--changeset` or `--include-local-changes`, not snapshot restore semantics
+  `--changeset` or `--copy-in`, not snapshot restore semantics
 - if direct stage-cache selection is ever exposed, it should use a separate
   operator/debug surface rather than sharing snapshot semantics
 

--- a/docs/plans/sandbox-transfer-invariants.md
+++ b/docs/plans/sandbox-transfer-invariants.md
@@ -1,14 +1,14 @@
 # Sandbox Transfer Invariants
 
 **Status:** Stabilization plan
-**Last reviewed:** 2026-04-26
+**Last reviewed:** 2026-04-28
 
 ## Summary
 
 Cleanroom now has explicit primitives for moving files and archive payloads into
 and out of persistent sandboxes. These primitives are intended to be the
 substrate for one-off `cleanroom copy` usage first, and later for faster
-workspace sync, diff, and export workflows.
+workspace copy-in, copy-out, diff, and sync workflows.
 
 The transfer layer should stay backend-neutral above the final command-runner
 boundary. Firecracker and Darwin-VZ can differ in how they execute a guest
@@ -30,9 +30,9 @@ The current transfer surface covers:
   one sandbox file to local path
 
 The current surface does not cover recursive local directory upload,
-sandbox-to-sandbox copy, full workspace sync, conflict detection, rsync-style
-delete behavior, or patch/diff generation. Those should build on this layer
-after these invariants are stable.
+sandbox-to-sandbox copy, full workspace copy-in/copy-out automation, conflict
+detection, rsync-style delete behavior, or patch/diff generation. Those should
+build on this layer after these invariants are stable.
 
 ## Required Invariants
 
@@ -144,7 +144,8 @@ CLI tests should cover:
 
 ## Delivery Guidance
 
-Do not broaden this PR into workspace sync. The stabilization target is a small,
-well-defined transfer layer whose behavior is hard to regress. Once this matrix
-is covered, workspace sync can layer higher-level planning, change detection,
-and delete behavior on top without reopening backend copy semantics.
+Do not broaden this PR into workspace copy-in/copy-out automation. The
+stabilization target is a small, well-defined transfer layer whose behavior is
+hard to regress. Once this matrix is covered, workspace copy-in/copy-out can
+layer higher-level planning, change detection, and delete behavior on top
+without reopening backend copy semantics.

--- a/docs/plans/workspace-sync.md
+++ b/docs/plans/workspace-sync.md
@@ -11,9 +11,9 @@ Replace the current `--include-local-changes` UX with a clearer `--copy` flag
 and add explicit workspace copy/export primitives for the common "edit
 locally, run in Cleanroom, bring changes back" workflow.
 
-In this plan, "workspace" means the project tree inside the cleanroom,
-normally `/workspace`. It does not mean the full sandbox filesystem, and it
-does not create a host mount.
+In this plan, "workspace" means the project tree inside the cleanroom at the
+resolved repository path, normally `/workspace`. It does not mean the full
+sandbox filesystem, and it does not create a host mount.
 
 The user-facing workspace vocabulary is:
 
@@ -60,19 +60,22 @@ cleanroom exec --sync -- npm run generate
 
 Top-level flags:
 
-- `--copy` copies local workspace changes into `/workspace` before running.
-  It is automation over the same operation as `cleanroom workspace copy`.
-- `--export-on-exit` exports the included `/workspace` file set back into the
-  local workspace after the command or console session exits.
+- `--copy` copies local workspace changes into the sandbox workspace before
+  running. It is automation over the same operation as
+  `cleanroom workspace copy`.
+- `--export-on-exit` exports the included sandbox workspace file set back into
+  the local workspace after the command or console session exits.
 - `--sync` is equivalent to `--copy --export-on-exit`.
 
 ## Goals
 
 - Make local development workflows feel direct: edits made locally appear in
-  `/workspace`, and useful changes made in `/workspace` can come back.
+  the sandbox workspace, and useful changes made there can come back.
 - Keep CI and hermetic workflows explicit and available.
-- Keep `/workspace` copy/export behavior as command primitives that can be
-  used manually and by top-level automation.
+- Keep workspace copy/export behavior as command primitives that can be used
+  manually and by top-level automation.
+- Support custom `repository.path` values rather than hardcoding workspace
+  operations to `/workspace`.
 - Keep ordinary `exec`, `console`, and `create` startup fast by avoiding
   implicit whole-tree copy operations.
 - Replace `--include-local-changes` with `--copy` instead of carrying both
@@ -97,6 +100,10 @@ Top-level flags:
 - Making `cleanroom sandbox create` infer repository policy or local workspace
   state.
 - Exporting ignored workspace artifacts by default.
+- Adding an export conflict override such as `--force` or `--overwrite` in the
+  MVP.
+- Supporting arbitrary local export roots in the MVP.
+- Running export automatically from `cleanroom sandbox rm`.
 - Replacing artifact upload/download APIs for non-workspace build outputs.
 - Requiring the guest image to provide the `rsync` binary.
 
@@ -114,8 +121,8 @@ cleanroom cp <sandbox-id>:/absolute/path <local-file-or-directory>
 It is intentionally not a workspace lifecycle command. Current behavior is
 scoped to one local file to one sandbox path, or one sandbox file to one local
 path. Recursive local directory upload, workspace baselines, conflict
-detection, dry-run export planning, and `/workspace` mirror semantics are out
-of scope for `cp`.
+detection, dry-run export planning, and workspace mirror semantics are out of
+scope for `cp`.
 
 Workspace commands should use a shared workspace planner with
 workspace-specific safety semantics. The planner selects the transport from
@@ -127,6 +134,11 @@ the source workspace:
 
 Top-level `--copy` must call the same copy operation as
 `cleanroom workspace copy`; it is not a separate changeset-only mode.
+
+Workspace commands must operate on the sandbox's recorded workspace root. For
+repository-backed sandboxes, that root is the resolved `repository.path`,
+defaulting to `/workspace`. Commands should not silently assume `/workspace`
+when the policy or request used a different repository path.
 
 ### `cleanroom workspace copy`
 
@@ -140,7 +152,8 @@ cleanroom workspace copy --dry-run <sandbox-id>
 Default behavior:
 
 - source: the caller's local repository/workspace root
-- destination: the sandbox workspace root, normally `/workspace`
+- destination: the sandbox workspace root, resolved from `repository.path` and
+  normally `/workspace`
 - mirror local additions, modifications, and deletes from the included
   workspace file set into the cleanroom workspace
 - skip `.git/`
@@ -169,13 +182,14 @@ cleanroom workspace export --dry-run <sandbox-id>
 
 Default behavior:
 
-- source: the sandbox workspace root, normally `/workspace`
+- source: the sandbox workspace root, resolved from `repository.path` and
+  normally `/workspace`
 - destination: the caller's local repository/workspace root
 - mirror cleanroom additions, modifications, and deletes from the included
   workspace file set into the local workspace
-- if the source `/workspace` is a Git worktree, produce an export changeset
+- if the source workspace is a Git worktree, produce an export changeset
   against the recorded cleanroom baseline
-- if the source `/workspace` is not a Git worktree, use raw workspace transfer
+- if the source workspace is not a Git worktree, use raw workspace transfer
 - honor Git ignore rules by default for Git-backed source workspaces; ignored
   paths such as `node_modules/`, `.venv/`, and cache directories are not
   export candidates
@@ -188,13 +202,12 @@ Default behavior:
 checkout?" This is intentionally different from `workspace diff`.
 
 If local files diverged while the cleanroom was running, export should fail
-closed and name the conflicting paths. A later force or overwrite mode can be
-added if we have a concrete need, but the initial export path should be
-conflict-safe.
+closed and name the conflicting paths. A later conflict override can be added
+from concrete usage, but the initial export path should be conflict-safe.
 
 ### `cleanroom workspace diff`
 
-Show how `/workspace` differs from the cleanroom's recorded workspace
+Show how the sandbox workspace differs from the cleanroom's recorded workspace
 baseline.
 
 ```sh
@@ -238,7 +251,8 @@ repository changeset path:
 1. create or select the sandbox,
 2. create a repository changeset from local additions, modifications, and
    deletes,
-3. apply that changeset after the exact checkout is prepared in `/workspace`,
+3. apply that changeset after the exact checkout is prepared in the resolved
+   sandbox workspace root,
 4. record local binding metadata so later `workspace copy`,
    `workspace export`, and automated exports know the local root.
 
@@ -264,9 +278,9 @@ For `--keep`, export should still run after the execution/session exits, but
 the sandbox should remain available. The user can run more explicit
 `workspace copy`, `workspace diff`, or `workspace export` commands later.
 
-For `cleanroom create`, export-on-termination needs extra local binding
-semantics. That should be a later phase. The first version should support
-manual `workspace export <sandbox-id>` for sandboxes created with `create`.
+For `cleanroom create`, the first version should support manual
+`workspace export <sandbox-id>` for sandboxes created with `create`.
+`cleanroom sandbox rm` should not write back into the caller's checkout.
 
 ### `--sync`
 
@@ -320,6 +334,16 @@ There is no bidirectional merge command in v1.
 - `diff` means cleanroom workspace against cleanroom baseline
 - `sync` is a documented alias for copy plus export-on-exit
 
+### Workspace root follows repository.path
+
+Workspace operations use the sandbox's recorded workspace root. For
+repository-backed sandboxes, that is the resolved `repository.path`, defaulting
+to `/workspace`.
+
+This keeps workspace copy/export aligned with existing command execution: if a
+policy checks the repository out somewhere other than `/workspace`, copy,
+export, diff, and top-level automation operate on that same path.
+
 ### Mirror semantics are scoped by the workspace file set
 
 Workspace copy/export should mirror additions, modifications, and deletes in
@@ -327,10 +351,10 @@ the named direction, but only inside the included workspace file set. This
 keeps the mental model simple without copying platform-specific dependency
 trees:
 
-- copy makes the included `/workspace` source set match the included local
-  source set
-- export makes the included local source set match the included `/workspace`
-  source set
+- copy makes the included sandbox workspace source set match the included
+  local source set
+- export makes the included local source set match the included sandbox
+  workspace source set
 
 For Git-backed source workspaces, the default included file set is:
 
@@ -382,6 +406,22 @@ cleanroom workspace export --dry-run <sandbox-id>
 The exported payload should remain available under Cleanroom state so users can
 recover it manually if needed.
 
+The MVP should not provide a conflict override such as `--force` or
+`--overwrite`. A later override can be added from concrete usage.
+
+### Local root binding is explicit
+
+Workspace export should write only to a trusted local root:
+
+- Prefer the local root bound by the last `workspace copy` or top-level
+  `--copy`.
+- If there is no binding, allow export from the current working tree only when
+  its repository identity matches the sandbox repository identity.
+- Refuse export when the local root is ambiguous.
+
+The MVP should not add an arbitrary `--local-root` override. That avoids
+writing a cleanroom export into the wrong checkout.
+
 ### No hidden mounts
 
 Workspace copy/export should be implemented as explicit file transfer events,
@@ -427,9 +467,9 @@ silently fall back to raw copy, because that changes ignore/delete semantics.
 
 For efficient raw-transfer implementation, the CLI can batch file changes into
 the existing archive-write path plus a workspace manifest. Export can use the
-inverse shape: build a manifest and payload from `/workspace`, stream it to the
-CLI through archive/read primitives, and let the CLI apply it to the local
-workspace after local conflict checks pass.
+inverse shape: build a manifest and payload from the sandbox workspace root,
+stream it to the CLI through archive/read primitives, and let the CLI apply it
+to the local workspace after local conflict checks pass.
 
 `cleanroom cp` remains the one-file convenience layer over the same substrate.
 It should not grow workspace baselines or mirror behavior.
@@ -443,7 +483,8 @@ supporting non-Git workspaces through raw transfer.
 Cleanroom should record workspace metadata per sandbox:
 
 - sandbox ID
-- workspace root inside the sandbox, normally `/workspace`
+- workspace root inside the sandbox, resolved from `repository.path` and
+  normally `/workspace`
 - local root path used for the last copy, stored client-side only
 - cleanroom workspace baseline manifest or tree digest
 - last copy manifest used for export conflict detection
@@ -542,6 +583,8 @@ Status: landed.
 - Add `cleanroom workspace copy`.
 - Add `cleanroom workspace copy --dry-run`.
 - Add `--copy` to `exec`, `console`, and `create`.
+- Resolve the destination workspace root from `repository.path`, defaulting to
+  `/workspace`.
 - Use repository changesets when the source workspace is a Git worktree.
 - Use raw workspace transfer when the source workspace is not a Git worktree.
 - Add tests that ignored files and directories, including a representative
@@ -560,8 +603,14 @@ Status: landed.
 - Add `cleanroom workspace export --dry-run`.
 - Add `cleanroom workspace export`.
 - Add `cleanroom workspace diff`.
+- Resolve the sandbox workspace root from `repository.path`, defaulting to
+  `/workspace`.
 - Add export tests proving ignored cleanroom outputs are not written back to
   the local checkout by default.
+- Add export tests proving local divergence fails closed with no force or
+  overwrite mode.
+- Add export tests proving an unbound export refuses to write unless the
+  current working tree matches the sandbox repository identity.
 - Require explicit sandbox IDs or support `--last` consistently with existing
   inspect commands.
 - Store local binding metadata in client-side Cleanroom state.
@@ -575,8 +624,7 @@ Status: landed.
 
 ### Phase 4: Optional live local-to-cleanroom copy
 
-- Decide whether `--copy-live` is still needed after one-shot copy/export has
-  been exercised.
+- Defer `--copy-live` until one-shot copy/export has been exercised.
 - If implemented, add `--copy-live` to `exec` and `console`.
 - Keep `--sync` as `--copy --export-on-exit` unless we explicitly choose a
   breaking semantic change.
@@ -587,23 +635,25 @@ Status: landed.
 - Surface live copy failures without hiding workload output.
 - Ensure live copy cannot race with an export operation.
 
-### Phase 5: Export-on-terminate for kept sandboxes
+### Phase 5: Optional export-on-terminate for kept sandboxes
 
-- Decide whether `create` should record an export-on-termination binding.
-- If implemented, make `cleanroom sandbox rm` run export before termination
-  when a local binding exists.
-- If export fails, refuse termination by default and provide an explicit
-  discard flag.
+- Do not make `cleanroom sandbox rm` write to the caller's checkout in the MVP.
+- If export-on-terminate is added later, require an explicit create-time opt-in
+  such as `cleanroom create --export-on-terminate`.
+- If an explicit export-on-terminate fails, refuse termination by default and
+  provide an explicit discard flag.
 
-## Open Decisions
+## Resolved Decisions
 
-- Whether custom `repository.path` values should be supported by workspace
-  commands or whether workspace copy should standardize on `/workspace`.
-- Whether export conflict override should be named `--force`, `--overwrite`,
-  or left out until there is a concrete need.
-- Whether workspace commands should support an explicit local root override, or
-  only use the bound/calling repository root.
-- What explicit-path UX should exist later for exporting ignored generated
-  artifacts when `cleanroom cp` is too low-level.
-- Whether live copy deserves a separate `--copy-live` flag after the one-shot
-  workflow lands.
+- Workspace commands support custom `repository.path` values and default to
+  `/workspace`.
+- Export has no conflict override in the MVP.
+- Export uses the bound local root or a matching current working tree; there is
+  no arbitrary local-root override in the MVP.
+- Ignored generated artifacts remain excluded by default. Future support should
+  use explicit relative includes, for example
+  `cleanroom workspace export <sandbox-id> --include path/to/generated-file`.
+- Live copy is deferred. `--sync` remains one-shot
+  `--copy --export-on-exit`.
+- `cleanroom sandbox rm` does not export automatically. Export-on-terminate is
+  future work and must require explicit opt-in.

--- a/docs/plans/workspace-sync.md
+++ b/docs/plans/workspace-sync.md
@@ -1,14 +1,14 @@
-# Workspace Copy and Export Plan
+# Workspace Copy-In and Copy-Out Plan
 
 **Spec reference:** `spec.md` sections 5.1.1, 5.4, 5.4.2
 **Related plan:** `docs/plans/sandbox-transfer-invariants.md`
 **Status:** Proposed
-**Last reviewed:** 2026-04-27
+**Last reviewed:** 2026-04-28
 
 ## Summary
 
-Replace the current `--include-local-changes` UX with a clearer `--copy` flag
-and add explicit workspace copy/export primitives for the common "edit
+Replace the current `--include-local-changes` UX with a clearer `--copy-in` flag
+and add explicit workspace copy-in/copy-out primitives for the common "edit
 locally, run in Cleanroom, bring changes back" workflow.
 
 In this plan, "workspace" means the project tree inside the cleanroom at the
@@ -17,15 +17,15 @@ sandbox filesystem, and it does not create a host mount.
 
 The user-facing workspace vocabulary is:
 
-- `cleanroom workspace copy`
-- `cleanroom workspace export`
+- `cleanroom workspace copy-in`
+- `cleanroom workspace copy-out`
 - `cleanroom workspace diff`
 
 The direction is named by the verb:
 
-- `workspace copy` mirrors the included local workspace file set into the
+- `workspace copy-in` mirrors the included local workspace file set into the
   cleanroom workspace.
-- `workspace export` mirrors the included cleanroom workspace file set back
+- `workspace copy-out` mirrors the included cleanroom workspace file set back
   into the caller's local workspace.
 - `workspace diff` shows how the cleanroom workspace differs from its recorded
   cleanroom baseline.
@@ -43,8 +43,8 @@ cleanroom cp ./fixture.json <sandbox-id>:/tmp/fixture.json
 cleanroom cp <sandbox-id>:/tmp/result.json ./result.json
 ```
 
-Workspace copy/export should reuse existing substrates rather than redefine
-low-level copy semantics. For Git-backed source workspaces, copy and export
+Workspace copy-in/copy-out should reuse existing substrates rather than redefine
+low-level copy semantics. For Git-backed source workspaces, copy-in and copy-out
 should use repository changesets as the transport. For non-Git source
 workspaces, they should use raw workspace transfer over the file/path/archive
 layer. That is an implementation choice; the user-facing behavior should be
@@ -53,42 +53,42 @@ the same.
 The higher-level automation should stay small and literal:
 
 ```sh
-cleanroom exec --copy -- npm test
-cleanroom exec --export-on-exit -- npm run fix
+cleanroom exec --copy-in -- npm test
+cleanroom exec --copy-out -- npm run fix
 cleanroom exec --sync -- npm run generate
 ```
 
 Top-level flags:
 
-- `--copy` copies local workspace changes into the sandbox workspace before
+- `--copy-in` copies local workspace changes into the sandbox workspace before
   running. It is automation over the same operation as
-  `cleanroom workspace copy`.
-- `--export-on-exit` exports the included sandbox workspace file set back into
+  `cleanroom workspace copy-in`.
+- `--copy-out` copies the included sandbox workspace file set back into
   the local workspace after the command or console session exits.
-- `--sync` is equivalent to `--copy --export-on-exit`.
+- `--sync` is equivalent to `--copy-in --copy-out`.
 
 ## Goals
 
 - Make local development workflows feel direct: edits made locally appear in
   the sandbox workspace, and useful changes made there can come back.
 - Keep CI and hermetic workflows explicit and available.
-- Keep workspace copy/export behavior as command primitives that can be used
+- Keep workspace copy-in/copy-out behavior as command primitives that can be used
   manually and by top-level automation.
 - Support custom `repository.path` values rather than hardcoding workspace
   operations to `/workspace`.
 - Keep ordinary `exec`, `console`, and `create` startup fast by avoiding
   implicit whole-tree copy operations.
-- Replace `--include-local-changes` with `--copy` instead of carrying both
+- Replace `--include-local-changes` with `--copy-in` instead of carrying both
   names long term.
-- Exclude ignored dependency/cache/runtime directories from copy/export by
-  default, so a Linux `node_modules/` never gets exported back to a macOS
+- Exclude ignored dependency/cache/runtime directories from copy-in/copy-out by
+  default, so a Linux `node_modules/` never gets copied back to a macOS
   checkout unless the user deliberately asks for that exact path.
 - Avoid host filesystem mounts and backend-specific file sharing assumptions.
-- Make export safe by default: no silent overwrite of unrelated local changes,
+- Make copy-out safe by default: no silent overwrite of unrelated local changes,
   a dry-run path for previewing local effects, and clear conflict reporting.
 - Preserve the existing repo-aware checkout model for clean committed inputs.
 - Reuse the sandbox file/path/archive transfer layer for payload movement.
-- Keep `--copy` and `workspace copy` behavior identical; only the transport
+- Keep `--copy-in` and `workspace copy-in` behavior identical; only the transport
   should differ between Git and non-Git sources.
 
 ## Non-goals
@@ -96,14 +96,14 @@ Top-level flags:
 - General-purpose arbitrary path copy across the whole sandbox filesystem; that
   belongs to `cleanroom copy` / `cleanroom cp`.
 - Bidirectional conflict resolution or a full file synchronization daemon.
-- Making workspace copy/export the default behavior for top-level commands.
+- Making workspace copy-in/copy-out the default behavior for top-level commands.
 - Making `cleanroom sandbox create` infer repository policy or local workspace
   state.
-- Exporting ignored workspace artifacts by default.
-- Adding an export conflict override such as `--force` or `--overwrite` in the
+- Copying ignored workspace artifacts out by default.
+- Adding a copy-out conflict override such as `--force` or `--overwrite` in the
   MVP.
-- Supporting arbitrary local export roots in the MVP.
-- Running export automatically from `cleanroom sandbox rm`.
+- Supporting arbitrary local copy-out roots in the MVP.
+- Running copy-out automatically from `cleanroom sandbox rm`.
 - Replacing artifact upload/download APIs for non-workspace build outputs.
 - Requiring the guest image to provide the `rsync` binary.
 
@@ -121,7 +121,7 @@ cleanroom cp <sandbox-id>:/absolute/path <local-file-or-directory>
 It is intentionally not a workspace lifecycle command. Current behavior is
 scoped to one local file to one sandbox path, or one sandbox file to one local
 path. Recursive local directory upload, workspace baselines, conflict
-detection, dry-run export planning, and workspace mirror semantics are out of
+detection, dry-run copy-out planning, and workspace mirror semantics are out of
 scope for `cp`.
 
 Workspace commands should use a shared workspace planner with
@@ -132,11 +132,11 @@ the source workspace:
 - Non-Git source: raw workspace transfer using the backend-neutral
   file/path/archive layer.
 
-Top-level `--copy` should call the same copy operation as
-`cleanroom workspace copy`; it is not a separate changeset-only mode. The
+Top-level `--copy-in` should call the same copy-in operation as
+`cleanroom workspace copy-in`; it is not a separate changeset-only mode. The
 first implementation keeps that guarantee for Git-backed workspaces. For
-non-Git workspaces, `cleanroom workspace copy` can use raw transfer against an
-existing sandbox, but top-level `--copy` must stay disabled until there is a
+non-Git workspaces, `cleanroom workspace copy-in` can use raw transfer against an
+existing sandbox, but top-level `--copy-in` must stay disabled until there is a
 create-time raw workspace primitive that runs before dependency and service
 bootstrap.
 
@@ -145,13 +145,13 @@ repository-backed sandboxes, that root is the resolved `repository.path`,
 defaulting to `/workspace`. Commands should not silently assume `/workspace`
 when the policy or request used a different repository path.
 
-### `cleanroom workspace copy`
+### `cleanroom workspace copy-in`
 
 Copy the caller's local workspace into the cleanroom workspace.
 
 ```sh
-cleanroom workspace copy <sandbox-id>
-cleanroom workspace copy --dry-run <sandbox-id>
+cleanroom workspace copy-in <sandbox-id>
+cleanroom workspace copy-in --dry-run <sandbox-id>
 ```
 
 Default behavior:
@@ -166,24 +166,24 @@ Default behavior:
 - if the source is not a Git worktree, use raw workspace transfer, but refuse
   when the sandbox does not expose a recorded workspace root
 - honor Git ignore rules by default for Git-backed source workspaces
-- record the local binding and manifest needed for later export conflict
+- record the local binding and manifest needed for later copy-out conflict
   checks
 
-`workspace copy --dry-run` reports the planned remote writes and deletes
+`workspace copy-in --dry-run` reports the planned remote writes and deletes
 without applying them.
 
-Because the cleanroom side is disposable, copy can use mirror semantics inside
-the included workspace file set. `workspace copy` and `--copy` should share the
-same planner and produce the same cleanroom workspace contents for the same
-source.
+Because the cleanroom side is disposable, copy-in can use mirror semantics
+inside the included workspace file set. `workspace copy-in` and `--copy-in`
+should share the same planner and produce the same cleanroom workspace contents
+for the same source.
 
-### `cleanroom workspace export`
+### `cleanroom workspace copy-out`
 
-Export cleanroom workspace changes back to the caller's local workspace.
+Copy cleanroom workspace changes back to the caller's local workspace.
 
 ```sh
-cleanroom workspace export <sandbox-id>
-cleanroom workspace export --dry-run <sandbox-id>
+cleanroom workspace copy-out <sandbox-id>
+cleanroom workspace copy-out --dry-run <sandbox-id>
 ```
 
 Default behavior:
@@ -193,23 +193,23 @@ Default behavior:
 - destination: the caller's local repository/workspace root
 - mirror cleanroom additions, modifications, and deletes from the included
   workspace file set into the local workspace
-- if the source workspace is a Git worktree, produce an export changeset
+- if the source workspace is a Git worktree, produce a copy-out changeset
   against the recorded cleanroom baseline
 - if the source workspace is not a Git worktree, use raw workspace transfer
 - honor Git ignore rules by default for Git-backed source workspaces; ignored
   paths such as `node_modules/`, `.venv/`, and cache directories are not
-  export candidates
+  copy-out candidates
 - refuse to overwrite or delete a local path that changed since the last
-  copy/import baseline
-- leave a recoverable export payload in Cleanroom state if local conflict
+  copy-in or initial workspace baseline
+- leave a recoverable copy-out payload in Cleanroom state if local conflict
   checks fail
 
-`workspace export --dry-run` answers "what would be written to my local
+`workspace copy-out --dry-run` answers "what would be written to my local
 checkout?" This is intentionally different from `workspace diff`.
 
-If local files diverged while the cleanroom was running, export should fail
+If local files diverged while the cleanroom was running, copy-out should fail
 closed and name the conflicting paths. A later conflict override can be added
-from concrete usage, but the initial export path should be conflict-safe.
+from concrete usage, but the initial copy-out path should be conflict-safe.
 
 ### `cleanroom workspace diff`
 
@@ -225,23 +225,23 @@ cleanroom workspace diff --name-only <sandbox-id>
 This command answers "what changed inside the cleanroom workspace?"
 
 It does not answer "what would be written locally?" Use
-`workspace export --dry-run` for that.
+`workspace copy-out --dry-run` for that.
 
 The baseline should be the cleanroom's own workspace baseline: the workspace
 state created from the exact checkout or restored stage before workload changes
-are considered user output. If a later `workspace copy` copied local edits into
+are considered user output. If a later `workspace copy-in` copied local edits into
 the cleanroom, `workspace diff` may show those edits too. That is acceptable:
-the command is scoped to cleanroom workspace state, not local export effects.
+the command is scoped to cleanroom workspace state, not local copy-out effects.
 
 ## Top-Level Automation
 
 Top-level automation should compose the same workspace operations exposed by
-the manual commands. `--copy` must behave exactly like
-`cleanroom workspace copy` for the same source and destination; the only
+the manual commands. `--copy-in` must behave exactly like
+`cleanroom workspace copy-in` for the same source and destination; the only
 difference is that the top-level command creates or selects the sandbox before
-running the copy operation.
+running the copy-in operation.
 
-### `--copy`
+### `--copy-in`
 
 Supported on:
 
@@ -249,7 +249,7 @@ Supported on:
 - `cleanroom console`
 - `cleanroom create`
 
-`--copy` replaces `--include-local-changes` as the top-level copy-in flag.
+`--copy-in` replaces `--include-local-changes` as the top-level copy-in flag.
 
 For Git-backed source workspaces, the implementation should reuse the existing
 repository changeset path:
@@ -259,10 +259,10 @@ repository changeset path:
    deletes,
 3. apply that changeset after the exact checkout is prepared in the resolved
    sandbox workspace root,
-4. record local binding metadata so later `workspace copy`,
-   `workspace export`, and automated exports know the local root.
+4. record local binding metadata so later `workspace copy-in`,
+   `workspace copy-out`, and automated copy-out operations know the local root.
 
-For non-Git source workspaces, the same `--copy` flag should eventually use raw
+For non-Git source workspaces, the same `--copy-in` flag should eventually use raw
 workspace transfer instead of a changeset, but only once raw transfer can run as
 part of sandbox creation before bootstrap.
 
@@ -270,23 +270,23 @@ The existing changeset path already has the right ignore shape: it stages the
 working tree through Git, so ignored files are not part of the copied payload
 unless they are tracked.
 
-### `--export-on-exit`
+### `--copy-out`
 
 Supported on:
 
 - `cleanroom exec`
 - `cleanroom console`
 
-For an automatically-created sandbox, `--export-on-exit` should run
-`workspace export` after the execution/session exits and before the CLI
+For an automatically-created sandbox, `--copy-out` should run
+`workspace copy-out` after the execution/session exits and before the CLI
 terminates the sandbox.
 
-For `--keep`, export should still run after the execution/session exits, but
+For `--keep`, copy-out should still run after the execution/session exits, but
 the sandbox should remain available. The user can run more explicit
-`workspace copy`, `workspace diff`, or `workspace export` commands later.
+`workspace copy-in`, `workspace diff`, or `workspace copy-out` commands later.
 
 For `cleanroom create`, the first version should support manual
-`workspace export <sandbox-id>` for sandboxes created with `create`.
+`workspace copy-out <sandbox-id>` for sandboxes created with `create`.
 `cleanroom sandbox rm` should not write back into the caller's checkout.
 
 ### `--sync`
@@ -299,32 +299,32 @@ Supported on:
 `--sync` is a convenience alias for:
 
 ```sh
---copy --export-on-exit
+--copy-in --copy-out
 ```
 
 Help text should state that equivalence literally. `--sync` should not be the
 primitive that implementation code special-cases; it should resolve into the
-directional copy/export options early in CLI parsing.
+directional copy-in/copy-out options early in CLI parsing.
 
 ### Defaults
 
-Workspace copy/export must be explicit. Even a source-scoped workspace mirror
+Workspace copy-in/copy-out must be explicit. Even a source-scoped workspace mirror
 can touch a large number of files, so making it implicit would add a large file
 operation to ordinary executions and make the common command path unexpectedly
 slow.
 
 Defaults:
 
-- `cleanroom exec`: exact committed checkout, no workspace copy/export unless
-  `--copy`, `--export-on-exit`, or `--sync` is requested
-- `cleanroom console`: exact committed checkout, no workspace copy/export
+- `cleanroom exec`: exact committed checkout, no workspace copy-in/copy-out unless
+  `--copy-in`, `--copy-out`, or `--sync` is requested
+- `cleanroom console`: exact committed checkout, no workspace copy-in/copy-out
   unless requested
-- `cleanroom create`: exact committed checkout unless `--copy` is requested
+- `cleanroom create`: exact committed checkout unless `--copy-in` is requested
 - CI or non-interactive execution: same exact committed checkout behavior
-- reused sandboxes via `--in <id>`: no implicit copy/export unless requested
+- reused sandboxes via `--in <id>`: no implicit copy-in/copy-out unless requested
 - snapshot-backed sandboxes via `--from <snapshot-id>`: no implicit
-  copy/export in the first version
-- export is never implicit except through explicit `--export-on-exit` or
+  copy-in/copy-out in the first version
+- copy-out is never implicit except through explicit `--copy-out` or
   `--sync`
 
 This deliberately avoids local-interactive detection, config defaults, and
@@ -336,10 +336,10 @@ environment overrides.
 
 There is no bidirectional merge command in v1.
 
-- `copy` means local to cleanroom
-- `export` means cleanroom to local
+- `copy-in` means local to cleanroom
+- `copy-out` means cleanroom to local
 - `diff` means cleanroom workspace against cleanroom baseline
-- `sync` is a documented alias for copy plus export-on-exit
+- `sync` is a documented alias for copy-in plus copy-out
 
 ### Workspace root follows repository.path
 
@@ -347,20 +347,20 @@ Workspace operations use the sandbox's recorded workspace root. For
 repository-backed sandboxes, that is the resolved `repository.path`, defaulting
 to `/workspace`.
 
-This keeps workspace copy/export aligned with existing command execution: if a
-policy checks the repository out somewhere other than `/workspace`, copy,
-export, diff, and top-level automation operate on that same path.
+This keeps workspace copy-in/copy-out aligned with existing command execution: if a
+policy checks the repository out somewhere other than `/workspace`, copy-in,
+copy-out, diff, and top-level automation operate on that same path.
 
 ### Mirror semantics are scoped by the workspace file set
 
-Workspace copy/export should mirror additions, modifications, and deletes in
+Workspace copy-in/copy-out should mirror additions, modifications, and deletes in
 the named direction, but only inside the included workspace file set. This
 keeps the mental model simple without copying platform-specific dependency
 trees:
 
-- copy makes the included sandbox workspace source set match the included
+- copy-in makes the included sandbox workspace source set match the included
   local source set
-- export makes the included local source set match the included sandbox
+- copy-out makes the included local source set match the included sandbox
   workspace source set
 
 For Git-backed source workspaces, the default included file set is:
@@ -374,7 +374,7 @@ For Git-backed source workspaces, the default included file set is:
 Ignored paths are excluded by default for Git-backed sources in both
 directions. In practice, that means `node_modules/`, `.venv/`, build caches,
 and other ignored runtime outputs are not copied from macOS into Linux and are
-not exported from Linux back to macOS.
+not copied out from Linux back to macOS.
 
 The implementation should ask Git for this file set, using commands equivalent
 to `git ls-files` with standard excludes or the existing temporary-index
@@ -387,30 +387,30 @@ unsafe paths. There is no Git ignore model to infer, so raw copy is literal.
 The safety mechanism is conflict detection and dry-run output, not making
 delete behavior a separate mode.
 
-Delete propagation is also limited to the included file set. Git-backed export
+Delete propagation is also limited to the included file set. Git-backed copy-out
 should not delete ignored local paths, even if the cleanroom workspace does not
 contain them.
 
 If a user deliberately wants ignored artifacts, they should use `cleanroom cp`
 for explicit paths or a future explicit include path. The MVP should not add a
 global `--include-ignored` switch because it is too easy to accidentally
-export platform-specific dependency trees.
+copy out platform-specific dependency trees.
 
-### Export detects local divergence
+### Copy-out detects local divergence
 
-Before exporting, the CLI should compare the current local paths that would be
-written or deleted against the manifest recorded at the last `workspace copy`
-or initial workspace import.
+Before copying out, the CLI should compare the current local paths that would be
+written or deleted against the manifest recorded at the last `workspace copy-in`
+or initial workspace baseline.
 
-If a local target changed independently, export should refuse by default.
+If a local target changed independently, copy-out should refuse by default.
 
 The refusal message should name the conflicting paths and suggest:
 
 ```sh
-cleanroom workspace export --dry-run <sandbox-id>
+cleanroom workspace copy-out --dry-run <sandbox-id>
 ```
 
-The exported payload should remain available under Cleanroom state so users can
+The copied-out payload should remain available under Cleanroom state so users can
 recover it manually if needed.
 
 The MVP should not provide a conflict override such as `--force` or
@@ -418,20 +418,20 @@ The MVP should not provide a conflict override such as `--force` or
 
 ### Local root binding is explicit
 
-Workspace export should write only to a trusted local root:
+Workspace copy-out should write only to a trusted local root:
 
-- Prefer the local root bound by the last `workspace copy` or top-level
-  `--copy`.
-- If there is no binding, allow export from the current working tree only when
+- Prefer the local root bound by the last `workspace copy-in` or top-level
+  `--copy-in`.
+- If there is no binding, allow copy-out from the current working tree only when
   its repository identity matches the sandbox repository identity.
-- Refuse export when the local root is ambiguous.
+- Refuse copy-out when the local root is ambiguous.
 
 The MVP should not add an arbitrary `--local-root` override. That avoids
-writing a cleanroom export into the wrong checkout.
+writing cleanroom copy-out results into the wrong checkout.
 
 ### No hidden mounts
 
-Workspace copy/export should be implemented as explicit file transfer events,
+Workspace copy-in/copy-out should be implemented as explicit file transfer events,
 not as a bind mount or backend-specific shared directory. That keeps the API
 and security model backend-neutral.
 
@@ -450,7 +450,7 @@ The lower transfer layer already owns the per-file and archive mechanics:
 - archive sandbox paths to a bounded byte stream
 - extract one archive stream into a sandbox directory
 
-Workspace copy/export should add a higher-level planning representation that
+Workspace copy-in/copy-out should add a higher-level planning representation that
 is independent of transport:
 
 - normalized relative path
@@ -473,7 +473,7 @@ the baseline is missing or incompatible, fail with a clear error. Do not
 silently fall back to raw copy, because that changes ignore/delete semantics.
 
 For efficient raw-transfer implementation, the CLI can batch file changes into
-the existing archive-write path plus a workspace manifest. Export can use the
+the existing archive-write path plus a workspace manifest. Copy-out can use the
 inverse shape: build a manifest and payload from the sandbox workspace root,
 stream it to the CLI through archive/read primitives, and let the CLI apply it
 to the local workspace after local conflict checks pass.
@@ -492,12 +492,13 @@ Cleanroom should record workspace metadata per sandbox:
 - sandbox ID
 - workspace root inside the sandbox, resolved from `repository.path` and
   normally `/workspace`
-- local root path used for the last copy, stored client-side only
+- local root path used for the last workspace copy-in or copy-out, stored
+  client-side only
 - cleanroom workspace baseline manifest or tree digest
-- last copy manifest used for export conflict detection
-- ignore/source file-set mode used for the last copy
+- last workspace copy-in manifest used for copy-out conflict detection
+- ignore/source file-set mode used for the last workspace operation
 - selected source transport, either Git changeset or raw transfer
-- last copy time
+- last workspace operation time
 
 The server should store sandbox/workspace facts needed to operate inside the
 sandbox. The CLI should store local filesystem paths in local state, not in
@@ -510,10 +511,10 @@ The public CLI should lead the design. The transfer substrate now provides the
 low-level file/path/archive operations; workspace APIs should stay narrow and
 workspace-aware:
 
-- apply a workspace copy payload to a sandbox workspace, whether represented
+- apply a workspace copy-in payload to a sandbox workspace, whether represented
   as a Git changeset or a raw transfer manifest
 - produce a workspace diff against the cleanroom baseline
-- produce a workspace export payload and manifest
+- produce a workspace copy-out payload and manifest
 
 Those operations should reject:
 
@@ -532,15 +533,15 @@ scoping, baseline tracking, mirror planning, and conflict metadata.
 `--include-local-changes` currently packages local dirty state as an explicit
 repository changeset during sandbox creation.
 
-This plan should rename that user-facing behavior to `--copy`:
+This plan should rename that user-facing behavior to `--copy-in`:
 
-- `--copy` is the top-level one-shot copy-in flag for local workspace changes
-- `workspace copy` is the manual form of the same copy-in operation
+- `--copy-in` is the top-level one-shot copy-in flag for local workspace changes
+- `workspace copy-in` is the manual form of the same copy-in operation
 - Git source workspaces use repository changesets
 - non-Git source workspaces use raw workspace transfer
-- `workspace export` is the explicit copy-out primitive
-- `--export-on-exit` is the top-level copy-out automation
-- `--sync` composes copy-in with export-on-exit
+- `workspace copy-out` is the explicit copy-out primitive
+- `--copy-out` is the top-level copy-out automation
+- `--sync` composes copy-in with copy-out
 
 The term "repository changeset" should remain an implementation and diagnostic
 term. CLI help and docs for the happy path should describe the behavior as
@@ -548,7 +549,7 @@ copying workspace changes.
 
 Because Cleanroom is pre-1.0, prefer removing `--include-local-changes` rather
 than keeping a long compatibility path. If a short alias is kept during
-transition, it should be documented as equivalent to `--copy` and then deleted
+transition, it should be documented as equivalent to `--copy-in` and then deleted
 before v1.
 
 ## CI and Hermetic Workflows
@@ -561,14 +562,14 @@ cleanroom exec -- npm test
 
 The default should continue to be exact committed checkout behavior:
 
-- no workspace copy unless requested
-- no export back to the checkout
+- no workspace copy-in unless requested
+- no copy-out back to the checkout
 - dirty worktree warning if relevant
 - repository content comes from the resolved commit and explicit policy
 
-No environment or config default should implicitly enable workspace copy/export.
+No environment or config default should implicitly enable workspace copy-in/copy-out.
 CI, automation, and normal local executions get exact checkout behavior by
-omitting workspace copy/export flags.
+omitting workspace copy-in/copy-out flags.
 
 ## Delivery Strategy
 
@@ -585,85 +586,85 @@ Status: landed.
 
 ### Phase 1: Unified workspace copy-in
 
-- Add a shared workspace copy planner used by both manual commands and
+- Add a shared workspace copy-in planner used by both manual commands and
   top-level automation.
-- Add `cleanroom workspace copy`.
-- Add `cleanroom workspace copy --dry-run`.
-- Add `--copy` to `exec`, `console`, and `create`.
+- Add `cleanroom workspace copy-in`.
+- Add `cleanroom workspace copy-in --dry-run`.
+- Add `--copy-in` to `exec`, `console`, and `create`.
 - Resolve the destination workspace root from `repository.path`, defaulting to
   `/workspace`.
 - Use repository changesets when the source workspace is a Git worktree.
-- Use raw workspace transfer for manual `workspace copy` when the source
+- Use raw workspace transfer for manual `workspace copy-in` when the source
   workspace is not a Git worktree.
-- Reject top-level `--copy` for non-Git workspaces until raw transfer can be
+- Reject top-level `--copy-in` for non-Git workspaces until raw transfer can be
   attached to sandbox creation before bootstrap.
 - Add tests that ignored files and directories, including a representative
   `node_modules/`, are not included in Git-backed copy unless tracked.
-- Add tests that `workspace copy` and top-level `--copy` produce the same
+- Add tests that `workspace copy-in` and top-level `--copy-in` produce the same
   destination contents for Git sources.
 - Remove or immediately deprecate `--include-local-changes` as the old spelling
   of the same behavior.
 - Apply copied changes after exact checkout setup and before command execution
   or console entry.
-- Store enough local binding metadata for later export work.
-- Update help text and docs so `--copy` is the only recommended copy-in flag.
+- Store enough local binding metadata for later copy-out work.
+- Update help text and docs so `--copy-in` is the only recommended copy-in flag.
 
-### Phase 2: Workspace export and diff
+### Phase 2: Workspace copy-out and diff
 
-- Add `cleanroom workspace export --dry-run`.
-- Add `cleanroom workspace export`.
+- Add `cleanroom workspace copy-out --dry-run`.
+- Add `cleanroom workspace copy-out`.
 - Add `cleanroom workspace diff`.
 - Resolve the sandbox workspace root from `repository.path`, defaulting to
   `/workspace`.
-- Add export tests proving ignored cleanroom outputs are not written back to
+- Add copy-out tests proving ignored cleanroom outputs are not written back to
   the local checkout by default.
-- Add export tests proving local divergence fails closed with no force or
+- Add copy-out tests proving local divergence fails closed with no force or
   overwrite mode.
-- Add export tests proving an unbound export refuses to write unless the
+- Add copy-out tests proving an unbound copy-out refuses to write unless the
   current working tree matches the sandbox repository identity.
 - Require explicit sandbox IDs or support `--last` consistently with existing
   inspect commands.
 - Store local binding metadata in client-side Cleanroom state.
 
-### Phase 3: Safe top-level export automation
+### Phase 3: Safe top-level copy-out automation
 
-- Add `--export-on-exit` to `exec` and `console`.
-- Add `--sync` as an alias for `--copy --export-on-exit`.
+- Add `--copy-out` to `exec` and `console`.
+- Add `--sync` as an alias for `--copy-in --copy-out`.
 - Add integration tests for local divergence, delete propagation, and dry-run
   output.
 
 ### Phase 4: Optional live local-to-cleanroom copy
 
-- Defer `--copy-live` until one-shot copy/export has been exercised.
-- If implemented, add `--copy-live` to `exec` and `console`.
-- Keep `--sync` as `--copy --export-on-exit` unless we explicitly choose a
+- Defer `--copy-in-live` until one-shot copy-in/copy-out has been exercised.
+- If implemented, add `--copy-in-live` to `exec` and `console`.
+- Keep `--sync` as `--copy-in --copy-out` unless we explicitly choose a
   breaking semantic change.
-- Add file watching for `exec --copy-live` and `console --copy-live`.
+- Add file watching for `exec --copy-in-live` and `console --copy-in-live`.
 - Batch rapid local changes.
 - Propagate local delete events without periodically deleting unrelated
   cleanroom-only generated files.
 - Surface live copy failures without hiding workload output.
-- Ensure live copy cannot race with an export operation.
+- Ensure live copy cannot race with a copy-out operation.
 
-### Phase 5: Optional export-on-terminate for kept sandboxes
+### Phase 5: Optional copy-out-on-terminate for kept sandboxes
 
 - Do not make `cleanroom sandbox rm` write to the caller's checkout in the MVP.
-- If export-on-terminate is added later, require an explicit create-time opt-in
-  such as `cleanroom create --export-on-terminate`.
-- If an explicit export-on-terminate fails, refuse termination by default and
+- If copy-out-on-terminate is added later, require an explicit create-time opt-in
+  such as `cleanroom create --copy-out-on-terminate`.
+- If an explicit copy-out-on-terminate fails, refuse termination by default and
   provide an explicit discard flag.
 
 ## Resolved Decisions
 
 - Workspace commands support custom `repository.path` values and default to
   `/workspace`.
-- Export has no conflict override in the MVP.
-- Export uses the bound local root or a matching current working tree; there is
+- Copy-out has no conflict override in the MVP.
+- Copy-out uses the bound local root or a matching current working tree; there is
   no arbitrary local-root override in the MVP.
 - Ignored generated artifacts remain excluded by default. Future support should
   use explicit relative includes, for example
-  `cleanroom workspace export <sandbox-id> --include path/to/generated-file`.
+  `cleanroom workspace copy-out <sandbox-id> --include path/to/generated-file`.
 - Live copy is deferred. `--sync` remains one-shot
-  `--copy --export-on-exit`.
-- `cleanroom sandbox rm` does not export automatically. Export-on-terminate is
+  `--copy-in --copy-out`.
+- `cleanroom sandbox rm` does not copy out automatically. Copy-out-on-terminate is
   future work and must require explicit opt-in.

--- a/docs/plans/workspace-sync.md
+++ b/docs/plans/workspace-sync.md
@@ -157,13 +157,14 @@ cleanroom workspace copy --dry-run <sandbox-id>
 Default behavior:
 
 - source: the caller's local repository/workspace root
-- destination: the sandbox workspace root, resolved from `repository.path` and
-  normally `/workspace`
+- destination: the sandbox's recorded workspace root, resolved from
+  `repository.path` at sandbox creation and normally `/workspace`
 - mirror local additions, modifications, and deletes from the included
   workspace file set into the cleanroom workspace
 - skip `.git/`
 - if the source is a Git worktree, package and apply a repository changeset
-- if the source is not a Git worktree, use raw workspace transfer
+- if the source is not a Git worktree, use raw workspace transfer, but refuse
+  when the sandbox does not expose a recorded workspace root
 - honor Git ignore rules by default for Git-backed source workspaces
 - record the local binding and manifest needed for later export conflict
   checks

--- a/docs/plans/workspace-sync.md
+++ b/docs/plans/workspace-sync.md
@@ -1,0 +1,609 @@
+# Workspace Copy and Export Plan
+
+**Spec reference:** `spec.md` sections 5.1.1, 5.4, 5.4.2
+**Related plan:** `docs/plans/sandbox-transfer-invariants.md`
+**Status:** Proposed
+**Last reviewed:** 2026-04-27
+
+## Summary
+
+Replace the current `--include-local-changes` UX with a clearer `--copy` flag
+and add explicit workspace copy/export primitives for the common "edit
+locally, run in Cleanroom, bring changes back" workflow.
+
+In this plan, "workspace" means the project tree inside the cleanroom,
+normally `/workspace`. It does not mean the full sandbox filesystem, and it
+does not create a host mount.
+
+The user-facing workspace vocabulary is:
+
+- `cleanroom workspace copy`
+- `cleanroom workspace export`
+- `cleanroom workspace diff`
+
+The direction is named by the verb:
+
+- `workspace copy` mirrors the included local workspace file set into the
+  cleanroom workspace.
+- `workspace export` mirrors the included cleanroom workspace file set back
+  into the caller's local workspace.
+- `workspace diff` shows how the cleanroom workspace differs from its recorded
+  cleanroom baseline.
+
+Mirror semantics include deletes inside the workspace file set. The safety
+boundary is not "never delete"; it is "be explicit about direction, honor
+ignored files, offer dry runs, and refuse to overwrite or delete local paths
+that changed independently."
+
+Cleanroom already has one-off sandbox transfer primitives for explicit file
+movement:
+
+```sh
+cleanroom cp ./fixture.json <sandbox-id>:/tmp/fixture.json
+cleanroom cp <sandbox-id>:/tmp/result.json ./result.json
+```
+
+Workspace copy/export should reuse existing substrates rather than redefine
+low-level copy semantics. For Git-backed source workspaces, copy and export
+should use repository changesets as the transport. For non-Git source
+workspaces, they should use raw workspace transfer over the file/path/archive
+layer. That is an implementation choice; the user-facing behavior should be
+the same.
+
+The higher-level automation should stay small and literal:
+
+```sh
+cleanroom exec --copy -- npm test
+cleanroom exec --export-on-exit -- npm run fix
+cleanroom exec --sync -- npm run generate
+```
+
+Top-level flags:
+
+- `--copy` copies local workspace changes into `/workspace` before running.
+  It is automation over the same operation as `cleanroom workspace copy`.
+- `--export-on-exit` exports the included `/workspace` file set back into the
+  local workspace after the command or console session exits.
+- `--sync` is equivalent to `--copy --export-on-exit`.
+
+## Goals
+
+- Make local development workflows feel direct: edits made locally appear in
+  `/workspace`, and useful changes made in `/workspace` can come back.
+- Keep CI and hermetic workflows explicit and available.
+- Keep `/workspace` copy/export behavior as command primitives that can be
+  used manually and by top-level automation.
+- Keep ordinary `exec`, `console`, and `create` startup fast by avoiding
+  implicit whole-tree copy operations.
+- Replace `--include-local-changes` with `--copy` instead of carrying both
+  names long term.
+- Exclude ignored dependency/cache/runtime directories from copy/export by
+  default, so a Linux `node_modules/` never gets exported back to a macOS
+  checkout unless the user deliberately asks for that exact path.
+- Avoid host filesystem mounts and backend-specific file sharing assumptions.
+- Make export safe by default: no silent overwrite of unrelated local changes,
+  a dry-run path for previewing local effects, and clear conflict reporting.
+- Preserve the existing repo-aware checkout model for clean committed inputs.
+- Reuse the sandbox file/path/archive transfer layer for payload movement.
+- Keep `--copy` and `workspace copy` behavior identical; only the transport
+  should differ between Git and non-Git sources.
+
+## Non-goals
+
+- General-purpose arbitrary path copy across the whole sandbox filesystem; that
+  belongs to `cleanroom copy` / `cleanroom cp`.
+- Bidirectional conflict resolution or a full file synchronization daemon.
+- Making workspace copy/export the default behavior for top-level commands.
+- Making `cleanroom sandbox create` infer repository policy or local workspace
+  state.
+- Exporting ignored workspace artifacts by default.
+- Replacing artifact upload/download APIs for non-workspace build outputs.
+- Requiring the guest image to provide the `rsync` binary.
+
+## Command Model
+
+### Existing one-off copy primitive
+
+The existing `cleanroom cp` command is for direct file movement:
+
+```sh
+cleanroom cp <local-file> <sandbox-id>:/absolute/path
+cleanroom cp <sandbox-id>:/absolute/path <local-file-or-directory>
+```
+
+It is intentionally not a workspace lifecycle command. Current behavior is
+scoped to one local file to one sandbox path, or one sandbox file to one local
+path. Recursive local directory upload, workspace baselines, conflict
+detection, dry-run export planning, and `/workspace` mirror semantics are out
+of scope for `cp`.
+
+Workspace commands should use a shared workspace planner with
+workspace-specific safety semantics. The planner selects the transport from
+the source workspace:
+
+- Git source: repository changeset.
+- Non-Git source: raw workspace transfer using the backend-neutral
+  file/path/archive layer.
+
+Top-level `--copy` must call the same copy operation as
+`cleanroom workspace copy`; it is not a separate changeset-only mode.
+
+### `cleanroom workspace copy`
+
+Copy the caller's local workspace into the cleanroom workspace.
+
+```sh
+cleanroom workspace copy <sandbox-id>
+cleanroom workspace copy --dry-run <sandbox-id>
+```
+
+Default behavior:
+
+- source: the caller's local repository/workspace root
+- destination: the sandbox workspace root, normally `/workspace`
+- mirror local additions, modifications, and deletes from the included
+  workspace file set into the cleanroom workspace
+- skip `.git/`
+- if the source is a Git worktree, package and apply a repository changeset
+- if the source is not a Git worktree, use raw workspace transfer
+- honor Git ignore rules by default for Git-backed source workspaces
+- record the local binding and manifest needed for later export conflict
+  checks
+
+`workspace copy --dry-run` reports the planned remote writes and deletes
+without applying them.
+
+Because the cleanroom side is disposable, copy can use mirror semantics inside
+the included workspace file set. `workspace copy` and `--copy` should share the
+same planner and produce the same cleanroom workspace contents for the same
+source.
+
+### `cleanroom workspace export`
+
+Export cleanroom workspace changes back to the caller's local workspace.
+
+```sh
+cleanroom workspace export <sandbox-id>
+cleanroom workspace export --dry-run <sandbox-id>
+```
+
+Default behavior:
+
+- source: the sandbox workspace root, normally `/workspace`
+- destination: the caller's local repository/workspace root
+- mirror cleanroom additions, modifications, and deletes from the included
+  workspace file set into the local workspace
+- if the source `/workspace` is a Git worktree, produce an export changeset
+  against the recorded cleanroom baseline
+- if the source `/workspace` is not a Git worktree, use raw workspace transfer
+- honor Git ignore rules by default for Git-backed source workspaces; ignored
+  paths such as `node_modules/`, `.venv/`, and cache directories are not
+  export candidates
+- refuse to overwrite or delete a local path that changed since the last
+  copy/import baseline
+- leave a recoverable export payload in Cleanroom state if local conflict
+  checks fail
+
+`workspace export --dry-run` answers "what would be written to my local
+checkout?" This is intentionally different from `workspace diff`.
+
+If local files diverged while the cleanroom was running, export should fail
+closed and name the conflicting paths. A later force or overwrite mode can be
+added if we have a concrete need, but the initial export path should be
+conflict-safe.
+
+### `cleanroom workspace diff`
+
+Show how `/workspace` differs from the cleanroom's recorded workspace
+baseline.
+
+```sh
+cleanroom workspace diff <sandbox-id>
+cleanroom workspace diff --stat <sandbox-id>
+cleanroom workspace diff --name-only <sandbox-id>
+```
+
+This command answers "what changed inside the cleanroom workspace?"
+
+It does not answer "what would be written locally?" Use
+`workspace export --dry-run` for that.
+
+The baseline should be the cleanroom's own workspace baseline: the workspace
+state created from the exact checkout or restored stage before workload changes
+are considered user output. If a later `workspace copy` copied local edits into
+the cleanroom, `workspace diff` may show those edits too. That is acceptable:
+the command is scoped to cleanroom workspace state, not local export effects.
+
+## Top-Level Automation
+
+Top-level automation should compose the same workspace operations exposed by
+the manual commands. `--copy` must behave exactly like
+`cleanroom workspace copy` for the same source and destination; the only
+difference is that the top-level command creates or selects the sandbox before
+running the copy operation.
+
+### `--copy`
+
+Supported on:
+
+- `cleanroom exec`
+- `cleanroom console`
+- `cleanroom create`
+
+`--copy` replaces `--include-local-changes` as the top-level copy-in flag.
+
+For Git-backed source workspaces, the implementation should reuse the existing
+repository changeset path:
+
+1. create or select the sandbox,
+2. create a repository changeset from local additions, modifications, and
+   deletes,
+3. apply that changeset after the exact checkout is prepared in `/workspace`,
+4. record local binding metadata so later `workspace copy`,
+   `workspace export`, and automated exports know the local root.
+
+For non-Git source workspaces, the same `--copy` flag should use raw workspace
+transfer instead of a changeset.
+
+The existing changeset path already has the right ignore shape: it stages the
+working tree through Git, so ignored files are not part of the copied payload
+unless they are tracked.
+
+### `--export-on-exit`
+
+Supported on:
+
+- `cleanroom exec`
+- `cleanroom console`
+
+For an automatically-created sandbox, `--export-on-exit` should run
+`workspace export` after the execution/session exits and before the CLI
+terminates the sandbox.
+
+For `--keep`, export should still run after the execution/session exits, but
+the sandbox should remain available. The user can run more explicit
+`workspace copy`, `workspace diff`, or `workspace export` commands later.
+
+For `cleanroom create`, export-on-termination needs extra local binding
+semantics. That should be a later phase. The first version should support
+manual `workspace export <sandbox-id>` for sandboxes created with `create`.
+
+### `--sync`
+
+Supported on:
+
+- `cleanroom exec`
+- `cleanroom console`
+
+`--sync` is a convenience alias for:
+
+```sh
+--copy --export-on-exit
+```
+
+Help text should state that equivalence literally. `--sync` should not be the
+primitive that implementation code special-cases; it should resolve into the
+directional copy/export options early in CLI parsing.
+
+### Defaults
+
+Workspace copy/export must be explicit. Even a source-scoped workspace mirror
+can touch a large number of files, so making it implicit would add a large file
+operation to ordinary executions and make the common command path unexpectedly
+slow.
+
+Defaults:
+
+- `cleanroom exec`: exact committed checkout, no workspace copy/export unless
+  `--copy`, `--export-on-exit`, or `--sync` is requested
+- `cleanroom console`: exact committed checkout, no workspace copy/export
+  unless requested
+- `cleanroom create`: exact committed checkout unless `--copy` is requested
+- CI or non-interactive execution: same exact committed checkout behavior
+- reused sandboxes via `--in <id>`: no implicit copy/export unless requested
+- snapshot-backed sandboxes via `--from <snapshot-id>`: no implicit
+  copy/export in the first version
+- export is never implicit except through explicit `--export-on-exit` or
+  `--sync`
+
+This deliberately avoids local-interactive detection, config defaults, and
+environment overrides.
+
+## Safety Model
+
+### Direction is explicit
+
+There is no bidirectional merge command in v1.
+
+- `copy` means local to cleanroom
+- `export` means cleanroom to local
+- `diff` means cleanroom workspace against cleanroom baseline
+- `sync` is a documented alias for copy plus export-on-exit
+
+### Mirror semantics are scoped by the workspace file set
+
+Workspace copy/export should mirror additions, modifications, and deletes in
+the named direction, but only inside the included workspace file set. This
+keeps the mental model simple without copying platform-specific dependency
+trees:
+
+- copy makes the included `/workspace` source set match the included local
+  source set
+- export makes the included local source set match the included `/workspace`
+  source set
+
+For Git-backed source workspaces, the default included file set is:
+
+- tracked paths
+- tracked paths deleted locally or inside the cleanroom
+- untracked paths that are not ignored by Git's standard ignore rules
+- paths previously copied by Cleanroom and recorded in the local binding
+  manifest
+
+Ignored paths are excluded by default for Git-backed sources in both
+directions. In practice, that means `node_modules/`, `.venv/`, build caches,
+and other ignored runtime outputs are not copied from macOS into Linux and are
+not exported from Linux back to macOS.
+
+The implementation should ask Git for this file set, using commands equivalent
+to `git ls-files` with standard excludes or the existing temporary-index
+changeset flow. It should not hand-parse `.gitignore`.
+
+For non-Git source workspaces, the default included file set is the raw
+workspace tree, excluding Cleanroom control metadata and destination-specific
+unsafe paths. There is no Git ignore model to infer, so raw copy is literal.
+
+The safety mechanism is conflict detection and dry-run output, not making
+delete behavior a separate mode.
+
+Delete propagation is also limited to the included file set. Git-backed export
+should not delete ignored local paths, even if the cleanroom workspace does not
+contain them.
+
+If a user deliberately wants ignored artifacts, they should use `cleanroom cp`
+for explicit paths or a future explicit include path. The MVP should not add a
+global `--include-ignored` switch because it is too easy to accidentally
+export platform-specific dependency trees.
+
+### Export detects local divergence
+
+Before exporting, the CLI should compare the current local paths that would be
+written or deleted against the manifest recorded at the last `workspace copy`
+or initial workspace import.
+
+If a local target changed independently, export should refuse by default.
+
+The refusal message should name the conflicting paths and suggest:
+
+```sh
+cleanroom workspace export --dry-run <sandbox-id>
+```
+
+The exported payload should remain available under Cleanroom state so users can
+recover it manually if needed.
+
+### No hidden mounts
+
+Workspace copy/export should be implemented as explicit file transfer events,
+not as a bind mount or backend-specific shared directory. That keeps the API
+and security model backend-neutral.
+
+## Transfer Representation
+
+The implementation should not depend on the `rsync` binary being installed in
+the guest. "Mirror" describes user semantics, not the wire protocol.
+
+The lower transfer layer already owns the per-file and archive mechanics:
+
+- stat one sandbox path
+- walk one sandbox tree
+- read one sandbox file as a bounded byte stream
+- write one local file stream to one sandbox file
+- remove one sandbox path
+- archive sandbox paths to a bounded byte stream
+- extract one archive stream into a sandbox directory
+
+Workspace copy/export should add a higher-level planning representation that
+is independent of transport:
+
+- normalized relative path
+- file type for regular files and directories
+- mode bits needed for executable files
+- content digest
+- optional content payload
+- delete marker
+- included/excluded reason, so dry runs can explain when ignored paths are not
+  candidates
+
+The planner should then select one of two transports:
+
+- Git changeset transport when the source workspace is a Git worktree and the
+  destination has the compatible recorded baseline.
+- Raw transfer transport when the source workspace is not a Git worktree.
+
+If the source is Git but the destination cannot accept the changeset because
+the baseline is missing or incompatible, fail with a clear error. Do not
+silently fall back to raw copy, because that changes ignore/delete semantics.
+
+For efficient raw-transfer implementation, the CLI can batch file changes into
+the existing archive-write path plus a workspace manifest. Export can use the
+inverse shape: build a manifest and payload from `/workspace`, stream it to the
+CLI through archive/read primitives, and let the CLI apply it to the local
+workspace after local conflict checks pass.
+
+`cleanroom cp` remains the one-file convenience layer over the same substrate.
+It should not grow workspace baselines or mirror behavior.
+
+Git remains useful for baseline, ignore, and diff calculation when the source
+workspace is a Git checkout. V1 should lean on that for safety while still
+supporting non-Git workspaces through raw transfer.
+
+## State and Metadata
+
+Cleanroom should record workspace metadata per sandbox:
+
+- sandbox ID
+- workspace root inside the sandbox, normally `/workspace`
+- local root path used for the last copy, stored client-side only
+- cleanroom workspace baseline manifest or tree digest
+- last copy manifest used for export conflict detection
+- ignore/source file-set mode used for the last copy
+- selected source transport, either Git changeset or raw transfer
+- last copy time
+
+The server should store sandbox/workspace facts needed to operate inside the
+sandbox. The CLI should store local filesystem paths in local state, not in
+portable server metadata, because the server may be remote and local paths may
+be sensitive or meaningless elsewhere.
+
+## API Shape
+
+The public CLI should lead the design. The transfer substrate now provides the
+low-level file/path/archive operations; workspace APIs should stay narrow and
+workspace-aware:
+
+- apply a workspace copy payload to a sandbox workspace, whether represented
+  as a Git changeset or a raw transfer manifest
+- produce a workspace diff against the cleanroom baseline
+- produce a workspace export payload and manifest
+
+Those operations should reject:
+
+- missing sandbox ID
+- stopped or non-ready sandbox
+- sandbox with an active execution
+- paths outside the workspace root
+- path traversal entries
+
+The workspace API should not reimplement `cleanroom cp`. It should consume the
+existing transfer and repository-changeset substrates, then add workspace-root
+scoping, baseline tracking, mirror planning, and conflict metadata.
+
+## Interaction With Existing Local Changesets
+
+`--include-local-changes` currently packages local dirty state as an explicit
+repository changeset during sandbox creation.
+
+This plan should rename that user-facing behavior to `--copy`:
+
+- `--copy` is the top-level one-shot copy-in flag for local workspace changes
+- `workspace copy` is the manual form of the same copy-in operation
+- Git source workspaces use repository changesets
+- non-Git source workspaces use raw workspace transfer
+- `workspace export` is the explicit copy-out primitive
+- `--export-on-exit` is the top-level copy-out automation
+- `--sync` composes copy-in with export-on-exit
+
+The term "repository changeset" should remain an implementation and diagnostic
+term. CLI help and docs for the happy path should describe the behavior as
+copying workspace changes.
+
+Because Cleanroom is pre-1.0, prefer removing `--include-local-changes` rather
+than keeping a long compatibility path. If a short alias is kept during
+transition, it should be documented as equivalent to `--copy` and then deleted
+before v1.
+
+## CI and Hermetic Workflows
+
+CI should remain straightforward:
+
+```sh
+cleanroom exec -- npm test
+```
+
+The default should continue to be exact committed checkout behavior:
+
+- no workspace copy unless requested
+- no export back to the checkout
+- dirty worktree warning if relevant
+- repository content comes from the resolved commit and explicit policy
+
+No environment or config default should implicitly enable workspace copy/export.
+CI, automation, and normal local executions get exact checkout behavior by
+omitting workspace copy/export flags.
+
+## Delivery Strategy
+
+### Phase 0: Transfer substrate
+
+Status: landed.
+
+- `cleanroom copy` / `cleanroom cp` supports one local file to one sandbox path
+  and one sandbox file to one local path.
+- Backend-neutral transfer helpers cover stat, walk, bounded read, streaming
+  write, remove, archive read, and archive write.
+- `docs/plans/sandbox-transfer-invariants.md` owns the low-level invariants and
+  adversarial file-transfer test matrix.
+
+### Phase 1: Unified workspace copy-in
+
+- Add a shared workspace copy planner used by both manual commands and
+  top-level automation.
+- Add `cleanroom workspace copy`.
+- Add `cleanroom workspace copy --dry-run`.
+- Add `--copy` to `exec`, `console`, and `create`.
+- Use repository changesets when the source workspace is a Git worktree.
+- Use raw workspace transfer when the source workspace is not a Git worktree.
+- Add tests that ignored files and directories, including a representative
+  `node_modules/`, are not included in Git-backed copy unless tracked.
+- Add tests that `workspace copy` and top-level `--copy` produce the same
+  destination contents for Git and non-Git sources.
+- Remove or immediately deprecate `--include-local-changes` as the old spelling
+  of the same behavior.
+- Apply copied changes after exact checkout setup and before command execution
+  or console entry.
+- Store enough local binding metadata for later export work.
+- Update help text and docs so `--copy` is the only recommended copy-in flag.
+
+### Phase 2: Workspace export and diff
+
+- Add `cleanroom workspace export --dry-run`.
+- Add `cleanroom workspace export`.
+- Add `cleanroom workspace diff`.
+- Add export tests proving ignored cleanroom outputs are not written back to
+  the local checkout by default.
+- Require explicit sandbox IDs or support `--last` consistently with existing
+  inspect commands.
+- Store local binding metadata in client-side Cleanroom state.
+
+### Phase 3: Safe top-level export automation
+
+- Add `--export-on-exit` to `exec` and `console`.
+- Add `--sync` as an alias for `--copy --export-on-exit`.
+- Add integration tests for local divergence, delete propagation, and dry-run
+  output.
+
+### Phase 4: Optional live local-to-cleanroom copy
+
+- Decide whether `--copy-live` is still needed after one-shot copy/export has
+  been exercised.
+- If implemented, add `--copy-live` to `exec` and `console`.
+- Keep `--sync` as `--copy --export-on-exit` unless we explicitly choose a
+  breaking semantic change.
+- Add file watching for `exec --copy-live` and `console --copy-live`.
+- Batch rapid local changes.
+- Propagate local delete events without periodically deleting unrelated
+  cleanroom-only generated files.
+- Surface live copy failures without hiding workload output.
+- Ensure live copy cannot race with an export operation.
+
+### Phase 5: Export-on-terminate for kept sandboxes
+
+- Decide whether `create` should record an export-on-termination binding.
+- If implemented, make `cleanroom sandbox rm` run export before termination
+  when a local binding exists.
+- If export fails, refuse termination by default and provide an explicit
+  discard flag.
+
+## Open Decisions
+
+- Whether custom `repository.path` values should be supported by workspace
+  commands or whether workspace copy should standardize on `/workspace`.
+- Whether export conflict override should be named `--force`, `--overwrite`,
+  or left out until there is a concrete need.
+- Whether workspace commands should support an explicit local root override, or
+  only use the bound/calling repository root.
+- What explicit-path UX should exist later for exporting ignored generated
+  artifacts when `cleanroom cp` is too low-level.
+- Whether live copy deserves a separate `--copy-live` flag after the one-shot
+  workflow lands.

--- a/docs/plans/workspace-sync.md
+++ b/docs/plans/workspace-sync.md
@@ -132,8 +132,13 @@ the source workspace:
 - Non-Git source: raw workspace transfer using the backend-neutral
   file/path/archive layer.
 
-Top-level `--copy` must call the same copy operation as
-`cleanroom workspace copy`; it is not a separate changeset-only mode.
+Top-level `--copy` should call the same copy operation as
+`cleanroom workspace copy`; it is not a separate changeset-only mode. The
+first implementation keeps that guarantee for Git-backed workspaces. For
+non-Git workspaces, `cleanroom workspace copy` can use raw transfer against an
+existing sandbox, but top-level `--copy` must stay disabled until there is a
+create-time raw workspace primitive that runs before dependency and service
+bootstrap.
 
 Workspace commands must operate on the sandbox's recorded workspace root. For
 repository-backed sandboxes, that root is the resolved `repository.path`,
@@ -256,8 +261,9 @@ repository changeset path:
 4. record local binding metadata so later `workspace copy`,
    `workspace export`, and automated exports know the local root.
 
-For non-Git source workspaces, the same `--copy` flag should use raw workspace
-transfer instead of a changeset.
+For non-Git source workspaces, the same `--copy` flag should eventually use raw
+workspace transfer instead of a changeset, but only once raw transfer can run as
+part of sandbox creation before bootstrap.
 
 The existing changeset path already has the right ignore shape: it stages the
 working tree through Git, so ignored files are not part of the copied payload
@@ -586,11 +592,14 @@ Status: landed.
 - Resolve the destination workspace root from `repository.path`, defaulting to
   `/workspace`.
 - Use repository changesets when the source workspace is a Git worktree.
-- Use raw workspace transfer when the source workspace is not a Git worktree.
+- Use raw workspace transfer for manual `workspace copy` when the source
+  workspace is not a Git worktree.
+- Reject top-level `--copy` for non-Git workspaces until raw transfer can be
+  attached to sandbox creation before bootstrap.
 - Add tests that ignored files and directories, including a representative
   `node_modules/`, are not included in Git-backed copy unless tracked.
 - Add tests that `workspace copy` and top-level `--copy` produce the same
-  destination contents for Git and non-Git sources.
+  destination contents for Git sources.
 - Remove or immediately deprecate `--include-local-changes` as the old spelling
   of the same behavior.
 - Apply copied changes after exact checkout setup and before command execution

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -60,6 +60,7 @@ type CLI struct {
 	Exec      ExecCommand      `cmd:"" help:"Execute a command in a sandbox"`
 	Console   ConsoleCommand   `cmd:"" help:"Run a command with an interactive tty in a sandbox"`
 	Copy      CopyCommand      `name:"copy" aliases:"cp" cmd:"" help:"Copy one file into or out of a sandbox"`
+	Workspace WorkspaceCommand `cmd:"" help:"Manage sandbox workspace contents"`
 	Serve     ServeCommand     `cmd:"" help:"Run the cleanroom control-plane server in the foreground"`
 	Daemon    DaemonCommand    `cmd:"" help:"Manage daemon/service lifecycle"`
 	Doctor    DoctorCommand    `cmd:"" help:"Run environment and backend diagnostics"`

--- a/internal/cli/cli_parse_test.go
+++ b/internal/cli/cli_parse_test.go
@@ -365,6 +365,21 @@ func TestTopLevelCommandsParseCopyFlag(t *testing.T) {
 	})
 }
 
+func TestWorkspaceCopyParses(t *testing.T) {
+	c := &CLI{}
+	parser := newParserForTest(t, c)
+
+	if _, err := parser.Parse([]string{"workspace", "copy", "--dry-run", "cr_123"}); err != nil {
+		t.Fatalf("parse workspace copy returned error: %v", err)
+	}
+	if got, want := c.Workspace.Copy.SandboxID, "cr_123"; got != want {
+		t.Fatalf("unexpected workspace copy sandbox id: got %q want %q", got, want)
+	}
+	if !c.Workspace.Copy.DryRun {
+		t.Fatal("expected workspace copy dry-run flag to be set")
+	}
+}
+
 func TestIncludeLocalChangesFlagRejected(t *testing.T) {
 	c := &CLI{}
 	parser := newParserForTest(t, c)

--- a/internal/cli/cli_parse_test.go
+++ b/internal/cli/cli_parse_test.go
@@ -330,6 +330,54 @@ func TestTopLevelCreateParsesDangerouslyAllowAll(t *testing.T) {
 	}
 }
 
+func TestTopLevelCommandsParseCopyFlag(t *testing.T) {
+	t.Run("create", func(t *testing.T) {
+		c := &CLI{}
+		parser := newParserForTest(t, c)
+		if _, err := parser.Parse([]string{"create", "--copy"}); err != nil {
+			t.Fatalf("parse create --copy returned error: %v", err)
+		}
+		if !c.Create.Copy {
+			t.Fatal("expected create copy flag to be set")
+		}
+	})
+
+	t.Run("exec", func(t *testing.T) {
+		c := &CLI{}
+		parser := newParserForTest(t, c)
+		if _, err := parser.Parse([]string{"exec", "--copy", "--", "echo", "ok"}); err != nil {
+			t.Fatalf("parse exec --copy returned error: %v", err)
+		}
+		if !c.Exec.Copy {
+			t.Fatal("expected exec copy flag to be set")
+		}
+	})
+
+	t.Run("console", func(t *testing.T) {
+		c := &CLI{}
+		parser := newParserForTest(t, c)
+		if _, err := parser.Parse([]string{"console", "--copy"}); err != nil {
+			t.Fatalf("parse console --copy returned error: %v", err)
+		}
+		if !c.Console.Copy {
+			t.Fatal("expected console copy flag to be set")
+		}
+	})
+}
+
+func TestIncludeLocalChangesFlagRejected(t *testing.T) {
+	c := &CLI{}
+	parser := newParserForTest(t, c)
+
+	_, err := parser.Parse([]string{"create", "--include-local-changes"})
+	if err == nil {
+		t.Fatal("expected removed --include-local-changes flag to be rejected")
+	}
+	if !strings.Contains(err.Error(), "unknown flag") || !strings.Contains(err.Error(), "--include-local-changes") {
+		t.Fatalf("expected unknown flag parse error, got %v", err)
+	}
+}
+
 func TestExecParsesImageOverride(t *testing.T) {
 	c := &CLI{}
 	parser := newParserForTest(t, c)

--- a/internal/cli/cli_parse_test.go
+++ b/internal/cli/cli_parse_test.go
@@ -330,53 +330,53 @@ func TestTopLevelCreateParsesDangerouslyAllowAll(t *testing.T) {
 	}
 }
 
-func TestTopLevelCommandsParseCopyFlag(t *testing.T) {
+func TestTopLevelCommandsParseCopyInFlag(t *testing.T) {
 	t.Run("create", func(t *testing.T) {
 		c := &CLI{}
 		parser := newParserForTest(t, c)
-		if _, err := parser.Parse([]string{"create", "--copy"}); err != nil {
-			t.Fatalf("parse create --copy returned error: %v", err)
+		if _, err := parser.Parse([]string{"create", "--copy-in"}); err != nil {
+			t.Fatalf("parse create --copy-in returned error: %v", err)
 		}
-		if !c.Create.Copy {
-			t.Fatal("expected create copy flag to be set")
+		if !c.Create.CopyIn {
+			t.Fatal("expected create copy-in flag to be set")
 		}
 	})
 
 	t.Run("exec", func(t *testing.T) {
 		c := &CLI{}
 		parser := newParserForTest(t, c)
-		if _, err := parser.Parse([]string{"exec", "--copy", "--", "echo", "ok"}); err != nil {
-			t.Fatalf("parse exec --copy returned error: %v", err)
+		if _, err := parser.Parse([]string{"exec", "--copy-in", "--", "echo", "ok"}); err != nil {
+			t.Fatalf("parse exec --copy-in returned error: %v", err)
 		}
-		if !c.Exec.Copy {
-			t.Fatal("expected exec copy flag to be set")
+		if !c.Exec.CopyIn {
+			t.Fatal("expected exec copy-in flag to be set")
 		}
 	})
 
 	t.Run("console", func(t *testing.T) {
 		c := &CLI{}
 		parser := newParserForTest(t, c)
-		if _, err := parser.Parse([]string{"console", "--copy"}); err != nil {
-			t.Fatalf("parse console --copy returned error: %v", err)
+		if _, err := parser.Parse([]string{"console", "--copy-in"}); err != nil {
+			t.Fatalf("parse console --copy-in returned error: %v", err)
 		}
-		if !c.Console.Copy {
-			t.Fatal("expected console copy flag to be set")
+		if !c.Console.CopyIn {
+			t.Fatal("expected console copy-in flag to be set")
 		}
 	})
 }
 
-func TestWorkspaceCopyParses(t *testing.T) {
+func TestWorkspaceCopyInParses(t *testing.T) {
 	c := &CLI{}
 	parser := newParserForTest(t, c)
 
-	if _, err := parser.Parse([]string{"workspace", "copy", "--dry-run", "cr_123"}); err != nil {
-		t.Fatalf("parse workspace copy returned error: %v", err)
+	if _, err := parser.Parse([]string{"workspace", "copy-in", "--dry-run", "cr_123"}); err != nil {
+		t.Fatalf("parse workspace copy-in returned error: %v", err)
 	}
-	if got, want := c.Workspace.Copy.SandboxID, "cr_123"; got != want {
-		t.Fatalf("unexpected workspace copy sandbox id: got %q want %q", got, want)
+	if got, want := c.Workspace.CopyIn.SandboxID, "cr_123"; got != want {
+		t.Fatalf("unexpected workspace copy-in sandbox id: got %q want %q", got, want)
 	}
-	if !c.Workspace.Copy.DryRun {
-		t.Fatal("expected workspace copy dry-run flag to be set")
+	if !c.Workspace.CopyIn.DryRun {
+		t.Fatal("expected workspace copy-in dry-run flag to be set")
 	}
 }
 

--- a/internal/cli/console.go
+++ b/internal/cli/console.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/buildkite/cleanroom/internal/controlclient"
 	"github.com/buildkite/cleanroom/internal/observability"
+	"github.com/buildkite/cleanroom/internal/repositorycheckout"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
@@ -103,6 +104,9 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) (runErr error) {
 	sandboxID = target.SandboxID
 	createdSandbox := target.CreatedSandbox
 	repository := target.Repository
+	if repository == nil && strings.TrimSpace(target.WorkspaceRoot) != "" {
+		command = repositorycheckout.WrapCommandInWorkdir(command, workspaceWorkdirCheckout(target.WorkspaceRoot))
+	}
 	printedSandboxID := false
 	printSandboxID := func() error {
 		if printedSandboxID {

--- a/internal/cli/console.go
+++ b/internal/cli/console.go
@@ -21,7 +21,7 @@ type ConsoleCommand struct {
 	From    string `name:"from" help:"Create the sandbox from an existing snapshot ID"`
 	Image   string `help:"Override sandbox image ref for newly created sandboxes (tag, digest, or local Docker image)"`
 	repositoryOverrideFlags
-	repositoryChangesetFlags
+	workspaceCopyFlags
 	Keep                bool     `help:"Keep a newly created sandbox after the console exits"`
 	DangerouslyAllowAll bool     `name:"dangerously-allow-all" help:"Disable network egress filtering for a newly created sandbox"`
 	Env                 []string `short:"e" name:"env" help:"Set guest environment variables; use KEY to inherit from the local environment or KEY=VALUE to set an explicit value"`
@@ -34,7 +34,7 @@ type ConsoleCommand struct {
 }
 
 func (c *ConsoleCommand) Run(ctx *runtimeContext) (runErr error) {
-	if err := validateExecutionSandboxArgs(c.Chdir, c.In, c.From, c.Keep, c.DangerouslyAllowAll, c.repositoryOverrideFlags, c.repositoryChangesetFlags); err != nil {
+	if err := validateExecutionSandboxArgs(c.Chdir, c.In, c.From, c.Keep, c.DangerouslyAllowAll, c.repositoryOverrideFlags, c.workspaceCopyFlags); err != nil {
 		return err
 	}
 
@@ -93,7 +93,7 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) (runErr error) {
 		return err
 	}
 
-	target, err := resolveExecutionSandbox(rootCtx, client, ctx, cwd, host, c.Backend, c.In, c.From, c.Image, c.LaunchSeconds, c.DangerouslyAllowAll, c.repositoryOverrideFlags, c.repositoryChangesetFlags)
+	target, err := resolveExecutionSandbox(rootCtx, client, ctx, cwd, host, c.Backend, c.In, c.From, c.Image, c.LaunchSeconds, c.DangerouslyAllowAll, c.repositoryOverrideFlags, c.workspaceCopyFlags)
 	if err != nil {
 		if strings.TrimSpace(c.From) != "" {
 			err = explainSnapshotRuntimeDisabledError(err, ctx)

--- a/internal/cli/copy_test.go
+++ b/internal/cli/copy_test.go
@@ -926,6 +926,8 @@ type copyIntegrationAdapter struct {
 	statFn     func(context.Context, string, string) (*backend.SandboxPathInfo, error)
 	readFn     func(context.Context, string, string, int64, func([]byte) error) error
 	writeFn    func(context.Context, string, string, io.Reader, fs.FileMode, time.Time) (int64, error)
+	removeFn   func(context.Context, string, string, bool) error
+	extractFn  func(context.Context, string, string, io.Reader) (int64, error)
 }
 
 func (a *copyIntegrationAdapter) DownloadSandboxFile(ctx context.Context, sandboxID, path string, maxBytes int64) ([]byte, error) {
@@ -961,6 +963,20 @@ func (a *copyIntegrationAdapter) WriteSandboxFile(ctx context.Context, sandboxID
 		return a.writeFn(ctx, sandboxID, path, r, mode, mtime)
 	}
 	return 0, errors.New("write not configured")
+}
+
+func (a *copyIntegrationAdapter) RemoveSandboxPath(ctx context.Context, sandboxID, path string, recursive bool) error {
+	if a.removeFn != nil {
+		return a.removeFn(ctx, sandboxID, path, recursive)
+	}
+	return errors.New("remove not configured")
+}
+
+func (a *copyIntegrationAdapter) ExtractSandboxArchive(ctx context.Context, sandboxID, destination string, r io.Reader) (int64, error) {
+	if a.extractFn != nil {
+		return a.extractFn(ctx, sandboxID, destination, r)
+	}
+	return 0, errors.New("extract not configured")
 }
 
 func copyTestSandboxFileStat(mode fs.FileMode, mtime time.Time) func(context.Context, string, string) (*backend.SandboxPathInfo, error) {

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -24,7 +24,7 @@ type ExecCommand struct {
 	From    string `name:"from" help:"Create the sandbox from an existing snapshot ID"`
 	Image   string `help:"Override sandbox image ref for newly created sandboxes (tag, digest, or local Docker image)"`
 	repositoryOverrideFlags
-	repositoryChangesetFlags
+	workspaceCopyFlags
 	Keep                bool     `help:"Keep a newly created sandbox after the command completes"`
 	DangerouslyAllowAll bool     `name:"dangerously-allow-all" help:"Disable network egress filtering for a newly created sandbox"`
 	Env                 []string `short:"e" name:"env" help:"Set guest environment variables; use KEY to inherit from the local environment or KEY=VALUE to set an explicit value"`
@@ -39,7 +39,7 @@ type ExecCommand struct {
 }
 
 func (e *ExecCommand) Run(ctx *runtimeContext) (runErr error) {
-	if err := validateExecutionSandboxArgs(e.Chdir, e.In, e.From, e.Keep, e.DangerouslyAllowAll, e.repositoryOverrideFlags, e.repositoryChangesetFlags); err != nil {
+	if err := validateExecutionSandboxArgs(e.Chdir, e.In, e.From, e.Keep, e.DangerouslyAllowAll, e.repositoryOverrideFlags, e.workspaceCopyFlags); err != nil {
 		return err
 	}
 	if e.TTY && e.NoStdin {
@@ -99,7 +99,7 @@ func (e *ExecCommand) Run(ctx *runtimeContext) (runErr error) {
 		return err
 	}
 
-	target, err := resolveExecutionSandbox(rootCtx, client, ctx, cwd, host, e.Backend, e.In, e.From, e.Image, e.LaunchSeconds, e.DangerouslyAllowAll, e.repositoryOverrideFlags, e.repositoryChangesetFlags)
+	target, err := resolveExecutionSandbox(rootCtx, client, ctx, cwd, host, e.Backend, e.In, e.From, e.Image, e.LaunchSeconds, e.DangerouslyAllowAll, e.repositoryOverrideFlags, e.workspaceCopyFlags)
 	if err != nil {
 		if strings.TrimSpace(e.From) != "" {
 			err = explainSnapshotRuntimeDisabledError(err, ctx)

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -109,6 +109,10 @@ func (e *ExecCommand) Run(ctx *runtimeContext) (runErr error) {
 	sandboxID = target.SandboxID
 	createdSandbox := target.CreatedSandbox
 	repository := target.Repository
+	command := append([]string(nil), e.Command...)
+	if repository == nil && strings.TrimSpace(target.WorkspaceRoot) != "" {
+		command = repositorycheckout.WrapCommandInWorkdir(command, workspaceWorkdirCheckout(target.WorkspaceRoot))
+	}
 	printedSandboxID := false
 	printSandboxID := func() error {
 		if printedSandboxID {
@@ -183,7 +187,7 @@ func (e *ExecCommand) Run(ctx *runtimeContext) (runErr error) {
 			host,
 			sandboxID,
 			repository,
-			e.Command,
+			command,
 			executionEnv,
 			e.LaunchSeconds,
 			interactiveExecutionOptions{
@@ -205,7 +209,7 @@ func (e *ExecCommand) Run(ctx *runtimeContext) (runErr error) {
 
 	createExecutionResp, err := client.CreateExecution(rootCtx, &cleanroomv1.CreateExecutionRequest{
 		SandboxId:          sandboxID,
-		Command:            repositorycheckout.NormalizeCommand(e.Command),
+		Command:            repositorycheckout.NormalizeCommand(command),
 		Env:                executionEnv,
 		Kind:               cleanroomv1.ExecutionKind_EXECUTION_KIND_BATCH,
 		RepositoryCheckout: repositoryCheckoutProto(repository),

--- a/internal/cli/exec_integration_test.go
+++ b/internal/cli/exec_integration_test.go
@@ -212,7 +212,7 @@ func startIntegrationServerWithConfig(t *testing.T, adapter backend.Adapter, cfg
 		},
 	}
 
-	httpServer := httptest.NewServer(controlserver.New(svc, nil).Handler())
+	httpServer := httptest.NewServer(controlserver.New(svc, nil).TrustInternalWorkspaceCopyInRequests().Handler())
 	t.Cleanup(httpServer.Close)
 
 	quicCtx, quicCancel := context.WithCancel(context.Background())
@@ -261,7 +261,7 @@ func startUnixIntegrationServer(t *testing.T, adapter backend.Adapter) (string, 
 	if err != nil {
 		t.Fatalf("listen on unix socket: %v", err)
 	}
-	server := &http.Server{Handler: controlserver.New(svc, nil).Handler()}
+	server := &http.Server{Handler: controlserver.New(svc, nil).TrustInternalWorkspaceCopyInRequests().Handler()}
 	go func() {
 		_ = server.Serve(listener)
 	}()

--- a/internal/cli/execution_shared.go
+++ b/internal/cli/execution_shared.go
@@ -97,6 +97,7 @@ func resolveExecutionSandbox(
 	workspaceRoot := ""
 	if copyFlags.Copy && fromSnapshot == "" {
 		changesetAppliedDuringCreate := existingSandboxID == "" && repository != nil && changeset != nil
+		copyRepository := repository
 		if repository == nil {
 			workspaceRoot, err = resolveSandboxWorkspaceDestination(callCtx, client, sandboxID)
 			if err != nil {
@@ -110,14 +111,14 @@ func resolveExecutionSandbox(
 			if err != nil {
 				return nil, err
 			}
-			repository = effectiveRepository
-			workspaceRoot = repository.DestinationDir
+			copyRepository = effectiveRepository
+			workspaceRoot = effectiveRepository.DestinationDir
 		}
 		if !changesetAppliedDuringCreate {
 			if err := copyWorkspaceToSandbox(callCtx, ctx, client, workspaceCopyOptions{
 				CWD:           cwd,
 				SandboxID:     sandboxID,
-				Repository:    repository,
+				Repository:    copyRepository,
 				Destination:   workspaceRoot,
 				ForceGitReset: existingSandboxID != "",
 			}); err != nil {
@@ -125,6 +126,9 @@ func resolveExecutionSandbox(
 					terminateSandboxBestEffort(callCtx, client, sandboxID, 0, nil, "")
 				}
 				return nil, err
+			}
+			if existingSandboxID != "" && copyRepository != nil {
+				repository = nil
 			}
 		}
 	}

--- a/internal/cli/execution_shared.go
+++ b/internal/cli/execution_shared.go
@@ -98,7 +98,7 @@ func resolveExecutionSandbox(
 	if copyFlags.Copy && fromSnapshot == "" {
 		changesetAppliedDuringCreate := existingSandboxID == "" && repository != nil && changeset != nil
 		if repository == nil {
-			workspaceRoot, err = resolveWorkspaceDestinationRoot(cwd, ctx.Loader)
+			workspaceRoot, err = resolveSandboxWorkspaceDestination(callCtx, client, sandboxID)
 			if err != nil {
 				return nil, err
 			}
@@ -108,6 +108,7 @@ func resolveExecutionSandbox(
 				CWD:           cwd,
 				SandboxID:     sandboxID,
 				Repository:    repository,
+				Destination:   workspaceRoot,
 				ForceGitReset: existingSandboxID != "",
 			}); err != nil {
 				if createdSandbox {

--- a/internal/cli/execution_shared.go
+++ b/internal/cli/execution_shared.go
@@ -63,6 +63,9 @@ func resolveExecutionSandbox(
 		if err != nil {
 			return nil, err
 		}
+		if err := validateTopLevelWorkspaceCopyTransport(repository, copyFlags.Copy && existingSandboxID == ""); err != nil {
+			return nil, err
+		}
 		if existingSandboxID == "" {
 			changeset, err = resolveRepositoryChangeset(repository, copyFlags.Copy)
 			if err != nil {

--- a/internal/cli/execution_shared.go
+++ b/internal/cli/execution_shared.go
@@ -59,7 +59,11 @@ func resolveExecutionSandbox(
 	var changeset *cleanroomv1.RepositoryChangeset
 	if fromSnapshot == "" && (existingSandboxID == "" || copyFlags.Copy) {
 		var err error
-		repository, err = resolveRepositoryCheckoutWithOverride(cwd, ctx.Loader, repositoryOverride)
+		if copyFlags.Copy && existingSandboxID != "" && !repositoryOverride.hasRepositoryOverride() {
+			repository, err = resolveWorkspaceCopyRepositoryCheckout(cwd, ctx.Loader)
+		} else {
+			repository, err = resolveRepositoryCheckoutWithOverride(cwd, ctx.Loader, repositoryOverride)
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/internal/cli/execution_shared.go
+++ b/internal/cli/execution_shared.go
@@ -49,25 +49,25 @@ func resolveExecutionSandbox(
 	launchSeconds int64,
 	dangerouslyAllowAll bool,
 	repositoryOverride repositoryOverrideFlags,
-	changesetFlags repositoryChangesetFlags,
+	copyFlags workspaceCopyFlags,
 ) (*executionSandbox, error) {
 	existingSandboxID = strings.TrimSpace(existingSandboxID)
 	fromSnapshot = strings.TrimSpace(fromSnapshot)
 
 	var repository *resolvedRepositoryCheckout
-	localChanges := repositoryLocalChanges{}
+	var changeset *cleanroomv1.RepositoryChangeset
 	if existingSandboxID == "" && fromSnapshot == "" {
 		var err error
 		repository, err = resolveRepositoryCheckoutWithOverride(cwd, ctx.Loader, repositoryOverride)
 		if err != nil {
 			return nil, err
 		}
-		localChanges, err = resolveRepositoryLocalChanges(repository, changesetFlags.IncludeLocalChanges)
+		changeset, err = resolveRepositoryChangeset(repository, copyFlags.Copy)
 		if err != nil {
 			return nil, err
 		}
 	}
-	warnDirtyRepositoryCheckout(repository, localChanges.Changeset != nil || localChanges.CommitBundle != nil)
+	warnDirtyRepositoryCheckout(repository, changeset != nil)
 
 	sandboxID, createdSandbox, err := ensureSandboxID(
 		callCtx,
@@ -82,7 +82,7 @@ func resolveExecutionSandbox(
 		launchSeconds,
 		dangerouslyAllowAll,
 		repository,
-		localChanges,
+		changeset,
 	)
 	if err != nil {
 		return nil, err
@@ -95,7 +95,7 @@ func resolveExecutionSandbox(
 	}, nil
 }
 
-func ensureSandboxID(callCtx context.Context, client *controlclient.Client, loader policyLoader, cwd, host, backendName, existingSandboxID, fromSnapshot, imageRefOverride string, launchSeconds int64, dangerouslyAllowAll bool, repository *resolvedRepositoryCheckout, localChanges repositoryLocalChanges) (string, bool, error) {
+func ensureSandboxID(callCtx context.Context, client *controlclient.Client, loader policyLoader, cwd, host, backendName, existingSandboxID, fromSnapshot, imageRefOverride string, launchSeconds int64, dangerouslyAllowAll bool, repository *resolvedRepositoryCheckout, changeset *cleanroomv1.RepositoryChangeset) (string, bool, error) {
 	sandboxID := strings.TrimSpace(existingSandboxID)
 	fromSnapshot = strings.TrimSpace(fromSnapshot)
 	if sandboxID != "" {
@@ -135,7 +135,7 @@ func ensureSandboxID(callCtx context.Context, client *controlclient.Client, load
 		return sandboxID, true, nil
 	}
 
-	sandboxID, _, err := createTopLevelSandbox(callCtx, client, loader, cwd, host, backendName, imageRefOverride, launchSeconds, dangerouslyAllowAll, repository, localChanges)
+	sandboxID, _, err := createTopLevelSandbox(callCtx, client, loader, cwd, host, backendName, imageRefOverride, launchSeconds, dangerouslyAllowAll, repository, changeset)
 	if err != nil {
 		return "", false, err
 	}
@@ -202,7 +202,7 @@ func executionCommandSummary(command []string) string {
 	return summary
 }
 
-func validateExecutionSandboxArgs(chdir, existingSandboxID, fromSnapshot string, keep, dangerouslyAllowAll bool, repositoryOverride repositoryOverrideFlags, changesetFlags repositoryChangesetFlags) error {
+func validateExecutionSandboxArgs(chdir, existingSandboxID, fromSnapshot string, keep, dangerouslyAllowAll bool, repositoryOverride repositoryOverrideFlags, copyFlags workspaceCopyFlags) error {
 	sandboxID := strings.TrimSpace(existingSandboxID)
 	snapshotID := strings.TrimSpace(fromSnapshot)
 	hasChdir := strings.TrimSpace(chdir) != ""
@@ -210,7 +210,7 @@ func validateExecutionSandboxArgs(chdir, existingSandboxID, fromSnapshot string,
 	if _, err := repositoryOverride.resolve(".", nil); err != nil {
 		return err
 	}
-	if err := changesetFlags.validate(existingSandboxID, fromSnapshot, repositoryOverride); err != nil {
+	if err := copyFlags.validate(existingSandboxID, fromSnapshot, repositoryOverride); err != nil {
 		return err
 	}
 

--- a/internal/cli/execution_shared.go
+++ b/internal/cli/execution_shared.go
@@ -121,6 +121,7 @@ func resolveExecutionSandbox(
 				Repository:    copyRepository,
 				Destination:   workspaceRoot,
 				ForceGitReset: existingSandboxID != "",
+				LaunchSeconds: launchSeconds,
 			}); err != nil {
 				if createdSandbox {
 					terminateSandboxBestEffort(callCtx, client, sandboxID, 0, nil, "")

--- a/internal/cli/execution_shared.go
+++ b/internal/cli/execution_shared.go
@@ -102,6 +102,16 @@ func resolveExecutionSandbox(
 			if err != nil {
 				return nil, err
 			}
+		} else if existingSandboxID != "" {
+			effectiveRepository, _, err := resolveGitWorkspaceCheckout(callCtx, client, workspaceCopyOptions{
+				SandboxID:  sandboxID,
+				Repository: repository,
+			})
+			if err != nil {
+				return nil, err
+			}
+			repository = effectiveRepository
+			workspaceRoot = repository.DestinationDir
 		}
 		if !changesetAppliedDuringCreate {
 			if err := copyWorkspaceToSandbox(callCtx, ctx, client, workspaceCopyOptions{

--- a/internal/cli/execution_shared.go
+++ b/internal/cli/execution_shared.go
@@ -56,7 +56,7 @@ func resolveExecutionSandbox(
 	fromSnapshot = strings.TrimSpace(fromSnapshot)
 
 	var repository *resolvedRepositoryCheckout
-	var changeset *cleanroomv1.RepositoryChangeset
+	localChanges := repositoryLocalChanges{}
 	if fromSnapshot == "" && (existingSandboxID == "" || copyFlags.CopyIn) {
 		var err error
 		if copyFlags.CopyIn && existingSandboxID != "" && !repositoryOverride.hasRepositoryOverride() {
@@ -71,7 +71,7 @@ func resolveExecutionSandbox(
 			return nil, err
 		}
 		if existingSandboxID == "" {
-			changeset, err = resolveRepositoryChangeset(repository, copyFlags.CopyIn)
+			localChanges, err = resolveRepositoryLocalChanges(repository, copyFlags.CopyIn)
 			if err != nil {
 				return nil, err
 			}
@@ -92,7 +92,7 @@ func resolveExecutionSandbox(
 		launchSeconds,
 		dangerouslyAllowAll,
 		repository,
-		changeset,
+		localChanges,
 	)
 	if err != nil {
 		return nil, err
@@ -100,7 +100,7 @@ func resolveExecutionSandbox(
 
 	workspaceRoot := ""
 	if copyFlags.CopyIn && fromSnapshot == "" {
-		changesetAppliedDuringCreate := existingSandboxID == "" && repository != nil && changeset != nil
+		localChangesAttachedDuringCreate := existingSandboxID == "" && repository != nil && (localChanges.Changeset != nil || localChanges.CommitBundle != nil)
 		copyRepository := repository
 		if repository == nil {
 			workspaceRoot, err = resolveSandboxWorkspaceDestination(callCtx, client, sandboxID)
@@ -118,7 +118,7 @@ func resolveExecutionSandbox(
 			copyRepository = effectiveRepository
 			workspaceRoot = effectiveRepository.DestinationDir
 		}
-		if !changesetAppliedDuringCreate {
+		if !localChangesAttachedDuringCreate {
 			if err := copyWorkspaceToSandbox(callCtx, ctx, client, workspaceCopyOptions{
 				CWD:           cwd,
 				SandboxID:     sandboxID,
@@ -146,7 +146,7 @@ func resolveExecutionSandbox(
 	}, nil
 }
 
-func ensureSandboxID(callCtx context.Context, client *controlclient.Client, loader policyLoader, cwd, host, backendName, existingSandboxID, fromSnapshot, imageRefOverride string, launchSeconds int64, dangerouslyAllowAll bool, repository *resolvedRepositoryCheckout, changeset *cleanroomv1.RepositoryChangeset) (string, bool, error) {
+func ensureSandboxID(callCtx context.Context, client *controlclient.Client, loader policyLoader, cwd, host, backendName, existingSandboxID, fromSnapshot, imageRefOverride string, launchSeconds int64, dangerouslyAllowAll bool, repository *resolvedRepositoryCheckout, localChanges repositoryLocalChanges) (string, bool, error) {
 	sandboxID := strings.TrimSpace(existingSandboxID)
 	fromSnapshot = strings.TrimSpace(fromSnapshot)
 	if sandboxID != "" {
@@ -186,7 +186,7 @@ func ensureSandboxID(callCtx context.Context, client *controlclient.Client, load
 		return sandboxID, true, nil
 	}
 
-	sandboxID, _, err := createTopLevelSandbox(callCtx, client, loader, cwd, host, backendName, imageRefOverride, launchSeconds, dangerouslyAllowAll, repository, changeset)
+	sandboxID, _, err := createTopLevelSandbox(callCtx, client, loader, cwd, host, backendName, imageRefOverride, launchSeconds, dangerouslyAllowAll, repository, localChanges)
 	if err != nil {
 		return "", false, err
 	}

--- a/internal/cli/execution_shared.go
+++ b/internal/cli/execution_shared.go
@@ -57,9 +57,9 @@ func resolveExecutionSandbox(
 
 	var repository *resolvedRepositoryCheckout
 	var changeset *cleanroomv1.RepositoryChangeset
-	if fromSnapshot == "" && (existingSandboxID == "" || copyFlags.Copy) {
+	if fromSnapshot == "" && (existingSandboxID == "" || copyFlags.CopyIn) {
 		var err error
-		if copyFlags.Copy && existingSandboxID != "" && !repositoryOverride.hasRepositoryOverride() {
+		if copyFlags.CopyIn && existingSandboxID != "" && !repositoryOverride.hasRepositoryOverride() {
 			repository, err = resolveWorkspaceCopyRepositoryCheckout(cwd, ctx.Loader)
 		} else {
 			repository, err = resolveRepositoryCheckoutWithOverride(cwd, ctx.Loader, repositoryOverride)
@@ -67,17 +67,17 @@ func resolveExecutionSandbox(
 		if err != nil {
 			return nil, err
 		}
-		if err := validateTopLevelWorkspaceCopyTransport(repository, copyFlags.Copy && existingSandboxID == ""); err != nil {
+		if err := validateTopLevelWorkspaceCopyTransport(repository, copyFlags.CopyIn && existingSandboxID == ""); err != nil {
 			return nil, err
 		}
 		if existingSandboxID == "" {
-			changeset, err = resolveRepositoryChangeset(repository, copyFlags.Copy)
+			changeset, err = resolveRepositoryChangeset(repository, copyFlags.CopyIn)
 			if err != nil {
 				return nil, err
 			}
 		}
 	}
-	warnDirtyRepositoryCheckout(repository, copyFlags.Copy && repository != nil && fromSnapshot == "")
+	warnDirtyRepositoryCheckout(repository, copyFlags.CopyIn && repository != nil && fromSnapshot == "")
 
 	sandboxID, createdSandbox, err := ensureSandboxID(
 		callCtx,
@@ -99,7 +99,7 @@ func resolveExecutionSandbox(
 	}
 
 	workspaceRoot := ""
-	if copyFlags.Copy && fromSnapshot == "" {
+	if copyFlags.CopyIn && fromSnapshot == "" {
 		changesetAppliedDuringCreate := existingSandboxID == "" && repository != nil && changeset != nil
 		copyRepository := repository
 		if repository == nil {
@@ -277,7 +277,7 @@ func validateExecutionSandboxArgs(chdir, existingSandboxID, fromSnapshot string,
 	if snapshotID != "" && dangerouslyAllowAll {
 		return errors.New("--dangerously-allow-all cannot be used with --from")
 	}
-	if sandboxID != "" && hasChdir && !copyFlags.Copy {
+	if sandboxID != "" && hasChdir && !copyFlags.CopyIn {
 		return errors.New("--chdir cannot be used with --in")
 	}
 	if snapshotID != "" && hasChdir {

--- a/internal/cli/execution_shared.go
+++ b/internal/cli/execution_shared.go
@@ -36,6 +36,7 @@ type executionSandbox struct {
 	SandboxID      string
 	CreatedSandbox bool
 	Repository     *resolvedRepositoryCheckout
+	WorkspaceRoot  string
 }
 
 // resolveExecutionSandbox keeps `exec` and `console` on the same sandbox
@@ -56,18 +57,20 @@ func resolveExecutionSandbox(
 
 	var repository *resolvedRepositoryCheckout
 	var changeset *cleanroomv1.RepositoryChangeset
-	if existingSandboxID == "" && fromSnapshot == "" {
+	if fromSnapshot == "" && (existingSandboxID == "" || copyFlags.Copy) {
 		var err error
 		repository, err = resolveRepositoryCheckoutWithOverride(cwd, ctx.Loader, repositoryOverride)
 		if err != nil {
 			return nil, err
 		}
-		changeset, err = resolveRepositoryChangeset(repository, copyFlags.Copy)
-		if err != nil {
-			return nil, err
+		if existingSandboxID == "" {
+			changeset, err = resolveRepositoryChangeset(repository, copyFlags.Copy)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
-	warnDirtyRepositoryCheckout(repository, changeset != nil)
+	warnDirtyRepositoryCheckout(repository, copyFlags.Copy && repository != nil && fromSnapshot == "")
 
 	sandboxID, createdSandbox, err := ensureSandboxID(
 		callCtx,
@@ -88,10 +91,35 @@ func resolveExecutionSandbox(
 		return nil, err
 	}
 
+	workspaceRoot := ""
+	if copyFlags.Copy && fromSnapshot == "" {
+		changesetAppliedDuringCreate := existingSandboxID == "" && repository != nil && changeset != nil
+		if repository == nil {
+			workspaceRoot, err = resolveWorkspaceDestinationRoot(cwd, ctx.Loader)
+			if err != nil {
+				return nil, err
+			}
+		}
+		if !changesetAppliedDuringCreate {
+			if err := copyWorkspaceToSandbox(callCtx, ctx, client, workspaceCopyOptions{
+				CWD:           cwd,
+				SandboxID:     sandboxID,
+				Repository:    repository,
+				ForceGitReset: existingSandboxID != "",
+			}); err != nil {
+				if createdSandbox {
+					terminateSandboxBestEffort(callCtx, client, sandboxID, 0, nil, "")
+				}
+				return nil, err
+			}
+		}
+	}
+
 	return &executionSandbox{
 		SandboxID:      sandboxID,
 		CreatedSandbox: createdSandbox,
 		Repository:     repository,
+		WorkspaceRoot:  workspaceRoot,
 	}, nil
 }
 
@@ -226,7 +254,7 @@ func validateExecutionSandboxArgs(chdir, existingSandboxID, fromSnapshot string,
 	if snapshotID != "" && dangerouslyAllowAll {
 		return errors.New("--dangerously-allow-all cannot be used with --from")
 	}
-	if sandboxID != "" && hasChdir {
+	if sandboxID != "" && hasChdir && !copyFlags.Copy {
 		return errors.New("--chdir cannot be used with --in")
 	}
 	if snapshotID != "" && hasChdir {

--- a/internal/cli/repository.go
+++ b/internal/cli/repository.go
@@ -89,6 +89,23 @@ func resolveRepositoryCheckoutWithOverride(cwd string, loader policyLoader, over
 		}
 		return nil, err
 	}
+	return resolveRepositoryCheckoutFromConfig(cwd, loader, repository, true)
+}
+
+func resolveWorkspaceCopyRepositoryCheckout(cwd string, loader policyLoader) (*resolvedRepositoryCheckout, error) {
+	repository, err := resolveRepositoryCheckout(cwd, loader)
+	if err != nil || repository != nil {
+		return repository, err
+	}
+	return resolveRepositoryCheckoutFromConfig(cwd, loader, policy.RepositoryConfig{
+		Implicit: true,
+		Mode:     "current-repo",
+		Remote:   "origin",
+		Path:     defaultRepositoryOverridePath,
+	}, false)
+}
+
+func resolveRepositoryCheckoutFromConfig(cwd string, loader policyLoader, repository policy.RepositoryConfig, validatePolicy bool) (*resolvedRepositoryCheckout, error) {
 	repoRoot, err := resolveRepositoryRoot(cwd, repository)
 	if err != nil {
 		if errors.Is(err, errSkipRepositoryCheckout) {
@@ -118,12 +135,14 @@ func resolveRepositoryCheckoutWithOverride(cwd string, loader policyLoader, over
 		return nil, err
 	}
 
-	compiled, _, err := loader.LoadAndCompile(cwd)
-	if err != nil {
-		return nil, err
-	}
-	if compiled != nil && !compiled.Allows(remoteHost, 443) {
-		return nil, fmt.Errorf("repository remote host %q is not allowed by sandbox policy", remoteHost)
+	if validatePolicy && loader != nil {
+		compiled, _, err := loader.LoadAndCompile(cwd)
+		if err != nil {
+			return nil, err
+		}
+		if compiled != nil && !compiled.Allows(remoteHost, 443) {
+			return nil, fmt.Errorf("repository remote host %q is not allowed by sandbox policy", remoteHost)
+		}
 	}
 
 	return &resolvedRepositoryCheckout{

--- a/internal/cli/repository.go
+++ b/internal/cli/repository.go
@@ -97,12 +97,54 @@ func resolveWorkspaceCopyRepositoryCheckout(cwd string, loader policyLoader) (*r
 	if err != nil || repository != nil {
 		return repository, err
 	}
+	remoteName, err := resolveImplicitRepositoryRemote(cwd)
+	if err != nil {
+		if errors.Is(err, errSkipRepositoryCheckout) {
+			return nil, nil
+		}
+		return nil, err
+	}
 	return resolveRepositoryCheckoutFromConfig(cwd, loader, policy.RepositoryConfig{
 		Implicit: true,
 		Mode:     "current-repo",
-		Remote:   "origin",
+		Remote:   remoteName,
 		Path:     defaultRepositoryOverridePath,
 	}, false)
+}
+
+func resolveImplicitRepositoryRemote(cwd string) (string, error) {
+	repoRoot, err := resolveRepositoryRoot(cwd, policy.RepositoryConfig{
+		Implicit: true,
+		Mode:     "current-repo",
+		Path:     defaultRepositoryOverridePath,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	if upstream, err := gitOutput(repoRoot, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"); err == nil {
+		if remote, _, ok := strings.Cut(strings.TrimSpace(upstream), "/"); ok && strings.TrimSpace(remote) != "" {
+			return strings.TrimSpace(remote), nil
+		}
+	}
+
+	remoteOutput, err := gitOutput(repoRoot, "remote")
+	if err != nil {
+		return "", fmt.Errorf("list repository remotes: %w", err)
+	}
+	remotes := strings.Fields(remoteOutput)
+	switch len(remotes) {
+	case 0:
+		return "", errors.New("workspace copy-in requires a repository remote")
+	case 1:
+		return remotes[0], nil
+	}
+	for _, remote := range remotes {
+		if remote == "origin" {
+			return remote, nil
+		}
+	}
+	return "", fmt.Errorf("workspace copy-in found multiple repository remotes (%s); configure repository.remote in cleanroom.yaml", strings.Join(remotes, ", "))
 }
 
 func resolveRepositoryCheckoutFromConfig(cwd string, loader policyLoader, repository policy.RepositoryConfig, validatePolicy bool) (*resolvedRepositoryCheckout, error) {

--- a/internal/cli/repository_changeset.go
+++ b/internal/cli/repository_changeset.go
@@ -13,13 +13,11 @@ type workspaceCopyFlags struct {
 	Copy bool `name:"copy" help:"Copy local workspace changes into the sandbox workspace before running"`
 }
 
-func (f workspaceCopyFlags) validate(existingSandboxID, fromSnapshot string, repositoryOverride repositoryOverrideFlags) error {
+func (f workspaceCopyFlags) validate(_ string, fromSnapshot string, repositoryOverride repositoryOverrideFlags) error {
 	if !f.Copy {
 		return nil
 	}
 	switch {
-	case strings.TrimSpace(existingSandboxID) != "":
-		return errors.New("--copy cannot be used with --in")
 	case strings.TrimSpace(fromSnapshot) != "":
 		return errors.New("--copy cannot be used with --from")
 	case repositoryOverride.hasRepositoryOverride():
@@ -34,7 +32,7 @@ func resolveRepositoryChangeset(repository *resolvedRepositoryCheckout, copyWork
 		return nil, nil
 	}
 	if repository == nil {
-		return nil, errors.New("--copy requires a repository-aware top-level command")
+		return nil, nil
 	}
 	if strings.TrimSpace(repository.RootDir) == "" {
 		return nil, errors.New("--copy requires a local repository checkout")

--- a/internal/cli/repository_changeset.go
+++ b/internal/cli/repository_changeset.go
@@ -6,64 +6,46 @@ import (
 	"strings"
 
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
-	"github.com/buildkite/cleanroom/internal/repositorybundle"
 	"github.com/buildkite/cleanroom/internal/repositorychangeset"
 )
 
-type repositoryChangesetFlags struct {
-	IncludeLocalChanges bool `name:"include-local-changes" help:"Package local-only commits plus uncommitted changes and apply them after exact repository checkout"`
+type workspaceCopyFlags struct {
+	Copy bool `name:"copy" help:"Copy local workspace changes into the sandbox workspace before running"`
 }
 
-type repositoryLocalChanges struct {
-	Changeset    *cleanroomv1.RepositoryChangeset
-	CommitBundle *cleanroomv1.RepositoryCommitBundle
-}
-
-func (f repositoryChangesetFlags) validate(existingSandboxID, fromSnapshot string, repositoryOverride repositoryOverrideFlags) error {
-	if !f.IncludeLocalChanges {
+func (f workspaceCopyFlags) validate(existingSandboxID, fromSnapshot string, repositoryOverride repositoryOverrideFlags) error {
+	if !f.Copy {
 		return nil
 	}
 	switch {
 	case strings.TrimSpace(existingSandboxID) != "":
-		return errors.New("--include-local-changes cannot be used with --in")
+		return errors.New("--copy cannot be used with --in")
 	case strings.TrimSpace(fromSnapshot) != "":
-		return errors.New("--include-local-changes cannot be used with --from")
+		return errors.New("--copy cannot be used with --from")
 	case repositoryOverride.hasRepositoryOverride():
-		return errors.New("--include-local-changes cannot be used with --repo-url or --repo-commit")
+		return errors.New("--copy cannot be used with --repo-url or --repo-commit")
 	default:
 		return nil
 	}
 }
 
-func resolveRepositoryLocalChanges(repository *resolvedRepositoryCheckout, includeLocalChanges bool) (repositoryLocalChanges, error) {
-	if !includeLocalChanges {
-		return repositoryLocalChanges{}, nil
+func resolveRepositoryChangeset(repository *resolvedRepositoryCheckout, copyWorkspace bool) (*cleanroomv1.RepositoryChangeset, error) {
+	if !copyWorkspace {
+		return nil, nil
 	}
 	if repository == nil {
-		return repositoryLocalChanges{}, errors.New("--include-local-changes requires a repository-aware top-level command")
+		return nil, errors.New("--copy requires a repository-aware top-level command")
 	}
 	if strings.TrimSpace(repository.RootDir) == "" {
-		return repositoryLocalChanges{}, errors.New("--include-local-changes requires a local repository checkout")
-	}
-	if strings.TrimSpace(repository.RemoteName) == "" {
-		return repositoryLocalChanges{}, errors.New("--include-local-changes requires a named repository remote")
-	}
-
-	commitBundle, err := repositorybundle.BuildFromRepository(repository.RootDir, repository.RemoteName, toRepositoryCheckout(repository))
-	if err != nil {
-		return repositoryLocalChanges{}, fmt.Errorf("package local repository commits: %w", err)
+		return nil, errors.New("--copy requires a local repository checkout")
 	}
 
 	changeset, err := repositorychangeset.BuildFromWorkingTree(repository.RootDir, toRepositoryCheckout(repository))
 	if err != nil {
-		return repositoryLocalChanges{}, fmt.Errorf("package local repository changes: %w", err)
+		return nil, fmt.Errorf("package local repository changes: %w", err)
 	}
-	out := repositoryLocalChanges{}
-	if commitBundle != nil {
-		out.CommitBundle = commitBundle.ToProto()
+	if changeset == nil {
+		return nil, nil
 	}
-	if changeset != nil {
-		out.Changeset = changeset.ToProto()
-	}
-	return out, nil
+	return changeset.ToProto(), nil
 }

--- a/internal/cli/repository_changeset.go
+++ b/internal/cli/repository_changeset.go
@@ -27,6 +27,13 @@ func (f workspaceCopyFlags) validate(_ string, fromSnapshot string, repositoryOv
 	}
 }
 
+func validateTopLevelWorkspaceCopyTransport(repository *resolvedRepositoryCheckout, copyWorkspace bool) error {
+	if !copyWorkspace || repository != nil {
+		return nil
+	}
+	return errors.New("--copy for non-Git workspaces cannot be used while creating a sandbox yet; create the sandbox first, then run cleanroom workspace copy <sandbox-id>")
+}
+
 func resolveRepositoryChangeset(repository *resolvedRepositoryCheckout, copyWorkspace bool) (*cleanroomv1.RepositoryChangeset, error) {
 	if !copyWorkspace {
 		return nil, nil

--- a/internal/cli/repository_changeset.go
+++ b/internal/cli/repository_changeset.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+	"github.com/buildkite/cleanroom/internal/repositorybundle"
 	"github.com/buildkite/cleanroom/internal/repositorychangeset"
 )
 
@@ -34,23 +35,40 @@ func validateTopLevelWorkspaceCopyTransport(repository *resolvedRepositoryChecko
 	return errors.New("--copy-in for non-Git workspaces cannot be used while creating a sandbox yet; create the sandbox first, then run cleanroom workspace copy-in <sandbox-id>")
 }
 
-func resolveRepositoryChangeset(repository *resolvedRepositoryCheckout, copyWorkspace bool) (*cleanroomv1.RepositoryChangeset, error) {
+type repositoryLocalChanges struct {
+	Changeset    *cleanroomv1.RepositoryChangeset
+	CommitBundle *cleanroomv1.RepositoryCommitBundle
+}
+
+func resolveRepositoryLocalChanges(repository *resolvedRepositoryCheckout, copyWorkspace bool) (repositoryLocalChanges, error) {
 	if !copyWorkspace {
-		return nil, nil
+		return repositoryLocalChanges{}, nil
 	}
 	if repository == nil {
-		return nil, nil
+		return repositoryLocalChanges{}, nil
 	}
 	if strings.TrimSpace(repository.RootDir) == "" {
-		return nil, errors.New("--copy-in requires a local repository checkout")
+		return repositoryLocalChanges{}, errors.New("--copy-in requires a local repository checkout")
+	}
+	if strings.TrimSpace(repository.RemoteName) == "" {
+		return repositoryLocalChanges{}, errors.New("--copy-in requires a named repository remote")
+	}
+
+	commitBundle, err := repositorybundle.BuildFromRepository(repository.RootDir, repository.RemoteName, toRepositoryCheckout(repository))
+	if err != nil {
+		return repositoryLocalChanges{}, fmt.Errorf("package local repository commits: %w", err)
 	}
 
 	changeset, err := repositorychangeset.BuildFromWorkingTree(repository.RootDir, toRepositoryCheckout(repository))
 	if err != nil {
-		return nil, fmt.Errorf("package local repository changes: %w", err)
+		return repositoryLocalChanges{}, fmt.Errorf("package local repository changes: %w", err)
 	}
-	if changeset == nil {
-		return nil, nil
+	out := repositoryLocalChanges{}
+	if commitBundle != nil {
+		out.CommitBundle = commitBundle.ToProto()
 	}
-	return changeset.ToProto(), nil
+	if changeset != nil {
+		out.Changeset = changeset.ToProto()
+	}
+	return out, nil
 }

--- a/internal/cli/repository_changeset.go
+++ b/internal/cli/repository_changeset.go
@@ -10,18 +10,18 @@ import (
 )
 
 type workspaceCopyFlags struct {
-	Copy bool `name:"copy" help:"Copy local workspace changes into the sandbox workspace before running"`
+	CopyIn bool `name:"copy-in" help:"Copy local workspace changes into the sandbox workspace before running"`
 }
 
 func (f workspaceCopyFlags) validate(_ string, fromSnapshot string, repositoryOverride repositoryOverrideFlags) error {
-	if !f.Copy {
+	if !f.CopyIn {
 		return nil
 	}
 	switch {
 	case strings.TrimSpace(fromSnapshot) != "":
-		return errors.New("--copy cannot be used with --from")
+		return errors.New("--copy-in cannot be used with --from")
 	case repositoryOverride.hasRepositoryOverride():
-		return errors.New("--copy cannot be used with --repo-url or --repo-commit")
+		return errors.New("--copy-in cannot be used with --repo-url or --repo-commit")
 	default:
 		return nil
 	}
@@ -31,7 +31,7 @@ func validateTopLevelWorkspaceCopyTransport(repository *resolvedRepositoryChecko
 	if !copyWorkspace || repository != nil {
 		return nil
 	}
-	return errors.New("--copy for non-Git workspaces cannot be used while creating a sandbox yet; create the sandbox first, then run cleanroom workspace copy <sandbox-id>")
+	return errors.New("--copy-in for non-Git workspaces cannot be used while creating a sandbox yet; create the sandbox first, then run cleanroom workspace copy-in <sandbox-id>")
 }
 
 func resolveRepositoryChangeset(repository *resolvedRepositoryCheckout, copyWorkspace bool) (*cleanroomv1.RepositoryChangeset, error) {
@@ -42,7 +42,7 @@ func resolveRepositoryChangeset(repository *resolvedRepositoryCheckout, copyWork
 		return nil, nil
 	}
 	if strings.TrimSpace(repository.RootDir) == "" {
-		return nil, errors.New("--copy requires a local repository checkout")
+		return nil, errors.New("--copy-in requires a local repository checkout")
 	}
 
 	changeset, err := repositorychangeset.BuildFromWorkingTree(repository.RootDir, toRepositoryCheckout(repository))

--- a/internal/cli/repository_test.go
+++ b/internal/cli/repository_test.go
@@ -826,7 +826,7 @@ func TestCreateCommandWarnsWhenRepositoryIsDirtyUsesANSIWhenForced(t *testing.T)
 	}
 }
 
-func TestCreateCommandCopySuppressesDirtyWarning(t *testing.T) {
+func TestCreateCommandCopyInSuppressesDirtyWarning(t *testing.T) {
 	repoDir := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
 	if err := os.WriteFile(filepath.Join(repoDir, "dirty.txt"), []byte("dirty\n"), 0o644); err != nil {
 		t.Fatalf("write dirty file: %v", err)
@@ -865,7 +865,7 @@ func TestCreateCommandCopySuppressesDirtyWarning(t *testing.T) {
 	outcome := runCreateAliasWithCapture(CreateCommand{
 		clientFlags:        clientFlags{Host: host},
 		Chdir:              repoDir,
-		workspaceCopyFlags: workspaceCopyFlags{Copy: true},
+		workspaceCopyFlags: workspaceCopyFlags{CopyIn: true},
 	}, runtimeContext{
 		CWD: repoDir,
 		Loader: repositoryIntegrationLoader{

--- a/internal/cli/repository_test.go
+++ b/internal/cli/repository_test.go
@@ -826,7 +826,7 @@ func TestCreateCommandWarnsWhenRepositoryIsDirtyUsesANSIWhenForced(t *testing.T)
 	}
 }
 
-func TestCreateCommandIncludesLocalChangesWithoutDirtyWarning(t *testing.T) {
+func TestCreateCommandCopySuppressesDirtyWarning(t *testing.T) {
 	repoDir := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
 	if err := os.WriteFile(filepath.Join(repoDir, "dirty.txt"), []byte("dirty\n"), 0o644); err != nil {
 		t.Fatalf("write dirty file: %v", err)
@@ -863,9 +863,9 @@ func TestCreateCommandIncludesLocalChangesWithoutDirtyWarning(t *testing.T) {
 	}
 
 	outcome := runCreateAliasWithCapture(CreateCommand{
-		clientFlags:              clientFlags{Host: host},
-		Chdir:                    repoDir,
-		repositoryChangesetFlags: repositoryChangesetFlags{IncludeLocalChanges: true},
+		clientFlags:        clientFlags{Host: host},
+		Chdir:              repoDir,
+		workspaceCopyFlags: workspaceCopyFlags{Copy: true},
 	}, runtimeContext{
 		CWD: repoDir,
 		Loader: repositoryIntegrationLoader{
@@ -906,102 +906,6 @@ func TestCreateCommandIncludesLocalChangesWithoutDirtyWarning(t *testing.T) {
 	}
 	if !strings.Contains(patches[0], "dirty.txt") {
 		t.Fatalf("expected changeset patch to reference dirty.txt, got %q", patches[0])
-	}
-}
-
-func TestCreateCommandIncludesLocalOnlyCommitsWithLocalChangesFlag(t *testing.T) {
-	repoDir := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
-	commitFile(t, repoDir, "local.txt", "local\n", "local commit")
-	wantCommit := headCommit(t, repoDir)
-
-	adapter := &integrationAdapter{}
-	host, _ := startIntegrationServer(t, adapter)
-
-	var (
-		mu       sync.Mutex
-		commands [][]string
-		bundles  [][]byte
-	)
-	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
-		mu.Lock()
-		commands = append(commands, append([]string(nil), req.Command...))
-		mu.Unlock()
-		if stream.OnAttach != nil {
-			var stdin bytes.Buffer
-			stream.OnAttach(backend.AttachIO{
-				WriteStdin: func(data []byte) error {
-					_, err := stdin.Write(data)
-					return err
-				},
-				CloseStdin: func() error {
-					mu.Lock()
-					bundles = append(bundles, append([]byte(nil), stdin.Bytes()...))
-					mu.Unlock()
-					return nil
-				},
-			})
-		}
-		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
-	}
-
-	outcome := runCreateAliasWithCapture(CreateCommand{
-		clientFlags:              clientFlags{Host: host},
-		Chdir:                    repoDir,
-		repositoryChangesetFlags: repositoryChangesetFlags{IncludeLocalChanges: true},
-	}, runtimeContext{
-		CWD: repoDir,
-		Loader: repositoryIntegrationLoader{
-			compiled: &policy.CompiledPolicy{
-				Version:        1,
-				ImageRef:       "ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-				ImageDigest:    "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-				NetworkDefault: "deny",
-				Allow:          []policy.AllowRule{{Host: "github.com", Ports: []int{443}}},
-			},
-			repository: policy.RepositoryConfig{
-				Mode:   "current-repo",
-				Remote: "origin",
-				Path:   "/workspace",
-			},
-		},
-	})
-	if outcome.cause != nil {
-		t.Fatalf("capture failure: %v", outcome.cause)
-	}
-	if outcome.err != nil {
-		t.Fatalf("CreateCommand.Run returned error: %v", outcome.err)
-	}
-	if strings.Contains(outcome.stderr, "repository has local modifications") {
-		t.Fatalf("expected dirty repository warning to be suppressed, got %q", outcome.stderr)
-	}
-
-	mu.Lock()
-	defer mu.Unlock()
-	if got, want := len(commands), 1; got != want {
-		t.Fatalf("expected repository bootstrap only, got %d want %d", got, want)
-	}
-	joined := strings.Join(commands[0], " ")
-	if !strings.Contains(joined, `git -C "$dest" fetch --progress "$bundle_file" "+HEAD:$bundle_ref"`) {
-		t.Fatalf("expected bootstrap command to fetch attached bundle, got %q", joined)
-	}
-	if !strings.Contains(joined, wantCommit) {
-		t.Fatalf("expected bootstrap command to checkout local commit %q, got %q", wantCommit, joined)
-	}
-	if got, want := len(bundles), 1; got != want {
-		t.Fatalf("expected one attached commit bundle, got %d want %d", got, want)
-	}
-
-	bundlePath := filepath.Join(t.TempDir(), "commits.bundle")
-	if err := os.WriteFile(bundlePath, bundles[0], 0o600); err != nil {
-		t.Fatalf("write captured bundle: %v", err)
-	}
-	cmd := exec.Command("git", "-C", repoDir, "bundle", "list-heads", bundlePath, "HEAD")
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("git bundle list-heads failed: %v\n%s", err, string(out))
-	}
-	if !strings.Contains(string(out), wantCommit+" HEAD") {
-		t.Fatalf("expected bundle HEAD %q, got %q", wantCommit, string(out))
 	}
 }
 

--- a/internal/cli/repository_test.go
+++ b/internal/cli/repository_test.go
@@ -84,6 +84,17 @@ func headCommit(t *testing.T, dir string) string {
 	return strings.TrimSpace(string(out))
 }
 
+func runGitInRepository(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, string(out))
+	}
+	return strings.TrimSpace(string(out))
+}
+
 func commitFile(t *testing.T, dir, name, content, message string) {
 	t.Helper()
 	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
@@ -693,6 +704,25 @@ func TestResolveRepositoryCheckoutSkipsImplicitDefaultOutsideGitRepo(t *testing.
 	}
 }
 
+func TestResolveWorkspaceCopyRepositoryCheckoutUsesNonOriginRemoteWithoutPolicy(t *testing.T) {
+	repoDir := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
+	runGitInRepository(t, repoDir, "remote", "rename", "origin", "upstream")
+
+	checkout, err := resolveWorkspaceCopyRepositoryCheckout(repoDir, repositoryNotFoundLoader{})
+	if err != nil {
+		t.Fatalf("resolveWorkspaceCopyRepositoryCheckout returned error: %v", err)
+	}
+	if checkout == nil {
+		t.Fatal("expected repository checkout result")
+	}
+	if got, want := checkout.RemoteName, "upstream"; got != want {
+		t.Fatalf("unexpected remote name: got %q want %q", got, want)
+	}
+	if got, want := checkout.RemoteURL, "https://github.com/buildkite/cleanroom.git"; got != want {
+		t.Fatalf("unexpected remote url: got %q want %q", got, want)
+	}
+}
+
 func TestExecCommandWithSandboxIDAllowsMissingPolicyInCurrentDirectory(t *testing.T) {
 	adapter := &integrationAdapter{}
 	host, _ := startIntegrationServer(t, adapter)
@@ -906,6 +936,99 @@ func TestCreateCommandCopyInSuppressesDirtyWarning(t *testing.T) {
 	}
 	if !strings.Contains(patches[0], "dirty.txt") {
 		t.Fatalf("expected changeset patch to reference dirty.txt, got %q", patches[0])
+	}
+}
+
+func TestCreateCommandCopyInIncludesLocalOnlyCommits(t *testing.T) {
+	repoDir := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
+	commitFile(t, repoDir, "local.txt", "local\n", "local commit")
+	wantCommit := headCommit(t, repoDir)
+
+	adapter := &integrationAdapter{}
+	host, _ := startIntegrationServer(t, adapter)
+
+	var (
+		mu       sync.Mutex
+		commands [][]string
+		bundles  [][]byte
+	)
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+		mu.Lock()
+		commands = append(commands, append([]string(nil), req.Command...))
+		mu.Unlock()
+		if stream.OnAttach != nil {
+			var stdin bytes.Buffer
+			stream.OnAttach(backend.AttachIO{
+				WriteStdin: func(data []byte) error {
+					_, err := stdin.Write(data)
+					return err
+				},
+				CloseStdin: func() error {
+					mu.Lock()
+					bundles = append(bundles, append([]byte(nil), stdin.Bytes()...))
+					mu.Unlock()
+					return nil
+				},
+			})
+		}
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+	}
+
+	outcome := runCreateAliasWithCapture(CreateCommand{
+		clientFlags:        clientFlags{Host: host},
+		Chdir:              repoDir,
+		workspaceCopyFlags: workspaceCopyFlags{CopyIn: true},
+	}, runtimeContext{
+		CWD: repoDir,
+		Loader: repositoryIntegrationLoader{
+			compiled: &policy.CompiledPolicy{
+				Version:        1,
+				ImageRef:       "ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+				ImageDigest:    "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+				NetworkDefault: "deny",
+				Allow:          []policy.AllowRule{{Host: "github.com", Ports: []int{443}}},
+			},
+			repository: policy.RepositoryConfig{
+				Mode:   "current-repo",
+				Remote: "origin",
+				Path:   "/workspace",
+			},
+		},
+	})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err != nil {
+		t.Fatalf("CreateCommand.Run returned error: %v", outcome.err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if got, want := len(commands), 1; got != want {
+		t.Fatalf("expected repository bootstrap only, got %d want %d", got, want)
+	}
+	joined := strings.Join(commands[0], " ")
+	if !strings.Contains(joined, `git -C "$dest" fetch --progress "$bundle_file" "+HEAD:$bundle_ref"`) {
+		t.Fatalf("expected bootstrap command to fetch attached bundle, got %q", joined)
+	}
+	if !strings.Contains(joined, wantCommit) {
+		t.Fatalf("expected bootstrap command to checkout local commit %q, got %q", wantCommit, joined)
+	}
+	if got, want := len(bundles), 1; got != want {
+		t.Fatalf("expected one attached commit bundle, got %d want %d", got, want)
+	}
+
+	bundlePath := filepath.Join(t.TempDir(), "commits.bundle")
+	if err := os.WriteFile(bundlePath, bundles[0], 0o600); err != nil {
+		t.Fatalf("write captured bundle: %v", err)
+	}
+	cmd := exec.Command("git", "-C", repoDir, "bundle", "list-heads", bundlePath, "HEAD")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git bundle list-heads failed: %v\n%s", err, string(out))
+	}
+	if !strings.Contains(string(out), wantCommit+" HEAD") {
+		t.Fatalf("expected bundle HEAD %q, got %q", wantCommit, string(out))
 	}
 }
 

--- a/internal/cli/sandbox.go
+++ b/internal/cli/sandbox.go
@@ -58,7 +58,7 @@ type CreateCommand struct {
 	From    string `name:"from" help:"Create the sandbox from an existing snapshot ID"`
 	Image   string `help:"Override sandbox image ref (tag, digest, or local Docker image)"`
 	repositoryOverrideFlags
-	repositoryChangesetFlags
+	workspaceCopyFlags
 	DangerouslyAllowAll bool  `name:"dangerously-allow-all" help:"Disable network egress filtering for a newly created sandbox"`
 	LaunchSeconds       int64 `help:"VM boot/guest-agent readiness timeout in seconds"`
 	JSON                bool  `help:"Print sandbox as JSON"`
@@ -286,7 +286,7 @@ func runSandboxCreate(ctx *runtimeContext, connectFlags clientFlags, backend, fr
 		if err != nil {
 			return err
 		}
-		_, sandbox, err = createSandboxWithPolicy(context.Background(), client, compiled, backend, launchSeconds, nil, repositoryLocalChanges{})
+		_, sandbox, err = createSandboxWithPolicy(context.Background(), client, compiled, backend, launchSeconds, nil, nil)
 		if err != nil {
 			return err
 		}
@@ -332,13 +332,13 @@ func (c *CreateCommand) Run(ctx *runtimeContext) error {
 	if err != nil {
 		return err
 	}
-	localChanges, err := resolveRepositoryLocalChanges(repository, c.IncludeLocalChanges)
+	changeset, err := resolveRepositoryChangeset(repository, c.Copy)
 	if err != nil {
 		return err
 	}
-	warnDirtyRepositoryCheckout(repository, localChanges.Changeset != nil || localChanges.CommitBundle != nil)
+	warnDirtyRepositoryCheckout(repository, changeset != nil)
 
-	sandboxID, sandbox, err := createTopLevelSandbox(context.Background(), client, ctx.Loader, cwd, host, c.Backend, c.Image, c.LaunchSeconds, c.DangerouslyAllowAll, repository, localChanges)
+	sandboxID, sandbox, err := createTopLevelSandbox(context.Background(), client, ctx.Loader, cwd, host, c.Backend, c.Image, c.LaunchSeconds, c.DangerouslyAllowAll, repository, changeset)
 	if err != nil {
 		return err
 	}
@@ -355,7 +355,7 @@ func (c *CreateCommand) validate() error {
 	if _, err := c.repositoryOverrideFlags.resolve(".", nil); err != nil {
 		return err
 	}
-	if err := c.repositoryChangesetFlags.validate("", c.From, c.repositoryOverrideFlags); err != nil {
+	if err := c.workspaceCopyFlags.validate("", c.From, c.repositoryOverrideFlags); err != nil {
 		return err
 	}
 	if c.repositoryOverrideFlags.hasRepositoryOverride() && strings.TrimSpace(c.From) != "" {
@@ -375,7 +375,7 @@ func createTopLevelSandbox(
 	launchSeconds int64,
 	dangerouslyAllowAll bool,
 	repository *resolvedRepositoryCheckout,
-	localChanges repositoryLocalChanges,
+	changeset *cleanroomv1.RepositoryChangeset,
 ) (string, *cleanroomv1.Sandbox, error) {
 	compiled, _, err := loader.LoadAndCompile(cwd)
 	if err != nil {
@@ -394,7 +394,7 @@ func createTopLevelSandbox(
 		return "", nil, err
 	}
 
-	return createSandboxWithPolicy(callCtx, client, compiled, backendName, launchSeconds, repository, localChanges)
+	return createSandboxWithPolicy(callCtx, client, compiled, backendName, launchSeconds, repository, changeset)
 }
 
 func overrideCompiledPolicyNetworkDefault(compiled *policy.CompiledPolicy, dangerouslyAllowAll bool) (*policy.CompiledPolicy, error) {
@@ -492,7 +492,7 @@ func createSandboxWithPolicy(
 	backendName string,
 	launchSeconds int64,
 	repository *resolvedRepositoryCheckout,
-	localChanges repositoryLocalChanges,
+	changeset *cleanroomv1.RepositoryChangeset,
 ) (string, *cleanroomv1.Sandbox, error) {
 	if compiled == nil {
 		return "", nil, errors.New("create sandbox: missing compiled policy")
@@ -503,10 +503,9 @@ func createSandboxWithPolicy(
 		Options: &cleanroomv1.SandboxOptions{
 			LaunchSeconds: launchSeconds,
 		},
-		Policy:                 compiled.ToProto(),
-		RepositoryCheckout:     repositoryCheckoutProto(repository),
-		RepositoryChangeset:    localChanges.Changeset,
-		RepositoryCommitBundle: localChanges.CommitBundle,
+		Policy:              compiled.ToProto(),
+		RepositoryCheckout:  repositoryCheckoutProto(repository),
+		RepositoryChangeset: changeset,
 	})
 	if err != nil {
 		return "", nil, fmt.Errorf("create sandbox: %w", err)

--- a/internal/cli/sandbox.go
+++ b/internal/cli/sandbox.go
@@ -332,6 +332,9 @@ func (c *CreateCommand) Run(ctx *runtimeContext) error {
 	if err != nil {
 		return err
 	}
+	if err := validateTopLevelWorkspaceCopyTransport(repository, c.Copy); err != nil {
+		return err
+	}
 	changeset, err := resolveRepositoryChangeset(repository, c.Copy)
 	if err != nil {
 		return err
@@ -341,14 +344,6 @@ func (c *CreateCommand) Run(ctx *runtimeContext) error {
 	sandboxID, sandbox, err := createTopLevelSandbox(context.Background(), client, ctx.Loader, cwd, host, c.Backend, c.Image, c.LaunchSeconds, c.DangerouslyAllowAll, repository, changeset)
 	if err != nil {
 		return err
-	}
-	if c.Copy && repository == nil {
-		if err := copyWorkspaceToSandbox(context.Background(), ctx, client, workspaceCopyOptions{
-			CWD:       cwd,
-			SandboxID: sandboxID,
-		}); err != nil {
-			return fmt.Errorf("copy workspace into sandbox %s: %w", sandboxID, err)
-		}
 	}
 	if c.JSON {
 		enc := json.NewEncoder(ctx.Stdout)

--- a/internal/cli/sandbox.go
+++ b/internal/cli/sandbox.go
@@ -342,6 +342,14 @@ func (c *CreateCommand) Run(ctx *runtimeContext) error {
 	if err != nil {
 		return err
 	}
+	if c.Copy && repository == nil {
+		if err := copyWorkspaceToSandbox(context.Background(), ctx, client, workspaceCopyOptions{
+			CWD:       cwd,
+			SandboxID: sandboxID,
+		}); err != nil {
+			return fmt.Errorf("copy workspace into sandbox %s: %w", sandboxID, err)
+		}
+	}
 	if c.JSON {
 		enc := json.NewEncoder(ctx.Stdout)
 		enc.SetIndent("", "  ")

--- a/internal/cli/sandbox.go
+++ b/internal/cli/sandbox.go
@@ -332,10 +332,10 @@ func (c *CreateCommand) Run(ctx *runtimeContext) error {
 	if err != nil {
 		return err
 	}
-	if err := validateTopLevelWorkspaceCopyTransport(repository, c.Copy); err != nil {
+	if err := validateTopLevelWorkspaceCopyTransport(repository, c.CopyIn); err != nil {
 		return err
 	}
-	changeset, err := resolveRepositoryChangeset(repository, c.Copy)
+	changeset, err := resolveRepositoryChangeset(repository, c.CopyIn)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/sandbox.go
+++ b/internal/cli/sandbox.go
@@ -286,7 +286,7 @@ func runSandboxCreate(ctx *runtimeContext, connectFlags clientFlags, backend, fr
 		if err != nil {
 			return err
 		}
-		_, sandbox, err = createSandboxWithPolicy(context.Background(), client, compiled, backend, launchSeconds, nil, nil)
+		_, sandbox, err = createSandboxWithPolicy(context.Background(), client, compiled, backend, launchSeconds, nil, repositoryLocalChanges{})
 		if err != nil {
 			return err
 		}
@@ -335,13 +335,13 @@ func (c *CreateCommand) Run(ctx *runtimeContext) error {
 	if err := validateTopLevelWorkspaceCopyTransport(repository, c.CopyIn); err != nil {
 		return err
 	}
-	changeset, err := resolveRepositoryChangeset(repository, c.CopyIn)
+	localChanges, err := resolveRepositoryLocalChanges(repository, c.CopyIn)
 	if err != nil {
 		return err
 	}
-	warnDirtyRepositoryCheckout(repository, changeset != nil)
+	warnDirtyRepositoryCheckout(repository, c.CopyIn && repository != nil)
 
-	sandboxID, sandbox, err := createTopLevelSandbox(context.Background(), client, ctx.Loader, cwd, host, c.Backend, c.Image, c.LaunchSeconds, c.DangerouslyAllowAll, repository, changeset)
+	sandboxID, sandbox, err := createTopLevelSandbox(context.Background(), client, ctx.Loader, cwd, host, c.Backend, c.Image, c.LaunchSeconds, c.DangerouslyAllowAll, repository, localChanges)
 	if err != nil {
 		return err
 	}
@@ -378,7 +378,7 @@ func createTopLevelSandbox(
 	launchSeconds int64,
 	dangerouslyAllowAll bool,
 	repository *resolvedRepositoryCheckout,
-	changeset *cleanroomv1.RepositoryChangeset,
+	localChanges repositoryLocalChanges,
 ) (string, *cleanroomv1.Sandbox, error) {
 	compiled, _, err := loader.LoadAndCompile(cwd)
 	if err != nil {
@@ -397,7 +397,7 @@ func createTopLevelSandbox(
 		return "", nil, err
 	}
 
-	return createSandboxWithPolicy(callCtx, client, compiled, backendName, launchSeconds, repository, changeset)
+	return createSandboxWithPolicy(callCtx, client, compiled, backendName, launchSeconds, repository, localChanges)
 }
 
 func overrideCompiledPolicyNetworkDefault(compiled *policy.CompiledPolicy, dangerouslyAllowAll bool) (*policy.CompiledPolicy, error) {
@@ -495,7 +495,7 @@ func createSandboxWithPolicy(
 	backendName string,
 	launchSeconds int64,
 	repository *resolvedRepositoryCheckout,
-	changeset *cleanroomv1.RepositoryChangeset,
+	localChanges repositoryLocalChanges,
 ) (string, *cleanroomv1.Sandbox, error) {
 	if compiled == nil {
 		return "", nil, errors.New("create sandbox: missing compiled policy")
@@ -506,9 +506,10 @@ func createSandboxWithPolicy(
 		Options: &cleanroomv1.SandboxOptions{
 			LaunchSeconds: launchSeconds,
 		},
-		Policy:              compiled.ToProto(),
-		RepositoryCheckout:  repositoryCheckoutProto(repository),
-		RepositoryChangeset: changeset,
+		Policy:                 compiled.ToProto(),
+		RepositoryCheckout:     repositoryCheckoutProto(repository),
+		RepositoryChangeset:    localChanges.Changeset,
+		RepositoryCommitBundle: localChanges.CommitBundle,
 	})
 	if err != nil {
 		return "", nil, fmt.Errorf("create sandbox: %w", err)

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -173,10 +173,7 @@ func (s *ServeCommand) runServer(ctx *runtimeContext) error {
 	if interceptor := ctx.Observability.ConnectInterceptor(); interceptor != nil {
 		serverInterceptors = append(serverInterceptors, interceptor)
 	}
-	server := controlserver.New(service, httpLogger, serverInterceptors...)
-	if ep.Scheme == "unix" {
-		server.TrustInternalWorkspaceCopyInRequests()
-	}
+	server := controlserver.New(service, httpLogger, serverInterceptors...).TrustInternalWorkspaceCopyInRequests()
 
 	runCtx, cancel := serveSignalNotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -173,7 +173,12 @@ func (s *ServeCommand) runServer(ctx *runtimeContext) error {
 	if interceptor := ctx.Observability.ConnectInterceptor(); interceptor != nil {
 		serverInterceptors = append(serverInterceptors, interceptor)
 	}
-	server := controlserver.New(service, httpLogger, serverInterceptors...).TrustInternalWorkspaceCopyInRequests()
+	server := controlserver.New(service, httpLogger, serverInterceptors...)
+	if ep.Scheme == "unix" {
+		server.TrustInternalWorkspaceCopyInRequests()
+	} else {
+		server.TrustInternalWorkspaceCopyInRequestsFromLoopback()
+	}
 
 	runCtx, cancel := serveSignalNotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -174,6 +174,9 @@ func (s *ServeCommand) runServer(ctx *runtimeContext) error {
 		serverInterceptors = append(serverInterceptors, interceptor)
 	}
 	server := controlserver.New(service, httpLogger, serverInterceptors...)
+	if ep.Scheme == "unix" {
+		server.TrustInternalWorkspaceCopyInRequests()
+	}
 
 	runCtx, cancel := serveSignalNotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()

--- a/internal/cli/workspace.go
+++ b/internal/cli/workspace.go
@@ -38,6 +38,7 @@ type workspaceCopyOptions struct {
 	Repository    *resolvedRepositoryCheckout
 	Destination   string
 	ForceGitReset bool
+	LaunchSeconds int64
 }
 
 type workspacePlanEntry struct {
@@ -105,7 +106,7 @@ func copyGitWorkspaceToSandbox(callCtx context.Context, ctx *runtimeContext, cli
 			if err != nil {
 				return err
 			}
-			return runWorkspaceExecution(callCtx, ctx, client, opts.SandboxID, effectiveRepository, repositorychangeset.ResetCommand(checkout), nil)
+			return runWorkspaceExecution(callCtx, ctx, client, opts.SandboxID, effectiveRepository, repositorychangeset.ResetCommand(checkout), nil, opts.LaunchSeconds)
 		}
 		return nil
 	}
@@ -121,7 +122,7 @@ func copyGitWorkspaceToSandbox(callCtx context.Context, ctx *runtimeContext, cli
 	if opts.ForceGitReset {
 		command = repositorychangeset.ApplyCommandResettingCheckout(checkout, changeset)
 	}
-	return runWorkspaceExecution(callCtx, ctx, client, opts.SandboxID, effectiveRepository, command, bytes.NewReader(changeset.Patch))
+	return runWorkspaceExecution(callCtx, ctx, client, opts.SandboxID, effectiveRepository, command, bytes.NewReader(changeset.Patch), opts.LaunchSeconds)
 }
 
 func resolveGitWorkspaceCheckout(callCtx context.Context, client *controlclient.Client, opts workspaceCopyOptions) (*resolvedRepositoryCheckout, *repositorycheckout.Checkout, error) {
@@ -143,7 +144,7 @@ func resolveGitWorkspaceCheckout(callCtx context.Context, client *controlclient.
 	return &effectiveRepository, checkout, nil
 }
 
-func runWorkspaceExecution(callCtx context.Context, ctx *runtimeContext, client *controlclient.Client, sandboxID string, repository *resolvedRepositoryCheckout, command []string, input io.Reader) error {
+func runWorkspaceExecution(callCtx context.Context, ctx *runtimeContext, client *controlclient.Client, sandboxID string, repository *resolvedRepositoryCheckout, command []string, input io.Reader, launchSeconds int64) error {
 	if len(command) == 0 {
 		return errors.New("workspace copy execution command is empty")
 	}
@@ -154,6 +155,8 @@ func runWorkspaceExecution(callCtx context.Context, ctx *runtimeContext, client 
 		RepositoryCheckout: repositoryCheckoutProto(repository),
 		Options: &cleanroomv1.ExecutionOptions{
 			PreserveRepositoryChangesetPendingExecution: true,
+			SkipRunBefore: true,
+			LaunchSeconds: launchSeconds,
 		},
 	})
 	if err != nil {
@@ -210,7 +213,7 @@ func copyRawWorkspaceToSandbox(callCtx context.Context, ctx *runtimeContext, cli
 	if _, err := rawWorkspacePlan(opts.CWD, destination); err != nil {
 		return err
 	}
-	if err := cleanRawWorkspaceDestination(callCtx, ctx, client, opts.SandboxID, destination); err != nil {
+	if err := cleanRawWorkspaceDestination(callCtx, ctx, client, opts.SandboxID, destination, opts.LaunchSeconds); err != nil {
 		return err
 	}
 	if err := extractRawWorkspaceArchive(callCtx, client, opts.SandboxID, destination, opts.CWD); err != nil {
@@ -219,7 +222,7 @@ func copyRawWorkspaceToSandbox(callCtx context.Context, ctx *runtimeContext, cli
 	return nil
 }
 
-func cleanRawWorkspaceDestination(callCtx context.Context, ctx *runtimeContext, client *controlclient.Client, sandboxID, destination string) error {
+func cleanRawWorkspaceDestination(callCtx context.Context, ctx *runtimeContext, client *controlclient.Client, sandboxID, destination string, launchSeconds int64) error {
 	statResp, err := client.StatSandboxPath(tracePreservingContext(callCtx), &cleanroomv1.StatSandboxPathRequest{
 		SandboxId: sandboxID,
 		Path:      destination,
@@ -237,7 +240,7 @@ func cleanRawWorkspaceDestination(callCtx context.Context, ctx *runtimeContext, 
 	if info.GetType() != cleanroomv1.SandboxPathType_SANDBOX_PATH_TYPE_DIRECTORY {
 		return removeRawWorkspaceDestinationRoot(callCtx, client, sandboxID, destination)
 	}
-	return runWorkspaceExecution(callCtx, ctx, client, sandboxID, nil, rawWorkspaceCleanCommand(destination), nil)
+	return runWorkspaceExecution(callCtx, ctx, client, sandboxID, nil, rawWorkspaceCleanCommand(destination), nil, launchSeconds)
 }
 
 func removeRawWorkspaceDestinationRoot(callCtx context.Context, client *controlclient.Client, sandboxID, destination string) error {

--- a/internal/cli/workspace.go
+++ b/internal/cli/workspace.go
@@ -91,7 +91,14 @@ func copyGitWorkspaceToSandbox(callCtx context.Context, ctx *runtimeContext, cli
 	}
 	if changeset == nil {
 		if opts.DryRun {
-			return nil
+			if !opts.ForceGitReset {
+				return nil
+			}
+			_, checkout, err := resolveGitWorkspaceCheckout(callCtx, client, opts)
+			if err != nil {
+				return err
+			}
+			return printWorkspacePlan(runtimeStdout(ctx), gitWorkspacePlan(checkout.DestinationDir, nil, true))
 		}
 		if opts.ForceGitReset {
 			effectiveRepository, checkout, err := resolveGitWorkspaceCheckout(callCtx, client, opts)
@@ -107,7 +114,7 @@ func copyGitWorkspaceToSandbox(callCtx context.Context, ctx *runtimeContext, cli
 		return err
 	}
 	if opts.DryRun {
-		return printWorkspacePlan(runtimeStdout(ctx), gitWorkspacePlan(checkout.DestinationDir, changeset.Files))
+		return printWorkspacePlan(runtimeStdout(ctx), gitWorkspacePlan(checkout.DestinationDir, changeset.Files, opts.ForceGitReset))
 	}
 
 	command := repositorychangeset.ApplyCommand(checkout, changeset)
@@ -162,8 +169,14 @@ func runWorkspaceExecution(callCtx context.Context, ctx *runtimeContext, client 
 	return streamWorkspaceExecutionWithInput(callCtx, ctx, client, sandboxID, executionID, input)
 }
 
-func gitWorkspacePlan(destination string, files []repositorychangeset.File) []workspacePlanEntry {
-	entries := make([]workspacePlanEntry, 0, len(files))
+func gitWorkspacePlan(destination string, files []repositorychangeset.File, reset bool) []workspacePlanEntry {
+	entries := make([]workspacePlanEntry, 0, len(files)+1)
+	if reset {
+		entries = append(entries, workspacePlanEntry{
+			Action: "reset",
+			Path:   workspaceRemotePath(destination, ""),
+		})
+	}
 	for _, file := range files {
 		action := "write"
 		if file.Deleted {

--- a/internal/cli/workspace.go
+++ b/internal/cli/workspace.go
@@ -36,6 +36,7 @@ type workspaceCopyOptions struct {
 	SandboxID     string
 	DryRun        bool
 	Repository    *resolvedRepositoryCheckout
+	Destination   string
 	ForceGitReset bool
 }
 
@@ -146,9 +147,13 @@ func gitWorkspacePlan(destination string, files []repositorychangeset.File) []wo
 }
 
 func copyRawWorkspaceToSandbox(callCtx context.Context, ctx *runtimeContext, client *controlclient.Client, opts workspaceCopyOptions) error {
-	destination, err := resolveWorkspaceDestinationRoot(opts.CWD, ctx.Loader)
-	if err != nil {
-		return err
+	destination := strings.TrimSpace(opts.Destination)
+	if destination == "" {
+		var err error
+		destination, err = resolveSandboxWorkspaceDestination(callCtx, client, opts.SandboxID)
+		if err != nil {
+			return err
+		}
 	}
 	if err := validateRawWorkspaceDestinationRoot(destination); err != nil {
 		return err
@@ -176,18 +181,25 @@ func copyRawWorkspaceToSandbox(callCtx context.Context, ctx *runtimeContext, cli
 	return nil
 }
 
-func resolveWorkspaceDestinationRoot(cwd string, loader policyLoader) (string, error) {
-	repository, err := loadRepositoryConfig(cwd, loader)
+func resolveSandboxWorkspaceDestination(callCtx context.Context, client *controlclient.Client, sandboxID string) (string, error) {
+	if client == nil {
+		return "", errors.New("workspace copy requires a control client")
+	}
+	resp, err := client.GetSandbox(tracePreservingContext(callCtx), &cleanroomv1.GetSandboxRequest{
+		SandboxId: sandboxID,
+	})
 	if err != nil {
-		if errors.Is(err, errSkipRepositoryCheckout) {
-			return defaultRepositoryOverridePath, nil
-		}
-		return "", err
+		return "", fmt.Errorf("inspect sandbox workspace: %w", err)
 	}
-	if strings.TrimSpace(repository.Path) == "" {
-		return defaultRepositoryOverridePath, nil
+	sandbox := resp.GetSandbox()
+	if sandbox == nil {
+		return "", fmt.Errorf("sandbox %q not found", sandboxID)
 	}
-	return repository.Path, nil
+	destination := strings.TrimSpace(sandbox.GetRepositoryCheckout().GetDestinationDir())
+	if destination == "" {
+		return "", fmt.Errorf("sandbox %q does not have a recorded workspace root; create it from a repository checkout or use cleanroom copy for explicit paths", sandboxID)
+	}
+	return destination, nil
 }
 
 func validateRawWorkspaceDestinationRoot(destination string) error {

--- a/internal/cli/workspace.go
+++ b/internal/cli/workspace.go
@@ -158,6 +158,9 @@ func runWorkspaceExecution(callCtx context.Context, ctx *runtimeContext, client 
 		Command:            command,
 		Kind:               cleanroomv1.ExecutionKind_EXECUTION_KIND_BATCH,
 		RepositoryCheckout: repositoryCheckoutProto(repository),
+		Options: &cleanroomv1.ExecutionOptions{
+			PreserveRepositoryChangesetPendingExecution: true,
+		},
 	})
 	if err != nil {
 		return fmt.Errorf("create workspace copy execution: %w", err)

--- a/internal/cli/workspace.go
+++ b/internal/cli/workspace.go
@@ -84,24 +84,37 @@ func copyGitWorkspaceToSandbox(callCtx context.Context, ctx *runtimeContext, cli
 	if strings.TrimSpace(repository.RootDir) == "" {
 		return errors.New("workspace copy requires a local repository checkout")
 	}
-	changeset, err := repositorychangeset.BuildFromWorkingTree(repository.RootDir, toRepositoryCheckout(repository))
+	checkout := toRepositoryCheckout(repository)
+	changeset, err := repositorychangeset.BuildFromWorkingTree(repository.RootDir, checkout)
 	if err != nil {
 		return fmt.Errorf("package local workspace changes: %w", err)
 	}
 	if changeset == nil {
+		if opts.DryRun {
+			return nil
+		}
+		if opts.ForceGitReset {
+			return runWorkspaceExecution(callCtx, ctx, client, opts.SandboxID, repository, repositorychangeset.ResetCommand(checkout), nil)
+		}
 		return nil
 	}
 	if opts.DryRun {
 		return printWorkspacePlan(runtimeStdout(ctx), gitWorkspacePlan(repository.DestinationDir, changeset.Files))
 	}
 
-	checkout := toRepositoryCheckout(repository)
 	command := repositorychangeset.ApplyCommand(checkout, changeset)
 	if opts.ForceGitReset {
 		command = repositorychangeset.ApplyCommandResettingCheckout(checkout, changeset)
 	}
+	return runWorkspaceExecution(callCtx, ctx, client, opts.SandboxID, repository, command, bytes.NewReader(changeset.Patch))
+}
+
+func runWorkspaceExecution(callCtx context.Context, ctx *runtimeContext, client *controlclient.Client, sandboxID string, repository *resolvedRepositoryCheckout, command []string, input io.Reader) error {
+	if len(command) == 0 {
+		return errors.New("workspace copy execution command is empty")
+	}
 	createResp, err := client.CreateExecution(tracePreservingContext(callCtx), &cleanroomv1.CreateExecutionRequest{
-		SandboxId:          opts.SandboxID,
+		SandboxId:          sandboxID,
 		Command:            command,
 		Kind:               cleanroomv1.ExecutionKind_EXECUTION_KIND_BATCH,
 		RepositoryCheckout: repositoryCheckoutProto(repository),
@@ -113,7 +126,7 @@ func copyGitWorkspaceToSandbox(callCtx context.Context, ctx *runtimeContext, cli
 	if executionID == "" {
 		return errors.New("workspace copy execution response missing execution id")
 	}
-	return streamWorkspaceExecutionWithInput(callCtx, ctx, client, opts.SandboxID, executionID, bytes.NewReader(changeset.Patch))
+	return streamWorkspaceExecutionWithInput(callCtx, ctx, client, sandboxID, executionID, input)
 }
 
 func gitWorkspacePlan(destination string, files []repositorychangeset.File) []workspacePlanEntry {
@@ -135,6 +148,9 @@ func gitWorkspacePlan(destination string, files []repositorychangeset.File) []wo
 func copyRawWorkspaceToSandbox(callCtx context.Context, ctx *runtimeContext, client *controlclient.Client, opts workspaceCopyOptions) error {
 	destination, err := resolveWorkspaceDestinationRoot(opts.CWD, ctx.Loader)
 	if err != nil {
+		return err
+	}
+	if err := validateRawWorkspaceDestinationRoot(destination); err != nil {
 		return err
 	}
 	if opts.DryRun {
@@ -172,6 +188,37 @@ func resolveWorkspaceDestinationRoot(cwd string, loader policyLoader) (string, e
 		return defaultRepositoryOverridePath, nil
 	}
 	return repository.Path, nil
+}
+
+func validateRawWorkspaceDestinationRoot(destination string) error {
+	cleaned := posixpath.Clean(strings.TrimSpace(destination))
+	if cleaned == "." || cleaned == "" {
+		return errors.New("workspace destination root is required")
+	}
+	if !strings.HasPrefix(cleaned, "/") {
+		return fmt.Errorf("workspace destination root %q must be absolute", destination)
+	}
+	switch cleaned {
+	case "/",
+		"/bin",
+		"/boot",
+		"/dev",
+		"/etc",
+		"/home",
+		"/lib",
+		"/lib64",
+		"/proc",
+		"/root",
+		"/run",
+		"/sbin",
+		"/sys",
+		"/tmp",
+		"/usr",
+		"/var":
+		return fmt.Errorf("workspace destination root %q is unsafe for raw workspace copy", destination)
+	default:
+		return nil
+	}
 }
 
 func rawWorkspacePlan(sourceRoot, destination string) ([]workspacePlanEntry, error) {
@@ -386,11 +433,15 @@ func streamWorkspaceExecutionWithInput(callCtx context.Context, ctx *runtimeCont
 		return fmt.Errorf("stream workspace copy execution: %w", err)
 	}
 
-	stdinErrCh := make(chan error, 1)
-	go func() {
-		stdinErrCh <- writeExecutionInput(tracePreservingContext(callCtx), client, sandboxID, executionID, input)
-		close(stdinErrCh)
-	}()
+	var stdinErrCh <-chan error
+	if input != nil {
+		ch := make(chan error, 1)
+		stdinErrCh = ch
+		go func() {
+			ch <- writeExecutionInput(tracePreservingContext(callCtx), client, sandboxID, executionID, input)
+			close(ch)
+		}()
+	}
 
 	exitCode := 0
 	haveExitCode := false

--- a/internal/cli/workspace.go
+++ b/internal/cli/workspace.go
@@ -1,0 +1,474 @@
+package cli
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	posixpath "path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/buildkite/cleanroom/internal/controlclient"
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+	"github.com/buildkite/cleanroom/internal/repositorychangeset"
+	"github.com/buildkite/cleanroom/internal/repositorycheckout"
+)
+
+type WorkspaceCommand struct {
+	Copy WorkspaceCopyCommand `cmd:"" help:"Copy local workspace changes into a sandbox"`
+}
+
+type WorkspaceCopyCommand struct {
+	clientFlags
+	Chdir     string `short:"c" help:"Change to this local directory before planning the workspace copy"`
+	DryRun    bool   `name:"dry-run" help:"Show the workspace paths that would be copied without modifying the sandbox"`
+	SandboxID string `arg:"" required:"" help:"Sandbox ID to copy into"`
+}
+
+type workspaceCopyOptions struct {
+	CWD           string
+	SandboxID     string
+	DryRun        bool
+	Repository    *resolvedRepositoryCheckout
+	ForceGitReset bool
+}
+
+type workspacePlanEntry struct {
+	Action string
+	Path   string
+}
+
+func (c *WorkspaceCopyCommand) Run(ctx *runtimeContext) error {
+	cwd, err := resolveCWD(ctx.CWD, c.Chdir)
+	if err != nil {
+		return err
+	}
+	client, err := c.connect(ctx)
+	if err != nil {
+		return err
+	}
+	repository, err := resolveRepositoryCheckout(cwd, ctx.Loader)
+	if err != nil {
+		return err
+	}
+	return copyWorkspaceToSandbox(context.Background(), ctx, client, workspaceCopyOptions{
+		CWD:           cwd,
+		SandboxID:     c.SandboxID,
+		DryRun:        c.DryRun,
+		Repository:    repository,
+		ForceGitReset: true,
+	})
+}
+
+func copyWorkspaceToSandbox(callCtx context.Context, ctx *runtimeContext, client *controlclient.Client, opts workspaceCopyOptions) error {
+	if strings.TrimSpace(opts.SandboxID) == "" {
+		return errors.New("missing sandbox id")
+	}
+	if strings.TrimSpace(opts.CWD) == "" {
+		return errors.New("missing local workspace root")
+	}
+	if opts.Repository != nil {
+		return copyGitWorkspaceToSandbox(callCtx, ctx, client, opts)
+	}
+	return copyRawWorkspaceToSandbox(callCtx, ctx, client, opts)
+}
+
+func copyGitWorkspaceToSandbox(callCtx context.Context, ctx *runtimeContext, client *controlclient.Client, opts workspaceCopyOptions) error {
+	repository := opts.Repository
+	if strings.TrimSpace(repository.RootDir) == "" {
+		return errors.New("workspace copy requires a local repository checkout")
+	}
+	changeset, err := repositorychangeset.BuildFromWorkingTree(repository.RootDir, toRepositoryCheckout(repository))
+	if err != nil {
+		return fmt.Errorf("package local workspace changes: %w", err)
+	}
+	if changeset == nil {
+		return nil
+	}
+	if opts.DryRun {
+		return printWorkspacePlan(runtimeStdout(ctx), gitWorkspacePlan(repository.DestinationDir, changeset.Files))
+	}
+
+	checkout := toRepositoryCheckout(repository)
+	command := repositorychangeset.ApplyCommand(checkout, changeset)
+	if opts.ForceGitReset {
+		command = repositorychangeset.ApplyCommandResettingCheckout(checkout, changeset)
+	}
+	createResp, err := client.CreateExecution(tracePreservingContext(callCtx), &cleanroomv1.CreateExecutionRequest{
+		SandboxId:          opts.SandboxID,
+		Command:            command,
+		Kind:               cleanroomv1.ExecutionKind_EXECUTION_KIND_BATCH,
+		RepositoryCheckout: repositoryCheckoutProto(repository),
+	})
+	if err != nil {
+		return fmt.Errorf("create workspace copy execution: %w", err)
+	}
+	executionID := strings.TrimSpace(createResp.GetExecution().GetExecutionId())
+	if executionID == "" {
+		return errors.New("workspace copy execution response missing execution id")
+	}
+	return streamWorkspaceExecutionWithInput(callCtx, ctx, client, opts.SandboxID, executionID, bytes.NewReader(changeset.Patch))
+}
+
+func gitWorkspacePlan(destination string, files []repositorychangeset.File) []workspacePlanEntry {
+	entries := make([]workspacePlanEntry, 0, len(files))
+	for _, file := range files {
+		action := "write"
+		if file.Deleted {
+			action = "delete"
+		}
+		entries = append(entries, workspacePlanEntry{
+			Action: action,
+			Path:   workspaceRemotePath(destination, file.Path),
+		})
+	}
+	sortWorkspacePlan(entries)
+	return entries
+}
+
+func copyRawWorkspaceToSandbox(callCtx context.Context, ctx *runtimeContext, client *controlclient.Client, opts workspaceCopyOptions) error {
+	destination, err := resolveWorkspaceDestinationRoot(opts.CWD, ctx.Loader)
+	if err != nil {
+		return err
+	}
+	if opts.DryRun {
+		entries, err := rawWorkspacePlan(opts.CWD, destination)
+		if err != nil {
+			return err
+		}
+		return printWorkspacePlan(runtimeStdout(ctx), entries)
+	}
+	if _, err := rawWorkspacePlan(opts.CWD, destination); err != nil {
+		return err
+	}
+	if _, err := client.RemoveSandboxPath(tracePreservingContext(callCtx), &cleanroomv1.RemoveSandboxPathRequest{
+		SandboxId: opts.SandboxID,
+		Path:      destination,
+		Recursive: true,
+	}); err != nil && !isSandboxPathNotFoundError(err) {
+		return fmt.Errorf("remove sandbox workspace root: %w", err)
+	}
+	if err := extractRawWorkspaceArchive(callCtx, client, opts.SandboxID, destination, opts.CWD); err != nil {
+		return err
+	}
+	return nil
+}
+
+func resolveWorkspaceDestinationRoot(cwd string, loader policyLoader) (string, error) {
+	repository, err := loadRepositoryConfig(cwd, loader)
+	if err != nil {
+		if errors.Is(err, errSkipRepositoryCheckout) {
+			return defaultRepositoryOverridePath, nil
+		}
+		return "", err
+	}
+	if strings.TrimSpace(repository.Path) == "" {
+		return defaultRepositoryOverridePath, nil
+	}
+	return repository.Path, nil
+}
+
+func rawWorkspacePlan(sourceRoot, destination string) ([]workspacePlanEntry, error) {
+	entries := []workspacePlanEntry{{
+		Action: "delete",
+		Path:   destination,
+	}}
+	err := walkRawWorkspace(sourceRoot, func(path string, d fs.DirEntry, info fs.FileInfo, rel string) error {
+		if rel == "" {
+			return nil
+		}
+		if info.IsDir() {
+			return nil
+		}
+		entries = append(entries, workspacePlanEntry{
+			Action: "write",
+			Path:   workspaceRemotePath(destination, rel),
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sortWorkspacePlan(entries)
+	return entries, nil
+}
+
+func extractRawWorkspaceArchive(callCtx context.Context, client *controlclient.Client, sandboxID, destination, sourceRoot string) error {
+	stream := client.ExtractSandboxArchive(tracePreservingContext(callCtx))
+	if err := stream.Send(&cleanroomv1.ExtractSandboxArchiveRequest{
+		Payload: &cleanroomv1.ExtractSandboxArchiveRequest_Init{Init: &cleanroomv1.ExtractSandboxArchiveInit{
+			SandboxId:   sandboxID,
+			Destination: destination,
+		}},
+	}); err != nil {
+		return fmt.Errorf("start sandbox workspace archive extract: %w", err)
+	}
+
+	reader, writer := io.Pipe()
+	writeDone := make(chan error, 1)
+	go func() {
+		err := writeRawWorkspaceTar(writer, sourceRoot)
+		if err != nil {
+			_ = writer.CloseWithError(err)
+		} else {
+			_ = writer.Close()
+		}
+		writeDone <- err
+	}()
+
+	buf := make([]byte, 32*1024)
+	for {
+		n, readErr := reader.Read(buf)
+		if n > 0 {
+			if err := stream.Send(&cleanroomv1.ExtractSandboxArchiveRequest{
+				Payload: &cleanroomv1.ExtractSandboxArchiveRequest_Data{Data: append([]byte(nil), buf[:n]...)},
+			}); err != nil {
+				_ = reader.CloseWithError(err)
+				<-writeDone
+				return fmt.Errorf("write sandbox workspace archive: %w", err)
+			}
+		}
+		if readErr != nil {
+			if !errors.Is(readErr, io.EOF) {
+				<-writeDone
+				return fmt.Errorf("read local workspace archive: %w", readErr)
+			}
+			break
+		}
+	}
+	if writeErr := <-writeDone; writeErr != nil {
+		return writeErr
+	}
+	if _, err := stream.CloseAndReceive(); err != nil {
+		return fmt.Errorf("extract sandbox workspace archive: %w", err)
+	}
+	return nil
+}
+
+func writeRawWorkspaceTar(w io.Writer, sourceRoot string) (err error) {
+	tw := tar.NewWriter(w)
+	defer func() {
+		if closeErr := tw.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}()
+	return walkRawWorkspace(sourceRoot, func(path string, d fs.DirEntry, info fs.FileInfo, rel string) error {
+		if rel == "" {
+			return nil
+		}
+		link := ""
+		if info.Mode()&os.ModeSymlink != 0 {
+			target, err := os.Readlink(path)
+			if err != nil {
+				return fmt.Errorf("read symlink %s: %w", path, err)
+			}
+			link = target
+		}
+
+		header, err := tar.FileInfoHeader(info, link)
+		if err != nil {
+			return fmt.Errorf("create archive header for %s: %w", path, err)
+		}
+		header.Name = filepath.ToSlash(rel)
+		header.Uid = 0
+		header.Gid = 0
+		header.Uname = ""
+		header.Gname = ""
+		if info.IsDir() {
+			header.Name = strings.TrimRight(header.Name, "/") + "/"
+		}
+		if err := tw.WriteHeader(header); err != nil {
+			return fmt.Errorf("write archive header for %s: %w", path, err)
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		file, err := os.Open(path)
+		if err != nil {
+			return fmt.Errorf("open %s: %w", path, err)
+		}
+		if _, err := io.Copy(tw, file); err != nil {
+			_ = file.Close()
+			return fmt.Errorf("archive %s: %w", path, err)
+		}
+		if err := file.Close(); err != nil {
+			return fmt.Errorf("close %s: %w", path, err)
+		}
+		return nil
+	})
+}
+
+func walkRawWorkspace(sourceRoot string, visit func(path string, d fs.DirEntry, info fs.FileInfo, rel string) error) error {
+	sourceRoot = filepath.Clean(sourceRoot)
+	return filepath.WalkDir(sourceRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(sourceRoot, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			rel = ""
+		}
+		if shouldSkipRawWorkspacePath(rel, d) {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		switch {
+		case info.IsDir(), info.Mode().IsRegular(), info.Mode()&os.ModeSymlink != 0:
+			return visit(path, d, info, filepath.ToSlash(rel))
+		default:
+			return fmt.Errorf("workspace copy cannot archive unsupported file %s", path)
+		}
+	})
+}
+
+func shouldSkipRawWorkspacePath(rel string, d fs.DirEntry) bool {
+	if rel == "" {
+		return false
+	}
+	name := filepath.Base(rel)
+	return d.IsDir() && (name == ".git" || name == ".cleanroom")
+}
+
+func workspaceRemotePath(root, rel string) string {
+	root = strings.TrimRight(strings.TrimSpace(root), "/")
+	if root == "" {
+		root = defaultRepositoryOverridePath
+	}
+	rel = strings.TrimPrefix(posixpath.Clean(filepath.ToSlash(rel)), "/")
+	if rel == "." || rel == "" {
+		return root
+	}
+	return posixpath.Join(root, rel)
+}
+
+func printWorkspacePlan(w io.Writer, entries []workspacePlanEntry) error {
+	for _, entry := range entries {
+		if _, err := fmt.Fprintf(w, "%s\t%s\n", entry.Action, entry.Path); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func sortWorkspacePlan(entries []workspacePlanEntry) {
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].Action != entries[j].Action {
+			return entries[i].Action < entries[j].Action
+		}
+		return entries[i].Path < entries[j].Path
+	})
+}
+
+func streamWorkspaceExecutionWithInput(callCtx context.Context, ctx *runtimeContext, client *controlclient.Client, sandboxID, executionID string, input io.Reader) error {
+	streamCtx, streamCancel := context.WithCancel(tracePreservingContext(callCtx))
+	defer streamCancel()
+	stream, err := client.StreamExecution(streamCtx, &cleanroomv1.StreamExecutionRequest{
+		SandboxId:   sandboxID,
+		ExecutionId: executionID,
+		Follow:      true,
+	})
+	if err != nil {
+		return fmt.Errorf("stream workspace copy execution: %w", err)
+	}
+
+	stdinErrCh := make(chan error, 1)
+	go func() {
+		stdinErrCh <- writeExecutionInput(tracePreservingContext(callCtx), client, sandboxID, executionID, input)
+		close(stdinErrCh)
+	}()
+
+	exitCode := 0
+	haveExitCode := false
+	for stream.Receive() {
+		event := stream.Msg()
+		switch payload := event.Payload.(type) {
+		case *cleanroomv1.ExecutionStreamEvent_Stdout:
+			if _, err := runtimeStdout(ctx).Write(payload.Stdout); err != nil {
+				return err
+			}
+		case *cleanroomv1.ExecutionStreamEvent_Stderr:
+			if _, err := ctx.stderr().Write(payload.Stderr); err != nil {
+				return err
+			}
+		case *cleanroomv1.ExecutionStreamEvent_Warning:
+			if err := writeExecutionWarning(ctx.stderr(), payload.Warning); err != nil {
+				return err
+			}
+		case *cleanroomv1.ExecutionStreamEvent_Exit:
+			exitCode = int(payload.Exit.GetExitCode())
+			haveExitCode = true
+		}
+		if err := pollExecutionStdinErr(stdinErrCh); err != nil {
+			streamCancel()
+			return err
+		}
+	}
+	if err := stream.Err(); err != nil && !isCanceledStreamErr(err) {
+		return fmt.Errorf("stream workspace copy execution: %w", err)
+	}
+	if err := waitExecutionStdinErr(stdinErrCh, executionStdinErrDrainTimeout); err != nil {
+		return err
+	}
+	if !haveExitCode {
+		if fetchedExitCode, ok := getFinalExecutionExitCode(callCtx, client, sandboxID, executionID); ok {
+			exitCode = fetchedExitCode
+			haveExitCode = true
+		}
+	}
+	if !haveExitCode {
+		return errors.New("workspace copy execution ended without exit status")
+	}
+	if exitCode != 0 {
+		return exitCodeError{code: exitCode}
+	}
+	return nil
+}
+
+func writeExecutionInput(callCtx context.Context, client *controlclient.Client, sandboxID, executionID string, r io.Reader) error {
+	buf := make([]byte, 32*1024)
+	for {
+		n, readErr := r.Read(buf)
+		if n > 0 {
+			if _, err := client.WriteExecutionStdin(callCtx, &cleanroomv1.WriteExecutionStdinRequest{
+				SandboxId:   sandboxID,
+				ExecutionId: executionID,
+				Data:        append([]byte(nil), buf[:n]...),
+			}); err != nil {
+				return fmt.Errorf("write workspace copy payload: %w", err)
+			}
+		}
+		if readErr != nil {
+			if !errors.Is(readErr, io.EOF) {
+				return fmt.Errorf("read workspace copy payload: %w", readErr)
+			}
+			break
+		}
+	}
+	return closeExecutionStdin(callCtx, client, sandboxID, executionID)
+}
+
+func runtimeStdout(ctx *runtimeContext) io.Writer {
+	if ctx != nil && ctx.Stdout != nil {
+		return ctx.Stdout
+	}
+	return os.Stdout
+}
+
+func workspaceWorkdirCheckout(destination string) *repositorycheckout.Checkout {
+	return &repositorycheckout.Checkout{DestinationDir: destination}
+}

--- a/internal/cli/workspace.go
+++ b/internal/cli/workspace.go
@@ -132,16 +132,10 @@ func resolveGitWorkspaceCheckout(callCtx context.Context, client *controlclient.
 	destination := strings.TrimSpace(opts.Destination)
 	if destination == "" {
 		var err error
-		destination, err = resolveSandboxWorkspaceDestinationIfRecorded(callCtx, client, opts.SandboxID)
+		destination, err = resolveSandboxWorkspaceDestination(callCtx, client, opts.SandboxID)
 		if err != nil {
 			return nil, nil, err
 		}
-	}
-	if destination == "" {
-		destination = strings.TrimSpace(repository.DestinationDir)
-	}
-	if destination == "" {
-		return nil, nil, errors.New("workspace copy requires a repository destination")
 	}
 	effectiveRepository := *repository
 	effectiveRepository.DestinationDir = destination

--- a/internal/cli/workspace.go
+++ b/internal/cli/workspace.go
@@ -223,24 +223,37 @@ func copyRawWorkspaceToSandbox(callCtx context.Context, ctx *runtimeContext, cli
 }
 
 func cleanRawWorkspaceDestination(callCtx context.Context, ctx *runtimeContext, client *controlclient.Client, sandboxID, destination string) error {
-	state, err := sandboxDestinationDirectoryState(tracePreservingContext(callCtx), client, sandboxID, destination)
+	statResp, err := client.StatSandboxPath(tracePreservingContext(callCtx), &cleanroomv1.StatSandboxPathRequest{
+		SandboxId: sandboxID,
+		Path:      destination,
+	})
 	if err != nil {
+		if isSandboxPathNotFoundError(err) {
+			return nil
+		}
 		return fmt.Errorf("inspect sandbox workspace destination: %w", err)
 	}
-	switch state {
-	case sandboxDestinationMissing:
-		return nil
-	case sandboxDestinationOther:
-		if _, err := client.RemoveSandboxPath(tracePreservingContext(callCtx), &cleanroomv1.RemoveSandboxPathRequest{
-			SandboxId: sandboxID,
-			Path:      destination,
-		}); err != nil && !isSandboxPathNotFoundError(err) {
-			return fmt.Errorf("remove non-directory workspace destination: %w", err)
-		}
-		return nil
-	default:
-		return runWorkspaceExecution(callCtx, ctx, client, sandboxID, nil, rawWorkspaceCleanCommand(destination), nil)
+	info := statResp.GetInfo()
+	if info == nil {
+		return errors.New("inspect sandbox workspace destination: missing path info")
 	}
+	if info.GetType() != cleanroomv1.SandboxPathType_SANDBOX_PATH_TYPE_DIRECTORY {
+		return removeRawWorkspaceDestinationRoot(callCtx, client, sandboxID, destination)
+	}
+	return runWorkspaceExecution(callCtx, ctx, client, sandboxID, nil, rawWorkspaceCleanCommand(destination), nil)
+}
+
+func removeRawWorkspaceDestinationRoot(callCtx context.Context, client *controlclient.Client, sandboxID, destination string) error {
+	if _, err := client.RemoveSandboxPath(tracePreservingContext(callCtx), &cleanroomv1.RemoveSandboxPathRequest{
+		SandboxId: sandboxID,
+		Path:      destination,
+	}); err != nil {
+		if isSandboxPathNotFoundError(err) {
+			return nil
+		}
+		return fmt.Errorf("remove non-directory workspace destination: %w", err)
+	}
+	return nil
 }
 
 func rawWorkspaceCleanCommand(destination string) []string {

--- a/internal/cli/workspace.go
+++ b/internal/cli/workspace.go
@@ -21,13 +21,13 @@ import (
 )
 
 type WorkspaceCommand struct {
-	Copy WorkspaceCopyCommand `cmd:"" help:"Copy local workspace changes into a sandbox"`
+	CopyIn WorkspaceCopyInCommand `name:"copy-in" cmd:"" help:"Copy local workspace changes into a sandbox"`
 }
 
-type WorkspaceCopyCommand struct {
+type WorkspaceCopyInCommand struct {
 	clientFlags
-	Chdir     string `short:"c" help:"Change to this local directory before planning the workspace copy"`
-	DryRun    bool   `name:"dry-run" help:"Show the workspace paths that would be copied without modifying the sandbox"`
+	Chdir     string `short:"c" help:"Change to this local directory before planning the workspace copy-in"`
+	DryRun    bool   `name:"dry-run" help:"Show the workspace paths that would be copied in without modifying the sandbox"`
 	SandboxID string `arg:"" required:"" help:"Sandbox ID to copy into"`
 }
 
@@ -46,7 +46,7 @@ type workspacePlanEntry struct {
 	Path   string
 }
 
-func (c *WorkspaceCopyCommand) Run(ctx *runtimeContext) error {
+func (c *WorkspaceCopyInCommand) Run(ctx *runtimeContext) error {
 	cwd, err := resolveCWD(ctx.CWD, c.Chdir)
 	if err != nil {
 		return err
@@ -84,7 +84,7 @@ func copyWorkspaceToSandbox(callCtx context.Context, ctx *runtimeContext, client
 func copyGitWorkspaceToSandbox(callCtx context.Context, ctx *runtimeContext, client *controlclient.Client, opts workspaceCopyOptions) error {
 	repository := opts.Repository
 	if strings.TrimSpace(repository.RootDir) == "" {
-		return errors.New("workspace copy requires a local repository checkout")
+		return errors.New("workspace copy-in requires a local repository checkout")
 	}
 	changeset, err := repositorychangeset.BuildFromWorkingTree(repository.RootDir, toRepositoryCheckout(repository))
 	if err != nil {
@@ -128,7 +128,7 @@ func copyGitWorkspaceToSandbox(callCtx context.Context, ctx *runtimeContext, cli
 func resolveGitWorkspaceCheckout(callCtx context.Context, client *controlclient.Client, opts workspaceCopyOptions) (*resolvedRepositoryCheckout, *repositorycheckout.Checkout, error) {
 	repository := opts.Repository
 	if repository == nil {
-		return nil, nil, errors.New("workspace copy requires a local repository checkout")
+		return nil, nil, errors.New("workspace copy-in requires a local repository checkout")
 	}
 	destination := strings.TrimSpace(opts.Destination)
 	if destination == "" {
@@ -146,7 +146,7 @@ func resolveGitWorkspaceCheckout(callCtx context.Context, client *controlclient.
 
 func runWorkspaceExecution(callCtx context.Context, ctx *runtimeContext, client *controlclient.Client, sandboxID string, repository *resolvedRepositoryCheckout, command []string, input io.Reader, launchSeconds int64) error {
 	if len(command) == 0 {
-		return errors.New("workspace copy execution command is empty")
+		return errors.New("workspace copy-in execution command is empty")
 	}
 	createResp, err := client.CreateExecution(tracePreservingContext(callCtx), &cleanroomv1.CreateExecutionRequest{
 		SandboxId:          sandboxID,
@@ -160,11 +160,11 @@ func runWorkspaceExecution(callCtx context.Context, ctx *runtimeContext, client 
 		},
 	})
 	if err != nil {
-		return fmt.Errorf("create workspace copy execution: %w", err)
+		return fmt.Errorf("create workspace copy-in execution: %w", err)
 	}
 	executionID := strings.TrimSpace(createResp.GetExecution().GetExecutionId())
 	if executionID == "" {
-		return errors.New("workspace copy execution response missing execution id")
+		return errors.New("workspace copy-in execution response missing execution id")
 	}
 	return streamWorkspaceExecutionWithInput(callCtx, ctx, client, sandboxID, executionID, input)
 }
@@ -288,7 +288,7 @@ func resolveSandboxWorkspaceDestination(callCtx context.Context, client *control
 
 func resolveSandboxWorkspaceDestinationIfRecorded(callCtx context.Context, client *controlclient.Client, sandboxID string) (string, error) {
 	if client == nil {
-		return "", errors.New("workspace copy requires a control client")
+		return "", errors.New("workspace copy-in requires a control client")
 	}
 	resp, err := client.GetSandbox(tracePreservingContext(callCtx), &cleanroomv1.GetSandboxRequest{
 		SandboxId: sandboxID,
@@ -328,7 +328,7 @@ func validateRawWorkspaceDestinationRoot(destination string) error {
 		"/tmp",
 		"/usr",
 		"/var":
-		return fmt.Errorf("workspace destination root %q is unsafe for raw workspace copy", destination)
+		return fmt.Errorf("workspace destination root %q is unsafe for raw workspace copy-in", destination)
 	default:
 		return nil
 	}
@@ -494,7 +494,7 @@ func walkRawWorkspace(sourceRoot string, visit func(path string, d fs.DirEntry, 
 		case info.IsDir(), info.Mode().IsRegular(), info.Mode()&os.ModeSymlink != 0:
 			return visit(path, d, info, filepath.ToSlash(rel))
 		default:
-			return fmt.Errorf("workspace copy cannot archive unsupported file %s", path)
+			return fmt.Errorf("workspace copy-in cannot archive unsupported file %s", path)
 		}
 	})
 }
@@ -569,7 +569,7 @@ func streamWorkspaceExecutionWithInput(callCtx context.Context, ctx *runtimeCont
 		Follow:      true,
 	})
 	if err != nil {
-		return fmt.Errorf("stream workspace copy execution: %w", err)
+		return fmt.Errorf("stream workspace copy-in execution: %w", err)
 	}
 
 	var stdinErrCh <-chan error
@@ -609,7 +609,7 @@ func streamWorkspaceExecutionWithInput(callCtx context.Context, ctx *runtimeCont
 		}
 	}
 	if err := stream.Err(); err != nil && !isCanceledStreamErr(err) {
-		return fmt.Errorf("stream workspace copy execution: %w", err)
+		return fmt.Errorf("stream workspace copy-in execution: %w", err)
 	}
 	if err := waitExecutionStdinErr(stdinErrCh, executionStdinErrDrainTimeout); err != nil {
 		return err
@@ -621,7 +621,7 @@ func streamWorkspaceExecutionWithInput(callCtx context.Context, ctx *runtimeCont
 		}
 	}
 	if !haveExitCode {
-		return errors.New("workspace copy execution ended without exit status")
+		return errors.New("workspace copy-in execution ended without exit status")
 	}
 	if exitCode != 0 {
 		return exitCodeError{code: exitCode}
@@ -639,12 +639,12 @@ func writeExecutionInput(callCtx context.Context, client *controlclient.Client, 
 				ExecutionId: executionID,
 				Data:        append([]byte(nil), buf[:n]...),
 			}); err != nil {
-				return fmt.Errorf("write workspace copy payload: %w", err)
+				return fmt.Errorf("write workspace copy-in payload: %w", err)
 			}
 		}
 		if readErr != nil {
 			if !errors.Is(readErr, io.EOF) {
-				return fmt.Errorf("read workspace copy payload: %w", readErr)
+				return fmt.Errorf("read workspace copy-in payload: %w", readErr)
 			}
 			break
 		}

--- a/internal/cli/workspace.go
+++ b/internal/cli/workspace.go
@@ -86,7 +86,11 @@ func copyGitWorkspaceToSandbox(callCtx context.Context, ctx *runtimeContext, cli
 	if strings.TrimSpace(repository.RootDir) == "" {
 		return errors.New("workspace copy-in requires a local repository checkout")
 	}
-	changeset, err := repositorychangeset.BuildFromWorkingTree(repository.RootDir, toRepositoryCheckout(repository))
+	effectiveRepository, checkout, err := resolveGitWorkspaceCheckout(callCtx, client, opts)
+	if err != nil {
+		return err
+	}
+	changeset, err := repositorychangeset.BuildFromWorkingTree(repository.RootDir, checkout)
 	if err != nil {
 		return fmt.Errorf("package local workspace changes: %w", err)
 	}
@@ -95,24 +99,12 @@ func copyGitWorkspaceToSandbox(callCtx context.Context, ctx *runtimeContext, cli
 			if !opts.ForceGitReset {
 				return nil
 			}
-			_, checkout, err := resolveGitWorkspaceCheckout(callCtx, client, opts)
-			if err != nil {
-				return err
-			}
 			return printWorkspacePlan(runtimeStdout(ctx), gitWorkspacePlan(checkout.DestinationDir, nil, true))
 		}
 		if opts.ForceGitReset {
-			effectiveRepository, checkout, err := resolveGitWorkspaceCheckout(callCtx, client, opts)
-			if err != nil {
-				return err
-			}
 			return runWorkspaceExecution(callCtx, ctx, client, opts.SandboxID, effectiveRepository, repositorychangeset.ResetCommand(checkout), nil, opts.LaunchSeconds)
 		}
 		return nil
-	}
-	effectiveRepository, checkout, err := resolveGitWorkspaceCheckout(callCtx, client, opts)
-	if err != nil {
-		return err
 	}
 	if opts.DryRun {
 		return printWorkspacePlan(runtimeStdout(ctx), gitWorkspacePlan(checkout.DestinationDir, changeset.Files, opts.ForceGitReset))
@@ -130,15 +122,23 @@ func resolveGitWorkspaceCheckout(callCtx context.Context, client *controlclient.
 	if repository == nil {
 		return nil, nil, errors.New("workspace copy-in requires a local repository checkout")
 	}
+	effectiveRepository := *repository
 	destination := strings.TrimSpace(opts.Destination)
 	if destination == "" {
-		var err error
-		destination, err = resolveSandboxWorkspaceDestination(callCtx, client, opts.SandboxID)
+		sandboxRepository, err := resolveSandboxRepositoryCheckout(callCtx, client, opts.SandboxID)
 		if err != nil {
 			return nil, nil, err
 		}
+		destination = strings.TrimSpace(sandboxRepository.GetDestinationDir())
+		if remoteURL := strings.TrimSpace(sandboxRepository.GetRemoteUrl()); remoteURL != "" {
+			effectiveRepository.RemoteURL = remoteURL
+		}
+		if commitSHA := strings.TrimSpace(sandboxRepository.GetCommitSha()); commitSHA != "" {
+			effectiveRepository.CommitSHA = commitSHA
+		}
+		effectiveRepository.Submodules = sandboxRepository.GetSubmodules()
+		effectiveRepository.Branch = strings.TrimSpace(sandboxRepository.GetBranch())
 	}
-	effectiveRepository := *repository
 	effectiveRepository.DestinationDir = destination
 	checkout := toRepositoryCheckout(&effectiveRepository)
 	return &effectiveRepository, checkout, nil
@@ -276,10 +276,11 @@ func workspaceShellQuote(value string) string {
 }
 
 func resolveSandboxWorkspaceDestination(callCtx context.Context, client *controlclient.Client, sandboxID string) (string, error) {
-	destination, err := resolveSandboxWorkspaceDestinationIfRecorded(callCtx, client, sandboxID)
+	repository, err := resolveSandboxRepositoryCheckout(callCtx, client, sandboxID)
 	if err != nil {
 		return "", err
 	}
+	destination := strings.TrimSpace(repository.GetDestinationDir())
 	if destination == "" {
 		return "", fmt.Errorf("sandbox %q does not have a recorded workspace root; create it from a repository checkout or use cleanroom copy for explicit paths", sandboxID)
 	}
@@ -287,20 +288,42 @@ func resolveSandboxWorkspaceDestination(callCtx context.Context, client *control
 }
 
 func resolveSandboxWorkspaceDestinationIfRecorded(callCtx context.Context, client *controlclient.Client, sandboxID string) (string, error) {
+	repository, err := resolveSandboxRepositoryCheckoutIfRecorded(callCtx, client, sandboxID)
+	if err != nil || repository == nil {
+		return "", err
+	}
+	return strings.TrimSpace(repository.GetDestinationDir()), nil
+}
+
+func resolveSandboxRepositoryCheckout(callCtx context.Context, client *controlclient.Client, sandboxID string) (*cleanroomv1.RepositoryCheckout, error) {
+	repository, err := resolveSandboxRepositoryCheckoutIfRecorded(callCtx, client, sandboxID)
+	if err != nil {
+		return nil, err
+	}
+	if repository == nil || strings.TrimSpace(repository.GetDestinationDir()) == "" {
+		return nil, fmt.Errorf("sandbox %q does not have a recorded workspace root; create it from a repository checkout or use cleanroom copy for explicit paths", sandboxID)
+	}
+	return repository, nil
+}
+
+func resolveSandboxRepositoryCheckoutIfRecorded(callCtx context.Context, client *controlclient.Client, sandboxID string) (*cleanroomv1.RepositoryCheckout, error) {
 	if client == nil {
-		return "", errors.New("workspace copy-in requires a control client")
+		return nil, errors.New("workspace copy-in requires a control client")
 	}
 	resp, err := client.GetSandbox(tracePreservingContext(callCtx), &cleanroomv1.GetSandboxRequest{
 		SandboxId: sandboxID,
 	})
 	if err != nil {
-		return "", fmt.Errorf("inspect sandbox workspace: %w", err)
+		return nil, fmt.Errorf("inspect sandbox workspace: %w", err)
 	}
 	sandbox := resp.GetSandbox()
 	if sandbox == nil {
-		return "", fmt.Errorf("sandbox %q not found", sandboxID)
+		return nil, fmt.Errorf("sandbox %q not found", sandboxID)
 	}
-	return strings.TrimSpace(sandbox.GetRepositoryCheckout().GetDestinationDir()), nil
+	if sandbox.GetRepositoryCheckout() == nil {
+		return nil, nil
+	}
+	return sandbox.GetRepositoryCheckout(), nil
 }
 
 func validateRawWorkspaceDestinationRoot(destination string) error {

--- a/internal/cli/workspace.go
+++ b/internal/cli/workspace.go
@@ -148,7 +148,7 @@ func runWorkspaceExecution(callCtx context.Context, ctx *runtimeContext, client 
 	if len(command) == 0 {
 		return errors.New("workspace copy-in execution command is empty")
 	}
-	createResp, err := client.CreateExecution(tracePreservingContext(callCtx), &cleanroomv1.CreateExecutionRequest{
+	createResp, err := client.CreateWorkspaceCopyInExecution(tracePreservingContext(callCtx), &cleanroomv1.CreateExecutionRequest{
 		SandboxId:          sandboxID,
 		Command:            command,
 		Kind:               cleanroomv1.ExecutionKind_EXECUTION_KIND_BATCH,
@@ -577,7 +577,11 @@ func streamWorkspaceExecutionWithInput(callCtx context.Context, ctx *runtimeCont
 		ch := make(chan error, 1)
 		stdinErrCh = ch
 		go func() {
-			ch <- writeExecutionInput(tracePreservingContext(callCtx), client, sandboxID, executionID, input)
+			err := writeExecutionInput(tracePreservingContext(callCtx), client, sandboxID, executionID, input)
+			if err != nil {
+				streamCancel()
+			}
+			ch <- err
 			close(ch)
 		}()
 	}

--- a/internal/cli/workspace.go
+++ b/internal/cli/workspace.go
@@ -55,7 +55,7 @@ func (c *WorkspaceCopyCommand) Run(ctx *runtimeContext) error {
 	if err != nil {
 		return err
 	}
-	repository, err := resolveRepositoryCheckout(cwd, ctx.Loader)
+	repository, err := resolveWorkspaceCopyRepositoryCheckout(cwd, ctx.Loader)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/workspace.go
+++ b/internal/cli/workspace.go
@@ -85,8 +85,7 @@ func copyGitWorkspaceToSandbox(callCtx context.Context, ctx *runtimeContext, cli
 	if strings.TrimSpace(repository.RootDir) == "" {
 		return errors.New("workspace copy requires a local repository checkout")
 	}
-	checkout := toRepositoryCheckout(repository)
-	changeset, err := repositorychangeset.BuildFromWorkingTree(repository.RootDir, checkout)
+	changeset, err := repositorychangeset.BuildFromWorkingTree(repository.RootDir, toRepositoryCheckout(repository))
 	if err != nil {
 		return fmt.Errorf("package local workspace changes: %w", err)
 	}
@@ -95,19 +94,52 @@ func copyGitWorkspaceToSandbox(callCtx context.Context, ctx *runtimeContext, cli
 			return nil
 		}
 		if opts.ForceGitReset {
-			return runWorkspaceExecution(callCtx, ctx, client, opts.SandboxID, repository, repositorychangeset.ResetCommand(checkout), nil)
+			effectiveRepository, checkout, err := resolveGitWorkspaceCheckout(callCtx, client, opts)
+			if err != nil {
+				return err
+			}
+			return runWorkspaceExecution(callCtx, ctx, client, opts.SandboxID, effectiveRepository, repositorychangeset.ResetCommand(checkout), nil)
 		}
 		return nil
 	}
+	effectiveRepository, checkout, err := resolveGitWorkspaceCheckout(callCtx, client, opts)
+	if err != nil {
+		return err
+	}
 	if opts.DryRun {
-		return printWorkspacePlan(runtimeStdout(ctx), gitWorkspacePlan(repository.DestinationDir, changeset.Files))
+		return printWorkspacePlan(runtimeStdout(ctx), gitWorkspacePlan(checkout.DestinationDir, changeset.Files))
 	}
 
 	command := repositorychangeset.ApplyCommand(checkout, changeset)
 	if opts.ForceGitReset {
 		command = repositorychangeset.ApplyCommandResettingCheckout(checkout, changeset)
 	}
-	return runWorkspaceExecution(callCtx, ctx, client, opts.SandboxID, repository, command, bytes.NewReader(changeset.Patch))
+	return runWorkspaceExecution(callCtx, ctx, client, opts.SandboxID, effectiveRepository, command, bytes.NewReader(changeset.Patch))
+}
+
+func resolveGitWorkspaceCheckout(callCtx context.Context, client *controlclient.Client, opts workspaceCopyOptions) (*resolvedRepositoryCheckout, *repositorycheckout.Checkout, error) {
+	repository := opts.Repository
+	if repository == nil {
+		return nil, nil, errors.New("workspace copy requires a local repository checkout")
+	}
+	destination := strings.TrimSpace(opts.Destination)
+	if destination == "" {
+		var err error
+		destination, err = resolveSandboxWorkspaceDestinationIfRecorded(callCtx, client, opts.SandboxID)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+	if destination == "" {
+		destination = strings.TrimSpace(repository.DestinationDir)
+	}
+	if destination == "" {
+		return nil, nil, errors.New("workspace copy requires a repository destination")
+	}
+	effectiveRepository := *repository
+	effectiveRepository.DestinationDir = destination
+	checkout := toRepositoryCheckout(&effectiveRepository)
+	return &effectiveRepository, checkout, nil
 }
 
 func runWorkspaceExecution(callCtx context.Context, ctx *runtimeContext, client *controlclient.Client, sandboxID string, repository *resolvedRepositoryCheckout, command []string, input io.Reader) error {
@@ -201,6 +233,17 @@ func workspaceShellQuote(value string) string {
 }
 
 func resolveSandboxWorkspaceDestination(callCtx context.Context, client *controlclient.Client, sandboxID string) (string, error) {
+	destination, err := resolveSandboxWorkspaceDestinationIfRecorded(callCtx, client, sandboxID)
+	if err != nil {
+		return "", err
+	}
+	if destination == "" {
+		return "", fmt.Errorf("sandbox %q does not have a recorded workspace root; create it from a repository checkout or use cleanroom copy for explicit paths", sandboxID)
+	}
+	return destination, nil
+}
+
+func resolveSandboxWorkspaceDestinationIfRecorded(callCtx context.Context, client *controlclient.Client, sandboxID string) (string, error) {
 	if client == nil {
 		return "", errors.New("workspace copy requires a control client")
 	}
@@ -214,11 +257,7 @@ func resolveSandboxWorkspaceDestination(callCtx context.Context, client *control
 	if sandbox == nil {
 		return "", fmt.Errorf("sandbox %q not found", sandboxID)
 	}
-	destination := strings.TrimSpace(sandbox.GetRepositoryCheckout().GetDestinationDir())
-	if destination == "" {
-		return "", fmt.Errorf("sandbox %q does not have a recorded workspace root; create it from a repository checkout or use cleanroom copy for explicit paths", sandboxID)
-	}
-	return destination, nil
+	return strings.TrimSpace(sandbox.GetRepositoryCheckout().GetDestinationDir()), nil
 }
 
 func validateRawWorkspaceDestinationRoot(destination string) error {
@@ -383,7 +422,10 @@ func writeRawWorkspaceTar(w io.Writer, sourceRoot string) (err error) {
 }
 
 func walkRawWorkspace(sourceRoot string, visit func(path string, d fs.DirEntry, info fs.FileInfo, rel string) error) error {
-	sourceRoot = filepath.Clean(sourceRoot)
+	sourceRoot, err := resolveRawWorkspaceSourceRoot(sourceRoot)
+	if err != nil {
+		return err
+	}
 	return filepath.WalkDir(sourceRoot, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -412,6 +454,26 @@ func walkRawWorkspace(sourceRoot string, visit func(path string, d fs.DirEntry, 
 			return fmt.Errorf("workspace copy cannot archive unsupported file %s", path)
 		}
 	})
+}
+
+func resolveRawWorkspaceSourceRoot(sourceRoot string) (string, error) {
+	sourceRoot = strings.TrimSpace(sourceRoot)
+	if sourceRoot == "" {
+		return "", errors.New("missing local workspace root")
+	}
+	cleaned := filepath.Clean(sourceRoot)
+	resolved, err := filepath.EvalSymlinks(cleaned)
+	if err != nil {
+		return "", fmt.Errorf("resolve workspace source root %q: %w", cleaned, err)
+	}
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return "", fmt.Errorf("inspect workspace source root %q: %w", resolved, err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("workspace source root %q is not a directory", cleaned)
+	}
+	return resolved, nil
 }
 
 func shouldSkipRawWorkspacePath(rel string, d fs.DirEntry) bool {

--- a/internal/cli/workspace.go
+++ b/internal/cli/workspace.go
@@ -168,17 +168,36 @@ func copyRawWorkspaceToSandbox(callCtx context.Context, ctx *runtimeContext, cli
 	if _, err := rawWorkspacePlan(opts.CWD, destination); err != nil {
 		return err
 	}
-	if _, err := client.RemoveSandboxPath(tracePreservingContext(callCtx), &cleanroomv1.RemoveSandboxPathRequest{
-		SandboxId: opts.SandboxID,
-		Path:      destination,
-		Recursive: true,
-	}); err != nil && !isSandboxPathNotFoundError(err) {
-		return fmt.Errorf("remove sandbox workspace root: %w", err)
+	if err := cleanRawWorkspaceDestination(callCtx, ctx, client, opts.SandboxID, destination); err != nil {
+		return err
 	}
 	if err := extractRawWorkspaceArchive(callCtx, client, opts.SandboxID, destination, opts.CWD); err != nil {
 		return err
 	}
 	return nil
+}
+
+func cleanRawWorkspaceDestination(callCtx context.Context, ctx *runtimeContext, client *controlclient.Client, sandboxID, destination string) error {
+	return runWorkspaceExecution(callCtx, ctx, client, sandboxID, nil, rawWorkspaceCleanCommand(destination), nil)
+}
+
+func rawWorkspaceCleanCommand(destination string) []string {
+	script := []string{
+		"set -eu",
+		"dest=" + workspaceShellQuote(destination),
+		`if [ -e "$dest" ] && [ ! -d "$dest" ]; then echo "workspace destination is not a directory: $dest" >&2; exit 1; fi`,
+		`mkdir -p "$dest"`,
+		`for entry in "$dest"/* "$dest"/.[!.]* "$dest"/..?*; do`,
+		`  [ -e "$entry" ] || [ -L "$entry" ] || continue`,
+		`  [ "$(basename "$entry")" = ".git" ] && continue`,
+		`  rm -rf -- "$entry"`,
+		`done`,
+	}
+	return []string{"sh", "-lc", strings.Join(script, "\n")}
+}
+
+func workspaceShellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", `'"'"'`) + "'"
 }
 
 func resolveSandboxWorkspaceDestination(callCtx context.Context, client *controlclient.Client, sandboxID string) (string, error) {
@@ -400,7 +419,10 @@ func shouldSkipRawWorkspacePath(rel string, d fs.DirEntry) bool {
 		return false
 	}
 	name := filepath.Base(rel)
-	return d.IsDir() && (name == ".git" || name == ".cleanroom")
+	if name == ".git" {
+		return true
+	}
+	return d.IsDir() && name == ".cleanroom"
 }
 
 func workspaceRemotePath(root, rel string) string {

--- a/internal/cli/workspace.go
+++ b/internal/cli/workspace.go
@@ -210,7 +210,24 @@ func copyRawWorkspaceToSandbox(callCtx context.Context, ctx *runtimeContext, cli
 }
 
 func cleanRawWorkspaceDestination(callCtx context.Context, ctx *runtimeContext, client *controlclient.Client, sandboxID, destination string) error {
-	return runWorkspaceExecution(callCtx, ctx, client, sandboxID, nil, rawWorkspaceCleanCommand(destination), nil)
+	state, err := sandboxDestinationDirectoryState(tracePreservingContext(callCtx), client, sandboxID, destination)
+	if err != nil {
+		return fmt.Errorf("inspect sandbox workspace destination: %w", err)
+	}
+	switch state {
+	case sandboxDestinationMissing:
+		return nil
+	case sandboxDestinationOther:
+		if _, err := client.RemoveSandboxPath(tracePreservingContext(callCtx), &cleanroomv1.RemoveSandboxPathRequest{
+			SandboxId: sandboxID,
+			Path:      destination,
+		}); err != nil && !isSandboxPathNotFoundError(err) {
+			return fmt.Errorf("remove non-directory workspace destination: %w", err)
+		}
+		return nil
+	default:
+		return runWorkspaceExecution(callCtx, ctx, client, sandboxID, nil, rawWorkspaceCleanCommand(destination), nil)
+	}
 }
 
 func rawWorkspaceCleanCommand(destination string) []string {

--- a/internal/cli/workspace_test.go
+++ b/internal/cli/workspace_test.go
@@ -133,6 +133,98 @@ func TestWorkspaceCopyInAppliesGitChangeset(t *testing.T) {
 	}
 }
 
+func TestWorkspaceCopyInAppliesLocalOnlyCommitsFromSandboxBase(t *testing.T) {
+	repoDir := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
+	baseCommit := headCommit(t, repoDir)
+	branch, err := gitOutput(repoDir, "branch", "--show-current")
+	if err != nil {
+		t.Fatalf("resolve repository branch: %v", err)
+	}
+	commitFile(t, repoDir, "local.txt", "local\n", "local commit")
+	localCommit := headCommit(t, repoDir)
+
+	adapter := &integrationAdapter{}
+	host, _ := startIntegrationServer(t, adapter)
+	sandboxID := createWorkspaceCopyTestSandboxWithRepositoryCommitBranch(t, host, "/sandbox-workspace", baseCommit, strings.TrimSpace(branch))
+
+	var (
+		mu       sync.Mutex
+		commands [][]string
+		patches  []string
+	)
+	adapter.runStreamFn = func(ctx context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+		mu.Lock()
+		commands = append(commands, append([]string(nil), req.Command...))
+		mu.Unlock()
+
+		if !strings.Contains(strings.Join(req.Command, " "), `git -C "$dest" apply --binary --whitespace=nowarn "$patch_file"`) {
+			return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+		}
+
+		closed := make(chan struct{})
+		var closeOnce sync.Once
+		var stdin bytes.Buffer
+		if stream.OnAttach != nil {
+			stream.OnAttach(backend.AttachIO{
+				WriteStdin: func(data []byte) error {
+					_, err := stdin.Write(data)
+					return err
+				},
+				CloseStdin: func() error {
+					mu.Lock()
+					patches = append(patches, stdin.String())
+					mu.Unlock()
+					closeOnce.Do(func() { close(closed) })
+					return nil
+				},
+			})
+		}
+		select {
+		case <-closed:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+	}
+
+	stdout, _ := makeStdoutCapture(t)
+	stderr, _ := makeStdoutCapture(t)
+	cmd := WorkspaceCopyInCommand{
+		clientFlags: clientFlags{Host: host},
+		Chdir:       repoDir,
+		SandboxID:   sandboxID,
+	}
+	if err := cmd.Run(&runtimeContext{
+		CWD:           repoDir,
+		Loader:        workspaceCopyRepositoryLoader(),
+		Config:        runtimeconfig.Config{},
+		Observability: newTestObservability(t),
+		Stdout:        stdout,
+		Stderr:        stderr,
+	}); err != nil {
+		t.Fatalf("WorkspaceCopyInCommand.Run returned error: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(commands) < 1 {
+		t.Fatalf("expected changeset apply command, got %d", len(commands))
+	}
+	applyCommand := strings.Join(commands[len(commands)-1], " ")
+	if !strings.Contains(applyCommand, baseCommit) {
+		t.Fatalf("expected workspace copy-in to reset to sandbox base commit %q, got %q", baseCommit, applyCommand)
+	}
+	if strings.Contains(applyCommand, localCommit) {
+		t.Fatalf("expected workspace copy-in not to request local-only commit %q, got %q", localCommit, applyCommand)
+	}
+	if got, want := len(patches), 1; got != want {
+		t.Fatalf("expected one attached changeset patch, got %d", got)
+	}
+	if !strings.Contains(patches[0], "local.txt") {
+		t.Fatalf("expected changeset patch to include local-only commit file, got %q", patches[0])
+	}
+}
+
 func TestWorkspaceCopyInReturnsWhenPatchStdinWriteFails(t *testing.T) {
 	repoDir := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
 	if err := os.WriteFile(filepath.Join(repoDir, "dirty.txt"), []byte("dirty\n"), 0o644); err != nil {

--- a/internal/cli/workspace_test.go
+++ b/internal/cli/workspace_test.go
@@ -217,7 +217,7 @@ func TestWorkspaceCopyResetsGitCheckoutWhenLocalRepoClean(t *testing.T) {
 	}
 }
 
-func TestResolveExecutionSandboxReturnsSandboxWorkspaceRootAfterGitCopyInExistingSandbox(t *testing.T) {
+func TestResolveExecutionSandboxClearsRepositoryAfterGitCopyInExistingSandbox(t *testing.T) {
 	repoDir := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
 
 	adapter := &integrationAdapter{}
@@ -259,11 +259,11 @@ func TestResolveExecutionSandboxReturnsSandboxWorkspaceRootAfterGitCopyInExistin
 	if err != nil {
 		t.Fatalf("resolveExecutionSandbox returned error: %v", err)
 	}
-	if target.Repository == nil {
-		t.Fatal("expected returned execution sandbox to include repository checkout")
+	if target.Repository != nil {
+		t.Fatalf("expected returned execution sandbox to avoid repository checkout after copy, got %#v", target.Repository)
 	}
-	if got, want := target.Repository.DestinationDir, "/sandbox-workspace"; got != want {
-		t.Fatalf("unexpected returned repository destination: got %q want %q", got, want)
+	if got, want := target.WorkspaceRoot, "/sandbox-workspace"; got != want {
+		t.Fatalf("unexpected returned workspace root: got %q want %q", got, want)
 	}
 }
 
@@ -678,6 +678,38 @@ func TestWorkspaceCopyRejectsRawCopyWhenSandboxWorkspaceRootUnknown(t *testing.T
 	})
 	if err == nil {
 		t.Fatal("expected raw workspace copy to reject sandbox without recorded workspace root")
+	}
+	if !strings.Contains(err.Error(), "does not have a recorded workspace root") {
+		t.Fatalf("expected recorded workspace root error, got %v", err)
+	}
+}
+
+func TestWorkspaceCopyRejectsGitCopyWhenSandboxWorkspaceRootUnknown(t *testing.T) {
+	repoDir := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
+	if err := os.WriteFile(filepath.Join(repoDir, "dirty.txt"), []byte("dirty\n"), 0o644); err != nil {
+		t.Fatalf("write dirty file: %v", err)
+	}
+	adapter := &integrationAdapter{}
+	host, _ := startIntegrationServer(t, adapter)
+	sandboxID := createWorkspaceCopyTestSandbox(t, host, workspaceCopyTestPolicy())
+
+	stdout, _ := makeStdoutCapture(t)
+	stderr, _ := makeStdoutCapture(t)
+	cmd := WorkspaceCopyCommand{
+		clientFlags: clientFlags{Host: host},
+		Chdir:       repoDir,
+		SandboxID:   sandboxID,
+	}
+	err := cmd.Run(&runtimeContext{
+		CWD:           repoDir,
+		Loader:        workspaceCopyRepositoryLoader(),
+		Config:        runtimeconfig.Config{},
+		Observability: newTestObservability(t),
+		Stdout:        stdout,
+		Stderr:        stderr,
+	})
+	if err == nil {
+		t.Fatal("expected git workspace copy to reject sandbox without recorded workspace root")
 	}
 	if !strings.Contains(err.Error(), "does not have a recorded workspace root") {
 		t.Fatalf("expected recorded workspace root error, got %v", err)

--- a/internal/cli/workspace_test.go
+++ b/internal/cli/workspace_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/buildkite/cleanroom/internal/runtimeconfig"
 )
 
-func TestWorkspaceCopyAppliesGitChangeset(t *testing.T) {
+func TestWorkspaceCopyInAppliesGitChangeset(t *testing.T) {
 	repoDir := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
 	if err := os.WriteFile(filepath.Join(repoDir, ".gitignore"), []byte("node_modules/\n"), 0o644); err != nil {
 		t.Fatalf("write gitignore: %v", err)
@@ -90,7 +90,7 @@ func TestWorkspaceCopyAppliesGitChangeset(t *testing.T) {
 
 	stdout, _ := makeStdoutCapture(t)
 	stderr, _ := makeStdoutCapture(t)
-	cmd := WorkspaceCopyCommand{
+	cmd := WorkspaceCopyInCommand{
 		clientFlags: clientFlags{Host: host},
 		Chdir:       repoDir,
 		SandboxID:   sandboxID,
@@ -103,7 +103,7 @@ func TestWorkspaceCopyAppliesGitChangeset(t *testing.T) {
 		Stdout:        stdout,
 		Stderr:        stderr,
 	}); err != nil {
-		t.Fatalf("WorkspaceCopyCommand.Run returned error: %v", err)
+		t.Fatalf("WorkspaceCopyInCommand.Run returned error: %v", err)
 	}
 
 	mu.Lock()
@@ -113,13 +113,13 @@ func TestWorkspaceCopyAppliesGitChangeset(t *testing.T) {
 	}
 	applyCommand := strings.Join(commands[len(commands)-1], " ")
 	if !strings.Contains(applyCommand, `git -C "$dest" reset --hard "$base_commit"`) {
-		t.Fatalf("expected workspace copy to reset the checkout before applying, got %q", applyCommand)
+		t.Fatalf("expected workspace copy-in to reset the checkout before applying, got %q", applyCommand)
 	}
 	if !strings.Contains(applyCommand, "dest='/sandbox-workspace'") {
-		t.Fatalf("expected workspace copy to target sandbox-recorded checkout root, got %q", applyCommand)
+		t.Fatalf("expected workspace copy-in to target sandbox-recorded checkout root, got %q", applyCommand)
 	}
 	if strings.Contains(applyCommand, "dest='/workspace'") {
-		t.Fatalf("expected workspace copy not to use stale local policy checkout root, got %q", applyCommand)
+		t.Fatalf("expected workspace copy-in not to use stale local policy checkout root, got %q", applyCommand)
 	}
 	if got, want := len(patches), 1; got != want {
 		t.Fatalf("expected one attached changeset patch, got %d", got)
@@ -132,7 +132,7 @@ func TestWorkspaceCopyAppliesGitChangeset(t *testing.T) {
 	}
 }
 
-func TestWorkspaceCopyUsesGitChangesetForGitWorktreeWithoutRepositoryPolicy(t *testing.T) {
+func TestWorkspaceCopyInUsesGitChangesetForGitWorktreeWithoutRepositoryPolicy(t *testing.T) {
 	repoDir := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
 	if err := os.WriteFile(filepath.Join(repoDir, ".gitignore"), []byte("node_modules/\n"), 0o644); err != nil {
 		t.Fatalf("write gitignore: %v", err)
@@ -209,7 +209,7 @@ func TestWorkspaceCopyUsesGitChangesetForGitWorktreeWithoutRepositoryPolicy(t *t
 
 	stdout, _ := makeStdoutCapture(t)
 	stderr, _ := makeStdoutCapture(t)
-	cmd := WorkspaceCopyCommand{
+	cmd := WorkspaceCopyInCommand{
 		clientFlags: clientFlags{Host: host},
 		Chdir:       repoDir,
 		SandboxID:   sandboxID,
@@ -222,20 +222,20 @@ func TestWorkspaceCopyUsesGitChangesetForGitWorktreeWithoutRepositoryPolicy(t *t
 		Stdout:        stdout,
 		Stderr:        stderr,
 	}); err != nil {
-		t.Fatalf("WorkspaceCopyCommand.Run returned error: %v", err)
+		t.Fatalf("WorkspaceCopyInCommand.Run returned error: %v", err)
 	}
 
 	mu.Lock()
 	defer mu.Unlock()
 	if rawArchiveCalled {
-		t.Fatal("expected Git worktree workspace copy to avoid raw archive transport")
+		t.Fatal("expected Git worktree workspace copy-in to avoid raw archive transport")
 	}
 	if len(commands) < 1 {
 		t.Fatalf("expected changeset apply command, got %d", len(commands))
 	}
 	applyCommand := strings.Join(commands[len(commands)-1], " ")
 	if !strings.Contains(applyCommand, `git -C "$dest" apply --binary --whitespace=nowarn "$patch_file"`) {
-		t.Fatalf("expected workspace copy to use Git changeset apply, got %q", applyCommand)
+		t.Fatalf("expected workspace copy-in to use Git changeset apply, got %q", applyCommand)
 	}
 	if got, want := len(patches), 1; got != want {
 		t.Fatalf("expected one attached changeset patch, got %d", got)
@@ -248,7 +248,7 @@ func TestWorkspaceCopyUsesGitChangesetForGitWorktreeWithoutRepositoryPolicy(t *t
 	}
 }
 
-func TestWorkspaceCopyResetsGitCheckoutWhenLocalRepoClean(t *testing.T) {
+func TestWorkspaceCopyInResetsGitCheckoutWhenLocalRepoClean(t *testing.T) {
 	repoDir := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
 
 	adapter := &integrationAdapter{}
@@ -294,7 +294,7 @@ func TestWorkspaceCopyResetsGitCheckoutWhenLocalRepoClean(t *testing.T) {
 
 	stdout, _ := makeStdoutCapture(t)
 	stderr, _ := makeStdoutCapture(t)
-	cmd := WorkspaceCopyCommand{
+	cmd := WorkspaceCopyInCommand{
 		clientFlags: clientFlags{Host: host},
 		Chdir:       repoDir,
 		SandboxID:   sandboxID,
@@ -307,7 +307,7 @@ func TestWorkspaceCopyResetsGitCheckoutWhenLocalRepoClean(t *testing.T) {
 		Stdout:        stdout,
 		Stderr:        stderr,
 	}); err != nil {
-		t.Fatalf("WorkspaceCopyCommand.Run returned error: %v", err)
+		t.Fatalf("WorkspaceCopyInCommand.Run returned error: %v", err)
 	}
 
 	mu.Lock()
@@ -317,16 +317,16 @@ func TestWorkspaceCopyResetsGitCheckoutWhenLocalRepoClean(t *testing.T) {
 	}
 	resetCommand := strings.Join(commands[len(commands)-1], " ")
 	if !strings.Contains(resetCommand, `git -C "$dest" reset --hard "$base_commit"`) {
-		t.Fatalf("expected clean workspace copy to reset the checkout, got %q", resetCommand)
+		t.Fatalf("expected clean workspace copy-in to reset the checkout, got %q", resetCommand)
 	}
 	if !strings.Contains(resetCommand, "dest='/sandbox-workspace'") {
-		t.Fatalf("expected clean workspace copy to target sandbox-recorded checkout root, got %q", resetCommand)
+		t.Fatalf("expected clean workspace copy-in to target sandbox-recorded checkout root, got %q", resetCommand)
 	}
 	if strings.Contains(resetCommand, "dest='/workspace'") {
-		t.Fatalf("expected clean workspace copy not to use stale local policy checkout root, got %q", resetCommand)
+		t.Fatalf("expected clean workspace copy-in not to use stale local policy checkout root, got %q", resetCommand)
 	}
 	if strings.Contains(resetCommand, `git -C "$dest" apply --binary`) {
-		t.Fatalf("expected clean workspace copy to avoid applying an empty patch, got %q", resetCommand)
+		t.Fatalf("expected clean workspace copy-in to avoid applying an empty patch, got %q", resetCommand)
 	}
 	if stdinWrites != 0 || stdinCloses != 0 {
 		t.Fatalf("expected reset-only copy to avoid stdin attachment, got writes=%d closes=%d", stdinWrites, stdinCloses)
@@ -377,7 +377,7 @@ func TestResolveExecutionSandboxClearsRepositoryAfterGitCopyInExistingSandbox(t 
 		37,
 		false,
 		repositoryOverrideFlags{},
-		workspaceCopyFlags{Copy: true},
+		workspaceCopyFlags{CopyIn: true},
 	)
 	if err != nil {
 		t.Fatalf("resolveExecutionSandbox returned error: %v", err)
@@ -391,14 +391,14 @@ func TestResolveExecutionSandboxClearsRepositoryAfterGitCopyInExistingSandbox(t 
 	mu.Lock()
 	defer mu.Unlock()
 	if len(launchSeconds) == 0 {
-		t.Fatal("expected workspace copy execution to run")
+		t.Fatal("expected workspace copy-in execution to run")
 	}
 	if got, want := launchSeconds[0], int64(37); got != want {
-		t.Fatalf("unexpected workspace copy launch seconds: got %d want %d", got, want)
+		t.Fatalf("unexpected workspace copy-in launch seconds: got %d want %d", got, want)
 	}
 }
 
-func TestResolveExecutionSandboxCopyUsesGitWorktreeWithoutRepositoryPolicy(t *testing.T) {
+func TestResolveExecutionSandboxCopyInUsesGitWorktreeWithoutRepositoryPolicy(t *testing.T) {
 	repoDir := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
 	if err := os.WriteFile(filepath.Join(repoDir, ".gitignore"), []byte("node_modules/\n"), 0o644); err != nil {
 		t.Fatalf("write gitignore: %v", err)
@@ -492,7 +492,7 @@ func TestResolveExecutionSandboxCopyUsesGitWorktreeWithoutRepositoryPolicy(t *te
 		0,
 		false,
 		repositoryOverrideFlags{},
-		workspaceCopyFlags{Copy: true},
+		workspaceCopyFlags{CopyIn: true},
 	)
 	if err != nil {
 		t.Fatalf("resolveExecutionSandbox returned error: %v", err)
@@ -507,14 +507,14 @@ func TestResolveExecutionSandboxCopyUsesGitWorktreeWithoutRepositoryPolicy(t *te
 	mu.Lock()
 	defer mu.Unlock()
 	if rawArchiveCalled {
-		t.Fatal("expected Git worktree --copy to avoid raw archive transport")
+		t.Fatal("expected Git worktree --copy-in to avoid raw archive transport")
 	}
 	if len(commands) < 1 {
 		t.Fatalf("expected changeset apply command, got %d", len(commands))
 	}
 	applyCommand := strings.Join(commands[len(commands)-1], " ")
 	if !strings.Contains(applyCommand, `git -C "$dest" apply --binary --whitespace=nowarn "$patch_file"`) {
-		t.Fatalf("expected --copy to use Git changeset apply, got %q", applyCommand)
+		t.Fatalf("expected --copy-in to use Git changeset apply, got %q", applyCommand)
 	}
 	if got, want := len(patches), 1; got != want {
 		t.Fatalf("expected one attached changeset patch, got %d", got)
@@ -524,7 +524,7 @@ func TestResolveExecutionSandboxCopyUsesGitWorktreeWithoutRepositoryPolicy(t *te
 	}
 }
 
-func TestWorkspaceCopyDryRunReportsCleanGitResetWithoutExecuting(t *testing.T) {
+func TestWorkspaceCopyInDryRunReportsCleanGitResetWithoutExecuting(t *testing.T) {
 	repoDir := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
 
 	adapter := &integrationAdapter{}
@@ -551,7 +551,7 @@ func TestWorkspaceCopyDryRunReportsCleanGitResetWithoutExecuting(t *testing.T) {
 
 	stdout, stdoutText := makeStdoutCapture(t)
 	stderr, _ := makeStdoutCapture(t)
-	cmd := WorkspaceCopyCommand{
+	cmd := WorkspaceCopyInCommand{
 		clientFlags: clientFlags{Host: host},
 		Chdir:       repoDir,
 		DryRun:      true,
@@ -565,7 +565,7 @@ func TestWorkspaceCopyDryRunReportsCleanGitResetWithoutExecuting(t *testing.T) {
 		Stdout:        stdout,
 		Stderr:        stderr,
 	}); err != nil {
-		t.Fatalf("WorkspaceCopyCommand.Run returned error: %v", err)
+		t.Fatalf("WorkspaceCopyInCommand.Run returned error: %v", err)
 	}
 	if got, want := stdoutText(), "reset\t/sandbox-workspace\n"; got != want {
 		t.Fatalf("unexpected clean dry-run plan: got %q want %q", got, want)
@@ -573,11 +573,11 @@ func TestWorkspaceCopyDryRunReportsCleanGitResetWithoutExecuting(t *testing.T) {
 	mu.Lock()
 	defer mu.Unlock()
 	if len(commands) != 0 {
-		t.Fatalf("dry-run should not run workspace copy execution, got %q", strings.Join(commands[0], " "))
+		t.Fatalf("dry-run should not run workspace copy-in execution, got %q", strings.Join(commands[0], " "))
 	}
 }
 
-func TestWorkspaceCopyUsesRawArchiveForNonGitWorkspace(t *testing.T) {
+func TestWorkspaceCopyInUsesRawArchiveForNonGitWorkspace(t *testing.T) {
 	sourceRoot := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(sourceRoot, "app"), 0o755); err != nil {
 		t.Fatalf("create app dir: %v", err)
@@ -645,7 +645,7 @@ func TestWorkspaceCopyUsesRawArchiveForNonGitWorkspace(t *testing.T) {
 	stdout, _ := makeStdoutCapture(t)
 	stderr, _ := makeStdoutCapture(t)
 
-	cmd := WorkspaceCopyCommand{
+	cmd := WorkspaceCopyInCommand{
 		clientFlags: clientFlags{Host: host},
 		Chdir:       sourceRoot,
 		SandboxID:   sandboxID,
@@ -658,7 +658,7 @@ func TestWorkspaceCopyUsesRawArchiveForNonGitWorkspace(t *testing.T) {
 		Stdout:        stdout,
 		Stderr:        stderr,
 	}); err != nil {
-		t.Fatalf("WorkspaceCopyCommand.Run returned error: %v", err)
+		t.Fatalf("WorkspaceCopyInCommand.Run returned error: %v", err)
 	}
 
 	mu.Lock()
@@ -684,7 +684,7 @@ func TestWorkspaceCopyUsesRawArchiveForNonGitWorkspace(t *testing.T) {
 	}
 }
 
-func TestWorkspaceCopySkipsRawCleanWhenDestinationMissing(t *testing.T) {
+func TestWorkspaceCopyInSkipsRawCleanWhenDestinationMissing(t *testing.T) {
 	sourceRoot := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(sourceRoot, "app"), 0o755); err != nil {
 		t.Fatalf("create app dir: %v", err)
@@ -737,7 +737,7 @@ func TestWorkspaceCopySkipsRawCleanWhenDestinationMissing(t *testing.T) {
 	stdout, _ := makeStdoutCapture(t)
 	stderr, _ := makeStdoutCapture(t)
 
-	cmd := WorkspaceCopyCommand{
+	cmd := WorkspaceCopyInCommand{
 		clientFlags: clientFlags{Host: host},
 		Chdir:       sourceRoot,
 		SandboxID:   sandboxID,
@@ -750,7 +750,7 @@ func TestWorkspaceCopySkipsRawCleanWhenDestinationMissing(t *testing.T) {
 		Stdout:        stdout,
 		Stderr:        stderr,
 	}); err != nil {
-		t.Fatalf("WorkspaceCopyCommand.Run returned error: %v", err)
+		t.Fatalf("WorkspaceCopyInCommand.Run returned error: %v", err)
 	}
 
 	mu.Lock()
@@ -766,7 +766,7 @@ func TestWorkspaceCopySkipsRawCleanWhenDestinationMissing(t *testing.T) {
 	}
 }
 
-func TestWorkspaceCopyRemovesSymlinkedRawDestinationRoot(t *testing.T) {
+func TestWorkspaceCopyInRemovesSymlinkedRawDestinationRoot(t *testing.T) {
 	sourceRoot := t.TempDir()
 	if err := os.WriteFile(filepath.Join(sourceRoot, "main.txt"), []byte("payload\n"), 0o644); err != nil {
 		t.Fatalf("write workspace file: %v", err)
@@ -808,7 +808,7 @@ func TestWorkspaceCopyRemovesSymlinkedRawDestinationRoot(t *testing.T) {
 	stdout, _ := makeStdoutCapture(t)
 	stderr, _ := makeStdoutCapture(t)
 
-	cmd := WorkspaceCopyCommand{
+	cmd := WorkspaceCopyInCommand{
 		clientFlags: clientFlags{Host: host},
 		Chdir:       sourceRoot,
 		SandboxID:   sandboxID,
@@ -821,7 +821,7 @@ func TestWorkspaceCopyRemovesSymlinkedRawDestinationRoot(t *testing.T) {
 		Stdout:        stdout,
 		Stderr:        stderr,
 	}); err != nil {
-		t.Fatalf("WorkspaceCopyCommand.Run returned error: %v", err)
+		t.Fatalf("WorkspaceCopyInCommand.Run returned error: %v", err)
 	}
 
 	mu.Lock()
@@ -897,7 +897,7 @@ func TestRawWorkspaceCopyFollowsSymlinkedSourceRoot(t *testing.T) {
 	}
 }
 
-func TestWorkspaceCopyRejectsUnsafeRawDestinationRoot(t *testing.T) {
+func TestWorkspaceCopyInRejectsUnsafeRawDestinationRoot(t *testing.T) {
 	sourceRoot := t.TempDir()
 	err := copyRawWorkspaceToSandbox(context.Background(), &runtimeContext{}, nil, workspaceCopyOptions{
 		CWD:         sourceRoot,
@@ -907,12 +907,12 @@ func TestWorkspaceCopyRejectsUnsafeRawDestinationRoot(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected unsafe raw workspace destination to be rejected")
 	}
-	if !strings.Contains(err.Error(), "unsafe for raw workspace copy") {
+	if !strings.Contains(err.Error(), "unsafe for raw workspace copy-in") {
 		t.Fatalf("expected unsafe destination error, got %v", err)
 	}
 }
 
-func TestWorkspaceCopyRejectsRawCopyWhenSandboxWorkspaceRootUnknown(t *testing.T) {
+func TestWorkspaceCopyInRejectsRawCopyWhenSandboxWorkspaceRootUnknown(t *testing.T) {
 	sourceRoot := t.TempDir()
 	adapter := &copyIntegrationAdapter{}
 	host, _ := startIntegrationServer(t, adapter)
@@ -920,7 +920,7 @@ func TestWorkspaceCopyRejectsRawCopyWhenSandboxWorkspaceRootUnknown(t *testing.T
 
 	stdout, _ := makeStdoutCapture(t)
 	stderr, _ := makeStdoutCapture(t)
-	cmd := WorkspaceCopyCommand{
+	cmd := WorkspaceCopyInCommand{
 		clientFlags: clientFlags{Host: host},
 		Chdir:       sourceRoot,
 		SandboxID:   sandboxID,
@@ -934,14 +934,14 @@ func TestWorkspaceCopyRejectsRawCopyWhenSandboxWorkspaceRootUnknown(t *testing.T
 		Stderr:        stderr,
 	})
 	if err == nil {
-		t.Fatal("expected raw workspace copy to reject sandbox without recorded workspace root")
+		t.Fatal("expected raw workspace copy-in to reject sandbox without recorded workspace root")
 	}
 	if !strings.Contains(err.Error(), "does not have a recorded workspace root") {
 		t.Fatalf("expected recorded workspace root error, got %v", err)
 	}
 }
 
-func TestWorkspaceCopyRejectsGitCopyWhenSandboxWorkspaceRootUnknown(t *testing.T) {
+func TestWorkspaceCopyInRejectsGitCopyWhenSandboxWorkspaceRootUnknown(t *testing.T) {
 	repoDir := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
 	if err := os.WriteFile(filepath.Join(repoDir, "dirty.txt"), []byte("dirty\n"), 0o644); err != nil {
 		t.Fatalf("write dirty file: %v", err)
@@ -952,7 +952,7 @@ func TestWorkspaceCopyRejectsGitCopyWhenSandboxWorkspaceRootUnknown(t *testing.T
 
 	stdout, _ := makeStdoutCapture(t)
 	stderr, _ := makeStdoutCapture(t)
-	cmd := WorkspaceCopyCommand{
+	cmd := WorkspaceCopyInCommand{
 		clientFlags: clientFlags{Host: host},
 		Chdir:       repoDir,
 		SandboxID:   sandboxID,
@@ -966,14 +966,14 @@ func TestWorkspaceCopyRejectsGitCopyWhenSandboxWorkspaceRootUnknown(t *testing.T
 		Stderr:        stderr,
 	})
 	if err == nil {
-		t.Fatal("expected git workspace copy to reject sandbox without recorded workspace root")
+		t.Fatal("expected git workspace copy-in to reject sandbox without recorded workspace root")
 	}
 	if !strings.Contains(err.Error(), "does not have a recorded workspace root") {
 		t.Fatalf("expected recorded workspace root error, got %v", err)
 	}
 }
 
-func TestTopLevelCopyRejectsNonGitWorkspaceWhenCreatingSandbox(t *testing.T) {
+func TestTopLevelCopyInRejectsNonGitWorkspaceWhenCreatingSandbox(t *testing.T) {
 	cwd := t.TempDir()
 	_, err := resolveExecutionSandbox(
 		context.Background(),
@@ -991,10 +991,10 @@ func TestTopLevelCopyRejectsNonGitWorkspaceWhenCreatingSandbox(t *testing.T) {
 		0,
 		false,
 		repositoryOverrideFlags{},
-		workspaceCopyFlags{Copy: true},
+		workspaceCopyFlags{CopyIn: true},
 	)
 	if err == nil {
-		t.Fatal("expected non-Git top-level --copy to be rejected before sandbox creation")
+		t.Fatal("expected non-Git top-level --copy-in to be rejected before sandbox creation")
 	}
 	if !strings.Contains(err.Error(), "non-Git workspaces") {
 		t.Fatalf("expected non-Git copy error, got %v", err)

--- a/internal/cli/workspace_test.go
+++ b/internal/cli/workspace_test.go
@@ -38,7 +38,15 @@ func TestWorkspaceCopyAppliesGitChangeset(t *testing.T) {
 
 	adapter := &integrationAdapter{}
 	host, _ := startIntegrationServer(t, adapter)
-	sandboxID := createWorkspaceCopyTestSandbox(t, host, workspaceCopyTestPolicy())
+	head, err := gitOutput(repoDir, "rev-parse", "HEAD")
+	if err != nil {
+		t.Fatalf("resolve repository HEAD: %v", err)
+	}
+	branch, err := gitOutput(repoDir, "branch", "--show-current")
+	if err != nil {
+		t.Fatalf("resolve repository branch: %v", err)
+	}
+	sandboxID := createWorkspaceCopyTestSandboxWithRepositoryCommitBranch(t, host, "/sandbox-workspace", head, branch)
 
 	var (
 		mu       sync.Mutex
@@ -100,12 +108,18 @@ func TestWorkspaceCopyAppliesGitChangeset(t *testing.T) {
 
 	mu.Lock()
 	defer mu.Unlock()
-	if len(commands) < 2 {
-		t.Fatalf("expected repository bootstrap and changeset apply commands, got %d", len(commands))
+	if len(commands) < 1 {
+		t.Fatalf("expected changeset apply command, got %d", len(commands))
 	}
 	applyCommand := strings.Join(commands[len(commands)-1], " ")
 	if !strings.Contains(applyCommand, `git -C "$dest" reset --hard "$base_commit"`) {
 		t.Fatalf("expected workspace copy to reset the checkout before applying, got %q", applyCommand)
+	}
+	if !strings.Contains(applyCommand, "dest='/sandbox-workspace'") {
+		t.Fatalf("expected workspace copy to target sandbox-recorded checkout root, got %q", applyCommand)
+	}
+	if strings.Contains(applyCommand, "dest='/workspace'") {
+		t.Fatalf("expected workspace copy not to use stale local policy checkout root, got %q", applyCommand)
 	}
 	if got, want := len(patches), 1; got != want {
 		t.Fatalf("expected one attached changeset patch, got %d", got)
@@ -123,7 +137,15 @@ func TestWorkspaceCopyResetsGitCheckoutWhenLocalRepoClean(t *testing.T) {
 
 	adapter := &integrationAdapter{}
 	host, _ := startIntegrationServer(t, adapter)
-	sandboxID := createWorkspaceCopyTestSandbox(t, host, workspaceCopyTestPolicy())
+	head, err := gitOutput(repoDir, "rev-parse", "HEAD")
+	if err != nil {
+		t.Fatalf("resolve repository HEAD: %v", err)
+	}
+	branch, err := gitOutput(repoDir, "branch", "--show-current")
+	if err != nil {
+		t.Fatalf("resolve repository branch: %v", err)
+	}
+	sandboxID := createWorkspaceCopyTestSandboxWithRepositoryCommitBranch(t, host, "/sandbox-workspace", head, branch)
 
 	var (
 		mu          sync.Mutex
@@ -174,12 +196,18 @@ func TestWorkspaceCopyResetsGitCheckoutWhenLocalRepoClean(t *testing.T) {
 
 	mu.Lock()
 	defer mu.Unlock()
-	if len(commands) < 2 {
-		t.Fatalf("expected repository bootstrap and checkout reset commands, got %d", len(commands))
+	if len(commands) < 1 {
+		t.Fatalf("expected checkout reset command, got %d", len(commands))
 	}
 	resetCommand := strings.Join(commands[len(commands)-1], " ")
 	if !strings.Contains(resetCommand, `git -C "$dest" reset --hard "$base_commit"`) {
 		t.Fatalf("expected clean workspace copy to reset the checkout, got %q", resetCommand)
+	}
+	if !strings.Contains(resetCommand, "dest='/sandbox-workspace'") {
+		t.Fatalf("expected clean workspace copy to target sandbox-recorded checkout root, got %q", resetCommand)
+	}
+	if strings.Contains(resetCommand, "dest='/workspace'") {
+		t.Fatalf("expected clean workspace copy not to use stale local policy checkout root, got %q", resetCommand)
 	}
 	if strings.Contains(resetCommand, `git -C "$dest" apply --binary`) {
 		t.Fatalf("expected clean workspace copy to avoid applying an empty patch, got %q", resetCommand)
@@ -334,6 +362,63 @@ func TestWorkspaceCopyUsesRawArchiveForNonGitWorkspace(t *testing.T) {
 	}
 }
 
+func TestRawWorkspaceCopyFollowsSymlinkedSourceRoot(t *testing.T) {
+	realRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(realRoot, "app"), 0o755); err != nil {
+		t.Fatalf("create app dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(realRoot, "app/main.txt"), []byte("payload\n"), 0o644); err != nil {
+		t.Fatalf("write workspace file: %v", err)
+	}
+
+	linkRoot := filepath.Join(t.TempDir(), "workspace-link")
+	if err := os.Symlink(realRoot, linkRoot); err != nil {
+		t.Fatalf("create workspace symlink: %v", err)
+	}
+
+	entries, err := rawWorkspacePlan(linkRoot, "/workspace")
+	if err != nil {
+		t.Fatalf("rawWorkspacePlan returned error: %v", err)
+	}
+	foundPlanEntry := false
+	for _, entry := range entries {
+		if entry.Action == "write" && entry.Path == "/workspace/app/main.txt" {
+			foundPlanEntry = true
+			break
+		}
+	}
+	if !foundPlanEntry {
+		t.Fatalf("expected symlinked workspace root plan to include app/main.txt, got %#v", entries)
+	}
+
+	var archive bytes.Buffer
+	if err := writeRawWorkspaceTar(&archive, linkRoot); err != nil {
+		t.Fatalf("writeRawWorkspaceTar returned error: %v", err)
+	}
+	tr := tar.NewReader(&archive)
+	files := map[string]string{}
+	for {
+		header, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("read archive: %v", err)
+		}
+		if header.Typeflag != tar.TypeReg {
+			continue
+		}
+		data, err := io.ReadAll(tr)
+		if err != nil {
+			t.Fatalf("read archived file: %v", err)
+		}
+		files[header.Name] = string(data)
+	}
+	if got, want := files["app/main.txt"], "payload\n"; got != want {
+		t.Fatalf("unexpected archived file content: got %q want %q; files=%#v", got, want, files)
+	}
+}
+
 func TestWorkspaceCopyRejectsUnsafeRawDestinationRoot(t *testing.T) {
 	sourceRoot := t.TempDir()
 	err := copyRawWorkspaceToSandbox(context.Background(), &runtimeContext{}, nil, workspaceCopyOptions{
@@ -425,6 +510,10 @@ func createWorkspaceCopyTestSandbox(t *testing.T, host string, compiled *cleanro
 }
 
 func createWorkspaceCopyTestSandboxWithRepository(t *testing.T, host, destination string) string {
+	return createWorkspaceCopyTestSandboxWithRepositoryCommitBranch(t, host, destination, "0123456789abcdef0123456789abcdef01234567", "")
+}
+
+func createWorkspaceCopyTestSandboxWithRepositoryCommitBranch(t *testing.T, host, destination, commit, branch string) string {
 	t.Helper()
 
 	client := mustNewControlClient(t, host)
@@ -433,8 +522,9 @@ func createWorkspaceCopyTestSandboxWithRepository(t *testing.T, host, destinatio
 		Policy:  workspaceCopyTestPolicy(),
 		RepositoryCheckout: &cleanroomv1.RepositoryCheckout{
 			RemoteUrl:      "https://github.com/buildkite/cleanroom.git",
-			CommitSha:      "0123456789abcdef0123456789abcdef01234567",
+			CommitSha:      strings.TrimSpace(commit),
 			DestinationDir: destination,
+			Branch:         strings.TrimSpace(branch),
 		},
 	})
 	if err != nil {

--- a/internal/cli/workspace_test.go
+++ b/internal/cli/workspace_test.go
@@ -1,0 +1,262 @@
+package cli
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/buildkite/cleanroom/internal/runtimeconfig"
+)
+
+func TestWorkspaceCopyAppliesGitChangeset(t *testing.T) {
+	repoDir := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
+	if err := os.WriteFile(filepath.Join(repoDir, ".gitignore"), []byte("node_modules/\n"), 0o644); err != nil {
+		t.Fatalf("write gitignore: %v", err)
+	}
+	runGitInDir(t, repoDir, "add", ".gitignore")
+	runGitInDir(t, repoDir, "commit", "-m", "ignore dependencies")
+	if err := os.WriteFile(filepath.Join(repoDir, "dirty.txt"), []byte("dirty\n"), 0o644); err != nil {
+		t.Fatalf("write dirty file: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(repoDir, "node_modules/pkg"), 0o755); err != nil {
+		t.Fatalf("create ignored dependency dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, "node_modules/pkg/index.js"), []byte("ignored\n"), 0o644); err != nil {
+		t.Fatalf("write ignored dependency file: %v", err)
+	}
+
+	adapter := &integrationAdapter{}
+	host, _ := startIntegrationServer(t, adapter)
+	sandboxID := createWorkspaceCopyTestSandbox(t, host, workspaceCopyTestPolicy())
+
+	var (
+		mu       sync.Mutex
+		commands [][]string
+		patches  []string
+	)
+	adapter.runStreamFn = func(ctx context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+		mu.Lock()
+		commands = append(commands, append([]string(nil), req.Command...))
+		mu.Unlock()
+
+		if !strings.Contains(strings.Join(req.Command, " "), `git -C "$dest" apply --binary --whitespace=nowarn "$patch_file"`) {
+			return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+		}
+
+		closed := make(chan struct{})
+		var closeOnce sync.Once
+		var stdin bytes.Buffer
+		if stream.OnAttach != nil {
+			stream.OnAttach(backend.AttachIO{
+				WriteStdin: func(data []byte) error {
+					_, err := stdin.Write(data)
+					return err
+				},
+				CloseStdin: func() error {
+					mu.Lock()
+					patches = append(patches, stdin.String())
+					mu.Unlock()
+					closeOnce.Do(func() { close(closed) })
+					return nil
+				},
+			})
+		}
+		select {
+		case <-closed:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+	}
+
+	stdout, _ := makeStdoutCapture(t)
+	stderr, _ := makeStdoutCapture(t)
+	cmd := WorkspaceCopyCommand{
+		clientFlags: clientFlags{Host: host},
+		Chdir:       repoDir,
+		SandboxID:   sandboxID,
+	}
+	if err := cmd.Run(&runtimeContext{
+		CWD:           repoDir,
+		Loader:        workspaceCopyRepositoryLoader(),
+		Config:        runtimeconfig.Config{},
+		Observability: newTestObservability(t),
+		Stdout:        stdout,
+		Stderr:        stderr,
+	}); err != nil {
+		t.Fatalf("WorkspaceCopyCommand.Run returned error: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(commands) < 2 {
+		t.Fatalf("expected repository bootstrap and changeset apply commands, got %d", len(commands))
+	}
+	applyCommand := strings.Join(commands[len(commands)-1], " ")
+	if !strings.Contains(applyCommand, `git -C "$dest" reset --hard "$base_commit"`) {
+		t.Fatalf("expected workspace copy to reset the checkout before applying, got %q", applyCommand)
+	}
+	if got, want := len(patches), 1; got != want {
+		t.Fatalf("expected one attached changeset patch, got %d", got)
+	}
+	if !strings.Contains(patches[0], "dirty.txt") {
+		t.Fatalf("expected changeset patch to reference dirty.txt, got %q", patches[0])
+	}
+	if strings.Contains(patches[0], "node_modules") {
+		t.Fatalf("expected ignored dependency tree to be excluded, got %q", patches[0])
+	}
+}
+
+func TestWorkspaceCopyUsesRawArchiveForNonGitWorkspace(t *testing.T) {
+	sourceRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(sourceRoot, "app"), 0o755); err != nil {
+		t.Fatalf("create app dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceRoot, "app/main.txt"), []byte("payload\n"), 0o644); err != nil {
+		t.Fatalf("write workspace file: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(sourceRoot, ".git"), 0o755); err != nil {
+		t.Fatalf("create skipped git dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceRoot, ".git/config"), []byte("skip\n"), 0o644); err != nil {
+		t.Fatalf("write skipped git config: %v", err)
+	}
+
+	var (
+		removedPath string
+		recursive   bool
+		destination string
+		files       = map[string]string{}
+	)
+	adapter := &copyIntegrationAdapter{
+		removeFn: func(_ context.Context, _ string, path string, rec bool) error {
+			removedPath = path
+			recursive = rec
+			return nil
+		},
+		extractFn: func(_ context.Context, _ string, dest string, r io.Reader) (int64, error) {
+			destination = dest
+			tr := tar.NewReader(r)
+			for {
+				header, err := tr.Next()
+				if errors.Is(err, io.EOF) {
+					break
+				}
+				if err != nil {
+					return 0, err
+				}
+				if header.Typeflag != tar.TypeReg {
+					continue
+				}
+				data, err := io.ReadAll(tr)
+				if err != nil {
+					return 0, err
+				}
+				files[header.Name] = string(data)
+			}
+			return 0, nil
+		},
+	}
+	host, _ := startIntegrationServer(t, adapter)
+	sandboxID := createWorkspaceCopyTestSandbox(t, host, copyTestPolicy())
+	stdout, _ := makeStdoutCapture(t)
+	stderr, _ := makeStdoutCapture(t)
+
+	cmd := WorkspaceCopyCommand{
+		clientFlags: clientFlags{Host: host},
+		Chdir:       sourceRoot,
+		SandboxID:   sandboxID,
+	}
+	if err := cmd.Run(&runtimeContext{
+		CWD:           sourceRoot,
+		Loader:        repositoryNotFoundLoader{},
+		Config:        runtimeconfig.Config{},
+		Observability: newTestObservability(t),
+		Stdout:        stdout,
+		Stderr:        stderr,
+	}); err != nil {
+		t.Fatalf("WorkspaceCopyCommand.Run returned error: %v", err)
+	}
+
+	if got, want := removedPath, "/workspace"; got != want {
+		t.Fatalf("unexpected removed workspace root: got %q want %q", got, want)
+	}
+	if !recursive {
+		t.Fatal("expected workspace root removal to be recursive")
+	}
+	if got, want := destination, "/workspace"; got != want {
+		t.Fatalf("unexpected extract destination: got %q want %q", got, want)
+	}
+	if got, want := files["app/main.txt"], "payload\n"; got != want {
+		t.Fatalf("unexpected archived file content: got %q want %q", got, want)
+	}
+	if _, ok := files[".git/config"]; ok {
+		t.Fatalf("expected .git directory to be skipped, got files %#v", files)
+	}
+}
+
+func createWorkspaceCopyTestSandbox(t *testing.T, host string, compiled *cleanroomv1.Policy) string {
+	t.Helper()
+
+	client := mustNewControlClient(t, host)
+	resp, err := client.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Backend: "firecracker",
+		Policy:  compiled,
+	})
+	if err != nil {
+		t.Fatalf("create sandbox: %v", err)
+	}
+	sandboxID := strings.TrimSpace(resp.GetSandbox().GetSandboxId())
+	if sandboxID == "" {
+		t.Fatal("create sandbox response missing sandbox id")
+	}
+	return sandboxID
+}
+
+func workspaceCopyTestPolicy() *cleanroomv1.Policy {
+	return (&policy.CompiledPolicy{
+		Version:        1,
+		ImageRef:       "ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		ImageDigest:    "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		NetworkDefault: "deny",
+		Allow:          []policy.AllowRule{{Host: "github.com", Ports: []int{443}}},
+	}).ToProto()
+}
+
+func workspaceCopyRepositoryLoader() repositoryIntegrationLoader {
+	return repositoryIntegrationLoader{
+		compiled: &policy.CompiledPolicy{
+			Version:        1,
+			ImageRef:       "ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			ImageDigest:    "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			NetworkDefault: "deny",
+			Allow:          []policy.AllowRule{{Host: "github.com", Ports: []int{443}}},
+		},
+		repository: policy.RepositoryConfig{
+			Mode:   "current-repo",
+			Remote: "origin",
+			Path:   "/workspace",
+		},
+	}
+}
+
+func runGitInDir(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, string(out))
+	}
+}

--- a/internal/cli/workspace_test.go
+++ b/internal/cli/workspace_test.go
@@ -289,6 +289,12 @@ func TestWorkspaceCopyUsesRawArchiveForNonGitWorkspace(t *testing.T) {
 		files       = map[string]string{}
 	)
 	adapter := &copyIntegrationAdapter{
+		statFn: func(_ context.Context, _ string, path string) (*backend.SandboxPathInfo, error) {
+			return &backend.SandboxPathInfo{
+				Path: path,
+				Type: backend.SandboxPathTypeDirectory,
+			}, nil
+		},
 		extractFn: func(_ context.Context, _ string, dest string, r io.Reader) (int64, error) {
 			destination = dest
 			tr := tar.NewReader(r)
@@ -359,6 +365,88 @@ func TestWorkspaceCopyUsesRawArchiveForNonGitWorkspace(t *testing.T) {
 	}
 	if _, ok := files["app/submodule/.git"]; ok {
 		t.Fatalf("expected .git file to be skipped, got files %#v", files)
+	}
+}
+
+func TestWorkspaceCopySkipsRawCleanWhenDestinationMissing(t *testing.T) {
+	sourceRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(sourceRoot, "app"), 0o755); err != nil {
+		t.Fatalf("create app dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceRoot, "app/main.txt"), []byte("payload\n"), 0o644); err != nil {
+		t.Fatalf("write workspace file: %v", err)
+	}
+
+	var (
+		mu          sync.Mutex
+		commands    [][]string
+		destination string
+		files       = map[string]string{}
+	)
+	adapter := &copyIntegrationAdapter{
+		statFn: func(_ context.Context, _ string, path string) (*backend.SandboxPathInfo, error) {
+			return nil, backend.NewSandboxPathNotFoundError(path)
+		},
+		extractFn: func(_ context.Context, _ string, dest string, r io.Reader) (int64, error) {
+			destination = dest
+			tr := tar.NewReader(r)
+			for {
+				header, err := tr.Next()
+				if errors.Is(err, io.EOF) {
+					break
+				}
+				if err != nil {
+					return 0, err
+				}
+				if header.Typeflag != tar.TypeReg {
+					continue
+				}
+				data, err := io.ReadAll(tr)
+				if err != nil {
+					return 0, err
+				}
+				files[header.Name] = string(data)
+			}
+			return 0, nil
+		},
+	}
+	host, _ := startIntegrationServer(t, adapter)
+	sandboxID := createWorkspaceCopyTestSandboxWithRepository(t, host, "/workspace-app")
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
+		mu.Lock()
+		commands = append(commands, append([]string(nil), req.Command...))
+		mu.Unlock()
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+	}
+	stdout, _ := makeStdoutCapture(t)
+	stderr, _ := makeStdoutCapture(t)
+
+	cmd := WorkspaceCopyCommand{
+		clientFlags: clientFlags{Host: host},
+		Chdir:       sourceRoot,
+		SandboxID:   sandboxID,
+	}
+	if err := cmd.Run(&runtimeContext{
+		CWD:           sourceRoot,
+		Loader:        repositoryNotFoundLoader{},
+		Config:        runtimeconfig.Config{},
+		Observability: newTestObservability(t),
+		Stdout:        stdout,
+		Stderr:        stderr,
+	}); err != nil {
+		t.Fatalf("WorkspaceCopyCommand.Run returned error: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(commands) != 0 {
+		t.Fatalf("expected missing raw workspace destination to skip clean execution, got %d command(s)", len(commands))
+	}
+	if got, want := destination, "/workspace-app"; got != want {
+		t.Fatalf("unexpected extract destination: got %q want %q", got, want)
+	}
+	if got, want := files["app/main.txt"], "payload\n"; got != want {
+		t.Fatalf("unexpected archived file content: got %q want %q", got, want)
 	}
 }
 

--- a/internal/cli/workspace_test.go
+++ b/internal/cli/workspace_test.go
@@ -217,11 +217,70 @@ func TestWorkspaceCopyResetsGitCheckoutWhenLocalRepoClean(t *testing.T) {
 	}
 }
 
-func TestWorkspaceCopyDryRunDoesNotResetCleanGitCheckout(t *testing.T) {
+func TestResolveExecutionSandboxReturnsSandboxWorkspaceRootAfterGitCopyInExistingSandbox(t *testing.T) {
 	repoDir := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
 
 	adapter := &integrationAdapter{}
 	host, _ := startIntegrationServer(t, adapter)
+	head, err := gitOutput(repoDir, "rev-parse", "HEAD")
+	if err != nil {
+		t.Fatalf("resolve repository HEAD: %v", err)
+	}
+	branch, err := gitOutput(repoDir, "branch", "--show-current")
+	if err != nil {
+		t.Fatalf("resolve repository branch: %v", err)
+	}
+	sandboxID := createWorkspaceCopyTestSandboxWithRepositoryCommitBranch(t, host, "/sandbox-workspace", head, branch)
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+	}
+
+	client := mustNewControlClient(t, host)
+	target, err := resolveExecutionSandbox(
+		context.Background(),
+		client,
+		&runtimeContext{
+			CWD:           repoDir,
+			Loader:        workspaceCopyRepositoryLoader(),
+			Config:        runtimeconfig.Config{},
+			Observability: newTestObservability(t),
+		},
+		repoDir,
+		host,
+		"",
+		sandboxID,
+		"",
+		"",
+		0,
+		false,
+		repositoryOverrideFlags{},
+		workspaceCopyFlags{Copy: true},
+	)
+	if err != nil {
+		t.Fatalf("resolveExecutionSandbox returned error: %v", err)
+	}
+	if target.Repository == nil {
+		t.Fatal("expected returned execution sandbox to include repository checkout")
+	}
+	if got, want := target.Repository.DestinationDir, "/sandbox-workspace"; got != want {
+		t.Fatalf("unexpected returned repository destination: got %q want %q", got, want)
+	}
+}
+
+func TestWorkspaceCopyDryRunReportsCleanGitResetWithoutExecuting(t *testing.T) {
+	repoDir := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
+
+	adapter := &integrationAdapter{}
+	host, _ := startIntegrationServer(t, adapter)
+	head, err := gitOutput(repoDir, "rev-parse", "HEAD")
+	if err != nil {
+		t.Fatalf("resolve repository HEAD: %v", err)
+	}
+	branch, err := gitOutput(repoDir, "branch", "--show-current")
+	if err != nil {
+		t.Fatalf("resolve repository branch: %v", err)
+	}
+	sandboxID := createWorkspaceCopyTestSandboxWithRepositoryCommitBranch(t, host, "/sandbox-workspace", head, branch)
 	var (
 		mu       sync.Mutex
 		commands [][]string
@@ -239,7 +298,7 @@ func TestWorkspaceCopyDryRunDoesNotResetCleanGitCheckout(t *testing.T) {
 		clientFlags: clientFlags{Host: host},
 		Chdir:       repoDir,
 		DryRun:      true,
-		SandboxID:   "cr_dryrun",
+		SandboxID:   sandboxID,
 	}
 	if err := cmd.Run(&runtimeContext{
 		CWD:           repoDir,
@@ -251,8 +310,8 @@ func TestWorkspaceCopyDryRunDoesNotResetCleanGitCheckout(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("WorkspaceCopyCommand.Run returned error: %v", err)
 	}
-	if got := stdoutText(); got != "" {
-		t.Fatalf("expected clean dry-run to print no planned changes, got %q", got)
+	if got, want := stdoutText(), "reset\t/sandbox-workspace\n"; got != want {
+		t.Fatalf("unexpected clean dry-run plan: got %q want %q", got, want)
 	}
 	mu.Lock()
 	defer mu.Unlock()

--- a/internal/cli/workspace_test.go
+++ b/internal/cli/workspace_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/buildkite/cleanroom/internal/backend"
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
@@ -129,6 +130,90 @@ func TestWorkspaceCopyInAppliesGitChangeset(t *testing.T) {
 	}
 	if strings.Contains(patches[0], "node_modules") {
 		t.Fatalf("expected ignored dependency tree to be excluded, got %q", patches[0])
+	}
+}
+
+func TestWorkspaceCopyInReturnsWhenPatchStdinWriteFails(t *testing.T) {
+	repoDir := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
+	if err := os.WriteFile(filepath.Join(repoDir, "dirty.txt"), []byte("dirty\n"), 0o644); err != nil {
+		t.Fatalf("write dirty file: %v", err)
+	}
+
+	adapter := &integrationAdapter{}
+	host, _ := startIntegrationServer(t, adapter)
+	head, err := gitOutput(repoDir, "rev-parse", "HEAD")
+	if err != nil {
+		t.Fatalf("resolve repository HEAD: %v", err)
+	}
+	branch, err := gitOutput(repoDir, "branch", "--show-current")
+	if err != nil {
+		t.Fatalf("resolve repository branch: %v", err)
+	}
+	sandboxID := createWorkspaceCopyTestSandboxWithRepositoryCommitBranch(t, host, "/sandbox-workspace", head, branch)
+
+	applyExecutionIDCh := make(chan string, 1)
+	adapter.runStreamFn = func(ctx context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+		if !strings.Contains(strings.Join(req.Command, " "), `git -C "$dest" apply --binary --whitespace=nowarn "$patch_file"`) {
+			return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+		}
+		select {
+		case applyExecutionIDCh <- req.ExecutionID:
+		default:
+		}
+		if stream.OnAttach != nil {
+			stream.OnAttach(backend.AttachIO{
+				WriteStdin: func([]byte) error {
+					return errors.New("broken stdin")
+				},
+				CloseStdin: func() error {
+					return nil
+				},
+			})
+		}
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+
+	stdout, _ := makeStdoutCapture(t)
+	stderr, _ := makeStdoutCapture(t)
+	cmd := WorkspaceCopyInCommand{
+		clientFlags: clientFlags{Host: host},
+		Chdir:       repoDir,
+		SandboxID:   sandboxID,
+	}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- cmd.Run(&runtimeContext{
+			CWD:           repoDir,
+			Loader:        workspaceCopyRepositoryLoader(),
+			Config:        runtimeconfig.Config{},
+			Observability: newTestObservability(t),
+			Stdout:        stdout,
+			Stderr:        stderr,
+		})
+	}()
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("expected WorkspaceCopyInCommand.Run to return stdin write error")
+		}
+		if !strings.Contains(err.Error(), "write workspace copy-in payload") || !strings.Contains(err.Error(), "broken stdin") {
+			t.Fatalf("expected stdin write error, got %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for workspace copy-in to return stdin write error")
+	}
+
+	client := mustNewControlClient(t, host)
+	select {
+	case executionID := <-applyExecutionIDCh:
+		_, _ = client.CancelExecution(context.Background(), &cleanroomv1.CancelExecutionRequest{
+			SandboxId:   sandboxID,
+			ExecutionId: executionID,
+			Signal:      2,
+		})
+	default:
 	}
 }
 

--- a/internal/cli/workspace_test.go
+++ b/internal/cli/workspace_test.go
@@ -509,6 +509,80 @@ func TestWorkspaceCopySkipsRawCleanWhenDestinationMissing(t *testing.T) {
 	}
 }
 
+func TestWorkspaceCopyRemovesSymlinkedRawDestinationRoot(t *testing.T) {
+	sourceRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(sourceRoot, "main.txt"), []byte("payload\n"), 0o644); err != nil {
+		t.Fatalf("write workspace file: %v", err)
+	}
+
+	var (
+		mu               sync.Mutex
+		commands         [][]string
+		removedPath      string
+		removedRecursive bool
+		destination      string
+	)
+	adapter := &copyIntegrationAdapter{
+		statFn: func(_ context.Context, _ string, path string) (*backend.SandboxPathInfo, error) {
+			return &backend.SandboxPathInfo{
+				Path:          path,
+				Type:          backend.SandboxPathTypeSymlink,
+				SymlinkTarget: "/",
+			}, nil
+		},
+		removeFn: func(_ context.Context, _ string, path string, recursive bool) error {
+			removedPath = path
+			removedRecursive = recursive
+			return nil
+		},
+		extractFn: func(_ context.Context, _ string, dest string, r io.Reader) (int64, error) {
+			destination = dest
+			return io.Copy(io.Discard, r)
+		},
+	}
+	host, _ := startIntegrationServer(t, adapter)
+	sandboxID := createWorkspaceCopyTestSandboxWithRepository(t, host, "/workspace-app")
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
+		mu.Lock()
+		commands = append(commands, append([]string(nil), req.Command...))
+		mu.Unlock()
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+	}
+	stdout, _ := makeStdoutCapture(t)
+	stderr, _ := makeStdoutCapture(t)
+
+	cmd := WorkspaceCopyCommand{
+		clientFlags: clientFlags{Host: host},
+		Chdir:       sourceRoot,
+		SandboxID:   sandboxID,
+	}
+	if err := cmd.Run(&runtimeContext{
+		CWD:           sourceRoot,
+		Loader:        repositoryNotFoundLoader{},
+		Config:        runtimeconfig.Config{},
+		Observability: newTestObservability(t),
+		Stdout:        stdout,
+		Stderr:        stderr,
+	}); err != nil {
+		t.Fatalf("WorkspaceCopyCommand.Run returned error: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(commands) != 0 {
+		t.Fatalf("expected symlinked raw workspace destination to skip clean execution, got %d command(s)", len(commands))
+	}
+	if got, want := removedPath, "/workspace-app"; got != want {
+		t.Fatalf("unexpected removed path: got %q want %q", got, want)
+	}
+	if removedRecursive {
+		t.Fatal("expected symlinked raw workspace destination to be removed non-recursively")
+	}
+	if got, want := destination, "/workspace-app"; got != want {
+		t.Fatalf("unexpected extract destination: got %q want %q", got, want)
+	}
+}
+
 func TestRawWorkspaceCopyFollowsSymlinkedSourceRoot(t *testing.T) {
 	realRoot := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(realRoot, "app"), 0o755); err != nil {

--- a/internal/cli/workspace_test.go
+++ b/internal/cli/workspace_test.go
@@ -118,6 +118,121 @@ func TestWorkspaceCopyAppliesGitChangeset(t *testing.T) {
 	}
 }
 
+func TestWorkspaceCopyResetsGitCheckoutWhenLocalRepoClean(t *testing.T) {
+	repoDir := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
+
+	adapter := &integrationAdapter{}
+	host, _ := startIntegrationServer(t, adapter)
+	sandboxID := createWorkspaceCopyTestSandbox(t, host, workspaceCopyTestPolicy())
+
+	var (
+		mu          sync.Mutex
+		commands    [][]string
+		stdinWrites int
+		stdinCloses int
+	)
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+		mu.Lock()
+		commands = append(commands, append([]string(nil), req.Command...))
+		mu.Unlock()
+		if stream.OnAttach != nil {
+			stream.OnAttach(backend.AttachIO{
+				WriteStdin: func(_ []byte) error {
+					mu.Lock()
+					stdinWrites++
+					mu.Unlock()
+					return nil
+				},
+				CloseStdin: func() error {
+					mu.Lock()
+					stdinCloses++
+					mu.Unlock()
+					return nil
+				},
+			})
+		}
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+	}
+
+	stdout, _ := makeStdoutCapture(t)
+	stderr, _ := makeStdoutCapture(t)
+	cmd := WorkspaceCopyCommand{
+		clientFlags: clientFlags{Host: host},
+		Chdir:       repoDir,
+		SandboxID:   sandboxID,
+	}
+	if err := cmd.Run(&runtimeContext{
+		CWD:           repoDir,
+		Loader:        workspaceCopyRepositoryLoader(),
+		Config:        runtimeconfig.Config{},
+		Observability: newTestObservability(t),
+		Stdout:        stdout,
+		Stderr:        stderr,
+	}); err != nil {
+		t.Fatalf("WorkspaceCopyCommand.Run returned error: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(commands) < 2 {
+		t.Fatalf("expected repository bootstrap and checkout reset commands, got %d", len(commands))
+	}
+	resetCommand := strings.Join(commands[len(commands)-1], " ")
+	if !strings.Contains(resetCommand, `git -C "$dest" reset --hard "$base_commit"`) {
+		t.Fatalf("expected clean workspace copy to reset the checkout, got %q", resetCommand)
+	}
+	if strings.Contains(resetCommand, `git -C "$dest" apply --binary`) {
+		t.Fatalf("expected clean workspace copy to avoid applying an empty patch, got %q", resetCommand)
+	}
+	if stdinWrites != 0 || stdinCloses != 0 {
+		t.Fatalf("expected reset-only copy to avoid stdin attachment, got writes=%d closes=%d", stdinWrites, stdinCloses)
+	}
+}
+
+func TestWorkspaceCopyDryRunDoesNotResetCleanGitCheckout(t *testing.T) {
+	repoDir := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
+
+	adapter := &integrationAdapter{}
+	host, _ := startIntegrationServer(t, adapter)
+	var (
+		mu       sync.Mutex
+		commands [][]string
+	)
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
+		mu.Lock()
+		commands = append(commands, append([]string(nil), req.Command...))
+		mu.Unlock()
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+	}
+
+	stdout, stdoutText := makeStdoutCapture(t)
+	stderr, _ := makeStdoutCapture(t)
+	cmd := WorkspaceCopyCommand{
+		clientFlags: clientFlags{Host: host},
+		Chdir:       repoDir,
+		DryRun:      true,
+		SandboxID:   "cr_dryrun",
+	}
+	if err := cmd.Run(&runtimeContext{
+		CWD:           repoDir,
+		Loader:        workspaceCopyRepositoryLoader(),
+		Config:        runtimeconfig.Config{},
+		Observability: newTestObservability(t),
+		Stdout:        stdout,
+		Stderr:        stderr,
+	}); err != nil {
+		t.Fatalf("WorkspaceCopyCommand.Run returned error: %v", err)
+	}
+	if got := stdoutText(); got != "" {
+		t.Fatalf("expected clean dry-run to print no planned changes, got %q", got)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(commands) != 0 {
+		t.Fatalf("dry-run should not run workspace copy execution, got %q", strings.Join(commands[0], " "))
+	}
+}
+
 func TestWorkspaceCopyUsesRawArchiveForNonGitWorkspace(t *testing.T) {
 	sourceRoot := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(sourceRoot, "app"), 0o755); err != nil {
@@ -203,6 +318,54 @@ func TestWorkspaceCopyUsesRawArchiveForNonGitWorkspace(t *testing.T) {
 	}
 	if _, ok := files[".git/config"]; ok {
 		t.Fatalf("expected .git directory to be skipped, got files %#v", files)
+	}
+}
+
+func TestWorkspaceCopyRejectsUnsafeRawDestinationRoot(t *testing.T) {
+	sourceRoot := t.TempDir()
+	err := copyRawWorkspaceToSandbox(context.Background(), &runtimeContext{
+		Loader: repositoryIntegrationLoader{
+			repository: policy.RepositoryConfig{
+				Mode: "current-repo",
+				Path: "/",
+			},
+		},
+	}, nil, workspaceCopyOptions{
+		CWD:       sourceRoot,
+		SandboxID: "cr_123",
+	})
+	if err == nil {
+		t.Fatal("expected unsafe raw workspace destination to be rejected")
+	}
+	if !strings.Contains(err.Error(), "unsafe for raw workspace copy") {
+		t.Fatalf("expected unsafe destination error, got %v", err)
+	}
+}
+
+func TestTopLevelCopyRejectsNonGitWorkspaceWhenCreatingSandbox(t *testing.T) {
+	cwd := t.TempDir()
+	_, err := resolveExecutionSandbox(
+		context.Background(),
+		nil,
+		&runtimeContext{
+			CWD:    cwd,
+			Loader: repositoryNotFoundLoader{},
+		},
+		cwd,
+		"",
+		"",
+		"",
+		"",
+		"",
+		0,
+		repositoryOverrideFlags{},
+		workspaceCopyFlags{Copy: true},
+	)
+	if err == nil {
+		t.Fatal("expected non-Git top-level --copy to be rejected before sandbox creation")
+	}
+	if !strings.Contains(err.Error(), "non-Git workspaces") {
+		t.Fatalf("expected non-Git copy error, got %v", err)
 	}
 }
 

--- a/internal/cli/workspace_test.go
+++ b/internal/cli/workspace_test.go
@@ -132,6 +132,122 @@ func TestWorkspaceCopyAppliesGitChangeset(t *testing.T) {
 	}
 }
 
+func TestWorkspaceCopyUsesGitChangesetForGitWorktreeWithoutRepositoryPolicy(t *testing.T) {
+	repoDir := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
+	if err := os.WriteFile(filepath.Join(repoDir, ".gitignore"), []byte("node_modules/\n"), 0o644); err != nil {
+		t.Fatalf("write gitignore: %v", err)
+	}
+	runGitInDir(t, repoDir, "add", ".gitignore")
+	runGitInDir(t, repoDir, "commit", "-m", "ignore dependencies")
+	if err := os.WriteFile(filepath.Join(repoDir, "dirty.txt"), []byte("dirty\n"), 0o644); err != nil {
+		t.Fatalf("write dirty file: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(repoDir, "node_modules/pkg"), 0o755); err != nil {
+		t.Fatalf("create ignored dependency dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, "node_modules/pkg/index.js"), []byte("ignored\n"), 0o644); err != nil {
+		t.Fatalf("write ignored dependency file: %v", err)
+	}
+
+	var rawArchiveCalled bool
+	adapter := &copyIntegrationAdapter{
+		extractFn: func(context.Context, string, string, io.Reader) (int64, error) {
+			rawArchiveCalled = true
+			return 0, errors.New("raw archive should not run")
+		},
+	}
+	host, _ := startIntegrationServer(t, adapter)
+	head, err := gitOutput(repoDir, "rev-parse", "HEAD")
+	if err != nil {
+		t.Fatalf("resolve repository HEAD: %v", err)
+	}
+	branch, err := gitOutput(repoDir, "branch", "--show-current")
+	if err != nil {
+		t.Fatalf("resolve repository branch: %v", err)
+	}
+	sandboxID := createWorkspaceCopyTestSandboxWithRepositoryCommitBranch(t, host, "/sandbox-workspace", head, branch)
+
+	var (
+		mu       sync.Mutex
+		commands [][]string
+		patches  []string
+	)
+	adapter.runStreamFn = func(ctx context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+		mu.Lock()
+		commands = append(commands, append([]string(nil), req.Command...))
+		mu.Unlock()
+
+		if !strings.Contains(strings.Join(req.Command, " "), `git -C "$dest" apply --binary --whitespace=nowarn "$patch_file"`) {
+			return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+		}
+
+		closed := make(chan struct{})
+		var closeOnce sync.Once
+		var stdin bytes.Buffer
+		if stream.OnAttach != nil {
+			stream.OnAttach(backend.AttachIO{
+				WriteStdin: func(data []byte) error {
+					_, err := stdin.Write(data)
+					return err
+				},
+				CloseStdin: func() error {
+					mu.Lock()
+					patches = append(patches, stdin.String())
+					mu.Unlock()
+					closeOnce.Do(func() { close(closed) })
+					return nil
+				},
+			})
+		}
+		select {
+		case <-closed:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+	}
+
+	stdout, _ := makeStdoutCapture(t)
+	stderr, _ := makeStdoutCapture(t)
+	cmd := WorkspaceCopyCommand{
+		clientFlags: clientFlags{Host: host},
+		Chdir:       repoDir,
+		SandboxID:   sandboxID,
+	}
+	if err := cmd.Run(&runtimeContext{
+		CWD:           repoDir,
+		Loader:        repositoryNotFoundLoader{},
+		Config:        runtimeconfig.Config{},
+		Observability: newTestObservability(t),
+		Stdout:        stdout,
+		Stderr:        stderr,
+	}); err != nil {
+		t.Fatalf("WorkspaceCopyCommand.Run returned error: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if rawArchiveCalled {
+		t.Fatal("expected Git worktree workspace copy to avoid raw archive transport")
+	}
+	if len(commands) < 1 {
+		t.Fatalf("expected changeset apply command, got %d", len(commands))
+	}
+	applyCommand := strings.Join(commands[len(commands)-1], " ")
+	if !strings.Contains(applyCommand, `git -C "$dest" apply --binary --whitespace=nowarn "$patch_file"`) {
+		t.Fatalf("expected workspace copy to use Git changeset apply, got %q", applyCommand)
+	}
+	if got, want := len(patches), 1; got != want {
+		t.Fatalf("expected one attached changeset patch, got %d", got)
+	}
+	if !strings.Contains(patches[0], "dirty.txt") {
+		t.Fatalf("expected changeset patch to reference dirty.txt, got %q", patches[0])
+	}
+	if strings.Contains(patches[0], "node_modules") {
+		t.Fatalf("expected ignored dependency tree to be excluded, got %q", patches[0])
+	}
+}
+
 func TestWorkspaceCopyResetsGitCheckoutWhenLocalRepoClean(t *testing.T) {
 	repoDir := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
 
@@ -279,6 +395,132 @@ func TestResolveExecutionSandboxClearsRepositoryAfterGitCopyInExistingSandbox(t 
 	}
 	if got, want := launchSeconds[0], int64(37); got != want {
 		t.Fatalf("unexpected workspace copy launch seconds: got %d want %d", got, want)
+	}
+}
+
+func TestResolveExecutionSandboxCopyUsesGitWorktreeWithoutRepositoryPolicy(t *testing.T) {
+	repoDir := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
+	if err := os.WriteFile(filepath.Join(repoDir, ".gitignore"), []byte("node_modules/\n"), 0o644); err != nil {
+		t.Fatalf("write gitignore: %v", err)
+	}
+	runGitInDir(t, repoDir, "add", ".gitignore")
+	runGitInDir(t, repoDir, "commit", "-m", "ignore dependencies")
+	if err := os.WriteFile(filepath.Join(repoDir, "dirty.txt"), []byte("dirty\n"), 0o644); err != nil {
+		t.Fatalf("write dirty file: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(repoDir, "node_modules/pkg"), 0o755); err != nil {
+		t.Fatalf("create ignored dependency dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, "node_modules/pkg/index.js"), []byte("ignored\n"), 0o644); err != nil {
+		t.Fatalf("write ignored dependency file: %v", err)
+	}
+
+	var rawArchiveCalled bool
+	adapter := &copyIntegrationAdapter{
+		extractFn: func(context.Context, string, string, io.Reader) (int64, error) {
+			rawArchiveCalled = true
+			return 0, errors.New("raw archive should not run")
+		},
+	}
+	host, _ := startIntegrationServer(t, adapter)
+	head, err := gitOutput(repoDir, "rev-parse", "HEAD")
+	if err != nil {
+		t.Fatalf("resolve repository HEAD: %v", err)
+	}
+	branch, err := gitOutput(repoDir, "branch", "--show-current")
+	if err != nil {
+		t.Fatalf("resolve repository branch: %v", err)
+	}
+	sandboxID := createWorkspaceCopyTestSandboxWithRepositoryCommitBranch(t, host, "/sandbox-workspace", head, branch)
+
+	var (
+		mu       sync.Mutex
+		commands [][]string
+		patches  []string
+	)
+	adapter.runStreamFn = func(ctx context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+		mu.Lock()
+		commands = append(commands, append([]string(nil), req.Command...))
+		mu.Unlock()
+
+		if !strings.Contains(strings.Join(req.Command, " "), `git -C "$dest" apply --binary --whitespace=nowarn "$patch_file"`) {
+			return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+		}
+
+		closed := make(chan struct{})
+		var closeOnce sync.Once
+		var stdin bytes.Buffer
+		if stream.OnAttach != nil {
+			stream.OnAttach(backend.AttachIO{
+				WriteStdin: func(data []byte) error {
+					_, err := stdin.Write(data)
+					return err
+				},
+				CloseStdin: func() error {
+					mu.Lock()
+					patches = append(patches, stdin.String())
+					mu.Unlock()
+					closeOnce.Do(func() { close(closed) })
+					return nil
+				},
+			})
+		}
+		select {
+		case <-closed:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+	}
+
+	client := mustNewControlClient(t, host)
+	target, err := resolveExecutionSandbox(
+		context.Background(),
+		client,
+		&runtimeContext{
+			CWD:           repoDir,
+			Loader:        repositoryNotFoundLoader{},
+			Config:        runtimeconfig.Config{},
+			Observability: newTestObservability(t),
+		},
+		repoDir,
+		host,
+		"",
+		sandboxID,
+		"",
+		"",
+		0,
+		false,
+		repositoryOverrideFlags{},
+		workspaceCopyFlags{Copy: true},
+	)
+	if err != nil {
+		t.Fatalf("resolveExecutionSandbox returned error: %v", err)
+	}
+	if target.Repository != nil {
+		t.Fatalf("expected returned execution sandbox to avoid repository checkout after copy, got %#v", target.Repository)
+	}
+	if got, want := target.WorkspaceRoot, "/sandbox-workspace"; got != want {
+		t.Fatalf("unexpected returned workspace root: got %q want %q", got, want)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if rawArchiveCalled {
+		t.Fatal("expected Git worktree --copy to avoid raw archive transport")
+	}
+	if len(commands) < 1 {
+		t.Fatalf("expected changeset apply command, got %d", len(commands))
+	}
+	applyCommand := strings.Join(commands[len(commands)-1], " ")
+	if !strings.Contains(applyCommand, `git -C "$dest" apply --binary --whitespace=nowarn "$patch_file"`) {
+		t.Fatalf("expected --copy to use Git changeset apply, got %q", applyCommand)
+	}
+	if got, want := len(patches), 1; got != want {
+		t.Fatalf("expected one attached changeset patch, got %d", got)
+	}
+	if strings.Contains(patches[0], "node_modules") {
+		t.Fatalf("expected ignored dependency tree to be excluded, got %q", patches[0])
 	}
 }
 

--- a/internal/cli/workspace_test.go
+++ b/internal/cli/workspace_test.go
@@ -284,7 +284,7 @@ func TestWorkspaceCopyUsesRawArchiveForNonGitWorkspace(t *testing.T) {
 		},
 	}
 	host, _ := startIntegrationServer(t, adapter)
-	sandboxID := createWorkspaceCopyTestSandbox(t, host, copyTestPolicy())
+	sandboxID := createWorkspaceCopyTestSandboxWithRepository(t, host, "/workspace-app")
 	stdout, _ := makeStdoutCapture(t)
 	stderr, _ := makeStdoutCapture(t)
 
@@ -304,13 +304,13 @@ func TestWorkspaceCopyUsesRawArchiveForNonGitWorkspace(t *testing.T) {
 		t.Fatalf("WorkspaceCopyCommand.Run returned error: %v", err)
 	}
 
-	if got, want := removedPath, "/workspace"; got != want {
+	if got, want := removedPath, "/workspace-app"; got != want {
 		t.Fatalf("unexpected removed workspace root: got %q want %q", got, want)
 	}
 	if !recursive {
 		t.Fatal("expected workspace root removal to be recursive")
 	}
-	if got, want := destination, "/workspace"; got != want {
+	if got, want := destination, "/workspace-app"; got != want {
 		t.Fatalf("unexpected extract destination: got %q want %q", got, want)
 	}
 	if got, want := files["app/main.txt"], "payload\n"; got != want {
@@ -323,22 +323,45 @@ func TestWorkspaceCopyUsesRawArchiveForNonGitWorkspace(t *testing.T) {
 
 func TestWorkspaceCopyRejectsUnsafeRawDestinationRoot(t *testing.T) {
 	sourceRoot := t.TempDir()
-	err := copyRawWorkspaceToSandbox(context.Background(), &runtimeContext{
-		Loader: repositoryIntegrationLoader{
-			repository: policy.RepositoryConfig{
-				Mode: "current-repo",
-				Path: "/",
-			},
-		},
-	}, nil, workspaceCopyOptions{
-		CWD:       sourceRoot,
-		SandboxID: "cr_123",
+	err := copyRawWorkspaceToSandbox(context.Background(), &runtimeContext{}, nil, workspaceCopyOptions{
+		CWD:         sourceRoot,
+		SandboxID:   "cr_123",
+		Destination: "/",
 	})
 	if err == nil {
 		t.Fatal("expected unsafe raw workspace destination to be rejected")
 	}
 	if !strings.Contains(err.Error(), "unsafe for raw workspace copy") {
 		t.Fatalf("expected unsafe destination error, got %v", err)
+	}
+}
+
+func TestWorkspaceCopyRejectsRawCopyWhenSandboxWorkspaceRootUnknown(t *testing.T) {
+	sourceRoot := t.TempDir()
+	adapter := &copyIntegrationAdapter{}
+	host, _ := startIntegrationServer(t, adapter)
+	sandboxID := createWorkspaceCopyTestSandbox(t, host, copyTestPolicy())
+
+	stdout, _ := makeStdoutCapture(t)
+	stderr, _ := makeStdoutCapture(t)
+	cmd := WorkspaceCopyCommand{
+		clientFlags: clientFlags{Host: host},
+		Chdir:       sourceRoot,
+		SandboxID:   sandboxID,
+	}
+	err := cmd.Run(&runtimeContext{
+		CWD:           sourceRoot,
+		Loader:        repositoryNotFoundLoader{},
+		Config:        runtimeconfig.Config{},
+		Observability: newTestObservability(t),
+		Stdout:        stdout,
+		Stderr:        stderr,
+	})
+	if err == nil {
+		t.Fatal("expected raw workspace copy to reject sandbox without recorded workspace root")
+	}
+	if !strings.Contains(err.Error(), "does not have a recorded workspace root") {
+		t.Fatalf("expected recorded workspace root error, got %v", err)
 	}
 }
 
@@ -358,6 +381,7 @@ func TestTopLevelCopyRejectsNonGitWorkspaceWhenCreatingSandbox(t *testing.T) {
 		"",
 		"",
 		0,
+		false,
 		repositoryOverrideFlags{},
 		workspaceCopyFlags{Copy: true},
 	)
@@ -376,6 +400,29 @@ func createWorkspaceCopyTestSandbox(t *testing.T, host string, compiled *cleanro
 	resp, err := client.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
 		Backend: "firecracker",
 		Policy:  compiled,
+	})
+	if err != nil {
+		t.Fatalf("create sandbox: %v", err)
+	}
+	sandboxID := strings.TrimSpace(resp.GetSandbox().GetSandboxId())
+	if sandboxID == "" {
+		t.Fatal("create sandbox response missing sandbox id")
+	}
+	return sandboxID
+}
+
+func createWorkspaceCopyTestSandboxWithRepository(t *testing.T, host, destination string) string {
+	t.Helper()
+
+	client := mustNewControlClient(t, host)
+	resp, err := client.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Backend: "firecracker",
+		Policy:  workspaceCopyTestPolicy(),
+		RepositoryCheckout: &cleanroomv1.RepositoryCheckout{
+			RemoteUrl:      "https://github.com/buildkite/cleanroom.git",
+			CommitSha:      "0123456789abcdef0123456789abcdef01234567",
+			DestinationDir: destination,
+		},
 	})
 	if err != nil {
 		t.Fatalf("create sandbox: %v", err)

--- a/internal/cli/workspace_test.go
+++ b/internal/cli/workspace_test.go
@@ -247,19 +247,20 @@ func TestWorkspaceCopyUsesRawArchiveForNonGitWorkspace(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(sourceRoot, ".git/config"), []byte("skip\n"), 0o644); err != nil {
 		t.Fatalf("write skipped git config: %v", err)
 	}
+	if err := os.MkdirAll(filepath.Join(sourceRoot, "app/submodule"), 0o755); err != nil {
+		t.Fatalf("create submodule dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceRoot, "app/submodule/.git"), []byte("gitdir: ../../.git/modules/submodule\n"), 0o644); err != nil {
+		t.Fatalf("write skipped git file: %v", err)
+	}
 
 	var (
-		removedPath string
-		recursive   bool
+		mu          sync.Mutex
+		commands    [][]string
 		destination string
 		files       = map[string]string{}
 	)
 	adapter := &copyIntegrationAdapter{
-		removeFn: func(_ context.Context, _ string, path string, rec bool) error {
-			removedPath = path
-			recursive = rec
-			return nil
-		},
 		extractFn: func(_ context.Context, _ string, dest string, r io.Reader) (int64, error) {
 			destination = dest
 			tr := tar.NewReader(r)
@@ -285,6 +286,12 @@ func TestWorkspaceCopyUsesRawArchiveForNonGitWorkspace(t *testing.T) {
 	}
 	host, _ := startIntegrationServer(t, adapter)
 	sandboxID := createWorkspaceCopyTestSandboxWithRepository(t, host, "/workspace-app")
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
+		mu.Lock()
+		commands = append(commands, append([]string(nil), req.Command...))
+		mu.Unlock()
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+	}
 	stdout, _ := makeStdoutCapture(t)
 	stderr, _ := makeStdoutCapture(t)
 
@@ -304,11 +311,14 @@ func TestWorkspaceCopyUsesRawArchiveForNonGitWorkspace(t *testing.T) {
 		t.Fatalf("WorkspaceCopyCommand.Run returned error: %v", err)
 	}
 
-	if got, want := removedPath, "/workspace-app"; got != want {
-		t.Fatalf("unexpected removed workspace root: got %q want %q", got, want)
+	mu.Lock()
+	defer mu.Unlock()
+	if len(commands) != 1 {
+		t.Fatalf("expected one raw workspace clean command, got %d", len(commands))
 	}
-	if !recursive {
-		t.Fatal("expected workspace root removal to be recursive")
+	cleanCommand := strings.Join(commands[0], " ")
+	if !strings.Contains(cleanCommand, `basename "$entry"`) || !strings.Contains(cleanCommand, `= ".git"`) {
+		t.Fatalf("expected raw workspace clean command to preserve .git, got %q", cleanCommand)
 	}
 	if got, want := destination, "/workspace-app"; got != want {
 		t.Fatalf("unexpected extract destination: got %q want %q", got, want)
@@ -318,6 +328,9 @@ func TestWorkspaceCopyUsesRawArchiveForNonGitWorkspace(t *testing.T) {
 	}
 	if _, ok := files[".git/config"]; ok {
 		t.Fatalf("expected .git directory to be skipped, got files %#v", files)
+	}
+	if _, ok := files["app/submodule/.git"]; ok {
+		t.Fatalf("expected .git file to be skipped, got files %#v", files)
 	}
 }
 

--- a/internal/cli/workspace_test.go
+++ b/internal/cli/workspace_test.go
@@ -231,7 +231,14 @@ func TestResolveExecutionSandboxClearsRepositoryAfterGitCopyInExistingSandbox(t 
 		t.Fatalf("resolve repository branch: %v", err)
 	}
 	sandboxID := createWorkspaceCopyTestSandboxWithRepositoryCommitBranch(t, host, "/sandbox-workspace", head, branch)
+	var (
+		mu            sync.Mutex
+		launchSeconds []int64
+	)
 	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
+		mu.Lock()
+		launchSeconds = append(launchSeconds, req.LaunchSeconds)
+		mu.Unlock()
 		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
 	}
 
@@ -251,7 +258,7 @@ func TestResolveExecutionSandboxClearsRepositoryAfterGitCopyInExistingSandbox(t 
 		sandboxID,
 		"",
 		"",
-		0,
+		37,
 		false,
 		repositoryOverrideFlags{},
 		workspaceCopyFlags{Copy: true},
@@ -264,6 +271,14 @@ func TestResolveExecutionSandboxClearsRepositoryAfterGitCopyInExistingSandbox(t 
 	}
 	if got, want := target.WorkspaceRoot, "/sandbox-workspace"; got != want {
 		t.Fatalf("unexpected returned workspace root: got %q want %q", got, want)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(launchSeconds) == 0 {
+		t.Fatal("expected workspace copy execution to run")
+	}
+	if got, want := launchSeconds[0], int64(37); got != want {
+		t.Fatalf("unexpected workspace copy launch seconds: got %d want %d", got, want)
 	}
 }
 

--- a/internal/controlclient/client.go
+++ b/internal/controlclient/client.go
@@ -255,6 +255,18 @@ func (c *Client) CreateExecution(ctx context.Context, req *cleanroomv1.CreateExe
 	return resp.Msg, nil
 }
 
+const internalWorkspaceCopyInHeader = "Cleanroom-Internal-Workspace-Copy-In"
+
+func (c *Client) CreateWorkspaceCopyInExecution(ctx context.Context, req *cleanroomv1.CreateExecutionRequest) (*cleanroomv1.CreateExecutionResponse, error) {
+	connectReq := connect.NewRequest(req)
+	connectReq.Header().Set(internalWorkspaceCopyInHeader, "1")
+	resp, err := c.executionClient.CreateExecution(ctx, connectReq)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Msg, nil
+}
+
 func (c *Client) AttachExecution(ctx context.Context, req *cleanroomv1.AttachExecutionRequest) (*cleanroomv1.AttachExecutionResponse, error) {
 	resp, err := c.executionClient.AttachExecution(ctx, connect.NewRequest(req))
 	if err != nil {

--- a/internal/controlserver/server.go
+++ b/internal/controlserver/server.go
@@ -40,6 +40,8 @@ type Server struct {
 	interceptors []connect.Interceptor
 }
 
+const internalWorkspaceCopyInHeader = "Cleanroom-Internal-Workspace-Copy-In"
+
 func New(service *controlservice.Service, logger *log.Logger, interceptors ...connect.Interceptor) *Server {
 	return &Server{service: service, logger: logger, interceptors: interceptors}
 }
@@ -352,7 +354,11 @@ func (s *Server) ListExecutions(ctx context.Context, req *connect.Request[cleanr
 }
 
 func (s *Server) CreateExecution(ctx context.Context, req *connect.Request[cleanroomv1.CreateExecutionRequest]) (*connect.Response[cleanroomv1.CreateExecutionResponse], error) {
-	resp, err := s.service.CreateExecution(ctx, req.Msg)
+	createExecution := s.service.CreateExecution
+	if req.Header().Get(internalWorkspaceCopyInHeader) == "1" {
+		createExecution = s.service.CreateInternalWorkspaceCopyInExecution
+	}
+	resp, err := createExecution(ctx, req.Msg)
 	if err != nil {
 		return nil, toConnectError(err)
 	}

--- a/internal/controlserver/server.go
+++ b/internal/controlserver/server.go
@@ -35,13 +35,24 @@ type TLSOptions struct {
 }
 
 type Server struct {
-	service                              *controlservice.Service
-	logger                               *log.Logger
-	interceptors                         []connect.Interceptor
-	trustedInternalWorkspaceCopyInHeader bool
+	service                      *controlservice.Service
+	logger                       *log.Logger
+	interceptors                 []connect.Interceptor
+	internalWorkspaceCopyInTrust internalWorkspaceCopyInTrustMode
 }
 
-const internalWorkspaceCopyInHeader = "Cleanroom-Internal-Workspace-Copy-In"
+type internalWorkspaceCopyInTrustMode int
+
+const (
+	internalWorkspaceCopyInTrustNone internalWorkspaceCopyInTrustMode = iota
+	internalWorkspaceCopyInTrustAll
+	internalWorkspaceCopyInTrustLoopback
+)
+
+const (
+	internalWorkspaceCopyInHeader        = "Cleanroom-Internal-Workspace-Copy-In"
+	internalWorkspaceCopyInTrustedHeader = "Cleanroom-Internal-Workspace-Copy-In-Trusted"
+)
 
 func New(service *controlservice.Service, logger *log.Logger, interceptors ...connect.Interceptor) *Server {
 	return &Server{service: service, logger: logger, interceptors: interceptors}
@@ -49,7 +60,14 @@ func New(service *controlservice.Service, logger *log.Logger, interceptors ...co
 
 func (s *Server) TrustInternalWorkspaceCopyInRequests() *Server {
 	if s != nil {
-		s.trustedInternalWorkspaceCopyInHeader = true
+		s.internalWorkspaceCopyInTrust = internalWorkspaceCopyInTrustAll
+	}
+	return s
+}
+
+func (s *Server) TrustInternalWorkspaceCopyInRequestsFromLoopback() *Server {
+	if s != nil {
+		s.internalWorkspaceCopyInTrust = internalWorkspaceCopyInTrustLoopback
 	}
 	return s
 }
@@ -73,7 +91,11 @@ func (s *Server) Handler() http.Handler {
 		w.WriteHeader(http.StatusOK)
 		_, _ = io.WriteString(w, "ok\n")
 	})
-	return h2c.NewHandler(mux, &http2.Server{})
+	handler := h2c.NewHandler(mux, &http2.Server{})
+	if s.internalWorkspaceCopyInTrust == internalWorkspaceCopyInTrustLoopback {
+		return markLoopbackInternalWorkspaceCopyInRequests(handler)
+	}
+	return handler
 }
 
 func (s *Server) CreateSandbox(ctx context.Context, req *connect.Request[cleanroomv1.CreateSandboxRequest]) (*connect.Response[cleanroomv1.CreateSandboxResponse], error) {
@@ -364,7 +386,13 @@ func (s *Server) ListExecutions(ctx context.Context, req *connect.Request[cleanr
 func (s *Server) CreateExecution(ctx context.Context, req *connect.Request[cleanroomv1.CreateExecutionRequest]) (*connect.Response[cleanroomv1.CreateExecutionResponse], error) {
 	createExecution := s.service.CreateExecution
 	if req.Header().Get(internalWorkspaceCopyInHeader) == "1" {
-		if !s.trustedInternalWorkspaceCopyInHeader {
+		switch s.internalWorkspaceCopyInTrust {
+		case internalWorkspaceCopyInTrustAll:
+		case internalWorkspaceCopyInTrustLoopback:
+			if req.Header().Get(internalWorkspaceCopyInTrustedHeader) != "1" {
+				return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("internal workspace copy-in requests require a trusted control endpoint"))
+			}
+		default:
 			return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("internal workspace copy-in requests require a trusted control endpoint"))
 		}
 		createExecution = s.service.CreateInternalWorkspaceCopyInExecution
@@ -374,6 +402,25 @@ func (s *Server) CreateExecution(ctx context.Context, req *connect.Request[clean
 		return nil, toConnectError(err)
 	}
 	return connect.NewResponse(resp), nil
+}
+
+func markLoopbackInternalWorkspaceCopyInRequests(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Header.Del(internalWorkspaceCopyInTrustedHeader)
+		if r.Header.Get(internalWorkspaceCopyInHeader) == "1" && isLoopbackRemoteAddr(r.RemoteAddr) {
+			r.Header.Set(internalWorkspaceCopyInTrustedHeader, "1")
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func isLoopbackRemoteAddr(remoteAddr string) bool {
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		host = remoteAddr
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
 func (s *Server) AttachExecution(ctx context.Context, req *connect.Request[cleanroomv1.AttachExecutionRequest]) (*connect.Response[cleanroomv1.AttachExecutionResponse], error) {

--- a/internal/controlserver/server.go
+++ b/internal/controlserver/server.go
@@ -35,15 +35,23 @@ type TLSOptions struct {
 }
 
 type Server struct {
-	service      *controlservice.Service
-	logger       *log.Logger
-	interceptors []connect.Interceptor
+	service                              *controlservice.Service
+	logger                               *log.Logger
+	interceptors                         []connect.Interceptor
+	trustedInternalWorkspaceCopyInHeader bool
 }
 
 const internalWorkspaceCopyInHeader = "Cleanroom-Internal-Workspace-Copy-In"
 
 func New(service *controlservice.Service, logger *log.Logger, interceptors ...connect.Interceptor) *Server {
 	return &Server{service: service, logger: logger, interceptors: interceptors}
+}
+
+func (s *Server) TrustInternalWorkspaceCopyInRequests() *Server {
+	if s != nil {
+		s.trustedInternalWorkspaceCopyInHeader = true
+	}
+	return s
 }
 
 func (s *Server) Handler() http.Handler {
@@ -356,6 +364,9 @@ func (s *Server) ListExecutions(ctx context.Context, req *connect.Request[cleanr
 func (s *Server) CreateExecution(ctx context.Context, req *connect.Request[cleanroomv1.CreateExecutionRequest]) (*connect.Response[cleanroomv1.CreateExecutionResponse], error) {
 	createExecution := s.service.CreateExecution
 	if req.Header().Get(internalWorkspaceCopyInHeader) == "1" {
+		if !s.trustedInternalWorkspaceCopyInHeader {
+			return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("internal workspace copy-in requests require a trusted control endpoint"))
+		}
 		createExecution = s.service.CreateInternalWorkspaceCopyInExecution
 	}
 	resp, err := createExecution(ctx, req.Msg)

--- a/internal/controlserver/server_handler_test.go
+++ b/internal/controlserver/server_handler_test.go
@@ -321,6 +321,30 @@ func TestExecutionEventStreamReturnsHistoryThenFollowUpdates(t *testing.T) {
 	}
 }
 
+func TestCreateExecutionRejectsSpoofedInternalWorkspaceCopyInHeader(t *testing.T) {
+	service := newHandlerTestService(newHandlerTestAdapter())
+	httpServer := httptest.NewServer(New(service, nil).Handler())
+	defer httpServer.Close()
+
+	executionClient := cleanroomv1connect.NewExecutionServiceClient(http.DefaultClient, httpServer.URL)
+	req := connect.NewRequest(&cleanroomv1.CreateExecutionRequest{
+		SandboxId: "sbx_spoofed",
+		Command:   []string{"sh", "-lc", "true"},
+		Options: &cleanroomv1.ExecutionOptions{
+			SkipRunBefore: true,
+		},
+	})
+	req.Header().Set(internalWorkspaceCopyInHeader, "1")
+
+	_, err := executionClient.CreateExecution(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected CreateExecution to reject spoofed internal workspace copy-in header")
+	}
+	if code := connect.CodeOf(err); code != connect.CodeUnauthenticated {
+		t.Fatalf("unexpected error code: got %v want %v (err=%v)", code, connect.CodeUnauthenticated, err)
+	}
+}
+
 func TestToConnectErrorMapsExpectedCodes(t *testing.T) {
 	t.Parallel()
 

--- a/internal/controlserver/server_handler_test.go
+++ b/internal/controlserver/server_handler_test.go
@@ -345,6 +345,52 @@ func TestCreateExecutionRejectsSpoofedInternalWorkspaceCopyInHeader(t *testing.T
 	}
 }
 
+func TestCreateExecutionRejectsInternalWorkspaceCopyInHeaderWhenLoopbackTrustUnmarked(t *testing.T) {
+	service := newHandlerTestService(newHandlerTestAdapter())
+	server := New(service, nil).TrustInternalWorkspaceCopyInRequestsFromLoopback()
+
+	req := connect.NewRequest(&cleanroomv1.CreateExecutionRequest{
+		SandboxId: "sbx_unmarked",
+		Command:   []string{"sh", "-lc", "true"},
+		Options: &cleanroomv1.ExecutionOptions{
+			SkipRunBefore: true,
+		},
+	})
+	req.Header().Set(internalWorkspaceCopyInHeader, "1")
+
+	_, err := server.CreateExecution(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected CreateExecution to reject unmarked internal workspace copy-in request")
+	}
+	if code := connect.CodeOf(err); code != connect.CodeUnauthenticated {
+		t.Fatalf("unexpected error code: got %v want %v (err=%v)", code, connect.CodeUnauthenticated, err)
+	}
+}
+
+func TestCreateExecutionAllowsInternalWorkspaceCopyInHeaderFromLoopbackTrustedEndpoint(t *testing.T) {
+	service := newHandlerTestService(newHandlerTestAdapter())
+	httpServer := httptest.NewServer(New(service, nil).TrustInternalWorkspaceCopyInRequestsFromLoopback().Handler())
+	defer httpServer.Close()
+
+	executionClient := cleanroomv1connect.NewExecutionServiceClient(http.DefaultClient, httpServer.URL)
+	req := connect.NewRequest(&cleanroomv1.CreateExecutionRequest{
+		SandboxId: "sbx_loopback_trusted",
+		Command:   []string{"sh", "-lc", "true"},
+		Options: &cleanroomv1.ExecutionOptions{
+			SkipRunBefore: true,
+		},
+	})
+	req.Header().Set(internalWorkspaceCopyInHeader, "1")
+
+	_, err := executionClient.CreateExecution(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected CreateExecution to return unknown sandbox")
+	}
+	if code := connect.CodeOf(err); code != connect.CodeNotFound {
+		t.Fatalf("unexpected error code: got %v want %v (err=%v)", code, connect.CodeNotFound, err)
+	}
+}
+
 func TestCreateExecutionAllowsInternalWorkspaceCopyInHeaderWhenTrusted(t *testing.T) {
 	service := newHandlerTestService(newHandlerTestAdapter())
 	httpServer := httptest.NewServer(New(service, nil).TrustInternalWorkspaceCopyInRequests().Handler())
@@ -366,6 +412,81 @@ func TestCreateExecutionAllowsInternalWorkspaceCopyInHeaderWhenTrusted(t *testin
 	}
 	if code := connect.CodeOf(err); code != connect.CodeNotFound {
 		t.Fatalf("unexpected error code: got %v want %v (err=%v)", code, connect.CodeNotFound, err)
+	}
+}
+
+func TestMarkLoopbackInternalWorkspaceCopyInRequestsStripsSpoofedMarkerFromRemote(t *testing.T) {
+	var gotTrusted string
+	handler := markLoopbackInternalWorkspaceCopyInRequests(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		gotTrusted = r.Header.Get(internalWorkspaceCopyInTrustedHeader)
+	}))
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	req.RemoteAddr = "203.0.113.10:12345"
+	req.Header.Set(internalWorkspaceCopyInHeader, "1")
+	req.Header.Set(internalWorkspaceCopyInTrustedHeader, "1")
+
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	if gotTrusted != "" {
+		t.Fatalf("expected spoofed trust marker to be stripped for remote caller, got %q", gotTrusted)
+	}
+}
+
+func TestMarkLoopbackInternalWorkspaceCopyInRequestsMarksLoopback(t *testing.T) {
+	var gotTrusted string
+	handler := markLoopbackInternalWorkspaceCopyInRequests(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		gotTrusted = r.Header.Get(internalWorkspaceCopyInTrustedHeader)
+	}))
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	req.RemoteAddr = "127.0.0.1:12345"
+	req.Header.Set(internalWorkspaceCopyInHeader, "1")
+
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	if gotTrusted != "1" {
+		t.Fatalf("expected loopback copy-in request to be marked trusted, got %q", gotTrusted)
+	}
+}
+
+func TestIsLoopbackRemoteAddr(t *testing.T) {
+	tests := []struct {
+		name       string
+		remoteAddr string
+		want       bool
+	}{
+		{
+			name:       "ipv4 loopback",
+			remoteAddr: "127.0.0.1:12345",
+			want:       true,
+		},
+		{
+			name:       "ipv6 loopback",
+			remoteAddr: "[::1]:12345",
+			want:       true,
+		},
+		{
+			name:       "remote ipv4",
+			remoteAddr: "203.0.113.10:12345",
+			want:       false,
+		},
+		{
+			name:       "private network is still remote",
+			remoteAddr: "10.0.0.2:12345",
+			want:       false,
+		},
+		{
+			name:       "invalid",
+			remoteAddr: "not-an-address",
+			want:       false,
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isLoopbackRemoteAddr(tc.remoteAddr); got != tc.want {
+				t.Fatalf("isLoopbackRemoteAddr(%q) = %v, want %v", tc.remoteAddr, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/controlserver/server_handler_test.go
+++ b/internal/controlserver/server_handler_test.go
@@ -345,6 +345,30 @@ func TestCreateExecutionRejectsSpoofedInternalWorkspaceCopyInHeader(t *testing.T
 	}
 }
 
+func TestCreateExecutionAllowsInternalWorkspaceCopyInHeaderWhenTrusted(t *testing.T) {
+	service := newHandlerTestService(newHandlerTestAdapter())
+	httpServer := httptest.NewServer(New(service, nil).TrustInternalWorkspaceCopyInRequests().Handler())
+	defer httpServer.Close()
+
+	executionClient := cleanroomv1connect.NewExecutionServiceClient(http.DefaultClient, httpServer.URL)
+	req := connect.NewRequest(&cleanroomv1.CreateExecutionRequest{
+		SandboxId: "sbx_trusted",
+		Command:   []string{"sh", "-lc", "true"},
+		Options: &cleanroomv1.ExecutionOptions{
+			SkipRunBefore: true,
+		},
+	})
+	req.Header().Set(internalWorkspaceCopyInHeader, "1")
+
+	_, err := executionClient.CreateExecution(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected CreateExecution to return unknown sandbox")
+	}
+	if code := connect.CodeOf(err); code != connect.CodeNotFound {
+		t.Fatalf("unexpected error code: got %v want %v (err=%v)", code, connect.CodeNotFound, err)
+	}
+}
+
 func TestToConnectErrorMapsExpectedCodes(t *testing.T) {
 	t.Parallel()
 

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -1780,6 +1780,14 @@ func (s *Service) TerminateSandbox(ctx context.Context, req *cleanroomv1.Termina
 }
 
 func (s *Service) CreateExecution(ctx context.Context, req *cleanroomv1.CreateExecutionRequest) (resp *cleanroomv1.CreateExecutionResponse, err error) {
+	return s.createExecution(ctx, req, false)
+}
+
+func (s *Service) CreateInternalWorkspaceCopyInExecution(ctx context.Context, req *cleanroomv1.CreateExecutionRequest) (resp *cleanroomv1.CreateExecutionResponse, err error) {
+	return s.createExecution(ctx, req, true)
+}
+
+func (s *Service) createExecution(ctx context.Context, req *cleanroomv1.CreateExecutionRequest, internalWorkspaceCopyIn bool) (resp *cleanroomv1.CreateExecutionResponse, err error) {
 	if req == nil {
 		return nil, errors.New("missing request")
 	}
@@ -1835,6 +1843,9 @@ func (s *Service) CreateExecution(ctx context.Context, req *cleanroomv1.CreateEx
 			SkipRunBefore: opts.GetSkipRunBefore(),
 		}
 		tty = opts.GetTty()
+	}
+	if err := validateInternalExecutionOptions(execOpts, internalWorkspaceCopyIn); err != nil {
+		return nil, err
 	}
 	kind, err := resolveExecutionKind(req.GetKind(), tty)
 	if err != nil {
@@ -1990,6 +2001,19 @@ func (s *Service) CreateExecution(ctx context.Context, req *cleanroomv1.CreateEx
 		)
 	}
 	return resp, nil
+}
+
+func validateInternalExecutionOptions(opts executionOptions, internalWorkspaceCopyIn bool) error {
+	if internalWorkspaceCopyIn {
+		return nil
+	}
+	if opts.PreserveRepositoryChangesetPendingExecution {
+		return errors.New("preserve repository changeset pending execution is only available for internal workspace copy-in executions")
+	}
+	if opts.SkipRunBefore {
+		return errors.New("skip run before is only available for internal workspace copy-in executions")
+	}
+	return nil
 }
 
 func (s *Service) AttachExecution(_ context.Context, req *cleanroomv1.AttachExecutionRequest) (*cleanroomv1.AttachExecutionResponse, error) {

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -164,7 +164,8 @@ type changesetMetadataStore interface {
 }
 
 type executionOptions struct {
-	LaunchSeconds int64
+	LaunchSeconds                               int64
+	PreserveRepositoryChangesetPendingExecution bool
 }
 
 type executionSnapshot struct {
@@ -1829,6 +1830,7 @@ func (s *Service) CreateExecution(ctx context.Context, req *cleanroomv1.CreateEx
 	if opts := req.GetOptions(); opts != nil {
 		execOpts = executionOptions{
 			LaunchSeconds: opts.GetLaunchSeconds(),
+			PreserveRepositoryChangesetPendingExecution: opts.GetPreserveRepositoryChangesetPendingExecution(),
 		}
 		tty = opts.GetTty()
 	}
@@ -2883,7 +2885,7 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 	finished := s.clock().Now()
 	recordExecutionMetrics(finalStatus, finished)
 	s.finalizeExecutionLocked(ex, finalStatus, finalExitCode, ex.Message, "", finished)
-	if finalStatus == cleanroomv1.ExecutionStatus_EXECUTION_STATUS_SUCCEEDED {
+	if finalStatus == cleanroomv1.ExecutionStatus_EXECUTION_STATUS_SUCCEEDED && !ex.Options.PreserveRepositoryChangesetPendingExecution {
 		s.markRepositoryChangesetExecutionConsumedLocked(sandboxID)
 	}
 

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -166,6 +166,7 @@ type changesetMetadataStore interface {
 type executionOptions struct {
 	LaunchSeconds                               int64
 	PreserveRepositoryChangesetPendingExecution bool
+	SkipRunBefore                               bool
 }
 
 type executionSnapshot struct {
@@ -1831,6 +1832,7 @@ func (s *Service) CreateExecution(ctx context.Context, req *cleanroomv1.CreateEx
 		execOpts = executionOptions{
 			LaunchSeconds: opts.GetLaunchSeconds(),
 			PreserveRepositoryChangesetPendingExecution: opts.GetPreserveRepositoryChangesetPendingExecution(),
+			SkipRunBefore: opts.GetSkipRunBefore(),
 		}
 		tty = opts.GetTty()
 	}
@@ -1905,7 +1907,7 @@ func (s *Service) CreateExecution(ctx context.Context, req *cleanroomv1.CreateEx
 		runRepository = sandboxRepository
 	}
 	var preRunBefore []string
-	if sandboxPolicy != nil && sandboxPolicy.Run.HasBefore() {
+	if !execOpts.SkipRunBefore && sandboxPolicy != nil && sandboxPolicy.Run.HasBefore() {
 		preRunBefore = append([]string(nil), sandboxPolicy.Run.Before...)
 		if runRepository != nil {
 			preRunBefore = repositorycheckout.WrapCommandInWorkdir(preRunBefore, runRepository)

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -4939,7 +4939,7 @@ func TestCreateExecutionCanPreservePendingChangesetForInternalWorkspaceCopy(t *t
 		}
 	}
 
-	copyResp, err := svc.CreateExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
+	copyResp, err := svc.CreateInternalWorkspaceCopyInExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
 		SandboxId:          sandboxID,
 		Command:            []string{"sh", "-lc", "true"},
 		RepositoryCheckout: repositoryCheckout,
@@ -4980,7 +4980,42 @@ func TestCreateExecutionCanPreservePendingChangesetForInternalWorkspaceCopy(t *t
 	}
 }
 
-func TestCreateExecutionCanSkipRunBefore(t *testing.T) {
+func TestCreateExecutionRejectsInternalWorkspaceCopyInOptions(t *testing.T) {
+	svc := newTestService(&stubAdapter{})
+
+	createSandboxResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Policy: testRepositoryRunBeforePolicy(),
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createSandboxResp.GetSandbox().GetSandboxId()
+
+	for name, opts := range map[string]*cleanroomv1.ExecutionOptions{
+		"preserve pending changeset": {
+			PreserveRepositoryChangesetPendingExecution: true,
+		},
+		"skip run before": {
+			SkipRunBefore: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := svc.CreateExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
+				SandboxId: sandboxID,
+				Command:   []string{"sh", "-lc", "pwd"},
+				Options:   opts,
+			})
+			if err == nil {
+				t.Fatal("expected CreateExecution to reject internal workspace copy-in option")
+			}
+			if !strings.Contains(err.Error(), "internal workspace copy-in executions") {
+				t.Fatalf("expected internal workspace copy-in error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestCreateInternalWorkspaceCopyInExecutionCanSkipRunBefore(t *testing.T) {
 	adapter := &stubAdapter{}
 	svc := newTestService(adapter)
 
@@ -5003,7 +5038,7 @@ func TestCreateExecutionCanSkipRunBefore(t *testing.T) {
 	}
 	sandboxID := createSandboxResp.GetSandbox().GetSandboxId()
 
-	resp, err := svc.CreateExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
+	resp, err := svc.CreateInternalWorkspaceCopyInExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
 		SandboxId: sandboxID,
 		Command:   []string{"sh", "-lc", "pwd"},
 		Options: &cleanroomv1.ExecutionOptions{

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -4980,6 +4980,54 @@ func TestCreateExecutionCanPreservePendingChangesetForInternalWorkspaceCopy(t *t
 	}
 }
 
+func TestCreateExecutionCanSkipRunBefore(t *testing.T) {
+	adapter := &stubAdapter{}
+	svc := newTestService(adapter)
+
+	var (
+		mu       sync.Mutex
+		commands [][]string
+	)
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
+		mu.Lock()
+		commands = append(commands, append([]string(nil), req.Command...))
+		mu.Unlock()
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+	}
+
+	createSandboxResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Policy: testRepositoryRunBeforePolicy(),
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createSandboxResp.GetSandbox().GetSandboxId()
+
+	resp, err := svc.CreateExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
+		SandboxId: sandboxID,
+		Command:   []string{"sh", "-lc", "pwd"},
+		Options: &cleanroomv1.ExecutionOptions{
+			SkipRunBefore: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateExecution returned error: %v", err)
+	}
+	if _, err := svc.WaitExecution(context.Background(), sandboxID, resp.GetExecution().GetExecutionId()); err != nil {
+		t.Fatalf("WaitExecution returned error: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if got, want := len(commands), 1; got != want {
+		t.Fatalf("expected only user command when run.before is skipped, got %d command(s)", got)
+	}
+	joined := strings.Join(commands[0], " ")
+	if strings.Contains(joined, "echo pre-run") {
+		t.Fatalf("expected run.before to be skipped, got %q", joined)
+	}
+}
+
 func TestCreateExecutionKeepsPendingChangesetAfterRunBeforeFailure(t *testing.T) {
 	adapter := &stubAdapter{}
 	svc := newTestService(adapter)

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -4886,6 +4886,100 @@ func TestCreateExecutionPreservesFirstMatchingRepositoryAfterChangesetSandboxCre
 	}
 }
 
+func TestCreateExecutionCanPreservePendingChangesetForInternalWorkspaceCopy(t *testing.T) {
+	adapter := &stubAdapter{}
+	svc := newTestService(adapter)
+
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"README.md": "hello\n",
+	})
+	svc.RepositoryStore = mirrors
+	repository := repositorycheckout.FromProto(repositoryCheckout)
+	if err := os.WriteFile(filepath.Join(mirrors.mirrorPath, "README.md"), []byte("hello from changeset\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(README.md) returned error: %v", err)
+	}
+	changeset, err := repositorychangeset.BuildFromWorkingTree(mirrors.mirrorPath, repository)
+	if err != nil {
+		t.Fatalf("BuildFromWorkingTree returned error: %v", err)
+	}
+	if changeset == nil {
+		t.Fatal("expected repository changeset")
+	}
+
+	var (
+		mu       sync.Mutex
+		commands [][]string
+	)
+	runCalled := make(chan struct{}, 8)
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
+		mu.Lock()
+		commands = append(commands, append([]string(nil), req.Command...))
+		mu.Unlock()
+		select {
+		case runCalled <- struct{}{}:
+		default:
+		}
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+	}
+
+	createSandboxResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Policy:              testRepositoryPolicy(),
+		RepositoryCheckout:  repositoryCheckout,
+		RepositoryChangeset: changeset.ToProto(),
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createSandboxResp.GetSandbox().GetSandboxId()
+	for i := 0; i < 2; i++ {
+		select {
+		case <-runCalled:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for changeset sandbox bootstrap")
+		}
+	}
+
+	copyResp, err := svc.CreateExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
+		SandboxId:          sandboxID,
+		Command:            []string{"sh", "-lc", "true"},
+		RepositoryCheckout: repositoryCheckout,
+		Options: &cleanroomv1.ExecutionOptions{
+			PreserveRepositoryChangesetPendingExecution: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateExecution internal copy returned error: %v", err)
+	}
+	if _, err := svc.WaitExecution(context.Background(), sandboxID, copyResp.GetExecution().GetExecutionId()); err != nil {
+		t.Fatalf("WaitExecution internal copy returned error: %v", err)
+	}
+
+	userResp, err := svc.CreateExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
+		SandboxId:          sandboxID,
+		Command:            []string{"sh", "-lc", "pwd"},
+		RepositoryCheckout: repositoryCheckout,
+	})
+	if err != nil {
+		t.Fatalf("CreateExecution user command returned error: %v", err)
+	}
+	if _, err := svc.WaitExecution(context.Background(), sandboxID, userResp.GetExecution().GetExecutionId()); err != nil {
+		t.Fatalf("WaitExecution user command returned error: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if got, want := len(commands), 4; got != want {
+		t.Fatalf("expected create bootstrap + changeset apply + internal copy + user execution, got %d command(s)", got)
+	}
+	userCommand := strings.Join(commands[3], " ")
+	if strings.Contains(userCommand, `git -C "$dest" fetch --filter=blob:none --progress origin "$commit"`) {
+		t.Fatalf("expected user execution to preserve pending changeset state instead of refreshing checkout, got %q", userCommand)
+	}
+	if !repositoryWrappedCommandContains(userCommand, `exec 'sh' '-lc' 'pwd'`) {
+		t.Fatalf("expected wrapped user command, got %q", userCommand)
+	}
+}
+
 func TestCreateExecutionKeepsPendingChangesetAfterRunBeforeFailure(t *testing.T) {
 	adapter := &stubAdapter{}
 	svc := newTestService(adapter)

--- a/internal/controlservice/state_helpers.go
+++ b/internal/controlservice/state_helpers.go
@@ -129,17 +129,18 @@ func cloneSandboxLocked(state *sandboxState) *cleanroomv1.Sandbox {
 		policyHash = state.Policy.Hash
 	}
 	return &cleanroomv1.Sandbox{
-		SandboxId:         state.ID,
-		Status:            state.Status,
-		Backend:           state.Backend,
-		PolicyHash:        policyHash,
-		CreatedAt:         timestamppb.New(state.CreatedAt),
-		UpdatedAt:         timestamppb.New(state.UpdatedAt),
-		LastExecutionId:   state.LastExecutionID,
-		ActiveExecutionId: state.ActiveExecutionID,
-		SourceKind:        state.SourceKind,
-		SourceId:          state.SourceID,
-		BackingSnapshotId: state.BackingSnapshotID,
+		SandboxId:          state.ID,
+		Status:             state.Status,
+		Backend:            state.Backend,
+		PolicyHash:         policyHash,
+		CreatedAt:          timestamppb.New(state.CreatedAt),
+		UpdatedAt:          timestamppb.New(state.UpdatedAt),
+		LastExecutionId:    state.LastExecutionID,
+		ActiveExecutionId:  state.ActiveExecutionID,
+		SourceKind:         state.SourceKind,
+		SourceId:           state.SourceID,
+		BackingSnapshotId:  state.BackingSnapshotID,
+		RepositoryCheckout: cloneRepositoryCheckout(state.Repository).ToProto(),
 	}
 }
 

--- a/internal/gen/cleanroom/v1/control.pb.go
+++ b/internal/gen/cleanroom/v1/control.pb.go
@@ -3974,6 +3974,7 @@ type ExecutionOptions struct {
 	LaunchSeconds                               int64                  `protobuf:"varint,5,opt,name=launch_seconds,json=launchSeconds,proto3" json:"launch_seconds,omitempty"`
 	Tty                                         bool                   `protobuf:"varint,6,opt,name=tty,proto3" json:"tty,omitempty"`
 	PreserveRepositoryChangesetPendingExecution bool                   `protobuf:"varint,8,opt,name=preserve_repository_changeset_pending_execution,json=preserveRepositoryChangesetPendingExecution,proto3" json:"preserve_repository_changeset_pending_execution,omitempty"`
+	SkipRunBefore                               bool                   `protobuf:"varint,9,opt,name=skip_run_before,json=skipRunBefore,proto3" json:"skip_run_before,omitempty"`
 	unknownFields                               protoimpl.UnknownFields
 	sizeCache                                   protoimpl.SizeCache
 }
@@ -4025,6 +4026,13 @@ func (x *ExecutionOptions) GetTty() bool {
 func (x *ExecutionOptions) GetPreserveRepositoryChangesetPendingExecution() bool {
 	if x != nil {
 		return x.PreserveRepositoryChangesetPendingExecution
+	}
+	return false
+}
+
+func (x *ExecutionOptions) GetSkipRunBefore() bool {
+	if x != nil {
+		return x.SkipRunBefore
 	}
 	return false
 }
@@ -5500,11 +5508,12 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\x03tty\x18\b \x01(\bR\x03tty\x12/\n" +
 	"\x04kind\x18\n" +
 	" \x01(\x0e2\x1b.cleanroom.v1.ExecutionKindR\x04kindJ\x04\b\t\x10\n" +
-	"R\x06run_id\"\xd7\x01\n" +
+	"R\x06run_id\"\xff\x01\n" +
 	"\x10ExecutionOptions\x12%\n" +
 	"\x0elaunch_seconds\x18\x05 \x01(\x03R\rlaunchSeconds\x12\x10\n" +
 	"\x03tty\x18\x06 \x01(\bR\x03tty\x12d\n" +
-	"/preserve_repository_changeset_pending_execution\x18\b \x01(\bR+preserveRepositoryChangesetPendingExecutionJ\x04\b\x02\x10\x03J\x04\b\a\x10\bR\x13read_only_workspaceR\x03cwd\"\xa1\x02\n" +
+	"/preserve_repository_changeset_pending_execution\x18\b \x01(\bR+preserveRepositoryChangesetPendingExecution\x12&\n" +
+	"\x0fskip_run_before\x18\t \x01(\bR\rskipRunBeforeJ\x04\b\x02\x10\x03J\x04\b\a\x10\bR\x13read_only_workspaceR\x03cwd\"\xa1\x02\n" +
 	"\x16CreateExecutionRequest\x12\x1d\n" +
 	"\n" +
 	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\x12\x18\n" +

--- a/internal/gen/cleanroom/v1/control.pb.go
+++ b/internal/gen/cleanroom/v1/control.pb.go
@@ -3970,11 +3970,12 @@ func (x *Execution) GetKind() ExecutionKind {
 }
 
 type ExecutionOptions struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	LaunchSeconds int64                  `protobuf:"varint,5,opt,name=launch_seconds,json=launchSeconds,proto3" json:"launch_seconds,omitempty"`
-	Tty           bool                   `protobuf:"varint,6,opt,name=tty,proto3" json:"tty,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state                                       protoimpl.MessageState `protogen:"open.v1"`
+	LaunchSeconds                               int64                  `protobuf:"varint,5,opt,name=launch_seconds,json=launchSeconds,proto3" json:"launch_seconds,omitempty"`
+	Tty                                         bool                   `protobuf:"varint,6,opt,name=tty,proto3" json:"tty,omitempty"`
+	PreserveRepositoryChangesetPendingExecution bool                   `protobuf:"varint,8,opt,name=preserve_repository_changeset_pending_execution,json=preserveRepositoryChangesetPendingExecution,proto3" json:"preserve_repository_changeset_pending_execution,omitempty"`
+	unknownFields                               protoimpl.UnknownFields
+	sizeCache                                   protoimpl.SizeCache
 }
 
 func (x *ExecutionOptions) Reset() {
@@ -4017,6 +4018,13 @@ func (x *ExecutionOptions) GetLaunchSeconds() int64 {
 func (x *ExecutionOptions) GetTty() bool {
 	if x != nil {
 		return x.Tty
+	}
+	return false
+}
+
+func (x *ExecutionOptions) GetPreserveRepositoryChangesetPendingExecution() bool {
+	if x != nil {
+		return x.PreserveRepositoryChangesetPendingExecution
 	}
 	return false
 }
@@ -5492,10 +5500,11 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\x03tty\x18\b \x01(\bR\x03tty\x12/\n" +
 	"\x04kind\x18\n" +
 	" \x01(\x0e2\x1b.cleanroom.v1.ExecutionKindR\x04kindJ\x04\b\t\x10\n" +
-	"R\x06run_id\"q\n" +
+	"R\x06run_id\"\xd7\x01\n" +
 	"\x10ExecutionOptions\x12%\n" +
 	"\x0elaunch_seconds\x18\x05 \x01(\x03R\rlaunchSeconds\x12\x10\n" +
-	"\x03tty\x18\x06 \x01(\bR\x03ttyJ\x04\b\x02\x10\x03J\x04\b\a\x10\bR\x13read_only_workspaceR\x03cwd\"\xa1\x02\n" +
+	"\x03tty\x18\x06 \x01(\bR\x03tty\x12d\n" +
+	"/preserve_repository_changeset_pending_execution\x18\b \x01(\bR+preserveRepositoryChangesetPendingExecutionJ\x04\b\x02\x10\x03J\x04\b\a\x10\bR\x13read_only_workspaceR\x03cwd\"\xa1\x02\n" +
 	"\x16CreateExecutionRequest\x12\x1d\n" +
 	"\n" +
 	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\x12\x18\n" +

--- a/internal/gen/cleanroom/v1/control.pb.go
+++ b/internal/gen/cleanroom/v1/control.pb.go
@@ -338,20 +338,21 @@ func (ExecutionKind) EnumDescriptor() ([]byte, []int) {
 }
 
 type Sandbox struct {
-	state             protoimpl.MessageState `protogen:"open.v1"`
-	SandboxId         string                 `protobuf:"bytes,1,opt,name=sandbox_id,json=sandboxId,proto3" json:"sandbox_id,omitempty"`
-	Status            SandboxStatus          `protobuf:"varint,2,opt,name=status,proto3,enum=cleanroom.v1.SandboxStatus" json:"status,omitempty"`
-	Backend           string                 `protobuf:"bytes,3,opt,name=backend,proto3" json:"backend,omitempty"`
-	PolicyHash        string                 `protobuf:"bytes,4,opt,name=policy_hash,json=policyHash,proto3" json:"policy_hash,omitempty"`
-	CreatedAt         *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
-	UpdatedAt         *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=updated_at,json=updatedAt,proto3" json:"updated_at,omitempty"`
-	LastExecutionId   string                 `protobuf:"bytes,7,opt,name=last_execution_id,json=lastExecutionId,proto3" json:"last_execution_id,omitempty"`
-	ActiveExecutionId string                 `protobuf:"bytes,8,opt,name=active_execution_id,json=activeExecutionId,proto3" json:"active_execution_id,omitempty"`
-	SourceKind        string                 `protobuf:"bytes,9,opt,name=source_kind,json=sourceKind,proto3" json:"source_kind,omitempty"`
-	SourceId          string                 `protobuf:"bytes,10,opt,name=source_id,json=sourceId,proto3" json:"source_id,omitempty"`
-	BackingSnapshotId string                 `protobuf:"bytes,11,opt,name=backing_snapshot_id,json=backingSnapshotId,proto3" json:"backing_snapshot_id,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	state              protoimpl.MessageState `protogen:"open.v1"`
+	SandboxId          string                 `protobuf:"bytes,1,opt,name=sandbox_id,json=sandboxId,proto3" json:"sandbox_id,omitempty"`
+	Status             SandboxStatus          `protobuf:"varint,2,opt,name=status,proto3,enum=cleanroom.v1.SandboxStatus" json:"status,omitempty"`
+	Backend            string                 `protobuf:"bytes,3,opt,name=backend,proto3" json:"backend,omitempty"`
+	PolicyHash         string                 `protobuf:"bytes,4,opt,name=policy_hash,json=policyHash,proto3" json:"policy_hash,omitempty"`
+	CreatedAt          *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	UpdatedAt          *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=updated_at,json=updatedAt,proto3" json:"updated_at,omitempty"`
+	LastExecutionId    string                 `protobuf:"bytes,7,opt,name=last_execution_id,json=lastExecutionId,proto3" json:"last_execution_id,omitempty"`
+	ActiveExecutionId  string                 `protobuf:"bytes,8,opt,name=active_execution_id,json=activeExecutionId,proto3" json:"active_execution_id,omitempty"`
+	SourceKind         string                 `protobuf:"bytes,9,opt,name=source_kind,json=sourceKind,proto3" json:"source_kind,omitempty"`
+	SourceId           string                 `protobuf:"bytes,10,opt,name=source_id,json=sourceId,proto3" json:"source_id,omitempty"`
+	BackingSnapshotId  string                 `protobuf:"bytes,11,opt,name=backing_snapshot_id,json=backingSnapshotId,proto3" json:"backing_snapshot_id,omitempty"`
+	RepositoryCheckout *RepositoryCheckout    `protobuf:"bytes,12,opt,name=repository_checkout,json=repositoryCheckout,proto3" json:"repository_checkout,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *Sandbox) Reset() {
@@ -459,6 +460,13 @@ func (x *Sandbox) GetBackingSnapshotId() string {
 		return x.BackingSnapshotId
 	}
 	return ""
+}
+
+func (x *Sandbox) GetRepositoryCheckout() *RepositoryCheckout {
+	if x != nil {
+		return x.RepositoryCheckout
+	}
+	return nil
 }
 
 type Snapshot struct {
@@ -5187,7 +5195,7 @@ var File_proto_cleanroom_v1_control_proto protoreflect.FileDescriptor
 
 const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\n" +
-	" proto/cleanroom/v1/control.proto\x12\fcleanroom.v1\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xd8\x03\n" +
+	" proto/cleanroom/v1/control.proto\x12\fcleanroom.v1\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xab\x04\n" +
 	"\aSandbox\x12\x1d\n" +
 	"\n" +
 	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\x123\n" +
@@ -5205,7 +5213,8 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"sourceKind\x12\x1b\n" +
 	"\tsource_id\x18\n" +
 	" \x01(\tR\bsourceId\x12.\n" +
-	"\x13backing_snapshot_id\x18\v \x01(\tR\x11backingSnapshotId\"\xfc\x02\n" +
+	"\x13backing_snapshot_id\x18\v \x01(\tR\x11backingSnapshotId\x12Q\n" +
+	"\x13repository_checkout\x18\f \x01(\v2 .cleanroom.v1.RepositoryCheckoutR\x12repositoryCheckout\"\xfc\x02\n" +
 	"\bSnapshot\x12\x1f\n" +
 	"\vsnapshot_id\x18\x01 \x01(\tR\n" +
 	"snapshotId\x12*\n" +
@@ -5764,119 +5773,120 @@ var file_proto_cleanroom_v1_control_proto_depIdxs = []int32{
 	0,  // 0: cleanroom.v1.Sandbox.status:type_name -> cleanroom.v1.SandboxStatus
 	81, // 1: cleanroom.v1.Sandbox.created_at:type_name -> google.protobuf.Timestamp
 	81, // 2: cleanroom.v1.Sandbox.updated_at:type_name -> google.protobuf.Timestamp
-	81, // 3: cleanroom.v1.Snapshot.created_at:type_name -> google.protobuf.Timestamp
-	16, // 4: cleanroom.v1.Snapshot.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
-	8,  // 5: cleanroom.v1.PolicyServices.docker:type_name -> cleanroom.v1.PolicyDockerService
-	10, // 6: cleanroom.v1.PolicyServices.key:type_name -> cleanroom.v1.PolicyDependencyKey
-	10, // 7: cleanroom.v1.PolicyDependencies.key:type_name -> cleanroom.v1.PolicyDependencyKey
-	7,  // 8: cleanroom.v1.Policy.allow:type_name -> cleanroom.v1.PolicyAllowRule
-	9,  // 9: cleanroom.v1.Policy.services:type_name -> cleanroom.v1.PolicyServices
-	11, // 10: cleanroom.v1.Policy.dependencies:type_name -> cleanroom.v1.PolicyDependencies
-	12, // 11: cleanroom.v1.Policy.run:type_name -> cleanroom.v1.PolicyRun
-	13, // 12: cleanroom.v1.Policy.resources:type_name -> cleanroom.v1.PolicyResources
-	17, // 13: cleanroom.v1.RepositoryChangeset.files:type_name -> cleanroom.v1.RepositoryChangesetFile
-	15, // 14: cleanroom.v1.CreateSandboxRequest.options:type_name -> cleanroom.v1.SandboxOptions
-	14, // 15: cleanroom.v1.CreateSandboxRequest.policy:type_name -> cleanroom.v1.Policy
-	16, // 16: cleanroom.v1.CreateSandboxRequest.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
-	18, // 17: cleanroom.v1.CreateSandboxRequest.repository_changeset:type_name -> cleanroom.v1.RepositoryChangeset
-	19, // 18: cleanroom.v1.CreateSandboxRequest.repository_commit_bundle:type_name -> cleanroom.v1.RepositoryCommitBundle
-	5,  // 19: cleanroom.v1.CreateSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
-	1,  // 20: cleanroom.v1.CreateSandboxEvent.phase:type_name -> cleanroom.v1.CreateSandboxPhase
-	21, // 21: cleanroom.v1.CreateSandboxEvent.response:type_name -> cleanroom.v1.CreateSandboxResponse
-	81, // 22: cleanroom.v1.CreateSandboxEvent.occurred_at:type_name -> google.protobuf.Timestamp
-	5,  // 23: cleanroom.v1.GetSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
-	5,  // 24: cleanroom.v1.ListSandboxesResponse.sandboxes:type_name -> cleanroom.v1.Sandbox
-	62, // 25: cleanroom.v1.ListExecutionsResponse.executions:type_name -> cleanroom.v1.Execution
-	2,  // 26: cleanroom.v1.SandboxPathInfo.type:type_name -> cleanroom.v1.SandboxPathType
-	81, // 27: cleanroom.v1.SandboxPathInfo.mtime:type_name -> google.protobuf.Timestamp
-	33, // 28: cleanroom.v1.StatSandboxPathResponse.info:type_name -> cleanroom.v1.SandboxPathInfo
-	33, // 29: cleanroom.v1.WalkSandboxTreeResponse.info:type_name -> cleanroom.v1.SandboxPathInfo
-	81, // 30: cleanroom.v1.WriteSandboxFileInit.mtime:type_name -> google.protobuf.Timestamp
-	40, // 31: cleanroom.v1.WriteSandboxFileRequest.init:type_name -> cleanroom.v1.WriteSandboxFileInit
-	47, // 32: cleanroom.v1.ExtractSandboxArchiveRequest.init:type_name -> cleanroom.v1.ExtractSandboxArchiveInit
-	0,  // 33: cleanroom.v1.SandboxEvent.status:type_name -> cleanroom.v1.SandboxStatus
-	81, // 34: cleanroom.v1.SandboxEvent.occurred_at:type_name -> google.protobuf.Timestamp
-	6,  // 35: cleanroom.v1.CreateSnapshotResponse.snapshot:type_name -> cleanroom.v1.Snapshot
-	6,  // 36: cleanroom.v1.GetSnapshotResponse.snapshot:type_name -> cleanroom.v1.Snapshot
-	6,  // 37: cleanroom.v1.ListSnapshotsResponse.snapshots:type_name -> cleanroom.v1.Snapshot
-	3,  // 38: cleanroom.v1.Execution.status:type_name -> cleanroom.v1.ExecutionStatus
-	81, // 39: cleanroom.v1.Execution.started_at:type_name -> google.protobuf.Timestamp
-	81, // 40: cleanroom.v1.Execution.finished_at:type_name -> google.protobuf.Timestamp
-	4,  // 41: cleanroom.v1.Execution.kind:type_name -> cleanroom.v1.ExecutionKind
-	63, // 42: cleanroom.v1.CreateExecutionRequest.options:type_name -> cleanroom.v1.ExecutionOptions
-	4,  // 43: cleanroom.v1.CreateExecutionRequest.kind:type_name -> cleanroom.v1.ExecutionKind
-	16, // 44: cleanroom.v1.CreateExecutionRequest.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
-	62, // 45: cleanroom.v1.CreateExecutionResponse.execution:type_name -> cleanroom.v1.Execution
-	81, // 46: cleanroom.v1.AttachExecutionResponse.expires_at:type_name -> google.protobuf.Timestamp
-	62, // 47: cleanroom.v1.GetExecutionResponse.execution:type_name -> cleanroom.v1.Execution
-	62, // 48: cleanroom.v1.InspectExecutionResponse.execution:type_name -> cleanroom.v1.Execution
-	82, // 49: cleanroom.v1.InspectExecutionResponse.observability:type_name -> google.protobuf.Struct
-	3,  // 50: cleanroom.v1.CancelExecutionResponse.status:type_name -> cleanroom.v1.ExecutionStatus
-	3,  // 51: cleanroom.v1.ExecutionExit.status:type_name -> cleanroom.v1.ExecutionStatus
-	3,  // 52: cleanroom.v1.ExecutionStreamEvent.status:type_name -> cleanroom.v1.ExecutionStatus
-	79, // 53: cleanroom.v1.ExecutionStreamEvent.exit:type_name -> cleanroom.v1.ExecutionExit
-	81, // 54: cleanroom.v1.ExecutionStreamEvent.occurred_at:type_name -> google.protobuf.Timestamp
-	20, // 55: cleanroom.v1.SandboxService.CreateSandbox:input_type -> cleanroom.v1.CreateSandboxRequest
-	20, // 56: cleanroom.v1.SandboxService.CreateSandboxStream:input_type -> cleanroom.v1.CreateSandboxRequest
-	23, // 57: cleanroom.v1.SandboxService.GetSandbox:input_type -> cleanroom.v1.GetSandboxRequest
-	25, // 58: cleanroom.v1.SandboxService.ListSandboxes:input_type -> cleanroom.v1.ListSandboxesRequest
-	29, // 59: cleanroom.v1.SandboxService.DownloadSandboxFile:input_type -> cleanroom.v1.DownloadSandboxFileRequest
-	31, // 60: cleanroom.v1.SandboxService.UploadSandboxFile:input_type -> cleanroom.v1.UploadSandboxFileRequest
-	34, // 61: cleanroom.v1.SandboxService.StatSandboxPath:input_type -> cleanroom.v1.StatSandboxPathRequest
-	36, // 62: cleanroom.v1.SandboxService.WalkSandboxTree:input_type -> cleanroom.v1.WalkSandboxTreeRequest
-	38, // 63: cleanroom.v1.SandboxService.ReadSandboxFile:input_type -> cleanroom.v1.ReadSandboxFileRequest
-	41, // 64: cleanroom.v1.SandboxService.WriteSandboxFile:input_type -> cleanroom.v1.WriteSandboxFileRequest
-	43, // 65: cleanroom.v1.SandboxService.RemoveSandboxPath:input_type -> cleanroom.v1.RemoveSandboxPathRequest
-	45, // 66: cleanroom.v1.SandboxService.ArchiveSandboxPaths:input_type -> cleanroom.v1.ArchiveSandboxPathsRequest
-	48, // 67: cleanroom.v1.SandboxService.ExtractSandboxArchive:input_type -> cleanroom.v1.ExtractSandboxArchiveRequest
-	50, // 68: cleanroom.v1.SandboxService.TerminateSandbox:input_type -> cleanroom.v1.TerminateSandboxRequest
-	52, // 69: cleanroom.v1.SandboxService.StreamSandboxEvents:input_type -> cleanroom.v1.StreamSandboxEventsRequest
-	54, // 70: cleanroom.v1.SnapshotService.CreateSnapshot:input_type -> cleanroom.v1.CreateSnapshotRequest
-	56, // 71: cleanroom.v1.SnapshotService.GetSnapshot:input_type -> cleanroom.v1.GetSnapshotRequest
-	58, // 72: cleanroom.v1.SnapshotService.ListSnapshots:input_type -> cleanroom.v1.ListSnapshotsRequest
-	60, // 73: cleanroom.v1.SnapshotService.DeleteSnapshot:input_type -> cleanroom.v1.DeleteSnapshotRequest
-	27, // 74: cleanroom.v1.ExecutionService.ListExecutions:input_type -> cleanroom.v1.ListExecutionsRequest
-	64, // 75: cleanroom.v1.ExecutionService.CreateExecution:input_type -> cleanroom.v1.CreateExecutionRequest
-	66, // 76: cleanroom.v1.ExecutionService.AttachExecution:input_type -> cleanroom.v1.AttachExecutionRequest
-	68, // 77: cleanroom.v1.ExecutionService.GetExecution:input_type -> cleanroom.v1.GetExecutionRequest
-	70, // 78: cleanroom.v1.ExecutionService.InspectExecution:input_type -> cleanroom.v1.InspectExecutionRequest
-	72, // 79: cleanroom.v1.ExecutionService.CancelExecution:input_type -> cleanroom.v1.CancelExecutionRequest
-	74, // 80: cleanroom.v1.ExecutionService.WriteExecutionStdin:input_type -> cleanroom.v1.WriteExecutionStdinRequest
-	76, // 81: cleanroom.v1.ExecutionService.CloseExecutionStdin:input_type -> cleanroom.v1.CloseExecutionStdinRequest
-	78, // 82: cleanroom.v1.ExecutionService.StreamExecution:input_type -> cleanroom.v1.StreamExecutionRequest
-	21, // 83: cleanroom.v1.SandboxService.CreateSandbox:output_type -> cleanroom.v1.CreateSandboxResponse
-	22, // 84: cleanroom.v1.SandboxService.CreateSandboxStream:output_type -> cleanroom.v1.CreateSandboxEvent
-	24, // 85: cleanroom.v1.SandboxService.GetSandbox:output_type -> cleanroom.v1.GetSandboxResponse
-	26, // 86: cleanroom.v1.SandboxService.ListSandboxes:output_type -> cleanroom.v1.ListSandboxesResponse
-	30, // 87: cleanroom.v1.SandboxService.DownloadSandboxFile:output_type -> cleanroom.v1.DownloadSandboxFileResponse
-	32, // 88: cleanroom.v1.SandboxService.UploadSandboxFile:output_type -> cleanroom.v1.UploadSandboxFileResponse
-	35, // 89: cleanroom.v1.SandboxService.StatSandboxPath:output_type -> cleanroom.v1.StatSandboxPathResponse
-	37, // 90: cleanroom.v1.SandboxService.WalkSandboxTree:output_type -> cleanroom.v1.WalkSandboxTreeResponse
-	39, // 91: cleanroom.v1.SandboxService.ReadSandboxFile:output_type -> cleanroom.v1.ReadSandboxFileResponse
-	42, // 92: cleanroom.v1.SandboxService.WriteSandboxFile:output_type -> cleanroom.v1.WriteSandboxFileResponse
-	44, // 93: cleanroom.v1.SandboxService.RemoveSandboxPath:output_type -> cleanroom.v1.RemoveSandboxPathResponse
-	46, // 94: cleanroom.v1.SandboxService.ArchiveSandboxPaths:output_type -> cleanroom.v1.ArchiveSandboxPathsResponse
-	49, // 95: cleanroom.v1.SandboxService.ExtractSandboxArchive:output_type -> cleanroom.v1.ExtractSandboxArchiveResponse
-	51, // 96: cleanroom.v1.SandboxService.TerminateSandbox:output_type -> cleanroom.v1.TerminateSandboxResponse
-	53, // 97: cleanroom.v1.SandboxService.StreamSandboxEvents:output_type -> cleanroom.v1.SandboxEvent
-	55, // 98: cleanroom.v1.SnapshotService.CreateSnapshot:output_type -> cleanroom.v1.CreateSnapshotResponse
-	57, // 99: cleanroom.v1.SnapshotService.GetSnapshot:output_type -> cleanroom.v1.GetSnapshotResponse
-	59, // 100: cleanroom.v1.SnapshotService.ListSnapshots:output_type -> cleanroom.v1.ListSnapshotsResponse
-	61, // 101: cleanroom.v1.SnapshotService.DeleteSnapshot:output_type -> cleanroom.v1.DeleteSnapshotResponse
-	28, // 102: cleanroom.v1.ExecutionService.ListExecutions:output_type -> cleanroom.v1.ListExecutionsResponse
-	65, // 103: cleanroom.v1.ExecutionService.CreateExecution:output_type -> cleanroom.v1.CreateExecutionResponse
-	67, // 104: cleanroom.v1.ExecutionService.AttachExecution:output_type -> cleanroom.v1.AttachExecutionResponse
-	69, // 105: cleanroom.v1.ExecutionService.GetExecution:output_type -> cleanroom.v1.GetExecutionResponse
-	71, // 106: cleanroom.v1.ExecutionService.InspectExecution:output_type -> cleanroom.v1.InspectExecutionResponse
-	73, // 107: cleanroom.v1.ExecutionService.CancelExecution:output_type -> cleanroom.v1.CancelExecutionResponse
-	75, // 108: cleanroom.v1.ExecutionService.WriteExecutionStdin:output_type -> cleanroom.v1.WriteExecutionStdinResponse
-	77, // 109: cleanroom.v1.ExecutionService.CloseExecutionStdin:output_type -> cleanroom.v1.CloseExecutionStdinResponse
-	80, // 110: cleanroom.v1.ExecutionService.StreamExecution:output_type -> cleanroom.v1.ExecutionStreamEvent
-	83, // [83:111] is the sub-list for method output_type
-	55, // [55:83] is the sub-list for method input_type
-	55, // [55:55] is the sub-list for extension type_name
-	55, // [55:55] is the sub-list for extension extendee
-	0,  // [0:55] is the sub-list for field type_name
+	16, // 3: cleanroom.v1.Sandbox.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
+	81, // 4: cleanroom.v1.Snapshot.created_at:type_name -> google.protobuf.Timestamp
+	16, // 5: cleanroom.v1.Snapshot.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
+	8,  // 6: cleanroom.v1.PolicyServices.docker:type_name -> cleanroom.v1.PolicyDockerService
+	10, // 7: cleanroom.v1.PolicyServices.key:type_name -> cleanroom.v1.PolicyDependencyKey
+	10, // 8: cleanroom.v1.PolicyDependencies.key:type_name -> cleanroom.v1.PolicyDependencyKey
+	7,  // 9: cleanroom.v1.Policy.allow:type_name -> cleanroom.v1.PolicyAllowRule
+	9,  // 10: cleanroom.v1.Policy.services:type_name -> cleanroom.v1.PolicyServices
+	11, // 11: cleanroom.v1.Policy.dependencies:type_name -> cleanroom.v1.PolicyDependencies
+	12, // 12: cleanroom.v1.Policy.run:type_name -> cleanroom.v1.PolicyRun
+	13, // 13: cleanroom.v1.Policy.resources:type_name -> cleanroom.v1.PolicyResources
+	17, // 14: cleanroom.v1.RepositoryChangeset.files:type_name -> cleanroom.v1.RepositoryChangesetFile
+	15, // 15: cleanroom.v1.CreateSandboxRequest.options:type_name -> cleanroom.v1.SandboxOptions
+	14, // 16: cleanroom.v1.CreateSandboxRequest.policy:type_name -> cleanroom.v1.Policy
+	16, // 17: cleanroom.v1.CreateSandboxRequest.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
+	18, // 18: cleanroom.v1.CreateSandboxRequest.repository_changeset:type_name -> cleanroom.v1.RepositoryChangeset
+	19, // 19: cleanroom.v1.CreateSandboxRequest.repository_commit_bundle:type_name -> cleanroom.v1.RepositoryCommitBundle
+	5,  // 20: cleanroom.v1.CreateSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
+	1,  // 21: cleanroom.v1.CreateSandboxEvent.phase:type_name -> cleanroom.v1.CreateSandboxPhase
+	21, // 22: cleanroom.v1.CreateSandboxEvent.response:type_name -> cleanroom.v1.CreateSandboxResponse
+	81, // 23: cleanroom.v1.CreateSandboxEvent.occurred_at:type_name -> google.protobuf.Timestamp
+	5,  // 24: cleanroom.v1.GetSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
+	5,  // 25: cleanroom.v1.ListSandboxesResponse.sandboxes:type_name -> cleanroom.v1.Sandbox
+	62, // 26: cleanroom.v1.ListExecutionsResponse.executions:type_name -> cleanroom.v1.Execution
+	2,  // 27: cleanroom.v1.SandboxPathInfo.type:type_name -> cleanroom.v1.SandboxPathType
+	81, // 28: cleanroom.v1.SandboxPathInfo.mtime:type_name -> google.protobuf.Timestamp
+	33, // 29: cleanroom.v1.StatSandboxPathResponse.info:type_name -> cleanroom.v1.SandboxPathInfo
+	33, // 30: cleanroom.v1.WalkSandboxTreeResponse.info:type_name -> cleanroom.v1.SandboxPathInfo
+	81, // 31: cleanroom.v1.WriteSandboxFileInit.mtime:type_name -> google.protobuf.Timestamp
+	40, // 32: cleanroom.v1.WriteSandboxFileRequest.init:type_name -> cleanroom.v1.WriteSandboxFileInit
+	47, // 33: cleanroom.v1.ExtractSandboxArchiveRequest.init:type_name -> cleanroom.v1.ExtractSandboxArchiveInit
+	0,  // 34: cleanroom.v1.SandboxEvent.status:type_name -> cleanroom.v1.SandboxStatus
+	81, // 35: cleanroom.v1.SandboxEvent.occurred_at:type_name -> google.protobuf.Timestamp
+	6,  // 36: cleanroom.v1.CreateSnapshotResponse.snapshot:type_name -> cleanroom.v1.Snapshot
+	6,  // 37: cleanroom.v1.GetSnapshotResponse.snapshot:type_name -> cleanroom.v1.Snapshot
+	6,  // 38: cleanroom.v1.ListSnapshotsResponse.snapshots:type_name -> cleanroom.v1.Snapshot
+	3,  // 39: cleanroom.v1.Execution.status:type_name -> cleanroom.v1.ExecutionStatus
+	81, // 40: cleanroom.v1.Execution.started_at:type_name -> google.protobuf.Timestamp
+	81, // 41: cleanroom.v1.Execution.finished_at:type_name -> google.protobuf.Timestamp
+	4,  // 42: cleanroom.v1.Execution.kind:type_name -> cleanroom.v1.ExecutionKind
+	63, // 43: cleanroom.v1.CreateExecutionRequest.options:type_name -> cleanroom.v1.ExecutionOptions
+	4,  // 44: cleanroom.v1.CreateExecutionRequest.kind:type_name -> cleanroom.v1.ExecutionKind
+	16, // 45: cleanroom.v1.CreateExecutionRequest.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
+	62, // 46: cleanroom.v1.CreateExecutionResponse.execution:type_name -> cleanroom.v1.Execution
+	81, // 47: cleanroom.v1.AttachExecutionResponse.expires_at:type_name -> google.protobuf.Timestamp
+	62, // 48: cleanroom.v1.GetExecutionResponse.execution:type_name -> cleanroom.v1.Execution
+	62, // 49: cleanroom.v1.InspectExecutionResponse.execution:type_name -> cleanroom.v1.Execution
+	82, // 50: cleanroom.v1.InspectExecutionResponse.observability:type_name -> google.protobuf.Struct
+	3,  // 51: cleanroom.v1.CancelExecutionResponse.status:type_name -> cleanroom.v1.ExecutionStatus
+	3,  // 52: cleanroom.v1.ExecutionExit.status:type_name -> cleanroom.v1.ExecutionStatus
+	3,  // 53: cleanroom.v1.ExecutionStreamEvent.status:type_name -> cleanroom.v1.ExecutionStatus
+	79, // 54: cleanroom.v1.ExecutionStreamEvent.exit:type_name -> cleanroom.v1.ExecutionExit
+	81, // 55: cleanroom.v1.ExecutionStreamEvent.occurred_at:type_name -> google.protobuf.Timestamp
+	20, // 56: cleanroom.v1.SandboxService.CreateSandbox:input_type -> cleanroom.v1.CreateSandboxRequest
+	20, // 57: cleanroom.v1.SandboxService.CreateSandboxStream:input_type -> cleanroom.v1.CreateSandboxRequest
+	23, // 58: cleanroom.v1.SandboxService.GetSandbox:input_type -> cleanroom.v1.GetSandboxRequest
+	25, // 59: cleanroom.v1.SandboxService.ListSandboxes:input_type -> cleanroom.v1.ListSandboxesRequest
+	29, // 60: cleanroom.v1.SandboxService.DownloadSandboxFile:input_type -> cleanroom.v1.DownloadSandboxFileRequest
+	31, // 61: cleanroom.v1.SandboxService.UploadSandboxFile:input_type -> cleanroom.v1.UploadSandboxFileRequest
+	34, // 62: cleanroom.v1.SandboxService.StatSandboxPath:input_type -> cleanroom.v1.StatSandboxPathRequest
+	36, // 63: cleanroom.v1.SandboxService.WalkSandboxTree:input_type -> cleanroom.v1.WalkSandboxTreeRequest
+	38, // 64: cleanroom.v1.SandboxService.ReadSandboxFile:input_type -> cleanroom.v1.ReadSandboxFileRequest
+	41, // 65: cleanroom.v1.SandboxService.WriteSandboxFile:input_type -> cleanroom.v1.WriteSandboxFileRequest
+	43, // 66: cleanroom.v1.SandboxService.RemoveSandboxPath:input_type -> cleanroom.v1.RemoveSandboxPathRequest
+	45, // 67: cleanroom.v1.SandboxService.ArchiveSandboxPaths:input_type -> cleanroom.v1.ArchiveSandboxPathsRequest
+	48, // 68: cleanroom.v1.SandboxService.ExtractSandboxArchive:input_type -> cleanroom.v1.ExtractSandboxArchiveRequest
+	50, // 69: cleanroom.v1.SandboxService.TerminateSandbox:input_type -> cleanroom.v1.TerminateSandboxRequest
+	52, // 70: cleanroom.v1.SandboxService.StreamSandboxEvents:input_type -> cleanroom.v1.StreamSandboxEventsRequest
+	54, // 71: cleanroom.v1.SnapshotService.CreateSnapshot:input_type -> cleanroom.v1.CreateSnapshotRequest
+	56, // 72: cleanroom.v1.SnapshotService.GetSnapshot:input_type -> cleanroom.v1.GetSnapshotRequest
+	58, // 73: cleanroom.v1.SnapshotService.ListSnapshots:input_type -> cleanroom.v1.ListSnapshotsRequest
+	60, // 74: cleanroom.v1.SnapshotService.DeleteSnapshot:input_type -> cleanroom.v1.DeleteSnapshotRequest
+	27, // 75: cleanroom.v1.ExecutionService.ListExecutions:input_type -> cleanroom.v1.ListExecutionsRequest
+	64, // 76: cleanroom.v1.ExecutionService.CreateExecution:input_type -> cleanroom.v1.CreateExecutionRequest
+	66, // 77: cleanroom.v1.ExecutionService.AttachExecution:input_type -> cleanroom.v1.AttachExecutionRequest
+	68, // 78: cleanroom.v1.ExecutionService.GetExecution:input_type -> cleanroom.v1.GetExecutionRequest
+	70, // 79: cleanroom.v1.ExecutionService.InspectExecution:input_type -> cleanroom.v1.InspectExecutionRequest
+	72, // 80: cleanroom.v1.ExecutionService.CancelExecution:input_type -> cleanroom.v1.CancelExecutionRequest
+	74, // 81: cleanroom.v1.ExecutionService.WriteExecutionStdin:input_type -> cleanroom.v1.WriteExecutionStdinRequest
+	76, // 82: cleanroom.v1.ExecutionService.CloseExecutionStdin:input_type -> cleanroom.v1.CloseExecutionStdinRequest
+	78, // 83: cleanroom.v1.ExecutionService.StreamExecution:input_type -> cleanroom.v1.StreamExecutionRequest
+	21, // 84: cleanroom.v1.SandboxService.CreateSandbox:output_type -> cleanroom.v1.CreateSandboxResponse
+	22, // 85: cleanroom.v1.SandboxService.CreateSandboxStream:output_type -> cleanroom.v1.CreateSandboxEvent
+	24, // 86: cleanroom.v1.SandboxService.GetSandbox:output_type -> cleanroom.v1.GetSandboxResponse
+	26, // 87: cleanroom.v1.SandboxService.ListSandboxes:output_type -> cleanroom.v1.ListSandboxesResponse
+	30, // 88: cleanroom.v1.SandboxService.DownloadSandboxFile:output_type -> cleanroom.v1.DownloadSandboxFileResponse
+	32, // 89: cleanroom.v1.SandboxService.UploadSandboxFile:output_type -> cleanroom.v1.UploadSandboxFileResponse
+	35, // 90: cleanroom.v1.SandboxService.StatSandboxPath:output_type -> cleanroom.v1.StatSandboxPathResponse
+	37, // 91: cleanroom.v1.SandboxService.WalkSandboxTree:output_type -> cleanroom.v1.WalkSandboxTreeResponse
+	39, // 92: cleanroom.v1.SandboxService.ReadSandboxFile:output_type -> cleanroom.v1.ReadSandboxFileResponse
+	42, // 93: cleanroom.v1.SandboxService.WriteSandboxFile:output_type -> cleanroom.v1.WriteSandboxFileResponse
+	44, // 94: cleanroom.v1.SandboxService.RemoveSandboxPath:output_type -> cleanroom.v1.RemoveSandboxPathResponse
+	46, // 95: cleanroom.v1.SandboxService.ArchiveSandboxPaths:output_type -> cleanroom.v1.ArchiveSandboxPathsResponse
+	49, // 96: cleanroom.v1.SandboxService.ExtractSandboxArchive:output_type -> cleanroom.v1.ExtractSandboxArchiveResponse
+	51, // 97: cleanroom.v1.SandboxService.TerminateSandbox:output_type -> cleanroom.v1.TerminateSandboxResponse
+	53, // 98: cleanroom.v1.SandboxService.StreamSandboxEvents:output_type -> cleanroom.v1.SandboxEvent
+	55, // 99: cleanroom.v1.SnapshotService.CreateSnapshot:output_type -> cleanroom.v1.CreateSnapshotResponse
+	57, // 100: cleanroom.v1.SnapshotService.GetSnapshot:output_type -> cleanroom.v1.GetSnapshotResponse
+	59, // 101: cleanroom.v1.SnapshotService.ListSnapshots:output_type -> cleanroom.v1.ListSnapshotsResponse
+	61, // 102: cleanroom.v1.SnapshotService.DeleteSnapshot:output_type -> cleanroom.v1.DeleteSnapshotResponse
+	28, // 103: cleanroom.v1.ExecutionService.ListExecutions:output_type -> cleanroom.v1.ListExecutionsResponse
+	65, // 104: cleanroom.v1.ExecutionService.CreateExecution:output_type -> cleanroom.v1.CreateExecutionResponse
+	67, // 105: cleanroom.v1.ExecutionService.AttachExecution:output_type -> cleanroom.v1.AttachExecutionResponse
+	69, // 106: cleanroom.v1.ExecutionService.GetExecution:output_type -> cleanroom.v1.GetExecutionResponse
+	71, // 107: cleanroom.v1.ExecutionService.InspectExecution:output_type -> cleanroom.v1.InspectExecutionResponse
+	73, // 108: cleanroom.v1.ExecutionService.CancelExecution:output_type -> cleanroom.v1.CancelExecutionResponse
+	75, // 109: cleanroom.v1.ExecutionService.WriteExecutionStdin:output_type -> cleanroom.v1.WriteExecutionStdinResponse
+	77, // 110: cleanroom.v1.ExecutionService.CloseExecutionStdin:output_type -> cleanroom.v1.CloseExecutionStdinResponse
+	80, // 111: cleanroom.v1.ExecutionService.StreamExecution:output_type -> cleanroom.v1.ExecutionStreamEvent
+	84, // [84:112] is the sub-list for method output_type
+	56, // [56:84] is the sub-list for method input_type
+	56, // [56:56] is the sub-list for extension type_name
+	56, // [56:56] is the sub-list for extension extendee
+	0,  // [0:56] is the sub-list for field type_name
 }
 
 func init() { file_proto_cleanroom_v1_control_proto_init() }

--- a/internal/repositorychangeset/changeset.go
+++ b/internal/repositorychangeset/changeset.go
@@ -343,6 +343,25 @@ func ApplyCommandResettingCheckout(checkout *repositorycheckout.Checkout, change
 	return applyCommand(checkout, changeset, true)
 }
 
+func ResetCommand(checkout *repositorycheckout.Checkout) []string {
+	if checkout == nil {
+		return nil
+	}
+	baseCommitSHA := strings.ToLower(strings.TrimSpace(checkout.CommitSHA))
+	if baseCommitSHA == "" {
+		return nil
+	}
+	script := []string{
+		"set -eu",
+		"dest=" + shellQuote(checkout.DestinationDir),
+		"base_commit=" + shellQuote(baseCommitSHA),
+		`if [ ! -d "$dest/.git" ]; then echo "repository destination is not a git checkout: $dest" >&2; exit 1; fi`,
+		`git -C "$dest" reset --hard "$base_commit" >/dev/null`,
+		`git -C "$dest" clean -fd >/dev/null`,
+	}
+	return []string{"sh", "-lc", strings.Join(script, "\n")}
+}
+
 func applyCommand(checkout *repositorycheckout.Checkout, changeset *Changeset, resetCheckout bool) []string {
 	if checkout == nil || changeset == nil {
 		return nil

--- a/internal/repositorychangeset/changeset.go
+++ b/internal/repositorychangeset/changeset.go
@@ -357,7 +357,7 @@ func ResetCommand(checkout *repositorycheckout.Checkout) []string {
 		"base_commit=" + shellQuote(baseCommitSHA),
 		`if [ ! -d "$dest/.git" ]; then echo "repository destination is not a git checkout: $dest" >&2; exit 1; fi`,
 		`git -C "$dest" reset --hard "$base_commit" >/dev/null`,
-		`git -C "$dest" clean -fd >/dev/null`,
+		`git -C "$dest" clean -ffd >/dev/null`,
 	}
 	return []string{"sh", "-lc", strings.Join(script, "\n")}
 }
@@ -376,7 +376,7 @@ func applyCommand(checkout *repositorycheckout.Checkout, changeset *Changeset, r
 	if resetCheckout {
 		script = append(script,
 			`git -C "$dest" reset --hard "$base_commit" >/dev/null`,
-			`git -C "$dest" clean -fd >/dev/null`,
+			`git -C "$dest" clean -ffd >/dev/null`,
 		)
 	}
 	script = append(script,

--- a/internal/repositorychangeset/changeset.go
+++ b/internal/repositorychangeset/changeset.go
@@ -336,14 +336,31 @@ func (c *Changeset) ChangedFileDigest(path string) (digest string, deleted, ok b
 }
 
 func ApplyCommand(checkout *repositorycheckout.Checkout, changeset *Changeset) []string {
+	return applyCommand(checkout, changeset, false)
+}
+
+func ApplyCommandResettingCheckout(checkout *repositorycheckout.Checkout, changeset *Changeset) []string {
+	return applyCommand(checkout, changeset, true)
+}
+
+func applyCommand(checkout *repositorycheckout.Checkout, changeset *Changeset, resetCheckout bool) []string {
 	if checkout == nil || changeset == nil {
 		return nil
 	}
 	script := []string{
 		"set -eu",
 		"dest=" + shellQuote(checkout.DestinationDir),
+		"base_commit=" + shellQuote(changeset.BaseCommitSHA),
 		"expected_tree=" + shellQuote(changeset.TreeDigest),
 		`if [ ! -d "$dest/.git" ]; then echo "repository destination is not a git checkout: $dest" >&2; exit 1; fi`,
+	}
+	if resetCheckout {
+		script = append(script,
+			`git -C "$dest" reset --hard "$base_commit" >/dev/null`,
+			`git -C "$dest" clean -fd >/dev/null`,
+		)
+	}
+	script = append(script,
 		`patch_file="$(mktemp)"`,
 		`index_file="$(mktemp)"`,
 		`cleanup() { rm -f "$patch_file" "$index_file"; }`,
@@ -354,7 +371,7 @@ func ApplyCommand(checkout *repositorycheckout.Checkout, changeset *Changeset) [
 		`GIT_INDEX_FILE="$index_file" git -C "$dest" add -A --all .`,
 		`got_tree="$(GIT_INDEX_FILE="$index_file" git -C "$dest" write-tree)"`,
 		`if [ "$got_tree" != "$expected_tree" ]; then echo "repository changeset tree mismatch: expected $expected_tree got $got_tree" >&2; exit 1; fi`,
-	}
+	)
 	return []string{"sh", "-lc", strings.Join(script, "\n")}
 }
 

--- a/internal/repositorychangeset/changeset_test.go
+++ b/internal/repositorychangeset/changeset_test.go
@@ -300,6 +300,28 @@ func TestDigestPathsFromBaseUsesPatchedContents(t *testing.T) {
 	}
 }
 
+func TestResetCommandsUseDoubleForceClean(t *testing.T) {
+	checkout := &repositorycheckout.Checkout{
+		CommitSHA:      "0123456789abcdef0123456789abcdef01234567",
+		DestinationDir: "/workspace",
+	}
+	changeset := &Changeset{
+		BaseCommitSHA: checkout.CommitSHA,
+		TreeDigest:    "89abcdef0123456789abcdef0123456789abcdef",
+		Patch:         []byte("diff --git a/README.md b/README.md\n"),
+	}
+
+	resetCommand := strings.Join(ResetCommand(checkout), "\n")
+	if !strings.Contains(resetCommand, `git -C "$dest" clean -ffd >/dev/null`) {
+		t.Fatalf("expected reset command to double-force clean, got %q", resetCommand)
+	}
+
+	applyCommand := strings.Join(ApplyCommandResettingCheckout(checkout, changeset), "\n")
+	if !strings.Contains(applyCommand, `git -C "$dest" clean -ffd >/dev/null`) {
+		t.Fatalf("expected apply-reset command to double-force clean, got %q", applyCommand)
+	}
+}
+
 func initGitRepository(t *testing.T) string {
 	t.Helper()
 

--- a/proto/cleanroom/v1/control.proto
+++ b/proto/cleanroom/v1/control.proto
@@ -469,6 +469,7 @@ message ExecutionOptions {
   int64 launch_seconds = 5;
   bool tty = 6;
   bool preserve_repository_changeset_pending_execution = 8;
+  bool skip_run_before = 9;
 }
 
 message CreateExecutionRequest {

--- a/proto/cleanroom/v1/control.proto
+++ b/proto/cleanroom/v1/control.proto
@@ -468,6 +468,7 @@ message ExecutionOptions {
   reserved "read_only_workspace", "cwd";
   int64 launch_seconds = 5;
   bool tty = 6;
+  bool preserve_repository_changeset_pending_execution = 8;
 }
 
 message CreateExecutionRequest {

--- a/proto/cleanroom/v1/control.proto
+++ b/proto/cleanroom/v1/control.proto
@@ -56,6 +56,7 @@ message Sandbox {
   string source_kind = 9;
   string source_id = 10;
   string backing_snapshot_id = 11;
+  RepositoryCheckout repository_checkout = 12;
 }
 
 message Snapshot {


### PR DESCRIPTION
## Summary

- Rename the top-level local-workspace flag to `--copy-in` and the manual workspace command to `cleanroom workspace copy-in`.
- Update the workspace plan around directional `copy-in`, `copy-out`, and `--sync` semantics, replacing the old copy/export wording.
- Align adjacent plan docs that referenced workspace export or `--include-local-changes` as the active spelling.
- Keep Git-backed copy-in behavior on repository changesets and non-Git manual copy-in on raw workspace transfer, with the top-level non-Git guard unchanged.
- Document Git ignore handling so ignored dependency/runtime trees like `node_modules/` are not copied in or copied out by default.

## Validation

- `mise x -- go test ./internal/cli`
- `mise x -- go test ./...`
- `git diff --check`
