### PR TITLE
feat: Attach Firecracker cache output volumes

### DIFF
--- a/docs/plans/dependency-service-volume-caches.md
+++ b/docs/plans/dependency-service-volume-caches.md
@@ -812,8 +812,6 @@ Completed in phase 3:
 
 Remaining phase 3 work:
 
-- implement backend preparation and attachment of output volumes before VM
-  launch
 - mount declared `outputs.dirs` and restore declared `outputs.files` inside the
   guest before block commands run
 - run missed dependency and service blocks from isolated input projections
@@ -821,6 +819,48 @@ Remaining phase 3 work:
 - snapshot and publish output records after successful missed blocks
 - keep aggregate exact full-rootfs stage caches as the fallback path until
   per-block execution is complete
+
+### Phase 4 PR Status
+
+The fourth implementation PR starts the backend side of the runtime path for
+Firecracker. It consumes the launch-time `backend.CacheOutputVolumeSpec` list
+and prepares writable sidecar ext4 volumes before the VM starts. It still does
+not mount those volumes in the guest, restore file outputs, run block commands,
+capture writes, or publish block output snapshots; aggregate dependency and
+service bootstrap commands remain the runtime fallback.
+
+Completed in phase 4:
+
+- Firecracker advertises `sandbox.cache_output_volumes` but intentionally does
+  not advertise `sandbox.overlay_write_capture` until the guest execution path
+  exists
+- cold provisions and snapshot restores forward cache output volume specs into
+  Firecracker launch
+- Firecracker validates cache output volume specs before launch, rejects
+  malformed specs, and rejects duplicate runtime volume IDs
+- cache hits prepare writable volumes by cloning or copying the recorded source
+  storage ref
+- cache misses create an empty ext4 source image and prepare a writable output
+  volume from it
+- prepared output volumes are attached as non-root, writable Firecracker block
+  devices alongside the rootfs
+- output volume cleanup is included in all launch failure and sandbox cleanup
+  paths
+- tests cover capability reporting, launch request forwarding, hit and miss
+  volume preparation, malformed specs, and cleanup on partial prepare failure
+
+Remaining runtime work after phase 4:
+
+- mount output block devices in the guest at Cleanroom-managed locations
+- map declared `outputs.dirs` into the command view and restore declared
+  `outputs.files` from output volumes
+- run missed dependency and service blocks from isolated input projections
+- inspect overlay write capture results and warn/fallback on escaped writes
+- snapshot and publish output records after successful missed blocks
+- advertise `sandbox.overlay_write_capture` once escaped-write detection and
+  isolated block execution are wired through
+- decide whether output volume sizing stays internal or becomes policy-visible
+  after real workloads show the right default
 
 ## Tests
 

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -65,8 +65,8 @@ type Adapter struct {
 	sandboxMu                   sync.Mutex
 	sandboxes                   map[string]*sandboxInstance
 	provisioning                map[string]struct{}
-	launchSandboxVMFn           func(context.Context, string, *policy.CompiledPolicy, backend.FirecrackerConfig) (*sandboxInstance, error)
-	launchSandboxVMFromRootFSFn func(context.Context, string, *policy.CompiledPolicy, backend.FirecrackerConfig, string) (*sandboxInstance, error)
+	launchSandboxVMFn           func(context.Context, string, *policy.CompiledPolicy, backend.FirecrackerConfig, []backend.CacheOutputVolumeSpec) (*sandboxInstance, error)
+	launchSandboxVMFromRootFSFn func(context.Context, string, *policy.CompiledPolicy, backend.FirecrackerConfig, string, []backend.CacheOutputVolumeSpec) (*sandboxInstance, error)
 	runGuestCommandFn           func(context.Context, context.Context, <-chan struct{}, func() error, string, uint32, vsockexec.ExecRequest, backend.OutputStream) (vsockexec.ExecResponse, guestExecTiming, error)
 
 	GatewayRegistry gatewayRegistry
@@ -334,11 +334,12 @@ func (a *Adapter) Name() string {
 
 func (a *Adapter) Capabilities() map[string]bool {
 	return map[string]bool{
-		backend.CapabilityNetworkDefaultDeny:     true,
-		backend.CapabilityNetworkAllowlistEgress: true,
-		backend.CapabilityDNSControlOrEquivalent: true,
-		backend.CapabilityNetworkGuestInterface:  true,
-		backend.CapabilitySandboxPortDial:        true,
+		backend.CapabilityNetworkDefaultDeny:        true,
+		backend.CapabilityNetworkAllowlistEgress:    true,
+		backend.CapabilityDNSControlOrEquivalent:    true,
+		backend.CapabilityNetworkGuestInterface:     true,
+		backend.CapabilitySandboxPortDial:           true,
+		backend.CapabilitySandboxCacheOutputVolumes: true,
 	}
 }
 
@@ -392,7 +393,7 @@ func (a *Adapter) ProvisionSandbox(ctx context.Context, req backend.ProvisionReq
 		launch = a.launchSandboxVM
 	}
 
-	instance, err := launch(ctx, sandboxID, req.Policy, req.FirecrackerConfig)
+	instance, err := launch(ctx, sandboxID, req.Policy, req.FirecrackerConfig, req.CacheOutputVolumes)
 	if err != nil {
 		a.sandboxMu.Lock()
 		delete(a.provisioning, sandboxID)
@@ -773,7 +774,7 @@ func (a *Adapter) ProvisionSandboxFromSnapshot(ctx context.Context, req backend.
 	if launch == nil {
 		launch = a.launchSandboxVMFromRootFS
 	}
-	instance, err := launch(ctx, sandboxID, req.Policy, req.FirecrackerConfig, storageRef)
+	instance, err := launch(ctx, sandboxID, req.Policy, req.FirecrackerConfig, storageRef, req.CacheOutputVolumes)
 	if err != nil {
 		a.sandboxMu.Lock()
 		delete(a.provisioning, sandboxID)
@@ -1708,7 +1709,7 @@ func (a *Adapter) getImageManager() (imageEnsurer, error) {
 	return a.imageManager, nil
 }
 
-func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compiled *policy.CompiledPolicy, cfg backend.FirecrackerConfig) (*sandboxInstance, error) {
+func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compiled *policy.CompiledPolicy, cfg backend.FirecrackerConfig, cacheOutputVolumeSpecs []backend.CacheOutputVolumeSpec) (*sandboxInstance, error) {
 	if compiled == nil {
 		return nil, errors.New("missing compiled policy")
 	}
@@ -1720,7 +1721,7 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 	if err != nil {
 		return nil, err
 	}
-	instance, err := a.launchSandboxVMFromRootFS(ctx, sandboxID, compiled, cfg, preparedRootFSPath)
+	instance, err := a.launchSandboxVMFromRootFS(ctx, sandboxID, compiled, cfg, preparedRootFSPath, cacheOutputVolumeSpecs)
 	if err != nil {
 		return nil, err
 	}
@@ -1729,7 +1730,7 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 	return instance, nil
 }
 
-func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID string, compiled *policy.CompiledPolicy, cfg backend.FirecrackerConfig, sourceRootFSPath string) (*sandboxInstance, error) {
+func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID string, compiled *policy.CompiledPolicy, cfg backend.FirecrackerConfig, sourceRootFSPath string, cacheOutputVolumeSpecs []backend.CacheOutputVolumeSpec) (*sandboxInstance, error) {
 	if compiled == nil {
 		return nil, errors.New("missing compiled policy")
 	}
@@ -1795,6 +1796,22 @@ func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID strin
 		return nil, fmt.Errorf("prepare persistent rootfs: %w", err)
 	}
 	vmRootFSPath := writableVolume.AttachmentPath
+	cacheOutputVolumes, cleanupCacheOutputVolumes, err := prepareCacheOutputVolumes(
+		ctx,
+		observability.WithLoggerFields(observability.WithTraceContext(baseFirecrackerLogger(a.Logger), ctx), observability.LogFieldSandboxID, sandboxID),
+		cfg,
+		sandboxID,
+		runDir,
+		cacheOutputVolumeSpecs,
+	)
+	if err != nil {
+		cleanupVolume()
+		return nil, fmt.Errorf("prepare cache output volumes: %w", err)
+	}
+	cleanupStorage := func() {
+		cleanupCacheOutputVolumes()
+		cleanupVolume()
+	}
 
 	sandboxLogger := observability.WithLoggerFields(observability.WithTraceContext(baseFirecrackerLogger(a.Logger), ctx), observability.LogFieldSandboxID, sandboxID)
 	hostRuntime := hostRuntimeForConfigWithLogger(cfg, sandboxLogger)
@@ -1831,7 +1848,7 @@ func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID strin
 		OnBlocked:   nflogOnBlocked,
 	})
 	if err != nil {
-		cleanupVolume()
+		cleanupStorage()
 		return nil, fmt.Errorf("setup host network: %w", err)
 	}
 	networkCfg := networkLease.Config
@@ -1842,7 +1859,7 @@ func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID strin
 	if a.GatewayRegistry != nil {
 		if err := a.GatewayRegistry.Register(networkCfg.GuestIP, sandboxID, compiled); err != nil {
 			cleanupNetwork()
-			cleanupVolume()
+			cleanupStorage()
 			return nil, fmt.Errorf("register sandbox in gateway: %w", err)
 		}
 	}
@@ -1852,7 +1869,7 @@ func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID strin
 			a.GatewayRegistry.Release(networkCfg.GuestIP)
 		}
 		cleanupNetwork()
-		cleanupVolume()
+		cleanupStorage()
 	}
 
 	vsockPath := filepath.Join(runDir, "vsock.sock")
@@ -1869,12 +1886,12 @@ func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID strin
 				dockerBootArgs,
 			),
 		},
-		Drives: []drive{{
+		Drives: append([]drive{{
 			DriveID:      "rootfs",
 			PathOnHost:   vmRootFSPath,
 			IsRootDevice: true,
 			IsReadOnly:   false,
-		}},
+		}}, cacheOutputVolumeDrives(cacheOutputVolumes)...),
 		MachineConfig: machineConfig{
 			VCPUCount:  cfg.VCPUs,
 			MemSizeMiB: cfg.MemoryMiB,
@@ -1938,7 +1955,7 @@ func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID strin
 		fcCmd:          fcCmd,
 		exitedCh:       make(chan struct{}),
 		cleanupNetwork: cleanupNetwork,
-		cleanupVolume:  cleanupVolume,
+		cleanupVolume:  cleanupStorage,
 		vmRootFSPath:   vmRootFSPath,
 		volumeRef:      writableVolume.Ref,
 	}

--- a/internal/backend/firecracker/cache_output_volumes.go
+++ b/internal/backend/firecracker/cache_output_volumes.go
@@ -1,0 +1,298 @@
+package firecracker
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/ext4image"
+	"github.com/buildkite/cleanroom/internal/hosttools"
+	"github.com/buildkite/cleanroom/internal/volumestore"
+	charmlog "github.com/charmbracelet/log"
+)
+
+const defaultCacheOutputVolumeMinimumBytes int64 = 512 << 20
+
+var (
+	cacheOutputVolumeMinimumBytes     = defaultCacheOutputVolumeMinimumBytes
+	createEmptyCacheOutputExt4ImageFn = createEmptyCacheOutputExt4Image
+)
+
+type preparedCacheOutputVolume struct {
+	Spec   backend.CacheOutputVolumeSpec
+	Drive  drive
+	Volume volumestore.WritableVolume
+}
+
+func prepareCacheOutputVolumes(ctx context.Context, logger *charmlog.Logger, cfg backend.FirecrackerConfig, sandboxID, runDir string, specs []backend.CacheOutputVolumeSpec) ([]preparedCacheOutputVolume, func(), error) {
+	if len(specs) == 0 {
+		return nil, func() {}, nil
+	}
+	if strings.TrimSpace(sandboxID) == "" {
+		return nil, nil, errors.New("missing sandbox id for cache output volumes")
+	}
+	if strings.TrimSpace(runDir) == "" {
+		return nil, nil, errors.New("missing run dir for cache output volumes")
+	}
+
+	prepared := make([]preparedCacheOutputVolume, 0, len(specs))
+	cleanups := make([]func(), 0, len(specs))
+	cleanup := func() {
+		for i := len(cleanups) - 1; i >= 0; i-- {
+			cleanups[i]()
+		}
+	}
+	seenVolumeIDs := make(map[string]struct{}, len(specs))
+	for i, spec := range specs {
+		if err := validateCacheOutputVolumeSpec(spec); err != nil {
+			cleanup()
+			return nil, nil, fmt.Errorf("cache output volume %d: %w", i, err)
+		}
+		if _, ok := seenVolumeIDs[strings.TrimSpace(spec.VolumeID)]; ok {
+			cleanup()
+			return nil, nil, fmt.Errorf("cache output volume %d: duplicate volume id %q", i, spec.VolumeID)
+		}
+		seenVolumeIDs[strings.TrimSpace(spec.VolumeID)] = struct{}{}
+
+		sourceRef, volumeCfg, err := cacheOutputVolumeSource(ctx, cfg, runDir, spec)
+		if err != nil {
+			cleanup()
+			return nil, nil, fmt.Errorf("cache output volume %q: %w", spec.VolumeID, err)
+		}
+		runtimeVolumeID := cacheOutputRuntimeVolumeID(sandboxID, spec.VolumeID, i)
+		attachmentPath := filepath.Join(runDir, fmt.Sprintf("cache-output-%02d.ext4", i))
+		volume, volumeCleanup, err := prepareWritableVolumeWithLogger(ctx, logger, volumeCfg, runtimeVolumeID, attachmentPath, sourceRef, cacheOutputVolumeMinimumBytes)
+		if err != nil {
+			cleanup()
+			return nil, nil, fmt.Errorf("cache output volume %q: %w", spec.VolumeID, err)
+		}
+		cleanups = append(cleanups, volumeCleanup)
+		prepared = append(prepared, preparedCacheOutputVolume{
+			Spec: spec,
+			Drive: drive{
+				DriveID:      cacheOutputDriveID(i),
+				PathOnHost:   volume.AttachmentPath,
+				IsRootDevice: false,
+				IsReadOnly:   false,
+			},
+			Volume: volume,
+		})
+	}
+	return prepared, cleanup, nil
+}
+
+func validateCacheOutputVolumeSpec(spec backend.CacheOutputVolumeSpec) error {
+	if strings.TrimSpace(spec.Stage) == "" {
+		return errors.New("missing stage")
+	}
+	if strings.TrimSpace(spec.BlockName) == "" {
+		return errors.New("missing block name")
+	}
+	if strings.TrimSpace(spec.CacheKey) == "" {
+		return errors.New("missing cache key")
+	}
+	if strings.TrimSpace(spec.VolumeID) == "" {
+		return errors.New("missing volume id")
+	}
+	if len(spec.DirMappings) == 0 && len(spec.FileMappings) == 0 {
+		return errors.New("missing output mappings")
+	}
+	for i, mapping := range spec.DirMappings {
+		if strings.TrimSpace(mapping.GuestPath) == "" {
+			return fmt.Errorf("dir mapping %d missing guest path", i)
+		}
+		if strings.TrimSpace(mapping.Subpath) == "" {
+			return fmt.Errorf("dir mapping %d missing volume subpath", i)
+		}
+	}
+	for i, mapping := range spec.FileMappings {
+		if strings.TrimSpace(mapping.GuestPath) == "" {
+			return fmt.Errorf("file mapping %d missing guest path", i)
+		}
+		if strings.TrimSpace(mapping.Subpath) == "" {
+			return fmt.Errorf("file mapping %d missing volume subpath", i)
+		}
+	}
+	return nil
+}
+
+func cacheOutputVolumeSource(ctx context.Context, cfg backend.FirecrackerConfig, runDir string, spec backend.CacheOutputVolumeSpec) (sourceRef string, volumeCfg backend.FirecrackerConfig, err error) {
+	sourceRef = strings.TrimSpace(spec.SourceSnapshotRef)
+	if sourceRef == "" {
+		sourceRef = strings.TrimSpace(spec.StorageRef)
+	}
+	volumeCfg = cfg
+	if driver := strings.TrimSpace(spec.StorageDriver); driver != "" {
+		volumeCfg.Snapshots.Driver = driver
+	}
+	if sourceRef == "" {
+		sourceRef = filepath.Join(runDir, "cache-output-empty-base.ext4")
+		if err := createEmptyCacheOutputExt4ImageFn(ctx, sourceRef, cacheOutputVolumeMinimumBytes); err != nil {
+			return "", volumeCfg, fmt.Errorf("create empty cache output volume source: %w", err)
+		}
+		return sourceRef, volumeCfg, nil
+	}
+
+	volumeCfg, err = snapshotConfigForStorageRef(volumeCfg, sourceRef)
+	if err != nil {
+		return "", volumeCfg, err
+	}
+	if driver := strings.TrimSpace(spec.StorageDriver); driver != "" {
+		effectiveDriver := strings.TrimSpace(volumeCfg.Snapshots.Driver)
+		if effectiveDriver == "" {
+			effectiveDriver = "file"
+		}
+		if !strings.EqualFold(driver, effectiveDriver) {
+			return "", volumeCfg, fmt.Errorf("storage driver %q does not match source driver %q", driver, effectiveDriver)
+		}
+	}
+	return sourceRef, volumeCfg, nil
+}
+
+func createEmptyCacheOutputExt4Image(ctx context.Context, path string, minimumBytes int64) error {
+	if strings.TrimSpace(path) == "" {
+		return errors.New("missing empty cache output image path")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create empty cache output image directory: %w", err)
+	}
+	sizeBytes := ext4image.AlignBytes(minimumBytes)
+	if err := os.Truncate(path, sizeBytes); err != nil {
+		return fmt.Errorf("truncate empty cache output image %q to %d bytes: %w", path, sizeBytes, err)
+	}
+	mkfsPath, err := hosttools.ResolveE2FSProgsBinary("mkfs.ext4")
+	if err != nil {
+		return fmt.Errorf("find mkfs.ext4 for cache output volume: %w", err)
+	}
+	if out, err := exec.CommandContext(ctx, mkfsPath, "-q", "-F", path).CombinedOutput(); err != nil {
+		_ = os.Remove(path)
+		trimmed := strings.TrimSpace(string(out))
+		if trimmed == "" {
+			return fmt.Errorf("create empty cache output ext4 image: %w", err)
+		}
+		return fmt.Errorf("create empty cache output ext4 image: %w: %s", err, trimmed)
+	}
+	return nil
+}
+
+func prepareWritableVolumeWithLogger(ctx context.Context, logger *charmlog.Logger, cfg backend.FirecrackerConfig, volumeID, attachmentPath, sourceRef string, minimumBytes int64) (volumestore.WritableVolume, func(), error) {
+	driverCfg, err := snapshotConfigForStorageRef(cfg, sourceRef)
+	if err != nil {
+		return volumestore.WritableVolume{}, nil, err
+	}
+	if strings.EqualFold(strings.TrimSpace(driverCfg.Snapshots.Driver), "zfs") {
+		hostRuntime := hostRuntimeForConfigWithLogger(driverCfg, logger)
+		zfsReq := zfsWritableVolumeRequest{
+			VolumeID:     volumeID,
+			MinimumBytes: minimumBytes,
+		}
+		if filepath.IsAbs(strings.TrimSpace(sourceRef)) {
+			zfsReq.SourcePath = sourceRef
+		} else {
+			zfsReq.SnapshotRef = sourceRef
+		}
+		volume, err := hostRuntime.PrepareZFSWritableVolume(ctx, zfsReq)
+		if err != nil {
+			return volumestore.WritableVolume{}, nil, err
+		}
+		cleanupVolume := func() {
+			if err := hostRuntime.DestroyZFSVolume(context.Background(), volume.Ref); err != nil {
+				logPersistentVolumeCleanup(logger, volume.Ref, err)
+			}
+		}
+		return volumestore.WritableVolume{
+			Ref:            volume.Ref,
+			AttachmentPath: volume.AttachmentPath,
+		}, cleanupVolume, nil
+	}
+	driver, err := rootFSVolumeStoreDriverFn(driverCfg)
+	if err != nil {
+		return volumestore.WritableVolume{}, nil, err
+	}
+	return preparePersistentWritableVolumeAtPathWithLogger(ctx, logger, driver, volumeID, attachmentPath, sourceRef, minimumBytes)
+}
+
+func preparePersistentWritableVolumeAtPathWithLogger(ctx context.Context, logger *charmlog.Logger, driver volumestore.Driver, volumeID, attachmentPath, sourceRef string, minimumBytes int64) (volumestore.WritableVolume, func(), error) {
+	sourceRef = strings.TrimSpace(sourceRef)
+	if sourceRef == "" {
+		return volumestore.WritableVolume{}, nil, errors.New("missing persistent volume source")
+	}
+
+	resizeVolume := func(volume volumestore.WritableVolume) (volumestore.WritableVolume, func(), error) {
+		cleanupVolume := func() {
+			if err := driver.DestroyVolume(context.Background(), volumestore.DestroyVolumeRequest{VolumeRef: volume.Ref}); err != nil {
+				logPersistentVolumeCleanup(logger, volume.Ref, err)
+			}
+		}
+		if err := volumestore.EnsureWritableVolumeMinimumSize(ctx, driver, volume, minimumBytes); err != nil {
+			cleanupVolume()
+			return volumestore.WritableVolume{}, nil, fmt.Errorf("resize persistent volume: %w", err)
+		}
+		return volume, cleanupVolume, nil
+	}
+
+	if filepath.IsAbs(sourceRef) {
+		rootfsPath, err := filepath.Abs(sourceRef)
+		if err != nil {
+			return volumestore.WritableVolume{}, nil, err
+		}
+		if _, err := os.Stat(rootfsPath); err != nil {
+			return volumestore.WritableVolume{}, nil, fmt.Errorf("volume source %s: %w", rootfsPath, err)
+		}
+
+		baseVolume, err := driver.EnsureBaseVolume(ctx, volumestore.EnsureBaseVolumeRequest{
+			BaseID:       strings.TrimSuffix(filepath.Base(rootfsPath), filepath.Ext(rootfsPath)),
+			SourcePath:   rootfsPath,
+			MinimumBytes: minimumBytes,
+		})
+		if err != nil {
+			return volumestore.WritableVolume{}, nil, fmt.Errorf("prepare base volume: %w", err)
+		}
+		volume, err := driver.CreateWritableVolume(ctx, volumestore.CreateWritableVolumeRequest{
+			VolumeID:       volumeID,
+			BaseRef:        baseVolume.Ref,
+			AttachmentPath: attachmentPath,
+		})
+		if err != nil {
+			return volumestore.WritableVolume{}, nil, err
+		}
+		return resizeVolume(volume)
+	}
+
+	volume, err := driver.CloneSnapshotToVolume(ctx, volumestore.CloneSnapshotToVolumeRequest{
+		VolumeID:       volumeID,
+		SnapshotRef:    sourceRef,
+		AttachmentPath: attachmentPath,
+	})
+	if err != nil {
+		return volumestore.WritableVolume{}, nil, err
+	}
+	return resizeVolume(volume)
+}
+
+func cacheOutputVolumeDrives(volumes []preparedCacheOutputVolume) []drive {
+	if len(volumes) == 0 {
+		return nil
+	}
+	drives := make([]drive, 0, len(volumes))
+	for _, volume := range volumes {
+		drives = append(drives, volume.Drive)
+	}
+	return drives
+}
+
+func cacheOutputDriveID(index int) string {
+	return fmt.Sprintf("cacheout%d", index)
+}
+
+func cacheOutputRuntimeVolumeID(sandboxID, specVolumeID string, index int) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(sandboxID) + "\x00" + strings.TrimSpace(specVolumeID)))
+	return fmt.Sprintf("%s-cache-output-%02d-%s", strings.TrimSpace(sandboxID), index, hex.EncodeToString(sum[:6]))
+}

--- a/internal/backend/firecracker/cache_output_volumes_test.go
+++ b/internal/backend/firecracker/cache_output_volumes_test.go
@@ -1,0 +1,239 @@
+package firecracker
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/volumestore"
+)
+
+func TestCapabilitiesAdvertiseCacheOutputVolumesWithoutOverlayCapture(t *testing.T) {
+	t.Parallel()
+
+	caps := (&Adapter{}).Capabilities()
+	if !caps[backend.CapabilitySandboxCacheOutputVolumes] {
+		t.Fatalf("expected %s capability", backend.CapabilitySandboxCacheOutputVolumes)
+	}
+	if caps[backend.CapabilitySandboxOverlayWriteCapture] {
+		t.Fatalf("did not expect %s capability before overlay execution is implemented", backend.CapabilitySandboxOverlayWriteCapture)
+	}
+}
+
+func TestPrepareCacheOutputVolumesClonesHitsAndCreatesMisses(t *testing.T) {
+	runDir := t.TempDir()
+	prevDriverFn := rootFSVolumeStoreDriverFn
+	prevCreateEmpty := createEmptyCacheOutputExt4ImageFn
+	prevMinimumBytes := cacheOutputVolumeMinimumBytes
+	t.Cleanup(func() {
+		rootFSVolumeStoreDriverFn = prevDriverFn
+		createEmptyCacheOutputExt4ImageFn = prevCreateEmpty
+		cacheOutputVolumeMinimumBytes = prevMinimumBytes
+	})
+	cacheOutputVolumeMinimumBytes = 0
+
+	var cloneReqs []volumestore.CloneSnapshotToVolumeRequest
+	var createReqs []volumestore.CreateWritableVolumeRequest
+	var destroyReqs []volumestore.DestroyVolumeRequest
+	rootFSVolumeStoreDriverFn = func(backend.FirecrackerConfig) (volumestore.Driver, error) {
+		return testVolumeDriver{
+			ensureBaseVolumeFn: func(_ context.Context, req volumestore.EnsureBaseVolumeRequest) (volumestore.BaseVolume, error) {
+				if strings.TrimSpace(req.SourcePath) == "" {
+					t.Fatal("expected source path for empty cache output base volume")
+				}
+				return volumestore.BaseVolume{Ref: "base:" + filepath.Base(req.SourcePath)}, nil
+			},
+			createWritableVolumeFn: func(_ context.Context, req volumestore.CreateWritableVolumeRequest) (volumestore.WritableVolume, error) {
+				createReqs = append(createReqs, req)
+				return volumestore.WritableVolume{
+					Ref:            "volume:" + req.VolumeID,
+					AttachmentPath: req.AttachmentPath,
+				}, nil
+			},
+			cloneSnapshotToVolumeFn: func(_ context.Context, req volumestore.CloneSnapshotToVolumeRequest) (volumestore.WritableVolume, error) {
+				cloneReqs = append(cloneReqs, req)
+				return volumestore.WritableVolume{
+					Ref:            "volume:" + req.VolumeID,
+					AttachmentPath: req.AttachmentPath,
+				}, nil
+			},
+			destroyVolumeFn: func(_ context.Context, req volumestore.DestroyVolumeRequest) error {
+				destroyReqs = append(destroyReqs, req)
+				return nil
+			},
+		}, nil
+	}
+	createEmptyCacheOutputExt4ImageFn = func(_ context.Context, path string, minimumBytes int64) error {
+		if got, want := minimumBytes, cacheOutputVolumeMinimumBytes; got != want {
+			t.Fatalf("unexpected empty volume minimum bytes: got %d want %d", got, want)
+		}
+		return os.WriteFile(path, []byte("empty-ext4"), 0o644)
+	}
+
+	specs := []backend.CacheOutputVolumeSpec{
+		{
+			Stage:             "dependency-volume",
+			BlockName:         "toolchains",
+			CacheKey:          "dependency-volume:v1:toolchains",
+			VolumeID:          "dependency-volume-abc123",
+			SourceSnapshotRef: "snapshot:toolchains",
+			StorageDriver:     "file",
+			StorageRef:        "snapshot:toolchains",
+			DirMappings: []backend.CacheOutputDirMapping{
+				{GuestPath: "/root/.local/share/mise", Subpath: "dirs/0"},
+			},
+		},
+		{
+			Stage:     "service-volume",
+			BlockName: "postgres",
+			CacheKey:  "service-volume:v1:postgres",
+			VolumeID:  "service-volume-def456",
+			DirMappings: []backend.CacheOutputDirMapping{
+				{GuestPath: "/var/lib/cleanroom/services/postgres", Subpath: "dirs/0"},
+			},
+		},
+	}
+
+	prepared, cleanup, err := prepareCacheOutputVolumes(context.Background(), nil, backend.FirecrackerConfig{}, "sandbox-1", runDir, specs)
+	if err != nil {
+		t.Fatalf("prepareCacheOutputVolumes returned error: %v", err)
+	}
+	if got, want := len(prepared), 2; got != want {
+		t.Fatalf("unexpected prepared volume count: got %d want %d", got, want)
+	}
+	if got, want := len(cloneReqs), 1; got != want {
+		t.Fatalf("unexpected clone request count: got %d want %d", got, want)
+	}
+	if got, want := cloneReqs[0].SnapshotRef, "snapshot:toolchains"; got != want {
+		t.Fatalf("unexpected clone snapshot ref: got %q want %q", got, want)
+	}
+	if got, want := len(createReqs), 1; got != want {
+		t.Fatalf("unexpected create request count: got %d want %d", got, want)
+	}
+	if got, want := createReqs[0].BaseRef, "base:cache-output-empty-base.ext4"; got != want {
+		t.Fatalf("unexpected miss base ref: got %q want suffix %q", createReqs[0].BaseRef, want)
+	}
+	wantDrives := []drive{
+		{DriveID: "cacheout0", PathOnHost: filepath.Join(runDir, "cache-output-00.ext4")},
+		{DriveID: "cacheout1", PathOnHost: filepath.Join(runDir, "cache-output-01.ext4")},
+	}
+	gotDrives := cacheOutputVolumeDrives(prepared)
+	for i := range gotDrives {
+		gotDrives[i].IsReadOnly = false
+		gotDrives[i].IsRootDevice = false
+	}
+	if !reflect.DeepEqual(gotDrives, wantDrives) {
+		t.Fatalf("unexpected cache output drives: got %#v want %#v", gotDrives, wantDrives)
+	}
+
+	cleanup()
+	if got, want := len(destroyReqs), 2; got != want {
+		t.Fatalf("unexpected destroy request count: got %d want %d", got, want)
+	}
+	if got, want := destroyReqs[0].VolumeRef, prepared[1].Volume.Ref; got != want {
+		t.Fatalf("expected reverse cleanup order first ref %q, got %q", want, got)
+	}
+}
+
+func TestPrepareCacheOutputVolumesRejectsMalformedSpecs(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := prepareCacheOutputVolumes(context.Background(), nil, backend.FirecrackerConfig{}, "sandbox-1", t.TempDir(), []backend.CacheOutputVolumeSpec{
+		{
+			Stage:     "dependency-volume",
+			BlockName: "toolchains",
+			CacheKey:  "dependency-volume:v1:toolchains",
+			VolumeID:  "dependency-volume-abc123",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected malformed spec to fail")
+	}
+	if !strings.Contains(err.Error(), "missing output mappings") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPrepareCacheOutputVolumesCleansUpOnFailure(t *testing.T) {
+	runDir := t.TempDir()
+	prevDriverFn := rootFSVolumeStoreDriverFn
+	prevMinimumBytes := cacheOutputVolumeMinimumBytes
+	t.Cleanup(func() {
+		rootFSVolumeStoreDriverFn = prevDriverFn
+		cacheOutputVolumeMinimumBytes = prevMinimumBytes
+	})
+	cacheOutputVolumeMinimumBytes = 0
+
+	var destroyReqs []volumestore.DestroyVolumeRequest
+	rootFSVolumeStoreDriverFn = func(backend.FirecrackerConfig) (volumestore.Driver, error) {
+		return testVolumeDriver{
+			cloneSnapshotToVolumeFn: func(_ context.Context, req volumestore.CloneSnapshotToVolumeRequest) (volumestore.WritableVolume, error) {
+				if strings.Contains(req.SnapshotRef, "bad") {
+					return volumestore.WritableVolume{}, errors.New("clone failed")
+				}
+				return volumestore.WritableVolume{
+					Ref:            "volume:" + req.VolumeID,
+					AttachmentPath: req.AttachmentPath,
+				}, nil
+			},
+			destroyVolumeFn: func(_ context.Context, req volumestore.DestroyVolumeRequest) error {
+				destroyReqs = append(destroyReqs, req)
+				return nil
+			},
+		}, nil
+	}
+
+	_, _, err := prepareCacheOutputVolumes(context.Background(), nil, backend.FirecrackerConfig{}, "sandbox-1", runDir, []backend.CacheOutputVolumeSpec{
+		{
+			Stage:             "dependency-volume",
+			BlockName:         "toolchains",
+			CacheKey:          "dependency-volume:v1:toolchains",
+			VolumeID:          "dependency-volume-abc123",
+			SourceSnapshotRef: "snapshot:good",
+			DirMappings: []backend.CacheOutputDirMapping{
+				{GuestPath: "/root/.local/share/mise", Subpath: "dirs/0"},
+			},
+		},
+		{
+			Stage:             "dependency-volume",
+			BlockName:         "go-modules",
+			CacheKey:          "dependency-volume:v1:go-modules",
+			VolumeID:          "dependency-volume-def456",
+			SourceSnapshotRef: "snapshot:bad",
+			DirMappings: []backend.CacheOutputDirMapping{
+				{GuestPath: "/root/go/pkg/mod", Subpath: "dirs/0"},
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected prepareCacheOutputVolumes to fail")
+	}
+	if !strings.Contains(err.Error(), "clone failed") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, want := len(destroyReqs), 1; got != want {
+		t.Fatalf("expected prepared volume cleanup, got %d destroy requests want %d", got, want)
+	}
+}
+
+func testCacheOutputVolumeSpecs() []backend.CacheOutputVolumeSpec {
+	return []backend.CacheOutputVolumeSpec{
+		{
+			Stage:             "dependency-volume",
+			BlockName:         "toolchains",
+			CacheKey:          "dependency-volume:v1:toolchains",
+			VolumeID:          "dependency-volume-abc123",
+			SourceSnapshotRef: "snapshot:toolchains",
+			StorageDriver:     "file",
+			StorageRef:        "snapshot:toolchains",
+			DirMappings: []backend.CacheOutputDirMapping{
+				{GuestPath: "/root/.local/share/mise", Subpath: "dirs/0"},
+			},
+		},
+	}
+}

--- a/internal/backend/firecracker/persistent_test.go
+++ b/internal/backend/firecracker/persistent_test.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -23,7 +24,7 @@ func TestProvisionSandboxRejectsConcurrentProvisionForSameID(t *testing.T) {
 	block := make(chan struct{})
 	started := make(chan struct{})
 	adapter := &Adapter{
-		launchSandboxVMFn: func(_ context.Context, sandboxID string, _ *policy.CompiledPolicy, _ backend.FirecrackerConfig) (*sandboxInstance, error) {
+		launchSandboxVMFn: func(_ context.Context, sandboxID string, _ *policy.CompiledPolicy, _ backend.FirecrackerConfig, _ []backend.CacheOutputVolumeSpec) (*sandboxInstance, error) {
 			if sandboxID != "cr-test" {
 				t.Fatalf("unexpected sandbox id %q", sandboxID)
 			}
@@ -60,7 +61,7 @@ func TestProvisionSandboxRejectsStageScopedNetworkPolicy(t *testing.T) {
 	t.Parallel()
 
 	adapter := &Adapter{
-		launchSandboxVMFn: func(context.Context, string, *policy.CompiledPolicy, backend.FirecrackerConfig) (*sandboxInstance, error) {
+		launchSandboxVMFn: func(context.Context, string, *policy.CompiledPolicy, backend.FirecrackerConfig, []backend.CacheOutputVolumeSpec) (*sandboxInstance, error) {
 			t.Fatal("launchSandboxVMFn should not be called")
 			return nil, nil
 		},
@@ -75,6 +76,37 @@ func TestProvisionSandboxRejectsStageScopedNetworkPolicy(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "stage-scoped network") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestProvisionSandboxForwardsCacheOutputVolumes(t *testing.T) {
+	t.Parallel()
+
+	specs := testCacheOutputVolumeSpecs()
+	var gotSpecs []backend.CacheOutputVolumeSpec
+	adapter := &Adapter{
+		launchSandboxVMFn: func(_ context.Context, sandboxID string, _ *policy.CompiledPolicy, _ backend.FirecrackerConfig, cacheOutputVolumes []backend.CacheOutputVolumeSpec) (*sandboxInstance, error) {
+			if sandboxID != "cr-test" {
+				t.Fatalf("unexpected sandbox id %q", sandboxID)
+			}
+			gotSpecs = append([]backend.CacheOutputVolumeSpec(nil), cacheOutputVolumes...)
+			return &sandboxInstance{SandboxID: sandboxID}, nil
+		},
+	}
+	compiled := &policy.CompiledPolicy{
+		NetworkDefault: "deny",
+		ImageRef:       "ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+	}
+
+	if err := adapter.ProvisionSandbox(context.Background(), backend.ProvisionRequest{
+		SandboxID:          "cr-test",
+		Policy:             compiled,
+		CacheOutputVolumes: specs,
+	}); err != nil {
+		t.Fatalf("ProvisionSandbox returned error: %v", err)
+	}
+	if !reflect.DeepEqual(gotSpecs, specs) {
+		t.Fatalf("unexpected cache output volume specs: got %#v want %#v", gotSpecs, specs)
 	}
 }
 

--- a/internal/backend/firecracker/snapshot_test.go
+++ b/internal/backend/firecracker/snapshot_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"syscall"
 	"testing"
@@ -666,12 +667,15 @@ func TestProvisionSandboxFromSnapshotUsesSnapshotRootFS(t *testing.T) {
 		gotRootFS  string
 		gotSandbox string
 		gotPolicy  *policy.CompiledPolicy
+		gotSpecs   []backend.CacheOutputVolumeSpec
 	)
+	specs := testCacheOutputVolumeSpecs()
 	adapter := &Adapter{
-		launchSandboxVMFromRootFSFn: func(_ context.Context, sandboxID string, compiled *policy.CompiledPolicy, _ backend.FirecrackerConfig, sourceRootFSPath string) (*sandboxInstance, error) {
+		launchSandboxVMFromRootFSFn: func(_ context.Context, sandboxID string, compiled *policy.CompiledPolicy, _ backend.FirecrackerConfig, sourceRootFSPath string, cacheOutputVolumes []backend.CacheOutputVolumeSpec) (*sandboxInstance, error) {
 			gotSandbox = sandboxID
 			gotPolicy = compiled
 			gotRootFS = sourceRootFSPath
+			gotSpecs = append([]backend.CacheOutputVolumeSpec(nil), cacheOutputVolumes...)
 			return &sandboxInstance{SandboxID: sandboxID}, nil
 		},
 	}
@@ -683,10 +687,11 @@ func TestProvisionSandboxFromSnapshotUsesSnapshotRootFS(t *testing.T) {
 	}
 
 	if err := adapter.ProvisionSandboxFromSnapshot(context.Background(), backend.ProvisionFromSnapshotRequest{
-		SandboxID:  "cr-test",
-		SnapshotID: "snap-test",
-		StorageRef: "/tmp/snap-test.ext4",
-		Policy:     compiled,
+		SandboxID:          "cr-test",
+		SnapshotID:         "snap-test",
+		StorageRef:         "/tmp/snap-test.ext4",
+		Policy:             compiled,
+		CacheOutputVolumes: specs,
 	}); err != nil {
 		t.Fatalf("ProvisionSandboxFromSnapshot returned error: %v", err)
 	}
@@ -698,6 +703,9 @@ func TestProvisionSandboxFromSnapshotUsesSnapshotRootFS(t *testing.T) {
 	}
 	if gotPolicy != compiled {
 		t.Fatal("expected compiled policy to be forwarded")
+	}
+	if !reflect.DeepEqual(gotSpecs, specs) {
+		t.Fatalf("unexpected cache output volume specs: got %#v want %#v", gotSpecs, specs)
 	}
 	if _, ok := adapter.sandboxes["cr-test"]; !ok {
 		t.Fatal("expected provisioned sandbox to be stored")


### PR DESCRIPTION
## Problem

The control service can now pass per-block cache output volume specs into backend launches, but Firecracker still ignored those specs. That left the next runtime slice blocked: there was no backend path to prepare output volumes before VM start.

## Changes

- Advertise Firecracker support for `sandbox.cache_output_volumes`, while still withholding `sandbox.overlay_write_capture` until guest execution lands.
- Forward cache output volume specs through cold provisions and snapshot restores.
- Prepare writable sidecar ext4 volumes before VM launch, using cached source refs for hits and an empty ext4 source image for misses.
- Attach prepared volumes as non-root writable Firecracker drives and include them in launch cleanup paths.
- Update the dependency/service volume-cache plan with the completed phase and remaining runtime work.

## Validation

- `mise exec -- go test ./internal/backend/firecracker`
- `mise exec -- go test ./internal/controlservice`
- `mise exec -- go test ./...`
