### PR TITLE
fix: Delay cache output mounts until dependency stages

### DIFF
--- a/cmd/cleanroom-guest-agent/cache_output_mounts.go
+++ b/cmd/cleanroom-guest-agent/cache_output_mounts.go
@@ -43,12 +43,15 @@ type cacheOutputMountAction struct {
 
 var cacheOutputMountState struct {
 	sync.Mutex
-	signature string
+	signature      string
+	mountedTargets []string
 }
 
 func setupCacheOutputMountsOnce(mounts []vsockexec.CacheOutputMount) error {
 	if len(mounts) == 0 {
-		return nil
+		cacheOutputMountState.Lock()
+		defer cacheOutputMountState.Unlock()
+		return clearCacheOutputMountStateLocked()
 	}
 	signature, err := cacheOutputMountSignature(mounts)
 	if err != nil {
@@ -63,10 +66,12 @@ func setupCacheOutputMountsOnce(mounts []vsockexec.CacheOutputMount) error {
 	if cacheOutputMountState.signature != "" {
 		return errors.New("cache output mount plan changed after setup")
 	}
-	if err := setupCacheOutputMounts(mounts); err != nil {
+	mountedTargets, err := setupCacheOutputMounts(mounts)
+	if err != nil {
 		return err
 	}
 	cacheOutputMountState.signature = signature
+	cacheOutputMountState.mountedTargets = mountedTargets
 	return nil
 }
 
@@ -78,16 +83,38 @@ func cacheOutputMountSignature(mounts []vsockexec.CacheOutputMount) (string, err
 	return string(data), nil
 }
 
-func setupCacheOutputMounts(mounts []vsockexec.CacheOutputMount) error {
+func setupCacheOutputMounts(mounts []vsockexec.CacheOutputMount) ([]string, error) {
 	actions, err := cacheOutputMountActions(mounts)
 	if err != nil {
-		return err
+		return nil, err
 	}
+	mountedTargets := make([]string, 0, len(actions))
 	for _, action := range actions {
-		if err := executeCacheOutputMountAction(action); err != nil {
-			return err
+		mounted, err := executeCacheOutputMountAction(action)
+		if err != nil {
+			cleanupErr := unmountCacheOutputTargets(mountedTargets)
+			if cleanupErr != nil {
+				return nil, fmt.Errorf("%w; cleanup mounted cache output targets: %v", err, cleanupErr)
+			}
+			return nil, err
+		}
+		if mounted {
+			mountedTargets = append(mountedTargets, action.Target)
 		}
 	}
+	return mountedTargets, nil
+}
+
+func clearCacheOutputMountStateLocked() error {
+	if cacheOutputMountState.signature == "" {
+		cacheOutputMountState.mountedTargets = nil
+		return nil
+	}
+	if err := unmountCacheOutputTargets(cacheOutputMountState.mountedTargets); err != nil {
+		return err
+	}
+	cacheOutputMountState.signature = ""
+	cacheOutputMountState.mountedTargets = nil
 	return nil
 }
 
@@ -181,49 +208,71 @@ func cleanCacheOutputSubpath(value string) (string, error) {
 	return cleaned, nil
 }
 
-func executeCacheOutputMountAction(action cacheOutputMountAction) error {
+func executeCacheOutputMountAction(action cacheOutputMountAction) (bool, error) {
 	switch action.Kind {
 	case cacheOutputActionMkdir:
 		if action.VolumeRoot != "" {
 			_, err := ensureCacheOutputVolumeDir(action.VolumeRoot, action.VolumeSubpath, action.Mode, action.RequireExisting)
-			return err
+			return false, err
 		}
-		return ensureCacheOutputDir(action.Target, action.Mode, action.RequireExisting, action.RequireEmpty)
+		return false, ensureCacheOutputDir(action.Target, action.Mode, action.RequireExisting, action.RequireEmpty)
 	case cacheOutputActionMount:
 		if err := unix.Mount(action.Source, action.Target, action.FSType, action.Flags, action.Data); err != nil && err != unix.EBUSY {
-			return fmt.Errorf("mount cache output volume %s at %s: %w", action.Source, action.Target, err)
+			return false, fmt.Errorf("mount cache output volume %s at %s: %w", action.Source, action.Target, err)
+		} else if err == unix.EBUSY {
+			return false, nil
 		}
+		return true, nil
 	case cacheOutputActionBind:
 		sourcePath := action.Source
 		if action.VolumeRoot != "" {
 			resolved, err := ensureCacheOutputVolumeDir(action.VolumeRoot, action.VolumeSubpath, 0, true)
 			if err != nil {
-				return err
+				return false, err
 			}
 			sourcePath = resolved
 		}
 		if err := unix.Mount(sourcePath, action.Target, "", action.Flags, ""); err != nil && err != unix.EBUSY {
-			return fmt.Errorf("bind cache output path %s at %s: %w", sourcePath, action.Target, err)
+			return false, fmt.Errorf("bind cache output path %s at %s: %w", sourcePath, action.Target, err)
+		} else if err == unix.EBUSY {
+			return false, nil
 		}
+		return true, nil
 	case cacheOutputActionRestoreFile:
 		if action.VolumeRoot != "" {
 			source, sourcePath, err := openCacheOutputVolumeFile(action.VolumeRoot, action.VolumeSubpath, action.Required)
 			if err != nil {
-				return err
+				return false, err
 			}
 			if source == nil {
-				return nil
+				return false, nil
 			}
 			defer source.Close()
-			return restoreCacheOutputFileFrom(source, sourcePath, action.Target, action.Mode)
+			return false, restoreCacheOutputFileFrom(source, sourcePath, action.Target, action.Mode)
 		}
 		if err := restoreCacheOutputFile(action.Source, action.Target, action.Mode, action.Required); err != nil {
-			return err
+			return false, err
 		}
 	default:
-		return fmt.Errorf("unknown cache output mount action %q", action.Kind)
+		return false, fmt.Errorf("unknown cache output mount action %q", action.Kind)
 	}
-	return nil
+	return false, nil
+}
+
+var unmountCacheOutputTarget = unix.Unmount
+
+func unmountCacheOutputTargets(targets []string) error {
+	var errs []error
+	for i := len(targets) - 1; i >= 0; i-- {
+		target := strings.TrimSpace(targets[i])
+		if target == "" {
+			continue
+		}
+		if err := unmountCacheOutputTarget(target, unix.MNT_DETACH); err != nil && err != unix.EINVAL && err != unix.ENOENT {
+			errs = append(errs, fmt.Errorf("unmount cache output target %s: %w", target, err))
+		}
+	}
+	return errors.Join(errs...)
 }
 
 func ensureCacheOutputVolumeDir(root, subpath string, mode fs.FileMode, requireExisting bool) (string, error) {

--- a/cmd/cleanroom-guest-agent/cache_output_mounts_test.go
+++ b/cmd/cleanroom-guest-agent/cache_output_mounts_test.go
@@ -416,11 +416,14 @@ func TestCacheOutputCaptureSourcePathResolvesAbsoluteSymlinkInsideSourceRoot(t *
 func TestSetupCacheOutputMountsOnceRejectsChangedPlan(t *testing.T) {
 	cacheOutputMountState.Lock()
 	previousSignature := cacheOutputMountState.signature
+	previousMountedTargets := append([]string(nil), cacheOutputMountState.mountedTargets...)
 	cacheOutputMountState.signature = "first"
+	cacheOutputMountState.mountedTargets = nil
 	cacheOutputMountState.Unlock()
 	t.Cleanup(func() {
 		cacheOutputMountState.Lock()
 		cacheOutputMountState.signature = previousSignature
+		cacheOutputMountState.mountedTargets = previousMountedTargets
 		cacheOutputMountState.Unlock()
 	})
 
@@ -438,5 +441,48 @@ func TestSetupCacheOutputMountsOnceRejectsChangedPlan(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "mount plan changed") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSetupCacheOutputMountsOnceClearsMountedTargetsOnEmptyPlan(t *testing.T) {
+	cacheOutputMountState.Lock()
+	previousSignature := cacheOutputMountState.signature
+	previousMountedTargets := append([]string(nil), cacheOutputMountState.mountedTargets...)
+	cacheOutputMountState.signature = "first"
+	cacheOutputMountState.mountedTargets = []string{"/run/cleanroom/cache-output-volumes/cacheout0", "/workspace/node_modules"}
+	cacheOutputMountState.Unlock()
+	t.Cleanup(func() {
+		cacheOutputMountState.Lock()
+		cacheOutputMountState.signature = previousSignature
+		cacheOutputMountState.mountedTargets = previousMountedTargets
+		cacheOutputMountState.Unlock()
+	})
+
+	previousUnmount := unmountCacheOutputTarget
+	var unmounts []string
+	unmountCacheOutputTarget = func(target string, flags int) error {
+		if flags != unix.MNT_DETACH {
+			t.Fatalf("unexpected unmount flags: got %d want %d", flags, unix.MNT_DETACH)
+		}
+		unmounts = append(unmounts, target)
+		return nil
+	}
+	t.Cleanup(func() { unmountCacheOutputTarget = previousUnmount })
+
+	if err := setupCacheOutputMountsOnce(nil); err != nil {
+		t.Fatalf("setupCacheOutputMountsOnce returned error: %v", err)
+	}
+
+	wantUnmounts := []string{"/workspace/node_modules", "/run/cleanroom/cache-output-volumes/cacheout0"}
+	if !reflect.DeepEqual(unmounts, wantUnmounts) {
+		t.Fatalf("unexpected unmounts: got %#v want %#v", unmounts, wantUnmounts)
+	}
+	cacheOutputMountState.Lock()
+	defer cacheOutputMountState.Unlock()
+	if cacheOutputMountState.signature != "" {
+		t.Fatalf("expected cleared signature, got %q", cacheOutputMountState.signature)
+	}
+	if len(cacheOutputMountState.mountedTargets) != 0 {
+		t.Fatalf("expected cleared mounted targets, got %#v", cacheOutputMountState.mountedTargets)
 	}
 }

--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -1549,14 +1549,14 @@ func (a *Adapter) executeInSandbox(bootCtx context.Context, runCtx context.Conte
 		return nil, errors.New("missing command")
 	}
 
-	policy := req.Policy
-	if policy == nil {
-		policy = instance.Policy
+	activePolicy := req.Policy
+	if activePolicy == nil {
+		activePolicy = instance.Policy
 	}
-	if policy == nil {
+	if activePolicy == nil {
 		return nil, errors.New("missing compiled policy")
 	}
-	networkPolicy := policy.NetworkPolicyForStage(req.NetworkStage)
+	networkPolicy := activePolicy.NetworkPolicyForStage(req.NetworkStage)
 	allowlistSupported, allowlistStatusDetail, _, supportErr := allowlistSupportForConfig(instance.FirecrackerConfig)
 	if supportErr != nil {
 		return nil, supportErr
@@ -1653,10 +1653,12 @@ func (a *Adapter) executeInSandbox(bootCtx context.Context, runCtx context.Conte
 		Env:                     append([]string(nil), req.Env...),
 		ClosedEnv:               req.ClosedEnv,
 		TTY:                     req.TTY,
-		CacheOutputMounts:       cloneDarwinVZCacheOutputMounts(instance.cacheOutputMounts),
 		CacheOutputFileCaptures: cacheOutputCaptures,
 		InputProjection:         darwinVZInputProjection(req.InputProjection),
 		OverlayCapture:          guestexec.ToVSOCKOverlayCapture(req.OverlayCapture),
+	}
+	if req.NetworkStage != policy.NetworkStageWorkspace {
+		guestReq.CacheOutputMounts = cloneDarwinVZCacheOutputMounts(instance.cacheOutputMounts)
 	}
 	if !req.ClosedEnv && a.GatewayRegistry != nil && gatewayScopeToken != "" {
 		gwPort := a.GatewayPort

--- a/internal/backend/darwinvz/persistent_test.go
+++ b/internal/backend/darwinvz/persistent_test.go
@@ -300,6 +300,74 @@ func TestRunInSandboxRejectsExitedSandbox(t *testing.T) {
 	}
 }
 
+func TestExecuteInSandboxSkipsCacheOutputMountsForWorkspaceStage(t *testing.T) {
+	t.Parallel()
+
+	socketDir, err := os.MkdirTemp("", "cr-cache-mounts-")
+	if err != nil {
+		t.Fatalf("create temp dir: %v", err)
+	}
+	defer os.RemoveAll(socketDir)
+
+	socketPath := filepath.Join(socketDir, "proxy.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen unix socket: %v", err)
+	}
+	defer listener.Close()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		conn, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			t.Errorf("accept guest exec connection: %v", acceptErr)
+			return
+		}
+		defer conn.Close()
+
+		var req vsockexec.ExecRequest
+		if decodeErr := json.NewDecoder(conn).Decode(&req); decodeErr != nil {
+			t.Errorf("decode guest exec request: %v", decodeErr)
+			return
+		}
+		if len(req.CacheOutputMounts) != 0 {
+			t.Errorf("workspace stage should not receive cache output mounts, got %#v", req.CacheOutputMounts)
+		}
+		if encodeErr := vsockexec.EncodeStreamFrame(conn, vsockexec.ExecStreamFrame{Type: "exit", ExitCode: 0}); encodeErr != nil {
+			t.Errorf("encode guest exec response: %v", encodeErr)
+		}
+	}()
+
+	adapter := &Adapter{}
+	_, err = adapter.executeInSandbox(context.Background(), context.Background(), &sandboxInstance{
+		SandboxID:       "cr-test",
+		ProxySocketPath: socketPath,
+		Policy:          &policy.CompiledPolicy{NetworkDefault: "deny"},
+		Helper:          &helperSession{},
+		exitedCh:        make(chan struct{}),
+		cacheOutputMounts: []vsockexec.CacheOutputMount{
+			{
+				DevicePath: "/dev/vdb",
+				MountPath:  "/run/cleanroom/cache-output-volumes/cacheout0",
+				DirMappings: []vsockexec.CacheOutputDirMount{
+					{GuestPath: "/workspace/node_modules", Subpath: "dirs/0"},
+				},
+			},
+		},
+	}, backend.ExecutionRequest{
+		SandboxID:    "cr-test",
+		ExecutionID:  "run-123",
+		Command:      []string{"true"},
+		Policy:       &policy.CompiledPolicy{NetworkDefault: "deny"},
+		NetworkStage: policy.NetworkStageWorkspace,
+	}, backend.OutputStream{})
+	if err != nil {
+		t.Fatalf("executeInSandbox returned error: %v", err)
+	}
+	<-done
+}
+
 func TestProbeGuestExecReadyWaitsForGuestResponse(t *testing.T) {
 	t.Parallel()
 

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -533,7 +533,11 @@ func (a *Adapter) RunInSandbox(ctx context.Context, req backend.ExecutionRequest
 		return nil, err
 	}
 
-	guestResult, timing, err := a.executeInSandbox(ctx, instance, req.LaunchSeconds, req.Command, req.Dir, req.Env, req.ClosedEnv, req.InputProjection, cacheOutputCaptures, req.OverlayCapture, req.TTY, stream)
+	cacheOutputMounts := cloneCacheOutputMounts(instance.cacheOutputMounts)
+	if req.NetworkStage == policy.NetworkStageWorkspace {
+		cacheOutputMounts = nil
+	}
+	guestResult, timing, err := a.executeInSandbox(ctx, instance, req.LaunchSeconds, req.Command, req.Dir, req.Env, req.ClosedEnv, req.InputProjection, cacheOutputMounts, cacheOutputCaptures, req.OverlayCapture, req.TTY, stream)
 	if err != nil {
 		observation.ExitCode = 1
 		observation.GuestError = err.Error()
@@ -625,7 +629,7 @@ func (a *Adapter) runFileTransferCommand(ctx context.Context, sandboxID string, 
 	if err != nil {
 		return nil, err
 	}
-	result, _, err := a.executeInSandbox(ctx, instance, 0, cmd, "", nil, false, nil, nil, nil, false, stream)
+	result, _, err := a.executeInSandbox(ctx, instance, 0, cmd, "", nil, false, nil, cloneCacheOutputMounts(instance.cacheOutputMounts), nil, nil, false, stream)
 	if err != nil {
 		return nil, err
 	}
@@ -703,7 +707,7 @@ func (a *Adapter) CreateSnapshot(ctx context.Context, req backend.SnapshotReques
 		return nil, fmt.Errorf("sandbox %q is not running: %w", sandboxID, err)
 	}
 
-	syncResp, _, err := a.executeInSandbox(ctx, instance, snapshotSyncTimeoutSeconds, []string{"sync"}, "", nil, false, nil, nil, nil, false, backend.OutputStream{})
+	syncResp, _, err := a.executeInSandbox(ctx, instance, snapshotSyncTimeoutSeconds, []string{"sync"}, "", nil, false, nil, cloneCacheOutputMounts(instance.cacheOutputMounts), nil, nil, false, backend.OutputStream{})
 	if err != nil {
 		return nil, fmt.Errorf("sync sandbox filesystem before snapshot: %w", err)
 	}
@@ -840,14 +844,14 @@ func (a *Adapter) DeleteSnapshot(ctx context.Context, req backend.DeleteSnapshot
 	return nil
 }
 
-func (a *Adapter) executeInSandbox(ctx context.Context, instance *sandboxInstance, launchSeconds int64, command []string, dir string, env []string, closedEnv bool, inputProjection *backend.InputProjection, cacheOutputFileCaptures []vsockexec.CacheOutputFileCapture, overlayCapture *backend.OverlayCapture, tty bool, stream backend.OutputStream) (vsockexec.ExecResponse, guestExecTiming, error) {
+func (a *Adapter) executeInSandbox(ctx context.Context, instance *sandboxInstance, launchSeconds int64, command []string, dir string, env []string, closedEnv bool, inputProjection *backend.InputProjection, cacheOutputMounts []vsockexec.CacheOutputMount, cacheOutputFileCaptures []vsockexec.CacheOutputFileCapture, overlayCapture *backend.OverlayCapture, tty bool, stream backend.OutputStream) (vsockexec.ExecResponse, guestExecTiming, error) {
 	guestReq := vsockexec.ExecRequest{
 		Command:                 append([]string(nil), command...),
 		Dir:                     strings.TrimSpace(dir),
 		Env:                     append([]string(nil), env...),
 		ClosedEnv:               closedEnv,
 		TTY:                     tty,
-		CacheOutputMounts:       cloneCacheOutputMounts(instance.cacheOutputMounts),
+		CacheOutputMounts:       cloneCacheOutputMounts(cacheOutputMounts),
 		CacheOutputFileCaptures: append([]vsockexec.CacheOutputFileCapture(nil), cacheOutputFileCaptures...),
 		InputProjection:         vsockInputProjection(inputProjection),
 		OverlayCapture:          guestexec.ToVSOCKOverlayCapture(overlayCapture),

--- a/internal/backend/firecracker/cache_output_snapshots.go
+++ b/internal/backend/firecracker/cache_output_snapshots.go
@@ -71,7 +71,7 @@ func (a *Adapter) SnapshotCacheOutputVolumes(ctx context.Context, req backend.Sn
 		})
 	}
 
-	syncResp, _, err := a.executeInSandbox(ctx, instance, snapshotSyncTimeoutSeconds, []string{"sync"}, "", nil, false, nil, nil, nil, false, backend.OutputStream{})
+	syncResp, _, err := a.executeInSandbox(ctx, instance, snapshotSyncTimeoutSeconds, []string{"sync"}, "", nil, false, nil, cloneCacheOutputMounts(instance.cacheOutputMounts), nil, nil, false, backend.OutputStream{})
 	if err != nil {
 		return nil, fmt.Errorf("sync sandbox filesystem before cache output snapshot: %w", err)
 	}

--- a/internal/backend/firecracker/cache_output_snapshots_test.go
+++ b/internal/backend/firecracker/cache_output_snapshots_test.go
@@ -51,18 +51,30 @@ func TestSnapshotCacheOutputVolumesSyncsPausesAndSnapshotsSelectedVolumes(t *tes
 	}
 
 	var syncCommands [][]string
+	wantMounts := []vsockexec.CacheOutputMount{
+		{
+			DevicePath: "/dev/vdb",
+			MountPath:  "/run/cleanroom/cache-output-volumes/cacheout0",
+			DirMappings: []vsockexec.CacheOutputDirMount{
+				{GuestPath: "/workspace/node_modules", Subpath: "dirs/0"},
+			},
+		},
+	}
+	var gotSyncMounts []vsockexec.CacheOutputMount
 	adapter := &Adapter{
 		runGuestCommandFn: func(_ context.Context, _ context.Context, _ <-chan struct{}, _ func() error, _ string, _ uint32, req vsockexec.ExecRequest, _ backend.OutputStream) (vsockexec.ExecResponse, guestExecTiming, error) {
 			syncCommands = append(syncCommands, append([]string(nil), req.Command...))
+			gotSyncMounts = cloneCacheOutputMounts(req.CacheOutputMounts)
 			return vsockexec.ExecResponse{ExitCode: 0}, guestExecTiming{}, nil
 		},
 		sandboxes: map[string]*sandboxInstance{
 			"cr-test": {
-				SandboxID: "cr-test",
-				VsockPath: "/tmp/fake.sock",
-				GuestPort: 10700,
-				fcCmd:     &exec.Cmd{Process: &os.Process{Pid: 42}},
-				exitedCh:  make(chan struct{}),
+				SandboxID:         "cr-test",
+				VsockPath:         "/tmp/fake.sock",
+				GuestPort:         10700,
+				fcCmd:             &exec.Cmd{Process: &os.Process{Pid: 42}},
+				exitedCh:          make(chan struct{}),
+				cacheOutputMounts: cloneCacheOutputMounts(wantMounts),
 				cacheOutputVolumes: []preparedCacheOutputVolume{
 					testPreparedCacheOutputVolumeWithDriver("dependency-volume", "deps", "key-a", "volume-a", "volume-a-ref", "file"),
 					testPreparedCacheOutputVolume("dependency-volume", "tools", "key-b", "volume-b", "volume-b-ref"),
@@ -84,6 +96,9 @@ func TestSnapshotCacheOutputVolumesSyncsPausesAndSnapshotsSelectedVolumes(t *tes
 	}
 	if got, want := syncCommands, [][]string{{"sync"}}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("unexpected sync commands: got %#v want %#v", got, want)
+	}
+	if !reflect.DeepEqual(gotSyncMounts, wantMounts) {
+		t.Fatalf("unexpected sync cache output mounts: got %#v want %#v", gotSyncMounts, wantMounts)
 	}
 	if got, want := signals, []syscall.Signal{syscall.SIGSTOP, syscall.SIGCONT}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("unexpected signals: got %v want %v", got, want)

--- a/internal/backend/firecracker/persistent_test.go
+++ b/internal/backend/firecracker/persistent_test.go
@@ -273,6 +273,86 @@ func TestRunInSandboxForwardsCacheOutputMounts(t *testing.T) {
 	}
 }
 
+func TestRunFileTransferCommandForwardsCacheOutputMounts(t *testing.T) {
+	t.Parallel()
+
+	wantMounts := []vsockexec.CacheOutputMount{
+		{
+			DevicePath:    "/dev/vdb",
+			MountPath:     "/run/cleanroom/cache-output-volumes/cacheout0",
+			SourcePresent: true,
+			DirMappings: []vsockexec.CacheOutputDirMount{
+				{GuestPath: "/workspace/node_modules", Subpath: "dirs/0"},
+			},
+		},
+	}
+	var gotCommand []string
+	var gotMounts []vsockexec.CacheOutputMount
+	adapter := &Adapter{}
+	adapter.runGuestCommandFn = func(_ context.Context, _ context.Context, _ <-chan struct{}, _ func() error, _ string, _ uint32, req vsockexec.ExecRequest, _ backend.OutputStream) (vsockexec.ExecResponse, guestExecTiming, error) {
+		gotCommand = append([]string(nil), req.Command...)
+		gotMounts = cloneCacheOutputMounts(req.CacheOutputMounts)
+		return vsockexec.ExecResponse{ExitCode: 0}, guestExecTiming{}, nil
+	}
+	adapter.sandboxes = map[string]*sandboxInstance{
+		"cr-test": {
+			SandboxID:         "cr-test",
+			VsockPath:         "/tmp/fake.sock",
+			GuestPort:         10700,
+			cacheOutputMounts: cloneCacheOutputMounts(wantMounts),
+		},
+	}
+
+	if _, err := adapter.runFileTransferCommand(context.Background(), "cr-test", []string{"stat", "/workspace/node_modules"}, backend.OutputStream{}); err != nil {
+		t.Fatalf("runFileTransferCommand returned error: %v", err)
+	}
+	if got, want := gotCommand, []string{"stat", "/workspace/node_modules"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected command: got %#v want %#v", got, want)
+	}
+	if !reflect.DeepEqual(gotMounts, wantMounts) {
+		t.Fatalf("unexpected cache output mounts: got %#v want %#v", gotMounts, wantMounts)
+	}
+}
+
+func TestRunInSandboxSkipsCacheOutputMountsForWorkspaceStage(t *testing.T) {
+	t.Parallel()
+
+	var gotMounts []vsockexec.CacheOutputMount
+	adapter := &Adapter{}
+	adapter.runGuestCommandFn = func(_ context.Context, _ context.Context, _ <-chan struct{}, _ func() error, _ string, _ uint32, req vsockexec.ExecRequest, _ backend.OutputStream) (vsockexec.ExecResponse, guestExecTiming, error) {
+		gotMounts = cloneCacheOutputMounts(req.CacheOutputMounts)
+		return vsockexec.ExecResponse{ExitCode: 0}, guestExecTiming{}, nil
+	}
+	adapter.sandboxes = map[string]*sandboxInstance{
+		"cr-test": {
+			SandboxID: "cr-test",
+			VsockPath: "/tmp/fake.sock",
+			GuestPort: 10700,
+			cacheOutputMounts: []vsockexec.CacheOutputMount{
+				{
+					DevicePath: "/dev/vdb",
+					MountPath:  "/run/cleanroom/cache-output-volumes/cacheout0",
+					DirMappings: []vsockexec.CacheOutputDirMount{
+						{GuestPath: "/workspace/node_modules", Subpath: "dirs/0"},
+					},
+				},
+			},
+		},
+	}
+
+	if _, err := adapter.RunInSandbox(context.Background(), backend.ExecutionRequest{
+		SandboxID:    "cr-test",
+		ExecutionID:  "run-123",
+		Command:      []string{"true"},
+		NetworkStage: policy.NetworkStageWorkspace,
+	}, backend.OutputStream{}); err != nil {
+		t.Fatalf("RunInSandbox returned error: %v", err)
+	}
+	if len(gotMounts) != 0 {
+		t.Fatalf("workspace stage should not receive cache output mounts, got %#v", gotMounts)
+	}
+}
+
 func TestRunInSandboxForwardsCacheOutputFileCaptures(t *testing.T) {
 	t.Parallel()
 

--- a/internal/backend/firecracker/snapshot_test.go
+++ b/internal/backend/firecracker/snapshot_test.go
@@ -102,21 +102,33 @@ func TestCreateSnapshotSyncsPausesAndClonesRootFS(t *testing.T) {
 	}
 	t.Cleanup(func() { sendProcessSignal = prevSignal })
 
+	wantMounts := []vsockexec.CacheOutputMount{
+		{
+			DevicePath: "/dev/vdb",
+			MountPath:  "/run/cleanroom/cache-output-volumes/cacheout0",
+			DirMappings: []vsockexec.CacheOutputDirMount{
+				{GuestPath: "/workspace/node_modules", Subpath: "dirs/0"},
+			},
+		},
+	}
+	var gotMounts []vsockexec.CacheOutputMount
 	adapter := &Adapter{
 		runGuestCommandFn: func(_ context.Context, _ context.Context, _ <-chan struct{}, _ func() error, _ string, _ uint32, req vsockexec.ExecRequest, _ backend.OutputStream) (vsockexec.ExecResponse, guestExecTiming, error) {
 			if len(req.Command) != 1 || req.Command[0] != "sync" {
 				t.Fatalf("unexpected command: %v", req.Command)
 			}
+			gotMounts = cloneCacheOutputMounts(req.CacheOutputMounts)
 			return vsockexec.ExecResponse{ExitCode: 0}, guestExecTiming{}, nil
 		},
 		sandboxes: map[string]*sandboxInstance{
 			"cr-test": {
-				SandboxID:    "cr-test",
-				VsockPath:    "/tmp/fake.sock",
-				GuestPort:    10700,
-				fcCmd:        &exec.Cmd{Process: &os.Process{Pid: 42}},
-				exitedCh:     make(chan struct{}),
-				vmRootFSPath: rootfsPath,
+				SandboxID:         "cr-test",
+				VsockPath:         "/tmp/fake.sock",
+				GuestPort:         10700,
+				fcCmd:             &exec.Cmd{Process: &os.Process{Pid: 42}},
+				exitedCh:          make(chan struct{}),
+				vmRootFSPath:      rootfsPath,
+				cacheOutputMounts: cloneCacheOutputMounts(wantMounts),
 			},
 		},
 	}
@@ -141,6 +153,9 @@ func TestCreateSnapshotSyncsPausesAndClonesRootFS(t *testing.T) {
 	}
 	if got, want := string(data), "snapshot-bytes"; got != want {
 		t.Fatalf("unexpected snapshot contents: got %q want %q", got, want)
+	}
+	if !reflect.DeepEqual(gotMounts, wantMounts) {
+		t.Fatalf("unexpected sync cache output mounts: got %#v want %#v", gotMounts, wantMounts)
 	}
 	if len(signals) != 2 || signals[0] != syscall.SIGSTOP || signals[1] != syscall.SIGCONT {
 		t.Fatalf("unexpected signals: %v", signals)


### PR DESCRIPTION
## Problem

Manual smoke testing the merged dependency-volume cache flow against the installed daemon exposed a regression: cache-output volumes are mounted on the first guest command, including the workspace-stage repository bootstrap. When an output is declared inside the checkout, such as `node_modules`, the guest agent creates the output mount path before `git clone` runs. The clone then fails because the repository destination is no longer empty.

That breaks the intended invisible-cache model for normal workspace outputs.

## Fix

Skip cache-output mount setup for workspace-stage commands in both `darwin-vz` and `firecracker`, and make an empty guest-agent mount plan clear any cache-output mounts that were previously established. That protects both the initial repository checkout and later workspace-stage refreshes after dependency or execution commands have already mounted outputs.

Cache-output volumes are still attached to the VM, and the mount plan is still sent for dependency, services, execution, file-transfer, and snapshot sync commands. Package-manager outputs such as `node_modules` are therefore mounted before dependency/service commands run, remain visible to normal sandbox file operations, and are flushed before output-volume snapshots.

## Manual testing

Using a foreground patched server on a separate Unix socket, with a smoke policy equivalent to:

```yaml
repository:
  path: /__cleanroom_smoke
sandbox:
  dependencies:
    - name: node-modules
      command: |
        mkdir -p node_modules
        printf 'dep=%s\n' "$(cat lock.txt)" > node_modules/marker.txt
      inputs:
        files: [lock.txt]
      outputs:
        dirs: [node_modules]
```

Verified:

- installed latest failed before the fix with `repository destination already exists and is not empty`.
- first patched run created the checkout and wrote `node_modules/marker.txt` inside the repo path.
- second patched run restored the dependency block output; Tempo trace `8a81b468ab476a756ac48db609f75320` showed `cleanroom.sandbox.lookup_dependency_block_volume_caches` with `cleanroom.cache.result=hit`, `hit_count=1`, `miss_count=0`.
- a source-only commit missed the block cache and republished under the new source identity.
- changing `lock.txt` missed and produced `dep=v2`.
- an undeclared write emitted the expected warning, skipped block-volume publication, reran exact fallback, and repeated the miss on the next run.

## Tests

- `mise exec -- go test ./cmd/cleanroom-guest-agent ./internal/backend/firecracker ./internal/backend/darwinvz`
- `mise exec -- go test ./internal/backend/firecracker ./internal/backend/darwinvz`
- `mise exec -- go test ./internal/controlservice`
- `mise run test`
