### PR TITLE
fix: Repair Firecracker volume cache misses

### DIFF
--- a/internal/backend/firecracker/cache_output_volumes.go
+++ b/internal/backend/firecracker/cache_output_volumes.go
@@ -166,8 +166,16 @@ func createEmptyCacheOutputExt4Image(ctx context.Context, path string, minimumBy
 		return fmt.Errorf("create empty cache output image directory: %w", err)
 	}
 	sizeBytes := ext4image.AlignBytes(minimumBytes)
-	if err := os.Truncate(path, sizeBytes); err != nil {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o600)
+	if err != nil {
+		return fmt.Errorf("create empty cache output image %q: %w", path, err)
+	}
+	if err := file.Truncate(sizeBytes); err != nil {
+		_ = file.Close()
 		return fmt.Errorf("truncate empty cache output image %q to %d bytes: %w", path, sizeBytes, err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close empty cache output image %q: %w", path, err)
 	}
 	mkfsPath, err := hosttools.ResolveE2FSProgsBinary("mkfs.ext4")
 	if err != nil {

--- a/internal/backend/firecracker/cache_output_volumes_test.go
+++ b/internal/backend/firecracker/cache_output_volumes_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/ext4image"
 	"github.com/buildkite/cleanroom/internal/volumestore"
 	"github.com/buildkite/cleanroom/internal/vsockexec"
 )
@@ -138,6 +139,27 @@ func TestPrepareCacheOutputVolumesClonesHitsAndCreatesMisses(t *testing.T) {
 	}
 	if got, want := destroyReqs[0].VolumeRef, prepared[1].Volume.Ref; got != want {
 		t.Fatalf("expected reverse cleanup order first ref %q, got %q", want, got)
+	}
+}
+
+func TestCreateEmptyCacheOutputExt4ImageCreatesMissingFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	mkfsPath := filepath.Join(tmpDir, "mkfs.ext4")
+	if err := os.WriteFile(mkfsPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write fake mkfs.ext4: %v", err)
+	}
+	t.Setenv("PATH", tmpDir)
+
+	imagePath := filepath.Join(tmpDir, "nested", "cache-output-empty-base.ext4")
+	if err := createEmptyCacheOutputExt4Image(context.Background(), imagePath, 1); err != nil {
+		t.Fatalf("createEmptyCacheOutputExt4Image returned error: %v", err)
+	}
+	info, err := os.Stat(imagePath)
+	if err != nil {
+		t.Fatalf("stat image: %v", err)
+	}
+	if got, want := info.Size(), ext4image.AlignBytes(1); got != want {
+		t.Fatalf("unexpected image size: got %d want %d", got, want)
 	}
 }
 

--- a/internal/backend/firecracker/host_runtime.go
+++ b/internal/backend/firecracker/host_runtime.go
@@ -323,6 +323,15 @@ func (r hostRuntimeVolumeCommandRunner) Output(ctx context.Context, command stri
 	return r.runner.Output(ctx, append([]string{command}, args...)...)
 }
 
+func (r hostRuntimeVolumeCommandRunner) WaitForDevicePath(ctx context.Context, path string) error {
+	if waiter, ok := r.runner.(interface {
+		WaitForDevicePath(context.Context, string) error
+	}); ok {
+		return waiter.WaitForDevicePath(ctx, path)
+	}
+	return volumestore.WaitForZvolDevicePath(ctx, path)
+}
+
 func (r hostRuntimeVolumeCommandRunner) OutputTo(ctx context.Context, dst io.Writer, command string, args ...string) error {
 	streamer, ok := r.runner.(interface {
 		OutputTo(context.Context, io.Writer, ...string) error

--- a/internal/backend/firecracker/privileged_test.go
+++ b/internal/backend/firecracker/privileged_test.go
@@ -80,6 +80,10 @@ func (r testPrivilegedCommandRunner) Output(ctx context.Context, args ...string)
 	return r.output(ctx, args...)
 }
 
+func (r testPrivilegedCommandRunner) WaitForDevicePath(context.Context, string) error {
+	return nil
+}
+
 func (r testPrivilegedCommandRunner) RunBatch(ctx context.Context, commands [][]string) error {
 	if r.runBatch == nil {
 		return nil

--- a/internal/volumestore/zfs.go
+++ b/internal/volumestore/zfs.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 	"unicode"
 )
 
@@ -18,11 +19,15 @@ const zfsBaseNamespace = "base"
 const zfsSandboxNamespace = "sandboxes"
 const zfsSnapshotNamespace = "snapshots"
 const zfsSnapshotImportNamespace = "imports"
+const zfsDeviceWaitTimeout = 5 * time.Second
+const zfsDeviceWaitInterval = 100 * time.Millisecond
 
 type ZFSCommandRunner interface {
 	Run(ctx context.Context, command string, args ...string) error
 	Output(ctx context.Context, command string, args ...string) ([]byte, error)
 }
+
+type ZFSDeviceWaiter func(context.Context, string) error
 
 type ZFSCommandOutputStreamer interface {
 	OutputTo(ctx context.Context, dst io.Writer, command string, args ...string) error
@@ -36,6 +41,7 @@ type ZFSDriverOptions struct {
 	DatasetRoot             string
 	Runner                  ZFSCommandRunner
 	Stat                    func(string) (os.FileInfo, error)
+	DeviceWaiter            ZFSDeviceWaiter
 	DisableSnapshotMetadata bool
 }
 
@@ -43,6 +49,7 @@ type ZFSDriver struct {
 	datasetRoot             string
 	runner                  ZFSCommandRunner
 	stat                    func(string) (os.FileInfo, error)
+	deviceWaiter            ZFSDeviceWaiter
 	disableSnapshotMetadata bool
 }
 
@@ -59,11 +66,23 @@ func NewZFSDriver(opts ZFSDriverOptions) (*ZFSDriver, error) {
 	if statFn == nil {
 		statFn = os.Stat
 	}
+	deviceWaiter := opts.DeviceWaiter
+	if deviceWaiter == nil {
+		if runnerWaiter, ok := opts.Runner.(interface {
+			WaitForDevicePath(context.Context, string) error
+		}); ok {
+			deviceWaiter = runnerWaiter.WaitForDevicePath
+		}
+	}
+	if deviceWaiter == nil {
+		deviceWaiter = WaitForZvolDevicePath
+	}
 
 	return &ZFSDriver{
 		datasetRoot:             datasetRoot,
 		runner:                  opts.Runner,
 		stat:                    statFn,
+		deviceWaiter:            deviceWaiter,
 		disableSnapshotMetadata: opts.DisableSnapshotMetadata,
 	}, nil
 }
@@ -98,7 +117,12 @@ func (d *ZFSDriver) EnsureBaseVolume(ctx context.Context, req EnsureBaseVolumeRe
 		if err := d.runner.Run(ctx, "zfs", "create", "-p", "-V", strconv.FormatInt(volumeSize, 10), baseDataset); err != nil {
 			return BaseVolume{}, fmt.Errorf("create zfs base volume %q: %w", baseDataset, err)
 		}
-		if err := d.runner.Run(ctx, "dd", "if="+sourcePath, "of="+zvolDevicePath(baseDataset), "bs=4M", "conv=fsync", "status=none"); err != nil {
+		devicePath := zvolDevicePath(baseDataset)
+		if err := d.deviceWaiter(ctx, devicePath); err != nil {
+			_ = d.runner.Run(context.Background(), "zfs", "destroy", "-r", baseDataset)
+			return BaseVolume{}, fmt.Errorf("wait for zfs base volume device %q: %w", devicePath, err)
+		}
+		if err := d.runner.Run(ctx, "dd", "if="+sourcePath, "of="+devicePath, "bs=4M", "conv=fsync", "status=none"); err != nil {
 			_ = d.runner.Run(context.Background(), "zfs", "destroy", "-r", baseDataset)
 			return BaseVolume{}, fmt.Errorf("initialize zfs base volume %q: %w", baseDataset, err)
 		}
@@ -653,9 +677,14 @@ func (d *ZFSDriver) cloneSnapshot(ctx context.Context, snapshotRef, dataset stri
 	if err := d.runner.Run(ctx, "zfs", "clone", "-p", snapshotRef, dataset); err != nil {
 		return WritableVolume{}, fmt.Errorf("clone zfs snapshot %q into %q: %w", snapshotRef, dataset, err)
 	}
+	devicePath := zvolDevicePath(dataset)
+	if err := d.deviceWaiter(ctx, devicePath); err != nil {
+		_ = d.runner.Run(context.Background(), "zfs", "destroy", "-r", dataset)
+		return WritableVolume{}, fmt.Errorf("wait for zfs clone device %q: %w", devicePath, err)
+	}
 	return WritableVolume{
 		Ref:            dataset,
-		AttachmentPath: zvolDevicePath(dataset),
+		AttachmentPath: devicePath,
 	}, nil
 }
 
@@ -708,6 +737,34 @@ func sanitizeZFSDatasetComponent(value string) string {
 
 func zvolDevicePath(dataset string) string {
 	return filepath.Join(append([]string{"/dev/zvol"}, strings.Split(strings.TrimSpace(dataset), "/")...)...)
+}
+
+func WaitForZvolDevicePath(ctx context.Context, path string) error {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return errors.New("missing zvol device path")
+	}
+
+	deadline := time.NewTimer(zfsDeviceWaitTimeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(zfsDeviceWaitInterval)
+	defer ticker.Stop()
+
+	for {
+		if _, err := os.Stat(path); err == nil {
+			return nil
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("inspect zvol device path %q: %w", path, err)
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-deadline.C:
+			return fmt.Errorf("timed out waiting for zvol device path %q", path)
+		case <-ticker.C:
+		}
+	}
 }
 
 func parseZFSSendEstimateBytes(out []byte) int64 {

--- a/internal/volumestore/zfs_test.go
+++ b/internal/volumestore/zfs_test.go
@@ -86,6 +86,10 @@ func (r *zfsTestRunner) Run(_ context.Context, command string, args ...string) e
 	return nil
 }
 
+func (r *zfsTestRunner) WaitForDevicePath(context.Context, string) error {
+	return nil
+}
+
 func (r *zfsTestRunner) Output(_ context.Context, command string, args ...string) ([]byte, error) {
 	r.commands = append(r.commands, strings.Join(append([]string{command}, args...), " "))
 	if command == "zfs" && len(args) == 7 && args[0] == "list" && args[1] == "-H" && args[2] == "-d" && args[3] == "1" && args[4] == "-o" && args[5] == "name" {
@@ -306,6 +310,82 @@ func TestZFSDriverEnsureBaseVolumeAndCloneLifecycle(t *testing.T) {
 		"zfs snapshot tank/cleanroom/base/runtime-key@base",
 		"zfs list -H -o name tank/cleanroom/sandboxes/sandbox-1",
 		"zfs clone -p tank/cleanroom/base/runtime-key@base tank/cleanroom/sandboxes/sandbox-1",
+	}
+	if got, want := runner.commands, wantCommands; strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("unexpected zfs commands:\n got: %v\nwant: %v", got, want)
+	}
+}
+
+func TestZFSDriverEnsureBaseVolumeWaitsForZvolDeviceBeforeDD(t *testing.T) {
+	sourcePath := filepath.Join(t.TempDir(), "prepared.ext4")
+	if err := os.WriteFile(sourcePath, []byte("base-bytes"), 0o644); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+
+	runner := &zfsTestRunner{exists: map[string]bool{}}
+	driver, err := NewZFSDriver(ZFSDriverOptions{
+		DatasetRoot: "tank/cleanroom",
+		Runner:      runner,
+		DeviceWaiter: func(_ context.Context, path string) error {
+			runner.commands = append(runner.commands, "wait "+path)
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewZFSDriver returned error: %v", err)
+	}
+
+	if _, err := driver.EnsureBaseVolume(context.Background(), EnsureBaseVolumeRequest{
+		BaseID:     "runtime-key",
+		SourcePath: sourcePath,
+	}); err != nil {
+		t.Fatalf("EnsureBaseVolume returned error: %v", err)
+	}
+
+	wantCommands := []string{
+		"zfs list -H -o name tank/cleanroom/base/runtime-key",
+		"zfs create -p -V 10 tank/cleanroom/base/runtime-key",
+		"wait /dev/zvol/tank/cleanroom/base/runtime-key",
+		"dd if=" + sourcePath + " of=/dev/zvol/tank/cleanroom/base/runtime-key bs=4M conv=fsync status=none",
+		"zfs list -H -o name tank/cleanroom/base/runtime-key@base",
+		"zfs snapshot tank/cleanroom/base/runtime-key@base",
+	}
+	if got, want := runner.commands, wantCommands; strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("unexpected zfs commands:\n got: %v\nwant: %v", got, want)
+	}
+}
+
+func TestZFSDriverCloneWaitsForZvolDeviceBeforeReturn(t *testing.T) {
+	runner := &zfsTestRunner{exists: map[string]bool{
+		"tank/cleanroom/base/runtime-key@base": true,
+	}}
+	driver, err := NewZFSDriver(ZFSDriverOptions{
+		DatasetRoot: "tank/cleanroom",
+		Runner:      runner,
+		DeviceWaiter: func(_ context.Context, path string) error {
+			runner.commands = append(runner.commands, "wait "+path)
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewZFSDriver returned error: %v", err)
+	}
+
+	volume, err := driver.CreateWritableVolume(context.Background(), CreateWritableVolumeRequest{
+		VolumeID: "sandbox-1",
+		BaseRef:  "tank/cleanroom/base/runtime-key@base",
+	})
+	if err != nil {
+		t.Fatalf("CreateWritableVolume returned error: %v", err)
+	}
+	if got, want := volume.AttachmentPath, "/dev/zvol/tank/cleanroom/sandboxes/sandbox-1"; got != want {
+		t.Fatalf("unexpected attachment path: got %q want %q", got, want)
+	}
+
+	wantCommands := []string{
+		"zfs list -H -o name tank/cleanroom/sandboxes/sandbox-1",
+		"zfs clone -p tank/cleanroom/base/runtime-key@base tank/cleanroom/sandboxes/sandbox-1",
+		"wait /dev/zvol/tank/cleanroom/sandboxes/sandbox-1",
 	}
 	if got, want := runner.commands, wantCommands; strings.Join(got, "\n") != strings.Join(want, "\n") {
 		t.Fatalf("unexpected zfs commands:\n got: %v\nwant: %v", got, want)


### PR DESCRIPTION
## Summary

Fixes two Linux/Firecracker blockers found during manual SSM testing of dependency and service output-volume caches:

- create the empty cache-output ext4 image before truncating it, so file-backed Firecracker cache misses can prepare a writable output volume
- wait for ZFS zvol device paths after `zfs create -V` and `zfs clone`, so root-run daemons do not race `/dev/zvol/...` before `dd` or Firecracker attach

## Validation

- `mise exec -- go test ./internal/backend/firecracker ./internal/volumestore`
- Installed this branch on Linux dev box `i-010794cab2e52df3a` via SSM
- `cleanroom version v0.6.0-54-gf2d7dd1`
- `cleanroom doctor --json` reported backend `firecracker`, snapshot driver `zfs`, `sandbox.cache_output_volumes=true`, and `sandbox.overlay_write_capture=true`
- Live ZFS-backed Firecracker manual suite passed:
  - source-only commit change reused dependency and service output volumes
  - README-only input change invalidated only the service output volume
  - escaped writes emitted warnings, preserved the escaped marker, and did not reuse the declared output cache across a source-only commit
  - cleanup left `cleanroom sandbox ls --json` at `0`

## Notes

This PR keeps the public policy surface unchanged. The ZFS wait lives in the volume driver so it covers direct-root daemon execution as well as helper-backed execution.
