### PR TITLE
feat: Prune stale ZFS import datasets

### DIFF
--- a/docs/plans/system-storage-prune.md
+++ b/docs/plans/system-storage-prune.md
@@ -21,7 +21,7 @@ The immediate problem is orphaned host state. A local inspection showed `~/.loca
 
 ## Non-Goals
 
-- Do not add background deletion in the first slice. The initial workflow is explicit and user initiated.
+- Do not add broad background deletion. Lifecycle-scoped cleanup can use the same inventory and prune executor once the manual command proves the deletion model.
 - Do not delete explicit snapshots by default. Users should opt in with `--all` or a snapshot-specific command.
 - Do not blindly remove content-cache storage while the gateway may be using it.
 - Do not make cache policy part of `cleanroom.yaml`. This is host maintenance, not project policy.
@@ -49,6 +49,7 @@ cleanroom system prune [--dry-run] [--force] [--older-than duration] [--all]
 - Orphan backend snapshot directories not referenced by snapshot metadata or stage-cache metadata.
 - Old execution artifacts that exceed the existing service retention window.
 - Stale prepared runtime rootfs cache entries when they are not the current runtime key.
+- Unreferenced ZFS import datasets under the Firecracker/ZFS managed import namespace.
 
 `system prune --all` expands the candidate set to system-managed caches:
 
@@ -65,6 +66,7 @@ Without `--force`, `system prune` should prompt on TTY and refuse on non-TTY. `-
 | Sandbox runtime dirs | `StateBaseDir()/sandboxes` | Backend adapters | Orphans only |
 | Explicit snapshots | `StateBaseDir()/snapshots` plus `snapshotstore` | Snapshot service | No |
 | Stage-cache snapshots | `StateBaseDir()/snapshots` plus `cachestore` | Dependency cache | Only with policy or `--all` |
+| ZFS import datasets | `<zfs dataset>/snapshots/imports` plus snapshot/cache metadata | Firecracker ZFS stage transfer | Unreferenced only |
 | Images | `CacheBaseDir()/images` plus image metadata in state | Image manager | No |
 | Runtime rootfs cache | `CacheBaseDir()/<backend>/runtime-rootfs` | Backend adapters | Stale entries |
 | Repository mirrors | `StateBaseDir()/repos` | Git gateway | No |
@@ -114,6 +116,7 @@ The inventory should build a reference set before considering deletion:
 - Live daemon sandbox ids from the control service protect matching sandbox runtime directories.
 - Explicit snapshot records from `snapshotstore.List` protect their `StorageRef`.
 - Stage-cache records from `cachestore.List` protect their backing snapshot storage unless the prune policy explicitly includes stage caches.
+- Snapshot and stage-cache records protect direct ZFS import datasets when their `StorageRef` points at `<dataset>/snapshots/imports/<id>@base`.
 - Known image records protect image filesystem layers and metadata.
 - The currently selected backend runtime rootfs key protects the matching prepared runtime rootfs file.
 - Recent execution artifacts remain protected according to the existing control-service retention settings.
@@ -125,6 +128,7 @@ Entries that are missing metadata but live under a cleanroom-owned root can beco
 Use typed deletion paths when metadata exists:
 
 - Stage-cache records should be deleted through `cachestore.Delete` and the owning volume store deletion path.
+- ZFS import datasets should be destroyed through the Firecracker/ZFS volume driver, restricted to direct children under the import namespace.
 - Explicit snapshots should be deleted only by snapshot-specific commands or `system prune --all --snapshots`, through `snapshotstore.Delete` and the owning volume store.
 - Images should be deleted through the image manager.
 
@@ -173,10 +177,16 @@ This is what lets us clean up abandoned directories from older versions without 
    burst of terminations from starting many filesystem removals at once, and
    avoids introducing a daemon-wide background prune.
 
+   The same worker can also run a startup-only ZFS import cleanup job on
+   Firecracker/ZFS hosts. That job inventories direct import datasets, protects
+   anything referenced by snapshot or cache metadata, and destroys only
+   unreferenced import datasets through the ZFS driver.
+
 ## Tests
 
 - Inventory reports byte totals for every known category.
 - Referenced snapshot and stage-cache storage is protected.
+- Referenced ZFS import datasets are protected; unreferenced direct import datasets are reclaimable and destroyed through the ZFS driver.
 - Unreferenced snapshot directories under the backend snapshot root are reclaimable.
 - Active sandbox runtime directories are protected even if their filesystem metadata is stale.
 - Orphan sandbox runtime directories are reclaimable without relying on id prefix format.

--- a/docs/plans/zfs-stage-cache-replication.md
+++ b/docs/plans/zfs-stage-cache-replication.md
@@ -129,14 +129,23 @@ The foundation slice has landed:
 - helper-gated ZFS metadata reads for mixed-version root-helper deployments
 - incremental export planning with `zfs send -nP -i`
 
-The active slice is the local ZFS transfer primitive:
+The local ZFS transfer primitive has landed:
 
 - stream an already validated incremental export with `zfs send -i`
 - receive a stream into an unpublished managed ZFS dataset cloned from the
   local parent snapshot
 - destroy the unpublished dataset on receive or validation failure
-- keep peer lookup, transfer tokens, and receiver-side cache publication out of
-  scope until the local driver path is proven
+- prove the clone, receive, promote, and describe contract with a gated real
+  ZFS integration test
+- inventory and prune unreferenced import datasets through `system df`,
+  `system prune`, and daemon startup cleanup
+
+The active next slice is the peer protocol:
+
+- lookup RPC and export HTTP endpoint
+- sender-side transfer tokens
+- receiver-side import orchestration around the proven local ZFS primitive
+- cache publication only after receiver-side metadata validation
 
 ## Design Principles
 
@@ -434,6 +443,12 @@ Before adding broad retention policy, add the minimum safe cleanup model:
 - in-flight exports and imports pin their source and destination refs
 - temporary receive datasets are destroyed on failure and on daemon startup
   cleanup
+- `system df` and `system prune` include Firecracker/ZFS import datasets when
+  the host is configured for the ZFS snapshot driver
+- daemon startup queues import cleanup onto the same bounded background worker
+  used for terminated sandbox storage cleanup
+- cleanup only destroys direct children under `snapshots/imports/<id>` that are
+  not referenced by snapshot or cache metadata
 
 Full quota-based eviction can follow this plan, but v1 must not make shared
 storage refs unsafe.
@@ -491,7 +506,9 @@ The peer API exposes powerful local cache data. Keep v1 conservative:
 | `internal/volumestore/store.go` | Add optional incremental snapshot transfer interface. |
 | `internal/volumestore/zfs.go` | Implement ZFS description, incremental export, and incremental import. |
 | `internal/backend/firecracker/host_runtime.go` | Add helper-backed ZFS send/receive operations if direct `zfs` access stays behind the privileged helper. |
-| `scripts/cleanroom-root-helper.sh` | Allow narrowly scoped `zfs get guid`, `zfs send`, and `zfs receive` operations for managed Cleanroom refs only. |
+| `internal/storagegc/storagegc.go` | Inventory and prune unreferenced ZFS import datasets without touching referenced cache storage. |
+| `internal/cli/system.go` | Include ZFS import datasets in `system df` and `system prune` on Firecracker/ZFS hosts. |
+| `scripts/cleanroom-root-helper.sh` | Allow narrowly scoped `zfs get guid`, `zfs send`, `zfs receive`, and import-namespace `zfs list` operations for managed Cleanroom refs only. |
 | `internal/observability/*` | Add peer cache transfer span attributes and metrics. |
 
 ## Implementation Order
@@ -507,7 +524,7 @@ Status: landed.
 
 ### 2. ZFS incremental transfer contract
 
-Status: active.
+Status: landed.
 
 - Add the optional transfer interface in `internal/volumestore`.
 - Implement `DescribeSnapshot` for ZFS using ZFS GUID properties.
@@ -521,6 +538,8 @@ prevents incremental send, fix the ZFS driver before adding peer APIs.
 
 ### 3. Import into temporary storage
 
+Status: landed.
+
 - Implement ZFS incremental receive into an unpublished managed dataset cloned
   from the local parent snapshot.
 - Return a local `Snapshot` only after receive succeeds.
@@ -528,6 +547,8 @@ prevents incremental send, fix the ZFS driver before adding peer APIs.
 - Add daemon startup cleanup for stale temporary import datasets.
 
 ### 4. Static peer lookup API
+
+Status: next.
 
 - Add runtime config for peer URLs and token env vars.
 - Add lookup RPC and export HTTP endpoint.

--- a/internal/backend/firecracker/host_runtime_test.go
+++ b/internal/backend/firecracker/host_runtime_test.go
@@ -135,6 +135,45 @@ func TestSetupGatewayFirewallUsesHostRuntime(t *testing.T) {
 	}
 }
 
+func TestNewZFSImportDatasetStoreRequiresZFSDriverAndDataset(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  backend.FirecrackerConfig
+		want bool
+	}{
+		{
+			name: "file driver",
+			cfg: backend.FirecrackerConfig{Snapshots: backend.SnapshotConfig{
+				Driver:     "file",
+				ZFSDataset: "tank/cleanroom",
+			}},
+		},
+		{
+			name: "missing dataset",
+			cfg: backend.FirecrackerConfig{Snapshots: backend.SnapshotConfig{
+				Driver: "zfs",
+			}},
+		},
+		{
+			name: "zfs driver and dataset",
+			cfg: backend.FirecrackerConfig{Snapshots: backend.SnapshotConfig{
+				Driver:     "zfs",
+				ZFSDataset: "tank/cleanroom",
+			}},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NewZFSImportDatasetStore(tt.cfg)
+			if (got != nil) != tt.want {
+				t.Fatalf("NewZFSImportDatasetStore() configured=%v, want %v", got != nil, tt.want)
+			}
+		})
+	}
+}
+
 func TestPrepareWritableRootVolumeUsesHostRuntimeForZFS(t *testing.T) {
 	prevHostRuntimeFn := newHostRuntimeFn
 	t.Cleanup(func() { newHostRuntimeFn = prevHostRuntimeFn })

--- a/internal/backend/firecracker/zfs_import_dataset_store.go
+++ b/internal/backend/firecracker/zfs_import_dataset_store.go
@@ -1,0 +1,46 @@
+package firecracker
+
+import (
+	"context"
+	"strings"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/volumestore"
+)
+
+type ZFSImportDatasetStore struct {
+	cfg backend.FirecrackerConfig
+}
+
+func NewZFSImportDatasetStore(cfg backend.FirecrackerConfig) *ZFSImportDatasetStore {
+	if !strings.EqualFold(strings.TrimSpace(cfg.Snapshots.Driver), "zfs") {
+		return nil
+	}
+	if strings.TrimSpace(cfg.Snapshots.ZFSDataset) == "" {
+		return nil
+	}
+	return &ZFSImportDatasetStore{cfg: cfg}
+}
+
+func (s *ZFSImportDatasetStore) ListZFSImportDatasets(ctx context.Context) ([]string, error) {
+	driver, err := s.openDriver()
+	if err != nil {
+		return nil, err
+	}
+	return driver.ListZFSImportDatasets(ctx)
+}
+
+func (s *ZFSImportDatasetStore) DestroyZFSImportDataset(ctx context.Context, dataset string) error {
+	driver, err := s.openDriver()
+	if err != nil {
+		return err
+	}
+	return driver.DestroyZFSImportDataset(ctx, dataset)
+}
+
+func (s *ZFSImportDatasetStore) openDriver() (*volumestore.ZFSDriver, error) {
+	return volumestore.NewZFSDriver(volumestore.ZFSDriverOptions{
+		DatasetRoot: strings.TrimSpace(s.cfg.Snapshots.ZFSDataset),
+		Runner:      hostRuntimeVolumeCommandRunner{runner: newPrivilegedCommandRunner(s.cfg)},
+	})
+}

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -169,6 +169,7 @@ func (s *ServeCommand) runServer(ctx *runtimeContext) error {
 	if err != nil {
 		return err
 	}
+	service.ScheduleStartupStorageCleanup()
 	serverInterceptors := make([]connect.Interceptor, 0, 1)
 	if interceptor := ctx.Observability.ConnectInterceptor(); interceptor != nil {
 		serverInterceptors = append(serverInterceptors, interceptor)
@@ -339,13 +340,14 @@ func newControlService(ctx *runtimeContext, logger *log.Logger, mirrors gateway.
 		return service, nil
 	}
 	service := &controlservice.Service{
-		Loader:          ctx.Loader,
-		Config:          ctx.Config,
-		Backends:        ctx.Backends,
-		Logger:          logger,
-		Observability:   ctx.Observability,
-		RepositoryStore: repositorystore.NewMirrorBacked(mirrors),
-		SnapshotStore:   snapshotMetadataStore,
+		Loader:                ctx.Loader,
+		Config:                ctx.Config,
+		Backends:              ctx.Backends,
+		Logger:                logger,
+		Observability:         ctx.Observability,
+		RepositoryStore:       repositorystore.NewMirrorBacked(mirrors),
+		SnapshotStore:         snapshotMetadataStore,
+		ZFSImportDatasetStore: systemZFSImportDatasetStore(ctx.Config),
 	}
 	if cacheMetadataStore != nil {
 		service.CacheStore = cacheMetadataStore

--- a/internal/cli/system.go
+++ b/internal/cli/system.go
@@ -15,7 +15,9 @@ import (
 	"text/tabwriter"
 	"time"
 
+	backendfirecracker "github.com/buildkite/cleanroom/internal/backend/firecracker"
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+	"github.com/buildkite/cleanroom/internal/runtimeconfig"
 	"github.com/buildkite/cleanroom/internal/storagegc"
 	"golang.org/x/term"
 )
@@ -44,12 +46,14 @@ var systemInventory = storagegc.Inventory
 var systemPlanPrune = storagegc.PlanPrune
 var systemExecutePrune = storagegc.ExecutePrune
 var systemListSandboxIDs = listSystemSandboxIDs
+var systemZFSImportDatasetStore = defaultSystemZFSImportDatasetStore
 var systemIsTerminal = func(f *os.File) bool {
 	return f != nil && term.IsTerminal(int(f.Fd()))
 }
 
 func (c *SystemDFCommand) Run(ctx *runtimeContext) error {
-	report, warning, err := loadSystemInventory(context.Background(), ctx, c.clientFlags, false, 0)
+	zfsImportDatasetStore := systemZFSImportDatasetStore(ctx.Config)
+	report, warning, err := loadSystemInventory(context.Background(), ctx, c.clientFlags, false, 0, zfsImportDatasetStore)
 	if err != nil {
 		return err
 	}
@@ -69,7 +73,8 @@ func (c *SystemPruneCommand) Run(ctx *runtimeContext) error {
 	if err != nil {
 		return err
 	}
-	report, _, err := loadSystemInventory(context.Background(), ctx, c.clientFlags, true, 0)
+	zfsImportDatasetStore := systemZFSImportDatasetStore(ctx.Config)
+	report, _, err := loadSystemInventory(context.Background(), ctx, c.clientFlags, true, 0, zfsImportDatasetStore)
 	if err != nil {
 		return err
 	}
@@ -101,7 +106,9 @@ func (c *SystemPruneCommand) Run(ctx *runtimeContext) error {
 		}
 	}
 
-	result, err := systemExecutePrune(context.Background(), report, plan, storagegc.ExecuteOptions{})
+	result, err := systemExecutePrune(context.Background(), report, plan, storagegc.ExecuteOptions{
+		ZFSImportDatasetStore: zfsImportDatasetStore,
+	})
 	if err != nil {
 		return err
 	}
@@ -115,7 +122,7 @@ func (c *SystemPruneCommand) Run(ctx *runtimeContext) error {
 	return err
 }
 
-func loadSystemInventory(ctx context.Context, runtimeCtx *runtimeContext, flags clientFlags, requireSandboxState bool, executionMaxAge time.Duration) (storagegc.Report, error, error) {
+func loadSystemInventory(ctx context.Context, runtimeCtx *runtimeContext, flags clientFlags, requireSandboxState bool, executionMaxAge time.Duration, zfsImportDatasetStore storagegc.ZFSImportDatasetStore) (storagegc.Report, error, error) {
 	sandboxIDs, stateKnown, listErr := systemListSandboxIDs(ctx, runtimeCtx, flags)
 	if listErr != nil && requireSandboxState {
 		return storagegc.Report{}, nil, fmt.Errorf("list sandboxes before prune: %w", listErr)
@@ -124,15 +131,24 @@ func loadSystemInventory(ctx context.Context, runtimeCtx *runtimeContext, flags 
 		executionMaxAge = storagegc.DefaultExecutionMaxAge
 	}
 	report, err := systemInventory(ctx, storagegc.InventoryOptions{
-		Config:            runtimeCtx.Config,
-		ActiveSandboxIDs:  sandboxIDs,
-		SandboxStateKnown: stateKnown,
-		ExecutionMaxAge:   executionMaxAge,
+		Config:                runtimeCtx.Config,
+		ActiveSandboxIDs:      sandboxIDs,
+		SandboxStateKnown:     stateKnown,
+		ExecutionMaxAge:       executionMaxAge,
+		ZFSImportDatasetStore: zfsImportDatasetStore,
 	})
 	if err != nil {
 		return storagegc.Report{}, nil, err
 	}
 	return report, listErr, nil
+}
+
+func defaultSystemZFSImportDatasetStore(cfg runtimeconfig.Config) storagegc.ZFSImportDatasetStore {
+	store := backendfirecracker.NewZFSImportDatasetStore(runtimeconfig.MergeBackendConfig(cfg, "firecracker", 0))
+	if store == nil {
+		return nil
+	}
+	return store
 }
 
 func listSystemSandboxIDs(ctx context.Context, runtimeCtx *runtimeContext, flags clientFlags) ([]string, bool, error) {

--- a/internal/cli/system_test.go
+++ b/internal/cli/system_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/buildkite/cleanroom/internal/runtimeconfig"
 	"github.com/buildkite/cleanroom/internal/storagegc"
 )
 
@@ -76,6 +77,64 @@ func TestSystemPruneOlderThanDoesNotOverrideExecutionRetention(t *testing.T) {
 	}
 	if got, want := gotOlderThan, 7*24*time.Hour; got != want {
 		t.Fatalf("unexpected prune older-than: got %s want %s", got, want)
+	}
+}
+
+type testSystemZFSImportDatasetStore struct{}
+
+func (testSystemZFSImportDatasetStore) ListZFSImportDatasets(context.Context) ([]string, error) {
+	return nil, nil
+}
+
+func (testSystemZFSImportDatasetStore) DestroyZFSImportDataset(context.Context, string) error {
+	return nil
+}
+
+func TestSystemPruneThreadsZFSImportDatasetStore(t *testing.T) {
+	previousListSandboxIDs := systemListSandboxIDs
+	previousInventory := systemInventory
+	previousPlanPrune := systemPlanPrune
+	previousExecutePrune := systemExecutePrune
+	previousZFSImportDatasetStore := systemZFSImportDatasetStore
+	t.Cleanup(func() {
+		systemListSandboxIDs = previousListSandboxIDs
+		systemInventory = previousInventory
+		systemPlanPrune = previousPlanPrune
+		systemExecutePrune = previousExecutePrune
+		systemZFSImportDatasetStore = previousZFSImportDatasetStore
+	})
+
+	store := testSystemZFSImportDatasetStore{}
+	systemZFSImportDatasetStore = func(runtimeconfig.Config) storagegc.ZFSImportDatasetStore {
+		return store
+	}
+	systemListSandboxIDs = func(context.Context, *runtimeContext, clientFlags) ([]string, bool, error) {
+		return nil, true, nil
+	}
+	systemInventory = func(_ context.Context, opts storagegc.InventoryOptions) (storagegc.Report, error) {
+		if opts.ZFSImportDatasetStore != store {
+			t.Fatalf("inventory zfs import dataset store = %#v, want %#v", opts.ZFSImportDatasetStore, store)
+		}
+		return storagegc.Report{GeneratedAt: time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)}, nil
+	}
+	systemPlanPrune = func(storagegc.Report, storagegc.PruneOptions) storagegc.Plan {
+		return storagegc.Plan{Actions: []storagegc.Action{{
+			Kind: storagegc.KindZFSImportDataset,
+			ID:   "stale",
+		}}}
+	}
+	systemExecutePrune = func(_ context.Context, _ storagegc.Report, _ storagegc.Plan, opts storagegc.ExecuteOptions) (storagegc.Result, error) {
+		if opts.ZFSImportDatasetStore != store {
+			t.Fatalf("execute zfs import dataset store = %#v, want %#v", opts.ZFSImportDatasetStore, store)
+		}
+		return storagegc.Result{DeletedEntries: 1}, nil
+	}
+
+	stdout, _ := makeStdoutCapture(t)
+	t.Cleanup(func() { _ = stdout.Close() })
+
+	if err := (&SystemPruneCommand{Force: true}).Run(&runtimeContext{Stdout: stdout}); err != nil {
+		t.Fatalf("SystemPruneCommand.Run returned error: %v", err)
 	}
 }
 

--- a/internal/controlservice/runtime.go
+++ b/internal/controlservice/runtime.go
@@ -52,13 +52,14 @@ type serviceTimeouts struct {
 }
 
 type serviceRuntime struct {
-	clock                                    serviceClock
-	ids                                      serviceIDSource
-	retention                                *retentionPolicy
-	timeouts                                 *serviceTimeouts
-	defaultDownloadMaxBytes                  int64
-	terminatedSandboxStorageCleanup          func(string)
-	terminatedSandboxStorageCleanupQueueSize int
+	clock                           serviceClock
+	ids                             serviceIDSource
+	retention                       *retentionPolicy
+	timeouts                        *serviceTimeouts
+	defaultDownloadMaxBytes         int64
+	terminatedSandboxStorageCleanup func(string)
+	zfsImportDatasetStorageCleanup  func()
+	storageCleanupQueueSize         int
 }
 
 var defaultRetentionPolicy = retentionPolicy{
@@ -81,7 +82,7 @@ var defaultServiceTimeouts = serviceTimeouts{
 
 const defaultDownloadMaxBytes int64 = 10 * 1024 * 1024
 
-const defaultTerminatedSandboxStorageCleanupQueueSize = 128
+const defaultStorageCleanupQueueSize = 128
 
 func (s *Service) clock() serviceClock {
 	if s.runtime.clock != nil {
@@ -118,9 +119,9 @@ func (s *Service) downloadMaxBytesDefault() int64 {
 	return defaultDownloadMaxBytes
 }
 
-func (s *Service) terminatedSandboxStorageCleanupQueueSize() int {
-	if s.runtime.terminatedSandboxStorageCleanupQueueSize > 0 {
-		return s.runtime.terminatedSandboxStorageCleanupQueueSize
+func (s *Service) storageCleanupQueueSize() int {
+	if s.runtime.storageCleanupQueueSize > 0 {
+		return s.runtime.storageCleanupQueueSize
 	}
-	return defaultTerminatedSandboxStorageCleanupQueueSize
+	return defaultStorageCleanupQueueSize
 }

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -50,14 +50,15 @@ type Service struct {
 	RepositoryStore repositorystore.RepositoryStore
 	runtime         serviceRuntime
 	interactive     interactiveSessionBroker
-	storageCleanup  terminatedSandboxStorageCleanupScheduler
+	storageCleanup  storageCleanupScheduler
 	// Snapshot lifecycle still lives on Service because it coordinates backend
 	// adapters, sandbox state, and metadata persistence in one operation chain.
 	// If this grows again, extract a dedicated snapshot manager rather than
 	// adding more snapshot-specific branching here.
-	SnapshotStore  snapshotMetadataStore
-	CacheStore     cacheMetadataStore
-	ChangesetStore changesetMetadataStore
+	SnapshotStore         snapshotMetadataStore
+	CacheStore            cacheMetadataStore
+	ZFSImportDatasetStore storagegc.ZFSImportDatasetStore
+	ChangesetStore        changesetMetadataStore
 
 	mu                sync.RWMutex
 	sandboxes         map[string]*sandboxState
@@ -66,11 +67,31 @@ type Service struct {
 	snapshotDeletions map[string]struct{}
 }
 
-type terminatedSandboxStorageCleanupScheduler struct {
+type storageCleanupScheduler struct {
 	once   sync.Once
-	queue  chan string
+	queue  chan storageCleanupJob
 	mu     sync.Mutex
 	queued map[string]struct{}
+}
+
+type storageCleanupJob struct {
+	Kind string
+	ID   string
+}
+
+const (
+	storageCleanupKindTerminatedSandbox = "terminated-sandbox"
+	storageCleanupKindZFSImportDatasets = "zfs-import-datasets"
+	storageCleanupZFSImportDatasetsID   = "imports"
+)
+
+func (j storageCleanupJob) key() string {
+	kind := strings.TrimSpace(j.Kind)
+	id := strings.TrimSpace(j.ID)
+	if kind == "" || id == "" {
+		return ""
+	}
+	return kind + ":" + id
 }
 
 type sandboxState struct {
@@ -2313,54 +2334,86 @@ func (s *Service) terminateCreatedSandbox(ctx context.Context, adapter backend.A
 	return err
 }
 
+func (s *Service) ScheduleStartupStorageCleanup() {
+	s.scheduleZFSImportDatasetStorageCleanup()
+}
+
 func (s *Service) scheduleTerminatedSandboxStorageCleanup(sandboxID string) {
 	sandboxID = strings.TrimSpace(sandboxID)
 	if sandboxID == "" {
 		return
 	}
-	scheduler := s.startTerminatedSandboxStorageCleanupWorker()
+	s.scheduleStorageCleanup(storageCleanupJob{Kind: storageCleanupKindTerminatedSandbox, ID: sandboxID})
+}
+
+func (s *Service) scheduleZFSImportDatasetStorageCleanup() {
+	if s.ZFSImportDatasetStore == nil {
+		return
+	}
+	s.scheduleStorageCleanup(storageCleanupJob{Kind: storageCleanupKindZFSImportDatasets, ID: storageCleanupZFSImportDatasetsID})
+}
+
+func (s *Service) scheduleStorageCleanup(job storageCleanupJob) {
+	key := job.key()
+	if key == "" {
+		return
+	}
+	scheduler := s.startStorageCleanupWorker()
 
 	scheduler.mu.Lock()
-	if _, ok := scheduler.queued[sandboxID]; ok {
+	if _, ok := scheduler.queued[key]; ok {
 		scheduler.mu.Unlock()
 		return
 	}
-	scheduler.queued[sandboxID] = struct{}{}
+	scheduler.queued[key] = struct{}{}
 	queue := scheduler.queue
 	scheduler.mu.Unlock()
 
 	select {
-	case queue <- sandboxID:
+	case queue <- job:
 	default:
 		scheduler.mu.Lock()
-		delete(scheduler.queued, sandboxID)
+		delete(scheduler.queued, key)
 		scheduler.mu.Unlock()
 		if s.Logger != nil {
-			s.Logger.Warn("terminated sandbox storage cleanup queue full", "sandbox_id", sandboxID, "queue_size", cap(queue))
+			s.Logger.Warn("storage cleanup queue full", "kind", job.Kind, "id", job.ID, "queue_size", cap(queue))
 		}
 	}
 }
 
-func (s *Service) startTerminatedSandboxStorageCleanupWorker() *terminatedSandboxStorageCleanupScheduler {
+func (s *Service) startStorageCleanupWorker() *storageCleanupScheduler {
 	scheduler := &s.storageCleanup
 	scheduler.once.Do(func() {
-		scheduler.queue = make(chan string, s.terminatedSandboxStorageCleanupQueueSize())
+		scheduler.queue = make(chan storageCleanupJob, s.storageCleanupQueueSize())
 		scheduler.queued = make(map[string]struct{})
 		// The worker lives for the service lifetime; cleanup is best-effort and
 		// does not have a separate shutdown path.
-		go s.runTerminatedSandboxStorageCleanupWorker()
+		go s.runStorageCleanupWorker()
 	})
 	return scheduler
 }
 
-func (s *Service) runTerminatedSandboxStorageCleanupWorker() {
+func (s *Service) runStorageCleanupWorker() {
 	scheduler := &s.storageCleanup
-	for sandboxID := range scheduler.queue {
-		s.runTerminatedSandboxStorageCleanup(sandboxID)
+	for job := range scheduler.queue {
+		s.runStorageCleanup(job)
 
 		scheduler.mu.Lock()
-		delete(scheduler.queued, sandboxID)
+		delete(scheduler.queued, job.key())
 		scheduler.mu.Unlock()
+	}
+}
+
+func (s *Service) runStorageCleanup(job storageCleanupJob) {
+	switch job.Kind {
+	case storageCleanupKindTerminatedSandbox:
+		s.runTerminatedSandboxStorageCleanup(job.ID)
+	case storageCleanupKindZFSImportDatasets:
+		s.runZFSImportDatasetStorageCleanup()
+	default:
+		if s.Logger != nil {
+			s.Logger.Warn("unknown storage cleanup job", "kind", job.Kind, "id", job.ID)
+		}
 	}
 }
 
@@ -2370,6 +2423,14 @@ func (s *Service) runTerminatedSandboxStorageCleanup(sandboxID string) {
 		cleanup = s.cleanupTerminatedSandboxStorage
 	}
 	cleanup(sandboxID)
+}
+
+func (s *Service) runZFSImportDatasetStorageCleanup() {
+	cleanup := s.runtime.zfsImportDatasetStorageCleanup
+	if cleanup == nil {
+		cleanup = s.cleanupZFSImportDatasets
+	}
+	cleanup()
 }
 
 func (s *Service) cleanupTerminatedSandboxStorage(sandboxID string) {
@@ -2409,6 +2470,49 @@ func (s *Service) cleanupTerminatedSandboxStorage(sandboxID string) {
 	if s.Logger != nil && result.DeletedEntries > 0 {
 		s.Logger.Info("cleaned up terminated sandbox storage",
 			"sandbox_id", sandboxID,
+			"deleted_entries", result.DeletedEntries,
+			"reclaimed_bytes", result.ReclaimedBytes,
+		)
+	}
+}
+
+func (s *Service) cleanupZFSImportDatasets() {
+	if s.ZFSImportDatasetStore == nil {
+		return
+	}
+	cleanupCtx, cancel := context.WithTimeout(context.Background(), s.timeouts().storageCleanupTimeout)
+	defer cancel()
+
+	report, err := storagegc.Inventory(cleanupCtx, storagegc.InventoryOptions{
+		Config:                s.Config,
+		SnapshotStore:         s.SnapshotStore,
+		CacheStore:            s.CacheStore,
+		ZFSImportDatasetStore: s.ZFSImportDatasetStore,
+		Now:                   s.clock().Now(),
+		Kinds:                 []string{storagegc.KindZFSImportDataset},
+		SkipSize:              true,
+	})
+	if err != nil {
+		if s.Logger != nil {
+			s.Logger.Warn("inventory zfs import datasets for cleanup failed", "error", err)
+		}
+		return
+	}
+	plan := storagegc.PlanLifecyclePrune(report, storagegc.LifecycleOptions{ZFSImportDatasets: true})
+	if len(plan.Actions) == 0 {
+		return
+	}
+	result, err := storagegc.ExecutePrune(cleanupCtx, report, plan, storagegc.ExecuteOptions{
+		ZFSImportDatasetStore: s.ZFSImportDatasetStore,
+	})
+	if err != nil {
+		if s.Logger != nil {
+			s.Logger.Warn("cleanup zfs import datasets failed", "error", err)
+		}
+		return
+	}
+	if s.Logger != nil && result.DeletedEntries > 0 {
+		s.Logger.Info("cleaned up zfs import datasets",
 			"deleted_entries", result.DeletedEntries,
 			"reclaimed_bytes", result.ReclaimedBytes,
 		)

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -1381,6 +1381,25 @@ func (s *memoryCacheStore) Delete(_ context.Context, stage, cacheKey string) err
 	return nil
 }
 
+type memoryZFSImportDatasetStore struct {
+	mu        sync.Mutex
+	datasets  []string
+	destroyed []string
+}
+
+func (s *memoryZFSImportDatasetStore) ListZFSImportDatasets(context.Context) ([]string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.datasets...), nil
+}
+
+func (s *memoryZFSImportDatasetStore) DestroyZFSImportDataset(_ context.Context, dataset string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.destroyed = append(s.destroyed, dataset)
+	return nil
+}
+
 type memoryChangesetStore struct {
 	mu      sync.Mutex
 	records map[string]changesetstore.Record
@@ -7261,7 +7280,7 @@ func TestTerminateSandboxSchedulesStorageCleanupAsync(t *testing.T) {
 func TestTerminateSandboxStorageCleanupWorkerRunsSeriallyAndDedupes(t *testing.T) {
 	adapter := &stubAdapter{}
 	svc := newTestService(adapter)
-	svc.runtime.terminatedSandboxStorageCleanupQueueSize = 4
+	svc.runtime.storageCleanupQueueSize = 4
 
 	started := make(chan string, 3)
 	finished := make(chan string, 3)
@@ -7328,6 +7347,68 @@ func TestTerminateSandboxStorageCleanupWorkerRunsSeriallyAndDedupes(t *testing.T
 	case got := <-started:
 		t.Fatalf("duplicate cleanup was not deduped, started %q", got)
 	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestScheduleStartupStorageCleanupQueuesZFSImportCleanup(t *testing.T) {
+	adapter := &stubAdapter{}
+	svc := newTestService(adapter)
+	svc.ZFSImportDatasetStore = &memoryZFSImportDatasetStore{}
+
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+	defer close(release)
+	svc.runtime.zfsImportDatasetStorageCleanup = func() {
+		started <- struct{}{}
+		<-release
+	}
+
+	svc.ScheduleStartupStorageCleanup()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for zfs import storage cleanup to start")
+	}
+}
+
+func TestZFSImportDatasetStorageCleanupDestroysOnlyUnreferencedImports(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", filepath.Join(tmpDir, "state-home"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(tmpDir, "cache-home"))
+
+	snapshotStore := newMemorySnapshotStore()
+	if err := snapshotStore.Create(context.Background(), snapshotstore.Record{
+		SnapshotID: "snap-import",
+		Backend:    "firecracker",
+		StorageRef: "tank/cleanroom/snapshots/imports/protected-snapshot@base",
+	}); err != nil {
+		t.Fatalf("create snapshot record: %v", err)
+	}
+	cacheStore := newMemoryCacheStore()
+	if err := cacheStore.Upsert(context.Background(), cachestore.Record{
+		Stage:      "dependencies",
+		CacheKey:   "cache-import",
+		Backend:    "firecracker",
+		StorageRef: "tank/cleanroom/snapshots/imports/protected-cache@base",
+	}); err != nil {
+		t.Fatalf("create cache record: %v", err)
+	}
+	zfsStore := &memoryZFSImportDatasetStore{datasets: []string{
+		"tank/cleanroom/snapshots/imports/protected-snapshot",
+		"tank/cleanroom/snapshots/imports/protected-cache",
+		"tank/cleanroom/snapshots/imports/stale",
+	}}
+	svc := newTestServiceWithSnapshotStore(&stubAdapter{}, snapshotStore)
+	svc.CacheStore = cacheStore
+	svc.ZFSImportDatasetStore = zfsStore
+
+	svc.cleanupZFSImportDatasets()
+
+	zfsStore.mu.Lock()
+	defer zfsStore.mu.Unlock()
+	if got, want := zfsStore.destroyed, []string{"tank/cleanroom/snapshots/imports/stale"}; len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("unexpected destroyed datasets: got %v want %v", got, want)
 	}
 }
 

--- a/internal/storagegc/storagegc.go
+++ b/internal/storagegc/storagegc.go
@@ -28,6 +28,7 @@ const (
 	KindContentCache      = "content-cache"
 	KindExecutionArtifact = "execution-artifacts"
 	KindChangesetStore    = "changesets"
+	KindZFSImportDataset  = "zfs-import-dataset"
 )
 
 const DefaultExecutionMaxAge = 24 * time.Hour
@@ -46,18 +47,24 @@ type ImageManager interface {
 	Remove(context.Context, string) ([]imagemgr.Record, error)
 }
 
+type ZFSImportDatasetStore interface {
+	ListZFSImportDatasets(context.Context) ([]string, error)
+	DestroyZFSImportDataset(context.Context, string) error
+}
+
 type InventoryOptions struct {
 	Config           runtimeconfig.Config
 	ActiveSandboxIDs []string
 	// SandboxRuntimeIDs limits sandbox-runtime scanning to specific sandbox ids.
 	// Empty means scan every sandbox runtime directory.
-	SandboxRuntimeIDs []string
-	SandboxStateKnown bool
-	SnapshotStore     SnapshotLister
-	CacheStore        CacheStore
-	ImageManager      ImageManager
-	Now               time.Time
-	ExecutionMaxAge   time.Duration
+	SandboxRuntimeIDs     []string
+	SandboxStateKnown     bool
+	SnapshotStore         SnapshotLister
+	CacheStore            CacheStore
+	ImageManager          ImageManager
+	ZFSImportDatasetStore ZFSImportDatasetStore
+	Now                   time.Time
+	ExecutionMaxAge       time.Duration
 	// SkipSize avoids recursive filesystem sizing. It is intended for
 	// lifecycle cleanup paths where deletion is targeted and byte accounting is
 	// not user-facing.
@@ -110,6 +117,7 @@ type PruneOptions struct {
 // just completed the owning lifecycle transition.
 type LifecycleOptions struct {
 	TerminatedSandboxIDs []string
+	ZFSImportDatasets    bool
 }
 
 type Action struct {
@@ -127,8 +135,9 @@ type Plan struct {
 }
 
 type ExecuteOptions struct {
-	CacheStore   CacheStore
-	ImageManager ImageManager
+	CacheStore            CacheStore
+	ImageManager          ImageManager
+	ZFSImportDatasetStore ZFSImportDatasetStore
 }
 
 type Result struct {
@@ -171,7 +180,8 @@ func Inventory(ctx context.Context, opts InventoryOptions) (Report, error) {
 
 	includedKinds := stringSet(opts.Kinds)
 	referencedSnapshotPaths := map[string][]string{}
-	if inventoryIncludes(includedKinds, KindSnapshot) || inventoryIncludes(includedKinds, KindStageCache) || inventoryIncludes(includedKinds, KindOrphanSnapshot) {
+	referencedZFSImportDatasets := map[string][]string{}
+	if inventoryIncludes(includedKinds, KindSnapshot) || inventoryIncludes(includedKinds, KindStageCache) || inventoryIncludes(includedKinds, KindOrphanSnapshot) || inventoryIncludes(includedKinds, KindZFSImportDataset) {
 		snapshotStore := opts.SnapshotStore
 		if snapshotStore == nil {
 			store, err := snapshotstore.New(snapshotstore.Options{})
@@ -194,13 +204,14 @@ func Inventory(ctx context.Context, opts InventoryOptions) (Report, error) {
 				}
 				addPathReference(referencedSnapshotPaths, entry.Path, "snapshot metadata "+record.SnapshotID)
 			}
+			addZFSImportDatasetReference(referencedZFSImportDatasets, record.StorageRef, "snapshot metadata "+record.SnapshotID)
 			if inventoryIncludes(includedKinds, KindSnapshot) {
 				report.Entries = append(report.Entries, entry)
 			}
 		}
 	}
 
-	if inventoryIncludes(includedKinds, KindStageCache) || inventoryIncludes(includedKinds, KindOrphanSnapshot) {
+	if inventoryIncludes(includedKinds, KindStageCache) || inventoryIncludes(includedKinds, KindOrphanSnapshot) || inventoryIncludes(includedKinds, KindZFSImportDataset) {
 		cacheStore := opts.CacheStore
 		if cacheStore == nil {
 			store, err := cachestore.New(cachestore.Options{})
@@ -227,6 +238,7 @@ func Inventory(ctx context.Context, opts InventoryOptions) (Report, error) {
 				}
 				addPathReference(referencedSnapshotPaths, entry.Path, "stage-cache metadata "+record.Stage+"/"+record.CacheKey)
 			}
+			addZFSImportDatasetReference(referencedZFSImportDatasets, record.StorageRef, "stage-cache metadata "+record.Stage+"/"+record.CacheKey)
 			if inventoryIncludes(includedKinds, KindStageCache) {
 				report.Entries = append(report.Entries, entry)
 			}
@@ -248,6 +260,14 @@ func Inventory(ctx context.Context, opts InventoryOptions) (Report, error) {
 			return Report{}, err
 		}
 		report.Entries = append(report.Entries, orphanSnapshots...)
+	}
+
+	if inventoryIncludes(includedKinds, KindZFSImportDataset) && opts.ZFSImportDatasetStore != nil {
+		importDatasets, err := scanZFSImportDatasets(ctx, opts.ZFSImportDatasetStore, referencedZFSImportDatasets)
+		if err != nil {
+			return Report{}, err
+		}
+		report.Entries = append(report.Entries, importDatasets...)
 	}
 
 	if inventoryIncludes(includedKinds, KindRuntimeRootFS) {
@@ -375,39 +395,57 @@ func PlanPrune(report Report, opts PruneOptions) Plan {
 // completed a lifecycle transition. It is intentionally narrower than
 // PlanPrune and does not apply age or --all policy.
 func PlanLifecyclePrune(report Report, opts LifecycleOptions) Plan {
-	if !report.SandboxStateKnown {
-		return Plan{}
-	}
 	terminatedSandboxes := stringSet(opts.TerminatedSandboxIDs)
-	if len(terminatedSandboxes) == 0 {
+	if len(terminatedSandboxes) == 0 && !opts.ZFSImportDatasets {
 		return Plan{}
 	}
 
 	plan := Plan{}
 	for _, entry := range report.Entries {
-		if entry.Kind != KindSandboxRuntime {
+		switch entry.Kind {
+		case KindSandboxRuntime:
+			if !report.SandboxStateKnown {
+				continue
+			}
+			if _, ok := terminatedSandboxes[entry.ID]; !ok {
+				continue
+			}
+			actionPath, ok := deletionPathForReport(report, entry)
+			if !ok || actionPath == "" {
+				continue
+			}
+			action := Action{
+				Kind:      entry.Kind,
+				ID:        entry.ID,
+				Path:      actionPath,
+				SizeBytes: entry.SizeBytes,
+				Reason:    "terminated sandbox lifecycle cleanup",
+				Entry:     entry,
+			}
+			plan.Actions = append(plan.Actions, action)
+			plan.ReclaimableBytes += action.SizeBytes
+		case KindZFSImportDataset:
+			if !opts.ZFSImportDatasets || !entry.Reclaimable {
+				continue
+			}
+			action := Action{
+				Kind:      entry.Kind,
+				ID:        entry.ID,
+				SizeBytes: entry.SizeBytes,
+				Reason:    "stale zfs import dataset lifecycle cleanup",
+				Entry:     entry,
+			}
+			plan.Actions = append(plan.Actions, action)
+			plan.ReclaimableBytes += action.SizeBytes
+		default:
 			continue
 		}
-		if _, ok := terminatedSandboxes[entry.ID]; !ok {
-			continue
-		}
-		actionPath, ok := deletionPathForReport(report, entry)
-		if !ok || actionPath == "" {
-			continue
-		}
-		action := Action{
-			Kind:      entry.Kind,
-			ID:        entry.ID,
-			Path:      actionPath,
-			SizeBytes: entry.SizeBytes,
-			Reason:    "terminated sandbox lifecycle cleanup",
-			Entry:     entry,
-		}
-		plan.Actions = append(plan.Actions, action)
-		plan.ReclaimableBytes += action.SizeBytes
 	}
 	sort.Slice(plan.Actions, func(i, j int) bool {
-		return plan.Actions[i].ID < plan.Actions[j].ID
+		if plan.Actions[i].Kind == plan.Actions[j].Kind {
+			return plan.Actions[i].ID < plan.Actions[j].ID
+		}
+		return plan.Actions[i].Kind < plan.Actions[j].Kind
 	})
 	return plan
 }
@@ -430,6 +468,7 @@ func ExecutePrune(ctx context.Context, report Report, plan Plan, opts ExecuteOpt
 
 	cacheStore := opts.CacheStore
 	imageManager := opts.ImageManager
+	zfsImportDatasetStore := opts.ZFSImportDatasetStore
 	for _, action := range plan.Actions {
 		switch action.Kind {
 		case KindStageCache:
@@ -448,6 +487,10 @@ func ExecutePrune(ctx context.Context, report Report, plan Plan, opts ExecuteOpt
 				}
 				imageManager = manager
 			}
+		case KindZFSImportDataset:
+			if zfsImportDatasetStore == nil {
+				return Result{}, errors.New("zfs import dataset store is not configured")
+			}
 		}
 	}
 
@@ -456,7 +499,7 @@ func ExecutePrune(ctx context.Context, report Report, plan Plan, opts ExecuteOpt
 		if err := ctx.Err(); err != nil {
 			return result, err
 		}
-		if err := executeAction(ctx, report, action, roots, cacheStore, imageManager); err != nil {
+		if err := executeAction(ctx, report, action, roots, cacheStore, imageManager, zfsImportDatasetStore); err != nil {
 			return result, err
 		}
 		result.DeletedEntries++
@@ -465,7 +508,7 @@ func ExecutePrune(ctx context.Context, report Report, plan Plan, opts ExecuteOpt
 	return result, nil
 }
 
-func executeAction(ctx context.Context, report Report, action Action, roots []string, cacheStore CacheStore, imageManager ImageManager) error {
+func executeAction(ctx context.Context, report Report, action Action, roots []string, cacheStore CacheStore, imageManager ImageManager, zfsImportDatasetStore ZFSImportDatasetStore) error {
 	switch action.Kind {
 	case KindImageCache:
 		if imageManager == nil {
@@ -487,6 +530,14 @@ func executeAction(ctx context.Context, report Report, action Action, roots []st
 			return fmt.Errorf("delete stage-cache metadata %q/%q: %w", action.Entry.Stage, action.Entry.CacheKey, err)
 		}
 		return removeOwnedPath(stageCachePath, roots)
+	case KindZFSImportDataset:
+		if zfsImportDatasetStore == nil {
+			return errors.New("zfs import dataset store is not configured")
+		}
+		if err := zfsImportDatasetStore.DestroyZFSImportDataset(ctx, action.Entry.StorageRef); err != nil {
+			return fmt.Errorf("destroy zfs import dataset %q: %w", action.Entry.StorageRef, err)
+		}
+		return nil
 	default:
 		return removeOwnedPath(action.Path, roots)
 	}
@@ -632,6 +683,42 @@ func scanOrphanSnapshotDirs(ctx context.Context, snapshotRoots []string, refs ma
 				})
 			}
 		}
+	}
+	return out, nil
+}
+
+func scanZFSImportDatasets(ctx context.Context, store ZFSImportDatasetStore, refs map[string][]string) ([]Entry, error) {
+	datasets, err := store.ListZFSImportDatasets(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list zfs import datasets: %w", err)
+	}
+	out := make([]Entry, 0, len(datasets))
+	seen := map[string]struct{}{}
+	for _, dataset := range datasets {
+		dataset = strings.TrimSpace(dataset)
+		if dataset == "" {
+			continue
+		}
+		if _, ok := zfsImportDatasetFromRef(dataset); !ok {
+			continue
+		}
+		if _, ok := seen[dataset]; ok {
+			continue
+		}
+		seen[dataset] = struct{}{}
+		entry := Entry{
+			Kind:        KindZFSImportDataset,
+			ID:          zfsImportDatasetID(dataset),
+			StorageRef:  dataset,
+			Reclaimable: true,
+			Reason:      "unreferenced zfs import dataset",
+		}
+		if protections := refs[dataset]; len(protections) > 0 {
+			entry.Reclaimable = false
+			entry.Reason = "zfs import dataset referenced by metadata"
+			entry.ProtectedBy = append(entry.ProtectedBy, protections...)
+		}
+		out = append(out, entry)
 	}
 	return out, nil
 }
@@ -795,6 +882,42 @@ func storageRefPath(storageRef string) string {
 		return ""
 	}
 	return cleanPath(ref)
+}
+
+func addZFSImportDatasetReference(refs map[string][]string, storageRef, reason string) {
+	dataset, ok := zfsImportDatasetFromRef(storageRef)
+	if !ok {
+		return
+	}
+	refs[dataset] = append(refs[dataset], reason)
+}
+
+func zfsImportDatasetFromRef(ref string) (string, bool) {
+	dataset := strings.TrimSpace(ref)
+	if dataset == "" || filepath.IsAbs(dataset) {
+		return "", false
+	}
+	if before, _, ok := strings.Cut(dataset, "@"); ok {
+		dataset = before
+	}
+	components := strings.Split(dataset, "/")
+	if len(components) < 4 {
+		return "", false
+	}
+	if components[len(components)-3] != "snapshots" || components[len(components)-2] != "imports" || strings.TrimSpace(components[len(components)-1]) == "" {
+		return "", false
+	}
+	for _, component := range components {
+		if strings.TrimSpace(component) == "" {
+			return "", false
+		}
+	}
+	return dataset, true
+}
+
+func zfsImportDatasetID(dataset string) string {
+	_, dataset = filepath.Split(strings.TrimSpace(dataset))
+	return dataset
 }
 
 func deletionPathForReport(report Report, entry Entry) (string, bool) {

--- a/internal/storagegc/storagegc_test.go
+++ b/internal/storagegc/storagegc_test.go
@@ -58,6 +58,21 @@ func (m *stubImageManager) Remove(_ context.Context, selector string) ([]imagemg
 	return nil, nil
 }
 
+type stubZFSImportDatasetStore struct {
+	datasets  []string
+	err       error
+	destroyed []string
+}
+
+func (s *stubZFSImportDatasetStore) ListZFSImportDatasets(context.Context) ([]string, error) {
+	return s.datasets, s.err
+}
+
+func (s *stubZFSImportDatasetStore) DestroyZFSImportDataset(_ context.Context, dataset string) error {
+	s.destroyed = append(s.destroyed, dataset)
+	return nil
+}
+
 func TestInventoryProtectsReferencesAndFindsOrphans(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("XDG_STATE_HOME", filepath.Join(tmpDir, "state-home"))
@@ -317,6 +332,65 @@ func TestInventoryStageCacheFilterKeepsSnapshotProtections(t *testing.T) {
 	}
 }
 
+func TestInventoryProtectsReferencedZFSImportDatasets(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", filepath.Join(tmpDir, "state-home"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(tmpDir, "cache-home"))
+
+	store := &stubZFSImportDatasetStore{datasets: []string{
+		"tank/cleanroom/snapshots/imports/explicit",
+		"tank/cleanroom/snapshots/imports/cache",
+		"tank/cleanroom/snapshots/imports/stale",
+	}}
+	report, err := Inventory(context.Background(), InventoryOptions{
+		SnapshotStore: stubSnapshotStore{records: []snapshotstore.Record{{
+			SnapshotID: "snap-explicit",
+			Backend:    "firecracker",
+			StorageRef: "tank/cleanroom/snapshots/imports/explicit@base",
+		}}},
+		CacheStore: &stubCacheStore{records: []cachestore.Record{{
+			Stage:      "dependencies",
+			CacheKey:   "cache",
+			Backend:    "firecracker",
+			StorageRef: "tank/cleanroom/snapshots/imports/cache@base",
+		}}},
+		ImageManager:          &stubImageManager{err: errors.New("image manager should not be used")},
+		ZFSImportDatasetStore: store,
+		Kinds:                 []string{KindZFSImportDataset},
+		SkipSize:              true,
+	})
+	if err != nil {
+		t.Fatalf("Inventory returned error: %v", err)
+	}
+
+	explicit := findEntry(t, report, KindZFSImportDataset, "explicit")
+	if explicit.Reclaimable {
+		t.Fatalf("expected explicit import dataset to be protected")
+	}
+	if !slices.Contains(explicit.ProtectedBy, "snapshot metadata snap-explicit") {
+		t.Fatalf("expected snapshot protection, got %#v", explicit.ProtectedBy)
+	}
+
+	cache := findEntry(t, report, KindZFSImportDataset, "cache")
+	if cache.Reclaimable {
+		t.Fatalf("expected cache import dataset to be protected")
+	}
+	if !slices.Contains(cache.ProtectedBy, "stage-cache metadata dependencies/cache") {
+		t.Fatalf("expected stage-cache protection, got %#v", cache.ProtectedBy)
+	}
+
+	stale := findEntry(t, report, KindZFSImportDataset, "stale")
+	if !stale.Reclaimable {
+		t.Fatalf("expected stale import dataset to be reclaimable")
+	}
+	if got, want := stale.Reason, "unreferenced zfs import dataset"; got != want {
+		t.Fatalf("unexpected stale reason: got %q want %q", got, want)
+	}
+	if got, want := stale.StorageRef, "tank/cleanroom/snapshots/imports/stale"; got != want {
+		t.Fatalf("unexpected stale storage ref: got %q want %q", got, want)
+	}
+}
+
 func TestPlanPruneIncludesAllAndOlderThanCaches(t *testing.T) {
 	now := time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)
 	report := Report{
@@ -382,6 +456,44 @@ func TestPlanPruneIncludesAllAndOlderThanCaches(t *testing.T) {
 	assertPlanAction(t, allPlan, KindImageCache, "sha256:image")
 }
 
+func TestPlanAndExecutePruneDestroysUnreferencedZFSImportDatasets(t *testing.T) {
+	report := Report{
+		Entries: []Entry{
+			{
+				Kind:        KindZFSImportDataset,
+				ID:          "protected",
+				StorageRef:  "tank/cleanroom/snapshots/imports/protected",
+				Reason:      "referenced zfs import dataset",
+				ProtectedBy: []string{"stage-cache metadata dependencies/cache"},
+			},
+			{
+				Kind:        KindZFSImportDataset,
+				ID:          "stale",
+				StorageRef:  "tank/cleanroom/snapshots/imports/stale",
+				Reclaimable: true,
+				Reason:      "unreferenced zfs import dataset",
+			},
+		},
+	}
+	plan := PlanPrune(report, PruneOptions{})
+	if got, want := len(plan.Actions), 1; got != want {
+		t.Fatalf("unexpected prune action count: got %d want %d", got, want)
+	}
+	assertPlanAction(t, plan, KindZFSImportDataset, "stale")
+
+	store := &stubZFSImportDatasetStore{}
+	result, err := ExecutePrune(context.Background(), report, plan, ExecuteOptions{ZFSImportDatasetStore: store})
+	if err != nil {
+		t.Fatalf("ExecutePrune returned error: %v", err)
+	}
+	if got, want := result.DeletedEntries, 1; got != want {
+		t.Fatalf("unexpected deleted entries: got %d want %d", got, want)
+	}
+	if got, want := store.destroyed, []string{"tank/cleanroom/snapshots/imports/stale"}; len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("unexpected destroyed datasets: got %v want %v", got, want)
+	}
+}
+
 func TestPlanLifecyclePruneDeletesTerminatedSandboxRuntime(t *testing.T) {
 	tmpDir := t.TempDir()
 	runtimeDir := filepath.Join(tmpDir, "state", "cleanroom", "sandboxes", "sandbox-1")
@@ -422,6 +534,43 @@ func TestPlanLifecyclePruneDeletesTerminatedSandboxRuntime(t *testing.T) {
 	}
 	if _, err := os.Stat(runtimeDir); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("expected runtime dir to be removed, stat err: %v", err)
+	}
+}
+
+func TestPlanLifecyclePruneIncludesUnreferencedZFSImportDatasets(t *testing.T) {
+	report := Report{
+		SandboxStateKnown: false,
+		Entries: []Entry{
+			{
+				Kind:        KindSandboxRuntime,
+				ID:          "sandbox-1",
+				Path:        "/tmp/sandbox-1",
+				Reclaimable: true,
+			},
+			{
+				Kind:        KindZFSImportDataset,
+				ID:          "stale",
+				StorageRef:  "tank/cleanroom/snapshots/imports/stale",
+				Reclaimable: true,
+			},
+			{
+				Kind:        KindZFSImportDataset,
+				ID:          "protected",
+				StorageRef:  "tank/cleanroom/snapshots/imports/protected",
+				ProtectedBy: []string{"snapshot metadata snap"},
+			},
+		},
+	}
+	plan := PlanLifecyclePrune(report, LifecycleOptions{
+		TerminatedSandboxIDs: []string{"sandbox-1"},
+		ZFSImportDatasets:    true,
+	})
+	if got, want := len(plan.Actions), 1; got != want {
+		t.Fatalf("unexpected lifecycle action count: got %d want %d", got, want)
+	}
+	assertPlanAction(t, plan, KindZFSImportDataset, "stale")
+	if got, want := plan.Actions[0].Reason, "stale zfs import dataset lifecycle cleanup"; got != want {
+		t.Fatalf("unexpected action reason: got %q want %q", got, want)
 	}
 }
 

--- a/internal/volumestore/zfs.go
+++ b/internal/volumestore/zfs.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"unicode"
@@ -416,6 +417,39 @@ func (d *ZFSDriver) ImportIncrementalSnapshot(ctx context.Context, req Increment
 	}, nil
 }
 
+func (d *ZFSDriver) ListZFSImportDatasets(ctx context.Context) ([]string, error) {
+	importNamespace := d.importNamespaceDataset()
+	out, err := d.runner.Output(ctx, "zfs", "list", "-H", "-d", "1", "-o", "name", importNamespace)
+	if err != nil {
+		if isZFSMissingError(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("list zfs import datasets under %q: %w", importNamespace, err)
+	}
+
+	var datasets []string
+	for _, line := range strings.Split(string(out), "\n") {
+		dataset := strings.TrimSpace(line)
+		if dataset == "" || dataset == importNamespace {
+			continue
+		}
+		if !d.isImportDataset(dataset) {
+			continue
+		}
+		datasets = append(datasets, dataset)
+	}
+	slices.Sort(datasets)
+	return datasets, nil
+}
+
+func (d *ZFSDriver) DestroyZFSImportDataset(ctx context.Context, dataset string) error {
+	dataset = strings.TrimSpace(dataset)
+	if !d.isImportDataset(dataset) {
+		return fmt.Errorf("zfs import dataset %q is not under %q", dataset, d.importNamespaceDataset())
+	}
+	return d.DestroyVolume(ctx, DestroyVolumeRequest{VolumeRef: dataset})
+}
+
 func (d *ZFSDriver) datasetPath(parts ...string) string {
 	items := []string{d.datasetRoot}
 	for _, part := range parts {
@@ -517,6 +551,20 @@ func (d *ZFSDriver) snapshotRef(dataset, snapshotName string) string {
 
 func (d *ZFSDriver) importDataset(snapshotID string) string {
 	return d.datasetPath(zfsSnapshotNamespace, zfsSnapshotImportNamespace, snapshotID)
+}
+
+func (d *ZFSDriver) importNamespaceDataset() string {
+	return d.datasetPath(zfsSnapshotNamespace, zfsSnapshotImportNamespace)
+}
+
+func (d *ZFSDriver) isImportDataset(dataset string) bool {
+	dataset = strings.Trim(strings.TrimSpace(dataset), "/")
+	namespace := d.importNamespaceDataset()
+	if dataset == namespace {
+		return false
+	}
+	rel, ok := strings.CutPrefix(dataset, namespace+"/")
+	return ok && rel != "" && !strings.Contains(rel, "/")
 }
 
 func storedZFSSnapshotDataset(snapshotRef string) (string, bool) {

--- a/internal/volumestore/zfs_test.go
+++ b/internal/volumestore/zfs_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -87,6 +88,25 @@ func (r *zfsTestRunner) Run(_ context.Context, command string, args ...string) e
 
 func (r *zfsTestRunner) Output(_ context.Context, command string, args ...string) ([]byte, error) {
 	r.commands = append(r.commands, strings.Join(append([]string{command}, args...), " "))
+	if command == "zfs" && len(args) == 7 && args[0] == "list" && args[1] == "-H" && args[2] == "-d" && args[3] == "1" && args[4] == "-o" && args[5] == "name" {
+		parent := args[6]
+		if !r.exists[parent] {
+			return nil, errors.New("cannot open dataset: dataset does not exist")
+		}
+		var refs []string
+		for ref := range r.exists {
+			if ref == parent {
+				refs = append(refs, ref)
+				continue
+			}
+			child, ok := strings.CutPrefix(ref, parent+"/")
+			if ok && child != "" && !strings.Contains(child, "/") && !strings.Contains(child, "@") {
+				refs = append(refs, ref)
+			}
+		}
+		slices.Sort(refs)
+		return []byte(strings.Join(refs, "\n") + "\n"), nil
+	}
 	if command == "zfs" && len(args) == 5 && args[0] == "list" {
 		ref := args[4]
 		if r.exists[ref] {
@@ -164,6 +184,78 @@ func (r *zfsTestRunner) InputFrom(_ context.Context, src io.Reader, command stri
 		r.guids[snapshotRef] = "guid-" + strings.ReplaceAll(snapshotRef, "/", "-")
 	}
 	return nil
+}
+
+func TestZFSDriverListsImportDatasets(t *testing.T) {
+	runner := &zfsTestRunner{
+		exists: map[string]bool{
+			"tank/cleanroom/snapshots/imports":                   true,
+			"tank/cleanroom/snapshots/imports/imported-b":        true,
+			"tank/cleanroom/snapshots/imports/imported-a":        true,
+			"tank/cleanroom/snapshots/imports/imported-a@base":   true,
+			"tank/cleanroom/snapshots/imports/imported-a/nested": true,
+			"tank/cleanroom/snapshots/golden":                    true,
+		},
+	}
+	driver, err := NewZFSDriver(ZFSDriverOptions{
+		DatasetRoot: "tank/cleanroom",
+		Runner:      runner,
+	})
+	if err != nil {
+		t.Fatalf("NewZFSDriver returned error: %v", err)
+	}
+
+	datasets, err := driver.ListZFSImportDatasets(context.Background())
+	if err != nil {
+		t.Fatalf("ListZFSImportDatasets returned error: %v", err)
+	}
+	want := []string{
+		"tank/cleanroom/snapshots/imports/imported-a",
+		"tank/cleanroom/snapshots/imports/imported-b",
+	}
+	if strings.Join(datasets, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("unexpected import datasets:\n got: %v\nwant: %v", datasets, want)
+	}
+
+	wantCommands := []string{
+		"zfs list -H -d 1 -o name tank/cleanroom/snapshots/imports",
+	}
+	if got := runner.commands; strings.Join(got, "\n") != strings.Join(wantCommands, "\n") {
+		t.Fatalf("unexpected zfs commands:\n got: %v\nwant: %v", got, wantCommands)
+	}
+}
+
+func TestZFSDriverDestroyImportDatasetRejectsNamespaceAndNestedDatasets(t *testing.T) {
+	runner := &zfsTestRunner{exists: map[string]bool{
+		"tank/cleanroom/snapshots/imports/imported": true,
+	}}
+	driver, err := NewZFSDriver(ZFSDriverOptions{
+		DatasetRoot: "tank/cleanroom",
+		Runner:      runner,
+	})
+	if err != nil {
+		t.Fatalf("NewZFSDriver returned error: %v", err)
+	}
+
+	for _, dataset := range []string{
+		"tank/cleanroom/snapshots/imports",
+		"tank/cleanroom/snapshots/imports/imported/nested",
+		"tank/cleanroom/snapshots/golden",
+	} {
+		if err := driver.DestroyZFSImportDataset(context.Background(), dataset); err == nil {
+			t.Fatalf("expected DestroyZFSImportDataset to reject %q", dataset)
+		}
+	}
+	if err := driver.DestroyZFSImportDataset(context.Background(), "tank/cleanroom/snapshots/imports/imported"); err != nil {
+		t.Fatalf("DestroyZFSImportDataset returned error: %v", err)
+	}
+
+	wantCommands := []string{
+		"zfs destroy -r tank/cleanroom/snapshots/imports/imported",
+	}
+	if got := runner.commands; strings.Join(got, "\n") != strings.Join(wantCommands, "\n") {
+		t.Fatalf("unexpected zfs commands:\n got: %v\nwant: %v", got, wantCommands)
+	}
 }
 
 func TestZFSDriverEnsureBaseVolumeAndCloneLifecycle(t *testing.T) {

--- a/scripts/cleanroom-root-helper.sh
+++ b/scripts/cleanroom-root-helper.sh
@@ -165,6 +165,23 @@ is_cleanroom_zfs_snapshot_import_dataset() {
   return 1
 }
 
+is_cleanroom_zfs_snapshot_import_namespace_dataset() {
+  local v="$1"
+  is_cleanroom_zfs_dataset "$v" || return 1
+
+  local IFS='/'
+  read -r -a components <<<"$v"
+  local component_count="${#components[@]}"
+  local i
+
+  for ((i = 0; i <= component_count - 3; i++)); do
+    if [[ "${components[$i]}" == "cleanroom" && "${components[$((i + 1))]}" == "snapshots" && "${components[$((i + 2))]}" == "imports" && $((component_count - i)) -eq 3 ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
 is_zvol_device_path() {
   local p="$1"
   [[ "$p" == /dev/zvol/* ]] || return 1
@@ -431,6 +448,11 @@ run_zfs() {
 
   if [[ "$#" -eq 7 && "$1" == "list" && "$2" == "-H" && "$3" == "-d" && "$4" == "0" && "$5" == "-o" && "$6" == "name" ]]; then
     is_cleanroom_zfs_dataset "$7" || die "zfs list -d 0: unsupported dataset '$7'"
+    exec "$bin" "$@"
+  fi
+
+  if [[ "$#" -eq 7 && "$1" == "list" && "$2" == "-H" && "$3" == "-d" && "$4" == "1" && "$5" == "-o" && "$6" == "name" ]]; then
+    is_cleanroom_zfs_snapshot_import_namespace_dataset "$7" || die "zfs list -d 1: unsupported dataset '$7'"
     exec "$bin" "$@"
   fi
 

--- a/scripts/root_helper_test.go
+++ b/scripts/root_helper_test.go
@@ -35,6 +35,7 @@ func TestCleanroomRootHelperDeclaresCapabilitiesAndZFSSupport(t *testing.T) {
 		"is_cleanroom_zfs_snapshot_ref()",
 		"is_cleanroom_zfs_stored_snapshot_ref()",
 		"is_cleanroom_zfs_snapshot_import_dataset()",
+		"is_cleanroom_zfs_snapshot_import_namespace_dataset()",
 		"is_zvol_device_path()",
 		"run_zfs()",
 		"zfs get: unsupported ref",
@@ -44,6 +45,7 @@ func TestCleanroomRootHelperDeclaresCapabilitiesAndZFSSupport(t *testing.T) {
 		`is_cleanroom_zfs_stored_snapshot_ref "$5"`,
 		`is_cleanroom_zfs_stored_snapshot_ref "$4"`,
 		`is_cleanroom_zfs_snapshot_import_dataset "$4"`,
+		`is_cleanroom_zfs_snapshot_import_namespace_dataset "$7"`,
 		"zfs set: unsupported dataset",
 		"zfs promote: unsupported dataset",
 		"run_dd()",
@@ -85,6 +87,11 @@ is_cleanroom_zfs_snapshot_import_dataset tank/cleanroom/snapshots/imports/import
 ! is_cleanroom_zfs_snapshot_import_dataset tank/cleanroom/base/imported
 ! is_cleanroom_zfs_snapshot_import_dataset tank/cleanroom/sandboxes/imported
 ! is_cleanroom_zfs_snapshot_import_dataset tank/cleanroom/snapshots/imports/imported/nested
+
+is_cleanroom_zfs_snapshot_import_namespace_dataset tank/cleanroom/snapshots/imports
+! is_cleanroom_zfs_snapshot_import_namespace_dataset tank/cleanroom/snapshots/imports/imported
+! is_cleanroom_zfs_snapshot_import_namespace_dataset tank/cleanroom/snapshots/imports/imported/nested
+! is_cleanroom_zfs_snapshot_import_namespace_dataset tank/cleanroom/snapshots
 `
 	cmd := exec.Command("bash", "-c", checks)
 	if out, err := cmd.CombinedOutput(); err != nil {


### PR DESCRIPTION
## Summary

- Extend `storagegc` so Firecracker/ZFS import datasets are inventoried, protected by snapshot/cache metadata, and pruned only when unreferenced.
- Wire the Firecracker ZFS import dataset store into `system df`, `system prune`, and daemon startup cleanup via the existing bounded storage cleanup worker.
- Keep the privileged helper allowlist narrow by only permitting import-namespace `zfs list` and direct import-dataset destruction paths, and update the storage/ZFS plans to reflect the landed first slice.

## Validation

- `bash -n scripts/cleanroom-root-helper.sh`
- `mise run lint-shell`
- `mise exec -- go test ./internal/storagegc ./internal/volumestore ./internal/backend/firecracker ./internal/controlservice ./internal/cli ./scripts`
- `mise exec -- go test ./...`
- `git diff --check`