### PR TITLE
feat: Capture cache output files

### DIFF
--- a/cmd/cleanroom-guest-agent/cache_output_mounts.go
+++ b/cmd/cleanroom-guest-agent/cache_output_mounts.go
@@ -461,3 +461,116 @@ func restoreCacheOutputFileFrom(source *os.File, sourcePath, targetPath string, 
 	}
 	return nil
 }
+
+func captureCacheOutputFiles(captures []vsockexec.CacheOutputFileCapture) error {
+	for i, capture := range captures {
+		if err := captureCacheOutputFile(capture); err != nil {
+			return fmt.Errorf("capture cache output file %d: %w", i, err)
+		}
+	}
+	return nil
+}
+
+func captureCacheOutputFile(capture vsockexec.CacheOutputFileCapture) error {
+	guestPath, err := cleanAbsoluteCacheOutputPath("guest path", capture.GuestPath)
+	if err != nil {
+		return err
+	}
+	mountPath, err := cleanAbsoluteCacheOutputPath("mount path", capture.MountPath)
+	if err != nil {
+		return err
+	}
+	subpath, err := cleanCacheOutputSubpath(capture.Subpath)
+	if err != nil {
+		return err
+	}
+	if err := requireCacheOutputDirNoSymlink(mountPath); err != nil {
+		return err
+	}
+
+	source, err := openCacheOutputCaptureSource(guestPath)
+	if err != nil {
+		return err
+	}
+	defer source.Close()
+
+	targetDirSubpath := filepath.Dir(subpath)
+	targetDir := mountPath
+	if targetDirSubpath != "." {
+		var err error
+		targetDir, err = ensureCacheOutputVolumeDir(mountPath, targetDirSubpath, 0o755, false)
+		if err != nil {
+			return err
+		}
+	}
+	return copyCacheOutputFile(source, guestPath, filepath.Join(targetDir, filepath.Base(subpath)), fs.FileMode(capture.Mode).Perm())
+}
+
+func openCacheOutputCaptureSource(path string) (*os.File, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, fmt.Errorf("stat cache output file source %s: %w", path, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("cache output file source %s is a symlink", path)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("cache output file source %s is not a regular file", path)
+	}
+	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, fmt.Errorf("open cache output file source %s: %w", path, err)
+	}
+	return os.NewFile(uintptr(fd), path), nil
+}
+
+func copyCacheOutputFile(source *os.File, sourcePath, targetPath string, mode fs.FileMode) error {
+	info, err := source.Stat()
+	if err != nil {
+		return fmt.Errorf("stat cache output file source %s: %w", sourcePath, err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("cache output file source %s is not a regular file", sourcePath)
+	}
+	if mode == 0 {
+		mode = info.Mode().Perm()
+	}
+	if mode == 0 {
+		mode = 0o644
+	}
+
+	targetDir := filepath.Dir(targetPath)
+	if err := ensureCacheOutputDir(targetDir, 0o755, true, false); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(targetDir, "."+filepath.Base(targetPath)+".cleanroom-cache-capture-*")
+	if err != nil {
+		return fmt.Errorf("create temporary cache output file target for %s: %w", targetPath, err)
+	}
+	tmpPath := tmp.Name()
+	_, copyErr := io.Copy(tmp, source)
+	chmodErr := tmp.Chmod(mode.Perm())
+	syncErr := tmp.Sync()
+	closeErr := tmp.Close()
+	if copyErr != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("copy cache output file %s to %s: %w", sourcePath, targetPath, copyErr)
+	}
+	if chmodErr != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("chmod temporary cache output file target %s: %w", tmpPath, chmodErr)
+	}
+	if syncErr != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("sync temporary cache output file target %s: %w", tmpPath, syncErr)
+	}
+	if closeErr != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("close temporary cache output file target %s: %w", tmpPath, closeErr)
+	}
+	if err := os.Rename(tmpPath, targetPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("replace cache output file target %s: %w", targetPath, err)
+	}
+	return nil
+}

--- a/cmd/cleanroom-guest-agent/cache_output_mounts_test.go
+++ b/cmd/cleanroom-guest-agent/cache_output_mounts_test.go
@@ -242,6 +242,96 @@ func TestRestoreCacheOutputFileReplacesExistingTarget(t *testing.T) {
 	}
 }
 
+func TestCaptureCacheOutputFilesCopiesDeclaredOutputToVolume(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "root", ".cache", "tool", "index.json")
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o755); err != nil {
+		t.Fatalf("create source parent: %v", err)
+	}
+	if err := os.WriteFile(sourcePath, []byte("index"), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	mountPath := filepath.Join(dir, "volume")
+	if err := os.MkdirAll(mountPath, 0o755); err != nil {
+		t.Fatalf("create mount path: %v", err)
+	}
+
+	err := captureCacheOutputFiles([]vsockexec.CacheOutputFileCapture{
+		{
+			GuestPath: sourcePath,
+			MountPath: mountPath,
+			Subpath:   "files/0",
+			Mode:      0o600,
+		},
+	})
+	if err != nil {
+		t.Fatalf("captureCacheOutputFiles returned error: %v", err)
+	}
+	targetPath := filepath.Join(mountPath, "files", "0")
+	data, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("read captured file: %v", err)
+	}
+	if got, want := string(data), "index"; got != want {
+		t.Fatalf("unexpected captured data: got %q want %q", got, want)
+	}
+	info, err := os.Stat(targetPath)
+	if err != nil {
+		t.Fatalf("stat captured file: %v", err)
+	}
+	if got, want := info.Mode().Perm(), os.FileMode(0o600); got != want {
+		t.Fatalf("unexpected captured mode: got %v want %v", got, want)
+	}
+}
+
+func TestCaptureCacheOutputFilesRequiresRegularSource(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source")
+	if err := os.Symlink("/etc/passwd", sourcePath); err != nil {
+		t.Fatalf("create source symlink: %v", err)
+	}
+	mountPath := filepath.Join(dir, "volume")
+	if err := os.MkdirAll(mountPath, 0o755); err != nil {
+		t.Fatalf("create mount path: %v", err)
+	}
+
+	err := captureCacheOutputFiles([]vsockexec.CacheOutputFileCapture{
+		{
+			GuestPath: sourcePath,
+			MountPath: mountPath,
+			Subpath:   "files/0",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected symlink source to fail")
+	}
+}
+
+func TestCaptureCacheOutputFilesRequiresSource(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	mountPath := filepath.Join(dir, "volume")
+	if err := os.MkdirAll(mountPath, 0o755); err != nil {
+		t.Fatalf("create mount path: %v", err)
+	}
+
+	err := captureCacheOutputFiles([]vsockexec.CacheOutputFileCapture{
+		{
+			GuestPath: filepath.Join(dir, "missing"),
+			MountPath: mountPath,
+			Subpath:   "files/0",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected missing source to fail")
+	}
+}
+
 func TestSetupCacheOutputMountsOnceRejectsChangedPlan(t *testing.T) {
 	cacheOutputMountState.Lock()
 	previousSignature := cacheOutputMountState.signature

--- a/cmd/cleanroom-guest-agent/main.go
+++ b/cmd/cleanroom-guest-agent/main.go
@@ -128,7 +128,11 @@ func handleConnTTY(conn io.ReadWriteCloser, dec *json.Decoder, req vsockexec.Exe
 	// PTY read returns EIO when the slave side closes; ignore the error.
 	_, _ = io.Copy(streamFrameWriter{send: sender.Send, kind: "stdout"}, ptmx)
 
-	sendExitResult(sender, cmd.Wait(), req.OverlayCapture)
+	waitErr := cmd.Wait()
+	if waitErr == nil {
+		waitErr = captureCacheOutputFiles(req.CacheOutputFileCaptures)
+	}
+	sendExitResult(sender, waitErr, req.OverlayCapture)
 }
 
 func handleConnPipes(conn io.ReadWriteCloser, dec *json.Decoder, req vsockexec.ExecRequest) {
@@ -181,6 +185,9 @@ func handleConnPipes(conn io.ReadWriteCloser, dec *json.Decoder, req vsockexec.E
 
 	wg.Wait()
 	waitErr := cmd.Wait()
+	if waitErr == nil {
+		waitErr = captureCacheOutputFiles(req.CacheOutputFileCaptures)
+	}
 	sendExitResult(sender, waitErr, req.OverlayCapture)
 }
 

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -348,17 +348,18 @@ type OutputStream struct {
 }
 
 type ExecutionRequest struct {
-	SandboxID       string
-	ExecutionID     string
-	Command         []string
-	Dir             string
-	Env             []string
-	ClosedEnv       bool
-	TTY             bool
-	InputProjection *InputProjection
-	OverlayCapture  *OverlayCapture
-	Policy          *policy.CompiledPolicy
-	NetworkStage    policy.NetworkStage
+	SandboxID               string
+	ExecutionID             string
+	Command                 []string
+	Dir                     string
+	Env                     []string
+	ClosedEnv               bool
+	TTY                     bool
+	InputProjection         *InputProjection
+	CacheOutputFileCaptures []CacheOutputFileCapture
+	OverlayCapture          *OverlayCapture
+	Policy                  *policy.CompiledPolicy
+	NetworkStage            policy.NetworkStage
 	FirecrackerConfig
 }
 
@@ -367,6 +368,13 @@ type InputProjection struct {
 	TargetRoot          string
 	Files               []string
 	MountSourceReadOnly bool
+}
+
+type CacheOutputFileCapture struct {
+	VolumeID      string
+	GuestPath     string
+	VolumeSubpath string
+	Mode          fs.FileMode
 }
 
 type OverlayCapture struct {

--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -1638,15 +1638,21 @@ func (a *Adapter) executeInSandbox(bootCtx context.Context, runCtx context.Conte
 		}
 	}
 
+	cacheOutputCaptures, err := darwinVZCacheOutputFileCaptures(instance.cacheOutputVolumes, req.CacheOutputFileCaptures)
+	if err != nil {
+		return nil, err
+	}
+
 	guestReq := vsockexec.ExecRequest{
-		Command:           append([]string(nil), req.Command...),
-		Dir:               strings.TrimSpace(req.Dir),
-		Env:               append([]string(nil), req.Env...),
-		ClosedEnv:         req.ClosedEnv,
-		TTY:               req.TTY,
-		CacheOutputMounts: cloneDarwinVZCacheOutputMounts(instance.cacheOutputMounts),
-		InputProjection:   darwinVZInputProjection(req.InputProjection),
-		OverlayCapture:    guestexec.ToVSOCKOverlayCapture(req.OverlayCapture),
+		Command:                 append([]string(nil), req.Command...),
+		Dir:                     strings.TrimSpace(req.Dir),
+		Env:                     append([]string(nil), req.Env...),
+		ClosedEnv:               req.ClosedEnv,
+		TTY:                     req.TTY,
+		CacheOutputMounts:       cloneDarwinVZCacheOutputMounts(instance.cacheOutputMounts),
+		CacheOutputFileCaptures: cacheOutputCaptures,
+		InputProjection:         darwinVZInputProjection(req.InputProjection),
+		OverlayCapture:          guestexec.ToVSOCKOverlayCapture(req.OverlayCapture),
 	}
 	if !req.ClosedEnv && a.GatewayRegistry != nil && gatewayScopeToken != "" {
 		gwPort := a.GatewayPort

--- a/internal/backend/darwinvz/cache_output_volumes_darwin.go
+++ b/internal/backend/darwinvz/cache_output_volumes_darwin.go
@@ -287,6 +287,34 @@ func darwinVZCacheOutputVolumeMounts(volumes []preparedDarwinVZCacheOutputVolume
 	return mounts
 }
 
+func darwinVZCacheOutputFileCaptures(volumes []preparedDarwinVZCacheOutputVolume, captures []backend.CacheOutputFileCapture) ([]vsockexec.CacheOutputFileCapture, error) {
+	if len(captures) == 0 {
+		return nil, nil
+	}
+	mountsByVolumeID := make(map[string]string, len(volumes))
+	for _, volume := range volumes {
+		mountsByVolumeID[strings.TrimSpace(volume.Spec.VolumeID)] = strings.TrimSpace(volume.MountPath)
+	}
+	out := make([]vsockexec.CacheOutputFileCapture, 0, len(captures))
+	for i, capture := range captures {
+		volumeID := strings.TrimSpace(capture.VolumeID)
+		if volumeID == "" {
+			return nil, fmt.Errorf("cache output file capture %d missing volume id", i)
+		}
+		mountPath, ok := mountsByVolumeID[volumeID]
+		if !ok {
+			return nil, fmt.Errorf("cache output file capture %d references unknown volume id %q", i, capture.VolumeID)
+		}
+		out = append(out, vsockexec.CacheOutputFileCapture{
+			GuestPath: strings.TrimSpace(capture.GuestPath),
+			MountPath: mountPath,
+			Subpath:   strings.TrimSpace(capture.VolumeSubpath),
+			Mode:      uint32(capture.Mode.Perm()),
+		})
+	}
+	return out, nil
+}
+
 func cloneDarwinVZCacheOutputMounts(mounts []vsockexec.CacheOutputMount) []vsockexec.CacheOutputMount {
 	if len(mounts) == 0 {
 		return nil

--- a/internal/backend/darwinvz/cache_output_volumes_test.go
+++ b/internal/backend/darwinvz/cache_output_volumes_test.go
@@ -89,6 +89,38 @@ func TestDarwinVZCacheOutputDiskPathsPreserveLaunchOrder(t *testing.T) {
 	}
 }
 
+func TestDarwinVZCacheOutputFileCapturesUsePreparedMountPath(t *testing.T) {
+	t.Parallel()
+
+	captures, err := darwinVZCacheOutputFileCaptures([]preparedDarwinVZCacheOutputVolume{
+		{
+			Spec:      backend.CacheOutputVolumeSpec{VolumeID: "volume-a"},
+			MountPath: "/run/cleanroom/cache-output-volumes/cacheout0",
+		},
+	}, []backend.CacheOutputFileCapture{
+		{
+			VolumeID:      "volume-a",
+			GuestPath:     "/root/.config/tool/index.json",
+			VolumeSubpath: "files/0",
+			Mode:          0o600,
+		},
+	})
+	if err != nil {
+		t.Fatalf("darwinVZCacheOutputFileCaptures returned error: %v", err)
+	}
+	want := []vsockexec.CacheOutputFileCapture{
+		{
+			GuestPath: "/root/.config/tool/index.json",
+			MountPath: "/run/cleanroom/cache-output-volumes/cacheout0",
+			Subpath:   "files/0",
+			Mode:      0o600,
+		},
+	}
+	if !reflect.DeepEqual(captures, want) {
+		t.Fatalf("unexpected cache output file captures: got %#v want %#v", captures, want)
+	}
+}
+
 func TestDarwinVZCacheOutputDevicePathSkipsRootDisk(t *testing.T) {
 	t.Parallel()
 

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -525,7 +525,14 @@ func (a *Adapter) RunInSandbox(ctx context.Context, req backend.ExecutionRequest
 		defer a.GatewayRegistry.ClearActiveExecutionTrace(sandboxID, req.ExecutionID)
 	}
 
-	guestResult, timing, err := a.executeInSandbox(ctx, instance, req.LaunchSeconds, req.Command, req.Dir, req.Env, req.ClosedEnv, req.InputProjection, req.OverlayCapture, req.TTY, stream)
+	cacheOutputCaptures, err := cacheOutputFileCaptures(instance.cacheOutputVolumes, req.CacheOutputFileCaptures)
+	if err != nil {
+		observation.ExitCode = 1
+		observation.GuestError = err.Error()
+		return nil, err
+	}
+
+	guestResult, timing, err := a.executeInSandbox(ctx, instance, req.LaunchSeconds, req.Command, req.Dir, req.Env, req.ClosedEnv, req.InputProjection, cacheOutputCaptures, req.OverlayCapture, req.TTY, stream)
 	if err != nil {
 		observation.ExitCode = 1
 		observation.GuestError = err.Error()
@@ -617,7 +624,7 @@ func (a *Adapter) runFileTransferCommand(ctx context.Context, sandboxID string, 
 	if err != nil {
 		return nil, err
 	}
-	result, _, err := a.executeInSandbox(ctx, instance, 0, cmd, "", nil, false, nil, nil, false, stream)
+	result, _, err := a.executeInSandbox(ctx, instance, 0, cmd, "", nil, false, nil, nil, nil, false, stream)
 	if err != nil {
 		return nil, err
 	}
@@ -695,7 +702,7 @@ func (a *Adapter) CreateSnapshot(ctx context.Context, req backend.SnapshotReques
 		return nil, fmt.Errorf("sandbox %q is not running: %w", sandboxID, err)
 	}
 
-	syncResp, _, err := a.executeInSandbox(ctx, instance, snapshotSyncTimeoutSeconds, []string{"sync"}, "", nil, false, nil, nil, false, backend.OutputStream{})
+	syncResp, _, err := a.executeInSandbox(ctx, instance, snapshotSyncTimeoutSeconds, []string{"sync"}, "", nil, false, nil, nil, nil, false, backend.OutputStream{})
 	if err != nil {
 		return nil, fmt.Errorf("sync sandbox filesystem before snapshot: %w", err)
 	}
@@ -832,16 +839,17 @@ func (a *Adapter) DeleteSnapshot(ctx context.Context, req backend.DeleteSnapshot
 	return nil
 }
 
-func (a *Adapter) executeInSandbox(ctx context.Context, instance *sandboxInstance, launchSeconds int64, command []string, dir string, env []string, closedEnv bool, inputProjection *backend.InputProjection, overlayCapture *backend.OverlayCapture, tty bool, stream backend.OutputStream) (vsockexec.ExecResponse, guestExecTiming, error) {
+func (a *Adapter) executeInSandbox(ctx context.Context, instance *sandboxInstance, launchSeconds int64, command []string, dir string, env []string, closedEnv bool, inputProjection *backend.InputProjection, cacheOutputFileCaptures []vsockexec.CacheOutputFileCapture, overlayCapture *backend.OverlayCapture, tty bool, stream backend.OutputStream) (vsockexec.ExecResponse, guestExecTiming, error) {
 	guestReq := vsockexec.ExecRequest{
-		Command:           append([]string(nil), command...),
-		Dir:               strings.TrimSpace(dir),
-		Env:               append([]string(nil), env...),
-		ClosedEnv:         closedEnv,
-		TTY:               tty,
-		CacheOutputMounts: cloneCacheOutputMounts(instance.cacheOutputMounts),
-		InputProjection:   vsockInputProjection(inputProjection),
-		OverlayCapture:    guestexec.ToVSOCKOverlayCapture(overlayCapture),
+		Command:                 append([]string(nil), command...),
+		Dir:                     strings.TrimSpace(dir),
+		Env:                     append([]string(nil), env...),
+		ClosedEnv:               closedEnv,
+		TTY:                     tty,
+		CacheOutputMounts:       cloneCacheOutputMounts(instance.cacheOutputMounts),
+		CacheOutputFileCaptures: append([]vsockexec.CacheOutputFileCapture(nil), cacheOutputFileCaptures...),
+		InputProjection:         vsockInputProjection(inputProjection),
+		OverlayCapture:          guestexec.ToVSOCKOverlayCapture(overlayCapture),
 	}
 	entropy := make([]byte, 64)
 	if _, err := cryptorand.Read(entropy); err == nil {

--- a/internal/backend/firecracker/cache_output_snapshots.go
+++ b/internal/backend/firecracker/cache_output_snapshots.go
@@ -72,7 +72,7 @@ func (a *Adapter) SnapshotCacheOutputVolumes(ctx context.Context, req backend.Sn
 		})
 	}
 
-	syncResp, _, err := a.executeInSandbox(ctx, instance, snapshotSyncTimeoutSeconds, []string{"sync"}, "", nil, false, nil, nil, false, backend.OutputStream{})
+	syncResp, _, err := a.executeInSandbox(ctx, instance, snapshotSyncTimeoutSeconds, []string{"sync"}, "", nil, false, nil, nil, nil, false, backend.OutputStream{})
 	if err != nil {
 		return nil, fmt.Errorf("sync sandbox filesystem before cache output snapshot: %w", err)
 	}

--- a/internal/backend/firecracker/cache_output_volumes.go
+++ b/internal/backend/firecracker/cache_output_volumes.go
@@ -328,6 +328,34 @@ func cacheOutputVolumeMounts(volumes []preparedCacheOutputVolume) []vsockexec.Ca
 	return mounts
 }
 
+func cacheOutputFileCaptures(volumes []preparedCacheOutputVolume, captures []backend.CacheOutputFileCapture) ([]vsockexec.CacheOutputFileCapture, error) {
+	if len(captures) == 0 {
+		return nil, nil
+	}
+	mountsByVolumeID := make(map[string]string, len(volumes))
+	for _, volume := range volumes {
+		mountsByVolumeID[strings.TrimSpace(volume.Spec.VolumeID)] = cacheOutputGuestMountPath(volume.Drive.DriveID)
+	}
+	out := make([]vsockexec.CacheOutputFileCapture, 0, len(captures))
+	for i, capture := range captures {
+		volumeID := strings.TrimSpace(capture.VolumeID)
+		if volumeID == "" {
+			return nil, fmt.Errorf("cache output file capture %d missing volume id", i)
+		}
+		mountPath, ok := mountsByVolumeID[volumeID]
+		if !ok {
+			return nil, fmt.Errorf("cache output file capture %d references unknown volume id %q", i, capture.VolumeID)
+		}
+		out = append(out, vsockexec.CacheOutputFileCapture{
+			GuestPath: strings.TrimSpace(capture.GuestPath),
+			MountPath: mountPath,
+			Subpath:   strings.TrimSpace(capture.VolumeSubpath),
+			Mode:      uint32(capture.Mode.Perm()),
+		})
+	}
+	return out, nil
+}
+
 func cloneCacheOutputMounts(mounts []vsockexec.CacheOutputMount) []vsockexec.CacheOutputMount {
 	if len(mounts) == 0 {
 		return nil

--- a/internal/backend/firecracker/persistent_test.go
+++ b/internal/backend/firecracker/persistent_test.go
@@ -273,6 +273,59 @@ func TestRunInSandboxForwardsCacheOutputMounts(t *testing.T) {
 	}
 }
 
+func TestRunInSandboxForwardsCacheOutputFileCaptures(t *testing.T) {
+	t.Parallel()
+
+	var gotCaptures []vsockexec.CacheOutputFileCapture
+	adapter := &Adapter{}
+	adapter.runGuestCommandFn = func(_ context.Context, _ context.Context, _ <-chan struct{}, _ func() error, _ string, _ uint32, req vsockexec.ExecRequest, _ backend.OutputStream) (vsockexec.ExecResponse, guestExecTiming, error) {
+		gotCaptures = append([]vsockexec.CacheOutputFileCapture(nil), req.CacheOutputFileCaptures...)
+		return vsockexec.ExecResponse{ExitCode: 0}, guestExecTiming{}, nil
+	}
+	adapter.sandboxes = map[string]*sandboxInstance{
+		"cr-test": {
+			SandboxID: "cr-test",
+			VsockPath: "/tmp/fake.sock",
+			GuestPort: 10700,
+			cacheOutputVolumes: []preparedCacheOutputVolume{
+				{
+					Spec: backend.CacheOutputVolumeSpec{VolumeID: "volume-a"},
+					Drive: drive{
+						DriveID: "cacheout0",
+					},
+				},
+			},
+		},
+	}
+
+	if _, err := adapter.RunInSandbox(context.Background(), backend.ExecutionRequest{
+		SandboxID:   "cr-test",
+		ExecutionID: "run-123",
+		Command:     []string{"true"},
+		CacheOutputFileCaptures: []backend.CacheOutputFileCapture{
+			{
+				VolumeID:      "volume-a",
+				GuestPath:     "/root/.config/tool/index.json",
+				VolumeSubpath: "files/0",
+				Mode:          0o600,
+			},
+		},
+	}, backend.OutputStream{}); err != nil {
+		t.Fatalf("RunInSandbox returned error: %v", err)
+	}
+	want := []vsockexec.CacheOutputFileCapture{
+		{
+			GuestPath: "/root/.config/tool/index.json",
+			MountPath: "/run/cleanroom/cache-output-volumes/cacheout0",
+			Subpath:   "files/0",
+			Mode:      0o600,
+		},
+	}
+	if !reflect.DeepEqual(gotCaptures, want) {
+		t.Fatalf("unexpected cache output file captures: got %#v want %#v", gotCaptures, want)
+	}
+}
+
 func TestRunInSandboxForwardsInputProjection(t *testing.T) {
 	t.Parallel()
 

--- a/internal/controlservice/block_volume_specs.go
+++ b/internal/controlservice/block_volume_specs.go
@@ -50,6 +50,30 @@ func serviceBlockVolumeOutputSpecs(plan serviceBlockVolumePlan) ([]backend.Cache
 	return blockVolumeOutputSpecs(blocks)
 }
 
+func dependencyBlockVolumeFileCaptures(block dependencyBlockVolumeBlockPlan) []backend.CacheOutputFileCapture {
+	return blockVolumeFileCaptures(dependencyVolumeStageName, block.CacheKey, block.Outputs)
+}
+
+func serviceBlockVolumeFileCaptures(block serviceBlockVolumeBlockPlan) []backend.CacheOutputFileCapture {
+	return blockVolumeFileCaptures(serviceVolumeStageName, block.CacheKey, block.Outputs)
+}
+
+func blockVolumeFileCaptures(stage, cacheKey string, outputs policy.StageBlockOutputs) []backend.CacheOutputFileCapture {
+	if len(outputs.Files) == 0 {
+		return nil
+	}
+	volumeID := blockVolumeID(stage, cacheKey)
+	captures := make([]backend.CacheOutputFileCapture, 0, len(outputs.Files))
+	for i, file := range outputs.Files {
+		captures = append(captures, backend.CacheOutputFileCapture{
+			VolumeID:      volumeID,
+			GuestPath:     strings.TrimSpace(file),
+			VolumeSubpath: blockVolumeOutputSubpath("files", i),
+		})
+	}
+	return captures
+}
+
 func blockVolumeOutputSpecs(blocks []blockVolumeOutputSpecBlock) ([]backend.CacheOutputVolumeSpec, error) {
 	if len(blocks) == 0 {
 		return nil, nil

--- a/internal/controlservice/bootstrap_runner.go
+++ b/internal/controlservice/bootstrap_runner.go
@@ -27,9 +27,10 @@ func (s *Service) runPersistentSandboxCommand(
 }
 
 type persistentSandboxCommandOptions struct {
-	Dir             string
-	ClosedEnv       bool
-	InputProjection *backend.InputProjection
+	Dir                     string
+	ClosedEnv               bool
+	InputProjection         *backend.InputProjection
+	CacheOutputFileCaptures []backend.CacheOutputFileCapture
 }
 
 func (s *Service) runPersistentSandboxCommandWithOptions(
@@ -46,17 +47,27 @@ func (s *Service) runPersistentSandboxCommandWithOptions(
 	stream backend.OutputStream,
 ) (*backend.ExecutionResult, error) {
 	return adapter.RunInSandbox(ctx, backend.ExecutionRequest{
-		SandboxID:         sandboxID,
-		ExecutionID:       executionID,
-		Command:           append([]string(nil), command...),
-		Dir:               strings.TrimSpace(opts.Dir),
-		Env:               append([]string(nil), env...),
-		ClosedEnv:         opts.ClosedEnv,
-		InputProjection:   cloneInputProjection(opts.InputProjection),
-		Policy:            compiled,
-		NetworkStage:      networkStage,
-		FirecrackerConfig: withRunDir(firecrackerCfg, internalBootstrapArtifactsDir(sandboxID, executionID)),
+		SandboxID:               sandboxID,
+		ExecutionID:             executionID,
+		Command:                 append([]string(nil), command...),
+		Dir:                     strings.TrimSpace(opts.Dir),
+		Env:                     append([]string(nil), env...),
+		ClosedEnv:               opts.ClosedEnv,
+		InputProjection:         cloneInputProjection(opts.InputProjection),
+		CacheOutputFileCaptures: cloneCacheOutputFileCaptures(opts.CacheOutputFileCaptures),
+		Policy:                  compiled,
+		NetworkStage:            networkStage,
+		FirecrackerConfig:       withRunDir(firecrackerCfg, internalBootstrapArtifactsDir(sandboxID, executionID)),
 	}, stream)
+}
+
+func cloneCacheOutputFileCaptures(captures []backend.CacheOutputFileCapture) []backend.CacheOutputFileCapture {
+	if len(captures) == 0 {
+		return nil
+	}
+	out := make([]backend.CacheOutputFileCapture, len(captures))
+	copy(out, captures)
+	return out
 }
 
 func (s *Service) runPersistentBootstrapCommand(

--- a/internal/controlservice/dependency_volume_execution.go
+++ b/internal/controlservice/dependency_volume_execution.go
@@ -110,9 +110,10 @@ func (s *Service) bootstrapDependencyBlockVolumeBlock(
 		env,
 		nil,
 		persistentSandboxCommandOptions{
-			Dir:             sourceRoot,
-			ClosedEnv:       true,
-			InputProjection: inputProjection,
+			Dir:                     sourceRoot,
+			ClosedEnv:               true,
+			InputProjection:         inputProjection,
+			CacheOutputFileCaptures: dependencyBlockVolumeFileCaptures(block),
 		},
 		reporter,
 	)

--- a/internal/controlservice/dependency_volume_plan_test.go
+++ b/internal/controlservice/dependency_volume_plan_test.go
@@ -562,7 +562,7 @@ func TestCreateSandboxPublishesDependencyBlockVolumeCachesForMisses(t *testing.T
 	}
 }
 
-func TestCreateSandboxSkipsDependencyBlockVolumePublicationForFileOutputs(t *testing.T) {
+func TestCreateSandboxPublishesDependencyBlockVolumeFileOutputs(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	adapter := dependencyBlockVolumeRuntimeAdapter()
 	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
@@ -587,6 +587,58 @@ func TestCreateSandboxSkipsDependencyBlockVolumePublicationForFileOutputs(t *tes
 			},
 		},
 	}
+	compiled, err := policy.FromProto(policyProto)
+	if err != nil {
+		t.Fatalf("FromProto returned error: %v", err)
+	}
+	repository := repositorycheckout.FromProto(repositoryCheckout)
+	plan, ok, err := svc.finalizeDependencyBlockVolumePlan(context.Background(), compiled, repository, nil, nil, "firecracker", "runtime-base:test")
+	if err != nil {
+		t.Fatalf("finalizeDependencyBlockVolumePlan returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected dependency block-volume plan")
+	}
+	block := plan.Blocks[0]
+	volumeID := blockVolumeID(dependencyVolumeStageName, block.CacheKey)
+	capturedFileOutput := false
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
+		if len(req.CacheOutputFileCaptures) > 0 {
+			capturedFileOutput = true
+			if got, want := req.CacheOutputFileCaptures, []backend.CacheOutputFileCapture{{
+				VolumeID:      volumeID,
+				GuestPath:     block.Outputs.Files[0],
+				VolumeSubpath: "files/0",
+			}}; !slices.Equal(got, want) {
+				t.Fatalf("unexpected cache output file captures: got %#v want %#v", got, want)
+			}
+		}
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0}, nil
+	}
+	adapter.snapshotCacheOutputsFn = func(_ context.Context, req backend.SnapshotCacheOutputVolumesRequest) (*backend.SnapshotCacheOutputVolumesResult, error) {
+		if got, want := req.VolumeIDs, []string{volumeID}; !slices.Equal(got, want) {
+			t.Fatalf("unexpected snapshot volume ids: got %v want %v", got, want)
+		}
+		return &backend.SnapshotCacheOutputVolumesResult{Volumes: []backend.CacheOutputVolumeSnapshot{
+			{
+				Stage:         dependencyVolumeStageName,
+				BlockName:     block.BlockName,
+				CacheKey:      block.CacheKey,
+				VolumeID:      volumeID,
+				SnapshotID:    req.SnapshotIDPrefix + "-" + block.BlockName,
+				StorageDriver: "file",
+				StorageRef:    "/snapshots/" + block.BlockName + ".ext4",
+				SnapshotRef:   "snapshot:" + block.BlockName,
+				Outputs: []backend.CacheOutputVolumeSnapshotOutput{
+					{
+						Kind:          "file",
+						GuestPath:     block.Outputs.Files[0],
+						VolumeSubpath: "files/0",
+					},
+				},
+			},
+		}}, nil
+	}
 
 	if _, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
 		Policy:             policyProto,
@@ -594,17 +646,37 @@ func TestCreateSandboxSkipsDependencyBlockVolumePublicationForFileOutputs(t *tes
 	}); err != nil {
 		t.Fatalf("CreateSandbox returned error: %v", err)
 	}
-	if got := adapter.snapshotCacheOutputsCalls; got != 0 {
-		t.Fatalf("did not expect cache output snapshots for file-output dependency block, got %d", got)
+	if !capturedFileOutput {
+		t.Fatal("expected dependency block execution to capture declared file output")
+	}
+	if got, want := adapter.snapshotCacheOutputsCalls, 1; got != want {
+		t.Fatalf("unexpected cache output snapshot calls: got %d want %d", got, want)
 	}
 	records, err := cacheStore.List(context.Background())
 	if err != nil {
 		t.Fatalf("List returned error: %v", err)
 	}
-	for _, record := range records {
-		if record.Stage == dependencyVolumeStageName {
-			t.Fatalf("did not expect dependency block-volume record for file-output block: %#v", record)
+	var record cachestore.Record
+	for _, candidate := range records {
+		if candidate.Stage == dependencyVolumeStageName {
+			record = candidate
 		}
+	}
+	if record.CacheKey == "" {
+		t.Fatal("expected dependency block-volume record for file-output block")
+	}
+	if got, want := len(record.OutputRecords), 1; got != want {
+		t.Fatalf("unexpected output record count: got %d want %d", got, want)
+	}
+	output := record.OutputRecords[0]
+	if got, want := output.Kind, "file"; got != want {
+		t.Fatalf("unexpected output kind: got %q want %q", got, want)
+	}
+	if got, want := output.Path, block.Outputs.Files[0]; got != want {
+		t.Fatalf("unexpected output path: got %q want %q", got, want)
+	}
+	if got, want := output.VolumeSubpath, "files/0"; got != want {
+		t.Fatalf("unexpected output subpath: got %q want %q", got, want)
 	}
 }
 

--- a/internal/controlservice/dependency_volume_publish.go
+++ b/internal/controlservice/dependency_volume_publish.go
@@ -37,12 +37,8 @@ func (s *Service) maybePublishDependencyBlockVolumeCaches(
 	if len(missed) == 0 {
 		return
 	}
-	publishable := publishableDependencyBlockVolumeBlocks(missed)
-	if len(publishable) == 0 {
-		return
-	}
-	volumeIDs := make([]string, 0, len(publishable))
-	for _, block := range publishable {
+	volumeIDs := make([]string, 0, len(missed))
+	for _, block := range missed {
 		volumeIDs = append(volumeIDs, blockVolumeID(dependencyVolumeStageName, block.CacheKey))
 	}
 
@@ -66,9 +62,9 @@ func (s *Service) maybePublishDependencyBlockVolumeCaches(
 	}
 
 	now := s.clock().Now()
-	records := make([]cachestore.Record, 0, len(publishable))
-	snapshots := make([]backend.CacheOutputVolumeSnapshot, 0, len(publishable))
-	for _, block := range publishable {
+	records := make([]cachestore.Record, 0, len(missed))
+	snapshots := make([]backend.CacheOutputVolumeSnapshot, 0, len(missed))
+	for _, block := range missed {
 		volumeID := blockVolumeID(dependencyVolumeStageName, block.CacheKey)
 		snapshot := snapshotsByVolumeID[volumeID]
 		snapshots = append(snapshots, snapshot)
@@ -99,17 +95,6 @@ func missedDependencyBlockVolumeBlocks(plan dependencyBlockVolumePlan) []depende
 		}
 	}
 	return missed
-}
-
-func publishableDependencyBlockVolumeBlocks(blocks []dependencyBlockVolumeBlockPlan) []dependencyBlockVolumeBlockPlan {
-	publishable := make([]dependencyBlockVolumeBlockPlan, 0, len(blocks))
-	for _, block := range blocks {
-		if len(block.Outputs.Files) > 0 {
-			continue
-		}
-		publishable = append(publishable, block)
-	}
-	return publishable
 }
 
 func dependencyBlockVolumeSnapshotsByVolumeID(volumeIDs []string, result *backend.SnapshotCacheOutputVolumesResult) (map[string]backend.CacheOutputVolumeSnapshot, error) {

--- a/internal/controlservice/service_volume_execution.go
+++ b/internal/controlservice/service_volume_execution.go
@@ -110,9 +110,10 @@ func (s *Service) bootstrapServiceBlockVolumeBlock(
 		env,
 		nil,
 		persistentSandboxCommandOptions{
-			Dir:             sourceRoot,
-			ClosedEnv:       true,
-			InputProjection: inputProjection,
+			Dir:                     sourceRoot,
+			ClosedEnv:               true,
+			InputProjection:         inputProjection,
+			CacheOutputFileCaptures: serviceBlockVolumeFileCaptures(block),
 		},
 		reporter,
 	)

--- a/internal/controlservice/service_volume_plan_test.go
+++ b/internal/controlservice/service_volume_plan_test.go
@@ -562,7 +562,7 @@ func TestCreateSandboxPublishesServiceBlockVolumeCachesForMisses(t *testing.T) {
 	}
 }
 
-func TestCreateSandboxSkipsServiceBlockVolumePublicationForFileOutputs(t *testing.T) {
+func TestCreateSandboxPublishesServiceBlockVolumeFileOutputs(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	adapter := dependencyBlockVolumeRuntimeAdapter()
 	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
@@ -612,6 +612,53 @@ func TestCreateSandboxSkipsServiceBlockVolumePublicationForFileOutputs(t *testin
 			t.Fatalf("Create dependency block-volume record returned error: %v", err)
 		}
 	}
+	servicePlan, ok, err := svc.finalizeServiceBlockVolumePlan(context.Background(), compiled, repository, nil, nil, "firecracker", "runtime-base:test", dependencyPlan)
+	if err != nil {
+		t.Fatalf("finalizeServiceBlockVolumePlan returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected service block-volume plan")
+	}
+	block := servicePlan.Blocks[0]
+	volumeID := blockVolumeID(serviceVolumeStageName, block.CacheKey)
+	capturedFileOutput := false
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
+		if len(req.CacheOutputFileCaptures) > 0 {
+			capturedFileOutput = true
+			if got, want := req.CacheOutputFileCaptures, []backend.CacheOutputFileCapture{{
+				VolumeID:      volumeID,
+				GuestPath:     block.Outputs.Files[0],
+				VolumeSubpath: "files/0",
+			}}; !slices.Equal(got, want) {
+				t.Fatalf("unexpected cache output file captures: got %#v want %#v", got, want)
+			}
+		}
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0}, nil
+	}
+	adapter.snapshotCacheOutputsFn = func(_ context.Context, req backend.SnapshotCacheOutputVolumesRequest) (*backend.SnapshotCacheOutputVolumesResult, error) {
+		if got, want := req.VolumeIDs, []string{volumeID}; !slices.Equal(got, want) {
+			t.Fatalf("unexpected snapshot volume ids: got %v want %v", got, want)
+		}
+		return &backend.SnapshotCacheOutputVolumesResult{Volumes: []backend.CacheOutputVolumeSnapshot{
+			{
+				Stage:         serviceVolumeStageName,
+				BlockName:     block.BlockName,
+				CacheKey:      block.CacheKey,
+				VolumeID:      volumeID,
+				SnapshotID:    req.SnapshotIDPrefix + "-" + block.BlockName,
+				StorageDriver: "file",
+				StorageRef:    "/snapshots/" + block.BlockName + ".ext4",
+				SnapshotRef:   "snapshot:" + block.BlockName,
+				Outputs: []backend.CacheOutputVolumeSnapshotOutput{
+					{
+						Kind:          "file",
+						GuestPath:     block.Outputs.Files[0],
+						VolumeSubpath: "files/0",
+					},
+				},
+			},
+		}}, nil
+	}
 
 	if _, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
 		Policy:             policyProto,
@@ -619,17 +666,37 @@ func TestCreateSandboxSkipsServiceBlockVolumePublicationForFileOutputs(t *testin
 	}); err != nil {
 		t.Fatalf("CreateSandbox returned error: %v", err)
 	}
-	if got := adapter.snapshotCacheOutputsCalls; got != 0 {
-		t.Fatalf("did not expect cache output snapshots for file-output service block, got %d", got)
+	if !capturedFileOutput {
+		t.Fatal("expected service block execution to capture declared file output")
+	}
+	if got, want := adapter.snapshotCacheOutputsCalls, 1; got != want {
+		t.Fatalf("unexpected cache output snapshot calls: got %d want %d", got, want)
 	}
 	records, err := cacheStore.List(context.Background())
 	if err != nil {
 		t.Fatalf("List returned error: %v", err)
 	}
-	for _, record := range records {
-		if record.Stage == serviceVolumeStageName {
-			t.Fatalf("did not expect service block-volume record for file-output block: %#v", record)
+	var record cachestore.Record
+	for _, candidate := range records {
+		if candidate.Stage == serviceVolumeStageName {
+			record = candidate
 		}
+	}
+	if record.CacheKey == "" {
+		t.Fatal("expected service block-volume record for file-output block")
+	}
+	if got, want := len(record.OutputRecords), 1; got != want {
+		t.Fatalf("unexpected output record count: got %d want %d", got, want)
+	}
+	output := record.OutputRecords[0]
+	if got, want := output.Kind, "file"; got != want {
+		t.Fatalf("unexpected output kind: got %q want %q", got, want)
+	}
+	if got, want := output.Path, block.Outputs.Files[0]; got != want {
+		t.Fatalf("unexpected output path: got %q want %q", got, want)
+	}
+	if got, want := output.VolumeSubpath, "files/0"; got != want {
+		t.Fatalf("unexpected output subpath: got %q want %q", got, want)
 	}
 }
 

--- a/internal/controlservice/service_volume_publish.go
+++ b/internal/controlservice/service_volume_publish.go
@@ -37,12 +37,8 @@ func (s *Service) maybePublishServiceBlockVolumeCaches(
 	if len(missed) == 0 {
 		return
 	}
-	publishable := publishableServiceBlockVolumeBlocks(missed)
-	if len(publishable) == 0 {
-		return
-	}
-	volumeIDs := make([]string, 0, len(publishable))
-	for _, block := range publishable {
+	volumeIDs := make([]string, 0, len(missed))
+	for _, block := range missed {
 		volumeIDs = append(volumeIDs, blockVolumeID(serviceVolumeStageName, block.CacheKey))
 	}
 
@@ -66,9 +62,9 @@ func (s *Service) maybePublishServiceBlockVolumeCaches(
 	}
 
 	now := s.clock().Now()
-	records := make([]cachestore.Record, 0, len(publishable))
-	snapshots := make([]backend.CacheOutputVolumeSnapshot, 0, len(publishable))
-	for _, block := range publishable {
+	records := make([]cachestore.Record, 0, len(missed))
+	snapshots := make([]backend.CacheOutputVolumeSnapshot, 0, len(missed))
+	for _, block := range missed {
 		volumeID := blockVolumeID(serviceVolumeStageName, block.CacheKey)
 		snapshot := snapshotsByVolumeID[volumeID]
 		snapshots = append(snapshots, snapshot)
@@ -99,17 +95,6 @@ func missedServiceBlockVolumeBlocks(plan serviceBlockVolumePlan) []serviceBlockV
 		}
 	}
 	return missed
-}
-
-func publishableServiceBlockVolumeBlocks(blocks []serviceBlockVolumeBlockPlan) []serviceBlockVolumeBlockPlan {
-	publishable := make([]serviceBlockVolumeBlockPlan, 0, len(blocks))
-	for _, block := range blocks {
-		if len(block.Outputs.Files) > 0 {
-			continue
-		}
-		publishable = append(publishable, block)
-	}
-	return publishable
 }
 
 func serviceBlockVolumeSnapshotsByVolumeID(volumeIDs []string, result *backend.SnapshotCacheOutputVolumesResult) (map[string]backend.CacheOutputVolumeSnapshot, error) {

--- a/internal/vsockexec/protocol.go
+++ b/internal/vsockexec/protocol.go
@@ -14,15 +14,16 @@ const (
 )
 
 type ExecRequest struct {
-	Command           []string           `json:"command"`
-	Dir               string             `json:"dir,omitempty"`
-	Env               []string           `json:"env,omitempty"`
-	ClosedEnv         bool               `json:"closed_env,omitempty"`
-	EntropySeed       []byte             `json:"entropy_seed,omitempty"`
-	TTY               bool               `json:"tty,omitempty"`
-	CacheOutputMounts []CacheOutputMount `json:"cache_output_mounts,omitempty"`
-	InputProjection   *InputProjection   `json:"input_projection,omitempty"`
-	OverlayCapture    *OverlayCapture    `json:"overlay_capture,omitempty"`
+	Command                 []string                 `json:"command"`
+	Dir                     string                   `json:"dir,omitempty"`
+	Env                     []string                 `json:"env,omitempty"`
+	ClosedEnv               bool                     `json:"closed_env,omitempty"`
+	EntropySeed             []byte                   `json:"entropy_seed,omitempty"`
+	TTY                     bool                     `json:"tty,omitempty"`
+	CacheOutputMounts       []CacheOutputMount       `json:"cache_output_mounts,omitempty"`
+	CacheOutputFileCaptures []CacheOutputFileCapture `json:"cache_output_file_captures,omitempty"`
+	InputProjection         *InputProjection         `json:"input_projection,omitempty"`
+	OverlayCapture          *OverlayCapture          `json:"overlay_capture,omitempty"`
 }
 
 type InputProjection struct {
@@ -47,6 +48,13 @@ type CacheOutputDirMount struct {
 
 type CacheOutputFileMount struct {
 	GuestPath string `json:"guest_path"`
+	Subpath   string `json:"subpath"`
+	Mode      uint32 `json:"mode,omitempty"`
+}
+
+type CacheOutputFileCapture struct {
+	GuestPath string `json:"guest_path"`
+	MountPath string `json:"mount_path"`
 	Subpath   string `json:"subpath"`
 	Mode      uint32 `json:"mode,omitempty"`
 }


### PR DESCRIPTION
## What this is part of

This is another slice of `docs/plans/dependency-service-volume-caches.md`. The larger goal is to let dependency and service blocks reuse per-block cache output volumes instead of falling back to the whole dependency/service stage when one block misses.

PR #309 deliberately kept blocks with `outputs.files` from publishing volume-cache records because the runtime could describe those files in metadata, but it did not yet copy the files into the aggregate cache output volume. That would have made future cache hits point at missing file data.

## What changed

- Adds a cache-output file capture field to the backend and `vsockexec` execution protocol.
- Maps each capture from stable backend `VolumeID` to the prepared guest cache-output mount path in both Firecracker and darwin-vz.
- Captures declared `outputs.files` after a dependency/service block command exits successfully, using atomic guest-side copies into the block output volume.
- Fails the block execution if a declared output file is missing, a symlink, or not a regular file.
- Removes the temporary dependency/service publish gate from PR #309 so file-output block records can publish once their files are copied into the volume.

This still does not change the public policy surface. It also does not make the block-volume path the default fallback for escaped writes; that remains a later slice.

## Validation

- `GOCACHE=/private/tmp/cleanroom-go-build-cache mise exec -- go test -count=1 ./cmd/cleanroom-guest-agent ./internal/backend/firecracker ./internal/backend/darwinvz ./internal/backend ./internal/controlservice ./internal/vsockexec`
- `GOCACHE=/private/tmp/cleanroom-go-build-cache mise exec -- go test ./...`
- `docker run --rm -v "$PWD":/work -v /Users/lachlan/Develop/cleanroom/.git:/Users/lachlan/Develop/cleanroom/.git:ro -w /work -e GOCACHE=/tmp/go-build-cache golang:1.26.2 go test ./...`
