### PR TITLE
fix: Gate file-output volume cache publication

### DIFF
--- a/internal/controlservice/dependency_volume_plan_test.go
+++ b/internal/controlservice/dependency_volume_plan_test.go
@@ -562,6 +562,52 @@ func TestCreateSandboxPublishesDependencyBlockVolumeCachesForMisses(t *testing.T
 	}
 }
 
+func TestCreateSandboxSkipsDependencyBlockVolumePublicationForFileOutputs(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	adapter := dependencyBlockVolumeRuntimeAdapter()
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"mise.toml": "go = \"1.26.2\"\n",
+		"tool.lock": "tool v1\n",
+	})
+	svc := newTestService(adapter)
+	svc.RepositoryStore = mirrors
+	cacheStore := newMemoryCacheStore()
+	svc.CacheStore = cacheStore
+
+	policyProto := testRepositoryPolicy()
+	policyProto.Dependencies = &cleanroomv1.PolicyDependencies{
+		Blocks: []*cleanroomv1.PolicyBlock{
+			{
+				Name:    "tool-index",
+				Command: []string{"sh", "-lc", "mkdir -p /root/.cache/tool && touch /root/.cache/tool/index.json"},
+				Inputs:  &cleanroomv1.PolicyBlockInputs{Files: []string{"mise.toml", "tool.lock"}},
+				Outputs: &cleanroomv1.PolicyBlockOutputs{
+					Files: []string{"/root/.cache/tool/index.json"},
+				},
+			},
+		},
+	}
+
+	if _, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Policy:             policyProto,
+		RepositoryCheckout: repositoryCheckout,
+	}); err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	if got := adapter.snapshotCacheOutputsCalls; got != 0 {
+		t.Fatalf("did not expect cache output snapshots for file-output dependency block, got %d", got)
+	}
+	records, err := cacheStore.List(context.Background())
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	for _, record := range records {
+		if record.Stage == dependencyVolumeStageName {
+			t.Fatalf("did not expect dependency block-volume record for file-output block: %#v", record)
+		}
+	}
+}
+
 func TestDependencyBlockVolumeRuntimeDecisionRequiresOutputVolumesAndOverlay(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/controlservice/dependency_volume_publish.go
+++ b/internal/controlservice/dependency_volume_publish.go
@@ -37,8 +37,12 @@ func (s *Service) maybePublishDependencyBlockVolumeCaches(
 	if len(missed) == 0 {
 		return
 	}
-	volumeIDs := make([]string, 0, len(missed))
-	for _, block := range missed {
+	publishable := publishableDependencyBlockVolumeBlocks(missed)
+	if len(publishable) == 0 {
+		return
+	}
+	volumeIDs := make([]string, 0, len(publishable))
+	for _, block := range publishable {
 		volumeIDs = append(volumeIDs, blockVolumeID(dependencyVolumeStageName, block.CacheKey))
 	}
 
@@ -62,9 +66,9 @@ func (s *Service) maybePublishDependencyBlockVolumeCaches(
 	}
 
 	now := s.clock().Now()
-	records := make([]cachestore.Record, 0, len(missed))
-	snapshots := make([]backend.CacheOutputVolumeSnapshot, 0, len(missed))
-	for _, block := range missed {
+	records := make([]cachestore.Record, 0, len(publishable))
+	snapshots := make([]backend.CacheOutputVolumeSnapshot, 0, len(publishable))
+	for _, block := range publishable {
 		volumeID := blockVolumeID(dependencyVolumeStageName, block.CacheKey)
 		snapshot := snapshotsByVolumeID[volumeID]
 		snapshots = append(snapshots, snapshot)
@@ -95,6 +99,17 @@ func missedDependencyBlockVolumeBlocks(plan dependencyBlockVolumePlan) []depende
 		}
 	}
 	return missed
+}
+
+func publishableDependencyBlockVolumeBlocks(blocks []dependencyBlockVolumeBlockPlan) []dependencyBlockVolumeBlockPlan {
+	publishable := make([]dependencyBlockVolumeBlockPlan, 0, len(blocks))
+	for _, block := range blocks {
+		if len(block.Outputs.Files) > 0 {
+			continue
+		}
+		publishable = append(publishable, block)
+	}
+	return publishable
 }
 
 func dependencyBlockVolumeSnapshotsByVolumeID(volumeIDs []string, result *backend.SnapshotCacheOutputVolumesResult) (map[string]backend.CacheOutputVolumeSnapshot, error) {

--- a/internal/controlservice/service_volume_plan_test.go
+++ b/internal/controlservice/service_volume_plan_test.go
@@ -562,6 +562,77 @@ func TestCreateSandboxPublishesServiceBlockVolumeCachesForMisses(t *testing.T) {
 	}
 }
 
+func TestCreateSandboxSkipsServiceBlockVolumePublicationForFileOutputs(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	adapter := dependencyBlockVolumeRuntimeAdapter()
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"mise.toml":          "go = \"1.26.2\"\n",
+		"go.mod":             "module example.com/test\n\ngo 1.26.2\n",
+		"go.sum":             "example.com/test v0.0.0 h1:abc123\n",
+		"docker-compose.yml": "services:\n  postgres:\n    image: postgres:17\n",
+		"db/schema.sql":      "create table widgets (id serial primary key);\n",
+		"scripts/prepare-db": "#!/bin/sh\ntrue\n",
+	})
+	svc := newTestService(adapter)
+	svc.RepositoryStore = mirrors
+	cacheStore := newMemoryCacheStore()
+	svc.CacheStore = cacheStore
+
+	policyProto := testRepositoryTwoDependencyBlocksPolicy()
+	policyProto.Docker = &cleanroomv1.PolicyDocker{Required: true}
+	policyProto.Services = &cleanroomv1.PolicyServices{
+		Blocks: []*cleanroomv1.PolicyBlock{
+			{
+				Name:    "postgres-config",
+				Command: []string{"sh", "-lc", "mkdir -p /var/lib/cleanroom/services && touch /var/lib/cleanroom/services/postgres.conf"},
+				Inputs: &cleanroomv1.PolicyBlockInputs{
+					Files: []string{"docker-compose.yml", "db/schema.sql", "scripts/prepare-db"},
+				},
+				Outputs: &cleanroomv1.PolicyBlockOutputs{
+					Files: []string{"/var/lib/cleanroom/services/postgres.conf"},
+				},
+			},
+		},
+	}
+
+	compiled, err := policy.FromProto(policyProto)
+	if err != nil {
+		t.Fatalf("FromProto returned error: %v", err)
+	}
+	repository := repositorycheckout.FromProto(repositoryCheckout)
+	dependencyPlan, ok, err := svc.finalizeDependencyBlockVolumePlan(context.Background(), compiled, repository, nil, nil, "firecracker", "runtime-base:test")
+	if err != nil {
+		t.Fatalf("finalizeDependencyBlockVolumePlan returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected dependency block-volume plan")
+	}
+	for _, block := range dependencyPlan.Blocks {
+		if err := cacheStore.Create(context.Background(), dependencyBlockVolumeTestRecord(compiled, block)); err != nil {
+			t.Fatalf("Create dependency block-volume record returned error: %v", err)
+		}
+	}
+
+	if _, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Policy:             policyProto,
+		RepositoryCheckout: repositoryCheckout,
+	}); err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	if got := adapter.snapshotCacheOutputsCalls; got != 0 {
+		t.Fatalf("did not expect cache output snapshots for file-output service block, got %d", got)
+	}
+	records, err := cacheStore.List(context.Background())
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	for _, record := range records {
+		if record.Stage == serviceVolumeStageName {
+			t.Fatalf("did not expect service block-volume record for file-output block: %#v", record)
+		}
+	}
+}
+
 func TestCreateSandboxLooksUpServiceBlockVolumesAfterDependencyStageRestore(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	adapter := dependencyBlockVolumeRuntimeAdapter()

--- a/internal/controlservice/service_volume_publish.go
+++ b/internal/controlservice/service_volume_publish.go
@@ -37,8 +37,12 @@ func (s *Service) maybePublishServiceBlockVolumeCaches(
 	if len(missed) == 0 {
 		return
 	}
-	volumeIDs := make([]string, 0, len(missed))
-	for _, block := range missed {
+	publishable := publishableServiceBlockVolumeBlocks(missed)
+	if len(publishable) == 0 {
+		return
+	}
+	volumeIDs := make([]string, 0, len(publishable))
+	for _, block := range publishable {
 		volumeIDs = append(volumeIDs, blockVolumeID(serviceVolumeStageName, block.CacheKey))
 	}
 
@@ -62,9 +66,9 @@ func (s *Service) maybePublishServiceBlockVolumeCaches(
 	}
 
 	now := s.clock().Now()
-	records := make([]cachestore.Record, 0, len(missed))
-	snapshots := make([]backend.CacheOutputVolumeSnapshot, 0, len(missed))
-	for _, block := range missed {
+	records := make([]cachestore.Record, 0, len(publishable))
+	snapshots := make([]backend.CacheOutputVolumeSnapshot, 0, len(publishable))
+	for _, block := range publishable {
 		volumeID := blockVolumeID(serviceVolumeStageName, block.CacheKey)
 		snapshot := snapshotsByVolumeID[volumeID]
 		snapshots = append(snapshots, snapshot)
@@ -95,6 +99,17 @@ func missedServiceBlockVolumeBlocks(plan serviceBlockVolumePlan) []serviceBlockV
 		}
 	}
 	return missed
+}
+
+func publishableServiceBlockVolumeBlocks(blocks []serviceBlockVolumeBlockPlan) []serviceBlockVolumeBlockPlan {
+	publishable := make([]serviceBlockVolumeBlockPlan, 0, len(blocks))
+	for _, block := range blocks {
+		if len(block.Outputs.Files) > 0 {
+			continue
+		}
+		publishable = append(publishable, block)
+	}
+	return publishable
 }
 
 func serviceBlockVolumeSnapshotsByVolumeID(volumeIDs []string, result *backend.SnapshotCacheOutputVolumesResult) (map[string]backend.CacheOutputVolumeSnapshot, error) {


### PR DESCRIPTION
## Why

This is a correctness guard for the dependency/service volume-cache runtime in `docs/plans/dependency-service-volume-caches.md`.

Dependency and service block-volume publication now works for declared directory outputs. Declared file outputs are different: the runtime can restore files from an existing output volume, but it does not yet copy newly produced file outputs from the sandbox root back into the aggregate output volume after a miss.

Publishing a file-output block before that copy step exists would create cache metadata that points at a snapshot missing the declared file. A later cache hit would then try to restore a required file that is not in the volume.

## What changed

- Dependency block-volume publication skips missed blocks that declare `outputs.files`.
- Service block-volume publication does the same.
- Directory-only blocks keep publishing as before, including later blocks in the same plan.
- Added create-sandbox regression coverage for dependency and service file-output blocks so they execute without snapshotting or persisting invalid volume-cache records.

The follow-up file-output runtime slice can remove this guard once missed block execution copies declared file outputs into the output volume and materializes them back into the sandbox root.

## Validation

- `GOCACHE=/private/tmp/cleanroom-go-build-cache mise exec -- go test ./internal/controlservice`
- `GOCACHE=/private/tmp/cleanroom-go-build-cache mise exec -- go test ./...`
- `docker run --rm -v "$PWD":/work -v /Users/lachlan/Develop/cleanroom/.git:/Users/lachlan/Develop/cleanroom/.git:ro -w /work -e GOCACHE=/tmp/go-build-cache golang:1.26.2 go test ./...`
