### PR TITLE
feat: Request overlay capture for block volume misses

### DIFF
--- a/internal/controlservice/block_volume_overlay_capture.go
+++ b/internal/controlservice/block_volume_overlay_capture.go
@@ -1,0 +1,29 @@
+package controlservice
+
+import (
+	"path/filepath"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/policy"
+)
+
+const blockVolumeOverlayCaptureRoot = "/run/cleanroom/overlay-captures"
+
+var blockVolumeOverlayCaptureIgnoredPrefixes = []string{"/tmp", "/var/tmp", "/run"}
+
+func dependencyBlockVolumeOverlayCapture(block dependencyBlockVolumeBlockPlan) *backend.OverlayCapture {
+	return blockVolumeOverlayCapture(dependencyVolumeStageName, block.CacheKey, block.Outputs)
+}
+
+func serviceBlockVolumeOverlayCapture(block serviceBlockVolumeBlockPlan) *backend.OverlayCapture {
+	return blockVolumeOverlayCapture(serviceVolumeStageName, block.CacheKey, block.Outputs)
+}
+
+func blockVolumeOverlayCapture(stage, cacheKey string, outputs policy.StageBlockOutputs) *backend.OverlayCapture {
+	return &backend.OverlayCapture{
+		UpperDir:            filepath.Join(blockVolumeOverlayCaptureRoot, blockVolumeID(stage, cacheKey), "upper"),
+		BaselinePaths:       append([]string(nil), outputs.Dirs...),
+		DeclaredFileOutputs: append([]string(nil), outputs.Files...),
+		IgnoredPrefixes:     append([]string(nil), blockVolumeOverlayCaptureIgnoredPrefixes...),
+	}
+}

--- a/internal/controlservice/bootstrap_runner.go
+++ b/internal/controlservice/bootstrap_runner.go
@@ -31,6 +31,7 @@ type persistentSandboxCommandOptions struct {
 	ClosedEnv               bool
 	InputProjection         *backend.InputProjection
 	CacheOutputFileCaptures []backend.CacheOutputFileCapture
+	OverlayCapture          *backend.OverlayCapture
 }
 
 func (s *Service) runPersistentSandboxCommandWithOptions(
@@ -55,10 +56,23 @@ func (s *Service) runPersistentSandboxCommandWithOptions(
 		ClosedEnv:               opts.ClosedEnv,
 		InputProjection:         cloneInputProjection(opts.InputProjection),
 		CacheOutputFileCaptures: cloneCacheOutputFileCaptures(opts.CacheOutputFileCaptures),
+		OverlayCapture:          cloneOverlayCapture(opts.OverlayCapture),
 		Policy:                  compiled,
 		NetworkStage:            networkStage,
 		FirecrackerConfig:       withRunDir(firecrackerCfg, internalBootstrapArtifactsDir(sandboxID, executionID)),
 	}, stream)
+}
+
+func cloneOverlayCapture(capture *backend.OverlayCapture) *backend.OverlayCapture {
+	if capture == nil {
+		return nil
+	}
+	return &backend.OverlayCapture{
+		UpperDir:            capture.UpperDir,
+		BaselinePaths:       append([]string(nil), capture.BaselinePaths...),
+		DeclaredFileOutputs: append([]string(nil), capture.DeclaredFileOutputs...),
+		IgnoredPrefixes:     append([]string(nil), capture.IgnoredPrefixes...),
+	}
 }
 
 func cloneCacheOutputFileCaptures(captures []backend.CacheOutputFileCapture) []backend.CacheOutputFileCapture {

--- a/internal/controlservice/dependency_volume_execution.go
+++ b/internal/controlservice/dependency_volume_execution.go
@@ -123,6 +123,7 @@ func (s *Service) bootstrapDependencyBlockVolumeBlock(
 			ClosedEnv:               true,
 			InputProjection:         inputProjection,
 			CacheOutputFileCaptures: dependencyBlockVolumeFileCaptures(block),
+			OverlayCapture:          dependencyBlockVolumeOverlayCapture(block),
 		},
 		reporter,
 	)

--- a/internal/controlservice/dependency_volume_plan_test.go
+++ b/internal/controlservice/dependency_volume_plan_test.go
@@ -747,6 +747,8 @@ func TestBootstrapDependencyBlockVolumePlanRunsMissesFromInputProjection(t *test
 				Command:   append([]string(nil), compiled.Dependencies.Blocks[1].Command...),
 				Env:       cloneDependencyBlockEnv(compiled.Dependencies.Blocks[1].Env),
 				Inputs:    append([]string(nil), compiled.Dependencies.Blocks[1].Inputs.Files...),
+				Outputs:   compiled.Dependencies.Blocks[1].Outputs,
+				CacheKey:  "dependency-volume:go-modules",
 			},
 		},
 	}
@@ -806,6 +808,21 @@ func TestBootstrapDependencyBlockVolumePlanRunsMissesFromInputProjection(t *test
 	}
 	if !req.InputProjection.MountSourceReadOnly {
 		t.Fatal("expected projection to be mounted read-only over source")
+	}
+	if req.OverlayCapture == nil {
+		t.Fatal("expected overlay capture request")
+	}
+	if got, want := req.OverlayCapture.UpperDir, filepath.Join(blockVolumeOverlayCaptureRoot, blockVolumeID(dependencyVolumeStageName, plan.Blocks[1].CacheKey), "upper"); got != want {
+		t.Fatalf("unexpected overlay capture upper dir: got %q want %q", got, want)
+	}
+	if !slices.Equal(req.OverlayCapture.BaselinePaths, plan.Blocks[1].Outputs.Dirs) {
+		t.Fatalf("unexpected overlay capture baseline paths: got %v want %v", req.OverlayCapture.BaselinePaths, plan.Blocks[1].Outputs.Dirs)
+	}
+	if !slices.Equal(req.OverlayCapture.DeclaredFileOutputs, plan.Blocks[1].Outputs.Files) {
+		t.Fatalf("unexpected overlay capture file outputs: got %v want %v", req.OverlayCapture.DeclaredFileOutputs, plan.Blocks[1].Outputs.Files)
+	}
+	if !slices.Equal(req.OverlayCapture.IgnoredPrefixes, blockVolumeOverlayCaptureIgnoredPrefixes) {
+		t.Fatalf("unexpected overlay capture ignored prefixes: got %v want %v", req.OverlayCapture.IgnoredPrefixes, blockVolumeOverlayCaptureIgnoredPrefixes)
 	}
 }
 

--- a/internal/controlservice/service_volume_execution.go
+++ b/internal/controlservice/service_volume_execution.go
@@ -123,6 +123,7 @@ func (s *Service) bootstrapServiceBlockVolumeBlock(
 			ClosedEnv:               true,
 			InputProjection:         inputProjection,
 			CacheOutputFileCaptures: serviceBlockVolumeFileCaptures(block),
+			OverlayCapture:          serviceBlockVolumeOverlayCapture(block),
 		},
 		reporter,
 	)

--- a/internal/controlservice/service_volume_plan_test.go
+++ b/internal/controlservice/service_volume_plan_test.go
@@ -2,6 +2,7 @@ package controlservice
 
 import (
 	"context"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
@@ -915,6 +916,8 @@ func TestBootstrapServiceBlockVolumePlanRunsMissesFromInputProjection(t *testing
 				Command:   append([]string(nil), compiled.Services.Blocks[1].Command...),
 				Env:       cloneDependencyBlockEnv(compiled.Services.Blocks[1].Env),
 				Inputs:    append([]string(nil), compiled.Services.Blocks[1].Inputs.Files...),
+				Outputs:   compiled.Services.Blocks[1].Outputs,
+				CacheKey:  "service-volume:app-service",
 			},
 		},
 	}
@@ -977,6 +980,21 @@ func TestBootstrapServiceBlockVolumePlanRunsMissesFromInputProjection(t *testing
 	}
 	if !req.InputProjection.MountSourceReadOnly {
 		t.Fatal("expected projection to be mounted read-only over source")
+	}
+	if req.OverlayCapture == nil {
+		t.Fatal("expected overlay capture request")
+	}
+	if got, want := req.OverlayCapture.UpperDir, filepath.Join(blockVolumeOverlayCaptureRoot, blockVolumeID(serviceVolumeStageName, plan.Blocks[1].CacheKey), "upper"); got != want {
+		t.Fatalf("unexpected overlay capture upper dir: got %q want %q", got, want)
+	}
+	if !slices.Equal(req.OverlayCapture.BaselinePaths, plan.Blocks[1].Outputs.Dirs) {
+		t.Fatalf("unexpected overlay capture baseline paths: got %v want %v", req.OverlayCapture.BaselinePaths, plan.Blocks[1].Outputs.Dirs)
+	}
+	if !slices.Equal(req.OverlayCapture.DeclaredFileOutputs, plan.Blocks[1].Outputs.Files) {
+		t.Fatalf("unexpected overlay capture file outputs: got %v want %v", req.OverlayCapture.DeclaredFileOutputs, plan.Blocks[1].Outputs.Files)
+	}
+	if !slices.Equal(req.OverlayCapture.IgnoredPrefixes, blockVolumeOverlayCaptureIgnoredPrefixes) {
+		t.Fatalf("unexpected overlay capture ignored prefixes: got %v want %v", req.OverlayCapture.IgnoredPrefixes, blockVolumeOverlayCaptureIgnoredPrefixes)
 	}
 }
 


### PR DESCRIPTION
## What this is part of

This is a small runtime-boundary slice of `docs/plans/dependency-service-volume-caches.md`. The previous PR taught the control service to stop publishing block-volume records when an execution result reports escaped writes. This PR makes missed dependency/service block executions carry the overlay-capture request that will feed that gate.

## What changed

- Adds a managed overlay-capture request builder for dependency and service block-volume misses.
- Uses a deterministic upperdir under `/run/cleanroom/overlay-captures/<volume-id>/upper`.
- Allows declared `outputs.files` and declared output directory mountpoints in the escaped-write scanner inputs.
- Ignores scratch prefixes `/tmp`, `/var/tmp`, and `/run` in the capture request.
- Clones the request through the persistent bootstrap runner before it reaches the backend execution request.

Real Firecracker and darwin-vz still do not advertise `sandbox.overlay_write_capture`. The guest overlay runner still needs to create/clear this upperdir and execute the command through the overlay view before those backends can safely advertise the capability.

## Validation

- `GOCACHE=/private/tmp/cleanroom-go-build-cache mise exec -- go test -count=1 ./internal/controlservice`
- `GOCACHE=/private/tmp/cleanroom-go-build-cache mise exec -- go test ./...`
- `docker run --rm -v "$PWD":/work -v /Users/lachlan/Develop/cleanroom/.git:/Users/lachlan/Develop/cleanroom/.git:ro -w /work -e GOCACHE=/tmp/go-build-cache golang:1.26.2 go test ./...`
