### PR TITLE
feat: Allow repo sandbox egress override

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,13 @@ cleanroom console -- bash
 cleanroom exec --tty -- bash
 ```
 
+Temporarily disable egress filtering for a newly created repository sandbox:
+
+```bash
+cleanroom console --dangerously-allow-all -- bash
+cleanroom exec --dangerously-allow-all -- npm test
+```
+
 ## Policy file
 
 A `cleanroom.yaml` in your repo defines the sandbox policy. Cleanroom also checks `.buildkite/cleanroom.yaml` as a fallback.

--- a/internal/cli/cli_parse_test.go
+++ b/internal/cli/cli_parse_test.go
@@ -318,6 +318,18 @@ func TestTopLevelCreateParsesFromSnapshot(t *testing.T) {
 	}
 }
 
+func TestTopLevelCreateParsesDangerouslyAllowAll(t *testing.T) {
+	c := &CLI{}
+	parser := newParserForTest(t, c)
+
+	if _, err := parser.Parse([]string{"create", "--dangerously-allow-all"}); err != nil {
+		t.Fatalf("parse create --dangerously-allow-all returned error: %v", err)
+	}
+	if !c.Create.DangerouslyAllowAll {
+		t.Fatal("expected create dangerously-allow-all flag to be set")
+	}
+}
+
 func TestExecParsesImageOverride(t *testing.T) {
 	c := &CLI{}
 	parser := newParserForTest(t, c)
@@ -328,6 +340,18 @@ func TestExecParsesImageOverride(t *testing.T) {
 	}
 	if got, want := c.Exec.Image, imageRef; got != want {
 		t.Fatalf("unexpected exec image override: got %q want %q", got, want)
+	}
+}
+
+func TestExecParsesDangerouslyAllowAll(t *testing.T) {
+	c := &CLI{}
+	parser := newParserForTest(t, c)
+
+	if _, err := parser.Parse([]string{"exec", "--dangerously-allow-all", "--", "echo", "ok"}); err != nil {
+		t.Fatalf("parse exec --dangerously-allow-all returned error: %v", err)
+	}
+	if !c.Exec.DangerouslyAllowAll {
+		t.Fatal("expected exec dangerously-allow-all flag to be set")
 	}
 }
 
@@ -389,6 +413,18 @@ func TestConsoleParsesImageOverride(t *testing.T) {
 	}
 	if got, want := c.Console.Image, imageRef; got != want {
 		t.Fatalf("unexpected console image override: got %q want %q", got, want)
+	}
+}
+
+func TestConsoleParsesDangerouslyAllowAll(t *testing.T) {
+	c := &CLI{}
+	parser := newParserForTest(t, c)
+
+	if _, err := parser.Parse([]string{"console", "--dangerously-allow-all"}); err != nil {
+		t.Fatalf("parse console --dangerously-allow-all returned error: %v", err)
+	}
+	if !c.Console.DangerouslyAllowAll {
+		t.Fatal("expected console dangerously-allow-all flag to be set")
 	}
 }
 

--- a/internal/cli/console.go
+++ b/internal/cli/console.go
@@ -3,12 +3,14 @@ package cli
 import (
 	"context"
 	"errors"
+	"os"
+	"strings"
+
+	"github.com/buildkite/cleanroom/internal/controlclient"
 	"github.com/buildkite/cleanroom/internal/observability"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
-	"os"
-	"strings"
 )
 
 type ConsoleCommand struct {
@@ -20,17 +22,19 @@ type ConsoleCommand struct {
 	Image   string `help:"Override sandbox image ref for newly created sandboxes (tag, digest, or local Docker image)"`
 	repositoryOverrideFlags
 	repositoryChangesetFlags
-	Keep           bool     `help:"Keep a newly created sandbox after the console exits"`
-	Env            []string `short:"e" name:"env" help:"Set guest environment variables; use KEY to inherit from the local environment or KEY=VALUE to set an explicit value"`
-	PrintSandboxID bool     `name:"print-sandbox-id" help:"Print resolved sandbox_id=<id> to stderr before attaching"`
+	Keep                bool     `help:"Keep a newly created sandbox after the console exits"`
+	DangerouslyAllowAll bool     `name:"dangerously-allow-all" help:"Disable network egress filtering for a newly created sandbox"`
+	Env                 []string `short:"e" name:"env" help:"Set guest environment variables; use KEY to inherit from the local environment or KEY=VALUE to set an explicit value"`
+	PrintSandboxID      bool     `name:"print-sandbox-id" help:"Print resolved sandbox_id=<id> to stderr before attaching"`
 
 	LaunchSeconds int64 `help:"VM boot/guest-agent readiness timeout in seconds"`
 
-	Command []string `arg:"" passthrough:"partial" optional:"" help:"Command to run with an interactive tty (default: sh)"`
+	Command   []string `arg:"" passthrough:"partial" optional:"" help:"Command to run with an interactive tty (default: sh)"`
+	preAttach func(context.Context, *controlclient.Client, string) error
 }
 
 func (c *ConsoleCommand) Run(ctx *runtimeContext) (runErr error) {
-	if err := validateExecutionSandboxArgs(c.Chdir, c.In, c.From, c.Keep, c.repositoryOverrideFlags, c.repositoryChangesetFlags); err != nil {
+	if err := validateExecutionSandboxArgs(c.Chdir, c.In, c.From, c.Keep, c.DangerouslyAllowAll, c.repositoryOverrideFlags, c.repositoryChangesetFlags); err != nil {
 		return err
 	}
 
@@ -89,7 +93,7 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) (runErr error) {
 		return err
 	}
 
-	target, err := resolveExecutionSandbox(rootCtx, client, ctx, cwd, host, c.Backend, c.In, c.From, c.Image, c.LaunchSeconds, c.repositoryOverrideFlags, c.repositoryChangesetFlags)
+	target, err := resolveExecutionSandbox(rootCtx, client, ctx, cwd, host, c.Backend, c.In, c.From, c.Image, c.LaunchSeconds, c.DangerouslyAllowAll, c.repositoryOverrideFlags, c.repositoryChangesetFlags)
 	if err != nil {
 		if strings.TrimSpace(c.From) != "" {
 			err = explainSnapshotRuntimeDisabledError(err, ctx)
@@ -141,6 +145,11 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) (runErr error) {
 		}
 		terminateSandboxBestEffort(rootCtx, client, sandboxID, 0, logger, "terminate sandbox after console failed")
 	}()
+	if c.preAttach != nil {
+		if err := c.preAttach(rootCtx, client, sandboxID); err != nil {
+			return err
+		}
+	}
 
 	interactiveResult, err := runInteractiveExecution(
 		rootCtx,

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -25,12 +25,13 @@ type ExecCommand struct {
 	Image   string `help:"Override sandbox image ref for newly created sandboxes (tag, digest, or local Docker image)"`
 	repositoryOverrideFlags
 	repositoryChangesetFlags
-	Keep           bool     `help:"Keep a newly created sandbox after the command completes"`
-	Env            []string `short:"e" name:"env" help:"Set guest environment variables; use KEY to inherit from the local environment or KEY=VALUE to set an explicit value"`
-	TTY            bool     `name:"tty" help:"Allocate a tty and attach through the interactive transport; stdout and stderr merge into a single stream"`
-	NoStdin        bool     `short:"n" name:"no-stdin" aliases:"stdin-eof" help:"Close stdin immediately instead of attaching it"`
-	PrintSandboxID bool     `name:"print-sandbox-id" help:"Print resolved sandbox_id=<id> to stderr before streaming output"`
-	PrintTraceID   bool     `name:"print-trace-id" help:"Print trace_id=<id> to stderr after a successful execution when available"`
+	Keep                bool     `help:"Keep a newly created sandbox after the command completes"`
+	DangerouslyAllowAll bool     `name:"dangerously-allow-all" help:"Disable network egress filtering for a newly created sandbox"`
+	Env                 []string `short:"e" name:"env" help:"Set guest environment variables; use KEY to inherit from the local environment or KEY=VALUE to set an explicit value"`
+	TTY                 bool     `name:"tty" help:"Allocate a tty and attach through the interactive transport; stdout and stderr merge into a single stream"`
+	NoStdin             bool     `short:"n" name:"no-stdin" aliases:"stdin-eof" help:"Close stdin immediately instead of attaching it"`
+	PrintSandboxID      bool     `name:"print-sandbox-id" help:"Print resolved sandbox_id=<id> to stderr before streaming output"`
+	PrintTraceID        bool     `name:"print-trace-id" help:"Print trace_id=<id> to stderr after a successful execution when available"`
 
 	LaunchSeconds int64 `help:"VM boot/guest-agent readiness timeout in seconds"`
 
@@ -38,7 +39,7 @@ type ExecCommand struct {
 }
 
 func (e *ExecCommand) Run(ctx *runtimeContext) (runErr error) {
-	if err := validateExecutionSandboxArgs(e.Chdir, e.In, e.From, e.Keep, e.repositoryOverrideFlags, e.repositoryChangesetFlags); err != nil {
+	if err := validateExecutionSandboxArgs(e.Chdir, e.In, e.From, e.Keep, e.DangerouslyAllowAll, e.repositoryOverrideFlags, e.repositoryChangesetFlags); err != nil {
 		return err
 	}
 	if e.TTY && e.NoStdin {
@@ -98,7 +99,7 @@ func (e *ExecCommand) Run(ctx *runtimeContext) (runErr error) {
 		return err
 	}
 
-	target, err := resolveExecutionSandbox(rootCtx, client, ctx, cwd, host, e.Backend, e.In, e.From, e.Image, e.LaunchSeconds, e.repositoryOverrideFlags, e.repositoryChangesetFlags)
+	target, err := resolveExecutionSandbox(rootCtx, client, ctx, cwd, host, e.Backend, e.In, e.From, e.Image, e.LaunchSeconds, e.DangerouslyAllowAll, e.repositoryOverrideFlags, e.repositoryChangesetFlags)
 	if err != nil {
 		if strings.TrimSpace(e.From) != "" {
 			err = explainSnapshotRuntimeDisabledError(err, ctx)

--- a/internal/cli/exec_integration_test.go
+++ b/internal/cli/exec_integration_test.go
@@ -145,10 +145,12 @@ func (a *snapshotIntegrationAdapter) TerminateSandbox(ctx context.Context, sandb
 
 type integrationLoader struct{}
 
+const integrationPolicyImageRef = "ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
 func (integrationLoader) LoadAndCompile(_ string) (*policy.CompiledPolicy, string, error) {
 	return &policy.CompiledPolicy{
 		Version:        1,
-		ImageRef:       "ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		ImageRef:       integrationPolicyImageRef,
 		ImageDigest:    "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 		NetworkDefault: "deny",
 	}, "/repo/cleanroom.yaml", nil
@@ -526,6 +528,34 @@ func TestExecIntegrationStreamsOutput(t *testing.T) {
 	}
 	if strings.Index(outcome.stdout, "one\n") > strings.Index(outcome.stdout, "two\n") {
 		t.Fatalf("expected ordered stdout chunks, got %q", outcome.stdout)
+	}
+}
+
+func TestExecIntegrationDangerouslyAllowAllSetsAllowNetworkDefault(t *testing.T) {
+	adapter := &snapshotIntegrationAdapter{}
+	host, _ := startIntegrationServer(t, adapter)
+	cwd := t.TempDir()
+
+	outcome := runExecWithCapture(ExecCommand{
+		clientFlags:         clientFlags{Host: host},
+		Chdir:               cwd,
+		DangerouslyAllowAll: true,
+		Command:             []string{"echo", "ok"},
+	}, runtimeContext{
+		CWD:    cwd,
+		Loader: integrationLoader{},
+	})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err != nil {
+		t.Fatalf("ExecCommand.Run returned error: %v", outcome.err)
+	}
+	if adapter.provisionReq.Policy == nil {
+		t.Fatal("expected provisioned policy")
+	}
+	if got, want := adapter.provisionReq.Policy.NetworkDefault, "allow"; got != want {
+		t.Fatalf("unexpected provisioned network default: got %q want %q", got, want)
 	}
 }
 

--- a/internal/cli/execution_shared.go
+++ b/internal/cli/execution_shared.go
@@ -47,6 +47,7 @@ func resolveExecutionSandbox(
 	ctx *runtimeContext,
 	cwd, host, backendName, existingSandboxID, fromSnapshot, imageRefOverride string,
 	launchSeconds int64,
+	dangerouslyAllowAll bool,
 	repositoryOverride repositoryOverrideFlags,
 	changesetFlags repositoryChangesetFlags,
 ) (*executionSandbox, error) {
@@ -79,6 +80,7 @@ func resolveExecutionSandbox(
 		fromSnapshot,
 		imageRefOverride,
 		launchSeconds,
+		dangerouslyAllowAll,
 		repository,
 		changeset,
 	)
@@ -93,7 +95,7 @@ func resolveExecutionSandbox(
 	}, nil
 }
 
-func ensureSandboxID(callCtx context.Context, client *controlclient.Client, loader policyLoader, cwd, host, backendName, existingSandboxID, fromSnapshot, imageRefOverride string, launchSeconds int64, repository *resolvedRepositoryCheckout, changeset *cleanroomv1.RepositoryChangeset) (string, bool, error) {
+func ensureSandboxID(callCtx context.Context, client *controlclient.Client, loader policyLoader, cwd, host, backendName, existingSandboxID, fromSnapshot, imageRefOverride string, launchSeconds int64, dangerouslyAllowAll bool, repository *resolvedRepositoryCheckout, changeset *cleanroomv1.RepositoryChangeset) (string, bool, error) {
 	sandboxID := strings.TrimSpace(existingSandboxID)
 	fromSnapshot = strings.TrimSpace(fromSnapshot)
 	if sandboxID != "" {
@@ -102,6 +104,9 @@ func ensureSandboxID(callCtx context.Context, client *controlclient.Client, load
 		}
 		if strings.TrimSpace(imageRefOverride) != "" {
 			return "", false, errors.New("--image cannot be used with --in")
+		}
+		if dangerouslyAllowAll {
+			return "", false, errors.New("--dangerously-allow-all cannot be used with --in")
 		}
 		return sandboxID, false, nil
 	}
@@ -115,6 +120,9 @@ func ensureSandboxID(callCtx context.Context, client *controlclient.Client, load
 		if strings.TrimSpace(backendName) != "" {
 			return "", false, errors.New("--backend cannot be used with --from")
 		}
+		if dangerouslyAllowAll {
+			return "", false, errors.New("--dangerously-allow-all cannot be used with --from")
+		}
 		_, sandboxID, err := createSandboxWithProgress(callCtx, os.Stderr, client, &cleanroomv1.CreateSandboxRequest{
 			Options: &cleanroomv1.SandboxOptions{
 				LaunchSeconds: launchSeconds,
@@ -127,7 +135,7 @@ func ensureSandboxID(callCtx context.Context, client *controlclient.Client, load
 		return sandboxID, true, nil
 	}
 
-	sandboxID, _, err := createTopLevelSandbox(callCtx, client, loader, cwd, host, backendName, imageRefOverride, launchSeconds, repository, changeset)
+	sandboxID, _, err := createTopLevelSandbox(callCtx, client, loader, cwd, host, backendName, imageRefOverride, launchSeconds, dangerouslyAllowAll, repository, changeset)
 	if err != nil {
 		return "", false, err
 	}
@@ -194,7 +202,7 @@ func executionCommandSummary(command []string) string {
 	return summary
 }
 
-func validateExecutionSandboxArgs(chdir, existingSandboxID, fromSnapshot string, keep bool, repositoryOverride repositoryOverrideFlags, changesetFlags repositoryChangesetFlags) error {
+func validateExecutionSandboxArgs(chdir, existingSandboxID, fromSnapshot string, keep, dangerouslyAllowAll bool, repositoryOverride repositoryOverrideFlags, changesetFlags repositoryChangesetFlags) error {
 	sandboxID := strings.TrimSpace(existingSandboxID)
 	snapshotID := strings.TrimSpace(fromSnapshot)
 	hasChdir := strings.TrimSpace(chdir) != ""
@@ -211,6 +219,12 @@ func validateExecutionSandboxArgs(chdir, existingSandboxID, fromSnapshot string,
 	}
 	if sandboxID != "" && keep {
 		return errors.New("--keep cannot be used with --in")
+	}
+	if sandboxID != "" && dangerouslyAllowAll {
+		return errors.New("--dangerously-allow-all cannot be used with --in")
+	}
+	if snapshotID != "" && dangerouslyAllowAll {
+		return errors.New("--dangerously-allow-all cannot be used with --from")
 	}
 	if sandboxID != "" && hasChdir {
 		return errors.New("--chdir cannot be used with --in")

--- a/internal/cli/sandbox.go
+++ b/internal/cli/sandbox.go
@@ -59,8 +59,9 @@ type CreateCommand struct {
 	Image   string `help:"Override sandbox image ref (tag, digest, or local Docker image)"`
 	repositoryOverrideFlags
 	repositoryChangesetFlags
-	LaunchSeconds int64 `help:"VM boot/guest-agent readiness timeout in seconds"`
-	JSON          bool  `help:"Print sandbox as JSON"`
+	DangerouslyAllowAll bool  `name:"dangerously-allow-all" help:"Disable network egress filtering for a newly created sandbox"`
+	LaunchSeconds       int64 `help:"VM boot/guest-agent readiness timeout in seconds"`
+	JSON                bool  `help:"Print sandbox as JSON"`
 }
 
 func (c *SandboxListCommand) Run(ctx *runtimeContext) error {
@@ -315,7 +316,7 @@ func (c *CreateCommand) Run(ctx *runtimeContext) error {
 		return err
 	}
 	if strings.TrimSpace(c.From) != "" {
-		return runSandboxCreate(ctx, c.clientFlags, c.Backend, c.From, c.Image, false, false, c.LaunchSeconds, c.JSON)
+		return runSandboxCreate(ctx, c.clientFlags, c.Backend, c.From, c.Image, false, c.DangerouslyAllowAll, c.LaunchSeconds, c.JSON)
 	}
 	host := c.resolvedHost(ctx.Config)
 	client, err := c.connect(ctx)
@@ -337,7 +338,7 @@ func (c *CreateCommand) Run(ctx *runtimeContext) error {
 	}
 	warnDirtyRepositoryCheckout(repository, changeset != nil)
 
-	sandboxID, sandbox, err := createTopLevelSandbox(context.Background(), client, ctx.Loader, cwd, host, c.Backend, c.Image, c.LaunchSeconds, repository, changeset)
+	sandboxID, sandbox, err := createTopLevelSandbox(context.Background(), client, ctx.Loader, cwd, host, c.Backend, c.Image, c.LaunchSeconds, c.DangerouslyAllowAll, repository, changeset)
 	if err != nil {
 		return err
 	}
@@ -360,6 +361,9 @@ func (c *CreateCommand) validate() error {
 	if c.repositoryOverrideFlags.hasRepositoryOverride() && strings.TrimSpace(c.From) != "" {
 		return errors.New("--repo-url cannot be used with --from")
 	}
+	if c.DangerouslyAllowAll && strings.TrimSpace(c.From) != "" {
+		return errors.New("--dangerously-allow-all cannot be used with --from")
+	}
 	return nil
 }
 
@@ -369,6 +373,7 @@ func createTopLevelSandbox(
 	loader policyLoader,
 	cwd, host, backendName, imageRefOverride string,
 	launchSeconds int64,
+	dangerouslyAllowAll bool,
 	repository *resolvedRepositoryCheckout,
 	changeset *cleanroomv1.RepositoryChangeset,
 ) (string, *cleanroomv1.Sandbox, error) {
@@ -384,8 +389,25 @@ func createTopLevelSandbox(
 	if err != nil {
 		return "", nil, err
 	}
+	compiled, err = overrideCompiledPolicyNetworkDefault(compiled, dangerouslyAllowAll)
+	if err != nil {
+		return "", nil, err
+	}
 
 	return createSandboxWithPolicy(callCtx, client, compiled, backendName, launchSeconds, repository, changeset)
+}
+
+func overrideCompiledPolicyNetworkDefault(compiled *policy.CompiledPolicy, dangerouslyAllowAll bool) (*policy.CompiledPolicy, error) {
+	if !dangerouslyAllowAll {
+		return compiled, nil
+	}
+	if compiled == nil {
+		return nil, errors.New("create sandbox: missing compiled policy")
+	}
+	pb := compiled.ToProto()
+	pb.NetworkDefault = "allow"
+	pb.Hash = ""
+	return policy.FromProto(pb)
 }
 
 func createSandboxWithProgress(


### PR DESCRIPTION
## Summary

Adds `--dangerously-allow-all` to repository-aware sandbox creation flows.

The existing flag only worked for `cleanroom sandbox create`, which is repo-agnostic. This extends the same temporary egress override to newly created repository sandboxes used by:

```bash
cleanroom console --dangerously-allow-all -- bash
cleanroom exec --dangerously-allow-all -- npm test
cleanroom create --dangerously-allow-all
```

The flag is rejected with `--in`/`--sandbox-id` and `--from`, because those reuse an existing sandbox policy instead of compiling a new one.

## Testing

- `mise exec -- go test ./internal/cli`
