### PR TITLE
feat: Publish service volume cache records

### DIFF
--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -876,7 +876,12 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 			emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_SERVICES, "running services bootstrap")
 			if err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.bootstrap_services", bootstrapAttrs, func(ctx context.Context) error {
 				if serviceBlockVolumePlanAvailable {
-					return s.bootstrapServiceBlockVolumePlanInPersistentSandbox(ctx, adapter, sandboxID, compiled, firecrackerCfg, repository, serviceBlockVolumePlan, reporter)
+					return s.bootstrapServiceBlockVolumePlanInPersistentSandbox(ctx, adapter, sandboxID, serviceBlockVolumePublishConfig{
+						Adapter:    cacheOutputSnapshotAdapter,
+						Backend:    backendName,
+						Changeset:  changeset,
+						Repository: repository,
+					}, compiled, firecrackerCfg, repository, serviceBlockVolumePlan, reporter)
 				}
 				return s.bootstrapServicesStageInPersistentSandbox(ctx, adapter, sandboxID, compiled, firecrackerCfg, servicesStagePlan, reporter)
 			}); err != nil {
@@ -945,7 +950,12 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 			emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_SERVICES, "running services bootstrap")
 			if err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.bootstrap_services", bootstrapAttrs, func(ctx context.Context) error {
 				if serviceBlockVolumePlanAvailable {
-					return s.bootstrapServiceBlockVolumePlanInPersistentSandbox(ctx, adapter, sandboxID, compiled, firecrackerCfg, repository, serviceBlockVolumePlan, reporter)
+					return s.bootstrapServiceBlockVolumePlanInPersistentSandbox(ctx, adapter, sandboxID, serviceBlockVolumePublishConfig{
+						Adapter:    cacheOutputSnapshotAdapter,
+						Backend:    backendName,
+						Changeset:  changeset,
+						Repository: repository,
+					}, compiled, firecrackerCfg, repository, serviceBlockVolumePlan, reporter)
 				}
 				return s.bootstrapServicesStageInPersistentSandbox(ctx, adapter, sandboxID, compiled, firecrackerCfg, servicesStagePlan, reporter)
 			}); err != nil {
@@ -1141,7 +1151,12 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 		emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_SERVICES, "running services bootstrap")
 		if err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.bootstrap_services", bootstrapAttrs, func(ctx context.Context) error {
 			if serviceBlockVolumePlanAvailable {
-				return s.bootstrapServiceBlockVolumePlanInPersistentSandbox(ctx, adapter, sandboxID, compiled, firecrackerCfg, repository, serviceBlockVolumePlan, reporter)
+				return s.bootstrapServiceBlockVolumePlanInPersistentSandbox(ctx, adapter, sandboxID, serviceBlockVolumePublishConfig{
+					Adapter:    cacheOutputSnapshotAdapter,
+					Backend:    backendName,
+					Changeset:  changeset,
+					Repository: repository,
+				}, compiled, firecrackerCfg, repository, serviceBlockVolumePlan, reporter)
 			}
 			return s.bootstrapServicesStageInPersistentSandbox(ctx, adapter, sandboxID, compiled, firecrackerCfg, servicesStagePlan, reporter)
 		}); err != nil {

--- a/internal/controlservice/service_volume_execution.go
+++ b/internal/controlservice/service_volume_execution.go
@@ -10,16 +10,25 @@ import (
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
 	"github.com/buildkite/cleanroom/internal/observability"
 	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/buildkite/cleanroom/internal/repositorychangeset"
 	"github.com/buildkite/cleanroom/internal/repositorycheckout"
 	"go.opentelemetry.io/otel/attribute"
 )
 
 const serviceInputProjectionRoot = "/run/cleanroom/input-projections/services"
 
+type serviceBlockVolumePublishConfig struct {
+	Adapter    backend.CacheOutputVolumeSnapshottingAdapter
+	Backend    string
+	Changeset  *repositorychangeset.Changeset
+	Repository *repositorycheckout.Checkout
+}
+
 func (s *Service) bootstrapServiceBlockVolumePlanInPersistentSandbox(
 	ctx context.Context,
 	adapter backend.Adapter,
 	sandboxID string,
+	publish serviceBlockVolumePublishConfig,
 	compiled *policy.CompiledPolicy,
 	firecrackerCfg backend.FirecrackerConfig,
 	repository *repositorycheckout.Checkout,
@@ -52,6 +61,14 @@ func (s *Service) bootstrapServiceBlockVolumePlanInPersistentSandbox(
 			return s.bootstrapServiceBlockVolumeBlock(ctx, adapter, sandboxID, compiled, firecrackerCfg, repository, block, reporter)
 		}); err != nil {
 			return fmt.Errorf("service block %q: %w", blockName, err)
+		}
+		if publish.Adapter != nil {
+			emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_PUBLISH_SERVICES_STAGE_CACHE, "publishing service outputs: "+blockName)
+			s.maybePublishServiceBlockVolumeCaches(ctx, publish.Adapter, sandboxID, publish.Backend, compiled, firecrackerCfg, publish.Repository, publish.Changeset, serviceBlockVolumePlan{
+				ReuseNamespace:       plan.ReuseNamespace,
+				DependencyOutputKeys: append([]string(nil), plan.DependencyOutputKeys...),
+				Blocks:               []serviceBlockVolumeBlockPlan{block},
+			})
 		}
 	}
 	return nil

--- a/internal/controlservice/service_volume_plan_test.go
+++ b/internal/controlservice/service_volume_plan_test.go
@@ -2,6 +2,7 @@ package controlservice
 
 import (
 	"context"
+	"slices"
 	"strings"
 	"testing"
 
@@ -384,6 +385,183 @@ func TestCreateSandboxLooksUpServiceBlockVolumeCaches(t *testing.T) {
 	}
 }
 
+func TestCreateSandboxPublishesServiceBlockVolumeCachesForMisses(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	adapter := dependencyBlockVolumeRuntimeAdapter()
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"mise.toml":           "go = \"1.26.2\"\n",
+		"go.mod":              "module example.com/test\n\ngo 1.26.2\n",
+		"go.sum":              "example.com/test v0.0.0 h1:abc123\n",
+		"docker-compose.yml":  "services:\n  postgres:\n    image: postgres:17\n",
+		"db/schema.sql":       "create table widgets (id serial primary key);\n",
+		"db/seed.sql":         "insert into widgets default values;\n",
+		"scripts/prepare-db":  "#!/bin/sh\ntrue\n",
+		"scripts/prepare-app": "#!/bin/sh\ntrue\n",
+	})
+	svc := newTestService(adapter)
+	svc.RepositoryStore = mirrors
+	cacheStore := newMemoryCacheStore()
+	svc.CacheStore = cacheStore
+
+	compiled, err := policy.FromProto(testRepositoryTwoDependencyTwoServiceBlocksPolicy())
+	if err != nil {
+		t.Fatalf("FromProto returned error: %v", err)
+	}
+	repository := repositorycheckout.FromProto(repositoryCheckout)
+	dependencyPlan, ok, err := svc.finalizeDependencyBlockVolumePlan(context.Background(), compiled, repository, nil, nil, "firecracker", "runtime-base:test")
+	if err != nil {
+		t.Fatalf("finalizeDependencyBlockVolumePlan returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected dependency block-volume plan")
+	}
+	for _, block := range dependencyPlan.Blocks {
+		if err := cacheStore.Create(context.Background(), dependencyBlockVolumeTestRecord(compiled, block)); err != nil {
+			t.Fatalf("Create dependency block-volume record returned error: %v", err)
+		}
+	}
+	servicePlan, ok, err := svc.finalizeServiceBlockVolumePlan(context.Background(), compiled, repository, nil, nil, "firecracker", "runtime-base:test", dependencyPlan)
+	if err != nil {
+		t.Fatalf("finalizeServiceBlockVolumePlan returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected service block-volume plan")
+	}
+	blockByVolumeID := make(map[string]serviceBlockVolumeBlockPlan, len(servicePlan.Blocks))
+	wantVolumeIDs := make([]string, 0, len(servicePlan.Blocks))
+	for _, block := range servicePlan.Blocks {
+		volumeID := blockVolumeID(serviceVolumeStageName, block.CacheKey)
+		blockByVolumeID[volumeID] = block
+		wantVolumeIDs = append(wantVolumeIDs, volumeID)
+	}
+	gotSnapshotVolumeIDs := make([]string, 0, len(servicePlan.Blocks))
+
+	adapter.snapshotCacheOutputsFn = func(_ context.Context, req backend.SnapshotCacheOutputVolumesRequest) (*backend.SnapshotCacheOutputVolumesResult, error) {
+		if got, want := req.SandboxID, adapter.provisionReq.SandboxID; got != want {
+			t.Fatalf("unexpected snapshot sandbox id: got %q want %q", got, want)
+		}
+		if strings.TrimSpace(req.SnapshotIDPrefix) == "" {
+			t.Fatal("expected snapshot id prefix")
+		}
+		if got, want := len(req.VolumeIDs), 1; got != want {
+			t.Fatalf("unexpected snapshot volume id count: got %d want %d (%v)", got, want, req.VolumeIDs)
+		}
+		volumeID := req.VolumeIDs[0]
+		gotSnapshotVolumeIDs = append(gotSnapshotVolumeIDs, volumeID)
+		block, ok := blockByVolumeID[volumeID]
+		if !ok {
+			t.Fatalf("unexpected snapshot volume id %q", volumeID)
+		}
+		return &backend.SnapshotCacheOutputVolumesResult{Volumes: []backend.CacheOutputVolumeSnapshot{
+			{
+				Stage:              serviceVolumeStageName,
+				BlockName:          block.BlockName,
+				CacheKey:           block.CacheKey,
+				VolumeID:           volumeID,
+				SnapshotID:         req.SnapshotIDPrefix + "-" + block.BlockName,
+				StorageDriver:      "file",
+				StorageRef:         "/snapshots/" + block.BlockName + ".ext4",
+				SnapshotRef:        "snapshot:" + block.BlockName,
+				StorageSizeBytes:   100,
+				ExclusiveSizeBytes: 10,
+				DriverMetadata:     "metadata:" + block.BlockName,
+				Outputs: []backend.CacheOutputVolumeSnapshotOutput{
+					{
+						Kind:          "dir",
+						GuestPath:     block.Outputs.Dirs[0],
+						VolumeSubpath: "dirs/0",
+					},
+				},
+			},
+		}}, nil
+	}
+
+	if _, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Policy:             testRepositoryTwoDependencyTwoServiceBlocksPolicy(),
+		RepositoryCheckout: repositoryCheckout,
+	}); err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	if got, want := adapter.snapshotCacheOutputsCalls, len(servicePlan.Blocks); got != want {
+		t.Fatalf("unexpected cache output snapshot calls: got %d want %d", got, want)
+	}
+	if !slices.Equal(gotSnapshotVolumeIDs, wantVolumeIDs) {
+		t.Fatalf("unexpected snapshot volume ids: got %v want %v", gotSnapshotVolumeIDs, wantVolumeIDs)
+	}
+	if got, want := adapter.runCalls, 1+len(servicePlan.Blocks); got != want {
+		t.Fatalf("expected repository plus service block miss executions, got %d want %d", got, want)
+	}
+
+	records, err := cacheStore.List(context.Background())
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	recordsByKey := make(map[string]cachestore.Record)
+	for _, record := range records {
+		if record.Stage == serviceVolumeStageName {
+			recordsByKey[record.CacheKey] = record
+		}
+	}
+	if got, want := len(recordsByKey), len(servicePlan.Blocks); got != want {
+		t.Fatalf("unexpected service block-volume record count: got %d want %d", got, want)
+	}
+	for _, block := range servicePlan.Blocks {
+		record, ok := recordsByKey[block.CacheKey]
+		if !ok {
+			t.Fatalf("missing service block-volume record for %q", block.BlockName)
+		}
+		if got := record.BackingSnapshotID; strings.TrimSpace(got) == "" || !strings.HasSuffix(got, "-"+block.BlockName) {
+			t.Fatalf("expected generated backing snapshot id for %s, got %q", block.BlockName, got)
+		}
+		if got, want := record.Backend, "firecracker"; got != want {
+			t.Fatalf("unexpected backend: got %q want %q", got, want)
+		}
+		if got, want := record.PolicyHash, compiled.Hash; got != want {
+			t.Fatalf("unexpected policy hash: got %q want %q", got, want)
+		}
+		if got, want := record.InputManifestDigest, block.InputManifestDigest; got != want {
+			t.Fatalf("unexpected input digest for %s: got %q want %q", block.BlockName, got, want)
+		}
+		if got, want := record.CommandDigest, block.CommandDigest; got != want {
+			t.Fatalf("unexpected command digest for %s: got %q want %q", block.BlockName, got, want)
+		}
+		if got, want := record.EnvDigest, block.EnvDigest; got != want {
+			t.Fatalf("unexpected env digest for %s: got %q want %q", block.BlockName, got, want)
+		}
+		if got, want := record.NormalizedOutputsDigest, block.NormalizedOutputsDigest; got != want {
+			t.Fatalf("unexpected outputs digest for %s: got %q want %q", block.BlockName, got, want)
+		}
+		if got, want := record.ProducerVersion, block.ProducerVersion; got != want {
+			t.Fatalf("unexpected producer version for %s: got %q want %q", block.BlockName, got, want)
+		}
+		if got, want := record.StorageRef, "/snapshots/"+block.BlockName+".ext4"; got != want {
+			t.Fatalf("unexpected storage ref for %s: got %q want %q", block.BlockName, got, want)
+		}
+		if got, want := record.StorageDriver, "file"; got != want {
+			t.Fatalf("unexpected storage driver for %s: got %q want %q", block.BlockName, got, want)
+		}
+		if got, want := len(record.OutputRecords), 1; got != want {
+			t.Fatalf("unexpected output record count for %s: got %d want %d", block.BlockName, got, want)
+		}
+		output := record.OutputRecords[0]
+		if got, want := output.Kind, "dir"; got != want {
+			t.Fatalf("unexpected output kind for %s: got %q want %q", block.BlockName, got, want)
+		}
+		if got, want := output.Path, block.Outputs.Dirs[0]; got != want {
+			t.Fatalf("unexpected output path for %s: got %q want %q", block.BlockName, got, want)
+		}
+		if got, want := output.VolumeSubpath, "dirs/0"; got != want {
+			t.Fatalf("unexpected output subpath for %s: got %q want %q", block.BlockName, got, want)
+		}
+		if got, want := output.StorageRef, record.StorageRef; got != want {
+			t.Fatalf("unexpected output storage ref for %s: got %q want %q", block.BlockName, got, want)
+		}
+		if got, want := output.SnapshotRef, "snapshot:"+block.BlockName; got != want {
+			t.Fatalf("unexpected output snapshot ref for %s: got %q want %q", block.BlockName, got, want)
+		}
+	}
+}
+
 func TestCreateSandboxLooksUpServiceBlockVolumesAfterDependencyStageRestore(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	adapter := dependencyBlockVolumeRuntimeAdapter()
@@ -615,6 +793,7 @@ func TestBootstrapServiceBlockVolumePlanRunsMissesFromInputProjection(t *testing
 		context.Background(),
 		adapter,
 		"cr-test",
+		serviceBlockVolumePublishConfig{},
 		compiled,
 		backend.FirecrackerConfig{},
 		repository,

--- a/internal/controlservice/service_volume_publish.go
+++ b/internal/controlservice/service_volume_publish.go
@@ -1,0 +1,231 @@
+package controlservice
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/cachestore"
+	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/buildkite/cleanroom/internal/repositorychangeset"
+	"github.com/buildkite/cleanroom/internal/repositorycheckout"
+)
+
+func (s *Service) maybePublishServiceBlockVolumeCaches(
+	ctx context.Context,
+	adapter backend.CacheOutputVolumeSnapshottingAdapter,
+	sandboxID, backendName string,
+	compiled *policy.CompiledPolicy,
+	firecrackerCfg backend.FirecrackerConfig,
+	repository *repositorycheckout.Checkout,
+	changeset *repositorychangeset.Changeset,
+	plan serviceBlockVolumePlan,
+) {
+	if adapter == nil || compiled == nil || repository == nil || strings.TrimSpace(sandboxID) == "" || len(plan.Blocks) == 0 {
+		return
+	}
+	store, err := s.cacheStoreOrErr()
+	if err != nil {
+		s.logServicesStageWarning("publish service block-volume caches", sandboxID, err)
+		return
+	}
+
+	missed := missedServiceBlockVolumeBlocks(plan)
+	if len(missed) == 0 {
+		return
+	}
+	volumeIDs := make([]string, 0, len(missed))
+	for _, block := range missed {
+		volumeIDs = append(volumeIDs, blockVolumeID(serviceVolumeStageName, block.CacheKey))
+	}
+
+	snapshotCfg := withSnapshotDriver(backendName, firecrackerCfg, firecrackerCfg.Snapshots.Driver)
+	result, err := adapter.SnapshotCacheOutputVolumes(ctx, backend.SnapshotCacheOutputVolumesRequest{
+		SandboxID:         sandboxID,
+		SnapshotIDPrefix:  newSnapshotID(),
+		VolumeIDs:         volumeIDs,
+		FirecrackerConfig: snapshotCfg,
+	})
+	if err != nil {
+		s.logServicesStageWarning("publish service block-volume caches", sandboxID, err)
+		return
+	}
+
+	snapshotsByVolumeID, err := serviceBlockVolumeSnapshotsByVolumeID(volumeIDs, result)
+	if err != nil {
+		s.cleanupServiceBlockVolumeSnapshots(adapter, backendName, firecrackerCfg, cacheOutputVolumeSnapshots(result))
+		s.logServicesStageWarning("publish service block-volume caches", sandboxID, err)
+		return
+	}
+
+	now := s.clock().Now()
+	records := make([]cachestore.Record, 0, len(missed))
+	snapshots := make([]backend.CacheOutputVolumeSnapshot, 0, len(missed))
+	for _, block := range missed {
+		volumeID := blockVolumeID(serviceVolumeStageName, block.CacheKey)
+		snapshot := snapshotsByVolumeID[volumeID]
+		snapshots = append(snapshots, snapshot)
+		record := serviceBlockVolumeCacheRecordFromSnapshot(backendName, compiled, repository, changeset, block, snapshot, now)
+		if reason := blockVolumeOutputRecordMissReason(block.Outputs, record.OutputRecords); reason != "" {
+			s.cleanupServiceBlockVolumeSnapshots(adapter, backendName, firecrackerCfg, snapshots)
+			s.logServicesStageWarning("publish service block-volume caches", sandboxID, fmt.Errorf("snapshot output records for block %q do not match declared outputs: %s", block.BlockName, reason))
+			return
+		}
+		records = append(records, record)
+	}
+
+	for i, record := range records {
+		if err := store.Create(ctx, record); err != nil {
+			s.cleanupServiceBlockVolumeSnapshots(adapter, backendName, firecrackerCfg, snapshots[i:])
+			s.logServicesStageWarning("persist service block-volume cache metadata", sandboxID, err)
+			return
+		}
+		s.logServiceBlockVolumePublished(record, sandboxID)
+	}
+}
+
+func missedServiceBlockVolumeBlocks(plan serviceBlockVolumePlan) []serviceBlockVolumeBlockPlan {
+	missed := make([]serviceBlockVolumeBlockPlan, 0, len(plan.Blocks))
+	for _, block := range plan.Blocks {
+		if !block.CacheHit {
+			missed = append(missed, block)
+		}
+	}
+	return missed
+}
+
+func serviceBlockVolumeSnapshotsByVolumeID(volumeIDs []string, result *backend.SnapshotCacheOutputVolumesResult) (map[string]backend.CacheOutputVolumeSnapshot, error) {
+	expected := make(map[string]struct{}, len(volumeIDs))
+	for _, volumeID := range volumeIDs {
+		volumeID = strings.TrimSpace(volumeID)
+		if volumeID != "" {
+			expected[volumeID] = struct{}{}
+		}
+	}
+	snapshots := cacheOutputVolumeSnapshots(result)
+	if len(snapshots) != len(expected) {
+		return nil, fmt.Errorf("cache output snapshot returned %d volumes, expected %d", len(snapshots), len(expected))
+	}
+	byID := make(map[string]backend.CacheOutputVolumeSnapshot, len(snapshots))
+	for _, snapshot := range snapshots {
+		volumeID := strings.TrimSpace(snapshot.VolumeID)
+		if _, ok := expected[volumeID]; !ok {
+			return nil, fmt.Errorf("cache output snapshot returned unexpected volume id %q", snapshot.VolumeID)
+		}
+		if _, exists := byID[volumeID]; exists {
+			return nil, fmt.Errorf("cache output snapshot returned duplicate volume id %q", snapshot.VolumeID)
+		}
+		if strings.TrimSpace(snapshot.SnapshotID) == "" {
+			return nil, fmt.Errorf("cache output snapshot for volume %q is missing snapshot id", snapshot.VolumeID)
+		}
+		if strings.TrimSpace(snapshot.StorageDriver) == "" || strings.TrimSpace(snapshot.StorageRef) == "" {
+			return nil, fmt.Errorf("cache output snapshot for volume %q is missing storage metadata", snapshot.VolumeID)
+		}
+		byID[volumeID] = snapshot
+	}
+	return byID, nil
+}
+
+func serviceBlockVolumeCacheRecordFromSnapshot(
+	backendName string,
+	compiled *policy.CompiledPolicy,
+	repository *repositorycheckout.Checkout,
+	changeset *repositorychangeset.Changeset,
+	block serviceBlockVolumeBlockPlan,
+	snapshot backend.CacheOutputVolumeSnapshot,
+	now time.Time,
+) cachestore.Record {
+	record := cachestore.Record{
+		CacheKey:                strings.TrimSpace(block.CacheKey),
+		Stage:                   serviceVolumeStageName,
+		State:                   cacheStateReady,
+		BackingSnapshotID:       strings.TrimSpace(snapshot.SnapshotID),
+		Backend:                 strings.TrimSpace(backendName),
+		Architecture:            runtime.GOARCH,
+		PolicyHash:              compiled.Hash,
+		Policy:                  compiled.ToProto(),
+		Repository:              cloneRepositoryCheckout(normalizeRepositoryCheckoutForComparison(repository)).ToProto(),
+		RepositoryHasChangeset:  changeset != nil,
+		RepositoryChangesetID:   repositoryChangesetID(repository, changeset),
+		StorageDriver:           strings.TrimSpace(snapshot.StorageDriver),
+		StorageRef:              strings.TrimSpace(snapshot.StorageRef),
+		StorageSizeBytes:        snapshot.StorageSizeBytes,
+		ExclusiveSizeBytes:      snapshot.ExclusiveSizeBytes,
+		DriverMetadata:          strings.TrimSpace(snapshot.DriverMetadata),
+		InputManifestDigest:     strings.TrimSpace(block.InputManifestDigest),
+		CommandDigest:           strings.TrimSpace(block.CommandDigest),
+		EnvDigest:               strings.TrimSpace(block.EnvDigest),
+		NormalizedOutputsDigest: strings.TrimSpace(block.NormalizedOutputsDigest),
+		OutputRecords:           serviceBlockVolumeOutputRecordsFromSnapshot(snapshot),
+		CreatedAt:               now,
+		LastUsedAt:              now,
+		LastValidatedAt:         now.UTC(),
+		ProducerVersion:         strings.TrimSpace(block.ProducerVersion),
+	}
+	return record
+}
+
+func serviceBlockVolumeOutputRecordsFromSnapshot(snapshot backend.CacheOutputVolumeSnapshot) []cachestore.OutputRecord {
+	if len(snapshot.Outputs) == 0 {
+		return nil
+	}
+	records := make([]cachestore.OutputRecord, 0, len(snapshot.Outputs))
+	for _, output := range snapshot.Outputs {
+		records = append(records, cachestore.OutputRecord{
+			Kind:          strings.TrimSpace(output.Kind),
+			Path:          strings.TrimSpace(output.GuestPath),
+			VolumeSubpath: strings.TrimSpace(output.VolumeSubpath),
+			StorageDriver: strings.TrimSpace(snapshot.StorageDriver),
+			StorageRef:    strings.TrimSpace(snapshot.StorageRef),
+			SnapshotRef:   strings.TrimSpace(snapshot.SnapshotRef),
+		})
+	}
+	return records
+}
+
+func (s *Service) cleanupServiceBlockVolumeSnapshots(adapter backend.CacheOutputVolumeSnapshottingAdapter, backendName string, firecrackerCfg backend.FirecrackerConfig, snapshots []backend.CacheOutputVolumeSnapshot) {
+	if len(snapshots) == 0 {
+		return
+	}
+	deleteAdapter, ok := adapter.(backend.SnapshottingAdapter)
+	if !ok {
+		s.logServicesStageWarning("rollback service block-volume cache snapshots", "", fmt.Errorf("backend %q cannot delete snapshots", backendName))
+		return
+	}
+	for i := len(snapshots) - 1; i >= 0; i-- {
+		snapshot := snapshots[i]
+		storageRef := strings.TrimSpace(snapshot.StorageRef)
+		if storageRef == "" {
+			continue
+		}
+		deleteCfg := withSnapshotDriver(backendName, firecrackerCfg, snapshot.StorageDriver)
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		err := deleteAdapter.DeleteSnapshot(cleanupCtx, backend.DeleteSnapshotRequest{
+			SnapshotID:        strings.TrimSpace(snapshot.SnapshotID),
+			StorageRef:        storageRef,
+			FirecrackerConfig: deleteCfg,
+		})
+		cancel()
+		if err != nil {
+			s.logServicesStageWarning("rollback service block-volume cache snapshot", "", err)
+		}
+	}
+}
+
+func (s *Service) logServiceBlockVolumePublished(record cachestore.Record, sandboxID string) {
+	if s == nil || s.Logger == nil {
+		return
+	}
+	s.Logger.Debug("service block-volume cache published",
+		"stage", strings.TrimSpace(record.Stage),
+		"cache_key", strings.TrimSpace(record.CacheKey),
+		"producer_version", strings.TrimSpace(record.ProducerVersion),
+		"storage_driver", strings.TrimSpace(record.StorageDriver),
+		"storage_ref", strings.TrimSpace(record.StorageRef),
+		"output_records", len(record.OutputRecords),
+		"sandbox_id", strings.TrimSpace(sandboxID),
+	)
+}


### PR DESCRIPTION
## Why

This is the service publication slice of `docs/plans/dependency-service-volume-caches.md`. Dependency block-volume misses can now snapshot and publish their output-volume cache records; service blocks need the same durable publication path so later sandboxes can reuse service preparation without rerunning the command.

Without this slice, service block-volume lookup and projected execution can run, but a service miss never becomes a reusable `service-volume` cache record.

## What changed

- Snapshot each missed service block output volume immediately after that block succeeds.
- Persist `service-volume` cache records with the service block cache key, input/command/env/output digests, producer version, backend storage metadata, and output-volume records.
- Keep publication non-fatal like the existing stage-cache publishers, while cleaning up newly created snapshots if validation or metadata persistence fails.
- Wire the publish hook through all create-sandbox paths that run service block-volume misses.

This PR intentionally does not add escaped-write gating or file-output extraction. Those remain follow-up runtime slices from the plan.

## Validation

- `GOCACHE=/private/tmp/cleanroom-go-build-cache mise exec -- go test ./internal/controlservice`
- `GOCACHE=/private/tmp/cleanroom-go-build-cache mise exec -- go test ./...`
- `docker run --rm -v "$PWD":/work -v /Users/lachlan/Develop/cleanroom/.git:/Users/lachlan/Develop/cleanroom/.git:ro -w /work -e GOCACHE=/tmp/go-build-cache golang:1.26.2 go test ./...`
