### PR TITLE
feat: Add dependency and service cache blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Agent sandboxing tools are [proliferating fast](docs/research.md). Most focus on
 
 **Standard OCI images.** Use any OCI image from any registry as your sandbox base. Digest-pinned in policy for reproducibility. No custom VM image format or vendor-specific base images. Same image works across backends.
 
-**Docker inside the sandbox.** Enable a guest Docker daemon with a single policy flag (`services.docker.required: true`). Docker Hub pulls are mirrored through the host gateway cache, and you can build and run containers inside the microVM.
+**Docker inside the sandbox.** Enable a guest Docker daemon with a single policy flag (`docker.required: true`). Docker Hub pulls are mirrored through the host gateway cache, and you can build and run containers inside the microVM.
 
 **Coming soon:** broader guest-side package-manager rewrites with lockfile enforcement, broader non-Docker-Hub registry caching, hermetic offline build flows, and richer audit surfaces. See the [spec](docs/spec.md) for the full roadmap.
 
@@ -127,42 +127,45 @@ commands become repo-aware: Cleanroom resolves the current git remote and local
 `HEAD`, materializes that checkout in the sandbox, and starts commands in the
 configured guest path. Cleanroom no longer auto-detects or auto-wraps commands
 for `mise`; if you want `mise`, run it explicitly in the command you execute or
-in `sandbox.dependencies.command` or `sandbox.services.command` so it can
-participate in create-time stage caching.
+in a dependency or service block command so it can participate in create-time
+stage caching.
 
 You can also define create-time and per-execution setup:
 
 ```yaml
 sandbox:
+  docker:
+    required: true
   dependencies:
-    command: bundle install
-    key:
-      files: [Gemfile.lock]
-    # Optional: reuse dependency state across source-only commits when the
-    # dependency outputs survive a checkout refresh.
-    # reuse: portable
+    - name: gems
+      command: bundle install
+      inputs:
+        files: [Gemfile.lock]
+      outputs:
+        dirs: ["${HOME}/.bundle"]
   services:
-    docker:
-      required: true
-    command: |
-      docker compose up -d postgres valkey
-      bin/rails db:prepare
-      docker compose stop postgres valkey
-    key:
-      files: [docker-compose.yml, db/schema.rb]
+    - name: database
+      command: |
+        docker compose up -d postgres valkey
+        bin/rails db:prepare
+        docker compose stop postgres valkey
+      inputs:
+        files: [docker-compose.yml, db/schema.rb]
+      outputs:
+        dirs: [/var/lib/cleanroom/services/database]
   run:
     before: docker compose up -d postgres valkey
 ```
 
-Use `sandbox.dependencies.command` for deterministic repo-local bootstrap,
-`sandbox.services.command` for snapshotable on-disk service preparation, and
+Use `sandbox.dependencies` blocks for deterministic repo-local bootstrap,
+`sandbox.services` blocks for snapshotable on-disk service preparation, and
 `sandbox.run.before` for live startup that must happen before each execution.
-Set `sandbox.services.docker.required: true` when the services bootstrap needs
-the guest Docker daemon.
+Set `sandbox.docker.required: true` when the sandbox needs the guest Docker
+daemon.
 
-`sandbox.dependencies.command` and `sandbox.services.command` support either a
-shell string or an argv sequence. Prefer the string form unless you specifically
-need exact argv semantics.
+Dependency and service block commands support either a shell string or an argv
+sequence. Prefer the string form unless you specifically need exact argv
+semantics.
 `sandbox.run.before` always runs through `sh -lc`.
 
 Pre-create a long-running sandbox without running a command:
@@ -286,9 +289,8 @@ Enable Docker as a guest service:
 
 ```yaml
 sandbox:
-  services:
-    docker:
-      required: true
+  docker:
+    required: true
 ```
 
 Validate policy without running anything:

--- a/docs/api.md
+++ b/docs/api.md
@@ -359,8 +359,7 @@ Behavior contract:
 5. For repo-aware top-level commands, materialize that checkout in the sandbox
    and default the guest working directory to `repository.path`.
    - Cleanroom does not auto-detect or auto-wrap `mise`; call it explicitly in
-     `sandbox.dependencies.command`, `sandbox.services.command`, or the
-     workload command when needed
+     dependency blocks, service blocks, or the workload command when needed
 6. Create execution with explicit kind, env, and TTY options.
 7. Attach stdio according to command mode:
    - `cleanroom exec` defaults to attached stdin plus separate stdout/stderr

--- a/docs/plans/dependency-service-volume-caches.md
+++ b/docs/plans/dependency-service-volume-caches.md
@@ -148,6 +148,8 @@ resolved from the post-changeset repository tree when a changeset is present.
 
 - `~` and `~/...` expand to the sandbox user's home directory.
 - `${HOME}` and `$HOME` expand to the same canonical home directory.
+- `${WORKSPACE}` and `$WORKSPACE` expand to the Cleanroom workspace root before
+  workspace-output validation runs.
 - unknown variables, `~otheruser`, relative paths, empty paths, globs in output
   paths, and paths that normalize outside their allowed root are rejected.
 - normalized absolute guest paths are used for cache keys and mount decisions.
@@ -172,10 +174,12 @@ The canonical home directory is the `HOME` value Cleanroom supplies in the
 closed block execution environment. Cleanroom must set that value before output
 path normalization. Block `env` values are literal strings, except leading `~`,
 `~/`, `$HOME`, `$HOME/`, `${HOME}`, and `${HOME}/` forms are expanded to the
-same canonical home directory. Other `$...` values, URLs, relative paths, empty
-strings, and trailing spaces are preserved and included in the block environment
-digest as provided. The first implementation should not discover a different
-home directory from the image at runtime.
+same canonical home directory, and leading `$WORKSPACE`, `$WORKSPACE/`,
+`${WORKSPACE}`, and `${WORKSPACE}/` forms are expanded to the canonical
+workspace root. Other `$...` values, URLs, relative paths, empty strings, and
+trailing spaces are preserved and included in the block environment digest as
+provided. The first implementation should not discover a different home
+directory from the image at runtime.
 
 ## Semantics
 
@@ -629,7 +633,8 @@ Create-sandbox stream messages should stay user-readable:
 1. Add schema types for `sandbox.docker.required`, dependency blocks, and service
    blocks, including `outputs.dirs` and `outputs.files`, in
    `internal/policy/policy.go` and `proto/cleanroom/v1/control.proto`.
-2. Add path expansion and validation helpers for `${HOME}`, `$HOME`, and `~`.
+2. Add path expansion and validation helpers for `${HOME}`, `$HOME`, `~`, and
+   `${WORKSPACE}`.
 3. Add deterministic input-manifest hashing for literal files and globs.
 4. Add dependency and service volume cache-key helpers in
    `internal/cachekey/cachekey.go`.
@@ -662,8 +667,8 @@ Completed in phase 1:
 - policy schema and proto support for ordered dependency and service blocks
 - `sandbox.docker.required` as the Docker runtime requirement
 - validation for block names, commands, input files, `outputs.dirs`,
-  `outputs.files`, `${HOME}`, `$HOME`, `~`, duplicate paths, overlapping paths,
-  and `/workspace` output rejection
+  `outputs.files`, `${HOME}`, `$HOME`, `~`, `${WORKSPACE}`, duplicate paths,
+  overlapping paths, and workspace output rejection
 - rejection of the old YAML object forms for `sandbox.dependencies`,
   `sandbox.services.command`, `sandbox.services.key`, and
   `sandbox.services.docker.required`
@@ -730,6 +735,7 @@ Minimum coverage:
 - policy validation rejects duplicate or overlapping normalized output directories
 - policy validation rejects file outputs inside directory outputs
 - path normalization makes `~/go/pkg/mod` and `${HOME}/go/pkg/mod` equivalent
+  and rejects `${WORKSPACE}` outputs after expansion
 - input manifests are deterministic across file order and glob order
 - input manifest validation rejects empty glob matches
 - input manifest validation rejects directories, symlinks, and other

--- a/docs/plans/dependency-service-volume-caches.md
+++ b/docs/plans/dependency-service-volume-caches.md
@@ -144,8 +144,7 @@ explain and test. Existing policies should be migrated to the new list shape and
 `inputs.files` are repository-relative paths or glob patterns. They are
 resolved from the post-changeset repository tree when a changeset is present.
 
-`outputs.dirs`, `outputs.files`, and block `env` values support limited
-guest-path expansion:
+`outputs.dirs` and `outputs.files` support limited guest-path expansion:
 
 - `~` and `~/...` expand to the sandbox user's home directory.
 - `${HOME}` and `$HOME` expand to the same canonical home directory.
@@ -159,8 +158,9 @@ guest-path expansion:
   capture and restored by Cleanroom before later blocks or user commands.
 - declared outputs are required in the first slice. Optional outputs can be added
   later as an explicit schema feature.
-- normalized output directories must be unique and non-overlapping. Parent/child
-  directory pairs are rejected in the first slice.
+- normalized output paths must be unique and non-overlapping across all
+  dependency and service blocks. Parent/child directory pairs are rejected in
+  the first slice.
 - a file output inside a declared output directory is rejected as redundant.
 - multiple file outputs may share a parent directory. Cleanroom should not use a
   single-file bind mount as the primary mechanism because atomic replacement
@@ -169,10 +169,13 @@ guest-path expansion:
 This must be string normalization, not shell expansion.
 
 The canonical home directory is the `HOME` value Cleanroom supplies in the
-closed block execution environment. Cleanroom must set that value before path
-normalization, include it in the block environment digest, and expand `~`,
-`$HOME`, and `${HOME}` to that exact value. The first implementation should not
-discover a different home directory from the image at runtime.
+closed block execution environment. Cleanroom must set that value before output
+path normalization. Block `env` values are literal strings, except leading `~`,
+`~/`, `$HOME`, `$HOME/`, `${HOME}`, and `${HOME}/` forms are expanded to the
+same canonical home directory. Other `$...` values, URLs, relative paths, empty
+strings, and trailing spaces are preserved and included in the block environment
+digest as provided. The first implementation should not discover a different
+home directory from the image at runtime.
 
 ## Semantics
 
@@ -363,14 +366,15 @@ service_volume_key = H(
 )
 ```
 
-Input manifests should record path, file type, mode, content digest, symlink
-target, and deleted state. They should be sorted before hashing. Missing
-required literal paths should fail. Glob matches should be sorted and should
-fail if the pattern is invalid or matches no files. Optional inputs can be added
-later as an explicit schema feature; the first implementation should not hash an
-empty glob as an empty input set because that is usually a typo and creates an
-overbroad cache key. Input projection validation must reject symlink escapes
-before running the block command.
+Input manifests should record regular-file path, mode, and content digest, and
+reject directories, symlinks, devices, and other non-regular inputs. They should
+be sorted before hashing. Missing required literal paths should fail. Glob
+matches should be sorted and should fail if the pattern is invalid, matches no
+files, or matches non-regular files. Optional inputs can be added later as an
+explicit schema feature; the first implementation should not hash an empty glob
+as an empty input set because that is usually a typo and creates an overbroad
+cache key. Input projection validation must reject symlink escapes before
+running the block command.
 
 The normalized output declaration is part of the key because changing directory
 mount destinations or file-output restore paths can change command behavior even
@@ -648,9 +652,66 @@ Create-sandbox stream messages should stay user-readable:
 14. Add end-to-end tests that prove a source-only commit reuses dependency and
     service output volumes without rerunning their commands.
 
-Steps 1 through 6 can be developed with unit tests before backend work. Steps 8
-and 9 are the main backend slices. Steps 10 and 11 depend on the backend request
-fields but can use a stub adapter in control-service tests.
+### Phase 1 PR Status
+
+The first implementation PR covers the contract and plumbing layer, not the
+runtime sidecar-volume execution path.
+
+Completed in phase 1:
+
+- policy schema and proto support for ordered dependency and service blocks
+- `sandbox.docker.required` as the Docker runtime requirement
+- validation for block names, commands, input files, `outputs.dirs`,
+  `outputs.files`, `${HOME}`, `$HOME`, `~`, duplicate paths, overlapping paths,
+  and `/workspace` output rejection
+- rejection of the old YAML object forms for `sandbox.dependencies`,
+  `sandbox.services.command`, `sandbox.services.key`, and
+  `sandbox.services.docker.required`
+- deterministic input-manifest helper package for literal regular files,
+  regular-file globs, file contents, and modes, rejecting non-regular inputs
+- glob-aware dependency key-file hashing for the existing stage-cache path,
+  including changeset-aware resolution
+- dependency and service output-volume cache-key helper APIs
+- reuse namespace helper, defaulting to canonical repository remote when no
+  explicit namespace is provided
+- cache metadata fields for command, env, normalized outputs, output manifests,
+  and output records
+- backend capability flags and provision request fields for cache output volumes
+  and overlay write capture
+- README, spec, API docs, and example policies updated to the new schema
+- tests for schema validation, cache keys, input manifests, cache metadata,
+  glob expansion, generated proto round trips, CLI Docker policy creation, and
+  existing dependency/services stage-cache behavior
+
+Current runtime behavior after phase 1:
+
+- dependency and service blocks are compiled into the existing aggregate
+  dependency/services stage bootstrap command
+- existing full-rootfs dependency and services stage caches continue to work
+- declared outputs are validated and represented in policy/proto/cache metadata,
+  but they are not yet restored or published as independent output volumes
+- overlayfs write capture is represented as a backend capability contract, but
+  no backend runner enforces escaped-write detection yet
+
+Remaining work:
+
+- build per-block dependency and service planning instead of only aggregate
+  bootstrap planning
+- materialize isolated declared-input projections before running cacheable
+  blocks
+- implement the guest overlay write-capture runner
+- prepare output volumes before VM launch, mount declared `outputs.dirs`, and
+  copy declared `outputs.files`
+- publish and restore output-volume snapshots and output manifests
+- implement escaped-write warning plus exact full-rootfs fallback
+- add observability events for per-block lookup, restore, execution, publish,
+  and fallback decisions
+- add end-to-end tests proving source-only commits reuse dependency and service
+  output volumes without rerunning block commands
+
+Steps 8 and 9 remain the main backend slices. Steps 10 and 11 should now build
+on the phase 1 request fields and metadata, with stub-adapter tests before the
+Firecracker implementation.
 
 ## Tests
 
@@ -671,6 +732,8 @@ Minimum coverage:
 - path normalization makes `~/go/pkg/mod` and `${HOME}/go/pkg/mod` equivalent
 - input manifests are deterministic across file order and glob order
 - input manifest validation rejects empty glob matches
+- input manifest validation rejects directories, symlinks, and other
+  non-regular files
 - input projection rejects symlinks that escape the declared input set
 - cache keys change when inputs, env, command, output declarations, runtime key, or
   prior block output keys change

--- a/docs/plans/dependency-service-volume-caches.md
+++ b/docs/plans/dependency-service-volume-caches.md
@@ -1,0 +1,709 @@
+# Dependency and Service Volume Cache Plan
+
+**Spec reference:** `spec.md` sections 5.1.1, 5.2, 6.4
+**Status:** Proposed
+**Last reviewed:** 2026-05-02
+
+## Summary
+
+Make dependency and service preparation reusable from deterministic file inputs
+without coupling the cache entry to one exact repository checkout.
+
+The current layered-cache plan snapshots whole root filesystems. That is still
+the right fallback for exact workspace reuse, but it makes portable dependency
+reuse awkward because dependency outputs can be wiped by repository refresh. The
+target model here is different: declared input files produce declared output
+directories and files, and Cleanroom backs those outputs with cacheable storage.
+
+## Problem
+
+Dependency and service preparation often has two different kinds of state:
+
+- source files that define what should be installed or prepared
+- materialized output such as toolchains, package stores, compiled extensions,
+  Docker layers, database data directories, or service seed state
+
+Today dependency and service stage cache keys are conservative because they are
+built on parent workspace or dependency stage keys. That avoids unsafe reuse,
+but it also means a source-only repository change can miss caches even when the
+dependency or service inputs did not change.
+
+Portable dependency reuse improves this for some cases, but it still restores a
+full rootfs snapshot that contains an older checkout. Cleanroom then refreshes
+the checkout and validates declared key files. This only works when useful
+dependency output survives `git reset --hard` and `git clean -ffdx`, which
+excludes common repo-local outputs like `node_modules`, `vendor`, generated
+files, or service prep that writes under `/workspace`.
+
+## Goals
+
+- Key dependency and service cache entries from declared file inputs, command
+  digest, environment, policy/runtime inputs, and normalized output declarations.
+- Support multiple ordered dependency blocks so toolchain, language package,
+  and application dependency prep can reuse independently.
+- Back declared output directories with snapshot-capable volumes before commands
+  run.
+- Restore matching output-volume snapshots and file outputs at the same guest
+  paths on cache hit.
+- Run cacheable dependency and service commands from an isolated, read-only
+  projection of their declared inputs rather than from the full workspace.
+- Use guest overlayfs write capture, where supported, to detect persistent writes
+  outside declared outputs before publishing a file-keyed cache entry.
+- Scope file-keyed volume reuse to the canonical repository remote by default.
+- Keep `content-cache` responsible for host-side reuse of immutable downloaded
+  bytes.
+- Keep exact full-rootfs stage caches available for existing behavior and for
+  commands that do not fit this stricter input/output contract.
+- Preserve backend-neutral policy and control-plane semantics, with backend
+  capability checks for volume attachment and fast clone support.
+
+## Non-goals
+
+- Replacing `content-cache` with another package-byte cache.
+- Capturing live VM memory, service processes, or open sockets.
+- Making arbitrary shell commands safely cross-repo reusable without declared
+  inputs and outputs.
+- Sharing cacheable dependency or service outputs across repositories without an
+  explicit trust namespace.
+- Tracing arbitrary command reads in the first implementation slice.
+- Requiring users to enumerate every file created inside an output directory.
+- Persisting undeclared writes when a file-keyed cache hit skips the command.
+- Supporting host workspace mounts.
+- Supporting workspace output declarations in the first implementation slice.
+
+## Policy Shape
+
+The new schema should make both dependencies and services ordered lists of named
+cacheable blocks. Each block declares the files that define the key and the guest
+paths that should produce reusable outputs. Docker is a sandbox runtime
+capability, not a service cache block, so Docker enablement moves to
+`sandbox.docker.required`.
+
+Block names must be unique within their phase, stable across policy edits, and
+safe for logs and cache metadata. A conservative first rule is
+`[A-Za-z0-9][A-Za-z0-9_.-]*`.
+
+```yaml
+sandbox:
+  docker:
+    required: true
+
+  dependencies:
+    - name: toolchains
+      command: mise install
+      inputs:
+        files:
+          - mise.toml
+          - mise.lock
+      outputs:
+        dirs:
+          - "${HOME}/.local/share/mise"
+          - "${HOME}/.cache/mise"
+
+    - name: go-modules
+      command: mise exec -- go mod download
+      inputs:
+        files:
+          - mise.toml
+          - mise.lock
+          - go.mod
+          - go.sum
+      env:
+        GOMODCACHE: "${HOME}/go/pkg/mod"
+        GOCACHE: "${HOME}/.cache/go-build"
+      outputs:
+        dirs:
+          - "${HOME}/go/pkg/mod"
+          - "${HOME}/.cache/go-build"
+
+  services:
+    - name: postgres
+      command: |
+        ./scripts/prepare-postgres-volume.sh
+      inputs:
+        files:
+          - compose.yaml
+          - .env.cleanroom
+          - scripts/prepare-postgres-volume.sh
+          - db/schema.sql
+          - db/seed.sql
+      outputs:
+        dirs:
+          - /var/lib/cleanroom/services/postgres
+```
+
+There is no backward-compatibility layer for the old single-object
+`sandbox.dependencies` shape, the old `sandbox.services.command` and
+`sandbox.services.key` shape, or `sandbox.services.docker.required`. This project
+is pre-1.0, and carrying both shapes would make the cache contract harder to
+explain and test. Existing policies should be migrated to the new list shape and
+`sandbox.docker.required`.
+
+### Path expansion
+
+`inputs.files` are repository-relative paths or glob patterns. They are
+resolved from the post-changeset repository tree when a changeset is present.
+
+`outputs.dirs`, `outputs.files`, and block `env` values support limited
+guest-path expansion:
+
+- `~` and `~/...` expand to the sandbox user's home directory.
+- `${HOME}` and `$HOME` expand to the same canonical home directory.
+- unknown variables, `~otheruser`, relative paths, empty paths, globs in output
+  paths, and paths that normalize outside their allowed root are rejected.
+- normalized absolute guest paths are used for cache keys and mount decisions.
+- output directories and files under `/workspace` are rejected in the first
+  slice.
+- `outputs.dirs` are whole directory trees backed by writable cache volumes.
+- `outputs.files` are individual regular files captured from overlayfs write
+  capture and restored by Cleanroom before later blocks or user commands.
+- declared outputs are required in the first slice. Optional outputs can be added
+  later as an explicit schema feature.
+- normalized output directories must be unique and non-overlapping. Parent/child
+  directory pairs are rejected in the first slice.
+- a file output inside a declared output directory is rejected as redundant.
+- multiple file outputs may share a parent directory. Cleanroom should not use a
+  single-file bind mount as the primary mechanism because atomic replacement
+  patterns commonly unlink and rename files.
+
+This must be string normalization, not shell expansion.
+
+The canonical home directory is the `HOME` value Cleanroom supplies in the
+closed block execution environment. Cleanroom must set that value before path
+normalization, include it in the block environment digest, and expand `~`,
+`$HOME`, and `${HOME}` to that exact value. The first implementation should not
+discover a different home directory from the image at runtime.
+
+## Semantics
+
+Dependency blocks run in policy order. A later dependency block sees the outputs
+restored or produced by earlier blocks.
+
+Each block has an independent cache identity. If `toolchains` hits and
+`go-modules` misses, Cleanroom restores the toolchain output volumes, runs only
+the Go module block, then snapshots the Go module outputs.
+
+Cacheable block commands do not run from the live `/workspace` checkout.
+Cleanroom materializes the declared `inputs.files` into a read-only input
+projection that preserves repository-relative paths, then runs the command with
+that projection as the working directory. Declared output directories are
+writable mounts, and declared output files are captured from the overlay upperdir
+after the command. The real workspace is still prepared for user code and for
+exact full-rootfs fallback, but file-keyed volume-cache publication must not
+depend on undeclared workspace reads.
+
+If a dependency or service command needs files that are not in its declared
+input set, the policy should declare those files or globs. If the command needs
+the whole repository and cannot be reduced to a declared input set, it should use
+exact full-rootfs stage caching rather than the new volume-cache block shape.
+
+Input projection must not provide symlink escape hatches back into the live
+workspace or arbitrary runtime paths. The first slice should reject projected
+input symlinks with absolute targets or `..` traversal outside the projection
+unless the resolved target is also part of the declared input set and can be
+materialized inside the projection.
+
+Service blocks run after dependency blocks. A service block key includes the
+selected dependency output identities it depends on. The first implementation
+can make every service block depend on the complete ordered dependency result;
+later work can add explicit `depends_on` if needed.
+
+Directory outputs are backed before the command runs. On a miss, Cleanroom
+creates a writable output volume, maps each `outputs.dirs` path into that
+volume, runs the command, and snapshots the output volume. On a hit, Cleanroom
+clones the output snapshot and maps it into the guest at the same normalized
+directory paths before skipping the command.
+
+File outputs are captured from the command's overlayfs upperdir. Cleanroom does
+not bind-mount individual files and should not hide an existing parent directory
+behind an empty capture directory. On a miss, after the command exits, Cleanroom
+copies each declared `outputs.files` path from the overlay view into the block's
+output store and materializes the same file into the sandbox root for later
+blocks. On a hit, Cleanroom restores declared file outputs into the sandbox root
+before later blocks or user commands run.
+
+Parent directories for directory outputs may be created by Cleanroom. The
+directory output itself must either be absent or be an empty directory before the
+cache volume is mapped in the first implementation. Rejecting
+pre-existing non-empty directory paths keeps the initial semantics simple and
+avoids hiding image-provided files behind a cache volume.
+
+The command must not leave persistent state outside declared outputs. Where the
+backend supports guest overlayfs write capture, Cleanroom should enforce this by
+running the command against an overlay root and inspecting the upperdir after the
+command. If escaped persistent writes are found, Cleanroom must not publish the
+file-keyed volume cache entry.
+
+Escaped writes are a publication gate, not the determinism mechanism. The
+determinism mechanism is the isolated input projection plus declared output
+mounts and captured files. The publication gate prevents Cleanroom from caching
+a subset of command effects under a key that would later skip the command.
+
+### Reuse namespace
+
+The initial reuse namespace is the canonical repository remote URL. That gives
+cross-commit reuse inside one repository without allowing arbitrary repositories
+to share dependency or service outputs just because their declared inputs match.
+
+The namespace should be an explicit cache-key component even if it is not exposed
+in the first public schema. A future policy field may allow broader sharing, but
+only by naming a trust namespace deliberately.
+
+Local commit bundles and changesets still resolve against the same canonical
+repository remote. Their effects are included through the post-apply input
+manifest rather than by changing the reuse namespace.
+
+### Environment and network determinism
+
+Block commands should receive a closed environment: Cleanroom's deterministic
+baseline variables plus the block's declared `env`. Host process environment
+values must not leak into file-keyed volume-cache commands unless they are
+explicitly declared and hashed.
+
+`dependency_env_digest` and `service_env_digest` include declared block env,
+Cleanroom-supplied cache path variables, `HOME`, working directory, and any
+other baseline values that can affect command behavior.
+
+The compiled policy hash constrains network access, but it does not make mutable
+upstream responses deterministic. File-keyed volume cache is only safe for
+dependency or service commands whose external inputs are pinned by declared
+files, resolved through immutable/cache-backed artifacts, or otherwise included
+in the input manifest. Commands that resolve `latest` style upstream state
+should stay on exact full-rootfs caching until a resolver can record the
+resolved artifact identity.
+
+### Overlay write capture
+
+Overlay write capture is the preferred cheap mechanism for detecting undeclared
+persistent writes. It is a guest execution feature, not a host volume-driver
+feature.
+
+For a cacheable block miss, the runner should:
+
+1. create a guest mount namespace for the block
+2. mount the current rootfs as an overlay lowerdir
+3. create per-block `upperdir`, `workdir`, and merged root directories
+4. mount scratch paths such as `/tmp`, `/run`, and `/var/tmp` as tmpfs or filter
+   them from the escaped-write report
+5. mount the read-only input projection at the command working directory
+6. mount each `outputs.dirs` mapping as writable inside the merged root
+7. run the command inside the merged root with `chroot`, `pivot_root`, or an
+   equivalent backend runner primitive
+8. inspect the upperdir after the command exits
+
+The upperdir is the path-shaped diff for everything that was not sent to a
+declared directory output or scratch mount. Cleanroom should subtract its own
+setup baseline, such as mountpoint directories it created before the command,
+before reporting escaped writes.
+
+Declared file outputs are allowed entries in the upperdir. Cleanroom copies
+their final contents into the output store and restores them into the sandbox
+root after the overlay run. Ancestor directories created only to reach declared
+file outputs are also allowed. Any other persistent upperdir entry is an escaped
+write.
+
+If escaped writes are found, the first implementation should warn, skip
+file-keyed cache publication, restart from the pre-block state, and rerun the
+block through the exact full-rootfs path. It must not discard the upperdir and
+continue as if the block succeeded normally, because later commands would see a
+sandbox that differs from the command's real effects.
+
+Once the feature is stable, escaped writes should become hard failures for
+cacheable blocks. The first slice uses exact fallback to keep existing workflows
+moving while users learn the declaration contract.
+
+A local `darwin-vz` experiment on 2026-05-02 validated the basic guest
+mechanism: the managed Linux guest exposes overlayfs, root commands can mount an
+overlay with `/` as the lowerdir, writes and whiteout deletes appear in the
+upperdir, and bind-mounted declared output directories do not appear in the
+upperdir except for setup-created mountpoints. That proves the mechanism is
+viable, but not that every backend can attach reusable output volumes yet.
+
+## Cache Keys
+
+Add cache-key helpers for dependency and service volume outputs in
+`internal/cachekey/cachekey.go`.
+
+Dependency block key:
+
+```text
+dependency_volume_key = H(
+  backend,
+  runtime_key,
+  reuse_namespace,
+  compiled_policy_hash,
+  block_name,
+  dependency_command_digest,
+  dependency_env_digest,
+  dependency_input_manifest_digest,
+  normalized_outputs_digest,
+  prior_dependency_output_keys_digest,
+  output_volume_layout_version,
+  producer_version
+)
+```
+
+Service block key:
+
+```text
+service_volume_key = H(
+  backend,
+  runtime_key,
+  reuse_namespace,
+  compiled_policy_hash,
+  block_name,
+  service_command_digest,
+  service_env_digest,
+  service_input_manifest_digest,
+  normalized_outputs_digest,
+  dependency_output_keys_digest,
+  prior_service_output_keys_digest,
+  output_volume_layout_version,
+  producer_version
+)
+```
+
+Input manifests should record path, file type, mode, content digest, symlink
+target, and deleted state. They should be sorted before hashing. Missing
+required literal paths should fail. Glob matches should be sorted and should
+fail if the pattern is invalid or matches no files. Optional inputs can be added
+later as an explicit schema feature; the first implementation should not hash an
+empty glob as an empty input set because that is usually a typo and creates an
+overbroad cache key. Input projection validation must reject symlink escapes
+before running the block command.
+
+The normalized output declaration is part of the key because changing directory
+mount destinations or file-output restore paths can change command behavior even
+when file inputs are the same.
+
+## Volume Layout
+
+Start with one aggregate output store per block. Directory outputs use mounted
+subdirectories. File outputs use stored files that Cleanroom copies into the
+sandbox root on cache hit or after a successful miss.
+
+Example:
+
+```text
+outputs.dirs:
+  - ${HOME}/.local/share/mise
+  - ${HOME}/go/pkg/mod
+outputs.files:
+  - ${HOME}/.cache/tool/index.json
+
+dependency block volume:
+  dirs/
+    home-cleanroom-.local-share-mise/
+    home-cleanroom-go-pkg-mod/
+  files/
+    home-cleanroom-.cache-tool-index.json
+
+guest view:
+  /home/cleanroom/.local/share/mise -> mounted/bound mapped output dir
+  /home/cleanroom/go/pkg/mod        -> mounted/bound mapped output dir
+  /home/cleanroom/.cache/tool/index.json restored as a file
+```
+
+The aggregate-per-block layout makes lookup, clone, publish, and rollback
+atomic. Per-path volumes can come later if partial reuse becomes important.
+Directory outputs may need real block devices or bind mounts for speed. File
+outputs are expected to be small enough that copying them is acceptable and
+avoids brittle single-file mounts.
+
+## Backend Boundary
+
+Add backend capabilities and request fields for cache output volumes rather than
+teaching the control service backend internals.
+
+Suggested capability names:
+
+- `sandbox.cache_output_volumes`
+- `sandbox.cache_output_fast_clone`
+- `sandbox.overlay_write_capture`
+
+The first implementation should not rely on hotplug. All directory output
+volumes needed for dependency and service blocks must be resolved before VM
+launch, then passed to provisioning as sidecar volume specs. Cache hits clone
+existing output snapshots; misses create empty writable volumes. The VM boots
+once with the rootfs plus all cache output volumes attached. File outputs can be
+stored in the same aggregate output store, but they are restored by file copy
+rather than by mounting a single file.
+
+Suggested backend types in `internal/backend/backend.go`:
+
+```go
+type CacheOutputVolumeSpec struct {
+  Stage string
+  BlockName string
+  VolumeID string
+  SourceSnapshotRef string
+  DirMappings []CacheOutputDirMapping
+  FileMappings []CacheOutputFileMapping
+}
+
+type CacheOutputDirMapping struct {
+  GuestPath string
+  VolumeSubpath string
+}
+
+type CacheOutputFileMapping struct {
+  GuestPath string
+  VolumePath string
+}
+
+type ProvisionRequest struct {
+  SandboxID string
+  Policy *policy.CompiledPolicy
+  FirecrackerConfig
+  CacheOutputVolumes []CacheOutputVolumeSpec
+}
+
+type ProvisionFromSnapshotRequest struct {
+  SandboxID string
+  SnapshotID string
+  StorageRef string
+  Policy *policy.CompiledPolicy
+  FirecrackerConfig
+  CacheOutputVolumes []CacheOutputVolumeSpec
+}
+
+type CacheOutputVolumeAdapter interface {
+  Adapter
+  SnapshotCacheOutputVolumes(context.Context, SnapshotCacheOutputVolumesRequest) (*SnapshotCacheOutputVolumesResult, error)
+  DestroyCacheOutputVolumes(context.Context, DestroyCacheOutputVolumesRequest) error
+}
+```
+
+The provisioning request carries enough information for the backend to create or
+clone sidecar volumes before launch and mount directory outputs at the
+normalized guest paths. Snapshot and destroy requests should return enough
+metadata for the control service to persist cache records and clean up failed
+attempts. File mappings are used by the guest runner to extract and restore
+individual file outputs from the aggregate output store.
+
+Firecracker is the first target. It already has a volume-store abstraction in
+`internal/volumestore/store.go` and ZFS-backed clone support in
+`internal/backend/firecracker/backend.go`. The first Firecracker slice can
+extend the launch drives list with one additional block device per aggregate
+output volume, then run guest-side mount or bind setup before the
+dependency/service command. It should also add the guest overlay write-capture
+runner for missed cacheable blocks. Firecracker hotplug is out of scope for the
+first slice.
+
+Darwin-VZ should initially report `sandbox.cache_output_volumes` as unsupported
+unless the backend grows additional disk attach and guest mount support. Its
+current docs state that `/workspace` lives on the rootfs, and current launch code
+prepares a single writable rootfs image. It may still report
+`sandbox.overlay_write_capture` independently once the guest runner has a
+supported mount-namespace path; the local experiment showed the guest kernel and
+root execution environment are capable of the basic overlayfs operations.
+
+Backends without `sandbox.cache_output_volumes` should still run the new block
+schema with the same isolated input-projection semantics, using ordinary rootfs
+directories at the normalized output directories and ordinary rootfs files at
+the normalized output file paths instead of sidecar volumes. They do not publish
+volume caches, but they may still publish exact full-rootfs stage caches after
+the projected block commands run. If they support
+`sandbox.overlay_write_capture`, they can still report escaped writes for
+diagnostics. This keeps command behavior stable across backends while allowing
+fast volume restore only where supported.
+
+## Metadata Store
+
+The existing cache metadata model in `internal/cachestore/store.go` is centered
+on one cache key and one storage ref. Volume caches need one cache entry with
+one or more output volume refs.
+
+Add either:
+
+- a new `cache_volume_outputs` table keyed by stage, cache key, output index, and
+  normalized path, or
+- a JSON output manifest field if the store remains small and SQLite-only.
+
+Prefer a normalized table if garbage collection and per-output observability are
+expected soon. Each output record should include:
+
+- output kind: directory or file
+- normalized guest path
+- volume subpath
+- storage driver
+- storage ref
+- snapshot ref when different from storage ref
+- output manifest digest
+- created time and last-used time inherited from the parent cache record
+
+Cache records should still carry policy hash, backend, producer version, input
+manifest digest, normalized outputs digest, command digest, and parent dependency
+or service output keys.
+
+## Control Service Changes
+
+Expected files:
+
+- `internal/policy/policy.go`
+- `proto/cleanroom/v1/control.proto`
+- `internal/cachekey/cachekey.go`
+- `internal/cachestore/store.go`
+- `internal/controlservice/dependency_stage.go`
+- `internal/controlservice/services_stage.go`
+- `internal/controlservice/service.go`
+- `internal/controlservice/cache_observability.go`
+- `internal/controlservice/bootstrap_runner.go`
+
+Policy loading should make the new schema canonical immediately:
+
+- `sandbox.dependencies` is an ordered list of dependency blocks
+- `sandbox.services` is an ordered list of service blocks
+- `sandbox.docker.required` is the Docker runtime requirement
+- the old single-object `sandbox.dependencies` shape is rejected
+- the old `sandbox.services.command` and `sandbox.services.key` shape is rejected
+- the old `sandbox.services.docker.required` location is rejected
+
+The control service should build all dependency and service block plans before
+sandbox provisioning or snapshot restore. For each block it should:
+
+1. compute normalized input and output manifests
+2. compute the block cache key
+3. look up a ready cache record
+4. add a hit or empty output-volume spec to the provision request
+5. provision or restore the sandbox with all output volumes already attached
+6. materialize read-only input projections for missed blocks
+7. run only missed block commands through overlay write capture when supported
+8. extract and restore declared file outputs for missed blocks
+9. rerun the block through exact full-rootfs fallback when escaped writes are
+   found before later phases
+10. snapshot output volumes for missed blocks and persist metadata
+
+Service block planning follows the same pre-launch shape, but service commands
+run after dependency commands and include dependency output keys in their cache
+identity.
+
+## Escaped Write Handling
+
+Workspace cleanliness alone is not enough because a dependency or service block
+can write to `/etc`, `/usr/local`, `$HOME`, or another persistent rootfs path.
+The publish gate should inspect the overlay upperdir, not only `/workspace`.
+
+For dependency and service volume blocks:
+
+- writes under `outputs.dirs` go to mounted output directories
+- declared `outputs.files` are copied from the overlay upperdir into the output
+  store and then materialized back into the sandbox root
+- scratch writes under tmpfs or explicitly ignored scratch paths are not
+  published and are not escaped writes
+- any other persistent upperdir entry is an escaped write
+
+Escaped writes prevent file-keyed volume cache publication. In the first
+implementation, Cleanroom should warn and rerun the block through exact
+full-rootfs fallback so the sandbox still contains the command's real effects.
+After the feature is stable, cacheable blocks should fail hard on escaped writes.
+The user schema should still avoid a confusing `mode` field.
+
+## Observability
+
+Extend cache telemetry without replacing existing stage names. Add attributes
+for block name and volume-cache operation:
+
+- `cleanroom.cache.stage=dependency|services`
+- `cleanroom.cache.operation=lookup|prepare_volume|restore|publish|invalidate`
+- `cleanroom.cache.result=hit|miss|restored|published|fallback|failed`
+- `cleanroom.cache.block_name=<name>`
+- `cleanroom.cache.output_dir_count=<count>`
+- `cleanroom.cache.output_file_count=<count>`
+- `cleanroom.cache.escaped_write_count=<count>`
+
+Create-sandbox stream messages should stay user-readable:
+
+- `checking dependency cache: toolchains`
+- `restoring dependency outputs: toolchains`
+- `running dependency bootstrap: go-modules`
+- `skipping portable dependency cache for go-modules: undeclared writes detected`
+- `publishing service outputs: postgres`
+
+## Implementation Order
+
+1. Add schema types for `sandbox.docker.required`, dependency blocks, and service
+   blocks, including `outputs.dirs` and `outputs.files`, in
+   `internal/policy/policy.go` and `proto/cleanroom/v1/control.proto`.
+2. Add path expansion and validation helpers for `${HOME}`, `$HOME`, and `~`.
+3. Add deterministic input-manifest hashing for literal files and globs.
+4. Add dependency and service volume cache-key helpers in
+   `internal/cachekey/cachekey.go`.
+5. Add reuse namespace handling, defaulting to canonical repository remote.
+6. Extend cache metadata to record output volume refs and manifests.
+7. Add backend capability flags and provision request fields for cache output
+   volumes and overlay write capture in `internal/backend/backend.go`.
+8. Add a guest overlay write-capture runner that can execute one missed block
+   from an input projection, mount declared directory outputs, extract declared
+   file outputs, and report escaped writes.
+9. Implement Firecracker pre-launch output-volume preparation, mount setup,
+   snapshotting, clone restore, and cleanup.
+10. Wire dependency block planning and lookup into
+   `internal/controlservice/dependency_stage.go` and `service.go`.
+11. Wire service block planning and lookup into
+   `internal/controlservice/services_stage.go` and `service.go`.
+12. Add isolated input projection materialization and escaped-write exact
+    fallback handling.
+13. Update observability events, stream phases, docs, and examples.
+14. Add end-to-end tests that prove a source-only commit reuses dependency and
+    service output volumes without rerunning their commands.
+
+Steps 1 through 6 can be developed with unit tests before backend work. Steps 8
+and 9 are the main backend slices. Steps 10 and 11 depend on the backend request
+fields but can use a stub adapter in control-service tests.
+
+## Tests
+
+Minimum coverage:
+
+- policy validation accepts ordered dependency/service blocks
+- policy validation accepts `sandbox.docker.required` as the Docker runtime
+  requirement
+- policy validation rejects the old single-object `sandbox.dependencies` shape
+- policy validation rejects the old `sandbox.services.command` and
+  `sandbox.services.key` shape
+- policy validation rejects the old `sandbox.services.docker.required` location
+- policy validation rejects duplicate block names
+- policy validation rejects invalid output dir and file paths, relative paths, unknown
+  variables, `~otheruser`, and `/workspace` outputs
+- policy validation rejects duplicate or overlapping normalized output directories
+- policy validation rejects file outputs inside directory outputs
+- path normalization makes `~/go/pkg/mod` and `${HOME}/go/pkg/mod` equivalent
+- input manifests are deterministic across file order and glob order
+- input manifest validation rejects empty glob matches
+- input projection rejects symlinks that escape the declared input set
+- cache keys change when inputs, env, command, output declarations, runtime key, or
+  prior block output keys change
+- cache keys change when the reuse namespace changes
+- cache keys change when Cleanroom baseline command environment changes
+- cacheable block commands run from an isolated declared-input projection, not
+  from `/workspace`
+- dependency block cache hit restores output volumes and skips the command
+- file output cache hit restores the file without hiding sibling files in the
+  parent directory
+- partial dependency hit runs only missing later blocks
+- service block key changes when dependency output keys change
+- overlay write capture reports created, modified, deleted, and renamed paths in
+  the upperdir
+- declared directory output writes do not appear as escaped writes
+- declared file outputs are extracted from the upperdir and restored into the
+  sandbox root
+- persistent writes outside declared outputs prevent portable volume cache
+  publication and trigger exact fallback before later phases continue
+- Firecracker launch includes cache output block devices before the VM starts
+- backend cleanup runs when command execution, snapshot publication, or metadata
+  persistence fails
+- Firecracker ZFS path clones output volumes rather than copying ext4 bytes
+
+## Settled Decisions
+
+- Empty globs fail. Optional inputs can be added later with explicit schema.
+- The new list schema replaces the old dependency object directly.
+- `sandbox.services` is an ordered service block list immediately.
+- Docker enablement moves to `sandbox.docker.required`.
+- `${HOME}` is the value Cleanroom sets in the closed block execution
+  environment and hashes into the block key.
+- Escaped writes warn and trigger exact full-rootfs fallback in the first
+  implementation.
+- Escaped writes should become hard failures for cacheable blocks once the
+  feature is stable.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -86,28 +86,38 @@ sandbox:
     vcpus: 4
     memory: 8GiB
     disk: 16GiB
+  docker:
+    required: true
   dependencies:
-    network:
-      allow:
-        - proxy.golang.org:443
-        - sum.golang.org:443
-    command: mise exec -- go mod download
-    key:
-      files:
-        - .mise.toml
-        - go.mod
-        - go.sum
-    reuse: portable
-  services:
-    network:
-      allow: ghcr.io:443
-    docker:
-      required: true
+    - name: toolchains
+      command: mise install
+      inputs:
+        files:
+          - .mise.toml
+      outputs:
+        dirs:
+          - ${HOME}/.cache/mise
+          - ${HOME}/.local/share/mise
+    - name: go-modules
+      command: mise exec -- go mod download
+      inputs:
+        files:
+          - go.mod
+          - go.sum
+      outputs:
+        dirs:
+          - ${HOME}/go/pkg/mod
   run:
-    network: {}
     before: mise exec -- go test ./...
   network:
     default: deny
+    dependencies:
+      allow:
+        - proxy.golang.org:443
+        - sum.golang.org:443
+    services:
+      allow: ghcr.io:443
+    execution: {}
 ```
 
 ### 5.1.1 Repository bootstrap config
@@ -162,13 +172,23 @@ explicit request-time changeset input.
 - `sandbox.resources.vcpus` must be a positive integer.
 - `sandbox.resources.memory` and `sandbox.resources.disk` must be positive byte sizes. They accept raw bytes or size strings such as `4096MiB`, `8GiB`, or `16GiB`.
 - Resource requirements raise the effective backend runtime settings when the host runtime config is lower; they do not lower larger host defaults.
-- `sandbox.dependencies.command` defaults to unset; when present, Cleanroom runs that command in the repository workdir during sandbox creation and makes the result eligible for dependency-stage caching.
-- `sandbox.dependencies.command` accepts either a YAML string or a YAML sequence; strings execute as `sh -lc <value>`, and strings are the preferred form.
-- `sandbox.dependencies.key.files` defaults to empty; when present, Cleanroom hashes those repository-relative files from the exact committed checkout and includes them in the dependency-stage cache key.
-- `sandbox.dependencies.reuse` defaults to `exact`; `portable` opts into dependency-stage reuse across source-only commits by restoring the dependency snapshot, refreshing the checkout, and reusing it only when declared key files still match.
-- `sandbox.services.command` defaults to unset; when present, Cleanroom runs that command in the repository workdir after dependency bootstrap during sandbox creation and makes the result eligible for services-stage caching.
-- `sandbox.services.command` accepts either a YAML string or a YAML sequence; strings execute as `sh -lc <value>`, and strings are the preferred form.
-- `sandbox.services.key.files` defaults to empty; when present, Cleanroom hashes those repository-relative files from the exact committed checkout and includes them in the services-stage cache key.
+- `sandbox.docker.required` defaults to `false`; when true, Cleanroom starts the guest Docker daemon for the sandbox.
+- `sandbox.dependencies` defaults to an empty block list; each block has `name`, `command`, `inputs.files`, and `outputs.dirs` or `outputs.files`.
+- Dependency block commands run in the repository workdir during sandbox creation and make declared outputs eligible for dependency-stage caching.
+- Dependency block commands accept either a YAML string or a YAML sequence; strings execute as `sh -lc <value>`, and strings are the preferred form.
+- `sandbox.services` defaults to an empty block list; each block has `name`, `command`, `inputs.files`, and `outputs.dirs` or `outputs.files`.
+- Service block commands run in the repository workdir after dependency bootstrap during sandbox creation and make declared outputs eligible for services-stage caching.
+- Service block commands accept either a YAML string or a YAML sequence; strings execute as `sh -lc <value>`, and strings are the preferred form.
+- Block `inputs.files` are repository-relative regular files or globs matching
+  regular files. Literal paths must exist; globs must match at least one path.
+- Block `outputs.dirs` and `outputs.files` are absolute guest paths outside
+  `/workspace` and cannot be `/`; `${HOME}`, `$HOME`, and `~` expand to the
+  Cleanroom block execution home.
+- Block `env` values are literal strings, except leading home-directory
+  shorthand forms (`~`, `~/`, `$HOME`, `$HOME/`, `${HOME}`, `${HOME}/`) expand
+  to the Cleanroom block execution home.
+- Normalized outputs must be unique and non-overlapping across all dependency
+  and service blocks.
 - `sandbox.run.before` defaults to unset; when present, each execution runs that shell command in the repository workdir immediately before the requested command.
 - `sandbox.run.before` must be a YAML string or block string and executes as `sh -lc <value>`.
 - Policy schema intentionally has no field for implicit dirty-worktree inclusion; explicit local modifications are a separate request-time changeset input.
@@ -176,12 +196,10 @@ explicit request-time changeset input.
   entries or a single scalar entry.
 - `repository.network.allow` is the workspace-stage allowlist for repository
   checkout and explicit repository changeset application.
-- `sandbox.dependencies.network.allow` applies only while
-  `sandbox.dependencies.command` runs.
-- `sandbox.services.network.allow` applies only while
-  `sandbox.services.command` runs.
-- `sandbox.run.network.allow` applies to `sandbox.run.before` and the requested
-  execution command.
+- `sandbox.network.dependencies.allow` applies only while dependency blocks run.
+- `sandbox.network.services.allow` applies only while service blocks run.
+- `sandbox.network.execution.allow` applies to `sandbox.run.before` and the
+  requested execution command.
 - Stage-local network blocks do not inherit from one another. An omitted
   stage-local block means no external egress for that stage when any stage-local
   network block is configured.
@@ -266,8 +284,8 @@ A future runtime policy object may contain:
   - they resolve the local repository remote URL and committed `HEAD`
   - they materialize that checkout inside the sandbox before the command runs
   - they start commands in `repository.path`
-  - when `sandbox.dependencies.command` is set, sandbox creation runs that dependency bootstrap command after repository bootstrap and may publish a reusable dependency stage for later warm hits
-  - when `sandbox.services.command` is set, sandbox creation runs that services bootstrap command after dependency bootstrap and may publish a reusable services stage for later warm hits
+  - when `sandbox.dependencies` blocks are set, sandbox creation runs those dependency bootstrap blocks after repository bootstrap and may publish a reusable dependency stage for later warm hits
+  - when `sandbox.services` blocks are set, sandbox creation runs those services bootstrap blocks after dependency bootstrap and may publish a reusable services stage for later warm hits
   - when `sandbox.run.before` is set, each execution runs that shell command immediately before the requested command
   - Cleanroom does not auto-detect or auto-wrap `mise`; use explicit commands such as `mise exec -- ...` when needed
 - When explicitly requested, top-level commands may package local modifications against committed `HEAD` into a reproducible changeset, send that changeset as a separate sandbox-creation input, and apply it after repository bootstrap and before dependency bootstrap, services bootstrap, or workload execution.
@@ -336,11 +354,11 @@ Requirements:
 - If changeset application fails, or if the resulting repository tree digest
   does not match the expected post-apply tree digest, sandbox creation must fail
   closed.
-- Dependency bootstrap key resolution must use the post-apply repository tree
+- Dependency and service input resolution must use the post-apply repository tree
   when a changeset is present.
-- Portable dependency reuse requires declared dependency key files and must
-  refresh the checkout before running user code; if key-file validation fails,
-  the restored child is discarded and normal dependency bootstrap is used.
+- File-keyed dependency and service output reuse requires declared block inputs
+  and outputs and must validate declared inputs before publishing reusable
+  outputs.
 - Changesets are separate from both user snapshots and system-managed stage
   caches. They are explicit request inputs, not snapshot restore targets.
 
@@ -364,10 +382,11 @@ Minimum required fields:
   - optional `workspace`, `dependencies`, `services`, and `execution`
     allowlists
 - `services`
-  - Docker service requirement
-  - optional services bootstrap command and key files
+  - optional service blocks with command, inputs, and outputs
 - `dependencies`
-  - optional dependency bootstrap command, key files, and reuse mode
+  - optional dependency blocks with command, inputs, and outputs
+- `docker`
+  - Docker service requirement
 - `run`
   - optional pre-run command
 - `resources`

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -173,7 +173,8 @@ explicit request-time changeset input.
 - `sandbox.resources.memory` and `sandbox.resources.disk` must be positive byte sizes. They accept raw bytes or size strings such as `4096MiB`, `8GiB`, or `16GiB`.
 - Resource requirements raise the effective backend runtime settings when the host runtime config is lower; they do not lower larger host defaults.
 - `sandbox.docker.required` defaults to `false`; when true, Cleanroom starts the guest Docker daemon for the sandbox.
-- `sandbox.dependencies` defaults to an empty block list; each block has `name`, `command`, `inputs.files`, and `outputs.dirs` or `outputs.files`.
+- `sandbox.dependencies` defaults to an empty block list; each block has `name`, `command`, `inputs.files`, and `outputs.dirs` or `outputs.files`. It may be a block list directly, or an object with `reuse` and `blocks` when dependency-stage options are needed.
+- `sandbox.dependencies.reuse` may be `portable` when `sandbox.dependencies.blocks` declares at least one input file; omitted or `exact` means exact checkout reuse only.
 - Dependency block commands run in the repository workdir during sandbox creation and make declared outputs eligible for dependency-stage caching.
 - Dependency block commands accept either a YAML string or a YAML sequence; strings execute as `sh -lc <value>`, and strings are the preferred form.
 - `sandbox.services` defaults to an empty block list; each block has `name`, `command`, `inputs.files`, and `outputs.dirs` or `outputs.files`.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -104,6 +104,8 @@ sandbox:
         files:
           - go.mod
           - go.sum
+      env:
+        GOMODCACHE: ${HOME}/go/pkg/mod
       outputs:
         dirs:
           - ${HOME}/go/pkg/mod
@@ -184,10 +186,12 @@ explicit request-time changeset input.
   regular files. Literal paths must exist; globs must match at least one path.
 - Block `outputs.dirs` and `outputs.files` are absolute guest paths outside
   `/workspace` and cannot be `/`; `${HOME}`, `$HOME`, and `~` expand to the
-  Cleanroom block execution home.
+  Cleanroom block execution home, while `${WORKSPACE}` and `$WORKSPACE` expand
+  to the Cleanroom workspace root before the workspace-output rejection runs.
 - Block `env` values are literal strings, except leading home-directory
-  shorthand forms (`~`, `~/`, `$HOME`, `$HOME/`, `${HOME}`, `${HOME}/`) expand
-  to the Cleanroom block execution home.
+  and workspace shorthand forms (`~`, `~/`, `$HOME`, `$HOME/`, `${HOME}`,
+  `${HOME}/`, `$WORKSPACE`, `$WORKSPACE/`, `${WORKSPACE}`, `${WORKSPACE}/`)
+  expand to the corresponding Cleanroom guest paths.
 - Normalized outputs must be unique and non-overlapping across all dependency
   and service blocks.
 - `sandbox.run.before` defaults to unset; when present, each execution runs that shell command in the repository workdir immediately before the requested command.

--- a/examples/buildkite-agent/cleanroom.yaml
+++ b/examples/buildkite-agent/cleanroom.yaml
@@ -6,15 +6,27 @@ sandbox:
     memory: 12GiB
     disk: 12GiB
   dependencies:
-    command: |
-      mise settings ruby.compile=false
-      mise install
-      mise exec -- go mod download
-    key:
-      files:
-        - .mise.toml
-        - go.mod
-        - go.sum
+    - name: toolchains
+      command: |
+        mise settings ruby.compile=false
+        mise install
+      inputs:
+        files:
+          - .mise.toml
+      outputs:
+        dirs:
+          - ${HOME}/.cache/mise
+          - ${HOME}/.local/share/mise
+          - ${HOME}/.local/state/mise
+    - name: go-modules
+      command: mise exec -- go mod download
+      inputs:
+        files:
+          - go.mod
+          - go.sum
+      outputs:
+        dirs:
+          - ${HOME}/go/pkg/mod
   network:
     default: deny
     allow:

--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -12,7 +12,7 @@ mise run install
 
 ## Files
 
-- `cleanroom.yaml`: digest-pinned Docker image ref, `sandbox.services.docker.required: true`, and a deny-by-default network allowlist for the upstream Docker Hub endpoints that the host gateway validates and fetches against.
+- `cleanroom.yaml`: digest-pinned Docker image ref, `sandbox.docker.required: true`, and a deny-by-default network allowlist for the upstream Docker Hub endpoints that the host gateway validates and fetches against.
 
 ## Quick test flow
 

--- a/examples/docker/cleanroom.yaml
+++ b/examples/docker/cleanroom.yaml
@@ -4,9 +4,8 @@ repository:
 sandbox:
   image:
     ref: index.docker.io/library/docker@sha256:aa3df78ecf320f5fafdce71c659f1629e96e9de0968305fe1de670e0ca9176ce
-  services:
-    docker:
-      required: true
+  docker:
+    required: true
   network:
     default: deny
     allow:

--- a/examples/rails/README.md
+++ b/examples/rails/README.md
@@ -48,7 +48,7 @@ cleanroom exec \
 
 ## What this exercises
 
-- `sandbox.dependencies.command` fills the remaining guest package gap
+- the `bundle` dependency block fills the remaining guest package gap
   (`default-libmysqlclient-dev`, `libxml2-dev`) and runs a full `bundle install`
 - Bundler mirror env injection rewrites the default `https://rubygems.org`
   source through Cleanroom's `/rubygems/` gateway route

--- a/examples/rails/README.md
+++ b/examples/rails/README.md
@@ -50,6 +50,8 @@ cleanroom exec \
 
 - the `bundle` dependency block fills the remaining guest package gap
   (`default-libmysqlclient-dev`, `libxml2-dev`) and runs a full `bundle install`
+- the block sets Bundler env so gems and Bundler app config are materialized
+  under the declared `/usr/local/bundle` output
 - Bundler mirror env injection rewrites the default `https://rubygems.org`
   source through Cleanroom's `/rubygems/` gateway route
 - the dependency stage is keyed on `Gemfile`, `Gemfile.lock`, and the component

--- a/examples/rails/cleanroom.yaml
+++ b/examples/rails/cleanroom.yaml
@@ -8,33 +8,37 @@ sandbox:
     memory: 4GiB
     disk: 14GiB
   dependencies:
-    command:
-      - sh
-      - -lc
-      - >-
-        apt-get update &&
-        apt-get install --yes --no-install-recommends
-        default-libmysqlclient-dev
-        libxml2-dev
-        &&
-        bundle install --jobs 4 --retry 1
-    key:
-      files:
-        - Gemfile
-        - Gemfile.lock
-        - rails.gemspec
-        - actioncable/actioncable.gemspec
-        - actionmailbox/actionmailbox.gemspec
-        - actionmailer/actionmailer.gemspec
-        - actionpack/actionpack.gemspec
-        - actiontext/actiontext.gemspec
-        - actionview/actionview.gemspec
-        - activejob/activejob.gemspec
-        - activemodel/activemodel.gemspec
-        - activerecord/activerecord.gemspec
-        - activestorage/activestorage.gemspec
-        - activesupport/activesupport.gemspec
-        - railties/railties.gemspec
+    - name: bundle
+      command:
+        - sh
+        - -lc
+        - >-
+          apt-get update &&
+          apt-get install --yes --no-install-recommends
+          default-libmysqlclient-dev
+          libxml2-dev
+          &&
+          bundle install --jobs 4 --retry 1
+      inputs:
+        files:
+          - Gemfile
+          - Gemfile.lock
+          - rails.gemspec
+          - actioncable/actioncable.gemspec
+          - actionmailbox/actionmailbox.gemspec
+          - actionmailer/actionmailer.gemspec
+          - actionpack/actionpack.gemspec
+          - actiontext/actiontext.gemspec
+          - actionview/actionview.gemspec
+          - activejob/activejob.gemspec
+          - activemodel/activemodel.gemspec
+          - activerecord/activerecord.gemspec
+          - activestorage/activestorage.gemspec
+          - activesupport/activesupport.gemspec
+          - railties/railties.gemspec
+      outputs:
+        dirs:
+          - /usr/local/bundle
   network:
     default: deny
     allow:

--- a/examples/rails/cleanroom.yaml
+++ b/examples/rails/cleanroom.yaml
@@ -9,6 +9,10 @@ sandbox:
     disk: 14GiB
   dependencies:
     - name: bundle
+      env:
+        GEM_HOME: /usr/local/bundle
+        BUNDLE_PATH: /usr/local/bundle
+        BUNDLE_APP_CONFIG: /usr/local/bundle
       command:
         - sh
         - -lc

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -13,23 +13,26 @@ import (
 )
 
 const (
-	CapabilityExecStreaming            = "exec.streaming"
-	CapabilitySandboxSnapshot          = "sandbox.snapshot"
-	CapabilitySandboxFileDownload      = "sandbox.file_download"
-	CapabilitySandboxFileUpload        = "sandbox.file_upload"
-	CapabilitySandboxPathStat          = "sandbox.path_stat"
-	CapabilitySandboxTreeWalk          = "sandbox.tree_walk"
-	CapabilitySandboxFileRead          = "sandbox.file_read"
-	CapabilitySandboxFileWrite         = "sandbox.file_write"
-	CapabilitySandboxPathRemove        = "sandbox.path_remove"
-	CapabilitySandboxArchiveRead       = "sandbox.archive_read"
-	CapabilitySandboxArchiveWrite      = "sandbox.archive_write"
-	CapabilityNetworkDefaultDeny       = "network.default_deny"
-	CapabilityNetworkAllowlistEgress   = "network.allowlist_egress"
-	CapabilityNetworkStageScopedEgress = "network.stage_scoped_egress"
-	CapabilityDNSControlOrEquivalent   = "dns_control_or_equivalent"
-	CapabilityNetworkGuestInterface    = "network.guest_interface"
-	CapabilitySandboxPortDial          = "sandbox.port_dial"
+	CapabilityExecStreaming               = "exec.streaming"
+	CapabilitySandboxSnapshot             = "sandbox.snapshot"
+	CapabilitySandboxFileDownload         = "sandbox.file_download"
+	CapabilitySandboxFileUpload           = "sandbox.file_upload"
+	CapabilitySandboxPathStat             = "sandbox.path_stat"
+	CapabilitySandboxTreeWalk             = "sandbox.tree_walk"
+	CapabilitySandboxFileRead             = "sandbox.file_read"
+	CapabilitySandboxFileWrite            = "sandbox.file_write"
+	CapabilitySandboxPathRemove           = "sandbox.path_remove"
+	CapabilitySandboxArchiveRead          = "sandbox.archive_read"
+	CapabilitySandboxArchiveWrite         = "sandbox.archive_write"
+	CapabilityNetworkDefaultDeny          = "network.default_deny"
+	CapabilityNetworkAllowlistEgress      = "network.allowlist_egress"
+	CapabilityNetworkStageScopedEgress    = "network.stage_scoped_egress"
+	CapabilityDNSControlOrEquivalent      = "dns_control_or_equivalent"
+	CapabilityNetworkGuestInterface       = "network.guest_interface"
+	CapabilitySandboxPortDial             = "sandbox.port_dial"
+	CapabilitySandboxCacheOutputVolumes   = "sandbox.cache_output_volumes"
+	CapabilitySandboxCacheOutputFastClone = "sandbox.cache_output_fast_clone"
+	CapabilitySandboxOverlayWriteCapture  = "sandbox.overlay_write_capture"
 )
 
 var knownCapabilityKeys = []string{
@@ -50,6 +53,9 @@ var knownCapabilityKeys = []string{
 	CapabilityDNSControlOrEquivalent,
 	CapabilityNetworkGuestInterface,
 	CapabilitySandboxPortDial,
+	CapabilitySandboxCacheOutputVolumes,
+	CapabilitySandboxCacheOutputFastClone,
+	CapabilitySandboxOverlayWriteCapture,
 }
 
 type Adapter interface {
@@ -232,8 +238,9 @@ type SandboxPortDialer interface {
 }
 
 type ProvisionRequest struct {
-	SandboxID string
-	Policy    *policy.CompiledPolicy
+	SandboxID          string
+	Policy             *policy.CompiledPolicy
+	CacheOutputVolumes []CacheOutputVolumeSpec
 	FirecrackerConfig
 }
 
@@ -248,11 +255,35 @@ type SnapshotResult struct {
 }
 
 type ProvisionFromSnapshotRequest struct {
-	SandboxID  string
-	SnapshotID string
-	StorageRef string
-	Policy     *policy.CompiledPolicy
+	SandboxID          string
+	SnapshotID         string
+	StorageRef         string
+	Policy             *policy.CompiledPolicy
+	CacheOutputVolumes []CacheOutputVolumeSpec
 	FirecrackerConfig
+}
+
+type CacheOutputVolumeSpec struct {
+	Stage             string
+	BlockName         string
+	CacheKey          string
+	VolumeID          string
+	SourceSnapshotRef string
+	StorageDriver     string
+	StorageRef        string
+	DirMappings       []CacheOutputDirMapping
+	FileMappings      []CacheOutputFileMapping
+}
+
+type CacheOutputDirMapping struct {
+	GuestPath string
+	Subpath   string
+}
+
+type CacheOutputFileMapping struct {
+	GuestPath string
+	Subpath   string
+	Mode      fs.FileMode
 }
 
 type DeleteSnapshotRequest struct {

--- a/internal/backend/capabilities_test.go
+++ b/internal/backend/capabilities_test.go
@@ -93,6 +93,15 @@ func TestCapabilitiesForAdapterInfersInterfaceCapabilities(t *testing.T) {
 			t.Fatalf("expected %s=true", key)
 		}
 	}
+	for _, key := range []string{
+		CapabilitySandboxCacheOutputVolumes,
+		CapabilitySandboxCacheOutputFastClone,
+		CapabilitySandboxOverlayWriteCapture,
+	} {
+		if caps[key] {
+			t.Fatalf("expected %s=false without backend reporter", key)
+		}
+	}
 }
 
 func TestCapabilitiesForAdapterMergesReporterCapabilities(t *testing.T) {

--- a/internal/backend/darwinvz/docker_bootargs_test.go
+++ b/internal/backend/darwinvz/docker_bootargs_test.go
@@ -20,9 +20,7 @@ func TestDockerServiceBootArgsDisabledByDefault(t *testing.T) {
 
 func TestDockerServiceBootArgsUsesPolicyAndRuntimeSettings(t *testing.T) {
 	compiled := &policy.CompiledPolicy{
-		Services: policy.Services{
-			Docker: policy.DockerService{Required: true},
-		},
+		Docker: policy.DockerService{Required: true},
 	}
 	cfg := backend.FirecrackerConfig{
 		DockerStartupSeconds: 45,
@@ -47,9 +45,7 @@ func TestDockerServiceBootArgsUsesPolicyAndRuntimeSettings(t *testing.T) {
 
 func TestDockerServiceBootArgsSkipsMirrorWithoutLiveRoute(t *testing.T) {
 	compiled := &policy.CompiledPolicy{
-		Services: policy.Services{
-			Docker: policy.DockerService{Required: true},
-		},
+		Docker: policy.DockerService{Required: true},
 	}
 
 	got := dockerServiceBootArgs(compiled, backend.FirecrackerConfig{}, 8170, gateway.ProxyRoutes{})

--- a/internal/backend/firecracker/docker_bootargs_test.go
+++ b/internal/backend/firecracker/docker_bootargs_test.go
@@ -18,9 +18,7 @@ func TestDockerServiceBootArgsDisabledByDefault(t *testing.T) {
 
 func TestDockerServiceBootArgsUsesPolicyAndRuntimeSettings(t *testing.T) {
 	compiled := &policy.CompiledPolicy{
-		Services: policy.Services{
-			Docker: policy.DockerService{Required: true},
-		},
+		Docker: policy.DockerService{Required: true},
 	}
 	cfg := backend.FirecrackerConfig{
 		DockerStartupSeconds: 45,
@@ -45,9 +43,7 @@ func TestDockerServiceBootArgsUsesPolicyAndRuntimeSettings(t *testing.T) {
 
 func TestDockerServiceBootArgsUsesSafeDefaults(t *testing.T) {
 	compiled := &policy.CompiledPolicy{
-		Services: policy.Services{
-			Docker: policy.DockerService{Required: true},
-		},
+		Docker: policy.DockerService{Required: true},
 	}
 	got := dockerServiceBootArgs(compiled, backend.FirecrackerConfig{}, 0, gateway.ProxyRoutes{})
 	for _, want := range []string{
@@ -63,9 +59,7 @@ func TestDockerServiceBootArgsUsesSafeDefaults(t *testing.T) {
 
 func TestDockerServiceBootArgsSkipsMirrorWithoutLiveRoute(t *testing.T) {
 	compiled := &policy.CompiledPolicy{
-		Services: policy.Services{
-			Docker: policy.DockerService{Required: true},
-		},
+		Docker: policy.DockerService{Required: true},
 	}
 
 	got := dockerServiceBootArgs(compiled, backend.FirecrackerConfig{}, 8170, gateway.ProxyRoutes{})

--- a/internal/cachekey/cachekey.go
+++ b/internal/cachekey/cachekey.go
@@ -70,6 +70,41 @@ type PortableDependencyStageInputs struct {
 	ProducerVersion             string
 }
 
+// DependencyVolumeInputs are the inputs that define a cacheable dependency
+// block output volume.
+type DependencyVolumeInputs struct {
+	Backend                         string
+	RuntimeKey                      string
+	ReuseNamespace                  string
+	CompiledPolicyHash              string
+	BlockName                       string
+	CommandDigest                   string
+	EnvDigest                       string
+	InputManifestDigest             string
+	NormalizedOutputsDigest         string
+	PriorDependencyOutputKeysDigest string
+	OutputVolumeLayoutVersion       string
+	ProducerVersion                 string
+}
+
+// ServiceVolumeInputs are the inputs that define a cacheable service block
+// output volume.
+type ServiceVolumeInputs struct {
+	Backend                      string
+	RuntimeKey                   string
+	ReuseNamespace               string
+	CompiledPolicyHash           string
+	BlockName                    string
+	CommandDigest                string
+	EnvDigest                    string
+	InputManifestDigest          string
+	NormalizedOutputsDigest      string
+	DependencyOutputKeysDigest   string
+	PriorServiceOutputKeysDigest string
+	OutputVolumeLayoutVersion    string
+	ProducerVersion              string
+}
+
 // RuntimeStageKey returns the canonical cache key for a runtime stage output.
 func RuntimeStageKey(in RuntimeStageInputs) string {
 	return buildStageKey("runtime", []component{
@@ -138,6 +173,56 @@ func PortableDependencyStageKey(in PortableDependencyStageInputs) string {
 	})
 }
 
+// DependencyVolumeKey returns the canonical cache key for a dependency block
+// output volume.
+func DependencyVolumeKey(in DependencyVolumeInputs) string {
+	return buildStageKey("dependency-volume", []component{
+		{name: "backend", value: canonicalIdentifier(in.Backend)},
+		{name: "runtime_key", value: canonicalReference(in.RuntimeKey)},
+		{name: "reuse_namespace", value: canonicalReuseNamespace(in.ReuseNamespace)},
+		{name: "compiled_policy_hash", value: canonicalDigest(in.CompiledPolicyHash)},
+		{name: "block_name", value: canonicalIdentifier(in.BlockName)},
+		{name: "command_digest", value: canonicalDigest(in.CommandDigest)},
+		{name: "env_digest", value: canonicalDigest(in.EnvDigest)},
+		{name: "input_manifest_digest", value: canonicalDigest(in.InputManifestDigest)},
+		{name: "normalized_outputs_digest", value: canonicalDigest(in.NormalizedOutputsDigest)},
+		{name: "prior_dependency_output_keys_digest", value: canonicalDigest(in.PriorDependencyOutputKeysDigest)},
+		{name: "output_volume_layout_version", value: canonicalIdentifier(in.OutputVolumeLayoutVersion)},
+		{name: "producer_version", value: canonicalIdentifier(in.ProducerVersion)},
+	})
+}
+
+// ServiceVolumeKey returns the canonical cache key for a service block output
+// volume.
+func ServiceVolumeKey(in ServiceVolumeInputs) string {
+	return buildStageKey("service-volume", []component{
+		{name: "backend", value: canonicalIdentifier(in.Backend)},
+		{name: "runtime_key", value: canonicalReference(in.RuntimeKey)},
+		{name: "reuse_namespace", value: canonicalReuseNamespace(in.ReuseNamespace)},
+		{name: "compiled_policy_hash", value: canonicalDigest(in.CompiledPolicyHash)},
+		{name: "block_name", value: canonicalIdentifier(in.BlockName)},
+		{name: "command_digest", value: canonicalDigest(in.CommandDigest)},
+		{name: "env_digest", value: canonicalDigest(in.EnvDigest)},
+		{name: "input_manifest_digest", value: canonicalDigest(in.InputManifestDigest)},
+		{name: "normalized_outputs_digest", value: canonicalDigest(in.NormalizedOutputsDigest)},
+		{name: "dependency_output_keys_digest", value: canonicalDigest(in.DependencyOutputKeysDigest)},
+		{name: "prior_service_output_keys_digest", value: canonicalDigest(in.PriorServiceOutputKeysDigest)},
+		{name: "output_volume_layout_version", value: canonicalIdentifier(in.OutputVolumeLayoutVersion)},
+		{name: "producer_version", value: canonicalIdentifier(in.ProducerVersion)},
+	})
+}
+
+// ReuseNamespace returns the cache reuse boundary for file-keyed output volumes.
+// Explicit namespaces are trusted by policy; otherwise reuse is scoped to the
+// canonical repository remote.
+func ReuseNamespace(explicit, canonicalRemote string) string {
+	explicit = strings.TrimSpace(explicit)
+	if explicit != "" {
+		return explicit
+	}
+	return canonicalRemoteURL(canonicalRemote)
+}
+
 type component struct {
 	name  string
 	value string
@@ -176,6 +261,10 @@ func canonicalIdentifier(value string) string {
 }
 
 func canonicalReference(value string) string {
+	return strings.TrimSpace(value)
+}
+
+func canonicalReuseNamespace(value string) string {
 	return strings.TrimSpace(value)
 }
 

--- a/internal/cachekey/cachekey_test.go
+++ b/internal/cachekey/cachekey_test.go
@@ -130,3 +130,81 @@ func TestPortableDependencyStageKey(t *testing.T) {
 		t.Fatalf("portable dependency stage key did not change after repository mutation: %q", got)
 	}
 }
+
+func TestDependencyVolumeKey(t *testing.T) {
+	inputs := DependencyVolumeInputs{
+		Backend:                         "firecracker",
+		RuntimeKey:                      "runtime:v1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		ReuseNamespace:                  "https://github.com/buildkite/cleanroom.git",
+		CompiledPolicyHash:              "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+		BlockName:                       "go-modules",
+		CommandDigest:                   "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+		EnvDigest:                       "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+		InputManifestDigest:             "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+		NormalizedOutputsDigest:         "sha256:5555555555555555555555555555555555555555555555555555555555555555",
+		PriorDependencyOutputKeysDigest: "sha256:6666666666666666666666666666666666666666666666666666666666666666",
+		OutputVolumeLayoutVersion:       "aggregate-v1",
+		ProducerVersion:                 "cleanroom/dependency-volume-v1",
+	}
+
+	got := DependencyVolumeKey(inputs)
+	if !strings.HasPrefix(got, "dependency-volume:v1:") {
+		t.Fatalf("dependency volume key prefix = %q, want %q", got, "dependency-volume:v1:")
+	}
+	if gotAgain := DependencyVolumeKey(inputs); got != gotAgain {
+		t.Fatalf("dependency volume key changed for identical inputs: first %q second %q", got, gotAgain)
+	}
+
+	mutated := inputs
+	mutated.ReuseNamespace = "https://github.com/buildkite/other.git"
+	if gotMutated := DependencyVolumeKey(mutated); got == gotMutated {
+		t.Fatalf("dependency volume key did not change after reuse namespace mutation: %q", got)
+	}
+
+	mutated = inputs
+	mutated.NormalizedOutputsDigest = "sha256:7777777777777777777777777777777777777777777777777777777777777777"
+	if gotMutated := DependencyVolumeKey(mutated); got == gotMutated {
+		t.Fatalf("dependency volume key did not change after outputs mutation: %q", got)
+	}
+}
+
+func TestServiceVolumeKey(t *testing.T) {
+	inputs := ServiceVolumeInputs{
+		Backend:                      "firecracker",
+		RuntimeKey:                   "runtime:v1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		ReuseNamespace:               "https://github.com/buildkite/cleanroom.git",
+		CompiledPolicyHash:           "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+		BlockName:                    "postgres",
+		CommandDigest:                "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+		EnvDigest:                    "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+		InputManifestDigest:          "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+		NormalizedOutputsDigest:      "sha256:5555555555555555555555555555555555555555555555555555555555555555",
+		DependencyOutputKeysDigest:   "sha256:6666666666666666666666666666666666666666666666666666666666666666",
+		PriorServiceOutputKeysDigest: "sha256:7777777777777777777777777777777777777777777777777777777777777777",
+		OutputVolumeLayoutVersion:    "aggregate-v1",
+		ProducerVersion:              "cleanroom/service-volume-v1",
+	}
+
+	got := ServiceVolumeKey(inputs)
+	if !strings.HasPrefix(got, "service-volume:v1:") {
+		t.Fatalf("service volume key prefix = %q, want %q", got, "service-volume:v1:")
+	}
+	if gotAgain := ServiceVolumeKey(inputs); got != gotAgain {
+		t.Fatalf("service volume key changed for identical inputs: first %q second %q", got, gotAgain)
+	}
+
+	mutated := inputs
+	mutated.DependencyOutputKeysDigest = "sha256:8888888888888888888888888888888888888888888888888888888888888888"
+	if gotMutated := ServiceVolumeKey(mutated); got == gotMutated {
+		t.Fatalf("service volume key did not change after dependency output keys mutation: %q", got)
+	}
+}
+
+func TestReuseNamespaceDefaultsToCanonicalRemote(t *testing.T) {
+	if got, want := ReuseNamespace("", " https://github.com/buildkite/cleanroom.git "), "https://github.com/buildkite/cleanroom.git"; got != want {
+		t.Fatalf("unexpected default reuse namespace: got %q want %q", got, want)
+	}
+	if got, want := ReuseNamespace("org/buildkite", "https://github.com/buildkite/cleanroom.git"), "org/buildkite"; got != want {
+		t.Fatalf("unexpected explicit reuse namespace: got %q want %q", got, want)
+	}
+}

--- a/internal/cachestore/store.go
+++ b/internal/cachestore/store.go
@@ -3,6 +3,7 @@ package cachestore
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -31,11 +32,26 @@ type Record struct {
 	StorageDriver            string
 	StorageRef               string
 	InputManifestDigest      string
+	CommandDigest            string
+	EnvDigest                string
+	NormalizedOutputsDigest  string
+	OutputManifestDigest     string
 	DependencyKeyFilesDigest string
+	OutputRecords            []OutputRecord
 	CheckoutRefreshRequired  bool
 	CreatedAt                time.Time
 	LastUsedAt               time.Time
 	ProducerVersion          string
+}
+
+type OutputRecord struct {
+	Kind           string `json:"kind"`
+	Path           string `json:"path"`
+	VolumeSubpath  string `json:"volume_subpath,omitempty"`
+	StorageDriver  string `json:"storage_driver"`
+	StorageRef     string `json:"storage_ref"`
+	SnapshotRef    string `json:"snapshot_ref,omitempty"`
+	ManifestDigest string `json:"manifest_digest,omitempty"`
 }
 
 type Options struct {
@@ -123,6 +139,13 @@ func (s *Store) persist(ctx context.Context, record Record, replace bool) error 
 			return fmt.Errorf("marshal cache repository %q: %w", record.CacheKey, err)
 		}
 	}
+	var outputRecordsBytes []byte
+	if len(record.OutputRecords) > 0 {
+		outputRecordsBytes, err = json.Marshal(record.OutputRecords)
+		if err != nil {
+			return fmt.Errorf("marshal cache output records %q: %w", record.CacheKey, err)
+		}
+	}
 
 	db, err := s.open(ctx)
 	if err != nil {
@@ -148,12 +171,17 @@ func (s *Store) persist(ctx context.Context, record Record, replace bool) error 
 			storage_driver,
 			storage_ref,
 			input_manifest_digest,
+			command_digest,
+			env_digest,
+			normalized_outputs_digest,
+			output_manifest_digest,
 			dependency_key_files_digest,
+			output_records_json,
 			checkout_refresh_required,
 			created_at_unix_nano,
 			last_used_at_unix_nano,
 			producer_version
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`
 	if replace {
 		verb = "upsert"
@@ -174,12 +202,17 @@ func (s *Store) persist(ctx context.Context, record Record, replace bool) error 
 				storage_driver,
 				storage_ref,
 				input_manifest_digest,
+				command_digest,
+				env_digest,
+				normalized_outputs_digest,
+				output_manifest_digest,
 				dependency_key_files_digest,
+				output_records_json,
 				checkout_refresh_required,
 				created_at_unix_nano,
 				last_used_at_unix_nano,
 				producer_version
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 			ON CONFLICT(stage, cache_key) DO UPDATE SET
 				reuse_mode = excluded.reuse_mode,
 				state = excluded.state,
@@ -194,7 +227,12 @@ func (s *Store) persist(ctx context.Context, record Record, replace bool) error 
 				storage_driver = excluded.storage_driver,
 				storage_ref = excluded.storage_ref,
 				input_manifest_digest = excluded.input_manifest_digest,
+				command_digest = excluded.command_digest,
+				env_digest = excluded.env_digest,
+				normalized_outputs_digest = excluded.normalized_outputs_digest,
+				output_manifest_digest = excluded.output_manifest_digest,
 				dependency_key_files_digest = excluded.dependency_key_files_digest,
+				output_records_json = excluded.output_records_json,
 				checkout_refresh_required = excluded.checkout_refresh_required,
 				created_at_unix_nano = excluded.created_at_unix_nano,
 				last_used_at_unix_nano = excluded.last_used_at_unix_nano,
@@ -218,7 +256,12 @@ func (s *Store) persist(ctx context.Context, record Record, replace bool) error 
 		record.StorageDriver,
 		record.StorageRef,
 		nullableString(record.InputManifestDigest),
+		nullableString(record.CommandDigest),
+		nullableString(record.EnvDigest),
+		nullableString(record.NormalizedOutputsDigest),
+		nullableString(record.OutputManifestDigest),
 		nullableString(record.DependencyKeyFilesDigest),
+		nullableBytes(outputRecordsBytes),
 		boolToInt(record.CheckoutRefreshRequired),
 		record.CreatedAt.UTC().UnixNano(),
 		record.LastUsedAt.UTC().UnixNano(),
@@ -253,7 +296,12 @@ func (s *Store) GetReady(ctx context.Context, stage, cacheKey string) (Record, b
 			storage_driver,
 			storage_ref,
 			input_manifest_digest,
+			command_digest,
+			env_digest,
+			normalized_outputs_digest,
+			output_manifest_digest,
 			dependency_key_files_digest,
+			output_records_json,
 			checkout_refresh_required,
 			created_at_unix_nano,
 			last_used_at_unix_nano,
@@ -325,7 +373,12 @@ func (s *Store) List(ctx context.Context) ([]Record, error) {
 			storage_driver,
 			storage_ref,
 			input_manifest_digest,
+			command_digest,
+			env_digest,
+			normalized_outputs_digest,
+			output_manifest_digest,
 			dependency_key_files_digest,
+			output_records_json,
 			checkout_refresh_required,
 			created_at_unix_nano,
 			last_used_at_unix_nano,
@@ -402,7 +455,12 @@ func (s *Store) initDB(ctx context.Context) error {
 			storage_driver TEXT NOT NULL DEFAULT 'file',
 			storage_ref TEXT NOT NULL,
 			input_manifest_digest TEXT,
+			command_digest TEXT,
+			env_digest TEXT,
+			normalized_outputs_digest TEXT,
+			output_manifest_digest TEXT,
 			dependency_key_files_digest TEXT,
+			output_records_json BLOB,
 			checkout_refresh_required INTEGER NOT NULL DEFAULT 0,
 			created_at_unix_nano INTEGER NOT NULL,
 			last_used_at_unix_nano INTEGER NOT NULL,
@@ -433,6 +491,21 @@ func (s *Store) initDB(ctx context.Context) error {
 	if _, err := db.ExecContext(ctx, `ALTER TABLE cache_entries ADD COLUMN checkout_refresh_required INTEGER NOT NULL DEFAULT 0`); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
 		return fmt.Errorf("ensure cache metadata checkout_refresh_required column: %w", err)
 	}
+	if _, err := db.ExecContext(ctx, `ALTER TABLE cache_entries ADD COLUMN command_digest TEXT`); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
+		return fmt.Errorf("ensure cache metadata command_digest column: %w", err)
+	}
+	if _, err := db.ExecContext(ctx, `ALTER TABLE cache_entries ADD COLUMN env_digest TEXT`); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
+		return fmt.Errorf("ensure cache metadata env_digest column: %w", err)
+	}
+	if _, err := db.ExecContext(ctx, `ALTER TABLE cache_entries ADD COLUMN normalized_outputs_digest TEXT`); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
+		return fmt.Errorf("ensure cache metadata normalized_outputs_digest column: %w", err)
+	}
+	if _, err := db.ExecContext(ctx, `ALTER TABLE cache_entries ADD COLUMN output_manifest_digest TEXT`); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
+		return fmt.Errorf("ensure cache metadata output_manifest_digest column: %w", err)
+	}
+	if _, err := db.ExecContext(ctx, `ALTER TABLE cache_entries ADD COLUMN output_records_json BLOB`); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
+		return fmt.Errorf("ensure cache metadata output_records_json column: %w", err)
+	}
 	return nil
 }
 
@@ -451,7 +524,12 @@ func scanRecord(row recordScanner) (Record, error) {
 		repositoryChangesetID    sql.NullString
 		parentCacheKey           sql.NullString
 		inputDigest              sql.NullString
+		commandDigest            sql.NullString
+		envDigest                sql.NullString
+		normalizedOutputsDigest  sql.NullString
+		outputManifestDigest     sql.NullString
 		dependencyKeyFilesDigest sql.NullString
+		outputRecordsBytes       []byte
 		createdAtNano            int64
 		lastUsedAtNano           int64
 	)
@@ -471,7 +549,12 @@ func scanRecord(row recordScanner) (Record, error) {
 		&record.StorageDriver,
 		&record.StorageRef,
 		&inputDigest,
+		&commandDigest,
+		&envDigest,
+		&normalizedOutputsDigest,
+		&outputManifestDigest,
 		&dependencyKeyFilesDigest,
+		&outputRecordsBytes,
 		&checkoutRefreshRequired,
 		&createdAtNano,
 		&lastUsedAtNano,
@@ -503,8 +586,25 @@ func scanRecord(row recordScanner) (Record, error) {
 	if inputDigest.Valid {
 		record.InputManifestDigest = inputDigest.String
 	}
+	if commandDigest.Valid {
+		record.CommandDigest = commandDigest.String
+	}
+	if envDigest.Valid {
+		record.EnvDigest = envDigest.String
+	}
+	if normalizedOutputsDigest.Valid {
+		record.NormalizedOutputsDigest = normalizedOutputsDigest.String
+	}
+	if outputManifestDigest.Valid {
+		record.OutputManifestDigest = outputManifestDigest.String
+	}
 	if dependencyKeyFilesDigest.Valid {
 		record.DependencyKeyFilesDigest = dependencyKeyFilesDigest.String
+	}
+	if len(outputRecordsBytes) > 0 {
+		if err := json.Unmarshal(outputRecordsBytes, &record.OutputRecords); err != nil {
+			return Record{}, fmt.Errorf("decode cache output records %q/%q: %w", record.Stage, record.CacheKey, err)
+		}
 	}
 	record.CheckoutRefreshRequired = checkoutRefreshRequired != 0
 	record.CreatedAt = time.Unix(0, createdAtNano).UTC()
@@ -514,6 +614,13 @@ func scanRecord(row recordScanner) (Record, error) {
 
 func nullableString(value string) any {
 	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	return value
+}
+
+func nullableBytes(value []byte) any {
+	if len(value) == 0 {
 		return nil
 	}
 	return value

--- a/internal/cachestore/store_test.go
+++ b/internal/cachestore/store_test.go
@@ -46,11 +46,26 @@ func TestStoreCreateGetReadyListDelete(t *testing.T) {
 		StorageRef:               "/tmp/workspace-test.ext4",
 		StorageDriver:            "file",
 		InputManifestDigest:      "sha256:manifest",
+		CommandDigest:            "sha256:command",
+		EnvDigest:                "sha256:env",
+		NormalizedOutputsDigest:  "sha256:outputs",
+		OutputManifestDigest:     "sha256:output-manifest",
 		DependencyKeyFilesDigest: "sha256:dependency-key-files",
-		CheckoutRefreshRequired:  true,
-		CreatedAt:                time.Unix(1700000000, 123).UTC(),
-		LastUsedAt:               time.Unix(1700000001, 456).UTC(),
-		ProducerVersion:          "cleanroom-test/1",
+		OutputRecords: []OutputRecord{
+			{
+				Kind:           "directory",
+				Path:           "/root/go/pkg/mod",
+				VolumeSubpath:  "dirs/root-go-pkg-mod",
+				StorageDriver:  "file",
+				StorageRef:     "/tmp/go-mod-output.ext4",
+				SnapshotRef:    "/tmp/go-mod-output-snapshot.ext4",
+				ManifestDigest: "sha256:go-mod-output",
+			},
+		},
+		CheckoutRefreshRequired: true,
+		CreatedAt:               time.Unix(1700000000, 123).UTC(),
+		LastUsedAt:              time.Unix(1700000001, 456).UTC(),
+		ProducerVersion:         "cleanroom-test/1",
 	}
 	if err := store.Create(context.Background(), record); err != nil {
 		t.Fatalf("Create returned error: %v", err)
@@ -63,8 +78,14 @@ func TestStoreCreateGetReadyListDelete(t *testing.T) {
 	if !ok {
 		t.Fatal("expected stored ready cache")
 	}
-	if got.CacheKey != record.CacheKey || got.Stage != record.Stage || got.State != record.State || got.PolicyHash != record.PolicyHash || got.StorageRef != record.StorageRef || got.StorageDriver != record.StorageDriver || got.ParentCacheKey != record.ParentCacheKey || got.ReuseMode != record.ReuseMode || got.RepositoryChangesetID != record.RepositoryChangesetID || got.InputManifestDigest != record.InputManifestDigest || got.DependencyKeyFilesDigest != record.DependencyKeyFilesDigest || got.CheckoutRefreshRequired != record.CheckoutRefreshRequired || got.ProducerVersion != record.ProducerVersion {
+	if got.CacheKey != record.CacheKey || got.Stage != record.Stage || got.State != record.State || got.PolicyHash != record.PolicyHash || got.StorageRef != record.StorageRef || got.StorageDriver != record.StorageDriver || got.ParentCacheKey != record.ParentCacheKey || got.ReuseMode != record.ReuseMode || got.RepositoryChangesetID != record.RepositoryChangesetID || got.InputManifestDigest != record.InputManifestDigest || got.CommandDigest != record.CommandDigest || got.EnvDigest != record.EnvDigest || got.NormalizedOutputsDigest != record.NormalizedOutputsDigest || got.OutputManifestDigest != record.OutputManifestDigest || got.DependencyKeyFilesDigest != record.DependencyKeyFilesDigest || got.CheckoutRefreshRequired != record.CheckoutRefreshRequired || got.ProducerVersion != record.ProducerVersion {
 		t.Fatalf("unexpected cache record: %#v", got)
+	}
+	if got, want := len(got.OutputRecords), len(record.OutputRecords); got != want {
+		t.Fatalf("unexpected output record count: got %d want %d", got, want)
+	}
+	if got, want := got.OutputRecords[0], record.OutputRecords[0]; got != want {
+		t.Fatalf("unexpected output record: %#v want %#v", got, want)
 	}
 	if !got.CreatedAt.Equal(record.CreatedAt) {
 		t.Fatalf("unexpected created_at: got %s want %s", got.CreatedAt.Format(time.RFC3339Nano), record.CreatedAt.Format(time.RFC3339Nano))

--- a/internal/cli/repository_test.go
+++ b/internal/cli/repository_test.go
@@ -268,7 +268,16 @@ func TestCreateCommandShowsDependencyBootstrapOutputDuringSandboxCreate(t *testi
 				NetworkDefault: "deny",
 				Allow:          []policy.AllowRule{{Host: "github.com", Ports: []int{443}}},
 				Dependencies: policy.Dependencies{
-					Command: []string{"go", "mod", "download"},
+					Blocks: []policy.StageBlock{
+						{
+							Name:    "go-modules",
+							Command: []string{"go", "mod", "download"},
+							Inputs:  policy.StageBlockInputs{Files: []string{"README.md"}},
+							Outputs: policy.StageBlockOutputs{Dirs: []string{"/root/go/pkg/mod"}},
+						},
+					},
+					Command:  []string{"go", "mod", "download"},
+					KeyFiles: []string{"README.md"},
 				},
 			},
 			repository: policy.RepositoryConfig{

--- a/internal/cli/sandbox.go
+++ b/internal/cli/sandbox.go
@@ -553,10 +553,8 @@ func defaultSandboxCreatePolicy(host, imageRefOverride string, requireDockerServ
 		Version:        1,
 		ImageRef:       resolvedRef,
 		NetworkDefault: networkDefault,
-		Services: &cleanroomv1.PolicyServices{
-			Docker: &cleanroomv1.PolicyDockerService{
-				Required: requireDockerService,
-			},
+		Docker: &cleanroomv1.PolicyDocker{
+			Required: requireDockerService,
 		},
 	})
 	if err != nil {

--- a/internal/cli/sandbox_create_integration_test.go
+++ b/internal/cli/sandbox_create_integration_test.go
@@ -164,7 +164,7 @@ func TestSandboxCreateIntegrationDockerRequiresGuestService(t *testing.T) {
 	if adapter.provisionReq.Policy == nil {
 		t.Fatal("expected provisioned policy")
 	}
-	if !adapter.provisionReq.Policy.Services.Docker.Required {
+	if !adapter.provisionReq.Policy.Docker.Required {
 		t.Fatal("expected provisioned docker service to be required")
 	}
 }

--- a/internal/controlservice/dependency_stage.go
+++ b/internal/controlservice/dependency_stage.go
@@ -8,6 +8,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"path"
+	"sort"
 	"strings"
 
 	"github.com/buildkite/cleanroom/internal/backend"
@@ -209,9 +211,13 @@ func stageKeyFilesDigestAtCommit(ctx context.Context, repoDir, commitSHA string,
 	if trimmedCommitSHA == "" {
 		return "", fmt.Errorf("%s key file commit SHA is empty", stageName)
 	}
+	expandedFiles, err := expandStageKeyFilesAtCommit(ctx, repoDir, trimmedCommitSHA, files, stageName)
+	if err != nil {
+		return "", err
+	}
 
-	manifest := make([]stageKeyFileDigest, 0, len(files))
-	for _, file := range files {
+	manifest := make([]stageKeyFileDigest, 0, len(expandedFiles))
+	for _, file := range expandedFiles {
 		digest, err := gitFileDigestAtCommit(ctx, strings.TrimSpace(repoDir), trimmedCommitSHA, file)
 		if err != nil {
 			return "", fmt.Errorf("read %s key file %q: %w", stageName, file, err)
@@ -229,6 +235,76 @@ func stageKeyFilesDigestAtCommit(ctx context.Context, repoDir, commitSHA string,
 
 	sum := sha256.Sum256(payload)
 	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
+func expandStageKeyFilesAtCommit(ctx context.Context, repoDir, commitSHA string, files []string, stageName string) ([]string, error) {
+	seen := make(map[string]struct{}, len(files))
+	var expanded []string
+	var treeFiles []string
+	for _, file := range files {
+		file = strings.TrimSpace(file)
+		if !strings.ContainsAny(file, "*?[") {
+			if _, ok := seen[file]; ok {
+				continue
+			}
+			seen[file] = struct{}{}
+			expanded = append(expanded, file)
+			continue
+		}
+		if _, err := path.Match(file, ""); err != nil {
+			return nil, fmt.Errorf("%s key file glob %q is invalid: %w", stageName, file, err)
+		}
+		if treeFiles == nil {
+			var err error
+			treeFiles, err = gitFilesAtCommit(ctx, repoDir, commitSHA)
+			if err != nil {
+				return nil, fmt.Errorf("list %s key files at commit: %w", stageName, err)
+			}
+		}
+		matches := 0
+		for _, candidate := range treeFiles {
+			matched, err := path.Match(file, candidate)
+			if err != nil {
+				return nil, fmt.Errorf("%s key file glob %q is invalid: %w", stageName, file, err)
+			}
+			if !matched {
+				continue
+			}
+			matches++
+			if _, ok := seen[candidate]; ok {
+				continue
+			}
+			seen[candidate] = struct{}{}
+			expanded = append(expanded, candidate)
+		}
+		if matches == 0 {
+			return nil, fmt.Errorf("%s key file glob %q matched no files", stageName, file)
+		}
+	}
+	sort.Strings(expanded)
+	return expanded, nil
+}
+
+func gitFilesAtCommit(ctx context.Context, repoDir, commitSHA string) ([]string, error) {
+	cmd := exec.CommandContext(ctx, "git", "-C", repoDir, "ls-tree", "-r", "--name-only", "-z", commitSHA)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		message := strings.TrimSpace(string(output))
+		if message == "" {
+			message = err.Error()
+		}
+		return nil, fmt.Errorf("%s", message)
+	}
+	parts := bytes.Split(output, []byte{0})
+	files := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if len(part) == 0 {
+			continue
+		}
+		files = append(files, string(part))
+	}
+	sort.Strings(files)
+	return files, nil
 }
 
 func gitFileDigestAtCommit(ctx context.Context, repoDir, commitSHA, file string) (string, error) {

--- a/internal/controlservice/network_stage_test.go
+++ b/internal/controlservice/network_stage_test.go
@@ -111,16 +111,22 @@ func testStageScopedNetworkPolicy() *cleanroomv1.Policy {
 			Execution: &cleanroomv1.PolicyNetwork{},
 		},
 		Dependencies: &cleanroomv1.PolicyDependencies{
-			Command: []string{"mise", "exec", "--", "go", "mod", "download"},
-			Key: &cleanroomv1.PolicyDependencyKey{
-				Files: []string{"go.mod", "go.sum"},
-			},
+			Blocks: []*cleanroomv1.PolicyBlock{testPolicyBlock(
+				"go-modules",
+				[]string{"mise", "exec", "--", "go", "mod", "download"},
+				[]string{"go.mod", "go.sum"},
+				[]string{"/root/go/pkg/mod"},
+				nil,
+			)},
 		},
 		Services: &cleanroomv1.PolicyServices{
-			Command: []string{"docker", "compose", "up", "-d", "postgres"},
-			Key: &cleanroomv1.PolicyDependencyKey{
-				Files: []string{"docker-compose.yml"},
-			},
+			Blocks: []*cleanroomv1.PolicyBlock{testPolicyBlock(
+				"postgres",
+				[]string{"docker", "compose", "up", "-d", "postgres"},
+				[]string{"docker-compose.yml"},
+				[]string{"/var/lib/cleanroom/services/postgres"},
+				nil,
+			)},
 		},
 		Run: &cleanroomv1.PolicyRun{
 			Before: []string{"sh", "-lc", "echo pre-run"},

--- a/internal/controlservice/rootfs_sizing.go
+++ b/internal/controlservice/rootfs_sizing.go
@@ -21,7 +21,7 @@ func withRepositoryBootstrapRootFSMinimum(
 	}
 
 	minimumBytes := repositoryBootstrapMinimumRootFSBytes
-	if compiled != nil && compiled.Services.Docker.Required {
+	if compiled != nil && compiled.Docker.Required {
 		minimumBytes = repositoryBootstrapDockerMinimumRootFSBytes
 	}
 	if cfg.MinimumRootFSBytes < minimumBytes {

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -389,22 +389,28 @@ func testRepositoryPolicy() *cleanroomv1.Policy {
 func testRepositoryDependencyPolicy() *cleanroomv1.Policy {
 	policyProto := testRepositoryPolicy()
 	policyProto.Dependencies = &cleanroomv1.PolicyDependencies{
-		Command: []string{"mise", "exec", "--", "go", "mod", "download"},
-		Key: &cleanroomv1.PolicyDependencyKey{
-			Files: []string{"go.mod", "go.sum"},
-		},
+		Blocks: []*cleanroomv1.PolicyBlock{testPolicyBlock(
+			"go-modules",
+			[]string{"mise", "exec", "--", "go", "mod", "download"},
+			[]string{"go.mod", "go.sum"},
+			[]string{"/root/go/pkg/mod"},
+			nil,
+		)},
 	}
 	return policyProto
 }
 
 func testRepositoryDependencyAndServicesPolicy() *cleanroomv1.Policy {
 	policyProto := testRepositoryDependencyPolicy()
+	policyProto.Docker = &cleanroomv1.PolicyDocker{Required: true}
 	policyProto.Services = &cleanroomv1.PolicyServices{
-		Docker:  &cleanroomv1.PolicyDockerService{Required: true},
-		Command: []string{"docker", "compose", "up", "-d", "postgres"},
-		Key: &cleanroomv1.PolicyDependencyKey{
-			Files: []string{"docker-compose.yml"},
-		},
+		Blocks: []*cleanroomv1.PolicyBlock{testPolicyBlock(
+			"postgres",
+			[]string{"docker", "compose", "up", "-d", "postgres"},
+			[]string{"docker-compose.yml"},
+			[]string{"/var/lib/cleanroom/services/postgres"},
+			nil,
+		)},
 	}
 
 	return policyProto
@@ -415,6 +421,20 @@ func testRepositoryPortableDependencyPolicy() *cleanroomv1.Policy {
 	policyProto.Dependencies.Reuse = policy.DependencyReusePortable
 
 	return policyProto
+}
+
+func testPolicyBlock(name string, command, inputFiles, outputDirs, outputFiles []string) *cleanroomv1.PolicyBlock {
+	return &cleanroomv1.PolicyBlock{
+		Name:    name,
+		Command: append([]string(nil), command...),
+		Inputs: &cleanroomv1.PolicyBlockInputs{
+			Files: append([]string(nil), inputFiles...),
+		},
+		Outputs: &cleanroomv1.PolicyBlockOutputs{
+			Dirs:  append([]string(nil), outputDirs...),
+			Files: append([]string(nil), outputFiles...),
+		},
+	}
 }
 
 func testRepositoryRunBeforePolicy() *cleanroomv1.Policy {
@@ -3118,7 +3138,7 @@ func TestCreateSandboxPublishesDependencyStageCacheForConfiguredDependencies(t *
 		t.Fatalf("expected two bootstrap commands, got %d want %d", got, want)
 	}
 	dependencyBootstrap := strings.Join(runCommands[1], " ")
-	if !repositoryWrappedCommandContains(dependencyBootstrap, `exec 'mise' 'exec' '--' 'go' 'mod' 'download'`) {
+	if !strings.Contains(dependencyBootstrap, "mise") || !strings.Contains(dependencyBootstrap, "go") || !strings.Contains(dependencyBootstrap, "download") {
 		t.Fatalf("expected configured dependency bootstrap to preserve explicit mise command, got %q", dependencyBootstrap)
 	}
 }
@@ -3343,7 +3363,7 @@ func TestCreateSandboxPublishesServicesStageCacheForConfiguredServices(t *testin
 		t.Fatalf("expected three bootstrap commands, got %d want %d", got, want)
 	}
 	servicesBootstrap := strings.Join(runCommands[2], " ")
-	if !repositoryWrappedCommandContains(servicesBootstrap, `exec 'docker' 'compose' 'up' '-d' 'postgres'`) {
+	if !strings.Contains(servicesBootstrap, "docker") || !strings.Contains(servicesBootstrap, "compose") || !strings.Contains(servicesBootstrap, "postgres") {
 		t.Fatalf("expected services bootstrap to preserve explicit docker compose command, got %q", servicesBootstrap)
 	}
 }
@@ -3591,7 +3611,7 @@ func TestCreateSandboxReusesPortableDependencyStageAfterCheckoutRefresh(t *testi
 	if !strings.Contains(refreshCommand, updatedCommit) || !strings.Contains(refreshCommand, `git -C "$dest" fetch --filter=blob:none --progress origin "$commit"`) {
 		t.Fatalf("expected portable hit to refresh checkout to %s, got %q", updatedCommit, refreshCommand)
 	}
-	if dependencyBootstrap := strings.Join(runCommands[1], " "); !repositoryWrappedCommandContains(dependencyBootstrap, `exec 'mise' 'exec' '--' 'go' 'mod' 'download'`) {
+	if dependencyBootstrap := strings.Join(runCommands[1], " "); !strings.Contains(dependencyBootstrap, "mise") || !strings.Contains(dependencyBootstrap, "go") || !strings.Contains(dependencyBootstrap, "download") {
 		t.Fatalf("expected first run to bootstrap dependencies, got %q", dependencyBootstrap)
 	}
 	if validationCommand := strings.Join(runCommands[3], "\n"); !strings.Contains(validationCommand, "sha256sum") {
@@ -3893,7 +3913,7 @@ func TestCreateSandboxBootstrapsServicesAfterPortableDependencyStageRestore(t *t
 		t.Fatalf("expected portable hit to refresh checkout to %s, got %q", updatedCommit, refreshCommand)
 	}
 	servicesBootstrap := strings.Join(runCommands[5], " ")
-	if !repositoryWrappedCommandContains(servicesBootstrap, `exec 'docker' 'compose' 'up' '-d' 'postgres'`) {
+	if !strings.Contains(servicesBootstrap, "docker") || !strings.Contains(servicesBootstrap, "compose") || !strings.Contains(servicesBootstrap, "postgres") {
 		t.Fatalf("expected services bootstrap after portable restore, got %q", servicesBootstrap)
 	}
 }
@@ -3953,6 +3973,39 @@ func TestDependencyStageKeyFilesDigestDerivesHashesFromRepositoryChangesetPatch(
 	}
 	if got, want := tamperedDigest, changesetDigest; got != want {
 		t.Fatalf("expected dependency key file digest to ignore tampered file hashes: got %q want %q", got, want)
+	}
+}
+
+func TestDependencyStageKeyFilesDigestExpandsGlobsDeterministically(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"go.mod":             "module example.com/test\n\ngo 1.26.2\n",
+		"go.sum":             "example.com/test v0.0.0 h1:abc123\n",
+		"docker-compose.yml": "services:\n  postgres:\n    image: postgres:17\n",
+	})
+	repository := repositorycheckout.FromProto(repositoryCheckout)
+
+	svc := newTestService(&stubAdapter{})
+	svc.RepositoryStore = mirrors
+
+	globDigest, err := svc.dependencyStageKeyFilesDigest(context.Background(), repository, nil, nil, []string{"*.sum", "go.*"})
+	if err != nil {
+		t.Fatalf("dependencyStageKeyFilesDigest with glob returned error: %v", err)
+	}
+	explicitDigest, err := svc.dependencyStageKeyFilesDigest(context.Background(), repository, nil, nil, []string{"go.mod", "go.sum"})
+	if err != nil {
+		t.Fatalf("dependencyStageKeyFilesDigest with explicit files returned error: %v", err)
+	}
+	if got, want := globDigest, explicitDigest; got != want {
+		t.Fatalf("expected glob and explicit digest to match: got %q want %q", got, want)
+	}
+
+	_, err = svc.dependencyStageKeyFilesDigest(context.Background(), repository, nil, nil, []string{"*.missing"})
+	if err == nil {
+		t.Fatal("expected empty glob to fail")
+	}
+	if !strings.Contains(err.Error(), "matched no files") {
+		t.Fatalf("unexpected empty glob error: %v", err)
 	}
 }
 
@@ -4077,7 +4130,7 @@ func TestCreateSandboxBootstrapsDependenciesAfterWorkspaceStageRestoreWithoutDep
 		t.Fatalf("expected one dependency bootstrap command, got %d want %d", got, want)
 	}
 	dependencyBootstrap := strings.Join(runCommands[0], " ")
-	if !repositoryWrappedCommandContains(dependencyBootstrap, `exec 'mise' 'exec' '--' 'go' 'mod' 'download'`) {
+	if !strings.Contains(dependencyBootstrap, "mise") || !strings.Contains(dependencyBootstrap, "go") || !strings.Contains(dependencyBootstrap, "download") {
 		t.Fatalf("expected dependency bootstrap to preserve explicit mise command, got %q", dependencyBootstrap)
 	}
 }
@@ -6396,9 +6449,7 @@ func TestCreateSandboxSetsRepositoryBootstrapRootFSMinimum(t *testing.T) {
 	}
 
 	policyProto := testRepositoryPolicy()
-	policyProto.Services = &cleanroomv1.PolicyServices{
-		Docker: &cleanroomv1.PolicyDockerService{Required: true},
-	}
+	policyProto.Docker = &cleanroomv1.PolicyDocker{Required: true}
 
 	_, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
 		Backend:            "darwin-vz",

--- a/internal/gen/cleanroom/v1/control.pb.go
+++ b/internal/gen/cleanroom/v1/control.pb.go
@@ -923,27 +923,27 @@ func (x *PolicyAllowRule) GetPorts() []int32 {
 	return nil
 }
 
-type PolicyDockerService struct {
+type PolicyDocker struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Required      bool                   `protobuf:"varint,1,opt,name=required,proto3" json:"required,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *PolicyDockerService) Reset() {
-	*x = PolicyDockerService{}
+func (x *PolicyDocker) Reset() {
+	*x = PolicyDocker{}
 	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *PolicyDockerService) String() string {
+func (x *PolicyDocker) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*PolicyDockerService) ProtoMessage() {}
+func (*PolicyDocker) ProtoMessage() {}
 
-func (x *PolicyDockerService) ProtoReflect() protoreflect.Message {
+func (x *PolicyDocker) ProtoReflect() protoreflect.Message {
 	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -955,30 +955,200 @@ func (x *PolicyDockerService) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use PolicyDockerService.ProtoReflect.Descriptor instead.
-func (*PolicyDockerService) Descriptor() ([]byte, []int) {
+// Deprecated: Use PolicyDocker.ProtoReflect.Descriptor instead.
+func (*PolicyDocker) Descriptor() ([]byte, []int) {
 	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{7}
 }
 
-func (x *PolicyDockerService) GetRequired() bool {
+func (x *PolicyDocker) GetRequired() bool {
 	if x != nil {
 		return x.Required
 	}
 	return false
 }
 
+type PolicyBlockInputs struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Files         []string               `protobuf:"bytes,1,rep,name=files,proto3" json:"files,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PolicyBlockInputs) Reset() {
+	*x = PolicyBlockInputs{}
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PolicyBlockInputs) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PolicyBlockInputs) ProtoMessage() {}
+
+func (x *PolicyBlockInputs) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PolicyBlockInputs.ProtoReflect.Descriptor instead.
+func (*PolicyBlockInputs) Descriptor() ([]byte, []int) {
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *PolicyBlockInputs) GetFiles() []string {
+	if x != nil {
+		return x.Files
+	}
+	return nil
+}
+
+type PolicyBlockOutputs struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Dirs          []string               `protobuf:"bytes,1,rep,name=dirs,proto3" json:"dirs,omitempty"`
+	Files         []string               `protobuf:"bytes,2,rep,name=files,proto3" json:"files,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PolicyBlockOutputs) Reset() {
+	*x = PolicyBlockOutputs{}
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PolicyBlockOutputs) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PolicyBlockOutputs) ProtoMessage() {}
+
+func (x *PolicyBlockOutputs) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PolicyBlockOutputs.ProtoReflect.Descriptor instead.
+func (*PolicyBlockOutputs) Descriptor() ([]byte, []int) {
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *PolicyBlockOutputs) GetDirs() []string {
+	if x != nil {
+		return x.Dirs
+	}
+	return nil
+}
+
+func (x *PolicyBlockOutputs) GetFiles() []string {
+	if x != nil {
+		return x.Files
+	}
+	return nil
+}
+
+type PolicyBlock struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Command       []string               `protobuf:"bytes,2,rep,name=command,proto3" json:"command,omitempty"`
+	Inputs        *PolicyBlockInputs     `protobuf:"bytes,3,opt,name=inputs,proto3" json:"inputs,omitempty"`
+	Env           map[string]string      `protobuf:"bytes,4,rep,name=env,proto3" json:"env,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Outputs       *PolicyBlockOutputs    `protobuf:"bytes,5,opt,name=outputs,proto3" json:"outputs,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PolicyBlock) Reset() {
+	*x = PolicyBlock{}
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PolicyBlock) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PolicyBlock) ProtoMessage() {}
+
+func (x *PolicyBlock) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PolicyBlock.ProtoReflect.Descriptor instead.
+func (*PolicyBlock) Descriptor() ([]byte, []int) {
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *PolicyBlock) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *PolicyBlock) GetCommand() []string {
+	if x != nil {
+		return x.Command
+	}
+	return nil
+}
+
+func (x *PolicyBlock) GetInputs() *PolicyBlockInputs {
+	if x != nil {
+		return x.Inputs
+	}
+	return nil
+}
+
+func (x *PolicyBlock) GetEnv() map[string]string {
+	if x != nil {
+		return x.Env
+	}
+	return nil
+}
+
+func (x *PolicyBlock) GetOutputs() *PolicyBlockOutputs {
+	if x != nil {
+		return x.Outputs
+	}
+	return nil
+}
+
 type PolicyServices struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Docker        *PolicyDockerService   `protobuf:"bytes,1,opt,name=docker,proto3" json:"docker,omitempty"`
-	Command       []string               `protobuf:"bytes,2,rep,name=command,proto3" json:"command,omitempty"`
-	Key           *PolicyDependencyKey   `protobuf:"bytes,3,opt,name=key,proto3" json:"key,omitempty"`
+	Blocks        []*PolicyBlock         `protobuf:"bytes,4,rep,name=blocks,proto3" json:"blocks,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *PolicyServices) Reset() {
 	*x = PolicyServices{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[8]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -990,7 +1160,7 @@ func (x *PolicyServices) String() string {
 func (*PolicyServices) ProtoMessage() {}
 
 func (x *PolicyServices) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[8]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1003,86 +1173,27 @@ func (x *PolicyServices) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyServices.ProtoReflect.Descriptor instead.
 func (*PolicyServices) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{8}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{11}
 }
 
-func (x *PolicyServices) GetDocker() *PolicyDockerService {
+func (x *PolicyServices) GetBlocks() []*PolicyBlock {
 	if x != nil {
-		return x.Docker
-	}
-	return nil
-}
-
-func (x *PolicyServices) GetCommand() []string {
-	if x != nil {
-		return x.Command
-	}
-	return nil
-}
-
-func (x *PolicyServices) GetKey() *PolicyDependencyKey {
-	if x != nil {
-		return x.Key
-	}
-	return nil
-}
-
-type PolicyDependencyKey struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Files         []string               `protobuf:"bytes,1,rep,name=files,proto3" json:"files,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *PolicyDependencyKey) Reset() {
-	*x = PolicyDependencyKey{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[9]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *PolicyDependencyKey) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*PolicyDependencyKey) ProtoMessage() {}
-
-func (x *PolicyDependencyKey) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[9]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use PolicyDependencyKey.ProtoReflect.Descriptor instead.
-func (*PolicyDependencyKey) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{9}
-}
-
-func (x *PolicyDependencyKey) GetFiles() []string {
-	if x != nil {
-		return x.Files
+		return x.Blocks
 	}
 	return nil
 }
 
 type PolicyDependencies struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Command       []string               `protobuf:"bytes,1,rep,name=command,proto3" json:"command,omitempty"`
-	Key           *PolicyDependencyKey   `protobuf:"bytes,2,opt,name=key,proto3" json:"key,omitempty"`
 	Reuse         string                 `protobuf:"bytes,3,opt,name=reuse,proto3" json:"reuse,omitempty"`
+	Blocks        []*PolicyBlock         `protobuf:"bytes,4,rep,name=blocks,proto3" json:"blocks,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *PolicyDependencies) Reset() {
 	*x = PolicyDependencies{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[10]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1094,7 +1205,7 @@ func (x *PolicyDependencies) String() string {
 func (*PolicyDependencies) ProtoMessage() {}
 
 func (x *PolicyDependencies) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[10]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1107,21 +1218,7 @@ func (x *PolicyDependencies) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyDependencies.ProtoReflect.Descriptor instead.
 func (*PolicyDependencies) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{10}
-}
-
-func (x *PolicyDependencies) GetCommand() []string {
-	if x != nil {
-		return x.Command
-	}
-	return nil
-}
-
-func (x *PolicyDependencies) GetKey() *PolicyDependencyKey {
-	if x != nil {
-		return x.Key
-	}
-	return nil
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *PolicyDependencies) GetReuse() string {
@@ -1129,6 +1226,13 @@ func (x *PolicyDependencies) GetReuse() string {
 		return x.Reuse
 	}
 	return ""
+}
+
+func (x *PolicyDependencies) GetBlocks() []*PolicyBlock {
+	if x != nil {
+		return x.Blocks
+	}
+	return nil
 }
 
 type PolicyRun struct {
@@ -1140,7 +1244,7 @@ type PolicyRun struct {
 
 func (x *PolicyRun) Reset() {
 	*x = PolicyRun{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[11]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1152,7 +1256,7 @@ func (x *PolicyRun) String() string {
 func (*PolicyRun) ProtoMessage() {}
 
 func (x *PolicyRun) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[11]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1165,7 +1269,7 @@ func (x *PolicyRun) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyRun.ProtoReflect.Descriptor instead.
 func (*PolicyRun) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{11}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *PolicyRun) GetBefore() []string {
@@ -1184,7 +1288,7 @@ type PolicyNetwork struct {
 
 func (x *PolicyNetwork) Reset() {
 	*x = PolicyNetwork{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[12]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1196,7 +1300,7 @@ func (x *PolicyNetwork) String() string {
 func (*PolicyNetwork) ProtoMessage() {}
 
 func (x *PolicyNetwork) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[12]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1209,7 +1313,7 @@ func (x *PolicyNetwork) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyNetwork.ProtoReflect.Descriptor instead.
 func (*PolicyNetwork) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{12}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *PolicyNetwork) GetAllow() []*PolicyAllowRule {
@@ -1231,7 +1335,7 @@ type PolicyNetworkStages struct {
 
 func (x *PolicyNetworkStages) Reset() {
 	*x = PolicyNetworkStages{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[13]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1243,7 +1347,7 @@ func (x *PolicyNetworkStages) String() string {
 func (*PolicyNetworkStages) ProtoMessage() {}
 
 func (x *PolicyNetworkStages) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[13]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1256,7 +1360,7 @@ func (x *PolicyNetworkStages) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyNetworkStages.ProtoReflect.Descriptor instead.
 func (*PolicyNetworkStages) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{13}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *PolicyNetworkStages) GetWorkspace() *PolicyNetwork {
@@ -1298,7 +1402,7 @@ type PolicyResources struct {
 
 func (x *PolicyResources) Reset() {
 	*x = PolicyResources{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[14]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1310,7 +1414,7 @@ func (x *PolicyResources) String() string {
 func (*PolicyResources) ProtoMessage() {}
 
 func (x *PolicyResources) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[14]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1323,7 +1427,7 @@ func (x *PolicyResources) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyResources.ProtoReflect.Descriptor instead.
 func (*PolicyResources) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{14}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *PolicyResources) GetVcpus() int64 {
@@ -1360,13 +1464,14 @@ type Policy struct {
 	Run            *PolicyRun             `protobuf:"bytes,10,opt,name=run,proto3" json:"run,omitempty"`
 	Resources      *PolicyResources       `protobuf:"bytes,11,opt,name=resources,proto3" json:"resources,omitempty"`
 	NetworkStages  *PolicyNetworkStages   `protobuf:"bytes,12,opt,name=network_stages,json=networkStages,proto3" json:"network_stages,omitempty"`
+	Docker         *PolicyDocker          `protobuf:"bytes,13,opt,name=docker,proto3" json:"docker,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
 
 func (x *Policy) Reset() {
 	*x = Policy{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[15]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1378,7 +1483,7 @@ func (x *Policy) String() string {
 func (*Policy) ProtoMessage() {}
 
 func (x *Policy) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[15]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1391,7 +1496,7 @@ func (x *Policy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Policy.ProtoReflect.Descriptor instead.
 func (*Policy) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{15}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *Policy) GetVersion() int32 {
@@ -1471,6 +1576,13 @@ func (x *Policy) GetNetworkStages() *PolicyNetworkStages {
 	return nil
 }
 
+func (x *Policy) GetDocker() *PolicyDocker {
+	if x != nil {
+		return x.Docker
+	}
+	return nil
+}
+
 type SandboxOptions struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	LaunchSeconds int64                  `protobuf:"varint,3,opt,name=launch_seconds,json=launchSeconds,proto3" json:"launch_seconds,omitempty"`
@@ -1480,7 +1592,7 @@ type SandboxOptions struct {
 
 func (x *SandboxOptions) Reset() {
 	*x = SandboxOptions{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[16]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1492,7 +1604,7 @@ func (x *SandboxOptions) String() string {
 func (*SandboxOptions) ProtoMessage() {}
 
 func (x *SandboxOptions) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[16]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1505,7 +1617,7 @@ func (x *SandboxOptions) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxOptions.ProtoReflect.Descriptor instead.
 func (*SandboxOptions) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{16}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *SandboxOptions) GetLaunchSeconds() int64 {
@@ -1528,7 +1640,7 @@ type RepositoryCheckout struct {
 
 func (x *RepositoryCheckout) Reset() {
 	*x = RepositoryCheckout{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[17]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1540,7 +1652,7 @@ func (x *RepositoryCheckout) String() string {
 func (*RepositoryCheckout) ProtoMessage() {}
 
 func (x *RepositoryCheckout) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[17]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1553,7 +1665,7 @@ func (x *RepositoryCheckout) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RepositoryCheckout.ProtoReflect.Descriptor instead.
 func (*RepositoryCheckout) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{17}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *RepositoryCheckout) GetRemoteUrl() string {
@@ -1602,7 +1714,7 @@ type RepositoryChangesetFile struct {
 
 func (x *RepositoryChangesetFile) Reset() {
 	*x = RepositoryChangesetFile{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[18]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1614,7 +1726,7 @@ func (x *RepositoryChangesetFile) String() string {
 func (*RepositoryChangesetFile) ProtoMessage() {}
 
 func (x *RepositoryChangesetFile) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[18]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1627,7 +1739,7 @@ func (x *RepositoryChangesetFile) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RepositoryChangesetFile.ProtoReflect.Descriptor instead.
 func (*RepositoryChangesetFile) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{18}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *RepositoryChangesetFile) GetPath() string {
@@ -1665,7 +1777,7 @@ type RepositoryChangeset struct {
 
 func (x *RepositoryChangeset) Reset() {
 	*x = RepositoryChangeset{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[19]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1677,7 +1789,7 @@ func (x *RepositoryChangeset) String() string {
 func (*RepositoryChangeset) ProtoMessage() {}
 
 func (x *RepositoryChangeset) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[19]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1690,7 +1802,7 @@ func (x *RepositoryChangeset) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RepositoryChangeset.ProtoReflect.Descriptor instead.
 func (*RepositoryChangeset) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{19}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *RepositoryChangeset) GetFormat() string {
@@ -1747,7 +1859,7 @@ type RepositoryCommitBundle struct {
 
 func (x *RepositoryCommitBundle) Reset() {
 	*x = RepositoryCommitBundle{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[20]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1759,7 +1871,7 @@ func (x *RepositoryCommitBundle) String() string {
 func (*RepositoryCommitBundle) ProtoMessage() {}
 
 func (x *RepositoryCommitBundle) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[20]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1772,7 +1884,7 @@ func (x *RepositoryCommitBundle) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RepositoryCommitBundle.ProtoReflect.Descriptor instead.
 func (*RepositoryCommitBundle) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{20}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *RepositoryCommitBundle) GetFormat() string {
@@ -1821,7 +1933,7 @@ type CreateSandboxRequest struct {
 
 func (x *CreateSandboxRequest) Reset() {
 	*x = CreateSandboxRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[21]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1833,7 +1945,7 @@ func (x *CreateSandboxRequest) String() string {
 func (*CreateSandboxRequest) ProtoMessage() {}
 
 func (x *CreateSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[21]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1846,7 +1958,7 @@ func (x *CreateSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSandboxRequest.ProtoReflect.Descriptor instead.
 func (*CreateSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{21}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *CreateSandboxRequest) GetBackend() string {
@@ -1931,7 +2043,7 @@ type CreateSandboxResponse struct {
 
 func (x *CreateSandboxResponse) Reset() {
 	*x = CreateSandboxResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[22]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1943,7 +2055,7 @@ func (x *CreateSandboxResponse) String() string {
 func (*CreateSandboxResponse) ProtoMessage() {}
 
 func (x *CreateSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[22]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1956,7 +2068,7 @@ func (x *CreateSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSandboxResponse.ProtoReflect.Descriptor instead.
 func (*CreateSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{22}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *CreateSandboxResponse) GetSandbox() *Sandbox {
@@ -2019,7 +2131,7 @@ type CreateSandboxEvent struct {
 
 func (x *CreateSandboxEvent) Reset() {
 	*x = CreateSandboxEvent{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[23]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2031,7 +2143,7 @@ func (x *CreateSandboxEvent) String() string {
 func (*CreateSandboxEvent) ProtoMessage() {}
 
 func (x *CreateSandboxEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[23]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2044,7 +2156,7 @@ func (x *CreateSandboxEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSandboxEvent.ProtoReflect.Descriptor instead.
 func (*CreateSandboxEvent) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{23}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *CreateSandboxEvent) GetPhase() CreateSandboxPhase {
@@ -2156,7 +2268,7 @@ type GetSandboxRequest struct {
 
 func (x *GetSandboxRequest) Reset() {
 	*x = GetSandboxRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[24]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2168,7 +2280,7 @@ func (x *GetSandboxRequest) String() string {
 func (*GetSandboxRequest) ProtoMessage() {}
 
 func (x *GetSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[24]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2181,7 +2293,7 @@ func (x *GetSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSandboxRequest.ProtoReflect.Descriptor instead.
 func (*GetSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{24}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *GetSandboxRequest) GetSandboxId() string {
@@ -2200,7 +2312,7 @@ type GetSandboxResponse struct {
 
 func (x *GetSandboxResponse) Reset() {
 	*x = GetSandboxResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[25]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2212,7 +2324,7 @@ func (x *GetSandboxResponse) String() string {
 func (*GetSandboxResponse) ProtoMessage() {}
 
 func (x *GetSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[25]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2225,7 +2337,7 @@ func (x *GetSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSandboxResponse.ProtoReflect.Descriptor instead.
 func (*GetSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{25}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *GetSandboxResponse) GetSandbox() *Sandbox {
@@ -2243,7 +2355,7 @@ type ListSandboxesRequest struct {
 
 func (x *ListSandboxesRequest) Reset() {
 	*x = ListSandboxesRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[26]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2255,7 +2367,7 @@ func (x *ListSandboxesRequest) String() string {
 func (*ListSandboxesRequest) ProtoMessage() {}
 
 func (x *ListSandboxesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[26]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2268,7 +2380,7 @@ func (x *ListSandboxesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSandboxesRequest.ProtoReflect.Descriptor instead.
 func (*ListSandboxesRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{26}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{28}
 }
 
 type ListSandboxesResponse struct {
@@ -2280,7 +2392,7 @@ type ListSandboxesResponse struct {
 
 func (x *ListSandboxesResponse) Reset() {
 	*x = ListSandboxesResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[27]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2292,7 +2404,7 @@ func (x *ListSandboxesResponse) String() string {
 func (*ListSandboxesResponse) ProtoMessage() {}
 
 func (x *ListSandboxesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[27]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2305,7 +2417,7 @@ func (x *ListSandboxesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSandboxesResponse.ProtoReflect.Descriptor instead.
 func (*ListSandboxesResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{27}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *ListSandboxesResponse) GetSandboxes() []*Sandbox {
@@ -2325,7 +2437,7 @@ type ListExecutionsRequest struct {
 
 func (x *ListExecutionsRequest) Reset() {
 	*x = ListExecutionsRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[28]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2337,7 +2449,7 @@ func (x *ListExecutionsRequest) String() string {
 func (*ListExecutionsRequest) ProtoMessage() {}
 
 func (x *ListExecutionsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[28]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2350,7 +2462,7 @@ func (x *ListExecutionsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListExecutionsRequest.ProtoReflect.Descriptor instead.
 func (*ListExecutionsRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{28}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *ListExecutionsRequest) GetSandboxId() string {
@@ -2376,7 +2488,7 @@ type ListExecutionsResponse struct {
 
 func (x *ListExecutionsResponse) Reset() {
 	*x = ListExecutionsResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[29]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2388,7 +2500,7 @@ func (x *ListExecutionsResponse) String() string {
 func (*ListExecutionsResponse) ProtoMessage() {}
 
 func (x *ListExecutionsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[29]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2401,7 +2513,7 @@ func (x *ListExecutionsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListExecutionsResponse.ProtoReflect.Descriptor instead.
 func (*ListExecutionsResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{29}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *ListExecutionsResponse) GetExecutions() []*Execution {
@@ -2422,7 +2534,7 @@ type DownloadSandboxFileRequest struct {
 
 func (x *DownloadSandboxFileRequest) Reset() {
 	*x = DownloadSandboxFileRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[30]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2434,7 +2546,7 @@ func (x *DownloadSandboxFileRequest) String() string {
 func (*DownloadSandboxFileRequest) ProtoMessage() {}
 
 func (x *DownloadSandboxFileRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[30]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2447,7 +2559,7 @@ func (x *DownloadSandboxFileRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DownloadSandboxFileRequest.ProtoReflect.Descriptor instead.
 func (*DownloadSandboxFileRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{30}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *DownloadSandboxFileRequest) GetSandboxId() string {
@@ -2483,7 +2595,7 @@ type DownloadSandboxFileResponse struct {
 
 func (x *DownloadSandboxFileResponse) Reset() {
 	*x = DownloadSandboxFileResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[31]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2495,7 +2607,7 @@ func (x *DownloadSandboxFileResponse) String() string {
 func (*DownloadSandboxFileResponse) ProtoMessage() {}
 
 func (x *DownloadSandboxFileResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[31]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2508,7 +2620,7 @@ func (x *DownloadSandboxFileResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DownloadSandboxFileResponse.ProtoReflect.Descriptor instead.
 func (*DownloadSandboxFileResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{31}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *DownloadSandboxFileResponse) GetSandboxId() string {
@@ -2551,7 +2663,7 @@ type UploadSandboxFileRequest struct {
 
 func (x *UploadSandboxFileRequest) Reset() {
 	*x = UploadSandboxFileRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[32]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2563,7 +2675,7 @@ func (x *UploadSandboxFileRequest) String() string {
 func (*UploadSandboxFileRequest) ProtoMessage() {}
 
 func (x *UploadSandboxFileRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[32]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2576,7 +2688,7 @@ func (x *UploadSandboxFileRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UploadSandboxFileRequest.ProtoReflect.Descriptor instead.
 func (*UploadSandboxFileRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{32}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *UploadSandboxFileRequest) GetSandboxId() string {
@@ -2618,7 +2730,7 @@ type UploadSandboxFileResponse struct {
 
 func (x *UploadSandboxFileResponse) Reset() {
 	*x = UploadSandboxFileResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[33]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2630,7 +2742,7 @@ func (x *UploadSandboxFileResponse) String() string {
 func (*UploadSandboxFileResponse) ProtoMessage() {}
 
 func (x *UploadSandboxFileResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[33]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2643,7 +2755,7 @@ func (x *UploadSandboxFileResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UploadSandboxFileResponse.ProtoReflect.Descriptor instead.
 func (*UploadSandboxFileResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{33}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *UploadSandboxFileResponse) GetSandboxId() string {
@@ -2681,7 +2793,7 @@ type SandboxPathInfo struct {
 
 func (x *SandboxPathInfo) Reset() {
 	*x = SandboxPathInfo{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[34]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2693,7 +2805,7 @@ func (x *SandboxPathInfo) String() string {
 func (*SandboxPathInfo) ProtoMessage() {}
 
 func (x *SandboxPathInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[34]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2706,7 +2818,7 @@ func (x *SandboxPathInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxPathInfo.ProtoReflect.Descriptor instead.
 func (*SandboxPathInfo) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{34}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *SandboxPathInfo) GetPath() string {
@@ -2761,7 +2873,7 @@ type StatSandboxPathRequest struct {
 
 func (x *StatSandboxPathRequest) Reset() {
 	*x = StatSandboxPathRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[35]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2773,7 +2885,7 @@ func (x *StatSandboxPathRequest) String() string {
 func (*StatSandboxPathRequest) ProtoMessage() {}
 
 func (x *StatSandboxPathRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[35]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2786,7 +2898,7 @@ func (x *StatSandboxPathRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StatSandboxPathRequest.ProtoReflect.Descriptor instead.
 func (*StatSandboxPathRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{35}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *StatSandboxPathRequest) GetSandboxId() string {
@@ -2812,7 +2924,7 @@ type StatSandboxPathResponse struct {
 
 func (x *StatSandboxPathResponse) Reset() {
 	*x = StatSandboxPathResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[36]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2824,7 +2936,7 @@ func (x *StatSandboxPathResponse) String() string {
 func (*StatSandboxPathResponse) ProtoMessage() {}
 
 func (x *StatSandboxPathResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[36]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2837,7 +2949,7 @@ func (x *StatSandboxPathResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StatSandboxPathResponse.ProtoReflect.Descriptor instead.
 func (*StatSandboxPathResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{36}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *StatSandboxPathResponse) GetInfo() *SandboxPathInfo {
@@ -2857,7 +2969,7 @@ type WalkSandboxTreeRequest struct {
 
 func (x *WalkSandboxTreeRequest) Reset() {
 	*x = WalkSandboxTreeRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[37]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2869,7 +2981,7 @@ func (x *WalkSandboxTreeRequest) String() string {
 func (*WalkSandboxTreeRequest) ProtoMessage() {}
 
 func (x *WalkSandboxTreeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[37]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2882,7 +2994,7 @@ func (x *WalkSandboxTreeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WalkSandboxTreeRequest.ProtoReflect.Descriptor instead.
 func (*WalkSandboxTreeRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{37}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *WalkSandboxTreeRequest) GetSandboxId() string {
@@ -2908,7 +3020,7 @@ type WalkSandboxTreeResponse struct {
 
 func (x *WalkSandboxTreeResponse) Reset() {
 	*x = WalkSandboxTreeResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[38]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2920,7 +3032,7 @@ func (x *WalkSandboxTreeResponse) String() string {
 func (*WalkSandboxTreeResponse) ProtoMessage() {}
 
 func (x *WalkSandboxTreeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[38]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2933,7 +3045,7 @@ func (x *WalkSandboxTreeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WalkSandboxTreeResponse.ProtoReflect.Descriptor instead.
 func (*WalkSandboxTreeResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{38}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *WalkSandboxTreeResponse) GetInfo() *SandboxPathInfo {
@@ -2954,7 +3066,7 @@ type ReadSandboxFileRequest struct {
 
 func (x *ReadSandboxFileRequest) Reset() {
 	*x = ReadSandboxFileRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[39]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2966,7 +3078,7 @@ func (x *ReadSandboxFileRequest) String() string {
 func (*ReadSandboxFileRequest) ProtoMessage() {}
 
 func (x *ReadSandboxFileRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[39]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2979,7 +3091,7 @@ func (x *ReadSandboxFileRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReadSandboxFileRequest.ProtoReflect.Descriptor instead.
 func (*ReadSandboxFileRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{39}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *ReadSandboxFileRequest) GetSandboxId() string {
@@ -3012,7 +3124,7 @@ type ReadSandboxFileResponse struct {
 
 func (x *ReadSandboxFileResponse) Reset() {
 	*x = ReadSandboxFileResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[40]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3024,7 +3136,7 @@ func (x *ReadSandboxFileResponse) String() string {
 func (*ReadSandboxFileResponse) ProtoMessage() {}
 
 func (x *ReadSandboxFileResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[40]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3037,7 +3149,7 @@ func (x *ReadSandboxFileResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReadSandboxFileResponse.ProtoReflect.Descriptor instead.
 func (*ReadSandboxFileResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{40}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *ReadSandboxFileResponse) GetData() []byte {
@@ -3059,7 +3171,7 @@ type WriteSandboxFileInit struct {
 
 func (x *WriteSandboxFileInit) Reset() {
 	*x = WriteSandboxFileInit{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[41]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3071,7 +3183,7 @@ func (x *WriteSandboxFileInit) String() string {
 func (*WriteSandboxFileInit) ProtoMessage() {}
 
 func (x *WriteSandboxFileInit) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[41]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3084,7 +3196,7 @@ func (x *WriteSandboxFileInit) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WriteSandboxFileInit.ProtoReflect.Descriptor instead.
 func (*WriteSandboxFileInit) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{41}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *WriteSandboxFileInit) GetSandboxId() string {
@@ -3128,7 +3240,7 @@ type WriteSandboxFileRequest struct {
 
 func (x *WriteSandboxFileRequest) Reset() {
 	*x = WriteSandboxFileRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[42]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3140,7 +3252,7 @@ func (x *WriteSandboxFileRequest) String() string {
 func (*WriteSandboxFileRequest) ProtoMessage() {}
 
 func (x *WriteSandboxFileRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[42]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3153,7 +3265,7 @@ func (x *WriteSandboxFileRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WriteSandboxFileRequest.ProtoReflect.Descriptor instead.
 func (*WriteSandboxFileRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{42}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *WriteSandboxFileRequest) GetPayload() isWriteSandboxFileRequest_Payload {
@@ -3208,7 +3320,7 @@ type WriteSandboxFileResponse struct {
 
 func (x *WriteSandboxFileResponse) Reset() {
 	*x = WriteSandboxFileResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[43]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3220,7 +3332,7 @@ func (x *WriteSandboxFileResponse) String() string {
 func (*WriteSandboxFileResponse) ProtoMessage() {}
 
 func (x *WriteSandboxFileResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[43]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3233,7 +3345,7 @@ func (x *WriteSandboxFileResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WriteSandboxFileResponse.ProtoReflect.Descriptor instead.
 func (*WriteSandboxFileResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{43}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *WriteSandboxFileResponse) GetSandboxId() string {
@@ -3268,7 +3380,7 @@ type RemoveSandboxPathRequest struct {
 
 func (x *RemoveSandboxPathRequest) Reset() {
 	*x = RemoveSandboxPathRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[44]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3280,7 +3392,7 @@ func (x *RemoveSandboxPathRequest) String() string {
 func (*RemoveSandboxPathRequest) ProtoMessage() {}
 
 func (x *RemoveSandboxPathRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[44]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3293,7 +3405,7 @@ func (x *RemoveSandboxPathRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveSandboxPathRequest.ProtoReflect.Descriptor instead.
 func (*RemoveSandboxPathRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{44}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *RemoveSandboxPathRequest) GetSandboxId() string {
@@ -3328,7 +3440,7 @@ type RemoveSandboxPathResponse struct {
 
 func (x *RemoveSandboxPathResponse) Reset() {
 	*x = RemoveSandboxPathResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[45]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3340,7 +3452,7 @@ func (x *RemoveSandboxPathResponse) String() string {
 func (*RemoveSandboxPathResponse) ProtoMessage() {}
 
 func (x *RemoveSandboxPathResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[45]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3353,7 +3465,7 @@ func (x *RemoveSandboxPathResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveSandboxPathResponse.ProtoReflect.Descriptor instead.
 func (*RemoveSandboxPathResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{45}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *RemoveSandboxPathResponse) GetSandboxId() string {
@@ -3388,7 +3500,7 @@ type ArchiveSandboxPathsRequest struct {
 
 func (x *ArchiveSandboxPathsRequest) Reset() {
 	*x = ArchiveSandboxPathsRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[46]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3400,7 +3512,7 @@ func (x *ArchiveSandboxPathsRequest) String() string {
 func (*ArchiveSandboxPathsRequest) ProtoMessage() {}
 
 func (x *ArchiveSandboxPathsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[46]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3413,7 +3525,7 @@ func (x *ArchiveSandboxPathsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ArchiveSandboxPathsRequest.ProtoReflect.Descriptor instead.
 func (*ArchiveSandboxPathsRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{46}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *ArchiveSandboxPathsRequest) GetSandboxId() string {
@@ -3446,7 +3558,7 @@ type ArchiveSandboxPathsResponse struct {
 
 func (x *ArchiveSandboxPathsResponse) Reset() {
 	*x = ArchiveSandboxPathsResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[47]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3458,7 +3570,7 @@ func (x *ArchiveSandboxPathsResponse) String() string {
 func (*ArchiveSandboxPathsResponse) ProtoMessage() {}
 
 func (x *ArchiveSandboxPathsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[47]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3471,7 +3583,7 @@ func (x *ArchiveSandboxPathsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ArchiveSandboxPathsResponse.ProtoReflect.Descriptor instead.
 func (*ArchiveSandboxPathsResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{47}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *ArchiveSandboxPathsResponse) GetData() []byte {
@@ -3491,7 +3603,7 @@ type ExtractSandboxArchiveInit struct {
 
 func (x *ExtractSandboxArchiveInit) Reset() {
 	*x = ExtractSandboxArchiveInit{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[48]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3503,7 +3615,7 @@ func (x *ExtractSandboxArchiveInit) String() string {
 func (*ExtractSandboxArchiveInit) ProtoMessage() {}
 
 func (x *ExtractSandboxArchiveInit) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[48]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3516,7 +3628,7 @@ func (x *ExtractSandboxArchiveInit) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExtractSandboxArchiveInit.ProtoReflect.Descriptor instead.
 func (*ExtractSandboxArchiveInit) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{48}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *ExtractSandboxArchiveInit) GetSandboxId() string {
@@ -3546,7 +3658,7 @@ type ExtractSandboxArchiveRequest struct {
 
 func (x *ExtractSandboxArchiveRequest) Reset() {
 	*x = ExtractSandboxArchiveRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[49]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3558,7 +3670,7 @@ func (x *ExtractSandboxArchiveRequest) String() string {
 func (*ExtractSandboxArchiveRequest) ProtoMessage() {}
 
 func (x *ExtractSandboxArchiveRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[49]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3571,7 +3683,7 @@ func (x *ExtractSandboxArchiveRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExtractSandboxArchiveRequest.ProtoReflect.Descriptor instead.
 func (*ExtractSandboxArchiveRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{49}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *ExtractSandboxArchiveRequest) GetPayload() isExtractSandboxArchiveRequest_Payload {
@@ -3626,7 +3738,7 @@ type ExtractSandboxArchiveResponse struct {
 
 func (x *ExtractSandboxArchiveResponse) Reset() {
 	*x = ExtractSandboxArchiveResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[50]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3638,7 +3750,7 @@ func (x *ExtractSandboxArchiveResponse) String() string {
 func (*ExtractSandboxArchiveResponse) ProtoMessage() {}
 
 func (x *ExtractSandboxArchiveResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[50]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3651,7 +3763,7 @@ func (x *ExtractSandboxArchiveResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExtractSandboxArchiveResponse.ProtoReflect.Descriptor instead.
 func (*ExtractSandboxArchiveResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{50}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *ExtractSandboxArchiveResponse) GetSandboxId() string {
@@ -3684,7 +3796,7 @@ type TerminateSandboxRequest struct {
 
 func (x *TerminateSandboxRequest) Reset() {
 	*x = TerminateSandboxRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[51]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3696,7 +3808,7 @@ func (x *TerminateSandboxRequest) String() string {
 func (*TerminateSandboxRequest) ProtoMessage() {}
 
 func (x *TerminateSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[51]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3709,7 +3821,7 @@ func (x *TerminateSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TerminateSandboxRequest.ProtoReflect.Descriptor instead.
 func (*TerminateSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{51}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *TerminateSandboxRequest) GetSandboxId() string {
@@ -3730,7 +3842,7 @@ type TerminateSandboxResponse struct {
 
 func (x *TerminateSandboxResponse) Reset() {
 	*x = TerminateSandboxResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[52]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3742,7 +3854,7 @@ func (x *TerminateSandboxResponse) String() string {
 func (*TerminateSandboxResponse) ProtoMessage() {}
 
 func (x *TerminateSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[52]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3755,7 +3867,7 @@ func (x *TerminateSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TerminateSandboxResponse.ProtoReflect.Descriptor instead.
 func (*TerminateSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{52}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *TerminateSandboxResponse) GetSandboxId() string {
@@ -3789,7 +3901,7 @@ type StreamSandboxEventsRequest struct {
 
 func (x *StreamSandboxEventsRequest) Reset() {
 	*x = StreamSandboxEventsRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[53]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3801,7 +3913,7 @@ func (x *StreamSandboxEventsRequest) String() string {
 func (*StreamSandboxEventsRequest) ProtoMessage() {}
 
 func (x *StreamSandboxEventsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[53]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3814,7 +3926,7 @@ func (x *StreamSandboxEventsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamSandboxEventsRequest.ProtoReflect.Descriptor instead.
 func (*StreamSandboxEventsRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{53}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *StreamSandboxEventsRequest) GetSandboxId() string {
@@ -3843,7 +3955,7 @@ type SandboxEvent struct {
 
 func (x *SandboxEvent) Reset() {
 	*x = SandboxEvent{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[54]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3855,7 +3967,7 @@ func (x *SandboxEvent) String() string {
 func (*SandboxEvent) ProtoMessage() {}
 
 func (x *SandboxEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[54]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3868,7 +3980,7 @@ func (x *SandboxEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxEvent.ProtoReflect.Descriptor instead.
 func (*SandboxEvent) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{54}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *SandboxEvent) GetSandboxId() string {
@@ -3909,7 +4021,7 @@ type CreateSnapshotRequest struct {
 
 func (x *CreateSnapshotRequest) Reset() {
 	*x = CreateSnapshotRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[55]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3921,7 +4033,7 @@ func (x *CreateSnapshotRequest) String() string {
 func (*CreateSnapshotRequest) ProtoMessage() {}
 
 func (x *CreateSnapshotRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[55]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3934,7 +4046,7 @@ func (x *CreateSnapshotRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSnapshotRequest.ProtoReflect.Descriptor instead.
 func (*CreateSnapshotRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{55}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *CreateSnapshotRequest) GetSandboxId() string {
@@ -3961,7 +4073,7 @@ type CreateSnapshotResponse struct {
 
 func (x *CreateSnapshotResponse) Reset() {
 	*x = CreateSnapshotResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[56]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3973,7 +4085,7 @@ func (x *CreateSnapshotResponse) String() string {
 func (*CreateSnapshotResponse) ProtoMessage() {}
 
 func (x *CreateSnapshotResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[56]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3986,7 +4098,7 @@ func (x *CreateSnapshotResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSnapshotResponse.ProtoReflect.Descriptor instead.
 func (*CreateSnapshotResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{56}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *CreateSnapshotResponse) GetSnapshot() *Snapshot {
@@ -4012,7 +4124,7 @@ type GetSnapshotRequest struct {
 
 func (x *GetSnapshotRequest) Reset() {
 	*x = GetSnapshotRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[57]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4024,7 +4136,7 @@ func (x *GetSnapshotRequest) String() string {
 func (*GetSnapshotRequest) ProtoMessage() {}
 
 func (x *GetSnapshotRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[57]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4037,7 +4149,7 @@ func (x *GetSnapshotRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSnapshotRequest.ProtoReflect.Descriptor instead.
 func (*GetSnapshotRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{57}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *GetSnapshotRequest) GetSnapshotId() string {
@@ -4056,7 +4168,7 @@ type GetSnapshotResponse struct {
 
 func (x *GetSnapshotResponse) Reset() {
 	*x = GetSnapshotResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[58]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4068,7 +4180,7 @@ func (x *GetSnapshotResponse) String() string {
 func (*GetSnapshotResponse) ProtoMessage() {}
 
 func (x *GetSnapshotResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[58]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4081,7 +4193,7 @@ func (x *GetSnapshotResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSnapshotResponse.ProtoReflect.Descriptor instead.
 func (*GetSnapshotResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{58}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *GetSnapshotResponse) GetSnapshot() *Snapshot {
@@ -4099,7 +4211,7 @@ type ListSnapshotsRequest struct {
 
 func (x *ListSnapshotsRequest) Reset() {
 	*x = ListSnapshotsRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[59]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4111,7 +4223,7 @@ func (x *ListSnapshotsRequest) String() string {
 func (*ListSnapshotsRequest) ProtoMessage() {}
 
 func (x *ListSnapshotsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[59]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4124,7 +4236,7 @@ func (x *ListSnapshotsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSnapshotsRequest.ProtoReflect.Descriptor instead.
 func (*ListSnapshotsRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{59}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{61}
 }
 
 type ListSnapshotsResponse struct {
@@ -4136,7 +4248,7 @@ type ListSnapshotsResponse struct {
 
 func (x *ListSnapshotsResponse) Reset() {
 	*x = ListSnapshotsResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[60]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4148,7 +4260,7 @@ func (x *ListSnapshotsResponse) String() string {
 func (*ListSnapshotsResponse) ProtoMessage() {}
 
 func (x *ListSnapshotsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[60]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4161,7 +4273,7 @@ func (x *ListSnapshotsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSnapshotsResponse.ProtoReflect.Descriptor instead.
 func (*ListSnapshotsResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{60}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *ListSnapshotsResponse) GetSnapshots() []*Snapshot {
@@ -4180,7 +4292,7 @@ type DeleteSnapshotRequest struct {
 
 func (x *DeleteSnapshotRequest) Reset() {
 	*x = DeleteSnapshotRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[61]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4192,7 +4304,7 @@ func (x *DeleteSnapshotRequest) String() string {
 func (*DeleteSnapshotRequest) ProtoMessage() {}
 
 func (x *DeleteSnapshotRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[61]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4205,7 +4317,7 @@ func (x *DeleteSnapshotRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSnapshotRequest.ProtoReflect.Descriptor instead.
 func (*DeleteSnapshotRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{61}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *DeleteSnapshotRequest) GetSnapshotId() string {
@@ -4226,7 +4338,7 @@ type DeleteSnapshotResponse struct {
 
 func (x *DeleteSnapshotResponse) Reset() {
 	*x = DeleteSnapshotResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[62]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4238,7 +4350,7 @@ func (x *DeleteSnapshotResponse) String() string {
 func (*DeleteSnapshotResponse) ProtoMessage() {}
 
 func (x *DeleteSnapshotResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[62]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4251,7 +4363,7 @@ func (x *DeleteSnapshotResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSnapshotResponse.ProtoReflect.Descriptor instead.
 func (*DeleteSnapshotResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{62}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *DeleteSnapshotResponse) GetSnapshotId() string {
@@ -4292,7 +4404,7 @@ type Execution struct {
 
 func (x *Execution) Reset() {
 	*x = Execution{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[63]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4304,7 +4416,7 @@ func (x *Execution) String() string {
 func (*Execution) ProtoMessage() {}
 
 func (x *Execution) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[63]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4317,7 +4429,7 @@ func (x *Execution) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Execution.ProtoReflect.Descriptor instead.
 func (*Execution) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{63}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *Execution) GetExecutionId() string {
@@ -4395,7 +4507,7 @@ type ExecutionOptions struct {
 
 func (x *ExecutionOptions) Reset() {
 	*x = ExecutionOptions{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[64]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4407,7 +4519,7 @@ func (x *ExecutionOptions) String() string {
 func (*ExecutionOptions) ProtoMessage() {}
 
 func (x *ExecutionOptions) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[64]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4420,7 +4532,7 @@ func (x *ExecutionOptions) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionOptions.ProtoReflect.Descriptor instead.
 func (*ExecutionOptions) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{64}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *ExecutionOptions) GetLaunchSeconds() int64 {
@@ -4465,7 +4577,7 @@ type CreateExecutionRequest struct {
 
 func (x *CreateExecutionRequest) Reset() {
 	*x = CreateExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[65]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4477,7 +4589,7 @@ func (x *CreateExecutionRequest) String() string {
 func (*CreateExecutionRequest) ProtoMessage() {}
 
 func (x *CreateExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[65]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4490,7 +4602,7 @@ func (x *CreateExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateExecutionRequest.ProtoReflect.Descriptor instead.
 func (*CreateExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{65}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *CreateExecutionRequest) GetSandboxId() string {
@@ -4544,7 +4656,7 @@ type CreateExecutionResponse struct {
 
 func (x *CreateExecutionResponse) Reset() {
 	*x = CreateExecutionResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[66]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4556,7 +4668,7 @@ func (x *CreateExecutionResponse) String() string {
 func (*CreateExecutionResponse) ProtoMessage() {}
 
 func (x *CreateExecutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[66]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4569,7 +4681,7 @@ func (x *CreateExecutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateExecutionResponse.ProtoReflect.Descriptor instead.
 func (*CreateExecutionResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{66}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *CreateExecutionResponse) GetExecution() *Execution {
@@ -4591,7 +4703,7 @@ type AttachExecutionRequest struct {
 
 func (x *AttachExecutionRequest) Reset() {
 	*x = AttachExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[67]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4603,7 +4715,7 @@ func (x *AttachExecutionRequest) String() string {
 func (*AttachExecutionRequest) ProtoMessage() {}
 
 func (x *AttachExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[67]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4616,7 +4728,7 @@ func (x *AttachExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachExecutionRequest.ProtoReflect.Descriptor instead.
 func (*AttachExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{67}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{69}
 }
 
 func (x *AttachExecutionRequest) GetSandboxId() string {
@@ -4661,7 +4773,7 @@ type AttachExecutionResponse struct {
 
 func (x *AttachExecutionResponse) Reset() {
 	*x = AttachExecutionResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[68]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4673,7 +4785,7 @@ func (x *AttachExecutionResponse) String() string {
 func (*AttachExecutionResponse) ProtoMessage() {}
 
 func (x *AttachExecutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[68]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4686,7 +4798,7 @@ func (x *AttachExecutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachExecutionResponse.ProtoReflect.Descriptor instead.
 func (*AttachExecutionResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{68}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *AttachExecutionResponse) GetSessionId() string {
@@ -4741,7 +4853,7 @@ type GetExecutionRequest struct {
 
 func (x *GetExecutionRequest) Reset() {
 	*x = GetExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[69]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4753,7 +4865,7 @@ func (x *GetExecutionRequest) String() string {
 func (*GetExecutionRequest) ProtoMessage() {}
 
 func (x *GetExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[69]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4766,7 +4878,7 @@ func (x *GetExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetExecutionRequest.ProtoReflect.Descriptor instead.
 func (*GetExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{69}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *GetExecutionRequest) GetSandboxId() string {
@@ -4792,7 +4904,7 @@ type GetExecutionResponse struct {
 
 func (x *GetExecutionResponse) Reset() {
 	*x = GetExecutionResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[70]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4804,7 +4916,7 @@ func (x *GetExecutionResponse) String() string {
 func (*GetExecutionResponse) ProtoMessage() {}
 
 func (x *GetExecutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[70]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4817,7 +4929,7 @@ func (x *GetExecutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetExecutionResponse.ProtoReflect.Descriptor instead.
 func (*GetExecutionResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{70}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *GetExecutionResponse) GetExecution() *Execution {
@@ -4837,7 +4949,7 @@ type InspectExecutionRequest struct {
 
 func (x *InspectExecutionRequest) Reset() {
 	*x = InspectExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[71]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4849,7 +4961,7 @@ func (x *InspectExecutionRequest) String() string {
 func (*InspectExecutionRequest) ProtoMessage() {}
 
 func (x *InspectExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[71]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4862,7 +4974,7 @@ func (x *InspectExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectExecutionRequest.ProtoReflect.Descriptor instead.
 func (*InspectExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{71}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *InspectExecutionRequest) GetSandboxId() string {
@@ -4899,7 +5011,7 @@ type InspectExecutionResponse struct {
 
 func (x *InspectExecutionResponse) Reset() {
 	*x = InspectExecutionResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[72]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4911,7 +5023,7 @@ func (x *InspectExecutionResponse) String() string {
 func (*InspectExecutionResponse) ProtoMessage() {}
 
 func (x *InspectExecutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[72]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4924,7 +5036,7 @@ func (x *InspectExecutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectExecutionResponse.ProtoReflect.Descriptor instead.
 func (*InspectExecutionResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{72}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{74}
 }
 
 func (x *InspectExecutionResponse) GetExecution() *Execution {
@@ -5022,7 +5134,7 @@ type CancelExecutionRequest struct {
 
 func (x *CancelExecutionRequest) Reset() {
 	*x = CancelExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[73]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5034,7 +5146,7 @@ func (x *CancelExecutionRequest) String() string {
 func (*CancelExecutionRequest) ProtoMessage() {}
 
 func (x *CancelExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[73]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5047,7 +5159,7 @@ func (x *CancelExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelExecutionRequest.ProtoReflect.Descriptor instead.
 func (*CancelExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{73}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{75}
 }
 
 func (x *CancelExecutionRequest) GetSandboxId() string {
@@ -5083,7 +5195,7 @@ type CancelExecutionResponse struct {
 
 func (x *CancelExecutionResponse) Reset() {
 	*x = CancelExecutionResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[74]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5095,7 +5207,7 @@ func (x *CancelExecutionResponse) String() string {
 func (*CancelExecutionResponse) ProtoMessage() {}
 
 func (x *CancelExecutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[74]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5108,7 +5220,7 @@ func (x *CancelExecutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelExecutionResponse.ProtoReflect.Descriptor instead.
 func (*CancelExecutionResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{74}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{76}
 }
 
 func (x *CancelExecutionResponse) GetSandboxId() string {
@@ -5150,7 +5262,7 @@ type WriteExecutionStdinRequest struct {
 
 func (x *WriteExecutionStdinRequest) Reset() {
 	*x = WriteExecutionStdinRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[75]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5162,7 +5274,7 @@ func (x *WriteExecutionStdinRequest) String() string {
 func (*WriteExecutionStdinRequest) ProtoMessage() {}
 
 func (x *WriteExecutionStdinRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[75]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5175,7 +5287,7 @@ func (x *WriteExecutionStdinRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WriteExecutionStdinRequest.ProtoReflect.Descriptor instead.
 func (*WriteExecutionStdinRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{75}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{77}
 }
 
 func (x *WriteExecutionStdinRequest) GetSandboxId() string {
@@ -5207,7 +5319,7 @@ type WriteExecutionStdinResponse struct {
 
 func (x *WriteExecutionStdinResponse) Reset() {
 	*x = WriteExecutionStdinResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[76]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5219,7 +5331,7 @@ func (x *WriteExecutionStdinResponse) String() string {
 func (*WriteExecutionStdinResponse) ProtoMessage() {}
 
 func (x *WriteExecutionStdinResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[76]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5232,7 +5344,7 @@ func (x *WriteExecutionStdinResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WriteExecutionStdinResponse.ProtoReflect.Descriptor instead.
 func (*WriteExecutionStdinResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{76}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{78}
 }
 
 type CloseExecutionStdinRequest struct {
@@ -5245,7 +5357,7 @@ type CloseExecutionStdinRequest struct {
 
 func (x *CloseExecutionStdinRequest) Reset() {
 	*x = CloseExecutionStdinRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[77]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5257,7 +5369,7 @@ func (x *CloseExecutionStdinRequest) String() string {
 func (*CloseExecutionStdinRequest) ProtoMessage() {}
 
 func (x *CloseExecutionStdinRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[77]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5270,7 +5382,7 @@ func (x *CloseExecutionStdinRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CloseExecutionStdinRequest.ProtoReflect.Descriptor instead.
 func (*CloseExecutionStdinRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{77}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{79}
 }
 
 func (x *CloseExecutionStdinRequest) GetSandboxId() string {
@@ -5295,7 +5407,7 @@ type CloseExecutionStdinResponse struct {
 
 func (x *CloseExecutionStdinResponse) Reset() {
 	*x = CloseExecutionStdinResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[78]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5307,7 +5419,7 @@ func (x *CloseExecutionStdinResponse) String() string {
 func (*CloseExecutionStdinResponse) ProtoMessage() {}
 
 func (x *CloseExecutionStdinResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[78]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5320,7 +5432,7 @@ func (x *CloseExecutionStdinResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CloseExecutionStdinResponse.ProtoReflect.Descriptor instead.
 func (*CloseExecutionStdinResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{78}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{80}
 }
 
 type StreamExecutionRequest struct {
@@ -5334,7 +5446,7 @@ type StreamExecutionRequest struct {
 
 func (x *StreamExecutionRequest) Reset() {
 	*x = StreamExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[79]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5346,7 +5458,7 @@ func (x *StreamExecutionRequest) String() string {
 func (*StreamExecutionRequest) ProtoMessage() {}
 
 func (x *StreamExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[79]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5359,7 +5471,7 @@ func (x *StreamExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamExecutionRequest.ProtoReflect.Descriptor instead.
 func (*StreamExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{79}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{81}
 }
 
 func (x *StreamExecutionRequest) GetSandboxId() string {
@@ -5394,7 +5506,7 @@ type ExecutionExit struct {
 
 func (x *ExecutionExit) Reset() {
 	*x = ExecutionExit{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[80]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5406,7 +5518,7 @@ func (x *ExecutionExit) String() string {
 func (*ExecutionExit) ProtoMessage() {}
 
 func (x *ExecutionExit) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[80]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5419,7 +5531,7 @@ func (x *ExecutionExit) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionExit.ProtoReflect.Descriptor instead.
 func (*ExecutionExit) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{80}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{82}
 }
 
 func (x *ExecutionExit) GetExitCode() int32 {
@@ -5465,7 +5577,7 @@ type ExecutionStreamEvent struct {
 
 func (x *ExecutionStreamEvent) Reset() {
 	*x = ExecutionStreamEvent{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[81]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5477,7 +5589,7 @@ func (x *ExecutionStreamEvent) String() string {
 func (*ExecutionStreamEvent) ProtoMessage() {}
 
 func (x *ExecutionStreamEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[81]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5490,7 +5602,7 @@ func (x *ExecutionStreamEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionStreamEvent.ProtoReflect.Descriptor instead.
 func (*ExecutionStreamEvent) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{81}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{83}
 }
 
 func (x *ExecutionStreamEvent) GetSandboxId() string {
@@ -5630,7 +5742,7 @@ type SandboxPortOpenResult struct {
 
 func (x *SandboxPortOpenResult) Reset() {
 	*x = SandboxPortOpenResult{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[82]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5642,7 +5754,7 @@ func (x *SandboxPortOpenResult) String() string {
 func (*SandboxPortOpenResult) ProtoMessage() {}
 
 func (x *SandboxPortOpenResult) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[82]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5655,7 +5767,7 @@ func (x *SandboxPortOpenResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxPortOpenResult.ProtoReflect.Descriptor instead.
 func (*SandboxPortOpenResult) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{82}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{84}
 }
 
 func (x *SandboxPortOpenResult) GetError() string {
@@ -5731,19 +5843,28 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\x13repository_checkout\x18\t \x01(\v2 .cleanroom.v1.RepositoryCheckoutR\x12repositoryCheckout\";\n" +
 	"\x0fPolicyAllowRule\x12\x12\n" +
 	"\x04host\x18\x01 \x01(\tR\x04host\x12\x14\n" +
-	"\x05ports\x18\x02 \x03(\x05R\x05ports\"1\n" +
-	"\x13PolicyDockerService\x12\x1a\n" +
-	"\brequired\x18\x01 \x01(\bR\brequired\"\x9a\x01\n" +
-	"\x0ePolicyServices\x129\n" +
-	"\x06docker\x18\x01 \x01(\v2!.cleanroom.v1.PolicyDockerServiceR\x06docker\x12\x18\n" +
-	"\acommand\x18\x02 \x03(\tR\acommand\x123\n" +
-	"\x03key\x18\x03 \x01(\v2!.cleanroom.v1.PolicyDependencyKeyR\x03key\"+\n" +
-	"\x13PolicyDependencyKey\x12\x14\n" +
-	"\x05files\x18\x01 \x03(\tR\x05files\"y\n" +
-	"\x12PolicyDependencies\x12\x18\n" +
-	"\acommand\x18\x01 \x03(\tR\acommand\x123\n" +
-	"\x03key\x18\x02 \x01(\v2!.cleanroom.v1.PolicyDependencyKeyR\x03key\x12\x14\n" +
-	"\x05reuse\x18\x03 \x01(\tR\x05reuse\"#\n" +
+	"\x05ports\x18\x02 \x03(\x05R\x05ports\"*\n" +
+	"\fPolicyDocker\x12\x1a\n" +
+	"\brequired\x18\x01 \x01(\bR\brequired\")\n" +
+	"\x11PolicyBlockInputs\x12\x14\n" +
+	"\x05files\x18\x01 \x03(\tR\x05files\">\n" +
+	"\x12PolicyBlockOutputs\x12\x12\n" +
+	"\x04dirs\x18\x01 \x03(\tR\x04dirs\x12\x14\n" +
+	"\x05files\x18\x02 \x03(\tR\x05files\"\x9e\x02\n" +
+	"\vPolicyBlock\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x18\n" +
+	"\acommand\x18\x02 \x03(\tR\acommand\x127\n" +
+	"\x06inputs\x18\x03 \x01(\v2\x1f.cleanroom.v1.PolicyBlockInputsR\x06inputs\x124\n" +
+	"\x03env\x18\x04 \x03(\v2\".cleanroom.v1.PolicyBlock.EnvEntryR\x03env\x12:\n" +
+	"\aoutputs\x18\x05 \x01(\v2 .cleanroom.v1.PolicyBlockOutputsR\aoutputs\x1a6\n" +
+	"\bEnvEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"k\n" +
+	"\x0ePolicyServices\x121\n" +
+	"\x06blocks\x18\x04 \x03(\v2\x19.cleanroom.v1.PolicyBlockR\x06blocksJ\x04\b\x01\x10\x02J\x04\b\x02\x10\x03J\x04\b\x03\x10\x04R\x06dockerR\acommandR\x03key\"w\n" +
+	"\x12PolicyDependencies\x12\x14\n" +
+	"\x05reuse\x18\x03 \x01(\tR\x05reuse\x121\n" +
+	"\x06blocks\x18\x04 \x03(\v2\x19.cleanroom.v1.PolicyBlockR\x06blocksJ\x04\b\x01\x10\x02J\x04\b\x02\x10\x03R\acommandR\x03key\"#\n" +
 	"\tPolicyRun\x12\x16\n" +
 	"\x06before\x18\x01 \x03(\tR\x06before\"D\n" +
 	"\rPolicyNetwork\x123\n" +
@@ -5757,7 +5878,7 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\x05vcpus\x18\x01 \x01(\x03R\x05vcpus\x12!\n" +
 	"\fmemory_bytes\x18\x02 \x01(\x03R\vmemoryBytes\x12\x1d\n" +
 	"\n" +
-	"disk_bytes\x18\x03 \x01(\x03R\tdiskBytes\"\x86\x04\n" +
+	"disk_bytes\x18\x03 \x01(\x03R\tdiskBytes\"\xba\x04\n" +
 	"\x06Policy\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\x05R\aversion\x12\x1b\n" +
 	"\timage_ref\x18\x02 \x01(\tR\bimageRef\x12!\n" +
@@ -5770,7 +5891,8 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\x03run\x18\n" +
 	" \x01(\v2\x17.cleanroom.v1.PolicyRunR\x03run\x12;\n" +
 	"\tresources\x18\v \x01(\v2\x1d.cleanroom.v1.PolicyResourcesR\tresources\x12H\n" +
-	"\x0enetwork_stages\x18\f \x01(\v2!.cleanroom.v1.PolicyNetworkStagesR\rnetworkStages\"R\n" +
+	"\x0enetwork_stages\x18\f \x01(\v2!.cleanroom.v1.PolicyNetworkStagesR\rnetworkStages\x122\n" +
+	"\x06docker\x18\r \x01(\v2\x1a.cleanroom.v1.PolicyDockerR\x06docker\"R\n" +
 	"\x0eSandboxOptions\x12%\n" +
 	"\x0elaunch_seconds\x18\x03 \x01(\x03R\rlaunchSecondsJ\x04\b\x02\x10\x03R\x13read_only_workspace\"\xe1\x01\n" +
 	"\x12RepositoryCheckout\x12\x1d\n" +
@@ -6196,7 +6318,7 @@ func file_proto_cleanroom_v1_control_proto_rawDescGZIP() []byte {
 }
 
 var file_proto_cleanroom_v1_control_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_proto_cleanroom_v1_control_proto_msgTypes = make([]protoimpl.MessageInfo, 84)
+var file_proto_cleanroom_v1_control_proto_msgTypes = make([]protoimpl.MessageInfo, 87)
 var file_proto_cleanroom_v1_control_proto_goTypes = []any{
 	(SandboxStatus)(0),                    // 0: cleanroom.v1.SandboxStatus
 	(CreateSandboxPhase)(0),               // 1: cleanroom.v1.CreateSandboxPhase
@@ -6210,216 +6332,222 @@ var file_proto_cleanroom_v1_control_proto_goTypes = []any{
 	(*SandboxPortCloseWrite)(nil),         // 9: cleanroom.v1.SandboxPortCloseWrite
 	(*Snapshot)(nil),                      // 10: cleanroom.v1.Snapshot
 	(*PolicyAllowRule)(nil),               // 11: cleanroom.v1.PolicyAllowRule
-	(*PolicyDockerService)(nil),           // 12: cleanroom.v1.PolicyDockerService
-	(*PolicyServices)(nil),                // 13: cleanroom.v1.PolicyServices
-	(*PolicyDependencyKey)(nil),           // 14: cleanroom.v1.PolicyDependencyKey
-	(*PolicyDependencies)(nil),            // 15: cleanroom.v1.PolicyDependencies
-	(*PolicyRun)(nil),                     // 16: cleanroom.v1.PolicyRun
-	(*PolicyNetwork)(nil),                 // 17: cleanroom.v1.PolicyNetwork
-	(*PolicyNetworkStages)(nil),           // 18: cleanroom.v1.PolicyNetworkStages
-	(*PolicyResources)(nil),               // 19: cleanroom.v1.PolicyResources
-	(*Policy)(nil),                        // 20: cleanroom.v1.Policy
-	(*SandboxOptions)(nil),                // 21: cleanroom.v1.SandboxOptions
-	(*RepositoryCheckout)(nil),            // 22: cleanroom.v1.RepositoryCheckout
-	(*RepositoryChangesetFile)(nil),       // 23: cleanroom.v1.RepositoryChangesetFile
-	(*RepositoryChangeset)(nil),           // 24: cleanroom.v1.RepositoryChangeset
-	(*RepositoryCommitBundle)(nil),        // 25: cleanroom.v1.RepositoryCommitBundle
-	(*CreateSandboxRequest)(nil),          // 26: cleanroom.v1.CreateSandboxRequest
-	(*CreateSandboxResponse)(nil),         // 27: cleanroom.v1.CreateSandboxResponse
-	(*CreateSandboxEvent)(nil),            // 28: cleanroom.v1.CreateSandboxEvent
-	(*GetSandboxRequest)(nil),             // 29: cleanroom.v1.GetSandboxRequest
-	(*GetSandboxResponse)(nil),            // 30: cleanroom.v1.GetSandboxResponse
-	(*ListSandboxesRequest)(nil),          // 31: cleanroom.v1.ListSandboxesRequest
-	(*ListSandboxesResponse)(nil),         // 32: cleanroom.v1.ListSandboxesResponse
-	(*ListExecutionsRequest)(nil),         // 33: cleanroom.v1.ListExecutionsRequest
-	(*ListExecutionsResponse)(nil),        // 34: cleanroom.v1.ListExecutionsResponse
-	(*DownloadSandboxFileRequest)(nil),    // 35: cleanroom.v1.DownloadSandboxFileRequest
-	(*DownloadSandboxFileResponse)(nil),   // 36: cleanroom.v1.DownloadSandboxFileResponse
-	(*UploadSandboxFileRequest)(nil),      // 37: cleanroom.v1.UploadSandboxFileRequest
-	(*UploadSandboxFileResponse)(nil),     // 38: cleanroom.v1.UploadSandboxFileResponse
-	(*SandboxPathInfo)(nil),               // 39: cleanroom.v1.SandboxPathInfo
-	(*StatSandboxPathRequest)(nil),        // 40: cleanroom.v1.StatSandboxPathRequest
-	(*StatSandboxPathResponse)(nil),       // 41: cleanroom.v1.StatSandboxPathResponse
-	(*WalkSandboxTreeRequest)(nil),        // 42: cleanroom.v1.WalkSandboxTreeRequest
-	(*WalkSandboxTreeResponse)(nil),       // 43: cleanroom.v1.WalkSandboxTreeResponse
-	(*ReadSandboxFileRequest)(nil),        // 44: cleanroom.v1.ReadSandboxFileRequest
-	(*ReadSandboxFileResponse)(nil),       // 45: cleanroom.v1.ReadSandboxFileResponse
-	(*WriteSandboxFileInit)(nil),          // 46: cleanroom.v1.WriteSandboxFileInit
-	(*WriteSandboxFileRequest)(nil),       // 47: cleanroom.v1.WriteSandboxFileRequest
-	(*WriteSandboxFileResponse)(nil),      // 48: cleanroom.v1.WriteSandboxFileResponse
-	(*RemoveSandboxPathRequest)(nil),      // 49: cleanroom.v1.RemoveSandboxPathRequest
-	(*RemoveSandboxPathResponse)(nil),     // 50: cleanroom.v1.RemoveSandboxPathResponse
-	(*ArchiveSandboxPathsRequest)(nil),    // 51: cleanroom.v1.ArchiveSandboxPathsRequest
-	(*ArchiveSandboxPathsResponse)(nil),   // 52: cleanroom.v1.ArchiveSandboxPathsResponse
-	(*ExtractSandboxArchiveInit)(nil),     // 53: cleanroom.v1.ExtractSandboxArchiveInit
-	(*ExtractSandboxArchiveRequest)(nil),  // 54: cleanroom.v1.ExtractSandboxArchiveRequest
-	(*ExtractSandboxArchiveResponse)(nil), // 55: cleanroom.v1.ExtractSandboxArchiveResponse
-	(*TerminateSandboxRequest)(nil),       // 56: cleanroom.v1.TerminateSandboxRequest
-	(*TerminateSandboxResponse)(nil),      // 57: cleanroom.v1.TerminateSandboxResponse
-	(*StreamSandboxEventsRequest)(nil),    // 58: cleanroom.v1.StreamSandboxEventsRequest
-	(*SandboxEvent)(nil),                  // 59: cleanroom.v1.SandboxEvent
-	(*CreateSnapshotRequest)(nil),         // 60: cleanroom.v1.CreateSnapshotRequest
-	(*CreateSnapshotResponse)(nil),        // 61: cleanroom.v1.CreateSnapshotResponse
-	(*GetSnapshotRequest)(nil),            // 62: cleanroom.v1.GetSnapshotRequest
-	(*GetSnapshotResponse)(nil),           // 63: cleanroom.v1.GetSnapshotResponse
-	(*ListSnapshotsRequest)(nil),          // 64: cleanroom.v1.ListSnapshotsRequest
-	(*ListSnapshotsResponse)(nil),         // 65: cleanroom.v1.ListSnapshotsResponse
-	(*DeleteSnapshotRequest)(nil),         // 66: cleanroom.v1.DeleteSnapshotRequest
-	(*DeleteSnapshotResponse)(nil),        // 67: cleanroom.v1.DeleteSnapshotResponse
-	(*Execution)(nil),                     // 68: cleanroom.v1.Execution
-	(*ExecutionOptions)(nil),              // 69: cleanroom.v1.ExecutionOptions
-	(*CreateExecutionRequest)(nil),        // 70: cleanroom.v1.CreateExecutionRequest
-	(*CreateExecutionResponse)(nil),       // 71: cleanroom.v1.CreateExecutionResponse
-	(*AttachExecutionRequest)(nil),        // 72: cleanroom.v1.AttachExecutionRequest
-	(*AttachExecutionResponse)(nil),       // 73: cleanroom.v1.AttachExecutionResponse
-	(*GetExecutionRequest)(nil),           // 74: cleanroom.v1.GetExecutionRequest
-	(*GetExecutionResponse)(nil),          // 75: cleanroom.v1.GetExecutionResponse
-	(*InspectExecutionRequest)(nil),       // 76: cleanroom.v1.InspectExecutionRequest
-	(*InspectExecutionResponse)(nil),      // 77: cleanroom.v1.InspectExecutionResponse
-	(*CancelExecutionRequest)(nil),        // 78: cleanroom.v1.CancelExecutionRequest
-	(*CancelExecutionResponse)(nil),       // 79: cleanroom.v1.CancelExecutionResponse
-	(*WriteExecutionStdinRequest)(nil),    // 80: cleanroom.v1.WriteExecutionStdinRequest
-	(*WriteExecutionStdinResponse)(nil),   // 81: cleanroom.v1.WriteExecutionStdinResponse
-	(*CloseExecutionStdinRequest)(nil),    // 82: cleanroom.v1.CloseExecutionStdinRequest
-	(*CloseExecutionStdinResponse)(nil),   // 83: cleanroom.v1.CloseExecutionStdinResponse
-	(*StreamExecutionRequest)(nil),        // 84: cleanroom.v1.StreamExecutionRequest
-	(*ExecutionExit)(nil),                 // 85: cleanroom.v1.ExecutionExit
-	(*ExecutionStreamEvent)(nil),          // 86: cleanroom.v1.ExecutionStreamEvent
-	(*SandboxPortOpenResult)(nil),         // 87: cleanroom.v1.SandboxPortOpenResult
-	nil,                                   // 88: cleanroom.v1.Sandbox.BackendCapabilitiesEntry
-	(*timestamppb.Timestamp)(nil),         // 89: google.protobuf.Timestamp
-	(*structpb.Struct)(nil),               // 90: google.protobuf.Struct
+	(*PolicyDocker)(nil),                  // 12: cleanroom.v1.PolicyDocker
+	(*PolicyBlockInputs)(nil),             // 13: cleanroom.v1.PolicyBlockInputs
+	(*PolicyBlockOutputs)(nil),            // 14: cleanroom.v1.PolicyBlockOutputs
+	(*PolicyBlock)(nil),                   // 15: cleanroom.v1.PolicyBlock
+	(*PolicyServices)(nil),                // 16: cleanroom.v1.PolicyServices
+	(*PolicyDependencies)(nil),            // 17: cleanroom.v1.PolicyDependencies
+	(*PolicyRun)(nil),                     // 18: cleanroom.v1.PolicyRun
+	(*PolicyNetwork)(nil),                 // 19: cleanroom.v1.PolicyNetwork
+	(*PolicyNetworkStages)(nil),           // 20: cleanroom.v1.PolicyNetworkStages
+	(*PolicyResources)(nil),               // 21: cleanroom.v1.PolicyResources
+	(*Policy)(nil),                        // 22: cleanroom.v1.Policy
+	(*SandboxOptions)(nil),                // 23: cleanroom.v1.SandboxOptions
+	(*RepositoryCheckout)(nil),            // 24: cleanroom.v1.RepositoryCheckout
+	(*RepositoryChangesetFile)(nil),       // 25: cleanroom.v1.RepositoryChangesetFile
+	(*RepositoryChangeset)(nil),           // 26: cleanroom.v1.RepositoryChangeset
+	(*RepositoryCommitBundle)(nil),        // 27: cleanroom.v1.RepositoryCommitBundle
+	(*CreateSandboxRequest)(nil),          // 28: cleanroom.v1.CreateSandboxRequest
+	(*CreateSandboxResponse)(nil),         // 29: cleanroom.v1.CreateSandboxResponse
+	(*CreateSandboxEvent)(nil),            // 30: cleanroom.v1.CreateSandboxEvent
+	(*GetSandboxRequest)(nil),             // 31: cleanroom.v1.GetSandboxRequest
+	(*GetSandboxResponse)(nil),            // 32: cleanroom.v1.GetSandboxResponse
+	(*ListSandboxesRequest)(nil),          // 33: cleanroom.v1.ListSandboxesRequest
+	(*ListSandboxesResponse)(nil),         // 34: cleanroom.v1.ListSandboxesResponse
+	(*ListExecutionsRequest)(nil),         // 35: cleanroom.v1.ListExecutionsRequest
+	(*ListExecutionsResponse)(nil),        // 36: cleanroom.v1.ListExecutionsResponse
+	(*DownloadSandboxFileRequest)(nil),    // 37: cleanroom.v1.DownloadSandboxFileRequest
+	(*DownloadSandboxFileResponse)(nil),   // 38: cleanroom.v1.DownloadSandboxFileResponse
+	(*UploadSandboxFileRequest)(nil),      // 39: cleanroom.v1.UploadSandboxFileRequest
+	(*UploadSandboxFileResponse)(nil),     // 40: cleanroom.v1.UploadSandboxFileResponse
+	(*SandboxPathInfo)(nil),               // 41: cleanroom.v1.SandboxPathInfo
+	(*StatSandboxPathRequest)(nil),        // 42: cleanroom.v1.StatSandboxPathRequest
+	(*StatSandboxPathResponse)(nil),       // 43: cleanroom.v1.StatSandboxPathResponse
+	(*WalkSandboxTreeRequest)(nil),        // 44: cleanroom.v1.WalkSandboxTreeRequest
+	(*WalkSandboxTreeResponse)(nil),       // 45: cleanroom.v1.WalkSandboxTreeResponse
+	(*ReadSandboxFileRequest)(nil),        // 46: cleanroom.v1.ReadSandboxFileRequest
+	(*ReadSandboxFileResponse)(nil),       // 47: cleanroom.v1.ReadSandboxFileResponse
+	(*WriteSandboxFileInit)(nil),          // 48: cleanroom.v1.WriteSandboxFileInit
+	(*WriteSandboxFileRequest)(nil),       // 49: cleanroom.v1.WriteSandboxFileRequest
+	(*WriteSandboxFileResponse)(nil),      // 50: cleanroom.v1.WriteSandboxFileResponse
+	(*RemoveSandboxPathRequest)(nil),      // 51: cleanroom.v1.RemoveSandboxPathRequest
+	(*RemoveSandboxPathResponse)(nil),     // 52: cleanroom.v1.RemoveSandboxPathResponse
+	(*ArchiveSandboxPathsRequest)(nil),    // 53: cleanroom.v1.ArchiveSandboxPathsRequest
+	(*ArchiveSandboxPathsResponse)(nil),   // 54: cleanroom.v1.ArchiveSandboxPathsResponse
+	(*ExtractSandboxArchiveInit)(nil),     // 55: cleanroom.v1.ExtractSandboxArchiveInit
+	(*ExtractSandboxArchiveRequest)(nil),  // 56: cleanroom.v1.ExtractSandboxArchiveRequest
+	(*ExtractSandboxArchiveResponse)(nil), // 57: cleanroom.v1.ExtractSandboxArchiveResponse
+	(*TerminateSandboxRequest)(nil),       // 58: cleanroom.v1.TerminateSandboxRequest
+	(*TerminateSandboxResponse)(nil),      // 59: cleanroom.v1.TerminateSandboxResponse
+	(*StreamSandboxEventsRequest)(nil),    // 60: cleanroom.v1.StreamSandboxEventsRequest
+	(*SandboxEvent)(nil),                  // 61: cleanroom.v1.SandboxEvent
+	(*CreateSnapshotRequest)(nil),         // 62: cleanroom.v1.CreateSnapshotRequest
+	(*CreateSnapshotResponse)(nil),        // 63: cleanroom.v1.CreateSnapshotResponse
+	(*GetSnapshotRequest)(nil),            // 64: cleanroom.v1.GetSnapshotRequest
+	(*GetSnapshotResponse)(nil),           // 65: cleanroom.v1.GetSnapshotResponse
+	(*ListSnapshotsRequest)(nil),          // 66: cleanroom.v1.ListSnapshotsRequest
+	(*ListSnapshotsResponse)(nil),         // 67: cleanroom.v1.ListSnapshotsResponse
+	(*DeleteSnapshotRequest)(nil),         // 68: cleanroom.v1.DeleteSnapshotRequest
+	(*DeleteSnapshotResponse)(nil),        // 69: cleanroom.v1.DeleteSnapshotResponse
+	(*Execution)(nil),                     // 70: cleanroom.v1.Execution
+	(*ExecutionOptions)(nil),              // 71: cleanroom.v1.ExecutionOptions
+	(*CreateExecutionRequest)(nil),        // 72: cleanroom.v1.CreateExecutionRequest
+	(*CreateExecutionResponse)(nil),       // 73: cleanroom.v1.CreateExecutionResponse
+	(*AttachExecutionRequest)(nil),        // 74: cleanroom.v1.AttachExecutionRequest
+	(*AttachExecutionResponse)(nil),       // 75: cleanroom.v1.AttachExecutionResponse
+	(*GetExecutionRequest)(nil),           // 76: cleanroom.v1.GetExecutionRequest
+	(*GetExecutionResponse)(nil),          // 77: cleanroom.v1.GetExecutionResponse
+	(*InspectExecutionRequest)(nil),       // 78: cleanroom.v1.InspectExecutionRequest
+	(*InspectExecutionResponse)(nil),      // 79: cleanroom.v1.InspectExecutionResponse
+	(*CancelExecutionRequest)(nil),        // 80: cleanroom.v1.CancelExecutionRequest
+	(*CancelExecutionResponse)(nil),       // 81: cleanroom.v1.CancelExecutionResponse
+	(*WriteExecutionStdinRequest)(nil),    // 82: cleanroom.v1.WriteExecutionStdinRequest
+	(*WriteExecutionStdinResponse)(nil),   // 83: cleanroom.v1.WriteExecutionStdinResponse
+	(*CloseExecutionStdinRequest)(nil),    // 84: cleanroom.v1.CloseExecutionStdinRequest
+	(*CloseExecutionStdinResponse)(nil),   // 85: cleanroom.v1.CloseExecutionStdinResponse
+	(*StreamExecutionRequest)(nil),        // 86: cleanroom.v1.StreamExecutionRequest
+	(*ExecutionExit)(nil),                 // 87: cleanroom.v1.ExecutionExit
+	(*ExecutionStreamEvent)(nil),          // 88: cleanroom.v1.ExecutionStreamEvent
+	(*SandboxPortOpenResult)(nil),         // 89: cleanroom.v1.SandboxPortOpenResult
+	nil,                                   // 90: cleanroom.v1.Sandbox.BackendCapabilitiesEntry
+	nil,                                   // 91: cleanroom.v1.PolicyBlock.EnvEntry
+	(*timestamppb.Timestamp)(nil),         // 92: google.protobuf.Timestamp
+	(*structpb.Struct)(nil),               // 93: google.protobuf.Struct
 }
 var file_proto_cleanroom_v1_control_proto_depIdxs = []int32{
 	0,  // 0: cleanroom.v1.Sandbox.status:type_name -> cleanroom.v1.SandboxStatus
-	89, // 1: cleanroom.v1.Sandbox.created_at:type_name -> google.protobuf.Timestamp
-	89, // 2: cleanroom.v1.Sandbox.updated_at:type_name -> google.protobuf.Timestamp
-	22, // 3: cleanroom.v1.Sandbox.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
-	88, // 4: cleanroom.v1.Sandbox.backend_capabilities:type_name -> cleanroom.v1.Sandbox.BackendCapabilitiesEntry
+	92, // 1: cleanroom.v1.Sandbox.created_at:type_name -> google.protobuf.Timestamp
+	92, // 2: cleanroom.v1.Sandbox.updated_at:type_name -> google.protobuf.Timestamp
+	24, // 3: cleanroom.v1.Sandbox.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
+	90, // 4: cleanroom.v1.Sandbox.backend_capabilities:type_name -> cleanroom.v1.Sandbox.BackendCapabilitiesEntry
 	8,  // 5: cleanroom.v1.SandboxPortFrame.open:type_name -> cleanroom.v1.SandboxPortOpen
 	9,  // 6: cleanroom.v1.SandboxPortFrame.close_write:type_name -> cleanroom.v1.SandboxPortCloseWrite
-	87, // 7: cleanroom.v1.SandboxPortFrame.open_result:type_name -> cleanroom.v1.SandboxPortOpenResult
-	89, // 8: cleanroom.v1.Snapshot.created_at:type_name -> google.protobuf.Timestamp
-	22, // 9: cleanroom.v1.Snapshot.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
-	12, // 10: cleanroom.v1.PolicyServices.docker:type_name -> cleanroom.v1.PolicyDockerService
-	14, // 11: cleanroom.v1.PolicyServices.key:type_name -> cleanroom.v1.PolicyDependencyKey
-	14, // 12: cleanroom.v1.PolicyDependencies.key:type_name -> cleanroom.v1.PolicyDependencyKey
-	11, // 13: cleanroom.v1.PolicyNetwork.allow:type_name -> cleanroom.v1.PolicyAllowRule
-	17, // 14: cleanroom.v1.PolicyNetworkStages.workspace:type_name -> cleanroom.v1.PolicyNetwork
-	17, // 15: cleanroom.v1.PolicyNetworkStages.dependencies:type_name -> cleanroom.v1.PolicyNetwork
-	17, // 16: cleanroom.v1.PolicyNetworkStages.services:type_name -> cleanroom.v1.PolicyNetwork
-	17, // 17: cleanroom.v1.PolicyNetworkStages.execution:type_name -> cleanroom.v1.PolicyNetwork
-	11, // 18: cleanroom.v1.Policy.allow:type_name -> cleanroom.v1.PolicyAllowRule
-	13, // 19: cleanroom.v1.Policy.services:type_name -> cleanroom.v1.PolicyServices
-	15, // 20: cleanroom.v1.Policy.dependencies:type_name -> cleanroom.v1.PolicyDependencies
-	16, // 21: cleanroom.v1.Policy.run:type_name -> cleanroom.v1.PolicyRun
-	19, // 22: cleanroom.v1.Policy.resources:type_name -> cleanroom.v1.PolicyResources
-	18, // 23: cleanroom.v1.Policy.network_stages:type_name -> cleanroom.v1.PolicyNetworkStages
-	23, // 24: cleanroom.v1.RepositoryChangeset.files:type_name -> cleanroom.v1.RepositoryChangesetFile
-	21, // 25: cleanroom.v1.CreateSandboxRequest.options:type_name -> cleanroom.v1.SandboxOptions
-	20, // 26: cleanroom.v1.CreateSandboxRequest.policy:type_name -> cleanroom.v1.Policy
-	22, // 27: cleanroom.v1.CreateSandboxRequest.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
-	24, // 28: cleanroom.v1.CreateSandboxRequest.repository_changeset:type_name -> cleanroom.v1.RepositoryChangeset
-	25, // 29: cleanroom.v1.CreateSandboxRequest.repository_commit_bundle:type_name -> cleanroom.v1.RepositoryCommitBundle
-	5,  // 30: cleanroom.v1.CreateSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
-	1,  // 31: cleanroom.v1.CreateSandboxEvent.phase:type_name -> cleanroom.v1.CreateSandboxPhase
-	27, // 32: cleanroom.v1.CreateSandboxEvent.response:type_name -> cleanroom.v1.CreateSandboxResponse
-	89, // 33: cleanroom.v1.CreateSandboxEvent.occurred_at:type_name -> google.protobuf.Timestamp
-	5,  // 34: cleanroom.v1.GetSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
-	5,  // 35: cleanroom.v1.ListSandboxesResponse.sandboxes:type_name -> cleanroom.v1.Sandbox
-	68, // 36: cleanroom.v1.ListExecutionsResponse.executions:type_name -> cleanroom.v1.Execution
-	2,  // 37: cleanroom.v1.SandboxPathInfo.type:type_name -> cleanroom.v1.SandboxPathType
-	89, // 38: cleanroom.v1.SandboxPathInfo.mtime:type_name -> google.protobuf.Timestamp
-	39, // 39: cleanroom.v1.StatSandboxPathResponse.info:type_name -> cleanroom.v1.SandboxPathInfo
-	39, // 40: cleanroom.v1.WalkSandboxTreeResponse.info:type_name -> cleanroom.v1.SandboxPathInfo
-	89, // 41: cleanroom.v1.WriteSandboxFileInit.mtime:type_name -> google.protobuf.Timestamp
-	46, // 42: cleanroom.v1.WriteSandboxFileRequest.init:type_name -> cleanroom.v1.WriteSandboxFileInit
-	53, // 43: cleanroom.v1.ExtractSandboxArchiveRequest.init:type_name -> cleanroom.v1.ExtractSandboxArchiveInit
-	0,  // 44: cleanroom.v1.SandboxEvent.status:type_name -> cleanroom.v1.SandboxStatus
-	89, // 45: cleanroom.v1.SandboxEvent.occurred_at:type_name -> google.protobuf.Timestamp
-	10, // 46: cleanroom.v1.CreateSnapshotResponse.snapshot:type_name -> cleanroom.v1.Snapshot
-	10, // 47: cleanroom.v1.GetSnapshotResponse.snapshot:type_name -> cleanroom.v1.Snapshot
-	10, // 48: cleanroom.v1.ListSnapshotsResponse.snapshots:type_name -> cleanroom.v1.Snapshot
-	3,  // 49: cleanroom.v1.Execution.status:type_name -> cleanroom.v1.ExecutionStatus
-	89, // 50: cleanroom.v1.Execution.started_at:type_name -> google.protobuf.Timestamp
-	89, // 51: cleanroom.v1.Execution.finished_at:type_name -> google.protobuf.Timestamp
-	4,  // 52: cleanroom.v1.Execution.kind:type_name -> cleanroom.v1.ExecutionKind
-	69, // 53: cleanroom.v1.CreateExecutionRequest.options:type_name -> cleanroom.v1.ExecutionOptions
-	4,  // 54: cleanroom.v1.CreateExecutionRequest.kind:type_name -> cleanroom.v1.ExecutionKind
-	22, // 55: cleanroom.v1.CreateExecutionRequest.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
-	68, // 56: cleanroom.v1.CreateExecutionResponse.execution:type_name -> cleanroom.v1.Execution
-	89, // 57: cleanroom.v1.AttachExecutionResponse.expires_at:type_name -> google.protobuf.Timestamp
-	68, // 58: cleanroom.v1.GetExecutionResponse.execution:type_name -> cleanroom.v1.Execution
-	68, // 59: cleanroom.v1.InspectExecutionResponse.execution:type_name -> cleanroom.v1.Execution
-	90, // 60: cleanroom.v1.InspectExecutionResponse.observability:type_name -> google.protobuf.Struct
-	3,  // 61: cleanroom.v1.CancelExecutionResponse.status:type_name -> cleanroom.v1.ExecutionStatus
-	3,  // 62: cleanroom.v1.ExecutionExit.status:type_name -> cleanroom.v1.ExecutionStatus
-	3,  // 63: cleanroom.v1.ExecutionStreamEvent.status:type_name -> cleanroom.v1.ExecutionStatus
-	85, // 64: cleanroom.v1.ExecutionStreamEvent.exit:type_name -> cleanroom.v1.ExecutionExit
-	89, // 65: cleanroom.v1.ExecutionStreamEvent.occurred_at:type_name -> google.protobuf.Timestamp
-	26, // 66: cleanroom.v1.SandboxService.CreateSandbox:input_type -> cleanroom.v1.CreateSandboxRequest
-	26, // 67: cleanroom.v1.SandboxService.CreateSandboxStream:input_type -> cleanroom.v1.CreateSandboxRequest
-	29, // 68: cleanroom.v1.SandboxService.GetSandbox:input_type -> cleanroom.v1.GetSandboxRequest
-	31, // 69: cleanroom.v1.SandboxService.ListSandboxes:input_type -> cleanroom.v1.ListSandboxesRequest
-	35, // 70: cleanroom.v1.SandboxService.DownloadSandboxFile:input_type -> cleanroom.v1.DownloadSandboxFileRequest
-	37, // 71: cleanroom.v1.SandboxService.UploadSandboxFile:input_type -> cleanroom.v1.UploadSandboxFileRequest
-	40, // 72: cleanroom.v1.SandboxService.StatSandboxPath:input_type -> cleanroom.v1.StatSandboxPathRequest
-	42, // 73: cleanroom.v1.SandboxService.WalkSandboxTree:input_type -> cleanroom.v1.WalkSandboxTreeRequest
-	44, // 74: cleanroom.v1.SandboxService.ReadSandboxFile:input_type -> cleanroom.v1.ReadSandboxFileRequest
-	47, // 75: cleanroom.v1.SandboxService.WriteSandboxFile:input_type -> cleanroom.v1.WriteSandboxFileRequest
-	49, // 76: cleanroom.v1.SandboxService.RemoveSandboxPath:input_type -> cleanroom.v1.RemoveSandboxPathRequest
-	51, // 77: cleanroom.v1.SandboxService.ArchiveSandboxPaths:input_type -> cleanroom.v1.ArchiveSandboxPathsRequest
-	54, // 78: cleanroom.v1.SandboxService.ExtractSandboxArchive:input_type -> cleanroom.v1.ExtractSandboxArchiveRequest
-	56, // 79: cleanroom.v1.SandboxService.TerminateSandbox:input_type -> cleanroom.v1.TerminateSandboxRequest
-	58, // 80: cleanroom.v1.SandboxService.StreamSandboxEvents:input_type -> cleanroom.v1.StreamSandboxEventsRequest
-	7,  // 81: cleanroom.v1.SandboxService.DialSandboxPort:input_type -> cleanroom.v1.SandboxPortFrame
-	60, // 82: cleanroom.v1.SnapshotService.CreateSnapshot:input_type -> cleanroom.v1.CreateSnapshotRequest
-	62, // 83: cleanroom.v1.SnapshotService.GetSnapshot:input_type -> cleanroom.v1.GetSnapshotRequest
-	64, // 84: cleanroom.v1.SnapshotService.ListSnapshots:input_type -> cleanroom.v1.ListSnapshotsRequest
-	66, // 85: cleanroom.v1.SnapshotService.DeleteSnapshot:input_type -> cleanroom.v1.DeleteSnapshotRequest
-	33, // 86: cleanroom.v1.ExecutionService.ListExecutions:input_type -> cleanroom.v1.ListExecutionsRequest
-	70, // 87: cleanroom.v1.ExecutionService.CreateExecution:input_type -> cleanroom.v1.CreateExecutionRequest
-	72, // 88: cleanroom.v1.ExecutionService.AttachExecution:input_type -> cleanroom.v1.AttachExecutionRequest
-	74, // 89: cleanroom.v1.ExecutionService.GetExecution:input_type -> cleanroom.v1.GetExecutionRequest
-	76, // 90: cleanroom.v1.ExecutionService.InspectExecution:input_type -> cleanroom.v1.InspectExecutionRequest
-	78, // 91: cleanroom.v1.ExecutionService.CancelExecution:input_type -> cleanroom.v1.CancelExecutionRequest
-	80, // 92: cleanroom.v1.ExecutionService.WriteExecutionStdin:input_type -> cleanroom.v1.WriteExecutionStdinRequest
-	82, // 93: cleanroom.v1.ExecutionService.CloseExecutionStdin:input_type -> cleanroom.v1.CloseExecutionStdinRequest
-	84, // 94: cleanroom.v1.ExecutionService.StreamExecution:input_type -> cleanroom.v1.StreamExecutionRequest
-	27, // 95: cleanroom.v1.SandboxService.CreateSandbox:output_type -> cleanroom.v1.CreateSandboxResponse
-	28, // 96: cleanroom.v1.SandboxService.CreateSandboxStream:output_type -> cleanroom.v1.CreateSandboxEvent
-	30, // 97: cleanroom.v1.SandboxService.GetSandbox:output_type -> cleanroom.v1.GetSandboxResponse
-	32, // 98: cleanroom.v1.SandboxService.ListSandboxes:output_type -> cleanroom.v1.ListSandboxesResponse
-	36, // 99: cleanroom.v1.SandboxService.DownloadSandboxFile:output_type -> cleanroom.v1.DownloadSandboxFileResponse
-	38, // 100: cleanroom.v1.SandboxService.UploadSandboxFile:output_type -> cleanroom.v1.UploadSandboxFileResponse
-	41, // 101: cleanroom.v1.SandboxService.StatSandboxPath:output_type -> cleanroom.v1.StatSandboxPathResponse
-	43, // 102: cleanroom.v1.SandboxService.WalkSandboxTree:output_type -> cleanroom.v1.WalkSandboxTreeResponse
-	45, // 103: cleanroom.v1.SandboxService.ReadSandboxFile:output_type -> cleanroom.v1.ReadSandboxFileResponse
-	48, // 104: cleanroom.v1.SandboxService.WriteSandboxFile:output_type -> cleanroom.v1.WriteSandboxFileResponse
-	50, // 105: cleanroom.v1.SandboxService.RemoveSandboxPath:output_type -> cleanroom.v1.RemoveSandboxPathResponse
-	52, // 106: cleanroom.v1.SandboxService.ArchiveSandboxPaths:output_type -> cleanroom.v1.ArchiveSandboxPathsResponse
-	55, // 107: cleanroom.v1.SandboxService.ExtractSandboxArchive:output_type -> cleanroom.v1.ExtractSandboxArchiveResponse
-	57, // 108: cleanroom.v1.SandboxService.TerminateSandbox:output_type -> cleanroom.v1.TerminateSandboxResponse
-	59, // 109: cleanroom.v1.SandboxService.StreamSandboxEvents:output_type -> cleanroom.v1.SandboxEvent
-	7,  // 110: cleanroom.v1.SandboxService.DialSandboxPort:output_type -> cleanroom.v1.SandboxPortFrame
-	61, // 111: cleanroom.v1.SnapshotService.CreateSnapshot:output_type -> cleanroom.v1.CreateSnapshotResponse
-	63, // 112: cleanroom.v1.SnapshotService.GetSnapshot:output_type -> cleanroom.v1.GetSnapshotResponse
-	65, // 113: cleanroom.v1.SnapshotService.ListSnapshots:output_type -> cleanroom.v1.ListSnapshotsResponse
-	67, // 114: cleanroom.v1.SnapshotService.DeleteSnapshot:output_type -> cleanroom.v1.DeleteSnapshotResponse
-	34, // 115: cleanroom.v1.ExecutionService.ListExecutions:output_type -> cleanroom.v1.ListExecutionsResponse
-	71, // 116: cleanroom.v1.ExecutionService.CreateExecution:output_type -> cleanroom.v1.CreateExecutionResponse
-	73, // 117: cleanroom.v1.ExecutionService.AttachExecution:output_type -> cleanroom.v1.AttachExecutionResponse
-	75, // 118: cleanroom.v1.ExecutionService.GetExecution:output_type -> cleanroom.v1.GetExecutionResponse
-	77, // 119: cleanroom.v1.ExecutionService.InspectExecution:output_type -> cleanroom.v1.InspectExecutionResponse
-	79, // 120: cleanroom.v1.ExecutionService.CancelExecution:output_type -> cleanroom.v1.CancelExecutionResponse
-	81, // 121: cleanroom.v1.ExecutionService.WriteExecutionStdin:output_type -> cleanroom.v1.WriteExecutionStdinResponse
-	83, // 122: cleanroom.v1.ExecutionService.CloseExecutionStdin:output_type -> cleanroom.v1.CloseExecutionStdinResponse
-	86, // 123: cleanroom.v1.ExecutionService.StreamExecution:output_type -> cleanroom.v1.ExecutionStreamEvent
-	95, // [95:124] is the sub-list for method output_type
-	66, // [66:95] is the sub-list for method input_type
-	66, // [66:66] is the sub-list for extension type_name
-	66, // [66:66] is the sub-list for extension extendee
-	0,  // [0:66] is the sub-list for field type_name
+	89, // 7: cleanroom.v1.SandboxPortFrame.open_result:type_name -> cleanroom.v1.SandboxPortOpenResult
+	92, // 8: cleanroom.v1.Snapshot.created_at:type_name -> google.protobuf.Timestamp
+	24, // 9: cleanroom.v1.Snapshot.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
+	13, // 10: cleanroom.v1.PolicyBlock.inputs:type_name -> cleanroom.v1.PolicyBlockInputs
+	91, // 11: cleanroom.v1.PolicyBlock.env:type_name -> cleanroom.v1.PolicyBlock.EnvEntry
+	14, // 12: cleanroom.v1.PolicyBlock.outputs:type_name -> cleanroom.v1.PolicyBlockOutputs
+	15, // 13: cleanroom.v1.PolicyServices.blocks:type_name -> cleanroom.v1.PolicyBlock
+	15, // 14: cleanroom.v1.PolicyDependencies.blocks:type_name -> cleanroom.v1.PolicyBlock
+	11, // 15: cleanroom.v1.PolicyNetwork.allow:type_name -> cleanroom.v1.PolicyAllowRule
+	19, // 16: cleanroom.v1.PolicyNetworkStages.workspace:type_name -> cleanroom.v1.PolicyNetwork
+	19, // 17: cleanroom.v1.PolicyNetworkStages.dependencies:type_name -> cleanroom.v1.PolicyNetwork
+	19, // 18: cleanroom.v1.PolicyNetworkStages.services:type_name -> cleanroom.v1.PolicyNetwork
+	19, // 19: cleanroom.v1.PolicyNetworkStages.execution:type_name -> cleanroom.v1.PolicyNetwork
+	11, // 20: cleanroom.v1.Policy.allow:type_name -> cleanroom.v1.PolicyAllowRule
+	16, // 21: cleanroom.v1.Policy.services:type_name -> cleanroom.v1.PolicyServices
+	17, // 22: cleanroom.v1.Policy.dependencies:type_name -> cleanroom.v1.PolicyDependencies
+	18, // 23: cleanroom.v1.Policy.run:type_name -> cleanroom.v1.PolicyRun
+	21, // 24: cleanroom.v1.Policy.resources:type_name -> cleanroom.v1.PolicyResources
+	20, // 25: cleanroom.v1.Policy.network_stages:type_name -> cleanroom.v1.PolicyNetworkStages
+	12, // 26: cleanroom.v1.Policy.docker:type_name -> cleanroom.v1.PolicyDocker
+	25, // 27: cleanroom.v1.RepositoryChangeset.files:type_name -> cleanroom.v1.RepositoryChangesetFile
+	23, // 28: cleanroom.v1.CreateSandboxRequest.options:type_name -> cleanroom.v1.SandboxOptions
+	22, // 29: cleanroom.v1.CreateSandboxRequest.policy:type_name -> cleanroom.v1.Policy
+	24, // 30: cleanroom.v1.CreateSandboxRequest.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
+	26, // 31: cleanroom.v1.CreateSandboxRequest.repository_changeset:type_name -> cleanroom.v1.RepositoryChangeset
+	27, // 32: cleanroom.v1.CreateSandboxRequest.repository_commit_bundle:type_name -> cleanroom.v1.RepositoryCommitBundle
+	5,  // 33: cleanroom.v1.CreateSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
+	1,  // 34: cleanroom.v1.CreateSandboxEvent.phase:type_name -> cleanroom.v1.CreateSandboxPhase
+	29, // 35: cleanroom.v1.CreateSandboxEvent.response:type_name -> cleanroom.v1.CreateSandboxResponse
+	92, // 36: cleanroom.v1.CreateSandboxEvent.occurred_at:type_name -> google.protobuf.Timestamp
+	5,  // 37: cleanroom.v1.GetSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
+	5,  // 38: cleanroom.v1.ListSandboxesResponse.sandboxes:type_name -> cleanroom.v1.Sandbox
+	70, // 39: cleanroom.v1.ListExecutionsResponse.executions:type_name -> cleanroom.v1.Execution
+	2,  // 40: cleanroom.v1.SandboxPathInfo.type:type_name -> cleanroom.v1.SandboxPathType
+	92, // 41: cleanroom.v1.SandboxPathInfo.mtime:type_name -> google.protobuf.Timestamp
+	41, // 42: cleanroom.v1.StatSandboxPathResponse.info:type_name -> cleanroom.v1.SandboxPathInfo
+	41, // 43: cleanroom.v1.WalkSandboxTreeResponse.info:type_name -> cleanroom.v1.SandboxPathInfo
+	92, // 44: cleanroom.v1.WriteSandboxFileInit.mtime:type_name -> google.protobuf.Timestamp
+	48, // 45: cleanroom.v1.WriteSandboxFileRequest.init:type_name -> cleanroom.v1.WriteSandboxFileInit
+	55, // 46: cleanroom.v1.ExtractSandboxArchiveRequest.init:type_name -> cleanroom.v1.ExtractSandboxArchiveInit
+	0,  // 47: cleanroom.v1.SandboxEvent.status:type_name -> cleanroom.v1.SandboxStatus
+	92, // 48: cleanroom.v1.SandboxEvent.occurred_at:type_name -> google.protobuf.Timestamp
+	10, // 49: cleanroom.v1.CreateSnapshotResponse.snapshot:type_name -> cleanroom.v1.Snapshot
+	10, // 50: cleanroom.v1.GetSnapshotResponse.snapshot:type_name -> cleanroom.v1.Snapshot
+	10, // 51: cleanroom.v1.ListSnapshotsResponse.snapshots:type_name -> cleanroom.v1.Snapshot
+	3,  // 52: cleanroom.v1.Execution.status:type_name -> cleanroom.v1.ExecutionStatus
+	92, // 53: cleanroom.v1.Execution.started_at:type_name -> google.protobuf.Timestamp
+	92, // 54: cleanroom.v1.Execution.finished_at:type_name -> google.protobuf.Timestamp
+	4,  // 55: cleanroom.v1.Execution.kind:type_name -> cleanroom.v1.ExecutionKind
+	71, // 56: cleanroom.v1.CreateExecutionRequest.options:type_name -> cleanroom.v1.ExecutionOptions
+	4,  // 57: cleanroom.v1.CreateExecutionRequest.kind:type_name -> cleanroom.v1.ExecutionKind
+	24, // 58: cleanroom.v1.CreateExecutionRequest.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
+	70, // 59: cleanroom.v1.CreateExecutionResponse.execution:type_name -> cleanroom.v1.Execution
+	92, // 60: cleanroom.v1.AttachExecutionResponse.expires_at:type_name -> google.protobuf.Timestamp
+	70, // 61: cleanroom.v1.GetExecutionResponse.execution:type_name -> cleanroom.v1.Execution
+	70, // 62: cleanroom.v1.InspectExecutionResponse.execution:type_name -> cleanroom.v1.Execution
+	93, // 63: cleanroom.v1.InspectExecutionResponse.observability:type_name -> google.protobuf.Struct
+	3,  // 64: cleanroom.v1.CancelExecutionResponse.status:type_name -> cleanroom.v1.ExecutionStatus
+	3,  // 65: cleanroom.v1.ExecutionExit.status:type_name -> cleanroom.v1.ExecutionStatus
+	3,  // 66: cleanroom.v1.ExecutionStreamEvent.status:type_name -> cleanroom.v1.ExecutionStatus
+	87, // 67: cleanroom.v1.ExecutionStreamEvent.exit:type_name -> cleanroom.v1.ExecutionExit
+	92, // 68: cleanroom.v1.ExecutionStreamEvent.occurred_at:type_name -> google.protobuf.Timestamp
+	28, // 69: cleanroom.v1.SandboxService.CreateSandbox:input_type -> cleanroom.v1.CreateSandboxRequest
+	28, // 70: cleanroom.v1.SandboxService.CreateSandboxStream:input_type -> cleanroom.v1.CreateSandboxRequest
+	31, // 71: cleanroom.v1.SandboxService.GetSandbox:input_type -> cleanroom.v1.GetSandboxRequest
+	33, // 72: cleanroom.v1.SandboxService.ListSandboxes:input_type -> cleanroom.v1.ListSandboxesRequest
+	37, // 73: cleanroom.v1.SandboxService.DownloadSandboxFile:input_type -> cleanroom.v1.DownloadSandboxFileRequest
+	39, // 74: cleanroom.v1.SandboxService.UploadSandboxFile:input_type -> cleanroom.v1.UploadSandboxFileRequest
+	42, // 75: cleanroom.v1.SandboxService.StatSandboxPath:input_type -> cleanroom.v1.StatSandboxPathRequest
+	44, // 76: cleanroom.v1.SandboxService.WalkSandboxTree:input_type -> cleanroom.v1.WalkSandboxTreeRequest
+	46, // 77: cleanroom.v1.SandboxService.ReadSandboxFile:input_type -> cleanroom.v1.ReadSandboxFileRequest
+	49, // 78: cleanroom.v1.SandboxService.WriteSandboxFile:input_type -> cleanroom.v1.WriteSandboxFileRequest
+	51, // 79: cleanroom.v1.SandboxService.RemoveSandboxPath:input_type -> cleanroom.v1.RemoveSandboxPathRequest
+	53, // 80: cleanroom.v1.SandboxService.ArchiveSandboxPaths:input_type -> cleanroom.v1.ArchiveSandboxPathsRequest
+	56, // 81: cleanroom.v1.SandboxService.ExtractSandboxArchive:input_type -> cleanroom.v1.ExtractSandboxArchiveRequest
+	58, // 82: cleanroom.v1.SandboxService.TerminateSandbox:input_type -> cleanroom.v1.TerminateSandboxRequest
+	60, // 83: cleanroom.v1.SandboxService.StreamSandboxEvents:input_type -> cleanroom.v1.StreamSandboxEventsRequest
+	7,  // 84: cleanroom.v1.SandboxService.DialSandboxPort:input_type -> cleanroom.v1.SandboxPortFrame
+	62, // 85: cleanroom.v1.SnapshotService.CreateSnapshot:input_type -> cleanroom.v1.CreateSnapshotRequest
+	64, // 86: cleanroom.v1.SnapshotService.GetSnapshot:input_type -> cleanroom.v1.GetSnapshotRequest
+	66, // 87: cleanroom.v1.SnapshotService.ListSnapshots:input_type -> cleanroom.v1.ListSnapshotsRequest
+	68, // 88: cleanroom.v1.SnapshotService.DeleteSnapshot:input_type -> cleanroom.v1.DeleteSnapshotRequest
+	35, // 89: cleanroom.v1.ExecutionService.ListExecutions:input_type -> cleanroom.v1.ListExecutionsRequest
+	72, // 90: cleanroom.v1.ExecutionService.CreateExecution:input_type -> cleanroom.v1.CreateExecutionRequest
+	74, // 91: cleanroom.v1.ExecutionService.AttachExecution:input_type -> cleanroom.v1.AttachExecutionRequest
+	76, // 92: cleanroom.v1.ExecutionService.GetExecution:input_type -> cleanroom.v1.GetExecutionRequest
+	78, // 93: cleanroom.v1.ExecutionService.InspectExecution:input_type -> cleanroom.v1.InspectExecutionRequest
+	80, // 94: cleanroom.v1.ExecutionService.CancelExecution:input_type -> cleanroom.v1.CancelExecutionRequest
+	82, // 95: cleanroom.v1.ExecutionService.WriteExecutionStdin:input_type -> cleanroom.v1.WriteExecutionStdinRequest
+	84, // 96: cleanroom.v1.ExecutionService.CloseExecutionStdin:input_type -> cleanroom.v1.CloseExecutionStdinRequest
+	86, // 97: cleanroom.v1.ExecutionService.StreamExecution:input_type -> cleanroom.v1.StreamExecutionRequest
+	29, // 98: cleanroom.v1.SandboxService.CreateSandbox:output_type -> cleanroom.v1.CreateSandboxResponse
+	30, // 99: cleanroom.v1.SandboxService.CreateSandboxStream:output_type -> cleanroom.v1.CreateSandboxEvent
+	32, // 100: cleanroom.v1.SandboxService.GetSandbox:output_type -> cleanroom.v1.GetSandboxResponse
+	34, // 101: cleanroom.v1.SandboxService.ListSandboxes:output_type -> cleanroom.v1.ListSandboxesResponse
+	38, // 102: cleanroom.v1.SandboxService.DownloadSandboxFile:output_type -> cleanroom.v1.DownloadSandboxFileResponse
+	40, // 103: cleanroom.v1.SandboxService.UploadSandboxFile:output_type -> cleanroom.v1.UploadSandboxFileResponse
+	43, // 104: cleanroom.v1.SandboxService.StatSandboxPath:output_type -> cleanroom.v1.StatSandboxPathResponse
+	45, // 105: cleanroom.v1.SandboxService.WalkSandboxTree:output_type -> cleanroom.v1.WalkSandboxTreeResponse
+	47, // 106: cleanroom.v1.SandboxService.ReadSandboxFile:output_type -> cleanroom.v1.ReadSandboxFileResponse
+	50, // 107: cleanroom.v1.SandboxService.WriteSandboxFile:output_type -> cleanroom.v1.WriteSandboxFileResponse
+	52, // 108: cleanroom.v1.SandboxService.RemoveSandboxPath:output_type -> cleanroom.v1.RemoveSandboxPathResponse
+	54, // 109: cleanroom.v1.SandboxService.ArchiveSandboxPaths:output_type -> cleanroom.v1.ArchiveSandboxPathsResponse
+	57, // 110: cleanroom.v1.SandboxService.ExtractSandboxArchive:output_type -> cleanroom.v1.ExtractSandboxArchiveResponse
+	59, // 111: cleanroom.v1.SandboxService.TerminateSandbox:output_type -> cleanroom.v1.TerminateSandboxResponse
+	61, // 112: cleanroom.v1.SandboxService.StreamSandboxEvents:output_type -> cleanroom.v1.SandboxEvent
+	7,  // 113: cleanroom.v1.SandboxService.DialSandboxPort:output_type -> cleanroom.v1.SandboxPortFrame
+	63, // 114: cleanroom.v1.SnapshotService.CreateSnapshot:output_type -> cleanroom.v1.CreateSnapshotResponse
+	65, // 115: cleanroom.v1.SnapshotService.GetSnapshot:output_type -> cleanroom.v1.GetSnapshotResponse
+	67, // 116: cleanroom.v1.SnapshotService.ListSnapshots:output_type -> cleanroom.v1.ListSnapshotsResponse
+	69, // 117: cleanroom.v1.SnapshotService.DeleteSnapshot:output_type -> cleanroom.v1.DeleteSnapshotResponse
+	36, // 118: cleanroom.v1.ExecutionService.ListExecutions:output_type -> cleanroom.v1.ListExecutionsResponse
+	73, // 119: cleanroom.v1.ExecutionService.CreateExecution:output_type -> cleanroom.v1.CreateExecutionResponse
+	75, // 120: cleanroom.v1.ExecutionService.AttachExecution:output_type -> cleanroom.v1.AttachExecutionResponse
+	77, // 121: cleanroom.v1.ExecutionService.GetExecution:output_type -> cleanroom.v1.GetExecutionResponse
+	79, // 122: cleanroom.v1.ExecutionService.InspectExecution:output_type -> cleanroom.v1.InspectExecutionResponse
+	81, // 123: cleanroom.v1.ExecutionService.CancelExecution:output_type -> cleanroom.v1.CancelExecutionResponse
+	83, // 124: cleanroom.v1.ExecutionService.WriteExecutionStdin:output_type -> cleanroom.v1.WriteExecutionStdinResponse
+	85, // 125: cleanroom.v1.ExecutionService.CloseExecutionStdin:output_type -> cleanroom.v1.CloseExecutionStdinResponse
+	88, // 126: cleanroom.v1.ExecutionService.StreamExecution:output_type -> cleanroom.v1.ExecutionStreamEvent
+	98, // [98:127] is the sub-list for method output_type
+	69, // [69:98] is the sub-list for method input_type
+	69, // [69:69] is the sub-list for extension type_name
+	69, // [69:69] is the sub-list for extension extendee
+	0,  // [0:69] is the sub-list for field type_name
 }
 
 func init() { file_proto_cleanroom_v1_control_proto_init() }
@@ -6433,25 +6561,25 @@ func file_proto_cleanroom_v1_control_proto_init() {
 		(*SandboxPortFrame_CloseWrite)(nil),
 		(*SandboxPortFrame_OpenResult)(nil),
 	}
-	file_proto_cleanroom_v1_control_proto_msgTypes[21].OneofWrappers = []any{
+	file_proto_cleanroom_v1_control_proto_msgTypes[23].OneofWrappers = []any{
 		(*CreateSandboxRequest_SnapshotId)(nil),
 	}
-	file_proto_cleanroom_v1_control_proto_msgTypes[23].OneofWrappers = []any{
+	file_proto_cleanroom_v1_control_proto_msgTypes[25].OneofWrappers = []any{
 		(*CreateSandboxEvent_Message)(nil),
 		(*CreateSandboxEvent_Stdout)(nil),
 		(*CreateSandboxEvent_Stderr)(nil),
 		(*CreateSandboxEvent_Warning)(nil),
 		(*CreateSandboxEvent_Response)(nil),
 	}
-	file_proto_cleanroom_v1_control_proto_msgTypes[42].OneofWrappers = []any{
+	file_proto_cleanroom_v1_control_proto_msgTypes[44].OneofWrappers = []any{
 		(*WriteSandboxFileRequest_Init)(nil),
 		(*WriteSandboxFileRequest_Data)(nil),
 	}
-	file_proto_cleanroom_v1_control_proto_msgTypes[49].OneofWrappers = []any{
+	file_proto_cleanroom_v1_control_proto_msgTypes[51].OneofWrappers = []any{
 		(*ExtractSandboxArchiveRequest_Init)(nil),
 		(*ExtractSandboxArchiveRequest_Data)(nil),
 	}
-	file_proto_cleanroom_v1_control_proto_msgTypes[81].OneofWrappers = []any{
+	file_proto_cleanroom_v1_control_proto_msgTypes[83].OneofWrappers = []any{
 		(*ExecutionStreamEvent_Stdout)(nil),
 		(*ExecutionStreamEvent_Stderr)(nil),
 		(*ExecutionStreamEvent_Exit)(nil),
@@ -6464,7 +6592,7 @@ func file_proto_cleanroom_v1_control_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proto_cleanroom_v1_control_proto_rawDesc), len(file_proto_cleanroom_v1_control_proto_rawDesc)),
 			NumEnums:      5,
-			NumMessages:   84,
+			NumMessages:   87,
 			NumExtensions: 0,
 			NumServices:   3,
 		},

--- a/internal/inputmanifest/inputmanifest.go
+++ b/internal/inputmanifest/inputmanifest.go
@@ -1,0 +1,183 @@
+package inputmanifest
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+type Entry struct {
+	Path          string `json:"path"`
+	Type          string `json:"type,omitempty"`
+	Mode          uint32 `json:"mode,omitempty"`
+	SHA256        string `json:"sha256,omitempty"`
+	SymlinkTarget string `json:"symlink_target,omitempty"`
+	Deleted       bool   `json:"deleted,omitempty"`
+}
+
+type Manifest struct {
+	Entries []Entry `json:"entries"`
+}
+
+func Build(root string, inputs []string) (Manifest, error) {
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return Manifest{}, fmt.Errorf("input manifest root is empty")
+	}
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return Manifest{}, fmt.Errorf("resolve input manifest root: %w", err)
+	}
+
+	seen := make(map[string]struct{})
+	var paths []string
+	for _, input := range inputs {
+		normalized, err := normalizeInputPath(input)
+		if err != nil {
+			return Manifest{}, err
+		}
+		matches, err := expandInput(absRoot, normalized)
+		if err != nil {
+			return Manifest{}, err
+		}
+		for _, match := range matches {
+			if _, ok := seen[match]; ok {
+				continue
+			}
+			seen[match] = struct{}{}
+			paths = append(paths, match)
+		}
+	}
+	sort.Strings(paths)
+
+	entries := make([]Entry, 0, len(paths))
+	for _, rel := range paths {
+		entry, err := entryForPath(absRoot, rel)
+		if err != nil {
+			return Manifest{}, err
+		}
+		entries = append(entries, entry)
+	}
+	return Manifest{Entries: entries}, nil
+}
+
+func Digest(root string, inputs []string) (string, Manifest, error) {
+	manifest, err := Build(root, inputs)
+	if err != nil {
+		return "", Manifest{}, err
+	}
+	payload, err := json.Marshal(manifest.Entries)
+	if err != nil {
+		return "", Manifest{}, fmt.Errorf("marshal input manifest: %w", err)
+	}
+	sum := sha256.Sum256(payload)
+	return "sha256:" + hex.EncodeToString(sum[:]), manifest, nil
+}
+
+func normalizeInputPath(input string) (string, error) {
+	trimmed := strings.TrimSpace(input)
+	if trimmed == "" {
+		return "", fmt.Errorf("input path cannot be empty")
+	}
+	if strings.HasPrefix(trimmed, "/") {
+		return "", fmt.Errorf("input path %q must be relative", input)
+	}
+	normalized := path.Clean(strings.ReplaceAll(trimmed, "\\", "/"))
+	if normalized == "." || normalized == ".." || strings.HasPrefix(normalized, "../") {
+		return "", fmt.Errorf("input path %q must stay within the repository root", input)
+	}
+	return normalized, nil
+}
+
+func expandInput(root, input string) ([]string, error) {
+	if !hasGlob(input) {
+		if _, err := os.Lstat(filepath.Join(root, filepath.FromSlash(input))); err != nil {
+			if os.IsNotExist(err) {
+				return nil, fmt.Errorf("input path %q does not exist", input)
+			}
+			return nil, fmt.Errorf("stat input path %q: %w", input, err)
+		}
+		return []string{input}, nil
+	}
+
+	pattern := filepath.Join(root, filepath.FromSlash(input))
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("invalid input glob %q: %w", input, err)
+	}
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("input glob %q matched no files", input)
+	}
+	relMatches := make([]string, 0, len(matches))
+	for _, match := range matches {
+		rel, err := filepath.Rel(root, match)
+		if err != nil {
+			return nil, fmt.Errorf("resolve input glob match %q: %w", match, err)
+		}
+		normalized := path.Clean(filepath.ToSlash(rel))
+		if normalized == "." || normalized == ".." || strings.HasPrefix(normalized, "../") {
+			return nil, fmt.Errorf("input glob %q matched path outside root", input)
+		}
+		relMatches = append(relMatches, normalized)
+	}
+	sort.Strings(relMatches)
+	return relMatches, nil
+}
+
+func hasGlob(value string) bool {
+	return strings.ContainsAny(value, "*?[")
+}
+
+func entryForPath(root, rel string) (Entry, error) {
+	fullPath := filepath.Join(root, filepath.FromSlash(rel))
+	info, err := os.Lstat(fullPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return Entry{}, fmt.Errorf("input path %q does not exist", rel)
+		}
+		return Entry{}, fmt.Errorf("stat input path %q: %w", rel, err)
+	}
+
+	entry := Entry{
+		Path: rel,
+		Mode: uint32(info.Mode().Perm()),
+	}
+	mode := info.Mode()
+	switch {
+	case mode.Type() == 0:
+		entry.Type = "file"
+		digest, err := fileDigest(fullPath)
+		if err != nil {
+			return Entry{}, err
+		}
+		entry.SHA256 = digest
+	case mode.IsDir():
+		return Entry{}, fmt.Errorf("input path %q is a directory; inputs.files must name regular files", rel)
+	case mode&os.ModeSymlink != 0:
+		return Entry{}, fmt.Errorf("input path %q is a symlink; inputs.files must name regular files", rel)
+	default:
+		return Entry{}, fmt.Errorf("input path %q is not a regular file", rel)
+	}
+	return entry, nil
+}
+
+func fileDigest(filePath string) (string, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return "", fmt.Errorf("open input file %q: %w", filePath, err)
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", fmt.Errorf("hash input file %q: %w", filePath, err)
+	}
+	return "sha256:" + hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/internal/inputmanifest/inputmanifest_test.go
+++ b/internal/inputmanifest/inputmanifest_test.go
@@ -1,0 +1,128 @@
+package inputmanifest
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDigestIsDeterministicAcrossInputAndGlobOrder(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "a.lock"), "a")
+	writeFile(t, filepath.Join(root, "b.lock"), "b")
+
+	first, firstManifest, err := Digest(root, []string{"b.lock", "*.lock"})
+	if err != nil {
+		t.Fatalf("Digest returned error: %v", err)
+	}
+	second, secondManifest, err := Digest(root, []string{"*.lock", "a.lock"})
+	if err != nil {
+		t.Fatalf("Digest returned error: %v", err)
+	}
+	if first != second {
+		t.Fatalf("digest changed across equivalent inputs: got %q want %q", second, first)
+	}
+	if got, want := len(firstManifest.Entries), 2; got != want {
+		t.Fatalf("unexpected first manifest entry count: got %d want %d", got, want)
+	}
+	if got, want := len(secondManifest.Entries), 2; got != want {
+		t.Fatalf("unexpected second manifest entry count: got %d want %d", got, want)
+	}
+	if got, want := firstManifest.Entries[0].Path, "a.lock"; got != want {
+		t.Fatalf("entries are not sorted: got first path %q want %q", got, want)
+	}
+}
+
+func TestDigestChangesWhenFileContentChanges(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	path := filepath.Join(root, "go.sum")
+	writeFile(t, path, "before")
+
+	before, _, err := Digest(root, []string{"go.sum"})
+	if err != nil {
+		t.Fatalf("Digest returned error: %v", err)
+	}
+	writeFile(t, path, "after")
+	after, _, err := Digest(root, []string{"go.sum"})
+	if err != nil {
+		t.Fatalf("Digest returned error: %v", err)
+	}
+	if before == after {
+		t.Fatalf("digest did not change after file content mutation: %q", before)
+	}
+}
+
+func TestBuildRejectsNonRegularInputs(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, "locks"), 0o755); err != nil {
+		t.Fatalf("Mkdir returned error: %v", err)
+	}
+	if err := os.Symlink("real.lock", filepath.Join(root, "link.lock")); err != nil {
+		t.Fatalf("Symlink returned error: %v", err)
+	}
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "directory", input: "locks", want: "is a directory"},
+		{name: "symlink", input: "link.lock", want: "is a symlink"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := Build(root, []string{tc.input})
+			if err == nil {
+				t.Fatal("expected Build to reject non-regular input")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected error containing %q, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+func TestBuildRejectsMissingLiteralAndEmptyGlob(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "missing literal", input: "go.sum", want: "does not exist"},
+		{name: "empty glob", input: "*.lock", want: "matched no files"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := Build(root, []string{tc.input})
+			if err == nil {
+				t.Fatal("expected Build to fail")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected error containing %q, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s) returned error: %v", path, err)
+	}
+}

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -38,11 +38,12 @@ type rawPolicy struct {
 		Image struct {
 			Ref string `yaml:"ref"`
 		} `yaml:"image"`
-		Dependencies rawDependenciesConfig `yaml:"dependencies"`
-		Run          rawRunConfig          `yaml:"run"`
-		Services     rawServices           `yaml:"services"`
-		Resources    rawResources          `yaml:"resources"`
-		Network      rawSandboxNetwork     `yaml:"network"`
+		Docker       rawDockerConfig   `yaml:"docker"`
+		Dependencies rawPolicyBlocks   `yaml:"dependencies"`
+		Run          rawRunConfig      `yaml:"run"`
+		Services     rawPolicyBlocks   `yaml:"services"`
+		Resources    rawResources      `yaml:"resources"`
+		Network      rawSandboxNetwork `yaml:"network"`
 	} `yaml:"sandbox"`
 }
 
@@ -55,35 +56,35 @@ type rawRepository struct {
 	Network    *rawStageNetworkConfig `yaml:"network"`
 }
 
-type rawDependencyKey struct {
-	Files []string `yaml:"files"`
-}
-
-type rawDependenciesConfig struct {
-	Command rawDependencyCommandSpec `yaml:"command"`
-	Key     rawDependencyKey         `yaml:"key"`
-	Reuse   string                   `yaml:"reuse"`
-	Network *rawStageNetworkConfig   `yaml:"network"`
-}
-
 type rawDependencyCommandSpec []string
 
 type rawRunConfig struct {
-	Before  rawShellCommandSpec    `yaml:"before"`
-	Network *rawStageNetworkConfig `yaml:"network"`
+	Before rawShellCommandSpec `yaml:"before"`
 }
 
 type rawShellCommandSpec []string
 
-type rawServices struct {
-	Docker  rawDockerService         `yaml:"docker"`
-	Command rawDependencyCommandSpec `yaml:"command"`
-	Key     rawDependencyKey         `yaml:"key"`
-	Network *rawStageNetworkConfig   `yaml:"network"`
+type rawDockerConfig struct {
+	Required bool `yaml:"required"`
 }
 
-type rawDockerService struct {
-	Required bool `yaml:"required"`
+type rawPolicyBlocks []rawPolicyBlock
+
+type rawPolicyBlock struct {
+	Name    string                   `yaml:"name"`
+	Command rawDependencyCommandSpec `yaml:"command"`
+	Inputs  rawPolicyBlockInputs     `yaml:"inputs"`
+	Env     map[string]string        `yaml:"env"`
+	Outputs rawPolicyBlockOutputs    `yaml:"outputs"`
+}
+
+type rawPolicyBlockInputs struct {
+	Files []string `yaml:"files"`
+}
+
+type rawPolicyBlockOutputs struct {
+	Dirs  []string `yaml:"dirs"`
+	Files []string `yaml:"files"`
 }
 
 type rawResources struct {
@@ -93,8 +94,11 @@ type rawResources struct {
 }
 
 type rawSandboxNetwork struct {
-	Default string        `yaml:"default"`
-	Allow   rawAllowRules `yaml:"allow"`
+	Default      string                 `yaml:"default"`
+	Allow        rawAllowRules          `yaml:"allow"`
+	Dependencies *rawStageNetworkConfig `yaml:"dependencies"`
+	Services     *rawStageNetworkConfig `yaml:"services"`
+	Execution    *rawStageNetworkConfig `yaml:"execution"`
 }
 
 type rawStageNetworkConfig struct {
@@ -112,6 +116,7 @@ type CompiledPolicy struct {
 	Version        int                   `json:"version"`
 	ImageRef       string                `json:"image_ref"`
 	ImageDigest    string                `json:"image_digest"`
+	Docker         DockerService         `json:"docker"`
 	Services       Services              `json:"services"`
 	NetworkDefault string                `json:"network_default"`
 	Allow          []AllowRule           `json:"allow"`
@@ -131,15 +136,16 @@ type RepositoryConfig struct {
 }
 
 type Services struct {
-	Docker   DockerService `json:"docker"`
-	Command  []string      `json:"command,omitempty"`
-	KeyFiles []string      `json:"key_files,omitempty"`
+	Blocks   []StageBlock `json:"blocks,omitempty"`
+	Command  []string     `json:"-"`
+	KeyFiles []string     `json:"-"`
 }
 
 type Dependencies struct {
-	Command  []string `json:"command,omitempty"`
-	KeyFiles []string `json:"key_files,omitempty"`
-	Reuse    string   `json:"reuse,omitempty"`
+	Blocks   []StageBlock `json:"blocks,omitempty"`
+	Command  []string     `json:"-"`
+	KeyFiles []string     `json:"-"`
+	Reuse    string       `json:"-"`
 }
 
 type Run struct {
@@ -172,6 +178,23 @@ type NetworkStagePolicies struct {
 
 type DockerService struct {
 	Required bool `json:"required"`
+}
+
+type StageBlock struct {
+	Name    string            `json:"name"`
+	Command []string          `json:"command"`
+	Inputs  StageBlockInputs  `json:"inputs"`
+	Env     map[string]string `json:"env,omitempty"`
+	Outputs StageBlockOutputs `json:"outputs"`
+}
+
+type StageBlockInputs struct {
+	Files []string `json:"files,omitempty"`
+}
+
+type StageBlockOutputs struct {
+	Dirs  []string `json:"dirs,omitempty"`
+	Files []string `json:"files,omitempty"`
 }
 
 type Resources struct {
@@ -242,15 +265,15 @@ func normalizeRawNetworkStages(raw rawPolicy) (*NetworkStagePolicies, error) {
 			return nil, err
 		}
 	}
-	out.Dependencies, err = normalizeRawStageNetwork(raw.Sandbox.Dependencies.Network)
+	out.Dependencies, err = normalizeRawStageNetwork(raw.Sandbox.Network.Dependencies)
 	if err != nil {
 		return nil, err
 	}
-	out.Services, err = normalizeRawStageNetwork(raw.Sandbox.Services.Network)
+	out.Services, err = normalizeRawStageNetwork(raw.Sandbox.Network.Services)
 	if err != nil {
 		return nil, err
 	}
-	out.Execution, err = normalizeRawStageNetwork(raw.Sandbox.Run.Network)
+	out.Execution, err = normalizeRawStageNetwork(raw.Sandbox.Network.Execution)
 	if err != nil {
 		return nil, err
 	}
@@ -349,12 +372,16 @@ func Compile(raw rawPolicy) (*CompiledPolicy, error) {
 		return nil, errors.New("sandbox.network.allow cannot be combined with stage-local network blocks")
 	}
 
+	docker := normalizeDocker(raw.Sandbox.Docker)
 	dependencies, err := normalizeDependencies(raw.Sandbox.Dependencies)
 	if err != nil {
 		return nil, err
 	}
 	services, err := normalizeServices(raw.Sandbox.Services)
 	if err != nil {
+		return nil, err
+	}
+	if err := validatePolicyOutputRelationships(dependencies.Blocks, services.Blocks); err != nil {
 		return nil, err
 	}
 	run, err := normalizeRun(raw.Sandbox.Run)
@@ -370,6 +397,7 @@ func Compile(raw rawPolicy) (*CompiledPolicy, error) {
 		Version:        raw.Version,
 		ImageRef:       parsedRef.Original,
 		ImageDigest:    parsedRef.Digest(),
+		Docker:         docker,
 		Services:       services,
 		NetworkDefault: networkDefault,
 		Allow:          allow,
@@ -512,15 +540,15 @@ func (p *CompiledPolicy) RequiresDockerService() bool {
 	if p == nil {
 		return false
 	}
-	return p.Services.Docker.Required
+	return p.Docker.Required
 }
 
 func (s Services) BootstrapEnabled() bool {
-	return len(s.Command) > 0
+	return len(s.Blocks) > 0 || len(s.Command) > 0
 }
 
 func (d Dependencies) Enabled() bool {
-	return len(d.Command) > 0
+	return len(d.Blocks) > 0 || len(d.Command) > 0
 }
 
 const (
@@ -798,24 +826,16 @@ func (p *CompiledPolicy) ToProto() *cleanroomv1.Policy {
 		Version:     int32(p.Version),
 		ImageRef:    p.ImageRef,
 		ImageDigest: p.ImageDigest,
-		Services: &cleanroomv1.PolicyServices{
-			Docker: &cleanroomv1.PolicyDockerService{
-				Required: p.Services.Docker.Required,
-			},
-			Command: append([]string(nil), p.Services.Command...),
-			Key: &cleanroomv1.PolicyDependencyKey{
-				Files: append([]string(nil), p.Services.KeyFiles...),
-			},
+		Docker: &cleanroomv1.PolicyDocker{
+			Required: p.Docker.Required,
 		},
+		Services:       &cleanroomv1.PolicyServices{Blocks: stageBlocksToProto(p.Services.Blocks)},
 		NetworkDefault: p.NetworkDefault,
 		Allow:          allowRulesToProto(p.Allow),
 		NetworkStages:  networkStagesToProto(p.NetworkStages),
 		Dependencies: &cleanroomv1.PolicyDependencies{
-			Command: append([]string(nil), p.Dependencies.Command...),
-			Key: &cleanroomv1.PolicyDependencyKey{
-				Files: append([]string(nil), p.Dependencies.KeyFiles...),
-			},
-			Reuse: p.Dependencies.Reuse,
+			Reuse:  p.Dependencies.Reuse,
+			Blocks: stageBlocksToProto(p.Dependencies.Blocks),
 		},
 		Run: &cleanroomv1.PolicyRun{
 			Before: append([]string(nil), p.Run.Before...),
@@ -984,12 +1004,16 @@ func FromProto(pb *cleanroomv1.Policy) (*CompiledPolicy, error) {
 		return nil, errors.New("policy network_default must be deny when stage-local network blocks are configured")
 	}
 
+	docker := DockerService{Required: pb.GetDocker().GetRequired()}
 	dependencies, err := dependenciesFromProto(pb.GetDependencies())
 	if err != nil {
 		return nil, err
 	}
 	services, err := servicesFromProto(pb.GetServices())
 	if err != nil {
+		return nil, err
+	}
+	if err := validatePolicyOutputRelationships(dependencies.Blocks, services.Blocks); err != nil {
 		return nil, err
 	}
 	run, err := runFromProto(pb.GetRun())
@@ -1005,6 +1029,7 @@ func FromProto(pb *cleanroomv1.Policy) (*CompiledPolicy, error) {
 		Version:        int(pb.GetVersion()),
 		ImageRef:       parsedRef.Original,
 		ImageDigest:    parsedRef.Digest(),
+		Docker:         docker,
 		Services:       services,
 		NetworkDefault: networkDefault,
 		Allow:          allow,
@@ -1026,35 +1051,20 @@ func FromProto(pb *cleanroomv1.Policy) (*CompiledPolicy, error) {
 	return compiled, nil
 }
 
-func normalizeDependencies(raw rawDependenciesConfig) (Dependencies, error) {
-	command, err := normalizeBootstrapCommand(raw.Command, "sandbox.dependencies.command")
+func normalizeDocker(raw rawDockerConfig) DockerService {
+	return DockerService{Required: raw.Required}
+}
+
+func normalizeDependencies(raw rawPolicyBlocks) (Dependencies, error) {
+	blocks, err := normalizeStageBlocks(raw, "sandbox.dependencies")
 	if err != nil {
 		return Dependencies{}, err
 	}
-	keyFiles, err := normalizeBootstrapKeyFiles(raw.Key.Files, "sandbox.dependencies.key.files")
-	if err != nil {
-		return Dependencies{}, err
-	}
-	reuse, err := normalizeDependencyReuse(raw.Reuse, "sandbox.dependencies.reuse")
-	if err != nil {
-		return Dependencies{}, err
-	}
-	if len(command) == 0 {
-		if len(keyFiles) > 0 {
-			return Dependencies{}, errors.New("sandbox.dependencies.key.files requires sandbox.dependencies.command")
-		}
-		if reuse != "" {
-			return Dependencies{}, errors.New("sandbox.dependencies.reuse requires sandbox.dependencies.command")
-		}
-		return Dependencies{}, nil
-	}
-	if reuse == DependencyReusePortable && len(keyFiles) == 0 {
-		return Dependencies{}, errors.New("sandbox.dependencies.reuse=portable requires sandbox.dependencies.key.files")
-	}
+	command := combinedStageBlockCommand(blocks)
 	return Dependencies{
+		Blocks:   blocks,
 		Command:  command,
-		KeyFiles: keyFiles,
-		Reuse:    reuse,
+		KeyFiles: combinedStageBlockInputFiles(blocks),
 	}, nil
 }
 
@@ -1062,55 +1072,47 @@ func dependenciesFromProto(pb *cleanroomv1.PolicyDependencies) (Dependencies, er
 	if pb == nil {
 		return Dependencies{}, nil
 	}
-	command, err := normalizeBootstrapCommand(pb.GetCommand(), "policy dependencies.command")
+	blocks, err := stageBlocksFromProto(pb.GetBlocks(), "policy dependencies")
 	if err != nil {
 		return Dependencies{}, err
 	}
-	keyFiles, err := normalizeBootstrapKeyFiles(pb.GetKey().GetFiles(), "policy dependencies.key.files")
+	keyFiles := combinedStageBlockInputFiles(blocks)
+	reuse, err := normalizeDependencyReuse(pb.GetReuse(), keyFiles, "policy dependencies.reuse")
 	if err != nil {
 		return Dependencies{}, err
-	}
-	reuse, err := normalizeDependencyReuse(pb.GetReuse(), "policy dependencies.reuse")
-	if err != nil {
-		return Dependencies{}, err
-	}
-	if len(command) == 0 {
-		if len(keyFiles) > 0 {
-			return Dependencies{}, errors.New("policy dependencies.key.files requires dependencies.command")
-		}
-		if reuse != "" {
-			return Dependencies{}, errors.New("policy dependencies.reuse requires dependencies.command")
-		}
-		return Dependencies{}, nil
-	}
-	if reuse == DependencyReusePortable && len(keyFiles) == 0 {
-		return Dependencies{}, errors.New("policy dependencies.reuse=portable requires dependencies.key.files")
 	}
 	return Dependencies{
-		Command:  command,
+		Blocks:   blocks,
+		Command:  combinedStageBlockCommand(blocks),
 		KeyFiles: keyFiles,
 		Reuse:    reuse,
 	}, nil
 }
 
-func normalizeServices(raw rawServices) (Services, error) {
-	command, err := normalizeBootstrapCommand(raw.Command, "sandbox.services.command")
+func normalizeDependencyReuse(raw string, keyFiles []string, field string) (string, error) {
+	reuse := strings.TrimSpace(strings.ToLower(raw))
+	switch reuse {
+	case "", DependencyReuseExact:
+		return "", nil
+	case DependencyReusePortable:
+		if len(keyFiles) == 0 {
+			return "", fmt.Errorf("%s=portable requires key files", field)
+		}
+		return reuse, nil
+	default:
+		return "", fmt.Errorf("unsupported %s %q: expected %q", field, raw, DependencyReusePortable)
+	}
+}
+
+func normalizeServices(raw rawPolicyBlocks) (Services, error) {
+	blocks, err := normalizeStageBlocks(raw, "sandbox.services")
 	if err != nil {
 		return Services{}, err
-	}
-	keyFiles, err := normalizeBootstrapKeyFiles(raw.Key.Files, "sandbox.services.key.files")
-	if err != nil {
-		return Services{}, err
-	}
-	if len(command) == 0 && len(keyFiles) > 0 {
-		return Services{}, errors.New("sandbox.services.key.files requires sandbox.services.command")
 	}
 	return Services{
-		Docker: DockerService{
-			Required: raw.Docker.Required,
-		},
-		Command:  command,
-		KeyFiles: keyFiles,
+		Blocks:   blocks,
+		Command:  combinedStageBlockCommand(blocks),
+		KeyFiles: combinedStageBlockInputFiles(blocks),
 	}, nil
 }
 
@@ -1118,23 +1120,14 @@ func servicesFromProto(pb *cleanroomv1.PolicyServices) (Services, error) {
 	if pb == nil {
 		return Services{}, nil
 	}
-	command, err := normalizeBootstrapCommand(pb.GetCommand(), "policy services.command")
+	blocks, err := stageBlocksFromProto(pb.GetBlocks(), "policy services")
 	if err != nil {
 		return Services{}, err
-	}
-	keyFiles, err := normalizeBootstrapKeyFiles(pb.GetKey().GetFiles(), "policy services.key.files")
-	if err != nil {
-		return Services{}, err
-	}
-	if len(command) == 0 && len(keyFiles) > 0 {
-		return Services{}, errors.New("policy services.key.files requires services.command")
 	}
 	return Services{
-		Docker: DockerService{
-			Required: pb.GetDocker().GetRequired(),
-		},
-		Command:  command,
-		KeyFiles: keyFiles,
+		Blocks:   blocks,
+		Command:  combinedStageBlockCommand(blocks),
+		KeyFiles: combinedStageBlockInputFiles(blocks),
 	}, nil
 }
 
@@ -1265,16 +1258,413 @@ func normalizeBootstrapKeyFiles(raw []string, field string) ([]string, error) {
 	return files, nil
 }
 
-func normalizeDependencyReuse(raw, field string) (string, error) {
-	trimmed := strings.TrimSpace(strings.ToLower(raw))
-	switch trimmed {
-	case "", DependencyReuseExact:
-		return "", nil
-	case DependencyReusePortable:
-		return DependencyReusePortable, nil
-	default:
-		return "", fmt.Errorf("%s must be %q or %q", field, DependencyReuseExact, DependencyReusePortable)
+const defaultBlockHome = "/root"
+
+func normalizeStageBlocks(raw []rawPolicyBlock, field string) ([]StageBlock, error) {
+	if len(raw) == 0 {
+		return nil, nil
 	}
+	seenNames := make(map[string]struct{}, len(raw))
+	blocks := make([]StageBlock, 0, len(raw))
+	for i, candidate := range raw {
+		block, err := normalizeStageBlock(candidate, fmt.Sprintf("%s[%d]", field, i))
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := seenNames[block.Name]; ok {
+			return nil, fmt.Errorf("%s[%d].name %q is duplicated", field, i, block.Name)
+		}
+		seenNames[block.Name] = struct{}{}
+		blocks = append(blocks, block)
+	}
+	if err := validateStageBlockOutputRelationships(blocks, field); err != nil {
+		return nil, err
+	}
+	return blocks, nil
+}
+
+func normalizeStageBlock(raw rawPolicyBlock, field string) (StageBlock, error) {
+	name := strings.TrimSpace(raw.Name)
+	if name == "" {
+		return StageBlock{}, fmt.Errorf("%s.name is required", field)
+	}
+	if !validStageBlockName(name) {
+		return StageBlock{}, fmt.Errorf("%s.name %q must match [A-Za-z0-9][A-Za-z0-9_.-]*", field, name)
+	}
+	command, err := normalizeBootstrapCommand(raw.Command, field+".command")
+	if err != nil {
+		return StageBlock{}, err
+	}
+	if len(command) == 0 {
+		return StageBlock{}, fmt.Errorf("%s.command is required", field)
+	}
+	inputFiles, err := normalizeBootstrapKeyFiles(raw.Inputs.Files, field+".inputs.files")
+	if err != nil {
+		return StageBlock{}, err
+	}
+	if len(inputFiles) == 0 {
+		return StageBlock{}, fmt.Errorf("%s.inputs.files must include at least one file or glob", field)
+	}
+	env, err := normalizeBlockEnv(raw.Env, field+".env")
+	if err != nil {
+		return StageBlock{}, err
+	}
+	outputs, err := normalizeBlockOutputs(raw.Outputs, field+".outputs")
+	if err != nil {
+		return StageBlock{}, err
+	}
+	if len(outputs.Dirs) == 0 && len(outputs.Files) == 0 {
+		return StageBlock{}, fmt.Errorf("%s.outputs must include at least one dir or file", field)
+	}
+	return StageBlock{
+		Name:    name,
+		Command: command,
+		Inputs:  StageBlockInputs{Files: inputFiles},
+		Env:     env,
+		Outputs: outputs,
+	}, nil
+}
+
+func validStageBlockName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i, r := range name {
+		if (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			continue
+		}
+		if i > 0 && (r == '_' || r == '.' || r == '-') {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func normalizeBlockEnv(raw map[string]string, field string) (map[string]string, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	env := make(map[string]string, len(raw))
+	for key, value := range raw {
+		name := strings.TrimSpace(key)
+		if name == "" {
+			return nil, fmt.Errorf("%s contains an empty key", field)
+		}
+		if !validEnvName(name) {
+			return nil, fmt.Errorf("%s.%s must be a valid environment variable name", field, name)
+		}
+		env[name] = expandGuestEnvValue(value)
+	}
+	return env, nil
+}
+
+func expandGuestEnvValue(value string) string {
+	switch {
+	case value == "~":
+		return defaultBlockHome
+	case strings.HasPrefix(value, "~/"):
+		return defaultBlockHome + value[1:]
+	case value == "$HOME":
+		return defaultBlockHome
+	case strings.HasPrefix(value, "$HOME/"):
+		return defaultBlockHome + strings.TrimPrefix(value, "$HOME")
+	case value == "${HOME}":
+		return defaultBlockHome
+	case strings.HasPrefix(value, "${HOME}/"):
+		return defaultBlockHome + strings.TrimPrefix(value, "${HOME}")
+	default:
+		return value
+	}
+}
+
+func validEnvName(name string) bool {
+	for i, r := range name {
+		if i == 0 {
+			if (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || r == '_' {
+				continue
+			}
+			return false
+		}
+		if (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_' {
+			continue
+		}
+		return false
+	}
+	return name != ""
+}
+
+func normalizeBlockOutputs(raw rawPolicyBlockOutputs, field string) (StageBlockOutputs, error) {
+	dirs, err := normalizeOutputPaths(raw.Dirs, field+".dirs")
+	if err != nil {
+		return StageBlockOutputs{}, err
+	}
+	files, err := normalizeOutputPaths(raw.Files, field+".files")
+	if err != nil {
+		return StageBlockOutputs{}, err
+	}
+	if err := validateOutputPathRelationships(dirs, files, field); err != nil {
+		return StageBlockOutputs{}, err
+	}
+	return StageBlockOutputs{Dirs: dirs, Files: files}, nil
+}
+
+func normalizeOutputPaths(raw []string, field string) ([]string, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	seen := make(map[string]struct{}, len(raw))
+	paths := make([]string, 0, len(raw))
+	for i, candidate := range raw {
+		normalized, err := expandGuestPathValue(strings.TrimSpace(candidate), fmt.Sprintf("%s[%d]", field, i), true)
+		if err != nil {
+			return nil, err
+		}
+		if strings.HasPrefix(normalized, "/workspace/") || normalized == "/workspace" {
+			return nil, fmt.Errorf("%s[%d] must not be under /workspace", field, i)
+		}
+		if normalized == "/" {
+			return nil, fmt.Errorf("%s[%d] must not be /", field, i)
+		}
+		if _, ok := seen[normalized]; ok {
+			return nil, fmt.Errorf("%s[%d] duplicates output path %q", field, i, normalized)
+		}
+		seen[normalized] = struct{}{}
+		paths = append(paths, normalized)
+	}
+	sort.Strings(paths)
+	return paths, nil
+}
+
+func expandGuestPathValue(value, field string, requireAbsolute bool) (string, error) {
+	if value == "" {
+		return "", fmt.Errorf("%s cannot be empty", field)
+	}
+	if value == "~" {
+		value = defaultBlockHome
+	} else if strings.HasPrefix(value, "~/") {
+		value = defaultBlockHome + value[1:]
+	} else if strings.HasPrefix(value, "~") {
+		return "", fmt.Errorf("%s does not support ~user expansion", field)
+	}
+	value = strings.ReplaceAll(value, "${HOME}", defaultBlockHome)
+	value = strings.ReplaceAll(value, "$HOME", defaultBlockHome)
+	if strings.Contains(value, "$") {
+		return "", fmt.Errorf("%s contains an unsupported variable expansion", field)
+	}
+	value = path.Clean(strings.ReplaceAll(value, "\\", "/"))
+	if strings.ContainsAny(value, "*?[") {
+		return "", fmt.Errorf("%s must not contain glob characters", field)
+	}
+	if requireAbsolute && !strings.HasPrefix(value, "/") {
+		return "", fmt.Errorf("%s must be absolute", field)
+	}
+	return value, nil
+}
+
+func validateOutputPathRelationships(dirs, files []string, field string) error {
+	for i, dir := range dirs {
+		for j, other := range dirs {
+			if i == j {
+				continue
+			}
+			if pathContains(dir, other) {
+				return fmt.Errorf("%s.dirs contains overlapping paths %q and %q", field, dir, other)
+			}
+		}
+		for _, file := range files {
+			if file == dir || pathContains(dir, file) {
+				return fmt.Errorf("%s.files path %q is inside output dir %q", field, file, dir)
+			}
+		}
+	}
+	return nil
+}
+
+type stageBlockOutputPath struct {
+	Block string
+	Kind  string
+	Path  string
+}
+
+func validateStageBlockOutputRelationships(blocks []StageBlock, field string) error {
+	seen := make(map[string]stageBlockOutputPath)
+	var dirs []stageBlockOutputPath
+	var files []stageBlockOutputPath
+
+	for _, block := range blocks {
+		for _, dir := range block.Outputs.Dirs {
+			ref := stageBlockOutputPath{Block: block.Name, Kind: "dir", Path: dir}
+			if previous, ok := seen[dir]; ok {
+				return fmt.Errorf("%s block %q output %s %q duplicates block %q output %s", field, block.Name, ref.Kind, ref.Path, previous.Block, previous.Kind)
+			}
+			seen[dir] = ref
+			dirs = append(dirs, ref)
+		}
+		for _, file := range block.Outputs.Files {
+			ref := stageBlockOutputPath{Block: block.Name, Kind: "file", Path: file}
+			if previous, ok := seen[file]; ok {
+				return fmt.Errorf("%s block %q output %s %q duplicates block %q output %s", field, block.Name, ref.Kind, ref.Path, previous.Block, previous.Kind)
+			}
+			seen[file] = ref
+			files = append(files, ref)
+		}
+	}
+
+	for i, dir := range dirs {
+		for j, other := range dirs {
+			if i == j {
+				continue
+			}
+			if pathContains(dir.Path, other.Path) {
+				return fmt.Errorf("%s block %q output dir %q overlaps block %q output dir %q", field, dir.Block, dir.Path, other.Block, other.Path)
+			}
+		}
+		for _, file := range files {
+			if pathContains(dir.Path, file.Path) {
+				return fmt.Errorf("%s block %q output dir %q overlaps block %q output file %q", field, dir.Block, dir.Path, file.Block, file.Path)
+			}
+		}
+	}
+	return nil
+}
+
+func validatePolicyOutputRelationships(dependencyBlocks, serviceBlocks []StageBlock) error {
+	if len(dependencyBlocks) == 0 || len(serviceBlocks) == 0 {
+		return nil
+	}
+	blocks := make([]StageBlock, 0, len(dependencyBlocks)+len(serviceBlocks))
+	blocks = appendLabeledStageBlocks(blocks, "dependencies", dependencyBlocks)
+	blocks = appendLabeledStageBlocks(blocks, "services", serviceBlocks)
+	return validateStageBlockOutputRelationships(blocks, "sandbox")
+}
+
+func appendLabeledStageBlocks(dst []StageBlock, stage string, blocks []StageBlock) []StageBlock {
+	for _, block := range blocks {
+		candidate := block
+		candidate.Name = stage + "." + block.Name
+		dst = append(dst, candidate)
+	}
+	return dst
+}
+
+func pathContains(parent, child string) bool {
+	parent = path.Clean(parent)
+	child = path.Clean(child)
+	if parent == "/" {
+		return child != "/"
+	}
+	return strings.HasPrefix(child, parent+"/")
+}
+
+func stageBlocksToProto(blocks []StageBlock) []*cleanroomv1.PolicyBlock {
+	out := make([]*cleanroomv1.PolicyBlock, 0, len(blocks))
+	for _, block := range blocks {
+		out = append(out, &cleanroomv1.PolicyBlock{
+			Name:    block.Name,
+			Command: append([]string(nil), block.Command...),
+			Inputs: &cleanroomv1.PolicyBlockInputs{
+				Files: append([]string(nil), block.Inputs.Files...),
+			},
+			Env: cloneStringMap(block.Env),
+			Outputs: &cleanroomv1.PolicyBlockOutputs{
+				Dirs:  append([]string(nil), block.Outputs.Dirs...),
+				Files: append([]string(nil), block.Outputs.Files...),
+			},
+		})
+	}
+	return out
+}
+
+func stageBlocksFromProto(blocks []*cleanroomv1.PolicyBlock, field string) ([]StageBlock, error) {
+	raw := make([]rawPolicyBlock, 0, len(blocks))
+	for _, block := range blocks {
+		if block == nil {
+			raw = append(raw, rawPolicyBlock{})
+			continue
+		}
+		raw = append(raw, rawPolicyBlock{
+			Name:    block.GetName(),
+			Command: rawDependencyCommandSpec(append([]string(nil), block.GetCommand()...)),
+			Inputs: rawPolicyBlockInputs{
+				Files: append([]string(nil), block.GetInputs().GetFiles()...),
+			},
+			Env: cloneStringMap(block.GetEnv()),
+			Outputs: rawPolicyBlockOutputs{
+				Dirs:  append([]string(nil), block.GetOutputs().GetDirs()...),
+				Files: append([]string(nil), block.GetOutputs().GetFiles()...),
+			},
+		})
+	}
+	return normalizeStageBlocks(raw, field+".blocks")
+}
+
+func cloneStringMap(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}
+
+func combinedStageBlockInputFiles(blocks []StageBlock) []string {
+	seen := make(map[string]struct{})
+	var files []string
+	for _, block := range blocks {
+		for _, file := range block.Inputs.Files {
+			if _, ok := seen[file]; ok {
+				continue
+			}
+			seen[file] = struct{}{}
+			files = append(files, file)
+		}
+	}
+	sort.Strings(files)
+	return files
+}
+
+func combinedStageBlockCommand(blocks []StageBlock) []string {
+	if len(blocks) == 0 {
+		return nil
+	}
+	var script strings.Builder
+	script.WriteString("set -eu\n")
+	for _, block := range blocks {
+		script.WriteString("(\n")
+		if len(block.Env) > 0 {
+			keys := make([]string, 0, len(block.Env))
+			for key := range block.Env {
+				keys = append(keys, key)
+			}
+			sort.Strings(keys)
+			for _, key := range keys {
+				script.WriteString("export ")
+				script.WriteString(key)
+				script.WriteString("=")
+				script.WriteString(shellQuote(block.Env[key]))
+				script.WriteString("\n")
+			}
+		}
+		script.WriteString(commandShellLine(block.Command))
+		script.WriteString("\n")
+		script.WriteString(")\n")
+	}
+	return []string{"sh", "-lc", script.String()}
+}
+
+func commandShellLine(command []string) string {
+	parts := make([]string, 0, len(command))
+	for _, arg := range command {
+		parts = append(parts, shellQuote(arg))
+	}
+	return strings.Join(parts, " ")
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", `'"'"'`) + "'"
 }
 
 func hashPolicy(p *CompiledPolicy) (string, error) {

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -38,12 +38,12 @@ type rawPolicy struct {
 		Image struct {
 			Ref string `yaml:"ref"`
 		} `yaml:"image"`
-		Docker       rawDockerConfig   `yaml:"docker"`
-		Dependencies rawPolicyBlocks   `yaml:"dependencies"`
-		Run          rawRunConfig      `yaml:"run"`
-		Services     rawPolicyBlocks   `yaml:"services"`
-		Resources    rawResources      `yaml:"resources"`
-		Network      rawSandboxNetwork `yaml:"network"`
+		Docker       rawDockerConfig    `yaml:"docker"`
+		Dependencies rawDependencyStage `yaml:"dependencies"`
+		Run          rawRunConfig       `yaml:"run"`
+		Services     rawPolicyBlocks    `yaml:"services"`
+		Resources    rawResources       `yaml:"resources"`
+		Network      rawSandboxNetwork  `yaml:"network"`
 	} `yaml:"sandbox"`
 }
 
@@ -69,6 +69,12 @@ type rawDockerConfig struct {
 }
 
 type rawPolicyBlocks []rawPolicyBlock
+
+type rawDependencyStage struct {
+	Reuse       string
+	Blocks      rawPolicyBlocks
+	blocksField string
+}
 
 type rawPolicyBlock struct {
 	Name    string                   `yaml:"name"`
@@ -608,6 +614,47 @@ func (c *rawDependencyCommandSpec) UnmarshalYAML(node *yaml.Node) error {
 	}
 }
 
+func (stage *rawDependencyStage) UnmarshalYAML(node *yaml.Node) error {
+	if node == nil {
+		return nil
+	}
+	node = dereferenceYAMLAlias(node)
+	if node.Kind == yaml.ScalarNode && node.ShortTag() == "!!null" {
+		return nil
+	}
+	switch node.Kind {
+	case yaml.SequenceNode:
+		var blocks rawPolicyBlocks
+		if err := node.Decode(&blocks); err != nil {
+			return err
+		}
+		stage.Blocks = blocks
+		stage.blocksField = "sandbox.dependencies"
+		return nil
+	case yaml.MappingNode:
+		stage.blocksField = "sandbox.dependencies.blocks"
+		for i := 0; i < len(node.Content); i += 2 {
+			key := node.Content[i]
+			value := node.Content[i+1]
+			switch key.Value {
+			case "reuse":
+				if err := value.Decode(&stage.Reuse); err != nil {
+					return err
+				}
+			case "blocks":
+				if err := value.Decode(&stage.Blocks); err != nil {
+					return err
+				}
+			default:
+				return fmt.Errorf("sandbox.dependencies.%s is not supported; use sandbox.dependencies.blocks", key.Value)
+			}
+		}
+		return nil
+	default:
+		return fmt.Errorf("sandbox.dependencies must be a list of blocks or an object with reuse and blocks")
+	}
+}
+
 func (rules *rawAllowRules) UnmarshalYAML(node *yaml.Node) error {
 	if node == nil {
 		*rules = nil
@@ -1055,16 +1102,26 @@ func normalizeDocker(raw rawDockerConfig) DockerService {
 	return DockerService{Required: raw.Required}
 }
 
-func normalizeDependencies(raw rawPolicyBlocks) (Dependencies, error) {
-	blocks, err := normalizeStageBlocks(raw, "sandbox.dependencies")
+func normalizeDependencies(raw rawDependencyStage) (Dependencies, error) {
+	blocksField := raw.blocksField
+	if blocksField == "" {
+		blocksField = "sandbox.dependencies"
+	}
+	blocks, err := normalizeStageBlocks(raw.Blocks, blocksField)
 	if err != nil {
 		return Dependencies{}, err
 	}
 	command := combinedStageBlockCommand(blocks)
+	keyFiles := combinedStageBlockInputFiles(blocks)
+	reuse, err := normalizeDependencyReuse(raw.Reuse, keyFiles, "sandbox.dependencies.reuse")
+	if err != nil {
+		return Dependencies{}, err
+	}
 	return Dependencies{
 		Blocks:   blocks,
 		Command:  command,
-		KeyFiles: combinedStageBlockInputFiles(blocks),
+		KeyFiles: keyFiles,
+		Reuse:    reuse,
 	}, nil
 }
 

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -1446,9 +1446,15 @@ func expandGuestPathValue(value, field string, requireAbsolute bool) (string, er
 		value = defaultBlockHome + value[1:]
 	} else if strings.HasPrefix(value, "~") {
 		return "", fmt.Errorf("%s does not support ~user expansion", field)
+	} else if value == "$HOME" {
+		value = defaultBlockHome
+	} else if strings.HasPrefix(value, "$HOME/") {
+		value = defaultBlockHome + strings.TrimPrefix(value, "$HOME")
+	} else if value == "${HOME}" {
+		value = defaultBlockHome
+	} else if strings.HasPrefix(value, "${HOME}/") {
+		value = defaultBlockHome + strings.TrimPrefix(value, "${HOME}")
 	}
-	value = strings.ReplaceAll(value, "${HOME}", defaultBlockHome)
-	value = strings.ReplaceAll(value, "$HOME", defaultBlockHome)
 	if strings.Contains(value, "$") {
 		return "", fmt.Errorf("%s contains an unsupported variable expansion", field)
 	}

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -1315,7 +1315,10 @@ func normalizeBootstrapKeyFiles(raw []string, field string) ([]string, error) {
 	return files, nil
 }
 
-const defaultBlockHome = "/root"
+const (
+	defaultBlockHome      = "/root"
+	defaultBlockWorkspace = "/workspace"
+)
 
 func normalizeStageBlocks(raw []rawPolicyBlock, field string) ([]StageBlock, error) {
 	if len(raw) == 0 {
@@ -1430,6 +1433,14 @@ func expandGuestEnvValue(value string) string {
 		return defaultBlockHome
 	case strings.HasPrefix(value, "${HOME}/"):
 		return defaultBlockHome + strings.TrimPrefix(value, "${HOME}")
+	case value == "$WORKSPACE":
+		return defaultBlockWorkspace
+	case strings.HasPrefix(value, "$WORKSPACE/"):
+		return defaultBlockWorkspace + strings.TrimPrefix(value, "$WORKSPACE")
+	case value == "${WORKSPACE}":
+		return defaultBlockWorkspace
+	case strings.HasPrefix(value, "${WORKSPACE}/"):
+		return defaultBlockWorkspace + strings.TrimPrefix(value, "${WORKSPACE}")
 	default:
 		return value
 	}
@@ -1511,6 +1522,14 @@ func expandGuestPathValue(value, field string, requireAbsolute bool) (string, er
 		value = defaultBlockHome
 	} else if strings.HasPrefix(value, "${HOME}/") {
 		value = defaultBlockHome + strings.TrimPrefix(value, "${HOME}")
+	} else if value == "$WORKSPACE" {
+		value = defaultBlockWorkspace
+	} else if strings.HasPrefix(value, "$WORKSPACE/") {
+		value = defaultBlockWorkspace + strings.TrimPrefix(value, "$WORKSPACE")
+	} else if value == "${WORKSPACE}" {
+		value = defaultBlockWorkspace
+	} else if strings.HasPrefix(value, "${WORKSPACE}/") {
+		value = defaultBlockWorkspace + strings.TrimPrefix(value, "${WORKSPACE}")
 	}
 	if strings.Contains(value, "$") {
 		return "", fmt.Errorf("%s contains an unsupported variable expansion", field)

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -21,6 +21,24 @@ func baseRawPolicy() rawPolicy {
 	return raw
 }
 
+func rawBlock(name string, command []string, inputs []string, outputs rawPolicyBlockOutputs) rawPolicyBlock {
+	return rawPolicyBlock{
+		Name:    name,
+		Command: rawDependencyCommandSpec(command),
+		Inputs:  rawPolicyBlockInputs{Files: inputs},
+		Outputs: outputs,
+	}
+}
+
+func protoBlock(name string, command []string, inputs []string, outputs *cleanroomv1.PolicyBlockOutputs) *cleanroomv1.PolicyBlock {
+	return &cleanroomv1.PolicyBlock{
+		Name:    name,
+		Command: command,
+		Inputs:  &cleanroomv1.PolicyBlockInputs{Files: inputs},
+		Outputs: outputs,
+	}
+}
+
 func TestLoaderPrefersRootPolicy(t *testing.T) {
 	t.Parallel()
 
@@ -228,19 +246,16 @@ repository:
 sandbox:
   image:
     ref: ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-  dependencies:
-    network:
+  network:
+    default: deny
+    dependencies:
       allow:
         - proxy.golang.org:443
         - host: storage.googleapis.com
           ports: [443, 443]
-  services:
-    network:
+    services:
       allow: registry-1.docker.io:443
-  run:
-    network: {}
-  network:
-    default: deny
+    execution: {}
 `), &raw); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
@@ -287,10 +302,10 @@ func TestNetworkPolicyForStageRehashesStageScopedPolicies(t *testing.T) {
 			Allow: rawAllowRules{{Host: "github.com", Ports: []int{443}}},
 		},
 	}
-	raw.Sandbox.Dependencies.Network = &rawStageNetworkConfig{
+	raw.Sandbox.Network.Dependencies = &rawStageNetworkConfig{
 		Allow: rawAllowRules{{Host: "proxy.golang.org", Ports: []int{443}}},
 	}
-	raw.Sandbox.Run.Network = &rawStageNetworkConfig{}
+	raw.Sandbox.Network.Execution = &rawStageNetworkConfig{}
 
 	compiled, err := Compile(raw)
 	if err != nil {
@@ -454,13 +469,13 @@ func TestCompileCapturesDockerServiceRequirement(t *testing.T) {
 	t.Parallel()
 
 	raw := baseRawPolicy()
-	raw.Sandbox.Services.Docker.Required = true
+	raw.Sandbox.Docker.Required = true
 
 	compiled, err := Compile(raw)
 	if err != nil {
 		t.Fatalf("compile: %v", err)
 	}
-	if !compiled.Services.Docker.Required {
+	if !compiled.Docker.Required {
 		t.Fatal("expected compiled policy to require docker service")
 	}
 }
@@ -548,38 +563,31 @@ func TestCompileNormalizesDependencyBootstrapConfig(t *testing.T) {
 	t.Parallel()
 
 	raw := baseRawPolicy()
-	raw.Sandbox.Dependencies.Command = []string{"go", "mod", "download"}
-	raw.Sandbox.Dependencies.Key.Files = []string{"./go.sum", "go.mod", "go.sum"}
+	raw.Sandbox.Dependencies = rawPolicyBlocks{
+		rawBlock("go-modules", []string{"go", "mod", "download"}, []string{"./go.sum", "go.mod", "go.sum"}, rawPolicyBlockOutputs{
+			Dirs: []string{"${HOME}/go/pkg/mod"},
+		}),
+	}
 
 	compiled, err := Compile(raw)
 	if err != nil {
 		t.Fatalf("compile: %v", err)
 	}
-	if got, want := compiled.Dependencies.Command, []string{"go", "mod", "download"}; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+	if len(compiled.Dependencies.Blocks) != 1 {
+		t.Fatalf("unexpected dependency block count: got %d want 1", len(compiled.Dependencies.Blocks))
+	}
+	block := compiled.Dependencies.Blocks[0]
+	if got, want := block.Name, "go-modules"; got != want {
+		t.Fatalf("unexpected dependency block name: got %q want %q", got, want)
+	}
+	if got, want := block.Command, []string{"go", "mod", "download"}; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
 		t.Fatalf("unexpected dependency command: got %v want %v", got, want)
 	}
 	if got, want := compiled.Dependencies.KeyFiles, []string{"go.mod", "go.sum"}; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
 		t.Fatalf("unexpected dependency key files: got %v want %v", got, want)
 	}
-	if got := compiled.Dependencies.Reuse; got != "" {
-		t.Fatalf("expected default dependency reuse mode to be empty/exact, got %q", got)
-	}
-}
-
-func TestCompileNormalizesPortableDependencyReuse(t *testing.T) {
-	t.Parallel()
-
-	raw := baseRawPolicy()
-	raw.Sandbox.Dependencies.Command = []string{"go", "mod", "download"}
-	raw.Sandbox.Dependencies.Key.Files = []string{"go.mod", "go.sum"}
-	raw.Sandbox.Dependencies.Reuse = "portable"
-
-	compiled, err := Compile(raw)
-	if err != nil {
-		t.Fatalf("compile: %v", err)
-	}
-	if got, want := compiled.Dependencies.Reuse, DependencyReusePortable; got != want {
-		t.Fatalf("unexpected dependency reuse mode: got %q want %q", got, want)
+	if got, want := block.Outputs.Dirs, []string{"/root/go/pkg/mod"}; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("unexpected dependency outputs: got %v want %v", got, want)
 	}
 }
 
@@ -587,22 +595,223 @@ func TestCompileNormalizesServicesBootstrapConfig(t *testing.T) {
 	t.Parallel()
 
 	raw := baseRawPolicy()
-	raw.Sandbox.Services.Docker.Required = true
-	raw.Sandbox.Services.Command = []string{"docker", "compose", "up", "-d", "postgres"}
-	raw.Sandbox.Services.Key.Files = []string{"./docker-compose.yml", "docker-compose.yml"}
+	raw.Sandbox.Docker.Required = true
+	raw.Sandbox.Services = rawPolicyBlocks{
+		rawBlock("postgres", []string{"docker", "compose", "up", "-d", "postgres"}, []string{"./docker-compose.yml", "docker-compose.yml"}, rawPolicyBlockOutputs{
+			Dirs: []string{"/var/lib/cleanroom/services/postgres"},
+		}),
+	}
 
 	compiled, err := Compile(raw)
 	if err != nil {
 		t.Fatalf("compile: %v", err)
 	}
-	if !compiled.Services.Docker.Required {
+	if !compiled.Docker.Required {
 		t.Fatal("expected compiled policy to preserve docker service requirement")
 	}
-	if got, want := compiled.Services.Command, []string{"docker", "compose", "up", "-d", "postgres"}; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+	if len(compiled.Services.Blocks) != 1 {
+		t.Fatalf("unexpected services block count: got %d want 1", len(compiled.Services.Blocks))
+	}
+	if got, want := compiled.Services.Blocks[0].Command, []string{"docker", "compose", "up", "-d", "postgres"}; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
 		t.Fatalf("unexpected services command: got %v want %v", got, want)
 	}
 	if got, want := compiled.Services.KeyFiles, []string{"docker-compose.yml"}; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
 		t.Fatalf("unexpected services key files: got %v want %v", got, want)
+	}
+}
+
+func TestUnmarshalRejectsOldServicesObjectShape(t *testing.T) {
+	t.Parallel()
+
+	var raw rawPolicy
+	err := yaml.Unmarshal([]byte(`
+version: 1
+sandbox:
+  image:
+    ref: ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+  services:
+    docker:
+      required: true
+    command: docker compose up -d postgres
+    key:
+      files: [docker-compose.yml]
+  network:
+    default: deny
+`), &raw)
+	if err == nil {
+		t.Fatal("expected unmarshal to reject old services object shape")
+	}
+}
+
+func TestCompileRejectsDuplicateDependencyBlockNames(t *testing.T) {
+	t.Parallel()
+
+	raw := baseRawPolicy()
+	raw.Sandbox.Dependencies = rawPolicyBlocks{
+		rawBlock("go-modules", []string{"go", "mod", "download"}, []string{"go.mod"}, rawPolicyBlockOutputs{Dirs: []string{"${HOME}/go/pkg/mod"}}),
+		rawBlock("go-modules", []string{"go", "env"}, []string{"go.sum"}, rawPolicyBlockOutputs{Dirs: []string{"${HOME}/.cache/go-build"}}),
+	}
+
+	_, err := Compile(raw)
+	if err == nil {
+		t.Fatal("expected compile to reject duplicate block names")
+	}
+	if !strings.Contains(err.Error(), "duplicated") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCompileRejectsInvalidOutputPaths(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		outputs rawPolicyBlockOutputs
+		want    string
+	}{
+		{name: "relative dir", outputs: rawPolicyBlockOutputs{Dirs: []string{"var/cache"}}, want: "must be absolute"},
+		{name: "workspace dir", outputs: rawPolicyBlockOutputs{Dirs: []string{"/workspace/node_modules"}}, want: "must not be under /workspace"},
+		{name: "root dir", outputs: rawPolicyBlockOutputs{Dirs: []string{"/"}}, want: "must not be /"},
+		{name: "unknown variable", outputs: rawPolicyBlockOutputs{Dirs: []string{"${CACHE}/go"}}, want: "unsupported variable expansion"},
+		{name: "other user home", outputs: rawPolicyBlockOutputs{Dirs: []string{"~builder/.cache"}}, want: "does not support ~user expansion"},
+		{name: "duplicate normalized dirs", outputs: rawPolicyBlockOutputs{Dirs: []string{"~/go/pkg/mod", "${HOME}/go/pkg/mod"}}, want: "duplicates output path"},
+		{name: "overlapping dirs", outputs: rawPolicyBlockOutputs{Dirs: []string{"${HOME}/go", "${HOME}/go/pkg/mod"}}, want: "overlapping paths"},
+		{name: "file inside dir", outputs: rawPolicyBlockOutputs{Dirs: []string{"${HOME}/.cache/mise"}, Files: []string{"${HOME}/.cache/mise/index.json"}}, want: "inside output dir"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			raw := baseRawPolicy()
+			raw.Sandbox.Dependencies = rawPolicyBlocks{
+				rawBlock("deps", []string{"true"}, []string{"go.mod"}, tc.outputs),
+			}
+
+			_, err := Compile(raw)
+			if err == nil {
+				t.Fatal("expected compile to reject output path")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected error containing %q, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+func TestCompileRejectsOverlappingOutputsAcrossDependencyBlocks(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		first  rawPolicyBlockOutputs
+		second rawPolicyBlockOutputs
+		want   string
+	}{
+		{
+			name:   "duplicate dir",
+			first:  rawPolicyBlockOutputs{Dirs: []string{"${HOME}/go/pkg/mod"}},
+			second: rawPolicyBlockOutputs{Dirs: []string{"~/go/pkg/mod"}},
+			want:   "duplicates",
+		},
+		{
+			name:   "nested dir",
+			first:  rawPolicyBlockOutputs{Dirs: []string{"${HOME}/go"}},
+			second: rawPolicyBlockOutputs{Dirs: []string{"${HOME}/go/pkg/mod"}},
+			want:   "overlaps",
+		},
+		{
+			name:   "file inside dir",
+			first:  rawPolicyBlockOutputs{Dirs: []string{"${HOME}/.cache/mise"}},
+			second: rawPolicyBlockOutputs{Files: []string{"${HOME}/.cache/mise/state.json"}},
+			want:   "overlaps",
+		},
+		{
+			name:   "duplicate file",
+			first:  rawPolicyBlockOutputs{Files: []string{"${HOME}/.bundle/config"}},
+			second: rawPolicyBlockOutputs{Files: []string{"~/.bundle/config"}},
+			want:   "duplicates",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			raw := baseRawPolicy()
+			raw.Sandbox.Dependencies = rawPolicyBlocks{
+				rawBlock("first", []string{"true"}, []string{"go.mod"}, tc.first),
+				rawBlock("second", []string{"true"}, []string{"go.sum"}, tc.second),
+			}
+
+			_, err := Compile(raw)
+			if err == nil {
+				t.Fatal("expected compile to reject overlapping outputs")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected error containing %q, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+func TestCompileRejectsOverlappingOutputsAcrossDependencyAndServiceBlocks(t *testing.T) {
+	t.Parallel()
+
+	raw := baseRawPolicy()
+	raw.Sandbox.Dependencies = rawPolicyBlocks{
+		rawBlock("go", []string{"true"}, []string{"go.mod"}, rawPolicyBlockOutputs{Dirs: []string{"${HOME}/go"}}),
+	}
+	raw.Sandbox.Services = rawPolicyBlocks{
+		rawBlock("postgres", []string{"true"}, []string{"docker-compose.yml"}, rawPolicyBlockOutputs{Files: []string{"${HOME}/go/service.state"}}),
+	}
+
+	_, err := Compile(raw)
+	if err == nil {
+		t.Fatal("expected compile to reject overlapping dependency and service outputs")
+	}
+	if !strings.Contains(err.Error(), "overlaps") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCompilePreservesLiteralBlockEnvValues(t *testing.T) {
+	t.Parallel()
+
+	raw := baseRawPolicy()
+	raw.Sandbox.Dependencies = rawPolicyBlocks{
+		{
+			Name:    "go",
+			Command: rawDependencyCommandSpec{"true"},
+			Inputs:  rawPolicyBlockInputs{Files: []string{"go.mod"}},
+			Env: map[string]string{
+				"EMPTY":      "",
+				"GOCACHE":    "${HOME}/.cache/go-build",
+				"GOPROXY":    "https://proxy.golang.org,direct",
+				"RAW_PATH":   "a/../b",
+				"TRAILING":   "value ",
+				"UNEXPANDED": "$CACHE/go",
+			},
+			Outputs: rawPolicyBlockOutputs{Dirs: []string{"${HOME}/go/pkg/mod"}},
+		},
+	}
+
+	compiled, err := Compile(raw)
+	if err != nil {
+		t.Fatalf("Compile returned error: %v", err)
+	}
+	env := compiled.Dependencies.Blocks[0].Env
+	for key, want := range map[string]string{
+		"EMPTY":      "",
+		"GOCACHE":    "/root/.cache/go-build",
+		"GOPROXY":    "https://proxy.golang.org,direct",
+		"RAW_PATH":   "a/../b",
+		"TRAILING":   "value ",
+		"UNEXPANDED": "$CACHE/go",
+	} {
+		if got := env[key]; got != want {
+			t.Fatalf("unexpected env %s: got %q want %q", key, got, want)
+		}
 	}
 }
 
@@ -616,9 +825,12 @@ sandbox:
   image:
     ref: ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
   dependencies:
-    command: bundle install
-    key:
-      files: [Gemfile.lock]
+    - name: gems
+      command: bundle install
+      inputs:
+        files: [Gemfile.lock]
+      outputs:
+        dirs: ["${HOME}/.bundle"]
   network:
     default: deny
 `), &raw); err != nil {
@@ -629,7 +841,10 @@ sandbox:
 	if err != nil {
 		t.Fatalf("compile: %v", err)
 	}
-	if got, want := compiled.Dependencies.Command, []string{"sh", "-lc", "bundle install"}; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+	if len(compiled.Dependencies.Blocks) != 1 {
+		t.Fatalf("unexpected dependency block count: got %d want 1", len(compiled.Dependencies.Blocks))
+	}
+	if got, want := compiled.Dependencies.Blocks[0].Command, []string{"sh", "-lc", "bundle install"}; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
 		t.Fatalf("unexpected dependency command: got %v want %v", got, want)
 	}
 	if got, want := compiled.Dependencies.KeyFiles, []string{"Gemfile.lock"}; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
@@ -637,32 +852,24 @@ sandbox:
 	}
 }
 
-func TestCompileTreatsNullDependencyCommandAsUnset(t *testing.T) {
+func TestUnmarshalRejectsOldDependencyObjectShape(t *testing.T) {
 	t.Parallel()
 
 	var raw rawPolicy
-	if err := yaml.Unmarshal([]byte(`
+	err := yaml.Unmarshal([]byte(`
 version: 1
 sandbox:
   image:
     ref: ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
   dependencies:
-    command: null
+    command: bundle install
+    key:
+      files: [Gemfile.lock]
   network:
     default: deny
-`), &raw); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-
-	compiled, err := Compile(raw)
-	if err != nil {
-		t.Fatalf("compile: %v", err)
-	}
-	if compiled.Dependencies.Enabled() {
-		t.Fatal("expected null dependency command to disable dependency bootstrap")
-	}
-	if len(compiled.Dependencies.Command) != 0 {
-		t.Fatalf("expected null dependency command to normalize to empty, got %v", compiled.Dependencies.Command)
+`), &raw)
+	if err == nil {
+		t.Fatal("expected unmarshal to reject old dependency object shape")
 	}
 }
 
@@ -677,9 +884,12 @@ sandbox:
   image:
     ref: ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
   dependencies:
-    command: *deps
-    key:
-      files: [go.mod, go.sum]
+    - name: go-modules
+      command: *deps
+      inputs:
+        files: [go.mod, go.sum]
+      outputs:
+        dirs: [~/go/pkg/mod]
   network:
     default: deny
 `), &raw); err != nil {
@@ -690,38 +900,52 @@ sandbox:
 	if err != nil {
 		t.Fatalf("compile: %v", err)
 	}
-	if got, want := compiled.Dependencies.Command, []string{"mise", "exec", "--", "go", "mod", "download"}; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+	if len(compiled.Dependencies.Blocks) != 1 {
+		t.Fatalf("unexpected dependency block count: got %d want 1", len(compiled.Dependencies.Blocks))
+	}
+	if got, want := compiled.Dependencies.Blocks[0].Command, []string{"mise", "exec", "--", "go", "mod", "download"}; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
 		t.Fatalf("unexpected dependency command: got %v want %v", got, want)
 	}
 }
 
-func TestCompileRejectsDependencyKeyFilesWithoutCommand(t *testing.T) {
+func TestCompileRejectsDependencyInputsWithoutCommand(t *testing.T) {
 	t.Parallel()
 
 	raw := baseRawPolicy()
-	raw.Sandbox.Dependencies.Key.Files = []string{"go.sum"}
+	raw.Sandbox.Dependencies = rawPolicyBlocks{
+		{
+			Name: "go-modules",
+			Inputs: rawPolicyBlockInputs{
+				Files: []string{"go.sum"},
+			},
+			Outputs: rawPolicyBlockOutputs{
+				Dirs: []string{"${HOME}/go/pkg/mod"},
+			},
+		},
+	}
 
 	_, err := Compile(raw)
 	if err == nil {
-		t.Fatal("expected compile to reject dependency key files without a command")
+		t.Fatal("expected compile to reject dependency inputs without a command")
 	}
-	if !strings.Contains(err.Error(), "sandbox.dependencies.key.files") {
+	if !strings.Contains(err.Error(), "sandbox.dependencies[0].command") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
-func TestCompileRejectsPortableDependencyReuseWithoutKeyFiles(t *testing.T) {
+func TestCompileRejectsDependencyBlockWithoutOutputs(t *testing.T) {
 	t.Parallel()
 
 	raw := baseRawPolicy()
-	raw.Sandbox.Dependencies.Command = []string{"go", "mod", "download"}
-	raw.Sandbox.Dependencies.Reuse = "portable"
+	raw.Sandbox.Dependencies = rawPolicyBlocks{
+		rawBlock("go-modules", []string{"go", "mod", "download"}, []string{"go.sum"}, rawPolicyBlockOutputs{}),
+	}
 
 	_, err := Compile(raw)
 	if err == nil {
-		t.Fatal("expected compile to reject portable dependency reuse without key files")
+		t.Fatal("expected compile to reject dependency block without outputs")
 	}
-	if !strings.Contains(err.Error(), "sandbox.dependencies.reuse=portable") {
+	if !strings.Contains(err.Error(), "sandbox.dependencies[0].outputs") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -736,7 +960,12 @@ sandbox:
   image:
     ref: ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
   dependencies:
-    command: false
+    - name: go-modules
+      command: false
+      inputs:
+        files: [go.mod]
+      outputs:
+        dirs: ["${HOME}/go/pkg/mod"]
   network:
     default: deny
 `), &raw)
@@ -1036,17 +1265,47 @@ func TestFromProtoPropagatesDockerServiceRequirement(t *testing.T) {
 		Version:        1,
 		ImageRef:       validImageRef,
 		NetworkDefault: "deny",
-		Services: &cleanroomv1.PolicyServices{
-			Docker: &cleanroomv1.PolicyDockerService{
-				Required: true,
-			},
+		Docker: &cleanroomv1.PolicyDocker{
+			Required: true,
 		},
 	})
 	if err != nil {
 		t.Fatalf("FromProto returned error: %v", err)
 	}
-	if !compiled.Services.Docker.Required {
+	if !compiled.Docker.Required {
 		t.Fatal("expected docker service requirement from proto policy")
+	}
+}
+
+func TestFromProtoRejectsOverlappingDependencyAndServiceOutputs(t *testing.T) {
+	t.Parallel()
+
+	_, err := FromProto(&cleanroomv1.Policy{
+		Version:        1,
+		ImageRef:       validImageRef,
+		NetworkDefault: "deny",
+		Dependencies: &cleanroomv1.PolicyDependencies{
+			Blocks: []*cleanroomv1.PolicyBlock{protoBlock(
+				"go",
+				[]string{"true"},
+				[]string{"go.mod"},
+				&cleanroomv1.PolicyBlockOutputs{Dirs: []string{"/root/go"}},
+			)},
+		},
+		Services: &cleanroomv1.PolicyServices{
+			Blocks: []*cleanroomv1.PolicyBlock{protoBlock(
+				"postgres",
+				[]string{"true"},
+				[]string{"docker-compose.yml"},
+				&cleanroomv1.PolicyBlockOutputs{Files: []string{"/root/go/service.state"}},
+			)},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected FromProto to reject overlapping dependency and service outputs")
+	}
+	if !strings.Contains(err.Error(), "overlaps") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
@@ -1123,10 +1382,10 @@ func TestCompiledPolicyProtoRoundTripPreservesStageScopedNetwork(t *testing.T) {
 			Allow: rawAllowRules{{Host: "github.com", Ports: []int{443}}},
 		},
 	}
-	raw.Sandbox.Dependencies.Network = &rawStageNetworkConfig{
+	raw.Sandbox.Network.Dependencies = &rawStageNetworkConfig{
 		Allow: rawAllowRules{{Host: "proxy.golang.org", Ports: []int{443}}},
 	}
-	raw.Sandbox.Run.Network = &rawStageNetworkConfig{}
+	raw.Sandbox.Network.Execution = &rawStageNetworkConfig{}
 
 	compiled, err := Compile(raw)
 	if err != nil {
@@ -1158,12 +1417,17 @@ func TestCompiledPolicyProtoRoundTripPreservesDependenciesAndServices(t *testing
 	t.Parallel()
 
 	raw := baseRawPolicy()
-	raw.Sandbox.Dependencies.Command = []string{"go", "mod", "download"}
-	raw.Sandbox.Dependencies.Key.Files = []string{"go.mod", "go.sum"}
-	raw.Sandbox.Dependencies.Reuse = "portable"
-	raw.Sandbox.Services.Docker.Required = true
-	raw.Sandbox.Services.Command = []string{"docker", "compose", "up", "-d", "postgres"}
-	raw.Sandbox.Services.Key.Files = []string{"docker-compose.yml"}
+	raw.Sandbox.Docker.Required = true
+	raw.Sandbox.Dependencies = rawPolicyBlocks{
+		rawBlock("go-modules", []string{"go", "mod", "download"}, []string{"go.mod", "go.sum"}, rawPolicyBlockOutputs{
+			Dirs: []string{"${HOME}/go/pkg/mod"},
+		}),
+	}
+	raw.Sandbox.Services = rawPolicyBlocks{
+		rawBlock("postgres", []string{"docker", "compose", "up", "-d", "postgres"}, []string{"docker-compose.yml"}, rawPolicyBlockOutputs{
+			Dirs: []string{"/var/lib/cleanroom/services/postgres"},
+		}),
+	}
 	raw.Sandbox.Run.Before = rawShellCommandSpec{"sh", "-lc", "bin/rails db:prepare"}
 	vcpus := int64(6)
 	memory := bytesize.Size(12 << 30)
@@ -1186,10 +1450,10 @@ func TestCompiledPolicyProtoRoundTripPreservesDependenciesAndServices(t *testing
 	if got, want := strings.Join(roundTripped.Dependencies.KeyFiles, "\x00"), strings.Join(compiled.Dependencies.KeyFiles, "\x00"); got != want {
 		t.Fatalf("unexpected dependency key files after round trip: got %q want %q", got, want)
 	}
-	if got, want := roundTripped.Dependencies.Reuse, compiled.Dependencies.Reuse; got != want {
-		t.Fatalf("unexpected dependency reuse after round trip: got %q want %q", got, want)
+	if got, want := len(roundTripped.Dependencies.Blocks), len(compiled.Dependencies.Blocks); got != want {
+		t.Fatalf("unexpected dependency block count after round trip: got %d want %d", got, want)
 	}
-	if got, want := roundTripped.Services.Docker.Required, compiled.Services.Docker.Required; got != want {
+	if got, want := roundTripped.Docker.Required, compiled.Docker.Required; got != want {
 		t.Fatalf("unexpected docker requirement after round trip: got %t want %t", got, want)
 	}
 	if got, want := strings.Join(roundTripped.Services.Command, "\x00"), strings.Join(compiled.Services.Command, "\x00"); got != want {

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -30,6 +30,13 @@ func rawBlock(name string, command []string, inputs []string, outputs rawPolicyB
 	}
 }
 
+func rawDependencyBlocks(blocks ...rawPolicyBlock) rawDependencyStage {
+	return rawDependencyStage{
+		Blocks:      rawPolicyBlocks(blocks),
+		blocksField: "sandbox.dependencies",
+	}
+}
+
 func protoBlock(name string, command []string, inputs []string, outputs *cleanroomv1.PolicyBlockOutputs) *cleanroomv1.PolicyBlock {
 	return &cleanroomv1.PolicyBlock{
 		Name:    name,
@@ -563,11 +570,11 @@ func TestCompileNormalizesDependencyBootstrapConfig(t *testing.T) {
 	t.Parallel()
 
 	raw := baseRawPolicy()
-	raw.Sandbox.Dependencies = rawPolicyBlocks{
+	raw.Sandbox.Dependencies = rawDependencyBlocks(
 		rawBlock("go-modules", []string{"go", "mod", "download"}, []string{"./go.sum", "go.mod", "go.sum"}, rawPolicyBlockOutputs{
 			Dirs: []string{"${HOME}/go/pkg/mod"},
 		}),
-	}
+	)
 
 	compiled, err := Compile(raw)
 	if err != nil {
@@ -588,6 +595,66 @@ func TestCompileNormalizesDependencyBootstrapConfig(t *testing.T) {
 	}
 	if got, want := block.Outputs.Dirs, []string{"/root/go/pkg/mod"}; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
 		t.Fatalf("unexpected dependency outputs: got %v want %v", got, want)
+	}
+}
+
+func TestCompilePreservesDependencyReuseFromYAML(t *testing.T) {
+	t.Parallel()
+
+	var raw rawPolicy
+	if err := yaml.Unmarshal([]byte(`
+version: 1
+sandbox:
+  image:
+    ref: ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+  dependencies:
+    reuse: portable
+    blocks:
+      - name: go-modules
+        command: go mod download
+        inputs:
+          files:
+            - go.mod
+            - go.sum
+        outputs:
+          dirs:
+            - ${HOME}/go/pkg/mod
+  network:
+    default: deny
+`), &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	compiled, err := Compile(raw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if got, want := compiled.Dependencies.Reuse, DependencyReusePortable; got != want {
+		t.Fatalf("unexpected dependency reuse mode: got %q want %q", got, want)
+	}
+	if got, want := compiled.Dependencies.KeyFiles, []string{"go.mod", "go.sum"}; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("unexpected dependency key files: got %v want %v", got, want)
+	}
+}
+
+func TestUnmarshalRejectsOldDependenciesObjectShape(t *testing.T) {
+	t.Parallel()
+
+	var raw rawPolicy
+	err := yaml.Unmarshal([]byte(`
+version: 1
+sandbox:
+  image:
+    ref: ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+  dependencies:
+    command: go mod download
+    key:
+      files: [go.mod, go.sum]
+  network:
+    default: deny
+`), &raw)
+	if err == nil {
+		t.Fatal("expected unmarshal to reject old dependencies object shape")
 	}
 }
 
@@ -647,10 +714,10 @@ func TestCompileRejectsDuplicateDependencyBlockNames(t *testing.T) {
 	t.Parallel()
 
 	raw := baseRawPolicy()
-	raw.Sandbox.Dependencies = rawPolicyBlocks{
+	raw.Sandbox.Dependencies = rawDependencyBlocks(
 		rawBlock("go-modules", []string{"go", "mod", "download"}, []string{"go.mod"}, rawPolicyBlockOutputs{Dirs: []string{"${HOME}/go/pkg/mod"}}),
 		rawBlock("go-modules", []string{"go", "env"}, []string{"go.sum"}, rawPolicyBlockOutputs{Dirs: []string{"${HOME}/.cache/go-build"}}),
-	}
+	)
 
 	_, err := Compile(raw)
 	if err == nil {
@@ -686,9 +753,9 @@ func TestCompileRejectsInvalidOutputPaths(t *testing.T) {
 			t.Parallel()
 
 			raw := baseRawPolicy()
-			raw.Sandbox.Dependencies = rawPolicyBlocks{
+			raw.Sandbox.Dependencies = rawDependencyBlocks(
 				rawBlock("deps", []string{"true"}, []string{"go.mod"}, tc.outputs),
-			}
+			)
 
 			_, err := Compile(raw)
 			if err == nil {
@@ -741,10 +808,10 @@ func TestCompileRejectsOverlappingOutputsAcrossDependencyBlocks(t *testing.T) {
 			t.Parallel()
 
 			raw := baseRawPolicy()
-			raw.Sandbox.Dependencies = rawPolicyBlocks{
+			raw.Sandbox.Dependencies = rawDependencyBlocks(
 				rawBlock("first", []string{"true"}, []string{"go.mod"}, tc.first),
 				rawBlock("second", []string{"true"}, []string{"go.sum"}, tc.second),
-			}
+			)
 
 			_, err := Compile(raw)
 			if err == nil {
@@ -761,9 +828,9 @@ func TestCompileRejectsOverlappingOutputsAcrossDependencyAndServiceBlocks(t *tes
 	t.Parallel()
 
 	raw := baseRawPolicy()
-	raw.Sandbox.Dependencies = rawPolicyBlocks{
+	raw.Sandbox.Dependencies = rawDependencyBlocks(
 		rawBlock("go", []string{"true"}, []string{"go.mod"}, rawPolicyBlockOutputs{Dirs: []string{"${HOME}/go"}}),
-	}
+	)
 	raw.Sandbox.Services = rawPolicyBlocks{
 		rawBlock("postgres", []string{"true"}, []string{"docker-compose.yml"}, rawPolicyBlockOutputs{Files: []string{"${HOME}/go/service.state"}}),
 	}
@@ -781,8 +848,8 @@ func TestCompilePreservesLiteralBlockEnvValues(t *testing.T) {
 	t.Parallel()
 
 	raw := baseRawPolicy()
-	raw.Sandbox.Dependencies = rawPolicyBlocks{
-		{
+	raw.Sandbox.Dependencies = rawDependencyBlocks(
+		rawPolicyBlock{
 			Name:    "go",
 			Command: rawDependencyCommandSpec{"true"},
 			Inputs:  rawPolicyBlockInputs{Files: []string{"go.mod"}},
@@ -796,7 +863,7 @@ func TestCompilePreservesLiteralBlockEnvValues(t *testing.T) {
 			},
 			Outputs: rawPolicyBlockOutputs{Dirs: []string{"${HOME}/go/pkg/mod"}},
 		},
-	}
+	)
 
 	compiled, err := Compile(raw)
 	if err != nil {
@@ -914,8 +981,8 @@ func TestCompileRejectsDependencyInputsWithoutCommand(t *testing.T) {
 	t.Parallel()
 
 	raw := baseRawPolicy()
-	raw.Sandbox.Dependencies = rawPolicyBlocks{
-		{
+	raw.Sandbox.Dependencies = rawDependencyBlocks(
+		rawPolicyBlock{
 			Name: "go-modules",
 			Inputs: rawPolicyBlockInputs{
 				Files: []string{"go.sum"},
@@ -924,7 +991,7 @@ func TestCompileRejectsDependencyInputsWithoutCommand(t *testing.T) {
 				Dirs: []string{"${HOME}/go/pkg/mod"},
 			},
 		},
-	}
+	)
 
 	_, err := Compile(raw)
 	if err == nil {
@@ -939,9 +1006,9 @@ func TestCompileRejectsDependencyBlockWithoutOutputs(t *testing.T) {
 	t.Parallel()
 
 	raw := baseRawPolicy()
-	raw.Sandbox.Dependencies = rawPolicyBlocks{
+	raw.Sandbox.Dependencies = rawDependencyBlocks(
 		rawBlock("go-modules", []string{"go", "mod", "download"}, []string{"go.sum"}, rawPolicyBlockOutputs{}),
-	}
+	)
 
 	_, err := Compile(raw)
 	if err == nil {
@@ -1420,11 +1487,11 @@ func TestCompiledPolicyProtoRoundTripPreservesDependenciesAndServices(t *testing
 
 	raw := baseRawPolicy()
 	raw.Sandbox.Docker.Required = true
-	raw.Sandbox.Dependencies = rawPolicyBlocks{
+	raw.Sandbox.Dependencies = rawDependencyBlocks(
 		rawBlock("go-modules", []string{"go", "mod", "download"}, []string{"go.mod", "go.sum"}, rawPolicyBlockOutputs{
 			Dirs: []string{"${HOME}/go/pkg/mod"},
 		}),
-	}
+	)
 	raw.Sandbox.Services = rawPolicyBlocks{
 		rawBlock("postgres", []string{"docker", "compose", "up", "-d", "postgres"}, []string{"docker-compose.yml"}, rawPolicyBlockOutputs{
 			Dirs: []string{"/var/lib/cleanroom/services/postgres"},

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -673,6 +673,8 @@ func TestCompileRejectsInvalidOutputPaths(t *testing.T) {
 		{name: "workspace dir", outputs: rawPolicyBlockOutputs{Dirs: []string{"/workspace/node_modules"}}, want: "must not be under /workspace"},
 		{name: "root dir", outputs: rawPolicyBlockOutputs{Dirs: []string{"/"}}, want: "must not be /"},
 		{name: "unknown variable", outputs: rawPolicyBlockOutputs{Dirs: []string{"${CACHE}/go"}}, want: "unsupported variable expansion"},
+		{name: "home variable typo", outputs: rawPolicyBlockOutputs{Dirs: []string{"$HOMECACHE/go"}}, want: "unsupported variable expansion"},
+		{name: "home braced variable typo", outputs: rawPolicyBlockOutputs{Dirs: []string{"${HOME}CACHE/go"}}, want: "unsupported variable expansion"},
 		{name: "other user home", outputs: rawPolicyBlockOutputs{Dirs: []string{"~builder/.cache"}}, want: "does not support ~user expansion"},
 		{name: "duplicate normalized dirs", outputs: rawPolicyBlockOutputs{Dirs: []string{"~/go/pkg/mod", "${HOME}/go/pkg/mod"}}, want: "duplicates output path"},
 		{name: "overlapping dirs", outputs: rawPolicyBlockOutputs{Dirs: []string{"${HOME}/go", "${HOME}/go/pkg/mod"}}, want: "overlapping paths"},

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -742,6 +742,9 @@ func TestCompileRejectsInvalidOutputPaths(t *testing.T) {
 		{name: "unknown variable", outputs: rawPolicyBlockOutputs{Dirs: []string{"${CACHE}/go"}}, want: "unsupported variable expansion"},
 		{name: "home variable typo", outputs: rawPolicyBlockOutputs{Dirs: []string{"$HOMECACHE/go"}}, want: "unsupported variable expansion"},
 		{name: "home braced variable typo", outputs: rawPolicyBlockOutputs{Dirs: []string{"${HOME}CACHE/go"}}, want: "unsupported variable expansion"},
+		{name: "workspace variable dir", outputs: rawPolicyBlockOutputs{Dirs: []string{"${WORKSPACE}/vendor/bundle"}}, want: "must not be under /workspace"},
+		{name: "workspace variable typo", outputs: rawPolicyBlockOutputs{Dirs: []string{"$WORKSPACECACHE/go"}}, want: "unsupported variable expansion"},
+		{name: "workspace braced variable typo", outputs: rawPolicyBlockOutputs{Dirs: []string{"${WORKSPACE}CACHE/go"}}, want: "unsupported variable expansion"},
 		{name: "other user home", outputs: rawPolicyBlockOutputs{Dirs: []string{"~builder/.cache"}}, want: "does not support ~user expansion"},
 		{name: "duplicate normalized dirs", outputs: rawPolicyBlockOutputs{Dirs: []string{"~/go/pkg/mod", "${HOME}/go/pkg/mod"}}, want: "duplicates output path"},
 		{name: "overlapping dirs", outputs: rawPolicyBlockOutputs{Dirs: []string{"${HOME}/go", "${HOME}/go/pkg/mod"}}, want: "overlapping paths"},
@@ -860,6 +863,8 @@ func TestCompilePreservesLiteralBlockEnvValues(t *testing.T) {
 				"RAW_PATH":   "a/../b",
 				"TRAILING":   "value ",
 				"UNEXPANDED": "$CACHE/go",
+				"WORKDIR":    "${WORKSPACE}",
+				"WORKCACHE":  "$WORKSPACE/.cache",
 			},
 			Outputs: rawPolicyBlockOutputs{Dirs: []string{"${HOME}/go/pkg/mod"}},
 		},
@@ -877,6 +882,8 @@ func TestCompilePreservesLiteralBlockEnvValues(t *testing.T) {
 		"RAW_PATH":   "a/../b",
 		"TRAILING":   "value ",
 		"UNEXPANDED": "$CACHE/go",
+		"WORKDIR":    "/workspace",
+		"WORKCACHE":  "/workspace/.cache",
 	} {
 		if got := env[key]; got != want {
 			t.Fatalf("unexpected env %s: got %q want %q", key, got, want)

--- a/internal/repositorychangeset/changeset.go
+++ b/internal/repositorychangeset/changeset.go
@@ -158,18 +158,12 @@ func (c *Changeset) DigestPathsFromBase(repoRoot string, paths []string) ([]File
 		return nil, fmt.Errorf("apply repository changeset patch to temporary git index: %w", err)
 	}
 
-	files := make([]File, 0, len(paths))
-	seen := make(map[string]struct{}, len(paths))
-	for _, rawPath := range paths {
-		normalizedPath := normalizePath(rawPath)
-		if normalizedPath == "" {
-			return nil, fmt.Errorf("repository changeset digest path %q is invalid", rawPath)
-		}
-		if _, exists := seen[normalizedPath]; exists {
-			return nil, fmt.Errorf("repository changeset digest path %q is duplicated", normalizedPath)
-		}
-		seen[normalizedPath] = struct{}{}
-
+	expandedPaths, err := expandDigestPathsInIndex(repoRoot, env, paths)
+	if err != nil {
+		return nil, err
+	}
+	files := make([]File, 0, len(expandedPaths))
+	for _, normalizedPath := range expandedPaths {
 		file := File{Path: normalizedPath}
 		exists, err := pathExistsInIndex(repoRoot, env, normalizedPath)
 		if err != nil {
@@ -192,6 +186,57 @@ func (c *Changeset) DigestPathsFromBase(repoRoot string, paths []string) ([]File
 		return files[i].Path < files[j].Path
 	})
 	return files, nil
+}
+
+func expandDigestPathsInIndex(repoRoot string, env []string, paths []string) ([]string, error) {
+	seen := make(map[string]struct{}, len(paths))
+	var expanded []string
+	var indexPaths []string
+	for _, rawPath := range paths {
+		normalizedPath := normalizePath(rawPath)
+		if normalizedPath == "" {
+			return nil, fmt.Errorf("repository changeset digest path %q is invalid", rawPath)
+		}
+		if !strings.ContainsAny(normalizedPath, "*?[") {
+			if _, exists := seen[normalizedPath]; exists {
+				continue
+			}
+			seen[normalizedPath] = struct{}{}
+			expanded = append(expanded, normalizedPath)
+			continue
+		}
+		if _, err := path.Match(normalizedPath, ""); err != nil {
+			return nil, fmt.Errorf("repository changeset digest path glob %q is invalid: %w", normalizedPath, err)
+		}
+		if indexPaths == nil {
+			var err error
+			indexPaths, err = listIndexPaths(repoRoot, env)
+			if err != nil {
+				return nil, err
+			}
+		}
+		matches := 0
+		for _, candidate := range indexPaths {
+			matched, err := path.Match(normalizedPath, candidate)
+			if err != nil {
+				return nil, fmt.Errorf("repository changeset digest path glob %q is invalid: %w", normalizedPath, err)
+			}
+			if !matched {
+				continue
+			}
+			matches++
+			if _, exists := seen[candidate]; exists {
+				continue
+			}
+			seen[candidate] = struct{}{}
+			expanded = append(expanded, candidate)
+		}
+		if matches == 0 {
+			return nil, fmt.Errorf("repository changeset digest path glob %q matched no files", normalizedPath)
+		}
+	}
+	sort.Strings(expanded)
+	return expanded, nil
 }
 
 func FromProto(proto *cleanroomv1.RepositoryChangeset) *Changeset {
@@ -514,6 +559,24 @@ func pathExistsInIndex(repoRoot string, env []string, normalizedPath string) (bo
 		return false, err
 	}
 	return strings.TrimSpace(string(output)) != "", nil
+}
+
+func listIndexPaths(repoRoot string, env []string) ([]string, error) {
+	output, err := gitOutput(repoRoot, env, "ls-files", "-z")
+	if err != nil {
+		return nil, fmt.Errorf("list repository changeset index paths: %w", err)
+	}
+	tokens := splitNullTerminated(output)
+	paths := make([]string, 0, len(tokens))
+	for _, token := range tokens {
+		normalizedPath := normalizePath(token)
+		if normalizedPath == "" {
+			return nil, fmt.Errorf("parse repository changeset index path from %q", token)
+		}
+		paths = append(paths, normalizedPath)
+	}
+	sort.Strings(paths)
+	return paths, nil
 }
 
 func buildDigest(baseCommitSHA, treeDigest string, patch []byte, files []File) string {

--- a/internal/repositorychangeset/changeset.go
+++ b/internal/repositorychangeset/changeset.go
@@ -158,7 +158,7 @@ func (c *Changeset) DigestPathsFromBase(repoRoot string, paths []string) ([]File
 		return nil, fmt.Errorf("apply repository changeset patch to temporary git index: %w", err)
 	}
 
-	expandedPaths, err := expandDigestPathsInIndex(repoRoot, env, paths)
+	expandedPaths, err := expandDigestPathsInIndex(repoRoot, env, baseCommitSHA, paths)
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +188,7 @@ func (c *Changeset) DigestPathsFromBase(repoRoot string, paths []string) ([]File
 	return files, nil
 }
 
-func expandDigestPathsInIndex(repoRoot string, env []string, paths []string) ([]string, error) {
+func expandDigestPathsInIndex(repoRoot string, env []string, baseCommitSHA string, paths []string) ([]string, error) {
 	seen := make(map[string]struct{}, len(paths))
 	var expanded []string
 	var indexPaths []string
@@ -210,7 +210,7 @@ func expandDigestPathsInIndex(repoRoot string, env []string, paths []string) ([]
 		}
 		if indexPaths == nil {
 			var err error
-			indexPaths, err = listIndexPaths(repoRoot, env)
+			indexPaths, err = listIndexPathsIncludingDeleted(repoRoot, env, baseCommitSHA)
 			if err != nil {
 				return nil, err
 			}
@@ -572,6 +572,49 @@ func listIndexPaths(repoRoot string, env []string) ([]string, error) {
 		normalizedPath := normalizePath(token)
 		if normalizedPath == "" {
 			return nil, fmt.Errorf("parse repository changeset index path from %q", token)
+		}
+		paths = append(paths, normalizedPath)
+	}
+	sort.Strings(paths)
+	return paths, nil
+}
+
+func listIndexPathsIncludingDeleted(repoRoot string, env []string, baseCommitSHA string) ([]string, error) {
+	paths, err := listIndexPaths(repoRoot, env)
+	if err != nil {
+		return nil, err
+	}
+	deletedPaths, err := listDeletedIndexPaths(repoRoot, env, baseCommitSHA)
+	if err != nil {
+		return nil, err
+	}
+	if len(deletedPaths) == 0 {
+		return paths, nil
+	}
+	seen := make(map[string]struct{}, len(paths)+len(deletedPaths))
+	combined := make([]string, 0, len(paths)+len(deletedPaths))
+	for _, candidate := range append(paths, deletedPaths...) {
+		if _, exists := seen[candidate]; exists {
+			continue
+		}
+		seen[candidate] = struct{}{}
+		combined = append(combined, candidate)
+	}
+	sort.Strings(combined)
+	return combined, nil
+}
+
+func listDeletedIndexPaths(repoRoot string, env []string, baseCommitSHA string) ([]string, error) {
+	output, err := gitOutput(repoRoot, env, "diff", "--cached", "--name-only", "-z", "--diff-filter=D", strings.TrimSpace(baseCommitSHA), "--")
+	if err != nil {
+		return nil, fmt.Errorf("list deleted repository changeset index paths: %w", err)
+	}
+	tokens := splitNullTerminated(output)
+	paths := make([]string, 0, len(tokens))
+	for _, token := range tokens {
+		normalizedPath := normalizePath(token)
+		if normalizedPath == "" {
+			return nil, fmt.Errorf("parse deleted repository changeset index path from %q", token)
 		}
 		paths = append(paths, normalizedPath)
 	}

--- a/internal/repositorychangeset/changeset_test.go
+++ b/internal/repositorychangeset/changeset_test.go
@@ -368,6 +368,49 @@ func TestDigestPathsFromBaseExpandsGlobs(t *testing.T) {
 	}
 }
 
+func TestDigestPathsFromBaseExpandsDeletedGlobMatches(t *testing.T) {
+	repoDir := initGitRepository(t)
+	if err := os.WriteFile(filepath.Join(repoDir, "go.sum"), []byte("example.com/test v0.0.0 h1:abc123\n"), 0o644); err != nil {
+		t.Fatalf("write go.sum: %v", err)
+	}
+	runGit(t, repoDir, "add", "go.sum")
+	runGit(t, repoDir, "commit", "-m", "add go sum")
+
+	checkout := &repositorycheckout.Checkout{
+		RemoteURL:      "https://github.com/buildkite/cleanroom.git",
+		CommitSHA:      headCommit(t, repoDir),
+		DestinationDir: "/workspace",
+	}
+
+	if err := os.Remove(filepath.Join(repoDir, "go.sum")); err != nil {
+		t.Fatalf("delete go.sum: %v", err)
+	}
+	changeset, err := BuildFromWorkingTree(repoDir, checkout)
+	if err != nil {
+		t.Fatalf("BuildFromWorkingTree returned error: %v", err)
+	}
+	if changeset == nil {
+		t.Fatal("expected changeset")
+	}
+
+	digests, err := changeset.DigestPathsFromBase(repoDir, []string{"*.sum"})
+	if err != nil {
+		t.Fatalf("DigestPathsFromBase returned error: %v", err)
+	}
+	if got, want := len(digests), 1; got != want {
+		t.Fatalf("unexpected digest count: got %d want %d", got, want)
+	}
+	if got, want := digests[0].Path, "go.sum"; got != want {
+		t.Fatalf("unexpected digest path: got %q want %q", got, want)
+	}
+	if !digests[0].Deleted {
+		t.Fatal("expected go.sum to be recorded as deleted")
+	}
+	if digests[0].SHA256 != "" {
+		t.Fatalf("expected deleted go.sum digest to be empty, got %q", digests[0].SHA256)
+	}
+}
+
 func initGitRepository(t *testing.T) string {
 	t.Helper()
 

--- a/internal/repositorychangeset/changeset_test.go
+++ b/internal/repositorychangeset/changeset_test.go
@@ -322,6 +322,52 @@ func TestResetCommandsUseDoubleForceClean(t *testing.T) {
 	}
 }
 
+func TestDigestPathsFromBaseExpandsGlobs(t *testing.T) {
+	repoDir := initGitRepository(t)
+	if err := os.WriteFile(filepath.Join(repoDir, "go.mod"), []byte("module example.com/test\n"), 0o644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, "go.sum"), []byte("example.com/test v0.0.0 h1:abc123\n"), 0o644); err != nil {
+		t.Fatalf("write go.sum: %v", err)
+	}
+
+	checkout := &repositorycheckout.Checkout{
+		RemoteURL:      "https://github.com/buildkite/cleanroom.git",
+		CommitSHA:      headCommit(t, repoDir),
+		DestinationDir: "/workspace",
+	}
+
+	changeset, err := BuildFromWorkingTree(repoDir, checkout)
+	if err != nil {
+		t.Fatalf("BuildFromWorkingTree returned error: %v", err)
+	}
+	if changeset == nil {
+		t.Fatal("expected changeset")
+	}
+
+	digests, err := changeset.DigestPathsFromBase(repoDir, []string{"*.sum", "go.*"})
+	if err != nil {
+		t.Fatalf("DigestPathsFromBase returned error: %v", err)
+	}
+	if got, want := len(digests), 2; got != want {
+		t.Fatalf("unexpected digest count: got %d want %d", got, want)
+	}
+	if got, want := digests[0].Path, "go.mod"; got != want {
+		t.Fatalf("unexpected first digest path: got %q want %q", got, want)
+	}
+	if got, want := digests[1].Path, "go.sum"; got != want {
+		t.Fatalf("unexpected second digest path: got %q want %q", got, want)
+	}
+
+	_, err = changeset.DigestPathsFromBase(repoDir, []string{"*.missing"})
+	if err == nil {
+		t.Fatal("expected empty glob to fail")
+	}
+	if !strings.Contains(err.Error(), "matched no files") {
+		t.Fatalf("unexpected empty glob error: %v", err)
+	}
+}
+
 func initGitRepository(t *testing.T) string {
 	t.Helper()
 

--- a/proto/cleanroom/v1/control.proto
+++ b/proto/cleanroom/v1/control.proto
@@ -112,24 +112,38 @@ message PolicyAllowRule {
   repeated int32 ports = 2;
 }
 
-message PolicyDockerService {
+message PolicyDocker {
   bool required = 1;
 }
 
-message PolicyServices {
-  PolicyDockerService docker = 1;
-  repeated string command = 2;
-  PolicyDependencyKey key = 3;
-}
-
-message PolicyDependencyKey {
+message PolicyBlockInputs {
   repeated string files = 1;
 }
 
+message PolicyBlockOutputs {
+  repeated string dirs = 1;
+  repeated string files = 2;
+}
+
+message PolicyBlock {
+  string name = 1;
+  repeated string command = 2;
+  PolicyBlockInputs inputs = 3;
+  map<string, string> env = 4;
+  PolicyBlockOutputs outputs = 5;
+}
+
+message PolicyServices {
+  reserved 1, 2, 3;
+  reserved "docker", "command", "key";
+  repeated PolicyBlock blocks = 4;
+}
+
 message PolicyDependencies {
-  repeated string command = 1;
-  PolicyDependencyKey key = 2;
+  reserved 1, 2;
+  reserved "command", "key";
   string reuse = 3;
+  repeated PolicyBlock blocks = 4;
 }
 
 message PolicyRun {
@@ -165,6 +179,7 @@ message Policy {
   PolicyRun run = 10;
   PolicyResources resources = 11;
   PolicyNetworkStages network_stages = 12;
+  PolicyDocker docker = 13;
 }
 
 message SandboxOptions {

--- a/scripts/ci-example-smoke.sh
+++ b/scripts/ci-example-smoke.sh
@@ -40,9 +40,8 @@ repository:
 sandbox:
   image:
     ref: ghcr.io/buildkite/cleanroom-base/alpine-docker@sha256:19c696770ae8f3f36e786bf25a0e08e5a5c18b9a7fe52bde7d988c3da500bf08
-  services:
-    docker:
-      required: true
+  docker:
+    required: true
   network:
     default: deny
     allow:


### PR DESCRIPTION
## What changed

This PR lands the first implementation slice for dependency/service volume caches. It adds the policy and proto contract for ordered dependency and service blocks, moves the Docker runtime requirement to `sandbox.docker.required`, and validates declared block inputs and outputs.

It also adds the supporting plumbing for the next backend slices: deterministic input manifest helpers, glob-aware dependency key-file hashing on the existing stage-cache path, dependency/service output-volume cache key helpers, cache metadata fields for output records and manifest digests, and backend capability/request fields for cache output volumes and overlay write capture.

Docs, spec text, and examples are updated to the new schema.

## Important boundary

This PR does not yet restore or publish declared outputs as independent sidecar volumes. Dependency and service blocks currently compile into the existing aggregate dependency/services stage bootstrap path, so the current full-rootfs stage cache behavior is preserved while the new contract is reviewed.

The remaining work is tracked in `docs/plans/dependency-service-volume-caches.md`: per-block planning, isolated input projections, overlay write capture, Firecracker pre-launch volume attachment, output snapshot publish/restore, escaped-write fallback handling, observability, and end-to-end reuse tests.

## Validation

- `mise exec -- go test ./...`
- `mise exec -- go run ./cmd/cleanroom policy validate --chdir examples/docker`
- `mise exec -- go run ./cmd/cleanroom policy validate --chdir examples/buildkite-agent`
- `mise exec -- go run ./cmd/cleanroom policy validate --chdir examples/rails`