### PR TITLE
docs: Clarify volume cache env keying

### DIFF
--- a/cmd/cleanroom-guest-agent/main.go
+++ b/cmd/cleanroom-guest-agent/main.go
@@ -18,6 +18,7 @@ import (
 	"unsafe"
 
 	"github.com/buildkite/cleanroom/internal/gateway"
+	"github.com/buildkite/cleanroom/internal/guestenv"
 	"github.com/buildkite/cleanroom/internal/vsockexec"
 	"github.com/creack/pty"
 	"github.com/mdlayher/vsock"
@@ -373,10 +374,10 @@ func buildCommandEnv(requestEnv []string, inheritAmbient bool) ([]string, error)
 	configureGatewayGoEnv(base, requestKeys)
 
 	if strings.TrimSpace(base["HOME"]) == "" {
-		base["HOME"] = "/root"
+		base["HOME"] = guestenv.DefaultHome
 	}
 	if strings.TrimSpace(base["PATH"]) == "" {
-		base["PATH"] = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/.local/bin"
+		base["PATH"] = guestenv.DefaultPath
 	}
 
 	out := make([]string, 0, len(base))

--- a/cmd/cleanroom-guest-agent/main_test.go
+++ b/cmd/cleanroom-guest-agent/main_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/buildkite/cleanroom/internal/gateway"
+	"github.com/buildkite/cleanroom/internal/guestenv"
 	"github.com/buildkite/cleanroom/internal/vsockexec"
 )
 
@@ -83,11 +84,11 @@ func TestBuildCommandEnvCanDisableAmbientInheritance(t *testing.T) {
 	if got["DECLARED"] != "value" {
 		t.Fatalf("expected declared env to be present, got %q", got["DECLARED"])
 	}
-	if got["HOME"] != "/root" {
+	if got["HOME"] != guestenv.DefaultHome {
 		t.Fatalf("expected default HOME, got %q", got["HOME"])
 	}
-	if got["PATH"] == "" {
-		t.Fatal("expected default PATH")
+	if got["PATH"] != guestenv.DefaultPath {
+		t.Fatalf("expected default PATH, got %q", got["PATH"])
 	}
 }
 

--- a/docs/plans/dependency-service-volume-caches.md
+++ b/docs/plans/dependency-service-volume-caches.md
@@ -2,7 +2,7 @@
 
 **Spec reference:** `spec.md` sections 5.1.1, 5.2, 6.4
 **Status:** Ready for initial Firecracker and darwin-vz release
-**Last reviewed:** 2026-05-05
+**Last reviewed:** 2026-05-06
 
 ## Summary
 
@@ -199,15 +199,16 @@ resolved from the post-changeset repository tree when a changeset is present.
 This must be string normalization, not shell expansion.
 
 The canonical home directory is the `HOME` value Cleanroom supplies in the
-closed block execution environment. Cleanroom must set that value before output
-path normalization. Block `env` values are literal strings, except leading `~`,
-`~/`, `$HOME`, `$HOME/`, `${HOME}`, and `${HOME}/` forms are expanded to the
-same canonical home directory, and leading `$WORKSPACE`, `$WORKSPACE/`,
-`${WORKSPACE}`, and `${WORKSPACE}/` forms are expanded to the canonical
-workspace root. Other `$...` values, URLs, relative paths, empty strings, and
-trailing spaces are preserved and included in the block environment digest as
-provided. The first implementation should not discover a different home
-directory from the image at runtime.
+closed block execution environment. Cleanroom sets that value before output path
+normalization and keeps the policy normalizer tied to the guest-agent default.
+Block `env` values are literal strings, except leading `~`, `~/`, `$HOME`,
+`$HOME/`, `${HOME}`, and `${HOME}/` forms are expanded to the same canonical
+home directory, and leading `$WORKSPACE`, `$WORKSPACE/`, `${WORKSPACE}`, and
+`${WORKSPACE}/` forms are expanded to the canonical workspace root. Other
+`$...` values, URLs, relative paths, empty strings, and trailing spaces are
+preserved and included in the block environment digest as provided. The first
+implementation should not discover a different home directory from the image at
+runtime.
 
 ## Semantics
 
@@ -290,14 +291,16 @@ manifest rather than by changing the reuse namespace.
 
 ### Environment and network determinism
 
-Block commands should receive a closed environment: Cleanroom's deterministic
-baseline variables plus the block's declared `env`. Host process environment
-values must not leak into file-keyed volume-cache commands unless they are
-explicitly declared and hashed.
+Block commands receive a closed environment: the block's declared `env` plus
+Cleanroom's fixed guest baseline defaults such as `HOME` and `PATH`. Host
+process environment values must not leak into file-keyed volume-cache commands
+unless they are explicitly declared and hashed.
 
-`dependency_env_digest` and `service_env_digest` include declared block env,
-Cleanroom-supplied cache path variables, `HOME`, working directory, and any
-other baseline values that can affect command behavior.
+`dependency_env_digest` and `service_env_digest` include only the declared block
+environment after Cleanroom path normalization. The repository working directory
+is covered by the compiled policy hash. Changes to Cleanroom baseline defaults
+that can affect command behavior must bump the dependency or service volume
+producer version instead of silently reusing old output-volume records.
 
 The compiled policy hash constrains network access, but it does not make mutable
 upstream responses deterministic. File-keyed volume cache is only safe for
@@ -1145,7 +1148,8 @@ Minimum coverage:
 - `sandbox.services` is an ordered service block list immediately.
 - Docker enablement moves to `sandbox.docker.required`.
 - `${HOME}` is the value Cleanroom sets in the closed block execution
-  environment and hashes into the block key.
+  environment. Declared env expansions are hashed into the block key; fixed
+  guest baseline defaults are covered by the producer version.
 - Escaped writes warn and trigger exact full-rootfs fallback in the first
   implementation.
 - Escaped writes should become hard failures for cacheable blocks once the

--- a/internal/controlservice/dependency_volume_plan.go
+++ b/internal/controlservice/dependency_volume_plan.go
@@ -16,7 +16,9 @@ import (
 )
 
 const (
-	dependencyVolumeStageName           = "dependency-volume"
+	dependencyVolumeStageName = "dependency-volume"
+	// Bump when dependency block-volume production semantics change, including
+	// guest baseline environment defaults that can affect command behavior.
 	dependencyVolumeProducerVersion     = "cleanroom/dependency-volume-v1"
 	dependencyVolumeOutputLayoutVersion = "aggregate-v1"
 )

--- a/internal/controlservice/service_volume_plan.go
+++ b/internal/controlservice/service_volume_plan.go
@@ -16,7 +16,9 @@ import (
 )
 
 const (
-	serviceVolumeStageName           = "service-volume"
+	serviceVolumeStageName = "service-volume"
+	// Bump when service block-volume production semantics change, including
+	// guest baseline environment defaults that can affect command behavior.
 	serviceVolumeProducerVersion     = "cleanroom/service-volume-v1"
 	serviceVolumeOutputLayoutVersion = "aggregate-v1"
 )

--- a/internal/guestenv/defaults.go
+++ b/internal/guestenv/defaults.go
@@ -1,0 +1,13 @@
+package guestenv
+
+const (
+	// DefaultHome is the guest home used by policy normalization and guest command
+	// environment fallback. Changing it can change block command behavior, so
+	// dependency/service volume producer versions must change with it.
+	DefaultHome = "/root"
+
+	// DefaultPath is the guest PATH used when neither ambient nor request env
+	// supplies one. Changing it has the same producer-version requirement as
+	// DefaultHome.
+	DefaultPath = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:" + DefaultHome + "/.local/bin"
+)

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/buildkite/cleanroom/internal/bytesize"
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+	"github.com/buildkite/cleanroom/internal/guestenv"
 	"github.com/buildkite/cleanroom/internal/ociref"
 	"gopkg.in/yaml.v3"
 )
@@ -1316,7 +1317,7 @@ func normalizeBootstrapKeyFiles(raw []string, field string) ([]string, error) {
 }
 
 const (
-	defaultBlockHome      = "/root"
+	defaultBlockHome      = guestenv.DefaultHome
 	defaultBlockWorkspace = "/workspace"
 )
 

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/buildkite/cleanroom/internal/bytesize"
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+	"github.com/buildkite/cleanroom/internal/guestenv"
 	"gopkg.in/yaml.v3"
 )
 
@@ -593,7 +594,7 @@ func TestCompileNormalizesDependencyBootstrapConfig(t *testing.T) {
 	if got, want := compiled.Dependencies.KeyFiles, []string{"go.mod", "go.sum"}; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
 		t.Fatalf("unexpected dependency key files: got %v want %v", got, want)
 	}
-	if got, want := block.Outputs.Dirs, []string{"/root/go/pkg/mod"}; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+	if got, want := block.Outputs.Dirs, []string{guestenv.DefaultHome + "/go/pkg/mod"}; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
 		t.Fatalf("unexpected dependency outputs: got %v want %v", got, want)
 	}
 }
@@ -877,7 +878,7 @@ func TestCompilePreservesLiteralBlockEnvValues(t *testing.T) {
 	env := compiled.Dependencies.Blocks[0].Env
 	for key, want := range map[string]string{
 		"EMPTY":      "",
-		"GOCACHE":    "/root/.cache/go-build",
+		"GOCACHE":    guestenv.DefaultHome + "/.cache/go-build",
 		"GOPROXY":    "https://proxy.golang.org,direct",
 		"RAW_PATH":   "a/../b",
 		"TRAILING":   "value ",
@@ -1365,7 +1366,7 @@ func TestFromProtoRejectsOverlappingDependencyAndServiceOutputs(t *testing.T) {
 				"go",
 				[]string{"true"},
 				[]string{"go.mod"},
-				&cleanroomv1.PolicyBlockOutputs{Dirs: []string{"/root/go"}},
+				&cleanroomv1.PolicyBlockOutputs{Dirs: []string{guestenv.DefaultHome + "/go"}},
 			)},
 		},
 		Services: &cleanroomv1.PolicyServices{
@@ -1373,7 +1374,7 @@ func TestFromProtoRejectsOverlappingDependencyAndServiceOutputs(t *testing.T) {
 				"postgres",
 				[]string{"true"},
 				[]string{"docker-compose.yml"},
-				&cleanroomv1.PolicyBlockOutputs{Files: []string{"/root/go/service.state"}},
+				&cleanroomv1.PolicyBlockOutputs{Files: []string{guestenv.DefaultHome + "/go/service.state"}},
 			)},
 		},
 	})


### PR DESCRIPTION
## Summary
- Clarifies the dependency/service volume-cache plan so env digests cover declared block env after Cleanroom normalization, while fixed guest baseline defaults are a producer-version contract.
- Adds shared guest HOME/PATH defaults so policy path normalization and guest command fallback stay aligned.
- Marks dependency and service volume producer-version constants as the place to bump when guest baseline production semantics change.

## Validation
- mise exec -- go test ./... -count=1
- mise run check