### PR TITLE
fix: Gate block volume publishing on escaped writes

### DIFF
--- a/internal/controlservice/block_volume_escaped_writes.go
+++ b/internal/controlservice/block_volume_escaped_writes.go
@@ -1,0 +1,35 @@
+package controlservice
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+)
+
+func blockVolumeEscapedWriteWarning(stage, blockName string, result *backend.ExecutionResult) string {
+	if result == nil || result.OverlayCapture == nil || len(result.OverlayCapture.EscapedWrites) == 0 {
+		return ""
+	}
+	count := len(result.OverlayCapture.EscapedWrites)
+	return fmt.Sprintf("%s block %q wrote outside declared outputs (%d escaped writes: %s); skipping block-volume cache publication", stage, blockName, count, blockVolumeEscapedWriteSummary(result.OverlayCapture.EscapedWrites))
+}
+
+func blockVolumeEscapedWriteSummary(entries []backend.OverlayCaptureEntry) string {
+	const limit = 3
+	paths := make([]string, 0, min(len(entries), limit))
+	for i, entry := range entries {
+		if i >= limit {
+			break
+		}
+		path := strings.TrimSpace(entry.Path)
+		if path == "" {
+			path = "<unknown>"
+		}
+		paths = append(paths, path)
+	}
+	if len(entries) > limit {
+		paths = append(paths, fmt.Sprintf("+%d more", len(entries)-limit))
+	}
+	return strings.Join(paths, ", ")
+}

--- a/internal/controlservice/dependency_volume_execution.go
+++ b/internal/controlservice/dependency_volume_execution.go
@@ -35,11 +35,12 @@ func (s *Service) bootstrapDependencyBlockVolumePlanInPersistentSandbox(
 	repository *repositorycheckout.Checkout,
 	plan dependencyBlockVolumePlan,
 	reporter CreateSandboxReporter,
-) error {
+) (bool, error) {
 	if adapter == nil || compiled == nil || repository == nil || strings.TrimSpace(sandboxID) == "" || len(plan.Blocks) == 0 {
-		return nil
+		return true, nil
 	}
 
+	publishable := true
 	for _, block := range plan.Blocks {
 		blockName := strings.TrimSpace(block.BlockName)
 		if block.CacheHit {
@@ -58,12 +59,20 @@ func (s *Service) bootstrapDependencyBlockVolumePlanInPersistentSandbox(
 		}
 
 		emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_DEPENDENCIES, "running dependency bootstrap: "+blockName)
+		var result *backend.ExecutionResult
 		if err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.bootstrap_dependency_block", attrs, func(ctx context.Context) error {
-			return s.bootstrapDependencyBlockVolumeBlock(ctx, adapter, sandboxID, compiled, firecrackerCfg, repository, block, reporter)
+			var err error
+			result, err = s.bootstrapDependencyBlockVolumeBlock(ctx, adapter, sandboxID, compiled, firecrackerCfg, repository, block, reporter)
+			return err
 		}); err != nil {
-			return fmt.Errorf("dependency block %q: %w", blockName, err)
+			return publishable, fmt.Errorf("dependency block %q: %w", blockName, err)
 		}
-		if publish.Adapter != nil {
+		if warning := blockVolumeEscapedWriteWarning("dependency", blockName, result); warning != "" {
+			publishable = false
+			emitCreateSandboxWarning(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_DEPENDENCIES, warning)
+			s.logDependencyStageWarning("publish dependency block-volume caches", sandboxID, fmt.Errorf("%s", warning))
+		}
+		if publishable && publish.Adapter != nil {
 			emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_PUBLISH_DEPENDENCY_STAGE_CACHE, "publishing dependency outputs: "+blockName)
 			s.maybePublishDependencyBlockVolumeCaches(ctx, publish.Adapter, sandboxID, publish.Backend, compiled, firecrackerCfg, publish.Repository, publish.Changeset, dependencyBlockVolumePlan{
 				ReuseNamespace: plan.ReuseNamespace,
@@ -71,7 +80,7 @@ func (s *Service) bootstrapDependencyBlockVolumePlanInPersistentSandbox(
 			})
 		}
 	}
-	return nil
+	return publishable, nil
 }
 
 func (s *Service) bootstrapDependencyBlockVolumeBlock(
@@ -83,9 +92,9 @@ func (s *Service) bootstrapDependencyBlockVolumeBlock(
 	repository *repositorycheckout.Checkout,
 	block dependencyBlockVolumeBlockPlan,
 	reporter CreateSandboxReporter,
-) error {
+) (*backend.ExecutionResult, error) {
 	if len(block.Command) == 0 {
-		return nil
+		return nil, nil
 	}
 	sourceRoot := strings.TrimSpace(repository.DestinationDir)
 	if sourceRoot == "" {
@@ -117,7 +126,7 @@ func (s *Service) bootstrapDependencyBlockVolumeBlock(
 		},
 		reporter,
 	)
-	return persistentBootstrapCommandError(result, stdout, stderr, err, "dependency block bootstrap returned no result", "dependency block bootstrap failed with exit code %d")
+	return result, persistentBootstrapCommandError(result, stdout, stderr, err, "dependency block bootstrap returned no result", "dependency block bootstrap failed with exit code %d")
 }
 
 func stageBlockEnvList(env map[string]string) []string {

--- a/internal/controlservice/dependency_volume_plan_test.go
+++ b/internal/controlservice/dependency_volume_plan_test.go
@@ -759,7 +759,7 @@ func TestBootstrapDependencyBlockVolumePlanRunsMissesFromInputProjection(t *test
 		},
 	}
 	svc := newTestService(adapter)
-	err = svc.bootstrapDependencyBlockVolumePlanInPersistentSandbox(
+	publishable, err := svc.bootstrapDependencyBlockVolumePlanInPersistentSandbox(
 		context.Background(),
 		adapter,
 		"cr-test",
@@ -772,6 +772,9 @@ func TestBootstrapDependencyBlockVolumePlanRunsMissesFromInputProjection(t *test
 	)
 	if err != nil {
 		t.Fatalf("bootstrapDependencyBlockVolumePlanInPersistentSandbox returned error: %v", err)
+	}
+	if !publishable {
+		t.Fatal("expected dependency block volume plan to remain publishable")
 	}
 	if got, want := len(gotReqs), 1; got != want {
 		t.Fatalf("unexpected run count: got %d want %d", got, want)
@@ -803,6 +806,82 @@ func TestBootstrapDependencyBlockVolumePlanRunsMissesFromInputProjection(t *test
 	}
 	if !req.InputProjection.MountSourceReadOnly {
 		t.Fatal("expected projection to be mounted read-only over source")
+	}
+}
+
+func TestBootstrapDependencyBlockVolumePlanStopsPublishingAfterEscapedWrites(t *testing.T) {
+	compiled, err := policy.FromProto(testRepositoryTwoDependencyBlocksPolicy())
+	if err != nil {
+		t.Fatalf("policy.FromProto returned error: %v", err)
+	}
+	repository := repositorycheckout.FromProto(testRepositoryCheckoutProto())
+	plan := dependencyBlockVolumePlan{
+		Blocks: []dependencyBlockVolumeBlockPlan{
+			{
+				BlockName: "toolchains",
+				Command:   append([]string(nil), compiled.Dependencies.Blocks[0].Command...),
+				Env:       cloneDependencyBlockEnv(compiled.Dependencies.Blocks[0].Env),
+				Inputs:    append([]string(nil), compiled.Dependencies.Blocks[0].Inputs.Files...),
+				Outputs:   compiled.Dependencies.Blocks[0].Outputs,
+				CacheKey:  "dependency-volume:toolchains",
+			},
+			{
+				BlockName: "go-modules",
+				Command:   append([]string(nil), compiled.Dependencies.Blocks[1].Command...),
+				Env:       cloneDependencyBlockEnv(compiled.Dependencies.Blocks[1].Env),
+				Inputs:    append([]string(nil), compiled.Dependencies.Blocks[1].Inputs.Files...),
+				Outputs:   compiled.Dependencies.Blocks[1].Outputs,
+				CacheKey:  "dependency-volume:go-modules",
+			},
+		},
+	}
+
+	runCalls := 0
+	adapter := &stubAdapter{
+		runStreamFn: func(_ context.Context, req backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
+			runCalls++
+			result := &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0}
+			if runCalls == 1 {
+				result.OverlayCapture = &backend.OverlayCaptureResult{
+					EscapedWrites: []backend.OverlayCaptureEntry{{Path: "/etc/profile", Kind: "write", Mode: 0o644}},
+				}
+			}
+			return result, nil
+		},
+		snapshotCacheOutputsFn: func(context.Context, backend.SnapshotCacheOutputVolumesRequest) (*backend.SnapshotCacheOutputVolumesResult, error) {
+			t.Fatal("did not expect dependency block-volume snapshot after escaped writes")
+			return nil, nil
+		},
+	}
+	svc := newTestService(adapter)
+	var warnings []string
+	publishable, err := svc.bootstrapDependencyBlockVolumePlanInPersistentSandbox(
+		context.Background(),
+		adapter,
+		"cr-test",
+		dependencyBlockVolumePublishConfig{Adapter: adapter, Backend: "firecracker", Repository: repository},
+		compiled,
+		backend.FirecrackerConfig{},
+		repository,
+		plan,
+		CreateSandboxReporterFuncs{OnWarning: func(_ cleanroomv1.CreateSandboxPhase, warning string) {
+			warnings = append(warnings, warning)
+		}},
+	)
+	if err != nil {
+		t.Fatalf("bootstrapDependencyBlockVolumePlanInPersistentSandbox returned error: %v", err)
+	}
+	if publishable {
+		t.Fatal("expected dependency block volume plan to stop being publishable")
+	}
+	if got, want := runCalls, 2; got != want {
+		t.Fatalf("unexpected run count: got %d want %d", got, want)
+	}
+	if got := adapter.snapshotCacheOutputsCalls; got != 0 {
+		t.Fatalf("unexpected cache output snapshot calls: got %d", got)
+	}
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "/etc/profile") {
+		t.Fatalf("expected escaped-write warning, got %v", warnings)
 	}
 }
 

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -406,6 +406,7 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 	dependencyStagePlan := dependencyStagePlan{}
 	dependencyBlockVolumePlan := dependencyBlockVolumePlan{}
 	dependencyBlockVolumePlanAvailable := false
+	dependencyBlockVolumePublicationSafe := true
 	dependencyCacheOutputVolumes := []backend.CacheOutputVolumeSpec(nil)
 	dependencyStageBootstrapEnabled := false
 	dependencyStageCachingEnabled := false
@@ -876,12 +877,17 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 			emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_SERVICES, "running services bootstrap")
 			if err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.bootstrap_services", bootstrapAttrs, func(ctx context.Context) error {
 				if serviceBlockVolumePlanAvailable {
-					return s.bootstrapServiceBlockVolumePlanInPersistentSandbox(ctx, adapter, sandboxID, serviceBlockVolumePublishConfig{
+					publishConfig := serviceBlockVolumePublishConfig{
 						Adapter:    cacheOutputSnapshotAdapter,
 						Backend:    backendName,
 						Changeset:  changeset,
 						Repository: repository,
-					}, compiled, firecrackerCfg, repository, serviceBlockVolumePlan, reporter)
+					}
+					if !dependencyBlockVolumePublicationSafe {
+						publishConfig.Adapter = nil
+					}
+					_, err := s.bootstrapServiceBlockVolumePlanInPersistentSandbox(ctx, adapter, sandboxID, publishConfig, compiled, firecrackerCfg, repository, serviceBlockVolumePlan, reporter)
+					return err
 				}
 				return s.bootstrapServicesStageInPersistentSandbox(ctx, adapter, sandboxID, compiled, firecrackerCfg, servicesStagePlan, reporter)
 			}); err != nil {
@@ -914,14 +920,17 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 				}
 			}
 			emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_DEPENDENCIES, "running dependency bootstrap")
+			dependencyPublishable := true
 			if err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.bootstrap_dependencies", bootstrapAttrs, func(ctx context.Context) error {
 				if dependencyBlockVolumePlanAvailable {
-					return s.bootstrapDependencyBlockVolumePlanInPersistentSandbox(ctx, adapter, sandboxID, dependencyBlockVolumePublishConfig{
+					var err error
+					dependencyPublishable, err = s.bootstrapDependencyBlockVolumePlanInPersistentSandbox(ctx, adapter, sandboxID, dependencyBlockVolumePublishConfig{
 						Adapter:    cacheOutputSnapshotAdapter,
 						Backend:    backendName,
 						Changeset:  changeset,
 						Repository: repository,
 					}, compiled, firecrackerCfg, repository, dependencyBlockVolumePlan, reporter)
+					return err
 				}
 				return s.bootstrapDependencyStageInPersistentSandbox(ctx, adapter, sandboxID, compiled, firecrackerCfg, dependencyStagePlan, reporter)
 			}); err != nil {
@@ -930,6 +939,9 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 					return nil, fmt.Errorf("bootstrap dependency stage: %w; cleanup failed: %v", err, cleanupErr)
 				}
 				return nil, fmt.Errorf("bootstrap dependency stage: %w", err)
+			}
+			if dependencyBlockVolumePlanAvailable {
+				dependencyBlockVolumePublicationSafe = dependencyPublishable
 			}
 			if dependencyStageCachingEnabled && !dependencyBlockVolumePlanAvailable {
 				emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_PUBLISH_DEPENDENCY_STAGE_CACHE, "publishing dependency stage cache")
@@ -950,12 +962,17 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 			emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_SERVICES, "running services bootstrap")
 			if err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.bootstrap_services", bootstrapAttrs, func(ctx context.Context) error {
 				if serviceBlockVolumePlanAvailable {
-					return s.bootstrapServiceBlockVolumePlanInPersistentSandbox(ctx, adapter, sandboxID, serviceBlockVolumePublishConfig{
+					publishConfig := serviceBlockVolumePublishConfig{
 						Adapter:    cacheOutputSnapshotAdapter,
 						Backend:    backendName,
 						Changeset:  changeset,
 						Repository: repository,
-					}, compiled, firecrackerCfg, repository, serviceBlockVolumePlan, reporter)
+					}
+					if !dependencyBlockVolumePublicationSafe {
+						publishConfig.Adapter = nil
+					}
+					_, err := s.bootstrapServiceBlockVolumePlanInPersistentSandbox(ctx, adapter, sandboxID, publishConfig, compiled, firecrackerCfg, repository, serviceBlockVolumePlan, reporter)
+					return err
 				}
 				return s.bootstrapServicesStageInPersistentSandbox(ctx, adapter, sandboxID, compiled, firecrackerCfg, servicesStagePlan, reporter)
 			}); err != nil {
@@ -1104,14 +1121,17 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 			}
 		}
 		emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_DEPENDENCIES, "running dependency bootstrap")
+		dependencyPublishable := true
 		if err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.bootstrap_dependencies", bootstrapAttrs, func(ctx context.Context) error {
 			if dependencyBlockVolumePlanAvailable {
-				return s.bootstrapDependencyBlockVolumePlanInPersistentSandbox(ctx, adapter, sandboxID, dependencyBlockVolumePublishConfig{
+				var err error
+				dependencyPublishable, err = s.bootstrapDependencyBlockVolumePlanInPersistentSandbox(ctx, adapter, sandboxID, dependencyBlockVolumePublishConfig{
 					Adapter:    cacheOutputSnapshotAdapter,
 					Backend:    backendName,
 					Changeset:  changeset,
 					Repository: repository,
 				}, compiled, firecrackerCfg, repository, dependencyBlockVolumePlan, reporter)
+				return err
 			}
 			return s.bootstrapDependencyStageInPersistentSandbox(ctx, adapter, sandboxID, compiled, firecrackerCfg, dependencyStagePlan, reporter)
 		}); err != nil {
@@ -1119,6 +1139,9 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 				return nil, fmt.Errorf("bootstrap dependency stage: %w; cleanup failed: %v", err, terminateErr)
 			}
 			return nil, fmt.Errorf("bootstrap dependency stage: %w", err)
+		}
+		if dependencyBlockVolumePlanAvailable {
+			dependencyBlockVolumePublicationSafe = dependencyPublishable
 		}
 		if err := s.ensureSandboxCreateStillProvisioning(sandboxID); err != nil {
 			return nil, err
@@ -1151,12 +1174,17 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 		emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_SERVICES, "running services bootstrap")
 		if err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.bootstrap_services", bootstrapAttrs, func(ctx context.Context) error {
 			if serviceBlockVolumePlanAvailable {
-				return s.bootstrapServiceBlockVolumePlanInPersistentSandbox(ctx, adapter, sandboxID, serviceBlockVolumePublishConfig{
+				publishConfig := serviceBlockVolumePublishConfig{
 					Adapter:    cacheOutputSnapshotAdapter,
 					Backend:    backendName,
 					Changeset:  changeset,
 					Repository: repository,
-				}, compiled, firecrackerCfg, repository, serviceBlockVolumePlan, reporter)
+				}
+				if !dependencyBlockVolumePublicationSafe {
+					publishConfig.Adapter = nil
+				}
+				_, err := s.bootstrapServiceBlockVolumePlanInPersistentSandbox(ctx, adapter, sandboxID, publishConfig, compiled, firecrackerCfg, repository, serviceBlockVolumePlan, reporter)
+				return err
 			}
 			return s.bootstrapServicesStageInPersistentSandbox(ctx, adapter, sandboxID, compiled, firecrackerCfg, servicesStagePlan, reporter)
 		}); err != nil {

--- a/internal/controlservice/service_volume_execution.go
+++ b/internal/controlservice/service_volume_execution.go
@@ -34,11 +34,12 @@ func (s *Service) bootstrapServiceBlockVolumePlanInPersistentSandbox(
 	repository *repositorycheckout.Checkout,
 	plan serviceBlockVolumePlan,
 	reporter CreateSandboxReporter,
-) error {
+) (bool, error) {
 	if adapter == nil || compiled == nil || repository == nil || strings.TrimSpace(sandboxID) == "" || len(plan.Blocks) == 0 {
-		return nil
+		return true, nil
 	}
 
+	publishable := true
 	for _, block := range plan.Blocks {
 		blockName := strings.TrimSpace(block.BlockName)
 		if block.CacheHit {
@@ -57,12 +58,20 @@ func (s *Service) bootstrapServiceBlockVolumePlanInPersistentSandbox(
 		}
 
 		emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_SERVICES, "running service bootstrap: "+blockName)
+		var result *backend.ExecutionResult
 		if err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.bootstrap_service_block", attrs, func(ctx context.Context) error {
-			return s.bootstrapServiceBlockVolumeBlock(ctx, adapter, sandboxID, compiled, firecrackerCfg, repository, block, reporter)
+			var err error
+			result, err = s.bootstrapServiceBlockVolumeBlock(ctx, adapter, sandboxID, compiled, firecrackerCfg, repository, block, reporter)
+			return err
 		}); err != nil {
-			return fmt.Errorf("service block %q: %w", blockName, err)
+			return publishable, fmt.Errorf("service block %q: %w", blockName, err)
 		}
-		if publish.Adapter != nil {
+		if warning := blockVolumeEscapedWriteWarning("service", blockName, result); warning != "" {
+			publishable = false
+			emitCreateSandboxWarning(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_SERVICES, warning)
+			s.logServicesStageWarning("publish service block-volume caches", sandboxID, fmt.Errorf("%s", warning))
+		}
+		if publishable && publish.Adapter != nil {
 			emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_PUBLISH_SERVICES_STAGE_CACHE, "publishing service outputs: "+blockName)
 			s.maybePublishServiceBlockVolumeCaches(ctx, publish.Adapter, sandboxID, publish.Backend, compiled, firecrackerCfg, publish.Repository, publish.Changeset, serviceBlockVolumePlan{
 				ReuseNamespace:       plan.ReuseNamespace,
@@ -71,7 +80,7 @@ func (s *Service) bootstrapServiceBlockVolumePlanInPersistentSandbox(
 			})
 		}
 	}
-	return nil
+	return publishable, nil
 }
 
 func (s *Service) bootstrapServiceBlockVolumeBlock(
@@ -83,9 +92,9 @@ func (s *Service) bootstrapServiceBlockVolumeBlock(
 	repository *repositorycheckout.Checkout,
 	block serviceBlockVolumeBlockPlan,
 	reporter CreateSandboxReporter,
-) error {
+) (*backend.ExecutionResult, error) {
 	if len(block.Command) == 0 {
-		return nil
+		return nil, nil
 	}
 	sourceRoot := strings.TrimSpace(repository.DestinationDir)
 	if sourceRoot == "" {
@@ -117,5 +126,5 @@ func (s *Service) bootstrapServiceBlockVolumeBlock(
 		},
 		reporter,
 	)
-	return persistentBootstrapCommandError(result, stdout, stderr, err, "service block bootstrap returned no result", "service block bootstrap failed with exit code %d")
+	return result, persistentBootstrapCommandError(result, stdout, stderr, err, "service block bootstrap returned no result", "service block bootstrap failed with exit code %d")
 }

--- a/internal/controlservice/service_volume_plan_test.go
+++ b/internal/controlservice/service_volume_plan_test.go
@@ -927,7 +927,7 @@ func TestBootstrapServiceBlockVolumePlanRunsMissesFromInputProjection(t *testing
 		},
 	}
 	svc := newTestService(adapter)
-	err = svc.bootstrapServiceBlockVolumePlanInPersistentSandbox(
+	publishable, err := svc.bootstrapServiceBlockVolumePlanInPersistentSandbox(
 		context.Background(),
 		adapter,
 		"cr-test",
@@ -940,6 +940,9 @@ func TestBootstrapServiceBlockVolumePlanRunsMissesFromInputProjection(t *testing
 	)
 	if err != nil {
 		t.Fatalf("bootstrapServiceBlockVolumePlanInPersistentSandbox returned error: %v", err)
+	}
+	if !publishable {
+		t.Fatal("expected service block volume plan to remain publishable")
 	}
 	if got, want := len(gotReqs), 1; got != want {
 		t.Fatalf("unexpected run count: got %d want %d", got, want)
@@ -974,6 +977,139 @@ func TestBootstrapServiceBlockVolumePlanRunsMissesFromInputProjection(t *testing
 	}
 	if !req.InputProjection.MountSourceReadOnly {
 		t.Fatal("expected projection to be mounted read-only over source")
+	}
+}
+
+func TestBootstrapServiceBlockVolumePlanStopsPublishingAfterEscapedWrites(t *testing.T) {
+	compiled, err := policy.FromProto(testRepositoryTwoDependencyTwoServiceBlocksPolicy())
+	if err != nil {
+		t.Fatalf("policy.FromProto returned error: %v", err)
+	}
+	repository := repositorycheckout.FromProto(testRepositoryCheckoutProto())
+	plan := serviceBlockVolumePlan{
+		Blocks: []serviceBlockVolumeBlockPlan{
+			{
+				BlockName: "postgres-data",
+				Command:   append([]string(nil), compiled.Services.Blocks[0].Command...),
+				Env:       cloneDependencyBlockEnv(compiled.Services.Blocks[0].Env),
+				Inputs:    append([]string(nil), compiled.Services.Blocks[0].Inputs.Files...),
+				Outputs:   compiled.Services.Blocks[0].Outputs,
+				CacheKey:  "service-volume:postgres-data",
+			},
+			{
+				BlockName: "app-service",
+				Command:   append([]string(nil), compiled.Services.Blocks[1].Command...),
+				Env:       cloneDependencyBlockEnv(compiled.Services.Blocks[1].Env),
+				Inputs:    append([]string(nil), compiled.Services.Blocks[1].Inputs.Files...),
+				Outputs:   compiled.Services.Blocks[1].Outputs,
+				CacheKey:  "service-volume:app-service",
+			},
+		},
+	}
+
+	runCalls := 0
+	adapter := &stubAdapter{
+		runStreamFn: func(_ context.Context, req backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
+			runCalls++
+			result := &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0}
+			if runCalls == 1 {
+				result.OverlayCapture = &backend.OverlayCaptureResult{
+					EscapedWrites: []backend.OverlayCaptureEntry{{Path: "/usr/local/bin/tool", Kind: "write", Mode: 0o755}},
+				}
+			}
+			return result, nil
+		},
+		snapshotCacheOutputsFn: func(context.Context, backend.SnapshotCacheOutputVolumesRequest) (*backend.SnapshotCacheOutputVolumesResult, error) {
+			t.Fatal("did not expect service block-volume snapshot after escaped writes")
+			return nil, nil
+		},
+	}
+	svc := newTestService(adapter)
+	var warnings []string
+	publishable, err := svc.bootstrapServiceBlockVolumePlanInPersistentSandbox(
+		context.Background(),
+		adapter,
+		"cr-test",
+		serviceBlockVolumePublishConfig{Adapter: adapter, Backend: "firecracker", Repository: repository},
+		compiled,
+		backend.FirecrackerConfig{},
+		repository,
+		plan,
+		CreateSandboxReporterFuncs{OnWarning: func(_ cleanroomv1.CreateSandboxPhase, warning string) {
+			warnings = append(warnings, warning)
+		}},
+	)
+	if err != nil {
+		t.Fatalf("bootstrapServiceBlockVolumePlanInPersistentSandbox returned error: %v", err)
+	}
+	if publishable {
+		t.Fatal("expected service block volume plan to stop being publishable")
+	}
+	if got, want := runCalls, 2; got != want {
+		t.Fatalf("unexpected run count: got %d want %d", got, want)
+	}
+	if got := adapter.snapshotCacheOutputsCalls; got != 0 {
+		t.Fatalf("unexpected cache output snapshot calls: got %d", got)
+	}
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "/usr/local/bin/tool") {
+		t.Fatalf("expected escaped-write warning, got %v", warnings)
+	}
+}
+
+func TestCreateSandboxSkipsServiceBlockVolumePublicationAfterDependencyEscapedWrites(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	adapter := dependencyBlockVolumeRuntimeAdapter()
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"mise.toml":           "go = \"1.26.2\"\n",
+		"go.mod":              "module example.com/test\n\ngo 1.26.2\n",
+		"go.sum":              "example.com/test v0.0.0 h1:abc123\n",
+		"docker-compose.yml":  "services:\n  postgres:\n    image: postgres:17\n",
+		"db/schema.sql":       "create table widgets (id serial primary key);\n",
+		"db/seed.sql":         "insert into widgets default values;\n",
+		"scripts/prepare-db":  "#!/bin/sh\ntrue\n",
+		"scripts/prepare-app": "#!/bin/sh\ntrue\n",
+	})
+	svc := newTestService(adapter)
+	svc.RepositoryStore = mirrors
+	cacheStore := newMemoryCacheStore()
+	svc.CacheStore = cacheStore
+
+	dependencyEscaped := false
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
+		result := &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0}
+		if req.NetworkStage == policy.NetworkStageDependencies && req.ClosedEnv && !dependencyEscaped {
+			dependencyEscaped = true
+			result.OverlayCapture = &backend.OverlayCaptureResult{
+				EscapedWrites: []backend.OverlayCaptureEntry{{Path: "/etc/profile", Kind: "write", Mode: 0o644}},
+			}
+		}
+		return result, nil
+	}
+	adapter.snapshotCacheOutputsFn = func(context.Context, backend.SnapshotCacheOutputVolumesRequest) (*backend.SnapshotCacheOutputVolumesResult, error) {
+		t.Fatal("did not expect dependency or service block-volume snapshots after dependency escaped writes")
+		return nil, nil
+	}
+
+	if _, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Policy:             testRepositoryTwoDependencyTwoServiceBlocksPolicy(),
+		RepositoryCheckout: repositoryCheckout,
+	}); err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	if !dependencyEscaped {
+		t.Fatal("expected dependency block execution to report escaped writes")
+	}
+	if got := adapter.snapshotCacheOutputsCalls; got != 0 {
+		t.Fatalf("unexpected cache output snapshot calls: got %d", got)
+	}
+	records, err := cacheStore.List(context.Background())
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	for _, record := range records {
+		if record.Stage == dependencyVolumeStageName || record.Stage == serviceVolumeStageName {
+			t.Fatalf("did not expect block-volume cache record after dependency escaped writes, got %#v", record)
+		}
 	}
 }
 


### PR DESCRIPTION
## What this is part of

This is another control-service slice of `docs/plans/dependency-service-volume-caches.md`. The block-volume path can only publish reusable dependency/service records when the block run did not leave persistent state outside declared outputs.

The guest/backend overlay-capture plumbing already has a way to return escaped-write entries. This PR teaches the dependency and service block runners what to do with that signal before we advertise `sandbox.overlay_write_capture` on real backends.

## What changed

- Dependency and service block runners now inspect `ExecutionResult.OverlayCapture.EscapedWrites` after a successful block command.
- If escaped writes are present, Cleanroom emits a create warning and disables block-volume publication for that block and later blocks in the same plan.
- If dependency block publication becomes unsafe, service block-volume publication is also disabled for the same create, so downstream service records are not derived from undeclared dependency state.
- The current sandbox still keeps running. This is a publication gate only; the guest overlay runner and exact fallback/restart behavior remain separate later slices.

## Validation

- `GOCACHE=/private/tmp/cleanroom-go-build-cache mise exec -- go test -count=1 ./internal/controlservice`
- `GOCACHE=/private/tmp/cleanroom-go-build-cache mise exec -- go test ./...`
- `docker run --rm -v "$PWD":/work -v /Users/lachlan/Develop/cleanroom/.git:/Users/lachlan/Develop/cleanroom/.git:ro -w /work -e GOCACHE=/tmp/go-build-cache golang:1.26.2 go test ./...`
