### PR TITLE
feat: Publish dependency block volume caches

### DIFF
--- a/docs/plans/dependency-service-volume-caches.md
+++ b/docs/plans/dependency-service-volume-caches.md
@@ -1,7 +1,7 @@
 # Dependency and Service Volume Cache Plan
 
 **Spec reference:** `spec.md` sections 5.1.1, 5.2, 6.4
-**Status:** Proposed
+**Status:** In implementation
 **Last reviewed:** 2026-05-03
 
 ## Summary
@@ -935,12 +935,37 @@ Completed in phase 6:
   block-volume runtime path is selected, because declared directory outputs are
   mounted from sidecar volumes and would not be captured by a rootfs snapshot
 
-Remaining runtime work after phase 6:
+### Phase 7 PR Status
 
-- publish a replacement cache artifact for dependency block misses; until then
-  this path is execution substrate rather than reusable block-volume caching
+The seventh implementation PR adds dependency block cache publication plumbing.
+This is the first slice that can write `dependency-volume` cache metadata for
+missed dependency blocks, but the end-to-end Firecracker path remains gated by
+the existing block-volume runtime decision. Firecracker can snapshot attached
+cache output volumes now, but it still does not advertise
+`sandbox.overlay_write_capture`, so the default runtime does not publish
+file-keyed dependency volume caches until escaped-write capture is wired.
+
+Completed in phase 7:
+
+- backend adapters can implement `SnapshotCacheOutputVolumes` for cache output
+  volumes attached to a running persistent sandbox
+- Firecracker keeps prepared cache output volume handles on the sandbox instance
+  and can sync the guest, pause the VM, snapshot requested output volumes, clean
+  up partial snapshots on failure, and resume the VM
+- after dependency block misses run successfully, control-service snapshots
+  directory-only dependency output volumes and persists `dependency-volume`
+  records with block input, command, environment, output, prior-block, runtime,
+  and storage metadata
+- dependency block cache publication is wired for both restored-workspace and
+  fresh-provision dependency bootstrap paths
+- dependency blocks with `outputs.files` are explicitly skipped for publication
+  until file output capture/materialization is implemented
+- exact full-rootfs dependency-stage publication remains skipped whenever the
+  block-volume runtime path is selected
+
+Remaining runtime work after phase 7:
+
 - inspect overlay write capture results and warn/fallback on escaped writes
-- snapshot and publish dependency output records after successful missed blocks
 - materialize captured dependency file outputs into both the output volume and
   sandbox root after a missed block run
 - run missed service blocks from isolated input projections

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -171,6 +171,13 @@ type SnapshottingAdapter interface {
 	DeleteSnapshot(ctx context.Context, req DeleteSnapshotRequest) error
 }
 
+// CacheOutputVolumeSnapshotter snapshots cache output volumes that were
+// attached to an already-provisioned sandbox.
+type CacheOutputVolumeSnapshotter interface {
+	Adapter
+	SnapshotCacheOutputVolumes(ctx context.Context, req SnapshotCacheOutputVolumesRequest) (*SnapshotCacheOutputVolumesResult, error)
+}
+
 // RuntimeBaseKeyProvider returns a stable identifier for the backend runtime
 // base that a reusable workspace stage depends on.
 type RuntimeBaseKeyProvider interface {
@@ -251,6 +258,37 @@ type SnapshotRequest struct {
 }
 
 type SnapshotResult struct {
+	StorageRef         string
+	StorageSizeBytes   int64
+	ExclusiveSizeBytes int64
+	DriverMetadata     string
+}
+
+type SnapshotCacheOutputVolumesRequest struct {
+	SandboxID string
+	Volumes   []CacheOutputVolumeSnapshotRequest
+	FirecrackerConfig
+}
+
+type CacheOutputVolumeSnapshotRequest struct {
+	Stage      string
+	BlockName  string
+	CacheKey   string
+	VolumeID   string
+	SnapshotID string
+}
+
+type SnapshotCacheOutputVolumesResult struct {
+	Volumes []CacheOutputVolumeSnapshot
+}
+
+type CacheOutputVolumeSnapshot struct {
+	Stage              string
+	BlockName          string
+	CacheKey           string
+	VolumeID           string
+	SnapshotID         string
+	StorageDriver      string
 	StorageRef         string
 	StorageSizeBytes   int64
 	ExclusiveSizeBytes int64

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -88,27 +88,28 @@ type gatewayRegistry interface {
 }
 
 type sandboxInstance struct {
-	SandboxID         string
-	RunDir            string
-	ConfigPath        string
-	VsockPath         string
-	GuestPort         uint32
-	Policy            *policy.CompiledPolicy
-	ImageRef          string
-	ImageDigest       string
-	CommandTimeout    int64
-	HostIP            string
-	GuestIP           string
-	fcCmd             *exec.Cmd
-	exitedCh          chan struct{}
-	exitMu            sync.RWMutex
-	exitErr           error
-	exitReady         bool
-	cleanupNetwork    func()
-	cleanupVolume     func()
-	vmRootFSPath      string
-	volumeRef         string
-	cacheOutputMounts []vsockexec.CacheOutputMount
+	SandboxID          string
+	RunDir             string
+	ConfigPath         string
+	VsockPath          string
+	GuestPort          uint32
+	Policy             *policy.CompiledPolicy
+	ImageRef           string
+	ImageDigest        string
+	CommandTimeout     int64
+	HostIP             string
+	GuestIP            string
+	fcCmd              *exec.Cmd
+	exitedCh           chan struct{}
+	exitMu             sync.RWMutex
+	exitErr            error
+	exitReady          bool
+	cleanupNetwork     func()
+	cleanupVolume      func()
+	vmRootFSPath       string
+	volumeRef          string
+	cacheOutputMounts  []vsockexec.CacheOutputMount
+	cacheOutputVolumes []preparedCacheOutputVolume
 
 	warnings backend.WarningEmitter
 }
@@ -1950,24 +1951,25 @@ func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID strin
 	}
 
 	instance := &sandboxInstance{
-		SandboxID:         sandboxID,
-		RunDir:            runDir,
-		ConfigPath:        configPath,
-		VsockPath:         vsockPath,
-		GuestPort:         cfg.GuestPort,
-		Policy:            compiled,
-		ImageRef:          compiled.ImageRef,
-		ImageDigest:       compiled.ImageDigest,
-		CommandTimeout:    cfg.LaunchSeconds,
-		HostIP:            networkCfg.HostIP,
-		GuestIP:           networkCfg.GuestIP,
-		fcCmd:             fcCmd,
-		exitedCh:          make(chan struct{}),
-		cleanupNetwork:    cleanupNetwork,
-		cleanupVolume:     cleanupStorage,
-		vmRootFSPath:      vmRootFSPath,
-		volumeRef:         writableVolume.Ref,
-		cacheOutputMounts: cacheOutputVolumeMounts(cacheOutputVolumes),
+		SandboxID:          sandboxID,
+		RunDir:             runDir,
+		ConfigPath:         configPath,
+		VsockPath:          vsockPath,
+		GuestPort:          cfg.GuestPort,
+		Policy:             compiled,
+		ImageRef:           compiled.ImageRef,
+		ImageDigest:        compiled.ImageDigest,
+		CommandTimeout:     cfg.LaunchSeconds,
+		HostIP:             networkCfg.HostIP,
+		GuestIP:            networkCfg.GuestIP,
+		fcCmd:              fcCmd,
+		exitedCh:           make(chan struct{}),
+		cleanupNetwork:     cleanupNetwork,
+		cleanupVolume:      cleanupStorage,
+		vmRootFSPath:       vmRootFSPath,
+		volumeRef:          writableVolume.Ref,
+		cacheOutputMounts:  cacheOutputVolumeMounts(cacheOutputVolumes),
+		cacheOutputVolumes: cacheOutputVolumes,
 	}
 	instanceRef.Store(instance)
 	go func() {

--- a/internal/backend/firecracker/cache_output_volumes.go
+++ b/internal/backend/firecracker/cache_output_volumes.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/buildkite/cleanroom/internal/backend"
 	"github.com/buildkite/cleanroom/internal/ext4image"
@@ -22,6 +23,7 @@ import (
 
 const defaultCacheOutputVolumeMinimumBytes int64 = 512 << 20
 const cacheOutputGuestMountRoot = "/run/cleanroom/cache-output-volumes"
+const cacheOutputSnapshotCleanupTimeout = 10 * time.Second
 
 var (
 	cacheOutputVolumeMinimumBytes     = defaultCacheOutputVolumeMinimumBytes
@@ -75,19 +77,19 @@ func (a *Adapter) SnapshotCacheOutputVolumes(ctx context.Context, req backend.Sn
 	}
 	snapshotLogger := observability.WithLoggerFields(observability.WithTraceContext(baseFirecrackerLogger(a.Logger), ctx), observability.LogFieldSandboxID, sandboxID)
 	created := make([]backend.CacheOutputVolumeSnapshot, 0, len(req.Volumes))
-	paused := true
+	var cleanupAfterResume []backend.CacheOutputVolumeSnapshot
 	defer func() {
-		if !paused {
-			return
+		resumeErr := resumeSandboxProcess(instance)
+		if resumeErr != nil && retErr == nil {
+			cleanupAfterResume = append(cleanupAfterResume, created...)
 		}
-		if err := resumeSandboxProcess(instance); err != nil && retErr == nil {
-			cleanupErr := cleanupCacheOutputVolumeSnapshots(context.Background(), snapshotLogger, req.FirecrackerConfig, created)
+		if cleanupErr := cleanupCacheOutputVolumeSnapshotsWithTimeout(snapshotLogger, req.FirecrackerConfig, cleanupAfterResume); cleanupErr != nil {
 			result = nil
-			if cleanupErr != nil {
-				retErr = fmt.Errorf("resume firecracker sandbox after cache output snapshot: %w (cleanup snapshots failed: %v)", err, cleanupErr)
-				return
-			}
-			retErr = fmt.Errorf("resume firecracker sandbox after cache output snapshot: %w", err)
+			retErr = errors.Join(retErr, fmt.Errorf("cleanup cache output snapshots after failure: %w", cleanupErr))
+		}
+		if resumeErr != nil {
+			result = nil
+			retErr = errors.Join(retErr, fmt.Errorf("resume firecracker sandbox after cache output snapshot: %w", resumeErr))
 		}
 	}()
 
@@ -96,16 +98,22 @@ func (a *Adapter) SnapshotCacheOutputVolumes(ctx context.Context, req backend.Sn
 	for i, volumeReq := range req.Volumes {
 		snapshot, err := snapshotCacheOutputVolume(ctx, snapshotLogger, req.FirecrackerConfig, volumesByID, flushedDrivers, volumeReq)
 		if err != nil {
-			cleanupErr := cleanupCacheOutputVolumeSnapshots(context.Background(), snapshotLogger, req.FirecrackerConfig, created)
-			if cleanupErr != nil {
-				return nil, fmt.Errorf("snapshot cache output volume %d: %w (cleanup snapshots failed: %v)", i, err, cleanupErr)
-			}
+			cleanupAfterResume = append(cleanupAfterResume, created...)
 			return nil, fmt.Errorf("snapshot cache output volume %d: %w", i, err)
 		}
 		created = append(created, snapshot)
 		out.Volumes = append(out.Volumes, snapshot)
 	}
 	return out, nil
+}
+
+func cleanupCacheOutputVolumeSnapshotsWithTimeout(logger *charmlog.Logger, cfg backend.FirecrackerConfig, snapshots []backend.CacheOutputVolumeSnapshot) error {
+	if len(snapshots) == 0 {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), cacheOutputSnapshotCleanupTimeout)
+	defer cancel()
+	return cleanupCacheOutputVolumeSnapshots(ctx, logger, cfg, snapshots)
 }
 
 func snapshotCacheOutputVolume(

--- a/internal/backend/firecracker/cache_output_volumes.go
+++ b/internal/backend/firecracker/cache_output_volumes.go
@@ -14,6 +14,7 @@ import (
 	"github.com/buildkite/cleanroom/internal/backend"
 	"github.com/buildkite/cleanroom/internal/ext4image"
 	"github.com/buildkite/cleanroom/internal/hosttools"
+	"github.com/buildkite/cleanroom/internal/observability"
 	"github.com/buildkite/cleanroom/internal/volumestore"
 	"github.com/buildkite/cleanroom/internal/vsockexec"
 	charmlog "github.com/charmbracelet/log"
@@ -31,6 +32,172 @@ type preparedCacheOutputVolume struct {
 	Spec   backend.CacheOutputVolumeSpec
 	Drive  drive
 	Volume volumestore.WritableVolume
+}
+
+func (a *Adapter) SnapshotCacheOutputVolumes(ctx context.Context, req backend.SnapshotCacheOutputVolumesRequest) (result *backend.SnapshotCacheOutputVolumesResult, retErr error) {
+	sandboxID := strings.TrimSpace(req.SandboxID)
+	if sandboxID == "" {
+		return nil, errors.New("missing sandbox_id")
+	}
+	if len(req.Volumes) == 0 {
+		return &backend.SnapshotCacheOutputVolumesResult{}, nil
+	}
+
+	a.sandboxMu.Lock()
+	instance, ok := a.sandboxes[sandboxID]
+	a.sandboxMu.Unlock()
+	if !ok {
+		return nil, fmt.Errorf("unknown sandbox %q", sandboxID)
+	}
+	if err := instance.exitedErrOrNil(); err != nil {
+		return nil, fmt.Errorf("sandbox %q is not running: %w", sandboxID, err)
+	}
+
+	volumesByID := make(map[string]preparedCacheOutputVolume, len(instance.cacheOutputVolumes))
+	for _, volume := range instance.cacheOutputVolumes {
+		volumesByID[strings.TrimSpace(volume.Spec.VolumeID)] = volume
+	}
+
+	syncResp, _, err := a.executeInSandbox(ctx, instance, snapshotSyncTimeoutSeconds, []string{"sync"}, "", nil, false, nil, false, backend.OutputStream{})
+	if err != nil {
+		return nil, fmt.Errorf("sync sandbox filesystem before cache output snapshot: %w", err)
+	}
+	if syncResp.ExitCode != 0 {
+		guestErr := strings.TrimSpace(syncResp.Error)
+		if guestErr != "" {
+			return nil, fmt.Errorf("sync sandbox filesystem before cache output snapshot: guest sync command exited with code %d: %s", syncResp.ExitCode, guestErr)
+		}
+		return nil, fmt.Errorf("sync sandbox filesystem before cache output snapshot: guest sync command exited with code %d", syncResp.ExitCode)
+	}
+
+	if err := pauseSandboxProcess(instance); err != nil {
+		return nil, err
+	}
+	snapshotLogger := observability.WithLoggerFields(observability.WithTraceContext(baseFirecrackerLogger(a.Logger), ctx), observability.LogFieldSandboxID, sandboxID)
+	created := make([]backend.CacheOutputVolumeSnapshot, 0, len(req.Volumes))
+	paused := true
+	defer func() {
+		if !paused {
+			return
+		}
+		if err := resumeSandboxProcess(instance); err != nil && retErr == nil {
+			cleanupErr := cleanupCacheOutputVolumeSnapshots(context.Background(), snapshotLogger, req.FirecrackerConfig, created)
+			result = nil
+			if cleanupErr != nil {
+				retErr = fmt.Errorf("resume firecracker sandbox after cache output snapshot: %w (cleanup snapshots failed: %v)", err, cleanupErr)
+				return
+			}
+			retErr = fmt.Errorf("resume firecracker sandbox after cache output snapshot: %w", err)
+		}
+	}()
+
+	flushedDrivers := map[string]struct{}{}
+	out := &backend.SnapshotCacheOutputVolumesResult{Volumes: make([]backend.CacheOutputVolumeSnapshot, 0, len(req.Volumes))}
+	for i, volumeReq := range req.Volumes {
+		snapshot, err := snapshotCacheOutputVolume(ctx, snapshotLogger, req.FirecrackerConfig, volumesByID, flushedDrivers, volumeReq)
+		if err != nil {
+			cleanupErr := cleanupCacheOutputVolumeSnapshots(context.Background(), snapshotLogger, req.FirecrackerConfig, created)
+			if cleanupErr != nil {
+				return nil, fmt.Errorf("snapshot cache output volume %d: %w (cleanup snapshots failed: %v)", i, err, cleanupErr)
+			}
+			return nil, fmt.Errorf("snapshot cache output volume %d: %w", i, err)
+		}
+		created = append(created, snapshot)
+		out.Volumes = append(out.Volumes, snapshot)
+	}
+	return out, nil
+}
+
+func snapshotCacheOutputVolume(
+	ctx context.Context,
+	logger *charmlog.Logger,
+	cfg backend.FirecrackerConfig,
+	volumesByID map[string]preparedCacheOutputVolume,
+	flushedDrivers map[string]struct{},
+	req backend.CacheOutputVolumeSnapshotRequest,
+) (backend.CacheOutputVolumeSnapshot, error) {
+	volumeID := strings.TrimSpace(req.VolumeID)
+	if volumeID == "" {
+		return backend.CacheOutputVolumeSnapshot{}, errors.New("missing volume id")
+	}
+	snapshotID := strings.TrimSpace(req.SnapshotID)
+	if snapshotID == "" {
+		return backend.CacheOutputVolumeSnapshot{}, fmt.Errorf("cache output volume %q missing snapshot id", volumeID)
+	}
+	prepared, ok := volumesByID[volumeID]
+	if !ok {
+		return backend.CacheOutputVolumeSnapshot{}, fmt.Errorf("cache output volume %q is not attached", volumeID)
+	}
+	volumeRef := strings.TrimSpace(prepared.Volume.Ref)
+	if volumeRef == "" {
+		return backend.CacheOutputVolumeSnapshot{}, fmt.Errorf("cache output volume %q has no snapshot-capable ref", volumeID)
+	}
+
+	driverCfg, err := snapshotConfigForStorageRef(cfg, volumeRef)
+	if err != nil {
+		return backend.CacheOutputVolumeSnapshot{}, err
+	}
+	if err := validateSnapshotStorageConfig(driverCfg); err != nil {
+		return backend.CacheOutputVolumeSnapshot{}, err
+	}
+	driverName := normalizedSnapshotDriverName(driverCfg)
+	if _, ok := flushedDrivers[driverName]; !ok {
+		if err := flushSnapshotHostFilesystem(ctx, driverName); err != nil {
+			return backend.CacheOutputVolumeSnapshot{}, err
+		}
+		flushedDrivers[driverName] = struct{}{}
+	}
+
+	result, err := createSnapshotStorage(ctx, logger, driverCfg, snapshotID, volumeRef)
+	if err != nil {
+		return backend.CacheOutputVolumeSnapshot{}, err
+	}
+	if result == nil {
+		return backend.CacheOutputVolumeSnapshot{}, errors.New("snapshot storage returned no result")
+	}
+	storageRef := strings.TrimSpace(result.StorageRef)
+	if storageRef == "" {
+		return backend.CacheOutputVolumeSnapshot{}, errors.New("snapshot storage returned empty storage ref")
+	}
+	return backend.CacheOutputVolumeSnapshot{
+		Stage:              strings.TrimSpace(req.Stage),
+		BlockName:          strings.TrimSpace(req.BlockName),
+		CacheKey:           strings.TrimSpace(req.CacheKey),
+		VolumeID:           volumeID,
+		SnapshotID:         snapshotID,
+		StorageDriver:      driverName,
+		StorageRef:         storageRef,
+		StorageSizeBytes:   result.StorageSizeBytes,
+		ExclusiveSizeBytes: result.ExclusiveSizeBytes,
+		DriverMetadata:     strings.TrimSpace(result.DriverMetadata),
+	}, nil
+}
+
+func cleanupCacheOutputVolumeSnapshots(ctx context.Context, logger *charmlog.Logger, cfg backend.FirecrackerConfig, snapshots []backend.CacheOutputVolumeSnapshot) error {
+	var errs []error
+	for i := len(snapshots) - 1; i >= 0; i-- {
+		storageRef := strings.TrimSpace(snapshots[i].StorageRef)
+		if storageRef == "" {
+			continue
+		}
+		driverCfg, err := snapshotConfigForStorageRef(cfg, storageRef)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		if err := destroySnapshotStorage(ctx, logger, driverCfg, storageRef); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func normalizedSnapshotDriverName(cfg backend.FirecrackerConfig) string {
+	driverName := strings.ToLower(strings.TrimSpace(cfg.Snapshots.Driver))
+	if driverName == "" {
+		return "file"
+	}
+	return driverName
 }
 
 func prepareCacheOutputVolumes(ctx context.Context, logger *charmlog.Logger, cfg backend.FirecrackerConfig, sandboxID, runDir string, specs []backend.CacheOutputVolumeSpec) ([]preparedCacheOutputVolume, func(), error) {

--- a/internal/backend/firecracker/cache_output_volumes_test.go
+++ b/internal/backend/firecracker/cache_output_volumes_test.go
@@ -1,12 +1,15 @@
 package firecracker
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/buildkite/cleanroom/internal/backend"
@@ -287,6 +290,105 @@ func TestPrepareCacheOutputVolumesCleansUpOnFailure(t *testing.T) {
 	}
 	if got, want := len(destroyReqs), 1; got != want {
 		t.Fatalf("expected prepared volume cleanup, got %d destroy requests want %d", got, want)
+	}
+}
+
+func TestSnapshotCacheOutputVolumesSnapshotsPreparedVolumes(t *testing.T) {
+	stateHome := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateHome)
+
+	volumePath := filepath.Join(t.TempDir(), "output-volume.ext4")
+	volumeBytes := []byte("dependency output volume bytes")
+	if err := os.WriteFile(volumePath, volumeBytes, 0o644); err != nil {
+		t.Fatalf("write output volume: %v", err)
+	}
+
+	var signals []syscall.Signal
+	prevSignal := sendProcessSignal
+	sendProcessSignal = func(_ *os.Process, sig syscall.Signal) error {
+		signals = append(signals, sig)
+		return nil
+	}
+	t.Cleanup(func() { sendProcessSignal = prevSignal })
+
+	adapter := &Adapter{
+		runGuestCommandFn: func(_ context.Context, _ context.Context, _ <-chan struct{}, _ func() error, _ string, _ uint32, req vsockexec.ExecRequest, _ backend.OutputStream) (vsockexec.ExecResponse, guestExecTiming, error) {
+			if len(req.Command) != 1 || req.Command[0] != "sync" {
+				t.Fatalf("unexpected command: %v", req.Command)
+			}
+			return vsockexec.ExecResponse{ExitCode: 0}, guestExecTiming{}, nil
+		},
+		sandboxes: map[string]*sandboxInstance{
+			"cr-test": {
+				SandboxID: "cr-test",
+				VsockPath: "/tmp/fake.sock",
+				GuestPort: 10700,
+				fcCmd:     &exec.Cmd{Process: &os.Process{Pid: 42}},
+				exitedCh:  make(chan struct{}),
+				cacheOutputVolumes: []preparedCacheOutputVolume{
+					{
+						Spec: backend.CacheOutputVolumeSpec{
+							Stage:     "dependency-volume",
+							BlockName: "go-modules",
+							CacheKey:  "dependency-volume:v1:test",
+							VolumeID:  "volume-test",
+						},
+						Volume: volumestore.WritableVolume{
+							Ref:            volumePath,
+							AttachmentPath: volumePath,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := adapter.SnapshotCacheOutputVolumes(context.Background(), backend.SnapshotCacheOutputVolumesRequest{
+		SandboxID: "cr-test",
+		Volumes: []backend.CacheOutputVolumeSnapshotRequest{
+			{
+				Stage:      "dependency-volume",
+				BlockName:  "go-modules",
+				CacheKey:   "dependency-volume:v1:test",
+				VolumeID:   "volume-test",
+				SnapshotID: "snapshot-test",
+			},
+		},
+		FirecrackerConfig: backend.FirecrackerConfig{
+			Snapshots: backend.SnapshotConfig{Enabled: true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SnapshotCacheOutputVolumes returned error: %v", err)
+	}
+	if got, want := len(result.Volumes), 1; got != want {
+		t.Fatalf("unexpected snapshot count: got %d want %d", got, want)
+	}
+	snapshot := result.Volumes[0]
+	if got, want := snapshot.StorageDriver, "file"; got != want {
+		t.Fatalf("unexpected storage driver: got %q want %q", got, want)
+	}
+	if got, want := snapshot.StorageRef, filepath.Join(stateHome, "cleanroom", "snapshots", "firecracker", "snapshot-test", "rootfs.ext4"); got != want {
+		t.Fatalf("unexpected storage ref: got %q want %q", got, want)
+	}
+	if got, want := snapshot.Stage, "dependency-volume"; got != want {
+		t.Fatalf("unexpected stage: got %q want %q", got, want)
+	}
+	if got, want := snapshot.BlockName, "go-modules"; got != want {
+		t.Fatalf("unexpected block name: got %q want %q", got, want)
+	}
+	if got, want := snapshot.VolumeID, "volume-test"; got != want {
+		t.Fatalf("unexpected volume id: got %q want %q", got, want)
+	}
+	data, err := os.ReadFile(snapshot.StorageRef)
+	if err != nil {
+		t.Fatalf("read output volume snapshot: %v", err)
+	}
+	if !bytes.Equal(data, volumeBytes) {
+		t.Fatalf("snapshot bytes mismatch: got %q want %q", data, volumeBytes)
+	}
+	if want := []syscall.Signal{syscall.SIGSTOP, syscall.SIGCONT}; !reflect.DeepEqual(signals, want) {
+		t.Fatalf("unexpected signals: got %v want %v", signals, want)
 	}
 }
 

--- a/internal/backend/firecracker/cache_output_volumes_test.go
+++ b/internal/backend/firecracker/cache_output_volumes_test.go
@@ -392,6 +392,159 @@ func TestSnapshotCacheOutputVolumesSnapshotsPreparedVolumes(t *testing.T) {
 	}
 }
 
+func TestSnapshotCacheOutputVolumesResumesBeforeCleaningUpAfterSnapshotFailure(t *testing.T) {
+	prevSignal := sendProcessSignal
+	prevDriverFn := snapshotVolumeStoreDriverFn
+	t.Cleanup(func() {
+		sendProcessSignal = prevSignal
+		snapshotVolumeStoreDriverFn = prevDriverFn
+	})
+
+	var calls []string
+	sendProcessSignal = func(_ *os.Process, sig syscall.Signal) error {
+		switch sig {
+		case syscall.SIGSTOP:
+			calls = append(calls, "signal:stop")
+		case syscall.SIGCONT:
+			calls = append(calls, "signal:cont")
+		default:
+			calls = append(calls, "signal:"+sig.String())
+		}
+		return nil
+	}
+	snapshotVolumeStoreDriverFn = func(backend.FirecrackerConfig) (volumestore.Driver, error) {
+		return testVolumeDriver{
+			snapshotVolumeFn: func(_ context.Context, req volumestore.SnapshotVolumeRequest) (volumestore.Snapshot, error) {
+				calls = append(calls, "snapshot:"+req.SnapshotID)
+				if req.SnapshotID == "snapshot-second" {
+					return volumestore.Snapshot{}, errors.New("snapshot failed")
+				}
+				return volumestore.Snapshot{StorageRef: "snapshot:first"}, nil
+			},
+			destroySnapshotFn: func(_ context.Context, req volumestore.DestroySnapshotRequest) error {
+				calls = append(calls, "cleanup:"+req.SnapshotRef)
+				return nil
+			},
+		}, nil
+	}
+
+	adapter := cacheOutputSnapshotTestAdapter([]preparedCacheOutputVolume{
+		{
+			Spec:   backend.CacheOutputVolumeSpec{VolumeID: "volume-first"},
+			Volume: volumestore.WritableVolume{Ref: "/tmp/volume-first.ext4"},
+		},
+		{
+			Spec:   backend.CacheOutputVolumeSpec{VolumeID: "volume-second"},
+			Volume: volumestore.WritableVolume{Ref: "/tmp/volume-second.ext4"},
+		},
+	})
+	result, err := adapter.SnapshotCacheOutputVolumes(context.Background(), backend.SnapshotCacheOutputVolumesRequest{
+		SandboxID: "cr-test",
+		Volumes: []backend.CacheOutputVolumeSnapshotRequest{
+			{VolumeID: "volume-first", SnapshotID: "snapshot-first"},
+			{VolumeID: "volume-second", SnapshotID: "snapshot-second"},
+		},
+		FirecrackerConfig: backend.FirecrackerConfig{
+			Snapshots: backend.SnapshotConfig{Enabled: true},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected SnapshotCacheOutputVolumes to fail")
+	}
+	if result != nil {
+		t.Fatalf("expected nil result, got %#v", result)
+	}
+	if !strings.Contains(err.Error(), "snapshot failed") {
+		t.Fatalf("expected snapshot error, got %v", err)
+	}
+	want := []string{
+		"signal:stop",
+		"snapshot:snapshot-first",
+		"snapshot:snapshot-second",
+		"signal:cont",
+		"cleanup:snapshot:first",
+	}
+	if !reflect.DeepEqual(calls, want) {
+		t.Fatalf("unexpected call order: got %v want %v", calls, want)
+	}
+}
+
+func TestSnapshotCacheOutputVolumesReportsResumeFailureAfterSnapshotFailure(t *testing.T) {
+	prevSignal := sendProcessSignal
+	prevDriverFn := snapshotVolumeStoreDriverFn
+	t.Cleanup(func() {
+		sendProcessSignal = prevSignal
+		snapshotVolumeStoreDriverFn = prevDriverFn
+	})
+
+	sendProcessSignal = func(_ *os.Process, sig syscall.Signal) error {
+		if sig == syscall.SIGCONT {
+			return os.ErrPermission
+		}
+		return nil
+	}
+	snapshotVolumeStoreDriverFn = func(backend.FirecrackerConfig) (volumestore.Driver, error) {
+		return testVolumeDriver{
+			snapshotVolumeFn: func(_ context.Context, req volumestore.SnapshotVolumeRequest) (volumestore.Snapshot, error) {
+				if req.SnapshotID == "snapshot-second" {
+					return volumestore.Snapshot{}, errors.New("snapshot failed")
+				}
+				return volumestore.Snapshot{StorageRef: "snapshot:first"}, nil
+			},
+			destroySnapshotFn: func(context.Context, volumestore.DestroySnapshotRequest) error { return nil },
+		}, nil
+	}
+
+	adapter := cacheOutputSnapshotTestAdapter([]preparedCacheOutputVolume{
+		{
+			Spec:   backend.CacheOutputVolumeSpec{VolumeID: "volume-first"},
+			Volume: volumestore.WritableVolume{Ref: "/tmp/volume-first.ext4"},
+		},
+		{
+			Spec:   backend.CacheOutputVolumeSpec{VolumeID: "volume-second"},
+			Volume: volumestore.WritableVolume{Ref: "/tmp/volume-second.ext4"},
+		},
+	})
+	result, err := adapter.SnapshotCacheOutputVolumes(context.Background(), backend.SnapshotCacheOutputVolumesRequest{
+		SandboxID: "cr-test",
+		Volumes: []backend.CacheOutputVolumeSnapshotRequest{
+			{VolumeID: "volume-first", SnapshotID: "snapshot-first"},
+			{VolumeID: "volume-second", SnapshotID: "snapshot-second"},
+		},
+		FirecrackerConfig: backend.FirecrackerConfig{
+			Snapshots: backend.SnapshotConfig{Enabled: true},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected SnapshotCacheOutputVolumes to fail")
+	}
+	if result != nil {
+		t.Fatalf("expected nil result, got %#v", result)
+	}
+	message := err.Error()
+	if !strings.Contains(message, "snapshot failed") || !strings.Contains(message, "resume firecracker sandbox") {
+		t.Fatalf("expected snapshot and resume errors, got %v", err)
+	}
+}
+
+func cacheOutputSnapshotTestAdapter(volumes []preparedCacheOutputVolume) *Adapter {
+	return &Adapter{
+		runGuestCommandFn: func(context.Context, context.Context, <-chan struct{}, func() error, string, uint32, vsockexec.ExecRequest, backend.OutputStream) (vsockexec.ExecResponse, guestExecTiming, error) {
+			return vsockexec.ExecResponse{ExitCode: 0}, guestExecTiming{}, nil
+		},
+		sandboxes: map[string]*sandboxInstance{
+			"cr-test": {
+				SandboxID:          "cr-test",
+				VsockPath:          "/tmp/fake.sock",
+				GuestPort:          10700,
+				fcCmd:              &exec.Cmd{Process: &os.Process{Pid: 42}},
+				exitedCh:           make(chan struct{}),
+				cacheOutputVolumes: volumes,
+			},
+		},
+	}
+}
+
 func testCacheOutputVolumeSpecs() []backend.CacheOutputVolumeSpec {
 	return []backend.CacheOutputVolumeSpec{
 		{

--- a/internal/controlservice/dependency_volume_plan.go
+++ b/internal/controlservice/dependency_volume_plan.go
@@ -23,6 +23,7 @@ import (
 
 const (
 	dependencyVolumeStageName           = "dependency-volume"
+	dependencyVolumeReuseMode           = "file-keyed-volume"
 	dependencyVolumeProducerVersion     = "cleanroom/dependency-volume-v1"
 	dependencyVolumeOutputLayoutVersion = "aggregate-v1"
 )
@@ -39,6 +40,7 @@ type dependencyBlockVolumeBlockPlan struct {
 	Inputs                          []string
 	Outputs                         policy.StageBlockOutputs
 	CacheKey                        string
+	RuntimeBaseKey                  string
 	CommandDigest                   string
 	EnvDigest                       string
 	InputManifestDigest             string
@@ -218,6 +220,7 @@ func (s *Service) finalizeDependencyBlockVolumeBlockPlan(
 		Inputs:                          append([]string(nil), block.Inputs.Files...),
 		Outputs:                         cloneStageBlockOutputs(block.Outputs),
 		CacheKey:                        cacheKey,
+		RuntimeBaseKey:                  strings.TrimSpace(runtimeBaseKey),
 		CommandDigest:                   commandDigest,
 		EnvDigest:                       envDigest,
 		InputManifestDigest:             strings.TrimSpace(inputDigest),

--- a/internal/controlservice/dependency_volume_plan_test.go
+++ b/internal/controlservice/dependency_volume_plan_test.go
@@ -381,7 +381,8 @@ func TestCreateSandboxLooksUpDependencyBlockVolumeCaches(t *testing.T) {
 			}); err != nil {
 				t.Fatalf("CreateSandbox returned error: %v", err)
 			}
-			if got, want := cacheStore.getReadyCount(dependencyVolumeStageName), len(plan.Blocks); got != want {
+			expectedLookups := len(plan.Blocks) + len(plan.Blocks) - tc.wantHits
+			if got, want := cacheStore.getReadyCount(dependencyVolumeStageName), expectedLookups; got != want {
 				t.Fatalf("unexpected dependency block-volume lookup count: got %d want %d", got, want)
 			}
 			if got := cacheStore.getReadyHitCount(dependencyVolumeStageName); got != tc.wantHits {

--- a/internal/controlservice/dependency_volume_publish.go
+++ b/internal/controlservice/dependency_volume_publish.go
@@ -1,0 +1,264 @@
+package controlservice
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/cachestore"
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/buildkite/cleanroom/internal/repositorychangeset"
+	"github.com/buildkite/cleanroom/internal/repositorycheckout"
+)
+
+type dependencyBlockVolumePublishBlock struct {
+	Block      dependencyBlockVolumeBlockPlan
+	Spec       backend.CacheOutputVolumeSpec
+	SnapshotID string
+}
+
+func (s *Service) maybePublishDependencyBlockVolumeCaches(
+	ctx context.Context,
+	snapshotAdapter backend.SnapshottingAdapter,
+	adapter backend.Adapter,
+	sandboxID, backendName string,
+	compiled *policy.CompiledPolicy,
+	firecrackerCfg backend.FirecrackerConfig,
+	repository *repositorycheckout.Checkout,
+	changeset *repositorychangeset.Changeset,
+	plan dependencyBlockVolumePlan,
+	reporter CreateSandboxReporter,
+) {
+	if adapter == nil || compiled == nil || repository == nil || strings.TrimSpace(sandboxID) == "" || len(plan.Blocks) == 0 {
+		return
+	}
+	if snapshotAdapter == nil || !snapshotOperationsEnabledForBackend(backendName, s.Config) {
+		return
+	}
+	volumeSnapshotter, ok := adapter.(backend.CacheOutputVolumeSnapshotter)
+	if !ok {
+		s.logDependencyBlockVolumeWarning("publish dependency block output caches", sandboxID, errors.New("backend does not support cache output volume snapshots"))
+		return
+	}
+	store, err := s.cacheStoreOrErr()
+	if err != nil {
+		s.logDependencyBlockVolumeWarning("publish dependency block output caches", sandboxID, err)
+		return
+	}
+
+	blocks := make([]dependencyBlockVolumePublishBlock, 0, len(plan.Blocks))
+	requests := make([]backend.CacheOutputVolumeSnapshotRequest, 0, len(plan.Blocks))
+	for _, block := range plan.Blocks {
+		blockName := strings.TrimSpace(block.BlockName)
+		if block.CacheHit {
+			continue
+		}
+		if len(block.Outputs.Files) > 0 {
+			s.logDependencyBlockVolumeWarning("publish dependency block output cache", sandboxID, fmt.Errorf("dependency block %q declares file outputs, which are not captured yet", blockName))
+			continue
+		}
+		if record, found, lookupErr := store.GetReady(ctx, dependencyVolumeStageName, block.CacheKey); lookupErr != nil {
+			s.logDependencyBlockVolumeWarning("lookup dependency block output cache before publish", sandboxID, lookupErr)
+			continue
+		} else if found {
+			s.logDependencyBlockVolumeAlreadyPublished(record)
+			continue
+		}
+
+		spec, err := blockVolumeOutputSpec(blockVolumeOutputSpecBlock{
+			Stage:     dependencyVolumeStageName,
+			BlockName: block.BlockName,
+			CacheKey:  block.CacheKey,
+			Outputs:   block.Outputs,
+		})
+		if err != nil {
+			s.logDependencyBlockVolumeWarning("prepare dependency block output cache publish", sandboxID, err)
+			continue
+		}
+		snapshotID := newSnapshotID()
+		blocks = append(blocks, dependencyBlockVolumePublishBlock{
+			Block:      block,
+			Spec:       spec,
+			SnapshotID: snapshotID,
+		})
+		requests = append(requests, backend.CacheOutputVolumeSnapshotRequest{
+			Stage:      dependencyVolumeStageName,
+			BlockName:  block.BlockName,
+			CacheKey:   block.CacheKey,
+			VolumeID:   spec.VolumeID,
+			SnapshotID: snapshotID,
+		})
+	}
+	if len(requests) == 0 {
+		return
+	}
+
+	snapshotCfg := withSnapshotDriver(backendName, firecrackerCfg, firecrackerCfg.Snapshots.Driver)
+	result, err := volumeSnapshotter.SnapshotCacheOutputVolumes(ctx, backend.SnapshotCacheOutputVolumesRequest{
+		SandboxID:         sandboxID,
+		Volumes:           requests,
+		FirecrackerConfig: snapshotCfg,
+	})
+	if err != nil {
+		s.logDependencyBlockVolumeWarning("snapshot dependency block output volumes", sandboxID, err)
+		return
+	}
+	if result == nil {
+		s.logDependencyBlockVolumeWarning("snapshot dependency block output volumes", sandboxID, errors.New("backend returned no result"))
+		return
+	}
+	snapshotsByVolumeID := make(map[string]backend.CacheOutputVolumeSnapshot, len(result.Volumes))
+	for _, snapshot := range result.Volumes {
+		volumeID := strings.TrimSpace(snapshot.VolumeID)
+		if volumeID == "" {
+			s.logDependencyBlockVolumeWarning("snapshot dependency block output volumes", sandboxID, errors.New("backend returned snapshot without volume id"))
+			continue
+		}
+		snapshotsByVolumeID[volumeID] = snapshot
+	}
+
+	for _, publishBlock := range blocks {
+		blockName := strings.TrimSpace(publishBlock.Block.BlockName)
+		emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_PUBLISH_DEPENDENCY_STAGE_CACHE, "publishing dependency outputs: "+blockName)
+		snapshot, ok := snapshotsByVolumeID[strings.TrimSpace(publishBlock.Spec.VolumeID)]
+		if !ok {
+			s.logDependencyBlockVolumeWarning("persist dependency block output cache metadata", sandboxID, fmt.Errorf("backend returned no snapshot for dependency block %q", blockName))
+			continue
+		}
+		record, err := dependencyBlockVolumeRecordFromSnapshot(compiled, repository, changeset, publishBlock, snapshot, backendName, s.clock().Now())
+		if err != nil {
+			s.logDependencyBlockVolumeWarning("prepare dependency block output cache metadata", sandboxID, err)
+			s.deleteDependencyBlockVolumeSnapshot(ctx, snapshotAdapter, snapshotCfg, snapshot)
+			continue
+		}
+		if err := store.Create(ctx, record); err != nil {
+			s.deleteDependencyBlockVolumeSnapshot(ctx, snapshotAdapter, snapshotCfg, snapshot)
+			s.logDependencyBlockVolumeWarning("persist dependency block output cache metadata", sandboxID, err)
+			continue
+		}
+		s.logDependencyBlockVolumePublished(record, sandboxID)
+	}
+}
+
+func dependencyBlockVolumeRecordFromSnapshot(
+	compiled *policy.CompiledPolicy,
+	repository *repositorycheckout.Checkout,
+	changeset *repositorychangeset.Changeset,
+	publishBlock dependencyBlockVolumePublishBlock,
+	snapshot backend.CacheOutputVolumeSnapshot,
+	backendName string,
+	now time.Time,
+) (cachestore.Record, error) {
+	block := publishBlock.Block
+	outputRecords := make([]cachestore.OutputRecord, 0, len(publishBlock.Spec.DirMappings))
+	for _, mapping := range publishBlock.Spec.DirMappings {
+		outputRecords = append(outputRecords, cachestore.OutputRecord{
+			Kind:          "dir",
+			Path:          strings.TrimSpace(mapping.GuestPath),
+			VolumeSubpath: strings.TrimSpace(mapping.Subpath),
+			StorageDriver: strings.TrimSpace(snapshot.StorageDriver),
+			StorageRef:    strings.TrimSpace(snapshot.StorageRef),
+			SnapshotRef:   strings.TrimSpace(snapshot.StorageRef),
+		})
+	}
+	if reason := blockVolumeOutputRecordMissReason(block.Outputs, outputRecords); reason != "" {
+		return cachestore.Record{}, fmt.Errorf("dependency block %q output records are invalid: %s", block.BlockName, reason)
+	}
+	outputManifestDigest, err := digestCanonicalJSON(outputRecords)
+	if err != nil {
+		return cachestore.Record{}, fmt.Errorf("digest dependency block %q output records: %w", block.BlockName, err)
+	}
+
+	storageDriver := strings.TrimSpace(snapshot.StorageDriver)
+	storageRef := strings.TrimSpace(snapshot.StorageRef)
+	if storageDriver == "" {
+		return cachestore.Record{}, fmt.Errorf("dependency block %q snapshot missing storage driver", block.BlockName)
+	}
+	if storageRef == "" {
+		return cachestore.Record{}, fmt.Errorf("dependency block %q snapshot missing storage ref", block.BlockName)
+	}
+	now = now.UTC()
+	if now.IsZero() {
+		return cachestore.Record{}, errors.New("dependency block volume publish time is zero")
+	}
+	record := cachestore.Record{
+		CacheKey:                strings.TrimSpace(block.CacheKey),
+		Stage:                   dependencyVolumeStageName,
+		ReuseMode:               dependencyVolumeReuseMode,
+		State:                   cacheStateReady,
+		BackingSnapshotID:       strings.TrimSpace(snapshot.SnapshotID),
+		Backend:                 strings.TrimSpace(backendName),
+		PolicyHash:              compiled.Hash,
+		Policy:                  compiled.ToProto(),
+		Repository:              cloneRepositoryCheckout(normalizeRepositoryCheckoutForComparison(repository)).ToProto(),
+		RepositoryHasChangeset:  changeset != nil,
+		RepositoryChangesetID:   repositoryChangesetID(repository, changeset),
+		ParentCacheKey:          strings.TrimSpace(block.PriorDependencyOutputKeysDigest),
+		StorageDriver:           storageDriver,
+		StorageRef:              storageRef,
+		InputManifestDigest:     strings.TrimSpace(block.InputManifestDigest),
+		CommandDigest:           strings.TrimSpace(block.CommandDigest),
+		EnvDigest:               strings.TrimSpace(block.EnvDigest),
+		NormalizedOutputsDigest: strings.TrimSpace(block.NormalizedOutputsDigest),
+		OutputManifestDigest:    outputManifestDigest,
+		OutputRecords:           outputRecords,
+		CreatedAt:               now,
+		LastUsedAt:              now,
+		ProducerVersion:         strings.TrimSpace(block.ProducerVersion),
+	}
+	populateStageCacheRecordMetadata(&record, block.RuntimeBaseKey, &backend.SnapshotResult{
+		StorageRef:         storageRef,
+		StorageSizeBytes:   snapshot.StorageSizeBytes,
+		ExclusiveSizeBytes: snapshot.ExclusiveSizeBytes,
+		DriverMetadata:     snapshot.DriverMetadata,
+	}, now)
+	return record, nil
+}
+
+func (s *Service) deleteDependencyBlockVolumeSnapshot(ctx context.Context, snapshotAdapter backend.SnapshottingAdapter, cfg backend.FirecrackerConfig, snapshot backend.CacheOutputVolumeSnapshot) {
+	if snapshotAdapter == nil {
+		return
+	}
+	if err := snapshotAdapter.DeleteSnapshot(ctx, backend.DeleteSnapshotRequest{
+		SnapshotID:        strings.TrimSpace(snapshot.SnapshotID),
+		StorageRef:        strings.TrimSpace(snapshot.StorageRef),
+		FirecrackerConfig: cfg,
+	}); err != nil {
+		s.logDependencyBlockVolumeWarning("rollback dependency block output cache after metadata failure", "", err)
+	}
+}
+
+func (s *Service) logDependencyBlockVolumeAlreadyPublished(record cachestore.Record) {
+	if s == nil || s.Logger == nil {
+		return
+	}
+	s.Logger.Debug("dependency block output cache already published",
+		"cache_key", strings.TrimSpace(record.CacheKey),
+		"backend", strings.TrimSpace(record.Backend),
+	)
+}
+
+func (s *Service) logDependencyBlockVolumePublished(record cachestore.Record, sandboxID string) {
+	if s == nil || s.Logger == nil {
+		return
+	}
+	s.Logger.Info("dependency block output cache published",
+		"sandbox_id", strings.TrimSpace(sandboxID),
+		"cache_key", strings.TrimSpace(record.CacheKey),
+		"backend", strings.TrimSpace(record.Backend),
+	)
+}
+
+func (s *Service) logDependencyBlockVolumeWarning(operation, sandboxID string, err error) {
+	if s == nil || s.Logger == nil || err == nil {
+		return
+	}
+	s.Logger.Warn(operation,
+		"sandbox_id", strings.TrimSpace(sandboxID),
+		"error", err,
+	)
+}

--- a/internal/controlservice/dependency_volume_publish_test.go
+++ b/internal/controlservice/dependency_volume_publish_test.go
@@ -1,0 +1,181 @@
+package controlservice
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/buildkite/cleanroom/internal/repositorycheckout"
+)
+
+func TestMaybePublishDependencyBlockVolumeCachesPublishesMisses(t *testing.T) {
+	adapter := dependencyBlockVolumeRuntimeAdapter()
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"mise.toml": "go = \"1.26.2\"\n",
+		"go.mod":    "module example.com/test\n\ngo 1.26.2\n",
+		"go.sum":    "example.com/test v0.0.0 h1:abc123\n",
+	})
+	svc := newTestService(adapter)
+	svc.RepositoryStore = mirrors
+	svc.runtime.clock = stubClock{now: time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)}
+
+	compiled, err := policy.FromProto(testRepositoryTwoDependencyBlocksPolicy())
+	if err != nil {
+		t.Fatalf("policy.FromProto returned error: %v", err)
+	}
+	repository := repositorycheckout.FromProto(repositoryCheckout)
+	plan, ok, err := svc.finalizeDependencyBlockVolumePlan(context.Background(), compiled, repository, nil, nil, "firecracker", "runtime-base:test")
+	if err != nil {
+		t.Fatalf("finalizeDependencyBlockVolumePlan returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected dependency block-volume plan")
+	}
+
+	svc.maybePublishDependencyBlockVolumeCaches(
+		context.Background(),
+		adapter,
+		adapter,
+		"cr-test",
+		"firecracker",
+		compiled,
+		backend.FirecrackerConfig{},
+		repository,
+		nil,
+		plan,
+		nil,
+	)
+
+	if got, want := adapter.snapshotCacheOutputsCalls, 1; got != want {
+		t.Fatalf("unexpected snapshot call count: got %d want %d", got, want)
+	}
+	if got, want := len(adapter.snapshotCacheOutputsReq.Volumes), len(plan.Blocks); got != want {
+		t.Fatalf("unexpected snapshot volume count: got %d want %d", got, want)
+	}
+	if !adapter.snapshotCacheOutputsReq.FirecrackerConfig.Snapshots.Enabled {
+		t.Fatal("expected snapshot config to be enabled")
+	}
+	if got, want := adapter.snapshotCacheOutputsReq.FirecrackerConfig.Snapshots.Driver, "file"; got != want {
+		t.Fatalf("unexpected snapshot driver: got %q want %q", got, want)
+	}
+
+	for i, block := range plan.Blocks {
+		volumeReq := adapter.snapshotCacheOutputsReq.Volumes[i]
+		if got, want := volumeReq.VolumeID, blockVolumeID(dependencyVolumeStageName, block.CacheKey); got != want {
+			t.Fatalf("unexpected volume id for block %q: got %q want %q", block.BlockName, got, want)
+		}
+		if got, want := volumeReq.BlockName, block.BlockName; got != want {
+			t.Fatalf("unexpected snapshot block name: got %q want %q", got, want)
+		}
+
+		record, found, err := svc.CacheStore.GetReady(context.Background(), dependencyVolumeStageName, block.CacheKey)
+		if err != nil {
+			t.Fatalf("GetReady returned error for block %q: %v", block.BlockName, err)
+		}
+		if !found {
+			t.Fatalf("expected published cache record for block %q", block.BlockName)
+		}
+		if got, want := record.ReuseMode, dependencyVolumeReuseMode; got != want {
+			t.Fatalf("unexpected reuse mode for block %q: got %q want %q", block.BlockName, got, want)
+		}
+		if got, want := record.Backend, "firecracker"; got != want {
+			t.Fatalf("unexpected backend for block %q: got %q want %q", block.BlockName, got, want)
+		}
+		if got, want := record.RuntimeBaseKey, "runtime-base:test"; got != want {
+			t.Fatalf("unexpected runtime base key for block %q: got %q want %q", block.BlockName, got, want)
+		}
+		if got, want := record.StorageDriver, "file"; got != want {
+			t.Fatalf("unexpected storage driver for block %q: got %q want %q", block.BlockName, got, want)
+		}
+		if got, want := record.StorageRef, "/tmp/"+volumeReq.VolumeID+".ext4"; got != want {
+			t.Fatalf("unexpected storage ref for block %q: got %q want %q", block.BlockName, got, want)
+		}
+		if got, want := record.BackingSnapshotID, volumeReq.SnapshotID; got != want {
+			t.Fatalf("unexpected snapshot id for block %q: got %q want %q", block.BlockName, got, want)
+		}
+		if got, want := record.ParentCacheKey, block.PriorDependencyOutputKeysDigest; got != want {
+			t.Fatalf("unexpected parent cache key for block %q: got %q want %q", block.BlockName, got, want)
+		}
+		if !strings.HasPrefix(record.OutputManifestDigest, "sha256:") {
+			t.Fatalf("expected output manifest digest for block %q, got %q", block.BlockName, record.OutputManifestDigest)
+		}
+		if got, want := len(record.OutputRecords), len(block.Outputs.Dirs); got != want {
+			t.Fatalf("unexpected output record count for block %q: got %d want %d", block.BlockName, got, want)
+		}
+		if got, want := record.OutputRecords[0].Path, block.Outputs.Dirs[0]; got != want {
+			t.Fatalf("unexpected output record path for block %q: got %q want %q", block.BlockName, got, want)
+		}
+		if got, want := record.OutputRecords[0].VolumeSubpath, "dirs/0"; got != want {
+			t.Fatalf("unexpected output record subpath for block %q: got %q want %q", block.BlockName, got, want)
+		}
+	}
+
+	lookedUp, err := svc.lookupDependencyBlockVolumeCaches(context.Background(), "firecracker", compiled, plan)
+	if err != nil {
+		t.Fatalf("lookupDependencyBlockVolumeCaches returned error: %v", err)
+	}
+	for _, block := range lookedUp.Blocks {
+		if !block.CacheHit {
+			t.Fatalf("expected published block %q to be a cache hit, reason=%q", block.BlockName, block.LookupReason)
+		}
+	}
+}
+
+func TestMaybePublishDependencyBlockVolumeCachesSkipsFileOutputs(t *testing.T) {
+	adapter := dependencyBlockVolumeRuntimeAdapter()
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"Gemfile.lock": "GEM\n",
+	})
+	svc := newTestService(adapter)
+	svc.RepositoryStore = mirrors
+
+	policyProto := testRepositoryPolicy()
+	policyProto.Dependencies = &cleanroomv1.PolicyDependencies{
+		Blocks: []*cleanroomv1.PolicyBlock{testPolicyBlock(
+			"bundler",
+			[]string{"bundle", "install"},
+			[]string{"Gemfile.lock"},
+			nil,
+			[]string{"/root/.bundle/config"},
+		)},
+	}
+	compiled, err := policy.FromProto(policyProto)
+	if err != nil {
+		t.Fatalf("policy.FromProto returned error: %v", err)
+	}
+	repository := repositorycheckout.FromProto(repositoryCheckout)
+	plan, ok, err := svc.finalizeDependencyBlockVolumePlan(context.Background(), compiled, repository, nil, nil, "firecracker", "runtime-base:test")
+	if err != nil {
+		t.Fatalf("finalizeDependencyBlockVolumePlan returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected dependency block-volume plan")
+	}
+
+	svc.maybePublishDependencyBlockVolumeCaches(
+		context.Background(),
+		adapter,
+		adapter,
+		"cr-test",
+		"firecracker",
+		compiled,
+		backend.FirecrackerConfig{},
+		repository,
+		nil,
+		plan,
+		nil,
+	)
+
+	if got := adapter.snapshotCacheOutputsCalls; got != 0 {
+		t.Fatalf("expected file-output block to skip snapshot publication, got %d snapshot calls", got)
+	}
+	if _, found, err := svc.CacheStore.GetReady(context.Background(), dependencyVolumeStageName, plan.Blocks[0].CacheKey); err != nil {
+		t.Fatalf("GetReady returned error: %v", err)
+	} else if found {
+		t.Fatal("did not expect cache record for file-output block")
+	}
+}

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -917,7 +917,10 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 				}
 				return nil, fmt.Errorf("bootstrap dependency stage: %w", err)
 			}
-			if dependencyStageCachingEnabled && !dependencyBlockVolumePlanAvailable {
+			if dependencyBlockVolumePlanAvailable {
+				emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_PUBLISH_DEPENDENCY_STAGE_CACHE, "publishing dependency block output caches")
+				s.maybePublishDependencyBlockVolumeCaches(ctx, snapshotAdapter, adapter, sandboxID, backendName, compiled, firecrackerCfg, repository, changeset, dependencyBlockVolumePlan, reporter)
+			} else if dependencyStageCachingEnabled {
 				emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_PUBLISH_DEPENDENCY_STAGE_CACHE, "publishing dependency stage cache")
 				s.maybePublishDependencyStageCache(ctx, snapshotAdapter, sandboxID, backendName, compiled, firecrackerCfg, repository, changeset, dependencyStagePlan, replacedDependencyStageRecord)
 			}
@@ -1096,7 +1099,19 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 		if err := s.ensureSandboxCreateStillProvisioning(sandboxID); err != nil {
 			return nil, err
 		}
-		if dependencyStageCachingEnabled && snapshotCapable && !dependencyBlockVolumePlanAvailable {
+		if dependencyBlockVolumePlanAvailable && snapshotCapable {
+			emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_PUBLISH_DEPENDENCY_STAGE_CACHE, "publishing dependency block output caches")
+			_ = s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.publish_dependency_block_output_caches", []attribute.KeyValue{
+				attribute.String("cleanroom.backend", backendName),
+				attribute.String("cleanroom.sandbox.id", sandboxID),
+			}, func(ctx context.Context) error {
+				s.maybePublishDependencyBlockVolumeCaches(ctx, snapshotAdapter, adapter, sandboxID, backendName, compiled, firecrackerCfg, repository, changeset, dependencyBlockVolumePlan, reporter)
+				return nil
+			})
+			if err := s.ensureSandboxCreateStillProvisioning(sandboxID); err != nil {
+				return nil, err
+			}
+		} else if dependencyStageCachingEnabled && snapshotCapable {
 			emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_PUBLISH_DEPENDENCY_STAGE_CACHE, "publishing dependency stage cache")
 			_ = s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.publish_dependency_stage_cache", []attribute.KeyValue{
 				attribute.String("cleanroom.backend", backendName),

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -49,6 +49,7 @@ type stubAdapter struct {
 	provisionFn                func(context.Context, backend.ProvisionRequest) error
 	provisionFromSnapshotFn    func(context.Context, backend.ProvisionFromSnapshotRequest) error
 	createSnapshotFn           func(context.Context, backend.SnapshotRequest) (*backend.SnapshotResult, error)
+	snapshotCacheOutputsFn     func(context.Context, backend.SnapshotCacheOutputVolumesRequest) (*backend.SnapshotCacheOutputVolumesResult, error)
 	deleteSnapshotFn           func(context.Context, backend.DeleteSnapshotRequest) error
 	terminateFn                func(context.Context, string) error
 	downloadFn                 func(context.Context, string, string, int64) ([]byte, error)
@@ -64,11 +65,13 @@ type stubAdapter struct {
 	provisionReq               backend.ProvisionRequest
 	provisionFromSnapshotReq   backend.ProvisionFromSnapshotRequest
 	createSnapshotReq          backend.SnapshotRequest
+	snapshotCacheOutputsReq    backend.SnapshotCacheOutputVolumesRequest
 	deleteSnapshotReq          backend.DeleteSnapshotRequest
 	runCalls                   int
 	provisionCalls             int
 	provisionFromSnapshotCalls int
 	createSnapshotCalls        int
+	snapshotCacheOutputsCalls  int
 	deleteSnapshotCalls        int
 	terminateCalls             int
 	runtimeBaseKeyOverride     string
@@ -141,6 +144,31 @@ func (s *stubAdapter) CreateSnapshot(ctx context.Context, req backend.SnapshotRe
 		return s.createSnapshotFn(ctx, req)
 	}
 	return &backend.SnapshotResult{StorageRef: "/tmp/snapshot.ext4"}, nil
+}
+
+func (s *stubAdapter) SnapshotCacheOutputVolumes(ctx context.Context, req backend.SnapshotCacheOutputVolumesRequest) (*backend.SnapshotCacheOutputVolumesResult, error) {
+	s.snapshotCacheOutputsReq = req
+	s.snapshotCacheOutputsCalls++
+	if s.snapshotCacheOutputsFn != nil {
+		return s.snapshotCacheOutputsFn(ctx, req)
+	}
+	result := &backend.SnapshotCacheOutputVolumesResult{
+		Volumes: make([]backend.CacheOutputVolumeSnapshot, 0, len(req.Volumes)),
+	}
+	for _, volume := range req.Volumes {
+		result.Volumes = append(result.Volumes, backend.CacheOutputVolumeSnapshot{
+			Stage:              volume.Stage,
+			BlockName:          volume.BlockName,
+			CacheKey:           volume.CacheKey,
+			VolumeID:           volume.VolumeID,
+			SnapshotID:         volume.SnapshotID,
+			StorageDriver:      "file",
+			StorageRef:         "/tmp/" + volume.VolumeID + ".ext4",
+			StorageSizeBytes:   1024,
+			ExclusiveSizeBytes: 1024,
+		})
+	}
+	return result, nil
 }
 
 func (s *stubAdapter) ProvisionSandboxFromSnapshot(ctx context.Context, req backend.ProvisionFromSnapshotRequest) error {


### PR DESCRIPTION
## Summary

This is the next dependency/service volume-cache slice. It adds the dependency block cache publication plumbing behind the existing block-volume runtime gate.

- add a backend `SnapshotCacheOutputVolumes` contract for attached cache output volumes
- teach Firecracker to snapshot prepared cache output volumes from a running sandbox by syncing, pausing, snapshotting, cleaning up on failure, and resuming
- persist `dependency-volume` records for successful directory-only dependency block misses, including input/command/env/output/prior-block/runtime/storage metadata
- keep file-output publication skipped until file output capture/materialization lands
- update the plan with phase 7 status and remaining work

Firecracker still does not advertise `sandbox.overlay_write_capture`, so the default runtime path remains gated until escaped-write detection is wired.

## Tests

- `mise exec -- go test ./internal/controlservice -run 'TestMaybePublishDependencyBlockVolumeCaches|TestCreateSandboxLooksUpDependencyBlockVolumeCaches|TestDependencyBlockVolumeRuntimeDecision|TestBootstrapDependencyBlockVolumePlan' -count=1`
- `mise exec -- go test ./internal/backend/firecracker -run 'TestSnapshotCacheOutputVolumes|TestPrepareCacheOutputVolumes|TestCacheOutputVolume|TestProvisionSandboxForwardsCacheOutputVolumes|TestProvisionSandboxFromSnapshotUsesSnapshotRootFS' -count=1`
- `mise exec -- go test ./internal/backend ./internal/backend/firecracker ./internal/controlservice -count=1`
- `mise exec -- go test ./... -count=1`
