### PR TITLE
feat: Mirror guest Docker registries via gateway

### DIFF
--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -99,8 +99,13 @@ gateway:
   oci:
     registries:
       ghcr.io: https://ghcr.io
+      public.ecr.aws: https://public.ecr.aws
       registry.internal:5000: https://registry.internal:5000
 ```
+
+The map key is the registry name used by the guest, and the value is the
+host-side upstream used by the cache. Keys are normalized as registry hosts;
+they are not arbitrary aliases.
 
 Not wired yet:
 
@@ -121,10 +126,25 @@ Current scope:
 - pull-style `GET` and `HEAD` requests only
 - mirror traffic routed to the same `docker.io` -> `registry-1.docker.io`
   upstream mapping used by `/registry/`
+- guest `dockerd` pulls for runtime-configured non-Docker-Hub registries are
+  mirrored through `/registry/<host>/` by generated Docker registry host config.
+  For example, `gateway.oci.registries.public.ecr.aws` makes guest pulls from
+  `public.ecr.aws/...` use
+  `http://gateway.cleanroom.internal:8170/registry/public.ecr.aws/...` inside
+  the guest.
+
+Policy still applies to the registry host from the map key. A sandbox must
+allow `public.ecr.aws:443` for the `public.ecr.aws` mirror path to fetch
+upstream, even though the guest talks to the Cleanroom gateway over HTTP.
+Registries that are not present in `gateway.oci.registries` are not installed
+as guest `dockerd` registry mirrors; they either use Docker's normal direct
+registry path subject to network policy, or fail when direct egress is denied.
+Configured registry host config points the registry namespace's server at the
+Cleanroom gateway, so configured non-Docker-Hub pulls do not have a direct
+upstream fallback inside `dockerd`.
 
 Not wired yet:
 
-- guest daemon rewrites for non-Docker-Hub registries
 - Docker push or other write operations through the mirror
 
 ## Go module proxy route

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -473,7 +473,8 @@ These rules are installed during sandbox network setup and torn down during clea
 - The gateway resolves a registry prefix from the request path, maps it to an upstream registry URL, and applies the sandbox allowlist against the mapped policy host and port before forwarding upstream.
 - Current route scope is OCI pull-style `GET` and `HEAD` traffic.
 - The gateway also exposes a Docker Hub-compatible `/v2/` mirror endpoint backed by the same OCI cache so guest `dockerd` can use the shared gateway as a Docker Hub registry mirror.
-- Current Docker mirror scope is Docker Hub pull-style `GET` and `HEAD` traffic.
+- Guest `dockerd` also gets generated Docker registry-host config for non-Docker-Hub registries explicitly configured in runtime config under `gateway.oci.registries`, pointing those registry namespaces' server endpoint at the gateway `/registry/<host>/` path without a direct upstream fallback.
+- Current Docker mirror scope is pull-style `GET` and `HEAD` traffic for Docker Hub and runtime-configured registry hosts.
 - The gateway exposes a `/goproxy/` route backed by embedded `content-cache` Go module proxy handlers, including mirrored sumdb traffic under `/goproxy/sumdb/`.
 - Current Go module scope includes `GOPROXY` metadata requests, module zip downloads, and mirrored checksum-database requests.
 - The gateway also exposes a `/rubygems/` route backed by embedded `content-cache` RubyGems handlers for Bundler mirror traffic to `rubygems.org`.

--- a/internal/backend/darwinvz/docker_bootargs.go
+++ b/internal/backend/darwinvz/docker_bootargs.go
@@ -35,7 +35,7 @@ func dockerServiceBootArgs(compiled *policy.CompiledPolicy, cfg backend.Firecrac
 		storageDriver,
 		iptables,
 	)
-	if routes.DockerHubMirror && gatewayPort > 0 {
+	if (routes.DockerHubMirror || len(routes.DockerRegistryMirrors) > 0) && gatewayPort > 0 {
 		host := sanitizeKernelArgValue(gateway.GuestGatewayHostname)
 		if host != "" {
 			args += fmt.Sprintf(
@@ -45,7 +45,34 @@ func dockerServiceBootArgs(compiled *policy.CompiledPolicy, cfg backend.Firecrac
 			)
 		}
 	}
+	if len(routes.DockerRegistryMirrors) > 0 && gatewayPort > 0 {
+		if registries := sanitizeRegistryMirrorList(routes.DockerRegistryMirrors); registries != "" {
+			args += fmt.Sprintf(" cleanroom_service_docker_registry_mirror_registries=%s", registries)
+		}
+	}
 	return args
+}
+
+func sanitizeRegistryMirrorList(registries []string) string {
+	out := make([]string, 0, len(registries))
+	for _, registry := range registries {
+		registry = strings.ToLower(strings.TrimSpace(registry))
+		if registry == "" {
+			continue
+		}
+		valid := true
+		for _, r := range registry {
+			isAlphaNum := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')
+			if !isAlphaNum && r != '.' && r != '-' && r != ':' {
+				valid = false
+				break
+			}
+		}
+		if valid {
+			out = append(out, registry)
+		}
+	}
+	return strings.Join(out, ",")
 }
 
 func sanitizeKernelArgValue(value string) string {

--- a/internal/backend/darwinvz/docker_bootargs_test.go
+++ b/internal/backend/darwinvz/docker_bootargs_test.go
@@ -43,6 +43,45 @@ func TestDockerServiceBootArgsUsesPolicyAndRuntimeSettings(t *testing.T) {
 	}
 }
 
+func TestDockerServiceBootArgsIncludesConfiguredRegistryMirrors(t *testing.T) {
+	compiled := &policy.CompiledPolicy{
+		Docker: policy.DockerService{Required: true},
+	}
+
+	got := dockerServiceBootArgs(compiled, backend.FirecrackerConfig{}, 8170, gateway.ProxyRoutes{
+		DockerHubMirror:       true,
+		DockerRegistryMirrors: []string{"public.ecr.aws", "ghcr.io", "bad/path"},
+	})
+	for _, want := range []string{
+		"cleanroom_service_docker_registry_mirror_host=gateway.cleanroom.internal",
+		"cleanroom_service_docker_registry_mirror_port=8170",
+		"cleanroom_service_docker_registry_mirror_registries=public.ecr.aws,ghcr.io",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %q in docker boot args %q", want, got)
+		}
+	}
+}
+
+func TestDockerServiceBootArgsConfiguredRegistryMirrorsCarryGatewayEndpoint(t *testing.T) {
+	compiled := &policy.CompiledPolicy{
+		Docker: policy.DockerService{Required: true},
+	}
+
+	got := dockerServiceBootArgs(compiled, backend.FirecrackerConfig{}, 8170, gateway.ProxyRoutes{
+		DockerRegistryMirrors: []string{"public.ecr.aws"},
+	})
+	for _, want := range []string{
+		"cleanroom_service_docker_registry_mirror_host=gateway.cleanroom.internal",
+		"cleanroom_service_docker_registry_mirror_port=8170",
+		"cleanroom_service_docker_registry_mirror_registries=public.ecr.aws",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %q in docker boot args %q", want, got)
+		}
+	}
+}
+
 func TestDockerServiceBootArgsSkipsMirrorWithoutLiveRoute(t *testing.T) {
 	compiled := &policy.CompiledPolicy{
 		Docker: policy.DockerService{Required: true},
@@ -54,5 +93,8 @@ func TestDockerServiceBootArgsSkipsMirrorWithoutLiveRoute(t *testing.T) {
 	}
 	if strings.Contains(got, "cleanroom_service_docker_registry_mirror_port") {
 		t.Fatalf("did not expect docker mirror port in boot args %q", got)
+	}
+	if strings.Contains(got, "cleanroom_service_docker_registry_mirror_registries") {
+		t.Fatalf("did not expect docker mirror registries in boot args %q", got)
 	}
 }

--- a/internal/backend/darwinvz/guest_init_script.go
+++ b/internal/backend/darwinvz/guest_init_script.go
@@ -180,9 +180,30 @@ if [ "$DOCKER_REQUIRED" = "1" ] && command -v dockerd >/dev/null 2>&1; then
   DOCKER_IPTABLES="$(arg_value cleanroom_service_docker_iptables || true)"
   DOCKER_MIRROR_HOST="$(arg_value cleanroom_service_docker_registry_mirror_host || true)"
   DOCKER_MIRROR_PORT="$(arg_value cleanroom_service_docker_registry_mirror_port || true)"
+  DOCKER_MIRROR_REGISTRIES="$(arg_value cleanroom_service_docker_registry_mirror_registries || true)"
   case "$DOCKER_MIRROR_PORT" in
     ''|*[!0-9]*) DOCKER_MIRROR_PORT="" ;;
   esac
+
+  if [ -n "$DOCKER_MIRROR_HOST" ] && [ -n "$DOCKER_MIRROR_PORT" ] && [ -n "$DOCKER_MIRROR_REGISTRIES" ]; then
+    old_ifs="$IFS"
+    IFS=','
+    for registry in $DOCKER_MIRROR_REGISTRIES; do
+      IFS="$old_ifs"
+      case "$registry" in
+        ''|*/*|*[[:space:]]*) ;;
+        *)
+          mirror_dir="/etc/docker/certs.d/$registry"
+          mkdir -p "$mirror_dir" 2>/dev/null || true
+          {
+            printf 'server = "http://%s:%s/registry/%s"\n' "$DOCKER_MIRROR_HOST" "$DOCKER_MIRROR_PORT" "$registry"
+          } > "$mirror_dir/hosts.toml" 2>/dev/null || true
+        ;;
+      esac
+      IFS=','
+    done
+    IFS="$old_ifs"
+  fi
 
   DOCKER_ARGS="--host=unix:///var/run/docker.sock --storage-driver=$DOCKER_STORAGE_DRIVER"
   if [ "$DOCKER_IPTABLES" = "0" ] || [ "$DOCKER_IPTABLES" = "false" ]; then

--- a/internal/backend/darwinvz/guest_init_script_test.go
+++ b/internal/backend/darwinvz/guest_init_script_test.go
@@ -109,11 +109,26 @@ func TestGuestInitScriptAutostartsDockerWhenAvailable(t *testing.T) {
 	if !strings.Contains(guestInitScriptTemplate, "DOCKER_MIRROR_PORT=\"$(arg_value cleanroom_service_docker_registry_mirror_port || true)\"") {
 		t.Fatal("expected docker registry mirror port boot arg lookup in init script")
 	}
+	if !strings.Contains(guestInitScriptTemplate, "DOCKER_MIRROR_REGISTRIES=\"$(arg_value cleanroom_service_docker_registry_mirror_registries || true)\"") {
+		t.Fatal("expected docker registry mirror registries boot arg lookup in init script")
+	}
 	if !strings.Contains(guestInitScriptTemplate, "--registry-mirror=http://$DOCKER_MIRROR_HOST:$DOCKER_MIRROR_PORT") {
 		t.Fatal("expected init script to configure dockerd registry mirror when provided")
 	}
 	if !strings.Contains(guestInitScriptTemplate, "--insecure-registry=$DOCKER_MIRROR_HOST:$DOCKER_MIRROR_PORT") {
 		t.Fatal("expected init script to mark the dockerd mirror as insecure for guest HTTP access")
+	}
+	if !strings.Contains(guestInitScriptTemplate, `mirror_dir="/etc/docker/certs.d/$registry"`) {
+		t.Fatal("expected init script to configure per-registry Docker host config")
+	}
+	if strings.Contains(guestInitScriptTemplate, `/etc/containerd/certs.d`) {
+		t.Fatal("expected init script to write registry host config where dockerd reads it")
+	}
+	if !strings.Contains(guestInitScriptTemplate, `printf 'server = "http://%s:%s/registry/%s"\n' "$DOCKER_MIRROR_HOST" "$DOCKER_MIRROR_PORT" "$registry"`) {
+		t.Fatal("expected init script to make the Cleanroom registry gateway path authoritative")
+	}
+	if strings.Contains(guestInitScriptTemplate, `printf 'server = "https://%s"\n' "$registry"`) {
+		t.Fatal("expected init script not to configure direct upstream fallback")
 	}
 
 	if !strings.Contains(guestInitScriptTemplate, "docker version >/dev/null 2>&1") {

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -236,9 +236,30 @@ if [ "$DOCKER_REQUIRED" = "1" ] && command -v dockerd >/dev/null 2>&1; then
   DOCKER_IPTABLES="$(arg_value cleanroom_service_docker_iptables || true)"
   DOCKER_MIRROR_HOST="$(arg_value cleanroom_service_docker_registry_mirror_host || true)"
   DOCKER_MIRROR_PORT="$(arg_value cleanroom_service_docker_registry_mirror_port || true)"
+  DOCKER_MIRROR_REGISTRIES="$(arg_value cleanroom_service_docker_registry_mirror_registries || true)"
   case "$DOCKER_MIRROR_PORT" in
     ''|*[!0-9]*) DOCKER_MIRROR_PORT="" ;;
   esac
+
+  if [ -n "$DOCKER_MIRROR_HOST" ] && [ -n "$DOCKER_MIRROR_PORT" ] && [ -n "$DOCKER_MIRROR_REGISTRIES" ]; then
+    old_ifs="$IFS"
+    IFS=','
+    for registry in $DOCKER_MIRROR_REGISTRIES; do
+      IFS="$old_ifs"
+      case "$registry" in
+        ''|*/*|*[[:space:]]*) ;;
+        *)
+          mirror_dir="/etc/docker/certs.d/$registry"
+          mkdir -p "$mirror_dir" 2>/dev/null || true
+          {
+            printf 'server = "http://%s:%s/registry/%s"\n' "$DOCKER_MIRROR_HOST" "$DOCKER_MIRROR_PORT" "$registry"
+          } > "$mirror_dir/hosts.toml" 2>/dev/null || true
+        ;;
+      esac
+      IFS=','
+    done
+    IFS="$old_ifs"
+  fi
 
   DOCKER_ARGS="--host=unix:///var/run/docker.sock --storage-driver=$DOCKER_STORAGE_DRIVER"
   if [ "$DOCKER_IPTABLES" = "0" ] || [ "$DOCKER_IPTABLES" = "false" ]; then
@@ -2580,7 +2601,7 @@ func dockerServiceBootArgs(compiled *policy.CompiledPolicy, cfg backend.Firecrac
 		storageDriver,
 		iptables,
 	)
-	if routes.DockerHubMirror && gatewayPort > 0 {
+	if (routes.DockerHubMirror || len(routes.DockerRegistryMirrors) > 0) && gatewayPort > 0 {
 		host := sanitizeKernelArgValue(gateway.GuestGatewayHostname)
 		if host != "" {
 			args += fmt.Sprintf(
@@ -2590,7 +2611,34 @@ func dockerServiceBootArgs(compiled *policy.CompiledPolicy, cfg backend.Firecrac
 			)
 		}
 	}
+	if len(routes.DockerRegistryMirrors) > 0 && gatewayPort > 0 {
+		if registries := sanitizeRegistryMirrorList(routes.DockerRegistryMirrors); registries != "" {
+			args += fmt.Sprintf(" cleanroom_service_docker_registry_mirror_registries=%s", registries)
+		}
+	}
 	return args
+}
+
+func sanitizeRegistryMirrorList(registries []string) string {
+	out := make([]string, 0, len(registries))
+	for _, registry := range registries {
+		registry = strings.ToLower(strings.TrimSpace(registry))
+		if registry == "" {
+			continue
+		}
+		valid := true
+		for _, r := range registry {
+			isAlphaNum := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')
+			if !isAlphaNum && r != '.' && r != '-' && r != ':' {
+				valid = false
+				break
+			}
+		}
+		if valid {
+			out = append(out, registry)
+		}
+	}
+	return strings.Join(out, ",")
 }
 
 func sanitizeKernelArgValue(value string) string {

--- a/internal/backend/firecracker/docker_bootargs_test.go
+++ b/internal/backend/firecracker/docker_bootargs_test.go
@@ -41,6 +41,45 @@ func TestDockerServiceBootArgsUsesPolicyAndRuntimeSettings(t *testing.T) {
 	}
 }
 
+func TestDockerServiceBootArgsIncludesConfiguredRegistryMirrors(t *testing.T) {
+	compiled := &policy.CompiledPolicy{
+		Docker: policy.DockerService{Required: true},
+	}
+
+	got := dockerServiceBootArgs(compiled, backend.FirecrackerConfig{}, 8170, gateway.ProxyRoutes{
+		DockerHubMirror:       true,
+		DockerRegistryMirrors: []string{"public.ecr.aws", "ghcr.io", "bad/path"},
+	})
+	for _, want := range []string{
+		"cleanroom_service_docker_registry_mirror_host=gateway.cleanroom.internal",
+		"cleanroom_service_docker_registry_mirror_port=8170",
+		"cleanroom_service_docker_registry_mirror_registries=public.ecr.aws,ghcr.io",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %q in docker boot args %q", want, got)
+		}
+	}
+}
+
+func TestDockerServiceBootArgsConfiguredRegistryMirrorsCarryGatewayEndpoint(t *testing.T) {
+	compiled := &policy.CompiledPolicy{
+		Docker: policy.DockerService{Required: true},
+	}
+
+	got := dockerServiceBootArgs(compiled, backend.FirecrackerConfig{}, 8170, gateway.ProxyRoutes{
+		DockerRegistryMirrors: []string{"public.ecr.aws"},
+	})
+	for _, want := range []string{
+		"cleanroom_service_docker_registry_mirror_host=gateway.cleanroom.internal",
+		"cleanroom_service_docker_registry_mirror_port=8170",
+		"cleanroom_service_docker_registry_mirror_registries=public.ecr.aws",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %q in docker boot args %q", want, got)
+		}
+	}
+}
+
 func TestDockerServiceBootArgsUsesSafeDefaults(t *testing.T) {
 	compiled := &policy.CompiledPolicy{
 		Docker: policy.DockerService{Required: true},
@@ -68,5 +107,8 @@ func TestDockerServiceBootArgsSkipsMirrorWithoutLiveRoute(t *testing.T) {
 	}
 	if strings.Contains(got, "cleanroom_service_docker_registry_mirror_port") {
 		t.Fatalf("did not expect docker mirror port in boot args %q", got)
+	}
+	if strings.Contains(got, "cleanroom_service_docker_registry_mirror_registries") {
+		t.Fatalf("did not expect docker mirror registries in boot args %q", got)
 	}
 }

--- a/internal/backend/firecracker/guest_init_script_test.go
+++ b/internal/backend/firecracker/guest_init_script_test.go
@@ -24,11 +24,26 @@ func TestGuestInitScriptAutostartsDockerWhenAvailable(t *testing.T) {
 	if !strings.Contains(guestInitScriptTemplate, "DOCKER_MIRROR_PORT=\"$(arg_value cleanroom_service_docker_registry_mirror_port || true)\"") {
 		t.Fatal("expected docker registry mirror port boot arg lookup in init script")
 	}
+	if !strings.Contains(guestInitScriptTemplate, "DOCKER_MIRROR_REGISTRIES=\"$(arg_value cleanroom_service_docker_registry_mirror_registries || true)\"") {
+		t.Fatal("expected docker registry mirror registries boot arg lookup in init script")
+	}
 	if !strings.Contains(guestInitScriptTemplate, "--registry-mirror=http://$DOCKER_MIRROR_HOST:$DOCKER_MIRROR_PORT") {
 		t.Fatal("expected init script to configure dockerd registry mirror when provided")
 	}
 	if !strings.Contains(guestInitScriptTemplate, "--insecure-registry=$DOCKER_MIRROR_HOST:$DOCKER_MIRROR_PORT") {
 		t.Fatal("expected init script to mark the dockerd mirror as insecure for guest HTTP access")
+	}
+	if !strings.Contains(guestInitScriptTemplate, `mirror_dir="/etc/docker/certs.d/$registry"`) {
+		t.Fatal("expected init script to configure per-registry Docker host config")
+	}
+	if strings.Contains(guestInitScriptTemplate, `/etc/containerd/certs.d`) {
+		t.Fatal("expected init script to write registry host config where dockerd reads it")
+	}
+	if !strings.Contains(guestInitScriptTemplate, `printf 'server = "http://%s:%s/registry/%s"\n' "$DOCKER_MIRROR_HOST" "$DOCKER_MIRROR_PORT" "$registry"`) {
+		t.Fatal("expected init script to make the Cleanroom registry gateway path authoritative")
+	}
+	if strings.Contains(guestInitScriptTemplate, `printf 'server = "https://%s"\n' "$registry"`) {
+		t.Fatal("expected init script not to configure direct upstream fallback")
 	}
 	if !strings.Contains(guestInitScriptTemplate, "docker version >/dev/null 2>&1") {
 		t.Fatal("expected init script to wait for dockerd API readiness")

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -137,10 +137,11 @@ func (s *ServeCommand) runServer(ctx *runtimeContext) error {
 	}
 
 	configureGatewayBackends(ctx.Backends, gwRegistry, gwPort, gwServer.Addr(), darwinGatewayHost, gateway.ProxyRoutes{
-		DockerHubMirror: contentCache != nil && contentCache.HasOCIHandler(),
-		RubyGems:        contentCache != nil && contentCache.HasRubyGemsHandler(),
-		GoProxy:         contentCache != nil && contentCache.HasGoProxyHandler() && contentCache.HasSumDBHandler(),
-		Fetch:           contentCache != nil && contentCache.FetchAllowsHost("dl.google.com"),
+		DockerHubMirror:       contentCache != nil && contentCache.HasOCIHandler(),
+		DockerRegistryMirrors: dockerRegistryMirrorHosts(contentCache),
+		RubyGems:              contentCache != nil && contentCache.HasRubyGemsHandler(),
+		GoProxy:               contentCache != nil && contentCache.HasGoProxyHandler() && contentCache.HasSumDBHandler(),
+		Fetch:                 contentCache != nil && contentCache.FetchAllowsHost("dl.google.com"),
 	})
 
 	if fcAdapter, ok := ctx.Backends["firecracker"].(*firecracker.Adapter); ok && fcAdapter.GatewayRegistry != nil {
@@ -270,6 +271,13 @@ func configureBackendLogging(backends map[string]backend.Adapter, logger *log.Lo
 			observability.LogFieldBackend, "firecracker",
 		)
 	}
+}
+
+func dockerRegistryMirrorHosts(contentCache *gateway.ContentCache) []string {
+	if contentCache == nil || !contentCache.HasOCIHandler() {
+		return nil
+	}
+	return contentCache.OCIMirrorHosts()
 }
 
 func configureGatewayBackends(backends map[string]backend.Adapter, gwRegistry *gateway.Registry, gwPort int, gwListenAddr, darwinGatewayHost string, routes gateway.ProxyRoutes) {

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -73,7 +73,13 @@ func TestConfigureGatewayBackendsConfiguresDarwinVZGateway(t *testing.T) {
 		"darwin-vz":   darwinAdapter,
 	}
 
-	configureGatewayBackends(backends, gwRegistry, 8170, "0.0.0.0:8170", "192.168.64.1", gateway.ProxyRoutes{DockerHubMirror: true, RubyGems: true, GoProxy: true, Fetch: true})
+	configureGatewayBackends(backends, gwRegistry, 8170, "0.0.0.0:8170", "192.168.64.1", gateway.ProxyRoutes{
+		DockerHubMirror:       true,
+		DockerRegistryMirrors: []string{"ghcr.io"},
+		RubyGems:              true,
+		GoProxy:               true,
+		Fetch:                 true,
+	})
 
 	if fcAdapter.GatewayRegistry == nil {
 		t.Fatal("expected firecracker adapter to use the host gateway registry")
@@ -83,6 +89,9 @@ func TestConfigureGatewayBackendsConfiguresDarwinVZGateway(t *testing.T) {
 	}
 	if !fcAdapter.GatewayRoutes.DockerHubMirror {
 		t.Fatal("expected firecracker adapter to receive live docker hub mirror state")
+	}
+	if got, want := fcAdapter.GatewayRoutes.DockerRegistryMirrors, []string{"ghcr.io"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected firecracker docker registry mirrors: got %v want %v", got, want)
 	}
 	if !fcAdapter.GatewayRoutes.RubyGems {
 		t.Fatal("expected firecracker adapter to receive live rubygems route state")
@@ -104,6 +113,9 @@ func TestConfigureGatewayBackendsConfiguresDarwinVZGateway(t *testing.T) {
 	}
 	if !darwinAdapter.GatewayRoutes.DockerHubMirror {
 		t.Fatal("expected darwin-vz adapter to receive live docker hub mirror state")
+	}
+	if got, want := darwinAdapter.GatewayRoutes.DockerRegistryMirrors, []string{"ghcr.io"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected darwin-vz docker registry mirrors: got %v want %v", got, want)
 	}
 	if !darwinAdapter.GatewayRoutes.RubyGems {
 		t.Fatal("expected darwin-vz adapter to receive live rubygems route state")

--- a/internal/gateway/contentcache.go
+++ b/internal/gateway/contentcache.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -209,9 +210,10 @@ func NewContentCache(cfg ContentCacheConfig) (*ContentCache, error) {
 	}
 
 	cache := &ContentCache{
-		closer:      db,
-		gitHandlers: make(map[string]http.Handler),
-		ociHandlers: make(map[string]ociHandlerEntry),
+		closer:         db,
+		gitHandlers:    make(map[string]http.Handler),
+		ociHandlers:    make(map[string]ociHandlerEntry),
+		ociMirrorHosts: configuredOCIMirrorHosts(cfg.OCIRegistries),
 	}
 	goProxyUpstreamURL := strings.TrimSpace(ccgoproxy.DefaultUpstreamURL)
 	goProxyPolicyHost, goProxyPolicyPort, err := registryHostPort(goProxyUpstreamURL)
@@ -460,6 +462,36 @@ func normalizeOCIRegistryMappings(registries map[string]string) (map[string]stri
 		out[normalizedPrefix] = normalizedURL
 	}
 	return out, nil
+}
+
+func configuredOCIMirrorHosts(registries map[string]string) []string {
+	if len(registries) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(registries))
+	seen := make(map[string]struct{}, len(registries))
+	for prefix := range registries {
+		normalizedPrefix := strings.ToLower(strings.TrimSpace(prefix))
+		if normalizedPrefix == "" || strings.Contains(normalizedPrefix, "/") || !isRegistryHostPrefix(normalizedPrefix) || isDockerHubMirrorPrefix(normalizedPrefix) {
+			continue
+		}
+		if _, ok := seen[normalizedPrefix]; ok {
+			continue
+		}
+		seen[normalizedPrefix] = struct{}{}
+		out = append(out, normalizedPrefix)
+	}
+	slices.Sort(out)
+	return out
+}
+
+func isDockerHubMirrorPrefix(prefix string) bool {
+	switch strings.ToLower(strings.TrimSpace(prefix)) {
+	case "docker.io", "index.docker.io", "registry-1.docker.io":
+		return true
+	default:
+		return false
+	}
 }
 
 func resolveOCIRegistryRoute(prefix string, registries map[string]string) (ociRoute, error) {

--- a/internal/gateway/contentcache_test.go
+++ b/internal/gateway/contentcache_test.go
@@ -20,6 +20,29 @@ func registryTestScopeWithRules(rules ...policy.AllowRule) *SandboxScope {
 	}
 }
 
+func TestConfiguredOCIMirrorHostsOnlyIncludesConfiguredNonDockerHubRegistries(t *testing.T) {
+	t.Parallel()
+
+	got := configuredOCIMirrorHosts(map[string]string{
+		"ghcr.io":            "https://ghcr.io",
+		" public.ecr.aws ":   " https://public.ecr.aws ",
+		"docker.io":          "https://registry-1.docker.io",
+		"index.docker.io":    "https://registry-1.docker.io",
+		"registry.internal/": "https://registry.internal",
+		"":                   "https://example.invalid",
+	})
+
+	want := []string{"ghcr.io", "public.ecr.aws"}
+	if len(got) != len(want) {
+		t.Fatalf("unexpected mirror host count: got %v want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("unexpected mirror host at %d: got %q want %q (all: %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
 func TestNewGitContentCacheHTTPClientDoesNotFollowRedirects(t *testing.T) {
 	t.Parallel()
 

--- a/internal/gateway/contentcache_types.go
+++ b/internal/gateway/contentcache_types.go
@@ -87,6 +87,7 @@ type ContentCache struct {
 	ociHandlers     map[string]ociHandlerEntry
 	buildOCIHandler ociHandlerFactory
 	resolveOCIRoute ociRouteResolver
+	ociMirrorHosts  []string
 
 	goProxy  goProxyHandlerEntry
 	sumdb    sumDBHandlerEntry
@@ -172,6 +173,17 @@ func (c *ContentCache) GitHandlerForHost(host string) (http.Handler, error) {
 // HasOCIHandler reports whether OCI caching is configured.
 func (c *ContentCache) HasOCIHandler() bool {
 	return c != nil && c.buildOCIHandler != nil
+}
+
+// OCIMirrorHosts returns the runtime-configured registry hosts that are safe to
+// expose to guest container runtimes as explicit registry mirrors.
+func (c *ContentCache) OCIMirrorHosts() []string {
+	if c == nil || len(c.ociMirrorHosts) == 0 {
+		return nil
+	}
+	out := make([]string, len(c.ociMirrorHosts))
+	copy(out, c.ociMirrorHosts)
+	return out
 }
 
 // HasGoProxyHandler reports whether Go module proxy caching is configured.

--- a/internal/gateway/git_proxy_env.go
+++ b/internal/gateway/git_proxy_env.go
@@ -35,10 +35,11 @@ const (
 
 // ProxyRoutes describes which gateway-backed guest proxy routes are live.
 type ProxyRoutes struct {
-	DockerHubMirror bool
-	RubyGems        bool
-	GoProxy         bool
-	Fetch           bool
+	DockerHubMirror       bool
+	DockerRegistryMirrors []string
+	RubyGems              bool
+	GoProxy               bool
+	Fetch                 bool
 }
 
 // GitProxyEnvVars returns git config environment variables that rewrite allowed


### PR DESCRIPTION
## Problem

Cleanroom already routes Docker Hub pulls from guest `dockerd` through the host gateway OCI cache, but configured non-Docker-Hub registries such as `public.ecr.aws` and `ghcr.io` were not exposed to guest Docker. Those pulls could bypass the host gateway cache path or fail when direct upstream egress was denied.

## Changes

- Carry runtime-configured `gateway.oci.registries` hosts into backend Docker service boot args.
- Generate guest Docker registry host config for configured non-Docker-Hub registries so `dockerd` uses `http://gateway.cleanroom.internal:8170/registry/<host>`.
- Keep Docker Hub on the existing `/v2/` registry mirror behavior.
- Exclude Docker Hub aliases and invalid/path-like keys from generated non-Hub mirror config.
- Document the runtime config shape and policy implications, including that configured non-Hub Docker registry config has no direct upstream fallback inside `dockerd`.

## Validation

- `mise exec -- go test ./internal/backend/firecracker ./internal/backend/darwinvz`
- `mise exec -- go test ./...`
- `git diff --check`