### PR TITLE
feat: Add backend overlay capture plumbing

### DIFF
--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -318,6 +318,7 @@ type ExecutionRequest struct {
 	ClosedEnv       bool
 	TTY             bool
 	InputProjection *InputProjection
+	OverlayCapture  *OverlayCapture
 	Policy          *policy.CompiledPolicy
 	NetworkStage    policy.NetworkStage
 	FirecrackerConfig
@@ -328,6 +329,24 @@ type InputProjection struct {
 	TargetRoot          string
 	Files               []string
 	MountSourceReadOnly bool
+}
+
+type OverlayCapture struct {
+	UpperDir            string
+	BaselinePaths       []string
+	DeclaredFileOutputs []string
+	IgnoredPrefixes     []string
+}
+
+type OverlayCaptureResult struct {
+	Entries       []OverlayCaptureEntry
+	EscapedWrites []OverlayCaptureEntry
+}
+
+type OverlayCaptureEntry struct {
+	Path string
+	Kind string
+	Mode fs.FileMode
 }
 
 type FirecrackerConfig struct {
@@ -366,14 +385,15 @@ type SnapshotConfig struct {
 }
 
 type ExecutionResult struct {
-	ExecutionID string
-	ExitCode    int
-	LaunchedVM  bool
-	PlanPath    string
-	RunDir      string
-	ImageRef    string
-	ImageDigest string
-	Message     string
+	ExecutionID    string
+	ExitCode       int
+	LaunchedVM     bool
+	PlanPath       string
+	RunDir         string
+	ImageRef       string
+	ImageDigest    string
+	Message        string
+	OverlayCapture *OverlayCaptureResult
 }
 
 type DoctorRequest struct {

--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -1185,6 +1185,7 @@ func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream 
 		ClosedEnv:       req.ClosedEnv,
 		TTY:             req.TTY,
 		InputProjection: darwinVZInputProjection(req.InputProjection),
+		OverlayCapture:  guestexec.ToVSOCKOverlayCapture(req.OverlayCapture),
 	}
 	if !req.ClosedEnv && a.GatewayRegistry != nil && gatewayScopeToken != "" {
 		gwPort := a.GatewayPort
@@ -1228,14 +1229,15 @@ func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream 
 	observation.GuestError = guestRes.Error
 
 	return &backend.ExecutionResult{
-		ExecutionID: req.ExecutionID,
-		ExitCode:    guestRes.ExitCode,
-		LaunchedVM:  true,
-		PlanPath:    vmPlanPath,
-		RunDir:      runDir,
-		ImageRef:    resolvedImageRef,
-		ImageDigest: resolvedImageDigest,
-		Message:     message,
+		ExecutionID:    req.ExecutionID,
+		ExitCode:       guestRes.ExitCode,
+		LaunchedVM:     true,
+		PlanPath:       vmPlanPath,
+		RunDir:         runDir,
+		ImageRef:       resolvedImageRef,
+		ImageDigest:    resolvedImageDigest,
+		Message:        message,
+		OverlayCapture: guestexec.FromVSOCKOverlayCaptureResult(guestRes.OverlayCapture),
 	}, nil
 }
 
@@ -1642,6 +1644,7 @@ func (a *Adapter) executeInSandbox(bootCtx context.Context, runCtx context.Conte
 		TTY:               req.TTY,
 		CacheOutputMounts: cloneDarwinVZCacheOutputMounts(instance.cacheOutputMounts),
 		InputProjection:   darwinVZInputProjection(req.InputProjection),
+		OverlayCapture:    guestexec.ToVSOCKOverlayCapture(req.OverlayCapture),
 	}
 	if !req.ClosedEnv && a.GatewayRegistry != nil && gatewayScopeToken != "" {
 		gwPort := a.GatewayPort
@@ -1672,14 +1675,15 @@ func (a *Adapter) executeInSandbox(bootCtx context.Context, runCtx context.Conte
 	}
 
 	return &backend.ExecutionResult{
-		ExecutionID: req.ExecutionID,
-		ExitCode:    guestRes.ExitCode,
-		LaunchedVM:  false,
-		PlanPath:    instance.ConfigPath,
-		RunDir:      req.RunDir,
-		ImageRef:    instance.ImageRef,
-		ImageDigest: instance.ImageDigest,
-		Message:     darwinVZResultMessage(guestRes.Error),
+		ExecutionID:    req.ExecutionID,
+		ExitCode:       guestRes.ExitCode,
+		LaunchedVM:     false,
+		PlanPath:       instance.ConfigPath,
+		RunDir:         req.RunDir,
+		ImageRef:       instance.ImageRef,
+		ImageDigest:    instance.ImageDigest,
+		Message:        darwinVZResultMessage(guestRes.Error),
+		OverlayCapture: guestexec.FromVSOCKOverlayCaptureResult(guestRes.OverlayCapture),
 	}, nil
 }
 

--- a/internal/backend/darwinvz/persistent_test.go
+++ b/internal/backend/darwinvz/persistent_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -190,6 +191,85 @@ func TestRunInSandboxUsesRequestLaunchSecondsOverride(t *testing.T) {
 	}
 	if elapsed := time.Since(start); elapsed < 2*time.Second {
 		t.Fatalf("expected launch-seconds override to increase timeout, elapsed=%s err=%v", elapsed, err)
+	}
+}
+
+func TestExecuteInSandboxForwardsOverlayCapture(t *testing.T) {
+	t.Parallel()
+
+	socketPath := filepath.Join("/tmp", "cr-ov-"+strconv.FormatInt(time.Now().UnixNano(), 36)+".sock")
+	defer os.Remove(socketPath)
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen unix socket: %v", err)
+	}
+	defer listener.Close()
+
+	wantCapture := &vsockexec.OverlayCapture{
+		UpperDir:            "/run/cleanroom/overlay/upper",
+		BaselinePaths:       []string{"/workspace"},
+		DeclaredFileOutputs: []string{"/workspace/dist/result.txt"},
+		IgnoredPrefixes:     []string{"/tmp"},
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		conn, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			t.Errorf("accept guest exec connection: %v", acceptErr)
+			return
+		}
+		defer conn.Close()
+
+		var req vsockexec.ExecRequest
+		if decodeErr := json.NewDecoder(conn).Decode(&req); decodeErr != nil {
+			t.Errorf("decode guest exec request: %v", decodeErr)
+			return
+		}
+		if !reflect.DeepEqual(req.OverlayCapture, wantCapture) {
+			t.Errorf("unexpected overlay capture request: got %#v want %#v", req.OverlayCapture, wantCapture)
+		}
+		if encodeErr := vsockexec.EncodeStreamFrame(conn, vsockexec.ExecStreamFrame{
+			Type:     "exit",
+			ExitCode: 0,
+			OverlayCapture: &vsockexec.OverlayCaptureResult{
+				EscapedWrites: []vsockexec.OverlayCaptureEntry{
+					{Path: "/etc/profile", Kind: "write", Mode: 0o644},
+				},
+			},
+		}); encodeErr != nil {
+			t.Errorf("encode guest exec response: %v", encodeErr)
+		}
+	}()
+
+	adapter := &Adapter{}
+	result, err := adapter.executeInSandbox(context.Background(), context.Background(), &sandboxInstance{
+		SandboxID:       "cr-test",
+		ProxySocketPath: socketPath,
+		Policy:          &policy.CompiledPolicy{NetworkDefault: "deny"},
+		Helper:          &helperSession{},
+		exitedCh:        make(chan struct{}),
+	}, backend.ExecutionRequest{
+		SandboxID:   "cr-test",
+		ExecutionID: "run-123",
+		Command:     []string{"true"},
+		Policy:      &policy.CompiledPolicy{NetworkDefault: "deny"},
+		OverlayCapture: &backend.OverlayCapture{
+			UpperDir:            "/run/cleanroom/overlay/upper",
+			BaselinePaths:       []string{"/workspace"},
+			DeclaredFileOutputs: []string{"/workspace/dist/result.txt"},
+			IgnoredPrefixes:     []string{"/tmp"},
+		},
+	}, backend.OutputStream{})
+	if err != nil {
+		t.Fatalf("executeInSandbox returned error: %v", err)
+	}
+	<-done
+	if result.OverlayCapture == nil {
+		t.Fatal("expected overlay capture result")
+	}
+	if got, want := result.OverlayCapture.EscapedWrites[0], (backend.OverlayCaptureEntry{Path: "/etc/profile", Kind: "write", Mode: 0o644}); got != want {
+		t.Fatalf("unexpected escaped write: got %#v want %#v", got, want)
 	}
 }
 

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -503,7 +503,7 @@ func (a *Adapter) RunInSandbox(ctx context.Context, req backend.ExecutionRequest
 		defer a.GatewayRegistry.ClearActiveExecutionTrace(sandboxID, req.ExecutionID)
 	}
 
-	guestResult, timing, err := a.executeInSandbox(ctx, instance, req.LaunchSeconds, req.Command, req.Dir, req.Env, req.ClosedEnv, req.InputProjection, req.TTY, stream)
+	guestResult, timing, err := a.executeInSandbox(ctx, instance, req.LaunchSeconds, req.Command, req.Dir, req.Env, req.ClosedEnv, req.InputProjection, req.OverlayCapture, req.TTY, stream)
 	if err != nil {
 		observation.ExitCode = 1
 		observation.GuestError = err.Error()
@@ -520,14 +520,15 @@ func (a *Adapter) RunInSandbox(ctx context.Context, req backend.ExecutionRequest
 	}
 
 	result = &backend.ExecutionResult{
-		ExecutionID: req.ExecutionID,
-		ExitCode:    guestResult.ExitCode,
-		LaunchedVM:  false,
-		PlanPath:    instance.ConfigPath,
-		RunDir:      runDir,
-		ImageRef:    instance.ImageRef,
-		ImageDigest: instance.ImageDigest,
-		Message:     message,
+		ExecutionID:    req.ExecutionID,
+		ExitCode:       guestResult.ExitCode,
+		LaunchedVM:     false,
+		PlanPath:       instance.ConfigPath,
+		RunDir:         runDir,
+		ImageRef:       instance.ImageRef,
+		ImageDigest:    instance.ImageDigest,
+		Message:        message,
+		OverlayCapture: guestexec.FromVSOCKOverlayCaptureResult(guestResult.OverlayCapture),
 	}
 	return result, nil
 }
@@ -594,7 +595,7 @@ func (a *Adapter) runFileTransferCommand(ctx context.Context, sandboxID string, 
 	if err != nil {
 		return nil, err
 	}
-	result, _, err := a.executeInSandbox(ctx, instance, 0, cmd, "", nil, false, nil, false, stream)
+	result, _, err := a.executeInSandbox(ctx, instance, 0, cmd, "", nil, false, nil, nil, false, stream)
 	if err != nil {
 		return nil, err
 	}
@@ -672,7 +673,7 @@ func (a *Adapter) CreateSnapshot(ctx context.Context, req backend.SnapshotReques
 		return nil, fmt.Errorf("sandbox %q is not running: %w", sandboxID, err)
 	}
 
-	syncResp, _, err := a.executeInSandbox(ctx, instance, snapshotSyncTimeoutSeconds, []string{"sync"}, "", nil, false, nil, false, backend.OutputStream{})
+	syncResp, _, err := a.executeInSandbox(ctx, instance, snapshotSyncTimeoutSeconds, []string{"sync"}, "", nil, false, nil, nil, false, backend.OutputStream{})
 	if err != nil {
 		return nil, fmt.Errorf("sync sandbox filesystem before snapshot: %w", err)
 	}
@@ -809,7 +810,7 @@ func (a *Adapter) DeleteSnapshot(ctx context.Context, req backend.DeleteSnapshot
 	return nil
 }
 
-func (a *Adapter) executeInSandbox(ctx context.Context, instance *sandboxInstance, launchSeconds int64, command []string, dir string, env []string, closedEnv bool, inputProjection *backend.InputProjection, tty bool, stream backend.OutputStream) (vsockexec.ExecResponse, guestExecTiming, error) {
+func (a *Adapter) executeInSandbox(ctx context.Context, instance *sandboxInstance, launchSeconds int64, command []string, dir string, env []string, closedEnv bool, inputProjection *backend.InputProjection, overlayCapture *backend.OverlayCapture, tty bool, stream backend.OutputStream) (vsockexec.ExecResponse, guestExecTiming, error) {
 	guestReq := vsockexec.ExecRequest{
 		Command:           append([]string(nil), command...),
 		Dir:               strings.TrimSpace(dir),
@@ -818,6 +819,7 @@ func (a *Adapter) executeInSandbox(ctx context.Context, instance *sandboxInstanc
 		TTY:               tty,
 		CacheOutputMounts: cloneCacheOutputMounts(instance.cacheOutputMounts),
 		InputProjection:   vsockInputProjection(inputProjection),
+		OverlayCapture:    guestexec.ToVSOCKOverlayCapture(overlayCapture),
 	}
 	entropy := make([]byte, 64)
 	if _, err := cryptorand.Read(entropy); err == nil {
@@ -1325,6 +1327,7 @@ func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream 
 		ClosedEnv:       req.ClosedEnv,
 		TTY:             req.TTY,
 		InputProjection: vsockInputProjection(req.InputProjection),
+		OverlayCapture:  guestexec.ToVSOCKOverlayCapture(req.OverlayCapture),
 	}
 	entropy := make([]byte, 64)
 	if _, err := cryptorand.Read(entropy); err == nil {
@@ -1354,14 +1357,15 @@ func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream 
 	timingSummary := fmt.Sprintf("timings boot=%s vsock_wait=%s exec=%s", vmReady, guestTiming.WaitForAgent, guestTiming.CommandRun)
 
 	return &backend.ExecutionResult{
-		ExecutionID: req.ExecutionID,
-		ExitCode:    guestResult.ExitCode,
-		LaunchedVM:  true,
-		PlanPath:    cfgPath,
-		RunDir:      runDir,
-		ImageRef:    imageArtifact.Ref,
-		ImageDigest: imageArtifact.Digest,
-		Message:     message + "; " + timingSummary,
+		ExecutionID:    req.ExecutionID,
+		ExitCode:       guestResult.ExitCode,
+		LaunchedVM:     true,
+		PlanPath:       cfgPath,
+		RunDir:         runDir,
+		ImageRef:       imageArtifact.Ref,
+		ImageDigest:    imageArtifact.Digest,
+		Message:        message + "; " + timingSummary,
+		OverlayCapture: guestexec.FromVSOCKOverlayCaptureResult(guestResult.OverlayCapture),
 	}, nil
 }
 

--- a/internal/backend/firecracker/persistent_test.go
+++ b/internal/backend/firecracker/persistent_test.go
@@ -322,6 +322,62 @@ func TestRunInSandboxForwardsInputProjection(t *testing.T) {
 	}
 }
 
+func TestRunInSandboxForwardsOverlayCapture(t *testing.T) {
+	t.Parallel()
+
+	wantCapture := &backend.OverlayCapture{
+		UpperDir:            "/run/cleanroom/overlay/upper",
+		BaselinePaths:       []string{"/workspace"},
+		DeclaredFileOutputs: []string{"/workspace/dist/result.txt"},
+		IgnoredPrefixes:     []string{"/tmp"},
+	}
+	wantGuestCapture := &vsockexec.OverlayCapture{
+		UpperDir:            "/run/cleanroom/overlay/upper",
+		BaselinePaths:       []string{"/workspace"},
+		DeclaredFileOutputs: []string{"/workspace/dist/result.txt"},
+		IgnoredPrefixes:     []string{"/tmp"},
+	}
+	var gotCapture *vsockexec.OverlayCapture
+	adapter := &Adapter{}
+	adapter.runGuestCommandFn = func(_ context.Context, _ context.Context, _ <-chan struct{}, _ func() error, _ string, _ uint32, req vsockexec.ExecRequest, _ backend.OutputStream) (vsockexec.ExecResponse, guestExecTiming, error) {
+		gotCapture = req.OverlayCapture
+		return vsockexec.ExecResponse{
+			ExitCode: 0,
+			OverlayCapture: &vsockexec.OverlayCaptureResult{
+				EscapedWrites: []vsockexec.OverlayCaptureEntry{
+					{Path: "/etc/profile", Kind: "write", Mode: 0o644},
+				},
+			},
+		}, guestExecTiming{}, nil
+	}
+	adapter.sandboxes = map[string]*sandboxInstance{
+		"cr-test": {
+			SandboxID: "cr-test",
+			VsockPath: "/tmp/fake.sock",
+			GuestPort: 10700,
+		},
+	}
+
+	result, err := adapter.RunInSandbox(context.Background(), backend.ExecutionRequest{
+		SandboxID:      "cr-test",
+		ExecutionID:    "run-123",
+		Command:        []string{"true"},
+		OverlayCapture: wantCapture,
+	}, backend.OutputStream{})
+	if err != nil {
+		t.Fatalf("RunInSandbox returned error: %v", err)
+	}
+	if !reflect.DeepEqual(gotCapture, wantGuestCapture) {
+		t.Fatalf("unexpected overlay capture request: got %#v want %#v", gotCapture, wantGuestCapture)
+	}
+	if result.OverlayCapture == nil {
+		t.Fatal("expected overlay capture result")
+	}
+	if got, want := result.OverlayCapture.EscapedWrites[0], (backend.OverlayCaptureEntry{Path: "/etc/profile", Kind: "write", Mode: 0o644}); got != want {
+		t.Fatalf("unexpected escaped write: got %#v want %#v", got, want)
+	}
+}
+
 func TestRunInSandboxClosedEnvSkipsGatewayEnv(t *testing.T) {
 	t.Parallel()
 

--- a/internal/backend/guestexec/guestexec.go
+++ b/internal/backend/guestexec/guestexec.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/fs"
 	"sync"
 	"time"
 
@@ -80,6 +81,43 @@ func DecodeResponse(r io.Reader, stream backend.OutputStream) (vsockexec.ExecRes
 		OnStdout: stream.OnStdout,
 		OnStderr: stream.OnStderr,
 	})
+}
+
+func ToVSOCKOverlayCapture(capture *backend.OverlayCapture) *vsockexec.OverlayCapture {
+	if capture == nil {
+		return nil
+	}
+	return &vsockexec.OverlayCapture{
+		UpperDir:            capture.UpperDir,
+		BaselinePaths:       append([]string(nil), capture.BaselinePaths...),
+		DeclaredFileOutputs: append([]string(nil), capture.DeclaredFileOutputs...),
+		IgnoredPrefixes:     append([]string(nil), capture.IgnoredPrefixes...),
+	}
+}
+
+func FromVSOCKOverlayCaptureResult(result *vsockexec.OverlayCaptureResult) *backend.OverlayCaptureResult {
+	if result == nil {
+		return nil
+	}
+	return &backend.OverlayCaptureResult{
+		Entries:       backendOverlayCaptureEntries(result.Entries),
+		EscapedWrites: backendOverlayCaptureEntries(result.EscapedWrites),
+	}
+}
+
+func backendOverlayCaptureEntries(entries []vsockexec.OverlayCaptureEntry) []backend.OverlayCaptureEntry {
+	if len(entries) == 0 {
+		return nil
+	}
+	out := make([]backend.OverlayCaptureEntry, 0, len(entries))
+	for _, entry := range entries {
+		out = append(out, backend.OverlayCaptureEntry{
+			Path: entry.Path,
+			Kind: entry.Kind,
+			Mode: fs.FileMode(entry.Mode),
+		})
+	}
+	return out
 }
 
 type inputFrameSender struct {

--- a/internal/backend/guestexec/guestexec_test.go
+++ b/internal/backend/guestexec/guestexec_test.go
@@ -121,6 +121,38 @@ func TestDecodeResponseForwardsStreamCallbacks(t *testing.T) {
 	}
 }
 
+func TestOverlayCaptureConversionClonesRequestsAndResults(t *testing.T) {
+	capture := &backend.OverlayCapture{
+		UpperDir:            "/run/cleanroom/overlay/upper",
+		BaselinePaths:       []string{"/workspace"},
+		DeclaredFileOutputs: []string{"/workspace/dist/result.txt"},
+		IgnoredPrefixes:     []string{"/tmp"},
+	}
+	req := ToVSOCKOverlayCapture(capture)
+	if req == nil {
+		t.Fatal("expected vsock overlay capture request")
+	}
+	capture.BaselinePaths[0] = "/changed"
+	if got, want := req.BaselinePaths[0], "/workspace"; got != want {
+		t.Fatalf("overlay capture request was not cloned: got %q want %q", got, want)
+	}
+
+	result := FromVSOCKOverlayCaptureResult(&vsockexec.OverlayCaptureResult{
+		Entries: []vsockexec.OverlayCaptureEntry{
+			{Path: "/workspace/dist/result.txt", Kind: "write", Mode: 0o644},
+		},
+		EscapedWrites: []vsockexec.OverlayCaptureEntry{
+			{Path: "/etc/profile", Kind: "write", Mode: 0o644},
+		},
+	})
+	if result == nil {
+		t.Fatal("expected backend overlay capture result")
+	}
+	if got, want := result.EscapedWrites[0], (backend.OverlayCaptureEntry{Path: "/etc/profile", Kind: "write", Mode: 0o644}); got != want {
+		t.Fatalf("unexpected escaped write: got %#v want %#v", got, want)
+	}
+}
+
 type fakeConn struct {
 	deadline       time.Time
 	setDeadlineErr error


### PR DESCRIPTION
## Context

This is the next small slice of the dependency/service volume-cache work after the overlay scanner and guest-agent scan protocol. It does not turn on `sandbox.overlay_write_capture` yet. The point is to make overlay-capture requests and results available through the backend execution boundary so later control-service runtime slices can ask Firecracker or darwin-vz to run a block with capture enabled.

## What changed

- Adds backend-level `OverlayCapture` request/result types on `ExecutionRequest` and `ExecutionResult`.
- Converts those types to and from the existing guest vsock exec protocol in the shared guest-exec helper.
- Forwards overlay-capture requests through persistent and one-shot Firecracker executions.
- Forwards overlay-capture requests through persistent and one-shot darwin-vz executions.
- Keeps existing nil behavior unchanged for ordinary executions, file transfers, and snapshot sync commands.

## Validation

- `GOCACHE=/private/tmp/cleanroom-go-build-cache mise exec -- go test ./...`
- `docker run --rm -v "$PWD":/work -v /Users/lachlan/Develop/cleanroom/.git:/Users/lachlan/Develop/cleanroom/.git:ro -w /work -e GOCACHE=/tmp/go-build-cache golang:1.26.2 go test ./...`
