### PR TITLE
feat: Use copy-in manifest for copy-out

### DIFF
--- a/docs/plans/workspace-sync.md
+++ b/docs/plans/workspace-sync.md
@@ -16,12 +16,16 @@
   `workspace copy-out` applies sandbox changes to the matching local checkout,
   saves a recoverable patch and manifest before applying, refuses local baseline
   mismatches, and refuses target paths that changed independently.
-- This changeset should land client-side Git workspace binding metadata:
+- PR #275 landed client-side Git workspace binding metadata:
   `workspace copy-in` and top-level `--copy-in` record the trusted local root,
   canonical remote, baseline commit, sandbox workspace root, operation time, and
   copy-in manifest; `workspace copy-out` prefers that bound root.
-- Non-Git/raw copy-out writes, copy-out application from a prior copy-in
-  manifest, top-level `--copy-out`, and `--sync` remain follow-up work.
+- This changeset should make Git-backed `workspace copy-out` use the recorded
+  copy-in manifest as the local conflict and apply base, so copy-out can safely
+  write back after a prior copy-in that included dirty edits or local-only
+  commits.
+- Non-Git/raw copy-out writes, top-level `--copy-out`, and `--sync` remain
+  follow-up work.
 
 ## Summary
 
@@ -229,10 +233,13 @@ If local files diverged while the cleanroom was running, copy-out should fail
 closed and name the conflicting paths. A later conflict override can be added
 from concrete usage, but the initial copy-out path should be conflict-safe.
 
-The first write-capable implementation is Git-backed only. Until local binding
-metadata lands, unbound copy-out writes require the local checkout `HEAD` to
-match the sandbox's recorded repository baseline. If it does not match, the
-command saves the sandbox patch in Cleanroom state and refuses to write.
+The first write-capable implementation is Git-backed only. Unbound copy-out
+writes require the local checkout `HEAD` to match the sandbox's recorded
+repository baseline. Bound copy-out writes use the recorded copy-in manifest as
+the local conflict and apply base, so a checkout that still matches its last
+copy-in state can receive sandbox changes even when its `HEAD` is not the
+sandbox baseline. If conflict checks fail, the command saves the sandbox patch
+in Cleanroom state and refuses to write.
 
 ### `cleanroom workspace diff`
 
@@ -448,9 +455,9 @@ Workspace copy-out should write only to a trusted local root:
 - If there is no binding, allow copy-out from the current working tree only when
   its repository identity matches the sandbox repository identity.
 - Refuse copy-out when the local root is ambiguous.
-- Until copy-out can apply against a prior copy-in manifest, bound Git copy-out
-  should still fail closed for local target paths that do not match the sandbox
-  baseline.
+- Bound Git copy-out uses the prior copy-in manifest as the expected local state
+  for paths that were copied in, and uses the sandbox baseline for other target
+  paths.
 
 The MVP should not add an arbitrary `--local-root` override. That avoids
 writing cleanroom copy-out results into the wrong checkout.
@@ -650,10 +657,11 @@ Status: landed.
   write unless the current working tree matches the sandbox repository baseline.
 - Require explicit sandbox IDs or support `--last` consistently with existing
   inspect commands.
-- This changeset: store Git local binding metadata in client-side Cleanroom
+- PR #275: store Git local binding metadata in client-side Cleanroom
   state and prefer the bound local root during `workspace copy-out`.
-- Follow-up: use the recorded copy-in manifest as the local conflict/apply base,
-  then add top-level `--copy-out` automation.
+- This changeset: use the recorded copy-in manifest as the local conflict/apply
+  base.
+- Follow-up: add top-level `--copy-out` automation.
 
 ### Phase 3: Safe top-level copy-out automation
 

--- a/internal/cli/repository_changeset.go
+++ b/internal/cli/repository_changeset.go
@@ -38,6 +38,7 @@ func validateTopLevelWorkspaceCopyTransport(repository *resolvedRepositoryChecko
 type repositoryLocalChanges struct {
 	Changeset    *cleanroomv1.RepositoryChangeset
 	CommitBundle *cleanroomv1.RepositoryCommitBundle
+	Files        []repositorychangeset.File
 }
 
 func resolveRepositoryLocalChanges(repository *resolvedRepositoryCheckout, copyWorkspace bool) (repositoryLocalChanges, error) {
@@ -68,6 +69,7 @@ func resolveRepositoryLocalChanges(repository *resolvedRepositoryCheckout, copyW
 		out.CommitBundle = commitBundle.ToProto()
 	}
 	if changeset != nil {
+		out.Files = append([]repositorychangeset.File(nil), changeset.Files...)
 		out.Changeset = changeset.ToProto()
 	}
 	return out, nil

--- a/internal/cli/workspace.go
+++ b/internal/cli/workspace.go
@@ -410,6 +410,10 @@ func ensureGitWorkspaceCopyOutSafeWithBinding(localRoot, baseCommit string, bind
 	if err != nil {
 		return err
 	}
+	staged, err := gitWorkspaceStagedPaths(localRoot, paths)
+	if err != nil {
+		return err
+	}
 	for _, path := range paths {
 		expected, ok := manifest[path]
 		if !ok {
@@ -420,6 +424,15 @@ func ensureGitWorkspaceCopyOutSafeWithBinding(localRoot, baseCommit string, bind
 		}
 		if err := ensureGitWorkspaceFileMatchesExpected(localRoot, path, current[path], expected); err != nil {
 			return err
+		}
+		if staged[path] {
+			index, err := gitWorkspaceIndexFile(localRoot, nil, path)
+			if err != nil {
+				return err
+			}
+			if err := ensureGitWorkspaceFileMatchesExpected(localRoot, path, index, expected); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -669,6 +682,26 @@ func gitWorkspaceCurrentFiles(localRoot string, paths []string) (map[string]work
 		files[path] = file
 	}
 	return files, nil
+}
+
+func gitWorkspaceStagedPaths(localRoot string, paths []string) (map[string]bool, error) {
+	staged := make(map[string]bool)
+	if len(paths) == 0 {
+		return staged, nil
+	}
+	args := append([]string{"diff", "--cached", "--name-only", "--no-renames", "-z", "--"}, paths...)
+	output, err := gitOutputRaw(localRoot, nil, args...)
+	if err != nil {
+		return nil, fmt.Errorf("inspect staged local workspace paths: %w", err)
+	}
+	for _, rawPath := range splitNullTerminatedWorkspaceFields(output) {
+		path, err := workspaceRelativePath(rawPath)
+		if err != nil {
+			return nil, err
+		}
+		staged[path] = true
+	}
+	return staged, nil
 }
 
 func gitWorkspaceCommitFile(localRoot, commit, rel string) (workspaceBindingFile, error) {

--- a/internal/cli/workspace.go
+++ b/internal/cli/workspace.go
@@ -599,6 +599,7 @@ func buildGitWorkspaceCopyOutPatchFromLocalBase(localRoot, baseCommit, sandboxPa
 	if len(paths) == 0 {
 		return nil, nil, nil
 	}
+	pathspecs := gitWorkspacePathspecs(paths)
 	localTree, err := gitWorkspaceCurrentTree(localRoot)
 	if err != nil {
 		return nil, nil, err
@@ -607,12 +608,12 @@ func buildGitWorkspaceCopyOutPatchFromLocalBase(localRoot, baseCommit, sandboxPa
 	if err != nil {
 		return nil, nil, err
 	}
-	nameStatusArgs := append([]string{"diff", "--name-status", "--no-renames", "-z", localTree, sandboxTree, "--"}, paths...)
+	nameStatusArgs := append([]string{"diff", "--name-status", "--no-renames", "-z", localTree, sandboxTree, "--"}, pathspecs...)
 	nameStatus, err := gitOutputRaw(localRoot, nil, nameStatusArgs...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("build workspace copy-out local name-status: %w", err)
 	}
-	patchArgs := append([]string{"diff", "--binary", "--full-index", "--no-ext-diff", "--no-color", "--no-renames", localTree, sandboxTree, "--"}, paths...)
+	patchArgs := append([]string{"diff", "--binary", "--full-index", "--no-ext-diff", "--no-color", "--no-renames", localTree, sandboxTree, "--"}, pathspecs...)
 	patch, err := gitOutputRaw(localRoot, nil, patchArgs...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("build workspace copy-out local patch: %w", err)
@@ -689,7 +690,7 @@ func gitWorkspaceStagedPaths(localRoot string, paths []string) (map[string]bool,
 	if len(paths) == 0 {
 		return staged, nil
 	}
-	args := append([]string{"diff", "--cached", "--name-only", "--no-renames", "-z", "--"}, paths...)
+	args := append([]string{"diff", "--cached", "--name-only", "--no-renames", "-z", "--"}, gitWorkspacePathspecs(paths)...)
 	output, err := gitOutputRaw(localRoot, nil, args...)
 	if err != nil {
 		return nil, fmt.Errorf("inspect staged local workspace paths: %w", err)
@@ -743,11 +744,11 @@ func gitWorkspaceIndexFile(localRoot string, env []string, rel string) (workspac
 }
 
 func gitWorkspacePathModeInIndex(localRoot string, env []string, rel string) (string, bool, error) {
-	output, err := gitOutputRaw(localRoot, env, "ls-files", "--stage", "-z", "--", rel)
+	output, err := gitOutputRaw(localRoot, env, "ls-files", "--stage", "-z", "--", gitWorkspacePathspec(rel))
 	if err != nil {
 		return "", false, fmt.Errorf("inspect local workspace path %q in temporary index: %w", rel, err)
 	}
-	mode, exists, err := gitWorkspaceEntryMode(output)
+	mode, exists, err := gitWorkspaceEntryMode(output, rel)
 	if err != nil {
 		return "", false, fmt.Errorf("parse local workspace path %q in temporary index: %w", rel, err)
 	}
@@ -755,28 +756,45 @@ func gitWorkspacePathModeInIndex(localRoot string, env []string, rel string) (st
 }
 
 func gitWorkspacePathModeInCommit(localRoot, commit, rel string) (string, bool, error) {
-	output, err := gitOutputRaw(localRoot, nil, "ls-tree", "-z", strings.TrimSpace(commit), "--", rel)
+	output, err := gitOutputRaw(localRoot, nil, "ls-tree", "-z", strings.TrimSpace(commit), "--", gitWorkspacePathspec(rel))
 	if err != nil {
 		return "", false, fmt.Errorf("inspect sandbox baseline path %q: %w", rel, err)
 	}
-	mode, exists, err := gitWorkspaceEntryMode(output)
+	mode, exists, err := gitWorkspaceEntryMode(output, rel)
 	if err != nil {
 		return "", false, fmt.Errorf("parse sandbox baseline path %q: %w", rel, err)
 	}
 	return mode, exists, nil
 }
 
-func gitWorkspaceEntryMode(output []byte) (string, bool, error) {
+func gitWorkspaceEntryMode(output []byte, rel string) (string, bool, error) {
+	normalized, err := workspaceRelativePath(rel)
+	if err != nil {
+		return "", false, err
+	}
 	output = bytes.TrimRight(output, "\x00")
 	if len(bytes.TrimSpace(output)) == 0 {
 		return "", false, nil
 	}
-	entry, _, _ := bytes.Cut(output, []byte{0})
-	fields := strings.Fields(string(entry))
-	if len(fields) < 3 || strings.TrimSpace(fields[0]) == "" {
-		return "", false, fmt.Errorf("parse git entry %q", string(entry))
+	for _, entry := range bytes.Split(output, []byte{0}) {
+		metadata, rawPath, ok := bytes.Cut(entry, []byte{'\t'})
+		if !ok {
+			return "", false, fmt.Errorf("parse git entry %q", string(entry))
+		}
+		path, err := workspaceRelativePath(string(rawPath))
+		if err != nil {
+			return "", false, err
+		}
+		if path != normalized {
+			continue
+		}
+		fields := strings.Fields(string(metadata))
+		if len(fields) < 3 || strings.TrimSpace(fields[0]) == "" {
+			return "", false, fmt.Errorf("parse git entry %q", string(entry))
+		}
+		return fields[0], true, nil
 	}
-	return fields[0], true, nil
+	return "", false, nil
 }
 
 func workspaceCopyOutPaths(files []repositorychangeset.File) ([]string, error) {
@@ -795,6 +813,18 @@ func workspaceCopyOutPaths(files []repositorychangeset.File) ([]string, error) {
 	}
 	sort.Strings(paths)
 	return paths, nil
+}
+
+func gitWorkspacePathspecs(paths []string) []string {
+	pathspecs := make([]string, 0, len(paths))
+	for _, path := range paths {
+		pathspecs = append(pathspecs, gitWorkspacePathspec(path))
+	}
+	return pathspecs
+}
+
+func gitWorkspacePathspec(path string) string {
+	return ":(literal)" + path
 }
 
 func temporaryGitIndex() (string, func(), error) {

--- a/internal/cli/workspace.go
+++ b/internal/cli/workspace.go
@@ -4,12 +4,15 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"io/fs"
 	"os"
+	"os/exec"
 	posixpath "path"
 	"path/filepath"
 	"sort"
@@ -235,17 +238,40 @@ func copyWorkspaceOut(callCtx context.Context, ctx *runtimeContext, client *cont
 		return err
 	}
 	if opts.DryRun {
-		command := repositorychangeset.WorktreeNameStatusCommand(checkout)
-		if len(command) == 0 {
-			return errors.New("sandbox repository checkout is missing the information needed to plan workspace copy-out")
-		}
-		output, err := runWorkspaceExecutionCapture(callCtx, ctx, client, opts.SandboxID, command, opts.LaunchSeconds)
-		if err != nil {
-			return err
-		}
-		files, err := parseGitNameStatusWorkspaceFiles(output)
-		if err != nil {
-			return err
+		var files []repositorychangeset.File
+		if useGitWorkspaceCopyOutApplyBase(opts.Binding, opts.Repository, checkout) {
+			var patch []byte
+			files, patch, err = captureGitWorkspaceCopyOutPayload(callCtx, ctx, client, opts, checkout)
+			if err != nil {
+				return err
+			}
+			if len(files) > 0 {
+				patchPath, cleanup, err := writeTemporaryWorkspaceCopyOutPatch(patch)
+				if err != nil {
+					return err
+				}
+				defer cleanup()
+				if err := ensureGitWorkspaceCopyOutSafe(opts.Repository, checkout, opts.Binding, files); err != nil {
+					return err
+				}
+				files, _, err = prepareGitWorkspaceCopyOutApplyPatch(opts.Repository, checkout, files, patchPath, "")
+				if err != nil {
+					return err
+				}
+			}
+		} else {
+			command := repositorychangeset.WorktreeNameStatusCommand(checkout)
+			if len(command) == 0 {
+				return errors.New("sandbox repository checkout is missing the information needed to plan workspace copy-out")
+			}
+			output, err := runWorkspaceExecutionCapture(callCtx, ctx, client, opts.SandboxID, command, opts.LaunchSeconds)
+			if err != nil {
+				return err
+			}
+			files, err = parseGitNameStatusWorkspaceFiles(output)
+			if err != nil {
+				return err
+			}
 		}
 		entries, err := gitWorkspaceCopyOutPlanFiles(opts.CWD, files)
 		if err != nil {
@@ -254,23 +280,7 @@ func copyWorkspaceOut(callCtx context.Context, ctx *runtimeContext, client *cont
 		return printWorkspacePlan(runtimeStdout(ctx), entries)
 	}
 
-	command := repositorychangeset.WorktreeCopyOutCommand(checkout)
-	if len(command) == 0 {
-		return errors.New("sandbox repository checkout is missing the information needed to copy workspace changes out")
-	}
-	output, err := runWorkspaceExecutionCapture(callCtx, ctx, client, opts.SandboxID, command, opts.LaunchSeconds)
-	if err != nil {
-		return err
-	}
-	nameStatus, patch, err := parseGitWorkspaceCopyOutPayload(output)
-	if err != nil {
-		return err
-	}
-	files, err := parseGitNameStatusWorkspaceFiles(nameStatus)
-	if err != nil {
-		return err
-	}
-	entries, err := gitWorkspaceCopyOutPlanFiles(opts.CWD, files)
+	files, patch, err := captureGitWorkspaceCopyOutPayload(callCtx, ctx, client, opts, checkout)
 	if err != nil {
 		return err
 	}
@@ -281,10 +291,24 @@ func copyWorkspaceOut(callCtx context.Context, ctx *runtimeContext, client *cont
 	if err != nil {
 		return err
 	}
-	if err := ensureGitWorkspaceCopyOutSafe(opts.Repository, checkout, files); err != nil {
+	if err := ensureGitWorkspaceCopyOutSafe(opts.Repository, checkout, opts.Binding, files); err != nil {
 		return fmt.Errorf("%w; sandbox changes saved to %s", err, recovery.Directory)
 	}
-	if err := applyGitWorkspaceCopyOutPatch(opts.Repository.RootDir, recovery.PatchPath); err != nil {
+	applyPath := recovery.PatchPath
+	if useGitWorkspaceCopyOutApplyBase(opts.Binding, opts.Repository, checkout) {
+		files, applyPath, err = prepareGitWorkspaceCopyOutApplyPatch(opts.Repository, checkout, files, recovery.PatchPath, recovery.Directory)
+		if err != nil {
+			return fmt.Errorf("%w; sandbox changes saved to %s", err, recovery.Directory)
+		}
+		if len(files) == 0 {
+			return nil
+		}
+	}
+	entries, err := gitWorkspaceCopyOutPlanFiles(opts.CWD, files)
+	if err != nil {
+		return err
+	}
+	if err := applyGitWorkspaceCopyOutPatch(opts.Repository.RootDir, applyPath); err != nil {
 		return fmt.Errorf("%w; sandbox changes saved to %s", err, recovery.Directory)
 	}
 	return printWorkspacePlan(runtimeStdout(ctx), entries)
@@ -343,7 +367,7 @@ func validateWorkspaceCopyOutLocalRepository(local *resolvedRepositoryCheckout, 
 	return nil
 }
 
-func ensureGitWorkspaceCopyOutSafe(local *resolvedRepositoryCheckout, checkout *repositorycheckout.Checkout, files []repositorychangeset.File) error {
+func ensureGitWorkspaceCopyOutSafe(local *resolvedRepositoryCheckout, checkout *repositorycheckout.Checkout, binding *workspaceBinding, files []repositorychangeset.File) error {
 	if local == nil || strings.TrimSpace(local.RootDir) == "" {
 		return errors.New("workspace copy-out requires a local Git repository checkout matching the sandbox repository")
 	}
@@ -355,13 +379,102 @@ func ensureGitWorkspaceCopyOutSafe(local *resolvedRepositoryCheckout, checkout *
 	if localCommit == "" || sandboxCommit == "" {
 		return errors.New("workspace copy-out requires local and sandbox repository commits")
 	}
-	if !strings.EqualFold(localCommit, sandboxCommit) {
+	if binding == nil && !strings.EqualFold(localCommit, sandboxCommit) {
 		return fmt.Errorf("workspace copy-out requires local checkout HEAD %s to match sandbox baseline %s", shortGitSHA(localCommit), shortGitSHA(sandboxCommit))
+	}
+	if binding != nil {
+		return ensureGitWorkspaceCopyOutSafeWithBinding(local.RootDir, sandboxCommit, binding, files)
 	}
 	for _, file := range files {
 		if err := ensureGitWorkspaceCopyOutPathSafe(local.RootDir, sandboxCommit, file.Path); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+func ensureGitWorkspaceCopyOutSafeWithBinding(localRoot, baseCommit string, binding *workspaceBinding, files []repositorychangeset.File) error {
+	manifest, err := workspaceCopyInManifestMap(binding)
+	if err != nil {
+		return err
+	}
+	paths := make([]string, 0, len(files))
+	for _, file := range files {
+		path, err := workspaceRelativePath(file.Path)
+		if err != nil {
+			return err
+		}
+		paths = append(paths, path)
+	}
+	current, err := gitWorkspaceCurrentFiles(localRoot, paths)
+	if err != nil {
+		return err
+	}
+	for _, path := range paths {
+		expected, ok := manifest[path]
+		if !ok {
+			expected, err = gitWorkspaceCommitFile(localRoot, baseCommit, path)
+			if err != nil {
+				return err
+			}
+		}
+		if err := ensureGitWorkspaceFileMatchesExpected(localRoot, path, current[path], expected); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func workspaceCopyInManifestMap(binding *workspaceBinding) (map[string]workspaceBindingFile, error) {
+	manifest := make(map[string]workspaceBindingFile)
+	if binding == nil {
+		return manifest, nil
+	}
+	for _, file := range binding.CopyInManifest {
+		path, err := workspaceRelativePath(file.Path)
+		if err != nil {
+			return nil, err
+		}
+		if _, exists := manifest[path]; exists {
+			return nil, fmt.Errorf("workspace binding copy-in manifest path %q is duplicated", path)
+		}
+		entry := workspaceBindingFile{
+			Path:    path,
+			SHA256:  strings.TrimSpace(file.SHA256),
+			Mode:    strings.TrimSpace(file.Mode),
+			Deleted: file.Deleted,
+		}
+		if entry.Deleted {
+			entry.SHA256 = ""
+			entry.Mode = ""
+		} else if entry.SHA256 == "" {
+			return nil, fmt.Errorf("workspace binding copy-in manifest path %q is missing sha256", path)
+		} else if entry.Mode == "" {
+			return nil, fmt.Errorf("workspace binding copy-in manifest path %q is missing git mode", path)
+		}
+		manifest[path] = entry
+	}
+	return manifest, nil
+}
+
+func ensureGitWorkspaceFileMatchesExpected(localRoot, rel string, current, expected workspaceBindingFile) error {
+	if expected.Deleted {
+		if !current.Deleted {
+			return fmt.Errorf("local workspace path %q changed independently; refusing workspace copy-out", rel)
+		}
+		localPath, err := workspaceLocalPath(localRoot, rel)
+		if err != nil {
+			return err
+		}
+		if _, err := os.Lstat(localPath); err == nil {
+			return fmt.Errorf("local workspace path %q exists outside workspace copy-in base; refusing workspace copy-out", rel)
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("inspect local workspace path %q: %w", rel, err)
+		}
+		return nil
+	}
+	if current.Deleted || current.SHA256 != expected.SHA256 || current.Mode != expected.Mode {
+		return fmt.Errorf("local workspace path %q changed independently; refusing workspace copy-out", rel)
 	}
 	return nil
 }
@@ -403,6 +516,308 @@ func gitPathExistsInCommit(localRoot, commit, rel string) (bool, error) {
 		return false, fmt.Errorf("inspect sandbox baseline path %q: %w", rel, err)
 	}
 	return strings.Trim(output, "\x00 \n\r\t") != "", nil
+}
+
+func captureGitWorkspaceCopyOutPayload(callCtx context.Context, ctx *runtimeContext, client *controlclient.Client, opts workspaceCopyOptions, checkout *repositorycheckout.Checkout) ([]repositorychangeset.File, []byte, error) {
+	command := repositorychangeset.WorktreeCopyOutCommand(checkout)
+	if len(command) == 0 {
+		return nil, nil, errors.New("sandbox repository checkout is missing the information needed to copy workspace changes out")
+	}
+	output, err := runWorkspaceExecutionCapture(callCtx, ctx, client, opts.SandboxID, command, opts.LaunchSeconds)
+	if err != nil {
+		return nil, nil, err
+	}
+	nameStatus, patch, err := parseGitWorkspaceCopyOutPayload(output)
+	if err != nil {
+		return nil, nil, err
+	}
+	files, err := parseGitNameStatusWorkspaceFiles(nameStatus)
+	if err != nil {
+		return nil, nil, err
+	}
+	return files, patch, nil
+}
+
+func useGitWorkspaceCopyOutApplyBase(binding *workspaceBinding, local *resolvedRepositoryCheckout, checkout *repositorycheckout.Checkout) bool {
+	if binding == nil {
+		return false
+	}
+	if len(binding.CopyInManifest) > 0 {
+		return true
+	}
+	if local == nil || checkout == nil {
+		return false
+	}
+	localCommit := strings.TrimSpace(local.CommitSHA)
+	sandboxCommit := strings.TrimSpace(checkout.CommitSHA)
+	return localCommit != "" && sandboxCommit != "" && !strings.EqualFold(localCommit, sandboxCommit)
+}
+
+func prepareGitWorkspaceCopyOutApplyPatch(local *resolvedRepositoryCheckout, checkout *repositorycheckout.Checkout, files []repositorychangeset.File, sandboxPatchPath, recoveryDir string) ([]repositorychangeset.File, string, error) {
+	if local == nil || strings.TrimSpace(local.RootDir) == "" {
+		return nil, "", errors.New("workspace copy-out requires a local Git repository checkout matching the sandbox repository")
+	}
+	if checkout == nil || strings.TrimSpace(checkout.CommitSHA) == "" {
+		return nil, "", errors.New("workspace copy-out requires a sandbox repository baseline")
+	}
+	nameStatus, patch, err := buildGitWorkspaceCopyOutPatchFromLocalBase(local.RootDir, checkout.CommitSHA, sandboxPatchPath, files)
+	if err != nil {
+		return nil, "", err
+	}
+	applyFiles, err := parseGitNameStatusWorkspaceFiles(nameStatus)
+	if err != nil {
+		return nil, "", err
+	}
+	if len(applyFiles) == 0 || strings.TrimSpace(recoveryDir) == "" {
+		return applyFiles, "", nil
+	}
+	patchPath := filepath.Join(recoveryDir, "local-apply.patch")
+	if err := os.WriteFile(patchPath, patch, 0o600); err != nil {
+		return nil, "", fmt.Errorf("write workspace copy-out local apply patch: %w", err)
+	}
+	return applyFiles, patchPath, nil
+}
+
+func buildGitWorkspaceCopyOutPatchFromLocalBase(localRoot, baseCommit, sandboxPatchPath string, files []repositorychangeset.File) ([]byte, []byte, error) {
+	paths, err := workspaceCopyOutPaths(files)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(paths) == 0 {
+		return nil, nil, nil
+	}
+	localTree, err := gitWorkspaceCurrentTree(localRoot)
+	if err != nil {
+		return nil, nil, err
+	}
+	sandboxTree, err := gitWorkspaceSandboxTree(localRoot, baseCommit, sandboxPatchPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	nameStatusArgs := append([]string{"diff", "--name-status", "--no-renames", "-z", localTree, sandboxTree, "--"}, paths...)
+	nameStatus, err := gitOutputRaw(localRoot, nil, nameStatusArgs...)
+	if err != nil {
+		return nil, nil, fmt.Errorf("build workspace copy-out local name-status: %w", err)
+	}
+	patchArgs := append([]string{"diff", "--binary", "--full-index", "--no-ext-diff", "--no-color", "--no-renames", localTree, sandboxTree, "--"}, paths...)
+	patch, err := gitOutputRaw(localRoot, nil, patchArgs...)
+	if err != nil {
+		return nil, nil, fmt.Errorf("build workspace copy-out local patch: %w", err)
+	}
+	return nameStatus, patch, nil
+}
+
+func gitWorkspaceCurrentTree(localRoot string) (string, error) {
+	indexPath, cleanup, err := temporaryGitIndex()
+	if err != nil {
+		return "", err
+	}
+	defer cleanup()
+	env := append(os.Environ(), "GIT_INDEX_FILE="+indexPath)
+	if _, err := gitOutputRaw(localRoot, env, "read-tree", "HEAD"); err != nil {
+		return "", fmt.Errorf("initialize local workspace copy-out index: %w", err)
+	}
+	if _, err := gitOutputRaw(localRoot, env, "add", "-A", "--all", "."); err != nil {
+		return "", fmt.Errorf("stage local workspace copy-out base: %w", err)
+	}
+	tree, err := gitOutputRaw(localRoot, env, "write-tree")
+	if err != nil {
+		return "", fmt.Errorf("write local workspace copy-out tree: %w", err)
+	}
+	return strings.TrimSpace(string(tree)), nil
+}
+
+func gitWorkspaceSandboxTree(localRoot, baseCommit, sandboxPatchPath string) (string, error) {
+	indexPath, cleanup, err := temporaryGitIndex()
+	if err != nil {
+		return "", err
+	}
+	defer cleanup()
+	env := append(os.Environ(), "GIT_INDEX_FILE="+indexPath)
+	if _, err := gitOutputRaw(localRoot, env, "read-tree", strings.ToLower(strings.TrimSpace(baseCommit))); err != nil {
+		return "", fmt.Errorf("initialize sandbox workspace copy-out index: %w", err)
+	}
+	if _, err := gitOutputRaw(localRoot, env, "apply", "--cached", "--binary", "--whitespace=nowarn", sandboxPatchPath); err != nil {
+		return "", fmt.Errorf("apply sandbox workspace copy-out patch to temporary index: %w", err)
+	}
+	tree, err := gitOutputRaw(localRoot, env, "write-tree")
+	if err != nil {
+		return "", fmt.Errorf("write sandbox workspace copy-out tree: %w", err)
+	}
+	return strings.TrimSpace(string(tree)), nil
+}
+
+func gitWorkspaceCurrentFiles(localRoot string, paths []string) (map[string]workspaceBindingFile, error) {
+	indexPath, cleanup, err := temporaryGitIndex()
+	if err != nil {
+		return nil, err
+	}
+	defer cleanup()
+	env := append(os.Environ(), "GIT_INDEX_FILE="+indexPath)
+	if _, err := gitOutputRaw(localRoot, env, "read-tree", "HEAD"); err != nil {
+		return nil, fmt.Errorf("initialize local workspace manifest index: %w", err)
+	}
+	if _, err := gitOutputRaw(localRoot, env, "add", "-A", "--all", "."); err != nil {
+		return nil, fmt.Errorf("stage local workspace manifest state: %w", err)
+	}
+	files := make(map[string]workspaceBindingFile, len(paths))
+	for _, path := range paths {
+		file, err := gitWorkspaceIndexFile(localRoot, env, path)
+		if err != nil {
+			return nil, err
+		}
+		files[path] = file
+	}
+	return files, nil
+}
+
+func gitWorkspaceCommitFile(localRoot, commit, rel string) (workspaceBindingFile, error) {
+	file := workspaceBindingFile{Path: rel}
+	mode, exists, err := gitWorkspacePathModeInCommit(localRoot, commit, rel)
+	if err != nil {
+		return file, err
+	}
+	if !exists {
+		file.Deleted = true
+		return file, nil
+	}
+	file.Mode = mode
+	blob, err := gitOutputRaw(localRoot, nil, "show", strings.TrimSpace(commit)+":"+rel)
+	if err != nil {
+		return file, fmt.Errorf("read sandbox baseline path %q: %w", rel, err)
+	}
+	file.SHA256 = workspaceSHA256Digest(blob)
+	return file, nil
+}
+
+func gitWorkspaceIndexFile(localRoot string, env []string, rel string) (workspaceBindingFile, error) {
+	file := workspaceBindingFile{Path: rel}
+	mode, exists, err := gitWorkspacePathModeInIndex(localRoot, env, rel)
+	if err != nil {
+		return file, err
+	}
+	if !exists {
+		file.Deleted = true
+		return file, nil
+	}
+	file.Mode = mode
+	blob, err := gitOutputRaw(localRoot, env, "show", ":"+rel)
+	if err != nil {
+		return file, fmt.Errorf("read local workspace path %q from temporary index: %w", rel, err)
+	}
+	file.SHA256 = workspaceSHA256Digest(blob)
+	return file, nil
+}
+
+func gitWorkspacePathModeInIndex(localRoot string, env []string, rel string) (string, bool, error) {
+	output, err := gitOutputRaw(localRoot, env, "ls-files", "--stage", "-z", "--", rel)
+	if err != nil {
+		return "", false, fmt.Errorf("inspect local workspace path %q in temporary index: %w", rel, err)
+	}
+	mode, exists, err := gitWorkspaceEntryMode(output)
+	if err != nil {
+		return "", false, fmt.Errorf("parse local workspace path %q in temporary index: %w", rel, err)
+	}
+	return mode, exists, nil
+}
+
+func gitWorkspacePathModeInCommit(localRoot, commit, rel string) (string, bool, error) {
+	output, err := gitOutputRaw(localRoot, nil, "ls-tree", "-z", strings.TrimSpace(commit), "--", rel)
+	if err != nil {
+		return "", false, fmt.Errorf("inspect sandbox baseline path %q: %w", rel, err)
+	}
+	mode, exists, err := gitWorkspaceEntryMode(output)
+	if err != nil {
+		return "", false, fmt.Errorf("parse sandbox baseline path %q: %w", rel, err)
+	}
+	return mode, exists, nil
+}
+
+func gitWorkspaceEntryMode(output []byte) (string, bool, error) {
+	output = bytes.TrimRight(output, "\x00")
+	if len(bytes.TrimSpace(output)) == 0 {
+		return "", false, nil
+	}
+	entry, _, _ := bytes.Cut(output, []byte{0})
+	fields := strings.Fields(string(entry))
+	if len(fields) < 3 || strings.TrimSpace(fields[0]) == "" {
+		return "", false, fmt.Errorf("parse git entry %q", string(entry))
+	}
+	return fields[0], true, nil
+}
+
+func workspaceCopyOutPaths(files []repositorychangeset.File) ([]string, error) {
+	paths := make([]string, 0, len(files))
+	seen := make(map[string]struct{}, len(files))
+	for _, file := range files {
+		path, err := workspaceRelativePath(file.Path)
+		if err != nil {
+			return nil, err
+		}
+		if _, exists := seen[path]; exists {
+			continue
+		}
+		seen[path] = struct{}{}
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	return paths, nil
+}
+
+func temporaryGitIndex() (string, func(), error) {
+	indexFile, err := os.CreateTemp("", "cleanroom-workspace-copy-out-index-*")
+	if err != nil {
+		return "", nil, fmt.Errorf("create temporary git index: %w", err)
+	}
+	indexPath := indexFile.Name()
+	if err := indexFile.Close(); err != nil {
+		_ = os.Remove(indexPath)
+		return "", nil, fmt.Errorf("close temporary git index %q: %w", indexPath, err)
+	}
+	return indexPath, func() { _ = os.Remove(indexPath) }, nil
+}
+
+func writeTemporaryWorkspaceCopyOutPatch(patch []byte) (string, func(), error) {
+	patchFile, err := os.CreateTemp("", "cleanroom-workspace-copy-out-*.patch")
+	if err != nil {
+		return "", nil, fmt.Errorf("create temporary workspace copy-out patch: %w", err)
+	}
+	patchPath := patchFile.Name()
+	if _, err := patchFile.Write(patch); err != nil {
+		_ = patchFile.Close()
+		_ = os.Remove(patchPath)
+		return "", nil, fmt.Errorf("write temporary workspace copy-out patch: %w", err)
+	}
+	if err := patchFile.Close(); err != nil {
+		_ = os.Remove(patchPath)
+		return "", nil, fmt.Errorf("close temporary workspace copy-out patch %q: %w", patchPath, err)
+	}
+	return patchPath, func() { _ = os.Remove(patchPath) }, nil
+}
+
+func gitOutputRaw(dir string, env []string, args ...string) ([]byte, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if env != nil {
+		cmd.Env = env
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		msg := err.Error()
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			if stderr := strings.TrimSpace(string(exitErr.Stderr)); stderr != "" {
+				msg = stderr
+			}
+		}
+		return nil, errors.New(msg)
+	}
+	return out, nil
+}
+
+func workspaceSHA256Digest(data []byte) string {
+	sum := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(sum[:])
 }
 
 func applyGitWorkspaceCopyOutPatch(localRoot, patchPath string) error {

--- a/internal/cli/workspace_binding.go
+++ b/internal/cli/workspace_binding.go
@@ -36,6 +36,7 @@ type workspaceBinding struct {
 type workspaceBindingFile struct {
 	Path    string `json:"path"`
 	SHA256  string `json:"sha256,omitempty"`
+	Mode    string `json:"mode,omitempty"`
 	Deleted bool   `json:"deleted,omitempty"`
 }
 
@@ -102,6 +103,10 @@ func recordGitWorkspaceBinding(sandboxID string, repository *resolvedRepositoryC
 	if operation == "" {
 		operation = "copy-in"
 	}
+	manifest, err := workspaceBindingFiles(files)
+	if err != nil {
+		return err
+	}
 	return writeWorkspaceBinding(&workspaceBinding{
 		Version:             workspaceBindingVersion,
 		SandboxID:           sandboxID,
@@ -113,7 +118,7 @@ func recordGitWorkspaceBinding(sandboxID string, repository *resolvedRepositoryC
 		Transport:           workspaceBindingTransportGit,
 		LastOperation:       operation,
 		LastOperationAt:     time.Now().UTC().Format(time.RFC3339Nano),
-		CopyInManifest:      workspaceBindingFiles(files),
+		CopyInManifest:      manifest,
 	})
 }
 
@@ -204,22 +209,40 @@ func validateWorkspaceBinding(binding *workspaceBinding, sandboxID string, check
 	return nil
 }
 
-func workspaceBindingFiles(files []repositorychangeset.File) []workspaceBindingFile {
+func workspaceBindingFiles(files []repositorychangeset.File) ([]workspaceBindingFile, error) {
 	if len(files) == 0 {
-		return nil
+		return nil, nil
 	}
 	out := make([]workspaceBindingFile, 0, len(files))
 	for _, file := range files {
+		path, err := workspaceRelativePath(file.Path)
+		if err != nil {
+			return nil, err
+		}
+		mode := strings.TrimSpace(file.Mode)
+		sha256 := strings.TrimSpace(file.SHA256)
+		if file.Deleted {
+			mode = ""
+			sha256 = ""
+		} else if sha256 == "" {
+			return nil, fmt.Errorf("workspace binding copy-in manifest path %q is missing sha256", path)
+		} else if mode == "" {
+			return nil, fmt.Errorf("workspace binding copy-in manifest path %q is missing git mode", path)
+		}
 		out = append(out, workspaceBindingFile{
-			Path:    file.Path,
-			SHA256:  file.SHA256,
+			Path:    path,
+			SHA256:  sha256,
+			Mode:    mode,
 			Deleted: file.Deleted,
 		})
 	}
-	return out
+	return out, nil
 }
 
 func repositoryLocalChangesFiles(localChanges repositoryLocalChanges) []repositorychangeset.File {
+	if len(localChanges.Files) > 0 {
+		return append([]repositorychangeset.File(nil), localChanges.Files...)
+	}
 	changeset := localChanges.Changeset
 	if changeset == nil {
 		return nil

--- a/internal/cli/workspace_test.go
+++ b/internal/cli/workspace_test.go
@@ -1395,6 +1395,65 @@ func TestWorkspaceCopyOutRejectsLocalModeDivergenceFromCopyInManifestBase(t *tes
 	assertWorkspaceCopyOutRecoveryPayload(t, fixture.sandboxID)
 }
 
+func TestWorkspaceCopyOutAppliesLiteralPathspecFromCopyInManifestBase(t *testing.T) {
+	fixture := setupWorkspaceCopyOutManifestBaseWithLocalMutate(t, func(localRoot string) {
+		if err := os.WriteFile(filepath.Join(localRoot, "A.txt"), []byte("decoy\n"), 0o755); err != nil {
+			t.Fatalf("write decoy file: %v", err)
+		}
+		if err := os.Chmod(filepath.Join(localRoot, "A.txt"), 0o755); err != nil {
+			t.Fatalf("chmod decoy file: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(localRoot, "[AB].txt"), []byte("local brackets\n"), 0o644); err != nil {
+			t.Fatalf("write bracket file: %v", err)
+		}
+	}, func(localRoot string) {
+		if err := os.WriteFile(filepath.Join(localRoot, "[AB].txt"), []byte("local brackets\nsandbox\n"), 0o644); err != nil {
+			t.Fatalf("write sandbox bracket file: %v", err)
+		}
+	})
+
+	stdout, stdoutText := makeStdoutCapture(t)
+	stderr, _ := makeStdoutCapture(t)
+	cmd := WorkspaceCopyOutCommand{
+		clientFlags: clientFlags{Host: fixture.host},
+		SandboxID:   fixture.sandboxID,
+	}
+	if err := cmd.Run(&runtimeContext{
+		CWD:           t.TempDir(),
+		Loader:        repositoryNotFoundLoader{},
+		Config:        runtimeconfig.Config{},
+		Observability: newTestObservability(t),
+		Stdout:        stdout,
+		Stderr:        stderr,
+	}); err != nil {
+		t.Fatalf("WorkspaceCopyOutCommand.Run returned error: %v", err)
+	}
+
+	bracketPath := filepath.Join(fixture.localRoot, "[AB].txt")
+	bracket, err := os.ReadFile(bracketPath)
+	if err != nil {
+		t.Fatalf("read bracket file: %v", err)
+	}
+	if got, want := string(bracket), "local brackets\nsandbox\n"; got != want {
+		t.Fatalf("unexpected bracket file content: got %q want %q", got, want)
+	}
+	decoyInfo, err := os.Stat(filepath.Join(fixture.localRoot, "A.txt"))
+	if err != nil {
+		t.Fatalf("stat decoy file: %v", err)
+	}
+	if got, want := decoyInfo.Mode().Perm(), os.FileMode(0o755); got != want {
+		t.Fatalf("copy-out should leave decoy mode unchanged: got %o want %o", got, want)
+	}
+	expected := strings.Join([]string{
+		"write\t" + filepath.Join(fixture.resolvedLocalRoot, "[AB].txt"),
+		"",
+	}, "\n")
+	if got := stdoutText(); got != expected {
+		t.Fatalf("unexpected copy-out output: got %q want %q", got, expected)
+	}
+	assertWorkspaceCopyOutRecoveryPayload(t, fixture.sandboxID)
+}
+
 func TestWorkspaceCopyOutRejectsStagedDivergenceFromCopyInManifestBase(t *testing.T) {
 	fixture := setupWorkspaceCopyOutManifestBase(t, func(localRoot string) {
 		if err := os.WriteFile(filepath.Join(localRoot, "README.md"), []byte("local\nsandbox\n"), 0o644); err != nil {
@@ -2336,6 +2395,11 @@ type workspaceCopyOutManifestFixture struct {
 
 func setupWorkspaceCopyOutManifestBase(t *testing.T, sandboxMutate func(string)) workspaceCopyOutManifestFixture {
 	t.Helper()
+	return setupWorkspaceCopyOutManifestBaseWithLocalMutate(t, nil, sandboxMutate)
+}
+
+func setupWorkspaceCopyOutManifestBaseWithLocalMutate(t *testing.T, localMutate, sandboxMutate func(string)) workspaceCopyOutManifestFixture {
+	t.Helper()
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	localRoot := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
 	resolvedLocalRoot, err := gitOutput(localRoot, "rev-parse", "--show-toplevel")
@@ -2355,6 +2419,9 @@ func setupWorkspaceCopyOutManifestBase(t *testing.T, sandboxMutate func(string))
 	}
 	if err := os.WriteFile(filepath.Join(localRoot, "local.txt"), []byte("local only\n"), 0o644); err != nil {
 		t.Fatalf("write local-only file: %v", err)
+	}
+	if localMutate != nil {
+		localMutate(localRoot)
 	}
 	runGitInDir(t, localRoot, "add", "-A")
 	runGitInDir(t, localRoot, "commit", "-m", "local copy-in state")

--- a/internal/cli/workspace_test.go
+++ b/internal/cli/workspace_test.go
@@ -20,6 +20,7 @@ import (
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
 	"github.com/buildkite/cleanroom/internal/policy"
 	"github.com/buildkite/cleanroom/internal/repositorychangeset"
+	"github.com/buildkite/cleanroom/internal/repositorycheckout"
 	"github.com/buildkite/cleanroom/internal/runtimeconfig"
 )
 
@@ -881,6 +882,7 @@ func TestWorkspaceBindingRecordsCopyInManifest(t *testing.T) {
 	files := []repositorychangeset.File{{
 		Path:   "dirty.txt",
 		SHA256: "sha256:dirty",
+		Mode:   "100644",
 	}, {
 		Path:    "removed.txt",
 		Deleted: true,
@@ -893,7 +895,7 @@ func TestWorkspaceBindingRecordsCopyInManifest(t *testing.T) {
 	}
 	binding := mustReadWorkspaceBinding(t, "cr_manifest")
 	expected := []workspaceBindingFile{
-		{Path: "dirty.txt", SHA256: "sha256:dirty"},
+		{Path: "dirty.txt", SHA256: "sha256:dirty", Mode: "100644"},
 		{Path: "removed.txt", Deleted: true},
 	}
 	if !reflect.DeepEqual(binding.CopyInManifest, expected) {
@@ -1192,6 +1194,205 @@ func TestWorkspaceCopyOutAppliesSandboxGitPatch(t *testing.T) {
 		t.Fatalf("expected one combined copy-out execution, got %d", len(commands))
 	}
 	assertWorkspaceCopyOutRecoveryPayload(t, sandboxID)
+}
+
+func TestWorkspaceCopyOutAppliesFromCopyInManifestBase(t *testing.T) {
+	fixture := setupWorkspaceCopyOutManifestBase(t, func(localRoot string) {
+		if err := os.WriteFile(filepath.Join(localRoot, "README.md"), []byte("local\nsandbox\n"), 0o644); err != nil {
+			t.Fatalf("write sandbox README: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(localRoot, "local.txt"), []byte("local only\nsandbox\n"), 0o644); err != nil {
+			t.Fatalf("write sandbox local file: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(localRoot, "generated.txt"), []byte("generated\n"), 0o644); err != nil {
+			t.Fatalf("write sandbox generated file: %v", err)
+		}
+	})
+
+	stdout, stdoutText := makeStdoutCapture(t)
+	stderr, _ := makeStdoutCapture(t)
+	cmd := WorkspaceCopyOutCommand{
+		clientFlags: clientFlags{Host: fixture.host},
+		SandboxID:   fixture.sandboxID,
+	}
+	if err := cmd.Run(&runtimeContext{
+		CWD:           t.TempDir(),
+		Loader:        repositoryNotFoundLoader{},
+		Config:        runtimeconfig.Config{},
+		Observability: newTestObservability(t),
+		Stdout:        stdout,
+		Stderr:        stderr,
+	}); err != nil {
+		t.Fatalf("WorkspaceCopyOutCommand.Run returned error: %v", err)
+	}
+
+	for path, want := range map[string]string{
+		"README.md":     "local\nsandbox\n",
+		"local.txt":     "local only\nsandbox\n",
+		"generated.txt": "generated\n",
+	} {
+		got, err := os.ReadFile(filepath.Join(fixture.localRoot, path))
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		if string(got) != want {
+			t.Fatalf("unexpected %s content: got %q want %q", path, got, want)
+		}
+	}
+
+	expected := strings.Join([]string{
+		"write\t" + filepath.Join(fixture.resolvedLocalRoot, "README.md"),
+		"write\t" + filepath.Join(fixture.resolvedLocalRoot, "generated.txt"),
+		"write\t" + filepath.Join(fixture.resolvedLocalRoot, "local.txt"),
+		"",
+	}, "\n")
+	if got := stdoutText(); got != expected {
+		t.Fatalf("unexpected copy-out output: got %q want %q", got, expected)
+	}
+	assertWorkspaceCopyOutRecoveryPayload(t, fixture.sandboxID)
+}
+
+func TestWorkspaceCopyOutDryRunUsesCopyInManifestBase(t *testing.T) {
+	fixture := setupWorkspaceCopyOutManifestBase(t, func(localRoot string) {
+		if err := os.WriteFile(filepath.Join(localRoot, "README.md"), []byte("local\nsandbox\n"), 0o644); err != nil {
+			t.Fatalf("write sandbox README: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(localRoot, "generated.txt"), []byte("generated\n"), 0o644); err != nil {
+			t.Fatalf("write sandbox generated file: %v", err)
+		}
+	})
+
+	stdout, stdoutText := makeStdoutCapture(t)
+	stderr, _ := makeStdoutCapture(t)
+	cmd := WorkspaceCopyOutCommand{
+		clientFlags: clientFlags{Host: fixture.host},
+		DryRun:      true,
+		SandboxID:   fixture.sandboxID,
+	}
+	if err := cmd.Run(&runtimeContext{
+		CWD:           t.TempDir(),
+		Loader:        repositoryNotFoundLoader{},
+		Config:        runtimeconfig.Config{},
+		Observability: newTestObservability(t),
+		Stdout:        stdout,
+		Stderr:        stderr,
+	}); err != nil {
+		t.Fatalf("WorkspaceCopyOutCommand.Run returned error: %v", err)
+	}
+
+	readme, err := os.ReadFile(filepath.Join(fixture.localRoot, "README.md"))
+	if err != nil {
+		t.Fatalf("read README: %v", err)
+	}
+	if got, want := string(readme), "local\n"; got != want {
+		t.Fatalf("dry-run should not modify README: got %q want %q", got, want)
+	}
+	if _, err := os.Stat(filepath.Join(fixture.localRoot, "generated.txt")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("dry-run should not write generated file, got err %v", err)
+	}
+
+	expected := strings.Join([]string{
+		"write\t" + filepath.Join(fixture.resolvedLocalRoot, "README.md"),
+		"write\t" + filepath.Join(fixture.resolvedLocalRoot, "generated.txt"),
+		"",
+	}, "\n")
+	if got := stdoutText(); got != expected {
+		t.Fatalf("unexpected copy-out dry-run output: got %q want %q", got, expected)
+	}
+}
+
+func TestWorkspaceCopyOutRejectsLocalDivergenceFromCopyInManifestBase(t *testing.T) {
+	fixture := setupWorkspaceCopyOutManifestBase(t, func(localRoot string) {
+		if err := os.WriteFile(filepath.Join(localRoot, "README.md"), []byte("local\nsandbox\n"), 0o644); err != nil {
+			t.Fatalf("write sandbox README: %v", err)
+		}
+	})
+	if err := os.WriteFile(filepath.Join(fixture.localRoot, "README.md"), []byte("local divergent\n"), 0o644); err != nil {
+		t.Fatalf("write divergent local README: %v", err)
+	}
+
+	stdout, _ := makeStdoutCapture(t)
+	stderr, _ := makeStdoutCapture(t)
+	cmd := WorkspaceCopyOutCommand{
+		clientFlags: clientFlags{Host: fixture.host},
+		SandboxID:   fixture.sandboxID,
+	}
+	err := cmd.Run(&runtimeContext{
+		CWD:           t.TempDir(),
+		Loader:        repositoryNotFoundLoader{},
+		Config:        runtimeconfig.Config{},
+		Observability: newTestObservability(t),
+		Stdout:        stdout,
+		Stderr:        stderr,
+	})
+	if err == nil {
+		t.Fatal("expected local divergence from copy-in manifest to be rejected")
+	}
+	if !strings.Contains(err.Error(), `local workspace path "README.md" changed independently`) {
+		t.Fatalf("expected manifest divergence error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "sandbox changes saved to") {
+		t.Fatalf("expected recovery payload path in error, got %v", err)
+	}
+	readme, err := os.ReadFile(filepath.Join(fixture.localRoot, "README.md"))
+	if err != nil {
+		t.Fatalf("read README: %v", err)
+	}
+	if got, want := string(readme), "local divergent\n"; got != want {
+		t.Fatalf("copy-out should not overwrite divergent local file: got %q want %q", got, want)
+	}
+	assertWorkspaceCopyOutRecoveryPayload(t, fixture.sandboxID)
+}
+
+func TestWorkspaceCopyOutRejectsLocalModeDivergenceFromCopyInManifestBase(t *testing.T) {
+	fixture := setupWorkspaceCopyOutManifestBase(t, func(localRoot string) {
+		if err := os.WriteFile(filepath.Join(localRoot, "README.md"), []byte("local\nsandbox\n"), 0o644); err != nil {
+			t.Fatalf("write sandbox README: %v", err)
+		}
+	})
+	readmePath := filepath.Join(fixture.localRoot, "README.md")
+	if err := os.Chmod(readmePath, 0o755); err != nil {
+		t.Fatalf("chmod local README: %v", err)
+	}
+
+	stdout, _ := makeStdoutCapture(t)
+	stderr, _ := makeStdoutCapture(t)
+	cmd := WorkspaceCopyOutCommand{
+		clientFlags: clientFlags{Host: fixture.host},
+		SandboxID:   fixture.sandboxID,
+	}
+	err := cmd.Run(&runtimeContext{
+		CWD:           t.TempDir(),
+		Loader:        repositoryNotFoundLoader{},
+		Config:        runtimeconfig.Config{},
+		Observability: newTestObservability(t),
+		Stdout:        stdout,
+		Stderr:        stderr,
+	})
+	if err == nil {
+		t.Fatal("expected local mode divergence from copy-in manifest to be rejected")
+	}
+	if !strings.Contains(err.Error(), `local workspace path "README.md" changed independently`) {
+		t.Fatalf("expected manifest divergence error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "sandbox changes saved to") {
+		t.Fatalf("expected recovery payload path in error, got %v", err)
+	}
+	info, err := os.Stat(readmePath)
+	if err != nil {
+		t.Fatalf("stat README: %v", err)
+	}
+	if got, want := info.Mode().Perm(), os.FileMode(0o755); got != want {
+		t.Fatalf("copy-out should leave local README mode unchanged: got %o want %o", got, want)
+	}
+	readme, err := os.ReadFile(readmePath)
+	if err != nil {
+		t.Fatalf("read README: %v", err)
+	}
+	if got, want := string(readme), "local\n"; got != want {
+		t.Fatalf("copy-out should leave local README content unchanged: got %q want %q", got, want)
+	}
+	assertWorkspaceCopyOutRecoveryPayload(t, fixture.sandboxID)
 }
 
 func TestWorkspaceCopyOutRejectsLocalDivergence(t *testing.T) {
@@ -2071,6 +2272,86 @@ func workspaceCopyRepositoryLoader() repositoryIntegrationLoader {
 			Remote: "origin",
 			Path:   "/workspace",
 		},
+	}
+}
+
+type workspaceCopyOutManifestFixture struct {
+	localRoot         string
+	resolvedLocalRoot string
+	host              string
+	sandboxID         string
+}
+
+func setupWorkspaceCopyOutManifestBase(t *testing.T, sandboxMutate func(string)) workspaceCopyOutManifestFixture {
+	t.Helper()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	localRoot := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
+	resolvedLocalRoot, err := gitOutput(localRoot, "rev-parse", "--show-toplevel")
+	if err != nil {
+		t.Fatalf("resolve local repository root: %v", err)
+	}
+	baseCommit := headCommit(t, localRoot)
+	checkout := &repositorycheckout.Checkout{
+		RemoteURL:      "https://github.com/buildkite/cleanroom.git",
+		CommitSHA:      baseCommit,
+		DestinationDir: "/sandbox-workspace",
+		Branch:         "main",
+	}
+
+	if err := os.WriteFile(filepath.Join(localRoot, "README.md"), []byte("local\n"), 0o644); err != nil {
+		t.Fatalf("write local README: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(localRoot, "local.txt"), []byte("local only\n"), 0o644); err != nil {
+		t.Fatalf("write local-only file: %v", err)
+	}
+	runGitInDir(t, localRoot, "add", "-A")
+	runGitInDir(t, localRoot, "commit", "-m", "local copy-in state")
+	copyInCommit := headCommit(t, localRoot)
+
+	changeset, err := repositorychangeset.BuildFromWorkingTree(localRoot, checkout)
+	if err != nil {
+		t.Fatalf("build copy-in manifest changeset: %v", err)
+	}
+	if changeset == nil {
+		t.Fatal("expected copy-in manifest changeset")
+	}
+	repository, err := resolveWorkspaceCopyRepositoryCheckout(localRoot, repositoryNotFoundLoader{})
+	if err != nil {
+		t.Fatalf("resolve local repository checkout: %v", err)
+	}
+
+	adapter := &integrationAdapter{}
+	host, _ := startIntegrationServer(t, adapter)
+	sandboxID := createWorkspaceCopyTestSandboxWithRepositoryCommitBranch(t, host, "/sandbox-workspace", baseCommit, "main")
+	if err := recordGitWorkspaceBinding(sandboxID, repository, checkout, changeset.Files, "copy-in"); err != nil {
+		t.Fatalf("record workspace binding: %v", err)
+	}
+
+	sandboxMutate(localRoot)
+	runGitInDir(t, localRoot, "add", "-A")
+	nameStatus := gitOutputBytes(t, localRoot, "diff", "--cached", "--name-status", "--no-renames", "-z", baseCommit)
+	patch := gitOutputBytes(t, localRoot, "diff", "--cached", "--binary", "--full-index", "--no-ext-diff", "--no-color", "--no-renames", baseCommit)
+	runGitInDir(t, localRoot, "reset", "--hard", copyInCommit)
+	runGitInDir(t, localRoot, "clean", "-fd")
+
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+		command := strings.Join(req.Command, " ")
+		switch {
+		case strings.Contains(command, "cleanroom-copy-out-v1"):
+			if stream.OnStdout != nil {
+				stream.OnStdout(workspaceCopyOutTestPayload(nameStatus, patch))
+			}
+		default:
+			t.Fatalf("unexpected workspace copy-out command: %q", command)
+		}
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+	}
+
+	return workspaceCopyOutManifestFixture{
+		localRoot:         localRoot,
+		resolvedLocalRoot: resolvedLocalRoot,
+		host:              host,
+		sandboxID:         sandboxID,
 	}
 }
 

--- a/internal/cli/workspace_test.go
+++ b/internal/cli/workspace_test.go
@@ -1395,6 +1395,58 @@ func TestWorkspaceCopyOutRejectsLocalModeDivergenceFromCopyInManifestBase(t *tes
 	assertWorkspaceCopyOutRecoveryPayload(t, fixture.sandboxID)
 }
 
+func TestWorkspaceCopyOutRejectsStagedDivergenceFromCopyInManifestBase(t *testing.T) {
+	fixture := setupWorkspaceCopyOutManifestBase(t, func(localRoot string) {
+		if err := os.WriteFile(filepath.Join(localRoot, "README.md"), []byte("local\nsandbox\n"), 0o644); err != nil {
+			t.Fatalf("write sandbox README: %v", err)
+		}
+	})
+	readmePath := filepath.Join(fixture.localRoot, "README.md")
+	if err := os.WriteFile(readmePath, []byte("staged divergent\n"), 0o644); err != nil {
+		t.Fatalf("write staged divergent README: %v", err)
+	}
+	runGitInDir(t, fixture.localRoot, "add", "README.md")
+	if err := os.WriteFile(readmePath, []byte("local\n"), 0o644); err != nil {
+		t.Fatalf("restore working tree README: %v", err)
+	}
+
+	stdout, _ := makeStdoutCapture(t)
+	stderr, _ := makeStdoutCapture(t)
+	cmd := WorkspaceCopyOutCommand{
+		clientFlags: clientFlags{Host: fixture.host},
+		SandboxID:   fixture.sandboxID,
+	}
+	err := cmd.Run(&runtimeContext{
+		CWD:           t.TempDir(),
+		Loader:        repositoryNotFoundLoader{},
+		Config:        runtimeconfig.Config{},
+		Observability: newTestObservability(t),
+		Stdout:        stdout,
+		Stderr:        stderr,
+	})
+	if err == nil {
+		t.Fatal("expected staged divergence from copy-in manifest to be rejected")
+	}
+	if !strings.Contains(err.Error(), `local workspace path "README.md" changed independently`) {
+		t.Fatalf("expected staged divergence error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "sandbox changes saved to") {
+		t.Fatalf("expected recovery payload path in error, got %v", err)
+	}
+	readme, err := os.ReadFile(readmePath)
+	if err != nil {
+		t.Fatalf("read README: %v", err)
+	}
+	if got, want := string(readme), "local\n"; got != want {
+		t.Fatalf("copy-out should leave local README content unchanged: got %q want %q", got, want)
+	}
+	staged := gitOutputBytes(t, fixture.localRoot, "show", ":README.md")
+	if got, want := string(staged), "staged divergent\n"; got != want {
+		t.Fatalf("copy-out should leave staged README content unchanged: got %q want %q", got, want)
+	}
+	assertWorkspaceCopyOutRecoveryPayload(t, fixture.sandboxID)
+}
+
 func TestWorkspaceCopyOutRejectsLocalDivergence(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	localRoot := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")

--- a/internal/repositorychangeset/changeset.go
+++ b/internal/repositorychangeset/changeset.go
@@ -576,24 +576,37 @@ func patchHasGitlinkChanges(patch []byte) bool {
 }
 
 func pathModeInIndex(repoRoot string, env []string, normalizedPath string) (string, bool, error) {
-	output, err := gitOutput(repoRoot, env, "ls-files", "--stage", "-z", "--", normalizedPath)
+	output, err := gitOutput(repoRoot, env, "ls-files", "--stage", "-z", "--", literalGitPathspec(normalizedPath))
 	if err != nil {
 		return "", false, err
 	}
-	return gitIndexMode(output)
+	return gitIndexMode(output, normalizedPath)
 }
 
-func gitIndexMode(output []byte) (string, bool, error) {
+func gitIndexMode(output []byte, normalizedPath string) (string, bool, error) {
 	output = bytes.TrimRight(output, "\x00")
 	if len(bytes.TrimSpace(output)) == 0 {
 		return "", false, nil
 	}
-	entry, _, _ := bytes.Cut(output, []byte{0})
-	fields := strings.Fields(string(entry))
-	if len(fields) < 3 || strings.TrimSpace(fields[0]) == "" {
-		return "", false, fmt.Errorf("parse git index entry %q", string(entry))
+	for _, entry := range bytes.Split(output, []byte{0}) {
+		metadata, rawPath, ok := bytes.Cut(entry, []byte{'\t'})
+		if !ok {
+			return "", false, fmt.Errorf("parse git index entry %q", string(entry))
+		}
+		if normalizePath(string(rawPath)) != normalizedPath {
+			continue
+		}
+		fields := strings.Fields(string(metadata))
+		if len(fields) < 3 || strings.TrimSpace(fields[0]) == "" {
+			return "", false, fmt.Errorf("parse git index entry %q", string(entry))
+		}
+		return fields[0], true, nil
 	}
-	return fields[0], true, nil
+	return "", false, nil
+}
+
+func literalGitPathspec(normalizedPath string) string {
+	return ":(literal)" + normalizedPath
 }
 
 func buildDigest(baseCommitSHA, treeDigest string, patch []byte, files []File) string {

--- a/internal/repositorychangeset/changeset.go
+++ b/internal/repositorychangeset/changeset.go
@@ -21,6 +21,7 @@ const FormatGitDiffV1 = "git-diff-v1"
 type File struct {
 	Path    string
 	SHA256  string
+	Mode    string
 	Deleted bool
 }
 
@@ -171,7 +172,7 @@ func (c *Changeset) DigestPathsFromBase(repoRoot string, paths []string) ([]File
 		seen[normalizedPath] = struct{}{}
 
 		file := File{Path: normalizedPath}
-		exists, err := pathExistsInIndex(repoRoot, env, normalizedPath)
+		mode, exists, err := pathModeInIndex(repoRoot, env, normalizedPath)
 		if err != nil {
 			return nil, fmt.Errorf("check repository changeset path %q in temporary git index: %w", normalizedPath, err)
 		}
@@ -180,6 +181,7 @@ func (c *Changeset) DigestPathsFromBase(repoRoot string, paths []string) ([]File
 			files = append(files, file)
 			continue
 		}
+		file.Mode = mode
 
 		blob, err := gitOutput(repoRoot, env, "show", ":"+normalizedPath)
 		if err != nil {
@@ -475,6 +477,15 @@ func changedFiles(repoRoot string, env []string, baseCommitSHA string) ([]File, 
 			continue
 		}
 
+		mode, exists, err := pathModeInIndex(repoRoot, env, normalizedPath)
+		if err != nil {
+			return nil, fmt.Errorf("inspect repository changeset file %q in temporary git index: %w", normalizedPath, err)
+		}
+		if !exists {
+			return nil, fmt.Errorf("repository changeset file %q is missing from temporary git index", normalizedPath)
+		}
+		file.Mode = mode
+
 		blob, err := gitOutput(repoRoot, env, "show", ":"+normalizedPath)
 		if err != nil {
 			return nil, fmt.Errorf("read repository changeset file %q from temporary git index: %w", normalizedPath, err)
@@ -564,12 +575,25 @@ func patchHasGitlinkChanges(patch []byte) bool {
 	return false
 }
 
-func pathExistsInIndex(repoRoot string, env []string, normalizedPath string) (bool, error) {
-	output, err := gitOutput(repoRoot, env, "ls-files", "--stage", "--", normalizedPath)
+func pathModeInIndex(repoRoot string, env []string, normalizedPath string) (string, bool, error) {
+	output, err := gitOutput(repoRoot, env, "ls-files", "--stage", "-z", "--", normalizedPath)
 	if err != nil {
-		return false, err
+		return "", false, err
 	}
-	return strings.TrimSpace(string(output)) != "", nil
+	return gitIndexMode(output)
+}
+
+func gitIndexMode(output []byte) (string, bool, error) {
+	output = bytes.TrimRight(output, "\x00")
+	if len(bytes.TrimSpace(output)) == 0 {
+		return "", false, nil
+	}
+	entry, _, _ := bytes.Cut(output, []byte{0})
+	fields := strings.Fields(string(entry))
+	if len(fields) < 3 || strings.TrimSpace(fields[0]) == "" {
+		return "", false, fmt.Errorf("parse git index entry %q", string(entry))
+	}
+	return fields[0], true, nil
 }
 
 func buildDigest(baseCommitSHA, treeDigest string, patch []byte, files []File) string {

--- a/internal/repositorychangeset/changeset_test.go
+++ b/internal/repositorychangeset/changeset_test.go
@@ -18,6 +18,9 @@ func TestBuildFromWorkingTree(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(repoDir, "new.txt"), []byte("new file\n"), 0o755); err != nil {
 		t.Fatalf("write new file: %v", err)
 	}
+	if err := os.Chmod(filepath.Join(repoDir, "new.txt"), 0o755); err != nil {
+		t.Fatalf("chmod new file: %v", err)
+	}
 
 	checkout := &repositorycheckout.Checkout{
 		RemoteURL:      "https://github.com/buildkite/cleanroom.git",
@@ -55,6 +58,16 @@ func TestBuildFromWorkingTree(t *testing.T) {
 	}
 	if digest, deleted, ok := changeset.ChangedFileDigest("new.txt"); !ok || deleted || digest == "" {
 		t.Fatalf("expected new.txt digest, got digest=%q deleted=%v ok=%v", digest, deleted, ok)
+	}
+	modes := make(map[string]string, len(changeset.Files))
+	for _, file := range changeset.Files {
+		modes[file.Path] = file.Mode
+	}
+	if got, want := modes["README.md"], "100644"; got != want {
+		t.Fatalf("unexpected README.md mode: got %q want %q", got, want)
+	}
+	if got, want := modes["new.txt"], "100755"; got != want {
+		t.Fatalf("unexpected new.txt mode: got %q want %q", got, want)
 	}
 
 	again, err := BuildFromWorkingTree(repoDir, checkout)
@@ -297,6 +310,9 @@ func TestDigestPathsFromBaseUsesPatchedContents(t *testing.T) {
 	}
 	if digests[0].Deleted {
 		t.Fatal("expected README.md to be present after applying changeset")
+	}
+	if got, want := digests[0].Mode, "100644"; got != want {
+		t.Fatalf("unexpected README.md mode: got %q want %q", got, want)
 	}
 }
 

--- a/internal/repositorychangeset/changeset_test.go
+++ b/internal/repositorychangeset/changeset_test.go
@@ -21,6 +21,15 @@ func TestBuildFromWorkingTree(t *testing.T) {
 	if err := os.Chmod(filepath.Join(repoDir, "new.txt"), 0o755); err != nil {
 		t.Fatalf("chmod new file: %v", err)
 	}
+	if err := os.WriteFile(filepath.Join(repoDir, "A.txt"), []byte("decoy\n"), 0o755); err != nil {
+		t.Fatalf("write decoy file: %v", err)
+	}
+	if err := os.Chmod(filepath.Join(repoDir, "A.txt"), 0o755); err != nil {
+		t.Fatalf("chmod decoy file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, "[AB].txt"), []byte("literal brackets\n"), 0o644); err != nil {
+		t.Fatalf("write bracket file: %v", err)
+	}
 
 	checkout := &repositorycheckout.Checkout{
 		RemoteURL:      "https://github.com/buildkite/cleanroom.git",
@@ -68,6 +77,12 @@ func TestBuildFromWorkingTree(t *testing.T) {
 	}
 	if got, want := modes["new.txt"], "100755"; got != want {
 		t.Fatalf("unexpected new.txt mode: got %q want %q", got, want)
+	}
+	if got, want := modes["A.txt"], "100755"; got != want {
+		t.Fatalf("unexpected A.txt mode: got %q want %q", got, want)
+	}
+	if got, want := modes["[AB].txt"], "100644"; got != want {
+		t.Fatalf("unexpected [AB].txt mode: got %q want %q", got, want)
 	}
 
 	again, err := BuildFromWorkingTree(repoDir, checkout)


### PR DESCRIPTION
## Summary

Teach Git-backed `workspace copy-out` to use the recorded copy-in manifest as the local conflict and apply base when a sandbox is bound to a local checkout.

This lets copy-out safely write sandbox changes back after a prior `workspace copy-in` or top-level `--copy-in` copied dirty edits or local-only commits into the sandbox. Unbound copy-out remains strict: the local checkout still has to match the sandbox baseline before writing.

## Details

- compare bound copy-out target paths against the recorded copy-in manifest, falling back to the sandbox baseline for paths that were not copied in
- derive the local apply patch from the current local copy-in state to the sandbox worktree state instead of applying the sandbox-baseline patch directly
- keep dry-run output aligned with the actual local writes for bound copy-out
- update `docs/plans/workspace-sync.md` to mark PR #275 landed and record this slice as the manifest-base follow-up

## Validation

- `mise exec -- go test ./internal/cli -run 'TestWorkspaceCopyOut(AppliesFromCopyInManifestBase|DryRunUsesCopyInManifestBase|RejectsLocalDivergenceFromCopyInManifestBase|AppliesSandboxGitPatch|RejectsBaselineMismatch|DryRunUsesBoundLocalRoot)'`
- `mise exec -- go test ./internal/cli`
- `mise exec -- go test ./...`
- `git diff --check`
