### PR TITLE
fix: Report fast clone capability from snapshot driver

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -89,14 +89,7 @@ func (d *DoctorCommand) Run(ctx *runtimeContext) error {
 		},
 	)
 	for _, key := range backend.SortedCapabilityKeys(capabilities) {
-		status := "warn"
-		message := fmt.Sprintf("%s: unsupported", key)
-		if capabilities[key] {
-			status = "pass"
-			message = fmt.Sprintf("%s: supported", key)
-		} else if disabledMessage, ok := disabledSnapshotCapabilityMessage(key, backendName, ctx.Config, ctx.ConfigPath, adapterCapabilities); ok {
-			message = disabledMessage
-		}
+		status, message := capabilityDoctorStatus(key, capabilities, backendName, ctx.Config, ctx.ConfigPath, adapterCapabilities)
 		checks = append(checks, backend.DoctorCheck{
 			Name:    capabilityCheckName(key),
 			Status:  status,
@@ -228,10 +221,60 @@ func applyRuntimeCapabilityOverrides(caps map[string]bool, backendName string, c
 	out := backend.CloneCapabilities(caps)
 	snapshotCfg, ok := runtimeconfig.SnapshotConfigForBackend(cfg, backendName)
 	if ok && snapshotCfg.Enabled {
+		out[backend.CapabilitySandboxCacheOutputFastClone] = out[backend.CapabilitySandboxCacheOutputVolumes] &&
+			cacheOutputFastCloneSupportedByConfig(backendName, snapshotCfg)
 		return out
 	}
 	out[backend.CapabilitySandboxSnapshot] = false
+	out[backend.CapabilitySandboxCacheOutputFastClone] = false
 	return out
+}
+
+func capabilityDoctorStatus(capabilityKey string, capabilities map[string]bool, backendName string, cfg runtimeconfig.Config, configPath string, adapterCaps map[string]bool) (string, string) {
+	if capabilityKey == backend.CapabilitySandboxCacheOutputFastClone {
+		return cacheOutputFastCloneDoctorStatus(capabilities[capabilityKey], backendName, cfg)
+	}
+	if capabilities[capabilityKey] {
+		return "pass", fmt.Sprintf("%s: supported", capabilityKey)
+	}
+	if disabledMessage, ok := disabledSnapshotCapabilityMessage(capabilityKey, backendName, cfg, configPath, adapterCaps); ok {
+		return "warn", disabledMessage
+	}
+	return "warn", fmt.Sprintf("%s: unsupported", capabilityKey)
+}
+
+func cacheOutputFastCloneDoctorStatus(supported bool, backendName string, cfg runtimeconfig.Config) (string, string) {
+	const capability = backend.CapabilitySandboxCacheOutputFastClone
+	snapshotCfg, ok := runtimeconfig.SnapshotConfigForBackend(cfg, backendName)
+	if !ok {
+		return "warn", fmt.Sprintf("%s: unsupported", capability)
+	}
+	driver := runtimeconfig.SnapshotDriverOrDefault(backendName, snapshotCfg.Driver)
+	if supported {
+		if strings.EqualFold(strings.TrimSpace(backendName), "darwin-vz") && strings.EqualFold(driver, "apfs") {
+			return "pass", fmt.Sprintf("%s: supported by configured snapshot driver %q; falls back to copying if clonefile is unavailable", capability, driver)
+		}
+		return "pass", fmt.Sprintf("%s: supported by configured snapshot driver %q", capability, driver)
+	}
+	if !snapshotCfg.Enabled {
+		return "warn", fmt.Sprintf("%s: requires snapshots to be enabled", capability)
+	}
+	if strings.EqualFold(strings.TrimSpace(backendName), "firecracker") && strings.EqualFold(driver, "zfs") && strings.TrimSpace(snapshotCfg.ZFSDataset) == "" {
+		return "warn", fmt.Sprintf("%s: unsupported because zfs snapshot driver requires snapshots.zfs_dataset", capability)
+	}
+	return "warn", fmt.Sprintf("%s: unsupported by configured snapshot driver %q", capability, driver)
+}
+
+func cacheOutputFastCloneSupportedByConfig(backendName string, snapshotCfg runtimeconfig.SnapshotConfig) bool {
+	driver := runtimeconfig.SnapshotDriverOrDefault(backendName, snapshotCfg.Driver)
+	switch strings.TrimSpace(backendName) {
+	case "darwin-vz":
+		return strings.EqualFold(driver, "apfs")
+	case "firecracker":
+		return strings.EqualFold(driver, "zfs") && strings.TrimSpace(snapshotCfg.ZFSDataset) != ""
+	default:
+		return false
+	}
 }
 
 func disabledSnapshotCapabilityMessage(capabilityKey, backendName string, cfg runtimeconfig.Config, configPath string, adapterCaps map[string]bool) (string, bool) {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -61,6 +61,33 @@ func (doctorSnapshotAdapter) DeleteSnapshot(context.Context, backend.DeleteSnaps
 	return nil
 }
 
+type doctorCacheOutputAdapter struct{ doctorTestAdapter }
+
+func (doctorCacheOutputAdapter) Capabilities() map[string]bool {
+	return map[string]bool{
+		backend.CapabilityExecStreaming:               true,
+		backend.CapabilitySandboxSnapshot:             true,
+		backend.CapabilitySandboxFileDownload:         true,
+		backend.CapabilitySandboxFileUpload:           true,
+		backend.CapabilitySandboxPathStat:             true,
+		backend.CapabilitySandboxTreeWalk:             true,
+		backend.CapabilitySandboxFileRead:             true,
+		backend.CapabilitySandboxFileWrite:            true,
+		backend.CapabilitySandboxPathRemove:           true,
+		backend.CapabilitySandboxArchiveRead:          true,
+		backend.CapabilitySandboxArchiveWrite:         true,
+		backend.CapabilityNetworkDefaultDeny:          true,
+		backend.CapabilityNetworkAllowlistEgress:      true,
+		backend.CapabilityNetworkStageScopedEgress:    true,
+		backend.CapabilityDNSControlOrEquivalent:      true,
+		backend.CapabilityNetworkGuestInterface:       true,
+		backend.CapabilitySandboxPortDial:             true,
+		backend.CapabilitySandboxCacheOutputVolumes:   true,
+		backend.CapabilitySandboxCacheOutputFastClone: false,
+		backend.CapabilitySandboxOverlayWriteCapture:  true,
+	}
+}
+
 type doctorFailingLoader struct{}
 
 func (doctorFailingLoader) LoadAndCompile(string) (*policy.CompiledPolicy, string, error) {
@@ -69,6 +96,16 @@ func (doctorFailingLoader) LoadAndCompile(string) (*policy.CompiledPolicy, strin
 
 func (doctorFailingLoader) LoadRepository(string) (policy.RepositoryConfig, string, error) {
 	return policy.RepositoryConfig{}, "", errors.New("policy unavailable")
+}
+
+type doctorStaticLoader struct{}
+
+func (doctorStaticLoader) LoadAndCompile(cwd string) (*policy.CompiledPolicy, string, error) {
+	return &policy.CompiledPolicy{Hash: "policy_hash"}, filepath.Join(cwd, "cleanroom.yaml"), nil
+}
+
+func (doctorStaticLoader) LoadRepository(string) (policy.RepositoryConfig, string, error) {
+	return policy.RepositoryConfig{}, "", nil
 }
 
 func TestDoctorCommandJSONIncludesCapabilities(t *testing.T) {
@@ -165,6 +202,182 @@ func TestDoctorCommandJSONIncludesCapabilities(t *testing.T) {
 	}
 	if !foundCapabilityCheck {
 		t.Fatal("expected capability_network_guest_interface check in doctor output")
+	}
+}
+
+func TestApplyRuntimeCapabilityOverridesConfiguresFastCloneBySnapshotDriver(t *testing.T) {
+	baseCaps := map[string]bool{
+		backend.CapabilitySandboxSnapshot:           true,
+		backend.CapabilitySandboxCacheOutputVolumes: true,
+	}
+
+	tests := []struct {
+		name        string
+		backendName string
+		config      runtimeconfig.Config
+		wantFast    bool
+		wantSnap    bool
+	}{
+		{
+			name:        "darwin-vz default apfs",
+			backendName: "darwin-vz",
+			config: runtimeconfig.Config{
+				Backends: runtimeconfig.Backends{
+					DarwinVZ: runtimeconfig.DarwinVZConfig{
+						Snapshots: runtimeconfig.SnapshotConfig{Enabled: true},
+					},
+				},
+			},
+			wantFast: true,
+			wantSnap: true,
+		},
+		{
+			name:        "darwin-vz file",
+			backendName: "darwin-vz",
+			config: runtimeconfig.Config{
+				Backends: runtimeconfig.Backends{
+					DarwinVZ: runtimeconfig.DarwinVZConfig{
+						Snapshots: runtimeconfig.SnapshotConfig{Enabled: true, Driver: "file"},
+					},
+				},
+			},
+			wantFast: false,
+			wantSnap: true,
+		},
+		{
+			name:        "firecracker zfs",
+			backendName: "firecracker",
+			config: runtimeconfig.Config{
+				Backends: runtimeconfig.Backends{
+					Firecracker: runtimeconfig.FirecrackerConfig{
+						Snapshots: runtimeconfig.SnapshotConfig{Enabled: true, Driver: "zfs", ZFSDataset: "tank/cleanroom"},
+					},
+				},
+			},
+			wantFast: true,
+			wantSnap: true,
+		},
+		{
+			name:        "firecracker zfs without dataset",
+			backendName: "firecracker",
+			config: runtimeconfig.Config{
+				Backends: runtimeconfig.Backends{
+					Firecracker: runtimeconfig.FirecrackerConfig{
+						Snapshots: runtimeconfig.SnapshotConfig{Enabled: true, Driver: "zfs"},
+					},
+				},
+			},
+			wantFast: false,
+			wantSnap: true,
+		},
+		{
+			name:        "firecracker file",
+			backendName: "firecracker",
+			config: runtimeconfig.Config{
+				Backends: runtimeconfig.Backends{
+					Firecracker: runtimeconfig.FirecrackerConfig{
+						Snapshots: runtimeconfig.SnapshotConfig{Enabled: true, Driver: "file"},
+					},
+				},
+			},
+			wantFast: false,
+			wantSnap: true,
+		},
+		{
+			name:        "snapshots disabled",
+			backendName: "darwin-vz",
+			config: runtimeconfig.Config{
+				Backends: runtimeconfig.Backends{
+					DarwinVZ: runtimeconfig.DarwinVZConfig{
+						Snapshots: runtimeconfig.SnapshotConfig{Enabled: false, Driver: "apfs"},
+					},
+				},
+			},
+			wantFast: false,
+			wantSnap: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := applyRuntimeCapabilityOverrides(baseCaps, tt.backendName, tt.config)
+			if got[backend.CapabilitySandboxCacheOutputFastClone] != tt.wantFast {
+				t.Fatalf("unexpected %s: got %t want %t", backend.CapabilitySandboxCacheOutputFastClone, got[backend.CapabilitySandboxCacheOutputFastClone], tt.wantFast)
+			}
+			if got[backend.CapabilitySandboxSnapshot] != tt.wantSnap {
+				t.Fatalf("unexpected %s: got %t want %t", backend.CapabilitySandboxSnapshot, got[backend.CapabilitySandboxSnapshot], tt.wantSnap)
+			}
+		})
+	}
+}
+
+func TestDoctorCommandReportsConfiguredFastCloneCapability(t *testing.T) {
+	tmpDir := t.TempDir()
+	stdoutPath := filepath.Join(tmpDir, "doctor.json")
+	stdout, err := os.Create(stdoutPath)
+	if err != nil {
+		t.Fatalf("create stdout file: %v", err)
+	}
+
+	cmd := DoctorCommand{
+		Backend: "darwin-vz",
+		JSON:    true,
+	}
+	err = cmd.Run(&runtimeContext{
+		CWD:    tmpDir,
+		Stdout: stdout,
+		Loader: doctorStaticLoader{},
+		Config: runtimeconfig.Config{
+			Backends: runtimeconfig.Backends{
+				DarwinVZ: runtimeconfig.DarwinVZConfig{
+					Snapshots: runtimeconfig.SnapshotConfig{Enabled: true},
+				},
+			},
+		},
+		ConfigPath: filepath.Join(tmpDir, "config.yaml"),
+		Backends: map[string]backend.Adapter{
+			"darwin-vz": doctorCacheOutputAdapter{},
+		},
+	})
+	if closeErr := stdout.Close(); closeErr != nil {
+		t.Fatalf("close stdout file: %v", closeErr)
+	}
+	if err != nil {
+		t.Fatalf("DoctorCommand.Run returned error: %v", err)
+	}
+
+	raw, err := os.ReadFile(stdoutPath)
+	if err != nil {
+		t.Fatalf("read doctor output: %v", err)
+	}
+
+	var payload struct {
+		Capabilities map[string]bool       `json:"capabilities"`
+		Checks       []backend.DoctorCheck `json:"checks"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("unmarshal doctor JSON: %v", err)
+	}
+
+	if !payload.Capabilities[backend.CapabilitySandboxCacheOutputFastClone] {
+		t.Fatalf("expected %s=true", backend.CapabilitySandboxCacheOutputFastClone)
+	}
+
+	foundFastCloneCheck := false
+	for _, check := range payload.Checks {
+		if check.Name != "capability_sandbox_cache_output_fast_clone" {
+			continue
+		}
+		foundFastCloneCheck = true
+		if check.Status != "pass" {
+			t.Fatalf("expected fast clone capability check to pass, got %q", check.Status)
+		}
+		if !strings.Contains(check.Message, "supported by configured snapshot driver \"apfs\"") {
+			t.Fatalf("expected apfs support message, got %q", check.Message)
+		}
+	}
+	if !foundFastCloneCheck {
+		t.Fatal("expected capability_sandbox_cache_output_fast_clone check in doctor output")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Report `sandbox.cache_output_fast_clone` from the configured backend snapshot driver instead of treating it as generically unsupported.
- Mark fast clone supported for darwin-vz/APFS and Firecracker/ZFS with a configured dataset; keep file-backed snapshots as unsupported.
- Keep the machine-readable capabilities map aligned with the rendered doctor checks.

## Validation
- `mise exec -- go test ./internal/cli`
- `mise exec -- go run ./cmd/cleanroom doctor` reports `summary: 41 pass, 0 warn, 0 fail` on local darwin-vz/APFS config.
