### PR TITLE
chore: Move observability Grafana to port 3330

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -45,7 +45,7 @@ docker compose -f examples/observability/docker-compose.yaml up -d
 
 That stack provides:
 
-- Grafana at `http://localhost:3300`
+- Grafana at `http://localhost:3330`
 - Prometheus at `http://localhost:9090`
 - Tempo at `http://localhost:3200`
 - an OpenTelemetry Collector listening on `localhost:14317` and `http://localhost:14318`

--- a/examples/observability/README.md
+++ b/examples/observability/README.md
@@ -20,7 +20,7 @@ docker compose up -d
 
 The local endpoints are:
 
-- Grafana: `http://localhost:3300`
+- Grafana: `http://localhost:3330`
 - Prometheus: `http://localhost:9090`
 - Tempo HTTP API: `http://localhost:3200`
 - OTLP gRPC ingest: `localhost:14317`

--- a/examples/observability/docker-compose.yaml
+++ b/examples/observability/docker-compose.yaml
@@ -47,7 +47,7 @@ services:
       - ./grafana/dashboards:/etc/grafana/provisioning/dashboards/cleanroom:ro
       - grafana-data:/var/lib/grafana
     ports:
-      - "3300:3000"
+      - "3330:3000"
     depends_on:
       - prometheus
       - tempo


### PR DESCRIPTION
## Summary
- move local observability Grafana from host port 3300 to 3330
- keep Grafana's container port at 3000
- update observability docs for the corrected local URL

## Why
- `buildkite-minio-1` already publishes host port 3300 to MinIO port 9000
- the existing observability stack was running without Grafana because 3300 was occupied

## Testing
- lsof -nP -iTCP:3330 -sTCP:LISTEN || true
- docker compose -f examples/observability/docker-compose.yaml config
- git diff --check
- rg -n "localhost:3300|3300:3000|localhost:3330|3330:3000|localhost:3000|3000:3000" -S docs/observability.md examples/observability