### PR TITLE
feat: Add ZFS cache peer sender

### DIFF
--- a/docs/plans/zfs-stage-cache-replication.md
+++ b/docs/plans/zfs-stage-cache-replication.md
@@ -13,11 +13,13 @@ The first slice is deliberately narrow:
 
 - `firecracker` backend only
 - `zfs` snapshot driver only
-- system-managed stage caches only: workspace, dependency, and services
+- system-managed dependency and services stage children only
 - configured peers only
 - incremental transfer only when the receiver already has the parent snapshot
 - no full snapshot export, APFS support, user snapshots, generic binary diff, or
   scheduler in v1
+- no remote workspace-stage fill until runtime/base lineage has a dedicated
+  parent contract
 
 This keeps the hot path fast over the wire and fast to apply:
 
@@ -33,14 +35,14 @@ the peer transfer is a miss and Cleanroom builds the stage locally.
 
 Host-local stage caches already skip repeated repository and dependency work on
 one machine. A new host in the same queue or host pool still has to rebuild the
-same workspace, dependency, or services stage unless its local cache is warm.
+same dependency or services stage unless its local cache is warm.
 
 Full snapshot export is too expensive for the target use case. The useful case
 is usually adjacent hosts that share the lower stage already:
 
 - both hosts have the same runtime base
-- both hosts have the same workspace stage and want a dependency or services
-  child
+- both hosts have the same workspace stage and one host wants a dependency or
+  services child
 - both hosts have an older dependency stage and one host wants the newer
   services stage
 
@@ -51,6 +53,8 @@ to full rootfs size.
 
 - Reuse Cleanroom system stage caches across adjacent hosts without rebuilding.
 - Use ZFS-native incremental send/receive for the first fast path.
+- Start with dependency and services children whose parent cache already exists
+  locally on the receiver.
 - Keep cache identity and trust decisions in the Cleanroom control plane.
 - Keep driver-specific transfer complexity inside the ZFS volume driver and
   Firecracker host runtime.
@@ -140,12 +144,19 @@ The local ZFS transfer primitive has landed:
 - inventory and prune unreferenced import datasets through `system df`,
   `system prune`, and daemon startup cleanup
 
-The active next slice is the peer protocol:
+The sender side of the peer protocol has landed:
 
 - lookup RPC and export HTTP endpoint
 - sender-side transfer tokens
+- dependency and services child exports only, with an explicit parent stage,
+  parent cache key, and parent ZFS GUID
+
+The next slice is receiver-side import orchestration:
+
 - receiver-side import orchestration around the proven local ZFS primitive
 - cache publication only after receiver-side metadata validation
+- dependency/services import attempts only after the receiver already has the
+  workspace or dependency parent locally
 
 ## Design Principles
 
@@ -267,6 +278,7 @@ storage_driver
 architecture
 producer_version
 policy_hash
+parent_stage
 parent_cache_key
 parent_zfs_snapshot_guid
 ```
@@ -286,10 +298,16 @@ candidate:
   cache_key
   backing_snapshot_id
   storage_ref
+  parent_stage
   parent_cache_key
   zfs_snapshot_guid
   zfs_parent_snapshot_guid
   producer_version
+  backend
+  storage_driver
+  architecture
+  policy_hash
+  estimated_bytes
   expires_at
 ```
 
@@ -406,7 +424,7 @@ When a peer lookup arrives:
 3. Reject non-ready records.
 4. Reject non-`firecracker` or non-`zfs` records.
 5. Compare backend, driver, architecture, producer version, policy hash,
-   parent cache key, and parent ZFS GUID.
+   parent stage, parent cache key, and parent ZFS GUID.
 6. Ask the ZFS driver for an incremental export plan.
 7. Mint a short-lived transfer token bound to the candidate and request.
 
@@ -483,6 +501,7 @@ labels.
 The peer API exposes powerful local cache data. Keep v1 conservative:
 
 - require authentication for lookup and export
+- accept v1 bearer tokens only from configured `cache.peers[*].token_env`
 - restrict exports to system stage caches
 - never export user snapshots
 - never export non-ready records
@@ -499,7 +518,7 @@ The peer API exposes powerful local cache data. Keep v1 conservative:
 | `internal/runtimeconfig/config.go` | Add `CacheConfig` with configured peers. |
 | `proto/cleanroom/v1/control.proto` | Add peer cache lookup RPC messages or a new peer cache service. |
 | `internal/controlservice/service.go` | Hook peer import into stage-cache miss handling before local build. |
-| `internal/controlservice/workspace_stage.go` | Include peer import for workspace-stage misses once parent runtime/base lineage is available. |
+| `internal/controlservice/workspace_stage.go` | Keep workspace-stage peer import out of the v1 slice until parent runtime/base lineage has a dedicated contract. |
 | `internal/controlservice/dependency_stage.go` | Include peer import for exact dependency and portable dependency records where parent lineage can be proven. |
 | `internal/controlservice/services_stage.go` | Include peer import for services-stage misses where parent dependency/workspace lineage can be proven. |
 | `internal/cachestore/store.go` | Add driver lineage metadata, architecture/runtime fields, and storage-size fields. |
@@ -548,7 +567,7 @@ Status: landed.
 
 ### 4. Static peer lookup API
 
-Status: next.
+Status: sender side landed; receiver client is next.
 
 - Add runtime config for peer URLs and token env vars.
 - Add lookup RPC and export HTTP endpoint.
@@ -558,8 +577,12 @@ Status: next.
 
 ### 5. Receiver-side peer import
 
+Status: next.
+
 - On local stage-cache miss, query configured peers when parent ZFS lineage is
   available.
+- Attempt v1 peer import only for dependency and services stage children, not
+  workspace-stage misses.
 - Coalesce duplicate imports for the same `stage/cache_key`.
 - Stream export response directly into `ImportIncremental`.
 - Validate imported metadata locally.
@@ -619,6 +642,8 @@ Status: next.
 
 ## Future Work
 
+- Workspace-stage peer import once runtime/base lineage has a dedicated parent
+  identity and validation contract.
 - Scheduler or peer registry for larger pools.
 - Dragonfly-style piece scheduling and fanout if one sender becomes a
   bottleneck.
@@ -629,13 +654,10 @@ Status: next.
 
 ## Open Questions
 
-- Does the current ZFS `SnapshotVolume` promotion flow preserve the exact
-  sendable parent relationship needed for incremental stage transfer, or do we
-  need to preserve bookmarks during stage publication?
 - Should peer lookup happen before or after portable dependency-stage lookup?
 - Should imported records preserve the sender's `created_at`, or should they
   use receiver import time with sender provenance in driver metadata?
-- What is the smallest safe authentication setup for first deployment: bearer
-  token, mTLS, or both?
+- Do we need separate inbound and outbound peer auth config before exposing
+  this outside one trusted host pool?
 - Should peer transfer be opportunistic only, or should policies later be able
   to require remote cache import before rebuilding?

--- a/internal/backend/firecracker/host_runtime_test.go
+++ b/internal/backend/firecracker/host_runtime_test.go
@@ -166,9 +166,13 @@ func TestNewZFSImportDatasetStoreRequiresZFSDriverAndDataset(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := NewZFSImportDatasetStore(tt.cfg)
-			if (got != nil) != tt.want {
-				t.Fatalf("NewZFSImportDatasetStore() configured=%v, want %v", got != nil, tt.want)
+			importStore := NewZFSImportDatasetStore(tt.cfg)
+			if (importStore != nil) != tt.want {
+				t.Fatalf("NewZFSImportDatasetStore() configured=%v, want %v", importStore != nil, tt.want)
+			}
+			transferDriver := NewZFSIncrementalTransferDriver(tt.cfg)
+			if (transferDriver != nil) != tt.want {
+				t.Fatalf("NewZFSIncrementalTransferDriver() configured=%v, want %v", transferDriver != nil, tt.want)
 			}
 		})
 	}

--- a/internal/backend/firecracker/zfs_import_dataset_store.go
+++ b/internal/backend/firecracker/zfs_import_dataset_store.go
@@ -2,6 +2,7 @@ package firecracker
 
 import (
 	"context"
+	"io"
 	"strings"
 
 	"github.com/buildkite/cleanroom/internal/backend"
@@ -13,10 +14,7 @@ type ZFSImportDatasetStore struct {
 }
 
 func NewZFSImportDatasetStore(cfg backend.FirecrackerConfig) *ZFSImportDatasetStore {
-	if !strings.EqualFold(strings.TrimSpace(cfg.Snapshots.Driver), "zfs") {
-		return nil
-	}
-	if strings.TrimSpace(cfg.Snapshots.ZFSDataset) == "" {
+	if !firecrackerZFSDriverConfigured(cfg) {
 		return nil
 	}
 	return &ZFSImportDatasetStore{cfg: cfg}
@@ -39,8 +37,63 @@ func (s *ZFSImportDatasetStore) DestroyZFSImportDataset(ctx context.Context, dat
 }
 
 func (s *ZFSImportDatasetStore) openDriver() (*volumestore.ZFSDriver, error) {
+	return openFirecrackerZFSDriver(s.cfg)
+}
+
+type ZFSIncrementalTransferDriver struct {
+	cfg backend.FirecrackerConfig
+}
+
+func NewZFSIncrementalTransferDriver(cfg backend.FirecrackerConfig) *ZFSIncrementalTransferDriver {
+	if !firecrackerZFSDriverConfigured(cfg) {
+		return nil
+	}
+	return &ZFSIncrementalTransferDriver{cfg: cfg}
+}
+
+func (d *ZFSIncrementalTransferDriver) DescribeSnapshot(ctx context.Context, req volumestore.DescribeSnapshotRequest) (volumestore.SnapshotDescription, error) {
+	driver, err := d.openDriver()
+	if err != nil {
+		return volumestore.SnapshotDescription{}, err
+	}
+	return driver.DescribeSnapshot(ctx, req)
+}
+
+func (d *ZFSIncrementalTransferDriver) PlanIncrementalSnapshotExport(ctx context.Context, req volumestore.IncrementalSnapshotExportRequest) (volumestore.IncrementalSnapshotExportPlan, error) {
+	driver, err := d.openDriver()
+	if err != nil {
+		return volumestore.IncrementalSnapshotExportPlan{}, err
+	}
+	return driver.PlanIncrementalSnapshotExport(ctx, req)
+}
+
+func (d *ZFSIncrementalTransferDriver) ExportIncrementalSnapshot(ctx context.Context, plan volumestore.IncrementalSnapshotExportPlan, dst io.Writer) error {
+	driver, err := d.openDriver()
+	if err != nil {
+		return err
+	}
+	return driver.ExportIncrementalSnapshot(ctx, plan, dst)
+}
+
+func (d *ZFSIncrementalTransferDriver) ImportIncrementalSnapshot(ctx context.Context, req volumestore.IncrementalSnapshotImportRequest, src io.Reader) (volumestore.Snapshot, error) {
+	driver, err := d.openDriver()
+	if err != nil {
+		return volumestore.Snapshot{}, err
+	}
+	return driver.ImportIncrementalSnapshot(ctx, req, src)
+}
+
+func (d *ZFSIncrementalTransferDriver) openDriver() (*volumestore.ZFSDriver, error) {
+	return openFirecrackerZFSDriver(d.cfg)
+}
+
+func openFirecrackerZFSDriver(cfg backend.FirecrackerConfig) (*volumestore.ZFSDriver, error) {
 	return volumestore.NewZFSDriver(volumestore.ZFSDriverOptions{
-		DatasetRoot: strings.TrimSpace(s.cfg.Snapshots.ZFSDataset),
-		Runner:      hostRuntimeVolumeCommandRunner{runner: newPrivilegedCommandRunner(s.cfg)},
+		DatasetRoot: strings.TrimSpace(cfg.Snapshots.ZFSDataset),
+		Runner:      hostRuntimeVolumeCommandRunner{runner: newPrivilegedCommandRunner(cfg)},
 	})
+}
+
+func firecrackerZFSDriverConfigured(cfg backend.FirecrackerConfig) bool {
+	return strings.EqualFold(strings.TrimSpace(cfg.Snapshots.Driver), "zfs") && strings.TrimSpace(cfg.Snapshots.ZFSDataset) != ""
 }

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -340,14 +340,15 @@ func newControlService(ctx *runtimeContext, logger *log.Logger, mirrors gateway.
 		return service, nil
 	}
 	service := &controlservice.Service{
-		Loader:                ctx.Loader,
-		Config:                ctx.Config,
-		Backends:              ctx.Backends,
-		Logger:                logger,
-		Observability:         ctx.Observability,
-		RepositoryStore:       repositorystore.NewMirrorBacked(mirrors),
-		SnapshotStore:         snapshotMetadataStore,
-		ZFSImportDatasetStore: systemZFSImportDatasetStore(ctx.Config),
+		Loader:                  ctx.Loader,
+		Config:                  ctx.Config,
+		Backends:                ctx.Backends,
+		Logger:                  logger,
+		Observability:           ctx.Observability,
+		RepositoryStore:         repositorystore.NewMirrorBacked(mirrors),
+		SnapshotStore:           snapshotMetadataStore,
+		ZFSImportDatasetStore:   systemZFSImportDatasetStore(ctx.Config),
+		CachePeerTransferDriver: systemCachePeerTransferDriver(ctx.Config),
 	}
 	if cacheMetadataStore != nil {
 		service.CacheStore = cacheMetadataStore

--- a/internal/cli/system.go
+++ b/internal/cli/system.go
@@ -19,6 +19,7 @@ import (
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
 	"github.com/buildkite/cleanroom/internal/runtimeconfig"
 	"github.com/buildkite/cleanroom/internal/storagegc"
+	"github.com/buildkite/cleanroom/internal/volumestore"
 	"golang.org/x/term"
 )
 
@@ -47,6 +48,7 @@ var systemPlanPrune = storagegc.PlanPrune
 var systemExecutePrune = storagegc.ExecutePrune
 var systemListSandboxIDs = listSystemSandboxIDs
 var systemZFSImportDatasetStore = defaultSystemZFSImportDatasetStore
+var systemCachePeerTransferDriver = defaultSystemCachePeerTransferDriver
 var systemIsTerminal = func(f *os.File) bool {
 	return f != nil && term.IsTerminal(int(f.Fd()))
 }
@@ -149,6 +151,14 @@ func defaultSystemZFSImportDatasetStore(cfg runtimeconfig.Config) storagegc.ZFSI
 		return nil
 	}
 	return store
+}
+
+func defaultSystemCachePeerTransferDriver(cfg runtimeconfig.Config) volumestore.IncrementalSnapshotTransferDriver {
+	driver := backendfirecracker.NewZFSIncrementalTransferDriver(runtimeconfig.MergeBackendConfig(cfg, "firecracker", 0))
+	if driver == nil {
+		return nil
+	}
+	return driver
 }
 
 func listSystemSandboxIDs(ctx context.Context, runtimeCtx *runtimeContext, flags clientFlags) ([]string, bool, error) {

--- a/internal/controlserver/cache_peer_test.go
+++ b/internal/controlserver/cache_peer_test.go
@@ -2,6 +2,7 @@ package controlserver
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -163,8 +164,82 @@ func TestCachePeerLookupAndExportOverHTTP(t *testing.T) {
 	}
 }
 
+func TestCachePeerExportDoesNotAppendHTTPErrorAfterStreamStarts(t *testing.T) {
+	t.Setenv("CLEANROOM_CACHE_PEER_TOKEN", "shared-secret")
+	store := newHandlerCacheStore()
+	insertHandlerCachePeerRecord(t, store, handlerCachePeerRecordOptions{
+		Stage:        "workspace",
+		CacheKey:     "workspace-parent",
+		StorageRef:   "tank/cleanroom/snapshots/workspace@base",
+		SnapshotGUID: "parent-guid",
+	})
+	insertHandlerCachePeerRecord(t, store, handlerCachePeerRecordOptions{
+		Stage:              "dependency",
+		CacheKey:           "dependency-child",
+		ParentCacheKey:     "workspace-parent",
+		StorageRef:         "tank/cleanroom/snapshots/dependency@base",
+		SnapshotGUID:       "child-guid",
+		ParentSnapshotGUID: "parent-guid",
+		ProducerVersion:    "cleanroom/dependency-stage-v1",
+	})
+
+	service := newHandlerTestService(newHandlerTestAdapter())
+	service.Config.Cache = runtimeconfig.CacheConfig{
+		Peers: []runtimeconfig.CachePeerConfig{{URL: "https://peer.example", TokenEnv: "CLEANROOM_CACHE_PEER_TOKEN"}},
+	}
+	service.CacheStore = store
+	service.CachePeerTransferDriver = &handlerCachePeerTransferDriver{
+		writeBeforeErr: "partial-zfs-stream",
+		exportErr:      errors.New("zfs send interrupted"),
+	}
+	httpServer := httptest.NewServer(New(service, nil).Handler())
+	defer httpServer.Close()
+
+	client := cleanroomv1connect.NewCachePeerServiceClient(http.DefaultClient, httpServer.URL)
+	lookupReq := connect.NewRequest(&cleanroomv1.LookupCachePeerRequest{
+		Stage:                 "dependency",
+		CacheKey:              "dependency-child",
+		Backend:               "firecracker",
+		StorageDriver:         "zfs",
+		Architecture:          runtime.GOARCH,
+		ProducerVersion:       "cleanroom/dependency-stage-v1",
+		PolicyHash:            "policy-hash",
+		ParentStage:           "workspace",
+		ParentCacheKey:        "workspace-parent",
+		ParentZfsSnapshotGuid: "parent-guid",
+	})
+	lookupReq.Header().Set("Authorization", "Bearer shared-secret")
+	lookupResp, err := client.LookupCachePeer(context.Background(), lookupReq)
+	if err != nil {
+		t.Fatalf("LookupCachePeer returned error: %v", err)
+	}
+
+	exportReq, err := http.NewRequest(http.MethodGet, httpServer.URL+cachePeerZFSIncrementalExportPathPrefix+lookupResp.Msg.GetCandidate().GetTransferToken(), nil)
+	if err != nil {
+		t.Fatalf("create export request: %v", err)
+	}
+	exportReq.Header.Set("Authorization", "Bearer shared-secret")
+	exportResp, err := http.DefaultClient.Do(exportReq)
+	if err != nil {
+		t.Fatalf("GET export returned error: %v", err)
+	}
+	defer exportResp.Body.Close()
+	body, err := io.ReadAll(exportResp.Body)
+	if err != nil {
+		t.Fatalf("read export body: %v", err)
+	}
+	if got, want := exportResp.StatusCode, http.StatusOK; got != want {
+		t.Fatalf("unexpected export status: got %d want %d body=%q", got, want, string(body))
+	}
+	if got, want := string(body), "partial-zfs-stream"; got != want {
+		t.Fatalf("unexpected export body: got %q want %q", got, want)
+	}
+}
+
 type handlerCachePeerTransferDriver struct {
-	payload string
+	payload        string
+	writeBeforeErr string
+	exportErr      error
 }
 
 func (d *handlerCachePeerTransferDriver) DescribeSnapshot(context.Context, volumestore.DescribeSnapshotRequest) (volumestore.SnapshotDescription, error) {
@@ -182,6 +257,14 @@ func (d *handlerCachePeerTransferDriver) PlanIncrementalSnapshotExport(_ context
 }
 
 func (d *handlerCachePeerTransferDriver) ExportIncrementalSnapshot(_ context.Context, _ volumestore.IncrementalSnapshotExportPlan, dst io.Writer) error {
+	if d.writeBeforeErr != "" {
+		if _, err := io.WriteString(dst, d.writeBeforeErr); err != nil {
+			return err
+		}
+	}
+	if d.exportErr != nil {
+		return d.exportErr
+	}
 	_, err := io.WriteString(dst, d.payload)
 	return err
 }

--- a/internal/controlserver/cache_peer_test.go
+++ b/internal/controlserver/cache_peer_test.go
@@ -38,6 +38,43 @@ func TestCachePeerLookupRequiresBearerToken(t *testing.T) {
 	}
 }
 
+func TestCachePeerLookupReturnsMissWhenCacheStoreUnavailable(t *testing.T) {
+	t.Setenv("CLEANROOM_CACHE_PEER_TOKEN", "shared-secret")
+	service := newHandlerTestService(newHandlerTestAdapter())
+	service.Config.Cache = runtimeconfig.CacheConfig{
+		Peers: []runtimeconfig.CachePeerConfig{{URL: "https://peer.example", TokenEnv: "CLEANROOM_CACHE_PEER_TOKEN"}},
+	}
+	service.CacheStore = nil
+	service.CachePeerTransferDriver = &handlerCachePeerTransferDriver{payload: "zfs-stream"}
+	httpServer := httptest.NewServer(New(service, nil).Handler())
+	defer httpServer.Close()
+
+	client := cleanroomv1connect.NewCachePeerServiceClient(http.DefaultClient, httpServer.URL)
+	lookupReq := connect.NewRequest(&cleanroomv1.LookupCachePeerRequest{
+		Stage:                 "dependency",
+		CacheKey:              "dependency-child",
+		Backend:               "firecracker",
+		StorageDriver:         "zfs",
+		Architecture:          runtime.GOARCH,
+		ProducerVersion:       "cleanroom/dependency-stage-v1",
+		PolicyHash:            "policy-hash",
+		ParentStage:           "workspace",
+		ParentCacheKey:        "workspace-parent",
+		ParentZfsSnapshotGuid: "parent-guid",
+	})
+	lookupReq.Header().Set("Authorization", "Bearer shared-secret")
+	lookupResp, err := client.LookupCachePeer(context.Background(), lookupReq)
+	if err != nil {
+		t.Fatalf("LookupCachePeer returned error: %v", err)
+	}
+	if lookupResp.Msg.GetCandidate() != nil {
+		t.Fatalf("expected miss, got candidate %#v", lookupResp.Msg.GetCandidate())
+	}
+	if got, want := lookupResp.Msg.GetMissReason(), "cache metadata unavailable"; got != want {
+		t.Fatalf("unexpected miss reason: got %q want %q", got, want)
+	}
+}
+
 func TestCachePeerLookupAndExportOverHTTP(t *testing.T) {
 	t.Setenv("CLEANROOM_CACHE_PEER_TOKEN", "shared-secret")
 	store := newHandlerCacheStore()

--- a/internal/controlserver/cache_peer_test.go
+++ b/internal/controlserver/cache_peer_test.go
@@ -1,0 +1,245 @@
+package controlserver
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"strings"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/buildkite/cleanroom/internal/cachestore"
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+	"github.com/buildkite/cleanroom/internal/gen/cleanroom/v1/cleanroomv1connect"
+	"github.com/buildkite/cleanroom/internal/runtimeconfig"
+	"github.com/buildkite/cleanroom/internal/volumestore"
+)
+
+func TestCachePeerLookupRequiresBearerToken(t *testing.T) {
+	service := newHandlerTestService(newHandlerTestAdapter())
+	service.Config.Cache = runtimeconfig.CacheConfig{
+		Peers: []runtimeconfig.CachePeerConfig{{URL: "https://peer.example", TokenEnv: "CLEANROOM_CACHE_PEER_TOKEN"}},
+	}
+	httpServer := httptest.NewServer(New(service, nil).Handler())
+	defer httpServer.Close()
+
+	client := cleanroomv1connect.NewCachePeerServiceClient(http.DefaultClient, httpServer.URL)
+	_, err := client.LookupCachePeer(context.Background(), connect.NewRequest(&cleanroomv1.LookupCachePeerRequest{
+		Stage:    "dependency",
+		CacheKey: "cache",
+	}))
+	if err == nil {
+		t.Fatal("expected unauthenticated cache peer lookup")
+	}
+	if code := connect.CodeOf(err); code != connect.CodeUnauthenticated {
+		t.Fatalf("unexpected error code: got %v want %v (err=%v)", code, connect.CodeUnauthenticated, err)
+	}
+}
+
+func TestCachePeerLookupAndExportOverHTTP(t *testing.T) {
+	t.Setenv("CLEANROOM_CACHE_PEER_TOKEN", "shared-secret")
+	store := newHandlerCacheStore()
+	insertHandlerCachePeerRecord(t, store, handlerCachePeerRecordOptions{
+		Stage:        "workspace",
+		CacheKey:     "workspace-parent",
+		StorageRef:   "tank/cleanroom/snapshots/workspace@base",
+		SnapshotGUID: "parent-guid",
+	})
+	insertHandlerCachePeerRecord(t, store, handlerCachePeerRecordOptions{
+		Stage:              "dependency",
+		CacheKey:           "dependency-child",
+		ParentCacheKey:     "workspace-parent",
+		StorageRef:         "tank/cleanroom/snapshots/dependency@base",
+		SnapshotGUID:       "child-guid",
+		ParentSnapshotGUID: "parent-guid",
+		ProducerVersion:    "cleanroom/dependency-stage-v1",
+	})
+
+	service := newHandlerTestService(newHandlerTestAdapter())
+	service.Config.Cache = runtimeconfig.CacheConfig{
+		Peers: []runtimeconfig.CachePeerConfig{{URL: "https://peer.example", TokenEnv: "CLEANROOM_CACHE_PEER_TOKEN"}},
+	}
+	service.CacheStore = store
+	service.CachePeerTransferDriver = &handlerCachePeerTransferDriver{payload: "zfs-stream"}
+	httpServer := httptest.NewServer(New(service, nil).Handler())
+	defer httpServer.Close()
+
+	client := cleanroomv1connect.NewCachePeerServiceClient(http.DefaultClient, httpServer.URL)
+	lookupReq := connect.NewRequest(&cleanroomv1.LookupCachePeerRequest{
+		Stage:                 "dependency",
+		CacheKey:              "dependency-child",
+		Backend:               "firecracker",
+		StorageDriver:         "zfs",
+		Architecture:          runtime.GOARCH,
+		ProducerVersion:       "cleanroom/dependency-stage-v1",
+		PolicyHash:            "policy-hash",
+		ParentStage:           "workspace",
+		ParentCacheKey:        "workspace-parent",
+		ParentZfsSnapshotGuid: "parent-guid",
+	})
+	lookupReq.Header().Set("Authorization", "Bearer shared-secret")
+	lookupResp, err := client.LookupCachePeer(context.Background(), lookupReq)
+	if err != nil {
+		t.Fatalf("LookupCachePeer returned error: %v", err)
+	}
+	token := lookupResp.Msg.GetCandidate().GetTransferToken()
+	if strings.TrimSpace(token) == "" {
+		t.Fatalf("expected transfer token, response %#v", lookupResp.Msg)
+	}
+
+	exportReq, err := http.NewRequest(http.MethodGet, httpServer.URL+cachePeerZFSIncrementalExportPathPrefix+token, nil)
+	if err != nil {
+		t.Fatalf("create export request: %v", err)
+	}
+	exportReq.Header.Set("Authorization", "Bearer shared-secret")
+	exportResp, err := http.DefaultClient.Do(exportReq)
+	if err != nil {
+		t.Fatalf("GET export returned error: %v", err)
+	}
+	defer exportResp.Body.Close()
+	if got, want := exportResp.StatusCode, http.StatusOK; got != want {
+		body, _ := io.ReadAll(exportResp.Body)
+		t.Fatalf("unexpected export status: got %d want %d body=%q", got, want, string(body))
+	}
+	body, err := io.ReadAll(exportResp.Body)
+	if err != nil {
+		t.Fatalf("read export body: %v", err)
+	}
+	if got, want := string(body), "zfs-stream"; got != want {
+		t.Fatalf("unexpected export body: got %q want %q", got, want)
+	}
+
+	secondReq, err := http.NewRequest(http.MethodGet, httpServer.URL+cachePeerZFSIncrementalExportPathPrefix+token, nil)
+	if err != nil {
+		t.Fatalf("create second export request: %v", err)
+	}
+	secondReq.Header.Set("Authorization", "Bearer shared-secret")
+	secondResp, err := http.DefaultClient.Do(secondReq)
+	if err != nil {
+		t.Fatalf("second GET export returned error: %v", err)
+	}
+	defer secondResp.Body.Close()
+	if got, want := secondResp.StatusCode, http.StatusNotFound; got != want {
+		t.Fatalf("unexpected second export status: got %d want %d", got, want)
+	}
+}
+
+type handlerCachePeerTransferDriver struct {
+	payload string
+}
+
+func (d *handlerCachePeerTransferDriver) DescribeSnapshot(context.Context, volumestore.DescribeSnapshotRequest) (volumestore.SnapshotDescription, error) {
+	return volumestore.SnapshotDescription{}, nil
+}
+
+func (d *handlerCachePeerTransferDriver) PlanIncrementalSnapshotExport(_ context.Context, req volumestore.IncrementalSnapshotExportRequest) (volumestore.IncrementalSnapshotExportPlan, error) {
+	return volumestore.IncrementalSnapshotExportPlan{
+		FromSnapshotRef:  req.FromSnapshotRef,
+		FromSnapshotGUID: req.FromSnapshotGUID,
+		ToSnapshotRef:    req.ToSnapshotRef,
+		ToSnapshotGUID:   req.ToSnapshotGUID,
+		EstimatedBytes:   42,
+	}, nil
+}
+
+func (d *handlerCachePeerTransferDriver) ExportIncrementalSnapshot(_ context.Context, _ volumestore.IncrementalSnapshotExportPlan, dst io.Writer) error {
+	_, err := io.WriteString(dst, d.payload)
+	return err
+}
+
+func (d *handlerCachePeerTransferDriver) ImportIncrementalSnapshot(context.Context, volumestore.IncrementalSnapshotImportRequest, io.Reader) (volumestore.Snapshot, error) {
+	return volumestore.Snapshot{}, nil
+}
+
+type handlerCacheStore struct {
+	records map[string]cachestore.Record
+}
+
+func newHandlerCacheStore() *handlerCacheStore {
+	return &handlerCacheStore{records: map[string]cachestore.Record{}}
+}
+
+func (s *handlerCacheStore) Create(_ context.Context, record cachestore.Record) error {
+	s.records[handlerCacheStoreKey(record.Stage, record.CacheKey)] = record
+	return nil
+}
+
+func (s *handlerCacheStore) Upsert(_ context.Context, record cachestore.Record) error {
+	s.records[handlerCacheStoreKey(record.Stage, record.CacheKey)] = record
+	return nil
+}
+
+func (s *handlerCacheStore) GetReady(_ context.Context, stage, cacheKey string) (cachestore.Record, bool, error) {
+	record, ok := s.records[handlerCacheStoreKey(stage, cacheKey)]
+	if !ok || record.State != "ready" {
+		return cachestore.Record{}, false, nil
+	}
+	return record, true, nil
+}
+
+func (s *handlerCacheStore) Touch(context.Context, string, string) error {
+	return nil
+}
+
+func (s *handlerCacheStore) List(context.Context) ([]cachestore.Record, error) {
+	records := make([]cachestore.Record, 0, len(s.records))
+	for _, record := range s.records {
+		records = append(records, record)
+	}
+	return records, nil
+}
+
+func (s *handlerCacheStore) Delete(_ context.Context, stage, cacheKey string) error {
+	delete(s.records, handlerCacheStoreKey(stage, cacheKey))
+	return nil
+}
+
+func handlerCacheStoreKey(stage, cacheKey string) string {
+	return strings.TrimSpace(stage) + "\x00" + strings.TrimSpace(cacheKey)
+}
+
+type handlerCachePeerRecordOptions struct {
+	Stage              string
+	CacheKey           string
+	ParentCacheKey     string
+	StorageRef         string
+	SnapshotGUID       string
+	ParentSnapshotGUID string
+	ProducerVersion    string
+}
+
+func insertHandlerCachePeerRecord(t *testing.T, store *handlerCacheStore, opts handlerCachePeerRecordOptions) {
+	t.Helper()
+	producerVersion := opts.ProducerVersion
+	if producerVersion == "" {
+		producerVersion = "cleanroom/workspace-stage-v1"
+	}
+	metadata, err := volumestore.EncodeZFSDriverMetadata(volumestore.ZFSDriverMetadata{
+		Dataset:            opts.StorageRef,
+		SnapshotGUID:       opts.SnapshotGUID,
+		ParentSnapshotGUID: opts.ParentSnapshotGUID,
+	})
+	if err != nil {
+		t.Fatalf("encode zfs metadata: %v", err)
+	}
+	if err := store.Upsert(context.Background(), cachestore.Record{
+		CacheKey:          opts.CacheKey,
+		Stage:             opts.Stage,
+		State:             "ready",
+		BackingSnapshotID: opts.CacheKey + "-snapshot",
+		Backend:           "firecracker",
+		Architecture:      runtime.GOARCH,
+		PolicyHash:        "policy-hash",
+		ParentCacheKey:    opts.ParentCacheKey,
+		StorageDriver:     "zfs",
+		StorageRef:        opts.StorageRef,
+		DriverMetadata:    metadata,
+		ProducerVersion:   producerVersion,
+	}); err != nil {
+		t.Fatalf("insert handler cache record: %v", err)
+	}
+}
+
+var _ volumestore.IncrementalSnapshotTransferDriver = (*handlerCachePeerTransferDriver)(nil)

--- a/internal/controlserver/server.go
+++ b/internal/controlserver/server.go
@@ -129,7 +129,14 @@ func (s *Server) handleCachePeerZFSIncrementalExport(w http.ResponseWriter, req 
 		return
 	}
 	w.Header().Set("Content-Type", "application/octet-stream")
-	if err := s.service.ExportCachePeerZFSIncremental(req.Context(), token, w); err != nil {
+	tracker := &cachePeerExportResponseWriter{ResponseWriter: w}
+	if err := s.service.ExportCachePeerZFSIncremental(req.Context(), token, tracker); err != nil {
+		if tracker.bodyStarted {
+			if s.logger != nil {
+				s.logger.Warn("cache peer zfs export failed after streaming started", "error", err)
+			}
+			return
+		}
 		if errors.Is(err, controlservice.ErrCachePeerExportTokenNotFound) {
 			http.NotFound(w, req)
 			return
@@ -139,6 +146,18 @@ func (s *Server) handleCachePeerZFSIncrementalExport(w http.ResponseWriter, req 
 		}
 		http.Error(w, "cache peer export failed", http.StatusInternalServerError)
 	}
+}
+
+type cachePeerExportResponseWriter struct {
+	http.ResponseWriter
+	bodyStarted bool
+}
+
+func (w *cachePeerExportResponseWriter) Write(data []byte) (int, error) {
+	if len(data) > 0 {
+		w.bodyStarted = true
+	}
+	return w.ResponseWriter.Write(data)
 }
 
 func (s *Server) CreateSandbox(ctx context.Context, req *connect.Request[cleanroomv1.CreateSandboxRequest]) (*connect.Response[cleanroomv1.CreateSandboxResponse], error) {

--- a/internal/controlserver/server.go
+++ b/internal/controlserver/server.go
@@ -82,10 +82,13 @@ func (s *Server) Handler() http.Handler {
 
 	sandboxPath, sandboxHandler := cleanroomv1connect.NewSandboxServiceHandler(s, handlerOptions...)
 	snapshotPath, snapshotHandler := cleanroomv1connect.NewSnapshotServiceHandler(s, handlerOptions...)
+	cachePeerPath, cachePeerHandler := cleanroomv1connect.NewCachePeerServiceHandler(s, handlerOptions...)
 	executionPath, executionHandler := cleanroomv1connect.NewExecutionServiceHandler(s, handlerOptions...)
 	mux.Handle(sandboxPath, sandboxHandler)
 	mux.Handle(snapshotPath, snapshotHandler)
+	mux.Handle(cachePeerPath, cachePeerHandler)
 	mux.Handle(executionPath, executionHandler)
+	mux.HandleFunc(cachePeerZFSIncrementalExportPathPrefix, s.handleCachePeerZFSIncrementalExport)
 
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -96,6 +99,46 @@ func (s *Server) Handler() http.Handler {
 		return markLoopbackInternalWorkspaceCopyInRequests(handler)
 	}
 	return handler
+}
+
+const cachePeerZFSIncrementalExportPathPrefix = "/v1/cache/export/zfs-incremental/"
+
+func (s *Server) LookupCachePeer(ctx context.Context, req *connect.Request[cleanroomv1.LookupCachePeerRequest]) (*connect.Response[cleanroomv1.LookupCachePeerResponse], error) {
+	if err := s.service.AuthorizeCachePeerBearer(req.Header().Get("Authorization")); err != nil {
+		return nil, connect.NewError(connect.CodeUnauthenticated, err)
+	}
+	resp, err := s.service.LookupCachePeer(ctx, req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (s *Server) handleCachePeerZFSIncrementalExport(w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if err := s.service.AuthorizeCachePeerBearer(req.Header.Get("Authorization")); err != nil {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	token := strings.TrimSpace(strings.TrimPrefix(req.URL.Path, cachePeerZFSIncrementalExportPathPrefix))
+	if token == "" || strings.Contains(token, "/") {
+		http.NotFound(w, req)
+		return
+	}
+	w.Header().Set("Content-Type", "application/octet-stream")
+	if err := s.service.ExportCachePeerZFSIncremental(req.Context(), token, w); err != nil {
+		if errors.Is(err, controlservice.ErrCachePeerExportTokenNotFound) {
+			http.NotFound(w, req)
+			return
+		}
+		if s.logger != nil {
+			s.logger.Warn("cache peer zfs export failed", "error", err)
+		}
+		http.Error(w, "cache peer export failed", http.StatusInternalServerError)
+	}
 }
 
 func (s *Server) CreateSandbox(ctx context.Context, req *connect.Request[cleanroomv1.CreateSandboxRequest]) (*connect.Response[cleanroomv1.CreateSandboxResponse], error) {

--- a/internal/controlservice/cache_peer.go
+++ b/internal/controlservice/cache_peer.go
@@ -1,0 +1,390 @@
+package controlservice
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/buildkite/cleanroom/internal/cachestore"
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+	"github.com/buildkite/cleanroom/internal/volumestore"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+var (
+	ErrCachePeerUnauthorized        = errors.New("cache peer request unauthorized")
+	ErrCachePeerExportTokenNotFound = errors.New("cache peer export token not found")
+)
+
+const (
+	cachePeerMissUnsupportedStage      = "unsupported stage"
+	cachePeerMissUnsupportedBackend    = "unsupported backend"
+	cachePeerMissUnsupportedDriver     = "unsupported storage driver"
+	cachePeerMissRecordNotFound        = "record not found"
+	cachePeerMissParentRecordNotFound  = "parent record not found"
+	cachePeerMissRecordMismatch        = "record metadata mismatch"
+	cachePeerMissUnsupportedParent     = "unsupported parent stage"
+	cachePeerMissParentGUIDMismatch    = "parent zfs snapshot guid mismatch"
+	cachePeerMissDriverMetadataMissing = "zfs driver metadata missing"
+	cachePeerMissTransferUnavailable   = "incremental transfer unavailable"
+)
+
+type cachePeerExport struct {
+	Token                 string
+	Stage                 string
+	CacheKey              string
+	ParentStage           string
+	ParentCacheKey        string
+	Backend               string
+	StorageDriver         string
+	Architecture          string
+	ProducerVersion       string
+	PolicyHash            string
+	ParentZFSSnapshotGUID string
+	ZFSSnapshotGUID       string
+	ExpiresAt             time.Time
+}
+
+func (s *Service) AuthorizeCachePeerBearer(authorization string) error {
+	scheme, token, ok := strings.Cut(strings.TrimSpace(authorization), " ")
+	if !ok || !strings.EqualFold(scheme, "Bearer") || strings.TrimSpace(token) == "" {
+		return ErrCachePeerUnauthorized
+	}
+	token = strings.TrimSpace(token)
+	for _, configured := range s.cachePeerBearerTokens() {
+		if subtle.ConstantTimeCompare([]byte(token), []byte(configured)) == 1 {
+			return nil
+		}
+	}
+	return ErrCachePeerUnauthorized
+}
+
+func (s *Service) cachePeerBearerTokens() []string {
+	seen := map[string]struct{}{}
+	var tokens []string
+	for _, peer := range s.Config.Cache.Peers {
+		tokenEnv := strings.TrimSpace(peer.TokenEnv)
+		if tokenEnv == "" {
+			continue
+		}
+		token := strings.TrimSpace(os.Getenv(tokenEnv))
+		if token == "" {
+			continue
+		}
+		if _, ok := seen[token]; ok {
+			continue
+		}
+		seen[token] = struct{}{}
+		tokens = append(tokens, token)
+	}
+	return tokens
+}
+
+func (s *Service) LookupCachePeer(ctx context.Context, req *cleanroomv1.LookupCachePeerRequest) (*cleanroomv1.LookupCachePeerResponse, error) {
+	if req == nil {
+		return nil, errors.New("missing cache peer lookup request")
+	}
+	if strings.TrimSpace(req.GetStage()) == "" {
+		return nil, errors.New("missing cache peer lookup stage")
+	}
+	if strings.TrimSpace(req.GetCacheKey()) == "" {
+		return nil, errors.New("missing cache peer lookup cache key")
+	}
+
+	match, missReason, err := s.planCachePeerExport(ctx, cachePeerLookupFromProto(req))
+	if err != nil {
+		return nil, err
+	}
+	if missReason != "" {
+		return cachePeerMiss(missReason), nil
+	}
+
+	token, err := newCachePeerExportToken()
+	if err != nil {
+		return nil, err
+	}
+	expiresAt := s.clock().Now().Add(s.cachePeerExportTokenTTL()).UTC()
+	export := cachePeerExport{
+		Token:                 token,
+		Stage:                 match.Child.Stage,
+		CacheKey:              match.Child.CacheKey,
+		ParentStage:           match.Parent.Stage,
+		ParentCacheKey:        match.Child.ParentCacheKey,
+		Backend:               match.Child.Backend,
+		StorageDriver:         match.Child.StorageDriver,
+		Architecture:          match.Child.Architecture,
+		ProducerVersion:       match.Child.ProducerVersion,
+		PolicyHash:            match.Child.PolicyHash,
+		ParentZFSSnapshotGUID: match.ParentMetadata.SnapshotGUID,
+		ZFSSnapshotGUID:       match.ChildMetadata.SnapshotGUID,
+		ExpiresAt:             expiresAt,
+	}
+	s.storeCachePeerExport(export)
+
+	return &cleanroomv1.LookupCachePeerResponse{
+		Candidate: &cleanroomv1.CachePeerCandidate{
+			TransferToken:         token,
+			Stage:                 match.Child.Stage,
+			CacheKey:              match.Child.CacheKey,
+			BackingSnapshotId:     match.Child.BackingSnapshotID,
+			StorageRef:            match.Child.StorageRef,
+			ParentStage:           match.Parent.Stage,
+			ParentCacheKey:        match.Child.ParentCacheKey,
+			ZfsSnapshotGuid:       match.ChildMetadata.SnapshotGUID,
+			ZfsParentSnapshotGuid: match.ChildMetadata.ParentSnapshotGUID,
+			ProducerVersion:       match.Child.ProducerVersion,
+			Backend:               match.Child.Backend,
+			StorageDriver:         match.Child.StorageDriver,
+			Architecture:          match.Child.Architecture,
+			PolicyHash:            match.Child.PolicyHash,
+			EstimatedBytes:        match.Plan.EstimatedBytes,
+			ExpiresAt:             timestamppb.New(expiresAt),
+		},
+	}, nil
+}
+
+func (s *Service) ExportCachePeerZFSIncremental(ctx context.Context, token string, dst io.Writer) error {
+	if dst == nil {
+		return errors.New("missing cache peer export writer")
+	}
+	export, ok := s.consumeCachePeerExport(strings.TrimSpace(token), s.clock().Now())
+	if !ok {
+		return ErrCachePeerExportTokenNotFound
+	}
+	match, missReason, err := s.planCachePeerExport(ctx, cachePeerLookup{
+		Stage:                 export.Stage,
+		CacheKey:              export.CacheKey,
+		Backend:               export.Backend,
+		StorageDriver:         export.StorageDriver,
+		Architecture:          export.Architecture,
+		ProducerVersion:       export.ProducerVersion,
+		PolicyHash:            export.PolicyHash,
+		ParentStage:           export.ParentStage,
+		ParentCacheKey:        export.ParentCacheKey,
+		ParentZFSSnapshotGUID: export.ParentZFSSnapshotGUID,
+	})
+	if err != nil {
+		return err
+	}
+	if missReason != "" {
+		return fmt.Errorf("cache peer export candidate no longer valid: %s", missReason)
+	}
+	if match.ChildMetadata.SnapshotGUID != export.ZFSSnapshotGUID {
+		return fmt.Errorf("cache peer export candidate no longer valid: zfs snapshot guid mismatch")
+	}
+	return s.CachePeerTransferDriver.ExportIncrementalSnapshot(ctx, match.Plan, dst)
+}
+
+type cachePeerLookup struct {
+	Stage                 string
+	CacheKey              string
+	Backend               string
+	StorageDriver         string
+	Architecture          string
+	ProducerVersion       string
+	PolicyHash            string
+	ParentStage           string
+	ParentCacheKey        string
+	ParentZFSSnapshotGUID string
+}
+
+type cachePeerExportMatch struct {
+	Child          cachestore.Record
+	Parent         cachestore.Record
+	ChildMetadata  volumestore.ZFSDriverMetadata
+	ParentMetadata volumestore.ZFSDriverMetadata
+	Plan           volumestore.IncrementalSnapshotExportPlan
+}
+
+func cachePeerLookupFromProto(req *cleanroomv1.LookupCachePeerRequest) cachePeerLookup {
+	return cachePeerLookup{
+		Stage:                 strings.TrimSpace(req.GetStage()),
+		CacheKey:              strings.TrimSpace(req.GetCacheKey()),
+		Backend:               strings.TrimSpace(req.GetBackend()),
+		StorageDriver:         strings.TrimSpace(req.GetStorageDriver()),
+		Architecture:          strings.TrimSpace(req.GetArchitecture()),
+		ProducerVersion:       strings.TrimSpace(req.GetProducerVersion()),
+		PolicyHash:            strings.TrimSpace(req.GetPolicyHash()),
+		ParentStage:           strings.TrimSpace(req.GetParentStage()),
+		ParentCacheKey:        strings.TrimSpace(req.GetParentCacheKey()),
+		ParentZFSSnapshotGUID: strings.TrimSpace(req.GetParentZfsSnapshotGuid()),
+	}
+}
+
+func (s *Service) planCachePeerExport(ctx context.Context, lookup cachePeerLookup) (cachePeerExportMatch, string, error) {
+	if lookup.Stage != dependencyStageName && lookup.Stage != servicesStageName {
+		return cachePeerExportMatch{}, cachePeerMissUnsupportedStage, nil
+	}
+	if !cachePeerParentStageSupported(lookup.Stage, lookup.ParentStage) {
+		return cachePeerExportMatch{}, cachePeerMissUnsupportedParent, nil
+	}
+	if lookup.Backend != "firecracker" {
+		return cachePeerExportMatch{}, cachePeerMissUnsupportedBackend, nil
+	}
+	if lookup.StorageDriver != "zfs" {
+		return cachePeerExportMatch{}, cachePeerMissUnsupportedDriver, nil
+	}
+	if lookup.Architecture == "" || lookup.ProducerVersion == "" || lookup.PolicyHash == "" || lookup.ParentCacheKey == "" || lookup.ParentZFSSnapshotGUID == "" {
+		return cachePeerExportMatch{}, cachePeerMissRecordMismatch, nil
+	}
+	if s.CachePeerTransferDriver == nil {
+		return cachePeerExportMatch{}, cachePeerMissTransferUnavailable, nil
+	}
+
+	store, err := s.cacheStoreOrErr()
+	if err != nil {
+		return cachePeerExportMatch{}, "", err
+	}
+	child, ok, err := store.GetReady(ctx, lookup.Stage, lookup.CacheKey)
+	if err != nil {
+		return cachePeerExportMatch{}, "", err
+	}
+	if !ok {
+		return cachePeerExportMatch{}, cachePeerMissRecordNotFound, nil
+	}
+	if missReason := cachePeerChildRecordMissReason(child, lookup); missReason != "" {
+		return cachePeerExportMatch{}, missReason, nil
+	}
+
+	parent, ok, err := store.GetReady(ctx, lookup.ParentStage, lookup.ParentCacheKey)
+	if err != nil {
+		return cachePeerExportMatch{}, "", err
+	}
+	if !ok {
+		return cachePeerExportMatch{}, cachePeerMissParentRecordNotFound, nil
+	}
+	if strings.TrimSpace(parent.Backend) != lookup.Backend || strings.TrimSpace(parent.StorageDriver) != lookup.StorageDriver {
+		return cachePeerExportMatch{}, cachePeerMissRecordMismatch, nil
+	}
+
+	childMetadata, ok := cachePeerRecordZFSMetadata(child)
+	if !ok {
+		return cachePeerExportMatch{}, cachePeerMissDriverMetadataMissing, nil
+	}
+	parentMetadata, ok := cachePeerRecordZFSMetadata(parent)
+	if !ok {
+		return cachePeerExportMatch{}, cachePeerMissDriverMetadataMissing, nil
+	}
+	if parentMetadata.SnapshotGUID != lookup.ParentZFSSnapshotGUID || childMetadata.ParentSnapshotGUID != lookup.ParentZFSSnapshotGUID {
+		return cachePeerExportMatch{}, cachePeerMissParentGUIDMismatch, nil
+	}
+
+	plan, err := s.CachePeerTransferDriver.PlanIncrementalSnapshotExport(ctx, volumestore.IncrementalSnapshotExportRequest{
+		FromSnapshotRef:  strings.TrimSpace(parent.StorageRef),
+		FromSnapshotGUID: parentMetadata.SnapshotGUID,
+		ToSnapshotRef:    strings.TrimSpace(child.StorageRef),
+		ToSnapshotGUID:   childMetadata.SnapshotGUID,
+	})
+	if err != nil {
+		return cachePeerExportMatch{}, cachePeerMissTransferUnavailable, nil
+	}
+	return cachePeerExportMatch{
+		Child:          child,
+		Parent:         parent,
+		ChildMetadata:  childMetadata,
+		ParentMetadata: parentMetadata,
+		Plan:           plan,
+	}, "", nil
+}
+
+func cachePeerChildRecordMissReason(record cachestore.Record, lookup cachePeerLookup) string {
+	if strings.TrimSpace(record.Backend) != lookup.Backend {
+		return cachePeerMissUnsupportedBackend
+	}
+	if strings.TrimSpace(record.StorageDriver) != lookup.StorageDriver {
+		return cachePeerMissUnsupportedDriver
+	}
+	if strings.TrimSpace(record.Architecture) != lookup.Architecture {
+		return cachePeerMissRecordMismatch
+	}
+	if strings.TrimSpace(record.ProducerVersion) != lookup.ProducerVersion {
+		return cachePeerMissRecordMismatch
+	}
+	if strings.TrimSpace(record.PolicyHash) != lookup.PolicyHash {
+		return cachePeerMissRecordMismatch
+	}
+	if strings.TrimSpace(record.ParentCacheKey) != lookup.ParentCacheKey {
+		return cachePeerMissRecordMismatch
+	}
+	if lookup.Architecture != runtime.GOARCH {
+		return cachePeerMissRecordMismatch
+	}
+	return ""
+}
+
+func cachePeerParentStageSupported(stage, parentStage string) bool {
+	switch stage {
+	case dependencyStageName:
+		return parentStage == workspaceStageName
+	case servicesStageName:
+		return parentStage == workspaceStageName || parentStage == dependencyStageName
+	default:
+		return false
+	}
+}
+
+func cachePeerRecordZFSMetadata(record cachestore.Record) (volumestore.ZFSDriverMetadata, bool) {
+	metadata, err := volumestore.DecodeZFSDriverMetadata(record.DriverMetadata)
+	if err != nil {
+		return volumestore.ZFSDriverMetadata{}, false
+	}
+	if strings.TrimSpace(metadata.SnapshotGUID) == "" {
+		return volumestore.ZFSDriverMetadata{}, false
+	}
+	return metadata, true
+}
+
+func cachePeerMiss(reason string) *cleanroomv1.LookupCachePeerResponse {
+	return &cleanroomv1.LookupCachePeerResponse{MissReason: reason}
+}
+
+func newCachePeerExportToken() (string, error) {
+	var raw [32]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", fmt.Errorf("generate cache peer export token: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(raw[:]), nil
+}
+
+func (s *Service) storeCachePeerExport(export cachePeerExport) {
+	s.cachePeerExportsMu.Lock()
+	defer s.cachePeerExportsMu.Unlock()
+	if s.cachePeerExports == nil {
+		s.cachePeerExports = map[string]cachePeerExport{}
+	}
+	now := s.clock().Now()
+	for token, candidate := range s.cachePeerExports {
+		if !candidate.ExpiresAt.After(now) {
+			delete(s.cachePeerExports, token)
+		}
+	}
+	s.cachePeerExports[export.Token] = export
+}
+
+func (s *Service) consumeCachePeerExport(token string, now time.Time) (cachePeerExport, bool) {
+	if token == "" {
+		return cachePeerExport{}, false
+	}
+	s.cachePeerExportsMu.Lock()
+	defer s.cachePeerExportsMu.Unlock()
+	if s.cachePeerExports == nil {
+		return cachePeerExport{}, false
+	}
+	export, ok := s.cachePeerExports[token]
+	if !ok {
+		return cachePeerExport{}, false
+	}
+	delete(s.cachePeerExports, token)
+	if !export.ExpiresAt.After(now) {
+		return cachePeerExport{}, false
+	}
+	return export, true
+}

--- a/internal/controlservice/cache_peer.go
+++ b/internal/controlservice/cache_peer.go
@@ -28,6 +28,7 @@ const (
 	cachePeerMissUnsupportedStage      = "unsupported stage"
 	cachePeerMissUnsupportedBackend    = "unsupported backend"
 	cachePeerMissUnsupportedDriver     = "unsupported storage driver"
+	cachePeerMissCacheStoreUnavailable = "cache metadata unavailable"
 	cachePeerMissRecordNotFound        = "record not found"
 	cachePeerMissParentRecordNotFound  = "parent record not found"
 	cachePeerMissRecordMismatch        = "record metadata mismatch"
@@ -241,7 +242,7 @@ func (s *Service) planCachePeerExport(ctx context.Context, lookup cachePeerLooku
 
 	store, err := s.cacheStoreOrErr()
 	if err != nil {
-		return cachePeerExportMatch{}, "", err
+		return cachePeerExportMatch{}, cachePeerMissCacheStoreUnavailable, nil
 	}
 	child, ok, err := store.GetReady(ctx, lookup.Stage, lookup.CacheKey)
 	if err != nil {

--- a/internal/controlservice/cache_peer_test.go
+++ b/internal/controlservice/cache_peer_test.go
@@ -1,0 +1,399 @@
+package controlservice
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/buildkite/cleanroom/internal/cachestore"
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+	"github.com/buildkite/cleanroom/internal/runtimeconfig"
+	"github.com/buildkite/cleanroom/internal/volumestore"
+)
+
+type stubCachePeerTransferDriver struct {
+	planRequests  []volumestore.IncrementalSnapshotExportRequest
+	exportPlans   []volumestore.IncrementalSnapshotExportPlan
+	exportPayload string
+}
+
+func (d *stubCachePeerTransferDriver) DescribeSnapshot(context.Context, volumestore.DescribeSnapshotRequest) (volumestore.SnapshotDescription, error) {
+	return volumestore.SnapshotDescription{}, nil
+}
+
+func (d *stubCachePeerTransferDriver) PlanIncrementalSnapshotExport(_ context.Context, req volumestore.IncrementalSnapshotExportRequest) (volumestore.IncrementalSnapshotExportPlan, error) {
+	d.planRequests = append(d.planRequests, req)
+	return volumestore.IncrementalSnapshotExportPlan{
+		FromSnapshotRef:  req.FromSnapshotRef,
+		FromSnapshotGUID: req.FromSnapshotGUID,
+		ToSnapshotRef:    req.ToSnapshotRef,
+		ToSnapshotGUID:   req.ToSnapshotGUID,
+		EstimatedBytes:   1234,
+	}, nil
+}
+
+func (d *stubCachePeerTransferDriver) ExportIncrementalSnapshot(_ context.Context, plan volumestore.IncrementalSnapshotExportPlan, dst io.Writer) error {
+	d.exportPlans = append(d.exportPlans, plan)
+	_, err := io.WriteString(dst, d.exportPayload)
+	return err
+}
+
+func (d *stubCachePeerTransferDriver) ImportIncrementalSnapshot(context.Context, volumestore.IncrementalSnapshotImportRequest, io.Reader) (volumestore.Snapshot, error) {
+	return volumestore.Snapshot{}, nil
+}
+
+func TestLookupCachePeerDependencyStageMintsBoundExportToken(t *testing.T) {
+	store := newMemoryCacheStore()
+	insertCachePeerRecord(t, store, cachePeerRecordOptions{
+		Stage:        workspaceStageName,
+		CacheKey:     "workspace-parent",
+		StorageRef:   "tank/cleanroom/snapshots/workspace@base",
+		SnapshotGUID: "parent-guid",
+	})
+	insertCachePeerRecord(t, store, cachePeerRecordOptions{
+		Stage:              dependencyStageName,
+		CacheKey:           "dependency-child",
+		ParentCacheKey:     "workspace-parent",
+		StorageRef:         "tank/cleanroom/snapshots/dependency@base",
+		SnapshotGUID:       "child-guid",
+		ParentSnapshotGUID: "parent-guid",
+		ProducerVersion:    dependencyStageProducerVersion,
+	})
+	transfer := &stubCachePeerTransferDriver{exportPayload: "zfs-stream"}
+	svc := newTestService(&stubAdapter{})
+	svc.CacheStore = store
+	svc.CachePeerTransferDriver = transfer
+	now := time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)
+	svc.runtime.clock = stubClock{now: now}
+	svc.runtime.cachePeerExportTokenTTL = time.Minute
+
+	resp, err := svc.LookupCachePeer(context.Background(), dependencyCachePeerLookupRequest())
+	if err != nil {
+		t.Fatalf("LookupCachePeer returned error: %v", err)
+	}
+	candidate := resp.GetCandidate()
+	if candidate == nil {
+		t.Fatalf("expected cache peer candidate, miss reason %q", resp.GetMissReason())
+	}
+	if got, want := candidate.GetTransferToken(), ""; got == want {
+		t.Fatal("expected transfer token")
+	}
+	if got, want := candidate.GetZfsSnapshotGuid(), "child-guid"; got != want {
+		t.Fatalf("unexpected child guid: got %q want %q", got, want)
+	}
+	if got, want := candidate.GetZfsParentSnapshotGuid(), "parent-guid"; got != want {
+		t.Fatalf("unexpected parent guid: got %q want %q", got, want)
+	}
+	if got, want := candidate.GetParentStage(), workspaceStageName; got != want {
+		t.Fatalf("unexpected parent stage: got %q want %q", got, want)
+	}
+	if got, want := candidate.GetEstimatedBytes(), int64(1234); got != want {
+		t.Fatalf("unexpected estimated bytes: got %d want %d", got, want)
+	}
+	if got, want := candidate.GetExpiresAt().AsTime(), now.Add(time.Minute); !got.Equal(want) {
+		t.Fatalf("unexpected expiry: got %s want %s", got, want)
+	}
+	if got, want := transfer.planRequests, []volumestore.IncrementalSnapshotExportRequest{{
+		FromSnapshotRef:  "tank/cleanroom/snapshots/workspace@base",
+		FromSnapshotGUID: "parent-guid",
+		ToSnapshotRef:    "tank/cleanroom/snapshots/dependency@base",
+		ToSnapshotGUID:   "child-guid",
+	}}; len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("unexpected plan requests: got %#v want %#v", got, want)
+	}
+
+	var stream bytes.Buffer
+	if err := svc.ExportCachePeerZFSIncremental(context.Background(), candidate.GetTransferToken(), &stream); err != nil {
+		t.Fatalf("ExportCachePeerZFSIncremental returned error: %v", err)
+	}
+	if got, want := stream.String(), "zfs-stream"; got != want {
+		t.Fatalf("unexpected exported stream: got %q want %q", got, want)
+	}
+	if got, want := len(transfer.planRequests), 2; got != want {
+		t.Fatalf("expected export to revalidate the candidate, plan calls got %d want %d", got, want)
+	}
+	if err := svc.ExportCachePeerZFSIncremental(context.Background(), candidate.GetTransferToken(), &stream); err != ErrCachePeerExportTokenNotFound {
+		t.Fatalf("expected single-use token error, got %v", err)
+	}
+}
+
+func TestLookupCachePeerSupportsServicesStageWithExplicitParent(t *testing.T) {
+	store := newMemoryCacheStore()
+	insertCachePeerRecord(t, store, cachePeerRecordOptions{
+		Stage:        dependencyStageName,
+		CacheKey:     "dependency-parent",
+		StorageRef:   "tank/cleanroom/snapshots/dependency@base",
+		SnapshotGUID: "parent-guid",
+	})
+	insertCachePeerRecord(t, store, cachePeerRecordOptions{
+		Stage:              servicesStageName,
+		CacheKey:           "services-child",
+		ParentCacheKey:     "dependency-parent",
+		StorageRef:         "tank/cleanroom/snapshots/services@base",
+		SnapshotGUID:       "child-guid",
+		ParentSnapshotGUID: "parent-guid",
+		ProducerVersion:    servicesStageProducerVersion,
+	})
+	transfer := &stubCachePeerTransferDriver{}
+	svc := newTestService(&stubAdapter{})
+	svc.CacheStore = store
+	svc.CachePeerTransferDriver = transfer
+
+	req := dependencyCachePeerLookupRequest()
+	req.Stage = servicesStageName
+	req.CacheKey = "services-child"
+	req.ProducerVersion = servicesStageProducerVersion
+	req.ParentStage = dependencyStageName
+	req.ParentCacheKey = "dependency-parent"
+	resp, err := svc.LookupCachePeer(context.Background(), req)
+	if err != nil {
+		t.Fatalf("LookupCachePeer returned error: %v", err)
+	}
+	candidate := resp.GetCandidate()
+	if candidate == nil {
+		t.Fatalf("expected services cache peer candidate, miss reason %q", resp.GetMissReason())
+	}
+	if got, want := candidate.GetParentStage(), dependencyStageName; got != want {
+		t.Fatalf("unexpected parent stage: got %q want %q", got, want)
+	}
+	if got, want := transfer.planRequests, []volumestore.IncrementalSnapshotExportRequest{{
+		FromSnapshotRef:  "tank/cleanroom/snapshots/dependency@base",
+		FromSnapshotGUID: "parent-guid",
+		ToSnapshotRef:    "tank/cleanroom/snapshots/services@base",
+		ToSnapshotGUID:   "child-guid",
+	}}; len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("unexpected services plan requests: got %#v want %#v", got, want)
+	}
+}
+
+func TestLookupCachePeerMissesOnParentGUIDMismatch(t *testing.T) {
+	store := newMemoryCacheStore()
+	insertCachePeerRecord(t, store, cachePeerRecordOptions{
+		Stage:        workspaceStageName,
+		CacheKey:     "workspace-parent",
+		StorageRef:   "tank/cleanroom/snapshots/workspace@base",
+		SnapshotGUID: "different-parent-guid",
+	})
+	insertCachePeerRecord(t, store, cachePeerRecordOptions{
+		Stage:              dependencyStageName,
+		CacheKey:           "dependency-child",
+		ParentCacheKey:     "workspace-parent",
+		StorageRef:         "tank/cleanroom/snapshots/dependency@base",
+		SnapshotGUID:       "child-guid",
+		ParentSnapshotGUID: "different-parent-guid",
+		ProducerVersion:    dependencyStageProducerVersion,
+	})
+	svc := newTestService(&stubAdapter{})
+	svc.CacheStore = store
+	svc.CachePeerTransferDriver = &stubCachePeerTransferDriver{}
+
+	resp, err := svc.LookupCachePeer(context.Background(), dependencyCachePeerLookupRequest())
+	if err != nil {
+		t.Fatalf("LookupCachePeer returned error: %v", err)
+	}
+	if resp.GetCandidate() != nil {
+		t.Fatalf("expected miss, got candidate %#v", resp.GetCandidate())
+	}
+	if got, want := resp.GetMissReason(), cachePeerMissParentGUIDMismatch; got != want {
+		t.Fatalf("unexpected miss reason: got %q want %q", got, want)
+	}
+}
+
+func TestLookupCachePeerMissesForIncompatibleRequests(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*cleanroomv1.LookupCachePeerRequest)
+		want   string
+	}{
+		{
+			name: "unsupported stage",
+			mutate: func(req *cleanroomv1.LookupCachePeerRequest) {
+				req.Stage = workspaceStageName
+			},
+			want: cachePeerMissUnsupportedStage,
+		},
+		{
+			name: "unsupported parent stage",
+			mutate: func(req *cleanroomv1.LookupCachePeerRequest) {
+				req.ParentStage = dependencyStageName
+			},
+			want: cachePeerMissUnsupportedParent,
+		},
+		{
+			name: "unsupported backend",
+			mutate: func(req *cleanroomv1.LookupCachePeerRequest) {
+				req.Backend = "darwin-vz"
+			},
+			want: cachePeerMissUnsupportedBackend,
+		},
+		{
+			name: "unsupported driver",
+			mutate: func(req *cleanroomv1.LookupCachePeerRequest) {
+				req.StorageDriver = "file"
+			},
+			want: cachePeerMissUnsupportedDriver,
+		},
+		{
+			name: "policy mismatch",
+			mutate: func(req *cleanroomv1.LookupCachePeerRequest) {
+				req.PolicyHash = "different-policy"
+			},
+			want: cachePeerMissRecordMismatch,
+		},
+		{
+			name:   "transfer unavailable",
+			mutate: func(*cleanroomv1.LookupCachePeerRequest) {},
+			want:   cachePeerMissTransferUnavailable,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := newMemoryCacheStore()
+			insertCachePeerRecord(t, store, cachePeerRecordOptions{
+				Stage:        workspaceStageName,
+				CacheKey:     "workspace-parent",
+				StorageRef:   "tank/cleanroom/snapshots/workspace@base",
+				SnapshotGUID: "parent-guid",
+			})
+			insertCachePeerRecord(t, store, cachePeerRecordOptions{
+				Stage:              dependencyStageName,
+				CacheKey:           "dependency-child",
+				ParentCacheKey:     "workspace-parent",
+				StorageRef:         "tank/cleanroom/snapshots/dependency@base",
+				SnapshotGUID:       "child-guid",
+				ParentSnapshotGUID: "parent-guid",
+				ProducerVersion:    dependencyStageProducerVersion,
+			})
+			svc := newTestService(&stubAdapter{})
+			svc.CacheStore = store
+			if tt.want != cachePeerMissTransferUnavailable {
+				svc.CachePeerTransferDriver = &stubCachePeerTransferDriver{}
+			}
+			req := dependencyCachePeerLookupRequest()
+			tt.mutate(req)
+
+			resp, err := svc.LookupCachePeer(context.Background(), req)
+			if err != nil {
+				t.Fatalf("LookupCachePeer returned error: %v", err)
+			}
+			if resp.GetCandidate() != nil {
+				t.Fatalf("expected miss, got candidate %#v", resp.GetCandidate())
+			}
+			if got := resp.GetMissReason(); got != tt.want {
+				t.Fatalf("unexpected miss reason: got %q want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExportCachePeerZFSIncrementalRejectsExpiredToken(t *testing.T) {
+	store := newMemoryCacheStore()
+	insertCachePeerRecord(t, store, cachePeerRecordOptions{
+		Stage:        workspaceStageName,
+		CacheKey:     "workspace-parent",
+		StorageRef:   "tank/cleanroom/snapshots/workspace@base",
+		SnapshotGUID: "parent-guid",
+	})
+	insertCachePeerRecord(t, store, cachePeerRecordOptions{
+		Stage:              dependencyStageName,
+		CacheKey:           "dependency-child",
+		ParentCacheKey:     "workspace-parent",
+		StorageRef:         "tank/cleanroom/snapshots/dependency@base",
+		SnapshotGUID:       "child-guid",
+		ParentSnapshotGUID: "parent-guid",
+		ProducerVersion:    dependencyStageProducerVersion,
+	})
+	svc := newTestService(&stubAdapter{})
+	svc.CacheStore = store
+	svc.CachePeerTransferDriver = &stubCachePeerTransferDriver{}
+	now := time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)
+	svc.runtime.clock = stubClock{now: now}
+	svc.runtime.cachePeerExportTokenTTL = time.Minute
+
+	resp, err := svc.LookupCachePeer(context.Background(), dependencyCachePeerLookupRequest())
+	if err != nil {
+		t.Fatalf("LookupCachePeer returned error: %v", err)
+	}
+	svc.runtime.clock = stubClock{now: now.Add(2 * time.Minute)}
+
+	var stream bytes.Buffer
+	if err := svc.ExportCachePeerZFSIncremental(context.Background(), resp.GetCandidate().GetTransferToken(), &stream); err != ErrCachePeerExportTokenNotFound {
+		t.Fatalf("expected expired token error, got %v", err)
+	}
+}
+
+func TestAuthorizeCachePeerBearerUsesConfiguredTokenEnv(t *testing.T) {
+	t.Setenv("CLEANROOM_CACHE_PEER_TOKEN", "shared-secret")
+	svc := newTestService(&stubAdapter{})
+	svc.Config.Cache = runtimeconfig.CacheConfig{
+		Peers: []runtimeconfig.CachePeerConfig{{URL: "https://peer.example", TokenEnv: "CLEANROOM_CACHE_PEER_TOKEN"}},
+	}
+
+	if err := svc.AuthorizeCachePeerBearer("Bearer shared-secret"); err != nil {
+		t.Fatalf("AuthorizeCachePeerBearer returned error: %v", err)
+	}
+	if err := svc.AuthorizeCachePeerBearer("Bearer wrong-secret"); err != ErrCachePeerUnauthorized {
+		t.Fatalf("expected unauthorized error for wrong token, got %v", err)
+	}
+}
+
+type cachePeerRecordOptions struct {
+	Stage              string
+	CacheKey           string
+	ParentCacheKey     string
+	StorageRef         string
+	SnapshotGUID       string
+	ParentSnapshotGUID string
+	ProducerVersion    string
+}
+
+func insertCachePeerRecord(t *testing.T, store *memoryCacheStore, opts cachePeerRecordOptions) {
+	t.Helper()
+	producerVersion := opts.ProducerVersion
+	if producerVersion == "" {
+		producerVersion = workspaceStageProducerVersion
+	}
+	metadata, err := volumestore.EncodeZFSDriverMetadata(volumestore.ZFSDriverMetadata{
+		Dataset:            opts.StorageRef,
+		SnapshotGUID:       opts.SnapshotGUID,
+		ParentSnapshotGUID: opts.ParentSnapshotGUID,
+	})
+	if err != nil {
+		t.Fatalf("encode zfs metadata: %v", err)
+	}
+	if err := store.Upsert(context.Background(), cachestore.Record{
+		CacheKey:          opts.CacheKey,
+		Stage:             opts.Stage,
+		State:             cacheStateReady,
+		BackingSnapshotID: opts.CacheKey + "-snapshot",
+		Backend:           "firecracker",
+		Architecture:      runtime.GOARCH,
+		PolicyHash:        "policy-hash",
+		ParentCacheKey:    opts.ParentCacheKey,
+		StorageDriver:     "zfs",
+		StorageRef:        opts.StorageRef,
+		DriverMetadata:    metadata,
+		ProducerVersion:   producerVersion,
+	}); err != nil {
+		t.Fatalf("insert cache peer record: %v", err)
+	}
+}
+
+func dependencyCachePeerLookupRequest() *cleanroomv1.LookupCachePeerRequest {
+	return &cleanroomv1.LookupCachePeerRequest{
+		Stage:                 dependencyStageName,
+		CacheKey:              "dependency-child",
+		Backend:               "firecracker",
+		StorageDriver:         "zfs",
+		Architecture:          runtime.GOARCH,
+		ProducerVersion:       dependencyStageProducerVersion,
+		PolicyHash:            "policy-hash",
+		ParentStage:           workspaceStageName,
+		ParentCacheKey:        "workspace-parent",
+		ParentZfsSnapshotGuid: "parent-guid",
+	}
+}

--- a/internal/controlservice/cache_peer_test.go
+++ b/internal/controlservice/cache_peer_test.go
@@ -202,6 +202,23 @@ func TestLookupCachePeerMissesOnParentGUIDMismatch(t *testing.T) {
 	}
 }
 
+func TestLookupCachePeerMissesWhenCacheStoreUnavailable(t *testing.T) {
+	svc := newTestService(&stubAdapter{})
+	svc.CacheStore = nil
+	svc.CachePeerTransferDriver = &stubCachePeerTransferDriver{}
+
+	resp, err := svc.LookupCachePeer(context.Background(), dependencyCachePeerLookupRequest())
+	if err != nil {
+		t.Fatalf("LookupCachePeer returned error: %v", err)
+	}
+	if resp.GetCandidate() != nil {
+		t.Fatalf("expected miss, got candidate %#v", resp.GetCandidate())
+	}
+	if got, want := resp.GetMissReason(), cachePeerMissCacheStoreUnavailable; got != want {
+		t.Fatalf("unexpected miss reason: got %q want %q", got, want)
+	}
+}
+
 func TestLookupCachePeerMissesForIncompatibleRequests(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/controlservice/runtime.go
+++ b/internal/controlservice/runtime.go
@@ -60,6 +60,7 @@ type serviceRuntime struct {
 	terminatedSandboxStorageCleanup func(string)
 	zfsImportDatasetStorageCleanup  func()
 	storageCleanupQueueSize         int
+	cachePeerExportTokenTTL         time.Duration
 }
 
 var defaultRetentionPolicy = retentionPolicy{
@@ -83,6 +84,7 @@ var defaultServiceTimeouts = serviceTimeouts{
 const defaultDownloadMaxBytes int64 = 10 * 1024 * 1024
 
 const defaultStorageCleanupQueueSize = 128
+const defaultCachePeerExportTokenTTL = 5 * time.Minute
 
 func (s *Service) clock() serviceClock {
 	if s.runtime.clock != nil {
@@ -124,4 +126,11 @@ func (s *Service) storageCleanupQueueSize() int {
 		return s.runtime.storageCleanupQueueSize
 	}
 	return defaultStorageCleanupQueueSize
+}
+
+func (s *Service) cachePeerExportTokenTTL() time.Duration {
+	if s.runtime.cachePeerExportTokenTTL > 0 {
+		return s.runtime.cachePeerExportTokenTTL
+	}
+	return defaultCachePeerExportTokenTTL
 }

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -29,6 +29,7 @@ import (
 	"github.com/buildkite/cleanroom/internal/runtimeconfig"
 	"github.com/buildkite/cleanroom/internal/snapshotstore"
 	"github.com/buildkite/cleanroom/internal/storagegc"
+	"github.com/buildkite/cleanroom/internal/volumestore"
 	"github.com/charmbracelet/log"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -55,10 +56,13 @@ type Service struct {
 	// adapters, sandbox state, and metadata persistence in one operation chain.
 	// If this grows again, extract a dedicated snapshot manager rather than
 	// adding more snapshot-specific branching here.
-	SnapshotStore         snapshotMetadataStore
-	CacheStore            cacheMetadataStore
-	ZFSImportDatasetStore storagegc.ZFSImportDatasetStore
-	ChangesetStore        changesetMetadataStore
+	SnapshotStore           snapshotMetadataStore
+	CacheStore              cacheMetadataStore
+	ZFSImportDatasetStore   storagegc.ZFSImportDatasetStore
+	CachePeerTransferDriver volumestore.IncrementalSnapshotTransferDriver
+	ChangesetStore          changesetMetadataStore
+	cachePeerExportsMu      sync.Mutex
+	cachePeerExports        map[string]cachePeerExport
 
 	mu                sync.RWMutex
 	sandboxes         map[string]*sandboxState

--- a/internal/gen/cleanroom/v1/cleanroomv1connect/control.connect.go
+++ b/internal/gen/cleanroom/v1/cleanroomv1connect/control.connect.go
@@ -25,6 +25,8 @@ const (
 	SandboxServiceName = "cleanroom.v1.SandboxService"
 	// SnapshotServiceName is the fully-qualified name of the SnapshotService service.
 	SnapshotServiceName = "cleanroom.v1.SnapshotService"
+	// CachePeerServiceName is the fully-qualified name of the CachePeerService service.
+	CachePeerServiceName = "cleanroom.v1.CachePeerService"
 	// ExecutionServiceName is the fully-qualified name of the ExecutionService service.
 	ExecutionServiceName = "cleanroom.v1.ExecutionService"
 )
@@ -97,6 +99,9 @@ const (
 	// SnapshotServiceDeleteSnapshotProcedure is the fully-qualified name of the SnapshotService's
 	// DeleteSnapshot RPC.
 	SnapshotServiceDeleteSnapshotProcedure = "/cleanroom.v1.SnapshotService/DeleteSnapshot"
+	// CachePeerServiceLookupCachePeerProcedure is the fully-qualified name of the CachePeerService's
+	// LookupCachePeer RPC.
+	CachePeerServiceLookupCachePeerProcedure = "/cleanroom.v1.CachePeerService/LookupCachePeer"
 	// ExecutionServiceListExecutionsProcedure is the fully-qualified name of the ExecutionService's
 	// ListExecutions RPC.
 	ExecutionServiceListExecutionsProcedure = "/cleanroom.v1.ExecutionService/ListExecutions"
@@ -732,6 +737,76 @@ func (UnimplementedSnapshotServiceHandler) ListSnapshots(context.Context, *conne
 
 func (UnimplementedSnapshotServiceHandler) DeleteSnapshot(context.Context, *connect.Request[v1.DeleteSnapshotRequest]) (*connect.Response[v1.DeleteSnapshotResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cleanroom.v1.SnapshotService.DeleteSnapshot is not implemented"))
+}
+
+// CachePeerServiceClient is a client for the cleanroom.v1.CachePeerService service.
+type CachePeerServiceClient interface {
+	LookupCachePeer(context.Context, *connect.Request[v1.LookupCachePeerRequest]) (*connect.Response[v1.LookupCachePeerResponse], error)
+}
+
+// NewCachePeerServiceClient constructs a client for the cleanroom.v1.CachePeerService service. By
+// default, it uses the Connect protocol with the binary Protobuf Codec, asks for gzipped responses,
+// and sends uncompressed requests. To use the gRPC or gRPC-Web protocols, supply the
+// connect.WithGRPC() or connect.WithGRPCWeb() options.
+//
+// The URL supplied here should be the base URL for the Connect or gRPC server (for example,
+// http://api.acme.com or https://acme.com/grpc).
+func NewCachePeerServiceClient(httpClient connect.HTTPClient, baseURL string, opts ...connect.ClientOption) CachePeerServiceClient {
+	baseURL = strings.TrimRight(baseURL, "/")
+	cachePeerServiceMethods := v1.File_proto_cleanroom_v1_control_proto.Services().ByName("CachePeerService").Methods()
+	return &cachePeerServiceClient{
+		lookupCachePeer: connect.NewClient[v1.LookupCachePeerRequest, v1.LookupCachePeerResponse](
+			httpClient,
+			baseURL+CachePeerServiceLookupCachePeerProcedure,
+			connect.WithSchema(cachePeerServiceMethods.ByName("LookupCachePeer")),
+			connect.WithClientOptions(opts...),
+		),
+	}
+}
+
+// cachePeerServiceClient implements CachePeerServiceClient.
+type cachePeerServiceClient struct {
+	lookupCachePeer *connect.Client[v1.LookupCachePeerRequest, v1.LookupCachePeerResponse]
+}
+
+// LookupCachePeer calls cleanroom.v1.CachePeerService.LookupCachePeer.
+func (c *cachePeerServiceClient) LookupCachePeer(ctx context.Context, req *connect.Request[v1.LookupCachePeerRequest]) (*connect.Response[v1.LookupCachePeerResponse], error) {
+	return c.lookupCachePeer.CallUnary(ctx, req)
+}
+
+// CachePeerServiceHandler is an implementation of the cleanroom.v1.CachePeerService service.
+type CachePeerServiceHandler interface {
+	LookupCachePeer(context.Context, *connect.Request[v1.LookupCachePeerRequest]) (*connect.Response[v1.LookupCachePeerResponse], error)
+}
+
+// NewCachePeerServiceHandler builds an HTTP handler from the service implementation. It returns the
+// path on which to mount the handler and the handler itself.
+//
+// By default, handlers support the Connect, gRPC, and gRPC-Web protocols with the binary Protobuf
+// and JSON codecs. They also support gzip compression.
+func NewCachePeerServiceHandler(svc CachePeerServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
+	cachePeerServiceMethods := v1.File_proto_cleanroom_v1_control_proto.Services().ByName("CachePeerService").Methods()
+	cachePeerServiceLookupCachePeerHandler := connect.NewUnaryHandler(
+		CachePeerServiceLookupCachePeerProcedure,
+		svc.LookupCachePeer,
+		connect.WithSchema(cachePeerServiceMethods.ByName("LookupCachePeer")),
+		connect.WithHandlerOptions(opts...),
+	)
+	return "/cleanroom.v1.CachePeerService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case CachePeerServiceLookupCachePeerProcedure:
+			cachePeerServiceLookupCachePeerHandler.ServeHTTP(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+}
+
+// UnimplementedCachePeerServiceHandler returns CodeUnimplemented from all methods.
+type UnimplementedCachePeerServiceHandler struct{}
+
+func (UnimplementedCachePeerServiceHandler) LookupCachePeer(context.Context, *connect.Request[v1.LookupCachePeerRequest]) (*connect.Response[v1.LookupCachePeerResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cleanroom.v1.CachePeerService.LookupCachePeer is not implemented"))
 }
 
 // ExecutionServiceClient is a client for the cleanroom.v1.ExecutionService service.

--- a/internal/gen/cleanroom/v1/control.pb.go
+++ b/internal/gen/cleanroom/v1/control.pb.go
@@ -4387,6 +4387,338 @@ func (x *DeleteSnapshotResponse) GetMessage() string {
 	return ""
 }
 
+type LookupCachePeerRequest struct {
+	state                 protoimpl.MessageState `protogen:"open.v1"`
+	Stage                 string                 `protobuf:"bytes,1,opt,name=stage,proto3" json:"stage,omitempty"`
+	CacheKey              string                 `protobuf:"bytes,2,opt,name=cache_key,json=cacheKey,proto3" json:"cache_key,omitempty"`
+	Backend               string                 `protobuf:"bytes,3,opt,name=backend,proto3" json:"backend,omitempty"`
+	StorageDriver         string                 `protobuf:"bytes,4,opt,name=storage_driver,json=storageDriver,proto3" json:"storage_driver,omitempty"`
+	Architecture          string                 `protobuf:"bytes,5,opt,name=architecture,proto3" json:"architecture,omitempty"`
+	ProducerVersion       string                 `protobuf:"bytes,6,opt,name=producer_version,json=producerVersion,proto3" json:"producer_version,omitempty"`
+	PolicyHash            string                 `protobuf:"bytes,7,opt,name=policy_hash,json=policyHash,proto3" json:"policy_hash,omitempty"`
+	ParentCacheKey        string                 `protobuf:"bytes,8,opt,name=parent_cache_key,json=parentCacheKey,proto3" json:"parent_cache_key,omitempty"`
+	ParentZfsSnapshotGuid string                 `protobuf:"bytes,9,opt,name=parent_zfs_snapshot_guid,json=parentZfsSnapshotGuid,proto3" json:"parent_zfs_snapshot_guid,omitempty"`
+	ParentStage           string                 `protobuf:"bytes,10,opt,name=parent_stage,json=parentStage,proto3" json:"parent_stage,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
+}
+
+func (x *LookupCachePeerRequest) Reset() {
+	*x = LookupCachePeerRequest{}
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[65]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LookupCachePeerRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LookupCachePeerRequest) ProtoMessage() {}
+
+func (x *LookupCachePeerRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[65]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LookupCachePeerRequest.ProtoReflect.Descriptor instead.
+func (*LookupCachePeerRequest) Descriptor() ([]byte, []int) {
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{65}
+}
+
+func (x *LookupCachePeerRequest) GetStage() string {
+	if x != nil {
+		return x.Stage
+	}
+	return ""
+}
+
+func (x *LookupCachePeerRequest) GetCacheKey() string {
+	if x != nil {
+		return x.CacheKey
+	}
+	return ""
+}
+
+func (x *LookupCachePeerRequest) GetBackend() string {
+	if x != nil {
+		return x.Backend
+	}
+	return ""
+}
+
+func (x *LookupCachePeerRequest) GetStorageDriver() string {
+	if x != nil {
+		return x.StorageDriver
+	}
+	return ""
+}
+
+func (x *LookupCachePeerRequest) GetArchitecture() string {
+	if x != nil {
+		return x.Architecture
+	}
+	return ""
+}
+
+func (x *LookupCachePeerRequest) GetProducerVersion() string {
+	if x != nil {
+		return x.ProducerVersion
+	}
+	return ""
+}
+
+func (x *LookupCachePeerRequest) GetPolicyHash() string {
+	if x != nil {
+		return x.PolicyHash
+	}
+	return ""
+}
+
+func (x *LookupCachePeerRequest) GetParentCacheKey() string {
+	if x != nil {
+		return x.ParentCacheKey
+	}
+	return ""
+}
+
+func (x *LookupCachePeerRequest) GetParentZfsSnapshotGuid() string {
+	if x != nil {
+		return x.ParentZfsSnapshotGuid
+	}
+	return ""
+}
+
+func (x *LookupCachePeerRequest) GetParentStage() string {
+	if x != nil {
+		return x.ParentStage
+	}
+	return ""
+}
+
+type LookupCachePeerResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Candidate     *CachePeerCandidate    `protobuf:"bytes,1,opt,name=candidate,proto3" json:"candidate,omitempty"`
+	MissReason    string                 `protobuf:"bytes,2,opt,name=miss_reason,json=missReason,proto3" json:"miss_reason,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *LookupCachePeerResponse) Reset() {
+	*x = LookupCachePeerResponse{}
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[66]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LookupCachePeerResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LookupCachePeerResponse) ProtoMessage() {}
+
+func (x *LookupCachePeerResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[66]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LookupCachePeerResponse.ProtoReflect.Descriptor instead.
+func (*LookupCachePeerResponse) Descriptor() ([]byte, []int) {
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{66}
+}
+
+func (x *LookupCachePeerResponse) GetCandidate() *CachePeerCandidate {
+	if x != nil {
+		return x.Candidate
+	}
+	return nil
+}
+
+func (x *LookupCachePeerResponse) GetMissReason() string {
+	if x != nil {
+		return x.MissReason
+	}
+	return ""
+}
+
+type CachePeerCandidate struct {
+	state                 protoimpl.MessageState `protogen:"open.v1"`
+	TransferToken         string                 `protobuf:"bytes,1,opt,name=transfer_token,json=transferToken,proto3" json:"transfer_token,omitempty"`
+	Stage                 string                 `protobuf:"bytes,2,opt,name=stage,proto3" json:"stage,omitempty"`
+	CacheKey              string                 `protobuf:"bytes,3,opt,name=cache_key,json=cacheKey,proto3" json:"cache_key,omitempty"`
+	BackingSnapshotId     string                 `protobuf:"bytes,4,opt,name=backing_snapshot_id,json=backingSnapshotId,proto3" json:"backing_snapshot_id,omitempty"`
+	StorageRef            string                 `protobuf:"bytes,5,opt,name=storage_ref,json=storageRef,proto3" json:"storage_ref,omitempty"`
+	ParentCacheKey        string                 `protobuf:"bytes,6,opt,name=parent_cache_key,json=parentCacheKey,proto3" json:"parent_cache_key,omitempty"`
+	ZfsSnapshotGuid       string                 `protobuf:"bytes,7,opt,name=zfs_snapshot_guid,json=zfsSnapshotGuid,proto3" json:"zfs_snapshot_guid,omitempty"`
+	ZfsParentSnapshotGuid string                 `protobuf:"bytes,8,opt,name=zfs_parent_snapshot_guid,json=zfsParentSnapshotGuid,proto3" json:"zfs_parent_snapshot_guid,omitempty"`
+	ProducerVersion       string                 `protobuf:"bytes,9,opt,name=producer_version,json=producerVersion,proto3" json:"producer_version,omitempty"`
+	Backend               string                 `protobuf:"bytes,10,opt,name=backend,proto3" json:"backend,omitempty"`
+	StorageDriver         string                 `protobuf:"bytes,11,opt,name=storage_driver,json=storageDriver,proto3" json:"storage_driver,omitempty"`
+	Architecture          string                 `protobuf:"bytes,12,opt,name=architecture,proto3" json:"architecture,omitempty"`
+	PolicyHash            string                 `protobuf:"bytes,13,opt,name=policy_hash,json=policyHash,proto3" json:"policy_hash,omitempty"`
+	EstimatedBytes        int64                  `protobuf:"varint,14,opt,name=estimated_bytes,json=estimatedBytes,proto3" json:"estimated_bytes,omitempty"`
+	ExpiresAt             *timestamppb.Timestamp `protobuf:"bytes,15,opt,name=expires_at,json=expiresAt,proto3" json:"expires_at,omitempty"`
+	ParentStage           string                 `protobuf:"bytes,16,opt,name=parent_stage,json=parentStage,proto3" json:"parent_stage,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
+}
+
+func (x *CachePeerCandidate) Reset() {
+	*x = CachePeerCandidate{}
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[67]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CachePeerCandidate) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CachePeerCandidate) ProtoMessage() {}
+
+func (x *CachePeerCandidate) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[67]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CachePeerCandidate.ProtoReflect.Descriptor instead.
+func (*CachePeerCandidate) Descriptor() ([]byte, []int) {
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{67}
+}
+
+func (x *CachePeerCandidate) GetTransferToken() string {
+	if x != nil {
+		return x.TransferToken
+	}
+	return ""
+}
+
+func (x *CachePeerCandidate) GetStage() string {
+	if x != nil {
+		return x.Stage
+	}
+	return ""
+}
+
+func (x *CachePeerCandidate) GetCacheKey() string {
+	if x != nil {
+		return x.CacheKey
+	}
+	return ""
+}
+
+func (x *CachePeerCandidate) GetBackingSnapshotId() string {
+	if x != nil {
+		return x.BackingSnapshotId
+	}
+	return ""
+}
+
+func (x *CachePeerCandidate) GetStorageRef() string {
+	if x != nil {
+		return x.StorageRef
+	}
+	return ""
+}
+
+func (x *CachePeerCandidate) GetParentCacheKey() string {
+	if x != nil {
+		return x.ParentCacheKey
+	}
+	return ""
+}
+
+func (x *CachePeerCandidate) GetZfsSnapshotGuid() string {
+	if x != nil {
+		return x.ZfsSnapshotGuid
+	}
+	return ""
+}
+
+func (x *CachePeerCandidate) GetZfsParentSnapshotGuid() string {
+	if x != nil {
+		return x.ZfsParentSnapshotGuid
+	}
+	return ""
+}
+
+func (x *CachePeerCandidate) GetProducerVersion() string {
+	if x != nil {
+		return x.ProducerVersion
+	}
+	return ""
+}
+
+func (x *CachePeerCandidate) GetBackend() string {
+	if x != nil {
+		return x.Backend
+	}
+	return ""
+}
+
+func (x *CachePeerCandidate) GetStorageDriver() string {
+	if x != nil {
+		return x.StorageDriver
+	}
+	return ""
+}
+
+func (x *CachePeerCandidate) GetArchitecture() string {
+	if x != nil {
+		return x.Architecture
+	}
+	return ""
+}
+
+func (x *CachePeerCandidate) GetPolicyHash() string {
+	if x != nil {
+		return x.PolicyHash
+	}
+	return ""
+}
+
+func (x *CachePeerCandidate) GetEstimatedBytes() int64 {
+	if x != nil {
+		return x.EstimatedBytes
+	}
+	return 0
+}
+
+func (x *CachePeerCandidate) GetExpiresAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.ExpiresAt
+	}
+	return nil
+}
+
+func (x *CachePeerCandidate) GetParentStage() string {
+	if x != nil {
+		return x.ParentStage
+	}
+	return ""
+}
+
 type Execution struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	ExecutionId   string                 `protobuf:"bytes,1,opt,name=execution_id,json=executionId,proto3" json:"execution_id,omitempty"`
@@ -4404,7 +4736,7 @@ type Execution struct {
 
 func (x *Execution) Reset() {
 	*x = Execution{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[65]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4416,7 +4748,7 @@ func (x *Execution) String() string {
 func (*Execution) ProtoMessage() {}
 
 func (x *Execution) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[65]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4429,7 +4761,7 @@ func (x *Execution) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Execution.ProtoReflect.Descriptor instead.
 func (*Execution) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{65}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *Execution) GetExecutionId() string {
@@ -4507,7 +4839,7 @@ type ExecutionOptions struct {
 
 func (x *ExecutionOptions) Reset() {
 	*x = ExecutionOptions{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[66]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4519,7 +4851,7 @@ func (x *ExecutionOptions) String() string {
 func (*ExecutionOptions) ProtoMessage() {}
 
 func (x *ExecutionOptions) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[66]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4532,7 +4864,7 @@ func (x *ExecutionOptions) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionOptions.ProtoReflect.Descriptor instead.
 func (*ExecutionOptions) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{66}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{69}
 }
 
 func (x *ExecutionOptions) GetLaunchSeconds() int64 {
@@ -4577,7 +4909,7 @@ type CreateExecutionRequest struct {
 
 func (x *CreateExecutionRequest) Reset() {
 	*x = CreateExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[67]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4589,7 +4921,7 @@ func (x *CreateExecutionRequest) String() string {
 func (*CreateExecutionRequest) ProtoMessage() {}
 
 func (x *CreateExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[67]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4602,7 +4934,7 @@ func (x *CreateExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateExecutionRequest.ProtoReflect.Descriptor instead.
 func (*CreateExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{67}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *CreateExecutionRequest) GetSandboxId() string {
@@ -4656,7 +4988,7 @@ type CreateExecutionResponse struct {
 
 func (x *CreateExecutionResponse) Reset() {
 	*x = CreateExecutionResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[68]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4668,7 +5000,7 @@ func (x *CreateExecutionResponse) String() string {
 func (*CreateExecutionResponse) ProtoMessage() {}
 
 func (x *CreateExecutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[68]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4681,7 +5013,7 @@ func (x *CreateExecutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateExecutionResponse.ProtoReflect.Descriptor instead.
 func (*CreateExecutionResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{68}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *CreateExecutionResponse) GetExecution() *Execution {
@@ -4703,7 +5035,7 @@ type AttachExecutionRequest struct {
 
 func (x *AttachExecutionRequest) Reset() {
 	*x = AttachExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[69]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4715,7 +5047,7 @@ func (x *AttachExecutionRequest) String() string {
 func (*AttachExecutionRequest) ProtoMessage() {}
 
 func (x *AttachExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[69]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4728,7 +5060,7 @@ func (x *AttachExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachExecutionRequest.ProtoReflect.Descriptor instead.
 func (*AttachExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{69}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *AttachExecutionRequest) GetSandboxId() string {
@@ -4773,7 +5105,7 @@ type AttachExecutionResponse struct {
 
 func (x *AttachExecutionResponse) Reset() {
 	*x = AttachExecutionResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[70]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4785,7 +5117,7 @@ func (x *AttachExecutionResponse) String() string {
 func (*AttachExecutionResponse) ProtoMessage() {}
 
 func (x *AttachExecutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[70]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4798,7 +5130,7 @@ func (x *AttachExecutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachExecutionResponse.ProtoReflect.Descriptor instead.
 func (*AttachExecutionResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{70}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *AttachExecutionResponse) GetSessionId() string {
@@ -4853,7 +5185,7 @@ type GetExecutionRequest struct {
 
 func (x *GetExecutionRequest) Reset() {
 	*x = GetExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[71]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4865,7 +5197,7 @@ func (x *GetExecutionRequest) String() string {
 func (*GetExecutionRequest) ProtoMessage() {}
 
 func (x *GetExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[71]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4878,7 +5210,7 @@ func (x *GetExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetExecutionRequest.ProtoReflect.Descriptor instead.
 func (*GetExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{71}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{74}
 }
 
 func (x *GetExecutionRequest) GetSandboxId() string {
@@ -4904,7 +5236,7 @@ type GetExecutionResponse struct {
 
 func (x *GetExecutionResponse) Reset() {
 	*x = GetExecutionResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[72]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4916,7 +5248,7 @@ func (x *GetExecutionResponse) String() string {
 func (*GetExecutionResponse) ProtoMessage() {}
 
 func (x *GetExecutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[72]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4929,7 +5261,7 @@ func (x *GetExecutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetExecutionResponse.ProtoReflect.Descriptor instead.
 func (*GetExecutionResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{72}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{75}
 }
 
 func (x *GetExecutionResponse) GetExecution() *Execution {
@@ -4949,7 +5281,7 @@ type InspectExecutionRequest struct {
 
 func (x *InspectExecutionRequest) Reset() {
 	*x = InspectExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[73]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4961,7 +5293,7 @@ func (x *InspectExecutionRequest) String() string {
 func (*InspectExecutionRequest) ProtoMessage() {}
 
 func (x *InspectExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[73]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4974,7 +5306,7 @@ func (x *InspectExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectExecutionRequest.ProtoReflect.Descriptor instead.
 func (*InspectExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{73}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{76}
 }
 
 func (x *InspectExecutionRequest) GetSandboxId() string {
@@ -5011,7 +5343,7 @@ type InspectExecutionResponse struct {
 
 func (x *InspectExecutionResponse) Reset() {
 	*x = InspectExecutionResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[74]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5023,7 +5355,7 @@ func (x *InspectExecutionResponse) String() string {
 func (*InspectExecutionResponse) ProtoMessage() {}
 
 func (x *InspectExecutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[74]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5036,7 +5368,7 @@ func (x *InspectExecutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectExecutionResponse.ProtoReflect.Descriptor instead.
 func (*InspectExecutionResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{74}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{77}
 }
 
 func (x *InspectExecutionResponse) GetExecution() *Execution {
@@ -5134,7 +5466,7 @@ type CancelExecutionRequest struct {
 
 func (x *CancelExecutionRequest) Reset() {
 	*x = CancelExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[75]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5146,7 +5478,7 @@ func (x *CancelExecutionRequest) String() string {
 func (*CancelExecutionRequest) ProtoMessage() {}
 
 func (x *CancelExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[75]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5159,7 +5491,7 @@ func (x *CancelExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelExecutionRequest.ProtoReflect.Descriptor instead.
 func (*CancelExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{75}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{78}
 }
 
 func (x *CancelExecutionRequest) GetSandboxId() string {
@@ -5195,7 +5527,7 @@ type CancelExecutionResponse struct {
 
 func (x *CancelExecutionResponse) Reset() {
 	*x = CancelExecutionResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[76]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5207,7 +5539,7 @@ func (x *CancelExecutionResponse) String() string {
 func (*CancelExecutionResponse) ProtoMessage() {}
 
 func (x *CancelExecutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[76]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5220,7 +5552,7 @@ func (x *CancelExecutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelExecutionResponse.ProtoReflect.Descriptor instead.
 func (*CancelExecutionResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{76}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{79}
 }
 
 func (x *CancelExecutionResponse) GetSandboxId() string {
@@ -5262,7 +5594,7 @@ type WriteExecutionStdinRequest struct {
 
 func (x *WriteExecutionStdinRequest) Reset() {
 	*x = WriteExecutionStdinRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[77]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5274,7 +5606,7 @@ func (x *WriteExecutionStdinRequest) String() string {
 func (*WriteExecutionStdinRequest) ProtoMessage() {}
 
 func (x *WriteExecutionStdinRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[77]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5287,7 +5619,7 @@ func (x *WriteExecutionStdinRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WriteExecutionStdinRequest.ProtoReflect.Descriptor instead.
 func (*WriteExecutionStdinRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{77}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{80}
 }
 
 func (x *WriteExecutionStdinRequest) GetSandboxId() string {
@@ -5319,7 +5651,7 @@ type WriteExecutionStdinResponse struct {
 
 func (x *WriteExecutionStdinResponse) Reset() {
 	*x = WriteExecutionStdinResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[78]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5331,7 +5663,7 @@ func (x *WriteExecutionStdinResponse) String() string {
 func (*WriteExecutionStdinResponse) ProtoMessage() {}
 
 func (x *WriteExecutionStdinResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[78]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5344,7 +5676,7 @@ func (x *WriteExecutionStdinResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WriteExecutionStdinResponse.ProtoReflect.Descriptor instead.
 func (*WriteExecutionStdinResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{78}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{81}
 }
 
 type CloseExecutionStdinRequest struct {
@@ -5357,7 +5689,7 @@ type CloseExecutionStdinRequest struct {
 
 func (x *CloseExecutionStdinRequest) Reset() {
 	*x = CloseExecutionStdinRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[79]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5369,7 +5701,7 @@ func (x *CloseExecutionStdinRequest) String() string {
 func (*CloseExecutionStdinRequest) ProtoMessage() {}
 
 func (x *CloseExecutionStdinRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[79]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5382,7 +5714,7 @@ func (x *CloseExecutionStdinRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CloseExecutionStdinRequest.ProtoReflect.Descriptor instead.
 func (*CloseExecutionStdinRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{79}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{82}
 }
 
 func (x *CloseExecutionStdinRequest) GetSandboxId() string {
@@ -5407,7 +5739,7 @@ type CloseExecutionStdinResponse struct {
 
 func (x *CloseExecutionStdinResponse) Reset() {
 	*x = CloseExecutionStdinResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[80]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5419,7 +5751,7 @@ func (x *CloseExecutionStdinResponse) String() string {
 func (*CloseExecutionStdinResponse) ProtoMessage() {}
 
 func (x *CloseExecutionStdinResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[80]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5432,7 +5764,7 @@ func (x *CloseExecutionStdinResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CloseExecutionStdinResponse.ProtoReflect.Descriptor instead.
 func (*CloseExecutionStdinResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{80}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{83}
 }
 
 type StreamExecutionRequest struct {
@@ -5446,7 +5778,7 @@ type StreamExecutionRequest struct {
 
 func (x *StreamExecutionRequest) Reset() {
 	*x = StreamExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[81]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5458,7 +5790,7 @@ func (x *StreamExecutionRequest) String() string {
 func (*StreamExecutionRequest) ProtoMessage() {}
 
 func (x *StreamExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[81]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5471,7 +5803,7 @@ func (x *StreamExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamExecutionRequest.ProtoReflect.Descriptor instead.
 func (*StreamExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{81}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{84}
 }
 
 func (x *StreamExecutionRequest) GetSandboxId() string {
@@ -5506,7 +5838,7 @@ type ExecutionExit struct {
 
 func (x *ExecutionExit) Reset() {
 	*x = ExecutionExit{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[82]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5518,7 +5850,7 @@ func (x *ExecutionExit) String() string {
 func (*ExecutionExit) ProtoMessage() {}
 
 func (x *ExecutionExit) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[82]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5531,7 +5863,7 @@ func (x *ExecutionExit) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionExit.ProtoReflect.Descriptor instead.
 func (*ExecutionExit) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{82}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{85}
 }
 
 func (x *ExecutionExit) GetExitCode() int32 {
@@ -5577,7 +5909,7 @@ type ExecutionStreamEvent struct {
 
 func (x *ExecutionStreamEvent) Reset() {
 	*x = ExecutionStreamEvent{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[83]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[86]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5589,7 +5921,7 @@ func (x *ExecutionStreamEvent) String() string {
 func (*ExecutionStreamEvent) ProtoMessage() {}
 
 func (x *ExecutionStreamEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[83]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[86]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5602,7 +5934,7 @@ func (x *ExecutionStreamEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionStreamEvent.ProtoReflect.Descriptor instead.
 func (*ExecutionStreamEvent) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{83}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{86}
 }
 
 func (x *ExecutionStreamEvent) GetSandboxId() string {
@@ -5742,7 +6074,7 @@ type SandboxPortOpenResult struct {
 
 func (x *SandboxPortOpenResult) Reset() {
 	*x = SandboxPortOpenResult{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[84]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5754,7 +6086,7 @@ func (x *SandboxPortOpenResult) String() string {
 func (*SandboxPortOpenResult) ProtoMessage() {}
 
 func (x *SandboxPortOpenResult) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[84]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5767,7 +6099,7 @@ func (x *SandboxPortOpenResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxPortOpenResult.ProtoReflect.Descriptor instead.
 func (*SandboxPortOpenResult) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{84}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{87}
 }
 
 func (x *SandboxPortOpenResult) GetError() string {
@@ -6107,7 +6439,45 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\vsnapshot_id\x18\x01 \x01(\tR\n" +
 	"snapshotId\x12\x18\n" +
 	"\adeleted\x18\x02 \x01(\bR\adeleted\x12\x18\n" +
-	"\amessage\x18\x03 \x01(\tR\amessage\"\x84\x03\n" +
+	"\amessage\x18\x03 \x01(\tR\amessage\"\x82\x03\n" +
+	"\x16LookupCachePeerRequest\x12\x14\n" +
+	"\x05stage\x18\x01 \x01(\tR\x05stage\x12\x1b\n" +
+	"\tcache_key\x18\x02 \x01(\tR\bcacheKey\x12\x18\n" +
+	"\abackend\x18\x03 \x01(\tR\abackend\x12%\n" +
+	"\x0estorage_driver\x18\x04 \x01(\tR\rstorageDriver\x12\"\n" +
+	"\farchitecture\x18\x05 \x01(\tR\farchitecture\x12)\n" +
+	"\x10producer_version\x18\x06 \x01(\tR\x0fproducerVersion\x12\x1f\n" +
+	"\vpolicy_hash\x18\a \x01(\tR\n" +
+	"policyHash\x12(\n" +
+	"\x10parent_cache_key\x18\b \x01(\tR\x0eparentCacheKey\x127\n" +
+	"\x18parent_zfs_snapshot_guid\x18\t \x01(\tR\x15parentZfsSnapshotGuid\x12!\n" +
+	"\fparent_stage\x18\n" +
+	" \x01(\tR\vparentStage\"z\n" +
+	"\x17LookupCachePeerResponse\x12>\n" +
+	"\tcandidate\x18\x01 \x01(\v2 .cleanroom.v1.CachePeerCandidateR\tcandidate\x12\x1f\n" +
+	"\vmiss_reason\x18\x02 \x01(\tR\n" +
+	"missReason\"\x86\x05\n" +
+	"\x12CachePeerCandidate\x12%\n" +
+	"\x0etransfer_token\x18\x01 \x01(\tR\rtransferToken\x12\x14\n" +
+	"\x05stage\x18\x02 \x01(\tR\x05stage\x12\x1b\n" +
+	"\tcache_key\x18\x03 \x01(\tR\bcacheKey\x12.\n" +
+	"\x13backing_snapshot_id\x18\x04 \x01(\tR\x11backingSnapshotId\x12\x1f\n" +
+	"\vstorage_ref\x18\x05 \x01(\tR\n" +
+	"storageRef\x12(\n" +
+	"\x10parent_cache_key\x18\x06 \x01(\tR\x0eparentCacheKey\x12*\n" +
+	"\x11zfs_snapshot_guid\x18\a \x01(\tR\x0fzfsSnapshotGuid\x127\n" +
+	"\x18zfs_parent_snapshot_guid\x18\b \x01(\tR\x15zfsParentSnapshotGuid\x12)\n" +
+	"\x10producer_version\x18\t \x01(\tR\x0fproducerVersion\x12\x18\n" +
+	"\abackend\x18\n" +
+	" \x01(\tR\abackend\x12%\n" +
+	"\x0estorage_driver\x18\v \x01(\tR\rstorageDriver\x12\"\n" +
+	"\farchitecture\x18\f \x01(\tR\farchitecture\x12\x1f\n" +
+	"\vpolicy_hash\x18\r \x01(\tR\n" +
+	"policyHash\x12'\n" +
+	"\x0festimated_bytes\x18\x0e \x01(\x03R\x0eestimatedBytes\x129\n" +
+	"\n" +
+	"expires_at\x18\x0f \x01(\v2\x1a.google.protobuf.TimestampR\texpiresAt\x12!\n" +
+	"\fparent_stage\x18\x10 \x01(\tR\vparentStage\"\x84\x03\n" +
 	"\tExecution\x12!\n" +
 	"\fexecution_id\x18\x01 \x01(\tR\vexecutionId\x12\x1d\n" +
 	"\n" +
@@ -6293,7 +6663,9 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\x0eCreateSnapshot\x12#.cleanroom.v1.CreateSnapshotRequest\x1a$.cleanroom.v1.CreateSnapshotResponse\x12R\n" +
 	"\vGetSnapshot\x12 .cleanroom.v1.GetSnapshotRequest\x1a!.cleanroom.v1.GetSnapshotResponse\x12X\n" +
 	"\rListSnapshots\x12\".cleanroom.v1.ListSnapshotsRequest\x1a#.cleanroom.v1.ListSnapshotsResponse\x12[\n" +
-	"\x0eDeleteSnapshot\x12#.cleanroom.v1.DeleteSnapshotRequest\x1a$.cleanroom.v1.DeleteSnapshotResponse2\x80\a\n" +
+	"\x0eDeleteSnapshot\x12#.cleanroom.v1.DeleteSnapshotRequest\x1a$.cleanroom.v1.DeleteSnapshotResponse2r\n" +
+	"\x10CachePeerService\x12^\n" +
+	"\x0fLookupCachePeer\x12$.cleanroom.v1.LookupCachePeerRequest\x1a%.cleanroom.v1.LookupCachePeerResponse2\x80\a\n" +
 	"\x10ExecutionService\x12[\n" +
 	"\x0eListExecutions\x12#.cleanroom.v1.ListExecutionsRequest\x1a$.cleanroom.v1.ListExecutionsResponse\x12^\n" +
 	"\x0fCreateExecution\x12$.cleanroom.v1.CreateExecutionRequest\x1a%.cleanroom.v1.CreateExecutionResponse\x12^\n" +
@@ -6318,7 +6690,7 @@ func file_proto_cleanroom_v1_control_proto_rawDescGZIP() []byte {
 }
 
 var file_proto_cleanroom_v1_control_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_proto_cleanroom_v1_control_proto_msgTypes = make([]protoimpl.MessageInfo, 87)
+var file_proto_cleanroom_v1_control_proto_msgTypes = make([]protoimpl.MessageInfo, 90)
 var file_proto_cleanroom_v1_control_proto_goTypes = []any{
 	(SandboxStatus)(0),                    // 0: cleanroom.v1.SandboxStatus
 	(CreateSandboxPhase)(0),               // 1: cleanroom.v1.CreateSandboxPhase
@@ -6390,164 +6762,171 @@ var file_proto_cleanroom_v1_control_proto_goTypes = []any{
 	(*ListSnapshotsResponse)(nil),         // 67: cleanroom.v1.ListSnapshotsResponse
 	(*DeleteSnapshotRequest)(nil),         // 68: cleanroom.v1.DeleteSnapshotRequest
 	(*DeleteSnapshotResponse)(nil),        // 69: cleanroom.v1.DeleteSnapshotResponse
-	(*Execution)(nil),                     // 70: cleanroom.v1.Execution
-	(*ExecutionOptions)(nil),              // 71: cleanroom.v1.ExecutionOptions
-	(*CreateExecutionRequest)(nil),        // 72: cleanroom.v1.CreateExecutionRequest
-	(*CreateExecutionResponse)(nil),       // 73: cleanroom.v1.CreateExecutionResponse
-	(*AttachExecutionRequest)(nil),        // 74: cleanroom.v1.AttachExecutionRequest
-	(*AttachExecutionResponse)(nil),       // 75: cleanroom.v1.AttachExecutionResponse
-	(*GetExecutionRequest)(nil),           // 76: cleanroom.v1.GetExecutionRequest
-	(*GetExecutionResponse)(nil),          // 77: cleanroom.v1.GetExecutionResponse
-	(*InspectExecutionRequest)(nil),       // 78: cleanroom.v1.InspectExecutionRequest
-	(*InspectExecutionResponse)(nil),      // 79: cleanroom.v1.InspectExecutionResponse
-	(*CancelExecutionRequest)(nil),        // 80: cleanroom.v1.CancelExecutionRequest
-	(*CancelExecutionResponse)(nil),       // 81: cleanroom.v1.CancelExecutionResponse
-	(*WriteExecutionStdinRequest)(nil),    // 82: cleanroom.v1.WriteExecutionStdinRequest
-	(*WriteExecutionStdinResponse)(nil),   // 83: cleanroom.v1.WriteExecutionStdinResponse
-	(*CloseExecutionStdinRequest)(nil),    // 84: cleanroom.v1.CloseExecutionStdinRequest
-	(*CloseExecutionStdinResponse)(nil),   // 85: cleanroom.v1.CloseExecutionStdinResponse
-	(*StreamExecutionRequest)(nil),        // 86: cleanroom.v1.StreamExecutionRequest
-	(*ExecutionExit)(nil),                 // 87: cleanroom.v1.ExecutionExit
-	(*ExecutionStreamEvent)(nil),          // 88: cleanroom.v1.ExecutionStreamEvent
-	(*SandboxPortOpenResult)(nil),         // 89: cleanroom.v1.SandboxPortOpenResult
-	nil,                                   // 90: cleanroom.v1.Sandbox.BackendCapabilitiesEntry
-	nil,                                   // 91: cleanroom.v1.PolicyBlock.EnvEntry
-	(*timestamppb.Timestamp)(nil),         // 92: google.protobuf.Timestamp
-	(*structpb.Struct)(nil),               // 93: google.protobuf.Struct
+	(*LookupCachePeerRequest)(nil),        // 70: cleanroom.v1.LookupCachePeerRequest
+	(*LookupCachePeerResponse)(nil),       // 71: cleanroom.v1.LookupCachePeerResponse
+	(*CachePeerCandidate)(nil),            // 72: cleanroom.v1.CachePeerCandidate
+	(*Execution)(nil),                     // 73: cleanroom.v1.Execution
+	(*ExecutionOptions)(nil),              // 74: cleanroom.v1.ExecutionOptions
+	(*CreateExecutionRequest)(nil),        // 75: cleanroom.v1.CreateExecutionRequest
+	(*CreateExecutionResponse)(nil),       // 76: cleanroom.v1.CreateExecutionResponse
+	(*AttachExecutionRequest)(nil),        // 77: cleanroom.v1.AttachExecutionRequest
+	(*AttachExecutionResponse)(nil),       // 78: cleanroom.v1.AttachExecutionResponse
+	(*GetExecutionRequest)(nil),           // 79: cleanroom.v1.GetExecutionRequest
+	(*GetExecutionResponse)(nil),          // 80: cleanroom.v1.GetExecutionResponse
+	(*InspectExecutionRequest)(nil),       // 81: cleanroom.v1.InspectExecutionRequest
+	(*InspectExecutionResponse)(nil),      // 82: cleanroom.v1.InspectExecutionResponse
+	(*CancelExecutionRequest)(nil),        // 83: cleanroom.v1.CancelExecutionRequest
+	(*CancelExecutionResponse)(nil),       // 84: cleanroom.v1.CancelExecutionResponse
+	(*WriteExecutionStdinRequest)(nil),    // 85: cleanroom.v1.WriteExecutionStdinRequest
+	(*WriteExecutionStdinResponse)(nil),   // 86: cleanroom.v1.WriteExecutionStdinResponse
+	(*CloseExecutionStdinRequest)(nil),    // 87: cleanroom.v1.CloseExecutionStdinRequest
+	(*CloseExecutionStdinResponse)(nil),   // 88: cleanroom.v1.CloseExecutionStdinResponse
+	(*StreamExecutionRequest)(nil),        // 89: cleanroom.v1.StreamExecutionRequest
+	(*ExecutionExit)(nil),                 // 90: cleanroom.v1.ExecutionExit
+	(*ExecutionStreamEvent)(nil),          // 91: cleanroom.v1.ExecutionStreamEvent
+	(*SandboxPortOpenResult)(nil),         // 92: cleanroom.v1.SandboxPortOpenResult
+	nil,                                   // 93: cleanroom.v1.Sandbox.BackendCapabilitiesEntry
+	nil,                                   // 94: cleanroom.v1.PolicyBlock.EnvEntry
+	(*timestamppb.Timestamp)(nil),         // 95: google.protobuf.Timestamp
+	(*structpb.Struct)(nil),               // 96: google.protobuf.Struct
 }
 var file_proto_cleanroom_v1_control_proto_depIdxs = []int32{
-	0,  // 0: cleanroom.v1.Sandbox.status:type_name -> cleanroom.v1.SandboxStatus
-	92, // 1: cleanroom.v1.Sandbox.created_at:type_name -> google.protobuf.Timestamp
-	92, // 2: cleanroom.v1.Sandbox.updated_at:type_name -> google.protobuf.Timestamp
-	24, // 3: cleanroom.v1.Sandbox.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
-	90, // 4: cleanroom.v1.Sandbox.backend_capabilities:type_name -> cleanroom.v1.Sandbox.BackendCapabilitiesEntry
-	8,  // 5: cleanroom.v1.SandboxPortFrame.open:type_name -> cleanroom.v1.SandboxPortOpen
-	9,  // 6: cleanroom.v1.SandboxPortFrame.close_write:type_name -> cleanroom.v1.SandboxPortCloseWrite
-	89, // 7: cleanroom.v1.SandboxPortFrame.open_result:type_name -> cleanroom.v1.SandboxPortOpenResult
-	92, // 8: cleanroom.v1.Snapshot.created_at:type_name -> google.protobuf.Timestamp
-	24, // 9: cleanroom.v1.Snapshot.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
-	13, // 10: cleanroom.v1.PolicyBlock.inputs:type_name -> cleanroom.v1.PolicyBlockInputs
-	91, // 11: cleanroom.v1.PolicyBlock.env:type_name -> cleanroom.v1.PolicyBlock.EnvEntry
-	14, // 12: cleanroom.v1.PolicyBlock.outputs:type_name -> cleanroom.v1.PolicyBlockOutputs
-	15, // 13: cleanroom.v1.PolicyServices.blocks:type_name -> cleanroom.v1.PolicyBlock
-	15, // 14: cleanroom.v1.PolicyDependencies.blocks:type_name -> cleanroom.v1.PolicyBlock
-	11, // 15: cleanroom.v1.PolicyNetwork.allow:type_name -> cleanroom.v1.PolicyAllowRule
-	19, // 16: cleanroom.v1.PolicyNetworkStages.workspace:type_name -> cleanroom.v1.PolicyNetwork
-	19, // 17: cleanroom.v1.PolicyNetworkStages.dependencies:type_name -> cleanroom.v1.PolicyNetwork
-	19, // 18: cleanroom.v1.PolicyNetworkStages.services:type_name -> cleanroom.v1.PolicyNetwork
-	19, // 19: cleanroom.v1.PolicyNetworkStages.execution:type_name -> cleanroom.v1.PolicyNetwork
-	11, // 20: cleanroom.v1.Policy.allow:type_name -> cleanroom.v1.PolicyAllowRule
-	16, // 21: cleanroom.v1.Policy.services:type_name -> cleanroom.v1.PolicyServices
-	17, // 22: cleanroom.v1.Policy.dependencies:type_name -> cleanroom.v1.PolicyDependencies
-	18, // 23: cleanroom.v1.Policy.run:type_name -> cleanroom.v1.PolicyRun
-	21, // 24: cleanroom.v1.Policy.resources:type_name -> cleanroom.v1.PolicyResources
-	20, // 25: cleanroom.v1.Policy.network_stages:type_name -> cleanroom.v1.PolicyNetworkStages
-	12, // 26: cleanroom.v1.Policy.docker:type_name -> cleanroom.v1.PolicyDocker
-	25, // 27: cleanroom.v1.RepositoryChangeset.files:type_name -> cleanroom.v1.RepositoryChangesetFile
-	23, // 28: cleanroom.v1.CreateSandboxRequest.options:type_name -> cleanroom.v1.SandboxOptions
-	22, // 29: cleanroom.v1.CreateSandboxRequest.policy:type_name -> cleanroom.v1.Policy
-	24, // 30: cleanroom.v1.CreateSandboxRequest.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
-	26, // 31: cleanroom.v1.CreateSandboxRequest.repository_changeset:type_name -> cleanroom.v1.RepositoryChangeset
-	27, // 32: cleanroom.v1.CreateSandboxRequest.repository_commit_bundle:type_name -> cleanroom.v1.RepositoryCommitBundle
-	5,  // 33: cleanroom.v1.CreateSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
-	1,  // 34: cleanroom.v1.CreateSandboxEvent.phase:type_name -> cleanroom.v1.CreateSandboxPhase
-	29, // 35: cleanroom.v1.CreateSandboxEvent.response:type_name -> cleanroom.v1.CreateSandboxResponse
-	92, // 36: cleanroom.v1.CreateSandboxEvent.occurred_at:type_name -> google.protobuf.Timestamp
-	5,  // 37: cleanroom.v1.GetSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
-	5,  // 38: cleanroom.v1.ListSandboxesResponse.sandboxes:type_name -> cleanroom.v1.Sandbox
-	70, // 39: cleanroom.v1.ListExecutionsResponse.executions:type_name -> cleanroom.v1.Execution
-	2,  // 40: cleanroom.v1.SandboxPathInfo.type:type_name -> cleanroom.v1.SandboxPathType
-	92, // 41: cleanroom.v1.SandboxPathInfo.mtime:type_name -> google.protobuf.Timestamp
-	41, // 42: cleanroom.v1.StatSandboxPathResponse.info:type_name -> cleanroom.v1.SandboxPathInfo
-	41, // 43: cleanroom.v1.WalkSandboxTreeResponse.info:type_name -> cleanroom.v1.SandboxPathInfo
-	92, // 44: cleanroom.v1.WriteSandboxFileInit.mtime:type_name -> google.protobuf.Timestamp
-	48, // 45: cleanroom.v1.WriteSandboxFileRequest.init:type_name -> cleanroom.v1.WriteSandboxFileInit
-	55, // 46: cleanroom.v1.ExtractSandboxArchiveRequest.init:type_name -> cleanroom.v1.ExtractSandboxArchiveInit
-	0,  // 47: cleanroom.v1.SandboxEvent.status:type_name -> cleanroom.v1.SandboxStatus
-	92, // 48: cleanroom.v1.SandboxEvent.occurred_at:type_name -> google.protobuf.Timestamp
-	10, // 49: cleanroom.v1.CreateSnapshotResponse.snapshot:type_name -> cleanroom.v1.Snapshot
-	10, // 50: cleanroom.v1.GetSnapshotResponse.snapshot:type_name -> cleanroom.v1.Snapshot
-	10, // 51: cleanroom.v1.ListSnapshotsResponse.snapshots:type_name -> cleanroom.v1.Snapshot
-	3,  // 52: cleanroom.v1.Execution.status:type_name -> cleanroom.v1.ExecutionStatus
-	92, // 53: cleanroom.v1.Execution.started_at:type_name -> google.protobuf.Timestamp
-	92, // 54: cleanroom.v1.Execution.finished_at:type_name -> google.protobuf.Timestamp
-	4,  // 55: cleanroom.v1.Execution.kind:type_name -> cleanroom.v1.ExecutionKind
-	71, // 56: cleanroom.v1.CreateExecutionRequest.options:type_name -> cleanroom.v1.ExecutionOptions
-	4,  // 57: cleanroom.v1.CreateExecutionRequest.kind:type_name -> cleanroom.v1.ExecutionKind
-	24, // 58: cleanroom.v1.CreateExecutionRequest.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
-	70, // 59: cleanroom.v1.CreateExecutionResponse.execution:type_name -> cleanroom.v1.Execution
-	92, // 60: cleanroom.v1.AttachExecutionResponse.expires_at:type_name -> google.protobuf.Timestamp
-	70, // 61: cleanroom.v1.GetExecutionResponse.execution:type_name -> cleanroom.v1.Execution
-	70, // 62: cleanroom.v1.InspectExecutionResponse.execution:type_name -> cleanroom.v1.Execution
-	93, // 63: cleanroom.v1.InspectExecutionResponse.observability:type_name -> google.protobuf.Struct
-	3,  // 64: cleanroom.v1.CancelExecutionResponse.status:type_name -> cleanroom.v1.ExecutionStatus
-	3,  // 65: cleanroom.v1.ExecutionExit.status:type_name -> cleanroom.v1.ExecutionStatus
-	3,  // 66: cleanroom.v1.ExecutionStreamEvent.status:type_name -> cleanroom.v1.ExecutionStatus
-	87, // 67: cleanroom.v1.ExecutionStreamEvent.exit:type_name -> cleanroom.v1.ExecutionExit
-	92, // 68: cleanroom.v1.ExecutionStreamEvent.occurred_at:type_name -> google.protobuf.Timestamp
-	28, // 69: cleanroom.v1.SandboxService.CreateSandbox:input_type -> cleanroom.v1.CreateSandboxRequest
-	28, // 70: cleanroom.v1.SandboxService.CreateSandboxStream:input_type -> cleanroom.v1.CreateSandboxRequest
-	31, // 71: cleanroom.v1.SandboxService.GetSandbox:input_type -> cleanroom.v1.GetSandboxRequest
-	33, // 72: cleanroom.v1.SandboxService.ListSandboxes:input_type -> cleanroom.v1.ListSandboxesRequest
-	37, // 73: cleanroom.v1.SandboxService.DownloadSandboxFile:input_type -> cleanroom.v1.DownloadSandboxFileRequest
-	39, // 74: cleanroom.v1.SandboxService.UploadSandboxFile:input_type -> cleanroom.v1.UploadSandboxFileRequest
-	42, // 75: cleanroom.v1.SandboxService.StatSandboxPath:input_type -> cleanroom.v1.StatSandboxPathRequest
-	44, // 76: cleanroom.v1.SandboxService.WalkSandboxTree:input_type -> cleanroom.v1.WalkSandboxTreeRequest
-	46, // 77: cleanroom.v1.SandboxService.ReadSandboxFile:input_type -> cleanroom.v1.ReadSandboxFileRequest
-	49, // 78: cleanroom.v1.SandboxService.WriteSandboxFile:input_type -> cleanroom.v1.WriteSandboxFileRequest
-	51, // 79: cleanroom.v1.SandboxService.RemoveSandboxPath:input_type -> cleanroom.v1.RemoveSandboxPathRequest
-	53, // 80: cleanroom.v1.SandboxService.ArchiveSandboxPaths:input_type -> cleanroom.v1.ArchiveSandboxPathsRequest
-	56, // 81: cleanroom.v1.SandboxService.ExtractSandboxArchive:input_type -> cleanroom.v1.ExtractSandboxArchiveRequest
-	58, // 82: cleanroom.v1.SandboxService.TerminateSandbox:input_type -> cleanroom.v1.TerminateSandboxRequest
-	60, // 83: cleanroom.v1.SandboxService.StreamSandboxEvents:input_type -> cleanroom.v1.StreamSandboxEventsRequest
-	7,  // 84: cleanroom.v1.SandboxService.DialSandboxPort:input_type -> cleanroom.v1.SandboxPortFrame
-	62, // 85: cleanroom.v1.SnapshotService.CreateSnapshot:input_type -> cleanroom.v1.CreateSnapshotRequest
-	64, // 86: cleanroom.v1.SnapshotService.GetSnapshot:input_type -> cleanroom.v1.GetSnapshotRequest
-	66, // 87: cleanroom.v1.SnapshotService.ListSnapshots:input_type -> cleanroom.v1.ListSnapshotsRequest
-	68, // 88: cleanroom.v1.SnapshotService.DeleteSnapshot:input_type -> cleanroom.v1.DeleteSnapshotRequest
-	35, // 89: cleanroom.v1.ExecutionService.ListExecutions:input_type -> cleanroom.v1.ListExecutionsRequest
-	72, // 90: cleanroom.v1.ExecutionService.CreateExecution:input_type -> cleanroom.v1.CreateExecutionRequest
-	74, // 91: cleanroom.v1.ExecutionService.AttachExecution:input_type -> cleanroom.v1.AttachExecutionRequest
-	76, // 92: cleanroom.v1.ExecutionService.GetExecution:input_type -> cleanroom.v1.GetExecutionRequest
-	78, // 93: cleanroom.v1.ExecutionService.InspectExecution:input_type -> cleanroom.v1.InspectExecutionRequest
-	80, // 94: cleanroom.v1.ExecutionService.CancelExecution:input_type -> cleanroom.v1.CancelExecutionRequest
-	82, // 95: cleanroom.v1.ExecutionService.WriteExecutionStdin:input_type -> cleanroom.v1.WriteExecutionStdinRequest
-	84, // 96: cleanroom.v1.ExecutionService.CloseExecutionStdin:input_type -> cleanroom.v1.CloseExecutionStdinRequest
-	86, // 97: cleanroom.v1.ExecutionService.StreamExecution:input_type -> cleanroom.v1.StreamExecutionRequest
-	29, // 98: cleanroom.v1.SandboxService.CreateSandbox:output_type -> cleanroom.v1.CreateSandboxResponse
-	30, // 99: cleanroom.v1.SandboxService.CreateSandboxStream:output_type -> cleanroom.v1.CreateSandboxEvent
-	32, // 100: cleanroom.v1.SandboxService.GetSandbox:output_type -> cleanroom.v1.GetSandboxResponse
-	34, // 101: cleanroom.v1.SandboxService.ListSandboxes:output_type -> cleanroom.v1.ListSandboxesResponse
-	38, // 102: cleanroom.v1.SandboxService.DownloadSandboxFile:output_type -> cleanroom.v1.DownloadSandboxFileResponse
-	40, // 103: cleanroom.v1.SandboxService.UploadSandboxFile:output_type -> cleanroom.v1.UploadSandboxFileResponse
-	43, // 104: cleanroom.v1.SandboxService.StatSandboxPath:output_type -> cleanroom.v1.StatSandboxPathResponse
-	45, // 105: cleanroom.v1.SandboxService.WalkSandboxTree:output_type -> cleanroom.v1.WalkSandboxTreeResponse
-	47, // 106: cleanroom.v1.SandboxService.ReadSandboxFile:output_type -> cleanroom.v1.ReadSandboxFileResponse
-	50, // 107: cleanroom.v1.SandboxService.WriteSandboxFile:output_type -> cleanroom.v1.WriteSandboxFileResponse
-	52, // 108: cleanroom.v1.SandboxService.RemoveSandboxPath:output_type -> cleanroom.v1.RemoveSandboxPathResponse
-	54, // 109: cleanroom.v1.SandboxService.ArchiveSandboxPaths:output_type -> cleanroom.v1.ArchiveSandboxPathsResponse
-	57, // 110: cleanroom.v1.SandboxService.ExtractSandboxArchive:output_type -> cleanroom.v1.ExtractSandboxArchiveResponse
-	59, // 111: cleanroom.v1.SandboxService.TerminateSandbox:output_type -> cleanroom.v1.TerminateSandboxResponse
-	61, // 112: cleanroom.v1.SandboxService.StreamSandboxEvents:output_type -> cleanroom.v1.SandboxEvent
-	7,  // 113: cleanroom.v1.SandboxService.DialSandboxPort:output_type -> cleanroom.v1.SandboxPortFrame
-	63, // 114: cleanroom.v1.SnapshotService.CreateSnapshot:output_type -> cleanroom.v1.CreateSnapshotResponse
-	65, // 115: cleanroom.v1.SnapshotService.GetSnapshot:output_type -> cleanroom.v1.GetSnapshotResponse
-	67, // 116: cleanroom.v1.SnapshotService.ListSnapshots:output_type -> cleanroom.v1.ListSnapshotsResponse
-	69, // 117: cleanroom.v1.SnapshotService.DeleteSnapshot:output_type -> cleanroom.v1.DeleteSnapshotResponse
-	36, // 118: cleanroom.v1.ExecutionService.ListExecutions:output_type -> cleanroom.v1.ListExecutionsResponse
-	73, // 119: cleanroom.v1.ExecutionService.CreateExecution:output_type -> cleanroom.v1.CreateExecutionResponse
-	75, // 120: cleanroom.v1.ExecutionService.AttachExecution:output_type -> cleanroom.v1.AttachExecutionResponse
-	77, // 121: cleanroom.v1.ExecutionService.GetExecution:output_type -> cleanroom.v1.GetExecutionResponse
-	79, // 122: cleanroom.v1.ExecutionService.InspectExecution:output_type -> cleanroom.v1.InspectExecutionResponse
-	81, // 123: cleanroom.v1.ExecutionService.CancelExecution:output_type -> cleanroom.v1.CancelExecutionResponse
-	83, // 124: cleanroom.v1.ExecutionService.WriteExecutionStdin:output_type -> cleanroom.v1.WriteExecutionStdinResponse
-	85, // 125: cleanroom.v1.ExecutionService.CloseExecutionStdin:output_type -> cleanroom.v1.CloseExecutionStdinResponse
-	88, // 126: cleanroom.v1.ExecutionService.StreamExecution:output_type -> cleanroom.v1.ExecutionStreamEvent
-	98, // [98:127] is the sub-list for method output_type
-	69, // [69:98] is the sub-list for method input_type
-	69, // [69:69] is the sub-list for extension type_name
-	69, // [69:69] is the sub-list for extension extendee
-	0,  // [0:69] is the sub-list for field type_name
+	0,   // 0: cleanroom.v1.Sandbox.status:type_name -> cleanroom.v1.SandboxStatus
+	95,  // 1: cleanroom.v1.Sandbox.created_at:type_name -> google.protobuf.Timestamp
+	95,  // 2: cleanroom.v1.Sandbox.updated_at:type_name -> google.protobuf.Timestamp
+	24,  // 3: cleanroom.v1.Sandbox.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
+	93,  // 4: cleanroom.v1.Sandbox.backend_capabilities:type_name -> cleanroom.v1.Sandbox.BackendCapabilitiesEntry
+	8,   // 5: cleanroom.v1.SandboxPortFrame.open:type_name -> cleanroom.v1.SandboxPortOpen
+	9,   // 6: cleanroom.v1.SandboxPortFrame.close_write:type_name -> cleanroom.v1.SandboxPortCloseWrite
+	92,  // 7: cleanroom.v1.SandboxPortFrame.open_result:type_name -> cleanroom.v1.SandboxPortOpenResult
+	95,  // 8: cleanroom.v1.Snapshot.created_at:type_name -> google.protobuf.Timestamp
+	24,  // 9: cleanroom.v1.Snapshot.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
+	13,  // 10: cleanroom.v1.PolicyBlock.inputs:type_name -> cleanroom.v1.PolicyBlockInputs
+	94,  // 11: cleanroom.v1.PolicyBlock.env:type_name -> cleanroom.v1.PolicyBlock.EnvEntry
+	14,  // 12: cleanroom.v1.PolicyBlock.outputs:type_name -> cleanroom.v1.PolicyBlockOutputs
+	15,  // 13: cleanroom.v1.PolicyServices.blocks:type_name -> cleanroom.v1.PolicyBlock
+	15,  // 14: cleanroom.v1.PolicyDependencies.blocks:type_name -> cleanroom.v1.PolicyBlock
+	11,  // 15: cleanroom.v1.PolicyNetwork.allow:type_name -> cleanroom.v1.PolicyAllowRule
+	19,  // 16: cleanroom.v1.PolicyNetworkStages.workspace:type_name -> cleanroom.v1.PolicyNetwork
+	19,  // 17: cleanroom.v1.PolicyNetworkStages.dependencies:type_name -> cleanroom.v1.PolicyNetwork
+	19,  // 18: cleanroom.v1.PolicyNetworkStages.services:type_name -> cleanroom.v1.PolicyNetwork
+	19,  // 19: cleanroom.v1.PolicyNetworkStages.execution:type_name -> cleanroom.v1.PolicyNetwork
+	11,  // 20: cleanroom.v1.Policy.allow:type_name -> cleanroom.v1.PolicyAllowRule
+	16,  // 21: cleanroom.v1.Policy.services:type_name -> cleanroom.v1.PolicyServices
+	17,  // 22: cleanroom.v1.Policy.dependencies:type_name -> cleanroom.v1.PolicyDependencies
+	18,  // 23: cleanroom.v1.Policy.run:type_name -> cleanroom.v1.PolicyRun
+	21,  // 24: cleanroom.v1.Policy.resources:type_name -> cleanroom.v1.PolicyResources
+	20,  // 25: cleanroom.v1.Policy.network_stages:type_name -> cleanroom.v1.PolicyNetworkStages
+	12,  // 26: cleanroom.v1.Policy.docker:type_name -> cleanroom.v1.PolicyDocker
+	25,  // 27: cleanroom.v1.RepositoryChangeset.files:type_name -> cleanroom.v1.RepositoryChangesetFile
+	23,  // 28: cleanroom.v1.CreateSandboxRequest.options:type_name -> cleanroom.v1.SandboxOptions
+	22,  // 29: cleanroom.v1.CreateSandboxRequest.policy:type_name -> cleanroom.v1.Policy
+	24,  // 30: cleanroom.v1.CreateSandboxRequest.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
+	26,  // 31: cleanroom.v1.CreateSandboxRequest.repository_changeset:type_name -> cleanroom.v1.RepositoryChangeset
+	27,  // 32: cleanroom.v1.CreateSandboxRequest.repository_commit_bundle:type_name -> cleanroom.v1.RepositoryCommitBundle
+	5,   // 33: cleanroom.v1.CreateSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
+	1,   // 34: cleanroom.v1.CreateSandboxEvent.phase:type_name -> cleanroom.v1.CreateSandboxPhase
+	29,  // 35: cleanroom.v1.CreateSandboxEvent.response:type_name -> cleanroom.v1.CreateSandboxResponse
+	95,  // 36: cleanroom.v1.CreateSandboxEvent.occurred_at:type_name -> google.protobuf.Timestamp
+	5,   // 37: cleanroom.v1.GetSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
+	5,   // 38: cleanroom.v1.ListSandboxesResponse.sandboxes:type_name -> cleanroom.v1.Sandbox
+	73,  // 39: cleanroom.v1.ListExecutionsResponse.executions:type_name -> cleanroom.v1.Execution
+	2,   // 40: cleanroom.v1.SandboxPathInfo.type:type_name -> cleanroom.v1.SandboxPathType
+	95,  // 41: cleanroom.v1.SandboxPathInfo.mtime:type_name -> google.protobuf.Timestamp
+	41,  // 42: cleanroom.v1.StatSandboxPathResponse.info:type_name -> cleanroom.v1.SandboxPathInfo
+	41,  // 43: cleanroom.v1.WalkSandboxTreeResponse.info:type_name -> cleanroom.v1.SandboxPathInfo
+	95,  // 44: cleanroom.v1.WriteSandboxFileInit.mtime:type_name -> google.protobuf.Timestamp
+	48,  // 45: cleanroom.v1.WriteSandboxFileRequest.init:type_name -> cleanroom.v1.WriteSandboxFileInit
+	55,  // 46: cleanroom.v1.ExtractSandboxArchiveRequest.init:type_name -> cleanroom.v1.ExtractSandboxArchiveInit
+	0,   // 47: cleanroom.v1.SandboxEvent.status:type_name -> cleanroom.v1.SandboxStatus
+	95,  // 48: cleanroom.v1.SandboxEvent.occurred_at:type_name -> google.protobuf.Timestamp
+	10,  // 49: cleanroom.v1.CreateSnapshotResponse.snapshot:type_name -> cleanroom.v1.Snapshot
+	10,  // 50: cleanroom.v1.GetSnapshotResponse.snapshot:type_name -> cleanroom.v1.Snapshot
+	10,  // 51: cleanroom.v1.ListSnapshotsResponse.snapshots:type_name -> cleanroom.v1.Snapshot
+	72,  // 52: cleanroom.v1.LookupCachePeerResponse.candidate:type_name -> cleanroom.v1.CachePeerCandidate
+	95,  // 53: cleanroom.v1.CachePeerCandidate.expires_at:type_name -> google.protobuf.Timestamp
+	3,   // 54: cleanroom.v1.Execution.status:type_name -> cleanroom.v1.ExecutionStatus
+	95,  // 55: cleanroom.v1.Execution.started_at:type_name -> google.protobuf.Timestamp
+	95,  // 56: cleanroom.v1.Execution.finished_at:type_name -> google.protobuf.Timestamp
+	4,   // 57: cleanroom.v1.Execution.kind:type_name -> cleanroom.v1.ExecutionKind
+	74,  // 58: cleanroom.v1.CreateExecutionRequest.options:type_name -> cleanroom.v1.ExecutionOptions
+	4,   // 59: cleanroom.v1.CreateExecutionRequest.kind:type_name -> cleanroom.v1.ExecutionKind
+	24,  // 60: cleanroom.v1.CreateExecutionRequest.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
+	73,  // 61: cleanroom.v1.CreateExecutionResponse.execution:type_name -> cleanroom.v1.Execution
+	95,  // 62: cleanroom.v1.AttachExecutionResponse.expires_at:type_name -> google.protobuf.Timestamp
+	73,  // 63: cleanroom.v1.GetExecutionResponse.execution:type_name -> cleanroom.v1.Execution
+	73,  // 64: cleanroom.v1.InspectExecutionResponse.execution:type_name -> cleanroom.v1.Execution
+	96,  // 65: cleanroom.v1.InspectExecutionResponse.observability:type_name -> google.protobuf.Struct
+	3,   // 66: cleanroom.v1.CancelExecutionResponse.status:type_name -> cleanroom.v1.ExecutionStatus
+	3,   // 67: cleanroom.v1.ExecutionExit.status:type_name -> cleanroom.v1.ExecutionStatus
+	3,   // 68: cleanroom.v1.ExecutionStreamEvent.status:type_name -> cleanroom.v1.ExecutionStatus
+	90,  // 69: cleanroom.v1.ExecutionStreamEvent.exit:type_name -> cleanroom.v1.ExecutionExit
+	95,  // 70: cleanroom.v1.ExecutionStreamEvent.occurred_at:type_name -> google.protobuf.Timestamp
+	28,  // 71: cleanroom.v1.SandboxService.CreateSandbox:input_type -> cleanroom.v1.CreateSandboxRequest
+	28,  // 72: cleanroom.v1.SandboxService.CreateSandboxStream:input_type -> cleanroom.v1.CreateSandboxRequest
+	31,  // 73: cleanroom.v1.SandboxService.GetSandbox:input_type -> cleanroom.v1.GetSandboxRequest
+	33,  // 74: cleanroom.v1.SandboxService.ListSandboxes:input_type -> cleanroom.v1.ListSandboxesRequest
+	37,  // 75: cleanroom.v1.SandboxService.DownloadSandboxFile:input_type -> cleanroom.v1.DownloadSandboxFileRequest
+	39,  // 76: cleanroom.v1.SandboxService.UploadSandboxFile:input_type -> cleanroom.v1.UploadSandboxFileRequest
+	42,  // 77: cleanroom.v1.SandboxService.StatSandboxPath:input_type -> cleanroom.v1.StatSandboxPathRequest
+	44,  // 78: cleanroom.v1.SandboxService.WalkSandboxTree:input_type -> cleanroom.v1.WalkSandboxTreeRequest
+	46,  // 79: cleanroom.v1.SandboxService.ReadSandboxFile:input_type -> cleanroom.v1.ReadSandboxFileRequest
+	49,  // 80: cleanroom.v1.SandboxService.WriteSandboxFile:input_type -> cleanroom.v1.WriteSandboxFileRequest
+	51,  // 81: cleanroom.v1.SandboxService.RemoveSandboxPath:input_type -> cleanroom.v1.RemoveSandboxPathRequest
+	53,  // 82: cleanroom.v1.SandboxService.ArchiveSandboxPaths:input_type -> cleanroom.v1.ArchiveSandboxPathsRequest
+	56,  // 83: cleanroom.v1.SandboxService.ExtractSandboxArchive:input_type -> cleanroom.v1.ExtractSandboxArchiveRequest
+	58,  // 84: cleanroom.v1.SandboxService.TerminateSandbox:input_type -> cleanroom.v1.TerminateSandboxRequest
+	60,  // 85: cleanroom.v1.SandboxService.StreamSandboxEvents:input_type -> cleanroom.v1.StreamSandboxEventsRequest
+	7,   // 86: cleanroom.v1.SandboxService.DialSandboxPort:input_type -> cleanroom.v1.SandboxPortFrame
+	62,  // 87: cleanroom.v1.SnapshotService.CreateSnapshot:input_type -> cleanroom.v1.CreateSnapshotRequest
+	64,  // 88: cleanroom.v1.SnapshotService.GetSnapshot:input_type -> cleanroom.v1.GetSnapshotRequest
+	66,  // 89: cleanroom.v1.SnapshotService.ListSnapshots:input_type -> cleanroom.v1.ListSnapshotsRequest
+	68,  // 90: cleanroom.v1.SnapshotService.DeleteSnapshot:input_type -> cleanroom.v1.DeleteSnapshotRequest
+	70,  // 91: cleanroom.v1.CachePeerService.LookupCachePeer:input_type -> cleanroom.v1.LookupCachePeerRequest
+	35,  // 92: cleanroom.v1.ExecutionService.ListExecutions:input_type -> cleanroom.v1.ListExecutionsRequest
+	75,  // 93: cleanroom.v1.ExecutionService.CreateExecution:input_type -> cleanroom.v1.CreateExecutionRequest
+	77,  // 94: cleanroom.v1.ExecutionService.AttachExecution:input_type -> cleanroom.v1.AttachExecutionRequest
+	79,  // 95: cleanroom.v1.ExecutionService.GetExecution:input_type -> cleanroom.v1.GetExecutionRequest
+	81,  // 96: cleanroom.v1.ExecutionService.InspectExecution:input_type -> cleanroom.v1.InspectExecutionRequest
+	83,  // 97: cleanroom.v1.ExecutionService.CancelExecution:input_type -> cleanroom.v1.CancelExecutionRequest
+	85,  // 98: cleanroom.v1.ExecutionService.WriteExecutionStdin:input_type -> cleanroom.v1.WriteExecutionStdinRequest
+	87,  // 99: cleanroom.v1.ExecutionService.CloseExecutionStdin:input_type -> cleanroom.v1.CloseExecutionStdinRequest
+	89,  // 100: cleanroom.v1.ExecutionService.StreamExecution:input_type -> cleanroom.v1.StreamExecutionRequest
+	29,  // 101: cleanroom.v1.SandboxService.CreateSandbox:output_type -> cleanroom.v1.CreateSandboxResponse
+	30,  // 102: cleanroom.v1.SandboxService.CreateSandboxStream:output_type -> cleanroom.v1.CreateSandboxEvent
+	32,  // 103: cleanroom.v1.SandboxService.GetSandbox:output_type -> cleanroom.v1.GetSandboxResponse
+	34,  // 104: cleanroom.v1.SandboxService.ListSandboxes:output_type -> cleanroom.v1.ListSandboxesResponse
+	38,  // 105: cleanroom.v1.SandboxService.DownloadSandboxFile:output_type -> cleanroom.v1.DownloadSandboxFileResponse
+	40,  // 106: cleanroom.v1.SandboxService.UploadSandboxFile:output_type -> cleanroom.v1.UploadSandboxFileResponse
+	43,  // 107: cleanroom.v1.SandboxService.StatSandboxPath:output_type -> cleanroom.v1.StatSandboxPathResponse
+	45,  // 108: cleanroom.v1.SandboxService.WalkSandboxTree:output_type -> cleanroom.v1.WalkSandboxTreeResponse
+	47,  // 109: cleanroom.v1.SandboxService.ReadSandboxFile:output_type -> cleanroom.v1.ReadSandboxFileResponse
+	50,  // 110: cleanroom.v1.SandboxService.WriteSandboxFile:output_type -> cleanroom.v1.WriteSandboxFileResponse
+	52,  // 111: cleanroom.v1.SandboxService.RemoveSandboxPath:output_type -> cleanroom.v1.RemoveSandboxPathResponse
+	54,  // 112: cleanroom.v1.SandboxService.ArchiveSandboxPaths:output_type -> cleanroom.v1.ArchiveSandboxPathsResponse
+	57,  // 113: cleanroom.v1.SandboxService.ExtractSandboxArchive:output_type -> cleanroom.v1.ExtractSandboxArchiveResponse
+	59,  // 114: cleanroom.v1.SandboxService.TerminateSandbox:output_type -> cleanroom.v1.TerminateSandboxResponse
+	61,  // 115: cleanroom.v1.SandboxService.StreamSandboxEvents:output_type -> cleanroom.v1.SandboxEvent
+	7,   // 116: cleanroom.v1.SandboxService.DialSandboxPort:output_type -> cleanroom.v1.SandboxPortFrame
+	63,  // 117: cleanroom.v1.SnapshotService.CreateSnapshot:output_type -> cleanroom.v1.CreateSnapshotResponse
+	65,  // 118: cleanroom.v1.SnapshotService.GetSnapshot:output_type -> cleanroom.v1.GetSnapshotResponse
+	67,  // 119: cleanroom.v1.SnapshotService.ListSnapshots:output_type -> cleanroom.v1.ListSnapshotsResponse
+	69,  // 120: cleanroom.v1.SnapshotService.DeleteSnapshot:output_type -> cleanroom.v1.DeleteSnapshotResponse
+	71,  // 121: cleanroom.v1.CachePeerService.LookupCachePeer:output_type -> cleanroom.v1.LookupCachePeerResponse
+	36,  // 122: cleanroom.v1.ExecutionService.ListExecutions:output_type -> cleanroom.v1.ListExecutionsResponse
+	76,  // 123: cleanroom.v1.ExecutionService.CreateExecution:output_type -> cleanroom.v1.CreateExecutionResponse
+	78,  // 124: cleanroom.v1.ExecutionService.AttachExecution:output_type -> cleanroom.v1.AttachExecutionResponse
+	80,  // 125: cleanroom.v1.ExecutionService.GetExecution:output_type -> cleanroom.v1.GetExecutionResponse
+	82,  // 126: cleanroom.v1.ExecutionService.InspectExecution:output_type -> cleanroom.v1.InspectExecutionResponse
+	84,  // 127: cleanroom.v1.ExecutionService.CancelExecution:output_type -> cleanroom.v1.CancelExecutionResponse
+	86,  // 128: cleanroom.v1.ExecutionService.WriteExecutionStdin:output_type -> cleanroom.v1.WriteExecutionStdinResponse
+	88,  // 129: cleanroom.v1.ExecutionService.CloseExecutionStdin:output_type -> cleanroom.v1.CloseExecutionStdinResponse
+	91,  // 130: cleanroom.v1.ExecutionService.StreamExecution:output_type -> cleanroom.v1.ExecutionStreamEvent
+	101, // [101:131] is the sub-list for method output_type
+	71,  // [71:101] is the sub-list for method input_type
+	71,  // [71:71] is the sub-list for extension type_name
+	71,  // [71:71] is the sub-list for extension extendee
+	0,   // [0:71] is the sub-list for field type_name
 }
 
 func init() { file_proto_cleanroom_v1_control_proto_init() }
@@ -6579,7 +6958,7 @@ func file_proto_cleanroom_v1_control_proto_init() {
 		(*ExtractSandboxArchiveRequest_Init)(nil),
 		(*ExtractSandboxArchiveRequest_Data)(nil),
 	}
-	file_proto_cleanroom_v1_control_proto_msgTypes[83].OneofWrappers = []any{
+	file_proto_cleanroom_v1_control_proto_msgTypes[86].OneofWrappers = []any{
 		(*ExecutionStreamEvent_Stdout)(nil),
 		(*ExecutionStreamEvent_Stderr)(nil),
 		(*ExecutionStreamEvent_Exit)(nil),
@@ -6592,9 +6971,9 @@ func file_proto_cleanroom_v1_control_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proto_cleanroom_v1_control_proto_rawDesc), len(file_proto_cleanroom_v1_control_proto_rawDesc)),
 			NumEnums:      5,
-			NumMessages:   87,
+			NumMessages:   90,
 			NumExtensions: 0,
-			NumServices:   3,
+			NumServices:   4,
 		},
 		GoTypes:           file_proto_cleanroom_v1_control_proto_goTypes,
 		DependencyIndexes: file_proto_cleanroom_v1_control_proto_depIdxs,

--- a/internal/volumestore/zfs_metadata.go
+++ b/internal/volumestore/zfs_metadata.go
@@ -46,3 +46,17 @@ func EncodeZFSDriverMetadata(metadata ZFSDriverMetadata) (string, error) {
 	}
 	return string(out), nil
 }
+
+// DecodeZFSDriverMetadata parses the stable JSON representation persisted in
+// cache records and exchanged with peers.
+func DecodeZFSDriverMetadata(raw string) (ZFSDriverMetadata, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ZFSDriverMetadata{}, fmt.Errorf("decode zfs driver metadata: empty metadata")
+	}
+	var metadata ZFSDriverMetadata
+	if err := json.Unmarshal([]byte(raw), &metadata); err != nil {
+		return ZFSDriverMetadata{}, fmt.Errorf("decode zfs driver metadata: %w", err)
+	}
+	return metadata, nil
+}

--- a/proto/cleanroom/v1/control.proto
+++ b/proto/cleanroom/v1/control.proto
@@ -33,6 +33,10 @@ service SnapshotService {
   rpc DeleteSnapshot(DeleteSnapshotRequest) returns (DeleteSnapshotResponse);
 }
 
+service CachePeerService {
+  rpc LookupCachePeer(LookupCachePeerRequest) returns (LookupCachePeerResponse);
+}
+
 service ExecutionService {
   rpc ListExecutions(ListExecutionsRequest) returns (ListExecutionsResponse);
   rpc CreateExecution(CreateExecutionRequest) returns (CreateExecutionResponse);
@@ -485,6 +489,43 @@ message DeleteSnapshotResponse {
   string snapshot_id = 1;
   bool deleted = 2;
   string message = 3;
+}
+
+message LookupCachePeerRequest {
+  string stage = 1;
+  string cache_key = 2;
+  string backend = 3;
+  string storage_driver = 4;
+  string architecture = 5;
+  string producer_version = 6;
+  string policy_hash = 7;
+  string parent_cache_key = 8;
+  string parent_zfs_snapshot_guid = 9;
+  string parent_stage = 10;
+}
+
+message LookupCachePeerResponse {
+  CachePeerCandidate candidate = 1;
+  string miss_reason = 2;
+}
+
+message CachePeerCandidate {
+  string transfer_token = 1;
+  string stage = 2;
+  string cache_key = 3;
+  string backing_snapshot_id = 4;
+  string storage_ref = 5;
+  string parent_cache_key = 6;
+  string zfs_snapshot_guid = 7;
+  string zfs_parent_snapshot_guid = 8;
+  string producer_version = 9;
+  string backend = 10;
+  string storage_driver = 11;
+  string architecture = 12;
+  string policy_hash = 13;
+  int64 estimated_bytes = 14;
+  google.protobuf.Timestamp expires_at = 15;
+  string parent_stage = 16;
 }
 
 message Execution {


### PR DESCRIPTION
## Summary

This is the sender-side first phase of the Firecracker/ZFS stage-cache replication MVP.

It adds:

- a `CachePeerService.LookupCachePeer` RPC for peer cache candidate lookup
- a raw HTTP ZFS incremental export endpoint guarded by short-lived single-use transfer tokens
- bearer-token authorization from configured `cache.peers[*].token_env` values
- Firecracker/ZFS wiring for the incremental transfer driver
- sender-side validation for dependency and services stage children against explicit parent stage, parent cache key, parent ZFS GUID, backend, driver, architecture, producer version, and policy hash
- plan doc updates marking receiver import orchestration as the next slice

Scope boundary: this PR intentionally does not advertise workspace-stage cache transfer. The v1 peer path is for dependency/services children where the receiver already has the workspace or dependency parent locally. Workspace-stage peer import needs a separate runtime/base parent-lineage contract and is left as future work.

Receiver-side peer lookup/import is intentionally not in this PR. The next PR should query configured peers on a dependency/services local stage-cache miss, stream the selected export into `ImportIncrementalSnapshot`, validate the imported metadata locally, then publish the receiver-local cache record.

## Tests

- `mise exec -- go test ./internal/controlservice ./internal/controlserver ./internal/cli ./internal/backend/firecracker ./internal/volumestore`
- `mise exec -- go test ./...`
- `git diff --check HEAD~1..HEAD`
