### PR TITLE
feat: Snapshot cache output volumes

### DIFF
--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -171,6 +171,11 @@ type SnapshottingAdapter interface {
 	DeleteSnapshot(ctx context.Context, req DeleteSnapshotRequest) error
 }
 
+type CacheOutputVolumeSnapshottingAdapter interface {
+	Adapter
+	SnapshotCacheOutputVolumes(ctx context.Context, req SnapshotCacheOutputVolumesRequest) (*SnapshotCacheOutputVolumesResult, error)
+}
+
 // RuntimeBaseKeyProvider returns a stable identifier for the backend runtime
 // base that a reusable workspace stage depends on.
 type RuntimeBaseKeyProvider interface {
@@ -287,6 +292,38 @@ type CacheOutputFileMapping struct {
 	GuestPath string
 	Subpath   string
 	Mode      fs.FileMode
+}
+
+type SnapshotCacheOutputVolumesRequest struct {
+	SandboxID        string
+	SnapshotIDPrefix string
+	VolumeIDs        []string
+	FirecrackerConfig
+}
+
+type SnapshotCacheOutputVolumesResult struct {
+	Volumes []CacheOutputVolumeSnapshot
+}
+
+type CacheOutputVolumeSnapshot struct {
+	Stage              string
+	BlockName          string
+	CacheKey           string
+	VolumeID           string
+	StorageDriver      string
+	StorageRef         string
+	SnapshotRef        string
+	StorageSizeBytes   int64
+	ExclusiveSizeBytes int64
+	DriverMetadata     string
+	Outputs            []CacheOutputVolumeSnapshotOutput
+}
+
+type CacheOutputVolumeSnapshotOutput struct {
+	Kind          string
+	GuestPath     string
+	VolumeSubpath string
+	Mode          fs.FileMode
 }
 
 type DeleteSnapshotRequest struct {

--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -115,6 +115,7 @@ type sandboxInstance struct {
 	VMID                string
 	vmRootFSPath        string
 	cacheOutputMounts   []vsockexec.CacheOutputMount
+	cacheOutputVolumes  []preparedDarwinVZCacheOutputVolume
 	cleanupCacheOutputs func()
 	exitedCh            chan struct{}
 	exitMu              sync.RWMutex
@@ -1459,6 +1460,7 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 		VMID:                startedVM.VMID,
 		vmRootFSPath:        vmRootFSPath,
 		cacheOutputMounts:   darwinVZCacheOutputVolumeMounts(cacheOutputVolumes),
+		cacheOutputVolumes:  cacheOutputVolumes,
 		cleanupCacheOutputs: cleanupCacheOutputs,
 		exitedCh:            make(chan struct{}),
 	}

--- a/internal/backend/darwinvz/cache_output_snapshots_darwin.go
+++ b/internal/backend/darwinvz/cache_output_snapshots_darwin.go
@@ -81,7 +81,7 @@ func (a *Adapter) SnapshotCacheOutputVolumes(ctx context.Context, req backend.Sn
 	}
 	syncCtx, cancel := context.WithTimeout(ctx, time.Duration(connectSeconds)*time.Second)
 	defer cancel()
-	syncResult, err := executeInSandbox(syncCtx, ctx, instance, backend.ExecutionRequest{
+	syncResult, err := executeInSandbox(syncCtx, syncCtx, instance, backend.ExecutionRequest{
 		SandboxID: sandboxID,
 		Command:   []string{"sync"},
 		Policy:    instance.Policy,

--- a/internal/backend/darwinvz/cache_output_snapshots_darwin.go
+++ b/internal/backend/darwinvz/cache_output_snapshots_darwin.go
@@ -1,0 +1,259 @@
+//go:build darwin
+
+package darwinvz
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/volumestore"
+)
+
+type darwinVZCacheOutputSnapshotTarget struct {
+	volume     preparedDarwinVZCacheOutputVolume
+	cfg        backend.FirecrackerConfig
+	snapshotID string
+}
+
+type createdDarwinVZCacheOutputSnapshot struct {
+	driver     volumestore.Driver
+	storageRef string
+}
+
+func (a *Adapter) SnapshotCacheOutputVolumes(ctx context.Context, req backend.SnapshotCacheOutputVolumesRequest) (_ *backend.SnapshotCacheOutputVolumesResult, retErr error) {
+	sandboxID := strings.TrimSpace(req.SandboxID)
+	if sandboxID == "" {
+		return nil, errors.New("missing sandbox_id")
+	}
+	snapshotIDPrefix := strings.TrimSpace(req.SnapshotIDPrefix)
+	if snapshotIDPrefix == "" {
+		return nil, errors.New("missing snapshot_id_prefix")
+	}
+
+	a.sandboxMu.Lock()
+	instance, ok := a.sandboxes[sandboxID]
+	a.sandboxMu.Unlock()
+	if !ok {
+		return nil, fmt.Errorf("unknown sandbox %q", sandboxID)
+	}
+	if err := instance.exitedErrOrNil(); err != nil {
+		return nil, fmt.Errorf("sandbox %q is not running: %w", sandboxID, err)
+	}
+
+	volumes, err := selectDarwinVZCacheOutputVolumes(instance.cacheOutputVolumes, req.VolumeIDs)
+	if err != nil {
+		return nil, err
+	}
+	if len(volumes) == 0 {
+		return &backend.SnapshotCacheOutputVolumesResult{}, nil
+	}
+
+	targets := make([]darwinVZCacheOutputSnapshotTarget, 0, len(volumes))
+	for _, volume := range volumes {
+		cfg := darwinVZCacheOutputSnapshotConfig(req.FirecrackerConfig, volume.Spec)
+		if _, err := snapshotVolumeDriver(cfg); err != nil {
+			return nil, err
+		}
+		targets = append(targets, darwinVZCacheOutputSnapshotTarget{
+			volume:     volume,
+			cfg:        cfg,
+			snapshotID: darwinVZCacheOutputSnapshotID(snapshotIDPrefix, volume.Spec.VolumeID),
+		})
+	}
+
+	executeInSandbox := a.executeInSandboxFn
+	if executeInSandbox == nil {
+		executeInSandbox = a.executeInSandbox
+	}
+
+	connectSeconds := req.FirecrackerConfig.LaunchSeconds
+	if connectSeconds <= 0 {
+		connectSeconds = instance.CommandTimeout
+	}
+	if connectSeconds <= 0 {
+		connectSeconds = 30
+	}
+	syncCtx, cancel := context.WithTimeout(ctx, time.Duration(connectSeconds)*time.Second)
+	defer cancel()
+	syncResult, err := executeInSandbox(syncCtx, ctx, instance, backend.ExecutionRequest{
+		SandboxID: sandboxID,
+		Command:   []string{"sync"},
+		Policy:    instance.Policy,
+	}, backend.OutputStream{})
+	if err != nil {
+		return nil, fmt.Errorf("sync sandbox filesystem before cache output snapshot: %w", err)
+	}
+	if syncResult != nil && syncResult.ExitCode != 0 {
+		guestErr := strings.TrimSpace(syncResult.Message)
+		if guestErr != "" {
+			return nil, fmt.Errorf("sync sandbox filesystem before cache output snapshot: guest sync command exited with code %d: %s", syncResult.ExitCode, guestErr)
+		}
+		return nil, fmt.Errorf("sync sandbox filesystem before cache output snapshot: guest sync command exited with code %d", syncResult.ExitCode)
+	}
+
+	helperRequest := a.helperRequestFn
+	if helperRequest == nil {
+		helperRequest = func(ctx context.Context, helper *helperSession, req helperControlRequest) (helperControlResponse, error) {
+			return helper.request(ctx, req)
+		}
+	}
+	if instance.Helper == nil {
+		return nil, errors.New("darwin-vz sandbox helper is not available")
+	}
+	if strings.TrimSpace(instance.VMID) == "" {
+		return nil, errors.New("darwin-vz sandbox vm id is empty")
+	}
+
+	result := &backend.SnapshotCacheOutputVolumesResult{Volumes: make([]backend.CacheOutputVolumeSnapshot, 0, len(targets))}
+	createdSnapshots := make([]createdDarwinVZCacheOutputSnapshot, 0, len(targets))
+	cleanupCreated := func() {
+		for i := len(createdSnapshots) - 1; i >= 0; i-- {
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			_ = createdSnapshots[i].driver.DestroySnapshot(cleanupCtx, volumestore.DestroySnapshotRequest{SnapshotRef: createdSnapshots[i].storageRef})
+			cancel()
+		}
+	}
+	defer func() {
+		if retErr != nil {
+			cleanupCreated()
+		}
+	}()
+
+	if _, err := helperRequest(ctx, instance.Helper, helperControlRequest{Op: "PauseVM", VMID: instance.VMID}); err != nil {
+		return nil, fmt.Errorf("pause darwin-vz sandbox: %w", err)
+	}
+	defer func() {
+		resumeCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if _, err := helperRequest(resumeCtx, instance.Helper, helperControlRequest{Op: "ResumeVM", VMID: instance.VMID}); err != nil && retErr == nil {
+			result = nil
+			retErr = fmt.Errorf("resume darwin-vz sandbox after cache output snapshot: %w", err)
+		}
+	}()
+
+	for _, target := range targets {
+		driver, err := snapshotVolumeDriver(target.cfg)
+		if err != nil {
+			return nil, err
+		}
+		volume := target.volume
+		snapshot, snapshotDriver, storageDriver, err := snapshotDarwinVZCacheOutputVolume(ctx, driver, volumestore.SnapshotVolumeRequest{
+			SnapshotID: target.snapshotID,
+			VolumeRef:  volume.Volume.Ref,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("snapshot cache output volume %q: %w", volume.Spec.VolumeID, err)
+		}
+		storageRef := strings.TrimSpace(snapshot.StorageRef)
+		if storageRef == "" {
+			return nil, fmt.Errorf("snapshot cache output volume %q returned empty storage ref", volume.Spec.VolumeID)
+		}
+		snapshotRef := strings.TrimSpace(snapshot.Ref)
+		if snapshotRef == "" {
+			snapshotRef = storageRef
+		}
+		createdSnapshots = append(createdSnapshots, createdDarwinVZCacheOutputSnapshot{
+			driver:     snapshotDriver,
+			storageRef: storageRef,
+		})
+		result.Volumes = append(result.Volumes, backend.CacheOutputVolumeSnapshot{
+			Stage:              strings.TrimSpace(volume.Spec.Stage),
+			BlockName:          strings.TrimSpace(volume.Spec.BlockName),
+			CacheKey:           strings.TrimSpace(volume.Spec.CacheKey),
+			VolumeID:           strings.TrimSpace(volume.Spec.VolumeID),
+			StorageDriver:      storageDriver,
+			StorageRef:         storageRef,
+			SnapshotRef:        snapshotRef,
+			StorageSizeBytes:   snapshot.StorageSizeBytes,
+			ExclusiveSizeBytes: snapshot.ExclusiveSizeBytes,
+			DriverMetadata:     strings.TrimSpace(snapshot.DriverMetadata),
+			Outputs:            darwinVZCacheOutputVolumeSnapshotOutputs(volume.Spec),
+		})
+	}
+
+	return result, nil
+}
+
+func snapshotDarwinVZCacheOutputVolume(ctx context.Context, driver volumestore.Driver, req volumestore.SnapshotVolumeRequest) (volumestore.Snapshot, volumestore.Driver, string, error) {
+	if fallback, ok := driver.(*fallbackVolumeDriver); ok {
+		snapshot, err := fallback.primary.SnapshotVolume(ctx, req)
+		if err == nil || !fallback.shouldFallback(err) {
+			return snapshot, fallback.primary, fallback.primary.Name(), err
+		}
+		snapshot, err = fallback.fallback.SnapshotVolume(ctx, req)
+		return snapshot, fallback.fallback, fallback.fallback.Name(), err
+	}
+	snapshot, err := driver.SnapshotVolume(ctx, req)
+	return snapshot, driver, driver.Name(), err
+}
+
+func selectDarwinVZCacheOutputVolumes(volumes []preparedDarwinVZCacheOutputVolume, volumeIDs []string) ([]preparedDarwinVZCacheOutputVolume, error) {
+	if len(volumeIDs) == 0 {
+		return append([]preparedDarwinVZCacheOutputVolume(nil), volumes...), nil
+	}
+	byID := make(map[string]preparedDarwinVZCacheOutputVolume, len(volumes))
+	for _, volume := range volumes {
+		byID[strings.TrimSpace(volume.Spec.VolumeID)] = volume
+	}
+	selected := make([]preparedDarwinVZCacheOutputVolume, 0, len(volumeIDs))
+	seen := make(map[string]struct{}, len(volumeIDs))
+	for _, id := range volumeIDs {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			return nil, errors.New("cache output volume id cannot be empty")
+		}
+		if _, ok := seen[id]; ok {
+			return nil, fmt.Errorf("duplicate cache output volume id %q", id)
+		}
+		seen[id] = struct{}{}
+		volume, ok := byID[id]
+		if !ok {
+			return nil, fmt.Errorf("unknown cache output volume id %q", id)
+		}
+		selected = append(selected, volume)
+	}
+	return selected, nil
+}
+
+func darwinVZCacheOutputSnapshotConfig(cfg backend.FirecrackerConfig, spec backend.CacheOutputVolumeSpec) backend.FirecrackerConfig {
+	if driver := strings.TrimSpace(spec.StorageDriver); driver != "" {
+		cfg.Snapshots.Driver = driver
+	}
+	return cfg
+}
+
+func darwinVZCacheOutputSnapshotID(prefix, volumeID string) string {
+	hash := darwinVZCacheOutputSnapshotHash(strings.TrimSpace(volumeID))
+	return strings.TrimSpace(prefix) + "-" + hash[:16]
+}
+
+func darwinVZCacheOutputVolumeSnapshotOutputs(spec backend.CacheOutputVolumeSpec) []backend.CacheOutputVolumeSnapshotOutput {
+	out := make([]backend.CacheOutputVolumeSnapshotOutput, 0, len(spec.DirMappings)+len(spec.FileMappings))
+	for _, mapping := range spec.DirMappings {
+		out = append(out, backend.CacheOutputVolumeSnapshotOutput{
+			Kind:          "dir",
+			GuestPath:     strings.TrimSpace(mapping.GuestPath),
+			VolumeSubpath: strings.TrimSpace(mapping.Subpath),
+		})
+	}
+	for _, mapping := range spec.FileMappings {
+		out = append(out, backend.CacheOutputVolumeSnapshotOutput{
+			Kind:          "file",
+			GuestPath:     strings.TrimSpace(mapping.GuestPath),
+			VolumeSubpath: strings.TrimSpace(mapping.Subpath),
+			Mode:          mapping.Mode.Perm(),
+		})
+	}
+	return out
+}
+
+func darwinVZCacheOutputSnapshotHash(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/backend/darwinvz/cache_output_snapshots_darwin_test.go
+++ b/internal/backend/darwinvz/cache_output_snapshots_darwin_test.go
@@ -29,11 +29,19 @@ func TestSnapshotCacheOutputVolumesSyncsPausesAndSnapshotsSelectedVolumes(t *tes
 	var syncCommands [][]string
 	var helperOps []string
 	adapter := &Adapter{
-		executeInSandboxFn: func(_ context.Context, _ context.Context, instance *sandboxInstance, req backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
+		executeInSandboxFn: func(bootCtx context.Context, runCtx context.Context, instance *sandboxInstance, req backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
 			if instance == nil || instance.SandboxID != "cr-test" {
 				t.Fatalf("unexpected sandbox instance: %#v", instance)
 			}
 			syncCommands = append(syncCommands, append([]string(nil), req.Command...))
+			bootDeadline, bootOK := bootCtx.Deadline()
+			runDeadline, runOK := runCtx.Deadline()
+			if !bootOK || !runOK {
+				t.Fatalf("expected sync contexts to carry deadlines: boot=%v run=%v", bootOK, runOK)
+			}
+			if !bootDeadline.Equal(runDeadline) {
+				t.Fatalf("expected run context to use sync timeout deadline: boot=%s run=%s", bootDeadline, runDeadline)
+			}
 			return &backend.ExecutionResult{ExitCode: 0}, nil
 		},
 		helperRequestFn: func(_ context.Context, helper *helperSession, req helperControlRequest) (helperControlResponse, error) {

--- a/internal/backend/darwinvz/cache_output_snapshots_darwin_test.go
+++ b/internal/backend/darwinvz/cache_output_snapshots_darwin_test.go
@@ -1,0 +1,258 @@
+//go:build darwin
+
+package darwinvz
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/buildkite/cleanroom/internal/volumestore"
+	"golang.org/x/sys/unix"
+)
+
+func TestSnapshotCacheOutputVolumesSyncsPausesAndSnapshotsSelectedVolumes(t *testing.T) {
+	stateHome := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateHome)
+
+	volumePath := filepath.Join(t.TempDir(), "cache-output.ext4")
+	if err := os.WriteFile(volumePath, []byte("volume-bytes"), 0o644); err != nil {
+		t.Fatalf("write cache output volume: %v", err)
+	}
+
+	var syncCommands [][]string
+	var helperOps []string
+	adapter := &Adapter{
+		executeInSandboxFn: func(_ context.Context, _ context.Context, instance *sandboxInstance, req backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
+			if instance == nil || instance.SandboxID != "cr-test" {
+				t.Fatalf("unexpected sandbox instance: %#v", instance)
+			}
+			syncCommands = append(syncCommands, append([]string(nil), req.Command...))
+			return &backend.ExecutionResult{ExitCode: 0}, nil
+		},
+		helperRequestFn: func(_ context.Context, helper *helperSession, req helperControlRequest) (helperControlResponse, error) {
+			if helper == nil {
+				t.Fatal("expected helper session")
+			}
+			helperOps = append(helperOps, req.Op+":"+req.VMID)
+			return helperControlResponse{OK: true}, nil
+		},
+		sandboxes: map[string]*sandboxInstance{
+			"cr-test": {
+				SandboxID: "cr-test",
+				Helper:    &helperSession{},
+				VMID:      "vm-test",
+				Policy:    &policy.CompiledPolicy{NetworkDefault: "deny"},
+				exitedCh:  make(chan struct{}),
+				cacheOutputVolumes: []preparedDarwinVZCacheOutputVolume{
+					testPreparedDarwinVZCacheOutputVolume("dependency-volume", "deps", "key-a", "volume-a", volumePath),
+					testPreparedDarwinVZCacheOutputVolume("dependency-volume", "tools", "key-b", "volume-b", filepath.Join(t.TempDir(), "other.ext4")),
+				},
+			},
+		},
+	}
+
+	result, err := adapter.SnapshotCacheOutputVolumes(context.Background(), backend.SnapshotCacheOutputVolumesRequest{
+		SandboxID:        "cr-test",
+		SnapshotIDPrefix: "cacheout",
+		VolumeIDs:        []string{"volume-a"},
+		FirecrackerConfig: backend.FirecrackerConfig{
+			Snapshots: backend.SnapshotConfig{Enabled: true, Driver: "file"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SnapshotCacheOutputVolumes returned error: %v", err)
+	}
+	if got, want := syncCommands, [][]string{{"sync"}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected sync commands: got %#v want %#v", got, want)
+	}
+	if got, want := strings.Join(helperOps, ","), "PauseVM:vm-test,ResumeVM:vm-test"; got != want {
+		t.Fatalf("unexpected helper ops: got %q want %q", got, want)
+	}
+	if result == nil || len(result.Volumes) != 1 {
+		t.Fatalf("expected one snapshot result, got %#v", result)
+	}
+	snapshotID := darwinVZCacheOutputSnapshotID("cacheout", "volume-a")
+	wantStorageRef := filepath.Join(stateHome, "cleanroom", "snapshots", "darwin-vz", snapshotID, "rootfs.ext4")
+	snapshot := result.Volumes[0]
+	if got, want := snapshot.StorageRef, wantStorageRef; got != want {
+		t.Fatalf("unexpected storage ref: got %q want %q", got, want)
+	}
+	if got, want := snapshot.SnapshotRef, wantStorageRef; got != want {
+		t.Fatalf("unexpected snapshot ref: got %q want %q", got, want)
+	}
+	if got, want := snapshot.StorageDriver, "file"; got != want {
+		t.Fatalf("unexpected storage driver: got %q want %q", got, want)
+	}
+	if got, want := snapshot.Stage, "dependency-volume"; got != want {
+		t.Fatalf("unexpected stage: got %q want %q", got, want)
+	}
+	if got, want := snapshot.BlockName, "deps"; got != want {
+		t.Fatalf("unexpected block name: got %q want %q", got, want)
+	}
+	if got, want := snapshot.CacheKey, "key-a"; got != want {
+		t.Fatalf("unexpected cache key: got %q want %q", got, want)
+	}
+	if got, want := snapshot.VolumeID, "volume-a"; got != want {
+		t.Fatalf("unexpected volume id: got %q want %q", got, want)
+	}
+	if got, want := snapshot.Outputs, []backend.CacheOutputVolumeSnapshotOutput{
+		{Kind: "dir", GuestPath: "/deps", VolumeSubpath: "dir/0"},
+		{Kind: "file", GuestPath: "/deps.lock", VolumeSubpath: "file/0", Mode: 0o640},
+	}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected outputs: got %#v want %#v", got, want)
+	}
+	data, err := os.ReadFile(snapshot.StorageRef)
+	if err != nil {
+		t.Fatalf("read snapshot volume: %v", err)
+	}
+	if got, want := string(data), "volume-bytes"; got != want {
+		t.Fatalf("unexpected snapshot contents: got %q want %q", got, want)
+	}
+}
+
+func TestSnapshotCacheOutputVolumesCleansCreatedSnapshotsOnFailure(t *testing.T) {
+	stateHome := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateHome)
+
+	firstVolumePath := filepath.Join(t.TempDir(), "cache-output-a.ext4")
+	if err := os.WriteFile(firstVolumePath, []byte("volume-a"), 0o644); err != nil {
+		t.Fatalf("write first cache output volume: %v", err)
+	}
+	missingVolumePath := filepath.Join(t.TempDir(), "missing.ext4")
+
+	var helperOps []string
+	adapter := &Adapter{
+		executeInSandboxFn: func(context.Context, context.Context, *sandboxInstance, backend.ExecutionRequest, backend.OutputStream) (*backend.ExecutionResult, error) {
+			return &backend.ExecutionResult{ExitCode: 0}, nil
+		},
+		helperRequestFn: func(_ context.Context, _ *helperSession, req helperControlRequest) (helperControlResponse, error) {
+			helperOps = append(helperOps, req.Op+":"+req.VMID)
+			return helperControlResponse{OK: true}, nil
+		},
+		sandboxes: map[string]*sandboxInstance{
+			"cr-test": {
+				SandboxID: "cr-test",
+				Helper:    &helperSession{},
+				VMID:      "vm-test",
+				Policy:    &policy.CompiledPolicy{NetworkDefault: "deny"},
+				exitedCh:  make(chan struct{}),
+				cacheOutputVolumes: []preparedDarwinVZCacheOutputVolume{
+					testPreparedDarwinVZCacheOutputVolume("dependency-volume", "deps", "key-a", "volume-a", firstVolumePath),
+					testPreparedDarwinVZCacheOutputVolume("dependency-volume", "tools", "key-b", "volume-b", missingVolumePath),
+				},
+			},
+		},
+	}
+
+	_, err := adapter.SnapshotCacheOutputVolumes(context.Background(), backend.SnapshotCacheOutputVolumesRequest{
+		SandboxID:        "cr-test",
+		SnapshotIDPrefix: "cacheout",
+		FirecrackerConfig: backend.FirecrackerConfig{
+			Snapshots: backend.SnapshotConfig{Enabled: true, Driver: "file"},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), `snapshot cache output volume "volume-b"`) {
+		t.Fatalf("expected volume-b snapshot failure, got %v", err)
+	}
+	if got, want := strings.Join(helperOps, ","), "PauseVM:vm-test,ResumeVM:vm-test"; got != want {
+		t.Fatalf("unexpected helper ops: got %q want %q", got, want)
+	}
+
+	firstSnapshotPath := filepath.Join(stateHome, "cleanroom", "snapshots", "darwin-vz", darwinVZCacheOutputSnapshotID("cacheout", "volume-a"), "rootfs.ext4")
+	if _, err := os.Stat(firstSnapshotPath); !os.IsNotExist(err) {
+		t.Fatalf("expected first snapshot to be cleaned up, stat err=%v", err)
+	}
+}
+
+func TestSnapshotCacheOutputVolumesRejectsUnknownVolumeID(t *testing.T) {
+	adapter := &Adapter{
+		sandboxes: map[string]*sandboxInstance{
+			"cr-test": {
+				SandboxID: "cr-test",
+				exitedCh:  make(chan struct{}),
+				cacheOutputVolumes: []preparedDarwinVZCacheOutputVolume{
+					testPreparedDarwinVZCacheOutputVolume("dependency-volume", "deps", "key-a", "volume-a", "volume-a-ref"),
+				},
+			},
+		},
+	}
+
+	_, err := adapter.SnapshotCacheOutputVolumes(context.Background(), backend.SnapshotCacheOutputVolumesRequest{
+		SandboxID:        "cr-test",
+		SnapshotIDPrefix: "cacheout",
+		VolumeIDs:        []string{"missing"},
+		FirecrackerConfig: backend.FirecrackerConfig{
+			Snapshots: backend.SnapshotConfig{Enabled: true, Driver: "file"},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), `unknown cache output volume id "missing"`) {
+		t.Fatalf("expected unknown volume id error, got %v", err)
+	}
+}
+
+func TestSnapshotDarwinVZCacheOutputVolumeReportsFallbackDriver(t *testing.T) {
+	primary := &stubVolumeDriver{
+		name:        "apfs",
+		snapshotErr: fmt.Errorf("clonefile snapshot volume: %w", unix.ENOTSUP),
+	}
+	fallback := &stubVolumeDriver{
+		name:     "file",
+		snapshot: volumestore.Snapshot{Ref: "file-snapshot", StorageRef: "file-snapshot"},
+	}
+	driver := &fallbackVolumeDriver{
+		primary:        primary,
+		fallback:       fallback,
+		shouldFallback: shouldFallbackFromAPFS,
+	}
+
+	snapshot, snapshotDriver, storageDriver, err := snapshotDarwinVZCacheOutputVolume(context.Background(), driver, volumestore.SnapshotVolumeRequest{
+		SnapshotID: "snap-1",
+		VolumeRef:  "volume-ref",
+	})
+	if err != nil {
+		t.Fatalf("snapshotDarwinVZCacheOutputVolume returned error: %v", err)
+	}
+	if got, want := snapshot.StorageRef, "file-snapshot"; got != want {
+		t.Fatalf("unexpected snapshot storage ref: got %q want %q", got, want)
+	}
+	if snapshotDriver != fallback {
+		t.Fatalf("expected fallback driver to own snapshot cleanup, got %#v", snapshotDriver)
+	}
+	if got, want := storageDriver, "file"; got != want {
+		t.Fatalf("unexpected storage driver: got %q want %q", got, want)
+	}
+	if got, want := primary.snapshotCalls, 1; got != want {
+		t.Fatalf("unexpected primary snapshot calls: got %d want %d", got, want)
+	}
+	if got, want := fallback.snapshotCalls, 1; got != want {
+		t.Fatalf("unexpected fallback snapshot calls: got %d want %d", got, want)
+	}
+}
+
+func testPreparedDarwinVZCacheOutputVolume(stage, blockName, cacheKey, volumeID, volumeRef string) preparedDarwinVZCacheOutputVolume {
+	return preparedDarwinVZCacheOutputVolume{
+		Spec: backend.CacheOutputVolumeSpec{
+			Stage:     stage,
+			BlockName: blockName,
+			CacheKey:  cacheKey,
+			VolumeID:  volumeID,
+			DirMappings: []backend.CacheOutputDirMapping{{
+				GuestPath: "/deps",
+				Subpath:   "dir/0",
+			}},
+			FileMappings: []backend.CacheOutputFileMapping{{
+				GuestPath: "/deps.lock",
+				Subpath:   "file/0",
+				Mode:      0o640,
+			}},
+		},
+		Volume: volumestore.WritableVolume{Ref: volumeRef, AttachmentPath: volumeRef},
+	}
+}

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -88,27 +88,28 @@ type gatewayRegistry interface {
 }
 
 type sandboxInstance struct {
-	SandboxID         string
-	RunDir            string
-	ConfigPath        string
-	VsockPath         string
-	GuestPort         uint32
-	Policy            *policy.CompiledPolicy
-	ImageRef          string
-	ImageDigest       string
-	CommandTimeout    int64
-	HostIP            string
-	GuestIP           string
-	fcCmd             *exec.Cmd
-	exitedCh          chan struct{}
-	exitMu            sync.RWMutex
-	exitErr           error
-	exitReady         bool
-	cleanupNetwork    func()
-	cleanupVolume     func()
-	vmRootFSPath      string
-	volumeRef         string
-	cacheOutputMounts []vsockexec.CacheOutputMount
+	SandboxID          string
+	RunDir             string
+	ConfigPath         string
+	VsockPath          string
+	GuestPort          uint32
+	Policy             *policy.CompiledPolicy
+	ImageRef           string
+	ImageDigest        string
+	CommandTimeout     int64
+	HostIP             string
+	GuestIP            string
+	fcCmd              *exec.Cmd
+	exitedCh           chan struct{}
+	exitMu             sync.RWMutex
+	exitErr            error
+	exitReady          bool
+	cleanupNetwork     func()
+	cleanupVolume      func()
+	vmRootFSPath       string
+	volumeRef          string
+	cacheOutputMounts  []vsockexec.CacheOutputMount
+	cacheOutputVolumes []preparedCacheOutputVolume
 
 	warnings backend.WarningEmitter
 }
@@ -1975,24 +1976,25 @@ func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID strin
 	}
 
 	instance := &sandboxInstance{
-		SandboxID:         sandboxID,
-		RunDir:            runDir,
-		ConfigPath:        configPath,
-		VsockPath:         vsockPath,
-		GuestPort:         cfg.GuestPort,
-		Policy:            compiled,
-		ImageRef:          compiled.ImageRef,
-		ImageDigest:       compiled.ImageDigest,
-		CommandTimeout:    cfg.LaunchSeconds,
-		HostIP:            networkCfg.HostIP,
-		GuestIP:           networkCfg.GuestIP,
-		fcCmd:             fcCmd,
-		exitedCh:          make(chan struct{}),
-		cleanupNetwork:    cleanupNetwork,
-		cleanupVolume:     cleanupStorage,
-		vmRootFSPath:      vmRootFSPath,
-		volumeRef:         writableVolume.Ref,
-		cacheOutputMounts: cacheOutputVolumeMounts(cacheOutputVolumes),
+		SandboxID:          sandboxID,
+		RunDir:             runDir,
+		ConfigPath:         configPath,
+		VsockPath:          vsockPath,
+		GuestPort:          cfg.GuestPort,
+		Policy:             compiled,
+		ImageRef:           compiled.ImageRef,
+		ImageDigest:        compiled.ImageDigest,
+		CommandTimeout:     cfg.LaunchSeconds,
+		HostIP:             networkCfg.HostIP,
+		GuestIP:            networkCfg.GuestIP,
+		fcCmd:              fcCmd,
+		exitedCh:           make(chan struct{}),
+		cleanupNetwork:     cleanupNetwork,
+		cleanupVolume:      cleanupStorage,
+		vmRootFSPath:       vmRootFSPath,
+		volumeRef:          writableVolume.Ref,
+		cacheOutputMounts:  cacheOutputVolumeMounts(cacheOutputVolumes),
+		cacheOutputVolumes: cacheOutputVolumes,
 	}
 	instanceRef.Store(instance)
 	go func() {

--- a/internal/backend/firecracker/cache_output_snapshots.go
+++ b/internal/backend/firecracker/cache_output_snapshots.go
@@ -1,0 +1,224 @@
+package firecracker
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/observability"
+)
+
+type cacheOutputSnapshotTarget struct {
+	volume     preparedCacheOutputVolume
+	cfg        backend.FirecrackerConfig
+	snapshotID string
+}
+
+type createdCacheOutputSnapshot struct {
+	cfg        backend.FirecrackerConfig
+	storageRef string
+}
+
+func (a *Adapter) SnapshotCacheOutputVolumes(ctx context.Context, req backend.SnapshotCacheOutputVolumesRequest) (_ *backend.SnapshotCacheOutputVolumesResult, retErr error) {
+	sandboxID := strings.TrimSpace(req.SandboxID)
+	if sandboxID == "" {
+		return nil, errors.New("missing sandbox_id")
+	}
+	snapshotIDPrefix := strings.TrimSpace(req.SnapshotIDPrefix)
+	if snapshotIDPrefix == "" {
+		return nil, errors.New("missing snapshot_id_prefix")
+	}
+
+	a.sandboxMu.Lock()
+	instance, ok := a.sandboxes[sandboxID]
+	a.sandboxMu.Unlock()
+	if !ok {
+		return nil, fmt.Errorf("unknown sandbox %q", sandboxID)
+	}
+	if err := instance.exitedErrOrNil(); err != nil {
+		return nil, fmt.Errorf("sandbox %q is not running: %w", sandboxID, err)
+	}
+
+	volumes, err := selectCacheOutputVolumes(instance.cacheOutputVolumes, req.VolumeIDs)
+	if err != nil {
+		return nil, err
+	}
+	if len(volumes) == 0 {
+		return &backend.SnapshotCacheOutputVolumesResult{}, nil
+	}
+
+	targets := make([]cacheOutputSnapshotTarget, 0, len(volumes))
+	needsHostSync := false
+	for _, volume := range volumes {
+		cfg, err := cacheOutputSnapshotConfig(req.FirecrackerConfig, volume.Spec, volume.Volume.Ref)
+		if err != nil {
+			return nil, err
+		}
+		if err := validateSnapshotStorageConfig(cfg); err != nil {
+			return nil, err
+		}
+		if strings.EqualFold(strings.TrimSpace(cfg.Snapshots.Driver), "zfs") {
+			needsHostSync = true
+		}
+		targets = append(targets, cacheOutputSnapshotTarget{
+			volume:     volume,
+			cfg:        cfg,
+			snapshotID: cacheOutputSnapshotID(snapshotIDPrefix, volume.Spec.VolumeID),
+		})
+	}
+
+	syncResp, _, err := a.executeInSandbox(ctx, instance, snapshotSyncTimeoutSeconds, []string{"sync"}, "", nil, false, nil, nil, false, backend.OutputStream{})
+	if err != nil {
+		return nil, fmt.Errorf("sync sandbox filesystem before cache output snapshot: %w", err)
+	}
+	if syncResp.ExitCode != 0 {
+		guestErr := strings.TrimSpace(syncResp.Error)
+		if guestErr != "" {
+			return nil, fmt.Errorf("sync sandbox filesystem before cache output snapshot: guest sync command exited with code %d: %s", syncResp.ExitCode, guestErr)
+		}
+		return nil, fmt.Errorf("sync sandbox filesystem before cache output snapshot: guest sync command exited with code %d", syncResp.ExitCode)
+	}
+
+	logger := observability.WithLoggerFields(observability.WithTraceContext(baseFirecrackerLogger(a.Logger), ctx), observability.LogFieldSandboxID, sandboxID)
+	result := &backend.SnapshotCacheOutputVolumesResult{Volumes: make([]backend.CacheOutputVolumeSnapshot, 0, len(targets))}
+	createdSnapshots := make([]createdCacheOutputSnapshot, 0, len(targets))
+	cleanupCreated := func() {
+		for i := len(createdSnapshots) - 1; i >= 0; i-- {
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			_ = destroySnapshotStorage(cleanupCtx, logger, createdSnapshots[i].cfg, createdSnapshots[i].storageRef)
+			cancel()
+		}
+	}
+	defer func() {
+		if retErr != nil {
+			cleanupCreated()
+		}
+	}()
+
+	if err := pauseSandboxProcess(instance); err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := resumeSandboxProcess(instance); err != nil && retErr == nil {
+			result = nil
+			retErr = fmt.Errorf("resume firecracker sandbox after cache output snapshot: %w", err)
+		}
+	}()
+
+	if needsHostSync {
+		if err := flushSnapshotHostFilesystem(ctx, "zfs"); err != nil {
+			return nil, err
+		}
+	}
+
+	for _, target := range targets {
+		volume := target.volume
+		snapshot, err := createSnapshotStorage(ctx, logger, target.cfg, target.snapshotID, volume.Volume.Ref)
+		if err != nil {
+			return nil, fmt.Errorf("snapshot cache output volume %q: %w", volume.Spec.VolumeID, err)
+		}
+		if snapshot == nil {
+			return nil, fmt.Errorf("snapshot cache output volume %q returned no result", volume.Spec.VolumeID)
+		}
+		storageRef := strings.TrimSpace(snapshot.StorageRef)
+		if storageRef == "" {
+			return nil, fmt.Errorf("snapshot cache output volume %q returned empty storage ref", volume.Spec.VolumeID)
+		}
+		createdSnapshots = append(createdSnapshots, createdCacheOutputSnapshot{
+			cfg:        target.cfg,
+			storageRef: storageRef,
+		})
+		result.Volumes = append(result.Volumes, backend.CacheOutputVolumeSnapshot{
+			Stage:              strings.TrimSpace(volume.Spec.Stage),
+			BlockName:          strings.TrimSpace(volume.Spec.BlockName),
+			CacheKey:           strings.TrimSpace(volume.Spec.CacheKey),
+			VolumeID:           strings.TrimSpace(volume.Spec.VolumeID),
+			StorageDriver:      effectiveSnapshotDriver(target.cfg),
+			StorageRef:         storageRef,
+			SnapshotRef:        storageRef,
+			StorageSizeBytes:   snapshot.StorageSizeBytes,
+			ExclusiveSizeBytes: snapshot.ExclusiveSizeBytes,
+			DriverMetadata:     strings.TrimSpace(snapshot.DriverMetadata),
+			Outputs:            cacheOutputVolumeSnapshotOutputs(volume.Spec),
+		})
+	}
+	return result, nil
+}
+
+func selectCacheOutputVolumes(volumes []preparedCacheOutputVolume, volumeIDs []string) ([]preparedCacheOutputVolume, error) {
+	if len(volumeIDs) == 0 {
+		return append([]preparedCacheOutputVolume(nil), volumes...), nil
+	}
+	byID := make(map[string]preparedCacheOutputVolume, len(volumes))
+	for _, volume := range volumes {
+		byID[strings.TrimSpace(volume.Spec.VolumeID)] = volume
+	}
+	selected := make([]preparedCacheOutputVolume, 0, len(volumeIDs))
+	seen := make(map[string]struct{}, len(volumeIDs))
+	for _, id := range volumeIDs {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			return nil, errors.New("cache output volume id cannot be empty")
+		}
+		if _, ok := seen[id]; ok {
+			return nil, fmt.Errorf("duplicate cache output volume id %q", id)
+		}
+		seen[id] = struct{}{}
+		volume, ok := byID[id]
+		if !ok {
+			return nil, fmt.Errorf("unknown cache output volume id %q", id)
+		}
+		selected = append(selected, volume)
+	}
+	return selected, nil
+}
+
+func cacheOutputSnapshotID(prefix, volumeID string) string {
+	hash := sha256String(strings.TrimSpace(volumeID))
+	return strings.TrimSpace(prefix) + "-" + hash[:16]
+}
+
+func cacheOutputSnapshotConfig(cfg backend.FirecrackerConfig, spec backend.CacheOutputVolumeSpec, volumeRef string) (backend.FirecrackerConfig, error) {
+	if driver := strings.TrimSpace(spec.StorageDriver); driver != "" {
+		cfg.Snapshots.Driver = driver
+	}
+	return snapshotConfigForStorageRef(cfg, volumeRef)
+}
+
+func cacheOutputVolumeSnapshotOutputs(spec backend.CacheOutputVolumeSpec) []backend.CacheOutputVolumeSnapshotOutput {
+	out := make([]backend.CacheOutputVolumeSnapshotOutput, 0, len(spec.DirMappings)+len(spec.FileMappings))
+	for _, mapping := range spec.DirMappings {
+		out = append(out, backend.CacheOutputVolumeSnapshotOutput{
+			Kind:          "dir",
+			GuestPath:     strings.TrimSpace(mapping.GuestPath),
+			VolumeSubpath: strings.TrimSpace(mapping.Subpath),
+		})
+	}
+	for _, mapping := range spec.FileMappings {
+		out = append(out, backend.CacheOutputVolumeSnapshotOutput{
+			Kind:          "file",
+			GuestPath:     strings.TrimSpace(mapping.GuestPath),
+			VolumeSubpath: strings.TrimSpace(mapping.Subpath),
+			Mode:          mapping.Mode.Perm(),
+		})
+	}
+	return out
+}
+
+func effectiveSnapshotDriver(cfg backend.FirecrackerConfig) string {
+	driver := strings.ToLower(strings.TrimSpace(cfg.Snapshots.Driver))
+	if driver == "" {
+		return "file"
+	}
+	return driver
+}
+
+func sha256String(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/backend/firecracker/cache_output_snapshots_test.go
+++ b/internal/backend/firecracker/cache_output_snapshots_test.go
@@ -1,0 +1,256 @@
+package firecracker
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"reflect"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/volumestore"
+	"github.com/buildkite/cleanroom/internal/vsockexec"
+)
+
+func TestSnapshotCacheOutputVolumesSyncsPausesAndSnapshotsSelectedVolumes(t *testing.T) {
+	prevSnapshotDriver := snapshotVolumeStoreDriverFn
+	prevSignal := sendProcessSignal
+	t.Cleanup(func() {
+		snapshotVolumeStoreDriverFn = prevSnapshotDriver
+		sendProcessSignal = prevSignal
+	})
+
+	var signals []syscall.Signal
+	sendProcessSignal = func(_ *os.Process, sig syscall.Signal) error {
+		signals = append(signals, sig)
+		return nil
+	}
+
+	var snapshotReqs []volumestore.SnapshotVolumeRequest
+	snapshotVolumeStoreDriverFn = func(cfg backend.FirecrackerConfig) (volumestore.Driver, error) {
+		if !cfg.Snapshots.Enabled {
+			t.Fatal("expected snapshots to be enabled")
+		}
+		if got, want := cfg.Snapshots.Driver, "file"; got != want {
+			t.Fatalf("expected per-volume storage driver override, got %q want %q", got, want)
+		}
+		return testVolumeDriver{
+			snapshotVolumeFn: func(_ context.Context, req volumestore.SnapshotVolumeRequest) (volumestore.Snapshot, error) {
+				snapshotReqs = append(snapshotReqs, req)
+				return volumestore.Snapshot{
+					StorageRef:         "snapshot-storage-ref",
+					StorageSizeBytes:   123,
+					ExclusiveSizeBytes: 45,
+					DriverMetadata:     "metadata",
+				}, nil
+			},
+		}, nil
+	}
+
+	var syncCommands [][]string
+	adapter := &Adapter{
+		runGuestCommandFn: func(_ context.Context, _ context.Context, _ <-chan struct{}, _ func() error, _ string, _ uint32, req vsockexec.ExecRequest, _ backend.OutputStream) (vsockexec.ExecResponse, guestExecTiming, error) {
+			syncCommands = append(syncCommands, append([]string(nil), req.Command...))
+			return vsockexec.ExecResponse{ExitCode: 0}, guestExecTiming{}, nil
+		},
+		sandboxes: map[string]*sandboxInstance{
+			"cr-test": {
+				SandboxID: "cr-test",
+				VsockPath: "/tmp/fake.sock",
+				GuestPort: 10700,
+				fcCmd:     &exec.Cmd{Process: &os.Process{Pid: 42}},
+				exitedCh:  make(chan struct{}),
+				cacheOutputVolumes: []preparedCacheOutputVolume{
+					testPreparedCacheOutputVolumeWithDriver("dependency-volume", "deps", "key-a", "volume-a", "volume-a-ref", "file"),
+					testPreparedCacheOutputVolume("dependency-volume", "tools", "key-b", "volume-b", "volume-b-ref"),
+				},
+			},
+		},
+	}
+
+	result, err := adapter.SnapshotCacheOutputVolumes(context.Background(), backend.SnapshotCacheOutputVolumesRequest{
+		SandboxID:        "cr-test",
+		SnapshotIDPrefix: "cacheout",
+		VolumeIDs:        []string{"volume-a"},
+		FirecrackerConfig: backend.FirecrackerConfig{
+			Snapshots: backend.SnapshotConfig{Enabled: true, Driver: "zfs"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SnapshotCacheOutputVolumes returned error: %v", err)
+	}
+	if got, want := syncCommands, [][]string{{"sync"}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected sync commands: got %#v want %#v", got, want)
+	}
+	if got, want := signals, []syscall.Signal{syscall.SIGSTOP, syscall.SIGCONT}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected signals: got %v want %v", got, want)
+	}
+	if got, want := snapshotReqs, []volumestore.SnapshotVolumeRequest{{
+		SnapshotID: cacheOutputSnapshotID("cacheout", "volume-a"),
+		VolumeRef:  "volume-a-ref",
+	}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected snapshot requests: got %#v want %#v", got, want)
+	}
+	if result == nil || len(result.Volumes) != 1 {
+		t.Fatalf("expected one snapshot result, got %#v", result)
+	}
+	snapshot := result.Volumes[0]
+	if got, want := snapshot.Stage, "dependency-volume"; got != want {
+		t.Fatalf("unexpected stage: got %q want %q", got, want)
+	}
+	if got, want := snapshot.BlockName, "deps"; got != want {
+		t.Fatalf("unexpected block name: got %q want %q", got, want)
+	}
+	if got, want := snapshot.CacheKey, "key-a"; got != want {
+		t.Fatalf("unexpected cache key: got %q want %q", got, want)
+	}
+	if got, want := snapshot.VolumeID, "volume-a"; got != want {
+		t.Fatalf("unexpected volume id: got %q want %q", got, want)
+	}
+	if got, want := snapshot.StorageDriver, "file"; got != want {
+		t.Fatalf("unexpected storage driver: got %q want %q", got, want)
+	}
+	if got, want := snapshot.StorageRef, "snapshot-storage-ref"; got != want {
+		t.Fatalf("unexpected storage ref: got %q want %q", got, want)
+	}
+	if got, want := snapshot.SnapshotRef, "snapshot-storage-ref"; got != want {
+		t.Fatalf("unexpected snapshot ref: got %q want %q", got, want)
+	}
+	if got, want := snapshot.StorageSizeBytes, int64(123); got != want {
+		t.Fatalf("unexpected storage size: got %d want %d", got, want)
+	}
+	if got, want := snapshot.ExclusiveSizeBytes, int64(45); got != want {
+		t.Fatalf("unexpected exclusive size: got %d want %d", got, want)
+	}
+	if got, want := snapshot.DriverMetadata, "metadata"; got != want {
+		t.Fatalf("unexpected driver metadata: got %q want %q", got, want)
+	}
+	if got, want := snapshot.Outputs, []backend.CacheOutputVolumeSnapshotOutput{
+		{Kind: "dir", GuestPath: "/deps", VolumeSubpath: "dir/0"},
+		{Kind: "file", GuestPath: "/deps.lock", VolumeSubpath: "file/0", Mode: 0o640},
+	}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected outputs: got %#v want %#v", got, want)
+	}
+}
+
+func TestSnapshotCacheOutputVolumesCleansCreatedSnapshotsOnFailure(t *testing.T) {
+	prevSnapshotDriver := snapshotVolumeStoreDriverFn
+	prevSignal := sendProcessSignal
+	t.Cleanup(func() {
+		snapshotVolumeStoreDriverFn = prevSnapshotDriver
+		sendProcessSignal = prevSignal
+	})
+
+	var signals []syscall.Signal
+	sendProcessSignal = func(_ *os.Process, sig syscall.Signal) error {
+		signals = append(signals, sig)
+		return nil
+	}
+
+	var destroyed []string
+	snapshotVolumeStoreDriverFn = func(backend.FirecrackerConfig) (volumestore.Driver, error) {
+		return testVolumeDriver{
+			snapshotVolumeFn: func(_ context.Context, req volumestore.SnapshotVolumeRequest) (volumestore.Snapshot, error) {
+				if req.VolumeRef == "volume-b-ref" {
+					return volumestore.Snapshot{}, errors.New("boom")
+				}
+				return volumestore.Snapshot{StorageRef: "snapshot-a"}, nil
+			},
+			destroySnapshotFn: func(_ context.Context, req volumestore.DestroySnapshotRequest) error {
+				destroyed = append(destroyed, req.SnapshotRef)
+				return nil
+			},
+		}, nil
+	}
+
+	adapter := &Adapter{
+		runGuestCommandFn: func(context.Context, context.Context, <-chan struct{}, func() error, string, uint32, vsockexec.ExecRequest, backend.OutputStream) (vsockexec.ExecResponse, guestExecTiming, error) {
+			return vsockexec.ExecResponse{ExitCode: 0}, guestExecTiming{}, nil
+		},
+		sandboxes: map[string]*sandboxInstance{
+			"cr-test": {
+				SandboxID: "cr-test",
+				VsockPath: "/tmp/fake.sock",
+				GuestPort: 10700,
+				fcCmd:     &exec.Cmd{Process: &os.Process{Pid: 42}},
+				exitedCh:  make(chan struct{}),
+				cacheOutputVolumes: []preparedCacheOutputVolume{
+					testPreparedCacheOutputVolume("dependency-volume", "deps", "key-a", "volume-a", "volume-a-ref"),
+					testPreparedCacheOutputVolume("dependency-volume", "tools", "key-b", "volume-b", "volume-b-ref"),
+				},
+			},
+		},
+	}
+
+	_, err := adapter.SnapshotCacheOutputVolumes(context.Background(), backend.SnapshotCacheOutputVolumesRequest{
+		SandboxID:        "cr-test",
+		SnapshotIDPrefix: "cacheout",
+		FirecrackerConfig: backend.FirecrackerConfig{
+			Snapshots: backend.SnapshotConfig{Enabled: true},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), `snapshot cache output volume "volume-b"`) {
+		t.Fatalf("expected volume-b snapshot failure, got %v", err)
+	}
+	if got, want := signals, []syscall.Signal{syscall.SIGSTOP, syscall.SIGCONT}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected signals: got %v want %v", got, want)
+	}
+	if got, want := destroyed, []string{"snapshot-a"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected destroyed snapshots: got %#v want %#v", got, want)
+	}
+}
+
+func TestSnapshotCacheOutputVolumesRejectsUnknownVolumeID(t *testing.T) {
+	adapter := &Adapter{
+		sandboxes: map[string]*sandboxInstance{
+			"cr-test": {
+				SandboxID: "cr-test",
+				exitedCh:  make(chan struct{}),
+				cacheOutputVolumes: []preparedCacheOutputVolume{
+					testPreparedCacheOutputVolume("dependency-volume", "deps", "key-a", "volume-a", "volume-a-ref"),
+				},
+			},
+		},
+	}
+
+	_, err := adapter.SnapshotCacheOutputVolumes(context.Background(), backend.SnapshotCacheOutputVolumesRequest{
+		SandboxID:        "cr-test",
+		SnapshotIDPrefix: "cacheout",
+		VolumeIDs:        []string{"missing"},
+		FirecrackerConfig: backend.FirecrackerConfig{
+			Snapshots: backend.SnapshotConfig{Enabled: true},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), `unknown cache output volume id "missing"`) {
+		t.Fatalf("expected unknown volume id error, got %v", err)
+	}
+}
+
+func testPreparedCacheOutputVolume(stage, blockName, cacheKey, volumeID, volumeRef string) preparedCacheOutputVolume {
+	return testPreparedCacheOutputVolumeWithDriver(stage, blockName, cacheKey, volumeID, volumeRef, "")
+}
+
+func testPreparedCacheOutputVolumeWithDriver(stage, blockName, cacheKey, volumeID, volumeRef, storageDriver string) preparedCacheOutputVolume {
+	return preparedCacheOutputVolume{
+		Spec: backend.CacheOutputVolumeSpec{
+			Stage:         stage,
+			BlockName:     blockName,
+			CacheKey:      cacheKey,
+			VolumeID:      volumeID,
+			StorageDriver: storageDriver,
+			DirMappings: []backend.CacheOutputDirMapping{{
+				GuestPath: "/deps",
+				Subpath:   "dir/0",
+			}},
+			FileMappings: []backend.CacheOutputFileMapping{{
+				GuestPath: "/deps.lock",
+				Subpath:   "file/0",
+				Mode:      0o640,
+			}},
+		},
+		Volume: volumestore.WritableVolume{Ref: volumeRef, AttachmentPath: volumeRef},
+	}
+}


### PR DESCRIPTION
## Why

This is a backend slice of the dependency/service volume-cache plan in `docs/plans/dependency-service-volume-caches.md`.

Earlier slices can plan block-volume hits and misses, attach output volumes, mount declared directory outputs, run missed dependency/service blocks from input projections, and skip hit blocks. The next missing primitive is persistence: after a missed block succeeds, the control service needs a backend-neutral way to snapshot the prepared cache-output volume and turn it into output-record metadata. This PR adds that backend snapshot primitive; it does not publish cache records yet.

## What

- Adds `backend.CacheOutputVolumeSnapshottingAdapter` plus result metadata for per-volume snapshots and declared output mappings.
- Implements cache-output volume snapshotting for Firecracker:
  - select all prepared volumes or explicit volume IDs
  - honor per-volume `StorageDriver` overrides before falling back to request config
  - run guest `sync`, pause the VM, flush host filesystems for ZFS, snapshot each selected volume, and resume
  - clean up already-created snapshots if a later snapshot or resume fails
- Implements the same API for darwin-vz using the helper `PauseVM`/`ResumeVM` path and the darwin-vz volume-store driver.
- Keeps the slice inert until the control-service publication path calls the new interface.

## Tests

- `GOCACHE=/private/tmp/cleanroom-go-build-cache mise exec -- go test ./internal/backend/firecracker ./internal/backend/darwinvz ./internal/backend`
- `GOCACHE=/private/tmp/cleanroom-go-build-cache mise exec -- go test ./...`
- `docker run --rm -v "$PWD":/work -v /Users/lachlan/Develop/cleanroom/.git:/Users/lachlan/Develop/cleanroom/.git:ro -w /work -e GOCACHE=/tmp/go-build-cache golang:1.26.2 go test ./...`
