### PR TITLE
feat: Add guest overlay capture runner

### DIFF
--- a/cmd/cleanroom-guest-agent/cache_output_mounts.go
+++ b/cmd/cleanroom-guest-agent/cache_output_mounts.go
@@ -532,7 +532,7 @@ func cacheOutputCaptureSourcePath(guestPath, sourceRoot string) (string, error) 
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(sourceRoot, strings.TrimPrefix(guestPath, string(filepath.Separator))), nil
+	return resolveOverlayCaptureGuestTarget(sourceRoot, guestPath, 0)
 }
 
 func cacheOutputMaterializationTarget(root, guestPath string) (string, error) {

--- a/cmd/cleanroom-guest-agent/cache_output_mounts.go
+++ b/cmd/cleanroom-guest-agent/cache_output_mounts.go
@@ -462,16 +462,16 @@ func restoreCacheOutputFileFrom(source *os.File, sourcePath, targetPath string, 
 	return nil
 }
 
-func captureCacheOutputFiles(captures []vsockexec.CacheOutputFileCapture) error {
+func captureCacheOutputFiles(captures []vsockexec.CacheOutputFileCapture, sourceRoot string) error {
 	for i, capture := range captures {
-		if err := captureCacheOutputFile(capture); err != nil {
+		if err := captureCacheOutputFile(capture, sourceRoot); err != nil {
 			return fmt.Errorf("capture cache output file %d: %w", i, err)
 		}
 	}
 	return nil
 }
 
-func captureCacheOutputFile(capture vsockexec.CacheOutputFileCapture) error {
+func captureCacheOutputFile(capture vsockexec.CacheOutputFileCapture, sourceRoot string) error {
 	guestPath, err := cleanAbsoluteCacheOutputPath("guest path", capture.GuestPath)
 	if err != nil {
 		return err
@@ -488,7 +488,11 @@ func captureCacheOutputFile(capture vsockexec.CacheOutputFileCapture) error {
 		return err
 	}
 
-	source, err := openCacheOutputCaptureSource(guestPath)
+	sourcePath, err := cacheOutputCaptureSourcePath(guestPath, sourceRoot)
+	if err != nil {
+		return err
+	}
+	source, err := openCacheOutputCaptureSource(sourcePath)
 	if err != nil {
 		return err
 	}
@@ -503,7 +507,28 @@ func captureCacheOutputFile(capture vsockexec.CacheOutputFileCapture) error {
 			return err
 		}
 	}
-	return copyCacheOutputFile(source, guestPath, filepath.Join(targetDir, filepath.Base(subpath)), fs.FileMode(capture.Mode).Perm())
+	if err := copyCacheOutputFile(source, sourcePath, filepath.Join(targetDir, filepath.Base(subpath)), fs.FileMode(capture.Mode).Perm()); err != nil {
+		return err
+	}
+	if strings.TrimSpace(sourceRoot) == "" {
+		return nil
+	}
+	if _, err := source.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("rewind cache output file source %s: %w", sourcePath, err)
+	}
+	return copyCacheOutputFileWithParentMode(source, sourcePath, guestPath, fs.FileMode(capture.Mode).Perm(), false)
+}
+
+func cacheOutputCaptureSourcePath(guestPath, sourceRoot string) (string, error) {
+	sourceRoot = strings.TrimSpace(sourceRoot)
+	if sourceRoot == "" {
+		return guestPath, nil
+	}
+	sourceRoot, err := cleanAbsoluteCacheOutputPath("source root", sourceRoot)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(sourceRoot, strings.TrimPrefix(guestPath, string(filepath.Separator))), nil
 }
 
 func openCacheOutputCaptureSource(path string) (*os.File, error) {
@@ -525,6 +550,10 @@ func openCacheOutputCaptureSource(path string) (*os.File, error) {
 }
 
 func copyCacheOutputFile(source *os.File, sourcePath, targetPath string, mode fs.FileMode) error {
+	return copyCacheOutputFileWithParentMode(source, sourcePath, targetPath, mode, true)
+}
+
+func copyCacheOutputFileWithParentMode(source *os.File, sourcePath, targetPath string, mode fs.FileMode, requireParent bool) error {
 	info, err := source.Stat()
 	if err != nil {
 		return fmt.Errorf("stat cache output file source %s: %w", sourcePath, err)
@@ -540,7 +569,7 @@ func copyCacheOutputFile(source *os.File, sourcePath, targetPath string, mode fs
 	}
 
 	targetDir := filepath.Dir(targetPath)
-	if err := ensureCacheOutputDir(targetDir, 0o755, true, false); err != nil {
+	if err := ensureCacheOutputDir(targetDir, 0o755, requireParent, false); err != nil {
 		return err
 	}
 	tmp, err := os.CreateTemp(targetDir, "."+filepath.Base(targetPath)+".cleanroom-cache-capture-*")

--- a/cmd/cleanroom-guest-agent/cache_output_mounts.go
+++ b/cmd/cleanroom-guest-agent/cache_output_mounts.go
@@ -516,7 +516,11 @@ func captureCacheOutputFile(capture vsockexec.CacheOutputFileCapture, sourceRoot
 	if _, err := source.Seek(0, io.SeekStart); err != nil {
 		return fmt.Errorf("rewind cache output file source %s: %w", sourcePath, err)
 	}
-	return copyCacheOutputFileWithParentMode(source, sourcePath, guestPath, fs.FileMode(capture.Mode).Perm(), false)
+	targetPath, err := cacheOutputMaterializationTarget(string(filepath.Separator), guestPath)
+	if err != nil {
+		return err
+	}
+	return copyCacheOutputFileWithParentMode(source, sourcePath, targetPath, fs.FileMode(capture.Mode).Perm(), false)
 }
 
 func cacheOutputCaptureSourcePath(guestPath, sourceRoot string) (string, error) {
@@ -529,6 +533,10 @@ func cacheOutputCaptureSourcePath(guestPath, sourceRoot string) (string, error) 
 		return "", err
 	}
 	return filepath.Join(sourceRoot, strings.TrimPrefix(guestPath, string(filepath.Separator))), nil
+}
+
+func cacheOutputMaterializationTarget(root, guestPath string) (string, error) {
+	return resolveOverlayCaptureGuestTarget(root, guestPath, 0)
 }
 
 func openCacheOutputCaptureSource(path string) (*os.File, error) {

--- a/cmd/cleanroom-guest-agent/cache_output_mounts_test.go
+++ b/cmd/cleanroom-guest-agent/cache_output_mounts_test.go
@@ -373,6 +373,26 @@ func TestCaptureCacheOutputFilesReadsFromOverlayAndMaterializesGuestFile(t *test
 	}
 }
 
+func TestCacheOutputMaterializationTargetResolvesAbsoluteSymlinkInsideRoot(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "var"), 0o755); err != nil {
+		t.Fatalf("create var: %v", err)
+	}
+	if err := os.Symlink("/run", filepath.Join(root, "var", "run")); err != nil {
+		t.Fatalf("create var/run symlink: %v", err)
+	}
+
+	got, err := cacheOutputMaterializationTarget(root, "/var/run/tool/index.json")
+	if err != nil {
+		t.Fatalf("cacheOutputMaterializationTarget returned error: %v", err)
+	}
+	if want := filepath.Join(root, "run", "tool", "index.json"); got != want {
+		t.Fatalf("unexpected target: got %q want %q", got, want)
+	}
+}
+
 func TestSetupCacheOutputMountsOnceRejectsChangedPlan(t *testing.T) {
 	cacheOutputMountState.Lock()
 	previousSignature := cacheOutputMountState.signature

--- a/cmd/cleanroom-guest-agent/cache_output_mounts_test.go
+++ b/cmd/cleanroom-guest-agent/cache_output_mounts_test.go
@@ -265,7 +265,7 @@ func TestCaptureCacheOutputFilesCopiesDeclaredOutputToVolume(t *testing.T) {
 			Subpath:   "files/0",
 			Mode:      0o600,
 		},
-	})
+	}, "")
 	if err != nil {
 		t.Fatalf("captureCacheOutputFiles returned error: %v", err)
 	}
@@ -305,7 +305,7 @@ func TestCaptureCacheOutputFilesRequiresRegularSource(t *testing.T) {
 			MountPath: mountPath,
 			Subpath:   "files/0",
 		},
-	})
+	}, "")
 	if err == nil {
 		t.Fatal("expected symlink source to fail")
 	}
@@ -326,9 +326,50 @@ func TestCaptureCacheOutputFilesRequiresSource(t *testing.T) {
 			MountPath: mountPath,
 			Subpath:   "files/0",
 		},
-	})
+	}, "")
 	if err == nil {
 		t.Fatal("expected missing source to fail")
+	}
+}
+
+func TestCaptureCacheOutputFilesReadsFromOverlayAndMaterializesGuestFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	overlayRoot := filepath.Join(dir, "merged")
+	guestPath := filepath.Join(dir, "guest", "root", ".cache", "tool", "index.json")
+	overlaySource := filepath.Join(overlayRoot, strings.TrimPrefix(guestPath, string(filepath.Separator)))
+	if err := os.MkdirAll(filepath.Dir(overlaySource), 0o755); err != nil {
+		t.Fatalf("create overlay source parent: %v", err)
+	}
+	if err := os.WriteFile(overlaySource, []byte("index"), 0o644); err != nil {
+		t.Fatalf("write overlay source: %v", err)
+	}
+	mountPath := filepath.Join(dir, "volume")
+	if err := os.MkdirAll(mountPath, 0o755); err != nil {
+		t.Fatalf("create mount path: %v", err)
+	}
+
+	err := captureCacheOutputFiles([]vsockexec.CacheOutputFileCapture{
+		{
+			GuestPath: guestPath,
+			MountPath: mountPath,
+			Subpath:   "files/0",
+			Mode:      0o600,
+		},
+	}, overlayRoot)
+	if err != nil {
+		t.Fatalf("captureCacheOutputFiles returned error: %v", err)
+	}
+	if data, err := os.ReadFile(filepath.Join(mountPath, "files", "0")); err != nil {
+		t.Fatalf("read captured file: %v", err)
+	} else if got, want := string(data), "index"; got != want {
+		t.Fatalf("unexpected captured data: got %q want %q", got, want)
+	}
+	if data, err := os.ReadFile(guestPath); err != nil {
+		t.Fatalf("read materialized guest file: %v", err)
+	} else if got, want := string(data), "index"; got != want {
+		t.Fatalf("unexpected materialized data: got %q want %q", got, want)
 	}
 }
 

--- a/cmd/cleanroom-guest-agent/cache_output_mounts_test.go
+++ b/cmd/cleanroom-guest-agent/cache_output_mounts_test.go
@@ -393,6 +393,26 @@ func TestCacheOutputMaterializationTargetResolvesAbsoluteSymlinkInsideRoot(t *te
 	}
 }
 
+func TestCacheOutputCaptureSourcePathResolvesAbsoluteSymlinkInsideSourceRoot(t *testing.T) {
+	t.Parallel()
+
+	sourceRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(sourceRoot, "var"), 0o755); err != nil {
+		t.Fatalf("create var: %v", err)
+	}
+	if err := os.Symlink("/run", filepath.Join(sourceRoot, "var", "run")); err != nil {
+		t.Fatalf("create var/run symlink: %v", err)
+	}
+
+	got, err := cacheOutputCaptureSourcePath("/var/run/tool/index.json", sourceRoot)
+	if err != nil {
+		t.Fatalf("cacheOutputCaptureSourcePath returned error: %v", err)
+	}
+	if want := filepath.Join(sourceRoot, "run", "tool", "index.json"); got != want {
+		t.Fatalf("unexpected source: got %q want %q", got, want)
+	}
+}
+
 func TestSetupCacheOutputMountsOnceRejectsChangedPlan(t *testing.T) {
 	cacheOutputMountState.Lock()
 	previousSignature := cacheOutputMountState.signature

--- a/cmd/cleanroom-guest-agent/input_projection.go
+++ b/cmd/cleanroom-guest-agent/input_projection.go
@@ -301,13 +301,12 @@ func bindInputProjectionOverSource(sourceRoot, targetRoot string) (func(), error
 		return nil, fmt.Errorf("open current mount namespace: %w", err)
 	}
 	cleanup := func() {
+		defer runtime.UnlockOSThread()
+		defer oldNS.Close()
 		if err := unix.Setns(int(oldNS.Fd()), unix.CLONE_NEWNS); err != nil {
 			fmt.Fprintf(os.Stderr, "restore input projection mount namespace: %v\n", err)
-			_ = oldNS.Close()
 			return
 		}
-		_ = oldNS.Close()
-		runtime.UnlockOSThread()
 	}
 
 	if err := unix.Unshare(unix.CLONE_NEWNS); err != nil {

--- a/cmd/cleanroom-guest-agent/main.go
+++ b/cmd/cleanroom-guest-agent/main.go
@@ -199,6 +199,9 @@ func newGuestCommand(req vsockexec.ExecRequest, overlayRoot string) *exec.Cmd {
 	}
 	if strings.TrimSpace(overlayRoot) != "" {
 		cmd.SysProcAttr = &syscall.SysProcAttr{Chroot: overlayRoot}
+		if strings.TrimSpace(cmd.Dir) == "" {
+			cmd.Dir = "/"
+		}
 	}
 	return cmd
 }

--- a/cmd/cleanroom-guest-agent/main.go
+++ b/cmd/cleanroom-guest-agent/main.go
@@ -199,8 +199,11 @@ func newGuestCommand(req vsockexec.ExecRequest, overlayRoot string) *exec.Cmd {
 	}
 	if strings.TrimSpace(overlayRoot) != "" {
 		cmd.SysProcAttr = &syscall.SysProcAttr{Chroot: overlayRoot}
-		if strings.TrimSpace(cmd.Dir) == "" {
+		reqDir := strings.TrimSpace(req.Dir)
+		if reqDir == "" {
 			cmd.Dir = "/"
+		} else if !filepath.IsAbs(reqDir) {
+			cmd.Dir = filepath.Clean(string(filepath.Separator) + reqDir)
 		}
 	}
 	return cmd

--- a/cmd/cleanroom-guest-agent/main.go
+++ b/cmd/cleanroom-guest-agent/main.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"unsafe"
 
 	"github.com/buildkite/cleanroom/internal/gateway"
@@ -89,19 +90,22 @@ func handleConn(conn io.ReadWriteCloser) {
 	}
 	defer cleanupInputProjection()
 	req = projectedReq
+	overlayRoot, cleanupOverlayCapture, err := setupOverlayCapture(req)
+	if err != nil {
+		sendErrorResponse(conn, err)
+		return
+	}
+	defer cleanupOverlayCapture()
 
 	if req.TTY {
-		handleConnTTY(conn, dec, req)
+		handleConnTTY(conn, dec, req, overlayRoot)
 	} else {
-		handleConnPipes(conn, dec, req)
+		handleConnPipes(conn, dec, req, overlayRoot)
 	}
 }
 
-func handleConnTTY(conn io.ReadWriteCloser, dec *json.Decoder, req vsockexec.ExecRequest) {
-	cmd := exec.Command(req.Command[0], req.Command[1:]...)
-	if req.Dir != "" {
-		cmd.Dir = req.Dir
-	}
+func handleConnTTY(conn io.ReadWriteCloser, dec *json.Decoder, req vsockexec.ExecRequest, overlayRoot string) {
+	cmd := newGuestCommand(req, overlayRoot)
 	env, err := buildCommandEnv(req.Env, !req.ClosedEnv)
 	if err != nil {
 		sendErrorResponse(conn, err)
@@ -130,16 +134,13 @@ func handleConnTTY(conn io.ReadWriteCloser, dec *json.Decoder, req vsockexec.Exe
 
 	waitErr := cmd.Wait()
 	if waitErr == nil {
-		waitErr = captureCacheOutputFiles(req.CacheOutputFileCaptures)
+		waitErr = captureCacheOutputFiles(req.CacheOutputFileCaptures, overlayRoot)
 	}
 	sendExitResult(sender, waitErr, req.OverlayCapture)
 }
 
-func handleConnPipes(conn io.ReadWriteCloser, dec *json.Decoder, req vsockexec.ExecRequest) {
-	cmd := exec.Command(req.Command[0], req.Command[1:]...)
-	if req.Dir != "" {
-		cmd.Dir = req.Dir
-	}
+func handleConnPipes(conn io.ReadWriteCloser, dec *json.Decoder, req vsockexec.ExecRequest, overlayRoot string) {
+	cmd := newGuestCommand(req, overlayRoot)
 	env, err := buildCommandEnv(req.Env, !req.ClosedEnv)
 	if err != nil {
 		sendErrorResponse(conn, err)
@@ -186,9 +187,20 @@ func handleConnPipes(conn io.ReadWriteCloser, dec *json.Decoder, req vsockexec.E
 	wg.Wait()
 	waitErr := cmd.Wait()
 	if waitErr == nil {
-		waitErr = captureCacheOutputFiles(req.CacheOutputFileCaptures)
+		waitErr = captureCacheOutputFiles(req.CacheOutputFileCaptures, overlayRoot)
 	}
 	sendExitResult(sender, waitErr, req.OverlayCapture)
+}
+
+func newGuestCommand(req vsockexec.ExecRequest, overlayRoot string) *exec.Cmd {
+	cmd := exec.Command(req.Command[0], req.Command[1:]...)
+	if req.Dir != "" {
+		cmd.Dir = req.Dir
+	}
+	if strings.TrimSpace(overlayRoot) != "" {
+		cmd.SysProcAttr = &syscall.SysProcAttr{Chroot: overlayRoot}
+	}
+	return cmd
 }
 
 func readInputFrames(dec *json.Decoder, w io.Writer, closeStdin func(), resizeFn func(cols, rows uint16)) {

--- a/cmd/cleanroom-guest-agent/overlay_capture.go
+++ b/cmd/cleanroom-guest-agent/overlay_capture.go
@@ -156,19 +156,42 @@ func prepareOverlayCaptureLayout(layout overlayCaptureLayout) error {
 }
 
 func bindOverlayCaptureInputProjection(req vsockexec.ExecRequest, mergedRoot string, mounted *[]string) error {
+	source, target, readOnly, ok, err := overlayCaptureInputProjectionBind(req, mergedRoot)
+	if err != nil || !ok {
+		return err
+	}
+	return bindOverlayCapturePath(source, target, readOnly, mounted)
+}
+
+func overlayCaptureInputProjectionBind(req vsockexec.ExecRequest, mergedRoot string) (string, string, bool, bool, error) {
 	projection := req.InputProjection
-	if projection == nil || !projection.MountSourceReadOnly {
-		return nil
+	if projection == nil {
+		return "", "", false, false, nil
 	}
-	sourceRoot, err := cleanOverlayCaptureAbsolutePath("input projection source root", projection.SourceRoot)
+	source := ""
+	targetGuestPath := ""
+	readOnly := false
+	if projection.MountSourceReadOnly {
+		sourceRoot, err := cleanOverlayCaptureAbsolutePath("input projection source root", projection.SourceRoot)
+		if err != nil {
+			return "", "", false, false, err
+		}
+		source = sourceRoot
+		targetGuestPath = sourceRoot
+		readOnly = true
+	} else {
+		targetRoot, err := cleanOverlayCaptureAbsolutePath("input projection target root", projection.TargetRoot)
+		if err != nil {
+			return "", "", false, false, err
+		}
+		source = targetRoot
+		targetGuestPath = targetRoot
+	}
+	target, err := overlayCaptureGuestTarget(mergedRoot, targetGuestPath)
 	if err != nil {
-		return err
+		return "", "", false, false, err
 	}
-	target, err := overlayCaptureGuestTarget(mergedRoot, sourceRoot)
-	if err != nil {
-		return err
-	}
-	return bindOverlayCapturePath(sourceRoot, target, true, mounted)
+	return source, target, readOnly, true, nil
 }
 
 func bindOverlayCaptureGuestPath(mergedRoot, guestPath string, readOnly bool, mounted *[]string) error {

--- a/cmd/cleanroom-guest-agent/overlay_capture.go
+++ b/cmd/cleanroom-guest-agent/overlay_capture.go
@@ -3,11 +3,253 @@
 package main
 
 import (
+	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
 
 	"github.com/buildkite/cleanroom/internal/overlaycapture"
 	"github.com/buildkite/cleanroom/internal/vsockexec"
+	"golang.org/x/sys/unix"
 )
+
+type overlayCaptureLayout struct {
+	BaseDir    string
+	UpperDir   string
+	WorkDir    string
+	MergedRoot string
+}
+
+var overlayCaptureRoot = "/run/cleanroom/overlay-captures"
+var overlayCaptureVirtualMounts = []string{"/dev", "/proc", "/sys"}
+var overlayCaptureScratchMounts = []struct {
+	Path string
+	Data string
+}{
+	{Path: "/tmp", Data: "mode=1777"},
+	{Path: "/var/tmp", Data: "mode=1777"},
+	{Path: "/run", Data: "mode=0755"},
+}
+
+func setupOverlayCapture(req vsockexec.ExecRequest) (string, func(), error) {
+	capture := req.OverlayCapture
+	if capture == nil {
+		return "", func() {}, nil
+	}
+
+	layout, err := newOverlayCaptureLayout(capture.UpperDir)
+	if err != nil {
+		return "", nil, err
+	}
+	namespaceCleanup, err := enterOverlayCaptureMountNamespace()
+	if err != nil {
+		return "", nil, err
+	}
+	mounted := []string{}
+	cleanup := func() {
+		for i := len(mounted) - 1; i >= 0; i-- {
+			_ = unix.Unmount(mounted[i], unix.MNT_DETACH)
+		}
+		_ = os.RemoveAll(layout.WorkDir)
+		_ = os.RemoveAll(layout.MergedRoot)
+		namespaceCleanup()
+	}
+
+	if err := prepareOverlayCaptureLayout(layout); err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	overlayData := fmt.Sprintf("lowerdir=/,upperdir=%s,workdir=%s", layout.UpperDir, layout.WorkDir)
+	if err := unix.Mount("cleanroom-overlay-capture", layout.MergedRoot, "overlay", 0, overlayData); err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("mount overlay capture root %s: %w", layout.MergedRoot, err)
+	}
+	mounted = append(mounted, layout.MergedRoot)
+
+	for _, scratch := range overlayCaptureScratchMounts {
+		if err := mountOverlayCaptureScratchPath(layout.MergedRoot, scratch.Path, scratch.Data, &mounted); err != nil {
+			cleanup()
+			return "", nil, err
+		}
+	}
+	if err := bindOverlayCaptureInputProjection(req, layout.MergedRoot, &mounted); err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	for _, guestPath := range capture.BaselinePaths {
+		if err := bindOverlayCaptureGuestPath(layout.MergedRoot, guestPath, false, &mounted); err != nil {
+			cleanup()
+			return "", nil, err
+		}
+	}
+	for _, guestPath := range overlayCaptureVirtualMounts {
+		if err := bindOverlayCaptureGuestPath(layout.MergedRoot, guestPath, false, &mounted); err != nil && !errors.Is(err, os.ErrNotExist) {
+			cleanup()
+			return "", nil, err
+		}
+	}
+	return layout.MergedRoot, cleanup, nil
+}
+
+func enterOverlayCaptureMountNamespace() (func(), error) {
+	runtime.LockOSThread()
+	oldNS, err := os.Open("/proc/self/ns/mnt")
+	if err != nil {
+		runtime.UnlockOSThread()
+		return nil, fmt.Errorf("open current overlay capture mount namespace: %w", err)
+	}
+	cleanup := func() {
+		if err := unix.Setns(int(oldNS.Fd()), unix.CLONE_NEWNS); err != nil {
+			fmt.Fprintf(os.Stderr, "restore overlay capture mount namespace: %v\n", err)
+			_ = oldNS.Close()
+			return
+		}
+		_ = oldNS.Close()
+		runtime.UnlockOSThread()
+	}
+	if err := unix.Unshare(unix.CLONE_NEWNS); err != nil {
+		cleanup()
+		return nil, fmt.Errorf("create overlay capture mount namespace: %w", err)
+	}
+	if err := unix.Mount("", "/", "", unix.MS_REC|unix.MS_PRIVATE, ""); err != nil {
+		cleanup()
+		return nil, fmt.Errorf("make overlay capture mount namespace private: %w", err)
+	}
+	return cleanup, nil
+}
+
+func newOverlayCaptureLayout(upperDir string) (overlayCaptureLayout, error) {
+	upperDir, err := cleanOverlayCaptureAbsolutePath("overlay upperdir", upperDir)
+	if err != nil {
+		return overlayCaptureLayout{}, err
+	}
+	root, err := cleanOverlayCaptureAbsolutePath("overlay capture root", overlayCaptureRoot)
+	if err != nil {
+		return overlayCaptureLayout{}, err
+	}
+	if upperDir == root || !strings.HasPrefix(upperDir, root+string(filepath.Separator)) {
+		return overlayCaptureLayout{}, fmt.Errorf("overlay upperdir %q must be under %s", upperDir, root)
+	}
+	baseDir := filepath.Dir(upperDir)
+	return overlayCaptureLayout{
+		BaseDir:    baseDir,
+		UpperDir:   upperDir,
+		WorkDir:    filepath.Join(baseDir, "work"),
+		MergedRoot: filepath.Join(baseDir, "merged"),
+	}, nil
+}
+
+func prepareOverlayCaptureLayout(layout overlayCaptureLayout) error {
+	if err := os.MkdirAll(layout.BaseDir, 0o755); err != nil {
+		return fmt.Errorf("create overlay capture base directory %s: %w", layout.BaseDir, err)
+	}
+	for _, dir := range []string{layout.UpperDir, layout.WorkDir, layout.MergedRoot} {
+		if err := os.RemoveAll(dir); err != nil {
+			return fmt.Errorf("clear overlay capture directory %s: %w", dir, err)
+		}
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("create overlay capture directory %s: %w", dir, err)
+		}
+	}
+	return nil
+}
+
+func bindOverlayCaptureInputProjection(req vsockexec.ExecRequest, mergedRoot string, mounted *[]string) error {
+	projection := req.InputProjection
+	if projection == nil || !projection.MountSourceReadOnly {
+		return nil
+	}
+	sourceRoot, err := cleanOverlayCaptureAbsolutePath("input projection source root", projection.SourceRoot)
+	if err != nil {
+		return err
+	}
+	return bindOverlayCapturePath(sourceRoot, overlayCaptureGuestTarget(mergedRoot, sourceRoot), true, mounted)
+}
+
+func bindOverlayCaptureGuestPath(mergedRoot, guestPath string, readOnly bool, mounted *[]string) error {
+	source, err := cleanOverlayCaptureAbsolutePath("overlay capture guest path", guestPath)
+	if err != nil {
+		return err
+	}
+	return bindOverlayCapturePath(source, overlayCaptureGuestTarget(mergedRoot, source), readOnly, mounted)
+}
+
+func bindOverlayCapturePath(source, target string, readOnly bool, mounted *[]string) error {
+	info, err := os.Stat(source)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		return fmt.Errorf("stat overlay capture bind source %s: %w", source, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("overlay capture bind source %s is not a directory", source)
+	}
+	if err := ensureOverlayCaptureDir(target); err != nil {
+		return err
+	}
+	if err := unix.Mount(source, target, "", unix.MS_BIND|unix.MS_REC, ""); err != nil {
+		return fmt.Errorf("bind overlay capture path %s at %s: %w", source, target, err)
+	}
+	*mounted = append(*mounted, target)
+	if readOnly {
+		if err := unix.Mount("", target, "", unix.MS_BIND|unix.MS_REMOUNT|unix.MS_RDONLY|unix.MS_REC, ""); err != nil {
+			return fmt.Errorf("remount overlay capture bind %s read-only: %w", target, err)
+		}
+	}
+	return nil
+}
+
+func mountOverlayCaptureScratchPath(mergedRoot, guestPath, data string, mounted *[]string) error {
+	target := overlayCaptureGuestTarget(mergedRoot, guestPath)
+	if err := ensureOverlayCaptureDir(target); err != nil {
+		return err
+	}
+	if err := unix.Mount("tmpfs", target, "tmpfs", unix.MS_NOSUID|unix.MS_NODEV, data); err != nil {
+		return fmt.Errorf("mount overlay capture scratch path %s: %w", guestPath, err)
+	}
+	*mounted = append(*mounted, target)
+	return nil
+}
+
+func cleanOverlayCaptureAbsolutePath(name, value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", fmt.Errorf("missing %s", name)
+	}
+	cleaned := filepath.Clean(value)
+	if !filepath.IsAbs(cleaned) {
+		return "", fmt.Errorf("%s %q is not absolute", name, value)
+	}
+	if cleaned == "/" {
+		return "", fmt.Errorf("%s must not be /", name)
+	}
+	return cleaned, nil
+}
+
+func overlayCaptureGuestTarget(mergedRoot, guestPath string) string {
+	guestPath = filepath.Clean(guestPath)
+	return filepath.Join(mergedRoot, strings.TrimPrefix(guestPath, string(filepath.Separator)))
+}
+
+func ensureOverlayCaptureDir(path string) error {
+	info, err := os.Stat(path)
+	if err == nil {
+		if !info.IsDir() {
+			return fmt.Errorf("overlay capture path %s is not a directory", path)
+		}
+		return nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("stat overlay capture path %s: %w", path, err)
+	}
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		return fmt.Errorf("create overlay capture path %s: %w", path, err)
+	}
+	return nil
+}
 
 func scanOverlayCapture(capture *vsockexec.OverlayCapture) (*vsockexec.OverlayCaptureResult, error) {
 	if capture == nil {

--- a/cmd/cleanroom-guest-agent/overlay_capture.go
+++ b/cmd/cleanroom-guest-agent/overlay_capture.go
@@ -101,13 +101,12 @@ func enterOverlayCaptureMountNamespace() (func(), error) {
 		return nil, fmt.Errorf("open current overlay capture mount namespace: %w", err)
 	}
 	cleanup := func() {
+		defer runtime.UnlockOSThread()
+		defer oldNS.Close()
 		if err := unix.Setns(int(oldNS.Fd()), unix.CLONE_NEWNS); err != nil {
 			fmt.Fprintf(os.Stderr, "restore overlay capture mount namespace: %v\n", err)
-			_ = oldNS.Close()
 			return
 		}
-		_ = oldNS.Close()
-		runtime.UnlockOSThread()
 	}
 	if err := unix.Unshare(unix.CLONE_NEWNS); err != nil {
 		cleanup()

--- a/cmd/cleanroom-guest-agent/overlay_capture.go
+++ b/cmd/cleanroom-guest-agent/overlay_capture.go
@@ -164,7 +164,11 @@ func bindOverlayCaptureInputProjection(req vsockexec.ExecRequest, mergedRoot str
 	if err != nil {
 		return err
 	}
-	return bindOverlayCapturePath(sourceRoot, overlayCaptureGuestTarget(mergedRoot, sourceRoot), true, mounted)
+	target, err := overlayCaptureGuestTarget(mergedRoot, sourceRoot)
+	if err != nil {
+		return err
+	}
+	return bindOverlayCapturePath(sourceRoot, target, true, mounted)
 }
 
 func bindOverlayCaptureGuestPath(mergedRoot, guestPath string, readOnly bool, mounted *[]string) error {
@@ -172,7 +176,11 @@ func bindOverlayCaptureGuestPath(mergedRoot, guestPath string, readOnly bool, mo
 	if err != nil {
 		return err
 	}
-	return bindOverlayCapturePath(source, overlayCaptureGuestTarget(mergedRoot, source), readOnly, mounted)
+	target, err := overlayCaptureGuestTarget(mergedRoot, source)
+	if err != nil {
+		return err
+	}
+	return bindOverlayCapturePath(source, target, readOnly, mounted)
 }
 
 func bindOverlayCapturePath(source, target string, readOnly bool, mounted *[]string) error {
@@ -202,7 +210,10 @@ func bindOverlayCapturePath(source, target string, readOnly bool, mounted *[]str
 }
 
 func mountOverlayCaptureScratchPath(mergedRoot, guestPath, data string, mounted *[]string) error {
-	target := overlayCaptureGuestTarget(mergedRoot, guestPath)
+	target, err := overlayCaptureGuestTarget(mergedRoot, guestPath)
+	if err != nil {
+		return err
+	}
 	if err := ensureOverlayCaptureDir(target); err != nil {
 		return err
 	}
@@ -228,9 +239,53 @@ func cleanOverlayCaptureAbsolutePath(name, value string) (string, error) {
 	return cleaned, nil
 }
 
-func overlayCaptureGuestTarget(mergedRoot, guestPath string) string {
-	guestPath = filepath.Clean(guestPath)
-	return filepath.Join(mergedRoot, strings.TrimPrefix(guestPath, string(filepath.Separator)))
+func overlayCaptureGuestTarget(mergedRoot, guestPath string) (string, error) {
+	mergedRoot, err := cleanOverlayCaptureAbsolutePath("overlay merged root", mergedRoot)
+	if err != nil {
+		return "", err
+	}
+	guestPath, err = cleanOverlayCaptureAbsolutePath("overlay capture guest path", guestPath)
+	if err != nil {
+		return "", err
+	}
+	return resolveOverlayCaptureGuestTarget(mergedRoot, guestPath, 0)
+}
+
+func resolveOverlayCaptureGuestTarget(mergedRoot, guestPath string, depth int) (string, error) {
+	if depth > 32 {
+		return "", fmt.Errorf("overlay capture guest path %q has too many symlinks", guestPath)
+	}
+	parts := strings.Split(strings.TrimPrefix(filepath.Clean(guestPath), string(filepath.Separator)), string(filepath.Separator))
+	currentTarget := filepath.Clean(mergedRoot)
+	currentGuest := string(filepath.Separator)
+	for i, part := range parts {
+		if part == "" {
+			continue
+		}
+		candidate := filepath.Join(currentTarget, part)
+		info, err := os.Lstat(candidate)
+		if err == nil && info.Mode()&os.ModeSymlink != 0 {
+			link, err := os.Readlink(candidate)
+			if err != nil {
+				return "", fmt.Errorf("read overlay capture path symlink %s: %w", candidate, err)
+			}
+			remaining := filepath.Join(parts[i+1:]...)
+			baseGuest := filepath.Dir(filepath.Join(currentGuest, part))
+			nextGuest := ""
+			if filepath.IsAbs(link) {
+				nextGuest = filepath.Join(link, remaining)
+			} else {
+				nextGuest = filepath.Join(baseGuest, link, remaining)
+			}
+			return resolveOverlayCaptureGuestTarget(mergedRoot, nextGuest, depth+1)
+		}
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf("stat overlay capture path %s: %w", candidate, err)
+		}
+		currentTarget = candidate
+		currentGuest = filepath.Join(currentGuest, part)
+	}
+	return currentTarget, nil
 }
 
 func ensureOverlayCaptureDir(path string) error {

--- a/cmd/cleanroom-guest-agent/overlay_capture_e2e_test.go
+++ b/cmd/cleanroom-guest-agent/overlay_capture_e2e_test.go
@@ -1,0 +1,130 @@
+//go:build linux
+
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/vsockexec"
+)
+
+const guestOverlayCaptureE2EEnv = "CLEANROOM_GUEST_AGENT_OVERLAY_E2E"
+
+func TestOverlayCaptureExecutesCommandInMergedRootE2E(t *testing.T) {
+	if strings.TrimSpace(os.Getenv(guestOverlayCaptureE2EEnv)) == "" {
+		t.Skipf("set %s=1 to run privileged guest overlay capture e2e", guestOverlayCaptureE2EEnv)
+	}
+	if os.Geteuid() != 0 {
+		t.Skip("guest overlay capture e2e requires root")
+	}
+	if rootFSType := mountFSType("/"); rootFSType == "overlay" {
+		t.Skip("guest overlay capture e2e requires a non-overlay root filesystem for lowerdir=/")
+	}
+
+	tempDir := t.TempDir()
+	restoreOverlayRoot := setTestOverlayCaptureRoot(t, filepath.Join(tempDir, "overlay-captures"))
+	defer restoreOverlayRoot()
+	outputRoot := filepath.Join(string(filepath.Separator), "mnt", "cleanroom-overlay-e2e")
+	declaredFile := filepath.Join(outputRoot, "declared.txt")
+	escapedFile := filepath.Join(string(filepath.Separator), "etc", "cleanroom-overlay-e2e-escaped")
+	t.Cleanup(func() {
+		_ = os.RemoveAll(outputRoot)
+		_ = os.Remove(escapedFile)
+	})
+	if err := os.MkdirAll(outputRoot, 0o755); err != nil {
+		t.Fatalf("create output root: %v", err)
+	}
+	mountPath := filepath.Join(tempDir, "volume")
+	if err := os.MkdirAll(mountPath, 0o755); err != nil {
+		t.Fatalf("create capture volume: %v", err)
+	}
+
+	var req bytes.Buffer
+	if err := vsockexec.EncodeRequest(&req, vsockexec.ExecRequest{
+		Command: []string{
+			"sh",
+			"-lc",
+			"printf declared > " + shellQuote(declaredFile) + "; printf escaped > " + shellQuote(escapedFile),
+		},
+		CacheOutputFileCaptures: []vsockexec.CacheOutputFileCapture{
+			{GuestPath: declaredFile, MountPath: mountPath, Subpath: "files/declared.txt"},
+		},
+		OverlayCapture: &vsockexec.OverlayCapture{
+			UpperDir:            filepath.Join(overlayCaptureRoot, "e2e", "upper"),
+			DeclaredFileOutputs: []string{declaredFile},
+			IgnoredPrefixes:     []string{"/tmp", "/var/tmp", "/run"},
+		},
+	}); err != nil {
+		t.Fatalf("encode request: %v", err)
+	}
+	conn := &guestOverlayCaptureTestConn{Reader: bytes.NewReader(req.Bytes())}
+	handleConn(conn)
+
+	res, err := vsockexec.DecodeStreamResponse(bytes.NewReader(conn.output.Bytes()), vsockexec.StreamCallbacks{})
+	if err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got, want := res.ExitCode, 0; got != want {
+		t.Fatalf("unexpected exit code: got %d want %d error %q", got, want, res.Error)
+	}
+	if res.OverlayCapture == nil {
+		t.Fatal("expected overlay capture result")
+	}
+	if !slices.ContainsFunc(res.OverlayCapture.EscapedWrites, func(entry vsockexec.OverlayCaptureEntry) bool {
+		return entry.Path == escapedFile && entry.Kind == "write"
+	}) {
+		t.Fatalf("missing escaped write for %s in %#v", escapedFile, res.OverlayCapture.EscapedWrites)
+	}
+	if data, err := os.ReadFile(filepath.Join(mountPath, "files", "declared.txt")); err != nil {
+		t.Fatalf("read captured declared file: %v", err)
+	} else if got, want := string(data), "declared"; got != want {
+		t.Fatalf("unexpected captured file: got %q want %q", got, want)
+	}
+	if data, err := os.ReadFile(declaredFile); err != nil {
+		t.Fatalf("read materialized declared file: %v", err)
+	} else if got, want := string(data), "declared"; got != want {
+		t.Fatalf("unexpected materialized file: got %q want %q", got, want)
+	}
+	if _, err := os.Stat(escapedFile); !os.IsNotExist(err) {
+		t.Fatalf("escaped write leaked into base root: %v", err)
+	}
+}
+
+type guestOverlayCaptureTestConn struct {
+	*bytes.Reader
+	output bytes.Buffer
+}
+
+func (c *guestOverlayCaptureTestConn) Write(p []byte) (int, error) {
+	return c.output.Write(p)
+}
+
+func (c *guestOverlayCaptureTestConn) Close() error {
+	return nil
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}
+
+var _ io.ReadWriteCloser = (*guestOverlayCaptureTestConn)(nil)
+
+func mountFSType(target string) string {
+	data, err := os.ReadFile("/proc/mounts")
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 3 && fields[1] == target {
+			return fields[2]
+		}
+	}
+	return ""
+}

--- a/cmd/cleanroom-guest-agent/overlay_capture_test.go
+++ b/cmd/cleanroom-guest-agent/overlay_capture_test.go
@@ -107,7 +107,48 @@ func TestOverlayCaptureLayoutRejectsUnsafeUpperDir(t *testing.T) {
 func TestOverlayCaptureGuestTargetStaysUnderMergedRoot(t *testing.T) {
 	t.Parallel()
 
-	if got, want := overlayCaptureGuestTarget("/merged", "/home/cleanroom/.cache"), "/merged/home/cleanroom/.cache"; got != want {
+	got, err := overlayCaptureGuestTarget("/merged", "/home/cleanroom/.cache")
+	if err != nil {
+		t.Fatalf("overlayCaptureGuestTarget returned error: %v", err)
+	}
+	if want := "/merged/home/cleanroom/.cache"; got != want {
+		t.Fatalf("unexpected guest target: got %q want %q", got, want)
+	}
+}
+
+func TestOverlayCaptureGuestTargetResolvesAbsoluteSymlinkInsideMergedRoot(t *testing.T) {
+	t.Parallel()
+
+	mergedRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(mergedRoot, "var"), 0o755); err != nil {
+		t.Fatalf("create var: %v", err)
+	}
+	if err := os.Symlink("/run", filepath.Join(mergedRoot, "var", "run")); err != nil {
+		t.Fatalf("create var/run symlink: %v", err)
+	}
+
+	got, err := overlayCaptureGuestTarget(mergedRoot, "/var/run/service")
+	if err != nil {
+		t.Fatalf("overlayCaptureGuestTarget returned error: %v", err)
+	}
+	if want := filepath.Join(mergedRoot, "run", "service"); got != want {
+		t.Fatalf("unexpected guest target: got %q want %q", got, want)
+	}
+}
+
+func TestOverlayCaptureGuestTargetResolvesRelativeSymlinkInsideMergedRoot(t *testing.T) {
+	t.Parallel()
+
+	mergedRoot := t.TempDir()
+	if err := os.Symlink("usr/lib64", filepath.Join(mergedRoot, "lib64")); err != nil {
+		t.Fatalf("create lib64 symlink: %v", err)
+	}
+
+	got, err := overlayCaptureGuestTarget(mergedRoot, "/lib64/pkg")
+	if err != nil {
+		t.Fatalf("overlayCaptureGuestTarget returned error: %v", err)
+	}
+	if want := filepath.Join(mergedRoot, "usr", "lib64", "pkg"); got != want {
 		t.Fatalf("unexpected guest target: got %q want %q", got, want)
 	}
 }

--- a/cmd/cleanroom-guest-agent/overlay_capture_test.go
+++ b/cmd/cleanroom-guest-agent/overlay_capture_test.go
@@ -219,6 +219,30 @@ func TestNewGuestCommandUsesOverlayRootAsChroot(t *testing.T) {
 	}
 }
 
+func TestNewGuestCommandNormalizesOverlayRootRelativeDirs(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		dir  string
+		want string
+	}{
+		{name: "empty", dir: "", want: "/"},
+		{name: "dot", dir: ".", want: "/"},
+		{name: "relative", dir: "workspace/subdir", want: "/workspace/subdir"},
+		{name: "relative parent", dir: "../workspace", want: "/workspace"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cmd := newGuestCommand(vsockexec.ExecRequest{Command: []string{"sh", "-lc", "true"}, Dir: tc.dir}, "/run/cleanroom/overlay/merged")
+			if got := cmd.Dir; got != tc.want {
+				t.Fatalf("unexpected command dir: got %q want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func assertOverlayCaptureEntry(t *testing.T, entries []vsockexec.OverlayCaptureEntry, want vsockexec.OverlayCaptureEntry) {
 	t.Helper()
 	for _, got := range entries {

--- a/cmd/cleanroom-guest-agent/overlay_capture_test.go
+++ b/cmd/cleanroom-guest-agent/overlay_capture_test.go
@@ -153,6 +153,57 @@ func TestOverlayCaptureGuestTargetResolvesRelativeSymlinkInsideMergedRoot(t *tes
 	}
 }
 
+func TestOverlayCaptureInputProjectionBindUsesTargetRootWhenNotMountedOverSource(t *testing.T) {
+	t.Parallel()
+
+	source, target, readOnly, ok, err := overlayCaptureInputProjectionBind(vsockexec.ExecRequest{
+		InputProjection: &vsockexec.InputProjection{
+			SourceRoot:          "/workspace",
+			TargetRoot:          "/run/cleanroom/input-projections/dependencies/toolchain",
+			MountSourceReadOnly: false,
+		},
+	}, "/merged")
+	if err != nil {
+		t.Fatalf("overlayCaptureInputProjectionBind returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected input projection bind")
+	}
+	if source != "/run/cleanroom/input-projections/dependencies/toolchain" {
+		t.Fatalf("unexpected source: %q", source)
+	}
+	if target != "/merged/run/cleanroom/input-projections/dependencies/toolchain" {
+		t.Fatalf("unexpected target: %q", target)
+	}
+	if readOnly {
+		t.Fatal("did not expect read-only bind for target-root projection")
+	}
+}
+
+func TestOverlayCaptureInputProjectionBindUsesSourceRootWhenMountedReadOnly(t *testing.T) {
+	t.Parallel()
+
+	source, target, readOnly, ok, err := overlayCaptureInputProjectionBind(vsockexec.ExecRequest{
+		InputProjection: &vsockexec.InputProjection{
+			SourceRoot:          "/workspace",
+			TargetRoot:          "/run/cleanroom/input-projections/dependencies/toolchain",
+			MountSourceReadOnly: true,
+		},
+	}, "/merged")
+	if err != nil {
+		t.Fatalf("overlayCaptureInputProjectionBind returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected input projection bind")
+	}
+	if source != "/workspace" || target != "/merged/workspace" {
+		t.Fatalf("unexpected bind: source %q target %q", source, target)
+	}
+	if !readOnly {
+		t.Fatal("expected read-only bind for source-root projection")
+	}
+}
+
 func TestNewGuestCommandUsesOverlayRootAsChroot(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/cleanroom-guest-agent/overlay_capture_test.go
+++ b/cmd/cleanroom-guest-agent/overlay_capture_test.go
@@ -72,6 +72,61 @@ func TestSendExitResultIncludesOverlayCapture(t *testing.T) {
 	assertOverlayCaptureEntry(t, res.OverlayCapture.EscapedWrites, vsockexec.OverlayCaptureEntry{Path: "/etc/profile", Kind: "write", Mode: 0o644})
 }
 
+func TestOverlayCaptureLayoutUsesSiblingWorkAndMergedRoots(t *testing.T) {
+	t.Parallel()
+
+	layout, err := newOverlayCaptureLayout("/run/cleanroom/overlay-captures/dependency-cache/upper")
+	if err != nil {
+		t.Fatalf("newOverlayCaptureLayout returned error: %v", err)
+	}
+	if got, want := layout.BaseDir, "/run/cleanroom/overlay-captures/dependency-cache"; got != want {
+		t.Fatalf("unexpected base dir: got %q want %q", got, want)
+	}
+	if got, want := layout.WorkDir, "/run/cleanroom/overlay-captures/dependency-cache/work"; got != want {
+		t.Fatalf("unexpected work dir: got %q want %q", got, want)
+	}
+	if got, want := layout.MergedRoot, "/run/cleanroom/overlay-captures/dependency-cache/merged"; got != want {
+		t.Fatalf("unexpected merged root: got %q want %q", got, want)
+	}
+}
+
+func TestOverlayCaptureLayoutRejectsUnsafeUpperDir(t *testing.T) {
+	t.Parallel()
+
+	if _, err := newOverlayCaptureLayout("relative/upper"); err == nil {
+		t.Fatal("expected relative upperdir to fail")
+	}
+	if _, err := newOverlayCaptureLayout("/"); err == nil {
+		t.Fatal("expected root upperdir to fail")
+	}
+	if _, err := newOverlayCaptureLayout("/var/tmp/upper"); err == nil {
+		t.Fatal("expected upperdir outside managed root to fail")
+	}
+}
+
+func TestOverlayCaptureGuestTargetStaysUnderMergedRoot(t *testing.T) {
+	t.Parallel()
+
+	if got, want := overlayCaptureGuestTarget("/merged", "/home/cleanroom/.cache"), "/merged/home/cleanroom/.cache"; got != want {
+		t.Fatalf("unexpected guest target: got %q want %q", got, want)
+	}
+}
+
+func TestNewGuestCommandUsesOverlayRootAsChroot(t *testing.T) {
+	t.Parallel()
+
+	cmd := newGuestCommand(vsockexec.ExecRequest{Command: []string{"sh", "-lc", "true"}, Dir: "/workspace"}, "/run/cleanroom/overlay/merged")
+	if cmd.SysProcAttr == nil {
+		t.Fatal("expected SysProcAttr")
+	}
+	if got, want := cmd.SysProcAttr.Chroot, "/run/cleanroom/overlay/merged"; got != want {
+		t.Fatalf("unexpected chroot: got %q want %q", got, want)
+	}
+	if got, want := cmd.Dir, "/workspace"; got != want {
+		t.Fatalf("unexpected command dir: got %q want %q", got, want)
+	}
+}
+
 func assertOverlayCaptureEntry(t *testing.T, entries []vsockexec.OverlayCaptureEntry, want vsockexec.OverlayCaptureEntry) {
 	t.Helper()
 	for _, got := range entries {
@@ -90,5 +145,14 @@ func writeOverlayCaptureTestFile(t *testing.T, root, rel string) {
 	}
 	if err := os.WriteFile(path, []byte(rel), 0o644); err != nil {
 		t.Fatalf("write %s: %v", rel, err)
+	}
+}
+
+func setTestOverlayCaptureRoot(t *testing.T, root string) func() {
+	t.Helper()
+	previous := overlayCaptureRoot
+	overlayCaptureRoot = root
+	return func() {
+		overlayCaptureRoot = previous
 	}
 }

--- a/docs/plans/dependency-service-volume-caches.md
+++ b/docs/plans/dependency-service-volume-caches.md
@@ -952,6 +952,40 @@ Remaining runtime work after phase 6:
 - decide whether output volume sizing stays internal or becomes policy-visible
   after real workloads show the right default
 
+### Guest Overlay Runner Status
+
+The guest-agent overlay runner slice turns an `overlay_capture` execution
+request into real Linux guest setup, but backend capability advertisement remains
+gated until it is exercised against managed VM roots.
+
+Completed in the guest overlay runner slice:
+
+- the Linux guest agent creates a per-execution mount namespace for overlay
+  capture requests
+- each request gets fresh `upper`, `work`, and `merged` directories under the
+  requested overlay capture root
+- the current rootfs is mounted as the overlay lowerdir and commands execute
+  inside the merged root with `chroot`
+- scratch paths such as `/tmp`, `/var/tmp`, and `/run` are mounted as tmpfs
+  inside the merged root before declared outputs are rebound
+- the read-only input projection is rebound inside the merged root when present
+- declared output directories are rebound inside the merged root so their writes
+  land in the sidecar output volumes rather than the overlay upperdir
+- declared file outputs are captured from the merged root, copied into the
+  aggregate output store, and materialized back into the sandbox root for later
+  blocks
+- an opt-in privileged guest-agent E2E documents the expected behavior on a
+  non-overlay Linux root filesystem
+
+Remaining overlay-capture runtime work:
+
+- run the opt-in guest-agent E2E inside the managed Firecracker and darwin-vz
+  guest roots instead of Docker's overlay-backed rootfs
+- wire escaped-write fallback so Cleanroom restarts from the pre-block state and
+  reruns through the exact full-rootfs path before later phases continue
+- advertise `sandbox.overlay_write_capture` only after the managed VM validation
+  and fallback path are in place
+
 ### Darwin-VZ Sidecar Volume Status
 
 The darwin-vz backend now consumes launch-time `backend.CacheOutputVolumeSpec`


### PR DESCRIPTION
## What this is part of

This is the next runtime-boundary slice for `docs/plans/dependency-service-volume-caches.md`. The earlier PRs can now request overlay capture for dependency/service block-volume misses; this PR makes the Linux guest agent honor that request by running the command through a merged overlay root.

It still intentionally does **not** advertise `sandbox.overlay_write_capture` from Firecracker or darwin-vz. That capability should only flip once this runner has been exercised in the managed VM roots and the exact fallback/restart path is wired.

## What changed

- Create a per-execution mount namespace for `overlay_capture` requests.
- Prepare fresh `upper`, `work`, and `merged` directories under `/run/cleanroom/overlay-captures`.
- Mount `/` as the overlay lowerdir and run the command with `chroot` into the merged root.
- Mount scratch paths as tmpfs and rebind the read-only input projection plus declared output dirs inside the merged root.
- Capture declared file outputs from the merged root, store them in the aggregate output volume, and materialize them back into the sandbox root for later blocks.
- Document this runner slice in the dependency/service volume-cache plan.

## Validation

- `GOCACHE=/private/tmp/cleanroom-go-build-cache mise exec -- go test -count=1 ./cmd/cleanroom-guest-agent`
- `GOCACHE=/private/tmp/cleanroom-go-build-cache mise exec -- go test ./...`
- `docker run --rm -v "$PWD":/work -v /Users/lachlan/Develop/cleanroom/.git:/Users/lachlan/Develop/cleanroom/.git:ro -w /work -e GOCACHE=/tmp/go-build-cache golang:1.26.2 go test ./...`
- `docker run --rm --privileged -v "$PWD":/work -w /work -e GOCACHE=/tmp/go-build-cache -e CLEANROOM_GUEST_AGENT_OVERLAY_E2E=1 golang:1.26.2 go test -v -run TestOverlayCaptureExecutesCommandInMergedRootE2E -count=1 ./cmd/cleanroom-guest-agent` (skips in Docker because `/` is overlayfs; the test is for managed ext4 guest roots)
