### PR TITLE
feat: Publish dependency volume cache records

### DIFF
--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -310,6 +310,7 @@ type CacheOutputVolumeSnapshot struct {
 	BlockName          string
 	CacheKey           string
 	VolumeID           string
+	SnapshotID         string
 	StorageDriver      string
 	StorageRef         string
 	SnapshotRef        string

--- a/internal/backend/darwinvz/cache_output_snapshots_darwin.go
+++ b/internal/backend/darwinvz/cache_output_snapshots_darwin.go
@@ -167,6 +167,7 @@ func (a *Adapter) SnapshotCacheOutputVolumes(ctx context.Context, req backend.Sn
 			BlockName:          strings.TrimSpace(volume.Spec.BlockName),
 			CacheKey:           strings.TrimSpace(volume.Spec.CacheKey),
 			VolumeID:           strings.TrimSpace(volume.Spec.VolumeID),
+			SnapshotID:         strings.TrimSpace(target.snapshotID),
 			StorageDriver:      storageDriver,
 			StorageRef:         storageRef,
 			SnapshotRef:        snapshotRef,

--- a/internal/backend/darwinvz/cache_output_snapshots_darwin_test.go
+++ b/internal/backend/darwinvz/cache_output_snapshots_darwin_test.go
@@ -92,6 +92,9 @@ func TestSnapshotCacheOutputVolumesSyncsPausesAndSnapshotsSelectedVolumes(t *tes
 	if got, want := snapshot.StorageRef, wantStorageRef; got != want {
 		t.Fatalf("unexpected storage ref: got %q want %q", got, want)
 	}
+	if got, want := snapshot.SnapshotID, snapshotID; got != want {
+		t.Fatalf("unexpected snapshot id: got %q want %q", got, want)
+	}
 	if got, want := snapshot.SnapshotRef, wantStorageRef; got != want {
 		t.Fatalf("unexpected snapshot ref: got %q want %q", got, want)
 	}

--- a/internal/backend/firecracker/cache_output_snapshots.go
+++ b/internal/backend/firecracker/cache_output_snapshots.go
@@ -138,6 +138,7 @@ func (a *Adapter) SnapshotCacheOutputVolumes(ctx context.Context, req backend.Sn
 			BlockName:          strings.TrimSpace(volume.Spec.BlockName),
 			CacheKey:           strings.TrimSpace(volume.Spec.CacheKey),
 			VolumeID:           strings.TrimSpace(volume.Spec.VolumeID),
+			SnapshotID:         strings.TrimSpace(target.snapshotID),
 			StorageDriver:      effectiveSnapshotDriver(target.cfg),
 			StorageRef:         storageRef,
 			SnapshotRef:        storageRef,

--- a/internal/backend/firecracker/cache_output_snapshots_test.go
+++ b/internal/backend/firecracker/cache_output_snapshots_test.go
@@ -110,6 +110,9 @@ func TestSnapshotCacheOutputVolumesSyncsPausesAndSnapshotsSelectedVolumes(t *tes
 	if got, want := snapshot.VolumeID, "volume-a"; got != want {
 		t.Fatalf("unexpected volume id: got %q want %q", got, want)
 	}
+	if got, want := snapshot.SnapshotID, cacheOutputSnapshotID("cacheout", "volume-a"); got != want {
+		t.Fatalf("unexpected snapshot id: got %q want %q", got, want)
+	}
 	if got, want := snapshot.StorageDriver, "file"; got != want {
 		t.Fatalf("unexpected storage driver: got %q want %q", got, want)
 	}

--- a/internal/controlservice/dependency_volume_execution.go
+++ b/internal/controlservice/dependency_volume_execution.go
@@ -11,16 +11,25 @@ import (
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
 	"github.com/buildkite/cleanroom/internal/observability"
 	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/buildkite/cleanroom/internal/repositorychangeset"
 	"github.com/buildkite/cleanroom/internal/repositorycheckout"
 	"go.opentelemetry.io/otel/attribute"
 )
 
 const dependencyInputProjectionRoot = "/run/cleanroom/input-projections/dependencies"
 
+type dependencyBlockVolumePublishConfig struct {
+	Adapter    backend.CacheOutputVolumeSnapshottingAdapter
+	Backend    string
+	Changeset  *repositorychangeset.Changeset
+	Repository *repositorycheckout.Checkout
+}
+
 func (s *Service) bootstrapDependencyBlockVolumePlanInPersistentSandbox(
 	ctx context.Context,
 	adapter backend.Adapter,
 	sandboxID string,
+	publish dependencyBlockVolumePublishConfig,
 	compiled *policy.CompiledPolicy,
 	firecrackerCfg backend.FirecrackerConfig,
 	repository *repositorycheckout.Checkout,
@@ -53,6 +62,13 @@ func (s *Service) bootstrapDependencyBlockVolumePlanInPersistentSandbox(
 			return s.bootstrapDependencyBlockVolumeBlock(ctx, adapter, sandboxID, compiled, firecrackerCfg, repository, block, reporter)
 		}); err != nil {
 			return fmt.Errorf("dependency block %q: %w", blockName, err)
+		}
+		if publish.Adapter != nil {
+			emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_PUBLISH_DEPENDENCY_STAGE_CACHE, "publishing dependency outputs: "+blockName)
+			s.maybePublishDependencyBlockVolumeCaches(ctx, publish.Adapter, sandboxID, publish.Backend, compiled, firecrackerCfg, publish.Repository, publish.Changeset, dependencyBlockVolumePlan{
+				ReuseNamespace: plan.ReuseNamespace,
+				Blocks:         []dependencyBlockVolumeBlockPlan{block},
+			})
 		}
 	}
 	return nil

--- a/internal/controlservice/dependency_volume_plan_test.go
+++ b/internal/controlservice/dependency_volume_plan_test.go
@@ -400,6 +400,168 @@ func TestCreateSandboxLooksUpDependencyBlockVolumeCaches(t *testing.T) {
 	}
 }
 
+func TestCreateSandboxPublishesDependencyBlockVolumeCachesForMisses(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	adapter := dependencyBlockVolumeRuntimeAdapter()
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"mise.toml": "go = \"1.26.2\"\n",
+		"go.mod":    "module example.com/test\n\ngo 1.26.2\n",
+		"go.sum":    "example.com/test v0.0.0 h1:abc123\n",
+	})
+	svc := newTestService(adapter)
+	svc.RepositoryStore = mirrors
+
+	compiled, err := policy.FromProto(testRepositoryTwoDependencyBlocksPolicy())
+	if err != nil {
+		t.Fatalf("FromProto returned error: %v", err)
+	}
+	repository := repositorycheckout.FromProto(repositoryCheckout)
+	plan, ok, err := svc.finalizeDependencyBlockVolumePlan(context.Background(), compiled, repository, nil, nil, "firecracker", "runtime-base:test")
+	if err != nil {
+		t.Fatalf("finalizeDependencyBlockVolumePlan returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected dependency block-volume plan")
+	}
+	blockByVolumeID := make(map[string]dependencyBlockVolumeBlockPlan, len(plan.Blocks))
+	wantVolumeIDs := make([]string, 0, len(plan.Blocks))
+	for _, block := range plan.Blocks {
+		volumeID := blockVolumeID(dependencyVolumeStageName, block.CacheKey)
+		blockByVolumeID[volumeID] = block
+		wantVolumeIDs = append(wantVolumeIDs, volumeID)
+	}
+	gotSnapshotVolumeIDs := make([]string, 0, len(plan.Blocks))
+
+	adapter.snapshotCacheOutputsFn = func(_ context.Context, req backend.SnapshotCacheOutputVolumesRequest) (*backend.SnapshotCacheOutputVolumesResult, error) {
+		if got, want := req.SandboxID, adapter.provisionReq.SandboxID; got != want {
+			t.Fatalf("unexpected snapshot sandbox id: got %q want %q", got, want)
+		}
+		if strings.TrimSpace(req.SnapshotIDPrefix) == "" {
+			t.Fatal("expected snapshot id prefix")
+		}
+		if got, want := len(req.VolumeIDs), 1; got != want {
+			t.Fatalf("unexpected snapshot volume id count: got %d want %d (%v)", got, want, req.VolumeIDs)
+		}
+		volumeID := req.VolumeIDs[0]
+		gotSnapshotVolumeIDs = append(gotSnapshotVolumeIDs, volumeID)
+		block, ok := blockByVolumeID[volumeID]
+		if !ok {
+			t.Fatalf("unexpected snapshot volume id %q", volumeID)
+		}
+		return &backend.SnapshotCacheOutputVolumesResult{Volumes: []backend.CacheOutputVolumeSnapshot{
+			{
+				Stage:              dependencyVolumeStageName,
+				BlockName:          block.BlockName,
+				CacheKey:           block.CacheKey,
+				VolumeID:           volumeID,
+				SnapshotID:         req.SnapshotIDPrefix + "-" + block.BlockName,
+				StorageDriver:      "file",
+				StorageRef:         "/snapshots/" + block.BlockName + ".ext4",
+				SnapshotRef:        "snapshot:" + block.BlockName,
+				StorageSizeBytes:   100,
+				ExclusiveSizeBytes: 10,
+				DriverMetadata:     "metadata:" + block.BlockName,
+				Outputs: []backend.CacheOutputVolumeSnapshotOutput{
+					{
+						Kind:          "dir",
+						GuestPath:     block.Outputs.Dirs[0],
+						VolumeSubpath: "dir/0",
+					},
+				},
+			},
+		}}, nil
+	}
+
+	if _, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Policy:             testRepositoryTwoDependencyBlocksPolicy(),
+		RepositoryCheckout: repositoryCheckout,
+	}); err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	if got, want := adapter.snapshotCacheOutputsCalls, len(plan.Blocks); got != want {
+		t.Fatalf("unexpected cache output snapshot calls: got %d want %d", got, want)
+	}
+	if !slices.Equal(gotSnapshotVolumeIDs, wantVolumeIDs) {
+		t.Fatalf("unexpected snapshot volume ids: got %v want %v", gotSnapshotVolumeIDs, wantVolumeIDs)
+	}
+	if got, want := adapter.runCalls, 1+len(plan.Blocks); got != want {
+		t.Fatalf("expected repository plus dependency block miss executions, got %d want %d", got, want)
+	}
+
+	cacheStore, ok := svc.CacheStore.(*memoryCacheStore)
+	if !ok {
+		t.Fatalf("expected memory cache store, got %T", svc.CacheStore)
+	}
+	records, err := cacheStore.List(context.Background())
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	recordsByKey := make(map[string]cachestore.Record)
+	for _, record := range records {
+		if record.Stage == dependencyVolumeStageName {
+			recordsByKey[record.CacheKey] = record
+		}
+	}
+	if got, want := len(recordsByKey), len(plan.Blocks); got != want {
+		t.Fatalf("unexpected dependency block-volume record count: got %d want %d", got, want)
+	}
+	for _, block := range plan.Blocks {
+		record, ok := recordsByKey[block.CacheKey]
+		if !ok {
+			t.Fatalf("missing dependency block-volume record for %q", block.BlockName)
+		}
+		if got := record.BackingSnapshotID; strings.TrimSpace(got) == "" || !strings.HasSuffix(got, "-"+block.BlockName) {
+			t.Fatalf("expected generated backing snapshot id for %s, got %q", block.BlockName, got)
+		}
+		if got, want := record.Backend, "firecracker"; got != want {
+			t.Fatalf("unexpected backend: got %q want %q", got, want)
+		}
+		if got, want := record.PolicyHash, compiled.Hash; got != want {
+			t.Fatalf("unexpected policy hash: got %q want %q", got, want)
+		}
+		if got, want := record.InputManifestDigest, block.InputManifestDigest; got != want {
+			t.Fatalf("unexpected input digest for %s: got %q want %q", block.BlockName, got, want)
+		}
+		if got, want := record.CommandDigest, block.CommandDigest; got != want {
+			t.Fatalf("unexpected command digest for %s: got %q want %q", block.BlockName, got, want)
+		}
+		if got, want := record.EnvDigest, block.EnvDigest; got != want {
+			t.Fatalf("unexpected env digest for %s: got %q want %q", block.BlockName, got, want)
+		}
+		if got, want := record.NormalizedOutputsDigest, block.NormalizedOutputsDigest; got != want {
+			t.Fatalf("unexpected outputs digest for %s: got %q want %q", block.BlockName, got, want)
+		}
+		if got, want := record.ProducerVersion, block.ProducerVersion; got != want {
+			t.Fatalf("unexpected producer version for %s: got %q want %q", block.BlockName, got, want)
+		}
+		if got, want := record.StorageRef, "/snapshots/"+block.BlockName+".ext4"; got != want {
+			t.Fatalf("unexpected storage ref for %s: got %q want %q", block.BlockName, got, want)
+		}
+		if got, want := record.StorageDriver, "file"; got != want {
+			t.Fatalf("unexpected storage driver for %s: got %q want %q", block.BlockName, got, want)
+		}
+		if got, want := len(record.OutputRecords), 1; got != want {
+			t.Fatalf("unexpected output record count for %s: got %d want %d", block.BlockName, got, want)
+		}
+		output := record.OutputRecords[0]
+		if got, want := output.Kind, "dir"; got != want {
+			t.Fatalf("unexpected output kind for %s: got %q want %q", block.BlockName, got, want)
+		}
+		if got, want := output.Path, block.Outputs.Dirs[0]; got != want {
+			t.Fatalf("unexpected output path for %s: got %q want %q", block.BlockName, got, want)
+		}
+		if got, want := output.VolumeSubpath, "dir/0"; got != want {
+			t.Fatalf("unexpected output subpath for %s: got %q want %q", block.BlockName, got, want)
+		}
+		if got, want := output.StorageRef, record.StorageRef; got != want {
+			t.Fatalf("unexpected output storage ref for %s: got %q want %q", block.BlockName, got, want)
+		}
+		if got, want := output.SnapshotRef, "snapshot:"+block.BlockName; got != want {
+			t.Fatalf("unexpected output snapshot ref for %s: got %q want %q", block.BlockName, got, want)
+		}
+	}
+}
+
 func TestDependencyBlockVolumeRuntimeDecisionRequiresOutputVolumesAndOverlay(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -483,6 +645,7 @@ func TestBootstrapDependencyBlockVolumePlanRunsMissesFromInputProjection(t *test
 		context.Background(),
 		adapter,
 		"cr-test",
+		dependencyBlockVolumePublishConfig{},
 		compiled,
 		backend.FirecrackerConfig{},
 		repository,

--- a/internal/controlservice/dependency_volume_publish.go
+++ b/internal/controlservice/dependency_volume_publish.go
@@ -1,0 +1,238 @@
+package controlservice
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/cachestore"
+	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/buildkite/cleanroom/internal/repositorychangeset"
+	"github.com/buildkite/cleanroom/internal/repositorycheckout"
+)
+
+func (s *Service) maybePublishDependencyBlockVolumeCaches(
+	ctx context.Context,
+	adapter backend.CacheOutputVolumeSnapshottingAdapter,
+	sandboxID, backendName string,
+	compiled *policy.CompiledPolicy,
+	firecrackerCfg backend.FirecrackerConfig,
+	repository *repositorycheckout.Checkout,
+	changeset *repositorychangeset.Changeset,
+	plan dependencyBlockVolumePlan,
+) {
+	if adapter == nil || compiled == nil || repository == nil || strings.TrimSpace(sandboxID) == "" || len(plan.Blocks) == 0 {
+		return
+	}
+	store, err := s.cacheStoreOrErr()
+	if err != nil {
+		s.logDependencyStageWarning("publish dependency block-volume caches", sandboxID, err)
+		return
+	}
+
+	missed := missedDependencyBlockVolumeBlocks(plan)
+	if len(missed) == 0 {
+		return
+	}
+	volumeIDs := make([]string, 0, len(missed))
+	for _, block := range missed {
+		volumeIDs = append(volumeIDs, blockVolumeID(dependencyVolumeStageName, block.CacheKey))
+	}
+
+	snapshotCfg := withSnapshotDriver(backendName, firecrackerCfg, firecrackerCfg.Snapshots.Driver)
+	result, err := adapter.SnapshotCacheOutputVolumes(ctx, backend.SnapshotCacheOutputVolumesRequest{
+		SandboxID:         sandboxID,
+		SnapshotIDPrefix:  newSnapshotID(),
+		VolumeIDs:         volumeIDs,
+		FirecrackerConfig: snapshotCfg,
+	})
+	if err != nil {
+		s.logDependencyStageWarning("publish dependency block-volume caches", sandboxID, err)
+		return
+	}
+
+	snapshotsByVolumeID, err := dependencyBlockVolumeSnapshotsByVolumeID(volumeIDs, result)
+	if err != nil {
+		s.cleanupDependencyBlockVolumeSnapshots(adapter, backendName, firecrackerCfg, cacheOutputVolumeSnapshots(result))
+		s.logDependencyStageWarning("publish dependency block-volume caches", sandboxID, err)
+		return
+	}
+
+	now := s.clock().Now()
+	records := make([]cachestore.Record, 0, len(missed))
+	snapshots := make([]backend.CacheOutputVolumeSnapshot, 0, len(missed))
+	for _, block := range missed {
+		volumeID := blockVolumeID(dependencyVolumeStageName, block.CacheKey)
+		snapshot := snapshotsByVolumeID[volumeID]
+		snapshots = append(snapshots, snapshot)
+		record := dependencyBlockVolumeCacheRecordFromSnapshot(backendName, compiled, repository, changeset, block, snapshot, now)
+		if reason := blockVolumeOutputRecordMissReason(block.Outputs, record.OutputRecords); reason != "" {
+			s.cleanupDependencyBlockVolumeSnapshots(adapter, backendName, firecrackerCfg, snapshots)
+			s.logDependencyStageWarning("publish dependency block-volume caches", sandboxID, fmt.Errorf("snapshot output records for block %q do not match declared outputs: %s", block.BlockName, reason))
+			return
+		}
+		records = append(records, record)
+	}
+
+	for i, record := range records {
+		if err := store.Create(ctx, record); err != nil {
+			s.cleanupDependencyBlockVolumeSnapshots(adapter, backendName, firecrackerCfg, snapshots[i:])
+			s.logDependencyStageWarning("persist dependency block-volume cache metadata", sandboxID, err)
+			return
+		}
+		s.logDependencyBlockVolumePublished(record, sandboxID)
+	}
+}
+
+func missedDependencyBlockVolumeBlocks(plan dependencyBlockVolumePlan) []dependencyBlockVolumeBlockPlan {
+	missed := make([]dependencyBlockVolumeBlockPlan, 0, len(plan.Blocks))
+	for _, block := range plan.Blocks {
+		if !block.CacheHit {
+			missed = append(missed, block)
+		}
+	}
+	return missed
+}
+
+func dependencyBlockVolumeSnapshotsByVolumeID(volumeIDs []string, result *backend.SnapshotCacheOutputVolumesResult) (map[string]backend.CacheOutputVolumeSnapshot, error) {
+	expected := make(map[string]struct{}, len(volumeIDs))
+	for _, volumeID := range volumeIDs {
+		volumeID = strings.TrimSpace(volumeID)
+		if volumeID != "" {
+			expected[volumeID] = struct{}{}
+		}
+	}
+	snapshots := cacheOutputVolumeSnapshots(result)
+	if len(snapshots) != len(expected) {
+		return nil, fmt.Errorf("cache output snapshot returned %d volumes, expected %d", len(snapshots), len(expected))
+	}
+	byID := make(map[string]backend.CacheOutputVolumeSnapshot, len(snapshots))
+	for _, snapshot := range snapshots {
+		volumeID := strings.TrimSpace(snapshot.VolumeID)
+		if _, ok := expected[volumeID]; !ok {
+			return nil, fmt.Errorf("cache output snapshot returned unexpected volume id %q", snapshot.VolumeID)
+		}
+		if _, exists := byID[volumeID]; exists {
+			return nil, fmt.Errorf("cache output snapshot returned duplicate volume id %q", snapshot.VolumeID)
+		}
+		if strings.TrimSpace(snapshot.SnapshotID) == "" {
+			return nil, fmt.Errorf("cache output snapshot for volume %q is missing snapshot id", snapshot.VolumeID)
+		}
+		if strings.TrimSpace(snapshot.StorageDriver) == "" || strings.TrimSpace(snapshot.StorageRef) == "" {
+			return nil, fmt.Errorf("cache output snapshot for volume %q is missing storage metadata", snapshot.VolumeID)
+		}
+		byID[volumeID] = snapshot
+	}
+	return byID, nil
+}
+
+func cacheOutputVolumeSnapshots(result *backend.SnapshotCacheOutputVolumesResult) []backend.CacheOutputVolumeSnapshot {
+	if result == nil || len(result.Volumes) == 0 {
+		return nil
+	}
+	return append([]backend.CacheOutputVolumeSnapshot(nil), result.Volumes...)
+}
+
+func dependencyBlockVolumeCacheRecordFromSnapshot(
+	backendName string,
+	compiled *policy.CompiledPolicy,
+	repository *repositorycheckout.Checkout,
+	changeset *repositorychangeset.Changeset,
+	block dependencyBlockVolumeBlockPlan,
+	snapshot backend.CacheOutputVolumeSnapshot,
+	now time.Time,
+) cachestore.Record {
+	record := cachestore.Record{
+		CacheKey:                strings.TrimSpace(block.CacheKey),
+		Stage:                   dependencyVolumeStageName,
+		State:                   cacheStateReady,
+		BackingSnapshotID:       strings.TrimSpace(snapshot.SnapshotID),
+		Backend:                 strings.TrimSpace(backendName),
+		Architecture:            runtime.GOARCH,
+		PolicyHash:              compiled.Hash,
+		Policy:                  compiled.ToProto(),
+		Repository:              cloneRepositoryCheckout(normalizeRepositoryCheckoutForComparison(repository)).ToProto(),
+		RepositoryHasChangeset:  changeset != nil,
+		RepositoryChangesetID:   repositoryChangesetID(repository, changeset),
+		StorageDriver:           strings.TrimSpace(snapshot.StorageDriver),
+		StorageRef:              strings.TrimSpace(snapshot.StorageRef),
+		StorageSizeBytes:        snapshot.StorageSizeBytes,
+		ExclusiveSizeBytes:      snapshot.ExclusiveSizeBytes,
+		DriverMetadata:          strings.TrimSpace(snapshot.DriverMetadata),
+		InputManifestDigest:     strings.TrimSpace(block.InputManifestDigest),
+		CommandDigest:           strings.TrimSpace(block.CommandDigest),
+		EnvDigest:               strings.TrimSpace(block.EnvDigest),
+		NormalizedOutputsDigest: strings.TrimSpace(block.NormalizedOutputsDigest),
+		OutputRecords:           dependencyBlockVolumeOutputRecordsFromSnapshot(snapshot),
+		CreatedAt:               now,
+		LastUsedAt:              now,
+		LastValidatedAt:         now.UTC(),
+		ProducerVersion:         strings.TrimSpace(block.ProducerVersion),
+	}
+	return record
+}
+
+func dependencyBlockVolumeOutputRecordsFromSnapshot(snapshot backend.CacheOutputVolumeSnapshot) []cachestore.OutputRecord {
+	if len(snapshot.Outputs) == 0 {
+		return nil
+	}
+	records := make([]cachestore.OutputRecord, 0, len(snapshot.Outputs))
+	for _, output := range snapshot.Outputs {
+		records = append(records, cachestore.OutputRecord{
+			Kind:          strings.TrimSpace(output.Kind),
+			Path:          strings.TrimSpace(output.GuestPath),
+			VolumeSubpath: strings.TrimSpace(output.VolumeSubpath),
+			StorageDriver: strings.TrimSpace(snapshot.StorageDriver),
+			StorageRef:    strings.TrimSpace(snapshot.StorageRef),
+			SnapshotRef:   strings.TrimSpace(snapshot.SnapshotRef),
+		})
+	}
+	return records
+}
+
+func (s *Service) cleanupDependencyBlockVolumeSnapshots(adapter backend.CacheOutputVolumeSnapshottingAdapter, backendName string, firecrackerCfg backend.FirecrackerConfig, snapshots []backend.CacheOutputVolumeSnapshot) {
+	if len(snapshots) == 0 {
+		return
+	}
+	deleteAdapter, ok := adapter.(backend.SnapshottingAdapter)
+	if !ok {
+		s.logDependencyStageWarning("rollback dependency block-volume cache snapshots", "", fmt.Errorf("backend %q cannot delete snapshots", backendName))
+		return
+	}
+	for i := len(snapshots) - 1; i >= 0; i-- {
+		snapshot := snapshots[i]
+		storageRef := strings.TrimSpace(snapshot.StorageRef)
+		if storageRef == "" {
+			continue
+		}
+		deleteCfg := withSnapshotDriver(backendName, firecrackerCfg, snapshot.StorageDriver)
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		err := deleteAdapter.DeleteSnapshot(cleanupCtx, backend.DeleteSnapshotRequest{
+			SnapshotID:        strings.TrimSpace(snapshot.SnapshotID),
+			StorageRef:        storageRef,
+			FirecrackerConfig: deleteCfg,
+		})
+		cancel()
+		if err != nil {
+			s.logDependencyStageWarning("rollback dependency block-volume cache snapshot", "", err)
+		}
+	}
+}
+
+func (s *Service) logDependencyBlockVolumePublished(record cachestore.Record, sandboxID string) {
+	if s == nil || s.Logger == nil {
+		return
+	}
+	s.Logger.Debug("dependency block-volume cache published",
+		"stage", strings.TrimSpace(record.Stage),
+		"cache_key", strings.TrimSpace(record.CacheKey),
+		"producer_version", strings.TrimSpace(record.ProducerVersion),
+		"storage_driver", strings.TrimSpace(record.StorageDriver),
+		"storage_ref", strings.TrimSpace(record.StorageRef),
+		"output_records", len(record.OutputRecords),
+		"sandbox_id", strings.TrimSpace(sandboxID),
+	)
+}

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -418,6 +418,7 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 	var restoredWorkspaceResp *cleanroomv1.CreateSandboxResponse
 	var restoredDependencyResp *cleanroomv1.CreateSandboxResponse
 	snapshotAdapter, snapshotCapable := adapter.(backend.SnapshottingAdapter)
+	cacheOutputSnapshotAdapter, _ := adapter.(backend.CacheOutputVolumeSnapshottingAdapter)
 	if repository != nil {
 		dependencyStagePlan, dependencyStageBootstrapEnabled = dependencyStagePlanForRepository(compiled, repository)
 		servicesStagePlan, servicesStageBootstrapEnabled = servicesStagePlanForRepository(compiled, repository)
@@ -910,7 +911,12 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 			emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_DEPENDENCIES, "running dependency bootstrap")
 			if err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.bootstrap_dependencies", bootstrapAttrs, func(ctx context.Context) error {
 				if dependencyBlockVolumePlanAvailable {
-					return s.bootstrapDependencyBlockVolumePlanInPersistentSandbox(ctx, adapter, sandboxID, compiled, firecrackerCfg, repository, dependencyBlockVolumePlan, reporter)
+					return s.bootstrapDependencyBlockVolumePlanInPersistentSandbox(ctx, adapter, sandboxID, dependencyBlockVolumePublishConfig{
+						Adapter:    cacheOutputSnapshotAdapter,
+						Backend:    backendName,
+						Changeset:  changeset,
+						Repository: repository,
+					}, compiled, firecrackerCfg, repository, dependencyBlockVolumePlan, reporter)
 				}
 				return s.bootstrapDependencyStageInPersistentSandbox(ctx, adapter, sandboxID, compiled, firecrackerCfg, dependencyStagePlan, reporter)
 			}); err != nil {
@@ -1090,7 +1096,12 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 		emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_DEPENDENCIES, "running dependency bootstrap")
 		if err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.bootstrap_dependencies", bootstrapAttrs, func(ctx context.Context) error {
 			if dependencyBlockVolumePlanAvailable {
-				return s.bootstrapDependencyBlockVolumePlanInPersistentSandbox(ctx, adapter, sandboxID, compiled, firecrackerCfg, repository, dependencyBlockVolumePlan, reporter)
+				return s.bootstrapDependencyBlockVolumePlanInPersistentSandbox(ctx, adapter, sandboxID, dependencyBlockVolumePublishConfig{
+					Adapter:    cacheOutputSnapshotAdapter,
+					Backend:    backendName,
+					Changeset:  changeset,
+					Repository: repository,
+				}, compiled, firecrackerCfg, repository, dependencyBlockVolumePlan, reporter)
 			}
 			return s.bootstrapDependencyStageInPersistentSandbox(ctx, adapter, sandboxID, compiled, firecrackerCfg, dependencyStagePlan, reporter)
 		}); err != nil {

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -49,6 +49,7 @@ type stubAdapter struct {
 	provisionFn                func(context.Context, backend.ProvisionRequest) error
 	provisionFromSnapshotFn    func(context.Context, backend.ProvisionFromSnapshotRequest) error
 	createSnapshotFn           func(context.Context, backend.SnapshotRequest) (*backend.SnapshotResult, error)
+	snapshotCacheOutputsFn     func(context.Context, backend.SnapshotCacheOutputVolumesRequest) (*backend.SnapshotCacheOutputVolumesResult, error)
 	deleteSnapshotFn           func(context.Context, backend.DeleteSnapshotRequest) error
 	terminateFn                func(context.Context, string) error
 	downloadFn                 func(context.Context, string, string, int64) ([]byte, error)
@@ -64,11 +65,13 @@ type stubAdapter struct {
 	provisionReq               backend.ProvisionRequest
 	provisionFromSnapshotReq   backend.ProvisionFromSnapshotRequest
 	createSnapshotReq          backend.SnapshotRequest
+	snapshotCacheOutputsReq    backend.SnapshotCacheOutputVolumesRequest
 	deleteSnapshotReq          backend.DeleteSnapshotRequest
 	runCalls                   int
 	provisionCalls             int
 	provisionFromSnapshotCalls int
 	createSnapshotCalls        int
+	snapshotCacheOutputsCalls  int
 	deleteSnapshotCalls        int
 	terminateCalls             int
 	runtimeBaseKeyOverride     string
@@ -141,6 +144,15 @@ func (s *stubAdapter) CreateSnapshot(ctx context.Context, req backend.SnapshotRe
 		return s.createSnapshotFn(ctx, req)
 	}
 	return &backend.SnapshotResult{StorageRef: "/tmp/snapshot.ext4"}, nil
+}
+
+func (s *stubAdapter) SnapshotCacheOutputVolumes(ctx context.Context, req backend.SnapshotCacheOutputVolumesRequest) (*backend.SnapshotCacheOutputVolumesResult, error) {
+	s.snapshotCacheOutputsReq = req
+	s.snapshotCacheOutputsCalls++
+	if s.snapshotCacheOutputsFn != nil {
+		return s.snapshotCacheOutputsFn(ctx, req)
+	}
+	return &backend.SnapshotCacheOutputVolumesResult{}, nil
 }
 
 func (s *stubAdapter) ProvisionSandboxFromSnapshot(ctx context.Context, req backend.ProvisionFromSnapshotRequest) error {


### PR DESCRIPTION
## Why

This is the dependency publication slice of `docs/plans/dependency-service-volume-caches.md`. The previous slices taught the persistent sandbox to run dependency blocks from cache-output volumes and added backend support for snapshotting those volumes after a block writes them.

Without this slice, dependency block-volume misses can run correctly, but there is still no durable cache record for a later sandbox to reuse. Every run pays the miss cost again.

## What changed

- Snapshot each missed dependency block output volume immediately after that block succeeds, before later dependency blocks can mutate any earlier output volume.
- Persist `dependency-volume` cache records with the block's cache key, input/command/env/output digests, producer version, backend storage metadata, and output-volume records.
- Keep publication non-fatal like the existing stage-cache publishers, but clean up newly created snapshots when validation or metadata persistence fails.
- Return backend-generated cache-output snapshot IDs so the cache record can reference the backing snapshot directly.

Service block publication is intentionally left for a follow-up slice; this PR only makes dependency block-volume misses publishable.

## Validation

- `GOCACHE=/private/tmp/cleanroom-go-build-cache mise exec -- go test ./internal/controlservice ./internal/backend/firecracker ./internal/backend/darwinvz ./internal/backend`
- `GOCACHE=/private/tmp/cleanroom-go-build-cache mise exec -- go test ./...`
- `docker run --rm -v "$PWD":/work -v /Users/lachlan/Develop/cleanroom/.git:/Users/lachlan/Develop/cleanroom/.git:ro -w /work -e GOCACHE=/tmp/go-build-cache golang:1.26.2 go test ./...`
