### PR TITLE
fix: Add explicit workspace copy-out force

### DIFF
--- a/docs/plans/workspace-sync.md
+++ b/docs/plans/workspace-sync.md
@@ -14,8 +14,8 @@
   safety that requires a matching local Git checkout before copy-out planning.
 - PR #274 landed the first write-capable Phase 2 slice: Git-backed
   `workspace copy-out` applies sandbox changes to the matching local checkout,
-  saves a recoverable patch and manifest before applying, refuses local baseline
-  mismatches, and refuses target paths that changed independently.
+  refuses local baseline mismatches, and refuses target paths that changed
+  independently.
 - PR #275 landed client-side Git workspace binding metadata:
   `workspace copy-in` and top-level `--copy-in` record the trusted local root,
   canonical remote, baseline commit, sandbox workspace root, operation time, and
@@ -23,12 +23,15 @@
 - PR #276 landed Git-backed `workspace copy-out` from the recorded copy-in
   manifest base, so copy-out can safely write back after a prior copy-in that
   included dirty edits or local-only commits.
-- This changeset adds Git-backed top-level `--copy-out` and `--sync` automation
+- PR #280 landed Git-backed top-level `--copy-out` and `--sync` automation
   for `cleanroom exec` and `cleanroom console`. It composes the manual
   copy-in/copy-out operations, prevalidates existing sandbox copy-out targets,
   and runs copy-out before automatic sandbox termination.
-- Non-Git/raw copy-out writes and raw create-time workspace support remain
-  follow-up work.
+- This changeset removes copy-out recovery payload directories from the normal
+  UX, reports copy-out conflicts together, and adds
+  `workspace copy-out --force` as the explicit local overwrite path.
+- Non-Git workspace copy-in/copy-out is explicitly out of scope for now. The
+  supported workspace-sync surface is Git-backed.
 
 ## Summary
 
@@ -68,12 +71,10 @@ cleanroom cp ./fixture.json <sandbox-id>:/tmp/fixture.json
 cleanroom cp <sandbox-id>:/tmp/result.json ./result.json
 ```
 
-Workspace copy-in/copy-out should reuse existing substrates rather than redefine
-low-level copy semantics. For Git-backed source workspaces, copy-in and copy-out
-should use repository changesets as the transport. For non-Git source
-workspaces, they should use raw workspace transfer over the file/path/archive
-layer. That is an implementation choice; the user-facing behavior should be
-the same.
+Workspace copy-in/copy-out should reuse existing Git substrates rather than
+redefine low-level copy semantics. For the supported workspace-sync surface,
+the local workspace must be a Git worktree and copy-in/copy-out use repository
+changesets plus Git metadata for baseline, ignore, and conflict safety.
 
 The higher-level automation should stay small and literal:
 
@@ -112,9 +113,8 @@ Top-level flags:
 - Make copy-out safe by default: no silent overwrite of unrelated local changes,
   a dry-run path for previewing local effects, and clear conflict reporting.
 - Preserve the existing repo-aware checkout model for clean committed inputs.
-- Reuse the sandbox file/path/archive transfer layer for payload movement.
-- Keep `--copy-in` and `workspace copy-in` behavior identical; only the transport
-  should differ between Git and non-Git sources.
+- Keep `--copy-in` and `workspace copy-in` behavior identical for Git-backed
+  workspaces.
 
 ## Non-goals
 
@@ -125,8 +125,8 @@ Top-level flags:
 - Making `cleanroom sandbox create` infer repository policy or local workspace
   state.
 - Copying ignored workspace artifacts out by default.
-- Adding a copy-out conflict override such as `--force` or `--overwrite` in the
-  MVP.
+- Supporting non-Git workspace copy-in/copy-out in the current workspace-sync
+  UX. Use `cleanroom cp` for explicit file movement instead.
 - Supporting arbitrary local copy-out roots in the MVP.
 - Running copy-out automatically from `cleanroom sandbox rm`.
 - Replacing artifact upload/download APIs for non-workspace build outputs.
@@ -149,21 +149,13 @@ path. Recursive local directory upload, workspace baselines, conflict
 detection, dry-run copy-out planning, and workspace mirror semantics are out of
 scope for `cp`.
 
-Workspace commands should use a shared workspace planner with
-workspace-specific safety semantics. The planner selects the transport from
-the source workspace:
-
-- Git source: repository changeset.
-- Non-Git source: raw workspace transfer using the backend-neutral
-  file/path/archive layer.
+Workspace commands should use a shared Git workspace planner with
+workspace-specific safety semantics. The planner requires a local Git worktree;
+non-Git directories are not accepted by the supported workspace copy UX.
 
 Top-level `--copy-in` should call the same copy-in operation as
 `cleanroom workspace copy-in`; it is not a separate changeset-only mode. The
-first implementation keeps that guarantee for Git-backed workspaces. For
-non-Git workspaces, `cleanroom workspace copy-in` can use raw transfer against an
-existing sandbox, but top-level `--copy-in` must stay disabled until there is a
-create-time raw workspace primitive that runs before dependency and service
-bootstrap.
+implementation keeps that guarantee for Git-backed workspaces.
 
 Workspace commands must operate on the sandbox's recorded workspace root. For
 repository-backed sandboxes, that root is the resolved `repository.path`,
@@ -187,10 +179,9 @@ Default behavior:
 - mirror local additions, modifications, and deletes from the included
   workspace file set into the cleanroom workspace
 - skip `.git/`
-- if the source is a Git worktree, package and apply a repository changeset
-- if the source is not a Git worktree, use raw workspace transfer, but refuse
-  when the sandbox does not expose a recorded workspace root
-- honor Git ignore rules by default for Git-backed source workspaces
+- require the source to be a Git worktree, then package and apply a repository
+  changeset
+- honor Git ignore rules by default
 - record the local binding and manifest needed for later copy-out conflict
   checks
 
@@ -209,6 +200,7 @@ Copy cleanroom workspace changes back to the caller's local workspace.
 ```sh
 cleanroom workspace copy-out <sandbox-id>
 cleanroom workspace copy-out --dry-run <sandbox-id>
+cleanroom workspace copy-out --force <sandbox-id>
 ```
 
 Default behavior:
@@ -218,31 +210,31 @@ Default behavior:
 - destination: the caller's local repository/workspace root
 - mirror cleanroom additions, modifications, and deletes from the included
   workspace file set into the local workspace
-- if the source workspace is a Git worktree, produce a copy-out changeset
-  against the recorded cleanroom baseline
-- if the source workspace is not a Git worktree, use raw workspace transfer
-- honor Git ignore rules by default for Git-backed source workspaces; ignored
-  paths such as `node_modules/`, `.venv/`, and cache directories are not
-  copy-out candidates
+- require a local Git worktree whose repository identity matches the sandbox,
+  then produce a copy-out changeset against the recorded cleanroom baseline
+- honor Git ignore rules by default; ignored paths such as `node_modules/`,
+  `.venv/`, and cache directories are not copy-out candidates
 - refuse to overwrite or delete a local path that changed since the last
   copy-in or initial workspace baseline
-- leave a recoverable copy-out payload in Cleanroom state if local conflict
-  checks fail
+- with `--force`, overwrite or delete only the local target paths present in
+  the sandbox copy-out changeset while still requiring repository identity and
+  workspace-root safety checks
 
 `workspace copy-out --dry-run` answers "what would be written to my local
 checkout?" This is intentionally different from `workspace diff`.
 
 If local files diverged while the cleanroom was running, copy-out should fail
-closed and name the conflicting paths. A later conflict override can be added
-from concrete usage, but the initial copy-out path should be conflict-safe.
+closed, name all conflicting paths it can detect, and suggest `--force` for the
+explicit overwrite path.
 
-The first write-capable implementation is Git-backed only. Unbound copy-out
-writes require the local checkout `HEAD` to match the sandbox's recorded
-repository baseline. Bound copy-out writes use the recorded copy-in manifest as
-the local conflict and apply base, so a checkout that still matches its last
-copy-in state can receive sandbox changes even when its `HEAD` is not the
-sandbox baseline. If conflict checks fail, the command saves the sandbox patch
-in Cleanroom state and refuses to write.
+The first write-capable implementation is Git-backed only. By default, unbound
+copy-out writes require the local checkout `HEAD` to match the sandbox's
+recorded repository baseline. Bound copy-out writes use the recorded copy-in
+manifest as the local conflict and apply base, so a checkout that still matches
+its last copy-in state can receive sandbox changes even when its `HEAD` is not
+the sandbox baseline. If conflict checks fail, the command refuses to write.
+For top-level `exec --copy-out` and `console --copy-out`, the sandbox is
+preserved on copy-out failure so the sandbox itself remains the recovery object.
 
 ### `cleanroom workspace diff`
 
@@ -295,9 +287,7 @@ repository changeset path:
 4. record local binding metadata so later `workspace copy-in`,
    `workspace copy-out`, and automated copy-out operations know the local root.
 
-For non-Git source workspaces, the same `--copy-in` flag should eventually use raw
-workspace transfer instead of a changeset, but only once raw transfer can run as
-part of sandbox creation before bootstrap.
+Non-Git source workspaces are rejected by `--copy-in` for now.
 
 The existing changeset path already has the right ignore shape: it stages the
 working tree through Git, so ignored files are not part of the copied payload
@@ -425,9 +415,10 @@ The implementation should ask Git for this file set, using commands equivalent
 to `git ls-files` with standard excludes or the existing temporary-index
 changeset flow. It should not hand-parse `.gitignore`.
 
-For non-Git source workspaces, the default included file set is the raw
-workspace tree, excluding Cleanroom control metadata and destination-specific
-unsafe paths. There is no Git ignore model to infer, so raw copy is literal.
+Non-Git source workspaces are out of scope for the supported workspace copy UX.
+Without Git metadata there is no existing baseline, ignore model, or
+copy-in manifest to drive safe mirror semantics, so users should use
+`cleanroom cp` for explicit file movement instead.
 
 The safety mechanism is conflict detection and dry-run output, not making
 delete behavior a separate mode.
@@ -453,13 +444,13 @@ The refusal message should name the conflicting paths and suggest:
 
 ```sh
 cleanroom workspace copy-out --dry-run <sandbox-id>
+cleanroom workspace copy-out --force <sandbox-id>
 ```
 
-The copied-out payload should remain available under Cleanroom state so users can
-recover it manually if needed.
-
-The MVP should not provide a conflict override such as `--force` or
-`--overwrite`. A later override can be added from concrete usage.
+`--force` is the only conflict override in the current UX. It should overwrite
+or delete the local target paths present in the sandbox copy-out changeset, but
+it must not bypass repository identity, workspace-root, or path traversal
+safety checks.
 
 ### Local root binding is explicit
 
@@ -510,28 +501,19 @@ is independent of transport:
 - included/excluded reason, so dry runs can explain when ignored paths are not
   candidates
 
-The planner should then select one of two transports:
-
-- Git changeset transport when the source workspace is a Git worktree and the
-  destination has the compatible recorded baseline.
-- Raw transfer transport when the source workspace is not a Git worktree.
+The planner should use Git changeset transport when the source workspace is a
+Git worktree and the destination has the compatible recorded baseline.
 
 If the source is Git but the destination cannot accept the changeset because
 the baseline is missing or incompatible, fail with a clear error. Do not
 silently fall back to raw copy, because that changes ignore/delete semantics.
 
-For efficient raw-transfer implementation, the CLI can batch file changes into
-the existing archive-write path plus a workspace manifest. Copy-out can use the
-inverse shape: build a manifest and payload from the sandbox workspace root,
-stream it to the CLI through archive/read primitives, and let the CLI apply it
-to the local workspace after local conflict checks pass.
-
 `cleanroom cp` remains the one-file convenience layer over the same substrate.
 It should not grow workspace baselines or mirror behavior.
 
 Git remains useful for baseline, ignore, and diff calculation when the source
-workspace is a Git checkout. V1 should lean on that for safety while still
-supporting non-Git workspaces through raw transfer.
+workspace is a Git checkout. V1 should lean on that for safety and leave
+non-Git workspace mirroring out of scope.
 
 ## State and Metadata
 
@@ -545,7 +527,7 @@ Cleanroom should record workspace metadata per sandbox:
 - cleanroom workspace baseline manifest or tree digest
 - last workspace copy-in manifest used for copy-out conflict detection
 - ignore/source file-set mode used for the last workspace operation
-- selected source transport, either Git changeset or raw transfer
+- selected Git source file-set mode
 - last workspace operation time
 
 The server should store sandbox/workspace facts needed to operate inside the
@@ -559,8 +541,7 @@ The public CLI should lead the design. The transfer substrate now provides the
 low-level file/path/archive operations; workspace APIs should stay narrow and
 workspace-aware:
 
-- apply a workspace copy-in payload to a sandbox workspace, whether represented
-  as a Git changeset or a raw transfer manifest
+- apply a Git workspace copy-in payload to a sandbox workspace
 - produce a workspace diff against the cleanroom baseline
 - produce a workspace copy-out payload and manifest
 
@@ -586,7 +567,7 @@ This plan should rename that user-facing behavior to `--copy-in`:
 - `--copy-in` is the top-level one-shot copy-in flag for local workspace changes
 - `workspace copy-in` is the manual form of the same copy-in operation
 - Git source workspaces use repository changesets
-- non-Git source workspaces use raw workspace transfer
+- non-Git source workspaces are not supported by workspace copy-in/copy-out
 - `workspace copy-out` is the explicit copy-out primitive
 - `--copy-out` is the top-level copy-out automation
 - `--sync` composes copy-in with copy-out
@@ -634,6 +615,7 @@ Status: landed.
 
 ### Phase 1: Unified workspace copy-in
 
+- Status: landed for Git-backed workspaces.
 - Add a shared workspace copy-in planner used by both manual commands and
   top-level automation.
 - Add `cleanroom workspace copy-in`.
@@ -642,10 +624,7 @@ Status: landed.
 - Resolve the destination workspace root from `repository.path`, defaulting to
   `/workspace`.
 - Use repository changesets when the source workspace is a Git worktree.
-- Use raw workspace transfer for manual `workspace copy-in` when the source
-  workspace is not a Git worktree.
-- Reject top-level `--copy-in` for non-Git workspaces until raw transfer can be
-  attached to sandbox creation before bootstrap.
+- Reject workspace copy-in for non-Git workspaces in the supported UX.
 - Add tests that ignored files and directories, including a representative
   `node_modules/`, are not included in Git-backed copy unless tracked.
 - Add tests that `workspace copy-in` and top-level `--copy-in` produce the same
@@ -659,6 +638,7 @@ Status: landed.
 
 ### Phase 2: Workspace copy-out and diff
 
+- Status: landed for Git-backed workspaces.
 - PR #272: add `cleanroom workspace copy-out --dry-run`.
 - PR #274: add Git-backed `cleanroom workspace copy-out` writes.
 - PR #272: add `cleanroom workspace diff`.
@@ -666,23 +646,24 @@ Status: landed.
   to `/workspace`.
 - Covered by repository changeset tests: ignored cleanroom outputs are not
   included in Git-backed copy-out candidates by default.
-- PR #274: add copy-out tests proving local divergence fails closed with
-  no force or overwrite mode.
+- PR #274: add copy-out tests proving local divergence fails closed by default.
 - PR #274: add copy-out tests proving an unbound copy-out refuses to
   write unless the current working tree matches the sandbox repository baseline.
 - Require explicit sandbox IDs or support `--last` consistently with existing
   inspect commands.
 - PR #275: store Git local binding metadata in client-side Cleanroom
   state and prefer the bound local root during `workspace copy-out`.
-- This changeset: use the recorded copy-in manifest as the local conflict/apply
+- PR #276: use the recorded copy-in manifest as the local conflict/apply
   base.
-- Follow-up: add top-level `--copy-out` automation.
+- This changeset: add `workspace copy-out --force`, aggregate local copy-out
+  conflicts, and stop writing recovery payload directories.
 
 ### Phase 3: Safe top-level copy-out automation
 
-- Add `--copy-out` to `exec` and `console`.
-- Add `--sync` as an alias for `--copy-in --copy-out`.
-- Add integration tests for local divergence, delete propagation, and dry-run
+- Status: landed in PR #280.
+- PR #280: add `--copy-out` to `exec` and `console`.
+- PR #280: add `--sync` as an alias for `--copy-in --copy-out`.
+- PR #280: add integration tests for local divergence, delete propagation, and dry-run
   output.
 
 ### Phase 4: Optional live local-to-cleanroom copy
@@ -710,7 +691,11 @@ Status: landed.
 
 - Workspace commands support custom `repository.path` values and default to
   `/workspace`.
-- Copy-out has no conflict override in the MVP.
+- Workspace copy-in/copy-out is Git-backed only for now. Non-Git workspace
+  mirroring is out of scope; use `cleanroom cp` for explicit file movement.
+- Copy-out has one explicit conflict override: `workspace copy-out --force`.
+  It overwrites only local target paths from the sandbox copy-out changeset and
+  does not bypass repository identity or workspace-root safety.
 - Copy-out uses the bound local root or a matching current working tree; there is
   no arbitrary local-root override in the MVP.
 - Ignored generated artifacts remain excluded by default. Future support should

--- a/internal/cli/cli_parse_test.go
+++ b/internal/cli/cli_parse_test.go
@@ -525,7 +525,7 @@ func TestWorkspaceCopyOutAndDiffParse(t *testing.T) {
 	t.Run("copy-out", func(t *testing.T) {
 		c := &CLI{}
 		parser := newParserForTest(t, c)
-		if _, err := parser.Parse([]string{"workspace", "copy-out", "--dry-run", "cr_123"}); err != nil {
+		if _, err := parser.Parse([]string{"workspace", "copy-out", "--dry-run", "--force", "cr_123"}); err != nil {
 			t.Fatalf("parse workspace copy-out returned error: %v", err)
 		}
 		if got, want := c.Workspace.CopyOut.SandboxID, "cr_123"; got != want {
@@ -533,6 +533,9 @@ func TestWorkspaceCopyOutAndDiffParse(t *testing.T) {
 		}
 		if !c.Workspace.CopyOut.DryRun {
 			t.Fatal("expected workspace copy-out dry-run flag to be set")
+		}
+		if !c.Workspace.CopyOut.Force {
+			t.Fatal("expected workspace copy-out force flag to be set")
 		}
 	})
 

--- a/internal/cli/execution_shared.go
+++ b/internal/cli/execution_shared.go
@@ -71,7 +71,7 @@ func resolveExecutionSandbox(
 		if err != nil {
 			return nil, err
 		}
-		if err := validateTopLevelWorkspaceCopyTransport(repository, (copyIn || copyOut) && existingSandboxID == ""); err != nil {
+		if err := validateTopLevelWorkspaceCopyTransport(repository, copyIn || (copyOut && existingSandboxID == "")); err != nil {
 			return nil, err
 		}
 		if existingSandboxID == "" {

--- a/internal/cli/repository_changeset.go
+++ b/internal/cli/repository_changeset.go
@@ -62,7 +62,7 @@ func validateTopLevelWorkspaceCopyTransport(repository *resolvedRepositoryChecko
 	if !copyWorkspace || repository != nil {
 		return nil
 	}
-	return errors.New("top-level workspace copy for non-Git workspaces is not supported yet; create or select the sandbox, then use cleanroom workspace copy-in or cleanroom workspace copy-out explicitly")
+	return errors.New("workspace copy requires a local Git repository checkout")
 }
 
 type repositoryLocalChanges struct {

--- a/internal/cli/workspace.go
+++ b/internal/cli/workspace.go
@@ -1,16 +1,13 @@
 package cli
 
 import (
-	"archive/tar"
 	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
-	"io/fs"
 	"os"
 	"os/exec"
 	posixpath "path"
@@ -18,11 +15,9 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/buildkite/cleanroom/internal/controlclient"
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
-	"github.com/buildkite/cleanroom/internal/paths"
 	"github.com/buildkite/cleanroom/internal/repositorychangeset"
 	"github.com/buildkite/cleanroom/internal/repositorycheckout"
 )
@@ -44,6 +39,7 @@ type WorkspaceCopyOutCommand struct {
 	clientFlags
 	Chdir     string `short:"c" help:"Change to this local directory before planning the workspace copy-out"`
 	DryRun    bool   `name:"dry-run" help:"Show the local workspace paths that would be copied out without modifying local files"`
+	Force     bool   `help:"Overwrite conflicting local workspace paths with sandbox changes"`
 	SandboxID string `arg:"" required:"" help:"Sandbox ID to copy out from"`
 }
 
@@ -60,6 +56,7 @@ type workspaceCopyOptions struct {
 	Binding       *workspaceBinding
 	Destination   string
 	ForceGitReset bool
+	ForceCopyOut  bool
 	LaunchSeconds int64
 	PlanOutput    io.Writer
 }
@@ -69,25 +66,9 @@ type workspacePlanEntry struct {
 	Path   string
 }
 
-type workspaceCopyOutRecoveryPayload struct {
-	Directory string
-	PatchPath string
-}
-
-type workspaceCopyOutRecoveryManifest struct {
-	CreatedAt         string                         `json:"created_at"`
-	SandboxID         string                         `json:"sandbox_id"`
-	LocalRoot         string                         `json:"local_root"`
-	SandboxRemoteURL  string                         `json:"sandbox_remote_url"`
-	SandboxCommitSHA  string                         `json:"sandbox_commit_sha"`
-	SandboxBranch     string                         `json:"sandbox_branch,omitempty"`
-	SandboxWorkspace  string                         `json:"sandbox_workspace"`
-	CandidateWorktree []workspaceCopyOutRecoveryFile `json:"candidate_worktree"`
-}
-
-type workspaceCopyOutRecoveryFile struct {
-	Action string `json:"action"`
-	Path   string `json:"path"`
+type workspaceCopyOutConflict struct {
+	Path   string
+	Reason string
 }
 
 func (c *WorkspaceCopyInCommand) Run(ctx *runtimeContext) error {
@@ -125,6 +106,7 @@ func (c *WorkspaceCopyOutCommand) Run(ctx *runtimeContext) error {
 	if err != nil {
 		return err
 	}
+	opts.ForceCopyOut = c.Force
 	return copyWorkspaceOut(context.Background(), ctx, client, opts)
 }
 
@@ -184,7 +166,7 @@ func copyWorkspaceToSandbox(callCtx context.Context, ctx *runtimeContext, client
 	if opts.Repository != nil {
 		return copyGitWorkspaceToSandbox(callCtx, ctx, client, opts)
 	}
-	return copyRawWorkspaceToSandbox(callCtx, ctx, client, opts)
+	return errors.New("workspace copy-in requires a local Git repository checkout")
 }
 
 func copyGitWorkspaceToSandbox(callCtx context.Context, ctx *runtimeContext, client *controlclient.Client, opts workspaceCopyOptions) error {
@@ -237,25 +219,27 @@ func copyWorkspaceOut(callCtx context.Context, ctx *runtimeContext, client *cont
 	}
 	if opts.DryRun {
 		var files []repositorychangeset.File
-		if useGitWorkspaceCopyOutApplyBase(opts.Binding, opts.Repository, checkout) {
+		if opts.ForceCopyOut || useGitWorkspaceCopyOutApplyBase(opts.Binding, opts.Repository, checkout) {
 			var patch []byte
 			files, patch, err = captureGitWorkspaceCopyOutPayload(callCtx, ctx, client, opts, checkout)
 			if err != nil {
 				return err
 			}
 			if len(files) > 0 {
+				var cleanupApply func()
 				patchPath, cleanup, err := writeTemporaryWorkspaceCopyOutPatch(patch)
 				if err != nil {
 					return err
 				}
 				defer cleanup()
-				if err := ensureGitWorkspaceCopyOutSafe(opts.Repository, checkout, opts.Binding, files); err != nil {
+				if err := ensureGitWorkspaceCopyOutSafe(opts.Repository, checkout, opts.Binding, files, opts.ForceCopyOut); err != nil {
 					return err
 				}
-				files, _, err = prepareGitWorkspaceCopyOutApplyPatch(opts.Repository, checkout, files, patchPath, "")
+				files, _, cleanupApply, err = prepareGitWorkspaceCopyOutApplyPatch(opts.Repository, checkout, files, patchPath)
 				if err != nil {
 					return err
 				}
+				defer cleanupApply()
 			}
 		} else {
 			command := repositorychangeset.WorktreeNameStatusCommand(checkout)
@@ -285,21 +269,32 @@ func copyWorkspaceOut(callCtx context.Context, ctx *runtimeContext, client *cont
 	if len(files) == 0 {
 		return nil
 	}
-	recovery, err := writeWorkspaceCopyOutRecoveryPayload(opts, checkout, files, patch)
+	patchPath, cleanupPatch, err := writeTemporaryWorkspaceCopyOutPatch(patch)
 	if err != nil {
 		return err
 	}
-	if err := ensureGitWorkspaceCopyOutSafe(opts.Repository, checkout, opts.Binding, files); err != nil {
-		return fmt.Errorf("%w; sandbox changes saved to %s", err, recovery.Directory)
+	defer cleanupPatch()
+	if err := ensureGitWorkspaceCopyOutSafe(opts.Repository, checkout, opts.Binding, files, opts.ForceCopyOut); err != nil {
+		return err
 	}
-	applyPath := recovery.PatchPath
-	if useGitWorkspaceCopyOutApplyBase(opts.Binding, opts.Repository, checkout) {
-		files, applyPath, err = prepareGitWorkspaceCopyOutApplyPatch(opts.Repository, checkout, files, recovery.PatchPath, recovery.Directory)
+	applyPath := patchPath
+	cleanupApply := func() {}
+	if opts.ForceCopyOut || useGitWorkspaceCopyOutApplyBase(opts.Binding, opts.Repository, checkout) {
+		files, applyPath, cleanupApply, err = prepareGitWorkspaceCopyOutApplyPatch(opts.Repository, checkout, files, patchPath)
 		if err != nil {
-			return fmt.Errorf("%w; sandbox changes saved to %s", err, recovery.Directory)
+			return err
 		}
+		defer cleanupApply()
 		if len(files) == 0 {
 			return nil
+		}
+	}
+	if opts.ForceCopyOut {
+		if err := resetGitWorkspaceCopyOutForceIndex(opts.Repository.RootDir, files); err != nil {
+			return err
+		}
+		if err := removeGitWorkspaceCopyOutForceObstacles(opts.Repository.RootDir, files); err != nil {
+			return err
 		}
 	}
 	entries, err := gitWorkspaceCopyOutPlanFiles(opts.CWD, files)
@@ -307,7 +302,7 @@ func copyWorkspaceOut(callCtx context.Context, ctx *runtimeContext, client *cont
 		return err
 	}
 	if err := applyGitWorkspaceCopyOutPatch(opts.Repository.RootDir, applyPath); err != nil {
-		return fmt.Errorf("%w; sandbox changes saved to %s", err, recovery.Directory)
+		return err
 	}
 	return printWorkspacePlan(workspacePlanOutput(ctx, opts), entries)
 }
@@ -392,7 +387,7 @@ func validateWorkspaceCopyOutLocalRepository(local *resolvedRepositoryCheckout, 
 	return nil
 }
 
-func ensureGitWorkspaceCopyOutSafe(local *resolvedRepositoryCheckout, checkout *repositorycheckout.Checkout, binding *workspaceBinding, files []repositorychangeset.File) error {
+func ensureGitWorkspaceCopyOutSafe(local *resolvedRepositoryCheckout, checkout *repositorycheckout.Checkout, binding *workspaceBinding, files []repositorychangeset.File, force bool) error {
 	if local == nil || strings.TrimSpace(local.RootDir) == "" {
 		return errors.New("workspace copy-out requires a local Git repository checkout matching the sandbox repository")
 	}
@@ -405,17 +400,27 @@ func ensureGitWorkspaceCopyOutSafe(local *resolvedRepositoryCheckout, checkout *
 		return errors.New("workspace copy-out requires local and sandbox repository commits")
 	}
 	if binding == nil && !strings.EqualFold(localCommit, sandboxCommit) {
-		return fmt.Errorf("workspace copy-out requires local checkout HEAD %s to match sandbox baseline %s", shortGitSHA(localCommit), shortGitSHA(sandboxCommit))
+		if !force {
+			return fmt.Errorf("workspace copy-out requires local checkout HEAD %s to match sandbox baseline %s; rerun with --force to overwrite local target paths", shortGitSHA(localCommit), shortGitSHA(sandboxCommit))
+		}
+	}
+	if force {
+		return nil
 	}
 	if binding != nil {
 		return ensureGitWorkspaceCopyOutSafeWithBinding(local.RootDir, sandboxCommit, binding, files)
 	}
+	var conflicts []workspaceCopyOutConflict
 	for _, file := range files {
-		if err := ensureGitWorkspaceCopyOutPathSafe(local.RootDir, sandboxCommit, file.Path); err != nil {
+		conflict, err := gitWorkspaceCopyOutPathConflict(local.RootDir, sandboxCommit, file.Path)
+		if err != nil {
 			return err
 		}
+		if conflict != nil {
+			conflicts = append(conflicts, *conflict)
+		}
 	}
-	return nil
+	return workspaceCopyOutConflictError(conflicts)
 }
 
 func ensureGitWorkspaceCopyOutSafeWithBinding(localRoot, baseCommit string, binding *workspaceBinding, files []repositorychangeset.File) error {
@@ -439,6 +444,7 @@ func ensureGitWorkspaceCopyOutSafeWithBinding(localRoot, baseCommit string, bind
 	if err != nil {
 		return err
 	}
+	var conflicts []workspaceCopyOutConflict
 	for _, path := range paths {
 		expected, ok := manifest[path]
 		if !ok {
@@ -447,20 +453,28 @@ func ensureGitWorkspaceCopyOutSafeWithBinding(localRoot, baseCommit string, bind
 				return err
 			}
 		}
-		if err := ensureGitWorkspaceFileMatchesExpected(localRoot, path, current[path], expected); err != nil {
+		conflict, err := gitWorkspaceFileConflict(localRoot, path, current[path], expected)
+		if err != nil {
 			return err
+		}
+		if conflict != nil {
+			conflicts = append(conflicts, *conflict)
 		}
 		if staged[path] {
 			index, err := gitWorkspaceIndexFile(localRoot, nil, path)
 			if err != nil {
 				return err
 			}
-			if err := ensureGitWorkspaceFileMatchesExpected(localRoot, path, index, expected); err != nil {
+			conflict, err := gitWorkspaceFileConflict(localRoot, path, index, expected)
+			if err != nil {
 				return err
+			}
+			if conflict != nil {
+				conflicts = append(conflicts, *conflict)
 			}
 		}
 	}
-	return nil
+	return workspaceCopyOutConflictError(conflicts)
 }
 
 func workspaceCopyInManifestMap(binding *workspaceBinding) (map[string]workspaceBindingFile, error) {
@@ -495,57 +509,57 @@ func workspaceCopyInManifestMap(binding *workspaceBinding) (map[string]workspace
 	return manifest, nil
 }
 
-func ensureGitWorkspaceFileMatchesExpected(localRoot, rel string, current, expected workspaceBindingFile) error {
+func gitWorkspaceFileConflict(localRoot, rel string, current, expected workspaceBindingFile) (*workspaceCopyOutConflict, error) {
 	if expected.Deleted {
 		if !current.Deleted {
-			return fmt.Errorf("local workspace path %q changed independently; refusing workspace copy-out", rel)
+			return &workspaceCopyOutConflict{Path: rel, Reason: "changed independently"}, nil
 		}
 		localPath, err := workspaceLocalPath(localRoot, rel)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if _, err := os.Lstat(localPath); err == nil {
-			return fmt.Errorf("local workspace path %q exists outside workspace copy-in base; refusing workspace copy-out", rel)
+			return &workspaceCopyOutConflict{Path: rel, Reason: "exists outside workspace copy-in base"}, nil
 		} else if !errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("inspect local workspace path %q: %w", rel, err)
+			return nil, fmt.Errorf("inspect local workspace path %q: %w", rel, err)
 		}
-		return nil
+		return nil, nil
 	}
 	if current.Deleted || current.SHA256 != expected.SHA256 || current.Mode != expected.Mode {
-		return fmt.Errorf("local workspace path %q changed independently; refusing workspace copy-out", rel)
+		return &workspaceCopyOutConflict{Path: rel, Reason: "changed independently"}, nil
 	}
-	return nil
+	return nil, nil
 }
 
-func ensureGitWorkspaceCopyOutPathSafe(localRoot, baseCommit, rel string) error {
+func gitWorkspaceCopyOutPathConflict(localRoot, baseCommit, rel string) (*workspaceCopyOutConflict, error) {
 	normalized, err := workspaceRelativePath(rel)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	status, err := gitOutput(localRoot, "status", "--porcelain", "--", normalized)
 	if err != nil {
-		return fmt.Errorf("inspect local workspace path %q: %w", normalized, err)
+		return nil, fmt.Errorf("inspect local workspace path %q: %w", normalized, err)
 	}
 	if strings.TrimSpace(status) != "" {
-		return fmt.Errorf("local workspace path %q changed independently; refusing workspace copy-out", normalized)
+		return &workspaceCopyOutConflict{Path: normalized, Reason: "changed independently"}, nil
 	}
 	existsInBaseline, err := gitPathExistsInCommit(localRoot, baseCommit, normalized)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if existsInBaseline {
-		return nil
+		return nil, nil
 	}
 	localPath, err := workspaceLocalPath(localRoot, normalized)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if _, err := os.Lstat(localPath); err == nil {
-		return fmt.Errorf("local workspace path %q exists outside sandbox baseline; refusing workspace copy-out", normalized)
+		return &workspaceCopyOutConflict{Path: normalized, Reason: "exists outside sandbox baseline"}, nil
 	} else if !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("inspect local workspace path %q: %w", normalized, err)
+		return nil, fmt.Errorf("inspect local workspace path %q: %w", normalized, err)
 	}
-	return nil
+	return nil, nil
 }
 
 func gitPathExistsInCommit(localRoot, commit, rel string) (bool, error) {
@@ -554,6 +568,45 @@ func gitPathExistsInCommit(localRoot, commit, rel string) (bool, error) {
 		return false, fmt.Errorf("inspect sandbox baseline path %q: %w", rel, err)
 	}
 	return strings.Trim(output, "\x00 \n\r\t") != "", nil
+}
+
+func workspaceCopyOutConflictError(conflicts []workspaceCopyOutConflict) error {
+	if len(conflicts) == 0 {
+		return nil
+	}
+	byPath := make(map[string]workspaceCopyOutConflict, len(conflicts))
+	for _, conflict := range conflicts {
+		path := strings.TrimSpace(conflict.Path)
+		reason := strings.TrimSpace(conflict.Reason)
+		if path == "" {
+			continue
+		}
+		if reason == "" {
+			reason = "changed independently"
+		}
+		if _, ok := byPath[path]; !ok {
+			byPath[path] = workspaceCopyOutConflict{Path: path, Reason: reason}
+		}
+	}
+	if len(byPath) == 0 {
+		return nil
+	}
+	paths := make([]string, 0, len(byPath))
+	for path := range byPath {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	if len(paths) == 1 {
+		conflict := byPath[paths[0]]
+		return fmt.Errorf("local workspace path %q %s; refusing workspace copy-out; rerun with --force to overwrite local target paths", conflict.Path, conflict.Reason)
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "workspace copy-out found %d local conflicts; refusing workspace copy-out; rerun with --force to overwrite local target paths:", len(paths))
+	for _, path := range paths {
+		conflict := byPath[path]
+		fmt.Fprintf(&b, "\n- %s: %s", conflict.Path, conflict.Reason)
+	}
+	return errors.New(b.String())
 }
 
 func captureGitWorkspaceCopyOutPayload(callCtx context.Context, ctx *runtimeContext, client *controlclient.Client, opts workspaceCopyOptions, checkout *repositorycheckout.Checkout) ([]repositorychangeset.File, []byte, error) {
@@ -591,29 +644,68 @@ func useGitWorkspaceCopyOutApplyBase(binding *workspaceBinding, local *resolvedR
 	return localCommit != "" && sandboxCommit != "" && !strings.EqualFold(localCommit, sandboxCommit)
 }
 
-func prepareGitWorkspaceCopyOutApplyPatch(local *resolvedRepositoryCheckout, checkout *repositorycheckout.Checkout, files []repositorychangeset.File, sandboxPatchPath, recoveryDir string) ([]repositorychangeset.File, string, error) {
+func prepareGitWorkspaceCopyOutApplyPatch(local *resolvedRepositoryCheckout, checkout *repositorycheckout.Checkout, files []repositorychangeset.File, sandboxPatchPath string) ([]repositorychangeset.File, string, func(), error) {
 	if local == nil || strings.TrimSpace(local.RootDir) == "" {
-		return nil, "", errors.New("workspace copy-out requires a local Git repository checkout matching the sandbox repository")
+		return nil, "", nil, errors.New("workspace copy-out requires a local Git repository checkout matching the sandbox repository")
 	}
 	if checkout == nil || strings.TrimSpace(checkout.CommitSHA) == "" {
-		return nil, "", errors.New("workspace copy-out requires a sandbox repository baseline")
+		return nil, "", nil, errors.New("workspace copy-out requires a sandbox repository baseline")
 	}
 	nameStatus, patch, err := buildGitWorkspaceCopyOutPatchFromLocalBase(local.RootDir, checkout.CommitSHA, sandboxPatchPath, files)
 	if err != nil {
-		return nil, "", err
+		return nil, "", nil, err
 	}
 	applyFiles, err := parseGitNameStatusWorkspaceFiles(nameStatus)
 	if err != nil {
-		return nil, "", err
+		return nil, "", nil, err
 	}
-	if len(applyFiles) == 0 || strings.TrimSpace(recoveryDir) == "" {
-		return applyFiles, "", nil
+	if len(applyFiles) == 0 {
+		return applyFiles, "", func() {}, nil
 	}
-	patchPath := filepath.Join(recoveryDir, "local-apply.patch")
-	if err := os.WriteFile(patchPath, patch, 0o600); err != nil {
-		return nil, "", fmt.Errorf("write workspace copy-out local apply patch: %w", err)
+	patchPath, cleanup, err := writeTemporaryWorkspaceCopyOutPatch(patch)
+	if err != nil {
+		return nil, "", nil, fmt.Errorf("write workspace copy-out local apply patch: %w", err)
 	}
-	return applyFiles, patchPath, nil
+	return applyFiles, patchPath, cleanup, nil
+}
+
+func resetGitWorkspaceCopyOutForceIndex(localRoot string, files []repositorychangeset.File) error {
+	paths, err := workspaceCopyOutPaths(files)
+	if err != nil {
+		return err
+	}
+	if len(paths) == 0 {
+		return nil
+	}
+	args := append([]string{"reset", "-q", "--"}, gitWorkspacePathspecs(paths)...)
+	if _, err := gitOutputRaw(localRoot, nil, args...); err != nil {
+		return fmt.Errorf("reset staged workspace copy-out target paths: %w", err)
+	}
+	return nil
+}
+
+func removeGitWorkspaceCopyOutForceObstacles(localRoot string, files []repositorychangeset.File) error {
+	paths, err := workspaceCopyOutPaths(files)
+	if err != nil {
+		return err
+	}
+	current, err := gitWorkspaceCurrentFiles(localRoot, paths)
+	if err != nil {
+		return err
+	}
+	for _, path := range paths {
+		if !current[path].Deleted {
+			continue
+		}
+		localPath, err := workspaceLocalPath(localRoot, path)
+		if err != nil {
+			return err
+		}
+		if err := os.RemoveAll(localPath); err != nil {
+			return fmt.Errorf("remove local workspace path %q before forced copy-out: %w", path, err)
+		}
+	}
+	return nil
 }
 
 func buildGitWorkspaceCopyOutPatchFromLocalBase(localRoot, baseCommit, sandboxPatchPath string, files []repositorychangeset.File) ([]byte, []byte, error) {
@@ -921,70 +1013,6 @@ func applyGitWorkspaceCopyOutPatch(localRoot, patchPath string) error {
 	return nil
 }
 
-func writeWorkspaceCopyOutRecoveryPayload(opts workspaceCopyOptions, checkout *repositorycheckout.Checkout, files []repositorychangeset.File, patch []byte) (*workspaceCopyOutRecoveryPayload, error) {
-	base, err := paths.StateBaseDir()
-	if err != nil {
-		return nil, fmt.Errorf("resolve workspace copy-out state directory: %w", err)
-	}
-	recoveryRoot := filepath.Join(base, "workspace-copy-out")
-	if err := os.MkdirAll(recoveryRoot, 0o700); err != nil {
-		return nil, fmt.Errorf("create workspace copy-out state directory: %w", err)
-	}
-	payloadDir, err := os.MkdirTemp(recoveryRoot, safeWorkspaceStateName(opts.SandboxID)+"-")
-	if err != nil {
-		return nil, fmt.Errorf("create workspace copy-out recovery payload: %w", err)
-	}
-	patchPath := filepath.Join(payloadDir, "changes.patch")
-	if err := os.WriteFile(patchPath, patch, 0o600); err != nil {
-		return nil, fmt.Errorf("write workspace copy-out recovery patch: %w", err)
-	}
-	manifest := workspaceCopyOutRecoveryManifest{
-		CreatedAt:         time.Now().UTC().Format(time.RFC3339Nano),
-		SandboxID:         strings.TrimSpace(opts.SandboxID),
-		LocalRoot:         strings.TrimSpace(opts.CWD),
-		CandidateWorktree: workspaceCopyOutRecoveryFiles(files),
-	}
-	if checkout != nil {
-		manifest.SandboxRemoteURL = strings.TrimSpace(checkout.RemoteURL)
-		manifest.SandboxCommitSHA = strings.TrimSpace(checkout.CommitSHA)
-		manifest.SandboxBranch = strings.TrimSpace(checkout.Branch)
-		manifest.SandboxWorkspace = strings.TrimSpace(checkout.DestinationDir)
-	}
-	data, err := json.MarshalIndent(manifest, "", "  ")
-	if err != nil {
-		return nil, fmt.Errorf("encode workspace copy-out recovery manifest: %w", err)
-	}
-	data = append(data, '\n')
-	if err := os.WriteFile(filepath.Join(payloadDir, "manifest.json"), data, 0o600); err != nil {
-		return nil, fmt.Errorf("write workspace copy-out recovery manifest: %w", err)
-	}
-	return &workspaceCopyOutRecoveryPayload{
-		Directory: payloadDir,
-		PatchPath: patchPath,
-	}, nil
-}
-
-func workspaceCopyOutRecoveryFiles(files []repositorychangeset.File) []workspaceCopyOutRecoveryFile {
-	recoveryFiles := make([]workspaceCopyOutRecoveryFile, 0, len(files))
-	for _, file := range files {
-		action := "write"
-		if file.Deleted {
-			action = "delete"
-		}
-		recoveryFiles = append(recoveryFiles, workspaceCopyOutRecoveryFile{
-			Action: action,
-			Path:   file.Path,
-		})
-	}
-	sort.Slice(recoveryFiles, func(i, j int) bool {
-		if recoveryFiles[i].Action != recoveryFiles[j].Action {
-			return recoveryFiles[i].Action < recoveryFiles[j].Action
-		}
-		return recoveryFiles[i].Path < recoveryFiles[j].Path
-	})
-	return recoveryFiles
-}
-
 func safeWorkspaceStateName(value string) string {
 	value = strings.TrimSpace(value)
 	if value == "" {
@@ -1225,90 +1253,6 @@ func hasWindowsDriveAbsolutePathPrefix(path string) bool {
 	return (drive >= 'A' && drive <= 'Z') || (drive >= 'a' && drive <= 'z')
 }
 
-func copyRawWorkspaceToSandbox(callCtx context.Context, ctx *runtimeContext, client *controlclient.Client, opts workspaceCopyOptions) error {
-	destination := strings.TrimSpace(opts.Destination)
-	if destination == "" {
-		var err error
-		destination, err = resolveSandboxWorkspaceDestination(callCtx, client, opts.SandboxID)
-		if err != nil {
-			return err
-		}
-	}
-	if err := validateRawWorkspaceDestinationRoot(destination); err != nil {
-		return err
-	}
-	if opts.DryRun {
-		entries, err := rawWorkspacePlan(opts.CWD, destination)
-		if err != nil {
-			return err
-		}
-		return printWorkspacePlan(runtimeStdout(ctx), entries)
-	}
-	if _, err := rawWorkspacePlan(opts.CWD, destination); err != nil {
-		return err
-	}
-	if err := cleanRawWorkspaceDestination(callCtx, ctx, client, opts.SandboxID, destination, opts.LaunchSeconds); err != nil {
-		return err
-	}
-	if err := extractRawWorkspaceArchive(callCtx, client, opts.SandboxID, destination, opts.CWD); err != nil {
-		return err
-	}
-	return nil
-}
-
-func cleanRawWorkspaceDestination(callCtx context.Context, ctx *runtimeContext, client *controlclient.Client, sandboxID, destination string, launchSeconds int64) error {
-	statResp, err := client.StatSandboxPath(tracePreservingContext(callCtx), &cleanroomv1.StatSandboxPathRequest{
-		SandboxId: sandboxID,
-		Path:      destination,
-	})
-	if err != nil {
-		if isSandboxPathNotFoundError(err) {
-			return nil
-		}
-		return fmt.Errorf("inspect sandbox workspace destination: %w", err)
-	}
-	info := statResp.GetInfo()
-	if info == nil {
-		return errors.New("inspect sandbox workspace destination: missing path info")
-	}
-	if info.GetType() != cleanroomv1.SandboxPathType_SANDBOX_PATH_TYPE_DIRECTORY {
-		return removeRawWorkspaceDestinationRoot(callCtx, client, sandboxID, destination)
-	}
-	return runWorkspaceExecution(callCtx, ctx, client, sandboxID, nil, rawWorkspaceCleanCommand(destination), nil, launchSeconds)
-}
-
-func removeRawWorkspaceDestinationRoot(callCtx context.Context, client *controlclient.Client, sandboxID, destination string) error {
-	if _, err := client.RemoveSandboxPath(tracePreservingContext(callCtx), &cleanroomv1.RemoveSandboxPathRequest{
-		SandboxId: sandboxID,
-		Path:      destination,
-	}); err != nil {
-		if isSandboxPathNotFoundError(err) {
-			return nil
-		}
-		return fmt.Errorf("remove non-directory workspace destination: %w", err)
-	}
-	return nil
-}
-
-func rawWorkspaceCleanCommand(destination string) []string {
-	script := []string{
-		"set -eu",
-		"dest=" + workspaceShellQuote(destination),
-		`if [ -e "$dest" ] && [ ! -d "$dest" ]; then echo "workspace destination is not a directory: $dest" >&2; exit 1; fi`,
-		`mkdir -p "$dest"`,
-		`for entry in "$dest"/* "$dest"/.[!.]* "$dest"/..?*; do`,
-		`  [ -e "$entry" ] || [ -L "$entry" ] || continue`,
-		`  [ "$(basename "$entry")" = ".git" ] && continue`,
-		`  rm -rf -- "$entry"`,
-		`done`,
-	}
-	return []string{"sh", "-lc", strings.Join(script, "\n")}
-}
-
-func workspaceShellQuote(value string) string {
-	return "'" + strings.ReplaceAll(value, "'", `'"'"'`) + "'"
-}
-
 func resolveSandboxWorkspaceDestination(callCtx context.Context, client *controlclient.Client, sandboxID string) (string, error) {
 	repository, err := resolveSandboxRepositoryCheckout(callCtx, client, sandboxID)
 	if err != nil {
@@ -1358,233 +1302,6 @@ func resolveSandboxRepositoryCheckoutIfRecorded(callCtx context.Context, client 
 		return nil, nil
 	}
 	return sandbox.GetRepositoryCheckout(), nil
-}
-
-func validateRawWorkspaceDestinationRoot(destination string) error {
-	cleaned := posixpath.Clean(strings.TrimSpace(destination))
-	if cleaned == "." || cleaned == "" {
-		return errors.New("workspace destination root is required")
-	}
-	if !strings.HasPrefix(cleaned, "/") {
-		return fmt.Errorf("workspace destination root %q must be absolute", destination)
-	}
-	switch cleaned {
-	case "/",
-		"/bin",
-		"/boot",
-		"/dev",
-		"/etc",
-		"/home",
-		"/lib",
-		"/lib64",
-		"/proc",
-		"/root",
-		"/run",
-		"/sbin",
-		"/sys",
-		"/tmp",
-		"/usr",
-		"/var":
-		return fmt.Errorf("workspace destination root %q is unsafe for raw workspace copy-in", destination)
-	default:
-		return nil
-	}
-}
-
-func rawWorkspacePlan(sourceRoot, destination string) ([]workspacePlanEntry, error) {
-	entries := []workspacePlanEntry{{
-		Action: "delete",
-		Path:   destination,
-	}}
-	err := walkRawWorkspace(sourceRoot, func(path string, d fs.DirEntry, info fs.FileInfo, rel string) error {
-		if rel == "" {
-			return nil
-		}
-		if info.IsDir() {
-			return nil
-		}
-		entries = append(entries, workspacePlanEntry{
-			Action: "write",
-			Path:   workspaceRemotePath(destination, rel),
-		})
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	sortWorkspacePlan(entries)
-	return entries, nil
-}
-
-func extractRawWorkspaceArchive(callCtx context.Context, client *controlclient.Client, sandboxID, destination, sourceRoot string) error {
-	stream := client.ExtractSandboxArchive(tracePreservingContext(callCtx))
-	if err := stream.Send(&cleanroomv1.ExtractSandboxArchiveRequest{
-		Payload: &cleanroomv1.ExtractSandboxArchiveRequest_Init{Init: &cleanroomv1.ExtractSandboxArchiveInit{
-			SandboxId:   sandboxID,
-			Destination: destination,
-		}},
-	}); err != nil {
-		return fmt.Errorf("start sandbox workspace archive extract: %w", err)
-	}
-
-	reader, writer := io.Pipe()
-	writeDone := make(chan error, 1)
-	go func() {
-		err := writeRawWorkspaceTar(writer, sourceRoot)
-		if err != nil {
-			_ = writer.CloseWithError(err)
-		} else {
-			_ = writer.Close()
-		}
-		writeDone <- err
-	}()
-
-	buf := make([]byte, 32*1024)
-	for {
-		n, readErr := reader.Read(buf)
-		if n > 0 {
-			if err := stream.Send(&cleanroomv1.ExtractSandboxArchiveRequest{
-				Payload: &cleanroomv1.ExtractSandboxArchiveRequest_Data{Data: append([]byte(nil), buf[:n]...)},
-			}); err != nil {
-				_ = reader.CloseWithError(err)
-				<-writeDone
-				return fmt.Errorf("write sandbox workspace archive: %w", err)
-			}
-		}
-		if readErr != nil {
-			if !errors.Is(readErr, io.EOF) {
-				<-writeDone
-				return fmt.Errorf("read local workspace archive: %w", readErr)
-			}
-			break
-		}
-	}
-	if writeErr := <-writeDone; writeErr != nil {
-		return writeErr
-	}
-	if _, err := stream.CloseAndReceive(); err != nil {
-		return fmt.Errorf("extract sandbox workspace archive: %w", err)
-	}
-	return nil
-}
-
-func writeRawWorkspaceTar(w io.Writer, sourceRoot string) (err error) {
-	tw := tar.NewWriter(w)
-	defer func() {
-		if closeErr := tw.Close(); closeErr != nil && err == nil {
-			err = closeErr
-		}
-	}()
-	return walkRawWorkspace(sourceRoot, func(path string, d fs.DirEntry, info fs.FileInfo, rel string) error {
-		if rel == "" {
-			return nil
-		}
-		link := ""
-		if info.Mode()&os.ModeSymlink != 0 {
-			target, err := os.Readlink(path)
-			if err != nil {
-				return fmt.Errorf("read symlink %s: %w", path, err)
-			}
-			link = target
-		}
-
-		header, err := tar.FileInfoHeader(info, link)
-		if err != nil {
-			return fmt.Errorf("create archive header for %s: %w", path, err)
-		}
-		header.Name = filepath.ToSlash(rel)
-		header.Uid = 0
-		header.Gid = 0
-		header.Uname = ""
-		header.Gname = ""
-		if info.IsDir() {
-			header.Name = strings.TrimRight(header.Name, "/") + "/"
-		}
-		if err := tw.WriteHeader(header); err != nil {
-			return fmt.Errorf("write archive header for %s: %w", path, err)
-		}
-		if !info.Mode().IsRegular() {
-			return nil
-		}
-		file, err := os.Open(path)
-		if err != nil {
-			return fmt.Errorf("open %s: %w", path, err)
-		}
-		if _, err := io.Copy(tw, file); err != nil {
-			_ = file.Close()
-			return fmt.Errorf("archive %s: %w", path, err)
-		}
-		if err := file.Close(); err != nil {
-			return fmt.Errorf("close %s: %w", path, err)
-		}
-		return nil
-	})
-}
-
-func walkRawWorkspace(sourceRoot string, visit func(path string, d fs.DirEntry, info fs.FileInfo, rel string) error) error {
-	sourceRoot, err := resolveRawWorkspaceSourceRoot(sourceRoot)
-	if err != nil {
-		return err
-	}
-	return filepath.WalkDir(sourceRoot, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		rel, err := filepath.Rel(sourceRoot, path)
-		if err != nil {
-			return err
-		}
-		if rel == "." {
-			rel = ""
-		}
-		if shouldSkipRawWorkspacePath(rel, d) {
-			if d.IsDir() {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		info, err := d.Info()
-		if err != nil {
-			return err
-		}
-		switch {
-		case info.IsDir(), info.Mode().IsRegular(), info.Mode()&os.ModeSymlink != 0:
-			return visit(path, d, info, filepath.ToSlash(rel))
-		default:
-			return fmt.Errorf("workspace copy-in cannot archive unsupported file %s", path)
-		}
-	})
-}
-
-func resolveRawWorkspaceSourceRoot(sourceRoot string) (string, error) {
-	sourceRoot = strings.TrimSpace(sourceRoot)
-	if sourceRoot == "" {
-		return "", errors.New("missing local workspace root")
-	}
-	cleaned := filepath.Clean(sourceRoot)
-	resolved, err := filepath.EvalSymlinks(cleaned)
-	if err != nil {
-		return "", fmt.Errorf("resolve workspace source root %q: %w", cleaned, err)
-	}
-	info, err := os.Stat(resolved)
-	if err != nil {
-		return "", fmt.Errorf("inspect workspace source root %q: %w", resolved, err)
-	}
-	if !info.IsDir() {
-		return "", fmt.Errorf("workspace source root %q is not a directory", cleaned)
-	}
-	return resolved, nil
-}
-
-func shouldSkipRawWorkspacePath(rel string, d fs.DirEntry) bool {
-	if rel == "" {
-		return false
-	}
-	name := filepath.Base(rel)
-	if name == ".git" {
-		return true
-	}
-	return d.IsDir() && name == ".cleanroom"
 }
 
 func workspaceRemotePath(root, rel string) string {

--- a/internal/cli/workspace_test.go
+++ b/internal/cli/workspace_test.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"archive/tar"
 	"bytes"
 	"context"
 	"errors"
@@ -1193,7 +1192,7 @@ func TestWorkspaceCopyOutAppliesSandboxGitPatch(t *testing.T) {
 	if len(commands) != 1 {
 		t.Fatalf("expected one combined copy-out execution, got %d", len(commands))
 	}
-	assertWorkspaceCopyOutRecoveryPayload(t, sandboxID)
+	assertNoWorkspaceCopyOutRecoveryPayload(t)
 }
 
 func TestWorkspaceCopyOutAppliesFromCopyInManifestBase(t *testing.T) {
@@ -1249,7 +1248,7 @@ func TestWorkspaceCopyOutAppliesFromCopyInManifestBase(t *testing.T) {
 	if got := stdoutText(); got != expected {
 		t.Fatalf("unexpected copy-out output: got %q want %q", got, expected)
 	}
-	assertWorkspaceCopyOutRecoveryPayload(t, fixture.sandboxID)
+	assertNoWorkspaceCopyOutRecoveryPayload(t)
 }
 
 func TestWorkspaceCopyOutDryRunUsesCopyInManifestBase(t *testing.T) {
@@ -1331,9 +1330,6 @@ func TestWorkspaceCopyOutRejectsLocalDivergenceFromCopyInManifestBase(t *testing
 	if !strings.Contains(err.Error(), `local workspace path "README.md" changed independently`) {
 		t.Fatalf("expected manifest divergence error, got %v", err)
 	}
-	if !strings.Contains(err.Error(), "sandbox changes saved to") {
-		t.Fatalf("expected recovery payload path in error, got %v", err)
-	}
 	readme, err := os.ReadFile(filepath.Join(fixture.localRoot, "README.md"))
 	if err != nil {
 		t.Fatalf("read README: %v", err)
@@ -1341,7 +1337,149 @@ func TestWorkspaceCopyOutRejectsLocalDivergenceFromCopyInManifestBase(t *testing
 	if got, want := string(readme), "local divergent\n"; got != want {
 		t.Fatalf("copy-out should not overwrite divergent local file: got %q want %q", got, want)
 	}
-	assertWorkspaceCopyOutRecoveryPayload(t, fixture.sandboxID)
+	assertNoWorkspaceCopyOutRecoveryPayload(t)
+}
+
+func TestWorkspaceCopyOutReportsAllLocalDivergenceFromCopyInManifestBase(t *testing.T) {
+	fixture := setupWorkspaceCopyOutManifestBase(t, func(localRoot string) {
+		if err := os.WriteFile(filepath.Join(localRoot, "README.md"), []byte("local\nsandbox\n"), 0o644); err != nil {
+			t.Fatalf("write sandbox README: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(localRoot, "local.txt"), []byte("local only\nsandbox\n"), 0o644); err != nil {
+			t.Fatalf("write sandbox local file: %v", err)
+		}
+	})
+	if err := os.WriteFile(filepath.Join(fixture.localRoot, "README.md"), []byte("local divergent\n"), 0o644); err != nil {
+		t.Fatalf("write divergent local README: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(fixture.localRoot, "local.txt"), []byte("local divergent\n"), 0o644); err != nil {
+		t.Fatalf("write divergent local file: %v", err)
+	}
+
+	stdout, _ := makeStdoutCapture(t)
+	stderr, _ := makeStdoutCapture(t)
+	cmd := WorkspaceCopyOutCommand{
+		clientFlags: clientFlags{Host: fixture.host},
+		SandboxID:   fixture.sandboxID,
+	}
+	err := cmd.Run(&runtimeContext{
+		CWD:           t.TempDir(),
+		Loader:        repositoryNotFoundLoader{},
+		Config:        runtimeconfig.Config{},
+		Observability: newTestObservability(t),
+		Stdout:        stdout,
+		Stderr:        stderr,
+	})
+	if err == nil {
+		t.Fatal("expected local divergence from copy-in manifest to be rejected")
+	}
+	for _, want := range []string{
+		"workspace copy-out found 2 local conflicts",
+		"README.md: changed independently",
+		"local.txt: changed independently",
+		"--force",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("expected error to contain %q, got %v", want, err)
+		}
+	}
+	assertNoWorkspaceCopyOutRecoveryPayload(t)
+}
+
+func TestWorkspaceCopyOutForceOverwritesLocalDivergenceFromCopyInManifestBase(t *testing.T) {
+	fixture := setupWorkspaceCopyOutManifestBase(t, func(localRoot string) {
+		if err := os.WriteFile(filepath.Join(localRoot, "README.md"), []byte("local\nsandbox\n"), 0o644); err != nil {
+			t.Fatalf("write sandbox README: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(localRoot, "local.txt"), []byte("local only\nsandbox\n"), 0o644); err != nil {
+			t.Fatalf("write sandbox local file: %v", err)
+		}
+	})
+	if err := os.WriteFile(filepath.Join(fixture.localRoot, "README.md"), []byte("local divergent\n"), 0o644); err != nil {
+		t.Fatalf("write divergent local README: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(fixture.localRoot, "local.txt"), []byte("local divergent\n"), 0o644); err != nil {
+		t.Fatalf("write divergent local file: %v", err)
+	}
+
+	stdout, _ := makeStdoutCapture(t)
+	stderr, _ := makeStdoutCapture(t)
+	cmd := WorkspaceCopyOutCommand{
+		clientFlags: clientFlags{Host: fixture.host},
+		Force:       true,
+		SandboxID:   fixture.sandboxID,
+	}
+	if err := cmd.Run(&runtimeContext{
+		CWD:           t.TempDir(),
+		Loader:        repositoryNotFoundLoader{},
+		Config:        runtimeconfig.Config{},
+		Observability: newTestObservability(t),
+		Stdout:        stdout,
+		Stderr:        stderr,
+	}); err != nil {
+		t.Fatalf("WorkspaceCopyOutCommand.Run returned error: %v", err)
+	}
+	for path, want := range map[string]string{
+		"README.md": "local\nsandbox\n",
+		"local.txt": "local only\nsandbox\n",
+	} {
+		got, err := os.ReadFile(filepath.Join(fixture.localRoot, path))
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		if string(got) != want {
+			t.Fatalf("unexpected %s content: got %q want %q", path, got, want)
+		}
+	}
+	assertNoWorkspaceCopyOutRecoveryPayload(t)
+}
+
+func TestWorkspaceCopyOutForceClearsStagedDivergenceFromCopyInManifestBase(t *testing.T) {
+	fixture := setupWorkspaceCopyOutManifestBase(t, func(localRoot string) {
+		if err := os.WriteFile(filepath.Join(localRoot, "README.md"), []byte("local\nsandbox\n"), 0o644); err != nil {
+			t.Fatalf("write sandbox README: %v", err)
+		}
+	})
+	readmePath := filepath.Join(fixture.localRoot, "README.md")
+	if err := os.WriteFile(readmePath, []byte("staged divergent\n"), 0o644); err != nil {
+		t.Fatalf("write staged divergent README: %v", err)
+	}
+	runGitInDir(t, fixture.localRoot, "add", "README.md")
+	if err := os.WriteFile(readmePath, []byte("local\n"), 0o644); err != nil {
+		t.Fatalf("restore working tree README: %v", err)
+	}
+
+	stdout, _ := makeStdoutCapture(t)
+	stderr, _ := makeStdoutCapture(t)
+	cmd := WorkspaceCopyOutCommand{
+		clientFlags: clientFlags{Host: fixture.host},
+		Force:       true,
+		SandboxID:   fixture.sandboxID,
+	}
+	if err := cmd.Run(&runtimeContext{
+		CWD:           t.TempDir(),
+		Loader:        repositoryNotFoundLoader{},
+		Config:        runtimeconfig.Config{},
+		Observability: newTestObservability(t),
+		Stdout:        stdout,
+		Stderr:        stderr,
+	}); err != nil {
+		t.Fatalf("WorkspaceCopyOutCommand.Run returned error: %v", err)
+	}
+	readme, err := os.ReadFile(readmePath)
+	if err != nil {
+		t.Fatalf("read README: %v", err)
+	}
+	if got, want := string(readme), "local\nsandbox\n"; got != want {
+		t.Fatalf("unexpected README content: got %q want %q", got, want)
+	}
+	if staged := gitOutputBytes(t, fixture.localRoot, "diff", "--cached", "--name-only", "--", "README.md"); len(staged) != 0 {
+		t.Fatalf("force copy-out should clear stale staged target content, got cached diff %q", staged)
+	}
+	if status := gitOutputBytes(t, fixture.localRoot, "status", "--short", "--", "README.md"); string(status) != " M README.md\n" {
+		t.Fatalf("unexpected README status after force copy-out: got %q", status)
+	}
+	assertNoWorkspaceCopyOutRecoveryPayload(t)
 }
 
 func TestWorkspaceCopyOutRejectsLocalModeDivergenceFromCopyInManifestBase(t *testing.T) {
@@ -1375,9 +1513,6 @@ func TestWorkspaceCopyOutRejectsLocalModeDivergenceFromCopyInManifestBase(t *tes
 	if !strings.Contains(err.Error(), `local workspace path "README.md" changed independently`) {
 		t.Fatalf("expected manifest divergence error, got %v", err)
 	}
-	if !strings.Contains(err.Error(), "sandbox changes saved to") {
-		t.Fatalf("expected recovery payload path in error, got %v", err)
-	}
 	info, err := os.Stat(readmePath)
 	if err != nil {
 		t.Fatalf("stat README: %v", err)
@@ -1392,7 +1527,7 @@ func TestWorkspaceCopyOutRejectsLocalModeDivergenceFromCopyInManifestBase(t *tes
 	if got, want := string(readme), "local\n"; got != want {
 		t.Fatalf("copy-out should leave local README content unchanged: got %q want %q", got, want)
 	}
-	assertWorkspaceCopyOutRecoveryPayload(t, fixture.sandboxID)
+	assertNoWorkspaceCopyOutRecoveryPayload(t)
 }
 
 func TestWorkspaceCopyOutAppliesLiteralPathspecFromCopyInManifestBase(t *testing.T) {
@@ -1451,7 +1586,7 @@ func TestWorkspaceCopyOutAppliesLiteralPathspecFromCopyInManifestBase(t *testing
 	if got := stdoutText(); got != expected {
 		t.Fatalf("unexpected copy-out output: got %q want %q", got, expected)
 	}
-	assertWorkspaceCopyOutRecoveryPayload(t, fixture.sandboxID)
+	assertNoWorkspaceCopyOutRecoveryPayload(t)
 }
 
 func TestWorkspaceCopyOutRejectsStagedDivergenceFromCopyInManifestBase(t *testing.T) {
@@ -1489,9 +1624,6 @@ func TestWorkspaceCopyOutRejectsStagedDivergenceFromCopyInManifestBase(t *testin
 	if !strings.Contains(err.Error(), `local workspace path "README.md" changed independently`) {
 		t.Fatalf("expected staged divergence error, got %v", err)
 	}
-	if !strings.Contains(err.Error(), "sandbox changes saved to") {
-		t.Fatalf("expected recovery payload path in error, got %v", err)
-	}
 	readme, err := os.ReadFile(readmePath)
 	if err != nil {
 		t.Fatalf("read README: %v", err)
@@ -1503,7 +1635,7 @@ func TestWorkspaceCopyOutRejectsStagedDivergenceFromCopyInManifestBase(t *testin
 	if got, want := string(staged), "staged divergent\n"; got != want {
 		t.Fatalf("copy-out should leave staged README content unchanged: got %q want %q", got, want)
 	}
-	assertWorkspaceCopyOutRecoveryPayload(t, fixture.sandboxID)
+	assertNoWorkspaceCopyOutRecoveryPayload(t)
 }
 
 func TestWorkspaceCopyOutRejectsLocalDivergence(t *testing.T) {
@@ -1559,9 +1691,6 @@ func TestWorkspaceCopyOutRejectsLocalDivergence(t *testing.T) {
 	if !strings.Contains(err.Error(), `local workspace path "README.md" changed independently`) {
 		t.Fatalf("expected local path divergence error, got %v", err)
 	}
-	if !strings.Contains(err.Error(), "sandbox changes saved to") {
-		t.Fatalf("expected recovery payload path in error, got %v", err)
-	}
 	readme, err := os.ReadFile(filepath.Join(localRoot, "README.md"))
 	if err != nil {
 		t.Fatalf("read README: %v", err)
@@ -1569,7 +1698,7 @@ func TestWorkspaceCopyOutRejectsLocalDivergence(t *testing.T) {
 	if got, want := string(readme), "local\n"; got != want {
 		t.Fatalf("copy-out should not overwrite divergent local file: got %q want %q", got, want)
 	}
-	assertWorkspaceCopyOutRecoveryPayload(t, sandboxID)
+	assertNoWorkspaceCopyOutRecoveryPayload(t)
 }
 
 func TestWorkspaceCopyOutRejectsIgnoredLocalTarget(t *testing.T) {
@@ -1643,7 +1772,7 @@ func TestWorkspaceCopyOutRejectsIgnoredLocalTarget(t *testing.T) {
 	if got, want := string(output), "local ignored\n"; got != want {
 		t.Fatalf("copy-out should not overwrite ignored local file: got %q want %q", got, want)
 	}
-	assertWorkspaceCopyOutRecoveryPayload(t, sandboxID)
+	assertNoWorkspaceCopyOutRecoveryPayload(t)
 }
 
 func TestWorkspaceCopyOutRejectsBaselineMismatch(t *testing.T) {
@@ -1701,10 +1830,130 @@ func TestWorkspaceCopyOutRejectsBaselineMismatch(t *testing.T) {
 	if !strings.Contains(err.Error(), "requires local checkout HEAD") {
 		t.Fatalf("expected baseline mismatch error, got %v", err)
 	}
-	if !strings.Contains(err.Error(), "sandbox changes saved to") {
-		t.Fatalf("expected recovery payload path in error, got %v", err)
+	assertNoWorkspaceCopyOutRecoveryPayload(t)
+}
+
+func TestWorkspaceCopyOutForceAllowsBaselineMismatch(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	localRoot := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
+	baseCommit := headCommit(t, localRoot)
+
+	if err := os.WriteFile(filepath.Join(localRoot, "README.md"), []byte("sandbox\n"), 0o644); err != nil {
+		t.Fatalf("write sandbox readme: %v", err)
 	}
-	assertWorkspaceCopyOutRecoveryPayload(t, sandboxID)
+	runGitInDir(t, localRoot, "add", "README.md")
+	nameStatus := gitOutputBytes(t, localRoot, "diff", "--cached", "--name-status", "--no-renames", "-z", baseCommit)
+	patch := gitOutputBytes(t, localRoot, "diff", "--cached", "--binary", "--full-index", "--no-ext-diff", "--no-color", "--no-renames", baseCommit)
+	runGitInDir(t, localRoot, "reset", "--hard", baseCommit)
+	if err := os.WriteFile(filepath.Join(localRoot, "local.txt"), []byte("local commit\n"), 0o644); err != nil {
+		t.Fatalf("write local commit file: %v", err)
+	}
+	runGitInDir(t, localRoot, "add", "local.txt")
+	runGitInDir(t, localRoot, "commit", "-m", "local commit")
+
+	adapter := &integrationAdapter{}
+	host, _ := startIntegrationServer(t, adapter)
+	sandboxID := createWorkspaceCopyTestSandboxWithRepositoryCommitBranch(t, host, "/sandbox-workspace", baseCommit, "main")
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+		command := strings.Join(req.Command, " ")
+		switch {
+		case strings.Contains(command, "cleanroom-copy-out-v1"):
+			if stream.OnStdout != nil {
+				stream.OnStdout(workspaceCopyOutTestPayload(nameStatus, patch))
+			}
+		default:
+			t.Fatalf("unexpected workspace copy-out command: %q", command)
+		}
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+	}
+
+	stdout, _ := makeStdoutCapture(t)
+	stderr, _ := makeStdoutCapture(t)
+	cmd := WorkspaceCopyOutCommand{
+		clientFlags: clientFlags{Host: host},
+		Chdir:       localRoot,
+		Force:       true,
+		SandboxID:   sandboxID,
+	}
+	if err := cmd.Run(&runtimeContext{
+		CWD:           localRoot,
+		Loader:        repositoryNotFoundLoader{},
+		Config:        runtimeconfig.Config{},
+		Observability: newTestObservability(t),
+		Stdout:        stdout,
+		Stderr:        stderr,
+	}); err != nil {
+		t.Fatalf("WorkspaceCopyOutCommand.Run returned error: %v", err)
+	}
+	readme, err := os.ReadFile(filepath.Join(localRoot, "README.md"))
+	if err != nil {
+		t.Fatalf("read README: %v", err)
+	}
+	if got, want := string(readme), "sandbox\n"; got != want {
+		t.Fatalf("unexpected README content: got %q want %q", got, want)
+	}
+	local, err := os.ReadFile(filepath.Join(localRoot, "local.txt"))
+	if err != nil {
+		t.Fatalf("read local file: %v", err)
+	}
+	if got, want := string(local), "local commit\n"; got != want {
+		t.Fatalf("force copy-out should leave untargeted local file alone: got %q want %q", got, want)
+	}
+	assertNoWorkspaceCopyOutRecoveryPayload(t)
+}
+
+func TestWorkspaceCopyOutForceDryRunUsesLocalApplyBase(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	localRoot := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
+	baseCommit := headCommit(t, localRoot)
+
+	if err := os.WriteFile(filepath.Join(localRoot, "README.md"), []byte("sandbox\n"), 0o644); err != nil {
+		t.Fatalf("write sandbox readme: %v", err)
+	}
+	runGitInDir(t, localRoot, "add", "README.md")
+	nameStatus := gitOutputBytes(t, localRoot, "diff", "--cached", "--name-status", "--no-renames", "-z", baseCommit)
+	patch := gitOutputBytes(t, localRoot, "diff", "--cached", "--binary", "--full-index", "--no-ext-diff", "--no-color", "--no-renames", baseCommit)
+	runGitInDir(t, localRoot, "commit", "-m", "local already has sandbox readme")
+
+	adapter := &integrationAdapter{}
+	host, _ := startIntegrationServer(t, adapter)
+	sandboxID := createWorkspaceCopyTestSandboxWithRepositoryCommitBranch(t, host, "/sandbox-workspace", baseCommit, "main")
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+		command := strings.Join(req.Command, " ")
+		switch {
+		case strings.Contains(command, "cleanroom-copy-out-v1"):
+			if stream.OnStdout != nil {
+				stream.OnStdout(workspaceCopyOutTestPayload(nameStatus, patch))
+			}
+		default:
+			t.Fatalf("unexpected workspace copy-out command: %q", command)
+		}
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+	}
+
+	stdout, stdoutText := makeStdoutCapture(t)
+	stderr, _ := makeStdoutCapture(t)
+	cmd := WorkspaceCopyOutCommand{
+		clientFlags: clientFlags{Host: host},
+		Chdir:       localRoot,
+		DryRun:      true,
+		Force:       true,
+		SandboxID:   sandboxID,
+	}
+	if err := cmd.Run(&runtimeContext{
+		CWD:           localRoot,
+		Loader:        repositoryNotFoundLoader{},
+		Config:        runtimeconfig.Config{},
+		Observability: newTestObservability(t),
+		Stdout:        stdout,
+		Stderr:        stderr,
+	}); err != nil {
+		t.Fatalf("WorkspaceCopyOutCommand.Run returned error: %v", err)
+	}
+	if got := stdoutText(); got != "" {
+		t.Fatalf("force dry-run should plan from local apply base: got %q", got)
+	}
+	assertNoWorkspaceCopyOutRecoveryPayload(t)
 }
 
 func TestWorkspaceCopyOutPlanRejectsWindowsDrivePaths(t *testing.T) {
@@ -1889,349 +2138,14 @@ func TestWorkspaceDiffStreamsSandboxGitDiff(t *testing.T) {
 	}
 }
 
-func TestWorkspaceCopyInUsesRawArchiveForNonGitWorkspace(t *testing.T) {
-	sourceRoot := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(sourceRoot, "app"), 0o755); err != nil {
-		t.Fatalf("create app dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(sourceRoot, "app/main.txt"), []byte("payload\n"), 0o644); err != nil {
-		t.Fatalf("write workspace file: %v", err)
-	}
-	if err := os.MkdirAll(filepath.Join(sourceRoot, ".git"), 0o755); err != nil {
-		t.Fatalf("create skipped git dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(sourceRoot, ".git/config"), []byte("skip\n"), 0o644); err != nil {
-		t.Fatalf("write skipped git config: %v", err)
-	}
-	if err := os.MkdirAll(filepath.Join(sourceRoot, "app/submodule"), 0o755); err != nil {
-		t.Fatalf("create submodule dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(sourceRoot, "app/submodule/.git"), []byte("gitdir: ../../.git/modules/submodule\n"), 0o644); err != nil {
-		t.Fatalf("write skipped git file: %v", err)
-	}
-
-	var (
-		mu          sync.Mutex
-		commands    [][]string
-		destination string
-		files       = map[string]string{}
-	)
-	adapter := &copyIntegrationAdapter{
-		statFn: func(_ context.Context, _ string, path string) (*backend.SandboxPathInfo, error) {
-			return &backend.SandboxPathInfo{
-				Path: path,
-				Type: backend.SandboxPathTypeDirectory,
-			}, nil
-		},
-		extractFn: func(_ context.Context, _ string, dest string, r io.Reader) (int64, error) {
-			destination = dest
-			tr := tar.NewReader(r)
-			for {
-				header, err := tr.Next()
-				if errors.Is(err, io.EOF) {
-					break
-				}
-				if err != nil {
-					return 0, err
-				}
-				if header.Typeflag != tar.TypeReg {
-					continue
-				}
-				data, err := io.ReadAll(tr)
-				if err != nil {
-					return 0, err
-				}
-				files[header.Name] = string(data)
-			}
-			return 0, nil
-		},
-	}
-	host, _ := startIntegrationServer(t, adapter)
-	sandboxID := createWorkspaceCopyTestSandboxWithRepository(t, host, "/workspace-app")
-	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
-		mu.Lock()
-		commands = append(commands, append([]string(nil), req.Command...))
-		mu.Unlock()
-		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
-	}
-	stdout, _ := makeStdoutCapture(t)
-	stderr, _ := makeStdoutCapture(t)
-
-	cmd := WorkspaceCopyInCommand{
-		clientFlags: clientFlags{Host: host},
-		Chdir:       sourceRoot,
-		SandboxID:   sandboxID,
-	}
-	if err := cmd.Run(&runtimeContext{
-		CWD:           sourceRoot,
-		Loader:        repositoryNotFoundLoader{},
-		Config:        runtimeconfig.Config{},
-		Observability: newTestObservability(t),
-		Stdout:        stdout,
-		Stderr:        stderr,
-	}); err != nil {
-		t.Fatalf("WorkspaceCopyInCommand.Run returned error: %v", err)
-	}
-
-	mu.Lock()
-	defer mu.Unlock()
-	if len(commands) != 1 {
-		t.Fatalf("expected one raw workspace clean command, got %d", len(commands))
-	}
-	cleanCommand := strings.Join(commands[0], " ")
-	if !strings.Contains(cleanCommand, `basename "$entry"`) || !strings.Contains(cleanCommand, `= ".git"`) {
-		t.Fatalf("expected raw workspace clean command to preserve .git, got %q", cleanCommand)
-	}
-	if got, want := destination, "/workspace-app"; got != want {
-		t.Fatalf("unexpected extract destination: got %q want %q", got, want)
-	}
-	if got, want := files["app/main.txt"], "payload\n"; got != want {
-		t.Fatalf("unexpected archived file content: got %q want %q", got, want)
-	}
-	if _, ok := files[".git/config"]; ok {
-		t.Fatalf("expected .git directory to be skipped, got files %#v", files)
-	}
-	if _, ok := files["app/submodule/.git"]; ok {
-		t.Fatalf("expected .git file to be skipped, got files %#v", files)
-	}
-}
-
-func TestWorkspaceCopyInSkipsRawCleanWhenDestinationMissing(t *testing.T) {
-	sourceRoot := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(sourceRoot, "app"), 0o755); err != nil {
-		t.Fatalf("create app dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(sourceRoot, "app/main.txt"), []byte("payload\n"), 0o644); err != nil {
-		t.Fatalf("write workspace file: %v", err)
-	}
-
-	var (
-		mu          sync.Mutex
-		commands    [][]string
-		destination string
-		files       = map[string]string{}
-	)
-	adapter := &copyIntegrationAdapter{
-		statFn: func(_ context.Context, _ string, path string) (*backend.SandboxPathInfo, error) {
-			return nil, backend.NewSandboxPathNotFoundError(path)
-		},
-		extractFn: func(_ context.Context, _ string, dest string, r io.Reader) (int64, error) {
-			destination = dest
-			tr := tar.NewReader(r)
-			for {
-				header, err := tr.Next()
-				if errors.Is(err, io.EOF) {
-					break
-				}
-				if err != nil {
-					return 0, err
-				}
-				if header.Typeflag != tar.TypeReg {
-					continue
-				}
-				data, err := io.ReadAll(tr)
-				if err != nil {
-					return 0, err
-				}
-				files[header.Name] = string(data)
-			}
-			return 0, nil
-		},
-	}
-	host, _ := startIntegrationServer(t, adapter)
-	sandboxID := createWorkspaceCopyTestSandboxWithRepository(t, host, "/workspace-app")
-	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
-		mu.Lock()
-		commands = append(commands, append([]string(nil), req.Command...))
-		mu.Unlock()
-		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
-	}
-	stdout, _ := makeStdoutCapture(t)
-	stderr, _ := makeStdoutCapture(t)
-
-	cmd := WorkspaceCopyInCommand{
-		clientFlags: clientFlags{Host: host},
-		Chdir:       sourceRoot,
-		SandboxID:   sandboxID,
-	}
-	if err := cmd.Run(&runtimeContext{
-		CWD:           sourceRoot,
-		Loader:        repositoryNotFoundLoader{},
-		Config:        runtimeconfig.Config{},
-		Observability: newTestObservability(t),
-		Stdout:        stdout,
-		Stderr:        stderr,
-	}); err != nil {
-		t.Fatalf("WorkspaceCopyInCommand.Run returned error: %v", err)
-	}
-
-	mu.Lock()
-	defer mu.Unlock()
-	if len(commands) != 0 {
-		t.Fatalf("expected missing raw workspace destination to skip clean execution, got %d command(s)", len(commands))
-	}
-	if got, want := destination, "/workspace-app"; got != want {
-		t.Fatalf("unexpected extract destination: got %q want %q", got, want)
-	}
-	if got, want := files["app/main.txt"], "payload\n"; got != want {
-		t.Fatalf("unexpected archived file content: got %q want %q", got, want)
-	}
-}
-
-func TestWorkspaceCopyInRemovesSymlinkedRawDestinationRoot(t *testing.T) {
-	sourceRoot := t.TempDir()
-	if err := os.WriteFile(filepath.Join(sourceRoot, "main.txt"), []byte("payload\n"), 0o644); err != nil {
-		t.Fatalf("write workspace file: %v", err)
-	}
-
-	var (
-		mu               sync.Mutex
-		commands         [][]string
-		removedPath      string
-		removedRecursive bool
-		destination      string
-	)
-	adapter := &copyIntegrationAdapter{
-		statFn: func(_ context.Context, _ string, path string) (*backend.SandboxPathInfo, error) {
-			return &backend.SandboxPathInfo{
-				Path:          path,
-				Type:          backend.SandboxPathTypeSymlink,
-				SymlinkTarget: "/",
-			}, nil
-		},
-		removeFn: func(_ context.Context, _ string, path string, recursive bool) error {
-			removedPath = path
-			removedRecursive = recursive
-			return nil
-		},
-		extractFn: func(_ context.Context, _ string, dest string, r io.Reader) (int64, error) {
-			destination = dest
-			return io.Copy(io.Discard, r)
-		},
-	}
-	host, _ := startIntegrationServer(t, adapter)
-	sandboxID := createWorkspaceCopyTestSandboxWithRepository(t, host, "/workspace-app")
-	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
-		mu.Lock()
-		commands = append(commands, append([]string(nil), req.Command...))
-		mu.Unlock()
-		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
-	}
-	stdout, _ := makeStdoutCapture(t)
-	stderr, _ := makeStdoutCapture(t)
-
-	cmd := WorkspaceCopyInCommand{
-		clientFlags: clientFlags{Host: host},
-		Chdir:       sourceRoot,
-		SandboxID:   sandboxID,
-	}
-	if err := cmd.Run(&runtimeContext{
-		CWD:           sourceRoot,
-		Loader:        repositoryNotFoundLoader{},
-		Config:        runtimeconfig.Config{},
-		Observability: newTestObservability(t),
-		Stdout:        stdout,
-		Stderr:        stderr,
-	}); err != nil {
-		t.Fatalf("WorkspaceCopyInCommand.Run returned error: %v", err)
-	}
-
-	mu.Lock()
-	defer mu.Unlock()
-	if len(commands) != 0 {
-		t.Fatalf("expected symlinked raw workspace destination to skip clean execution, got %d command(s)", len(commands))
-	}
-	if got, want := removedPath, "/workspace-app"; got != want {
-		t.Fatalf("unexpected removed path: got %q want %q", got, want)
-	}
-	if removedRecursive {
-		t.Fatal("expected symlinked raw workspace destination to be removed non-recursively")
-	}
-	if got, want := destination, "/workspace-app"; got != want {
-		t.Fatalf("unexpected extract destination: got %q want %q", got, want)
-	}
-}
-
-func TestRawWorkspaceCopyFollowsSymlinkedSourceRoot(t *testing.T) {
-	realRoot := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(realRoot, "app"), 0o755); err != nil {
-		t.Fatalf("create app dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(realRoot, "app/main.txt"), []byte("payload\n"), 0o644); err != nil {
-		t.Fatalf("write workspace file: %v", err)
-	}
-
-	linkRoot := filepath.Join(t.TempDir(), "workspace-link")
-	if err := os.Symlink(realRoot, linkRoot); err != nil {
-		t.Fatalf("create workspace symlink: %v", err)
-	}
-
-	entries, err := rawWorkspacePlan(linkRoot, "/workspace")
-	if err != nil {
-		t.Fatalf("rawWorkspacePlan returned error: %v", err)
-	}
-	foundPlanEntry := false
-	for _, entry := range entries {
-		if entry.Action == "write" && entry.Path == "/workspace/app/main.txt" {
-			foundPlanEntry = true
-			break
-		}
-	}
-	if !foundPlanEntry {
-		t.Fatalf("expected symlinked workspace root plan to include app/main.txt, got %#v", entries)
-	}
-
-	var archive bytes.Buffer
-	if err := writeRawWorkspaceTar(&archive, linkRoot); err != nil {
-		t.Fatalf("writeRawWorkspaceTar returned error: %v", err)
-	}
-	tr := tar.NewReader(&archive)
-	files := map[string]string{}
-	for {
-		header, err := tr.Next()
-		if errors.Is(err, io.EOF) {
-			break
-		}
-		if err != nil {
-			t.Fatalf("read archive: %v", err)
-		}
-		if header.Typeflag != tar.TypeReg {
-			continue
-		}
-		data, err := io.ReadAll(tr)
-		if err != nil {
-			t.Fatalf("read archived file: %v", err)
-		}
-		files[header.Name] = string(data)
-	}
-	if got, want := files["app/main.txt"], "payload\n"; got != want {
-		t.Fatalf("unexpected archived file content: got %q want %q; files=%#v", got, want, files)
-	}
-}
-
-func TestWorkspaceCopyInRejectsUnsafeRawDestinationRoot(t *testing.T) {
-	sourceRoot := t.TempDir()
-	err := copyRawWorkspaceToSandbox(context.Background(), &runtimeContext{}, nil, workspaceCopyOptions{
-		CWD:         sourceRoot,
-		SandboxID:   "cr_123",
-		Destination: "/",
-	})
-	if err == nil {
-		t.Fatal("expected unsafe raw workspace destination to be rejected")
-	}
-	if !strings.Contains(err.Error(), "unsafe for raw workspace copy-in") {
-		t.Fatalf("expected unsafe destination error, got %v", err)
-	}
-}
-
-func TestWorkspaceCopyInRejectsRawCopyWhenSandboxWorkspaceRootUnknown(t *testing.T) {
+func TestWorkspaceCopyInRejectsNonGitWorkspace(t *testing.T) {
 	sourceRoot := t.TempDir()
 	adapter := &copyIntegrationAdapter{}
 	host, _ := startIntegrationServer(t, adapter)
-	sandboxID := createWorkspaceCopyTestSandbox(t, host, copyTestPolicy())
-
+	sandboxID := createWorkspaceCopyTestSandboxWithRepository(t, host, "/workspace-app")
 	stdout, _ := makeStdoutCapture(t)
 	stderr, _ := makeStdoutCapture(t)
+
 	cmd := WorkspaceCopyInCommand{
 		clientFlags: clientFlags{Host: host},
 		Chdir:       sourceRoot,
@@ -2246,10 +2160,10 @@ func TestWorkspaceCopyInRejectsRawCopyWhenSandboxWorkspaceRootUnknown(t *testing
 		Stderr:        stderr,
 	})
 	if err == nil {
-		t.Fatal("expected raw workspace copy-in to reject sandbox without recorded workspace root")
+		t.Fatal("expected non-Git workspace copy-in to be rejected")
 	}
-	if !strings.Contains(err.Error(), "does not have a recorded workspace root") {
-		t.Fatalf("expected recorded workspace root error, got %v", err)
+	if !strings.Contains(err.Error(), "requires a local Git repository checkout") {
+		t.Fatalf("expected Git checkout error, got %v", err)
 	}
 }
 
@@ -2285,31 +2199,35 @@ func TestWorkspaceCopyInRejectsGitCopyWhenSandboxWorkspaceRootUnknown(t *testing
 	}
 }
 
-func TestTopLevelCopyInRejectsNonGitWorkspaceWhenCreatingSandbox(t *testing.T) {
-	cwd := t.TempDir()
-	_, err := resolveExecutionSandbox(
-		context.Background(),
-		nil,
-		&runtimeContext{
-			CWD:    cwd,
-			Loader: repositoryNotFoundLoader{},
-		},
-		cwd,
-		"",
-		"",
-		"",
-		"",
-		"",
-		0,
-		false,
-		repositoryOverrideFlags{},
-		workspaceCopyFlags{CopyIn: true},
-	)
-	if err == nil {
-		t.Fatal("expected non-Git top-level --copy-in to be rejected before sandbox creation")
-	}
-	if !strings.Contains(err.Error(), "non-Git workspaces") {
-		t.Fatalf("expected non-Git copy error, got %v", err)
+func TestTopLevelCopyInRejectsNonGitWorkspace(t *testing.T) {
+	for _, existingSandboxID := range []string{"", "cr_existing"} {
+		t.Run(fmt.Sprintf("existing=%t", existingSandboxID != ""), func(t *testing.T) {
+			cwd := t.TempDir()
+			_, err := resolveExecutionSandbox(
+				context.Background(),
+				nil,
+				&runtimeContext{
+					CWD:    cwd,
+					Loader: repositoryNotFoundLoader{},
+				},
+				cwd,
+				"",
+				"",
+				existingSandboxID,
+				"",
+				"",
+				0,
+				false,
+				repositoryOverrideFlags{},
+				workspaceCopyFlags{CopyIn: true},
+			)
+			if err == nil {
+				t.Fatal("expected non-Git top-level --copy-in to be rejected")
+			}
+			if !strings.Contains(err.Error(), "requires a local Git repository checkout") {
+				t.Fatalf("expected non-Git copy error, got %v", err)
+			}
+		})
 	}
 }
 
@@ -2474,32 +2392,18 @@ func setupWorkspaceCopyOutManifestBaseWithLocalMutate(t *testing.T, localMutate,
 	}
 }
 
-func assertWorkspaceCopyOutRecoveryPayload(t *testing.T, sandboxID string) {
+func assertNoWorkspaceCopyOutRecoveryPayload(t *testing.T) {
 	t.Helper()
 	recoveryRoot := filepath.Join(os.Getenv("XDG_STATE_HOME"), "cleanroom", "workspace-copy-out")
 	entries, err := os.ReadDir(recoveryRoot)
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return
+		}
 		t.Fatalf("read workspace copy-out recovery root: %v", err)
 	}
-	prefix := safeWorkspaceStateName(sandboxID) + "-"
-	var matches []os.DirEntry
-	for _, entry := range entries {
-		if entry.IsDir() && strings.HasPrefix(entry.Name(), prefix) {
-			matches = append(matches, entry)
-		}
-	}
-	if len(matches) != 1 {
-		t.Fatalf("expected one recovery payload for %q, got %d", sandboxID, len(matches))
-	}
-	payloadDir := filepath.Join(recoveryRoot, matches[0].Name())
-	for _, name := range []string{"changes.patch", "manifest.json"} {
-		info, err := os.Stat(filepath.Join(payloadDir, name))
-		if err != nil {
-			t.Fatalf("expected recovery payload %s: %v", name, err)
-		}
-		if info.Size() == 0 {
-			t.Fatalf("expected non-empty recovery payload %s", name)
-		}
+	if len(entries) != 0 {
+		t.Fatalf("expected no workspace copy-out recovery payloads, got %d", len(entries))
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `workspace copy-out --force` as the explicit overwrite path for local target conflicts
- aggregate copy-out conflicts and remove recovery payload directory creation from the normal UX
- make workspace copy-in/copy-out Git-backed only for now, including plan doc updates and removal of dead raw workspace-copy helpers

## Validation
- `git diff --check`
- `mise exec -- go test ./internal/cli`
- `mise exec -- go test ./...`
- `mise exec -- go run ./cmd/cleanroom workspace copy-out --help`