### PR TITLE
fix: Rerun block volumes after escaped writes

### DIFF
--- a/internal/controlservice/block_volume_escaped_writes.go
+++ b/internal/controlservice/block_volume_escaped_writes.go
@@ -12,7 +12,7 @@ func blockVolumeEscapedWriteWarning(stage, blockName string, result *backend.Exe
 		return ""
 	}
 	count := len(result.OverlayCapture.EscapedWrites)
-	return fmt.Sprintf("%s block %q wrote outside declared outputs (%d escaped writes: %s); skipping block-volume cache publication", stage, blockName, count, blockVolumeEscapedWriteSummary(result.OverlayCapture.EscapedWrites))
+	return fmt.Sprintf("%s block %q wrote outside declared outputs (%d escaped writes: %s); skipping block-volume cache publication and rerunning without overlay capture", stage, blockName, count, blockVolumeEscapedWriteSummary(result.OverlayCapture.EscapedWrites))
 }
 
 func blockVolumeEscapedWriteSummary(entries []backend.OverlayCaptureEntry) string {

--- a/internal/controlservice/block_volume_fallback.go
+++ b/internal/controlservice/block_volume_fallback.go
@@ -133,7 +133,7 @@ func blockVolumeOutputResetCommand(outputs policy.StageBlockOutputs) []string {
 		script.WriteString("  rm -f -- " + quoted + "\n")
 		script.WriteString("  mkdir -p -- " + quoted + "\n")
 		script.WriteString("elif [ -d " + quoted + " ]; then\n")
-		script.WriteString("  rm -rf -- " + quoted + "/* " + quoted + "/.[!.]* " + quoted + "/..?*\n")
+		script.WriteString("  find " + quoted + " -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +\n")
 		script.WriteString("else\n")
 		script.WriteString("  rm -rf -- " + quoted + "\n")
 		script.WriteString("  mkdir -p -- " + quoted + "\n")

--- a/internal/controlservice/block_volume_fallback.go
+++ b/internal/controlservice/block_volume_fallback.go
@@ -1,0 +1,159 @@
+package controlservice
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/buildkite/cleanroom/internal/repositorycheckout"
+)
+
+func (s *Service) runBlockVolumeExactFallback(
+	ctx context.Context,
+	adapter backend.Adapter,
+	sandboxID string,
+	compiled *policy.CompiledPolicy,
+	firecrackerCfg backend.FirecrackerConfig,
+	phase cleanroomv1.CreateSandboxPhase,
+	networkStage policy.NetworkStage,
+	stageName string,
+	blockName string,
+	sourceRoot string,
+	command []string,
+	env []string,
+	outputs policy.StageBlockOutputs,
+	resetOutputs bool,
+	reporter CreateSandboxReporter,
+) (*backend.ExecutionResult, error) {
+	if resetOutputs {
+		if err := s.resetBlockVolumeOutputs(ctx, adapter, sandboxID, compiled, firecrackerCfg, phase, networkStage, stageName, blockName, outputs, reporter); err != nil {
+			return nil, err
+		}
+	}
+
+	emitCreateSandboxMessage(reporter, phase, fmt.Sprintf("running %s bootstrap without block-volume cache: %s", stageName, blockName))
+	_, result, stdout, stderr, err := s.runPersistentBootstrapCommandWithOptions(
+		ctx,
+		adapter,
+		sandboxID,
+		compiled,
+		firecrackerCfg,
+		phase,
+		networkStage,
+		command,
+		env,
+		nil,
+		persistentSandboxCommandOptions{
+			Dir:       sourceRoot,
+			ClosedEnv: true,
+		},
+		reporter,
+	)
+	if fallbackErr := persistentBootstrapCommandError(
+		result,
+		stdout,
+		stderr,
+		err,
+		fmt.Sprintf("%s block fallback returned no result", stageName),
+		fmt.Sprintf("%s block fallback failed with exit code %%d", stageName),
+	); fallbackErr != nil {
+		return result, fallbackErr
+	}
+	return result, nil
+}
+
+func (s *Service) resetBlockVolumeOutputs(
+	ctx context.Context,
+	adapter backend.Adapter,
+	sandboxID string,
+	compiled *policy.CompiledPolicy,
+	firecrackerCfg backend.FirecrackerConfig,
+	phase cleanroomv1.CreateSandboxPhase,
+	networkStage policy.NetworkStage,
+	stageName string,
+	blockName string,
+	outputs policy.StageBlockOutputs,
+	reporter CreateSandboxReporter,
+) error {
+	command := blockVolumeOutputResetCommand(outputs)
+	if len(command) == 0 {
+		return nil
+	}
+
+	emitCreateSandboxMessage(reporter, phase, fmt.Sprintf("resetting %s outputs before block-volume fallback: %s", stageName, blockName))
+	_, result, stdout, stderr, err := s.runPersistentBootstrapCommandWithOptions(
+		ctx,
+		adapter,
+		sandboxID,
+		compiled,
+		firecrackerCfg,
+		phase,
+		networkStage,
+		command,
+		nil,
+		nil,
+		persistentSandboxCommandOptions{ClosedEnv: true},
+		reporter,
+	)
+	if resetErr := persistentBootstrapCommandError(
+		result,
+		stdout,
+		stderr,
+		err,
+		fmt.Sprintf("%s block output reset returned no result", stageName),
+		fmt.Sprintf("%s block output reset failed with exit code %%d", stageName),
+	); resetErr != nil {
+		return fmt.Errorf("reset %s block %q outputs before fallback: %w", stageName, blockName, resetErr)
+	}
+	return nil
+}
+
+func blockVolumeOutputResetCommand(outputs policy.StageBlockOutputs) []string {
+	var script strings.Builder
+	script.WriteString("set -eu\n")
+	wrote := false
+	for _, path := range outputs.Files {
+		path = strings.TrimSpace(path)
+		if path == "" {
+			continue
+		}
+		script.WriteString("rm -f -- " + blockVolumeShellQuote(path) + "\n")
+		wrote = true
+	}
+	for _, path := range outputs.Dirs {
+		path = strings.TrimSpace(path)
+		if path == "" {
+			continue
+		}
+		quoted := blockVolumeShellQuote(path)
+		script.WriteString("if [ -d " + quoted + " ]; then\n")
+		script.WriteString("  rm -rf -- " + quoted + "/* " + quoted + "/.[!.]* " + quoted + "/..?*\n")
+		script.WriteString("else\n")
+		script.WriteString("  rm -rf -- " + quoted + "\n")
+		script.WriteString("  mkdir -p -- " + quoted + "\n")
+		script.WriteString("fi\n")
+		wrote = true
+	}
+	if !wrote {
+		return nil
+	}
+	return []string{"sh", "-lc", script.String()}
+}
+
+func blockVolumeSourceRoot(repository *repositorycheckout.Checkout) string {
+	if repository == nil {
+		return "/workspace"
+	}
+	sourceRoot := strings.TrimSpace(repository.DestinationDir)
+	if sourceRoot == "" {
+		return "/workspace"
+	}
+	return sourceRoot
+}
+
+func blockVolumeShellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", `'"'"'`) + "'"
+}

--- a/internal/controlservice/block_volume_fallback.go
+++ b/internal/controlservice/block_volume_fallback.go
@@ -120,7 +120,7 @@ func blockVolumeOutputResetCommand(outputs policy.StageBlockOutputs) []string {
 		if path == "" {
 			continue
 		}
-		script.WriteString("rm -f -- " + blockVolumeShellQuote(path) + "\n")
+		script.WriteString("rm -rf -- " + blockVolumeShellQuote(path) + "\n")
 		wrote = true
 	}
 	for _, path := range outputs.Dirs {
@@ -129,7 +129,10 @@ func blockVolumeOutputResetCommand(outputs policy.StageBlockOutputs) []string {
 			continue
 		}
 		quoted := blockVolumeShellQuote(path)
-		script.WriteString("if [ -d " + quoted + " ]; then\n")
+		script.WriteString("if [ -L " + quoted + " ]; then\n")
+		script.WriteString("  rm -f -- " + quoted + "\n")
+		script.WriteString("  mkdir -p -- " + quoted + "\n")
+		script.WriteString("elif [ -d " + quoted + " ]; then\n")
 		script.WriteString("  rm -rf -- " + quoted + "/* " + quoted + "/.[!.]* " + quoted + "/..?*\n")
 		script.WriteString("else\n")
 		script.WriteString("  rm -rf -- " + quoted + "\n")

--- a/internal/controlservice/block_volume_fallback_test.go
+++ b/internal/controlservice/block_volume_fallback_test.go
@@ -41,6 +41,34 @@ func TestBlockVolumeOutputResetCommandDoesNotFollowOutputDirSymlink(t *testing.T
 	}
 }
 
+func TestBlockVolumeOutputResetCommandClearsOutputDirEntries(t *testing.T) {
+	tempDir := t.TempDir()
+	outputDir := filepath.Join(tempDir, "output")
+	if err := os.MkdirAll(filepath.Join(outputDir, "nested"), 0o755); err != nil {
+		t.Fatalf("create nested output dir: %v", err)
+	}
+	for _, path := range []string{
+		filepath.Join(outputDir, "regular"),
+		filepath.Join(outputDir, ".hidden"),
+		filepath.Join(outputDir, "..prefixed"),
+		filepath.Join(outputDir, "nested", "value"),
+	} {
+		if err := os.WriteFile(path, []byte("stale"), 0o644); err != nil {
+			t.Fatalf("write stale output %s: %v", path, err)
+		}
+	}
+
+	runBlockVolumeResetCommand(t, policy.StageBlockOutputs{Dirs: []string{outputDir}})
+
+	entries, err := os.ReadDir(outputDir)
+	if err != nil {
+		t.Fatalf("read output dir after reset: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected output dir to be empty after reset, got %v", entries)
+	}
+}
+
 func TestBlockVolumeOutputResetCommandRemovesWrongTypeFileOutput(t *testing.T) {
 	tempDir := t.TempDir()
 	outputFile := filepath.Join(tempDir, "file-output")

--- a/internal/controlservice/block_volume_fallback_test.go
+++ b/internal/controlservice/block_volume_fallback_test.go
@@ -1,0 +1,99 @@
+package controlservice
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/policy"
+)
+
+func TestBlockVolumeOutputResetCommandDoesNotFollowOutputDirSymlink(t *testing.T) {
+	tempDir := t.TempDir()
+	targetDir := filepath.Join(tempDir, "target")
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		t.Fatalf("create target dir: %v", err)
+	}
+	targetFile := filepath.Join(targetDir, "keep")
+	if err := os.WriteFile(targetFile, []byte("keep"), 0o644); err != nil {
+		t.Fatalf("write target file: %v", err)
+	}
+	outputDir := filepath.Join(tempDir, "output")
+	if err := os.Symlink(targetDir, outputDir); err != nil {
+		t.Fatalf("create output symlink: %v", err)
+	}
+
+	runBlockVolumeResetCommand(t, policy.StageBlockOutputs{Dirs: []string{outputDir}})
+
+	if _, err := os.Lstat(outputDir); err != nil {
+		t.Fatalf("stat reset output path: %v", err)
+	}
+	if info, err := os.Lstat(outputDir); err != nil {
+		t.Fatalf("lstat reset output path: %v", err)
+	} else if info.Mode()&os.ModeSymlink != 0 {
+		t.Fatalf("expected reset output path to be a directory, got symlink")
+	}
+	if data, err := os.ReadFile(targetFile); err != nil {
+		t.Fatalf("read symlink target file after reset: %v", err)
+	} else if got, want := string(data), "keep"; got != want {
+		t.Fatalf("unexpected symlink target contents: got %q want %q", got, want)
+	}
+}
+
+func TestBlockVolumeOutputResetCommandRemovesWrongTypeFileOutput(t *testing.T) {
+	tempDir := t.TempDir()
+	outputFile := filepath.Join(tempDir, "file-output")
+	if err := os.MkdirAll(outputFile, 0o755); err != nil {
+		t.Fatalf("create wrong-type output dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(outputFile, "stale"), []byte("stale"), 0o644); err != nil {
+		t.Fatalf("write stale file: %v", err)
+	}
+
+	runBlockVolumeResetCommand(t, policy.StageBlockOutputs{Files: []string{outputFile}})
+
+	if _, err := os.Lstat(outputFile); !os.IsNotExist(err) {
+		t.Fatalf("expected wrong-type file output path to be removed, got err=%v", err)
+	}
+}
+
+func TestBlockVolumeOutputResetCommandRemovesFileOutputSymlinkWithoutFollowing(t *testing.T) {
+	tempDir := t.TempDir()
+	targetDir := filepath.Join(tempDir, "target")
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		t.Fatalf("create target dir: %v", err)
+	}
+	targetFile := filepath.Join(targetDir, "keep")
+	if err := os.WriteFile(targetFile, []byte("keep"), 0o644); err != nil {
+		t.Fatalf("write target file: %v", err)
+	}
+	outputFile := filepath.Join(tempDir, "file-output")
+	if err := os.Symlink(targetDir, outputFile); err != nil {
+		t.Fatalf("create output file symlink: %v", err)
+	}
+
+	runBlockVolumeResetCommand(t, policy.StageBlockOutputs{Files: []string{outputFile}})
+
+	if _, err := os.Lstat(outputFile); !os.IsNotExist(err) {
+		t.Fatalf("expected file output symlink to be removed, got err=%v", err)
+	}
+	if data, err := os.ReadFile(targetFile); err != nil {
+		t.Fatalf("read symlink target file after reset: %v", err)
+	} else if got, want := string(data), "keep"; got != want {
+		t.Fatalf("unexpected symlink target contents: got %q want %q", got, want)
+	}
+}
+
+func runBlockVolumeResetCommand(t *testing.T, outputs policy.StageBlockOutputs) {
+	t.Helper()
+	command := blockVolumeOutputResetCommand(outputs)
+	if len(command) == 0 {
+		t.Fatal("expected reset command")
+	}
+	cmd := exec.Command(command[0], command[1:]...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("reset command failed: %v\n%s", err, out)
+	}
+}

--- a/internal/controlservice/dependency_volume_execution.go
+++ b/internal/controlservice/dependency_volume_execution.go
@@ -43,6 +43,15 @@ func (s *Service) bootstrapDependencyBlockVolumePlanInPersistentSandbox(
 	publishable := true
 	for _, block := range plan.Blocks {
 		blockName := strings.TrimSpace(block.BlockName)
+		if !publishable {
+			// Later block-volume hits are unsafe once an earlier block needed
+			// exact fallback; their keys assume prior blocks are represented by
+			// declared output cache identities only.
+			if _, err := s.bootstrapDependencyBlockVolumeFallback(ctx, adapter, sandboxID, compiled, firecrackerCfg, repository, block, true, reporter); err != nil {
+				return publishable, fmt.Errorf("dependency block %q fallback: %w", blockName, err)
+			}
+			continue
+		}
 		if block.CacheHit {
 			emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_DEPENDENCIES, "restoring dependency outputs: "+blockName)
 			continue
@@ -71,6 +80,9 @@ func (s *Service) bootstrapDependencyBlockVolumePlanInPersistentSandbox(
 			publishable = false
 			emitCreateSandboxWarning(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_DEPENDENCIES, warning)
 			s.logDependencyStageWarning("publish dependency block-volume caches", sandboxID, fmt.Errorf("%s", warning))
+			if _, err := s.bootstrapDependencyBlockVolumeFallback(ctx, adapter, sandboxID, compiled, firecrackerCfg, repository, block, true, reporter); err != nil {
+				return publishable, fmt.Errorf("dependency block %q fallback: %w", blockName, err)
+			}
 		}
 		if publishable && publish.Adapter != nil {
 			emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_PUBLISH_DEPENDENCY_STAGE_CACHE, "publishing dependency outputs: "+blockName)
@@ -81,6 +93,40 @@ func (s *Service) bootstrapDependencyBlockVolumePlanInPersistentSandbox(
 		}
 	}
 	return publishable, nil
+}
+
+func (s *Service) bootstrapDependencyBlockVolumeFallback(
+	ctx context.Context,
+	adapter backend.Adapter,
+	sandboxID string,
+	compiled *policy.CompiledPolicy,
+	firecrackerCfg backend.FirecrackerConfig,
+	repository *repositorycheckout.Checkout,
+	block dependencyBlockVolumeBlockPlan,
+	resetOutputs bool,
+	reporter CreateSandboxReporter,
+) (*backend.ExecutionResult, error) {
+	if len(block.Command) == 0 {
+		return nil, nil
+	}
+	sourceRoot := blockVolumeSourceRoot(repository)
+	return s.runBlockVolumeExactFallback(
+		ctx,
+		adapter,
+		sandboxID,
+		compiled,
+		firecrackerCfg,
+		cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_DEPENDENCIES,
+		policy.NetworkStageDependencies,
+		"dependency",
+		strings.TrimSpace(block.BlockName),
+		sourceRoot,
+		block.Command,
+		stageBlockEnvList(block.Env),
+		block.Outputs,
+		resetOutputs,
+		reporter,
+	)
 }
 
 func (s *Service) bootstrapDependencyBlockVolumeBlock(

--- a/internal/controlservice/dependency_volume_plan_test.go
+++ b/internal/controlservice/dependency_volume_plan_test.go
@@ -849,16 +849,17 @@ func TestBootstrapDependencyBlockVolumePlanStopsPublishingAfterEscapedWrites(t *
 				Inputs:    append([]string(nil), compiled.Dependencies.Blocks[1].Inputs.Files...),
 				Outputs:   compiled.Dependencies.Blocks[1].Outputs,
 				CacheKey:  "dependency-volume:go-modules",
+				CacheHit:  true,
 			},
 		},
 	}
 
-	runCalls := 0
+	var gotReqs []backend.ExecutionRequest
 	adapter := &stubAdapter{
 		runStreamFn: func(_ context.Context, req backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
-			runCalls++
+			gotReqs = append(gotReqs, req)
 			result := &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0}
-			if runCalls == 1 {
+			if len(gotReqs) == 1 {
 				result.OverlayCapture = &backend.OverlayCaptureResult{
 					EscapedWrites: []backend.OverlayCaptureEntry{{Path: "/etc/profile", Kind: "write", Mode: 0o644}},
 				}
@@ -891,14 +892,71 @@ func TestBootstrapDependencyBlockVolumePlanStopsPublishingAfterEscapedWrites(t *
 	if publishable {
 		t.Fatal("expected dependency block volume plan to stop being publishable")
 	}
-	if got, want := runCalls, 2; got != want {
+	if got, want := len(gotReqs), 5; got != want {
 		t.Fatalf("unexpected run count: got %d want %d", got, want)
 	}
+	if gotReqs[0].OverlayCapture == nil {
+		t.Fatal("expected first dependency block attempt to use overlay capture")
+	}
+	assertBlockVolumeResetRequest(t, gotReqs[1], policy.NetworkStageDependencies)
+	assertBlockVolumeFallbackRequest(t, gotReqs[2], compiled.Dependencies.Blocks[0].Command, policy.NetworkStageDependencies)
+	assertBlockVolumeResetRequest(t, gotReqs[3], policy.NetworkStageDependencies)
+	assertBlockVolumeFallbackRequest(t, gotReqs[4], compiled.Dependencies.Blocks[1].Command, policy.NetworkStageDependencies)
 	if got := adapter.snapshotCacheOutputsCalls; got != 0 {
 		t.Fatalf("unexpected cache output snapshot calls: got %d", got)
 	}
 	if len(warnings) != 1 || !strings.Contains(warnings[0], "/etc/profile") {
 		t.Fatalf("expected escaped-write warning, got %v", warnings)
+	}
+}
+
+func assertBlockVolumeResetRequest(t *testing.T, req backend.ExecutionRequest, networkStage policy.NetworkStage) {
+	t.Helper()
+	if got, want := req.NetworkStage, networkStage; got != want {
+		t.Fatalf("unexpected reset network stage: got %q want %q", got, want)
+	}
+	if got, want := strings.Join(req.Command[:min(len(req.Command), 2)], "\x00"), "sh\x00-lc"; got != want {
+		t.Fatalf("unexpected reset command prefix: got %v want sh -lc", req.Command)
+	}
+	if len(req.Command) < 3 || !strings.Contains(req.Command[2], "rm -rf --") {
+		t.Fatalf("expected reset command to remove output contents, got %v", req.Command)
+	}
+	if !req.ClosedEnv {
+		t.Fatal("expected reset request to use a closed environment")
+	}
+	if req.InputProjection != nil {
+		t.Fatalf("reset request should not use input projection: %#v", req.InputProjection)
+	}
+	if len(req.CacheOutputFileCaptures) != 0 {
+		t.Fatalf("reset request should not capture output files: %#v", req.CacheOutputFileCaptures)
+	}
+	if req.OverlayCapture != nil {
+		t.Fatalf("reset request should not use overlay capture: %#v", req.OverlayCapture)
+	}
+}
+
+func assertBlockVolumeFallbackRequest(t *testing.T, req backend.ExecutionRequest, command []string, networkStage policy.NetworkStage) {
+	t.Helper()
+	if got, want := strings.Join(req.Command, "\x00"), strings.Join(command, "\x00"); got != want {
+		t.Fatalf("unexpected fallback command: got %q want %q", got, want)
+	}
+	if got, want := req.NetworkStage, networkStage; got != want {
+		t.Fatalf("unexpected fallback network stage: got %q want %q", got, want)
+	}
+	if got, want := req.Dir, "/workspace"; got != want {
+		t.Fatalf("unexpected fallback dir: got %q want %q", got, want)
+	}
+	if !req.ClosedEnv {
+		t.Fatal("expected fallback request to use a closed environment")
+	}
+	if req.InputProjection != nil {
+		t.Fatalf("fallback request should not use input projection: %#v", req.InputProjection)
+	}
+	if len(req.CacheOutputFileCaptures) != 0 {
+		t.Fatalf("fallback request should not capture output files: %#v", req.CacheOutputFileCaptures)
+	}
+	if req.OverlayCapture != nil {
+		t.Fatalf("fallback request should not use overlay capture: %#v", req.OverlayCapture)
 	}
 }
 

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -885,6 +885,7 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 					}
 					if !dependencyBlockVolumePublicationSafe {
 						publishConfig.Adapter = nil
+						publishConfig.ForceExactFallback = true
 					}
 					_, err := s.bootstrapServiceBlockVolumePlanInPersistentSandbox(ctx, adapter, sandboxID, publishConfig, compiled, firecrackerCfg, repository, serviceBlockVolumePlan, reporter)
 					return err
@@ -970,6 +971,7 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 					}
 					if !dependencyBlockVolumePublicationSafe {
 						publishConfig.Adapter = nil
+						publishConfig.ForceExactFallback = true
 					}
 					_, err := s.bootstrapServiceBlockVolumePlanInPersistentSandbox(ctx, adapter, sandboxID, publishConfig, compiled, firecrackerCfg, repository, serviceBlockVolumePlan, reporter)
 					return err
@@ -1182,6 +1184,7 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 				}
 				if !dependencyBlockVolumePublicationSafe {
 					publishConfig.Adapter = nil
+					publishConfig.ForceExactFallback = true
 				}
 				_, err := s.bootstrapServiceBlockVolumePlanInPersistentSandbox(ctx, adapter, sandboxID, publishConfig, compiled, firecrackerCfg, repository, serviceBlockVolumePlan, reporter)
 				return err

--- a/internal/controlservice/service_volume_execution.go
+++ b/internal/controlservice/service_volume_execution.go
@@ -18,10 +18,11 @@ import (
 const serviceInputProjectionRoot = "/run/cleanroom/input-projections/services"
 
 type serviceBlockVolumePublishConfig struct {
-	Adapter    backend.CacheOutputVolumeSnapshottingAdapter
-	Backend    string
-	Changeset  *repositorychangeset.Changeset
-	Repository *repositorycheckout.Checkout
+	Adapter            backend.CacheOutputVolumeSnapshottingAdapter
+	Backend            string
+	Changeset          *repositorychangeset.Changeset
+	Repository         *repositorycheckout.Checkout
+	ForceExactFallback bool
 }
 
 func (s *Service) bootstrapServiceBlockVolumePlanInPersistentSandbox(
@@ -39,9 +40,17 @@ func (s *Service) bootstrapServiceBlockVolumePlanInPersistentSandbox(
 		return true, nil
 	}
 
-	publishable := true
+	publishable := !publish.ForceExactFallback
 	for _, block := range plan.Blocks {
 		blockName := strings.TrimSpace(block.BlockName)
+		if !publishable {
+			// Later block-volume hits are unsafe once this phase, or the
+			// dependency phase it builds on, needed exact fallback.
+			if _, err := s.bootstrapServiceBlockVolumeFallback(ctx, adapter, sandboxID, compiled, firecrackerCfg, repository, block, true, reporter); err != nil {
+				return publishable, fmt.Errorf("service block %q fallback: %w", blockName, err)
+			}
+			continue
+		}
 		if block.CacheHit {
 			emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_SERVICES, "restoring service outputs: "+blockName)
 			continue
@@ -70,6 +79,9 @@ func (s *Service) bootstrapServiceBlockVolumePlanInPersistentSandbox(
 			publishable = false
 			emitCreateSandboxWarning(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_SERVICES, warning)
 			s.logServicesStageWarning("publish service block-volume caches", sandboxID, fmt.Errorf("%s", warning))
+			if _, err := s.bootstrapServiceBlockVolumeFallback(ctx, adapter, sandboxID, compiled, firecrackerCfg, repository, block, true, reporter); err != nil {
+				return publishable, fmt.Errorf("service block %q fallback: %w", blockName, err)
+			}
 		}
 		if publishable && publish.Adapter != nil {
 			emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_PUBLISH_SERVICES_STAGE_CACHE, "publishing service outputs: "+blockName)
@@ -81,6 +93,40 @@ func (s *Service) bootstrapServiceBlockVolumePlanInPersistentSandbox(
 		}
 	}
 	return publishable, nil
+}
+
+func (s *Service) bootstrapServiceBlockVolumeFallback(
+	ctx context.Context,
+	adapter backend.Adapter,
+	sandboxID string,
+	compiled *policy.CompiledPolicy,
+	firecrackerCfg backend.FirecrackerConfig,
+	repository *repositorycheckout.Checkout,
+	block serviceBlockVolumeBlockPlan,
+	resetOutputs bool,
+	reporter CreateSandboxReporter,
+) (*backend.ExecutionResult, error) {
+	if len(block.Command) == 0 {
+		return nil, nil
+	}
+	sourceRoot := blockVolumeSourceRoot(repository)
+	return s.runBlockVolumeExactFallback(
+		ctx,
+		adapter,
+		sandboxID,
+		compiled,
+		firecrackerCfg,
+		cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_SERVICES,
+		policy.NetworkStageServices,
+		"service",
+		strings.TrimSpace(block.BlockName),
+		sourceRoot,
+		block.Command,
+		stageBlockEnvList(block.Env),
+		block.Outputs,
+		resetOutputs,
+		reporter,
+	)
 }
 
 func (s *Service) bootstrapServiceBlockVolumeBlock(

--- a/internal/controlservice/service_volume_plan_test.go
+++ b/internal/controlservice/service_volume_plan_test.go
@@ -1021,16 +1021,17 @@ func TestBootstrapServiceBlockVolumePlanStopsPublishingAfterEscapedWrites(t *tes
 				Inputs:    append([]string(nil), compiled.Services.Blocks[1].Inputs.Files...),
 				Outputs:   compiled.Services.Blocks[1].Outputs,
 				CacheKey:  "service-volume:app-service",
+				CacheHit:  true,
 			},
 		},
 	}
 
-	runCalls := 0
+	var gotReqs []backend.ExecutionRequest
 	adapter := &stubAdapter{
 		runStreamFn: func(_ context.Context, req backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
-			runCalls++
+			gotReqs = append(gotReqs, req)
 			result := &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0}
-			if runCalls == 1 {
+			if len(gotReqs) == 1 {
 				result.OverlayCapture = &backend.OverlayCaptureResult{
 					EscapedWrites: []backend.OverlayCaptureEntry{{Path: "/usr/local/bin/tool", Kind: "write", Mode: 0o755}},
 				}
@@ -1063,14 +1064,90 @@ func TestBootstrapServiceBlockVolumePlanStopsPublishingAfterEscapedWrites(t *tes
 	if publishable {
 		t.Fatal("expected service block volume plan to stop being publishable")
 	}
-	if got, want := runCalls, 2; got != want {
+	if got, want := len(gotReqs), 5; got != want {
 		t.Fatalf("unexpected run count: got %d want %d", got, want)
 	}
+	if gotReqs[0].OverlayCapture == nil {
+		t.Fatal("expected first service block attempt to use overlay capture")
+	}
+	assertBlockVolumeResetRequest(t, gotReqs[1], policy.NetworkStageServices)
+	assertBlockVolumeFallbackRequest(t, gotReqs[2], compiled.Services.Blocks[0].Command, policy.NetworkStageServices)
+	assertBlockVolumeResetRequest(t, gotReqs[3], policy.NetworkStageServices)
+	assertBlockVolumeFallbackRequest(t, gotReqs[4], compiled.Services.Blocks[1].Command, policy.NetworkStageServices)
 	if got := adapter.snapshotCacheOutputsCalls; got != 0 {
 		t.Fatalf("unexpected cache output snapshot calls: got %d", got)
 	}
 	if len(warnings) != 1 || !strings.Contains(warnings[0], "/usr/local/bin/tool") {
 		t.Fatalf("expected escaped-write warning, got %v", warnings)
+	}
+}
+
+func TestBootstrapServiceBlockVolumePlanForceExactFallbackIgnoresCacheHits(t *testing.T) {
+	compiled, err := policy.FromProto(testRepositoryTwoDependencyTwoServiceBlocksPolicy())
+	if err != nil {
+		t.Fatalf("policy.FromProto returned error: %v", err)
+	}
+	repository := repositorycheckout.FromProto(testRepositoryCheckoutProto())
+	plan := serviceBlockVolumePlan{
+		Blocks: []serviceBlockVolumeBlockPlan{
+			{
+				BlockName: "postgres-data",
+				Command:   append([]string(nil), compiled.Services.Blocks[0].Command...),
+				Env:       cloneDependencyBlockEnv(compiled.Services.Blocks[0].Env),
+				Inputs:    append([]string(nil), compiled.Services.Blocks[0].Inputs.Files...),
+				Outputs:   compiled.Services.Blocks[0].Outputs,
+				CacheKey:  "service-volume:postgres-data",
+				CacheHit:  true,
+			},
+			{
+				BlockName: "app-service",
+				Command:   append([]string(nil), compiled.Services.Blocks[1].Command...),
+				Env:       cloneDependencyBlockEnv(compiled.Services.Blocks[1].Env),
+				Inputs:    append([]string(nil), compiled.Services.Blocks[1].Inputs.Files...),
+				Outputs:   compiled.Services.Blocks[1].Outputs,
+				CacheKey:  "service-volume:app-service",
+			},
+		},
+	}
+
+	var gotReqs []backend.ExecutionRequest
+	adapter := &stubAdapter{
+		runStreamFn: func(_ context.Context, req backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
+			gotReqs = append(gotReqs, req)
+			return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0}, nil
+		},
+		snapshotCacheOutputsFn: func(context.Context, backend.SnapshotCacheOutputVolumesRequest) (*backend.SnapshotCacheOutputVolumesResult, error) {
+			t.Fatal("did not expect service block-volume snapshot during forced fallback")
+			return nil, nil
+		},
+	}
+	svc := newTestService(adapter)
+	publishable, err := svc.bootstrapServiceBlockVolumePlanInPersistentSandbox(
+		context.Background(),
+		adapter,
+		"cr-test",
+		serviceBlockVolumePublishConfig{ForceExactFallback: true},
+		compiled,
+		backend.FirecrackerConfig{},
+		repository,
+		plan,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("bootstrapServiceBlockVolumePlanInPersistentSandbox returned error: %v", err)
+	}
+	if publishable {
+		t.Fatal("expected forced fallback to remain unpublishable")
+	}
+	if got, want := len(gotReqs), 4; got != want {
+		t.Fatalf("unexpected run count: got %d want %d", got, want)
+	}
+	assertBlockVolumeResetRequest(t, gotReqs[0], policy.NetworkStageServices)
+	assertBlockVolumeFallbackRequest(t, gotReqs[1], compiled.Services.Blocks[0].Command, policy.NetworkStageServices)
+	assertBlockVolumeResetRequest(t, gotReqs[2], policy.NetworkStageServices)
+	assertBlockVolumeFallbackRequest(t, gotReqs[3], compiled.Services.Blocks[1].Command, policy.NetworkStageServices)
+	if got := adapter.snapshotCacheOutputsCalls; got != 0 {
+		t.Fatalf("unexpected cache output snapshot calls: got %d", got)
 	}
 }
 


### PR DESCRIPTION
## Why

This is the escaped-write safety slice for dependency/service volume caches. The volume-cache path runs missed blocks through overlay capture so Cleanroom can avoid publishing a partial cache entry when a command writes outside declared outputs. Before this change, the sandbox could still continue after such a run with only the declared outputs visible, which meant later phases did not see the command’s real full-rootfs effects.

## What changed

- When a dependency or service block reports escaped writes, Cleanroom now warns, skips block-volume publication, resets that block’s declared outputs, and reruns the block without overlay capture or input projection.
- Once a block falls back, later blocks in the same phase ignore block-volume cache hits and run through the same exact fallback path. Those cache hits are unsafe because their keys assume prior blocks were represented only by declared output identities.
- Service block-volume execution is forced into exact fallback when dependency block-volume publication became unsafe.
- Added tests for escaped-write fallback, later cache-hit bypass, and dependency-driven service fallback.

## Validation

- `GOCACHE=/private/tmp/cleanroom-go-build-cache mise exec -- go test -run 'TestBootstrapDependencyBlockVolumePlanStopsPublishingAfterEscapedWrites|TestBootstrapServiceBlockVolumePlanStopsPublishingAfterEscapedWrites|TestBootstrapServiceBlockVolumePlanForceExactFallbackIgnoresCacheHits|TestCreateSandboxSkipsServiceBlockVolumePublicationAfterDependencyEscapedWrites' -count=1 ./internal/controlservice`\n- `GOCACHE=/private/tmp/cleanroom-go-build-cache mise exec -- go test -count=1 ./internal/controlservice`\n- `GOCACHE=/private/tmp/cleanroom-go-build-cache mise exec -- go test ./...`\n- `docker run --rm -v "$PWD":/work -v /Users/lachlan/Develop/cleanroom/.git:/Users/lachlan/Develop/cleanroom/.git:ro -w /work -e GOCACHE=/tmp/go-build-cache golang:1.26.2 go test ./...`