### PR TITLE
docs: Update workspace output examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,12 +137,12 @@ sandbox:
   docker:
     required: true
   dependencies:
-    - name: gems
-      command: bundle install
+    - name: node
+      command: npm ci
       inputs:
-        files: [Gemfile.lock]
+        files: [package.json, package-lock.json]
       outputs:
-        dirs: ["${HOME}/.bundle"]
+        dirs: [node_modules]
   services:
     - name: database
       command: |

--- a/docs/plans/dependency-service-volume-caches.md
+++ b/docs/plans/dependency-service-volume-caches.md
@@ -471,18 +471,20 @@ Telemetry should include:
 
 ## Current State
 
-Current main has useful pieces but not the intended semantics:
+Current main has the first implementation slice:
 
 - policy and proto support ordered dependency and service blocks
-- policy currently rejects `/workspace` outputs
-- dependency and service miss execution currently uses a read-only input
-  projection over the workspace
+- policy validation accepts repository-relative and workspace-local outputs
+- dependency and service miss execution runs against the normal writable
+  checkout with overlay capture
 - guest overlay capture exists
 - Firecracker and darwin-vz have sidecar output-volume support
-- publishing and restore paths are wired around the projection-first model
+- volume cache keys include repository destination and conservative repository
+  source identity
 
-The reset work should preserve the reusable backend pieces while changing the
-semantic center back to normal checkout execution plus overlay-first capture.
+Remaining slices should make source-only reuse safe by adding read auditing,
+then remove the conservative source-identity keying when observed reads prove
+the block only consumed declared mutable inputs.
 
 ## Delivery Strategy
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -184,10 +184,15 @@ explicit request-time changeset input.
 - Service block commands accept either a YAML string or a YAML sequence; strings execute as `sh -lc <value>`, and strings are the preferred form.
 - Block `inputs.files` are repository-relative regular files or globs matching
   regular files. Literal paths must exist; globs must match at least one path.
-- Block `outputs.dirs` and `outputs.files` are absolute guest paths outside
-  `/workspace` and cannot be `/`; `${HOME}`, `$HOME`, and `~` expand to the
-  Cleanroom block execution home, while `${WORKSPACE}` and `$WORKSPACE` expand
-  to the Cleanroom workspace root before the workspace-output rejection runs.
+- Block `outputs.dirs` and `outputs.files` are guest paths written by the block.
+  Relative paths are repository-relative and resolve against `repository.path`;
+  for example `node_modules` resolves to `/workspace/node_modules` with the
+  default repository path. Absolute paths are also valid. Outputs cannot be `/`
+  or the repository root, must stay within the repository root when declared
+  with a relative path or `$WORKSPACE` prefix, and must not contain glob
+  characters. `${HOME}`, `$HOME`, and `~` expand to the Cleanroom block
+  execution home, while `${WORKSPACE}` and `$WORKSPACE` expand to the normalized
+  repository path.
 - Block `env` values are literal strings, except leading home-directory
   and workspace shorthand forms (`~`, `~/`, `$HOME`, `$HOME/`, `${HOME}`,
   `${HOME}/`, `$WORKSPACE`, `$WORKSPACE/`, `${WORKSPACE}`, `${WORKSPACE}/`)

--- a/examples/rails/README.md
+++ b/examples/rails/README.md
@@ -43,6 +43,8 @@ cleanroom exec \
   --backend darwin-vz \
   --repo-url https://github.com/rails/rails.git \
   --repo-commit cfa4e1b475472c7980a42dd810f237951db5108a \
+  -e BUNDLE_PATH=/workspace/vendor/bundle \
+  -e BUNDLE_APP_CONFIG=/workspace/vendor/bundle/.bundle \
   -- sh -lc 'cd activesupport && bin/test test/benchmarkable_test.rb'
 ```
 
@@ -52,6 +54,8 @@ cleanroom exec \
   (`default-libmysqlclient-dev`, `libxml2-dev`) and runs a full `bundle install`
 - the block sets Bundler env so gems and Bundler app config are materialized
   under the declared repository-local `vendor/bundle` output
+- the execution command passes the same Bundler env because dependency block
+  env is scoped to the create-time dependency command
 - Bundler mirror env injection rewrites the default `https://rubygems.org`
   source through Cleanroom's `/rubygems/` gateway route
 - the dependency stage is keyed on `Gemfile`, `Gemfile.lock`, and the component

--- a/examples/rails/README.md
+++ b/examples/rails/README.md
@@ -51,7 +51,7 @@ cleanroom exec \
 - the `bundle` dependency block fills the remaining guest package gap
   (`default-libmysqlclient-dev`, `libxml2-dev`) and runs a full `bundle install`
 - the block sets Bundler env so gems and Bundler app config are materialized
-  under the declared `/usr/local/bundle` output
+  under the declared repository-local `vendor/bundle` output
 - Bundler mirror env injection rewrites the default `https://rubygems.org`
   source through Cleanroom's `/rubygems/` gateway route
 - the dependency stage is keyed on `Gemfile`, `Gemfile.lock`, and the component

--- a/examples/rails/cleanroom.yaml
+++ b/examples/rails/cleanroom.yaml
@@ -10,8 +10,8 @@ sandbox:
   dependencies:
     - name: bundle
       env:
-        BUNDLE_PATH: vendor/bundle
-        BUNDLE_APP_CONFIG: vendor/bundle/.bundle
+        BUNDLE_PATH: "${WORKSPACE}/vendor/bundle"
+        BUNDLE_APP_CONFIG: "${WORKSPACE}/vendor/bundle/.bundle"
       command:
         - sh
         - -lc

--- a/examples/rails/cleanroom.yaml
+++ b/examples/rails/cleanroom.yaml
@@ -10,9 +10,8 @@ sandbox:
   dependencies:
     - name: bundle
       env:
-        GEM_HOME: /usr/local/bundle
-        BUNDLE_PATH: /usr/local/bundle
-        BUNDLE_APP_CONFIG: /usr/local/bundle
+        BUNDLE_PATH: vendor/bundle
+        BUNDLE_APP_CONFIG: vendor/bundle/.bundle
       command:
         - sh
         - -lc
@@ -42,7 +41,7 @@ sandbox:
           - railties/railties.gemspec
       outputs:
         dirs:
-          - /usr/local/bundle
+          - vendor/bundle
   network:
     default: deny
     allow:


### PR DESCRIPTION
## Problem

After #334, dependency and service outputs can be declared where tools naturally write them inside the checkout. Some user-facing documentation still described the old model: outputs outside `/workspace`, Bundler forced into `/usr/local/bundle`, and examples that did not show repository-relative outputs.

## What Changed

- Update the spec rule for block outputs to describe repository-relative outputs, `$WORKSPACE` expansion, and the remaining validation limits.
- Change the README setup example to use a natural repo-local `node_modules` output.
- Update the Rails example to install Bundler output into `vendor/bundle` instead of `/usr/local/bundle`.
- Refresh the volume-cache plan current-state section now that the first implementation slice has merged.

## Examples

The README now shows:

```yaml
sandbox:
  dependencies:
    - name: node
      command: npm ci
      inputs:
        files: [package.json, package-lock.json]
      outputs:
        dirs: [node_modules]
```

The Rails example now declares:

```yaml
env:
  BUNDLE_PATH: vendor/bundle
  BUNDLE_APP_CONFIG: vendor/bundle/.bundle
outputs:
  dirs:
    - vendor/bundle
```

## Validation

- `cleanroom policy validate` in `examples/basic`
- `cleanroom policy validate` in `examples/docker`
- `cleanroom policy validate` in `examples/buildkite-agent`
- `cleanroom policy validate` in `examples/rails`
- `mise exec -- go test ./internal/policy -count=1`