### PR TITLE
feat: Add system storage prune commands

### DIFF
--- a/docs/plans/system-storage-prune.md
+++ b/docs/plans/system-storage-prune.md
@@ -1,0 +1,189 @@
+# System Storage Prune Plan
+
+**Related plan:** `docs/plans/layered-caching.md`
+**Status:** In progress
+**Last reviewed:** 2026-05-03
+
+## Summary
+
+Add a backend-agnostic storage inventory and prune workflow for host-side cleanroom state. The user-facing shape should feel like `docker system df` and `docker system prune`: first show where disk is going, then reclaim storage that cleanroom can prove is no longer referenced.
+
+The immediate problem is orphaned host state. A local inspection showed `~/.local/state/cleanroom` at 471 GiB, with 360 GiB under `snapshots` and 109 GiB under `sandboxes`, while the snapshot metadata database reported zero tracked snapshots and `cleanroom sandbox ls --all` showed only one stopped sandbox. That means happy-path cleanup exists, but we need a way to discover and remove state that was left behind by crashes, old daemon versions, interrupted runs, or manual experimentation.
+
+## Goals
+
+- Provide `cleanroom system df` to summarize cleanroom-owned disk usage by category.
+- Provide `cleanroom system prune` to remove reclaimable host storage safely.
+- Preserve explicit user artifacts by default, especially named snapshots, images, repository mirrors, and content-cache blobs.
+- Treat backend storage as an implementation detail; CLI flags and JSON output should describe cleanroom concepts rather than APFS, ext4, or VZ internals.
+- Make dry-run output exact enough that users can see the paths, ids, byte counts, and reasons before deletion.
+- Let future cleanup paths share one inventory model instead of adding independent ad hoc prune commands.
+
+## Non-Goals
+
+- Do not add background deletion in the first slice. The initial workflow is explicit and user initiated.
+- Do not delete explicit snapshots by default. Users should opt in with `--all` or a snapshot-specific command.
+- Do not blindly remove content-cache storage while the gateway may be using it.
+- Do not make cache policy part of `cleanroom.yaml`. This is host maintenance, not project policy.
+- Do not depend on sandbox id naming conventions such as old `cr_` or newer `cr-` prefixes.
+
+## Command Model
+
+Add a new `system` command group:
+
+```console
+cleanroom system df [--json]
+cleanroom system prune [--dry-run] [--force] [--older-than duration] [--all]
+```
+
+`system df` prints a grouped inventory:
+
+- Total bytes by category.
+- Reclaimable bytes by category.
+- Protected bytes by category.
+- A short reason for protected entries when verbose or JSON output is requested.
+
+`system prune` defaults to a conservative reclaim set:
+
+- Orphan sandbox runtime directories not present in daemon state.
+- Orphan backend snapshot directories not referenced by snapshot metadata or stage-cache metadata.
+- Old execution artifacts that exceed the existing service retention window.
+- Stale prepared runtime rootfs cache entries when they are not the current runtime key.
+
+`system prune --all` expands the candidate set to system-managed caches:
+
+- Stage-cache snapshots that are not currently referenced by a live sandbox.
+- Pulled or imported image cache entries that are not currently used.
+- Repository mirrors and content-cache storage only when the implementation can prune through the owning component safely, or when the daemon is stopped and the command can prove exclusive access.
+
+Without `--force`, `system prune` should prompt on TTY and refuse on non-TTY. `--dry-run` never deletes and should be the recommended first command in docs and error hints.
+
+## Storage Categories
+
+| Category | Primary Path | Owner | Default Prune |
+| --- | --- | --- | --- |
+| Sandbox runtime dirs | `StateBaseDir()/sandboxes` | Backend adapters | Orphans only |
+| Explicit snapshots | `StateBaseDir()/snapshots` plus `snapshotstore` | Snapshot service | No |
+| Stage-cache snapshots | `StateBaseDir()/snapshots` plus `cachestore` | Dependency cache | Only with policy or `--all` |
+| Images | `CacheBaseDir()/images` plus image metadata in state | Image manager | No |
+| Runtime rootfs cache | `CacheBaseDir()/<backend>/runtime-rootfs` | Backend adapters | Stale entries |
+| Repository mirrors | `StateBaseDir()/repos` | Git gateway | No |
+| Content cache | `CacheBaseDir()/content-cache` | Content-cache gateway | No |
+| Execution artifacts | `StateBaseDir()/executions` | Control service | Old retained artifacts |
+| Changesets | `StateBaseDir()/changesets` | Changeset store | No |
+
+The important distinction is between immutable byte reuse and guest-prepared state reuse. Content-cache and repository mirrors speed up transferring source bytes into cleanroom. Stage-cache snapshots and runtime rootfs caches are prepared guest state. Pruning one should not imply pruning the other.
+
+## Inventory Model
+
+Introduce a small internal package, for example `internal/storagegc`, that owns inventory and prune planning:
+
+```go
+type Entry struct {
+    Kind        string
+    ID          string
+    Backend     string
+    Path        string
+    StorageRef  string
+    SizeBytes   int64
+    Reclaimable bool
+    Reason      string
+    ProtectedBy []string
+    CreatedAt   time.Time
+    LastUsedAt  time.Time
+}
+
+type Report struct {
+    Entries []Entry
+    Totals  map[string]CategoryTotal
+}
+```
+
+The package should expose three phases:
+
+- `Inventory`: read daemon state, metadata stores, runtime config, and known storage roots.
+- `PlanPrune`: apply the selected retention policy and produce ordered delete actions.
+- `ExecutePrune`: perform deletes through typed owners where possible and raw filesystem deletes only for proven orphans.
+
+This keeps `internal/cli/system.go` small and makes the core behavior testable without invoking the CLI.
+
+## Protection Rules
+
+The inventory should build a reference set before considering deletion:
+
+- Live daemon sandbox ids from the control service protect matching sandbox runtime directories.
+- Explicit snapshot records from `snapshotstore.List` protect their `StorageRef`.
+- Stage-cache records from `cachestore.List` protect their backing snapshot storage unless the prune policy explicitly includes stage caches.
+- Known image records protect image filesystem layers and metadata.
+- The currently selected backend runtime rootfs key protects the matching prepared runtime rootfs file.
+- Recent execution artifacts remain protected according to the existing control-service retention settings.
+
+Entries that are missing metadata but live under a cleanroom-owned root can become orphan candidates. Entries outside known cleanroom roots should never be deleted by this command.
+
+## Deletion Rules
+
+Use typed deletion paths when metadata exists:
+
+- Stage-cache records should be deleted through `cachestore.Delete` and the owning volume store deletion path.
+- Explicit snapshots should be deleted only by snapshot-specific commands or `system prune --all --snapshots`, through `snapshotstore.Delete` and the owning volume store.
+- Images should be deleted through the image manager.
+
+Use raw filesystem deletion only when all of these are true:
+
+- The path is under a known cleanroom state or cache root.
+- No metadata store references it.
+- No live daemon state references it.
+- The directory shape matches a storage category scanner owns.
+
+This is what lets us clean up abandoned directories from older versions without teaching every historical format to the current metadata stores.
+
+## Implementation Slices
+
+1. Add `cleanroom system df --json` with inventory only.
+   - Add `System SystemCommand` to the CLI root.
+   - Scan known roots and metadata stores.
+   - Report protected and reclaimable bytes without deleting anything.
+   - Add tests using temporary XDG state, cache, and data directories.
+
+2. Add conservative `cleanroom system prune`.
+   - Support `--dry-run`, `--force`, and TTY confirmation.
+   - Delete only orphan sandbox runtime dirs, orphan snapshot dirs, stale runtime rootfs files, and old execution artifacts.
+   - Keep raw filesystem deletion limited to proven orphan paths.
+
+3. Add policy-backed cache pruning.
+   - Support `--older-than` for stage caches and runtime rootfs caches.
+   - Touch stage-cache records on restore so age-based pruning reflects actual reuse.
+   - Prefer count or byte-limit internals later, but keep the first public interface duration-based.
+
+4. Add explicit `--all` expansion.
+   - Include image cache pruning through the image manager.
+   - Include repository and content-cache pruning only via safe owner APIs or offline-only checks.
+   - Print a stronger confirmation prompt that names the expanded categories.
+
+5. Add automatic cleanup hooks after the explicit command is proven.
+   - On daemon startup, mark obvious orphan entries for later pruning but do not delete immediately.
+   - After sandbox termination, opportunistically remove runtime dirs that belong to the terminated sandbox.
+   - Consider a bounded background prune for system-managed caches only after the manual command has telemetry and tests.
+
+## Tests
+
+- Inventory reports byte totals for every known category.
+- Referenced snapshot and stage-cache storage is protected.
+- Unreferenced snapshot directories under the backend snapshot root are reclaimable.
+- Active sandbox runtime directories are protected even if their filesystem metadata is stale.
+- Orphan sandbox runtime directories are reclaimable without relying on id prefix format.
+- `system prune --dry-run` returns the same planned actions without deleting paths.
+- `system prune` refuses to delete in non-interactive mode without `--force`.
+- Raw filesystem deletion refuses paths outside cleanroom-owned roots.
+- JSON output is stable enough for scripts and future UI use.
+
+## Open Questions
+
+- Should the default `system prune` include stopped but still known sandboxes, or only unknown orphan sandbox directories? The safest first slice is unknown orphans only.
+- Should explicit snapshot pruning live under `system prune --all --snapshots`, or should it remain only under `cleanroom snapshot rm`? Keeping it snapshot-specific is less surprising.
+- Should content-cache get its own owner-level prune API first? That is preferable before exposing content-cache deletion through `system prune --all`.
+- Should automatic cleanup run in the daemon or remain a CLI-initiated maintenance command? The explicit command should come first so the deletion model is observable and testable.
+
+## Recommended First Slice
+
+Build `cleanroom system df --json` and `cleanroom system prune --dry-run` first. That gives immediate visibility into disk use and validates the reference graph without risking deletion. Once the dry-run output correctly identifies the current orphan snapshot and sandbox storage, enable conservative deletion behind `--force`.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -70,6 +70,7 @@ type CLI struct {
 	Execution   ExecutionCommand   `cmd:"" help:"Inspect command executions and diagnostics"`
 	Status      StatusCommand      `cmd:"" help:"Browse retained execution artifacts"`
 	Sandbox     SandboxCommand     `cmd:"" help:"Manage sandboxes"`
+	System      SystemCommand      `cmd:"" help:"Inspect and prune host storage"`
 	Version     VersionCommand     `cmd:"" help:"Print version information"`
 }
 

--- a/internal/cli/cli_parse_test.go
+++ b/internal/cli/cli_parse_test.go
@@ -174,6 +174,39 @@ func TestSandboxCreateParses(t *testing.T) {
 	}
 }
 
+func TestSystemCommandsParse(t *testing.T) {
+	c := &CLI{}
+	parser := newParserForTest(t, c)
+
+	if _, err := parser.Parse([]string{"system", "df", "--json"}); err != nil {
+		t.Fatalf("parse system df returned error: %v", err)
+	}
+	if !c.System.DF.JSON {
+		t.Fatal("expected system df --json flag to be set")
+	}
+
+	c = &CLI{}
+	parser = newParserForTest(t, c)
+	if _, err := parser.Parse([]string{"system", "prune", "--dry-run", "--all", "--table", "--json", "--older-than", "7d"}); err != nil {
+		t.Fatalf("parse system prune returned error: %v", err)
+	}
+	if !c.System.Prune.DryRun {
+		t.Fatal("expected system prune --dry-run flag to be set")
+	}
+	if !c.System.Prune.All {
+		t.Fatal("expected system prune --all flag to be set")
+	}
+	if !c.System.Prune.Table {
+		t.Fatal("expected system prune --table flag to be set")
+	}
+	if !c.System.Prune.JSON {
+		t.Fatal("expected system prune --json flag to be set")
+	}
+	if got, want := c.System.Prune.OlderThan, "7d"; got != want {
+		t.Fatalf("unexpected older-than: got %q want %q", got, want)
+	}
+}
+
 func TestSandboxCreateRejectsExposureFlags(t *testing.T) {
 	c := &CLI{}
 	parser := newParserForTest(t, c)

--- a/internal/cli/system.go
+++ b/internal/cli/system.go
@@ -1,0 +1,381 @@
+package cli
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+	"github.com/buildkite/cleanroom/internal/storagegc"
+	"golang.org/x/term"
+)
+
+type SystemCommand struct {
+	DF    SystemDFCommand    `name:"df" cmd:"" help:"Show cleanroom host storage usage"`
+	Prune SystemPruneCommand `name:"prune" cmd:"" help:"Remove reclaimable cleanroom host storage"`
+}
+
+type SystemDFCommand struct {
+	clientFlags
+	JSON bool `help:"Print storage inventory as JSON"`
+}
+
+type SystemPruneCommand struct {
+	clientFlags
+	DryRun    bool   `name:"dry-run" help:"Show what would be removed without deleting anything"`
+	Force     bool   `help:"Do not prompt before deleting"`
+	All       bool   `help:"Include system-managed caches such as stage caches, runtime rootfs caches, and image caches"`
+	Table     bool   `help:"Print every prune action as a table"`
+	JSON      bool   `help:"Print prune plan and result as JSON"`
+	OlderThan string `name:"older-than" help:"Include eligible cache entries older than this duration (for example 24h or 7d)"`
+}
+
+var systemInventory = storagegc.Inventory
+var systemPlanPrune = storagegc.PlanPrune
+var systemExecutePrune = storagegc.ExecutePrune
+var systemIsTerminal = func(f *os.File) bool {
+	return f != nil && term.IsTerminal(int(f.Fd()))
+}
+
+func (c *SystemDFCommand) Run(ctx *runtimeContext) error {
+	report, warning, err := loadSystemInventory(context.Background(), ctx, c.clientFlags, false, 0)
+	if err != nil {
+		return err
+	}
+	if warning != nil {
+		_, _ = fmt.Fprintf(ctx.stderr(), "warning: %v\n", warning)
+	}
+	if c.JSON {
+		enc := json.NewEncoder(stdout(ctx))
+		enc.SetIndent("", "  ")
+		return enc.Encode(report)
+	}
+	return writeSystemDF(stdout(ctx), report)
+}
+
+func (c *SystemPruneCommand) Run(ctx *runtimeContext) error {
+	olderThan, err := parseSystemPruneDuration(c.OlderThan)
+	if err != nil {
+		return err
+	}
+	report, _, err := loadSystemInventory(context.Background(), ctx, c.clientFlags, true, olderThan)
+	if err != nil {
+		return err
+	}
+	plan := systemPlanPrune(report, storagegc.PruneOptions{
+		All:       c.All,
+		OlderThan: olderThan,
+		Now:       report.GeneratedAt,
+	})
+	if c.JSON && c.DryRun {
+		return writeSystemPruneJSON(stdout(ctx), plan, true, nil)
+	}
+	if len(plan.Actions) == 0 {
+		if c.JSON {
+			return writeSystemPruneJSON(stdout(ctx), plan, c.DryRun, nil)
+		}
+		_, err := fmt.Fprintln(stdout(ctx), "nothing to prune")
+		return err
+	}
+
+	if c.DryRun {
+		if c.Table {
+			return writeSystemPruneTable(stdout(ctx), plan, "would reclaim")
+		}
+		return writeSystemPruneSummary(stdout(ctx), plan, true)
+	}
+	if !c.Force {
+		if err := confirmSystemPrune(ctx.stderr(), os.Stdin, len(plan.Actions), plan.ReclaimableBytes); err != nil {
+			return err
+		}
+	}
+
+	result, err := systemExecutePrune(context.Background(), report, plan, storagegc.ExecuteOptions{})
+	if err != nil {
+		return err
+	}
+	if c.JSON {
+		return writeSystemPruneJSON(stdout(ctx), plan, false, &result)
+	}
+	if c.Table {
+		return writeSystemPruneTable(stdout(ctx), plan, "reclaimed")
+	}
+	_, err = fmt.Fprintf(stdout(ctx), "reclaimed %s from %d entries\n", formatStorageBytes(result.ReclaimedBytes), result.DeletedEntries)
+	return err
+}
+
+func loadSystemInventory(ctx context.Context, runtimeCtx *runtimeContext, flags clientFlags, requireSandboxState bool, executionMaxAge time.Duration) (storagegc.Report, error, error) {
+	sandboxIDs, stateKnown, listErr := listSystemSandboxIDs(ctx, runtimeCtx, flags)
+	if listErr != nil && requireSandboxState {
+		return storagegc.Report{}, nil, fmt.Errorf("list sandboxes before prune: %w", listErr)
+	}
+	if executionMaxAge <= 0 {
+		executionMaxAge = storagegc.DefaultExecutionMaxAge
+	}
+	report, err := systemInventory(ctx, storagegc.InventoryOptions{
+		Config:            runtimeCtx.Config,
+		ActiveSandboxIDs:  sandboxIDs,
+		SandboxStateKnown: stateKnown,
+		ExecutionMaxAge:   executionMaxAge,
+	})
+	if err != nil {
+		return storagegc.Report{}, nil, err
+	}
+	return report, listErr, nil
+}
+
+func listSystemSandboxIDs(ctx context.Context, runtimeCtx *runtimeContext, flags clientFlags) ([]string, bool, error) {
+	client, err := flags.connect(runtimeCtx)
+	if err != nil {
+		return nil, false, err
+	}
+	resp, err := client.ListSandboxes(ctx, &cleanroomv1.ListSandboxesRequest{})
+	if err != nil {
+		return nil, false, err
+	}
+	ids := make([]string, 0, len(resp.GetSandboxes()))
+	for _, sandbox := range resp.GetSandboxes() {
+		id := strings.TrimSpace(sandbox.GetSandboxId())
+		if id != "" {
+			ids = append(ids, id)
+		}
+	}
+	return ids, true, nil
+}
+
+func writeSystemDF(w io.Writer, report storagegc.Report) error {
+	if len(report.Entries) == 0 {
+		_, err := fmt.Fprintln(w, "no cleanroom storage found")
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "state: %s\ncache: %s\n", report.StateBaseDir, report.CacheBaseDir); err != nil {
+		return err
+	}
+	tw := tabwriter.NewWriter(w, 0, 2, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "CATEGORY\tITEMS\tTOTAL\tRECLAIMABLE\tPROTECTED"); err != nil {
+		return err
+	}
+	for _, kind := range sortedTotalKinds(report.Totals) {
+		total := report.Totals[kind]
+		if _, err := fmt.Fprintf(
+			tw,
+			"%s\t%d\t%s\t%s\t%s\n",
+			kind,
+			total.Count,
+			formatStorageBytes(total.TotalBytes),
+			formatStorageBytes(total.ReclaimableBytes),
+			formatStorageBytes(total.ProtectedBytes),
+		); err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
+}
+
+type systemPruneSummaryRow struct {
+	Kind             string `json:"kind"`
+	Count            int    `json:"count"`
+	ReclaimableBytes int64  `json:"reclaimable_bytes"`
+}
+
+type systemPruneJSONOutput struct {
+	DryRun           bool                    `json:"dry_run"`
+	ReclaimableBytes int64                   `json:"reclaimable_bytes"`
+	Entries          int                     `json:"entries"`
+	Summary          []systemPruneSummaryRow `json:"summary"`
+	Actions          []storagegc.Action      `json:"actions"`
+	Result           *storagegc.Result       `json:"result,omitempty"`
+}
+
+func writeSystemPruneSummary(w io.Writer, plan storagegc.Plan, dryRun bool) error {
+	verb := "will reclaim"
+	if dryRun {
+		verb = "would reclaim"
+	}
+	if _, err := fmt.Fprintf(w, "%s %s from %d entries\n", verb, formatStorageBytes(plan.ReclaimableBytes), len(plan.Actions)); err != nil {
+		return err
+	}
+	tw := tabwriter.NewWriter(w, 0, 2, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "KIND\tITEMS\tRECLAIMABLE"); err != nil {
+		return err
+	}
+	for _, row := range summarizePrunePlan(plan) {
+		if _, err := fmt.Fprintf(tw, "%s\t%d\t%s\n", row.Kind, row.Count, formatStorageBytes(row.ReclaimableBytes)); err != nil {
+			return err
+		}
+	}
+	if err := tw.Flush(); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "Use --table to show every path, or --json for machine-readable details."); err != nil {
+		return err
+	}
+	return nil
+}
+
+func writeSystemPruneTable(w io.Writer, plan storagegc.Plan, verb string) error {
+	if _, err := fmt.Fprintf(w, "%s %s from %d entries\n", verb, formatStorageBytes(plan.ReclaimableBytes), len(plan.Actions)); err != nil {
+		return err
+	}
+	tw := tabwriter.NewWriter(w, 0, 2, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "KIND\tID\tSIZE\tREASON\tPATH"); err != nil {
+		return err
+	}
+	for _, action := range sortedPruneActions(plan.Actions) {
+		if _, err := fmt.Fprintf(
+			tw,
+			"%s\t%s\t%s\t%s\t%s\n",
+			action.Kind,
+			action.ID,
+			formatStorageBytes(action.SizeBytes),
+			action.Reason,
+			action.Path,
+		); err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
+}
+
+func writeSystemPruneJSON(w io.Writer, plan storagegc.Plan, dryRun bool, result *storagegc.Result) error {
+	actions := plan.Actions
+	if actions == nil {
+		actions = []storagegc.Action{}
+	}
+	summary := summarizePrunePlan(plan)
+	if summary == nil {
+		summary = []systemPruneSummaryRow{}
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(systemPruneJSONOutput{
+		DryRun:           dryRun,
+		ReclaimableBytes: plan.ReclaimableBytes,
+		Entries:          len(actions),
+		Summary:          summary,
+		Actions:          actions,
+		Result:           result,
+	})
+}
+
+func summarizePrunePlan(plan storagegc.Plan) []systemPruneSummaryRow {
+	rowsByKind := map[string]systemPruneSummaryRow{}
+	for _, action := range plan.Actions {
+		row := rowsByKind[action.Kind]
+		row.Kind = action.Kind
+		row.Count++
+		row.ReclaimableBytes += action.SizeBytes
+		rowsByKind[action.Kind] = row
+	}
+	rows := make([]systemPruneSummaryRow, 0, len(rowsByKind))
+	for _, row := range rowsByKind {
+		rows = append(rows, row)
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].ReclaimableBytes == rows[j].ReclaimableBytes {
+			return rows[i].Kind < rows[j].Kind
+		}
+		return rows[i].ReclaimableBytes > rows[j].ReclaimableBytes
+	})
+	return rows
+}
+
+func sortedPruneActions(actions []storagegc.Action) []storagegc.Action {
+	out := append([]storagegc.Action(nil), actions...)
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].SizeBytes == out[j].SizeBytes {
+			if out[i].Kind == out[j].Kind {
+				return out[i].ID < out[j].ID
+			}
+			return out[i].Kind < out[j].Kind
+		}
+		return out[i].SizeBytes > out[j].SizeBytes
+	})
+	return out
+}
+
+func confirmSystemPrune(stderr *os.File, stdin *os.File, count int, bytes int64) error {
+	if !systemIsTerminal(stdin) {
+		return errors.New("refusing to prune without --force in non-interactive mode")
+	}
+	if _, err := fmt.Fprintf(stderr, "Prune %d cleanroom storage entries and reclaim %s? [y/N] ", count, formatStorageBytes(bytes)); err != nil {
+		return err
+	}
+	reader := bufio.NewReader(stdin)
+	line, err := reader.ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return err
+	}
+	answer := strings.ToLower(strings.TrimSpace(line))
+	if answer != "y" && answer != "yes" {
+		return errors.New("prune cancelled")
+	}
+	return nil
+}
+
+func parseSystemPruneDuration(value string) (time.Duration, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0, nil
+	}
+	if d, err := time.ParseDuration(value); err == nil {
+		if d < 0 {
+			return 0, errors.New("--older-than must be non-negative")
+		}
+		return d, nil
+	}
+	if strings.HasSuffix(value, "d") {
+		days, err := strconv.ParseFloat(strings.TrimSuffix(value, "d"), 64)
+		if err != nil {
+			return 0, fmt.Errorf("parse --older-than %q: %w", value, err)
+		}
+		if days < 0 {
+			return 0, errors.New("--older-than must be non-negative")
+		}
+		return time.Duration(days * float64(24*time.Hour)), nil
+	}
+	return 0, fmt.Errorf("parse --older-than %q: use Go duration syntax such as 24h or day syntax such as 7d", value)
+}
+
+func sortedTotalKinds(totals map[string]storagegc.CategoryTotal) []string {
+	kinds := make([]string, 0, len(totals))
+	for kind := range totals {
+		kinds = append(kinds, kind)
+	}
+	sort.Strings(kinds)
+	return kinds
+}
+
+func formatStorageBytes(bytes int64) string {
+	if bytes < 0 {
+		return "-" + formatStorageBytes(-bytes)
+	}
+	const unit = 1024
+	if bytes < unit {
+		return fmt.Sprintf("%d B", bytes)
+	}
+	value := float64(bytes)
+	for _, suffix := range []string{"KiB", "MiB", "GiB", "TiB", "PiB"} {
+		value /= unit
+		if value < unit {
+			return fmt.Sprintf("%.1f %s", value, suffix)
+		}
+	}
+	return fmt.Sprintf("%.1f EiB", value/unit)
+}
+
+func stdout(ctx *runtimeContext) *os.File {
+	if ctx != nil && ctx.Stdout != nil {
+		return ctx.Stdout
+	}
+	return os.Stdout
+}

--- a/internal/cli/system.go
+++ b/internal/cli/system.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"sort"
 	"strconv"
@@ -342,7 +343,11 @@ func parseSystemPruneDuration(value string) (time.Duration, error) {
 		if days < 0 {
 			return 0, errors.New("--older-than must be non-negative")
 		}
-		return time.Duration(days * float64(24*time.Hour)), nil
+		duration := days * float64(24*time.Hour)
+		if math.IsNaN(duration) || math.IsInf(duration, 0) || duration > float64(1<<63-1) {
+			return 0, fmt.Errorf("parse --older-than %q: duration is too large", value)
+		}
+		return time.Duration(duration), nil
 	}
 	return 0, fmt.Errorf("parse --older-than %q: use Go duration syntax such as 24h or day syntax such as 7d", value)
 }

--- a/internal/cli/system.go
+++ b/internal/cli/system.go
@@ -42,6 +42,7 @@ type SystemPruneCommand struct {
 var systemInventory = storagegc.Inventory
 var systemPlanPrune = storagegc.PlanPrune
 var systemExecutePrune = storagegc.ExecutePrune
+var systemListSandboxIDs = listSystemSandboxIDs
 var systemIsTerminal = func(f *os.File) bool {
 	return f != nil && term.IsTerminal(int(f.Fd()))
 }
@@ -67,7 +68,7 @@ func (c *SystemPruneCommand) Run(ctx *runtimeContext) error {
 	if err != nil {
 		return err
 	}
-	report, _, err := loadSystemInventory(context.Background(), ctx, c.clientFlags, true, olderThan)
+	report, _, err := loadSystemInventory(context.Background(), ctx, c.clientFlags, true, 0)
 	if err != nil {
 		return err
 	}
@@ -114,7 +115,7 @@ func (c *SystemPruneCommand) Run(ctx *runtimeContext) error {
 }
 
 func loadSystemInventory(ctx context.Context, runtimeCtx *runtimeContext, flags clientFlags, requireSandboxState bool, executionMaxAge time.Duration) (storagegc.Report, error, error) {
-	sandboxIDs, stateKnown, listErr := listSystemSandboxIDs(ctx, runtimeCtx, flags)
+	sandboxIDs, stateKnown, listErr := systemListSandboxIDs(ctx, runtimeCtx, flags)
 	if listErr != nil && requireSandboxState {
 		return storagegc.Report{}, nil, fmt.Errorf("list sandboxes before prune: %w", listErr)
 	}

--- a/internal/cli/system_test.go
+++ b/internal/cli/system_test.go
@@ -32,11 +32,11 @@ func TestParseSystemPruneDuration(t *testing.T) {
 }
 
 func TestParseSystemPruneDurationRejectsInvalidValue(t *testing.T) {
-	if _, err := parseSystemPruneDuration("soon"); err == nil {
-		t.Fatal("expected invalid duration to fail")
-	}
-	if _, err := parseSystemPruneDuration("-1h"); err == nil {
-		t.Fatal("expected negative duration to fail")
+	tests := []string{"soon", "-1h", "NaNd", "Infd", "1e100d"}
+	for _, input := range tests {
+		if _, err := parseSystemPruneDuration(input); err == nil {
+			t.Fatalf("expected %q to fail", input)
+		}
 	}
 }
 

--- a/internal/cli/system_test.go
+++ b/internal/cli/system_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -36,6 +37,45 @@ func TestParseSystemPruneDurationRejectsInvalidValue(t *testing.T) {
 	}
 	if _, err := parseSystemPruneDuration("-1h"); err == nil {
 		t.Fatal("expected negative duration to fail")
+	}
+}
+
+func TestSystemPruneOlderThanDoesNotOverrideExecutionRetention(t *testing.T) {
+	previousListSandboxIDs := systemListSandboxIDs
+	previousInventory := systemInventory
+	previousPlanPrune := systemPlanPrune
+	t.Cleanup(func() {
+		systemListSandboxIDs = previousListSandboxIDs
+		systemInventory = previousInventory
+		systemPlanPrune = previousPlanPrune
+	})
+
+	systemListSandboxIDs = func(context.Context, *runtimeContext, clientFlags) ([]string, bool, error) {
+		return nil, true, nil
+	}
+	var gotExecutionMaxAge time.Duration
+	systemInventory = func(_ context.Context, opts storagegc.InventoryOptions) (storagegc.Report, error) {
+		gotExecutionMaxAge = opts.ExecutionMaxAge
+		return storagegc.Report{GeneratedAt: time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)}, nil
+	}
+	var gotOlderThan time.Duration
+	systemPlanPrune = func(_ storagegc.Report, opts storagegc.PruneOptions) storagegc.Plan {
+		gotOlderThan = opts.OlderThan
+		return storagegc.Plan{}
+	}
+
+	stdout, _ := makeStdoutCapture(t)
+	t.Cleanup(func() { _ = stdout.Close() })
+
+	err := (&SystemPruneCommand{DryRun: true, OlderThan: "7d"}).Run(&runtimeContext{Stdout: stdout})
+	if err != nil {
+		t.Fatalf("SystemPruneCommand.Run returned error: %v", err)
+	}
+	if got, want := gotExecutionMaxAge, storagegc.DefaultExecutionMaxAge; got != want {
+		t.Fatalf("unexpected execution retention: got %s want %s", got, want)
+	}
+	if got, want := gotOlderThan, 7*24*time.Hour; got != want {
+		t.Fatalf("unexpected prune older-than: got %s want %s", got, want)
 	}
 }
 

--- a/internal/cli/system_test.go
+++ b/internal/cli/system_test.go
@@ -1,0 +1,168 @@
+package cli
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/buildkite/cleanroom/internal/storagegc"
+)
+
+func TestParseSystemPruneDuration(t *testing.T) {
+	tests := []struct {
+		input string
+		want  time.Duration
+	}{
+		{input: "", want: 0},
+		{input: "24h", want: 24 * time.Hour},
+		{input: "7d", want: 7 * 24 * time.Hour},
+		{input: "1.5d", want: 36 * time.Hour},
+	}
+	for _, tt := range tests {
+		got, err := parseSystemPruneDuration(tt.input)
+		if err != nil {
+			t.Fatalf("parseSystemPruneDuration(%q) returned error: %v", tt.input, err)
+		}
+		if got != tt.want {
+			t.Fatalf("parseSystemPruneDuration(%q) = %s, want %s", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestParseSystemPruneDurationRejectsInvalidValue(t *testing.T) {
+	if _, err := parseSystemPruneDuration("soon"); err == nil {
+		t.Fatal("expected invalid duration to fail")
+	}
+	if _, err := parseSystemPruneDuration("-1h"); err == nil {
+		t.Fatal("expected negative duration to fail")
+	}
+}
+
+func TestWriteSystemDFPrintsTotals(t *testing.T) {
+	stdout, readStdout := makeStdoutCapture(t)
+	t.Cleanup(func() { _ = stdout.Close() })
+
+	err := writeSystemDF(stdout, storagegc.Report{
+		StateBaseDir: "/state/cleanroom",
+		CacheBaseDir: "/cache/cleanroom",
+		Entries: []storagegc.Entry{
+			{Kind: storagegc.KindSandboxRuntime, ID: "orphan", SizeBytes: 2048, Reclaimable: true},
+		},
+		Totals: map[string]storagegc.CategoryTotal{
+			storagegc.KindSandboxRuntime: {
+				Count:            1,
+				TotalBytes:       2048,
+				ReclaimableBytes: 2048,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("writeSystemDF returned error: %v", err)
+	}
+	output := readStdout()
+	assertContainsAll(t, output, "state: /state/cleanroom", "cache: /cache/cleanroom", "sandbox-runtime", "2.0 KiB")
+}
+
+func TestWriteSystemPruneSummaryPrintsGroupedActions(t *testing.T) {
+	stdout, readStdout := makeStdoutCapture(t)
+	t.Cleanup(func() { _ = stdout.Close() })
+
+	err := writeSystemPruneSummary(stdout, storagegc.Plan{
+		ReclaimableBytes: 8192,
+		Actions: []storagegc.Action{
+			{
+				Kind:      storagegc.KindOrphanSnapshot,
+				ID:        "snap-orphan",
+				Path:      "/state/cleanroom/snapshots/darwin-vz/snap-orphan",
+				SizeBytes: 4096,
+				Reason:    "not referenced",
+			},
+			{
+				Kind:      storagegc.KindOrphanSnapshot,
+				ID:        "snap-other",
+				Path:      "/state/cleanroom/snapshots/darwin-vz/snap-other",
+				SizeBytes: 2048,
+				Reason:    "not referenced",
+			},
+			{
+				Kind:      storagegc.KindSandboxRuntime,
+				ID:        "cr-orphan",
+				Path:      "/state/cleanroom/sandboxes/cr-orphan",
+				SizeBytes: 2048,
+				Reason:    "not present",
+			},
+		},
+	}, true)
+	if err != nil {
+		t.Fatalf("writeSystemPruneSummary returned error: %v", err)
+	}
+	output := readStdout()
+	assertContainsAll(t, output, "would reclaim 8.0 KiB", "KIND", "ITEMS", "RECLAIMABLE", "orphan-snapshot", "2", "6.0 KiB", "sandbox-runtime", "1", "2.0 KiB", "Use --table")
+	if strings.Contains(output, "snap-orphan") {
+		t.Fatalf("summary output should not include per-action IDs, got %q", output)
+	}
+	if strings.Contains(output, "will reclaim") {
+		t.Fatalf("dry-run output should say would reclaim, got %q", output)
+	}
+}
+
+func TestWriteSystemPruneTablePrintsActions(t *testing.T) {
+	stdout, readStdout := makeStdoutCapture(t)
+	t.Cleanup(func() { _ = stdout.Close() })
+
+	err := writeSystemPruneTable(stdout, storagegc.Plan{
+		ReclaimableBytes: 4096,
+		Actions: []storagegc.Action{
+			{
+				Kind:      storagegc.KindOrphanSnapshot,
+				ID:        "snap-orphan",
+				Path:      "/state/cleanroom/snapshots/darwin-vz/snap-orphan",
+				SizeBytes: 4096,
+				Reason:    "not referenced",
+			},
+		},
+	}, "would reclaim")
+	if err != nil {
+		t.Fatalf("writeSystemPruneTable returned error: %v", err)
+	}
+	output := readStdout()
+	assertContainsAll(t, output, "would reclaim 4.0 KiB", "orphan-snapshot", "snap-orphan", "not referenced")
+}
+
+func TestWriteSystemPruneJSONIncludesSummaryAndActions(t *testing.T) {
+	stdout, readStdout := makeStdoutCapture(t)
+	t.Cleanup(func() { _ = stdout.Close() })
+
+	err := writeSystemPruneJSON(stdout, storagegc.Plan{
+		ReclaimableBytes: 4096,
+		Actions: []storagegc.Action{
+			{
+				Kind:      storagegc.KindOrphanSnapshot,
+				ID:        "snap-orphan",
+				Path:      "/state/cleanroom/snapshots/darwin-vz/snap-orphan",
+				SizeBytes: 4096,
+				Reason:    "not referenced",
+			},
+		},
+	}, true, nil)
+	if err != nil {
+		t.Fatalf("writeSystemPruneJSON returned error: %v", err)
+	}
+	var payload systemPruneJSONOutput
+	if err := json.Unmarshal([]byte(readStdout()), &payload); err != nil {
+		t.Fatalf("unmarshal prune JSON: %v", err)
+	}
+	if !payload.DryRun {
+		t.Fatal("expected dry_run to be true")
+	}
+	if got, want := payload.Entries, 1; got != want {
+		t.Fatalf("unexpected entries: got %d want %d", got, want)
+	}
+	if got, want := len(payload.Summary), 1; got != want {
+		t.Fatalf("unexpected summary rows: got %d want %d", got, want)
+	}
+	if got, want := len(payload.Actions), 1; got != want {
+		t.Fatalf("unexpected actions: got %d want %d", got, want)
+	}
+}

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -794,11 +794,9 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 		Policy:            compiled,
 		FirecrackerConfig: firecrackerCfg,
 	}); err != nil {
-		s.mu.Lock()
-		if current, ok := s.sandboxes[sandboxID]; ok {
-			s.dropSandboxLocked(sandboxID, current)
+		if stateErr := s.dropProvisioningSandboxAfterCreateError(sandboxID); stateErr != nil {
+			return nil, stateErr
 		}
-		s.mu.Unlock()
 		return nil, fmt.Errorf("provision sandbox: %w", err)
 	}
 	if err := s.ensureSandboxCreateStillProvisioning(sandboxID); err != nil {
@@ -2279,6 +2277,17 @@ func (s *Service) ensureSandboxCreateStillProvisioning(sandboxID string) error {
 	defer s.mu.RUnlock()
 	_, err := s.sandboxCreateProvisioningStateLocked(sandboxID)
 	return err
+}
+
+func (s *Service) dropProvisioningSandboxAfterCreateError(sandboxID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	current, err := s.sandboxCreateProvisioningStateLocked(sandboxID)
+	if err != nil {
+		return err
+	}
+	s.dropSandboxLocked(sandboxID, current)
+	return nil
 }
 
 func (s *Service) sandboxCreateProvisioningStateLocked(sandboxID string) (*sandboxState, error) {

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -742,6 +742,26 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 	now := s.clock().Now()
 	sandboxID := s.ids().NewSandboxID()
 	span.SetAttributes(attribute.String("cleanroom.sandbox.id", sandboxID))
+	state := &sandboxState{
+		ID:                                  sandboxID,
+		Backend:                             backendName,
+		Capabilities:                        backend.CapabilitiesForAdapter(adapter),
+		Policy:                              compiled,
+		Firecracker:                         firecrackerCfg,
+		Repository:                          cloneRepositoryCheckout(repository),
+		RepositoryCommitBundle:              cloneRepositoryCommitBundle(commitBundle),
+		RepositoryHasChangeset:              changeset != nil,
+		RepositoryChangesetPendingExecution: changeset != nil,
+		CreatedAt:                           now,
+		UpdatedAt:                           now,
+		Status:                              cleanroomv1.SandboxStatus_SANDBOX_STATUS_PROVISIONING,
+		events:                              newEventFeed[*cleanroomv1.SandboxEvent](s.retention().maxRetainedSandboxEvents),
+		Done:                                make(chan struct{}),
+	}
+	s.mu.Lock()
+	s.ensureMapsLocked()
+	s.sandboxes[sandboxID] = state
+	s.mu.Unlock()
 	if logger != nil {
 		logger.Debug("create sandbox requested",
 			observability.LogFieldSandboxID, sandboxID,
@@ -763,6 +783,11 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 		Policy:            compiled,
 		FirecrackerConfig: firecrackerCfg,
 	}); err != nil {
+		s.mu.Lock()
+		if current, ok := s.sandboxes[sandboxID]; ok {
+			s.dropSandboxLocked(sandboxID, current)
+		}
+		s.mu.Unlock()
 		return nil, fmt.Errorf("provision sandbox: %w", err)
 	}
 	if logger != nil {
@@ -885,26 +910,27 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 		}
 	}
 
-	state := &sandboxState{
-		ID:                                  sandboxID,
-		Backend:                             backendName,
-		Capabilities:                        backend.CapabilitiesForAdapter(adapter),
-		Policy:                              compiled,
-		Firecracker:                         firecrackerCfg,
-		Repository:                          cloneRepositoryCheckout(repository),
-		RepositoryCommitBundle:              cloneRepositoryCommitBundle(commitBundle),
-		RepositoryHasChangeset:              changeset != nil,
-		RepositoryChangesetPendingExecution: changeset != nil,
-		CreatedAt:                           now,
-		UpdatedAt:                           now,
-		Status:                              cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY,
-		events:                              newEventFeed[*cleanroomv1.SandboxEvent](s.retention().maxRetainedSandboxEvents),
-		Done:                                make(chan struct{}),
-	}
-
 	s.mu.Lock()
 	s.ensureMapsLocked()
-	s.sandboxes[sandboxID] = state
+	state, ok = s.sandboxes[sandboxID]
+	if !ok {
+		state = &sandboxState{
+			ID:                                  sandboxID,
+			Backend:                             backendName,
+			Capabilities:                        backend.CapabilitiesForAdapter(adapter),
+			Policy:                              compiled,
+			Firecracker:                         firecrackerCfg,
+			Repository:                          cloneRepositoryCheckout(repository),
+			RepositoryCommitBundle:              cloneRepositoryCommitBundle(commitBundle),
+			RepositoryHasChangeset:              changeset != nil,
+			RepositoryChangesetPendingExecution: changeset != nil,
+			CreatedAt:                           now,
+			UpdatedAt:                           now,
+			events:                              newEventFeed[*cleanroomv1.SandboxEvent](s.retention().maxRetainedSandboxEvents),
+			Done:                                make(chan struct{}),
+		}
+		s.sandboxes[sandboxID] = state
+	}
 	s.recordSandboxEventLocked(state, cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY, "sandbox created and ready")
 	s.pruneStateLocked(now)
 	resp = &cleanroomv1.CreateSandboxResponse{

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -89,6 +89,8 @@ type sandboxState struct {
 	DoneClosed                          bool
 }
 
+var errSandboxCreateAborted = errors.New("sandbox creation aborted")
+
 type executionState struct {
 	ID                string
 	SandboxID         string
@@ -460,6 +462,9 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 						s.logServicesStageRestore(record, restoreResp.GetSandbox().GetSandboxId())
 						return restoreResp, nil
 					}
+					if errors.Is(restoreErr, errSandboxCreateAborted) {
+						return nil, restoreErr
+					}
 					recordCopy := record
 					replacedServicesStageRecord = &recordCopy
 					s.logServicesStageRestoreWarning(record, restoreErr)
@@ -520,6 +525,8 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 							return restoreResp, nil
 						}
 						restoredDependencyResp = restoreResp
+					} else if errors.Is(restoreErr, errSandboxCreateAborted) {
+						return nil, restoreErr
 					} else {
 						recordCopy := record
 						replacedDependencyStageRecord = &recordCopy
@@ -575,6 +582,8 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 								return restoreResp, nil
 							}
 							restoredDependencyResp = restoreResp
+						} else if errors.Is(restoreErr, errSandboxCreateAborted) {
+							return nil, restoreErr
 						} else {
 							s.logDependencyStageRestoreWarning(portableRecord, restoreErr)
 						}
@@ -636,6 +645,8 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 							return restoreResp, nil
 						}
 						restoredWorkspaceResp = restoreResp
+					} else if errors.Is(restoreErr, errSandboxCreateAborted) {
+						return nil, restoreErr
 					} else {
 						recordCopy := record
 						replacedWorkspaceStageRecord = &recordCopy
@@ -790,6 +801,9 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 		s.mu.Unlock()
 		return nil, fmt.Errorf("provision sandbox: %w", err)
 	}
+	if err := s.ensureSandboxCreateStillProvisioning(sandboxID); err != nil {
+		return nil, err
+	}
 	if logger != nil {
 		logger.Debug("sandbox provisioned",
 			observability.LogFieldSandboxID, sandboxID,
@@ -817,6 +831,9 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 		}
 		return nil, fmt.Errorf("bootstrap repository checkout: %w", err)
 	}
+	if err := s.ensureSandboxCreateStillProvisioning(sandboxID); err != nil {
+		return nil, err
+	}
 	if changeset != nil {
 		changesetAttrs := []attribute.KeyValue{
 			attribute.String(observability.AttrBackend, backendName),
@@ -836,6 +853,9 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 			}
 			return nil, fmt.Errorf("apply repository changeset: %w", err)
 		}
+		if err := s.ensureSandboxCreateStillProvisioning(sandboxID); err != nil {
+			return nil, err
+		}
 	}
 	if snapshotCapable && workspaceStageCachingEnabled {
 		emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_PUBLISH_WORKSPACE_STAGE_CACHE, "publishing workspace stage cache")
@@ -846,6 +866,9 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 			s.maybePublishWorkspaceStageCache(ctx, snapshotAdapter, sandboxID, backendName, compiled, firecrackerCfg, workspaceStageRuntimeBaseKey, repository, changeset, replacedWorkspaceStageRecord)
 			return nil
 		})
+		if err := s.ensureSandboxCreateStillProvisioning(sandboxID); err != nil {
+			return nil, err
+		}
 	}
 	if dependencyStageBootstrapEnabled {
 		bootstrapAttrs := []attribute.KeyValue{
@@ -867,6 +890,9 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 			}
 			return nil, fmt.Errorf("bootstrap dependency stage: %w", err)
 		}
+		if err := s.ensureSandboxCreateStillProvisioning(sandboxID); err != nil {
+			return nil, err
+		}
 		if dependencyStageCachingEnabled && snapshotCapable {
 			emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_PUBLISH_DEPENDENCY_STAGE_CACHE, "publishing dependency stage cache")
 			_ = s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.publish_dependency_stage_cache", []attribute.KeyValue{
@@ -876,6 +902,9 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 				s.maybePublishDependencyStageCache(ctx, snapshotAdapter, sandboxID, backendName, compiled, firecrackerCfg, repository, changeset, dependencyStagePlan, replacedDependencyStageRecord)
 				return nil
 			})
+			if err := s.ensureSandboxCreateStillProvisioning(sandboxID); err != nil {
+				return nil, err
+			}
 		}
 	}
 	if servicesStageBootstrapEnabled {
@@ -898,6 +927,9 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 			}
 			return nil, fmt.Errorf("bootstrap services stage: %w", err)
 		}
+		if err := s.ensureSandboxCreateStillProvisioning(sandboxID); err != nil {
+			return nil, err
+		}
 		if servicesStageCachingEnabled && snapshotCapable {
 			emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_PUBLISH_SERVICES_STAGE_CACHE, "publishing services stage cache")
 			_ = s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.publish_services_stage_cache", []attribute.KeyValue{
@@ -907,29 +939,18 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 				s.maybePublishServicesStageCache(ctx, snapshotAdapter, sandboxID, backendName, compiled, firecrackerCfg, repository, changeset, servicesStagePlan, replacedServicesStageRecord)
 				return nil
 			})
+			if err := s.ensureSandboxCreateStillProvisioning(sandboxID); err != nil {
+				return nil, err
+			}
 		}
 	}
 
 	s.mu.Lock()
 	s.ensureMapsLocked()
-	state, ok = s.sandboxes[sandboxID]
-	if !ok {
-		state = &sandboxState{
-			ID:                                  sandboxID,
-			Backend:                             backendName,
-			Capabilities:                        backend.CapabilitiesForAdapter(adapter),
-			Policy:                              compiled,
-			Firecracker:                         firecrackerCfg,
-			Repository:                          cloneRepositoryCheckout(repository),
-			RepositoryCommitBundle:              cloneRepositoryCommitBundle(commitBundle),
-			RepositoryHasChangeset:              changeset != nil,
-			RepositoryChangesetPendingExecution: changeset != nil,
-			CreatedAt:                           now,
-			UpdatedAt:                           now,
-			events:                              newEventFeed[*cleanroomv1.SandboxEvent](s.retention().maxRetainedSandboxEvents),
-			Done:                                make(chan struct{}),
-		}
-		s.sandboxes[sandboxID] = state
+	state, err = s.sandboxCreateProvisioningStateLocked(sandboxID)
+	if err != nil {
+		s.mu.Unlock()
+		return nil, err
 	}
 	s.recordSandboxEventLocked(state, cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY, "sandbox created and ready")
 	s.pruneStateLocked(now)
@@ -2251,6 +2272,29 @@ func (s *Service) terminateCreatedSandbox(ctx context.Context, adapter backend.A
 	s.mu.Unlock()
 
 	return err
+}
+
+func (s *Service) ensureSandboxCreateStillProvisioning(sandboxID string) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	_, err := s.sandboxCreateProvisioningStateLocked(sandboxID)
+	return err
+}
+
+func (s *Service) sandboxCreateProvisioningStateLocked(sandboxID string) (*sandboxState, error) {
+	state, ok := s.sandboxes[sandboxID]
+	if !ok {
+		return nil, fmt.Errorf("sandbox %q was removed during creation: %w", sandboxID, errSandboxCreateAborted)
+	}
+	if state.Status != cleanroomv1.SandboxStatus_SANDBOX_STATUS_PROVISIONING {
+		switch state.Status {
+		case cleanroomv1.SandboxStatus_SANDBOX_STATUS_STOPPING, cleanroomv1.SandboxStatus_SANDBOX_STATUS_STOPPED:
+			return nil, fmt.Errorf("sandbox %q was terminated during creation: %w", sandboxID, errSandboxCreateAborted)
+		default:
+			return nil, fmt.Errorf("sandbox %q left provisioning during creation with status %s: %w", sandboxID, state.Status, errSandboxCreateAborted)
+		}
+	}
+	return state, nil
 }
 
 func (s *Service) ConsumeInteractiveSession(sessionID, token string) (*InteractiveSession, error) {

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -7749,6 +7749,43 @@ func TestListSandboxesReturnsNewestSnapshotFirst(t *testing.T) {
 	}
 }
 
+func TestListSandboxesIncludesProvisioningSandbox(t *testing.T) {
+	provisionStarted := make(chan struct{})
+	releaseProvision := make(chan struct{})
+	adapter := &stubAdapter{
+		provisionFn: func(context.Context, backend.ProvisionRequest) error {
+			close(provisionStarted)
+			<-releaseProvision
+			return nil
+		},
+	}
+	svc := newTestService(adapter)
+
+	createDone := make(chan error, 1)
+	go func() {
+		_, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+		createDone <- err
+	}()
+
+	<-provisionStarted
+	resp, err := svc.ListSandboxes(context.Background(), &cleanroomv1.ListSandboxesRequest{})
+	if err != nil {
+		t.Fatalf("ListSandboxes returned error: %v", err)
+	}
+	sandboxes := resp.GetSandboxes()
+	if got, want := len(sandboxes), 1; got != want {
+		t.Fatalf("unexpected sandbox count: got %d want %d", got, want)
+	}
+	if got, want := sandboxes[0].GetStatus(), cleanroomv1.SandboxStatus_SANDBOX_STATUS_PROVISIONING; got != want {
+		t.Fatalf("unexpected sandbox status: got %v want %v", got, want)
+	}
+
+	close(releaseProvision)
+	if err := <-createDone; err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+}
+
 func TestExecutionRetentionBoundsOutput(t *testing.T) {
 	adapter := &stubAdapter{
 		runStreamFn: func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -7786,6 +7786,122 @@ func TestListSandboxesIncludesProvisioningSandbox(t *testing.T) {
 	}
 }
 
+func TestCreateSandboxAbortsWhenTerminatedDuringProvision(t *testing.T) {
+	provisionStarted := make(chan struct{})
+	releaseProvision := make(chan struct{})
+	adapter := &stubAdapter{
+		provisionFn: func(context.Context, backend.ProvisionRequest) error {
+			close(provisionStarted)
+			<-releaseProvision
+			return nil
+		},
+	}
+	svc := newTestService(adapter)
+
+	createDone := make(chan error, 1)
+	go func() {
+		_, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+		createDone <- err
+	}()
+
+	<-provisionStarted
+	sandboxID := requireProvisioningSandboxID(t, svc)
+	if _, err := svc.TerminateSandbox(context.Background(), &cleanroomv1.TerminateSandboxRequest{SandboxId: sandboxID}); err != nil {
+		t.Fatalf("TerminateSandbox returned error: %v", err)
+	}
+	close(releaseProvision)
+	if err := <-createDone; !errors.Is(err, errSandboxCreateAborted) {
+		t.Fatalf("CreateSandbox error = %v, want %v", err, errSandboxCreateAborted)
+	}
+
+	resp, err := svc.GetSandbox(context.Background(), &cleanroomv1.GetSandboxRequest{SandboxId: sandboxID})
+	if err != nil {
+		t.Fatalf("GetSandbox returned error: %v", err)
+	}
+	if got, want := resp.GetSandbox().GetStatus(), cleanroomv1.SandboxStatus_SANDBOX_STATUS_STOPPED; got != want {
+		t.Fatalf("unexpected sandbox status: got %v want %v", got, want)
+	}
+	if got, want := adapter.terminateCalls, 1; got != want {
+		t.Fatalf("unexpected terminate calls: got %d want %d", got, want)
+	}
+}
+
+func TestCreateSandboxFromSnapshotAbortsWhenTerminatedDuringRestore(t *testing.T) {
+	store := newMemorySnapshotStore()
+	restoreStarted := make(chan struct{})
+	releaseRestore := make(chan struct{})
+	adapter := &stubAdapter{
+		createSnapshotFn: func(_ context.Context, req backend.SnapshotRequest) (*backend.SnapshotResult, error) {
+			return &backend.SnapshotResult{StorageRef: "/snapshots/" + req.SnapshotID + ".ext4"}, nil
+		},
+		provisionFromSnapshotFn: func(context.Context, backend.ProvisionFromSnapshotRequest) error {
+			close(restoreStarted)
+			<-releaseRestore
+			return nil
+		},
+	}
+	svc := newTestServiceWithSnapshotStore(adapter, store)
+
+	sourceResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	snapshotResp, err := svc.CreateSnapshot(context.Background(), &cleanroomv1.CreateSnapshotRequest{
+		SandboxId: sourceResp.GetSandbox().GetSandboxId(),
+		Name:      "base",
+	})
+	if err != nil {
+		t.Fatalf("CreateSnapshot returned error: %v", err)
+	}
+
+	createDone := make(chan error, 1)
+	go func() {
+		_, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+			Source: &cleanroomv1.CreateSandboxRequest_SnapshotId{SnapshotId: snapshotResp.GetSnapshot().GetSnapshotId()},
+		})
+		createDone <- err
+	}()
+
+	<-restoreStarted
+	sandboxID := requireProvisioningSandboxID(t, svc)
+	if _, err := svc.TerminateSandbox(context.Background(), &cleanroomv1.TerminateSandboxRequest{SandboxId: sandboxID}); err != nil {
+		t.Fatalf("TerminateSandbox returned error: %v", err)
+	}
+	close(releaseRestore)
+	if err := <-createDone; !errors.Is(err, errSandboxCreateAborted) {
+		t.Fatalf("CreateSandbox from snapshot error = %v, want %v", err, errSandboxCreateAborted)
+	}
+
+	resp, err := svc.GetSandbox(context.Background(), &cleanroomv1.GetSandboxRequest{SandboxId: sandboxID})
+	if err != nil {
+		t.Fatalf("GetSandbox returned error: %v", err)
+	}
+	if got, want := resp.GetSandbox().GetStatus(), cleanroomv1.SandboxStatus_SANDBOX_STATUS_STOPPED; got != want {
+		t.Fatalf("unexpected sandbox status: got %v want %v", got, want)
+	}
+	if got, want := adapter.provisionFromSnapshotCalls, 1; got != want {
+		t.Fatalf("unexpected provision-from-snapshot calls: got %d want %d", got, want)
+	}
+	if got, want := adapter.terminateCalls, 1; got != want {
+		t.Fatalf("unexpected terminate calls: got %d want %d", got, want)
+	}
+}
+
+func requireProvisioningSandboxID(t *testing.T, svc *Service) string {
+	t.Helper()
+	resp, err := svc.ListSandboxes(context.Background(), &cleanroomv1.ListSandboxesRequest{})
+	if err != nil {
+		t.Fatalf("ListSandboxes returned error: %v", err)
+	}
+	for _, sandbox := range resp.GetSandboxes() {
+		if sandbox.GetStatus() == cleanroomv1.SandboxStatus_SANDBOX_STATUS_PROVISIONING {
+			return sandbox.GetSandboxId()
+		}
+	}
+	t.Fatalf("no provisioning sandbox in %d sandboxes", len(resp.GetSandboxes()))
+	return ""
+}
+
 func TestExecutionRetentionBoundsOutput(t *testing.T) {
 	adapter := &stubAdapter{
 		runStreamFn: func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -2925,6 +2925,63 @@ func TestCreateSandboxFallsBackWhenWorkspaceStageRestoreFails(t *testing.T) {
 	}
 }
 
+func TestCreateSandboxDoesNotFallbackWhenWorkspaceStageRestoreIsTerminated(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	store := newMemorySnapshotStore()
+	restoreStarted := make(chan struct{})
+	releaseRestore := make(chan struct{})
+	adapter := &stubAdapter{
+		createSnapshotFn: func(_ context.Context, req backend.SnapshotRequest) (*backend.SnapshotResult, error) {
+			return &backend.SnapshotResult{StorageRef: "/snapshots/" + req.SnapshotID + ".ext4"}, nil
+		},
+	}
+	mirrors := &stubRepositoryMirrorStore{}
+	svc := newTestServiceWithSnapshotStore(adapter, store)
+	svc.RepositoryStore = mirrors
+
+	req := &cleanroomv1.CreateSandboxRequest{
+		Policy:             testRepositoryPolicy(),
+		RepositoryCheckout: testRepositoryCheckoutProto(),
+	}
+
+	if _, err := svc.CreateSandbox(context.Background(), req); err != nil {
+		t.Fatalf("first CreateSandbox returned error: %v", err)
+	}
+	adapter.provisionFromSnapshotFn = func(context.Context, backend.ProvisionFromSnapshotRequest) error {
+		close(restoreStarted)
+		<-releaseRestore
+		return errors.New("snapshot restore interrupted")
+	}
+
+	createDone := make(chan error, 1)
+	go func() {
+		_, err := svc.CreateSandbox(context.Background(), req)
+		createDone <- err
+	}()
+
+	<-restoreStarted
+	sandboxID := requireProvisioningSandboxID(t, svc)
+	if _, err := svc.TerminateSandbox(context.Background(), &cleanroomv1.TerminateSandboxRequest{SandboxId: sandboxID}); err != nil {
+		t.Fatalf("TerminateSandbox returned error: %v", err)
+	}
+	close(releaseRestore)
+	if err := <-createDone; !errors.Is(err, errSandboxCreateAborted) {
+		t.Fatalf("CreateSandbox error = %v, want %v", err, errSandboxCreateAborted)
+	}
+	if got, want := adapter.provisionFromSnapshotCalls, 1; got != want {
+		t.Fatalf("unexpected provision-from-snapshot calls: got %d want %d", got, want)
+	}
+	if got, want := adapter.provisionCalls, 1; got != want {
+		t.Fatalf("terminated restore should not fall back to cold provision: got %d want %d", got, want)
+	}
+	if got, want := adapter.createSnapshotCalls, 1; got != want {
+		t.Fatalf("terminated restore should not republish cache: got %d want %d", got, want)
+	}
+	if got, want := adapter.terminateCalls, 1; got != want {
+		t.Fatalf("unexpected terminate calls: got %d want %d", got, want)
+	}
+}
+
 func TestDeleteWorkspaceStageCacheSnapshotRejectsInFlightRestore(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	store := newMemorySnapshotStore()

--- a/internal/controlservice/stored_rootfs.go
+++ b/internal/controlservice/stored_rootfs.go
@@ -182,6 +182,9 @@ func (s *Service) createSandboxFromStoredRootFS(ctx context.Context, req *cleanr
 		s.mu.Unlock()
 		return nil, fmt.Errorf("provision sandbox from snapshot: %w", err)
 	}
+	if err := s.ensureSandboxCreateStillProvisioning(sandboxID); err != nil {
+		return nil, err
+	}
 
 	if sourceKind == "" {
 		sourceKind = "stored rootfs"
@@ -191,26 +194,11 @@ func (s *Service) createSandboxFromStoredRootFS(ctx context.Context, req *cleanr
 
 	s.mu.Lock()
 	s.ensureMapsLocked()
-	state, ok = s.sandboxes[sandboxID]
-	if !ok {
-		state = &sandboxState{
-			ID:                                  sandboxID,
-			Backend:                             backendName,
-			Capabilities:                        backend.CapabilitiesForAdapter(adapter),
-			Policy:                              effectivePolicy,
-			Firecracker:                         firecrackerCfg,
-			Repository:                          cloneRepositoryCheckout(record.Repository),
-			RepositoryHasChangeset:              record.RepositoryHasChangeset,
-			RepositoryChangesetPendingExecution: record.RepositoryChangesetPendingExecution,
-			SourceKind:                          sourceKind,
-			SourceID:                            sourceID,
-			BackingSnapshotID:                   backingSnapshotID,
-			CreatedAt:                           now,
-			UpdatedAt:                           now,
-			events:                              newEventFeed[*cleanroomv1.SandboxEvent](s.retention().maxRetainedSandboxEvents),
-			Done:                                make(chan struct{}),
-		}
-		s.sandboxes[sandboxID] = state
+	var stateErr error
+	state, stateErr = s.sandboxCreateProvisioningStateLocked(sandboxID)
+	if stateErr != nil {
+		s.mu.Unlock()
+		return nil, stateErr
 	}
 	s.recordSandboxEventLocked(state, cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY, eventMessage)
 	s.pruneStateLocked(now)

--- a/internal/controlservice/stored_rootfs.go
+++ b/internal/controlservice/stored_rootfs.go
@@ -140,22 +140,6 @@ func (s *Service) createSandboxFromStoredRootFS(ctx context.Context, req *cleanr
 	case "workspace stage cache":
 		emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_RESTORE_WORKSPACE_STAGE_CACHE, "restoring workspace stage cache")
 	}
-	if err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.restore_snapshot", []attribute.KeyValue{
-		attribute.String(observability.AttrBackend, backendName),
-		attribute.String(observability.AttrSandboxID, sandboxID),
-		attribute.String("cleanroom.source_kind", sourceKind),
-	}, func(ctx context.Context) error {
-		return snapshotAdapter.ProvisionSandboxFromSnapshot(ctx, backend.ProvisionFromSnapshotRequest{
-			SandboxID:         sandboxID,
-			SnapshotID:        provisionSnapshotID,
-			StorageRef:        record.StorageRef,
-			Policy:            effectivePolicy,
-			FirecrackerConfig: firecrackerCfg,
-		})
-	}); err != nil {
-		return nil, fmt.Errorf("provision sandbox from snapshot: %w", err)
-	}
-
 	state := &sandboxState{
 		ID:                                  sandboxID,
 		Backend:                             backendName,
@@ -170,9 +154,33 @@ func (s *Service) createSandboxFromStoredRootFS(ctx context.Context, req *cleanr
 		BackingSnapshotID:                   backingSnapshotID,
 		CreatedAt:                           now,
 		UpdatedAt:                           now,
-		Status:                              cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY,
+		Status:                              cleanroomv1.SandboxStatus_SANDBOX_STATUS_PROVISIONING,
 		events:                              newEventFeed[*cleanroomv1.SandboxEvent](s.retention().maxRetainedSandboxEvents),
 		Done:                                make(chan struct{}),
+	}
+	s.mu.Lock()
+	s.ensureMapsLocked()
+	s.sandboxes[sandboxID] = state
+	s.mu.Unlock()
+	if err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.restore_snapshot", []attribute.KeyValue{
+		attribute.String(observability.AttrBackend, backendName),
+		attribute.String(observability.AttrSandboxID, sandboxID),
+		attribute.String("cleanroom.source_kind", sourceKind),
+	}, func(ctx context.Context) error {
+		return snapshotAdapter.ProvisionSandboxFromSnapshot(ctx, backend.ProvisionFromSnapshotRequest{
+			SandboxID:         sandboxID,
+			SnapshotID:        provisionSnapshotID,
+			StorageRef:        record.StorageRef,
+			Policy:            effectivePolicy,
+			FirecrackerConfig: firecrackerCfg,
+		})
+	}); err != nil {
+		s.mu.Lock()
+		if current, ok := s.sandboxes[sandboxID]; ok {
+			s.dropSandboxLocked(sandboxID, current)
+		}
+		s.mu.Unlock()
+		return nil, fmt.Errorf("provision sandbox from snapshot: %w", err)
 	}
 
 	if sourceKind == "" {
@@ -183,7 +191,27 @@ func (s *Service) createSandboxFromStoredRootFS(ctx context.Context, req *cleanr
 
 	s.mu.Lock()
 	s.ensureMapsLocked()
-	s.sandboxes[sandboxID] = state
+	state, ok = s.sandboxes[sandboxID]
+	if !ok {
+		state = &sandboxState{
+			ID:                                  sandboxID,
+			Backend:                             backendName,
+			Capabilities:                        backend.CapabilitiesForAdapter(adapter),
+			Policy:                              effectivePolicy,
+			Firecracker:                         firecrackerCfg,
+			Repository:                          cloneRepositoryCheckout(record.Repository),
+			RepositoryHasChangeset:              record.RepositoryHasChangeset,
+			RepositoryChangesetPendingExecution: record.RepositoryChangesetPendingExecution,
+			SourceKind:                          sourceKind,
+			SourceID:                            sourceID,
+			BackingSnapshotID:                   backingSnapshotID,
+			CreatedAt:                           now,
+			UpdatedAt:                           now,
+			events:                              newEventFeed[*cleanroomv1.SandboxEvent](s.retention().maxRetainedSandboxEvents),
+			Done:                                make(chan struct{}),
+		}
+		s.sandboxes[sandboxID] = state
+	}
 	s.recordSandboxEventLocked(state, cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY, eventMessage)
 	s.pruneStateLocked(now)
 	resp := &cleanroomv1.CreateSandboxResponse{

--- a/internal/controlservice/stored_rootfs.go
+++ b/internal/controlservice/stored_rootfs.go
@@ -175,11 +175,9 @@ func (s *Service) createSandboxFromStoredRootFS(ctx context.Context, req *cleanr
 			FirecrackerConfig: firecrackerCfg,
 		})
 	}); err != nil {
-		s.mu.Lock()
-		if current, ok := s.sandboxes[sandboxID]; ok {
-			s.dropSandboxLocked(sandboxID, current)
+		if stateErr := s.dropProvisioningSandboxAfterCreateError(sandboxID); stateErr != nil {
+			return nil, stateErr
 		}
-		s.mu.Unlock()
 		return nil, fmt.Errorf("provision sandbox from snapshot: %w", err)
 	}
 	if err := s.ensureSandboxCreateStillProvisioning(sandboxID); err != nil {

--- a/internal/storagegc/size_fallback.go
+++ b/internal/storagegc/size_fallback.go
@@ -1,0 +1,12 @@
+//go:build !darwin && !linux
+
+package storagegc
+
+import "os"
+
+func allocatedFileSize(info os.FileInfo) int64 {
+	if info == nil {
+		return 0
+	}
+	return info.Size()
+}

--- a/internal/storagegc/size_unix.go
+++ b/internal/storagegc/size_unix.go
@@ -1,0 +1,18 @@
+//go:build darwin || linux
+
+package storagegc
+
+import (
+	"os"
+	"syscall"
+)
+
+func allocatedFileSize(info os.FileInfo) int64 {
+	if info == nil {
+		return 0
+	}
+	if stat, ok := info.Sys().(*syscall.Stat_t); ok && stat.Blocks >= 0 {
+		return int64(stat.Blocks) * 512
+	}
+	return info.Size()
+}

--- a/internal/storagegc/storagegc.go
+++ b/internal/storagegc/storagegc.go
@@ -1,0 +1,870 @@
+package storagegc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/buildkite/cleanroom/internal/cachestore"
+	"github.com/buildkite/cleanroom/internal/imagemgr"
+	"github.com/buildkite/cleanroom/internal/paths"
+	"github.com/buildkite/cleanroom/internal/runtimeconfig"
+	"github.com/buildkite/cleanroom/internal/snapshotstore"
+)
+
+const (
+	KindSandboxRuntime    = "sandbox-runtime"
+	KindSnapshot          = "snapshot"
+	KindOrphanSnapshot    = "orphan-snapshot"
+	KindStageCache        = "stage-cache"
+	KindImageCache        = "image-cache"
+	KindRuntimeRootFS     = "runtime-rootfs-cache"
+	KindRepositoryCache   = "repository-cache"
+	KindContentCache      = "content-cache"
+	KindExecutionArtifact = "execution-artifacts"
+	KindChangesetStore    = "changesets"
+)
+
+const DefaultExecutionMaxAge = 24 * time.Hour
+
+type SnapshotLister interface {
+	List(context.Context) ([]snapshotstore.Record, error)
+}
+
+type CacheStore interface {
+	List(context.Context) ([]cachestore.Record, error)
+	Delete(context.Context, string, string) error
+}
+
+type ImageManager interface {
+	List(context.Context) ([]imagemgr.Record, error)
+	Remove(context.Context, string) ([]imagemgr.Record, error)
+}
+
+type InventoryOptions struct {
+	Config            runtimeconfig.Config
+	ActiveSandboxIDs  []string
+	SandboxStateKnown bool
+	SnapshotStore     SnapshotLister
+	CacheStore        CacheStore
+	ImageManager      ImageManager
+	Now               time.Time
+	ExecutionMaxAge   time.Duration
+}
+
+type Entry struct {
+	Kind        string    `json:"kind"`
+	ID          string    `json:"id,omitempty"`
+	Backend     string    `json:"backend,omitempty"`
+	Stage       string    `json:"stage,omitempty"`
+	CacheKey    string    `json:"cache_key,omitempty"`
+	Path        string    `json:"path,omitempty"`
+	StorageRef  string    `json:"storage_ref,omitempty"`
+	SizeBytes   int64     `json:"size_bytes"`
+	Reclaimable bool      `json:"reclaimable"`
+	Reason      string    `json:"reason,omitempty"`
+	ProtectedBy []string  `json:"protected_by,omitempty"`
+	CreatedAt   time.Time `json:"created_at,omitempty"`
+	LastUsedAt  time.Time `json:"last_used_at,omitempty"`
+}
+
+type CategoryTotal struct {
+	Count            int   `json:"count"`
+	TotalBytes       int64 `json:"total_bytes"`
+	ReclaimableBytes int64 `json:"reclaimable_bytes"`
+	ProtectedBytes   int64 `json:"protected_bytes"`
+}
+
+type Report struct {
+	GeneratedAt       time.Time                `json:"generated_at"`
+	StateBaseDir      string                   `json:"state_base_dir"`
+	CacheBaseDir      string                   `json:"cache_base_dir"`
+	SnapshotRoots     []string                 `json:"snapshot_roots"`
+	SandboxStateKnown bool                     `json:"sandbox_state_known"`
+	Entries           []Entry                  `json:"entries"`
+	Totals            map[string]CategoryTotal `json:"totals"`
+}
+
+type PruneOptions struct {
+	All       bool
+	OlderThan time.Duration
+	Now       time.Time
+}
+
+type Action struct {
+	Kind      string `json:"kind"`
+	ID        string `json:"id,omitempty"`
+	Path      string `json:"path,omitempty"`
+	SizeBytes int64  `json:"size_bytes"`
+	Reason    string `json:"reason,omitempty"`
+	Entry     Entry  `json:"entry"`
+}
+
+type Plan struct {
+	Actions          []Action `json:"actions"`
+	ReclaimableBytes int64    `json:"reclaimable_bytes"`
+}
+
+type ExecuteOptions struct {
+	CacheStore   CacheStore
+	ImageManager ImageManager
+}
+
+type Result struct {
+	DeletedEntries int   `json:"deleted_entries"`
+	ReclaimedBytes int64 `json:"reclaimed_bytes"`
+}
+
+func Inventory(ctx context.Context, opts InventoryOptions) (Report, error) {
+	now := opts.Now.UTC()
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	executionMaxAge := opts.ExecutionMaxAge
+	if executionMaxAge <= 0 {
+		executionMaxAge = DefaultExecutionMaxAge
+	}
+
+	stateBase, err := paths.StateBaseDir()
+	if err != nil {
+		return Report{}, fmt.Errorf("resolve state base dir: %w", err)
+	}
+	cacheBase, err := paths.CacheBaseDir()
+	if err != nil {
+		return Report{}, fmt.Errorf("resolve cache base dir: %w", err)
+	}
+	snapshotRoots, err := snapshotRoots(opts.Config)
+	if err != nil {
+		return Report{}, err
+	}
+
+	report := Report{
+		GeneratedAt:       now,
+		StateBaseDir:      stateBase,
+		CacheBaseDir:      cacheBase,
+		SnapshotRoots:     snapshotRoots,
+		SandboxStateKnown: opts.SandboxStateKnown,
+		Entries:           []Entry{},
+		Totals:            map[string]CategoryTotal{},
+	}
+
+	snapshotStore := opts.SnapshotStore
+	if snapshotStore == nil {
+		store, err := snapshotstore.New(snapshotstore.Options{})
+		if err != nil {
+			return Report{}, err
+		}
+		snapshotStore = store
+	}
+	cacheStore := opts.CacheStore
+	if cacheStore == nil {
+		store, err := cachestore.New(cachestore.Options{})
+		if err != nil {
+			return Report{}, err
+		}
+		cacheStore = store
+	}
+	imageManager := opts.ImageManager
+	if imageManager == nil {
+		manager, err := imagemgr.New(imagemgr.Options{})
+		if err != nil {
+			return Report{}, err
+		}
+		imageManager = manager
+	}
+
+	referencedSnapshotPaths := map[string][]string{}
+	snapshotRecords, err := snapshotStore.List(ctx)
+	if err != nil {
+		return Report{}, fmt.Errorf("list snapshot metadata: %w", err)
+	}
+	for _, record := range snapshotRecords {
+		entry := entryFromSnapshotRecord(record)
+		if entry.Path != "" {
+			if size, err := pathSize(entry.Path); err == nil {
+				entry.SizeBytes = size
+			} else {
+				return Report{}, fmt.Errorf("size snapshot %q: %w", record.SnapshotID, err)
+			}
+			addPathReference(referencedSnapshotPaths, entry.Path, "snapshot metadata "+record.SnapshotID)
+		}
+		report.Entries = append(report.Entries, entry)
+	}
+
+	cacheRecords, err := cacheStore.List(ctx)
+	if err != nil {
+		return Report{}, fmt.Errorf("list cache metadata: %w", err)
+	}
+	for _, record := range cacheRecords {
+		entry := entryFromCacheRecord(record)
+		if entry.Path != "" {
+			if size, err := pathSize(entry.Path); err == nil {
+				entry.SizeBytes = size
+			} else {
+				return Report{}, fmt.Errorf("size cache %q/%q: %w", record.Stage, record.CacheKey, err)
+			}
+			if protections := referencedSnapshotPaths[cleanPath(entry.Path)]; len(protections) > 0 {
+				entry.ProtectedBy = append(entry.ProtectedBy, protections...)
+				entry.Reason = "stage-cache metadata; also referenced by explicit snapshot metadata"
+			}
+			addPathReference(referencedSnapshotPaths, entry.Path, "stage-cache metadata "+record.Stage+"/"+record.CacheKey)
+		}
+		report.Entries = append(report.Entries, entry)
+	}
+
+	activeSandboxes := stringSet(opts.ActiveSandboxIDs)
+	sandboxEntries, err := scanSandboxRuntimeDirs(filepath.Join(stateBase, "sandboxes"), activeSandboxes, opts.SandboxStateKnown)
+	if err != nil {
+		return Report{}, err
+	}
+	report.Entries = append(report.Entries, sandboxEntries...)
+
+	orphanSnapshots, err := scanOrphanSnapshotDirs(snapshotRoots, referencedSnapshotPaths)
+	if err != nil {
+		return Report{}, err
+	}
+	report.Entries = append(report.Entries, orphanSnapshots...)
+
+	runtimeRootFS, err := scanRuntimeRootFS(cacheBase)
+	if err != nil {
+		return Report{}, err
+	}
+	report.Entries = append(report.Entries, runtimeRootFS...)
+
+	imageEntries, err := scanImageEntries(ctx, imageManager)
+	if err != nil {
+		return Report{}, err
+	}
+	report.Entries = append(report.Entries, imageEntries...)
+
+	executionEntries, err := scanExecutionArtifacts(filepath.Join(stateBase, "executions"), now, executionMaxAge)
+	if err != nil {
+		return Report{}, err
+	}
+	report.Entries = append(report.Entries, executionEntries...)
+
+	for _, root := range []struct {
+		kind string
+		path string
+	}{
+		{kind: KindRepositoryCache, path: filepath.Join(stateBase, "repos")},
+		{kind: KindContentCache, path: filepath.Join(cacheBase, "content-cache")},
+		{kind: KindChangesetStore, path: filepath.Join(stateBase, "changesets")},
+	} {
+		entry, ok, err := protectedRootEntry(root.kind, root.path)
+		if err != nil {
+			return Report{}, err
+		}
+		if ok {
+			report.Entries = append(report.Entries, entry)
+		}
+	}
+
+	sortEntries(report.Entries)
+	report.Totals = totalsByKind(report.Entries)
+	return report, nil
+}
+
+func PlanPrune(report Report, opts PruneOptions) Plan {
+	now := opts.Now.UTC()
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+
+	plan := Plan{}
+	for _, entry := range report.Entries {
+		reclaimable := entry.Reclaimable
+		reason := entry.Reason
+		if !reclaimable && opts.OlderThan > 0 && olderThan(entry, now, opts.OlderThan) {
+			switch entry.Kind {
+			case KindRuntimeRootFS:
+				reclaimable = true
+				reason = fmt.Sprintf("older than %s", opts.OlderThan)
+			case KindStageCache:
+				if entry.Path != "" && stageCacheStorageExclusive(entry) {
+					reclaimable = true
+					reason = fmt.Sprintf("stage cache older than %s", opts.OlderThan)
+				}
+			}
+		}
+		if !reclaimable && opts.All {
+			switch entry.Kind {
+			case KindRuntimeRootFS:
+				reclaimable = true
+				reason = "system cache selected by --all"
+			case KindStageCache:
+				if entry.Path != "" && stageCacheStorageExclusive(entry) {
+					reclaimable = true
+					reason = "stage cache selected by --all"
+				}
+			case KindImageCache:
+				reclaimable = true
+				reason = "image cache selected by --all"
+			}
+		}
+		if !reclaimable {
+			continue
+		}
+		action := Action{
+			Kind:      entry.Kind,
+			ID:        entry.ID,
+			Path:      deletionPath(entry),
+			SizeBytes: entry.SizeBytes,
+			Reason:    reason,
+			Entry:     entry,
+		}
+		plan.Actions = append(plan.Actions, action)
+		plan.ReclaimableBytes += action.SizeBytes
+	}
+	sort.Slice(plan.Actions, func(i, j int) bool {
+		if plan.Actions[i].Kind == plan.Actions[j].Kind {
+			return plan.Actions[i].ID < plan.Actions[j].ID
+		}
+		return plan.Actions[i].Kind < plan.Actions[j].Kind
+	})
+	return plan
+}
+
+func stageCacheStorageExclusive(entry Entry) bool {
+	for _, protection := range entry.ProtectedBy {
+		if strings.HasPrefix(protection, "snapshot metadata ") {
+			return false
+		}
+	}
+	return true
+}
+
+func ExecutePrune(ctx context.Context, report Report, plan Plan, opts ExecuteOptions) (Result, error) {
+	if len(plan.Actions) == 0 {
+		return Result{}, nil
+	}
+	roots := append([]string{report.StateBaseDir, report.CacheBaseDir}, report.SnapshotRoots...)
+	roots = uniqueCleanPaths(roots)
+
+	cacheStore := opts.CacheStore
+	if cacheStore == nil {
+		store, err := cachestore.New(cachestore.Options{})
+		if err != nil {
+			return Result{}, err
+		}
+		cacheStore = store
+	}
+	imageManager := opts.ImageManager
+	if imageManager == nil {
+		manager, err := imagemgr.New(imagemgr.Options{})
+		if err != nil {
+			return Result{}, err
+		}
+		imageManager = manager
+	}
+
+	result := Result{}
+	for _, action := range plan.Actions {
+		if err := executeAction(ctx, action, roots, cacheStore, imageManager); err != nil {
+			return result, err
+		}
+		result.DeletedEntries++
+		result.ReclaimedBytes += action.SizeBytes
+	}
+	return result, nil
+}
+
+func executeAction(ctx context.Context, action Action, roots []string, cacheStore CacheStore, imageManager ImageManager) error {
+	switch action.Kind {
+	case KindImageCache:
+		if imageManager == nil {
+			return errors.New("image manager is not configured")
+		}
+		if _, err := imageManager.Remove(ctx, action.Entry.ID); err != nil {
+			return fmt.Errorf("remove image cache %q: %w", action.Entry.ID, err)
+		}
+		return nil
+	case KindStageCache:
+		if err := removeOwnedPath(action.Path, roots); err != nil {
+			return err
+		}
+		if cacheStore == nil {
+			return errors.New("cache metadata store is not configured")
+		}
+		if err := cacheStore.Delete(ctx, action.Entry.Stage, action.Entry.CacheKey); err != nil {
+			return fmt.Errorf("delete stage-cache metadata %q/%q: %w", action.Entry.Stage, action.Entry.CacheKey, err)
+		}
+		return nil
+	default:
+		return removeOwnedPath(action.Path, roots)
+	}
+}
+
+func entryFromSnapshotRecord(record snapshotstore.Record) Entry {
+	path := storageRefPath(record.StorageRef)
+	return Entry{
+		Kind:        KindSnapshot,
+		ID:          record.SnapshotID,
+		Backend:     record.Backend,
+		Path:        path,
+		StorageRef:  record.StorageRef,
+		Reclaimable: false,
+		Reason:      "explicit snapshot metadata",
+		ProtectedBy: []string{"snapshot metadata"},
+		CreatedAt:   record.CreatedAt,
+		LastUsedAt:  record.CreatedAt,
+	}
+}
+
+func entryFromCacheRecord(record cachestore.Record) Entry {
+	path := storageRefPath(record.StorageRef)
+	protectedBy := []string{"stage-cache metadata"}
+	reason := "stage-cache metadata"
+	if path == "" {
+		reason = "stage-cache metadata uses non-filesystem storage"
+	}
+	return Entry{
+		Kind:        KindStageCache,
+		ID:          record.Stage + "/" + record.CacheKey,
+		Backend:     record.Backend,
+		Stage:       record.Stage,
+		CacheKey:    record.CacheKey,
+		Path:        path,
+		StorageRef:  record.StorageRef,
+		Reclaimable: false,
+		Reason:      reason,
+		ProtectedBy: protectedBy,
+		CreatedAt:   record.CreatedAt,
+		LastUsedAt:  record.LastUsedAt,
+	}
+}
+
+func scanSandboxRuntimeDirs(baseDir string, activeIDs map[string]struct{}, stateKnown bool) ([]Entry, error) {
+	dirEntries, err := os.ReadDir(baseDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read sandbox runtime directory %q: %w", baseDir, err)
+	}
+	out := make([]Entry, 0, len(dirEntries))
+	for _, dirEntry := range dirEntries {
+		if !dirEntry.IsDir() {
+			continue
+		}
+		path := filepath.Join(baseDir, dirEntry.Name())
+		size, err := pathSize(path)
+		if err != nil {
+			return nil, fmt.Errorf("size sandbox runtime %q: %w", path, err)
+		}
+		info, err := dirEntry.Info()
+		if err != nil {
+			return nil, fmt.Errorf("inspect sandbox runtime %q: %w", path, err)
+		}
+		entry := Entry{
+			Kind:       KindSandboxRuntime,
+			ID:         dirEntry.Name(),
+			Path:       path,
+			SizeBytes:  size,
+			CreatedAt:  info.ModTime().UTC(),
+			LastUsedAt: info.ModTime().UTC(),
+		}
+		if !stateKnown {
+			entry.Reason = "daemon sandbox state unavailable"
+			entry.ProtectedBy = []string{"unknown daemon state"}
+		} else if _, ok := activeIDs[dirEntry.Name()]; ok {
+			entry.Reason = "known daemon sandbox"
+			entry.ProtectedBy = []string{"daemon state"}
+		} else {
+			entry.Reclaimable = true
+			entry.Reason = "not present in daemon state"
+		}
+		out = append(out, entry)
+	}
+	return out, nil
+}
+
+func scanOrphanSnapshotDirs(snapshotRoots []string, refs map[string][]string) ([]Entry, error) {
+	var out []Entry
+	seen := map[string]struct{}{}
+	for _, root := range snapshotRoots {
+		for _, backendName := range []string{"firecracker", "darwin-vz"} {
+			namespaceDir := filepath.Join(root, backendName)
+			dirEntries, err := os.ReadDir(namespaceDir)
+			if err != nil {
+				if errors.Is(err, os.ErrNotExist) {
+					continue
+				}
+				return nil, fmt.Errorf("read snapshot namespace %q: %w", namespaceDir, err)
+			}
+			for _, dirEntry := range dirEntries {
+				if !dirEntry.IsDir() {
+					continue
+				}
+				dirPath := filepath.Join(namespaceDir, dirEntry.Name())
+				if _, ok := seen[cleanPath(dirPath)]; ok {
+					continue
+				}
+				seen[cleanPath(dirPath)] = struct{}{}
+				rootFSPath := filepath.Join(dirPath, "rootfs.ext4")
+				if _, ok := refs[cleanPath(rootFSPath)]; ok {
+					continue
+				}
+				if _, ok := refs[cleanPath(dirPath)]; ok {
+					continue
+				}
+				size, err := pathSize(dirPath)
+				if err != nil {
+					return nil, fmt.Errorf("size orphan snapshot %q: %w", dirPath, err)
+				}
+				info, err := dirEntry.Info()
+				if err != nil {
+					return nil, fmt.Errorf("inspect orphan snapshot %q: %w", dirPath, err)
+				}
+				out = append(out, Entry{
+					Kind:        KindOrphanSnapshot,
+					ID:          dirEntry.Name(),
+					Backend:     backendName,
+					Path:        dirPath,
+					StorageRef:  rootFSPath,
+					SizeBytes:   size,
+					Reclaimable: true,
+					Reason:      "not referenced by snapshot or cache metadata",
+					CreatedAt:   info.ModTime().UTC(),
+					LastUsedAt:  info.ModTime().UTC(),
+				})
+			}
+		}
+	}
+	return out, nil
+}
+
+func scanRuntimeRootFS(cacheBase string) ([]Entry, error) {
+	var out []Entry
+	for _, backendName := range []string{"firecracker", "darwin-vz"} {
+		dir := filepath.Join(cacheBase, backendName, "runtime-rootfs")
+		dirEntries, err := os.ReadDir(dir)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return nil, fmt.Errorf("read runtime rootfs cache %q: %w", dir, err)
+		}
+		for _, dirEntry := range dirEntries {
+			if dirEntry.IsDir() {
+				continue
+			}
+			path := filepath.Join(dir, dirEntry.Name())
+			info, err := dirEntry.Info()
+			if err != nil {
+				return nil, fmt.Errorf("inspect runtime rootfs cache %q: %w", path, err)
+			}
+			out = append(out, Entry{
+				Kind:        KindRuntimeRootFS,
+				ID:          strings.TrimSuffix(dirEntry.Name(), filepath.Ext(dirEntry.Name())),
+				Backend:     backendName,
+				Path:        path,
+				SizeBytes:   info.Size(),
+				Reclaimable: false,
+				Reason:      "runtime rootfs cache preserved unless selected",
+				ProtectedBy: []string{"runtime rootfs cache"},
+				CreatedAt:   info.ModTime().UTC(),
+				LastUsedAt:  info.ModTime().UTC(),
+			})
+		}
+	}
+	return out, nil
+}
+
+func scanImageEntries(ctx context.Context, imageManager ImageManager) ([]Entry, error) {
+	records, err := imageManager.List(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list image cache metadata: %w", err)
+	}
+	out := make([]Entry, 0, len(records))
+	for _, record := range records {
+		var size int64
+		if path := strings.TrimSpace(record.RootFSPath); path != "" {
+			if actualSize, err := pathSize(path); err == nil && actualSize > 0 {
+				size = actualSize
+			} else if err == nil {
+				size = 0
+			} else if err != nil {
+				return nil, fmt.Errorf("size image cache %q: %w", record.Digest, err)
+			}
+		}
+		out = append(out, Entry{
+			Kind:        KindImageCache,
+			ID:          record.Digest,
+			Path:        record.RootFSPath,
+			SizeBytes:   size,
+			Reclaimable: false,
+			Reason:      "image cache metadata",
+			ProtectedBy: []string{"image metadata"},
+			CreatedAt:   record.CreatedAt,
+			LastUsedAt:  record.LastUsedAt,
+		})
+	}
+	return out, nil
+}
+
+func scanExecutionArtifacts(baseDir string, now time.Time, maxAge time.Duration) ([]Entry, error) {
+	dirEntries, err := os.ReadDir(baseDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read execution artifacts directory %q: %w", baseDir, err)
+	}
+	out := make([]Entry, 0, len(dirEntries))
+	for _, dirEntry := range dirEntries {
+		if !dirEntry.IsDir() {
+			continue
+		}
+		path := filepath.Join(baseDir, dirEntry.Name())
+		size, err := pathSize(path)
+		if err != nil {
+			return nil, fmt.Errorf("size execution artifacts %q: %w", path, err)
+		}
+		info, err := dirEntry.Info()
+		if err != nil {
+			return nil, fmt.Errorf("inspect execution artifacts %q: %w", path, err)
+		}
+		modTime := info.ModTime().UTC()
+		entry := Entry{
+			Kind:       KindExecutionArtifact,
+			ID:         dirEntry.Name(),
+			Path:       path,
+			SizeBytes:  size,
+			CreatedAt:  modTime,
+			LastUsedAt: modTime,
+		}
+		if now.Sub(modTime) > maxAge {
+			entry.Reclaimable = true
+			entry.Reason = fmt.Sprintf("older than %s", maxAge)
+		} else {
+			entry.Reason = "recent execution artifacts"
+			entry.ProtectedBy = []string{"execution retention window"}
+		}
+		out = append(out, entry)
+	}
+	return out, nil
+}
+
+func protectedRootEntry(kind, path string) (Entry, bool, error) {
+	size, err := pathSize(path)
+	if err != nil {
+		return Entry{}, false, fmt.Errorf("size %s root %q: %w", kind, path, err)
+	}
+	if size == 0 {
+		if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+			return Entry{}, false, nil
+		}
+	}
+	return Entry{
+		Kind:        kind,
+		Path:        path,
+		SizeBytes:   size,
+		Reclaimable: false,
+		Reason:      "preserved by default",
+		ProtectedBy: []string{"explicit prune not implemented"},
+	}, true, nil
+}
+
+func snapshotRoots(cfg runtimeconfig.Config) ([]string, error) {
+	defaultRoot, err := paths.SnapshotDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolve default snapshot dir: %w", err)
+	}
+	roots := []string{defaultRoot}
+	for _, snapshotCfg := range []runtimeconfig.SnapshotConfig{
+		cfg.Backends.Firecracker.Snapshots,
+		cfg.Backends.DarwinVZ.Snapshots,
+	} {
+		if baseDir := strings.TrimSpace(snapshotCfg.BaseDir); baseDir != "" {
+			roots = append(roots, baseDir)
+		}
+	}
+	return uniqueCleanPaths(roots), nil
+}
+
+func storageRefPath(storageRef string) string {
+	ref := strings.TrimSpace(storageRef)
+	if ref == "" || !filepath.IsAbs(ref) {
+		return ""
+	}
+	return cleanPath(ref)
+}
+
+func deletionPath(entry Entry) string {
+	switch entry.Kind {
+	case KindOrphanSnapshot:
+		return entry.Path
+	case KindStageCache:
+		if entry.Path == "" {
+			return ""
+		}
+		return filepath.Dir(entry.Path)
+	default:
+		return entry.Path
+	}
+}
+
+func removeOwnedPath(path string, roots []string) error {
+	path = cleanPath(path)
+	if path == "" {
+		return errors.New("missing prune path")
+	}
+	if !pathWithinAnyRoot(path, roots) {
+		return fmt.Errorf("refusing to remove %q outside cleanroom-owned roots", path)
+	}
+	if err := os.RemoveAll(path); err != nil {
+		return fmt.Errorf("remove %q: %w", path, err)
+	}
+	return nil
+}
+
+func pathWithinAnyRoot(path string, roots []string) bool {
+	path = cleanPath(path)
+	for _, root := range roots {
+		root = cleanPath(root)
+		if root == "" || path == root {
+			continue
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			continue
+		}
+		if rel != "." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && rel != ".." {
+			return true
+		}
+	}
+	return false
+}
+
+func pathSize(path string) (int64, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return 0, nil
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	if !info.IsDir() {
+		return allocatedFileSize(info), nil
+	}
+
+	var total int64
+	err = filepath.WalkDir(path, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		total += allocatedFileSize(info)
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+	return total, nil
+}
+
+func addPathReference(refs map[string][]string, path, reason string) {
+	path = cleanPath(path)
+	if path == "" {
+		return
+	}
+	refs[path] = append(refs[path], reason)
+}
+
+func olderThan(entry Entry, now time.Time, age time.Duration) bool {
+	if age <= 0 {
+		return false
+	}
+	t := entry.LastUsedAt
+	if t.IsZero() {
+		t = entry.CreatedAt
+	}
+	if t.IsZero() {
+		return false
+	}
+	return now.Sub(t) > age
+}
+
+func totalsByKind(entries []Entry) map[string]CategoryTotal {
+	totals := map[string]CategoryTotal{}
+	for _, entry := range entries {
+		total := totals[entry.Kind]
+		total.Count++
+		total.TotalBytes += entry.SizeBytes
+		if entry.Reclaimable {
+			total.ReclaimableBytes += entry.SizeBytes
+		} else {
+			total.ProtectedBytes += entry.SizeBytes
+		}
+		totals[entry.Kind] = total
+	}
+	return totals
+}
+
+func sortEntries(entries []Entry) {
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].Kind == entries[j].Kind {
+			if entries[i].ID == entries[j].ID {
+				return entries[i].Path < entries[j].Path
+			}
+			return entries[i].ID < entries[j].ID
+		}
+		return entries[i].Kind < entries[j].Kind
+	})
+}
+
+func stringSet(values []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			out[value] = struct{}{}
+		}
+	}
+	return out
+}
+
+func uniqueCleanPaths(paths []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(paths))
+	for _, path := range paths {
+		path = cleanPath(path)
+		if path == "" {
+			continue
+		}
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+		out = append(out, path)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func cleanPath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	if abs, err := filepath.Abs(path); err == nil {
+		return filepath.Clean(abs)
+	}
+	return filepath.Clean(path)
+}

--- a/internal/storagegc/storagegc.go
+++ b/internal/storagegc/storagegc.go
@@ -286,7 +286,7 @@ func PlanPrune(report Report, opts PruneOptions) Plan {
 				reclaimable = true
 				reason = fmt.Sprintf("older than %s", opts.OlderThan)
 			case KindStageCache:
-				if entry.Path != "" && stageCacheStorageExclusive(entry) {
+				if entry.Path != "" && stageCacheStorageExclusive(entry) && stageCacheStorageManaged(entry, report.SnapshotRoots) {
 					reclaimable = true
 					reason = fmt.Sprintf("stage cache older than %s", opts.OlderThan)
 				}
@@ -298,7 +298,7 @@ func PlanPrune(report Report, opts PruneOptions) Plan {
 				reclaimable = true
 				reason = "system cache selected by --all"
 			case KindStageCache:
-				if entry.Path != "" && stageCacheStorageExclusive(entry) {
+				if entry.Path != "" && stageCacheStorageExclusive(entry) && stageCacheStorageManaged(entry, report.SnapshotRoots) {
 					reclaimable = true
 					reason = "stage cache selected by --all"
 				}
@@ -310,10 +310,14 @@ func PlanPrune(report Report, opts PruneOptions) Plan {
 		if !reclaimable {
 			continue
 		}
+		actionPath, ok := deletionPathForReport(report, entry)
+		if !ok {
+			continue
+		}
 		action := Action{
 			Kind:      entry.Kind,
 			ID:        entry.ID,
-			Path:      deletionPath(entry),
+			Path:      actionPath,
 			SizeBytes: entry.SizeBytes,
 			Reason:    reason,
 			Entry:     entry,
@@ -365,7 +369,7 @@ func ExecutePrune(ctx context.Context, report Report, plan Plan, opts ExecuteOpt
 
 	result := Result{}
 	for _, action := range plan.Actions {
-		if err := executeAction(ctx, action, roots, cacheStore, imageManager); err != nil {
+		if err := executeAction(ctx, report, action, roots, cacheStore, imageManager); err != nil {
 			return result, err
 		}
 		result.DeletedEntries++
@@ -374,7 +378,7 @@ func ExecutePrune(ctx context.Context, report Report, plan Plan, opts ExecuteOpt
 	return result, nil
 }
 
-func executeAction(ctx context.Context, action Action, roots []string, cacheStore CacheStore, imageManager ImageManager) error {
+func executeAction(ctx context.Context, report Report, action Action, roots []string, cacheStore CacheStore, imageManager ImageManager) error {
 	switch action.Kind {
 	case KindImageCache:
 		if imageManager == nil {
@@ -385,8 +389,9 @@ func executeAction(ctx context.Context, action Action, roots []string, cacheStor
 		}
 		return nil
 	case KindStageCache:
-		if err := removeOwnedPath(action.Path, roots); err != nil {
-			return err
+		stageCachePath, ok := managedSnapshotDirectory(action.Entry.Path, report.SnapshotRoots, action.Entry.Backend)
+		if !ok {
+			return fmt.Errorf("refusing to remove stage-cache storage_ref %q outside managed snapshot storage", action.Entry.StorageRef)
 		}
 		if cacheStore == nil {
 			return errors.New("cache metadata store is not configured")
@@ -394,7 +399,7 @@ func executeAction(ctx context.Context, action Action, roots []string, cacheStor
 		if err := cacheStore.Delete(ctx, action.Entry.Stage, action.Entry.CacheKey); err != nil {
 			return fmt.Errorf("delete stage-cache metadata %q/%q: %w", action.Entry.Stage, action.Entry.CacheKey, err)
 		}
-		return nil
+		return removeOwnedPath(stageCachePath, roots)
 	default:
 		return removeOwnedPath(action.Path, roots)
 	}
@@ -564,7 +569,7 @@ func scanRuntimeRootFS(cacheBase string) ([]Entry, error) {
 				ID:          strings.TrimSuffix(dirEntry.Name(), filepath.Ext(dirEntry.Name())),
 				Backend:     backendName,
 				Path:        path,
-				SizeBytes:   info.Size(),
+				SizeBytes:   allocatedFileSize(info),
 				Reclaimable: false,
 				Reason:      "runtime rootfs cache preserved unless selected",
 				ProtectedBy: []string{"runtime rootfs cache"},
@@ -696,6 +701,15 @@ func storageRefPath(storageRef string) string {
 	return cleanPath(ref)
 }
 
+func deletionPathForReport(report Report, entry Entry) (string, bool) {
+	switch entry.Kind {
+	case KindStageCache:
+		return managedSnapshotDirectory(entry.Path, report.SnapshotRoots, entry.Backend)
+	default:
+		return deletionPath(entry), true
+	}
+}
+
 func deletionPath(entry Entry) string {
 	switch entry.Kind {
 	case KindOrphanSnapshot:
@@ -708,6 +722,41 @@ func deletionPath(entry Entry) string {
 	default:
 		return entry.Path
 	}
+}
+
+func stageCacheStorageManaged(entry Entry, snapshotRoots []string) bool {
+	_, ok := managedSnapshotDirectory(entry.Path, snapshotRoots, entry.Backend)
+	return ok
+}
+
+func managedSnapshotDirectory(path string, snapshotRoots []string, backendName string) (string, bool) {
+	path = cleanPath(path)
+	if path == "" || filepath.Base(path) != "rootfs.ext4" {
+		return "", false
+	}
+	backendName = strings.TrimSpace(backendName)
+	if backendName != "firecracker" && backendName != "darwin-vz" {
+		return "", false
+	}
+	for _, root := range snapshotRoots {
+		root = cleanPath(root)
+		if root == "" {
+			continue
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil || rel == "." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
+			continue
+		}
+		parts := strings.Split(rel, string(filepath.Separator))
+		if len(parts) != 3 {
+			continue
+		}
+		if parts[0] != backendName || strings.TrimSpace(parts[1]) == "" || parts[2] != "rootfs.ext4" {
+			continue
+		}
+		return filepath.Dir(path), true
+	}
+	return "", false
 }
 
 func removeOwnedPath(path string, roots []string) error {

--- a/internal/storagegc/storagegc_test.go
+++ b/internal/storagegc/storagegc_test.go
@@ -1,0 +1,363 @@
+package storagegc
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/buildkite/cleanroom/internal/cachestore"
+	"github.com/buildkite/cleanroom/internal/imagemgr"
+	"github.com/buildkite/cleanroom/internal/snapshotstore"
+)
+
+type stubSnapshotStore struct {
+	records []snapshotstore.Record
+	err     error
+}
+
+func (s stubSnapshotStore) List(context.Context) ([]snapshotstore.Record, error) {
+	return s.records, s.err
+}
+
+type stubCacheStore struct {
+	records []cachestore.Record
+	err     error
+	deleted []string
+}
+
+func (s *stubCacheStore) List(context.Context) ([]cachestore.Record, error) {
+	return s.records, s.err
+}
+
+func (s *stubCacheStore) Delete(_ context.Context, stage, cacheKey string) error {
+	s.deleted = append(s.deleted, stage+"/"+cacheKey)
+	return nil
+}
+
+type stubImageManager struct {
+	records []imagemgr.Record
+	err     error
+	removed []string
+}
+
+func (m *stubImageManager) List(context.Context) ([]imagemgr.Record, error) {
+	return m.records, m.err
+}
+
+func (m *stubImageManager) Remove(_ context.Context, selector string) ([]imagemgr.Record, error) {
+	m.removed = append(m.removed, selector)
+	return nil, nil
+}
+
+func TestInventoryProtectsReferencesAndFindsOrphans(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", filepath.Join(tmpDir, "state-home"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(tmpDir, "cache-home"))
+
+	stateBase := filepath.Join(tmpDir, "state-home", "cleanroom")
+	cacheBase := filepath.Join(tmpDir, "cache-home", "cleanroom")
+	now := time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)
+
+	activeSandboxPath := filepath.Join(stateBase, "sandboxes", "active-sandbox", "disk.img")
+	writeFile(t, activeSandboxPath, "active")
+	orphanSandboxPath := filepath.Join(stateBase, "sandboxes", "orphan-sandbox", "disk.img")
+	writeFile(t, orphanSandboxPath, strings.Repeat("o", 7))
+
+	snapshotRootFS := filepath.Join(stateBase, "snapshots", "darwin-vz", "snap-keep", "rootfs.ext4")
+	writeFile(t, snapshotRootFS, strings.Repeat("s", 11))
+	orphanSnapshotRootFS := filepath.Join(stateBase, "snapshots", "darwin-vz", "snap-orphan", "rootfs.ext4")
+	writeFile(t, orphanSnapshotRootFS, strings.Repeat("x", 13))
+	stageRootFS := filepath.Join(stateBase, "snapshots", "firecracker", "stage-keep", "rootfs.ext4")
+	writeFile(t, stageRootFS, strings.Repeat("c", 17))
+
+	oldExecutionFile := filepath.Join(stateBase, "executions", "exec-old", "stdout")
+	writeFile(t, oldExecutionFile, "old")
+	oldTime := now.Add(-48 * time.Hour)
+	if err := os.Chtimes(filepath.Dir(oldExecutionFile), oldTime, oldTime); err != nil {
+		t.Fatalf("set old execution mtime: %v", err)
+	}
+	recentExecutionFile := filepath.Join(stateBase, "executions", "exec-recent", "stdout")
+	writeFile(t, recentExecutionFile, "recent")
+	if err := os.Chtimes(filepath.Dir(recentExecutionFile), now.Add(-time.Hour), now.Add(-time.Hour)); err != nil {
+		t.Fatalf("set recent execution mtime: %v", err)
+	}
+
+	runtimeRootFS := filepath.Join(cacheBase, "darwin-vz", "runtime-rootfs", "abc.ext4")
+	writeFile(t, runtimeRootFS, strings.Repeat("r", 19))
+	imageRootFS := filepath.Join(cacheBase, "images", "digest.ext4")
+	writeFile(t, imageRootFS, strings.Repeat("i", 23))
+
+	report, err := Inventory(context.Background(), InventoryOptions{
+		ActiveSandboxIDs:  []string{"active-sandbox"},
+		SandboxStateKnown: true,
+		SnapshotStore: stubSnapshotStore{records: []snapshotstore.Record{
+			{
+				SnapshotID: "snap-keep",
+				Backend:    "darwin-vz",
+				StorageRef: snapshotRootFS,
+				CreatedAt:  now.Add(-3 * time.Hour),
+			},
+		}},
+		CacheStore: &stubCacheStore{records: []cachestore.Record{
+			{
+				Stage:      "dependencies",
+				CacheKey:   "cache-keep",
+				Backend:    "firecracker",
+				StorageRef: stageRootFS,
+				CreatedAt:  now.Add(-4 * time.Hour),
+				LastUsedAt: now.Add(-2 * time.Hour),
+			},
+		}},
+		ImageManager: &stubImageManager{records: []imagemgr.Record{
+			{
+				Digest:     "sha256:digest",
+				RootFSPath: imageRootFS,
+				SizeBytes:  1,
+				CreatedAt:  now.Add(-5 * time.Hour),
+				LastUsedAt: now.Add(-time.Hour),
+			},
+		}},
+		Now:             now,
+		ExecutionMaxAge: 24 * time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("Inventory returned error: %v", err)
+	}
+
+	assertEntry(t, report, KindSandboxRuntime, "active-sandbox", false, "known daemon sandbox")
+	assertEntry(t, report, KindSandboxRuntime, "orphan-sandbox", true, "not present in daemon state")
+	assertEntry(t, report, KindSnapshot, "snap-keep", false, "explicit snapshot metadata")
+	assertEntry(t, report, KindStageCache, "dependencies/cache-keep", false, "stage-cache metadata")
+	assertEntry(t, report, KindOrphanSnapshot, "snap-orphan", true, "not referenced by snapshot or cache metadata")
+	assertEntry(t, report, KindExecutionArtifact, "exec-old", true, "older than 24h0m0s")
+	assertEntry(t, report, KindExecutionArtifact, "exec-recent", false, "recent execution artifacts")
+	assertEntry(t, report, KindRuntimeRootFS, "abc", false, "runtime rootfs cache preserved unless selected")
+	assertEntry(t, report, KindImageCache, "sha256:digest", false, "image cache metadata")
+
+	expectedOrphanSize, err := pathSize(filepath.Dir(orphanSnapshotRootFS))
+	if err != nil {
+		t.Fatalf("size orphan snapshot fixture: %v", err)
+	}
+	if got, want := report.Totals[KindOrphanSnapshot].ReclaimableBytes, expectedOrphanSize; got != want {
+		t.Fatalf("unexpected orphan snapshot reclaimable bytes: got %d want %d", got, want)
+	}
+}
+
+func TestInventoryCountsAllocatedBytesForSparseFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", filepath.Join(tmpDir, "state-home"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(tmpDir, "cache-home"))
+
+	stateBase := filepath.Join(tmpDir, "state-home", "cleanroom")
+	sparseRootFS := filepath.Join(stateBase, "snapshots", "darwin-vz", "snap-orphan", "rootfs.ext4")
+	if err := os.MkdirAll(filepath.Dir(sparseRootFS), 0o755); err != nil {
+		t.Fatalf("create sparse snapshot directory: %v", err)
+	}
+	f, err := os.Create(sparseRootFS)
+	if err != nil {
+		t.Fatalf("create sparse rootfs: %v", err)
+	}
+	if err := f.Truncate(8 << 30); err != nil {
+		_ = f.Close()
+		t.Fatalf("truncate sparse rootfs: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close sparse rootfs: %v", err)
+	}
+
+	report, err := Inventory(context.Background(), InventoryOptions{
+		SandboxStateKnown: true,
+		SnapshotStore:     stubSnapshotStore{},
+		CacheStore:        &stubCacheStore{},
+		ImageManager:      &stubImageManager{},
+	})
+	if err != nil {
+		t.Fatalf("Inventory returned error: %v", err)
+	}
+	entry := findEntry(t, report, KindOrphanSnapshot, "snap-orphan")
+	if entry.SizeBytes >= 8<<30 {
+		t.Fatalf("expected sparse file to report allocated bytes below logical size, got %d", entry.SizeBytes)
+	}
+}
+
+func TestInventoryProtectsSandboxDirsWhenDaemonStateIsUnknown(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", filepath.Join(tmpDir, "state-home"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(tmpDir, "cache-home"))
+
+	stateBase := filepath.Join(tmpDir, "state-home", "cleanroom")
+	writeFile(t, filepath.Join(stateBase, "sandboxes", "maybe-active", "disk.img"), "active")
+
+	report, err := Inventory(context.Background(), InventoryOptions{
+		SandboxStateKnown: false,
+		SnapshotStore:     stubSnapshotStore{},
+		CacheStore:        &stubCacheStore{},
+		ImageManager:      &stubImageManager{},
+	})
+	if err != nil {
+		t.Fatalf("Inventory returned error: %v", err)
+	}
+	assertEntry(t, report, KindSandboxRuntime, "maybe-active", false, "daemon sandbox state unavailable")
+}
+
+func TestPlanPruneIncludesAllAndOlderThanCaches(t *testing.T) {
+	now := time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)
+	report := Report{Entries: []Entry{
+		{
+			Kind:       KindRuntimeRootFS,
+			ID:         "old-runtime",
+			Path:       "/tmp/runtime.ext4",
+			SizeBytes:  10,
+			LastUsedAt: now.Add(-48 * time.Hour),
+		},
+		{
+			Kind:       KindStageCache,
+			ID:         "dependencies/cache",
+			Stage:      "dependencies",
+			CacheKey:   "cache",
+			Path:       "/tmp/snapshots/firecracker/cache/rootfs.ext4",
+			SizeBytes:  20,
+			LastUsedAt: now.Add(-48 * time.Hour),
+		},
+		{
+			Kind:        KindStageCache,
+			ID:          "dependencies/shared",
+			Stage:       "dependencies",
+			CacheKey:    "shared",
+			Path:        "/tmp/snapshots/firecracker/shared/rootfs.ext4",
+			SizeBytes:   25,
+			ProtectedBy: []string{"stage-cache metadata", "snapshot metadata explicit"},
+			LastUsedAt:  now.Add(-48 * time.Hour),
+		},
+		{
+			Kind:       KindImageCache,
+			ID:         "sha256:image",
+			Path:       "/tmp/images/image.ext4",
+			SizeBytes:  30,
+			LastUsedAt: now.Add(-time.Hour),
+		},
+		{
+			Kind:      KindSnapshot,
+			ID:        "explicit",
+			Path:      "/tmp/snapshots/firecracker/explicit/rootfs.ext4",
+			SizeBytes: 40,
+		},
+	}}
+
+	agedPlan := PlanPrune(report, PruneOptions{OlderThan: 24 * time.Hour, Now: now})
+	if got, want := len(agedPlan.Actions), 2; got != want {
+		t.Fatalf("unexpected aged action count: got %d want %d", got, want)
+	}
+	assertPlanAction(t, agedPlan, KindRuntimeRootFS, "old-runtime")
+	assertPlanAction(t, agedPlan, KindStageCache, "dependencies/cache")
+
+	allPlan := PlanPrune(report, PruneOptions{All: true, Now: now})
+	if got, want := len(allPlan.Actions), 3; got != want {
+		t.Fatalf("unexpected --all action count: got %d want %d", got, want)
+	}
+	assertPlanAction(t, allPlan, KindRuntimeRootFS, "old-runtime")
+	assertPlanAction(t, allPlan, KindStageCache, "dependencies/cache")
+	assertPlanAction(t, allPlan, KindImageCache, "sha256:image")
+}
+
+func TestExecutePruneDeletesOwnedPathsAndStageCacheMetadata(t *testing.T) {
+	tmpDir := t.TempDir()
+	stageRootFS := filepath.Join(tmpDir, "state", "cleanroom", "snapshots", "firecracker", "cache", "rootfs.ext4")
+	writeFile(t, stageRootFS, "cache")
+	report := Report{
+		StateBaseDir:  filepath.Join(tmpDir, "state", "cleanroom"),
+		CacheBaseDir:  filepath.Join(tmpDir, "cache", "cleanroom"),
+		SnapshotRoots: []string{filepath.Join(tmpDir, "state", "cleanroom", "snapshots")},
+		Entries: []Entry{
+			{
+				Kind:       KindStageCache,
+				ID:         "dependencies/cache",
+				Stage:      "dependencies",
+				CacheKey:   "cache",
+				Path:       stageRootFS,
+				SizeBytes:  5,
+				LastUsedAt: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+	plan := PlanPrune(report, PruneOptions{All: true, Now: time.Date(2026, 5, 3, 0, 0, 0, 0, time.UTC)})
+	cacheStore := &stubCacheStore{}
+	result, err := ExecutePrune(context.Background(), report, plan, ExecuteOptions{CacheStore: cacheStore, ImageManager: &stubImageManager{}})
+	if err != nil {
+		t.Fatalf("ExecutePrune returned error: %v", err)
+	}
+	if got, want := result.DeletedEntries, 1; got != want {
+		t.Fatalf("unexpected deleted entries: got %d want %d", got, want)
+	}
+	if _, err := os.Stat(filepath.Dir(stageRootFS)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected stage cache directory to be removed, stat err=%v", err)
+	}
+	if got, want := cacheStore.deleted, []string{"dependencies/cache"}; len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("unexpected metadata deletes: got %v want %v", got, want)
+	}
+}
+
+func TestExecutePruneRefusesPathsOutsideCleanroomRoots(t *testing.T) {
+	tmpDir := t.TempDir()
+	report := Report{
+		StateBaseDir:  filepath.Join(tmpDir, "state", "cleanroom"),
+		CacheBaseDir:  filepath.Join(tmpDir, "cache", "cleanroom"),
+		SnapshotRoots: []string{filepath.Join(tmpDir, "state", "cleanroom", "snapshots")},
+	}
+	plan := Plan{
+		Actions: []Action{{
+			Kind: KindOrphanSnapshot,
+			ID:   "outside",
+			Path: filepath.Join(tmpDir, "outside"),
+		}},
+	}
+	if _, err := ExecutePrune(context.Background(), report, plan, ExecuteOptions{CacheStore: &stubCacheStore{}, ImageManager: &stubImageManager{}}); err == nil {
+		t.Fatal("expected ExecutePrune to refuse an outside path")
+	}
+}
+
+func assertEntry(t *testing.T, report Report, kind, id string, reclaimable bool, reason string) {
+	t.Helper()
+	entry := findEntry(t, report, kind, id)
+	if entry.Reclaimable != reclaimable {
+		t.Fatalf("entry %s/%s reclaimable got %t want %t", kind, id, entry.Reclaimable, reclaimable)
+	}
+	if !strings.Contains(entry.Reason, reason) {
+		t.Fatalf("entry %s/%s reason got %q want to contain %q", kind, id, entry.Reason, reason)
+	}
+}
+
+func findEntry(t *testing.T, report Report, kind, id string) Entry {
+	t.Helper()
+	for _, entry := range report.Entries {
+		if entry.Kind == kind && entry.ID == id {
+			return entry
+		}
+	}
+	t.Fatalf("entry %s/%s not found in %#v", kind, id, report.Entries)
+	return Entry{}
+}
+
+func assertPlanAction(t *testing.T, plan Plan, kind, id string) {
+	t.Helper()
+	for _, action := range plan.Actions {
+		if action.Kind == kind && action.ID == id {
+			return
+		}
+	}
+	t.Fatalf("action %s/%s not found in %#v", kind, id, plan.Actions)
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create parent for %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/internal/storagegc/storagegc_test.go
+++ b/internal/storagegc/storagegc_test.go
@@ -24,9 +24,10 @@ func (s stubSnapshotStore) List(context.Context) ([]snapshotstore.Record, error)
 }
 
 type stubCacheStore struct {
-	records []cachestore.Record
-	err     error
-	deleted []string
+	records   []cachestore.Record
+	err       error
+	deleteErr error
+	deleted   []string
 }
 
 func (s *stubCacheStore) List(context.Context) ([]cachestore.Record, error) {
@@ -35,6 +36,9 @@ func (s *stubCacheStore) List(context.Context) ([]cachestore.Record, error) {
 
 func (s *stubCacheStore) Delete(_ context.Context, stage, cacheKey string) error {
 	s.deleted = append(s.deleted, stage+"/"+cacheKey)
+	if s.deleteErr != nil {
+		return s.deleteErr
+	}
 	return nil
 }
 
@@ -153,21 +157,14 @@ func TestInventoryCountsAllocatedBytesForSparseFiles(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", filepath.Join(tmpDir, "cache-home"))
 
 	stateBase := filepath.Join(tmpDir, "state-home", "cleanroom")
+	cacheBase := filepath.Join(tmpDir, "cache-home", "cleanroom")
 	sparseRootFS := filepath.Join(stateBase, "snapshots", "darwin-vz", "snap-orphan", "rootfs.ext4")
 	if err := os.MkdirAll(filepath.Dir(sparseRootFS), 0o755); err != nil {
 		t.Fatalf("create sparse snapshot directory: %v", err)
 	}
-	f, err := os.Create(sparseRootFS)
-	if err != nil {
-		t.Fatalf("create sparse rootfs: %v", err)
-	}
-	if err := f.Truncate(8 << 30); err != nil {
-		_ = f.Close()
-		t.Fatalf("truncate sparse rootfs: %v", err)
-	}
-	if err := f.Close(); err != nil {
-		t.Fatalf("close sparse rootfs: %v", err)
-	}
+	writeSparseFile(t, sparseRootFS, 8<<30)
+	sparseRuntimeRootFS := filepath.Join(cacheBase, "darwin-vz", "runtime-rootfs", "runtime.ext4")
+	writeSparseFile(t, sparseRuntimeRootFS, 8<<30)
 
 	report, err := Inventory(context.Background(), InventoryOptions{
 		SandboxStateKnown: true,
@@ -181,6 +178,10 @@ func TestInventoryCountsAllocatedBytesForSparseFiles(t *testing.T) {
 	entry := findEntry(t, report, KindOrphanSnapshot, "snap-orphan")
 	if entry.SizeBytes >= 8<<30 {
 		t.Fatalf("expected sparse file to report allocated bytes below logical size, got %d", entry.SizeBytes)
+	}
+	runtimeEntry := findEntry(t, report, KindRuntimeRootFS, "runtime")
+	if runtimeEntry.SizeBytes >= 8<<30 {
+		t.Fatalf("expected sparse runtime rootfs to report allocated bytes below logical size, got %d", runtimeEntry.SizeBytes)
 	}
 }
 
@@ -206,47 +207,52 @@ func TestInventoryProtectsSandboxDirsWhenDaemonStateIsUnknown(t *testing.T) {
 
 func TestPlanPruneIncludesAllAndOlderThanCaches(t *testing.T) {
 	now := time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)
-	report := Report{Entries: []Entry{
-		{
-			Kind:       KindRuntimeRootFS,
-			ID:         "old-runtime",
-			Path:       "/tmp/runtime.ext4",
-			SizeBytes:  10,
-			LastUsedAt: now.Add(-48 * time.Hour),
+	report := Report{
+		SnapshotRoots: []string{"/tmp/snapshots"},
+		Entries: []Entry{
+			{
+				Kind:       KindRuntimeRootFS,
+				ID:         "old-runtime",
+				Path:       "/tmp/runtime.ext4",
+				SizeBytes:  10,
+				LastUsedAt: now.Add(-48 * time.Hour),
+			},
+			{
+				Kind:       KindStageCache,
+				ID:         "dependencies/cache",
+				Stage:      "dependencies",
+				CacheKey:   "cache",
+				Backend:    "firecracker",
+				Path:       "/tmp/snapshots/firecracker/cache/rootfs.ext4",
+				SizeBytes:  20,
+				LastUsedAt: now.Add(-48 * time.Hour),
+			},
+			{
+				Kind:        KindStageCache,
+				ID:          "dependencies/shared",
+				Stage:       "dependencies",
+				CacheKey:    "shared",
+				Backend:     "firecracker",
+				Path:        "/tmp/snapshots/firecracker/shared/rootfs.ext4",
+				SizeBytes:   25,
+				ProtectedBy: []string{"stage-cache metadata", "snapshot metadata explicit"},
+				LastUsedAt:  now.Add(-48 * time.Hour),
+			},
+			{
+				Kind:       KindImageCache,
+				ID:         "sha256:image",
+				Path:       "/tmp/images/image.ext4",
+				SizeBytes:  30,
+				LastUsedAt: now.Add(-time.Hour),
+			},
+			{
+				Kind:      KindSnapshot,
+				ID:        "explicit",
+				Path:      "/tmp/snapshots/firecracker/explicit/rootfs.ext4",
+				SizeBytes: 40,
+			},
 		},
-		{
-			Kind:       KindStageCache,
-			ID:         "dependencies/cache",
-			Stage:      "dependencies",
-			CacheKey:   "cache",
-			Path:       "/tmp/snapshots/firecracker/cache/rootfs.ext4",
-			SizeBytes:  20,
-			LastUsedAt: now.Add(-48 * time.Hour),
-		},
-		{
-			Kind:        KindStageCache,
-			ID:          "dependencies/shared",
-			Stage:       "dependencies",
-			CacheKey:    "shared",
-			Path:        "/tmp/snapshots/firecracker/shared/rootfs.ext4",
-			SizeBytes:   25,
-			ProtectedBy: []string{"stage-cache metadata", "snapshot metadata explicit"},
-			LastUsedAt:  now.Add(-48 * time.Hour),
-		},
-		{
-			Kind:       KindImageCache,
-			ID:         "sha256:image",
-			Path:       "/tmp/images/image.ext4",
-			SizeBytes:  30,
-			LastUsedAt: now.Add(-time.Hour),
-		},
-		{
-			Kind:      KindSnapshot,
-			ID:        "explicit",
-			Path:      "/tmp/snapshots/firecracker/explicit/rootfs.ext4",
-			SizeBytes: 40,
-		},
-	}}
+	}
 
 	agedPlan := PlanPrune(report, PruneOptions{OlderThan: 24 * time.Hour, Now: now})
 	if got, want := len(agedPlan.Actions), 2; got != want {
@@ -264,6 +270,50 @@ func TestPlanPruneIncludesAllAndOlderThanCaches(t *testing.T) {
 	assertPlanAction(t, allPlan, KindImageCache, "sha256:image")
 }
 
+func TestPlanPruneSkipsStageCacheOutsideManagedSnapshotStorage(t *testing.T) {
+	now := time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)
+	report := Report{
+		SnapshotRoots: []string{"/tmp/snapshots"},
+		Entries: []Entry{
+			{
+				Kind:       KindStageCache,
+				ID:         "dependencies/repo",
+				Stage:      "dependencies",
+				CacheKey:   "repo",
+				Backend:    "firecracker",
+				Path:       "/tmp/state/cleanroom/repos/rootfs.ext4",
+				SizeBytes:  20,
+				LastUsedAt: now.Add(-48 * time.Hour),
+			},
+			{
+				Kind:       KindStageCache,
+				ID:         "dependencies/nested",
+				Stage:      "dependencies",
+				CacheKey:   "nested",
+				Backend:    "firecracker",
+				Path:       "/tmp/snapshots/firecracker/cache/nested/rootfs.ext4",
+				SizeBytes:  20,
+				LastUsedAt: now.Add(-48 * time.Hour),
+			},
+			{
+				Kind:       KindStageCache,
+				ID:         "dependencies/wrong-backend",
+				Stage:      "dependencies",
+				CacheKey:   "wrong-backend",
+				Backend:    "darwin-vz",
+				Path:       "/tmp/snapshots/firecracker/cache/rootfs.ext4",
+				SizeBytes:  20,
+				LastUsedAt: now.Add(-48 * time.Hour),
+			},
+		},
+	}
+
+	allPlan := PlanPrune(report, PruneOptions{All: true, Now: now})
+	if got := len(allPlan.Actions); got != 0 {
+		t.Fatalf("expected no unmanaged stage-cache actions, got %#v", allPlan.Actions)
+	}
+}
+
 func TestExecutePruneDeletesOwnedPathsAndStageCacheMetadata(t *testing.T) {
 	tmpDir := t.TempDir()
 	stageRootFS := filepath.Join(tmpDir, "state", "cleanroom", "snapshots", "firecracker", "cache", "rootfs.ext4")
@@ -278,6 +328,7 @@ func TestExecutePruneDeletesOwnedPathsAndStageCacheMetadata(t *testing.T) {
 				ID:         "dependencies/cache",
 				Stage:      "dependencies",
 				CacheKey:   "cache",
+				Backend:    "firecracker",
 				Path:       stageRootFS,
 				SizeBytes:  5,
 				LastUsedAt: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
@@ -298,6 +349,38 @@ func TestExecutePruneDeletesOwnedPathsAndStageCacheMetadata(t *testing.T) {
 	}
 	if got, want := cacheStore.deleted, []string{"dependencies/cache"}; len(got) != len(want) || got[0] != want[0] {
 		t.Fatalf("unexpected metadata deletes: got %v want %v", got, want)
+	}
+}
+
+func TestExecutePruneKeepsStageCacheStorageWhenMetadataDeleteFails(t *testing.T) {
+	tmpDir := t.TempDir()
+	stageRootFS := filepath.Join(tmpDir, "state", "cleanroom", "snapshots", "firecracker", "cache", "rootfs.ext4")
+	writeFile(t, stageRootFS, "cache")
+	report := Report{
+		StateBaseDir:  filepath.Join(tmpDir, "state", "cleanroom"),
+		CacheBaseDir:  filepath.Join(tmpDir, "cache", "cleanroom"),
+		SnapshotRoots: []string{filepath.Join(tmpDir, "state", "cleanroom", "snapshots")},
+		Entries: []Entry{
+			{
+				Kind:       KindStageCache,
+				ID:         "dependencies/cache",
+				Stage:      "dependencies",
+				CacheKey:   "cache",
+				Backend:    "firecracker",
+				Path:       stageRootFS,
+				StorageRef: stageRootFS,
+				SizeBytes:  5,
+				LastUsedAt: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+	plan := PlanPrune(report, PruneOptions{All: true, Now: time.Date(2026, 5, 3, 0, 0, 0, 0, time.UTC)})
+	cacheStore := &stubCacheStore{deleteErr: errors.New("metadata locked")}
+	if _, err := ExecutePrune(context.Background(), report, plan, ExecuteOptions{CacheStore: cacheStore, ImageManager: &stubImageManager{}}); err == nil {
+		t.Fatal("expected ExecutePrune to return metadata delete error")
+	}
+	if _, err := os.Stat(filepath.Dir(stageRootFS)); err != nil {
+		t.Fatalf("expected stage cache directory to remain, stat err=%v", err)
 	}
 }
 
@@ -359,5 +442,23 @@ func writeFile(t *testing.T, path, content string) {
 	}
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func writeSparseFile(t *testing.T, path string, size int64) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create parent for %s: %v", path, err)
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create sparse file %s: %v", path, err)
+	}
+	if err := f.Truncate(size); err != nil {
+		_ = f.Close()
+		t.Fatalf("truncate sparse file %s: %v", path, err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close sparse file %s: %v", path, err)
 	}
 }


### PR DESCRIPTION
## Summary

Adds a backend-agnostic `cleanroom system` command group for inspecting and pruning host-side Cleanroom storage:

- `cleanroom system df [--json]` summarizes storage by category, including reclaimable and protected bytes.
- `cleanroom system prune [--dry-run] [--force] [--all] [--older-than] [--table] [--json]` plans and removes reclaimable storage.
- Default prune is conservative: orphan snapshot directories, orphan sandbox runtime directories, and old execution artifacts.
- Expanded cache pruning stays explicit with `--all`, and explicit snapshots, content-cache, repo mirrors, and changesets remain protected by default.

## Why

Cleanroom can leave large host-side state behind after interrupted runs, older daemon versions, or manual experiments. On a local machine this showed up as hundreds of GiB of orphan snapshot and sandbox runtime storage. The new commands make this visible and provide a Docker-prune-style cleanup path.

## Notes

Disk usage is based on allocated blocks on Darwin/Linux so APFS clones and sparse ext4 images report real disk pressure rather than logical image size.

## Validation

- `mise exec -- go test ./internal/cli ./internal/storagegc`
- `mise exec -- go test ./...`
- `mise exec -- go vet ./internal/cli ./internal/storagegc`
- `mise run build:go`
- `git diff --check`
- Local smoke tests for `cleanroom system df`, `cleanroom system prune --dry-run`, `--table`, and `--json`