### PR TITLE
feat: Wire block-volume cache lookup

### DIFF
--- a/docs/plans/dependency-service-volume-caches.md
+++ b/docs/plans/dependency-service-volume-caches.md
@@ -2,7 +2,7 @@
 
 **Spec reference:** `spec.md` sections 5.1.1, 5.2, 6.4
 **Status:** Proposed
-**Last reviewed:** 2026-05-02
+**Last reviewed:** 2026-05-03
 
 ## Summary
 
@@ -700,7 +700,9 @@ Current runtime behavior after phase 1:
 
 Remaining work:
 
-- wire dependency block-volume planning into the sandbox creation runtime path
+- extend dependency block-volume runtime wiring from lookup-only planning to
+  output-volume preparation, restore, execution, and publication
+- wire service block-volume planning into the sandbox creation runtime path
 - materialize isolated declared-input projections before running cacheable
   blocks
 - implement the guest overlay write-capture runner
@@ -721,7 +723,8 @@ Firecracker implementation.
 
 The second implementation PR starts the runtime-control layer without changing
 the sandbox execution path yet. Existing dependency bootstraps still run through
-the aggregate dependency stage cache.
+the aggregate dependency stage cache, even when dependency block-volume records
+hit.
 
 Completed in phase 2:
 
@@ -733,12 +736,21 @@ Completed in phase 2:
   cache metadata fields introduced in phase 1
 - runtime fallback decision requires backend support for cache output volumes and
   overlay write capture before the future block-volume path can be selected
+- sandbox creation now evaluates dependency block-volume lookup after exact and
+  portable dependency-stage cache restore fail or miss, and before workspace
+  cache restore or fresh provisioning
+- unsupported backends and missing cache metadata stores fall back to the
+  aggregate dependency stage path before doing per-block key resolution
+- dependency block-volume lookup observability records block counts, hit counts,
+  miss counts, and logs fallback and lookup summaries
 - tests cover ordered keying, prior-block invalidation, partial cache hits, and
   fallback when backend capabilities are missing
+- `CreateSandbox` tests cover unsupported backend fallback, missing store
+  fallback, partial dependency block-volume hits, and all-hit lookup behavior
+  while confirming the aggregate dependency bootstrap still runs
 
 Remaining phase 2 work:
 
-- make dependency sandbox creation consume the block-volume plan
 - prepare and attach output volumes before VM launch
 - run missed dependency blocks from isolated input projections
 - restore hit output records before later dependency blocks run

--- a/docs/plans/dependency-service-volume-caches.md
+++ b/docs/plans/dependency-service-volume-caches.md
@@ -753,14 +753,18 @@ Completed in phase 2:
   digest, input manifest digest, normalized output declarations, ordered
   dependency output keys, and prior service output keys
 - sandbox creation now evaluates service block-volume lookup after services
-  stage restore misses and after dependency block-volume planning is available
-  for policies with dependency blocks
+  stage restore misses, including after dependency-stage cache restores, once
+  dependency block-volume planning is available for policies with dependency
+  blocks
 - service block-volume lookup observability records block counts, hit counts,
   miss counts, and logs fallback and lookup summaries
 - tests cover service keying, dependency-output invalidation, prior-service
   invalidation, partial service cache hits, unsupported backend fallback, missing
   store fallback, partial `CreateSandbox` hits, and all-hit lookup behavior while
   confirming the aggregate services bootstrap still runs
+- regression coverage proves service block-volume lookup still runs when the
+  aggregate services stage cache misses and an aggregate dependency stage cache
+  restores
 
 Remaining phase 2 work:
 

--- a/docs/plans/dependency-service-volume-caches.md
+++ b/docs/plans/dependency-service-volume-caches.md
@@ -702,7 +702,8 @@ Remaining work:
 
 - extend dependency block-volume runtime wiring from lookup-only planning to
   output-volume preparation, restore, execution, and publication
-- wire service block-volume planning into the sandbox creation runtime path
+- extend service block-volume runtime wiring from lookup-only planning to
+  output-volume preparation, restore, execution, and publication
 - materialize isolated declared-input projections before running cacheable
   blocks
 - implement the guest overlay write-capture runner
@@ -722,9 +723,8 @@ Firecracker implementation.
 ### Phase 2 PR Status
 
 The second implementation PR starts the runtime-control layer without changing
-the sandbox execution path yet. Existing dependency bootstraps still run through
-the aggregate dependency stage cache, even when dependency block-volume records
-hit.
+the sandbox execution path yet. Existing dependency and service bootstraps still
+run through the aggregate stage cache paths, even when block-volume records hit.
 
 Completed in phase 2:
 
@@ -748,6 +748,19 @@ Completed in phase 2:
 - `CreateSandbox` tests cover unsupported backend fallback, missing store
   fallback, partial dependency block-volume hits, and all-hit lookup behavior
   while confirming the aggregate dependency bootstrap still runs
+- service block-volume planner computes one cache key per ordered service block
+  from backend, runtime key, reuse namespace, policy hash, command digest, env
+  digest, input manifest digest, normalized output declarations, ordered
+  dependency output keys, and prior service output keys
+- sandbox creation now evaluates service block-volume lookup after services
+  stage restore misses and after dependency block-volume planning is available
+  for policies with dependency blocks
+- service block-volume lookup observability records block counts, hit counts,
+  miss counts, and logs fallback and lookup summaries
+- tests cover service keying, dependency-output invalidation, prior-service
+  invalidation, partial service cache hits, unsupported backend fallback, missing
+  store fallback, partial `CreateSandbox` hits, and all-hit lookup behavior while
+  confirming the aggregate services bootstrap still runs
 
 Remaining phase 2 work:
 
@@ -755,6 +768,9 @@ Remaining phase 2 work:
 - run missed dependency blocks from isolated input projections
 - restore hit output records before later dependency blocks run
 - publish output records after successful missed blocks
+- run missed service blocks from isolated input projections
+- restore hit service output records before later service blocks run
+- publish service output records after successful missed blocks
 
 ## Tests
 

--- a/internal/controlservice/dependency_volume_plan.go
+++ b/internal/controlservice/dependency_volume_plan.go
@@ -17,6 +17,8 @@ import (
 	"github.com/buildkite/cleanroom/internal/repositorybundle"
 	"github.com/buildkite/cleanroom/internal/repositorychangeset"
 	"github.com/buildkite/cleanroom/internal/repositorycheckout"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 const (
@@ -68,6 +70,59 @@ func dependencyBlockVolumeRuntimeDecisionForAdapter(adapter backend.Adapter) dep
 		}
 	}
 	return dependencyBlockVolumeRuntimeDecision{Enabled: true}
+}
+
+func (s *Service) lookupDependencyBlockVolumePlanForCreateSandbox(
+	ctx context.Context,
+	adapter backend.Adapter,
+	backendName string,
+	compiled *policy.CompiledPolicy,
+	repository *repositorycheckout.Checkout,
+	changeset *repositorychangeset.Changeset,
+	commitBundle *repositorybundle.Bundle,
+	runtimeBaseKey string,
+) {
+	blockCount := 0
+	if compiled != nil {
+		blockCount = len(compiled.Dependencies.Blocks)
+	}
+	decision := dependencyBlockVolumeRuntimeDecisionForAdapter(adapter)
+	if !decision.Enabled {
+		s.logDependencyBlockVolumeCacheFallback(backendName, blockCount, decision.FallbackReason)
+		return
+	}
+
+	if _, err := s.cacheStoreOrErr(); err != nil {
+		s.logDependencyBlockVolumeCacheFallback(backendName, blockCount, err.Error())
+		return
+	}
+
+	plan, ok, err := s.finalizeDependencyBlockVolumePlan(ctx, compiled, repository, changeset, commitBundle, backendName, runtimeBaseKey)
+	if err != nil {
+		s.logDependencyStageWarning("resolve dependency block-volume cache keys", "", err)
+		return
+	}
+	if !ok {
+		return
+	}
+
+	err = s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.lookup_dependency_block_volume_caches", cachePhaseAttributes(
+		observability.CacheStageDependency,
+		observability.CacheOperationLookup,
+		repository,
+		attribute.String(observability.AttrBackend, backendName),
+		attribute.Int("cleanroom.cache.block_count", len(plan.Blocks)),
+	), func(ctx context.Context) error {
+		var lookupErr error
+		plan, lookupErr = s.lookupDependencyBlockVolumeCaches(ctx, backendName, compiled, plan)
+		setDependencyBlockVolumeLookupSpanAttributes(ctx, plan, lookupErr)
+		return lookupErr
+	})
+	if err != nil {
+		s.logDependencyStageWarning("lookup dependency block-volume caches", "", err)
+		return
+	}
+	s.logDependencyBlockVolumeCacheLookup(backendName, plan)
 }
 
 func (s *Service) finalizeDependencyBlockVolumePlan(
@@ -201,6 +256,58 @@ func (s *Service) lookupDependencyBlockVolumeCaches(ctx context.Context, backend
 		block.CacheRecord = record
 	}
 	return out, nil
+}
+
+func dependencyBlockVolumePlanHitMissCounts(plan dependencyBlockVolumePlan) (hits, misses int) {
+	for _, block := range plan.Blocks {
+		if block.CacheHit {
+			hits++
+			continue
+		}
+		misses++
+	}
+	return hits, misses
+}
+
+func setDependencyBlockVolumeLookupSpanAttributes(ctx context.Context, plan dependencyBlockVolumePlan, err error) {
+	hits, misses := dependencyBlockVolumePlanHitMissCounts(plan)
+	result := observability.CacheResultFailed
+	if err == nil {
+		result = observability.CacheResultMiss
+		if len(plan.Blocks) > 0 && misses == 0 {
+			result = observability.CacheResultHit
+		}
+	}
+	trace.SpanFromContext(ctx).SetAttributes(
+		attribute.String(observability.AttrCacheResult, result),
+		attribute.Int("cleanroom.cache.hit_count", hits),
+		attribute.Int("cleanroom.cache.miss_count", misses),
+	)
+}
+
+func (s *Service) logDependencyBlockVolumeCacheFallback(backendName string, blockCount int, reason string) {
+	if s == nil || s.Logger == nil {
+		return
+	}
+	s.Logger.Debug("dependency block-volume cache fallback",
+		observability.LogFieldBackend, backendName,
+		"blocks", blockCount,
+		"reason", strings.TrimSpace(reason),
+	)
+}
+
+func (s *Service) logDependencyBlockVolumeCacheLookup(backendName string, plan dependencyBlockVolumePlan) {
+	if s == nil || s.Logger == nil {
+		return
+	}
+	hits, misses := dependencyBlockVolumePlanHitMissCounts(plan)
+	s.Logger.Debug("dependency block-volume cache lookup",
+		observability.LogFieldBackend, backendName,
+		"blocks", len(plan.Blocks),
+		"hits", hits,
+		"misses", misses,
+		"reuse_namespace", plan.ReuseNamespace,
+	)
 }
 
 func dependencyBlockVolumeRecordMissReason(record cachestore.Record, backendName string, compiled *policy.CompiledPolicy, block dependencyBlockVolumeBlockPlan) string {

--- a/internal/controlservice/dependency_volume_plan.go
+++ b/internal/controlservice/dependency_volume_plan.go
@@ -57,6 +57,10 @@ type dependencyBlockVolumeRuntimeDecision struct {
 }
 
 func dependencyBlockVolumeRuntimeDecisionForAdapter(adapter backend.Adapter) dependencyBlockVolumeRuntimeDecision {
+	return blockVolumeRuntimeDecisionForAdapter(adapter)
+}
+
+func blockVolumeRuntimeDecisionForAdapter(adapter backend.Adapter) dependencyBlockVolumeRuntimeDecision {
 	if adapter == nil {
 		return dependencyBlockVolumeRuntimeDecision{FallbackReason: "backend adapter unavailable"}
 	}
@@ -81,29 +85,29 @@ func (s *Service) lookupDependencyBlockVolumePlanForCreateSandbox(
 	changeset *repositorychangeset.Changeset,
 	commitBundle *repositorybundle.Bundle,
 	runtimeBaseKey string,
-) {
+) (dependencyBlockVolumePlan, bool) {
 	blockCount := 0
 	if compiled != nil {
 		blockCount = len(compiled.Dependencies.Blocks)
 	}
-	decision := dependencyBlockVolumeRuntimeDecisionForAdapter(adapter)
+	decision := blockVolumeRuntimeDecisionForAdapter(adapter)
 	if !decision.Enabled {
 		s.logDependencyBlockVolumeCacheFallback(backendName, blockCount, decision.FallbackReason)
-		return
+		return dependencyBlockVolumePlan{}, false
 	}
 
 	if _, err := s.cacheStoreOrErr(); err != nil {
 		s.logDependencyBlockVolumeCacheFallback(backendName, blockCount, err.Error())
-		return
+		return dependencyBlockVolumePlan{}, false
 	}
 
 	plan, ok, err := s.finalizeDependencyBlockVolumePlan(ctx, compiled, repository, changeset, commitBundle, backendName, runtimeBaseKey)
 	if err != nil {
 		s.logDependencyStageWarning("resolve dependency block-volume cache keys", "", err)
-		return
+		return dependencyBlockVolumePlan{}, false
 	}
 	if !ok {
-		return
+		return dependencyBlockVolumePlan{}, false
 	}
 
 	err = s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.lookup_dependency_block_volume_caches", cachePhaseAttributes(
@@ -120,9 +124,10 @@ func (s *Service) lookupDependencyBlockVolumePlanForCreateSandbox(
 	})
 	if err != nil {
 		s.logDependencyStageWarning("lookup dependency block-volume caches", "", err)
-		return
+		return dependencyBlockVolumePlan{}, false
 	}
 	s.logDependencyBlockVolumeCacheLookup(backendName, plan)
+	return plan, true
 }
 
 func (s *Service) finalizeDependencyBlockVolumePlan(

--- a/internal/controlservice/dependency_volume_plan_test.go
+++ b/internal/controlservice/dependency_volume_plan_test.go
@@ -469,6 +469,10 @@ func (s *recordingCacheStore) getReadyKeys(stage string) []string {
 	return keys
 }
 
+func (s *recordingCacheStore) resetLookups() {
+	s.lookups = nil
+}
+
 func dependencyBlockVolumeTestRecord(compiled *policy.CompiledPolicy, block dependencyBlockVolumeBlockPlan) cachestore.Record {
 	return cachestore.Record{
 		CacheKey:                block.CacheKey,

--- a/internal/controlservice/dependency_volume_plan_test.go
+++ b/internal/controlservice/dependency_volume_plan_test.go
@@ -190,6 +190,131 @@ func TestLookupDependencyBlockVolumeCachesTreatsMissingStoreAsMiss(t *testing.T)
 	}
 }
 
+func TestCreateSandboxSkipsDependencyBlockVolumeLookupWhenBackendUnsupported(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	adapter := &stubAdapter{}
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"mise.toml": "go = \"1.26.2\"\n",
+		"go.mod":    "module example.com/test\n\ngo 1.26.2\n",
+		"go.sum":    "example.com/test v0.0.0 h1:abc123\n",
+	})
+	svc := newTestService(adapter)
+	svc.RepositoryStore = mirrors
+	cacheStore := &recordingCacheStore{inner: newMemoryCacheStore()}
+	svc.CacheStore = cacheStore
+
+	if _, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Policy:             testRepositoryTwoDependencyBlocksPolicy(),
+		RepositoryCheckout: repositoryCheckout,
+	}); err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	if got := cacheStore.getReadyCount(dependencyVolumeStageName); got != 0 {
+		t.Fatalf("expected unsupported backend to skip dependency block-volume cache lookups, got %d", got)
+	}
+	if got, want := adapter.runCalls, 2; got != want {
+		t.Fatalf("expected aggregate repository + dependency bootstrap executions, got %d want %d", got, want)
+	}
+}
+
+func TestCreateSandboxFallsBackWhenDependencyBlockVolumeStoreMissing(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	adapter := dependencyBlockVolumeRuntimeAdapter()
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"mise.toml": "go = \"1.26.2\"\n",
+		"go.mod":    "module example.com/test\n\ngo 1.26.2\n",
+		"go.sum":    "example.com/test v0.0.0 h1:abc123\n",
+	})
+	svc := newTestService(adapter)
+	svc.RepositoryStore = mirrors
+	svc.CacheStore = nil
+
+	if _, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Policy:             testRepositoryTwoDependencyBlocksPolicy(),
+		RepositoryCheckout: repositoryCheckout,
+	}); err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	if got, want := adapter.runCalls, 2; got != want {
+		t.Fatalf("expected aggregate repository + dependency bootstrap executions, got %d want %d", got, want)
+	}
+}
+
+func TestCreateSandboxLooksUpDependencyBlockVolumeCaches(t *testing.T) {
+	tests := []struct {
+		name     string
+		records  int
+		wantHits int
+	}{
+		{
+			name:     "partial hit",
+			records:  1,
+			wantHits: 1,
+		},
+		{
+			name:     "all hit",
+			records:  2,
+			wantHits: 2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			adapter := dependencyBlockVolumeRuntimeAdapter()
+			mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+				"mise.toml": "go = \"1.26.2\"\n",
+				"go.mod":    "module example.com/test\n\ngo 1.26.2\n",
+				"go.sum":    "example.com/test v0.0.0 h1:abc123\n",
+			})
+			svc := newTestService(adapter)
+			svc.RepositoryStore = mirrors
+			cacheStore := &recordingCacheStore{inner: newMemoryCacheStore()}
+			svc.CacheStore = cacheStore
+
+			compiled, err := policy.FromProto(testRepositoryTwoDependencyBlocksPolicy())
+			if err != nil {
+				t.Fatalf("FromProto returned error: %v", err)
+			}
+			repository := repositorycheckout.FromProto(repositoryCheckout)
+			plan, ok, err := svc.finalizeDependencyBlockVolumePlan(context.Background(), compiled, repository, nil, nil, "firecracker", "runtime-base:test")
+			if err != nil {
+				t.Fatalf("finalizeDependencyBlockVolumePlan returned error: %v", err)
+			}
+			if !ok {
+				t.Fatal("expected dependency block-volume plan")
+			}
+			for i := 0; i < tc.records; i++ {
+				if err := cacheStore.Create(context.Background(), dependencyBlockVolumeTestRecord(compiled, plan.Blocks[i])); err != nil {
+					t.Fatalf("Create dependency block-volume record %d returned error: %v", i, err)
+				}
+			}
+
+			if _, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+				Policy:             testRepositoryTwoDependencyBlocksPolicy(),
+				RepositoryCheckout: repositoryCheckout,
+			}); err != nil {
+				t.Fatalf("CreateSandbox returned error: %v", err)
+			}
+			if got, want := cacheStore.getReadyCount(dependencyVolumeStageName), len(plan.Blocks); got != want {
+				t.Fatalf("unexpected dependency block-volume lookup count: got %d want %d", got, want)
+			}
+			if got := cacheStore.getReadyHitCount(dependencyVolumeStageName); got != tc.wantHits {
+				t.Fatalf("unexpected dependency block-volume hit count: got %d want %d", got, tc.wantHits)
+			}
+			gotKeys := cacheStore.getReadyKeys(dependencyVolumeStageName)
+			for i, wantKey := range []string{plan.Blocks[0].CacheKey, plan.Blocks[1].CacheKey} {
+				if got := gotKeys[i]; got != wantKey {
+					t.Fatalf("unexpected lookup key %d: got %q want %q", i, got, wantKey)
+				}
+			}
+			if got, want := adapter.runCalls, 2; got != want {
+				t.Fatalf("expected aggregate repository + dependency bootstrap executions, got %d want %d", got, want)
+			}
+		})
+	}
+}
+
 func TestDependencyBlockVolumeRuntimeDecisionRequiresOutputVolumesAndOverlay(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -264,6 +389,84 @@ func testRepositoryTwoDependencyBlocksPolicy() *cleanroomv1.Policy {
 		},
 	}
 	return policyProto
+}
+
+func dependencyBlockVolumeRuntimeAdapter() *portDialAdapter {
+	return &portDialAdapter{capabilities: map[string]bool{
+		backend.CapabilitySandboxCacheOutputVolumes:  true,
+		backend.CapabilitySandboxOverlayWriteCapture: true,
+	}}
+}
+
+type recordingCacheStore struct {
+	inner   cacheMetadataStore
+	lookups []recordingCacheStoreLookup
+}
+
+type recordingCacheStoreLookup struct {
+	stage    string
+	cacheKey string
+	hit      bool
+}
+
+func (s *recordingCacheStore) Create(ctx context.Context, record cachestore.Record) error {
+	return s.inner.Create(ctx, record)
+}
+
+func (s *recordingCacheStore) Upsert(ctx context.Context, record cachestore.Record) error {
+	return s.inner.Upsert(ctx, record)
+}
+
+func (s *recordingCacheStore) GetReady(ctx context.Context, stage, cacheKey string) (cachestore.Record, bool, error) {
+	record, ok, err := s.inner.GetReady(ctx, stage, cacheKey)
+	s.lookups = append(s.lookups, recordingCacheStoreLookup{
+		stage:    stage,
+		cacheKey: cacheKey,
+		hit:      ok,
+	})
+	return record, ok, err
+}
+
+func (s *recordingCacheStore) Touch(ctx context.Context, stage, cacheKey string) error {
+	return s.inner.Touch(ctx, stage, cacheKey)
+}
+
+func (s *recordingCacheStore) List(ctx context.Context) ([]cachestore.Record, error) {
+	return s.inner.List(ctx)
+}
+
+func (s *recordingCacheStore) Delete(ctx context.Context, stage, cacheKey string) error {
+	return s.inner.Delete(ctx, stage, cacheKey)
+}
+
+func (s *recordingCacheStore) getReadyCount(stage string) int {
+	count := 0
+	for _, lookup := range s.lookups {
+		if lookup.stage == stage {
+			count++
+		}
+	}
+	return count
+}
+
+func (s *recordingCacheStore) getReadyHitCount(stage string) int {
+	count := 0
+	for _, lookup := range s.lookups {
+		if lookup.stage == stage && lookup.hit {
+			count++
+		}
+	}
+	return count
+}
+
+func (s *recordingCacheStore) getReadyKeys(stage string) []string {
+	keys := make([]string, 0, len(s.lookups))
+	for _, lookup := range s.lookups {
+		if lookup.stage == stage {
+			keys = append(keys, lookup.cacheKey)
+		}
+	}
+	return keys
 }
 
 func dependencyBlockVolumeTestRecord(compiled *policy.CompiledPolicy, block dependencyBlockVolumeBlockPlan) cachestore.Record {

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -377,6 +377,8 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 	workspaceStageKey := ""
 	workspaceStageCachingEnabled := false
 	dependencyStagePlan := dependencyStagePlan{}
+	dependencyBlockVolumePlan := dependencyBlockVolumePlan{}
+	dependencyBlockVolumePlanAvailable := false
 	dependencyStageBootstrapEnabled := false
 	dependencyStageCachingEnabled := false
 	servicesStagePlan := servicesStagePlan{}
@@ -604,7 +606,17 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 			}
 
 			if dependencyStageBootstrapEnabled && restoredDependencyResp == nil {
-				s.lookupDependencyBlockVolumePlanForCreateSandbox(ctx, adapter, backendName, compiled, repository, changeset, commitBundle, workspaceStageRuntimeBaseKey)
+				dependencyBlockVolumePlan, dependencyBlockVolumePlanAvailable = s.lookupDependencyBlockVolumePlanForCreateSandbox(ctx, adapter, backendName, compiled, repository, changeset, commitBundle, workspaceStageRuntimeBaseKey)
+			}
+			if servicesStageBootstrapEnabled && restoredDependencyResp == nil {
+				decision := blockVolumeRuntimeDecisionForAdapter(adapter)
+				if !decision.Enabled {
+					s.logServiceBlockVolumeCacheFallback(backendName, len(compiled.Services.Blocks), decision.FallbackReason)
+				} else if dependencyStageBootstrapEnabled && !dependencyBlockVolumePlanAvailable {
+					s.logServiceBlockVolumeCacheFallback(backendName, len(compiled.Services.Blocks), "dependency block-volume plan unavailable")
+				} else {
+					s.lookupServiceBlockVolumePlanForCreateSandbox(ctx, backendName, compiled, repository, changeset, commitBundle, workspaceStageRuntimeBaseKey, dependencyBlockVolumePlan)
+				}
 			}
 
 			if restoredDependencyResp == nil {

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -609,14 +609,7 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 				dependencyBlockVolumePlan, dependencyBlockVolumePlanAvailable = s.lookupDependencyBlockVolumePlanForCreateSandbox(ctx, adapter, backendName, compiled, repository, changeset, commitBundle, workspaceStageRuntimeBaseKey)
 			}
 			if servicesStageBootstrapEnabled && restoredDependencyResp == nil {
-				decision := blockVolumeRuntimeDecisionForAdapter(adapter)
-				if !decision.Enabled {
-					s.logServiceBlockVolumeCacheFallback(backendName, len(compiled.Services.Blocks), decision.FallbackReason)
-				} else if dependencyStageBootstrapEnabled && !dependencyBlockVolumePlanAvailable {
-					s.logServiceBlockVolumeCacheFallback(backendName, len(compiled.Services.Blocks), "dependency block-volume plan unavailable")
-				} else {
-					s.lookupServiceBlockVolumePlanForCreateSandbox(ctx, backendName, compiled, repository, changeset, commitBundle, workspaceStageRuntimeBaseKey, dependencyBlockVolumePlan)
-				}
+				s.maybeLookupServiceBlockVolumePlanForCreateSandbox(ctx, adapter, backendName, compiled, repository, changeset, commitBundle, workspaceStageRuntimeBaseKey, dependencyStageBootstrapEnabled, dependencyBlockVolumePlan, dependencyBlockVolumePlanAvailable)
 			}
 
 			if restoredDependencyResp == nil {
@@ -689,6 +682,11 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 		sandboxID := restoredDependencyResp.GetSandbox().GetSandboxId()
 		span.SetAttributes(attribute.String("cleanroom.sandbox.id", sandboxID))
 		if servicesStageBootstrapEnabled {
+			if dependencyStageBootstrapEnabled && !dependencyBlockVolumePlanAvailable && blockVolumeRuntimeDecisionForAdapter(adapter).Enabled {
+				dependencyBlockVolumePlan, dependencyBlockVolumePlanAvailable = s.lookupDependencyBlockVolumePlanForCreateSandbox(ctx, adapter, backendName, compiled, repository, changeset, commitBundle, workspaceStageRuntimeBaseKey)
+			}
+			s.maybeLookupServiceBlockVolumePlanForCreateSandbox(ctx, adapter, backendName, compiled, repository, changeset, commitBundle, workspaceStageRuntimeBaseKey, dependencyStageBootstrapEnabled, dependencyBlockVolumePlan, dependencyBlockVolumePlanAvailable)
+
 			bootstrapAttrs := []attribute.KeyValue{
 				attribute.String(observability.AttrBackend, backendName),
 				attribute.String(observability.AttrSandboxID, sandboxID),

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -603,6 +603,10 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 				}
 			}
 
+			if dependencyStageBootstrapEnabled && restoredDependencyResp == nil {
+				s.lookupDependencyBlockVolumePlanForCreateSandbox(ctx, adapter, backendName, compiled, repository, changeset, commitBundle, workspaceStageRuntimeBaseKey)
+			}
+
 			if restoredDependencyResp == nil {
 				emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_WORKSPACE_STAGE_CACHE, "checking workspace stage cache")
 				var record cachestore.Record

--- a/internal/controlservice/service_volume_plan.go
+++ b/internal/controlservice/service_volume_plan.go
@@ -1,0 +1,323 @@
+package controlservice
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/buildkite/cleanroom/internal/cachekey"
+	"github.com/buildkite/cleanroom/internal/cachestore"
+	"github.com/buildkite/cleanroom/internal/observability"
+	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/buildkite/cleanroom/internal/repositorybundle"
+	"github.com/buildkite/cleanroom/internal/repositorychangeset"
+	"github.com/buildkite/cleanroom/internal/repositorycheckout"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const (
+	serviceVolumeStageName           = "service-volume"
+	serviceVolumeProducerVersion     = "cleanroom/service-volume-v1"
+	serviceVolumeOutputLayoutVersion = "aggregate-v1"
+)
+
+type serviceBlockVolumePlan struct {
+	ReuseNamespace       string
+	DependencyOutputKeys []string
+	Blocks               []serviceBlockVolumeBlockPlan
+}
+
+type serviceBlockVolumeBlockPlan struct {
+	BlockName                    string
+	Command                      []string
+	Env                          map[string]string
+	Inputs                       []string
+	Outputs                      policy.StageBlockOutputs
+	CacheKey                     string
+	CommandDigest                string
+	EnvDigest                    string
+	InputManifestDigest          string
+	NormalizedOutputsDigest      string
+	DependencyOutputKeysDigest   string
+	PriorServiceOutputKeysDigest string
+	OutputVolumeLayoutVersion    string
+	ProducerVersion              string
+	CacheHit                     bool
+	LookupReason                 string
+	CacheRecord                  cachestore.Record
+}
+
+func (s *Service) lookupServiceBlockVolumePlanForCreateSandbox(
+	ctx context.Context,
+	backendName string,
+	compiled *policy.CompiledPolicy,
+	repository *repositorycheckout.Checkout,
+	changeset *repositorychangeset.Changeset,
+	commitBundle *repositorybundle.Bundle,
+	runtimeBaseKey string,
+	dependencyPlan dependencyBlockVolumePlan,
+) {
+	blockCount := 0
+	if compiled != nil {
+		blockCount = len(compiled.Services.Blocks)
+	}
+	if _, err := s.cacheStoreOrErr(); err != nil {
+		s.logServiceBlockVolumeCacheFallback(backendName, blockCount, err.Error())
+		return
+	}
+
+	plan, ok, err := s.finalizeServiceBlockVolumePlan(ctx, compiled, repository, changeset, commitBundle, backendName, runtimeBaseKey, dependencyPlan)
+	if err != nil {
+		s.logServicesStageWarning("resolve service block-volume cache keys", "", err)
+		return
+	}
+	if !ok {
+		return
+	}
+
+	err = s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.lookup_service_block_volume_caches", cachePhaseAttributes(
+		observability.CacheStageServices,
+		observability.CacheOperationLookup,
+		repository,
+		attribute.String(observability.AttrBackend, backendName),
+		attribute.Int("cleanroom.cache.block_count", len(plan.Blocks)),
+	), func(ctx context.Context) error {
+		var lookupErr error
+		plan, lookupErr = s.lookupServiceBlockVolumeCaches(ctx, backendName, compiled, plan)
+		setServiceBlockVolumeLookupSpanAttributes(ctx, plan, lookupErr)
+		return lookupErr
+	})
+	if err != nil {
+		s.logServicesStageWarning("lookup service block-volume caches", "", err)
+		return
+	}
+	s.logServiceBlockVolumeCacheLookup(backendName, plan)
+}
+
+func (s *Service) finalizeServiceBlockVolumePlan(
+	ctx context.Context,
+	compiled *policy.CompiledPolicy,
+	repository *repositorycheckout.Checkout,
+	changeset *repositorychangeset.Changeset,
+	commitBundle *repositorybundle.Bundle,
+	backendName string,
+	runtimeBaseKey string,
+	dependencyPlan dependencyBlockVolumePlan,
+) (serviceBlockVolumePlan, bool, error) {
+	if compiled == nil || repository == nil || len(compiled.Services.Blocks) == 0 || strings.TrimSpace(runtimeBaseKey) == "" {
+		return serviceBlockVolumePlan{}, false, nil
+	}
+
+	normalizedRepository := normalizeRepositoryCheckoutForComparison(repository)
+	reuseNamespace := cachekey.ReuseNamespace("", normalizedRepository.RemoteURL)
+	dependencyOutputKeys := dependencyBlockVolumePlanCacheKeys(dependencyPlan)
+	plan := serviceBlockVolumePlan{
+		ReuseNamespace:       reuseNamespace,
+		DependencyOutputKeys: dependencyOutputKeys,
+	}
+	priorServiceOutputKeys := make([]string, 0, len(compiled.Services.Blocks))
+
+	for _, block := range compiled.Services.Blocks {
+		blockPlan, err := s.finalizeServiceBlockVolumeBlockPlan(ctx, compiled, repository, changeset, commitBundle, backendName, runtimeBaseKey, reuseNamespace, dependencyOutputKeys, block, priorServiceOutputKeys)
+		if err != nil {
+			return serviceBlockVolumePlan{}, false, err
+		}
+		plan.Blocks = append(plan.Blocks, blockPlan)
+		priorServiceOutputKeys = append(priorServiceOutputKeys, blockPlan.CacheKey)
+	}
+
+	return plan, true, nil
+}
+
+func (s *Service) finalizeServiceBlockVolumeBlockPlan(
+	ctx context.Context,
+	compiled *policy.CompiledPolicy,
+	repository *repositorycheckout.Checkout,
+	changeset *repositorychangeset.Changeset,
+	commitBundle *repositorybundle.Bundle,
+	backendName string,
+	runtimeBaseKey string,
+	reuseNamespace string,
+	dependencyOutputKeys []string,
+	block policy.StageBlock,
+	priorServiceOutputKeys []string,
+) (serviceBlockVolumeBlockPlan, error) {
+	inputDigest, err := s.stageKeyFilesDigest(ctx, repository, changeset, commitBundle, block.Inputs.Files, serviceVolumeStageName+" "+block.Name)
+	if err != nil {
+		return serviceBlockVolumeBlockPlan{}, err
+	}
+	commandDigest, err := digestCanonicalJSON(block.Command)
+	if err != nil {
+		return serviceBlockVolumeBlockPlan{}, fmt.Errorf("digest service block %q command: %w", block.Name, err)
+	}
+	envDigest, err := digestCanonicalJSON(sortedEnvEntries(block.Env))
+	if err != nil {
+		return serviceBlockVolumeBlockPlan{}, fmt.Errorf("digest service block %q env: %w", block.Name, err)
+	}
+	outputsDigest, err := digestCanonicalJSON(block.Outputs)
+	if err != nil {
+		return serviceBlockVolumeBlockPlan{}, fmt.Errorf("digest service block %q outputs: %w", block.Name, err)
+	}
+	dependencyDigest, err := digestCanonicalJSON(append([]string{}, dependencyOutputKeys...))
+	if err != nil {
+		return serviceBlockVolumeBlockPlan{}, fmt.Errorf("digest service block %q dependency output keys: %w", block.Name, err)
+	}
+	priorDigest, err := digestCanonicalJSON(append([]string{}, priorServiceOutputKeys...))
+	if err != nil {
+		return serviceBlockVolumeBlockPlan{}, fmt.Errorf("digest service block %q prior output keys: %w", block.Name, err)
+	}
+
+	cacheKey := cachekey.ServiceVolumeKey(cachekey.ServiceVolumeInputs{
+		Backend:                      strings.TrimSpace(backendName),
+		RuntimeKey:                   strings.TrimSpace(runtimeBaseKey),
+		ReuseNamespace:               strings.TrimSpace(reuseNamespace),
+		CompiledPolicyHash:           strings.TrimSpace(compiled.Hash),
+		BlockName:                    strings.TrimSpace(block.Name),
+		CommandDigest:                commandDigest,
+		EnvDigest:                    envDigest,
+		InputManifestDigest:          strings.TrimSpace(inputDigest),
+		NormalizedOutputsDigest:      outputsDigest,
+		DependencyOutputKeysDigest:   dependencyDigest,
+		PriorServiceOutputKeysDigest: priorDigest,
+		OutputVolumeLayoutVersion:    serviceVolumeOutputLayoutVersion,
+		ProducerVersion:              serviceVolumeProducerVersion,
+	})
+	if strings.TrimSpace(cacheKey) == "" {
+		return serviceBlockVolumeBlockPlan{}, fmt.Errorf("service block %q produced an empty cache key", block.Name)
+	}
+
+	return serviceBlockVolumeBlockPlan{
+		BlockName:                    block.Name,
+		Command:                      append([]string(nil), block.Command...),
+		Env:                          cloneDependencyBlockEnv(block.Env),
+		Inputs:                       append([]string(nil), block.Inputs.Files...),
+		Outputs:                      cloneStageBlockOutputs(block.Outputs),
+		CacheKey:                     cacheKey,
+		CommandDigest:                commandDigest,
+		EnvDigest:                    envDigest,
+		InputManifestDigest:          strings.TrimSpace(inputDigest),
+		NormalizedOutputsDigest:      outputsDigest,
+		DependencyOutputKeysDigest:   dependencyDigest,
+		PriorServiceOutputKeysDigest: priorDigest,
+		OutputVolumeLayoutVersion:    serviceVolumeOutputLayoutVersion,
+		ProducerVersion:              serviceVolumeProducerVersion,
+	}, nil
+}
+
+func (s *Service) lookupServiceBlockVolumeCaches(ctx context.Context, backendName string, compiled *policy.CompiledPolicy, plan serviceBlockVolumePlan) (serviceBlockVolumePlan, error) {
+	if len(plan.Blocks) == 0 {
+		return plan, nil
+	}
+	store, err := s.cacheStoreOrErr()
+	if err != nil {
+		return plan, nil
+	}
+
+	out := serviceBlockVolumePlan{
+		ReuseNamespace:       plan.ReuseNamespace,
+		DependencyOutputKeys: append([]string(nil), plan.DependencyOutputKeys...),
+		Blocks:               make([]serviceBlockVolumeBlockPlan, len(plan.Blocks)),
+	}
+	copy(out.Blocks, plan.Blocks)
+	for i := range out.Blocks {
+		block := &out.Blocks[i]
+		record, ok, err := store.GetReady(ctx, serviceVolumeStageName, block.CacheKey)
+		if err != nil {
+			return out, err
+		}
+		if !ok {
+			block.LookupReason = observability.CacheLookupReasonRecordNotFound
+			continue
+		}
+		if reason := serviceBlockVolumeRecordMissReason(record, backendName, compiled, *block); reason != "" {
+			block.LookupReason = reason
+			continue
+		}
+		block.CacheHit = true
+		block.LookupReason = ""
+		block.CacheRecord = record
+	}
+	return out, nil
+}
+
+func dependencyBlockVolumePlanCacheKeys(plan dependencyBlockVolumePlan) []string {
+	if len(plan.Blocks) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(plan.Blocks))
+	for _, block := range plan.Blocks {
+		keys = append(keys, block.CacheKey)
+	}
+	return keys
+}
+
+func serviceBlockVolumePlanHitMissCounts(plan serviceBlockVolumePlan) (hits, misses int) {
+	for _, block := range plan.Blocks {
+		if block.CacheHit {
+			hits++
+			continue
+		}
+		misses++
+	}
+	return hits, misses
+}
+
+func setServiceBlockVolumeLookupSpanAttributes(ctx context.Context, plan serviceBlockVolumePlan, err error) {
+	hits, misses := serviceBlockVolumePlanHitMissCounts(plan)
+	result := observability.CacheResultFailed
+	if err == nil {
+		result = observability.CacheResultMiss
+		if len(plan.Blocks) > 0 && misses == 0 {
+			result = observability.CacheResultHit
+		}
+	}
+	trace.SpanFromContext(ctx).SetAttributes(
+		attribute.String(observability.AttrCacheResult, result),
+		attribute.Int("cleanroom.cache.hit_count", hits),
+		attribute.Int("cleanroom.cache.miss_count", misses),
+	)
+}
+
+func (s *Service) logServiceBlockVolumeCacheFallback(backendName string, blockCount int, reason string) {
+	if s == nil || s.Logger == nil {
+		return
+	}
+	s.Logger.Debug("service block-volume cache fallback",
+		observability.LogFieldBackend, backendName,
+		"blocks", blockCount,
+		"reason", strings.TrimSpace(reason),
+	)
+}
+
+func (s *Service) logServiceBlockVolumeCacheLookup(backendName string, plan serviceBlockVolumePlan) {
+	if s == nil || s.Logger == nil {
+		return
+	}
+	hits, misses := serviceBlockVolumePlanHitMissCounts(plan)
+	s.Logger.Debug("service block-volume cache lookup",
+		observability.LogFieldBackend, backendName,
+		"blocks", len(plan.Blocks),
+		"hits", hits,
+		"misses", misses,
+		"reuse_namespace", plan.ReuseNamespace,
+	)
+}
+
+func serviceBlockVolumeRecordMissReason(record cachestore.Record, backendName string, compiled *policy.CompiledPolicy, block serviceBlockVolumeBlockPlan) string {
+	if strings.TrimSpace(record.Backend) != strings.TrimSpace(backendName) {
+		return observability.CacheLookupReasonBackendMismatch
+	}
+	if compiled == nil || strings.TrimSpace(record.PolicyHash) != strings.TrimSpace(compiled.Hash) {
+		return observability.CacheLookupReasonPolicyHashMismatch
+	}
+	if strings.TrimSpace(record.InputManifestDigest) != strings.TrimSpace(block.InputManifestDigest) ||
+		strings.TrimSpace(record.CommandDigest) != strings.TrimSpace(block.CommandDigest) ||
+		strings.TrimSpace(record.EnvDigest) != strings.TrimSpace(block.EnvDigest) ||
+		strings.TrimSpace(record.NormalizedOutputsDigest) != strings.TrimSpace(block.NormalizedOutputsDigest) ||
+		strings.TrimSpace(record.ProducerVersion) != strings.TrimSpace(block.ProducerVersion) ||
+		len(record.OutputRecords) == 0 {
+		return observability.CacheLookupReasonRecordNotFound
+	}
+	return ""
+}

--- a/internal/controlservice/service_volume_plan.go
+++ b/internal/controlservice/service_volume_plan.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/buildkite/cleanroom/internal/backend"
 	"github.com/buildkite/cleanroom/internal/cachekey"
 	"github.com/buildkite/cleanroom/internal/cachestore"
 	"github.com/buildkite/cleanroom/internal/observability"
@@ -46,6 +47,35 @@ type serviceBlockVolumeBlockPlan struct {
 	CacheHit                     bool
 	LookupReason                 string
 	CacheRecord                  cachestore.Record
+}
+
+func (s *Service) maybeLookupServiceBlockVolumePlanForCreateSandbox(
+	ctx context.Context,
+	adapter backend.Adapter,
+	backendName string,
+	compiled *policy.CompiledPolicy,
+	repository *repositorycheckout.Checkout,
+	changeset *repositorychangeset.Changeset,
+	commitBundle *repositorybundle.Bundle,
+	runtimeBaseKey string,
+	dependencyStageBootstrapEnabled bool,
+	dependencyPlan dependencyBlockVolumePlan,
+	dependencyPlanAvailable bool,
+) {
+	blockCount := 0
+	if compiled != nil {
+		blockCount = len(compiled.Services.Blocks)
+	}
+	decision := blockVolumeRuntimeDecisionForAdapter(adapter)
+	if !decision.Enabled {
+		s.logServiceBlockVolumeCacheFallback(backendName, blockCount, decision.FallbackReason)
+		return
+	}
+	if dependencyStageBootstrapEnabled && !dependencyPlanAvailable {
+		s.logServiceBlockVolumeCacheFallback(backendName, blockCount, "dependency block-volume plan unavailable")
+		return
+	}
+	s.lookupServiceBlockVolumePlanForCreateSandbox(ctx, backendName, compiled, repository, changeset, commitBundle, runtimeBaseKey, dependencyPlan)
 }
 
 func (s *Service) lookupServiceBlockVolumePlanForCreateSandbox(

--- a/internal/controlservice/service_volume_plan_test.go
+++ b/internal/controlservice/service_volume_plan_test.go
@@ -324,6 +324,88 @@ func TestCreateSandboxLooksUpServiceBlockVolumeCaches(t *testing.T) {
 	}
 }
 
+func TestCreateSandboxLooksUpServiceBlockVolumesAfterDependencyStageRestore(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	adapter := dependencyBlockVolumeRuntimeAdapter()
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"mise.toml":           "go = \"1.26.2\"\n",
+		"go.mod":              "module example.com/test\n\ngo 1.26.2\n",
+		"go.sum":              "example.com/test v0.0.0 h1:abc123\n",
+		"docker-compose.yml":  "services:\n  postgres:\n    image: postgres:17\n",
+		"db/schema.sql":       "create table widgets (id serial primary key);\n",
+		"db/seed.sql":         "insert into widgets default values;\n",
+		"scripts/prepare-db":  "#!/bin/sh\ntrue\n",
+		"scripts/prepare-app": "#!/bin/sh\ntrue\n",
+	})
+	svc := newTestServiceWithSnapshotStore(adapter, newMemorySnapshotStore())
+	svc.RepositoryStore = mirrors
+	cacheStore := &recordingCacheStore{inner: newMemoryCacheStore()}
+	svc.CacheStore = cacheStore
+
+	req := &cleanroomv1.CreateSandboxRequest{
+		Policy:             testRepositoryTwoDependencyTwoServiceBlocksPolicy(),
+		RepositoryCheckout: repositoryCheckout,
+	}
+	if _, err := svc.CreateSandbox(context.Background(), req); err != nil {
+		t.Fatalf("first CreateSandbox returned error: %v", err)
+	}
+
+	records, err := cacheStore.List(context.Background())
+	if err != nil {
+		t.Fatalf("List cache records returned error: %v", err)
+	}
+	for _, record := range records {
+		if record.Stage == servicesStageName {
+			if err := cacheStore.Delete(context.Background(), record.Stage, record.CacheKey); err != nil {
+				t.Fatalf("Delete services cache record returned error: %v", err)
+			}
+		}
+	}
+
+	compiled, err := policy.FromProto(testRepositoryTwoDependencyTwoServiceBlocksPolicy())
+	if err != nil {
+		t.Fatalf("FromProto returned error: %v", err)
+	}
+	repository := repositorycheckout.FromProto(repositoryCheckout)
+	dependencyPlan, ok, err := svc.finalizeDependencyBlockVolumePlan(context.Background(), compiled, repository, nil, nil, "firecracker", "runtime-base:test")
+	if err != nil {
+		t.Fatalf("finalizeDependencyBlockVolumePlan returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected dependency block-volume plan")
+	}
+	servicePlan, ok, err := svc.finalizeServiceBlockVolumePlan(context.Background(), compiled, repository, nil, nil, "firecracker", "runtime-base:test", dependencyPlan)
+	if err != nil {
+		t.Fatalf("finalizeServiceBlockVolumePlan returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected service block-volume plan")
+	}
+	for i := range servicePlan.Blocks {
+		if err := cacheStore.Create(context.Background(), serviceBlockVolumeTestRecord(compiled, servicePlan.Blocks[i])); err != nil {
+			t.Fatalf("Create service block-volume record %d returned error: %v", i, err)
+		}
+	}
+	cacheStore.resetLookups()
+
+	secondResp, err := svc.CreateSandbox(context.Background(), req)
+	if err != nil {
+		t.Fatalf("second CreateSandbox returned error: %v", err)
+	}
+	if got, want := secondResp.GetSourceKind(), "dependency stage cache"; got != want {
+		t.Fatalf("unexpected response source kind: got %q want %q", got, want)
+	}
+	if got, want := cacheStore.getReadyCount(serviceVolumeStageName), len(servicePlan.Blocks); got != want {
+		t.Fatalf("unexpected service block-volume lookup count after dependency restore: got %d want %d", got, want)
+	}
+	if got, want := cacheStore.getReadyHitCount(serviceVolumeStageName), len(servicePlan.Blocks); got != want {
+		t.Fatalf("unexpected service block-volume hit count after dependency restore: got %d want %d", got, want)
+	}
+	if got, want := adapter.runCalls, 4; got != want {
+		t.Fatalf("expected aggregate services bootstrap to still run after dependency restore, got %d want %d", got, want)
+	}
+}
+
 func testRepositoryTwoDependencyTwoServiceBlocksPolicy() *cleanroomv1.Policy {
 	policyProto := testRepositoryTwoDependencyBlocksPolicy()
 	policyProto.Docker = &cleanroomv1.PolicyDocker{Required: true}

--- a/internal/controlservice/service_volume_plan_test.go
+++ b/internal/controlservice/service_volume_plan_test.go
@@ -1,0 +1,390 @@
+package controlservice
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/cachestore"
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+	"github.com/buildkite/cleanroom/internal/observability"
+	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/buildkite/cleanroom/internal/repositorycheckout"
+)
+
+func TestFinalizeServiceBlockVolumePlanBuildsOrderedKeys(t *testing.T) {
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"mise.toml":           "go = \"1.26.2\"\n",
+		"go.mod":              "module example.com/test\n\ngo 1.26.2\n",
+		"go.sum":              "example.com/test v0.0.0 h1:abc123\n",
+		"docker-compose.yml":  "services:\n  postgres:\n    image: postgres:17\n",
+		"db/schema.sql":       "create table widgets (id serial primary key);\n",
+		"db/seed.sql":         "insert into widgets default values;\n",
+		"scripts/prepare-db":  "#!/bin/sh\ntrue\n",
+		"scripts/prepare-app": "#!/bin/sh\ntrue\n",
+	})
+	svc := newTestService(&stubAdapter{})
+	svc.RepositoryStore = mirrors
+
+	compiled, err := policy.FromProto(testRepositoryTwoDependencyTwoServiceBlocksPolicy())
+	if err != nil {
+		t.Fatalf("FromProto returned error: %v", err)
+	}
+	repository := repositorycheckout.FromProto(repositoryCheckout)
+	dependencyPlan, ok, err := svc.finalizeDependencyBlockVolumePlan(context.Background(), compiled, repository, nil, nil, "firecracker", "runtime-base:test")
+	if err != nil {
+		t.Fatalf("finalizeDependencyBlockVolumePlan returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected dependency block-volume plan")
+	}
+
+	plan, ok, err := svc.finalizeServiceBlockVolumePlan(context.Background(), compiled, repository, nil, nil, "firecracker", "runtime-base:test", dependencyPlan)
+	if err != nil {
+		t.Fatalf("finalizeServiceBlockVolumePlan returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected service block-volume plan")
+	}
+	if got, want := plan.ReuseNamespace, "https://github.com/buildkite/cleanroom.git"; got != want {
+		t.Fatalf("unexpected reuse namespace: got %q want %q", got, want)
+	}
+	if got, want := len(plan.Blocks), 2; got != want {
+		t.Fatalf("unexpected service block count: got %d want %d", got, want)
+	}
+	if got, want := len(plan.DependencyOutputKeys), len(dependencyPlan.Blocks); got != want {
+		t.Fatalf("unexpected dependency output key count: got %d want %d", got, want)
+	}
+
+	first := plan.Blocks[0]
+	second := plan.Blocks[1]
+	if first.CacheKey == "" || second.CacheKey == "" {
+		t.Fatalf("expected non-empty block cache keys: first=%q second=%q", first.CacheKey, second.CacheKey)
+	}
+	if first.CacheKey == second.CacheKey {
+		t.Fatalf("expected distinct service block cache keys, got %q", first.CacheKey)
+	}
+	dependencyKeysDigest, err := digestCanonicalJSON(dependencyBlockVolumePlanCacheKeys(dependencyPlan))
+	if err != nil {
+		t.Fatalf("digest dependency output keys: %v", err)
+	}
+	if got := first.DependencyOutputKeysDigest; got != dependencyKeysDigest {
+		t.Fatalf("unexpected dependency output digest: got %q want %q", got, dependencyKeysDigest)
+	}
+	emptyPriorDigest, err := digestCanonicalJSON([]string{})
+	if err != nil {
+		t.Fatalf("digest empty prior keys: %v", err)
+	}
+	if got := first.PriorServiceOutputKeysDigest; got != emptyPriorDigest {
+		t.Fatalf("unexpected first prior output digest: got %q want %q", got, emptyPriorDigest)
+	}
+	firstKeyDigest, err := digestCanonicalJSON([]string{first.CacheKey})
+	if err != nil {
+		t.Fatalf("digest first cache key: %v", err)
+	}
+	if got := second.PriorServiceOutputKeysDigest; got != firstKeyDigest {
+		t.Fatalf("unexpected second prior output digest: got %q want %q", got, firstKeyDigest)
+	}
+	for _, block := range plan.Blocks {
+		for name, value := range map[string]string{
+			"command": block.CommandDigest,
+			"env":     block.EnvDigest,
+			"inputs":  block.InputManifestDigest,
+			"outputs": block.NormalizedOutputsDigest,
+		} {
+			if !strings.HasPrefix(value, "sha256:") {
+				t.Fatalf("expected %s digest for block %q, got %q", name, block.BlockName, value)
+			}
+		}
+	}
+
+	mutatedDependencyPlan := dependencyPlan
+	mutatedDependencyPlan.Blocks = append([]dependencyBlockVolumeBlockPlan(nil), dependencyPlan.Blocks...)
+	mutatedDependencyPlan.Blocks[0].CacheKey = "dependency-volume:v1:different"
+	mutatedPlan, ok, err := svc.finalizeServiceBlockVolumePlan(context.Background(), compiled, repository, nil, nil, "firecracker", "runtime-base:test", mutatedDependencyPlan)
+	if err != nil {
+		t.Fatalf("finalizeServiceBlockVolumePlan mutated returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected mutated service block-volume plan")
+	}
+	if got, want := mutatedPlan.Blocks[0].CacheKey, first.CacheKey; got == want {
+		t.Fatalf("expected first service block key to change after dependency output key mutation, got %q", got)
+	}
+}
+
+func TestLookupServiceBlockVolumeCachesReportsPartialHit(t *testing.T) {
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"mise.toml":           "go = \"1.26.2\"\n",
+		"go.mod":              "module example.com/test\n\ngo 1.26.2\n",
+		"go.sum":              "example.com/test v0.0.0 h1:abc123\n",
+		"docker-compose.yml":  "services:\n  postgres:\n    image: postgres:17\n",
+		"db/schema.sql":       "create table widgets (id serial primary key);\n",
+		"db/seed.sql":         "insert into widgets default values;\n",
+		"scripts/prepare-db":  "#!/bin/sh\ntrue\n",
+		"scripts/prepare-app": "#!/bin/sh\ntrue\n",
+	})
+	svc := newTestService(&stubAdapter{})
+	svc.RepositoryStore = mirrors
+
+	compiled, err := policy.FromProto(testRepositoryTwoDependencyTwoServiceBlocksPolicy())
+	if err != nil {
+		t.Fatalf("FromProto returned error: %v", err)
+	}
+	repository := repositorycheckout.FromProto(repositoryCheckout)
+	dependencyPlan, ok, err := svc.finalizeDependencyBlockVolumePlan(context.Background(), compiled, repository, nil, nil, "firecracker", "runtime-base:test")
+	if err != nil {
+		t.Fatalf("finalizeDependencyBlockVolumePlan returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected dependency block-volume plan")
+	}
+	plan, ok, err := svc.finalizeServiceBlockVolumePlan(context.Background(), compiled, repository, nil, nil, "firecracker", "runtime-base:test", dependencyPlan)
+	if err != nil {
+		t.Fatalf("finalizeServiceBlockVolumePlan returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected service block-volume plan")
+	}
+
+	first := plan.Blocks[0]
+	cacheStore, ok := svc.CacheStore.(*memoryCacheStore)
+	if !ok {
+		t.Fatalf("expected memory cache store, got %T", svc.CacheStore)
+	}
+	if err := cacheStore.Create(context.Background(), serviceBlockVolumeTestRecord(compiled, first)); err != nil {
+		t.Fatalf("Create cache record returned error: %v", err)
+	}
+
+	lookedUp, err := svc.lookupServiceBlockVolumeCaches(context.Background(), "firecracker", compiled, plan)
+	if err != nil {
+		t.Fatalf("lookupServiceBlockVolumeCaches returned error: %v", err)
+	}
+	if got, want := len(lookedUp.Blocks), 2; got != want {
+		t.Fatalf("unexpected looked up block count: got %d want %d", got, want)
+	}
+	if !lookedUp.Blocks[0].CacheHit {
+		t.Fatalf("expected first block cache hit, reason=%q", lookedUp.Blocks[0].LookupReason)
+	}
+	if lookedUp.Blocks[0].CacheRecord.CacheKey != first.CacheKey {
+		t.Fatalf("unexpected first block record key: got %q want %q", lookedUp.Blocks[0].CacheRecord.CacheKey, first.CacheKey)
+	}
+	if lookedUp.Blocks[1].CacheHit {
+		t.Fatal("did not expect second block cache hit")
+	}
+	if got, want := lookedUp.Blocks[1].LookupReason, observability.CacheLookupReasonRecordNotFound; got != want {
+		t.Fatalf("unexpected second block miss reason: got %q want %q", got, want)
+	}
+}
+
+func TestCreateSandboxSkipsServiceBlockVolumeLookupWhenBackendUnsupported(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	adapter := &stubAdapter{}
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"mise.toml":           "go = \"1.26.2\"\n",
+		"go.mod":              "module example.com/test\n\ngo 1.26.2\n",
+		"go.sum":              "example.com/test v0.0.0 h1:abc123\n",
+		"docker-compose.yml":  "services:\n  postgres:\n    image: postgres:17\n",
+		"db/schema.sql":       "create table widgets (id serial primary key);\n",
+		"db/seed.sql":         "insert into widgets default values;\n",
+		"scripts/prepare-db":  "#!/bin/sh\ntrue\n",
+		"scripts/prepare-app": "#!/bin/sh\ntrue\n",
+	})
+	svc := newTestService(adapter)
+	svc.RepositoryStore = mirrors
+	cacheStore := &recordingCacheStore{inner: newMemoryCacheStore()}
+	svc.CacheStore = cacheStore
+
+	if _, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Policy:             testRepositoryTwoDependencyTwoServiceBlocksPolicy(),
+		RepositoryCheckout: repositoryCheckout,
+	}); err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	if got := cacheStore.getReadyCount(serviceVolumeStageName); got != 0 {
+		t.Fatalf("expected unsupported backend to skip service block-volume cache lookups, got %d", got)
+	}
+	if got, want := adapter.runCalls, 3; got != want {
+		t.Fatalf("expected aggregate repository + dependency + services bootstrap executions, got %d want %d", got, want)
+	}
+}
+
+func TestCreateSandboxFallsBackWhenServiceBlockVolumeStoreMissing(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	adapter := dependencyBlockVolumeRuntimeAdapter()
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"mise.toml":           "go = \"1.26.2\"\n",
+		"go.mod":              "module example.com/test\n\ngo 1.26.2\n",
+		"go.sum":              "example.com/test v0.0.0 h1:abc123\n",
+		"docker-compose.yml":  "services:\n  postgres:\n    image: postgres:17\n",
+		"db/schema.sql":       "create table widgets (id serial primary key);\n",
+		"db/seed.sql":         "insert into widgets default values;\n",
+		"scripts/prepare-db":  "#!/bin/sh\ntrue\n",
+		"scripts/prepare-app": "#!/bin/sh\ntrue\n",
+	})
+	svc := newTestService(adapter)
+	svc.RepositoryStore = mirrors
+	svc.CacheStore = nil
+
+	if _, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Policy:             testRepositoryTwoDependencyTwoServiceBlocksPolicy(),
+		RepositoryCheckout: repositoryCheckout,
+	}); err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	if got, want := adapter.runCalls, 3; got != want {
+		t.Fatalf("expected aggregate repository + dependency + services bootstrap executions, got %d want %d", got, want)
+	}
+}
+
+func TestCreateSandboxLooksUpServiceBlockVolumeCaches(t *testing.T) {
+	tests := []struct {
+		name     string
+		records  int
+		wantHits int
+	}{
+		{
+			name:     "partial hit",
+			records:  1,
+			wantHits: 1,
+		},
+		{
+			name:     "all hit",
+			records:  2,
+			wantHits: 2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			adapter := dependencyBlockVolumeRuntimeAdapter()
+			mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+				"mise.toml":           "go = \"1.26.2\"\n",
+				"go.mod":              "module example.com/test\n\ngo 1.26.2\n",
+				"go.sum":              "example.com/test v0.0.0 h1:abc123\n",
+				"docker-compose.yml":  "services:\n  postgres:\n    image: postgres:17\n",
+				"db/schema.sql":       "create table widgets (id serial primary key);\n",
+				"db/seed.sql":         "insert into widgets default values;\n",
+				"scripts/prepare-db":  "#!/bin/sh\ntrue\n",
+				"scripts/prepare-app": "#!/bin/sh\ntrue\n",
+			})
+			svc := newTestService(adapter)
+			svc.RepositoryStore = mirrors
+			cacheStore := &recordingCacheStore{inner: newMemoryCacheStore()}
+			svc.CacheStore = cacheStore
+
+			compiled, err := policy.FromProto(testRepositoryTwoDependencyTwoServiceBlocksPolicy())
+			if err != nil {
+				t.Fatalf("FromProto returned error: %v", err)
+			}
+			repository := repositorycheckout.FromProto(repositoryCheckout)
+			dependencyPlan, ok, err := svc.finalizeDependencyBlockVolumePlan(context.Background(), compiled, repository, nil, nil, "firecracker", "runtime-base:test")
+			if err != nil {
+				t.Fatalf("finalizeDependencyBlockVolumePlan returned error: %v", err)
+			}
+			if !ok {
+				t.Fatal("expected dependency block-volume plan")
+			}
+			plan, ok, err := svc.finalizeServiceBlockVolumePlan(context.Background(), compiled, repository, nil, nil, "firecracker", "runtime-base:test", dependencyPlan)
+			if err != nil {
+				t.Fatalf("finalizeServiceBlockVolumePlan returned error: %v", err)
+			}
+			if !ok {
+				t.Fatal("expected service block-volume plan")
+			}
+			for i := 0; i < tc.records; i++ {
+				if err := cacheStore.Create(context.Background(), serviceBlockVolumeTestRecord(compiled, plan.Blocks[i])); err != nil {
+					t.Fatalf("Create service block-volume record %d returned error: %v", i, err)
+				}
+			}
+
+			if _, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+				Policy:             testRepositoryTwoDependencyTwoServiceBlocksPolicy(),
+				RepositoryCheckout: repositoryCheckout,
+			}); err != nil {
+				t.Fatalf("CreateSandbox returned error: %v", err)
+			}
+			if got, want := cacheStore.getReadyCount(serviceVolumeStageName), len(plan.Blocks); got != want {
+				t.Fatalf("unexpected service block-volume lookup count: got %d want %d", got, want)
+			}
+			if got := cacheStore.getReadyHitCount(serviceVolumeStageName); got != tc.wantHits {
+				t.Fatalf("unexpected service block-volume hit count: got %d want %d", got, tc.wantHits)
+			}
+			gotKeys := cacheStore.getReadyKeys(serviceVolumeStageName)
+			for i, wantKey := range []string{plan.Blocks[0].CacheKey, plan.Blocks[1].CacheKey} {
+				if got := gotKeys[i]; got != wantKey {
+					t.Fatalf("unexpected lookup key %d: got %q want %q", i, got, wantKey)
+				}
+			}
+			if got, want := adapter.runCalls, 3; got != want {
+				t.Fatalf("expected aggregate repository + dependency + services bootstrap executions, got %d want %d", got, want)
+			}
+		})
+	}
+}
+
+func testRepositoryTwoDependencyTwoServiceBlocksPolicy() *cleanroomv1.Policy {
+	policyProto := testRepositoryTwoDependencyBlocksPolicy()
+	policyProto.Docker = &cleanroomv1.PolicyDocker{Required: true}
+	policyProto.Services = &cleanroomv1.PolicyServices{
+		Blocks: []*cleanroomv1.PolicyBlock{
+			{
+				Name:    "postgres-data",
+				Command: []string{"./scripts/prepare-db"},
+				Inputs: &cleanroomv1.PolicyBlockInputs{
+					Files: []string{"docker-compose.yml", "db/schema.sql", "scripts/prepare-db"},
+				},
+				Env: map[string]string{
+					"PGDATA": "/var/lib/cleanroom/services/postgres",
+				},
+				Outputs: &cleanroomv1.PolicyBlockOutputs{
+					Dirs: []string{"/var/lib/cleanroom/services/postgres"},
+				},
+			},
+			{
+				Name:    "app-service",
+				Command: []string{"./scripts/prepare-app"},
+				Inputs: &cleanroomv1.PolicyBlockInputs{
+					Files: []string{"docker-compose.yml", "db/seed.sql", "scripts/prepare-app"},
+				},
+				Env: map[string]string{
+					"APP_SERVICE_DATA": "/var/lib/cleanroom/services/app",
+				},
+				Outputs: &cleanroomv1.PolicyBlockOutputs{
+					Dirs: []string{"/var/lib/cleanroom/services/app"},
+				},
+			},
+		},
+	}
+	return policyProto
+}
+
+func serviceBlockVolumeTestRecord(compiled *policy.CompiledPolicy, block serviceBlockVolumeBlockPlan) cachestore.Record {
+	return cachestore.Record{
+		CacheKey:                block.CacheKey,
+		Stage:                   serviceVolumeStageName,
+		State:                   cacheStateReady,
+		BackingSnapshotID:       "service-volume-snapshot",
+		Backend:                 "firecracker",
+		PolicyHash:              compiled.Hash,
+		Policy:                  compiled.ToProto(),
+		StorageDriver:           "file",
+		StorageRef:              "/snapshots/" + block.BlockName + ".ext4",
+		InputManifestDigest:     block.InputManifestDigest,
+		CommandDigest:           block.CommandDigest,
+		EnvDigest:               block.EnvDigest,
+		NormalizedOutputsDigest: block.NormalizedOutputsDigest,
+		OutputRecords: []cachestore.OutputRecord{
+			{
+				Kind:          "dir",
+				Path:          block.Outputs.Dirs[0],
+				VolumeSubpath: "dirs/0",
+				StorageDriver: "file",
+				StorageRef:    "/snapshots/" + block.BlockName + ".ext4",
+				SnapshotRef:   "snapshot:" + block.BlockName,
+			},
+		},
+		ProducerVersion: block.ProducerVersion,
+	}
+}


### PR DESCRIPTION
## Summary
- Wire `CreateSandbox` to evaluate dependency block-volume cache lookup after exact and portable dependency-stage cache restore misses, before workspace restore or fresh provisioning.
- Add service block-volume planning and lookup keyed by ordered dependency output keys and prior service output keys.
- Keep the runtime conservative: unsupported backends and missing cache metadata stores fall back to the aggregate dependency/services stage paths before per-block key resolution.
- Add hit/miss observability for dependency and service block-volume lookups and stub-adapter tests for unsupported, missing-store, partial-hit, and all-hit cases.
- Update the dependency/service volume cache plan with what landed in this phase and what remains.

## Tests
- `mise exec -- go test ./internal/controlservice`
- `mise exec -- go test ./...`
