### PR TITLE
feat: Advertise overlay capture support

### DIFF
--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -307,13 +307,14 @@ func (a *Adapter) Capabilities() map[string]bool {
 	}
 	dnsControlSupported := configuredMode == darwinVZNetworkModeFileHandle
 	return map[string]bool{
-		backend.CapabilityNetworkDefaultDeny:        true,
-		backend.CapabilityNetworkAllowlistEgress:    allowlistSupported,
-		backend.CapabilityNetworkStageScopedEgress:  allowlistSupported && dnsControlSupported,
-		backend.CapabilityDNSControlOrEquivalent:    dnsControlSupported,
-		backend.CapabilityNetworkGuestInterface:     true,
-		backend.CapabilitySandboxPortDial:           configuredMode == darwinVZNetworkModeFileHandle,
-		backend.CapabilitySandboxCacheOutputVolumes: true,
+		backend.CapabilityNetworkDefaultDeny:         true,
+		backend.CapabilityNetworkAllowlistEgress:     allowlistSupported,
+		backend.CapabilityNetworkStageScopedEgress:   allowlistSupported && dnsControlSupported,
+		backend.CapabilityDNSControlOrEquivalent:     dnsControlSupported,
+		backend.CapabilityNetworkGuestInterface:      true,
+		backend.CapabilitySandboxPortDial:            configuredMode == darwinVZNetworkModeFileHandle,
+		backend.CapabilitySandboxCacheOutputVolumes:  true,
+		backend.CapabilitySandboxOverlayWriteCapture: true,
 	}
 }
 

--- a/internal/backend/darwinvz/capabilities_test.go
+++ b/internal/backend/darwinvz/capabilities_test.go
@@ -46,9 +46,11 @@ func TestCapabilitiesMatchImplicitDefaultNetworkMode(t *testing.T) {
 		if !caps[backend.CapabilitySandboxCacheOutputVolumes] {
 			t.Fatalf("expected %s=true on darwin", backend.CapabilitySandboxCacheOutputVolumes)
 		}
-	}
-	if caps[backend.CapabilitySandboxOverlayWriteCapture] {
-		t.Fatalf("expected %s=false until escaped-write capture is wired through", backend.CapabilitySandboxOverlayWriteCapture)
+		if !caps[backend.CapabilitySandboxOverlayWriteCapture] {
+			t.Fatalf("expected %s=true on darwin", backend.CapabilitySandboxOverlayWriteCapture)
+		}
+	} else if caps[backend.CapabilitySandboxOverlayWriteCapture] {
+		t.Fatalf("expected %s=false", backend.CapabilitySandboxOverlayWriteCapture)
 	}
 }
 
@@ -80,7 +82,7 @@ func TestCapabilitiesDeclareAllowlistFilteringForFileHandleMode(t *testing.T) {
 	if !caps[backend.CapabilitySandboxCacheOutputVolumes] {
 		t.Fatalf("expected %s=true", backend.CapabilitySandboxCacheOutputVolumes)
 	}
-	if caps[backend.CapabilitySandboxOverlayWriteCapture] {
-		t.Fatalf("expected %s=false until escaped-write capture is wired through", backend.CapabilitySandboxOverlayWriteCapture)
+	if !caps[backend.CapabilitySandboxOverlayWriteCapture] {
+		t.Fatalf("expected %s=true", backend.CapabilitySandboxOverlayWriteCapture)
 	}
 }

--- a/internal/backend/darwinvz/persistent_test.go
+++ b/internal/backend/darwinvz/persistent_test.go
@@ -41,8 +41,8 @@ func TestCapabilitiesExposeSnapshotAndFileTransfer(t *testing.T) {
 	if !caps[backend.CapabilitySandboxCacheOutputVolumes] {
 		t.Fatalf("expected %s=true", backend.CapabilitySandboxCacheOutputVolumes)
 	}
-	if caps[backend.CapabilitySandboxOverlayWriteCapture] {
-		t.Fatalf("expected %s=false until escaped-write capture is wired through", backend.CapabilitySandboxOverlayWriteCapture)
+	if !caps[backend.CapabilitySandboxOverlayWriteCapture] {
+		t.Fatalf("expected %s=true", backend.CapabilitySandboxOverlayWriteCapture)
 	}
 	for _, key := range []string{
 		backend.CapabilitySandboxPathStat,

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -357,12 +357,13 @@ func (a *Adapter) Name() string {
 
 func (a *Adapter) Capabilities() map[string]bool {
 	return map[string]bool{
-		backend.CapabilityNetworkDefaultDeny:        true,
-		backend.CapabilityNetworkAllowlistEgress:    true,
-		backend.CapabilityDNSControlOrEquivalent:    true,
-		backend.CapabilityNetworkGuestInterface:     true,
-		backend.CapabilitySandboxPortDial:           true,
-		backend.CapabilitySandboxCacheOutputVolumes: true,
+		backend.CapabilityNetworkDefaultDeny:         true,
+		backend.CapabilityNetworkAllowlistEgress:     true,
+		backend.CapabilityDNSControlOrEquivalent:     true,
+		backend.CapabilityNetworkGuestInterface:      true,
+		backend.CapabilitySandboxPortDial:            true,
+		backend.CapabilitySandboxCacheOutputVolumes:  true,
+		backend.CapabilitySandboxOverlayWriteCapture: true,
 	}
 }
 

--- a/internal/backend/firecracker/cache_output_volumes_test.go
+++ b/internal/backend/firecracker/cache_output_volumes_test.go
@@ -14,15 +14,15 @@ import (
 	"github.com/buildkite/cleanroom/internal/vsockexec"
 )
 
-func TestCapabilitiesAdvertiseCacheOutputVolumesWithoutOverlayCapture(t *testing.T) {
+func TestCapabilitiesAdvertiseCacheOutputVolumesWithOverlayCapture(t *testing.T) {
 	t.Parallel()
 
 	caps := (&Adapter{}).Capabilities()
 	if !caps[backend.CapabilitySandboxCacheOutputVolumes] {
 		t.Fatalf("expected %s capability", backend.CapabilitySandboxCacheOutputVolumes)
 	}
-	if caps[backend.CapabilitySandboxOverlayWriteCapture] {
-		t.Fatalf("did not expect %s capability before overlay execution is implemented", backend.CapabilitySandboxOverlayWriteCapture)
+	if !caps[backend.CapabilitySandboxOverlayWriteCapture] {
+		t.Fatalf("expected %s capability", backend.CapabilitySandboxOverlayWriteCapture)
 	}
 }
 


### PR DESCRIPTION
## Problem

The dependency/service volume-cache runtime now has the pieces needed to enforce the file-keyed cache contract on the managed VM backends: sidecar output volumes, guest mounts, isolated input projections, overlay write capture, snapshot publication, and escaped-write exact fallback. Until the backends advertise `sandbox.overlay_write_capture`, the control service still treats the per-block volume-cache path as unsupported and falls back to aggregate stage caching.

This PR is the capability-advertisement slice for `docs/plans/dependency-service-volume-caches.md`. It lets Firecracker and darwin-vz opt into the block-volume runtime path after the real VM validation and fallback slices have landed.

## Changes

- Advertise `sandbox.overlay_write_capture` from Firecracker.
- Advertise `sandbox.overlay_write_capture` from darwin-vz on macOS.
- Update backend capability tests so the runtime gate is explicit.

## Validation

- `GOCACHE=/private/tmp/cleanroom-go-build-cache mise exec -- go test ./internal/backend/... ./internal/controlservice`
- `GOCACHE=/private/tmp/cleanroom-go-build-cache mise exec -- go test ./...`
- `docker run --rm -v "$PWD":/work -v /Users/lachlan/Develop/cleanroom/.git:/Users/lachlan/Develop/cleanroom/.git:ro -w /work -e GOCACHE=/tmp/go-build-cache golang:1.26.2 go test ./...`
