### PR TITLE
fix: Record invalid OCI gateway decisions

### DIFF
--- a/internal/gateway/oci_cached.go
+++ b/internal/gateway/oci_cached.go
@@ -61,12 +61,14 @@ func (h *cachedRegistryHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	// Extract the prefix (first path segment) to look up the upstream host.
 	prefix, _, hasSep := strings.Cut(remainder, "/")
 	if prefix == "" {
-		http.Error(w, "bad request: missing registry prefix", http.StatusBadRequest)
+		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonInvalidRequest)
+		writeReasonError(w, http.StatusBadRequest, reasonInvalidRequest, "missing registry prefix")
 		return
 	}
 	if !hasSep {
 		// Bare prefix with no trailing path — not a valid OCI request.
-		http.Error(w, "bad request: missing image path", http.StatusBadRequest)
+		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonInvalidRequest)
+		writeReasonError(w, http.StatusBadRequest, reasonInvalidRequest, "missing image path")
 		return
 	}
 	rest := strings.TrimPrefix(remainder, prefix+"/")

--- a/internal/gateway/oci_cached_test.go
+++ b/internal/gateway/oci_cached_test.go
@@ -326,15 +326,51 @@ func TestCachedRegistryHandlerEmptyPrefix(t *testing.T) {
 	backend := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal("backend should not be called for empty prefix")
 	})
-	h := newCachedRegistryHandler(&stubRegistryPrefixHandlerProvider{handler: backend}, nil)
+	provider := &stubRegistryPrefixHandlerProvider{handler: backend}
+	h := newCachedRegistryHandler(provider, nil)
 
 	req := httptest.NewRequest("GET", "/registry/", nil)
 	req = withScope(req, registryTestScope("registry-1.docker.io"))
+	req, obs := withGatewayRequestObservability(req)
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", w.Code)
+	}
+	if got := w.Header().Get(reasonCodeHeader); got != reasonInvalidRequest {
+		t.Fatalf("expected reason %s, got %q", reasonInvalidRequest, got)
+	}
+	requireGatewayRequestDecision(t, obs, gatewayActionDeny, reasonInvalidRequest)
+	if provider.lookupCalls != 0 {
+		t.Fatalf("expected invalid request to avoid metadata lookup, got %d lookups", provider.lookupCalls)
+	}
+}
+
+func TestCachedRegistryHandlerBarePrefixSetsGatewayDecision(t *testing.T) {
+	t.Parallel()
+
+	backend := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Fatal("backend should not be called for bare prefix")
+	})
+	provider := &stubRegistryPrefixHandlerProvider{handler: backend}
+	h := newCachedRegistryHandler(provider, nil)
+
+	req := httptest.NewRequest("GET", "/registry/docker.io", nil)
+	req = withScope(req, registryTestScope("docker.io"))
+	req, obs := withGatewayRequestObservability(req)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+	if got := w.Header().Get(reasonCodeHeader); got != reasonInvalidRequest {
+		t.Fatalf("expected reason %s, got %q", reasonInvalidRequest, got)
+	}
+	requireGatewayRequestDecision(t, obs, gatewayActionDeny, reasonInvalidRequest)
+	if provider.lookupCalls != 0 {
+		t.Fatalf("expected invalid request to avoid metadata lookup, got %d lookups", provider.lookupCalls)
 	}
 }
 


### PR DESCRIPTION
## Summary
- route malformed cached OCI registry requests through gateway decision telemetry
- return the standard invalid_request reason header for empty and bare registry prefixes
- add regression coverage for both malformed paths

## Tests
- mise exec -- go test ./internal/gateway