### PR TITLE
fix: Fail required Docker on unsupported images

### DIFF
--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -1316,6 +1316,9 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 	if _, err := os.Stat(rootFSPath); err != nil {
 		return nil, fmt.Errorf("rootfs %s: %w", rootFSPath, err)
 	}
+	if err := backend.ValidateDockerServiceRootFS(rootFSPath, imageRef, compiled.RequiresDockerService()); err != nil {
+		return nil, err
+	}
 
 	driver, err := rootFSVolumeDriver(cfg)
 	if err != nil {

--- a/internal/backend/docker_rootfs.go
+++ b/internal/backend/docker_rootfs.go
@@ -19,22 +19,22 @@ var dockerServiceDockerdPaths = []string{
 // ValidateDockerServiceRootFS fails fast when a Docker service policy is paired
 // with an image that cannot start dockerd from the guest's default PATH.
 func ValidateDockerServiceRootFS(rootFSPath, imageRef string, required bool) error {
-	return validateDockerServiceRootFS(rootFSPath, imageRef, required, ext4PathKind)
+	return validateDockerServiceRootFS(rootFSPath, imageRef, required, ext4edit.PathIsExecutable)
 }
 
-func validateDockerServiceRootFS(rootFSPath, imageRef string, required bool, pathKind func(string, string) (ext4edit.PathKind, error)) error {
+func validateDockerServiceRootFS(rootFSPath, imageRef string, required bool, pathIsExecutable func(string, string) (bool, error)) error {
 	if !required {
 		return nil
 	}
-	if pathKind == nil {
+	if pathIsExecutable == nil {
 		return fmt.Errorf("sandbox.docker.required is true, but the selected sandbox image cannot be inspected for dockerd")
 	}
 	for _, path := range dockerServiceDockerdPaths {
-		kind, err := pathKind(rootFSPath, path)
+		executable, err := pathIsExecutable(rootFSPath, path)
 		if err != nil {
 			return fmt.Errorf("inspect rootfs for required docker service path %q: %w", path, err)
 		}
-		if kind == ext4edit.PathKindRegular || kind == ext4edit.PathKindSymlink {
+		if executable {
 			return nil
 		}
 	}
@@ -48,8 +48,4 @@ func validateDockerServiceRootFS(rootFSPath, imageRef string, required bool, pat
 		imageLabel,
 		strings.Join(dockerServiceDockerdPaths, ", "),
 	)
-}
-
-func ext4PathKind(rootFSPath, path string) (ext4edit.PathKind, error) {
-	return ext4edit.PathTypeWithError(rootFSPath, path)
 }

--- a/internal/backend/docker_rootfs.go
+++ b/internal/backend/docker_rootfs.go
@@ -1,0 +1,58 @@
+package backend
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/buildkite/cleanroom/internal/ext4edit"
+)
+
+var dockerServiceDockerdPaths = []string{
+	"/usr/local/bin/dockerd",
+	"/usr/bin/dockerd",
+	"/usr/sbin/dockerd",
+	"/sbin/dockerd",
+	"/bin/dockerd",
+}
+
+// ValidateDockerServiceRootFS fails fast when a Docker service policy is paired
+// with an image that cannot start dockerd from the guest's default PATH.
+func ValidateDockerServiceRootFS(rootFSPath, imageRef string, required bool) error {
+	return validateDockerServiceRootFS(rootFSPath, imageRef, required, ext4PathExists)
+}
+
+func validateDockerServiceRootFS(rootFSPath, imageRef string, required bool, pathExists func(string, string) (bool, error)) error {
+	if !required {
+		return nil
+	}
+	if pathExists == nil {
+		return fmt.Errorf("sandbox.docker.required is true, but the selected sandbox image cannot be inspected for dockerd")
+	}
+	for _, path := range dockerServiceDockerdPaths {
+		exists, err := pathExists(rootFSPath, path)
+		if err != nil {
+			return fmt.Errorf("inspect rootfs for required docker service path %q: %w", path, err)
+		}
+		if exists {
+			return nil
+		}
+	}
+
+	imageLabel := "the selected sandbox image"
+	if trimmed := strings.TrimSpace(imageRef); trimmed != "" {
+		imageLabel = fmt.Sprintf("sandbox image %q", trimmed)
+	}
+	return fmt.Errorf(
+		"sandbox.docker.required is true, but %s does not contain dockerd in PATH (%s); use a Docker-capable image such as ghcr.io/buildkite/cleanroom-base/debian-docker or disable sandbox.docker.required",
+		imageLabel,
+		strings.Join(dockerServiceDockerdPaths, ", "),
+	)
+}
+
+func ext4PathExists(rootFSPath, path string) (bool, error) {
+	kind, err := ext4edit.PathTypeWithError(rootFSPath, path)
+	if err != nil {
+		return false, err
+	}
+	return kind != ext4edit.PathKindUnknown, nil
+}

--- a/internal/backend/docker_rootfs.go
+++ b/internal/backend/docker_rootfs.go
@@ -34,7 +34,7 @@ func validateDockerServiceRootFS(rootFSPath, imageRef string, required bool, pat
 		if err != nil {
 			return fmt.Errorf("inspect rootfs for required docker service path %q: %w", path, err)
 		}
-		if kind == ext4edit.PathKindRegular {
+		if kind == ext4edit.PathKindRegular || kind == ext4edit.PathKindSymlink {
 			return nil
 		}
 	}

--- a/internal/backend/docker_rootfs.go
+++ b/internal/backend/docker_rootfs.go
@@ -8,6 +8,7 @@ import (
 )
 
 var dockerServiceDockerdPaths = []string{
+	"/usr/local/sbin/dockerd",
 	"/usr/local/bin/dockerd",
 	"/usr/bin/dockerd",
 	"/usr/sbin/dockerd",

--- a/internal/backend/docker_rootfs.go
+++ b/internal/backend/docker_rootfs.go
@@ -19,22 +19,22 @@ var dockerServiceDockerdPaths = []string{
 // ValidateDockerServiceRootFS fails fast when a Docker service policy is paired
 // with an image that cannot start dockerd from the guest's default PATH.
 func ValidateDockerServiceRootFS(rootFSPath, imageRef string, required bool) error {
-	return validateDockerServiceRootFS(rootFSPath, imageRef, required, ext4PathExists)
+	return validateDockerServiceRootFS(rootFSPath, imageRef, required, ext4PathKind)
 }
 
-func validateDockerServiceRootFS(rootFSPath, imageRef string, required bool, pathExists func(string, string) (bool, error)) error {
+func validateDockerServiceRootFS(rootFSPath, imageRef string, required bool, pathKind func(string, string) (ext4edit.PathKind, error)) error {
 	if !required {
 		return nil
 	}
-	if pathExists == nil {
+	if pathKind == nil {
 		return fmt.Errorf("sandbox.docker.required is true, but the selected sandbox image cannot be inspected for dockerd")
 	}
 	for _, path := range dockerServiceDockerdPaths {
-		exists, err := pathExists(rootFSPath, path)
+		kind, err := pathKind(rootFSPath, path)
 		if err != nil {
 			return fmt.Errorf("inspect rootfs for required docker service path %q: %w", path, err)
 		}
-		if exists {
+		if kind == ext4edit.PathKindRegular {
 			return nil
 		}
 	}
@@ -50,10 +50,6 @@ func validateDockerServiceRootFS(rootFSPath, imageRef string, required bool, pat
 	)
 }
 
-func ext4PathExists(rootFSPath, path string) (bool, error) {
-	kind, err := ext4edit.PathTypeWithError(rootFSPath, path)
-	if err != nil {
-		return false, err
-	}
-	return kind != ext4edit.PathKindUnknown, nil
+func ext4PathKind(rootFSPath, path string) (ext4edit.PathKind, error) {
+	return ext4edit.PathTypeWithError(rootFSPath, path)
 }

--- a/internal/backend/docker_rootfs_test.go
+++ b/internal/backend/docker_rootfs_test.go
@@ -4,15 +4,17 @@ import (
 	"errors"
 	"strings"
 	"testing"
+
+	"github.com/buildkite/cleanroom/internal/ext4edit"
 )
 
 func TestValidateDockerServiceRootFSSkipsWhenDockerNotRequired(t *testing.T) {
 	t.Parallel()
 
 	called := false
-	err := validateDockerServiceRootFS("rootfs.ext4", "example/image", false, func(string, string) (bool, error) {
+	err := validateDockerServiceRootFS("rootfs.ext4", "example/image", false, func(string, string) (ext4edit.PathKind, error) {
 		called = true
-		return false, nil
+		return ext4edit.PathKindUnknown, nil
 	})
 	if err != nil {
 		t.Fatalf("ValidateDockerServiceRootFS returned error: %v", err)
@@ -25,8 +27,11 @@ func TestValidateDockerServiceRootFSSkipsWhenDockerNotRequired(t *testing.T) {
 func TestValidateDockerServiceRootFSAcceptsDockerdOnPath(t *testing.T) {
 	t.Parallel()
 
-	err := validateDockerServiceRootFS("rootfs.ext4", "example/image", true, func(_, path string) (bool, error) {
-		return path == "/usr/local/sbin/dockerd", nil
+	err := validateDockerServiceRootFS("rootfs.ext4", "example/image", true, func(_, path string) (ext4edit.PathKind, error) {
+		if path == "/usr/local/sbin/dockerd" {
+			return ext4edit.PathKindRegular, nil
+		}
+		return ext4edit.PathKindUnknown, nil
 	})
 	if err != nil {
 		t.Fatalf("ValidateDockerServiceRootFS returned error: %v", err)
@@ -36,8 +41,8 @@ func TestValidateDockerServiceRootFSAcceptsDockerdOnPath(t *testing.T) {
 func TestValidateDockerServiceRootFSRejectsMissingDockerd(t *testing.T) {
 	t.Parallel()
 
-	err := validateDockerServiceRootFS("rootfs.ext4", "ghcr.io/buildkite/cleanroom-base/alpine", true, func(string, string) (bool, error) {
-		return false, nil
+	err := validateDockerServiceRootFS("rootfs.ext4", "ghcr.io/buildkite/cleanroom-base/alpine", true, func(string, string) (ext4edit.PathKind, error) {
+		return ext4edit.PathKindUnknown, nil
 	})
 	if err == nil {
 		t.Fatal("expected error when docker is required but dockerd is missing")
@@ -58,8 +63,8 @@ func TestValidateDockerServiceRootFSPreservesInspectionErrors(t *testing.T) {
 	t.Parallel()
 
 	inspectErr := errors.New("debugfs unavailable")
-	err := validateDockerServiceRootFS("rootfs.ext4", "example/image", true, func(string, string) (bool, error) {
-		return false, inspectErr
+	err := validateDockerServiceRootFS("rootfs.ext4", "example/image", true, func(string, string) (ext4edit.PathKind, error) {
+		return ext4edit.PathKindUnknown, inspectErr
 	})
 	if err == nil {
 		t.Fatal("expected inspection error")
@@ -71,5 +76,22 @@ func TestValidateDockerServiceRootFSPreservesInspectionErrors(t *testing.T) {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("expected error to contain %q, got %q", want, err.Error())
 		}
+	}
+}
+
+func TestValidateDockerServiceRootFSRejectsDockerdDirectory(t *testing.T) {
+	t.Parallel()
+
+	err := validateDockerServiceRootFS("rootfs.ext4", "example/image", true, func(_, path string) (ext4edit.PathKind, error) {
+		if path == "/usr/local/sbin/dockerd" {
+			return ext4edit.PathKindDirectory, nil
+		}
+		return ext4edit.PathKindUnknown, nil
+	})
+	if err == nil {
+		t.Fatal("expected directory placeholder to be rejected")
+	}
+	if !strings.Contains(err.Error(), "does not contain dockerd in PATH") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/internal/backend/docker_rootfs_test.go
+++ b/internal/backend/docker_rootfs_test.go
@@ -38,6 +38,20 @@ func TestValidateDockerServiceRootFSAcceptsDockerdOnPath(t *testing.T) {
 	}
 }
 
+func TestValidateDockerServiceRootFSAcceptsSymlinkedDockerdOnPath(t *testing.T) {
+	t.Parallel()
+
+	err := validateDockerServiceRootFS("rootfs.ext4", "example/image", true, func(_, path string) (ext4edit.PathKind, error) {
+		if path == "/usr/local/bin/dockerd" {
+			return ext4edit.PathKindSymlink, nil
+		}
+		return ext4edit.PathKindUnknown, nil
+	})
+	if err != nil {
+		t.Fatalf("ValidateDockerServiceRootFS returned error: %v", err)
+	}
+}
+
 func TestValidateDockerServiceRootFSRejectsMissingDockerd(t *testing.T) {
 	t.Parallel()
 

--- a/internal/backend/docker_rootfs_test.go
+++ b/internal/backend/docker_rootfs_test.go
@@ -26,7 +26,7 @@ func TestValidateDockerServiceRootFSAcceptsDockerdOnPath(t *testing.T) {
 	t.Parallel()
 
 	err := validateDockerServiceRootFS("rootfs.ext4", "example/image", true, func(_, path string) (bool, error) {
-		return path == "/usr/local/bin/dockerd", nil
+		return path == "/usr/local/sbin/dockerd", nil
 	})
 	if err != nil {
 		t.Fatalf("ValidateDockerServiceRootFS returned error: %v", err)

--- a/internal/backend/docker_rootfs_test.go
+++ b/internal/backend/docker_rootfs_test.go
@@ -4,17 +4,15 @@ import (
 	"errors"
 	"strings"
 	"testing"
-
-	"github.com/buildkite/cleanroom/internal/ext4edit"
 )
 
 func TestValidateDockerServiceRootFSSkipsWhenDockerNotRequired(t *testing.T) {
 	t.Parallel()
 
 	called := false
-	err := validateDockerServiceRootFS("rootfs.ext4", "example/image", false, func(string, string) (ext4edit.PathKind, error) {
+	err := validateDockerServiceRootFS("rootfs.ext4", "example/image", false, func(string, string) (bool, error) {
 		called = true
-		return ext4edit.PathKindUnknown, nil
+		return false, nil
 	})
 	if err != nil {
 		t.Fatalf("ValidateDockerServiceRootFS returned error: %v", err)
@@ -27,25 +25,25 @@ func TestValidateDockerServiceRootFSSkipsWhenDockerNotRequired(t *testing.T) {
 func TestValidateDockerServiceRootFSAcceptsDockerdOnPath(t *testing.T) {
 	t.Parallel()
 
-	err := validateDockerServiceRootFS("rootfs.ext4", "example/image", true, func(_, path string) (ext4edit.PathKind, error) {
+	err := validateDockerServiceRootFS("rootfs.ext4", "example/image", true, func(_, path string) (bool, error) {
 		if path == "/usr/local/sbin/dockerd" {
-			return ext4edit.PathKindRegular, nil
+			return true, nil
 		}
-		return ext4edit.PathKindUnknown, nil
+		return false, nil
 	})
 	if err != nil {
 		t.Fatalf("ValidateDockerServiceRootFS returned error: %v", err)
 	}
 }
 
-func TestValidateDockerServiceRootFSAcceptsSymlinkedDockerdOnPath(t *testing.T) {
+func TestValidateDockerServiceRootFSAcceptsExecutableDockerdOnLaterPath(t *testing.T) {
 	t.Parallel()
 
-	err := validateDockerServiceRootFS("rootfs.ext4", "example/image", true, func(_, path string) (ext4edit.PathKind, error) {
+	err := validateDockerServiceRootFS("rootfs.ext4", "example/image", true, func(_, path string) (bool, error) {
 		if path == "/usr/local/bin/dockerd" {
-			return ext4edit.PathKindSymlink, nil
+			return true, nil
 		}
-		return ext4edit.PathKindUnknown, nil
+		return false, nil
 	})
 	if err != nil {
 		t.Fatalf("ValidateDockerServiceRootFS returned error: %v", err)
@@ -55,8 +53,8 @@ func TestValidateDockerServiceRootFSAcceptsSymlinkedDockerdOnPath(t *testing.T) 
 func TestValidateDockerServiceRootFSRejectsMissingDockerd(t *testing.T) {
 	t.Parallel()
 
-	err := validateDockerServiceRootFS("rootfs.ext4", "ghcr.io/buildkite/cleanroom-base/alpine", true, func(string, string) (ext4edit.PathKind, error) {
-		return ext4edit.PathKindUnknown, nil
+	err := validateDockerServiceRootFS("rootfs.ext4", "ghcr.io/buildkite/cleanroom-base/alpine", true, func(string, string) (bool, error) {
+		return false, nil
 	})
 	if err == nil {
 		t.Fatal("expected error when docker is required but dockerd is missing")
@@ -77,8 +75,8 @@ func TestValidateDockerServiceRootFSPreservesInspectionErrors(t *testing.T) {
 	t.Parallel()
 
 	inspectErr := errors.New("debugfs unavailable")
-	err := validateDockerServiceRootFS("rootfs.ext4", "example/image", true, func(string, string) (ext4edit.PathKind, error) {
-		return ext4edit.PathKindUnknown, inspectErr
+	err := validateDockerServiceRootFS("rootfs.ext4", "example/image", true, func(string, string) (bool, error) {
+		return false, inspectErr
 	})
 	if err == nil {
 		t.Fatal("expected inspection error")
@@ -96,11 +94,11 @@ func TestValidateDockerServiceRootFSPreservesInspectionErrors(t *testing.T) {
 func TestValidateDockerServiceRootFSRejectsDockerdDirectory(t *testing.T) {
 	t.Parallel()
 
-	err := validateDockerServiceRootFS("rootfs.ext4", "example/image", true, func(_, path string) (ext4edit.PathKind, error) {
+	err := validateDockerServiceRootFS("rootfs.ext4", "example/image", true, func(_, path string) (bool, error) {
 		if path == "/usr/local/sbin/dockerd" {
-			return ext4edit.PathKindDirectory, nil
+			return false, nil
 		}
-		return ext4edit.PathKindUnknown, nil
+		return false, nil
 	})
 	if err == nil {
 		t.Fatal("expected directory placeholder to be rejected")

--- a/internal/backend/docker_rootfs_test.go
+++ b/internal/backend/docker_rootfs_test.go
@@ -1,0 +1,75 @@
+package backend
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestValidateDockerServiceRootFSSkipsWhenDockerNotRequired(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	err := validateDockerServiceRootFS("rootfs.ext4", "example/image", false, func(string, string) (bool, error) {
+		called = true
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("ValidateDockerServiceRootFS returned error: %v", err)
+	}
+	if called {
+		t.Fatal("did not expect rootfs inspection when docker is not required")
+	}
+}
+
+func TestValidateDockerServiceRootFSAcceptsDockerdOnPath(t *testing.T) {
+	t.Parallel()
+
+	err := validateDockerServiceRootFS("rootfs.ext4", "example/image", true, func(_, path string) (bool, error) {
+		return path == "/usr/local/bin/dockerd", nil
+	})
+	if err != nil {
+		t.Fatalf("ValidateDockerServiceRootFS returned error: %v", err)
+	}
+}
+
+func TestValidateDockerServiceRootFSRejectsMissingDockerd(t *testing.T) {
+	t.Parallel()
+
+	err := validateDockerServiceRootFS("rootfs.ext4", "ghcr.io/buildkite/cleanroom-base/alpine", true, func(string, string) (bool, error) {
+		return false, nil
+	})
+	if err == nil {
+		t.Fatal("expected error when docker is required but dockerd is missing")
+	}
+	for _, want := range []string{
+		"sandbox.docker.required is true",
+		`ghcr.io/buildkite/cleanroom-base/alpine`,
+		"dockerd",
+		"ghcr.io/buildkite/cleanroom-base/debian-docker",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("expected error to contain %q, got %q", want, err.Error())
+		}
+	}
+}
+
+func TestValidateDockerServiceRootFSPreservesInspectionErrors(t *testing.T) {
+	t.Parallel()
+
+	inspectErr := errors.New("debugfs unavailable")
+	err := validateDockerServiceRootFS("rootfs.ext4", "example/image", true, func(string, string) (bool, error) {
+		return false, inspectErr
+	})
+	if err == nil {
+		t.Fatal("expected inspection error")
+	}
+	for _, want := range []string{
+		"inspect rootfs",
+		"debugfs unavailable",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("expected error to contain %q, got %q", want, err.Error())
+		}
+	}
+}

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -1812,6 +1812,12 @@ func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID strin
 	if err != nil {
 		return nil, err
 	}
+	if _, err := os.Stat(sourceRootFSPath); err != nil {
+		return nil, fmt.Errorf("rootfs %s: %w", sourceRootFSPath, err)
+	}
+	if err := backend.ValidateDockerServiceRootFS(sourceRootFSPath, compiled.ImageRef, compiled.RequiresDockerService()); err != nil {
+		return nil, err
+	}
 
 	runBaseDir, err := sandboxRuntimeBaseDir()
 	if err != nil {

--- a/internal/ext4edit/ext4edit.go
+++ b/internal/ext4edit/ext4edit.go
@@ -99,6 +99,54 @@ func PathTypeWithError(imagePath, path string) (PathKind, error) {
 	return DebugFSStatType(output), nil
 }
 
+// PathIsExecutable reports whether path resolves to a regular file with any
+// executable bit set.
+func PathIsExecutable(imagePath, path string) (bool, error) {
+	return pathIsExecutable(imagePath, path, 0)
+}
+
+func pathIsExecutable(imagePath, path string, symlinkDepth int) (bool, error) {
+	if symlinkDepth > 40 {
+		return false, fmt.Errorf("resolve symlink %q: too many nested symlinks", path)
+	}
+
+	resolvedPath, err := resolvePath(imagePath, path)
+	if err != nil {
+		if isMissingPathError(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	output, err := statPathDirect(imagePath, resolvedPath)
+	if err != nil {
+		if isMissingPathError(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	switch DebugFSStatType(output) {
+	case PathKindRegular:
+		mode, ok := DebugFSStatMode(output)
+		if !ok {
+			return false, fmt.Errorf("debugfs stat for %q did not include mode", resolvedPath)
+		}
+		return mode.Perm()&0o111 != 0, nil
+	case PathKindSymlink:
+		target, err := DebugFSStatLinkTarget(output)
+		if err != nil {
+			return false, fmt.Errorf("resolve symlink %q: %w", resolvedPath, err)
+		}
+		if !strings.HasPrefix(target, "/") {
+			target = filepath.Join(filepath.Dir(resolvedPath), target)
+		}
+		return pathIsExecutable(imagePath, target, symlinkDepth+1)
+	default:
+		return false, nil
+	}
+}
+
 // DebugFSCommandOutputError extracts actionable debugfs stderr/stdout error text.
 func DebugFSCommandOutputError(output string) string {
 	trimmed := strings.TrimSpace(output)
@@ -155,6 +203,28 @@ func DebugFSStatType(output string) PathKind {
 		}
 	}
 	return PathKindUnknown
+}
+
+// DebugFSStatMode parses a debugfs `stat` response into permission bits.
+func DebugFSStatMode(output string) (os.FileMode, bool) {
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		line = strings.TrimSpace(line)
+		modeIndex := strings.Index(line, "Mode:")
+		if modeIndex == -1 {
+			continue
+		}
+		rest := line[modeIndex+len("Mode:"):]
+		fields := strings.Fields(rest)
+		if len(fields) == 0 {
+			return 0, false
+		}
+		parsed, err := strconv.ParseUint(fields[0], 8, 32)
+		if err != nil {
+			return 0, false
+		}
+		return os.FileMode(parsed) & os.ModePerm, true
+	}
+	return 0, false
 }
 
 // DebugFSStatLinkTarget parses a debugfs `stat` response for a symlink target.

--- a/internal/ext4edit/ext4edit_test.go
+++ b/internal/ext4edit/ext4edit_test.go
@@ -116,6 +116,40 @@ func TestDebugFSStatTypeParsesSymlink(t *testing.T) {
 	}
 }
 
+func TestDebugFSStatModeParsesPermissions(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		output string
+		want   os.FileMode
+	}{
+		{
+			name:   "permissions only",
+			output: "debugfs 1.47.3 (8-Jul-2025)\nInode: 531   Type: regular    Mode:  0755   Flags: 0x80000\n",
+			want:   0o755,
+		},
+		{
+			name:   "mode with inode type bits",
+			output: "debugfs 1.47.3 (8-Jul-2025)\nInode: 531   Type: regular    Mode:  0100644   Flags: 0x80000\n",
+			want:   0o644,
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := DebugFSStatMode(tc.output)
+			if !ok {
+				t.Fatal("expected stat mode to parse")
+			}
+			if got != tc.want {
+				t.Fatalf("unexpected stat mode: got %#o want %#o", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestPathTypeWithErrorReturnsInspectionError(t *testing.T) {
 	t.Parallel()
 
@@ -138,6 +172,60 @@ func TestPathTypeWithErrorReturnsInspectionError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "debugfs") {
 		t.Fatalf("expected debugfs error, got %v", err)
+	}
+}
+
+func TestPathIsExecutableFollowsFinalSymlinkAndChecksMode(t *testing.T) {
+	debugfsBinary, mkfsBinary, ok := requireDebugFSTools(t)
+	if !ok {
+		return
+	}
+
+	imagePath := createExt4Image(t, mkfsBinary)
+	createExt4Dir(t, debugfsBinary, imagePath, "/usr")
+	createExt4Dir(t, debugfsBinary, imagePath, "/usr/bin")
+	createExt4Dir(t, debugfsBinary, imagePath, "/usr/local")
+	createExt4Dir(t, debugfsBinary, imagePath, "/usr/local/bin")
+
+	tmpDir := t.TempDir()
+	executableSrc := filepath.Join(tmpDir, "dockerd-real")
+	if err := os.WriteFile(executableSrc, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write executable source file: %v", err)
+	}
+	if err := InjectFile(imagePath, executableSrc, "/usr/local/bin/dockerd-real", 0o755); err != nil {
+		t.Fatalf("InjectFile executable: %v", err)
+	}
+	createExt4Symlink(t, debugfsBinary, imagePath, "/usr/bin/dockerd", "/usr/local/bin/dockerd-real")
+
+	nonExecutableSrc := filepath.Join(tmpDir, "not-dockerd")
+	if err := os.WriteFile(nonExecutableSrc, []byte("#!/bin/sh\nexit 0\n"), 0o644); err != nil {
+		t.Fatalf("write non-executable source file: %v", err)
+	}
+	if err := InjectFile(imagePath, nonExecutableSrc, "/usr/local/bin/not-dockerd", 0o644); err != nil {
+		t.Fatalf("InjectFile non-executable: %v", err)
+	}
+	createExt4Symlink(t, debugfsBinary, imagePath, "/usr/bin/not-dockerd", "/usr/local/bin/not-dockerd")
+	createExt4Symlink(t, debugfsBinary, imagePath, "/usr/bin/broken-dockerd", "/missing/dockerd")
+
+	for _, tc := range []struct {
+		path string
+		want bool
+	}{
+		{path: "/usr/bin/dockerd", want: true},
+		{path: "/usr/local/bin/dockerd-real", want: true},
+		{path: "/usr/bin/not-dockerd", want: false},
+		{path: "/usr/local/bin/not-dockerd", want: false},
+		{path: "/usr/bin/broken-dockerd", want: false},
+		{path: "/usr/bin/missing-dockerd", want: false},
+		{path: "/usr/bin", want: false},
+	} {
+		got, err := PathIsExecutable(imagePath, tc.path)
+		if err != nil {
+			t.Fatalf("PathIsExecutable(%q): %v", tc.path, err)
+		}
+		if got != tc.want {
+			t.Fatalf("PathIsExecutable(%q): got %v want %v", tc.path, got, tc.want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem

`cleanroom sandbox create --docker` succeeded against the default non-Docker base image, but the guest had no `dockerd`, no Docker CLI, and no Docker socket. That made `sandbox.docker.required` behave like a best-effort hint.

## Change

- add a shared rootfs preflight for `sandbox.docker.required`
- check both darwin-vz and firecracker rootfs launch paths before the VM starts
- return a clear error that points users to a Docker-capable image
- preserve rootfs inspection errors instead of reporting them as missing Docker

## Validation

- `git diff --check`
- `mise exec -- go test ./internal/cli ./internal/backend ./internal/backend/darwinvz ./internal/backend/firecracker`
- source-daemon smoke: default `sandbox create --docker` fails in ~230ms with `sandbox.docker.required is true ... does not contain dockerd`
- source-daemon smoke: `examples/docker` still starts Docker and reports server version `27.5.1`
