### PR TITLE
fix: Record cached gateway decisions

### DIFF
--- a/internal/gateway/git_cached.go
+++ b/internal/gateway/git_cached.go
@@ -44,14 +44,17 @@ func (h *cachedGitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if !gitRequestUsesDotGit(repoPath) {
 		if h.fallback == nil {
+			setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonUpstreamError)
 			writeReasonError(w, http.StatusBadGateway, reasonUpstreamError, "git cache fallback is not configured for non-.git remotes")
 			return
 		}
+		setGatewayRequestDecision(r.Context(), gatewayActionAllow, reasonFallback)
 		h.fallback.ServeHTTP(w, r)
 		return
 	}
 
 	if !scope.Policy.Allows(upstreamHost, 443) {
+		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonHostNotAllowed)
 		h.auditLog(r.Context(), scope.SandboxID, upstreamHost, repoPath, gatewayActionDeny, reasonHostNotAllowed)
 		writeReasonError(w, http.StatusForbidden, reasonHostNotAllowed, "upstream host is not allowed by sandbox policy")
 		return
@@ -59,6 +62,7 @@ func (h *cachedGitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Classify the request to reject pushes before hitting the cache layer.
 	if _, err := classifyGitRequest(r.Method, repoPath, r.URL.RawQuery); err != nil {
+		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonMethodNotAllowed)
 		h.auditLog(r.Context(), scope.SandboxID, upstreamHost, repoPath, gatewayActionDeny, reasonMethodNotAllowed)
 		writeReasonError(w, http.StatusForbidden, reasonMethodNotAllowed, err.Error())
 		return
@@ -68,18 +72,22 @@ func (h *cachedGitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		if errors.Is(err, errGitHostNotConfiguredForCaching) {
 			if h.fallback == nil {
+				setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonUpstreamError)
 				h.auditLog(r.Context(), scope.SandboxID, upstreamHost, repoPath, gatewayActionDeny, reasonUpstreamError)
 				writeReasonError(w, http.StatusBadGateway, reasonUpstreamError, fmt.Sprintf("git cache fallback is not configured for %s", upstreamHost))
 				return
 			}
+			setGatewayRequestDecision(r.Context(), gatewayActionAllow, reasonFallback)
 			h.auditLog(r.Context(), scope.SandboxID, upstreamHost, repoPath, gatewayActionAllow, reasonFallback)
 			h.fallback.ServeHTTP(w, r)
 			return
 		}
+		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonUpstreamError)
 		h.auditLog(r.Context(), scope.SandboxID, upstreamHost, repoPath, gatewayActionDeny, reasonUpstreamError)
 		writeReasonError(w, http.StatusBadGateway, reasonUpstreamError, fmt.Sprintf("git cache handler unavailable for %s: %v", upstreamHost, err))
 		return
 	}
+	setGatewayRequestDecision(r.Context(), gatewayActionAllow, reasonCached)
 	h.auditLog(r.Context(), scope.SandboxID, upstreamHost, repoPath, gatewayActionAllow, reasonCached)
 
 	// content-cache's git handler expects paths like /{host}/{repo}.git/...

--- a/internal/gateway/git_cached_test.go
+++ b/internal/gateway/git_cached_test.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -37,6 +38,26 @@ func cachedGitTestScope() *SandboxScope {
 	}
 }
 
+func withGatewayRequestObservability(r *http.Request) (*http.Request, *gatewayRequestObservability) {
+	obs := &gatewayRequestObservability{}
+	ctx := context.WithValue(r.Context(), gatewayRequestContextKey, obs)
+	return r.WithContext(ctx), obs
+}
+
+func requireGatewayRequestDecision(t *testing.T, obs *gatewayRequestObservability, action, reason string) {
+	t.Helper()
+
+	if obs == nil {
+		t.Fatal("missing gateway request observability")
+	}
+	if obs.action != action {
+		t.Fatalf("expected gateway action %q, got %q", action, obs.action)
+	}
+	if obs.reasonCode != reason {
+		t.Fatalf("expected gateway reason %q, got %q", reason, obs.reasonCode)
+	}
+}
+
 func TestCachedGitHandlerPolicyDeniesUnallowedHost(t *testing.T) {
 	t.Parallel()
 
@@ -47,6 +68,7 @@ func TestCachedGitHandlerPolicyDeniesUnallowedHost(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/git/evil.com/org/repo.git/info/refs?service=git-upload-pack", nil)
 	req = withScope(req, cachedGitTestScope())
+	req, obs := withGatewayRequestObservability(req)
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 
@@ -56,6 +78,7 @@ func TestCachedGitHandlerPolicyDeniesUnallowedHost(t *testing.T) {
 	if got := w.Header().Get(reasonCodeHeader); got != reasonHostNotAllowed {
 		t.Fatalf("expected reason %s, got %q", reasonHostNotAllowed, got)
 	}
+	requireGatewayRequestDecision(t, obs, gatewayActionDeny, reasonHostNotAllowed)
 }
 
 func TestCachedGitHandlerRejectsReceivePack(t *testing.T) {
@@ -68,12 +91,14 @@ func TestCachedGitHandlerRejectsReceivePack(t *testing.T) {
 
 	req := httptest.NewRequest("POST", "/git/github.com/org/repo.git/git-receive-pack", nil)
 	req = withScope(req, cachedGitTestScope())
+	req, obs := withGatewayRequestObservability(req)
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("expected 403, got %d", w.Code)
 	}
+	requireGatewayRequestDecision(t, obs, gatewayActionDeny, reasonMethodNotAllowed)
 }
 
 func TestCachedGitHandlerNoScope(t *testing.T) {
@@ -106,6 +131,7 @@ func TestCachedGitHandlerStripsGitPrefixAndDelegates(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/git/github.com/org/repo.git/info/refs?service=git-upload-pack", nil)
 	req = withScope(req, cachedGitTestScope())
+	req, obs := withGatewayRequestObservability(req)
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 
@@ -118,6 +144,7 @@ func TestCachedGitHandlerStripsGitPrefixAndDelegates(t *testing.T) {
 	if provider.host != "github.com" {
 		t.Fatalf("expected git cache host github.com, got %q", provider.host)
 	}
+	requireGatewayRequestDecision(t, obs, gatewayActionAllow, reasonCached)
 }
 
 func TestCachedGitHandlerUploadPackDelegates(t *testing.T) {
@@ -134,6 +161,7 @@ func TestCachedGitHandlerUploadPackDelegates(t *testing.T) {
 
 	req := httptest.NewRequest("POST", "/git/github.com/org/repo.git/git-upload-pack", nil)
 	req = withScope(req, cachedGitTestScope())
+	req, obs := withGatewayRequestObservability(req)
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 
@@ -149,6 +177,7 @@ func TestCachedGitHandlerUploadPackDelegates(t *testing.T) {
 	if provider.host != "github.com" {
 		t.Fatalf("expected git cache host github.com, got %q", provider.host)
 	}
+	requireGatewayRequestDecision(t, obs, gatewayActionAllow, reasonCached)
 }
 
 func TestCachedGitHandlerFallsBackForUnconfiguredCacheHost(t *testing.T) {
@@ -177,6 +206,7 @@ func TestCachedGitHandlerFallsBackForUnconfiguredCacheHost(t *testing.T) {
 			},
 		},
 	})
+	req, obs := withGatewayRequestObservability(req)
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 
@@ -192,6 +222,7 @@ func TestCachedGitHandlerFallsBackForUnconfiguredCacheHost(t *testing.T) {
 	if provider.host != "github.enterprise.test" {
 		t.Fatalf("expected cache host lookup for github.enterprise.test, got %q", provider.host)
 	}
+	requireGatewayRequestDecision(t, obs, gatewayActionAllow, reasonFallback)
 }
 
 func TestCachedGitHandlerFallsBackForNonDotGitRemotes(t *testing.T) {
@@ -212,6 +243,7 @@ func TestCachedGitHandlerFallsBackForNonDotGitRemotes(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/git/github.com/org/repo/info/refs?service=git-upload-pack", nil)
 	req = withScope(req, cachedGitTestScope())
+	req, obs := withGatewayRequestObservability(req)
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 
@@ -227,4 +259,5 @@ func TestCachedGitHandlerFallsBackForNonDotGitRemotes(t *testing.T) {
 	if provider.host != "" {
 		t.Fatalf("expected cache host lookup to be skipped, got %q", provider.host)
 	}
+	requireGatewayRequestDecision(t, obs, gatewayActionAllow, reasonFallback)
 }

--- a/internal/gateway/rubygems_cached.go
+++ b/internal/gateway/rubygems_cached.go
@@ -34,17 +34,20 @@ func (h *cachedRubyGemsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	}
 
 	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonMethodNotAllowed)
 		writeReasonError(w, http.StatusMethodNotAllowed, reasonMethodNotAllowed, "only GET and HEAD are permitted for rubygems")
 		return
 	}
 
 	policyHost, policyPort, upstreamHost, _, err := h.cache.RubyGemsUpstream()
 	if err != nil {
+		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonUpstreamError)
 		h.auditLog(r.Context(), scope.SandboxID, "rubygems", gatewayActionDeny, reasonRubyGemsUnavailable)
 		writeReasonError(w, http.StatusBadGateway, reasonUpstreamError, "rubygems cache is not configured")
 		return
 	}
 	if !scope.Policy.Allows(policyHost, policyPort) {
+		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonHostNotAllowed)
 		h.auditLog(r.Context(), scope.SandboxID, policyHost, gatewayActionDeny, reasonHostNotAllowed)
 		writeReasonError(w, http.StatusForbidden, reasonHostNotAllowed, "upstream rubygems host is not allowed by sandbox policy")
 		return
@@ -52,11 +55,13 @@ func (h *cachedRubyGemsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 
 	handler, err := h.cache.RubyGemsHandler()
 	if err != nil {
+		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonUpstreamError)
 		h.auditLog(r.Context(), scope.SandboxID, "rubygems", gatewayActionDeny, reasonRubyGemsUnavailable)
 		writeReasonError(w, http.StatusBadGateway, reasonUpstreamError, "rubygems cache is not configured")
 		return
 	}
 
+	setGatewayRequestDecision(r.Context(), gatewayActionAllow, reasonCached)
 	h.auditLog(r.Context(), scope.SandboxID, upstreamHost, gatewayActionAllow, reasonCached)
 
 	r = r.Clone(r.Context())

--- a/internal/gateway/rubygems_cached_test.go
+++ b/internal/gateway/rubygems_cached_test.go
@@ -48,6 +48,7 @@ func TestCachedRubyGemsHandlerStripsPrefixAndDelegates(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/rubygems/versions", nil)
 	req = withScope(req, registryTestScope("rubygems.org"))
+	req, obs := withGatewayRequestObservability(req)
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 
@@ -57,6 +58,7 @@ func TestCachedRubyGemsHandlerStripsPrefixAndDelegates(t *testing.T) {
 	if want := "/versions"; capturedPath != want {
 		t.Fatalf("expected backend path %q, got %q", want, capturedPath)
 	}
+	requireGatewayRequestDecision(t, obs, gatewayActionAllow, reasonCached)
 }
 
 func TestCachedRubyGemsHandlerDeniesUnallowedHost(t *testing.T) {
@@ -75,6 +77,7 @@ func TestCachedRubyGemsHandlerDeniesUnallowedHost(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/rubygems/versions", nil)
 	req = withScope(req, registryTestScope("github.com"))
+	req, obs := withGatewayRequestObservability(req)
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 
@@ -84,6 +87,7 @@ func TestCachedRubyGemsHandlerDeniesUnallowedHost(t *testing.T) {
 	if got := w.Header().Get(reasonCodeHeader); got != reasonHostNotAllowed {
 		t.Fatalf("expected reason %s, got %q", reasonHostNotAllowed, got)
 	}
+	requireGatewayRequestDecision(t, obs, gatewayActionDeny, reasonHostNotAllowed)
 }
 
 func TestCachedRubyGemsHandlerRejectsPost(t *testing.T) {
@@ -101,12 +105,14 @@ func TestCachedRubyGemsHandlerRejectsPost(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, "/rubygems/versions", nil)
 	req = withScope(req, registryTestScope("rubygems.org"))
+	req, obs := withGatewayRequestObservability(req)
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 
 	if w.Code != http.StatusMethodNotAllowed {
 		t.Fatalf("expected 405, got %d", w.Code)
 	}
+	requireGatewayRequestDecision(t, obs, gatewayActionDeny, reasonMethodNotAllowed)
 }
 
 func TestCachedRubyGemsHandlerNoScope(t *testing.T) {
@@ -138,10 +144,12 @@ func TestCachedRubyGemsHandlerUnavailable(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/rubygems/versions", nil)
 	req = withScope(req, registryTestScope("rubygems.org"))
+	req, obs := withGatewayRequestObservability(req)
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 
 	if w.Code != http.StatusBadGateway {
 		t.Fatalf("expected 502, got %d", w.Code)
 	}
+	requireGatewayRequestDecision(t, obs, gatewayActionDeny, reasonUpstreamError)
 }

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -423,8 +423,12 @@ func (s *Server) tracingMiddleware(next http.Handler) http.Handler {
 		if reasonCode != "" {
 			span.SetAttributes(attribute.String(observability.AttrReasonCode, reasonCode))
 		}
+		action := strings.TrimSpace(requestObs.action)
+		if action != "" {
+			span.SetAttributes(attribute.String(observability.AttrGatewayAction, action))
+		}
 		if metrics := s.gatewayMetrics(); metrics != nil {
-			metrics.RecordRequest(ctx, service, requestObs.action, reasonCode, status.statusCode, time.Since(startedAt))
+			metrics.RecordRequest(ctx, service, action, reasonCode, status.statusCode, time.Since(startedAt))
 		}
 		if status.statusCode >= http.StatusBadRequest {
 			span.SetStatus(codes.Error, http.StatusText(status.statusCode))

--- a/internal/gateway/server_test.go
+++ b/internal/gateway/server_test.go
@@ -199,7 +199,14 @@ func TestTracingMiddlewareEmitsGatewayMetrics(t *testing.T) {
 		_ = meterProvider.Shutdown(context.Background())
 	}()
 
-	srv := NewServer(ServerConfig{Registry: reg, MeterProvider: meterProvider})
+	recorder := tracetest.NewSpanRecorder()
+	tracerProvider := sdktrace.NewTracerProvider()
+	tracerProvider.RegisterSpanProcessor(recorder)
+	defer func() {
+		_ = tracerProvider.Shutdown(context.Background())
+	}()
+
+	srv := NewServer(ServerConfig{Registry: reg, TracerProvider: tracerProvider, MeterProvider: meterProvider})
 	handler := srv.identityMiddleware(srv.pathMiddleware(srv.tracingMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		setGatewayRequestDecision(r.Context(), "allow", "proxied")
 		w.WriteHeader(http.StatusNoContent)
@@ -225,6 +232,21 @@ func TestTracingMiddlewareEmitsGatewayMetrics(t *testing.T) {
 		"service": "git",
 		"action":  "allow",
 	}, 1)
+
+	spans := recorder.Ended()
+	var gatewaySpan sdktrace.ReadOnlySpan
+	for _, span := range spans {
+		if span.Name() == "cleanroom.gateway.git.request" {
+			gatewaySpan = span
+			break
+		}
+	}
+	if gatewaySpan == nil {
+		t.Fatalf("expected gateway span, got spans %#v", spans)
+	}
+	if got := spanAttributeValue(gatewaySpan, "cleanroom.gateway.action"); got != "allow" {
+		t.Fatalf("expected cleanroom.gateway.action=allow, got %q", got)
+	}
 }
 
 func TestGatewayStatusRecorderUnwrapsResponseWriterForResponseController(t *testing.T) {


### PR DESCRIPTION
## Summary
- record gateway request decisions for cached Git allow, deny, method-denied, and fallback branches
- record gateway request decisions for cached RubyGems allow, deny, method-denied, and unavailable branches
- copy recorded request actions onto gateway spans so the shared middleware drives both metrics and span attributes

## Tests
- `git diff --check`
- `mise exec -- go test ./internal/gateway`
- `mise exec -- go test ./...`