### PR TITLE
fix: Use loopback-only scope-token default

### DIFF
--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -28,10 +28,13 @@ Inside sandboxes, the shared gateway is exposed at
 ## Sandbox identity
 
 On `firecracker`, the gateway identifies the sandbox from the guest source IP.
-On `darwin-vz`, guests share NAT, so requests use the
-`X-Cleanroom-Scope-Token` header. The gateway normally restricts that header to
-configured gateway-source prefixes, but falls back to allowing it from any
-source if gateway-host resolution is unavailable.
+On `darwin-vz`, the file-handle gateway bridge forwards requests with the
+`X-Cleanroom-Scope-Token` header. The gateway accepts scope-token requests from
+loopback by default, which covers the host-local file-handle bridge. When a
+gateway host is configured, Cleanroom derives additional trusted IPv4 `/24` or
+IPv6 `/64` prefixes from that host or its resolved addresses. If gateway-host
+resolution fails or returns no addresses, Cleanroom falls back to loopback-only
+scope-token trust rather than accepting scope tokens from arbitrary sources.
 
 ## Git proxy
 

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -70,15 +70,11 @@ type gatewayRequestObservability struct {
 }
 
 // ScopeTokenHeader is the request header used for capability-token fallback
-// identity when source-IP identity is unavailable (for example darwin NAT).
+// identity when source-IP identity is unavailable.
 const ScopeTokenHeader = "X-Cleanroom-Scope-Token"
 
-var defaultDarwinVZScopeTokenSourcePrefix = netip.MustParsePrefix("192.168.64.0/24")
-
 func defaultScopeTokenSourcePolicy() ScopeTokenSourcePolicy {
-	return ScopeTokenSourcePolicy{
-		TrustedSourcePrefixes: []netip.Prefix{defaultDarwinVZScopeTokenSourcePrefix},
-	}
+	return ScopeTokenSourcePolicy{}
 }
 
 // ScopeFromContext retrieves the SandboxScope injected by identity middleware.

--- a/internal/gateway/server_test.go
+++ b/internal/gateway/server_test.go
@@ -336,7 +336,7 @@ func gatewayMetricAttributesMatch(set attribute.Set, want map[string]string) boo
 	return true
 }
 
-func TestIdentityMiddlewareFallsBackToScopeToken(t *testing.T) {
+func TestIdentityMiddlewareFallsBackToScopeTokenFromLoopback(t *testing.T) {
 	t.Parallel()
 
 	reg := NewRegistry()
@@ -353,7 +353,7 @@ func TestIdentityMiddlewareFallsBackToScopeToken(t *testing.T) {
 	handler := srv.identityMiddleware(inner)
 
 	req := httptest.NewRequest("GET", "/test", nil)
-	req.RemoteAddr = "192.168.64.10:12345"
+	req.RemoteAddr = "127.0.0.1:12345"
 	req.Header.Set(ScopeTokenHeader, "token-1")
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, req)
@@ -419,7 +419,7 @@ func TestIdentityMiddlewareFallsBackToScopeTokenWhenSourceTrustIsDisabled(t *tes
 	handler := srv.identityMiddleware(inner)
 
 	req := httptest.NewRequest("GET", "/test", nil)
-	req.RemoteAddr = "172.16.1.100:12345"
+	req.RemoteAddr = "192.168.64.10:12345"
 	req.Header.Set(ScopeTokenHeader, "token-1")
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, req)
@@ -492,7 +492,7 @@ func TestScopeTokenTrustedSourcePrefixesForGatewayHost(t *testing.T) {
 		{
 			name: "default host",
 			host: "",
-			want: []netip.Prefix{netip.MustParsePrefix("192.168.64.0/24")},
+			want: nil,
 		},
 		{
 			name: "configured ipv4 host",
@@ -552,7 +552,7 @@ func TestScopeTokenTrustedSourcePrefixesForGatewayHostResolvesHostnames(t *testi
 	}
 }
 
-func TestScopeTokenSourcePolicyForGatewayHostFallsBackToDefaultPrefixesOnLookupFailure(t *testing.T) {
+func TestScopeTokenSourcePolicyForGatewayHostFallsBackToLoopbackOnlyOnLookupFailure(t *testing.T) {
 	t.Parallel()
 
 	got := scopeTokenSourcePolicyForGatewayHost(context.Background(), "gateway.local", func(context.Context, string) ([]net.IP, error) {
@@ -562,18 +562,12 @@ func TestScopeTokenSourcePolicyForGatewayHostFallsBackToDefaultPrefixesOnLookupF
 	if got.AllowScopeTokenFromAnySource {
 		t.Fatal("did not expect source trust to be disabled on lookup failure")
 	}
-	want := []netip.Prefix{netip.MustParsePrefix("192.168.64.0/24")}
-	if len(got.TrustedSourcePrefixes) != len(want) {
-		t.Fatalf("len(prefixes) = %d, want %d", len(got.TrustedSourcePrefixes), len(want))
-	}
-	for i := range got.TrustedSourcePrefixes {
-		if got.TrustedSourcePrefixes[i] != want[i] {
-			t.Fatalf("prefix[%d] = %s, want %s", i, got.TrustedSourcePrefixes[i], want[i])
-		}
+	if len(got.TrustedSourcePrefixes) != 0 {
+		t.Fatalf("expected no trusted source prefixes on lookup failure, got %v", got.TrustedSourcePrefixes)
 	}
 }
 
-func TestScopeTokenSourcePolicyForGatewayHostFallsBackToDefaultPrefixesOnEmptyLookup(t *testing.T) {
+func TestScopeTokenSourcePolicyForGatewayHostFallsBackToLoopbackOnlyOnEmptyLookup(t *testing.T) {
 	t.Parallel()
 
 	got := scopeTokenSourcePolicyForGatewayHost(context.Background(), "gateway.local", func(context.Context, string) ([]net.IP, error) {
@@ -583,14 +577,8 @@ func TestScopeTokenSourcePolicyForGatewayHostFallsBackToDefaultPrefixesOnEmptyLo
 	if got.AllowScopeTokenFromAnySource {
 		t.Fatal("did not expect source trust to be disabled on empty lookup")
 	}
-	want := []netip.Prefix{netip.MustParsePrefix("192.168.64.0/24")}
-	if len(got.TrustedSourcePrefixes) != len(want) {
-		t.Fatalf("len(prefixes) = %d, want %d", len(got.TrustedSourcePrefixes), len(want))
-	}
-	for i := range got.TrustedSourcePrefixes {
-		if got.TrustedSourcePrefixes[i] != want[i] {
-			t.Fatalf("prefix[%d] = %s, want %s", i, got.TrustedSourcePrefixes[i], want[i])
-		}
+	if len(got.TrustedSourcePrefixes) != 0 {
+		t.Fatalf("expected no trusted source prefixes on empty lookup, got %v", got.TrustedSourcePrefixes)
 	}
 }
 


### PR DESCRIPTION
## Summary
- remove the stale `192.168.64.0/24` default trusted scope-token source prefix
- keep scope-token requests trusted from loopback by default for the darwin-vz file-handle bridge
- preserve configured gateway-host derived IPv4 `/24` and IPv6 `/64` trusted prefixes when explicitly configured
- update gateway docs to describe the loopback-only fallback behavior

## Tests
- `git diff --check`
- `mise exec -- go test ./internal/gateway`
- `mise exec -- go test ./...`