### PR TITLE
feat: Add network allow shorthand

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,10 +236,8 @@ sandbox:
   network:
     default: deny
     allow:
-      - host: api.github.com
-        ports: [443]
-      - host: registry.npmjs.org
-        ports: [443]
+      - api.github.com:443
+      - registry.npmjs.org:443
 ```
 
 `sandbox.resources` is optional and declares backend-neutral minimum workload
@@ -307,9 +305,7 @@ example:
 sandbox:
   network:
     default: deny
-    allow:
-      - host: github.com
-        ports: [443]
+    allow: github.com:443
 ```
 
 ## Backend support

--- a/docs/plans/network-allow-syntax.md
+++ b/docs/plans/network-allow-syntax.md
@@ -1,0 +1,94 @@
+# Network Allow Syntax Plan
+
+**Spec reference:** `docs/spec.md` section 5.2
+**Status:** Implemented
+**Last reviewed:** 2026-04-27
+
+## Summary
+
+Accept terse allow entries in the existing `sandbox.network.allow` policy block
+without changing compiled policy, proto payloads, cache keys, gateway behavior,
+or backend enforcement.
+
+This is a parser and documentation change only. The canonical model remains
+structured host-plus-ports allow rules.
+
+## Problem
+
+The current allowlist syntax is explicit but verbose:
+
+```yaml
+sandbox:
+  network:
+    default: deny
+    allow:
+      - host: github.com
+        ports: [443]
+      - host: proxy.golang.org
+        ports: [443]
+      - host: registry.npmjs.org
+        ports: [443, 80]
+```
+
+Most rules allow a single HTTPS destination. Requiring map syntax for every
+single-port host makes common policy files noisier than necessary.
+
+## Policy Shape
+
+Support string entries in `sandbox.network.allow`:
+
+```yaml
+sandbox:
+  network:
+    default: deny
+    allow:
+      - github.com:443
+      - proxy.golang.org:443
+      - host: registry.npmjs.org
+        ports: [443, 80]
+```
+
+Also accept a single string as a singleton allowlist:
+
+```yaml
+sandbox:
+  network:
+    default: deny
+    allow: github.com:443
+```
+
+## Semantics
+
+- String form is `host:port` only.
+- Bare hosts such as `github.com` are rejected.
+- URLs such as `https://github.com` are rejected.
+- Ports must be explicit and valid.
+- Map form remains `host` plus `ports`.
+- Do not make `host: github.com:443` special in map form.
+- IPv6 shorthand is reserved for later; reject it initially unless bracketed
+  literal support is deliberately added.
+- All accepted forms normalize to the existing `AllowRule{Host, Ports}` model.
+
+## Implementation Plan
+
+1. Replace the raw allow-rule representation with a YAML unmarshaller that
+   accepts either a scalar string or a mapping.
+2. Parse scalar strings with `net.SplitHostPort` or equivalent strict logic so
+   host and port boundaries are unambiguous.
+3. Reuse the current host normalization, port validation, duplicate removal, and
+   sorting behavior after parsing.
+4. Keep `CompiledPolicy.Allow`, `PolicyAllowRule`, client types, and generated
+   proto output unchanged.
+5. Update policy tests for scalar list entries, singleton scalar allowlists,
+   mixed scalar/map entries, and invalid shorthand.
+6. Update `docs/spec.md` and examples to show the shorthand for single-port
+   hosts while retaining map examples for multiple ports.
+
+## Definition Of Done
+
+- `cleanroom policy validate` accepts scalar and map allow entries.
+- Existing structured allow entries still work.
+- Invalid shorthand fails closed with field-specific errors.
+- Compiled policy output for shorthand input is identical to equivalent map
+  input.
+- No backend, gateway, proto, or cache behavior changes.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -100,12 +100,9 @@ sandbox:
   network:
     default: deny
     allow:
-      - host: api.github.com
-        ports: [443]
-      - host: proxy.golang.org
-        ports: [443]
-      - host: sum.golang.org
-        ports: [443]
+      - api.github.com:443
+      - proxy.golang.org:443
+      - sum.golang.org:443
 ```
 
 ### 5.1.1 Repository bootstrap config
@@ -170,8 +167,14 @@ explicit request-time changeset input.
 - `sandbox.run.before` defaults to unset; when present, each execution runs that shell command in the repository workdir immediately before the requested command.
 - `sandbox.run.before` must be a YAML string or block string and executes as `sh -lc <value>`.
 - Policy schema intentionally has no field for implicit dirty-worktree inclusion; explicit local modifications are a separate request-time changeset input.
-- `sandbox.network.allow` defaults to empty. Each entry must include an exact
-  `host` value and at least one explicit port in `ports`.
+- `sandbox.network.allow` defaults to empty. It accepts either a sequence of
+  entries or a single scalar entry.
+- An allow entry may be a mapping with an exact `host` value and at least one
+  explicit port in `ports`, or the scalar shorthand `host:port`.
+- The `host:port` shorthand must include one explicit port from 1 to 65535.
+  Bare hosts, URLs, paths, port ranges, and IPv6 literals are not accepted in
+  shorthand form. Use the mapping form for hosts that cannot be represented
+  unambiguously as `host:port`.
 - Host matching is exact after trimming whitespace and lowercasing the policy
   and requested host values. Wildcards and CIDR ranges are not part of the
   current policy-file schema.

--- a/examples/basic/cleanroom.yaml
+++ b/examples/basic/cleanroom.yaml
@@ -6,6 +6,4 @@ sandbox:
     ref: docker.io/library/alpine@sha256:a4f4213abb84c497377b8544c81b3564f313746700372ec4fe84653e4fb03805
   network:
     default: deny
-    allow:
-      - host: api.github.com
-        ports: [443]
+    allow: api.github.com:443

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -8,10 +8,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"path"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/buildkite/cleanroom/internal/bytesize"
@@ -41,8 +43,8 @@ type rawPolicy struct {
 		Services     rawServices           `yaml:"services"`
 		Resources    rawResources          `yaml:"resources"`
 		Network      struct {
-			Default string         `yaml:"default"`
-			Allow   []rawAllowRule `yaml:"allow"`
+			Default string        `yaml:"default"`
+			Allow   rawAllowRules `yaml:"allow"`
 		} `yaml:"network"`
 	} `yaml:"sandbox"`
 }
@@ -93,6 +95,8 @@ type rawAllowRule struct {
 	Host  string `yaml:"host"`
 	Ports []int  `yaml:"ports"`
 }
+
+type rawAllowRules []rawAllowRule
 
 type CompiledPolicy struct {
 	Version        int          `json:"version"`
@@ -403,6 +407,126 @@ func (c *rawDependencyCommandSpec) UnmarshalYAML(node *yaml.Node) error {
 	default:
 		return fmt.Errorf("command must be a string or sequence")
 	}
+}
+
+func (rules *rawAllowRules) UnmarshalYAML(node *yaml.Node) error {
+	if node == nil {
+		*rules = nil
+		return nil
+	}
+	node = dereferenceYAMLAlias(node)
+	if node.Kind == yaml.ScalarNode && node.ShortTag() == "!!null" {
+		*rules = nil
+		return nil
+	}
+
+	switch node.Kind {
+	case yaml.ScalarNode:
+		var rule rawAllowRule
+		if err := rule.UnmarshalYAML(node); err != nil {
+			return err
+		}
+		*rules = rawAllowRules{rule}
+		return nil
+	case yaml.SequenceNode:
+		out := make(rawAllowRules, 0, len(node.Content))
+		for _, item := range node.Content {
+			var rule rawAllowRule
+			if err := rule.UnmarshalYAML(item); err != nil {
+				return err
+			}
+			out = append(out, rule)
+		}
+		*rules = out
+		return nil
+	default:
+		return fmt.Errorf("sandbox.network.allow must be a string or sequence")
+	}
+}
+
+func (rule *rawAllowRule) UnmarshalYAML(node *yaml.Node) error {
+	if node == nil {
+		*rule = rawAllowRule{}
+		return nil
+	}
+	node = dereferenceYAMLAlias(node)
+
+	switch node.Kind {
+	case yaml.ScalarNode:
+		if node.ShortTag() != "!!str" {
+			return fmt.Errorf("network allow entry must be a host:port string or mapping")
+		}
+		parsed, err := parseAllowRuleShorthand(node.Value)
+		if err != nil {
+			return err
+		}
+		*rule = parsed
+		return nil
+	case yaml.MappingNode:
+		var out rawAllowRule
+		for i := 0; i < len(node.Content); i += 2 {
+			keyNode := dereferenceYAMLAlias(node.Content[i])
+			valueNode := dereferenceYAMLAlias(node.Content[i+1])
+			if keyNode == nil || keyNode.Kind != yaml.ScalarNode || keyNode.ShortTag() != "!!str" {
+				return fmt.Errorf("network allow mapping keys must be strings")
+			}
+			switch keyNode.Value {
+			case "host":
+				if err := valueNode.Decode(&out.Host); err != nil {
+					return err
+				}
+			case "ports":
+				if err := valueNode.Decode(&out.Ports); err != nil {
+					return err
+				}
+			default:
+				return fmt.Errorf("unknown network allow field %q", keyNode.Value)
+			}
+		}
+		*rule = out
+		return nil
+	default:
+		return fmt.Errorf("network allow entry must be a host:port string or mapping")
+	}
+}
+
+func parseAllowRuleShorthand(value string) (rawAllowRule, error) {
+	entry := strings.TrimSpace(value)
+	if entry == "" {
+		return rawAllowRule{}, errors.New("network allow shorthand cannot be empty")
+	}
+	if strings.Contains(entry, "://") {
+		return rawAllowRule{}, fmt.Errorf("network allow shorthand %q must be host:port, not a URL", entry)
+	}
+
+	host, portText, err := net.SplitHostPort(entry)
+	if err != nil {
+		return rawAllowRule{}, fmt.Errorf("network allow shorthand %q must be host:port", entry)
+	}
+	host = strings.TrimSpace(host)
+	portText = strings.TrimSpace(portText)
+	if host == "" {
+		return rawAllowRule{}, fmt.Errorf("network allow shorthand %q must include a host", entry)
+	}
+	if strings.Contains(host, "/") {
+		return rawAllowRule{}, fmt.Errorf("network allow shorthand %q must be host:port, not a URL or path", entry)
+	}
+	if strings.Contains(host, ":") {
+		return rawAllowRule{}, errors.New("network allow shorthand does not support IPv6 literals; use host and ports")
+	}
+
+	port, err := strconv.Atoi(portText)
+	if err != nil {
+		return rawAllowRule{}, fmt.Errorf("network allow shorthand %q contains invalid port %q", entry, portText)
+	}
+	if port < 1 || port > 65535 {
+		return rawAllowRule{}, fmt.Errorf("network allow shorthand %q contains invalid port %d", entry, port)
+	}
+
+	return rawAllowRule{
+		Host:  host,
+		Ports: []int{port},
+	}, nil
 }
 
 func dereferenceYAMLAlias(node *yaml.Node) *yaml.Node {

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -125,7 +125,7 @@ func TestCompileHashStable(t *testing.T) {
 	t.Parallel()
 
 	raw := baseRawPolicy()
-	raw.Sandbox.Network.Allow = []rawAllowRule{
+	raw.Sandbox.Network.Allow = rawAllowRules{
 		{Host: "api.github.com", Ports: []int{443, 443, 80}},
 		{Host: "registry.npmjs.org", Ports: []int{443}},
 	}
@@ -141,6 +141,141 @@ func TestCompileHashStable(t *testing.T) {
 
 	if compiledA.Hash != compiledB.Hash {
 		t.Fatalf("hash mismatch: %s != %s", compiledA.Hash, compiledB.Hash)
+	}
+}
+
+func TestCompileNormalizesNetworkAllowShorthand(t *testing.T) {
+	t.Parallel()
+
+	var raw rawPolicy
+	if err := yaml.Unmarshal([]byte(`
+version: 1
+sandbox:
+  image:
+    ref: ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+  network:
+    default: deny
+    allow:
+      - GitHub.com:443
+      - host: registry.npmjs.org
+        ports: [443, 80, 443]
+`), &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	compiled, err := Compile(raw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+
+	if len(compiled.Allow) != 2 {
+		t.Fatalf("unexpected allow rule count: got %d want 2", len(compiled.Allow))
+	}
+	if got, want := compiled.Allow[0].Host, "github.com"; got != want {
+		t.Fatalf("unexpected first allow host: got %q want %q", got, want)
+	}
+	if got, want := compiled.Allow[0].Ports, []int{443}; len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("unexpected first allow ports: got %v want %v", got, want)
+	}
+	if got, want := compiled.Allow[1].Host, "registry.npmjs.org"; got != want {
+		t.Fatalf("unexpected second allow host: got %q want %q", got, want)
+	}
+	if got, want := compiled.Allow[1].Ports, []int{80, 443}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("unexpected second allow ports: got %v want %v", got, want)
+	}
+}
+
+func TestCompileNormalizesNetworkAllowScalar(t *testing.T) {
+	t.Parallel()
+
+	var raw rawPolicy
+	if err := yaml.Unmarshal([]byte(`
+version: 1
+sandbox:
+  image:
+    ref: ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+  network:
+    default: deny
+    allow: proxy.golang.org:443
+`), &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	compiled, err := Compile(raw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if len(compiled.Allow) != 1 {
+		t.Fatalf("unexpected allow rule count: got %d want 1", len(compiled.Allow))
+	}
+	if !compiled.Allows("proxy.golang.org", 443) {
+		t.Fatal("expected proxy.golang.org:443 to be allowed")
+	}
+	if compiled.Allows("proxy.golang.org", 80) {
+		t.Fatal("did not expect proxy.golang.org:80 to be allowed")
+	}
+}
+
+func TestUnmarshalRejectsInvalidNetworkAllowShorthand(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		allow    string
+		contains string
+	}{
+		{name: "bare host", allow: "github.com", contains: "host:port"},
+		{name: "url", allow: "https://github.com:443", contains: "not a URL"},
+		{name: "invalid port", allow: "github.com:notaport", contains: "invalid port"},
+		{name: "zero port", allow: "github.com:0", contains: "invalid port 0"},
+		{name: "ipv6", allow: `"[2001:db8::1]:443"`, contains: "does not support IPv6"},
+		{name: "non string", allow: "[443]", contains: "host:port string or mapping"},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var raw rawPolicy
+			err := yaml.Unmarshal([]byte(`
+version: 1
+sandbox:
+  image:
+    ref: ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+  network:
+    default: deny
+    allow: `+tc.allow+`
+`), &raw)
+			if err == nil {
+				t.Fatal("expected unmarshal to reject invalid network allow shorthand")
+			}
+			if !strings.Contains(err.Error(), tc.contains) {
+				t.Fatalf("unexpected error: got %v want substring %q", err, tc.contains)
+			}
+		})
+	}
+}
+
+func TestUnmarshalRejectsUnknownNetworkAllowField(t *testing.T) {
+	t.Parallel()
+
+	var raw rawPolicy
+	err := yaml.Unmarshal([]byte(`
+version: 1
+sandbox:
+  image:
+    ref: ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+  network:
+    default: deny
+    allow:
+      - host: github.com
+        ports: [443]
+        protocol: tcp
+`), &raw)
+	if err == nil {
+		t.Fatal("expected unmarshal to reject unknown network allow field")
+	}
+	if !strings.Contains(err.Error(), "protocol") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- accept `host:port` scalar entries in `sandbox.network.allow`, including singleton scalar allowlists
- normalize shorthand into the existing compiled `AllowRule` model without proto/backend changes
- update docs, examples, and the standalone syntax plan

## Validation
- `mise exec -- go test ./...`
- `mise exec -- go run ./cmd/cleanroom policy validate --json --chdir examples/basic`
- `git diff --check origin/main...HEAD`