### PR TITLE
fix: Validate block-volume cache metadata

### DIFF
--- a/docs/plans/dependency-service-volume-caches.md
+++ b/docs/plans/dependency-service-volume-caches.md
@@ -734,6 +734,11 @@ Completed in phase 2:
   dependency output keys
 - dependency block-volume cache lookup marks per-block hits and misses using the
   cache metadata fields introduced in phase 1
+- dependency and service block-volume keys use strict regular-file input
+  manifests, rejecting symlinks, directories, gitlinks, missing paths, and
+  deleted paths before file-keyed cache reuse
+- dependency and service block-volume hits validate cached output records against
+  the declared output kind/path set before treating metadata as restorable
 - runtime fallback decision requires backend support for cache output volumes and
   overlay write capture before the future block-volume path can be selected
 - sandbox creation now evaluates dependency block-volume lookup after exact and
@@ -745,6 +750,8 @@ Completed in phase 2:
   miss counts, and logs fallback and lookup summaries
 - tests cover ordered keying, prior-block invalidation, partial cache hits, and
   fallback when backend capabilities are missing
+- tests cover strict input validation and output-record mismatch rejection before
+  block-volume records are treated as hits
 - `CreateSandbox` tests cover unsupported backend fallback, missing store
   fallback, partial dependency block-volume hits, and all-hit lookup behavior
   while confirming the aggregate dependency bootstrap still runs

--- a/internal/controlservice/dependency_stage.go
+++ b/internal/controlservice/dependency_stage.go
@@ -51,6 +51,12 @@ type stageKeyFileDigest struct {
 	Deleted bool   `json:"deleted,omitempty"`
 }
 
+type stageInputFileDigest struct {
+	Path   string `json:"path"`
+	Mode   string `json:"mode"`
+	SHA256 string `json:"sha256"`
+}
+
 func dependencyStagePlanForRepository(compiled *policy.CompiledPolicy, repository *repositorycheckout.Checkout) (dependencyStagePlan, bool) {
 	if compiled == nil || repository == nil || !compiled.Dependencies.Enabled() {
 		return dependencyStagePlan{}, false
@@ -183,6 +189,62 @@ func (s *Service) stageKeyFilesDigest(ctx context.Context, repository *repositor
 	return digest, nil
 }
 
+func (s *Service) stageInputFilesDigest(ctx context.Context, repository *repositorycheckout.Checkout, changeset *repositorychangeset.Changeset, commitBundle *repositorybundle.Bundle, files []string, stageName string) (string, error) {
+	if len(files) == 0 {
+		return "", nil
+	}
+	if repository == nil {
+		return "", fmt.Errorf("%s input files require a repository checkout", stageName)
+	}
+	if s.RepositoryStore == nil {
+		return "", fmt.Errorf("%s input files require repository store", stageName)
+	}
+	if commitBundle != nil {
+		prerequisiteCommit, err := s.ensureRepositoryCommitBundlePrerequisites(ctx, repository, commitBundle)
+		if err != nil {
+			return "", err
+		}
+		var digest string
+		err = s.RepositoryStore.WithRepository(ctx, repository.RemoteURL, prerequisiteCommit, repositorystore.FetchHints{}, func(repoDir string) error {
+			return commitBundle.WithRepository(ctx, repoDir, func(bundleRepoDir string) error {
+				var err error
+				if changeset != nil {
+					digest, err = stageInputFilesDigestWithChangeset(bundleRepoDir, changeset, files, stageName)
+				} else {
+					digest, err = stageInputFilesDigestAtCommit(ctx, bundleRepoDir, repository.CommitSHA, files, stageName)
+				}
+				return err
+			})
+		})
+		if err != nil {
+			return "", err
+		}
+		return digest, nil
+	}
+	if changeset != nil {
+		var digest string
+		err := s.RepositoryStore.WithRepository(ctx, repository.RemoteURL, repository.CommitSHA, repositorystore.FetchHints{}, func(repoDir string) error {
+			var err error
+			digest, err = stageInputFilesDigestWithChangeset(repoDir, changeset, files, stageName)
+			return err
+		})
+		if err != nil {
+			return "", err
+		}
+		return digest, nil
+	}
+	var digest string
+	err := s.RepositoryStore.WithRepository(ctx, repository.RemoteURL, repository.CommitSHA, repositorystore.FetchHints{}, func(repoDir string) error {
+		var err error
+		digest, err = stageInputFilesDigestAtCommit(ctx, repoDir, repository.CommitSHA, files, stageName)
+		return err
+	})
+	if err != nil {
+		return "", err
+	}
+	return digest, nil
+}
+
 func stageKeyFilesDigestWithChangeset(repoDir string, changeset *repositorychangeset.Changeset, files []string, stageName string) (string, error) {
 	manifest := make([]stageKeyFileDigest, 0, len(files))
 	digests, err := changeset.DigestPathsFromBase(strings.TrimSpace(repoDir), files)
@@ -204,6 +266,22 @@ func stageKeyFilesDigestWithChangeset(repoDir string, changeset *repositorychang
 
 	sum := sha256.Sum256(payload)
 	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
+func stageInputFilesDigestWithChangeset(repoDir string, changeset *repositorychangeset.Changeset, files []string, stageName string) (string, error) {
+	digests, err := changeset.DigestRegularFilesFromBase(strings.TrimSpace(repoDir), files)
+	if err != nil {
+		return "", fmt.Errorf("read %s input files from repository changeset: %w", stageName, err)
+	}
+	manifest := make([]stageInputFileDigest, 0, len(digests))
+	for _, file := range digests {
+		manifest = append(manifest, stageInputFileDigest{
+			Path:   file.Path,
+			Mode:   file.Mode,
+			SHA256: file.SHA256,
+		})
+	}
+	return digestStageInputFileManifest(manifest, stageName)
 }
 
 func stageKeyFilesDigestAtCommit(ctx context.Context, repoDir, commitSHA string, files []string, stageName string) (string, error) {
@@ -233,6 +311,50 @@ func stageKeyFilesDigestAtCommit(ctx context.Context, repoDir, commitSHA string,
 		return "", fmt.Errorf("marshal %s key file manifest: %w", stageName, err)
 	}
 
+	sum := sha256.Sum256(payload)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
+func stageInputFilesDigestAtCommit(ctx context.Context, repoDir, commitSHA string, files []string, stageName string) (string, error) {
+	trimmedCommitSHA := strings.TrimSpace(commitSHA)
+	if trimmedCommitSHA == "" {
+		return "", fmt.Errorf("%s input file commit SHA is empty", stageName)
+	}
+	expandedFiles, err := expandStageKeyFilesAtCommit(ctx, repoDir, trimmedCommitSHA, files, stageName)
+	if err != nil {
+		return "", err
+	}
+
+	manifest := make([]stageInputFileDigest, 0, len(expandedFiles))
+	for _, file := range expandedFiles {
+		entry, ok, err := gitTreeEntryAtCommit(ctx, strings.TrimSpace(repoDir), trimmedCommitSHA, file)
+		if err != nil {
+			return "", fmt.Errorf("inspect %s input file %q: %w", stageName, file, err)
+		}
+		if !ok {
+			return "", fmt.Errorf("%s input file %q does not exist", stageName, file)
+		}
+		if !isRegularGitTreeFile(entry) {
+			return "", fmt.Errorf("%s input file %q is %s; inputs.files must name regular files", stageName, file, gitTreeEntryKind(entry))
+		}
+		digest, err := gitFileDigestAtCommit(ctx, strings.TrimSpace(repoDir), trimmedCommitSHA, file)
+		if err != nil {
+			return "", fmt.Errorf("read %s input file %q: %w", stageName, file, err)
+		}
+		manifest = append(manifest, stageInputFileDigest{
+			Path:   file,
+			Mode:   entry.Mode,
+			SHA256: digest,
+		})
+	}
+	return digestStageInputFileManifest(manifest, stageName)
+}
+
+func digestStageInputFileManifest(manifest []stageInputFileDigest, stageName string) (string, error) {
+	payload, err := json.Marshal(manifest)
+	if err != nil {
+		return "", fmt.Errorf("marshal %s input file manifest: %w", stageName, err)
+	}
 	sum := sha256.Sum256(payload)
 	return "sha256:" + hex.EncodeToString(sum[:]), nil
 }
@@ -320,6 +442,63 @@ func gitFileDigestAtCommit(ctx context.Context, repoDir, commitSHA, file string)
 
 	sum := sha256.Sum256(output)
 	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
+type gitTreeEntry struct {
+	Mode string
+	Type string
+}
+
+func gitTreeEntryAtCommit(ctx context.Context, repoDir, commitSHA, file string) (gitTreeEntry, bool, error) {
+	cmd := exec.CommandContext(ctx, "git", "-C", repoDir, "ls-tree", "-z", commitSHA, "--", literalStageGitPathspec(file))
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		message := strings.TrimSpace(string(output))
+		if message == "" {
+			message = err.Error()
+		}
+		return gitTreeEntry{}, false, fmt.Errorf("%s", message)
+	}
+	output = bytes.TrimRight(output, "\x00")
+	if len(bytes.TrimSpace(output)) == 0 {
+		return gitTreeEntry{}, false, nil
+	}
+	for _, raw := range bytes.Split(output, []byte{0}) {
+		metadata, rawPath, ok := bytes.Cut(raw, []byte{'\t'})
+		if !ok {
+			return gitTreeEntry{}, false, fmt.Errorf("parse git tree entry %q", string(raw))
+		}
+		if path.Clean(strings.ReplaceAll(string(rawPath), "\\", "/")) != file {
+			continue
+		}
+		fields := strings.Fields(string(metadata))
+		if len(fields) < 3 {
+			return gitTreeEntry{}, false, fmt.Errorf("parse git tree entry %q", string(raw))
+		}
+		return gitTreeEntry{Mode: fields[0], Type: fields[1]}, true, nil
+	}
+	return gitTreeEntry{}, false, nil
+}
+
+func isRegularGitTreeFile(entry gitTreeEntry) bool {
+	return strings.TrimSpace(entry.Type) == "blob" && (entry.Mode == "100644" || entry.Mode == "100755")
+}
+
+func gitTreeEntryKind(entry gitTreeEntry) string {
+	switch strings.TrimSpace(entry.Mode) {
+	case "040000":
+		return "a directory"
+	case "120000":
+		return "a symlink"
+	case "160000":
+		return "a gitlink"
+	default:
+		return "not a regular file"
+	}
+}
+
+func literalStageGitPathspec(normalizedPath string) string {
+	return ":(literal)" + normalizedPath
 }
 
 func (s *Service) lookupDependencyStageCache(ctx context.Context, backendName string, compiled *policy.CompiledPolicy, repository *repositorycheckout.Checkout, changeset *repositorychangeset.Changeset, plan dependencyStagePlan) (cachestore.Record, bool, string, error) {

--- a/internal/controlservice/dependency_volume_plan.go
+++ b/internal/controlservice/dependency_volume_plan.go
@@ -172,7 +172,7 @@ func (s *Service) finalizeDependencyBlockVolumeBlockPlan(
 	block policy.StageBlock,
 	priorOutputKeys []string,
 ) (dependencyBlockVolumeBlockPlan, error) {
-	inputDigest, err := s.stageKeyFilesDigest(ctx, repository, changeset, commitBundle, block.Inputs.Files, dependencyVolumeStageName+" "+block.Name)
+	inputDigest, err := s.stageInputFilesDigest(ctx, repository, changeset, commitBundle, block.Inputs.Files, dependencyVolumeStageName+" "+block.Name)
 	if err != nil {
 		return dependencyBlockVolumeBlockPlan{}, err
 	}
@@ -326,11 +326,50 @@ func dependencyBlockVolumeRecordMissReason(record cachestore.Record, backendName
 		strings.TrimSpace(record.CommandDigest) != strings.TrimSpace(block.CommandDigest) ||
 		strings.TrimSpace(record.EnvDigest) != strings.TrimSpace(block.EnvDigest) ||
 		strings.TrimSpace(record.NormalizedOutputsDigest) != strings.TrimSpace(block.NormalizedOutputsDigest) ||
-		strings.TrimSpace(record.ProducerVersion) != strings.TrimSpace(block.ProducerVersion) ||
-		len(record.OutputRecords) == 0 {
+		strings.TrimSpace(record.ProducerVersion) != strings.TrimSpace(block.ProducerVersion) {
 		return observability.CacheLookupReasonRecordNotFound
 	}
+	if reason := blockVolumeOutputRecordMissReason(block.Outputs, record.OutputRecords); reason != "" {
+		return reason
+	}
 	return ""
+}
+
+func blockVolumeOutputRecordMissReason(outputs policy.StageBlockOutputs, records []cachestore.OutputRecord) string {
+	expected := make(map[string]struct{}, len(outputs.Dirs)+len(outputs.Files))
+	for _, dir := range outputs.Dirs {
+		expected[blockVolumeOutputRecordKey("dir", dir)] = struct{}{}
+	}
+	for _, file := range outputs.Files {
+		expected[blockVolumeOutputRecordKey("file", file)] = struct{}{}
+	}
+	if len(expected) == 0 || len(records) != len(expected) {
+		return observability.CacheLookupReasonRecordNotFound
+	}
+
+	seen := make(map[string]struct{}, len(records))
+	for _, record := range records {
+		kind := strings.TrimSpace(record.Kind)
+		path := strings.TrimSpace(record.Path)
+		key := blockVolumeOutputRecordKey(kind, path)
+		if _, ok := expected[key]; !ok {
+			return observability.CacheLookupReasonRecordNotFound
+		}
+		if _, ok := seen[key]; ok {
+			return observability.CacheLookupReasonRecordNotFound
+		}
+		seen[key] = struct{}{}
+		if strings.TrimSpace(record.VolumeSubpath) == "" ||
+			strings.TrimSpace(record.StorageDriver) == "" ||
+			strings.TrimSpace(record.StorageRef) == "" {
+			return observability.CacheLookupReasonRecordNotFound
+		}
+	}
+	return ""
+}
+
+func blockVolumeOutputRecordKey(kind, path string) string {
+	return strings.TrimSpace(kind) + "\x00" + strings.TrimSpace(path)
 }
 
 type envEntry struct {

--- a/internal/controlservice/dependency_volume_plan_test.go
+++ b/internal/controlservice/dependency_volume_plan_test.go
@@ -2,6 +2,8 @@ package controlservice
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -113,6 +115,44 @@ func TestFinalizeDependencyBlockVolumePlanBuildsOrderedKeys(t *testing.T) {
 	}
 }
 
+func TestFinalizeDependencyBlockVolumePlanRejectsSymlinkInput(t *testing.T) {
+	repoDir := t.TempDir()
+	runTestGit(t, repoDir, "init")
+	runTestGit(t, repoDir, "config", "user.email", "test@example.com")
+	runTestGit(t, repoDir, "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(repoDir, "real.lock"), []byte("real\n"), 0o644); err != nil {
+		t.Fatalf("write real.lock: %v", err)
+	}
+	if err := os.Symlink("real.lock", filepath.Join(repoDir, "link.lock")); err != nil {
+		t.Fatalf("symlink link.lock: %v", err)
+	}
+	runTestGit(t, repoDir, "add", ".")
+	runTestGit(t, repoDir, "commit", "-m", "test")
+	repositoryCheckout := &cleanroomv1.RepositoryCheckout{
+		RemoteUrl:      "https://github.com/buildkite/cleanroom.git",
+		CommitSha:      strings.TrimSpace(runTestGit(t, repoDir, "rev-parse", "HEAD")),
+		DestinationDir: "/workspace",
+	}
+
+	svc := newTestService(&stubAdapter{})
+	svc.RepositoryStore = &stubRepositoryMirrorStore{mirrorPath: repoDir}
+	policyProto := testRepositoryTwoDependencyBlocksPolicy()
+	policyProto.Dependencies.Blocks[0].Inputs.Files = []string{"link.lock"}
+	compiled, err := policy.FromProto(policyProto)
+	if err != nil {
+		t.Fatalf("FromProto returned error: %v", err)
+	}
+	repository := repositorycheckout.FromProto(repositoryCheckout)
+
+	_, _, err = svc.finalizeDependencyBlockVolumePlan(context.Background(), compiled, repository, nil, nil, "firecracker", "runtime-base:test")
+	if err == nil {
+		t.Fatal("expected symlink input to fail")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("expected symlink error, got %v", err)
+	}
+}
+
 func TestLookupDependencyBlockVolumeCachesReportsPartialHit(t *testing.T) {
 	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
 		"mise.toml": "go = \"1.26.2\"\n",
@@ -162,6 +202,50 @@ func TestLookupDependencyBlockVolumeCachesReportsPartialHit(t *testing.T) {
 	}
 	if got, want := lookedUp.Blocks[1].LookupReason, observability.CacheLookupReasonRecordNotFound; got != want {
 		t.Fatalf("unexpected second block miss reason: got %q want %q", got, want)
+	}
+}
+
+func TestLookupDependencyBlockVolumeCachesRejectsMismatchedOutputRecords(t *testing.T) {
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"mise.toml": "go = \"1.26.2\"\n",
+		"go.mod":    "module example.com/test\n\ngo 1.26.2\n",
+		"go.sum":    "example.com/test v0.0.0 h1:abc123\n",
+	})
+	svc := newTestService(&stubAdapter{})
+	svc.RepositoryStore = mirrors
+
+	compiled, err := policy.FromProto(testRepositoryTwoDependencyBlocksPolicy())
+	if err != nil {
+		t.Fatalf("FromProto returned error: %v", err)
+	}
+	repository := repositorycheckout.FromProto(repositoryCheckout)
+	plan, ok, err := svc.finalizeDependencyBlockVolumePlan(context.Background(), compiled, repository, nil, nil, "firecracker", "runtime-base:test")
+	if err != nil {
+		t.Fatalf("finalizeDependencyBlockVolumePlan returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected dependency block volume plan")
+	}
+
+	record := dependencyBlockVolumeTestRecord(compiled, plan.Blocks[0])
+	record.OutputRecords[0].Path = "/root/other"
+	cacheStore, ok := svc.CacheStore.(*memoryCacheStore)
+	if !ok {
+		t.Fatalf("expected memory cache store, got %T", svc.CacheStore)
+	}
+	if err := cacheStore.Create(context.Background(), record); err != nil {
+		t.Fatalf("Create cache record returned error: %v", err)
+	}
+
+	lookedUp, err := svc.lookupDependencyBlockVolumeCaches(context.Background(), "firecracker", compiled, plan)
+	if err != nil {
+		t.Fatalf("lookupDependencyBlockVolumeCaches returned error: %v", err)
+	}
+	if lookedUp.Blocks[0].CacheHit {
+		t.Fatal("did not expect cache hit with mismatched output record path")
+	}
+	if got, want := lookedUp.Blocks[0].LookupReason, observability.CacheLookupReasonRecordNotFound; got != want {
+		t.Fatalf("unexpected lookup reason: got %q want %q", got, want)
 	}
 }
 

--- a/internal/controlservice/service_volume_plan.go
+++ b/internal/controlservice/service_volume_plan.go
@@ -173,7 +173,7 @@ func (s *Service) finalizeServiceBlockVolumeBlockPlan(
 	block policy.StageBlock,
 	priorServiceOutputKeys []string,
 ) (serviceBlockVolumeBlockPlan, error) {
-	inputDigest, err := s.stageKeyFilesDigest(ctx, repository, changeset, commitBundle, block.Inputs.Files, serviceVolumeStageName+" "+block.Name)
+	inputDigest, err := s.stageInputFilesDigest(ctx, repository, changeset, commitBundle, block.Inputs.Files, serviceVolumeStageName+" "+block.Name)
 	if err != nil {
 		return serviceBlockVolumeBlockPlan{}, err
 	}
@@ -345,9 +345,11 @@ func serviceBlockVolumeRecordMissReason(record cachestore.Record, backendName st
 		strings.TrimSpace(record.CommandDigest) != strings.TrimSpace(block.CommandDigest) ||
 		strings.TrimSpace(record.EnvDigest) != strings.TrimSpace(block.EnvDigest) ||
 		strings.TrimSpace(record.NormalizedOutputsDigest) != strings.TrimSpace(block.NormalizedOutputsDigest) ||
-		strings.TrimSpace(record.ProducerVersion) != strings.TrimSpace(block.ProducerVersion) ||
-		len(record.OutputRecords) == 0 {
+		strings.TrimSpace(record.ProducerVersion) != strings.TrimSpace(block.ProducerVersion) {
 		return observability.CacheLookupReasonRecordNotFound
+	}
+	if reason := blockVolumeOutputRecordMissReason(block.Outputs, record.OutputRecords); reason != "" {
+		return reason
 	}
 	return ""
 }

--- a/internal/controlservice/service_volume_plan_test.go
+++ b/internal/controlservice/service_volume_plan_test.go
@@ -177,6 +177,62 @@ func TestLookupServiceBlockVolumeCachesReportsPartialHit(t *testing.T) {
 	}
 }
 
+func TestLookupServiceBlockVolumeCachesRejectsMismatchedOutputRecords(t *testing.T) {
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"mise.toml":           "go = \"1.26.2\"\n",
+		"go.mod":              "module example.com/test\n\ngo 1.26.2\n",
+		"go.sum":              "example.com/test v0.0.0 h1:abc123\n",
+		"docker-compose.yml":  "services:\n  postgres:\n    image: postgres:17\n",
+		"db/schema.sql":       "create table widgets (id serial primary key);\n",
+		"db/seed.sql":         "insert into widgets default values;\n",
+		"scripts/prepare-db":  "#!/bin/sh\ntrue\n",
+		"scripts/prepare-app": "#!/bin/sh\ntrue\n",
+	})
+	svc := newTestService(&stubAdapter{})
+	svc.RepositoryStore = mirrors
+
+	compiled, err := policy.FromProto(testRepositoryTwoDependencyTwoServiceBlocksPolicy())
+	if err != nil {
+		t.Fatalf("FromProto returned error: %v", err)
+	}
+	repository := repositorycheckout.FromProto(repositoryCheckout)
+	dependencyPlan, ok, err := svc.finalizeDependencyBlockVolumePlan(context.Background(), compiled, repository, nil, nil, "firecracker", "runtime-base:test")
+	if err != nil {
+		t.Fatalf("finalizeDependencyBlockVolumePlan returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected dependency block-volume plan")
+	}
+	plan, ok, err := svc.finalizeServiceBlockVolumePlan(context.Background(), compiled, repository, nil, nil, "firecracker", "runtime-base:test", dependencyPlan)
+	if err != nil {
+		t.Fatalf("finalizeServiceBlockVolumePlan returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected service block-volume plan")
+	}
+
+	record := serviceBlockVolumeTestRecord(compiled, plan.Blocks[0])
+	record.OutputRecords[0].Kind = "file"
+	cacheStore, ok := svc.CacheStore.(*memoryCacheStore)
+	if !ok {
+		t.Fatalf("expected memory cache store, got %T", svc.CacheStore)
+	}
+	if err := cacheStore.Create(context.Background(), record); err != nil {
+		t.Fatalf("Create cache record returned error: %v", err)
+	}
+
+	lookedUp, err := svc.lookupServiceBlockVolumeCaches(context.Background(), "firecracker", compiled, plan)
+	if err != nil {
+		t.Fatalf("lookupServiceBlockVolumeCaches returned error: %v", err)
+	}
+	if lookedUp.Blocks[0].CacheHit {
+		t.Fatal("did not expect cache hit with mismatched output record kind")
+	}
+	if got, want := lookedUp.Blocks[0].LookupReason, observability.CacheLookupReasonRecordNotFound; got != want {
+		t.Fatalf("unexpected lookup reason: got %q want %q", got, want)
+	}
+}
+
 func TestCreateSandboxSkipsServiceBlockVolumeLookupWhenBackendUnsupported(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	adapter := &stubAdapter{}

--- a/internal/repositorychangeset/changeset.go
+++ b/internal/repositorychangeset/changeset.go
@@ -107,6 +107,14 @@ func BuildFromWorkingTree(repoRoot string, checkout *repositorycheckout.Checkout
 }
 
 func (c *Changeset) DigestPathsFromBase(repoRoot string, paths []string) ([]File, error) {
+	return c.digestPathsFromBase(repoRoot, paths, false)
+}
+
+func (c *Changeset) DigestRegularFilesFromBase(repoRoot string, paths []string) ([]File, error) {
+	return c.digestPathsFromBase(repoRoot, paths, true)
+}
+
+func (c *Changeset) digestPathsFromBase(repoRoot string, paths []string, regularFilesOnly bool) ([]File, error) {
 	if c == nil {
 		return nil, errors.New("repository changeset is required")
 	}
@@ -159,7 +167,12 @@ func (c *Changeset) DigestPathsFromBase(repoRoot string, paths []string) ([]File
 		return nil, fmt.Errorf("apply repository changeset patch to temporary git index: %w", err)
 	}
 
-	expandedPaths, err := expandDigestPathsInIndex(repoRoot, env, baseCommitSHA, paths)
+	var expandedPaths []string
+	if regularFilesOnly {
+		expandedPaths, err = expandRegularDigestPathsInIndex(repoRoot, env, paths)
+	} else {
+		expandedPaths, err = expandDigestPathsInIndex(repoRoot, env, baseCommitSHA, paths)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -171,11 +184,17 @@ func (c *Changeset) DigestPathsFromBase(repoRoot string, paths []string) ([]File
 			return nil, fmt.Errorf("check repository changeset path %q in temporary git index: %w", normalizedPath, err)
 		}
 		if !exists {
+			if regularFilesOnly {
+				return nil, fmt.Errorf("repository changeset input path %q does not exist", normalizedPath)
+			}
 			file.Deleted = true
 			files = append(files, file)
 			continue
 		}
 		file.Mode = mode
+		if regularFilesOnly && !isRegularGitFileMode(mode) {
+			return nil, fmt.Errorf("repository changeset input path %q is %s; inputs.files must name regular files", normalizedPath, gitModeKind(mode))
+		}
 
 		blob, err := gitOutput(repoRoot, env, "show", ":"+normalizedPath)
 		if err != nil {
@@ -235,6 +254,57 @@ func expandDigestPathsInIndex(repoRoot string, env []string, baseCommitSHA strin
 		}
 		if matches == 0 {
 			return nil, fmt.Errorf("repository changeset digest path glob %q matched no files", normalizedPath)
+		}
+	}
+	sort.Strings(expanded)
+	return expanded, nil
+}
+
+func expandRegularDigestPathsInIndex(repoRoot string, env []string, paths []string) ([]string, error) {
+	seen := make(map[string]struct{}, len(paths))
+	var expanded []string
+	var indexPaths []string
+	for _, rawPath := range paths {
+		normalizedPath := normalizePath(rawPath)
+		if normalizedPath == "" {
+			return nil, fmt.Errorf("repository changeset input path %q is invalid", rawPath)
+		}
+		if !strings.ContainsAny(normalizedPath, "*?[") {
+			if _, exists := seen[normalizedPath]; exists {
+				continue
+			}
+			seen[normalizedPath] = struct{}{}
+			expanded = append(expanded, normalizedPath)
+			continue
+		}
+		if _, err := path.Match(normalizedPath, ""); err != nil {
+			return nil, fmt.Errorf("repository changeset input path glob %q is invalid: %w", normalizedPath, err)
+		}
+		if indexPaths == nil {
+			var err error
+			indexPaths, err = listIndexPaths(repoRoot, env)
+			if err != nil {
+				return nil, err
+			}
+		}
+		matches := 0
+		for _, candidate := range indexPaths {
+			matched, err := path.Match(normalizedPath, candidate)
+			if err != nil {
+				return nil, fmt.Errorf("repository changeset input path glob %q is invalid: %w", normalizedPath, err)
+			}
+			if !matched {
+				continue
+			}
+			matches++
+			if _, exists := seen[candidate]; exists {
+				continue
+			}
+			seen[candidate] = struct{}{}
+			expanded = append(expanded, candidate)
+		}
+		if matches == 0 {
+			return nil, fmt.Errorf("repository changeset input path glob %q matched no files", normalizedPath)
 		}
 	}
 	sort.Strings(expanded)
@@ -648,6 +718,28 @@ func gitIndexMode(output []byte, normalizedPath string) (string, bool, error) {
 		return fields[0], true, nil
 	}
 	return "", false, nil
+}
+
+func isRegularGitFileMode(mode string) bool {
+	switch strings.TrimSpace(mode) {
+	case "100644", "100755":
+		return true
+	default:
+		return false
+	}
+}
+
+func gitModeKind(mode string) string {
+	switch strings.TrimSpace(mode) {
+	case "040000":
+		return "a directory"
+	case "120000":
+		return "a symlink"
+	case "160000":
+		return "a gitlink"
+	default:
+		return "not a regular file"
+	}
 }
 
 func literalGitPathspec(normalizedPath string) string {

--- a/internal/repositorychangeset/changeset_test.go
+++ b/internal/repositorychangeset/changeset_test.go
@@ -331,6 +331,38 @@ func TestDigestPathsFromBaseUsesPatchedContents(t *testing.T) {
 	}
 }
 
+func TestDigestRegularFilesFromBaseRejectsSymlink(t *testing.T) {
+	repoDir := initGitRepository(t)
+	if err := os.WriteFile(filepath.Join(repoDir, "real.lock"), []byte("real\n"), 0o644); err != nil {
+		t.Fatalf("write real.lock: %v", err)
+	}
+	if err := os.Symlink("real.lock", filepath.Join(repoDir, "link.lock")); err != nil {
+		t.Fatalf("symlink link.lock: %v", err)
+	}
+
+	checkout := &repositorycheckout.Checkout{
+		RemoteURL:      "https://github.com/buildkite/cleanroom.git",
+		CommitSHA:      headCommit(t, repoDir),
+		DestinationDir: "/workspace",
+	}
+
+	changeset, err := BuildFromWorkingTree(repoDir, checkout)
+	if err != nil {
+		t.Fatalf("BuildFromWorkingTree returned error: %v", err)
+	}
+	if changeset == nil {
+		t.Fatal("expected changeset")
+	}
+
+	_, err = changeset.DigestRegularFilesFromBase(repoDir, []string{"link.lock"})
+	if err == nil {
+		t.Fatal("expected symlink input to fail")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("expected symlink error, got %v", err)
+	}
+}
+
 func TestResetCommandsUseDoubleForceClean(t *testing.T) {
 	checkout := &repositorycheckout.Checkout{
 		CommitSHA:      "0123456789abcdef0123456789abcdef01234567",


### PR DESCRIPTION
## Problem

PR #281 wires dependency and service block-volume lookup, but the hit predicate still needed two deterministic-cache guardrails before the runtime starts consuming those records:

- block-volume keys must reject readable non-regular inputs instead of hashing symlink contents or deleted paths
- ready records must prove their output metadata matches the block outputs before being treated as hits

## Changes

- Adds strict regular-file input digesting for dependency and service block-volume keys, including changeset-aware validation.
- Rejects symlinks, directories, gitlinks, missing paths, and deleted paths for block-volume input manifests.
- Validates output record kind/path/count and required storage refs before marking dependency or service block-volume records as hits.
- Updates the volume-cache plan with the completed validation guardrails.

## Validation

- `mise exec -- gofmt -w internal/repositorychangeset/changeset.go internal/repositorychangeset/changeset_test.go internal/controlservice/dependency_stage.go internal/controlservice/dependency_volume_plan.go internal/controlservice/dependency_volume_plan_test.go internal/controlservice/service_volume_plan.go internal/controlservice/service_volume_plan_test.go`
- `git diff --check`
- `mise exec -- go test ./...`
