### PR TITLE
feat: Plan dependency block volume caches

### DIFF
--- a/docs/plans/dependency-service-volume-caches.md
+++ b/docs/plans/dependency-service-volume-caches.md
@@ -700,8 +700,7 @@ Current runtime behavior after phase 1:
 
 Remaining work:
 
-- build per-block dependency and service planning instead of only aggregate
-  bootstrap planning
+- wire dependency block-volume planning into the sandbox creation runtime path
 - materialize isolated declared-input projections before running cacheable
   blocks
 - implement the guest overlay write-capture runner
@@ -717,6 +716,33 @@ Remaining work:
 Steps 8 and 9 remain the main backend slices. Steps 10 and 11 should now build
 on the phase 1 request fields and metadata, with stub-adapter tests before the
 Firecracker implementation.
+
+### Phase 2 PR Status
+
+The second implementation PR starts the runtime-control layer without changing
+the sandbox execution path yet. Existing dependency bootstraps still run through
+the aggregate dependency stage cache.
+
+Completed in phase 2:
+
+- dependency block-volume planner computes one cache key per ordered dependency
+  block from backend, runtime key, reuse namespace, policy hash, command digest,
+  env digest, input manifest digest, normalized output declarations, and prior
+  dependency output keys
+- dependency block-volume cache lookup marks per-block hits and misses using the
+  cache metadata fields introduced in phase 1
+- runtime fallback decision requires backend support for cache output volumes and
+  overlay write capture before the future block-volume path can be selected
+- tests cover ordered keying, prior-block invalidation, partial cache hits, and
+  fallback when backend capabilities are missing
+
+Remaining phase 2 work:
+
+- make dependency sandbox creation consume the block-volume plan
+- prepare and attach output volumes before VM launch
+- run missed dependency blocks from isolated input projections
+- restore hit output records before later dependency blocks run
+- publish output records after successful missed blocks
 
 ## Tests
 

--- a/internal/controlservice/dependency_volume_plan.go
+++ b/internal/controlservice/dependency_volume_plan.go
@@ -174,7 +174,7 @@ func (s *Service) lookupDependencyBlockVolumeCaches(ctx context.Context, backend
 	}
 	store, err := s.cacheStoreOrErr()
 	if err != nil {
-		return plan, err
+		return plan, nil
 	}
 
 	out := dependencyBlockVolumePlan{

--- a/internal/controlservice/dependency_volume_plan.go
+++ b/internal/controlservice/dependency_volume_plan.go
@@ -1,0 +1,270 @@
+package controlservice
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/cachekey"
+	"github.com/buildkite/cleanroom/internal/cachestore"
+	"github.com/buildkite/cleanroom/internal/observability"
+	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/buildkite/cleanroom/internal/repositorybundle"
+	"github.com/buildkite/cleanroom/internal/repositorychangeset"
+	"github.com/buildkite/cleanroom/internal/repositorycheckout"
+)
+
+const (
+	dependencyVolumeStageName           = "dependency-volume"
+	dependencyVolumeProducerVersion     = "cleanroom/dependency-volume-v1"
+	dependencyVolumeOutputLayoutVersion = "aggregate-v1"
+)
+
+type dependencyBlockVolumePlan struct {
+	ReuseNamespace string
+	Blocks         []dependencyBlockVolumeBlockPlan
+}
+
+type dependencyBlockVolumeBlockPlan struct {
+	BlockName                       string
+	Command                         []string
+	Env                             map[string]string
+	Inputs                          []string
+	Outputs                         policy.StageBlockOutputs
+	CacheKey                        string
+	CommandDigest                   string
+	EnvDigest                       string
+	InputManifestDigest             string
+	NormalizedOutputsDigest         string
+	PriorDependencyOutputKeysDigest string
+	OutputVolumeLayoutVersion       string
+	ProducerVersion                 string
+	CacheHit                        bool
+	LookupReason                    string
+	CacheRecord                     cachestore.Record
+}
+
+type dependencyBlockVolumeRuntimeDecision struct {
+	Enabled        bool
+	FallbackReason string
+}
+
+func dependencyBlockVolumeRuntimeDecisionForAdapter(adapter backend.Adapter) dependencyBlockVolumeRuntimeDecision {
+	if adapter == nil {
+		return dependencyBlockVolumeRuntimeDecision{FallbackReason: "backend adapter unavailable"}
+	}
+	caps := backend.CapabilitiesForAdapter(adapter)
+	for _, required := range []string{
+		backend.CapabilitySandboxCacheOutputVolumes,
+		backend.CapabilitySandboxOverlayWriteCapture,
+	} {
+		if !caps[required] {
+			return dependencyBlockVolumeRuntimeDecision{FallbackReason: "backend missing capability " + required}
+		}
+	}
+	return dependencyBlockVolumeRuntimeDecision{Enabled: true}
+}
+
+func (s *Service) finalizeDependencyBlockVolumePlan(
+	ctx context.Context,
+	compiled *policy.CompiledPolicy,
+	repository *repositorycheckout.Checkout,
+	changeset *repositorychangeset.Changeset,
+	commitBundle *repositorybundle.Bundle,
+	backendName string,
+	runtimeBaseKey string,
+) (dependencyBlockVolumePlan, bool, error) {
+	if compiled == nil || repository == nil || len(compiled.Dependencies.Blocks) == 0 || strings.TrimSpace(runtimeBaseKey) == "" {
+		return dependencyBlockVolumePlan{}, false, nil
+	}
+
+	normalizedRepository := normalizeRepositoryCheckoutForComparison(repository)
+	reuseNamespace := cachekey.ReuseNamespace("", normalizedRepository.RemoteURL)
+	plan := dependencyBlockVolumePlan{ReuseNamespace: reuseNamespace}
+	priorOutputKeys := make([]string, 0, len(compiled.Dependencies.Blocks))
+
+	for _, block := range compiled.Dependencies.Blocks {
+		blockPlan, err := s.finalizeDependencyBlockVolumeBlockPlan(ctx, compiled, repository, changeset, commitBundle, backendName, runtimeBaseKey, reuseNamespace, block, priorOutputKeys)
+		if err != nil {
+			return dependencyBlockVolumePlan{}, false, err
+		}
+		plan.Blocks = append(plan.Blocks, blockPlan)
+		priorOutputKeys = append(priorOutputKeys, blockPlan.CacheKey)
+	}
+
+	return plan, true, nil
+}
+
+func (s *Service) finalizeDependencyBlockVolumeBlockPlan(
+	ctx context.Context,
+	compiled *policy.CompiledPolicy,
+	repository *repositorycheckout.Checkout,
+	changeset *repositorychangeset.Changeset,
+	commitBundle *repositorybundle.Bundle,
+	backendName string,
+	runtimeBaseKey string,
+	reuseNamespace string,
+	block policy.StageBlock,
+	priorOutputKeys []string,
+) (dependencyBlockVolumeBlockPlan, error) {
+	inputDigest, err := s.stageKeyFilesDigest(ctx, repository, changeset, commitBundle, block.Inputs.Files, dependencyVolumeStageName+" "+block.Name)
+	if err != nil {
+		return dependencyBlockVolumeBlockPlan{}, err
+	}
+	commandDigest, err := digestCanonicalJSON(block.Command)
+	if err != nil {
+		return dependencyBlockVolumeBlockPlan{}, fmt.Errorf("digest dependency block %q command: %w", block.Name, err)
+	}
+	envDigest, err := digestCanonicalJSON(sortedEnvEntries(block.Env))
+	if err != nil {
+		return dependencyBlockVolumeBlockPlan{}, fmt.Errorf("digest dependency block %q env: %w", block.Name, err)
+	}
+	outputsDigest, err := digestCanonicalJSON(block.Outputs)
+	if err != nil {
+		return dependencyBlockVolumeBlockPlan{}, fmt.Errorf("digest dependency block %q outputs: %w", block.Name, err)
+	}
+	priorDigest, err := digestCanonicalJSON(append([]string{}, priorOutputKeys...))
+	if err != nil {
+		return dependencyBlockVolumeBlockPlan{}, fmt.Errorf("digest dependency block %q prior output keys: %w", block.Name, err)
+	}
+
+	cacheKey := cachekey.DependencyVolumeKey(cachekey.DependencyVolumeInputs{
+		Backend:                         strings.TrimSpace(backendName),
+		RuntimeKey:                      strings.TrimSpace(runtimeBaseKey),
+		ReuseNamespace:                  strings.TrimSpace(reuseNamespace),
+		CompiledPolicyHash:              strings.TrimSpace(compiled.Hash),
+		BlockName:                       strings.TrimSpace(block.Name),
+		CommandDigest:                   commandDigest,
+		EnvDigest:                       envDigest,
+		InputManifestDigest:             strings.TrimSpace(inputDigest),
+		NormalizedOutputsDigest:         outputsDigest,
+		PriorDependencyOutputKeysDigest: priorDigest,
+		OutputVolumeLayoutVersion:       dependencyVolumeOutputLayoutVersion,
+		ProducerVersion:                 dependencyVolumeProducerVersion,
+	})
+	if strings.TrimSpace(cacheKey) == "" {
+		return dependencyBlockVolumeBlockPlan{}, fmt.Errorf("dependency block %q produced an empty cache key", block.Name)
+	}
+
+	return dependencyBlockVolumeBlockPlan{
+		BlockName:                       block.Name,
+		Command:                         append([]string(nil), block.Command...),
+		Env:                             cloneDependencyBlockEnv(block.Env),
+		Inputs:                          append([]string(nil), block.Inputs.Files...),
+		Outputs:                         cloneStageBlockOutputs(block.Outputs),
+		CacheKey:                        cacheKey,
+		CommandDigest:                   commandDigest,
+		EnvDigest:                       envDigest,
+		InputManifestDigest:             strings.TrimSpace(inputDigest),
+		NormalizedOutputsDigest:         outputsDigest,
+		PriorDependencyOutputKeysDigest: priorDigest,
+		OutputVolumeLayoutVersion:       dependencyVolumeOutputLayoutVersion,
+		ProducerVersion:                 dependencyVolumeProducerVersion,
+	}, nil
+}
+
+func (s *Service) lookupDependencyBlockVolumeCaches(ctx context.Context, backendName string, compiled *policy.CompiledPolicy, plan dependencyBlockVolumePlan) (dependencyBlockVolumePlan, error) {
+	if len(plan.Blocks) == 0 {
+		return plan, nil
+	}
+	store, err := s.cacheStoreOrErr()
+	if err != nil {
+		return plan, err
+	}
+
+	out := dependencyBlockVolumePlan{
+		ReuseNamespace: plan.ReuseNamespace,
+		Blocks:         make([]dependencyBlockVolumeBlockPlan, len(plan.Blocks)),
+	}
+	copy(out.Blocks, plan.Blocks)
+	for i := range out.Blocks {
+		block := &out.Blocks[i]
+		record, ok, err := store.GetReady(ctx, dependencyVolumeStageName, block.CacheKey)
+		if err != nil {
+			return out, err
+		}
+		if !ok {
+			block.LookupReason = observability.CacheLookupReasonRecordNotFound
+			continue
+		}
+		if reason := dependencyBlockVolumeRecordMissReason(record, backendName, compiled, *block); reason != "" {
+			block.LookupReason = reason
+			continue
+		}
+		block.CacheHit = true
+		block.LookupReason = ""
+		block.CacheRecord = record
+	}
+	return out, nil
+}
+
+func dependencyBlockVolumeRecordMissReason(record cachestore.Record, backendName string, compiled *policy.CompiledPolicy, block dependencyBlockVolumeBlockPlan) string {
+	if strings.TrimSpace(record.Backend) != strings.TrimSpace(backendName) {
+		return observability.CacheLookupReasonBackendMismatch
+	}
+	if compiled == nil || strings.TrimSpace(record.PolicyHash) != strings.TrimSpace(compiled.Hash) {
+		return observability.CacheLookupReasonPolicyHashMismatch
+	}
+	if strings.TrimSpace(record.InputManifestDigest) != strings.TrimSpace(block.InputManifestDigest) ||
+		strings.TrimSpace(record.CommandDigest) != strings.TrimSpace(block.CommandDigest) ||
+		strings.TrimSpace(record.EnvDigest) != strings.TrimSpace(block.EnvDigest) ||
+		strings.TrimSpace(record.NormalizedOutputsDigest) != strings.TrimSpace(block.NormalizedOutputsDigest) ||
+		strings.TrimSpace(record.ProducerVersion) != strings.TrimSpace(block.ProducerVersion) ||
+		len(record.OutputRecords) == 0 {
+		return observability.CacheLookupReasonRecordNotFound
+	}
+	return ""
+}
+
+type envEntry struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+func sortedEnvEntries(env map[string]string) []envEntry {
+	if len(env) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(env))
+	for key := range env {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	entries := make([]envEntry, 0, len(keys))
+	for _, key := range keys {
+		entries = append(entries, envEntry{Name: key, Value: env[key]})
+	}
+	return entries
+}
+
+func cloneStageBlockOutputs(outputs policy.StageBlockOutputs) policy.StageBlockOutputs {
+	return policy.StageBlockOutputs{
+		Dirs:  append([]string(nil), outputs.Dirs...),
+		Files: append([]string(nil), outputs.Files...),
+	}
+}
+
+func cloneDependencyBlockEnv(env map[string]string) map[string]string {
+	if len(env) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(env))
+	for key, value := range env {
+		out[key] = value
+	}
+	return out
+}
+
+func digestCanonicalJSON(value any) (string, error) {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(payload)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}

--- a/internal/controlservice/dependency_volume_plan_test.go
+++ b/internal/controlservice/dependency_volume_plan_test.go
@@ -165,6 +165,31 @@ func TestLookupDependencyBlockVolumeCachesReportsPartialHit(t *testing.T) {
 	}
 }
 
+func TestLookupDependencyBlockVolumeCachesTreatsMissingStoreAsMiss(t *testing.T) {
+	svc := newTestService(&stubAdapter{})
+	svc.CacheStore = nil
+	plan := dependencyBlockVolumePlan{
+		ReuseNamespace: "https://github.com/buildkite/cleanroom.git",
+		Blocks: []dependencyBlockVolumeBlockPlan{
+			{
+				BlockName: "go-modules",
+				CacheKey:  "dependency-volume:v1:test",
+			},
+		},
+	}
+
+	got, err := svc.lookupDependencyBlockVolumeCaches(context.Background(), "firecracker", &policy.CompiledPolicy{Hash: "sha256:test"}, plan)
+	if err != nil {
+		t.Fatalf("lookupDependencyBlockVolumeCaches returned error: %v", err)
+	}
+	if got.Blocks[0].CacheHit {
+		t.Fatal("did not expect cache hit when cache store is unavailable")
+	}
+	if got.Blocks[0].LookupReason != "" {
+		t.Fatalf("expected missing cache store to leave lookup reason unchanged, got %q", got.Blocks[0].LookupReason)
+	}
+}
+
 func TestDependencyBlockVolumeRuntimeDecisionRequiresOutputVolumesAndOverlay(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/controlservice/dependency_volume_plan_test.go
+++ b/internal/controlservice/dependency_volume_plan_test.go
@@ -1,0 +1,271 @@
+package controlservice
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/cachestore"
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+	"github.com/buildkite/cleanroom/internal/observability"
+	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/buildkite/cleanroom/internal/repositorycheckout"
+)
+
+func TestFinalizeDependencyBlockVolumePlanBuildsOrderedKeys(t *testing.T) {
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"mise.toml": "go = \"1.26.2\"\n",
+		"go.mod":    "module example.com/test\n\ngo 1.26.2\n",
+		"go.sum":    "example.com/test v0.0.0 h1:abc123\n",
+	})
+	svc := newTestService(&stubAdapter{})
+	svc.RepositoryStore = mirrors
+
+	compiled, err := policy.FromProto(testRepositoryTwoDependencyBlocksPolicy())
+	if err != nil {
+		t.Fatalf("FromProto returned error: %v", err)
+	}
+	repository := repositorycheckout.FromProto(repositoryCheckout)
+
+	plan, ok, err := svc.finalizeDependencyBlockVolumePlan(context.Background(), compiled, repository, nil, nil, "firecracker", "runtime-base:test")
+	if err != nil {
+		t.Fatalf("finalizeDependencyBlockVolumePlan returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected dependency block volume plan")
+	}
+	if got, want := plan.ReuseNamespace, "https://github.com/buildkite/cleanroom.git"; got != want {
+		t.Fatalf("unexpected reuse namespace: got %q want %q", got, want)
+	}
+	if got, want := len(plan.Blocks), 2; got != want {
+		t.Fatalf("unexpected dependency block count: got %d want %d", got, want)
+	}
+
+	first := plan.Blocks[0]
+	second := plan.Blocks[1]
+	if first.CacheKey == "" || second.CacheKey == "" {
+		t.Fatalf("expected non-empty block cache keys: first=%q second=%q", first.CacheKey, second.CacheKey)
+	}
+	if first.CacheKey == second.CacheKey {
+		t.Fatalf("expected distinct dependency block cache keys, got %q", first.CacheKey)
+	}
+	emptyPriorDigest, err := digestCanonicalJSON([]string{})
+	if err != nil {
+		t.Fatalf("digest empty prior keys: %v", err)
+	}
+	if got := first.PriorDependencyOutputKeysDigest; got != emptyPriorDigest {
+		t.Fatalf("unexpected first prior output digest: got %q want %q", got, emptyPriorDigest)
+	}
+	firstKeyDigest, err := digestCanonicalJSON([]string{first.CacheKey})
+	if err != nil {
+		t.Fatalf("digest first cache key: %v", err)
+	}
+	if got := second.PriorDependencyOutputKeysDigest; got != firstKeyDigest {
+		t.Fatalf("unexpected second prior output digest: got %q want %q", got, firstKeyDigest)
+	}
+	replannedSecond, err := svc.finalizeDependencyBlockVolumeBlockPlan(
+		context.Background(),
+		compiled,
+		repository,
+		nil,
+		nil,
+		"firecracker",
+		"runtime-base:test",
+		plan.ReuseNamespace,
+		compiled.Dependencies.Blocks[1],
+		[]string{"dependency-volume:v1:different"},
+	)
+	if err != nil {
+		t.Fatalf("finalize second block with alternate prior key returned error: %v", err)
+	}
+	if got, want := replannedSecond.CacheKey, second.CacheKey; got == want {
+		t.Fatalf("expected second block key to change when prior dependency output key changes, got %q", got)
+	}
+	for _, block := range plan.Blocks {
+		for name, value := range map[string]string{
+			"command": block.CommandDigest,
+			"env":     block.EnvDigest,
+			"inputs":  block.InputManifestDigest,
+			"outputs": block.NormalizedOutputsDigest,
+		} {
+			if !strings.HasPrefix(value, "sha256:") {
+				t.Fatalf("expected %s digest for block %q, got %q", name, block.BlockName, value)
+			}
+		}
+	}
+
+	mutatedPolicy := testRepositoryTwoDependencyBlocksPolicy()
+	mutatedPolicy.Dependencies.Blocks[0].Env["MISE_DATA_DIR"] = "/root/.local/share/mise-other"
+	mutatedCompiled, err := policy.FromProto(mutatedPolicy)
+	if err != nil {
+		t.Fatalf("FromProto mutated policy returned error: %v", err)
+	}
+	mutatedPlan, ok, err := svc.finalizeDependencyBlockVolumePlan(context.Background(), mutatedCompiled, repository, nil, nil, "firecracker", "runtime-base:test")
+	if err != nil {
+		t.Fatalf("finalizeDependencyBlockVolumePlan mutated returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected mutated dependency block volume plan")
+	}
+	if got, want := mutatedPlan.Blocks[0].CacheKey, first.CacheKey; got == want {
+		t.Fatalf("expected first block key to change after env mutation, got %q", got)
+	}
+}
+
+func TestLookupDependencyBlockVolumeCachesReportsPartialHit(t *testing.T) {
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"mise.toml": "go = \"1.26.2\"\n",
+		"go.mod":    "module example.com/test\n\ngo 1.26.2\n",
+		"go.sum":    "example.com/test v0.0.0 h1:abc123\n",
+	})
+	svc := newTestService(&stubAdapter{})
+	svc.RepositoryStore = mirrors
+
+	compiled, err := policy.FromProto(testRepositoryTwoDependencyBlocksPolicy())
+	if err != nil {
+		t.Fatalf("FromProto returned error: %v", err)
+	}
+	repository := repositorycheckout.FromProto(repositoryCheckout)
+	plan, ok, err := svc.finalizeDependencyBlockVolumePlan(context.Background(), compiled, repository, nil, nil, "firecracker", "runtime-base:test")
+	if err != nil {
+		t.Fatalf("finalizeDependencyBlockVolumePlan returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected dependency block volume plan")
+	}
+
+	first := plan.Blocks[0]
+	cacheStore, ok := svc.CacheStore.(*memoryCacheStore)
+	if !ok {
+		t.Fatalf("expected memory cache store, got %T", svc.CacheStore)
+	}
+	if err := cacheStore.Create(context.Background(), dependencyBlockVolumeTestRecord(compiled, first)); err != nil {
+		t.Fatalf("Create cache record returned error: %v", err)
+	}
+
+	lookedUp, err := svc.lookupDependencyBlockVolumeCaches(context.Background(), "firecracker", compiled, plan)
+	if err != nil {
+		t.Fatalf("lookupDependencyBlockVolumeCaches returned error: %v", err)
+	}
+	if got, want := len(lookedUp.Blocks), 2; got != want {
+		t.Fatalf("unexpected looked up block count: got %d want %d", got, want)
+	}
+	if !lookedUp.Blocks[0].CacheHit {
+		t.Fatalf("expected first block cache hit, reason=%q", lookedUp.Blocks[0].LookupReason)
+	}
+	if lookedUp.Blocks[0].CacheRecord.CacheKey != first.CacheKey {
+		t.Fatalf("unexpected first block record key: got %q want %q", lookedUp.Blocks[0].CacheRecord.CacheKey, first.CacheKey)
+	}
+	if lookedUp.Blocks[1].CacheHit {
+		t.Fatal("did not expect second block cache hit")
+	}
+	if got, want := lookedUp.Blocks[1].LookupReason, observability.CacheLookupReasonRecordNotFound; got != want {
+		t.Fatalf("unexpected second block miss reason: got %q want %q", got, want)
+	}
+}
+
+func TestDependencyBlockVolumeRuntimeDecisionRequiresOutputVolumesAndOverlay(t *testing.T) {
+	tests := []struct {
+		name       string
+		adapter    backend.Adapter
+		wantEnable bool
+		wantReason string
+	}{
+		{
+			name:       "missing output volume capability",
+			adapter:    &stubAdapter{},
+			wantReason: backend.CapabilitySandboxCacheOutputVolumes,
+		},
+		{
+			name: "missing overlay capture capability",
+			adapter: &portDialAdapter{capabilities: map[string]bool{
+				backend.CapabilitySandboxCacheOutputVolumes: true,
+			}},
+			wantReason: backend.CapabilitySandboxOverlayWriteCapture,
+		},
+		{
+			name: "supported",
+			adapter: &portDialAdapter{capabilities: map[string]bool{
+				backend.CapabilitySandboxCacheOutputVolumes:  true,
+				backend.CapabilitySandboxOverlayWriteCapture: true,
+			}},
+			wantEnable: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			decision := dependencyBlockVolumeRuntimeDecisionForAdapter(tc.adapter)
+			if got := decision.Enabled; got != tc.wantEnable {
+				t.Fatalf("unexpected decision enabled: got %v want %v (reason=%q)", got, tc.wantEnable, decision.FallbackReason)
+			}
+			if tc.wantReason != "" && !strings.Contains(decision.FallbackReason, tc.wantReason) {
+				t.Fatalf("expected fallback reason containing %q, got %q", tc.wantReason, decision.FallbackReason)
+			}
+			if tc.wantEnable && decision.FallbackReason != "" {
+				t.Fatalf("expected empty fallback reason for enabled decision, got %q", decision.FallbackReason)
+			}
+		})
+	}
+}
+
+func testRepositoryTwoDependencyBlocksPolicy() *cleanroomv1.Policy {
+	policyProto := testRepositoryPolicy()
+	policyProto.Dependencies = &cleanroomv1.PolicyDependencies{
+		Blocks: []*cleanroomv1.PolicyBlock{
+			{
+				Name:    "toolchains",
+				Command: []string{"mise", "install"},
+				Inputs:  &cleanroomv1.PolicyBlockInputs{Files: []string{"mise.toml"}},
+				Env: map[string]string{
+					"MISE_DATA_DIR": "/root/.local/share/mise",
+				},
+				Outputs: &cleanroomv1.PolicyBlockOutputs{
+					Dirs: []string{"/root/.local/share/mise"},
+				},
+			},
+			{
+				Name:    "go-modules",
+				Command: []string{"mise", "exec", "--", "go", "mod", "download"},
+				Inputs:  &cleanroomv1.PolicyBlockInputs{Files: []string{"go.mod", "go.sum"}},
+				Env: map[string]string{
+					"GOMODCACHE": "/root/go/pkg/mod",
+				},
+				Outputs: &cleanroomv1.PolicyBlockOutputs{
+					Dirs: []string{"/root/go/pkg/mod"},
+				},
+			},
+		},
+	}
+	return policyProto
+}
+
+func dependencyBlockVolumeTestRecord(compiled *policy.CompiledPolicy, block dependencyBlockVolumeBlockPlan) cachestore.Record {
+	return cachestore.Record{
+		CacheKey:                block.CacheKey,
+		Stage:                   dependencyVolumeStageName,
+		State:                   cacheStateReady,
+		BackingSnapshotID:       "dependency-volume-snapshot",
+		Backend:                 "firecracker",
+		PolicyHash:              compiled.Hash,
+		Policy:                  compiled.ToProto(),
+		StorageDriver:           "file",
+		StorageRef:              "/snapshots/" + block.BlockName + ".ext4",
+		InputManifestDigest:     block.InputManifestDigest,
+		CommandDigest:           block.CommandDigest,
+		EnvDigest:               block.EnvDigest,
+		NormalizedOutputsDigest: block.NormalizedOutputsDigest,
+		OutputRecords: []cachestore.OutputRecord{
+			{
+				Kind:          "dir",
+				Path:          block.Outputs.Dirs[0],
+				VolumeSubpath: "dirs/0",
+				StorageDriver: "file",
+				StorageRef:    "/snapshots/" + block.BlockName + ".ext4",
+				SnapshotRef:   "snapshot:" + block.BlockName,
+			},
+		},
+		ProducerVersion: block.ProducerVersion,
+	}
+}


### PR DESCRIPTION
## Summary

Adds the next dependency/service volume-cache slice after #271: dependency block-volume planning in the control service.

This PR computes one cache key per ordered dependency block from the runtime key, reuse namespace, policy hash, command/env digests, input manifest digest, normalized outputs, and prior dependency output keys. It also adds block-volume cache lookup metadata checks and a runtime capability decision that keeps the current aggregate dependency stage path unless the backend advertises cache output volumes and overlay write capture.

Sandbox execution behavior is intentionally unchanged in this slice. The plan doc now marks this as phase 2 and leaves volume attachment, isolated input projections, restore, and publish for follow-up PRs.

## Tests

- `mise exec -- go test ./internal/controlservice`
- `mise exec -- go test ./...`
