### PR TITLE
feat: Import ZFS cache peers

### DIFF
--- a/docs/plans/zfs-stage-cache-replication.md
+++ b/docs/plans/zfs-stage-cache-replication.md
@@ -567,7 +567,7 @@ Status: landed.
 
 ### 4. Static peer lookup API
 
-Status: sender side landed; receiver client is next.
+Status: landed.
 
 - Add runtime config for peer URLs and token env vars.
 - Add lookup RPC and export HTTP endpoint.
@@ -577,7 +577,7 @@ Status: sender side landed; receiver client is next.
 
 ### 5. Receiver-side peer import
 
-Status: next.
+Status: landed for dependency and services stage caches.
 
 - On local stage-cache miss, query configured peers when parent ZFS lineage is
   available.
@@ -589,6 +589,8 @@ Status: next.
 - Publish the imported cache record and use the existing restore path.
 
 ### 6. Observability and fallback hardening
+
+Status: next.
 
 - Add logs, traces, and metrics.
 - Ensure every peer miss or failed import falls back to local build.
@@ -610,6 +612,8 @@ Status: next.
 - peer lookup rejects missing, non-ready, backend mismatch, driver mismatch,
   policy mismatch, producer mismatch, and parent GUID mismatch
 - transfer token binds exact request fields and expires
+- dependency and services receiver imports publish local records, restore from
+  those records, and skip local bootstrap work
 - duplicate imports coalesce
 - import failure does not publish metadata
 

--- a/internal/controlservice/cache_peer_import.go
+++ b/internal/controlservice/cache_peer_import.go
@@ -1,0 +1,434 @@
+package controlservice
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"runtime"
+	"strings"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/cachestore"
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+	"github.com/buildkite/cleanroom/internal/gen/cleanroom/v1/cleanroomv1connect"
+	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/buildkite/cleanroom/internal/repositorychangeset"
+	"github.com/buildkite/cleanroom/internal/repositorycheckout"
+	"github.com/buildkite/cleanroom/internal/runtimeconfig"
+	"github.com/buildkite/cleanroom/internal/volumestore"
+)
+
+const cachePeerZFSIncrementalExportPathPrefix = "/v1/cache/export/zfs-incremental/"
+
+type cachePeerImportResult struct {
+	record   cachestore.Record
+	imported bool
+}
+
+type cachePeerImportOptions struct {
+	Stage           string
+	CacheKey        string
+	ParentStage     string
+	ParentCacheKey  string
+	Backend         string
+	StorageDriver   string
+	ProducerVersion string
+	PolicyHash      string
+	NewRecord       func(snapshotID string, snapshot volumestore.Snapshot, now time.Time) cachestore.Record
+	ValidateRecord  func(context.Context) (cachestore.Record, bool, string, error)
+}
+
+type cachePeerCandidateMatch struct {
+	peer      runtimeconfig.CachePeerConfig
+	token     string
+	candidate *cleanroomv1.CachePeerCandidate
+}
+
+func (s *Service) importDependencyStageCacheFromPeers(
+	ctx context.Context,
+	adapter backend.SnapshottingAdapter,
+	backendName string,
+	compiled *policy.CompiledPolicy,
+	firecrackerCfg backend.FirecrackerConfig,
+	repository *repositorycheckout.Checkout,
+	changeset *repositorychangeset.Changeset,
+	plan dependencyStagePlan,
+) (cachestore.Record, bool, error) {
+	if adapter == nil || compiled == nil || repository == nil || strings.TrimSpace(plan.CacheKey) == "" {
+		return cachestore.Record{}, false, nil
+	}
+	result, err, _ := s.cachePeerImports.Do(cachePeerImportSingleflightKey(dependencyStageName, plan.CacheKey), func() (any, error) {
+		return s.importCachePeerStage(ctx, adapter, firecrackerCfg, cachePeerImportOptions{
+			Stage:           dependencyStageName,
+			CacheKey:        plan.CacheKey,
+			ParentStage:     workspaceStageName,
+			ParentCacheKey:  plan.ParentWorkspaceCacheKey,
+			Backend:         backendName,
+			StorageDriver:   "zfs",
+			ProducerVersion: dependencyStageProducerVersion,
+			PolicyHash:      compiled.Hash,
+			NewRecord: func(snapshotID string, snapshot volumestore.Snapshot, now time.Time) cachestore.Record {
+				record := cachestore.Record{
+					CacheKey:                 plan.CacheKey,
+					Stage:                    dependencyStageName,
+					ReuseMode:                dependencyStageReuseExact,
+					State:                    cacheStateReady,
+					BackingSnapshotID:        strings.TrimSpace(snapshotID),
+					Backend:                  backendName,
+					PolicyHash:               compiled.Hash,
+					Policy:                   compiled.ToProto(),
+					Repository:               cloneRepositoryCheckout(normalizeRepositoryCheckoutForComparison(repository)).ToProto(),
+					RepositoryHasChangeset:   changeset != nil,
+					RepositoryChangesetID:    repositoryChangesetID(repository, changeset),
+					ParentCacheKey:           plan.ParentWorkspaceCacheKey,
+					StorageDriver:            "zfs",
+					StorageRef:               strings.TrimSpace(snapshot.StorageRef),
+					DependencyKeyFilesDigest: plan.KeyFilesDigest,
+					ImportedFromPeer:         true,
+					CreatedAt:                now,
+					LastUsedAt:               now,
+					ProducerVersion:          dependencyStageProducerVersion,
+				}
+				populateStageCacheRecordMetadata(&record, plan.ParentRuntimeCacheKey, snapshotResultFromVolumeSnapshot(snapshot), now)
+				return record
+			},
+			ValidateRecord: func(ctx context.Context) (cachestore.Record, bool, string, error) {
+				return s.lookupDependencyStageCache(ctx, backendName, compiled, repository, changeset, plan)
+			},
+		})
+	})
+	if err != nil {
+		return cachestore.Record{}, false, err
+	}
+	importResult, ok := result.(cachePeerImportResult)
+	if !ok {
+		return cachestore.Record{}, false, nil
+	}
+	if importResult.imported && strings.TrimSpace(plan.PortableCacheKey) != "" {
+		if store, storeErr := s.cacheStoreOrErr(); storeErr == nil {
+			portableRecord := portableDependencyStageRecordFromExactRecord(importResult.record, compiled, repository, changeset, plan)
+			if err := store.Upsert(ctx, portableRecord); err != nil && s.Logger != nil {
+				s.Logger.Warn("persist portable dependency stage cache after peer import", "error", err)
+			}
+		}
+	}
+	return importResult.record, importResult.imported, nil
+}
+
+func (s *Service) importServicesStageCacheFromPeers(
+	ctx context.Context,
+	adapter backend.SnapshottingAdapter,
+	backendName string,
+	compiled *policy.CompiledPolicy,
+	firecrackerCfg backend.FirecrackerConfig,
+	repository *repositorycheckout.Checkout,
+	changeset *repositorychangeset.Changeset,
+	plan servicesStagePlan,
+) (cachestore.Record, bool, error) {
+	if adapter == nil || compiled == nil || repository == nil || strings.TrimSpace(plan.CacheKey) == "" {
+		return cachestore.Record{}, false, nil
+	}
+	parentStage := workspaceStageName
+	if record, ok, err := s.cacheRecordByKey(ctx, dependencyStageName, plan.ParentStageCacheKey); err == nil && ok && strings.TrimSpace(record.ReuseMode) != dependencyStageReusePortable {
+		parentStage = dependencyStageName
+	}
+	result, err, _ := s.cachePeerImports.Do(cachePeerImportSingleflightKey(servicesStageName, plan.CacheKey), func() (any, error) {
+		return s.importCachePeerStage(ctx, adapter, firecrackerCfg, cachePeerImportOptions{
+			Stage:           servicesStageName,
+			CacheKey:        plan.CacheKey,
+			ParentStage:     parentStage,
+			ParentCacheKey:  plan.ParentStageCacheKey,
+			Backend:         backendName,
+			StorageDriver:   "zfs",
+			ProducerVersion: servicesStageProducerVersion,
+			PolicyHash:      compiled.Hash,
+			NewRecord: func(snapshotID string, snapshot volumestore.Snapshot, now time.Time) cachestore.Record {
+				record := cachestore.Record{
+					CacheKey:               plan.CacheKey,
+					Stage:                  servicesStageName,
+					State:                  cacheStateReady,
+					BackingSnapshotID:      strings.TrimSpace(snapshotID),
+					Backend:                backendName,
+					PolicyHash:             compiled.Hash,
+					Policy:                 compiled.ToProto(),
+					Repository:             cloneRepositoryCheckout(normalizeRepositoryCheckoutForComparison(repository)).ToProto(),
+					RepositoryHasChangeset: changeset != nil,
+					RepositoryChangesetID:  repositoryChangesetID(repository, changeset),
+					ParentCacheKey:         plan.ParentStageCacheKey,
+					StorageDriver:          "zfs",
+					StorageRef:             strings.TrimSpace(snapshot.StorageRef),
+					ImportedFromPeer:       true,
+					CreatedAt:              now,
+					LastUsedAt:             now,
+					ProducerVersion:        servicesStageProducerVersion,
+				}
+				populateStageCacheRecordMetadata(&record, plan.RuntimeBaseKey, snapshotResultFromVolumeSnapshot(snapshot), now)
+				return record
+			},
+			ValidateRecord: func(ctx context.Context) (cachestore.Record, bool, string, error) {
+				return s.lookupServicesStageCache(ctx, backendName, compiled, repository, changeset, plan)
+			},
+		})
+	})
+	if err != nil {
+		return cachestore.Record{}, false, err
+	}
+	importResult, ok := result.(cachePeerImportResult)
+	if !ok {
+		return cachestore.Record{}, false, nil
+	}
+	return importResult.record, importResult.imported, nil
+}
+
+func (s *Service) importCachePeerStage(ctx context.Context, adapter backend.SnapshottingAdapter, firecrackerCfg backend.FirecrackerConfig, opts cachePeerImportOptions) (cachePeerImportResult, error) {
+	if len(s.Config.Cache.Peers) == 0 || s.CachePeerTransferDriver == nil || opts.NewRecord == nil || opts.ValidateRecord == nil {
+		return cachePeerImportResult{}, nil
+	}
+	if opts.Backend != "firecracker" || opts.StorageDriver != "zfs" {
+		return cachePeerImportResult{}, nil
+	}
+	if runtimeconfig.SnapshotDriverOrDefault(opts.Backend, firecrackerCfg.Snapshots.Driver) != "zfs" {
+		return cachePeerImportResult{}, nil
+	}
+
+	store, err := s.cacheStoreOrErr()
+	if err != nil {
+		return cachePeerImportResult{}, nil
+	}
+	parent, ok, err := store.GetReady(ctx, opts.ParentStage, opts.ParentCacheKey)
+	if err != nil {
+		return cachePeerImportResult{}, err
+	}
+	if !ok {
+		return cachePeerImportResult{}, nil
+	}
+	if strings.TrimSpace(parent.Backend) != opts.Backend || strings.TrimSpace(parent.StorageDriver) != opts.StorageDriver {
+		return cachePeerImportResult{}, nil
+	}
+	parentDesc, err := s.CachePeerTransferDriver.DescribeSnapshot(ctx, volumestore.DescribeSnapshotRequest{
+		SnapshotRef: strings.TrimSpace(parent.StorageRef),
+	})
+	if err != nil || strings.TrimSpace(parentDesc.SnapshotGUID) == "" {
+		return cachePeerImportResult{}, err
+	}
+
+	lookupReq := &cleanroomv1.LookupCachePeerRequest{
+		Stage:                 opts.Stage,
+		CacheKey:              opts.CacheKey,
+		Backend:               opts.Backend,
+		StorageDriver:         opts.StorageDriver,
+		Architecture:          runtime.GOARCH,
+		ProducerVersion:       opts.ProducerVersion,
+		PolicyHash:            opts.PolicyHash,
+		ParentStage:           opts.ParentStage,
+		ParentCacheKey:        opts.ParentCacheKey,
+		ParentZfsSnapshotGuid: parentDesc.SnapshotGUID,
+	}
+	match, ok := s.lookupCachePeerImportCandidate(ctx, lookupReq)
+	if !ok {
+		return cachePeerImportResult{}, nil
+	}
+
+	exportResp, err := s.openCachePeerExport(ctx, match)
+	if err != nil {
+		return cachePeerImportResult{}, nil
+	}
+	defer exportResp.Body.Close()
+
+	snapshotID := newSnapshotID()
+	imported, err := s.CachePeerTransferDriver.ImportIncrementalSnapshot(ctx, volumestore.IncrementalSnapshotImportRequest{
+		SnapshotID:           snapshotID,
+		ParentSnapshotRef:    strings.TrimSpace(parent.StorageRef),
+		ParentSnapshotGUID:   parentDesc.SnapshotGUID,
+		ExpectedSnapshotGUID: match.candidate.GetZfsSnapshotGuid(),
+	}, exportResp.Body)
+	if err != nil {
+		return cachePeerImportResult{}, nil
+	}
+	if err := validateImportedCachePeerSnapshot(imported, parentDesc.SnapshotGUID, match.candidate.GetZfsSnapshotGuid()); err != nil {
+		_ = adapter.DeleteSnapshot(context.Background(), backend.DeleteSnapshotRequest{
+			SnapshotID:        snapshotID,
+			StorageRef:        imported.StorageRef,
+			FirecrackerConfig: withSnapshotDriver(opts.Backend, firecrackerCfg, opts.StorageDriver),
+		})
+		return cachePeerImportResult{}, err
+	}
+
+	record := opts.NewRecord(snapshotID, imported, s.clock().Now())
+	if err := store.Create(ctx, record); err != nil {
+		existing, found, _, lookupErr := opts.ValidateRecord(ctx)
+		_ = adapter.DeleteSnapshot(context.Background(), backend.DeleteSnapshotRequest{
+			SnapshotID:        snapshotID,
+			StorageRef:        imported.StorageRef,
+			FirecrackerConfig: withSnapshotDriver(opts.Backend, firecrackerCfg, opts.StorageDriver),
+		})
+		if lookupErr != nil {
+			return cachePeerImportResult{}, fmt.Errorf("persist imported cache peer record: %w (lookup after conflict failed: %v)", err, lookupErr)
+		}
+		if found {
+			return cachePeerImportResult{record: existing, imported: true}, nil
+		}
+		return cachePeerImportResult{}, fmt.Errorf("persist imported cache peer record: %w", err)
+	}
+
+	validated, found, reason, err := opts.ValidateRecord(ctx)
+	if err != nil {
+		_ = store.Delete(context.Background(), record.Stage, record.CacheKey)
+		_ = adapter.DeleteSnapshot(context.Background(), backend.DeleteSnapshotRequest{
+			SnapshotID:        snapshotID,
+			StorageRef:        imported.StorageRef,
+			FirecrackerConfig: withSnapshotDriver(opts.Backend, firecrackerCfg, opts.StorageDriver),
+		})
+		return cachePeerImportResult{}, err
+	}
+	if !found {
+		_ = store.Delete(context.Background(), record.Stage, record.CacheKey)
+		_ = adapter.DeleteSnapshot(context.Background(), backend.DeleteSnapshotRequest{
+			SnapshotID:        snapshotID,
+			StorageRef:        imported.StorageRef,
+			FirecrackerConfig: withSnapshotDriver(opts.Backend, firecrackerCfg, opts.StorageDriver),
+		})
+		if strings.TrimSpace(reason) == "" {
+			reason = "unknown validation miss"
+		}
+		return cachePeerImportResult{}, fmt.Errorf("imported cache peer record failed validation: %s", reason)
+	}
+	return cachePeerImportResult{record: validated, imported: true}, nil
+}
+
+func (s *Service) lookupCachePeerImportCandidate(ctx context.Context, req *cleanroomv1.LookupCachePeerRequest) (cachePeerCandidateMatch, bool) {
+	for _, peer := range s.Config.Cache.Peers {
+		token := cachePeerTokenForConfig(peer)
+		if strings.TrimSpace(peer.URL) == "" || token == "" {
+			continue
+		}
+		client := cleanroomv1connect.NewCachePeerServiceClient(http.DefaultClient, strings.TrimRight(strings.TrimSpace(peer.URL), "/"))
+		connectReq := connect.NewRequest(req)
+		connectReq.Header().Set("Authorization", "Bearer "+token)
+		resp, err := client.LookupCachePeer(ctx, connectReq)
+		if err != nil {
+			if s.Logger != nil {
+				s.Logger.Debug("cache peer lookup failed", "peer", peer.URL, "error", err)
+			}
+			continue
+		}
+		candidate := resp.Msg.GetCandidate()
+		if candidate == nil {
+			continue
+		}
+		if !cachePeerCandidateMatchesRequest(candidate, req, s.clock().Now()) {
+			if s.Logger != nil {
+				s.Logger.Debug("cache peer candidate rejected", "peer", peer.URL)
+			}
+			continue
+		}
+		return cachePeerCandidateMatch{peer: peer, token: token, candidate: candidate}, true
+	}
+	return cachePeerCandidateMatch{}, false
+}
+
+func (s *Service) openCachePeerExport(ctx context.Context, match cachePeerCandidateMatch) (*http.Response, error) {
+	exportURL, err := cachePeerExportURL(match.peer.URL, match.candidate.GetTransferToken())
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, exportURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+match.token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1024))
+		_ = resp.Body.Close()
+		return nil, fmt.Errorf("cache peer export returned status %d", resp.StatusCode)
+	}
+	return resp, nil
+}
+
+func cachePeerCandidateMatchesRequest(candidate *cleanroomv1.CachePeerCandidate, req *cleanroomv1.LookupCachePeerRequest, now time.Time) bool {
+	if strings.TrimSpace(candidate.GetTransferToken()) == "" || strings.TrimSpace(candidate.GetZfsSnapshotGuid()) == "" {
+		return false
+	}
+	if expiresAt := candidate.GetExpiresAt(); expiresAt != nil {
+		expiresAtTime := expiresAt.AsTime()
+		if !expiresAtTime.IsZero() && !expiresAtTime.After(now) {
+			return false
+		}
+	}
+	return candidate.GetStage() == req.GetStage() &&
+		candidate.GetCacheKey() == req.GetCacheKey() &&
+		candidate.GetBackend() == req.GetBackend() &&
+		candidate.GetStorageDriver() == req.GetStorageDriver() &&
+		candidate.GetArchitecture() == req.GetArchitecture() &&
+		candidate.GetProducerVersion() == req.GetProducerVersion() &&
+		candidate.GetPolicyHash() == req.GetPolicyHash() &&
+		candidate.GetParentStage() == req.GetParentStage() &&
+		candidate.GetParentCacheKey() == req.GetParentCacheKey() &&
+		candidate.GetZfsParentSnapshotGuid() == req.GetParentZfsSnapshotGuid()
+}
+
+func cachePeerTokenForConfig(peer runtimeconfig.CachePeerConfig) string {
+	tokenEnv := strings.TrimSpace(peer.TokenEnv)
+	if tokenEnv == "" {
+		return ""
+	}
+	return strings.TrimSpace(os.Getenv(tokenEnv))
+}
+
+func cachePeerExportURL(baseURL, token string) (string, error) {
+	parsed, err := url.Parse(strings.TrimSpace(baseURL))
+	if err != nil {
+		return "", err
+	}
+	parsed.Path = strings.TrimRight(parsed.Path, "/") + cachePeerZFSIncrementalExportPathPrefix + url.PathEscape(strings.TrimSpace(token))
+	parsed.RawQuery = ""
+	return parsed.String(), nil
+}
+
+func cachePeerImportSingleflightKey(stage, cacheKey string) string {
+	return strings.TrimSpace(stage) + "\x00" + strings.TrimSpace(cacheKey)
+}
+
+func snapshotResultFromVolumeSnapshot(snapshot volumestore.Snapshot) *backend.SnapshotResult {
+	return &backend.SnapshotResult{
+		StorageRef:         strings.TrimSpace(snapshot.StorageRef),
+		StorageSizeBytes:   snapshot.StorageSizeBytes,
+		ExclusiveSizeBytes: snapshot.ExclusiveSizeBytes,
+		DriverMetadata:     strings.TrimSpace(snapshot.DriverMetadata),
+	}
+}
+
+func validateImportedCachePeerSnapshot(snapshot volumestore.Snapshot, parentGUID, expectedGUID string) error {
+	metadata, err := volumestore.DecodeZFSDriverMetadata(snapshot.DriverMetadata)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(metadata.SnapshotGUID) != strings.TrimSpace(expectedGUID) {
+		return fmt.Errorf("imported cache peer snapshot guid mismatch: got %q want %q", metadata.SnapshotGUID, expectedGUID)
+	}
+	if strings.TrimSpace(metadata.ParentSnapshotGUID) != strings.TrimSpace(parentGUID) {
+		return fmt.Errorf("imported cache peer parent guid mismatch: got %q want %q", metadata.ParentSnapshotGUID, parentGUID)
+	}
+	if strings.TrimSpace(snapshot.StorageRef) == "" {
+		return errors.New("imported cache peer snapshot missing storage ref")
+	}
+	return nil
+}
+
+func (s *Service) cacheRecordByKey(ctx context.Context, stage, cacheKey string) (cachestore.Record, bool, error) {
+	store, err := s.cacheStoreOrErr()
+	if err != nil {
+		return cachestore.Record{}, false, nil
+	}
+	return store.GetReady(ctx, stage, cacheKey)
+}

--- a/internal/controlservice/cache_peer_import.go
+++ b/internal/controlservice/cache_peer_import.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -25,6 +26,64 @@ import (
 )
 
 const cachePeerZFSIncrementalExportPathPrefix = "/v1/cache/export/zfs-incremental/"
+
+const (
+	cachePeerLookupTimeout               = 5 * time.Second
+	cachePeerExportDialTimeout           = 5 * time.Second
+	cachePeerExportReadIdleTimeout       = 30 * time.Second
+	cachePeerExportResponseHeaderTimeout = 10 * time.Second
+)
+
+var (
+	cachePeerLookupHTTPClient = &http.Client{
+		Timeout: cachePeerLookupTimeout,
+	}
+	cachePeerExportHTTPClient = &http.Client{
+		Transport: newCachePeerExportTransport(),
+	}
+)
+
+// Export streams can be much larger than lookup RPCs, so avoid a fixed total
+// client timeout and bound setup plus idle reads instead.
+func newCachePeerExportTransport() *http.Transport {
+	dialer := &net.Dialer{
+		Timeout:   cachePeerExportDialTimeout,
+		KeepAlive: 30 * time.Second,
+	}
+	return &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
+			conn, err := dialer.DialContext(ctx, network, address)
+			if err != nil {
+				return nil, err
+			}
+			return &cachePeerTimeoutConn{
+				Conn:            conn,
+				readIdleTimeout: cachePeerExportReadIdleTimeout,
+			}, nil
+		},
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		TLSHandshakeTimeout:   cachePeerExportDialTimeout,
+		ResponseHeaderTimeout: cachePeerExportResponseHeaderTimeout,
+		ExpectContinueTimeout: time.Second,
+		IdleConnTimeout:       90 * time.Second,
+	}
+}
+
+type cachePeerTimeoutConn struct {
+	net.Conn
+	readIdleTimeout time.Duration
+}
+
+func (c *cachePeerTimeoutConn) Read(p []byte) (int, error) {
+	if c.readIdleTimeout > 0 {
+		if err := c.Conn.SetReadDeadline(time.Now().Add(c.readIdleTimeout)); err != nil {
+			return 0, err
+		}
+	}
+	return c.Conn.Read(p)
+}
 
 type cachePeerImportResult struct {
 	record   cachestore.Record
@@ -330,7 +389,7 @@ func (s *Service) lookupCachePeerImportCandidates(ctx context.Context, req *clea
 		if strings.TrimSpace(peer.URL) == "" || token == "" {
 			continue
 		}
-		client := cleanroomv1connect.NewCachePeerServiceClient(http.DefaultClient, strings.TrimRight(strings.TrimSpace(peer.URL), "/"))
+		client := cleanroomv1connect.NewCachePeerServiceClient(cachePeerLookupHTTPClient, strings.TrimRight(strings.TrimSpace(peer.URL), "/"))
 		connectReq := connect.NewRequest(req)
 		connectReq.Header().Set("Authorization", "Bearer "+token)
 		resp, err := client.LookupCachePeer(ctx, connectReq)
@@ -365,7 +424,7 @@ func (s *Service) openCachePeerExport(ctx context.Context, match cachePeerCandid
 		return nil, err
 	}
 	req.Header.Set("Authorization", "Bearer "+match.token)
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := cachePeerExportHTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controlservice/cache_peer_import.go
+++ b/internal/controlservice/cache_peer_import.go
@@ -230,14 +230,32 @@ func (s *Service) importCachePeerStage(ctx context.Context, adapter backend.Snap
 		ParentCacheKey:        opts.ParentCacheKey,
 		ParentZfsSnapshotGuid: parentDesc.SnapshotGUID,
 	}
-	match, ok := s.lookupCachePeerImportCandidate(ctx, lookupReq)
-	if !ok {
-		return cachePeerImportResult{}, nil
+	matches := s.lookupCachePeerImportCandidates(ctx, lookupReq)
+	for _, match := range matches {
+		result, handled, err := s.importCachePeerCandidate(ctx, adapter, store, parent, parentDesc, firecrackerCfg, opts, match)
+		if err != nil || handled {
+			return result, err
+		}
 	}
+	return cachePeerImportResult{}, nil
+}
 
+func (s *Service) importCachePeerCandidate(
+	ctx context.Context,
+	adapter backend.SnapshottingAdapter,
+	store cacheMetadataStore,
+	parent cachestore.Record,
+	parentDesc volumestore.SnapshotDescription,
+	firecrackerCfg backend.FirecrackerConfig,
+	opts cachePeerImportOptions,
+	match cachePeerCandidateMatch,
+) (cachePeerImportResult, bool, error) {
 	exportResp, err := s.openCachePeerExport(ctx, match)
 	if err != nil {
-		return cachePeerImportResult{}, nil
+		if s.Logger != nil {
+			s.Logger.Debug("cache peer export failed", "peer", match.peer.URL, "error", err)
+		}
+		return cachePeerImportResult{}, false, nil
 	}
 	defer exportResp.Body.Close()
 
@@ -249,7 +267,10 @@ func (s *Service) importCachePeerStage(ctx context.Context, adapter backend.Snap
 		ExpectedSnapshotGUID: match.candidate.GetZfsSnapshotGuid(),
 	}, exportResp.Body)
 	if err != nil {
-		return cachePeerImportResult{}, nil
+		if s.Logger != nil {
+			s.Logger.Debug("cache peer import failed", "peer", match.peer.URL, "error", err)
+		}
+		return cachePeerImportResult{}, false, nil
 	}
 	if err := validateImportedCachePeerSnapshot(imported, parentDesc.SnapshotGUID, match.candidate.GetZfsSnapshotGuid()); err != nil {
 		_ = adapter.DeleteSnapshot(context.Background(), backend.DeleteSnapshotRequest{
@@ -257,7 +278,7 @@ func (s *Service) importCachePeerStage(ctx context.Context, adapter backend.Snap
 			StorageRef:        imported.StorageRef,
 			FirecrackerConfig: withSnapshotDriver(opts.Backend, firecrackerCfg, opts.StorageDriver),
 		})
-		return cachePeerImportResult{}, err
+		return cachePeerImportResult{}, true, err
 	}
 
 	record := opts.NewRecord(snapshotID, imported, s.clock().Now())
@@ -269,12 +290,12 @@ func (s *Service) importCachePeerStage(ctx context.Context, adapter backend.Snap
 			FirecrackerConfig: withSnapshotDriver(opts.Backend, firecrackerCfg, opts.StorageDriver),
 		})
 		if lookupErr != nil {
-			return cachePeerImportResult{}, fmt.Errorf("persist imported cache peer record: %w (lookup after conflict failed: %v)", err, lookupErr)
+			return cachePeerImportResult{}, true, fmt.Errorf("persist imported cache peer record: %w (lookup after conflict failed: %v)", err, lookupErr)
 		}
 		if found {
-			return cachePeerImportResult{record: existing, imported: true}, nil
+			return cachePeerImportResult{record: existing, imported: true}, true, nil
 		}
-		return cachePeerImportResult{}, fmt.Errorf("persist imported cache peer record: %w", err)
+		return cachePeerImportResult{}, true, fmt.Errorf("persist imported cache peer record: %w", err)
 	}
 
 	validated, found, reason, err := opts.ValidateRecord(ctx)
@@ -285,7 +306,7 @@ func (s *Service) importCachePeerStage(ctx context.Context, adapter backend.Snap
 			StorageRef:        imported.StorageRef,
 			FirecrackerConfig: withSnapshotDriver(opts.Backend, firecrackerCfg, opts.StorageDriver),
 		})
-		return cachePeerImportResult{}, err
+		return cachePeerImportResult{}, true, err
 	}
 	if !found {
 		_ = store.Delete(context.Background(), record.Stage, record.CacheKey)
@@ -297,12 +318,13 @@ func (s *Service) importCachePeerStage(ctx context.Context, adapter backend.Snap
 		if strings.TrimSpace(reason) == "" {
 			reason = "unknown validation miss"
 		}
-		return cachePeerImportResult{}, fmt.Errorf("imported cache peer record failed validation: %s", reason)
+		return cachePeerImportResult{}, true, fmt.Errorf("imported cache peer record failed validation: %s", reason)
 	}
-	return cachePeerImportResult{record: validated, imported: true}, nil
+	return cachePeerImportResult{record: validated, imported: true}, true, nil
 }
 
-func (s *Service) lookupCachePeerImportCandidate(ctx context.Context, req *cleanroomv1.LookupCachePeerRequest) (cachePeerCandidateMatch, bool) {
+func (s *Service) lookupCachePeerImportCandidates(ctx context.Context, req *cleanroomv1.LookupCachePeerRequest) []cachePeerCandidateMatch {
+	matches := make([]cachePeerCandidateMatch, 0, len(s.Config.Cache.Peers))
 	for _, peer := range s.Config.Cache.Peers {
 		token := cachePeerTokenForConfig(peer)
 		if strings.TrimSpace(peer.URL) == "" || token == "" {
@@ -328,9 +350,9 @@ func (s *Service) lookupCachePeerImportCandidate(ctx context.Context, req *clean
 			}
 			continue
 		}
-		return cachePeerCandidateMatch{peer: peer, token: token, candidate: candidate}, true
+		matches = append(matches, cachePeerCandidateMatch{peer: peer, token: token, candidate: candidate})
 	}
-	return cachePeerCandidateMatch{}, false
+	return matches
 }
 
 func (s *Service) openCachePeerExport(ctx context.Context, match cachePeerCandidateMatch) (*http.Response, error) {

--- a/internal/controlservice/cache_peer_import_test.go
+++ b/internal/controlservice/cache_peer_import_test.go
@@ -2,6 +2,7 @@ package controlservice
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"runtime"
@@ -19,6 +20,62 @@ import (
 	"github.com/buildkite/cleanroom/internal/volumestore"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+func TestCachePeerImportHTTPClientsHaveBoundedTimeouts(t *testing.T) {
+	if cachePeerLookupHTTPClient == http.DefaultClient {
+		t.Fatal("lookup client must not use http.DefaultClient")
+	}
+	if cachePeerLookupHTTPClient.Timeout <= 0 {
+		t.Fatal("lookup client must have a total timeout")
+	}
+
+	if cachePeerExportHTTPClient == http.DefaultClient {
+		t.Fatal("export client must not use http.DefaultClient")
+	}
+	if cachePeerExportHTTPClient.Timeout != 0 {
+		t.Fatal("export client must not set a total timeout; large streams can outlive a lookup deadline")
+	}
+	transport, ok := cachePeerExportHTTPClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("export client transport = %T, want *http.Transport", cachePeerExportHTTPClient.Transport)
+	}
+	if transport.DialContext == nil {
+		t.Fatal("export transport must bound dial time")
+	}
+	if cachePeerExportReadIdleTimeout <= 0 {
+		t.Fatal("export transport must bound idle body reads")
+	}
+	if transport.TLSHandshakeTimeout <= 0 {
+		t.Fatal("export transport must bound TLS handshakes")
+	}
+	if transport.ResponseHeaderTimeout <= 0 {
+		t.Fatal("export transport must bound response headers")
+	}
+	if transport.ExpectContinueTimeout <= 0 {
+		t.Fatal("export transport must bound expect-continue waits")
+	}
+}
+
+func TestCachePeerTimeoutConnReadTimesOutWhenIdle(t *testing.T) {
+	reader, writer := net.Pipe()
+	t.Cleanup(func() {
+		_ = reader.Close()
+		_ = writer.Close()
+	})
+
+	conn := &cachePeerTimeoutConn{
+		Conn:            reader,
+		readIdleTimeout: 10 * time.Millisecond,
+	}
+	start := time.Now()
+	_, err := conn.Read(make([]byte, 1))
+	if err == nil {
+		t.Fatal("expected idle read timeout")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("idle read timeout took too long: %s", elapsed)
+	}
+}
 
 func TestCreateSandboxImportsDependencyStageCacheFromPeer(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())

--- a/internal/controlservice/cache_peer_import_test.go
+++ b/internal/controlservice/cache_peer_import_test.go
@@ -1,0 +1,556 @@
+package controlservice
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/buildkite/cleanroom/internal/cachestore"
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+	"github.com/buildkite/cleanroom/internal/gen/cleanroom/v1/cleanroomv1connect"
+	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/buildkite/cleanroom/internal/repositorycheckout"
+	"github.com/buildkite/cleanroom/internal/runtimeconfig"
+	"github.com/buildkite/cleanroom/internal/volumestore"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestCreateSandboxImportsDependencyStageCacheFromPeer(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CLEANROOM_CACHE_PEER_TOKEN", "receiver-token")
+
+	adapter := &stubAdapter{}
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"go.mod": "module example.com/test\n\ngo 1.26.2\n",
+		"go.sum": "example.com/test v0.0.0 h1:abc123\n",
+	})
+	svc := newTestService(adapter)
+	svc.RepositoryStore = mirrors
+	svc.Config.Backends.Firecracker.Snapshots.Driver = "zfs"
+
+	compiled, err := policy.FromProto(testRepositoryDependencyPolicy())
+	if err != nil {
+		t.Fatalf("FromProto returned error: %v", err)
+	}
+	repository := repositorycheckout.FromProto(repositoryCheckout)
+	workspaceKey := workspaceStageCacheKey("firecracker", "runtime-base:test", compiled.Hash, repository, nil)
+	dependencyPlan, ok := dependencyStagePlanForRepository(compiled, repository)
+	if !ok {
+		t.Fatal("expected dependency stage plan")
+	}
+	dependencyPlan, ok, err = svc.finalizeDependencyStagePlan(context.Background(), compiled, repository, nil, nil, "firecracker", workspaceKey, "runtime-base:test", dependencyPlan)
+	if err != nil {
+		t.Fatalf("finalizeDependencyStagePlan returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected finalized dependency stage plan")
+	}
+
+	cacheStore := requireMemoryCacheStore(t, svc)
+	insertImportedPeerParentRecord(t, cacheStore, importedPeerParentRecordOptions{
+		Stage:           workspaceStageName,
+		CacheKey:        workspaceKey,
+		StorageRef:      "tank/local/workspace@base",
+		SnapshotGUID:    "workspace-guid",
+		ProducerVersion: workspaceStageProducerVersion,
+	})
+
+	importMetadata := encodeZFSMetadataForTest(t, "tank/local/imports/dependency@base", "dependency-guid", "workspace-guid")
+	transfer := &stubCachePeerTransferDriver{
+		describeSnapshots: map[string]volumestore.SnapshotDescription{
+			"tank/local/workspace@base": {
+				SnapshotRef:  "tank/local/workspace@base",
+				StorageRef:   "tank/local/workspace@base",
+				SnapshotGUID: "workspace-guid",
+			},
+		},
+		importSnapshot: volumestore.Snapshot{
+			StorageRef:     "tank/local/imports/dependency@base",
+			DriverMetadata: importMetadata,
+		},
+	}
+	svc.CachePeerTransferDriver = transfer
+
+	peer := newTestCachePeerImportServer(t, &cleanroomv1.CachePeerCandidate{
+		TransferToken:         "peer-token",
+		Stage:                 dependencyStageName,
+		CacheKey:              dependencyPlan.CacheKey,
+		ParentStage:           workspaceStageName,
+		ParentCacheKey:        workspaceKey,
+		Backend:               "firecracker",
+		StorageDriver:         "zfs",
+		Architecture:          runtime.GOARCH,
+		ProducerVersion:       dependencyStageProducerVersion,
+		PolicyHash:            compiled.Hash,
+		ZfsSnapshotGuid:       "dependency-guid",
+		ZfsParentSnapshotGuid: "workspace-guid",
+		BackingSnapshotId:     "peer-dependency-snapshot",
+		StorageRef:            "tank/peer/dependency@base",
+		EstimatedBytes:        128,
+		ExpiresAt:             timestamppb.New(time.Now().Add(time.Hour)),
+	})
+	svc.Config.Cache.Peers = []runtimeconfig.CachePeerConfig{{URL: peer.URL, TokenEnv: "CLEANROOM_CACHE_PEER_TOKEN"}}
+
+	resp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Policy:             testRepositoryDependencyPolicy(),
+		RepositoryCheckout: repositoryCheckout,
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	if got, want := resp.GetSourceKind(), "dependency stage cache"; got != want {
+		t.Fatalf("unexpected source kind: got %q want %q", got, want)
+	}
+	if got, want := adapter.provisionFromSnapshotCalls, 1; got != want {
+		t.Fatalf("expected restored imported dependency cache once, got %d want %d", got, want)
+	}
+	if got, want := adapter.provisionCalls, 0; got != want {
+		t.Fatalf("expected peer import restore to skip cold provision, got %d want %d", got, want)
+	}
+	if got, want := adapter.runCalls, 0; got != want {
+		t.Fatalf("expected peer import restore to skip bootstrap commands, got %d want %d", got, want)
+	}
+	if got, want := len(transfer.describeRequests), 1; got != want {
+		t.Fatalf("expected one parent describe request, got %d", got)
+	}
+	if got, want := transfer.describeRequests[0].SnapshotRef, "tank/local/workspace@base"; got != want {
+		t.Fatalf("unexpected describe ref: got %q want %q", got, want)
+	}
+	requireCachePeerImportRequest(t, transfer, "tank/local/workspace@base", "workspace-guid", "dependency-guid", "zfs-stream")
+	requireCachePeerLookup(t, peer, &cleanroomv1.LookupCachePeerRequest{
+		Stage:                 dependencyStageName,
+		CacheKey:              dependencyPlan.CacheKey,
+		Backend:               "firecracker",
+		StorageDriver:         "zfs",
+		Architecture:          runtime.GOARCH,
+		ProducerVersion:       dependencyStageProducerVersion,
+		PolicyHash:            compiled.Hash,
+		ParentStage:           workspaceStageName,
+		ParentCacheKey:        workspaceKey,
+		ParentZfsSnapshotGuid: "workspace-guid",
+	})
+
+	record, found, err := cacheStore.GetReady(context.Background(), dependencyStageName, dependencyPlan.CacheKey)
+	if err != nil {
+		t.Fatalf("GetReady returned error: %v", err)
+	}
+	if !found {
+		t.Fatal("expected imported dependency cache record")
+	}
+	if !record.ImportedFromPeer {
+		t.Fatal("expected dependency cache record to be marked as peer-imported")
+	}
+	if got, want := record.StorageRef, "tank/local/imports/dependency@base"; got != want {
+		t.Fatalf("unexpected imported storage ref: got %q want %q", got, want)
+	}
+	if got, want := record.ParentCacheKey, workspaceKey; got != want {
+		t.Fatalf("unexpected parent cache key: got %q want %q", got, want)
+	}
+	if got, want := record.DependencyKeyFilesDigest, dependencyPlan.KeyFilesDigest; got != want {
+		t.Fatalf("unexpected dependency key digest: got %q want %q", got, want)
+	}
+}
+
+func TestImportDependencyStageCacheFromPeerCleansUpInvalidSnapshot(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CLEANROOM_CACHE_PEER_TOKEN", "receiver-token")
+
+	adapter := &stubAdapter{}
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"go.mod": "module example.com/test\n\ngo 1.26.2\n",
+		"go.sum": "example.com/test v0.0.0 h1:abc123\n",
+	})
+	svc := newTestService(adapter)
+	svc.RepositoryStore = mirrors
+	svc.Config.Backends.Firecracker.Snapshots.Driver = "zfs"
+
+	compiled, err := policy.FromProto(testRepositoryDependencyPolicy())
+	if err != nil {
+		t.Fatalf("FromProto returned error: %v", err)
+	}
+	repository := repositorycheckout.FromProto(repositoryCheckout)
+	workspaceKey := workspaceStageCacheKey("firecracker", "runtime-base:test", compiled.Hash, repository, nil)
+	dependencyPlan, ok := dependencyStagePlanForRepository(compiled, repository)
+	if !ok {
+		t.Fatal("expected dependency stage plan")
+	}
+	dependencyPlan, ok, err = svc.finalizeDependencyStagePlan(context.Background(), compiled, repository, nil, nil, "firecracker", workspaceKey, "runtime-base:test", dependencyPlan)
+	if err != nil {
+		t.Fatalf("finalizeDependencyStagePlan returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected finalized dependency stage plan")
+	}
+
+	cacheStore := requireMemoryCacheStore(t, svc)
+	insertImportedPeerParentRecord(t, cacheStore, importedPeerParentRecordOptions{
+		Stage:           workspaceStageName,
+		CacheKey:        workspaceKey,
+		StorageRef:      "tank/local/workspace@base",
+		SnapshotGUID:    "workspace-guid",
+		ProducerVersion: workspaceStageProducerVersion,
+	})
+
+	wrongMetadata := encodeZFSMetadataForTest(t, "tank/local/imports/dependency@base", "wrong-dependency-guid", "workspace-guid")
+	transfer := &stubCachePeerTransferDriver{
+		describeSnapshots: map[string]volumestore.SnapshotDescription{
+			"tank/local/workspace@base": {
+				SnapshotRef:  "tank/local/workspace@base",
+				StorageRef:   "tank/local/workspace@base",
+				SnapshotGUID: "workspace-guid",
+			},
+		},
+		importSnapshot: volumestore.Snapshot{
+			StorageRef:     "tank/local/imports/dependency@base",
+			DriverMetadata: wrongMetadata,
+		},
+	}
+	svc.CachePeerTransferDriver = transfer
+
+	peer := newTestCachePeerImportServer(t, &cleanroomv1.CachePeerCandidate{
+		TransferToken:         "peer-token",
+		Stage:                 dependencyStageName,
+		CacheKey:              dependencyPlan.CacheKey,
+		ParentStage:           workspaceStageName,
+		ParentCacheKey:        workspaceKey,
+		Backend:               "firecracker",
+		StorageDriver:         "zfs",
+		Architecture:          runtime.GOARCH,
+		ProducerVersion:       dependencyStageProducerVersion,
+		PolicyHash:            compiled.Hash,
+		ZfsSnapshotGuid:       "dependency-guid",
+		ZfsParentSnapshotGuid: "workspace-guid",
+		ExpiresAt:             timestamppb.New(time.Now().Add(time.Hour)),
+	})
+	svc.Config.Cache.Peers = []runtimeconfig.CachePeerConfig{{URL: peer.URL, TokenEnv: "CLEANROOM_CACHE_PEER_TOKEN"}}
+
+	record, imported, err := svc.importDependencyStageCacheFromPeers(
+		context.Background(),
+		adapter,
+		"firecracker",
+		compiled,
+		runtimeconfig.MergeBackendConfig(svc.Config, "firecracker", 0),
+		repository,
+		nil,
+		dependencyPlan,
+	)
+	if err == nil {
+		t.Fatal("expected invalid peer snapshot metadata to fail")
+	}
+	if imported {
+		t.Fatalf("expected invalid import to report imported=false, got record %#v", record)
+	}
+	if got, want := adapter.deleteSnapshotCalls, 1; got != want {
+		t.Fatalf("expected invalid import to clean up imported snapshot, got delete calls %d want %d", got, want)
+	}
+	if got, want := adapter.deleteSnapshotReq.StorageRef, "tank/local/imports/dependency@base"; got != want {
+		t.Fatalf("unexpected cleanup storage ref: got %q want %q", got, want)
+	}
+	if got, want := adapter.deleteSnapshotReq.FirecrackerConfig.Snapshots.Driver, "zfs"; got != want {
+		t.Fatalf("unexpected cleanup snapshot driver: got %q want %q", got, want)
+	}
+	if _, found, err := cacheStore.GetReady(context.Background(), dependencyStageName, dependencyPlan.CacheKey); err != nil {
+		t.Fatalf("GetReady returned error: %v", err)
+	} else if found {
+		t.Fatal("expected invalid import to leave no dependency cache metadata")
+	}
+}
+
+func TestCreateSandboxImportsServicesStageCacheFromPeer(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CLEANROOM_CACHE_PEER_TOKEN", "receiver-token")
+
+	adapter := &stubAdapter{}
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"go.mod":             "module example.com/test\n\ngo 1.26.2\n",
+		"go.sum":             "example.com/test v0.0.0 h1:abc123\n",
+		"docker-compose.yml": "services:\n  postgres:\n    image: postgres:17\n",
+	})
+	svc := newTestService(adapter)
+	svc.RepositoryStore = mirrors
+	svc.Config.Backends.Firecracker.Snapshots.Driver = "zfs"
+
+	compiled, err := policy.FromProto(testRepositoryDependencyAndServicesPolicy())
+	if err != nil {
+		t.Fatalf("FromProto returned error: %v", err)
+	}
+	repository := repositorycheckout.FromProto(repositoryCheckout)
+	workspaceKey := workspaceStageCacheKey("firecracker", "runtime-base:test", compiled.Hash, repository, nil)
+	dependencyPlan, ok := dependencyStagePlanForRepository(compiled, repository)
+	if !ok {
+		t.Fatal("expected dependency stage plan")
+	}
+	dependencyPlan, ok, err = svc.finalizeDependencyStagePlan(context.Background(), compiled, repository, nil, nil, "firecracker", workspaceKey, "runtime-base:test", dependencyPlan)
+	if err != nil {
+		t.Fatalf("finalizeDependencyStagePlan returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected finalized dependency stage plan")
+	}
+	servicesPlan, ok := servicesStagePlanForRepository(compiled, repository)
+	if !ok {
+		t.Fatal("expected services stage plan")
+	}
+	servicesPlan, ok, err = svc.finalizeServicesStagePlan(context.Background(), compiled, repository, nil, nil, dependencyPlan.CacheKey, "runtime-base:test", servicesPlan)
+	if err != nil {
+		t.Fatalf("finalizeServicesStagePlan returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected finalized services stage plan")
+	}
+
+	cacheStore := requireMemoryCacheStore(t, svc)
+	insertImportedPeerParentRecord(t, cacheStore, importedPeerParentRecordOptions{
+		Stage:              dependencyStageName,
+		CacheKey:           dependencyPlan.CacheKey,
+		ParentCacheKey:     workspaceKey,
+		StorageRef:         "tank/local/dependency@base",
+		SnapshotGUID:       "dependency-guid",
+		ParentSnapshotGUID: "workspace-guid",
+		ProducerVersion:    dependencyStageProducerVersion,
+		ReuseMode:          dependencyStageReuseExact,
+	})
+
+	importMetadata := encodeZFSMetadataForTest(t, "tank/local/imports/services@base", "services-guid", "dependency-guid")
+	transfer := &stubCachePeerTransferDriver{
+		describeSnapshots: map[string]volumestore.SnapshotDescription{
+			"tank/local/dependency@base": {
+				SnapshotRef:  "tank/local/dependency@base",
+				StorageRef:   "tank/local/dependency@base",
+				SnapshotGUID: "dependency-guid",
+			},
+		},
+		importSnapshot: volumestore.Snapshot{
+			StorageRef:     "tank/local/imports/services@base",
+			DriverMetadata: importMetadata,
+		},
+	}
+	svc.CachePeerTransferDriver = transfer
+
+	peer := newTestCachePeerImportServer(t, &cleanroomv1.CachePeerCandidate{
+		TransferToken:         "peer-token",
+		Stage:                 servicesStageName,
+		CacheKey:              servicesPlan.CacheKey,
+		ParentStage:           dependencyStageName,
+		ParentCacheKey:        dependencyPlan.CacheKey,
+		Backend:               "firecracker",
+		StorageDriver:         "zfs",
+		Architecture:          runtime.GOARCH,
+		ProducerVersion:       servicesStageProducerVersion,
+		PolicyHash:            compiled.Hash,
+		ZfsSnapshotGuid:       "services-guid",
+		ZfsParentSnapshotGuid: "dependency-guid",
+		BackingSnapshotId:     "peer-services-snapshot",
+		StorageRef:            "tank/peer/services@base",
+		EstimatedBytes:        128,
+		ExpiresAt:             timestamppb.New(time.Now().Add(time.Hour)),
+	})
+	svc.Config.Cache.Peers = []runtimeconfig.CachePeerConfig{{URL: peer.URL, TokenEnv: "CLEANROOM_CACHE_PEER_TOKEN"}}
+
+	resp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Policy:             testRepositoryDependencyAndServicesPolicy(),
+		RepositoryCheckout: repositoryCheckout,
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	if got, want := resp.GetSourceKind(), "services stage cache"; got != want {
+		t.Fatalf("unexpected source kind: got %q want %q", got, want)
+	}
+	if got, want := adapter.provisionFromSnapshotCalls, 1; got != want {
+		t.Fatalf("expected restored imported services cache once, got %d want %d", got, want)
+	}
+	if got, want := adapter.provisionCalls, 0; got != want {
+		t.Fatalf("expected peer import restore to skip cold provision, got %d want %d", got, want)
+	}
+	if got, want := adapter.runCalls, 0; got != want {
+		t.Fatalf("expected peer import restore to skip bootstrap commands, got %d want %d", got, want)
+	}
+	requireCachePeerImportRequest(t, transfer, "tank/local/dependency@base", "dependency-guid", "services-guid", "zfs-stream")
+	requireCachePeerLookup(t, peer, &cleanroomv1.LookupCachePeerRequest{
+		Stage:                 servicesStageName,
+		CacheKey:              servicesPlan.CacheKey,
+		Backend:               "firecracker",
+		StorageDriver:         "zfs",
+		Architecture:          runtime.GOARCH,
+		ProducerVersion:       servicesStageProducerVersion,
+		PolicyHash:            compiled.Hash,
+		ParentStage:           dependencyStageName,
+		ParentCacheKey:        dependencyPlan.CacheKey,
+		ParentZfsSnapshotGuid: "dependency-guid",
+	})
+
+	record, found, err := cacheStore.GetReady(context.Background(), servicesStageName, servicesPlan.CacheKey)
+	if err != nil {
+		t.Fatalf("GetReady returned error: %v", err)
+	}
+	if !found {
+		t.Fatal("expected imported services cache record")
+	}
+	if !record.ImportedFromPeer {
+		t.Fatal("expected services cache record to be marked as peer-imported")
+	}
+	if got, want := record.StorageRef, "tank/local/imports/services@base"; got != want {
+		t.Fatalf("unexpected imported storage ref: got %q want %q", got, want)
+	}
+	if got, want := record.ParentCacheKey, dependencyPlan.CacheKey; got != want {
+		t.Fatalf("unexpected parent cache key: got %q want %q", got, want)
+	}
+}
+
+type testCachePeerImportServer struct {
+	*httptest.Server
+	requests       []*cleanroomv1.LookupCachePeerRequest
+	lookupAuth     []string
+	exportAuth     []string
+	exportRequests int
+	candidate      *cleanroomv1.CachePeerCandidate
+}
+
+func newTestCachePeerImportServer(t *testing.T, candidate *cleanroomv1.CachePeerCandidate) *testCachePeerImportServer {
+	t.Helper()
+	peer := &testCachePeerImportServer{candidate: candidate}
+	mux := http.NewServeMux()
+	path, handler := cleanroomv1connect.NewCachePeerServiceHandler(peer)
+	mux.Handle(path, handler)
+	mux.HandleFunc(cachePeerZFSIncrementalExportPathPrefix+"peer-token", func(w http.ResponseWriter, r *http.Request) {
+		peer.exportRequests++
+		peer.exportAuth = append(peer.exportAuth, r.Header.Get("Authorization"))
+		_, _ = w.Write([]byte("zfs-stream"))
+	})
+	peer.Server = httptest.NewServer(mux)
+	t.Cleanup(peer.Close)
+	return peer
+}
+
+func (p *testCachePeerImportServer) LookupCachePeer(_ context.Context, req *connect.Request[cleanroomv1.LookupCachePeerRequest]) (*connect.Response[cleanroomv1.LookupCachePeerResponse], error) {
+	p.lookupAuth = append(p.lookupAuth, req.Header().Get("Authorization"))
+	p.requests = append(p.requests, req.Msg)
+	return connect.NewResponse(&cleanroomv1.LookupCachePeerResponse{Candidate: p.candidate}), nil
+}
+
+func requireMemoryCacheStore(t *testing.T, svc *Service) *memoryCacheStore {
+	t.Helper()
+	cacheStore, ok := svc.CacheStore.(*memoryCacheStore)
+	if !ok {
+		t.Fatalf("expected memory cache store, got %T", svc.CacheStore)
+	}
+	return cacheStore
+}
+
+type importedPeerParentRecordOptions struct {
+	Stage              string
+	CacheKey           string
+	ParentCacheKey     string
+	StorageRef         string
+	SnapshotGUID       string
+	ParentSnapshotGUID string
+	ProducerVersion    string
+	ReuseMode          string
+}
+
+func insertImportedPeerParentRecord(t *testing.T, store *memoryCacheStore, opts importedPeerParentRecordOptions) {
+	t.Helper()
+	metadata := encodeZFSMetadataForTest(t, opts.StorageRef, opts.SnapshotGUID, opts.ParentSnapshotGUID)
+	if err := store.Create(context.Background(), cachestore.Record{
+		CacheKey:          opts.CacheKey,
+		Stage:             opts.Stage,
+		ReuseMode:         opts.ReuseMode,
+		State:             cacheStateReady,
+		BackingSnapshotID: strings.ReplaceAll(opts.CacheKey, ":", "-") + "-snapshot",
+		Backend:           "firecracker",
+		Architecture:      runtime.GOARCH,
+		ParentCacheKey:    opts.ParentCacheKey,
+		StorageDriver:     "zfs",
+		StorageRef:        opts.StorageRef,
+		DriverMetadata:    metadata,
+		ProducerVersion:   opts.ProducerVersion,
+	}); err != nil {
+		t.Fatalf("insert parent cache record: %v", err)
+	}
+}
+
+func encodeZFSMetadataForTest(t *testing.T, dataset, guid, parentGUID string) string {
+	t.Helper()
+	metadata, err := volumestore.EncodeZFSDriverMetadata(volumestore.ZFSDriverMetadata{
+		Dataset:            dataset,
+		SnapshotGUID:       guid,
+		ParentSnapshotGUID: parentGUID,
+	})
+	if err != nil {
+		t.Fatalf("EncodeZFSDriverMetadata returned error: %v", err)
+	}
+	return metadata
+}
+
+func requireCachePeerImportRequest(t *testing.T, transfer *stubCachePeerTransferDriver, parentRef, parentGUID, expectedGUID, payload string) {
+	t.Helper()
+	if got, want := len(transfer.importRequests), 1; got != want {
+		t.Fatalf("expected one import request, got %d", got)
+	}
+	req := transfer.importRequests[0]
+	if strings.TrimSpace(req.SnapshotID) == "" {
+		t.Fatal("expected imported snapshot id")
+	}
+	if got, want := req.ParentSnapshotRef, parentRef; got != want {
+		t.Fatalf("unexpected import parent ref: got %q want %q", got, want)
+	}
+	if got, want := req.ParentSnapshotGUID, parentGUID; got != want {
+		t.Fatalf("unexpected import parent guid: got %q want %q", got, want)
+	}
+	if got, want := req.ExpectedSnapshotGUID, expectedGUID; got != want {
+		t.Fatalf("unexpected import expected guid: got %q want %q", got, want)
+	}
+	if got, want := transfer.importPayloads, []string{payload}; len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("unexpected import payloads: got %#v want %#v", got, want)
+	}
+}
+
+func requireCachePeerLookup(t *testing.T, peer *testCachePeerImportServer, want *cleanroomv1.LookupCachePeerRequest) {
+	t.Helper()
+	if got, want := peer.lookupAuth, []string{"Bearer receiver-token"}; len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("unexpected lookup auth headers: got %#v want %#v", got, want)
+	}
+	if got, want := peer.exportAuth, []string{"Bearer receiver-token"}; len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("unexpected export auth headers: got %#v want %#v", got, want)
+	}
+	if got, want := peer.exportRequests, 1; got != want {
+		t.Fatalf("unexpected export request count: got %d want %d", got, want)
+	}
+	if got, want := len(peer.requests), 1; got != want {
+		t.Fatalf("expected one peer lookup request, got %d", got)
+	}
+	got := peer.requests[0]
+	fields := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"stage", got.GetStage(), want.GetStage()},
+		{"cache key", got.GetCacheKey(), want.GetCacheKey()},
+		{"backend", got.GetBackend(), want.GetBackend()},
+		{"storage driver", got.GetStorageDriver(), want.GetStorageDriver()},
+		{"architecture", got.GetArchitecture(), want.GetArchitecture()},
+		{"producer version", got.GetProducerVersion(), want.GetProducerVersion()},
+		{"policy hash", got.GetPolicyHash(), want.GetPolicyHash()},
+		{"parent stage", got.GetParentStage(), want.GetParentStage()},
+		{"parent cache key", got.GetParentCacheKey(), want.GetParentCacheKey()},
+		{"parent zfs guid", got.GetParentZfsSnapshotGuid(), want.GetParentZfsSnapshotGuid()},
+	}
+	for _, field := range fields {
+		if field.got != field.want {
+			t.Fatalf("unexpected lookup %s: got %q want %q", field.name, field.got, field.want)
+		}
+	}
+	if strings.TrimSpace(got.GetParentZfsSnapshotGuid()) == "" {
+		t.Fatal("expected peer lookup to include local parent zfs guid")
+	}
+	if got.GetParentZfsSnapshotGuid() != want.GetParentZfsSnapshotGuid() {
+		t.Fatalf("unexpected parent zfs guid: got %q want %q", got.GetParentZfsSnapshotGuid(), want.GetParentZfsSnapshotGuid())
+	}
+}

--- a/internal/controlservice/cache_peer_import_test.go
+++ b/internal/controlservice/cache_peer_import_test.go
@@ -501,6 +501,143 @@ func TestCreateSandboxImportsServicesStageCacheFromPeer(t *testing.T) {
 	}
 }
 
+func TestCreateSandboxImportsServicesStageAfterDependencyPeerImport(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CLEANROOM_CACHE_PEER_TOKEN", "receiver-token")
+
+	adapter := &stubAdapter{}
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"go.mod":             "module example.com/test\n\ngo 1.26.2\n",
+		"go.sum":             "example.com/test v0.0.0 h1:abc123\n",
+		"docker-compose.yml": "services:\n  postgres:\n    image: postgres:17\n",
+	})
+	svc := newTestService(adapter)
+	svc.RepositoryStore = mirrors
+	svc.Config.Backends.Firecracker.Snapshots.Driver = "zfs"
+
+	compiled, err := policy.FromProto(testRepositoryDependencyAndServicesPolicy())
+	if err != nil {
+		t.Fatalf("FromProto returned error: %v", err)
+	}
+	repository := repositorycheckout.FromProto(repositoryCheckout)
+	workspaceKey := workspaceStageCacheKey("firecracker", "runtime-base:test", compiled.Hash, repository, nil)
+	dependencyPlan, ok := dependencyStagePlanForRepository(compiled, repository)
+	if !ok {
+		t.Fatal("expected dependency stage plan")
+	}
+	dependencyPlan, ok, err = svc.finalizeDependencyStagePlan(context.Background(), compiled, repository, nil, nil, "firecracker", workspaceKey, "runtime-base:test", dependencyPlan)
+	if err != nil {
+		t.Fatalf("finalizeDependencyStagePlan returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected finalized dependency stage plan")
+	}
+	servicesPlan, ok := servicesStagePlanForRepository(compiled, repository)
+	if !ok {
+		t.Fatal("expected services stage plan")
+	}
+	servicesPlan, ok, err = svc.finalizeServicesStagePlan(context.Background(), compiled, repository, nil, nil, dependencyPlan.CacheKey, "runtime-base:test", servicesPlan)
+	if err != nil {
+		t.Fatalf("finalizeServicesStagePlan returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected finalized services stage plan")
+	}
+
+	cacheStore := requireMemoryCacheStore(t, svc)
+	insertImportedPeerParentRecord(t, cacheStore, importedPeerParentRecordOptions{
+		Stage:           workspaceStageName,
+		CacheKey:        workspaceKey,
+		StorageRef:      "tank/local/workspace@base",
+		SnapshotGUID:    "workspace-guid",
+		ProducerVersion: workspaceStageProducerVersion,
+	})
+
+	dependencyMetadata := encodeZFSMetadataForTest(t, "tank/local/imports/dependency@base", "dependency-guid", "workspace-guid")
+	servicesMetadata := encodeZFSMetadataForTest(t, "tank/local/imports/services@base", "services-guid", "dependency-guid")
+	transfer := &stubCachePeerTransferDriver{
+		describeSnapshots: map[string]volumestore.SnapshotDescription{
+			"tank/local/workspace@base": {
+				SnapshotRef:  "tank/local/workspace@base",
+				StorageRef:   "tank/local/workspace@base",
+				SnapshotGUID: "workspace-guid",
+			},
+			"tank/local/imports/dependency@base": {
+				SnapshotRef:  "tank/local/imports/dependency@base",
+				StorageRef:   "tank/local/imports/dependency@base",
+				SnapshotGUID: "dependency-guid",
+			},
+		},
+		importSnapshots: map[string]volumestore.Snapshot{
+			"dependency-guid": {
+				StorageRef:     "tank/local/imports/dependency@base",
+				DriverMetadata: dependencyMetadata,
+			},
+			"services-guid": {
+				StorageRef:     "tank/local/imports/services@base",
+				DriverMetadata: servicesMetadata,
+			},
+		},
+	}
+	svc.CachePeerTransferDriver = transfer
+
+	dependencyCandidate := cachePeerImportTestCandidate(dependencyPlan.CacheKey, workspaceKey, compiled.Hash, "dependency-token")
+	servicesCandidate := cachePeerImportTestServicesCandidate(servicesPlan.CacheKey, dependencyPlan.CacheKey, compiled.Hash, "services-token")
+	peer := newTestCachePeerImportServerWithCandidates(t, []*cleanroomv1.CachePeerCandidate{dependencyCandidate, servicesCandidate}, map[string]testCachePeerExport{
+		"dependency-token": {Status: http.StatusOK, Payload: "dependency-zfs-stream"},
+		"services-token":   {Status: http.StatusOK, Payload: "services-zfs-stream"},
+	})
+	svc.Config.Cache.Peers = []runtimeconfig.CachePeerConfig{{URL: peer.URL, TokenEnv: "CLEANROOM_CACHE_PEER_TOKEN"}}
+
+	resp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Policy:             testRepositoryDependencyAndServicesPolicy(),
+		RepositoryCheckout: repositoryCheckout,
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	if got, want := resp.GetSourceKind(), "services stage cache"; got != want {
+		t.Fatalf("unexpected source kind: got %q want %q", got, want)
+	}
+	if got, want := adapter.provisionFromSnapshotCalls, 1; got != want {
+		t.Fatalf("expected direct services cache restore once, got %d want %d", got, want)
+	}
+	if got, want := adapter.provisionCalls, 0; got != want {
+		t.Fatalf("expected remote dependency+services imports to skip cold provision, got %d want %d", got, want)
+	}
+	if got, want := adapter.runCalls, 0; got != want {
+		t.Fatalf("expected remote dependency+services imports to skip bootstraps, got %d want %d", got, want)
+	}
+	if got, want := transfer.importPayloads, []string{"dependency-zfs-stream", "services-zfs-stream"}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("unexpected import payloads: got %#v want %#v", got, want)
+	}
+	if got, want := len(transfer.importRequests), 2; got != want {
+		t.Fatalf("expected dependency and services import requests, got %d", got)
+	}
+	if got, want := transfer.importRequests[0].ParentSnapshotGUID, "workspace-guid"; got != want {
+		t.Fatalf("unexpected dependency import parent guid: got %q want %q", got, want)
+	}
+	if got, want := transfer.importRequests[1].ParentSnapshotGUID, "dependency-guid"; got != want {
+		t.Fatalf("unexpected services import parent guid: got %q want %q", got, want)
+	}
+	if got, want := transfer.importRequests[1].ParentSnapshotRef, "tank/local/imports/dependency@base"; got != want {
+		t.Fatalf("unexpected services import parent ref: got %q want %q", got, want)
+	}
+	if got, want := peer.exportRequests, 2; got != want {
+		t.Fatalf("expected dependency and services exports, got %d", got)
+	}
+	if _, found, err := cacheStore.GetReady(context.Background(), dependencyStageName, dependencyPlan.CacheKey); err != nil {
+		t.Fatalf("GetReady dependency returned error: %v", err)
+	} else if !found {
+		t.Fatal("expected imported dependency cache metadata")
+	}
+	if _, found, err := cacheStore.GetReady(context.Background(), servicesStageName, servicesPlan.CacheKey); err != nil {
+		t.Fatalf("GetReady services returned error: %v", err)
+	} else if !found {
+		t.Fatal("expected imported services cache metadata")
+	}
+}
+
 type testCachePeerImportServer struct {
 	*httptest.Server
 	requests       []*cleanroomv1.LookupCachePeerRequest
@@ -508,6 +645,13 @@ type testCachePeerImportServer struct {
 	exportAuth     []string
 	exportRequests int
 	candidate      *cleanroomv1.CachePeerCandidate
+	candidates     []*cleanroomv1.CachePeerCandidate
+	exports        map[string]testCachePeerExport
+}
+
+type testCachePeerExport struct {
+	Status  int
+	Payload string
 }
 
 func newTestCachePeerImportServer(t *testing.T, candidate *cleanroomv1.CachePeerCandidate) *testCachePeerImportServer {
@@ -515,26 +659,44 @@ func newTestCachePeerImportServer(t *testing.T, candidate *cleanroomv1.CachePeer
 }
 
 func newTestCachePeerImportServerWithExport(t *testing.T, candidate *cleanroomv1.CachePeerCandidate, status int, payload string) *testCachePeerImportServer {
-	t.Helper()
-	peer := &testCachePeerImportServer{candidate: candidate}
-	mux := http.NewServeMux()
-	path, handler := cleanroomv1connect.NewCachePeerServiceHandler(peer)
-	mux.Handle(path, handler)
 	token := "peer-token"
 	if candidate != nil && strings.TrimSpace(candidate.GetTransferToken()) != "" {
 		token = candidate.GetTransferToken()
 	}
-	if status == 0 {
-		status = http.StatusOK
+	return newTestCachePeerImportServerWithCandidates(t, []*cleanroomv1.CachePeerCandidate{candidate}, map[string]testCachePeerExport{
+		token: {Status: status, Payload: payload},
+	})
+}
+
+func newTestCachePeerImportServerWithCandidates(t *testing.T, candidates []*cleanroomv1.CachePeerCandidate, exports map[string]testCachePeerExport) *testCachePeerImportServer {
+	t.Helper()
+	peer := &testCachePeerImportServer{
+		candidates: candidates,
+		exports:    exports,
 	}
-	mux.HandleFunc(cachePeerZFSIncrementalExportPathPrefix+token, func(w http.ResponseWriter, r *http.Request) {
+	if len(candidates) > 0 {
+		peer.candidate = candidates[0]
+	}
+	mux := http.NewServeMux()
+	path, handler := cleanroomv1connect.NewCachePeerServiceHandler(peer)
+	mux.Handle(path, handler)
+	mux.HandleFunc(cachePeerZFSIncrementalExportPathPrefix, func(w http.ResponseWriter, r *http.Request) {
 		peer.exportRequests++
 		peer.exportAuth = append(peer.exportAuth, r.Header.Get("Authorization"))
-		if status != http.StatusOK {
-			http.Error(w, "export failed", status)
+		token := strings.TrimPrefix(r.URL.Path, cachePeerZFSIncrementalExportPathPrefix)
+		export, ok := peer.exports[token]
+		if !ok {
+			http.NotFound(w, r)
 			return
 		}
-		_, _ = w.Write([]byte(payload))
+		if export.Status == 0 {
+			export.Status = http.StatusOK
+		}
+		if export.Status != http.StatusOK {
+			http.Error(w, "export failed", export.Status)
+			return
+		}
+		_, _ = w.Write([]byte(export.Payload))
 	})
 	peer.Server = httptest.NewServer(mux)
 	t.Cleanup(peer.Close)
@@ -559,10 +721,33 @@ func cachePeerImportTestCandidate(cacheKey, parentCacheKey, policyHash, token st
 	}
 }
 
+func cachePeerImportTestServicesCandidate(cacheKey, parentCacheKey, policyHash, token string) *cleanroomv1.CachePeerCandidate {
+	return &cleanroomv1.CachePeerCandidate{
+		TransferToken:         token,
+		Stage:                 servicesStageName,
+		CacheKey:              cacheKey,
+		ParentStage:           dependencyStageName,
+		ParentCacheKey:        parentCacheKey,
+		Backend:               "firecracker",
+		StorageDriver:         "zfs",
+		Architecture:          runtime.GOARCH,
+		ProducerVersion:       servicesStageProducerVersion,
+		PolicyHash:            policyHash,
+		ZfsSnapshotGuid:       "services-guid",
+		ZfsParentSnapshotGuid: "dependency-guid",
+		ExpiresAt:             timestamppb.New(time.Now().Add(time.Hour)),
+	}
+}
+
 func (p *testCachePeerImportServer) LookupCachePeer(_ context.Context, req *connect.Request[cleanroomv1.LookupCachePeerRequest]) (*connect.Response[cleanroomv1.LookupCachePeerResponse], error) {
 	p.lookupAuth = append(p.lookupAuth, req.Header().Get("Authorization"))
 	p.requests = append(p.requests, req.Msg)
-	return connect.NewResponse(&cleanroomv1.LookupCachePeerResponse{Candidate: p.candidate}), nil
+	for _, candidate := range p.candidates {
+		if cachePeerCandidateMatchesRequest(candidate, req.Msg, time.Now().Add(-time.Second)) {
+			return connect.NewResponse(&cleanroomv1.LookupCachePeerResponse{Candidate: candidate}), nil
+		}
+	}
+	return connect.NewResponse(&cleanroomv1.LookupCachePeerResponse{}), nil
 }
 
 func requireMemoryCacheStore(t *testing.T, svc *Service) *memoryCacheStore {

--- a/internal/controlservice/cache_peer_import_test.go
+++ b/internal/controlservice/cache_peer_import_test.go
@@ -261,6 +261,104 @@ func TestImportDependencyStageCacheFromPeerCleansUpInvalidSnapshot(t *testing.T)
 	}
 }
 
+func TestImportDependencyStageCacheFromPeersContinuesAfterExportFailure(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CLEANROOM_CACHE_PEER_TOKEN", "receiver-token")
+
+	adapter := &stubAdapter{}
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"go.mod": "module example.com/test\n\ngo 1.26.2\n",
+		"go.sum": "example.com/test v0.0.0 h1:abc123\n",
+	})
+	svc := newTestService(adapter)
+	svc.RepositoryStore = mirrors
+	svc.Config.Backends.Firecracker.Snapshots.Driver = "zfs"
+
+	compiled, err := policy.FromProto(testRepositoryDependencyPolicy())
+	if err != nil {
+		t.Fatalf("FromProto returned error: %v", err)
+	}
+	repository := repositorycheckout.FromProto(repositoryCheckout)
+	workspaceKey := workspaceStageCacheKey("firecracker", "runtime-base:test", compiled.Hash, repository, nil)
+	dependencyPlan, ok := dependencyStagePlanForRepository(compiled, repository)
+	if !ok {
+		t.Fatal("expected dependency stage plan")
+	}
+	dependencyPlan, ok, err = svc.finalizeDependencyStagePlan(context.Background(), compiled, repository, nil, nil, "firecracker", workspaceKey, "runtime-base:test", dependencyPlan)
+	if err != nil {
+		t.Fatalf("finalizeDependencyStagePlan returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected finalized dependency stage plan")
+	}
+
+	cacheStore := requireMemoryCacheStore(t, svc)
+	insertImportedPeerParentRecord(t, cacheStore, importedPeerParentRecordOptions{
+		Stage:           workspaceStageName,
+		CacheKey:        workspaceKey,
+		StorageRef:      "tank/local/workspace@base",
+		SnapshotGUID:    "workspace-guid",
+		ProducerVersion: workspaceStageProducerVersion,
+	})
+
+	importMetadata := encodeZFSMetadataForTest(t, "tank/local/imports/dependency@base", "dependency-guid", "workspace-guid")
+	transfer := &stubCachePeerTransferDriver{
+		describeSnapshots: map[string]volumestore.SnapshotDescription{
+			"tank/local/workspace@base": {
+				SnapshotRef:  "tank/local/workspace@base",
+				StorageRef:   "tank/local/workspace@base",
+				SnapshotGUID: "workspace-guid",
+			},
+		},
+		importSnapshot: volumestore.Snapshot{
+			StorageRef:     "tank/local/imports/dependency@base",
+			DriverMetadata: importMetadata,
+		},
+	}
+	svc.CachePeerTransferDriver = transfer
+
+	firstCandidate := cachePeerImportTestCandidate(dependencyPlan.CacheKey, workspaceKey, compiled.Hash, "bad-token")
+	badPeer := newTestCachePeerImportServerWithExport(t, firstCandidate, http.StatusInternalServerError, "")
+	secondCandidate := cachePeerImportTestCandidate(dependencyPlan.CacheKey, workspaceKey, compiled.Hash, "good-token")
+	goodPeer := newTestCachePeerImportServerWithExport(t, secondCandidate, http.StatusOK, "good-zfs-stream")
+	svc.Config.Cache.Peers = []runtimeconfig.CachePeerConfig{
+		{URL: badPeer.URL, TokenEnv: "CLEANROOM_CACHE_PEER_TOKEN"},
+		{URL: goodPeer.URL, TokenEnv: "CLEANROOM_CACHE_PEER_TOKEN"},
+	}
+
+	record, imported, err := svc.importDependencyStageCacheFromPeers(
+		context.Background(),
+		adapter,
+		"firecracker",
+		compiled,
+		runtimeconfig.MergeBackendConfig(svc.Config, "firecracker", 0),
+		repository,
+		nil,
+		dependencyPlan,
+	)
+	if err != nil {
+		t.Fatalf("importDependencyStageCacheFromPeers returned error: %v", err)
+	}
+	if !imported {
+		t.Fatal("expected import to continue to second peer")
+	}
+	if got, want := record.StorageRef, "tank/local/imports/dependency@base"; got != want {
+		t.Fatalf("unexpected imported storage ref: got %q want %q", got, want)
+	}
+	if got, want := badPeer.exportRequests, 1; got != want {
+		t.Fatalf("expected first peer export to be attempted once, got %d", got)
+	}
+	if got, want := goodPeer.exportRequests, 1; got != want {
+		t.Fatalf("expected second peer export to be attempted once, got %d", got)
+	}
+	requireCachePeerImportRequest(t, transfer, "tank/local/workspace@base", "workspace-guid", "dependency-guid", "good-zfs-stream")
+	if _, found, err := cacheStore.GetReady(context.Background(), dependencyStageName, dependencyPlan.CacheKey); err != nil {
+		t.Fatalf("GetReady returned error: %v", err)
+	} else if !found {
+		t.Fatal("expected successful second-peer import to publish cache metadata")
+	}
+}
+
 func TestCreateSandboxImportsServicesStageCacheFromPeer(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	t.Setenv("CLEANROOM_CACHE_PEER_TOKEN", "receiver-token")
@@ -413,19 +511,52 @@ type testCachePeerImportServer struct {
 }
 
 func newTestCachePeerImportServer(t *testing.T, candidate *cleanroomv1.CachePeerCandidate) *testCachePeerImportServer {
+	return newTestCachePeerImportServerWithExport(t, candidate, http.StatusOK, "zfs-stream")
+}
+
+func newTestCachePeerImportServerWithExport(t *testing.T, candidate *cleanroomv1.CachePeerCandidate, status int, payload string) *testCachePeerImportServer {
 	t.Helper()
 	peer := &testCachePeerImportServer{candidate: candidate}
 	mux := http.NewServeMux()
 	path, handler := cleanroomv1connect.NewCachePeerServiceHandler(peer)
 	mux.Handle(path, handler)
-	mux.HandleFunc(cachePeerZFSIncrementalExportPathPrefix+"peer-token", func(w http.ResponseWriter, r *http.Request) {
+	token := "peer-token"
+	if candidate != nil && strings.TrimSpace(candidate.GetTransferToken()) != "" {
+		token = candidate.GetTransferToken()
+	}
+	if status == 0 {
+		status = http.StatusOK
+	}
+	mux.HandleFunc(cachePeerZFSIncrementalExportPathPrefix+token, func(w http.ResponseWriter, r *http.Request) {
 		peer.exportRequests++
 		peer.exportAuth = append(peer.exportAuth, r.Header.Get("Authorization"))
-		_, _ = w.Write([]byte("zfs-stream"))
+		if status != http.StatusOK {
+			http.Error(w, "export failed", status)
+			return
+		}
+		_, _ = w.Write([]byte(payload))
 	})
 	peer.Server = httptest.NewServer(mux)
 	t.Cleanup(peer.Close)
 	return peer
+}
+
+func cachePeerImportTestCandidate(cacheKey, parentCacheKey, policyHash, token string) *cleanroomv1.CachePeerCandidate {
+	return &cleanroomv1.CachePeerCandidate{
+		TransferToken:         token,
+		Stage:                 dependencyStageName,
+		CacheKey:              cacheKey,
+		ParentStage:           workspaceStageName,
+		ParentCacheKey:        parentCacheKey,
+		Backend:               "firecracker",
+		StorageDriver:         "zfs",
+		Architecture:          runtime.GOARCH,
+		ProducerVersion:       dependencyStageProducerVersion,
+		PolicyHash:            policyHash,
+		ZfsSnapshotGuid:       "dependency-guid",
+		ZfsParentSnapshotGuid: "workspace-guid",
+		ExpiresAt:             timestamppb.New(time.Now().Add(time.Hour)),
+	}
 }
 
 func (p *testCachePeerImportServer) LookupCachePeer(_ context.Context, req *connect.Request[cleanroomv1.LookupCachePeerRequest]) (*connect.Response[cleanroomv1.LookupCachePeerResponse], error) {

--- a/internal/controlservice/cache_peer_test.go
+++ b/internal/controlservice/cache_peer_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -15,12 +16,26 @@ import (
 )
 
 type stubCachePeerTransferDriver struct {
-	planRequests  []volumestore.IncrementalSnapshotExportRequest
-	exportPlans   []volumestore.IncrementalSnapshotExportPlan
-	exportPayload string
+	describeSnapshots map[string]volumestore.SnapshotDescription
+	describeRequests  []volumestore.DescribeSnapshotRequest
+	planRequests      []volumestore.IncrementalSnapshotExportRequest
+	exportPlans       []volumestore.IncrementalSnapshotExportPlan
+	exportPayload     string
+	importRequests    []volumestore.IncrementalSnapshotImportRequest
+	importPayloads    []string
+	importSnapshot    volumestore.Snapshot
 }
 
-func (d *stubCachePeerTransferDriver) DescribeSnapshot(context.Context, volumestore.DescribeSnapshotRequest) (volumestore.SnapshotDescription, error) {
+func (d *stubCachePeerTransferDriver) DescribeSnapshot(_ context.Context, req volumestore.DescribeSnapshotRequest) (volumestore.SnapshotDescription, error) {
+	d.describeRequests = append(d.describeRequests, req)
+	if d.describeSnapshots != nil {
+		if desc, ok := d.describeSnapshots[req.SnapshotRef]; ok {
+			return desc, nil
+		}
+		if desc, ok := d.describeSnapshots[req.StorageRef]; ok {
+			return desc, nil
+		}
+	}
 	return volumestore.SnapshotDescription{}, nil
 }
 
@@ -41,7 +56,16 @@ func (d *stubCachePeerTransferDriver) ExportIncrementalSnapshot(_ context.Contex
 	return err
 }
 
-func (d *stubCachePeerTransferDriver) ImportIncrementalSnapshot(context.Context, volumestore.IncrementalSnapshotImportRequest, io.Reader) (volumestore.Snapshot, error) {
+func (d *stubCachePeerTransferDriver) ImportIncrementalSnapshot(_ context.Context, req volumestore.IncrementalSnapshotImportRequest, src io.Reader) (volumestore.Snapshot, error) {
+	d.importRequests = append(d.importRequests, req)
+	payload, err := io.ReadAll(src)
+	if err != nil {
+		return volumestore.Snapshot{}, err
+	}
+	d.importPayloads = append(d.importPayloads, string(payload))
+	if strings.TrimSpace(d.importSnapshot.StorageRef) != "" || strings.TrimSpace(d.importSnapshot.DriverMetadata) != "" {
+		return d.importSnapshot, nil
+	}
 	return volumestore.Snapshot{}, nil
 }
 

--- a/internal/controlservice/cache_peer_test.go
+++ b/internal/controlservice/cache_peer_test.go
@@ -23,6 +23,7 @@ type stubCachePeerTransferDriver struct {
 	exportPayload     string
 	importRequests    []volumestore.IncrementalSnapshotImportRequest
 	importPayloads    []string
+	importSnapshots   map[string]volumestore.Snapshot
 	importSnapshot    volumestore.Snapshot
 }
 
@@ -63,6 +64,11 @@ func (d *stubCachePeerTransferDriver) ImportIncrementalSnapshot(_ context.Contex
 		return volumestore.Snapshot{}, err
 	}
 	d.importPayloads = append(d.importPayloads, string(payload))
+	if d.importSnapshots != nil {
+		if snapshot, ok := d.importSnapshots[req.ExpectedSnapshotGUID]; ok {
+			return snapshot, nil
+		}
+	}
 	if strings.TrimSpace(d.importSnapshot.StorageRef) != "" || strings.TrimSpace(d.importSnapshot.DriverMetadata) != "" {
 		return d.importSnapshot, nil
 	}

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -34,6 +34,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/sync/singleflight"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -63,6 +64,7 @@ type Service struct {
 	ChangesetStore          changesetMetadataStore
 	cachePeerExportsMu      sync.Mutex
 	cachePeerExports        map[string]cachePeerExport
+	cachePeerImports        singleflight.Group
 
 	mu                sync.RWMutex
 	sandboxes         map[string]*sandboxState
@@ -471,46 +473,71 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 				})
 				if err != nil {
 					s.logServicesStageWarning("lookup services stage cache", "", err)
-				} else if found {
-					s.logServicesStageCacheHit(record)
-					emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_SERVICES_STAGE_CACHE, "services stage cache hit")
-					emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_RESTORE_SERVICES_STAGE_CACHE, "restoring services stage cache")
-					restoreReq := &cleanroomv1.CreateSandboxRequest{
-						Backend: backendName,
-						Options: req.GetOptions(),
-					}
-					var restoreResp *cleanroomv1.CreateSandboxResponse
-					restoreErr := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.restore_services_stage_cache", cachePhaseAttributes(
-						observability.CacheStageServices,
-						observability.CacheOperationRestore,
-						repository,
-						attribute.String(observability.AttrBackend, backendName),
-					), func(ctx context.Context) error {
-						var err error
-						restoreResp, err = s.createSandboxFromCacheRecord(ctx, restoreReq, compiled, record, nil, reporter)
-						setCacheResultSpanAttribute(ctx, map[bool]string{true: observability.CacheResultFailed, false: observability.CacheResultRestored}[err != nil])
-						return err
-					})
-					if restoreErr == nil {
-						metricSourceKind = "services stage cache"
-						if cacheStore, err := s.cacheStoreOrErr(); err == nil {
-							if err := cacheStore.Touch(ctx, record.Stage, record.CacheKey); err != nil {
-								s.logServicesStageWarning("touch services stage cache", "", err)
-							}
-						}
-						s.retainRestoredSandboxRepositoryState(restoreResp, repository, commitBundle, changeset)
-						s.logServicesStageRestore(record, restoreResp.GetSandbox().GetSandboxId())
-						return restoreResp, nil
-					}
-					if errors.Is(restoreErr, errSandboxCreateAborted) {
-						return nil, restoreErr
-					}
-					recordCopy := record
-					replacedServicesStageRecord = &recordCopy
-					s.logServicesStageRestoreWarning(record, restoreErr)
 				} else {
-					s.logServicesStageCacheMiss(backendName, servicesStagePlan.CacheKey)
-					emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_SERVICES_STAGE_CACHE, "services stage cache miss")
+					if !found {
+						emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_SERVICES_STAGE_CACHE, "checking services stage cache peers")
+						importErr := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.import_services_stage_cache", cachePhaseAttributes(
+							observability.CacheStageServices,
+							observability.CacheOperationLookup,
+							repository,
+							attribute.String(observability.AttrBackend, backendName),
+						), func(ctx context.Context) error {
+							var imported bool
+							var err error
+							record, imported, err = s.importServicesStageCacheFromPeers(ctx, snapshotAdapter, backendName, compiled, firecrackerCfg, repository, changeset, servicesStagePlan)
+							found = imported
+							reason := lookupReason
+							if imported {
+								reason = ""
+							}
+							setCacheLookupSpanAttributes(ctx, imported, reason, err)
+							return err
+						})
+						if importErr != nil {
+							s.logServicesStageWarning("import services stage cache from peer", "", importErr)
+						}
+					}
+					if found {
+						s.logServicesStageCacheHit(record)
+						emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_SERVICES_STAGE_CACHE, "services stage cache hit")
+						emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_RESTORE_SERVICES_STAGE_CACHE, "restoring services stage cache")
+						restoreReq := &cleanroomv1.CreateSandboxRequest{
+							Backend: backendName,
+							Options: req.GetOptions(),
+						}
+						var restoreResp *cleanroomv1.CreateSandboxResponse
+						restoreErr := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.restore_services_stage_cache", cachePhaseAttributes(
+							observability.CacheStageServices,
+							observability.CacheOperationRestore,
+							repository,
+							attribute.String(observability.AttrBackend, backendName),
+						), func(ctx context.Context) error {
+							var err error
+							restoreResp, err = s.createSandboxFromCacheRecord(ctx, restoreReq, compiled, record, nil, reporter)
+							setCacheResultSpanAttribute(ctx, map[bool]string{true: observability.CacheResultFailed, false: observability.CacheResultRestored}[err != nil])
+							return err
+						})
+						if restoreErr == nil {
+							metricSourceKind = "services stage cache"
+							if cacheStore, err := s.cacheStoreOrErr(); err == nil {
+								if err := cacheStore.Touch(ctx, record.Stage, record.CacheKey); err != nil {
+									s.logServicesStageWarning("touch services stage cache", "", err)
+								}
+							}
+							s.retainRestoredSandboxRepositoryState(restoreResp, repository, commitBundle, changeset)
+							s.logServicesStageRestore(record, restoreResp.GetSandbox().GetSandboxId())
+							return restoreResp, nil
+						}
+						if errors.Is(restoreErr, errSandboxCreateAborted) {
+							return nil, restoreErr
+						}
+						recordCopy := record
+						replacedServicesStageRecord = &recordCopy
+						s.logServicesStageRestoreWarning(record, restoreErr)
+					} else {
+						s.logServicesStageCacheMiss(backendName, servicesStagePlan.CacheKey)
+						emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_SERVICES_STAGE_CACHE, "services stage cache miss")
+					}
 				}
 			}
 
@@ -555,49 +582,74 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 				})
 				if err != nil {
 					s.logDependencyStageWarning("lookup dependency stage cache", "", err)
-				} else if found {
-					s.logDependencyStageCacheHit(record)
-					emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_DEPENDENCY_STAGE_CACHE, "dependency stage cache hit")
-					emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_RESTORE_DEPENDENCY_STAGE_CACHE, "restoring dependency stage cache")
-					restoreReq := &cleanroomv1.CreateSandboxRequest{
-						Backend: backendName,
-						Options: req.GetOptions(),
-					}
-					var restoreResp *cleanroomv1.CreateSandboxResponse
-					restoreErr := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.restore_dependency_stage_cache", cachePhaseAttributes(
-						observability.CacheStageDependency,
-						observability.CacheOperationRestore,
-						repository,
-						attribute.String(observability.AttrBackend, backendName),
-					), func(ctx context.Context) error {
-						var err error
-						restoreResp, err = s.createSandboxFromCacheRecord(ctx, restoreReq, compiled, record, serviceCacheOutputVolumes, reporter)
-						setCacheResultSpanAttribute(ctx, map[bool]string{true: observability.CacheResultFailed, false: observability.CacheResultRestored}[err != nil])
-						return err
-					})
-					if restoreErr == nil {
-						metricSourceKind = "dependency stage cache"
-						if cacheStore, err := s.cacheStoreOrErr(); err == nil {
-							if err := cacheStore.Touch(ctx, record.Stage, record.CacheKey); err != nil {
-								s.logDependencyStageWarning("touch dependency stage cache", "", err)
-							}
-						}
-						s.retainRestoredSandboxRepositoryState(restoreResp, repository, commitBundle, changeset)
-						s.logDependencyStageRestore(record, restoreResp.GetSandbox().GetSandboxId())
-						if !servicesStageBootstrapEnabled {
-							return restoreResp, nil
-						}
-						restoredDependencyResp = restoreResp
-					} else if errors.Is(restoreErr, errSandboxCreateAborted) {
-						return nil, restoreErr
-					} else {
-						recordCopy := record
-						replacedDependencyStageRecord = &recordCopy
-						s.logDependencyStageRestoreWarning(record, restoreErr)
-					}
 				} else {
-					s.logDependencyStageCacheMiss(backendName, dependencyStagePlan.CacheKey)
-					emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_DEPENDENCY_STAGE_CACHE, "dependency stage cache miss")
+					if !found {
+						emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_DEPENDENCY_STAGE_CACHE, "checking dependency stage cache peers")
+						importErr := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.import_dependency_stage_cache", cachePhaseAttributes(
+							observability.CacheStageDependency,
+							observability.CacheOperationLookup,
+							repository,
+							attribute.String(observability.AttrBackend, backendName),
+						), func(ctx context.Context) error {
+							var imported bool
+							var err error
+							record, imported, err = s.importDependencyStageCacheFromPeers(ctx, snapshotAdapter, backendName, compiled, firecrackerCfg, repository, changeset, dependencyStagePlan)
+							found = imported
+							reason := lookupReason
+							if imported {
+								reason = ""
+							}
+							setCacheLookupSpanAttributes(ctx, imported, reason, err)
+							return err
+						})
+						if importErr != nil {
+							s.logDependencyStageWarning("import dependency stage cache from peer", "", importErr)
+						}
+					}
+					if found {
+						s.logDependencyStageCacheHit(record)
+						emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_DEPENDENCY_STAGE_CACHE, "dependency stage cache hit")
+						emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_RESTORE_DEPENDENCY_STAGE_CACHE, "restoring dependency stage cache")
+						restoreReq := &cleanroomv1.CreateSandboxRequest{
+							Backend: backendName,
+							Options: req.GetOptions(),
+						}
+						var restoreResp *cleanroomv1.CreateSandboxResponse
+						restoreErr := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.restore_dependency_stage_cache", cachePhaseAttributes(
+							observability.CacheStageDependency,
+							observability.CacheOperationRestore,
+							repository,
+							attribute.String(observability.AttrBackend, backendName),
+						), func(ctx context.Context) error {
+							var err error
+							restoreResp, err = s.createSandboxFromCacheRecord(ctx, restoreReq, compiled, record, serviceCacheOutputVolumes, reporter)
+							setCacheResultSpanAttribute(ctx, map[bool]string{true: observability.CacheResultFailed, false: observability.CacheResultRestored}[err != nil])
+							return err
+						})
+						if restoreErr == nil {
+							metricSourceKind = "dependency stage cache"
+							if cacheStore, err := s.cacheStoreOrErr(); err == nil {
+								if err := cacheStore.Touch(ctx, record.Stage, record.CacheKey); err != nil {
+									s.logDependencyStageWarning("touch dependency stage cache", "", err)
+								}
+							}
+							s.retainRestoredSandboxRepositoryState(restoreResp, repository, commitBundle, changeset)
+							s.logDependencyStageRestore(record, restoreResp.GetSandbox().GetSandboxId())
+							if !servicesStageBootstrapEnabled {
+								return restoreResp, nil
+							}
+							restoredDependencyResp = restoreResp
+						} else if errors.Is(restoreErr, errSandboxCreateAborted) {
+							return nil, restoreErr
+						} else {
+							recordCopy := record
+							replacedDependencyStageRecord = &recordCopy
+							s.logDependencyStageRestoreWarning(record, restoreErr)
+						}
+					} else {
+						s.logDependencyStageCacheMiss(backendName, dependencyStagePlan.CacheKey)
+						emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_DEPENDENCY_STAGE_CACHE, "dependency stage cache miss")
+					}
 				}
 
 				if strings.TrimSpace(dependencyStagePlan.PortableCacheKey) != "" {

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -607,6 +607,89 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 						}
 					}
 					if found {
+						if servicesStageCachingEnabled {
+							emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_SERVICES_STAGE_CACHE, "checking services stage cache")
+							var servicesRecord cachestore.Record
+							var servicesFound bool
+							var servicesLookupReason string
+							servicesLookupErr := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.lookup_services_stage_cache_after_dependency", cachePhaseAttributes(
+								observability.CacheStageServices,
+								observability.CacheOperationLookup,
+								repository,
+								attribute.String(observability.AttrBackend, backendName),
+							), func(ctx context.Context) error {
+								var lookupErr error
+								servicesRecord, servicesFound, servicesLookupReason, lookupErr = s.lookupServicesStageCache(ctx, backendName, compiled, repository, changeset, servicesStagePlan)
+								setCacheLookupSpanAttributes(ctx, servicesFound, servicesLookupReason, lookupErr)
+								return lookupErr
+							})
+							if servicesLookupErr != nil {
+								s.logServicesStageWarning("lookup services stage cache after dependency stage cache", "", servicesLookupErr)
+							} else {
+								if !servicesFound {
+									emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_SERVICES_STAGE_CACHE, "checking services stage cache peers")
+									importErr := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.import_services_stage_cache_after_dependency", cachePhaseAttributes(
+										observability.CacheStageServices,
+										observability.CacheOperationLookup,
+										repository,
+										attribute.String(observability.AttrBackend, backendName),
+									), func(ctx context.Context) error {
+										var imported bool
+										var err error
+										servicesRecord, imported, err = s.importServicesStageCacheFromPeers(ctx, snapshotAdapter, backendName, compiled, firecrackerCfg, repository, changeset, servicesStagePlan)
+										servicesFound = imported
+										reason := servicesLookupReason
+										if imported {
+											reason = ""
+										}
+										setCacheLookupSpanAttributes(ctx, imported, reason, err)
+										return err
+									})
+									if importErr != nil {
+										s.logServicesStageWarning("import services stage cache from peer after dependency stage cache", "", importErr)
+									}
+								}
+								if servicesFound {
+									s.logServicesStageCacheHit(servicesRecord)
+									emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_SERVICES_STAGE_CACHE, "services stage cache hit")
+									emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_RESTORE_SERVICES_STAGE_CACHE, "restoring services stage cache")
+									restoreReq := &cleanroomv1.CreateSandboxRequest{
+										Backend: backendName,
+										Options: req.GetOptions(),
+									}
+									var restoreResp *cleanroomv1.CreateSandboxResponse
+									restoreErr := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.restore_services_stage_cache", cachePhaseAttributes(
+										observability.CacheStageServices,
+										observability.CacheOperationRestore,
+										repository,
+										attribute.String(observability.AttrBackend, backendName),
+									), func(ctx context.Context) error {
+										var err error
+										restoreResp, err = s.createSandboxFromCacheRecord(ctx, restoreReq, compiled, servicesRecord, nil, reporter)
+										setCacheResultSpanAttribute(ctx, map[bool]string{true: observability.CacheResultFailed, false: observability.CacheResultRestored}[err != nil])
+										return err
+									})
+									if restoreErr == nil {
+										metricSourceKind = "services stage cache"
+										if cacheStore, err := s.cacheStoreOrErr(); err == nil {
+											if err := cacheStore.Touch(ctx, servicesRecord.Stage, servicesRecord.CacheKey); err != nil {
+												s.logServicesStageWarning("touch services stage cache", "", err)
+											}
+										}
+										s.retainRestoredSandboxRepositoryState(restoreResp, repository, commitBundle, changeset)
+										s.logServicesStageRestore(servicesRecord, restoreResp.GetSandbox().GetSandboxId())
+										return restoreResp, nil
+									}
+									if errors.Is(restoreErr, errSandboxCreateAborted) {
+										return nil, restoreErr
+									}
+									recordCopy := servicesRecord
+									replacedServicesStageRecord = &recordCopy
+									s.logServicesStageRestoreWarning(servicesRecord, restoreErr)
+								}
+							}
+						}
+
 						s.logDependencyStageCacheHit(record)
 						emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_DEPENDENCY_STAGE_CACHE, "dependency stage cache hit")
 						emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_RESTORE_DEPENDENCY_STAGE_CACHE, "restoring dependency stage cache")


### PR DESCRIPTION
## What changed

This adds the receiver side of the ZFS cache peer path for dependency and services stage caches.

- On a local dependency/services cache miss, Cleanroom now checks configured cache peers when the local parent snapshot has ZFS lineage.
- The receiver validates the peer candidate against backend, storage driver, architecture, producer version, policy hash, parent stage/key, and parent ZFS GUID.
- The export stream is pulled over the raw ZFS incremental endpoint and streamed directly into `ImportIncrementalSnapshot`.
- Imported snapshots are validated locally before publishing receiver-local cache metadata.
- Imported records reuse the existing cache restore path, and failed validation cleans up imported storage and avoids publishing ready metadata.
- The plan doc now marks the sender and receiver dependency/services slices as landed, with observability and two-daemon validation still next.

Workspace-stage peer import remains out of scope for this slice.

## Validation

- `mise exec -- go test ./internal/controlservice -run 'Test(CreateSandboxImports.*StageCacheFromPeer|ImportDependencyStageCacheFromPeerCleansUpInvalidSnapshot)'`
- `mise exec -- go test ./internal/controlservice`
- `mise exec -- go test ./...`
- `git diff --check`
