### PR TITLE
feat: Pass block output volume specs to launch

### DIFF
--- a/docs/plans/dependency-service-volume-caches.md
+++ b/docs/plans/dependency-service-volume-caches.md
@@ -773,15 +773,54 @@ Completed in phase 2:
   aggregate services stage cache misses and an aggregate dependency stage cache
   restores
 
-Remaining phase 2 work:
+Follow-up runtime work after phase 2:
 
-- prepare and attach output volumes before VM launch
 - run missed dependency blocks from isolated input projections
 - restore hit output records before later dependency blocks run
 - publish output records after successful missed blocks
 - run missed service blocks from isolated input projections
 - restore hit service output records before later service blocks run
 - publish service output records after successful missed blocks
+
+### Phase 3 PR Status
+
+The third implementation PR continues the runtime-control layer by turning
+block-volume lookup results into backend launch-time volume specs. It still does
+not make any backend attach, mount, restore, execute, or snapshot those volumes;
+aggregate dependency and service bootstrap commands continue to run.
+
+Completed in phase 3:
+
+- control service converts dependency and service block-volume plans into
+  `backend.CacheOutputVolumeSpec` values with stable volume IDs, declared
+  directory mappings, declared file mappings, and cache-hit source storage refs
+- cache-hit output records must describe one aggregate output volume per block
+  before the record can be consumed as a launch spec
+- service block-volume lookup returns its computed plan to the caller instead
+  of being logging-only
+- sandbox creation now computes dependency and service block-volume plans after
+  a services-stage cache miss and before dependency-stage or workspace-stage
+  restores, so later launch requests can carry all needed output-volume specs
+- dependency-stage and portable dependency-stage restores receive service
+  output-volume specs only, because dependency outputs are already present in
+  the restored rootfs and should not be shadowed by dependency sidecar mounts
+- workspace-stage restores and cold provisions receive dependency plus service
+  output-volume specs because those phases still need to run dependency and
+  service bootstrap work
+- tests cover spec construction for cache hits and misses, cold provision
+  request wiring, and dependency-stage restore request wiring
+
+Remaining phase 3 work:
+
+- implement backend preparation and attachment of output volumes before VM
+  launch
+- mount declared `outputs.dirs` and restore declared `outputs.files` inside the
+  guest before block commands run
+- run missed dependency and service blocks from isolated input projections
+- restore hit output records before later blocks run
+- snapshot and publish output records after successful missed blocks
+- keep aggregate exact full-rootfs stage caches as the fallback path until
+  per-block execution is complete
 
 ## Tests
 

--- a/internal/controlservice/block_volume_specs.go
+++ b/internal/controlservice/block_volume_specs.go
@@ -1,0 +1,212 @@
+package controlservice
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/cachestore"
+	"github.com/buildkite/cleanroom/internal/policy"
+)
+
+type blockVolumeOutputSpecBlock struct {
+	Stage       string
+	BlockName   string
+	CacheKey    string
+	Outputs     policy.StageBlockOutputs
+	CacheHit    bool
+	CacheRecord cachestore.Record
+}
+
+func dependencyBlockVolumeOutputSpecs(plan dependencyBlockVolumePlan) ([]backend.CacheOutputVolumeSpec, error) {
+	blocks := make([]blockVolumeOutputSpecBlock, 0, len(plan.Blocks))
+	for _, block := range plan.Blocks {
+		blocks = append(blocks, blockVolumeOutputSpecBlock{
+			Stage:       dependencyVolumeStageName,
+			BlockName:   block.BlockName,
+			CacheKey:    block.CacheKey,
+			Outputs:     block.Outputs,
+			CacheHit:    block.CacheHit,
+			CacheRecord: block.CacheRecord,
+		})
+	}
+	return blockVolumeOutputSpecs(blocks)
+}
+
+func serviceBlockVolumeOutputSpecs(plan serviceBlockVolumePlan) ([]backend.CacheOutputVolumeSpec, error) {
+	blocks := make([]blockVolumeOutputSpecBlock, 0, len(plan.Blocks))
+	for _, block := range plan.Blocks {
+		blocks = append(blocks, blockVolumeOutputSpecBlock{
+			Stage:       serviceVolumeStageName,
+			BlockName:   block.BlockName,
+			CacheKey:    block.CacheKey,
+			Outputs:     block.Outputs,
+			CacheHit:    block.CacheHit,
+			CacheRecord: block.CacheRecord,
+		})
+	}
+	return blockVolumeOutputSpecs(blocks)
+}
+
+func blockVolumeOutputSpecs(blocks []blockVolumeOutputSpecBlock) ([]backend.CacheOutputVolumeSpec, error) {
+	if len(blocks) == 0 {
+		return nil, nil
+	}
+	specs := make([]backend.CacheOutputVolumeSpec, 0, len(blocks))
+	for _, block := range blocks {
+		spec, err := blockVolumeOutputSpec(block)
+		if err != nil {
+			return nil, err
+		}
+		specs = append(specs, spec)
+	}
+	return specs, nil
+}
+
+func blockVolumeOutputSpec(block blockVolumeOutputSpecBlock) (backend.CacheOutputVolumeSpec, error) {
+	stage := strings.TrimSpace(block.Stage)
+	blockName := strings.TrimSpace(block.BlockName)
+	cacheKey := strings.TrimSpace(block.CacheKey)
+	if stage == "" {
+		return backend.CacheOutputVolumeSpec{}, fmt.Errorf("block output volume spec missing stage")
+	}
+	if blockName == "" {
+		return backend.CacheOutputVolumeSpec{}, fmt.Errorf("%s block output volume spec missing block name", stage)
+	}
+	if cacheKey == "" {
+		return backend.CacheOutputVolumeSpec{}, fmt.Errorf("%s block %q output volume spec missing cache key", stage, blockName)
+	}
+
+	spec := backend.CacheOutputVolumeSpec{
+		Stage:     stage,
+		BlockName: blockName,
+		CacheKey:  cacheKey,
+		VolumeID:  blockVolumeID(stage, cacheKey),
+	}
+	if block.CacheHit {
+		outputRecords, err := blockVolumeOutputRecordsByKey(block)
+		if err != nil {
+			return backend.CacheOutputVolumeSpec{}, err
+		}
+		for i, dir := range block.Outputs.Dirs {
+			record, ok := outputRecords[blockVolumeOutputRecordKey("dir", dir)]
+			if !ok {
+				return backend.CacheOutputVolumeSpec{}, fmt.Errorf("%s block %q cache hit missing dir output record %q", stage, blockName, dir)
+			}
+			if i == 0 {
+				spec.StorageDriver = strings.TrimSpace(record.StorageDriver)
+				spec.StorageRef = strings.TrimSpace(record.StorageRef)
+				spec.SourceSnapshotRef = blockVolumeSourceSnapshotRef(record)
+			}
+			spec.DirMappings = append(spec.DirMappings, backend.CacheOutputDirMapping{
+				GuestPath: strings.TrimSpace(dir),
+				Subpath:   strings.TrimSpace(record.VolumeSubpath),
+			})
+		}
+		for i, file := range block.Outputs.Files {
+			record, ok := outputRecords[blockVolumeOutputRecordKey("file", file)]
+			if !ok {
+				return backend.CacheOutputVolumeSpec{}, fmt.Errorf("%s block %q cache hit missing file output record %q", stage, blockName, file)
+			}
+			if len(block.Outputs.Dirs) == 0 && i == 0 {
+				spec.StorageDriver = strings.TrimSpace(record.StorageDriver)
+				spec.StorageRef = strings.TrimSpace(record.StorageRef)
+				spec.SourceSnapshotRef = blockVolumeSourceSnapshotRef(record)
+			}
+			spec.FileMappings = append(spec.FileMappings, backend.CacheOutputFileMapping{
+				GuestPath: strings.TrimSpace(file),
+				Subpath:   strings.TrimSpace(record.VolumeSubpath),
+			})
+		}
+		return spec, nil
+	}
+
+	for i, dir := range block.Outputs.Dirs {
+		spec.DirMappings = append(spec.DirMappings, backend.CacheOutputDirMapping{
+			GuestPath: strings.TrimSpace(dir),
+			Subpath:   blockVolumeOutputSubpath("dirs", i),
+		})
+	}
+	for i, file := range block.Outputs.Files {
+		spec.FileMappings = append(spec.FileMappings, backend.CacheOutputFileMapping{
+			GuestPath: strings.TrimSpace(file),
+			Subpath:   blockVolumeOutputSubpath("files", i),
+		})
+	}
+	return spec, nil
+}
+
+func blockVolumeOutputRecordsByKey(block blockVolumeOutputSpecBlock) (map[string]cachestore.OutputRecord, error) {
+	stage := strings.TrimSpace(block.Stage)
+	blockName := strings.TrimSpace(block.BlockName)
+	records := block.CacheRecord.OutputRecords
+	if reason := blockVolumeOutputRecordMissReason(block.Outputs, records); reason != "" {
+		return nil, fmt.Errorf("%s block %q cache hit has invalid output records: %s", stage, blockName, reason)
+	}
+	out := make(map[string]cachestore.OutputRecord, len(records))
+	var storageDriver, storageRef, sourceSnapshotRef string
+	for _, record := range records {
+		key := blockVolumeOutputRecordKey(record.Kind, record.Path)
+		if _, ok := out[key]; ok {
+			return nil, fmt.Errorf("%s block %q cache hit has duplicate output record %q", stage, blockName, strings.TrimSpace(record.Path))
+		}
+		recordStorageDriver := strings.TrimSpace(record.StorageDriver)
+		recordStorageRef := strings.TrimSpace(record.StorageRef)
+		recordSourceSnapshotRef := blockVolumeSourceSnapshotRef(record)
+		if storageDriver == "" && storageRef == "" && sourceSnapshotRef == "" {
+			storageDriver = recordStorageDriver
+			storageRef = recordStorageRef
+			sourceSnapshotRef = recordSourceSnapshotRef
+		} else if recordStorageDriver != storageDriver || recordStorageRef != storageRef || recordSourceSnapshotRef != sourceSnapshotRef {
+			return nil, fmt.Errorf("%s block %q cache hit spans multiple output volumes", stage, blockName)
+		}
+		out[key] = record
+	}
+	return out, nil
+}
+
+func blockVolumeSourceSnapshotRef(record cachestore.OutputRecord) string {
+	if snapshotRef := strings.TrimSpace(record.SnapshotRef); snapshotRef != "" {
+		return snapshotRef
+	}
+	return strings.TrimSpace(record.StorageRef)
+}
+
+func blockVolumeOutputSubpath(kind string, index int) string {
+	return fmt.Sprintf("%s/%d", kind, index)
+}
+
+func blockVolumeID(stage, cacheKey string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(stage) + "\x00" + strings.TrimSpace(cacheKey)))
+	return strings.TrimSpace(stage) + "-" + hex.EncodeToString(sum[:12])
+}
+
+func appendCacheOutputVolumeSpecs(groups ...[]backend.CacheOutputVolumeSpec) []backend.CacheOutputVolumeSpec {
+	total := 0
+	for _, group := range groups {
+		total += len(group)
+	}
+	if total == 0 {
+		return nil
+	}
+	out := make([]backend.CacheOutputVolumeSpec, 0, total)
+	for _, group := range groups {
+		out = append(out, cloneCacheOutputVolumeSpecs(group)...)
+	}
+	return out
+}
+
+func cloneCacheOutputVolumeSpecs(specs []backend.CacheOutputVolumeSpec) []backend.CacheOutputVolumeSpec {
+	if len(specs) == 0 {
+		return nil
+	}
+	out := make([]backend.CacheOutputVolumeSpec, len(specs))
+	for i, spec := range specs {
+		out[i] = spec
+		out[i].DirMappings = append([]backend.CacheOutputDirMapping(nil), spec.DirMappings...)
+		out[i].FileMappings = append([]backend.CacheOutputFileMapping(nil), spec.FileMappings...)
+	}
+	return out
+}

--- a/internal/controlservice/block_volume_specs_test.go
+++ b/internal/controlservice/block_volume_specs_test.go
@@ -1,0 +1,109 @@
+package controlservice
+
+import (
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/cachestore"
+	"github.com/buildkite/cleanroom/internal/policy"
+)
+
+func TestDependencyBlockVolumeOutputSpecsBuildsHitAndMissSpecs(t *testing.T) {
+	plan := dependencyBlockVolumePlan{
+		Blocks: []dependencyBlockVolumeBlockPlan{
+			{
+				BlockName: "toolchains",
+				CacheKey:  "dependency-volume:v1:toolchains",
+				Outputs: policy.StageBlockOutputs{
+					Dirs:  []string{"/root/.local/share/mise"},
+					Files: []string{"/root/.config/mise/config.toml"},
+				},
+				CacheHit: true,
+				CacheRecord: cachestore.Record{
+					OutputRecords: []cachestore.OutputRecord{
+						{
+							Kind:          "dir",
+							Path:          "/root/.local/share/mise",
+							VolumeSubpath: "dirs/0",
+							StorageDriver: "zfs",
+							StorageRef:    "pool/cleanroom/toolchains",
+							SnapshotRef:   "pool/cleanroom/toolchains@snap",
+						},
+						{
+							Kind:          "file",
+							Path:          "/root/.config/mise/config.toml",
+							VolumeSubpath: "files/0",
+							StorageDriver: "zfs",
+							StorageRef:    "pool/cleanroom/toolchains",
+							SnapshotRef:   "pool/cleanroom/toolchains@snap",
+						},
+					},
+				},
+			},
+			{
+				BlockName: "go-modules",
+				CacheKey:  "dependency-volume:v1:go-modules",
+				Outputs: policy.StageBlockOutputs{
+					Dirs:  []string{"/root/go/pkg/mod"},
+					Files: []string{"/root/.cache/go-build/README"},
+				},
+			},
+		},
+	}
+
+	specs, err := dependencyBlockVolumeOutputSpecs(plan)
+	if err != nil {
+		t.Fatalf("dependencyBlockVolumeOutputSpecs returned error: %v", err)
+	}
+	if got, want := len(specs), 2; got != want {
+		t.Fatalf("unexpected spec count: got %d want %d", got, want)
+	}
+
+	hit := requireCacheOutputVolumeSpec(t, specs, dependencyVolumeStageName, "toolchains")
+	if got, want := hit.CacheKey, "dependency-volume:v1:toolchains"; got != want {
+		t.Fatalf("unexpected hit cache key: got %q want %q", got, want)
+	}
+	if got, want := hit.StorageDriver, "zfs"; got != want {
+		t.Fatalf("unexpected hit storage driver: got %q want %q", got, want)
+	}
+	if got, want := hit.StorageRef, "pool/cleanroom/toolchains"; got != want {
+		t.Fatalf("unexpected hit storage ref: got %q want %q", got, want)
+	}
+	if got, want := hit.SourceSnapshotRef, "pool/cleanroom/toolchains@snap"; got != want {
+		t.Fatalf("unexpected hit source snapshot ref: got %q want %q", got, want)
+	}
+	if got, want := hit.DirMappings[0], (backend.CacheOutputDirMapping{GuestPath: "/root/.local/share/mise", Subpath: "dirs/0"}); got != want {
+		t.Fatalf("unexpected hit dir mapping: got %#v want %#v", got, want)
+	}
+	if got, want := hit.FileMappings[0].GuestPath, "/root/.config/mise/config.toml"; got != want {
+		t.Fatalf("unexpected hit file guest path: got %q want %q", got, want)
+	}
+	if got, want := hit.FileMappings[0].Subpath, "files/0"; got != want {
+		t.Fatalf("unexpected hit file subpath: got %q want %q", got, want)
+	}
+
+	miss := requireCacheOutputVolumeSpec(t, specs, dependencyVolumeStageName, "go-modules")
+	if miss.StorageDriver != "" || miss.StorageRef != "" || miss.SourceSnapshotRef != "" {
+		t.Fatalf("expected miss spec without source storage, got driver=%q storage=%q snapshot=%q", miss.StorageDriver, miss.StorageRef, miss.SourceSnapshotRef)
+	}
+	if got, want := miss.DirMappings[0], (backend.CacheOutputDirMapping{GuestPath: "/root/go/pkg/mod", Subpath: "dirs/0"}); got != want {
+		t.Fatalf("unexpected miss dir mapping: got %#v want %#v", got, want)
+	}
+	if got, want := miss.FileMappings[0].Subpath, "files/0"; got != want {
+		t.Fatalf("unexpected miss file subpath: got %q want %q", got, want)
+	}
+	if hit.VolumeID == "" || miss.VolumeID == "" || hit.VolumeID == miss.VolumeID {
+		t.Fatalf("expected stable distinct volume IDs, got hit=%q miss=%q", hit.VolumeID, miss.VolumeID)
+	}
+}
+
+func requireCacheOutputVolumeSpec(t *testing.T, specs []backend.CacheOutputVolumeSpec, stage, blockName string) backend.CacheOutputVolumeSpec {
+	t.Helper()
+	for _, spec := range specs {
+		if spec.Stage == stage && spec.BlockName == blockName {
+			return spec
+		}
+	}
+	t.Fatalf("missing cache output volume spec for %s/%s in %#v", stage, blockName, specs)
+	return backend.CacheOutputVolumeSpec{}
+}

--- a/internal/controlservice/dependency_stage.go
+++ b/internal/controlservice/dependency_stage.go
@@ -598,13 +598,14 @@ func (s *Service) restorePortableDependencyStageCache(
 	commitBundle *repositorybundle.Bundle,
 	options *cleanroomv1.SandboxOptions,
 	record cachestore.Record,
+	cacheOutputVolumes []backend.CacheOutputVolumeSpec,
 	reporter CreateSandboxReporter,
 ) (*cleanroomv1.CreateSandboxResponse, error) {
 	restoreReq := &cleanroomv1.CreateSandboxRequest{
 		Backend: backendName,
 		Options: options,
 	}
-	restoreResp, err := s.createSandboxFromCacheRecord(ctx, restoreReq, compiled, record, reporter)
+	restoreResp, err := s.createSandboxFromCacheRecord(ctx, restoreReq, compiled, record, cacheOutputVolumes, reporter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controlservice/dependency_volume_plan.go
+++ b/internal/controlservice/dependency_volume_plan.go
@@ -348,6 +348,9 @@ func blockVolumeOutputRecordMissReason(outputs policy.StageBlockOutputs, records
 	}
 
 	seen := make(map[string]struct{}, len(records))
+	storageDriver := ""
+	storageRef := ""
+	sourceSnapshotRef := ""
 	for _, record := range records {
 		kind := strings.TrimSpace(record.Kind)
 		path := strings.TrimSpace(record.Path)
@@ -362,6 +365,18 @@ func blockVolumeOutputRecordMissReason(outputs policy.StageBlockOutputs, records
 		if strings.TrimSpace(record.VolumeSubpath) == "" ||
 			strings.TrimSpace(record.StorageDriver) == "" ||
 			strings.TrimSpace(record.StorageRef) == "" {
+			return observability.CacheLookupReasonRecordNotFound
+		}
+		recordStorageDriver := strings.TrimSpace(record.StorageDriver)
+		recordStorageRef := strings.TrimSpace(record.StorageRef)
+		recordSourceSnapshotRef := blockVolumeSourceSnapshotRef(record)
+		if storageDriver == "" && storageRef == "" && sourceSnapshotRef == "" {
+			storageDriver = recordStorageDriver
+			storageRef = recordStorageRef
+			sourceSnapshotRef = recordSourceSnapshotRef
+			continue
+		}
+		if recordStorageDriver != storageDriver || recordStorageRef != storageRef || recordSourceSnapshotRef != sourceSnapshotRef {
 			return observability.CacheLookupReasonRecordNotFound
 		}
 	}

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -379,9 +379,13 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 	dependencyStagePlan := dependencyStagePlan{}
 	dependencyBlockVolumePlan := dependencyBlockVolumePlan{}
 	dependencyBlockVolumePlanAvailable := false
+	dependencyCacheOutputVolumes := []backend.CacheOutputVolumeSpec(nil)
 	dependencyStageBootstrapEnabled := false
 	dependencyStageCachingEnabled := false
 	servicesStagePlan := servicesStagePlan{}
+	serviceBlockVolumePlan := serviceBlockVolumePlan{}
+	serviceBlockVolumePlanAvailable := false
+	serviceCacheOutputVolumes := []backend.CacheOutputVolumeSpec(nil)
 	servicesStageBootstrapEnabled := false
 	servicesStageCachingEnabled := false
 	var restoredWorkspaceResp *cleanroomv1.CreateSandboxResponse
@@ -458,7 +462,7 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 						attribute.String(observability.AttrBackend, backendName),
 					), func(ctx context.Context) error {
 						var err error
-						restoreResp, err = s.createSandboxFromCacheRecord(ctx, restoreReq, compiled, record, reporter)
+						restoreResp, err = s.createSandboxFromCacheRecord(ctx, restoreReq, compiled, record, nil, reporter)
 						setCacheResultSpanAttribute(ctx, map[bool]string{true: observability.CacheResultFailed, false: observability.CacheResultRestored}[err != nil])
 						return err
 					})
@@ -482,6 +486,29 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 				} else {
 					s.logServicesStageCacheMiss(backendName, servicesStagePlan.CacheKey)
 					emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_SERVICES_STAGE_CACHE, "services stage cache miss")
+				}
+			}
+
+			if dependencyStageBootstrapEnabled {
+				dependencyBlockVolumePlan, dependencyBlockVolumePlanAvailable = s.lookupDependencyBlockVolumePlanForCreateSandbox(ctx, adapter, backendName, compiled, repository, changeset, commitBundle, workspaceStageRuntimeBaseKey)
+				if dependencyBlockVolumePlanAvailable {
+					var err error
+					dependencyCacheOutputVolumes, err = dependencyBlockVolumeOutputSpecs(dependencyBlockVolumePlan)
+					if err != nil {
+						dependencyCacheOutputVolumes = nil
+						s.logDependencyStageWarning("prepare dependency block output volume specs", "", err)
+					}
+				}
+			}
+			if servicesStageBootstrapEnabled {
+				serviceBlockVolumePlan, serviceBlockVolumePlanAvailable = s.maybeLookupServiceBlockVolumePlanForCreateSandbox(ctx, adapter, backendName, compiled, repository, changeset, commitBundle, workspaceStageRuntimeBaseKey, dependencyStageBootstrapEnabled, dependencyBlockVolumePlan, dependencyBlockVolumePlanAvailable)
+				if serviceBlockVolumePlanAvailable {
+					var err error
+					serviceCacheOutputVolumes, err = serviceBlockVolumeOutputSpecs(serviceBlockVolumePlan)
+					if err != nil {
+						serviceCacheOutputVolumes = nil
+						s.logServicesStageWarning("prepare service block output volume specs", "", err)
+					}
 				}
 			}
 
@@ -519,7 +546,7 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 						attribute.String(observability.AttrBackend, backendName),
 					), func(ctx context.Context) error {
 						var err error
-						restoreResp, err = s.createSandboxFromCacheRecord(ctx, restoreReq, compiled, record, reporter)
+						restoreResp, err = s.createSandboxFromCacheRecord(ctx, restoreReq, compiled, record, serviceCacheOutputVolumes, reporter)
 						setCacheResultSpanAttribute(ctx, map[bool]string{true: observability.CacheResultFailed, false: observability.CacheResultRestored}[err != nil])
 						return err
 					})
@@ -577,7 +604,7 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 							attribute.String(observability.AttrBackend, backendName),
 						), func(ctx context.Context) error {
 							var err error
-							restoreResp, err = s.restorePortableDependencyStageCache(ctx, adapter, backendName, compiled, firecrackerCfg, repository, changeset, commitBundle, req.GetOptions(), portableRecord, reporter)
+							restoreResp, err = s.restorePortableDependencyStageCache(ctx, adapter, backendName, compiled, firecrackerCfg, repository, changeset, commitBundle, req.GetOptions(), portableRecord, serviceCacheOutputVolumes, reporter)
 							setCacheResultSpanAttribute(ctx, map[bool]string{true: observability.CacheResultFailed, false: observability.CacheResultRestored}[err != nil])
 							return err
 						})
@@ -603,13 +630,6 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 						emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_DEPENDENCY_STAGE_CACHE, "portable dependency stage cache miss")
 					}
 				}
-			}
-
-			if dependencyStageBootstrapEnabled && restoredDependencyResp == nil {
-				dependencyBlockVolumePlan, dependencyBlockVolumePlanAvailable = s.lookupDependencyBlockVolumePlanForCreateSandbox(ctx, adapter, backendName, compiled, repository, changeset, commitBundle, workspaceStageRuntimeBaseKey)
-			}
-			if servicesStageBootstrapEnabled && restoredDependencyResp == nil {
-				s.maybeLookupServiceBlockVolumePlanForCreateSandbox(ctx, adapter, backendName, compiled, repository, changeset, commitBundle, workspaceStageRuntimeBaseKey, dependencyStageBootstrapEnabled, dependencyBlockVolumePlan, dependencyBlockVolumePlanAvailable)
 			}
 
 			if restoredDependencyResp == nil {
@@ -646,7 +666,7 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 						attribute.String(observability.AttrBackend, backendName),
 					), func(ctx context.Context) error {
 						var err error
-						restoreResp, err = s.createSandboxFromCacheRecord(ctx, restoreReq, compiled, record, reporter)
+						restoreResp, err = s.createSandboxFromCacheRecord(ctx, restoreReq, compiled, record, appendCacheOutputVolumeSpecs(dependencyCacheOutputVolumes, serviceCacheOutputVolumes), reporter)
 						setCacheResultSpanAttribute(ctx, map[bool]string{true: observability.CacheResultFailed, false: observability.CacheResultRestored}[err != nil])
 						return err
 					})
@@ -682,11 +702,6 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 		sandboxID := restoredDependencyResp.GetSandbox().GetSandboxId()
 		span.SetAttributes(attribute.String("cleanroom.sandbox.id", sandboxID))
 		if servicesStageBootstrapEnabled {
-			if dependencyStageBootstrapEnabled && !dependencyBlockVolumePlanAvailable && blockVolumeRuntimeDecisionForAdapter(adapter).Enabled {
-				dependencyBlockVolumePlan, dependencyBlockVolumePlanAvailable = s.lookupDependencyBlockVolumePlanForCreateSandbox(ctx, adapter, backendName, compiled, repository, changeset, commitBundle, workspaceStageRuntimeBaseKey)
-			}
-			s.maybeLookupServiceBlockVolumePlanForCreateSandbox(ctx, adapter, backendName, compiled, repository, changeset, commitBundle, workspaceStageRuntimeBaseKey, dependencyStageBootstrapEnabled, dependencyBlockVolumePlan, dependencyBlockVolumePlanAvailable)
-
 			bootstrapAttrs := []attribute.KeyValue{
 				attribute.String(observability.AttrBackend, backendName),
 				attribute.String(observability.AttrSandboxID, sandboxID),
@@ -813,9 +828,10 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 	}
 	emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_PROVISION_SANDBOX, "provisioning sandbox")
 	if err := adapter.ProvisionSandbox(ctx, backend.ProvisionRequest{
-		SandboxID:         sandboxID,
-		Policy:            compiled,
-		FirecrackerConfig: firecrackerCfg,
+		SandboxID:          sandboxID,
+		Policy:             compiled,
+		CacheOutputVolumes: appendCacheOutputVolumeSpecs(dependencyCacheOutputVolumes, serviceCacheOutputVolumes),
+		FirecrackerConfig:  firecrackerCfg,
 	}); err != nil {
 		if stateErr := s.dropProvisioningSandboxAfterCreateError(sandboxID); stateErr != nil {
 			return nil, stateErr
@@ -1048,7 +1064,7 @@ func (s *Service) createSandboxFromSnapshotRecord(ctx context.Context, req *clea
 	if err != nil {
 		return nil, err
 	}
-	return s.createSandboxFromStoredRootFS(ctx, req, source, nil, reporter)
+	return s.createSandboxFromStoredRootFS(ctx, req, source, nil, nil, reporter)
 }
 
 func (s *Service) GetSandbox(_ context.Context, req *cleanroomv1.GetSandboxRequest) (*cleanroomv1.GetSandboxResponse, error) {

--- a/internal/controlservice/service_volume_plan.go
+++ b/internal/controlservice/service_volume_plan.go
@@ -61,7 +61,7 @@ func (s *Service) maybeLookupServiceBlockVolumePlanForCreateSandbox(
 	dependencyStageBootstrapEnabled bool,
 	dependencyPlan dependencyBlockVolumePlan,
 	dependencyPlanAvailable bool,
-) {
+) (serviceBlockVolumePlan, bool) {
 	blockCount := 0
 	if compiled != nil {
 		blockCount = len(compiled.Services.Blocks)
@@ -69,13 +69,13 @@ func (s *Service) maybeLookupServiceBlockVolumePlanForCreateSandbox(
 	decision := blockVolumeRuntimeDecisionForAdapter(adapter)
 	if !decision.Enabled {
 		s.logServiceBlockVolumeCacheFallback(backendName, blockCount, decision.FallbackReason)
-		return
+		return serviceBlockVolumePlan{}, false
 	}
 	if dependencyStageBootstrapEnabled && !dependencyPlanAvailable {
 		s.logServiceBlockVolumeCacheFallback(backendName, blockCount, "dependency block-volume plan unavailable")
-		return
+		return serviceBlockVolumePlan{}, false
 	}
-	s.lookupServiceBlockVolumePlanForCreateSandbox(ctx, backendName, compiled, repository, changeset, commitBundle, runtimeBaseKey, dependencyPlan)
+	return s.lookupServiceBlockVolumePlanForCreateSandbox(ctx, backendName, compiled, repository, changeset, commitBundle, runtimeBaseKey, dependencyPlan)
 }
 
 func (s *Service) lookupServiceBlockVolumePlanForCreateSandbox(
@@ -87,23 +87,23 @@ func (s *Service) lookupServiceBlockVolumePlanForCreateSandbox(
 	commitBundle *repositorybundle.Bundle,
 	runtimeBaseKey string,
 	dependencyPlan dependencyBlockVolumePlan,
-) {
+) (serviceBlockVolumePlan, bool) {
 	blockCount := 0
 	if compiled != nil {
 		blockCount = len(compiled.Services.Blocks)
 	}
 	if _, err := s.cacheStoreOrErr(); err != nil {
 		s.logServiceBlockVolumeCacheFallback(backendName, blockCount, err.Error())
-		return
+		return serviceBlockVolumePlan{}, false
 	}
 
 	plan, ok, err := s.finalizeServiceBlockVolumePlan(ctx, compiled, repository, changeset, commitBundle, backendName, runtimeBaseKey, dependencyPlan)
 	if err != nil {
 		s.logServicesStageWarning("resolve service block-volume cache keys", "", err)
-		return
+		return serviceBlockVolumePlan{}, false
 	}
 	if !ok {
-		return
+		return serviceBlockVolumePlan{}, false
 	}
 
 	err = s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.lookup_service_block_volume_caches", cachePhaseAttributes(
@@ -120,9 +120,10 @@ func (s *Service) lookupServiceBlockVolumePlanForCreateSandbox(
 	})
 	if err != nil {
 		s.logServicesStageWarning("lookup service block-volume caches", "", err)
-		return
+		return serviceBlockVolumePlan{}, false
 	}
 	s.logServiceBlockVolumeCacheLookup(backendName, plan)
+	return plan, true
 }
 
 func (s *Service) finalizeServiceBlockVolumePlan(

--- a/internal/controlservice/service_volume_plan_test.go
+++ b/internal/controlservice/service_volume_plan_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/buildkite/cleanroom/internal/backend"
 	"github.com/buildkite/cleanroom/internal/cachestore"
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
 	"github.com/buildkite/cleanroom/internal/observability"
@@ -442,6 +443,10 @@ func TestCreateSandboxLooksUpServiceBlockVolumesAfterDependencyStageRestore(t *t
 			t.Fatalf("Create service block-volume record %d returned error: %v", i, err)
 		}
 	}
+	lookedUpServicePlan, err := svc.lookupServiceBlockVolumeCaches(context.Background(), "firecracker", compiled, servicePlan)
+	if err != nil {
+		t.Fatalf("lookupServiceBlockVolumeCaches returned error: %v", err)
+	}
 	cacheStore.resetLookups()
 
 	secondResp, err := svc.CreateSandbox(context.Background(), req)
@@ -457,9 +462,136 @@ func TestCreateSandboxLooksUpServiceBlockVolumesAfterDependencyStageRestore(t *t
 	if got, want := cacheStore.getReadyHitCount(serviceVolumeStageName), len(servicePlan.Blocks); got != want {
 		t.Fatalf("unexpected service block-volume hit count after dependency restore: got %d want %d", got, want)
 	}
+	if got, want := adapter.provisionFromSnapshotReq.CacheOutputVolumes, serviceBlockVolumeOutputSpecsForTest(t, lookedUpServicePlan); !cacheOutputVolumeSpecsEqual(got, want) {
+		t.Fatalf("unexpected dependency-stage restore output volume specs:\ngot:  %#v\nwant: %#v", got, want)
+	}
 	if got, want := adapter.runCalls, 4; got != want {
 		t.Fatalf("expected aggregate services bootstrap to still run after dependency restore, got %d want %d", got, want)
 	}
+}
+
+func TestCreateSandboxPassesBlockVolumeSpecsToColdProvision(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	adapter := dependencyBlockVolumeRuntimeAdapter()
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"mise.toml":           "go = \"1.26.2\"\n",
+		"go.mod":              "module example.com/test\n\ngo 1.26.2\n",
+		"go.sum":              "example.com/test v0.0.0 h1:abc123\n",
+		"docker-compose.yml":  "services:\n  postgres:\n    image: postgres:17\n",
+		"db/schema.sql":       "create table widgets (id serial primary key);\n",
+		"db/seed.sql":         "insert into widgets default values;\n",
+		"scripts/prepare-db":  "#!/bin/sh\ntrue\n",
+		"scripts/prepare-app": "#!/bin/sh\ntrue\n",
+	})
+	svc := newTestService(adapter)
+	svc.RepositoryStore = mirrors
+	cacheStore := newMemoryCacheStore()
+	svc.CacheStore = cacheStore
+
+	compiled, err := policy.FromProto(testRepositoryTwoDependencyTwoServiceBlocksPolicy())
+	if err != nil {
+		t.Fatalf("FromProto returned error: %v", err)
+	}
+	repository := repositorycheckout.FromProto(repositoryCheckout)
+	dependencyPlan, ok, err := svc.finalizeDependencyBlockVolumePlan(context.Background(), compiled, repository, nil, nil, "firecracker", "runtime-base:test")
+	if err != nil {
+		t.Fatalf("finalizeDependencyBlockVolumePlan returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected dependency block-volume plan")
+	}
+	servicePlan, ok, err := svc.finalizeServiceBlockVolumePlan(context.Background(), compiled, repository, nil, nil, "firecracker", "runtime-base:test", dependencyPlan)
+	if err != nil {
+		t.Fatalf("finalizeServiceBlockVolumePlan returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected service block-volume plan")
+	}
+	if err := cacheStore.Create(context.Background(), dependencyBlockVolumeTestRecord(compiled, dependencyPlan.Blocks[0])); err != nil {
+		t.Fatalf("Create dependency block-volume record returned error: %v", err)
+	}
+	if err := cacheStore.Create(context.Background(), serviceBlockVolumeTestRecord(compiled, servicePlan.Blocks[0])); err != nil {
+		t.Fatalf("Create service block-volume record returned error: %v", err)
+	}
+	lookedUpDependencyPlan, err := svc.lookupDependencyBlockVolumeCaches(context.Background(), "firecracker", compiled, dependencyPlan)
+	if err != nil {
+		t.Fatalf("lookupDependencyBlockVolumeCaches returned error: %v", err)
+	}
+	lookedUpServicePlan, err := svc.lookupServiceBlockVolumeCaches(context.Background(), "firecracker", compiled, servicePlan)
+	if err != nil {
+		t.Fatalf("lookupServiceBlockVolumeCaches returned error: %v", err)
+	}
+
+	if _, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Policy:             testRepositoryTwoDependencyTwoServiceBlocksPolicy(),
+		RepositoryCheckout: repositoryCheckout,
+	}); err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+
+	dependencySpecs := dependencyBlockVolumeOutputSpecsForTest(t, lookedUpDependencyPlan)
+	serviceSpecs := serviceBlockVolumeOutputSpecsForTest(t, lookedUpServicePlan)
+	want := appendCacheOutputVolumeSpecs(dependencySpecs, serviceSpecs)
+	if got := adapter.provisionReq.CacheOutputVolumes; !cacheOutputVolumeSpecsEqual(got, want) {
+		t.Fatalf("unexpected cold provision output volume specs:\ngot:  %#v\nwant: %#v", got, want)
+	}
+	hit := requireCacheOutputVolumeSpec(t, adapter.provisionReq.CacheOutputVolumes, dependencyVolumeStageName, dependencyPlan.Blocks[0].BlockName)
+	if got, want := hit.SourceSnapshotRef, "snapshot:"+dependencyPlan.Blocks[0].BlockName; got != want {
+		t.Fatalf("unexpected dependency hit snapshot ref: got %q want %q", got, want)
+	}
+	miss := requireCacheOutputVolumeSpec(t, adapter.provisionReq.CacheOutputVolumes, serviceVolumeStageName, servicePlan.Blocks[1].BlockName)
+	if miss.StorageRef != "" || miss.SourceSnapshotRef != "" {
+		t.Fatalf("expected service miss spec without source storage, got storage=%q snapshot=%q", miss.StorageRef, miss.SourceSnapshotRef)
+	}
+}
+
+func dependencyBlockVolumeOutputSpecsForTest(t *testing.T, plan dependencyBlockVolumePlan) []backend.CacheOutputVolumeSpec {
+	t.Helper()
+	specs, err := dependencyBlockVolumeOutputSpecs(plan)
+	if err != nil {
+		t.Fatalf("dependencyBlockVolumeOutputSpecs returned error: %v", err)
+	}
+	return specs
+}
+
+func serviceBlockVolumeOutputSpecsForTest(t *testing.T, plan serviceBlockVolumePlan) []backend.CacheOutputVolumeSpec {
+	t.Helper()
+	specs, err := serviceBlockVolumeOutputSpecs(plan)
+	if err != nil {
+		t.Fatalf("serviceBlockVolumeOutputSpecs returned error: %v", err)
+	}
+	return specs
+}
+
+func cacheOutputVolumeSpecsEqual(left, right []backend.CacheOutputVolumeSpec) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i].Stage != right[i].Stage ||
+			left[i].BlockName != right[i].BlockName ||
+			left[i].CacheKey != right[i].CacheKey ||
+			left[i].VolumeID != right[i].VolumeID ||
+			left[i].SourceSnapshotRef != right[i].SourceSnapshotRef ||
+			left[i].StorageDriver != right[i].StorageDriver ||
+			left[i].StorageRef != right[i].StorageRef {
+			return false
+		}
+		if len(left[i].DirMappings) != len(right[i].DirMappings) || len(left[i].FileMappings) != len(right[i].FileMappings) {
+			return false
+		}
+		for j := range left[i].DirMappings {
+			if left[i].DirMappings[j] != right[i].DirMappings[j] {
+				return false
+			}
+		}
+		for j := range left[i].FileMappings {
+			if left[i].FileMappings[j] != right[i].FileMappings[j] {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 func testRepositoryTwoDependencyTwoServiceBlocksPolicy() *cleanroomv1.Policy {

--- a/internal/controlservice/stored_rootfs.go
+++ b/internal/controlservice/stored_rootfs.go
@@ -75,7 +75,7 @@ func storedRootFSRecordFromCacheEntry(record cachestore.Record) (storedRootFSRec
 	}, nil
 }
 
-func (s *Service) createSandboxFromStoredRootFS(ctx context.Context, req *cleanroomv1.CreateSandboxRequest, record storedRootFSRecord, overridePolicy *policy.CompiledPolicy, reporter CreateSandboxReporter) (*cleanroomv1.CreateSandboxResponse, error) {
+func (s *Service) createSandboxFromStoredRootFS(ctx context.Context, req *cleanroomv1.CreateSandboxRequest, record storedRootFSRecord, overridePolicy *policy.CompiledPolicy, cacheOutputVolumes []backend.CacheOutputVolumeSpec, reporter CreateSandboxReporter) (*cleanroomv1.CreateSandboxResponse, error) {
 	backendName := record.Backend
 	if backendName == "" {
 		return nil, fmt.Errorf("stored rootfs record %q missing backend", record.ID)
@@ -168,11 +168,12 @@ func (s *Service) createSandboxFromStoredRootFS(ctx context.Context, req *cleanr
 		attribute.String("cleanroom.source_kind", sourceKind),
 	}, func(ctx context.Context) error {
 		return snapshotAdapter.ProvisionSandboxFromSnapshot(ctx, backend.ProvisionFromSnapshotRequest{
-			SandboxID:         sandboxID,
-			SnapshotID:        provisionSnapshotID,
-			StorageRef:        record.StorageRef,
-			Policy:            effectivePolicy,
-			FirecrackerConfig: firecrackerCfg,
+			SandboxID:          sandboxID,
+			SnapshotID:         provisionSnapshotID,
+			StorageRef:         record.StorageRef,
+			Policy:             effectivePolicy,
+			CacheOutputVolumes: cloneCacheOutputVolumeSpecs(cacheOutputVolumes),
+			FirecrackerConfig:  firecrackerCfg,
 		})
 	}); err != nil {
 		if stateErr := s.dropProvisioningSandboxAfterCreateError(sandboxID); stateErr != nil {
@@ -223,7 +224,7 @@ func (s *Service) createSandboxFromStoredRootFS(ctx context.Context, req *cleanr
 	return resp, nil
 }
 
-func (s *Service) createSandboxFromCacheRecord(ctx context.Context, req *cleanroomv1.CreateSandboxRequest, compiled *policy.CompiledPolicy, record cachestore.Record, reporter CreateSandboxReporter) (*cleanroomv1.CreateSandboxResponse, error) {
+func (s *Service) createSandboxFromCacheRecord(ctx context.Context, req *cleanroomv1.CreateSandboxRequest, compiled *policy.CompiledPolicy, record cachestore.Record, cacheOutputVolumes []backend.CacheOutputVolumeSpec, reporter CreateSandboxReporter) (*cleanroomv1.CreateSandboxResponse, error) {
 	source, err := storedRootFSRecordFromCacheEntry(record)
 	if err != nil {
 		return nil, err
@@ -238,5 +239,5 @@ func (s *Service) createSandboxFromCacheRecord(ctx context.Context, req *cleanro
 		}
 		defer s.finishSnapshotUse(backingSnapshotID)
 	}
-	return s.createSandboxFromStoredRootFS(ctx, req, source, compiled, reporter)
+	return s.createSandboxFromStoredRootFS(ctx, req, source, compiled, cacheOutputVolumes, reporter)
 }


### PR DESCRIPTION
## Summary

- convert dependency and service block-volume lookup plans into backend cache output volume specs
- pass service specs into dependency-stage restores, and dependency plus service specs into workspace restores and cold provisions
- update the dependency/service volume cache plan with the completed phase and remaining runtime work

## Tests

- mise exec -- go test ./internal/controlservice -run 'BlockVolume|CacheOutputVolume|CreateSandboxPassesBlockVolumeSpecs|LooksUpServiceBlockVolumesAfterDependencyStageRestore'\n- mise exec -- go test ./internal/controlservice\n- mise exec -- go test ./...\n