### PR TITLE
docs: Clarify registry redirect policy

### DIFF
--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -131,9 +131,13 @@ Current scope:
   `http://gateway.cleanroom.internal:8170/registry/public.ecr.aws/...` inside
   the guest.
 
-Policy still applies to the registry host from the map key. A sandbox must
-allow `public.ecr.aws:443` for the `public.ecr.aws` mirror path to fetch
-upstream, even though the guest talks to the Cleanroom gateway over HTTP.
+The initial upstream request is authorized against the registry host from the
+map key. A sandbox must allow `public.ecr.aws:443` for the
+`public.ecr.aws` mirror path to fetch upstream, even though the guest talks to
+the Cleanroom gateway over HTTP. Upstream registry redirects are checked against
+the redirected host, so policies must also allow any registry CDN host needed
+for the image pull. For example, GHCR blob downloads commonly redirect to
+`pkg-containers.githubusercontent.com:443`.
 Registries that are not present in `gateway.oci.registries` are not installed
 as guest `dockerd` registry mirrors unless they are one of the built-in public
 registry hosts. Other registries either use Docker's normal direct registry path

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -470,7 +470,7 @@ These rules are installed during sandbox network setup and torn down during clea
 #### 6.2.4 Package registry proxy
 
 - The gateway exposes a `/registry/` route backed by embedded `content-cache` OCI handlers.
-- The gateway resolves a registry prefix from the request path, maps it to an upstream registry URL, and applies the sandbox allowlist against the mapped policy host and port before forwarding upstream.
+- The gateway resolves a registry prefix from the request path, maps it to an upstream registry URL, and applies the sandbox allowlist against the mapped policy host and port before forwarding upstream. Registry redirects are also policy-checked against the redirected host and port.
 - Current route scope is OCI pull-style `GET` and `HEAD` traffic.
 - The gateway also exposes a Docker Hub-compatible `/v2/` mirror endpoint backed by the same OCI cache so guest `dockerd` can use the shared gateway as a Docker Hub registry mirror.
 - Guest `dockerd` also gets generated Docker registry-host config for built-in public registries (`ghcr.io`, `public.ecr.aws`) and non-Docker-Hub registries explicitly configured in runtime config under `gateway.oci.registries`, pointing those registry namespaces' server endpoint at the gateway `/registry/<host>/` path without a direct upstream fallback.


### PR DESCRIPTION
## Problem

The gateway docs said registry mirror policy applies to the registry map key, but the live OCI client also policy-checks upstream redirects. A GHCR Docker pull with only `ghcr.io:443` allowed failed on `pkg-containers.githubusercontent.com:443`.

## Change

- clarify that the initial registry request is checked against the mapped registry host
- document that registry redirects are checked against the redirected host and port
- call out GHCR blob redirects to `pkg-containers.githubusercontent.com:443`

## Validation

- `git diff --check`
- `/usr/local/bin/cleanroom policy validate --chdir examples/docker`
- live smoke before this docs change: GHCR pull failed with only `ghcr.io:443`, then passed after also allowing `pkg-containers.githubusercontent.com:443`
