### PR TITLE
fix: Silence install prompt without tty

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -267,8 +267,12 @@ prompt_install_homebrew_package() {
   local answer
 
   [ -r /dev/tty ] && [ -w /dev/tty ] || return 1
-  printf '[cleanroom-install] Install %s with Homebrew now? [y/N] ' "${package}" >/dev/tty
-  IFS= read -r answer </dev/tty || return 1
+  if ! { printf '[cleanroom-install] Install %s with Homebrew now? [y/N] ' "${package}" >/dev/tty; } 2>/dev/null; then
+    return 1
+  fi
+  if ! { IFS= read -r answer </dev/tty; } 2>/dev/null; then
+    return 1
+  fi
 
   case "${answer}" in
     y|Y|yes|YES|Yes) return 0 ;;

--- a/scripts/install_test.go
+++ b/scripts/install_test.go
@@ -1,0 +1,51 @@
+//go:build unix
+
+package scripts_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestInstallScriptPromptDeclinesSilentlyWithoutTTY(t *testing.T) {
+	content, err := os.ReadFile("install.sh")
+	if err != nil {
+		t.Fatalf("read install.sh: %v", err)
+	}
+
+	script := shellFunction(t, string(content), "prompt_install_homebrew_package") + "\nprompt_install_homebrew_package e2fsprogs\n"
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "bash", "-c", script)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() != nil {
+		t.Fatalf("prompt_install_homebrew_package hung without a tty; output: %q", string(out))
+	}
+	if err == nil {
+		t.Fatal("expected prompt_install_homebrew_package to decline without a tty")
+	}
+	if got := string(out); strings.TrimSpace(got) != "" {
+		t.Fatalf("expected missing tty prompt to be silent, got %q", got)
+	}
+}
+
+func shellFunction(t *testing.T, content, name string) string {
+	t.Helper()
+
+	start := strings.Index(content, name+"() {")
+	if start < 0 {
+		t.Fatalf("function %s not found", name)
+	}
+	rest := content[start:]
+	end := strings.Index(rest, "\n}\n\n")
+	if end < 0 {
+		t.Fatalf("function %s terminator not found", name)
+	}
+	return rest[:end+3]
+}


### PR DESCRIPTION
## Problem

The macOS installer can offer to install missing `e2fsprogs` via Homebrew, but in non-interactive runs the prompt path can leak bash's `/dev/tty` redirection error before falling back to the normal warning. That makes piped installs and CI logs noisier than intended.

## Changes

- Guard both prompt write/read operations so `/dev/tty` open failures are handled silently.
- Add a script package test that executes just `prompt_install_homebrew_package` without a TTY and verifies it declines without output.

## Validation

- `mise exec -- go test ./scripts -run TestInstallScriptPromptDeclinesSilentlyWithoutTTY`
- `mise exec -- go test ./scripts`
- `mise exec -- shellcheck -x scripts/install.sh`
- `git diff --check`
