### PR TITLE
feat: Run dependency blocks from input projections

### DIFF
--- a/cmd/cleanroom-guest-agent/input_projection.go
+++ b/cmd/cleanroom-guest-agent/input_projection.go
@@ -12,12 +12,14 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/buildkite/cleanroom/internal/vsockexec"
 	"golang.org/x/sys/unix"
 )
 
 var inputProjectionRoot = "/run/cleanroom/input-projections"
+var inputProjectionTimestamp = time.Unix(0, 0).UTC()
 
 func setupInputProjection(req vsockexec.ExecRequest) (vsockexec.ExecRequest, func(), error) {
 	projection := req.InputProjection
@@ -98,6 +100,9 @@ func materializeInputProjection(sourceRoot, targetRoot string, inputs []string) 
 		if err := copyInputProjectionFile(sourceRoot, targetRoot, rel); err != nil {
 			return err
 		}
+	}
+	if err := normalizeInputProjectionTimes(targetRoot); err != nil {
+		return err
 	}
 	return nil
 }
@@ -218,6 +223,18 @@ func copyInputProjectionFile(sourceRoot, targetRoot, rel string) error {
 	return nil
 }
 
+func normalizeInputProjectionTimes(targetRoot string) error {
+	return filepath.WalkDir(targetRoot, func(path string, _ os.DirEntry, err error) error {
+		if err != nil {
+			return fmt.Errorf("walk input projection path %s: %w", path, err)
+		}
+		if err := os.Chtimes(path, inputProjectionTimestamp, inputProjectionTimestamp); err != nil {
+			return fmt.Errorf("set deterministic input projection timestamp %s: %w", path, err)
+		}
+		return nil
+	})
+}
+
 func bindInputProjectionOverSource(sourceRoot, targetRoot string) (func(), error) {
 	runtime.LockOSThread()
 	oldNS, err := os.Open("/proc/self/ns/mnt")
@@ -251,5 +268,20 @@ func bindInputProjectionOverSource(sourceRoot, targetRoot string) (func(), error
 		cleanup()
 		return nil, fmt.Errorf("remount input projection %s read-only: %w", sourceRoot, err)
 	}
+	if err := hideInputProjectionBackingRoot(); err != nil {
+		cleanup()
+		return nil, err
+	}
 	return cleanup, nil
+}
+
+func hideInputProjectionBackingRoot() error {
+	root, err := cleanInputProjectionRoot("root", inputProjectionRoot)
+	if err != nil {
+		return err
+	}
+	if err := unix.Mount("tmpfs", root, "tmpfs", unix.MS_NOSUID|unix.MS_NODEV|unix.MS_NOEXEC|unix.MS_RDONLY, "size=4k,mode=0555"); err != nil {
+		return fmt.Errorf("hide input projection backing root %s: %w", root, err)
+	}
+	return nil
 }

--- a/cmd/cleanroom-guest-agent/input_projection.go
+++ b/cmd/cleanroom-guest-agent/input_projection.go
@@ -182,30 +182,18 @@ func cleanInputProjectionRelativePath(value string) (string, error) {
 }
 
 func copyInputProjectionFile(sourceRoot, targetRoot, rel string) error {
-	sourcePath := filepath.Join(sourceRoot, filepath.FromSlash(rel))
 	targetPath := filepath.Join(targetRoot, filepath.FromSlash(rel))
-
-	info, err := os.Lstat(sourcePath)
-	if err != nil {
-		return fmt.Errorf("stat input projection file %s: %w", sourcePath, err)
-	}
-	if info.Mode()&os.ModeSymlink != 0 {
-		return fmt.Errorf("input projection file %s is a symlink", sourcePath)
-	}
-	if !info.Mode().IsRegular() {
-		return fmt.Errorf("input projection file %s is not a regular file", sourcePath)
-	}
 
 	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
 		return fmt.Errorf("create input projection directory %s: %w", filepath.Dir(targetPath), err)
 	}
-	source, err := os.Open(sourcePath)
+	source, mode, err := openInputProjectionFile(sourceRoot, rel)
 	if err != nil {
-		return fmt.Errorf("open input projection file %s: %w", sourcePath, err)
+		return err
 	}
 	defer source.Close()
 
-	target, err := os.OpenFile(targetPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, info.Mode().Perm())
+	target, err := os.OpenFile(targetPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode.Perm())
 	if err != nil {
 		return fmt.Errorf("create input projection file %s: %w", targetPath, err)
 	}
@@ -213,7 +201,7 @@ func copyInputProjectionFile(sourceRoot, targetRoot, rel string) error {
 		_ = target.Close()
 		return fmt.Errorf("copy input projection file %s: %w", rel, err)
 	}
-	if err := target.Chmod(info.Mode().Perm()); err != nil {
+	if err := target.Chmod(mode.Perm()); err != nil {
 		_ = target.Close()
 		return fmt.Errorf("chmod input projection file %s: %w", targetPath, err)
 	}
@@ -221,6 +209,60 @@ func copyInputProjectionFile(sourceRoot, targetRoot, rel string) error {
 		return fmt.Errorf("close input projection file %s: %w", targetPath, err)
 	}
 	return nil
+}
+
+func openInputProjectionFile(sourceRoot, rel string) (*os.File, os.FileMode, error) {
+	dirFD, err := unix.Open(sourceRoot, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		if errors.Is(err, unix.ELOOP) {
+			return nil, 0, fmt.Errorf("input projection source root %s is a symlink", sourceRoot)
+		}
+		return nil, 0, fmt.Errorf("open input projection source root %s: %w", sourceRoot, err)
+	}
+	defer func() {
+		if dirFD >= 0 {
+			_ = unix.Close(dirFD)
+		}
+	}()
+
+	components := strings.Split(rel, "/")
+	currentPath := sourceRoot
+	for i, component := range components {
+		currentPath = filepath.Join(currentPath, component)
+		if i < len(components)-1 {
+			nextFD, err := unix.Openat(dirFD, component, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+			if err != nil {
+				if errors.Is(err, unix.ELOOP) {
+					return nil, 0, fmt.Errorf("input projection path %s contains a symlink component", currentPath)
+				}
+				return nil, 0, fmt.Errorf("open input projection directory %s: %w", currentPath, err)
+			}
+			_ = unix.Close(dirFD)
+			dirFD = nextFD
+			continue
+		}
+
+		fileFD, err := unix.Openat(dirFD, component, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+		if err != nil {
+			if errors.Is(err, unix.ELOOP) {
+				return nil, 0, fmt.Errorf("input projection file %s is a symlink", currentPath)
+			}
+			return nil, 0, fmt.Errorf("open input projection file %s: %w", currentPath, err)
+		}
+
+		var stat unix.Stat_t
+		if err := unix.Fstat(fileFD, &stat); err != nil {
+			_ = unix.Close(fileFD)
+			return nil, 0, fmt.Errorf("stat input projection file %s: %w", currentPath, err)
+		}
+		if stat.Mode&unix.S_IFMT != unix.S_IFREG {
+			_ = unix.Close(fileFD)
+			return nil, 0, fmt.Errorf("input projection file %s is not a regular file", currentPath)
+		}
+		return os.NewFile(uintptr(fileFD), currentPath), os.FileMode(stat.Mode & 0o777), nil
+	}
+
+	return nil, 0, fmt.Errorf("input projection path %q cannot be empty", rel)
 }
 
 func normalizeInputProjectionTimes(targetRoot string) error {

--- a/cmd/cleanroom-guest-agent/input_projection.go
+++ b/cmd/cleanroom-guest-agent/input_projection.go
@@ -214,7 +214,7 @@ func copyInputProjectionFile(sourceRoot, targetRoot, rel string) error {
 func openInputProjectionFile(sourceRoot, rel string) (*os.File, os.FileMode, error) {
 	dirFD, err := unix.Open(sourceRoot, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
 	if err != nil {
-		if errors.Is(err, unix.ELOOP) {
+		if inputProjectionPathIsSymlink(sourceRoot) {
 			return nil, 0, fmt.Errorf("input projection source root %s is a symlink", sourceRoot)
 		}
 		return nil, 0, fmt.Errorf("open input projection source root %s: %w", sourceRoot, err)
@@ -232,7 +232,7 @@ func openInputProjectionFile(sourceRoot, rel string) (*os.File, os.FileMode, err
 		if i < len(components)-1 {
 			nextFD, err := unix.Openat(dirFD, component, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
 			if err != nil {
-				if errors.Is(err, unix.ELOOP) {
+				if inputProjectionComponentIsSymlink(dirFD, component) {
 					return nil, 0, fmt.Errorf("input projection path %s contains a symlink component", currentPath)
 				}
 				return nil, 0, fmt.Errorf("open input projection directory %s: %w", currentPath, err)
@@ -244,7 +244,7 @@ func openInputProjectionFile(sourceRoot, rel string) (*os.File, os.FileMode, err
 
 		fileFD, err := unix.Openat(dirFD, component, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
 		if err != nil {
-			if errors.Is(err, unix.ELOOP) {
+			if inputProjectionComponentIsSymlink(dirFD, component) {
 				return nil, 0, fmt.Errorf("input projection file %s is a symlink", currentPath)
 			}
 			return nil, 0, fmt.Errorf("open input projection file %s: %w", currentPath, err)
@@ -263,6 +263,22 @@ func openInputProjectionFile(sourceRoot, rel string) (*os.File, os.FileMode, err
 	}
 
 	return nil, 0, fmt.Errorf("input projection path %q cannot be empty", rel)
+}
+
+func inputProjectionPathIsSymlink(path string) bool {
+	var stat unix.Stat_t
+	if err := unix.Lstat(path, &stat); err != nil {
+		return false
+	}
+	return stat.Mode&unix.S_IFMT == unix.S_IFLNK
+}
+
+func inputProjectionComponentIsSymlink(dirFD int, name string) bool {
+	var stat unix.Stat_t
+	if err := unix.Fstatat(dirFD, name, &stat, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return false
+	}
+	return stat.Mode&unix.S_IFMT == unix.S_IFLNK
 }
 
 func normalizeInputProjectionTimes(targetRoot string) error {

--- a/cmd/cleanroom-guest-agent/input_projection.go
+++ b/cmd/cleanroom-guest-agent/input_projection.go
@@ -1,0 +1,255 @@
+//go:build linux
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+
+	"github.com/buildkite/cleanroom/internal/vsockexec"
+	"golang.org/x/sys/unix"
+)
+
+var inputProjectionRoot = "/run/cleanroom/input-projections"
+
+func setupInputProjection(req vsockexec.ExecRequest) (vsockexec.ExecRequest, func(), error) {
+	projection := req.InputProjection
+	if projection == nil {
+		return req, func() {}, nil
+	}
+
+	sourceRoot, err := cleanInputProjectionRoot("source root", projection.SourceRoot)
+	if err != nil {
+		return req, nil, err
+	}
+	targetRoot, err := cleanInputProjectionTargetRoot(projection.TargetRoot)
+	if err != nil {
+		return req, nil, err
+	}
+	if len(projection.Files) == 0 {
+		return req, nil, errors.New("input projection has no files")
+	}
+
+	if err := materializeInputProjection(sourceRoot, targetRoot, projection.Files); err != nil {
+		return req, nil, err
+	}
+
+	cleanup := func() {}
+	if projection.MountSourceReadOnly {
+		cleanup, err = bindInputProjectionOverSource(sourceRoot, targetRoot)
+		if err != nil {
+			return req, nil, err
+		}
+		if strings.TrimSpace(req.Dir) == "" {
+			req.Dir = sourceRoot
+		}
+	} else if strings.TrimSpace(req.Dir) == "" {
+		req.Dir = targetRoot
+	}
+	return req, cleanup, nil
+}
+
+func cleanInputProjectionRoot(name, value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", fmt.Errorf("missing input projection %s", name)
+	}
+	cleaned := filepath.Clean(value)
+	if !filepath.IsAbs(cleaned) {
+		return "", fmt.Errorf("input projection %s %q is not absolute", name, value)
+	}
+	if cleaned == "/" {
+		return "", fmt.Errorf("input projection %s must not be /", name)
+	}
+	return cleaned, nil
+}
+
+func cleanInputProjectionTargetRoot(value string) (string, error) {
+	root, err := cleanInputProjectionRoot("target root", value)
+	if err != nil {
+		return "", err
+	}
+	if root == inputProjectionRoot || !strings.HasPrefix(root, inputProjectionRoot+"/") {
+		return "", fmt.Errorf("input projection target root %q must be under %s", value, inputProjectionRoot)
+	}
+	return root, nil
+}
+
+func materializeInputProjection(sourceRoot, targetRoot string, inputs []string) error {
+	if err := os.RemoveAll(targetRoot); err != nil {
+		return fmt.Errorf("clear input projection target %s: %w", targetRoot, err)
+	}
+	if err := os.MkdirAll(targetRoot, 0o755); err != nil {
+		return fmt.Errorf("create input projection target %s: %w", targetRoot, err)
+	}
+
+	files, err := expandInputProjectionFiles(sourceRoot, inputs)
+	if err != nil {
+		return err
+	}
+	for _, rel := range files {
+		if err := copyInputProjectionFile(sourceRoot, targetRoot, rel); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func expandInputProjectionFiles(sourceRoot string, inputs []string) ([]string, error) {
+	seen := make(map[string]struct{}, len(inputs))
+	var out []string
+	for _, input := range inputs {
+		normalized, err := cleanInputProjectionRelativePath(input)
+		if err != nil {
+			return nil, err
+		}
+		matches, err := inputProjectionMatches(sourceRoot, normalized)
+		if err != nil {
+			return nil, err
+		}
+		for _, match := range matches {
+			if _, ok := seen[match]; ok {
+				continue
+			}
+			seen[match] = struct{}{}
+			out = append(out, match)
+		}
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+func inputProjectionMatches(sourceRoot, input string) ([]string, error) {
+	if !strings.ContainsAny(input, "*?[") {
+		if _, err := os.Lstat(filepath.Join(sourceRoot, filepath.FromSlash(input))); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return nil, fmt.Errorf("input projection file %q does not exist", input)
+			}
+			return nil, fmt.Errorf("stat input projection file %q: %w", input, err)
+		}
+		return []string{input}, nil
+	}
+
+	pattern := filepath.Join(sourceRoot, filepath.FromSlash(input))
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("invalid input projection glob %q: %w", input, err)
+	}
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("input projection glob %q matched no files", input)
+	}
+	out := make([]string, 0, len(matches))
+	for _, match := range matches {
+		rel, err := filepath.Rel(sourceRoot, match)
+		if err != nil {
+			return nil, fmt.Errorf("resolve input projection match %q: %w", match, err)
+		}
+		normalized, err := cleanInputProjectionRelativePath(filepath.ToSlash(rel))
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, normalized)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+func cleanInputProjectionRelativePath(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", errors.New("input projection path cannot be empty")
+	}
+	if strings.HasPrefix(value, "/") {
+		return "", fmt.Errorf("input projection path %q must be relative", value)
+	}
+	normalized := path.Clean(strings.ReplaceAll(value, "\\", "/"))
+	if normalized == "." || normalized == ".." || strings.HasPrefix(normalized, "../") {
+		return "", fmt.Errorf("input projection path %q must stay within the source root", value)
+	}
+	return normalized, nil
+}
+
+func copyInputProjectionFile(sourceRoot, targetRoot, rel string) error {
+	sourcePath := filepath.Join(sourceRoot, filepath.FromSlash(rel))
+	targetPath := filepath.Join(targetRoot, filepath.FromSlash(rel))
+
+	info, err := os.Lstat(sourcePath)
+	if err != nil {
+		return fmt.Errorf("stat input projection file %s: %w", sourcePath, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("input projection file %s is a symlink", sourcePath)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("input projection file %s is not a regular file", sourcePath)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		return fmt.Errorf("create input projection directory %s: %w", filepath.Dir(targetPath), err)
+	}
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		return fmt.Errorf("open input projection file %s: %w", sourcePath, err)
+	}
+	defer source.Close()
+
+	target, err := os.OpenFile(targetPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, info.Mode().Perm())
+	if err != nil {
+		return fmt.Errorf("create input projection file %s: %w", targetPath, err)
+	}
+	if _, err := io.Copy(target, source); err != nil {
+		_ = target.Close()
+		return fmt.Errorf("copy input projection file %s: %w", rel, err)
+	}
+	if err := target.Chmod(info.Mode().Perm()); err != nil {
+		_ = target.Close()
+		return fmt.Errorf("chmod input projection file %s: %w", targetPath, err)
+	}
+	if err := target.Close(); err != nil {
+		return fmt.Errorf("close input projection file %s: %w", targetPath, err)
+	}
+	return nil
+}
+
+func bindInputProjectionOverSource(sourceRoot, targetRoot string) (func(), error) {
+	runtime.LockOSThread()
+	oldNS, err := os.Open("/proc/self/ns/mnt")
+	if err != nil {
+		runtime.UnlockOSThread()
+		return nil, fmt.Errorf("open current mount namespace: %w", err)
+	}
+	cleanup := func() {
+		if err := unix.Setns(int(oldNS.Fd()), unix.CLONE_NEWNS); err != nil {
+			fmt.Fprintf(os.Stderr, "restore input projection mount namespace: %v\n", err)
+			_ = oldNS.Close()
+			return
+		}
+		_ = oldNS.Close()
+		runtime.UnlockOSThread()
+	}
+
+	if err := unix.Unshare(unix.CLONE_NEWNS); err != nil {
+		cleanup()
+		return nil, fmt.Errorf("create input projection mount namespace: %w", err)
+	}
+	if err := unix.Mount("", "/", "", unix.MS_REC|unix.MS_PRIVATE, ""); err != nil {
+		cleanup()
+		return nil, fmt.Errorf("make input projection mount namespace private: %w", err)
+	}
+	if err := unix.Mount(targetRoot, sourceRoot, "", unix.MS_BIND|unix.MS_REC, ""); err != nil {
+		cleanup()
+		return nil, fmt.Errorf("bind input projection %s over %s: %w", targetRoot, sourceRoot, err)
+	}
+	if err := unix.Mount("", sourceRoot, "", unix.MS_BIND|unix.MS_REMOUNT|unix.MS_RDONLY|unix.MS_REC, ""); err != nil {
+		cleanup()
+		return nil, fmt.Errorf("remount input projection %s read-only: %w", sourceRoot, err)
+	}
+	return cleanup, nil
+}

--- a/cmd/cleanroom-guest-agent/input_projection_test.go
+++ b/cmd/cleanroom-guest-agent/input_projection_test.go
@@ -51,6 +51,8 @@ func TestSetupInputProjectionCopiesDeclaredFilesAndSetsDir(t *testing.T) {
 		t.Fatalf("stat projected main.go: %v", err)
 	} else if got, want := info.Mode().Perm(), os.FileMode(0o600); got != want {
 		t.Fatalf("unexpected projected mode: got %v want %v", got, want)
+	} else if !info.ModTime().Equal(inputProjectionTimestamp) {
+		t.Fatalf("unexpected projected mtime: got %s want %s", info.ModTime(), inputProjectionTimestamp)
 	}
 }
 

--- a/cmd/cleanroom-guest-agent/input_projection_test.go
+++ b/cmd/cleanroom-guest-agent/input_projection_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"slices"
@@ -99,6 +100,41 @@ func TestInputProjectionRejectsSymlink(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "symlink") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestInputProjectionRejectsSymlinkedParent(t *testing.T) {
+	restoreRoot := setTestInputProjectionRoot(t)
+	sourceRoot := t.TempDir()
+	escapeRoot := t.TempDir()
+	defer restoreRoot()
+	targetRoot := filepath.Join(inputProjectionRoot, "dependency", "toolchains")
+	if err := os.WriteFile(filepath.Join(escapeRoot, "passwd"), []byte("not from workspace\n"), 0o644); err != nil {
+		t.Fatalf("write escaped file: %v", err)
+	}
+	if err := os.Symlink(escapeRoot, filepath.Join(sourceRoot, "deps")); err != nil {
+		t.Fatalf("create symlinked parent: %v", err)
+	}
+
+	_, cleanup, err := setupInputProjection(vsockexec.ExecRequest{
+		Command: []string{"true"},
+		InputProjection: &vsockexec.InputProjection{
+			SourceRoot: sourceRoot,
+			TargetRoot: targetRoot,
+			Files:      []string{"deps/passwd"},
+		},
+	})
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if err == nil {
+		t.Fatal("expected symlinked parent input to fail")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(targetRoot, "deps", "passwd")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("projected escaped file unexpectedly exists: %v", err)
 	}
 }
 

--- a/cmd/cleanroom-guest-agent/input_projection_test.go
+++ b/cmd/cleanroom-guest-agent/input_projection_test.go
@@ -1,0 +1,110 @@
+//go:build linux
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/vsockexec"
+)
+
+func TestSetupInputProjectionCopiesDeclaredFilesAndSetsDir(t *testing.T) {
+	restoreRoot := setTestInputProjectionRoot(t)
+	sourceRoot := t.TempDir()
+	defer restoreRoot()
+	targetRoot := filepath.Join(inputProjectionRoot, "dependency", "go-modules")
+	if err := os.MkdirAll(filepath.Join(sourceRoot, "cmd"), 0o755); err != nil {
+		t.Fatalf("create source dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceRoot, "go.mod"), []byte("module example.test/app\n"), 0o644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceRoot, "cmd", "main.go"), []byte("package main\n"), 0o600); err != nil {
+		t.Fatalf("write main.go: %v", err)
+	}
+
+	req, cleanup, err := setupInputProjection(vsockexec.ExecRequest{
+		Command: []string{"true"},
+		InputProjection: &vsockexec.InputProjection{
+			SourceRoot: sourceRoot,
+			TargetRoot: targetRoot,
+			Files:      []string{"go.mod", "cmd/*.go"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("setupInputProjection returned error: %v", err)
+	}
+	defer cleanup()
+	if got, want := req.Dir, targetRoot; got != want {
+		t.Fatalf("unexpected command dir: got %q want %q", got, want)
+	}
+	if data, err := os.ReadFile(filepath.Join(targetRoot, "go.mod")); err != nil {
+		t.Fatalf("read projected go.mod: %v", err)
+	} else if got, want := string(data), "module example.test/app\n"; got != want {
+		t.Fatalf("unexpected projected go.mod: got %q want %q", got, want)
+	}
+	if info, err := os.Stat(filepath.Join(targetRoot, "cmd", "main.go")); err != nil {
+		t.Fatalf("stat projected main.go: %v", err)
+	} else if got, want := info.Mode().Perm(), os.FileMode(0o600); got != want {
+		t.Fatalf("unexpected projected mode: got %v want %v", got, want)
+	}
+}
+
+func TestExpandInputProjectionFilesSortsAndDedupes(t *testing.T) {
+	t.Parallel()
+
+	sourceRoot := t.TempDir()
+	for _, name := range []string{"b.sum", "a.sum"} {
+		if err := os.WriteFile(filepath.Join(sourceRoot, name), []byte(name), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	files, err := expandInputProjectionFiles(sourceRoot, []string{"*.sum", "a.sum"})
+	if err != nil {
+		t.Fatalf("expandInputProjectionFiles returned error: %v", err)
+	}
+	if want := []string{"a.sum", "b.sum"}; !slices.Equal(files, want) {
+		t.Fatalf("unexpected files: got %v want %v", files, want)
+	}
+}
+
+func TestInputProjectionRejectsSymlink(t *testing.T) {
+	restoreRoot := setTestInputProjectionRoot(t)
+	sourceRoot := t.TempDir()
+	defer restoreRoot()
+	targetRoot := filepath.Join(inputProjectionRoot, "dependency", "toolchains")
+	if err := os.Symlink("/etc/passwd", filepath.Join(sourceRoot, "link.lock")); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+
+	_, cleanup, err := setupInputProjection(vsockexec.ExecRequest{
+		Command: []string{"true"},
+		InputProjection: &vsockexec.InputProjection{
+			SourceRoot: sourceRoot,
+			TargetRoot: targetRoot,
+			Files:      []string{"link.lock"},
+		},
+	})
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if err == nil {
+		t.Fatal("expected symlink input to fail")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func setTestInputProjectionRoot(t *testing.T) func() {
+	t.Helper()
+	previous := inputProjectionRoot
+	inputProjectionRoot = filepath.Join(t.TempDir(), "input-projections")
+	return func() {
+		inputProjectionRoot = previous
+	}
+}

--- a/cmd/cleanroom-guest-agent/main.go
+++ b/cmd/cleanroom-guest-agent/main.go
@@ -102,7 +102,7 @@ func handleConnTTY(conn io.ReadWriteCloser, dec *json.Decoder, req vsockexec.Exe
 	if req.Dir != "" {
 		cmd.Dir = req.Dir
 	}
-	env, err := buildCommandEnv(req.Env)
+	env, err := buildCommandEnv(req.Env, !req.ClosedEnv)
 	if err != nil {
 		sendErrorResponse(conn, err)
 		return
@@ -136,7 +136,7 @@ func handleConnPipes(conn io.ReadWriteCloser, dec *json.Decoder, req vsockexec.E
 	if req.Dir != "" {
 		cmd.Dir = req.Dir
 	}
-	env, err := buildCommandEnv(req.Env)
+	env, err := buildCommandEnv(req.Env, !req.ClosedEnv)
 	if err != nil {
 		sendErrorResponse(conn, err)
 		return
@@ -310,19 +310,21 @@ func (w streamFrameWriter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-func buildCommandEnv(requestEnv []string) ([]string, error) {
-	// Start from the current process environment so caller-provided values can
-	// override, while ensuring we have baseline HOME/PATH defaults for lookups.
+func buildCommandEnv(requestEnv []string, inheritAmbient bool) ([]string, error) {
 	base := map[string]string{}
 	requestKeys := make(map[string]struct{}, len(requestEnv))
-	for _, entry := range os.Environ() {
-		parts := strings.SplitN(entry, "=", 2)
-		key := parts[0]
-		value := ""
-		if len(parts) == 2 {
-			value = parts[1]
+	if inheritAmbient {
+		// Start from the current process environment so caller-provided values can
+		// override, while ensuring we have baseline HOME/PATH defaults for lookups.
+		for _, entry := range os.Environ() {
+			parts := strings.SplitN(entry, "=", 2)
+			key := parts[0]
+			value := ""
+			if len(parts) == 2 {
+				value = parts[1]
+			}
+			base[key] = value
 		}
-		base[key] = value
 	}
 
 	for _, entry := range requestEnv {

--- a/cmd/cleanroom-guest-agent/main.go
+++ b/cmd/cleanroom-guest-agent/main.go
@@ -82,6 +82,13 @@ func handleConn(conn io.ReadWriteCloser) {
 		sendErrorResponse(conn, err)
 		return
 	}
+	projectedReq, cleanupInputProjection, err := setupInputProjection(req)
+	if err != nil {
+		sendErrorResponse(conn, err)
+		return
+	}
+	defer cleanupInputProjection()
+	req = projectedReq
 
 	if req.TTY {
 		handleConnTTY(conn, dec, req)

--- a/cmd/cleanroom-guest-agent/main_test.go
+++ b/cmd/cleanroom-guest-agent/main_test.go
@@ -19,7 +19,7 @@ func TestBuildCommandEnvAppliesGatewayDefaultsWhenUnset(t *testing.T) {
 	env, err := buildCommandEnv([]string{
 		gateway.GoProxyDefaultEnvKey + "=http://gateway.cleanroom.internal:8170/goproxy,direct",
 		gateway.MiseGoDownloadMirrorDefaultEnvKey + "=http://gateway.cleanroom.internal:8170/fetch/dl.google.com/go",
-	})
+	}, true)
 	if err != nil {
 		t.Fatalf("buildCommandEnv returned error: %v", err)
 	}
@@ -48,7 +48,7 @@ func TestBuildCommandEnvPreservesExplicitUserGoEnv(t *testing.T) {
 		"MISE_GO_DOWNLOAD_MIRROR=https://example.test/go",
 		gateway.GoProxyDefaultEnvKey + "=http://gateway.cleanroom.internal:8170/goproxy,direct",
 		gateway.MiseGoDownloadMirrorDefaultEnvKey + "=http://gateway.cleanroom.internal:8170/fetch/dl.google.com/go",
-	})
+	}, true)
 	if err != nil {
 		t.Fatalf("buildCommandEnv returned error: %v", err)
 	}
@@ -65,6 +65,29 @@ func TestBuildCommandEnvPreservesExplicitUserGoEnv(t *testing.T) {
 	}
 	if _, ok := got[gateway.MiseGoDownloadMirrorDefaultEnvKey]; ok {
 		t.Fatalf("did not expect %s to remain in child env", gateway.MiseGoDownloadMirrorDefaultEnvKey)
+	}
+}
+
+func TestBuildCommandEnvCanDisableAmbientInheritance(t *testing.T) {
+	t.Setenv("UNKEYED_AMBIENT", "leak")
+
+	env, err := buildCommandEnv([]string{"DECLARED=value"}, false)
+	if err != nil {
+		t.Fatalf("buildCommandEnv returned error: %v", err)
+	}
+
+	got := envMap(env)
+	if got["UNKEYED_AMBIENT"] != "" {
+		t.Fatalf("did not expect ambient env to be inherited, got %q", got["UNKEYED_AMBIENT"])
+	}
+	if got["DECLARED"] != "value" {
+		t.Fatalf("expected declared env to be present, got %q", got["DECLARED"])
+	}
+	if got["HOME"] != "/root" {
+		t.Fatalf("expected default HOME, got %q", got["HOME"])
+	}
+	if got["PATH"] == "" {
+		t.Fatal("expected default PATH")
 	}
 }
 

--- a/docs/plans/dependency-service-volume-caches.md
+++ b/docs/plans/dependency-service-volume-caches.md
@@ -921,6 +921,12 @@ Completed in phase 6:
 - when requested, the guest agent creates a per-command mount namespace and
   bind-mounts the projection read-only over the source workspace root before
   running the command
+- dependency block-volume misses run with a closed command environment instead
+  of inheriting ambient guest-agent or image environment variables
+- the guest agent hides the projection backing root inside the per-command mount
+  namespace after binding the projection over the source workspace
+- projected input files and directories receive deterministic timestamps so
+  command-visible mtimes do not vary under the same cache key
 - dependency block-volume misses now run as individual block commands from the
   projected workspace when the block-volume runtime path is available
 - dependency block-volume hits are skipped because their output volumes are

--- a/docs/plans/dependency-service-volume-caches.md
+++ b/docs/plans/dependency-service-volume-caches.md
@@ -891,13 +891,57 @@ Completed in phase 5:
 
 Remaining runtime work after phase 5:
 
-- run missed dependency and service blocks from isolated input projections
+- run missed service blocks from isolated input projections
 - inspect overlay write capture results and warn/fallback on escaped writes
 - snapshot and publish output records after successful missed blocks
 - materialize captured file outputs into both the output volume and sandbox root
   after a missed block run
 - advertise `sandbox.overlay_write_capture` once escaped-write detection and
   isolated block execution are wired through
+- decide whether output volume sizing stays internal or becomes policy-visible
+  after real workloads show the right default
+
+### Phase 6 PR Status
+
+The sixth implementation PR adds the dependency-block execution substrate needed
+for the v0.7 experimental path. It is still not the full publishable
+file-keyed cache path because escaped-write inspection and block output
+publication remain disabled.
+
+Completed in phase 6:
+
+- backend execution requests can carry an isolated input projection with a
+  source root, managed target root, declared files, and a read-only bind option
+- Firecracker and darwin-vz forward execution working directories and input
+  projection metadata through the guest exec protocol
+- the Linux guest agent materializes declared regular files and glob matches
+  into a managed projection under `/run/cleanroom/input-projections`
+- input projection materialization rejects absolute paths, `..` escapes,
+  missing inputs, directories, symlinks, and other non-regular files
+- when requested, the guest agent creates a per-command mount namespace and
+  bind-mounts the projection read-only over the source workspace root before
+  running the command
+- dependency block-volume misses now run as individual block commands from the
+  projected workspace when the block-volume runtime path is available
+- dependency block-volume hits are skipped because their output volumes are
+  already restored at VM launch
+- exact full-rootfs dependency-stage publication is skipped when the
+  block-volume runtime path is selected, because declared directory outputs are
+  mounted from sidecar volumes and would not be captured by a rootfs snapshot
+
+Remaining runtime work after phase 6:
+
+- publish a replacement cache artifact for dependency block misses; until then
+  this path is execution substrate rather than reusable block-volume caching
+- inspect overlay write capture results and warn/fallback on escaped writes
+- snapshot and publish dependency output records after successful missed blocks
+- materialize captured dependency file outputs into both the output volume and
+  sandbox root after a missed block run
+- run missed service blocks from isolated input projections
+- snapshot and publish service output records after successful missed service
+  blocks
+- advertise `sandbox.overlay_write_capture` once escaped-write detection and
+  block output publication are wired through
 - decide whether output volume sizing stays internal or becomes policy-visible
   after real workloads show the right default
 

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -310,14 +310,23 @@ type OutputStream struct {
 }
 
 type ExecutionRequest struct {
-	SandboxID    string
-	ExecutionID  string
-	Command      []string
-	Env          []string
-	TTY          bool
-	Policy       *policy.CompiledPolicy
-	NetworkStage policy.NetworkStage
+	SandboxID       string
+	ExecutionID     string
+	Command         []string
+	Dir             string
+	Env             []string
+	TTY             bool
+	InputProjection *InputProjection
+	Policy          *policy.CompiledPolicy
+	NetworkStage    policy.NetworkStage
 	FirecrackerConfig
+}
+
+type InputProjection struct {
+	SourceRoot          string
+	TargetRoot          string
+	Files               []string
+	MountSourceReadOnly bool
 }
 
 type FirecrackerConfig struct {

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -315,6 +315,7 @@ type ExecutionRequest struct {
 	Command         []string
 	Dir             string
 	Env             []string
+	ClosedEnv       bool
 	TTY             bool
 	InputProjection *InputProjection
 	Policy          *policy.CompiledPolicy

--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -1176,9 +1176,11 @@ func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream 
 	}
 
 	guestReq := vsockexec.ExecRequest{
-		Command: append([]string(nil), req.Command...),
-		Env:     append([]string(nil), req.Env...),
-		TTY:     req.TTY,
+		Command:         append([]string(nil), req.Command...),
+		Dir:             strings.TrimSpace(req.Dir),
+		Env:             append([]string(nil), req.Env...),
+		TTY:             req.TTY,
+		InputProjection: darwinVZInputProjection(req.InputProjection),
 	}
 	if a.GatewayRegistry != nil && gatewayScopeToken != "" {
 		gwPort := a.GatewayPort
@@ -1614,9 +1616,11 @@ func (a *Adapter) executeInSandbox(bootCtx context.Context, runCtx context.Conte
 	}
 
 	guestReq := vsockexec.ExecRequest{
-		Command: append([]string(nil), req.Command...),
-		Env:     append([]string(nil), req.Env...),
-		TTY:     req.TTY,
+		Command:         append([]string(nil), req.Command...),
+		Dir:             strings.TrimSpace(req.Dir),
+		Env:             append([]string(nil), req.Env...),
+		TTY:             req.TTY,
+		InputProjection: darwinVZInputProjection(req.InputProjection),
 	}
 	if a.GatewayRegistry != nil && gatewayScopeToken != "" {
 		gwPort := a.GatewayPort
@@ -2539,6 +2543,18 @@ func logExecutionNotice(backendName, runID, notice string) {
 		fields = append(fields, "execution_id", id)
 	}
 	log.Info(msg, fields...)
+}
+
+func darwinVZInputProjection(projection *backend.InputProjection) *vsockexec.InputProjection {
+	if projection == nil {
+		return nil
+	}
+	return &vsockexec.InputProjection{
+		SourceRoot:          strings.TrimSpace(projection.SourceRoot),
+		TargetRoot:          strings.TrimSpace(projection.TargetRoot),
+		Files:               append([]string(nil), projection.Files...),
+		MountSourceReadOnly: projection.MountSourceReadOnly,
+	}
 }
 
 func randomScopeToken() (string, error) {

--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -1179,10 +1179,11 @@ func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream 
 		Command:         append([]string(nil), req.Command...),
 		Dir:             strings.TrimSpace(req.Dir),
 		Env:             append([]string(nil), req.Env...),
+		ClosedEnv:       req.ClosedEnv,
 		TTY:             req.TTY,
 		InputProjection: darwinVZInputProjection(req.InputProjection),
 	}
-	if a.GatewayRegistry != nil && gatewayScopeToken != "" {
+	if !req.ClosedEnv && a.GatewayRegistry != nil && gatewayScopeToken != "" {
 		gwPort := a.GatewayPort
 		if gwPort <= 0 {
 			gwPort = gateway.DefaultPort
@@ -1619,10 +1620,11 @@ func (a *Adapter) executeInSandbox(bootCtx context.Context, runCtx context.Conte
 		Command:         append([]string(nil), req.Command...),
 		Dir:             strings.TrimSpace(req.Dir),
 		Env:             append([]string(nil), req.Env...),
+		ClosedEnv:       req.ClosedEnv,
 		TTY:             req.TTY,
 		InputProjection: darwinVZInputProjection(req.InputProjection),
 	}
-	if a.GatewayRegistry != nil && gatewayScopeToken != "" {
+	if !req.ClosedEnv && a.GatewayRegistry != nil && gatewayScopeToken != "" {
 		gwPort := a.GatewayPort
 		if gwPort <= 0 {
 			gwPort = gateway.DefaultPort

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -503,7 +503,7 @@ func (a *Adapter) RunInSandbox(ctx context.Context, req backend.ExecutionRequest
 		defer a.GatewayRegistry.ClearActiveExecutionTrace(sandboxID, req.ExecutionID)
 	}
 
-	guestResult, timing, err := a.executeInSandbox(ctx, instance, req.LaunchSeconds, req.Command, req.Env, req.TTY, stream)
+	guestResult, timing, err := a.executeInSandbox(ctx, instance, req.LaunchSeconds, req.Command, req.Dir, req.Env, req.InputProjection, req.TTY, stream)
 	if err != nil {
 		observation.ExitCode = 1
 		observation.GuestError = err.Error()
@@ -594,7 +594,7 @@ func (a *Adapter) runFileTransferCommand(ctx context.Context, sandboxID string, 
 	if err != nil {
 		return nil, err
 	}
-	result, _, err := a.executeInSandbox(ctx, instance, 0, cmd, nil, false, stream)
+	result, _, err := a.executeInSandbox(ctx, instance, 0, cmd, "", nil, nil, false, stream)
 	if err != nil {
 		return nil, err
 	}
@@ -672,7 +672,7 @@ func (a *Adapter) CreateSnapshot(ctx context.Context, req backend.SnapshotReques
 		return nil, fmt.Errorf("sandbox %q is not running: %w", sandboxID, err)
 	}
 
-	syncResp, _, err := a.executeInSandbox(ctx, instance, snapshotSyncTimeoutSeconds, []string{"sync"}, nil, false, backend.OutputStream{})
+	syncResp, _, err := a.executeInSandbox(ctx, instance, snapshotSyncTimeoutSeconds, []string{"sync"}, "", nil, nil, false, backend.OutputStream{})
 	if err != nil {
 		return nil, fmt.Errorf("sync sandbox filesystem before snapshot: %w", err)
 	}
@@ -809,12 +809,14 @@ func (a *Adapter) DeleteSnapshot(ctx context.Context, req backend.DeleteSnapshot
 	return nil
 }
 
-func (a *Adapter) executeInSandbox(ctx context.Context, instance *sandboxInstance, launchSeconds int64, command, env []string, tty bool, stream backend.OutputStream) (vsockexec.ExecResponse, guestExecTiming, error) {
+func (a *Adapter) executeInSandbox(ctx context.Context, instance *sandboxInstance, launchSeconds int64, command []string, dir string, env []string, inputProjection *backend.InputProjection, tty bool, stream backend.OutputStream) (vsockexec.ExecResponse, guestExecTiming, error) {
 	guestReq := vsockexec.ExecRequest{
 		Command:           append([]string(nil), command...),
+		Dir:               strings.TrimSpace(dir),
 		Env:               append([]string(nil), env...),
 		TTY:               tty,
 		CacheOutputMounts: cloneCacheOutputMounts(instance.cacheOutputMounts),
+		InputProjection:   vsockInputProjection(inputProjection),
 	}
 	entropy := make([]byte, 64)
 	if _, err := cryptorand.Read(entropy); err == nil {
@@ -1316,8 +1318,10 @@ func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream 
 	defer bootCancel()
 
 	guestReq := vsockexec.ExecRequest{
-		Command: req.Command,
-		TTY:     req.TTY,
+		Command:         req.Command,
+		Dir:             strings.TrimSpace(req.Dir),
+		TTY:             req.TTY,
+		InputProjection: vsockInputProjection(req.InputProjection),
 	}
 	entropy := make([]byte, 64)
 	if _, err := cryptorand.Read(entropy); err == nil {

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -503,7 +503,7 @@ func (a *Adapter) RunInSandbox(ctx context.Context, req backend.ExecutionRequest
 		defer a.GatewayRegistry.ClearActiveExecutionTrace(sandboxID, req.ExecutionID)
 	}
 
-	guestResult, timing, err := a.executeInSandbox(ctx, instance, req.LaunchSeconds, req.Command, req.Dir, req.Env, req.InputProjection, req.TTY, stream)
+	guestResult, timing, err := a.executeInSandbox(ctx, instance, req.LaunchSeconds, req.Command, req.Dir, req.Env, req.ClosedEnv, req.InputProjection, req.TTY, stream)
 	if err != nil {
 		observation.ExitCode = 1
 		observation.GuestError = err.Error()
@@ -594,7 +594,7 @@ func (a *Adapter) runFileTransferCommand(ctx context.Context, sandboxID string, 
 	if err != nil {
 		return nil, err
 	}
-	result, _, err := a.executeInSandbox(ctx, instance, 0, cmd, "", nil, nil, false, stream)
+	result, _, err := a.executeInSandbox(ctx, instance, 0, cmd, "", nil, false, nil, false, stream)
 	if err != nil {
 		return nil, err
 	}
@@ -672,7 +672,7 @@ func (a *Adapter) CreateSnapshot(ctx context.Context, req backend.SnapshotReques
 		return nil, fmt.Errorf("sandbox %q is not running: %w", sandboxID, err)
 	}
 
-	syncResp, _, err := a.executeInSandbox(ctx, instance, snapshotSyncTimeoutSeconds, []string{"sync"}, "", nil, nil, false, backend.OutputStream{})
+	syncResp, _, err := a.executeInSandbox(ctx, instance, snapshotSyncTimeoutSeconds, []string{"sync"}, "", nil, false, nil, false, backend.OutputStream{})
 	if err != nil {
 		return nil, fmt.Errorf("sync sandbox filesystem before snapshot: %w", err)
 	}
@@ -809,11 +809,12 @@ func (a *Adapter) DeleteSnapshot(ctx context.Context, req backend.DeleteSnapshot
 	return nil
 }
 
-func (a *Adapter) executeInSandbox(ctx context.Context, instance *sandboxInstance, launchSeconds int64, command []string, dir string, env []string, inputProjection *backend.InputProjection, tty bool, stream backend.OutputStream) (vsockexec.ExecResponse, guestExecTiming, error) {
+func (a *Adapter) executeInSandbox(ctx context.Context, instance *sandboxInstance, launchSeconds int64, command []string, dir string, env []string, closedEnv bool, inputProjection *backend.InputProjection, tty bool, stream backend.OutputStream) (vsockexec.ExecResponse, guestExecTiming, error) {
 	guestReq := vsockexec.ExecRequest{
 		Command:           append([]string(nil), command...),
 		Dir:               strings.TrimSpace(dir),
 		Env:               append([]string(nil), env...),
+		ClosedEnv:         closedEnv,
 		TTY:               tty,
 		CacheOutputMounts: cloneCacheOutputMounts(instance.cacheOutputMounts),
 		InputProjection:   vsockInputProjection(inputProjection),
@@ -822,7 +823,7 @@ func (a *Adapter) executeInSandbox(ctx context.Context, instance *sandboxInstanc
 	if _, err := cryptorand.Read(entropy); err == nil {
 		guestReq.EntropySeed = entropy
 	}
-	if a.GatewayRegistry != nil && instance.HostIP != "" {
+	if !closedEnv && a.GatewayRegistry != nil && instance.HostIP != "" {
 		gwPort := a.GatewayPort
 		if gwPort == 0 {
 			gwPort = gateway.DefaultPort
@@ -1320,6 +1321,8 @@ func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream 
 	guestReq := vsockexec.ExecRequest{
 		Command:         req.Command,
 		Dir:             strings.TrimSpace(req.Dir),
+		Env:             append([]string(nil), req.Env...),
+		ClosedEnv:       req.ClosedEnv,
 		TTY:             req.TTY,
 		InputProjection: vsockInputProjection(req.InputProjection),
 	}

--- a/internal/backend/firecracker/cache_output_volumes.go
+++ b/internal/backend/firecracker/cache_output_volumes.go
@@ -341,6 +341,18 @@ func cloneCacheOutputMounts(mounts []vsockexec.CacheOutputMount) []vsockexec.Cac
 	return out
 }
 
+func vsockInputProjection(projection *backend.InputProjection) *vsockexec.InputProjection {
+	if projection == nil {
+		return nil
+	}
+	return &vsockexec.InputProjection{
+		SourceRoot:          strings.TrimSpace(projection.SourceRoot),
+		TargetRoot:          strings.TrimSpace(projection.TargetRoot),
+		Files:               append([]string(nil), projection.Files...),
+		MountSourceReadOnly: projection.MountSourceReadOnly,
+	}
+}
+
 func cacheOutputGuestMountPath(driveID string) string {
 	return filepath.Join(cacheOutputGuestMountRoot, strings.TrimSpace(driveID))
 }

--- a/internal/backend/firecracker/persistent_test.go
+++ b/internal/backend/firecracker/persistent_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -16,6 +17,7 @@ import (
 	"github.com/buildkite/cleanroom/internal/backend"
 	"github.com/buildkite/cleanroom/internal/policy"
 	"github.com/buildkite/cleanroom/internal/vsockexec"
+	"go.opentelemetry.io/otel/trace"
 )
 
 func TestProvisionSandboxRejectsConcurrentProvisionForSameID(t *testing.T) {
@@ -281,10 +283,12 @@ func TestRunInSandboxForwardsInputProjection(t *testing.T) {
 		MountSourceReadOnly: true,
 	}
 	var gotDir string
+	var gotClosedEnv bool
 	var gotProjection *vsockexec.InputProjection
 	adapter := &Adapter{}
 	adapter.runGuestCommandFn = func(_ context.Context, _ context.Context, _ <-chan struct{}, _ func() error, _ string, _ uint32, req vsockexec.ExecRequest, _ backend.OutputStream) (vsockexec.ExecResponse, guestExecTiming, error) {
 		gotDir = req.Dir
+		gotClosedEnv = req.ClosedEnv
 		gotProjection = req.InputProjection
 		return vsockexec.ExecResponse{ExitCode: 0}, guestExecTiming{}, nil
 	}
@@ -301,6 +305,7 @@ func TestRunInSandboxForwardsInputProjection(t *testing.T) {
 		ExecutionID:     "run-123",
 		Command:         []string{"true"},
 		Dir:             "/workspace",
+		ClosedEnv:       true,
 		InputProjection: wantProjection,
 	}, backend.OutputStream{}); err != nil {
 		t.Fatalf("RunInSandbox returned error: %v", err)
@@ -308,11 +313,67 @@ func TestRunInSandboxForwardsInputProjection(t *testing.T) {
 	if got, want := gotDir, "/workspace"; got != want {
 		t.Fatalf("unexpected dir: got %q want %q", got, want)
 	}
+	if !gotClosedEnv {
+		t.Fatal("expected closed env to be forwarded")
+	}
 	want := vsockInputProjection(wantProjection)
 	if !reflect.DeepEqual(gotProjection, want) {
 		t.Fatalf("unexpected input projection: got %#v want %#v", gotProjection, want)
 	}
 }
+
+func TestRunInSandboxClosedEnvSkipsGatewayEnv(t *testing.T) {
+	t.Parallel()
+
+	var gotEnv []string
+	adapter := &Adapter{
+		GatewayRegistry: testGatewayRegistry{},
+		GatewayPort:     8170,
+	}
+	adapter.runGuestCommandFn = func(_ context.Context, _ context.Context, _ <-chan struct{}, _ func() error, _ string, _ uint32, req vsockexec.ExecRequest, _ backend.OutputStream) (vsockexec.ExecResponse, guestExecTiming, error) {
+		gotEnv = append([]string(nil), req.Env...)
+		return vsockexec.ExecResponse{ExitCode: 0}, guestExecTiming{}, nil
+	}
+	adapter.sandboxes = map[string]*sandboxInstance{
+		"cr-test": {
+			SandboxID: "cr-test",
+			VsockPath: "/tmp/fake.sock",
+			GuestPort: 10700,
+			HostIP:    "192.168.127.1",
+			Policy: &policy.CompiledPolicy{
+				Version:        1,
+				NetworkDefault: "deny",
+				Allow:          []policy.AllowRule{{Host: "github.com", Ports: []int{443}}},
+			},
+		},
+	}
+
+	if _, err := adapter.RunInSandbox(context.Background(), backend.ExecutionRequest{
+		SandboxID:   "cr-test",
+		ExecutionID: "run-closed-env",
+		Command:     []string{"true"},
+		Env:         []string{"DECLARED=value"},
+		ClosedEnv:   true,
+	}, backend.OutputStream{}); err != nil {
+		t.Fatalf("RunInSandbox returned error: %v", err)
+	}
+	if !slices.Contains(gotEnv, "DECLARED=value") {
+		t.Fatalf("expected declared env to be forwarded, got %v", gotEnv)
+	}
+	for _, entry := range gotEnv {
+		if strings.HasPrefix(entry, "GIT_CONFIG_") {
+			t.Fatalf("did not expect gateway env in closed environment, got %v", gotEnv)
+		}
+	}
+}
+
+type testGatewayRegistry struct{}
+
+func (testGatewayRegistry) Register(string, string, *policy.CompiledPolicy) error { return nil }
+func (testGatewayRegistry) Release(string)                                        {}
+func (testGatewayRegistry) SetActiveExecutionTrace(string, string, trace.SpanContext) {
+}
+func (testGatewayRegistry) ClearActiveExecutionTrace(string, string) {}
 
 func TestRunInSandboxWritesRunObservabilityForStatusCommand(t *testing.T) {
 	t.Parallel()

--- a/internal/backend/firecracker/persistent_test.go
+++ b/internal/backend/firecracker/persistent_test.go
@@ -271,6 +271,49 @@ func TestRunInSandboxForwardsCacheOutputMounts(t *testing.T) {
 	}
 }
 
+func TestRunInSandboxForwardsInputProjection(t *testing.T) {
+	t.Parallel()
+
+	wantProjection := &backend.InputProjection{
+		SourceRoot:          "/workspace",
+		TargetRoot:          "/run/cleanroom/input-projections/dependencies/go-modules",
+		Files:               []string{"go.mod", "go.sum"},
+		MountSourceReadOnly: true,
+	}
+	var gotDir string
+	var gotProjection *vsockexec.InputProjection
+	adapter := &Adapter{}
+	adapter.runGuestCommandFn = func(_ context.Context, _ context.Context, _ <-chan struct{}, _ func() error, _ string, _ uint32, req vsockexec.ExecRequest, _ backend.OutputStream) (vsockexec.ExecResponse, guestExecTiming, error) {
+		gotDir = req.Dir
+		gotProjection = req.InputProjection
+		return vsockexec.ExecResponse{ExitCode: 0}, guestExecTiming{}, nil
+	}
+	adapter.sandboxes = map[string]*sandboxInstance{
+		"cr-test": {
+			SandboxID: "cr-test",
+			VsockPath: "/tmp/fake.sock",
+			GuestPort: 10700,
+		},
+	}
+
+	if _, err := adapter.RunInSandbox(context.Background(), backend.ExecutionRequest{
+		SandboxID:       "cr-test",
+		ExecutionID:     "run-123",
+		Command:         []string{"true"},
+		Dir:             "/workspace",
+		InputProjection: wantProjection,
+	}, backend.OutputStream{}); err != nil {
+		t.Fatalf("RunInSandbox returned error: %v", err)
+	}
+	if got, want := gotDir, "/workspace"; got != want {
+		t.Fatalf("unexpected dir: got %q want %q", got, want)
+	}
+	want := vsockInputProjection(wantProjection)
+	if !reflect.DeepEqual(gotProjection, want) {
+		t.Fatalf("unexpected input projection: got %#v want %#v", gotProjection, want)
+	}
+}
+
 func TestRunInSandboxWritesRunObservabilityForStatusCommand(t *testing.T) {
 	t.Parallel()
 

--- a/internal/controlservice/bootstrap_runner.go
+++ b/internal/controlservice/bootstrap_runner.go
@@ -28,6 +28,7 @@ func (s *Service) runPersistentSandboxCommand(
 
 type persistentSandboxCommandOptions struct {
 	Dir             string
+	ClosedEnv       bool
 	InputProjection *backend.InputProjection
 }
 
@@ -50,6 +51,7 @@ func (s *Service) runPersistentSandboxCommandWithOptions(
 		Command:           append([]string(nil), command...),
 		Dir:               strings.TrimSpace(opts.Dir),
 		Env:               append([]string(nil), env...),
+		ClosedEnv:         opts.ClosedEnv,
 		InputProjection:   cloneInputProjection(opts.InputProjection),
 		Policy:            compiled,
 		NetworkStage:      networkStage,

--- a/internal/controlservice/bootstrap_runner.go
+++ b/internal/controlservice/bootstrap_runner.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/buildkite/cleanroom/internal/backend"
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
@@ -22,11 +23,34 @@ func (s *Service) runPersistentSandboxCommand(
 	env []string,
 	stream backend.OutputStream,
 ) (*backend.ExecutionResult, error) {
+	return s.runPersistentSandboxCommandWithOptions(ctx, adapter, sandboxID, compiled, firecrackerCfg, networkStage, executionID, command, env, persistentSandboxCommandOptions{}, stream)
+}
+
+type persistentSandboxCommandOptions struct {
+	Dir             string
+	InputProjection *backend.InputProjection
+}
+
+func (s *Service) runPersistentSandboxCommandWithOptions(
+	ctx context.Context,
+	adapter backend.Adapter,
+	sandboxID string,
+	compiled *policy.CompiledPolicy,
+	firecrackerCfg backend.FirecrackerConfig,
+	networkStage policy.NetworkStage,
+	executionID string,
+	command []string,
+	env []string,
+	opts persistentSandboxCommandOptions,
+	stream backend.OutputStream,
+) (*backend.ExecutionResult, error) {
 	return adapter.RunInSandbox(ctx, backend.ExecutionRequest{
 		SandboxID:         sandboxID,
 		ExecutionID:       executionID,
 		Command:           append([]string(nil), command...),
+		Dir:               strings.TrimSpace(opts.Dir),
 		Env:               append([]string(nil), env...),
+		InputProjection:   cloneInputProjection(opts.InputProjection),
 		Policy:            compiled,
 		NetworkStage:      networkStage,
 		FirecrackerConfig: withRunDir(firecrackerCfg, internalBootstrapArtifactsDir(sandboxID, executionID)),
@@ -45,11 +69,28 @@ func (s *Service) runPersistentBootstrapCommand(
 	stdin []byte,
 	reporter CreateSandboxReporter,
 ) (string, *backend.ExecutionResult, string, string, error) {
+	return s.runPersistentBootstrapCommandWithOptions(ctx, adapter, sandboxID, compiled, firecrackerCfg, phase, networkStage, command, nil, stdin, persistentSandboxCommandOptions{}, reporter)
+}
+
+func (s *Service) runPersistentBootstrapCommandWithOptions(
+	ctx context.Context,
+	adapter backend.Adapter,
+	sandboxID string,
+	compiled *policy.CompiledPolicy,
+	firecrackerCfg backend.FirecrackerConfig,
+	phase cleanroomv1.CreateSandboxPhase,
+	networkStage policy.NetworkStage,
+	command []string,
+	env []string,
+	stdin []byte,
+	opts persistentSandboxCommandOptions,
+	reporter CreateSandboxReporter,
+) (string, *backend.ExecutionResult, string, string, error) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	var attachErr error
 	bootstrapExecutionID := s.ids().NewExecutionID()
-	result, err := s.runPersistentSandboxCommand(ctx, adapter, sandboxID, compiled, firecrackerCfg, networkStage, bootstrapExecutionID, command, nil, backend.OutputStream{
+	result, err := s.runPersistentSandboxCommandWithOptions(ctx, adapter, sandboxID, compiled, firecrackerCfg, networkStage, bootstrapExecutionID, command, env, opts, backend.OutputStream{
 		OnStdout: func(chunk []byte) {
 			_, _ = stdout.Write(chunk)
 			emitCreateSandboxStdout(reporter, phase, chunk)
@@ -84,4 +125,16 @@ func (s *Service) runPersistentBootstrapCommand(
 		err = attachErr
 	}
 	return bootstrapExecutionID, result, stdout.String(), stderr.String(), err
+}
+
+func cloneInputProjection(projection *backend.InputProjection) *backend.InputProjection {
+	if projection == nil {
+		return nil
+	}
+	return &backend.InputProjection{
+		SourceRoot:          strings.TrimSpace(projection.SourceRoot),
+		TargetRoot:          strings.TrimSpace(projection.TargetRoot),
+		Files:               append([]string(nil), projection.Files...),
+		MountSourceReadOnly: projection.MountSourceReadOnly,
+	}
 }

--- a/internal/controlservice/dependency_volume_execution.go
+++ b/internal/controlservice/dependency_volume_execution.go
@@ -95,6 +95,7 @@ func (s *Service) bootstrapDependencyBlockVolumeBlock(
 		nil,
 		persistentSandboxCommandOptions{
 			Dir:             sourceRoot,
+			ClosedEnv:       true,
 			InputProjection: inputProjection,
 		},
 		reporter,

--- a/internal/controlservice/dependency_volume_execution.go
+++ b/internal/controlservice/dependency_volume_execution.go
@@ -1,0 +1,119 @@
+package controlservice
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+	"github.com/buildkite/cleanroom/internal/observability"
+	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/buildkite/cleanroom/internal/repositorycheckout"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+const dependencyInputProjectionRoot = "/run/cleanroom/input-projections/dependencies"
+
+func (s *Service) bootstrapDependencyBlockVolumePlanInPersistentSandbox(
+	ctx context.Context,
+	adapter backend.Adapter,
+	sandboxID string,
+	compiled *policy.CompiledPolicy,
+	firecrackerCfg backend.FirecrackerConfig,
+	repository *repositorycheckout.Checkout,
+	plan dependencyBlockVolumePlan,
+	reporter CreateSandboxReporter,
+) error {
+	if adapter == nil || compiled == nil || repository == nil || strings.TrimSpace(sandboxID) == "" || len(plan.Blocks) == 0 {
+		return nil
+	}
+
+	for _, block := range plan.Blocks {
+		blockName := strings.TrimSpace(block.BlockName)
+		if block.CacheHit {
+			emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_DEPENDENCIES, "restoring dependency outputs: "+blockName)
+			continue
+		}
+
+		attrs := []attribute.KeyValue{
+			attribute.String(observability.AttrBackend, adapter.Name()),
+			attribute.String(observability.AttrSandboxID, sandboxID),
+			attribute.String("cleanroom.cache.block", blockName),
+			attribute.Int(observability.AttrCommandArgc, len(block.Command)),
+		}
+		if commitSHA := strings.TrimSpace(repository.CommitSHA); commitSHA != "" {
+			attrs = append(attrs, attribute.String(observability.AttrRepositoryCommitSHA, commitSHA))
+		}
+
+		emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_DEPENDENCIES, "running dependency bootstrap: "+blockName)
+		if err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.bootstrap_dependency_block", attrs, func(ctx context.Context) error {
+			return s.bootstrapDependencyBlockVolumeBlock(ctx, adapter, sandboxID, compiled, firecrackerCfg, repository, block, reporter)
+		}); err != nil {
+			return fmt.Errorf("dependency block %q: %w", blockName, err)
+		}
+	}
+	return nil
+}
+
+func (s *Service) bootstrapDependencyBlockVolumeBlock(
+	ctx context.Context,
+	adapter backend.Adapter,
+	sandboxID string,
+	compiled *policy.CompiledPolicy,
+	firecrackerCfg backend.FirecrackerConfig,
+	repository *repositorycheckout.Checkout,
+	block dependencyBlockVolumeBlockPlan,
+	reporter CreateSandboxReporter,
+) error {
+	if len(block.Command) == 0 {
+		return nil
+	}
+	sourceRoot := strings.TrimSpace(repository.DestinationDir)
+	if sourceRoot == "" {
+		sourceRoot = "/workspace"
+	}
+	inputProjection := &backend.InputProjection{
+		SourceRoot:          sourceRoot,
+		TargetRoot:          filepath.Join(dependencyInputProjectionRoot, strings.TrimSpace(block.BlockName)),
+		Files:               append([]string(nil), block.Inputs...),
+		MountSourceReadOnly: true,
+	}
+	env := stageBlockEnvList(block.Env)
+	_, result, stdout, stderr, err := s.runPersistentBootstrapCommandWithOptions(
+		ctx,
+		adapter,
+		sandboxID,
+		compiled,
+		firecrackerCfg,
+		cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_DEPENDENCIES,
+		policy.NetworkStageDependencies,
+		block.Command,
+		env,
+		nil,
+		persistentSandboxCommandOptions{
+			Dir:             sourceRoot,
+			InputProjection: inputProjection,
+		},
+		reporter,
+	)
+	return persistentBootstrapCommandError(result, stdout, stderr, err, "dependency block bootstrap returned no result", "dependency block bootstrap failed with exit code %d")
+}
+
+func stageBlockEnvList(env map[string]string) []string {
+	if len(env) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(env))
+	for key := range env {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	out := make([]string, 0, len(keys))
+	for _, key := range keys {
+		out = append(out, key+"="+env[key])
+	}
+	return out
+}

--- a/internal/controlservice/dependency_volume_plan_test.go
+++ b/internal/controlservice/dependency_volume_plan_test.go
@@ -502,6 +502,9 @@ func TestBootstrapDependencyBlockVolumePlanRunsMissesFromInputProjection(t *test
 	if got, want := req.Dir, "/workspace"; got != want {
 		t.Fatalf("unexpected dir: got %q want %q", got, want)
 	}
+	if !req.ClosedEnv {
+		t.Fatal("expected dependency block execution to use a closed environment")
+	}
 	if !slices.Contains(req.Env, "GOMODCACHE=/root/go/pkg/mod") {
 		t.Fatalf("expected GOMODCACHE env, got %v", req.Env)
 	}

--- a/internal/controlservice/dependency_volume_plan_test.go
+++ b/internal/controlservice/dependency_volume_plan_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -392,8 +393,8 @@ func TestCreateSandboxLooksUpDependencyBlockVolumeCaches(t *testing.T) {
 					t.Fatalf("unexpected lookup key %d: got %q want %q", i, got, wantKey)
 				}
 			}
-			if got, want := adapter.runCalls, 2; got != want {
-				t.Fatalf("expected aggregate repository + dependency bootstrap executions, got %d want %d", got, want)
+			if got, want := adapter.runCalls, 1+len(plan.Blocks)-tc.wantHits; got != want {
+				t.Fatalf("expected repository plus dependency block miss executions, got %d want %d", got, want)
 			}
 		})
 	}
@@ -441,6 +442,83 @@ func TestDependencyBlockVolumeRuntimeDecisionRequiresOutputVolumesAndOverlay(t *
 				t.Fatalf("expected empty fallback reason for enabled decision, got %q", decision.FallbackReason)
 			}
 		})
+	}
+}
+
+func TestBootstrapDependencyBlockVolumePlanRunsMissesFromInputProjection(t *testing.T) {
+	t.Parallel()
+
+	compiled, err := policy.FromProto(testRepositoryTwoDependencyBlocksPolicy())
+	if err != nil {
+		t.Fatalf("policy.FromProto returned error: %v", err)
+	}
+	repository := repositorycheckout.FromProto(testRepositoryCheckoutProto())
+	plan := dependencyBlockVolumePlan{
+		Blocks: []dependencyBlockVolumeBlockPlan{
+			{
+				BlockName: "toolchains",
+				Command:   append([]string(nil), compiled.Dependencies.Blocks[0].Command...),
+				Env:       cloneDependencyBlockEnv(compiled.Dependencies.Blocks[0].Env),
+				Inputs:    append([]string(nil), compiled.Dependencies.Blocks[0].Inputs.Files...),
+				CacheHit:  true,
+			},
+			{
+				BlockName: "go-modules",
+				Command:   append([]string(nil), compiled.Dependencies.Blocks[1].Command...),
+				Env:       cloneDependencyBlockEnv(compiled.Dependencies.Blocks[1].Env),
+				Inputs:    append([]string(nil), compiled.Dependencies.Blocks[1].Inputs.Files...),
+			},
+		},
+	}
+
+	var gotReqs []backend.ExecutionRequest
+	adapter := &stubAdapter{
+		runStreamFn: func(_ context.Context, req backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
+			gotReqs = append(gotReqs, req)
+			return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0}, nil
+		},
+	}
+	svc := newTestService(adapter)
+	err = svc.bootstrapDependencyBlockVolumePlanInPersistentSandbox(
+		context.Background(),
+		adapter,
+		"cr-test",
+		compiled,
+		backend.FirecrackerConfig{},
+		repository,
+		plan,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("bootstrapDependencyBlockVolumePlanInPersistentSandbox returned error: %v", err)
+	}
+	if got, want := len(gotReqs), 1; got != want {
+		t.Fatalf("unexpected run count: got %d want %d", got, want)
+	}
+	req := gotReqs[0]
+	if got, want := strings.Join(req.Command, "\x00"), strings.Join(compiled.Dependencies.Blocks[1].Command, "\x00"); got != want {
+		t.Fatalf("unexpected command: got %q want %q", got, want)
+	}
+	if got, want := req.Dir, "/workspace"; got != want {
+		t.Fatalf("unexpected dir: got %q want %q", got, want)
+	}
+	if !slices.Contains(req.Env, "GOMODCACHE=/root/go/pkg/mod") {
+		t.Fatalf("expected GOMODCACHE env, got %v", req.Env)
+	}
+	if req.InputProjection == nil {
+		t.Fatal("expected input projection")
+	}
+	if got, want := req.InputProjection.SourceRoot, "/workspace"; got != want {
+		t.Fatalf("unexpected projection source root: got %q want %q", got, want)
+	}
+	if got, want := req.InputProjection.TargetRoot, "/run/cleanroom/input-projections/dependencies/go-modules"; got != want {
+		t.Fatalf("unexpected projection target root: got %q want %q", got, want)
+	}
+	if !slices.Equal(req.InputProjection.Files, []string{"go.mod", "go.sum"}) {
+		t.Fatalf("unexpected projection files: got %v", req.InputProjection.Files)
+	}
+	if !req.InputProjection.MountSourceReadOnly {
+		t.Fatal("expected projection to be mounted read-only over source")
 	}
 }
 

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -747,7 +747,7 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 				}
 				return nil, fmt.Errorf("bootstrap services stage: %w", err)
 			}
-			if servicesStageCachingEnabled {
+			if servicesStageCachingEnabled && !serviceBlockVolumePlanAvailable {
 				emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_PUBLISH_SERVICES_STAGE_CACHE, "publishing services stage cache")
 				s.maybePublishServicesStageCache(ctx, snapshotAdapter, sandboxID, backendName, compiled, firecrackerCfg, repository, changeset, servicesStagePlan, replacedServicesStageRecord)
 			}
@@ -771,6 +771,9 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 			}
 			emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_DEPENDENCIES, "running dependency bootstrap")
 			if err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.bootstrap_dependencies", bootstrapAttrs, func(ctx context.Context) error {
+				if dependencyBlockVolumePlanAvailable {
+					return s.bootstrapDependencyBlockVolumePlanInPersistentSandbox(ctx, adapter, sandboxID, compiled, firecrackerCfg, repository, dependencyBlockVolumePlan, reporter)
+				}
 				return s.bootstrapDependencyStageInPersistentSandbox(ctx, adapter, sandboxID, compiled, firecrackerCfg, dependencyStagePlan, reporter)
 			}); err != nil {
 				cleanupErr := s.terminateCreatedSandbox(context.Background(), adapter, sandboxID)
@@ -779,7 +782,7 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 				}
 				return nil, fmt.Errorf("bootstrap dependency stage: %w", err)
 			}
-			if dependencyStageCachingEnabled {
+			if dependencyStageCachingEnabled && !dependencyBlockVolumePlanAvailable {
 				emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_PUBLISH_DEPENDENCY_STAGE_CACHE, "publishing dependency stage cache")
 				s.maybePublishDependencyStageCache(ctx, snapshotAdapter, sandboxID, backendName, compiled, firecrackerCfg, repository, changeset, dependencyStagePlan, replacedDependencyStageRecord)
 			}
@@ -805,7 +808,7 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 				}
 				return nil, fmt.Errorf("bootstrap services stage: %w", err)
 			}
-			if servicesStageCachingEnabled {
+			if servicesStageCachingEnabled && !serviceBlockVolumePlanAvailable {
 				emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_PUBLISH_SERVICES_STAGE_CACHE, "publishing services stage cache")
 				s.maybePublishServicesStageCache(ctx, snapshotAdapter, sandboxID, backendName, compiled, firecrackerCfg, repository, changeset, servicesStagePlan, replacedServicesStageRecord)
 			}
@@ -945,6 +948,9 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 		}
 		emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_DEPENDENCIES, "running dependency bootstrap")
 		if err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.bootstrap_dependencies", bootstrapAttrs, func(ctx context.Context) error {
+			if dependencyBlockVolumePlanAvailable {
+				return s.bootstrapDependencyBlockVolumePlanInPersistentSandbox(ctx, adapter, sandboxID, compiled, firecrackerCfg, repository, dependencyBlockVolumePlan, reporter)
+			}
 			return s.bootstrapDependencyStageInPersistentSandbox(ctx, adapter, sandboxID, compiled, firecrackerCfg, dependencyStagePlan, reporter)
 		}); err != nil {
 			if terminateErr := s.terminateCreatedSandbox(context.Background(), adapter, sandboxID); terminateErr != nil {
@@ -955,7 +961,7 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 		if err := s.ensureSandboxCreateStillProvisioning(sandboxID); err != nil {
 			return nil, err
 		}
-		if dependencyStageCachingEnabled && snapshotCapable {
+		if dependencyStageCachingEnabled && snapshotCapable && !dependencyBlockVolumePlanAvailable {
 			emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_PUBLISH_DEPENDENCY_STAGE_CACHE, "publishing dependency stage cache")
 			_ = s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.publish_dependency_stage_cache", []attribute.KeyValue{
 				attribute.String("cleanroom.backend", backendName),
@@ -992,7 +998,7 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 		if err := s.ensureSandboxCreateStillProvisioning(sandboxID); err != nil {
 			return nil, err
 		}
-		if servicesStageCachingEnabled && snapshotCapable {
+		if servicesStageCachingEnabled && snapshotCapable && !serviceBlockVolumePlanAvailable {
 			emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_PUBLISH_SERVICES_STAGE_CACHE, "publishing services stage cache")
 			_ = s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.publish_services_stage_cache", []attribute.KeyValue{
 				attribute.String("cleanroom.backend", backendName),

--- a/internal/controlservice/service_volume_plan_test.go
+++ b/internal/controlservice/service_volume_plan_test.go
@@ -374,8 +374,8 @@ func TestCreateSandboxLooksUpServiceBlockVolumeCaches(t *testing.T) {
 					t.Fatalf("unexpected lookup key %d: got %q want %q", i, got, wantKey)
 				}
 			}
-			if got, want := adapter.runCalls, 3; got != want {
-				t.Fatalf("expected aggregate repository + dependency + services bootstrap executions, got %d want %d", got, want)
+			if got, want := adapter.runCalls, 4; got != want {
+				t.Fatalf("expected repository + dependency block misses + aggregate services bootstrap executions, got %d want %d", got, want)
 			}
 		})
 	}
@@ -424,6 +424,35 @@ func TestCreateSandboxLooksUpServiceBlockVolumesAfterDependencyStageRestore(t *t
 		t.Fatalf("FromProto returned error: %v", err)
 	}
 	repository := repositorycheckout.FromProto(repositoryCheckout)
+	aggregateDependencyPlan, aggregateDependencyEnabled := dependencyStagePlanForRepository(compiled, repository)
+	if !aggregateDependencyEnabled {
+		t.Fatal("expected aggregate dependency stage plan")
+	}
+	workspaceKey := workspaceStageCacheKey("firecracker", "runtime-base:test", compiled.Hash, repository, nil)
+	aggregateDependencyPlan, aggregateDependencyEnabled, err = svc.finalizeDependencyStagePlan(context.Background(), compiled, repository, nil, nil, "firecracker", workspaceKey, "runtime-base:test", aggregateDependencyPlan)
+	if err != nil {
+		t.Fatalf("finalizeDependencyStagePlan returned error: %v", err)
+	}
+	if !aggregateDependencyEnabled {
+		t.Fatal("expected finalized aggregate dependency stage plan")
+	}
+	if err := cacheStore.Create(context.Background(), cachestore.Record{
+		CacheKey:          aggregateDependencyPlan.CacheKey,
+		Stage:             dependencyStageName,
+		ReuseMode:         dependencyStageReuseExact,
+		State:             cacheStateReady,
+		BackingSnapshotID: "snapshot-dependency",
+		Backend:           "firecracker",
+		PolicyHash:        compiled.Hash,
+		Policy:            compiled.ToProto(),
+		Repository:        cloneRepositoryCheckout(normalizeRepositoryCheckoutForComparison(repository)).ToProto(),
+		ParentCacheKey:    aggregateDependencyPlan.ParentWorkspaceCacheKey,
+		StorageRef:        "/snapshots/dependency.ext4",
+		ProducerVersion:   dependencyStageProducerVersion,
+	}); err != nil {
+		t.Fatalf("Create aggregate dependency stage record returned error: %v", err)
+	}
+
 	dependencyPlan, ok, err := svc.finalizeDependencyBlockVolumePlan(context.Background(), compiled, repository, nil, nil, "firecracker", "runtime-base:test")
 	if err != nil {
 		t.Fatalf("finalizeDependencyBlockVolumePlan returned error: %v", err)
@@ -465,8 +494,8 @@ func TestCreateSandboxLooksUpServiceBlockVolumesAfterDependencyStageRestore(t *t
 	if got, want := adapter.provisionFromSnapshotReq.CacheOutputVolumes, serviceBlockVolumeOutputSpecsForTest(t, lookedUpServicePlan); !cacheOutputVolumeSpecsEqual(got, want) {
 		t.Fatalf("unexpected dependency-stage restore output volume specs:\ngot:  %#v\nwant: %#v", got, want)
 	}
-	if got, want := adapter.runCalls, 4; got != want {
-		t.Fatalf("expected aggregate services bootstrap to still run after dependency restore, got %d want %d", got, want)
+	if got, want := adapter.runCalls, 5; got != want {
+		t.Fatalf("expected dependency block misses on first create plus aggregate services bootstrap after dependency restore, got %d want %d", got, want)
 	}
 }
 

--- a/internal/vsockexec/protocol.go
+++ b/internal/vsockexec/protocol.go
@@ -17,6 +17,7 @@ type ExecRequest struct {
 	Command           []string           `json:"command"`
 	Dir               string             `json:"dir,omitempty"`
 	Env               []string           `json:"env,omitempty"`
+	ClosedEnv         bool               `json:"closed_env,omitempty"`
 	EntropySeed       []byte             `json:"entropy_seed,omitempty"`
 	TTY               bool               `json:"tty,omitempty"`
 	CacheOutputMounts []CacheOutputMount `json:"cache_output_mounts,omitempty"`

--- a/internal/vsockexec/protocol.go
+++ b/internal/vsockexec/protocol.go
@@ -20,6 +20,14 @@ type ExecRequest struct {
 	EntropySeed       []byte             `json:"entropy_seed,omitempty"`
 	TTY               bool               `json:"tty,omitempty"`
 	CacheOutputMounts []CacheOutputMount `json:"cache_output_mounts,omitempty"`
+	InputProjection   *InputProjection   `json:"input_projection,omitempty"`
+}
+
+type InputProjection struct {
+	SourceRoot          string   `json:"source_root"`
+	TargetRoot          string   `json:"target_root"`
+	Files               []string `json:"files,omitempty"`
+	MountSourceReadOnly bool     `json:"mount_source_read_only,omitempty"`
 }
 
 type CacheOutputMount struct {


### PR DESCRIPTION
## Summary

- add backend/vsock execution fields for isolated input projections and command working directories
- teach the Linux guest agent to materialize declared input files, reject non-regular inputs, and bind the projection read-only over the workspace for a command
- run dependency block-volume misses as individual block commands from the projected workspace when the block-volume runtime path is available
- skip aggregate dependency/services stage publication while sidecar output volumes are active, because rootfs snapshots would not contain sidecar output data
- update the dependency/service volume-cache plan with Phase 6 status and remaining v0.7 work

## Validation

- `mise exec -- go test -count=1 ./cmd/cleanroom-guest-agent ./internal/vsockexec ./internal/backend/firecracker ./internal/backend/darwinvz ./internal/controlservice`
- `mise exec -- go test ./...`
- `git diff --check`

Note: the first full-suite run hit a transient `internal/interactivequic` localhost dial timeout; `mise exec -- go test -count=1 ./internal/interactivequic` passed, and the full suite passed on rerun.
