### PR TITLE
fix: Configure guest loopback interface

### DIFF
--- a/internal/backend/darwinvz/guest_init_script_test.go
+++ b/internal/backend/darwinvz/guest_init_script_test.go
@@ -78,6 +78,15 @@ func TestGuestInitScriptBootstrapsNetwork(t *testing.T) {
 	}
 }
 
+func TestGuestInitScriptConfiguresLoopback(t *testing.T) {
+	if !strings.Contains(guestInitScriptTemplate, "ip link set lo up") {
+		t.Fatal("expected init script to bring up loopback")
+	}
+	if !strings.Contains(guestInitScriptTemplate, "ip addr add 127.0.0.1/8 dev lo") {
+		t.Fatal("expected init script to configure IPv4 loopback")
+	}
+}
+
 func TestGuestInitScriptAutostartsDockerWhenAvailable(t *testing.T) {
 	if !strings.Contains(guestInitScriptTemplate, "DOCKER_REQUIRED=\"$(arg_value cleanroom_service_docker_required || true)\"") {
 		t.Fatal("expected docker service required flag lookup in init script")

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -172,6 +172,15 @@ append_hosts_line_if_missing() {
 append_hosts_line_if_missing '^[[:space:]]*127\.0\.0\.1([[:space:]]|$).*localhost([[:space:]]|$)' '127.0.0.1 localhost'
 append_hosts_line_if_missing '^[[:space:]]*::1([[:space:]]|$).*localhost([[:space:]]|$)' '::1 localhost ip6-localhost ip6-loopback'
 
+if command -v ip >/dev/null 2>&1; then
+  ip link set dev lo up 2>/dev/null || true
+  ip addr add 127.0.0.1/8 dev lo 2>/dev/null || true
+  ip -6 addr add ::1/128 dev lo 2>/dev/null || true
+elif command -v ifconfig >/dev/null 2>&1; then
+  ifconfig lo 127.0.0.1 netmask 255.0.0.0 up 2>/dev/null || true
+  ifconfig lo inet6 ::1/128 up 2>/dev/null || true
+fi
+
 cmdline="$(cat /proc/cmdline 2>/dev/null || true)"
 arg_value() {
   key="$1"

--- a/internal/backend/firecracker/guest_init_script_test.go
+++ b/internal/backend/firecracker/guest_init_script_test.go
@@ -58,3 +58,12 @@ func TestGuestInitScriptAddsLocalhostHostsEntries(t *testing.T) {
 		t.Fatal("expected localhost hosts entry helper to append lines best-effort")
 	}
 }
+
+func TestGuestInitScriptConfiguresLoopback(t *testing.T) {
+	if !strings.Contains(guestInitScriptTemplate, "ip link set dev lo up") {
+		t.Fatal("expected init script to bring up loopback")
+	}
+	if !strings.Contains(guestInitScriptTemplate, "ip addr add 127.0.0.1/8 dev lo") {
+		t.Fatal("expected init script to configure IPv4 loopback")
+	}
+}


### PR DESCRIPTION
## Summary

Configures the guest loopback interface during VM init.

The init script already writes localhost entries into `/etc/hosts`, but some guest images still need `lo` brought up explicitly so localhost callbacks and agent tooling can bind or connect predictably.

## Testing

- `mise exec -- go test ./internal/backend/firecracker ./internal/backend/darwinvz`
