### PR TITLE
feat: Record workspace bindings

### DIFF
--- a/docs/plans/workspace-sync.md
+++ b/docs/plans/workspace-sync.md
@@ -12,12 +12,16 @@
   Git-backed `workspace diff`, Git-backed `workspace copy-out --dry-run`,
   sandbox-root resolution from the recorded repository checkout, and local-root
   safety that requires a matching local Git checkout before copy-out planning.
-- This changeset should land the first write-capable Phase 2 slice: Git-backed
+- PR #274 landed the first write-capable Phase 2 slice: Git-backed
   `workspace copy-out` applies sandbox changes to the matching local checkout,
   saves a recoverable patch and manifest before applying, refuses local baseline
   mismatches, and refuses target paths that changed independently.
-- Local binding metadata, non-Git/raw copy-out writes, top-level `--copy-out`,
-  and `--sync` remain follow-up work.
+- This changeset should land client-side Git workspace binding metadata:
+  `workspace copy-in` and top-level `--copy-in` record the trusted local root,
+  canonical remote, baseline commit, sandbox workspace root, operation time, and
+  copy-in manifest; `workspace copy-out` prefers that bound root.
+- Non-Git/raw copy-out writes, copy-out application from a prior copy-in
+  manifest, top-level `--copy-out`, and `--sync` remain follow-up work.
 
 ## Summary
 
@@ -444,6 +448,9 @@ Workspace copy-out should write only to a trusted local root:
 - If there is no binding, allow copy-out from the current working tree only when
   its repository identity matches the sandbox repository identity.
 - Refuse copy-out when the local root is ambiguous.
+- Until copy-out can apply against a prior copy-in manifest, bound Git copy-out
+  should still fail closed for local target paths that do not match the sandbox
+  baseline.
 
 The MVP should not add an arbitrary `--local-root` override. That avoids
 writing cleanroom copy-out results into the wrong checkout.
@@ -511,7 +518,7 @@ Cleanroom should record workspace metadata per sandbox:
 - sandbox ID
 - workspace root inside the sandbox, resolved from `repository.path` and
   normally `/workspace`
-- local root path used for the last workspace copy-in or copy-out, stored
+- local root path used for the last Git-backed workspace copy-in, stored
   client-side only
 - cleanroom workspace baseline manifest or tree digest
 - last workspace copy-in manifest used for copy-out conflict detection
@@ -631,19 +638,22 @@ Status: landed.
 ### Phase 2: Workspace copy-out and diff
 
 - PR #272: add `cleanroom workspace copy-out --dry-run`.
-- This changeset: add Git-backed `cleanroom workspace copy-out` writes.
+- PR #274: add Git-backed `cleanroom workspace copy-out` writes.
 - PR #272: add `cleanroom workspace diff`.
 - PR #272: resolve the sandbox workspace root from `repository.path`, defaulting
   to `/workspace`.
 - Covered by repository changeset tests: ignored cleanroom outputs are not
   included in Git-backed copy-out candidates by default.
-- This changeset: add copy-out tests proving local divergence fails closed with
+- PR #274: add copy-out tests proving local divergence fails closed with
   no force or overwrite mode.
-- This changeset: add copy-out tests proving an unbound copy-out refuses to
+- PR #274: add copy-out tests proving an unbound copy-out refuses to
   write unless the current working tree matches the sandbox repository baseline.
 - Require explicit sandbox IDs or support `--last` consistently with existing
   inspect commands.
-- Store local binding metadata in client-side Cleanroom state.
+- This changeset: store Git local binding metadata in client-side Cleanroom
+  state and prefer the bound local root during `workspace copy-out`.
+- Follow-up: use the recorded copy-in manifest as the local conflict/apply base,
+  then add top-level `--copy-out` automation.
 
 ### Phase 3: Safe top-level copy-out automation
 

--- a/internal/cli/execution_shared.go
+++ b/internal/cli/execution_shared.go
@@ -135,6 +135,8 @@ func resolveExecutionSandbox(
 			if existingSandboxID != "" && copyRepository != nil {
 				repository = nil
 			}
+		} else if repository != nil {
+			warnWorkspaceBindingError(ctx, recordGitWorkspaceBinding(sandboxID, repository, toRepositoryCheckout(repository), repositoryLocalChangesFiles(localChanges), "copy-in"))
 		}
 	}
 

--- a/internal/cli/repository_test.go
+++ b/internal/cli/repository_test.go
@@ -918,6 +918,7 @@ func TestCreateCommandWarnsWhenRepositoryIsDirtyUsesANSIWhenForced(t *testing.T)
 }
 
 func TestCreateCommandCopyInSuppressesDirtyWarning(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	repoDir := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
 	if err := os.WriteFile(filepath.Join(repoDir, "dirty.txt"), []byte("dirty\n"), 0o644); err != nil {
 		t.Fatalf("write dirty file: %v", err)
@@ -983,6 +984,20 @@ func TestCreateCommandCopyInSuppressesDirtyWarning(t *testing.T) {
 	if strings.Contains(outcome.stderr, "repository has local modifications") {
 		t.Fatalf("expected dirty repository warning to be suppressed, got %q", outcome.stderr)
 	}
+	sandboxID := strings.TrimSpace(outcome.stdout)
+	if sandboxID == "" {
+		t.Fatal("expected create command to print sandbox id")
+	}
+	binding := mustReadWorkspaceBinding(t, sandboxID)
+	if got, want := binding.LocalRoot, mustNormalizeWorkspaceLocalRoot(t, repoDir); got != want {
+		t.Fatalf("unexpected binding local root: got %q want %q", got, want)
+	}
+	if got, want := binding.SandboxWorkspace, "/workspace"; got != want {
+		t.Fatalf("unexpected binding workspace: got %q want %q", got, want)
+	}
+	if len(binding.CopyInManifest) != 1 || binding.CopyInManifest[0].Path != "dirty.txt" {
+		t.Fatalf("expected dirty.txt in binding manifest, got %+v", binding.CopyInManifest)
+	}
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -1000,7 +1015,53 @@ func TestCreateCommandCopyInSuppressesDirtyWarning(t *testing.T) {
 	}
 }
 
+func TestCreateCommandCopyInWarnsWhenBindingCannotBeSaved(t *testing.T) {
+	setBrokenWorkspaceStateHome(t)
+	repoDir := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
+
+	adapter := &integrationAdapter{}
+	host, _ := startIntegrationServer(t, adapter)
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+	}
+
+	outcome := runCreateAliasWithCapture(CreateCommand{
+		clientFlags:        clientFlags{Host: host},
+		Chdir:              repoDir,
+		workspaceCopyFlags: workspaceCopyFlags{CopyIn: true},
+	}, runtimeContext{
+		CWD: repoDir,
+		Loader: repositoryIntegrationLoader{
+			compiled: &policy.CompiledPolicy{
+				Version:        1,
+				ImageRef:       "ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+				ImageDigest:    "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+				NetworkDefault: "deny",
+				Allow:          []policy.AllowRule{{Host: "github.com", Ports: []int{443}}},
+			},
+			repository: policy.RepositoryConfig{
+				Mode:   "current-repo",
+				Remote: "origin",
+				Path:   "/workspace",
+			},
+		},
+	})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err != nil {
+		t.Fatalf("CreateCommand.Run returned error: %v", outcome.err)
+	}
+	if strings.TrimSpace(outcome.stdout) == "" {
+		t.Fatal("expected create command to print sandbox id")
+	}
+	if !strings.Contains(outcome.stderr, "warning: workspace binding was not saved") {
+		t.Fatalf("expected binding warning on stderr, got %q", outcome.stderr)
+	}
+}
+
 func TestCreateCommandCopyInIncludesLocalOnlyCommits(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	repoDir := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
 	commitFile(t, repoDir, "local.txt", "local\n", "local commit")
 	wantCommit := headCommit(t, repoDir)

--- a/internal/cli/sandbox.go
+++ b/internal/cli/sandbox.go
@@ -347,6 +347,9 @@ func (c *CreateCommand) Run(ctx *runtimeContext) error {
 	if err != nil {
 		return err
 	}
+	if c.CopyIn && repository != nil {
+		warnWorkspaceBindingError(ctx, recordGitWorkspaceBinding(sandboxID, repository, toRepositoryCheckout(repository), repositoryLocalChangesFiles(localChanges), "copy-in"))
+	}
 	if c.JSON {
 		enc := json.NewEncoder(ctx.Stdout)
 		enc.SetIndent("", "  ")

--- a/internal/cli/workspace.go
+++ b/internal/cli/workspace.go
@@ -54,6 +54,7 @@ type workspaceCopyOptions struct {
 	SandboxID     string
 	DryRun        bool
 	Repository    *resolvedRepositoryCheckout
+	Binding       *workspaceBinding
 	Destination   string
 	ForceGitReset bool
 	LaunchSeconds int64
@@ -112,7 +113,24 @@ func (c *WorkspaceCopyOutCommand) Run(ctx *runtimeContext) error {
 	if err != nil {
 		return err
 	}
-	repository, err := resolveWorkspaceCopyRepositoryCheckout(cwd, ctx.Loader)
+	binding, err := readWorkspaceBinding(c.SandboxID)
+	if err != nil {
+		return err
+	}
+	repositoryRoot := cwd
+	if binding != nil && binding.Transport == workspaceBindingTransportGit && strings.TrimSpace(binding.LocalRoot) != "" {
+		if strings.TrimSpace(c.Chdir) != "" {
+			chdirRepository, err := resolveWorkspaceCopyRepositoryCheckout(cwd, ctx.Loader)
+			if err != nil {
+				return err
+			}
+			if chdirRepository == nil || !sameWorkspaceLocalRoot(chdirRepository.RootDir, binding.LocalRoot) {
+				return fmt.Errorf("workspace copy-out sandbox %q is bound to local root %q, but --chdir resolved to %q", c.SandboxID, binding.LocalRoot, cwd)
+			}
+		}
+		repositoryRoot = binding.LocalRoot
+	}
+	repository, err := resolveWorkspaceCopyRepositoryCheckout(repositoryRoot, ctx.Loader)
 	if err != nil {
 		return err
 	}
@@ -129,6 +147,7 @@ func (c *WorkspaceCopyOutCommand) Run(ctx *runtimeContext) error {
 		SandboxID:  c.SandboxID,
 		DryRun:     c.DryRun,
 		Repository: repository,
+		Binding:    binding,
 	})
 }
 
@@ -176,8 +195,11 @@ func copyGitWorkspaceToSandbox(callCtx context.Context, ctx *runtimeContext, cli
 			return printWorkspacePlan(runtimeStdout(ctx), gitWorkspacePlan(checkout.DestinationDir, nil, true))
 		}
 		if opts.ForceGitReset {
-			return runWorkspaceExecution(callCtx, ctx, client, opts.SandboxID, effectiveRepository, repositorychangeset.ResetCommand(checkout), nil, opts.LaunchSeconds)
+			if err := runWorkspaceExecution(callCtx, ctx, client, opts.SandboxID, effectiveRepository, repositorychangeset.ResetCommand(checkout), nil, opts.LaunchSeconds); err != nil {
+				return err
+			}
 		}
+		warnWorkspaceBindingError(ctx, recordGitWorkspaceBinding(opts.SandboxID, effectiveRepository, checkout, nil, "copy-in"))
 		return nil
 	}
 	if opts.DryRun {
@@ -188,7 +210,11 @@ func copyGitWorkspaceToSandbox(callCtx context.Context, ctx *runtimeContext, cli
 	if opts.ForceGitReset {
 		command = repositorychangeset.ApplyCommandResettingCheckout(checkout, changeset)
 	}
-	return runWorkspaceExecution(callCtx, ctx, client, opts.SandboxID, effectiveRepository, command, bytes.NewReader(changeset.Patch), opts.LaunchSeconds)
+	if err := runWorkspaceExecution(callCtx, ctx, client, opts.SandboxID, effectiveRepository, command, bytes.NewReader(changeset.Patch), opts.LaunchSeconds); err != nil {
+		return err
+	}
+	warnWorkspaceBindingError(ctx, recordGitWorkspaceBinding(opts.SandboxID, effectiveRepository, checkout, changeset.Files, "copy-in"))
+	return nil
 }
 
 func copyWorkspaceOut(callCtx context.Context, ctx *runtimeContext, client *controlclient.Client, opts workspaceCopyOptions) error {
@@ -200,6 +226,9 @@ func copyWorkspaceOut(callCtx context.Context, ctx *runtimeContext, client *cont
 	}
 	checkout, err := sandboxRepositoryCheckout(callCtx, client, opts.SandboxID)
 	if err != nil {
+		return err
+	}
+	if err := validateWorkspaceBinding(opts.Binding, opts.SandboxID, checkout); err != nil {
 		return err
 	}
 	if err := validateWorkspaceCopyOutLocalRepository(opts.Repository, checkout); err != nil {

--- a/internal/cli/workspace_binding.go
+++ b/internal/cli/workspace_binding.go
@@ -1,0 +1,275 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/buildkite/cleanroom/internal/paths"
+	"github.com/buildkite/cleanroom/internal/repositorychangeset"
+	"github.com/buildkite/cleanroom/internal/repositorycheckout"
+)
+
+const (
+	workspaceBindingVersion      = 1
+	workspaceBindingTransportGit = "git"
+)
+
+type workspaceBinding struct {
+	Version             int                    `json:"version"`
+	SandboxID           string                 `json:"sandbox_id"`
+	LocalRoot           string                 `json:"local_root"`
+	SandboxWorkspace    string                 `json:"sandbox_workspace"`
+	RepositoryRemoteURL string                 `json:"repository_remote_url"`
+	RepositoryCommitSHA string                 `json:"repository_commit_sha"`
+	RepositoryBranch    string                 `json:"repository_branch,omitempty"`
+	Transport           string                 `json:"transport"`
+	LastOperation       string                 `json:"last_operation"`
+	LastOperationAt     string                 `json:"last_operation_at"`
+	CopyInManifest      []workspaceBindingFile `json:"copy_in_manifest,omitempty"`
+}
+
+type workspaceBindingFile struct {
+	Path    string `json:"path"`
+	SHA256  string `json:"sha256,omitempty"`
+	Deleted bool   `json:"deleted,omitempty"`
+}
+
+func readWorkspaceBinding(sandboxID string) (*workspaceBinding, error) {
+	path, err := workspaceBindingPath(sandboxID)
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read workspace binding: %w", err)
+	}
+	var binding workspaceBinding
+	if err := json.Unmarshal(data, &binding); err != nil {
+		return nil, fmt.Errorf("decode workspace binding: %w", err)
+	}
+	return &binding, nil
+}
+
+func recordGitWorkspaceBinding(sandboxID string, repository *resolvedRepositoryCheckout, checkout *repositorycheckout.Checkout, files []repositorychangeset.File, operation string) error {
+	if repository == nil || strings.TrimSpace(repository.RootDir) == "" {
+		return nil
+	}
+	sandboxID = strings.TrimSpace(sandboxID)
+	if sandboxID == "" {
+		return errors.New("workspace binding requires a sandbox id")
+	}
+	localRoot, err := normalizeWorkspaceLocalRoot(repository.RootDir)
+	if err != nil {
+		return err
+	}
+	remoteURL := strings.TrimSpace(repository.RemoteURL)
+	commitSHA := strings.TrimSpace(repository.CommitSHA)
+	branch := strings.TrimSpace(repository.Branch)
+	workspaceRoot := strings.TrimSpace(repository.DestinationDir)
+	if checkout != nil {
+		if value := strings.TrimSpace(checkout.RemoteURL); value != "" {
+			remoteURL = value
+		}
+		if value := strings.TrimSpace(checkout.CommitSHA); value != "" {
+			commitSHA = value
+		}
+		if value := strings.TrimSpace(checkout.Branch); value != "" {
+			branch = value
+		}
+		if value := strings.TrimSpace(checkout.DestinationDir); value != "" {
+			workspaceRoot = value
+		}
+	}
+	remoteURL, err = canonicalWorkspaceRemoteURL(remoteURL)
+	if err != nil {
+		return err
+	}
+	if commitSHA == "" {
+		return errors.New("workspace binding requires a repository commit")
+	}
+	if workspaceRoot == "" {
+		return errors.New("workspace binding requires a sandbox workspace root")
+	}
+	operation = strings.TrimSpace(operation)
+	if operation == "" {
+		operation = "copy-in"
+	}
+	return writeWorkspaceBinding(&workspaceBinding{
+		Version:             workspaceBindingVersion,
+		SandboxID:           sandboxID,
+		LocalRoot:           localRoot,
+		SandboxWorkspace:    workspaceRoot,
+		RepositoryRemoteURL: remoteURL,
+		RepositoryCommitSHA: commitSHA,
+		RepositoryBranch:    branch,
+		Transport:           workspaceBindingTransportGit,
+		LastOperation:       operation,
+		LastOperationAt:     time.Now().UTC().Format(time.RFC3339Nano),
+		CopyInManifest:      workspaceBindingFiles(files),
+	})
+}
+
+func warnWorkspaceBindingError(ctx *runtimeContext, err error) {
+	if err == nil {
+		return
+	}
+	_ = writeExecutionWarning(ctx.stderr(), "workspace binding was not saved: "+err.Error())
+}
+
+func writeWorkspaceBinding(binding *workspaceBinding) error {
+	if binding == nil {
+		return errors.New("workspace binding is required")
+	}
+	path, err := workspaceBindingPath(binding.SandboxID)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("create workspace binding directory: %w", err)
+	}
+	data, err := json.MarshalIndent(binding, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode workspace binding: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("write workspace binding: %w", err)
+	}
+	return nil
+}
+
+func workspaceBindingPath(sandboxID string) (string, error) {
+	sandboxID = strings.TrimSpace(sandboxID)
+	if sandboxID == "" {
+		return "", errors.New("workspace binding requires a sandbox id")
+	}
+	base, err := paths.StateBaseDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve workspace binding state directory: %w", err)
+	}
+	return filepath.Join(base, "workspace-bindings", safeWorkspaceStateName(sandboxID)+".json"), nil
+}
+
+func validateWorkspaceBinding(binding *workspaceBinding, sandboxID string, checkout *repositorycheckout.Checkout) error {
+	if binding == nil {
+		return nil
+	}
+	if binding.Version != workspaceBindingVersion {
+		return fmt.Errorf("workspace binding has unsupported version %d", binding.Version)
+	}
+	if got, want := strings.TrimSpace(binding.SandboxID), strings.TrimSpace(sandboxID); got != want {
+		return fmt.Errorf("workspace binding sandbox %q does not match requested sandbox %q", got, want)
+	}
+	if binding.Transport != workspaceBindingTransportGit {
+		return fmt.Errorf("workspace binding transport %q is not supported for Git copy-out", binding.Transport)
+	}
+	if checkout == nil {
+		return errors.New("workspace binding requires a sandbox repository checkout")
+	}
+	boundRemote, err := canonicalWorkspaceRemoteURL(binding.RepositoryRemoteURL)
+	if err != nil {
+		return err
+	}
+	sandboxRemote, err := canonicalWorkspaceRemoteURL(checkout.RemoteURL)
+	if err != nil {
+		return err
+	}
+	if boundRemote != sandboxRemote {
+		return fmt.Errorf("workspace binding repository remote %q does not match sandbox repository remote %q", boundRemote, sandboxRemote)
+	}
+	boundCommit := strings.TrimSpace(binding.RepositoryCommitSHA)
+	sandboxCommit := strings.TrimSpace(checkout.CommitSHA)
+	if boundCommit == "" || sandboxCommit == "" {
+		return errors.New("workspace binding requires local and sandbox repository commits")
+	}
+	if !strings.EqualFold(boundCommit, sandboxCommit) {
+		return fmt.Errorf("workspace binding repository commit %s does not match sandbox baseline %s", shortGitSHA(boundCommit), shortGitSHA(sandboxCommit))
+	}
+	boundWorkspace := strings.TrimSpace(binding.SandboxWorkspace)
+	sandboxWorkspace := strings.TrimSpace(checkout.DestinationDir)
+	if boundWorkspace == "" || sandboxWorkspace == "" {
+		return errors.New("workspace binding requires a sandbox workspace root")
+	}
+	if boundWorkspace != sandboxWorkspace {
+		return fmt.Errorf("workspace binding sandbox workspace %q does not match sandbox workspace %q", boundWorkspace, sandboxWorkspace)
+	}
+	return nil
+}
+
+func workspaceBindingFiles(files []repositorychangeset.File) []workspaceBindingFile {
+	if len(files) == 0 {
+		return nil
+	}
+	out := make([]workspaceBindingFile, 0, len(files))
+	for _, file := range files {
+		out = append(out, workspaceBindingFile{
+			Path:    file.Path,
+			SHA256:  file.SHA256,
+			Deleted: file.Deleted,
+		})
+	}
+	return out
+}
+
+func repositoryLocalChangesFiles(localChanges repositoryLocalChanges) []repositorychangeset.File {
+	changeset := localChanges.Changeset
+	if changeset == nil {
+		return nil
+	}
+	files := make([]repositorychangeset.File, 0, len(changeset.GetFiles()))
+	for _, file := range changeset.GetFiles() {
+		files = append(files, repositorychangeset.File{
+			Path:    file.GetPath(),
+			SHA256:  file.GetSha256(),
+			Deleted: file.GetDeleted(),
+		})
+	}
+	return files
+}
+
+func canonicalWorkspaceRemoteURL(remoteURL string) (string, error) {
+	remoteURL = strings.TrimSpace(remoteURL)
+	if remoteURL == "" {
+		return "", errors.New("workspace binding requires a repository remote")
+	}
+	canonical, _, err := repositorycheckout.CanonicalizeRemoteURL(remoteURL)
+	if err != nil {
+		return "", err
+	}
+	return canonical, nil
+}
+
+func normalizeWorkspaceLocalRoot(root string) (string, error) {
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return "", errors.New("workspace binding requires a local root")
+	}
+	absolute, err := filepath.Abs(root)
+	if err != nil {
+		return "", fmt.Errorf("resolve workspace binding local root: %w", err)
+	}
+	if resolved, err := filepath.EvalSymlinks(absolute); err == nil {
+		absolute = resolved
+	}
+	return filepath.Clean(absolute), nil
+}
+
+func sameWorkspaceLocalRoot(a, b string) bool {
+	left, err := normalizeWorkspaceLocalRoot(a)
+	if err != nil {
+		return false
+	}
+	right, err := normalizeWorkspaceLocalRoot(b)
+	if err != nil {
+		return false
+	}
+	return left == right
+}

--- a/internal/cli/workspace_test.go
+++ b/internal/cli/workspace_test.go
@@ -19,10 +19,12 @@ import (
 	"github.com/buildkite/cleanroom/internal/backend"
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
 	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/buildkite/cleanroom/internal/repositorychangeset"
 	"github.com/buildkite/cleanroom/internal/runtimeconfig"
 )
 
 func TestWorkspaceCopyInAppliesGitChangeset(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	repoDir := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
 	if err := os.WriteFile(filepath.Join(repoDir, ".gitignore"), []byte("node_modules/\n"), 0o644); err != nil {
 		t.Fatalf("write gitignore: %v", err)
@@ -136,6 +138,7 @@ func TestWorkspaceCopyInAppliesGitChangeset(t *testing.T) {
 }
 
 func TestWorkspaceCopyInAppliesLocalOnlyCommitsFromSandboxBase(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	repoDir := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
 	baseCommit := headCommit(t, repoDir)
 	branch, err := gitOutput(repoDir, "branch", "--show-current")
@@ -228,6 +231,7 @@ func TestWorkspaceCopyInAppliesLocalOnlyCommitsFromSandboxBase(t *testing.T) {
 }
 
 func TestWorkspaceCopyInReturnsWhenPatchStdinWriteFails(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	repoDir := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
 	if err := os.WriteFile(filepath.Join(repoDir, "dirty.txt"), []byte("dirty\n"), 0o644); err != nil {
 		t.Fatalf("write dirty file: %v", err)
@@ -312,6 +316,7 @@ func TestWorkspaceCopyInReturnsWhenPatchStdinWriteFails(t *testing.T) {
 }
 
 func TestWorkspaceCopyInUsesGitChangesetForGitWorktreeWithoutRepositoryPolicy(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	repoDir := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
 	if err := os.WriteFile(filepath.Join(repoDir, ".gitignore"), []byte("node_modules/\n"), 0o644); err != nil {
 		t.Fatalf("write gitignore: %v", err)
@@ -428,6 +433,7 @@ func TestWorkspaceCopyInUsesGitChangesetForGitWorktreeWithoutRepositoryPolicy(t 
 }
 
 func TestWorkspaceCopyInResetsGitCheckoutWhenLocalRepoClean(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	repoDir := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
 
 	adapter := &integrationAdapter{}
@@ -513,6 +519,7 @@ func TestWorkspaceCopyInResetsGitCheckoutWhenLocalRepoClean(t *testing.T) {
 }
 
 func TestResolveExecutionSandboxClearsRepositoryAfterGitCopyInExistingSandbox(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	repoDir := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
 
 	adapter := &integrationAdapter{}
@@ -578,6 +585,7 @@ func TestResolveExecutionSandboxClearsRepositoryAfterGitCopyInExistingSandbox(t 
 }
 
 func TestResolveExecutionSandboxCopyInUsesGitWorktreeWithoutRepositoryPolicy(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	repoDir := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
 	if err := os.WriteFile(filepath.Join(repoDir, ".gitignore"), []byte("node_modules/\n"), 0o644); err != nil {
 		t.Fatalf("write gitignore: %v", err)
@@ -756,6 +764,143 @@ func TestWorkspaceCopyInDryRunReportsCleanGitResetWithoutExecuting(t *testing.T)
 	}
 }
 
+func TestWorkspaceCopyInRecordsGitBinding(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	repoDir := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
+	head, err := gitOutput(repoDir, "rev-parse", "HEAD")
+	if err != nil {
+		t.Fatalf("resolve repository HEAD: %v", err)
+	}
+	branch, err := gitOutput(repoDir, "branch", "--show-current")
+	if err != nil {
+		t.Fatalf("resolve repository branch: %v", err)
+	}
+
+	adapter := &integrationAdapter{}
+	host, _ := startIntegrationServer(t, adapter)
+	sandboxID := createWorkspaceCopyTestSandboxWithRepositoryCommitBranch(t, host, "/sandbox-workspace", head, branch)
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
+		command := strings.Join(req.Command, " ")
+		if !strings.Contains(command, "reset --hard") {
+			t.Fatalf("expected clean copy-in reset command, got %q", command)
+		}
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+	}
+
+	stdout, _ := makeStdoutCapture(t)
+	stderr, _ := makeStdoutCapture(t)
+	cmd := WorkspaceCopyInCommand{
+		clientFlags: clientFlags{Host: host},
+		Chdir:       repoDir,
+		SandboxID:   sandboxID,
+	}
+	if err := cmd.Run(&runtimeContext{
+		CWD:           repoDir,
+		Loader:        repositoryNotFoundLoader{},
+		Config:        runtimeconfig.Config{},
+		Observability: newTestObservability(t),
+		Stdout:        stdout,
+		Stderr:        stderr,
+	}); err != nil {
+		t.Fatalf("WorkspaceCopyInCommand.Run returned error: %v", err)
+	}
+
+	binding := mustReadWorkspaceBinding(t, sandboxID)
+	if got, want := binding.LocalRoot, mustNormalizeWorkspaceLocalRoot(t, repoDir); got != want {
+		t.Fatalf("unexpected binding local root: got %q want %q", got, want)
+	}
+	if got, want := binding.RepositoryRemoteURL, "https://github.com/buildkite/cleanroom.git"; got != want {
+		t.Fatalf("unexpected binding remote: got %q want %q", got, want)
+	}
+	if got, want := binding.RepositoryCommitSHA, head; got != want {
+		t.Fatalf("unexpected binding commit: got %q want %q", got, want)
+	}
+	if got, want := binding.SandboxWorkspace, "/sandbox-workspace"; got != want {
+		t.Fatalf("unexpected binding workspace: got %q want %q", got, want)
+	}
+	if got, want := binding.Transport, workspaceBindingTransportGit; got != want {
+		t.Fatalf("unexpected binding transport: got %q want %q", got, want)
+	}
+	if got, want := binding.LastOperation, "copy-in"; got != want {
+		t.Fatalf("unexpected binding operation: got %q want %q", got, want)
+	}
+}
+
+func TestWorkspaceCopyInWarnsWhenBindingCannotBeSaved(t *testing.T) {
+	setBrokenWorkspaceStateHome(t)
+	repoDir := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
+	head, err := gitOutput(repoDir, "rev-parse", "HEAD")
+	if err != nil {
+		t.Fatalf("resolve repository HEAD: %v", err)
+	}
+	branch, err := gitOutput(repoDir, "branch", "--show-current")
+	if err != nil {
+		t.Fatalf("resolve repository branch: %v", err)
+	}
+
+	adapter := &integrationAdapter{}
+	host, _ := startIntegrationServer(t, adapter)
+	sandboxID := createWorkspaceCopyTestSandboxWithRepositoryCommitBranch(t, host, "/sandbox-workspace", head, branch)
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
+		command := strings.Join(req.Command, " ")
+		if !strings.Contains(command, "reset --hard") {
+			t.Fatalf("expected clean copy-in reset command, got %q", command)
+		}
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+	}
+
+	stdout, _ := makeStdoutCapture(t)
+	stderr, stderrText := makeStdoutCapture(t)
+	cmd := WorkspaceCopyInCommand{
+		clientFlags: clientFlags{Host: host},
+		Chdir:       repoDir,
+		SandboxID:   sandboxID,
+	}
+	if err := cmd.Run(&runtimeContext{
+		CWD:           repoDir,
+		Loader:        repositoryNotFoundLoader{},
+		Config:        runtimeconfig.Config{},
+		Observability: newTestObservability(t),
+		Stdout:        stdout,
+		Stderr:        stderr,
+	}); err != nil {
+		t.Fatalf("WorkspaceCopyInCommand.Run returned error: %v", err)
+	}
+	if got := stderrText(); !strings.Contains(got, "warning: workspace binding was not saved") {
+		t.Fatalf("expected binding warning on stderr, got %q", got)
+	}
+}
+
+func TestWorkspaceBindingRecordsCopyInManifest(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	repoDir := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
+	repository, err := resolveWorkspaceCopyRepositoryCheckout(repoDir, repositoryNotFoundLoader{})
+	if err != nil {
+		t.Fatalf("resolve repository checkout: %v", err)
+	}
+	files := []repositorychangeset.File{{
+		Path:   "dirty.txt",
+		SHA256: "sha256:dirty",
+	}, {
+		Path:    "removed.txt",
+		Deleted: true,
+	}}
+	checkout := toRepositoryCheckout(repository)
+	checkout.DestinationDir = "/sandbox-workspace"
+
+	if err := recordGitWorkspaceBinding("cr_manifest", repository, checkout, files, "copy-in"); err != nil {
+		t.Fatalf("recordGitWorkspaceBinding returned error: %v", err)
+	}
+	binding := mustReadWorkspaceBinding(t, "cr_manifest")
+	expected := []workspaceBindingFile{
+		{Path: "dirty.txt", SHA256: "sha256:dirty"},
+		{Path: "removed.txt", Deleted: true},
+	}
+	if !reflect.DeepEqual(binding.CopyInManifest, expected) {
+		t.Fatalf("unexpected binding manifest: got %+v want %+v", binding.CopyInManifest, expected)
+	}
+}
+
 func TestWorkspaceCopyOutDryRunReportsSandboxGitPlan(t *testing.T) {
 	localRoot := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
 	resolvedLocalRoot, err := gitOutput(localRoot, "rev-parse", "--show-toplevel")
@@ -824,6 +969,121 @@ func TestWorkspaceCopyOutDryRunReportsSandboxGitPlan(t *testing.T) {
 	}
 	if !strings.Contains(planCommand, "diff --cached --name-status --no-renames -z") {
 		t.Fatalf("expected copy-out planning to use git name-status, got %q", planCommand)
+	}
+}
+
+func TestWorkspaceCopyOutDryRunUsesBoundLocalRoot(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	localRoot := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
+	resolvedLocalRoot, err := gitOutput(localRoot, "rev-parse", "--show-toplevel")
+	if err != nil {
+		t.Fatalf("resolve local repository root: %v", err)
+	}
+	head, err := gitOutput(localRoot, "rev-parse", "HEAD")
+	if err != nil {
+		t.Fatalf("resolve repository HEAD: %v", err)
+	}
+	repository, err := resolveWorkspaceCopyRepositoryCheckout(localRoot, repositoryNotFoundLoader{})
+	if err != nil {
+		t.Fatalf("resolve repository checkout: %v", err)
+	}
+
+	adapter := &integrationAdapter{}
+	host, _ := startIntegrationServer(t, adapter)
+	sandboxID := createWorkspaceCopyTestSandboxWithRepositoryCommitBranch(t, host, "/sandbox-workspace", head, "main")
+	checkout := toRepositoryCheckout(repository)
+	checkout.DestinationDir = "/sandbox-workspace"
+	if err := recordGitWorkspaceBinding(sandboxID, repository, checkout, nil, "copy-in"); err != nil {
+		t.Fatalf("record workspace binding: %v", err)
+	}
+
+	var executionCalled bool
+	adapter.runStreamFn = func(_ context.Context, _ backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+		executionCalled = true
+		if stream.OnStdout != nil {
+			stream.OnStdout([]byte("M\x00changed.txt\x00"))
+		}
+		return &backend.ExecutionResult{ExitCode: 0, Message: "ok"}, nil
+	}
+
+	stdout, stdoutText := makeStdoutCapture(t)
+	stderr, _ := makeStdoutCapture(t)
+	cmd := WorkspaceCopyOutCommand{
+		clientFlags: clientFlags{Host: host},
+		DryRun:      true,
+		SandboxID:   sandboxID,
+	}
+	if err := cmd.Run(&runtimeContext{
+		CWD:           t.TempDir(),
+		Loader:        repositoryNotFoundLoader{},
+		Config:        runtimeconfig.Config{},
+		Observability: newTestObservability(t),
+		Stdout:        stdout,
+		Stderr:        stderr,
+	}); err != nil {
+		t.Fatalf("WorkspaceCopyOutCommand.Run returned error: %v", err)
+	}
+	if !executionCalled {
+		t.Fatal("expected sandbox planning execution")
+	}
+	expected := "write\t" + filepath.Join(resolvedLocalRoot, "changed.txt") + "\n"
+	if got := stdoutText(); got != expected {
+		t.Fatalf("unexpected copy-out dry-run plan: got %q want %q", got, expected)
+	}
+}
+
+func TestWorkspaceCopyOutRejectsExplicitRootOutsideBinding(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	localRoot := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
+	otherRoot := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
+	head, err := gitOutput(localRoot, "rev-parse", "HEAD")
+	if err != nil {
+		t.Fatalf("resolve repository HEAD: %v", err)
+	}
+	repository, err := resolveWorkspaceCopyRepositoryCheckout(localRoot, repositoryNotFoundLoader{})
+	if err != nil {
+		t.Fatalf("resolve repository checkout: %v", err)
+	}
+
+	adapter := &integrationAdapter{}
+	host, _ := startIntegrationServer(t, adapter)
+	sandboxID := createWorkspaceCopyTestSandboxWithRepositoryCommitBranch(t, host, "/sandbox-workspace", head, "main")
+	checkout := toRepositoryCheckout(repository)
+	checkout.DestinationDir = "/sandbox-workspace"
+	if err := recordGitWorkspaceBinding(sandboxID, repository, checkout, nil, "copy-in"); err != nil {
+		t.Fatalf("record workspace binding: %v", err)
+	}
+
+	var executionCalled bool
+	adapter.runStreamFn = func(_ context.Context, _ backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
+		executionCalled = true
+		return &backend.ExecutionResult{ExitCode: 0, Message: "ok"}, nil
+	}
+
+	stdout, _ := makeStdoutCapture(t)
+	stderr, _ := makeStdoutCapture(t)
+	cmd := WorkspaceCopyOutCommand{
+		clientFlags: clientFlags{Host: host},
+		Chdir:       otherRoot,
+		DryRun:      true,
+		SandboxID:   sandboxID,
+	}
+	err = cmd.Run(&runtimeContext{
+		CWD:           localRoot,
+		Loader:        repositoryNotFoundLoader{},
+		Config:        runtimeconfig.Config{},
+		Observability: newTestObservability(t),
+		Stdout:        stdout,
+		Stderr:        stderr,
+	})
+	if err == nil {
+		t.Fatal("expected mismatched explicit root to be rejected")
+	}
+	if !strings.Contains(err.Error(), "is bound to local root") {
+		t.Fatalf("expected bound local root error, got %v", err)
+	}
+	if executionCalled {
+		t.Fatal("expected copy-out to fail before sandbox planning execution")
 	}
 }
 
@@ -1841,6 +2101,36 @@ func assertWorkspaceCopyOutRecoveryPayload(t *testing.T, sandboxID string) {
 			t.Fatalf("expected non-empty recovery payload %s", name)
 		}
 	}
+}
+
+func mustReadWorkspaceBinding(t *testing.T, sandboxID string) *workspaceBinding {
+	t.Helper()
+	binding, err := readWorkspaceBinding(sandboxID)
+	if err != nil {
+		t.Fatalf("readWorkspaceBinding returned error: %v", err)
+	}
+	if binding == nil {
+		t.Fatalf("expected workspace binding for %q", sandboxID)
+	}
+	return binding
+}
+
+func mustNormalizeWorkspaceLocalRoot(t *testing.T, root string) string {
+	t.Helper()
+	normalized, err := normalizeWorkspaceLocalRoot(root)
+	if err != nil {
+		t.Fatalf("normalizeWorkspaceLocalRoot returned error: %v", err)
+	}
+	return normalized
+}
+
+func setBrokenWorkspaceStateHome(t *testing.T) {
+	t.Helper()
+	stateHome := filepath.Join(t.TempDir(), "state-home-file")
+	if err := os.WriteFile(stateHome, []byte("not a directory\n"), 0o644); err != nil {
+		t.Fatalf("write broken XDG_STATE_HOME: %v", err)
+	}
+	t.Setenv("XDG_STATE_HOME", stateHome)
 }
 
 func gitOutputBytes(t *testing.T, dir string, args ...string) []byte {


### PR DESCRIPTION
## Summary

- add client-side Git workspace binding state keyed by sandbox ID
- record trusted local root, canonical remote, baseline commit, sandbox workspace root, operation time, and copy-in manifest for `workspace copy-in` and top-level `--copy-in`
- make `workspace copy-out` prefer the bound local root and reject explicit `--chdir` roots outside the binding
- update the workspace sync plan now that PR #274 landed and mark manifest-based copy-out application as the next follow-up

## Tests

- `mise exec -- go test ./internal/cli`
- `mise exec -- go test ./...`