### PR TITLE
fix: Add libatomic to Debian base images

### DIFF
--- a/images/Dockerfile.base-image-debian
+++ b/images/Dockerfile.base-image-debian
@@ -9,6 +9,7 @@ RUN apt-get update \
       curl \
       git \
       iproute2 \
+      libatomic1 \
       openssh-client \
       strace \
     && rm -rf /var/lib/apt/lists/*

--- a/images/Dockerfile.base-image-debian-agents
+++ b/images/Dockerfile.base-image-debian-agents
@@ -13,6 +13,7 @@ RUN apt-get update \
       curl \
       git \
       iproute2 \
+      libatomic1 \
       openssh-client \
       python3 \
       strace \

--- a/images/Dockerfile.base-image-debian-docker
+++ b/images/Dockerfile.base-image-debian-docker
@@ -10,6 +10,7 @@ RUN apt-get update \
       docker.io \
       git \
       iproute2 \
+      libatomic1 \
       openssh-client \
       strace \
     && rm -rf /var/lib/apt/lists/*

--- a/images/Dockerfile.base-image-debian-ruby
+++ b/images/Dockerfile.base-image-debian-ruby
@@ -11,6 +11,7 @@ RUN apt-get update \
       default-libmysqlclient-dev \
       git \
       iproute2 \
+      libatomic1 \
       libffi-dev \
       libgdbm-dev \
       libncurses-dev \

--- a/images/dockerfiles_test.go
+++ b/images/dockerfiles_test.go
@@ -140,6 +140,25 @@ func TestDebianRubyBaseImageInstallsDefaultLibMySQLClientDev(t *testing.T) {
 	}
 }
 
+func TestDebianBaseImagesInstallLibatomicForMiseManagedNode(t *testing.T) {
+	t.Parallel()
+
+	for _, relPath := range debianPublishedBaseDockerfiles() {
+		relPath := relPath
+		t.Run(relPath, func(t *testing.T) {
+			t.Parallel()
+
+			raw, err := os.ReadFile(filepath.Join(".", relPath))
+			if err != nil {
+				t.Fatalf("read %s: %v", relPath, err)
+			}
+			if !dockerfileHasTrimmedLine(string(raw), "libatomic1 \\") {
+				t.Fatalf("%s does not install libatomic1 for mise-managed Node.js on arm64", relPath)
+			}
+		})
+	}
+}
+
 func TestPublishedBaseImagesInstallPinnedMiseRelease(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Adds `libatomic1` to the Debian published base images.

Mise-managed Node.js on arm64 can download and extract successfully but then fail at runtime with:

```text
libatomic.so.1: cannot open shared object file
```

Installing `libatomic1` in the Debian base, Docker, Ruby, and agents images gives Node-based agent tooling the runtime library it expects.

## Testing

- `mise exec -- go test ./images`
