### PR TITLE
feat: Add workspace copy-out previews

### DIFF
--- a/docs/plans/workspace-sync.md
+++ b/docs/plans/workspace-sync.md
@@ -2,8 +2,18 @@
 
 **Spec reference:** `spec.md` sections 5.1.1, 5.4, 5.4.2
 **Related plan:** `docs/plans/sandbox-transfer-invariants.md`
-**Status:** Proposed
-**Last reviewed:** 2026-04-28
+**Status:** In progress
+**Last reviewed:** 2026-05-02
+
+## Implementation Status
+
+- Phase 1 copy-in support landed in PR #251.
+- This changeset should land the read-only Phase 2 foundation:
+  Git-backed `workspace diff`, Git-backed `workspace copy-out --dry-run`,
+  sandbox-root resolution from the recorded repository checkout, and local-root
+  safety that requires a matching local Git checkout before copy-out planning.
+- Local copy-out writes, local binding metadata, recoverable copy-out payloads,
+  top-level `--copy-out`, and `--sync` remain follow-up work.
 
 ## Summary
 

--- a/internal/cli/cli_parse_test.go
+++ b/internal/cli/cli_parse_test.go
@@ -426,6 +426,33 @@ func TestWorkspaceCopyInParses(t *testing.T) {
 	}
 }
 
+func TestWorkspaceCopyOutAndDiffParse(t *testing.T) {
+	t.Run("copy-out", func(t *testing.T) {
+		c := &CLI{}
+		parser := newParserForTest(t, c)
+		if _, err := parser.Parse([]string{"workspace", "copy-out", "--dry-run", "cr_123"}); err != nil {
+			t.Fatalf("parse workspace copy-out returned error: %v", err)
+		}
+		if got, want := c.Workspace.CopyOut.SandboxID, "cr_123"; got != want {
+			t.Fatalf("unexpected workspace copy-out sandbox id: got %q want %q", got, want)
+		}
+		if !c.Workspace.CopyOut.DryRun {
+			t.Fatal("expected workspace copy-out dry-run flag to be set")
+		}
+	})
+
+	t.Run("diff", func(t *testing.T) {
+		c := &CLI{}
+		parser := newParserForTest(t, c)
+		if _, err := parser.Parse([]string{"workspace", "diff", "cr_123"}); err != nil {
+			t.Fatalf("parse workspace diff returned error: %v", err)
+		}
+		if got, want := c.Workspace.Diff.SandboxID, "cr_123"; got != want {
+			t.Fatalf("unexpected workspace diff sandbox id: got %q want %q", got, want)
+		}
+	})
+}
+
 func TestIncludeLocalChangesFlagRejected(t *testing.T) {
 	c := &CLI{}
 	parser := newParserForTest(t, c)

--- a/internal/cli/workspace.go
+++ b/internal/cli/workspace.go
@@ -401,11 +401,21 @@ func workspaceLocalPath(root, rel string) (string, error) {
 }
 
 func workspaceRelativePath(rel string) (string, error) {
-	cleaned := posixpath.Clean(filepath.ToSlash(rel))
-	if cleaned == "." || cleaned == "" || strings.HasPrefix(cleaned, "/") || cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+	slashed := filepath.ToSlash(rel)
+	cleaned := posixpath.Clean(slashed)
+	windowsCleaned := posixpath.Clean(strings.ReplaceAll(slashed, "\\", "/"))
+	if cleaned == "." || cleaned == "" || strings.HasPrefix(cleaned, "/") || hasWindowsDrivePathPrefix(windowsCleaned) || cleaned == ".." || strings.HasPrefix(cleaned, "../") {
 		return "", fmt.Errorf("workspace path %q is not a safe relative path", rel)
 	}
 	return cleaned, nil
+}
+
+func hasWindowsDrivePathPrefix(path string) bool {
+	if len(path) < 2 || path[1] != ':' {
+		return false
+	}
+	drive := path[0]
+	return (drive >= 'A' && drive <= 'Z') || (drive >= 'a' && drive <= 'z')
 }
 
 func copyRawWorkspaceToSandbox(callCtx context.Context, ctx *runtimeContext, client *controlclient.Client, opts workspaceCopyOptions) error {

--- a/internal/cli/workspace.go
+++ b/internal/cli/workspace.go
@@ -21,7 +21,9 @@ import (
 )
 
 type WorkspaceCommand struct {
-	CopyIn WorkspaceCopyInCommand `name:"copy-in" cmd:"" help:"Copy local workspace changes into a sandbox"`
+	CopyIn  WorkspaceCopyInCommand  `name:"copy-in" cmd:"" help:"Copy local workspace changes into a sandbox"`
+	CopyOut WorkspaceCopyOutCommand `name:"copy-out" cmd:"" help:"Preview or copy sandbox workspace changes back locally"`
+	Diff    WorkspaceDiffCommand    `cmd:"" help:"Show sandbox workspace changes"`
 }
 
 type WorkspaceCopyInCommand struct {
@@ -29,6 +31,18 @@ type WorkspaceCopyInCommand struct {
 	Chdir     string `short:"c" help:"Change to this local directory before planning the workspace copy-in"`
 	DryRun    bool   `name:"dry-run" help:"Show the workspace paths that would be copied in without modifying the sandbox"`
 	SandboxID string `arg:"" required:"" help:"Sandbox ID to copy into"`
+}
+
+type WorkspaceCopyOutCommand struct {
+	clientFlags
+	Chdir     string `short:"c" help:"Change to this local directory before planning the workspace copy-out"`
+	DryRun    bool   `name:"dry-run" help:"Show the local workspace paths that would be copied out without modifying local files"`
+	SandboxID string `arg:"" required:"" help:"Sandbox ID to copy out from"`
+}
+
+type WorkspaceDiffCommand struct {
+	clientFlags
+	SandboxID string `arg:"" required:"" help:"Sandbox ID to diff"`
 }
 
 type workspaceCopyOptions struct {
@@ -65,6 +79,44 @@ func (c *WorkspaceCopyInCommand) Run(ctx *runtimeContext) error {
 		DryRun:        c.DryRun,
 		Repository:    repository,
 		ForceGitReset: true,
+	})
+}
+
+func (c *WorkspaceCopyOutCommand) Run(ctx *runtimeContext) error {
+	cwd, err := resolveCWD(ctx.CWD, c.Chdir)
+	if err != nil {
+		return err
+	}
+	if !c.DryRun {
+		return errors.New("workspace copy-out writes are not implemented yet; use --dry-run to preview sandbox changes")
+	}
+	repository, err := resolveWorkspaceCopyRepositoryCheckout(cwd, ctx.Loader)
+	if err != nil {
+		return err
+	}
+	localRoot := cwd
+	if repository != nil && strings.TrimSpace(repository.RootDir) != "" {
+		localRoot = repository.RootDir
+	}
+	client, err := c.connect(ctx)
+	if err != nil {
+		return err
+	}
+	return previewWorkspaceCopyOut(context.Background(), ctx, client, workspaceCopyOptions{
+		CWD:        localRoot,
+		SandboxID:  c.SandboxID,
+		DryRun:     true,
+		Repository: repository,
+	})
+}
+
+func (c *WorkspaceDiffCommand) Run(ctx *runtimeContext) error {
+	client, err := c.connect(ctx)
+	if err != nil {
+		return err
+	}
+	return diffWorkspaceInSandbox(context.Background(), ctx, client, workspaceCopyOptions{
+		SandboxID: c.SandboxID,
 	})
 }
 
@@ -117,6 +169,83 @@ func copyGitWorkspaceToSandbox(callCtx context.Context, ctx *runtimeContext, cli
 	return runWorkspaceExecution(callCtx, ctx, client, opts.SandboxID, effectiveRepository, command, bytes.NewReader(changeset.Patch), opts.LaunchSeconds)
 }
 
+func previewWorkspaceCopyOut(callCtx context.Context, ctx *runtimeContext, client *controlclient.Client, opts workspaceCopyOptions) error {
+	if strings.TrimSpace(opts.SandboxID) == "" {
+		return errors.New("missing sandbox id")
+	}
+	if strings.TrimSpace(opts.CWD) == "" {
+		return errors.New("missing local workspace root")
+	}
+	checkout, err := sandboxRepositoryCheckout(callCtx, client, opts.SandboxID)
+	if err != nil {
+		return err
+	}
+	if err := validateWorkspaceCopyOutLocalRepository(opts.Repository, checkout); err != nil {
+		return err
+	}
+	command := repositorychangeset.WorktreeNameStatusCommand(checkout)
+	if len(command) == 0 {
+		return errors.New("sandbox repository checkout is missing the information needed to plan workspace copy-out")
+	}
+	output, err := runWorkspaceExecutionCapture(callCtx, ctx, client, opts.SandboxID, command, opts.LaunchSeconds)
+	if err != nil {
+		return err
+	}
+	entries, err := gitWorkspaceCopyOutPlan(opts.CWD, output)
+	if err != nil {
+		return err
+	}
+	return printWorkspacePlan(runtimeStdout(ctx), entries)
+}
+
+func diffWorkspaceInSandbox(callCtx context.Context, ctx *runtimeContext, client *controlclient.Client, opts workspaceCopyOptions) error {
+	if strings.TrimSpace(opts.SandboxID) == "" {
+		return errors.New("missing sandbox id")
+	}
+	checkout, err := sandboxRepositoryCheckout(callCtx, client, opts.SandboxID)
+	if err != nil {
+		return err
+	}
+	command := repositorychangeset.WorktreeDiffCommand(checkout)
+	if len(command) == 0 {
+		return errors.New("sandbox repository checkout is missing the information needed to diff workspace changes")
+	}
+	return runWorkspaceExecution(callCtx, ctx, client, opts.SandboxID, nil, command, nil, opts.LaunchSeconds)
+}
+
+func sandboxRepositoryCheckout(callCtx context.Context, client *controlclient.Client, sandboxID string) (*repositorycheckout.Checkout, error) {
+	repository, err := resolveSandboxRepositoryCheckout(callCtx, client, sandboxID)
+	if err != nil {
+		return nil, err
+	}
+	checkout := repositorycheckout.FromProto(repository)
+	if checkout == nil {
+		return nil, fmt.Errorf("sandbox %q does not have a recorded repository checkout", sandboxID)
+	}
+	return checkout, nil
+}
+
+func validateWorkspaceCopyOutLocalRepository(local *resolvedRepositoryCheckout, sandbox *repositorycheckout.Checkout) error {
+	if local == nil || strings.TrimSpace(local.RootDir) == "" {
+		return errors.New("workspace copy-out requires a local Git repository checkout matching the sandbox repository")
+	}
+	localRemote := strings.TrimSpace(local.RemoteURL)
+	if localRemote == "" {
+		return errors.New("workspace copy-out requires a local repository remote")
+	}
+	if sandbox == nil || strings.TrimSpace(sandbox.RemoteURL) == "" {
+		return errors.New("sandbox repository checkout is missing the remote needed to validate workspace copy-out")
+	}
+	sandboxRemote, _, err := repositorycheckout.CanonicalizeRemoteURL(sandbox.RemoteURL)
+	if err != nil {
+		return fmt.Errorf("validate sandbox repository remote for workspace copy-out: %w", err)
+	}
+	if localRemote != sandboxRemote {
+		return fmt.Errorf("workspace copy-out local repository remote %q does not match sandbox repository remote %q", localRemote, sandboxRemote)
+	}
+	return nil
+}
+
 func resolveGitWorkspaceCheckout(callCtx context.Context, client *controlclient.Client, opts workspaceCopyOptions) (*resolvedRepositoryCheckout, *repositorycheckout.Checkout, error) {
 	repository := opts.Repository
 	if repository == nil {
@@ -145,8 +274,20 @@ func resolveGitWorkspaceCheckout(callCtx context.Context, client *controlclient.
 }
 
 func runWorkspaceExecution(callCtx context.Context, ctx *runtimeContext, client *controlclient.Client, sandboxID string, repository *resolvedRepositoryCheckout, command []string, input io.Reader, launchSeconds int64) error {
+	return runWorkspaceExecutionWithStdout(callCtx, ctx, client, sandboxID, repository, command, input, launchSeconds, runtimeStdout(ctx))
+}
+
+func runWorkspaceExecutionCapture(callCtx context.Context, ctx *runtimeContext, client *controlclient.Client, sandboxID string, command []string, launchSeconds int64) ([]byte, error) {
+	var stdout bytes.Buffer
+	if err := runWorkspaceExecutionWithStdout(callCtx, ctx, client, sandboxID, nil, command, nil, launchSeconds, &stdout); err != nil {
+		return nil, err
+	}
+	return stdout.Bytes(), nil
+}
+
+func runWorkspaceExecutionWithStdout(callCtx context.Context, ctx *runtimeContext, client *controlclient.Client, sandboxID string, repository *resolvedRepositoryCheckout, command []string, input io.Reader, launchSeconds int64, stdout io.Writer) error {
 	if len(command) == 0 {
-		return errors.New("workspace copy-in execution command is empty")
+		return errors.New("workspace operation execution command is empty")
 	}
 	createResp, err := client.CreateWorkspaceCopyInExecution(tracePreservingContext(callCtx), &cleanroomv1.CreateExecutionRequest{
 		SandboxId:          sandboxID,
@@ -160,13 +301,13 @@ func runWorkspaceExecution(callCtx context.Context, ctx *runtimeContext, client 
 		},
 	})
 	if err != nil {
-		return fmt.Errorf("create workspace copy-in execution: %w", err)
+		return fmt.Errorf("create workspace operation execution: %w", err)
 	}
 	executionID := strings.TrimSpace(createResp.GetExecution().GetExecutionId())
 	if executionID == "" {
-		return errors.New("workspace copy-in execution response missing execution id")
+		return errors.New("workspace operation execution response missing execution id")
 	}
-	return streamWorkspaceExecutionWithInput(callCtx, ctx, client, sandboxID, executionID, input)
+	return streamWorkspaceExecutionWithInput(callCtx, ctx, client, sandboxID, executionID, input, stdout)
 }
 
 func gitWorkspacePlan(destination string, files []repositorychangeset.File, reset bool) []workspacePlanEntry {
@@ -189,6 +330,82 @@ func gitWorkspacePlan(destination string, files []repositorychangeset.File, rese
 	}
 	sortWorkspacePlan(entries)
 	return entries
+}
+
+func gitWorkspaceCopyOutPlan(localRoot string, nameStatus []byte) ([]workspacePlanEntry, error) {
+	files, err := parseGitNameStatusWorkspaceFiles(nameStatus)
+	if err != nil {
+		return nil, err
+	}
+	entries := make([]workspacePlanEntry, 0, len(files))
+	for _, file := range files {
+		localPath, err := workspaceLocalPath(localRoot, file.Path)
+		if err != nil {
+			return nil, err
+		}
+		action := "write"
+		if file.Deleted {
+			action = "delete"
+		}
+		entries = append(entries, workspacePlanEntry{
+			Action: action,
+			Path:   localPath,
+		})
+	}
+	sortWorkspacePlan(entries)
+	return entries, nil
+}
+
+func parseGitNameStatusWorkspaceFiles(output []byte) ([]repositorychangeset.File, error) {
+	tokens := splitNullTerminatedWorkspaceFields(output)
+	files := make([]repositorychangeset.File, 0, len(tokens)/2)
+	for i := 0; i < len(tokens); i += 2 {
+		if i+1 >= len(tokens) {
+			return nil, fmt.Errorf("parse workspace changes file status %q", tokens[i])
+		}
+		status := strings.TrimSpace(tokens[i])
+		if status == "" {
+			return nil, errors.New("parse workspace changes: empty file status")
+		}
+		rel, err := workspaceRelativePath(tokens[i+1])
+		if err != nil {
+			return nil, err
+		}
+		files = append(files, repositorychangeset.File{
+			Path:    rel,
+			Deleted: strings.HasPrefix(status, "D"),
+		})
+	}
+	return files, nil
+}
+
+func splitNullTerminatedWorkspaceFields(output []byte) []string {
+	trimmed := bytes.TrimRight(output, "\x00")
+	if len(trimmed) == 0 {
+		return nil
+	}
+	parts := bytes.Split(trimmed, []byte{0})
+	fields := make([]string, 0, len(parts))
+	for _, part := range parts {
+		fields = append(fields, string(part))
+	}
+	return fields
+}
+
+func workspaceLocalPath(root, rel string) (string, error) {
+	normalized, err := workspaceRelativePath(rel)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(root, filepath.FromSlash(normalized)), nil
+}
+
+func workspaceRelativePath(rel string) (string, error) {
+	cleaned := posixpath.Clean(filepath.ToSlash(rel))
+	if cleaned == "." || cleaned == "" || strings.HasPrefix(cleaned, "/") || cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return "", fmt.Errorf("workspace path %q is not a safe relative path", rel)
+	}
+	return cleaned, nil
 }
 
 func copyRawWorkspaceToSandbox(callCtx context.Context, ctx *runtimeContext, client *controlclient.Client, opts workspaceCopyOptions) error {
@@ -583,7 +800,10 @@ func sortWorkspacePlan(entries []workspacePlanEntry) {
 	})
 }
 
-func streamWorkspaceExecutionWithInput(callCtx context.Context, ctx *runtimeContext, client *controlclient.Client, sandboxID, executionID string, input io.Reader) error {
+func streamWorkspaceExecutionWithInput(callCtx context.Context, ctx *runtimeContext, client *controlclient.Client, sandboxID, executionID string, input io.Reader, stdout io.Writer) error {
+	if stdout == nil {
+		stdout = runtimeStdout(ctx)
+	}
 	streamCtx, streamCancel := context.WithCancel(tracePreservingContext(callCtx))
 	defer streamCancel()
 	stream, err := client.StreamExecution(streamCtx, &cleanroomv1.StreamExecutionRequest{
@@ -592,7 +812,7 @@ func streamWorkspaceExecutionWithInput(callCtx context.Context, ctx *runtimeCont
 		Follow:      true,
 	})
 	if err != nil {
-		return fmt.Errorf("stream workspace copy-in execution: %w", err)
+		return fmt.Errorf("stream workspace operation execution: %w", err)
 	}
 
 	var stdinErrCh <-chan error
@@ -615,7 +835,7 @@ func streamWorkspaceExecutionWithInput(callCtx context.Context, ctx *runtimeCont
 		event := stream.Msg()
 		switch payload := event.Payload.(type) {
 		case *cleanroomv1.ExecutionStreamEvent_Stdout:
-			if _, err := runtimeStdout(ctx).Write(payload.Stdout); err != nil {
+			if _, err := stdout.Write(payload.Stdout); err != nil {
 				return err
 			}
 		case *cleanroomv1.ExecutionStreamEvent_Stderr:
@@ -636,7 +856,7 @@ func streamWorkspaceExecutionWithInput(callCtx context.Context, ctx *runtimeCont
 		}
 	}
 	if err := stream.Err(); err != nil && !isCanceledStreamErr(err) {
-		return fmt.Errorf("stream workspace copy-in execution: %w", err)
+		return fmt.Errorf("stream workspace operation execution: %w", err)
 	}
 	if err := waitExecutionStdinErr(stdinErrCh, executionStdinErrDrainTimeout); err != nil {
 		return err
@@ -648,7 +868,7 @@ func streamWorkspaceExecutionWithInput(callCtx context.Context, ctx *runtimeCont
 		}
 	}
 	if !haveExitCode {
-		return errors.New("workspace copy-in execution ended without exit status")
+		return errors.New("workspace operation execution ended without exit status")
 	}
 	if exitCode != 0 {
 		return exitCodeError{code: exitCode}
@@ -666,12 +886,12 @@ func writeExecutionInput(callCtx context.Context, client *controlclient.Client, 
 				ExecutionId: executionID,
 				Data:        append([]byte(nil), buf[:n]...),
 			}); err != nil {
-				return fmt.Errorf("write workspace copy-in payload: %w", err)
+				return fmt.Errorf("write workspace operation payload: %w", err)
 			}
 		}
 		if readErr != nil {
 			if !errors.Is(readErr, io.EOF) {
-				return fmt.Errorf("read workspace copy-in payload: %w", readErr)
+				return fmt.Errorf("read workspace operation payload: %w", readErr)
 			}
 			break
 		}

--- a/internal/cli/workspace.go
+++ b/internal/cli/workspace.go
@@ -404,14 +404,14 @@ func workspaceRelativePath(rel string) (string, error) {
 	slashed := filepath.ToSlash(rel)
 	cleaned := posixpath.Clean(slashed)
 	windowsCleaned := posixpath.Clean(strings.ReplaceAll(slashed, "\\", "/"))
-	if cleaned == "." || cleaned == "" || strings.HasPrefix(cleaned, "/") || hasWindowsDrivePathPrefix(windowsCleaned) || cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+	if cleaned == "." || cleaned == "" || strings.HasPrefix(cleaned, "/") || hasWindowsDriveAbsolutePathPrefix(windowsCleaned) || cleaned == ".." || strings.HasPrefix(cleaned, "../") {
 		return "", fmt.Errorf("workspace path %q is not a safe relative path", rel)
 	}
 	return cleaned, nil
 }
 
-func hasWindowsDrivePathPrefix(path string) bool {
-	if len(path) < 2 || path[1] != ':' {
+func hasWindowsDriveAbsolutePathPrefix(path string) bool {
+	if len(path) < 3 || path[1] != ':' || path[2] != '/' {
 		return false
 	}
 	drive := path[0]

--- a/internal/cli/workspace_test.go
+++ b/internal/cli/workspace_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -830,7 +831,6 @@ func TestWorkspaceCopyOutPlanRejectsWindowsDrivePaths(t *testing.T) {
 		"C:/tmp.txt",
 		"c:/tmp.txt",
 		"D:\\tmp.txt",
-		"Z:tmp.txt",
 	} {
 		t.Run(rel, func(t *testing.T) {
 			_, err := gitWorkspaceCopyOutPlan(t.TempDir(), []byte("M\x00"+rel+"\x00"))
@@ -841,6 +841,21 @@ func TestWorkspaceCopyOutPlanRejectsWindowsDrivePaths(t *testing.T) {
 				t.Fatalf("expected safe relative path error, got %v", err)
 			}
 		})
+	}
+}
+
+func TestWorkspaceCopyOutPlanAllowsRelativeColonPaths(t *testing.T) {
+	localRoot := t.TempDir()
+	entries, err := gitWorkspaceCopyOutPlan(localRoot, []byte("M\x00a:b.txt\x00A\x00dir/Z:tmp.txt\x00"))
+	if err != nil {
+		t.Fatalf("gitWorkspaceCopyOutPlan returned error: %v", err)
+	}
+	expected := []workspacePlanEntry{
+		{Action: "write", Path: filepath.Join(localRoot, "a:b.txt")},
+		{Action: "write", Path: filepath.Join(localRoot, "dir", "Z:tmp.txt")},
+	}
+	if !reflect.DeepEqual(entries, expected) {
+		t.Fatalf("unexpected copy-out plan: got %+v want %+v", entries, expected)
 	}
 }
 

--- a/internal/cli/workspace_test.go
+++ b/internal/cli/workspace_test.go
@@ -825,6 +825,25 @@ func TestWorkspaceCopyOutDryRunReportsSandboxGitPlan(t *testing.T) {
 	}
 }
 
+func TestWorkspaceCopyOutPlanRejectsWindowsDrivePaths(t *testing.T) {
+	for _, rel := range []string{
+		"C:/tmp.txt",
+		"c:/tmp.txt",
+		"D:\\tmp.txt",
+		"Z:tmp.txt",
+	} {
+		t.Run(rel, func(t *testing.T) {
+			_, err := gitWorkspaceCopyOutPlan(t.TempDir(), []byte("M\x00"+rel+"\x00"))
+			if err == nil {
+				t.Fatal("expected Windows drive path to be rejected")
+			}
+			if !strings.Contains(err.Error(), "not a safe relative path") {
+				t.Fatalf("expected safe relative path error, got %v", err)
+			}
+		})
+	}
+}
+
 func TestWorkspaceCopyOutDryRunRejectsNonGitLocalRoot(t *testing.T) {
 	adapter := &integrationAdapter{}
 	host, _ := startIntegrationServer(t, adapter)

--- a/internal/cli/workspace_test.go
+++ b/internal/cli/workspace_test.go
@@ -290,7 +290,7 @@ func TestWorkspaceCopyInReturnsWhenPatchStdinWriteFails(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected WorkspaceCopyInCommand.Run to return stdin write error")
 		}
-		if !strings.Contains(err.Error(), "write workspace copy-in payload") || !strings.Contains(err.Error(), "broken stdin") {
+		if !strings.Contains(err.Error(), "write workspace operation payload") || !strings.Contains(err.Error(), "broken stdin") {
 			t.Fatalf("expected stdin write error, got %v", err)
 		}
 	case <-time.After(3 * time.Second):
@@ -751,6 +751,208 @@ func TestWorkspaceCopyInDryRunReportsCleanGitResetWithoutExecuting(t *testing.T)
 	defer mu.Unlock()
 	if len(commands) != 0 {
 		t.Fatalf("dry-run should not run workspace copy-in execution, got %q", strings.Join(commands[0], " "))
+	}
+}
+
+func TestWorkspaceCopyOutDryRunReportsSandboxGitPlan(t *testing.T) {
+	localRoot := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
+	resolvedLocalRoot, err := gitOutput(localRoot, "rev-parse", "--show-toplevel")
+	if err != nil {
+		t.Fatalf("resolve local repository root: %v", err)
+	}
+	subdir := filepath.Join(localRoot, "subdir")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatalf("create subdir: %v", err)
+	}
+	adapter := &integrationAdapter{}
+	host, _ := startIntegrationServer(t, adapter)
+	sandboxID := createWorkspaceCopyTestSandboxWithRepository(t, host, "/sandbox-workspace")
+
+	var (
+		mu       sync.Mutex
+		commands [][]string
+	)
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+		mu.Lock()
+		commands = append(commands, append([]string(nil), req.Command...))
+		mu.Unlock()
+		if stream.OnStdout != nil {
+			stream.OnStdout([]byte("M\x00changed.txt\x00D\x00removed.txt\x00A\x00nested/new.txt\x00"))
+		}
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+	}
+
+	stdout, stdoutText := makeStdoutCapture(t)
+	stderr, _ := makeStdoutCapture(t)
+	cmd := WorkspaceCopyOutCommand{
+		clientFlags: clientFlags{Host: host},
+		Chdir:       subdir,
+		DryRun:      true,
+		SandboxID:   sandboxID,
+	}
+	if err := cmd.Run(&runtimeContext{
+		CWD:           localRoot,
+		Loader:        repositoryNotFoundLoader{},
+		Config:        runtimeconfig.Config{},
+		Observability: newTestObservability(t),
+		Stdout:        stdout,
+		Stderr:        stderr,
+	}); err != nil {
+		t.Fatalf("WorkspaceCopyOutCommand.Run returned error: %v", err)
+	}
+
+	expected := strings.Join([]string{
+		"delete\t" + filepath.Join(resolvedLocalRoot, "removed.txt"),
+		"write\t" + filepath.Join(resolvedLocalRoot, "changed.txt"),
+		"write\t" + filepath.Join(resolvedLocalRoot, "nested", "new.txt"),
+		"",
+	}, "\n")
+	if got := stdoutText(); got != expected {
+		t.Fatalf("unexpected copy-out dry-run plan: got %q want %q", got, expected)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(commands) != 1 {
+		t.Fatalf("expected one workspace copy-out planning execution, got %d", len(commands))
+	}
+	planCommand := strings.Join(commands[0], " ")
+	if !strings.Contains(planCommand, "dest='/sandbox-workspace'") {
+		t.Fatalf("expected copy-out planning to use sandbox workspace root, got %q", planCommand)
+	}
+	if !strings.Contains(planCommand, "diff --cached --name-status --no-renames -z") {
+		t.Fatalf("expected copy-out planning to use git name-status, got %q", planCommand)
+	}
+}
+
+func TestWorkspaceCopyOutDryRunRejectsNonGitLocalRoot(t *testing.T) {
+	adapter := &integrationAdapter{}
+	host, _ := startIntegrationServer(t, adapter)
+	sandboxID := createWorkspaceCopyTestSandboxWithRepository(t, host, "/sandbox-workspace")
+
+	var executionCalled bool
+	adapter.runStreamFn = func(_ context.Context, _ backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
+		executionCalled = true
+		return &backend.ExecutionResult{ExitCode: 0, Message: "ok"}, nil
+	}
+
+	cwd := t.TempDir()
+	stdout, _ := makeStdoutCapture(t)
+	stderr, _ := makeStdoutCapture(t)
+	cmd := WorkspaceCopyOutCommand{
+		clientFlags: clientFlags{Host: host},
+		Chdir:       cwd,
+		DryRun:      true,
+		SandboxID:   sandboxID,
+	}
+	err := cmd.Run(&runtimeContext{
+		CWD:           cwd,
+		Loader:        repositoryNotFoundLoader{},
+		Config:        runtimeconfig.Config{},
+		Observability: newTestObservability(t),
+		Stdout:        stdout,
+		Stderr:        stderr,
+	})
+	if err == nil {
+		t.Fatal("expected non-Git copy-out root to be rejected")
+	}
+	if !strings.Contains(err.Error(), "requires a local Git repository checkout") {
+		t.Fatalf("expected local Git checkout error, got %v", err)
+	}
+	if executionCalled {
+		t.Fatal("expected copy-out to fail before sandbox planning execution")
+	}
+}
+
+func TestWorkspaceCopyOutDryRunRejectsMismatchedLocalRepository(t *testing.T) {
+	localRoot := initGitRepository(t, "https://github.com/buildkite/not-cleanroom.git")
+	adapter := &integrationAdapter{}
+	host, _ := startIntegrationServer(t, adapter)
+	sandboxID := createWorkspaceCopyTestSandboxWithRepository(t, host, "/sandbox-workspace")
+
+	var executionCalled bool
+	adapter.runStreamFn = func(_ context.Context, _ backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
+		executionCalled = true
+		return &backend.ExecutionResult{ExitCode: 0, Message: "ok"}, nil
+	}
+
+	stdout, _ := makeStdoutCapture(t)
+	stderr, _ := makeStdoutCapture(t)
+	cmd := WorkspaceCopyOutCommand{
+		clientFlags: clientFlags{Host: host},
+		Chdir:       localRoot,
+		DryRun:      true,
+		SandboxID:   sandboxID,
+	}
+	err := cmd.Run(&runtimeContext{
+		CWD:           localRoot,
+		Loader:        repositoryNotFoundLoader{},
+		Config:        runtimeconfig.Config{},
+		Observability: newTestObservability(t),
+		Stdout:        stdout,
+		Stderr:        stderr,
+	})
+	if err == nil {
+		t.Fatal("expected mismatched local repository to be rejected")
+	}
+	if !strings.Contains(err.Error(), "does not match sandbox repository remote") {
+		t.Fatalf("expected repository mismatch error, got %v", err)
+	}
+	if executionCalled {
+		t.Fatal("expected copy-out to fail before sandbox planning execution")
+	}
+}
+
+func TestWorkspaceDiffStreamsSandboxGitDiff(t *testing.T) {
+	diff := []byte("diff --git a/changed.txt b/changed.txt\n+changed\n")
+	adapter := &integrationAdapter{}
+	host, _ := startIntegrationServer(t, adapter)
+	sandboxID := createWorkspaceCopyTestSandboxWithRepository(t, host, "/sandbox-workspace")
+
+	var (
+		mu       sync.Mutex
+		commands [][]string
+	)
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+		mu.Lock()
+		commands = append(commands, append([]string(nil), req.Command...))
+		mu.Unlock()
+		if stream.OnStdout != nil {
+			stream.OnStdout(diff)
+		}
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+	}
+
+	stdout, stdoutText := makeStdoutCapture(t)
+	stderr, _ := makeStdoutCapture(t)
+	cmd := WorkspaceDiffCommand{
+		clientFlags: clientFlags{Host: host},
+		SandboxID:   sandboxID,
+	}
+	if err := cmd.Run(&runtimeContext{
+		CWD:           t.TempDir(),
+		Config:        runtimeconfig.Config{},
+		Observability: newTestObservability(t),
+		Stdout:        stdout,
+		Stderr:        stderr,
+	}); err != nil {
+		t.Fatalf("WorkspaceDiffCommand.Run returned error: %v", err)
+	}
+	if got := stdoutText(); got != string(diff) {
+		t.Fatalf("unexpected workspace diff output: got %q want %q", got, diff)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(commands) != 1 {
+		t.Fatalf("expected one workspace diff execution, got %d", len(commands))
+	}
+	diffCommand := strings.Join(commands[0], " ")
+	if !strings.Contains(diffCommand, "dest='/sandbox-workspace'") {
+		t.Fatalf("expected workspace diff to use sandbox workspace root, got %q", diffCommand)
+	}
+	if !strings.Contains(diffCommand, "diff --cached --binary --full-index") {
+		t.Fatalf("expected workspace diff to use git binary diff, got %q", diffCommand)
 	}
 }
 

--- a/internal/repositorychangeset/changeset.go
+++ b/internal/repositorychangeset/changeset.go
@@ -362,6 +362,14 @@ func ResetCommand(checkout *repositorycheckout.Checkout) []string {
 	return []string{"sh", "-lc", strings.Join(script, "\n")}
 }
 
+func WorktreeDiffCommand(checkout *repositorycheckout.Checkout) []string {
+	return worktreeChangesCommand(checkout, `GIT_INDEX_FILE="$index_file" git -C "$dest" diff --cached --binary --full-index --no-ext-diff --no-color --no-renames "$base_commit"`)
+}
+
+func WorktreeNameStatusCommand(checkout *repositorycheckout.Checkout) []string {
+	return worktreeChangesCommand(checkout, `GIT_INDEX_FILE="$index_file" git -C "$dest" diff --cached --name-status --no-renames -z "$base_commit"`)
+}
+
 func applyCommand(checkout *repositorycheckout.Checkout, changeset *Changeset, resetCheckout bool) []string {
 	if checkout == nil || changeset == nil {
 		return nil
@@ -391,6 +399,37 @@ func applyCommand(checkout *repositorycheckout.Checkout, changeset *Changeset, r
 		`got_tree="$(GIT_INDEX_FILE="$index_file" git -C "$dest" write-tree)"`,
 		`if [ "$got_tree" != "$expected_tree" ]; then echo "repository changeset tree mismatch: expected $expected_tree got $got_tree" >&2; exit 1; fi`,
 	)
+	return []string{"sh", "-lc", strings.Join(script, "\n")}
+}
+
+func worktreeChangesCommand(checkout *repositorycheckout.Checkout, emit string) []string {
+	if checkout == nil {
+		return nil
+	}
+	baseCommitSHA := strings.ToLower(strings.TrimSpace(checkout.CommitSHA))
+	if baseCommitSHA == "" || strings.TrimSpace(checkout.DestinationDir) == "" || strings.TrimSpace(emit) == "" {
+		return nil
+	}
+	script := []string{
+		"set -eu",
+		"dest=" + shellQuote(checkout.DestinationDir),
+		"base_commit=" + shellQuote(baseCommitSHA),
+		`if [ ! -d "$dest/.git" ]; then echo "repository destination is not a git checkout: $dest" >&2; exit 1; fi`,
+		`status_file="$(mktemp)"`,
+		`index_file="$(mktemp)"`,
+		`raw_file="$(mktemp)"`,
+		`cleanup() { rm -f "$status_file" "$index_file" "$raw_file"; }`,
+		`trap cleanup EXIT INT TERM`,
+		`git -C "$dest" status --porcelain=v2 --ignore-submodules=none >"$status_file"`,
+		`dirty_submodule="$(awk '($1 == "1" || $1 == "2") && length($3) == 4 && substr($3, 1, 1) == "S" && (substr($3, 3, 1) != "." || substr($3, 4, 1) != ".") { print $NF; exit }' "$status_file")"`,
+		`if [ -n "$dirty_submodule" ]; then echo "repository changeset cannot represent dirty submodule worktree $dirty_submodule; commit the submodule change or clean it first" >&2; exit 1; fi`,
+		`GIT_INDEX_FILE="$index_file" git -C "$dest" read-tree "$base_commit"`,
+		`GIT_INDEX_FILE="$index_file" git -C "$dest" add -A --all .`,
+		`GIT_INDEX_FILE="$index_file" git -C "$dest" diff --cached --raw --no-renames "$base_commit" >"$raw_file"`,
+		`gitlink_path="$(awk '($1 == ":160000" || $2 == "160000") { print $NF; exit }' "$raw_file")"`,
+		`if [ -n "$gitlink_path" ]; then echo "repository changeset cannot represent submodule gitlink change(s): $gitlink_path; commit and push the submodule update, or apply it manually inside the sandbox" >&2; exit 1; fi`,
+		emit,
+	}
 	return []string{"sh", "-lc", strings.Join(script, "\n")}
 }
 

--- a/internal/repositorychangeset/changeset_test.go
+++ b/internal/repositorychangeset/changeset_test.go
@@ -322,6 +322,133 @@ func TestResetCommandsUseDoubleForceClean(t *testing.T) {
 	}
 }
 
+func TestWorktreeNameStatusCommandReportsWorkingTreeChanges(t *testing.T) {
+	repoDir := initGitRepository(t)
+	if err := os.WriteFile(filepath.Join(repoDir, ".gitignore"), []byte("ignored/\n"), 0o644); err != nil {
+		t.Fatalf("write gitignore: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, "removed.txt"), []byte("remove me\n"), 0o644); err != nil {
+		t.Fatalf("write removed file: %v", err)
+	}
+	runGit(t, repoDir, "add", ".gitignore", "removed.txt")
+	runGit(t, repoDir, "commit", "-m", "add fixtures")
+	base := headCommit(t, repoDir)
+
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("changed\n"), 0o644); err != nil {
+		t.Fatalf("rewrite readme: %v", err)
+	}
+	if err := os.Remove(filepath.Join(repoDir, "removed.txt")); err != nil {
+		t.Fatalf("remove tracked file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, "new.txt"), []byte("new\n"), 0o644); err != nil {
+		t.Fatalf("write new file: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(repoDir, "ignored"), 0o755); err != nil {
+		t.Fatalf("create ignored dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, "ignored", "output.txt"), []byte("ignored\n"), 0o644); err != nil {
+		t.Fatalf("write ignored file: %v", err)
+	}
+
+	command := WorktreeNameStatusCommand(&repositorycheckout.Checkout{
+		CommitSHA:      base,
+		DestinationDir: repoDir,
+	})
+	out := runShellCommand(t, command)
+	for _, want := range []string{
+		"M\x00README.md\x00",
+		"D\x00removed.txt\x00",
+		"A\x00new.txt\x00",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected name-status output to contain %q, got %q", want, out)
+		}
+	}
+	if strings.Contains(out, "ignored") {
+		t.Fatalf("expected ignored files to stay out of name-status output, got %q", out)
+	}
+}
+
+func TestWorktreeChangesCommandsRejectDirtySubmoduleWorktree(t *testing.T) {
+	submoduleDir := initGitRepository(t)
+	superDir := t.TempDir()
+	runGit(t, superDir, "init")
+	runGit(t, superDir, "config", "user.name", "Cleanroom Test")
+	runGit(t, superDir, "config", "user.email", "cleanroom-test@example.com")
+	runGitWithEnv(t, superDir, []string{"GIT_ALLOW_PROTOCOL=file"}, "-c", "protocol.file.allow=always", "submodule", "add", submoduleDir, "deps/sub")
+	runGit(t, superDir, "commit", "-m", "add submodule")
+	base := headCommit(t, superDir)
+
+	if err := os.WriteFile(filepath.Join(superDir, "deps/sub/README.md"), []byte("dirty submodule\n"), 0o644); err != nil {
+		t.Fatalf("rewrite submodule readme: %v", err)
+	}
+
+	checkout := &repositorycheckout.Checkout{
+		CommitSHA:      base,
+		DestinationDir: superDir,
+		Submodules:     true,
+	}
+	for _, tc := range []struct {
+		name    string
+		command []string
+	}{
+		{name: "name-status", command: WorktreeNameStatusCommand(checkout)},
+		{name: "diff", command: WorktreeDiffCommand(checkout)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := runShellCommandResult(t, tc.command)
+			if err == nil {
+				t.Fatalf("expected dirty submodule worktree error, got output %q", out)
+			}
+			if !strings.Contains(out, "dirty submodule worktree") {
+				t.Fatalf("expected dirty submodule worktree error, got %v\n%s", err, out)
+			}
+		})
+	}
+}
+
+func TestWorktreeChangesCommandsRejectSubmoduleGitlinkChange(t *testing.T) {
+	submoduleDir := initGitRepository(t)
+	superDir := t.TempDir()
+	runGit(t, superDir, "init")
+	runGit(t, superDir, "config", "user.name", "Cleanroom Test")
+	runGit(t, superDir, "config", "user.email", "cleanroom-test@example.com")
+	runGitWithEnv(t, superDir, []string{"GIT_ALLOW_PROTOCOL=file"}, "-c", "protocol.file.allow=always", "submodule", "add", submoduleDir, "deps/sub")
+	runGit(t, superDir, "commit", "-m", "add submodule")
+	base := headCommit(t, superDir)
+
+	if err := os.WriteFile(filepath.Join(superDir, "deps/sub/README.md"), []byte("advanced submodule\n"), 0o644); err != nil {
+		t.Fatalf("rewrite submodule readme: %v", err)
+	}
+	runGit(t, filepath.Join(superDir, "deps/sub"), "add", "README.md")
+	runGit(t, filepath.Join(superDir, "deps/sub"), "config", "user.name", "Cleanroom Test")
+	runGit(t, filepath.Join(superDir, "deps/sub"), "config", "user.email", "cleanroom-test@example.com")
+	runGit(t, filepath.Join(superDir, "deps/sub"), "commit", "-m", "advance submodule")
+
+	checkout := &repositorycheckout.Checkout{
+		CommitSHA:      base,
+		DestinationDir: superDir,
+		Submodules:     true,
+	}
+	for _, tc := range []struct {
+		name    string
+		command []string
+	}{
+		{name: "name-status", command: WorktreeNameStatusCommand(checkout)},
+		{name: "diff", command: WorktreeDiffCommand(checkout)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := runShellCommandResult(t, tc.command)
+			if err == nil {
+				t.Fatalf("expected submodule gitlink error, got output %q", out)
+			}
+			if !strings.Contains(out, "submodule gitlink change") {
+				t.Fatalf("expected submodule gitlink error, got %v\n%s", err, out)
+			}
+		})
+	}
+}
+
 func initGitRepository(t *testing.T) string {
 	t.Helper()
 
@@ -361,6 +488,25 @@ func bytesContainAll(haystack []byte, needles ...[]byte) bool {
 func runGit(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 	return runGitWithEnv(t, dir, nil, args...)
+}
+
+func runShellCommand(t *testing.T, command []string) string {
+	t.Helper()
+	out, err := runShellCommandResult(t, command)
+	if err != nil {
+		t.Fatalf("command %v failed: %v\n%s", command, err, out)
+	}
+	return out
+}
+
+func runShellCommandResult(t *testing.T, command []string) (string, error) {
+	t.Helper()
+	if len(command) == 0 {
+		t.Fatal("missing command")
+	}
+	cmd := exec.Command(command[0], command[1:]...)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
 }
 
 func runGitWithEnv(t *testing.T, dir string, env []string, args ...string) string {


### PR DESCRIPTION
## Summary

Adds the read-only foundation for workspace copy-out on top of the copy-in work from PR #251:

- add `cleanroom workspace diff` for Git-backed sandboxes
- add `cleanroom workspace copy-out --dry-run` for Git-backed sandboxes
- resolve copy-out planning from the sandbox's recorded repository checkout and local matching Git checkout
- fail closed for unsupported submodule states instead of emitting incomplete diff/copy-out plans
- update the workspace sync plan with the landed and remaining slices

Actual local copy-out writes, local binding metadata, recoverable payloads, top-level `--copy-out`, and `--sync` remain follow-up work.

## Validation

- `mise exec -- go test ./internal/repositorychangeset -run 'TestWorktreeNameStatusCommandReportsWorkingTreeChanges|TestWorktreeChangesCommandsRejectDirtySubmoduleWorktree|TestWorktreeChangesCommandsRejectSubmoduleGitlinkChange' -count=1 -v`
- `mise exec -- go test ./internal/cli ./internal/repositorychangeset`
- `mise exec -- go test ./...`
- `git diff --check`