### PR TITLE
Add glob and submodule support to digest paths

### DIFF
--- a/cmd/cleanroom-guest-agent/input_projection.go
+++ b/cmd/cleanroom-guest-agent/input_projection.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bmatcuk/doublestar/v4"
 	"github.com/buildkite/cleanroom/internal/vsockexec"
 	"golang.org/x/sys/unix"
 )
@@ -142,8 +143,7 @@ func inputProjectionMatches(sourceRoot, input string) ([]string, error) {
 		return []string{input}, nil
 	}
 
-	pattern := filepath.Join(sourceRoot, filepath.FromSlash(input))
-	matches, err := filepath.Glob(pattern)
+	matches, err := doublestar.Glob(os.DirFS(sourceRoot), input, doublestar.WithFilesOnly())
 	if err != nil {
 		return nil, fmt.Errorf("invalid input projection glob %q: %w", input, err)
 	}
@@ -152,11 +152,7 @@ func inputProjectionMatches(sourceRoot, input string) ([]string, error) {
 	}
 	out := make([]string, 0, len(matches))
 	for _, match := range matches {
-		rel, err := filepath.Rel(sourceRoot, match)
-		if err != nil {
-			return nil, fmt.Errorf("resolve input projection match %q: %w", match, err)
-		}
-		normalized, err := cleanInputProjectionRelativePath(filepath.ToSlash(rel))
+		normalized, err := cleanInputProjectionRelativePath(filepath.ToSlash(match))
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/cleanroom-guest-agent/input_projection_test.go
+++ b/cmd/cleanroom-guest-agent/input_projection_test.go
@@ -138,6 +138,49 @@ func TestInputProjectionRejectsSymlinkedParent(t *testing.T) {
 	}
 }
 
+func TestExpandInputProjectionFilesDoublestarGlob(t *testing.T) {
+	t.Parallel()
+
+	sourceRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(sourceRoot, "vendor", "pkg"), 0o755); err != nil {
+		t.Fatalf("create vendor dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceRoot, "vendor", "pkg", "lib.go"), []byte("package pkg\n"), 0o644); err != nil {
+		t.Fatalf("write lib.go: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceRoot, "vendor", "top.go"), []byte("package vendor\n"), 0o644); err != nil {
+		t.Fatalf("write top.go: %v", err)
+	}
+
+	files, err := expandInputProjectionFiles(sourceRoot, []string{"vendor/**"})
+	if err != nil {
+		t.Fatalf("expandInputProjectionFiles returned error: %v", err)
+	}
+	if got, want := len(files), 2; got != want {
+		t.Fatalf("unexpected file count: got %d want %d", got, want)
+	}
+	joined := strings.Join(files, ",")
+	if !strings.Contains(joined, "vendor/pkg/lib.go") {
+		t.Fatalf("expected vendor/pkg/lib.go in results, got %v", files)
+	}
+	if !strings.Contains(joined, "vendor/top.go") {
+		t.Fatalf("expected vendor/top.go in results, got %v", files)
+	}
+}
+
+func TestExpandInputProjectionFilesDoublestarGlobNoMatch(t *testing.T) {
+	t.Parallel()
+
+	sourceRoot := t.TempDir()
+	_, err := expandInputProjectionFiles(sourceRoot, []string{"vendor/**"})
+	if err == nil {
+		t.Fatal("expected no-match error")
+	}
+	if !strings.Contains(err.Error(), "matched no files") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func setTestInputProjectionRoot(t *testing.T) func() {
 	t.Helper()
 	previous := inputProjectionRoot

--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/apparentlymart/go-cidr v1.1.0 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/bmatcuk/doublestar/v4 v4.10.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	connectrpc.com/connect v1.18.1
 	connectrpc.com/otelconnect v0.9.0
 	github.com/alecthomas/kong v1.14.0
+	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/buildkite/content-cache v1.2.1-0.20260419015425-0213634165a8
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/log v0.4.2
@@ -21,9 +22,13 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	go.jetify.com/typeid v1.3.0
 	go.opentelemetry.io/otel v1.43.0
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0
+	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
+	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
 	go.opentelemetry.io/proto/otlp v1.10.0
 	golang.org/x/net v0.52.0
@@ -41,7 +46,6 @@ require (
 	github.com/apparentlymart/go-cidr v1.1.0 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/bmatcuk/doublestar/v4 v4.10.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
@@ -92,12 +96,8 @@ require (
 	github.com/zeebo/blake3 v0.2.4 // indirect
 	go.etcd.io/bbolt v1.4.3 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.43.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.64.0 // indirect
-	go.opentelemetry.io/otel/metric v1.43.0 // indirect
-	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
 	go.uber.org/mock v0.5.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	golang.org/x/crypto v0.49.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -93,6 +93,8 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngEKAMDJEczWVA=
 github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
+github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bshuster-repo/logrus-logstash-hook v0.4.1/go.mod h1:zsTqEiSzDgAa/8GZR7E1qaXrhYNDKBYy5/dWPTIflbk=
 github.com/buger/jsonparser v0.0.0-20180808090653-f4dd9f5a6b44/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=

--- a/go.sum
+++ b/go.sum
@@ -824,8 +824,6 @@ go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/otel v1.43.0 h1:mYIM03dnh5zfN7HautFE4ieIig9amkNANT+xcVxAj9I=
 go.opentelemetry.io/otel v1.43.0/go.mod h1:JuG+u74mvjvcm8vj8pI5XiHy1zDeoCS2LB1spIq7Ay0=
-go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.42.0 h1:MdKucPl/HbzckWWEisiNqMPhRrAOQX8r4jTuGr636gk=
-go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.42.0/go.mod h1:RolT8tWtfHcjajEH5wFIZ4Dgh5jpPdFXYV9pTAk/qjc=
 go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0 h1:8UQVDcZxOJLtX6gxtDt3vY2WTgvZqMQRzjsqiIHQdkc=
 go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0/go.mod h1:2lmweYCiHYpEjQ/lSJBYhj9jP1zvCvQW4BqL9dnT7FQ=
 go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.43.0 h1:w1K+pCJoPpQifuVpsKamUdn9U0zM3xUziVOqsGksUrY=

--- a/internal/controlservice/dependency_stage.go
+++ b/internal/controlservice/dependency_stage.go
@@ -155,7 +155,7 @@ func (s *Service) stageKeyFilesDigest(ctx context.Context, repository *repositor
 			return commitBundle.WithRepository(ctx, repoDir, func(bundleRepoDir string) error {
 				var err error
 				if changeset != nil {
-					digest, err = stageKeyFilesDigestWithChangeset(bundleRepoDir, changeset, files, stageName, repository.Submodules)
+					digest, err = stageKeyFilesDigestWithChangeset(ctx, bundleRepoDir, changeset, files, stageName, repository.RemoteURL, repository.Submodules, s.RepositoryStore)
 				} else {
 					digest, err = stageKeyFilesDigestAtCommit(ctx, bundleRepoDir, repository.RemoteURL, repository.CommitSHA, files, stageName, repository.Submodules, s.RepositoryStore)
 				}
@@ -171,7 +171,7 @@ func (s *Service) stageKeyFilesDigest(ctx context.Context, repository *repositor
 		var digest string
 		err := s.RepositoryStore.WithRepository(ctx, repository.RemoteURL, repository.CommitSHA, repositorystore.FetchHints{}, func(repoDir string) error {
 			var err error
-			digest, err = stageKeyFilesDigestWithChangeset(repoDir, changeset, files, stageName, repository.Submodules)
+			digest, err = stageKeyFilesDigestWithChangeset(ctx, repoDir, changeset, files, stageName, repository.RemoteURL, repository.Submodules, s.RepositoryStore)
 			return err
 		})
 		if err != nil {
@@ -211,7 +211,7 @@ func (s *Service) stageInputFilesDigest(ctx context.Context, repository *reposit
 			return commitBundle.WithRepository(ctx, repoDir, func(bundleRepoDir string) error {
 				var err error
 				if changeset != nil {
-					digest, err = stageInputFilesDigestWithChangeset(bundleRepoDir, changeset, files, stageName, repository.Submodules)
+					digest, err = stageInputFilesDigestWithChangeset(ctx, bundleRepoDir, changeset, files, stageName, repository.RemoteURL, repository.Submodules, s.RepositoryStore)
 				} else {
 					digest, err = stageInputFilesDigestAtCommit(ctx, bundleRepoDir, repository.RemoteURL, repository.CommitSHA, files, stageName, repository.Submodules, s.RepositoryStore)
 				}
@@ -227,7 +227,7 @@ func (s *Service) stageInputFilesDigest(ctx context.Context, repository *reposit
 		var digest string
 		err := s.RepositoryStore.WithRepository(ctx, repository.RemoteURL, repository.CommitSHA, repositorystore.FetchHints{}, func(repoDir string) error {
 			var err error
-			digest, err = stageInputFilesDigestWithChangeset(repoDir, changeset, files, stageName, repository.Submodules)
+			digest, err = stageInputFilesDigestWithChangeset(ctx, repoDir, changeset, files, stageName, repository.RemoteURL, repository.Submodules, s.RepositoryStore)
 			return err
 		})
 		if err != nil {
@@ -247,9 +247,18 @@ func (s *Service) stageInputFilesDigest(ctx context.Context, repository *reposit
 	return digest, nil
 }
 
-func stageKeyFilesDigestWithChangeset(repoDir string, changeset *repositorychangeset.Changeset, files []string, stageName string, submodules bool) (string, error) {
+func stageKeyFilesDigestWithChangeset(ctx context.Context, repoDir string, changeset *repositorychangeset.Changeset, files []string, stageName string, parentRemoteURL string, submodules bool, store repositorystore.RepositoryStore) (string, error) {
 	manifest := make([]stageKeyFileDigest, 0, len(files))
-	digests, err := changeset.DigestPathsFromBaseWithOptions(strings.TrimSpace(repoDir), files, repositorychangeset.DigestPathsOptions{Submodules: submodules})
+	opts := repositorychangeset.DigestPathsOptions{
+		Submodules:      submodules,
+		ParentRemoteURL: parentRemoteURL,
+	}
+	if submodules && store != nil {
+		opts.EnsureSubmoduleMirror = func(ctx context.Context, url, sha string) (string, error) {
+			return store.EnsureSubmoduleMirror(ctx, url, sha)
+		}
+	}
+	digests, err := changeset.DigestPathsFromBaseWithOptions(strings.TrimSpace(repoDir), files, opts)
 	if err != nil {
 		return "", fmt.Errorf("read %s key files from repository changeset: %w", stageName, err)
 	}
@@ -270,8 +279,17 @@ func stageKeyFilesDigestWithChangeset(repoDir string, changeset *repositorychang
 	return "sha256:" + hex.EncodeToString(sum[:]), nil
 }
 
-func stageInputFilesDigestWithChangeset(repoDir string, changeset *repositorychangeset.Changeset, files []string, stageName string, submodules bool) (string, error) {
-	digests, err := changeset.DigestRegularFilesFromBaseWithOptions(strings.TrimSpace(repoDir), files, repositorychangeset.DigestPathsOptions{Submodules: submodules})
+func stageInputFilesDigestWithChangeset(ctx context.Context, repoDir string, changeset *repositorychangeset.Changeset, files []string, stageName string, parentRemoteURL string, submodules bool, store repositorystore.RepositoryStore) (string, error) {
+	opts := repositorychangeset.DigestPathsOptions{
+		Submodules:      submodules,
+		ParentRemoteURL: parentRemoteURL,
+	}
+	if submodules && store != nil {
+		opts.EnsureSubmoduleMirror = func(ctx context.Context, url, sha string) (string, error) {
+			return store.EnsureSubmoduleMirror(ctx, url, sha)
+		}
+	}
+	digests, err := changeset.DigestRegularFilesFromBaseWithOptions(strings.TrimSpace(repoDir), files, opts)
 	if err != nil {
 		return "", fmt.Errorf("read %s input files from repository changeset: %w", stageName, err)
 	}

--- a/internal/controlservice/dependency_stage.go
+++ b/internal/controlservice/dependency_stage.go
@@ -155,7 +155,7 @@ func (s *Service) stageKeyFilesDigest(ctx context.Context, repository *repositor
 			return commitBundle.WithRepository(ctx, repoDir, func(bundleRepoDir string) error {
 				var err error
 				if changeset != nil {
-					digest, err = stageKeyFilesDigestWithChangeset(bundleRepoDir, changeset, files, stageName)
+					digest, err = stageKeyFilesDigestWithChangeset(bundleRepoDir, changeset, files, stageName, repository.Submodules)
 				} else {
 					digest, err = stageKeyFilesDigestAtCommit(ctx, bundleRepoDir, repository.RemoteURL, repository.CommitSHA, files, stageName, repository.Submodules, s.RepositoryStore)
 				}
@@ -171,7 +171,7 @@ func (s *Service) stageKeyFilesDigest(ctx context.Context, repository *repositor
 		var digest string
 		err := s.RepositoryStore.WithRepository(ctx, repository.RemoteURL, repository.CommitSHA, repositorystore.FetchHints{}, func(repoDir string) error {
 			var err error
-			digest, err = stageKeyFilesDigestWithChangeset(repoDir, changeset, files, stageName)
+			digest, err = stageKeyFilesDigestWithChangeset(repoDir, changeset, files, stageName, repository.Submodules)
 			return err
 		})
 		if err != nil {
@@ -211,7 +211,7 @@ func (s *Service) stageInputFilesDigest(ctx context.Context, repository *reposit
 			return commitBundle.WithRepository(ctx, repoDir, func(bundleRepoDir string) error {
 				var err error
 				if changeset != nil {
-					digest, err = stageInputFilesDigestWithChangeset(bundleRepoDir, changeset, files, stageName)
+					digest, err = stageInputFilesDigestWithChangeset(bundleRepoDir, changeset, files, stageName, repository.Submodules)
 				} else {
 					digest, err = stageInputFilesDigestAtCommit(ctx, bundleRepoDir, repository.RemoteURL, repository.CommitSHA, files, stageName, repository.Submodules, s.RepositoryStore)
 				}
@@ -227,7 +227,7 @@ func (s *Service) stageInputFilesDigest(ctx context.Context, repository *reposit
 		var digest string
 		err := s.RepositoryStore.WithRepository(ctx, repository.RemoteURL, repository.CommitSHA, repositorystore.FetchHints{}, func(repoDir string) error {
 			var err error
-			digest, err = stageInputFilesDigestWithChangeset(repoDir, changeset, files, stageName)
+			digest, err = stageInputFilesDigestWithChangeset(repoDir, changeset, files, stageName, repository.Submodules)
 			return err
 		})
 		if err != nil {
@@ -247,9 +247,9 @@ func (s *Service) stageInputFilesDigest(ctx context.Context, repository *reposit
 	return digest, nil
 }
 
-func stageKeyFilesDigestWithChangeset(repoDir string, changeset *repositorychangeset.Changeset, files []string, stageName string) (string, error) {
+func stageKeyFilesDigestWithChangeset(repoDir string, changeset *repositorychangeset.Changeset, files []string, stageName string, submodules bool) (string, error) {
 	manifest := make([]stageKeyFileDigest, 0, len(files))
-	digests, err := changeset.DigestPathsFromBase(strings.TrimSpace(repoDir), files)
+	digests, err := changeset.DigestPathsFromBaseWithOptions(strings.TrimSpace(repoDir), files, repositorychangeset.DigestPathsOptions{Submodules: submodules})
 	if err != nil {
 		return "", fmt.Errorf("read %s key files from repository changeset: %w", stageName, err)
 	}
@@ -270,8 +270,8 @@ func stageKeyFilesDigestWithChangeset(repoDir string, changeset *repositorychang
 	return "sha256:" + hex.EncodeToString(sum[:]), nil
 }
 
-func stageInputFilesDigestWithChangeset(repoDir string, changeset *repositorychangeset.Changeset, files []string, stageName string) (string, error) {
-	digests, err := changeset.DigestRegularFilesFromBase(strings.TrimSpace(repoDir), files)
+func stageInputFilesDigestWithChangeset(repoDir string, changeset *repositorychangeset.Changeset, files []string, stageName string, submodules bool) (string, error) {
+	digests, err := changeset.DigestRegularFilesFromBaseWithOptions(strings.TrimSpace(repoDir), files, repositorychangeset.DigestPathsOptions{Submodules: submodules})
 	if err != nil {
 		return "", fmt.Errorf("read %s input files from repository changeset: %w", stageName, err)
 	}

--- a/internal/controlservice/dependency_stage.go
+++ b/internal/controlservice/dependency_stage.go
@@ -295,15 +295,16 @@ func stageKeyFilesDigestAtCommit(ctx context.Context, repoDir, commitSHA string,
 		return "", err
 	}
 
+	digests, err := gitFileDigestsAtCommit(ctx, strings.TrimSpace(repoDir), trimmedCommitSHA, expandedFiles)
+	if err != nil {
+		return "", fmt.Errorf("read %s key files: %w", stageName, err)
+	}
+
 	manifest := make([]stageKeyFileDigest, 0, len(expandedFiles))
 	for _, file := range expandedFiles {
-		digest, err := gitFileDigestAtCommit(ctx, strings.TrimSpace(repoDir), trimmedCommitSHA, file)
-		if err != nil {
-			return "", fmt.Errorf("read %s key file %q: %w", stageName, file, err)
-		}
 		manifest = append(manifest, stageKeyFileDigest{
 			Path:   file,
-			SHA256: digest,
+			SHA256: digests[file],
 		})
 	}
 
@@ -326,26 +327,37 @@ func stageInputFilesDigestAtCommit(ctx context.Context, repoDir, commitSHA strin
 		return "", err
 	}
 
-	manifest := make([]stageInputFileDigest, 0, len(expandedFiles))
+	treeEntries, err := gitTreeEntriesForFiles(ctx, strings.TrimSpace(repoDir), trimmedCommitSHA, expandedFiles)
+	if err != nil {
+		return "", fmt.Errorf("inspect %s input files: %w", stageName, err)
+	}
+
+	regularFiles := make([]string, 0, len(expandedFiles))
+	entryByFile := make(map[string]gitTreeEntry, len(expandedFiles))
 	for _, file := range expandedFiles {
-		entry, ok, err := gitTreeEntryAtCommit(ctx, strings.TrimSpace(repoDir), trimmedCommitSHA, file)
-		if err != nil {
-			return "", fmt.Errorf("inspect %s input file %q: %w", stageName, file, err)
-		}
+		entry, ok := treeEntries[file]
 		if !ok {
 			return "", fmt.Errorf("%s input file %q does not exist", stageName, file)
 		}
 		if !isRegularGitTreeFile(entry) {
 			return "", fmt.Errorf("%s input file %q is %s; inputs.files must name regular files", stageName, file, gitTreeEntryKind(entry))
 		}
-		digest, err := gitFileDigestAtCommit(ctx, strings.TrimSpace(repoDir), trimmedCommitSHA, file)
-		if err != nil {
-			return "", fmt.Errorf("read %s input file %q: %w", stageName, file, err)
-		}
+		regularFiles = append(regularFiles, file)
+		entryByFile[file] = entry
+	}
+
+	digests, err := gitFileDigestsAtCommit(ctx, strings.TrimSpace(repoDir), trimmedCommitSHA, regularFiles)
+	if err != nil {
+		return "", fmt.Errorf("read %s input files: %w", stageName, err)
+	}
+
+	manifest := make([]stageInputFileDigest, 0, len(regularFiles))
+	for _, file := range regularFiles {
+		entry := entryByFile[file]
 		manifest = append(manifest, stageInputFileDigest{
 			Path:   file,
 			Mode:   entry.Mode,
-			SHA256: digest,
+			SHA256: digests[file],
 		})
 	}
 	return digestStageInputFileManifest(manifest, stageName)
@@ -430,55 +442,9 @@ func gitFilesAtCommit(ctx context.Context, repoDir, commitSHA string) ([]string,
 	return files, nil
 }
 
-func gitFileDigestAtCommit(ctx context.Context, repoDir, commitSHA, file string) (string, error) {
-	cmd := exec.CommandContext(ctx, "git", "-C", repoDir, "show", commitSHA+":"+file)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		message := strings.TrimSpace(string(output))
-		if message == "" {
-			message = err.Error()
-		}
-		return "", fmt.Errorf("%s", message)
-	}
-
-	sum := sha256.Sum256(output)
-	return "sha256:" + hex.EncodeToString(sum[:]), nil
-}
-
 type gitTreeEntry struct {
 	Mode string
 	Type string
-}
-
-func gitTreeEntryAtCommit(ctx context.Context, repoDir, commitSHA, file string) (gitTreeEntry, bool, error) {
-	cmd := exec.CommandContext(ctx, "git", "-C", repoDir, "ls-tree", "-z", commitSHA, "--", literalStageGitPathspec(file))
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		message := strings.TrimSpace(string(output))
-		if message == "" {
-			message = err.Error()
-		}
-		return gitTreeEntry{}, false, fmt.Errorf("%s", message)
-	}
-	output = bytes.TrimRight(output, "\x00")
-	if len(bytes.TrimSpace(output)) == 0 {
-		return gitTreeEntry{}, false, nil
-	}
-	for _, raw := range bytes.Split(output, []byte{0}) {
-		metadata, rawPath, ok := bytes.Cut(raw, []byte{'\t'})
-		if !ok {
-			return gitTreeEntry{}, false, fmt.Errorf("parse git tree entry %q", string(raw))
-		}
-		if path.Clean(strings.ReplaceAll(string(rawPath), "\\", "/")) != file {
-			continue
-		}
-		fields := strings.Fields(string(metadata))
-		if len(fields) < 3 {
-			return gitTreeEntry{}, false, fmt.Errorf("parse git tree entry %q", string(raw))
-		}
-		return gitTreeEntry{Mode: fields[0], Type: fields[1]}, true, nil
-	}
-	return gitTreeEntry{}, false, nil
 }
 
 func isRegularGitTreeFile(entry gitTreeEntry) bool {

--- a/internal/controlservice/dependency_stage.go
+++ b/internal/controlservice/dependency_stage.go
@@ -157,7 +157,7 @@ func (s *Service) stageKeyFilesDigest(ctx context.Context, repository *repositor
 				if changeset != nil {
 					digest, err = stageKeyFilesDigestWithChangeset(bundleRepoDir, changeset, files, stageName)
 				} else {
-					digest, err = stageKeyFilesDigestAtCommit(ctx, bundleRepoDir, repository.CommitSHA, files, stageName, repository.Submodules, s.RepositoryStore)
+					digest, err = stageKeyFilesDigestAtCommit(ctx, bundleRepoDir, repository.RemoteURL, repository.CommitSHA, files, stageName, repository.Submodules, s.RepositoryStore)
 				}
 				return err
 			})
@@ -182,7 +182,7 @@ func (s *Service) stageKeyFilesDigest(ctx context.Context, repository *repositor
 	var digest string
 	err := s.RepositoryStore.WithRepository(ctx, repository.RemoteURL, repository.CommitSHA, repositorystore.FetchHints{}, func(repoDir string) error {
 		var err error
-		digest, err = stageKeyFilesDigestAtCommit(ctx, repoDir, repository.CommitSHA, files, stageName, repository.Submodules, s.RepositoryStore)
+		digest, err = stageKeyFilesDigestAtCommit(ctx, repoDir, repository.RemoteURL, repository.CommitSHA, files, stageName, repository.Submodules, s.RepositoryStore)
 		return err
 	})
 	if err != nil {
@@ -213,7 +213,7 @@ func (s *Service) stageInputFilesDigest(ctx context.Context, repository *reposit
 				if changeset != nil {
 					digest, err = stageInputFilesDigestWithChangeset(bundleRepoDir, changeset, files, stageName)
 				} else {
-					digest, err = stageInputFilesDigestAtCommit(ctx, bundleRepoDir, repository.CommitSHA, files, stageName, repository.Submodules, s.RepositoryStore)
+					digest, err = stageInputFilesDigestAtCommit(ctx, bundleRepoDir, repository.RemoteURL, repository.CommitSHA, files, stageName, repository.Submodules, s.RepositoryStore)
 				}
 				return err
 			})
@@ -238,7 +238,7 @@ func (s *Service) stageInputFilesDigest(ctx context.Context, repository *reposit
 	var digest string
 	err := s.RepositoryStore.WithRepository(ctx, repository.RemoteURL, repository.CommitSHA, repositorystore.FetchHints{}, func(repoDir string) error {
 		var err error
-		digest, err = stageInputFilesDigestAtCommit(ctx, repoDir, repository.CommitSHA, files, stageName, repository.Submodules, s.RepositoryStore)
+		digest, err = stageInputFilesDigestAtCommit(ctx, repoDir, repository.RemoteURL, repository.CommitSHA, files, stageName, repository.Submodules, s.RepositoryStore)
 		return err
 	})
 	if err != nil {
@@ -286,7 +286,7 @@ func stageInputFilesDigestWithChangeset(repoDir string, changeset *repositorycha
 	return digestStageInputFileManifest(manifest, stageName)
 }
 
-func stageKeyFilesDigestAtCommit(ctx context.Context, repoDir, commitSHA string, files []string, stageName string, submodules bool, store repositorystore.RepositoryStore) (string, error) {
+func stageKeyFilesDigestAtCommit(ctx context.Context, repoDir, parentRemoteURL, commitSHA string, files []string, stageName string, submodules bool, store repositorystore.RepositoryStore) (string, error) {
 	trimmedCommitSHA := strings.TrimSpace(commitSHA)
 	if trimmedCommitSHA == "" {
 		return "", fmt.Errorf("%s key file commit SHA is empty", stageName)
@@ -295,7 +295,7 @@ func stageKeyFilesDigestAtCommit(ctx context.Context, repoDir, commitSHA string,
 	var mirrorSubs []submodule.MirrorSubmodule
 	if submodules && store != nil {
 		var err error
-		mirrorSubs, err = submodule.ListMirrorSubmodulesAtCommit(ctx, repoDir, trimmedCommitSHA, func(ctx context.Context, url, sha string) (string, error) {
+		mirrorSubs, err = submodule.ListMirrorSubmodulesAtCommit(ctx, repoDir, parentRemoteURL, trimmedCommitSHA, func(ctx context.Context, url, sha string) (string, error) {
 			return store.EnsureSubmoduleMirror(ctx, url, sha)
 		})
 		if err != nil {
@@ -375,7 +375,7 @@ func stageKeyFilesDigestAtCommit(ctx context.Context, repoDir, commitSHA string,
 	return "sha256:" + hex.EncodeToString(sum[:]), nil
 }
 
-func stageInputFilesDigestAtCommit(ctx context.Context, repoDir, commitSHA string, files []string, stageName string, submodules bool, store repositorystore.RepositoryStore) (string, error) {
+func stageInputFilesDigestAtCommit(ctx context.Context, repoDir, parentRemoteURL, commitSHA string, files []string, stageName string, submodules bool, store repositorystore.RepositoryStore) (string, error) {
 	trimmedCommitSHA := strings.TrimSpace(commitSHA)
 	if trimmedCommitSHA == "" {
 		return "", fmt.Errorf("%s input file commit SHA is empty", stageName)
@@ -384,7 +384,7 @@ func stageInputFilesDigestAtCommit(ctx context.Context, repoDir, commitSHA strin
 	var mirrorSubs []submodule.MirrorSubmodule
 	if submodules && store != nil {
 		var err error
-		mirrorSubs, err = submodule.ListMirrorSubmodulesAtCommit(ctx, repoDir, trimmedCommitSHA, func(ctx context.Context, url, sha string) (string, error) {
+		mirrorSubs, err = submodule.ListMirrorSubmodulesAtCommit(ctx, repoDir, parentRemoteURL, trimmedCommitSHA, func(ctx context.Context, url, sha string) (string, error) {
 			return store.EnsureSubmoduleMirror(ctx, url, sha)
 		})
 		if err != nil {

--- a/internal/controlservice/dependency_stage.go
+++ b/internal/controlservice/dependency_stage.go
@@ -320,6 +320,18 @@ func stageKeyFilesDigestAtCommit(ctx context.Context, repoDir, commitSHA string,
 		subFiles[sm.Path] = append(subFiles[sm.Path], stripped)
 	}
 
+	if len(parentFiles) > 0 {
+		parentEntries, err := gitTreeEntriesForFiles(ctx, strings.TrimSpace(repoDir), trimmedCommitSHA, parentFiles)
+		if err != nil {
+			return "", fmt.Errorf("inspect %s key files: %w", stageName, err)
+		}
+		for _, file := range parentFiles {
+			if entry, ok := parentEntries[file]; ok && entry.Mode == "160000" {
+				return "", fmt.Errorf("%s key file %q is a gitlink; inputs.files must name regular files", stageName, file)
+			}
+		}
+	}
+
 	allDigests := make(map[string]string, len(expandedFiles))
 
 	if len(parentFiles) > 0 {
@@ -543,6 +555,15 @@ func expandStageKeyFilesAtCommit(ctx context.Context, repoDir, commitSHA string,
 			expanded = append(expanded, candidate)
 		}
 		if matches == 0 {
+			if len(mirrorSubs) == 0 {
+				if gitlinkPaths, glErr := gitGitlinkPathsAtCommit(ctx, repoDir, commitSHA); glErr == nil {
+					for _, glPath := range gitlinkPaths {
+						if strings.HasPrefix(file, glPath+"/") {
+							return nil, fmt.Errorf("%s key file glob %q is inside submodule %q; enable repository.submodules to digest submodule contents", stageName, file, glPath)
+						}
+					}
+				}
+			}
 			return nil, fmt.Errorf("%s key file glob %q matched no files", stageName, file)
 		}
 	}
@@ -570,6 +591,36 @@ func gitFilesAtCommit(ctx context.Context, repoDir, commitSHA string) ([]string,
 	}
 	sort.Strings(files)
 	return files, nil
+}
+
+func gitGitlinkPathsAtCommit(ctx context.Context, repoDir, commitSHA string) ([]string, error) {
+	cmd := exec.CommandContext(ctx, "git", "-C", repoDir, "ls-tree", "-r", "-z", commitSHA)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		message := strings.TrimSpace(string(output))
+		if message == "" {
+			message = err.Error()
+		}
+		return nil, fmt.Errorf("%s", message)
+	}
+	var paths []string
+	for _, raw := range bytes.Split(output, []byte{0}) {
+		if len(bytes.TrimSpace(raw)) == 0 {
+			continue
+		}
+		metadata, rawPath, ok := bytes.Cut(raw, []byte{'\t'})
+		if !ok {
+			continue
+		}
+		fields := strings.Fields(string(metadata))
+		if len(fields) < 2 {
+			continue
+		}
+		if fields[0] == "160000" {
+			paths = append(paths, string(rawPath))
+		}
+	}
+	return paths, nil
 }
 
 type gitTreeEntry struct {

--- a/internal/controlservice/dependency_stage.go
+++ b/internal/controlservice/dependency_stage.go
@@ -464,10 +464,6 @@ func gitTreeEntryKind(entry gitTreeEntry) string {
 	}
 }
 
-func literalStageGitPathspec(normalizedPath string) string {
-	return ":(literal)" + normalizedPath
-}
-
 func (s *Service) lookupDependencyStageCache(ctx context.Context, backendName string, compiled *policy.CompiledPolicy, repository *repositorycheckout.Checkout, changeset *repositorychangeset.Changeset, plan dependencyStagePlan) (cachestore.Record, bool, string, error) {
 	if compiled == nil || repository == nil || strings.TrimSpace(plan.CacheKey) == "" {
 		return cachestore.Record{}, false, "", nil

--- a/internal/controlservice/dependency_stage.go
+++ b/internal/controlservice/dependency_stage.go
@@ -23,6 +23,7 @@ import (
 	"github.com/buildkite/cleanroom/internal/repositorychangeset"
 	"github.com/buildkite/cleanroom/internal/repositorycheckout"
 	"github.com/buildkite/cleanroom/internal/repositorystore"
+	"github.com/buildkite/cleanroom/internal/submodule"
 )
 
 const (
@@ -156,7 +157,7 @@ func (s *Service) stageKeyFilesDigest(ctx context.Context, repository *repositor
 				if changeset != nil {
 					digest, err = stageKeyFilesDigestWithChangeset(bundleRepoDir, changeset, files, stageName)
 				} else {
-					digest, err = stageKeyFilesDigestAtCommit(ctx, bundleRepoDir, repository.CommitSHA, files, stageName)
+					digest, err = stageKeyFilesDigestAtCommit(ctx, bundleRepoDir, repository.CommitSHA, files, stageName, repository.Submodules, s.RepositoryStore)
 				}
 				return err
 			})
@@ -181,7 +182,7 @@ func (s *Service) stageKeyFilesDigest(ctx context.Context, repository *repositor
 	var digest string
 	err := s.RepositoryStore.WithRepository(ctx, repository.RemoteURL, repository.CommitSHA, repositorystore.FetchHints{}, func(repoDir string) error {
 		var err error
-		digest, err = stageKeyFilesDigestAtCommit(ctx, repoDir, repository.CommitSHA, files, stageName)
+		digest, err = stageKeyFilesDigestAtCommit(ctx, repoDir, repository.CommitSHA, files, stageName, repository.Submodules, s.RepositoryStore)
 		return err
 	})
 	if err != nil {
@@ -212,7 +213,7 @@ func (s *Service) stageInputFilesDigest(ctx context.Context, repository *reposit
 				if changeset != nil {
 					digest, err = stageInputFilesDigestWithChangeset(bundleRepoDir, changeset, files, stageName)
 				} else {
-					digest, err = stageInputFilesDigestAtCommit(ctx, bundleRepoDir, repository.CommitSHA, files, stageName)
+					digest, err = stageInputFilesDigestAtCommit(ctx, bundleRepoDir, repository.CommitSHA, files, stageName, repository.Submodules, s.RepositoryStore)
 				}
 				return err
 			})
@@ -237,7 +238,7 @@ func (s *Service) stageInputFilesDigest(ctx context.Context, repository *reposit
 	var digest string
 	err := s.RepositoryStore.WithRepository(ctx, repository.RemoteURL, repository.CommitSHA, repositorystore.FetchHints{}, func(repoDir string) error {
 		var err error
-		digest, err = stageInputFilesDigestAtCommit(ctx, repoDir, repository.CommitSHA, files, stageName)
+		digest, err = stageInputFilesDigestAtCommit(ctx, repoDir, repository.CommitSHA, files, stageName, repository.Submodules, s.RepositoryStore)
 		return err
 	})
 	if err != nil {
@@ -285,26 +286,71 @@ func stageInputFilesDigestWithChangeset(repoDir string, changeset *repositorycha
 	return digestStageInputFileManifest(manifest, stageName)
 }
 
-func stageKeyFilesDigestAtCommit(ctx context.Context, repoDir, commitSHA string, files []string, stageName string) (string, error) {
+func stageKeyFilesDigestAtCommit(ctx context.Context, repoDir, commitSHA string, files []string, stageName string, submodules bool, store repositorystore.RepositoryStore) (string, error) {
 	trimmedCommitSHA := strings.TrimSpace(commitSHA)
 	if trimmedCommitSHA == "" {
 		return "", fmt.Errorf("%s key file commit SHA is empty", stageName)
 	}
-	expandedFiles, err := expandStageKeyFilesAtCommit(ctx, repoDir, trimmedCommitSHA, files, stageName)
+
+	var mirrorSubs []submodule.MirrorSubmodule
+	if submodules && store != nil {
+		var err error
+		mirrorSubs, err = submodule.ListMirrorSubmodulesAtCommit(ctx, repoDir, trimmedCommitSHA, func(ctx context.Context, url, sha string) (string, error) {
+			return store.EnsureSubmoduleMirror(ctx, url, sha)
+		})
+		if err != nil {
+			return "", fmt.Errorf("load submodule mirrors: %w", err)
+		}
+	}
+
+	expandedFiles, err := expandStageKeyFilesAtCommit(ctx, repoDir, trimmedCommitSHA, files, stageName, mirrorSubs)
 	if err != nil {
 		return "", err
 	}
 
-	digests, err := gitFileDigestsAtCommit(ctx, strings.TrimSpace(repoDir), trimmedCommitSHA, expandedFiles)
-	if err != nil {
-		return "", fmt.Errorf("read %s key files: %w", stageName, err)
+	var parentFiles []string
+	subFiles := map[string][]string{}
+	for _, f := range expandedFiles {
+		sm, ok := submodule.FindMirrorSubmoduleForPath(f, mirrorSubs)
+		if !ok {
+			parentFiles = append(parentFiles, f)
+			continue
+		}
+		stripped := strings.TrimPrefix(f, sm.Path+"/")
+		subFiles[sm.Path] = append(subFiles[sm.Path], stripped)
+	}
+
+	allDigests := make(map[string]string, len(expandedFiles))
+
+	if len(parentFiles) > 0 {
+		parentDigests, err := gitFileDigestsAtCommit(ctx, strings.TrimSpace(repoDir), trimmedCommitSHA, parentFiles)
+		if err != nil {
+			return "", fmt.Errorf("read %s key files: %w", stageName, err)
+		}
+		for k, v := range parentDigests {
+			allDigests[k] = v
+		}
+	}
+
+	for _, sm := range mirrorSubs {
+		stripped := subFiles[sm.Path]
+		if len(stripped) == 0 {
+			continue
+		}
+		subDigests, err := gitFileDigestsAtCommit(ctx, sm.MirrorDir, sm.GitlinkSHA, stripped)
+		if err != nil {
+			return "", fmt.Errorf("read %s key files in submodule %q: %w", stageName, sm.Path, err)
+		}
+		for k, v := range subDigests {
+			allDigests[sm.Path+"/"+k] = v
+		}
 	}
 
 	manifest := make([]stageKeyFileDigest, 0, len(expandedFiles))
 	for _, file := range expandedFiles {
 		manifest = append(manifest, stageKeyFileDigest{
 			Path:   file,
-			SHA256: digests[file],
+			SHA256: allDigests[file],
 		})
 	}
 
@@ -317,38 +363,109 @@ func stageKeyFilesDigestAtCommit(ctx context.Context, repoDir, commitSHA string,
 	return "sha256:" + hex.EncodeToString(sum[:]), nil
 }
 
-func stageInputFilesDigestAtCommit(ctx context.Context, repoDir, commitSHA string, files []string, stageName string) (string, error) {
+func stageInputFilesDigestAtCommit(ctx context.Context, repoDir, commitSHA string, files []string, stageName string, submodules bool, store repositorystore.RepositoryStore) (string, error) {
 	trimmedCommitSHA := strings.TrimSpace(commitSHA)
 	if trimmedCommitSHA == "" {
 		return "", fmt.Errorf("%s input file commit SHA is empty", stageName)
 	}
-	expandedFiles, err := expandStageKeyFilesAtCommit(ctx, repoDir, trimmedCommitSHA, files, stageName)
+
+	var mirrorSubs []submodule.MirrorSubmodule
+	if submodules && store != nil {
+		var err error
+		mirrorSubs, err = submodule.ListMirrorSubmodulesAtCommit(ctx, repoDir, trimmedCommitSHA, func(ctx context.Context, url, sha string) (string, error) {
+			return store.EnsureSubmoduleMirror(ctx, url, sha)
+		})
+		if err != nil {
+			return "", fmt.Errorf("load submodule mirrors: %w", err)
+		}
+	}
+
+	expandedFiles, err := expandStageKeyFilesAtCommit(ctx, repoDir, trimmedCommitSHA, files, stageName, mirrorSubs)
 	if err != nil {
 		return "", err
 	}
 
-	treeEntries, err := gitTreeEntriesForFiles(ctx, strings.TrimSpace(repoDir), trimmedCommitSHA, expandedFiles)
-	if err != nil {
-		return "", fmt.Errorf("inspect %s input files: %w", stageName, err)
+	var parentFiles []string
+	subFiles := map[string][]string{}
+	for _, f := range expandedFiles {
+		sm, ok := submodule.FindMirrorSubmoduleForPath(f, mirrorSubs)
+		if !ok {
+			parentFiles = append(parentFiles, f)
+			continue
+		}
+		stripped := strings.TrimPrefix(f, sm.Path+"/")
+		subFiles[sm.Path] = append(subFiles[sm.Path], stripped)
+	}
+
+	entryByFile := make(map[string]gitTreeEntry, len(expandedFiles))
+
+	if len(parentFiles) > 0 {
+		treeEntries, err := gitTreeEntriesForFiles(ctx, strings.TrimSpace(repoDir), trimmedCommitSHA, parentFiles)
+		if err != nil {
+			return "", fmt.Errorf("inspect %s input files: %w", stageName, err)
+		}
+		for _, file := range parentFiles {
+			entry, ok := treeEntries[file]
+			if !ok {
+				return "", fmt.Errorf("%s input file %q does not exist", stageName, file)
+			}
+			if !isRegularGitTreeFile(entry) {
+				return "", fmt.Errorf("%s input file %q is %s; inputs.files must name regular files", stageName, file, gitTreeEntryKind(entry))
+			}
+			entryByFile[file] = entry
+		}
+	}
+
+	for _, sm := range mirrorSubs {
+		stripped := subFiles[sm.Path]
+		if len(stripped) == 0 {
+			continue
+		}
+		smEntries, err := gitTreeEntriesForFiles(ctx, sm.MirrorDir, sm.GitlinkSHA, stripped)
+		if err != nil {
+			return "", fmt.Errorf("inspect %s input files in submodule %q: %w", stageName, sm.Path, err)
+		}
+		for _, s := range stripped {
+			entry, ok := smEntries[s]
+			if !ok {
+				return "", fmt.Errorf("%s input file %q does not exist", stageName, sm.Path+"/"+s)
+			}
+			if !isRegularGitTreeFile(entry) {
+				return "", fmt.Errorf("%s input file %q is %s; inputs.files must name regular files", stageName, sm.Path+"/"+s, gitTreeEntryKind(entry))
+			}
+			entryByFile[sm.Path+"/"+s] = entry
+		}
 	}
 
 	regularFiles := make([]string, 0, len(expandedFiles))
-	entryByFile := make(map[string]gitTreeEntry, len(expandedFiles))
 	for _, file := range expandedFiles {
-		entry, ok := treeEntries[file]
-		if !ok {
-			return "", fmt.Errorf("%s input file %q does not exist", stageName, file)
-		}
-		if !isRegularGitTreeFile(entry) {
-			return "", fmt.Errorf("%s input file %q is %s; inputs.files must name regular files", stageName, file, gitTreeEntryKind(entry))
-		}
 		regularFiles = append(regularFiles, file)
-		entryByFile[file] = entry
 	}
 
-	digests, err := gitFileDigestsAtCommit(ctx, strings.TrimSpace(repoDir), trimmedCommitSHA, regularFiles)
-	if err != nil {
-		return "", fmt.Errorf("read %s input files: %w", stageName, err)
+	allDigests := make(map[string]string, len(regularFiles))
+
+	if len(parentFiles) > 0 {
+		parentDigests, err := gitFileDigestsAtCommit(ctx, strings.TrimSpace(repoDir), trimmedCommitSHA, parentFiles)
+		if err != nil {
+			return "", fmt.Errorf("read %s input files: %w", stageName, err)
+		}
+		for k, v := range parentDigests {
+			allDigests[k] = v
+		}
+	}
+
+	for _, sm := range mirrorSubs {
+		stripped := subFiles[sm.Path]
+		if len(stripped) == 0 {
+			continue
+		}
+		subDigests, err := gitFileDigestsAtCommit(ctx, sm.MirrorDir, sm.GitlinkSHA, stripped)
+		if err != nil {
+			return "", fmt.Errorf("read %s input files in submodule %q: %w", stageName, sm.Path, err)
+		}
+		for k, v := range subDigests {
+			allDigests[sm.Path+"/"+k] = v
+		}
 	}
 
 	manifest := make([]stageInputFileDigest, 0, len(regularFiles))
@@ -357,7 +474,7 @@ func stageInputFilesDigestAtCommit(ctx context.Context, repoDir, commitSHA strin
 		manifest = append(manifest, stageInputFileDigest{
 			Path:   file,
 			Mode:   entry.Mode,
-			SHA256: digests[file],
+			SHA256: allDigests[file],
 		})
 	}
 	return digestStageInputFileManifest(manifest, stageName)
@@ -372,10 +489,10 @@ func digestStageInputFileManifest(manifest []stageInputFileDigest, stageName str
 	return "sha256:" + hex.EncodeToString(sum[:]), nil
 }
 
-func expandStageKeyFilesAtCommit(ctx context.Context, repoDir, commitSHA string, files []string, stageName string) ([]string, error) {
+func expandStageKeyFilesAtCommit(ctx context.Context, repoDir, commitSHA string, files []string, stageName string, mirrorSubs []submodule.MirrorSubmodule) ([]string, error) {
 	seen := make(map[string]struct{}, len(files))
 	var expanded []string
-	var treeFiles []string
+	var candidates []string
 	for _, file := range files {
 		file = strings.TrimSpace(file)
 		if !strings.ContainsAny(file, "*?[") {
@@ -389,15 +506,33 @@ func expandStageKeyFilesAtCommit(ctx context.Context, repoDir, commitSHA string,
 		if !doublestar.ValidatePattern(file) {
 			return nil, fmt.Errorf("%s key file glob %q is invalid: %w", stageName, file, path.ErrBadPattern)
 		}
-		if treeFiles == nil {
-			var err error
-			treeFiles, err = gitFilesAtCommit(ctx, repoDir, commitSHA)
+		if candidates == nil {
+			parentFiles, err := gitFilesAtCommit(ctx, repoDir, commitSHA)
 			if err != nil {
 				return nil, fmt.Errorf("list %s key files at commit: %w", stageName, err)
 			}
+			gitlinkPaths := make(map[string]struct{}, len(mirrorSubs))
+			for _, sm := range mirrorSubs {
+				gitlinkPaths[sm.Path] = struct{}{}
+			}
+			candidates = make([]string, 0, len(parentFiles))
+			for _, f := range parentFiles {
+				if _, isGitlink := gitlinkPaths[f]; isGitlink {
+					continue
+				}
+				candidates = append(candidates, f)
+			}
+			for _, sm := range mirrorSubs {
+				smFiles, err := submodule.ListMirrorSubmoduleFilesAtSHA(ctx, sm)
+				if err != nil {
+					return nil, fmt.Errorf("list submodule %q files: %w", sm.Path, err)
+				}
+				candidates = append(candidates, smFiles...)
+			}
+			sort.Strings(candidates)
 		}
 		matches := 0
-		for _, candidate := range treeFiles {
+		for _, candidate := range candidates {
 			matched, err := doublestar.Match(file, candidate)
 			if err != nil {
 				return nil, fmt.Errorf("%s key file glob %q is invalid: %w", stageName, file, err)

--- a/internal/controlservice/dependency_stage.go
+++ b/internal/controlservice/dependency_stage.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/bmatcuk/doublestar/v4"
 	"github.com/buildkite/cleanroom/internal/backend"
 	"github.com/buildkite/cleanroom/internal/cachekey"
 	"github.com/buildkite/cleanroom/internal/cachestore"
@@ -373,8 +374,8 @@ func expandStageKeyFilesAtCommit(ctx context.Context, repoDir, commitSHA string,
 			expanded = append(expanded, file)
 			continue
 		}
-		if _, err := path.Match(file, ""); err != nil {
-			return nil, fmt.Errorf("%s key file glob %q is invalid: %w", stageName, file, err)
+		if !doublestar.ValidatePattern(file) {
+			return nil, fmt.Errorf("%s key file glob %q is invalid: %w", stageName, file, path.ErrBadPattern)
 		}
 		if treeFiles == nil {
 			var err error
@@ -385,7 +386,7 @@ func expandStageKeyFilesAtCommit(ctx context.Context, repoDir, commitSHA string,
 		}
 		matches := 0
 		for _, candidate := range treeFiles {
-			matched, err := path.Match(file, candidate)
+			matched, err := doublestar.Match(file, candidate)
 			if err != nil {
 				return nil, fmt.Errorf("%s key file glob %q is invalid: %w", stageName, file, err)
 			}

--- a/internal/controlservice/dependency_stage.go
+++ b/internal/controlservice/dependency_stage.go
@@ -437,12 +437,7 @@ func stageInputFilesDigestAtCommit(ctx context.Context, repoDir, commitSHA strin
 		}
 	}
 
-	regularFiles := make([]string, 0, len(expandedFiles))
-	for _, file := range expandedFiles {
-		regularFiles = append(regularFiles, file)
-	}
-
-	allDigests := make(map[string]string, len(regularFiles))
+	allDigests := make(map[string]string, len(expandedFiles))
 
 	if len(parentFiles) > 0 {
 		parentDigests, err := gitFileDigestsAtCommit(ctx, strings.TrimSpace(repoDir), trimmedCommitSHA, parentFiles)
@@ -468,8 +463,8 @@ func stageInputFilesDigestAtCommit(ctx context.Context, repoDir, commitSHA strin
 		}
 	}
 
-	manifest := make([]stageInputFileDigest, 0, len(regularFiles))
-	for _, file := range regularFiles {
+	manifest := make([]stageInputFileDigest, 0, len(expandedFiles))
+	for _, file := range expandedFiles {
 		entry := entryByFile[file]
 		manifest = append(manifest, stageInputFileDigest{
 			Path:   file,

--- a/internal/controlservice/dependency_stage_test.go
+++ b/internal/controlservice/dependency_stage_test.go
@@ -303,3 +303,35 @@ func TestStageInputFilesDigestAtCommitRejectsGitlinkLiteral(t *testing.T) {
 		t.Fatalf("expected gitlink error, got %v", err)
 	}
 }
+
+func TestStageKeyFilesDigestAtCommitRejectsGitlinkLiteral(t *testing.T) {
+	superDir, _, superMirror, subMirror := initControlServiceGitRepoWithSubmodule(t)
+	commitSHA := headControlServiceCommit(t, superDir)
+
+	runControlServiceGit(t, superMirror, "fetch", "--all")
+
+	store := &testSubmoduleStore{mirrorDir: subMirror}
+
+	_, err := stageKeyFilesDigestAtCommit(context.Background(), superMirror, commitSHA, []string{"vendor/emojis"}, "dependency", true, store)
+	if err == nil {
+		t.Fatal("expected error for gitlink literal")
+	}
+	if !strings.Contains(err.Error(), "is a gitlink") {
+		t.Fatalf("expected gitlink error, got %v", err)
+	}
+}
+
+func TestStageKeyFilesDigestAtCommitOptInErrorForSubmoduleGlob(t *testing.T) {
+	superDir, _, superMirror, _ := initControlServiceGitRepoWithSubmodule(t)
+	commitSHA := headControlServiceCommit(t, superDir)
+
+	runControlServiceGit(t, superMirror, "fetch", "--all")
+
+	_, err := stageKeyFilesDigestAtCommit(context.Background(), superMirror, commitSHA, []string{"vendor/emojis/**"}, "dependency", false, nil)
+	if err == nil {
+		t.Fatal("expected error for submodule glob with submodules disabled")
+	}
+	if !strings.Contains(err.Error(), "is inside submodule") && !strings.Contains(err.Error(), "matched no files") && !strings.Contains(err.Error(), "is a gitlink") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/controlservice/dependency_stage_test.go
+++ b/internal/controlservice/dependency_stage_test.go
@@ -261,6 +261,97 @@ func TestStageInputFilesDigestAtCommitMatchesChangesetPath(t *testing.T) {
 	}
 }
 
+func TestStageInputFilesDigestWithChangesetHonoursSubmodulesFlag(t *testing.T) {
+	superDir, subDir, _, _ := initControlServiceGitRepoWithSubmodule(t)
+
+	if err := os.WriteFile(filepath.Join(subDir, "emoji1.json"), []byte(`{"name":"smile"}`), 0o644); err != nil {
+		t.Fatalf("write emoji1.json: %v", err)
+	}
+	runControlServiceGit(t, subDir, "add", "emoji1.json")
+	runControlServiceGit(t, subDir, "commit", "-m", "add emoji")
+	runControlServiceGitWithEnv(t, superDir, []string{"GIT_ALLOW_PROTOCOL=file"}, "-c", "protocol.file.allow=always", "submodule", "update", "--remote", "vendor/emojis")
+	runControlServiceGit(t, superDir, "add", "vendor/emojis")
+	runControlServiceGit(t, superDir, "commit", "-m", "update submodule")
+	commitSHA := headControlServiceCommit(t, superDir)
+
+	if err := os.WriteFile(filepath.Join(superDir, "trigger.txt"), []byte("trigger changeset\n"), 0o644); err != nil {
+		t.Fatalf("write trigger.txt: %v", err)
+	}
+
+	checkout := &repositorycheckout.Checkout{
+		RemoteURL:      "https://github.com/buildkite/cleanroom.git",
+		CommitSHA:      commitSHA,
+		DestinationDir: "/workspace",
+		Submodules:     true,
+	}
+	changeset, err := repositorychangeset.BuildFromWorkingTree(superDir, checkout)
+	if err != nil {
+		t.Fatalf("BuildFromWorkingTree: %v", err)
+	}
+	if changeset == nil {
+		t.Fatal("expected changeset")
+	}
+
+	pattern := []string{"vendor/emojis/**"}
+
+	if _, err := stageInputFilesDigestWithChangeset(superDir, changeset, pattern, "test", false); err == nil {
+		t.Fatal("expected error when submodules disabled, got none")
+	}
+
+	digest, err := stageInputFilesDigestWithChangeset(superDir, changeset, pattern, "test", true)
+	if err != nil {
+		t.Fatalf("stageInputFilesDigestWithChangeset: %v", err)
+	}
+	if !strings.HasPrefix(digest, "sha256:") {
+		t.Fatalf("expected sha256 digest, got %q", digest)
+	}
+}
+
+func TestStageKeyFilesDigestWithChangesetHonoursSubmodulesFlag(t *testing.T) {
+	superDir, subDir, _, _ := initControlServiceGitRepoWithSubmodule(t)
+
+	if err := os.WriteFile(filepath.Join(subDir, "emoji1.json"), []byte(`{"name":"smile"}`), 0o644); err != nil {
+		t.Fatalf("write emoji1.json: %v", err)
+	}
+	runControlServiceGit(t, subDir, "add", "emoji1.json")
+	runControlServiceGit(t, subDir, "commit", "-m", "add emoji")
+	runControlServiceGitWithEnv(t, superDir, []string{"GIT_ALLOW_PROTOCOL=file"}, "-c", "protocol.file.allow=always", "submodule", "update", "--remote", "vendor/emojis")
+	runControlServiceGit(t, superDir, "add", "vendor/emojis")
+	runControlServiceGit(t, superDir, "commit", "-m", "update submodule")
+	commitSHA := headControlServiceCommit(t, superDir)
+
+	if err := os.WriteFile(filepath.Join(superDir, "trigger.txt"), []byte("trigger changeset\n"), 0o644); err != nil {
+		t.Fatalf("write trigger.txt: %v", err)
+	}
+
+	checkout := &repositorycheckout.Checkout{
+		RemoteURL:      "https://github.com/buildkite/cleanroom.git",
+		CommitSHA:      commitSHA,
+		DestinationDir: "/workspace",
+		Submodules:     true,
+	}
+	changeset, err := repositorychangeset.BuildFromWorkingTree(superDir, checkout)
+	if err != nil {
+		t.Fatalf("BuildFromWorkingTree: %v", err)
+	}
+	if changeset == nil {
+		t.Fatal("expected changeset")
+	}
+
+	pattern := []string{"vendor/emojis"}
+
+	if _, err := stageKeyFilesDigestWithChangeset(superDir, changeset, pattern, "dependency", false); err == nil {
+		t.Fatal("expected error when submodules disabled, got none")
+	}
+	digest, err := stageKeyFilesDigestWithChangeset(superDir, changeset, []string{"vendor/emojis/**"}, "dependency", true)
+	if err != nil {
+		t.Fatalf("stageKeyFilesDigestWithChangeset: %v", err)
+	}
+	if !strings.HasPrefix(digest, "sha256:") {
+		t.Fatalf("expected sha256 digest, got %q", digest)
+	}
+}
+
 func TestStageInputFilesDigestAtCommitNoGitmodulesAtCommit(t *testing.T) {
 	repoDir := initControlServiceGitRepo(t)
 	if err := os.MkdirAll(filepath.Join(repoDir, "src"), 0o755); err != nil {

--- a/internal/controlservice/dependency_stage_test.go
+++ b/internal/controlservice/dependency_stage_test.go
@@ -7,6 +7,10 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/buildkite/cleanroom/internal/repositorychangeset"
+	"github.com/buildkite/cleanroom/internal/repositorycheckout"
+	"github.com/buildkite/cleanroom/internal/repositorystore"
 )
 
 func TestExpandStageKeyFilesAtCommitDoublestarGlob(t *testing.T) {
@@ -24,7 +28,7 @@ func TestExpandStageKeyFilesAtCommitDoublestarGlob(t *testing.T) {
 	runControlServiceGit(t, repoDir, "commit", "-m", "add vendor files")
 	commitSHA := headControlServiceCommit(t, repoDir)
 
-	expanded, err := expandStageKeyFilesAtCommit(context.Background(), repoDir, commitSHA, []string{"vendor/**"}, "dependency")
+	expanded, err := expandStageKeyFilesAtCommit(context.Background(), repoDir, commitSHA, []string{"vendor/**"}, "dependency", nil)
 	if err != nil {
 		t.Fatalf("expandStageKeyFilesAtCommit returned error: %v", err)
 	}
@@ -44,7 +48,7 @@ func TestExpandStageKeyFilesAtCommitDoublestarGlobNoMatch(t *testing.T) {
 	repoDir := initControlServiceGitRepo(t)
 	commitSHA := headControlServiceCommit(t, repoDir)
 
-	_, err := expandStageKeyFilesAtCommit(context.Background(), repoDir, commitSHA, []string{"vendor/**"}, "dependency")
+	_, err := expandStageKeyFilesAtCommit(context.Background(), repoDir, commitSHA, []string{"vendor/**"}, "dependency", nil)
 	if err == nil {
 		t.Fatal("expected no-match error")
 	}
@@ -80,11 +84,222 @@ func headControlServiceCommit(t *testing.T, dir string) string {
 
 func runControlServiceGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
+	runControlServiceGitWithEnv(t, dir, nil, args...)
+}
+
+func runControlServiceGitWithEnv(t *testing.T, dir string, env []string, args ...string) {
+	t.Helper()
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir
-	cmd.Env = os.Environ()
+	cmd.Env = append(os.Environ(), env...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("git %v failed: %v\n%s", args, err, string(out))
+	}
+}
+
+func initControlServiceGitRepoWithSubmodule(t *testing.T) (superDir, subDir, superMirror, subMirror string) {
+	t.Helper()
+
+	subDir = t.TempDir()
+	runControlServiceGit(t, subDir, "init")
+	runControlServiceGit(t, subDir, "config", "user.name", "Cleanroom Test")
+	runControlServiceGit(t, subDir, "config", "user.email", "cleanroom-test@example.com")
+	if err := os.WriteFile(filepath.Join(subDir, "README.md"), []byte("submodule\n"), 0o644); err != nil {
+		t.Fatalf("write submodule README: %v", err)
+	}
+	runControlServiceGit(t, subDir, "add", "README.md")
+	runControlServiceGit(t, subDir, "commit", "-m", "initial submodule commit")
+
+	superDir = t.TempDir()
+	runControlServiceGit(t, superDir, "init")
+	runControlServiceGit(t, superDir, "config", "user.name", "Cleanroom Test")
+	runControlServiceGit(t, superDir, "config", "user.email", "cleanroom-test@example.com")
+	if err := os.WriteFile(filepath.Join(superDir, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("write super README: %v", err)
+	}
+	runControlServiceGit(t, superDir, "add", "README.md")
+	runControlServiceGit(t, superDir, "commit", "-m", "initial")
+	runControlServiceGitWithEnv(t, superDir, []string{"GIT_ALLOW_PROTOCOL=file"}, "-c", "protocol.file.allow=always", "submodule", "add", subDir, "vendor/emojis")
+	runControlServiceGit(t, superDir, "commit", "-m", "add submodule")
+
+	subMirror = t.TempDir()
+	runControlServiceGit(t, subMirror, "clone", "--mirror", subDir, subMirror)
+
+	superMirror = t.TempDir()
+	runControlServiceGit(t, superMirror, "clone", "--mirror", superDir, superMirror)
+
+	return superDir, subDir, superMirror, subMirror
+}
+
+type testSubmoduleStore struct {
+	mirrorDir string
+	calls     []testSubmoduleMirrorCall
+}
+
+type testSubmoduleMirrorCall struct {
+	URL string
+	SHA string
+}
+
+func (s *testSubmoduleStore) EnsureCommit(_ context.Context, _, _ string, _ repositorystore.FetchHints) error {
+	return nil
+}
+
+func (s *testSubmoduleStore) ReadFileAtCommit(_ context.Context, _, _, _ string) ([]byte, error) {
+	return nil, nil
+}
+
+func (s *testSubmoduleStore) WithRepository(_ context.Context, _, _ string, _ repositorystore.FetchHints, fn func(string) error) error {
+	return fn(s.mirrorDir)
+}
+
+func (s *testSubmoduleStore) TransportHints(_ context.Context, _, _ string, _ repositorystore.FetchHints) (repositorystore.TransportHints, error) {
+	return repositorystore.TransportHints{}, nil
+}
+
+func (s *testSubmoduleStore) EnsureSubmoduleMirror(_ context.Context, submoduleRemoteURL, gitlinkSHA string) (string, error) {
+	s.calls = append(s.calls, testSubmoduleMirrorCall{URL: submoduleRemoteURL, SHA: gitlinkSHA})
+	return s.mirrorDir, nil
+}
+
+func TestStageInputFilesDigestAtCommitDigestsSubmoduleFiles(t *testing.T) {
+	superDir, subDir, superMirror, subMirror := initControlServiceGitRepoWithSubmodule(t)
+
+	if err := os.WriteFile(filepath.Join(subDir, "emoji1.json"), []byte(`{"name":"smile"}`), 0o644); err != nil {
+		t.Fatalf("write emoji1.json: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(subDir, "emoji2.json"), []byte(`{"name":"wink"}`), 0o644); err != nil {
+		t.Fatalf("write emoji2.json: %v", err)
+	}
+	runControlServiceGit(t, subDir, "add", "emoji1.json", "emoji2.json")
+	runControlServiceGit(t, subDir, "commit", "-m", "add emojis")
+	runControlServiceGitWithEnv(t, superDir, []string{"GIT_ALLOW_PROTOCOL=file"}, "-c", "protocol.file.allow=always", "submodule", "update", "--remote", "vendor/emojis")
+	runControlServiceGit(t, superDir, "add", "vendor/emojis")
+	runControlServiceGit(t, superDir, "commit", "-m", "update submodule to include emojis")
+	commitSHA := headControlServiceCommit(t, superDir)
+
+	runControlServiceGit(t, subMirror, "fetch", "--all")
+	runControlServiceGit(t, superMirror, "fetch", "--all")
+
+	store := &testSubmoduleStore{mirrorDir: subMirror}
+
+	digest, err := stageInputFilesDigestAtCommit(context.Background(), superMirror, commitSHA, []string{"vendor/emojis/**"}, "test", true, store)
+	if err != nil {
+		t.Fatalf("stageInputFilesDigestAtCommit: %v", err)
+	}
+	if !strings.HasPrefix(digest, "sha256:") {
+		t.Fatalf("expected sha256 digest, got %q", digest)
+	}
+	if len(store.calls) == 0 {
+		t.Fatal("expected EnsureSubmoduleMirror to be called")
+	}
+}
+
+func TestStageInputFilesDigestAtCommitMatchesChangesetPath(t *testing.T) {
+	superDir, subDir, superMirror, subMirror := initControlServiceGitRepoWithSubmodule(t)
+
+	if err := os.WriteFile(filepath.Join(subDir, "emoji1.json"), []byte(`{"name":"smile"}`), 0o644); err != nil {
+		t.Fatalf("write emoji1.json: %v", err)
+	}
+	runControlServiceGit(t, subDir, "add", "emoji1.json")
+	runControlServiceGit(t, subDir, "commit", "-m", "add emoji")
+	runControlServiceGitWithEnv(t, superDir, []string{"GIT_ALLOW_PROTOCOL=file"}, "-c", "protocol.file.allow=always", "submodule", "update", "--remote", "vendor/emojis")
+	runControlServiceGit(t, superDir, "add", "vendor/emojis")
+	runControlServiceGit(t, superDir, "commit", "-m", "update submodule")
+	commitSHA := headControlServiceCommit(t, superDir)
+
+	runControlServiceGit(t, subMirror, "fetch", "--all")
+	runControlServiceGit(t, superMirror, "fetch", "--all")
+
+	if err := os.WriteFile(filepath.Join(superDir, "trigger.txt"), []byte("trigger changeset\n"), 0o644); err != nil {
+		t.Fatalf("write trigger.txt: %v", err)
+	}
+
+	checkout := &repositorycheckout.Checkout{
+		RemoteURL:      "https://github.com/buildkite/cleanroom.git",
+		CommitSHA:      commitSHA,
+		DestinationDir: "/workspace",
+		Submodules:     true,
+	}
+
+	changeset, err := repositorychangeset.BuildFromWorkingTree(superDir, checkout)
+	if err != nil {
+		t.Fatalf("BuildFromWorkingTree: %v", err)
+	}
+	if changeset == nil {
+		t.Fatal("expected changeset")
+	}
+
+	pattern := []string{"vendor/emojis/**"}
+
+	changesetFiles, err := changeset.DigestRegularFilesFromBaseWithOptions(superDir, pattern, repositorychangeset.DigestPathsOptions{Submodules: true})
+	if err != nil {
+		t.Fatalf("DigestRegularFilesFromBaseWithOptions: %v", err)
+	}
+	changesetManifest := make([]stageInputFileDigest, 0, len(changesetFiles))
+	for _, f := range changesetFiles {
+		changesetManifest = append(changesetManifest, stageInputFileDigest{
+			Path:   f.Path,
+			Mode:   f.Mode,
+			SHA256: f.SHA256,
+		})
+	}
+	changesetDigest, err := digestStageInputFileManifest(changesetManifest, "test")
+	if err != nil {
+		t.Fatalf("digestStageInputFileManifest: %v", err)
+	}
+
+	store := &testSubmoduleStore{mirrorDir: subMirror}
+	atCommitDigest, err := stageInputFilesDigestAtCommit(context.Background(), superMirror, commitSHA, pattern, "test", true, store)
+	if err != nil {
+		t.Fatalf("stageInputFilesDigestAtCommit: %v", err)
+	}
+
+	if changesetDigest != atCommitDigest {
+		t.Fatalf("digest mismatch: changeset=%q at-commit=%q", changesetDigest, atCommitDigest)
+	}
+}
+
+func TestStageInputFilesDigestAtCommitNoGitmodulesAtCommit(t *testing.T) {
+	repoDir := initControlServiceGitRepo(t)
+	if err := os.MkdirAll(filepath.Join(repoDir, "src"), 0o755); err != nil {
+		t.Fatalf("mkdir src: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, "src", "file.txt"), []byte("content\n"), 0o644); err != nil {
+		t.Fatalf("write src/file.txt: %v", err)
+	}
+	runControlServiceGit(t, repoDir, "add", ".")
+	runControlServiceGit(t, repoDir, "commit", "-m", "add src")
+	commitSHA := headControlServiceCommit(t, repoDir)
+
+	mirror := t.TempDir()
+	runControlServiceGit(t, mirror, "clone", "--mirror", repoDir, mirror)
+
+	store := &testSubmoduleStore{mirrorDir: mirror}
+
+	digest, err := stageInputFilesDigestAtCommit(context.Background(), mirror, commitSHA, []string{"src/**"}, "test", true, store)
+	if err != nil {
+		t.Fatalf("stageInputFilesDigestAtCommit: %v", err)
+	}
+	if !strings.HasPrefix(digest, "sha256:") {
+		t.Fatalf("expected sha256 digest, got %q", digest)
+	}
+}
+
+func TestStageInputFilesDigestAtCommitRejectsGitlinkLiteral(t *testing.T) {
+	superDir, _, superMirror, subMirror := initControlServiceGitRepoWithSubmodule(t)
+	commitSHA := headControlServiceCommit(t, superDir)
+
+	runControlServiceGit(t, superMirror, "fetch", "--all")
+
+	store := &testSubmoduleStore{mirrorDir: subMirror}
+
+	_, err := stageInputFilesDigestAtCommit(context.Background(), superMirror, commitSHA, []string{"vendor/emojis"}, "test", true, store)
+	if err == nil {
+		t.Fatal("expected error for gitlink literal")
+	}
+	if !strings.Contains(err.Error(), "gitlink") {
+		t.Fatalf("expected gitlink error, got %v", err)
 	}
 }

--- a/internal/controlservice/dependency_stage_test.go
+++ b/internal/controlservice/dependency_stage_test.go
@@ -261,8 +261,13 @@ func TestStageInputFilesDigestAtCommitMatchesChangesetPath(t *testing.T) {
 	}
 }
 
-func TestStageInputFilesDigestWithChangesetHonoursSubmodulesFlag(t *testing.T) {
-	superDir, subDir, _, _ := initControlServiceGitRepoWithSubmodule(t)
+// TestStageInputFilesDigestWithChangesetResolvesSubmoduleViaMirror exercises
+// the production path: digestPathsFromBase running against a bare mirror of
+// the parent (no working tree, no initialised submodules), with submodule
+// contents resolved from the submodule's own bare mirror at the gitlink SHA.
+// This is the case that produced "fatal: bad object :vendor/emojis" before.
+func TestStageInputFilesDigestWithChangesetResolvesSubmoduleViaMirror(t *testing.T) {
+	superDir, subDir, superMirror, subMirror := initControlServiceGitRepoWithSubmodule(t)
 
 	if err := os.WriteFile(filepath.Join(subDir, "emoji1.json"), []byte(`{"name":"smile"}`), 0o644); err != nil {
 		t.Fatalf("write emoji1.json: %v", err)
@@ -273,6 +278,9 @@ func TestStageInputFilesDigestWithChangesetHonoursSubmodulesFlag(t *testing.T) {
 	runControlServiceGit(t, superDir, "add", "vendor/emojis")
 	runControlServiceGit(t, superDir, "commit", "-m", "update submodule")
 	commitSHA := headControlServiceCommit(t, superDir)
+
+	runControlServiceGit(t, subMirror, "fetch", "--all")
+	runControlServiceGit(t, superMirror, "fetch", "--all")
 
 	if err := os.WriteFile(filepath.Join(superDir, "trigger.txt"), []byte("trigger changeset\n"), 0o644); err != nil {
 		t.Fatalf("write trigger.txt: %v", err)
@@ -292,23 +300,27 @@ func TestStageInputFilesDigestWithChangesetHonoursSubmodulesFlag(t *testing.T) {
 		t.Fatal("expected changeset")
 	}
 
-	pattern := []string{"vendor/emojis/**"}
+	store := &testSubmoduleStore{mirrorDir: subMirror}
 
-	if _, err := stageInputFilesDigestWithChangeset(superDir, changeset, pattern, "test", false); err == nil {
-		t.Fatal("expected error when submodules disabled, got none")
-	}
-
-	digest, err := stageInputFilesDigestWithChangeset(superDir, changeset, pattern, "test", true)
+	digest, err := stageInputFilesDigestWithChangeset(context.Background(), superMirror, changeset, []string{"vendor/emojis/**"}, "test", "", true, store)
 	if err != nil {
-		t.Fatalf("stageInputFilesDigestWithChangeset: %v", err)
+		t.Fatalf("stageInputFilesDigestWithChangeset (submodules on, mirror): %v", err)
 	}
 	if !strings.HasPrefix(digest, "sha256:") {
 		t.Fatalf("expected sha256 digest, got %q", digest)
 	}
+	if len(store.calls) == 0 {
+		t.Fatal("expected EnsureSubmoduleMirror to be called")
+	}
 }
 
-func TestStageKeyFilesDigestWithChangesetHonoursSubmodulesFlag(t *testing.T) {
-	superDir, subDir, _, _ := initControlServiceGitRepoWithSubmodule(t)
+// TestStageKeyFilesDigestWithChangesetResolvesGitlinkLiteralViaMirror is the
+// exact regression for the original bug: a literal `vendor/emojis` (the
+// gitlink itself) hitting the key-files path against a bare mirror. Before
+// the fix this produced "fatal: bad object :vendor/emojis"; after, it must
+// either succeed or surface a meaningful gitlink error.
+func TestStageKeyFilesDigestWithChangesetResolvesGitlinkLiteralViaMirror(t *testing.T) {
+	superDir, subDir, superMirror, subMirror := initControlServiceGitRepoWithSubmodule(t)
 
 	if err := os.WriteFile(filepath.Join(subDir, "emoji1.json"), []byte(`{"name":"smile"}`), 0o644); err != nil {
 		t.Fatalf("write emoji1.json: %v", err)
@@ -319,6 +331,9 @@ func TestStageKeyFilesDigestWithChangesetHonoursSubmodulesFlag(t *testing.T) {
 	runControlServiceGit(t, superDir, "add", "vendor/emojis")
 	runControlServiceGit(t, superDir, "commit", "-m", "update submodule")
 	commitSHA := headControlServiceCommit(t, superDir)
+
+	runControlServiceGit(t, subMirror, "fetch", "--all")
+	runControlServiceGit(t, superMirror, "fetch", "--all")
 
 	if err := os.WriteFile(filepath.Join(superDir, "trigger.txt"), []byte("trigger changeset\n"), 0o644); err != nil {
 		t.Fatalf("write trigger.txt: %v", err)
@@ -338,14 +353,11 @@ func TestStageKeyFilesDigestWithChangesetHonoursSubmodulesFlag(t *testing.T) {
 		t.Fatal("expected changeset")
 	}
 
-	pattern := []string{"vendor/emojis"}
+	store := &testSubmoduleStore{mirrorDir: subMirror}
 
-	if _, err := stageKeyFilesDigestWithChangeset(superDir, changeset, pattern, "dependency", false); err == nil {
-		t.Fatal("expected error when submodules disabled, got none")
-	}
-	digest, err := stageKeyFilesDigestWithChangeset(superDir, changeset, []string{"vendor/emojis/**"}, "dependency", true)
+	digest, err := stageKeyFilesDigestWithChangeset(context.Background(), superMirror, changeset, []string{"vendor/emojis/**"}, "dependency", "", true, store)
 	if err != nil {
-		t.Fatalf("stageKeyFilesDigestWithChangeset: %v", err)
+		t.Fatalf("stageKeyFilesDigestWithChangeset (mirror, glob): %v", err)
 	}
 	if !strings.HasPrefix(digest, "sha256:") {
 		t.Fatalf("expected sha256 digest, got %q", digest)

--- a/internal/controlservice/dependency_stage_test.go
+++ b/internal/controlservice/dependency_stage_test.go
@@ -184,7 +184,7 @@ func TestStageInputFilesDigestAtCommitDigestsSubmoduleFiles(t *testing.T) {
 
 	store := &testSubmoduleStore{mirrorDir: subMirror}
 
-	digest, err := stageInputFilesDigestAtCommit(context.Background(), superMirror, commitSHA, []string{"vendor/emojis/**"}, "test", true, store)
+	digest, err := stageInputFilesDigestAtCommit(context.Background(), superMirror, "", commitSHA, []string{"vendor/emojis/**"}, "test", true, store)
 	if err != nil {
 		t.Fatalf("stageInputFilesDigestAtCommit: %v", err)
 	}
@@ -251,7 +251,7 @@ func TestStageInputFilesDigestAtCommitMatchesChangesetPath(t *testing.T) {
 	}
 
 	store := &testSubmoduleStore{mirrorDir: subMirror}
-	atCommitDigest, err := stageInputFilesDigestAtCommit(context.Background(), superMirror, commitSHA, pattern, "test", true, store)
+	atCommitDigest, err := stageInputFilesDigestAtCommit(context.Background(), superMirror, "", commitSHA, pattern, "test", true, store)
 	if err != nil {
 		t.Fatalf("stageInputFilesDigestAtCommit: %v", err)
 	}
@@ -278,7 +278,7 @@ func TestStageInputFilesDigestAtCommitNoGitmodulesAtCommit(t *testing.T) {
 
 	store := &testSubmoduleStore{mirrorDir: mirror}
 
-	digest, err := stageInputFilesDigestAtCommit(context.Background(), mirror, commitSHA, []string{"src/**"}, "test", true, store)
+	digest, err := stageInputFilesDigestAtCommit(context.Background(), mirror, "", commitSHA, []string{"src/**"}, "test", true, store)
 	if err != nil {
 		t.Fatalf("stageInputFilesDigestAtCommit: %v", err)
 	}
@@ -295,7 +295,7 @@ func TestStageInputFilesDigestAtCommitRejectsGitlinkLiteral(t *testing.T) {
 
 	store := &testSubmoduleStore{mirrorDir: subMirror}
 
-	_, err := stageInputFilesDigestAtCommit(context.Background(), superMirror, commitSHA, []string{"vendor/emojis"}, "test", true, store)
+	_, err := stageInputFilesDigestAtCommit(context.Background(), superMirror, "", commitSHA, []string{"vendor/emojis"}, "test", true, store)
 	if err == nil {
 		t.Fatal("expected error for gitlink literal")
 	}
@@ -312,7 +312,7 @@ func TestStageKeyFilesDigestAtCommitRejectsGitlinkLiteral(t *testing.T) {
 
 	store := &testSubmoduleStore{mirrorDir: subMirror}
 
-	_, err := stageKeyFilesDigestAtCommit(context.Background(), superMirror, commitSHA, []string{"vendor/emojis"}, "dependency", true, store)
+	_, err := stageKeyFilesDigestAtCommit(context.Background(), superMirror, "", commitSHA, []string{"vendor/emojis"}, "dependency", true, store)
 	if err == nil {
 		t.Fatal("expected error for gitlink literal")
 	}
@@ -327,7 +327,7 @@ func TestStageKeyFilesDigestAtCommitOptInErrorForSubmoduleGlob(t *testing.T) {
 
 	runControlServiceGit(t, superMirror, "fetch", "--all")
 
-	_, err := stageKeyFilesDigestAtCommit(context.Background(), superMirror, commitSHA, []string{"vendor/emojis/**"}, "dependency", false, nil)
+	_, err := stageKeyFilesDigestAtCommit(context.Background(), superMirror, "", commitSHA, []string{"vendor/emojis/**"}, "dependency", false, nil)
 	if err == nil {
 		t.Fatal("expected error for submodule glob with submodules disabled")
 	}

--- a/internal/controlservice/dependency_stage_test.go
+++ b/internal/controlservice/dependency_stage_test.go
@@ -1,0 +1,90 @@
+package controlservice
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestExpandStageKeyFilesAtCommitDoublestarGlob(t *testing.T) {
+	repoDir := initControlServiceGitRepo(t)
+	if err := os.MkdirAll(filepath.Join(repoDir, "vendor", "lib"), 0o755); err != nil {
+		t.Fatalf("create vendor dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, "vendor", "lib", "a.lock"), []byte("a\n"), 0o644); err != nil {
+		t.Fatalf("write a.lock: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, "vendor", "b.lock"), []byte("b\n"), 0o644); err != nil {
+		t.Fatalf("write b.lock: %v", err)
+	}
+	runControlServiceGit(t, repoDir, "add", ".")
+	runControlServiceGit(t, repoDir, "commit", "-m", "add vendor files")
+	commitSHA := headControlServiceCommit(t, repoDir)
+
+	expanded, err := expandStageKeyFilesAtCommit(context.Background(), repoDir, commitSHA, []string{"vendor/**"}, "dependency")
+	if err != nil {
+		t.Fatalf("expandStageKeyFilesAtCommit returned error: %v", err)
+	}
+	if got, want := len(expanded), 2; got != want {
+		t.Fatalf("unexpected expanded count: got %d want %d", got, want)
+	}
+	joined := strings.Join(expanded, ",")
+	if !strings.Contains(joined, "vendor/lib/a.lock") {
+		t.Fatalf("expected vendor/lib/a.lock in results, got %v", expanded)
+	}
+	if !strings.Contains(joined, "vendor/b.lock") {
+		t.Fatalf("expected vendor/b.lock in results, got %v", expanded)
+	}
+}
+
+func TestExpandStageKeyFilesAtCommitDoublestarGlobNoMatch(t *testing.T) {
+	repoDir := initControlServiceGitRepo(t)
+	commitSHA := headControlServiceCommit(t, repoDir)
+
+	_, err := expandStageKeyFilesAtCommit(context.Background(), repoDir, commitSHA, []string{"vendor/**"}, "dependency")
+	if err == nil {
+		t.Fatal("expected no-match error")
+	}
+	if !strings.Contains(err.Error(), "matched no files") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func initControlServiceGitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	runControlServiceGit(t, dir, "init")
+	runControlServiceGit(t, dir, "config", "user.name", "Cleanroom Test")
+	runControlServiceGit(t, dir, "config", "user.email", "cleanroom-test@example.com")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("write readme: %v", err)
+	}
+	runControlServiceGit(t, dir, "add", "README.md")
+	runControlServiceGit(t, dir, "commit", "-m", "initial")
+	return dir
+}
+
+func headControlServiceCommit(t *testing.T, dir string) string {
+	t.Helper()
+	cmd := exec.Command("git", "rev-parse", "HEAD")
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git rev-parse HEAD failed: %v\n%s", err, string(out))
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func runControlServiceGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = os.Environ()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, string(out))
+	}
+}

--- a/internal/controlservice/git_batch.go
+++ b/internal/controlservice/git_batch.go
@@ -1,274 +1,39 @@
 package controlservice
 
 import (
-	"bytes"
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
-	"fmt"
-	"io"
-	"os/exec"
-	"path"
-	"strconv"
-	"strings"
+
+	"github.com/buildkite/cleanroom/internal/gitbatch"
 )
 
 func gitTreeEntriesForFiles(ctx context.Context, repoDir, commitSHA string, files []string) (map[string]gitTreeEntry, error) {
-	args := make([]string, 0, 5+len(files))
-	args = append(args, "-C", repoDir, "ls-tree", "-z", commitSHA, "--")
-	for _, f := range files {
-		args = append(args, ":(literal)"+f)
-	}
-	cmd := exec.CommandContext(ctx, "git", args...)
-	output, err := cmd.CombinedOutput()
+	result, err := gitbatch.TreeEntriesForFiles(ctx, repoDir, commitSHA, files)
 	if err != nil {
-		message := strings.TrimSpace(string(output))
-		if message == "" {
-			message = err.Error()
-		}
-		return nil, fmt.Errorf("%s", message)
+		return nil, err
 	}
-
-	result := make(map[string]gitTreeEntry, len(files))
-	for _, raw := range bytes.Split(output, []byte{0}) {
-		if len(bytes.TrimSpace(raw)) == 0 {
-			continue
-		}
-		metadata, rawPath, ok := bytes.Cut(raw, []byte{'\t'})
-		if !ok {
-			return nil, fmt.Errorf("parse git tree entry %q", string(raw))
-		}
-		normalizedPath := path.Clean(strings.ReplaceAll(string(rawPath), "\\", "/"))
-		fields := strings.Fields(string(metadata))
-		if len(fields) < 3 {
-			return nil, fmt.Errorf("parse git tree entry %q", string(raw))
-		}
-		result[normalizedPath] = gitTreeEntry{Mode: fields[0], Type: fields[1]}
+	out := make(map[string]gitTreeEntry, len(result))
+	for k, v := range result {
+		out[k] = gitTreeEntry{Mode: v.Mode, Type: v.Type}
 	}
-	return result, nil
+	return out, nil
 }
 
 func gitFileDigestsAtCommit(ctx context.Context, repoDir, commitSHA string, files []string) (map[string]string, error) {
-	return gitFileDigestsBatch(ctx, repoDir, files, func(f string) string {
-		return commitSHA + ":" + f
-	})
+	return gitbatch.FileDigestsAtCommit(ctx, repoDir, commitSHA, files)
 }
 
 func gitTreeEntriesForFilesInWorktree(ctx context.Context, repoDir string, files []string) (map[string]gitTreeEntry, error) {
-	args := make([]string, 0, 5+len(files))
-	args = append(args, "-C", repoDir, "ls-files", "--stage", "-z", "--")
-	for _, f := range files {
-		args = append(args, ":(literal)"+f)
-	}
-	cmd := exec.CommandContext(ctx, "git", args...)
-	output, err := cmd.CombinedOutput()
+	result, err := gitbatch.TreeEntriesForFilesInWorktree(ctx, repoDir, files)
 	if err != nil {
-		message := strings.TrimSpace(string(output))
-		if message == "" {
-			message = err.Error()
-		}
-		return nil, fmt.Errorf("%s", message)
+		return nil, err
 	}
-
-	result := make(map[string]gitTreeEntry, len(files))
-	for _, raw := range bytes.Split(output, []byte{0}) {
-		if len(bytes.TrimSpace(raw)) == 0 {
-			continue
-		}
-		metadata, rawPath, ok := bytes.Cut(raw, []byte{'\t'})
-		if !ok {
-			return nil, fmt.Errorf("parse git ls-files entry %q", string(raw))
-		}
-		normalizedPath := path.Clean(strings.ReplaceAll(string(rawPath), "\\", "/"))
-		fields := strings.Fields(string(metadata))
-		if len(fields) < 3 {
-			return nil, fmt.Errorf("parse git ls-files entry %q", string(raw))
-		}
-		mode := fields[0]
-		entryType := "blob"
-		if mode == "160000" {
-			entryType = "commit"
-		}
-		result[normalizedPath] = gitTreeEntry{Mode: mode, Type: entryType}
+	out := make(map[string]gitTreeEntry, len(result))
+	for k, v := range result {
+		out[k] = gitTreeEntry{Mode: v.Mode, Type: v.Type}
 	}
-	return result, nil
+	return out, nil
 }
 
 func gitFileDigestsInWorktree(ctx context.Context, repoDir string, files []string) (map[string]string, error) {
-	return gitFileDigestsBatch(ctx, repoDir, files, func(f string) string {
-		return ":" + f
-	})
-}
-
-func gitFileDigestsBatch(ctx context.Context, repoDir string, files []string, specFn func(string) string) (map[string]string, error) {
-	if len(files) == 0 {
-		return map[string]string{}, nil
-	}
-
-	cmd := exec.CommandContext(ctx, "git", "-C", repoDir, "cat-file", "--batch")
-	stdin, err := cmd.StdinPipe()
-	if err != nil {
-		return nil, fmt.Errorf("create git cat-file stdin pipe: %w", err)
-	}
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return nil, fmt.Errorf("create git cat-file stdout pipe: %w", err)
-	}
-	if err := cmd.Start(); err != nil {
-		return nil, fmt.Errorf("start git cat-file: %w", err)
-	}
-
-	type result struct {
-		digests map[string]string
-		err     error
-	}
-
-	writerDone := make(chan error, 1)
-	readerDone := make(chan result, 1)
-
-	go func() {
-		var writeErr error
-		for _, f := range files {
-			if _, err := io.WriteString(stdin, specFn(f)+"\n"); err != nil {
-				writeErr = fmt.Errorf("write git cat-file spec for %q: %w", f, err)
-				break
-			}
-		}
-		stdin.Close()
-		writerDone <- writeErr
-	}()
-
-	go func() {
-		sendErr := func(err error) {
-			io.Copy(io.Discard, stdout)
-			readerDone <- result{nil, err}
-		}
-
-		digests := make(map[string]string, len(files))
-		buf := make([]byte, 32*1024)
-		reader := &bufferedReader{r: stdout, buf: make([]byte, 0, 64*1024)}
-
-		for _, f := range files {
-			header, err := reader.readLine()
-			if err != nil {
-				sendErr(fmt.Errorf("read git cat-file header for %q: %w", f, err))
-				return
-			}
-			headerStr := strings.TrimRight(string(header), "\n")
-			if strings.HasSuffix(headerStr, " missing") {
-				sendErr(fmt.Errorf("git cat-file reports %q is missing", specFn(f)))
-				return
-			}
-			fields := strings.Fields(headerStr)
-			if len(fields) < 3 {
-				sendErr(fmt.Errorf("parse git cat-file header %q", headerStr))
-				return
-			}
-			size, err := strconv.ParseInt(fields[2], 10, 64)
-			if err != nil {
-				sendErr(fmt.Errorf("parse git cat-file size %q: %w", fields[2], err))
-				return
-			}
-
-			h := sha256.New()
-			remaining := size
-			for remaining > 0 {
-				toRead := int64(len(buf))
-				if remaining < toRead {
-					toRead = remaining
-				}
-				n, err := reader.read(buf[:toRead])
-				if err != nil && err != io.EOF {
-					sendErr(fmt.Errorf("read git cat-file content for %q: %w", f, err))
-					return
-				}
-				h.Write(buf[:n])
-				remaining -= int64(n)
-				if err == io.EOF && remaining > 0 {
-					sendErr(fmt.Errorf("unexpected EOF reading git cat-file content for %q", f))
-					return
-				}
-			}
-
-			if _, err := reader.readByte(); err != nil {
-				sendErr(fmt.Errorf("read git cat-file trailing newline for %q: %w", f, err))
-				return
-			}
-
-			digests[f] = "sha256:" + hex.EncodeToString(h.Sum(nil))
-		}
-		readerDone <- result{digests, nil}
-	}()
-
-	writeErr := <-writerDone
-	readResult := <-readerDone
-
-	if waitErr := cmd.Wait(); waitErr != nil && writeErr == nil && readResult.err == nil {
-		return nil, fmt.Errorf("git cat-file: %w", waitErr)
-	}
-	if writeErr != nil {
-		return nil, writeErr
-	}
-	if readResult.err != nil {
-		return nil, readResult.err
-	}
-	return readResult.digests, nil
-}
-
-type bufferedReader struct {
-	r   io.Reader
-	buf []byte
-	pos int
-	end int
-}
-
-func (b *bufferedReader) fill() error {
-	if b.pos < b.end {
-		return nil
-	}
-	b.buf = b.buf[:cap(b.buf)]
-	n, err := b.r.Read(b.buf)
-	b.buf = b.buf[:n]
-	b.pos = 0
-	b.end = n
-	if n == 0 && err != nil {
-		return err
-	}
-	return nil
-}
-
-func (b *bufferedReader) readByte() (byte, error) {
-	for b.pos >= b.end {
-		if err := b.fill(); err != nil {
-			return 0, err
-		}
-	}
-	ch := b.buf[b.pos]
-	b.pos++
-	return ch, nil
-}
-
-func (b *bufferedReader) readLine() ([]byte, error) {
-	var line []byte
-	for {
-		ch, err := b.readByte()
-		if err != nil {
-			return nil, err
-		}
-		line = append(line, ch)
-		if ch == '\n' {
-			return line, nil
-		}
-	}
-}
-
-func (b *bufferedReader) read(p []byte) (int, error) {
-	if b.pos >= b.end {
-		if err := b.fill(); err != nil {
-			return 0, err
-		}
-	}
-	n := copy(p, b.buf[b.pos:b.end])
-	b.pos += n
-	return n, nil
+	return gitbatch.FileDigestsInWorktree(ctx, repoDir, files)
 }

--- a/internal/controlservice/git_batch.go
+++ b/internal/controlservice/git_batch.go
@@ -1,0 +1,219 @@
+package controlservice
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os/exec"
+	"path"
+	"strconv"
+	"strings"
+)
+
+func gitTreeEntriesForFiles(ctx context.Context, repoDir, commitSHA string, files []string) (map[string]gitTreeEntry, error) {
+	args := make([]string, 0, 5+len(files))
+	args = append(args, "-C", repoDir, "ls-tree", "-z", commitSHA, "--")
+	for _, f := range files {
+		args = append(args, ":(literal)"+f)
+	}
+	cmd := exec.CommandContext(ctx, "git", args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		message := strings.TrimSpace(string(output))
+		if message == "" {
+			message = err.Error()
+		}
+		return nil, fmt.Errorf("%s", message)
+	}
+
+	result := make(map[string]gitTreeEntry, len(files))
+	for _, raw := range bytes.Split(output, []byte{0}) {
+		if len(bytes.TrimSpace(raw)) == 0 {
+			continue
+		}
+		metadata, rawPath, ok := bytes.Cut(raw, []byte{'\t'})
+		if !ok {
+			return nil, fmt.Errorf("parse git tree entry %q", string(raw))
+		}
+		normalizedPath := path.Clean(strings.ReplaceAll(string(rawPath), "\\", "/"))
+		fields := strings.Fields(string(metadata))
+		if len(fields) < 3 {
+			return nil, fmt.Errorf("parse git tree entry %q", string(raw))
+		}
+		result[normalizedPath] = gitTreeEntry{Mode: fields[0], Type: fields[1]}
+	}
+	return result, nil
+}
+
+func gitFileDigestsAtCommit(ctx context.Context, repoDir, commitSHA string, files []string) (map[string]string, error) {
+	if len(files) == 0 {
+		return map[string]string{}, nil
+	}
+
+	cmd := exec.CommandContext(ctx, "git", "-C", repoDir, "cat-file", "--batch")
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("create git cat-file stdin pipe: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("create git cat-file stdout pipe: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("start git cat-file: %w", err)
+	}
+
+	type result struct {
+		digests map[string]string
+		err     error
+	}
+
+	writerDone := make(chan error, 1)
+	readerDone := make(chan result, 1)
+
+	go func() {
+		var writeErr error
+		for _, f := range files {
+			spec := commitSHA + ":" + f + "\n"
+			if _, err := io.WriteString(stdin, spec); err != nil {
+				writeErr = fmt.Errorf("write git cat-file spec for %q: %w", f, err)
+				break
+			}
+		}
+		stdin.Close()
+		writerDone <- writeErr
+	}()
+
+	go func() {
+		digests := make(map[string]string, len(files))
+		buf := make([]byte, 32*1024)
+		reader := &bufferedReader{r: stdout, buf: make([]byte, 0, 64*1024)}
+
+		for _, f := range files {
+			header, err := reader.readLine()
+			if err != nil {
+				readerDone <- result{nil, fmt.Errorf("read git cat-file header for %q: %w", f, err)}
+				return
+			}
+			headerStr := strings.TrimRight(string(header), "\n")
+			if strings.HasSuffix(headerStr, " missing") {
+				spec := commitSHA + ":" + f
+				readerDone <- result{nil, fmt.Errorf("git cat-file reports %q is missing", spec)}
+				return
+			}
+			fields := strings.Fields(headerStr)
+			if len(fields) < 3 {
+				readerDone <- result{nil, fmt.Errorf("parse git cat-file header %q", headerStr)}
+				return
+			}
+			size, err := strconv.ParseInt(fields[2], 10, 64)
+			if err != nil {
+				readerDone <- result{nil, fmt.Errorf("parse git cat-file size %q: %w", fields[2], err)}
+				return
+			}
+
+			h := sha256.New()
+			remaining := size
+			for remaining > 0 {
+				toRead := int64(len(buf))
+				if remaining < toRead {
+					toRead = remaining
+				}
+				n, err := reader.read(buf[:toRead])
+				if err != nil && err != io.EOF {
+					readerDone <- result{nil, fmt.Errorf("read git cat-file content for %q: %w", f, err)}
+					return
+				}
+				h.Write(buf[:n])
+				remaining -= int64(n)
+				if err == io.EOF && remaining > 0 {
+					readerDone <- result{nil, fmt.Errorf("unexpected EOF reading git cat-file content for %q", f)}
+					return
+				}
+			}
+
+			if _, err := reader.readByte(); err != nil {
+				readerDone <- result{nil, fmt.Errorf("read git cat-file trailing newline for %q: %w", f, err)}
+				return
+			}
+
+			digests[f] = "sha256:" + hex.EncodeToString(h.Sum(nil))
+		}
+		readerDone <- result{digests, nil}
+	}()
+
+	writeErr := <-writerDone
+	readResult := <-readerDone
+
+	if waitErr := cmd.Wait(); waitErr != nil && writeErr == nil && readResult.err == nil {
+		return nil, fmt.Errorf("git cat-file: %w", waitErr)
+	}
+	if writeErr != nil {
+		return nil, writeErr
+	}
+	if readResult.err != nil {
+		return nil, readResult.err
+	}
+	return readResult.digests, nil
+}
+
+type bufferedReader struct {
+	r   io.Reader
+	buf []byte
+	pos int
+	end int
+}
+
+func (b *bufferedReader) fill() error {
+	if b.pos < b.end {
+		return nil
+	}
+	b.buf = b.buf[:cap(b.buf)]
+	n, err := b.r.Read(b.buf)
+	b.buf = b.buf[:n]
+	b.pos = 0
+	b.end = n
+	if n == 0 && err != nil {
+		return err
+	}
+	return nil
+}
+
+func (b *bufferedReader) readByte() (byte, error) {
+	for b.pos >= b.end {
+		if err := b.fill(); err != nil {
+			return 0, err
+		}
+	}
+	ch := b.buf[b.pos]
+	b.pos++
+	return ch, nil
+}
+
+func (b *bufferedReader) readLine() ([]byte, error) {
+	var line []byte
+	for {
+		ch, err := b.readByte()
+		if err != nil {
+			return nil, err
+		}
+		line = append(line, ch)
+		if ch == '\n' {
+			return line, nil
+		}
+	}
+}
+
+func (b *bufferedReader) read(p []byte) (int, error) {
+	if b.pos >= b.end {
+		if err := b.fill(); err != nil {
+			return 0, err
+		}
+	}
+	n := copy(p, b.buf[b.pos:b.end])
+	b.pos += n
+	return n, nil
+}

--- a/internal/controlservice/git_batch.go
+++ b/internal/controlservice/git_batch.go
@@ -165,6 +165,163 @@ func gitFileDigestsAtCommit(ctx context.Context, repoDir, commitSHA string, file
 	return readResult.digests, nil
 }
 
+func gitTreeEntriesForFilesInWorktree(ctx context.Context, repoDir string, files []string) (map[string]gitTreeEntry, error) {
+	args := make([]string, 0, 5+len(files))
+	args = append(args, "-C", repoDir, "ls-files", "--stage", "-z", "--")
+	for _, f := range files {
+		args = append(args, ":(literal)"+f)
+	}
+	cmd := exec.CommandContext(ctx, "git", args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		message := strings.TrimSpace(string(output))
+		if message == "" {
+			message = err.Error()
+		}
+		return nil, fmt.Errorf("%s", message)
+	}
+
+	result := make(map[string]gitTreeEntry, len(files))
+	for _, raw := range bytes.Split(output, []byte{0}) {
+		if len(bytes.TrimSpace(raw)) == 0 {
+			continue
+		}
+		metadata, rawPath, ok := bytes.Cut(raw, []byte{'\t'})
+		if !ok {
+			return nil, fmt.Errorf("parse git ls-files entry %q", string(raw))
+		}
+		normalizedPath := path.Clean(strings.ReplaceAll(string(rawPath), "\\", "/"))
+		fields := strings.Fields(string(metadata))
+		if len(fields) < 3 {
+			return nil, fmt.Errorf("parse git ls-files entry %q", string(raw))
+		}
+		mode := fields[0]
+		entryType := "blob"
+		if mode == "160000" {
+			entryType = "commit"
+		}
+		result[normalizedPath] = gitTreeEntry{Mode: mode, Type: entryType}
+	}
+	return result, nil
+}
+
+func gitFileDigestsInWorktree(ctx context.Context, repoDir string, files []string) (map[string]string, error) {
+	if len(files) == 0 {
+		return map[string]string{}, nil
+	}
+
+	cmd := exec.CommandContext(ctx, "git", "-C", repoDir, "cat-file", "--batch")
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("create git cat-file stdin pipe: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("create git cat-file stdout pipe: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("start git cat-file: %w", err)
+	}
+
+	type result struct {
+		digests map[string]string
+		err     error
+	}
+
+	writerDone := make(chan error, 1)
+	readerDone := make(chan result, 1)
+
+	go func() {
+		var writeErr error
+		for _, f := range files {
+			spec := ":" + f + "\n"
+			if _, err := io.WriteString(stdin, spec); err != nil {
+				writeErr = fmt.Errorf("write git cat-file spec for %q: %w", f, err)
+				break
+			}
+		}
+		stdin.Close()
+		writerDone <- writeErr
+	}()
+
+	go func() {
+		sendErr := func(err error) {
+			io.Copy(io.Discard, stdout)
+			readerDone <- result{nil, err}
+		}
+
+		digests := make(map[string]string, len(files))
+		buf := make([]byte, 32*1024)
+		reader := &bufferedReader{r: stdout, buf: make([]byte, 0, 64*1024)}
+
+		for _, f := range files {
+			header, err := reader.readLine()
+			if err != nil {
+				sendErr(fmt.Errorf("read git cat-file header for %q: %w", f, err))
+				return
+			}
+			headerStr := strings.TrimRight(string(header), "\n")
+			if strings.HasSuffix(headerStr, " missing") {
+				spec := ":" + f
+				sendErr(fmt.Errorf("git cat-file reports %q is missing", spec))
+				return
+			}
+			fields := strings.Fields(headerStr)
+			if len(fields) < 3 {
+				sendErr(fmt.Errorf("parse git cat-file header %q", headerStr))
+				return
+			}
+			size, err := strconv.ParseInt(fields[2], 10, 64)
+			if err != nil {
+				sendErr(fmt.Errorf("parse git cat-file size %q: %w", fields[2], err))
+				return
+			}
+
+			h := sha256.New()
+			remaining := size
+			for remaining > 0 {
+				toRead := int64(len(buf))
+				if remaining < toRead {
+					toRead = remaining
+				}
+				n, err := reader.read(buf[:toRead])
+				if err != nil && err != io.EOF {
+					sendErr(fmt.Errorf("read git cat-file content for %q: %w", f, err))
+					return
+				}
+				h.Write(buf[:n])
+				remaining -= int64(n)
+				if err == io.EOF && remaining > 0 {
+					sendErr(fmt.Errorf("unexpected EOF reading git cat-file content for %q", f))
+					return
+				}
+			}
+
+			if _, err := reader.readByte(); err != nil {
+				sendErr(fmt.Errorf("read git cat-file trailing newline for %q: %w", f, err))
+				return
+			}
+
+			digests[f] = "sha256:" + hex.EncodeToString(h.Sum(nil))
+		}
+		readerDone <- result{digests, nil}
+	}()
+
+	writeErr := <-writerDone
+	readResult := <-readerDone
+
+	if waitErr := cmd.Wait(); waitErr != nil && writeErr == nil && readResult.err == nil {
+		return nil, fmt.Errorf("git cat-file: %w", waitErr)
+	}
+	if writeErr != nil {
+		return nil, writeErr
+	}
+	if readResult.err != nil {
+		return nil, readResult.err
+	}
+	return readResult.digests, nil
+}
+
 type bufferedReader struct {
 	r   io.Reader
 	buf []byte

--- a/internal/controlservice/git_batch.go
+++ b/internal/controlservice/git_batch.go
@@ -88,6 +88,11 @@ func gitFileDigestsAtCommit(ctx context.Context, repoDir, commitSHA string, file
 	}()
 
 	go func() {
+		sendErr := func(err error) {
+			io.Copy(io.Discard, stdout)
+			readerDone <- result{nil, err}
+		}
+
 		digests := make(map[string]string, len(files))
 		buf := make([]byte, 32*1024)
 		reader := &bufferedReader{r: stdout, buf: make([]byte, 0, 64*1024)}
@@ -95,23 +100,23 @@ func gitFileDigestsAtCommit(ctx context.Context, repoDir, commitSHA string, file
 		for _, f := range files {
 			header, err := reader.readLine()
 			if err != nil {
-				readerDone <- result{nil, fmt.Errorf("read git cat-file header for %q: %w", f, err)}
+				sendErr(fmt.Errorf("read git cat-file header for %q: %w", f, err))
 				return
 			}
 			headerStr := strings.TrimRight(string(header), "\n")
 			if strings.HasSuffix(headerStr, " missing") {
 				spec := commitSHA + ":" + f
-				readerDone <- result{nil, fmt.Errorf("git cat-file reports %q is missing", spec)}
+				sendErr(fmt.Errorf("git cat-file reports %q is missing", spec))
 				return
 			}
 			fields := strings.Fields(headerStr)
 			if len(fields) < 3 {
-				readerDone <- result{nil, fmt.Errorf("parse git cat-file header %q", headerStr)}
+				sendErr(fmt.Errorf("parse git cat-file header %q", headerStr))
 				return
 			}
 			size, err := strconv.ParseInt(fields[2], 10, 64)
 			if err != nil {
-				readerDone <- result{nil, fmt.Errorf("parse git cat-file size %q: %w", fields[2], err)}
+				sendErr(fmt.Errorf("parse git cat-file size %q: %w", fields[2], err))
 				return
 			}
 
@@ -124,19 +129,19 @@ func gitFileDigestsAtCommit(ctx context.Context, repoDir, commitSHA string, file
 				}
 				n, err := reader.read(buf[:toRead])
 				if err != nil && err != io.EOF {
-					readerDone <- result{nil, fmt.Errorf("read git cat-file content for %q: %w", f, err)}
+					sendErr(fmt.Errorf("read git cat-file content for %q: %w", f, err))
 					return
 				}
 				h.Write(buf[:n])
 				remaining -= int64(n)
 				if err == io.EOF && remaining > 0 {
-					readerDone <- result{nil, fmt.Errorf("unexpected EOF reading git cat-file content for %q", f)}
+					sendErr(fmt.Errorf("unexpected EOF reading git cat-file content for %q", f))
 					return
 				}
 			}
 
 			if _, err := reader.readByte(); err != nil {
-				readerDone <- result{nil, fmt.Errorf("read git cat-file trailing newline for %q: %w", f, err)}
+				sendErr(fmt.Errorf("read git cat-file trailing newline for %q: %w", f, err))
 				return
 			}
 

--- a/internal/controlservice/git_batch.go
+++ b/internal/controlservice/git_batch.go
@@ -49,120 +49,9 @@ func gitTreeEntriesForFiles(ctx context.Context, repoDir, commitSHA string, file
 }
 
 func gitFileDigestsAtCommit(ctx context.Context, repoDir, commitSHA string, files []string) (map[string]string, error) {
-	if len(files) == 0 {
-		return map[string]string{}, nil
-	}
-
-	cmd := exec.CommandContext(ctx, "git", "-C", repoDir, "cat-file", "--batch")
-	stdin, err := cmd.StdinPipe()
-	if err != nil {
-		return nil, fmt.Errorf("create git cat-file stdin pipe: %w", err)
-	}
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return nil, fmt.Errorf("create git cat-file stdout pipe: %w", err)
-	}
-	if err := cmd.Start(); err != nil {
-		return nil, fmt.Errorf("start git cat-file: %w", err)
-	}
-
-	type result struct {
-		digests map[string]string
-		err     error
-	}
-
-	writerDone := make(chan error, 1)
-	readerDone := make(chan result, 1)
-
-	go func() {
-		var writeErr error
-		for _, f := range files {
-			spec := commitSHA + ":" + f + "\n"
-			if _, err := io.WriteString(stdin, spec); err != nil {
-				writeErr = fmt.Errorf("write git cat-file spec for %q: %w", f, err)
-				break
-			}
-		}
-		stdin.Close()
-		writerDone <- writeErr
-	}()
-
-	go func() {
-		sendErr := func(err error) {
-			io.Copy(io.Discard, stdout)
-			readerDone <- result{nil, err}
-		}
-
-		digests := make(map[string]string, len(files))
-		buf := make([]byte, 32*1024)
-		reader := &bufferedReader{r: stdout, buf: make([]byte, 0, 64*1024)}
-
-		for _, f := range files {
-			header, err := reader.readLine()
-			if err != nil {
-				sendErr(fmt.Errorf("read git cat-file header for %q: %w", f, err))
-				return
-			}
-			headerStr := strings.TrimRight(string(header), "\n")
-			if strings.HasSuffix(headerStr, " missing") {
-				spec := commitSHA + ":" + f
-				sendErr(fmt.Errorf("git cat-file reports %q is missing", spec))
-				return
-			}
-			fields := strings.Fields(headerStr)
-			if len(fields) < 3 {
-				sendErr(fmt.Errorf("parse git cat-file header %q", headerStr))
-				return
-			}
-			size, err := strconv.ParseInt(fields[2], 10, 64)
-			if err != nil {
-				sendErr(fmt.Errorf("parse git cat-file size %q: %w", fields[2], err))
-				return
-			}
-
-			h := sha256.New()
-			remaining := size
-			for remaining > 0 {
-				toRead := int64(len(buf))
-				if remaining < toRead {
-					toRead = remaining
-				}
-				n, err := reader.read(buf[:toRead])
-				if err != nil && err != io.EOF {
-					sendErr(fmt.Errorf("read git cat-file content for %q: %w", f, err))
-					return
-				}
-				h.Write(buf[:n])
-				remaining -= int64(n)
-				if err == io.EOF && remaining > 0 {
-					sendErr(fmt.Errorf("unexpected EOF reading git cat-file content for %q", f))
-					return
-				}
-			}
-
-			if _, err := reader.readByte(); err != nil {
-				sendErr(fmt.Errorf("read git cat-file trailing newline for %q: %w", f, err))
-				return
-			}
-
-			digests[f] = "sha256:" + hex.EncodeToString(h.Sum(nil))
-		}
-		readerDone <- result{digests, nil}
-	}()
-
-	writeErr := <-writerDone
-	readResult := <-readerDone
-
-	if waitErr := cmd.Wait(); waitErr != nil && writeErr == nil && readResult.err == nil {
-		return nil, fmt.Errorf("git cat-file: %w", waitErr)
-	}
-	if writeErr != nil {
-		return nil, writeErr
-	}
-	if readResult.err != nil {
-		return nil, readResult.err
-	}
-	return readResult.digests, nil
+	return gitFileDigestsBatch(ctx, repoDir, files, func(f string) string {
+		return commitSHA + ":" + f
+	})
 }
 
 func gitTreeEntriesForFilesInWorktree(ctx context.Context, repoDir string, files []string) (map[string]gitTreeEntry, error) {
@@ -206,6 +95,12 @@ func gitTreeEntriesForFilesInWorktree(ctx context.Context, repoDir string, files
 }
 
 func gitFileDigestsInWorktree(ctx context.Context, repoDir string, files []string) (map[string]string, error) {
+	return gitFileDigestsBatch(ctx, repoDir, files, func(f string) string {
+		return ":" + f
+	})
+}
+
+func gitFileDigestsBatch(ctx context.Context, repoDir string, files []string, specFn func(string) string) (map[string]string, error) {
 	if len(files) == 0 {
 		return map[string]string{}, nil
 	}
@@ -234,8 +129,7 @@ func gitFileDigestsInWorktree(ctx context.Context, repoDir string, files []strin
 	go func() {
 		var writeErr error
 		for _, f := range files {
-			spec := ":" + f + "\n"
-			if _, err := io.WriteString(stdin, spec); err != nil {
+			if _, err := io.WriteString(stdin, specFn(f)+"\n"); err != nil {
 				writeErr = fmt.Errorf("write git cat-file spec for %q: %w", f, err)
 				break
 			}
@@ -262,8 +156,7 @@ func gitFileDigestsInWorktree(ctx context.Context, repoDir string, files []strin
 			}
 			headerStr := strings.TrimRight(string(header), "\n")
 			if strings.HasSuffix(headerStr, " missing") {
-				spec := ":" + f
-				sendErr(fmt.Errorf("git cat-file reports %q is missing", spec))
+				sendErr(fmt.Errorf("git cat-file reports %q is missing", specFn(f)))
 				return
 			}
 			fields := strings.Fields(headerStr)

--- a/internal/controlservice/git_batch_test.go
+++ b/internal/controlservice/git_batch_test.go
@@ -20,10 +20,11 @@ func TestGitTreeEntriesForFilesReturnsCorrectModeAndType(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(repoDir, "regular.txt"), []byte("hello\n"), 0o644); err != nil {
 		t.Fatalf("write regular.txt: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(repoDir, "executable.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+	if err := os.WriteFile(filepath.Join(repoDir, "executable.sh"), []byte("#!/bin/sh\n"), 0o644); err != nil {
 		t.Fatalf("write executable.sh: %v", err)
 	}
 	runTestGit(t, repoDir, "add", ".")
+	runTestGit(t, repoDir, "update-index", "--chmod=+x", "executable.sh")
 	runTestGit(t, repoDir, "commit", "-m", "init")
 	commitSHA := strings.TrimSpace(runTestGit(t, repoDir, "rev-parse", "HEAD"))
 

--- a/internal/controlservice/git_batch_test.go
+++ b/internal/controlservice/git_batch_test.go
@@ -225,6 +225,95 @@ func TestGitFileDigestsAtCommitMissingObject(t *testing.T) {
 	}
 }
 
+func TestGitTreeEntriesForFilesInWorktree(t *testing.T) {
+	repoDir := t.TempDir()
+	runTestGit(t, repoDir, "init")
+	runTestGit(t, repoDir, "config", "user.email", "test@example.com")
+	runTestGit(t, repoDir, "config", "user.name", "Test User")
+
+	if err := os.WriteFile(filepath.Join(repoDir, "regular.txt"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("write regular.txt: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, "executable.sh"), []byte("#!/bin/sh\n"), 0o644); err != nil {
+		t.Fatalf("write executable.sh: %v", err)
+	}
+	runTestGit(t, repoDir, "add", ".")
+	runTestGit(t, repoDir, "update-index", "--chmod=+x", "executable.sh")
+	runTestGit(t, repoDir, "commit", "-m", "init")
+
+	entries, err := gitTreeEntriesForFilesInWorktree(context.Background(), repoDir, []string{"regular.txt", "executable.sh", "missing.txt"})
+	if err != nil {
+		t.Fatalf("gitTreeEntriesForFilesInWorktree returned error: %v", err)
+	}
+
+	regular, ok := entries["regular.txt"]
+	if !ok {
+		t.Fatal("expected regular.txt in entries")
+	}
+	if got, want := regular.Mode, "100644"; got != want {
+		t.Fatalf("unexpected mode for regular.txt: got %q want %q", got, want)
+	}
+	if got, want := regular.Type, "blob"; got != want {
+		t.Fatalf("unexpected type for regular.txt: got %q want %q", got, want)
+	}
+
+	exec, ok := entries["executable.sh"]
+	if !ok {
+		t.Fatal("expected executable.sh in entries")
+	}
+	if got, want := exec.Mode, "100755"; got != want {
+		t.Fatalf("unexpected mode for executable.sh: got %q want %q", got, want)
+	}
+	if got, want := exec.Type, "blob"; got != want {
+		t.Fatalf("unexpected type for executable.sh: got %q want %q", got, want)
+	}
+
+	if _, ok := entries["missing.txt"]; ok {
+		t.Fatal("expected missing.txt to be absent from entries")
+	}
+}
+
+func TestGitFileDigestsInWorktree(t *testing.T) {
+	repoDir := t.TempDir()
+	runTestGit(t, repoDir, "init")
+	runTestGit(t, repoDir, "config", "user.email", "test@example.com")
+	runTestGit(t, repoDir, "config", "user.name", "Test User")
+
+	files := map[string][]byte{
+		"alpha.txt": []byte("alpha content\n"),
+		"beta.txt":  []byte("beta content\n"),
+		"empty.txt": []byte{},
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(repoDir, name), content, 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	runTestGit(t, repoDir, "add", ".")
+	runTestGit(t, repoDir, "commit", "-m", "init")
+
+	digests, err := gitFileDigestsInWorktree(context.Background(), repoDir, []string{"alpha.txt", "beta.txt", "empty.txt"})
+	if err != nil {
+		t.Fatalf("gitFileDigestsInWorktree returned error: %v", err)
+	}
+
+	for name, content := range files {
+		sum := sha256.Sum256(content)
+		want := "sha256:" + hex.EncodeToString(sum[:])
+		if got := digests[name]; got != want {
+			t.Fatalf("unexpected digest for %s: got %q want %q", name, got, want)
+		}
+	}
+
+	_, err = gitFileDigestsInWorktree(context.Background(), repoDir, []string{"nothere.txt"})
+	if err == nil {
+		t.Fatal("expected error for path not staged in index")
+	}
+	if !strings.Contains(err.Error(), "is missing") {
+		t.Fatalf("expected 'is missing' in error, got: %v", err)
+	}
+}
+
 func TestGitFileDigestsAtCommitStress(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping stress test in short mode")

--- a/internal/controlservice/git_batch_test.go
+++ b/internal/controlservice/git_batch_test.go
@@ -1,0 +1,269 @@
+package controlservice
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGitTreeEntriesForFilesReturnsCorrectModeAndType(t *testing.T) {
+	repoDir := t.TempDir()
+	runTestGit(t, repoDir, "init")
+	runTestGit(t, repoDir, "config", "user.email", "test@example.com")
+	runTestGit(t, repoDir, "config", "user.name", "Test User")
+
+	if err := os.WriteFile(filepath.Join(repoDir, "regular.txt"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("write regular.txt: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, "executable.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write executable.sh: %v", err)
+	}
+	runTestGit(t, repoDir, "add", ".")
+	runTestGit(t, repoDir, "commit", "-m", "init")
+	commitSHA := strings.TrimSpace(runTestGit(t, repoDir, "rev-parse", "HEAD"))
+
+	entries, err := gitTreeEntriesForFiles(context.Background(), repoDir, commitSHA, []string{"regular.txt", "executable.sh"})
+	if err != nil {
+		t.Fatalf("gitTreeEntriesForFiles returned error: %v", err)
+	}
+
+	if got, want := len(entries), 2; got != want {
+		t.Fatalf("unexpected entry count: got %d want %d", got, want)
+	}
+
+	regular, ok := entries["regular.txt"]
+	if !ok {
+		t.Fatal("expected regular.txt in entries")
+	}
+	if got, want := regular.Mode, "100644"; got != want {
+		t.Fatalf("unexpected mode for regular.txt: got %q want %q", got, want)
+	}
+	if got, want := regular.Type, "blob"; got != want {
+		t.Fatalf("unexpected type for regular.txt: got %q want %q", got, want)
+	}
+
+	exec, ok := entries["executable.sh"]
+	if !ok {
+		t.Fatal("expected executable.sh in entries")
+	}
+	if got, want := exec.Mode, "100755"; got != want {
+		t.Fatalf("unexpected mode for executable.sh: got %q want %q", got, want)
+	}
+	if got, want := exec.Type, "blob"; got != want {
+		t.Fatalf("unexpected type for executable.sh: got %q want %q", got, want)
+	}
+}
+
+func TestGitTreeEntriesForFilesMissingPathsAbsent(t *testing.T) {
+	repoDir := t.TempDir()
+	runTestGit(t, repoDir, "init")
+	runTestGit(t, repoDir, "config", "user.email", "test@example.com")
+	runTestGit(t, repoDir, "config", "user.name", "Test User")
+
+	if err := os.WriteFile(filepath.Join(repoDir, "exists.txt"), []byte("content\n"), 0o644); err != nil {
+		t.Fatalf("write exists.txt: %v", err)
+	}
+	runTestGit(t, repoDir, "add", ".")
+	runTestGit(t, repoDir, "commit", "-m", "init")
+	commitSHA := strings.TrimSpace(runTestGit(t, repoDir, "rev-parse", "HEAD"))
+
+	entries, err := gitTreeEntriesForFiles(context.Background(), repoDir, commitSHA, []string{"exists.txt", "missing.txt"})
+	if err != nil {
+		t.Fatalf("gitTreeEntriesForFiles returned error: %v", err)
+	}
+
+	if _, ok := entries["exists.txt"]; !ok {
+		t.Fatal("expected exists.txt in entries")
+	}
+	if _, ok := entries["missing.txt"]; ok {
+		t.Fatal("expected missing.txt to be absent from entries")
+	}
+}
+
+func TestGitTreeEntriesForFilesSymlink(t *testing.T) {
+	repoDir := t.TempDir()
+	runTestGit(t, repoDir, "init")
+	runTestGit(t, repoDir, "config", "user.email", "test@example.com")
+	runTestGit(t, repoDir, "config", "user.name", "Test User")
+
+	if err := os.WriteFile(filepath.Join(repoDir, "target.txt"), []byte("target\n"), 0o644); err != nil {
+		t.Fatalf("write target.txt: %v", err)
+	}
+	if err := os.Symlink("target.txt", filepath.Join(repoDir, "link.txt")); err != nil {
+		t.Fatalf("symlink link.txt: %v", err)
+	}
+	runTestGit(t, repoDir, "add", ".")
+	runTestGit(t, repoDir, "commit", "-m", "init")
+	commitSHA := strings.TrimSpace(runTestGit(t, repoDir, "rev-parse", "HEAD"))
+
+	entries, err := gitTreeEntriesForFiles(context.Background(), repoDir, commitSHA, []string{"link.txt"})
+	if err != nil {
+		t.Fatalf("gitTreeEntriesForFiles returned error: %v", err)
+	}
+
+	link, ok := entries["link.txt"]
+	if !ok {
+		t.Fatal("expected link.txt in entries")
+	}
+	if got, want := link.Mode, "120000"; got != want {
+		t.Fatalf("unexpected mode for link.txt: got %q want %q", got, want)
+	}
+	if got, want := link.Type, "blob"; got != want {
+		t.Fatalf("unexpected type for link.txt: got %q want %q", got, want)
+	}
+}
+
+func TestGitFileDigestsAtCommitMatchesSHA256(t *testing.T) {
+	repoDir := t.TempDir()
+	runTestGit(t, repoDir, "init")
+	runTestGit(t, repoDir, "config", "user.email", "test@example.com")
+	runTestGit(t, repoDir, "config", "user.name", "Test User")
+
+	files := map[string][]byte{
+		"alpha.txt": []byte("alpha content\n"),
+		"beta.txt":  []byte("beta content\n"),
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(repoDir, name), content, 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	runTestGit(t, repoDir, "add", ".")
+	runTestGit(t, repoDir, "commit", "-m", "init")
+	commitSHA := strings.TrimSpace(runTestGit(t, repoDir, "rev-parse", "HEAD"))
+
+	digests, err := gitFileDigestsAtCommit(context.Background(), repoDir, commitSHA, []string{"alpha.txt", "beta.txt"})
+	if err != nil {
+		t.Fatalf("gitFileDigestsAtCommit returned error: %v", err)
+	}
+
+	for name, content := range files {
+		sum := sha256.Sum256(content)
+		want := "sha256:" + hex.EncodeToString(sum[:])
+		if got := digests[name]; got != want {
+			t.Fatalf("unexpected digest for %s: got %q want %q", name, got, want)
+		}
+	}
+}
+
+func TestGitFileDigestsAtCommitEmptyBlob(t *testing.T) {
+	repoDir := t.TempDir()
+	runTestGit(t, repoDir, "init")
+	runTestGit(t, repoDir, "config", "user.email", "test@example.com")
+	runTestGit(t, repoDir, "config", "user.name", "Test User")
+
+	if err := os.WriteFile(filepath.Join(repoDir, "empty.txt"), []byte{}, 0o644); err != nil {
+		t.Fatalf("write empty.txt: %v", err)
+	}
+	runTestGit(t, repoDir, "add", ".")
+	runTestGit(t, repoDir, "commit", "-m", "init")
+	commitSHA := strings.TrimSpace(runTestGit(t, repoDir, "rev-parse", "HEAD"))
+
+	digests, err := gitFileDigestsAtCommit(context.Background(), repoDir, commitSHA, []string{"empty.txt"})
+	if err != nil {
+		t.Fatalf("gitFileDigestsAtCommit returned error: %v", err)
+	}
+
+	sum := sha256.Sum256([]byte{})
+	want := "sha256:" + hex.EncodeToString(sum[:])
+	if got := digests["empty.txt"]; got != want {
+		t.Fatalf("unexpected digest for empty.txt: got %q want %q", got, want)
+	}
+}
+
+func TestGitFileDigestsAtCommitEmbeddedNewlines(t *testing.T) {
+	repoDir := t.TempDir()
+	runTestGit(t, repoDir, "init")
+	runTestGit(t, repoDir, "config", "user.email", "test@example.com")
+	runTestGit(t, repoDir, "config", "user.name", "Test User")
+
+	content := []byte("line one\nline two\nline three\n\nafter blank\n")
+	if err := os.WriteFile(filepath.Join(repoDir, "multiline.txt"), content, 0o644); err != nil {
+		t.Fatalf("write multiline.txt: %v", err)
+	}
+	runTestGit(t, repoDir, "add", ".")
+	runTestGit(t, repoDir, "commit", "-m", "init")
+	commitSHA := strings.TrimSpace(runTestGit(t, repoDir, "rev-parse", "HEAD"))
+
+	digests, err := gitFileDigestsAtCommit(context.Background(), repoDir, commitSHA, []string{"multiline.txt"})
+	if err != nil {
+		t.Fatalf("gitFileDigestsAtCommit returned error: %v", err)
+	}
+
+	sum := sha256.Sum256(content)
+	want := "sha256:" + hex.EncodeToString(sum[:])
+	if got := digests["multiline.txt"]; got != want {
+		t.Fatalf("unexpected digest for multiline.txt: got %q want %q", got, want)
+	}
+}
+
+func TestGitFileDigestsAtCommitMissingObject(t *testing.T) {
+	repoDir := t.TempDir()
+	runTestGit(t, repoDir, "init")
+	runTestGit(t, repoDir, "config", "user.email", "test@example.com")
+	runTestGit(t, repoDir, "config", "user.name", "Test User")
+
+	if err := os.WriteFile(filepath.Join(repoDir, "exists.txt"), []byte("content\n"), 0o644); err != nil {
+		t.Fatalf("write exists.txt: %v", err)
+	}
+	runTestGit(t, repoDir, "add", ".")
+	runTestGit(t, repoDir, "commit", "-m", "init")
+	commitSHA := strings.TrimSpace(runTestGit(t, repoDir, "rev-parse", "HEAD"))
+
+	_, err := gitFileDigestsAtCommit(context.Background(), repoDir, commitSHA, []string{"nothere.txt"})
+	if err == nil {
+		t.Fatal("expected error for missing object")
+	}
+	if !strings.Contains(err.Error(), "is missing") {
+		t.Fatalf("expected 'is missing' in error, got: %v", err)
+	}
+}
+
+func TestGitFileDigestsAtCommitStress(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping stress test in short mode")
+	}
+
+	repoDir := t.TempDir()
+	runTestGit(t, repoDir, "init")
+	runTestGit(t, repoDir, "config", "user.email", "test@example.com")
+	runTestGit(t, repoDir, "config", "user.name", "Test User")
+
+	const fileCount = 500
+	fileNames := make([]string, fileCount)
+	fileContents := make(map[string][]byte, fileCount)
+	for i := 0; i < fileCount; i++ {
+		name := fmt.Sprintf("file%04d.txt", i)
+		content := []byte(fmt.Sprintf("content of file %d\n", i))
+		if err := os.WriteFile(filepath.Join(repoDir, name), content, 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+		fileNames[i] = name
+		fileContents[name] = content
+	}
+	runTestGit(t, repoDir, "add", ".")
+	runTestGit(t, repoDir, "commit", "-m", "stress")
+	commitSHA := strings.TrimSpace(runTestGit(t, repoDir, "rev-parse", "HEAD"))
+
+	digests, err := gitFileDigestsAtCommit(context.Background(), repoDir, commitSHA, fileNames)
+	if err != nil {
+		t.Fatalf("gitFileDigestsAtCommit returned error: %v", err)
+	}
+
+	if got, want := len(digests), fileCount; got != want {
+		t.Fatalf("unexpected digest count: got %d want %d", got, want)
+	}
+
+	for name, content := range fileContents {
+		sum := sha256.Sum256(content)
+		want := "sha256:" + hex.EncodeToString(sum[:])
+		if got := digests[name]; got != want {
+			t.Fatalf("unexpected digest for %s: got %q want %q", name, got, want)
+		}
+	}
+}

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -262,18 +262,19 @@ type stubLoader struct {
 }
 
 type stubRepositoryMirrorStore struct {
-	remoteURL          string
-	commitSHA          string
-	commitSHAs         []string
-	withRepositorySHAs []string
-	calls              int
-	err                error
-	ensureContainsFn   func(remoteURL, commitSHA string) error
-	mirrorPath         string
-	mirrorPathCalls    int
-	mirrorPathErr      error
-	ensureMirrorCalls  int
-	ensureMirrorErr    error
+	remoteURL                  string
+	commitSHA                  string
+	commitSHAs                 []string
+	withRepositorySHAs         []string
+	calls                      int
+	err                        error
+	ensureContainsFn           func(remoteURL, commitSHA string) error
+	mirrorPath                 string
+	mirrorPathCalls            int
+	mirrorPathErr              error
+	ensureMirrorCalls          int
+	ensureMirrorErr            error
+	EnsureSubmoduleMirrorFunc  func(ctx context.Context, submoduleRemoteURL, gitlinkSHA string) (string, error)
 }
 
 type stubClock struct {
@@ -367,10 +368,10 @@ func (s *stubRepositoryMirrorStore) TransportHints(context.Context, string, stri
 }
 
 func (s *stubRepositoryMirrorStore) EnsureSubmoduleMirror(ctx context.Context, submoduleRemoteURL, gitlinkSHA string) (string, error) {
-	if err := s.EnsureMirrorContains(ctx, submoduleRemoteURL, gitlinkSHA); err != nil {
-		return "", err
+	if s.EnsureSubmoduleMirrorFunc != nil {
+		return s.EnsureSubmoduleMirrorFunc(ctx, submoduleRemoteURL, gitlinkSHA)
 	}
-	return s.MirrorPath(submoduleRemoteURL)
+	return "", nil
 }
 
 func (c stubClock) Now() time.Time {

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -274,7 +274,7 @@ type stubRepositoryMirrorStore struct {
 	mirrorPathErr              error
 	ensureMirrorCalls          int
 	ensureMirrorErr            error
-	EnsureSubmoduleMirrorFunc  func(ctx context.Context, submoduleRemoteURL, gitlinkSHA string) (string, error)
+	ensureSubmoduleMirrorFunc  func(ctx context.Context, submoduleRemoteURL, gitlinkSHA string) (string, error)
 }
 
 type stubClock struct {
@@ -368,8 +368,8 @@ func (s *stubRepositoryMirrorStore) TransportHints(context.Context, string, stri
 }
 
 func (s *stubRepositoryMirrorStore) EnsureSubmoduleMirror(ctx context.Context, submoduleRemoteURL, gitlinkSHA string) (string, error) {
-	if s.EnsureSubmoduleMirrorFunc != nil {
-		return s.EnsureSubmoduleMirrorFunc(ctx, submoduleRemoteURL, gitlinkSHA)
+	if s.ensureSubmoduleMirrorFunc != nil {
+		return s.ensureSubmoduleMirrorFunc(ctx, submoduleRemoteURL, gitlinkSHA)
 	}
 	return "", nil
 }

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -366,6 +366,13 @@ func (s *stubRepositoryMirrorStore) TransportHints(context.Context, string, stri
 	return repositorystore.TransportHints{}, nil
 }
 
+func (s *stubRepositoryMirrorStore) EnsureSubmoduleMirror(ctx context.Context, submoduleRemoteURL, gitlinkSHA string) (string, error) {
+	if err := s.EnsureMirrorContains(ctx, submoduleRemoteURL, gitlinkSHA); err != nil {
+		return "", err
+	}
+	return s.MirrorPath(submoduleRemoteURL)
+}
+
 func (c stubClock) Now() time.Time {
 	return c.now
 }

--- a/internal/gitbatch/gitbatch.go
+++ b/internal/gitbatch/gitbatch.go
@@ -1,0 +1,279 @@
+package gitbatch
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os/exec"
+	"path"
+	"strconv"
+	"strings"
+)
+
+type TreeEntry struct {
+	Mode string
+	Type string
+}
+
+func TreeEntriesForFiles(ctx context.Context, repoDir, commitSHA string, files []string) (map[string]TreeEntry, error) {
+	args := make([]string, 0, 5+len(files))
+	args = append(args, "-C", repoDir, "ls-tree", "-z", commitSHA, "--")
+	for _, f := range files {
+		args = append(args, ":(literal)"+f)
+	}
+	cmd := exec.CommandContext(ctx, "git", args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		message := strings.TrimSpace(string(output))
+		if message == "" {
+			message = err.Error()
+		}
+		return nil, fmt.Errorf("%s", message)
+	}
+
+	result := make(map[string]TreeEntry, len(files))
+	for _, raw := range bytes.Split(output, []byte{0}) {
+		if len(bytes.TrimSpace(raw)) == 0 {
+			continue
+		}
+		metadata, rawPath, ok := bytes.Cut(raw, []byte{'\t'})
+		if !ok {
+			return nil, fmt.Errorf("parse git tree entry %q", string(raw))
+		}
+		normalizedPath := path.Clean(strings.ReplaceAll(string(rawPath), "\\", "/"))
+		fields := strings.Fields(string(metadata))
+		if len(fields) < 3 {
+			return nil, fmt.Errorf("parse git tree entry %q", string(raw))
+		}
+		result[normalizedPath] = TreeEntry{Mode: fields[0], Type: fields[1]}
+	}
+	return result, nil
+}
+
+func FileDigestsAtCommit(ctx context.Context, repoDir, commitSHA string, files []string) (map[string]string, error) {
+	return FileDigestsBatch(ctx, repoDir, files, func(f string) string {
+		return commitSHA + ":" + f
+	})
+}
+
+func TreeEntriesForFilesInWorktree(ctx context.Context, repoDir string, files []string) (map[string]TreeEntry, error) {
+	args := make([]string, 0, 5+len(files))
+	args = append(args, "-C", repoDir, "ls-files", "--stage", "-z", "--")
+	for _, f := range files {
+		args = append(args, ":(literal)"+f)
+	}
+	cmd := exec.CommandContext(ctx, "git", args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		message := strings.TrimSpace(string(output))
+		if message == "" {
+			message = err.Error()
+		}
+		return nil, fmt.Errorf("%s", message)
+	}
+
+	result := make(map[string]TreeEntry, len(files))
+	for _, raw := range bytes.Split(output, []byte{0}) {
+		if len(bytes.TrimSpace(raw)) == 0 {
+			continue
+		}
+		metadata, rawPath, ok := bytes.Cut(raw, []byte{'\t'})
+		if !ok {
+			return nil, fmt.Errorf("parse git ls-files entry %q", string(raw))
+		}
+		normalizedPath := path.Clean(strings.ReplaceAll(string(rawPath), "\\", "/"))
+		fields := strings.Fields(string(metadata))
+		if len(fields) < 3 {
+			return nil, fmt.Errorf("parse git ls-files entry %q", string(raw))
+		}
+		mode := fields[0]
+		entryType := "blob"
+		if mode == "160000" {
+			entryType = "commit"
+		}
+		result[normalizedPath] = TreeEntry{Mode: mode, Type: entryType}
+	}
+	return result, nil
+}
+
+func FileDigestsInWorktree(ctx context.Context, repoDir string, files []string) (map[string]string, error) {
+	return FileDigestsBatch(ctx, repoDir, files, func(f string) string {
+		return ":" + f
+	})
+}
+
+func FileDigestsBatch(ctx context.Context, repoDir string, files []string, specFn func(string) string) (map[string]string, error) {
+	if len(files) == 0 {
+		return map[string]string{}, nil
+	}
+
+	cmd := exec.CommandContext(ctx, "git", "-C", repoDir, "cat-file", "--batch")
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("create git cat-file stdin pipe: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("create git cat-file stdout pipe: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("start git cat-file: %w", err)
+	}
+
+	type result struct {
+		digests map[string]string
+		err     error
+	}
+
+	writerDone := make(chan error, 1)
+	readerDone := make(chan result, 1)
+
+	go func() {
+		var writeErr error
+		for _, f := range files {
+			if _, err := io.WriteString(stdin, specFn(f)+"\n"); err != nil {
+				writeErr = fmt.Errorf("write git cat-file spec for %q: %w", f, err)
+				break
+			}
+		}
+		stdin.Close()
+		writerDone <- writeErr
+	}()
+
+	go func() {
+		sendErr := func(err error) {
+			io.Copy(io.Discard, stdout)
+			readerDone <- result{nil, err}
+		}
+
+		digests := make(map[string]string, len(files))
+		buf := make([]byte, 32*1024)
+		reader := &bufferedReader{r: stdout, buf: make([]byte, 0, 64*1024)}
+
+		for _, f := range files {
+			header, err := reader.readLine()
+			if err != nil {
+				sendErr(fmt.Errorf("read git cat-file header for %q: %w", f, err))
+				return
+			}
+			headerStr := strings.TrimRight(string(header), "\n")
+			if strings.HasSuffix(headerStr, " missing") {
+				sendErr(fmt.Errorf("git cat-file reports %q is missing", specFn(f)))
+				return
+			}
+			fields := strings.Fields(headerStr)
+			if len(fields) < 3 {
+				sendErr(fmt.Errorf("parse git cat-file header %q", headerStr))
+				return
+			}
+			size, err := strconv.ParseInt(fields[2], 10, 64)
+			if err != nil {
+				sendErr(fmt.Errorf("parse git cat-file size %q: %w", fields[2], err))
+				return
+			}
+
+			h := sha256.New()
+			remaining := size
+			for remaining > 0 {
+				toRead := int64(len(buf))
+				if remaining < toRead {
+					toRead = remaining
+				}
+				n, err := reader.read(buf[:toRead])
+				if err != nil && err != io.EOF {
+					sendErr(fmt.Errorf("read git cat-file content for %q: %w", f, err))
+					return
+				}
+				h.Write(buf[:n])
+				remaining -= int64(n)
+				if err == io.EOF && remaining > 0 {
+					sendErr(fmt.Errorf("unexpected EOF reading git cat-file content for %q", f))
+					return
+				}
+			}
+
+			if _, err := reader.readByte(); err != nil {
+				sendErr(fmt.Errorf("read git cat-file trailing newline for %q: %w", f, err))
+				return
+			}
+
+			digests[f] = "sha256:" + hex.EncodeToString(h.Sum(nil))
+		}
+		readerDone <- result{digests, nil}
+	}()
+
+	writeErr := <-writerDone
+	readResult := <-readerDone
+
+	if waitErr := cmd.Wait(); waitErr != nil && writeErr == nil && readResult.err == nil {
+		return nil, fmt.Errorf("git cat-file: %w", waitErr)
+	}
+	if writeErr != nil {
+		return nil, writeErr
+	}
+	if readResult.err != nil {
+		return nil, readResult.err
+	}
+	return readResult.digests, nil
+}
+
+type bufferedReader struct {
+	r   io.Reader
+	buf []byte
+	pos int
+	end int
+}
+
+func (b *bufferedReader) fill() error {
+	if b.pos < b.end {
+		return nil
+	}
+	b.buf = b.buf[:cap(b.buf)]
+	n, err := b.r.Read(b.buf)
+	b.buf = b.buf[:n]
+	b.pos = 0
+	b.end = n
+	if n == 0 && err != nil {
+		return err
+	}
+	return nil
+}
+
+func (b *bufferedReader) readByte() (byte, error) {
+	for b.pos >= b.end {
+		if err := b.fill(); err != nil {
+			return 0, err
+		}
+	}
+	ch := b.buf[b.pos]
+	b.pos++
+	return ch, nil
+}
+
+func (b *bufferedReader) readLine() ([]byte, error) {
+	var line []byte
+	for {
+		ch, err := b.readByte()
+		if err != nil {
+			return nil, err
+		}
+		line = append(line, ch)
+		if ch == '\n' {
+			return line, nil
+		}
+	}
+}
+
+func (b *bufferedReader) read(p []byte) (int, error) {
+	if b.pos >= b.end {
+		if err := b.fill(); err != nil {
+			return 0, err
+		}
+	}
+	n := copy(p, b.buf[b.pos:b.end])
+	b.pos += n
+	return n, nil
+}

--- a/internal/repositorychangeset/changeset.go
+++ b/internal/repositorychangeset/changeset.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/bmatcuk/doublestar/v4"
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
 	"github.com/buildkite/cleanroom/internal/repositorycheckout"
 )
@@ -226,8 +227,8 @@ func expandDigestPathsInIndex(repoRoot string, env []string, baseCommitSHA strin
 			expanded = append(expanded, normalizedPath)
 			continue
 		}
-		if _, err := path.Match(normalizedPath, ""); err != nil {
-			return nil, fmt.Errorf("repository changeset digest path glob %q is invalid: %w", normalizedPath, err)
+		if !doublestar.ValidatePattern(normalizedPath) {
+			return nil, fmt.Errorf("repository changeset digest path glob %q is invalid: %w", normalizedPath, path.ErrBadPattern)
 		}
 		if indexPaths == nil {
 			var err error
@@ -238,7 +239,7 @@ func expandDigestPathsInIndex(repoRoot string, env []string, baseCommitSHA strin
 		}
 		matches := 0
 		for _, candidate := range indexPaths {
-			matched, err := path.Match(normalizedPath, candidate)
+			matched, err := doublestar.Match(normalizedPath, candidate)
 			if err != nil {
 				return nil, fmt.Errorf("repository changeset digest path glob %q is invalid: %w", normalizedPath, err)
 			}
@@ -277,8 +278,8 @@ func expandRegularDigestPathsInIndex(repoRoot string, env []string, paths []stri
 			expanded = append(expanded, normalizedPath)
 			continue
 		}
-		if _, err := path.Match(normalizedPath, ""); err != nil {
-			return nil, fmt.Errorf("repository changeset input path glob %q is invalid: %w", normalizedPath, err)
+		if !doublestar.ValidatePattern(normalizedPath) {
+			return nil, fmt.Errorf("repository changeset input path glob %q is invalid: %w", normalizedPath, path.ErrBadPattern)
 		}
 		if indexPaths == nil {
 			var err error
@@ -289,7 +290,7 @@ func expandRegularDigestPathsInIndex(repoRoot string, env []string, paths []stri
 		}
 		matches := 0
 		for _, candidate := range indexPaths {
-			matched, err := path.Match(normalizedPath, candidate)
+			matched, err := doublestar.Match(normalizedPath, candidate)
 			if err != nil {
 				return nil, fmt.Errorf("repository changeset input path glob %q is invalid: %w", normalizedPath, err)
 			}

--- a/internal/repositorychangeset/changeset.go
+++ b/internal/repositorychangeset/changeset.go
@@ -277,6 +277,7 @@ func expandDigestPathsInIndex(repoRoot string, env []string, baseCommitSHA strin
 	seen := make(map[string]struct{}, len(paths))
 	var expanded []string
 	var indexPaths []string
+	var candidates []string
 	for _, rawPath := range paths {
 		normalizedPath := normalizePath(rawPath)
 		if normalizedPath == "" {
@@ -293,16 +294,20 @@ func expandDigestPathsInIndex(repoRoot string, env []string, baseCommitSHA strin
 		if !doublestar.ValidatePattern(normalizedPath) {
 			return nil, fmt.Errorf("repository changeset digest path glob %q is invalid: %w", normalizedPath, path.ErrBadPattern)
 		}
-		if indexPaths == nil {
+		if candidates == nil {
 			var err error
 			indexPaths, err = listIndexPathsIncludingDeleted(repoRoot, env, baseCommitSHA)
 			if err != nil {
 				return nil, err
 			}
-		}
-		candidates := indexPaths
-		if len(worktreeSubs) > 0 {
-			candidates = mergeSubmoduleFiles(candidates, worktreeSubs)
+			if len(worktreeSubs) > 0 {
+				candidates, err = mergeSubmoduleFiles(indexPaths, worktreeSubs)
+				if err != nil {
+					return nil, err
+				}
+			} else {
+				candidates = indexPaths
+			}
 		}
 		matches := 0
 		for _, candidate := range candidates {
@@ -335,6 +340,7 @@ func expandRegularDigestPathsInIndex(repoRoot string, env []string, paths []stri
 	seen := make(map[string]struct{}, len(paths))
 	var expanded []string
 	var indexPaths []string
+	var candidates []string
 	for _, rawPath := range paths {
 		normalizedPath := normalizePath(rawPath)
 		if normalizedPath == "" {
@@ -351,16 +357,20 @@ func expandRegularDigestPathsInIndex(repoRoot string, env []string, paths []stri
 		if !doublestar.ValidatePattern(normalizedPath) {
 			return nil, fmt.Errorf("repository changeset input path glob %q is invalid: %w", normalizedPath, path.ErrBadPattern)
 		}
-		if indexPaths == nil {
+		if candidates == nil {
 			var err error
 			indexPaths, err = listIndexPaths(repoRoot, env)
 			if err != nil {
 				return nil, err
 			}
-		}
-		candidates := indexPaths
-		if len(worktreeSubs) > 0 {
-			candidates = mergeSubmoduleFiles(candidates, worktreeSubs)
+			if len(worktreeSubs) > 0 {
+				candidates, err = mergeSubmoduleFiles(indexPaths, worktreeSubs)
+				if err != nil {
+					return nil, err
+				}
+			} else {
+				candidates = indexPaths
+			}
 		}
 		matches := 0
 		for _, candidate := range candidates {
@@ -824,7 +834,7 @@ func literalGitPathspec(normalizedPath string) string {
 	return ":(literal)" + normalizedPath
 }
 
-func mergeSubmoduleFiles(indexPaths []string, worktreeSubs []submodule.WorktreeSubmodule) []string {
+func mergeSubmoduleFiles(indexPaths []string, worktreeSubs []submodule.WorktreeSubmodule) ([]string, error) {
 	smPaths := make(map[string]struct{}, len(worktreeSubs))
 	for _, sm := range worktreeSubs {
 		smPaths[sm.Path] = struct{}{}
@@ -841,7 +851,7 @@ func mergeSubmoduleFiles(indexPaths []string, worktreeSubs []submodule.WorktreeS
 	for _, sm := range worktreeSubs {
 		smFiles, err := submodule.ListWorktreeSubmoduleFiles(sm)
 		if err != nil {
-			continue
+			return nil, fmt.Errorf("list files for submodule %q: %w", sm.Path, err)
 		}
 		for _, f := range smFiles {
 			if _, exists := seen[f]; exists {
@@ -852,7 +862,7 @@ func mergeSubmoduleFiles(indexPaths []string, worktreeSubs []submodule.WorktreeS
 		}
 	}
 	sort.Strings(merged)
-	return merged
+	return merged, nil
 }
 
 func checkGitlinkOptIn(repoRoot string, env []string, pattern string) error {

--- a/internal/repositorychangeset/changeset.go
+++ b/internal/repositorychangeset/changeset.go
@@ -2,6 +2,7 @@ package repositorychangeset
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/bmatcuk/doublestar/v4"
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+	"github.com/buildkite/cleanroom/internal/gitbatch"
 	"github.com/buildkite/cleanroom/internal/repositorycheckout"
 	"github.com/buildkite/cleanroom/internal/submodule"
 )
@@ -204,12 +206,38 @@ func (c *Changeset) digestPathsFromBase(repoRoot string, paths []string, regular
 		strippedPath string
 	}
 	subFiles := make(map[string]subFileKey)
+	subsByPath := make(map[string][]string)
 	if len(worktreeSubs) > 0 {
 		for _, normalizedPath := range expandedPaths {
 			if sm, ok := submodule.FindSubmoduleForPath(normalizedPath, worktreeSubs); ok {
 				strippedPath := strings.TrimPrefix(normalizedPath, sm.Path+"/")
 				subFiles[normalizedPath] = subFileKey{sm: sm, strippedPath: strippedPath}
+				subsByPath[sm.WorktreeDir] = append(subsByPath[sm.WorktreeDir], strippedPath)
 			}
+		}
+	}
+
+	subEntries := make(map[string]map[string]gitbatch.TreeEntry)
+	subDigests := make(map[string]map[string]string)
+	for worktreeDir, strippedPaths := range subsByPath {
+		entries, entriesErr := gitbatch.TreeEntriesForFilesInWorktree(context.Background(), worktreeDir, strippedPaths)
+		if entriesErr != nil {
+			return nil, fmt.Errorf("read submodule index at %q: %w", worktreeDir, entriesErr)
+		}
+		subEntries[worktreeDir] = entries
+
+		var regularPaths []string
+		for _, sp := range strippedPaths {
+			if e, ok := entries[sp]; ok && isRegularGitFileMode(e.Mode) {
+				regularPaths = append(regularPaths, sp)
+			}
+		}
+		if len(regularPaths) > 0 {
+			digests, digestErr := gitbatch.FileDigestsInWorktree(context.Background(), worktreeDir, regularPaths)
+			if digestErr != nil {
+				return nil, fmt.Errorf("read submodule file digests at %q: %w", worktreeDir, digestErr)
+			}
+			subDigests[worktreeDir] = digests
 		}
 	}
 
@@ -218,10 +246,8 @@ func (c *Changeset) digestPathsFromBase(repoRoot string, paths []string, regular
 		file := File{Path: normalizedPath}
 
 		if key, inSub := subFiles[normalizedPath]; inSub {
-			mode, exists, modeErr := pathModeInSubmodule(key.sm.WorktreeDir, key.strippedPath)
-			if modeErr != nil {
-				return nil, fmt.Errorf("check repository changeset path %q in submodule index: %w", normalizedPath, modeErr)
-			}
+			entries := subEntries[key.sm.WorktreeDir]
+			entry, exists := entries[key.strippedPath]
 			if !exists {
 				if regularFilesOnly {
 					return nil, fmt.Errorf("repository changeset input path %q does not exist", normalizedPath)
@@ -230,15 +256,15 @@ func (c *Changeset) digestPathsFromBase(repoRoot string, paths []string, regular
 				files = append(files, file)
 				continue
 			}
-			file.Mode = mode
-			if regularFilesOnly && !isRegularGitFileMode(mode) {
-				return nil, fmt.Errorf("repository changeset input path %q is %s; inputs.files must name regular files", normalizedPath, gitModeKind(mode))
+			file.Mode = entry.Mode
+			if regularFilesOnly && !isRegularGitFileMode(entry.Mode) {
+				return nil, fmt.Errorf("repository changeset input path %q is %s; inputs.files must name regular files", normalizedPath, gitModeKind(entry.Mode))
 			}
-			blob, blobErr := gitOutput(key.sm.WorktreeDir, os.Environ(), "show", ":"+key.strippedPath)
-			if blobErr != nil {
-				return nil, fmt.Errorf("read repository changeset path %q from submodule: %w", normalizedPath, blobErr)
+			digest, ok := subDigests[key.sm.WorktreeDir][key.strippedPath]
+			if !ok {
+				return nil, fmt.Errorf("read repository changeset path %q from submodule: missing digest", normalizedPath)
 			}
-			file.SHA256 = sha256Digest(blob)
+			file.SHA256 = digest
 			files = append(files, file)
 			continue
 		}
@@ -897,14 +923,6 @@ func checkGitlinkOptIn(repoRoot string, env []string, pattern string) error {
 		}
 	}
 	return nil
-}
-
-func pathModeInSubmodule(worktreeDir, strippedPath string) (string, bool, error) {
-	output, err := gitOutput(worktreeDir, os.Environ(), "ls-files", "--stage", "-z", "--", literalGitPathspec(strippedPath))
-	if err != nil {
-		return "", false, err
-	}
-	return gitIndexMode(output, strippedPath)
 }
 
 func listIndexPaths(repoRoot string, env []string) ([]string, error) {

--- a/internal/repositorychangeset/changeset.go
+++ b/internal/repositorychangeset/changeset.go
@@ -112,6 +112,156 @@ func BuildFromWorkingTree(repoRoot string, checkout *repositorycheckout.Checkout
 
 type DigestPathsOptions struct {
 	Submodules bool
+	// ParentRemoteURL is the parent repository's remote URL, used to resolve
+	// relative submodule URLs (e.g. ../sister.git) found in .gitmodules.
+	ParentRemoteURL string
+	// EnsureSubmoduleMirror, when set, makes the changeset digest path resolve
+	// submodule contents from per-submodule git mirrors at the gitlink SHA
+	// recorded in the temporary index. When nil (the default), the path falls
+	// back to reading submodule contents from the user's working tree, which
+	// only works when repoRoot is a real working tree with initialised
+	// submodules.
+	EnsureSubmoduleMirror func(ctx context.Context, remoteURL, gitlinkSHA string) (mirrorDir string, err error)
+}
+
+// submoduleSource describes one submodule's location and how to read its
+// contents during digesting. Either WorktreeDir is set (and we use
+// gitbatch.*InWorktree against the working tree) or MirrorDir + GitlinkSHA
+// is set (and we use gitbatch.*ForFiles / gitbatch.FileDigestsAtCommit
+// against the bare submodule mirror at the recorded gitlink SHA).
+type submoduleSource struct {
+	Path       string
+	SourceDir  string
+	GitlinkSHA string // empty for worktree mode
+}
+
+// submoduleSet groups submoduleSource entries with helpers used during digest
+// expansion and resolution.
+type submoduleSet []submoduleSource
+
+func (s submoduleSet) Paths() []string {
+	out := make([]string, len(s))
+	for i, sub := range s {
+		out[i] = sub.Path
+	}
+	return out
+}
+
+func (s submoduleSet) FindForPath(p string) (submoduleSource, bool) {
+	var best submoduleSource
+	found := false
+	for _, sub := range s {
+		if strings.HasPrefix(p, sub.Path+"/") {
+			if !found || len(sub.Path) > len(best.Path) {
+				best = sub
+				found = true
+			}
+		}
+	}
+	return best, found
+}
+
+func loadSubmodulesForDigest(repoRoot string, env []string, opts DigestPathsOptions) (submoduleSet, error) {
+	if !opts.Submodules {
+		return nil, nil
+	}
+	if opts.EnsureSubmoduleMirror != nil {
+		mirrors, err := submodule.ListMirrorSubmodulesAtIndex(context.Background(), repoRoot, env, opts.ParentRemoteURL, opts.EnsureSubmoduleMirror)
+		if err != nil {
+			return nil, fmt.Errorf("list submodules from index: %w", err)
+		}
+		set := make(submoduleSet, 0, len(mirrors))
+		for _, m := range mirrors {
+			set = append(set, submoduleSource{Path: m.Path, SourceDir: m.MirrorDir, GitlinkSHA: m.GitlinkSHA})
+		}
+		return set, nil
+	}
+	worktrees, err := submodule.ListWorktreeSubmodules(repoRoot)
+	if err != nil {
+		return nil, fmt.Errorf("list submodules: %w", err)
+	}
+	set := make(submoduleSet, 0, len(worktrees))
+	for _, w := range worktrees {
+		set = append(set, submoduleSource{Path: w.Path, SourceDir: w.WorktreeDir})
+	}
+	return set, nil
+}
+
+func listSubmoduleFiles(sub submoduleSource) ([]string, error) {
+	if sub.GitlinkSHA != "" {
+		ms := submodule.MirrorSubmodule{Path: sub.Path, MirrorDir: sub.SourceDir, GitlinkSHA: sub.GitlinkSHA}
+		files, err := submodule.ListMirrorSubmoduleFilesAtSHA(context.Background(), ms)
+		if err != nil {
+			return nil, err
+		}
+		return files, nil
+	}
+	return submodule.ListWorktreeSubmoduleFiles(submodule.WorktreeSubmodule{Path: sub.Path, WorktreeDir: sub.SourceDir})
+}
+
+type submoduleResolutionKey struct {
+	sourceDir    string
+	strippedPath string
+}
+
+func resolveSubmoduleDigests(subs submoduleSet, expandedPaths []string) (map[string]submoduleResolutionKey, map[string]map[string]gitbatch.TreeEntry, map[string]map[string]string, error) {
+	subFiles := make(map[string]submoduleResolutionKey)
+	type sourceInfo struct {
+		dir        string
+		gitlinkSHA string
+	}
+	pathsBySource := make(map[string]sourceInfo)
+	stripped := make(map[string][]string)
+	for _, normalizedPath := range expandedPaths {
+		sub, ok := subs.FindForPath(normalizedPath)
+		if !ok {
+			continue
+		}
+		strippedPath := strings.TrimPrefix(normalizedPath, sub.Path+"/")
+		subFiles[normalizedPath] = submoduleResolutionKey{sourceDir: sub.SourceDir, strippedPath: strippedPath}
+		pathsBySource[sub.SourceDir] = sourceInfo{dir: sub.SourceDir, gitlinkSHA: sub.GitlinkSHA}
+		stripped[sub.SourceDir] = append(stripped[sub.SourceDir], strippedPath)
+	}
+
+	subEntries := make(map[string]map[string]gitbatch.TreeEntry)
+	subDigests := make(map[string]map[string]string)
+	for sourceDir, strippedPaths := range stripped {
+		info := pathsBySource[sourceDir]
+		entries, err := readSubmoduleTreeEntries(info.dir, info.gitlinkSHA, strippedPaths)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("read submodule index at %q: %w", sourceDir, err)
+		}
+		subEntries[sourceDir] = entries
+
+		var regularPaths []string
+		for _, sp := range strippedPaths {
+			if e, ok := entries[sp]; ok && isRegularGitFileMode(e.Mode) {
+				regularPaths = append(regularPaths, sp)
+			}
+		}
+		if len(regularPaths) > 0 {
+			digests, err := readSubmoduleFileDigests(info.dir, info.gitlinkSHA, regularPaths)
+			if err != nil {
+				return nil, nil, nil, fmt.Errorf("read submodule file digests at %q: %w", sourceDir, err)
+			}
+			subDigests[sourceDir] = digests
+		}
+	}
+	return subFiles, subEntries, subDigests, nil
+}
+
+func readSubmoduleTreeEntries(sourceDir, gitlinkSHA string, strippedPaths []string) (map[string]gitbatch.TreeEntry, error) {
+	if gitlinkSHA != "" {
+		return gitbatch.TreeEntriesForFiles(context.Background(), sourceDir, gitlinkSHA, strippedPaths)
+	}
+	return gitbatch.TreeEntriesForFilesInWorktree(context.Background(), sourceDir, strippedPaths)
+}
+
+func readSubmoduleFileDigests(sourceDir, gitlinkSHA string, regularPaths []string) (map[string]string, error) {
+	if gitlinkSHA != "" {
+		return gitbatch.FileDigestsAtCommit(context.Background(), sourceDir, gitlinkSHA, regularPaths)
+	}
+	return gitbatch.FileDigestsInWorktree(context.Background(), sourceDir, regularPaths)
 }
 
 func (c *Changeset) DigestPathsFromBase(repoRoot string, paths []string) ([]File, error) {
@@ -183,62 +333,24 @@ func (c *Changeset) digestPathsFromBase(repoRoot string, paths []string, regular
 		return nil, fmt.Errorf("apply repository changeset patch to temporary git index: %w", err)
 	}
 
-	var worktreeSubs []submodule.WorktreeSubmodule
-	if opts.Submodules {
-		worktreeSubs, err = submodule.ListWorktreeSubmodules(repoRoot)
-		if err != nil {
-			return nil, fmt.Errorf("list submodules: %w", err)
-		}
+	subs, err := loadSubmodulesForDigest(repoRoot, env, opts)
+	if err != nil {
+		return nil, err
 	}
 
 	var expandedPaths []string
 	if regularFilesOnly {
-		expandedPaths, err = expandRegularDigestPathsInIndex(repoRoot, env, paths, worktreeSubs)
+		expandedPaths, err = expandRegularDigestPathsInIndex(repoRoot, env, paths, subs)
 	} else {
-		expandedPaths, err = expandDigestPathsInIndex(repoRoot, env, baseCommitSHA, paths, worktreeSubs)
+		expandedPaths, err = expandDigestPathsInIndex(repoRoot, env, baseCommitSHA, paths, subs)
 	}
 	if err != nil {
 		return nil, err
 	}
 
-	type subFileKey struct {
-		sm           submodule.WorktreeSubmodule
-		strippedPath string
-	}
-	subFiles := make(map[string]subFileKey)
-	subsByPath := make(map[string][]string)
-	if len(worktreeSubs) > 0 {
-		for _, normalizedPath := range expandedPaths {
-			if sm, ok := submodule.FindSubmoduleForPath(normalizedPath, worktreeSubs); ok {
-				strippedPath := strings.TrimPrefix(normalizedPath, sm.Path+"/")
-				subFiles[normalizedPath] = subFileKey{sm: sm, strippedPath: strippedPath}
-				subsByPath[sm.WorktreeDir] = append(subsByPath[sm.WorktreeDir], strippedPath)
-			}
-		}
-	}
-
-	subEntries := make(map[string]map[string]gitbatch.TreeEntry)
-	subDigests := make(map[string]map[string]string)
-	for worktreeDir, strippedPaths := range subsByPath {
-		entries, entriesErr := gitbatch.TreeEntriesForFilesInWorktree(context.Background(), worktreeDir, strippedPaths)
-		if entriesErr != nil {
-			return nil, fmt.Errorf("read submodule index at %q: %w", worktreeDir, entriesErr)
-		}
-		subEntries[worktreeDir] = entries
-
-		var regularPaths []string
-		for _, sp := range strippedPaths {
-			if e, ok := entries[sp]; ok && isRegularGitFileMode(e.Mode) {
-				regularPaths = append(regularPaths, sp)
-			}
-		}
-		if len(regularPaths) > 0 {
-			digests, digestErr := gitbatch.FileDigestsInWorktree(context.Background(), worktreeDir, regularPaths)
-			if digestErr != nil {
-				return nil, fmt.Errorf("read submodule file digests at %q: %w", worktreeDir, digestErr)
-			}
-			subDigests[worktreeDir] = digests
-		}
+	subFiles, subEntries, subDigests, err := resolveSubmoduleDigests(subs, expandedPaths)
+	if err != nil {
+		return nil, err
 	}
 
 	files := make([]File, 0, len(expandedPaths))
@@ -246,7 +358,7 @@ func (c *Changeset) digestPathsFromBase(repoRoot string, paths []string, regular
 		file := File{Path: normalizedPath}
 
 		if key, inSub := subFiles[normalizedPath]; inSub {
-			entries := subEntries[key.sm.WorktreeDir]
+			entries := subEntries[key.sourceDir]
 			entry, exists := entries[key.strippedPath]
 			if !exists {
 				if regularFilesOnly {
@@ -260,7 +372,7 @@ func (c *Changeset) digestPathsFromBase(repoRoot string, paths []string, regular
 			if regularFilesOnly && !isRegularGitFileMode(entry.Mode) {
 				return nil, fmt.Errorf("repository changeset input path %q is %s; inputs.files must name regular files", normalizedPath, gitModeKind(entry.Mode))
 			}
-			digest, ok := subDigests[key.sm.WorktreeDir][key.strippedPath]
+			digest, ok := subDigests[key.sourceDir][key.strippedPath]
 			if !ok {
 				return nil, fmt.Errorf("read repository changeset path %q from submodule: missing digest", normalizedPath)
 			}
@@ -299,7 +411,7 @@ func (c *Changeset) digestPathsFromBase(repoRoot string, paths []string, regular
 	return files, nil
 }
 
-func expandDigestPathsInIndex(repoRoot string, env []string, baseCommitSHA string, paths []string, worktreeSubs []submodule.WorktreeSubmodule) ([]string, error) {
+func expandDigestPathsInIndex(repoRoot string, env []string, baseCommitSHA string, paths []string, subs submoduleSet) ([]string, error) {
 	seen := make(map[string]struct{}, len(paths))
 	var expanded []string
 	var indexPaths []string
@@ -326,8 +438,8 @@ func expandDigestPathsInIndex(repoRoot string, env []string, baseCommitSHA strin
 			if err != nil {
 				return nil, err
 			}
-			if len(worktreeSubs) > 0 {
-				candidates, err = mergeSubmoduleFiles(indexPaths, worktreeSubs)
+			if len(subs) > 0 {
+				candidates, err = mergeSubmoduleFiles(indexPaths, subs)
 				if err != nil {
 					return nil, err
 				}
@@ -362,7 +474,7 @@ func expandDigestPathsInIndex(repoRoot string, env []string, baseCommitSHA strin
 	return expanded, nil
 }
 
-func expandRegularDigestPathsInIndex(repoRoot string, env []string, paths []string, worktreeSubs []submodule.WorktreeSubmodule) ([]string, error) {
+func expandRegularDigestPathsInIndex(repoRoot string, env []string, paths []string, subs submoduleSet) ([]string, error) {
 	seen := make(map[string]struct{}, len(paths))
 	var expanded []string
 	var indexPaths []string
@@ -389,8 +501,8 @@ func expandRegularDigestPathsInIndex(repoRoot string, env []string, paths []stri
 			if err != nil {
 				return nil, err
 			}
-			if len(worktreeSubs) > 0 {
-				candidates, err = mergeSubmoduleFiles(indexPaths, worktreeSubs)
+			if len(subs) > 0 {
+				candidates, err = mergeSubmoduleFiles(indexPaths, subs)
 				if err != nil {
 					return nil, err
 				}
@@ -860,10 +972,10 @@ func literalGitPathspec(normalizedPath string) string {
 	return ":(literal)" + normalizedPath
 }
 
-func mergeSubmoduleFiles(indexPaths []string, worktreeSubs []submodule.WorktreeSubmodule) ([]string, error) {
-	smPaths := make(map[string]struct{}, len(worktreeSubs))
-	for _, sm := range worktreeSubs {
-		smPaths[sm.Path] = struct{}{}
+func mergeSubmoduleFiles(indexPaths []string, subs submoduleSet) ([]string, error) {
+	smPaths := make(map[string]struct{}, len(subs))
+	for _, sub := range subs {
+		smPaths[sub.Path] = struct{}{}
 	}
 	seen := make(map[string]struct{}, len(indexPaths))
 	merged := make([]string, 0, len(indexPaths))
@@ -874,10 +986,10 @@ func mergeSubmoduleFiles(indexPaths []string, worktreeSubs []submodule.WorktreeS
 		seen[p] = struct{}{}
 		merged = append(merged, p)
 	}
-	for _, sm := range worktreeSubs {
-		smFiles, err := submodule.ListWorktreeSubmoduleFiles(sm)
+	for _, sub := range subs {
+		smFiles, err := listSubmoduleFiles(sub)
 		if err != nil {
-			return nil, fmt.Errorf("list files for submodule %q: %w", sm.Path, err)
+			return nil, fmt.Errorf("list files for submodule %q: %w", sub.Path, err)
 		}
 		for _, f := range smFiles {
 			if _, exists := seen[f]; exists {

--- a/internal/repositorychangeset/changeset.go
+++ b/internal/repositorychangeset/changeset.go
@@ -868,7 +868,7 @@ func mergeSubmoduleFiles(indexPaths []string, worktreeSubs []submodule.WorktreeS
 func checkGitlinkOptIn(repoRoot string, env []string, pattern string) error {
 	output, err := gitOutput(repoRoot, env, "ls-files", "--stage", "-z")
 	if err != nil {
-		return nil
+		return fmt.Errorf("list git index for gitlink check: %w", err)
 	}
 	output = bytes.TrimRight(output, "\x00")
 	for _, entry := range bytes.Split(output, []byte{0}) {

--- a/internal/repositorychangeset/changeset.go
+++ b/internal/repositorychangeset/changeset.go
@@ -15,6 +15,7 @@ import (
 	"github.com/bmatcuk/doublestar/v4"
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
 	"github.com/buildkite/cleanroom/internal/repositorycheckout"
+	"github.com/buildkite/cleanroom/internal/submodule"
 )
 
 const FormatGitDiffV1 = "git-diff-v1"
@@ -107,15 +108,27 @@ func BuildFromWorkingTree(repoRoot string, checkout *repositorycheckout.Checkout
 	}, nil
 }
 
+type DigestPathsOptions struct {
+	Submodules bool
+}
+
 func (c *Changeset) DigestPathsFromBase(repoRoot string, paths []string) ([]File, error) {
-	return c.digestPathsFromBase(repoRoot, paths, false)
+	return c.digestPathsFromBase(repoRoot, paths, false, DigestPathsOptions{})
 }
 
 func (c *Changeset) DigestRegularFilesFromBase(repoRoot string, paths []string) ([]File, error) {
-	return c.digestPathsFromBase(repoRoot, paths, true)
+	return c.digestPathsFromBase(repoRoot, paths, true, DigestPathsOptions{})
 }
 
-func (c *Changeset) digestPathsFromBase(repoRoot string, paths []string, regularFilesOnly bool) ([]File, error) {
+func (c *Changeset) DigestPathsFromBaseWithOptions(repoRoot string, paths []string, opts DigestPathsOptions) ([]File, error) {
+	return c.digestPathsFromBase(repoRoot, paths, false, opts)
+}
+
+func (c *Changeset) DigestRegularFilesFromBaseWithOptions(repoRoot string, paths []string, opts DigestPathsOptions) ([]File, error) {
+	return c.digestPathsFromBase(repoRoot, paths, true, opts)
+}
+
+func (c *Changeset) digestPathsFromBase(repoRoot string, paths []string, regularFilesOnly bool, opts DigestPathsOptions) ([]File, error) {
 	if c == nil {
 		return nil, errors.New("repository changeset is required")
 	}
@@ -168,18 +181,68 @@ func (c *Changeset) digestPathsFromBase(repoRoot string, paths []string, regular
 		return nil, fmt.Errorf("apply repository changeset patch to temporary git index: %w", err)
 	}
 
+	var worktreeSubs []submodule.WorktreeSubmodule
+	if opts.Submodules {
+		worktreeSubs, err = submodule.ListWorktreeSubmodules(repoRoot)
+		if err != nil {
+			return nil, fmt.Errorf("list submodules: %w", err)
+		}
+	}
+
 	var expandedPaths []string
 	if regularFilesOnly {
-		expandedPaths, err = expandRegularDigestPathsInIndex(repoRoot, env, paths)
+		expandedPaths, err = expandRegularDigestPathsInIndex(repoRoot, env, paths, worktreeSubs)
 	} else {
-		expandedPaths, err = expandDigestPathsInIndex(repoRoot, env, baseCommitSHA, paths)
+		expandedPaths, err = expandDigestPathsInIndex(repoRoot, env, baseCommitSHA, paths, worktreeSubs)
 	}
 	if err != nil {
 		return nil, err
 	}
+
+	type subFileKey struct {
+		sm           submodule.WorktreeSubmodule
+		strippedPath string
+	}
+	subFiles := make(map[string]subFileKey)
+	if len(worktreeSubs) > 0 {
+		for _, normalizedPath := range expandedPaths {
+			if sm, ok := submodule.FindSubmoduleForPath(normalizedPath, worktreeSubs); ok {
+				strippedPath := strings.TrimPrefix(normalizedPath, sm.Path+"/")
+				subFiles[normalizedPath] = subFileKey{sm: sm, strippedPath: strippedPath}
+			}
+		}
+	}
+
 	files := make([]File, 0, len(expandedPaths))
 	for _, normalizedPath := range expandedPaths {
 		file := File{Path: normalizedPath}
+
+		if key, inSub := subFiles[normalizedPath]; inSub {
+			mode, exists, modeErr := pathModeInSubmodule(key.sm.WorktreeDir, key.strippedPath)
+			if modeErr != nil {
+				return nil, fmt.Errorf("check repository changeset path %q in submodule index: %w", normalizedPath, modeErr)
+			}
+			if !exists {
+				if regularFilesOnly {
+					return nil, fmt.Errorf("repository changeset input path %q does not exist", normalizedPath)
+				}
+				file.Deleted = true
+				files = append(files, file)
+				continue
+			}
+			file.Mode = mode
+			if regularFilesOnly && !isRegularGitFileMode(mode) {
+				return nil, fmt.Errorf("repository changeset input path %q is %s; inputs.files must name regular files", normalizedPath, gitModeKind(mode))
+			}
+			blob, blobErr := gitOutput(key.sm.WorktreeDir, os.Environ(), "show", ":"+key.strippedPath)
+			if blobErr != nil {
+				return nil, fmt.Errorf("read repository changeset path %q from submodule: %w", normalizedPath, blobErr)
+			}
+			file.SHA256 = sha256Digest(blob)
+			files = append(files, file)
+			continue
+		}
+
 		mode, exists, err := pathModeInIndex(repoRoot, env, normalizedPath)
 		if err != nil {
 			return nil, fmt.Errorf("check repository changeset path %q in temporary git index: %w", normalizedPath, err)
@@ -210,7 +273,7 @@ func (c *Changeset) digestPathsFromBase(repoRoot string, paths []string, regular
 	return files, nil
 }
 
-func expandDigestPathsInIndex(repoRoot string, env []string, baseCommitSHA string, paths []string) ([]string, error) {
+func expandDigestPathsInIndex(repoRoot string, env []string, baseCommitSHA string, paths []string, worktreeSubs []submodule.WorktreeSubmodule) ([]string, error) {
 	seen := make(map[string]struct{}, len(paths))
 	var expanded []string
 	var indexPaths []string
@@ -237,8 +300,12 @@ func expandDigestPathsInIndex(repoRoot string, env []string, baseCommitSHA strin
 				return nil, err
 			}
 		}
+		candidates := indexPaths
+		if len(worktreeSubs) > 0 {
+			candidates = mergeSubmoduleFiles(candidates, worktreeSubs)
+		}
 		matches := 0
-		for _, candidate := range indexPaths {
+		for _, candidate := range candidates {
 			matched, err := doublestar.Match(normalizedPath, candidate)
 			if err != nil {
 				return nil, fmt.Errorf("repository changeset digest path glob %q is invalid: %w", normalizedPath, err)
@@ -254,6 +321,9 @@ func expandDigestPathsInIndex(repoRoot string, env []string, baseCommitSHA strin
 			expanded = append(expanded, candidate)
 		}
 		if matches == 0 {
+			if optInErr := checkGitlinkOptIn(repoRoot, env, normalizedPath); optInErr != nil {
+				return nil, optInErr
+			}
 			return nil, fmt.Errorf("repository changeset digest path glob %q matched no files", normalizedPath)
 		}
 	}
@@ -261,7 +331,7 @@ func expandDigestPathsInIndex(repoRoot string, env []string, baseCommitSHA strin
 	return expanded, nil
 }
 
-func expandRegularDigestPathsInIndex(repoRoot string, env []string, paths []string) ([]string, error) {
+func expandRegularDigestPathsInIndex(repoRoot string, env []string, paths []string, worktreeSubs []submodule.WorktreeSubmodule) ([]string, error) {
 	seen := make(map[string]struct{}, len(paths))
 	var expanded []string
 	var indexPaths []string
@@ -288,8 +358,12 @@ func expandRegularDigestPathsInIndex(repoRoot string, env []string, paths []stri
 				return nil, err
 			}
 		}
+		candidates := indexPaths
+		if len(worktreeSubs) > 0 {
+			candidates = mergeSubmoduleFiles(candidates, worktreeSubs)
+		}
 		matches := 0
-		for _, candidate := range indexPaths {
+		for _, candidate := range candidates {
 			matched, err := doublestar.Match(normalizedPath, candidate)
 			if err != nil {
 				return nil, fmt.Errorf("repository changeset input path glob %q is invalid: %w", normalizedPath, err)
@@ -305,6 +379,9 @@ func expandRegularDigestPathsInIndex(repoRoot string, env []string, paths []stri
 			expanded = append(expanded, candidate)
 		}
 		if matches == 0 {
+			if optInErr := checkGitlinkOptIn(repoRoot, env, normalizedPath); optInErr != nil {
+				return nil, optInErr
+			}
 			return nil, fmt.Errorf("repository changeset input path glob %q matched no files", normalizedPath)
 		}
 	}
@@ -745,6 +822,79 @@ func gitModeKind(mode string) string {
 
 func literalGitPathspec(normalizedPath string) string {
 	return ":(literal)" + normalizedPath
+}
+
+func mergeSubmoduleFiles(indexPaths []string, worktreeSubs []submodule.WorktreeSubmodule) []string {
+	smPaths := make(map[string]struct{}, len(worktreeSubs))
+	for _, sm := range worktreeSubs {
+		smPaths[sm.Path] = struct{}{}
+	}
+	seen := make(map[string]struct{}, len(indexPaths))
+	merged := make([]string, 0, len(indexPaths))
+	for _, p := range indexPaths {
+		if _, isGitlink := smPaths[p]; isGitlink {
+			continue
+		}
+		seen[p] = struct{}{}
+		merged = append(merged, p)
+	}
+	for _, sm := range worktreeSubs {
+		smFiles, err := submodule.ListWorktreeSubmoduleFiles(sm)
+		if err != nil {
+			continue
+		}
+		for _, f := range smFiles {
+			if _, exists := seen[f]; exists {
+				continue
+			}
+			seen[f] = struct{}{}
+			merged = append(merged, f)
+		}
+	}
+	sort.Strings(merged)
+	return merged
+}
+
+func checkGitlinkOptIn(repoRoot string, env []string, pattern string) error {
+	output, err := gitOutput(repoRoot, env, "ls-files", "--stage", "-z")
+	if err != nil {
+		return nil
+	}
+	output = bytes.TrimRight(output, "\x00")
+	for _, entry := range bytes.Split(output, []byte{0}) {
+		if len(entry) == 0 {
+			continue
+		}
+		metadata, rawPath, ok := bytes.Cut(entry, []byte{'\t'})
+		if !ok {
+			continue
+		}
+		fields := strings.Fields(string(metadata))
+		if len(fields) < 1 || fields[0] != "160000" {
+			continue
+		}
+		smPath := normalizePath(string(rawPath))
+		if smPath == "" {
+			continue
+		}
+		prefix := smPath + "/"
+		matched, matchErr := doublestar.Match(pattern, prefix+"x")
+		if matchErr != nil {
+			continue
+		}
+		if matched || strings.HasPrefix(pattern, prefix) {
+			return fmt.Errorf("repository changeset input path glob %q resolves into submodule %q; enable repository.submodules to digest submodule contents", pattern, smPath)
+		}
+	}
+	return nil
+}
+
+func pathModeInSubmodule(worktreeDir, strippedPath string) (string, bool, error) {
+	output, err := gitOutput(worktreeDir, os.Environ(), "ls-files", "--stage", "-z", "--", literalGitPathspec(strippedPath))
+	if err != nil {
+		return "", false, err
+	}
+	return gitIndexMode(output, strippedPath)
 }
 
 func listIndexPaths(repoRoot string, env []string) ([]string, error) {

--- a/internal/repositorychangeset/changeset_test.go
+++ b/internal/repositorychangeset/changeset_test.go
@@ -694,6 +694,246 @@ func TestWorktreeChangesCommandsRejectSubmoduleGitlinkChange(t *testing.T) {
 	}
 }
 
+func initGitRepositoryWithSubmodule(t *testing.T) (superDir, subDir string) {
+	t.Helper()
+	subDir = t.TempDir()
+	runGit(t, subDir, "init")
+	runGit(t, subDir, "config", "user.name", "Cleanroom Test")
+	runGit(t, subDir, "config", "user.email", "cleanroom-test@example.com")
+	if err := os.WriteFile(filepath.Join(subDir, "README.md"), []byte("submodule\n"), 0o644); err != nil {
+		t.Fatalf("write submodule README: %v", err)
+	}
+	runGit(t, subDir, "add", "README.md")
+	runGit(t, subDir, "commit", "-m", "initial submodule commit")
+
+	superDir = t.TempDir()
+	runGit(t, superDir, "init")
+	runGit(t, superDir, "config", "user.name", "Cleanroom Test")
+	runGit(t, superDir, "config", "user.email", "cleanroom-test@example.com")
+	if err := os.WriteFile(filepath.Join(superDir, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("write super README: %v", err)
+	}
+	runGit(t, superDir, "add", "README.md")
+	runGit(t, superDir, "commit", "-m", "initial")
+	runGitWithEnv(t, superDir, []string{"GIT_ALLOW_PROTOCOL=file"}, "-c", "protocol.file.allow=always", "submodule", "add", subDir, "vendor/emojis")
+	runGit(t, superDir, "commit", "-m", "add submodule")
+	return superDir, subDir
+}
+
+func TestDigestRegularFilesFromBaseExpandsSubmoduleGlob(t *testing.T) {
+	superDir, subDir := initGitRepositoryWithSubmodule(t)
+
+	if err := os.WriteFile(filepath.Join(subDir, "emoji1.json"), []byte(`{"name":"smile"}`), 0o644); err != nil {
+		t.Fatalf("write emoji1.json: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(subDir, "emoji2.json"), []byte(`{"name":"wink"}`), 0o644); err != nil {
+		t.Fatalf("write emoji2.json: %v", err)
+	}
+	runGit(t, subDir, "add", "emoji1.json", "emoji2.json")
+	runGit(t, subDir, "commit", "-m", "add emojis")
+	runGitWithEnv(t, superDir, []string{"GIT_ALLOW_PROTOCOL=file"}, "-c", "protocol.file.allow=always", "submodule", "update", "--remote", "vendor/emojis")
+	runGit(t, superDir, "add", "vendor/emojis")
+	runGit(t, superDir, "commit", "-m", "update submodule to include emojis")
+
+	if err := os.WriteFile(filepath.Join(superDir, "change.txt"), []byte("trigger changeset\n"), 0o644); err != nil {
+		t.Fatalf("write change.txt: %v", err)
+	}
+
+	checkout := &repositorycheckout.Checkout{
+		RemoteURL:      "https://github.com/buildkite/cleanroom.git",
+		CommitSHA:      headCommit(t, superDir),
+		DestinationDir: "/workspace",
+	}
+
+	changeset, err := BuildFromWorkingTree(superDir, checkout)
+	if err != nil {
+		t.Fatalf("BuildFromWorkingTree: %v", err)
+	}
+	if changeset == nil {
+		t.Fatal("expected changeset")
+	}
+
+	files, err := changeset.DigestRegularFilesFromBaseWithOptions(superDir, []string{"vendor/emojis/**"}, DigestPathsOptions{Submodules: true})
+	if err != nil {
+		t.Fatalf("DigestRegularFilesFromBaseWithOptions: %v", err)
+	}
+	if got, want := len(files), 3; got != want {
+		paths := make([]string, len(files))
+		for i, f := range files {
+			paths[i] = f.Path
+		}
+		t.Fatalf("unexpected file count: got %d want %d, paths: %v", got, want, paths)
+	}
+	for i := 1; i < len(files); i++ {
+		if files[i].Path < files[i-1].Path {
+			t.Fatalf("results not sorted: %q before %q", files[i-1].Path, files[i].Path)
+		}
+	}
+	for _, f := range files {
+		if f.Mode != "100644" {
+			t.Fatalf("expected mode 100644 for %q, got %q", f.Path, f.Mode)
+		}
+		if !strings.HasPrefix(f.SHA256, "sha256:") {
+			t.Fatalf("expected sha256 digest for %q, got %q", f.Path, f.SHA256)
+		}
+	}
+}
+
+func TestDigestRegularFilesFromBaseRejectsGitlinkLiteral(t *testing.T) {
+	superDir, _ := initGitRepositoryWithSubmodule(t)
+
+	if err := os.WriteFile(filepath.Join(superDir, "change.txt"), []byte("trigger changeset\n"), 0o644); err != nil {
+		t.Fatalf("write change.txt: %v", err)
+	}
+
+	checkout := &repositorycheckout.Checkout{
+		RemoteURL:      "https://github.com/buildkite/cleanroom.git",
+		CommitSHA:      headCommit(t, superDir),
+		DestinationDir: "/workspace",
+	}
+
+	changeset, err := BuildFromWorkingTree(superDir, checkout)
+	if err != nil {
+		t.Fatalf("BuildFromWorkingTree: %v", err)
+	}
+	if changeset == nil {
+		t.Fatal("expected changeset")
+	}
+
+	_, err = changeset.DigestRegularFilesFromBaseWithOptions(superDir, []string{"vendor/emojis"}, DigestPathsOptions{Submodules: true})
+	if err == nil {
+		t.Fatal("expected error for literal gitlink path")
+	}
+	if !strings.Contains(err.Error(), "gitlink") {
+		t.Fatalf("expected gitlink error, got %v", err)
+	}
+}
+
+func TestDigestRegularFilesFromBaseRequiresSubmodulesOptIn(t *testing.T) {
+	superDir, subDir := initGitRepositoryWithSubmodule(t)
+
+	if err := os.WriteFile(filepath.Join(subDir, "emoji1.json"), []byte(`{"name":"smile"}`), 0o644); err != nil {
+		t.Fatalf("write emoji1.json: %v", err)
+	}
+	runGit(t, subDir, "add", "emoji1.json")
+	runGit(t, subDir, "commit", "-m", "add emoji")
+	runGitWithEnv(t, superDir, []string{"GIT_ALLOW_PROTOCOL=file"}, "-c", "protocol.file.allow=always", "submodule", "update", "--remote", "vendor/emojis")
+	runGit(t, superDir, "add", "vendor/emojis")
+	runGit(t, superDir, "commit", "-m", "update submodule")
+
+	if err := os.WriteFile(filepath.Join(superDir, "change.txt"), []byte("trigger\n"), 0o644); err != nil {
+		t.Fatalf("write change.txt: %v", err)
+	}
+
+	checkout := &repositorycheckout.Checkout{
+		RemoteURL:      "https://github.com/buildkite/cleanroom.git",
+		CommitSHA:      headCommit(t, superDir),
+		DestinationDir: "/workspace",
+	}
+
+	changeset, err := BuildFromWorkingTree(superDir, checkout)
+	if err != nil {
+		t.Fatalf("BuildFromWorkingTree: %v", err)
+	}
+	if changeset == nil {
+		t.Fatal("expected changeset")
+	}
+
+	_, err = changeset.DigestRegularFilesFromBaseWithOptions(superDir, []string{"vendor/emojis/**"}, DigestPathsOptions{Submodules: false})
+	if err == nil {
+		t.Fatal("expected error when Submodules is false and pattern resolves into submodule")
+	}
+	if !strings.Contains(err.Error(), "submodule") && !strings.Contains(err.Error(), "gitlink") {
+		t.Fatalf("expected submodule or gitlink error, got %v", err)
+	}
+}
+
+func TestDigestRegularFilesFromBaseRejectsUninitialisedSubmodule(t *testing.T) {
+	superDir, _ := initGitRepositoryWithSubmodule(t)
+
+	if err := os.RemoveAll(filepath.Join(superDir, "vendor/emojis/.git")); err != nil {
+		t.Fatalf("remove submodule .git: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(superDir, "change.txt"), []byte("trigger\n"), 0o644); err != nil {
+		t.Fatalf("write change.txt: %v", err)
+	}
+
+	checkout := &repositorycheckout.Checkout{
+		RemoteURL:      "https://github.com/buildkite/cleanroom.git",
+		CommitSHA:      headCommit(t, superDir),
+		DestinationDir: "/workspace",
+	}
+
+	changeset, err := BuildFromWorkingTree(superDir, checkout)
+	if err != nil {
+		t.Fatalf("BuildFromWorkingTree: %v", err)
+	}
+	if changeset == nil {
+		t.Fatal("expected changeset")
+	}
+
+	_, err = changeset.DigestRegularFilesFromBaseWithOptions(superDir, []string{"vendor/emojis/**"}, DigestPathsOptions{Submodules: true})
+	if err == nil {
+		t.Fatal("expected error for uninitialised submodule")
+	}
+	if !strings.Contains(err.Error(), "initialised") && !strings.Contains(err.Error(), "initialized") && !strings.Contains(err.Error(), "submodule") {
+		t.Fatalf("expected uninitialised submodule error, got %v", err)
+	}
+}
+
+func TestDigestRegularFilesFromBaseStableAcrossRuns(t *testing.T) {
+	superDir, subDir := initGitRepositoryWithSubmodule(t)
+
+	if err := os.WriteFile(filepath.Join(subDir, "a.json"), []byte(`{"a":1}`), 0o644); err != nil {
+		t.Fatalf("write a.json: %v", err)
+	}
+	runGit(t, subDir, "add", "a.json")
+	runGit(t, subDir, "commit", "-m", "add a")
+	runGitWithEnv(t, superDir, []string{"GIT_ALLOW_PROTOCOL=file"}, "-c", "protocol.file.allow=always", "submodule", "update", "--remote", "vendor/emojis")
+	runGit(t, superDir, "add", "vendor/emojis")
+	runGit(t, superDir, "commit", "-m", "update submodule")
+
+	if err := os.WriteFile(filepath.Join(superDir, "change.txt"), []byte("trigger\n"), 0o644); err != nil {
+		t.Fatalf("write change.txt: %v", err)
+	}
+
+	checkout := &repositorycheckout.Checkout{
+		RemoteURL:      "https://github.com/buildkite/cleanroom.git",
+		CommitSHA:      headCommit(t, superDir),
+		DestinationDir: "/workspace",
+	}
+
+	changeset, err := BuildFromWorkingTree(superDir, checkout)
+	if err != nil {
+		t.Fatalf("BuildFromWorkingTree: %v", err)
+	}
+	if changeset == nil {
+		t.Fatal("expected changeset")
+	}
+
+	opts := DigestPathsOptions{Submodules: true}
+
+	first, err := changeset.DigestRegularFilesFromBaseWithOptions(superDir, []string{"vendor/emojis/**"}, opts)
+	if err != nil {
+		t.Fatalf("first DigestRegularFilesFromBaseWithOptions: %v", err)
+	}
+
+	second, err := changeset.DigestRegularFilesFromBaseWithOptions(superDir, []string{"vendor/emojis/**"}, opts)
+	if err != nil {
+		t.Fatalf("second DigestRegularFilesFromBaseWithOptions: %v", err)
+	}
+
+	if len(first) != len(second) {
+		t.Fatalf("file count mismatch: %d vs %d", len(first), len(second))
+	}
+	for i := range first {
+		if first[i].Path != second[i].Path || first[i].SHA256 != second[i].SHA256 {
+			t.Fatalf("result differs at index %d: %+v vs %+v", i, first[i], second[i])
+		}
+	}
+}
+
 func initGitRepository(t *testing.T) string {
 	t.Helper()
 

--- a/internal/repositorychangeset/changeset_test.go
+++ b/internal/repositorychangeset/changeset_test.go
@@ -385,6 +385,99 @@ func TestResetCommandsUseDoubleForceClean(t *testing.T) {
 	}
 }
 
+func TestDigestPathsFromBaseExpandsDoublestarGlobs(t *testing.T) {
+	repoDir := initGitRepository(t)
+	if err := os.MkdirAll(filepath.Join(repoDir, "subdir", "a"), 0o755); err != nil {
+		t.Fatalf("create nested dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, "subdir", "a", "b.txt"), []byte("nested\n"), 0o644); err != nil {
+		t.Fatalf("write nested file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, "subdir", "top.txt"), []byte("top\n"), 0o644); err != nil {
+		t.Fatalf("write top file: %v", err)
+	}
+
+	checkout := &repositorycheckout.Checkout{
+		RemoteURL:      "https://github.com/buildkite/cleanroom.git",
+		CommitSHA:      headCommit(t, repoDir),
+		DestinationDir: "/workspace",
+	}
+
+	changeset, err := BuildFromWorkingTree(repoDir, checkout)
+	if err != nil {
+		t.Fatalf("BuildFromWorkingTree returned error: %v", err)
+	}
+	if changeset == nil {
+		t.Fatal("expected changeset")
+	}
+
+	digests, err := changeset.DigestPathsFromBase(repoDir, []string{"subdir/**"})
+	if err != nil {
+		t.Fatalf("DigestPathsFromBase returned error: %v", err)
+	}
+	if got, want := len(digests), 2; got != want {
+		t.Fatalf("unexpected digest count: got %d want %d", got, want)
+	}
+	paths := make([]string, len(digests))
+	for i, d := range digests {
+		paths[i] = d.Path
+	}
+	if !strings.Contains(strings.Join(paths, ","), "subdir/a/b.txt") {
+		t.Fatalf("expected subdir/a/b.txt in results, got %v", paths)
+	}
+
+	_, err = changeset.DigestPathsFromBase(repoDir, []string{"subdir/**/missing.txt"})
+	if err == nil {
+		t.Fatal("expected empty doublestar glob to fail")
+	}
+	if !strings.Contains(err.Error(), "matched no files") {
+		t.Fatalf("unexpected empty glob error: %v", err)
+	}
+}
+
+func TestDigestRegularFilesFromBaseExpandsDoublestarGlobs(t *testing.T) {
+	repoDir := initGitRepository(t)
+	if err := os.MkdirAll(filepath.Join(repoDir, "vendor", "pkg"), 0o755); err != nil {
+		t.Fatalf("create vendor dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, "vendor", "pkg", "lib.go"), []byte("package pkg\n"), 0o644); err != nil {
+		t.Fatalf("write lib.go: %v", err)
+	}
+
+	checkout := &repositorycheckout.Checkout{
+		RemoteURL:      "https://github.com/buildkite/cleanroom.git",
+		CommitSHA:      headCommit(t, repoDir),
+		DestinationDir: "/workspace",
+	}
+
+	changeset, err := BuildFromWorkingTree(repoDir, checkout)
+	if err != nil {
+		t.Fatalf("BuildFromWorkingTree returned error: %v", err)
+	}
+	if changeset == nil {
+		t.Fatal("expected changeset")
+	}
+
+	digests, err := changeset.DigestRegularFilesFromBase(repoDir, []string{"vendor/**"})
+	if err != nil {
+		t.Fatalf("DigestRegularFilesFromBase returned error: %v", err)
+	}
+	if got, want := len(digests), 1; got != want {
+		t.Fatalf("unexpected digest count: got %d want %d", got, want)
+	}
+	if got, want := digests[0].Path, "vendor/pkg/lib.go"; got != want {
+		t.Fatalf("unexpected digest path: got %q want %q", got, want)
+	}
+
+	_, err = changeset.DigestRegularFilesFromBase(repoDir, []string{"vendor/**/missing.go"})
+	if err == nil {
+		t.Fatal("expected empty doublestar glob to fail")
+	}
+	if !strings.Contains(err.Error(), "matched no files") {
+		t.Fatalf("unexpected empty glob error: %v", err)
+	}
+}
+
 func TestDigestPathsFromBaseExpandsGlobs(t *testing.T) {
 	repoDir := initGitRepository(t)
 	if err := os.WriteFile(filepath.Join(repoDir, "go.mod"), []byte("module example.com/test\n"), 0o644); err != nil {

--- a/internal/repositorychangeset/changeset_test.go
+++ b/internal/repositorychangeset/changeset_test.go
@@ -1,6 +1,8 @@
 package repositorychangeset
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -720,16 +722,27 @@ func initGitRepositoryWithSubmodule(t *testing.T) (superDir, subDir string) {
 	return superDir, subDir
 }
 
+func sha256Hex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
 func TestDigestRegularFilesFromBaseExpandsSubmoduleGlob(t *testing.T) {
 	superDir, subDir := initGitRepositoryWithSubmodule(t)
 
-	if err := os.WriteFile(filepath.Join(subDir, "emoji1.json"), []byte(`{"name":"smile"}`), 0o644); err != nil {
-		t.Fatalf("write emoji1.json: %v", err)
+	subContents := map[string][]byte{
+		"emoji1.json": []byte(`{"name":"smile"}`),
+		"emoji2.json": []byte(`{"name":"wink"}`),
+		"emoji3.json": []byte(`{"name":"laugh"}`),
+		"emoji4.json": []byte(`{"name":"cry"}`),
+		"emoji5.json": []byte(`{"name":"angry"}`),
 	}
-	if err := os.WriteFile(filepath.Join(subDir, "emoji2.json"), []byte(`{"name":"wink"}`), 0o644); err != nil {
-		t.Fatalf("write emoji2.json: %v", err)
+	for name, content := range subContents {
+		if err := os.WriteFile(filepath.Join(subDir, name), content, 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
 	}
-	runGit(t, subDir, "add", "emoji1.json", "emoji2.json")
+	runGit(t, subDir, "add", ".")
 	runGit(t, subDir, "commit", "-m", "add emojis")
 	runGitWithEnv(t, superDir, []string{"GIT_ALLOW_PROTOCOL=file"}, "-c", "protocol.file.allow=always", "submodule", "update", "--remote", "vendor/emojis")
 	runGit(t, superDir, "add", "vendor/emojis")
@@ -757,27 +770,33 @@ func TestDigestRegularFilesFromBaseExpandsSubmoduleGlob(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DigestRegularFilesFromBaseWithOptions: %v", err)
 	}
-	wantPaths := []string{
-		"vendor/emojis/README.md",
-		"vendor/emojis/emoji1.json",
-		"vendor/emojis/emoji2.json",
+
+	wantFiles := map[string][]byte{
+		"vendor/emojis/README.md":  []byte("submodule\n"),
+		"vendor/emojis/emoji1.json": subContents["emoji1.json"],
+		"vendor/emojis/emoji2.json": subContents["emoji2.json"],
+		"vendor/emojis/emoji3.json": subContents["emoji3.json"],
+		"vendor/emojis/emoji4.json": subContents["emoji4.json"],
+		"vendor/emojis/emoji5.json": subContents["emoji5.json"],
 	}
-	if got, want := len(files), len(wantPaths); got != want {
+	if got, want := len(files), len(wantFiles); got != want {
 		gotPaths := make([]string, len(files))
 		for i, f := range files {
 			gotPaths[i] = f.Path
 		}
 		t.Fatalf("unexpected file count: got %d want %d, paths: %v", got, want, gotPaths)
 	}
-	for i, f := range files {
-		if f.Path != wantPaths[i] {
-			t.Fatalf("unexpected path at index %d: got %q want %q", i, f.Path, wantPaths[i])
+	for _, f := range files {
+		wantContent, ok := wantFiles[f.Path]
+		if !ok {
+			t.Fatalf("unexpected path %q in result", f.Path)
 		}
 		if f.Mode != "100644" {
 			t.Fatalf("expected mode 100644 for %q, got %q", f.Path, f.Mode)
 		}
-		if !strings.HasPrefix(f.SHA256, "sha256:") {
-			t.Fatalf("expected sha256 digest for %q, got %q", f.Path, f.SHA256)
+		wantDigest := sha256Hex(wantContent)
+		if f.SHA256 != wantDigest {
+			t.Fatalf("wrong digest for %q: got %q want %q", f.Path, f.SHA256, wantDigest)
 		}
 	}
 }

--- a/internal/repositorychangeset/changeset_test.go
+++ b/internal/repositorychangeset/changeset_test.go
@@ -757,19 +757,22 @@ func TestDigestRegularFilesFromBaseExpandsSubmoduleGlob(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DigestRegularFilesFromBaseWithOptions: %v", err)
 	}
-	if got, want := len(files), 3; got != want {
-		paths := make([]string, len(files))
+	wantPaths := []string{
+		"vendor/emojis/README.md",
+		"vendor/emojis/emoji1.json",
+		"vendor/emojis/emoji2.json",
+	}
+	if got, want := len(files), len(wantPaths); got != want {
+		gotPaths := make([]string, len(files))
 		for i, f := range files {
-			paths[i] = f.Path
+			gotPaths[i] = f.Path
 		}
-		t.Fatalf("unexpected file count: got %d want %d, paths: %v", got, want, paths)
+		t.Fatalf("unexpected file count: got %d want %d, paths: %v", got, want, gotPaths)
 	}
-	for i := 1; i < len(files); i++ {
-		if files[i].Path < files[i-1].Path {
-			t.Fatalf("results not sorted: %q before %q", files[i-1].Path, files[i].Path)
+	for i, f := range files {
+		if f.Path != wantPaths[i] {
+			t.Fatalf("unexpected path at index %d: got %q want %q", i, f.Path, wantPaths[i])
 		}
-	}
-	for _, f := range files {
 		if f.Mode != "100644" {
 			t.Fatalf("expected mode 100644 for %q, got %q", f.Path, f.Mode)
 		}

--- a/internal/repositorystore/store.go
+++ b/internal/repositorystore/store.go
@@ -94,6 +94,9 @@ func (s *mirrorBackedRepositoryStore) TransportHints(context.Context, string, st
 }
 
 func (s *mirrorBackedRepositoryStore) EnsureSubmoduleMirror(ctx context.Context, submoduleRemoteURL, gitlinkSHA string) (string, error) {
+	if s == nil || s.mirrors == nil {
+		return "", fmt.Errorf("repository store is nil")
+	}
 	if err := s.mirrors.EnsureMirrorContains(ctx, submoduleRemoteURL, gitlinkSHA); err != nil {
 		return "", err
 	}

--- a/internal/repositorystore/store.go
+++ b/internal/repositorystore/store.go
@@ -22,6 +22,7 @@ type RepositoryStore interface {
 	ReadFileAtCommit(ctx context.Context, remoteURL, commitSHA, path string) ([]byte, error)
 	WithRepository(ctx context.Context, remoteURL, commitSHA string, hints FetchHints, fn func(repoDir string) error) error
 	TransportHints(ctx context.Context, remoteURL, commitSHA string, hints FetchHints) (TransportHints, error)
+	EnsureSubmoduleMirror(ctx context.Context, submoduleRemoteURL, gitlinkSHA string) (mirrorDir string, err error)
 }
 
 type mirrorSource interface {
@@ -90,6 +91,13 @@ func (s *mirrorBackedRepositoryStore) WithRepository(ctx context.Context, remote
 
 func (s *mirrorBackedRepositoryStore) TransportHints(context.Context, string, string, FetchHints) (TransportHints, error) {
 	return TransportHints{}, nil
+}
+
+func (s *mirrorBackedRepositoryStore) EnsureSubmoduleMirror(ctx context.Context, submoduleRemoteURL, gitlinkSHA string) (string, error) {
+	if err := s.mirrors.EnsureMirrorContains(ctx, submoduleRemoteURL, gitlinkSHA); err != nil {
+		return "", err
+	}
+	return s.mirrors.MirrorPath(submoduleRemoteURL)
 }
 
 func (s *mirrorBackedRepositoryStore) repositoryPath(ctx context.Context, remoteURL string) (string, error) {

--- a/internal/repositorystore/store_test.go
+++ b/internal/repositorystore/store_test.go
@@ -87,6 +87,56 @@ func TestMirrorBackedRepositoryStoreReadFileAtCommit(t *testing.T) {
 	}
 }
 
+func TestEnsureSubmoduleMirror(t *testing.T) {
+	t.Parallel()
+
+	const wantRemoteURL = "https://github.com/example/submodule.git"
+	const wantSHA = "abc1234abc1234abc1234abc1234abc1234abc12"
+	const wantPath = "/mirrors/submodule"
+
+	mock := &mockMirrorSource{mirrorPath: wantPath}
+	store := NewMirrorBacked(mock)
+
+	got, err := store.EnsureSubmoduleMirror(context.Background(), wantRemoteURL, wantSHA)
+	if err != nil {
+		t.Fatalf("EnsureSubmoduleMirror returned error: %v", err)
+	}
+	if got != wantPath {
+		t.Fatalf("unexpected mirror dir: got %q want %q", got, wantPath)
+	}
+	if mock.ensureMirrorContainsURL != wantRemoteURL {
+		t.Fatalf("unexpected EnsureMirrorContains remoteURL: got %q want %q", mock.ensureMirrorContainsURL, wantRemoteURL)
+	}
+	if mock.ensureMirrorContainsSHA != wantSHA {
+		t.Fatalf("unexpected EnsureMirrorContains commitSHA: got %q want %q", mock.ensureMirrorContainsSHA, wantSHA)
+	}
+	if mock.mirrorPathURL != wantRemoteURL {
+		t.Fatalf("unexpected MirrorPath remoteURL: got %q want %q", mock.mirrorPathURL, wantRemoteURL)
+	}
+}
+
+type mockMirrorSource struct {
+	mirrorPath              string
+	ensureMirrorContainsURL string
+	ensureMirrorContainsSHA string
+	mirrorPathURL           string
+}
+
+func (m *mockMirrorSource) MirrorPath(remoteURL string) (string, error) {
+	m.mirrorPathURL = remoteURL
+	return m.mirrorPath, nil
+}
+
+func (m *mockMirrorSource) EnsureMirror(_ context.Context, remoteURL string) (string, error) {
+	return m.mirrorPath, nil
+}
+
+func (m *mockMirrorSource) EnsureMirrorContains(_ context.Context, remoteURL, commitSHA string) error {
+	m.ensureMirrorContainsURL = remoteURL
+	m.ensureMirrorContainsSHA = commitSHA
+	return nil
+}
+
 func runGitCommand(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 

--- a/internal/submodule/gitmodules.go
+++ b/internal/submodule/gitmodules.go
@@ -1,0 +1,78 @@
+package submodule
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+)
+
+type GitmoduleEntry struct {
+	Name string
+	Path string
+	URL  string
+}
+
+func ParseGitmodules(data []byte) ([]GitmoduleEntry, error) {
+	var entries []GitmoduleEntry
+	var current *GitmoduleEntry
+	seenPaths := make(map[string]struct{})
+
+	for _, rawLine := range bytes.Split(data, []byte("\n")) {
+		line := strings.TrimSpace(string(rawLine))
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			if current != nil {
+				if err := validateAndAppend(&entries, current, seenPaths); err != nil {
+					return nil, err
+				}
+			}
+			inner := line[1 : len(line)-1]
+			const prefix = `submodule "`
+			if !strings.HasPrefix(inner, prefix) || !strings.HasSuffix(inner, `"`) {
+				current = nil
+				continue
+			}
+			name := inner[len(prefix) : len(inner)-1]
+			current = &GitmoduleEntry{Name: name}
+			continue
+		}
+		if current == nil {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		switch key {
+		case "path":
+			current.Path = value
+		case "url":
+			current.URL = value
+		}
+	}
+	if current != nil {
+		if err := validateAndAppend(&entries, current, seenPaths); err != nil {
+			return nil, err
+		}
+	}
+	return entries, nil
+}
+
+func validateAndAppend(entries *[]GitmoduleEntry, entry *GitmoduleEntry, seenPaths map[string]struct{}) error {
+	if entry.Path == "" {
+		return fmt.Errorf("submodule %q is missing path", entry.Name)
+	}
+	if entry.URL == "" {
+		return fmt.Errorf("submodule %q is missing url", entry.Name)
+	}
+	if _, exists := seenPaths[entry.Path]; exists {
+		return fmt.Errorf("duplicate submodule path %q", entry.Path)
+	}
+	seenPaths[entry.Path] = struct{}{}
+	*entries = append(*entries, *entry)
+	return nil
+}

--- a/internal/submodule/gitmodules_test.go
+++ b/internal/submodule/gitmodules_test.go
@@ -1,0 +1,175 @@
+package submodule
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseGitmodules(t *testing.T) {
+	data := []byte(`
+[submodule "vendor/emojis"]
+    path = vendor/emojis
+    url = https://github.com/example/emojis
+    branch = main
+`)
+	entries, err := ParseGitmodules(data)
+	if err != nil {
+		t.Fatalf("ParseGitmodules returned error: %v", err)
+	}
+	if got, want := len(entries), 1; got != want {
+		t.Fatalf("expected %d entries, got %d", want, got)
+	}
+	if got, want := entries[0].Name, "vendor/emojis"; got != want {
+		t.Errorf("Name: got %q want %q", got, want)
+	}
+	if got, want := entries[0].Path, "vendor/emojis"; got != want {
+		t.Errorf("Path: got %q want %q", got, want)
+	}
+	if got, want := entries[0].URL, "https://github.com/example/emojis"; got != want {
+		t.Errorf("URL: got %q want %q", got, want)
+	}
+}
+
+func TestParseGitmodulesMultipleEntries(t *testing.T) {
+	data := []byte(`
+[submodule "alpha"]
+    path = alpha
+    url = https://github.com/example/alpha
+
+[submodule "beta"]
+    path = beta
+    url = https://github.com/example/beta
+`)
+	entries, err := ParseGitmodules(data)
+	if err != nil {
+		t.Fatalf("ParseGitmodules returned error: %v", err)
+	}
+	if got, want := len(entries), 2; got != want {
+		t.Fatalf("expected %d entries, got %d", want, got)
+	}
+	if got, want := entries[0].Name, "alpha"; got != want {
+		t.Errorf("first Name: got %q want %q", got, want)
+	}
+	if got, want := entries[1].Name, "beta"; got != want {
+		t.Errorf("second Name: got %q want %q", got, want)
+	}
+}
+
+func TestParseGitmodulesNameWithSpaces(t *testing.T) {
+	data := []byte(`
+[submodule "some module with spaces"]
+    path = some/module
+    url = https://github.com/example/module
+`)
+	entries, err := ParseGitmodules(data)
+	if err != nil {
+		t.Fatalf("ParseGitmodules returned error: %v", err)
+	}
+	if got, want := len(entries), 1; got != want {
+		t.Fatalf("expected %d entries, got %d", want, got)
+	}
+	if got, want := entries[0].Name, "some module with spaces"; got != want {
+		t.Errorf("Name: got %q want %q", got, want)
+	}
+}
+
+func TestParseGitmodulesMissingURL(t *testing.T) {
+	data := []byte(`
+[submodule "foo"]
+    path = foo
+`)
+	_, err := ParseGitmodules(data)
+	if err == nil {
+		t.Fatal("expected error for missing url")
+	}
+	if !strings.Contains(err.Error(), "missing url") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestParseGitmodulesMissingPath(t *testing.T) {
+	data := []byte(`
+[submodule "foo"]
+    url = https://github.com/example/foo
+`)
+	_, err := ParseGitmodules(data)
+	if err == nil {
+		t.Fatal("expected error for missing path")
+	}
+	if !strings.Contains(err.Error(), "missing path") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestParseGitmodulesIgnoresComments(t *testing.T) {
+	data := []byte(`
+# this is a comment
+[submodule "foo"]
+    # another comment
+    path = foo
+    url = https://github.com/example/foo
+`)
+	entries, err := ParseGitmodules(data)
+	if err != nil {
+		t.Fatalf("ParseGitmodules returned error: %v", err)
+	}
+	if got, want := len(entries), 1; got != want {
+		t.Fatalf("expected %d entries, got %d", want, got)
+	}
+}
+
+func TestParseGitmodulesIgnoresBlankLines(t *testing.T) {
+	data := []byte(`
+
+[submodule "foo"]
+
+    path = foo
+
+    url = https://github.com/example/foo
+
+`)
+	entries, err := ParseGitmodules(data)
+	if err != nil {
+		t.Fatalf("ParseGitmodules returned error: %v", err)
+	}
+	if got, want := len(entries), 1; got != want {
+		t.Fatalf("expected %d entries, got %d", want, got)
+	}
+}
+
+func TestParseGitmodulesDuplicatePath(t *testing.T) {
+	data := []byte(`
+[submodule "foo"]
+    path = shared/path
+    url = https://github.com/example/foo
+
+[submodule "bar"]
+    path = shared/path
+    url = https://github.com/example/bar
+`)
+	_, err := ParseGitmodules(data)
+	if err == nil {
+		t.Fatal("expected error for duplicate path")
+	}
+	if !strings.Contains(err.Error(), "duplicate") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestParseGitmodulesIgnoresUnknownKeys(t *testing.T) {
+	data := []byte(`
+[submodule "foo"]
+    path = foo
+    url = https://github.com/example/foo
+    branch = main
+    update = rebase
+    fetchRecurseSubmodules = true
+`)
+	entries, err := ParseGitmodules(data)
+	if err != nil {
+		t.Fatalf("ParseGitmodules returned error: %v", err)
+	}
+	if got, want := len(entries), 1; got != want {
+		t.Fatalf("expected %d entries, got %d", want, got)
+	}
+}

--- a/internal/submodule/mirror_test.go
+++ b/internal/submodule/mirror_test.go
@@ -56,7 +56,7 @@ func TestListMirrorSubmodulesAtCommit(t *testing.T) {
 		return subMirrorDir, nil
 	}
 
-	subs, err := ListMirrorSubmodulesAtCommit(context.Background(), superMirrorDir, commitSHA, ensureMirror)
+	subs, err := ListMirrorSubmodulesAtCommit(context.Background(), superMirrorDir, "", commitSHA, ensureMirror)
 	if err != nil {
 		t.Fatalf("ListMirrorSubmodulesAtCommit returned error: %v", err)
 	}
@@ -103,7 +103,7 @@ func TestListMirrorSubmodulesAtCommitNoGitmodules(t *testing.T) {
 		return "", nil
 	}
 
-	subs, err := ListMirrorSubmodulesAtCommit(context.Background(), mirrorDir, commitSHA, ensureMirror)
+	subs, err := ListMirrorSubmodulesAtCommit(context.Background(), mirrorDir, "", commitSHA, ensureMirror)
 	if err != nil {
 		t.Fatalf("ListMirrorSubmodulesAtCommit returned error: %v", err)
 	}

--- a/internal/submodule/mirror_test.go
+++ b/internal/submodule/mirror_test.go
@@ -1,0 +1,154 @@
+package submodule
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func initBareMirror(t *testing.T, sourceDir string) string {
+	t.Helper()
+	mirrorDir := t.TempDir()
+	cmd := exec.Command("git", "clone", "--mirror", sourceDir, mirrorDir)
+	cmd.Env = append(os.Environ(), "GIT_ALLOW_PROTOCOL=file")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git clone --mirror failed: %v\n%s", err, string(out))
+	}
+	return mirrorDir
+}
+
+func headCommit(t *testing.T, dir string) string {
+	t.Helper()
+	cmd := exec.Command("git", "rev-parse", "HEAD")
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git rev-parse HEAD failed: %v\n%s", err, string(out))
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func TestListMirrorSubmodulesAtCommit(t *testing.T) {
+	subDir := initSubmoduleRepo(t)
+	subMirrorDir := initBareMirror(t, subDir)
+	subURL := "https://example.com/sub.git"
+
+	superDir := t.TempDir()
+	runGit(t, superDir, "init")
+	runGit(t, superDir, "config", "user.name", "Cleanroom Test")
+	runGit(t, superDir, "config", "user.email", "cleanroom-test@example.com")
+	runGitWithEnv(t, superDir, []string{"GIT_ALLOW_PROTOCOL=file"}, "-c", "protocol.file.allow=always", "submodule", "add", subDir, "vendor/sub")
+	runGit(t, superDir, "config", "-f", ".gitmodules", "submodule.vendor/sub.url", subURL)
+	runGit(t, superDir, "add", ".gitmodules")
+	runGit(t, superDir, "commit", "-m", "add submodule")
+
+	superMirrorDir := initBareMirror(t, superDir)
+	commitSHA := headCommit(t, superDir)
+
+	var ensuredURL, ensuredSHA string
+	ensureMirror := func(ctx context.Context, remoteURL, sha string) (string, error) {
+		ensuredURL = remoteURL
+		ensuredSHA = sha
+		return subMirrorDir, nil
+	}
+
+	subs, err := ListMirrorSubmodulesAtCommit(context.Background(), superMirrorDir, commitSHA, ensureMirror)
+	if err != nil {
+		t.Fatalf("ListMirrorSubmodulesAtCommit returned error: %v", err)
+	}
+	if got, want := len(subs), 1; got != want {
+		t.Fatalf("expected %d submodules, got %d", want, got)
+	}
+	if got, want := subs[0].Path, "vendor/sub"; got != want {
+		t.Errorf("Path: got %q want %q", got, want)
+	}
+	if got, want := subs[0].RemoteURL, subURL; got != want {
+		t.Errorf("RemoteURL: got %q want %q", got, want)
+	}
+	if subs[0].GitlinkSHA == "" {
+		t.Error("expected non-empty GitlinkSHA")
+	}
+	if got, want := subs[0].MirrorDir, subMirrorDir; got != want {
+		t.Errorf("MirrorDir: got %q want %q", got, want)
+	}
+	if got, want := ensuredURL, subURL; got != want {
+		t.Errorf("ensureMirror called with URL %q, want %q", got, want)
+	}
+	if ensuredSHA == "" {
+		t.Error("ensureMirror called with empty SHA")
+	}
+	_ = ensuredSHA
+}
+
+func TestListMirrorSubmodulesAtCommitNoGitmodules(t *testing.T) {
+	plainDir := t.TempDir()
+	runGit(t, plainDir, "init")
+	runGit(t, plainDir, "config", "user.name", "Cleanroom Test")
+	runGit(t, plainDir, "config", "user.email", "cleanroom-test@example.com")
+	if err := os.WriteFile(filepath.Join(plainDir, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("write readme: %v", err)
+	}
+	runGit(t, plainDir, "add", "README.md")
+	runGit(t, plainDir, "commit", "-m", "initial")
+
+	mirrorDir := initBareMirror(t, plainDir)
+	commitSHA := headCommit(t, plainDir)
+
+	ensureMirror := func(ctx context.Context, remoteURL, sha string) (string, error) {
+		t.Error("ensureMirror should not be called when there are no submodules")
+		return "", nil
+	}
+
+	subs, err := ListMirrorSubmodulesAtCommit(context.Background(), mirrorDir, commitSHA, ensureMirror)
+	if err != nil {
+		t.Fatalf("ListMirrorSubmodulesAtCommit returned error: %v", err)
+	}
+	if len(subs) != 0 {
+		t.Errorf("expected empty submodule list, got %v", subs)
+	}
+}
+
+func TestListMirrorSubmoduleFilesAtSHA(t *testing.T) {
+	subDir := initSubmoduleRepo(t)
+	if err := os.WriteFile(filepath.Join(subDir, "data.json"), []byte(`{}`), 0o644); err != nil {
+		t.Fatalf("write data.json: %v", err)
+	}
+	runGit(t, subDir, "add", "data.json")
+	runGit(t, subDir, "commit", "-m", "add data.json")
+
+	mirrorDir := initBareMirror(t, subDir)
+	sha := headCommit(t, subDir)
+
+	sm := MirrorSubmodule{
+		Path:       "vendor/sub",
+		RemoteURL:  "https://example.com/sub.git",
+		GitlinkSHA: sha,
+		MirrorDir:  mirrorDir,
+	}
+
+	files, err := ListMirrorSubmoduleFilesAtSHA(context.Background(), sm)
+	if err != nil {
+		t.Fatalf("ListMirrorSubmoduleFilesAtSHA returned error: %v", err)
+	}
+
+	wantPrefix := "vendor/sub/"
+	for _, f := range files {
+		if !strings.HasPrefix(f, wantPrefix) {
+			t.Errorf("file %q missing expected prefix %q", f, wantPrefix)
+		}
+	}
+
+	found := false
+	for _, f := range files {
+		if f == "vendor/sub/data.json" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected vendor/sub/data.json in files, got %v", files)
+	}
+}

--- a/internal/submodule/submodule.go
+++ b/internal/submodule/submodule.go
@@ -38,12 +38,10 @@ func ListWorktreeSubmodules(repoRoot string) ([]WorktreeSubmodule, error) {
 			continue
 		}
 		prefix := line[0]
-		rest := line[1:]
-		fields := strings.Fields(rest)
-		if len(fields) < 2 {
-			return nil, fmt.Errorf("parse submodule status line %q", line)
+		smPath, err := parseSubmoduleStatusPath(line)
+		if err != nil {
+			return nil, err
 		}
-		smPath := fields[1]
 		switch prefix {
 		case '-':
 			return nil, fmt.Errorf("submodule %q is not initialised; run \"git submodule update --init\"", smPath)
@@ -66,6 +64,30 @@ func ListWorktreeSubmodules(repoRoot string) ([]WorktreeSubmodule, error) {
 	return result, nil
 }
 
+// parseSubmoduleStatusPath extracts the path from a single line of
+// `git submodule status` output. The format is `<char><sha> <path>[ (describe)]`,
+// where path may contain spaces, so splitting on whitespace is unsafe.
+func parseSubmoduleStatusPath(line string) (string, error) {
+	if len(line) < 42 {
+		return "", fmt.Errorf("parse submodule status line %q", line)
+	}
+	rest := line[1:]
+	sp := strings.IndexByte(rest, ' ')
+	if sp < 0 {
+		return "", fmt.Errorf("parse submodule status line %q", line)
+	}
+	smPath := rest[sp+1:]
+	if strings.HasSuffix(smPath, ")") {
+		if open := strings.LastIndex(smPath, " ("); open >= 0 {
+			smPath = smPath[:open]
+		}
+	}
+	if smPath == "" {
+		return "", fmt.Errorf("parse submodule status line %q", line)
+	}
+	return smPath, nil
+}
+
 func ListWorktreeSubmoduleFiles(sm WorktreeSubmodule) ([]string, error) {
 	out, err := gitOutput(sm.WorktreeDir, "ls-files", "-z")
 	if err != nil {
@@ -80,7 +102,7 @@ func ListWorktreeSubmoduleFiles(sm WorktreeSubmodule) ([]string, error) {
 	return result, nil
 }
 
-func ListMirrorSubmodulesAtCommit(ctx context.Context, parentMirrorDir, commitSHA string, ensureMirror func(ctx context.Context, remoteURL, commitSHA string) (mirrorDir string, err error)) ([]MirrorSubmodule, error) {
+func ListMirrorSubmodulesAtCommit(ctx context.Context, parentMirrorDir, parentRemoteURL, commitSHA string, ensureMirror func(ctx context.Context, remoteURL, commitSHA string) (mirrorDir string, err error)) ([]MirrorSubmodule, error) {
 	raw, err := gitOutputContext(ctx, parentMirrorDir, "show", commitSHA+":.gitmodules")
 	if err != nil {
 		msg := err.Error()
@@ -112,14 +134,19 @@ func ListMirrorSubmodulesAtCommit(ctx context.Context, parentMirrorDir, commitSH
 			return nil, err
 		}
 
-		mirrorDir, err := ensureMirror(ctx, entry.URL, gitlinkSHA)
+		resolvedURL, err := ResolveSubmoduleURL(parentRemoteURL, entry.URL)
+		if err != nil {
+			return nil, fmt.Errorf("resolve submodule URL for %q: %w", entry.Path, err)
+		}
+
+		mirrorDir, err := ensureMirror(ctx, resolvedURL, gitlinkSHA)
 		if err != nil {
 			return nil, fmt.Errorf("ensure mirror for submodule %q: %w", entry.Path, err)
 		}
 
 		result = append(result, MirrorSubmodule{
 			Path:       entry.Path,
-			RemoteURL:  entry.URL,
+			RemoteURL:  resolvedURL,
 			GitlinkSHA: gitlinkSHA,
 			MirrorDir:  mirrorDir,
 		})
@@ -188,6 +215,44 @@ func FindMirrorSubmoduleForPath(path string, mirrorSubs []MirrorSubmodule) (Mirr
 		}
 	}
 	return best, found
+}
+
+// ResolveSubmoduleURL resolves a submodule URL from .gitmodules against the
+// parent repository's remote URL, following git's resolve_relative_url rules.
+// Absolute URLs are returned as-is; only URLs beginning with `./` or `../`
+// are resolved relative to the parent.
+func ResolveSubmoduleURL(parentRemoteURL, submoduleURL string) (string, error) {
+	if !strings.HasPrefix(submoduleURL, "./") && !strings.HasPrefix(submoduleURL, "../") {
+		return submoduleURL, nil
+	}
+	if parentRemoteURL == "" {
+		return "", fmt.Errorf("relative submodule URL %q requires a parent remote URL", submoduleURL)
+	}
+
+	base := parentRemoteURL
+	scheme := ""
+	if i := strings.Index(base, "://"); i >= 0 {
+		scheme = base[:i+3]
+		base = base[i+3:]
+	}
+
+	sep := byte('/')
+	for {
+		switch {
+		case strings.HasPrefix(submoduleURL, "./"):
+			submoduleURL = submoduleURL[2:]
+		case strings.HasPrefix(submoduleURL, "../"):
+			submoduleURL = submoduleURL[3:]
+			slash := strings.LastIndexAny(base, "/:")
+			if slash < 0 {
+				return "", fmt.Errorf("cannot resolve relative submodule URL %q against parent %q", submoduleURL, parentRemoteURL)
+			}
+			sep = base[slash]
+			base = base[:slash]
+		default:
+			return scheme + base + string(sep) + submoduleURL, nil
+		}
+	}
 }
 
 func splitNullTerminated(data []byte) []string {

--- a/internal/submodule/submodule.go
+++ b/internal/submodule/submodule.go
@@ -158,6 +158,87 @@ func ListMirrorSubmodulesAtCommit(ctx context.Context, parentMirrorDir, parentRe
 	return result, nil
 }
 
+// ListMirrorSubmodulesAtIndex enumerates submodules from a temporary git
+// index. It reads .gitmodules from the index, resolves each entry's gitlink
+// SHA via `git ls-files --stage`, and ensures every submodule has a mirror
+// available. Returns an empty slice (with no error) when the index has no
+// .gitmodules.
+func ListMirrorSubmodulesAtIndex(ctx context.Context, repoRoot string, env []string, parentRemoteURL string, ensureMirror func(ctx context.Context, remoteURL, commitSHA string) (mirrorDir string, err error)) ([]MirrorSubmodule, error) {
+	raw, err := gitOutputWithEnv(repoRoot, env, "show", ":.gitmodules")
+	if err != nil {
+		msg := err.Error()
+		if strings.Contains(msg, "does not exist") || strings.Contains(msg, "exists on disk, but not") || strings.Contains(msg, "Path '.gitmodules' does not exist") {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read .gitmodules from index: %w", err)
+	}
+
+	entries, err := ParseGitmodules(raw)
+	if err != nil {
+		return nil, fmt.Errorf("parse .gitmodules from index: %w", err)
+	}
+
+	var result []MirrorSubmodule
+	for _, entry := range entries {
+		stageOut, err := gitOutputWithEnv(repoRoot, env, "ls-files", "--stage", "-z", "--", ":(literal)"+entry.Path)
+		if err != nil {
+			return nil, fmt.Errorf("ls-files for submodule %q in index: %w", entry.Path, err)
+		}
+		stageOut = bytes.TrimRight(stageOut, "\x00")
+		if len(bytes.TrimSpace(stageOut)) == 0 {
+			continue
+		}
+
+		gitlinkSHA, err := parseStageGitlinkSHA(stageOut, entry.Path)
+		if err != nil {
+			return nil, err
+		}
+
+		resolvedURL, err := ResolveSubmoduleURL(parentRemoteURL, entry.URL)
+		if err != nil {
+			return nil, fmt.Errorf("resolve submodule URL for %q: %w", entry.Path, err)
+		}
+
+		mirrorDir, err := ensureMirror(ctx, resolvedURL, gitlinkSHA)
+		if err != nil {
+			return nil, fmt.Errorf("ensure mirror for submodule %q: %w", entry.Path, err)
+		}
+
+		result = append(result, MirrorSubmodule{
+			Path:       entry.Path,
+			RemoteURL:  resolvedURL,
+			GitlinkSHA: gitlinkSHA,
+			MirrorDir:  mirrorDir,
+		})
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Path < result[j].Path
+	})
+	return result, nil
+}
+
+func parseStageGitlinkSHA(stageOut []byte, path string) (string, error) {
+	for _, raw := range bytes.Split(stageOut, []byte{0}) {
+		if len(raw) == 0 {
+			continue
+		}
+		meta, _, ok := bytes.Cut(raw, []byte{'\t'})
+		if !ok {
+			continue
+		}
+		fields := strings.Fields(string(meta))
+		if len(fields) < 3 {
+			continue
+		}
+		if fields[0] != "160000" {
+			return "", fmt.Errorf("submodule %q has unexpected mode %q (expected 160000)", path, fields[0])
+		}
+		return fields[1], nil
+	}
+	return "", fmt.Errorf("submodule %q not found in index", path)
+}
+
 func parseGitlinkSHA(treeOut []byte, path string) (string, error) {
 	line := strings.TrimSpace(string(bytes.TrimRight(treeOut, "\x00")))
 	meta, _, ok := strings.Cut(line, "\t")
@@ -271,6 +352,25 @@ func gitOutput(dir string, args ...string) ([]byte, error) {
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir
 	cmd.Env = os.Environ()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		msg := strings.TrimSpace(string(out))
+		if msg == "" {
+			msg = err.Error()
+		}
+		return nil, errors.New(msg)
+	}
+	return out, nil
+}
+
+func gitOutputWithEnv(dir string, env []string, args ...string) ([]byte, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if env != nil {
+		cmd.Env = env
+	} else {
+		cmd.Env = os.Environ()
+	}
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		msg := strings.TrimSpace(string(out))

--- a/internal/submodule/submodule.go
+++ b/internal/submodule/submodule.go
@@ -1,0 +1,233 @@
+package submodule
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+type WorktreeSubmodule struct {
+	Path        string
+	WorktreeDir string
+}
+
+type MirrorSubmodule struct {
+	Path       string
+	RemoteURL  string
+	GitlinkSHA string
+	MirrorDir  string
+}
+
+func ListWorktreeSubmodules(repoRoot string) ([]WorktreeSubmodule, error) {
+	out, err := gitOutput(repoRoot, "submodule", "status", "--recursive")
+	if err != nil {
+		return nil, fmt.Errorf("list submodules: %w", err)
+	}
+
+	seen := make(map[string]struct{})
+	var result []WorktreeSubmodule
+
+	for _, line := range strings.Split(strings.TrimRight(string(out), "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		prefix := line[0]
+		rest := line[1:]
+		fields := strings.Fields(rest)
+		if len(fields) < 2 {
+			return nil, fmt.Errorf("parse submodule status line %q", line)
+		}
+		smPath := fields[1]
+		switch prefix {
+		case '-':
+			return nil, fmt.Errorf("submodule %q is not initialised; run \"git submodule update --init\"", smPath)
+		case 'U':
+			return nil, fmt.Errorf("submodule %q has unresolved merge conflicts", smPath)
+		}
+		if _, exists := seen[smPath]; exists {
+			continue
+		}
+		seen[smPath] = struct{}{}
+		result = append(result, WorktreeSubmodule{
+			Path:        smPath,
+			WorktreeDir: filepath.Join(repoRoot, smPath),
+		})
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Path < result[j].Path
+	})
+	return result, nil
+}
+
+func ListWorktreeSubmoduleFiles(sm WorktreeSubmodule) ([]string, error) {
+	out, err := gitOutput(sm.WorktreeDir, "ls-files", "-z")
+	if err != nil {
+		return nil, fmt.Errorf("list submodule files for %q: %w", sm.Path, err)
+	}
+
+	var result []string
+	for _, f := range splitNullTerminated(out) {
+		result = append(result, sm.Path+"/"+f)
+	}
+	sort.Strings(result)
+	return result, nil
+}
+
+func ListMirrorSubmodulesAtCommit(ctx context.Context, parentMirrorDir, commitSHA string, ensureMirror func(ctx context.Context, remoteURL, commitSHA string) (mirrorDir string, err error)) ([]MirrorSubmodule, error) {
+	raw, err := gitOutputContext(ctx, parentMirrorDir, "show", commitSHA+":.gitmodules")
+	if err != nil {
+		msg := err.Error()
+		if strings.Contains(msg, "does not exist") || strings.Contains(msg, "exists on disk, but not") {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read .gitmodules at %s: %w", commitSHA, err)
+	}
+
+	entries, err := ParseGitmodules(raw)
+	if err != nil {
+		return nil, fmt.Errorf("parse .gitmodules at %s: %w", commitSHA, err)
+	}
+
+	var result []MirrorSubmodule
+	for _, entry := range entries {
+		treeOut, err := gitOutputContext(ctx, parentMirrorDir, "ls-tree", "-z", commitSHA, "--", ":(literal)"+entry.Path)
+		if err != nil {
+			return nil, fmt.Errorf("ls-tree for submodule %q at %s: %w", entry.Path, commitSHA, err)
+		}
+
+		treeOut = bytes.TrimRight(treeOut, "\x00\n")
+		if len(bytes.TrimSpace(treeOut)) == 0 {
+			continue
+		}
+
+		gitlinkSHA, err := parseGitlinkSHA(treeOut, entry.Path)
+		if err != nil {
+			return nil, err
+		}
+
+		mirrorDir, err := ensureMirror(ctx, entry.URL, gitlinkSHA)
+		if err != nil {
+			return nil, fmt.Errorf("ensure mirror for submodule %q: %w", entry.Path, err)
+		}
+
+		result = append(result, MirrorSubmodule{
+			Path:       entry.Path,
+			RemoteURL:  entry.URL,
+			GitlinkSHA: gitlinkSHA,
+			MirrorDir:  mirrorDir,
+		})
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Path < result[j].Path
+	})
+	return result, nil
+}
+
+func parseGitlinkSHA(treeOut []byte, path string) (string, error) {
+	line := strings.TrimSpace(string(bytes.TrimRight(treeOut, "\x00")))
+	meta, _, ok := strings.Cut(line, "\t")
+	if !ok {
+		return "", fmt.Errorf("parse ls-tree entry for %q: unexpected format %q", path, line)
+	}
+	fields := strings.Fields(meta)
+	if len(fields) < 3 {
+		return "", fmt.Errorf("parse ls-tree entry for %q: unexpected format %q", path, line)
+	}
+	mode := fields[0]
+	if mode != "160000" {
+		return "", fmt.Errorf("submodule %q has unexpected mode %q (expected 160000)", path, mode)
+	}
+	return fields[2], nil
+}
+
+func ListMirrorSubmoduleFilesAtSHA(ctx context.Context, sm MirrorSubmodule) ([]string, error) {
+	out, err := gitOutputContext(ctx, sm.MirrorDir, "ls-tree", "-r", "--name-only", "-z", sm.GitlinkSHA)
+	if err != nil {
+		return nil, fmt.Errorf("list mirror submodule files for %q at %s: %w", sm.Path, sm.GitlinkSHA, err)
+	}
+
+	var result []string
+	for _, f := range splitNullTerminated(out) {
+		result = append(result, sm.Path+"/"+f)
+	}
+	sort.Strings(result)
+	return result, nil
+}
+
+func FindSubmoduleForPath(path string, worktreeSubs []WorktreeSubmodule) (WorktreeSubmodule, bool) {
+	var best WorktreeSubmodule
+	found := false
+	for _, sm := range worktreeSubs {
+		if strings.HasPrefix(path, sm.Path+"/") {
+			if !found || len(sm.Path) > len(best.Path) {
+				best = sm
+				found = true
+			}
+		}
+	}
+	return best, found
+}
+
+func FindMirrorSubmoduleForPath(path string, mirrorSubs []MirrorSubmodule) (MirrorSubmodule, bool) {
+	var best MirrorSubmodule
+	found := false
+	for _, sm := range mirrorSubs {
+		if strings.HasPrefix(path, sm.Path+"/") {
+			if !found || len(sm.Path) > len(best.Path) {
+				best = sm
+				found = true
+			}
+		}
+	}
+	return best, found
+}
+
+func splitNullTerminated(data []byte) []string {
+	parts := bytes.Split(data, []byte{0})
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if len(part) == 0 {
+			continue
+		}
+		out = append(out, string(part))
+	}
+	return out
+}
+
+func gitOutput(dir string, args ...string) ([]byte, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = os.Environ()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		msg := strings.TrimSpace(string(out))
+		if msg == "" {
+			msg = err.Error()
+		}
+		return nil, errors.New(msg)
+	}
+	return out, nil
+}
+
+func gitOutputContext(ctx context.Context, dir string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = dir
+	cmd.Env = os.Environ()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		msg := strings.TrimSpace(string(out))
+		if msg == "" {
+			msg = err.Error()
+		}
+		return nil, errors.New(msg)
+	}
+	return out, nil
+}

--- a/internal/submodule/submodule_test.go
+++ b/internal/submodule/submodule_test.go
@@ -189,3 +189,110 @@ func TestFindSubmoduleForPathNestedPicksDeepest(t *testing.T) {
 		t.Errorf("Path: got %q want %q", got, want)
 	}
 }
+
+func TestParseSubmoduleStatusPathPreservesSpaces(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+		want string
+	}{
+		{
+			name: "path with spaces and describe suffix",
+			line: " 1234567890123456789012345678901234567890 vendor/with space (heads/main)",
+			want: "vendor/with space",
+		},
+		{
+			name: "path with spaces and no describe suffix",
+			line: "+1234567890123456789012345678901234567890 vendor/with space",
+			want: "vendor/with space",
+		},
+		{
+			name: "simple path",
+			line: " 1234567890123456789012345678901234567890 vendor/emojis (v1.0)",
+			want: "vendor/emojis",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseSubmoduleStatusPath(tc.line)
+			if err != nil {
+				t.Fatalf("parseSubmoduleStatusPath: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %q want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveSubmoduleURL(t *testing.T) {
+	cases := []struct {
+		name      string
+		parent    string
+		submodule string
+		want      string
+		wantErr   bool
+	}{
+		{
+			name:      "absolute https",
+			parent:    "https://example.com/parent.git",
+			submodule: "https://example.com/sister.git",
+			want:      "https://example.com/sister.git",
+		},
+		{
+			name:      "ssh-style absolute",
+			parent:    "https://example.com/parent.git",
+			submodule: "git@github.com:org/sister.git",
+			want:      "git@github.com:org/sister.git",
+		},
+		{
+			name:      "dot-slash relative",
+			parent:    "https://example.com/parent.git",
+			submodule: "./child.git",
+			want:      "https://example.com/parent.git/child.git",
+		},
+		{
+			name:      "dot-dot relative against https",
+			parent:    "https://example.com/org/parent.git",
+			submodule: "../sister.git",
+			want:      "https://example.com/org/sister.git",
+		},
+		{
+			name:      "two dot-dot segments",
+			parent:    "https://example.com/team/org/parent.git",
+			submodule: "../../sister.git",
+			want:      "https://example.com/team/sister.git",
+		},
+		{
+			name:      "ssh-form parent with relative",
+			parent:    "git@github.com:org/parent.git",
+			submodule: "../sister.git",
+			want:      "git@github.com:org/sister.git",
+		},
+		{
+			name:      "relative without parent errors",
+			parent:    "",
+			submodule: "../sister.git",
+			wantErr:   true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ResolveSubmoduleURL(tc.parent, tc.submodule)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ResolveSubmoduleURL: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %q want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/submodule/submodule_test.go
+++ b/internal/submodule/submodule_test.go
@@ -1,0 +1,191 @@
+package submodule
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func initSubmoduleRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	runGit(t, dir, "config", "user.name", "Cleanroom Test")
+	runGit(t, dir, "config", "user.email", "cleanroom-test@example.com")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("write readme: %v", err)
+	}
+	runGit(t, dir, "add", "README.md")
+	runGit(t, dir, "commit", "-m", "initial")
+	return dir
+}
+
+func initSuperproject(t *testing.T, submodulePaths map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	runGit(t, dir, "config", "user.name", "Cleanroom Test")
+	runGit(t, dir, "config", "user.email", "cleanroom-test@example.com")
+	for smDir, smPath := range submodulePaths {
+		runGitWithEnv(t, dir, []string{"GIT_ALLOW_PROTOCOL=file"}, "-c", "protocol.file.allow=always", "submodule", "add", smDir, smPath)
+	}
+	runGit(t, dir, "commit", "-m", "add submodules")
+	return dir
+}
+
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	return runGitWithEnv(t, dir, nil, args...)
+}
+
+func runGitWithEnv(t *testing.T, dir string, env []string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), env...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, string(out))
+	}
+	return string(out)
+}
+
+func TestListWorktreeSubmodules(t *testing.T) {
+	emojisDir := initSubmoduleRepo(t)
+	libsDir := initSubmoduleRepo(t)
+
+	superDir := t.TempDir()
+	runGit(t, superDir, "init")
+	runGit(t, superDir, "config", "user.name", "Cleanroom Test")
+	runGit(t, superDir, "config", "user.email", "cleanroom-test@example.com")
+	runGitWithEnv(t, superDir, []string{"GIT_ALLOW_PROTOCOL=file"}, "-c", "protocol.file.allow=always", "submodule", "add", emojisDir, "vendor/emojis")
+	runGitWithEnv(t, superDir, []string{"GIT_ALLOW_PROTOCOL=file"}, "-c", "protocol.file.allow=always", "submodule", "add", libsDir, "vendor/libs")
+	runGit(t, superDir, "commit", "-m", "add submodules")
+
+	subs, err := ListWorktreeSubmodules(superDir)
+	if err != nil {
+		t.Fatalf("ListWorktreeSubmodules returned error: %v", err)
+	}
+	if got, want := len(subs), 2; got != want {
+		t.Fatalf("expected %d submodules, got %d", want, got)
+	}
+	if got, want := subs[0].Path, "vendor/emojis"; got != want {
+		t.Errorf("first path: got %q want %q", got, want)
+	}
+	if got, want := subs[0].WorktreeDir, filepath.Join(superDir, "vendor/emojis"); got != want {
+		t.Errorf("first WorktreeDir: got %q want %q", got, want)
+	}
+	if got, want := subs[1].Path, "vendor/libs"; got != want {
+		t.Errorf("second path: got %q want %q", got, want)
+	}
+	if got, want := subs[1].WorktreeDir, filepath.Join(superDir, "vendor/libs"); got != want {
+		t.Errorf("second WorktreeDir: got %q want %q", got, want)
+	}
+}
+
+func TestListWorktreeSubmodulesRejectsUninitialised(t *testing.T) {
+	subDir := initSubmoduleRepo(t)
+	superDir := t.TempDir()
+	runGit(t, superDir, "init")
+	runGit(t, superDir, "config", "user.name", "Cleanroom Test")
+	runGit(t, superDir, "config", "user.email", "cleanroom-test@example.com")
+	runGitWithEnv(t, superDir, []string{"GIT_ALLOW_PROTOCOL=file"}, "-c", "protocol.file.allow=always", "submodule", "add", subDir, "vendor/sub")
+	runGit(t, superDir, "commit", "-m", "add submodule")
+
+	smGitDir := filepath.Join(superDir, "vendor/sub/.git")
+	if err := os.RemoveAll(smGitDir); err != nil {
+		t.Fatalf("remove submodule .git: %v", err)
+	}
+
+	_, err := ListWorktreeSubmodules(superDir)
+	if err == nil {
+		t.Fatal("expected error for uninitialised submodule")
+	}
+	if !strings.Contains(err.Error(), "is not initialised") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestListWorktreeSubmoduleFiles(t *testing.T) {
+	subDir := initSubmoduleRepo(t)
+	if err := os.WriteFile(filepath.Join(subDir, "emoji.json"), []byte(`{"emoji":"🎉"}`), 0o644); err != nil {
+		t.Fatalf("write emoji.json: %v", err)
+	}
+	runGit(t, subDir, "add", "emoji.json")
+	runGit(t, subDir, "commit", "-m", "add emoji.json")
+
+	superDir := t.TempDir()
+	runGit(t, superDir, "init")
+	runGit(t, superDir, "config", "user.name", "Cleanroom Test")
+	runGit(t, superDir, "config", "user.email", "cleanroom-test@example.com")
+	runGitWithEnv(t, superDir, []string{"GIT_ALLOW_PROTOCOL=file"}, "-c", "protocol.file.allow=always", "submodule", "add", subDir, "vendor/emojis")
+	runGit(t, superDir, "commit", "-m", "add submodule")
+
+	sm := WorktreeSubmodule{
+		Path:        "vendor/emojis",
+		WorktreeDir: filepath.Join(superDir, "vendor/emojis"),
+	}
+	files, err := ListWorktreeSubmoduleFiles(sm)
+	if err != nil {
+		t.Fatalf("ListWorktreeSubmoduleFiles returned error: %v", err)
+	}
+
+	wantPrefix := "vendor/emojis/"
+	for _, f := range files {
+		if !strings.HasPrefix(f, wantPrefix) {
+			t.Errorf("file %q missing expected prefix %q", f, wantPrefix)
+		}
+	}
+
+	found := false
+	for _, f := range files {
+		if f == "vendor/emojis/emoji.json" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected vendor/emojis/emoji.json in files, got %v", files)
+	}
+}
+
+func TestFindSubmoduleForPath(t *testing.T) {
+	subs := []WorktreeSubmodule{
+		{Path: "vendor/emojis", WorktreeDir: "/repo/vendor/emojis"},
+	}
+
+	sm, ok := FindSubmoduleForPath("vendor/emojis/foo.txt", subs)
+	if !ok {
+		t.Fatal("expected match for vendor/emojis/foo.txt")
+	}
+	if got, want := sm.Path, "vendor/emojis"; got != want {
+		t.Errorf("Path: got %q want %q", got, want)
+	}
+
+	_, ok = FindSubmoduleForPath("other/file.txt", subs)
+	if ok {
+		t.Error("expected no match for other/file.txt")
+	}
+
+	_, ok = FindSubmoduleForPath("vendor/emojis", subs)
+	if ok {
+		t.Error("expected no match for exact submodule path without trailing slash")
+	}
+}
+
+func TestFindSubmoduleForPathNestedPicksDeepest(t *testing.T) {
+	subs := []WorktreeSubmodule{
+		{Path: "a", WorktreeDir: "/repo/a"},
+		{Path: "a/b", WorktreeDir: "/repo/a/b"},
+		{Path: "a/b/c", WorktreeDir: "/repo/a/b/c"},
+	}
+
+	sm, ok := FindSubmoduleForPath("a/b/c/file.go", subs)
+	if !ok {
+		t.Fatal("expected match")
+	}
+	if got, want := sm.Path, "a/b/c"; got != want {
+		t.Errorf("Path: got %q want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Motivation

Cleanroom's dependency-stage cache key is computed by digesting every path that matches a glob in `dependencies[].inputs.files`. Two real-world cases didn't work before this branch:

1. **Recursive globs.** A pattern like `vendor/emojis/**` — common shorthand for "every file under this directory" — silently matched nothing, because the digest pipeline used `path.Match`/`filepath.Glob`, which treat `**` as a literal segment.
2. **Submodule contents.** Even with the right glob syntax, files living inside a git submodule (a `160000` gitlink in the parent tree) couldn't be digested. The pipeline tried to read them as parent-repo blobs and failed with `fatal: bad object :vendor/emojis`. The cache key never converged, so every `cleanroom exec` re-ran the dependency stage from scratch.

In Buildkite's case this hit `vendor/emojis/**`, plus several thousand files across `app/javascript`, `app/assets`, and `lib/webpack` once the glob was honoured. The downstream effect was a 30-second cache-key resolution per `cleanroom exec` (one `git show` fork per file) — even when nothing had changed.

## Example

A policy like this now works as expected:

```yaml
repository:
  submodules: true

dependencies:
  - name: setup
    inputs:
      files:
        - vendor/emojis/**
        - app/javascript/**
        - lib/webpack/**
```

With this branch:

- `vendor/emojis/**` resolves through the parent's `.gitmodules`, fetches the submodule mirror, and digests every regular file inside the submodule at its gitlink SHA.
- The cache key is stable across runs when nothing in the matched set changes, and changes when any digested file changes content.
- Cache-key resolution time drops from ~30s to a fraction of a second on large patterns, because `cat-file --batch` now streams thousands of digests through a single git process.
- Misuse gets clear errors: a literal gitlink path (`vendor/emojis`) is rejected with `is a gitlink; inputs.files must name regular files`, and a submodule glob without `repository.submodules: true` errors with an opt-in hint instead of silently matching nothing.

## Description

This branch adds two major capabilities to the digest computation paths: `**` glob support via the `doublestar` library, and submodule-aware file enumeration and hashing.

Without `**` support, patterns like `vendor/emojis/**` matched nothing because `path.Match` and `filepath.Glob` treat `**` as a literal segment. Without submodule support, files inside git submodules were either silently missed or incorrectly hashed as raw gitlink objects.

## Changes

- **`**` glob support**: Replace `path.Match`/`filepath.Glob` with `github.com/bmatcuk/doublestar/v4` at all three call sites (changeset, at-commit key files, at-commit input files). Tests added for `**` patterns at each site.
- **`internal/submodule` package**: New package implementing `ListWorktreeSubmodules`, `ListWorktreeSubmoduleFiles`, `ListMirrorSubmodulesAtCommit`, `ListMirrorSubmoduleFilesAtSHA`, `FindSubmoduleForPath`, `FindMirrorSubmoduleForPath`, and a `.gitmodules` parser.
- **`internal/gitbatch` package**: Shared batched `cat-file` helpers extracted from `controlservice` so both `controlservice` and `repositorychangeset` can reuse the same streaming digest logic without forking git per file.
- **Changeset digest path**: `DigestPathsOptions` with a `Submodules` flag; when enabled, submodule files are merged into the glob candidate set and digested via the correct submodule worktree. A `checkGitlinkOptIn` helper surfaces a clear error when a glob would resolve into an uninitialised submodule.
- **At-commit digest path**: Both `stageKeyFilesDigestAtCommit` and `stageInputFilesDigestAtCommit` now load submodule mirrors via `ListMirrorSubmodulesAtCommit` + `EnsureSubmoduleMirror`, expand globs across the combined file tree, and route per-file digest reads to the correct bare mirror.
- **`EnsureSubmoduleMirror`** added to `RepositoryStore` interface; `mirrorBackedRepositoryStore` delegates to `EnsureMirrorContains` + `MirrorPath`.
- **Batched cat-file**: Replaced per-file git shell-outs with a single `git cat-file --batch` session per digest call, eliminating ~3400 forks when globs match thousands of files. A deadlock fix drains stdout before signalling the reader goroutine done.
- **Misc fixes**: Nil guard on `EnsureSubmoduleMirror`, error propagation in `checkGitlinkOptIn` and `mergeSubmoduleFiles`, removal of a dead `literalStageGitPathspec` helper, redundant `regularFiles` copy removed.

## Verification

The test suite covers:
- Glob expansion across submodule files (changeset and at-commit paths)
- Literal gitlink rejection with a clear error
- The `checkGitlinkOptIn` opt-in guard
- Uninitialised submodule detection
- Digest stability across repeated calls
- `**` patterns at all three call sites
- Batched cat-file streaming correctness

## Rollback

Safe to revert — no migrations, no schema changes, no persistent state modified. Reverting removes the `Submodules` flag from `DigestPathsOptions` and drops the `doublestar` dependency.
