### PR TITLE
refactor: Consolidate block volume publishing

### DIFF
--- a/docs/plans/dependency-service-volume-caches.md
+++ b/docs/plans/dependency-service-volume-caches.md
@@ -2,7 +2,7 @@
 
 **Spec reference:** `spec.md` sections 5.1.1, 5.2, 6.4
 **Status:** Ready for initial Firecracker and darwin-vz release
-**Last reviewed:** 2026-05-04
+**Last reviewed:** 2026-05-05
 
 ## Summary
 
@@ -1056,6 +1056,30 @@ Remaining darwin-vz follow-up work:
 - keep expanding macOS smoke coverage with real dependency/service workloads
 - decide whether output volume sizing stays internal or becomes policy-visible
   after real workloads show the right default
+
+## Refactoring Follow-up
+
+The release-ready implementation deliberately landed feature slices before
+collapsing duplication. The follow-up refactor should keep policy, cache keys,
+metadata, backend requests, and guest behavior stable while improving cohesion
+inside the control service and backend adapters.
+
+Reviewable slices:
+
+- Slice 1: consolidate dependency and service block-volume publication around
+  one shared snapshot, metadata, rollback, and logging path.
+- Slice 2: collapse dependency and service block-volume planning into a shared
+  block plan with explicit phase inputs for the cache-key differences.
+- Slice 3: collapse dependency and service block execution after the shared
+  plan shape exists, preserving the service fallback rule when dependency
+  publication is unsafe.
+- Slice 4: extract backend-neutral cache-output volume helpers shared by
+  Firecracker and darwin-vz, while leaving VM pause, storage-driver, and launch
+  details in each adapter.
+- Slice 5: reconcile the older layered-cache plan and the unused
+  `internal/inputmanifest` package with the implemented block-volume model.
+- Slice 6: simplify `CreateSandbox` cache orchestration once the narrower
+  duplication has been removed.
 
 ## Tests
 

--- a/internal/controlservice/block_volume_publish.go
+++ b/internal/controlservice/block_volume_publish.go
@@ -1,0 +1,277 @@
+package controlservice
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/cachestore"
+	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/buildkite/cleanroom/internal/repositorychangeset"
+	"github.com/buildkite/cleanroom/internal/repositorycheckout"
+)
+
+type blockVolumePublishBlock struct {
+	BlockName               string
+	Outputs                 policy.StageBlockOutputs
+	CacheKey                string
+	CommandDigest           string
+	EnvDigest               string
+	InputManifestDigest     string
+	NormalizedOutputsDigest string
+	ProducerVersion         string
+	CacheHit                bool
+}
+
+type blockVolumePublishPhase struct {
+	StageName               string
+	PublishWarning          string
+	PersistWarning          string
+	RollbackWarning         string
+	RollbackSnapshotWarning string
+	PublishedMessage        string
+	LogWarning              func(*Service, string, string, error)
+}
+
+func (phase blockVolumePublishPhase) warn(s *Service, message, sandboxID string, err error) {
+	if phase.LogWarning == nil {
+		return
+	}
+	phase.LogWarning(s, message, sandboxID, err)
+}
+
+func (s *Service) maybePublishBlockVolumeCaches(
+	ctx context.Context,
+	adapter backend.CacheOutputVolumeSnapshottingAdapter,
+	sandboxID, backendName string,
+	compiled *policy.CompiledPolicy,
+	firecrackerCfg backend.FirecrackerConfig,
+	repository *repositorycheckout.Checkout,
+	changeset *repositorychangeset.Changeset,
+	phase blockVolumePublishPhase,
+	blocks []blockVolumePublishBlock,
+) {
+	if adapter == nil || compiled == nil || repository == nil || strings.TrimSpace(sandboxID) == "" || strings.TrimSpace(phase.StageName) == "" || len(blocks) == 0 {
+		return
+	}
+	store, err := s.cacheStoreOrErr()
+	if err != nil {
+		phase.warn(s, phase.PublishWarning, sandboxID, err)
+		return
+	}
+
+	missed := missedBlockVolumePublishBlocks(blocks)
+	if len(missed) == 0 {
+		return
+	}
+	volumeIDs := make([]string, 0, len(missed))
+	for _, block := range missed {
+		volumeIDs = append(volumeIDs, blockVolumeID(phase.StageName, block.CacheKey))
+	}
+
+	snapshotCfg := withSnapshotDriver(backendName, firecrackerCfg, firecrackerCfg.Snapshots.Driver)
+	result, err := adapter.SnapshotCacheOutputVolumes(ctx, backend.SnapshotCacheOutputVolumesRequest{
+		SandboxID:         sandboxID,
+		SnapshotIDPrefix:  newSnapshotID(),
+		VolumeIDs:         volumeIDs,
+		FirecrackerConfig: snapshotCfg,
+	})
+	if err != nil {
+		phase.warn(s, phase.PublishWarning, sandboxID, err)
+		return
+	}
+
+	snapshotsByVolumeID, err := blockVolumeSnapshotsByVolumeID(volumeIDs, result)
+	if err != nil {
+		s.cleanupBlockVolumeSnapshots(adapter, backendName, firecrackerCfg, phase, cacheOutputVolumeSnapshots(result))
+		phase.warn(s, phase.PublishWarning, sandboxID, err)
+		return
+	}
+
+	now := s.clock().Now()
+	records := make([]cachestore.Record, 0, len(missed))
+	snapshots := make([]backend.CacheOutputVolumeSnapshot, 0, len(missed))
+	for _, block := range missed {
+		volumeID := blockVolumeID(phase.StageName, block.CacheKey)
+		snapshots = append(snapshots, snapshotsByVolumeID[volumeID])
+	}
+	for i, block := range missed {
+		snapshot := snapshots[i]
+		record := blockVolumeCacheRecordFromSnapshot(backendName, compiled, repository, changeset, phase.StageName, block, snapshot, now)
+		if reason := blockVolumeOutputRecordMissReason(block.Outputs, record.OutputRecords); reason != "" {
+			s.cleanupBlockVolumeSnapshots(adapter, backendName, firecrackerCfg, phase, snapshots)
+			phase.warn(s, phase.PublishWarning, sandboxID, fmt.Errorf("snapshot output records for block %q do not match declared outputs: %s", block.BlockName, reason))
+			return
+		}
+		records = append(records, record)
+	}
+
+	for i, record := range records {
+		if err := store.Create(ctx, record); err != nil {
+			s.cleanupBlockVolumeSnapshots(adapter, backendName, firecrackerCfg, phase, snapshots[i:])
+			phase.warn(s, phase.PersistWarning, sandboxID, err)
+			return
+		}
+		s.logBlockVolumePublished(phase, record, sandboxID)
+	}
+}
+
+func missedBlockVolumePublishBlocks(blocks []blockVolumePublishBlock) []blockVolumePublishBlock {
+	missed := make([]blockVolumePublishBlock, 0, len(blocks))
+	for _, block := range blocks {
+		if !block.CacheHit {
+			missed = append(missed, block)
+		}
+	}
+	return missed
+}
+
+func blockVolumeSnapshotsByVolumeID(volumeIDs []string, result *backend.SnapshotCacheOutputVolumesResult) (map[string]backend.CacheOutputVolumeSnapshot, error) {
+	expected := make(map[string]struct{}, len(volumeIDs))
+	for _, volumeID := range volumeIDs {
+		volumeID = strings.TrimSpace(volumeID)
+		if volumeID != "" {
+			expected[volumeID] = struct{}{}
+		}
+	}
+	snapshots := cacheOutputVolumeSnapshots(result)
+	if len(snapshots) != len(expected) {
+		return nil, fmt.Errorf("cache output snapshot returned %d volumes, expected %d", len(snapshots), len(expected))
+	}
+	byID := make(map[string]backend.CacheOutputVolumeSnapshot, len(snapshots))
+	for _, snapshot := range snapshots {
+		volumeID := strings.TrimSpace(snapshot.VolumeID)
+		if _, ok := expected[volumeID]; !ok {
+			return nil, fmt.Errorf("cache output snapshot returned unexpected volume id %q", snapshot.VolumeID)
+		}
+		if _, exists := byID[volumeID]; exists {
+			return nil, fmt.Errorf("cache output snapshot returned duplicate volume id %q", snapshot.VolumeID)
+		}
+		if strings.TrimSpace(snapshot.SnapshotID) == "" {
+			return nil, fmt.Errorf("cache output snapshot for volume %q is missing snapshot id", snapshot.VolumeID)
+		}
+		if strings.TrimSpace(snapshot.StorageDriver) == "" || strings.TrimSpace(snapshot.StorageRef) == "" {
+			return nil, fmt.Errorf("cache output snapshot for volume %q is missing storage metadata", snapshot.VolumeID)
+		}
+		byID[volumeID] = snapshot
+	}
+	return byID, nil
+}
+
+func cacheOutputVolumeSnapshots(result *backend.SnapshotCacheOutputVolumesResult) []backend.CacheOutputVolumeSnapshot {
+	if result == nil || len(result.Volumes) == 0 {
+		return nil
+	}
+	return append([]backend.CacheOutputVolumeSnapshot(nil), result.Volumes...)
+}
+
+func blockVolumeCacheRecordFromSnapshot(
+	backendName string,
+	compiled *policy.CompiledPolicy,
+	repository *repositorycheckout.Checkout,
+	changeset *repositorychangeset.Changeset,
+	stageName string,
+	block blockVolumePublishBlock,
+	snapshot backend.CacheOutputVolumeSnapshot,
+	now time.Time,
+) cachestore.Record {
+	record := cachestore.Record{
+		CacheKey:                strings.TrimSpace(block.CacheKey),
+		Stage:                   strings.TrimSpace(stageName),
+		State:                   cacheStateReady,
+		BackingSnapshotID:       strings.TrimSpace(snapshot.SnapshotID),
+		Backend:                 strings.TrimSpace(backendName),
+		Architecture:            runtime.GOARCH,
+		PolicyHash:              compiled.Hash,
+		Policy:                  compiled.ToProto(),
+		Repository:              cloneRepositoryCheckout(normalizeRepositoryCheckoutForComparison(repository)).ToProto(),
+		RepositoryHasChangeset:  changeset != nil,
+		RepositoryChangesetID:   repositoryChangesetID(repository, changeset),
+		StorageDriver:           strings.TrimSpace(snapshot.StorageDriver),
+		StorageRef:              strings.TrimSpace(snapshot.StorageRef),
+		StorageSizeBytes:        snapshot.StorageSizeBytes,
+		ExclusiveSizeBytes:      snapshot.ExclusiveSizeBytes,
+		DriverMetadata:          strings.TrimSpace(snapshot.DriverMetadata),
+		InputManifestDigest:     strings.TrimSpace(block.InputManifestDigest),
+		CommandDigest:           strings.TrimSpace(block.CommandDigest),
+		EnvDigest:               strings.TrimSpace(block.EnvDigest),
+		NormalizedOutputsDigest: strings.TrimSpace(block.NormalizedOutputsDigest),
+		OutputRecords:           blockVolumeOutputRecordsFromSnapshot(snapshot),
+		CreatedAt:               now,
+		LastUsedAt:              now,
+		LastValidatedAt:         now.UTC(),
+		ProducerVersion:         strings.TrimSpace(block.ProducerVersion),
+	}
+	return record
+}
+
+func blockVolumeOutputRecordsFromSnapshot(snapshot backend.CacheOutputVolumeSnapshot) []cachestore.OutputRecord {
+	if len(snapshot.Outputs) == 0 {
+		return nil
+	}
+	records := make([]cachestore.OutputRecord, 0, len(snapshot.Outputs))
+	for _, output := range snapshot.Outputs {
+		records = append(records, cachestore.OutputRecord{
+			Kind:          strings.TrimSpace(output.Kind),
+			Path:          strings.TrimSpace(output.GuestPath),
+			VolumeSubpath: strings.TrimSpace(output.VolumeSubpath),
+			StorageDriver: strings.TrimSpace(snapshot.StorageDriver),
+			StorageRef:    strings.TrimSpace(snapshot.StorageRef),
+			SnapshotRef:   strings.TrimSpace(snapshot.SnapshotRef),
+		})
+	}
+	return records
+}
+
+func (s *Service) cleanupBlockVolumeSnapshots(
+	adapter backend.CacheOutputVolumeSnapshottingAdapter,
+	backendName string,
+	firecrackerCfg backend.FirecrackerConfig,
+	phase blockVolumePublishPhase,
+	snapshots []backend.CacheOutputVolumeSnapshot,
+) {
+	if len(snapshots) == 0 {
+		return
+	}
+	deleteAdapter, ok := adapter.(backend.SnapshottingAdapter)
+	if !ok {
+		phase.warn(s, phase.RollbackWarning, "", fmt.Errorf("backend %q cannot delete snapshots", backendName))
+		return
+	}
+	for i := len(snapshots) - 1; i >= 0; i-- {
+		snapshot := snapshots[i]
+		storageRef := strings.TrimSpace(snapshot.StorageRef)
+		if storageRef == "" {
+			continue
+		}
+		deleteCfg := withSnapshotDriver(backendName, firecrackerCfg, snapshot.StorageDriver)
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		err := deleteAdapter.DeleteSnapshot(cleanupCtx, backend.DeleteSnapshotRequest{
+			SnapshotID:        strings.TrimSpace(snapshot.SnapshotID),
+			StorageRef:        storageRef,
+			FirecrackerConfig: deleteCfg,
+		})
+		cancel()
+		if err != nil {
+			phase.warn(s, phase.RollbackSnapshotWarning, "", err)
+		}
+	}
+}
+
+func (s *Service) logBlockVolumePublished(phase blockVolumePublishPhase, record cachestore.Record, sandboxID string) {
+	if s == nil || s.Logger == nil {
+		return
+	}
+	s.Logger.Debug(phase.PublishedMessage,
+		"stage", strings.TrimSpace(record.Stage),
+		"cache_key", strings.TrimSpace(record.CacheKey),
+		"producer_version", strings.TrimSpace(record.ProducerVersion),
+		"storage_driver", strings.TrimSpace(record.StorageDriver),
+		"storage_ref", strings.TrimSpace(record.StorageRef),
+		"output_records", len(record.OutputRecords),
+		"sandbox_id", strings.TrimSpace(sandboxID),
+	)
+}

--- a/internal/controlservice/block_volume_publish_test.go
+++ b/internal/controlservice/block_volume_publish_test.go
@@ -1,0 +1,90 @@
+package controlservice
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/buildkite/cleanroom/internal/repositorycheckout"
+)
+
+func TestBlockVolumePublishCleansAllSnapshotsWhenOutputRecordValidationFails(t *testing.T) {
+	adapter := dependencyBlockVolumeRuntimeAdapter()
+	var deletedSnapshotIDs []string
+	adapter.deleteSnapshotFn = func(_ context.Context, req backend.DeleteSnapshotRequest) error {
+		deletedSnapshotIDs = append(deletedSnapshotIDs, req.SnapshotID)
+		return nil
+	}
+
+	svc := newTestService(adapter)
+	compiled, err := policy.FromProto(testRepositoryPolicy())
+	if err != nil {
+		t.Fatalf("FromProto returned error: %v", err)
+	}
+	repository := &repositorycheckout.Checkout{
+		RemoteURL:      "https://github.com/buildkite/cleanroom.git",
+		CommitSHA:      "0123456789abcdef0123456789abcdef01234567",
+		DestinationDir: "/workspace",
+	}
+	blocks := []blockVolumePublishBlock{
+		{
+			BlockName:               "one",
+			CacheKey:                "cache-one",
+			Outputs:                 policy.StageBlockOutputs{Dirs: []string{"/root/out-one"}},
+			CommandDigest:           "sha256:command-one",
+			EnvDigest:               "sha256:env-one",
+			InputManifestDigest:     "sha256:inputs-one",
+			NormalizedOutputsDigest: "sha256:outputs-one",
+			ProducerVersion:         dependencyVolumeProducerVersion,
+		},
+		{
+			BlockName:               "two",
+			CacheKey:                "cache-two",
+			Outputs:                 policy.StageBlockOutputs{Dirs: []string{"/root/out-two"}},
+			CommandDigest:           "sha256:command-two",
+			EnvDigest:               "sha256:env-two",
+			InputManifestDigest:     "sha256:inputs-two",
+			NormalizedOutputsDigest: "sha256:outputs-two",
+			ProducerVersion:         dependencyVolumeProducerVersion,
+		},
+	}
+	adapter.snapshotCacheOutputsFn = func(_ context.Context, req backend.SnapshotCacheOutputVolumesRequest) (*backend.SnapshotCacheOutputVolumesResult, error) {
+		return &backend.SnapshotCacheOutputVolumesResult{Volumes: []backend.CacheOutputVolumeSnapshot{
+			{
+				VolumeID:      req.VolumeIDs[0],
+				SnapshotID:    "snapshot-one",
+				StorageDriver: "file",
+				StorageRef:    "/snapshots/one.ext4",
+				Outputs: []backend.CacheOutputVolumeSnapshotOutput{
+					{Kind: "dir", GuestPath: "/root/unexpected", VolumeSubpath: "dirs/0"},
+				},
+			},
+			{
+				VolumeID:      req.VolumeIDs[1],
+				SnapshotID:    "snapshot-two",
+				StorageDriver: "file",
+				StorageRef:    "/snapshots/two.ext4",
+				Outputs: []backend.CacheOutputVolumeSnapshotOutput{
+					{Kind: "dir", GuestPath: "/root/out-two", VolumeSubpath: "dirs/0"},
+				},
+			},
+		}}, nil
+	}
+
+	svc.maybePublishBlockVolumeCaches(context.Background(), adapter, "sandbox-1", "firecracker", compiled, backend.FirecrackerConfig{}, repository, nil, dependencyBlockVolumePublishPhase, blocks)
+
+	slices.Sort(deletedSnapshotIDs)
+	if got, want := deletedSnapshotIDs, []string{"snapshot-one", "snapshot-two"}; !slices.Equal(got, want) {
+		t.Fatalf("unexpected deleted snapshots: got %v want %v", got, want)
+	}
+	cacheStore := svc.CacheStore.(*memoryCacheStore)
+	records, err := cacheStore.List(context.Background())
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if len(records) != 0 {
+		t.Fatalf("expected no cache records after validation failure, got %d", len(records))
+	}
+}

--- a/internal/controlservice/dependency_volume_publish.go
+++ b/internal/controlservice/dependency_volume_publish.go
@@ -2,17 +2,24 @@ package controlservice
 
 import (
 	"context"
-	"fmt"
-	"runtime"
-	"strings"
-	"time"
 
 	"github.com/buildkite/cleanroom/internal/backend"
-	"github.com/buildkite/cleanroom/internal/cachestore"
 	"github.com/buildkite/cleanroom/internal/policy"
 	"github.com/buildkite/cleanroom/internal/repositorychangeset"
 	"github.com/buildkite/cleanroom/internal/repositorycheckout"
 )
+
+var dependencyBlockVolumePublishPhase = blockVolumePublishPhase{
+	StageName:               dependencyVolumeStageName,
+	PublishWarning:          "publish dependency block-volume caches",
+	PersistWarning:          "persist dependency block-volume cache metadata",
+	RollbackWarning:         "rollback dependency block-volume cache snapshots",
+	RollbackSnapshotWarning: "rollback dependency block-volume cache snapshot",
+	PublishedMessage:        "dependency block-volume cache published",
+	LogWarning: func(s *Service, message, sandboxID string, err error) {
+		s.logDependencyStageWarning(message, sandboxID, err)
+	},
+}
 
 func (s *Service) maybePublishDependencyBlockVolumeCaches(
 	ctx context.Context,
@@ -24,215 +31,23 @@ func (s *Service) maybePublishDependencyBlockVolumeCaches(
 	changeset *repositorychangeset.Changeset,
 	plan dependencyBlockVolumePlan,
 ) {
-	if adapter == nil || compiled == nil || repository == nil || strings.TrimSpace(sandboxID) == "" || len(plan.Blocks) == 0 {
-		return
-	}
-	store, err := s.cacheStoreOrErr()
-	if err != nil {
-		s.logDependencyStageWarning("publish dependency block-volume caches", sandboxID, err)
-		return
-	}
-
-	missed := missedDependencyBlockVolumeBlocks(plan)
-	if len(missed) == 0 {
-		return
-	}
-	volumeIDs := make([]string, 0, len(missed))
-	for _, block := range missed {
-		volumeIDs = append(volumeIDs, blockVolumeID(dependencyVolumeStageName, block.CacheKey))
-	}
-
-	snapshotCfg := withSnapshotDriver(backendName, firecrackerCfg, firecrackerCfg.Snapshots.Driver)
-	result, err := adapter.SnapshotCacheOutputVolumes(ctx, backend.SnapshotCacheOutputVolumesRequest{
-		SandboxID:         sandboxID,
-		SnapshotIDPrefix:  newSnapshotID(),
-		VolumeIDs:         volumeIDs,
-		FirecrackerConfig: snapshotCfg,
-	})
-	if err != nil {
-		s.logDependencyStageWarning("publish dependency block-volume caches", sandboxID, err)
-		return
-	}
-
-	snapshotsByVolumeID, err := dependencyBlockVolumeSnapshotsByVolumeID(volumeIDs, result)
-	if err != nil {
-		s.cleanupDependencyBlockVolumeSnapshots(adapter, backendName, firecrackerCfg, cacheOutputVolumeSnapshots(result))
-		s.logDependencyStageWarning("publish dependency block-volume caches", sandboxID, err)
-		return
-	}
-
-	now := s.clock().Now()
-	records := make([]cachestore.Record, 0, len(missed))
-	snapshots := make([]backend.CacheOutputVolumeSnapshot, 0, len(missed))
-	for _, block := range missed {
-		volumeID := blockVolumeID(dependencyVolumeStageName, block.CacheKey)
-		snapshot := snapshotsByVolumeID[volumeID]
-		snapshots = append(snapshots, snapshot)
-		record := dependencyBlockVolumeCacheRecordFromSnapshot(backendName, compiled, repository, changeset, block, snapshot, now)
-		if reason := blockVolumeOutputRecordMissReason(block.Outputs, record.OutputRecords); reason != "" {
-			s.cleanupDependencyBlockVolumeSnapshots(adapter, backendName, firecrackerCfg, snapshots)
-			s.logDependencyStageWarning("publish dependency block-volume caches", sandboxID, fmt.Errorf("snapshot output records for block %q do not match declared outputs: %s", block.BlockName, reason))
-			return
-		}
-		records = append(records, record)
-	}
-
-	for i, record := range records {
-		if err := store.Create(ctx, record); err != nil {
-			s.cleanupDependencyBlockVolumeSnapshots(adapter, backendName, firecrackerCfg, snapshots[i:])
-			s.logDependencyStageWarning("persist dependency block-volume cache metadata", sandboxID, err)
-			return
-		}
-		s.logDependencyBlockVolumePublished(record, sandboxID)
-	}
+	s.maybePublishBlockVolumeCaches(ctx, adapter, sandboxID, backendName, compiled, firecrackerCfg, repository, changeset, dependencyBlockVolumePublishPhase, dependencyBlockVolumePublishBlocks(plan))
 }
 
-func missedDependencyBlockVolumeBlocks(plan dependencyBlockVolumePlan) []dependencyBlockVolumeBlockPlan {
-	missed := make([]dependencyBlockVolumeBlockPlan, 0, len(plan.Blocks))
+func dependencyBlockVolumePublishBlocks(plan dependencyBlockVolumePlan) []blockVolumePublishBlock {
+	blocks := make([]blockVolumePublishBlock, 0, len(plan.Blocks))
 	for _, block := range plan.Blocks {
-		if !block.CacheHit {
-			missed = append(missed, block)
-		}
-	}
-	return missed
-}
-
-func dependencyBlockVolumeSnapshotsByVolumeID(volumeIDs []string, result *backend.SnapshotCacheOutputVolumesResult) (map[string]backend.CacheOutputVolumeSnapshot, error) {
-	expected := make(map[string]struct{}, len(volumeIDs))
-	for _, volumeID := range volumeIDs {
-		volumeID = strings.TrimSpace(volumeID)
-		if volumeID != "" {
-			expected[volumeID] = struct{}{}
-		}
-	}
-	snapshots := cacheOutputVolumeSnapshots(result)
-	if len(snapshots) != len(expected) {
-		return nil, fmt.Errorf("cache output snapshot returned %d volumes, expected %d", len(snapshots), len(expected))
-	}
-	byID := make(map[string]backend.CacheOutputVolumeSnapshot, len(snapshots))
-	for _, snapshot := range snapshots {
-		volumeID := strings.TrimSpace(snapshot.VolumeID)
-		if _, ok := expected[volumeID]; !ok {
-			return nil, fmt.Errorf("cache output snapshot returned unexpected volume id %q", snapshot.VolumeID)
-		}
-		if _, exists := byID[volumeID]; exists {
-			return nil, fmt.Errorf("cache output snapshot returned duplicate volume id %q", snapshot.VolumeID)
-		}
-		if strings.TrimSpace(snapshot.SnapshotID) == "" {
-			return nil, fmt.Errorf("cache output snapshot for volume %q is missing snapshot id", snapshot.VolumeID)
-		}
-		if strings.TrimSpace(snapshot.StorageDriver) == "" || strings.TrimSpace(snapshot.StorageRef) == "" {
-			return nil, fmt.Errorf("cache output snapshot for volume %q is missing storage metadata", snapshot.VolumeID)
-		}
-		byID[volumeID] = snapshot
-	}
-	return byID, nil
-}
-
-func cacheOutputVolumeSnapshots(result *backend.SnapshotCacheOutputVolumesResult) []backend.CacheOutputVolumeSnapshot {
-	if result == nil || len(result.Volumes) == 0 {
-		return nil
-	}
-	return append([]backend.CacheOutputVolumeSnapshot(nil), result.Volumes...)
-}
-
-func dependencyBlockVolumeCacheRecordFromSnapshot(
-	backendName string,
-	compiled *policy.CompiledPolicy,
-	repository *repositorycheckout.Checkout,
-	changeset *repositorychangeset.Changeset,
-	block dependencyBlockVolumeBlockPlan,
-	snapshot backend.CacheOutputVolumeSnapshot,
-	now time.Time,
-) cachestore.Record {
-	record := cachestore.Record{
-		CacheKey:                strings.TrimSpace(block.CacheKey),
-		Stage:                   dependencyVolumeStageName,
-		State:                   cacheStateReady,
-		BackingSnapshotID:       strings.TrimSpace(snapshot.SnapshotID),
-		Backend:                 strings.TrimSpace(backendName),
-		Architecture:            runtime.GOARCH,
-		PolicyHash:              compiled.Hash,
-		Policy:                  compiled.ToProto(),
-		Repository:              cloneRepositoryCheckout(normalizeRepositoryCheckoutForComparison(repository)).ToProto(),
-		RepositoryHasChangeset:  changeset != nil,
-		RepositoryChangesetID:   repositoryChangesetID(repository, changeset),
-		StorageDriver:           strings.TrimSpace(snapshot.StorageDriver),
-		StorageRef:              strings.TrimSpace(snapshot.StorageRef),
-		StorageSizeBytes:        snapshot.StorageSizeBytes,
-		ExclusiveSizeBytes:      snapshot.ExclusiveSizeBytes,
-		DriverMetadata:          strings.TrimSpace(snapshot.DriverMetadata),
-		InputManifestDigest:     strings.TrimSpace(block.InputManifestDigest),
-		CommandDigest:           strings.TrimSpace(block.CommandDigest),
-		EnvDigest:               strings.TrimSpace(block.EnvDigest),
-		NormalizedOutputsDigest: strings.TrimSpace(block.NormalizedOutputsDigest),
-		OutputRecords:           dependencyBlockVolumeOutputRecordsFromSnapshot(snapshot),
-		CreatedAt:               now,
-		LastUsedAt:              now,
-		LastValidatedAt:         now.UTC(),
-		ProducerVersion:         strings.TrimSpace(block.ProducerVersion),
-	}
-	return record
-}
-
-func dependencyBlockVolumeOutputRecordsFromSnapshot(snapshot backend.CacheOutputVolumeSnapshot) []cachestore.OutputRecord {
-	if len(snapshot.Outputs) == 0 {
-		return nil
-	}
-	records := make([]cachestore.OutputRecord, 0, len(snapshot.Outputs))
-	for _, output := range snapshot.Outputs {
-		records = append(records, cachestore.OutputRecord{
-			Kind:          strings.TrimSpace(output.Kind),
-			Path:          strings.TrimSpace(output.GuestPath),
-			VolumeSubpath: strings.TrimSpace(output.VolumeSubpath),
-			StorageDriver: strings.TrimSpace(snapshot.StorageDriver),
-			StorageRef:    strings.TrimSpace(snapshot.StorageRef),
-			SnapshotRef:   strings.TrimSpace(snapshot.SnapshotRef),
+		blocks = append(blocks, blockVolumePublishBlock{
+			BlockName:               block.BlockName,
+			Outputs:                 block.Outputs,
+			CacheKey:                block.CacheKey,
+			CommandDigest:           block.CommandDigest,
+			EnvDigest:               block.EnvDigest,
+			InputManifestDigest:     block.InputManifestDigest,
+			NormalizedOutputsDigest: block.NormalizedOutputsDigest,
+			ProducerVersion:         block.ProducerVersion,
+			CacheHit:                block.CacheHit,
 		})
 	}
-	return records
-}
-
-func (s *Service) cleanupDependencyBlockVolumeSnapshots(adapter backend.CacheOutputVolumeSnapshottingAdapter, backendName string, firecrackerCfg backend.FirecrackerConfig, snapshots []backend.CacheOutputVolumeSnapshot) {
-	if len(snapshots) == 0 {
-		return
-	}
-	deleteAdapter, ok := adapter.(backend.SnapshottingAdapter)
-	if !ok {
-		s.logDependencyStageWarning("rollback dependency block-volume cache snapshots", "", fmt.Errorf("backend %q cannot delete snapshots", backendName))
-		return
-	}
-	for i := len(snapshots) - 1; i >= 0; i-- {
-		snapshot := snapshots[i]
-		storageRef := strings.TrimSpace(snapshot.StorageRef)
-		if storageRef == "" {
-			continue
-		}
-		deleteCfg := withSnapshotDriver(backendName, firecrackerCfg, snapshot.StorageDriver)
-		cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		err := deleteAdapter.DeleteSnapshot(cleanupCtx, backend.DeleteSnapshotRequest{
-			SnapshotID:        strings.TrimSpace(snapshot.SnapshotID),
-			StorageRef:        storageRef,
-			FirecrackerConfig: deleteCfg,
-		})
-		cancel()
-		if err != nil {
-			s.logDependencyStageWarning("rollback dependency block-volume cache snapshot", "", err)
-		}
-	}
-}
-
-func (s *Service) logDependencyBlockVolumePublished(record cachestore.Record, sandboxID string) {
-	if s == nil || s.Logger == nil {
-		return
-	}
-	s.Logger.Debug("dependency block-volume cache published",
-		"stage", strings.TrimSpace(record.Stage),
-		"cache_key", strings.TrimSpace(record.CacheKey),
-		"producer_version", strings.TrimSpace(record.ProducerVersion),
-		"storage_driver", strings.TrimSpace(record.StorageDriver),
-		"storage_ref", strings.TrimSpace(record.StorageRef),
-		"output_records", len(record.OutputRecords),
-		"sandbox_id", strings.TrimSpace(sandboxID),
-	)
+	return blocks
 }

--- a/internal/controlservice/service_volume_publish.go
+++ b/internal/controlservice/service_volume_publish.go
@@ -2,17 +2,24 @@ package controlservice
 
 import (
 	"context"
-	"fmt"
-	"runtime"
-	"strings"
-	"time"
 
 	"github.com/buildkite/cleanroom/internal/backend"
-	"github.com/buildkite/cleanroom/internal/cachestore"
 	"github.com/buildkite/cleanroom/internal/policy"
 	"github.com/buildkite/cleanroom/internal/repositorychangeset"
 	"github.com/buildkite/cleanroom/internal/repositorycheckout"
 )
+
+var serviceBlockVolumePublishPhase = blockVolumePublishPhase{
+	StageName:               serviceVolumeStageName,
+	PublishWarning:          "publish service block-volume caches",
+	PersistWarning:          "persist service block-volume cache metadata",
+	RollbackWarning:         "rollback service block-volume cache snapshots",
+	RollbackSnapshotWarning: "rollback service block-volume cache snapshot",
+	PublishedMessage:        "service block-volume cache published",
+	LogWarning: func(s *Service, message, sandboxID string, err error) {
+		s.logServicesStageWarning(message, sandboxID, err)
+	},
+}
 
 func (s *Service) maybePublishServiceBlockVolumeCaches(
 	ctx context.Context,
@@ -24,208 +31,23 @@ func (s *Service) maybePublishServiceBlockVolumeCaches(
 	changeset *repositorychangeset.Changeset,
 	plan serviceBlockVolumePlan,
 ) {
-	if adapter == nil || compiled == nil || repository == nil || strings.TrimSpace(sandboxID) == "" || len(plan.Blocks) == 0 {
-		return
-	}
-	store, err := s.cacheStoreOrErr()
-	if err != nil {
-		s.logServicesStageWarning("publish service block-volume caches", sandboxID, err)
-		return
-	}
-
-	missed := missedServiceBlockVolumeBlocks(plan)
-	if len(missed) == 0 {
-		return
-	}
-	volumeIDs := make([]string, 0, len(missed))
-	for _, block := range missed {
-		volumeIDs = append(volumeIDs, blockVolumeID(serviceVolumeStageName, block.CacheKey))
-	}
-
-	snapshotCfg := withSnapshotDriver(backendName, firecrackerCfg, firecrackerCfg.Snapshots.Driver)
-	result, err := adapter.SnapshotCacheOutputVolumes(ctx, backend.SnapshotCacheOutputVolumesRequest{
-		SandboxID:         sandboxID,
-		SnapshotIDPrefix:  newSnapshotID(),
-		VolumeIDs:         volumeIDs,
-		FirecrackerConfig: snapshotCfg,
-	})
-	if err != nil {
-		s.logServicesStageWarning("publish service block-volume caches", sandboxID, err)
-		return
-	}
-
-	snapshotsByVolumeID, err := serviceBlockVolumeSnapshotsByVolumeID(volumeIDs, result)
-	if err != nil {
-		s.cleanupServiceBlockVolumeSnapshots(adapter, backendName, firecrackerCfg, cacheOutputVolumeSnapshots(result))
-		s.logServicesStageWarning("publish service block-volume caches", sandboxID, err)
-		return
-	}
-
-	now := s.clock().Now()
-	records := make([]cachestore.Record, 0, len(missed))
-	snapshots := make([]backend.CacheOutputVolumeSnapshot, 0, len(missed))
-	for _, block := range missed {
-		volumeID := blockVolumeID(serviceVolumeStageName, block.CacheKey)
-		snapshot := snapshotsByVolumeID[volumeID]
-		snapshots = append(snapshots, snapshot)
-		record := serviceBlockVolumeCacheRecordFromSnapshot(backendName, compiled, repository, changeset, block, snapshot, now)
-		if reason := blockVolumeOutputRecordMissReason(block.Outputs, record.OutputRecords); reason != "" {
-			s.cleanupServiceBlockVolumeSnapshots(adapter, backendName, firecrackerCfg, snapshots)
-			s.logServicesStageWarning("publish service block-volume caches", sandboxID, fmt.Errorf("snapshot output records for block %q do not match declared outputs: %s", block.BlockName, reason))
-			return
-		}
-		records = append(records, record)
-	}
-
-	for i, record := range records {
-		if err := store.Create(ctx, record); err != nil {
-			s.cleanupServiceBlockVolumeSnapshots(adapter, backendName, firecrackerCfg, snapshots[i:])
-			s.logServicesStageWarning("persist service block-volume cache metadata", sandboxID, err)
-			return
-		}
-		s.logServiceBlockVolumePublished(record, sandboxID)
-	}
+	s.maybePublishBlockVolumeCaches(ctx, adapter, sandboxID, backendName, compiled, firecrackerCfg, repository, changeset, serviceBlockVolumePublishPhase, serviceBlockVolumePublishBlocks(plan))
 }
 
-func missedServiceBlockVolumeBlocks(plan serviceBlockVolumePlan) []serviceBlockVolumeBlockPlan {
-	missed := make([]serviceBlockVolumeBlockPlan, 0, len(plan.Blocks))
+func serviceBlockVolumePublishBlocks(plan serviceBlockVolumePlan) []blockVolumePublishBlock {
+	blocks := make([]blockVolumePublishBlock, 0, len(plan.Blocks))
 	for _, block := range plan.Blocks {
-		if !block.CacheHit {
-			missed = append(missed, block)
-		}
-	}
-	return missed
-}
-
-func serviceBlockVolumeSnapshotsByVolumeID(volumeIDs []string, result *backend.SnapshotCacheOutputVolumesResult) (map[string]backend.CacheOutputVolumeSnapshot, error) {
-	expected := make(map[string]struct{}, len(volumeIDs))
-	for _, volumeID := range volumeIDs {
-		volumeID = strings.TrimSpace(volumeID)
-		if volumeID != "" {
-			expected[volumeID] = struct{}{}
-		}
-	}
-	snapshots := cacheOutputVolumeSnapshots(result)
-	if len(snapshots) != len(expected) {
-		return nil, fmt.Errorf("cache output snapshot returned %d volumes, expected %d", len(snapshots), len(expected))
-	}
-	byID := make(map[string]backend.CacheOutputVolumeSnapshot, len(snapshots))
-	for _, snapshot := range snapshots {
-		volumeID := strings.TrimSpace(snapshot.VolumeID)
-		if _, ok := expected[volumeID]; !ok {
-			return nil, fmt.Errorf("cache output snapshot returned unexpected volume id %q", snapshot.VolumeID)
-		}
-		if _, exists := byID[volumeID]; exists {
-			return nil, fmt.Errorf("cache output snapshot returned duplicate volume id %q", snapshot.VolumeID)
-		}
-		if strings.TrimSpace(snapshot.SnapshotID) == "" {
-			return nil, fmt.Errorf("cache output snapshot for volume %q is missing snapshot id", snapshot.VolumeID)
-		}
-		if strings.TrimSpace(snapshot.StorageDriver) == "" || strings.TrimSpace(snapshot.StorageRef) == "" {
-			return nil, fmt.Errorf("cache output snapshot for volume %q is missing storage metadata", snapshot.VolumeID)
-		}
-		byID[volumeID] = snapshot
-	}
-	return byID, nil
-}
-
-func serviceBlockVolumeCacheRecordFromSnapshot(
-	backendName string,
-	compiled *policy.CompiledPolicy,
-	repository *repositorycheckout.Checkout,
-	changeset *repositorychangeset.Changeset,
-	block serviceBlockVolumeBlockPlan,
-	snapshot backend.CacheOutputVolumeSnapshot,
-	now time.Time,
-) cachestore.Record {
-	record := cachestore.Record{
-		CacheKey:                strings.TrimSpace(block.CacheKey),
-		Stage:                   serviceVolumeStageName,
-		State:                   cacheStateReady,
-		BackingSnapshotID:       strings.TrimSpace(snapshot.SnapshotID),
-		Backend:                 strings.TrimSpace(backendName),
-		Architecture:            runtime.GOARCH,
-		PolicyHash:              compiled.Hash,
-		Policy:                  compiled.ToProto(),
-		Repository:              cloneRepositoryCheckout(normalizeRepositoryCheckoutForComparison(repository)).ToProto(),
-		RepositoryHasChangeset:  changeset != nil,
-		RepositoryChangesetID:   repositoryChangesetID(repository, changeset),
-		StorageDriver:           strings.TrimSpace(snapshot.StorageDriver),
-		StorageRef:              strings.TrimSpace(snapshot.StorageRef),
-		StorageSizeBytes:        snapshot.StorageSizeBytes,
-		ExclusiveSizeBytes:      snapshot.ExclusiveSizeBytes,
-		DriverMetadata:          strings.TrimSpace(snapshot.DriverMetadata),
-		InputManifestDigest:     strings.TrimSpace(block.InputManifestDigest),
-		CommandDigest:           strings.TrimSpace(block.CommandDigest),
-		EnvDigest:               strings.TrimSpace(block.EnvDigest),
-		NormalizedOutputsDigest: strings.TrimSpace(block.NormalizedOutputsDigest),
-		OutputRecords:           serviceBlockVolumeOutputRecordsFromSnapshot(snapshot),
-		CreatedAt:               now,
-		LastUsedAt:              now,
-		LastValidatedAt:         now.UTC(),
-		ProducerVersion:         strings.TrimSpace(block.ProducerVersion),
-	}
-	return record
-}
-
-func serviceBlockVolumeOutputRecordsFromSnapshot(snapshot backend.CacheOutputVolumeSnapshot) []cachestore.OutputRecord {
-	if len(snapshot.Outputs) == 0 {
-		return nil
-	}
-	records := make([]cachestore.OutputRecord, 0, len(snapshot.Outputs))
-	for _, output := range snapshot.Outputs {
-		records = append(records, cachestore.OutputRecord{
-			Kind:          strings.TrimSpace(output.Kind),
-			Path:          strings.TrimSpace(output.GuestPath),
-			VolumeSubpath: strings.TrimSpace(output.VolumeSubpath),
-			StorageDriver: strings.TrimSpace(snapshot.StorageDriver),
-			StorageRef:    strings.TrimSpace(snapshot.StorageRef),
-			SnapshotRef:   strings.TrimSpace(snapshot.SnapshotRef),
+		blocks = append(blocks, blockVolumePublishBlock{
+			BlockName:               block.BlockName,
+			Outputs:                 block.Outputs,
+			CacheKey:                block.CacheKey,
+			CommandDigest:           block.CommandDigest,
+			EnvDigest:               block.EnvDigest,
+			InputManifestDigest:     block.InputManifestDigest,
+			NormalizedOutputsDigest: block.NormalizedOutputsDigest,
+			ProducerVersion:         block.ProducerVersion,
+			CacheHit:                block.CacheHit,
 		})
 	}
-	return records
-}
-
-func (s *Service) cleanupServiceBlockVolumeSnapshots(adapter backend.CacheOutputVolumeSnapshottingAdapter, backendName string, firecrackerCfg backend.FirecrackerConfig, snapshots []backend.CacheOutputVolumeSnapshot) {
-	if len(snapshots) == 0 {
-		return
-	}
-	deleteAdapter, ok := adapter.(backend.SnapshottingAdapter)
-	if !ok {
-		s.logServicesStageWarning("rollback service block-volume cache snapshots", "", fmt.Errorf("backend %q cannot delete snapshots", backendName))
-		return
-	}
-	for i := len(snapshots) - 1; i >= 0; i-- {
-		snapshot := snapshots[i]
-		storageRef := strings.TrimSpace(snapshot.StorageRef)
-		if storageRef == "" {
-			continue
-		}
-		deleteCfg := withSnapshotDriver(backendName, firecrackerCfg, snapshot.StorageDriver)
-		cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		err := deleteAdapter.DeleteSnapshot(cleanupCtx, backend.DeleteSnapshotRequest{
-			SnapshotID:        strings.TrimSpace(snapshot.SnapshotID),
-			StorageRef:        storageRef,
-			FirecrackerConfig: deleteCfg,
-		})
-		cancel()
-		if err != nil {
-			s.logServicesStageWarning("rollback service block-volume cache snapshot", "", err)
-		}
-	}
-}
-
-func (s *Service) logServiceBlockVolumePublished(record cachestore.Record, sandboxID string) {
-	if s == nil || s.Logger == nil {
-		return
-	}
-	s.Logger.Debug("service block-volume cache published",
-		"stage", strings.TrimSpace(record.Stage),
-		"cache_key", strings.TrimSpace(record.CacheKey),
-		"producer_version", strings.TrimSpace(record.ProducerVersion),
-		"storage_driver", strings.TrimSpace(record.StorageDriver),
-		"storage_ref", strings.TrimSpace(record.StorageRef),
-		"output_records", len(record.OutputRecords),
-		"sandbox_id", strings.TrimSpace(sandboxID),
-	)
+	return blocks
 }


### PR DESCRIPTION
## Problem

Dependency and service block-volume publication had two separate implementations for the same snapshot, metadata, rollback, and logging flow. That made the next cache refactors harder than they need to be, and it left room for rollback behavior to drift between phases.

## Change

- add a shared block-volume publish helper for dependency and service volume caches
- keep dependency and service behavior phase-specific through small descriptors and thin wrappers
- clean all newly-created output snapshots if output-record validation fails before metadata is written
- record the follow-up refactor slices in the volume-cache plan

## Validation

- `mise exec -- go test ./internal/controlservice`
- `mise exec -- go test ./...`