### PR TITLE
refactor: Share block volume execution

### DIFF
--- a/docs/plans/dependency-service-volume-caches.md
+++ b/docs/plans/dependency-service-volume-caches.md
@@ -1074,7 +1074,7 @@ Reviewable slices:
   implemented in the second refactor slice.
 - Slice 3: collapse dependency and service block execution after the shared
   plan shape exists, preserving the service fallback rule when dependency
-  publication is unsafe.
+  publication is unsafe. This is implemented in the third refactor slice.
 - Slice 4: extract backend-neutral cache-output volume helpers shared by
   Firecracker and darwin-vz, while leaving VM pause, storage-driver, and launch
   details in each adapter.

--- a/internal/controlservice/block_volume_execution.go
+++ b/internal/controlservice/block_volume_execution.go
@@ -1,0 +1,206 @@
+package controlservice
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+	"github.com/buildkite/cleanroom/internal/observability"
+	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/buildkite/cleanroom/internal/repositorychangeset"
+	"github.com/buildkite/cleanroom/internal/repositorycheckout"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+type blockVolumeExecutionPhase struct {
+	StageName           string
+	StageLabel          string
+	InputProjectionRoot string
+	BootstrapPhase      cleanroomv1.CreateSandboxPhase
+	PublishPhase        cleanroomv1.CreateSandboxPhase
+	NetworkStage        policy.NetworkStage
+	CachePublishPhase   blockVolumePublishPhase
+}
+
+type blockVolumeExecutionPublishConfig struct {
+	Adapter            backend.CacheOutputVolumeSnapshottingAdapter
+	Backend            string
+	Changeset          *repositorychangeset.Changeset
+	Repository         *repositorycheckout.Checkout
+	ForceExactFallback bool
+}
+
+func (s *Service) bootstrapBlockVolumePlanInPersistentSandbox(
+	ctx context.Context,
+	adapter backend.Adapter,
+	sandboxID string,
+	publish blockVolumeExecutionPublishConfig,
+	compiled *policy.CompiledPolicy,
+	firecrackerCfg backend.FirecrackerConfig,
+	repository *repositorycheckout.Checkout,
+	phase blockVolumeExecutionPhase,
+	blocks []blockVolumeBlockPlan,
+	reporter CreateSandboxReporter,
+) (bool, error) {
+	if adapter == nil || compiled == nil || repository == nil || strings.TrimSpace(sandboxID) == "" || len(blocks) == 0 {
+		return true, nil
+	}
+
+	publishable := !publish.ForceExactFallback
+	for _, block := range blocks {
+		blockName := strings.TrimSpace(block.BlockName)
+		if !publishable {
+			// Later block-volume hits are unsafe once this phase, or a phase it
+			// builds on, needed exact fallback.
+			if _, err := s.bootstrapBlockVolumeFallback(ctx, adapter, sandboxID, compiled, firecrackerCfg, repository, phase, block, true, reporter); err != nil {
+				return publishable, fmt.Errorf("%s block %q fallback: %w", phase.StageLabel, blockName, err)
+			}
+			continue
+		}
+		if block.CacheHit {
+			emitCreateSandboxMessage(reporter, phase.BootstrapPhase, fmt.Sprintf("restoring %s outputs: %s", phase.StageLabel, blockName))
+			continue
+		}
+
+		attrs := []attribute.KeyValue{
+			attribute.String(observability.AttrBackend, adapter.Name()),
+			attribute.String(observability.AttrSandboxID, sandboxID),
+			attribute.String("cleanroom.cache.block", blockName),
+			attribute.Int(observability.AttrCommandArgc, len(block.Command)),
+		}
+		if commitSHA := strings.TrimSpace(repository.CommitSHA); commitSHA != "" {
+			attrs = append(attrs, attribute.String(observability.AttrRepositoryCommitSHA, commitSHA))
+		}
+
+		emitCreateSandboxMessage(reporter, phase.BootstrapPhase, fmt.Sprintf("running %s bootstrap: %s", phase.StageLabel, blockName))
+		var result *backend.ExecutionResult
+		if err := s.traceCreateSandboxPhase(ctx, fmt.Sprintf("cleanroom.sandbox.bootstrap_%s_block", phase.StageLabel), attrs, func(ctx context.Context) error {
+			var err error
+			result, err = s.bootstrapBlockVolumeBlock(ctx, adapter, sandboxID, compiled, firecrackerCfg, repository, phase, block, reporter)
+			return err
+		}); err != nil {
+			return publishable, fmt.Errorf("%s block %q: %w", phase.StageLabel, blockName, err)
+		}
+		if warning := blockVolumeEscapedWriteWarning(phase.StageLabel, blockName, result); warning != "" {
+			publishable = false
+			emitCreateSandboxWarning(reporter, phase.BootstrapPhase, warning)
+			phase.CachePublishPhase.warn(s, phase.CachePublishPhase.PublishWarning, sandboxID, fmt.Errorf("%s", warning))
+			if _, err := s.bootstrapBlockVolumeFallback(ctx, adapter, sandboxID, compiled, firecrackerCfg, repository, phase, block, true, reporter); err != nil {
+				return publishable, fmt.Errorf("%s block %q fallback: %w", phase.StageLabel, blockName, err)
+			}
+		}
+		if publishable && publish.Adapter != nil {
+			emitCreateSandboxMessage(reporter, phase.PublishPhase, fmt.Sprintf("publishing %s outputs: %s", phase.StageLabel, blockName))
+			s.maybePublishBlockVolumeCaches(ctx, publish.Adapter, sandboxID, publish.Backend, compiled, firecrackerCfg, publish.Repository, publish.Changeset, phase.CachePublishPhase, []blockVolumePublishBlock{
+				blockVolumePublishBlockFromPlanBlock(block),
+			})
+		}
+	}
+	return publishable, nil
+}
+
+func (s *Service) bootstrapBlockVolumeFallback(
+	ctx context.Context,
+	adapter backend.Adapter,
+	sandboxID string,
+	compiled *policy.CompiledPolicy,
+	firecrackerCfg backend.FirecrackerConfig,
+	repository *repositorycheckout.Checkout,
+	phase blockVolumeExecutionPhase,
+	block blockVolumeBlockPlan,
+	resetOutputs bool,
+	reporter CreateSandboxReporter,
+) (*backend.ExecutionResult, error) {
+	if len(block.Command) == 0 {
+		return nil, nil
+	}
+	return s.runBlockVolumeExactFallback(
+		ctx,
+		adapter,
+		sandboxID,
+		compiled,
+		firecrackerCfg,
+		phase.BootstrapPhase,
+		phase.NetworkStage,
+		phase.StageLabel,
+		strings.TrimSpace(block.BlockName),
+		blockVolumeSourceRoot(repository),
+		block.Command,
+		stageBlockEnvList(block.Env),
+		block.Outputs,
+		resetOutputs,
+		reporter,
+	)
+}
+
+func (s *Service) bootstrapBlockVolumeBlock(
+	ctx context.Context,
+	adapter backend.Adapter,
+	sandboxID string,
+	compiled *policy.CompiledPolicy,
+	firecrackerCfg backend.FirecrackerConfig,
+	repository *repositorycheckout.Checkout,
+	phase blockVolumeExecutionPhase,
+	block blockVolumeBlockPlan,
+	reporter CreateSandboxReporter,
+) (*backend.ExecutionResult, error) {
+	if len(block.Command) == 0 {
+		return nil, nil
+	}
+	sourceRoot := blockVolumeSourceRoot(repository)
+	inputProjection := &backend.InputProjection{
+		SourceRoot:          sourceRoot,
+		TargetRoot:          filepath.Join(phase.InputProjectionRoot, strings.TrimSpace(block.BlockName)),
+		Files:               append([]string(nil), block.Inputs...),
+		MountSourceReadOnly: true,
+	}
+	env := stageBlockEnvList(block.Env)
+	_, result, stdout, stderr, err := s.runPersistentBootstrapCommandWithOptions(
+		ctx,
+		adapter,
+		sandboxID,
+		compiled,
+		firecrackerCfg,
+		phase.BootstrapPhase,
+		phase.NetworkStage,
+		block.Command,
+		env,
+		nil,
+		persistentSandboxCommandOptions{
+			Dir:                     sourceRoot,
+			ClosedEnv:               true,
+			InputProjection:         inputProjection,
+			CacheOutputFileCaptures: blockVolumeFileCaptures(phase.StageName, block.CacheKey, block.Outputs),
+			OverlayCapture:          blockVolumeOverlayCapture(phase.StageName, block.CacheKey, block.Outputs),
+		},
+		reporter,
+	)
+	return result, persistentBootstrapCommandError(
+		result,
+		stdout,
+		stderr,
+		err,
+		fmt.Sprintf("%s block bootstrap returned no result", phase.StageLabel),
+		fmt.Sprintf("%s block bootstrap failed with exit code %%d", phase.StageLabel),
+	)
+}
+
+func stageBlockEnvList(env map[string]string) []string {
+	if len(env) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(env))
+	for key := range env {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	out := make([]string, 0, len(keys))
+	for _, key := range keys {
+		out = append(out, key+"="+env[key])
+	}
+	return out
+}

--- a/internal/controlservice/block_volume_overlay_capture.go
+++ b/internal/controlservice/block_volume_overlay_capture.go
@@ -11,14 +11,6 @@ const blockVolumeOverlayCaptureRoot = "/run/cleanroom/overlay-captures"
 
 var blockVolumeOverlayCaptureIgnoredPrefixes = []string{"/tmp", "/var/tmp", "/run"}
 
-func dependencyBlockVolumeOverlayCapture(block dependencyBlockVolumeBlockPlan) *backend.OverlayCapture {
-	return blockVolumeOverlayCapture(dependencyVolumeStageName, block.CacheKey, block.Outputs)
-}
-
-func serviceBlockVolumeOverlayCapture(block serviceBlockVolumeBlockPlan) *backend.OverlayCapture {
-	return blockVolumeOverlayCapture(serviceVolumeStageName, block.CacheKey, block.Outputs)
-}
-
 func blockVolumeOverlayCapture(stage, cacheKey string, outputs policy.StageBlockOutputs) *backend.OverlayCapture {
 	return &backend.OverlayCapture{
 		UpperDir:            filepath.Join(blockVolumeOverlayCaptureRoot, blockVolumeID(stage, cacheKey), "upper"),

--- a/internal/controlservice/block_volume_publish.go
+++ b/internal/controlservice/block_volume_publish.go
@@ -26,6 +26,20 @@ type blockVolumePublishBlock struct {
 	CacheHit                bool
 }
 
+func blockVolumePublishBlockFromPlanBlock(block blockVolumeBlockPlan) blockVolumePublishBlock {
+	return blockVolumePublishBlock{
+		BlockName:               block.BlockName,
+		Outputs:                 block.Outputs,
+		CacheKey:                block.CacheKey,
+		CommandDigest:           block.CommandDigest,
+		EnvDigest:               block.EnvDigest,
+		InputManifestDigest:     block.InputManifestDigest,
+		NormalizedOutputsDigest: block.NormalizedOutputsDigest,
+		ProducerVersion:         block.ProducerVersion,
+		CacheHit:                block.CacheHit,
+	}
+}
+
 type blockVolumePublishPhase struct {
 	StageName               string
 	PublishWarning          string

--- a/internal/controlservice/block_volume_specs.go
+++ b/internal/controlservice/block_volume_specs.go
@@ -50,14 +50,6 @@ func serviceBlockVolumeOutputSpecs(plan serviceBlockVolumePlan) ([]backend.Cache
 	return blockVolumeOutputSpecs(blocks)
 }
 
-func dependencyBlockVolumeFileCaptures(block dependencyBlockVolumeBlockPlan) []backend.CacheOutputFileCapture {
-	return blockVolumeFileCaptures(dependencyVolumeStageName, block.CacheKey, block.Outputs)
-}
-
-func serviceBlockVolumeFileCaptures(block serviceBlockVolumeBlockPlan) []backend.CacheOutputFileCapture {
-	return blockVolumeFileCaptures(serviceVolumeStageName, block.CacheKey, block.Outputs)
-}
-
 func blockVolumeFileCaptures(stage, cacheKey string, outputs policy.StageBlockOutputs) []backend.CacheOutputFileCapture {
 	if len(outputs.Files) == 0 {
 		return nil

--- a/internal/controlservice/dependency_volume_execution.go
+++ b/internal/controlservice/dependency_volume_execution.go
@@ -2,21 +2,25 @@ package controlservice
 
 import (
 	"context"
-	"fmt"
-	"path/filepath"
-	"sort"
-	"strings"
 
 	"github.com/buildkite/cleanroom/internal/backend"
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
-	"github.com/buildkite/cleanroom/internal/observability"
 	"github.com/buildkite/cleanroom/internal/policy"
 	"github.com/buildkite/cleanroom/internal/repositorychangeset"
 	"github.com/buildkite/cleanroom/internal/repositorycheckout"
-	"go.opentelemetry.io/otel/attribute"
 )
 
 const dependencyInputProjectionRoot = "/run/cleanroom/input-projections/dependencies"
+
+var dependencyBlockVolumeExecutionPhase = blockVolumeExecutionPhase{
+	StageName:           dependencyVolumeStageName,
+	StageLabel:          "dependency",
+	InputProjectionRoot: dependencyInputProjectionRoot,
+	BootstrapPhase:      cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_DEPENDENCIES,
+	PublishPhase:        cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_PUBLISH_DEPENDENCY_STAGE_CACHE,
+	NetworkStage:        policy.NetworkStageDependencies,
+	CachePublishPhase:   dependencyBlockVolumePublishPhase,
+}
 
 type dependencyBlockVolumePublishConfig struct {
 	Adapter    backend.CacheOutputVolumeSnapshottingAdapter
@@ -36,158 +40,29 @@ func (s *Service) bootstrapDependencyBlockVolumePlanInPersistentSandbox(
 	plan dependencyBlockVolumePlan,
 	reporter CreateSandboxReporter,
 ) (bool, error) {
-	if adapter == nil || compiled == nil || repository == nil || strings.TrimSpace(sandboxID) == "" || len(plan.Blocks) == 0 {
-		return true, nil
-	}
-
-	publishable := true
-	for _, block := range plan.Blocks {
-		blockName := strings.TrimSpace(block.BlockName)
-		if !publishable {
-			// Later block-volume hits are unsafe once an earlier block needed
-			// exact fallback; their keys assume prior blocks are represented by
-			// declared output cache identities only.
-			if _, err := s.bootstrapDependencyBlockVolumeFallback(ctx, adapter, sandboxID, compiled, firecrackerCfg, repository, block, true, reporter); err != nil {
-				return publishable, fmt.Errorf("dependency block %q fallback: %w", blockName, err)
-			}
-			continue
-		}
-		if block.CacheHit {
-			emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_DEPENDENCIES, "restoring dependency outputs: "+blockName)
-			continue
-		}
-
-		attrs := []attribute.KeyValue{
-			attribute.String(observability.AttrBackend, adapter.Name()),
-			attribute.String(observability.AttrSandboxID, sandboxID),
-			attribute.String("cleanroom.cache.block", blockName),
-			attribute.Int(observability.AttrCommandArgc, len(block.Command)),
-		}
-		if commitSHA := strings.TrimSpace(repository.CommitSHA); commitSHA != "" {
-			attrs = append(attrs, attribute.String(observability.AttrRepositoryCommitSHA, commitSHA))
-		}
-
-		emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_DEPENDENCIES, "running dependency bootstrap: "+blockName)
-		var result *backend.ExecutionResult
-		if err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.bootstrap_dependency_block", attrs, func(ctx context.Context) error {
-			var err error
-			result, err = s.bootstrapDependencyBlockVolumeBlock(ctx, adapter, sandboxID, compiled, firecrackerCfg, repository, block, reporter)
-			return err
-		}); err != nil {
-			return publishable, fmt.Errorf("dependency block %q: %w", blockName, err)
-		}
-		if warning := blockVolumeEscapedWriteWarning("dependency", blockName, result); warning != "" {
-			publishable = false
-			emitCreateSandboxWarning(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_DEPENDENCIES, warning)
-			s.logDependencyStageWarning("publish dependency block-volume caches", sandboxID, fmt.Errorf("%s", warning))
-			if _, err := s.bootstrapDependencyBlockVolumeFallback(ctx, adapter, sandboxID, compiled, firecrackerCfg, repository, block, true, reporter); err != nil {
-				return publishable, fmt.Errorf("dependency block %q fallback: %w", blockName, err)
-			}
-		}
-		if publishable && publish.Adapter != nil {
-			emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_PUBLISH_DEPENDENCY_STAGE_CACHE, "publishing dependency outputs: "+blockName)
-			s.maybePublishDependencyBlockVolumeCaches(ctx, publish.Adapter, sandboxID, publish.Backend, compiled, firecrackerCfg, publish.Repository, publish.Changeset, dependencyBlockVolumePlan{
-				ReuseNamespace: plan.ReuseNamespace,
-				Blocks:         []dependencyBlockVolumeBlockPlan{block},
-			})
-		}
-	}
-	return publishable, nil
-}
-
-func (s *Service) bootstrapDependencyBlockVolumeFallback(
-	ctx context.Context,
-	adapter backend.Adapter,
-	sandboxID string,
-	compiled *policy.CompiledPolicy,
-	firecrackerCfg backend.FirecrackerConfig,
-	repository *repositorycheckout.Checkout,
-	block dependencyBlockVolumeBlockPlan,
-	resetOutputs bool,
-	reporter CreateSandboxReporter,
-) (*backend.ExecutionResult, error) {
-	if len(block.Command) == 0 {
-		return nil, nil
-	}
-	sourceRoot := blockVolumeSourceRoot(repository)
-	return s.runBlockVolumeExactFallback(
+	return s.bootstrapBlockVolumePlanInPersistentSandbox(
 		ctx,
 		adapter,
 		sandboxID,
-		compiled,
-		firecrackerCfg,
-		cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_DEPENDENCIES,
-		policy.NetworkStageDependencies,
-		"dependency",
-		strings.TrimSpace(block.BlockName),
-		sourceRoot,
-		block.Command,
-		stageBlockEnvList(block.Env),
-		block.Outputs,
-		resetOutputs,
-		reporter,
-	)
-}
-
-func (s *Service) bootstrapDependencyBlockVolumeBlock(
-	ctx context.Context,
-	adapter backend.Adapter,
-	sandboxID string,
-	compiled *policy.CompiledPolicy,
-	firecrackerCfg backend.FirecrackerConfig,
-	repository *repositorycheckout.Checkout,
-	block dependencyBlockVolumeBlockPlan,
-	reporter CreateSandboxReporter,
-) (*backend.ExecutionResult, error) {
-	if len(block.Command) == 0 {
-		return nil, nil
-	}
-	sourceRoot := strings.TrimSpace(repository.DestinationDir)
-	if sourceRoot == "" {
-		sourceRoot = "/workspace"
-	}
-	inputProjection := &backend.InputProjection{
-		SourceRoot:          sourceRoot,
-		TargetRoot:          filepath.Join(dependencyInputProjectionRoot, strings.TrimSpace(block.BlockName)),
-		Files:               append([]string(nil), block.Inputs...),
-		MountSourceReadOnly: true,
-	}
-	env := stageBlockEnvList(block.Env)
-	_, result, stdout, stderr, err := s.runPersistentBootstrapCommandWithOptions(
-		ctx,
-		adapter,
-		sandboxID,
-		compiled,
-		firecrackerCfg,
-		cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_DEPENDENCIES,
-		policy.NetworkStageDependencies,
-		block.Command,
-		env,
-		nil,
-		persistentSandboxCommandOptions{
-			Dir:                     sourceRoot,
-			ClosedEnv:               true,
-			InputProjection:         inputProjection,
-			CacheOutputFileCaptures: dependencyBlockVolumeFileCaptures(block),
-			OverlayCapture:          dependencyBlockVolumeOverlayCapture(block),
+		blockVolumeExecutionPublishConfig{
+			Adapter:    publish.Adapter,
+			Backend:    publish.Backend,
+			Changeset:  publish.Changeset,
+			Repository: publish.Repository,
 		},
+		compiled,
+		firecrackerCfg,
+		repository,
+		dependencyBlockVolumeExecutionPhase,
+		dependencyBlockVolumeExecutionBlocks(plan),
 		reporter,
 	)
-	return result, persistentBootstrapCommandError(result, stdout, stderr, err, "dependency block bootstrap returned no result", "dependency block bootstrap failed with exit code %d")
 }
 
-func stageBlockEnvList(env map[string]string) []string {
-	if len(env) == 0 {
-		return nil
+func dependencyBlockVolumeExecutionBlocks(plan dependencyBlockVolumePlan) []blockVolumeBlockPlan {
+	blocks := make([]blockVolumeBlockPlan, 0, len(plan.Blocks))
+	for _, block := range plan.Blocks {
+		blocks = append(blocks, blockVolumeBlockPlan(block))
 	}
-	keys := make([]string, 0, len(env))
-	for key := range env {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-	out := make([]string, 0, len(keys))
-	for _, key := range keys {
-		out = append(out, key+"="+env[key])
-	}
-	return out
+	return blocks
 }

--- a/internal/controlservice/dependency_volume_publish.go
+++ b/internal/controlservice/dependency_volume_publish.go
@@ -37,17 +37,7 @@ func (s *Service) maybePublishDependencyBlockVolumeCaches(
 func dependencyBlockVolumePublishBlocks(plan dependencyBlockVolumePlan) []blockVolumePublishBlock {
 	blocks := make([]blockVolumePublishBlock, 0, len(plan.Blocks))
 	for _, block := range plan.Blocks {
-		blocks = append(blocks, blockVolumePublishBlock{
-			BlockName:               block.BlockName,
-			Outputs:                 block.Outputs,
-			CacheKey:                block.CacheKey,
-			CommandDigest:           block.CommandDigest,
-			EnvDigest:               block.EnvDigest,
-			InputManifestDigest:     block.InputManifestDigest,
-			NormalizedOutputsDigest: block.NormalizedOutputsDigest,
-			ProducerVersion:         block.ProducerVersion,
-			CacheHit:                block.CacheHit,
-		})
+		blocks = append(blocks, blockVolumePublishBlockFromPlanBlock(blockVolumeBlockPlan(block)))
 	}
 	return blocks
 }

--- a/internal/controlservice/service_volume_execution.go
+++ b/internal/controlservice/service_volume_execution.go
@@ -2,20 +2,25 @@ package controlservice
 
 import (
 	"context"
-	"fmt"
-	"path/filepath"
-	"strings"
 
 	"github.com/buildkite/cleanroom/internal/backend"
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
-	"github.com/buildkite/cleanroom/internal/observability"
 	"github.com/buildkite/cleanroom/internal/policy"
 	"github.com/buildkite/cleanroom/internal/repositorychangeset"
 	"github.com/buildkite/cleanroom/internal/repositorycheckout"
-	"go.opentelemetry.io/otel/attribute"
 )
 
 const serviceInputProjectionRoot = "/run/cleanroom/input-projections/services"
+
+var serviceBlockVolumeExecutionPhase = blockVolumeExecutionPhase{
+	StageName:           serviceVolumeStageName,
+	StageLabel:          "service",
+	InputProjectionRoot: serviceInputProjectionRoot,
+	BootstrapPhase:      cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_SERVICES,
+	PublishPhase:        cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_PUBLISH_SERVICES_STAGE_CACHE,
+	NetworkStage:        policy.NetworkStageServices,
+	CachePublishPhase:   serviceBlockVolumePublishPhase,
+}
 
 type serviceBlockVolumePublishConfig struct {
 	Adapter            backend.CacheOutputVolumeSnapshottingAdapter
@@ -36,142 +41,30 @@ func (s *Service) bootstrapServiceBlockVolumePlanInPersistentSandbox(
 	plan serviceBlockVolumePlan,
 	reporter CreateSandboxReporter,
 ) (bool, error) {
-	if adapter == nil || compiled == nil || repository == nil || strings.TrimSpace(sandboxID) == "" || len(plan.Blocks) == 0 {
-		return true, nil
-	}
-
-	publishable := !publish.ForceExactFallback
-	for _, block := range plan.Blocks {
-		blockName := strings.TrimSpace(block.BlockName)
-		if !publishable {
-			// Later block-volume hits are unsafe once this phase, or the
-			// dependency phase it builds on, needed exact fallback.
-			if _, err := s.bootstrapServiceBlockVolumeFallback(ctx, adapter, sandboxID, compiled, firecrackerCfg, repository, block, true, reporter); err != nil {
-				return publishable, fmt.Errorf("service block %q fallback: %w", blockName, err)
-			}
-			continue
-		}
-		if block.CacheHit {
-			emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_SERVICES, "restoring service outputs: "+blockName)
-			continue
-		}
-
-		attrs := []attribute.KeyValue{
-			attribute.String(observability.AttrBackend, adapter.Name()),
-			attribute.String(observability.AttrSandboxID, sandboxID),
-			attribute.String("cleanroom.cache.block", blockName),
-			attribute.Int(observability.AttrCommandArgc, len(block.Command)),
-		}
-		if commitSHA := strings.TrimSpace(repository.CommitSHA); commitSHA != "" {
-			attrs = append(attrs, attribute.String(observability.AttrRepositoryCommitSHA, commitSHA))
-		}
-
-		emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_SERVICES, "running service bootstrap: "+blockName)
-		var result *backend.ExecutionResult
-		if err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.bootstrap_service_block", attrs, func(ctx context.Context) error {
-			var err error
-			result, err = s.bootstrapServiceBlockVolumeBlock(ctx, adapter, sandboxID, compiled, firecrackerCfg, repository, block, reporter)
-			return err
-		}); err != nil {
-			return publishable, fmt.Errorf("service block %q: %w", blockName, err)
-		}
-		if warning := blockVolumeEscapedWriteWarning("service", blockName, result); warning != "" {
-			publishable = false
-			emitCreateSandboxWarning(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_SERVICES, warning)
-			s.logServicesStageWarning("publish service block-volume caches", sandboxID, fmt.Errorf("%s", warning))
-			if _, err := s.bootstrapServiceBlockVolumeFallback(ctx, adapter, sandboxID, compiled, firecrackerCfg, repository, block, true, reporter); err != nil {
-				return publishable, fmt.Errorf("service block %q fallback: %w", blockName, err)
-			}
-		}
-		if publishable && publish.Adapter != nil {
-			emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_PUBLISH_SERVICES_STAGE_CACHE, "publishing service outputs: "+blockName)
-			s.maybePublishServiceBlockVolumeCaches(ctx, publish.Adapter, sandboxID, publish.Backend, compiled, firecrackerCfg, publish.Repository, publish.Changeset, serviceBlockVolumePlan{
-				ReuseNamespace:       plan.ReuseNamespace,
-				DependencyOutputKeys: append([]string(nil), plan.DependencyOutputKeys...),
-				Blocks:               []serviceBlockVolumeBlockPlan{block},
-			})
-		}
-	}
-	return publishable, nil
-}
-
-func (s *Service) bootstrapServiceBlockVolumeFallback(
-	ctx context.Context,
-	adapter backend.Adapter,
-	sandboxID string,
-	compiled *policy.CompiledPolicy,
-	firecrackerCfg backend.FirecrackerConfig,
-	repository *repositorycheckout.Checkout,
-	block serviceBlockVolumeBlockPlan,
-	resetOutputs bool,
-	reporter CreateSandboxReporter,
-) (*backend.ExecutionResult, error) {
-	if len(block.Command) == 0 {
-		return nil, nil
-	}
-	sourceRoot := blockVolumeSourceRoot(repository)
-	return s.runBlockVolumeExactFallback(
+	return s.bootstrapBlockVolumePlanInPersistentSandbox(
 		ctx,
 		adapter,
 		sandboxID,
-		compiled,
-		firecrackerCfg,
-		cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_SERVICES,
-		policy.NetworkStageServices,
-		"service",
-		strings.TrimSpace(block.BlockName),
-		sourceRoot,
-		block.Command,
-		stageBlockEnvList(block.Env),
-		block.Outputs,
-		resetOutputs,
-		reporter,
-	)
-}
-
-func (s *Service) bootstrapServiceBlockVolumeBlock(
-	ctx context.Context,
-	adapter backend.Adapter,
-	sandboxID string,
-	compiled *policy.CompiledPolicy,
-	firecrackerCfg backend.FirecrackerConfig,
-	repository *repositorycheckout.Checkout,
-	block serviceBlockVolumeBlockPlan,
-	reporter CreateSandboxReporter,
-) (*backend.ExecutionResult, error) {
-	if len(block.Command) == 0 {
-		return nil, nil
-	}
-	sourceRoot := strings.TrimSpace(repository.DestinationDir)
-	if sourceRoot == "" {
-		sourceRoot = "/workspace"
-	}
-	inputProjection := &backend.InputProjection{
-		SourceRoot:          sourceRoot,
-		TargetRoot:          filepath.Join(serviceInputProjectionRoot, strings.TrimSpace(block.BlockName)),
-		Files:               append([]string(nil), block.Inputs...),
-		MountSourceReadOnly: true,
-	}
-	env := stageBlockEnvList(block.Env)
-	_, result, stdout, stderr, err := s.runPersistentBootstrapCommandWithOptions(
-		ctx,
-		adapter,
-		sandboxID,
-		compiled,
-		firecrackerCfg,
-		cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_SERVICES,
-		policy.NetworkStageServices,
-		block.Command,
-		env,
-		nil,
-		persistentSandboxCommandOptions{
-			Dir:                     sourceRoot,
-			ClosedEnv:               true,
-			InputProjection:         inputProjection,
-			CacheOutputFileCaptures: serviceBlockVolumeFileCaptures(block),
-			OverlayCapture:          serviceBlockVolumeOverlayCapture(block),
+		blockVolumeExecutionPublishConfig{
+			Adapter:            publish.Adapter,
+			Backend:            publish.Backend,
+			Changeset:          publish.Changeset,
+			Repository:         publish.Repository,
+			ForceExactFallback: publish.ForceExactFallback,
 		},
+		compiled,
+		firecrackerCfg,
+		repository,
+		serviceBlockVolumeExecutionPhase,
+		serviceBlockVolumeExecutionBlocks(plan),
 		reporter,
 	)
-	return result, persistentBootstrapCommandError(result, stdout, stderr, err, "service block bootstrap returned no result", "service block bootstrap failed with exit code %d")
+}
+
+func serviceBlockVolumeExecutionBlocks(plan serviceBlockVolumePlan) []blockVolumeBlockPlan {
+	blocks := make([]blockVolumeBlockPlan, 0, len(plan.Blocks))
+	for _, block := range plan.Blocks {
+		blocks = append(blocks, blockVolumeBlockPlan(block))
+	}
+	return blocks
 }

--- a/internal/controlservice/service_volume_publish.go
+++ b/internal/controlservice/service_volume_publish.go
@@ -37,17 +37,7 @@ func (s *Service) maybePublishServiceBlockVolumeCaches(
 func serviceBlockVolumePublishBlocks(plan serviceBlockVolumePlan) []blockVolumePublishBlock {
 	blocks := make([]blockVolumePublishBlock, 0, len(plan.Blocks))
 	for _, block := range plan.Blocks {
-		blocks = append(blocks, blockVolumePublishBlock{
-			BlockName:               block.BlockName,
-			Outputs:                 block.Outputs,
-			CacheKey:                block.CacheKey,
-			CommandDigest:           block.CommandDigest,
-			EnvDigest:               block.EnvDigest,
-			InputManifestDigest:     block.InputManifestDigest,
-			NormalizedOutputsDigest: block.NormalizedOutputsDigest,
-			ProducerVersion:         block.ProducerVersion,
-			CacheHit:                block.CacheHit,
-		})
+		blocks = append(blocks, blockVolumePublishBlockFromPlanBlock(blockVolumeBlockPlan(block)))
 	}
 	return blocks
 }


### PR DESCRIPTION
This is slice 3 of the cache refactor stack, on top of #324. It removes the duplicated dependency and service block-volume execution loops without changing cache keys, metadata records, backend requests, or guest behavior.

Changes:
- add a phase-driven block-volume execution helper for misses, exact fallback, escaped-write handling, tracing, and per-block publish handoff
- keep dependency and service wrappers responsible for phase constants, network stage, input projection root, publish phase, and the service forced-fallback rule
- reuse the shared publish-block conversion from both phase publish wrappers
- mark slice 3 implemented in the plan doc

Validation:
- mise exec -- go test ./internal/controlservice
- mise exec -- go test ./...