### PR TITLE
refactor: Share cache output helpers

### DIFF
--- a/docs/plans/dependency-service-volume-caches.md
+++ b/docs/plans/dependency-service-volume-caches.md
@@ -1077,7 +1077,7 @@ Reviewable slices:
   publication is unsafe. This is implemented in the third refactor slice.
 - Slice 4: extract backend-neutral cache-output volume helpers shared by
   Firecracker and darwin-vz, while leaving VM pause, storage-driver, and launch
-  details in each adapter.
+  details in each adapter. This is implemented in the fourth refactor slice.
 - Slice 5: reconcile the older layered-cache plan and the unused
   `internal/inputmanifest` package with the implemented block-volume model.
 - Slice 6: simplify `CreateSandbox` cache orchestration once the narrower

--- a/internal/backend/cacheoutput/cacheoutput.go
+++ b/internal/backend/cacheoutput/cacheoutput.go
@@ -1,0 +1,267 @@
+package cacheoutput
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/ext4image"
+	"github.com/buildkite/cleanroom/internal/hosttools"
+	"github.com/buildkite/cleanroom/internal/vsockexec"
+)
+
+const DefaultVolumeMinimumBytes int64 = 512 << 20
+const GuestMountRoot = "/run/cleanroom/cache-output-volumes"
+
+type PreparedMount struct {
+	Spec       backend.CacheOutputVolumeSpec
+	DevicePath string
+	MountPath  string
+}
+
+func ValidateVolumeSpec(spec backend.CacheOutputVolumeSpec) error {
+	if strings.TrimSpace(spec.Stage) == "" {
+		return errors.New("missing stage")
+	}
+	if strings.TrimSpace(spec.BlockName) == "" {
+		return errors.New("missing block name")
+	}
+	if strings.TrimSpace(spec.CacheKey) == "" {
+		return errors.New("missing cache key")
+	}
+	if strings.TrimSpace(spec.VolumeID) == "" {
+		return errors.New("missing volume id")
+	}
+	if len(spec.DirMappings) == 0 && len(spec.FileMappings) == 0 {
+		return errors.New("missing output mappings")
+	}
+	for i, mapping := range spec.DirMappings {
+		if strings.TrimSpace(mapping.GuestPath) == "" {
+			return fmt.Errorf("dir mapping %d missing guest path", i)
+		}
+		if strings.TrimSpace(mapping.Subpath) == "" {
+			return fmt.Errorf("dir mapping %d missing volume subpath", i)
+		}
+	}
+	for i, mapping := range spec.FileMappings {
+		if strings.TrimSpace(mapping.GuestPath) == "" {
+			return fmt.Errorf("file mapping %d missing guest path", i)
+		}
+		if strings.TrimSpace(mapping.Subpath) == "" {
+			return fmt.Errorf("file mapping %d missing volume subpath", i)
+		}
+	}
+	return nil
+}
+
+func SourceRef(spec backend.CacheOutputVolumeSpec) string {
+	if sourceRef := strings.TrimSpace(spec.SourceSnapshotRef); sourceRef != "" {
+		return sourceRef
+	}
+	return strings.TrimSpace(spec.StorageRef)
+}
+
+func SpecHasSource(spec backend.CacheOutputVolumeSpec) bool {
+	return SourceRef(spec) != ""
+}
+
+func CreateEmptyExt4Image(ctx context.Context, path string, minimumBytes int64) error {
+	if strings.TrimSpace(path) == "" {
+		return errors.New("missing empty cache output image path")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create empty cache output image directory: %w", err)
+	}
+	sizeBytes := ext4image.AlignBytes(minimumBytes)
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o600)
+	if err != nil {
+		return fmt.Errorf("create empty cache output image %q: %w", path, err)
+	}
+	if err := file.Truncate(sizeBytes); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("truncate empty cache output image %q to %d bytes: %w", path, sizeBytes, err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close empty cache output image %q: %w", path, err)
+	}
+	mkfsPath, err := hosttools.ResolveE2FSProgsBinary("mkfs.ext4")
+	if err != nil {
+		return fmt.Errorf("find mkfs.ext4 for cache output volume: %w", err)
+	}
+	if out, err := exec.CommandContext(ctx, mkfsPath, "-q", "-F", path).CombinedOutput(); err != nil {
+		_ = os.Remove(path)
+		trimmed := strings.TrimSpace(string(out))
+		if trimmed == "" {
+			return fmt.Errorf("create empty cache output ext4 image: %w", err)
+		}
+		return fmt.Errorf("create empty cache output ext4 image: %w: %s", err, trimmed)
+	}
+	return nil
+}
+
+func RuntimeVolumeID(sandboxID, specVolumeID string, index int) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(sandboxID) + "\x00" + strings.TrimSpace(specVolumeID)))
+	return fmt.Sprintf("%s-cache-output-%02d-%s", strings.TrimSpace(sandboxID), index, hex.EncodeToString(sum[:6]))
+}
+
+func MountID(index int) string {
+	return fmt.Sprintf("cacheout%d", index)
+}
+
+func GuestMountPath(root, mountID string) string {
+	return filepath.Join(strings.TrimSpace(root), strings.TrimSpace(mountID))
+}
+
+func DevicePathAfterRoot(index int) string {
+	return "/dev/" + VirtioBlockDeviceName(index+1)
+}
+
+func VirtioBlockDeviceName(index int) string {
+	if index < 0 {
+		index = 0
+	}
+	letters := ""
+	for {
+		letters = string(rune('a'+index%26)) + letters
+		index = index/26 - 1
+		if index < 0 {
+			break
+		}
+	}
+	return "vd" + letters
+}
+
+func Mounts(volumes []PreparedMount) []vsockexec.CacheOutputMount {
+	if len(volumes) == 0 {
+		return nil
+	}
+	mounts := make([]vsockexec.CacheOutputMount, 0, len(volumes))
+	for _, volume := range volumes {
+		mount := vsockexec.CacheOutputMount{
+			DevicePath:    strings.TrimSpace(volume.DevicePath),
+			MountPath:     strings.TrimSpace(volume.MountPath),
+			SourcePresent: SpecHasSource(volume.Spec),
+		}
+		for _, mapping := range volume.Spec.DirMappings {
+			mount.DirMappings = append(mount.DirMappings, vsockexec.CacheOutputDirMount{
+				GuestPath: strings.TrimSpace(mapping.GuestPath),
+				Subpath:   strings.TrimSpace(mapping.Subpath),
+			})
+		}
+		for _, mapping := range volume.Spec.FileMappings {
+			mount.FileMappings = append(mount.FileMappings, vsockexec.CacheOutputFileMount{
+				GuestPath: strings.TrimSpace(mapping.GuestPath),
+				Subpath:   strings.TrimSpace(mapping.Subpath),
+				Mode:      uint32(mapping.Mode.Perm()),
+			})
+		}
+		mounts = append(mounts, mount)
+	}
+	return mounts
+}
+
+func FileCaptures(volumes []PreparedMount, captures []backend.CacheOutputFileCapture) ([]vsockexec.CacheOutputFileCapture, error) {
+	if len(captures) == 0 {
+		return nil, nil
+	}
+	mountsByVolumeID := make(map[string]string, len(volumes))
+	for _, volume := range volumes {
+		mountsByVolumeID[strings.TrimSpace(volume.Spec.VolumeID)] = strings.TrimSpace(volume.MountPath)
+	}
+	out := make([]vsockexec.CacheOutputFileCapture, 0, len(captures))
+	for i, capture := range captures {
+		volumeID := strings.TrimSpace(capture.VolumeID)
+		if volumeID == "" {
+			return nil, fmt.Errorf("cache output file capture %d missing volume id", i)
+		}
+		mountPath, ok := mountsByVolumeID[volumeID]
+		if !ok {
+			return nil, fmt.Errorf("cache output file capture %d references unknown volume id %q", i, capture.VolumeID)
+		}
+		out = append(out, vsockexec.CacheOutputFileCapture{
+			GuestPath: strings.TrimSpace(capture.GuestPath),
+			MountPath: mountPath,
+			Subpath:   strings.TrimSpace(capture.VolumeSubpath),
+			Mode:      uint32(capture.Mode.Perm()),
+		})
+	}
+	return out, nil
+}
+
+func CloneMounts(mounts []vsockexec.CacheOutputMount) []vsockexec.CacheOutputMount {
+	if len(mounts) == 0 {
+		return nil
+	}
+	out := make([]vsockexec.CacheOutputMount, len(mounts))
+	for i, mount := range mounts {
+		out[i] = mount
+		out[i].DirMappings = append([]vsockexec.CacheOutputDirMount(nil), mount.DirMappings...)
+		out[i].FileMappings = append([]vsockexec.CacheOutputFileMount(nil), mount.FileMappings...)
+	}
+	return out
+}
+
+func SnapshotID(prefix, volumeID string) string {
+	hash := SHA256String(strings.TrimSpace(volumeID))
+	return strings.TrimSpace(prefix) + "-" + hash[:16]
+}
+
+func SnapshotOutputs(spec backend.CacheOutputVolumeSpec) []backend.CacheOutputVolumeSnapshotOutput {
+	out := make([]backend.CacheOutputVolumeSnapshotOutput, 0, len(spec.DirMappings)+len(spec.FileMappings))
+	for _, mapping := range spec.DirMappings {
+		out = append(out, backend.CacheOutputVolumeSnapshotOutput{
+			Kind:          "dir",
+			GuestPath:     strings.TrimSpace(mapping.GuestPath),
+			VolumeSubpath: strings.TrimSpace(mapping.Subpath),
+		})
+	}
+	for _, mapping := range spec.FileMappings {
+		out = append(out, backend.CacheOutputVolumeSnapshotOutput{
+			Kind:          "file",
+			GuestPath:     strings.TrimSpace(mapping.GuestPath),
+			VolumeSubpath: strings.TrimSpace(mapping.Subpath),
+			Mode:          mapping.Mode.Perm(),
+		})
+	}
+	return out
+}
+
+func SelectByVolumeID[T any](volumes []T, volumeIDs []string, volumeID func(T) string) ([]T, error) {
+	if len(volumeIDs) == 0 {
+		return append([]T(nil), volumes...), nil
+	}
+	byID := make(map[string]T, len(volumes))
+	for _, volume := range volumes {
+		byID[strings.TrimSpace(volumeID(volume))] = volume
+	}
+	selected := make([]T, 0, len(volumeIDs))
+	seen := make(map[string]struct{}, len(volumeIDs))
+	for _, id := range volumeIDs {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			return nil, errors.New("cache output volume id cannot be empty")
+		}
+		if _, ok := seen[id]; ok {
+			return nil, fmt.Errorf("duplicate cache output volume id %q", id)
+		}
+		seen[id] = struct{}{}
+		volume, ok := byID[id]
+		if !ok {
+			return nil, fmt.Errorf("unknown cache output volume id %q", id)
+		}
+		selected = append(selected, volume)
+	}
+	return selected, nil
+}
+
+func SHA256String(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/backend/cacheoutput/cacheoutput_test.go
+++ b/internal/backend/cacheoutput/cacheoutput_test.go
@@ -1,0 +1,99 @@
+package cacheoutput
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/vsockexec"
+)
+
+func TestValidateVolumeSpecRejectsMissingOutputMappings(t *testing.T) {
+	t.Parallel()
+
+	err := ValidateVolumeSpec(backend.CacheOutputVolumeSpec{
+		Stage:     "dependency-volume",
+		BlockName: "toolchains",
+		CacheKey:  "cache-key",
+		VolumeID:  "volume-id",
+	})
+	if err == nil {
+		t.Fatal("expected missing output mappings to fail")
+	}
+	if !strings.Contains(err.Error(), "missing output mappings") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestMountsAndFileCapturesUsePreparedMounts(t *testing.T) {
+	t.Parallel()
+
+	volumes := []PreparedMount{
+		{
+			Spec: backend.CacheOutputVolumeSpec{
+				VolumeID:          "volume-a",
+				SourceSnapshotRef: "snapshot-a",
+				DirMappings: []backend.CacheOutputDirMapping{
+					{GuestPath: " /root/.cache/tool ", Subpath: " dirs/0 "},
+				},
+				FileMappings: []backend.CacheOutputFileMapping{
+					{GuestPath: " /root/.config/tool.json ", Subpath: " files/0 ", Mode: 0o600},
+				},
+			},
+			DevicePath: "/dev/vdb",
+			MountPath:  "/run/cleanroom/cache-output-volumes/cacheout0",
+		},
+	}
+
+	wantMounts := []vsockexec.CacheOutputMount{
+		{
+			DevicePath:    "/dev/vdb",
+			MountPath:     "/run/cleanroom/cache-output-volumes/cacheout0",
+			SourcePresent: true,
+			DirMappings: []vsockexec.CacheOutputDirMount{
+				{GuestPath: "/root/.cache/tool", Subpath: "dirs/0"},
+			},
+			FileMappings: []vsockexec.CacheOutputFileMount{
+				{GuestPath: "/root/.config/tool.json", Subpath: "files/0", Mode: 0o600},
+			},
+		},
+	}
+	if got := Mounts(volumes); !reflect.DeepEqual(got, wantMounts) {
+		t.Fatalf("unexpected mounts: got %#v want %#v", got, wantMounts)
+	}
+
+	captures, err := FileCaptures(volumes, []backend.CacheOutputFileCapture{
+		{VolumeID: "volume-a", GuestPath: " /root/.config/tool.json ", VolumeSubpath: " files/0 ", Mode: 0o600},
+	})
+	if err != nil {
+		t.Fatalf("FileCaptures returned error: %v", err)
+	}
+	wantCaptures := []vsockexec.CacheOutputFileCapture{
+		{
+			GuestPath: "/root/.config/tool.json",
+			MountPath: "/run/cleanroom/cache-output-volumes/cacheout0",
+			Subpath:   "files/0",
+			Mode:      0o600,
+		},
+	}
+	if !reflect.DeepEqual(captures, wantCaptures) {
+		t.Fatalf("unexpected captures: got %#v want %#v", captures, wantCaptures)
+	}
+}
+
+func TestSelectByVolumeIDRejectsDuplicateRequests(t *testing.T) {
+	t.Parallel()
+
+	_, err := SelectByVolumeID(
+		[]backend.CacheOutputVolumeSpec{{VolumeID: "volume-a"}},
+		[]string{"volume-a", "volume-a"},
+		func(spec backend.CacheOutputVolumeSpec) string { return spec.VolumeID },
+	)
+	if err == nil {
+		t.Fatal("expected duplicate volume ids to fail")
+	}
+	if !strings.Contains(err.Error(), `duplicate cache output volume id "volume-a"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/backend/darwinvz/cache_output_snapshots_darwin.go
+++ b/internal/backend/darwinvz/cache_output_snapshots_darwin.go
@@ -4,14 +4,13 @@ package darwinvz
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/backend/cacheoutput"
 	"github.com/buildkite/cleanroom/internal/volumestore"
 )
 
@@ -195,31 +194,9 @@ func snapshotDarwinVZCacheOutputVolume(ctx context.Context, driver volumestore.D
 }
 
 func selectDarwinVZCacheOutputVolumes(volumes []preparedDarwinVZCacheOutputVolume, volumeIDs []string) ([]preparedDarwinVZCacheOutputVolume, error) {
-	if len(volumeIDs) == 0 {
-		return append([]preparedDarwinVZCacheOutputVolume(nil), volumes...), nil
-	}
-	byID := make(map[string]preparedDarwinVZCacheOutputVolume, len(volumes))
-	for _, volume := range volumes {
-		byID[strings.TrimSpace(volume.Spec.VolumeID)] = volume
-	}
-	selected := make([]preparedDarwinVZCacheOutputVolume, 0, len(volumeIDs))
-	seen := make(map[string]struct{}, len(volumeIDs))
-	for _, id := range volumeIDs {
-		id = strings.TrimSpace(id)
-		if id == "" {
-			return nil, errors.New("cache output volume id cannot be empty")
-		}
-		if _, ok := seen[id]; ok {
-			return nil, fmt.Errorf("duplicate cache output volume id %q", id)
-		}
-		seen[id] = struct{}{}
-		volume, ok := byID[id]
-		if !ok {
-			return nil, fmt.Errorf("unknown cache output volume id %q", id)
-		}
-		selected = append(selected, volume)
-	}
-	return selected, nil
+	return cacheoutput.SelectByVolumeID(volumes, volumeIDs, func(volume preparedDarwinVZCacheOutputVolume) string {
+		return volume.Spec.VolumeID
+	})
 }
 
 func darwinVZCacheOutputSnapshotConfig(cfg backend.FirecrackerConfig, spec backend.CacheOutputVolumeSpec) backend.FirecrackerConfig {
@@ -230,31 +207,9 @@ func darwinVZCacheOutputSnapshotConfig(cfg backend.FirecrackerConfig, spec backe
 }
 
 func darwinVZCacheOutputSnapshotID(prefix, volumeID string) string {
-	hash := darwinVZCacheOutputSnapshotHash(strings.TrimSpace(volumeID))
-	return strings.TrimSpace(prefix) + "-" + hash[:16]
+	return cacheoutput.SnapshotID(prefix, volumeID)
 }
 
 func darwinVZCacheOutputVolumeSnapshotOutputs(spec backend.CacheOutputVolumeSpec) []backend.CacheOutputVolumeSnapshotOutput {
-	out := make([]backend.CacheOutputVolumeSnapshotOutput, 0, len(spec.DirMappings)+len(spec.FileMappings))
-	for _, mapping := range spec.DirMappings {
-		out = append(out, backend.CacheOutputVolumeSnapshotOutput{
-			Kind:          "dir",
-			GuestPath:     strings.TrimSpace(mapping.GuestPath),
-			VolumeSubpath: strings.TrimSpace(mapping.Subpath),
-		})
-	}
-	for _, mapping := range spec.FileMappings {
-		out = append(out, backend.CacheOutputVolumeSnapshotOutput{
-			Kind:          "file",
-			GuestPath:     strings.TrimSpace(mapping.GuestPath),
-			VolumeSubpath: strings.TrimSpace(mapping.Subpath),
-			Mode:          mapping.Mode.Perm(),
-		})
-	}
-	return out
-}
-
-func darwinVZCacheOutputSnapshotHash(value string) string {
-	sum := sha256.Sum256([]byte(value))
-	return hex.EncodeToString(sum[:])
+	return cacheoutput.SnapshotOutputs(spec)
 }

--- a/internal/backend/darwinvz/cache_output_volumes_darwin.go
+++ b/internal/backend/darwinvz/cache_output_volumes_darwin.go
@@ -4,24 +4,20 @@ package darwinvz
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
 	"github.com/buildkite/cleanroom/internal/backend"
-	"github.com/buildkite/cleanroom/internal/ext4image"
-	"github.com/buildkite/cleanroom/internal/hosttools"
+	"github.com/buildkite/cleanroom/internal/backend/cacheoutput"
 	"github.com/buildkite/cleanroom/internal/volumestore"
 	"github.com/buildkite/cleanroom/internal/vsockexec"
 )
 
-const defaultDarwinVZCacheOutputVolumeMinimumBytes int64 = 512 << 20
-const darwinVZCacheOutputGuestMountRoot = "/run/cleanroom/cache-output-volumes"
+const defaultDarwinVZCacheOutputVolumeMinimumBytes int64 = cacheoutput.DefaultVolumeMinimumBytes
+const darwinVZCacheOutputGuestMountRoot = cacheoutput.GuestMountRoot
 
 var (
 	darwinVZCacheOutputVolumeMinimumBytes     = defaultDarwinVZCacheOutputVolumeMinimumBytes
@@ -56,7 +52,7 @@ func prepareDarwinVZCacheOutputVolumes(ctx context.Context, cfg backend.Firecrac
 
 	seenVolumeIDs := make(map[string]struct{}, len(specs))
 	for i, spec := range specs {
-		if err := validateDarwinVZCacheOutputVolumeSpec(spec); err != nil {
+		if err := cacheoutput.ValidateVolumeSpec(spec); err != nil {
 			cleanup()
 			return nil, nil, fmt.Errorf("cache output volume %d: %w", i, err)
 		}
@@ -91,46 +87,8 @@ func prepareDarwinVZCacheOutputVolumes(ctx context.Context, cfg backend.Firecrac
 	return prepared, cleanup, nil
 }
 
-func validateDarwinVZCacheOutputVolumeSpec(spec backend.CacheOutputVolumeSpec) error {
-	if strings.TrimSpace(spec.Stage) == "" {
-		return errors.New("missing stage")
-	}
-	if strings.TrimSpace(spec.BlockName) == "" {
-		return errors.New("missing block name")
-	}
-	if strings.TrimSpace(spec.CacheKey) == "" {
-		return errors.New("missing cache key")
-	}
-	if strings.TrimSpace(spec.VolumeID) == "" {
-		return errors.New("missing volume id")
-	}
-	if len(spec.DirMappings) == 0 && len(spec.FileMappings) == 0 {
-		return errors.New("missing output mappings")
-	}
-	for i, mapping := range spec.DirMappings {
-		if strings.TrimSpace(mapping.GuestPath) == "" {
-			return fmt.Errorf("dir mapping %d missing guest path", i)
-		}
-		if strings.TrimSpace(mapping.Subpath) == "" {
-			return fmt.Errorf("dir mapping %d missing volume subpath", i)
-		}
-	}
-	for i, mapping := range spec.FileMappings {
-		if strings.TrimSpace(mapping.GuestPath) == "" {
-			return fmt.Errorf("file mapping %d missing guest path", i)
-		}
-		if strings.TrimSpace(mapping.Subpath) == "" {
-			return fmt.Errorf("file mapping %d missing volume subpath", i)
-		}
-	}
-	return nil
-}
-
 func darwinVZCacheOutputVolumeSource(ctx context.Context, cfg backend.FirecrackerConfig, runDir string, spec backend.CacheOutputVolumeSpec) (sourceRef string, volumeCfg backend.FirecrackerConfig, err error) {
-	sourceRef = strings.TrimSpace(spec.SourceSnapshotRef)
-	if sourceRef == "" {
-		sourceRef = strings.TrimSpace(spec.StorageRef)
-	}
+	sourceRef = cacheoutput.SourceRef(spec)
 	volumeCfg = cfg
 	if driver := strings.TrimSpace(spec.StorageDriver); driver != "" {
 		volumeCfg.Snapshots.Driver = driver
@@ -155,37 +113,7 @@ func darwinVZCacheOutputVolumeSource(ctx context.Context, cfg backend.Firecracke
 }
 
 func createEmptyDarwinVZCacheOutputExt4Image(ctx context.Context, path string, minimumBytes int64) error {
-	if strings.TrimSpace(path) == "" {
-		return errors.New("missing empty cache output image path")
-	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return fmt.Errorf("create empty cache output image directory: %w", err)
-	}
-	sizeBytes := ext4image.AlignBytes(minimumBytes)
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o600)
-	if err != nil {
-		return fmt.Errorf("create empty cache output image %q: %w", path, err)
-	}
-	if err := file.Truncate(sizeBytes); err != nil {
-		_ = file.Close()
-		return fmt.Errorf("truncate empty cache output image %q to %d bytes: %w", path, sizeBytes, err)
-	}
-	if err := file.Close(); err != nil {
-		return fmt.Errorf("close empty cache output image %q: %w", path, err)
-	}
-	mkfsPath, err := hosttools.ResolveE2FSProgsBinary("mkfs.ext4")
-	if err != nil {
-		return fmt.Errorf("find mkfs.ext4 for cache output volume: %w", err)
-	}
-	if out, err := exec.CommandContext(ctx, mkfsPath, "-q", "-F", path).CombinedOutput(); err != nil {
-		_ = os.Remove(path)
-		trimmed := strings.TrimSpace(string(out))
-		if trimmed == "" {
-			return fmt.Errorf("create empty cache output ext4 image: %w", err)
-		}
-		return fmt.Errorf("create empty cache output ext4 image: %w: %s", err, trimmed)
-	}
-	return nil
+	return cacheoutput.CreateEmptyExt4Image(ctx, path, minimumBytes)
 }
 
 func prepareDarwinVZCacheOutputWritableVolume(ctx context.Context, cfg backend.FirecrackerConfig, volumeID, attachmentPath, sourceRef string, minimumBytes int64) (volumestore.WritableVolume, func(), error) {
@@ -259,103 +187,44 @@ func darwinVZCacheOutputDiskPaths(volumes []preparedDarwinVZCacheOutputVolume) [
 }
 
 func darwinVZCacheOutputVolumeMounts(volumes []preparedDarwinVZCacheOutputVolume) []vsockexec.CacheOutputMount {
+	return cacheoutput.Mounts(darwinVZCacheOutputPreparedMounts(volumes))
+}
+
+func darwinVZCacheOutputPreparedMounts(volumes []preparedDarwinVZCacheOutputVolume) []cacheoutput.PreparedMount {
 	if len(volumes) == 0 {
 		return nil
 	}
-	mounts := make([]vsockexec.CacheOutputMount, 0, len(volumes))
+	mounts := make([]cacheoutput.PreparedMount, 0, len(volumes))
 	for _, volume := range volumes {
-		mount := vsockexec.CacheOutputMount{
-			DevicePath:    volume.DevicePath,
-			MountPath:     volume.MountPath,
-			SourcePresent: darwinVZCacheOutputSpecHasSource(volume.Spec),
-		}
-		for _, mapping := range volume.Spec.DirMappings {
-			mount.DirMappings = append(mount.DirMappings, vsockexec.CacheOutputDirMount{
-				GuestPath: strings.TrimSpace(mapping.GuestPath),
-				Subpath:   strings.TrimSpace(mapping.Subpath),
-			})
-		}
-		for _, mapping := range volume.Spec.FileMappings {
-			mount.FileMappings = append(mount.FileMappings, vsockexec.CacheOutputFileMount{
-				GuestPath: strings.TrimSpace(mapping.GuestPath),
-				Subpath:   strings.TrimSpace(mapping.Subpath),
-				Mode:      uint32(mapping.Mode.Perm()),
-			})
-		}
-		mounts = append(mounts, mount)
+		mounts = append(mounts, cacheoutput.PreparedMount{
+			Spec:       volume.Spec,
+			DevicePath: volume.DevicePath,
+			MountPath:  volume.MountPath,
+		})
 	}
 	return mounts
 }
 
 func darwinVZCacheOutputFileCaptures(volumes []preparedDarwinVZCacheOutputVolume, captures []backend.CacheOutputFileCapture) ([]vsockexec.CacheOutputFileCapture, error) {
-	if len(captures) == 0 {
-		return nil, nil
-	}
-	mountsByVolumeID := make(map[string]string, len(volumes))
-	for _, volume := range volumes {
-		mountsByVolumeID[strings.TrimSpace(volume.Spec.VolumeID)] = strings.TrimSpace(volume.MountPath)
-	}
-	out := make([]vsockexec.CacheOutputFileCapture, 0, len(captures))
-	for i, capture := range captures {
-		volumeID := strings.TrimSpace(capture.VolumeID)
-		if volumeID == "" {
-			return nil, fmt.Errorf("cache output file capture %d missing volume id", i)
-		}
-		mountPath, ok := mountsByVolumeID[volumeID]
-		if !ok {
-			return nil, fmt.Errorf("cache output file capture %d references unknown volume id %q", i, capture.VolumeID)
-		}
-		out = append(out, vsockexec.CacheOutputFileCapture{
-			GuestPath: strings.TrimSpace(capture.GuestPath),
-			MountPath: mountPath,
-			Subpath:   strings.TrimSpace(capture.VolumeSubpath),
-			Mode:      uint32(capture.Mode.Perm()),
-		})
-	}
-	return out, nil
+	return cacheoutput.FileCaptures(darwinVZCacheOutputPreparedMounts(volumes), captures)
 }
 
 func cloneDarwinVZCacheOutputMounts(mounts []vsockexec.CacheOutputMount) []vsockexec.CacheOutputMount {
-	if len(mounts) == 0 {
-		return nil
-	}
-	out := make([]vsockexec.CacheOutputMount, len(mounts))
-	for i, mount := range mounts {
-		out[i] = mount
-		out[i].DirMappings = append([]vsockexec.CacheOutputDirMount(nil), mount.DirMappings...)
-		out[i].FileMappings = append([]vsockexec.CacheOutputFileMount(nil), mount.FileMappings...)
-	}
-	return out
+	return cacheoutput.CloneMounts(mounts)
 }
 
 func darwinVZCacheOutputSpecHasSource(spec backend.CacheOutputVolumeSpec) bool {
-	return strings.TrimSpace(spec.SourceSnapshotRef) != "" || strings.TrimSpace(spec.StorageRef) != ""
+	return cacheoutput.SpecHasSource(spec)
 }
 
 func darwinVZCacheOutputRuntimeVolumeID(sandboxID, specVolumeID string, index int) string {
-	sum := sha256.Sum256([]byte(strings.TrimSpace(sandboxID) + "\x00" + strings.TrimSpace(specVolumeID)))
-	return fmt.Sprintf("%s-cache-output-%02d-%s", strings.TrimSpace(sandboxID), index, hex.EncodeToString(sum[:6]))
+	return cacheoutput.RuntimeVolumeID(sandboxID, specVolumeID, index)
 }
 
 func darwinVZCacheOutputGuestMountPath(index int) string {
-	return filepath.Join(darwinVZCacheOutputGuestMountRoot, fmt.Sprintf("cacheout%d", index))
+	return cacheoutput.GuestMountPath(darwinVZCacheOutputGuestMountRoot, cacheoutput.MountID(index))
 }
 
 func darwinVZCacheOutputDevicePath(index int) string {
-	return "/dev/" + darwinVZVirtioBlockDeviceName(index+1)
-}
-
-func darwinVZVirtioBlockDeviceName(index int) string {
-	if index < 0 {
-		index = 0
-	}
-	letters := ""
-	for {
-		letters = string(rune('a'+index%26)) + letters
-		index = index/26 - 1
-		if index < 0 {
-			break
-		}
-	}
-	return "vd" + letters
+	return cacheoutput.DevicePathAfterRoot(index)
 }

--- a/internal/backend/firecracker/cache_output_snapshots.go
+++ b/internal/backend/firecracker/cache_output_snapshots.go
@@ -2,14 +2,13 @@ package firecracker
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/backend/cacheoutput"
 	"github.com/buildkite/cleanroom/internal/observability"
 )
 
@@ -152,36 +151,13 @@ func (a *Adapter) SnapshotCacheOutputVolumes(ctx context.Context, req backend.Sn
 }
 
 func selectCacheOutputVolumes(volumes []preparedCacheOutputVolume, volumeIDs []string) ([]preparedCacheOutputVolume, error) {
-	if len(volumeIDs) == 0 {
-		return append([]preparedCacheOutputVolume(nil), volumes...), nil
-	}
-	byID := make(map[string]preparedCacheOutputVolume, len(volumes))
-	for _, volume := range volumes {
-		byID[strings.TrimSpace(volume.Spec.VolumeID)] = volume
-	}
-	selected := make([]preparedCacheOutputVolume, 0, len(volumeIDs))
-	seen := make(map[string]struct{}, len(volumeIDs))
-	for _, id := range volumeIDs {
-		id = strings.TrimSpace(id)
-		if id == "" {
-			return nil, errors.New("cache output volume id cannot be empty")
-		}
-		if _, ok := seen[id]; ok {
-			return nil, fmt.Errorf("duplicate cache output volume id %q", id)
-		}
-		seen[id] = struct{}{}
-		volume, ok := byID[id]
-		if !ok {
-			return nil, fmt.Errorf("unknown cache output volume id %q", id)
-		}
-		selected = append(selected, volume)
-	}
-	return selected, nil
+	return cacheoutput.SelectByVolumeID(volumes, volumeIDs, func(volume preparedCacheOutputVolume) string {
+		return volume.Spec.VolumeID
+	})
 }
 
 func cacheOutputSnapshotID(prefix, volumeID string) string {
-	hash := sha256String(strings.TrimSpace(volumeID))
-	return strings.TrimSpace(prefix) + "-" + hash[:16]
+	return cacheoutput.SnapshotID(prefix, volumeID)
 }
 
 func cacheOutputSnapshotConfig(cfg backend.FirecrackerConfig, spec backend.CacheOutputVolumeSpec, volumeRef string) (backend.FirecrackerConfig, error) {
@@ -192,23 +168,7 @@ func cacheOutputSnapshotConfig(cfg backend.FirecrackerConfig, spec backend.Cache
 }
 
 func cacheOutputVolumeSnapshotOutputs(spec backend.CacheOutputVolumeSpec) []backend.CacheOutputVolumeSnapshotOutput {
-	out := make([]backend.CacheOutputVolumeSnapshotOutput, 0, len(spec.DirMappings)+len(spec.FileMappings))
-	for _, mapping := range spec.DirMappings {
-		out = append(out, backend.CacheOutputVolumeSnapshotOutput{
-			Kind:          "dir",
-			GuestPath:     strings.TrimSpace(mapping.GuestPath),
-			VolumeSubpath: strings.TrimSpace(mapping.Subpath),
-		})
-	}
-	for _, mapping := range spec.FileMappings {
-		out = append(out, backend.CacheOutputVolumeSnapshotOutput{
-			Kind:          "file",
-			GuestPath:     strings.TrimSpace(mapping.GuestPath),
-			VolumeSubpath: strings.TrimSpace(mapping.Subpath),
-			Mode:          mapping.Mode.Perm(),
-		})
-	}
-	return out
+	return cacheoutput.SnapshotOutputs(spec)
 }
 
 func effectiveSnapshotDriver(cfg backend.FirecrackerConfig) string {
@@ -217,9 +177,4 @@ func effectiveSnapshotDriver(cfg backend.FirecrackerConfig) string {
 		return "file"
 	}
 	return driver
-}
-
-func sha256String(value string) string {
-	sum := sha256.Sum256([]byte(value))
-	return hex.EncodeToString(sum[:])
 }

--- a/internal/backend/firecracker/cache_output_volumes.go
+++ b/internal/backend/firecracker/cache_output_volumes.go
@@ -2,25 +2,21 @@ package firecracker
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
 	"github.com/buildkite/cleanroom/internal/backend"
-	"github.com/buildkite/cleanroom/internal/ext4image"
-	"github.com/buildkite/cleanroom/internal/hosttools"
+	"github.com/buildkite/cleanroom/internal/backend/cacheoutput"
 	"github.com/buildkite/cleanroom/internal/volumestore"
 	"github.com/buildkite/cleanroom/internal/vsockexec"
 	charmlog "github.com/charmbracelet/log"
 )
 
-const defaultCacheOutputVolumeMinimumBytes int64 = 512 << 20
-const cacheOutputGuestMountRoot = "/run/cleanroom/cache-output-volumes"
+const defaultCacheOutputVolumeMinimumBytes int64 = cacheoutput.DefaultVolumeMinimumBytes
+const cacheOutputGuestMountRoot = cacheoutput.GuestMountRoot
 
 var (
 	cacheOutputVolumeMinimumBytes     = defaultCacheOutputVolumeMinimumBytes
@@ -53,7 +49,7 @@ func prepareCacheOutputVolumes(ctx context.Context, logger *charmlog.Logger, cfg
 	}
 	seenVolumeIDs := make(map[string]struct{}, len(specs))
 	for i, spec := range specs {
-		if err := validateCacheOutputVolumeSpec(spec); err != nil {
+		if err := cacheoutput.ValidateVolumeSpec(spec); err != nil {
 			cleanup()
 			return nil, nil, fmt.Errorf("cache output volume %d: %w", i, err)
 		}
@@ -90,46 +86,8 @@ func prepareCacheOutputVolumes(ctx context.Context, logger *charmlog.Logger, cfg
 	return prepared, cleanup, nil
 }
 
-func validateCacheOutputVolumeSpec(spec backend.CacheOutputVolumeSpec) error {
-	if strings.TrimSpace(spec.Stage) == "" {
-		return errors.New("missing stage")
-	}
-	if strings.TrimSpace(spec.BlockName) == "" {
-		return errors.New("missing block name")
-	}
-	if strings.TrimSpace(spec.CacheKey) == "" {
-		return errors.New("missing cache key")
-	}
-	if strings.TrimSpace(spec.VolumeID) == "" {
-		return errors.New("missing volume id")
-	}
-	if len(spec.DirMappings) == 0 && len(spec.FileMappings) == 0 {
-		return errors.New("missing output mappings")
-	}
-	for i, mapping := range spec.DirMappings {
-		if strings.TrimSpace(mapping.GuestPath) == "" {
-			return fmt.Errorf("dir mapping %d missing guest path", i)
-		}
-		if strings.TrimSpace(mapping.Subpath) == "" {
-			return fmt.Errorf("dir mapping %d missing volume subpath", i)
-		}
-	}
-	for i, mapping := range spec.FileMappings {
-		if strings.TrimSpace(mapping.GuestPath) == "" {
-			return fmt.Errorf("file mapping %d missing guest path", i)
-		}
-		if strings.TrimSpace(mapping.Subpath) == "" {
-			return fmt.Errorf("file mapping %d missing volume subpath", i)
-		}
-	}
-	return nil
-}
-
 func cacheOutputVolumeSource(ctx context.Context, cfg backend.FirecrackerConfig, runDir string, spec backend.CacheOutputVolumeSpec) (sourceRef string, volumeCfg backend.FirecrackerConfig, err error) {
-	sourceRef = strings.TrimSpace(spec.SourceSnapshotRef)
-	if sourceRef == "" {
-		sourceRef = strings.TrimSpace(spec.StorageRef)
-	}
+	sourceRef = cacheoutput.SourceRef(spec)
 	volumeCfg = cfg
 	if driver := strings.TrimSpace(spec.StorageDriver); driver != "" {
 		volumeCfg.Snapshots.Driver = driver
@@ -159,37 +117,7 @@ func cacheOutputVolumeSource(ctx context.Context, cfg backend.FirecrackerConfig,
 }
 
 func createEmptyCacheOutputExt4Image(ctx context.Context, path string, minimumBytes int64) error {
-	if strings.TrimSpace(path) == "" {
-		return errors.New("missing empty cache output image path")
-	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return fmt.Errorf("create empty cache output image directory: %w", err)
-	}
-	sizeBytes := ext4image.AlignBytes(minimumBytes)
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o600)
-	if err != nil {
-		return fmt.Errorf("create empty cache output image %q: %w", path, err)
-	}
-	if err := file.Truncate(sizeBytes); err != nil {
-		_ = file.Close()
-		return fmt.Errorf("truncate empty cache output image %q to %d bytes: %w", path, sizeBytes, err)
-	}
-	if err := file.Close(); err != nil {
-		return fmt.Errorf("close empty cache output image %q: %w", path, err)
-	}
-	mkfsPath, err := hosttools.ResolveE2FSProgsBinary("mkfs.ext4")
-	if err != nil {
-		return fmt.Errorf("find mkfs.ext4 for cache output volume: %w", err)
-	}
-	if out, err := exec.CommandContext(ctx, mkfsPath, "-q", "-F", path).CombinedOutput(); err != nil {
-		_ = os.Remove(path)
-		trimmed := strings.TrimSpace(string(out))
-		if trimmed == "" {
-			return fmt.Errorf("create empty cache output ext4 image: %w", err)
-		}
-		return fmt.Errorf("create empty cache output ext4 image: %w: %s", err, trimmed)
-	}
-	return nil
+	return cacheoutput.CreateEmptyExt4Image(ctx, path, minimumBytes)
 }
 
 func prepareWritableVolumeWithLogger(ctx context.Context, logger *charmlog.Logger, cfg backend.FirecrackerConfig, volumeID, attachmentPath, sourceRef string, minimumBytes int64) (volumestore.WritableVolume, func(), error) {
@@ -299,82 +227,38 @@ func cacheOutputVolumeDrives(volumes []preparedCacheOutputVolume) []drive {
 }
 
 func cacheOutputDriveID(index int) string {
-	return fmt.Sprintf("cacheout%d", index)
+	return cacheoutput.MountID(index)
 }
 
 func cacheOutputRuntimeVolumeID(sandboxID, specVolumeID string, index int) string {
-	sum := sha256.Sum256([]byte(strings.TrimSpace(sandboxID) + "\x00" + strings.TrimSpace(specVolumeID)))
-	return fmt.Sprintf("%s-cache-output-%02d-%s", strings.TrimSpace(sandboxID), index, hex.EncodeToString(sum[:6]))
+	return cacheoutput.RuntimeVolumeID(sandboxID, specVolumeID, index)
 }
 
 func cacheOutputVolumeMounts(volumes []preparedCacheOutputVolume) []vsockexec.CacheOutputMount {
+	return cacheoutput.Mounts(cacheOutputPreparedMounts(volumes))
+}
+
+func cacheOutputPreparedMounts(volumes []preparedCacheOutputVolume) []cacheoutput.PreparedMount {
 	if len(volumes) == 0 {
 		return nil
 	}
-	mounts := make([]vsockexec.CacheOutputMount, 0, len(volumes))
+	mounts := make([]cacheoutput.PreparedMount, 0, len(volumes))
 	for i, volume := range volumes {
-		mount := vsockexec.CacheOutputMount{
-			DevicePath:    cacheOutputDevicePath(i),
-			MountPath:     cacheOutputGuestMountPath(volume.Drive.DriveID),
-			SourcePresent: cacheOutputSpecHasSource(volume.Spec),
-		}
-		for _, mapping := range volume.Spec.DirMappings {
-			mount.DirMappings = append(mount.DirMappings, vsockexec.CacheOutputDirMount{
-				GuestPath: strings.TrimSpace(mapping.GuestPath),
-				Subpath:   strings.TrimSpace(mapping.Subpath),
-			})
-		}
-		for _, mapping := range volume.Spec.FileMappings {
-			mount.FileMappings = append(mount.FileMappings, vsockexec.CacheOutputFileMount{
-				GuestPath: strings.TrimSpace(mapping.GuestPath),
-				Subpath:   strings.TrimSpace(mapping.Subpath),
-				Mode:      uint32(mapping.Mode.Perm()),
-			})
-		}
-		mounts = append(mounts, mount)
+		mounts = append(mounts, cacheoutput.PreparedMount{
+			Spec:       volume.Spec,
+			DevicePath: cacheOutputDevicePath(i),
+			MountPath:  cacheOutputGuestMountPath(volume.Drive.DriveID),
+		})
 	}
 	return mounts
 }
 
 func cacheOutputFileCaptures(volumes []preparedCacheOutputVolume, captures []backend.CacheOutputFileCapture) ([]vsockexec.CacheOutputFileCapture, error) {
-	if len(captures) == 0 {
-		return nil, nil
-	}
-	mountsByVolumeID := make(map[string]string, len(volumes))
-	for _, volume := range volumes {
-		mountsByVolumeID[strings.TrimSpace(volume.Spec.VolumeID)] = cacheOutputGuestMountPath(volume.Drive.DriveID)
-	}
-	out := make([]vsockexec.CacheOutputFileCapture, 0, len(captures))
-	for i, capture := range captures {
-		volumeID := strings.TrimSpace(capture.VolumeID)
-		if volumeID == "" {
-			return nil, fmt.Errorf("cache output file capture %d missing volume id", i)
-		}
-		mountPath, ok := mountsByVolumeID[volumeID]
-		if !ok {
-			return nil, fmt.Errorf("cache output file capture %d references unknown volume id %q", i, capture.VolumeID)
-		}
-		out = append(out, vsockexec.CacheOutputFileCapture{
-			GuestPath: strings.TrimSpace(capture.GuestPath),
-			MountPath: mountPath,
-			Subpath:   strings.TrimSpace(capture.VolumeSubpath),
-			Mode:      uint32(capture.Mode.Perm()),
-		})
-	}
-	return out, nil
+	return cacheoutput.FileCaptures(cacheOutputPreparedMounts(volumes), captures)
 }
 
 func cloneCacheOutputMounts(mounts []vsockexec.CacheOutputMount) []vsockexec.CacheOutputMount {
-	if len(mounts) == 0 {
-		return nil
-	}
-	out := make([]vsockexec.CacheOutputMount, len(mounts))
-	for i, mount := range mounts {
-		out[i] = mount
-		out[i].DirMappings = append([]vsockexec.CacheOutputDirMount(nil), mount.DirMappings...)
-		out[i].FileMappings = append([]vsockexec.CacheOutputFileMount(nil), mount.FileMappings...)
-	}
-	return out
+	return cacheoutput.CloneMounts(mounts)
 }
 
 func vsockInputProjection(projection *backend.InputProjection) *vsockexec.InputProjection {
@@ -390,28 +274,13 @@ func vsockInputProjection(projection *backend.InputProjection) *vsockexec.InputP
 }
 
 func cacheOutputGuestMountPath(driveID string) string {
-	return filepath.Join(cacheOutputGuestMountRoot, strings.TrimSpace(driveID))
+	return cacheoutput.GuestMountPath(cacheOutputGuestMountRoot, driveID)
 }
 
 func cacheOutputSpecHasSource(spec backend.CacheOutputVolumeSpec) bool {
-	return strings.TrimSpace(spec.SourceSnapshotRef) != "" || strings.TrimSpace(spec.StorageRef) != ""
+	return cacheoutput.SpecHasSource(spec)
 }
 
 func cacheOutputDevicePath(index int) string {
-	return "/dev/" + virtioBlockDeviceName(index+1)
-}
-
-func virtioBlockDeviceName(index int) string {
-	if index < 0 {
-		index = 0
-	}
-	letters := ""
-	for {
-		letters = string(rune('a'+index%26)) + letters
-		index = index/26 - 1
-		if index < 0 {
-			break
-		}
-	}
-	return "vd" + letters
+	return cacheoutput.DevicePathAfterRoot(index)
 }


### PR DESCRIPTION
This is slice 4 of the cache refactor stack, on top of #325. It moves backend-neutral cache-output-volume code into a shared helper package while keeping VM launch, pause/resume, storage-driver, and snapshot behavior in each adapter.

Changes:
- add internal/backend/cacheoutput for spec validation, empty ext4 creation, runtime volume ids, guest mount/capture conversion, snapshot ids, snapshot output manifests, and volume-id selection
- update Firecracker and darwin-vz to delegate the shared pieces while preserving their adapter-specific volume preparation and snapshot paths
- add direct tests for the shared helper package
- mark slice 4 implemented in the plan doc

Validation:
- mise exec -- go test ./internal/backend/cacheoutput ./internal/backend/firecracker ./internal/backend/darwinvz
- mise exec -- go test ./...