### PR TITLE
feat: Add darwin-vz cache output sidecars

### DIFF
--- a/cmd/cleanroom-darwin-vz/main.swift
+++ b/cmd/cleanroom-darwin-vz/main.swift
@@ -10,6 +10,7 @@ private struct ControlRequest: Decodable {
     let op: String
     let kernelPath: String?
     let rootFSPath: String?
+    let sidecarDiskPaths: [String]?
     let bootArgs: String?
     let networkMode: String?
     let vmnetSubnetCIDR: String?
@@ -32,6 +33,7 @@ private struct ControlRequest: Decodable {
         case op
         case kernelPath = "kernel_path"
         case rootFSPath = "rootfs_path"
+        case sidecarDiskPaths = "sidecar_disk_paths"
         case bootArgs = "boot_args"
         case networkMode = "network_mode"
         case vmnetSubnetCIDR = "vmnet_subnet_cidr"
@@ -484,12 +486,16 @@ private final class VMRuntime {
 
         let kernelPath = try requireAbsolutePath(req.kernelPath, field: "kernel_path")
         let rootFSPath = try requireAbsolutePath(req.rootFSPath, field: "rootfs_path")
+        let sidecarDiskPaths = try requireAbsolutePaths(req.sidecarDiskPaths ?? [], field: "sidecar_disk_paths")
         let runDir = try requireAbsolutePath(req.runDir, field: "run_dir")
         let proxySocketPath = try requireAbsolutePath(req.proxySocketPath, field: "proxy_socket_path")
         let consoleLogPath = try requireAbsolutePath(req.consoleLogPath, field: "console_log_path")
 
         try requireFile(kernelPath, field: "kernel_path")
         try requireFile(rootFSPath, field: "rootfs_path")
+        for (index, path) in sidecarDiskPaths.enumerated() {
+            try requireFile(path, field: "sidecar_disk_paths[\(index)]")
+        }
         try ensureDirectory(runDir)
         try ensureDirectory((proxySocketPath as NSString).deletingLastPathComponent)
         try ensureDirectory((consoleLogPath as NSString).deletingLastPathComponent)
@@ -521,6 +527,7 @@ private final class VMRuntime {
             runDir: runDir,
             kernelPath: kernelPath,
             rootFSPath: rootFSPath,
+            sidecarDiskPaths: sidecarDiskPaths,
             bootArgs: bootArgs,
             networkMode: req.networkMode?.trimmingCharacters(in: .whitespacesAndNewlines),
             vmnetSubnetCIDR: req.vmnetSubnetCIDR?.trimmingCharacters(in: .whitespacesAndNewlines),
@@ -875,6 +882,7 @@ private final class VMRuntime {
         runDir: String,
         kernelPath: String,
         rootFSPath: String,
+        sidecarDiskPaths: [String],
         bootArgs: String,
         networkMode: String?,
         vmnetSubnetCIDR: String?,
@@ -951,7 +959,13 @@ private final class VMRuntime {
 
         let diskAttachment = try VZDiskImageStorageDeviceAttachment(url: rootFSURL, readOnly: false)
         let blockDevice = VZVirtioBlockDeviceConfiguration(attachment: diskAttachment)
-        config.storageDevices = [blockDevice]
+        var storageDevices: [VZStorageDeviceConfiguration] = [blockDevice]
+        for sidecarPath in sidecarDiskPaths {
+            let sidecarURL = URL(fileURLWithPath: sidecarPath)
+            let sidecarAttachment = try VZDiskImageStorageDeviceAttachment(url: sidecarURL, readOnly: false)
+            storageDevices.append(VZVirtioBlockDeviceConfiguration(attachment: sidecarAttachment))
+        }
+        config.storageDevices = storageDevices
         config.networkDevices = [networkDevice]
 
         config.entropyDevices = [VZVirtioEntropyDeviceConfiguration()]
@@ -1213,6 +1227,12 @@ private func requireAbsolutePath(_ rawValue: String?, field: String) throws -> S
         throw HelperError.invalidRequest("\(field) must be absolute")
     }
     return path
+}
+
+private func requireAbsolutePaths(_ rawValues: [String], field: String) throws -> [String] {
+    try rawValues.enumerated().map { index, value in
+        try requireAbsolutePath(value, field: "\(field)[\(index)]")
+    }
 }
 
 private func requireFile(_ path: String, field: String) throws {

--- a/docs/plans/dependency-service-volume-caches.md
+++ b/docs/plans/dependency-service-volume-caches.md
@@ -498,13 +498,14 @@ dependency/service command. It should also add the guest overlay write-capture
 runner for missed cacheable blocks. Firecracker hotplug is out of scope for the
 first slice.
 
-Darwin-VZ should initially report `sandbox.cache_output_volumes` as unsupported
-unless the backend grows additional disk attach and guest mount support. Its
-current docs state that `/workspace` lives on the rootfs, and current launch code
-prepares a single writable rootfs image. It may still report
-`sandbox.overlay_write_capture` independently once the guest runner has a
-supported mount-namespace path; the local experiment showed the guest kernel and
-root execution environment are capable of the basic overlayfs operations.
+Darwin-VZ now reports `sandbox.cache_output_volumes` after gaining launch-time
+sidecar disk attachment and guest mount-plan forwarding. Its block-volume path
+uses the same ext4 aggregate output volume shape as Firecracker, but with
+Virtualization.framework storage devices attached by the macOS helper before VM
+start. It still does not report `sandbox.overlay_write_capture`; the local
+experiment showed the guest kernel and root execution environment are capable of
+the basic overlayfs operations, but escaped-write detection and publish gating
+must be wired through before the full block-volume runtime path can be enabled.
 
 Backends without `sandbox.cache_output_volumes` should still run the new block
 schema with the same isolated input-projection semantics, using ordinary rootfs
@@ -950,6 +951,43 @@ Remaining runtime work after phase 6:
   block output publication are wired through
 - decide whether output volume sizing stays internal or becomes policy-visible
   after real workloads show the right default
+
+### Darwin-VZ Sidecar Volume Status
+
+The darwin-vz backend now consumes launch-time `backend.CacheOutputVolumeSpec`
+values for persistent sandbox provisions and snapshot restores. It prepares
+writable sidecar ext4 volumes through the existing darwin-vz volume-store
+driver, passes their attachment paths to the Swift helper, and forwards the
+derived guest mount plan through the existing Linux guest-agent protocol.
+
+Completed in the darwin-vz sidecar slice:
+
+- darwin-vz advertises `sandbox.cache_output_volumes` but intentionally does not
+  advertise `sandbox.overlay_write_capture`
+- persistent provisions and snapshot restores forward cache output volume specs
+  into darwin-vz launch
+- cache hits prepare writable volumes from recorded source refs; misses create
+  empty ext4 output volume sources
+- the Swift helper accepts extra sidecar disk image paths and appends them as
+  writable `VZVirtioBlockDeviceConfiguration` storage devices after the rootfs
+- darwin-vz derives deterministic guest mount plans using `/dev/vdb`,
+  `/dev/vdc`, and later virtio block names in the same order as the sidecar
+  storage devices
+- sandbox executions forward the cache output mount plan to the Linux guest
+  agent, reusing the existing guest mount, bind, and file-restore behavior
+- sidecar volume cleanup runs on launch failure, readiness-probe failure, and
+  sandbox termination
+
+Remaining darwin-vz runtime work:
+
+- add escaped-write capture to the block runner and only then advertise
+  `sandbox.overlay_write_capture`
+- snapshot and publish dependency and service output records after successful
+  missed blocks
+- materialize captured file outputs into both the output volume and sandbox root
+  after a missed block run
+- add a macOS smoke test that proves a restored darwin-vz sidecar volume appears
+  at the declared guest path
 
 ## Tests
 

--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -65,7 +65,7 @@ type Adapter struct {
 	sandboxMu          sync.Mutex
 	sandboxes          map[string]*sandboxInstance
 	provisioning       map[string]struct{}
-	launchSandboxVMFn  func(context.Context, string, *policy.CompiledPolicy, backend.FirecrackerConfig) (*sandboxInstance, error)
+	launchSandboxVMFn  func(context.Context, string, *policy.CompiledPolicy, backend.FirecrackerConfig, []backend.CacheOutputVolumeSpec) (*sandboxInstance, error)
 	executeInSandboxFn func(context.Context, context.Context, *sandboxInstance, backend.ExecutionRequest, backend.OutputStream) (*backend.ExecutionResult, error)
 	helperRequestFn    func(context.Context, *helperSession, helperControlRequest) (helperControlResponse, error)
 
@@ -114,6 +114,8 @@ type sandboxInstance struct {
 	Helper              *helperSession
 	VMID                string
 	vmRootFSPath        string
+	cacheOutputMounts   []vsockexec.CacheOutputMount
+	cleanupCacheOutputs func()
 	exitedCh            chan struct{}
 	exitMu              sync.RWMutex
 	exitErr             error
@@ -304,12 +306,13 @@ func (a *Adapter) Capabilities() map[string]bool {
 	}
 	dnsControlSupported := configuredMode == darwinVZNetworkModeFileHandle
 	return map[string]bool{
-		backend.CapabilityNetworkDefaultDeny:       true,
-		backend.CapabilityNetworkAllowlistEgress:   allowlistSupported,
-		backend.CapabilityNetworkStageScopedEgress: allowlistSupported && dnsControlSupported,
-		backend.CapabilityDNSControlOrEquivalent:   dnsControlSupported,
-		backend.CapabilityNetworkGuestInterface:    true,
-		backend.CapabilitySandboxPortDial:          configuredMode == darwinVZNetworkModeFileHandle,
+		backend.CapabilityNetworkDefaultDeny:        true,
+		backend.CapabilityNetworkAllowlistEgress:    allowlistSupported,
+		backend.CapabilityNetworkStageScopedEgress:  allowlistSupported && dnsControlSupported,
+		backend.CapabilityDNSControlOrEquivalent:    dnsControlSupported,
+		backend.CapabilityNetworkGuestInterface:     true,
+		backend.CapabilitySandboxPortDial:           configuredMode == darwinVZNetworkModeFileHandle,
+		backend.CapabilitySandboxCacheOutputVolumes: true,
 	}
 }
 
@@ -336,7 +339,7 @@ func (a *Adapter) ProvisionSandbox(ctx context.Context, req backend.ProvisionReq
 	if req.Policy == nil {
 		return errors.New("missing compiled policy")
 	}
-	return a.provisionSandbox(ctx, sandboxID, req.Policy, req.FirecrackerConfig)
+	return a.provisionSandbox(ctx, sandboxID, req.Policy, req.FirecrackerConfig, req.CacheOutputVolumes)
 }
 
 func (a *Adapter) RunInSandbox(ctx context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (result *backend.ExecutionResult, retErr error) {
@@ -707,7 +710,7 @@ func (a *Adapter) ProvisionSandboxFromSnapshot(ctx context.Context, req backend.
 
 	cfg := req.FirecrackerConfig
 	cfg.RootFSPath = storageRef
-	return a.provisionSandbox(ctx, sandboxID, req.Policy, cfg)
+	return a.provisionSandbox(ctx, sandboxID, req.Policy, cfg, req.CacheOutputVolumes)
 }
 
 func (a *Adapter) DeleteSnapshot(ctx context.Context, req backend.DeleteSnapshotRequest) error {
@@ -1236,7 +1239,7 @@ func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream 
 	}, nil
 }
 
-func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compiled *policy.CompiledPolicy, cfg backend.FirecrackerConfig) (*sandboxInstance, error) {
+func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compiled *policy.CompiledPolicy, cfg backend.FirecrackerConfig, cacheOutputVolumeSpecs []backend.CacheOutputVolumeSpec) (*sandboxInstance, error) {
 	if compiled == nil {
 		return nil, errors.New("missing compiled policy")
 	}
@@ -1376,28 +1379,40 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 		}
 	}()
 
+	cacheOutputVolumes, cleanupCacheOutputs, err := prepareDarwinVZCacheOutputVolumes(ctx, cfg, sandboxID, runDir, cacheOutputVolumeSpecs)
+	if err != nil {
+		return nil, err
+	}
+	cacheOutputsNeedCleanup := true
+	defer func() {
+		if cacheOutputsNeedCleanup {
+			cleanupCacheOutputs()
+		}
+	}()
+
 	log.Debug("darwin-vz launch sandbox vm: starting helper-managed vm",
 		"sandbox_id", sandboxID,
 		"network_mode", strings.TrimSpace(networkCfg.Mode),
 		"launch_seconds", cfg.LaunchSeconds,
 	)
 	startedVM, err := startDarwinVZHelperVM(ctx, helper, darwinVZVMStartRequest{
-		SandboxID:      sandboxID,
-		ConfigPath:     configPath,
-		BackendName:    a.Name(),
-		RunDir:         runDir,
-		KernelPath:     kernelPath,
-		RootFSPath:     vmRootFSPath,
-		BootArgs:       bootArgs,
-		ConsoleLogPath: consolePath,
-		NetworkCfg:     networkCfg,
-		HostGatewayURL: a.GatewayBridgeURL,
-		GatewayPort:    a.GatewayPort,
-		Policy:         compiled,
-		VCPUs:          cfg.VCPUs,
-		MemoryMiB:      cfg.MemoryMiB,
-		GuestPort:      cfg.GuestPort,
-		LaunchSeconds:  cfg.LaunchSeconds,
+		SandboxID:        sandboxID,
+		ConfigPath:       configPath,
+		BackendName:      a.Name(),
+		RunDir:           runDir,
+		KernelPath:       kernelPath,
+		RootFSPath:       vmRootFSPath,
+		SidecarDiskPaths: darwinVZCacheOutputDiskPaths(cacheOutputVolumes),
+		BootArgs:         bootArgs,
+		ConsoleLogPath:   consolePath,
+		NetworkCfg:       networkCfg,
+		HostGatewayURL:   a.GatewayBridgeURL,
+		GatewayPort:      a.GatewayPort,
+		Policy:           compiled,
+		VCPUs:            cfg.VCPUs,
+		MemoryMiB:        cfg.MemoryMiB,
+		GuestPort:        cfg.GuestPort,
+		LaunchSeconds:    cfg.LaunchSeconds,
 	})
 	if err != nil {
 		return nil, err
@@ -1435,13 +1450,15 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 			HelperTimingMS: startedVM.TimingMS,
 			Network:        startedVM.NetworkMetadata,
 		},
-		NetworkMetadata:   startedVM.NetworkMetadata,
-		FileHandleGateway: startedVM.FileHandleGW,
-		CommandTimeout:    cfg.LaunchSeconds,
-		Helper:            helper,
-		VMID:              startedVM.VMID,
-		vmRootFSPath:      vmRootFSPath,
-		exitedCh:          make(chan struct{}),
+		NetworkMetadata:     startedVM.NetworkMetadata,
+		FileHandleGateway:   startedVM.FileHandleGW,
+		CommandTimeout:      cfg.LaunchSeconds,
+		Helper:              helper,
+		VMID:                startedVM.VMID,
+		vmRootFSPath:        vmRootFSPath,
+		cacheOutputMounts:   darwinVZCacheOutputVolumeMounts(cacheOutputVolumes),
+		cleanupCacheOutputs: cleanupCacheOutputs,
+		exitedCh:            make(chan struct{}),
 	}
 	go func() {
 		err, ok := <-helper.done
@@ -1463,13 +1480,14 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 		return nil, err
 	}
 
+	cacheOutputsNeedCleanup = false
 	helperNeedsClose = false
 	fileHandleGatewayNeedsClose = false
 	cleanupRunDir = false
 	return instance, nil
 }
 
-func (a *Adapter) provisionSandbox(ctx context.Context, sandboxID string, compiled *policy.CompiledPolicy, cfg backend.FirecrackerConfig) error {
+func (a *Adapter) provisionSandbox(ctx context.Context, sandboxID string, compiled *policy.CompiledPolicy, cfg backend.FirecrackerConfig, cacheOutputVolumes []backend.CacheOutputVolumeSpec) error {
 	a.sandboxMu.Lock()
 	if a.sandboxes == nil {
 		a.sandboxes = map[string]*sandboxInstance{}
@@ -1488,7 +1506,7 @@ func (a *Adapter) provisionSandbox(ctx context.Context, sandboxID string, compil
 	a.provisioning[sandboxID] = struct{}{}
 	a.sandboxMu.Unlock()
 
-	instance, err := a.launchSandbox(ctx, sandboxID, compiled, cfg)
+	instance, err := a.launchSandbox(ctx, sandboxID, compiled, cfg, cacheOutputVolumes)
 	if err != nil {
 		a.sandboxMu.Lock()
 		delete(a.provisioning, sandboxID)
@@ -1507,12 +1525,12 @@ func (a *Adapter) provisionSandbox(ctx context.Context, sandboxID string, compil
 	return nil
 }
 
-func (a *Adapter) launchSandbox(ctx context.Context, sandboxID string, compiled *policy.CompiledPolicy, cfg backend.FirecrackerConfig) (*sandboxInstance, error) {
+func (a *Adapter) launchSandbox(ctx context.Context, sandboxID string, compiled *policy.CompiledPolicy, cfg backend.FirecrackerConfig, cacheOutputVolumes []backend.CacheOutputVolumeSpec) (*sandboxInstance, error) {
 	launch := a.launchSandboxVMFn
 	if launch == nil {
 		launch = a.launchSandboxVM
 	}
-	return launch(ctx, sandboxID, compiled, cfg)
+	return launch(ctx, sandboxID, compiled, cfg, cacheOutputVolumes)
 }
 
 func (a *Adapter) executeInSandbox(bootCtx context.Context, runCtx context.Context, instance *sandboxInstance, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
@@ -1617,12 +1635,13 @@ func (a *Adapter) executeInSandbox(bootCtx context.Context, runCtx context.Conte
 	}
 
 	guestReq := vsockexec.ExecRequest{
-		Command:         append([]string(nil), req.Command...),
-		Dir:             strings.TrimSpace(req.Dir),
-		Env:             append([]string(nil), req.Env...),
-		ClosedEnv:       req.ClosedEnv,
-		TTY:             req.TTY,
-		InputProjection: darwinVZInputProjection(req.InputProjection),
+		Command:           append([]string(nil), req.Command...),
+		Dir:               strings.TrimSpace(req.Dir),
+		Env:               append([]string(nil), req.Env...),
+		ClosedEnv:         req.ClosedEnv,
+		TTY:               req.TTY,
+		CacheOutputMounts: cloneDarwinVZCacheOutputMounts(instance.cacheOutputMounts),
+		InputProjection:   darwinVZInputProjection(req.InputProjection),
 	}
 	if !req.ClosedEnv && a.GatewayRegistry != nil && gatewayScopeToken != "" {
 		gwPort := a.GatewayPort
@@ -1877,6 +1896,9 @@ func (s *sandboxInstance) shutdown() {
 	}
 	if s.FileHandleGateway != nil {
 		_ = s.FileHandleGateway.Close()
+	}
+	if s.cleanupCacheOutputs != nil {
+		s.cleanupCacheOutputs()
 	}
 	if strings.TrimSpace(s.RunDir) != "" {
 		_ = os.RemoveAll(s.RunDir)

--- a/internal/backend/darwinvz/cache_output_volumes_darwin.go
+++ b/internal/backend/darwinvz/cache_output_volumes_darwin.go
@@ -1,0 +1,333 @@
+//go:build darwin
+
+package darwinvz
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/ext4image"
+	"github.com/buildkite/cleanroom/internal/hosttools"
+	"github.com/buildkite/cleanroom/internal/volumestore"
+	"github.com/buildkite/cleanroom/internal/vsockexec"
+)
+
+const defaultDarwinVZCacheOutputVolumeMinimumBytes int64 = 512 << 20
+const darwinVZCacheOutputGuestMountRoot = "/run/cleanroom/cache-output-volumes"
+
+var (
+	darwinVZCacheOutputVolumeMinimumBytes     = defaultDarwinVZCacheOutputVolumeMinimumBytes
+	createEmptyDarwinVZCacheOutputExt4ImageFn = createEmptyDarwinVZCacheOutputExt4Image
+)
+
+type preparedDarwinVZCacheOutputVolume struct {
+	Spec       backend.CacheOutputVolumeSpec
+	Volume     volumestore.WritableVolume
+	DevicePath string
+	MountPath  string
+}
+
+func prepareDarwinVZCacheOutputVolumes(ctx context.Context, cfg backend.FirecrackerConfig, sandboxID, runDir string, specs []backend.CacheOutputVolumeSpec) ([]preparedDarwinVZCacheOutputVolume, func(), error) {
+	if len(specs) == 0 {
+		return nil, func() {}, nil
+	}
+	if strings.TrimSpace(sandboxID) == "" {
+		return nil, nil, errors.New("missing sandbox id for cache output volumes")
+	}
+	if strings.TrimSpace(runDir) == "" {
+		return nil, nil, errors.New("missing run dir for cache output volumes")
+	}
+
+	prepared := make([]preparedDarwinVZCacheOutputVolume, 0, len(specs))
+	cleanups := make([]func(), 0, len(specs))
+	cleanup := func() {
+		for i := len(cleanups) - 1; i >= 0; i-- {
+			cleanups[i]()
+		}
+	}
+
+	seenVolumeIDs := make(map[string]struct{}, len(specs))
+	for i, spec := range specs {
+		if err := validateDarwinVZCacheOutputVolumeSpec(spec); err != nil {
+			cleanup()
+			return nil, nil, fmt.Errorf("cache output volume %d: %w", i, err)
+		}
+		volumeID := strings.TrimSpace(spec.VolumeID)
+		if _, ok := seenVolumeIDs[volumeID]; ok {
+			cleanup()
+			return nil, nil, fmt.Errorf("cache output volume %d: duplicate volume id %q", i, spec.VolumeID)
+		}
+		seenVolumeIDs[volumeID] = struct{}{}
+
+		sourceRef, volumeCfg, err := darwinVZCacheOutputVolumeSource(ctx, cfg, runDir, spec)
+		if err != nil {
+			cleanup()
+			return nil, nil, fmt.Errorf("cache output volume %q: %w", spec.VolumeID, err)
+		}
+		runtimeVolumeID := darwinVZCacheOutputRuntimeVolumeID(sandboxID, spec.VolumeID, i)
+		attachmentPath := filepath.Join(runDir, fmt.Sprintf("cache-output-%02d.ext4", i))
+		volume, volumeCleanup, err := prepareDarwinVZCacheOutputWritableVolume(ctx, volumeCfg, runtimeVolumeID, attachmentPath, sourceRef, darwinVZCacheOutputVolumeMinimumBytes)
+		if err != nil {
+			cleanup()
+			return nil, nil, fmt.Errorf("cache output volume %q: %w", spec.VolumeID, err)
+		}
+		cleanups = append(cleanups, volumeCleanup)
+		prepared = append(prepared, preparedDarwinVZCacheOutputVolume{
+			Spec:       spec,
+			Volume:     volume,
+			DevicePath: darwinVZCacheOutputDevicePath(i),
+			MountPath:  darwinVZCacheOutputGuestMountPath(i),
+		})
+	}
+
+	return prepared, cleanup, nil
+}
+
+func validateDarwinVZCacheOutputVolumeSpec(spec backend.CacheOutputVolumeSpec) error {
+	if strings.TrimSpace(spec.Stage) == "" {
+		return errors.New("missing stage")
+	}
+	if strings.TrimSpace(spec.BlockName) == "" {
+		return errors.New("missing block name")
+	}
+	if strings.TrimSpace(spec.CacheKey) == "" {
+		return errors.New("missing cache key")
+	}
+	if strings.TrimSpace(spec.VolumeID) == "" {
+		return errors.New("missing volume id")
+	}
+	if len(spec.DirMappings) == 0 && len(spec.FileMappings) == 0 {
+		return errors.New("missing output mappings")
+	}
+	for i, mapping := range spec.DirMappings {
+		if strings.TrimSpace(mapping.GuestPath) == "" {
+			return fmt.Errorf("dir mapping %d missing guest path", i)
+		}
+		if strings.TrimSpace(mapping.Subpath) == "" {
+			return fmt.Errorf("dir mapping %d missing volume subpath", i)
+		}
+	}
+	for i, mapping := range spec.FileMappings {
+		if strings.TrimSpace(mapping.GuestPath) == "" {
+			return fmt.Errorf("file mapping %d missing guest path", i)
+		}
+		if strings.TrimSpace(mapping.Subpath) == "" {
+			return fmt.Errorf("file mapping %d missing volume subpath", i)
+		}
+	}
+	return nil
+}
+
+func darwinVZCacheOutputVolumeSource(ctx context.Context, cfg backend.FirecrackerConfig, runDir string, spec backend.CacheOutputVolumeSpec) (sourceRef string, volumeCfg backend.FirecrackerConfig, err error) {
+	sourceRef = strings.TrimSpace(spec.SourceSnapshotRef)
+	if sourceRef == "" {
+		sourceRef = strings.TrimSpace(spec.StorageRef)
+	}
+	volumeCfg = cfg
+	if driver := strings.TrimSpace(spec.StorageDriver); driver != "" {
+		volumeCfg.Snapshots.Driver = driver
+	}
+	if sourceRef == "" {
+		sourceRef = filepath.Join(runDir, "cache-output-empty-base.ext4")
+		if err := createEmptyDarwinVZCacheOutputExt4ImageFn(ctx, sourceRef, darwinVZCacheOutputVolumeMinimumBytes); err != nil {
+			return "", volumeCfg, fmt.Errorf("create empty cache output volume source: %w", err)
+		}
+		return sourceRef, volumeCfg, nil
+	}
+	if driver := strings.TrimSpace(spec.StorageDriver); driver != "" {
+		effectiveDriver := strings.TrimSpace(volumeCfg.Snapshots.Driver)
+		if effectiveDriver == "" {
+			effectiveDriver = "apfs"
+		}
+		if !strings.EqualFold(driver, effectiveDriver) {
+			return "", volumeCfg, fmt.Errorf("storage driver %q does not match source driver %q", driver, effectiveDriver)
+		}
+	}
+	return sourceRef, volumeCfg, nil
+}
+
+func createEmptyDarwinVZCacheOutputExt4Image(ctx context.Context, path string, minimumBytes int64) error {
+	if strings.TrimSpace(path) == "" {
+		return errors.New("missing empty cache output image path")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create empty cache output image directory: %w", err)
+	}
+	sizeBytes := ext4image.AlignBytes(minimumBytes)
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o600)
+	if err != nil {
+		return fmt.Errorf("create empty cache output image %q: %w", path, err)
+	}
+	if err := file.Truncate(sizeBytes); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("truncate empty cache output image %q to %d bytes: %w", path, sizeBytes, err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close empty cache output image %q: %w", path, err)
+	}
+	mkfsPath, err := hosttools.ResolveE2FSProgsBinary("mkfs.ext4")
+	if err != nil {
+		return fmt.Errorf("find mkfs.ext4 for cache output volume: %w", err)
+	}
+	if out, err := exec.CommandContext(ctx, mkfsPath, "-q", "-F", path).CombinedOutput(); err != nil {
+		_ = os.Remove(path)
+		trimmed := strings.TrimSpace(string(out))
+		if trimmed == "" {
+			return fmt.Errorf("create empty cache output ext4 image: %w", err)
+		}
+		return fmt.Errorf("create empty cache output ext4 image: %w: %s", err, trimmed)
+	}
+	return nil
+}
+
+func prepareDarwinVZCacheOutputWritableVolume(ctx context.Context, cfg backend.FirecrackerConfig, volumeID, attachmentPath, sourceRef string, minimumBytes int64) (volumestore.WritableVolume, func(), error) {
+	sourceRef = strings.TrimSpace(sourceRef)
+	if sourceRef == "" {
+		return volumestore.WritableVolume{}, nil, errors.New("missing persistent volume source")
+	}
+	driver, err := rootFSVolumeDriver(cfg)
+	if err != nil {
+		return volumestore.WritableVolume{}, nil, err
+	}
+
+	resizeVolume := func(volume volumestore.WritableVolume) (volumestore.WritableVolume, func(), error) {
+		cleanup := func() {
+			_ = driver.DestroyVolume(context.Background(), volumestore.DestroyVolumeRequest{VolumeRef: volume.Ref})
+		}
+		if err := volumestore.EnsureWritableVolumeMinimumSize(ctx, driver, volume, minimumBytes); err != nil {
+			cleanup()
+			return volumestore.WritableVolume{}, nil, fmt.Errorf("resize persistent volume: %w", err)
+		}
+		return volume, cleanup, nil
+	}
+
+	if filepath.IsAbs(sourceRef) {
+		sourcePath, err := filepath.Abs(sourceRef)
+		if err != nil {
+			return volumestore.WritableVolume{}, nil, err
+		}
+		if _, err := os.Stat(sourcePath); err != nil {
+			return volumestore.WritableVolume{}, nil, fmt.Errorf("volume source %s: %w", sourcePath, err)
+		}
+		baseVolume, err := driver.EnsureBaseVolume(ctx, volumestore.EnsureBaseVolumeRequest{
+			BaseID:       strings.TrimSuffix(filepath.Base(sourcePath), filepath.Ext(sourcePath)),
+			SourcePath:   sourcePath,
+			MinimumBytes: minimumBytes,
+		})
+		if err != nil {
+			return volumestore.WritableVolume{}, nil, fmt.Errorf("prepare base volume: %w", err)
+		}
+		volume, err := driver.CreateWritableVolume(ctx, volumestore.CreateWritableVolumeRequest{
+			VolumeID:       volumeID,
+			BaseRef:        baseVolume.Ref,
+			AttachmentPath: attachmentPath,
+		})
+		if err != nil {
+			return volumestore.WritableVolume{}, nil, err
+		}
+		return resizeVolume(volume)
+	}
+
+	volume, err := driver.CloneSnapshotToVolume(ctx, volumestore.CloneSnapshotToVolumeRequest{
+		VolumeID:       volumeID,
+		SnapshotRef:    sourceRef,
+		AttachmentPath: attachmentPath,
+	})
+	if err != nil {
+		return volumestore.WritableVolume{}, nil, err
+	}
+	return resizeVolume(volume)
+}
+
+func darwinVZCacheOutputDiskPaths(volumes []preparedDarwinVZCacheOutputVolume) []string {
+	if len(volumes) == 0 {
+		return nil
+	}
+	paths := make([]string, 0, len(volumes))
+	for _, volume := range volumes {
+		paths = append(paths, volume.Volume.AttachmentPath)
+	}
+	return paths
+}
+
+func darwinVZCacheOutputVolumeMounts(volumes []preparedDarwinVZCacheOutputVolume) []vsockexec.CacheOutputMount {
+	if len(volumes) == 0 {
+		return nil
+	}
+	mounts := make([]vsockexec.CacheOutputMount, 0, len(volumes))
+	for _, volume := range volumes {
+		mount := vsockexec.CacheOutputMount{
+			DevicePath:    volume.DevicePath,
+			MountPath:     volume.MountPath,
+			SourcePresent: darwinVZCacheOutputSpecHasSource(volume.Spec),
+		}
+		for _, mapping := range volume.Spec.DirMappings {
+			mount.DirMappings = append(mount.DirMappings, vsockexec.CacheOutputDirMount{
+				GuestPath: strings.TrimSpace(mapping.GuestPath),
+				Subpath:   strings.TrimSpace(mapping.Subpath),
+			})
+		}
+		for _, mapping := range volume.Spec.FileMappings {
+			mount.FileMappings = append(mount.FileMappings, vsockexec.CacheOutputFileMount{
+				GuestPath: strings.TrimSpace(mapping.GuestPath),
+				Subpath:   strings.TrimSpace(mapping.Subpath),
+				Mode:      uint32(mapping.Mode.Perm()),
+			})
+		}
+		mounts = append(mounts, mount)
+	}
+	return mounts
+}
+
+func cloneDarwinVZCacheOutputMounts(mounts []vsockexec.CacheOutputMount) []vsockexec.CacheOutputMount {
+	if len(mounts) == 0 {
+		return nil
+	}
+	out := make([]vsockexec.CacheOutputMount, len(mounts))
+	for i, mount := range mounts {
+		out[i] = mount
+		out[i].DirMappings = append([]vsockexec.CacheOutputDirMount(nil), mount.DirMappings...)
+		out[i].FileMappings = append([]vsockexec.CacheOutputFileMount(nil), mount.FileMappings...)
+	}
+	return out
+}
+
+func darwinVZCacheOutputSpecHasSource(spec backend.CacheOutputVolumeSpec) bool {
+	return strings.TrimSpace(spec.SourceSnapshotRef) != "" || strings.TrimSpace(spec.StorageRef) != ""
+}
+
+func darwinVZCacheOutputRuntimeVolumeID(sandboxID, specVolumeID string, index int) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(sandboxID) + "\x00" + strings.TrimSpace(specVolumeID)))
+	return fmt.Sprintf("%s-cache-output-%02d-%s", strings.TrimSpace(sandboxID), index, hex.EncodeToString(sum[:6]))
+}
+
+func darwinVZCacheOutputGuestMountPath(index int) string {
+	return filepath.Join(darwinVZCacheOutputGuestMountRoot, fmt.Sprintf("cacheout%d", index))
+}
+
+func darwinVZCacheOutputDevicePath(index int) string {
+	return "/dev/" + darwinVZVirtioBlockDeviceName(index+1)
+}
+
+func darwinVZVirtioBlockDeviceName(index int) string {
+	if index < 0 {
+		index = 0
+	}
+	letters := ""
+	for {
+		letters = string(rune('a'+index%26)) + letters
+		index = index/26 - 1
+		if index < 0 {
+			break
+		}
+	}
+	return "vd" + letters
+}

--- a/internal/backend/darwinvz/cache_output_volumes_test.go
+++ b/internal/backend/darwinvz/cache_output_volumes_test.go
@@ -1,0 +1,100 @@
+//go:build darwin
+
+package darwinvz
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/volumestore"
+	"github.com/buildkite/cleanroom/internal/vsockexec"
+)
+
+func TestDarwinVZCacheOutputVolumeMountsBuildsDeterministicGuestPlan(t *testing.T) {
+	t.Parallel()
+
+	mounts := darwinVZCacheOutputVolumeMounts([]preparedDarwinVZCacheOutputVolume{
+		{
+			Spec: backend.CacheOutputVolumeSpec{
+				Stage:             "dependency-volume",
+				BlockName:         "toolchains",
+				CacheKey:          "dependency-volume:v1:toolchains",
+				VolumeID:          "dependency-volume-abc123",
+				SourceSnapshotRef: "snapshot-ref",
+				DirMappings: []backend.CacheOutputDirMapping{
+					{GuestPath: "/root/.local/share/mise", Subpath: "dirs/0"},
+				},
+				FileMappings: []backend.CacheOutputFileMapping{
+					{GuestPath: "/root/.config/mise/config.toml", Subpath: "files/0", Mode: 0o600},
+				},
+			},
+			Volume:     volumestore.WritableVolume{AttachmentPath: "/tmp/cache-output-00.ext4"},
+			DevicePath: "/dev/vdb",
+			MountPath:  "/run/cleanroom/cache-output-volumes/cacheout0",
+		},
+		{
+			Spec: backend.CacheOutputVolumeSpec{
+				Stage:     "service-volume",
+				BlockName: "postgres",
+				CacheKey:  "service-volume:v1:postgres",
+				VolumeID:  "service-volume-def456",
+				DirMappings: []backend.CacheOutputDirMapping{
+					{GuestPath: "/var/lib/postgresql/data", Subpath: "dirs/0"},
+				},
+			},
+			Volume:     volumestore.WritableVolume{AttachmentPath: "/tmp/cache-output-01.ext4"},
+			DevicePath: "/dev/vdc",
+			MountPath:  "/run/cleanroom/cache-output-volumes/cacheout1",
+		},
+	})
+
+	want := []vsockexec.CacheOutputMount{
+		{
+			DevicePath:    "/dev/vdb",
+			MountPath:     "/run/cleanroom/cache-output-volumes/cacheout0",
+			SourcePresent: true,
+			DirMappings: []vsockexec.CacheOutputDirMount{
+				{GuestPath: "/root/.local/share/mise", Subpath: "dirs/0"},
+			},
+			FileMappings: []vsockexec.CacheOutputFileMount{
+				{GuestPath: "/root/.config/mise/config.toml", Subpath: "files/0", Mode: 0o600},
+			},
+		},
+		{
+			DevicePath:    "/dev/vdc",
+			MountPath:     "/run/cleanroom/cache-output-volumes/cacheout1",
+			SourcePresent: false,
+			DirMappings: []vsockexec.CacheOutputDirMount{
+				{GuestPath: "/var/lib/postgresql/data", Subpath: "dirs/0"},
+			},
+		},
+	}
+	if !reflect.DeepEqual(mounts, want) {
+		t.Fatalf("unexpected cache output mounts: got %#v want %#v", mounts, want)
+	}
+}
+
+func TestDarwinVZCacheOutputDiskPathsPreserveLaunchOrder(t *testing.T) {
+	t.Parallel()
+
+	paths := darwinVZCacheOutputDiskPaths([]preparedDarwinVZCacheOutputVolume{
+		{Volume: volumestore.WritableVolume{AttachmentPath: "/tmp/cache-output-00.ext4"}},
+		{Volume: volumestore.WritableVolume{AttachmentPath: "/tmp/cache-output-01.ext4"}},
+	})
+
+	want := []string{"/tmp/cache-output-00.ext4", "/tmp/cache-output-01.ext4"}
+	if !reflect.DeepEqual(paths, want) {
+		t.Fatalf("unexpected cache output disk paths: got %#v want %#v", paths, want)
+	}
+}
+
+func TestDarwinVZCacheOutputDevicePathSkipsRootDisk(t *testing.T) {
+	t.Parallel()
+
+	for index, want := range []string{"/dev/vdb", "/dev/vdc", "/dev/vdd"} {
+		if got := darwinVZCacheOutputDevicePath(index); got != want {
+			t.Fatalf("cacheOutputDevicePath(%d) = %q, want %q", index, got, want)
+		}
+	}
+}

--- a/internal/backend/darwinvz/capabilities_test.go
+++ b/internal/backend/darwinvz/capabilities_test.go
@@ -42,6 +42,14 @@ func TestCapabilitiesMatchImplicitDefaultNetworkMode(t *testing.T) {
 	} else if caps[backend.CapabilitySandboxPortDial] {
 		t.Fatalf("expected %s=false", backend.CapabilitySandboxPortDial)
 	}
+	if runtime.GOOS == "darwin" {
+		if !caps[backend.CapabilitySandboxCacheOutputVolumes] {
+			t.Fatalf("expected %s=true on darwin", backend.CapabilitySandboxCacheOutputVolumes)
+		}
+	}
+	if caps[backend.CapabilitySandboxOverlayWriteCapture] {
+		t.Fatalf("expected %s=false until escaped-write capture is wired through", backend.CapabilitySandboxOverlayWriteCapture)
+	}
 }
 
 func TestCapabilitiesDeclareAllowlistFilteringForFileHandleMode(t *testing.T) {
@@ -68,5 +76,11 @@ func TestCapabilitiesDeclareAllowlistFilteringForFileHandleMode(t *testing.T) {
 	}
 	if !caps[backend.CapabilitySandboxPortDial] {
 		t.Fatalf("expected %s=true", backend.CapabilitySandboxPortDial)
+	}
+	if !caps[backend.CapabilitySandboxCacheOutputVolumes] {
+		t.Fatalf("expected %s=true", backend.CapabilitySandboxCacheOutputVolumes)
+	}
+	if caps[backend.CapabilitySandboxOverlayWriteCapture] {
+		t.Fatalf("expected %s=false until escaped-write capture is wired through", backend.CapabilitySandboxOverlayWriteCapture)
 	}
 }

--- a/internal/backend/darwinvz/helper_client.go
+++ b/internal/backend/darwinvz/helper_client.go
@@ -28,26 +28,27 @@ var (
 )
 
 type helperControlRequest struct {
-	Op                              string `json:"op"`
-	KernelPath                      string `json:"kernel_path,omitempty"`
-	RootFSPath                      string `json:"rootfs_path,omitempty"`
-	BootArgs                        string `json:"boot_args,omitempty"`
-	NetworkMode                     string `json:"network_mode,omitempty"`
-	VMNetSubnetCIDR                 string `json:"vmnet_subnet_cidr,omitempty"`
-	VMNetExternalInterface          string `json:"vmnet_external_interface,omitempty"`
-	VMNetDisableNAT44               bool   `json:"vmnet_disable_nat44,omitempty"`
-	VMNetDisableNAT66               bool   `json:"vmnet_disable_nat66,omitempty"`
-	VMNetDisableDNSProxy            bool   `json:"vmnet_disable_dns_proxy,omitempty"`
-	VMNetDisableRouterAdvertisement bool   `json:"vmnet_disable_router_advertisement,omitempty"`
-	VCPUs                           int64  `json:"vcpus,omitempty"`
-	MemoryMiB                       int64  `json:"memory_mib,omitempty"`
-	GuestPort                       uint32 `json:"guest_port,omitempty"`
-	LaunchSeconds                   int64  `json:"launch_seconds,omitempty"`
-	RunDir                          string `json:"run_dir,omitempty"`
-	FileHandleSocketPath            string `json:"filehandle_socket_path,omitempty"`
-	ProxySocketPath                 string `json:"proxy_socket_path,omitempty"`
-	ConsoleLogPath                  string `json:"console_log_path,omitempty"`
-	VMID                            string `json:"vm_id,omitempty"`
+	Op                              string   `json:"op"`
+	KernelPath                      string   `json:"kernel_path,omitempty"`
+	RootFSPath                      string   `json:"rootfs_path,omitempty"`
+	SidecarDiskPaths                []string `json:"sidecar_disk_paths,omitempty"`
+	BootArgs                        string   `json:"boot_args,omitempty"`
+	NetworkMode                     string   `json:"network_mode,omitempty"`
+	VMNetSubnetCIDR                 string   `json:"vmnet_subnet_cidr,omitempty"`
+	VMNetExternalInterface          string   `json:"vmnet_external_interface,omitempty"`
+	VMNetDisableNAT44               bool     `json:"vmnet_disable_nat44,omitempty"`
+	VMNetDisableNAT66               bool     `json:"vmnet_disable_nat66,omitempty"`
+	VMNetDisableDNSProxy            bool     `json:"vmnet_disable_dns_proxy,omitempty"`
+	VMNetDisableRouterAdvertisement bool     `json:"vmnet_disable_router_advertisement,omitempty"`
+	VCPUs                           int64    `json:"vcpus,omitempty"`
+	MemoryMiB                       int64    `json:"memory_mib,omitempty"`
+	GuestPort                       uint32   `json:"guest_port,omitempty"`
+	LaunchSeconds                   int64    `json:"launch_seconds,omitempty"`
+	RunDir                          string   `json:"run_dir,omitempty"`
+	FileHandleSocketPath            string   `json:"filehandle_socket_path,omitempty"`
+	ProxySocketPath                 string   `json:"proxy_socket_path,omitempty"`
+	ConsoleLogPath                  string   `json:"console_log_path,omitempty"`
+	VMID                            string   `json:"vm_id,omitempty"`
 }
 
 type helperControlResponse struct {

--- a/internal/backend/darwinvz/persistent_e2e_test.go
+++ b/internal/backend/darwinvz/persistent_e2e_test.go
@@ -183,6 +183,119 @@ func TestPersistentSandboxE2E(t *testing.T) {
 	}
 }
 
+func TestPersistentSandboxCacheOutputVolumeE2E(t *testing.T) {
+	if strings.TrimSpace(os.Getenv(darwinVZE2EEnvEnabled)) == "" {
+		t.Skipf("set %s=1 to run real darwin-vz cache output volume e2e", darwinVZE2EEnvEnabled)
+	}
+	if testing.Short() {
+		t.Skip("skipping darwin-vz e2e in short mode")
+	}
+
+	helperPath, err := resolveHelperBinaryPath()
+	if err != nil {
+		t.Fatalf("resolve helper binary: %v", err)
+	}
+	hasEntitlement, err := helperHasVirtualizationEntitlement(helperPath)
+	if err != nil {
+		t.Fatalf("verify helper entitlement: %v", err)
+	}
+	if !hasEntitlement {
+		t.Fatalf("helper %q is missing com.apple.security.virtualization entitlement", helperPath)
+	}
+	if _, _, err := New().getGuestAgentBinary(); err != nil {
+		t.Fatalf("resolve guest agent binary: %v", err)
+	}
+
+	rootFSOverride := strings.TrimSpace(os.Getenv(darwinVZE2EEnvRootFS))
+	if rootFSOverride == "" {
+		if _, err := hosttools.ResolveE2FSProgsBinary("mkfs.ext4"); err != nil {
+			t.Fatalf("resolve mkfs.ext4: %v", err)
+		}
+		if _, err := hosttools.ResolveE2FSProgsBinary("debugfs"); err != nil {
+			t.Fatalf("resolve debugfs: %v", err)
+		}
+	}
+
+	imageRef := strings.TrimSpace(os.Getenv(darwinVZE2EEnvImageRef))
+	if imageRef == "" {
+		imageRef = defaultDarwinVZE2EImageRef()
+	}
+
+	cfg := backend.FirecrackerConfig{
+		KernelImagePath: strings.TrimSpace(os.Getenv(darwinVZE2EEnvKernelImage)),
+		RootFSPath:      rootFSOverride,
+		VCPUs:           1,
+		MemoryMiB:       1024,
+		LaunchSeconds:   90,
+	}
+	compiled := &policy.CompiledPolicy{
+		Version:        1,
+		ImageRef:       imageRef,
+		NetworkDefault: "deny",
+	}
+	sandboxID := fmt.Sprintf("cr-e2e-cache-output-%d", time.Now().UnixNano())
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	outputDir := "/var/lib/cleanroom-cache-output-e2e"
+	adapter := New()
+	if err := adapter.ProvisionSandbox(ctx, backend.ProvisionRequest{
+		SandboxID: sandboxID,
+		Policy:    compiled,
+		CacheOutputVolumes: []backend.CacheOutputVolumeSpec{
+			{
+				Stage:     "dependency-volume",
+				BlockName: "cache-output-e2e",
+				CacheKey:  "dependency-volume:v1:cache-output-e2e",
+				VolumeID:  "dependency-volume-cache-output-e2e",
+				DirMappings: []backend.CacheOutputDirMapping{
+					{GuestPath: outputDir, Subpath: "dirs/0"},
+				},
+			},
+		},
+		FirecrackerConfig: cfg,
+	}); err != nil {
+		t.Fatalf("ProvisionSandbox returned error: %v", err)
+	}
+	defer func() {
+		if err := adapter.TerminateSandbox(context.Background(), sandboxID); err != nil {
+			t.Fatalf("deferred TerminateSandbox returned error: %v", err)
+		}
+	}()
+
+	writeValue := "darwin-vz-cache-output-volume"
+	runPersistentCommand(ctx, t, adapter, sandboxID, compiled, cfg, "cache-output-write", nil, "sh", "-lc", fmt.Sprintf("printf '%s' > %s/value", writeValue, outputDir))
+	var stdout bytes.Buffer
+	runPersistentCommand(ctx, t, adapter, sandboxID, compiled, cfg, "cache-output-read", &stdout, "sh", "-lc", "cat "+outputDir+"/value")
+	if got, want := stdout.String(), writeValue; got != want {
+		t.Fatalf("unexpected cache output volume contents: got %q want %q", got, want)
+	}
+}
+
+func runPersistentCommand(ctx context.Context, t *testing.T, adapter *Adapter, sandboxID string, compiled *policy.CompiledPolicy, cfg backend.FirecrackerConfig, executionID string, stdout *bytes.Buffer, command ...string) {
+	t.Helper()
+
+	stream := backend.OutputStream{}
+	if stdout != nil {
+		stream.OnStdout = func(chunk []byte) {
+			_, _ = stdout.Write(chunk)
+		}
+	}
+	result, err := adapter.RunInSandbox(ctx, backend.ExecutionRequest{
+		SandboxID:         sandboxID,
+		ExecutionID:       executionID,
+		Command:           command,
+		Policy:            compiled,
+		FirecrackerConfig: cfg,
+	}, stream)
+	if err != nil {
+		t.Fatalf("%s RunInSandbox returned error: %v", executionID, err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("%s exit code = %d, want 0", executionID, result.ExitCode)
+	}
+}
+
 func TestPersistentSandboxE2EExecStreamingDoesNotHang(t *testing.T) {
 	if strings.TrimSpace(os.Getenv(darwinVZE2EEnvEnabled)) == "" {
 		t.Skipf("set %s=1 to run real darwin-vz persistence e2e", darwinVZE2EEnvEnabled)

--- a/internal/backend/darwinvz/persistent_test.go
+++ b/internal/backend/darwinvz/persistent_test.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -36,6 +37,12 @@ func TestCapabilitiesExposeSnapshotAndFileTransfer(t *testing.T) {
 	if !caps[backend.CapabilityNetworkStageScopedEgress] {
 		t.Fatalf("expected %s=true", backend.CapabilityNetworkStageScopedEgress)
 	}
+	if !caps[backend.CapabilitySandboxCacheOutputVolumes] {
+		t.Fatalf("expected %s=true", backend.CapabilitySandboxCacheOutputVolumes)
+	}
+	if caps[backend.CapabilitySandboxOverlayWriteCapture] {
+		t.Fatalf("expected %s=false until escaped-write capture is wired through", backend.CapabilitySandboxOverlayWriteCapture)
+	}
 	for _, key := range []string{
 		backend.CapabilitySandboxPathStat,
 		backend.CapabilitySandboxTreeWalk,
@@ -57,7 +64,7 @@ func TestProvisionSandboxRejectsConcurrentProvisionForSameID(t *testing.T) {
 	block := make(chan struct{})
 	started := make(chan struct{})
 	adapter := &Adapter{
-		launchSandboxVMFn: func(_ context.Context, sandboxID string, _ *policy.CompiledPolicy, _ backend.FirecrackerConfig) (*sandboxInstance, error) {
+		launchSandboxVMFn: func(_ context.Context, sandboxID string, _ *policy.CompiledPolicy, _ backend.FirecrackerConfig, _ []backend.CacheOutputVolumeSpec) (*sandboxInstance, error) {
 			if sandboxID != "cr-test" {
 				t.Fatalf("unexpected sandbox id %q", sandboxID)
 			}
@@ -99,6 +106,46 @@ func TestProvisionSandboxRejectsConcurrentProvisionForSameID(t *testing.T) {
 	close(block)
 	if err := <-errCh; err != nil {
 		t.Fatalf("first provision returned error: %v", err)
+	}
+}
+
+func TestProvisionSandboxForwardsCacheOutputVolumes(t *testing.T) {
+	t.Parallel()
+
+	specs := []backend.CacheOutputVolumeSpec{
+		{
+			Stage:     "dependency-volume",
+			BlockName: "toolchains",
+			CacheKey:  "dependency-volume:v1:toolchains",
+			VolumeID:  "dependency-volume-abc123",
+			DirMappings: []backend.CacheOutputDirMapping{
+				{GuestPath: "/root/.local/share/mise", Subpath: "dirs/0"},
+			},
+			FileMappings: []backend.CacheOutputFileMapping{
+				{GuestPath: "/root/.config/mise/config.toml", Subpath: "files/0", Mode: 0o600},
+			},
+		},
+	}
+	var got []backend.CacheOutputVolumeSpec
+	adapter := &Adapter{
+		launchSandboxVMFn: func(_ context.Context, sandboxID string, _ *policy.CompiledPolicy, _ backend.FirecrackerConfig, cacheOutputVolumes []backend.CacheOutputVolumeSpec) (*sandboxInstance, error) {
+			if sandboxID != "cr-test" {
+				t.Fatalf("unexpected sandbox id %q", sandboxID)
+			}
+			got = append([]backend.CacheOutputVolumeSpec(nil), cacheOutputVolumes...)
+			return &sandboxInstance{SandboxID: sandboxID}, nil
+		},
+	}
+
+	if err := adapter.ProvisionSandbox(context.Background(), backend.ProvisionRequest{
+		SandboxID:          "cr-test",
+		Policy:             &policy.CompiledPolicy{NetworkDefault: "deny"},
+		CacheOutputVolumes: specs,
+	}); err != nil {
+		t.Fatalf("ProvisionSandbox returned error: %v", err)
+	}
+	if !reflect.DeepEqual(got, specs) {
+		t.Fatalf("unexpected cache output specs: got %#v want %#v", got, specs)
 	}
 }
 

--- a/internal/backend/darwinvz/snapshot_test.go
+++ b/internal/backend/darwinvz/snapshot_test.go
@@ -90,7 +90,7 @@ func TestProvisionSandboxFromSnapshotUsesSnapshotRootFS(t *testing.T) {
 		gotCfg     backend.FirecrackerConfig
 	)
 	adapter := &Adapter{
-		launchSandboxVMFn: func(_ context.Context, sandboxID string, compiled *policy.CompiledPolicy, cfg backend.FirecrackerConfig) (*sandboxInstance, error) {
+		launchSandboxVMFn: func(_ context.Context, sandboxID string, compiled *policy.CompiledPolicy, cfg backend.FirecrackerConfig, _ []backend.CacheOutputVolumeSpec) (*sandboxInstance, error) {
 			gotSandbox = sandboxID
 			gotPolicy = compiled
 			gotCfg = cfg
@@ -136,7 +136,7 @@ func TestProvisionSandboxFromSnapshotRejectsMissingSnapshotRootFS(t *testing.T) 
 	missingSnapshotPath := filepath.Join(t.TempDir(), "missing-rootfs.ext4")
 	launchCalled := false
 	adapter := &Adapter{
-		launchSandboxVMFn: func(_ context.Context, sandboxID string, _ *policy.CompiledPolicy, _ backend.FirecrackerConfig) (*sandboxInstance, error) {
+		launchSandboxVMFn: func(_ context.Context, sandboxID string, _ *policy.CompiledPolicy, _ backend.FirecrackerConfig, _ []backend.CacheOutputVolumeSpec) (*sandboxInstance, error) {
 			launchCalled = true
 			return &sandboxInstance{SandboxID: sandboxID}, nil
 		},

--- a/internal/backend/darwinvz/vm_launch.go
+++ b/internal/backend/darwinvz/vm_launch.go
@@ -46,22 +46,23 @@ type darwinVZConfigFile struct {
 }
 
 type darwinVZVMStartRequest struct {
-	SandboxID      string
-	ConfigPath     string
-	BackendName    string
-	RunDir         string
-	KernelPath     string
-	RootFSPath     string
-	BootArgs       string
-	ConsoleLogPath string
-	NetworkCfg     darwinVZNetwork
-	HostGatewayURL string
-	GatewayPort    int
-	Policy         *policy.CompiledPolicy
-	VCPUs          int64
-	MemoryMiB      int64
-	GuestPort      uint32
-	LaunchSeconds  int64
+	SandboxID        string
+	ConfigPath       string
+	BackendName      string
+	RunDir           string
+	KernelPath       string
+	RootFSPath       string
+	SidecarDiskPaths []string
+	BootArgs         string
+	ConsoleLogPath   string
+	NetworkCfg       darwinVZNetwork
+	HostGatewayURL   string
+	GatewayPort      int
+	Policy           *policy.CompiledPolicy
+	VCPUs            int64
+	MemoryMiB        int64
+	GuestPort        uint32
+	LaunchSeconds    int64
 }
 
 type darwinVZVMStartResult struct {
@@ -123,6 +124,7 @@ func startDarwinVZHelperVM(ctx context.Context, helper *helperSession, req darwi
 		Op:                   "StartVM",
 		KernelPath:           req.KernelPath,
 		RootFSPath:           req.RootFSPath,
+		SidecarDiskPaths:     append([]string(nil), req.SidecarDiskPaths...),
 		BootArgs:             req.BootArgs,
 		NetworkMode:          req.NetworkCfg.Mode,
 		VMNetSubnetCIDR:      req.NetworkCfg.SubnetCIDR,


### PR DESCRIPTION
## Summary

Add darwin-vz launch-time support for dependency/service cache output sidecar volumes.

This wires darwin-vz into the same backend-neutral `CacheOutputVolumeSpec` path used by Firecracker:

- prepare writable sidecar ext4 volumes for cache hits and misses
- attach sidecar disk images through the macOS Virtualization.framework helper
- derive deterministic guest mount plans using `/dev/vdb`, `/dev/vdc`, ...
- forward the mount plan through the existing Linux guest-agent cache output mount protocol
- advertise `sandbox.cache_output_volumes` while keeping `sandbox.overlay_write_capture` disabled
- document the new darwin-vz sidecar status and remaining publish/capture work

The adversarial pass caught the empty-volume miss path trying to truncate a non-existent image file. The implementation now explicitly creates the ext4 image before sizing and formatting it.

## Verification

- `scripts/build-darwin-vz-helper.sh dist/cleanroom-darwin-vz.app`
- `mise exec -- go test ./internal/backend/darwinvz ./internal/controlservice`
- `mise exec -- go test ./internal/backend/... ./internal/controlservice`
- `git diff --check`
- `GOOS=linux GOARCH=$(mise exec -- go env GOARCH) CGO_ENABLED=0 mise exec -- go build -trimpath -o dist/cleanroom-guest-agent-linux-$(mise exec -- go env GOARCH) ./cmd/cleanroom-guest-agent`
- `CLEANROOM_DARWIN_VZ_E2E=1 CLEANROOM_DARWIN_VZ_HELPER="$PWD/dist/cleanroom-darwin-vz.app" mise exec -- go test ./internal/backend/darwinvz -run TestPersistentSandboxCacheOutputVolumeE2E -count=1 -timeout=8m`
