### PR TITLE
fix: Reject unreadable darwin-vz rootfs restores

### DIFF
--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -1053,6 +1053,10 @@ func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream 
 		observation.Error = err.Error()
 		return nil, fmt.Errorf("resize writable rootfs: %w", err)
 	}
+	if err := validateRootFSInspectable(vmRootFSPath); err != nil {
+		observation.Error = err.Error()
+		return nil, fmt.Errorf("validate writable rootfs: %w", err)
+	}
 	observation.RootFSCopyMS = time.Since(copyStart).Milliseconds()
 	defer func() {
 		_ = driver.DestroyVolume(context.Background(), volumestore.DestroyVolumeRequest{VolumeRef: vmRootFSPath})
@@ -1333,6 +1337,9 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 	vmRootFSPath = writableVolume.AttachmentPath
 	if err := ext4image.EnsureMinimumSize(ctx, vmRootFSPath, cfg.MinimumRootFSBytes); err != nil {
 		return nil, fmt.Errorf("resize persistent rootfs: %w", err)
+	}
+	if err := validateRootFSInspectable(vmRootFSPath); err != nil {
+		return nil, fmt.Errorf("validate persistent rootfs: %w", err)
 	}
 	rootFSCopyMS := time.Since(copyStart).Milliseconds()
 
@@ -2443,6 +2450,17 @@ func ext4PathType(imagePath, path string) ext4PathKind {
 	default:
 		return ext4PathKindUnknown
 	}
+}
+
+func validateRootFSInspectable(rootFSPath string) error {
+	kind, err := ext4edit.PathTypeWithError(rootFSPath, "/")
+	if err != nil {
+		return fmt.Errorf("inspect ext4 rootfs %q: %w", rootFSPath, err)
+	}
+	if kind != ext4edit.PathKindDirectory {
+		return fmt.Errorf("inspect ext4 rootfs %q: root path has type %q", rootFSPath, kind)
+	}
+	return nil
 }
 
 func (a *Adapter) resolveKernelPath(ctx context.Context, configuredPath string) (path, notice string, err error) {

--- a/internal/backend/darwinvz/init_path_test.go
+++ b/internal/backend/darwinvz/init_path_test.go
@@ -3,8 +3,12 @@
 package darwinvz
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/buildkite/cleanroom/internal/hosttools"
 )
 
 func TestGuestInitExecutableForShellPresenceUsesInitScriptWhenShellExists(t *testing.T) {
@@ -90,5 +94,26 @@ func TestPreparedRuntimeRootFSRequiredPathsDoNotRequireBinSh(t *testing.T) {
 		if path == "/bin/sh" {
 			t.Fatal("shell-less rootfs should not be rejected at prepare time")
 		}
+	}
+}
+
+func TestValidateRootFSInspectableRejectsUnreadableImage(t *testing.T) {
+	t.Parallel()
+
+	if _, err := hosttools.ResolveE2FSProgsBinary("debugfs"); err != nil {
+		t.Skipf("debugfs unavailable: %v", err)
+	}
+
+	imagePath := filepath.Join(t.TempDir(), "not-ext4.img")
+	if err := os.WriteFile(imagePath, []byte("not an ext4 image"), 0o600); err != nil {
+		t.Fatalf("write invalid image: %v", err)
+	}
+
+	err := validateRootFSInspectable(imagePath)
+	if err == nil {
+		t.Fatal("expected invalid image inspection to fail")
+	}
+	if !strings.Contains(err.Error(), "inspect ext4 rootfs") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/internal/ext4edit/ext4edit.go
+++ b/internal/ext4edit/ext4edit.go
@@ -71,15 +71,32 @@ func PathExists(imagePath, path string) bool {
 
 // PathType returns the ext4 inode type for the given path.
 func PathType(imagePath, path string) PathKind {
-	resolvedPath, err := resolvePath(imagePath, path)
+	kind, err := PathTypeWithError(imagePath, path)
 	if err != nil {
 		return PathKindUnknown
+	}
+	return kind
+}
+
+// PathTypeWithError returns the ext4 inode type for the given path, preserving
+// host-side inspection errors so callers can distinguish a missing path from an
+// unreadable image.
+func PathTypeWithError(imagePath, path string) (PathKind, error) {
+	resolvedPath, err := resolvePath(imagePath, path)
+	if err != nil {
+		if isMissingPathError(err) {
+			return PathKindUnknown, nil
+		}
+		return PathKindUnknown, err
 	}
 	output, err := statPathDirect(imagePath, resolvedPath)
 	if err != nil {
-		return PathKindUnknown
+		if isMissingPathError(err) {
+			return PathKindUnknown, nil
+		}
+		return PathKindUnknown, err
 	}
-	return DebugFSStatType(output)
+	return DebugFSStatType(output), nil
 }
 
 // DebugFSCommandOutputError extracts actionable debugfs stderr/stdout error text.
@@ -102,7 +119,12 @@ func DebugFSCommandOutputError(output string) string {
 			strings.Contains(lower, "ext2_lookup") ||
 			strings.Contains(lower, "command not found") ||
 			strings.Contains(lower, "no such file or directory") ||
-			strings.Contains(lower, "not a directory") {
+			strings.Contains(lower, "not a directory") ||
+			strings.Contains(lower, "filesystem not open") ||
+			strings.Contains(lower, "while trying to open") ||
+			strings.Contains(lower, "short read") ||
+			strings.Contains(lower, "checksum does not match") ||
+			strings.Contains(lower, "bad magic number") {
 			return msg
 		}
 	}

--- a/internal/ext4edit/ext4edit_test.go
+++ b/internal/ext4edit/ext4edit_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/buildkite/cleanroom/internal/hosttools"
@@ -78,6 +79,16 @@ func TestDebugFSCommandOutputErrorReportsUnknownCommand(t *testing.T) {
 	}
 }
 
+func TestDebugFSCommandOutputErrorReportsUnreadableFilesystem(t *testing.T) {
+	t.Parallel()
+
+	output := "debugfs 1.47.3 (8-Jul-2025)\nInode bitmap checksum does not match bitmap while reading allocation bitmaps\nstat: Filesystem not open\n"
+	got := DebugFSCommandOutputError(output)
+	if got == "" {
+		t.Fatal("expected unreadable-filesystem debugfs output to be treated as an error")
+	}
+}
+
 func TestDebugFSCommandOutputErrorIgnoresSuccessfulOutput(t *testing.T) {
 	t.Parallel()
 
@@ -102,6 +113,31 @@ func TestDebugFSStatTypeParsesSymlink(t *testing.T) {
 	output := "debugfs 1.47.3 (8-Jul-2025)\nInode: 82   Type: symlink    Mode:  0755   Flags: 0x0\n"
 	if got, want := DebugFSStatType(output), PathKindSymlink; got != want {
 		t.Fatalf("unexpected stat type: got %q want %q", got, want)
+	}
+}
+
+func TestPathTypeWithErrorReturnsInspectionError(t *testing.T) {
+	t.Parallel()
+
+	debugfsBinary, _, ok := requireDebugFSTools(t)
+	if !ok {
+		return
+	}
+	if debugfsBinary == "" {
+		t.Fatal("expected debugfs path")
+	}
+
+	imagePath := filepath.Join(t.TempDir(), "not-ext4.img")
+	if err := os.WriteFile(imagePath, []byte("not an ext4 image"), 0o600); err != nil {
+		t.Fatalf("write invalid image: %v", err)
+	}
+
+	_, err := PathTypeWithError(imagePath, "/")
+	if err == nil {
+		t.Fatal("expected invalid image inspection to fail")
+	}
+	if !strings.Contains(err.Error(), "debugfs") {
+		t.Fatalf("expected debugfs error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## What changed

- Treat debugfs output such as `Filesystem not open`, checksum mismatch, short read, and bad magic errors as ext4 inspection failures.
- Preserve ext4 path-type inspection errors via `PathTypeWithError`.
- Validate darwin-vz writable rootfs images before booting persistent or one-shot VMs, so unreadable stage-cache rootfs restores fail before Cleanroom chooses a guest init path.

## Why

A corrupted workspace-stage cache rootfs could make host-side inspection think `/bin/sh` was absent. Darwin-vz then booted directly into `cleanroom-guest-agent` instead of the Cleanroom init script, skipping `/dev/pts` setup and producing failures like `open /dev/ptmx: no such file or directory` and `exec: "sh": executable file not found in $PATH`.

Failing the restore early lets the existing workspace-stage fallback path cold-bootstrap and replace the bad cache instead of returning a broken sandbox.

## Validation

- `mise exec -- go test ./internal/ext4edit`
- `mise exec -- go test ./internal/backend/darwinvz`
- `mise exec -- go test ./internal/controlservice -run 'TestCreateSandboxFallsBackWhenWorkspaceStageRestoreFails'`
- Local smoke: `cleanroom exec --sync --print-sandbox-id /bin/sh -lc 'test -x /bin/sh && test -c /dev/ptmx && printf ok'`
- Local TTY smoke: `printf '' | cleanroom exec --sync --tty /bin/sh -lc 'printf ok'`