### PR TITLE
feat: Default public Docker registry mirrors

### DIFF
--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -86,20 +86,19 @@ the sandbox policy, and only then allows the upstream fetch.
 Current scope:
 
 - OCI pull-style `GET` and `HEAD` requests
-- built-in prefix mapping for Docker Hub (`docker.io` ->
-  `https://registry-1.docker.io`)
-- additional registry-prefix mappings configured via
+- built-in prefix mappings for Docker Hub (`docker.io` ->
+  `https://registry-1.docker.io`), GitHub Container Registry (`ghcr.io`), and
+  Amazon ECR Public (`public.ecr.aws`)
+- additional or overridden registry-prefix mappings configured via
   `gateway.oci.registries` in runtime config
 - custom registry keys must be real registry hosts, not arbitrary aliases
 
-Example runtime config:
+Example runtime config for additional registries:
 
 ```yaml
 gateway:
   oci:
     registries:
-      ghcr.io: https://ghcr.io
-      public.ecr.aws: https://public.ecr.aws
       registry.internal:5000: https://registry.internal:5000
 ```
 
@@ -126,10 +125,9 @@ Current scope:
 - pull-style `GET` and `HEAD` requests only
 - mirror traffic routed to the same `docker.io` -> `registry-1.docker.io`
   upstream mapping used by `/registry/`
-- guest `dockerd` pulls for runtime-configured non-Docker-Hub registries are
-  mirrored through `/registry/<host>/` by generated Docker registry host config.
-  For example, `gateway.oci.registries.public.ecr.aws` makes guest pulls from
-  `public.ecr.aws/...` use
+- guest `dockerd` pulls for built-in or runtime-configured non-Docker-Hub
+  registries are mirrored through `/registry/<host>/` by generated Docker
+  registry host config. For example, guest pulls from `public.ecr.aws/...` use
   `http://gateway.cleanroom.internal:8170/registry/public.ecr.aws/...` inside
   the guest.
 
@@ -137,8 +135,9 @@ Policy still applies to the registry host from the map key. A sandbox must
 allow `public.ecr.aws:443` for the `public.ecr.aws` mirror path to fetch
 upstream, even though the guest talks to the Cleanroom gateway over HTTP.
 Registries that are not present in `gateway.oci.registries` are not installed
-as guest `dockerd` registry mirrors; they either use Docker's normal direct
-registry path subject to network policy, or fail when direct egress is denied.
+as guest `dockerd` registry mirrors unless they are one of the built-in public
+registry hosts. Other registries either use Docker's normal direct registry path
+subject to network policy, or fail when direct egress is denied.
 Configured registry host config points the registry namespace's server at the
 Cleanroom gateway, so configured non-Docker-Hub pulls do not have a direct
 upstream fallback inside `dockerd`.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -473,8 +473,8 @@ These rules are installed during sandbox network setup and torn down during clea
 - The gateway resolves a registry prefix from the request path, maps it to an upstream registry URL, and applies the sandbox allowlist against the mapped policy host and port before forwarding upstream.
 - Current route scope is OCI pull-style `GET` and `HEAD` traffic.
 - The gateway also exposes a Docker Hub-compatible `/v2/` mirror endpoint backed by the same OCI cache so guest `dockerd` can use the shared gateway as a Docker Hub registry mirror.
-- Guest `dockerd` also gets generated Docker registry-host config for non-Docker-Hub registries explicitly configured in runtime config under `gateway.oci.registries`, pointing those registry namespaces' server endpoint at the gateway `/registry/<host>/` path without a direct upstream fallback.
-- Current Docker mirror scope is pull-style `GET` and `HEAD` traffic for Docker Hub and runtime-configured registry hosts.
+- Guest `dockerd` also gets generated Docker registry-host config for built-in public registries (`ghcr.io`, `public.ecr.aws`) and non-Docker-Hub registries explicitly configured in runtime config under `gateway.oci.registries`, pointing those registry namespaces' server endpoint at the gateway `/registry/<host>/` path without a direct upstream fallback.
+- Current Docker mirror scope is pull-style `GET` and `HEAD` traffic for Docker Hub, built-in public registry hosts, and runtime-configured registry hosts.
 - The gateway exposes a `/goproxy/` route backed by embedded `content-cache` Go module proxy handlers, including mirrored sumdb traffic under `/goproxy/sumdb/`.
 - Current Go module scope includes `GOPROXY` metadata requests, module zip downloads, and mirrored checksum-database requests.
 - The gateway also exposes a `/rubygems/` route backed by embedded `content-cache` RubyGems handlers for Bundler mirror traffic to `rubygems.org`.

--- a/internal/gateway/contentcache.go
+++ b/internal/gateway/contentcache.go
@@ -213,7 +213,7 @@ func NewContentCache(cfg ContentCacheConfig) (*ContentCache, error) {
 		closer:         db,
 		gitHandlers:    make(map[string]http.Handler),
 		ociHandlers:    make(map[string]ociHandlerEntry),
-		ociMirrorHosts: configuredOCIMirrorHosts(cfg.OCIRegistries),
+		ociMirrorHosts: ociMirrorHosts(cfg.OCIRegistries),
 	}
 	goProxyUpstreamURL := strings.TrimSpace(ccgoproxy.DefaultUpstreamURL)
 	goProxyPolicyHost, goProxyPolicyPort, err := registryHostPort(goProxyUpstreamURL)
@@ -437,11 +437,23 @@ func normalizeAllowedHostList(hosts []string) []string {
 	return out
 }
 
+var defaultOCIRegistryMappings = map[string]string{
+	"docker.io":            "https://registry-1.docker.io",
+	"index.docker.io":      "https://registry-1.docker.io",
+	"registry-1.docker.io": "https://registry-1.docker.io",
+	"ghcr.io":              "https://ghcr.io",
+	"public.ecr.aws":       "https://public.ecr.aws",
+}
+
+var defaultOCIMirrorHosts = []string{
+	"ghcr.io",
+	"public.ecr.aws",
+}
+
 func normalizeOCIRegistryMappings(registries map[string]string) (map[string]string, error) {
-	out := map[string]string{
-		"docker.io":            "https://registry-1.docker.io",
-		"index.docker.io":      "https://registry-1.docker.io",
-		"registry-1.docker.io": "https://registry-1.docker.io",
+	out := make(map[string]string, len(defaultOCIRegistryMappings)+len(registries))
+	for prefix, registryURL := range defaultOCIRegistryMappings {
+		out[prefix] = registryURL
 	}
 
 	for prefix, registryURL := range registries {
@@ -464,12 +476,17 @@ func normalizeOCIRegistryMappings(registries map[string]string) (map[string]stri
 	return out, nil
 }
 
-func configuredOCIMirrorHosts(registries map[string]string) []string {
-	if len(registries) == 0 {
-		return nil
+func ociMirrorHosts(registries map[string]string) []string {
+	out := make([]string, 0, len(defaultOCIMirrorHosts)+len(registries))
+	seen := make(map[string]struct{}, len(defaultOCIMirrorHosts)+len(registries))
+	for _, prefix := range defaultOCIMirrorHosts {
+		normalizedPrefix := strings.ToLower(strings.TrimSpace(prefix))
+		if normalizedPrefix == "" {
+			continue
+		}
+		seen[normalizedPrefix] = struct{}{}
+		out = append(out, normalizedPrefix)
 	}
-	out := make([]string, 0, len(registries))
-	seen := make(map[string]struct{}, len(registries))
 	for prefix := range registries {
 		normalizedPrefix := strings.ToLower(strings.TrimSpace(prefix))
 		if normalizedPrefix == "" || strings.Contains(normalizedPrefix, "/") || !isRegistryHostPrefix(normalizedPrefix) || isDockerHubMirrorPrefix(normalizedPrefix) {

--- a/internal/gateway/contentcache_test.go
+++ b/internal/gateway/contentcache_test.go
@@ -20,18 +20,34 @@ func registryTestScopeWithRules(rules ...policy.AllowRule) *SandboxScope {
 	}
 }
 
-func TestConfiguredOCIMirrorHostsOnlyIncludesConfiguredNonDockerHubRegistries(t *testing.T) {
+func TestOCIMirrorHostsIncludesBuiltInsAndConfiguredNonDockerHubRegistries(t *testing.T) {
 	t.Parallel()
 
-	got := configuredOCIMirrorHosts(map[string]string{
+	got := ociMirrorHosts(map[string]string{
 		"ghcr.io":            "https://ghcr.io",
 		" public.ecr.aws ":   " https://public.ecr.aws ",
 		"docker.io":          "https://registry-1.docker.io",
 		"index.docker.io":    "https://registry-1.docker.io",
+		"registry.internal":  "https://registry.internal",
 		"registry.internal/": "https://registry.internal",
 		"":                   "https://example.invalid",
 	})
 
+	want := []string{"ghcr.io", "public.ecr.aws", "registry.internal"}
+	if len(got) != len(want) {
+		t.Fatalf("unexpected mirror host count: got %v want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("unexpected mirror host at %d: got %q want %q (all: %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+func TestOCIMirrorHostsDefaultsToPublicRegistries(t *testing.T) {
+	t.Parallel()
+
+	got := ociMirrorHosts(nil)
 	want := []string{"ghcr.io", "public.ecr.aws"}
 	if len(got) != len(want) {
 		t.Fatalf("unexpected mirror host count: got %v want %v", got, want)

--- a/internal/gateway/contentcache_types.go
+++ b/internal/gateway/contentcache_types.go
@@ -175,8 +175,9 @@ func (c *ContentCache) HasOCIHandler() bool {
 	return c != nil && c.buildOCIHandler != nil
 }
 
-// OCIMirrorHosts returns the runtime-configured registry hosts that are safe to
-// expose to guest container runtimes as explicit registry mirrors.
+// OCIMirrorHosts returns the built-in and runtime-configured registry hosts
+// that are safe to expose to guest container runtimes as explicit registry
+// mirrors.
 func (c *ContentCache) OCIMirrorHosts() []string {
 	if c == nil || len(c.ociMirrorHosts) == 0 {
 		return nil

--- a/internal/gateway/oci_cached_test.go
+++ b/internal/gateway/oci_cached_test.go
@@ -471,6 +471,21 @@ func TestResolveOCIRegistryRouteUsesDockerHubAlias(t *testing.T) {
 	}
 }
 
+func TestNormalizeOCIRegistryMappingsIncludesBuiltInPublicRegistries(t *testing.T) {
+	t.Parallel()
+
+	routes, err := normalizeOCIRegistryMappings(nil)
+	if err != nil {
+		t.Fatalf("normalizeOCIRegistryMappings returned error: %v", err)
+	}
+	if got, want := routes["ghcr.io"], "https://ghcr.io"; got != want {
+		t.Fatalf("ghcr.io mapping = %q, want %q", got, want)
+	}
+	if got, want := routes["public.ecr.aws"], "https://public.ecr.aws"; got != want {
+		t.Fatalf("public.ecr.aws mapping = %q, want %q", got, want)
+	}
+}
+
 func TestNormalizeOCIRegistryMappingsRejectsSymbolicPrefix(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Problem

PR #298 made guest `dockerd` use the Cleanroom gateway/cache path for non-Docker-Hub registries, but only for registries explicitly listed in host runtime config. Common public registries such as `ghcr.io` and `public.ecr.aws` should work by default when a sandbox policy allows those hosts.

## Changes

- Add built-in OCI registry mappings for `ghcr.io` and `public.ecr.aws`.
- Include those hosts in the default guest Docker registry mirror set.
- Keep runtime `gateway.oci.registries` as the override/extension point for other registries.
- Update docs to distinguish built-in public registries from additional runtime-configured registries.

## Validation

- `mise exec -- go test ./internal/gateway ./internal/cli ./internal/backend/firecracker ./internal/backend/darwinvz`
- `mise exec -- go test ./...`
- `git diff --check`