### PR TITLE
refactor: Simplify cache bootstrap orchestration

### DIFF
--- a/docs/plans/dependency-service-volume-caches.md
+++ b/docs/plans/dependency-service-volume-caches.md
@@ -1082,7 +1082,8 @@ Reviewable slices:
   `internal/inputmanifest` package with the implemented block-volume model.
   This is implemented in the fifth refactor slice.
 - Slice 6: simplify `CreateSandbox` cache orchestration once the narrower
-  duplication has been removed.
+  duplication has been removed. This is implemented in the sixth refactor
+  slice.
 
 ## Tests
 

--- a/internal/controlservice/create_sandbox_cache_bootstrap.go
+++ b/internal/controlservice/create_sandbox_cache_bootstrap.go
@@ -1,0 +1,107 @@
+package controlservice
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+	"github.com/buildkite/cleanroom/internal/observability"
+	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/buildkite/cleanroom/internal/repositorychangeset"
+	"github.com/buildkite/cleanroom/internal/repositorycheckout"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+type createSandboxCacheBootstrapConfig struct {
+	Adapter                    backend.Adapter
+	BackendName                string
+	SandboxID                  string
+	Compiled                   *policy.CompiledPolicy
+	FirecrackerConfig          backend.FirecrackerConfig
+	Repository                 *repositorycheckout.Checkout
+	Changeset                  *repositorychangeset.Changeset
+	CacheOutputSnapshotAdapter backend.CacheOutputVolumeSnapshottingAdapter
+	Reporter                   CreateSandboxReporter
+}
+
+func (s *Service) bootstrapDependencyForCreateSandbox(
+	ctx context.Context,
+	cfg createSandboxCacheBootstrapConfig,
+	dependencyStagePlan dependencyStagePlan,
+	dependencyBlockVolumePlan dependencyBlockVolumePlan,
+	dependencyBlockVolumePlanAvailable bool,
+) (bool, error) {
+	emitCreateSandboxMessage(cfg.Reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_DEPENDENCIES, "running dependency bootstrap")
+	dependencyPublishable := true
+	err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.bootstrap_dependencies", createSandboxBootstrapAttrs(cfg.BackendName, cfg.SandboxID, len(dependencyStagePlan.BootstrapCommand), cfg.Repository), func(ctx context.Context) error {
+		if dependencyBlockVolumePlanAvailable {
+			var err error
+			dependencyPublishable, err = s.bootstrapDependencyBlockVolumePlanInPersistentSandbox(ctx, cfg.Adapter, cfg.SandboxID, dependencyBlockVolumePublishConfig{
+				Adapter:    cfg.CacheOutputSnapshotAdapter,
+				Backend:    cfg.BackendName,
+				Changeset:  cfg.Changeset,
+				Repository: cfg.Repository,
+			}, cfg.Compiled, cfg.FirecrackerConfig, cfg.Repository, dependencyBlockVolumePlan, cfg.Reporter)
+			return err
+		}
+		return s.bootstrapDependencyStageInPersistentSandbox(ctx, cfg.Adapter, cfg.SandboxID, cfg.Compiled, cfg.FirecrackerConfig, dependencyStagePlan, cfg.Reporter)
+	})
+	if err != nil {
+		if terminateErr := s.terminateCreatedSandbox(context.Background(), cfg.Adapter, cfg.SandboxID); terminateErr != nil {
+			return dependencyPublishable, fmt.Errorf("bootstrap dependency stage: %w; cleanup failed: %v", err, terminateErr)
+		}
+		return dependencyPublishable, fmt.Errorf("bootstrap dependency stage: %w", err)
+	}
+	return dependencyPublishable, nil
+}
+
+func (s *Service) bootstrapServicesForCreateSandbox(
+	ctx context.Context,
+	cfg createSandboxCacheBootstrapConfig,
+	servicesStagePlan servicesStagePlan,
+	serviceBlockVolumePlan serviceBlockVolumePlan,
+	serviceBlockVolumePlanAvailable bool,
+	dependencyBlockVolumePublicationSafe bool,
+) error {
+	emitCreateSandboxMessage(cfg.Reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_SERVICES, "running services bootstrap")
+	err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.bootstrap_services", createSandboxBootstrapAttrs(cfg.BackendName, cfg.SandboxID, len(servicesStagePlan.BootstrapCommand), cfg.Repository), func(ctx context.Context) error {
+		if serviceBlockVolumePlanAvailable {
+			publishConfig := serviceBlockVolumePublishConfig{
+				Adapter:    cfg.CacheOutputSnapshotAdapter,
+				Backend:    cfg.BackendName,
+				Changeset:  cfg.Changeset,
+				Repository: cfg.Repository,
+			}
+			if !dependencyBlockVolumePublicationSafe {
+				publishConfig.Adapter = nil
+				publishConfig.ForceExactFallback = true
+			}
+			_, err := s.bootstrapServiceBlockVolumePlanInPersistentSandbox(ctx, cfg.Adapter, cfg.SandboxID, publishConfig, cfg.Compiled, cfg.FirecrackerConfig, cfg.Repository, serviceBlockVolumePlan, cfg.Reporter)
+			return err
+		}
+		return s.bootstrapServicesStageInPersistentSandbox(ctx, cfg.Adapter, cfg.SandboxID, cfg.Compiled, cfg.FirecrackerConfig, servicesStagePlan, cfg.Reporter)
+	})
+	if err != nil {
+		if terminateErr := s.terminateCreatedSandbox(context.Background(), cfg.Adapter, cfg.SandboxID); terminateErr != nil {
+			return fmt.Errorf("bootstrap services stage: %w; cleanup failed: %v", err, terminateErr)
+		}
+		return fmt.Errorf("bootstrap services stage: %w", err)
+	}
+	return nil
+}
+
+func createSandboxBootstrapAttrs(backendName, sandboxID string, argc int, repository *repositorycheckout.Checkout) []attribute.KeyValue {
+	attrs := []attribute.KeyValue{
+		attribute.String(observability.AttrBackend, backendName),
+		attribute.String(observability.AttrSandboxID, sandboxID),
+		attribute.Int(observability.AttrCommandArgc, argc),
+	}
+	if repository != nil {
+		if commitSHA := strings.TrimSpace(repository.CommitSHA); commitSHA != "" {
+			attrs = append(attrs, attribute.String(observability.AttrRepositoryCommitSHA, commitSHA))
+		}
+	}
+	return attrs
+}

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -864,39 +864,18 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 		sandboxID := restoredDependencyResp.GetSandbox().GetSandboxId()
 		span.SetAttributes(attribute.String("cleanroom.sandbox.id", sandboxID))
 		if servicesStageBootstrapEnabled {
-			bootstrapAttrs := []attribute.KeyValue{
-				attribute.String(observability.AttrBackend, backendName),
-				attribute.String(observability.AttrSandboxID, sandboxID),
-				attribute.Int(observability.AttrCommandArgc, len(servicesStagePlan.BootstrapCommand)),
-			}
-			if repository != nil {
-				if commitSHA := strings.TrimSpace(repository.CommitSHA); commitSHA != "" {
-					bootstrapAttrs = append(bootstrapAttrs, attribute.String(observability.AttrRepositoryCommitSHA, commitSHA))
-				}
-			}
-			emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_SERVICES, "running services bootstrap")
-			if err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.bootstrap_services", bootstrapAttrs, func(ctx context.Context) error {
-				if serviceBlockVolumePlanAvailable {
-					publishConfig := serviceBlockVolumePublishConfig{
-						Adapter:    cacheOutputSnapshotAdapter,
-						Backend:    backendName,
-						Changeset:  changeset,
-						Repository: repository,
-					}
-					if !dependencyBlockVolumePublicationSafe {
-						publishConfig.Adapter = nil
-						publishConfig.ForceExactFallback = true
-					}
-					_, err := s.bootstrapServiceBlockVolumePlanInPersistentSandbox(ctx, adapter, sandboxID, publishConfig, compiled, firecrackerCfg, repository, serviceBlockVolumePlan, reporter)
-					return err
-				}
-				return s.bootstrapServicesStageInPersistentSandbox(ctx, adapter, sandboxID, compiled, firecrackerCfg, servicesStagePlan, reporter)
-			}); err != nil {
-				cleanupErr := s.terminateCreatedSandbox(context.Background(), adapter, sandboxID)
-				if cleanupErr != nil {
-					return nil, fmt.Errorf("bootstrap services stage: %w; cleanup failed: %v", err, cleanupErr)
-				}
-				return nil, fmt.Errorf("bootstrap services stage: %w", err)
+			if err := s.bootstrapServicesForCreateSandbox(ctx, createSandboxCacheBootstrapConfig{
+				Adapter:                    adapter,
+				BackendName:                backendName,
+				SandboxID:                  sandboxID,
+				Compiled:                   compiled,
+				FirecrackerConfig:          firecrackerCfg,
+				Repository:                 repository,
+				Changeset:                  changeset,
+				CacheOutputSnapshotAdapter: cacheOutputSnapshotAdapter,
+				Reporter:                   reporter,
+			}, servicesStagePlan, serviceBlockVolumePlan, serviceBlockVolumePlanAvailable, dependencyBlockVolumePublicationSafe); err != nil {
+				return nil, err
 			}
 			if servicesStageCachingEnabled && !serviceBlockVolumePlanAvailable {
 				emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_PUBLISH_SERVICES_STAGE_CACHE, "publishing services stage cache")
@@ -910,36 +889,19 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 		sandboxID := restoredWorkspaceResp.GetSandbox().GetSandboxId()
 		span.SetAttributes(attribute.String("cleanroom.sandbox.id", sandboxID))
 		if dependencyStageBootstrapEnabled {
-			bootstrapAttrs := []attribute.KeyValue{
-				attribute.String(observability.AttrBackend, backendName),
-				attribute.String(observability.AttrSandboxID, sandboxID),
-				attribute.Int(observability.AttrCommandArgc, len(dependencyStagePlan.BootstrapCommand)),
-			}
-			if repository != nil {
-				if commitSHA := strings.TrimSpace(repository.CommitSHA); commitSHA != "" {
-					bootstrapAttrs = append(bootstrapAttrs, attribute.String(observability.AttrRepositoryCommitSHA, commitSHA))
-				}
-			}
-			emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_DEPENDENCIES, "running dependency bootstrap")
-			dependencyPublishable := true
-			if err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.bootstrap_dependencies", bootstrapAttrs, func(ctx context.Context) error {
-				if dependencyBlockVolumePlanAvailable {
-					var err error
-					dependencyPublishable, err = s.bootstrapDependencyBlockVolumePlanInPersistentSandbox(ctx, adapter, sandboxID, dependencyBlockVolumePublishConfig{
-						Adapter:    cacheOutputSnapshotAdapter,
-						Backend:    backendName,
-						Changeset:  changeset,
-						Repository: repository,
-					}, compiled, firecrackerCfg, repository, dependencyBlockVolumePlan, reporter)
-					return err
-				}
-				return s.bootstrapDependencyStageInPersistentSandbox(ctx, adapter, sandboxID, compiled, firecrackerCfg, dependencyStagePlan, reporter)
-			}); err != nil {
-				cleanupErr := s.terminateCreatedSandbox(context.Background(), adapter, sandboxID)
-				if cleanupErr != nil {
-					return nil, fmt.Errorf("bootstrap dependency stage: %w; cleanup failed: %v", err, cleanupErr)
-				}
-				return nil, fmt.Errorf("bootstrap dependency stage: %w", err)
+			dependencyPublishable, err := s.bootstrapDependencyForCreateSandbox(ctx, createSandboxCacheBootstrapConfig{
+				Adapter:                    adapter,
+				BackendName:                backendName,
+				SandboxID:                  sandboxID,
+				Compiled:                   compiled,
+				FirecrackerConfig:          firecrackerCfg,
+				Repository:                 repository,
+				Changeset:                  changeset,
+				CacheOutputSnapshotAdapter: cacheOutputSnapshotAdapter,
+				Reporter:                   reporter,
+			}, dependencyStagePlan, dependencyBlockVolumePlan, dependencyBlockVolumePlanAvailable)
+			if err != nil {
+				return nil, err
 			}
 			if dependencyBlockVolumePlanAvailable {
 				dependencyBlockVolumePublicationSafe = dependencyPublishable
@@ -950,39 +912,18 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 			}
 		}
 		if servicesStageBootstrapEnabled {
-			bootstrapAttrs := []attribute.KeyValue{
-				attribute.String(observability.AttrBackend, backendName),
-				attribute.String(observability.AttrSandboxID, sandboxID),
-				attribute.Int(observability.AttrCommandArgc, len(servicesStagePlan.BootstrapCommand)),
-			}
-			if repository != nil {
-				if commitSHA := strings.TrimSpace(repository.CommitSHA); commitSHA != "" {
-					bootstrapAttrs = append(bootstrapAttrs, attribute.String(observability.AttrRepositoryCommitSHA, commitSHA))
-				}
-			}
-			emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_SERVICES, "running services bootstrap")
-			if err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.bootstrap_services", bootstrapAttrs, func(ctx context.Context) error {
-				if serviceBlockVolumePlanAvailable {
-					publishConfig := serviceBlockVolumePublishConfig{
-						Adapter:    cacheOutputSnapshotAdapter,
-						Backend:    backendName,
-						Changeset:  changeset,
-						Repository: repository,
-					}
-					if !dependencyBlockVolumePublicationSafe {
-						publishConfig.Adapter = nil
-						publishConfig.ForceExactFallback = true
-					}
-					_, err := s.bootstrapServiceBlockVolumePlanInPersistentSandbox(ctx, adapter, sandboxID, publishConfig, compiled, firecrackerCfg, repository, serviceBlockVolumePlan, reporter)
-					return err
-				}
-				return s.bootstrapServicesStageInPersistentSandbox(ctx, adapter, sandboxID, compiled, firecrackerCfg, servicesStagePlan, reporter)
-			}); err != nil {
-				cleanupErr := s.terminateCreatedSandbox(context.Background(), adapter, sandboxID)
-				if cleanupErr != nil {
-					return nil, fmt.Errorf("bootstrap services stage: %w; cleanup failed: %v", err, cleanupErr)
-				}
-				return nil, fmt.Errorf("bootstrap services stage: %w", err)
+			if err := s.bootstrapServicesForCreateSandbox(ctx, createSandboxCacheBootstrapConfig{
+				Adapter:                    adapter,
+				BackendName:                backendName,
+				SandboxID:                  sandboxID,
+				Compiled:                   compiled,
+				FirecrackerConfig:          firecrackerCfg,
+				Repository:                 repository,
+				Changeset:                  changeset,
+				CacheOutputSnapshotAdapter: cacheOutputSnapshotAdapter,
+				Reporter:                   reporter,
+			}, servicesStagePlan, serviceBlockVolumePlan, serviceBlockVolumePlanAvailable, dependencyBlockVolumePublicationSafe); err != nil {
+				return nil, err
 			}
 			if servicesStageCachingEnabled && !serviceBlockVolumePlanAvailable {
 				emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_PUBLISH_SERVICES_STAGE_CACHE, "publishing services stage cache")
@@ -1112,35 +1053,19 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 		}
 	}
 	if dependencyStageBootstrapEnabled {
-		bootstrapAttrs := []attribute.KeyValue{
-			attribute.String(observability.AttrBackend, backendName),
-			attribute.String(observability.AttrSandboxID, sandboxID),
-			attribute.Int(observability.AttrCommandArgc, len(dependencyStagePlan.BootstrapCommand)),
-		}
-		if repository != nil {
-			if commitSHA := strings.TrimSpace(repository.CommitSHA); commitSHA != "" {
-				bootstrapAttrs = append(bootstrapAttrs, attribute.String(observability.AttrRepositoryCommitSHA, commitSHA))
-			}
-		}
-		emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_DEPENDENCIES, "running dependency bootstrap")
-		dependencyPublishable := true
-		if err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.bootstrap_dependencies", bootstrapAttrs, func(ctx context.Context) error {
-			if dependencyBlockVolumePlanAvailable {
-				var err error
-				dependencyPublishable, err = s.bootstrapDependencyBlockVolumePlanInPersistentSandbox(ctx, adapter, sandboxID, dependencyBlockVolumePublishConfig{
-					Adapter:    cacheOutputSnapshotAdapter,
-					Backend:    backendName,
-					Changeset:  changeset,
-					Repository: repository,
-				}, compiled, firecrackerCfg, repository, dependencyBlockVolumePlan, reporter)
-				return err
-			}
-			return s.bootstrapDependencyStageInPersistentSandbox(ctx, adapter, sandboxID, compiled, firecrackerCfg, dependencyStagePlan, reporter)
-		}); err != nil {
-			if terminateErr := s.terminateCreatedSandbox(context.Background(), adapter, sandboxID); terminateErr != nil {
-				return nil, fmt.Errorf("bootstrap dependency stage: %w; cleanup failed: %v", err, terminateErr)
-			}
-			return nil, fmt.Errorf("bootstrap dependency stage: %w", err)
+		dependencyPublishable, err := s.bootstrapDependencyForCreateSandbox(ctx, createSandboxCacheBootstrapConfig{
+			Adapter:                    adapter,
+			BackendName:                backendName,
+			SandboxID:                  sandboxID,
+			Compiled:                   compiled,
+			FirecrackerConfig:          firecrackerCfg,
+			Repository:                 repository,
+			Changeset:                  changeset,
+			CacheOutputSnapshotAdapter: cacheOutputSnapshotAdapter,
+			Reporter:                   reporter,
+		}, dependencyStagePlan, dependencyBlockVolumePlan, dependencyBlockVolumePlanAvailable)
+		if err != nil {
+			return nil, err
 		}
 		if dependencyBlockVolumePlanAvailable {
 			dependencyBlockVolumePublicationSafe = dependencyPublishable
@@ -1163,38 +1088,18 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 		}
 	}
 	if servicesStageBootstrapEnabled {
-		bootstrapAttrs := []attribute.KeyValue{
-			attribute.String(observability.AttrBackend, backendName),
-			attribute.String(observability.AttrSandboxID, sandboxID),
-			attribute.Int(observability.AttrCommandArgc, len(servicesStagePlan.BootstrapCommand)),
-		}
-		if repository != nil {
-			if commitSHA := strings.TrimSpace(repository.CommitSHA); commitSHA != "" {
-				bootstrapAttrs = append(bootstrapAttrs, attribute.String(observability.AttrRepositoryCommitSHA, commitSHA))
-			}
-		}
-		emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_SERVICES, "running services bootstrap")
-		if err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.bootstrap_services", bootstrapAttrs, func(ctx context.Context) error {
-			if serviceBlockVolumePlanAvailable {
-				publishConfig := serviceBlockVolumePublishConfig{
-					Adapter:    cacheOutputSnapshotAdapter,
-					Backend:    backendName,
-					Changeset:  changeset,
-					Repository: repository,
-				}
-				if !dependencyBlockVolumePublicationSafe {
-					publishConfig.Adapter = nil
-					publishConfig.ForceExactFallback = true
-				}
-				_, err := s.bootstrapServiceBlockVolumePlanInPersistentSandbox(ctx, adapter, sandboxID, publishConfig, compiled, firecrackerCfg, repository, serviceBlockVolumePlan, reporter)
-				return err
-			}
-			return s.bootstrapServicesStageInPersistentSandbox(ctx, adapter, sandboxID, compiled, firecrackerCfg, servicesStagePlan, reporter)
-		}); err != nil {
-			if terminateErr := s.terminateCreatedSandbox(context.Background(), adapter, sandboxID); terminateErr != nil {
-				return nil, fmt.Errorf("bootstrap services stage: %w; cleanup failed: %v", err, terminateErr)
-			}
-			return nil, fmt.Errorf("bootstrap services stage: %w", err)
+		if err := s.bootstrapServicesForCreateSandbox(ctx, createSandboxCacheBootstrapConfig{
+			Adapter:                    adapter,
+			BackendName:                backendName,
+			SandboxID:                  sandboxID,
+			Compiled:                   compiled,
+			FirecrackerConfig:          firecrackerCfg,
+			Repository:                 repository,
+			Changeset:                  changeset,
+			CacheOutputSnapshotAdapter: cacheOutputSnapshotAdapter,
+			Reporter:                   reporter,
+		}, servicesStagePlan, serviceBlockVolumePlan, serviceBlockVolumePlanAvailable, dependencyBlockVolumePublicationSafe); err != nil {
+			return nil, err
 		}
 		if err := s.ensureSandboxCreateStillProvisioning(sandboxID); err != nil {
 			return nil, err


### PR DESCRIPTION
## Problem

`CreateSandbox` still carried the same dependency and services bootstrap branching in each cache-restore path and in the cold provisioning path. That made the exact-fallback rule for service volume publishing and the bootstrap cleanup behavior easy to drift.

## Change

This PR is slice 6 of the cache refactor stack. It moves the create-time dependency and services bootstrap decisions into shared helpers, while keeping stage-cache publishing and provisioning-state checks in the existing orchestration flow.

The helper preserves the current behavior for block-volume plans, aggregate stage plans, trace attributes, reporter phases, cleanup on bootstrap failure, and the service exact fallback when dependency volume publication is not safe.

## Validation

- `mise exec -- go test ./internal/controlservice`
- `mise exec -- go test ./...`
