### PR TITLE
docs: Update workspace sync guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,36 @@ cleanroom cp ./fixture.json <id>:/tmp/fixture.json
 cleanroom cp <id>:/tmp/result.json ./result.json
 ```
 
+Copy workspace changes through the Git-backed workspace sync flow:
+
+```bash
+# Copy local tracked and unignored workspace changes into an existing sandbox
+cleanroom workspace copy-in --dry-run <id>
+cleanroom workspace copy-in <id>
+
+# Inspect sandbox changes before writing anything locally
+cleanroom workspace diff <id>
+cleanroom workspace copy-out --dry-run <id>
+
+# Copy sandbox workspace changes back into the matching local checkout
+cleanroom workspace copy-out <id>
+cleanroom workspace copy-out --force <id>
+```
+
+Top-level commands can run the same operations automatically:
+
+```bash
+cleanroom exec --copy-in -- npm test
+cleanroom exec --copy-out -- npm run fmt
+cleanroom exec --sync -- npm run generate
+cleanroom console --sync -- sh
+```
+
+Workspace copy-in/copy-out currently requires a matching local Git worktree.
+Ignored paths such as dependency directories and build caches are excluded by
+default. Copy-out refuses local conflicts unless `--force` is used, and
+non-Git directories should use explicit `cleanroom cp` paths for now.
+
 Keep a sandbox created by `exec`:
 
 ```bash

--- a/docs/plans/local-only-repository-revisions.md
+++ b/docs/plans/local-only-repository-revisions.md
@@ -1,39 +1,43 @@
 # Local-Only Repository Revisions Plan
 
+**Status:** Landed; use `--copy-in`
+**Last reviewed:** 2026-05-03
+
 ## Summary
 
-Teach `--include-local-changes` to include the full local repository state needed
-to reproduce the current workspace:
+Teach `--copy-in` to include the full local repository state needed to
+reproduce the current workspace:
 
 - local-only committed Git history, carried as a Git bundle
 - uncommitted and untracked worktree changes, carried as the existing changeset
   overlay
 
-The later UX cleanup can rename or replace this behavior with `--copy-in`. For
-this phase, keep the existing flag and broaden what it includes.
+The older `--include-local-changes` flag has been removed. `--copy-in` is the
+supported user-facing request-time changeset surface.
 
 ## Problem
 
-Repo-aware commands currently resolve the local repository remote URL and
-committed `HEAD`, then ask the control plane to materialize that exact checkout
-inside the sandbox.
+Before this work, repo-aware commands resolved the local repository remote URL
+and committed `HEAD`, then asked the control plane to materialize that exact
+checkout inside the sandbox.
 
-That fails when `HEAD` is a local-only commit because the remote-backed
+That failed when `HEAD` was a local-only commit because the remote-backed
 repository store cannot fetch it. The commit object exists in the local clone,
 but it has not been pushed to the configured remote.
 
-The existing `--include-local-changes` path can package dirty worktree changes,
-but it assumes the base commit is already fetchable by the sandbox. That means it
-cannot represent the common workflow where a developer has both local commits and
-uncommitted edits.
+The old dirty-worktree changeset path could package uncommitted worktree
+changes, but it assumed the base commit was already fetchable by the sandbox.
+That meant it could not represent the common workflow where a developer had
+both local commits and uncommitted edits.
 
 ## Target Model
 
-Without `--include-local-changes`, repo-aware checkout stays remote-backed. If
-the resolved `HEAD` is not available from the configured remote, fail clearly and
-suggest pushing the branch or using `--include-local-changes`.
+The landed model keeps repo-aware checkout remote-backed unless copy-in is
+explicitly requested. Without `--copy-in`, if the resolved `HEAD` is not
+available from the configured remote, Cleanroom fails clearly and suggests
+pushing the branch or using `--copy-in`.
 
-With `--include-local-changes`, Cleanroom packages local repository state in two
+With `--copy-in`, Cleanroom packages local repository state in two
 layers:
 
 1. A Git bundle for local-only committed history.
@@ -48,7 +52,7 @@ The guest ends with:
 
 ## Git Bundle Layer
 
-The CLI should create a bundle for objects reachable from local `HEAD` but not
+The CLI creates a bundle for objects reachable from local `HEAD` but not
 reachable from the configured remote-tracking refs:
 
 ```sh
@@ -67,12 +71,12 @@ The control plane must verify:
 - the bundle contains the requested target commit
 - after remote checkout plus bundle fetch, the target commit is reachable
 
-If the bundle has missing remote prerequisites, fail clearly instead of uploading
-or accepting a large full-history bundle in the first version.
+If the bundle has missing remote prerequisites, Cleanroom fails clearly instead
+of uploading or accepting a large full-history bundle in the first version.
 
 ## API Shape
 
-Start simple by sending the bundle inline on sandbox creation:
+The landed API sends the bundle inline on sandbox creation:
 
 ```proto
 message CreateSandboxRequest {
@@ -89,17 +93,17 @@ message RepositoryCommitBundle {
 }
 ```
 
-Cleanroom should enforce an explicit bundle size limit before sending and after
+Cleanroom enforces an explicit bundle size limit before sending and after
 receiving the request. A first default of 64 MiB is enough for typical short WIP
 branches while still producing a clear failure mode for large histories.
 
 ## Guest Checkout Shape
 
-For remote-available commits without `--include-local-changes`, checkout stays
+For remote-available commits without `--copy-in`, checkout stays
 unchanged.
 
-For `--include-local-changes` with a local-only commit, bootstrap should fetch
-the bundle before checkout verification:
+For `--copy-in` with a local-only commit, bootstrap fetches the bundle
+before checkout verification:
 
 ```sh
 git clone --filter=blob:none --no-checkout --progress "$remote" "$dest"
@@ -118,8 +122,8 @@ remote control planes.
 ## Worktree Overlay Layer
 
 After the guest checks out the local target commit, apply the existing
-`--include-local-changes` worktree changeset if the host worktree has
-uncommitted or untracked changes.
+`--copy-in` worktree changeset if the host worktree has uncommitted or
+untracked changes.
 
 The overlay base should be the local target commit, not the remote merge base.
 That preserves the current patch-style validation while allowing the target
@@ -136,12 +140,12 @@ Cache lineage should use stable content identities:
 
 Do not key cache reuse on request-scoped names such as `source_id`.
 
-## Incremental Slices
+## Landed Slices
 
 1. Detect when the resolved repository commit is not fetchable from the
    configured remote.
-2. Under `--include-local-changes`, create a Git bundle for objects reachable
-   from `HEAD` and not reachable from the configured remote-tracking refs.
+2. Under `--copy-in`, create a Git bundle for objects reachable from `HEAD` and
+   not reachable from the configured remote-tracking refs.
 3. Add an inline `RepositoryCommitBundle` request payload for local-only
    committed history, with digest and size validation.
 4. Verify bundle prerequisites against the canonical remote.
@@ -157,8 +161,6 @@ Do not key cache reuse on request-scoped names such as `source_id`.
 
 ## Deferred
 
-- Rename or replace `--include-local-changes` with `--copy-in` once the broader
-  copy-in UX is ready.
 - Client-streamed bundle upload for larger histories if the inline request limit
   proves too restrictive.
 - Full-history bundles when no remote-available base exists.

--- a/docs/plans/workspace-sync.md
+++ b/docs/plans/workspace-sync.md
@@ -2,7 +2,7 @@
 
 **Spec reference:** `spec.md` sections 5.1.1, 5.4, 5.4.2
 **Related plan:** `docs/plans/sandbox-transfer-invariants.md`
-**Status:** In progress
+**Status:** Git-backed MVP landed; optional live-copy and copy-out-on-terminate deferred
 **Last reviewed:** 2026-05-03
 
 ## Implementation Status
@@ -27,17 +27,21 @@
   for `cleanroom exec` and `cleanroom console`. It composes the manual
   copy-in/copy-out operations, prevalidates existing sandbox copy-out targets,
   and runs copy-out before automatic sandbox termination.
-- This changeset removes copy-out recovery payload directories from the normal
-  UX, reports copy-out conflicts together, and adds
+- PR #283 removed copy-out recovery payload directories from the normal UX,
+  reports copy-out conflicts together, and adds
   `workspace copy-out --force` as the explicit local overwrite path.
 - Non-Git workspace copy-in/copy-out is explicitly out of scope for now. The
   supported workspace-sync surface is Git-backed.
+- The Git-backed MVP in Phases 1-3 is landed. Remaining phases are optional
+  follow-ups: live local-to-cleanroom copy and copy-out-on-terminate for kept
+  sandboxes.
 
 ## Summary
 
-Replace the current `--include-local-changes` UX with a clearer `--copy-in` flag
-and add explicit workspace copy-in/copy-out primitives for the common "edit
-locally, run in Cleanroom, bring changes back" workflow.
+Use explicit `--copy-in`, `--copy-out`, and `--sync` flags plus manual
+workspace commands for the common "edit locally, run in Cleanroom, bring
+changes back" workflow. These commands replace the earlier local-changes flag
+with directional workspace vocabulary.
 
 In this plan, "workspace" means the project tree inside the cleanroom at the
 resolved repository path, normally `/workspace`. It does not mean the full
@@ -104,8 +108,8 @@ Top-level flags:
   operations to `/workspace`.
 - Keep ordinary `exec`, `console`, and `create` startup fast by avoiding
   implicit whole-tree copy operations.
-- Replace `--include-local-changes` with `--copy-in` instead of carrying both
-  names long term.
+- Keep `--copy-in` as the supported replacement for the old local-changes flag
+  instead of carrying both names long term.
 - Exclude ignored dependency/cache/runtime directories from copy-in/copy-out by
   default, so a Linux `node_modules/` never gets copied back to a macOS
   checkout unless the user deliberately asks for that exact path.
@@ -274,7 +278,8 @@ Supported on:
 - `cleanroom console`
 - `cleanroom create`
 
-`--copy-in` replaces `--include-local-changes` as the top-level copy-in flag.
+`--copy-in` is the top-level copy-in flag. The old local-changes flag has been
+removed.
 
 For Git-backed source workspaces, the implementation should reuse the existing
 repository changeset path:
@@ -559,10 +564,10 @@ scoping, baseline tracking, mirror planning, and conflict metadata.
 
 ## Interaction With Existing Local Changesets
 
-`--include-local-changes` currently packages local dirty state as an explicit
-repository changeset during sandbox creation.
+The removed local-changes flag previously packaged local dirty state as an
+explicit repository changeset during sandbox creation.
 
-This plan should rename that user-facing behavior to `--copy-in`:
+The supported user-facing behavior is now `--copy-in`:
 
 - `--copy-in` is the top-level one-shot copy-in flag for local workspace changes
 - `workspace copy-in` is the manual form of the same copy-in operation
@@ -576,10 +581,7 @@ The term "repository changeset" should remain an implementation and diagnostic
 term. CLI help and docs for the happy path should describe the behavior as
 copying workspace changes.
 
-Because Cleanroom is pre-1.0, prefer removing `--include-local-changes` rather
-than keeping a long compatibility path. If a short alias is kept during
-transition, it should be documented as equivalent to `--copy-in` and then deleted
-before v1.
+Because Cleanroom is pre-1.0, no compatibility alias is kept for the old flag.
 
 ## CI and Hermetic Workflows
 
@@ -629,8 +631,7 @@ Status: landed.
   `node_modules/`, are not included in Git-backed copy unless tracked.
 - Add tests that `workspace copy-in` and top-level `--copy-in` produce the same
   destination contents for Git sources.
-- Remove or immediately deprecate `--include-local-changes` as the old spelling
-  of the same behavior.
+- Remove the old local-changes flag rather than carrying it as an alias.
 - Apply copied changes after exact checkout setup and before command execution
   or console entry.
 - Store enough local binding metadata for later copy-out work.
@@ -655,7 +656,7 @@ Status: landed.
   state and prefer the bound local root during `workspace copy-out`.
 - PR #276: use the recorded copy-in manifest as the local conflict/apply
   base.
-- This changeset: add `workspace copy-out --force`, aggregate local copy-out
+- PR #283: add `workspace copy-out --force`, aggregate local copy-out
   conflicts, and stop writing recovery payload directories.
 
 ### Phase 3: Safe top-level copy-out automation


### PR DESCRIPTION
## Summary

- document Git-backed workspace copy-in/copy-out and top-level `--copy-in`, `--copy-out`, and `--sync` examples in the README
- mark the workspace-sync Git-backed MVP as landed, with live copy and copy-out-on-terminate left as optional follow-ups
- update the local-only repository revisions plan to use `--copy-in` and note that `--include-local-changes` was removed

## Validation

- `git diff --check`
- `cleanroom exec --help` / `cleanroom workspace --help` / `cleanroom workspace copy-out --help`
