### PR TITLE
fix: Clean up terminated sandbox storage

### DIFF
--- a/docs/plans/system-storage-prune.md
+++ b/docs/plans/system-storage-prune.md
@@ -165,6 +165,14 @@ This is what lets us clean up abandoned directories from older versions without 
    - After sandbox termination, opportunistically remove runtime dirs that belong to the terminated sandbox.
    - Consider a bounded background prune for system-managed caches only after the manual command has telemetry and tests.
 
+   First hook: sandbox termination and failed-create cleanup should call into the
+   shared `storagegc` inventory, lifecycle planning, and execution path for the
+   terminated sandbox runtime directory only. The service should enqueue this
+   work onto a bounded, serial background worker and skip recursive byte sizing
+   before deletion. This keeps automatic cleanup lifecycle-scoped, prevents a
+   burst of terminations from starting many filesystem removals at once, and
+   avoids introducing a daemon-wide background prune.
+
 ## Tests
 
 - Inventory reports byte totals for every known category.

--- a/internal/controlservice/runtime.go
+++ b/internal/controlservice/runtime.go
@@ -48,14 +48,17 @@ type serviceTimeouts struct {
 	attachPollInterval           time.Duration
 	interactiveSessionTokenTTL   time.Duration
 	bootstrapCleanupTimeout      time.Duration
+	storageCleanupTimeout        time.Duration
 }
 
 type serviceRuntime struct {
-	clock                   serviceClock
-	ids                     serviceIDSource
-	retention               *retentionPolicy
-	timeouts                *serviceTimeouts
-	defaultDownloadMaxBytes int64
+	clock                                    serviceClock
+	ids                                      serviceIDSource
+	retention                                *retentionPolicy
+	timeouts                                 *serviceTimeouts
+	defaultDownloadMaxBytes                  int64
+	terminatedSandboxStorageCleanup          func(string)
+	terminatedSandboxStorageCleanupQueueSize int
 }
 
 var defaultRetentionPolicy = retentionPolicy{
@@ -73,9 +76,12 @@ var defaultServiceTimeouts = serviceTimeouts{
 	attachPollInterval:           10 * time.Millisecond,
 	interactiveSessionTokenTTL:   30 * time.Second,
 	bootstrapCleanupTimeout:      10 * time.Second,
+	storageCleanupTimeout:        10 * time.Second,
 }
 
 const defaultDownloadMaxBytes int64 = 10 * 1024 * 1024
+
+const defaultTerminatedSandboxStorageCleanupQueueSize = 128
 
 func (s *Service) clock() serviceClock {
 	if s.runtime.clock != nil {
@@ -110,4 +116,11 @@ func (s *Service) downloadMaxBytesDefault() int64 {
 		return s.runtime.defaultDownloadMaxBytes
 	}
 	return defaultDownloadMaxBytes
+}
+
+func (s *Service) terminatedSandboxStorageCleanupQueueSize() int {
+	if s.runtime.terminatedSandboxStorageCleanupQueueSize > 0 {
+		return s.runtime.terminatedSandboxStorageCleanupQueueSize
+	}
+	return defaultTerminatedSandboxStorageCleanupQueueSize
 }

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -28,6 +28,7 @@ import (
 	"github.com/buildkite/cleanroom/internal/repositorystore"
 	"github.com/buildkite/cleanroom/internal/runtimeconfig"
 	"github.com/buildkite/cleanroom/internal/snapshotstore"
+	"github.com/buildkite/cleanroom/internal/storagegc"
 	"github.com/charmbracelet/log"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -49,6 +50,7 @@ type Service struct {
 	RepositoryStore repositorystore.RepositoryStore
 	runtime         serviceRuntime
 	interactive     interactiveSessionBroker
+	storageCleanup  terminatedSandboxStorageCleanupScheduler
 	// Snapshot lifecycle still lives on Service because it coordinates backend
 	// adapters, sandbox state, and metadata persistence in one operation chain.
 	// If this grows again, extract a dedicated snapshot manager rather than
@@ -62,6 +64,13 @@ type Service struct {
 	executions        map[string]*executionState
 	snapshotOps       map[string]int
 	snapshotDeletions map[string]struct{}
+}
+
+type terminatedSandboxStorageCleanupScheduler struct {
+	once   sync.Once
+	queue  chan string
+	mu     sync.Mutex
+	queued map[string]struct{}
 }
 
 type sandboxState struct {
@@ -1867,6 +1876,7 @@ func (s *Service) TerminateSandbox(ctx context.Context, req *cleanroomv1.Termina
 			"backend", backendName,
 		)
 	}
+	s.scheduleTerminatedSandboxStorageCleanup(sandboxID)
 	return resp, nil
 }
 
@@ -2269,7 +2279,122 @@ func (s *Service) terminateCreatedSandbox(ctx context.Context, adapter backend.A
 	}
 	s.mu.Unlock()
 
+	s.scheduleTerminatedSandboxStorageCleanup(sandboxID)
 	return err
+}
+
+func (s *Service) scheduleTerminatedSandboxStorageCleanup(sandboxID string) {
+	sandboxID = strings.TrimSpace(sandboxID)
+	if sandboxID == "" {
+		return
+	}
+	scheduler := s.startTerminatedSandboxStorageCleanupWorker()
+
+	scheduler.mu.Lock()
+	if _, ok := scheduler.queued[sandboxID]; ok {
+		scheduler.mu.Unlock()
+		return
+	}
+	scheduler.queued[sandboxID] = struct{}{}
+	queue := scheduler.queue
+	scheduler.mu.Unlock()
+
+	select {
+	case queue <- sandboxID:
+	default:
+		scheduler.mu.Lock()
+		delete(scheduler.queued, sandboxID)
+		scheduler.mu.Unlock()
+		if s.Logger != nil {
+			s.Logger.Warn("terminated sandbox storage cleanup queue full", "sandbox_id", sandboxID, "queue_size", cap(queue))
+		}
+	}
+}
+
+func (s *Service) startTerminatedSandboxStorageCleanupWorker() *terminatedSandboxStorageCleanupScheduler {
+	scheduler := &s.storageCleanup
+	scheduler.once.Do(func() {
+		scheduler.queue = make(chan string, s.terminatedSandboxStorageCleanupQueueSize())
+		scheduler.queued = make(map[string]struct{})
+		// The worker lives for the service lifetime; cleanup is best-effort and
+		// does not have a separate shutdown path.
+		go s.runTerminatedSandboxStorageCleanupWorker()
+	})
+	return scheduler
+}
+
+func (s *Service) runTerminatedSandboxStorageCleanupWorker() {
+	scheduler := &s.storageCleanup
+	for sandboxID := range scheduler.queue {
+		s.runTerminatedSandboxStorageCleanup(sandboxID)
+
+		scheduler.mu.Lock()
+		delete(scheduler.queued, sandboxID)
+		scheduler.mu.Unlock()
+	}
+}
+
+func (s *Service) runTerminatedSandboxStorageCleanup(sandboxID string) {
+	cleanup := s.runtime.terminatedSandboxStorageCleanup
+	if cleanup == nil {
+		cleanup = s.cleanupTerminatedSandboxStorage
+	}
+	cleanup(sandboxID)
+}
+
+func (s *Service) cleanupTerminatedSandboxStorage(sandboxID string) {
+	sandboxID = strings.TrimSpace(sandboxID)
+	if sandboxID == "" {
+		return
+	}
+	cleanupCtx, cancel := context.WithTimeout(context.Background(), s.timeouts().storageCleanupTimeout)
+	defer cancel()
+
+	report, err := storagegc.Inventory(cleanupCtx, storagegc.InventoryOptions{
+		Config:            s.Config,
+		ActiveSandboxIDs:  s.currentSandboxIDs(),
+		SandboxRuntimeIDs: []string{sandboxID},
+		SandboxStateKnown: true,
+		Now:               s.clock().Now(),
+		Kinds:             []string{storagegc.KindSandboxRuntime},
+		SkipSize:          true,
+	})
+	if err != nil {
+		if s.Logger != nil {
+			s.Logger.Warn("inventory terminated sandbox storage for cleanup failed", "sandbox_id", sandboxID, "error", err)
+		}
+		return
+	}
+	plan := storagegc.PlanLifecyclePrune(report, storagegc.LifecycleOptions{TerminatedSandboxIDs: []string{sandboxID}})
+	if len(plan.Actions) == 0 {
+		return
+	}
+	result, err := storagegc.ExecutePrune(cleanupCtx, report, plan, storagegc.ExecuteOptions{})
+	if err != nil {
+		if s.Logger != nil {
+			s.Logger.Warn("cleanup terminated sandbox storage failed", "sandbox_id", sandboxID, "error", err)
+		}
+		return
+	}
+	if s.Logger != nil && result.DeletedEntries > 0 {
+		s.Logger.Info("cleaned up terminated sandbox storage",
+			"sandbox_id", sandboxID,
+			"deleted_entries", result.DeletedEntries,
+			"reclaimed_bytes", result.ReclaimedBytes,
+		)
+	}
+}
+
+func (s *Service) currentSandboxIDs() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	ids := make([]string, 0, len(s.sandboxes))
+	for sandboxID := range s.sandboxes {
+		if strings.TrimSpace(sandboxID) != "" {
+			ids = append(ids, sandboxID)
+		}
+	}
+	return ids
 }
 
 func (s *Service) ensureSandboxCreateStillProvisioning(sandboxID string) error {

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -4276,6 +4276,47 @@ func TestTerminateCreatedSandboxKeepsStateWhenTerminateFails(t *testing.T) {
 	}
 }
 
+func TestTerminateCreatedSandboxCleansRuntimeDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	stateHome := filepath.Join(tmpDir, "state-home")
+	t.Setenv("XDG_STATE_HOME", stateHome)
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(tmpDir, "cache-home"))
+
+	adapter := &stubAdapter{}
+	svc := newTestService(adapter)
+	sb := &sandboxState{
+		ID:        "sandbox_test",
+		Status:    cleanroomv1.SandboxStatus_SANDBOX_STATUS_PROVISIONING,
+		CreatedAt: time.Unix(1_700_000_000, 0).UTC(),
+		UpdatedAt: time.Unix(1_700_000_000, 0).UTC(),
+		events:    newEventFeed[*cleanroomv1.SandboxEvent](0),
+		Done:      make(chan struct{}),
+	}
+	svc.mu.Lock()
+	svc.ensureMapsLocked()
+	svc.sandboxes[sb.ID] = sb
+	svc.mu.Unlock()
+
+	runtimeDir := filepath.Join(stateHome, "cleanroom", "sandboxes", sb.ID)
+	if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+		t.Fatalf("create runtime dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(runtimeDir, "rootfs.ext4"), []byte("runtime"), 0o644); err != nil {
+		t.Fatalf("write runtime file: %v", err)
+	}
+
+	if err := svc.terminateCreatedSandbox(context.Background(), adapter, sb.ID); err != nil {
+		t.Fatalf("terminateCreatedSandbox returned error: %v", err)
+	}
+	waitForPathRemoved(t, runtimeDir)
+	svc.mu.RLock()
+	_, ok := svc.sandboxes[sb.ID]
+	svc.mu.RUnlock()
+	if ok {
+		t.Fatal("expected sandbox state to be dropped after successful cleanup")
+	}
+}
+
 func TestCreateExecutionWrapsRepositoryBootstrapInService(t *testing.T) {
 	adapter := &stubAdapter{}
 	mirrors := &stubRepositoryMirrorStore{}
@@ -7097,6 +7138,181 @@ func TestTerminateSandboxPropagatesRequestContextToBackend(t *testing.T) {
 
 	if !errors.Is(terminateCtxErr, context.Canceled) {
 		t.Fatalf("expected backend terminate context to be canceled, got %v", terminateCtxErr)
+	}
+}
+
+func TestTerminateSandboxSchedulesStorageCleanupAsync(t *testing.T) {
+	adapter := &stubAdapter{}
+	svc := newTestService(adapter)
+
+	started := make(chan string, 1)
+	release := make(chan struct{})
+	defer close(release)
+	svc.runtime.terminatedSandboxStorageCleanup = func(sandboxID string) {
+		started <- sandboxID
+		<-release
+	}
+
+	createResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createResp.GetSandbox().GetSandboxId()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := svc.TerminateSandbox(context.Background(), &cleanroomv1.TerminateSandboxRequest{SandboxId: sandboxID})
+		done <- err
+	}()
+
+	select {
+	case got := <-started:
+		if got != sandboxID {
+			t.Fatalf("unexpected cleanup sandbox id: got %q want %q", got, sandboxID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for storage cleanup to start")
+	}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("TerminateSandbox returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("TerminateSandbox blocked behind storage cleanup")
+	}
+}
+
+func TestTerminateSandboxStorageCleanupWorkerRunsSeriallyAndDedupes(t *testing.T) {
+	adapter := &stubAdapter{}
+	svc := newTestService(adapter)
+	svc.runtime.terminatedSandboxStorageCleanupQueueSize = 4
+
+	started := make(chan string, 3)
+	finished := make(chan string, 3)
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	closeRelease := func() {
+		releaseOnce.Do(func() {
+			close(release)
+		})
+	}
+	defer closeRelease()
+
+	svc.runtime.terminatedSandboxStorageCleanup = func(sandboxID string) {
+		started <- sandboxID
+		<-release
+		finished <- sandboxID
+	}
+
+	svc.scheduleTerminatedSandboxStorageCleanup("sandbox-1")
+	svc.scheduleTerminatedSandboxStorageCleanup("sandbox-1")
+	svc.scheduleTerminatedSandboxStorageCleanup("sandbox-2")
+
+	select {
+	case got := <-started:
+		if got != "sandbox-1" {
+			t.Fatalf("unexpected first cleanup: got %q want sandbox-1", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first storage cleanup")
+	}
+	select {
+	case got := <-started:
+		t.Fatalf("storage cleanup worker started %q while first cleanup was still running", got)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	closeRelease()
+
+	select {
+	case got := <-finished:
+		if got != "sandbox-1" {
+			t.Fatalf("unexpected first completed cleanup: got %q want sandbox-1", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first storage cleanup to finish")
+	}
+	select {
+	case got := <-started:
+		if got != "sandbox-2" {
+			t.Fatalf("unexpected second cleanup: got %q want sandbox-2", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for second storage cleanup")
+	}
+	select {
+	case got := <-finished:
+		if got != "sandbox-2" {
+			t.Fatalf("unexpected second completed cleanup: got %q want sandbox-2", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for second storage cleanup to finish")
+	}
+	select {
+	case got := <-started:
+		t.Fatalf("duplicate cleanup was not deduped, started %q", got)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestTerminateSandboxCleansUpRuntimeDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	stateHome := filepath.Join(tmpDir, "state-home")
+	t.Setenv("XDG_STATE_HOME", stateHome)
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(tmpDir, "cache-home"))
+
+	adapter := &stubAdapter{}
+	svc := newTestService(adapter)
+
+	createResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createResp.GetSandbox().GetSandboxId()
+	runtimeDir := filepath.Join(stateHome, "cleanroom", "sandboxes", sandboxID)
+	if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+		t.Fatalf("create runtime dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(runtimeDir, "rootfs.ext4"), []byte("runtime"), 0o644); err != nil {
+		t.Fatalf("write runtime file: %v", err)
+	}
+
+	if _, err := svc.TerminateSandbox(context.Background(), &cleanroomv1.TerminateSandboxRequest{SandboxId: sandboxID}); err != nil {
+		t.Fatalf("TerminateSandbox returned error: %v", err)
+	}
+	waitForPathRemoved(t, runtimeDir)
+
+	getResp, err := svc.GetSandbox(context.Background(), &cleanroomv1.GetSandboxRequest{SandboxId: sandboxID})
+	if err != nil {
+		t.Fatalf("GetSandbox returned error: %v", err)
+	}
+	if got, want := getResp.GetSandbox().GetStatus(), cleanroomv1.SandboxStatus_SANDBOX_STATUS_STOPPED; got != want {
+		t.Fatalf("unexpected sandbox status: got %v want %v", got, want)
+	}
+}
+
+func waitForPathRemoved(t *testing.T, path string) {
+	t.Helper()
+
+	deadline := time.After(2 * time.Second)
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		_, err := os.Stat(path)
+		if errors.Is(err, os.ErrNotExist) {
+			return
+		}
+		if err != nil {
+			t.Fatalf("stat %s: %v", path, err)
+		}
+
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for %s to be removed", path)
+		case <-ticker.C:
+		}
 	}
 }
 

--- a/internal/storagegc/storagegc.go
+++ b/internal/storagegc/storagegc.go
@@ -47,14 +47,24 @@ type ImageManager interface {
 }
 
 type InventoryOptions struct {
-	Config            runtimeconfig.Config
-	ActiveSandboxIDs  []string
+	Config           runtimeconfig.Config
+	ActiveSandboxIDs []string
+	// SandboxRuntimeIDs limits sandbox-runtime scanning to specific sandbox ids.
+	// Empty means scan every sandbox runtime directory.
+	SandboxRuntimeIDs []string
 	SandboxStateKnown bool
 	SnapshotStore     SnapshotLister
 	CacheStore        CacheStore
 	ImageManager      ImageManager
 	Now               time.Time
 	ExecutionMaxAge   time.Duration
+	// SkipSize avoids recursive filesystem sizing. It is intended for
+	// lifecycle cleanup paths where deletion is targeted and byte accounting is
+	// not user-facing.
+	SkipSize bool
+	// Kinds limits emitted entries. Empty means all categories; selected kinds
+	// may still read adjacent metadata when needed for protection checks.
+	Kinds []string
 }
 
 type Entry struct {
@@ -94,6 +104,12 @@ type PruneOptions struct {
 	All       bool
 	OlderThan time.Duration
 	Now       time.Time
+}
+
+// LifecycleOptions selects cleanup actions that are safe because the service
+// just completed the owning lifecycle transition.
+type LifecycleOptions struct {
+	TerminatedSandboxIDs []string
 }
 
 type Action struct {
@@ -153,100 +169,118 @@ func Inventory(ctx context.Context, opts InventoryOptions) (Report, error) {
 		Totals:            map[string]CategoryTotal{},
 	}
 
-	snapshotStore := opts.SnapshotStore
-	if snapshotStore == nil {
-		store, err := snapshotstore.New(snapshotstore.Options{})
-		if err != nil {
-			return Report{}, err
-		}
-		snapshotStore = store
-	}
-	cacheStore := opts.CacheStore
-	if cacheStore == nil {
-		store, err := cachestore.New(cachestore.Options{})
-		if err != nil {
-			return Report{}, err
-		}
-		cacheStore = store
-	}
-	imageManager := opts.ImageManager
-	if imageManager == nil {
-		manager, err := imagemgr.New(imagemgr.Options{})
-		if err != nil {
-			return Report{}, err
-		}
-		imageManager = manager
-	}
-
+	includedKinds := stringSet(opts.Kinds)
 	referencedSnapshotPaths := map[string][]string{}
-	snapshotRecords, err := snapshotStore.List(ctx)
-	if err != nil {
-		return Report{}, fmt.Errorf("list snapshot metadata: %w", err)
-	}
-	for _, record := range snapshotRecords {
-		entry := entryFromSnapshotRecord(record)
-		if entry.Path != "" {
-			if size, err := pathSize(entry.Path); err == nil {
-				entry.SizeBytes = size
-			} else {
-				return Report{}, fmt.Errorf("size snapshot %q: %w", record.SnapshotID, err)
+	if inventoryIncludes(includedKinds, KindSnapshot) || inventoryIncludes(includedKinds, KindStageCache) || inventoryIncludes(includedKinds, KindOrphanSnapshot) {
+		snapshotStore := opts.SnapshotStore
+		if snapshotStore == nil {
+			store, err := snapshotstore.New(snapshotstore.Options{})
+			if err != nil {
+				return Report{}, err
 			}
-			addPathReference(referencedSnapshotPaths, entry.Path, "snapshot metadata "+record.SnapshotID)
+			snapshotStore = store
 		}
-		report.Entries = append(report.Entries, entry)
-	}
-
-	cacheRecords, err := cacheStore.List(ctx)
-	if err != nil {
-		return Report{}, fmt.Errorf("list cache metadata: %w", err)
-	}
-	for _, record := range cacheRecords {
-		entry := entryFromCacheRecord(record)
-		if entry.Path != "" {
-			if size, err := pathSize(entry.Path); err == nil {
-				entry.SizeBytes = size
-			} else {
-				return Report{}, fmt.Errorf("size cache %q/%q: %w", record.Stage, record.CacheKey, err)
-			}
-			if protections := referencedSnapshotPaths[cleanPath(entry.Path)]; len(protections) > 0 {
-				entry.ProtectedBy = append(entry.ProtectedBy, protections...)
-				entry.Reason = "stage-cache metadata; also referenced by explicit snapshot metadata"
-			}
-			addPathReference(referencedSnapshotPaths, entry.Path, "stage-cache metadata "+record.Stage+"/"+record.CacheKey)
+		snapshotRecords, err := snapshotStore.List(ctx)
+		if err != nil {
+			return Report{}, fmt.Errorf("list snapshot metadata: %w", err)
 		}
-		report.Entries = append(report.Entries, entry)
+		for _, record := range snapshotRecords {
+			entry := entryFromSnapshotRecord(record)
+			if entry.Path != "" {
+				if size, err := maybePathSize(ctx, entry.Path, opts.SkipSize); err == nil {
+					entry.SizeBytes = size
+				} else {
+					return Report{}, fmt.Errorf("size snapshot %q: %w", record.SnapshotID, err)
+				}
+				addPathReference(referencedSnapshotPaths, entry.Path, "snapshot metadata "+record.SnapshotID)
+			}
+			if inventoryIncludes(includedKinds, KindSnapshot) {
+				report.Entries = append(report.Entries, entry)
+			}
+		}
 	}
 
-	activeSandboxes := stringSet(opts.ActiveSandboxIDs)
-	sandboxEntries, err := scanSandboxRuntimeDirs(filepath.Join(stateBase, "sandboxes"), activeSandboxes, opts.SandboxStateKnown)
-	if err != nil {
-		return Report{}, err
+	if inventoryIncludes(includedKinds, KindStageCache) || inventoryIncludes(includedKinds, KindOrphanSnapshot) {
+		cacheStore := opts.CacheStore
+		if cacheStore == nil {
+			store, err := cachestore.New(cachestore.Options{})
+			if err != nil {
+				return Report{}, err
+			}
+			cacheStore = store
+		}
+		cacheRecords, err := cacheStore.List(ctx)
+		if err != nil {
+			return Report{}, fmt.Errorf("list cache metadata: %w", err)
+		}
+		for _, record := range cacheRecords {
+			entry := entryFromCacheRecord(record)
+			if entry.Path != "" {
+				if size, err := maybePathSize(ctx, entry.Path, opts.SkipSize); err == nil {
+					entry.SizeBytes = size
+				} else {
+					return Report{}, fmt.Errorf("size cache %q/%q: %w", record.Stage, record.CacheKey, err)
+				}
+				if protections := referencedSnapshotPaths[cleanPath(entry.Path)]; len(protections) > 0 {
+					entry.ProtectedBy = append(entry.ProtectedBy, protections...)
+					entry.Reason = "stage-cache metadata; also referenced by explicit snapshot metadata"
+				}
+				addPathReference(referencedSnapshotPaths, entry.Path, "stage-cache metadata "+record.Stage+"/"+record.CacheKey)
+			}
+			if inventoryIncludes(includedKinds, KindStageCache) {
+				report.Entries = append(report.Entries, entry)
+			}
+		}
 	}
-	report.Entries = append(report.Entries, sandboxEntries...)
 
-	orphanSnapshots, err := scanOrphanSnapshotDirs(snapshotRoots, referencedSnapshotPaths)
-	if err != nil {
-		return Report{}, err
+	if inventoryIncludes(includedKinds, KindSandboxRuntime) {
+		activeSandboxes := stringSet(opts.ActiveSandboxIDs)
+		sandboxEntries, err := scanSandboxRuntimeDirs(ctx, filepath.Join(stateBase, "sandboxes"), activeSandboxes, stringSet(opts.SandboxRuntimeIDs), opts.SandboxStateKnown, opts.SkipSize)
+		if err != nil {
+			return Report{}, err
+		}
+		report.Entries = append(report.Entries, sandboxEntries...)
 	}
-	report.Entries = append(report.Entries, orphanSnapshots...)
 
-	runtimeRootFS, err := scanRuntimeRootFS(cacheBase)
-	if err != nil {
-		return Report{}, err
+	if inventoryIncludes(includedKinds, KindOrphanSnapshot) {
+		orphanSnapshots, err := scanOrphanSnapshotDirs(ctx, snapshotRoots, referencedSnapshotPaths, opts.SkipSize)
+		if err != nil {
+			return Report{}, err
+		}
+		report.Entries = append(report.Entries, orphanSnapshots...)
 	}
-	report.Entries = append(report.Entries, runtimeRootFS...)
 
-	imageEntries, err := scanImageEntries(ctx, imageManager)
-	if err != nil {
-		return Report{}, err
+	if inventoryIncludes(includedKinds, KindRuntimeRootFS) {
+		runtimeRootFS, err := scanRuntimeRootFS(cacheBase, opts.SkipSize)
+		if err != nil {
+			return Report{}, err
+		}
+		report.Entries = append(report.Entries, runtimeRootFS...)
 	}
-	report.Entries = append(report.Entries, imageEntries...)
 
-	executionEntries, err := scanExecutionArtifacts(filepath.Join(stateBase, "executions"), now, executionMaxAge)
-	if err != nil {
-		return Report{}, err
+	if inventoryIncludes(includedKinds, KindImageCache) {
+		imageManager := opts.ImageManager
+		if imageManager == nil {
+			manager, err := imagemgr.New(imagemgr.Options{})
+			if err != nil {
+				return Report{}, err
+			}
+			imageManager = manager
+		}
+		imageEntries, err := scanImageEntries(ctx, imageManager, opts.SkipSize)
+		if err != nil {
+			return Report{}, err
+		}
+		report.Entries = append(report.Entries, imageEntries...)
 	}
-	report.Entries = append(report.Entries, executionEntries...)
+
+	if inventoryIncludes(includedKinds, KindExecutionArtifact) {
+		executionEntries, err := scanExecutionArtifacts(ctx, filepath.Join(stateBase, "executions"), now, executionMaxAge, opts.SkipSize)
+		if err != nil {
+			return Report{}, err
+		}
+		report.Entries = append(report.Entries, executionEntries...)
+	}
 
 	for _, root := range []struct {
 		kind string
@@ -256,7 +290,10 @@ func Inventory(ctx context.Context, opts InventoryOptions) (Report, error) {
 		{kind: KindContentCache, path: filepath.Join(cacheBase, "content-cache")},
 		{kind: KindChangesetStore, path: filepath.Join(stateBase, "changesets")},
 	} {
-		entry, ok, err := protectedRootEntry(root.kind, root.path)
+		if !inventoryIncludes(includedKinds, root.kind) {
+			continue
+		}
+		entry, ok, err := protectedRootEntry(ctx, root.kind, root.path, opts.SkipSize)
 		if err != nil {
 			return Report{}, err
 		}
@@ -334,6 +371,47 @@ func PlanPrune(report Report, opts PruneOptions) Plan {
 	return plan
 }
 
+// PlanLifecyclePrune plans targeted cleanup for resources whose owner just
+// completed a lifecycle transition. It is intentionally narrower than
+// PlanPrune and does not apply age or --all policy.
+func PlanLifecyclePrune(report Report, opts LifecycleOptions) Plan {
+	if !report.SandboxStateKnown {
+		return Plan{}
+	}
+	terminatedSandboxes := stringSet(opts.TerminatedSandboxIDs)
+	if len(terminatedSandboxes) == 0 {
+		return Plan{}
+	}
+
+	plan := Plan{}
+	for _, entry := range report.Entries {
+		if entry.Kind != KindSandboxRuntime {
+			continue
+		}
+		if _, ok := terminatedSandboxes[entry.ID]; !ok {
+			continue
+		}
+		actionPath, ok := deletionPathForReport(report, entry)
+		if !ok || actionPath == "" {
+			continue
+		}
+		action := Action{
+			Kind:      entry.Kind,
+			ID:        entry.ID,
+			Path:      actionPath,
+			SizeBytes: entry.SizeBytes,
+			Reason:    "terminated sandbox lifecycle cleanup",
+			Entry:     entry,
+		}
+		plan.Actions = append(plan.Actions, action)
+		plan.ReclaimableBytes += action.SizeBytes
+	}
+	sort.Slice(plan.Actions, func(i, j int) bool {
+		return plan.Actions[i].ID < plan.Actions[j].ID
+	})
+	return plan
+}
+
 func stageCacheStorageExclusive(entry Entry) bool {
 	for _, protection := range entry.ProtectedBy {
 		if strings.HasPrefix(protection, "snapshot metadata ") {
@@ -351,24 +429,33 @@ func ExecutePrune(ctx context.Context, report Report, plan Plan, opts ExecuteOpt
 	roots = uniqueCleanPaths(roots)
 
 	cacheStore := opts.CacheStore
-	if cacheStore == nil {
-		store, err := cachestore.New(cachestore.Options{})
-		if err != nil {
-			return Result{}, err
-		}
-		cacheStore = store
-	}
 	imageManager := opts.ImageManager
-	if imageManager == nil {
-		manager, err := imagemgr.New(imagemgr.Options{})
-		if err != nil {
-			return Result{}, err
+	for _, action := range plan.Actions {
+		switch action.Kind {
+		case KindStageCache:
+			if cacheStore == nil {
+				store, err := cachestore.New(cachestore.Options{})
+				if err != nil {
+					return Result{}, err
+				}
+				cacheStore = store
+			}
+		case KindImageCache:
+			if imageManager == nil {
+				manager, err := imagemgr.New(imagemgr.Options{})
+				if err != nil {
+					return Result{}, err
+				}
+				imageManager = manager
+			}
 		}
-		imageManager = manager
 	}
 
 	result := Result{}
 	for _, action := range plan.Actions {
+		if err := ctx.Err(); err != nil {
+			return result, err
+		}
 		if err := executeAction(ctx, report, action, roots, cacheStore, imageManager); err != nil {
 			return result, err
 		}
@@ -444,7 +531,7 @@ func entryFromCacheRecord(record cachestore.Record) Entry {
 	}
 }
 
-func scanSandboxRuntimeDirs(baseDir string, activeIDs map[string]struct{}, stateKnown bool) ([]Entry, error) {
+func scanSandboxRuntimeDirs(ctx context.Context, baseDir string, activeIDs, selectedIDs map[string]struct{}, stateKnown, skipSize bool) ([]Entry, error) {
 	dirEntries, err := os.ReadDir(baseDir)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -457,8 +544,13 @@ func scanSandboxRuntimeDirs(baseDir string, activeIDs map[string]struct{}, state
 		if !dirEntry.IsDir() {
 			continue
 		}
+		if len(selectedIDs) > 0 {
+			if _, ok := selectedIDs[dirEntry.Name()]; !ok {
+				continue
+			}
+		}
 		path := filepath.Join(baseDir, dirEntry.Name())
-		size, err := pathSize(path)
+		size, err := maybePathSize(ctx, path, skipSize)
 		if err != nil {
 			return nil, fmt.Errorf("size sandbox runtime %q: %w", path, err)
 		}
@@ -489,7 +581,7 @@ func scanSandboxRuntimeDirs(baseDir string, activeIDs map[string]struct{}, state
 	return out, nil
 }
 
-func scanOrphanSnapshotDirs(snapshotRoots []string, refs map[string][]string) ([]Entry, error) {
+func scanOrphanSnapshotDirs(ctx context.Context, snapshotRoots []string, refs map[string][]string, skipSize bool) ([]Entry, error) {
 	var out []Entry
 	seen := map[string]struct{}{}
 	for _, root := range snapshotRoots {
@@ -518,7 +610,7 @@ func scanOrphanSnapshotDirs(snapshotRoots []string, refs map[string][]string) ([
 				if _, ok := refs[cleanPath(dirPath)]; ok {
 					continue
 				}
-				size, err := pathSize(dirPath)
+				size, err := maybePathSize(ctx, dirPath, skipSize)
 				if err != nil {
 					return nil, fmt.Errorf("size orphan snapshot %q: %w", dirPath, err)
 				}
@@ -544,7 +636,7 @@ func scanOrphanSnapshotDirs(snapshotRoots []string, refs map[string][]string) ([
 	return out, nil
 }
 
-func scanRuntimeRootFS(cacheBase string) ([]Entry, error) {
+func scanRuntimeRootFS(cacheBase string, skipSize bool) ([]Entry, error) {
 	var out []Entry
 	for _, backendName := range []string{"firecracker", "darwin-vz"} {
 		dir := filepath.Join(cacheBase, backendName, "runtime-rootfs")
@@ -564,12 +656,16 @@ func scanRuntimeRootFS(cacheBase string) ([]Entry, error) {
 			if err != nil {
 				return nil, fmt.Errorf("inspect runtime rootfs cache %q: %w", path, err)
 			}
+			size := int64(0)
+			if !skipSize {
+				size = allocatedFileSize(info)
+			}
 			out = append(out, Entry{
 				Kind:        KindRuntimeRootFS,
 				ID:          strings.TrimSuffix(dirEntry.Name(), filepath.Ext(dirEntry.Name())),
 				Backend:     backendName,
 				Path:        path,
-				SizeBytes:   allocatedFileSize(info),
+				SizeBytes:   size,
 				Reclaimable: false,
 				Reason:      "runtime rootfs cache preserved unless selected",
 				ProtectedBy: []string{"runtime rootfs cache"},
@@ -581,7 +677,7 @@ func scanRuntimeRootFS(cacheBase string) ([]Entry, error) {
 	return out, nil
 }
 
-func scanImageEntries(ctx context.Context, imageManager ImageManager) ([]Entry, error) {
+func scanImageEntries(ctx context.Context, imageManager ImageManager, skipSize bool) ([]Entry, error) {
 	records, err := imageManager.List(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("list image cache metadata: %w", err)
@@ -589,8 +685,8 @@ func scanImageEntries(ctx context.Context, imageManager ImageManager) ([]Entry, 
 	out := make([]Entry, 0, len(records))
 	for _, record := range records {
 		var size int64
-		if path := strings.TrimSpace(record.RootFSPath); path != "" {
-			if actualSize, err := pathSize(path); err == nil && actualSize > 0 {
+		if path := strings.TrimSpace(record.RootFSPath); path != "" && !skipSize {
+			if actualSize, err := pathSize(ctx, path); err == nil && actualSize > 0 {
 				size = actualSize
 			} else if err == nil {
 				size = 0
@@ -613,7 +709,7 @@ func scanImageEntries(ctx context.Context, imageManager ImageManager) ([]Entry, 
 	return out, nil
 }
 
-func scanExecutionArtifacts(baseDir string, now time.Time, maxAge time.Duration) ([]Entry, error) {
+func scanExecutionArtifacts(ctx context.Context, baseDir string, now time.Time, maxAge time.Duration, skipSize bool) ([]Entry, error) {
 	dirEntries, err := os.ReadDir(baseDir)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -627,7 +723,7 @@ func scanExecutionArtifacts(baseDir string, now time.Time, maxAge time.Duration)
 			continue
 		}
 		path := filepath.Join(baseDir, dirEntry.Name())
-		size, err := pathSize(path)
+		size, err := maybePathSize(ctx, path, skipSize)
 		if err != nil {
 			return nil, fmt.Errorf("size execution artifacts %q: %w", path, err)
 		}
@@ -656,8 +752,8 @@ func scanExecutionArtifacts(baseDir string, now time.Time, maxAge time.Duration)
 	return out, nil
 }
 
-func protectedRootEntry(kind, path string) (Entry, bool, error) {
-	size, err := pathSize(path)
+func protectedRootEntry(ctx context.Context, kind, path string, skipSize bool) (Entry, bool, error) {
+	size, err := maybePathSize(ctx, path, skipSize)
 	if err != nil {
 		return Entry{}, false, fmt.Errorf("size %s root %q: %w", kind, path, err)
 	}
@@ -773,6 +869,14 @@ func removeOwnedPath(path string, roots []string) error {
 	return nil
 }
 
+func inventoryIncludes(includedKinds map[string]struct{}, kind string) bool {
+	if len(includedKinds) == 0 {
+		return true
+	}
+	_, ok := includedKinds[kind]
+	return ok
+}
+
 func pathWithinAnyRoot(path string, roots []string) bool {
 	path = cleanPath(path)
 	for _, root := range roots {
@@ -791,7 +895,17 @@ func pathWithinAnyRoot(path string, roots []string) bool {
 	return false
 }
 
-func pathSize(path string) (int64, error) {
+func maybePathSize(ctx context.Context, path string, skip bool) (int64, error) {
+	if skip {
+		return 0, nil
+	}
+	return pathSize(ctx, path)
+}
+
+func pathSize(ctx context.Context, path string) (int64, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
 	path = strings.TrimSpace(path)
 	if path == "" {
 		return 0, nil
@@ -809,6 +923,9 @@ func pathSize(path string) (int64, error) {
 
 	var total int64
 	err = filepath.WalkDir(path, func(path string, entry os.DirEntry, err error) error {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
 		if err != nil {
 			return err
 		}

--- a/internal/storagegc/storagegc_test.go
+++ b/internal/storagegc/storagegc_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -142,7 +143,7 @@ func TestInventoryProtectsReferencesAndFindsOrphans(t *testing.T) {
 	assertEntry(t, report, KindRuntimeRootFS, "abc", false, "runtime rootfs cache preserved unless selected")
 	assertEntry(t, report, KindImageCache, "sha256:digest", false, "image cache metadata")
 
-	expectedOrphanSize, err := pathSize(filepath.Dir(orphanSnapshotRootFS))
+	expectedOrphanSize, err := pathSize(context.Background(), filepath.Dir(orphanSnapshotRootFS))
 	if err != nil {
 		t.Fatalf("size orphan snapshot fixture: %v", err)
 	}
@@ -203,6 +204,117 @@ func TestInventoryProtectsSandboxDirsWhenDaemonStateIsUnknown(t *testing.T) {
 		t.Fatalf("Inventory returned error: %v", err)
 	}
 	assertEntry(t, report, KindSandboxRuntime, "maybe-active", false, "daemon sandbox state unavailable")
+}
+
+func TestInventoryCanLimitKinds(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", filepath.Join(tmpDir, "state-home"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(tmpDir, "cache-home"))
+
+	stateBase := filepath.Join(tmpDir, "state-home", "cleanroom")
+	writeFile(t, filepath.Join(stateBase, "sandboxes", "sandbox-1", "disk.img"), "active")
+	writeFile(t, filepath.Join(stateBase, "sandboxes", "sandbox-2", "disk.img"), "active")
+
+	report, err := Inventory(context.Background(), InventoryOptions{
+		ActiveSandboxIDs:  []string{"sandbox-1"},
+		SandboxRuntimeIDs: []string{"sandbox-1"},
+		SandboxStateKnown: true,
+		SnapshotStore:     stubSnapshotStore{err: errors.New("snapshot store should not be used")},
+		CacheStore:        &stubCacheStore{err: errors.New("cache store should not be used")},
+		ImageManager:      &stubImageManager{err: errors.New("image manager should not be used")},
+		Kinds:             []string{KindSandboxRuntime},
+	})
+	if err != nil {
+		t.Fatalf("Inventory returned error: %v", err)
+	}
+	if got, want := len(report.Entries), 1; got != want {
+		t.Fatalf("unexpected entry count: got %d want %d", got, want)
+	}
+	assertEntry(t, report, KindSandboxRuntime, "sandbox-1", false, "known daemon sandbox")
+}
+
+func TestInventoryCanSkipSandboxRuntimeSizes(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", filepath.Join(tmpDir, "state-home"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(tmpDir, "cache-home"))
+
+	stateBase := filepath.Join(tmpDir, "state-home", "cleanroom")
+	writeFile(t, filepath.Join(stateBase, "sandboxes", "sandbox-1", "disk.img"), "active")
+
+	measured, err := Inventory(context.Background(), InventoryOptions{
+		SandboxRuntimeIDs: []string{"sandbox-1"},
+		SandboxStateKnown: true,
+		Kinds:             []string{KindSandboxRuntime},
+	})
+	if err != nil {
+		t.Fatalf("measured Inventory returned error: %v", err)
+	}
+	measuredEntry := findEntry(t, measured, KindSandboxRuntime, "sandbox-1")
+	if measuredEntry.SizeBytes <= 0 {
+		t.Fatalf("expected measured sandbox runtime size to be positive, got %d", measuredEntry.SizeBytes)
+	}
+
+	skipped, err := Inventory(context.Background(), InventoryOptions{
+		SandboxRuntimeIDs: []string{"sandbox-1"},
+		SandboxStateKnown: true,
+		Kinds:             []string{KindSandboxRuntime},
+		SkipSize:          true,
+	})
+	if err != nil {
+		t.Fatalf("skip-size Inventory returned error: %v", err)
+	}
+	skippedEntry := findEntry(t, skipped, KindSandboxRuntime, "sandbox-1")
+	if skippedEntry.SizeBytes != 0 {
+		t.Fatalf("expected skipped sandbox runtime size to be zero, got %d", skippedEntry.SizeBytes)
+	}
+	if got := skipped.Totals[KindSandboxRuntime].TotalBytes; got != 0 {
+		t.Fatalf("expected skipped sandbox runtime total bytes to be zero, got %d", got)
+	}
+}
+
+func TestInventoryStageCacheFilterKeepsSnapshotProtections(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", filepath.Join(tmpDir, "state-home"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(tmpDir, "cache-home"))
+
+	stateBase := filepath.Join(tmpDir, "state-home", "cleanroom")
+	stageRootFS := filepath.Join(stateBase, "snapshots", "firecracker", "stage-shared", "rootfs.ext4")
+	writeFile(t, stageRootFS, "cache")
+	now := time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)
+
+	report, err := Inventory(context.Background(), InventoryOptions{
+		SandboxStateKnown: true,
+		SnapshotStore: stubSnapshotStore{records: []snapshotstore.Record{
+			{
+				SnapshotID: "snap-explicit",
+				Backend:    "firecracker",
+				StorageRef: stageRootFS,
+				CreatedAt:  now,
+			},
+		}},
+		CacheStore: &stubCacheStore{records: []cachestore.Record{
+			{
+				Stage:      "dependencies",
+				CacheKey:   "cache-shared",
+				Backend:    "firecracker",
+				StorageRef: stageRootFS,
+				CreatedAt:  now,
+				LastUsedAt: now,
+			},
+		}},
+		ImageManager: &stubImageManager{err: errors.New("image manager should not be used")},
+		Kinds:        []string{KindStageCache},
+	})
+	if err != nil {
+		t.Fatalf("Inventory returned error: %v", err)
+	}
+	if got, want := len(report.Entries), 1; got != want {
+		t.Fatalf("unexpected entry count: got %d want %d", got, want)
+	}
+	entry := findEntry(t, report, KindStageCache, "dependencies/cache-shared")
+	if !slices.Contains(entry.ProtectedBy, "snapshot metadata snap-explicit") {
+		t.Fatalf("expected snapshot protection, got %#v", entry.ProtectedBy)
+	}
 }
 
 func TestPlanPruneIncludesAllAndOlderThanCaches(t *testing.T) {
@@ -268,6 +380,49 @@ func TestPlanPruneIncludesAllAndOlderThanCaches(t *testing.T) {
 	assertPlanAction(t, allPlan, KindRuntimeRootFS, "old-runtime")
 	assertPlanAction(t, allPlan, KindStageCache, "dependencies/cache")
 	assertPlanAction(t, allPlan, KindImageCache, "sha256:image")
+}
+
+func TestPlanLifecyclePruneDeletesTerminatedSandboxRuntime(t *testing.T) {
+	tmpDir := t.TempDir()
+	runtimeDir := filepath.Join(tmpDir, "state", "cleanroom", "sandboxes", "sandbox-1")
+	writeFile(t, filepath.Join(runtimeDir, "rootfs.ext4"), "sandbox")
+	cacheDir := filepath.Join(tmpDir, "cache", "cleanroom")
+
+	report := Report{
+		StateBaseDir:      filepath.Join(tmpDir, "state", "cleanroom"),
+		CacheBaseDir:      cacheDir,
+		SandboxStateKnown: true,
+		Entries: []Entry{
+			{
+				Kind:        KindSandboxRuntime,
+				ID:          "sandbox-1",
+				Path:        runtimeDir,
+				SizeBytes:   7,
+				Reason:      "known daemon sandbox",
+				ProtectedBy: []string{"daemon state"},
+			},
+		},
+	}
+	plan := PlanLifecyclePrune(report, LifecycleOptions{TerminatedSandboxIDs: []string{"sandbox-1"}})
+	if got, want := len(plan.Actions), 1; got != want {
+		t.Fatalf("unexpected lifecycle action count: got %d want %d", got, want)
+	}
+	if got, want := plan.Actions[0].Reason, "terminated sandbox lifecycle cleanup"; got != want {
+		t.Fatalf("unexpected action reason: got %q want %q", got, want)
+	}
+	result, err := ExecutePrune(context.Background(), report, plan, ExecuteOptions{
+		CacheStore:   &stubCacheStore{err: errors.New("cache store should not be used")},
+		ImageManager: &stubImageManager{err: errors.New("image manager should not be used")},
+	})
+	if err != nil {
+		t.Fatalf("ExecutePrune returned error: %v", err)
+	}
+	if got, want := result.DeletedEntries, 1; got != want {
+		t.Fatalf("unexpected deleted entries: got %d want %d", got, want)
+	}
+	if _, err := os.Stat(runtimeDir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected runtime dir to be removed, stat err: %v", err)
+	}
 }
 
 func TestPlanPruneSkipsStageCacheOutsideManagedSnapshotStorage(t *testing.T) {


### PR DESCRIPTION
## Summary

- add a lifecycle-only storage prune planner for resources whose owning transition just completed
- clean up terminated sandbox runtime directories after successful sandbox termination and failed-create teardown
- enqueue lifecycle cleanup on a bounded serial worker so foreground RPCs do not wait and cleanup cannot fan out into many concurrent filesystem removals
- skip recursive byte sizing for targeted lifecycle cleanup while keeping full sizing for `system df` and manual prune output
- allow storage inventory callers to limit emitted categories and target specific sandbox runtime ids
- document the first automatic cleanup hook in the storage prune plan

## Verification

- mise exec -- go test ./internal/storagegc ./internal/controlservice -run 'Test(InventoryCanSkipSandboxRuntimeSizes|InventoryCanLimitKinds|PlanLifecyclePruneDeletesTerminatedSandboxRuntime|TerminateSandboxSchedulesStorageCleanupAsync|TerminateSandboxStorageCleanupWorkerRunsSeriallyAndDedupes|TerminateSandboxCleansUpRuntimeDirectory|TerminateCreatedSandboxCleansRuntimeDirectory)$' -count=1
- mise exec -- go test -race ./internal/controlservice -run 'Test(TerminateSandboxSchedulesStorageCleanupAsync|TerminateSandboxStorageCleanupWorkerRunsSeriallyAndDedupes)$' -count=1
- mise exec -- go test ./...
- mise run build:go
- git diff --check
- mise exec -- go vet ./internal/storagegc

Note: `mise exec -- go vet ./internal/storagegc ./internal/controlservice` still hits pre-existing protobuf lock-copy warnings in `internal/controlservice/service_test.go`.
