### PR TITLE
feat: Add overlay capture exec protocol

### DIFF
--- a/cmd/cleanroom-guest-agent/main.go
+++ b/cmd/cleanroom-guest-agent/main.go
@@ -128,7 +128,7 @@ func handleConnTTY(conn io.ReadWriteCloser, dec *json.Decoder, req vsockexec.Exe
 	// PTY read returns EIO when the slave side closes; ignore the error.
 	_, _ = io.Copy(streamFrameWriter{send: sender.Send, kind: "stdout"}, ptmx)
 
-	sendExitResult(sender, cmd.Wait())
+	sendExitResult(sender, cmd.Wait(), req.OverlayCapture)
 }
 
 func handleConnPipes(conn io.ReadWriteCloser, dec *json.Decoder, req vsockexec.ExecRequest) {
@@ -181,15 +181,7 @@ func handleConnPipes(conn io.ReadWriteCloser, dec *json.Decoder, req vsockexec.E
 
 	wg.Wait()
 	waitErr := cmd.Wait()
-	exitCode, errMsg := exitResult(waitErr)
-
-	if err := sender.Send(vsockexec.ExecStreamFrame{
-		Type:     "exit",
-		ExitCode: exitCode,
-		Error:    errMsg,
-	}); err != nil {
-		return
-	}
+	sendExitResult(sender, waitErr, req.OverlayCapture)
 }
 
 func readInputFrames(dec *json.Decoder, w io.Writer, closeStdin func(), resizeFn func(cols, rows uint16)) {
@@ -236,12 +228,24 @@ func sendErrorResponse(w io.Writer, err error) {
 	}
 }
 
-func sendExitResult(sender *frameSender, waitErr error) {
+func sendExitResult(sender *frameSender, waitErr error, capture *vsockexec.OverlayCapture) {
 	exitCode, errMsg := exitResult(waitErr)
+	captureResult, captureErr := scanOverlayCapture(capture)
+	if captureErr != nil {
+		if exitCode == 0 {
+			exitCode = 1
+		}
+		if errMsg == "" {
+			errMsg = captureErr.Error()
+		} else {
+			errMsg += "; " + captureErr.Error()
+		}
+	}
 	if err := sender.Send(vsockexec.ExecStreamFrame{
-		Type:     "exit",
-		ExitCode: exitCode,
-		Error:    errMsg,
+		Type:           "exit",
+		ExitCode:       exitCode,
+		Error:          errMsg,
+		OverlayCapture: captureResult,
 	}); err != nil {
 		return
 	}

--- a/cmd/cleanroom-guest-agent/overlay_capture.go
+++ b/cmd/cleanroom-guest-agent/overlay_capture.go
@@ -1,0 +1,43 @@
+//go:build linux
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/buildkite/cleanroom/internal/overlaycapture"
+	"github.com/buildkite/cleanroom/internal/vsockexec"
+)
+
+func scanOverlayCapture(capture *vsockexec.OverlayCapture) (*vsockexec.OverlayCaptureResult, error) {
+	if capture == nil {
+		return nil, nil
+	}
+	result, err := overlaycapture.Scan(capture.UpperDir, overlaycapture.Options{
+		BaselinePaths:       append([]string(nil), capture.BaselinePaths...),
+		DeclaredFileOutputs: append([]string(nil), capture.DeclaredFileOutputs...),
+		IgnoredPrefixes:     append([]string(nil), capture.IgnoredPrefixes...),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("scan overlay capture: %w", err)
+	}
+	return &vsockexec.OverlayCaptureResult{
+		Entries:       overlayCaptureEntries(result.Entries),
+		EscapedWrites: overlayCaptureEntries(result.EscapedWrites),
+	}, nil
+}
+
+func overlayCaptureEntries(entries []overlaycapture.Entry) []vsockexec.OverlayCaptureEntry {
+	if len(entries) == 0 {
+		return nil
+	}
+	out := make([]vsockexec.OverlayCaptureEntry, 0, len(entries))
+	for _, entry := range entries {
+		out = append(out, vsockexec.OverlayCaptureEntry{
+			Path: entry.Path,
+			Kind: string(entry.Kind),
+			Mode: uint32(entry.Mode),
+		})
+	}
+	return out
+}

--- a/cmd/cleanroom-guest-agent/overlay_capture_test.go
+++ b/cmd/cleanroom-guest-agent/overlay_capture_test.go
@@ -1,0 +1,94 @@
+//go:build linux
+
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/vsockexec"
+)
+
+func TestScanOverlayCaptureReportsEscapedWrites(t *testing.T) {
+	t.Parallel()
+
+	upperDir := t.TempDir()
+	writeOverlayCaptureTestFile(t, upperDir, "workspace/result.txt")
+	writeOverlayCaptureTestFile(t, upperDir, "etc/profile")
+
+	result, err := scanOverlayCapture(&vsockexec.OverlayCapture{
+		UpperDir:            upperDir,
+		DeclaredFileOutputs: []string{"/workspace/result.txt"},
+	})
+	if err != nil {
+		t.Fatalf("scanOverlayCapture returned error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected overlay capture result")
+	}
+	if got, want := len(result.EscapedWrites), 1; got != want {
+		t.Fatalf("unexpected escaped write count: got %d want %d", got, want)
+	}
+	if got, want := result.EscapedWrites[0], (vsockexec.OverlayCaptureEntry{Path: "/etc/profile", Kind: "write", Mode: 0o644}); got != want {
+		t.Fatalf("unexpected escaped write: got %#v want %#v", got, want)
+	}
+}
+
+func TestSendExitResultFailsWhenOverlayCaptureScanFails(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	sendExitResult(newFrameSender(&buf), nil, &vsockexec.OverlayCapture{UpperDir: filepath.Join(t.TempDir(), "missing")})
+
+	res, err := vsockexec.DecodeStreamResponse(&buf, vsockexec.StreamCallbacks{})
+	if err != nil {
+		t.Fatalf("DecodeStreamResponse returned error: %v", err)
+	}
+	if got, want := res.ExitCode, 1; got != want {
+		t.Fatalf("unexpected exit code: got %d want %d", got, want)
+	}
+	if !strings.Contains(res.Error, "scan overlay capture") {
+		t.Fatalf("unexpected error: %q", res.Error)
+	}
+}
+
+func TestSendExitResultIncludesOverlayCapture(t *testing.T) {
+	t.Parallel()
+
+	upperDir := t.TempDir()
+	writeOverlayCaptureTestFile(t, upperDir, "etc/profile")
+
+	var buf bytes.Buffer
+	sendExitResult(newFrameSender(&buf), nil, &vsockexec.OverlayCapture{UpperDir: upperDir})
+
+	res, err := vsockexec.DecodeStreamResponse(&buf, vsockexec.StreamCallbacks{})
+	if err != nil {
+		t.Fatalf("DecodeStreamResponse returned error: %v", err)
+	}
+	if got, want := res.ExitCode, 0; got != want {
+		t.Fatalf("unexpected exit code: got %d want %d", got, want)
+	}
+	if res.OverlayCapture == nil {
+		t.Fatal("expected overlay capture result")
+	}
+	if got, want := len(res.OverlayCapture.EscapedWrites), 1; got != want {
+		t.Fatalf("unexpected escaped write count: got %d want %d", got, want)
+	}
+	if got, want := res.OverlayCapture.EscapedWrites[0].Path, "/etc/profile"; got != want {
+		t.Fatalf("unexpected escaped write path: got %q want %q", got, want)
+	}
+}
+
+func writeOverlayCaptureTestFile(t *testing.T, root, rel string) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create parent for %s: %v", rel, err)
+	}
+	if err := os.WriteFile(path, []byte(rel), 0o644); err != nil {
+		t.Fatalf("write %s: %v", rel, err)
+	}
+}

--- a/cmd/cleanroom-guest-agent/overlay_capture_test.go
+++ b/cmd/cleanroom-guest-agent/overlay_capture_test.go
@@ -29,12 +29,7 @@ func TestScanOverlayCaptureReportsEscapedWrites(t *testing.T) {
 	if result == nil {
 		t.Fatal("expected overlay capture result")
 	}
-	if got, want := len(result.EscapedWrites), 1; got != want {
-		t.Fatalf("unexpected escaped write count: got %d want %d", got, want)
-	}
-	if got, want := result.EscapedWrites[0], (vsockexec.OverlayCaptureEntry{Path: "/etc/profile", Kind: "write", Mode: 0o644}); got != want {
-		t.Fatalf("unexpected escaped write: got %#v want %#v", got, want)
-	}
+	assertOverlayCaptureEntry(t, result.EscapedWrites, vsockexec.OverlayCaptureEntry{Path: "/etc/profile", Kind: "write", Mode: 0o644})
 }
 
 func TestSendExitResultFailsWhenOverlayCaptureScanFails(t *testing.T) {
@@ -74,12 +69,17 @@ func TestSendExitResultIncludesOverlayCapture(t *testing.T) {
 	if res.OverlayCapture == nil {
 		t.Fatal("expected overlay capture result")
 	}
-	if got, want := len(res.OverlayCapture.EscapedWrites), 1; got != want {
-		t.Fatalf("unexpected escaped write count: got %d want %d", got, want)
+	assertOverlayCaptureEntry(t, res.OverlayCapture.EscapedWrites, vsockexec.OverlayCaptureEntry{Path: "/etc/profile", Kind: "write", Mode: 0o644})
+}
+
+func assertOverlayCaptureEntry(t *testing.T, entries []vsockexec.OverlayCaptureEntry, want vsockexec.OverlayCaptureEntry) {
+	t.Helper()
+	for _, got := range entries {
+		if got.Path == want.Path && got.Kind == want.Kind && got.Mode&0o777 == want.Mode&0o777 {
+			return
+		}
 	}
-	if got, want := res.OverlayCapture.EscapedWrites[0].Path, "/etc/profile"; got != want {
-		t.Fatalf("unexpected escaped write path: got %q want %q", got, want)
-	}
+	t.Fatalf("missing overlay capture entry %#v in %#v", want, entries)
 }
 
 func writeOverlayCaptureTestFile(t *testing.T, root, rel string) {

--- a/internal/vsockexec/protocol.go
+++ b/internal/vsockexec/protocol.go
@@ -22,6 +22,7 @@ type ExecRequest struct {
 	TTY               bool               `json:"tty,omitempty"`
 	CacheOutputMounts []CacheOutputMount `json:"cache_output_mounts,omitempty"`
 	InputProjection   *InputProjection   `json:"input_projection,omitempty"`
+	OverlayCapture    *OverlayCapture    `json:"overlay_capture,omitempty"`
 }
 
 type InputProjection struct {
@@ -50,17 +51,37 @@ type CacheOutputFileMount struct {
 	Mode      uint32 `json:"mode,omitempty"`
 }
 
+type OverlayCapture struct {
+	UpperDir            string   `json:"upper_dir"`
+	BaselinePaths       []string `json:"baseline_paths,omitempty"`
+	DeclaredFileOutputs []string `json:"declared_file_outputs,omitempty"`
+	IgnoredPrefixes     []string `json:"ignored_prefixes,omitempty"`
+}
+
+type OverlayCaptureResult struct {
+	Entries       []OverlayCaptureEntry `json:"entries,omitempty"`
+	EscapedWrites []OverlayCaptureEntry `json:"escaped_writes,omitempty"`
+}
+
+type OverlayCaptureEntry struct {
+	Path string `json:"path"`
+	Kind string `json:"kind"`
+	Mode uint32 `json:"mode,omitempty"`
+}
+
 type ExecResponse struct {
-	ExitCode int    `json:"exit_code"`
-	Error    string `json:"error,omitempty"`
+	ExitCode       int                   `json:"exit_code"`
+	Error          string                `json:"error,omitempty"`
+	OverlayCapture *OverlayCaptureResult `json:"overlay_capture,omitempty"`
 }
 
 // ExecStreamFrame is sent from guest to host. Types: stdout|stderr|exit.
 type ExecStreamFrame struct {
-	Type     string `json:"type,omitempty"` // stdout|stderr|exit
-	Data     []byte `json:"data,omitempty"`
-	ExitCode int    `json:"exit_code,omitempty"`
-	Error    string `json:"error,omitempty"`
+	Type           string                `json:"type,omitempty"` // stdout|stderr|exit
+	Data           []byte                `json:"data,omitempty"`
+	ExitCode       int                   `json:"exit_code,omitempty"`
+	Error          string                `json:"error,omitempty"`
+	OverlayCapture *OverlayCaptureResult `json:"overlay_capture,omitempty"`
 }
 
 func DecodeRequest(r io.Reader) (ExecRequest, error) {
@@ -158,6 +179,11 @@ func DecodeStreamResponse(r io.Reader, callbacks StreamCallbacks) (ExecResponse,
 			}
 			if errRaw, ok := raw["error"]; ok {
 				if err := json.Unmarshal(errRaw, &out.Error); err != nil {
+					return ExecResponse{}, err
+				}
+			}
+			if captureRaw, ok := raw["overlay_capture"]; ok {
+				if err := json.Unmarshal(captureRaw, &out.OverlayCapture); err != nil {
 					return ExecResponse{}, err
 				}
 			}

--- a/internal/vsockexec/protocol_test.go
+++ b/internal/vsockexec/protocol_test.go
@@ -230,6 +230,35 @@ func TestDecodeStreamResponseReturnsOnlyExitMetadata(t *testing.T) {
 	}
 }
 
+func TestDecodeStreamResponseIncludesOverlayCapture(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	if err := EncodeStreamFrame(&buf, ExecStreamFrame{
+		Type:     "exit",
+		ExitCode: 0,
+		OverlayCapture: &OverlayCaptureResult{
+			EscapedWrites: []OverlayCaptureEntry{{Path: "/etc/profile", Kind: "write", Mode: 0o644}},
+		},
+	}); err != nil {
+		t.Fatalf("EncodeStreamFrame exit: %v", err)
+	}
+
+	res, err := DecodeStreamResponse(&buf, StreamCallbacks{})
+	if err != nil {
+		t.Fatalf("DecodeStreamResponse: %v", err)
+	}
+	if res.OverlayCapture == nil {
+		t.Fatal("expected overlay capture result")
+	}
+	if got, want := len(res.OverlayCapture.EscapedWrites), 1; got != want {
+		t.Fatalf("unexpected escaped write count: got %d want %d", got, want)
+	}
+	if got, want := res.OverlayCapture.EscapedWrites[0], (OverlayCaptureEntry{Path: "/etc/profile", Kind: "write", Mode: 0o644}); got != want {
+		t.Fatalf("unexpected escaped write: got %#v want %#v", got, want)
+	}
+}
+
 func TestDecodeStreamResponseRejectsUntypedPayload(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What This Is Part Of

This is the next dependency/service volume-cache slice after the overlay capture scanner in PR 302. It is still part of the `docs/plans/dependency-service-volume-caches.md` work toward safe reusable dependency and service block outputs.

The scanner can now classify overlay upperdir writes, but later block execution wiring needs a way for the Linux guest agent to return that scan result to the host. This PR adds that request/result protocol and guest-agent scan hook without enabling the runtime path yet.

## What Changed

- added optional overlay capture request metadata to guest exec requests
- added overlay capture result metadata to streamed guest exec exit frames and decoded exec responses
- taught the Linux guest agent to scan a requested upperdir after command exit and include the result in the exit frame
- made overlay scan failures fail the guest exec result instead of silently returning a successful command without capture data
- covered protocol decode, guest-agent scan results, scan failure handling, and exit-frame capture behavior

## What This Deliberately Does Not Do

- does not advertise `sandbox.overlay_write_capture`
- does not mount or run commands through an overlay root yet
- does not change dependency or service block-volume runtime selection
- does not publish dependency/service output records

## Validation

- `GOCACHE=/private/tmp/cleanroom-go-build-cache mise exec -- go test ./internal/vsockexec ./cmd/cleanroom-guest-agent`
- `GOCACHE=/private/tmp/cleanroom-go-build-cache mise exec -- go test ./...`
