### PR TITLE
test: Add managed VM overlay capture E2Es

### DIFF
--- a/internal/backend/darwinvz/persistent_e2e_test.go
+++ b/internal/backend/darwinvz/persistent_e2e_test.go
@@ -272,6 +272,137 @@ func TestPersistentSandboxCacheOutputVolumeE2E(t *testing.T) {
 	}
 }
 
+func TestPersistentSandboxOverlayCaptureE2E(t *testing.T) {
+	if strings.TrimSpace(os.Getenv(darwinVZE2EEnvEnabled)) == "" {
+		t.Skipf("set %s=1 to run real darwin-vz overlay capture e2e", darwinVZE2EEnvEnabled)
+	}
+	if testing.Short() {
+		t.Skip("skipping darwin-vz e2e in short mode")
+	}
+
+	helperPath, err := resolveHelperBinaryPath()
+	if err != nil {
+		t.Fatalf("resolve helper binary: %v", err)
+	}
+	hasEntitlement, err := helperHasVirtualizationEntitlement(helperPath)
+	if err != nil {
+		t.Fatalf("verify helper entitlement: %v", err)
+	}
+	if !hasEntitlement {
+		t.Fatalf("helper %q is missing com.apple.security.virtualization entitlement", helperPath)
+	}
+	if _, _, err := New().getGuestAgentBinary(); err != nil {
+		t.Fatalf("resolve guest agent binary: %v", err)
+	}
+
+	rootFSOverride := strings.TrimSpace(os.Getenv(darwinVZE2EEnvRootFS))
+	if rootFSOverride == "" {
+		if _, err := hosttools.ResolveE2FSProgsBinary("mkfs.ext4"); err != nil {
+			t.Fatalf("resolve mkfs.ext4: %v", err)
+		}
+		if _, err := hosttools.ResolveE2FSProgsBinary("debugfs"); err != nil {
+			t.Fatalf("resolve debugfs: %v", err)
+		}
+	}
+
+	imageRef := strings.TrimSpace(os.Getenv(darwinVZE2EEnvImageRef))
+	if imageRef == "" {
+		imageRef = defaultDarwinVZE2EImageRef()
+	}
+
+	cfg := backend.FirecrackerConfig{
+		KernelImagePath: strings.TrimSpace(os.Getenv(darwinVZE2EEnvKernelImage)),
+		RootFSPath:      rootFSOverride,
+		VCPUs:           1,
+		MemoryMiB:       1024,
+		LaunchSeconds:   90,
+	}
+	compiled := &policy.CompiledPolicy{
+		Version:        1,
+		ImageRef:       imageRef,
+		NetworkDefault: "deny",
+	}
+	sandboxID := fmt.Sprintf("cr-e2e-overlay-%d", time.Now().UnixNano())
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	outputDir := "/var/lib/cleanroom-overlay-output-e2e"
+	declaredFile := "/root/cleanroom-overlay-file-e2e.txt"
+	escapedFile := fmt.Sprintf("/etc/%s-escaped", sandboxID)
+	adapter := New()
+	if err := adapter.ProvisionSandbox(ctx, backend.ProvisionRequest{
+		SandboxID: sandboxID,
+		Policy:    compiled,
+		CacheOutputVolumes: []backend.CacheOutputVolumeSpec{
+			{
+				Stage:     "dependency-volume",
+				BlockName: "overlay-e2e",
+				CacheKey:  "dependency-volume:v1:overlay-e2e",
+				VolumeID:  "dependency-volume-overlay-e2e",
+				DirMappings: []backend.CacheOutputDirMapping{
+					{GuestPath: outputDir, Subpath: "dirs/0"},
+				},
+				FileMappings: []backend.CacheOutputFileMapping{
+					{GuestPath: declaredFile, Subpath: "files/declared.txt", Mode: 0o644},
+				},
+			},
+		},
+		FirecrackerConfig: cfg,
+	}); err != nil {
+		t.Fatalf("ProvisionSandbox returned error: %v", err)
+	}
+	defer func() {
+		if err := adapter.TerminateSandbox(context.Background(), sandboxID); err != nil {
+			t.Fatalf("deferred TerminateSandbox returned error: %v", err)
+		}
+	}()
+
+	result, err := adapter.RunInSandbox(ctx, backend.ExecutionRequest{
+		SandboxID:   sandboxID,
+		ExecutionID: "overlay-capture",
+		Command: []string{
+			"sh",
+			"-lc",
+			fmt.Sprintf("printf dir-output > %s/value; printf file-output > %s; printf escaped > %s", outputDir, declaredFile, escapedFile),
+		},
+		Policy: compiled,
+		CacheOutputFileCaptures: []backend.CacheOutputFileCapture{
+			{VolumeID: "dependency-volume-overlay-e2e", GuestPath: declaredFile, VolumeSubpath: "files/declared.txt", Mode: 0o644},
+		},
+		OverlayCapture: &backend.OverlayCapture{
+			UpperDir:            fmt.Sprintf("/run/cleanroom/overlay-captures/%s/upper", sandboxID),
+			BaselinePaths:       []string{outputDir},
+			DeclaredFileOutputs: []string{declaredFile},
+			IgnoredPrefixes:     []string{"/tmp", "/var/tmp", "/run"},
+		},
+		FirecrackerConfig: cfg,
+	}, backend.OutputStream{})
+	if err != nil {
+		t.Fatalf("overlay RunInSandbox returned error: %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("overlay exit code = %d, want 0: %s", result.ExitCode, result.Message)
+	}
+	if result.OverlayCapture == nil {
+		t.Fatal("expected overlay capture result")
+	}
+	requireOverlayCaptureEntry(t, result.OverlayCapture.Entries, backend.OverlayCaptureEntry{Path: declaredFile, Kind: "write", Mode: 0o644})
+	requireNoOverlayCapturePath(t, result.OverlayCapture.EscapedWrites, declaredFile)
+	requireOverlayCaptureEntry(t, result.OverlayCapture.EscapedWrites, backend.OverlayCaptureEntry{Path: escapedFile, Kind: "write", Mode: 0o644})
+
+	var stdout bytes.Buffer
+	runPersistentCommand(ctx, t, adapter, sandboxID, compiled, cfg, "overlay-read-dir", &stdout, "sh", "-lc", "cat "+outputDir+"/value")
+	if got, want := stdout.String(), "dir-output"; got != want {
+		t.Fatalf("unexpected cache output dir contents: got %q want %q", got, want)
+	}
+	stdout.Reset()
+	runPersistentCommand(ctx, t, adapter, sandboxID, compiled, cfg, "overlay-read-file", &stdout, "sh", "-lc", "cat "+declaredFile)
+	if got, want := stdout.String(), "file-output"; got != want {
+		t.Fatalf("unexpected captured file contents: got %q want %q", got, want)
+	}
+	runPersistentCommand(ctx, t, adapter, sandboxID, compiled, cfg, "overlay-escaped-absent", nil, "test", "!", "-e", escapedFile)
+}
+
 func runPersistentCommand(ctx context.Context, t *testing.T, adapter *Adapter, sandboxID string, compiled *policy.CompiledPolicy, cfg backend.FirecrackerConfig, executionID string, stdout *bytes.Buffer, command ...string) {
 	t.Helper()
 
@@ -293,6 +424,25 @@ func runPersistentCommand(ctx context.Context, t *testing.T, adapter *Adapter, s
 	}
 	if result.ExitCode != 0 {
 		t.Fatalf("%s exit code = %d, want 0", executionID, result.ExitCode)
+	}
+}
+
+func requireOverlayCaptureEntry(t *testing.T, entries []backend.OverlayCaptureEntry, want backend.OverlayCaptureEntry) {
+	t.Helper()
+	for _, got := range entries {
+		if got.Path == want.Path && got.Kind == want.Kind && got.Mode.Perm() == want.Mode.Perm() {
+			return
+		}
+	}
+	t.Fatalf("missing overlay capture entry %#v in %#v", want, entries)
+}
+
+func requireNoOverlayCapturePath(t *testing.T, entries []backend.OverlayCaptureEntry, path string) {
+	t.Helper()
+	for _, got := range entries {
+		if got.Path == path {
+			t.Fatalf("unexpected overlay capture entry for %s in %#v", path, entries)
+		}
 	}
 }
 

--- a/internal/backend/firecracker/snapshot_zfs_e2e_test.go
+++ b/internal/backend/firecracker/snapshot_zfs_e2e_test.go
@@ -35,6 +35,139 @@ func defaultFirecrackerZFSE2EDataset() string {
 	return "cleanroom/data"
 }
 
+func TestOverlayCaptureCacheOutputZFSE2E(t *testing.T) {
+	if strings.TrimSpace(os.Getenv(firecrackerZFSE2EEnvEnabled)) == "" {
+		t.Skipf("set %s=1 to run real firecracker overlay capture e2e", firecrackerZFSE2EEnvEnabled)
+	}
+	if testing.Short() {
+		t.Skip("skipping firecracker zfs e2e in short mode")
+	}
+
+	imageRef := strings.TrimSpace(os.Getenv(firecrackerZFSE2EEnvImageRef))
+	if imageRef == "" {
+		imageRef = defaultFirecrackerZFSE2EImageRef()
+	}
+	cfg := backend.FirecrackerConfig{
+		BinaryPath:           strings.TrimSpace(os.Getenv(firecrackerZFSE2EEnvBinary)),
+		KernelImagePath:      strings.TrimSpace(os.Getenv(firecrackerZFSE2EEnvKernelImage)),
+		PrivilegedHelperPath: strings.TrimSpace(os.Getenv(firecrackerZFSE2EEnvHelper)),
+		VCPUs:                1,
+		MemoryMiB:            1024,
+		LaunchSeconds:        120,
+		Snapshots: backend.SnapshotConfig{
+			Enabled:               true,
+			Driver:                "zfs",
+			ZFSDataset:            strings.TrimSpace(os.Getenv(firecrackerZFSE2EEnvDataset)),
+			QuiesceTimeoutSeconds: 15,
+		},
+	}
+	if cfg.Snapshots.ZFSDataset == "" {
+		cfg.Snapshots.ZFSDataset = defaultFirecrackerZFSE2EDataset()
+	}
+
+	compiled := &policy.CompiledPolicy{
+		Version:        1,
+		ImageRef:       imageRef,
+		NetworkDefault: "deny",
+	}
+	adapter := New()
+
+	report, err := adapter.Doctor(context.Background(), backend.DoctorRequest{
+		Policy:            compiled,
+		FirecrackerConfig: cfg,
+	})
+	if err != nil {
+		t.Fatalf("Doctor returned error: %v", err)
+	}
+	if failures := firecrackerDoctorFailures(report); len(failures) > 0 {
+		t.Fatalf("firecracker doctor reported failures:\n%s", strings.Join(failures, "\n"))
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	sandboxID := fmt.Sprintf("cr-overlay-e2e-%d", time.Now().UnixNano())
+	outputDir := "/var/lib/cleanroom-overlay-output-e2e"
+	declaredFile := "/root/cleanroom-overlay-file-e2e.txt"
+	escapedFile := fmt.Sprintf("/etc/%s-escaped", sandboxID)
+	if err := adapter.ProvisionSandbox(ctx, backend.ProvisionRequest{
+		SandboxID: sandboxID,
+		Policy:    compiled,
+		CacheOutputVolumes: []backend.CacheOutputVolumeSpec{
+			{
+				Stage:     "dependency-volume",
+				BlockName: "overlay-e2e",
+				CacheKey:  "dependency-volume:v1:overlay-e2e",
+				VolumeID:  "dependency-volume-overlay-e2e",
+				DirMappings: []backend.CacheOutputDirMapping{
+					{GuestPath: outputDir, Subpath: "dirs/0"},
+				},
+				FileMappings: []backend.CacheOutputFileMapping{
+					{GuestPath: declaredFile, Subpath: "files/declared.txt", Mode: 0o644},
+				},
+			},
+		},
+		FirecrackerConfig: cfg,
+	}); err != nil {
+		t.Fatalf("ProvisionSandbox returned error: %v", err)
+	}
+	terminated := false
+	defer func() {
+		if terminated {
+			return
+		}
+		if err := adapter.TerminateSandbox(context.Background(), sandboxID); err != nil {
+			t.Errorf("deferred TerminateSandbox returned error: %v", err)
+		}
+	}()
+
+	result, err := adapter.RunInSandbox(ctx, backend.ExecutionRequest{
+		SandboxID:   sandboxID,
+		ExecutionID: "overlay-capture",
+		Command: []string{
+			"sh",
+			"-lc",
+			fmt.Sprintf("printf dir-output > %s/value; printf file-output > %s; printf escaped > %s", outputDir, declaredFile, escapedFile),
+		},
+		Policy: compiled,
+		CacheOutputFileCaptures: []backend.CacheOutputFileCapture{
+			{VolumeID: "dependency-volume-overlay-e2e", GuestPath: declaredFile, VolumeSubpath: "files/declared.txt", Mode: 0o644},
+		},
+		OverlayCapture: &backend.OverlayCapture{
+			UpperDir:            fmt.Sprintf("/run/cleanroom/overlay-captures/%s/upper", sandboxID),
+			BaselinePaths:       []string{outputDir},
+			DeclaredFileOutputs: []string{declaredFile},
+			IgnoredPrefixes:     []string{"/tmp", "/var/tmp", "/run"},
+		},
+		FirecrackerConfig: backend.FirecrackerConfig{LaunchSeconds: cfg.LaunchSeconds},
+	}, backend.OutputStream{})
+	if err != nil {
+		t.Fatalf("overlay RunInSandbox returned error: %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("overlay exit code = %d, want 0: %s", result.ExitCode, result.Message)
+	}
+	if result.OverlayCapture == nil {
+		t.Fatal("expected overlay capture result")
+	}
+	firecrackerRequireOverlayCaptureEntry(t, result.OverlayCapture.Entries, backend.OverlayCaptureEntry{Path: declaredFile, Kind: "write", Mode: 0o644})
+	firecrackerRequireNoOverlayCapturePath(t, result.OverlayCapture.EscapedWrites, declaredFile)
+	firecrackerRequireOverlayCaptureEntry(t, result.OverlayCapture.EscapedWrites, backend.OverlayCaptureEntry{Path: escapedFile, Kind: "write", Mode: 0o644})
+
+	if got, want := firecrackerRunPersistentCommand(ctx, t, adapter, sandboxID, compiled, cfg, "overlay-read-dir", "sh", "-lc", "cat "+outputDir+"/value"), "dir-output"; got != want {
+		t.Fatalf("unexpected cache output dir contents: got %q want %q", got, want)
+	}
+	if got, want := firecrackerRunPersistentCommand(ctx, t, adapter, sandboxID, compiled, cfg, "overlay-read-file", "sh", "-lc", "cat "+declaredFile), "file-output"; got != want {
+		t.Fatalf("unexpected captured file contents: got %q want %q", got, want)
+	}
+	firecrackerRunPersistentCommand(ctx, t, adapter, sandboxID, compiled, cfg, "overlay-escaped-absent", "test", "!", "-e", escapedFile)
+
+	if err := adapter.TerminateSandbox(ctx, sandboxID); err != nil {
+		t.Fatalf("TerminateSandbox returned error: %v", err)
+	}
+	terminated = true
+}
+
 func TestSnapshotLifecycleZFSE2E(t *testing.T) {
 	if strings.TrimSpace(os.Getenv(firecrackerZFSE2EEnvEnabled)) == "" {
 		t.Skipf("set %s=1 to run real firecracker zfs snapshot e2e", firecrackerZFSE2EEnvEnabled)
@@ -230,6 +363,49 @@ func TestSnapshotLifecycleZFSE2E(t *testing.T) {
 	}
 	deletedSnapshot = true
 	firecrackerRequireZFSRefState(t, ctx, cfg, snapshotStorageRef, false)
+}
+
+func firecrackerRunPersistentCommand(ctx context.Context, t *testing.T, adapter *Adapter, sandboxID string, compiled *policy.CompiledPolicy, cfg backend.FirecrackerConfig, executionID string, command ...string) string {
+	t.Helper()
+
+	var stdout bytes.Buffer
+	result, err := adapter.RunInSandbox(ctx, backend.ExecutionRequest{
+		SandboxID:   sandboxID,
+		ExecutionID: executionID,
+		Command:     command,
+		Policy:      compiled,
+		FirecrackerConfig: backend.FirecrackerConfig{
+			LaunchSeconds: cfg.LaunchSeconds,
+		},
+	}, backend.OutputStream{OnStdout: func(chunk []byte) {
+		_, _ = stdout.Write(chunk)
+	}})
+	if err != nil {
+		t.Fatalf("%s returned error: %v", executionID, err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("%s exit code=%d stdout=%q", executionID, result.ExitCode, stdout.String())
+	}
+	return strings.TrimSpace(stdout.String())
+}
+
+func firecrackerRequireOverlayCaptureEntry(t *testing.T, entries []backend.OverlayCaptureEntry, want backend.OverlayCaptureEntry) {
+	t.Helper()
+	for _, got := range entries {
+		if got.Path == want.Path && got.Kind == want.Kind && got.Mode.Perm() == want.Mode.Perm() {
+			return
+		}
+	}
+	t.Fatalf("missing overlay capture entry %#v in %#v", want, entries)
+}
+
+func firecrackerRequireNoOverlayCapturePath(t *testing.T, entries []backend.OverlayCaptureEntry, path string) {
+	t.Helper()
+	for _, got := range entries {
+		if got.Path == path {
+			t.Fatalf("unexpected overlay capture entry for %s in %#v", path, entries)
+		}
+	}
 }
 
 func firecrackerSandboxVolumeRef(t *testing.T, adapter *Adapter, sandboxID string) string {


### PR DESCRIPTION
## Why

This is the first remaining release-readiness slice for dependency/service volume caches on managed VM backends. The cache-output flow depends on overlay capture to distinguish declared outputs from escaped writes, so darwin-vz and Firecracker need backend-level E2E coverage before advertising the feature broadly.

## What changed

- Added a live darwin-vz persistent sandbox E2E that runs overlay capture with a cache-output sidecar volume.
- Added a Linux-gated Firecracker ZFS E2E covering the same overlay-capture/cache-output behavior.
- Both tests assert that declared file outputs appear as allowed overlay entries, declared outputs are not reported as escaped writes, real escaped writes are reported, sidecar directory writes persist, declared file captures persist, and escaped writes do not leak into the base root.

## Validation

- `GOCACHE=/private/tmp/cleanroom-go-build-cache CLEANROOM_DARWIN_VZ_E2E=1 mise exec -- go test -run 'TestPersistentSandboxOverlayCaptureE2E|TestPersistentSandboxCacheOutputVolumeE2E' -count=1 -v ./internal/backend/darwinvz`\n- `GOCACHE=/private/tmp/cleanroom-go-build-cache mise exec -- go test -count=1 ./internal/backend/darwinvz`\n- `GOCACHE=/private/tmp/cleanroom-go-build-cache mise exec -- go test -count=1 ./internal/backend/firecracker`\n- `GOCACHE=/private/tmp/cleanroom-go-build-cache mise exec -- go test ./...`\n- `docker run --rm -v "$PWD":/work -v /Users/lachlan/Develop/cleanroom/.git:/Users/lachlan/Develop/cleanroom/.git:ro -w /work -e GOCACHE=/tmp/go-build-cache golang:1.26.2 go test -run TestOverlayCaptureCacheOutputZFSE2E -count=1 -v ./internal/backend/firecracker`\n- Earlier full Linux container suite: `docker run --rm -v "$PWD":/work -v /Users/lachlan/Develop/cleanroom/.git:/Users/lachlan/Develop/cleanroom/.git:ro -w /work -e GOCACHE=/tmp/go-build-cache golang:1.26.2 go test ./...`\n\nFirecracker live execution remains gated behind `CLEANROOM_FIRECRACKER_ZFS_E2E=1` and requires a Linux/KVM/ZFS host, so this macOS host validated that test by Linux compile/skip rather than running the VM.