### PR TITLE
docs: Fix observability collector ports

### DIFF
--- a/examples/observability/README.md
+++ b/examples/observability/README.md
@@ -4,7 +4,7 @@ This example runs a local Grafana + Prometheus + Tempo stack with an OpenTelemet
 
 The data flow is:
 
-- Cleanroom sends OTLP traces and metrics to the collector on `localhost:4317` or `localhost:4318`.
+- Cleanroom sends OTLP traces and metrics to the collector on `localhost:14317` or `localhost:14318`.
 - The collector forwards traces to Tempo.
 - The collector exposes OTLP metrics as a Prometheus scrape endpoint.
 - Tempo generates trace-derived service graph and span metrics and remote-writes them to Prometheus.


### PR DESCRIPTION
## Summary
- Fix the observability example data-flow text to use the host collector ports exposed by the Compose stack.

## Validation
- Verified `examples/observability/README.md`, `docs/observability.md`, and `examples/observability/docker-compose.yaml` now agree on `14317`/`14318`.
- Docs-only change; no runtime tests run.
