### PR TITLE
fix: Protect forced workspace copy-out obstacles

### DIFF
--- a/internal/cli/exec_integration_test.go
+++ b/internal/cli/exec_integration_test.go
@@ -591,6 +591,9 @@ func TestExecIntegrationCopyOutRejectsBaselineMismatchBeforeCommand(t *testing.T
 	if !strings.Contains(outcome.err.Error(), "requires local checkout HEAD") {
 		t.Fatalf("expected baseline mismatch error, got %v", outcome.err)
 	}
+	if want := "cleanroom workspace copy-out --force " + sandboxID; !strings.Contains(outcome.err.Error(), want) {
+		t.Fatalf("expected copy-out force guidance %q, got %v", want, outcome.err)
+	}
 	if executionCalled {
 		t.Fatal("expected copy-out validation to fail before running command")
 	}

--- a/internal/cli/execution_shared.go
+++ b/internal/cli/execution_shared.go
@@ -199,7 +199,7 @@ func validateWorkspaceCopyOutBaselineBeforeExecution(opts workspaceCopyOptions, 
 		return errors.New("workspace copy-out requires local and sandbox repository commits")
 	}
 	if !strings.EqualFold(localCommit, sandboxCommit) {
-		return fmt.Errorf("workspace copy-out requires local checkout HEAD %s to match sandbox baseline %s", shortGitSHA(localCommit), shortGitSHA(sandboxCommit))
+		return fmt.Errorf("workspace copy-out requires local checkout HEAD %s to match sandbox baseline %s; %s", shortGitSHA(localCommit), shortGitSHA(sandboxCommit), workspaceCopyOutForceSuggestion(opts.ForceOutHint))
 	}
 	return nil
 }

--- a/internal/cli/workspace.go
+++ b/internal/cli/workspace.go
@@ -778,7 +778,7 @@ func quarantineGitWorkspaceCopyOutForceObstacles(localRoot string, files []repos
 	if len(candidates) == 0 {
 		return nil, nil
 	}
-	tempRoot, err := os.MkdirTemp(filepath.Dir(localRoot), ".cleanroom-copy-out-obstacles-*")
+	tempRoot, err := os.MkdirTemp(localRoot, ".cleanroom-copy-out-obstacles-*")
 	if err != nil {
 		return nil, fmt.Errorf("create forced copy-out obstacle quarantine: %w", err)
 	}

--- a/internal/cli/workspace.go
+++ b/internal/cli/workspace.go
@@ -284,9 +284,6 @@ func copyWorkspaceOut(callCtx context.Context, ctx *runtimeContext, client *cont
 	cleanupApply := func() {}
 	var forceQuarantine *workspaceCopyOutForceQuarantine
 	if opts.ForceCopyOut {
-		if err := resetGitWorkspaceCopyOutForceIndex(opts.Repository.RootDir, files); err != nil {
-			return err
-		}
 		forceQuarantine, err = quarantineGitWorkspaceCopyOutForceObstacles(opts.Repository.RootDir, files)
 		if err != nil {
 			return err
@@ -316,6 +313,18 @@ func copyWorkspaceOut(callCtx context.Context, ctx *runtimeContext, client *cont
 			err = errors.Join(err, forceQuarantine.Restore())
 		}
 		return err
+	}
+	if opts.ForceCopyOut {
+		var obstaclePaths []string
+		if forceQuarantine != nil {
+			obstaclePaths = forceQuarantine.Paths()
+		}
+		if err := resetGitWorkspaceCopyOutForceIndex(opts.Repository.RootDir, files, obstaclePaths); err != nil {
+			if forceQuarantine != nil {
+				err = errors.Join(err, forceQuarantine.Restore())
+			}
+			return err
+		}
 	}
 	if err := applyGitWorkspaceCopyOutPatch(opts.Repository.RootDir, applyPath); err != nil {
 		if forceQuarantine != nil {
@@ -707,16 +716,12 @@ func prepareGitWorkspaceCopyOutApplyPatch(local *resolvedRepositoryCheckout, che
 	return applyFiles, patchPath, cleanup, nil
 }
 
-func resetGitWorkspaceCopyOutForceIndex(localRoot string, files []repositorychangeset.File) error {
+func resetGitWorkspaceCopyOutForceIndex(localRoot string, files []repositorychangeset.File, extraPaths []string) error {
 	paths, err := workspaceCopyOutPaths(files)
 	if err != nil {
 		return err
 	}
-	obstacles, err := gitWorkspaceCopyOutForceObstaclePaths(localRoot, files, paths)
-	if err != nil {
-		return err
-	}
-	paths, err = mergeWorkspaceCopyOutPaths(paths, obstacles)
+	paths, err = mergeWorkspaceCopyOutPaths(paths, extraPaths)
 	if err != nil {
 		return err
 	}
@@ -910,8 +915,11 @@ func (q *workspaceCopyOutForceQuarantine) Restore() error {
 			restoreErr = errors.Join(restoreErr, fmt.Errorf("restore forced copy-out obstacle %q: %w", move.path, err))
 		}
 	}
+	if restoreErr != nil {
+		return fmt.Errorf("%w; forced copy-out obstacle backup remains at %s", restoreErr, q.tempRoot)
+	}
 	q.Cleanup()
-	return restoreErr
+	return nil
 }
 
 func (q *workspaceCopyOutForceQuarantine) Cleanup() {
@@ -919,6 +927,17 @@ func (q *workspaceCopyOutForceQuarantine) Cleanup() {
 		return
 	}
 	_ = os.RemoveAll(q.tempRoot)
+}
+
+func (q *workspaceCopyOutForceQuarantine) Paths() []string {
+	if q == nil || len(q.moves) == 0 {
+		return nil
+	}
+	paths := make([]string, 0, len(q.moves))
+	for _, move := range q.moves {
+		paths = append(paths, move.path)
+	}
+	return paths
 }
 
 func buildGitWorkspaceCopyOutPatchFromLocalBase(localRoot, baseCommit, sandboxPatchPath string, files []repositorychangeset.File) ([]byte, []byte, error) {

--- a/internal/cli/workspace.go
+++ b/internal/cli/workspace.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/buildkite/cleanroom/internal/controlclient"
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
@@ -57,6 +58,7 @@ type workspaceCopyOptions struct {
 	Destination   string
 	ForceGitReset bool
 	ForceCopyOut  bool
+	ForceOutHint  string
 	LaunchSeconds int64
 	PlanOutput    io.Writer
 }
@@ -142,6 +144,7 @@ func resolveWorkspaceCopyOutOptions(ctx *runtimeContext, cwd, chdir, sandboxID s
 		DryRun:        dryRun,
 		Repository:    repository,
 		Binding:       binding,
+		ForceOutHint:  workspaceCopyOutForceHint(sandboxID),
 		LaunchSeconds: launchSeconds,
 	}, nil
 }
@@ -232,7 +235,7 @@ func copyWorkspaceOut(callCtx context.Context, ctx *runtimeContext, client *cont
 					return err
 				}
 				defer cleanup()
-				if err := ensureGitWorkspaceCopyOutSafe(opts.Repository, checkout, opts.Binding, files, opts.ForceCopyOut); err != nil {
+				if err := ensureGitWorkspaceCopyOutSafe(opts.Repository, checkout, opts.Binding, files, opts.ForceCopyOut, opts.ForceOutHint); err != nil {
 					return err
 				}
 				files, _, cleanupApply, err = prepareGitWorkspaceCopyOutApplyPatch(opts.Repository, checkout, files, patchPath)
@@ -274,35 +277,54 @@ func copyWorkspaceOut(callCtx context.Context, ctx *runtimeContext, client *cont
 		return err
 	}
 	defer cleanupPatch()
-	if err := ensureGitWorkspaceCopyOutSafe(opts.Repository, checkout, opts.Binding, files, opts.ForceCopyOut); err != nil {
+	if err := ensureGitWorkspaceCopyOutSafe(opts.Repository, checkout, opts.Binding, files, opts.ForceCopyOut, opts.ForceOutHint); err != nil {
 		return err
 	}
 	applyPath := patchPath
 	cleanupApply := func() {}
-	if opts.ForceCopyOut || useGitWorkspaceCopyOutApplyBase(opts.Binding, opts.Repository, checkout) {
-		files, applyPath, cleanupApply, err = prepareGitWorkspaceCopyOutApplyPatch(opts.Repository, checkout, files, patchPath)
-		if err != nil {
-			return err
-		}
-		defer cleanupApply()
-		if len(files) == 0 {
-			return nil
-		}
-	}
+	var forceQuarantine *workspaceCopyOutForceQuarantine
 	if opts.ForceCopyOut {
 		if err := resetGitWorkspaceCopyOutForceIndex(opts.Repository.RootDir, files); err != nil {
 			return err
 		}
-		if err := removeGitWorkspaceCopyOutForceObstacles(opts.Repository.RootDir, files); err != nil {
+		forceQuarantine, err = quarantineGitWorkspaceCopyOutForceObstacles(opts.Repository.RootDir, files)
+		if err != nil {
 			return err
+		}
+	}
+	if opts.ForceCopyOut || useGitWorkspaceCopyOutApplyBase(opts.Binding, opts.Repository, checkout) {
+		files, applyPath, cleanupApply, err = prepareGitWorkspaceCopyOutApplyPatch(opts.Repository, checkout, files, patchPath)
+		if err != nil {
+			if forceQuarantine != nil {
+				err = errors.Join(err, forceQuarantine.Restore())
+			}
+			return err
+		}
+		defer cleanupApply()
+		if len(files) == 0 {
+			if forceQuarantine != nil {
+				if err := forceQuarantine.Restore(); err != nil {
+					return err
+				}
+			}
+			return nil
 		}
 	}
 	entries, err := gitWorkspaceCopyOutPlanFiles(opts.CWD, files)
 	if err != nil {
+		if forceQuarantine != nil {
+			err = errors.Join(err, forceQuarantine.Restore())
+		}
 		return err
 	}
 	if err := applyGitWorkspaceCopyOutPatch(opts.Repository.RootDir, applyPath); err != nil {
+		if forceQuarantine != nil {
+			err = errors.Join(err, forceQuarantine.Restore())
+		}
 		return err
+	}
+	if forceQuarantine != nil {
+		forceQuarantine.Cleanup()
 	}
 	return printWorkspacePlan(workspacePlanOutput(ctx, opts), entries)
 }
@@ -387,7 +409,7 @@ func validateWorkspaceCopyOutLocalRepository(local *resolvedRepositoryCheckout, 
 	return nil
 }
 
-func ensureGitWorkspaceCopyOutSafe(local *resolvedRepositoryCheckout, checkout *repositorycheckout.Checkout, binding *workspaceBinding, files []repositorychangeset.File, force bool) error {
+func ensureGitWorkspaceCopyOutSafe(local *resolvedRepositoryCheckout, checkout *repositorycheckout.Checkout, binding *workspaceBinding, files []repositorychangeset.File, force bool, forceHint string) error {
 	if local == nil || strings.TrimSpace(local.RootDir) == "" {
 		return errors.New("workspace copy-out requires a local Git repository checkout matching the sandbox repository")
 	}
@@ -401,14 +423,14 @@ func ensureGitWorkspaceCopyOutSafe(local *resolvedRepositoryCheckout, checkout *
 	}
 	if binding == nil && !strings.EqualFold(localCommit, sandboxCommit) {
 		if !force {
-			return fmt.Errorf("workspace copy-out requires local checkout HEAD %s to match sandbox baseline %s; rerun with --force to overwrite local target paths", shortGitSHA(localCommit), shortGitSHA(sandboxCommit))
+			return fmt.Errorf("workspace copy-out requires local checkout HEAD %s to match sandbox baseline %s; %s", shortGitSHA(localCommit), shortGitSHA(sandboxCommit), workspaceCopyOutForceSuggestion(forceHint))
 		}
 	}
 	if force {
 		return nil
 	}
 	if binding != nil {
-		return ensureGitWorkspaceCopyOutSafeWithBinding(local.RootDir, sandboxCommit, binding, files)
+		return ensureGitWorkspaceCopyOutSafeWithBinding(local.RootDir, sandboxCommit, binding, files, forceHint)
 	}
 	var conflicts []workspaceCopyOutConflict
 	for _, file := range files {
@@ -420,10 +442,10 @@ func ensureGitWorkspaceCopyOutSafe(local *resolvedRepositoryCheckout, checkout *
 			conflicts = append(conflicts, *conflict)
 		}
 	}
-	return workspaceCopyOutConflictError(conflicts)
+	return workspaceCopyOutConflictError(conflicts, forceHint)
 }
 
-func ensureGitWorkspaceCopyOutSafeWithBinding(localRoot, baseCommit string, binding *workspaceBinding, files []repositorychangeset.File) error {
+func ensureGitWorkspaceCopyOutSafeWithBinding(localRoot, baseCommit string, binding *workspaceBinding, files []repositorychangeset.File, forceHint string) error {
 	manifest, err := workspaceCopyInManifestMap(binding)
 	if err != nil {
 		return err
@@ -474,7 +496,7 @@ func ensureGitWorkspaceCopyOutSafeWithBinding(localRoot, baseCommit string, bind
 			}
 		}
 	}
-	return workspaceCopyOutConflictError(conflicts)
+	return workspaceCopyOutConflictError(conflicts, forceHint)
 }
 
 func workspaceCopyInManifestMap(binding *workspaceBinding) (map[string]workspaceBindingFile, error) {
@@ -570,7 +592,7 @@ func gitPathExistsInCommit(localRoot, commit, rel string) (bool, error) {
 	return strings.Trim(output, "\x00 \n\r\t") != "", nil
 }
 
-func workspaceCopyOutConflictError(conflicts []workspaceCopyOutConflict) error {
+func workspaceCopyOutConflictError(conflicts []workspaceCopyOutConflict, forceHint string) error {
 	if len(conflicts) == 0 {
 		return nil
 	}
@@ -598,15 +620,31 @@ func workspaceCopyOutConflictError(conflicts []workspaceCopyOutConflict) error {
 	sort.Strings(paths)
 	if len(paths) == 1 {
 		conflict := byPath[paths[0]]
-		return fmt.Errorf("local workspace path %q %s; refusing workspace copy-out; rerun with --force to overwrite local target paths", conflict.Path, conflict.Reason)
+		return fmt.Errorf("local workspace path %q %s; refusing workspace copy-out; %s", conflict.Path, conflict.Reason, workspaceCopyOutForceSuggestion(forceHint))
 	}
 	var b strings.Builder
-	fmt.Fprintf(&b, "workspace copy-out found %d local conflicts; refusing workspace copy-out; rerun with --force to overwrite local target paths:", len(paths))
+	fmt.Fprintf(&b, "workspace copy-out found %d local conflicts; refusing workspace copy-out; %s:", len(paths), workspaceCopyOutForceSuggestion(forceHint))
 	for _, path := range paths {
 		conflict := byPath[path]
 		fmt.Fprintf(&b, "\n- %s: %s", conflict.Path, conflict.Reason)
 	}
 	return errors.New(b.String())
+}
+
+func workspaceCopyOutForceHint(sandboxID string) string {
+	sandboxID = strings.TrimSpace(sandboxID)
+	if sandboxID == "" {
+		sandboxID = "<sandbox-id>"
+	}
+	return "cleanroom workspace copy-out --force " + sandboxID
+}
+
+func workspaceCopyOutForceSuggestion(forceHint string) string {
+	forceHint = strings.TrimSpace(forceHint)
+	if forceHint == "" {
+		forceHint = workspaceCopyOutForceHint("")
+	}
+	return "run " + forceHint + " to overwrite local target paths"
 }
 
 func captureGitWorkspaceCopyOutPayload(callCtx context.Context, ctx *runtimeContext, client *controlclient.Client, opts workspaceCopyOptions, checkout *repositorycheckout.Checkout) ([]repositorychangeset.File, []byte, error) {
@@ -674,6 +712,14 @@ func resetGitWorkspaceCopyOutForceIndex(localRoot string, files []repositorychan
 	if err != nil {
 		return err
 	}
+	obstacles, err := gitWorkspaceCopyOutForceObstaclePaths(localRoot, files, paths)
+	if err != nil {
+		return err
+	}
+	paths, err = mergeWorkspaceCopyOutPaths(paths, obstacles)
+	if err != nil {
+		return err
+	}
 	if len(paths) == 0 {
 		return nil
 	}
@@ -684,28 +730,195 @@ func resetGitWorkspaceCopyOutForceIndex(localRoot string, files []repositorychan
 	return nil
 }
 
-func removeGitWorkspaceCopyOutForceObstacles(localRoot string, files []repositorychangeset.File) error {
+func mergeWorkspaceCopyOutPaths(paths ...[]string) ([]string, error) {
+	seen := make(map[string]struct{})
+	var out []string
+	for _, group := range paths {
+		for _, path := range group {
+			normalized, err := workspaceRelativePath(path)
+			if err != nil {
+				return nil, err
+			}
+			if _, ok := seen[normalized]; ok {
+				continue
+			}
+			seen[normalized] = struct{}{}
+			out = append(out, normalized)
+		}
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+type workspaceCopyOutForceQuarantine struct {
+	tempRoot string
+	moves    []workspaceCopyOutForceMove
+}
+
+type workspaceCopyOutForceMove struct {
+	path     string
+	original string
+	stashed  string
+}
+
+func quarantineGitWorkspaceCopyOutForceObstacles(localRoot string, files []repositorychangeset.File) (*workspaceCopyOutForceQuarantine, error) {
 	paths, err := workspaceCopyOutPaths(files)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	current, err := gitWorkspaceCurrentFiles(localRoot, paths)
+	candidates, err := gitWorkspaceCopyOutForceObstaclePaths(localRoot, files, paths)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	for _, path := range paths {
-		if !current[path].Deleted {
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+	tempRoot, err := os.MkdirTemp(filepath.Dir(localRoot), ".cleanroom-copy-out-obstacles-*")
+	if err != nil {
+		return nil, fmt.Errorf("create forced copy-out obstacle quarantine: %w", err)
+	}
+	q := &workspaceCopyOutForceQuarantine{tempRoot: tempRoot}
+	for _, path := range candidates {
+		if q.hasMovedAncestor(path) {
 			continue
 		}
 		localPath, err := workspaceLocalPath(localRoot, path)
 		if err != nil {
-			return err
+			_ = q.Restore()
+			return nil, err
 		}
-		if err := os.RemoveAll(localPath); err != nil {
-			return fmt.Errorf("remove local workspace path %q before forced copy-out: %w", path, err)
+		if _, err := os.Lstat(localPath); err != nil {
+			if isWorkspacePathAbsent(err) {
+				continue
+			}
+			_ = q.Restore()
+			return nil, fmt.Errorf("inspect forced copy-out obstacle %q: %w", path, err)
+		}
+		stashedPath := filepath.Join(tempRoot, strconv.Itoa(len(q.moves)))
+		if err := os.Rename(localPath, stashedPath); err != nil {
+			_ = q.Restore()
+			return nil, fmt.Errorf("quarantine forced copy-out obstacle %q: %w", path, err)
+		}
+		q.moves = append(q.moves, workspaceCopyOutForceMove{
+			path:     path,
+			original: localPath,
+			stashed:  stashedPath,
+		})
+	}
+	if len(q.moves) == 0 {
+		q.Cleanup()
+		return nil, nil
+	}
+	return q, nil
+}
+
+func gitWorkspaceCopyOutForceObstaclePaths(localRoot string, files []repositorychangeset.File, paths []string) ([]string, error) {
+	deleted := make(map[string]bool, len(files))
+	for _, file := range files {
+		path, err := workspaceRelativePath(file.Path)
+		if err != nil {
+			return nil, err
+		}
+		deleted[path] = file.Deleted
+	}
+	candidates := make(map[string]struct{})
+	for _, target := range paths {
+		if deleted[target] {
+			continue
+		}
+		parts := strings.Split(target, "/")
+		for i := 1; i < len(parts); i++ {
+			prefix := strings.Join(parts[:i], "/")
+			localPath, err := workspaceLocalPath(localRoot, prefix)
+			if err != nil {
+				return nil, err
+			}
+			info, err := os.Lstat(localPath)
+			if err != nil {
+				if isWorkspacePathAbsent(err) {
+					continue
+				}
+				return nil, fmt.Errorf("inspect forced copy-out obstacle %q: %w", prefix, err)
+			}
+			if !info.IsDir() {
+				candidates[prefix] = struct{}{}
+				break
+			}
+		}
+		localPath, err := workspaceLocalPath(localRoot, target)
+		if err != nil {
+			return nil, err
+		}
+		info, err := os.Lstat(localPath)
+		if err != nil {
+			if isWorkspacePathAbsent(err) {
+				continue
+			}
+			return nil, fmt.Errorf("inspect forced copy-out obstacle %q: %w", target, err)
+		}
+		if info.IsDir() {
+			candidates[target] = struct{}{}
 		}
 	}
-	return nil
+	out := make([]string, 0, len(candidates))
+	for path := range candidates {
+		out = append(out, path)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		leftDepth := strings.Count(out[i], "/")
+		rightDepth := strings.Count(out[j], "/")
+		if leftDepth != rightDepth {
+			return leftDepth < rightDepth
+		}
+		return out[i] < out[j]
+	})
+	return out, nil
+}
+
+func isWorkspacePathAbsent(err error) bool {
+	return errors.Is(err, os.ErrNotExist) || errors.Is(err, syscall.ENOTDIR)
+}
+
+func (q *workspaceCopyOutForceQuarantine) hasMovedAncestor(path string) bool {
+	if q == nil {
+		return false
+	}
+	for _, move := range q.moves {
+		if path == move.path || strings.HasPrefix(path, move.path+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+func (q *workspaceCopyOutForceQuarantine) Restore() error {
+	if q == nil {
+		return nil
+	}
+	var restoreErr error
+	for i := len(q.moves) - 1; i >= 0; i-- {
+		move := q.moves[i]
+		if err := os.RemoveAll(move.original); err != nil {
+			restoreErr = errors.Join(restoreErr, fmt.Errorf("remove partial forced copy-out path %q: %w", move.path, err))
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(move.original), 0o755); err != nil {
+			restoreErr = errors.Join(restoreErr, fmt.Errorf("prepare restore for forced copy-out obstacle %q: %w", move.path, err))
+			continue
+		}
+		if err := os.Rename(move.stashed, move.original); err != nil {
+			restoreErr = errors.Join(restoreErr, fmt.Errorf("restore forced copy-out obstacle %q: %w", move.path, err))
+		}
+	}
+	q.Cleanup()
+	return restoreErr
+}
+
+func (q *workspaceCopyOutForceQuarantine) Cleanup() {
+	if q == nil || strings.TrimSpace(q.tempRoot) == "" {
+		return
+	}
+	_ = os.RemoveAll(q.tempRoot)
 }
 
 func buildGitWorkspaceCopyOutPatchFromLocalBase(localRoot, baseCommit, sandboxPatchPath string, files []repositorychangeset.File) ([]byte, []byte, error) {

--- a/internal/cli/workspace.go
+++ b/internal/cli/workspace.go
@@ -298,16 +298,18 @@ func copyWorkspaceOut(callCtx context.Context, ctx *runtimeContext, client *cont
 			return err
 		}
 		defer cleanupApply()
-		if len(files) == 0 {
-			if forceQuarantine != nil {
-				if err := forceQuarantine.Restore(); err != nil {
-					return err
-				}
-			}
+		if len(files) == 0 && forceQuarantine == nil {
 			return nil
 		}
 	}
-	entries, err := gitWorkspaceCopyOutPlanFiles(opts.CWD, files)
+	planFiles, err := gitWorkspaceCopyOutForcePlanFiles(files, forceQuarantine)
+	if err != nil {
+		if forceQuarantine != nil {
+			err = errors.Join(err, forceQuarantine.Restore())
+		}
+		return err
+	}
+	entries, err := gitWorkspaceCopyOutPlanFiles(opts.CWD, planFiles)
 	if err != nil {
 		if forceQuarantine != nil {
 			err = errors.Join(err, forceQuarantine.Restore())
@@ -326,16 +328,48 @@ func copyWorkspaceOut(callCtx context.Context, ctx *runtimeContext, client *cont
 			return err
 		}
 	}
-	if err := applyGitWorkspaceCopyOutPatch(opts.Repository.RootDir, applyPath); err != nil {
-		if forceQuarantine != nil {
-			err = errors.Join(err, forceQuarantine.Restore())
+	if len(files) > 0 {
+		if err := applyGitWorkspaceCopyOutPatch(opts.Repository.RootDir, applyPath); err != nil {
+			if forceQuarantine != nil {
+				err = errors.Join(err, forceQuarantine.Restore())
+			}
+			return err
 		}
-		return err
 	}
 	if forceQuarantine != nil {
 		forceQuarantine.Cleanup()
 	}
 	return printWorkspacePlan(workspacePlanOutput(ctx, opts), entries)
+}
+
+func gitWorkspaceCopyOutForcePlanFiles(files []repositorychangeset.File, quarantine *workspaceCopyOutForceQuarantine) ([]repositorychangeset.File, error) {
+	if quarantine == nil {
+		return files, nil
+	}
+	seen := make(map[string]struct{}, len(files))
+	planFiles := append([]repositorychangeset.File(nil), files...)
+	for _, file := range files {
+		path, err := workspaceRelativePath(file.Path)
+		if err != nil {
+			return nil, err
+		}
+		seen[path] = struct{}{}
+	}
+	for _, path := range quarantine.Paths() {
+		path, err := workspaceRelativePath(path)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+		planFiles = append(planFiles, repositorychangeset.File{
+			Path:    path,
+			Deleted: true,
+		})
+	}
+	return planFiles, nil
 }
 
 func workspacePlanOutput(ctx *runtimeContext, opts workspaceCopyOptions) io.Writer {
@@ -817,20 +851,9 @@ func quarantineGitWorkspaceCopyOutForceObstacles(localRoot string, files []repos
 	return q, nil
 }
 
-func gitWorkspaceCopyOutForceObstaclePaths(localRoot string, files []repositorychangeset.File, paths []string) ([]string, error) {
-	deleted := make(map[string]bool, len(files))
-	for _, file := range files {
-		path, err := workspaceRelativePath(file.Path)
-		if err != nil {
-			return nil, err
-		}
-		deleted[path] = file.Deleted
-	}
+func gitWorkspaceCopyOutForceObstaclePaths(localRoot string, _ []repositorychangeset.File, paths []string) ([]string, error) {
 	candidates := make(map[string]struct{})
 	for _, target := range paths {
-		if deleted[target] {
-			continue
-		}
 		parts := strings.Split(target, "/")
 		for i := 1; i < len(parts); i++ {
 			prefix := strings.Join(parts[:i], "/")

--- a/internal/cli/workspace.go
+++ b/internal/cli/workspace.go
@@ -301,7 +301,15 @@ func copyWorkspaceOut(callCtx context.Context, ctx *runtimeContext, client *cont
 		}
 	}
 	if opts.ForceCopyOut || useGitWorkspaceCopyOutApplyBase(opts.Binding, opts.Repository, checkout) {
-		files, applyPath, cleanupApply, err = prepareGitWorkspaceCopyOutApplyPatch(opts.Repository, checkout, files, patchPath)
+		var omittedPaths []string
+		if forceQuarantine != nil {
+			omittedPaths, err = forceQuarantine.OmittedPaths(opts.Repository.RootDir)
+			if err != nil {
+				err = errors.Join(err, forceQuarantine.Restore())
+				return err
+			}
+		}
+		files, applyPath, cleanupApply, err = prepareGitWorkspaceCopyOutApplyPatchWithOmittedPaths(opts.Repository, checkout, files, patchPath, omittedPaths)
 		if err != nil {
 			if forceQuarantine != nil {
 				err = errors.Join(err, forceQuarantine.Restore())
@@ -331,12 +339,19 @@ func copyWorkspaceOut(callCtx context.Context, ctx *runtimeContext, client *cont
 		}
 		return err
 	}
+	restoreForceIndex := func() error { return nil }
+	cleanupForceIndex := func() {}
 	if opts.ForceCopyOut {
-		var obstaclePaths []string
-		if forceQuarantine != nil {
-			obstaclePaths = forceQuarantine.Paths()
+		restoreForceIndex, cleanupForceIndex, err = snapshotGitWorkspaceCopyOutForceIndex(opts.Repository.RootDir, files, obstaclePaths)
+		if err != nil {
+			if forceQuarantine != nil {
+				err = errors.Join(err, forceQuarantine.Restore())
+			}
+			return err
 		}
+		defer cleanupForceIndex()
 		if err := resetGitWorkspaceCopyOutForceIndex(opts.Repository.RootDir, files, obstaclePaths); err != nil {
+			err = errors.Join(err, restoreForceIndex())
 			if forceQuarantine != nil {
 				err = errors.Join(err, forceQuarantine.Restore())
 			}
@@ -345,6 +360,9 @@ func copyWorkspaceOut(callCtx context.Context, ctx *runtimeContext, client *cont
 	}
 	if len(files) > 0 {
 		if err := applyGitWorkspaceCopyOutPatch(opts.Repository.RootDir, applyPath); err != nil {
+			if opts.ForceCopyOut {
+				err = errors.Join(err, restoreForceIndex())
+			}
 			if forceQuarantine != nil {
 				err = errors.Join(err, forceQuarantine.Restore())
 			}
@@ -788,6 +806,38 @@ func resetGitWorkspaceCopyOutForceIndex(localRoot string, files []repositorychan
 	return nil
 }
 
+func snapshotGitWorkspaceCopyOutForceIndex(localRoot string, files []repositorychangeset.File, extraPaths []string) (func() error, func(), error) {
+	paths, err := workspaceCopyOutPaths(files)
+	if err != nil {
+		return nil, nil, err
+	}
+	paths, err = mergeWorkspaceCopyOutPaths(paths, extraPaths)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(paths) == 0 {
+		return func() error { return nil }, func() {}, nil
+	}
+	args := append([]string{"diff", "--cached", "--binary", "--full-index", "--no-ext-diff", "--no-color", "--no-renames", "--"}, gitWorkspacePathspecs(paths)...)
+	patch, err := gitOutputRaw(localRoot, nil, args...)
+	if err != nil {
+		return nil, nil, fmt.Errorf("snapshot staged workspace copy-out target paths: %w", err)
+	}
+	if len(bytes.TrimSpace(patch)) == 0 {
+		return func() error { return nil }, func() {}, nil
+	}
+	patchPath, cleanup, err := writeTemporaryWorkspaceCopyOutPatch(patch)
+	if err != nil {
+		return nil, nil, err
+	}
+	return func() error {
+		if _, err := gitOutputRaw(localRoot, nil, "apply", "--cached", "--binary", "--whitespace=nowarn", patchPath); err != nil {
+			return fmt.Errorf("restore staged workspace copy-out target paths: %w", err)
+		}
+		return nil
+	}, cleanup, nil
+}
+
 func mergeWorkspaceCopyOutPaths(paths ...[]string) ([]string, error) {
 	seen := make(map[string]struct{})
 	var out []string
@@ -986,6 +1036,30 @@ func (q *workspaceCopyOutForceQuarantine) Paths() []string {
 	return paths
 }
 
+func (q *workspaceCopyOutForceQuarantine) OmittedPaths(localRoot string) ([]string, error) {
+	if q == nil {
+		return nil, nil
+	}
+	paths := q.Paths()
+	if strings.TrimSpace(q.tempRoot) == "" {
+		return paths, nil
+	}
+	rel, err := filepath.Rel(localRoot, q.tempRoot)
+	if err != nil {
+		return nil, fmt.Errorf("resolve forced copy-out quarantine path: %w", err)
+	}
+	rel = filepath.ToSlash(rel)
+	if strings.HasPrefix(rel, "../") || rel == ".." || filepath.IsAbs(rel) {
+		return nil, fmt.Errorf("forced copy-out quarantine path %q is outside local workspace root %q", q.tempRoot, localRoot)
+	}
+	path, err := workspaceRelativePath(rel)
+	if err != nil {
+		return nil, err
+	}
+	paths = append(paths, path)
+	return paths, nil
+}
+
 func buildGitWorkspaceCopyOutPatchFromLocalBase(localRoot, baseCommit, sandboxPatchPath string, files []repositorychangeset.File, omittedLocalPaths []string) ([]byte, []byte, error) {
 	paths, err := workspaceCopyOutPaths(files)
 	if err != nil {
@@ -1026,12 +1100,16 @@ func gitWorkspaceCurrentTree(localRoot string, omittedLocalPaths []string) (stri
 	if _, err := gitOutputRaw(localRoot, env, "read-tree", "HEAD"); err != nil {
 		return "", fmt.Errorf("initialize local workspace copy-out index: %w", err)
 	}
-	if _, err := gitOutputRaw(localRoot, env, "add", "-A", "--all", "."); err != nil {
-		return "", fmt.Errorf("stage local workspace copy-out base: %w", err)
-	}
 	omittedPaths, err := mergeWorkspaceCopyOutPaths(omittedLocalPaths)
 	if err != nil {
 		return "", err
+	}
+	addArgs := []string{"add", "-A", "--all", "."}
+	if len(omittedPaths) > 0 {
+		addArgs = append(addArgs, gitWorkspaceExcludePathspecs(omittedPaths)...)
+	}
+	if _, err := gitOutputRaw(localRoot, env, addArgs...); err != nil {
+		return "", fmt.Errorf("stage local workspace copy-out base: %w", err)
 	}
 	if len(omittedPaths) > 0 {
 		args := append([]string{"rm", "-r", "--cached", "--ignore-unmatch", "--"}, gitWorkspacePathspecs(omittedPaths)...)
@@ -1228,8 +1306,20 @@ func gitWorkspacePathspecs(paths []string) []string {
 	return pathspecs
 }
 
+func gitWorkspaceExcludePathspecs(paths []string) []string {
+	pathspecs := make([]string, 0, len(paths))
+	for _, path := range paths {
+		pathspecs = append(pathspecs, gitWorkspaceExcludePathspec(path))
+	}
+	return pathspecs
+}
+
 func gitWorkspacePathspec(path string) string {
 	return ":(literal)" + path
+}
+
+func gitWorkspaceExcludePathspec(path string) string {
+	return ":(exclude,literal)" + path
 }
 
 func temporaryGitIndex() (string, func(), error) {

--- a/internal/cli/workspace.go
+++ b/internal/cli/workspace.go
@@ -229,6 +229,7 @@ func copyWorkspaceOut(callCtx context.Context, ctx *runtimeContext, client *cont
 				return err
 			}
 			if len(files) > 0 {
+				var obstaclePaths []string
 				var cleanupApply func()
 				patchPath, cleanup, err := writeTemporaryWorkspaceCopyOutPatch(patch)
 				if err != nil {
@@ -238,11 +239,21 @@ func copyWorkspaceOut(callCtx context.Context, ctx *runtimeContext, client *cont
 				if err := ensureGitWorkspaceCopyOutSafe(opts.Repository, checkout, opts.Binding, files, opts.ForceCopyOut, opts.ForceOutHint); err != nil {
 					return err
 				}
-				files, _, cleanupApply, err = prepareGitWorkspaceCopyOutApplyPatch(opts.Repository, checkout, files, patchPath)
+				if opts.ForceCopyOut {
+					obstaclePaths, err = gitWorkspaceCopyOutForceObstaclePathsForFiles(opts.Repository.RootDir, files)
+					if err != nil {
+						return err
+					}
+				}
+				files, _, cleanupApply, err = prepareGitWorkspaceCopyOutApplyPatchWithOmittedPaths(opts.Repository, checkout, files, patchPath, obstaclePaths)
 				if err != nil {
 					return err
 				}
 				defer cleanupApply()
+				files, err = gitWorkspaceCopyOutForcePlanFiles(files, obstaclePaths)
+				if err != nil {
+					return err
+				}
 			}
 		} else {
 			command := repositorychangeset.WorktreeNameStatusCommand(checkout)
@@ -302,7 +313,11 @@ func copyWorkspaceOut(callCtx context.Context, ctx *runtimeContext, client *cont
 			return nil
 		}
 	}
-	planFiles, err := gitWorkspaceCopyOutForcePlanFiles(files, forceQuarantine)
+	var obstaclePaths []string
+	if forceQuarantine != nil {
+		obstaclePaths = forceQuarantine.Paths()
+	}
+	planFiles, err := gitWorkspaceCopyOutForcePlanFiles(files, obstaclePaths)
 	if err != nil {
 		if forceQuarantine != nil {
 			err = errors.Join(err, forceQuarantine.Restore())
@@ -342,8 +357,8 @@ func copyWorkspaceOut(callCtx context.Context, ctx *runtimeContext, client *cont
 	return printWorkspacePlan(workspacePlanOutput(ctx, opts), entries)
 }
 
-func gitWorkspaceCopyOutForcePlanFiles(files []repositorychangeset.File, quarantine *workspaceCopyOutForceQuarantine) ([]repositorychangeset.File, error) {
-	if quarantine == nil {
+func gitWorkspaceCopyOutForcePlanFiles(files []repositorychangeset.File, obstaclePaths []string) ([]repositorychangeset.File, error) {
+	if len(obstaclePaths) == 0 {
 		return files, nil
 	}
 	seen := make(map[string]struct{}, len(files))
@@ -355,7 +370,7 @@ func gitWorkspaceCopyOutForcePlanFiles(files []repositorychangeset.File, quarant
 		}
 		seen[path] = struct{}{}
 	}
-	for _, path := range quarantine.Paths() {
+	for _, path := range obstaclePaths {
 		path, err := workspaceRelativePath(path)
 		if err != nil {
 			return nil, err
@@ -726,13 +741,17 @@ func useGitWorkspaceCopyOutApplyBase(binding *workspaceBinding, local *resolvedR
 }
 
 func prepareGitWorkspaceCopyOutApplyPatch(local *resolvedRepositoryCheckout, checkout *repositorycheckout.Checkout, files []repositorychangeset.File, sandboxPatchPath string) ([]repositorychangeset.File, string, func(), error) {
+	return prepareGitWorkspaceCopyOutApplyPatchWithOmittedPaths(local, checkout, files, sandboxPatchPath, nil)
+}
+
+func prepareGitWorkspaceCopyOutApplyPatchWithOmittedPaths(local *resolvedRepositoryCheckout, checkout *repositorycheckout.Checkout, files []repositorychangeset.File, sandboxPatchPath string, omittedLocalPaths []string) ([]repositorychangeset.File, string, func(), error) {
 	if local == nil || strings.TrimSpace(local.RootDir) == "" {
 		return nil, "", nil, errors.New("workspace copy-out requires a local Git repository checkout matching the sandbox repository")
 	}
 	if checkout == nil || strings.TrimSpace(checkout.CommitSHA) == "" {
 		return nil, "", nil, errors.New("workspace copy-out requires a sandbox repository baseline")
 	}
-	nameStatus, patch, err := buildGitWorkspaceCopyOutPatchFromLocalBase(local.RootDir, checkout.CommitSHA, sandboxPatchPath, files)
+	nameStatus, patch, err := buildGitWorkspaceCopyOutPatchFromLocalBase(local.RootDir, checkout.CommitSHA, sandboxPatchPath, files, omittedLocalPaths)
 	if err != nil {
 		return nil, "", nil, err
 	}
@@ -801,11 +820,7 @@ type workspaceCopyOutForceMove struct {
 }
 
 func quarantineGitWorkspaceCopyOutForceObstacles(localRoot string, files []repositorychangeset.File) (*workspaceCopyOutForceQuarantine, error) {
-	paths, err := workspaceCopyOutPaths(files)
-	if err != nil {
-		return nil, err
-	}
-	candidates, err := gitWorkspaceCopyOutForceObstaclePaths(localRoot, files, paths)
+	candidates, err := gitWorkspaceCopyOutForceObstaclePathsForFiles(localRoot, files)
 	if err != nil {
 		return nil, err
 	}
@@ -851,7 +866,15 @@ func quarantineGitWorkspaceCopyOutForceObstacles(localRoot string, files []repos
 	return q, nil
 }
 
-func gitWorkspaceCopyOutForceObstaclePaths(localRoot string, _ []repositorychangeset.File, paths []string) ([]string, error) {
+func gitWorkspaceCopyOutForceObstaclePathsForFiles(localRoot string, files []repositorychangeset.File) ([]string, error) {
+	paths, err := workspaceCopyOutPaths(files)
+	if err != nil {
+		return nil, err
+	}
+	return gitWorkspaceCopyOutForceObstaclePaths(localRoot, paths)
+}
+
+func gitWorkspaceCopyOutForceObstaclePaths(localRoot string, paths []string) ([]string, error) {
 	candidates := make(map[string]struct{})
 	for _, target := range paths {
 		parts := strings.Split(target, "/")
@@ -963,7 +986,7 @@ func (q *workspaceCopyOutForceQuarantine) Paths() []string {
 	return paths
 }
 
-func buildGitWorkspaceCopyOutPatchFromLocalBase(localRoot, baseCommit, sandboxPatchPath string, files []repositorychangeset.File) ([]byte, []byte, error) {
+func buildGitWorkspaceCopyOutPatchFromLocalBase(localRoot, baseCommit, sandboxPatchPath string, files []repositorychangeset.File, omittedLocalPaths []string) ([]byte, []byte, error) {
 	paths, err := workspaceCopyOutPaths(files)
 	if err != nil {
 		return nil, nil, err
@@ -972,7 +995,7 @@ func buildGitWorkspaceCopyOutPatchFromLocalBase(localRoot, baseCommit, sandboxPa
 		return nil, nil, nil
 	}
 	pathspecs := gitWorkspacePathspecs(paths)
-	localTree, err := gitWorkspaceCurrentTree(localRoot)
+	localTree, err := gitWorkspaceCurrentTree(localRoot, omittedLocalPaths)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -993,7 +1016,7 @@ func buildGitWorkspaceCopyOutPatchFromLocalBase(localRoot, baseCommit, sandboxPa
 	return nameStatus, patch, nil
 }
 
-func gitWorkspaceCurrentTree(localRoot string) (string, error) {
+func gitWorkspaceCurrentTree(localRoot string, omittedLocalPaths []string) (string, error) {
 	indexPath, cleanup, err := temporaryGitIndex()
 	if err != nil {
 		return "", err
@@ -1005,6 +1028,16 @@ func gitWorkspaceCurrentTree(localRoot string) (string, error) {
 	}
 	if _, err := gitOutputRaw(localRoot, env, "add", "-A", "--all", "."); err != nil {
 		return "", fmt.Errorf("stage local workspace copy-out base: %w", err)
+	}
+	omittedPaths, err := mergeWorkspaceCopyOutPaths(omittedLocalPaths)
+	if err != nil {
+		return "", err
+	}
+	if len(omittedPaths) > 0 {
+		args := append([]string{"rm", "-r", "--cached", "--ignore-unmatch", "--"}, gitWorkspacePathspecs(omittedPaths)...)
+		if _, err := gitOutputRaw(localRoot, env, args...); err != nil {
+			return "", fmt.Errorf("omit forced workspace copy-out obstacles from local tree: %w", err)
+		}
 	}
 	tree, err := gitOutputRaw(localRoot, env, "write-tree")
 	if err != nil {

--- a/internal/cli/workspace_test.go
+++ b/internal/cli/workspace_test.go
@@ -1813,6 +1813,56 @@ func TestWorkspaceCopyOutForceQuarantineTempDirUsesRepoRoot(t *testing.T) {
 	}
 }
 
+func TestGitWorkspaceCurrentTreeOmitsForceObstaclePaths(t *testing.T) {
+	localRoot := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
+	quarantinePath := filepath.Join(localRoot, ".cleanroom-copy-out-obstacles-test")
+	if err := os.MkdirAll(quarantinePath, 0o755); err != nil {
+		t.Fatalf("create quarantine path: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(quarantinePath, "backup.txt"), []byte("backup\n"), 0o644); err != nil {
+		t.Fatalf("write quarantine backup: %v", err)
+	}
+
+	tree, err := gitWorkspaceCurrentTree(localRoot, []string{".cleanroom-copy-out-obstacles-test"})
+	if err != nil {
+		t.Fatalf("gitWorkspaceCurrentTree returned error: %v", err)
+	}
+	output, err := gitOutputRaw(localRoot, nil, "ls-tree", "-r", "--name-only", tree)
+	if err != nil {
+		t.Fatalf("inspect temporary tree: %v", err)
+	}
+	if strings.Contains(string(output), ".cleanroom-copy-out-obstacles-test") {
+		t.Fatalf("temporary local tree should omit quarantine path, got %q", output)
+	}
+}
+
+func TestWorkspaceCopyOutForceIndexSnapshotRestoresStagedObstacle(t *testing.T) {
+	localRoot := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
+	obstaclePath := filepath.Join(localRoot, "nested")
+	if err := os.WriteFile(obstaclePath, []byte("staged parent obstacle\n"), 0o644); err != nil {
+		t.Fatalf("write staged parent obstacle: %v", err)
+	}
+	runGitInDir(t, localRoot, "add", "nested")
+
+	restoreIndex, cleanupIndex, err := snapshotGitWorkspaceCopyOutForceIndex(localRoot, nil, []string{"nested"})
+	if err != nil {
+		t.Fatalf("snapshotGitWorkspaceCopyOutForceIndex returned error: %v", err)
+	}
+	defer cleanupIndex()
+	if err := resetGitWorkspaceCopyOutForceIndex(localRoot, nil, []string{"nested"}); err != nil {
+		t.Fatalf("resetGitWorkspaceCopyOutForceIndex returned error: %v", err)
+	}
+	if staged := gitOutputBytes(t, localRoot, "diff", "--cached", "--name-only", "--", "nested"); len(staged) != 0 {
+		t.Fatalf("expected staged obstacle to be reset, got cached diff %q", staged)
+	}
+	if err := restoreIndex(); err != nil {
+		t.Fatalf("restore staged force index: %v", err)
+	}
+	if staged := gitOutputBytes(t, localRoot, "show", ":nested"); string(staged) != "staged parent obstacle\n" {
+		t.Fatalf("unexpected restored staged obstacle: got %q", staged)
+	}
+}
+
 func TestWorkspaceCopyOutRejectsLocalModeDivergenceFromCopyInManifestBase(t *testing.T) {
 	fixture := setupWorkspaceCopyOutManifestBase(t, func(localRoot string) {
 		if err := os.WriteFile(filepath.Join(localRoot, "README.md"), []byte("local\nsandbox\n"), 0o644); err != nil {

--- a/internal/cli/workspace_test.go
+++ b/internal/cli/workspace_test.go
@@ -1482,6 +1482,137 @@ func TestWorkspaceCopyOutForceClearsStagedDivergenceFromCopyInManifestBase(t *te
 	assertNoWorkspaceCopyOutRecoveryPayload(t)
 }
 
+func TestWorkspaceCopyOutForceReplacesLocalDirectoryObstacleFromCopyInManifestBase(t *testing.T) {
+	fixture := setupWorkspaceCopyOutManifestBase(t, func(localRoot string) {
+		if err := os.WriteFile(filepath.Join(localRoot, "obstacle-target"), []byte("sandbox\n"), 0o644); err != nil {
+			t.Fatalf("write sandbox obstacle target: %v", err)
+		}
+	})
+	obstacleDir := filepath.Join(fixture.localRoot, "obstacle-target")
+	if err := os.MkdirAll(obstacleDir, 0o755); err != nil {
+		t.Fatalf("create local obstacle directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(obstacleDir, "keep.txt"), []byte("local obstacle\n"), 0o644); err != nil {
+		t.Fatalf("write local obstacle file: %v", err)
+	}
+
+	stdout, _ := makeStdoutCapture(t)
+	stderr, _ := makeStdoutCapture(t)
+	cmd := WorkspaceCopyOutCommand{
+		clientFlags: clientFlags{Host: fixture.host},
+		Force:       true,
+		SandboxID:   fixture.sandboxID,
+	}
+	if err := cmd.Run(&runtimeContext{
+		CWD:           t.TempDir(),
+		Loader:        repositoryNotFoundLoader{},
+		Config:        runtimeconfig.Config{},
+		Observability: newTestObservability(t),
+		Stdout:        stdout,
+		Stderr:        stderr,
+	}); err != nil {
+		t.Fatalf("WorkspaceCopyOutCommand.Run returned error: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(fixture.localRoot, "obstacle-target"))
+	if err != nil {
+		t.Fatalf("read copied-out obstacle target: %v", err)
+	}
+	if string(got) != "sandbox\n" {
+		t.Fatalf("unexpected obstacle target content: got %q", got)
+	}
+	assertNoWorkspaceCopyOutRecoveryPayload(t)
+}
+
+func TestWorkspaceCopyOutForceReplacesIgnoredLocalDirectoryObstacleFromCopyInManifestBase(t *testing.T) {
+	fixture := setupWorkspaceCopyOutManifestBaseWithLocalMutate(t, func(localRoot string) {
+		if err := os.WriteFile(filepath.Join(localRoot, ".gitignore"), []byte("obstacle-target/keep.txt\n"), 0o644); err != nil {
+			t.Fatalf("write gitignore: %v", err)
+		}
+	}, func(localRoot string) {
+		if err := os.WriteFile(filepath.Join(localRoot, "obstacle-target"), []byte("sandbox\n"), 0o644); err != nil {
+			t.Fatalf("write sandbox obstacle target: %v", err)
+		}
+	})
+	obstacleDir := filepath.Join(fixture.localRoot, "obstacle-target")
+	if err := os.MkdirAll(obstacleDir, 0o755); err != nil {
+		t.Fatalf("create local ignored obstacle directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(obstacleDir, "keep.txt"), []byte("ignored obstacle\n"), 0o644); err != nil {
+		t.Fatalf("write local ignored obstacle file: %v", err)
+	}
+
+	stdout, _ := makeStdoutCapture(t)
+	stderr, _ := makeStdoutCapture(t)
+	cmd := WorkspaceCopyOutCommand{
+		clientFlags: clientFlags{Host: fixture.host},
+		Force:       true,
+		SandboxID:   fixture.sandboxID,
+	}
+	if err := cmd.Run(&runtimeContext{
+		CWD:           t.TempDir(),
+		Loader:        repositoryNotFoundLoader{},
+		Config:        runtimeconfig.Config{},
+		Observability: newTestObservability(t),
+		Stdout:        stdout,
+		Stderr:        stderr,
+	}); err != nil {
+		t.Fatalf("WorkspaceCopyOutCommand.Run returned error: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(fixture.localRoot, "obstacle-target"))
+	if err != nil {
+		t.Fatalf("read copied-out obstacle target: %v", err)
+	}
+	if string(got) != "sandbox\n" {
+		t.Fatalf("unexpected obstacle target content: got %q", got)
+	}
+	assertNoWorkspaceCopyOutRecoveryPayload(t)
+}
+
+func TestWorkspaceCopyOutForceClearsStagedParentFileObstacleFromCopyInManifestBase(t *testing.T) {
+	fixture := setupWorkspaceCopyOutManifestBase(t, func(localRoot string) {
+		if err := os.MkdirAll(filepath.Join(localRoot, "nested"), 0o755); err != nil {
+			t.Fatalf("create sandbox nested directory: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(localRoot, "nested", "file.txt"), []byte("sandbox\n"), 0o644); err != nil {
+			t.Fatalf("write sandbox nested file: %v", err)
+		}
+	})
+	parentPath := filepath.Join(fixture.localRoot, "nested")
+	if err := os.WriteFile(parentPath, []byte("staged parent obstacle\n"), 0o644); err != nil {
+		t.Fatalf("write staged parent obstacle: %v", err)
+	}
+	runGitInDir(t, fixture.localRoot, "add", "nested")
+
+	stdout, _ := makeStdoutCapture(t)
+	stderr, _ := makeStdoutCapture(t)
+	cmd := WorkspaceCopyOutCommand{
+		clientFlags: clientFlags{Host: fixture.host},
+		Force:       true,
+		SandboxID:   fixture.sandboxID,
+	}
+	if err := cmd.Run(&runtimeContext{
+		CWD:           t.TempDir(),
+		Loader:        repositoryNotFoundLoader{},
+		Config:        runtimeconfig.Config{},
+		Observability: newTestObservability(t),
+		Stdout:        stdout,
+		Stderr:        stderr,
+	}); err != nil {
+		t.Fatalf("WorkspaceCopyOutCommand.Run returned error: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(fixture.localRoot, "nested", "file.txt"))
+	if err != nil {
+		t.Fatalf("read copied-out nested file: %v", err)
+	}
+	if string(got) != "sandbox\n" {
+		t.Fatalf("unexpected nested file content: got %q", got)
+	}
+	if staged := gitOutputBytes(t, fixture.localRoot, "diff", "--cached", "--name-only", "--", "nested"); len(staged) != 0 {
+		t.Fatalf("force copy-out should clear staged parent obstacle, got cached diff %q", staged)
+	}
+	assertNoWorkspaceCopyOutRecoveryPayload(t)
+}
+
 func TestWorkspaceCopyOutRejectsLocalModeDivergenceFromCopyInManifestBase(t *testing.T) {
 	fixture := setupWorkspaceCopyOutManifestBase(t, func(localRoot string) {
 		if err := os.WriteFile(filepath.Join(localRoot, "README.md"), []byte("local\nsandbox\n"), 0o644); err != nil {

--- a/internal/cli/workspace_test.go
+++ b/internal/cli/workspace_test.go
@@ -1482,6 +1482,66 @@ func TestWorkspaceCopyOutForceClearsStagedDivergenceFromCopyInManifestBase(t *te
 	assertNoWorkspaceCopyOutRecoveryPayload(t)
 }
 
+func TestWorkspaceCopyOutForceInvalidPatchPreservesStagedTargets(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	localRoot := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
+	baseCommit := headCommit(t, localRoot)
+	readmePath := filepath.Join(localRoot, "README.md")
+	if err := os.WriteFile(readmePath, []byte("staged divergent\n"), 0o644); err != nil {
+		t.Fatalf("write staged divergent README: %v", err)
+	}
+	runGitInDir(t, localRoot, "add", "README.md")
+	if err := os.WriteFile(readmePath, []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("restore working tree README: %v", err)
+	}
+
+	adapter := &integrationAdapter{}
+	host, _ := startIntegrationServer(t, adapter)
+	sandboxID := createWorkspaceCopyTestSandboxWithRepositoryCommitBranch(t, host, "/sandbox-workspace", baseCommit, "main")
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+		command := strings.Join(req.Command, " ")
+		switch {
+		case strings.Contains(command, "cleanroom-copy-out-v1"):
+			if stream.OnStdout != nil {
+				stream.OnStdout(workspaceCopyOutTestPayload([]byte("M\x00README.md\x00"), []byte("not a git patch\n")))
+			}
+		default:
+			t.Fatalf("unexpected workspace copy-out command: %q", command)
+		}
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+	}
+
+	stdout, _ := makeStdoutCapture(t)
+	stderr, _ := makeStdoutCapture(t)
+	cmd := WorkspaceCopyOutCommand{
+		clientFlags: clientFlags{Host: host},
+		Chdir:       localRoot,
+		Force:       true,
+		SandboxID:   sandboxID,
+	}
+	err := cmd.Run(&runtimeContext{
+		CWD:           localRoot,
+		Loader:        repositoryNotFoundLoader{},
+		Config:        runtimeconfig.Config{},
+		Observability: newTestObservability(t),
+		Stdout:        stdout,
+		Stderr:        stderr,
+	})
+	if err == nil {
+		t.Fatal("expected invalid sandbox patch to fail")
+	}
+	if !strings.Contains(err.Error(), "apply sandbox workspace copy-out patch to temporary index") {
+		t.Fatalf("expected temporary index apply error, got %v", err)
+	}
+	if staged := gitOutputBytes(t, localRoot, "diff", "--cached", "--name-only", "--", "README.md"); string(staged) != "README.md\n" {
+		t.Fatalf("force copy-out should preserve staged target content on patch prep failure, got cached diff %q", staged)
+	}
+	if staged := gitOutputBytes(t, localRoot, "show", ":README.md"); string(staged) != "staged divergent\n" {
+		t.Fatalf("unexpected staged README after failed force copy-out: got %q", staged)
+	}
+	assertNoWorkspaceCopyOutRecoveryPayload(t)
+}
+
 func TestWorkspaceCopyOutForceReplacesLocalDirectoryObstacleFromCopyInManifestBase(t *testing.T) {
 	fixture := setupWorkspaceCopyOutManifestBase(t, func(localRoot string) {
 		if err := os.WriteFile(filepath.Join(localRoot, "obstacle-target"), []byte("sandbox\n"), 0o644); err != nil {
@@ -1611,6 +1671,31 @@ func TestWorkspaceCopyOutForceClearsStagedParentFileObstacleFromCopyInManifestBa
 		t.Fatalf("force copy-out should clear staged parent obstacle, got cached diff %q", staged)
 	}
 	assertNoWorkspaceCopyOutRecoveryPayload(t)
+}
+
+func TestWorkspaceCopyOutForceQuarantineRestoreKeepsBackupOnFailure(t *testing.T) {
+	tempRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tempRoot, "survivor"), []byte("stashed\n"), 0o644); err != nil {
+		t.Fatalf("write quarantine survivor: %v", err)
+	}
+	q := &workspaceCopyOutForceQuarantine{
+		tempRoot: tempRoot,
+		moves: []workspaceCopyOutForceMove{{
+			path:     "obstacle-target",
+			original: filepath.Join(t.TempDir(), "obstacle-target"),
+			stashed:  filepath.Join(tempRoot, "missing"),
+		}},
+	}
+	err := q.Restore()
+	if err == nil {
+		t.Fatal("expected quarantine restore failure")
+	}
+	if !strings.Contains(err.Error(), tempRoot) {
+		t.Fatalf("expected restore error to include quarantine backup path %q, got %v", tempRoot, err)
+	}
+	if _, err := os.Stat(filepath.Join(tempRoot, "survivor")); err != nil {
+		t.Fatalf("expected failed restore to keep quarantine data: %v", err)
+	}
 }
 
 func TestWorkspaceCopyOutRejectsLocalModeDivergenceFromCopyInManifestBase(t *testing.T) {

--- a/internal/cli/workspace_test.go
+++ b/internal/cli/workspace_test.go
@@ -1628,6 +1628,50 @@ func TestWorkspaceCopyOutForceReplacesIgnoredLocalDirectoryObstacleFromCopyInMan
 	assertNoWorkspaceCopyOutRecoveryPayload(t)
 }
 
+func TestWorkspaceCopyOutForceDeletesLocalDirectoryObstacleFromCopyInManifestBase(t *testing.T) {
+	fixture := setupWorkspaceCopyOutManifestBase(t, func(localRoot string) {
+		if err := os.Remove(filepath.Join(localRoot, "README.md")); err != nil {
+			t.Fatalf("delete sandbox README: %v", err)
+		}
+	})
+	readmePath := filepath.Join(fixture.localRoot, "README.md")
+	if err := os.Remove(readmePath); err != nil {
+		t.Fatalf("remove local README file: %v", err)
+	}
+	if err := os.MkdirAll(readmePath, 0o755); err != nil {
+		t.Fatalf("create local README directory obstacle: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(readmePath, "keep.txt"), []byte("local obstacle\n"), 0o644); err != nil {
+		t.Fatalf("write local README obstacle file: %v", err)
+	}
+
+	stdout, stdoutText := makeStdoutCapture(t)
+	stderr, _ := makeStdoutCapture(t)
+	cmd := WorkspaceCopyOutCommand{
+		clientFlags: clientFlags{Host: fixture.host},
+		Force:       true,
+		SandboxID:   fixture.sandboxID,
+	}
+	if err := cmd.Run(&runtimeContext{
+		CWD:           t.TempDir(),
+		Loader:        repositoryNotFoundLoader{},
+		Config:        runtimeconfig.Config{},
+		Observability: newTestObservability(t),
+		Stdout:        stdout,
+		Stderr:        stderr,
+	}); err != nil {
+		t.Fatalf("WorkspaceCopyOutCommand.Run returned error: %v", err)
+	}
+	if _, err := os.Lstat(readmePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("force copy-out should delete local README directory obstacle, got err %v", err)
+	}
+	expected := "delete\t" + filepath.Join(fixture.resolvedLocalRoot, "README.md") + "\n"
+	if got := stdoutText(); got != expected {
+		t.Fatalf("unexpected copy-out output: got %q want %q", got, expected)
+	}
+	assertNoWorkspaceCopyOutRecoveryPayload(t)
+}
+
 func TestWorkspaceCopyOutForceClearsStagedParentFileObstacleFromCopyInManifestBase(t *testing.T) {
 	fixture := setupWorkspaceCopyOutManifestBase(t, func(localRoot string) {
 		if err := os.MkdirAll(filepath.Join(localRoot, "nested"), 0o755); err != nil {

--- a/internal/cli/workspace_test.go
+++ b/internal/cli/workspace_test.go
@@ -1672,6 +1672,51 @@ func TestWorkspaceCopyOutForceDeletesLocalDirectoryObstacleFromCopyInManifestBas
 	assertNoWorkspaceCopyOutRecoveryPayload(t)
 }
 
+func TestWorkspaceCopyOutForceDryRunPlansDeletedLocalDirectoryObstacleFromCopyInManifestBase(t *testing.T) {
+	fixture := setupWorkspaceCopyOutManifestBase(t, func(localRoot string) {
+		if err := os.Remove(filepath.Join(localRoot, "README.md")); err != nil {
+			t.Fatalf("delete sandbox README: %v", err)
+		}
+	})
+	readmePath := filepath.Join(fixture.localRoot, "README.md")
+	if err := os.Remove(readmePath); err != nil {
+		t.Fatalf("remove local README file: %v", err)
+	}
+	if err := os.MkdirAll(readmePath, 0o755); err != nil {
+		t.Fatalf("create local README directory obstacle: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(readmePath, "keep.txt"), []byte("local obstacle\n"), 0o644); err != nil {
+		t.Fatalf("write local README obstacle file: %v", err)
+	}
+
+	stdout, stdoutText := makeStdoutCapture(t)
+	stderr, _ := makeStdoutCapture(t)
+	cmd := WorkspaceCopyOutCommand{
+		clientFlags: clientFlags{Host: fixture.host},
+		DryRun:      true,
+		Force:       true,
+		SandboxID:   fixture.sandboxID,
+	}
+	if err := cmd.Run(&runtimeContext{
+		CWD:           t.TempDir(),
+		Loader:        repositoryNotFoundLoader{},
+		Config:        runtimeconfig.Config{},
+		Observability: newTestObservability(t),
+		Stdout:        stdout,
+		Stderr:        stderr,
+	}); err != nil {
+		t.Fatalf("WorkspaceCopyOutCommand.Run returned error: %v", err)
+	}
+	expected := "delete\t" + filepath.Join(fixture.resolvedLocalRoot, "README.md") + "\n"
+	if got := stdoutText(); got != expected {
+		t.Fatalf("unexpected dry-run copy-out output: got %q want %q", got, expected)
+	}
+	if got, err := os.ReadFile(filepath.Join(readmePath, "keep.txt")); err != nil || string(got) != "local obstacle\n" {
+		t.Fatalf("force dry-run should leave local README obstacle untouched, got %q err %v", got, err)
+	}
+	assertNoWorkspaceCopyOutRecoveryPayload(t)
+}
+
 func TestWorkspaceCopyOutForceClearsStagedParentFileObstacleFromCopyInManifestBase(t *testing.T) {
 	fixture := setupWorkspaceCopyOutManifestBase(t, func(localRoot string) {
 		if err := os.MkdirAll(filepath.Join(localRoot, "nested"), 0o755); err != nil {

--- a/internal/cli/workspace_test.go
+++ b/internal/cli/workspace_test.go
@@ -1698,6 +1698,32 @@ func TestWorkspaceCopyOutForceQuarantineRestoreKeepsBackupOnFailure(t *testing.T
 	}
 }
 
+func TestWorkspaceCopyOutForceQuarantineTempDirUsesRepoRoot(t *testing.T) {
+	localRoot := t.TempDir()
+	obstacleDir := filepath.Join(localRoot, "obstacle-target")
+	if err := os.MkdirAll(obstacleDir, 0o755); err != nil {
+		t.Fatalf("create obstacle directory: %v", err)
+	}
+	q, err := quarantineGitWorkspaceCopyOutForceObstacles(localRoot, []repositorychangeset.File{{
+		Path: "obstacle-target",
+	}})
+	if err != nil {
+		t.Fatalf("quarantineGitWorkspaceCopyOutForceObstacles returned error: %v", err)
+	}
+	if q == nil {
+		t.Fatal("expected obstacle quarantine")
+	}
+	if filepath.Dir(q.tempRoot) != localRoot {
+		t.Fatalf("expected quarantine temp dir under repo root %q, got %q", localRoot, q.tempRoot)
+	}
+	if err := q.Restore(); err != nil {
+		t.Fatalf("restore quarantine: %v", err)
+	}
+	if _, err := os.Stat(obstacleDir); err != nil {
+		t.Fatalf("expected obstacle to be restored: %v", err)
+	}
+}
+
 func TestWorkspaceCopyOutRejectsLocalModeDivergenceFromCopyInManifestBase(t *testing.T) {
 	fixture := setupWorkspaceCopyOutManifestBase(t, func(localRoot string) {
 		if err := os.WriteFile(filepath.Join(localRoot, "README.md"), []byte("local\nsandbox\n"), 0o644); err != nil {


### PR DESCRIPTION
## Summary

- quarantine local file/directory obstacles before rebuilding a forced copy-out apply patch
- restore quarantined obstacles if force planning or patch application fails, instead of deleting them before a failing `git apply`
- update copy-out conflict guidance to point at `cleanroom workspace copy-out --force <sandbox-id>` for top-level workflows

## Validation

- `git diff --check`
- `mise exec -- go test ./internal/cli -run 'TestWorkspaceCopyOutForce(ReplacesLocalDirectoryObstacle|ReplacesIgnoredLocalDirectoryObstacle|ClearsStagedParentFileObstacle|ClearsStagedDivergence|OverwritesLocalDivergence)|TestExecIntegrationCopyOutRejectsBaselineMismatchBeforeCommand'`\n- `mise exec -- go test ./internal/cli`\n- `mise exec -- go test ./internal/repositorychangeset`\n