### PR TITLE
feat: Add top-level workspace copy-out automation

### DIFF
--- a/docs/plans/workspace-sync.md
+++ b/docs/plans/workspace-sync.md
@@ -20,11 +20,14 @@
   `workspace copy-in` and top-level `--copy-in` record the trusted local root,
   canonical remote, baseline commit, sandbox workspace root, operation time, and
   copy-in manifest; `workspace copy-out` prefers that bound root.
-- This changeset should make Git-backed `workspace copy-out` use the recorded
-  copy-in manifest as the local conflict and apply base, so copy-out can safely
-  write back after a prior copy-in that included dirty edits or local-only
-  commits.
-- Non-Git/raw copy-out writes, top-level `--copy-out`, and `--sync` remain
+- PR #276 landed Git-backed `workspace copy-out` from the recorded copy-in
+  manifest base, so copy-out can safely write back after a prior copy-in that
+  included dirty edits or local-only commits.
+- This changeset adds Git-backed top-level `--copy-out` and `--sync` automation
+  for `cleanroom exec` and `cleanroom console`. It composes the manual
+  copy-in/copy-out operations, prevalidates existing sandbox copy-out targets,
+  and runs copy-out before automatic sandbox termination.
+- Non-Git/raw copy-out writes and raw create-time workspace support remain
   follow-up work.
 
 ## Summary
@@ -310,6 +313,18 @@ Supported on:
 For an automatically-created sandbox, `--copy-out` should run
 `workspace copy-out` after the execution/session exits and before the CLI
 terminates the sandbox.
+
+The first implementation is Git-backed only. For an existing sandbox, the CLI
+prevalidates the local copy-out target against the sandbox's recorded repository
+before running the command, then lets the command run in the sandbox's recorded
+checkout. The local checkout is only the copy-out destination. For a newly
+created sandbox, top-level `--copy-out` requires a local Git checkout so the
+sandbox and local destination share a repository identity.
+
+Copy-out should run after a successful command and after a command that exits
+non-zero, because the workspace may still contain useful generated fixes. It
+should not run after setup, transport, or forced-detach failures where the CLI
+cannot confidently observe the final workspace state.
 
 For `--keep`, copy-out should still run after the execution/session exits, but
 the sandbox should remain available. The user can run more explicit

--- a/internal/cli/cli_parse_test.go
+++ b/internal/cli/cli_parse_test.go
@@ -444,6 +444,68 @@ func TestTopLevelCommandsParseCopyInFlag(t *testing.T) {
 	})
 }
 
+func TestTopLevelCommandsParseCopyOutAndSyncFlags(t *testing.T) {
+	t.Run("exec copy-out", func(t *testing.T) {
+		c := &CLI{}
+		parser := newParserForTest(t, c)
+		if _, err := parser.Parse([]string{"exec", "--copy-out", "--", "echo", "ok"}); err != nil {
+			t.Fatalf("parse exec --copy-out returned error: %v", err)
+		}
+		if !c.Exec.CopyOut {
+			t.Fatal("expected exec copy-out flag to be set")
+		}
+	})
+
+	t.Run("exec sync", func(t *testing.T) {
+		c := &CLI{}
+		parser := newParserForTest(t, c)
+		if _, err := parser.Parse([]string{"exec", "--sync", "--", "echo", "ok"}); err != nil {
+			t.Fatalf("parse exec --sync returned error: %v", err)
+		}
+		if !c.Exec.Sync || !c.Exec.copyIn() || !c.Exec.copyOut() {
+			t.Fatalf("expected exec sync to imply copy-in and copy-out, got %+v", c.Exec.workspaceCopyFlags)
+		}
+	})
+
+	t.Run("console copy-out", func(t *testing.T) {
+		c := &CLI{}
+		parser := newParserForTest(t, c)
+		if _, err := parser.Parse([]string{"console", "--copy-out"}); err != nil {
+			t.Fatalf("parse console --copy-out returned error: %v", err)
+		}
+		if !c.Console.CopyOut {
+			t.Fatal("expected console copy-out flag to be set")
+		}
+	})
+
+	t.Run("console sync", func(t *testing.T) {
+		c := &CLI{}
+		parser := newParserForTest(t, c)
+		if _, err := parser.Parse([]string{"console", "--sync"}); err != nil {
+			t.Fatalf("parse console --sync returned error: %v", err)
+		}
+		if !c.Console.Sync || !c.Console.copyIn() || !c.Console.copyOut() {
+			t.Fatalf("expected console sync to imply copy-in and copy-out, got %+v", c.Console.workspaceCopyFlags)
+		}
+	})
+
+	t.Run("create rejects copy-out", func(t *testing.T) {
+		c := &CLI{}
+		parser := newParserForTest(t, c)
+		if _, err := parser.Parse([]string{"create", "--copy-out"}); err == nil {
+			t.Fatal("expected create --copy-out to be rejected")
+		}
+	})
+
+	t.Run("create rejects sync", func(t *testing.T) {
+		c := &CLI{}
+		parser := newParserForTest(t, c)
+		if _, err := parser.Parse([]string{"create", "--sync"}); err == nil {
+			t.Fatal("expected create --sync to be rejected")
+		}
+	})
+}
+
 func TestWorkspaceCopyInParses(t *testing.T) {
 	c := &CLI{}
 	parser := newParserForTest(t, c)

--- a/internal/cli/console.go
+++ b/internal/cli/console.go
@@ -93,6 +93,9 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) (runErr error) {
 	if err != nil {
 		return err
 	}
+	if err := validateWorkspaceCopyOutBeforeExecution(rootCtx, ctx, client, cwd, c.Chdir, c.In, c.LaunchSeconds, c.workspaceCopyFlags); err != nil {
+		return err
+	}
 
 	target, err := resolveExecutionSandbox(rootCtx, client, ctx, cwd, host, c.Backend, c.In, c.From, c.Image, c.LaunchSeconds, c.DangerouslyAllowAll, c.repositoryOverrideFlags, c.workspaceCopyFlags)
 	if err != nil {
@@ -142,13 +145,24 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) (runErr error) {
 		}
 	}
 	detached := false
+	preserveSandbox := false
 	autoTerminateSandbox := createdSandbox && !c.Keep
 	defer func() {
-		if detached || sandboxID == "" || !autoTerminateSandbox {
+		if detached || preserveSandbox || sandboxID == "" || !autoTerminateSandbox {
 			return
 		}
 		terminateSandboxBestEffort(rootCtx, client, sandboxID, 0, logger, "terminate sandbox after console failed")
 	}()
+	copyWorkspaceOutAfterRun := func(executionErr error) error {
+		copyOutErr := copyWorkspaceOutAfterExecution(rootCtx, ctx, client, cwd, c.Chdir, sandboxID, c.LaunchSeconds, c.workspaceCopyFlags)
+		if copyOutErr != nil && autoTerminateSandbox {
+			preserveSandbox = true
+			if err := printSandboxID(); err != nil {
+				copyOutErr = errors.Join(copyOutErr, err)
+			}
+		}
+		return joinExecutionAndWorkspaceCopyOutError(executionErr, copyOutErr)
+	}
 	if c.preAttach != nil {
 		if err := c.preAttach(rootCtx, client, sandboxID); err != nil {
 			return err
@@ -176,6 +190,10 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) (runErr error) {
 		if autoTerminateSandbox {
 			terminateSandboxBestEffort(rootCtx, client, sandboxID, sandboxTerminateTimeout, logger, "terminate sandbox after detach failed")
 		}
+		return err
+	}
+	if shouldRunWorkspaceCopyOutAfterExecution(err) {
+		return copyWorkspaceOutAfterRun(err)
 	}
 	return err
 }

--- a/internal/cli/console_integration_test.go
+++ b/internal/cli/console_integration_test.go
@@ -636,6 +636,31 @@ func TestConsoleIntegrationRejectsChdirWhenReusingSandbox(t *testing.T) {
 	}
 }
 
+func TestConsoleIntegrationRejectsChdirWhenCopyingOutFromReusedSandbox(t *testing.T) {
+	cwd := t.TempDir()
+	outcome := runConsoleWithCapture(ConsoleCommand{
+		clientFlags: clientFlags{Host: "tssvc://cleanroom"},
+		Chdir:       cwd,
+		In:          "cr_123",
+		workspaceCopyFlags: workspaceCopyFlags{
+			CopyOut: true,
+		},
+		Command: []string{"sh"},
+	}, "", runtimeContext{
+		CWD:    cwd,
+		Loader: failingLoader{},
+	})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err == nil {
+		t.Fatal("expected ConsoleCommand.Run to reject --chdir with --in --copy-out")
+	}
+	if got, want := outcome.err.Error(), "--chdir cannot be used with --in"; !strings.Contains(got, want) {
+		t.Fatalf("expected error to contain %q, got %q", want, got)
+	}
+}
+
 func TestConsoleIntegrationRejectsChdirWhenCreatingFromSnapshot(t *testing.T) {
 	cwd := t.TempDir()
 	outcome := runConsoleWithCapture(ConsoleCommand{

--- a/internal/cli/console_integration_test.go
+++ b/internal/cli/console_integration_test.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"errors"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -18,6 +20,130 @@ func runConsoleWithCapture(cmd ConsoleCommand, stdinData string, ctx runtimeCont
 	return runWithCapture(func(runCtx *runtimeContext) error {
 		return cmd.Run(runCtx)
 	}, &stdinData, ctx)
+}
+
+func TestConsoleIntegrationCopyOutAppliesSandboxChangesAfterSession(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	localRoot := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
+	resolvedLocalRoot, err := gitOutput(localRoot, "rev-parse", "--show-toplevel")
+	if err != nil {
+		t.Fatalf("resolve local repository root: %v", err)
+	}
+	baseCommit, copyOutPayload := prepareReadmeWorkspaceCopyOutPayload(t, localRoot, "console sandbox\n")
+
+	adapter := &integrationAdapter{}
+	host, _ := startIntegrationServer(t, adapter)
+	sandboxID := createWorkspaceCopyTestSandboxWithRepositoryCommitBranch(t, host, "/sandbox-workspace", baseCommit, "main")
+
+	var (
+		mu       sync.Mutex
+		commands []string
+	)
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+		command := strings.Join(req.Command, " ")
+		mu.Lock()
+		commands = append(commands, command)
+		mu.Unlock()
+		if strings.Contains(command, "cleanroom-copy-out-v1") {
+			if stream.OnStdout != nil {
+				stream.OnStdout(copyOutPayload)
+			}
+			return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+		}
+		if stream.OnStdout != nil {
+			stream.OnStdout([]byte("console ran\n"))
+		}
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+	}
+
+	outcome := runConsoleWithCapture(ConsoleCommand{
+		clientFlags:        clientFlags{Host: host},
+		In:                 sandboxID,
+		workspaceCopyFlags: workspaceCopyFlags{CopyOut: true},
+		Command:            []string{"sh"},
+	}, "exit\n", runtimeContext{
+		CWD:    localRoot,
+		Loader: workspaceCopyRepositoryLoader(),
+	})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err != nil {
+		t.Fatalf("ConsoleCommand.Run returned error: %v", outcome.err)
+	}
+	if got := mustReadFile(t, filepath.Join(localRoot, "README.md")); got != "console sandbox\n" {
+		t.Fatalf("unexpected copied-out README: got %q", got)
+	}
+	if !strings.Contains(outcome.stdout, "console ran\n") {
+		t.Fatalf("expected console stdout, got %q", outcome.stdout)
+	}
+	if strings.Contains(outcome.stdout, "write\t"+filepath.Join(resolvedLocalRoot, "README.md")+"\n") {
+		t.Fatalf("copy-out plan should not be written to stdout, got %q", outcome.stdout)
+	}
+	if !strings.Contains(outcome.stderr, "write\t"+filepath.Join(resolvedLocalRoot, "README.md")+"\n") {
+		t.Fatalf("expected copy-out plan in stderr, got %q", outcome.stderr)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if got, want := len(commands), 2; got != want {
+		t.Fatalf("expected console command plus workspace copy-out command, got %d: %v", got, commands)
+	}
+	if !strings.Contains(commands[1], "cleanroom-copy-out-v1") {
+		t.Fatalf("expected copy-out command second, got %q", commands[1])
+	}
+}
+
+func TestConsoleIntegrationCopyOutFailurePreservesCreatedSandbox(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	localRoot := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
+
+	adapter := &snapshotIntegrationAdapter{}
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+		command := strings.Join(req.Command, " ")
+		if strings.Contains(command, "cleanroom-copy-out-v1") {
+			return nil, errors.New("copy-out unavailable")
+		}
+		if stream.OnStdout != nil {
+			stream.OnStdout([]byte("console ran\n"))
+		}
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+	}
+	host, _ := startIntegrationServer(t, adapter)
+
+	outcome := runConsoleWithCapture(ConsoleCommand{
+		clientFlags:        clientFlags{Host: host},
+		workspaceCopyFlags: workspaceCopyFlags{CopyOut: true},
+		Command:            []string{"sh"},
+	}, "exit\n", runtimeContext{
+		CWD:    localRoot,
+		Loader: workspaceCopyRepositoryLoader(),
+	})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err == nil {
+		t.Fatal("expected copy-out failure")
+	}
+	if !strings.Contains(outcome.err.Error(), "workspace copy-out") {
+		t.Fatalf("expected workspace copy-out error, got %v", outcome.err)
+	}
+	if !strings.Contains(outcome.stdout, "console ran\n") {
+		t.Fatalf("expected console stdout, got %q", outcome.stdout)
+	}
+	sandboxID := parseSandboxID(outcome.stderr)
+	if sandboxID == "" {
+		t.Fatalf("expected sandbox id in stderr when preserving sandbox, got %q", outcome.stderr)
+	}
+	client := mustNewControlClient(t, host)
+	requireSandboxStatus(t, client, sandboxID, cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY)
+
+	adapter.mu.Lock()
+	terminateCalls := adapter.terminateCalls
+	adapter.mu.Unlock()
+	if terminateCalls != 0 {
+		t.Fatalf("expected copy-out failure to preserve created sandbox, got %d terminate calls", terminateCalls)
+	}
 }
 
 func TestConsoleIntegrationForwardsStdinAndStreamsOutput(t *testing.T) {

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -104,6 +104,9 @@ func (e *ExecCommand) Run(ctx *runtimeContext) (runErr error) {
 	if err != nil {
 		return err
 	}
+	if err := validateWorkspaceCopyOutBeforeExecution(rootCtx, ctx, client, cwd, e.Chdir, e.In, e.LaunchSeconds, e.workspaceCopyFlags); err != nil {
+		return err
+	}
 
 	target, err := resolveExecutionSandbox(rootCtx, client, ctx, cwd, host, e.Backend, e.In, e.From, e.Image, e.LaunchSeconds, e.DangerouslyAllowAll, e.repositoryOverrideFlags, e.workspaceCopyFlags)
 	if err != nil {
@@ -177,13 +180,24 @@ func (e *ExecCommand) Run(ctx *runtimeContext) (runErr error) {
 		}
 	}
 	detached := false
+	preserveSandbox := false
 	autoTerminateSandbox := createdSandbox && !e.Keep
 	defer func() {
-		if detached || !autoTerminateSandbox || sandboxID == "" {
+		if detached || preserveSandbox || !autoTerminateSandbox || sandboxID == "" {
 			return
 		}
 		terminateSandboxBestEffort(rootCtx, client, sandboxID, 0, logger, "terminate sandbox after exec failed")
 	}()
+	copyWorkspaceOutAfterRun := func(executionErr error) error {
+		copyOutErr := copyWorkspaceOutAfterExecution(rootCtx, ctx, client, cwd, e.Chdir, sandboxID, e.LaunchSeconds, e.workspaceCopyFlags)
+		if copyOutErr != nil && autoTerminateSandbox {
+			preserveSandbox = true
+			if err := printSandboxID(); err != nil {
+				copyOutErr = errors.Join(copyOutErr, err)
+			}
+		}
+		return joinExecutionAndWorkspaceCopyOutError(executionErr, copyOutErr)
+	}
 	exposureManager, exposed, err := startClientExposures(rootCtx, client, sandboxID, exposures)
 	if err != nil {
 		return err
@@ -219,6 +233,10 @@ func (e *ExecCommand) Run(ctx *runtimeContext) (runErr error) {
 			if autoTerminateSandbox {
 				terminateSandboxBestEffort(rootCtx, client, sandboxID, sandboxTerminateTimeout, logger, "terminate sandbox after detach failed")
 			}
+			return err
+		}
+		if shouldRunWorkspaceCopyOutAfterExecution(err) {
+			return copyWorkspaceOutAfterRun(err)
 		}
 		return err
 	}
@@ -338,8 +356,12 @@ func (e *ExecCommand) Run(ctx *runtimeContext) (runErr error) {
 	if !haveExitCode {
 		return errors.New("execution stream ended without exit status")
 	}
+	var executionErr error
 	if exitCode != 0 {
-		return exitCodeError{code: exitCode}
+		executionErr = exitCodeError{code: exitCode}
 	}
-	return nil
+	if shouldRunWorkspaceCopyOutAfterExecution(executionErr) {
+		return copyWorkspaceOutAfterRun(executionErr)
+	}
+	return executionErr
 }

--- a/internal/cli/exec_integration_test.go
+++ b/internal/cli/exec_integration_test.go
@@ -596,7 +596,7 @@ func TestExecIntegrationCopyOutRejectsBaselineMismatchBeforeCommand(t *testing.T
 	}
 }
 
-func TestWorkspaceCopyOutPrevalidationAllowsSyncBaselineMismatch(t *testing.T) {
+func TestWorkspaceCopyOutPrevalidationAllowsSyncToReplaceStaleBinding(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	localRoot := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
 	baseCommit := headCommit(t, localRoot)
@@ -606,12 +606,26 @@ func TestWorkspaceCopyOutPrevalidationAllowsSyncBaselineMismatch(t *testing.T) {
 	sandboxID := createWorkspaceCopyTestSandboxWithRepositoryCommitBranch(t, host, "/sandbox-workspace", baseCommit, "main")
 	client := mustNewControlClient(t, host)
 
+	if err := writeWorkspaceBinding(&workspaceBinding{
+		Version:             workspaceBindingVersion,
+		SandboxID:           sandboxID,
+		LocalRoot:           filepath.Join(localRoot, "moved"),
+		SandboxWorkspace:    "/sandbox-workspace",
+		RepositoryRemoteURL: "https://github.com/buildkite/cleanroom.git",
+		RepositoryCommitSHA: "0000000000000000000000000000000000000000",
+		Transport:           workspaceBindingTransportGit,
+		LastOperation:       "copy-in",
+		LastOperationAt:     time.Now().UTC().Format(time.RFC3339Nano),
+	}); err != nil {
+		t.Fatalf("write stale workspace binding: %v", err)
+	}
+
 	err := validateWorkspaceCopyOutBeforeExecution(context.Background(), &runtimeContext{
 		CWD:    localRoot,
 		Loader: repositoryNotFoundLoader{},
 	}, client, localRoot, "", sandboxID, 0, workspaceCopyFlags{Sync: true})
 	if err != nil {
-		t.Fatalf("expected --sync prevalidation to allow copy-in to establish the copy-out base, got %v", err)
+		t.Fatalf("expected --sync prevalidation to allow copy-in to replace the stale copy-out binding, got %v", err)
 	}
 }
 

--- a/internal/cli/exec_integration_test.go
+++ b/internal/cli/exec_integration_test.go
@@ -372,6 +372,273 @@ func runExecWithCapture(cmd ExecCommand, ctx runtimeContext) execOutcome {
 	}, &emptyStdin, ctx)
 }
 
+func TestExecIntegrationCopyOutAppliesSandboxChangesAfterCommand(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	localRoot := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
+	resolvedLocalRoot, err := gitOutput(localRoot, "rev-parse", "--show-toplevel")
+	if err != nil {
+		t.Fatalf("resolve local repository root: %v", err)
+	}
+	baseCommit, copyOutPayload := prepareReadmeWorkspaceCopyOutPayload(t, localRoot, "sandbox\n")
+
+	adapter := &integrationAdapter{}
+	host, _ := startIntegrationServer(t, adapter)
+	sandboxID := createWorkspaceCopyTestSandboxWithRepositoryCommitBranch(t, host, "/sandbox-workspace", baseCommit, "main")
+
+	var (
+		mu       sync.Mutex
+		commands []string
+	)
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+		command := strings.Join(req.Command, " ")
+		mu.Lock()
+		commands = append(commands, command)
+		mu.Unlock()
+		switch {
+		case strings.Contains(command, "cleanroom-copy-out-v1"):
+			if stream.OnStdout != nil {
+				stream.OnStdout(copyOutPayload)
+			}
+		default:
+			if stream.OnStdout != nil {
+				stream.OnStdout([]byte("command ran\n"))
+			}
+		}
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+	}
+
+	outcome := runExecWithCapture(ExecCommand{
+		clientFlags:        clientFlags{Host: host},
+		In:                 sandboxID,
+		workspaceCopyFlags: workspaceCopyFlags{CopyOut: true},
+		Command:            []string{"echo", "ok"},
+	}, runtimeContext{
+		CWD:    localRoot,
+		Loader: workspaceCopyRepositoryLoader(),
+	})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err != nil {
+		t.Fatalf("ExecCommand.Run returned error: %v", outcome.err)
+	}
+	if got := mustReadFile(t, filepath.Join(localRoot, "README.md")); got != "sandbox\n" {
+		t.Fatalf("unexpected copied-out README: got %q", got)
+	}
+	if !strings.Contains(outcome.stdout, "command ran\n") {
+		t.Fatalf("expected command stdout, got %q", outcome.stdout)
+	}
+	if strings.Contains(outcome.stdout, "write\t"+filepath.Join(resolvedLocalRoot, "README.md")+"\n") {
+		t.Fatalf("copy-out plan should not be written to stdout, got %q", outcome.stdout)
+	}
+	if !strings.Contains(outcome.stderr, "write\t"+filepath.Join(resolvedLocalRoot, "README.md")+"\n") {
+		t.Fatalf("expected copy-out plan in stderr, got %q", outcome.stderr)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if got, want := len(commands), 2; got != want {
+		t.Fatalf("expected user command plus workspace copy-out command, got %d: %v", got, commands)
+	}
+	if strings.Contains(commands[0], "cleanroom-copy-out-v1") {
+		t.Fatalf("expected user command before copy-out, got %q", commands[0])
+	}
+	if !strings.Contains(commands[1], "cleanroom-copy-out-v1") {
+		t.Fatalf("expected copy-out command second, got %q", commands[1])
+	}
+}
+
+func TestExecIntegrationCopyOutRunsAfterNonZeroExit(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	localRoot := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
+	resolvedLocalRoot, err := gitOutput(localRoot, "rev-parse", "--show-toplevel")
+	if err != nil {
+		t.Fatalf("resolve local repository root: %v", err)
+	}
+	baseCommit, copyOutPayload := prepareReadmeWorkspaceCopyOutPayload(t, localRoot, "sandbox after failure\n")
+
+	adapter := &integrationAdapter{}
+	host, _ := startIntegrationServer(t, adapter)
+	sandboxID := createWorkspaceCopyTestSandboxWithRepositoryCommitBranch(t, host, "/sandbox-workspace", baseCommit, "main")
+
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+		command := strings.Join(req.Command, " ")
+		if strings.Contains(command, "cleanroom-copy-out-v1") {
+			if stream.OnStdout != nil {
+				stream.OnStdout(copyOutPayload)
+			}
+			return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+		}
+		if stream.OnStderr != nil {
+			stream.OnStderr([]byte("failed\n"))
+		}
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 7, Message: "failed"}, nil
+	}
+
+	outcome := runExecWithCapture(ExecCommand{
+		clientFlags:        clientFlags{Host: host},
+		In:                 sandboxID,
+		workspaceCopyFlags: workspaceCopyFlags{CopyOut: true},
+		Command:            []string{"false"},
+	}, runtimeContext{
+		CWD:    localRoot,
+		Loader: workspaceCopyRepositoryLoader(),
+	})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	var exitErr exitCodeError
+	if !errors.As(outcome.err, &exitErr) || exitErr.ExitCode() != 7 {
+		t.Fatalf("expected exit code 7 after copy-out, got %v", outcome.err)
+	}
+	if got := mustReadFile(t, filepath.Join(localRoot, "README.md")); got != "sandbox after failure\n" {
+		t.Fatalf("unexpected copied-out README after failure: got %q", got)
+	}
+	if strings.Contains(outcome.stdout, "write\t"+filepath.Join(resolvedLocalRoot, "README.md")+"\n") {
+		t.Fatalf("copy-out plan should not be written to stdout, got %q", outcome.stdout)
+	}
+	if !strings.Contains(outcome.stderr, "failed\n") {
+		t.Fatalf("expected command stderr, got %q", outcome.stderr)
+	}
+	if !strings.Contains(outcome.stderr, "write\t"+filepath.Join(resolvedLocalRoot, "README.md")+"\n") {
+		t.Fatalf("expected copy-out plan in stderr, got %q", outcome.stderr)
+	}
+}
+
+func TestExecIntegrationCopyOutFailurePreservesCreatedSandbox(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	localRoot := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
+
+	adapter := &snapshotIntegrationAdapter{}
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+		command := strings.Join(req.Command, " ")
+		if strings.Contains(command, "cleanroom-copy-out-v1") {
+			return nil, errors.New("copy-out unavailable")
+		}
+		if stream.OnStdout != nil {
+			stream.OnStdout([]byte("command ran\n"))
+		}
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+	}
+	host, _ := startIntegrationServer(t, adapter)
+
+	outcome := runExecWithCapture(ExecCommand{
+		clientFlags:        clientFlags{Host: host},
+		workspaceCopyFlags: workspaceCopyFlags{CopyOut: true},
+		Command:            []string{"echo", "ok"},
+	}, runtimeContext{
+		CWD:    localRoot,
+		Loader: workspaceCopyRepositoryLoader(),
+	})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err == nil {
+		t.Fatal("expected copy-out failure")
+	}
+	if !strings.Contains(outcome.err.Error(), "workspace copy-out") {
+		t.Fatalf("expected workspace copy-out error, got %v", outcome.err)
+	}
+	if !strings.Contains(outcome.stdout, "command ran\n") {
+		t.Fatalf("expected command stdout, got %q", outcome.stdout)
+	}
+	sandboxID := parseSandboxID(outcome.stderr)
+	if sandboxID == "" {
+		t.Fatalf("expected sandbox id in stderr when preserving sandbox, got %q", outcome.stderr)
+	}
+	client := mustNewControlClient(t, host)
+	requireSandboxStatus(t, client, sandboxID, cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY)
+
+	adapter.mu.Lock()
+	terminateCalls := adapter.terminateCalls
+	adapter.mu.Unlock()
+	if terminateCalls != 0 {
+		t.Fatalf("expected copy-out failure to preserve created sandbox, got %d terminate calls", terminateCalls)
+	}
+}
+
+func TestExecIntegrationCopyOutRejectsBaselineMismatchBeforeCommand(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	localRoot := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
+	baseCommit := headCommit(t, localRoot)
+	commitFile(t, localRoot, "local.txt", "local\n", "local commit")
+
+	adapter := &integrationAdapter{}
+	host, _ := startIntegrationServer(t, adapter)
+	sandboxID := createWorkspaceCopyTestSandboxWithRepositoryCommitBranch(t, host, "/sandbox-workspace", baseCommit, "main")
+
+	var executionCalled bool
+	adapter.runStreamFn = func(_ context.Context, _ backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
+		executionCalled = true
+		return &backend.ExecutionResult{ExitCode: 0, Message: "ok"}, nil
+	}
+
+	outcome := runExecWithCapture(ExecCommand{
+		clientFlags:        clientFlags{Host: host},
+		In:                 sandboxID,
+		workspaceCopyFlags: workspaceCopyFlags{CopyOut: true},
+		Command:            []string{"echo", "ok"},
+	}, runtimeContext{
+		CWD:    localRoot,
+		Loader: repositoryNotFoundLoader{},
+	})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err == nil {
+		t.Fatal("expected baseline mismatch to be rejected")
+	}
+	if !strings.Contains(outcome.err.Error(), "requires local checkout HEAD") {
+		t.Fatalf("expected baseline mismatch error, got %v", outcome.err)
+	}
+	if executionCalled {
+		t.Fatal("expected copy-out validation to fail before running command")
+	}
+}
+
+func TestWorkspaceCopyOutPrevalidationAllowsSyncBaselineMismatch(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	localRoot := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
+	baseCommit := headCommit(t, localRoot)
+	commitFile(t, localRoot, "local.txt", "local\n", "local commit")
+
+	host, _ := startIntegrationServer(t, &integrationAdapter{})
+	sandboxID := createWorkspaceCopyTestSandboxWithRepositoryCommitBranch(t, host, "/sandbox-workspace", baseCommit, "main")
+	client := mustNewControlClient(t, host)
+
+	err := validateWorkspaceCopyOutBeforeExecution(context.Background(), &runtimeContext{
+		CWD:    localRoot,
+		Loader: repositoryNotFoundLoader{},
+	}, client, localRoot, "", sandboxID, 0, workspaceCopyFlags{Sync: true})
+	if err != nil {
+		t.Fatalf("expected --sync prevalidation to allow copy-in to establish the copy-out base, got %v", err)
+	}
+}
+
+func prepareReadmeWorkspaceCopyOutPayload(t *testing.T, localRoot, content string) (string, []byte) {
+	t.Helper()
+
+	baseCommit := headCommit(t, localRoot)
+	if err := os.WriteFile(filepath.Join(localRoot, "README.md"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write sandbox readme: %v", err)
+	}
+	runGitInDir(t, localRoot, "add", "README.md")
+	nameStatus := gitOutputBytes(t, localRoot, "diff", "--cached", "--name-status", "--no-renames", "-z", baseCommit)
+	patch := gitOutputBytes(t, localRoot, "diff", "--cached", "--binary", "--full-index", "--no-ext-diff", "--no-color", "--no-renames", baseCommit)
+	runGitInDir(t, localRoot, "reset", "--hard", baseCommit)
+	return baseCommit, workspaceCopyOutTestPayload(nameStatus, patch)
+}
+
+func mustReadFile(t *testing.T, path string) string {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(data)
+}
+
 func newTestObservability(t *testing.T) *observability.Runtime {
 	t.Helper()
 

--- a/internal/cli/exec_integration_test.go
+++ b/internal/cli/exec_integration_test.go
@@ -2224,6 +2224,31 @@ func TestExecIntegrationRejectsChdirWhenReusingSandbox(t *testing.T) {
 	}
 }
 
+func TestExecIntegrationRejectsChdirWhenCopyingOutFromReusedSandbox(t *testing.T) {
+	cwd := t.TempDir()
+	outcome := runExecWithCapture(ExecCommand{
+		clientFlags: clientFlags{Host: "tssvc://cleanroom"},
+		Chdir:       cwd,
+		In:          "cr_123",
+		workspaceCopyFlags: workspaceCopyFlags{
+			CopyOut: true,
+		},
+		Command: []string{"echo", "ok"},
+	}, runtimeContext{
+		CWD:    cwd,
+		Loader: failingLoader{},
+	})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err == nil {
+		t.Fatal("expected ExecCommand.Run to reject --chdir with --in --copy-out")
+	}
+	if got, want := outcome.err.Error(), "--chdir cannot be used with --in"; !strings.Contains(got, want) {
+		t.Fatalf("expected error to contain %q, got %q", want, got)
+	}
+}
+
 func TestExecIntegrationRejectsChdirWhenCreatingFromSnapshot(t *testing.T) {
 	cwd := t.TempDir()
 	outcome := runExecWithCapture(ExecCommand{

--- a/internal/cli/execution_shared.go
+++ b/internal/cli/execution_shared.go
@@ -354,7 +354,7 @@ func validateExecutionSandboxArgs(chdir, existingSandboxID, fromSnapshot string,
 	if snapshotID != "" && dangerouslyAllowAll {
 		return errors.New("--dangerously-allow-all cannot be used with --from")
 	}
-	if sandboxID != "" && hasChdir && !copyFlags.copyIn() && !copyFlags.copyOut() {
+	if sandboxID != "" && hasChdir && !copyFlags.copyIn() {
 		return errors.New("--chdir cannot be used with --in")
 	}
 	if snapshotID != "" && hasChdir {

--- a/internal/cli/execution_shared.go
+++ b/internal/cli/execution_shared.go
@@ -168,6 +168,9 @@ func validateWorkspaceCopyOutBeforeExecution(callCtx context.Context, ctx *runti
 	if !copyFlags.copyOut() || strings.TrimSpace(existingSandboxID) == "" {
 		return nil
 	}
+	if copyFlags.copyIn() {
+		return nil
+	}
 	opts, err := resolveWorkspaceCopyOutOptions(ctx, cwd, chdir, existingSandboxID, false, launchSeconds)
 	if err != nil {
 		return err
@@ -175,9 +178,6 @@ func validateWorkspaceCopyOutBeforeExecution(callCtx context.Context, ctx *runti
 	checkout, err := validateWorkspaceCopyOutInputs(callCtx, client, opts)
 	if err != nil {
 		return err
-	}
-	if copyFlags.copyIn() {
-		return nil
 	}
 	return validateWorkspaceCopyOutBaselineBeforeExecution(opts, checkout)
 }

--- a/internal/cli/execution_shared.go
+++ b/internal/cli/execution_shared.go
@@ -14,6 +14,7 @@ import (
 	"connectrpc.com/connect"
 	"github.com/buildkite/cleanroom/internal/controlclient"
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+	"github.com/buildkite/cleanroom/internal/repositorycheckout"
 	"github.com/charmbracelet/log"
 	"github.com/quic-go/quic-go"
 	"go.opentelemetry.io/otel/trace"
@@ -57,9 +58,12 @@ func resolveExecutionSandbox(
 
 	var repository *resolvedRepositoryCheckout
 	localChanges := repositoryLocalChanges{}
-	if fromSnapshot == "" && (existingSandboxID == "" || copyFlags.CopyIn) {
+	copyIn := copyFlags.copyIn()
+	copyOut := copyFlags.copyOut()
+
+	if fromSnapshot == "" && (existingSandboxID == "" || copyIn) {
 		var err error
-		if copyFlags.CopyIn && existingSandboxID != "" && !repositoryOverride.hasRepositoryOverride() {
+		if copyIn && existingSandboxID != "" && !repositoryOverride.hasRepositoryOverride() {
 			repository, err = resolveWorkspaceCopyRepositoryCheckout(cwd, ctx.Loader)
 		} else {
 			repository, err = resolveRepositoryCheckoutWithOverride(cwd, ctx.Loader, repositoryOverride)
@@ -67,17 +71,17 @@ func resolveExecutionSandbox(
 		if err != nil {
 			return nil, err
 		}
-		if err := validateTopLevelWorkspaceCopyTransport(repository, copyFlags.CopyIn && existingSandboxID == ""); err != nil {
+		if err := validateTopLevelWorkspaceCopyTransport(repository, (copyIn || copyOut) && existingSandboxID == ""); err != nil {
 			return nil, err
 		}
 		if existingSandboxID == "" {
-			localChanges, err = resolveRepositoryLocalChanges(repository, copyFlags.CopyIn)
+			localChanges, err = resolveRepositoryLocalChanges(repository, copyIn)
 			if err != nil {
 				return nil, err
 			}
 		}
 	}
-	warnDirtyRepositoryCheckout(repository, copyFlags.CopyIn && repository != nil && fromSnapshot == "")
+	warnDirtyRepositoryCheckout(repository, copyIn && repository != nil && fromSnapshot == "")
 
 	sandboxID, createdSandbox, err := ensureSandboxID(
 		callCtx,
@@ -99,7 +103,7 @@ func resolveExecutionSandbox(
 	}
 
 	workspaceRoot := ""
-	if copyFlags.CopyIn && fromSnapshot == "" {
+	if copyIn && fromSnapshot == "" {
 		localChangesAttachedDuringCreate := existingSandboxID == "" && repository != nil && (localChanges.Changeset != nil || localChanges.CommitBundle != nil)
 		copyRepository := repository
 		if repository == nil {
@@ -146,6 +150,77 @@ func resolveExecutionSandbox(
 		Repository:     repository,
 		WorkspaceRoot:  workspaceRoot,
 	}, nil
+}
+
+func copyWorkspaceOutAfterExecution(callCtx context.Context, ctx *runtimeContext, client *controlclient.Client, cwd, chdir, sandboxID string, launchSeconds int64, copyFlags workspaceCopyFlags) error {
+	if !copyFlags.copyOut() {
+		return nil
+	}
+	opts, err := resolveWorkspaceCopyOutOptions(ctx, cwd, chdir, sandboxID, false, launchSeconds)
+	if err != nil {
+		return err
+	}
+	opts.PlanOutput = ctx.stderr()
+	return copyWorkspaceOut(callCtx, ctx, client, opts)
+}
+
+func validateWorkspaceCopyOutBeforeExecution(callCtx context.Context, ctx *runtimeContext, client *controlclient.Client, cwd, chdir, existingSandboxID string, launchSeconds int64, copyFlags workspaceCopyFlags) error {
+	if !copyFlags.copyOut() || strings.TrimSpace(existingSandboxID) == "" {
+		return nil
+	}
+	opts, err := resolveWorkspaceCopyOutOptions(ctx, cwd, chdir, existingSandboxID, false, launchSeconds)
+	if err != nil {
+		return err
+	}
+	checkout, err := validateWorkspaceCopyOutInputs(callCtx, client, opts)
+	if err != nil {
+		return err
+	}
+	if copyFlags.copyIn() {
+		return nil
+	}
+	return validateWorkspaceCopyOutBaselineBeforeExecution(opts, checkout)
+}
+
+func validateWorkspaceCopyOutBaselineBeforeExecution(opts workspaceCopyOptions, checkout *repositorycheckout.Checkout) error {
+	if opts.Binding != nil {
+		return nil
+	}
+	local := opts.Repository
+	if local == nil {
+		return nil
+	}
+	localCommit := strings.TrimSpace(local.CommitSHA)
+	sandboxCommit := ""
+	if checkout != nil {
+		sandboxCommit = strings.TrimSpace(checkout.CommitSHA)
+	}
+	if localCommit == "" || sandboxCommit == "" {
+		return errors.New("workspace copy-out requires local and sandbox repository commits")
+	}
+	if !strings.EqualFold(localCommit, sandboxCommit) {
+		return fmt.Errorf("workspace copy-out requires local checkout HEAD %s to match sandbox baseline %s", shortGitSHA(localCommit), shortGitSHA(sandboxCommit))
+	}
+	return nil
+}
+
+func shouldRunWorkspaceCopyOutAfterExecution(err error) bool {
+	if err == nil {
+		return true
+	}
+	var exitErr exitCodeError
+	return errors.As(err, &exitErr)
+}
+
+func joinExecutionAndWorkspaceCopyOutError(executionErr, copyOutErr error) error {
+	if copyOutErr == nil {
+		return executionErr
+	}
+	copyOutErr = fmt.Errorf("workspace copy-out: %w", copyOutErr)
+	if executionErr == nil {
+		return copyOutErr
+	}
+	return errors.Join(executionErr, copyOutErr)
 }
 
 func ensureSandboxID(callCtx context.Context, client *controlclient.Client, loader policyLoader, cwd, host, backendName, existingSandboxID, fromSnapshot, imageRefOverride string, launchSeconds int64, dangerouslyAllowAll bool, repository *resolvedRepositoryCheckout, localChanges repositoryLocalChanges) (string, bool, error) {
@@ -263,7 +338,7 @@ func validateExecutionSandboxArgs(chdir, existingSandboxID, fromSnapshot string,
 	if _, err := repositoryOverride.resolve(".", nil); err != nil {
 		return err
 	}
-	if err := copyFlags.validate(existingSandboxID, fromSnapshot, repositoryOverride); err != nil {
+	if err := copyFlags.validate(fromSnapshot, repositoryOverride); err != nil {
 		return err
 	}
 
@@ -279,7 +354,7 @@ func validateExecutionSandboxArgs(chdir, existingSandboxID, fromSnapshot string,
 	if snapshotID != "" && dangerouslyAllowAll {
 		return errors.New("--dangerously-allow-all cannot be used with --from")
 	}
-	if sandboxID != "" && hasChdir && !copyFlags.CopyIn {
+	if sandboxID != "" && hasChdir && !copyFlags.copyIn() && !copyFlags.copyOut() {
 		return errors.New("--chdir cannot be used with --in")
 	}
 	if snapshotID != "" && hasChdir {

--- a/internal/cli/repository_changeset.go
+++ b/internal/cli/repository_changeset.go
@@ -10,19 +10,49 @@ import (
 	"github.com/buildkite/cleanroom/internal/repositorychangeset"
 )
 
-type workspaceCopyFlags struct {
+type workspaceCopyInFlags struct {
 	CopyIn bool `name:"copy-in" help:"Copy local workspace changes into the sandbox workspace before running"`
 }
 
-func (f workspaceCopyFlags) validate(_ string, fromSnapshot string, repositoryOverride repositoryOverrideFlags) error {
-	if !f.CopyIn {
+func (f workspaceCopyInFlags) validate(fromSnapshot string, repositoryOverride repositoryOverrideFlags) error {
+	switch {
+	case f.CopyIn && strings.TrimSpace(fromSnapshot) != "":
+		return errors.New("--copy-in cannot be used with --from")
+	case f.CopyIn && repositoryOverride.hasRepositoryOverride():
+		return errors.New("--copy-in cannot be used with --repo-url or --repo-commit")
+	default:
 		return nil
 	}
+}
+
+type workspaceCopyFlags struct {
+	CopyIn  bool `name:"copy-in" help:"Copy local workspace changes into the sandbox workspace before running"`
+	CopyOut bool `name:"copy-out" help:"Copy sandbox workspace changes back to the local workspace after running"`
+	Sync    bool `name:"sync" help:"Equivalent to --copy-in --copy-out"`
+}
+
+func (f workspaceCopyFlags) copyIn() bool {
+	return f.CopyIn || f.Sync
+}
+
+func (f workspaceCopyFlags) copyOut() bool {
+	return f.CopyOut || f.Sync
+}
+
+func (f workspaceCopyFlags) validate(fromSnapshot string, repositoryOverride repositoryOverrideFlags) error {
 	switch {
-	case strings.TrimSpace(fromSnapshot) != "":
+	case f.Sync && strings.TrimSpace(fromSnapshot) != "":
+		return errors.New("--sync cannot be used with --from")
+	case f.CopyIn && strings.TrimSpace(fromSnapshot) != "":
 		return errors.New("--copy-in cannot be used with --from")
-	case repositoryOverride.hasRepositoryOverride():
+	case f.CopyOut && strings.TrimSpace(fromSnapshot) != "":
+		return errors.New("--copy-out cannot be used with --from")
+	case f.Sync && repositoryOverride.hasRepositoryOverride():
+		return errors.New("--sync cannot be used with --repo-url or --repo-commit")
+	case f.CopyIn && repositoryOverride.hasRepositoryOverride():
 		return errors.New("--copy-in cannot be used with --repo-url or --repo-commit")
+	case f.CopyOut && repositoryOverride.hasRepositoryOverride():
+		return errors.New("--copy-out cannot be used with --repo-url or --repo-commit")
 	default:
 		return nil
 	}
@@ -32,7 +62,7 @@ func validateTopLevelWorkspaceCopyTransport(repository *resolvedRepositoryChecko
 	if !copyWorkspace || repository != nil {
 		return nil
 	}
-	return errors.New("--copy-in for non-Git workspaces cannot be used while creating a sandbox yet; create the sandbox first, then run cleanroom workspace copy-in <sandbox-id>")
+	return errors.New("top-level workspace copy for non-Git workspaces is not supported yet; create or select the sandbox, then use cleanroom workspace copy-in or cleanroom workspace copy-out explicitly")
 }
 
 type repositoryLocalChanges struct {

--- a/internal/cli/repository_test.go
+++ b/internal/cli/repository_test.go
@@ -964,9 +964,9 @@ func TestCreateCommandCopyInSuppressesDirtyWarning(t *testing.T) {
 	}
 
 	outcome := runCreateAliasWithCapture(CreateCommand{
-		clientFlags:        clientFlags{Host: host},
-		Chdir:              repoDir,
-		workspaceCopyFlags: workspaceCopyFlags{CopyIn: true},
+		clientFlags:          clientFlags{Host: host},
+		Chdir:                repoDir,
+		workspaceCopyInFlags: workspaceCopyInFlags{CopyIn: true},
 	}, runtimeContext{
 		CWD: repoDir,
 		Loader: repositoryIntegrationLoader{
@@ -1035,9 +1035,9 @@ func TestCreateCommandCopyInWarnsWhenBindingCannotBeSaved(t *testing.T) {
 	}
 
 	outcome := runCreateAliasWithCapture(CreateCommand{
-		clientFlags:        clientFlags{Host: host},
-		Chdir:              repoDir,
-		workspaceCopyFlags: workspaceCopyFlags{CopyIn: true},
+		clientFlags:          clientFlags{Host: host},
+		Chdir:                repoDir,
+		workspaceCopyInFlags: workspaceCopyInFlags{CopyIn: true},
 	}, runtimeContext{
 		CWD: repoDir,
 		Loader: repositoryIntegrationLoader{
@@ -1106,9 +1106,9 @@ func TestCreateCommandCopyInIncludesLocalOnlyCommits(t *testing.T) {
 	}
 
 	outcome := runCreateAliasWithCapture(CreateCommand{
-		clientFlags:        clientFlags{Host: host},
-		Chdir:              repoDir,
-		workspaceCopyFlags: workspaceCopyFlags{CopyIn: true},
+		clientFlags:          clientFlags{Host: host},
+		Chdir:                repoDir,
+		workspaceCopyInFlags: workspaceCopyInFlags{CopyIn: true},
 	}, runtimeContext{
 		CWD: repoDir,
 		Loader: repositoryIntegrationLoader{

--- a/internal/cli/sandbox.go
+++ b/internal/cli/sandbox.go
@@ -58,7 +58,7 @@ type CreateCommand struct {
 	From    string `name:"from" help:"Create the sandbox from an existing snapshot ID"`
 	Image   string `help:"Override sandbox image ref (tag, digest, or local Docker image)"`
 	repositoryOverrideFlags
-	workspaceCopyFlags
+	workspaceCopyInFlags
 	DangerouslyAllowAll bool  `name:"dangerously-allow-all" help:"Disable network egress filtering for a newly created sandbox"`
 	LaunchSeconds       int64 `help:"VM boot/guest-agent readiness timeout in seconds"`
 	JSON                bool  `help:"Print sandbox as JSON"`
@@ -365,7 +365,7 @@ func (c *CreateCommand) validate() error {
 	if _, err := c.repositoryOverrideFlags.resolve(".", nil); err != nil {
 		return err
 	}
-	if err := c.workspaceCopyFlags.validate("", c.From, c.repositoryOverrideFlags); err != nil {
+	if err := c.workspaceCopyInFlags.validate(c.From, c.repositoryOverrideFlags); err != nil {
 		return err
 	}
 	if c.repositoryOverrideFlags.hasRepositoryOverride() && strings.TrimSpace(c.From) != "" {

--- a/internal/cli/workspace.go
+++ b/internal/cli/workspace.go
@@ -61,6 +61,7 @@ type workspaceCopyOptions struct {
 	Destination   string
 	ForceGitReset bool
 	LaunchSeconds int64
+	PlanOutput    io.Writer
 }
 
 type workspacePlanEntry struct {
@@ -116,42 +117,51 @@ func (c *WorkspaceCopyOutCommand) Run(ctx *runtimeContext) error {
 	if err != nil {
 		return err
 	}
-	binding, err := readWorkspaceBinding(c.SandboxID)
+	client, err := c.connect(ctx)
 	if err != nil {
 		return err
 	}
+	opts, err := resolveWorkspaceCopyOutOptions(ctx, cwd, c.Chdir, c.SandboxID, c.DryRun, 0)
+	if err != nil {
+		return err
+	}
+	return copyWorkspaceOut(context.Background(), ctx, client, opts)
+}
+
+func resolveWorkspaceCopyOutOptions(ctx *runtimeContext, cwd, chdir, sandboxID string, dryRun bool, launchSeconds int64) (workspaceCopyOptions, error) {
+	binding, err := readWorkspaceBinding(sandboxID)
+	if err != nil {
+		return workspaceCopyOptions{}, err
+	}
 	repositoryRoot := cwd
 	if binding != nil && binding.Transport == workspaceBindingTransportGit && strings.TrimSpace(binding.LocalRoot) != "" {
-		if strings.TrimSpace(c.Chdir) != "" {
+		if strings.TrimSpace(chdir) != "" {
 			chdirRepository, err := resolveWorkspaceCopyRepositoryCheckout(cwd, ctx.Loader)
 			if err != nil {
-				return err
+				return workspaceCopyOptions{}, err
 			}
 			if chdirRepository == nil || !sameWorkspaceLocalRoot(chdirRepository.RootDir, binding.LocalRoot) {
-				return fmt.Errorf("workspace copy-out sandbox %q is bound to local root %q, but --chdir resolved to %q", c.SandboxID, binding.LocalRoot, cwd)
+				return workspaceCopyOptions{}, fmt.Errorf("workspace copy-out sandbox %q is bound to local root %q, but --chdir resolved to %q", sandboxID, binding.LocalRoot, cwd)
 			}
 		}
 		repositoryRoot = binding.LocalRoot
 	}
 	repository, err := resolveWorkspaceCopyRepositoryCheckout(repositoryRoot, ctx.Loader)
 	if err != nil {
-		return err
+		return workspaceCopyOptions{}, err
 	}
 	localRoot := cwd
 	if repository != nil && strings.TrimSpace(repository.RootDir) != "" {
 		localRoot = repository.RootDir
 	}
-	client, err := c.connect(ctx)
-	if err != nil {
-		return err
-	}
-	return copyWorkspaceOut(context.Background(), ctx, client, workspaceCopyOptions{
-		CWD:        localRoot,
-		SandboxID:  c.SandboxID,
-		DryRun:     c.DryRun,
-		Repository: repository,
-		Binding:    binding,
-	})
+	return workspaceCopyOptions{
+		CWD:           localRoot,
+		SandboxID:     sandboxID,
+		DryRun:        dryRun,
+		Repository:    repository,
+		Binding:       binding,
+		LaunchSeconds: launchSeconds,
+	}, nil
 }
 
 func (c *WorkspaceDiffCommand) Run(ctx *runtimeContext) error {
@@ -221,20 +231,8 @@ func copyGitWorkspaceToSandbox(callCtx context.Context, ctx *runtimeContext, cli
 }
 
 func copyWorkspaceOut(callCtx context.Context, ctx *runtimeContext, client *controlclient.Client, opts workspaceCopyOptions) error {
-	if strings.TrimSpace(opts.SandboxID) == "" {
-		return errors.New("missing sandbox id")
-	}
-	if strings.TrimSpace(opts.CWD) == "" {
-		return errors.New("missing local workspace root")
-	}
-	checkout, err := sandboxRepositoryCheckout(callCtx, client, opts.SandboxID)
+	checkout, err := validateWorkspaceCopyOutInputs(callCtx, client, opts)
 	if err != nil {
-		return err
-	}
-	if err := validateWorkspaceBinding(opts.Binding, opts.SandboxID, checkout); err != nil {
-		return err
-	}
-	if err := validateWorkspaceCopyOutLocalRepository(opts.Repository, checkout); err != nil {
 		return err
 	}
 	if opts.DryRun {
@@ -277,7 +275,7 @@ func copyWorkspaceOut(callCtx context.Context, ctx *runtimeContext, client *cont
 		if err != nil {
 			return err
 		}
-		return printWorkspacePlan(runtimeStdout(ctx), entries)
+		return printWorkspacePlan(workspacePlanOutput(ctx, opts), entries)
 	}
 
 	files, patch, err := captureGitWorkspaceCopyOutPayload(callCtx, ctx, client, opts, checkout)
@@ -311,7 +309,34 @@ func copyWorkspaceOut(callCtx context.Context, ctx *runtimeContext, client *cont
 	if err := applyGitWorkspaceCopyOutPatch(opts.Repository.RootDir, applyPath); err != nil {
 		return fmt.Errorf("%w; sandbox changes saved to %s", err, recovery.Directory)
 	}
-	return printWorkspacePlan(runtimeStdout(ctx), entries)
+	return printWorkspacePlan(workspacePlanOutput(ctx, opts), entries)
+}
+
+func workspacePlanOutput(ctx *runtimeContext, opts workspaceCopyOptions) io.Writer {
+	if opts.PlanOutput != nil {
+		return opts.PlanOutput
+	}
+	return runtimeStdout(ctx)
+}
+
+func validateWorkspaceCopyOutInputs(callCtx context.Context, client *controlclient.Client, opts workspaceCopyOptions) (*repositorycheckout.Checkout, error) {
+	if strings.TrimSpace(opts.SandboxID) == "" {
+		return nil, errors.New("missing sandbox id")
+	}
+	if strings.TrimSpace(opts.CWD) == "" {
+		return nil, errors.New("missing local workspace root")
+	}
+	checkout, err := sandboxRepositoryCheckout(callCtx, client, opts.SandboxID)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateWorkspaceBinding(opts.Binding, opts.SandboxID, checkout); err != nil {
+		return nil, err
+	}
+	if err := validateWorkspaceCopyOutLocalRepository(opts.Repository, checkout); err != nil {
+		return nil, err
+	}
+	return checkout, nil
 }
 
 func previewWorkspaceCopyOut(callCtx context.Context, ctx *runtimeContext, client *controlclient.Client, opts workspaceCopyOptions) error {


### PR DESCRIPTION
## Summary

- add `--copy-out` and `--sync` to `cleanroom exec` and `cleanroom console`
- run Git-backed copy-out after successful and non-zero command/session exits, before auto-terminating created sandboxes
- prevalidate existing sandbox copy-out targets and keep `cleanroom create` scoped to `--copy-in`
- update the workspace sync plan with the landed PR #276 slice and this automation slice

## Tests

- `mise exec -- go test ./internal/cli ./internal/repositorychangeset`
- `mise exec -- go test ./...`
- `git diff --check`
