### PR TITLE
feat: Add overlay capture scanner

### DIFF
--- a/internal/overlaycapture/opaque_linux.go
+++ b/internal/overlaycapture/opaque_linux.go
@@ -2,10 +2,42 @@
 
 package overlaycapture
 
-import "golang.org/x/sys/unix"
+import (
+	"errors"
+	"io/fs"
+
+	"golang.org/x/sys/unix"
+)
+
+func overlayEntryIsWhiteout(path string, info fs.FileInfo) bool {
+	if info.Mode()&fs.ModeCharDevice != 0 {
+		var stat unix.Stat_t
+		if err := unix.Lstat(path, &stat); err != nil {
+			return false
+		}
+		return unix.Major(uint64(stat.Rdev)) == 0 && unix.Minor(uint64(stat.Rdev)) == 0
+	}
+	if !info.Mode().IsRegular() || info.Size() != 0 {
+		return false
+	}
+	return hasOverlayXattr(path, "trusted.overlay.whiteout") || hasOverlayXattr(path, "user.overlay.whiteout")
+}
 
 func overlayDirIsOpaque(path string) bool {
+	return overlayXattrValueIs(path, "trusted.overlay.opaque", 'y') || overlayXattrValueIs(path, "user.overlay.opaque", 'y')
+}
+
+func hasOverlayXattr(path, name string) bool {
+	_, err := unix.Getxattr(path, name, nil)
+	return err == nil || (err != nil && !xattrMissing(err) && overlayXattrValueIs(path, name, 0))
+}
+
+func overlayXattrValueIs(path, name string, want byte) bool {
 	value := make([]byte, 1)
-	n, err := unix.Getxattr(path, "trusted.overlay.opaque", value)
-	return err == nil && n == 1 && value[0] == 'y'
+	n, err := unix.Getxattr(path, name, value)
+	return err == nil && n == 1 && (want == 0 || value[0] == want)
+}
+
+func xattrMissing(err error) bool {
+	return errors.Is(err, unix.ENODATA) || errors.Is(err, unix.ENOTSUP) || errors.Is(err, unix.EOPNOTSUPP)
 }

--- a/internal/overlaycapture/opaque_linux.go
+++ b/internal/overlaycapture/opaque_linux.go
@@ -24,18 +24,27 @@ func overlayEntryIsWhiteout(path string, info fs.FileInfo) bool {
 }
 
 func overlayDirIsOpaque(path string) bool {
-	return overlayXattrValueIs(path, "trusted.overlay.opaque", 'y') || overlayXattrValueIs(path, "user.overlay.opaque", 'y')
+	return overlayXattrValueIn(path, "trusted.overlay.opaque", 'y', 'x') ||
+		overlayXattrValueIn(path, "user.overlay.opaque", 'y', 'x')
 }
 
 func hasOverlayXattr(path, name string) bool {
 	_, err := unix.Getxattr(path, name, nil)
-	return err == nil || (err != nil && !xattrMissing(err) && overlayXattrValueIs(path, name, 0))
+	return err == nil || (err != nil && !xattrMissing(err) && overlayXattrValueIn(path, name, 0))
 }
 
-func overlayXattrValueIs(path, name string, want byte) bool {
+func overlayXattrValueIn(path, name string, allowed ...byte) bool {
 	value := make([]byte, 1)
 	n, err := unix.Getxattr(path, name, value)
-	return err == nil && n == 1 && (want == 0 || value[0] == want)
+	if err != nil || n != 1 {
+		return false
+	}
+	for _, want := range allowed {
+		if want == 0 || value[0] == want {
+			return true
+		}
+	}
+	return false
 }
 
 func xattrMissing(err error) bool {

--- a/internal/overlaycapture/opaque_linux.go
+++ b/internal/overlaycapture/opaque_linux.go
@@ -1,0 +1,11 @@
+//go:build linux
+
+package overlaycapture
+
+import "golang.org/x/sys/unix"
+
+func overlayDirIsOpaque(path string) bool {
+	value := make([]byte, 1)
+	n, err := unix.Getxattr(path, "trusted.overlay.opaque", value)
+	return err == nil && n == 1 && value[0] == 'y'
+}

--- a/internal/overlaycapture/opaque_linux_test.go
+++ b/internal/overlaycapture/opaque_linux_test.go
@@ -36,3 +36,31 @@ func TestScanReportsOverlayWhiteoutXattrAsDelete(t *testing.T) {
 	assertEntry(t, result.Entries, Entry{Path: "/workspace/.wh.cache", Kind: EntryKindDelete})
 	assertEntry(t, result.EscapedWrites, Entry{Path: "/workspace/.wh.cache", Kind: EntryKindDelete})
 }
+
+func TestScanReportsOverlayOpaqueXattrXAsOpaqueDir(t *testing.T) {
+	t.Parallel()
+
+	upperDir := t.TempDir()
+	opaqueDir := filepath.Join(upperDir, "workspace", "cache")
+	if err := os.MkdirAll(opaqueDir, 0o755); err != nil {
+		t.Fatalf("create opaque dir: %v", err)
+	}
+	setTestXattr(t, opaqueDir, "user.overlay.opaque", []byte{'x'})
+
+	result, err := Scan(upperDir, Options{})
+	if err != nil {
+		t.Fatalf("Scan returned error: %v", err)
+	}
+	assertEntry(t, result.Entries, Entry{Path: "/workspace/cache", Kind: EntryKindOpaqueDir})
+	assertEntry(t, result.EscapedWrites, Entry{Path: "/workspace/cache", Kind: EntryKindOpaqueDir})
+}
+
+func setTestXattr(t *testing.T, path, name string, value []byte) {
+	t.Helper()
+	if err := unix.Setxattr(path, name, value, 0); err != nil {
+		if errors.Is(err, unix.ENOTSUP) || errors.Is(err, unix.EOPNOTSUPP) {
+			t.Skipf("xattrs unsupported on temp filesystem: %v", err)
+		}
+		t.Fatalf("set %s xattr: %v", name, err)
+	}
+}

--- a/internal/overlaycapture/opaque_linux_test.go
+++ b/internal/overlaycapture/opaque_linux_test.go
@@ -33,6 +33,6 @@ func TestScanReportsOverlayWhiteoutXattrAsDelete(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Scan returned error: %v", err)
 	}
-	assertEntry(t, result.Entries, Entry{Path: "/workspace/cache", Kind: EntryKindDelete})
-	assertEntry(t, result.EscapedWrites, Entry{Path: "/workspace/cache", Kind: EntryKindDelete})
+	assertEntry(t, result.Entries, Entry{Path: "/workspace/.wh.cache", Kind: EntryKindDelete})
+	assertEntry(t, result.EscapedWrites, Entry{Path: "/workspace/.wh.cache", Kind: EntryKindDelete})
 }

--- a/internal/overlaycapture/opaque_linux_test.go
+++ b/internal/overlaycapture/opaque_linux_test.go
@@ -1,0 +1,38 @@
+//go:build linux
+
+package overlaycapture
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestScanReportsOverlayWhiteoutXattrAsDelete(t *testing.T) {
+	t.Parallel()
+
+	upperDir := t.TempDir()
+	whiteout := filepath.Join(upperDir, "workspace", ".wh.cache")
+	if err := os.MkdirAll(filepath.Dir(whiteout), 0o755); err != nil {
+		t.Fatalf("create whiteout parent: %v", err)
+	}
+	if err := os.WriteFile(whiteout, nil, 0o644); err != nil {
+		t.Fatalf("write whiteout marker: %v", err)
+	}
+	if err := unix.Setxattr(whiteout, "user.overlay.whiteout", nil, 0); err != nil {
+		if errors.Is(err, unix.ENOTSUP) || errors.Is(err, unix.EOPNOTSUPP) {
+			t.Skipf("xattrs unsupported on temp filesystem: %v", err)
+		}
+		t.Fatalf("set whiteout xattr: %v", err)
+	}
+
+	result, err := Scan(upperDir, Options{})
+	if err != nil {
+		t.Fatalf("Scan returned error: %v", err)
+	}
+	assertEntry(t, result.Entries, Entry{Path: "/workspace/cache", Kind: EntryKindDelete})
+	assertEntry(t, result.EscapedWrites, Entry{Path: "/workspace/cache", Kind: EntryKindDelete})
+}

--- a/internal/overlaycapture/opaque_other.go
+++ b/internal/overlaycapture/opaque_other.go
@@ -2,6 +2,12 @@
 
 package overlaycapture
 
+import "io/fs"
+
+func overlayEntryIsWhiteout(string, fs.FileInfo) bool {
+	return false
+}
+
 func overlayDirIsOpaque(string) bool {
 	return false
 }

--- a/internal/overlaycapture/opaque_other.go
+++ b/internal/overlaycapture/opaque_other.go
@@ -1,0 +1,7 @@
+//go:build !linux
+
+package overlaycapture
+
+func overlayDirIsOpaque(string) bool {
+	return false
+}

--- a/internal/overlaycapture/scan.go
+++ b/internal/overlaycapture/scan.go
@@ -87,9 +87,6 @@ func Scan(upperDir string, opts Options) (Result, error) {
 		entry := Entry{Path: guestPath, Kind: EntryKindWrite, Mode: info.Mode()}
 		if overlayEntryIsWhiteout(current, info) {
 			entry.Kind = EntryKindDelete
-			if target, ok := whiteoutPath(rel); ok {
-				entry.Path = target
-			}
 		} else if dirent.IsDir() && overlayDirIsOpaque(current) {
 			entry.Kind = EntryKindOpaqueDir
 		}
@@ -200,22 +197,6 @@ func upperdirRelGuestPath(rel string) string {
 		return "/"
 	}
 	return path.Clean("/" + rel)
-}
-
-func whiteoutPath(rel string) (string, bool) {
-	name := filepath.Base(rel)
-	if name == ".wh..wh..opq" || !strings.HasPrefix(name, ".wh.") {
-		return "", false
-	}
-	target := strings.TrimPrefix(name, ".wh.")
-	if target == "" {
-		return "", false
-	}
-	parent := filepath.Dir(rel)
-	if parent == "." {
-		return "/" + target, true
-	}
-	return upperdirRelGuestPath(filepath.Join(parent, target)), true
 }
 
 func sortEntries(entries []Entry) {

--- a/internal/overlaycapture/scan.go
+++ b/internal/overlaycapture/scan.go
@@ -80,25 +80,16 @@ func Scan(upperDir string, opts Options) (Result, error) {
 			return filepath.SkipDir
 		}
 
-		name := dirent.Name()
-		if name == ".wh..wh..opq" {
-			entry := Entry{Path: upperdirRelGuestPath(filepath.Dir(rel)), Kind: EntryKindOpaqueDir}
-			entries = append(entries, entry)
-			return nil
-		}
-		if target, ok := whiteoutPath(rel); ok {
-			entry := Entry{Path: target, Kind: EntryKindDelete}
-			entries = append(entries, entry)
-			return nil
-		}
-
 		info, err := dirent.Info()
 		if err != nil {
 			return fmt.Errorf("stat overlay upperdir path %s: %w", current, err)
 		}
 		entry := Entry{Path: guestPath, Kind: EntryKindWrite, Mode: info.Mode()}
-		if info.Mode()&fs.ModeCharDevice != 0 {
+		if overlayEntryIsWhiteout(current, info) {
 			entry.Kind = EntryKindDelete
+			if target, ok := whiteoutPath(rel); ok {
+				entry.Path = target
+			}
 		} else if dirent.IsDir() && overlayDirIsOpaque(current) {
 			entry.Kind = EntryKindOpaqueDir
 		}
@@ -157,6 +148,9 @@ func newFilter(opts Options) (filter, error) {
 		cleaned, err := cleanGuestPath("ignored prefix", value)
 		if err != nil {
 			return filter{}, err
+		}
+		if cleaned == "/" {
+			return filter{}, errors.New("ignored prefix cannot be /")
 		}
 		out.ignoredPrefixes = append(out.ignoredPrefixes, cleaned)
 	}

--- a/internal/overlaycapture/scan.go
+++ b/internal/overlaycapture/scan.go
@@ -1,0 +1,234 @@
+package overlaycapture
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+type EntryKind string
+
+const (
+	EntryKindWrite     EntryKind = "write"
+	EntryKindDelete    EntryKind = "delete"
+	EntryKindOpaqueDir EntryKind = "opaque_dir"
+)
+
+type Entry struct {
+	Path string
+	Kind EntryKind
+	Mode fs.FileMode
+}
+
+type Options struct {
+	BaselinePaths       []string
+	DeclaredFileOutputs []string
+	IgnoredPrefixes     []string
+}
+
+type Result struct {
+	Entries       []Entry
+	EscapedWrites []Entry
+}
+
+func Scan(upperDir string, opts Options) (Result, error) {
+	upperDir = strings.TrimSpace(upperDir)
+	if upperDir == "" {
+		return Result{}, errors.New("missing overlay upperdir")
+	}
+	upperDir = filepath.Clean(upperDir)
+	if !filepath.IsAbs(upperDir) {
+		return Result{}, fmt.Errorf("overlay upperdir %q is not absolute", upperDir)
+	}
+	info, err := os.Stat(upperDir)
+	if err != nil {
+		return Result{}, fmt.Errorf("stat overlay upperdir %s: %w", upperDir, err)
+	}
+	if !info.IsDir() {
+		return Result{}, fmt.Errorf("overlay upperdir %s is not a directory", upperDir)
+	}
+
+	filter, err := newFilter(opts)
+	if err != nil {
+		return Result{}, err
+	}
+
+	var entries []Entry
+	if err := filepath.WalkDir(upperDir, func(current string, dirent os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return fmt.Errorf("walk overlay upperdir path %s: %w", current, walkErr)
+		}
+		if current == upperDir {
+			return nil
+		}
+
+		rel, err := filepath.Rel(upperDir, current)
+		if err != nil {
+			return fmt.Errorf("rel overlay upperdir path %s: %w", current, err)
+		}
+		if rel == "." || filepath.IsAbs(rel) || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
+			return fmt.Errorf("overlay upperdir path %s escapes %s", current, upperDir)
+		}
+
+		guestPath := upperdirRelGuestPath(rel)
+		if filter.ignored(guestPath) && dirent.IsDir() {
+			return filepath.SkipDir
+		}
+
+		name := dirent.Name()
+		if name == ".wh..wh..opq" {
+			entry := Entry{Path: upperdirRelGuestPath(filepath.Dir(rel)), Kind: EntryKindOpaqueDir}
+			entries = append(entries, entry)
+			return nil
+		}
+		if target, ok := whiteoutPath(rel); ok {
+			entry := Entry{Path: target, Kind: EntryKindDelete}
+			entries = append(entries, entry)
+			return nil
+		}
+
+		info, err := dirent.Info()
+		if err != nil {
+			return fmt.Errorf("stat overlay upperdir path %s: %w", current, err)
+		}
+		entry := Entry{Path: guestPath, Kind: EntryKindWrite, Mode: info.Mode()}
+		if info.Mode()&fs.ModeCharDevice != 0 {
+			entry.Kind = EntryKindDelete
+		} else if dirent.IsDir() && overlayDirIsOpaque(current) {
+			entry.Kind = EntryKindOpaqueDir
+		}
+		entries = append(entries, entry)
+		return nil
+	}); err != nil {
+		return Result{}, err
+	}
+
+	sortEntries(entries)
+	escaped := make([]Entry, 0, len(entries))
+	for _, entry := range entries {
+		if filter.allowed(entry) {
+			continue
+		}
+		escaped = append(escaped, entry)
+	}
+	return Result{Entries: entries, EscapedWrites: escaped}, nil
+}
+
+type filter struct {
+	baseline        map[string]struct{}
+	fileOutputs     map[string]struct{}
+	fileAncestors   map[string]struct{}
+	ignoredPrefixes []string
+}
+
+func newFilter(opts Options) (filter, error) {
+	out := filter{
+		baseline:      make(map[string]struct{}, len(opts.BaselinePaths)),
+		fileOutputs:   make(map[string]struct{}, len(opts.DeclaredFileOutputs)),
+		fileAncestors: make(map[string]struct{}),
+	}
+
+	for _, value := range opts.BaselinePaths {
+		cleaned, err := cleanGuestPath("baseline path", value)
+		if err != nil {
+			return filter{}, err
+		}
+		out.baseline[cleaned] = struct{}{}
+	}
+	for _, value := range opts.DeclaredFileOutputs {
+		cleaned, err := cleanGuestPath("declared file output", value)
+		if err != nil {
+			return filter{}, err
+		}
+		if cleaned == "/" {
+			return filter{}, errors.New("declared file output cannot be /")
+		}
+		out.fileOutputs[cleaned] = struct{}{}
+		for dir := path.Dir(cleaned); dir != "." && dir != "/"; dir = path.Dir(dir) {
+			out.fileAncestors[dir] = struct{}{}
+		}
+	}
+	for _, value := range opts.IgnoredPrefixes {
+		cleaned, err := cleanGuestPath("ignored prefix", value)
+		if err != nil {
+			return filter{}, err
+		}
+		out.ignoredPrefixes = append(out.ignoredPrefixes, cleaned)
+	}
+	sort.Strings(out.ignoredPrefixes)
+	return out, nil
+}
+
+func (f filter) allowed(entry Entry) bool {
+	if f.ignored(entry.Path) {
+		return true
+	}
+	if _, ok := f.baseline[entry.Path]; ok && entry.Kind == EntryKindWrite && entry.Mode.IsDir() {
+		return true
+	}
+	if _, ok := f.fileOutputs[entry.Path]; ok {
+		return true
+	}
+	if _, ok := f.fileAncestors[entry.Path]; ok && entry.Kind == EntryKindWrite && entry.Mode.IsDir() {
+		return true
+	}
+	return false
+}
+
+func (f filter) ignored(guestPath string) bool {
+	for _, prefix := range f.ignoredPrefixes {
+		if guestPath == prefix || strings.HasPrefix(guestPath, prefix+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+func cleanGuestPath(name, value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", fmt.Errorf("missing %s", name)
+	}
+	if !strings.HasPrefix(value, "/") {
+		return "", fmt.Errorf("%s %q is not absolute", name, value)
+	}
+	return path.Clean(value), nil
+}
+
+func upperdirRelGuestPath(rel string) string {
+	rel = filepath.ToSlash(filepath.Clean(rel))
+	if rel == "." {
+		return "/"
+	}
+	return path.Clean("/" + rel)
+}
+
+func whiteoutPath(rel string) (string, bool) {
+	name := filepath.Base(rel)
+	if name == ".wh..wh..opq" || !strings.HasPrefix(name, ".wh.") {
+		return "", false
+	}
+	target := strings.TrimPrefix(name, ".wh.")
+	if target == "" {
+		return "", false
+	}
+	parent := filepath.Dir(rel)
+	if parent == "." {
+		return "/" + target, true
+	}
+	return upperdirRelGuestPath(filepath.Join(parent, target)), true
+}
+
+func sortEntries(entries []Entry) {
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].Path != entries[j].Path {
+			return entries[i].Path < entries[j].Path
+		}
+		return entries[i].Kind < entries[j].Kind
+	})
+}

--- a/internal/overlaycapture/scan.go
+++ b/internal/overlaycapture/scan.go
@@ -45,6 +45,14 @@ func Scan(upperDir string, opts Options) (Result, error) {
 	if !filepath.IsAbs(upperDir) {
 		return Result{}, fmt.Errorf("overlay upperdir %q is not absolute", upperDir)
 	}
+	resolvedUpperDir, err := filepath.EvalSymlinks(upperDir)
+	if err != nil {
+		return Result{}, fmt.Errorf("resolve overlay upperdir %s: %w", upperDir, err)
+	}
+	upperDir = filepath.Clean(resolvedUpperDir)
+	if !filepath.IsAbs(upperDir) {
+		return Result{}, fmt.Errorf("resolved overlay upperdir %q is not absolute", upperDir)
+	}
 	info, err := os.Stat(upperDir)
 	if err != nil {
 		return Result{}, fmt.Errorf("stat overlay upperdir %s: %w", upperDir, err)

--- a/internal/overlaycapture/scan.go
+++ b/internal/overlaycapture/scan.go
@@ -170,7 +170,7 @@ func (f filter) allowed(entry Entry) bool {
 	if _, ok := f.baseline[entry.Path]; ok && entry.Kind == EntryKindWrite && entry.Mode.IsDir() {
 		return true
 	}
-	if _, ok := f.fileOutputs[entry.Path]; ok {
+	if _, ok := f.fileOutputs[entry.Path]; ok && entry.Kind == EntryKindWrite && entry.Mode.IsRegular() {
 		return true
 	}
 	if _, ok := f.fileAncestors[entry.Path]; ok && entry.Kind == EntryKindWrite && entry.Mode.IsDir() {

--- a/internal/overlaycapture/scan_test.go
+++ b/internal/overlaycapture/scan_test.go
@@ -46,6 +46,21 @@ func TestScanReportsEscapedWrites(t *testing.T) {
 	}
 }
 
+func TestScanReportsDeclaredFileOutputDirectoryAsEscaped(t *testing.T) {
+	t.Parallel()
+
+	upperDir := t.TempDir()
+	mkdir(t, upperDir, "workspace/result.txt")
+
+	result, err := Scan(upperDir, Options{
+		DeclaredFileOutputs: []string{"/workspace/result.txt"},
+	})
+	if err != nil {
+		t.Fatalf("Scan returned error: %v", err)
+	}
+	assertEntry(t, result.EscapedWrites, Entry{Path: "/workspace/result.txt", Kind: EntryKindWrite})
+}
+
 func TestScanCanonicalizesSymlinkedUpperDir(t *testing.T) {
 	t.Parallel()
 

--- a/internal/overlaycapture/scan_test.go
+++ b/internal/overlaycapture/scan_test.go
@@ -65,7 +65,7 @@ func TestScanIgnoresScratchPrefixWithoutIgnoringSibling(t *testing.T) {
 	assertEntry(t, result.EscapedWrites, Entry{Path: "/tmpish/cache", Kind: EntryKindWrite, Mode: 0o644})
 }
 
-func TestScanReportsWhiteoutsAsDeletes(t *testing.T) {
+func TestScanDoesNotTreatRegularWhiteoutNamedFilesAsDeletes(t *testing.T) {
 	t.Parallel()
 
 	upperDir := t.TempDir()
@@ -76,25 +76,24 @@ func TestScanReportsWhiteoutsAsDeletes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Scan returned error: %v", err)
 	}
-	assertEntry(t, result.Entries, Entry{Path: "/home/user/deleted", Kind: EntryKindDelete})
-	assertEntry(t, result.EscapedWrites, Entry{Path: "/home/user/deleted", Kind: EntryKindDelete})
-	assertEntry(t, result.Entries, Entry{Path: "/var/lib/app", Kind: EntryKindOpaqueDir})
-	assertEntry(t, result.EscapedWrites, Entry{Path: "/var/lib/app", Kind: EntryKindOpaqueDir})
+	assertEntry(t, result.Entries, Entry{Path: "/home/user/.wh.deleted", Kind: EntryKindWrite})
+	assertEntry(t, result.EscapedWrites, Entry{Path: "/home/user/.wh.deleted", Kind: EntryKindWrite})
+	assertEntry(t, result.Entries, Entry{Path: "/var/lib/app/.wh..wh..opq", Kind: EntryKindWrite})
+	assertEntry(t, result.EscapedWrites, Entry{Path: "/var/lib/app/.wh..wh..opq", Kind: EntryKindWrite})
 }
 
 func TestScanDoesNotAllowDeleteOfBaselinePath(t *testing.T) {
 	t.Parallel()
 
-	upperDir := t.TempDir()
-	writeFile(t, upperDir, "mnt/.wh.cache")
-
-	result, err := Scan(upperDir, Options{
+	filter, err := newFilter(Options{
 		BaselinePaths: []string{"/mnt", "/mnt/cache"},
 	})
 	if err != nil {
-		t.Fatalf("Scan returned error: %v", err)
+		t.Fatalf("newFilter returned error: %v", err)
 	}
-	assertEntry(t, result.EscapedWrites, Entry{Path: "/mnt/cache", Kind: EntryKindDelete})
+	if filter.allowed(Entry{Path: "/mnt/cache", Kind: EntryKindDelete}) {
+		t.Fatal("baseline delete was allowed")
+	}
 }
 
 func TestScanRejectsEscapingOptions(t *testing.T) {
@@ -105,6 +104,17 @@ func TestScanRejectsEscapingOptions(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected relative declared file output to fail")
+	}
+}
+
+func TestScanRejectsRootIgnoredPrefix(t *testing.T) {
+	t.Parallel()
+
+	_, err := Scan(t.TempDir(), Options{
+		IgnoredPrefixes: []string{"/"},
+	})
+	if err == nil {
+		t.Fatal("expected root ignored prefix to fail")
 	}
 }
 

--- a/internal/overlaycapture/scan_test.go
+++ b/internal/overlaycapture/scan_test.go
@@ -1,0 +1,143 @@
+package overlaycapture
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+func TestScanAllowsDeclaredFileOutputsAndAncestors(t *testing.T) {
+	t.Parallel()
+
+	upperDir := t.TempDir()
+	writeFile(t, upperDir, "usr/local/bin/tool")
+	mkdir(t, upperDir, "root/.local/share/mise")
+
+	result, err := Scan(upperDir, Options{
+		BaselinePaths:       []string{"/root", "/root/.local", "/root/.local/share", "/root/.local/share/mise"},
+		DeclaredFileOutputs: []string{"/usr/local/bin/tool"},
+	})
+	if err != nil {
+		t.Fatalf("Scan returned error: %v", err)
+	}
+	if len(result.EscapedWrites) != 0 {
+		t.Fatalf("unexpected escaped writes: %#v", result.EscapedWrites)
+	}
+	assertEntry(t, result.Entries, Entry{Path: "/usr/local/bin/tool", Kind: EntryKindWrite, Mode: 0o644})
+}
+
+func TestScanReportsEscapedWrites(t *testing.T) {
+	t.Parallel()
+
+	upperDir := t.TempDir()
+	writeFile(t, upperDir, "workspace/dist/result.txt")
+	writeFile(t, upperDir, "etc/profile")
+
+	result, err := Scan(upperDir, Options{
+		DeclaredFileOutputs: []string{"/workspace/dist/result.txt"},
+	})
+	if err != nil {
+		t.Fatalf("Scan returned error: %v", err)
+	}
+	assertEntry(t, result.EscapedWrites, Entry{Path: "/etc/profile", Kind: EntryKindWrite, Mode: 0o644})
+	if hasEntry(result.EscapedWrites, "/workspace/dist/result.txt", EntryKindWrite) {
+		t.Fatalf("declared file output reported as escaped: %#v", result.EscapedWrites)
+	}
+}
+
+func TestScanIgnoresScratchPrefixWithoutIgnoringSibling(t *testing.T) {
+	t.Parallel()
+
+	upperDir := t.TempDir()
+	writeFile(t, upperDir, "tmp/cache")
+	writeFile(t, upperDir, "tmpish/cache")
+
+	result, err := Scan(upperDir, Options{
+		IgnoredPrefixes: []string{"/tmp"},
+	})
+	if err != nil {
+		t.Fatalf("Scan returned error: %v", err)
+	}
+	if hasEntry(result.EscapedWrites, "/tmp/cache", EntryKindWrite) {
+		t.Fatalf("ignored scratch write reported as escaped: %#v", result.EscapedWrites)
+	}
+	assertEntry(t, result.EscapedWrites, Entry{Path: "/tmpish/cache", Kind: EntryKindWrite, Mode: 0o644})
+}
+
+func TestScanReportsWhiteoutsAsDeletes(t *testing.T) {
+	t.Parallel()
+
+	upperDir := t.TempDir()
+	writeFile(t, upperDir, "home/user/.wh.deleted")
+	writeFile(t, upperDir, "var/lib/app/.wh..wh..opq")
+
+	result, err := Scan(upperDir, Options{})
+	if err != nil {
+		t.Fatalf("Scan returned error: %v", err)
+	}
+	assertEntry(t, result.Entries, Entry{Path: "/home/user/deleted", Kind: EntryKindDelete})
+	assertEntry(t, result.EscapedWrites, Entry{Path: "/home/user/deleted", Kind: EntryKindDelete})
+	assertEntry(t, result.Entries, Entry{Path: "/var/lib/app", Kind: EntryKindOpaqueDir})
+	assertEntry(t, result.EscapedWrites, Entry{Path: "/var/lib/app", Kind: EntryKindOpaqueDir})
+}
+
+func TestScanDoesNotAllowDeleteOfBaselinePath(t *testing.T) {
+	t.Parallel()
+
+	upperDir := t.TempDir()
+	writeFile(t, upperDir, "mnt/.wh.cache")
+
+	result, err := Scan(upperDir, Options{
+		BaselinePaths: []string{"/mnt", "/mnt/cache"},
+	})
+	if err != nil {
+		t.Fatalf("Scan returned error: %v", err)
+	}
+	assertEntry(t, result.EscapedWrites, Entry{Path: "/mnt/cache", Kind: EntryKindDelete})
+}
+
+func TestScanRejectsEscapingOptions(t *testing.T) {
+	t.Parallel()
+
+	_, err := Scan(t.TempDir(), Options{
+		DeclaredFileOutputs: []string{"../result"},
+	})
+	if err == nil {
+		t.Fatal("expected relative declared file output to fail")
+	}
+}
+
+func writeFile(t *testing.T, root, rel string) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create parent for %s: %v", rel, err)
+	}
+	if err := os.WriteFile(path, []byte(rel), 0o644); err != nil {
+		t.Fatalf("write %s: %v", rel, err)
+	}
+}
+
+func mkdir(t *testing.T, root, rel string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(root, filepath.FromSlash(rel)), 0o755); err != nil {
+		t.Fatalf("create %s: %v", rel, err)
+	}
+}
+
+func assertEntry(t *testing.T, entries []Entry, want Entry) {
+	t.Helper()
+	if slices.ContainsFunc(entries, func(got Entry) bool {
+		return got.Path == want.Path && got.Kind == want.Kind && (want.Mode == 0 || got.Mode.Perm() == want.Mode.Perm())
+	}) {
+		return
+	}
+	t.Fatalf("missing entry %#v in %#v", want, entries)
+}
+
+func hasEntry(entries []Entry, path string, kind EntryKind) bool {
+	return slices.ContainsFunc(entries, func(entry Entry) bool {
+		return entry.Path == path && entry.Kind == kind
+	})
+}

--- a/internal/overlaycapture/scan_test.go
+++ b/internal/overlaycapture/scan_test.go
@@ -46,6 +46,27 @@ func TestScanReportsEscapedWrites(t *testing.T) {
 	}
 }
 
+func TestScanCanonicalizesSymlinkedUpperDir(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	upperDir := filepath.Join(tempDir, "upper")
+	if err := os.MkdirAll(upperDir, 0o755); err != nil {
+		t.Fatalf("create upperdir: %v", err)
+	}
+	writeFile(t, upperDir, "etc/profile")
+	upperLink := filepath.Join(tempDir, "upper-link")
+	if err := os.Symlink(upperDir, upperLink); err != nil {
+		t.Fatalf("create upperdir symlink: %v", err)
+	}
+
+	result, err := Scan(upperLink, Options{})
+	if err != nil {
+		t.Fatalf("Scan returned error: %v", err)
+	}
+	assertEntry(t, result.EscapedWrites, Entry{Path: "/etc/profile", Kind: EntryKindWrite, Mode: 0o644})
+}
+
 func TestScanIgnoresScratchPrefixWithoutIgnoringSibling(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What This Is Part Of

This is the first follow-up slice after the darwin-vz cache-output sidecar volume work. It is part of the dependency/service volume-cache plan in `docs/plans/dependency-service-volume-caches.md`.

The larger goal is to make dependency and service block misses reusable without publishing a full rootfs snapshot. To do that safely, Cleanroom needs to know whether a block wrote only to declared outputs, or whether it also made persistent writes elsewhere in the sandbox. Those undeclared writes are the "escaped writes" that would make a file-keyed output cache unsafe.

## Why This Slice Exists

PR 301 made darwin-vz capable of attaching sidecar output volumes, but Cleanroom still must not advertise `sandbox.overlay_write_capture` or select the block-volume runtime path until escaped-write detection and output publication are wired through.

This PR adds the reusable scanner/classifier for the future overlay write-capture runner. It lets later slices inspect an overlay upperdir and decide which writes are safe to publish, which are setup noise, and which are escaped persistent writes that should trigger fallback.

## What Changed

- added an internal overlay upperdir scanner/classifier
- classified writes, deletes, and opaque-directory markers from overlayfs upperdir state
- allowed only safe setup baseline directory writes, declared file outputs, declared file-output ancestors, and configured scratch prefixes
- covered the baseline deletion case so a whiteout at a setup path is still treated as an escaped write

## What This Deliberately Does Not Do

- does not advertise `sandbox.overlay_write_capture`
- does not change dependency or service block-volume runtime selection
- does not wire the scanner into guest execution yet
- does not publish dependency/service output records
- does not change darwin-vz or Firecracker capability reporting

## Validation

- `GOCACHE=/private/tmp/cleanroom-go-build-cache mise exec -- go test ./internal/overlaycapture`
- `GOOS=linux GOARCH=arm64 GOCACHE=/private/tmp/cleanroom-go-build-cache mise exec -- go test -c ./internal/overlaycapture -o /private/tmp/cleanroom-overlaycapture-linux-arm64.test`
- `GOCACHE=/private/tmp/cleanroom-go-build-cache mise exec -- go test ./...`
