### PR TITLE
feat: Run service volume blocks from projections

### DIFF
--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -874,6 +874,9 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 			}
 			emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_SERVICES, "running services bootstrap")
 			if err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.bootstrap_services", bootstrapAttrs, func(ctx context.Context) error {
+				if serviceBlockVolumePlanAvailable {
+					return s.bootstrapServiceBlockVolumePlanInPersistentSandbox(ctx, adapter, sandboxID, compiled, firecrackerCfg, repository, serviceBlockVolumePlan, reporter)
+				}
 				return s.bootstrapServicesStageInPersistentSandbox(ctx, adapter, sandboxID, compiled, firecrackerCfg, servicesStagePlan, reporter)
 			}); err != nil {
 				cleanupErr := s.terminateCreatedSandbox(context.Background(), adapter, sandboxID)
@@ -935,6 +938,9 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 			}
 			emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_SERVICES, "running services bootstrap")
 			if err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.bootstrap_services", bootstrapAttrs, func(ctx context.Context) error {
+				if serviceBlockVolumePlanAvailable {
+					return s.bootstrapServiceBlockVolumePlanInPersistentSandbox(ctx, adapter, sandboxID, compiled, firecrackerCfg, repository, serviceBlockVolumePlan, reporter)
+				}
 				return s.bootstrapServicesStageInPersistentSandbox(ctx, adapter, sandboxID, compiled, firecrackerCfg, servicesStagePlan, reporter)
 			}); err != nil {
 				cleanupErr := s.terminateCreatedSandbox(context.Background(), adapter, sandboxID)
@@ -1123,6 +1129,9 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 		}
 		emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_SERVICES, "running services bootstrap")
 		if err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.bootstrap_services", bootstrapAttrs, func(ctx context.Context) error {
+			if serviceBlockVolumePlanAvailable {
+				return s.bootstrapServiceBlockVolumePlanInPersistentSandbox(ctx, adapter, sandboxID, compiled, firecrackerCfg, repository, serviceBlockVolumePlan, reporter)
+			}
 			return s.bootstrapServicesStageInPersistentSandbox(ctx, adapter, sandboxID, compiled, firecrackerCfg, servicesStagePlan, reporter)
 		}); err != nil {
 			if terminateErr := s.terminateCreatedSandbox(context.Background(), adapter, sandboxID); terminateErr != nil {

--- a/internal/controlservice/service_volume_execution.go
+++ b/internal/controlservice/service_volume_execution.go
@@ -1,0 +1,103 @@
+package controlservice
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+	"github.com/buildkite/cleanroom/internal/observability"
+	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/buildkite/cleanroom/internal/repositorycheckout"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+const serviceInputProjectionRoot = "/run/cleanroom/input-projections/services"
+
+func (s *Service) bootstrapServiceBlockVolumePlanInPersistentSandbox(
+	ctx context.Context,
+	adapter backend.Adapter,
+	sandboxID string,
+	compiled *policy.CompiledPolicy,
+	firecrackerCfg backend.FirecrackerConfig,
+	repository *repositorycheckout.Checkout,
+	plan serviceBlockVolumePlan,
+	reporter CreateSandboxReporter,
+) error {
+	if adapter == nil || compiled == nil || repository == nil || strings.TrimSpace(sandboxID) == "" || len(plan.Blocks) == 0 {
+		return nil
+	}
+
+	for _, block := range plan.Blocks {
+		blockName := strings.TrimSpace(block.BlockName)
+		if block.CacheHit {
+			emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_SERVICES, "restoring service outputs: "+blockName)
+			continue
+		}
+
+		attrs := []attribute.KeyValue{
+			attribute.String(observability.AttrBackend, adapter.Name()),
+			attribute.String(observability.AttrSandboxID, sandboxID),
+			attribute.String("cleanroom.cache.block", blockName),
+			attribute.Int(observability.AttrCommandArgc, len(block.Command)),
+		}
+		if commitSHA := strings.TrimSpace(repository.CommitSHA); commitSHA != "" {
+			attrs = append(attrs, attribute.String(observability.AttrRepositoryCommitSHA, commitSHA))
+		}
+
+		emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_SERVICES, "running service bootstrap: "+blockName)
+		if err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.bootstrap_service_block", attrs, func(ctx context.Context) error {
+			return s.bootstrapServiceBlockVolumeBlock(ctx, adapter, sandboxID, compiled, firecrackerCfg, repository, block, reporter)
+		}); err != nil {
+			return fmt.Errorf("service block %q: %w", blockName, err)
+		}
+	}
+	return nil
+}
+
+func (s *Service) bootstrapServiceBlockVolumeBlock(
+	ctx context.Context,
+	adapter backend.Adapter,
+	sandboxID string,
+	compiled *policy.CompiledPolicy,
+	firecrackerCfg backend.FirecrackerConfig,
+	repository *repositorycheckout.Checkout,
+	block serviceBlockVolumeBlockPlan,
+	reporter CreateSandboxReporter,
+) error {
+	if len(block.Command) == 0 {
+		return nil
+	}
+	sourceRoot := strings.TrimSpace(repository.DestinationDir)
+	if sourceRoot == "" {
+		sourceRoot = "/workspace"
+	}
+	inputProjection := &backend.InputProjection{
+		SourceRoot:          sourceRoot,
+		TargetRoot:          filepath.Join(serviceInputProjectionRoot, strings.TrimSpace(block.BlockName)),
+		Files:               append([]string(nil), block.Inputs...),
+		MountSourceReadOnly: true,
+	}
+	env := stageBlockEnvList(block.Env)
+	_, result, stdout, stderr, err := s.runPersistentBootstrapCommandWithOptions(
+		ctx,
+		adapter,
+		sandboxID,
+		compiled,
+		firecrackerCfg,
+		cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_SERVICES,
+		policy.NetworkStageServices,
+		block.Command,
+		env,
+		nil,
+		persistentSandboxCommandOptions{
+			Dir:             sourceRoot,
+			ClosedEnv:       true,
+			InputProjection: inputProjection,
+		},
+		reporter,
+	)
+	return persistentBootstrapCommandError(result, stdout, stderr, err, "service block bootstrap returned no result", "service block bootstrap failed with exit code %d")
+}

--- a/internal/controlservice/service_volume_plan_test.go
+++ b/internal/controlservice/service_volume_plan_test.go
@@ -296,19 +296,22 @@ func TestCreateSandboxFallsBackWhenServiceBlockVolumeStoreMissing(t *testing.T) 
 
 func TestCreateSandboxLooksUpServiceBlockVolumeCaches(t *testing.T) {
 	tests := []struct {
-		name     string
-		records  int
-		wantHits int
+		name         string
+		records      int
+		wantHits     int
+		wantRunCalls int
 	}{
 		{
-			name:     "partial hit",
-			records:  1,
-			wantHits: 1,
+			name:         "partial hit",
+			records:      1,
+			wantHits:     1,
+			wantRunCalls: 4,
 		},
 		{
-			name:     "all hit",
-			records:  2,
-			wantHits: 2,
+			name:         "all hit",
+			records:      2,
+			wantHits:     2,
+			wantRunCalls: 3,
 		},
 	}
 
@@ -374,8 +377,8 @@ func TestCreateSandboxLooksUpServiceBlockVolumeCaches(t *testing.T) {
 					t.Fatalf("unexpected lookup key %d: got %q want %q", i, got, wantKey)
 				}
 			}
-			if got, want := adapter.runCalls, 4; got != want {
-				t.Fatalf("expected repository + dependency block misses + aggregate services bootstrap executions, got %d want %d", got, want)
+			if got, want := adapter.runCalls, tc.wantRunCalls; got != want {
+				t.Fatalf("unexpected bootstrap execution count: got %d want %d", got, want)
 			}
 		})
 	}
@@ -571,6 +574,89 @@ func TestCreateSandboxPassesBlockVolumeSpecsToColdProvision(t *testing.T) {
 	miss := requireCacheOutputVolumeSpec(t, adapter.provisionReq.CacheOutputVolumes, serviceVolumeStageName, servicePlan.Blocks[1].BlockName)
 	if miss.StorageRef != "" || miss.SourceSnapshotRef != "" {
 		t.Fatalf("expected service miss spec without source storage, got storage=%q snapshot=%q", miss.StorageRef, miss.SourceSnapshotRef)
+	}
+}
+
+func TestBootstrapServiceBlockVolumePlanRunsMissesFromInputProjection(t *testing.T) {
+	t.Parallel()
+
+	compiled, err := policy.FromProto(testRepositoryTwoDependencyTwoServiceBlocksPolicy())
+	if err != nil {
+		t.Fatalf("policy.FromProto returned error: %v", err)
+	}
+	repository := repositorycheckout.FromProto(testRepositoryCheckoutProto())
+	plan := serviceBlockVolumePlan{
+		Blocks: []serviceBlockVolumeBlockPlan{
+			{
+				BlockName: "postgres-data",
+				Command:   append([]string(nil), compiled.Services.Blocks[0].Command...),
+				Env:       cloneDependencyBlockEnv(compiled.Services.Blocks[0].Env),
+				Inputs:    append([]string(nil), compiled.Services.Blocks[0].Inputs.Files...),
+				CacheHit:  true,
+			},
+			{
+				BlockName: "app-service",
+				Command:   append([]string(nil), compiled.Services.Blocks[1].Command...),
+				Env:       cloneDependencyBlockEnv(compiled.Services.Blocks[1].Env),
+				Inputs:    append([]string(nil), compiled.Services.Blocks[1].Inputs.Files...),
+			},
+		},
+	}
+
+	var gotReqs []backend.ExecutionRequest
+	adapter := &stubAdapter{
+		runStreamFn: func(_ context.Context, req backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
+			gotReqs = append(gotReqs, req)
+			return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0}, nil
+		},
+	}
+	svc := newTestService(adapter)
+	err = svc.bootstrapServiceBlockVolumePlanInPersistentSandbox(
+		context.Background(),
+		adapter,
+		"cr-test",
+		compiled,
+		backend.FirecrackerConfig{},
+		repository,
+		plan,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("bootstrapServiceBlockVolumePlanInPersistentSandbox returned error: %v", err)
+	}
+	if got, want := len(gotReqs), 1; got != want {
+		t.Fatalf("unexpected run count: got %d want %d", got, want)
+	}
+	req := gotReqs[0]
+	if got, want := strings.Join(req.Command, "\x00"), strings.Join(compiled.Services.Blocks[1].Command, "\x00"); got != want {
+		t.Fatalf("unexpected command: got %q want %q", got, want)
+	}
+	if got, want := req.NetworkStage, policy.NetworkStageServices; got != want {
+		t.Fatalf("unexpected network stage: got %q want %q", got, want)
+	}
+	if got, want := req.Dir, "/workspace"; got != want {
+		t.Fatalf("unexpected dir: got %q want %q", got, want)
+	}
+	if !req.ClosedEnv {
+		t.Fatal("expected service block execution to use a closed environment")
+	}
+	if !strings.Contains(strings.Join(req.Env, "\n"), "APP_SERVICE_DATA=/var/lib/cleanroom/services/app") {
+		t.Fatalf("expected APP_SERVICE_DATA env, got %v", req.Env)
+	}
+	if req.InputProjection == nil {
+		t.Fatal("expected input projection")
+	}
+	if got, want := req.InputProjection.SourceRoot, "/workspace"; got != want {
+		t.Fatalf("unexpected projection source root: got %q want %q", got, want)
+	}
+	if got, want := req.InputProjection.TargetRoot, "/run/cleanroom/input-projections/services/app-service"; got != want {
+		t.Fatalf("unexpected projection target root: got %q want %q", got, want)
+	}
+	if got, want := strings.Join(req.InputProjection.Files, "\x00"), strings.Join([]string{"db/seed.sql", "docker-compose.yml", "scripts/prepare-app"}, "\x00"); got != want {
+		t.Fatalf("unexpected projection files: got %v", req.InputProjection.Files)
+	}
+	if !req.InputProjection.MountSourceReadOnly {
+		t.Fatal("expected projection to be mounted read-only over source")
 	}
 }
 


### PR DESCRIPTION
## Context

This is the next runtime-control slice for dependency/service volume caches. Dependency block-volume misses already run as individual commands from an isolated input projection. Service block-volume lookup and launch specs existed, but missed service blocks still fell back to the aggregate services bootstrap command.

This PR gives service blocks the same execution substrate as dependency blocks. It still does not publish block-volume snapshots or enable `sandbox.overlay_write_capture`; that remains a later publication/fallback slice.

## What changed

- Adds service block-volume execution in persistent sandboxes.
- Skips cached service blocks because their output volumes are already restored at launch.
- Runs missed service blocks with a closed environment and a read-only input projection over the workspace.
- Uses service-stage network policy and service bootstrap stream phases for those individual block commands.
- Switches create-sandbox service bootstrap call sites to use block execution whenever a service block-volume plan is active.

## Validation

- `GOCACHE=/private/tmp/cleanroom-go-build-cache mise exec -- go test ./internal/controlservice`
- `GOCACHE=/private/tmp/cleanroom-go-build-cache mise exec -- go test ./...`
- `docker run --rm -v "$PWD":/work -v /Users/lachlan/Develop/cleanroom/.git:/Users/lachlan/Develop/cleanroom/.git:ro -w /work -e GOCACHE=/tmp/go-build-cache golang:1.26.2 go test ./...`
