### PR TITLE
feat: Add workspace copy-out writes

### DIFF
--- a/docs/plans/workspace-sync.md
+++ b/docs/plans/workspace-sync.md
@@ -3,17 +3,21 @@
 **Spec reference:** `spec.md` sections 5.1.1, 5.4, 5.4.2
 **Related plan:** `docs/plans/sandbox-transfer-invariants.md`
 **Status:** In progress
-**Last reviewed:** 2026-05-02
+**Last reviewed:** 2026-05-03
 
 ## Implementation Status
 
 - Phase 1 copy-in support landed in PR #251.
-- This changeset should land the read-only Phase 2 foundation:
+- PR #272 landed the read-only Phase 2 foundation:
   Git-backed `workspace diff`, Git-backed `workspace copy-out --dry-run`,
   sandbox-root resolution from the recorded repository checkout, and local-root
   safety that requires a matching local Git checkout before copy-out planning.
-- Local copy-out writes, local binding metadata, recoverable copy-out payloads,
-  top-level `--copy-out`, and `--sync` remain follow-up work.
+- This changeset should land the first write-capable Phase 2 slice: Git-backed
+  `workspace copy-out` applies sandbox changes to the matching local checkout,
+  saves a recoverable patch and manifest before applying, refuses local baseline
+  mismatches, and refuses target paths that changed independently.
+- Local binding metadata, non-Git/raw copy-out writes, top-level `--copy-out`,
+  and `--sync` remain follow-up work.
 
 ## Summary
 
@@ -220,6 +224,11 @@ checkout?" This is intentionally different from `workspace diff`.
 If local files diverged while the cleanroom was running, copy-out should fail
 closed and name the conflicting paths. A later conflict override can be added
 from concrete usage, but the initial copy-out path should be conflict-safe.
+
+The first write-capable implementation is Git-backed only. Until local binding
+metadata lands, unbound copy-out writes require the local checkout `HEAD` to
+match the sandbox's recorded repository baseline. If it does not match, the
+command saves the sandbox patch in Cleanroom state and refuses to write.
 
 ### `cleanroom workspace diff`
 
@@ -621,17 +630,17 @@ Status: landed.
 
 ### Phase 2: Workspace copy-out and diff
 
-- Add `cleanroom workspace copy-out --dry-run`.
-- Add `cleanroom workspace copy-out`.
-- Add `cleanroom workspace diff`.
-- Resolve the sandbox workspace root from `repository.path`, defaulting to
-  `/workspace`.
-- Add copy-out tests proving ignored cleanroom outputs are not written back to
-  the local checkout by default.
-- Add copy-out tests proving local divergence fails closed with no force or
-  overwrite mode.
-- Add copy-out tests proving an unbound copy-out refuses to write unless the
-  current working tree matches the sandbox repository identity.
+- PR #272: add `cleanroom workspace copy-out --dry-run`.
+- This changeset: add Git-backed `cleanroom workspace copy-out` writes.
+- PR #272: add `cleanroom workspace diff`.
+- PR #272: resolve the sandbox workspace root from `repository.path`, defaulting
+  to `/workspace`.
+- Covered by repository changeset tests: ignored cleanroom outputs are not
+  included in Git-backed copy-out candidates by default.
+- This changeset: add copy-out tests proving local divergence fails closed with
+  no force or overwrite mode.
+- This changeset: add copy-out tests proving an unbound copy-out refuses to
+  write unless the current working tree matches the sandbox repository baseline.
 - Require explicit sandbox IDs or support `--last` consistently with existing
   inspect commands.
 - Store local binding metadata in client-side Cleanroom state.

--- a/internal/cli/workspace.go
+++ b/internal/cli/workspace.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -12,10 +13,13 @@ import (
 	posixpath "path"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/buildkite/cleanroom/internal/controlclient"
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+	"github.com/buildkite/cleanroom/internal/paths"
 	"github.com/buildkite/cleanroom/internal/repositorychangeset"
 	"github.com/buildkite/cleanroom/internal/repositorycheckout"
 )
@@ -60,6 +64,27 @@ type workspacePlanEntry struct {
 	Path   string
 }
 
+type workspaceCopyOutRecoveryPayload struct {
+	Directory string
+	PatchPath string
+}
+
+type workspaceCopyOutRecoveryManifest struct {
+	CreatedAt         string                         `json:"created_at"`
+	SandboxID         string                         `json:"sandbox_id"`
+	LocalRoot         string                         `json:"local_root"`
+	SandboxRemoteURL  string                         `json:"sandbox_remote_url"`
+	SandboxCommitSHA  string                         `json:"sandbox_commit_sha"`
+	SandboxBranch     string                         `json:"sandbox_branch,omitempty"`
+	SandboxWorkspace  string                         `json:"sandbox_workspace"`
+	CandidateWorktree []workspaceCopyOutRecoveryFile `json:"candidate_worktree"`
+}
+
+type workspaceCopyOutRecoveryFile struct {
+	Action string `json:"action"`
+	Path   string `json:"path"`
+}
+
 func (c *WorkspaceCopyInCommand) Run(ctx *runtimeContext) error {
 	cwd, err := resolveCWD(ctx.CWD, c.Chdir)
 	if err != nil {
@@ -87,9 +112,6 @@ func (c *WorkspaceCopyOutCommand) Run(ctx *runtimeContext) error {
 	if err != nil {
 		return err
 	}
-	if !c.DryRun {
-		return errors.New("workspace copy-out writes are not implemented yet; use --dry-run to preview sandbox changes")
-	}
 	repository, err := resolveWorkspaceCopyRepositoryCheckout(cwd, ctx.Loader)
 	if err != nil {
 		return err
@@ -102,10 +124,10 @@ func (c *WorkspaceCopyOutCommand) Run(ctx *runtimeContext) error {
 	if err != nil {
 		return err
 	}
-	return previewWorkspaceCopyOut(context.Background(), ctx, client, workspaceCopyOptions{
+	return copyWorkspaceOut(context.Background(), ctx, client, workspaceCopyOptions{
 		CWD:        localRoot,
 		SandboxID:  c.SandboxID,
-		DryRun:     true,
+		DryRun:     c.DryRun,
 		Repository: repository,
 	})
 }
@@ -169,7 +191,7 @@ func copyGitWorkspaceToSandbox(callCtx context.Context, ctx *runtimeContext, cli
 	return runWorkspaceExecution(callCtx, ctx, client, opts.SandboxID, effectiveRepository, command, bytes.NewReader(changeset.Patch), opts.LaunchSeconds)
 }
 
-func previewWorkspaceCopyOut(callCtx context.Context, ctx *runtimeContext, client *controlclient.Client, opts workspaceCopyOptions) error {
+func copyWorkspaceOut(callCtx context.Context, ctx *runtimeContext, client *controlclient.Client, opts workspaceCopyOptions) error {
 	if strings.TrimSpace(opts.SandboxID) == "" {
 		return errors.New("missing sandbox id")
 	}
@@ -183,19 +205,65 @@ func previewWorkspaceCopyOut(callCtx context.Context, ctx *runtimeContext, clien
 	if err := validateWorkspaceCopyOutLocalRepository(opts.Repository, checkout); err != nil {
 		return err
 	}
-	command := repositorychangeset.WorktreeNameStatusCommand(checkout)
+	if opts.DryRun {
+		command := repositorychangeset.WorktreeNameStatusCommand(checkout)
+		if len(command) == 0 {
+			return errors.New("sandbox repository checkout is missing the information needed to plan workspace copy-out")
+		}
+		output, err := runWorkspaceExecutionCapture(callCtx, ctx, client, opts.SandboxID, command, opts.LaunchSeconds)
+		if err != nil {
+			return err
+		}
+		files, err := parseGitNameStatusWorkspaceFiles(output)
+		if err != nil {
+			return err
+		}
+		entries, err := gitWorkspaceCopyOutPlanFiles(opts.CWD, files)
+		if err != nil {
+			return err
+		}
+		return printWorkspacePlan(runtimeStdout(ctx), entries)
+	}
+
+	command := repositorychangeset.WorktreeCopyOutCommand(checkout)
 	if len(command) == 0 {
-		return errors.New("sandbox repository checkout is missing the information needed to plan workspace copy-out")
+		return errors.New("sandbox repository checkout is missing the information needed to copy workspace changes out")
 	}
 	output, err := runWorkspaceExecutionCapture(callCtx, ctx, client, opts.SandboxID, command, opts.LaunchSeconds)
 	if err != nil {
 		return err
 	}
-	entries, err := gitWorkspaceCopyOutPlan(opts.CWD, output)
+	nameStatus, patch, err := parseGitWorkspaceCopyOutPayload(output)
 	if err != nil {
 		return err
 	}
+	files, err := parseGitNameStatusWorkspaceFiles(nameStatus)
+	if err != nil {
+		return err
+	}
+	entries, err := gitWorkspaceCopyOutPlanFiles(opts.CWD, files)
+	if err != nil {
+		return err
+	}
+	if len(files) == 0 {
+		return nil
+	}
+	recovery, err := writeWorkspaceCopyOutRecoveryPayload(opts, checkout, files, patch)
+	if err != nil {
+		return err
+	}
+	if err := ensureGitWorkspaceCopyOutSafe(opts.Repository, checkout, files); err != nil {
+		return fmt.Errorf("%w; sandbox changes saved to %s", err, recovery.Directory)
+	}
+	if err := applyGitWorkspaceCopyOutPatch(opts.Repository.RootDir, recovery.PatchPath); err != nil {
+		return fmt.Errorf("%w; sandbox changes saved to %s", err, recovery.Directory)
+	}
 	return printWorkspacePlan(runtimeStdout(ctx), entries)
+}
+
+func previewWorkspaceCopyOut(callCtx context.Context, ctx *runtimeContext, client *controlclient.Client, opts workspaceCopyOptions) error {
+	opts.DryRun = true
+	return copyWorkspaceOut(callCtx, ctx, client, opts)
 }
 
 func diffWorkspaceInSandbox(callCtx context.Context, ctx *runtimeContext, client *controlclient.Client, opts workspaceCopyOptions) error {
@@ -244,6 +312,180 @@ func validateWorkspaceCopyOutLocalRepository(local *resolvedRepositoryCheckout, 
 		return fmt.Errorf("workspace copy-out local repository remote %q does not match sandbox repository remote %q", localRemote, sandboxRemote)
 	}
 	return nil
+}
+
+func ensureGitWorkspaceCopyOutSafe(local *resolvedRepositoryCheckout, checkout *repositorycheckout.Checkout, files []repositorychangeset.File) error {
+	if local == nil || strings.TrimSpace(local.RootDir) == "" {
+		return errors.New("workspace copy-out requires a local Git repository checkout matching the sandbox repository")
+	}
+	localCommit := strings.TrimSpace(local.CommitSHA)
+	sandboxCommit := ""
+	if checkout != nil {
+		sandboxCommit = strings.TrimSpace(checkout.CommitSHA)
+	}
+	if localCommit == "" || sandboxCommit == "" {
+		return errors.New("workspace copy-out requires local and sandbox repository commits")
+	}
+	if !strings.EqualFold(localCommit, sandboxCommit) {
+		return fmt.Errorf("workspace copy-out requires local checkout HEAD %s to match sandbox baseline %s", shortGitSHA(localCommit), shortGitSHA(sandboxCommit))
+	}
+	for _, file := range files {
+		if err := ensureGitWorkspaceCopyOutPathSafe(local.RootDir, sandboxCommit, file.Path); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func ensureGitWorkspaceCopyOutPathSafe(localRoot, baseCommit, rel string) error {
+	normalized, err := workspaceRelativePath(rel)
+	if err != nil {
+		return err
+	}
+	status, err := gitOutput(localRoot, "status", "--porcelain", "--", normalized)
+	if err != nil {
+		return fmt.Errorf("inspect local workspace path %q: %w", normalized, err)
+	}
+	if strings.TrimSpace(status) != "" {
+		return fmt.Errorf("local workspace path %q changed independently; refusing workspace copy-out", normalized)
+	}
+	existsInBaseline, err := gitPathExistsInCommit(localRoot, baseCommit, normalized)
+	if err != nil {
+		return err
+	}
+	if existsInBaseline {
+		return nil
+	}
+	localPath, err := workspaceLocalPath(localRoot, normalized)
+	if err != nil {
+		return err
+	}
+	if _, err := os.Lstat(localPath); err == nil {
+		return fmt.Errorf("local workspace path %q exists outside sandbox baseline; refusing workspace copy-out", normalized)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("inspect local workspace path %q: %w", normalized, err)
+	}
+	return nil
+}
+
+func gitPathExistsInCommit(localRoot, commit, rel string) (bool, error) {
+	output, err := gitOutput(localRoot, "ls-tree", "--name-only", "-z", commit, "--", rel)
+	if err != nil {
+		return false, fmt.Errorf("inspect sandbox baseline path %q: %w", rel, err)
+	}
+	return strings.Trim(output, "\x00 \n\r\t") != "", nil
+}
+
+func applyGitWorkspaceCopyOutPatch(localRoot, patchPath string) error {
+	if strings.TrimSpace(localRoot) == "" {
+		return errors.New("missing local workspace root")
+	}
+	if strings.TrimSpace(patchPath) == "" {
+		return errors.New("missing workspace copy-out patch")
+	}
+	if _, err := gitOutput(localRoot, "apply", "--binary", "--whitespace=nowarn", patchPath); err != nil {
+		return fmt.Errorf("apply workspace copy-out patch: %w", err)
+	}
+	return nil
+}
+
+func writeWorkspaceCopyOutRecoveryPayload(opts workspaceCopyOptions, checkout *repositorycheckout.Checkout, files []repositorychangeset.File, patch []byte) (*workspaceCopyOutRecoveryPayload, error) {
+	base, err := paths.StateBaseDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolve workspace copy-out state directory: %w", err)
+	}
+	recoveryRoot := filepath.Join(base, "workspace-copy-out")
+	if err := os.MkdirAll(recoveryRoot, 0o700); err != nil {
+		return nil, fmt.Errorf("create workspace copy-out state directory: %w", err)
+	}
+	payloadDir, err := os.MkdirTemp(recoveryRoot, safeWorkspaceStateName(opts.SandboxID)+"-")
+	if err != nil {
+		return nil, fmt.Errorf("create workspace copy-out recovery payload: %w", err)
+	}
+	patchPath := filepath.Join(payloadDir, "changes.patch")
+	if err := os.WriteFile(patchPath, patch, 0o600); err != nil {
+		return nil, fmt.Errorf("write workspace copy-out recovery patch: %w", err)
+	}
+	manifest := workspaceCopyOutRecoveryManifest{
+		CreatedAt:         time.Now().UTC().Format(time.RFC3339Nano),
+		SandboxID:         strings.TrimSpace(opts.SandboxID),
+		LocalRoot:         strings.TrimSpace(opts.CWD),
+		CandidateWorktree: workspaceCopyOutRecoveryFiles(files),
+	}
+	if checkout != nil {
+		manifest.SandboxRemoteURL = strings.TrimSpace(checkout.RemoteURL)
+		manifest.SandboxCommitSHA = strings.TrimSpace(checkout.CommitSHA)
+		manifest.SandboxBranch = strings.TrimSpace(checkout.Branch)
+		manifest.SandboxWorkspace = strings.TrimSpace(checkout.DestinationDir)
+	}
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("encode workspace copy-out recovery manifest: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(filepath.Join(payloadDir, "manifest.json"), data, 0o600); err != nil {
+		return nil, fmt.Errorf("write workspace copy-out recovery manifest: %w", err)
+	}
+	return &workspaceCopyOutRecoveryPayload{
+		Directory: payloadDir,
+		PatchPath: patchPath,
+	}, nil
+}
+
+func workspaceCopyOutRecoveryFiles(files []repositorychangeset.File) []workspaceCopyOutRecoveryFile {
+	recoveryFiles := make([]workspaceCopyOutRecoveryFile, 0, len(files))
+	for _, file := range files {
+		action := "write"
+		if file.Deleted {
+			action = "delete"
+		}
+		recoveryFiles = append(recoveryFiles, workspaceCopyOutRecoveryFile{
+			Action: action,
+			Path:   file.Path,
+		})
+	}
+	sort.Slice(recoveryFiles, func(i, j int) bool {
+		if recoveryFiles[i].Action != recoveryFiles[j].Action {
+			return recoveryFiles[i].Action < recoveryFiles[j].Action
+		}
+		return recoveryFiles[i].Path < recoveryFiles[j].Path
+	})
+	return recoveryFiles
+}
+
+func safeWorkspaceStateName(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "sandbox"
+	}
+	var b strings.Builder
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '-' || r == '_' || r == '.':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('-')
+		}
+	}
+	name := strings.Trim(b.String(), "-.")
+	if name == "" {
+		return "sandbox"
+	}
+	return name
+}
+
+func shortGitSHA(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) <= 12 {
+		return value
+	}
+	return value[:12]
 }
 
 func resolveGitWorkspaceCheckout(callCtx context.Context, client *controlclient.Client, opts workspaceCopyOptions) (*resolvedRepositoryCheckout, *repositorycheckout.Checkout, error) {
@@ -337,6 +579,10 @@ func gitWorkspaceCopyOutPlan(localRoot string, nameStatus []byte) ([]workspacePl
 	if err != nil {
 		return nil, err
 	}
+	return gitWorkspaceCopyOutPlanFiles(localRoot, files)
+}
+
+func gitWorkspaceCopyOutPlanFiles(localRoot string, files []repositorychangeset.File) ([]workspacePlanEntry, error) {
 	entries := make([]workspacePlanEntry, 0, len(files))
 	for _, file := range files {
 		localPath, err := workspaceLocalPath(localRoot, file.Path)
@@ -354,6 +600,35 @@ func gitWorkspaceCopyOutPlan(localRoot string, nameStatus []byte) ([]workspacePl
 	}
 	sortWorkspacePlan(entries)
 	return entries, nil
+}
+
+func parseGitWorkspaceCopyOutPayload(output []byte) ([]byte, []byte, error) {
+	header, payload, ok := bytes.Cut(output, []byte("\n"))
+	if !ok {
+		return nil, nil, errors.New("parse workspace copy-out payload: missing header")
+	}
+	fields := strings.Fields(string(header))
+	if len(fields) != 3 || fields[0] != "cleanroom-copy-out-v1" {
+		return nil, nil, fmt.Errorf("parse workspace copy-out payload header %q", string(header))
+	}
+	nameStatusSize, err := strconv.ParseInt(fields[1], 10, 64)
+	if err != nil || nameStatusSize < 0 {
+		return nil, nil, fmt.Errorf("parse workspace copy-out name-status size %q", fields[1])
+	}
+	patchSize, err := strconv.ParseInt(fields[2], 10, 64)
+	if err != nil || patchSize < 0 {
+		return nil, nil, fmt.Errorf("parse workspace copy-out patch size %q", fields[2])
+	}
+	totalSize := nameStatusSize + patchSize
+	if totalSize < nameStatusSize || totalSize > int64(len(payload)) {
+		return nil, nil, fmt.Errorf("parse workspace copy-out payload: expected %d bytes after header, got %d", totalSize, len(payload))
+	}
+	if totalSize != int64(len(payload)) {
+		return nil, nil, fmt.Errorf("parse workspace copy-out payload: unexpected trailing data after %d bytes", totalSize)
+	}
+	nameStatus := payload[:nameStatusSize]
+	patch := payload[nameStatusSize:totalSize]
+	return nameStatus, patch, nil
 }
 
 func parseGitNameStatusWorkspaceFiles(output []byte) ([]repositorychangeset.File, error) {

--- a/internal/cli/workspace_test.go
+++ b/internal/cli/workspace_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -826,6 +827,314 @@ func TestWorkspaceCopyOutDryRunReportsSandboxGitPlan(t *testing.T) {
 	}
 }
 
+func TestWorkspaceCopyOutAppliesSandboxGitPatch(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	localRoot := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
+	if err := os.WriteFile(filepath.Join(localRoot, "removed.txt"), []byte("remove me\n"), 0o644); err != nil {
+		t.Fatalf("write removed file: %v", err)
+	}
+	runGitInDir(t, localRoot, "add", "removed.txt")
+	runGitInDir(t, localRoot, "commit", "-m", "add removed file")
+	baseCommit := headCommit(t, localRoot)
+
+	if err := os.WriteFile(filepath.Join(localRoot, "README.md"), []byte("sandbox\n"), 0o644); err != nil {
+		t.Fatalf("write sandbox readme: %v", err)
+	}
+	if err := os.Remove(filepath.Join(localRoot, "removed.txt")); err != nil {
+		t.Fatalf("remove sandbox file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(localRoot, "new.txt"), []byte("new\n"), 0o644); err != nil {
+		t.Fatalf("write sandbox new file: %v", err)
+	}
+	runGitInDir(t, localRoot, "add", "-A")
+	nameStatus := gitOutputBytes(t, localRoot, "diff", "--cached", "--name-status", "--no-renames", "-z", baseCommit)
+	patch := gitOutputBytes(t, localRoot, "diff", "--cached", "--binary", "--full-index", "--no-ext-diff", "--no-color", "--no-renames", baseCommit)
+	runGitInDir(t, localRoot, "reset", "--hard", baseCommit)
+	runGitInDir(t, localRoot, "clean", "-fd")
+	resolvedLocalRoot, err := gitOutput(localRoot, "rev-parse", "--show-toplevel")
+	if err != nil {
+		t.Fatalf("resolve local repository root: %v", err)
+	}
+
+	adapter := &integrationAdapter{}
+	host, _ := startIntegrationServer(t, adapter)
+	sandboxID := createWorkspaceCopyTestSandboxWithRepositoryCommitBranch(t, host, "/sandbox-workspace", baseCommit, "main")
+
+	var (
+		mu       sync.Mutex
+		commands [][]string
+	)
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+		mu.Lock()
+		commands = append(commands, append([]string(nil), req.Command...))
+		mu.Unlock()
+		command := strings.Join(req.Command, " ")
+		switch {
+		case strings.Contains(command, "cleanroom-copy-out-v1"):
+			if stream.OnStdout != nil {
+				stream.OnStdout(workspaceCopyOutTestPayload(nameStatus, patch))
+			}
+		default:
+			t.Fatalf("unexpected workspace copy-out command: %q", command)
+		}
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+	}
+
+	stdout, stdoutText := makeStdoutCapture(t)
+	stderr, _ := makeStdoutCapture(t)
+	cmd := WorkspaceCopyOutCommand{
+		clientFlags: clientFlags{Host: host},
+		Chdir:       localRoot,
+		SandboxID:   sandboxID,
+	}
+	if err := cmd.Run(&runtimeContext{
+		CWD:           localRoot,
+		Loader:        repositoryNotFoundLoader{},
+		Config:        runtimeconfig.Config{},
+		Observability: newTestObservability(t),
+		Stdout:        stdout,
+		Stderr:        stderr,
+	}); err != nil {
+		t.Fatalf("WorkspaceCopyOutCommand.Run returned error: %v", err)
+	}
+
+	readme, err := os.ReadFile(filepath.Join(localRoot, "README.md"))
+	if err != nil {
+		t.Fatalf("read README: %v", err)
+	}
+	if got, want := string(readme), "sandbox\n"; got != want {
+		t.Fatalf("unexpected README content: got %q want %q", got, want)
+	}
+	newFile, err := os.ReadFile(filepath.Join(localRoot, "new.txt"))
+	if err != nil {
+		t.Fatalf("read new file: %v", err)
+	}
+	if got, want := string(newFile), "new\n"; got != want {
+		t.Fatalf("unexpected new file content: got %q want %q", got, want)
+	}
+	if _, err := os.Stat(filepath.Join(localRoot, "removed.txt")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected removed file to be deleted, got err %v", err)
+	}
+
+	expected := strings.Join([]string{
+		"delete\t" + filepath.Join(resolvedLocalRoot, "removed.txt"),
+		"write\t" + filepath.Join(resolvedLocalRoot, "README.md"),
+		"write\t" + filepath.Join(resolvedLocalRoot, "new.txt"),
+		"",
+	}, "\n")
+	if got := stdoutText(); got != expected {
+		t.Fatalf("unexpected copy-out output: got %q want %q", got, expected)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(commands) != 1 {
+		t.Fatalf("expected one combined copy-out execution, got %d", len(commands))
+	}
+	assertWorkspaceCopyOutRecoveryPayload(t, sandboxID)
+}
+
+func TestWorkspaceCopyOutRejectsLocalDivergence(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	localRoot := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
+	baseCommit := headCommit(t, localRoot)
+
+	if err := os.WriteFile(filepath.Join(localRoot, "README.md"), []byte("sandbox\n"), 0o644); err != nil {
+		t.Fatalf("write sandbox readme: %v", err)
+	}
+	runGitInDir(t, localRoot, "add", "README.md")
+	nameStatus := gitOutputBytes(t, localRoot, "diff", "--cached", "--name-status", "--no-renames", "-z", baseCommit)
+	patch := gitOutputBytes(t, localRoot, "diff", "--cached", "--binary", "--full-index", "--no-ext-diff", "--no-color", "--no-renames", baseCommit)
+	runGitInDir(t, localRoot, "reset", "--hard", baseCommit)
+	if err := os.WriteFile(filepath.Join(localRoot, "README.md"), []byte("local\n"), 0o644); err != nil {
+		t.Fatalf("write local readme: %v", err)
+	}
+
+	adapter := &integrationAdapter{}
+	host, _ := startIntegrationServer(t, adapter)
+	sandboxID := createWorkspaceCopyTestSandboxWithRepositoryCommitBranch(t, host, "/sandbox-workspace", baseCommit, "main")
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+		command := strings.Join(req.Command, " ")
+		switch {
+		case strings.Contains(command, "cleanroom-copy-out-v1"):
+			if stream.OnStdout != nil {
+				stream.OnStdout(workspaceCopyOutTestPayload(nameStatus, patch))
+			}
+		default:
+			t.Fatalf("unexpected workspace copy-out command: %q", command)
+		}
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+	}
+
+	stdout, _ := makeStdoutCapture(t)
+	stderr, _ := makeStdoutCapture(t)
+	cmd := WorkspaceCopyOutCommand{
+		clientFlags: clientFlags{Host: host},
+		Chdir:       localRoot,
+		SandboxID:   sandboxID,
+	}
+	err := cmd.Run(&runtimeContext{
+		CWD:           localRoot,
+		Loader:        repositoryNotFoundLoader{},
+		Config:        runtimeconfig.Config{},
+		Observability: newTestObservability(t),
+		Stdout:        stdout,
+		Stderr:        stderr,
+	})
+	if err == nil {
+		t.Fatal("expected local divergence to be rejected")
+	}
+	if !strings.Contains(err.Error(), `local workspace path "README.md" changed independently`) {
+		t.Fatalf("expected local path divergence error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "sandbox changes saved to") {
+		t.Fatalf("expected recovery payload path in error, got %v", err)
+	}
+	readme, err := os.ReadFile(filepath.Join(localRoot, "README.md"))
+	if err != nil {
+		t.Fatalf("read README: %v", err)
+	}
+	if got, want := string(readme), "local\n"; got != want {
+		t.Fatalf("copy-out should not overwrite divergent local file: got %q want %q", got, want)
+	}
+	assertWorkspaceCopyOutRecoveryPayload(t, sandboxID)
+}
+
+func TestWorkspaceCopyOutRejectsIgnoredLocalTarget(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	localRoot := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
+	if err := os.WriteFile(filepath.Join(localRoot, ".gitignore"), []byte("ignored/\n"), 0o644); err != nil {
+		t.Fatalf("write gitignore: %v", err)
+	}
+	runGitInDir(t, localRoot, "add", ".gitignore")
+	runGitInDir(t, localRoot, "commit", "-m", "ignore output")
+	baseCommit := headCommit(t, localRoot)
+
+	if err := os.MkdirAll(filepath.Join(localRoot, "ignored"), 0o755); err != nil {
+		t.Fatalf("create ignored dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(localRoot, "ignored", "output.txt"), []byte("sandbox\n"), 0o644); err != nil {
+		t.Fatalf("write sandbox ignored output: %v", err)
+	}
+	runGitInDir(t, localRoot, "add", "-f", "ignored/output.txt")
+	nameStatus := gitOutputBytes(t, localRoot, "diff", "--cached", "--name-status", "--no-renames", "-z", baseCommit)
+	patch := gitOutputBytes(t, localRoot, "diff", "--cached", "--binary", "--full-index", "--no-ext-diff", "--no-color", "--no-renames", baseCommit)
+	runGitInDir(t, localRoot, "reset", "--hard", baseCommit)
+	if err := os.MkdirAll(filepath.Join(localRoot, "ignored"), 0o755); err != nil {
+		t.Fatalf("recreate ignored dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(localRoot, "ignored", "output.txt"), []byte("local ignored\n"), 0o644); err != nil {
+		t.Fatalf("write local ignored output: %v", err)
+	}
+
+	adapter := &integrationAdapter{}
+	host, _ := startIntegrationServer(t, adapter)
+	sandboxID := createWorkspaceCopyTestSandboxWithRepositoryCommitBranch(t, host, "/sandbox-workspace", baseCommit, "main")
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+		command := strings.Join(req.Command, " ")
+		switch {
+		case strings.Contains(command, "cleanroom-copy-out-v1"):
+			if stream.OnStdout != nil {
+				stream.OnStdout(workspaceCopyOutTestPayload(nameStatus, patch))
+			}
+		default:
+			t.Fatalf("unexpected workspace copy-out command: %q", command)
+		}
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+	}
+
+	stdout, _ := makeStdoutCapture(t)
+	stderr, _ := makeStdoutCapture(t)
+	cmd := WorkspaceCopyOutCommand{
+		clientFlags: clientFlags{Host: host},
+		Chdir:       localRoot,
+		SandboxID:   sandboxID,
+	}
+	err := cmd.Run(&runtimeContext{
+		CWD:           localRoot,
+		Loader:        repositoryNotFoundLoader{},
+		Config:        runtimeconfig.Config{},
+		Observability: newTestObservability(t),
+		Stdout:        stdout,
+		Stderr:        stderr,
+	})
+	if err == nil {
+		t.Fatal("expected ignored local target to be rejected")
+	}
+	if !strings.Contains(err.Error(), `local workspace path "ignored/output.txt" exists outside sandbox baseline`) {
+		t.Fatalf("expected ignored local path conflict, got %v", err)
+	}
+	output, err := os.ReadFile(filepath.Join(localRoot, "ignored", "output.txt"))
+	if err != nil {
+		t.Fatalf("read ignored output: %v", err)
+	}
+	if got, want := string(output), "local ignored\n"; got != want {
+		t.Fatalf("copy-out should not overwrite ignored local file: got %q want %q", got, want)
+	}
+	assertWorkspaceCopyOutRecoveryPayload(t, sandboxID)
+}
+
+func TestWorkspaceCopyOutRejectsBaselineMismatch(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	localRoot := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
+	baseCommit := headCommit(t, localRoot)
+
+	if err := os.WriteFile(filepath.Join(localRoot, "README.md"), []byte("sandbox\n"), 0o644); err != nil {
+		t.Fatalf("write sandbox readme: %v", err)
+	}
+	runGitInDir(t, localRoot, "add", "README.md")
+	nameStatus := gitOutputBytes(t, localRoot, "diff", "--cached", "--name-status", "--no-renames", "-z", baseCommit)
+	patch := gitOutputBytes(t, localRoot, "diff", "--cached", "--binary", "--full-index", "--no-ext-diff", "--no-color", "--no-renames", baseCommit)
+	runGitInDir(t, localRoot, "reset", "--hard", baseCommit)
+	if err := os.WriteFile(filepath.Join(localRoot, "local.txt"), []byte("local commit\n"), 0o644); err != nil {
+		t.Fatalf("write local commit file: %v", err)
+	}
+	runGitInDir(t, localRoot, "add", "local.txt")
+	runGitInDir(t, localRoot, "commit", "-m", "local commit")
+
+	adapter := &integrationAdapter{}
+	host, _ := startIntegrationServer(t, adapter)
+	sandboxID := createWorkspaceCopyTestSandboxWithRepositoryCommitBranch(t, host, "/sandbox-workspace", baseCommit, "main")
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+		command := strings.Join(req.Command, " ")
+		switch {
+		case strings.Contains(command, "cleanroom-copy-out-v1"):
+			if stream.OnStdout != nil {
+				stream.OnStdout(workspaceCopyOutTestPayload(nameStatus, patch))
+			}
+		default:
+			t.Fatalf("unexpected workspace copy-out command: %q", command)
+		}
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+	}
+
+	stdout, _ := makeStdoutCapture(t)
+	stderr, _ := makeStdoutCapture(t)
+	cmd := WorkspaceCopyOutCommand{
+		clientFlags: clientFlags{Host: host},
+		Chdir:       localRoot,
+		SandboxID:   sandboxID,
+	}
+	err := cmd.Run(&runtimeContext{
+		CWD:           localRoot,
+		Loader:        repositoryNotFoundLoader{},
+		Config:        runtimeconfig.Config{},
+		Observability: newTestObservability(t),
+		Stdout:        stdout,
+		Stderr:        stderr,
+	})
+	if err == nil {
+		t.Fatal("expected baseline mismatch to be rejected")
+	}
+	if !strings.Contains(err.Error(), "requires local checkout HEAD") {
+		t.Fatalf("expected baseline mismatch error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "sandbox changes saved to") {
+		t.Fatalf("expected recovery payload path in error, got %v", err)
+	}
+	assertWorkspaceCopyOutRecoveryPayload(t, sandboxID)
+}
+
 func TestWorkspaceCopyOutPlanRejectsWindowsDrivePaths(t *testing.T) {
 	for _, rel := range []string{
 		"C:/tmp.txt",
@@ -856,6 +1165,24 @@ func TestWorkspaceCopyOutPlanAllowsRelativeColonPaths(t *testing.T) {
 	}
 	if !reflect.DeepEqual(entries, expected) {
 		t.Fatalf("unexpected copy-out plan: got %+v want %+v", entries, expected)
+	}
+}
+
+func TestParseGitWorkspaceCopyOutPayload(t *testing.T) {
+	nameStatus := []byte("M\x00changed.txt\x00")
+	patch := []byte("diff --git a/changed.txt b/changed.txt\n")
+	gotNameStatus, gotPatch, err := parseGitWorkspaceCopyOutPayload(workspaceCopyOutTestPayload(nameStatus, patch))
+	if err != nil {
+		t.Fatalf("parseGitWorkspaceCopyOutPayload returned error: %v", err)
+	}
+	if !bytes.Equal(gotNameStatus, nameStatus) {
+		t.Fatalf("unexpected name-status payload: got %q want %q", gotNameStatus, nameStatus)
+	}
+	if !bytes.Equal(gotPatch, patch) {
+		t.Fatalf("unexpected patch payload: got %q want %q", gotPatch, patch)
+	}
+	if _, _, err := parseGitWorkspaceCopyOutPayload([]byte("cleanroom-copy-out-v1 1 1\nabc")); err == nil {
+		t.Fatal("expected trailing payload data to be rejected")
 	}
 }
 
@@ -1485,6 +1812,53 @@ func workspaceCopyRepositoryLoader() repositoryIntegrationLoader {
 			Path:   "/workspace",
 		},
 	}
+}
+
+func assertWorkspaceCopyOutRecoveryPayload(t *testing.T, sandboxID string) {
+	t.Helper()
+	recoveryRoot := filepath.Join(os.Getenv("XDG_STATE_HOME"), "cleanroom", "workspace-copy-out")
+	entries, err := os.ReadDir(recoveryRoot)
+	if err != nil {
+		t.Fatalf("read workspace copy-out recovery root: %v", err)
+	}
+	prefix := safeWorkspaceStateName(sandboxID) + "-"
+	var matches []os.DirEntry
+	for _, entry := range entries {
+		if entry.IsDir() && strings.HasPrefix(entry.Name(), prefix) {
+			matches = append(matches, entry)
+		}
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected one recovery payload for %q, got %d", sandboxID, len(matches))
+	}
+	payloadDir := filepath.Join(recoveryRoot, matches[0].Name())
+	for _, name := range []string{"changes.patch", "manifest.json"} {
+		info, err := os.Stat(filepath.Join(payloadDir, name))
+		if err != nil {
+			t.Fatalf("expected recovery payload %s: %v", name, err)
+		}
+		if info.Size() == 0 {
+			t.Fatalf("expected non-empty recovery payload %s", name)
+		}
+	}
+}
+
+func gitOutputBytes(t *testing.T, dir string, args ...string) []byte {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, string(out))
+	}
+	return out
+}
+
+func workspaceCopyOutTestPayload(nameStatus, patch []byte) []byte {
+	payload := []byte(fmt.Sprintf("cleanroom-copy-out-v1 %d %d\n", len(nameStatus), len(patch)))
+	payload = append(payload, nameStatus...)
+	payload = append(payload, patch...)
+	return payload
 }
 
 func runGitInDir(t *testing.T, dir string, args ...string) {

--- a/internal/repositorychangeset/changeset.go
+++ b/internal/repositorychangeset/changeset.go
@@ -370,6 +370,23 @@ func WorktreeNameStatusCommand(checkout *repositorycheckout.Checkout) []string {
 	return worktreeChangesCommand(checkout, `GIT_INDEX_FILE="$index_file" git -C "$dest" diff --cached --name-status --no-renames -z "$base_commit"`)
 }
 
+func WorktreeCopyOutCommand(checkout *repositorycheckout.Checkout) []string {
+	emit := strings.Join([]string{
+		`name_status_file="$(mktemp)"`,
+		`patch_file="$(mktemp)"`,
+		`cleanup_copy_out() { rm -f "$name_status_file" "$patch_file"; }`,
+		`trap 'cleanup; cleanup_copy_out' EXIT INT TERM`,
+		`GIT_INDEX_FILE="$index_file" git -C "$dest" diff --cached --name-status --no-renames -z "$base_commit" >"$name_status_file"`,
+		`GIT_INDEX_FILE="$index_file" git -C "$dest" diff --cached --binary --full-index --no-ext-diff --no-color --no-renames "$base_commit" >"$patch_file"`,
+		`name_status_size="$(wc -c <"$name_status_file" | tr -d '[:space:]')"`,
+		`patch_size="$(wc -c <"$patch_file" | tr -d '[:space:]')"`,
+		`printf 'cleanroom-copy-out-v1 %s %s\n' "$name_status_size" "$patch_size"`,
+		`cat "$name_status_file"`,
+		`cat "$patch_file"`,
+	}, "\n")
+	return worktreeChangesCommand(checkout, emit)
+}
+
 func applyCommand(checkout *repositorycheckout.Checkout, changeset *Changeset, resetCheckout bool) []string {
 	if checkout == nil || changeset == nil {
 		return nil


### PR DESCRIPTION
## Summary

- implement Git-backed `cleanroom workspace copy-out` writes using a single sandbox payload that includes name-status and binary patch data from the same temp index
- save a recoverable patch plus manifest in Cleanroom state before applying locally
- reject baseline mismatches, independently changed target paths, and ignored/untracked local targets before writing
- update the workspace sync plan to mark PR #272 as the read-only baseline and this PR as the first write-capable slice

## Tests

- `mise exec -- go test ./internal/cli ./internal/repositorychangeset`
- `mise exec -- go test ./...`