### PR TITLE
refactor: Share block volume planning

### DIFF
--- a/docs/plans/dependency-service-volume-caches.md
+++ b/docs/plans/dependency-service-volume-caches.md
@@ -1067,9 +1067,11 @@ inside the control service and backend adapters.
 Reviewable slices:
 
 - Slice 1: consolidate dependency and service block-volume publication around
-  one shared snapshot, metadata, rollback, and logging path.
+  one shared snapshot, metadata, rollback, and logging path. This is implemented
+  in the first refactor slice.
 - Slice 2: collapse dependency and service block-volume planning into a shared
-  block plan with explicit phase inputs for the cache-key differences.
+  block plan with explicit phase inputs for the cache-key differences. This is
+  implemented in the second refactor slice.
 - Slice 3: collapse dependency and service block execution after the shared
   plan shape exists, preserving the service fallback rule when dependency
   publication is unsafe.

--- a/internal/controlservice/block_volume_plan.go
+++ b/internal/controlservice/block_volume_plan.go
@@ -20,12 +20,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-type blockVolumePlan struct {
-	ReuseNamespace       string
-	DependencyOutputKeys []string
-	Blocks               []blockVolumeBlockPlan
-}
-
 type blockVolumeBlockPlan struct {
 	BlockName                       string
 	Command                         []string
@@ -47,10 +41,20 @@ type blockVolumeBlockPlan struct {
 	CacheRecord                     cachestore.Record
 }
 
-type dependencyBlockVolumePlan blockVolumePlan
-type dependencyBlockVolumeBlockPlan = blockVolumeBlockPlan
-type serviceBlockVolumePlan blockVolumePlan
-type serviceBlockVolumeBlockPlan = blockVolumeBlockPlan
+type dependencyBlockVolumePlan struct {
+	ReuseNamespace string
+	Blocks         []dependencyBlockVolumeBlockPlan
+}
+
+type dependencyBlockVolumeBlockPlan blockVolumeBlockPlan
+
+type serviceBlockVolumePlan struct {
+	ReuseNamespace       string
+	DependencyOutputKeys []string
+	Blocks               []serviceBlockVolumeBlockPlan
+}
+
+type serviceBlockVolumeBlockPlan blockVolumeBlockPlan
 
 type blockVolumeRuntimeDecision struct {
 	Enabled        bool
@@ -118,43 +122,26 @@ func (s *Service) finalizeBlockVolumeBlockPlanBase(
 	}, nil
 }
 
-func (s *Service) lookupBlockVolumeCaches(ctx context.Context, stageName, backendName string, compiled *policy.CompiledPolicy, plan blockVolumePlan) (blockVolumePlan, error) {
-	if len(plan.Blocks) == 0 {
-		return plan, nil
-	}
-	store, err := s.cacheStoreOrErr()
+func lookupBlockVolumeCache(ctx context.Context, store cacheMetadataStore, stageName, backendName string, compiled *policy.CompiledPolicy, block blockVolumeBlockPlan) (blockVolumeBlockPlan, error) {
+	record, ok, err := store.GetReady(ctx, stageName, block.CacheKey)
 	if err != nil {
-		return plan, nil
+		return block, err
 	}
-
-	out := blockVolumePlan{
-		ReuseNamespace:       plan.ReuseNamespace,
-		DependencyOutputKeys: append([]string(nil), plan.DependencyOutputKeys...),
-		Blocks:               make([]blockVolumeBlockPlan, len(plan.Blocks)),
+	if !ok {
+		block.LookupReason = observability.CacheLookupReasonRecordNotFound
+		return block, nil
 	}
-	copy(out.Blocks, plan.Blocks)
-	for i := range out.Blocks {
-		block := &out.Blocks[i]
-		record, ok, err := store.GetReady(ctx, stageName, block.CacheKey)
-		if err != nil {
-			return out, err
-		}
-		if !ok {
-			block.LookupReason = observability.CacheLookupReasonRecordNotFound
-			continue
-		}
-		if reason := blockVolumeRecordMissReason(record, backendName, compiled, *block); reason != "" {
-			block.LookupReason = reason
-			continue
-		}
-		block.CacheHit = true
-		block.LookupReason = ""
-		block.CacheRecord = record
+	if reason := blockVolumeRecordMissReason(record, backendName, compiled, block); reason != "" {
+		block.LookupReason = reason
+		return block, nil
 	}
-	return out, nil
+	block.CacheHit = true
+	block.LookupReason = ""
+	block.CacheRecord = record
+	return block, nil
 }
 
-func blockVolumePlanCacheKeys(plan blockVolumePlan) []string {
+func dependencyBlockVolumePlanCacheKeys(plan dependencyBlockVolumePlan) []string {
 	if len(plan.Blocks) == 0 {
 		return nil
 	}
@@ -165,27 +152,11 @@ func blockVolumePlanCacheKeys(plan blockVolumePlan) []string {
 	return keys
 }
 
-func dependencyBlockVolumePlanCacheKeys(plan dependencyBlockVolumePlan) []string {
-	return blockVolumePlanCacheKeys(blockVolumePlan(plan))
-}
-
-func blockVolumePlanHitMissCounts(plan blockVolumePlan) (hits, misses int) {
-	for _, block := range plan.Blocks {
-		if block.CacheHit {
-			hits++
-			continue
-		}
-		misses++
-	}
-	return hits, misses
-}
-
-func setBlockVolumeLookupSpanAttributes(ctx context.Context, plan blockVolumePlan, err error) {
-	hits, misses := blockVolumePlanHitMissCounts(plan)
+func setBlockVolumeLookupSpanAttributes(ctx context.Context, blockCount, hits, misses int, err error) {
 	result := observability.CacheResultFailed
 	if err == nil {
 		result = observability.CacheResultMiss
-		if len(plan.Blocks) > 0 && misses == 0 {
+		if blockCount > 0 && misses == 0 {
 			result = observability.CacheResultHit
 		}
 	}

--- a/internal/controlservice/block_volume_plan.go
+++ b/internal/controlservice/block_volume_plan.go
@@ -1,0 +1,321 @@
+package controlservice
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/cachestore"
+	"github.com/buildkite/cleanroom/internal/observability"
+	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/buildkite/cleanroom/internal/repositorybundle"
+	"github.com/buildkite/cleanroom/internal/repositorychangeset"
+	"github.com/buildkite/cleanroom/internal/repositorycheckout"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type blockVolumePlan struct {
+	ReuseNamespace       string
+	DependencyOutputKeys []string
+	Blocks               []blockVolumeBlockPlan
+}
+
+type blockVolumeBlockPlan struct {
+	BlockName                       string
+	Command                         []string
+	Env                             map[string]string
+	Inputs                          []string
+	Outputs                         policy.StageBlockOutputs
+	CacheKey                        string
+	CommandDigest                   string
+	EnvDigest                       string
+	InputManifestDigest             string
+	NormalizedOutputsDigest         string
+	DependencyOutputKeysDigest      string
+	PriorDependencyOutputKeysDigest string
+	PriorServiceOutputKeysDigest    string
+	OutputVolumeLayoutVersion       string
+	ProducerVersion                 string
+	CacheHit                        bool
+	LookupReason                    string
+	CacheRecord                     cachestore.Record
+}
+
+type dependencyBlockVolumePlan blockVolumePlan
+type dependencyBlockVolumeBlockPlan = blockVolumeBlockPlan
+type serviceBlockVolumePlan blockVolumePlan
+type serviceBlockVolumeBlockPlan = blockVolumeBlockPlan
+
+type blockVolumeRuntimeDecision struct {
+	Enabled        bool
+	FallbackReason string
+}
+
+type dependencyBlockVolumeRuntimeDecision = blockVolumeRuntimeDecision
+
+func dependencyBlockVolumeRuntimeDecisionForAdapter(adapter backend.Adapter) dependencyBlockVolumeRuntimeDecision {
+	return blockVolumeRuntimeDecisionForAdapter(adapter)
+}
+
+func blockVolumeRuntimeDecisionForAdapter(adapter backend.Adapter) blockVolumeRuntimeDecision {
+	if adapter == nil {
+		return blockVolumeRuntimeDecision{FallbackReason: "backend adapter unavailable"}
+	}
+	caps := backend.CapabilitiesForAdapter(adapter)
+	for _, required := range []string{
+		backend.CapabilitySandboxCacheOutputVolumes,
+		backend.CapabilitySandboxOverlayWriteCapture,
+	} {
+		if !caps[required] {
+			return blockVolumeRuntimeDecision{FallbackReason: "backend missing capability " + required}
+		}
+	}
+	return blockVolumeRuntimeDecision{Enabled: true}
+}
+
+func (s *Service) finalizeBlockVolumeBlockPlanBase(
+	ctx context.Context,
+	repository *repositorycheckout.Checkout,
+	changeset *repositorychangeset.Changeset,
+	commitBundle *repositorybundle.Bundle,
+	stageName string,
+	phaseName string,
+	block policy.StageBlock,
+) (blockVolumeBlockPlan, error) {
+	inputDigest, err := s.stageInputFilesDigest(ctx, repository, changeset, commitBundle, block.Inputs.Files, stageName+" "+block.Name)
+	if err != nil {
+		return blockVolumeBlockPlan{}, err
+	}
+	commandDigest, err := digestCanonicalJSON(block.Command)
+	if err != nil {
+		return blockVolumeBlockPlan{}, fmt.Errorf("digest %s block %q command: %w", phaseName, block.Name, err)
+	}
+	envDigest, err := digestCanonicalJSON(sortedEnvEntries(block.Env))
+	if err != nil {
+		return blockVolumeBlockPlan{}, fmt.Errorf("digest %s block %q env: %w", phaseName, block.Name, err)
+	}
+	outputsDigest, err := digestCanonicalJSON(block.Outputs)
+	if err != nil {
+		return blockVolumeBlockPlan{}, fmt.Errorf("digest %s block %q outputs: %w", phaseName, block.Name, err)
+	}
+
+	return blockVolumeBlockPlan{
+		BlockName:               block.Name,
+		Command:                 append([]string(nil), block.Command...),
+		Env:                     cloneBlockEnv(block.Env),
+		Inputs:                  append([]string(nil), block.Inputs.Files...),
+		Outputs:                 cloneStageBlockOutputs(block.Outputs),
+		CommandDigest:           commandDigest,
+		EnvDigest:               envDigest,
+		InputManifestDigest:     strings.TrimSpace(inputDigest),
+		NormalizedOutputsDigest: outputsDigest,
+	}, nil
+}
+
+func (s *Service) lookupBlockVolumeCaches(ctx context.Context, stageName, backendName string, compiled *policy.CompiledPolicy, plan blockVolumePlan) (blockVolumePlan, error) {
+	if len(plan.Blocks) == 0 {
+		return plan, nil
+	}
+	store, err := s.cacheStoreOrErr()
+	if err != nil {
+		return plan, nil
+	}
+
+	out := blockVolumePlan{
+		ReuseNamespace:       plan.ReuseNamespace,
+		DependencyOutputKeys: append([]string(nil), plan.DependencyOutputKeys...),
+		Blocks:               make([]blockVolumeBlockPlan, len(plan.Blocks)),
+	}
+	copy(out.Blocks, plan.Blocks)
+	for i := range out.Blocks {
+		block := &out.Blocks[i]
+		record, ok, err := store.GetReady(ctx, stageName, block.CacheKey)
+		if err != nil {
+			return out, err
+		}
+		if !ok {
+			block.LookupReason = observability.CacheLookupReasonRecordNotFound
+			continue
+		}
+		if reason := blockVolumeRecordMissReason(record, backendName, compiled, *block); reason != "" {
+			block.LookupReason = reason
+			continue
+		}
+		block.CacheHit = true
+		block.LookupReason = ""
+		block.CacheRecord = record
+	}
+	return out, nil
+}
+
+func blockVolumePlanCacheKeys(plan blockVolumePlan) []string {
+	if len(plan.Blocks) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(plan.Blocks))
+	for _, block := range plan.Blocks {
+		keys = append(keys, block.CacheKey)
+	}
+	return keys
+}
+
+func dependencyBlockVolumePlanCacheKeys(plan dependencyBlockVolumePlan) []string {
+	return blockVolumePlanCacheKeys(blockVolumePlan(plan))
+}
+
+func blockVolumePlanHitMissCounts(plan blockVolumePlan) (hits, misses int) {
+	for _, block := range plan.Blocks {
+		if block.CacheHit {
+			hits++
+			continue
+		}
+		misses++
+	}
+	return hits, misses
+}
+
+func setBlockVolumeLookupSpanAttributes(ctx context.Context, plan blockVolumePlan, err error) {
+	hits, misses := blockVolumePlanHitMissCounts(plan)
+	result := observability.CacheResultFailed
+	if err == nil {
+		result = observability.CacheResultMiss
+		if len(plan.Blocks) > 0 && misses == 0 {
+			result = observability.CacheResultHit
+		}
+	}
+	trace.SpanFromContext(ctx).SetAttributes(
+		attribute.String(observability.AttrCacheResult, result),
+		attribute.Int("cleanroom.cache.hit_count", hits),
+		attribute.Int("cleanroom.cache.miss_count", misses),
+	)
+}
+
+func blockVolumeRecordMissReason(record cachestore.Record, backendName string, compiled *policy.CompiledPolicy, block blockVolumeBlockPlan) string {
+	if strings.TrimSpace(record.Backend) != strings.TrimSpace(backendName) {
+		return observability.CacheLookupReasonBackendMismatch
+	}
+	if compiled == nil || strings.TrimSpace(record.PolicyHash) != strings.TrimSpace(compiled.Hash) {
+		return observability.CacheLookupReasonPolicyHashMismatch
+	}
+	if strings.TrimSpace(record.InputManifestDigest) != strings.TrimSpace(block.InputManifestDigest) ||
+		strings.TrimSpace(record.CommandDigest) != strings.TrimSpace(block.CommandDigest) ||
+		strings.TrimSpace(record.EnvDigest) != strings.TrimSpace(block.EnvDigest) ||
+		strings.TrimSpace(record.NormalizedOutputsDigest) != strings.TrimSpace(block.NormalizedOutputsDigest) ||
+		strings.TrimSpace(record.ProducerVersion) != strings.TrimSpace(block.ProducerVersion) {
+		return observability.CacheLookupReasonRecordNotFound
+	}
+	if reason := blockVolumeOutputRecordMissReason(block.Outputs, record.OutputRecords); reason != "" {
+		return reason
+	}
+	return ""
+}
+
+func blockVolumeOutputRecordMissReason(outputs policy.StageBlockOutputs, records []cachestore.OutputRecord) string {
+	expected := make(map[string]struct{}, len(outputs.Dirs)+len(outputs.Files))
+	for _, dir := range outputs.Dirs {
+		expected[blockVolumeOutputRecordKey("dir", dir)] = struct{}{}
+	}
+	for _, file := range outputs.Files {
+		expected[blockVolumeOutputRecordKey("file", file)] = struct{}{}
+	}
+	if len(expected) == 0 || len(records) != len(expected) {
+		return observability.CacheLookupReasonRecordNotFound
+	}
+
+	seen := make(map[string]struct{}, len(records))
+	storageDriver := ""
+	storageRef := ""
+	sourceSnapshotRef := ""
+	for _, record := range records {
+		kind := strings.TrimSpace(record.Kind)
+		path := strings.TrimSpace(record.Path)
+		key := blockVolumeOutputRecordKey(kind, path)
+		if _, ok := expected[key]; !ok {
+			return observability.CacheLookupReasonRecordNotFound
+		}
+		if _, ok := seen[key]; ok {
+			return observability.CacheLookupReasonRecordNotFound
+		}
+		seen[key] = struct{}{}
+		if strings.TrimSpace(record.VolumeSubpath) == "" ||
+			strings.TrimSpace(record.StorageDriver) == "" ||
+			strings.TrimSpace(record.StorageRef) == "" {
+			return observability.CacheLookupReasonRecordNotFound
+		}
+		recordStorageDriver := strings.TrimSpace(record.StorageDriver)
+		recordStorageRef := strings.TrimSpace(record.StorageRef)
+		recordSourceSnapshotRef := blockVolumeSourceSnapshotRef(record)
+		if storageDriver == "" && storageRef == "" && sourceSnapshotRef == "" {
+			storageDriver = recordStorageDriver
+			storageRef = recordStorageRef
+			sourceSnapshotRef = recordSourceSnapshotRef
+			continue
+		}
+		if recordStorageDriver != storageDriver || recordStorageRef != storageRef || recordSourceSnapshotRef != sourceSnapshotRef {
+			return observability.CacheLookupReasonRecordNotFound
+		}
+	}
+	return ""
+}
+
+func blockVolumeOutputRecordKey(kind, path string) string {
+	return strings.TrimSpace(kind) + "\x00" + strings.TrimSpace(path)
+}
+
+type envEntry struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+func sortedEnvEntries(env map[string]string) []envEntry {
+	if len(env) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(env))
+	for key := range env {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	entries := make([]envEntry, 0, len(keys))
+	for _, key := range keys {
+		entries = append(entries, envEntry{Name: key, Value: env[key]})
+	}
+	return entries
+}
+
+func cloneStageBlockOutputs(outputs policy.StageBlockOutputs) policy.StageBlockOutputs {
+	return policy.StageBlockOutputs{
+		Dirs:  append([]string(nil), outputs.Dirs...),
+		Files: append([]string(nil), outputs.Files...),
+	}
+}
+
+func cloneBlockEnv(env map[string]string) map[string]string {
+	if len(env) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(env))
+	for key, value := range env {
+		out[key] = value
+	}
+	return out
+}
+
+func cloneDependencyBlockEnv(env map[string]string) map[string]string {
+	return cloneBlockEnv(env)
+}
+
+func digestCanonicalJSON(value any) (string, error) {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(payload)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}

--- a/internal/controlservice/dependency_volume_plan.go
+++ b/internal/controlservice/dependency_volume_plan.go
@@ -2,23 +2,17 @@ package controlservice
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
-	"encoding/json"
 	"fmt"
-	"sort"
 	"strings"
 
 	"github.com/buildkite/cleanroom/internal/backend"
 	"github.com/buildkite/cleanroom/internal/cachekey"
-	"github.com/buildkite/cleanroom/internal/cachestore"
 	"github.com/buildkite/cleanroom/internal/observability"
 	"github.com/buildkite/cleanroom/internal/policy"
 	"github.com/buildkite/cleanroom/internal/repositorybundle"
 	"github.com/buildkite/cleanroom/internal/repositorychangeset"
 	"github.com/buildkite/cleanroom/internal/repositorycheckout"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
 )
 
 const (
@@ -26,55 +20,6 @@ const (
 	dependencyVolumeProducerVersion     = "cleanroom/dependency-volume-v1"
 	dependencyVolumeOutputLayoutVersion = "aggregate-v1"
 )
-
-type dependencyBlockVolumePlan struct {
-	ReuseNamespace string
-	Blocks         []dependencyBlockVolumeBlockPlan
-}
-
-type dependencyBlockVolumeBlockPlan struct {
-	BlockName                       string
-	Command                         []string
-	Env                             map[string]string
-	Inputs                          []string
-	Outputs                         policy.StageBlockOutputs
-	CacheKey                        string
-	CommandDigest                   string
-	EnvDigest                       string
-	InputManifestDigest             string
-	NormalizedOutputsDigest         string
-	PriorDependencyOutputKeysDigest string
-	OutputVolumeLayoutVersion       string
-	ProducerVersion                 string
-	CacheHit                        bool
-	LookupReason                    string
-	CacheRecord                     cachestore.Record
-}
-
-type dependencyBlockVolumeRuntimeDecision struct {
-	Enabled        bool
-	FallbackReason string
-}
-
-func dependencyBlockVolumeRuntimeDecisionForAdapter(adapter backend.Adapter) dependencyBlockVolumeRuntimeDecision {
-	return blockVolumeRuntimeDecisionForAdapter(adapter)
-}
-
-func blockVolumeRuntimeDecisionForAdapter(adapter backend.Adapter) dependencyBlockVolumeRuntimeDecision {
-	if adapter == nil {
-		return dependencyBlockVolumeRuntimeDecision{FallbackReason: "backend adapter unavailable"}
-	}
-	caps := backend.CapabilitiesForAdapter(adapter)
-	for _, required := range []string{
-		backend.CapabilitySandboxCacheOutputVolumes,
-		backend.CapabilitySandboxOverlayWriteCapture,
-	} {
-		if !caps[required] {
-			return dependencyBlockVolumeRuntimeDecision{FallbackReason: "backend missing capability " + required}
-		}
-	}
-	return dependencyBlockVolumeRuntimeDecision{Enabled: true}
-}
 
 func (s *Service) lookupDependencyBlockVolumePlanForCreateSandbox(
 	ctx context.Context,
@@ -119,7 +64,7 @@ func (s *Service) lookupDependencyBlockVolumePlanForCreateSandbox(
 	), func(ctx context.Context) error {
 		var lookupErr error
 		plan, lookupErr = s.lookupDependencyBlockVolumeCaches(ctx, backendName, compiled, plan)
-		setDependencyBlockVolumeLookupSpanAttributes(ctx, plan, lookupErr)
+		setBlockVolumeLookupSpanAttributes(ctx, blockVolumePlan(plan), lookupErr)
 		return lookupErr
 	})
 	if err != nil {
@@ -172,21 +117,9 @@ func (s *Service) finalizeDependencyBlockVolumeBlockPlan(
 	block policy.StageBlock,
 	priorOutputKeys []string,
 ) (dependencyBlockVolumeBlockPlan, error) {
-	inputDigest, err := s.stageInputFilesDigest(ctx, repository, changeset, commitBundle, block.Inputs.Files, dependencyVolumeStageName+" "+block.Name)
+	blockPlan, err := s.finalizeBlockVolumeBlockPlanBase(ctx, repository, changeset, commitBundle, dependencyVolumeStageName, "dependency", block)
 	if err != nil {
 		return dependencyBlockVolumeBlockPlan{}, err
-	}
-	commandDigest, err := digestCanonicalJSON(block.Command)
-	if err != nil {
-		return dependencyBlockVolumeBlockPlan{}, fmt.Errorf("digest dependency block %q command: %w", block.Name, err)
-	}
-	envDigest, err := digestCanonicalJSON(sortedEnvEntries(block.Env))
-	if err != nil {
-		return dependencyBlockVolumeBlockPlan{}, fmt.Errorf("digest dependency block %q env: %w", block.Name, err)
-	}
-	outputsDigest, err := digestCanonicalJSON(block.Outputs)
-	if err != nil {
-		return dependencyBlockVolumeBlockPlan{}, fmt.Errorf("digest dependency block %q outputs: %w", block.Name, err)
 	}
 	priorDigest, err := digestCanonicalJSON(append([]string{}, priorOutputKeys...))
 	if err != nil {
@@ -199,10 +132,10 @@ func (s *Service) finalizeDependencyBlockVolumeBlockPlan(
 		ReuseNamespace:                  strings.TrimSpace(reuseNamespace),
 		CompiledPolicyHash:              strings.TrimSpace(compiled.Hash),
 		BlockName:                       strings.TrimSpace(block.Name),
-		CommandDigest:                   commandDigest,
-		EnvDigest:                       envDigest,
-		InputManifestDigest:             strings.TrimSpace(inputDigest),
-		NormalizedOutputsDigest:         outputsDigest,
+		CommandDigest:                   blockPlan.CommandDigest,
+		EnvDigest:                       blockPlan.EnvDigest,
+		InputManifestDigest:             blockPlan.InputManifestDigest,
+		NormalizedOutputsDigest:         blockPlan.NormalizedOutputsDigest,
 		PriorDependencyOutputKeysDigest: priorDigest,
 		OutputVolumeLayoutVersion:       dependencyVolumeOutputLayoutVersion,
 		ProducerVersion:                 dependencyVolumeProducerVersion,
@@ -211,83 +144,16 @@ func (s *Service) finalizeDependencyBlockVolumeBlockPlan(
 		return dependencyBlockVolumeBlockPlan{}, fmt.Errorf("dependency block %q produced an empty cache key", block.Name)
 	}
 
-	return dependencyBlockVolumeBlockPlan{
-		BlockName:                       block.Name,
-		Command:                         append([]string(nil), block.Command...),
-		Env:                             cloneDependencyBlockEnv(block.Env),
-		Inputs:                          append([]string(nil), block.Inputs.Files...),
-		Outputs:                         cloneStageBlockOutputs(block.Outputs),
-		CacheKey:                        cacheKey,
-		CommandDigest:                   commandDigest,
-		EnvDigest:                       envDigest,
-		InputManifestDigest:             strings.TrimSpace(inputDigest),
-		NormalizedOutputsDigest:         outputsDigest,
-		PriorDependencyOutputKeysDigest: priorDigest,
-		OutputVolumeLayoutVersion:       dependencyVolumeOutputLayoutVersion,
-		ProducerVersion:                 dependencyVolumeProducerVersion,
-	}, nil
+	blockPlan.CacheKey = cacheKey
+	blockPlan.PriorDependencyOutputKeysDigest = priorDigest
+	blockPlan.OutputVolumeLayoutVersion = dependencyVolumeOutputLayoutVersion
+	blockPlan.ProducerVersion = dependencyVolumeProducerVersion
+	return blockPlan, nil
 }
 
 func (s *Service) lookupDependencyBlockVolumeCaches(ctx context.Context, backendName string, compiled *policy.CompiledPolicy, plan dependencyBlockVolumePlan) (dependencyBlockVolumePlan, error) {
-	if len(plan.Blocks) == 0 {
-		return plan, nil
-	}
-	store, err := s.cacheStoreOrErr()
-	if err != nil {
-		return plan, nil
-	}
-
-	out := dependencyBlockVolumePlan{
-		ReuseNamespace: plan.ReuseNamespace,
-		Blocks:         make([]dependencyBlockVolumeBlockPlan, len(plan.Blocks)),
-	}
-	copy(out.Blocks, plan.Blocks)
-	for i := range out.Blocks {
-		block := &out.Blocks[i]
-		record, ok, err := store.GetReady(ctx, dependencyVolumeStageName, block.CacheKey)
-		if err != nil {
-			return out, err
-		}
-		if !ok {
-			block.LookupReason = observability.CacheLookupReasonRecordNotFound
-			continue
-		}
-		if reason := dependencyBlockVolumeRecordMissReason(record, backendName, compiled, *block); reason != "" {
-			block.LookupReason = reason
-			continue
-		}
-		block.CacheHit = true
-		block.LookupReason = ""
-		block.CacheRecord = record
-	}
-	return out, nil
-}
-
-func dependencyBlockVolumePlanHitMissCounts(plan dependencyBlockVolumePlan) (hits, misses int) {
-	for _, block := range plan.Blocks {
-		if block.CacheHit {
-			hits++
-			continue
-		}
-		misses++
-	}
-	return hits, misses
-}
-
-func setDependencyBlockVolumeLookupSpanAttributes(ctx context.Context, plan dependencyBlockVolumePlan, err error) {
-	hits, misses := dependencyBlockVolumePlanHitMissCounts(plan)
-	result := observability.CacheResultFailed
-	if err == nil {
-		result = observability.CacheResultMiss
-		if len(plan.Blocks) > 0 && misses == 0 {
-			result = observability.CacheResultHit
-		}
-	}
-	trace.SpanFromContext(ctx).SetAttributes(
-		attribute.String(observability.AttrCacheResult, result),
-		attribute.Int("cleanroom.cache.hit_count", hits),
-		attribute.Int("cleanroom.cache.miss_count", misses),
-	)
+	out, err := s.lookupBlockVolumeCaches(ctx, dependencyVolumeStageName, backendName, compiled, blockVolumePlan(plan))
+	return dependencyBlockVolumePlan(out), err
 }
 
 func (s *Service) logDependencyBlockVolumeCacheFallback(backendName string, blockCount int, reason string) {
@@ -305,7 +171,7 @@ func (s *Service) logDependencyBlockVolumeCacheLookup(backendName string, plan d
 	if s == nil || s.Logger == nil {
 		return
 	}
-	hits, misses := dependencyBlockVolumePlanHitMissCounts(plan)
+	hits, misses := blockVolumePlanHitMissCounts(blockVolumePlan(plan))
 	s.Logger.Debug("dependency block-volume cache lookup",
 		observability.LogFieldBackend, backendName,
 		"blocks", len(plan.Blocks),
@@ -313,124 +179,4 @@ func (s *Service) logDependencyBlockVolumeCacheLookup(backendName string, plan d
 		"misses", misses,
 		"reuse_namespace", plan.ReuseNamespace,
 	)
-}
-
-func dependencyBlockVolumeRecordMissReason(record cachestore.Record, backendName string, compiled *policy.CompiledPolicy, block dependencyBlockVolumeBlockPlan) string {
-	if strings.TrimSpace(record.Backend) != strings.TrimSpace(backendName) {
-		return observability.CacheLookupReasonBackendMismatch
-	}
-	if compiled == nil || strings.TrimSpace(record.PolicyHash) != strings.TrimSpace(compiled.Hash) {
-		return observability.CacheLookupReasonPolicyHashMismatch
-	}
-	if strings.TrimSpace(record.InputManifestDigest) != strings.TrimSpace(block.InputManifestDigest) ||
-		strings.TrimSpace(record.CommandDigest) != strings.TrimSpace(block.CommandDigest) ||
-		strings.TrimSpace(record.EnvDigest) != strings.TrimSpace(block.EnvDigest) ||
-		strings.TrimSpace(record.NormalizedOutputsDigest) != strings.TrimSpace(block.NormalizedOutputsDigest) ||
-		strings.TrimSpace(record.ProducerVersion) != strings.TrimSpace(block.ProducerVersion) {
-		return observability.CacheLookupReasonRecordNotFound
-	}
-	if reason := blockVolumeOutputRecordMissReason(block.Outputs, record.OutputRecords); reason != "" {
-		return reason
-	}
-	return ""
-}
-
-func blockVolumeOutputRecordMissReason(outputs policy.StageBlockOutputs, records []cachestore.OutputRecord) string {
-	expected := make(map[string]struct{}, len(outputs.Dirs)+len(outputs.Files))
-	for _, dir := range outputs.Dirs {
-		expected[blockVolumeOutputRecordKey("dir", dir)] = struct{}{}
-	}
-	for _, file := range outputs.Files {
-		expected[blockVolumeOutputRecordKey("file", file)] = struct{}{}
-	}
-	if len(expected) == 0 || len(records) != len(expected) {
-		return observability.CacheLookupReasonRecordNotFound
-	}
-
-	seen := make(map[string]struct{}, len(records))
-	storageDriver := ""
-	storageRef := ""
-	sourceSnapshotRef := ""
-	for _, record := range records {
-		kind := strings.TrimSpace(record.Kind)
-		path := strings.TrimSpace(record.Path)
-		key := blockVolumeOutputRecordKey(kind, path)
-		if _, ok := expected[key]; !ok {
-			return observability.CacheLookupReasonRecordNotFound
-		}
-		if _, ok := seen[key]; ok {
-			return observability.CacheLookupReasonRecordNotFound
-		}
-		seen[key] = struct{}{}
-		if strings.TrimSpace(record.VolumeSubpath) == "" ||
-			strings.TrimSpace(record.StorageDriver) == "" ||
-			strings.TrimSpace(record.StorageRef) == "" {
-			return observability.CacheLookupReasonRecordNotFound
-		}
-		recordStorageDriver := strings.TrimSpace(record.StorageDriver)
-		recordStorageRef := strings.TrimSpace(record.StorageRef)
-		recordSourceSnapshotRef := blockVolumeSourceSnapshotRef(record)
-		if storageDriver == "" && storageRef == "" && sourceSnapshotRef == "" {
-			storageDriver = recordStorageDriver
-			storageRef = recordStorageRef
-			sourceSnapshotRef = recordSourceSnapshotRef
-			continue
-		}
-		if recordStorageDriver != storageDriver || recordStorageRef != storageRef || recordSourceSnapshotRef != sourceSnapshotRef {
-			return observability.CacheLookupReasonRecordNotFound
-		}
-	}
-	return ""
-}
-
-func blockVolumeOutputRecordKey(kind, path string) string {
-	return strings.TrimSpace(kind) + "\x00" + strings.TrimSpace(path)
-}
-
-type envEntry struct {
-	Name  string `json:"name"`
-	Value string `json:"value"`
-}
-
-func sortedEnvEntries(env map[string]string) []envEntry {
-	if len(env) == 0 {
-		return nil
-	}
-	keys := make([]string, 0, len(env))
-	for key := range env {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-	entries := make([]envEntry, 0, len(keys))
-	for _, key := range keys {
-		entries = append(entries, envEntry{Name: key, Value: env[key]})
-	}
-	return entries
-}
-
-func cloneStageBlockOutputs(outputs policy.StageBlockOutputs) policy.StageBlockOutputs {
-	return policy.StageBlockOutputs{
-		Dirs:  append([]string(nil), outputs.Dirs...),
-		Files: append([]string(nil), outputs.Files...),
-	}
-}
-
-func cloneDependencyBlockEnv(env map[string]string) map[string]string {
-	if len(env) == 0 {
-		return nil
-	}
-	out := make(map[string]string, len(env))
-	for key, value := range env {
-		out[key] = value
-	}
-	return out
-}
-
-func digestCanonicalJSON(value any) (string, error) {
-	payload, err := json.Marshal(value)
-	if err != nil {
-		return "", err
-	}
-	sum := sha256.Sum256(payload)
-	return "sha256:" + hex.EncodeToString(sum[:]), nil
 }

--- a/internal/controlservice/dependency_volume_plan.go
+++ b/internal/controlservice/dependency_volume_plan.go
@@ -64,7 +64,8 @@ func (s *Service) lookupDependencyBlockVolumePlanForCreateSandbox(
 	), func(ctx context.Context) error {
 		var lookupErr error
 		plan, lookupErr = s.lookupDependencyBlockVolumeCaches(ctx, backendName, compiled, plan)
-		setBlockVolumeLookupSpanAttributes(ctx, blockVolumePlan(plan), lookupErr)
+		hits, misses := dependencyBlockVolumePlanHitMissCounts(plan)
+		setBlockVolumeLookupSpanAttributes(ctx, len(plan.Blocks), hits, misses, lookupErr)
 		return lookupErr
 	})
 	if err != nil {
@@ -148,12 +149,42 @@ func (s *Service) finalizeDependencyBlockVolumeBlockPlan(
 	blockPlan.PriorDependencyOutputKeysDigest = priorDigest
 	blockPlan.OutputVolumeLayoutVersion = dependencyVolumeOutputLayoutVersion
 	blockPlan.ProducerVersion = dependencyVolumeProducerVersion
-	return blockPlan, nil
+	return dependencyBlockVolumeBlockPlan(blockPlan), nil
 }
 
 func (s *Service) lookupDependencyBlockVolumeCaches(ctx context.Context, backendName string, compiled *policy.CompiledPolicy, plan dependencyBlockVolumePlan) (dependencyBlockVolumePlan, error) {
-	out, err := s.lookupBlockVolumeCaches(ctx, dependencyVolumeStageName, backendName, compiled, blockVolumePlan(plan))
-	return dependencyBlockVolumePlan(out), err
+	if len(plan.Blocks) == 0 {
+		return plan, nil
+	}
+	store, err := s.cacheStoreOrErr()
+	if err != nil {
+		return plan, nil
+	}
+
+	out := dependencyBlockVolumePlan{
+		ReuseNamespace: plan.ReuseNamespace,
+		Blocks:         make([]dependencyBlockVolumeBlockPlan, len(plan.Blocks)),
+	}
+	copy(out.Blocks, plan.Blocks)
+	for i := range out.Blocks {
+		block, err := lookupBlockVolumeCache(ctx, store, dependencyVolumeStageName, backendName, compiled, blockVolumeBlockPlan(out.Blocks[i]))
+		if err != nil {
+			return out, err
+		}
+		out.Blocks[i] = dependencyBlockVolumeBlockPlan(block)
+	}
+	return out, nil
+}
+
+func dependencyBlockVolumePlanHitMissCounts(plan dependencyBlockVolumePlan) (hits, misses int) {
+	for _, block := range plan.Blocks {
+		if block.CacheHit {
+			hits++
+			continue
+		}
+		misses++
+	}
+	return hits, misses
 }
 
 func (s *Service) logDependencyBlockVolumeCacheFallback(backendName string, blockCount int, reason string) {
@@ -171,7 +202,7 @@ func (s *Service) logDependencyBlockVolumeCacheLookup(backendName string, plan d
 	if s == nil || s.Logger == nil {
 		return
 	}
-	hits, misses := blockVolumePlanHitMissCounts(blockVolumePlan(plan))
+	hits, misses := dependencyBlockVolumePlanHitMissCounts(plan)
 	s.Logger.Debug("dependency block-volume cache lookup",
 		observability.LogFieldBackend, backendName,
 		"blocks", len(plan.Blocks),

--- a/internal/controlservice/service_volume_plan.go
+++ b/internal/controlservice/service_volume_plan.go
@@ -87,7 +87,8 @@ func (s *Service) lookupServiceBlockVolumePlanForCreateSandbox(
 	), func(ctx context.Context) error {
 		var lookupErr error
 		plan, lookupErr = s.lookupServiceBlockVolumeCaches(ctx, backendName, compiled, plan)
-		setBlockVolumeLookupSpanAttributes(ctx, blockVolumePlan(plan), lookupErr)
+		hits, misses := serviceBlockVolumePlanHitMissCounts(plan)
+		setBlockVolumeLookupSpanAttributes(ctx, len(plan.Blocks), hits, misses, lookupErr)
 		return lookupErr
 	})
 	if err != nil {
@@ -183,12 +184,43 @@ func (s *Service) finalizeServiceBlockVolumeBlockPlan(
 	blockPlan.PriorServiceOutputKeysDigest = priorDigest
 	blockPlan.OutputVolumeLayoutVersion = serviceVolumeOutputLayoutVersion
 	blockPlan.ProducerVersion = serviceVolumeProducerVersion
-	return blockPlan, nil
+	return serviceBlockVolumeBlockPlan(blockPlan), nil
 }
 
 func (s *Service) lookupServiceBlockVolumeCaches(ctx context.Context, backendName string, compiled *policy.CompiledPolicy, plan serviceBlockVolumePlan) (serviceBlockVolumePlan, error) {
-	out, err := s.lookupBlockVolumeCaches(ctx, serviceVolumeStageName, backendName, compiled, blockVolumePlan(plan))
-	return serviceBlockVolumePlan(out), err
+	if len(plan.Blocks) == 0 {
+		return plan, nil
+	}
+	store, err := s.cacheStoreOrErr()
+	if err != nil {
+		return plan, nil
+	}
+
+	out := serviceBlockVolumePlan{
+		ReuseNamespace:       plan.ReuseNamespace,
+		DependencyOutputKeys: append([]string(nil), plan.DependencyOutputKeys...),
+		Blocks:               make([]serviceBlockVolumeBlockPlan, len(plan.Blocks)),
+	}
+	copy(out.Blocks, plan.Blocks)
+	for i := range out.Blocks {
+		block, err := lookupBlockVolumeCache(ctx, store, serviceVolumeStageName, backendName, compiled, blockVolumeBlockPlan(out.Blocks[i]))
+		if err != nil {
+			return out, err
+		}
+		out.Blocks[i] = serviceBlockVolumeBlockPlan(block)
+	}
+	return out, nil
+}
+
+func serviceBlockVolumePlanHitMissCounts(plan serviceBlockVolumePlan) (hits, misses int) {
+	for _, block := range plan.Blocks {
+		if block.CacheHit {
+			hits++
+			continue
+		}
+		misses++
+	}
+	return hits, misses
 }
 
 func (s *Service) logServiceBlockVolumeCacheFallback(backendName string, blockCount int, reason string) {
@@ -206,7 +238,7 @@ func (s *Service) logServiceBlockVolumeCacheLookup(backendName string, plan serv
 	if s == nil || s.Logger == nil {
 		return
 	}
-	hits, misses := blockVolumePlanHitMissCounts(blockVolumePlan(plan))
+	hits, misses := serviceBlockVolumePlanHitMissCounts(plan)
 	s.Logger.Debug("service block-volume cache lookup",
 		observability.LogFieldBackend, backendName,
 		"blocks", len(plan.Blocks),

--- a/internal/controlservice/service_volume_plan.go
+++ b/internal/controlservice/service_volume_plan.go
@@ -7,14 +7,12 @@ import (
 
 	"github.com/buildkite/cleanroom/internal/backend"
 	"github.com/buildkite/cleanroom/internal/cachekey"
-	"github.com/buildkite/cleanroom/internal/cachestore"
 	"github.com/buildkite/cleanroom/internal/observability"
 	"github.com/buildkite/cleanroom/internal/policy"
 	"github.com/buildkite/cleanroom/internal/repositorybundle"
 	"github.com/buildkite/cleanroom/internal/repositorychangeset"
 	"github.com/buildkite/cleanroom/internal/repositorycheckout"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
 )
 
 const (
@@ -22,32 +20,6 @@ const (
 	serviceVolumeProducerVersion     = "cleanroom/service-volume-v1"
 	serviceVolumeOutputLayoutVersion = "aggregate-v1"
 )
-
-type serviceBlockVolumePlan struct {
-	ReuseNamespace       string
-	DependencyOutputKeys []string
-	Blocks               []serviceBlockVolumeBlockPlan
-}
-
-type serviceBlockVolumeBlockPlan struct {
-	BlockName                    string
-	Command                      []string
-	Env                          map[string]string
-	Inputs                       []string
-	Outputs                      policy.StageBlockOutputs
-	CacheKey                     string
-	CommandDigest                string
-	EnvDigest                    string
-	InputManifestDigest          string
-	NormalizedOutputsDigest      string
-	DependencyOutputKeysDigest   string
-	PriorServiceOutputKeysDigest string
-	OutputVolumeLayoutVersion    string
-	ProducerVersion              string
-	CacheHit                     bool
-	LookupReason                 string
-	CacheRecord                  cachestore.Record
-}
 
 func (s *Service) maybeLookupServiceBlockVolumePlanForCreateSandbox(
 	ctx context.Context,
@@ -115,7 +87,7 @@ func (s *Service) lookupServiceBlockVolumePlanForCreateSandbox(
 	), func(ctx context.Context) error {
 		var lookupErr error
 		plan, lookupErr = s.lookupServiceBlockVolumeCaches(ctx, backendName, compiled, plan)
-		setServiceBlockVolumeLookupSpanAttributes(ctx, plan, lookupErr)
+		setBlockVolumeLookupSpanAttributes(ctx, blockVolumePlan(plan), lookupErr)
 		return lookupErr
 	})
 	if err != nil {
@@ -174,21 +146,9 @@ func (s *Service) finalizeServiceBlockVolumeBlockPlan(
 	block policy.StageBlock,
 	priorServiceOutputKeys []string,
 ) (serviceBlockVolumeBlockPlan, error) {
-	inputDigest, err := s.stageInputFilesDigest(ctx, repository, changeset, commitBundle, block.Inputs.Files, serviceVolumeStageName+" "+block.Name)
+	blockPlan, err := s.finalizeBlockVolumeBlockPlanBase(ctx, repository, changeset, commitBundle, serviceVolumeStageName, "service", block)
 	if err != nil {
 		return serviceBlockVolumeBlockPlan{}, err
-	}
-	commandDigest, err := digestCanonicalJSON(block.Command)
-	if err != nil {
-		return serviceBlockVolumeBlockPlan{}, fmt.Errorf("digest service block %q command: %w", block.Name, err)
-	}
-	envDigest, err := digestCanonicalJSON(sortedEnvEntries(block.Env))
-	if err != nil {
-		return serviceBlockVolumeBlockPlan{}, fmt.Errorf("digest service block %q env: %w", block.Name, err)
-	}
-	outputsDigest, err := digestCanonicalJSON(block.Outputs)
-	if err != nil {
-		return serviceBlockVolumeBlockPlan{}, fmt.Errorf("digest service block %q outputs: %w", block.Name, err)
 	}
 	dependencyDigest, err := digestCanonicalJSON(append([]string{}, dependencyOutputKeys...))
 	if err != nil {
@@ -205,10 +165,10 @@ func (s *Service) finalizeServiceBlockVolumeBlockPlan(
 		ReuseNamespace:               strings.TrimSpace(reuseNamespace),
 		CompiledPolicyHash:           strings.TrimSpace(compiled.Hash),
 		BlockName:                    strings.TrimSpace(block.Name),
-		CommandDigest:                commandDigest,
-		EnvDigest:                    envDigest,
-		InputManifestDigest:          strings.TrimSpace(inputDigest),
-		NormalizedOutputsDigest:      outputsDigest,
+		CommandDigest:                blockPlan.CommandDigest,
+		EnvDigest:                    blockPlan.EnvDigest,
+		InputManifestDigest:          blockPlan.InputManifestDigest,
+		NormalizedOutputsDigest:      blockPlan.NormalizedOutputsDigest,
 		DependencyOutputKeysDigest:   dependencyDigest,
 		PriorServiceOutputKeysDigest: priorDigest,
 		OutputVolumeLayoutVersion:    serviceVolumeOutputLayoutVersion,
@@ -218,96 +178,17 @@ func (s *Service) finalizeServiceBlockVolumeBlockPlan(
 		return serviceBlockVolumeBlockPlan{}, fmt.Errorf("service block %q produced an empty cache key", block.Name)
 	}
 
-	return serviceBlockVolumeBlockPlan{
-		BlockName:                    block.Name,
-		Command:                      append([]string(nil), block.Command...),
-		Env:                          cloneDependencyBlockEnv(block.Env),
-		Inputs:                       append([]string(nil), block.Inputs.Files...),
-		Outputs:                      cloneStageBlockOutputs(block.Outputs),
-		CacheKey:                     cacheKey,
-		CommandDigest:                commandDigest,
-		EnvDigest:                    envDigest,
-		InputManifestDigest:          strings.TrimSpace(inputDigest),
-		NormalizedOutputsDigest:      outputsDigest,
-		DependencyOutputKeysDigest:   dependencyDigest,
-		PriorServiceOutputKeysDigest: priorDigest,
-		OutputVolumeLayoutVersion:    serviceVolumeOutputLayoutVersion,
-		ProducerVersion:              serviceVolumeProducerVersion,
-	}, nil
+	blockPlan.CacheKey = cacheKey
+	blockPlan.DependencyOutputKeysDigest = dependencyDigest
+	blockPlan.PriorServiceOutputKeysDigest = priorDigest
+	blockPlan.OutputVolumeLayoutVersion = serviceVolumeOutputLayoutVersion
+	blockPlan.ProducerVersion = serviceVolumeProducerVersion
+	return blockPlan, nil
 }
 
 func (s *Service) lookupServiceBlockVolumeCaches(ctx context.Context, backendName string, compiled *policy.CompiledPolicy, plan serviceBlockVolumePlan) (serviceBlockVolumePlan, error) {
-	if len(plan.Blocks) == 0 {
-		return plan, nil
-	}
-	store, err := s.cacheStoreOrErr()
-	if err != nil {
-		return plan, nil
-	}
-
-	out := serviceBlockVolumePlan{
-		ReuseNamespace:       plan.ReuseNamespace,
-		DependencyOutputKeys: append([]string(nil), plan.DependencyOutputKeys...),
-		Blocks:               make([]serviceBlockVolumeBlockPlan, len(plan.Blocks)),
-	}
-	copy(out.Blocks, plan.Blocks)
-	for i := range out.Blocks {
-		block := &out.Blocks[i]
-		record, ok, err := store.GetReady(ctx, serviceVolumeStageName, block.CacheKey)
-		if err != nil {
-			return out, err
-		}
-		if !ok {
-			block.LookupReason = observability.CacheLookupReasonRecordNotFound
-			continue
-		}
-		if reason := serviceBlockVolumeRecordMissReason(record, backendName, compiled, *block); reason != "" {
-			block.LookupReason = reason
-			continue
-		}
-		block.CacheHit = true
-		block.LookupReason = ""
-		block.CacheRecord = record
-	}
-	return out, nil
-}
-
-func dependencyBlockVolumePlanCacheKeys(plan dependencyBlockVolumePlan) []string {
-	if len(plan.Blocks) == 0 {
-		return nil
-	}
-	keys := make([]string, 0, len(plan.Blocks))
-	for _, block := range plan.Blocks {
-		keys = append(keys, block.CacheKey)
-	}
-	return keys
-}
-
-func serviceBlockVolumePlanHitMissCounts(plan serviceBlockVolumePlan) (hits, misses int) {
-	for _, block := range plan.Blocks {
-		if block.CacheHit {
-			hits++
-			continue
-		}
-		misses++
-	}
-	return hits, misses
-}
-
-func setServiceBlockVolumeLookupSpanAttributes(ctx context.Context, plan serviceBlockVolumePlan, err error) {
-	hits, misses := serviceBlockVolumePlanHitMissCounts(plan)
-	result := observability.CacheResultFailed
-	if err == nil {
-		result = observability.CacheResultMiss
-		if len(plan.Blocks) > 0 && misses == 0 {
-			result = observability.CacheResultHit
-		}
-	}
-	trace.SpanFromContext(ctx).SetAttributes(
-		attribute.String(observability.AttrCacheResult, result),
-		attribute.Int("cleanroom.cache.hit_count", hits),
-		attribute.Int("cleanroom.cache.miss_count", misses),
-	)
+	out, err := s.lookupBlockVolumeCaches(ctx, serviceVolumeStageName, backendName, compiled, blockVolumePlan(plan))
+	return serviceBlockVolumePlan(out), err
 }
 
 func (s *Service) logServiceBlockVolumeCacheFallback(backendName string, blockCount int, reason string) {
@@ -325,7 +206,7 @@ func (s *Service) logServiceBlockVolumeCacheLookup(backendName string, plan serv
 	if s == nil || s.Logger == nil {
 		return
 	}
-	hits, misses := serviceBlockVolumePlanHitMissCounts(plan)
+	hits, misses := blockVolumePlanHitMissCounts(blockVolumePlan(plan))
 	s.Logger.Debug("service block-volume cache lookup",
 		observability.LogFieldBackend, backendName,
 		"blocks", len(plan.Blocks),
@@ -333,24 +214,4 @@ func (s *Service) logServiceBlockVolumeCacheLookup(backendName string, plan serv
 		"misses", misses,
 		"reuse_namespace", plan.ReuseNamespace,
 	)
-}
-
-func serviceBlockVolumeRecordMissReason(record cachestore.Record, backendName string, compiled *policy.CompiledPolicy, block serviceBlockVolumeBlockPlan) string {
-	if strings.TrimSpace(record.Backend) != strings.TrimSpace(backendName) {
-		return observability.CacheLookupReasonBackendMismatch
-	}
-	if compiled == nil || strings.TrimSpace(record.PolicyHash) != strings.TrimSpace(compiled.Hash) {
-		return observability.CacheLookupReasonPolicyHashMismatch
-	}
-	if strings.TrimSpace(record.InputManifestDigest) != strings.TrimSpace(block.InputManifestDigest) ||
-		strings.TrimSpace(record.CommandDigest) != strings.TrimSpace(block.CommandDigest) ||
-		strings.TrimSpace(record.EnvDigest) != strings.TrimSpace(block.EnvDigest) ||
-		strings.TrimSpace(record.NormalizedOutputsDigest) != strings.TrimSpace(block.NormalizedOutputsDigest) ||
-		strings.TrimSpace(record.ProducerVersion) != strings.TrimSpace(block.ProducerVersion) {
-		return observability.CacheLookupReasonRecordNotFound
-	}
-	if reason := blockVolumeOutputRecordMissReason(block.Outputs, record.OutputRecords); reason != "" {
-		return reason
-	}
-	return ""
 }


### PR DESCRIPTION
## Problem

After the publication cleanup, dependency and service block-volume planning still carried duplicate structs, digest setup, cache lookup validation, and hit/miss span logic. That duplication makes the next execution refactor harder to do safely.

## Change

- add shared block-volume plan and block construction helpers
- keep dependency and service plan types distinct, so phase-specific functions still reject the wrong plan type at compile time
- centralize cache lookup validation, hit/miss span attributes, output-record checks, and common digest setup
- leave dependency and service cache-key construction in the phase-specific files
- update the volume-cache plan for the second refactor slice

This is stacked on #323.

## Validation

- `mise exec -- go test ./internal/controlservice`
- `mise exec -- go test ./...`