### PR TITLE
feat: Mount Firecracker cache output volumes

### DIFF
--- a/cmd/cleanroom-guest-agent/cache_output_mounts.go
+++ b/cmd/cleanroom-guest-agent/cache_output_mounts.go
@@ -30,6 +30,8 @@ type cacheOutputMountAction struct {
 	Kind            cacheOutputMountActionKind
 	Source          string
 	Target          string
+	VolumeRoot      string
+	VolumeSubpath   string
 	FSType          string
 	Flags           uintptr
 	Data            string
@@ -110,19 +112,19 @@ func cacheOutputMountActions(mounts []vsockexec.CacheOutputMount) ([]cacheOutput
 		)
 
 		for j, mapping := range mount.DirMappings {
-			guestPath, sourcePath, err := cacheOutputMappingPaths(mountPath, mapping.GuestPath, mapping.Subpath)
+			guestPath, sourcePath, cleanSubpath, err := cacheOutputMappingPaths(mountPath, mapping.GuestPath, mapping.Subpath)
 			if err != nil {
 				return nil, fmt.Errorf("cache output mount %d dir mapping %d: %w", i, j, err)
 			}
 			actions = append(actions,
-				cacheOutputMountAction{Kind: cacheOutputActionMkdir, Target: sourcePath, Mode: 0o755, RequireExisting: mount.SourcePresent},
+				cacheOutputMountAction{Kind: cacheOutputActionMkdir, Source: sourcePath, VolumeRoot: mountPath, VolumeSubpath: cleanSubpath, Mode: 0o755, RequireExisting: mount.SourcePresent},
 				cacheOutputMountAction{Kind: cacheOutputActionMkdir, Target: guestPath, Mode: 0o755, RequireEmpty: true},
-				cacheOutputMountAction{Kind: cacheOutputActionBind, Source: sourcePath, Target: guestPath, Flags: unix.MS_BIND},
+				cacheOutputMountAction{Kind: cacheOutputActionBind, Source: sourcePath, Target: guestPath, VolumeRoot: mountPath, VolumeSubpath: cleanSubpath, Flags: unix.MS_BIND},
 			)
 		}
 
 		for j, mapping := range mount.FileMappings {
-			guestPath, sourcePath, err := cacheOutputMappingPaths(mountPath, mapping.GuestPath, mapping.Subpath)
+			guestPath, sourcePath, cleanSubpath, err := cacheOutputMappingPaths(mountPath, mapping.GuestPath, mapping.Subpath)
 			if err != nil {
 				return nil, fmt.Errorf("cache output mount %d file mapping %d: %w", i, j, err)
 			}
@@ -133,11 +135,13 @@ func cacheOutputMountActions(mounts []vsockexec.CacheOutputMount) ([]cacheOutput
 			actions = append(actions,
 				cacheOutputMountAction{Kind: cacheOutputActionMkdir, Target: filepath.Dir(guestPath), Mode: 0o755},
 				cacheOutputMountAction{
-					Kind:     cacheOutputActionRestoreFile,
-					Source:   sourcePath,
-					Target:   guestPath,
-					Mode:     mode,
-					Required: mount.SourcePresent,
+					Kind:          cacheOutputActionRestoreFile,
+					Source:        sourcePath,
+					Target:        guestPath,
+					VolumeRoot:    mountPath,
+					VolumeSubpath: cleanSubpath,
+					Mode:          mode,
+					Required:      mount.SourcePresent,
 				},
 			)
 		}
@@ -145,16 +149,16 @@ func cacheOutputMountActions(mounts []vsockexec.CacheOutputMount) ([]cacheOutput
 	return actions, nil
 }
 
-func cacheOutputMappingPaths(mountPath, guestPath, subpath string) (string, string, error) {
+func cacheOutputMappingPaths(mountPath, guestPath, subpath string) (string, string, string, error) {
 	cleanGuestPath, err := cleanAbsoluteCacheOutputPath("guest path", guestPath)
 	if err != nil {
-		return "", "", err
+		return "", "", "", err
 	}
 	cleanSubpath, err := cleanCacheOutputSubpath(subpath)
 	if err != nil {
-		return "", "", err
+		return "", "", "", err
 	}
-	return cleanGuestPath, filepath.Join(mountPath, cleanSubpath), nil
+	return cleanGuestPath, filepath.Join(mountPath, cleanSubpath), cleanSubpath, nil
 }
 
 func cleanAbsoluteCacheOutputPath(name, value string) (string, error) {
@@ -184,23 +188,165 @@ func cleanCacheOutputSubpath(value string) (string, error) {
 func executeCacheOutputMountAction(action cacheOutputMountAction) error {
 	switch action.Kind {
 	case cacheOutputActionMkdir:
-		if err := ensureCacheOutputDir(action.Target, action.Mode, action.RequireExisting, action.RequireEmpty); err != nil {
+		if action.VolumeRoot != "" {
+			_, err := ensureCacheOutputVolumeDir(action.VolumeRoot, action.VolumeSubpath, action.Mode, action.RequireExisting)
 			return err
 		}
+		return ensureCacheOutputDir(action.Target, action.Mode, action.RequireExisting, action.RequireEmpty)
 	case cacheOutputActionMount:
 		if err := unix.Mount(action.Source, action.Target, action.FSType, action.Flags, action.Data); err != nil && err != unix.EBUSY {
 			return fmt.Errorf("mount cache output volume %s at %s: %w", action.Source, action.Target, err)
 		}
 	case cacheOutputActionBind:
-		if err := unix.Mount(action.Source, action.Target, "", action.Flags, ""); err != nil && err != unix.EBUSY {
-			return fmt.Errorf("bind cache output path %s at %s: %w", action.Source, action.Target, err)
+		sourcePath := action.Source
+		if action.VolumeRoot != "" {
+			resolved, err := ensureCacheOutputVolumeDir(action.VolumeRoot, action.VolumeSubpath, 0, true)
+			if err != nil {
+				return err
+			}
+			sourcePath = resolved
+		}
+		if err := unix.Mount(sourcePath, action.Target, "", action.Flags, ""); err != nil && err != unix.EBUSY {
+			return fmt.Errorf("bind cache output path %s at %s: %w", sourcePath, action.Target, err)
 		}
 	case cacheOutputActionRestoreFile:
+		if action.VolumeRoot != "" {
+			source, sourcePath, err := openCacheOutputVolumeFile(action.VolumeRoot, action.VolumeSubpath, action.Required)
+			if err != nil {
+				return err
+			}
+			if source == nil {
+				return nil
+			}
+			defer source.Close()
+			return restoreCacheOutputFileFrom(source, sourcePath, action.Target, action.Mode)
+		}
 		if err := restoreCacheOutputFile(action.Source, action.Target, action.Mode, action.Required); err != nil {
 			return err
 		}
 	default:
 		return fmt.Errorf("unknown cache output mount action %q", action.Kind)
+	}
+	return nil
+}
+
+func ensureCacheOutputVolumeDir(root, subpath string, mode fs.FileMode, requireExisting bool) (string, error) {
+	root, err := cleanAbsoluteCacheOutputPath("volume root", root)
+	if err != nil {
+		return "", err
+	}
+	cleanSubpath, err := cleanCacheOutputSubpath(subpath)
+	if err != nil {
+		return "", err
+	}
+	if mode == 0 {
+		mode = 0o755
+	}
+	if err := requireCacheOutputDirNoSymlink(root); err != nil {
+		return "", err
+	}
+	current := root
+	for _, part := range strings.Split(cleanSubpath, string(filepath.Separator)) {
+		current = filepath.Join(current, part)
+		info, err := os.Lstat(current)
+		if err == nil {
+			if info.Mode()&os.ModeSymlink != 0 {
+				return "", fmt.Errorf("cache output path %s is a symlink", current)
+			}
+			if !info.IsDir() {
+				return "", fmt.Errorf("cache output path %s is not a directory", current)
+			}
+			continue
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf("stat cache output path %s: %w", current, err)
+		}
+		if requireExisting {
+			return "", fmt.Errorf("cache output directory %s does not exist", current)
+		}
+		if err := os.Mkdir(current, mode.Perm()); err != nil {
+			if errors.Is(err, os.ErrExist) {
+				info, statErr := os.Lstat(current)
+				if statErr != nil {
+					return "", fmt.Errorf("stat cache output path %s: %w", current, statErr)
+				}
+				if info.Mode()&os.ModeSymlink != 0 {
+					return "", fmt.Errorf("cache output path %s is a symlink", current)
+				}
+				if !info.IsDir() {
+					return "", fmt.Errorf("cache output path %s is not a directory", current)
+				}
+				continue
+			}
+			return "", fmt.Errorf("create cache output directory %s: %w", current, err)
+		}
+	}
+	return current, nil
+}
+
+func openCacheOutputVolumeFile(root, subpath string, required bool) (*os.File, string, error) {
+	root, err := cleanAbsoluteCacheOutputPath("volume root", root)
+	if err != nil {
+		return nil, "", err
+	}
+	cleanSubpath, err := cleanCacheOutputSubpath(subpath)
+	if err != nil {
+		return nil, "", err
+	}
+	if err := requireCacheOutputDirNoSymlink(root); err != nil {
+		return nil, "", err
+	}
+
+	parts := strings.Split(cleanSubpath, string(filepath.Separator))
+	parent := root
+	for _, part := range parts[:len(parts)-1] {
+		parent = filepath.Join(parent, part)
+		info, err := os.Lstat(parent)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) && !required {
+				return nil, filepath.Join(root, cleanSubpath), nil
+			}
+			return nil, "", fmt.Errorf("stat cache output path %s: %w", parent, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return nil, "", fmt.Errorf("cache output path %s is a symlink", parent)
+		}
+		if !info.IsDir() {
+			return nil, "", fmt.Errorf("cache output path %s is not a directory", parent)
+		}
+	}
+
+	sourcePath := filepath.Join(parent, parts[len(parts)-1])
+	info, err := os.Lstat(sourcePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) && !required {
+			return nil, sourcePath, nil
+		}
+		return nil, "", fmt.Errorf("stat cache output file %s: %w", sourcePath, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, "", fmt.Errorf("cache output file %s is a symlink", sourcePath)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, "", fmt.Errorf("cache output file %s is not a regular file", sourcePath)
+	}
+	fd, err := unix.Open(sourcePath, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, "", fmt.Errorf("open cache output file %s: %w", sourcePath, err)
+	}
+	return os.NewFile(uintptr(fd), sourcePath), sourcePath, nil
+}
+
+func requireCacheOutputDirNoSymlink(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return fmt.Errorf("stat cache output path %s: %w", path, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("cache output path %s is a symlink", path)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("cache output path %s is not a directory", path)
 	}
 	return nil
 }
@@ -257,7 +403,10 @@ func restoreCacheOutputFile(sourcePath, targetPath string, mode fs.FileMode, req
 		return fmt.Errorf("open cache output file %s: %w", sourcePath, err)
 	}
 	defer source.Close()
+	return restoreCacheOutputFileFrom(source, sourcePath, targetPath, mode)
+}
 
+func restoreCacheOutputFileFrom(source *os.File, sourcePath, targetPath string, mode fs.FileMode) error {
 	info, err := source.Stat()
 	if err != nil {
 		return fmt.Errorf("stat cache output file %s: %w", sourcePath, err)
@@ -273,33 +422,46 @@ func restoreCacheOutputFile(sourcePath, targetPath string, mode fs.FileMode, req
 		mode = 0o644
 	}
 
+	targetDir := filepath.Dir(targetPath)
+	if err := ensureCacheOutputDir(targetDir, 0o755, true, false); err != nil {
+		return err
+	}
 	if targetInfo, err := os.Lstat(targetPath); err == nil {
 		if targetInfo.IsDir() {
 			return fmt.Errorf("cache output file target %s is a directory", targetPath)
-		}
-		if err := os.Remove(targetPath); err != nil {
-			return fmt.Errorf("replace cache output file target %s: %w", targetPath, err)
 		}
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("stat cache output file target %s: %w", targetPath, err)
 	}
 
-	target, err := os.OpenFile(targetPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, mode.Perm())
+	target, err := os.CreateTemp(targetDir, "."+filepath.Base(targetPath)+".cleanroom-cache-*")
 	if err != nil {
-		return fmt.Errorf("create cache output file target %s: %w", targetPath, err)
+		return fmt.Errorf("create temporary cache output file target for %s: %w", targetPath, err)
 	}
+	tmpPath := target.Name()
 	_, copyErr := io.Copy(target, source)
+	chmodErr := target.Chmod(mode.Perm())
+	syncErr := target.Sync()
 	closeErr := target.Close()
 	if copyErr != nil {
-		_ = os.Remove(targetPath)
+		_ = os.Remove(tmpPath)
 		return fmt.Errorf("restore cache output file %s to %s: %w", sourcePath, targetPath, copyErr)
 	}
-	if closeErr != nil {
-		_ = os.Remove(targetPath)
-		return fmt.Errorf("close cache output file target %s: %w", targetPath, closeErr)
+	if chmodErr != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("chmod temporary cache output file target %s: %w", tmpPath, chmodErr)
 	}
-	if err := os.Chmod(targetPath, mode.Perm()); err != nil {
-		return fmt.Errorf("chmod cache output file target %s: %w", targetPath, err)
+	if syncErr != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("sync temporary cache output file target %s: %w", tmpPath, syncErr)
+	}
+	if closeErr != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("close temporary cache output file target %s: %w", tmpPath, closeErr)
+	}
+	if err := os.Rename(tmpPath, targetPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("replace cache output file target %s: %w", targetPath, err)
 	}
 	return nil
 }

--- a/cmd/cleanroom-guest-agent/cache_output_mounts.go
+++ b/cmd/cleanroom-guest-agent/cache_output_mounts.go
@@ -1,0 +1,305 @@
+//go:build linux
+
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/buildkite/cleanroom/internal/vsockexec"
+	"golang.org/x/sys/unix"
+)
+
+type cacheOutputMountActionKind string
+
+const (
+	cacheOutputActionMkdir       cacheOutputMountActionKind = "mkdir"
+	cacheOutputActionMount       cacheOutputMountActionKind = "mount"
+	cacheOutputActionBind        cacheOutputMountActionKind = "bind"
+	cacheOutputActionRestoreFile cacheOutputMountActionKind = "restore-file"
+)
+
+type cacheOutputMountAction struct {
+	Kind            cacheOutputMountActionKind
+	Source          string
+	Target          string
+	FSType          string
+	Flags           uintptr
+	Data            string
+	Mode            fs.FileMode
+	RequireExisting bool
+	RequireEmpty    bool
+	Required        bool
+}
+
+var cacheOutputMountState struct {
+	sync.Mutex
+	signature string
+}
+
+func setupCacheOutputMountsOnce(mounts []vsockexec.CacheOutputMount) error {
+	if len(mounts) == 0 {
+		return nil
+	}
+	signature, err := cacheOutputMountSignature(mounts)
+	if err != nil {
+		return err
+	}
+
+	cacheOutputMountState.Lock()
+	defer cacheOutputMountState.Unlock()
+	if cacheOutputMountState.signature == signature {
+		return nil
+	}
+	if cacheOutputMountState.signature != "" {
+		return errors.New("cache output mount plan changed after setup")
+	}
+	if err := setupCacheOutputMounts(mounts); err != nil {
+		return err
+	}
+	cacheOutputMountState.signature = signature
+	return nil
+}
+
+func cacheOutputMountSignature(mounts []vsockexec.CacheOutputMount) (string, error) {
+	data, err := json.Marshal(mounts)
+	if err != nil {
+		return "", fmt.Errorf("encode cache output mount plan: %w", err)
+	}
+	return string(data), nil
+}
+
+func setupCacheOutputMounts(mounts []vsockexec.CacheOutputMount) error {
+	actions, err := cacheOutputMountActions(mounts)
+	if err != nil {
+		return err
+	}
+	for _, action := range actions {
+		if err := executeCacheOutputMountAction(action); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func cacheOutputMountActions(mounts []vsockexec.CacheOutputMount) ([]cacheOutputMountAction, error) {
+	actions := make([]cacheOutputMountAction, 0, len(mounts)*3)
+	for i, mount := range mounts {
+		devicePath, err := cleanAbsoluteCacheOutputPath("device path", mount.DevicePath)
+		if err != nil {
+			return nil, fmt.Errorf("cache output mount %d: %w", i, err)
+		}
+		mountPath, err := cleanAbsoluteCacheOutputPath("mount path", mount.MountPath)
+		if err != nil {
+			return nil, fmt.Errorf("cache output mount %d: %w", i, err)
+		}
+		if len(mount.DirMappings) == 0 && len(mount.FileMappings) == 0 {
+			return nil, fmt.Errorf("cache output mount %d: missing output mappings", i)
+		}
+
+		actions = append(actions,
+			cacheOutputMountAction{Kind: cacheOutputActionMkdir, Target: mountPath, Mode: 0o755},
+			cacheOutputMountAction{Kind: cacheOutputActionMount, Source: devicePath, Target: mountPath, FSType: "ext4"},
+		)
+
+		for j, mapping := range mount.DirMappings {
+			guestPath, sourcePath, err := cacheOutputMappingPaths(mountPath, mapping.GuestPath, mapping.Subpath)
+			if err != nil {
+				return nil, fmt.Errorf("cache output mount %d dir mapping %d: %w", i, j, err)
+			}
+			actions = append(actions,
+				cacheOutputMountAction{Kind: cacheOutputActionMkdir, Target: sourcePath, Mode: 0o755, RequireExisting: mount.SourcePresent},
+				cacheOutputMountAction{Kind: cacheOutputActionMkdir, Target: guestPath, Mode: 0o755, RequireEmpty: true},
+				cacheOutputMountAction{Kind: cacheOutputActionBind, Source: sourcePath, Target: guestPath, Flags: unix.MS_BIND},
+			)
+		}
+
+		for j, mapping := range mount.FileMappings {
+			guestPath, sourcePath, err := cacheOutputMappingPaths(mountPath, mapping.GuestPath, mapping.Subpath)
+			if err != nil {
+				return nil, fmt.Errorf("cache output mount %d file mapping %d: %w", i, j, err)
+			}
+			mode := fs.FileMode(mapping.Mode).Perm()
+			if mode == 0 {
+				mode = 0o644
+			}
+			actions = append(actions,
+				cacheOutputMountAction{Kind: cacheOutputActionMkdir, Target: filepath.Dir(guestPath), Mode: 0o755},
+				cacheOutputMountAction{
+					Kind:     cacheOutputActionRestoreFile,
+					Source:   sourcePath,
+					Target:   guestPath,
+					Mode:     mode,
+					Required: mount.SourcePresent,
+				},
+			)
+		}
+	}
+	return actions, nil
+}
+
+func cacheOutputMappingPaths(mountPath, guestPath, subpath string) (string, string, error) {
+	cleanGuestPath, err := cleanAbsoluteCacheOutputPath("guest path", guestPath)
+	if err != nil {
+		return "", "", err
+	}
+	cleanSubpath, err := cleanCacheOutputSubpath(subpath)
+	if err != nil {
+		return "", "", err
+	}
+	return cleanGuestPath, filepath.Join(mountPath, cleanSubpath), nil
+}
+
+func cleanAbsoluteCacheOutputPath(name, value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", fmt.Errorf("missing %s", name)
+	}
+	cleaned := filepath.Clean(value)
+	if !filepath.IsAbs(cleaned) {
+		return "", fmt.Errorf("%s %q is not absolute", name, value)
+	}
+	return cleaned, nil
+}
+
+func cleanCacheOutputSubpath(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", errors.New("missing volume subpath")
+	}
+	cleaned := filepath.Clean(value)
+	if filepath.IsAbs(cleaned) || cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return "", fmt.Errorf("volume subpath %q escapes output volume", value)
+	}
+	return cleaned, nil
+}
+
+func executeCacheOutputMountAction(action cacheOutputMountAction) error {
+	switch action.Kind {
+	case cacheOutputActionMkdir:
+		if err := ensureCacheOutputDir(action.Target, action.Mode, action.RequireExisting, action.RequireEmpty); err != nil {
+			return err
+		}
+	case cacheOutputActionMount:
+		if err := unix.Mount(action.Source, action.Target, action.FSType, action.Flags, action.Data); err != nil && err != unix.EBUSY {
+			return fmt.Errorf("mount cache output volume %s at %s: %w", action.Source, action.Target, err)
+		}
+	case cacheOutputActionBind:
+		if err := unix.Mount(action.Source, action.Target, "", action.Flags, ""); err != nil && err != unix.EBUSY {
+			return fmt.Errorf("bind cache output path %s at %s: %w", action.Source, action.Target, err)
+		}
+	case cacheOutputActionRestoreFile:
+		if err := restoreCacheOutputFile(action.Source, action.Target, action.Mode, action.Required); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unknown cache output mount action %q", action.Kind)
+	}
+	return nil
+}
+
+func ensureCacheOutputDir(path string, mode fs.FileMode, requireExisting, requireEmpty bool) error {
+	if mode == 0 {
+		mode = 0o755
+	}
+	info, err := os.Lstat(path)
+	if err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("cache output path %s is a symlink", path)
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("cache output path %s is not a directory", path)
+		}
+		if requireEmpty {
+			empty, err := isEmptyCacheOutputDir(path)
+			if err != nil {
+				return err
+			}
+			if !empty {
+				return fmt.Errorf("cache output directory %s is not empty", path)
+			}
+		}
+		return nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("stat cache output path %s: %w", path, err)
+	}
+	if requireExisting {
+		return fmt.Errorf("cache output directory %s does not exist", path)
+	}
+	if err := os.MkdirAll(path, mode.Perm()); err != nil {
+		return fmt.Errorf("create cache output directory %s: %w", path, err)
+	}
+	return nil
+}
+
+func isEmptyCacheOutputDir(path string) (bool, error) {
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return false, fmt.Errorf("read cache output directory %s: %w", path, err)
+	}
+	return len(entries) == 0, nil
+}
+
+func restoreCacheOutputFile(sourcePath, targetPath string, mode fs.FileMode, required bool) error {
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) && !required {
+			return nil
+		}
+		return fmt.Errorf("open cache output file %s: %w", sourcePath, err)
+	}
+	defer source.Close()
+
+	info, err := source.Stat()
+	if err != nil {
+		return fmt.Errorf("stat cache output file %s: %w", sourcePath, err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("cache output file %s is not a regular file", sourcePath)
+	}
+
+	if mode == 0 {
+		mode = info.Mode().Perm()
+	}
+	if mode == 0 {
+		mode = 0o644
+	}
+
+	if targetInfo, err := os.Lstat(targetPath); err == nil {
+		if targetInfo.IsDir() {
+			return fmt.Errorf("cache output file target %s is a directory", targetPath)
+		}
+		if err := os.Remove(targetPath); err != nil {
+			return fmt.Errorf("replace cache output file target %s: %w", targetPath, err)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("stat cache output file target %s: %w", targetPath, err)
+	}
+
+	target, err := os.OpenFile(targetPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, mode.Perm())
+	if err != nil {
+		return fmt.Errorf("create cache output file target %s: %w", targetPath, err)
+	}
+	_, copyErr := io.Copy(target, source)
+	closeErr := target.Close()
+	if copyErr != nil {
+		_ = os.Remove(targetPath)
+		return fmt.Errorf("restore cache output file %s to %s: %w", sourcePath, targetPath, copyErr)
+	}
+	if closeErr != nil {
+		_ = os.Remove(targetPath)
+		return fmt.Errorf("close cache output file target %s: %w", targetPath, closeErr)
+	}
+	if err := os.Chmod(targetPath, mode.Perm()); err != nil {
+		return fmt.Errorf("chmod cache output file target %s: %w", targetPath, err)
+	}
+	return nil
+}

--- a/cmd/cleanroom-guest-agent/cache_output_mounts.go
+++ b/cmd/cleanroom-guest-agent/cache_output_mounts.go
@@ -128,10 +128,6 @@ func cacheOutputMountActions(mounts []vsockexec.CacheOutputMount) ([]cacheOutput
 			if err != nil {
 				return nil, fmt.Errorf("cache output mount %d file mapping %d: %w", i, j, err)
 			}
-			mode := fs.FileMode(mapping.Mode).Perm()
-			if mode == 0 {
-				mode = 0o644
-			}
 			actions = append(actions,
 				cacheOutputMountAction{Kind: cacheOutputActionMkdir, Target: filepath.Dir(guestPath), Mode: 0o755},
 				cacheOutputMountAction{
@@ -140,7 +136,7 @@ func cacheOutputMountActions(mounts []vsockexec.CacheOutputMount) ([]cacheOutput
 					Target:        guestPath,
 					VolumeRoot:    mountPath,
 					VolumeSubpath: cleanSubpath,
-					Mode:          mode,
+					Mode:          fs.FileMode(mapping.Mode).Perm(),
 					Required:      mount.SourcePresent,
 				},
 			)

--- a/cmd/cleanroom-guest-agent/cache_output_mounts_test.go
+++ b/cmd/cleanroom-guest-agent/cache_output_mounts_test.go
@@ -1,0 +1,166 @@
+//go:build linux
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/vsockexec"
+	"golang.org/x/sys/unix"
+)
+
+func TestCacheOutputMountActionsMapsDirsAndRestoresFiles(t *testing.T) {
+	t.Parallel()
+
+	actions, err := cacheOutputMountActions([]vsockexec.CacheOutputMount{
+		{
+			DevicePath:    "/dev/vdb",
+			MountPath:     "/run/cleanroom/cache-output-volumes/cacheout0",
+			SourcePresent: true,
+			DirMappings: []vsockexec.CacheOutputDirMount{
+				{GuestPath: "/root/.local/share/mise", Subpath: "dirs/0"},
+			},
+			FileMappings: []vsockexec.CacheOutputFileMount{
+				{GuestPath: "/root/.config/mise/config.toml", Subpath: "files/0", Mode: 0o600},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("cacheOutputMountActions returned error: %v", err)
+	}
+
+	want := []cacheOutputMountAction{
+		{Kind: cacheOutputActionMkdir, Target: "/run/cleanroom/cache-output-volumes/cacheout0", Mode: 0o755},
+		{Kind: cacheOutputActionMount, Source: "/dev/vdb", Target: "/run/cleanroom/cache-output-volumes/cacheout0", FSType: "ext4"},
+		{Kind: cacheOutputActionMkdir, Target: "/run/cleanroom/cache-output-volumes/cacheout0/dirs/0", Mode: 0o755, RequireExisting: true},
+		{Kind: cacheOutputActionMkdir, Target: "/root/.local/share/mise", Mode: 0o755, RequireEmpty: true},
+		{Kind: cacheOutputActionBind, Source: "/run/cleanroom/cache-output-volumes/cacheout0/dirs/0", Target: "/root/.local/share/mise", Flags: unix.MS_BIND},
+		{Kind: cacheOutputActionMkdir, Target: "/root/.config/mise", Mode: 0o755},
+		{Kind: cacheOutputActionRestoreFile, Source: "/run/cleanroom/cache-output-volumes/cacheout0/files/0", Target: "/root/.config/mise/config.toml", Mode: 0o600, Required: true},
+	}
+	if !reflect.DeepEqual(actions, want) {
+		t.Fatalf("unexpected actions:\n got %#v\nwant %#v", actions, want)
+	}
+}
+
+func TestEnsureCacheOutputDirRejectsNonEmptyMountpoint(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "existing"), []byte("image content"), 0o644); err != nil {
+		t.Fatalf("write existing file: %v", err)
+	}
+
+	err := ensureCacheOutputDir(dir, 0o755, false, true)
+	if err == nil {
+		t.Fatal("expected non-empty directory to fail")
+	}
+	if !strings.Contains(err.Error(), "not empty") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestEnsureCacheOutputDirRequiresExistingHitSource(t *testing.T) {
+	t.Parallel()
+
+	err := ensureCacheOutputDir(filepath.Join(t.TempDir(), "missing"), 0o755, true, false)
+	if err == nil {
+		t.Fatal("expected missing hit source directory to fail")
+	}
+	if !strings.Contains(err.Error(), "does not exist") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCacheOutputMountActionsRejectsEscapingSubpath(t *testing.T) {
+	t.Parallel()
+
+	_, err := cacheOutputMountActions([]vsockexec.CacheOutputMount{
+		{
+			DevicePath: "/dev/vdb",
+			MountPath:  "/run/cleanroom/cache-output-volumes/cacheout0",
+			DirMappings: []vsockexec.CacheOutputDirMount{
+				{GuestPath: "/root/.local/share/mise", Subpath: "../escape"},
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected escaping subpath to fail")
+	}
+	if !strings.Contains(err.Error(), "escapes output volume") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRestoreCacheOutputFileCopiesHitAndSkipsMissingMiss(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "volume", "files", "0")
+	targetPath := filepath.Join(dir, "root", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o755); err != nil {
+		t.Fatalf("create source dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		t.Fatalf("create target dir: %v", err)
+	}
+	if err := os.WriteFile(sourcePath, []byte("restored"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	if err := restoreCacheOutputFile(sourcePath, targetPath, 0, true); err != nil {
+		t.Fatalf("restoreCacheOutputFile returned error: %v", err)
+	}
+	data, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if got, want := string(data), "restored"; got != want {
+		t.Fatalf("unexpected restored file content: got %q want %q", got, want)
+	}
+	if info, err := os.Stat(targetPath); err != nil {
+		t.Fatalf("stat target: %v", err)
+	} else if got, want := info.Mode().Perm(), os.FileMode(0o600); got != want {
+		t.Fatalf("unexpected restored file mode: got %v want %v", got, want)
+	}
+
+	missingTarget := filepath.Join(dir, "root", "missing.toml")
+	if err := restoreCacheOutputFile(filepath.Join(dir, "volume", "files", "missing"), missingTarget, 0, false); err != nil {
+		t.Fatalf("restore missing non-required file returned error: %v", err)
+	}
+	if _, err := os.Stat(missingTarget); !os.IsNotExist(err) {
+		t.Fatalf("expected missing non-required file not to be created, got err=%v", err)
+	}
+}
+
+func TestSetupCacheOutputMountsOnceRejectsChangedPlan(t *testing.T) {
+	cacheOutputMountState.Lock()
+	previousSignature := cacheOutputMountState.signature
+	cacheOutputMountState.signature = "first"
+	cacheOutputMountState.Unlock()
+	t.Cleanup(func() {
+		cacheOutputMountState.Lock()
+		cacheOutputMountState.signature = previousSignature
+		cacheOutputMountState.Unlock()
+	})
+
+	err := setupCacheOutputMountsOnce([]vsockexec.CacheOutputMount{
+		{
+			DevicePath: "/dev/vdb",
+			MountPath:  "/run/cleanroom/cache-output-volumes/cacheout0",
+			DirMappings: []vsockexec.CacheOutputDirMount{
+				{GuestPath: "/root/.local/share/mise", Subpath: "dirs/0"},
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected changed mount plan to fail")
+	}
+	if !strings.Contains(err.Error(), "mount plan changed") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/cmd/cleanroom-guest-agent/cache_output_mounts_test.go
+++ b/cmd/cleanroom-guest-agent/cache_output_mounts_test.go
@@ -47,6 +47,30 @@ func TestCacheOutputMountActionsMapsDirsAndRestoresFiles(t *testing.T) {
 	}
 }
 
+func TestCacheOutputMountActionsLeavesUnspecifiedFileModeUnset(t *testing.T) {
+	t.Parallel()
+
+	actions, err := cacheOutputMountActions([]vsockexec.CacheOutputMount{
+		{
+			DevicePath:    "/dev/vdb",
+			MountPath:     "/run/cleanroom/cache-output-volumes/cacheout0",
+			SourcePresent: true,
+			FileMappings: []vsockexec.CacheOutputFileMount{
+				{GuestPath: "/usr/local/bin/tool", Subpath: "files/0"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("cacheOutputMountActions returned error: %v", err)
+	}
+	if got, want := actions[len(actions)-1].Kind, cacheOutputActionRestoreFile; got != want {
+		t.Fatalf("unexpected final action kind: got %q want %q", got, want)
+	}
+	if got := actions[len(actions)-1].Mode; got != 0 {
+		t.Fatalf("unexpected restore file mode: got %v want 0", got)
+	}
+}
+
 func TestEnsureCacheOutputDirRejectsNonEmptyMountpoint(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/cleanroom-guest-agent/cache_output_mounts_test.go
+++ b/cmd/cleanroom-guest-agent/cache_output_mounts_test.go
@@ -36,11 +36,11 @@ func TestCacheOutputMountActionsMapsDirsAndRestoresFiles(t *testing.T) {
 	want := []cacheOutputMountAction{
 		{Kind: cacheOutputActionMkdir, Target: "/run/cleanroom/cache-output-volumes/cacheout0", Mode: 0o755},
 		{Kind: cacheOutputActionMount, Source: "/dev/vdb", Target: "/run/cleanroom/cache-output-volumes/cacheout0", FSType: "ext4"},
-		{Kind: cacheOutputActionMkdir, Target: "/run/cleanroom/cache-output-volumes/cacheout0/dirs/0", Mode: 0o755, RequireExisting: true},
+		{Kind: cacheOutputActionMkdir, Source: "/run/cleanroom/cache-output-volumes/cacheout0/dirs/0", VolumeRoot: "/run/cleanroom/cache-output-volumes/cacheout0", VolumeSubpath: "dirs/0", Mode: 0o755, RequireExisting: true},
 		{Kind: cacheOutputActionMkdir, Target: "/root/.local/share/mise", Mode: 0o755, RequireEmpty: true},
-		{Kind: cacheOutputActionBind, Source: "/run/cleanroom/cache-output-volumes/cacheout0/dirs/0", Target: "/root/.local/share/mise", Flags: unix.MS_BIND},
+		{Kind: cacheOutputActionBind, Source: "/run/cleanroom/cache-output-volumes/cacheout0/dirs/0", Target: "/root/.local/share/mise", VolumeRoot: "/run/cleanroom/cache-output-volumes/cacheout0", VolumeSubpath: "dirs/0", Flags: unix.MS_BIND},
 		{Kind: cacheOutputActionMkdir, Target: "/root/.config/mise", Mode: 0o755},
-		{Kind: cacheOutputActionRestoreFile, Source: "/run/cleanroom/cache-output-volumes/cacheout0/files/0", Target: "/root/.config/mise/config.toml", Mode: 0o600, Required: true},
+		{Kind: cacheOutputActionRestoreFile, Source: "/run/cleanroom/cache-output-volumes/cacheout0/files/0", Target: "/root/.config/mise/config.toml", VolumeRoot: "/run/cleanroom/cache-output-volumes/cacheout0", VolumeSubpath: "files/0", Mode: 0o600, Required: true},
 	}
 	if !reflect.DeepEqual(actions, want) {
 		t.Fatalf("unexpected actions:\n got %#v\nwant %#v", actions, want)
@@ -72,6 +72,51 @@ func TestEnsureCacheOutputDirRequiresExistingHitSource(t *testing.T) {
 		t.Fatal("expected missing hit source directory to fail")
 	}
 	if !strings.Contains(err.Error(), "does not exist") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestEnsureCacheOutputVolumeDirRejectsSymlinkParent(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(root, "dirs")); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+
+	_, err := ensureCacheOutputVolumeDir(root, "dirs/0", 0o755, false)
+	if err == nil {
+		t.Fatal("expected symlink parent to fail")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestOpenCacheOutputVolumeFileRejectsSymlinkFile(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "files"), 0o755); err != nil {
+		t.Fatalf("create files dir: %v", err)
+	}
+	outside := filepath.Join(t.TempDir(), "outside")
+	if err := os.WriteFile(outside, []byte("outside"), 0o644); err != nil {
+		t.Fatalf("write outside file: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, "files", "0")); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+
+	file, _, err := openCacheOutputVolumeFile(root, "files/0", true)
+	if file != nil {
+		_ = file.Close()
+	}
+	if err == nil {
+		t.Fatal("expected symlink file to fail")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -134,6 +179,42 @@ func TestRestoreCacheOutputFileCopiesHitAndSkipsMissingMiss(t *testing.T) {
 	}
 	if _, err := os.Stat(missingTarget); !os.IsNotExist(err) {
 		t.Fatalf("expected missing non-required file not to be created, got err=%v", err)
+	}
+}
+
+func TestRestoreCacheOutputFileReplacesExistingTarget(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "volume", "files", "0")
+	targetPath := filepath.Join(dir, "root", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o755); err != nil {
+		t.Fatalf("create source dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		t.Fatalf("create target dir: %v", err)
+	}
+	if err := os.WriteFile(sourcePath, []byte("new"), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	if err := os.WriteFile(targetPath, []byte("old"), 0o644); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+
+	if err := restoreCacheOutputFile(sourcePath, targetPath, 0o600, true); err != nil {
+		t.Fatalf("restoreCacheOutputFile returned error: %v", err)
+	}
+	data, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if got, want := string(data), "new"; got != want {
+		t.Fatalf("unexpected restored file content: got %q want %q", got, want)
+	}
+	if entries, err := os.ReadDir(filepath.Dir(targetPath)); err != nil {
+		t.Fatalf("read target dir: %v", err)
+	} else if len(entries) != 1 {
+		t.Fatalf("expected only restored target in directory, got %d entries", len(entries))
 	}
 }
 

--- a/cmd/cleanroom-guest-agent/main.go
+++ b/cmd/cleanroom-guest-agent/main.go
@@ -78,6 +78,10 @@ func handleConn(conn io.ReadWriteCloser) {
 	if len(req.EntropySeed) > 0 {
 		_ = injectEntropy(req.EntropySeed)
 	}
+	if err := setupCacheOutputMountsOnce(req.CacheOutputMounts); err != nil {
+		sendErrorResponse(conn, err)
+		return
+	}
 
 	if req.TTY {
 		handleConnTTY(conn, dec, req)

--- a/docs/plans/dependency-service-volume-caches.md
+++ b/docs/plans/dependency-service-volume-caches.md
@@ -851,12 +851,51 @@ Completed in phase 4:
 
 Remaining runtime work after phase 4:
 
-- mount output block devices in the guest at Cleanroom-managed locations
-- map declared `outputs.dirs` into the command view and restore declared
-  `outputs.files` from output volumes
 - run missed dependency and service blocks from isolated input projections
 - inspect overlay write capture results and warn/fallback on escaped writes
 - snapshot and publish output records after successful missed blocks
+- advertise `sandbox.overlay_write_capture` once escaped-write detection and
+  isolated block execution are wired through
+- decide whether output volume sizing stays internal or becomes policy-visible
+  after real workloads show the right default
+
+### Phase 5 PR Status
+
+The fifth implementation PR wires the prepared Firecracker output volumes into
+the guest execution protocol. It still keeps the block-volume runtime inactive
+because Firecracker does not advertise `sandbox.overlay_write_capture` yet, and
+it does not run per-block dependency or service commands.
+
+Completed in phase 5:
+
+- Firecracker derives a deterministic guest mount plan from prepared output
+  volumes, using `/dev/vdb`, `/dev/vdc`, and later virtio block device names in
+  the same order as the non-root drives
+- sandbox executions forward the mount plan to the Linux guest agent through
+  the internal vsock exec request
+- the guest agent mounts each cache output ext4 device at a Cleanroom-managed
+  path under `/run/cleanroom/cache-output-volumes`
+- declared `outputs.dirs` are created inside the output volume and bind-mounted
+  at the declared guest path before the command runs
+- cache hits require declared directory output subpaths to already exist inside
+  the restored output volume rather than creating empty replacements
+- declared directory output targets must be absent or empty directories before
+  the bind mount, so image-provided files are not silently hidden
+- declared `outputs.files` are restored by copying regular files out of the
+  output volume on cache hits, and missing file outputs are skipped on misses
+- the guest agent rejects changed mount plans after the first setup in a VM, so
+  repeated exec requests do not clobber restored file outputs
+- tests cover mount-plan construction, request forwarding, guest mount actions,
+  path validation, non-empty directory rejection, file restoration, and changed
+  plan rejection
+
+Remaining runtime work after phase 5:
+
+- run missed dependency and service blocks from isolated input projections
+- inspect overlay write capture results and warn/fallback on escaped writes
+- snapshot and publish output records after successful missed blocks
+- materialize captured file outputs into both the output volume and sandbox root
+  after a missed block run
 - advertise `sandbox.overlay_write_capture` once escaped-write detection and
   isolated block execution are wired through
 - decide whether output volume sizing stays internal or becomes policy-visible

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -88,26 +88,27 @@ type gatewayRegistry interface {
 }
 
 type sandboxInstance struct {
-	SandboxID      string
-	RunDir         string
-	ConfigPath     string
-	VsockPath      string
-	GuestPort      uint32
-	Policy         *policy.CompiledPolicy
-	ImageRef       string
-	ImageDigest    string
-	CommandTimeout int64
-	HostIP         string
-	GuestIP        string
-	fcCmd          *exec.Cmd
-	exitedCh       chan struct{}
-	exitMu         sync.RWMutex
-	exitErr        error
-	exitReady      bool
-	cleanupNetwork func()
-	cleanupVolume  func()
-	vmRootFSPath   string
-	volumeRef      string
+	SandboxID         string
+	RunDir            string
+	ConfigPath        string
+	VsockPath         string
+	GuestPort         uint32
+	Policy            *policy.CompiledPolicy
+	ImageRef          string
+	ImageDigest       string
+	CommandTimeout    int64
+	HostIP            string
+	GuestIP           string
+	fcCmd             *exec.Cmd
+	exitedCh          chan struct{}
+	exitMu            sync.RWMutex
+	exitErr           error
+	exitReady         bool
+	cleanupNetwork    func()
+	cleanupVolume     func()
+	vmRootFSPath      string
+	volumeRef         string
+	cacheOutputMounts []vsockexec.CacheOutputMount
 
 	warnings backend.WarningEmitter
 }
@@ -810,9 +811,10 @@ func (a *Adapter) DeleteSnapshot(ctx context.Context, req backend.DeleteSnapshot
 
 func (a *Adapter) executeInSandbox(ctx context.Context, instance *sandboxInstance, launchSeconds int64, command, env []string, tty bool, stream backend.OutputStream) (vsockexec.ExecResponse, guestExecTiming, error) {
 	guestReq := vsockexec.ExecRequest{
-		Command: append([]string(nil), command...),
-		Env:     append([]string(nil), env...),
-		TTY:     tty,
+		Command:           append([]string(nil), command...),
+		Env:               append([]string(nil), env...),
+		TTY:               tty,
+		CacheOutputMounts: cloneCacheOutputMounts(instance.cacheOutputMounts),
 	}
 	entropy := make([]byte, 64)
 	if _, err := cryptorand.Read(entropy); err == nil {
@@ -1941,23 +1943,24 @@ func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID strin
 	}
 
 	instance := &sandboxInstance{
-		SandboxID:      sandboxID,
-		RunDir:         runDir,
-		ConfigPath:     configPath,
-		VsockPath:      vsockPath,
-		GuestPort:      cfg.GuestPort,
-		Policy:         compiled,
-		ImageRef:       compiled.ImageRef,
-		ImageDigest:    compiled.ImageDigest,
-		CommandTimeout: cfg.LaunchSeconds,
-		HostIP:         networkCfg.HostIP,
-		GuestIP:        networkCfg.GuestIP,
-		fcCmd:          fcCmd,
-		exitedCh:       make(chan struct{}),
-		cleanupNetwork: cleanupNetwork,
-		cleanupVolume:  cleanupStorage,
-		vmRootFSPath:   vmRootFSPath,
-		volumeRef:      writableVolume.Ref,
+		SandboxID:         sandboxID,
+		RunDir:            runDir,
+		ConfigPath:        configPath,
+		VsockPath:         vsockPath,
+		GuestPort:         cfg.GuestPort,
+		Policy:            compiled,
+		ImageRef:          compiled.ImageRef,
+		ImageDigest:       compiled.ImageDigest,
+		CommandTimeout:    cfg.LaunchSeconds,
+		HostIP:            networkCfg.HostIP,
+		GuestIP:           networkCfg.GuestIP,
+		fcCmd:             fcCmd,
+		exitedCh:          make(chan struct{}),
+		cleanupNetwork:    cleanupNetwork,
+		cleanupVolume:     cleanupStorage,
+		vmRootFSPath:      vmRootFSPath,
+		volumeRef:         writableVolume.Ref,
+		cacheOutputMounts: cacheOutputVolumeMounts(cacheOutputVolumes),
 	}
 	instanceRef.Store(instance)
 	go func() {

--- a/internal/backend/firecracker/cache_output_volumes.go
+++ b/internal/backend/firecracker/cache_output_volumes.go
@@ -15,10 +15,12 @@ import (
 	"github.com/buildkite/cleanroom/internal/ext4image"
 	"github.com/buildkite/cleanroom/internal/hosttools"
 	"github.com/buildkite/cleanroom/internal/volumestore"
+	"github.com/buildkite/cleanroom/internal/vsockexec"
 	charmlog "github.com/charmbracelet/log"
 )
 
 const defaultCacheOutputVolumeMinimumBytes int64 = 512 << 20
+const cacheOutputGuestMountRoot = "/run/cleanroom/cache-output-volumes"
 
 var (
 	cacheOutputVolumeMinimumBytes     = defaultCacheOutputVolumeMinimumBytes
@@ -295,4 +297,73 @@ func cacheOutputDriveID(index int) string {
 func cacheOutputRuntimeVolumeID(sandboxID, specVolumeID string, index int) string {
 	sum := sha256.Sum256([]byte(strings.TrimSpace(sandboxID) + "\x00" + strings.TrimSpace(specVolumeID)))
 	return fmt.Sprintf("%s-cache-output-%02d-%s", strings.TrimSpace(sandboxID), index, hex.EncodeToString(sum[:6]))
+}
+
+func cacheOutputVolumeMounts(volumes []preparedCacheOutputVolume) []vsockexec.CacheOutputMount {
+	if len(volumes) == 0 {
+		return nil
+	}
+	mounts := make([]vsockexec.CacheOutputMount, 0, len(volumes))
+	for i, volume := range volumes {
+		mount := vsockexec.CacheOutputMount{
+			DevicePath:    cacheOutputDevicePath(i),
+			MountPath:     cacheOutputGuestMountPath(volume.Drive.DriveID),
+			SourcePresent: cacheOutputSpecHasSource(volume.Spec),
+		}
+		for _, mapping := range volume.Spec.DirMappings {
+			mount.DirMappings = append(mount.DirMappings, vsockexec.CacheOutputDirMount{
+				GuestPath: strings.TrimSpace(mapping.GuestPath),
+				Subpath:   strings.TrimSpace(mapping.Subpath),
+			})
+		}
+		for _, mapping := range volume.Spec.FileMappings {
+			mount.FileMappings = append(mount.FileMappings, vsockexec.CacheOutputFileMount{
+				GuestPath: strings.TrimSpace(mapping.GuestPath),
+				Subpath:   strings.TrimSpace(mapping.Subpath),
+				Mode:      uint32(mapping.Mode.Perm()),
+			})
+		}
+		mounts = append(mounts, mount)
+	}
+	return mounts
+}
+
+func cloneCacheOutputMounts(mounts []vsockexec.CacheOutputMount) []vsockexec.CacheOutputMount {
+	if len(mounts) == 0 {
+		return nil
+	}
+	out := make([]vsockexec.CacheOutputMount, len(mounts))
+	for i, mount := range mounts {
+		out[i] = mount
+		out[i].DirMappings = append([]vsockexec.CacheOutputDirMount(nil), mount.DirMappings...)
+		out[i].FileMappings = append([]vsockexec.CacheOutputFileMount(nil), mount.FileMappings...)
+	}
+	return out
+}
+
+func cacheOutputGuestMountPath(driveID string) string {
+	return filepath.Join(cacheOutputGuestMountRoot, strings.TrimSpace(driveID))
+}
+
+func cacheOutputSpecHasSource(spec backend.CacheOutputVolumeSpec) bool {
+	return strings.TrimSpace(spec.SourceSnapshotRef) != "" || strings.TrimSpace(spec.StorageRef) != ""
+}
+
+func cacheOutputDevicePath(index int) string {
+	return "/dev/" + virtioBlockDeviceName(index+1)
+}
+
+func virtioBlockDeviceName(index int) string {
+	if index < 0 {
+		index = 0
+	}
+	letters := ""
+	for {
+		letters = string(rune('a'+index%26)) + letters
+		index = index/26 - 1
+		if index < 0 {
+			break
+		}
+	}
+	return "vd" + letters
 }

--- a/internal/backend/firecracker/cache_output_volumes_test.go
+++ b/internal/backend/firecracker/cache_output_volumes_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/buildkite/cleanroom/internal/backend"
 	"github.com/buildkite/cleanroom/internal/volumestore"
+	"github.com/buildkite/cleanroom/internal/vsockexec"
 )
 
 func TestCapabilitiesAdvertiseCacheOutputVolumesWithoutOverlayCapture(t *testing.T) {
@@ -137,6 +138,74 @@ func TestPrepareCacheOutputVolumesClonesHitsAndCreatesMisses(t *testing.T) {
 	}
 	if got, want := destroyReqs[0].VolumeRef, prepared[1].Volume.Ref; got != want {
 		t.Fatalf("expected reverse cleanup order first ref %q, got %q", want, got)
+	}
+}
+
+func TestCacheOutputVolumeMountsBuildsDeterministicGuestPlan(t *testing.T) {
+	t.Parallel()
+
+	mounts := cacheOutputVolumeMounts([]preparedCacheOutputVolume{
+		{
+			Spec: backend.CacheOutputVolumeSpec{
+				SourceSnapshotRef: "snapshot:toolchains",
+				StorageRef:        "snapshot:toolchains",
+				DirMappings: []backend.CacheOutputDirMapping{
+					{GuestPath: " /root/.local/share/mise ", Subpath: " dirs/0 "},
+				},
+				FileMappings: []backend.CacheOutputFileMapping{
+					{GuestPath: " /root/.config/mise/config.toml ", Subpath: " files/0 ", Mode: 0o600},
+				},
+			},
+			Drive: drive{DriveID: "cacheout0"},
+		},
+		{
+			Spec: backend.CacheOutputVolumeSpec{
+				DirMappings: []backend.CacheOutputDirMapping{
+					{GuestPath: "/root/go/pkg/mod", Subpath: "dirs/0"},
+				},
+			},
+			Drive: drive{DriveID: "cacheout1"},
+		},
+	})
+
+	want := []vsockexec.CacheOutputMount{
+		{
+			DevicePath:    "/dev/vdb",
+			MountPath:     "/run/cleanroom/cache-output-volumes/cacheout0",
+			SourcePresent: true,
+			DirMappings: []vsockexec.CacheOutputDirMount{
+				{GuestPath: "/root/.local/share/mise", Subpath: "dirs/0"},
+			},
+			FileMappings: []vsockexec.CacheOutputFileMount{
+				{GuestPath: "/root/.config/mise/config.toml", Subpath: "files/0", Mode: 0o600},
+			},
+		},
+		{
+			DevicePath: "/dev/vdc",
+			MountPath:  "/run/cleanroom/cache-output-volumes/cacheout1",
+			DirMappings: []vsockexec.CacheOutputDirMount{
+				{GuestPath: "/root/go/pkg/mod", Subpath: "dirs/0"},
+			},
+		},
+	}
+	if !reflect.DeepEqual(mounts, want) {
+		t.Fatalf("unexpected cache output mounts: got %#v want %#v", mounts, want)
+	}
+}
+
+func TestCacheOutputDevicePathUsesVirtioBlockOrderAfterRoot(t *testing.T) {
+	t.Parallel()
+
+	tests := map[int]string{
+		0:  "/dev/vdb",
+		1:  "/dev/vdc",
+		24: "/dev/vdz",
+		25: "/dev/vdaa",
+	}
+	for index, want := range tests {
+		if got := cacheOutputDevicePath(index); got != want {
+			t.Fatalf("cacheOutputDevicePath(%d) = %q, want %q", index, got, want)
+		}
 	}
 }
 

--- a/internal/backend/firecracker/persistent_test.go
+++ b/internal/backend/firecracker/persistent_test.go
@@ -228,6 +228,49 @@ func TestRunInSandboxUsesRequestLaunchSecondsOverride(t *testing.T) {
 	}
 }
 
+func TestRunInSandboxForwardsCacheOutputMounts(t *testing.T) {
+	t.Parallel()
+
+	wantMounts := []vsockexec.CacheOutputMount{
+		{
+			DevicePath:    "/dev/vdb",
+			MountPath:     "/run/cleanroom/cache-output-volumes/cacheout0",
+			SourcePresent: true,
+			DirMappings: []vsockexec.CacheOutputDirMount{
+				{GuestPath: "/root/.local/share/mise", Subpath: "dirs/0"},
+			},
+			FileMappings: []vsockexec.CacheOutputFileMount{
+				{GuestPath: "/root/.config/mise/config.toml", Subpath: "files/0", Mode: 0o600},
+			},
+		},
+	}
+	var gotMounts []vsockexec.CacheOutputMount
+	adapter := &Adapter{}
+	adapter.runGuestCommandFn = func(_ context.Context, _ context.Context, _ <-chan struct{}, _ func() error, _ string, _ uint32, req vsockexec.ExecRequest, _ backend.OutputStream) (vsockexec.ExecResponse, guestExecTiming, error) {
+		gotMounts = cloneCacheOutputMounts(req.CacheOutputMounts)
+		return vsockexec.ExecResponse{ExitCode: 0}, guestExecTiming{}, nil
+	}
+	adapter.sandboxes = map[string]*sandboxInstance{
+		"cr-test": {
+			SandboxID:         "cr-test",
+			VsockPath:         "/tmp/fake.sock",
+			GuestPort:         10700,
+			cacheOutputMounts: cloneCacheOutputMounts(wantMounts),
+		},
+	}
+
+	if _, err := adapter.RunInSandbox(context.Background(), backend.ExecutionRequest{
+		SandboxID:   "cr-test",
+		ExecutionID: "run-123",
+		Command:     []string{"true"},
+	}, backend.OutputStream{}); err != nil {
+		t.Fatalf("RunInSandbox returned error: %v", err)
+	}
+	if !reflect.DeepEqual(gotMounts, wantMounts) {
+		t.Fatalf("unexpected cache output mounts: got %#v want %#v", gotMounts, wantMounts)
+	}
+}
+
 func TestRunInSandboxWritesRunObservabilityForStatusCommand(t *testing.T) {
 	t.Parallel()
 

--- a/internal/vsockexec/protocol.go
+++ b/internal/vsockexec/protocol.go
@@ -14,11 +14,31 @@ const (
 )
 
 type ExecRequest struct {
-	Command     []string `json:"command"`
-	Dir         string   `json:"dir,omitempty"`
-	Env         []string `json:"env,omitempty"`
-	EntropySeed []byte   `json:"entropy_seed,omitempty"`
-	TTY         bool     `json:"tty,omitempty"`
+	Command           []string           `json:"command"`
+	Dir               string             `json:"dir,omitempty"`
+	Env               []string           `json:"env,omitempty"`
+	EntropySeed       []byte             `json:"entropy_seed,omitempty"`
+	TTY               bool               `json:"tty,omitempty"`
+	CacheOutputMounts []CacheOutputMount `json:"cache_output_mounts,omitempty"`
+}
+
+type CacheOutputMount struct {
+	DevicePath    string                 `json:"device_path"`
+	MountPath     string                 `json:"mount_path"`
+	SourcePresent bool                   `json:"source_present,omitempty"`
+	DirMappings   []CacheOutputDirMount  `json:"dir_mappings,omitempty"`
+	FileMappings  []CacheOutputFileMount `json:"file_mappings,omitempty"`
+}
+
+type CacheOutputDirMount struct {
+	GuestPath string `json:"guest_path"`
+	Subpath   string `json:"subpath"`
+}
+
+type CacheOutputFileMount struct {
+	GuestPath string `json:"guest_path"`
+	Subpath   string `json:"subpath"`
+	Mode      uint32 `json:"mode,omitempty"`
 }
 
 type ExecResponse struct {


### PR DESCRIPTION
## Problem

Firecracker can now prepare and attach cache output sidecar disks, but the guest still did not receive enough information to mount those disks or expose declared outputs to commands. That left the block-volume runtime with attached devices but no usable guest view.

## Changes

- Extend the internal vsock exec request with cache output mount metadata.
- Derive deterministic Firecracker guest mount plans from prepared cache output volumes.
- Forward mount plans with sandbox executions.
- Add Linux guest-agent setup that mounts output ext4 devices under `/run/cleanroom/cache-output-volumes`, bind-mounts declared `outputs.dirs`, and restores declared `outputs.files` by file copy instead of file bind mounts.
- Reject non-empty directory output targets before bind mounting, and require cache-hit directory subpaths/files to exist in the restored volume.
- Keep the runtime inactive until Firecracker also supports `sandbox.overlay_write_capture`.
- Update the volume-cache plan with Phase 5 status and remaining runtime work.

## Validation

- `mise exec -- go test ./cmd/cleanroom-guest-agent`
- `mise exec -- go test ./internal/backend/firecracker`
- `mise exec -- go test ./internal/vsockexec`
- `mise exec -- go test ./...`
