### PR TITLE
feat: Support exposure flags on create and console

### DIFF
--- a/internal/cli/cli_parse_test.go
+++ b/internal/cli/cli_parse_test.go
@@ -207,16 +207,18 @@ func TestSystemCommandsParse(t *testing.T) {
 	}
 }
 
-func TestSandboxCreateRejectsExposureFlags(t *testing.T) {
+func TestSandboxCreateParsesExposureFlags(t *testing.T) {
 	c := &CLI{}
 	parser := newParserForTest(t, c)
 
-	_, err := parser.Parse([]string{"sandbox", "create", "--expose", "15432:5432"})
-	if err == nil {
-		t.Fatal("expected sandbox create --expose to be rejected")
+	if _, err := parser.Parse([]string{"sandbox", "create", "--expose", "15432:5432", "--expose-https", "buildkite:3000"}); err != nil {
+		t.Fatalf("parse sandbox create exposure flags returned error: %v", err)
 	}
-	if !strings.Contains(err.Error(), "unknown flag") || !strings.Contains(err.Error(), "--expose") {
-		t.Fatalf("expected unknown flag parse error, got %v", err)
+	if got, want := c.Sandbox.Create.Expose, []string{"15432:5432"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected sandbox create --expose values: got %v want %v", got, want)
+	}
+	if got, want := c.Sandbox.Create.ExposeHTTPS, []string{"buildkite:3000"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected sandbox create --expose-https values: got %v want %v", got, want)
 	}
 }
 
@@ -406,6 +408,21 @@ func TestTopLevelCreateParsesDangerouslyAllowAll(t *testing.T) {
 	}
 	if !c.Create.DangerouslyAllowAll {
 		t.Fatal("expected create dangerously-allow-all flag to be set")
+	}
+}
+
+func TestTopLevelCreateParsesExposureFlags(t *testing.T) {
+	c := &CLI{}
+	parser := newParserForTest(t, c)
+
+	if _, err := parser.Parse([]string{"create", "--expose", "5432", "--expose-https", "buildkite:3000"}); err != nil {
+		t.Fatalf("parse create exposure flags returned error: %v", err)
+	}
+	if got, want := c.Create.Expose, []string{"5432"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected create --expose values: got %v want %v", got, want)
+	}
+	if got, want := c.Create.ExposeHTTPS, []string{"buildkite:3000"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected create --expose-https values: got %v want %v", got, want)
 	}
 }
 
@@ -689,6 +706,24 @@ func TestConsoleParsesRepeatedEnvFlags(t *testing.T) {
 	}
 	if got, want := c.Console.Env, []string{"OPENAI_API_KEY", "DEBUG=1"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("unexpected console env flags: got %v want %v", got, want)
+	}
+}
+
+func TestConsoleParsesExposureFlags(t *testing.T) {
+	c := &CLI{}
+	parser := newParserForTest(t, c)
+
+	if _, err := parser.Parse([]string{"console", "--expose", "5432", "--expose-https", "buildkite:3000", "--", "sh"}); err != nil {
+		t.Fatalf("parse console exposure flags returned error: %v", err)
+	}
+	if got, want := c.Console.Expose, []string{"5432"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected console --expose values: got %v want %v", got, want)
+	}
+	if got, want := c.Console.ExposeHTTPS, []string{"buildkite:3000"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected console --expose-https values: got %v want %v", got, want)
+	}
+	if got, want := trimPassthroughSeparator(c.Console.Command), []string{"sh"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected console command: got %v want %v", got, want)
 	}
 }
 

--- a/internal/cli/console.go
+++ b/internal/cli/console.go
@@ -26,6 +26,8 @@ type ConsoleCommand struct {
 	Keep                bool     `help:"Keep a newly created sandbox after the console exits"`
 	DangerouslyAllowAll bool     `name:"dangerously-allow-all" help:"Disable network egress filtering for a newly created sandbox"`
 	Env                 []string `short:"e" name:"env" help:"Set guest environment variables; use KEY to inherit from the local environment or KEY=VALUE to set an explicit value"`
+	Expose              []string `name:"expose" help:"Expose raw TCP as <guest-port> or <host-port>:<guest-port>"`
+	ExposeHTTPS         []string `name:"expose-https" help:"Expose HTTPS as [name:]<guest-port> under cleanroom.localhost"`
 	PrintSandboxID      bool     `name:"print-sandbox-id" help:"Print resolved sandbox_id=<id> to stderr before attaching"`
 
 	LaunchSeconds int64 `help:"VM boot/guest-agent readiness timeout in seconds"`
@@ -90,6 +92,10 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) (runErr error) {
 		return err
 	}
 	executionEnv, err := resolveExecutionEnv(c.Env)
+	if err != nil {
+		return err
+	}
+	exposures, err := parseExposureFlags(c.Expose, c.ExposeHTTPS)
 	if err != nil {
 		return err
 	}
@@ -165,6 +171,16 @@ func (c *ConsoleCommand) Run(ctx *runtimeContext) (runErr error) {
 	}
 	if c.preAttach != nil {
 		if err := c.preAttach(rootCtx, client, sandboxID); err != nil {
+			return err
+		}
+	}
+	exposureManager, exposed, err := startClientExposures(rootCtx, client, sandboxID, exposures)
+	if err != nil {
+		return err
+	}
+	if exposureManager != nil {
+		defer exposureManager.Close()
+		if err := writeExposureLines(os.Stderr, exposed); err != nil {
 			return err
 		}
 	}

--- a/internal/cli/console_integration_test.go
+++ b/internal/cli/console_integration_test.go
@@ -614,6 +614,46 @@ func TestConsoleIntegrationRejectsKeepWhenReusingSandbox(t *testing.T) {
 	}
 }
 
+func TestConsoleIntegrationTerminatesCreatedSandboxWhenExposureSetupFails(t *testing.T) {
+	adapter := &snapshotIntegrationAdapter{}
+	host, _ := startIntegrationServer(t, adapter)
+	cwd := t.TempDir()
+
+	outcome := runConsoleWithCapture(ConsoleCommand{
+		clientFlags: clientFlags{Host: host},
+		Chdir:       cwd,
+		Expose:      []string{"3000"},
+		Command:     []string{"sh"},
+	}, "exit\n", runtimeContext{
+		CWD:    cwd,
+		Loader: integrationLoader{},
+	})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err == nil {
+		t.Fatal("expected ConsoleCommand.Run to fail during exposure setup")
+	}
+	if !strings.Contains(outcome.err.Error(), "does not support sandbox port dialing") {
+		t.Fatalf("unexpected ConsoleCommand.Run error: %v", outcome.err)
+	}
+
+	adapter.mu.Lock()
+	sandboxID := adapter.provisionReq.SandboxID
+	terminateCalls := adapter.terminateCalls
+	runInSandboxCalls := adapter.runInSandboxCalls
+	adapter.mu.Unlock()
+	if sandboxID == "" {
+		t.Fatal("expected sandbox to be provisioned before exposure setup")
+	}
+	if got, want := terminateCalls, 1; got != want {
+		t.Fatalf("expected created sandbox to be terminated after exposure setup failure: got %d", got)
+	}
+	if got, want := runInSandboxCalls, 0; got != want {
+		t.Fatalf("expected console execution not to start after exposure setup failure: got %d", got)
+	}
+}
+
 func TestConsoleIntegrationRejectsChdirWhenReusingSandbox(t *testing.T) {
 	cwd := t.TempDir()
 	outcome := runConsoleWithCapture(ConsoleCommand{

--- a/internal/cli/local_exposure.go
+++ b/internal/cli/local_exposure.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"strings"
@@ -92,6 +93,13 @@ func runForegroundClientExposures(ctx *runtimeContext, flags clientFlags, sandbo
 		return err
 	}
 
+	return runForegroundClientExposuresWithClient(ctx.Stdout, client, sandboxID, requested)
+}
+
+func runForegroundClientExposuresWithClient(w io.Writer, client *controlclient.Client, sandboxID string, requested []*cleanroomv1.PortExposure) error {
+	if len(requested) == 0 {
+		return nil
+	}
 	exposureCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	manager, registered, err := startClientExposures(exposureCtx, client, sandboxID, requested)
@@ -99,10 +107,10 @@ func runForegroundClientExposures(ctx *runtimeContext, flags clientFlags, sandbo
 		return err
 	}
 	defer manager.Close()
-	if err := writeExposureLines(ctx.Stdout, registered); err != nil {
+	if err := writeExposureLines(w, registered); err != nil {
 		return err
 	}
-	if _, err := fmt.Fprintln(ctx.Stdout, "press Ctrl-C to stop exposing ports"); err != nil {
+	if _, err := fmt.Fprintln(w, "press Ctrl-C to stop exposing ports"); err != nil {
 		return err
 	}
 

--- a/internal/cli/sandbox.go
+++ b/internal/cli/sandbox.go
@@ -24,13 +24,15 @@ type SandboxCommand struct {
 
 type SandboxCreateCommand struct {
 	clientFlags
-	Backend             string `help:"Execution backend (defaults to runtime config or host default)"`
-	From                string `name:"from" help:"Create the sandbox from an existing snapshot ID"`
-	Image               string `help:"Override sandbox image ref (tag, digest, or local Docker image)"`
-	Docker              bool   `help:"Enable the guest Docker service for this repo-agnostic sandbox"`
-	DangerouslyAllowAll bool   `name:"dangerously-allow-all" help:"Disable network egress filtering for this repo-agnostic sandbox"`
-	LaunchSeconds       int64  `help:"VM boot/guest-agent readiness timeout in seconds"`
-	JSON                bool   `help:"Print sandbox as JSON"`
+	Backend             string   `help:"Execution backend (defaults to runtime config or host default)"`
+	From                string   `name:"from" help:"Create the sandbox from an existing snapshot ID"`
+	Image               string   `help:"Override sandbox image ref (tag, digest, or local Docker image)"`
+	Docker              bool     `help:"Enable the guest Docker service for this repo-agnostic sandbox"`
+	DangerouslyAllowAll bool     `name:"dangerously-allow-all" help:"Disable network egress filtering for this repo-agnostic sandbox"`
+	Expose              []string `name:"expose" help:"Expose raw TCP as <guest-port> or <host-port>:<guest-port>"`
+	ExposeHTTPS         []string `name:"expose-https" help:"Expose HTTPS as [name:]<guest-port> under cleanroom.localhost"`
+	LaunchSeconds       int64    `help:"VM boot/guest-agent readiness timeout in seconds"`
+	JSON                bool     `help:"Print sandbox as JSON"`
 }
 
 type SandboxListCommand struct {
@@ -59,9 +61,11 @@ type CreateCommand struct {
 	Image   string `help:"Override sandbox image ref (tag, digest, or local Docker image)"`
 	repositoryOverrideFlags
 	workspaceCopyInFlags
-	DangerouslyAllowAll bool  `name:"dangerously-allow-all" help:"Disable network egress filtering for a newly created sandbox"`
-	LaunchSeconds       int64 `help:"VM boot/guest-agent readiness timeout in seconds"`
-	JSON                bool  `help:"Print sandbox as JSON"`
+	DangerouslyAllowAll bool     `name:"dangerously-allow-all" help:"Disable network egress filtering for a newly created sandbox"`
+	Expose              []string `name:"expose" help:"Expose raw TCP as <guest-port> or <host-port>:<guest-port>"`
+	ExposeHTTPS         []string `name:"expose-https" help:"Expose HTTPS as [name:]<guest-port> under cleanroom.localhost"`
+	LaunchSeconds       int64    `help:"VM boot/guest-agent readiness timeout in seconds"`
+	JSON                bool     `help:"Print sandbox as JSON"`
 }
 
 func (c *SandboxListCommand) Run(ctx *runtimeContext) error {
@@ -247,7 +251,11 @@ func (c *SandboxTerminateCommand) Run(ctx *runtimeContext) error {
 	return err
 }
 
-func runSandboxCreate(ctx *runtimeContext, connectFlags clientFlags, backend, from, imageRefOverride string, requireDockerService, dangerouslyAllowAll bool, launchSeconds int64, outputJSON bool) error {
+func runSandboxCreate(ctx *runtimeContext, connectFlags clientFlags, backend, from, imageRefOverride string, requireDockerService, dangerouslyAllowAll bool, exposureSpecs, httpsExposureSpecs []string, launchSeconds int64, outputJSON bool) error {
+	exposures, err := parseExposureFlags(exposureSpecs, httpsExposureSpecs)
+	if err != nil {
+		return err
+	}
 	resolvedHost := connectFlags.resolvedHost(ctx.Config)
 	client, err := connectFlags.connect(ctx)
 	if err != nil {
@@ -300,17 +308,19 @@ func runSandboxCreate(ctx *runtimeContext, connectFlags clientFlags, backend, fr
 	if outputJSON {
 		enc := json.NewEncoder(ctx.Stdout)
 		enc.SetIndent("", "  ")
-		return enc.Encode(sandbox)
+		if err := enc.Encode(sandbox); err != nil {
+			return err
+		}
+	} else {
+		if _, err := fmt.Fprintln(ctx.Stdout, sandboxID); err != nil {
+			return err
+		}
 	}
-
-	if _, err := fmt.Fprintln(ctx.Stdout, sandboxID); err != nil {
-		return err
-	}
-	return nil
+	return runForegroundClientExposuresWithClient(os.Stderr, client, sandboxID, exposures)
 }
 
 func (c *SandboxCreateCommand) Run(ctx *runtimeContext) error {
-	return runSandboxCreate(ctx, c.clientFlags, c.Backend, c.From, c.Image, c.Docker, c.DangerouslyAllowAll, c.LaunchSeconds, c.JSON)
+	return runSandboxCreate(ctx, c.clientFlags, c.Backend, c.From, c.Image, c.Docker, c.DangerouslyAllowAll, c.Expose, c.ExposeHTTPS, c.LaunchSeconds, c.JSON)
 }
 
 func (c *CreateCommand) Run(ctx *runtimeContext) error {
@@ -318,7 +328,11 @@ func (c *CreateCommand) Run(ctx *runtimeContext) error {
 		return err
 	}
 	if strings.TrimSpace(c.From) != "" {
-		return runSandboxCreate(ctx, c.clientFlags, c.Backend, c.From, c.Image, false, c.DangerouslyAllowAll, c.LaunchSeconds, c.JSON)
+		return runSandboxCreate(ctx, c.clientFlags, c.Backend, c.From, c.Image, false, c.DangerouslyAllowAll, c.Expose, c.ExposeHTTPS, c.LaunchSeconds, c.JSON)
+	}
+	exposures, err := parseExposureFlags(c.Expose, c.ExposeHTTPS)
+	if err != nil {
+		return err
 	}
 	host := c.resolvedHost(ctx.Config)
 	client, err := c.connect(ctx)
@@ -353,12 +367,15 @@ func (c *CreateCommand) Run(ctx *runtimeContext) error {
 	if c.JSON {
 		enc := json.NewEncoder(ctx.Stdout)
 		enc.SetIndent("", "  ")
-		return enc.Encode(sandbox)
+		if err := enc.Encode(sandbox); err != nil {
+			return err
+		}
+	} else {
+		if _, err := fmt.Fprintln(ctx.Stdout, sandboxID); err != nil {
+			return err
+		}
 	}
-	if _, err := fmt.Fprintln(ctx.Stdout, sandboxID); err != nil {
-		return err
-	}
-	return nil
+	return runForegroundClientExposuresWithClient(os.Stderr, client, sandboxID, exposures)
 }
 
 func (c *CreateCommand) validate() error {

--- a/internal/cli/sandbox_create_integration_test.go
+++ b/internal/cli/sandbox_create_integration_test.go
@@ -100,6 +100,44 @@ func TestSandboxCreateIntegrationJSONOutput(t *testing.T) {
 	}
 }
 
+func TestTopLevelCreateIntegrationReportsExposureSetupFailureAfterCreate(t *testing.T) {
+	adapter := &snapshotIntegrationAdapter{}
+	host, _ := startIntegrationServer(t, adapter)
+	cwd := t.TempDir()
+
+	outcome := runCreateAliasWithCapture(CreateCommand{
+		clientFlags: clientFlags{Host: host},
+		Chdir:       cwd,
+		Expose:      []string{"3000"},
+	}, runtimeContext{
+		CWD:    cwd,
+		Loader: integrationLoader{},
+	})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err == nil {
+		t.Fatal("expected CreateCommand.Run to fail during exposure setup")
+	}
+	if !strings.Contains(outcome.err.Error(), "does not support sandbox port dialing") {
+		t.Fatalf("unexpected CreateCommand.Run error: %v", outcome.err)
+	}
+	if strings.TrimSpace(outcome.stdout) == "" {
+		t.Fatalf("expected sandbox id before exposure setup error, got %q", outcome.stdout)
+	}
+
+	adapter.mu.Lock()
+	provisionCalls := adapter.provisionCalls
+	terminateCalls := adapter.terminateCalls
+	adapter.mu.Unlock()
+	if got, want := provisionCalls, 1; got != want {
+		t.Fatalf("expected one sandbox provision, got %d", got)
+	}
+	if got, want := terminateCalls, 0; got != want {
+		t.Fatalf("expected create to leave the created sandbox for inspection, got %d terminations", got)
+	}
+}
+
 func TestSandboxCreateIntegrationDangerouslyAllowAllSetsAllowNetworkDefault(t *testing.T) {
 	restore := stubPolicyUpdateResolver(t, func(_ context.Context, source string) (string, error) {
 		if got, want := source, defaultBumpRefSource; got != want {


### PR DESCRIPTION
## Summary

- Add `--expose` and `--expose-https` to `cleanroom create`, `cleanroom sandbox create`, and `cleanroom console`.
- Reuse the existing client-owned exposure lifecycle so create keeps stdout script-friendly while exposure URLs and the Ctrl-C prompt go to stderr.
- Cover parser behavior and unsupported-backend failure paths for create and console.

## Validation

- `mise exec -- go test ./internal/cli`
- `mise exec -- go test ./...`
- `mise exec -- go run ./cmd/cleanroom create --help`
- `mise exec -- go run ./cmd/cleanroom console --help`
- `mise exec -- go run ./cmd/cleanroom sandbox create --help`
