### PR TITLE
feat: Run volume cache blocks in workspace overlay

### DIFF
--- a/docs/plans/dependency-service-volume-caches.md
+++ b/docs/plans/dependency-service-volume-caches.md
@@ -240,6 +240,7 @@ The cache key includes:
 - canonical repository reuse namespace
 - compiled policy identity
 - normalized repository destination path
+- repository source identity while read auditing is unavailable
 - block stage and block name
 - command digest
 - normalized declared environment digest
@@ -324,10 +325,13 @@ workspace and mutable ambient reads, Cleanroom should compare observed reads
 with the declared block state. Undeclared mutable reads should skip portable
 publication and fall back to exact full-rootfs caching.
 
-Until read auditing exists, portable publication relies on the declared-input
-contract plus write-capture safety gates. That is acceptable for an initial
-implementation if the documentation and stream messages make fallback decisions
-clear.
+Until read auditing exists, cache records must either include the repository
+source identity in the key or fall back to exact full-rootfs caching. Including
+the source identity is conservative: it preserves normal writable workspace
+behavior and prevents stale reuse when commands read undeclared repository
+files, but it does not yet deliver source-only reuse across commits. Source-only
+reuse becomes safe once read auditing can prove the block did not consult
+undeclared mutable repository state.
 
 ### Ambient State Model
 
@@ -505,6 +509,8 @@ without exposing storage internals or user-visible modes.
 - Add runtime planning for baseline output collisions.
 - Make cache keys include the normalized repository destination plus normalized
   workspace output declarations.
+- Until read auditing lands, make cache keys include repository source identity
+  so undeclared repository reads cannot produce stale cache hits.
 - Define closed block environment and controlled ambient mutable state.
 
 Definition of done: schema validation accepts workspace outputs, but planning
@@ -530,8 +536,9 @@ directory.
 ### Slice 4: Restore and reuse
 
 - Restore declared outputs on cache hit at their exact guest paths.
-- Prove a source-only commit reuses dependency and service output caches without
-  rerunning block commands.
+- With read auditing enabled, prove a source-only commit reuses dependency and
+  service output caches without rerunning block commands when the observed reads
+  stay within declared inputs.
 - Ensure exact full-rootfs fallback still gives later phases the command's real
   effects.
 

--- a/docs/plans/dependency-service-volume-caches.md
+++ b/docs/plans/dependency-service-volume-caches.md
@@ -1,132 +1,104 @@
 # Dependency and Service Volume Cache Plan
 
 **Spec reference:** `spec.md` sections 5.1.1, 5.2, 6.4
-**Status:** Ready for initial Firecracker and darwin-vz release
-**Last reviewed:** 2026-05-06
+**Status:** Active
+**Last reviewed:** 2026-05-07
 
 ## Summary
 
-Make dependency and service preparation reusable from deterministic file inputs
-without coupling the cache entry to one exact repository checkout.
+Dependency and service caches should be deterministic without making dependency
+commands feel special. Users declare the files that define a block and the guest
+paths that block naturally writes. Cleanroom owns the internal mapping from
+those paths to managed cache storage.
 
-The current layered-cache plan snapshots whole root filesystems. That is still
-the right fallback for exact workspace reuse, but it makes portable dependency
-reuse awkward because dependency outputs can be wiped by repository refresh. The
-target model here is different: declared input files produce declared output
-directories and files, and Cleanroom backs those outputs with cacheable storage.
+The base design is overlay-first capture:
 
-## Release Readiness Snapshot
+1. Prepare the normal checkout at the repository path, usually `/workspace`.
+2. Run the dependency or service command against that normal filesystem shape.
+3. Capture writes through a guest overlay.
+4. Promote declared outputs into managed cache storage.
+5. Restore those same guest paths on cache hit.
 
-The initial Firecracker and darwin-vz implementation is now in place for
-dependency and service block-volume caches:
+Declared output paths may be under `/workspace`. That is the common case for
+`node_modules`, `vendor/bundle`, generated dependency indexes, and other
+repo-local dependency state. The cache mechanism must not require users to move
+those outputs outside the checkout.
 
-- policy, proto, cache-key, metadata, and backend request contracts are wired
-- Firecracker and darwin-vz prepare sidecar output volumes before VM launch,
-  mount declared directory outputs in the guest, restore file outputs on hits,
-  and snapshot output volumes after misses
-- dependency and service misses run from isolated declared-input projections
-  with closed environments
-- overlay write capture isolates persistent writes, allows declared file and
-  directory outputs, and reports escaped writes
-- escaped writes warn, skip file-keyed publication, reset declared outputs, and
-  rerun the block through the exact full-rootfs path before later phases
-  continue
-- Firecracker and darwin-vz advertise both `sandbox.cache_output_volumes` and
-  `sandbox.overlay_write_capture`
-- control-service coverage proves a source-only commit reuses dependency and
-  service output volumes without rerunning the block commands
-- opt-in managed-VM E2Es cover Firecracker ZFS and darwin-vz overlay capture
-  with cache output volumes
-
-Remaining work is release hardening rather than core enablement: run more
-real-workload smoke tests, decide whether output volume sizing needs a
-policy-visible control, and revisit escaped writes becoming hard failures once
-users have had time to migrate declarations.
+The previous read-only input projection model was too surprising. It made the
+workspace stop behaving like the workspace and forced users to rewrite commands
+around Cleanroom internals. Input projection may remain useful as a strict test
+primitive, but it is not the default cache execution model.
 
 ## Problem
 
-Dependency and service preparation often has two different kinds of state:
+Whole-rootfs dependency and service caches are tied to one exact checkout. They
+are safe, but source-only changes miss useful dependency state even when the
+dependency inputs did not change.
 
-- source files that define what should be installed or prepared
-- materialized output such as toolchains, package stores, compiled extensions,
-  Docker layers, database data directories, or service seed state
+Portable dependency reuse tried to recover some of this by restoring an older
+rootfs snapshot and refreshing the checkout. That still loses common repo-local
+outputs because checkout refresh can remove directories like `node_modules`,
+`vendor/bundle`, and generated files under `/workspace`.
 
-Today dependency and service stage cache keys are conservative because they are
-built on parent workspace or dependency stage keys. That avoids unsafe reuse,
-but it also means a source-only repository change can miss caches even when the
-dependency or service inputs did not change.
+The useful cache boundary is smaller:
 
-Portable dependency reuse improves this for some cases, but it still restores a
-full rootfs snapshot that contains an older checkout. Cleanroom then refreshes
-the checkout and validates declared key files. This only works when useful
-dependency output survives `git reset --hard` and `git clean -ffdx`, which
-excludes common repo-local outputs like `node_modules`, `vendor`, generated
-files, or service prep that writes under `/workspace`.
+- declared repository files and environment define the cache key
+- declared output paths define the materialized state that can be reused
+- everything else is either scratch, an escaped persistent write, or an
+  undeclared input that should block portable publication when detected
 
 ## Goals
 
-- Key dependency and service cache entries from declared file inputs, command
-  digest, environment, policy/runtime inputs, and normalized output declarations.
-- Support multiple ordered dependency blocks so toolchain, language package,
-  and application dependency prep can reuse independently.
-- Back declared output directories with snapshot-capable volumes before commands
-  run.
-- Restore matching output-volume snapshots and file outputs at the same guest
-  paths on cache hit.
-- Run cacheable dependency and service commands from an isolated, read-only
-  projection of their declared inputs rather than from the full workspace.
-- Use guest overlayfs write capture, where supported, to detect persistent writes
-  outside declared outputs before publishing a file-keyed cache entry.
-- Scope file-keyed volume reuse to the canonical repository remote by default.
-- Keep `content-cache` responsible for host-side reuse of immutable downloaded
-  bytes.
-- Keep exact full-rootfs stage caches available for existing behavior and for
-  commands that do not fit this stricter input/output contract.
-- Preserve backend-neutral policy and control-plane semantics, with backend
-  capability checks for volume attachment and fast clone support.
+- Keep the user contract to explicit `inputs.files`, optional `env`, and
+  declared `outputs.dirs` or `outputs.files`.
+- Let commands run in the normal checkout, with the normal working directory and
+  normal writable `/workspace` behavior.
+- Allow declared outputs under `/workspace`.
+- Restore cache hits at the exact same guest paths the command would have
+  written.
+- Use guest overlayfs write capture as the base miss path.
+- Promote declared outputs from the overlay view into managed cache storage.
+- Detect escaped persistent writes and skip portable publication when a block
+  writes outside declared outputs.
+- Keep exact full-rootfs stage caching available for unsupported backends,
+  incomplete declarations, and fallback paths.
+- Keep the policy and control-plane contract backend-neutral.
 
 ## Non-goals
 
-- Replacing `content-cache` with another package-byte cache.
-- Capturing live VM memory, service processes, or open sockets.
-- Making arbitrary shell commands safely cross-repo reusable without declared
-  inputs and outputs.
-- Sharing cacheable dependency or service outputs across repositories without an
-  explicit trust namespace.
-- Tracing arbitrary command reads in the first implementation slice.
-- Requiring users to enumerate every file created inside an output directory.
-- Persisting undeclared writes when a file-keyed cache hit skips the command.
-- Supporting host workspace mounts.
-- Supporting workspace output declarations in the first implementation slice.
+- Replacing `content-cache` as the package-byte cache.
+- Capturing live VM memory, service processes, sockets, or background daemons.
+- Making arbitrary commands safely reusable without declared inputs and outputs.
+- Asking users to name cache volumes, snapshots, or storage drivers.
+- Requiring users to enumerate every file inside an output directory.
+- Adding a user-visible cache mode for this behavior.
+- Making direct output-volume mounts the semantic foundation. They are an
+  optimization after overlay-first behavior is correct.
 
 ## Policy Shape
 
-The new schema should make both dependencies and services ordered lists of named
-cacheable blocks. Each block declares the files that define the key and the guest
-paths that should produce reusable outputs. Docker is a sandbox runtime
-capability, not a service cache block, so Docker enablement moves to
-`sandbox.docker.required`.
-
-Block names must be unique within their phase, stable across policy edits, and
-safe for logs and cache metadata. A conservative first rule is
-`[A-Za-z0-9][A-Za-z0-9_.-]*`.
+Dependency and service blocks are ordered lists. Each block has a stable name, a
+command, declared inputs, optional environment, declared outputs, and optional
+volatile paths for writes that are allowed but not persisted.
 
 ```yaml
 sandbox:
-  docker:
-    required: true
-
   dependencies:
-    - name: toolchains
-      command: mise install
+    - name: node
+      command: npm ci
       inputs:
         files:
-          - mise.toml
-          - mise.lock
+          - package.json
+          - package-lock.json
+          - .npmrc
+      env:
+        npm_config_cache: "${HOME}/.cache/npm"
       outputs:
         dirs:
-          - "${HOME}/.local/share/mise"
-          - "${HOME}/.cache/mise"
+          - node_modules
+      volatile:
+        paths:
+          - "${HOME}/.cache/npm/**"
 
     - name: go-modules
       command: mise exec -- go mod download
@@ -143,16 +115,39 @@ sandbox:
         dirs:
           - "${HOME}/go/pkg/mod"
           - "${HOME}/.cache/go-build"
+```
 
+Repo-local outputs are first-class:
+
+```yaml
+sandbox:
+  dependencies:
+    - name: ruby
+      command: bundle install
+      inputs:
+        files:
+          - Gemfile
+          - Gemfile.lock
+          - .ruby-version
+          - .bundle/config
+      env:
+        BUNDLE_PATH: "vendor/bundle"
+      outputs:
+        dirs:
+          - vendor/bundle
+```
+
+Service prep uses the same model:
+
+```yaml
+sandbox:
   services:
-    - name: postgres
-      command: |
-        ./scripts/prepare-postgres-volume.sh
+    - name: postgres-data
+      command: ./scripts/prepare-postgres-data.sh
       inputs:
         files:
           - compose.yaml
-          - .env.cleanroom
-          - scripts/prepare-postgres-volume.sh
+          - scripts/prepare-postgres-data.sh
           - db/schema.sql
           - db/seed.sql
       outputs:
@@ -160,997 +155,489 @@ sandbox:
           - /var/lib/cleanroom/services/postgres
 ```
 
-There is no backward-compatibility layer for the old single-object
-`sandbox.dependencies` shape, the old `sandbox.services.command` and
-`sandbox.services.key` shape, or `sandbox.services.docker.required`. This project
-is pre-1.0, and carrying both shapes would make the cache contract harder to
-explain and test. Existing policies should be migrated to the new list shape and
-`sandbox.docker.required`.
+### Path Expansion
 
-### Path expansion
+`inputs.files` are repository-relative paths or glob patterns. They are resolved
+from the post-checkout, post-changeset repository tree.
 
-`inputs.files` are repository-relative paths or glob patterns. They are
-resolved from the post-changeset repository tree when a changeset is present.
+`outputs.dirs`, `outputs.files`, `volatile.paths`, and block `env` values
+support limited guest path expansion. Expansion uses the normalized repository
+destination from `repository.path`; when the policy omits it, that destination
+defaults to `/workspace`.
 
-`outputs.dirs` and `outputs.files` support limited guest-path expansion:
+- `~` and `~/...` expand to the Cleanroom block execution home.
+- `${HOME}` and `$HOME` expand to the same home path.
+- `${WORKSPACE}` and `$WORKSPACE` expand to the normalized repository
+  destination path.
+- Relative output and volatile paths resolve against the repository destination
+  path. `node_modules` and `./node_modules` are equivalent, but examples should
+  prefer `node_modules`.
+- Unknown variables, empty output paths, globs in output paths, and paths that
+  normalize outside their allowed root are rejected.
+- Normalized outputs must be unique and non-overlapping across dependency and
+  service blocks.
+- A file output inside a declared output directory is rejected as redundant.
+- Block `env` values remain literal strings after the limited leading path
+  expansion above. Relative env values are not normalized by Cleanroom because
+  each tool owns its own environment semantics.
 
-- `~` and `~/...` expand to the sandbox user's home directory.
-- `${HOME}` and `$HOME` expand to the same canonical home directory.
-- `${WORKSPACE}` and `$WORKSPACE` expand to the Cleanroom workspace root before
-  workspace-output validation runs.
-- unknown variables, `~otheruser`, relative paths, empty paths, globs in output
-  paths, and paths that normalize outside their allowed root are rejected.
-- normalized absolute guest paths are used for cache keys and mount decisions.
-- output directories and files under `/workspace` are rejected in the first
-  slice.
-- `outputs.dirs` are whole directory trees backed by writable cache volumes.
-- `outputs.files` are individual regular files captured from overlayfs write
-  capture and restored by Cleanroom before later blocks or user commands.
-- declared outputs are required in the first slice. Optional outputs can be added
-  later as an explicit schema feature.
-- normalized output paths must be unique and non-overlapping across all
-  dependency and service blocks. Parent/child directory pairs are rejected in
-  the first slice.
-- a file output inside a declared output directory is rejected as redundant.
-- multiple file outputs may share a parent directory. Cleanroom should not use a
-  single-file bind mount as the primary mechanism because atomic replacement
-  patterns commonly unlink and rename files.
+Output paths under `/workspace` are allowed.
 
-This must be string normalization, not shell expansion.
+The normalized repository destination is part of the behavior, not a display
+detail. A repository at `/workspace` with `outputs.dirs: [node_modules]` and a
+repository at `/src` with the same relative declaration produce different
+normalized guest output paths, output records, and cache identities.
 
-The canonical home directory is the `HOME` value Cleanroom supplies in the
-closed block execution environment. Cleanroom sets that value before output path
-normalization and keeps the policy normalizer tied to the guest-agent default.
-Block `env` values are literal strings, except leading `~`, `~/`, `$HOME`,
-`$HOME/`, `${HOME}`, and `${HOME}/` forms are expanded to the same canonical
-home directory, and leading `$WORKSPACE`, `$WORKSPACE/`, `${WORKSPACE}`, and
-`${WORKSPACE}/` forms are expanded to the canonical workspace root. Other
-`$...` values, URLs, relative paths, empty strings, and trailing spaces are
-preserved and included in the block environment digest as provided. The first
-implementation should not discover a different home directory from the image at
-runtime.
+### Volatile Writes
+
+`volatile.paths` are explicit unpersisted write allowances. They are for logs,
+pid files, package-manager noise, and other data that may be created during the
+block but must not be required by later phases.
+
+```yaml
+sandbox:
+  dependencies:
+    - name: node
+      command: npm ci
+      inputs:
+        files:
+          - package.json
+          - package-lock.json
+      outputs:
+        dirs:
+          - node_modules
+      volatile:
+        paths:
+          - "${HOME}/.npm/_logs/**"
+          - ".cache/install-logs/**"
+```
+
+Volatile paths:
+
+- may be absolute guest paths or repository-relative paths
+- may use globs
+- are not copied into managed output storage
+- are not restored on cache hit
+- must not overlap declared outputs
+- must not be broad whole-tree ignores such as `/workspace/**`, `${WORKSPACE}/**`,
+  `/**`, `**`, `/etc/**`, or `/usr/**`
+
+Any persistent write outside declared outputs, scratch paths, and volatile paths
+is still an escaped write and blocks portable publication.
 
 ## Semantics
 
-Dependency blocks run in policy order. A later dependency block sees the outputs
-restored or produced by earlier blocks.
+Blocks run in policy order. A later block sees outputs restored or produced by
+earlier blocks.
 
-Each block has an independent cache identity. If `toolchains` hits and
-`go-modules` misses, Cleanroom restores the toolchain output volumes, runs only
-the Go module block, then snapshots the Go module outputs.
+Each block has an independent cache identity. If the `node` block hits and the
+`go-modules` block misses, Cleanroom restores `node` outputs, skips `npm ci`,
+and runs only the Go module command.
 
-Cacheable block commands do not run from the live `/workspace` checkout.
-Cleanroom materializes the declared `inputs.files` into a read-only input
-projection that preserves repository-relative paths, then runs the command with
-that projection as the working directory. Declared output directories are
-writable mounts, and declared output files are captured from the overlay upperdir
-after the command. The real workspace is still prepared for user code and for
-exact full-rootfs fallback, but file-keyed volume-cache publication must not
-depend on undeclared workspace reads.
+The cache key includes:
 
-If a dependency or service command needs files that are not in its declared
-input set, the policy should declare those files or globs. If the command needs
-the whole repository and cannot be reduced to a declared input set, it should use
-exact full-rootfs stage caching rather than the new volume-cache block shape.
+- backend and runtime identity
+- canonical repository reuse namespace
+- compiled policy identity
+- normalized repository destination path
+- block stage and block name
+- command digest
+- normalized declared environment digest
+- declared input manifest digest
+- normalized output and volatile declaration digest
+- prior dependency or service block output keys that this block depends on
+- output volume layout version
+- producer version
 
-Input projection must not provide symlink escape hatches back into the live
-workspace or arbitrary runtime paths. The first slice should reject projected
-input symlinks with absolute targets or `..` traversal outside the projection
-unless the resolved target is also part of the declared input set and can be
-materialized inside the projection.
+The declared input manifest records regular-file path, mode, and content digest
+for literal files and glob matches. Missing literal inputs fail. Empty glob
+matches fail. Symlinks, directories, devices, and other non-regular inputs fail
+until the input manifest format explicitly supports them.
 
-Service blocks run after dependency blocks. A service block key includes the
-selected dependency output identities it depends on. The first implementation
-can make every service block depend on the complete ordered dependency result;
-later work can add explicit `depends_on` if needed.
+### Cache Miss
 
-Directory outputs are backed before the command runs. On a miss, Cleanroom
-creates a writable output volume, maps each `outputs.dirs` path into that
-volume, runs the command, and snapshots the output volume. On a hit, Cleanroom
-clones the output snapshot and maps it into the guest at the same normalized
-directory paths before skipping the command.
+On a portable block miss, Cleanroom:
 
-File outputs are captured from the command's overlayfs upperdir. Cleanroom does
-not bind-mount individual files and should not hide an existing parent directory
-behind an empty capture directory. On a miss, after the command exits, Cleanroom
-copies each declared `outputs.files` path from the overlay view into the block's
-output store and materializes the same file into the sandbox root for later
-blocks. On a hit, Cleanroom restores declared file outputs into the sandbox root
-before later blocks or user commands run.
+1. Starts from the normal sandbox rootfs and normal repository checkout.
+2. Creates a per-block overlay root with the current rootfs as lowerdir.
+3. Mounts scratch paths such as `/tmp`, `/var/tmp`, and `/run` as scratch or
+   filters them from the escaped-write report.
+4. Runs the command inside the overlay view with the normal block working
+   directory, usually `/workspace`.
+5. Scans the overlay upperdir.
+6. Treats declared output writes, volatile writes, and scratch writes as allowed.
+7. Treats every other persistent write as an escaped write.
+8. Copies declared `outputs.dirs` and `outputs.files` from the merged overlay
+   view into a temporary managed output store only after publishability checks
+   pass.
+9. Publishes a portable cache entry only after output metadata is durably
+   persisted.
+10. Materializes the declared outputs back into the real sandbox root for later
+    blocks, services, and user commands.
 
-Parent directories for directory outputs may be created by Cleanroom. The
-directory output itself must either be absent or be an empty directory before the
-cache volume is mapped in the first implementation. Rejecting
-pre-existing non-empty directory paths keeps the initial semantics simple and
-avoids hiding image-provided files behind a cache volume.
+If escaped writes are found, Cleanroom skips portable publication, discards the
+overlay result, and reruns the block against the real rootfs through the exact
+full-rootfs path before later phases continue. This preserves command behavior
+without storing an unsafe partial cache entry.
 
-The command must not leave persistent state outside declared outputs. Where the
-backend supports guest overlayfs write capture, Cleanroom should enforce this by
-running the command against an overlay root and inspecting the upperdir after the
-command. If escaped persistent writes are found, Cleanroom must not publish the
-file-keyed volume cache entry.
+Any managed output store created during a miss is temporary until metadata
+publication succeeds. Cleanroom must destroy temporary output stores on command
+failure, escaped writes, undeclared read fallback, metadata persistence failure,
+context cancellation, and exact fallback. Cleanup errors should be surfaced or
+recorded so leaked storage is not silent.
 
-Escaped writes are a publication gate, not the determinism mechanism. The
-determinism mechanism is the isolated input projection plus declared output
-mounts and captured files. The publication gate prevents Cleanroom from caching
-a subset of command effects under a key that would later skip the command.
+### Cache Hit
 
-### Reuse namespace
+On a portable block hit, Cleanroom prepares the repository checkout normally,
+then restores declared outputs at their normalized guest paths before skipping
+the command.
 
-The initial reuse namespace is the canonical repository remote URL. That gives
-cross-commit reuse inside one repository without allowing arbitrary repositories
-to share dependency or service outputs just because their declared inputs match.
+Directory outputs are restored as whole directory trees. File outputs are
+restored as regular files without hiding sibling files in their parent
+directory.
 
-The namespace should be an explicit cache-key component even if it is not exposed
-in the first public schema. A future policy field may allow broader sharing, but
-only by naming a trust namespace deliberately.
+### Baseline Output Collisions
 
-Local commit bundles and changesets still resolve against the same canonical
-repository remote. Their effects are included through the post-apply input
-manifest rather than by changing the reuse namespace.
+The first implementation should only publish and restore portable directory
+outputs when the output path is absent or an empty directory in the baseline
+checkout. It should only publish and restore portable file outputs when the file
+path is absent in the baseline checkout.
 
-### Environment and network determinism
+If the committed tree already contains a non-empty output directory or an output
+file at the declared path, Cleanroom should skip portable volume publication for
+that block and use exact full-rootfs caching. Later work can support baseline
+merges by including the baseline output digest in the key, but that is not part
+of the reset slice.
 
-Block commands receive a closed environment: the block's declared `env` plus
-Cleanroom's fixed guest baseline defaults such as `HOME` and `PATH`. Host
-process environment values must not leak into file-keyed volume-cache commands
-unless they are explicitly declared and hashed.
+## Determinism Model
 
-`dependency_env_digest` and `service_env_digest` include only the declared block
-environment after Cleanroom path normalization. The repository working directory
-is covered by the compiled policy hash. Changes to Cleanroom baseline defaults
-that can affect command behavior must bump the dependency or service volume
-producer version instead of silently reusing old output-volume records.
+The user-facing determinism contract is that `inputs.files` must fully describe
+the repository files that influence the block output. Cleanroom should make
+that contract easy to test and hard to misuse, but it should not enforce it by
+changing the command's filesystem shape.
 
-The compiled policy hash constrains network access, but it does not make mutable
-upstream responses deterministic. File-keyed volume cache is only safe for
-dependency or service commands whose external inputs are pinned by declared
-files, resolved through immutable/cache-backed artifacts, or otherwise included
-in the input manifest. Commands that resolve `latest` style upstream state
-should stay on exact full-rootfs caching until a resolver can record the
-resolved artifact identity.
+Overlay write capture proves the block did not leave persistent effects outside
+declared outputs. It does not prove the block did not read undeclared files.
 
-### Overlay write capture
+Read auditing is the stronger future publish gate. When a backend can audit
+workspace and mutable ambient reads, Cleanroom should compare observed reads
+with the declared block state. Undeclared mutable reads should skip portable
+publication and fall back to exact full-rootfs caching.
 
-Overlay write capture is the preferred cheap mechanism for detecting undeclared
-persistent writes. It is a guest execution feature, not a host volume-driver
-feature.
+Until read auditing exists, portable publication relies on the declared-input
+contract plus write-capture safety gates. That is acceptable for an initial
+implementation if the documentation and stream messages make fallback decisions
+clear.
 
-For a cacheable block miss, the runner should:
+### Ambient State Model
 
-1. create a guest mount namespace for the block
-2. mount the current rootfs as an overlay lowerdir
-3. create per-block `upperdir`, `workdir`, and merged root directories
-4. mount scratch paths such as `/tmp`, `/run`, and `/var/tmp` as tmpfs or filter
-   them from the escaped-write report
-5. mount the read-only input projection at the command working directory
-6. mount each `outputs.dirs` mapping as writable inside the merged root
-7. run the command inside the merged root with `chroot`, `pivot_root`, or an
-   equivalent backend runner primitive
-8. inspect the upperdir after the command exits
+Portable blocks run with the normal checkout shape, but not with arbitrary
+ambient machine state. The publishable state model is:
 
-The upperdir is the path-shaped diff for everything that was not sent to a
-declared directory output or scratch mount. Cleanroom should subtract its own
-setup baseline, such as mountpoint directories it created before the command,
-before reporting escaped writes.
+- block commands receive a closed environment made from Cleanroom baseline
+  variables plus declared block `env`
+- normalized declared environment is hashed into the block identity
+- image and immutable rootfs reads are covered by backend, runtime, and image
+  identity
+- prior dependency and service outputs are covered by prior block output keys
+- `HOME` is a controlled Cleanroom home, not a copy of arbitrary host or guest
+  home state
+- mutable home, global, or tool state that can affect outputs must be declared
+  as `inputs.files`, declared as an output, declared as volatile, supplied by a
+  modeled secret/config input, or block portable publication
+- secrets must be referenced through declared secret/config identity; raw secret
+  values should not be silently hashed into cache keys or copied into output
+  records
 
-Declared file outputs are allowed entries in the upperdir. Cleanroom copies
-their final contents into the output store and restores them into the sandbox
-root after the overlay run. Ancestor directories created only to reach declared
-file outputs are also allowed. Any other persistent upperdir entry is an escaped
-write.
+Reads from immutable runtime paths such as `/usr/bin`, system libraries, and CA
+bundles are acceptable because runtime identity is in the key. Reads from
+mutable paths such as `${HOME}/.npmrc`, package-manager global config,
+credential helpers, restored scratch state, or generated global config are not
+acceptable unless they are explicitly modeled by the block contract.
 
-If escaped writes are found, the initial implementation warns, skips file-keyed
-cache publication, resets declared outputs, and reruns the block through the
-exact full-rootfs path before later phases continue. Escaped writes remain
-isolated in the overlay upperdir, so the fallback starts from the original rootfs
-view plus reset declared outputs rather than applying the partial overlay result.
-It must not discard the upperdir and continue as if the block succeeded normally,
-because later commands would see a sandbox that differs from the command's real
-effects.
+## Output Storage
 
-Once the feature is stable, escaped writes should become hard failures for
-cacheable blocks. The initial implementation uses exact fallback to keep
-existing workflows moving while users learn the declaration contract.
-
-A local `darwin-vz` experiment on 2026-05-02 validated the basic guest
-mechanism: the managed Linux guest exposes overlayfs, root commands can mount an
-overlay with `/` as the lowerdir, writes and whiteout deletes appear in the
-upperdir, and bind-mounted declared output directories do not appear in the
-upperdir except for setup-created mountpoints. Later managed-VM E2Es exercised
-the same overlay-capture and cache-output-volume path through darwin-vz and
-Firecracker.
-
-## Cache Keys
-
-Add cache-key helpers for dependency and service volume outputs in
-`internal/cachekey/cachekey.go`.
-
-Dependency block key:
-
-```text
-dependency_volume_key = H(
-  backend,
-  runtime_key,
-  reuse_namespace,
-  compiled_policy_hash,
-  block_name,
-  dependency_command_digest,
-  dependency_env_digest,
-  dependency_input_manifest_digest,
-  normalized_outputs_digest,
-  prior_dependency_output_keys_digest,
-  output_volume_layout_version,
-  producer_version
-)
-```
-
-Service block key:
-
-```text
-service_volume_key = H(
-  backend,
-  runtime_key,
-  reuse_namespace,
-  compiled_policy_hash,
-  block_name,
-  service_command_digest,
-  service_env_digest,
-  service_input_manifest_digest,
-  normalized_outputs_digest,
-  dependency_output_keys_digest,
-  prior_service_output_keys_digest,
-  output_volume_layout_version,
-  producer_version
-)
-```
-
-Input manifests should record regular-file path, mode, and content digest, and
-reject directories, symlinks, devices, and other non-regular inputs. They should
-be sorted before hashing. Missing required literal paths should fail. Glob
-matches should be sorted and should fail if the pattern is invalid, matches no
-files, or matches non-regular files. Optional inputs can be added later as an
-explicit schema feature; the first implementation should not hash an empty glob
-as an empty input set because that is usually a typo and creates an overbroad
-cache key. Input projection validation must reject symlink escapes before
-running the block command.
-
-The normalized output declaration is part of the key because changing directory
-mount destinations or file-output restore paths can change command behavior even
-when file inputs are the same.
-
-## Volume Layout
-
-Start with one aggregate output store per block. Directory outputs use mounted
-subdirectories. File outputs use stored files that Cleanroom copies into the
-sandbox root on cache hit or after a successful miss.
+Start with one aggregate managed output store per block. Directory outputs use
+subdirectories. File outputs use stored files.
 
 Example:
 
 ```text
-outputs.dirs:
-  - ${HOME}/.local/share/mise
-  - ${HOME}/go/pkg/mod
-outputs.files:
-  - ${HOME}/.cache/tool/index.json
+outputs:
+  dirs:
+    - node_modules
+    - ${HOME}/.npm
+  files:
+    - .cache/dependency-index.json
 
-dependency block volume:
+managed block output store:
   dirs/
-    home-cleanroom-.local-share-mise/
-    home-cleanroom-go-pkg-mod/
+    0/  -> /workspace/node_modules
+    1/  -> /root/.npm
   files/
-    home-cleanroom-.cache-tool-index.json
-
-guest view:
-  /home/cleanroom/.local/share/mise -> mounted/bound mapped output dir
-  /home/cleanroom/go/pkg/mod        -> mounted/bound mapped output dir
-  /home/cleanroom/.cache/tool/index.json restored as a file
+    0   -> /workspace/.cache/dependency-index.json
 ```
 
-The aggregate-per-block layout makes lookup, clone, publish, and rollback
+The aggregate-per-block layout keeps lookup, restore, publish, and cleanup
 atomic. Per-path volumes can come later if partial reuse becomes important.
-Directory outputs may need real block devices or bind mounts for speed. File
-outputs are expected to be small enough that copying them is acceptable and
-avoids brittle single-file mounts.
+
+## Direct Mount Optimization
+
+Overlay-first capture is the semantic baseline. After that works, Cleanroom can
+optimize misses by mounting writable output volumes at declared directory paths
+before running the command.
+
+Direct mounting is allowed only when it does not change command-visible
+filesystem contents:
+
+- the output directory is absent or empty in the baseline checkout
+- the mount happens at the same guest path declared in policy
+- the block still runs with overlay write capture for escaped-write detection
+- file outputs are still captured from the overlay view unless a later design
+  supports safe file-level promotion
+
+If those checks fail, Cleanroom uses overlay-copy promotion or exact fallback.
+Users do not choose this with policy. It is an internal optimization.
 
 ## Backend Boundary
 
-Add backend capabilities and request fields for cache output volumes rather than
-teaching the control service backend internals.
+The public policy stays backend-neutral. Backends advertise what they can safely
+do:
 
-Suggested capability names:
+- `sandbox.overlay_write_capture`: run a command in an overlay view and report
+  upperdir writes.
+- `sandbox.cache_output_volumes`: restore and snapshot managed output storage.
+- `sandbox.cache_output_fast_clone`: clone output storage without copying full
+  bytes.
+- future `sandbox.read_audit`: report workspace and mutable ambient reads for
+  publish validation.
 
-- `sandbox.cache_output_volumes`
-- `sandbox.cache_output_fast_clone`
-- `sandbox.overlay_write_capture`
+Backends without overlay write capture or output volume support should still run
+the commands normally and may use exact full-rootfs stage caches. They must not
+silently claim portable file-keyed output reuse.
 
-The first implementation should not rely on hotplug. All directory output
-volumes needed for dependency and service blocks must be resolved before VM
-launch, then passed to provisioning as sidecar volume specs. Cache hits clone
-existing output snapshots; misses create empty writable volumes. The VM boots
-once with the rootfs plus all cache output volumes attached. File outputs can be
-stored in the same aggregate output store, but they are restored by file copy
-rather than by mounting a single file.
+## Control Service Flow
 
-Suggested backend types in `internal/backend/backend.go`:
+For each dependency or service block:
 
-```go
-type CacheOutputVolumeSpec struct {
-  Stage string
-  BlockName string
-  VolumeID string
-  SourceSnapshotRef string
-  DirMappings []CacheOutputDirMapping
-  FileMappings []CacheOutputFileMapping
-}
+1. Normalize inputs, environment, and outputs.
+2. Resolve and hash declared inputs from the post-changeset tree.
+3. Compute the block cache key.
+4. Look up a ready output cache record.
+5. On hit, restore declared outputs and skip the command.
+6. On miss, run overlay-first capture.
+7. Check baseline collisions, escaped writes, ambient-state constraints, and any
+   read-audit result.
+8. Promote declared outputs into temporary managed storage only when publishable.
+9. Persist output records and output manifest digests.
+10. Mark the managed output store durable only after metadata persistence
+    succeeds.
+11. Materialize outputs into the sandbox root for later phases.
+12. On unsafe or unsupported cases, destroy temporary output stores and fall back
+    to exact full-rootfs execution.
 
-type CacheOutputDirMapping struct {
-  GuestPath string
-  VolumeSubpath string
-}
-
-type CacheOutputFileMapping struct {
-  GuestPath string
-  VolumePath string
-}
-
-type ProvisionRequest struct {
-  SandboxID string
-  Policy *policy.CompiledPolicy
-  FirecrackerConfig
-  CacheOutputVolumes []CacheOutputVolumeSpec
-}
-
-type ProvisionFromSnapshotRequest struct {
-  SandboxID string
-  SnapshotID string
-  StorageRef string
-  Policy *policy.CompiledPolicy
-  FirecrackerConfig
-  CacheOutputVolumes []CacheOutputVolumeSpec
-}
-
-type CacheOutputVolumeAdapter interface {
-  Adapter
-  SnapshotCacheOutputVolumes(context.Context, SnapshotCacheOutputVolumesRequest) (*SnapshotCacheOutputVolumesResult, error)
-  DestroyCacheOutputVolumes(context.Context, DestroyCacheOutputVolumesRequest) error
-}
-```
-
-The provisioning request carries enough information for the backend to create or
-clone sidecar volumes before launch and mount directory outputs at the
-normalized guest paths. Snapshot and destroy requests should return enough
-metadata for the control service to persist cache records and clean up failed
-attempts. File mappings are used by the guest runner to extract and restore
-individual file outputs from the aggregate output store.
-
-Firecracker was the first target. It already had a volume-store abstraction in
-`internal/volumestore/store.go` and ZFS-backed clone support in
-`internal/backend/firecracker/backend.go`. The implementation now extends the
-launch drives list with one additional block device per aggregate output
-volume, runs guest-side mount or bind setup before dependency/service commands,
-and uses the guest overlay write-capture runner for missed cacheable blocks.
-Firecracker hotplug remains out of scope for the initial release.
-
-Darwin-VZ reports `sandbox.cache_output_volumes` and
-`sandbox.overlay_write_capture` on macOS after gaining launch-time sidecar disk
-attachment, guest mount-plan forwarding, managed-VM overlay validation, and
-escaped-write fallback. Its block-volume path uses the same ext4 aggregate
-output volume shape as Firecracker, but with Virtualization.framework storage
-devices attached by the macOS helper before VM start.
-
-Backends without both `sandbox.cache_output_volumes` and
-`sandbox.overlay_write_capture` currently fail closed to the aggregate
-full-rootfs dependency/services stage path instead of selecting per-block volume
-caching. They may still publish exact full-rootfs stage caches. Running the new
-block schema through isolated input projections without sidecar volume
-publication remains a possible future portability layer, but it is not part of
-the initial release.
-
-## Metadata Store
-
-The existing cache metadata model in `internal/cachestore/store.go` is centered
-on one cache key and one storage ref. Volume caches need one cache entry with
-one or more output volume refs.
-
-Add either:
-
-- a new `cache_volume_outputs` table keyed by stage, cache key, output index, and
-  normalized path, or
-- a JSON output manifest field if the store remains small and SQLite-only.
-
-Prefer a normalized table if garbage collection and per-output observability are
-expected soon. Each output record should include:
-
-- output kind: directory or file
-- normalized guest path
-- volume subpath
-- storage driver
-- storage ref
-- snapshot ref when different from storage ref
-- output manifest digest
-- created time and last-used time inherited from the parent cache record
-
-Cache records should still carry policy hash, backend, producer version, input
-manifest digest, normalized outputs digest, command digest, and parent dependency
-or service output keys.
-
-## Control Service Changes
-
-Expected files:
-
-- `internal/policy/policy.go`
-- `proto/cleanroom/v1/control.proto`
-- `internal/cachekey/cachekey.go`
-- `internal/cachestore/store.go`
-- `internal/controlservice/dependency_stage.go`
-- `internal/controlservice/services_stage.go`
-- `internal/controlservice/service.go`
-- `internal/controlservice/cache_observability.go`
-- `internal/controlservice/bootstrap_runner.go`
-
-Policy loading should make the new schema canonical immediately:
-
-- `sandbox.dependencies` is an ordered list of dependency blocks
-- `sandbox.services` is an ordered list of service blocks
-- `sandbox.docker.required` is the Docker runtime requirement
-- the old single-object `sandbox.dependencies` shape is rejected
-- the old `sandbox.services.command` and `sandbox.services.key` shape is rejected
-- the old `sandbox.services.docker.required` location is rejected
-
-The control service should build all dependency and service block plans before
-sandbox provisioning or snapshot restore. For each block it should:
-
-1. compute normalized input and output manifests
-2. compute the block cache key
-3. look up a ready cache record
-4. add a hit or empty output-volume spec to the provision request
-5. provision or restore the sandbox with all output volumes already attached
-6. materialize read-only input projections for missed blocks
-7. run only missed block commands through overlay write capture when supported
-8. extract and restore declared file outputs for missed blocks
-9. rerun the block through exact full-rootfs fallback when escaped writes are
-   found before later phases
-10. snapshot output volumes for missed blocks and persist metadata
-
-Service block planning follows the same pre-launch shape, but service commands
-run after dependency commands and include dependency output keys in their cache
-identity.
-
-## Escaped Write Handling
-
-Workspace cleanliness alone is not enough because a dependency or service block
-can write to `/etc`, `/usr/local`, `$HOME`, or another persistent rootfs path.
-The publish gate should inspect the overlay upperdir, not only `/workspace`.
-
-For dependency and service volume blocks:
-
-- writes under `outputs.dirs` go to mounted output directories
-- declared `outputs.files` are copied from the overlay upperdir into the output
-  store and then materialized back into the sandbox root
-- scratch writes under tmpfs or explicitly ignored scratch paths are not
-  published and are not escaped writes
-- any other persistent upperdir entry is an escaped write
-
-Escaped writes prevent file-keyed volume cache publication. The initial
-implementation warns, resets declared outputs, and reruns the block through
-exact full-rootfs fallback so the sandbox still contains the command's real
-effects. After the feature is stable, cacheable blocks should fail hard on
-escaped writes. The user schema should still avoid a confusing `mode` field.
+Service block keys include the dependency output identities they depend on. The
+first implementation can make every service block depend on the complete
+ordered dependency result. Later work can add explicit `depends_on`.
 
 ## Observability
 
-Extend cache telemetry without replacing existing stage names. Add attributes
-for block name and volume-cache operation:
+Create-sandbox stream messages should describe the user-visible decision, not
+the storage mechanics:
+
+- `checking dependency cache: node`
+- `restoring dependency outputs: node`
+- `running dependency bootstrap: ruby`
+- `publishing dependency outputs: ruby`
+- `skipping portable dependency cache for ruby: undeclared writes detected`
+- `skipping portable dependency cache for node: output path exists in checkout`
+- `falling back to exact dependency cache: node`
+
+Telemetry should include:
 
 - `cleanroom.cache.stage=dependency|services`
-- `cleanroom.cache.operation=lookup|prepare_volume|restore|publish|invalidate`
-- `cleanroom.cache.result=hit|miss|restored|published|fallback|failed`
+- `cleanroom.cache.operation=lookup|restore|run|publish|fallback`
+- `cleanroom.cache.result=hit|miss|published|skipped|failed`
 - `cleanroom.cache.block_name=<name>`
 - `cleanroom.cache.output_dir_count=<count>`
 - `cleanroom.cache.output_file_count=<count>`
 - `cleanroom.cache.escaped_write_count=<count>`
-
-Create-sandbox stream messages should stay user-readable:
-
-- `checking dependency cache: toolchains`
-- `restoring dependency outputs: toolchains`
-- `running dependency bootstrap: go-modules`
-- `skipping portable dependency cache for go-modules: undeclared writes detected`
-- `publishing service outputs: postgres`
-
-## Implementation Order
-
-1. Add schema types for `sandbox.docker.required`, dependency blocks, and service
-   blocks, including `outputs.dirs` and `outputs.files`, in
-   `internal/policy/policy.go` and `proto/cleanroom/v1/control.proto`.
-2. Add path expansion and validation helpers for `${HOME}`, `$HOME`, `~`, and
-   `${WORKSPACE}`.
-3. Add deterministic input-manifest hashing for literal files and globs.
-4. Add dependency and service volume cache-key helpers in
-   `internal/cachekey/cachekey.go`.
-5. Add reuse namespace handling, defaulting to canonical repository remote.
-6. Extend cache metadata to record output volume refs and manifests.
-7. Add backend capability flags and provision request fields for cache output
-   volumes and overlay write capture in `internal/backend/backend.go`.
-8. Add a guest overlay write-capture runner that can execute one missed block
-   from an input projection, mount declared directory outputs, extract declared
-   file outputs, and report escaped writes.
-9. Implement Firecracker pre-launch output-volume preparation, mount setup,
-   snapshotting, clone restore, and cleanup.
-10. Wire dependency block planning and lookup into
-   `internal/controlservice/dependency_stage.go` and `service.go`.
-11. Wire service block planning and lookup into
-   `internal/controlservice/services_stage.go` and `service.go`.
-12. Add isolated input projection materialization and escaped-write exact
-    fallback handling.
-13. Update observability events, stream phases, docs, and examples.
-14. Add end-to-end tests that prove a source-only commit reuses dependency and
-    service output volumes without rerunning their commands.
-
-### Phase 1 PR Status
-
-The first implementation PR covers the contract and plumbing layer, not the
-runtime sidecar-volume execution path.
-
-Completed in phase 1:
-
-- policy schema and proto support for ordered dependency and service blocks
-- `sandbox.docker.required` as the Docker runtime requirement
-- validation for block names, commands, input files, `outputs.dirs`,
-  `outputs.files`, `${HOME}`, `$HOME`, `~`, `${WORKSPACE}`, duplicate paths,
-  overlapping paths, and workspace output rejection
-- rejection of the old YAML object forms for `sandbox.dependencies`,
-  `sandbox.services.command`, `sandbox.services.key`, and
-  `sandbox.services.docker.required`
-- deterministic input-manifest helper package for literal regular files,
-  regular-file globs, file contents, and modes, rejecting non-regular inputs
-- glob-aware dependency key-file hashing for the existing stage-cache path,
-  including changeset-aware resolution
-- dependency and service output-volume cache-key helper APIs
-- reuse namespace helper, defaulting to canonical repository remote when no
-  explicit namespace is provided
-- cache metadata fields for command, env, normalized outputs, output manifests,
-  and output records
-- backend capability flags and provision request fields for cache output volumes
-  and overlay write capture
-- README, spec, API docs, and example policies updated to the new schema
-- tests for schema validation, cache keys, input manifests, cache metadata,
-  glob expansion, generated proto round trips, CLI Docker policy creation, and
-  existing dependency/services stage-cache behavior
-
-Runtime behavior immediately after phase 1:
-
-- dependency and service blocks are compiled into the existing aggregate
-  dependency/services stage bootstrap command
-- existing full-rootfs dependency and services stage caches continue to work
-- declared outputs are validated and represented in policy/proto/cache metadata,
-  but they are not yet restored or published as independent output volumes
-- overlayfs write capture is represented as a backend capability contract, but
-  no backend runner enforces escaped-write detection yet
-
-Remaining work after phase 1, now completed by later slices:
-
-- extend dependency block-volume runtime wiring from lookup-only planning to
-  output-volume preparation, restore, execution, and publication
-- extend service block-volume runtime wiring from lookup-only planning to
-  output-volume preparation, restore, execution, and publication
-- materialize isolated declared-input projections before running cacheable
-  blocks
-- implement the guest overlay write-capture runner
-- prepare output volumes before VM launch, mount declared `outputs.dirs`, and
-  copy declared `outputs.files`
-- publish and restore output-volume snapshots and output manifests
-- implement escaped-write warning plus exact full-rootfs fallback
-- add observability events for per-block lookup, restore, execution, publish,
-  and fallback decisions
-- add end-to-end tests proving source-only commits reuse dependency and service
-  output volumes without rerunning block commands
-
-Steps 8 and 9 remain the main backend slices. Steps 10 and 11 should now build
-on the phase 1 request fields and metadata, with stub-adapter tests before the
-Firecracker implementation.
-
-### Phase 2 PR Status
-
-The second implementation PR starts the runtime-control layer without changing
-the sandbox execution path yet. Existing dependency and service bootstraps still
-run through the aggregate stage cache paths, even when block-volume records hit.
-
-Completed in phase 2:
-
-- dependency block-volume planner computes one cache key per ordered dependency
-  block from backend, runtime key, reuse namespace, policy hash, command digest,
-  env digest, input manifest digest, normalized output declarations, and prior
-  dependency output keys
-- dependency block-volume cache lookup marks per-block hits and misses using the
-  cache metadata fields introduced in phase 1
-- dependency and service block-volume keys use strict regular-file input
-  manifests, rejecting symlinks, directories, gitlinks, missing paths, and
-  deleted paths before file-keyed cache reuse
-- dependency and service block-volume hits validate cached output records against
-  the declared output kind/path set before treating metadata as restorable
-- runtime fallback decision requires backend support for cache output volumes and
-  overlay write capture before the future block-volume path can be selected
-- sandbox creation now evaluates dependency block-volume lookup after exact and
-  portable dependency-stage cache restore fail or miss, and before workspace
-  cache restore or fresh provisioning
-- unsupported backends and missing cache metadata stores fall back to the
-  aggregate dependency stage path before doing per-block key resolution
-- dependency block-volume lookup observability records block counts, hit counts,
-  miss counts, and logs fallback and lookup summaries
-- tests cover ordered keying, prior-block invalidation, partial cache hits, and
-  fallback when backend capabilities are missing
-- tests cover strict input validation and output-record mismatch rejection before
-  block-volume records are treated as hits
-- `CreateSandbox` tests cover unsupported backend fallback, missing store
-  fallback, partial dependency block-volume hits, and all-hit lookup behavior
-  while confirming the aggregate dependency bootstrap still runs
-- service block-volume planner computes one cache key per ordered service block
-  from backend, runtime key, reuse namespace, policy hash, command digest, env
-  digest, input manifest digest, normalized output declarations, ordered
-  dependency output keys, and prior service output keys
-- sandbox creation now evaluates service block-volume lookup after services
-  stage restore misses, including after dependency-stage cache restores, once
-  dependency block-volume planning is available for policies with dependency
-  blocks
-- service block-volume lookup observability records block counts, hit counts,
-  miss counts, and logs fallback and lookup summaries
-- tests cover service keying, dependency-output invalidation, prior-service
-  invalidation, partial service cache hits, unsupported backend fallback, missing
-  store fallback, partial `CreateSandbox` hits, and all-hit lookup behavior while
-  confirming the aggregate services bootstrap still runs
-- regression coverage proves service block-volume lookup still runs when the
-  aggregate services stage cache misses and an aggregate dependency stage cache
-  restores
-
-Resolved in later slices after phase 2:
-
-- run missed dependency blocks from isolated input projections
-- restore hit output records before later dependency blocks run
-- publish output records after successful missed blocks
-- run missed service blocks from isolated input projections
-- restore hit service output records before later service blocks run
-- publish service output records after successful missed blocks
-
-### Phase 3 PR Status
-
-The third implementation PR continues the runtime-control layer by turning
-block-volume lookup results into backend launch-time volume specs. It still does
-not make any backend attach, mount, restore, execute, or snapshot those volumes;
-aggregate dependency and service bootstrap commands continue to run.
-
-Completed in phase 3:
-
-- control service converts dependency and service block-volume plans into
-  `backend.CacheOutputVolumeSpec` values with stable volume IDs, declared
-  directory mappings, declared file mappings, and cache-hit source storage refs
-- cache-hit output records must describe one aggregate output volume per block
-  before the record can be consumed as a launch spec
-- service block-volume lookup returns its computed plan to the caller instead
-  of being logging-only
-- sandbox creation now computes dependency and service block-volume plans after
-  a services-stage cache miss and before dependency-stage or workspace-stage
-  restores, so later launch requests can carry all needed output-volume specs
-- dependency-stage and portable dependency-stage restores receive service
-  output-volume specs only, because dependency outputs are already present in
-  the restored rootfs and should not be shadowed by dependency sidecar mounts
-- workspace-stage restores and cold provisions receive dependency plus service
-  output-volume specs because those phases still need to run dependency and
-  service bootstrap work
-- tests cover spec construction for cache hits and misses, cold provision
-  request wiring, and dependency-stage restore request wiring
-
-Resolved in later slices after phase 3:
-
-- mount declared `outputs.dirs` and restore declared `outputs.files` inside the
-  guest before block commands run
-- run missed dependency and service blocks from isolated input projections
-- restore hit output records before later blocks run
-- snapshot and publish output records after successful missed blocks
-- keep aggregate exact full-rootfs stage caches as the fallback path until
-  per-block execution is complete
-
-### Phase 4 PR Status
-
-The fourth implementation PR starts the backend side of the runtime path for
-Firecracker. It consumes the launch-time `backend.CacheOutputVolumeSpec` list
-and prepares writable sidecar ext4 volumes before the VM starts. At this point
-it still did not mount those volumes in the guest, restore file outputs, run
-block commands, capture writes, or publish block output snapshots; later slices
-completed that runtime path.
-
-Completed in phase 4:
-
-- Firecracker advertises `sandbox.cache_output_volumes`; overlay write capture
-  remained gated until later slices validated the guest execution path
-- cold provisions and snapshot restores forward cache output volume specs into
-  Firecracker launch
-- Firecracker validates cache output volume specs before launch, rejects
-  malformed specs, and rejects duplicate runtime volume IDs
-- cache hits prepare writable volumes by cloning or copying the recorded source
-  storage ref
-- cache misses create an empty ext4 source image and prepare a writable output
-  volume from it
-- prepared output volumes are attached as non-root, writable Firecracker block
-  devices alongside the rootfs
-- output volume cleanup is included in all launch failure and sandbox cleanup
-  paths
-- tests cover capability reporting, launch request forwarding, hit and miss
-  volume preparation, malformed specs, and cleanup on partial prepare failure
-
-Resolved in later slices after phase 4:
-
-- run missed dependency and service blocks from isolated input projections
-- inspect overlay write capture results and warn/fallback on escaped writes
-- snapshot and publish output records after successful missed blocks
-- advertise `sandbox.overlay_write_capture` after escaped-write detection and
-  isolated block execution were wired through
-
-Still deferred after phase 4:
-
-- decide whether output volume sizing stays internal or becomes policy-visible
-  after real workloads show the right default
-
-### Phase 5 PR Status
-
-The fifth implementation PR wires the prepared Firecracker output volumes into
-the guest execution protocol. At this point it still kept the block-volume
-runtime inactive because Firecracker did not yet advertise
-`sandbox.overlay_write_capture`, and it did not run per-block dependency or
-service commands.
-
-Completed in phase 5:
-
-- Firecracker derives a deterministic guest mount plan from prepared output
-  volumes, using `/dev/vdb`, `/dev/vdc`, and later virtio block device names in
-  the same order as the non-root drives
-- sandbox executions forward the mount plan to the Linux guest agent through
-  the internal vsock exec request
-- the guest agent mounts each cache output ext4 device at a Cleanroom-managed
-  path under `/run/cleanroom/cache-output-volumes`
-- declared `outputs.dirs` are created inside the output volume and bind-mounted
-  at the declared guest path before the command runs
-- cache hits require declared directory output subpaths to already exist inside
-  the restored output volume rather than creating empty replacements
-- declared directory output targets must be absent or empty directories before
-  the bind mount, so image-provided files are not silently hidden
-- declared `outputs.files` are restored by copying regular files out of the
-  output volume on cache hits, and missing file outputs are skipped on misses
-- the guest agent rejects changed mount plans after the first setup in a VM, so
-  repeated exec requests do not clobber restored file outputs
-- tests cover mount-plan construction, request forwarding, guest mount actions,
-  path validation, non-empty directory rejection, file restoration, and changed
-  plan rejection
-
-Resolved in later slices after phase 5:
-
-- run missed service blocks from isolated input projections
-- inspect overlay write capture results and warn/fallback on escaped writes
-- snapshot and publish output records after successful missed blocks
-- materialize captured file outputs into both the output volume and sandbox root
-  after a missed block run
-- advertise `sandbox.overlay_write_capture` after escaped-write detection and
-  isolated block execution were wired through
-
-Still deferred after phase 5:
-
-- decide whether output volume sizing stays internal or becomes policy-visible
-  after real workloads show the right default
-
-### Phase 6 PR Status
-
-The sixth implementation PR adds the dependency-block execution substrate needed
-for the v0.7 experimental path. At this point it was still not the full
-publishable file-keyed cache path because escaped-write inspection and block
-output publication remained disabled.
-
-Completed in phase 6:
-
-- backend execution requests can carry an isolated input projection with a
-  source root, managed target root, declared files, and a read-only bind option
-- Firecracker and darwin-vz forward execution working directories and input
-  projection metadata through the guest exec protocol
-- the Linux guest agent materializes declared regular files and glob matches
-  into a managed projection under `/run/cleanroom/input-projections`
-- input projection materialization rejects absolute paths, `..` escapes,
-  missing inputs, directories, symlinks, and other non-regular files
-- when requested, the guest agent creates a per-command mount namespace and
-  bind-mounts the projection read-only over the source workspace root before
-  running the command
-- dependency block-volume misses run with a closed command environment instead
-  of inheriting ambient guest-agent or image environment variables
-- the guest agent hides the projection backing root inside the per-command mount
-  namespace after binding the projection over the source workspace
-- projected input files and directories receive deterministic timestamps so
-  command-visible mtimes do not vary under the same cache key
-- dependency block-volume misses now run as individual block commands from the
-  projected workspace when the block-volume runtime path is available
-- dependency block-volume hits are skipped because their output volumes are
-  already restored at VM launch
-- exact full-rootfs dependency-stage publication is skipped when the
-  block-volume runtime path is selected, because declared directory outputs are
-  mounted from sidecar volumes and would not be captured by a rootfs snapshot
-
-Resolved in later slices after phase 6:
-
-- publish a replacement cache artifact for dependency block misses
-- inspect overlay write capture results and warn/fallback on escaped writes
-- snapshot and publish dependency output records after successful missed blocks
-- materialize captured dependency file outputs into both the output volume and
-  sandbox root after a missed block run
-- run missed service blocks from isolated input projections
-- snapshot and publish service output records after successful missed service
-  blocks
-- advertise `sandbox.overlay_write_capture` after escaped-write detection and
-  block output publication were wired through
-
-Still deferred after phase 6:
-
-- decide whether output volume sizing stays internal or becomes policy-visible
-  after real workloads show the right default
-
-### Guest Overlay Runner Status
-
-The guest-agent overlay runner slice turns an `overlay_capture` execution
-request into real Linux guest setup. Backend capability advertisement remained
-gated until the path was exercised against managed VM roots and escaped-write
-fallback was wired through; that gate is now open for Firecracker and darwin-vz.
-
-Completed in the guest overlay runner slice:
-
-- the Linux guest agent creates a per-execution mount namespace for overlay
-  capture requests
-- each request gets fresh `upper`, `work`, and `merged` directories under the
-  requested overlay capture root
-- the current rootfs is mounted as the overlay lowerdir and commands execute
-  inside the merged root with `chroot`
-- scratch paths such as `/tmp`, `/var/tmp`, and `/run` are mounted as tmpfs
-  inside the merged root before declared outputs are rebound
-- the read-only input projection is rebound inside the merged root when present
-- declared output directories are rebound inside the merged root so their writes
-  land in the sidecar output volumes rather than the overlay upperdir
-- declared file outputs are captured from the merged root, copied into the
-  aggregate output store, and materialized back into the sandbox root for later
-  blocks
-- an opt-in privileged guest-agent E2E documents the expected behavior on a
-  non-overlay Linux root filesystem
-
-Resolved after the guest overlay runner slice:
-
-- opt-in managed-VM E2Es exercise overlay capture inside Firecracker and
-  darwin-vz guest roots
-- escaped-write fallback skips block-volume publication, resets declared
-  outputs, and reruns through the exact full-rootfs path before later phases
-  continue
-- Firecracker and darwin-vz advertise `sandbox.overlay_write_capture`
-
-### Darwin-VZ Sidecar Volume Status
-
-The darwin-vz backend now consumes launch-time `backend.CacheOutputVolumeSpec`
-values for persistent sandbox provisions and snapshot restores. It prepares
-writable sidecar ext4 volumes through the existing darwin-vz volume-store
-driver, passes their attachment paths to the Swift helper, and forwards the
-derived guest mount plan through the existing Linux guest-agent protocol.
-
-Completed in the darwin-vz sidecar slice and later release-readiness slices:
-
-- darwin-vz advertises `sandbox.cache_output_volumes` and, on macOS,
-  `sandbox.overlay_write_capture`
-- persistent provisions and snapshot restores forward cache output volume specs
-  into darwin-vz launch
-- cache hits prepare writable volumes from recorded source refs; misses create
-  empty ext4 output volume sources
-- the Swift helper accepts extra sidecar disk image paths and appends them as
-  writable `VZVirtioBlockDeviceConfiguration` storage devices after the rootfs
-- darwin-vz derives deterministic guest mount plans using `/dev/vdb`,
-  `/dev/vdc`, and later virtio block names in the same order as the sidecar
-  storage devices
-- sandbox executions forward the cache output mount plan to the Linux guest
-  agent, reusing the existing guest mount, bind, and file-restore behavior
-- sidecar volume cleanup runs on launch failure, readiness-probe failure, and
-  sandbox termination
-- opt-in darwin-vz E2Es cover cache output volume mount/restore behavior and
-  overlay capture with declared directory outputs, declared file outputs, and
-  escaped-write detection
-
-Remaining darwin-vz follow-up work:
-
-- keep expanding macOS smoke coverage with real dependency/service workloads
-- decide whether output volume sizing stays internal or becomes policy-visible
-  after real workloads show the right default
-
-## Refactoring Follow-up
-
-The release-ready implementation deliberately landed feature slices before
-collapsing duplication. The follow-up refactor should keep policy, cache keys,
-metadata, backend requests, and guest behavior stable while improving cohesion
-inside the control service and backend adapters.
-
-Reviewable slices:
-
-- Slice 1: consolidate dependency and service block-volume publication around
-  one shared snapshot, metadata, rollback, and logging path. This is implemented
-  in the first refactor slice.
-- Slice 2: collapse dependency and service block-volume planning into a shared
-  block plan with explicit phase inputs for the cache-key differences. This is
-  implemented in the second refactor slice.
-- Slice 3: collapse dependency and service block execution after the shared
-  plan shape exists, preserving the service fallback rule when dependency
-  publication is unsafe. This is implemented in the third refactor slice.
-- Slice 4: extract backend-neutral cache-output volume helpers shared by
-  Firecracker and darwin-vz, while leaving VM pause, storage-driver, and launch
-  details in each adapter. This is implemented in the fourth refactor slice.
-- Slice 5: reconcile the older layered-cache plan and the unused
-  `internal/inputmanifest` package with the implemented block-volume model.
-  This is implemented in the fifth refactor slice.
-- Slice 6: simplify `CreateSandbox` cache orchestration once the narrower
-  duplication has been removed. This is implemented in the sixth refactor
-  slice.
-
-## Tests
+- `cleanroom.cache.undeclared_read_count=<count>` when read auditing exists
+- `cleanroom.cache.temporary_output_cleanup=ok|failed` when cleanup runs
+
+## Current State
+
+Current main has useful pieces but not the intended semantics:
+
+- policy and proto support ordered dependency and service blocks
+- policy currently rejects `/workspace` outputs
+- dependency and service miss execution currently uses a read-only input
+  projection over the workspace
+- guest overlay capture exists
+- Firecracker and darwin-vz have sidecar output-volume support
+- publishing and restore paths are wired around the projection-first model
+
+The reset work should preserve the reusable backend pieces while changing the
+semantic center back to normal checkout execution plus overlay-first capture.
+
+## Delivery Strategy
+
+### Slice 1: Contract reset
+
+- Update spec, docs, examples, and tests so workspace-relative outputs are valid.
+- Remove wording that says dependency or service commands run from a read-only
+  declared-input projection.
+- Document overlay-first capture as the base miss path.
+- Add examples for `node_modules`, `vendor/bundle`, home cache dirs, and service
+  data dirs.
+- Add `volatile.paths` examples for unpersisted write allowances.
+
+Definition of done: policy docs and examples describe the intended model
+without exposing storage internals or user-visible modes.
+
+### Slice 2: Policy and planning
+
+- Remove policy rejection of outputs under `/workspace`.
+- Keep output path normalization, uniqueness, and overlap validation.
+- Add `volatile.paths` validation and escaped-write classification.
+- Make output normalization repository-path-aware instead of hard-coding
+  `/workspace`.
+- Add runtime planning for baseline output collisions.
+- Make cache keys include the normalized repository destination plus normalized
+  workspace output declarations.
+- Define closed block environment and controlled ambient mutable state.
+
+Definition of done: schema validation accepts workspace outputs, but planning
+can still skip portable publication when baseline collisions make restoration
+unsafe.
+
+### Slice 3: Overlay-first execution
+
+- Stop binding the input projection over the workspace for cacheable blocks.
+- Run block commands in the overlay view with the normal repository working
+  directory.
+- Promote declared output dirs and files from the merged overlay view.
+- Materialize promoted outputs back into the real sandbox root after a
+  publishable miss.
+- Preserve exact fallback when escaped writes are found.
+- Destroy temporary output stores on every fallback, cancellation, and publish
+  failure path.
+
+Definition of done: a dependency command can write
+`node_modules`, publish that output, and leave later blocks seeing the restored
+directory.
+
+### Slice 4: Restore and reuse
+
+- Restore declared outputs on cache hit at their exact guest paths.
+- Prove a source-only commit reuses dependency and service output caches without
+  rerunning block commands.
+- Ensure exact full-rootfs fallback still gives later phases the command's real
+  effects.
+
+Definition of done: managed VM smoke tests show a warm hit for workspace and
+home-directory outputs across a source-only commit.
+
+### Slice 5: Direct mount optimization
+
+- Mount writable output volumes before the command only for absent or empty
+  output directories.
+- Keep overlay capture active around direct mounts.
+- Fall back to overlay-copy promotion when a direct mount would hide baseline
+  contents.
+
+Definition of done: common large directory outputs avoid miss-time copying
+without changing command-visible behavior.
+
+### Slice 6: Read audit publish gate
+
+- Add backend capability for workspace and mutable ambient read auditing.
+- Compare observed workspace and mutable ambient reads with declared inputs,
+  modeled prior outputs, runtime identity, and declared secret/config inputs.
+- Skip portable publication and fall back to exact caching on undeclared mutable
+  reads.
+
+Definition of done: a block that reads an undeclared workspace or mutable
+ambient file is not published as portable cache when read auditing is available.
+
+## Verification
 
 Minimum coverage:
 
-- policy validation accepts ordered dependency/service blocks
-- policy validation accepts `sandbox.docker.required` as the Docker runtime
-  requirement
-- policy validation rejects the old single-object `sandbox.dependencies` shape
-- policy validation rejects the old `sandbox.services.command` and
-  `sandbox.services.key` shape
-- policy validation rejects the old `sandbox.services.docker.required` location
-- policy validation rejects duplicate block names
-- policy validation rejects invalid output dir and file paths, relative paths, unknown
-  variables, `~otheruser`, and `/workspace` outputs
-- policy validation rejects duplicate or overlapping normalized output directories
-- policy validation rejects file outputs inside directory outputs
-- path normalization makes `~/go/pkg/mod` and `${HOME}/go/pkg/mod` equivalent
-  and rejects `${WORKSPACE}` outputs after expansion
-- input manifests are deterministic across file order and glob order
-- input manifest validation rejects empty glob matches
-- input manifest validation rejects directories, symlinks, and other
-  non-regular files
-- input projection rejects symlinks that escape the declared input set
-- cache keys change when inputs, env, command, output declarations, runtime key, or
-  prior block output keys change
-- cache keys change when the reuse namespace changes
-- cache keys change when Cleanroom baseline command environment changes
-- cacheable block commands run from an isolated declared-input projection, not
-  from `/workspace`
-- dependency block cache hit restores output volumes and skips the command
-- file output cache hit restores the file without hiding sibling files in the
-  parent directory
-- partial dependency hit runs only missing later blocks
-- service block key changes when dependency output keys change
-- overlay write capture reports created, modified, deleted, and renamed paths in
-  the upperdir
-- declared directory output writes do not appear as escaped writes
-- declared file outputs are extracted from the upperdir and restored into the
-  sandbox root
-- persistent writes outside declared outputs prevent portable volume cache
-  publication and trigger exact fallback before later phases continue
-- a source-only commit reuses dependency and service output volumes without
-  rerunning block commands when declared inputs are unchanged
-- Firecracker launch includes cache output block devices before the VM starts
-- Firecracker and darwin-vz advertise `sandbox.overlay_write_capture` only where
-  the managed VM path supports sidecar output volumes, overlay capture, and
-  fallback
-- backend cleanup runs when command execution, snapshot publication, or metadata
-  persistence fails
-- Firecracker ZFS path clones output volumes rather than copying ext4 bytes
-- opt-in managed-VM E2Es cover Firecracker ZFS and darwin-vz overlay capture
-  with cache output volumes
+- policy validation accepts `node_modules`, `./node_modules`,
+  `${WORKSPACE}/node_modules`, and `/workspace/vendor/bundle` outputs
+- policy validation and cache-key tests cover `repository.path: /src`, proving
+  relative outputs and `${WORKSPACE}` normalize to `/src/...` and do not reuse
+  `/workspace/...` records
+- policy validation rejects unknown variables, duplicate outputs, overlapping
+  outputs, root output `/`, path traversal, globs in output paths, and file
+  outputs inside output dirs
+- policy validation accepts volatile globs and rejects volatile paths that
+  overlap outputs or ignore broad whole-tree prefixes
+- examples validate against the implemented schema
+- cache keys change when declared inputs, command, env, output declarations,
+  normalized repository destination, prior block outputs, runtime identity, or
+  producer version changes
+- block execution uses a closed environment and controlled `HOME`
+- overlay-first execution runs with the real repository path as the working
+  directory
+- declared workspace directory outputs are promoted from the overlay view
+- declared home directory outputs are promoted from the overlay view
+- declared file outputs are promoted and restored without hiding sibling files
+- escaped persistent writes skip portable publication and trigger exact fallback
+- volatile writes do not skip portable publication and are not restored on hit
+- baseline output collisions skip portable publication
+- temporary output stores are destroyed on command failure, escaped writes,
+  undeclared reads, metadata failure, cancellation, and exact fallback
+- cache hits restore output dirs and files before later dependency, service, and
+  execution phases
+- source-only commits reuse dependency and service outputs without rerunning
+  block commands
+- direct mount optimization is used only for absent or empty output dirs
+- read audit, when available, rejects undeclared workspace reads
+
+## Key Learnings From Pressure-Testing
+
+- Read-only input projection gives strong determinism but poor usability. It
+  should not be the default behavior because normal dependency commands expect
+  the full checkout.
+- Overlay write capture is the right base for invisible caching because it lets
+  commands run normally while still separating declared outputs from escaped
+  writes.
+- Direct output-volume mounts are valuable for performance, but only as an
+  optimization. Mounting too early can hide committed files and change command
+  behavior.
+- Volatile paths are necessary for harmless write noise, but they must stay
+  explicit and narrow so they do not become a generic ignore escape hatch.
+- Declared inputs are a correctness contract until read auditing exists. Read
+  auditing should become the stronger publish gate, not a user-visible mode.
+- Commands can run in the normal checkout without inheriting arbitrary mutable
+  state. Closed environments and controlled home/global state are required to
+  keep hidden inputs from invalidating portable reuse.
+- Temporary output storage must be treated as uncommitted until metadata
+  persistence succeeds; otherwise escaped-write fallback can leak storage.
 
 ## Settled Decisions
 
-- Empty globs fail. Optional inputs can be added later with explicit schema.
-- The new list schema replaces the old dependency object directly.
-- `sandbox.services` is an ordered service block list immediately.
-- Docker enablement moves to `sandbox.docker.required`.
-- `${HOME}` is the value Cleanroom sets in the closed block execution
-  environment. Declared env expansions are hashed into the block key; fixed
-  guest baseline defaults are covered by the producer version.
-- Escaped writes warn and trigger exact full-rootfs fallback in the first
-  implementation.
-- Escaped writes should become hard failures for cacheable blocks once the
-  feature is stable.
+- `inputs.files` plus declared outputs are the public cache contract.
+- Output paths are natural guest paths, not user-managed volume identifiers.
+- Workspace outputs are allowed.
+- Workspace outputs should usually be written as repository-relative paths such
+  as `node_modules`; `${WORKSPACE}/node_modules` and
+  `/workspace/node_modules` are accepted when an absolute guest path is clearer.
+- Relative workspace outputs and `${WORKSPACE}` are resolved against
+  `repository.path`, not hard-coded `/workspace`.
+- `volatile.paths` allow explicit unpersisted writes.
+- Portable blocks use a closed environment and controlled mutable ambient state.
+- Overlay-first capture is the base miss behavior.
+- Direct output mounts are an internal optimization.
+- Escaped persistent writes prevent portable publication.
+- No user-visible cache mode is added.
+
+## Deferred Work
+
+- Baseline merge support for output paths that already contain committed files.
+- Optional inputs and optional outputs.
+- Per-path output volumes for partial reuse.
+- Explicit service `depends_on`.
+- Cross-repository reuse namespaces beyond the canonical repository remote.

--- a/internal/cachekey/cachekey.go
+++ b/internal/cachekey/cachekey.go
@@ -77,6 +77,7 @@ type DependencyVolumeInputs struct {
 	RuntimeKey                      string
 	ReuseNamespace                  string
 	CompiledPolicyHash              string
+	DestinationDir                  string
 	BlockName                       string
 	CommandDigest                   string
 	EnvDigest                       string
@@ -94,6 +95,7 @@ type ServiceVolumeInputs struct {
 	RuntimeKey                   string
 	ReuseNamespace               string
 	CompiledPolicyHash           string
+	DestinationDir               string
 	BlockName                    string
 	CommandDigest                string
 	EnvDigest                    string
@@ -181,6 +183,7 @@ func DependencyVolumeKey(in DependencyVolumeInputs) string {
 		{name: "runtime_key", value: canonicalReference(in.RuntimeKey)},
 		{name: "reuse_namespace", value: canonicalReuseNamespace(in.ReuseNamespace)},
 		{name: "compiled_policy_hash", value: canonicalDigest(in.CompiledPolicyHash)},
+		{name: "destination_dir", value: canonicalAbsolutePath(in.DestinationDir)},
 		{name: "block_name", value: canonicalIdentifier(in.BlockName)},
 		{name: "command_digest", value: canonicalDigest(in.CommandDigest)},
 		{name: "env_digest", value: canonicalDigest(in.EnvDigest)},
@@ -200,6 +203,7 @@ func ServiceVolumeKey(in ServiceVolumeInputs) string {
 		{name: "runtime_key", value: canonicalReference(in.RuntimeKey)},
 		{name: "reuse_namespace", value: canonicalReuseNamespace(in.ReuseNamespace)},
 		{name: "compiled_policy_hash", value: canonicalDigest(in.CompiledPolicyHash)},
+		{name: "destination_dir", value: canonicalAbsolutePath(in.DestinationDir)},
 		{name: "block_name", value: canonicalIdentifier(in.BlockName)},
 		{name: "command_digest", value: canonicalDigest(in.CommandDigest)},
 		{name: "env_digest", value: canonicalDigest(in.EnvDigest)},

--- a/internal/cachekey/cachekey.go
+++ b/internal/cachekey/cachekey.go
@@ -78,6 +78,7 @@ type DependencyVolumeInputs struct {
 	ReuseNamespace                  string
 	CompiledPolicyHash              string
 	DestinationDir                  string
+	RepositorySourceDigest          string
 	BlockName                       string
 	CommandDigest                   string
 	EnvDigest                       string
@@ -96,6 +97,7 @@ type ServiceVolumeInputs struct {
 	ReuseNamespace               string
 	CompiledPolicyHash           string
 	DestinationDir               string
+	RepositorySourceDigest       string
 	BlockName                    string
 	CommandDigest                string
 	EnvDigest                    string
@@ -184,6 +186,7 @@ func DependencyVolumeKey(in DependencyVolumeInputs) string {
 		{name: "reuse_namespace", value: canonicalReuseNamespace(in.ReuseNamespace)},
 		{name: "compiled_policy_hash", value: canonicalDigest(in.CompiledPolicyHash)},
 		{name: "destination_dir", value: canonicalAbsolutePath(in.DestinationDir)},
+		{name: "repository_source_digest", value: canonicalDigest(in.RepositorySourceDigest)},
 		{name: "block_name", value: canonicalIdentifier(in.BlockName)},
 		{name: "command_digest", value: canonicalDigest(in.CommandDigest)},
 		{name: "env_digest", value: canonicalDigest(in.EnvDigest)},
@@ -204,6 +207,7 @@ func ServiceVolumeKey(in ServiceVolumeInputs) string {
 		{name: "reuse_namespace", value: canonicalReuseNamespace(in.ReuseNamespace)},
 		{name: "compiled_policy_hash", value: canonicalDigest(in.CompiledPolicyHash)},
 		{name: "destination_dir", value: canonicalAbsolutePath(in.DestinationDir)},
+		{name: "repository_source_digest", value: canonicalDigest(in.RepositorySourceDigest)},
 		{name: "block_name", value: canonicalIdentifier(in.BlockName)},
 		{name: "command_digest", value: canonicalDigest(in.CommandDigest)},
 		{name: "env_digest", value: canonicalDigest(in.EnvDigest)},

--- a/internal/cachekey/cachekey_test.go
+++ b/internal/cachekey/cachekey_test.go
@@ -137,6 +137,7 @@ func TestDependencyVolumeKey(t *testing.T) {
 		RuntimeKey:                      "runtime:v1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 		ReuseNamespace:                  "https://github.com/buildkite/cleanroom.git",
 		CompiledPolicyHash:              "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+		DestinationDir:                  "/workspace",
 		BlockName:                       "go-modules",
 		CommandDigest:                   "sha256:2222222222222222222222222222222222222222222222222222222222222222",
 		EnvDigest:                       "sha256:3333333333333333333333333333333333333333333333333333333333333333",
@@ -162,6 +163,12 @@ func TestDependencyVolumeKey(t *testing.T) {
 	}
 
 	mutated = inputs
+	mutated.DestinationDir = "/src"
+	if gotMutated := DependencyVolumeKey(mutated); got == gotMutated {
+		t.Fatalf("dependency volume key did not change after destination dir mutation: %q", got)
+	}
+
+	mutated = inputs
 	mutated.NormalizedOutputsDigest = "sha256:7777777777777777777777777777777777777777777777777777777777777777"
 	if gotMutated := DependencyVolumeKey(mutated); got == gotMutated {
 		t.Fatalf("dependency volume key did not change after outputs mutation: %q", got)
@@ -174,6 +181,7 @@ func TestServiceVolumeKey(t *testing.T) {
 		RuntimeKey:                   "runtime:v1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 		ReuseNamespace:               "https://github.com/buildkite/cleanroom.git",
 		CompiledPolicyHash:           "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+		DestinationDir:               "/workspace",
 		BlockName:                    "postgres",
 		CommandDigest:                "sha256:2222222222222222222222222222222222222222222222222222222222222222",
 		EnvDigest:                    "sha256:3333333333333333333333333333333333333333333333333333333333333333",
@@ -194,6 +202,12 @@ func TestServiceVolumeKey(t *testing.T) {
 	}
 
 	mutated := inputs
+	mutated.DestinationDir = "/src"
+	if gotMutated := ServiceVolumeKey(mutated); got == gotMutated {
+		t.Fatalf("service volume key did not change after destination dir mutation: %q", got)
+	}
+
+	mutated = inputs
 	mutated.DependencyOutputKeysDigest = "sha256:8888888888888888888888888888888888888888888888888888888888888888"
 	if gotMutated := ServiceVolumeKey(mutated); got == gotMutated {
 		t.Fatalf("service volume key did not change after dependency output keys mutation: %q", got)

--- a/internal/cachekey/cachekey_test.go
+++ b/internal/cachekey/cachekey_test.go
@@ -138,6 +138,7 @@ func TestDependencyVolumeKey(t *testing.T) {
 		ReuseNamespace:                  "https://github.com/buildkite/cleanroom.git",
 		CompiledPolicyHash:              "sha256:1111111111111111111111111111111111111111111111111111111111111111",
 		DestinationDir:                  "/workspace",
+		RepositorySourceDigest:          "sha256:9999999999999999999999999999999999999999999999999999999999999999",
 		BlockName:                       "go-modules",
 		CommandDigest:                   "sha256:2222222222222222222222222222222222222222222222222222222222222222",
 		EnvDigest:                       "sha256:3333333333333333333333333333333333333333333333333333333333333333",
@@ -169,6 +170,12 @@ func TestDependencyVolumeKey(t *testing.T) {
 	}
 
 	mutated = inputs
+	mutated.RepositorySourceDigest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	if gotMutated := DependencyVolumeKey(mutated); got == gotMutated {
+		t.Fatalf("dependency volume key did not change after repository source digest mutation: %q", got)
+	}
+
+	mutated = inputs
 	mutated.NormalizedOutputsDigest = "sha256:7777777777777777777777777777777777777777777777777777777777777777"
 	if gotMutated := DependencyVolumeKey(mutated); got == gotMutated {
 		t.Fatalf("dependency volume key did not change after outputs mutation: %q", got)
@@ -182,6 +189,7 @@ func TestServiceVolumeKey(t *testing.T) {
 		ReuseNamespace:               "https://github.com/buildkite/cleanroom.git",
 		CompiledPolicyHash:           "sha256:1111111111111111111111111111111111111111111111111111111111111111",
 		DestinationDir:               "/workspace",
+		RepositorySourceDigest:       "sha256:9999999999999999999999999999999999999999999999999999999999999999",
 		BlockName:                    "postgres",
 		CommandDigest:                "sha256:2222222222222222222222222222222222222222222222222222222222222222",
 		EnvDigest:                    "sha256:3333333333333333333333333333333333333333333333333333333333333333",
@@ -205,6 +213,12 @@ func TestServiceVolumeKey(t *testing.T) {
 	mutated.DestinationDir = "/src"
 	if gotMutated := ServiceVolumeKey(mutated); got == gotMutated {
 		t.Fatalf("service volume key did not change after destination dir mutation: %q", got)
+	}
+
+	mutated = inputs
+	mutated.RepositorySourceDigest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	if gotMutated := ServiceVolumeKey(mutated); got == gotMutated {
+		t.Fatalf("service volume key did not change after repository source digest mutation: %q", got)
 	}
 
 	mutated = inputs

--- a/internal/controlservice/block_volume_execution.go
+++ b/internal/controlservice/block_volume_execution.go
@@ -3,7 +3,6 @@ package controlservice
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"sort"
 	"strings"
 
@@ -17,13 +16,12 @@ import (
 )
 
 type blockVolumeExecutionPhase struct {
-	StageName           string
-	StageLabel          string
-	InputProjectionRoot string
-	BootstrapPhase      cleanroomv1.CreateSandboxPhase
-	PublishPhase        cleanroomv1.CreateSandboxPhase
-	NetworkStage        policy.NetworkStage
-	CachePublishPhase   blockVolumePublishPhase
+	StageName         string
+	StageLabel        string
+	BootstrapPhase    cleanroomv1.CreateSandboxPhase
+	PublishPhase      cleanroomv1.CreateSandboxPhase
+	NetworkStage      policy.NetworkStage
+	CachePublishPhase blockVolumePublishPhase
 }
 
 type blockVolumeExecutionPublishConfig struct {
@@ -152,12 +150,6 @@ func (s *Service) bootstrapBlockVolumeBlock(
 		return nil, nil
 	}
 	sourceRoot := blockVolumeSourceRoot(repository)
-	inputProjection := &backend.InputProjection{
-		SourceRoot:          sourceRoot,
-		TargetRoot:          filepath.Join(phase.InputProjectionRoot, strings.TrimSpace(block.BlockName)),
-		Files:               append([]string(nil), block.Inputs...),
-		MountSourceReadOnly: true,
-	}
 	env := stageBlockEnvList(block.Env)
 	_, result, stdout, stderr, err := s.runPersistentBootstrapCommandWithOptions(
 		ctx,
@@ -173,7 +165,6 @@ func (s *Service) bootstrapBlockVolumeBlock(
 		persistentSandboxCommandOptions{
 			Dir:                     sourceRoot,
 			ClosedEnv:               true,
-			InputProjection:         inputProjection,
 			CacheOutputFileCaptures: blockVolumeFileCaptures(phase.StageName, block.CacheKey, block.Outputs),
 			OverlayCapture:          blockVolumeOverlayCapture(phase.StageName, block.CacheKey, block.Outputs),
 		},

--- a/internal/controlservice/block_volume_plan.go
+++ b/internal/controlservice/block_volume_plan.go
@@ -30,6 +30,7 @@ type blockVolumeBlockPlan struct {
 	CommandDigest                   string
 	EnvDigest                       string
 	InputManifestDigest             string
+	RepositorySourceDigest          string
 	NormalizedOutputsDigest         string
 	DependencyOutputKeysDigest      string
 	PriorDependencyOutputKeysDigest string
@@ -104,6 +105,10 @@ func (s *Service) finalizeBlockVolumeBlockPlanBase(
 	if err != nil {
 		return blockVolumeBlockPlan{}, fmt.Errorf("digest %s block %q env: %w", phaseName, block.Name, err)
 	}
+	repositorySourceDigest, err := blockVolumeRepositorySourceDigest(repository, changeset)
+	if err != nil {
+		return blockVolumeBlockPlan{}, fmt.Errorf("digest %s block %q repository source: %w", phaseName, block.Name, err)
+	}
 	outputsDigest, err := digestCanonicalJSON(block.Outputs)
 	if err != nil {
 		return blockVolumeBlockPlan{}, fmt.Errorf("digest %s block %q outputs: %w", phaseName, block.Name, err)
@@ -118,8 +123,33 @@ func (s *Service) finalizeBlockVolumeBlockPlanBase(
 		CommandDigest:           commandDigest,
 		EnvDigest:               envDigest,
 		InputManifestDigest:     strings.TrimSpace(inputDigest),
+		RepositorySourceDigest:  repositorySourceDigest,
 		NormalizedOutputsDigest: outputsDigest,
 	}, nil
+}
+
+type blockVolumeRepositorySourceIdentity struct {
+	CanonicalRemoteURL          string `json:"canonical_remote_url,omitempty"`
+	CommitSHA                   string `json:"commit_sha,omitempty"`
+	SubmoduleMode               string `json:"submodule_mode,omitempty"`
+	ChangesetDigest             string `json:"changeset_digest,omitempty"`
+	CheckoutMode                string `json:"checkout_mode,omitempty"`
+	MaterializationRecipeDigest string `json:"materialization_recipe_digest,omitempty"`
+}
+
+func blockVolumeRepositorySourceDigest(repository *repositorycheckout.Checkout, changeset *repositorychangeset.Changeset) (string, error) {
+	normalizedRepository := normalizeRepositoryCheckoutForComparison(repository)
+	if normalizedRepository == nil {
+		return "", nil
+	}
+	return digestCanonicalJSON(blockVolumeRepositorySourceIdentity{
+		CanonicalRemoteURL:          strings.TrimSpace(normalizedRepository.RemoteURL),
+		CommitSHA:                   strings.TrimSpace(normalizedRepository.CommitSHA),
+		SubmoduleMode:               workspaceStageSubmoduleMode(normalizedRepository),
+		ChangesetDigest:             strings.TrimSpace(changesetDigest(changeset)),
+		CheckoutMode:                workspaceStageCheckoutMode(normalizedRepository),
+		MaterializationRecipeDigest: workspaceStageMaterializationRecipeDigest(normalizedRepository),
+	})
 }
 
 func lookupBlockVolumeCache(ctx context.Context, store cacheMetadataStore, stageName, backendName string, compiled *policy.CompiledPolicy, block blockVolumeBlockPlan) (blockVolumeBlockPlan, error) {

--- a/internal/controlservice/dependency_volume_execution.go
+++ b/internal/controlservice/dependency_volume_execution.go
@@ -10,16 +10,13 @@ import (
 	"github.com/buildkite/cleanroom/internal/repositorycheckout"
 )
 
-const dependencyInputProjectionRoot = "/run/cleanroom/input-projections/dependencies"
-
 var dependencyBlockVolumeExecutionPhase = blockVolumeExecutionPhase{
-	StageName:           dependencyVolumeStageName,
-	StageLabel:          "dependency",
-	InputProjectionRoot: dependencyInputProjectionRoot,
-	BootstrapPhase:      cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_DEPENDENCIES,
-	PublishPhase:        cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_PUBLISH_DEPENDENCY_STAGE_CACHE,
-	NetworkStage:        policy.NetworkStageDependencies,
-	CachePublishPhase:   dependencyBlockVolumePublishPhase,
+	StageName:         dependencyVolumeStageName,
+	StageLabel:        "dependency",
+	BootstrapPhase:    cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_DEPENDENCIES,
+	PublishPhase:      cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_PUBLISH_DEPENDENCY_STAGE_CACHE,
+	NetworkStage:      policy.NetworkStageDependencies,
+	CachePublishPhase: dependencyBlockVolumePublishPhase,
 }
 
 type dependencyBlockVolumePublishConfig struct {

--- a/internal/controlservice/dependency_volume_plan.go
+++ b/internal/controlservice/dependency_volume_plan.go
@@ -135,6 +135,7 @@ func (s *Service) finalizeDependencyBlockVolumeBlockPlan(
 		ReuseNamespace:                  strings.TrimSpace(reuseNamespace),
 		CompiledPolicyHash:              strings.TrimSpace(compiled.Hash),
 		DestinationDir:                  strings.TrimSpace(normalizeRepositoryCheckoutForComparison(repository).DestinationDir),
+		RepositorySourceDigest:          blockPlan.RepositorySourceDigest,
 		BlockName:                       strings.TrimSpace(block.Name),
 		CommandDigest:                   blockPlan.CommandDigest,
 		EnvDigest:                       blockPlan.EnvDigest,

--- a/internal/controlservice/dependency_volume_plan.go
+++ b/internal/controlservice/dependency_volume_plan.go
@@ -134,6 +134,7 @@ func (s *Service) finalizeDependencyBlockVolumeBlockPlan(
 		RuntimeKey:                      strings.TrimSpace(runtimeBaseKey),
 		ReuseNamespace:                  strings.TrimSpace(reuseNamespace),
 		CompiledPolicyHash:              strings.TrimSpace(compiled.Hash),
+		DestinationDir:                  strings.TrimSpace(normalizeRepositoryCheckoutForComparison(repository).DestinationDir),
 		BlockName:                       strings.TrimSpace(block.Name),
 		CommandDigest:                   blockPlan.CommandDigest,
 		EnvDigest:                       blockPlan.EnvDigest,

--- a/internal/controlservice/dependency_volume_plan_test.go
+++ b/internal/controlservice/dependency_volume_plan_test.go
@@ -114,6 +114,19 @@ func TestFinalizeDependencyBlockVolumePlanBuildsOrderedKeys(t *testing.T) {
 	if got, want := mutatedPlan.Blocks[0].CacheKey, first.CacheKey; got == want {
 		t.Fatalf("expected first block key to change after env mutation, got %q", got)
 	}
+
+	mutatedRepository := *repository
+	mutatedRepository.DestinationDir = "/src"
+	mutatedPlan, ok, err = svc.finalizeDependencyBlockVolumePlan(context.Background(), compiled, &mutatedRepository, nil, nil, "firecracker", "runtime-base:test")
+	if err != nil {
+		t.Fatalf("finalizeDependencyBlockVolumePlan destination mutation returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected destination-mutated dependency block volume plan")
+	}
+	if got, want := mutatedPlan.Blocks[0].CacheKey, first.CacheKey; got == want {
+		t.Fatalf("expected first block key to change after destination dir mutation, got %q", got)
+	}
 }
 
 func TestFinalizeDependencyBlockVolumePlanRejectsSymlinkInput(t *testing.T) {
@@ -725,7 +738,7 @@ func TestDependencyBlockVolumeRuntimeDecisionRequiresOutputVolumesAndOverlay(t *
 	}
 }
 
-func TestBootstrapDependencyBlockVolumePlanRunsMissesFromInputProjection(t *testing.T) {
+func TestBootstrapDependencyBlockVolumePlanRunsMissesFromWorkspaceOverlay(t *testing.T) {
 	t.Parallel()
 
 	compiled, err := policy.FromProto(testRepositoryTwoDependencyBlocksPolicy())
@@ -794,20 +807,8 @@ func TestBootstrapDependencyBlockVolumePlanRunsMissesFromInputProjection(t *test
 	if !slices.Contains(req.Env, "GOMODCACHE=/root/go/pkg/mod") {
 		t.Fatalf("expected GOMODCACHE env, got %v", req.Env)
 	}
-	if req.InputProjection == nil {
-		t.Fatal("expected input projection")
-	}
-	if got, want := req.InputProjection.SourceRoot, "/workspace"; got != want {
-		t.Fatalf("unexpected projection source root: got %q want %q", got, want)
-	}
-	if got, want := req.InputProjection.TargetRoot, "/run/cleanroom/input-projections/dependencies/go-modules"; got != want {
-		t.Fatalf("unexpected projection target root: got %q want %q", got, want)
-	}
-	if !slices.Equal(req.InputProjection.Files, []string{"go.mod", "go.sum"}) {
-		t.Fatalf("unexpected projection files: got %v", req.InputProjection.Files)
-	}
-	if !req.InputProjection.MountSourceReadOnly {
-		t.Fatal("expected projection to be mounted read-only over source")
+	if req.InputProjection != nil {
+		t.Fatalf("expected dependency block miss to run against the normal workspace, got projection %#v", req.InputProjection)
 	}
 	if req.OverlayCapture == nil {
 		t.Fatal("expected overlay capture request")

--- a/internal/controlservice/dependency_volume_plan_test.go
+++ b/internal/controlservice/dependency_volume_plan_test.go
@@ -87,10 +87,11 @@ func TestFinalizeDependencyBlockVolumePlanBuildsOrderedKeys(t *testing.T) {
 	}
 	for _, block := range plan.Blocks {
 		for name, value := range map[string]string{
-			"command": block.CommandDigest,
-			"env":     block.EnvDigest,
-			"inputs":  block.InputManifestDigest,
-			"outputs": block.NormalizedOutputsDigest,
+			"command":           block.CommandDigest,
+			"env":               block.EnvDigest,
+			"inputs":            block.InputManifestDigest,
+			"repository_source": block.RepositorySourceDigest,
+			"outputs":           block.NormalizedOutputsDigest,
 		} {
 			if !strings.HasPrefix(value, "sha256:") {
 				t.Fatalf("expected %s digest for block %q, got %q", name, block.BlockName, value)
@@ -126,6 +127,19 @@ func TestFinalizeDependencyBlockVolumePlanBuildsOrderedKeys(t *testing.T) {
 	}
 	if got, want := mutatedPlan.Blocks[0].CacheKey, first.CacheKey; got == want {
 		t.Fatalf("expected first block key to change after destination dir mutation, got %q", got)
+	}
+
+	mutatedRepository = *repository
+	mutatedRepository.Branch = "main"
+	mutatedPlan, ok, err = svc.finalizeDependencyBlockVolumePlan(context.Background(), compiled, &mutatedRepository, nil, nil, "firecracker", "runtime-base:test")
+	if err != nil {
+		t.Fatalf("finalizeDependencyBlockVolumePlan repository source mutation returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected repository-source-mutated dependency block volume plan")
+	}
+	if got, want := mutatedPlan.Blocks[0].CacheKey, first.CacheKey; got == want {
+		t.Fatalf("expected first block key to change after repository source mutation, got %q", got)
 	}
 }
 

--- a/internal/controlservice/service_volume_execution.go
+++ b/internal/controlservice/service_volume_execution.go
@@ -10,16 +10,13 @@ import (
 	"github.com/buildkite/cleanroom/internal/repositorycheckout"
 )
 
-const serviceInputProjectionRoot = "/run/cleanroom/input-projections/services"
-
 var serviceBlockVolumeExecutionPhase = blockVolumeExecutionPhase{
-	StageName:           serviceVolumeStageName,
-	StageLabel:          "service",
-	InputProjectionRoot: serviceInputProjectionRoot,
-	BootstrapPhase:      cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_SERVICES,
-	PublishPhase:        cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_PUBLISH_SERVICES_STAGE_CACHE,
-	NetworkStage:        policy.NetworkStageServices,
-	CachePublishPhase:   serviceBlockVolumePublishPhase,
+	StageName:         serviceVolumeStageName,
+	StageLabel:        "service",
+	BootstrapPhase:    cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_SERVICES,
+	PublishPhase:      cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_PUBLISH_SERVICES_STAGE_CACHE,
+	NetworkStage:      policy.NetworkStageServices,
+	CachePublishPhase: serviceBlockVolumePublishPhase,
 }
 
 type serviceBlockVolumePublishConfig struct {

--- a/internal/controlservice/service_volume_plan.go
+++ b/internal/controlservice/service_volume_plan.go
@@ -168,6 +168,7 @@ func (s *Service) finalizeServiceBlockVolumeBlockPlan(
 		ReuseNamespace:               strings.TrimSpace(reuseNamespace),
 		CompiledPolicyHash:           strings.TrimSpace(compiled.Hash),
 		DestinationDir:               strings.TrimSpace(normalizeRepositoryCheckoutForComparison(repository).DestinationDir),
+		RepositorySourceDigest:       blockPlan.RepositorySourceDigest,
 		BlockName:                    strings.TrimSpace(block.Name),
 		CommandDigest:                blockPlan.CommandDigest,
 		EnvDigest:                    blockPlan.EnvDigest,

--- a/internal/controlservice/service_volume_plan.go
+++ b/internal/controlservice/service_volume_plan.go
@@ -167,6 +167,7 @@ func (s *Service) finalizeServiceBlockVolumeBlockPlan(
 		RuntimeKey:                   strings.TrimSpace(runtimeBaseKey),
 		ReuseNamespace:               strings.TrimSpace(reuseNamespace),
 		CompiledPolicyHash:           strings.TrimSpace(compiled.Hash),
+		DestinationDir:               strings.TrimSpace(normalizeRepositoryCheckoutForComparison(repository).DestinationDir),
 		BlockName:                    strings.TrimSpace(block.Name),
 		CommandDigest:                blockPlan.CommandDigest,
 		EnvDigest:                    blockPlan.EnvDigest,

--- a/internal/controlservice/service_volume_plan_test.go
+++ b/internal/controlservice/service_volume_plan_test.go
@@ -91,10 +91,11 @@ func TestFinalizeServiceBlockVolumePlanBuildsOrderedKeys(t *testing.T) {
 	}
 	for _, block := range plan.Blocks {
 		for name, value := range map[string]string{
-			"command": block.CommandDigest,
-			"env":     block.EnvDigest,
-			"inputs":  block.InputManifestDigest,
-			"outputs": block.NormalizedOutputsDigest,
+			"command":           block.CommandDigest,
+			"env":               block.EnvDigest,
+			"inputs":            block.InputManifestDigest,
+			"repository_source": block.RepositorySourceDigest,
+			"outputs":           block.NormalizedOutputsDigest,
 		} {
 			if !strings.HasPrefix(value, "sha256:") {
 				t.Fatalf("expected %s digest for block %q, got %q", name, block.BlockName, value)
@@ -127,6 +128,19 @@ func TestFinalizeServiceBlockVolumePlanBuildsOrderedKeys(t *testing.T) {
 	}
 	if got, want := mutatedPlan.Blocks[0].CacheKey, first.CacheKey; got == want {
 		t.Fatalf("expected first service block key to change after destination dir mutation, got %q", got)
+	}
+
+	mutatedRepository = *repository
+	mutatedRepository.Branch = "main"
+	mutatedPlan, ok, err = svc.finalizeServiceBlockVolumePlan(context.Background(), compiled, &mutatedRepository, nil, nil, "firecracker", "runtime-base:test", dependencyPlan)
+	if err != nil {
+		t.Fatalf("finalizeServiceBlockVolumePlan repository source mutation returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected repository-source-mutated service block-volume plan")
+	}
+	if got, want := mutatedPlan.Blocks[0].CacheKey, first.CacheKey; got == want {
+		t.Fatalf("expected first service block key to change after repository source mutation, got %q", got)
 	}
 }
 
@@ -908,7 +922,7 @@ func TestCreateSandboxPassesBlockVolumeSpecsToColdProvision(t *testing.T) {
 	}
 }
 
-func TestCreateSandboxReusesDependencyAndServiceBlockVolumesAfterSourceOnlyChange(t *testing.T) {
+func TestCreateSandboxInvalidatesDependencyAndServiceBlockVolumesAfterSourceOnlyChange(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	adapter := dependencyBlockVolumeRuntimeAdapter()
 	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
@@ -1012,33 +1026,33 @@ func TestCreateSandboxReusesDependencyAndServiceBlockVolumesAfterSourceOnlyChang
 	}); err != nil {
 		t.Fatalf("second CreateSandbox returned error: %v", err)
 	}
-	if got, want := adapter.runCalls, firstRunCalls+1; got != want {
-		t.Fatalf("expected source-only create to run only repository bootstrap, got total run calls %d want %d", got, want)
+	if got, want := adapter.runCalls, firstRunCalls+1+wantBlockExecutions; got != want {
+		t.Fatalf("expected source-only create to rerun repository bootstrap and block executions, got total run calls %d want %d", got, want)
 	}
-	if got, want := len(blockExecutions), wantBlockExecutions; got != want {
-		t.Fatalf("expected source-only create to skip dependency/service block executions, got %d total block executions want %d", got, want)
+	if got, want := len(blockExecutions), wantBlockExecutions*2; got != want {
+		t.Fatalf("expected source-only create to rerun dependency/service block executions, got %d total block executions want %d", got, want)
 	}
-	if got, want := adapter.snapshotCacheOutputsCalls, firstSnapshotCalls; got != want {
-		t.Fatalf("expected source-only create to avoid republishing block volumes, got snapshot calls %d want %d", got, want)
+	if got, want := adapter.snapshotCacheOutputsCalls, firstSnapshotCalls+wantBlockExecutions; got != want {
+		t.Fatalf("expected source-only create to republish block volumes for the new source identity, got snapshot calls %d want %d", got, want)
 	}
 	if got, want := cacheStore.getReadyCount(dependencyVolumeStageName), len(dependencyPlan.Blocks); got != want {
 		t.Fatalf("expected source-only create to look up %d dependency block volumes, got %d", want, got)
 	}
-	if got, want := cacheStore.getReadyHitCount(dependencyVolumeStageName), len(dependencyPlan.Blocks); got != want {
-		t.Fatalf("expected source-only create to hit %d dependency block volumes, got %d", want, got)
+	if got := cacheStore.getReadyHitCount(dependencyVolumeStageName); got != 0 {
+		t.Fatalf("expected source-only create to miss dependency block volumes for the new source identity, got %d hits", got)
 	}
 	if got, want := cacheStore.getReadyCount(serviceVolumeStageName), len(servicePlan.Blocks); got != want {
 		t.Fatalf("expected source-only create to look up %d service block volumes, got %d", want, got)
 	}
-	if got, want := cacheStore.getReadyHitCount(serviceVolumeStageName), len(servicePlan.Blocks); got != want {
-		t.Fatalf("expected source-only create to hit %d service block volumes, got %d", want, got)
+	if got := cacheStore.getReadyHitCount(serviceVolumeStageName); got != 0 {
+		t.Fatalf("expected source-only create to miss service block volumes for the new source identity, got %d hits", got)
 	}
 	if got, want := len(adapter.provisionReq.CacheOutputVolumes), wantBlockExecutions; got != want {
-		t.Fatalf("expected source-only create to attach %d restored block volumes, got %d", want, got)
+		t.Fatalf("expected source-only create to attach %d fresh block volumes, got %d", want, got)
 	}
 	for _, spec := range adapter.provisionReq.CacheOutputVolumes {
-		if strings.TrimSpace(spec.StorageRef) == "" || strings.TrimSpace(spec.SourceSnapshotRef) == "" {
-			t.Fatalf("expected source-only create to restore volume %q from cached storage, got storage=%q source_snapshot=%q", spec.VolumeID, spec.StorageRef, spec.SourceSnapshotRef)
+		if strings.TrimSpace(spec.StorageRef) != "" || strings.TrimSpace(spec.SourceSnapshotRef) != "" {
+			t.Fatalf("expected source-only create to use fresh volume %q for the new source identity, got storage=%q source_snapshot=%q", spec.VolumeID, spec.StorageRef, spec.SourceSnapshotRef)
 		}
 	}
 }

--- a/internal/controlservice/service_volume_plan_test.go
+++ b/internal/controlservice/service_volume_plan_test.go
@@ -115,6 +115,19 @@ func TestFinalizeServiceBlockVolumePlanBuildsOrderedKeys(t *testing.T) {
 	if got, want := mutatedPlan.Blocks[0].CacheKey, first.CacheKey; got == want {
 		t.Fatalf("expected first service block key to change after dependency output key mutation, got %q", got)
 	}
+
+	mutatedRepository := *repository
+	mutatedRepository.DestinationDir = "/src"
+	mutatedPlan, ok, err = svc.finalizeServiceBlockVolumePlan(context.Background(), compiled, &mutatedRepository, nil, nil, "firecracker", "runtime-base:test", dependencyPlan)
+	if err != nil {
+		t.Fatalf("finalizeServiceBlockVolumePlan destination mutation returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected destination-mutated service block-volume plan")
+	}
+	if got, want := mutatedPlan.Blocks[0].CacheKey, first.CacheKey; got == want {
+		t.Fatalf("expected first service block key to change after destination dir mutation, got %q", got)
+	}
 }
 
 func TestLookupServiceBlockVolumeCachesReportsPartialHit(t *testing.T) {
@@ -937,10 +950,7 @@ func TestCreateSandboxReusesDependencyAndServiceBlockVolumesAfterSourceOnlyChang
 
 	var blockExecutions []backend.ExecutionRequest
 	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
-		if req.InputProjection != nil {
-			if req.OverlayCapture == nil {
-				t.Fatalf("block-volume execution %q did not request overlay capture", strings.Join(req.Command, " "))
-			}
+		if req.OverlayCapture != nil {
 			blockExecutions = append(blockExecutions, req)
 		}
 		return &backend.ExecutionResult{
@@ -1033,7 +1043,7 @@ func TestCreateSandboxReusesDependencyAndServiceBlockVolumesAfterSourceOnlyChang
 	}
 }
 
-func TestBootstrapServiceBlockVolumePlanRunsMissesFromInputProjection(t *testing.T) {
+func TestBootstrapServiceBlockVolumePlanRunsMissesFromWorkspaceOverlay(t *testing.T) {
 	t.Parallel()
 
 	compiled, err := policy.FromProto(testRepositoryTwoDependencyTwoServiceBlocksPolicy())
@@ -1105,20 +1115,8 @@ func TestBootstrapServiceBlockVolumePlanRunsMissesFromInputProjection(t *testing
 	if !strings.Contains(strings.Join(req.Env, "\n"), "APP_SERVICE_DATA=/var/lib/cleanroom/services/app") {
 		t.Fatalf("expected APP_SERVICE_DATA env, got %v", req.Env)
 	}
-	if req.InputProjection == nil {
-		t.Fatal("expected input projection")
-	}
-	if got, want := req.InputProjection.SourceRoot, "/workspace"; got != want {
-		t.Fatalf("unexpected projection source root: got %q want %q", got, want)
-	}
-	if got, want := req.InputProjection.TargetRoot, "/run/cleanroom/input-projections/services/app-service"; got != want {
-		t.Fatalf("unexpected projection target root: got %q want %q", got, want)
-	}
-	if got, want := strings.Join(req.InputProjection.Files, "\x00"), strings.Join([]string{"db/seed.sql", "docker-compose.yml", "scripts/prepare-app"}, "\x00"); got != want {
-		t.Fatalf("unexpected projection files: got %v", req.InputProjection.Files)
-	}
-	if !req.InputProjection.MountSourceReadOnly {
-		t.Fatal("expected projection to be mounted read-only over source")
+	if req.InputProjection != nil {
+		t.Fatalf("expected service block miss to run against the normal workspace, got projection %#v", req.InputProjection)
 	}
 	if req.OverlayCapture == nil {
 		t.Fatal("expected overlay capture request")

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -379,12 +379,17 @@ func Compile(raw rawPolicy) (*CompiledPolicy, error) {
 		return nil, errors.New("sandbox.network.allow cannot be combined with stage-local network blocks")
 	}
 
-	docker := normalizeDocker(raw.Sandbox.Docker)
-	dependencies, err := normalizeDependencies(raw.Sandbox.Dependencies)
+	repository, err := normalizeRepositoryConfig(raw.Repository)
 	if err != nil {
 		return nil, err
 	}
-	services, err := normalizeServices(raw.Sandbox.Services)
+
+	docker := normalizeDocker(raw.Sandbox.Docker)
+	dependencies, err := normalizeDependencies(raw.Sandbox.Dependencies, repository.Path)
+	if err != nil {
+		return nil, err
+	}
+	services, err := normalizeServices(raw.Sandbox.Services, repository.Path)
 	if err != nil {
 		return nil, err
 	}
@@ -811,19 +816,20 @@ func normalizeRepositoryConfig(raw *rawRepository) (RepositoryConfig, error) {
 		remote = "origin"
 	}
 
-	path := strings.TrimSpace(raw.Path)
-	if path == "" {
-		path = "/workspace"
+	repositoryPath := strings.TrimSpace(raw.Path)
+	if repositoryPath == "" {
+		repositoryPath = "/workspace"
 	}
-	if !strings.HasPrefix(path, "/") {
+	if !strings.HasPrefix(repositoryPath, "/") {
 		return RepositoryConfig{}, fmt.Errorf("repository.path %q must be absolute", raw.Path)
 	}
+	repositoryPath = path.Clean(repositoryPath)
 
 	return RepositoryConfig{
 		Implicit:   false,
 		Mode:       mode,
 		Remote:     remote,
-		Path:       path,
+		Path:       repositoryPath,
 		Submodules: raw.Submodules,
 	}, nil
 }
@@ -1103,12 +1109,12 @@ func normalizeDocker(raw rawDockerConfig) DockerService {
 	return DockerService{Required: raw.Required}
 }
 
-func normalizeDependencies(raw rawDependencyStage) (Dependencies, error) {
+func normalizeDependencies(raw rawDependencyStage, workspaceRoot string) (Dependencies, error) {
 	blocksField := raw.blocksField
 	if blocksField == "" {
 		blocksField = "sandbox.dependencies"
 	}
-	blocks, err := normalizeStageBlocks(raw.Blocks, blocksField)
+	blocks, err := normalizeStageBlocks(raw.Blocks, blocksField, workspaceRoot)
 	if err != nil {
 		return Dependencies{}, err
 	}
@@ -1162,8 +1168,8 @@ func normalizeDependencyReuse(raw string, keyFiles []string, field string) (stri
 	}
 }
 
-func normalizeServices(raw rawPolicyBlocks) (Services, error) {
-	blocks, err := normalizeStageBlocks(raw, "sandbox.services")
+func normalizeServices(raw rawPolicyBlocks, workspaceRoot string) (Services, error) {
+	blocks, err := normalizeStageBlocks(raw, "sandbox.services", workspaceRoot)
 	if err != nil {
 		return Services{}, err
 	}
@@ -1321,14 +1327,15 @@ const (
 	defaultBlockWorkspace = "/workspace"
 )
 
-func normalizeStageBlocks(raw []rawPolicyBlock, field string) ([]StageBlock, error) {
+func normalizeStageBlocks(raw []rawPolicyBlock, field string, workspaceRoot string) ([]StageBlock, error) {
 	if len(raw) == 0 {
 		return nil, nil
 	}
+	workspaceRoot = normalizeBlockWorkspaceRoot(workspaceRoot)
 	seenNames := make(map[string]struct{}, len(raw))
 	blocks := make([]StageBlock, 0, len(raw))
 	for i, candidate := range raw {
-		block, err := normalizeStageBlock(candidate, fmt.Sprintf("%s[%d]", field, i))
+		block, err := normalizeStageBlock(candidate, fmt.Sprintf("%s[%d]", field, i), workspaceRoot)
 		if err != nil {
 			return nil, err
 		}
@@ -1344,7 +1351,7 @@ func normalizeStageBlocks(raw []rawPolicyBlock, field string) ([]StageBlock, err
 	return blocks, nil
 }
 
-func normalizeStageBlock(raw rawPolicyBlock, field string) (StageBlock, error) {
+func normalizeStageBlock(raw rawPolicyBlock, field string, workspaceRoot string) (StageBlock, error) {
 	name := strings.TrimSpace(raw.Name)
 	if name == "" {
 		return StageBlock{}, fmt.Errorf("%s.name is required", field)
@@ -1366,11 +1373,11 @@ func normalizeStageBlock(raw rawPolicyBlock, field string) (StageBlock, error) {
 	if len(inputFiles) == 0 {
 		return StageBlock{}, fmt.Errorf("%s.inputs.files must include at least one file or glob", field)
 	}
-	env, err := normalizeBlockEnv(raw.Env, field+".env")
+	env, err := normalizeBlockEnv(raw.Env, field+".env", workspaceRoot)
 	if err != nil {
 		return StageBlock{}, err
 	}
-	outputs, err := normalizeBlockOutputs(raw.Outputs, field+".outputs")
+	outputs, err := normalizeBlockOutputs(raw.Outputs, field+".outputs", workspaceRoot)
 	if err != nil {
 		return StageBlock{}, err
 	}
@@ -1402,10 +1409,11 @@ func validStageBlockName(name string) bool {
 	return true
 }
 
-func normalizeBlockEnv(raw map[string]string, field string) (map[string]string, error) {
+func normalizeBlockEnv(raw map[string]string, field string, workspaceRoot string) (map[string]string, error) {
 	if len(raw) == 0 {
 		return nil, nil
 	}
+	workspaceRoot = normalizeBlockWorkspaceRoot(workspaceRoot)
 	env := make(map[string]string, len(raw))
 	for key, value := range raw {
 		name := strings.TrimSpace(key)
@@ -1415,12 +1423,13 @@ func normalizeBlockEnv(raw map[string]string, field string) (map[string]string, 
 		if !validEnvName(name) {
 			return nil, fmt.Errorf("%s.%s must be a valid environment variable name", field, name)
 		}
-		env[name] = expandGuestEnvValue(value)
+		env[name] = expandGuestEnvValue(value, workspaceRoot)
 	}
 	return env, nil
 }
 
-func expandGuestEnvValue(value string) string {
+func expandGuestEnvValue(value string, workspaceRoot string) string {
+	workspaceRoot = normalizeBlockWorkspaceRoot(workspaceRoot)
 	switch {
 	case value == "~":
 		return defaultBlockHome
@@ -1435,13 +1444,13 @@ func expandGuestEnvValue(value string) string {
 	case strings.HasPrefix(value, "${HOME}/"):
 		return defaultBlockHome + strings.TrimPrefix(value, "${HOME}")
 	case value == "$WORKSPACE":
-		return defaultBlockWorkspace
+		return workspaceRoot
 	case strings.HasPrefix(value, "$WORKSPACE/"):
-		return defaultBlockWorkspace + strings.TrimPrefix(value, "$WORKSPACE")
+		return workspaceRoot + strings.TrimPrefix(value, "$WORKSPACE")
 	case value == "${WORKSPACE}":
-		return defaultBlockWorkspace
+		return workspaceRoot
 	case strings.HasPrefix(value, "${WORKSPACE}/"):
-		return defaultBlockWorkspace + strings.TrimPrefix(value, "${WORKSPACE}")
+		return workspaceRoot + strings.TrimPrefix(value, "${WORKSPACE}")
 	default:
 		return value
 	}
@@ -1463,12 +1472,13 @@ func validEnvName(name string) bool {
 	return name != ""
 }
 
-func normalizeBlockOutputs(raw rawPolicyBlockOutputs, field string) (StageBlockOutputs, error) {
-	dirs, err := normalizeOutputPaths(raw.Dirs, field+".dirs")
+func normalizeBlockOutputs(raw rawPolicyBlockOutputs, field string, workspaceRoot string) (StageBlockOutputs, error) {
+	workspaceRoot = normalizeBlockWorkspaceRoot(workspaceRoot)
+	dirs, err := normalizeOutputPaths(raw.Dirs, field+".dirs", workspaceRoot)
 	if err != nil {
 		return StageBlockOutputs{}, err
 	}
-	files, err := normalizeOutputPaths(raw.Files, field+".files")
+	files, err := normalizeOutputPaths(raw.Files, field+".files", workspaceRoot)
 	if err != nil {
 		return StageBlockOutputs{}, err
 	}
@@ -1478,22 +1488,23 @@ func normalizeBlockOutputs(raw rawPolicyBlockOutputs, field string) (StageBlockO
 	return StageBlockOutputs{Dirs: dirs, Files: files}, nil
 }
 
-func normalizeOutputPaths(raw []string, field string) ([]string, error) {
+func normalizeOutputPaths(raw []string, field string, workspaceRoot string) ([]string, error) {
 	if len(raw) == 0 {
 		return nil, nil
 	}
+	workspaceRoot = normalizeBlockWorkspaceRoot(workspaceRoot)
 	seen := make(map[string]struct{}, len(raw))
 	paths := make([]string, 0, len(raw))
 	for i, candidate := range raw {
-		normalized, err := expandGuestPathValue(strings.TrimSpace(candidate), fmt.Sprintf("%s[%d]", field, i), true)
+		normalized, err := expandGuestPathValue(strings.TrimSpace(candidate), fmt.Sprintf("%s[%d]", field, i), workspaceRoot, true)
 		if err != nil {
 			return nil, err
 		}
-		if strings.HasPrefix(normalized, "/workspace/") || normalized == "/workspace" {
-			return nil, fmt.Errorf("%s[%d] must not be under /workspace", field, i)
-		}
 		if normalized == "/" {
 			return nil, fmt.Errorf("%s[%d] must not be /", field, i)
+		}
+		if normalized == workspaceRoot {
+			return nil, fmt.Errorf("%s[%d] must not be the repository root", field, i)
 		}
 		if _, ok := seen[normalized]; ok {
 			return nil, fmt.Errorf("%s[%d] duplicates output path %q", field, i, normalized)
@@ -1505,10 +1516,12 @@ func normalizeOutputPaths(raw []string, field string) ([]string, error) {
 	return paths, nil
 }
 
-func expandGuestPathValue(value, field string, requireAbsolute bool) (string, error) {
+func expandGuestPathValue(value, field string, workspaceRoot string, requireAbsolute bool) (string, error) {
+	workspaceRoot = normalizeBlockWorkspaceRoot(workspaceRoot)
 	if value == "" {
 		return "", fmt.Errorf("%s cannot be empty", field)
 	}
+	workspaceAnchored := false
 	if value == "~" {
 		value = defaultBlockHome
 	} else if strings.HasPrefix(value, "~/") {
@@ -1524,25 +1537,52 @@ func expandGuestPathValue(value, field string, requireAbsolute bool) (string, er
 	} else if strings.HasPrefix(value, "${HOME}/") {
 		value = defaultBlockHome + strings.TrimPrefix(value, "${HOME}")
 	} else if value == "$WORKSPACE" {
-		value = defaultBlockWorkspace
+		value = workspaceRoot
+		workspaceAnchored = true
 	} else if strings.HasPrefix(value, "$WORKSPACE/") {
-		value = defaultBlockWorkspace + strings.TrimPrefix(value, "$WORKSPACE")
+		value = workspaceRoot + strings.TrimPrefix(value, "$WORKSPACE")
+		workspaceAnchored = true
 	} else if value == "${WORKSPACE}" {
-		value = defaultBlockWorkspace
+		value = workspaceRoot
+		workspaceAnchored = true
 	} else if strings.HasPrefix(value, "${WORKSPACE}/") {
-		value = defaultBlockWorkspace + strings.TrimPrefix(value, "${WORKSPACE}")
+		value = workspaceRoot + strings.TrimPrefix(value, "${WORKSPACE}")
+		workspaceAnchored = true
 	}
 	if strings.Contains(value, "$") {
 		return "", fmt.Errorf("%s contains an unsupported variable expansion", field)
 	}
-	value = path.Clean(strings.ReplaceAll(value, "\\", "/"))
+	value = strings.ReplaceAll(value, "\\", "/")
 	if strings.ContainsAny(value, "*?[") {
 		return "", fmt.Errorf("%s must not contain glob characters", field)
+	}
+	if requireAbsolute && !strings.HasPrefix(value, "/") {
+		relative := path.Clean(value)
+		if relative == "." || relative == ".." || strings.HasPrefix(relative, "../") {
+			return "", fmt.Errorf("%s must stay within the repository root", field)
+		}
+		value = path.Join(workspaceRoot, relative)
+	} else {
+		value = path.Clean(value)
+	}
+	if workspaceAnchored && !pathWithinOrEqual(workspaceRoot, value) {
+		return "", fmt.Errorf("%s must stay within the repository root", field)
 	}
 	if requireAbsolute && !strings.HasPrefix(value, "/") {
 		return "", fmt.Errorf("%s must be absolute", field)
 	}
 	return value, nil
+}
+
+func normalizeBlockWorkspaceRoot(workspaceRoot string) string {
+	workspaceRoot = strings.TrimSpace(workspaceRoot)
+	if workspaceRoot == "" {
+		return defaultBlockWorkspace
+	}
+	if !strings.HasPrefix(workspaceRoot, "/") {
+		return defaultBlockWorkspace
+	}
+	return path.Clean(workspaceRoot)
 }
 
 func validateOutputPathRelationships(dirs, files []string, field string) error {
@@ -1640,6 +1680,12 @@ func pathContains(parent, child string) bool {
 	return strings.HasPrefix(child, parent+"/")
 }
 
+func pathWithinOrEqual(parent, child string) bool {
+	parent = path.Clean(parent)
+	child = path.Clean(child)
+	return child == parent || pathContains(parent, child)
+}
+
 func stageBlocksToProto(blocks []StageBlock) []*cleanroomv1.PolicyBlock {
 	out := make([]*cleanroomv1.PolicyBlock, 0, len(blocks))
 	for _, block := range blocks {
@@ -1679,7 +1725,7 @@ func stageBlocksFromProto(blocks []*cleanroomv1.PolicyBlock, field string) ([]St
 			},
 		})
 	}
-	return normalizeStageBlocks(raw, field+".blocks")
+	return normalizeStageBlocks(raw, field+".blocks", defaultBlockWorkspace)
 }
 
 func cloneStringMap(in map[string]string) map[string]string {

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -599,6 +599,91 @@ func TestCompileNormalizesDependencyBootstrapConfig(t *testing.T) {
 	}
 }
 
+func TestCompileNormalizesWorkspaceRelativeOutputPaths(t *testing.T) {
+	t.Parallel()
+
+	raw := baseRawPolicy()
+	raw.Sandbox.Dependencies = rawDependencyBlocks(
+		rawPolicyBlock{
+			Name:    "node",
+			Command: rawDependencyCommandSpec{"npm", "ci"},
+			Inputs:  rawPolicyBlockInputs{Files: []string{"package-lock.json"}},
+			Env: map[string]string{
+				"WORKDIR":   "${WORKSPACE}",
+				"WORKCACHE": "$WORKSPACE/.cache",
+			},
+			Outputs: rawPolicyBlockOutputs{
+				Dirs:  []string{"node_modules", "./vendor/bundle", "${WORKSPACE}/.cache/yarn"},
+				Files: []string{"tmp/state.json", "${WORKSPACE}/.npmrc"},
+			},
+		},
+	)
+
+	compiled, err := Compile(raw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	block := compiled.Dependencies.Blocks[0]
+	if got, want := block.Outputs.Dirs, []string{"/workspace/.cache/yarn", "/workspace/node_modules", "/workspace/vendor/bundle"}; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("unexpected output dirs: got %v want %v", got, want)
+	}
+	if got, want := block.Outputs.Files, []string{"/workspace/.npmrc", "/workspace/tmp/state.json"}; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("unexpected output files: got %v want %v", got, want)
+	}
+	if got, want := block.Env["WORKDIR"], "/workspace"; got != want {
+		t.Fatalf("unexpected WORKDIR: got %q want %q", got, want)
+	}
+	if got, want := block.Env["WORKCACHE"], "/workspace/.cache"; got != want {
+		t.Fatalf("unexpected WORKCACHE: got %q want %q", got, want)
+	}
+}
+
+func TestCompileNormalizesBlockWorkspaceAgainstRepositoryPath(t *testing.T) {
+	t.Parallel()
+
+	raw := baseRawPolicy()
+	raw.Repository = &rawRepository{Path: "/src/"}
+	raw.Sandbox.Dependencies = rawDependencyBlocks(
+		rawPolicyBlock{
+			Name:    "node",
+			Command: rawDependencyCommandSpec{"npm", "ci"},
+			Inputs:  rawPolicyBlockInputs{Files: []string{"package-lock.json"}},
+			Env: map[string]string{
+				"WORKDIR":   "${WORKSPACE}",
+				"WORKCACHE": "$WORKSPACE/.cache",
+			},
+			Outputs: rawPolicyBlockOutputs{
+				Dirs: []string{"node_modules", "${WORKSPACE}/vendor/bundle"},
+			},
+		},
+	)
+
+	compiled, err := Compile(raw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	block := compiled.Dependencies.Blocks[0]
+	if got, want := block.Outputs.Dirs, []string{"/src/node_modules", "/src/vendor/bundle"}; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("unexpected output dirs: got %v want %v", got, want)
+	}
+	if got, want := block.Env["WORKDIR"], "/src"; got != want {
+		t.Fatalf("unexpected WORKDIR: got %q want %q", got, want)
+	}
+	if got, want := block.Env["WORKCACHE"], "/src/.cache"; got != want {
+		t.Fatalf("unexpected WORKCACHE: got %q want %q", got, want)
+	}
+
+	defaultPathRaw := raw
+	defaultPathRaw.Repository = nil
+	defaultPathCompiled, err := Compile(defaultPathRaw)
+	if err != nil {
+		t.Fatalf("compile default repository path: %v", err)
+	}
+	if defaultPathCompiled.Hash == compiled.Hash {
+		t.Fatalf("expected repository.path to affect normalized block policy hash, got %q", compiled.Hash)
+	}
+}
+
 func TestCompilePreservesDependencyReuseFromYAML(t *testing.T) {
 	t.Parallel()
 
@@ -737,13 +822,15 @@ func TestCompileRejectsInvalidOutputPaths(t *testing.T) {
 		outputs rawPolicyBlockOutputs
 		want    string
 	}{
-		{name: "relative dir", outputs: rawPolicyBlockOutputs{Dirs: []string{"var/cache"}}, want: "must be absolute"},
-		{name: "workspace dir", outputs: rawPolicyBlockOutputs{Dirs: []string{"/workspace/node_modules"}}, want: "must not be under /workspace"},
 		{name: "root dir", outputs: rawPolicyBlockOutputs{Dirs: []string{"/"}}, want: "must not be /"},
+		{name: "repository root dir", outputs: rawPolicyBlockOutputs{Dirs: []string{"/workspace"}}, want: "must not be the repository root"},
+		{name: "workspace variable root dir", outputs: rawPolicyBlockOutputs{Dirs: []string{"${WORKSPACE}"}}, want: "must not be the repository root"},
+		{name: "relative escape", outputs: rawPolicyBlockOutputs{Dirs: []string{"../cache"}}, want: "must stay within the repository root"},
+		{name: "workspace variable escape", outputs: rawPolicyBlockOutputs{Dirs: []string{"${WORKSPACE}/../cache"}}, want: "must stay within the repository root"},
+		{name: "glob dir", outputs: rawPolicyBlockOutputs{Dirs: []string{"node_modules/*"}}, want: "must not contain glob characters"},
 		{name: "unknown variable", outputs: rawPolicyBlockOutputs{Dirs: []string{"${CACHE}/go"}}, want: "unsupported variable expansion"},
 		{name: "home variable typo", outputs: rawPolicyBlockOutputs{Dirs: []string{"$HOMECACHE/go"}}, want: "unsupported variable expansion"},
 		{name: "home braced variable typo", outputs: rawPolicyBlockOutputs{Dirs: []string{"${HOME}CACHE/go"}}, want: "unsupported variable expansion"},
-		{name: "workspace variable dir", outputs: rawPolicyBlockOutputs{Dirs: []string{"${WORKSPACE}/vendor/bundle"}}, want: "must not be under /workspace"},
 		{name: "workspace variable typo", outputs: rawPolicyBlockOutputs{Dirs: []string{"$WORKSPACECACHE/go"}}, want: "unsupported variable expansion"},
 		{name: "workspace braced variable typo", outputs: rawPolicyBlockOutputs{Dirs: []string{"${WORKSPACE}CACHE/go"}}, want: "unsupported variable expansion"},
 		{name: "other user home", outputs: rawPolicyBlockOutputs{Dirs: []string{"~builder/.cache"}}, want: "does not support ~user expansion"},


### PR DESCRIPTION
## Problem

Dependency and service volume caches are supposed to be mostly invisible: users declare the files that define a block and the paths the tool naturally writes, then Cleanroom handles the cache storage behind the scenes.

The current implementation had drifted away from that contract. Cacheable misses used a read-only input projection over `/workspace`, and policy rejected outputs under `/workspace`. That made common dependency tools surprising because outputs such as `node_modules`, `vendor/bundle`, and generated dependency state had to be moved outside the checkout. The volume cache key also did not explicitly model the configured repository destination path, so workspace-relative output declarations were not safe for repositories mounted somewhere other than `/workspace`.

## What Changed

- Allow dependency and service outputs to be declared inside the checkout.
- Resolve relative output paths against `repository.path`.
- Expand `$WORKSPACE` and `${WORKSPACE}` using the configured repository destination.
- Include the normalized repository destination directory in dependency and service volume cache keys.
- Run dependency/service volume-cache misses against the normal writable checkout with overlay capture, instead of mounting a read-only input projection over the workspace.

## Examples

Repo-local dependency output:

```yaml
sandbox:
  dependencies:
    - name: node
      command: npm ci
      inputs:
        files:
          - package.json
          - package-lock.json
      outputs:
        dirs:
          - node_modules
```

Home-level package store plus repo-local output:

```yaml
sandbox:
  dependencies:
    - name: go-modules
      command: mise exec -- go mod download
      inputs:
        files:
          - mise.toml
          - mise.lock
          - go.mod
          - go.sum
      env:
        GOMODCACHE: "${HOME}/go/pkg/mod"
      outputs:
        dirs:
          - "${HOME}/go/pkg/mod"
          - .cache/go-build
```

Custom checkout destination:

```yaml
repository:
  path: /src

sandbox:
  dependencies:
    - name: ruby
      command: bundle install
      inputs:
        files:
          - Gemfile.lock
      outputs:
        dirs:
          - vendor/bundle
```

With `repository.path: /src`, `vendor/bundle` is normalized to `/src/vendor/bundle`, and the volume cache key is distinct from the same declaration under `/workspace`.

## Validation

- `mise exec -- go test ./... -count=1`