### PR TITLE
fix: Seed existing output directories

### DIFF
--- a/cmd/cleanroom-guest-agent/cache_output_mounts.go
+++ b/cmd/cleanroom-guest-agent/cache_output_mounts.go
@@ -23,6 +23,7 @@ const (
 	cacheOutputActionMkdir       cacheOutputMountActionKind = "mkdir"
 	cacheOutputActionMount       cacheOutputMountActionKind = "mount"
 	cacheOutputActionBind        cacheOutputMountActionKind = "bind"
+	cacheOutputActionSeedDir     cacheOutputMountActionKind = "seed-dir"
 	cacheOutputActionRestoreFile cacheOutputMountActionKind = "restore-file"
 )
 
@@ -145,7 +146,14 @@ func cacheOutputMountActions(mounts []vsockexec.CacheOutputMount) ([]cacheOutput
 			}
 			actions = append(actions,
 				cacheOutputMountAction{Kind: cacheOutputActionMkdir, Source: sourcePath, VolumeRoot: mountPath, VolumeSubpath: cleanSubpath, Mode: 0o755, RequireExisting: mount.SourcePresent},
-				cacheOutputMountAction{Kind: cacheOutputActionMkdir, Target: guestPath, Mode: 0o755, RequireEmpty: true},
+				cacheOutputMountAction{Kind: cacheOutputActionMkdir, Target: guestPath, Mode: 0o755},
+			)
+			if !mount.SourcePresent {
+				actions = append(actions,
+					cacheOutputMountAction{Kind: cacheOutputActionSeedDir, Source: guestPath, Target: sourcePath, VolumeRoot: mountPath, VolumeSubpath: cleanSubpath},
+				)
+			}
+			actions = append(actions,
 				cacheOutputMountAction{Kind: cacheOutputActionBind, Source: sourcePath, Target: guestPath, VolumeRoot: mountPath, VolumeSubpath: cleanSubpath, Flags: unix.MS_BIND},
 			)
 		}
@@ -238,6 +246,10 @@ func executeCacheOutputMountAction(action cacheOutputMountAction) (bool, error) 
 			return false, nil
 		}
 		return true, nil
+	case cacheOutputActionSeedDir:
+		if err := seedCacheOutputDir(action.Source, action.Target); err != nil {
+			return false, err
+		}
 	case cacheOutputActionRestoreFile:
 		if action.VolumeRoot != "" {
 			source, sourcePath, err := openCacheOutputVolumeFile(action.VolumeRoot, action.VolumeSubpath, action.Required)
@@ -437,6 +449,107 @@ func isEmptyCacheOutputDir(path string) (bool, error) {
 		return false, fmt.Errorf("read cache output directory %s: %w", path, err)
 	}
 	return len(entries) == 0, nil
+}
+
+func removeCacheOutputDirContents(path string) error {
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return fmt.Errorf("read cache output directory %s: %w", path, err)
+	}
+	var errs []error
+	for _, entry := range entries {
+		entryPath := filepath.Join(path, entry.Name())
+		if err := os.RemoveAll(entryPath); err != nil {
+			errs = append(errs, fmt.Errorf("remove cache output path %s: %w", entryPath, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func seedCacheOutputDir(sourceRoot, targetRoot string) error {
+	sourceRoot, err := cleanAbsoluteCacheOutputPath("seed source", sourceRoot)
+	if err != nil {
+		return err
+	}
+	targetRoot, err = cleanAbsoluteCacheOutputPath("seed target", targetRoot)
+	if err != nil {
+		return err
+	}
+	if err := requireCacheOutputDirNoSymlink(targetRoot); err != nil {
+		return err
+	}
+	empty, err := isEmptyCacheOutputDir(targetRoot)
+	if err != nil {
+		return err
+	}
+	if !empty {
+		return nil
+	}
+
+	sourceInfo, err := os.Lstat(sourceRoot)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("stat cache output seed source %s: %w", sourceRoot, err)
+	}
+	if sourceInfo.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("cache output seed source %s is a symlink", sourceRoot)
+	}
+	if !sourceInfo.IsDir() {
+		return fmt.Errorf("cache output seed source %s is not a directory", sourceRoot)
+	}
+
+	err = filepath.WalkDir(sourceRoot, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return fmt.Errorf("walk cache output seed source %s: %w", path, err)
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return fmt.Errorf("stat cache output seed source %s: %w", path, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("cache output seed source %s is a symlink", path)
+		}
+
+		rel, err := filepath.Rel(sourceRoot, path)
+		if err != nil {
+			return fmt.Errorf("resolve cache output seed path %s: %w", path, err)
+		}
+		if rel == "." {
+			return nil
+		}
+		targetPath := filepath.Join(targetRoot, rel)
+		if info.IsDir() {
+			if err := os.Mkdir(targetPath, info.Mode().Perm()); err != nil && !errors.Is(err, os.ErrExist) {
+				return fmt.Errorf("create cache output seed directory %s: %w", targetPath, err)
+			}
+			return nil
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("cache output seed source %s is not a regular file or directory", path)
+		}
+		source, err := openCacheOutputCaptureSource(path)
+		if err != nil {
+			return err
+		}
+		copyErr := copyCacheOutputFile(source, path, targetPath, info.Mode().Perm())
+		closeErr := source.Close()
+		if copyErr != nil {
+			return copyErr
+		}
+		if closeErr != nil {
+			return fmt.Errorf("close cache output seed source %s: %w", path, closeErr)
+		}
+		return nil
+	})
+	if err != nil {
+		if cleanupErr := removeCacheOutputDirContents(targetRoot); cleanupErr != nil {
+			return fmt.Errorf("%w; cleanup cache output seed target %s: %v", err, targetRoot, cleanupErr)
+		}
+		return err
+	}
+	return nil
 }
 
 func restoreCacheOutputFile(sourcePath, targetPath string, mode fs.FileMode, required bool) error {

--- a/cmd/cleanroom-guest-agent/cache_output_mounts.go
+++ b/cmd/cleanroom-guest-agent/cache_output_mounts.go
@@ -38,7 +38,6 @@ type cacheOutputMountAction struct {
 	Data            string
 	Mode            fs.FileMode
 	RequireExisting bool
-	RequireEmpty    bool
 	Required        bool
 }
 
@@ -223,7 +222,7 @@ func executeCacheOutputMountAction(action cacheOutputMountAction) (bool, error) 
 			_, err := ensureCacheOutputVolumeDir(action.VolumeRoot, action.VolumeSubpath, action.Mode, action.RequireExisting)
 			return false, err
 		}
-		return false, ensureCacheOutputDir(action.Target, action.Mode, action.RequireExisting, action.RequireEmpty)
+		return false, ensureCacheOutputDir(action.Target, action.Mode, action.RequireExisting)
 	case cacheOutputActionMount:
 		if err := unix.Mount(action.Source, action.Target, action.FSType, action.Flags, action.Data); err != nil && err != unix.EBUSY {
 			return false, fmt.Errorf("mount cache output volume %s at %s: %w", action.Source, action.Target, err)
@@ -250,6 +249,7 @@ func executeCacheOutputMountAction(action cacheOutputMountAction) (bool, error) 
 		if err := seedCacheOutputDir(action.Source, action.Target); err != nil {
 			return false, err
 		}
+		return false, nil
 	case cacheOutputActionRestoreFile:
 		if action.VolumeRoot != "" {
 			source, sourcePath, err := openCacheOutputVolumeFile(action.VolumeRoot, action.VolumeSubpath, action.Required)
@@ -408,7 +408,7 @@ func requireCacheOutputDirNoSymlink(path string) error {
 	return nil
 }
 
-func ensureCacheOutputDir(path string, mode fs.FileMode, requireExisting, requireEmpty bool) error {
+func ensureCacheOutputDir(path string, mode fs.FileMode, requireExisting bool) error {
 	if mode == 0 {
 		mode = 0o755
 	}
@@ -419,15 +419,6 @@ func ensureCacheOutputDir(path string, mode fs.FileMode, requireExisting, requir
 		}
 		if !info.IsDir() {
 			return fmt.Errorf("cache output path %s is not a directory", path)
-		}
-		if requireEmpty {
-			empty, err := isEmptyCacheOutputDir(path)
-			if err != nil {
-				return err
-			}
-			if !empty {
-				return fmt.Errorf("cache output directory %s is not empty", path)
-			}
 		}
 		return nil
 	}
@@ -504,12 +495,12 @@ func seedCacheOutputDir(sourceRoot, targetRoot string) error {
 		if err != nil {
 			return fmt.Errorf("walk cache output seed source %s: %w", path, err)
 		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("cache output seed source %s is a symlink", path)
+		}
 		info, err := entry.Info()
 		if err != nil {
 			return fmt.Errorf("stat cache output seed source %s: %w", path, err)
-		}
-		if info.Mode()&os.ModeSymlink != 0 {
-			return fmt.Errorf("cache output seed source %s is a symlink", path)
 		}
 
 		rel, err := filepath.Rel(sourceRoot, path)
@@ -581,7 +572,7 @@ func restoreCacheOutputFileFrom(source *os.File, sourcePath, targetPath string, 
 	}
 
 	targetDir := filepath.Dir(targetPath)
-	if err := ensureCacheOutputDir(targetDir, 0o755, true, false); err != nil {
+	if err := ensureCacheOutputDir(targetDir, 0o755, true); err != nil {
 		return err
 	}
 	if targetInfo, err := os.Lstat(targetPath); err == nil {
@@ -739,7 +730,7 @@ func copyCacheOutputFileWithParentMode(source *os.File, sourcePath, targetPath s
 	}
 
 	targetDir := filepath.Dir(targetPath)
-	if err := ensureCacheOutputDir(targetDir, 0o755, requireParent, false); err != nil {
+	if err := ensureCacheOutputDir(targetDir, 0o755, requireParent); err != nil {
 		return err
 	}
 	tmp, err := os.CreateTemp(targetDir, "."+filepath.Base(targetPath)+".cleanroom-cache-capture-*")

--- a/cmd/cleanroom-guest-agent/cache_output_mounts_test.go
+++ b/cmd/cleanroom-guest-agent/cache_output_mounts_test.go
@@ -100,23 +100,6 @@ func TestCacheOutputMountActionsLeavesUnspecifiedFileModeUnset(t *testing.T) {
 	}
 }
 
-func TestEnsureCacheOutputDirRejectsNonEmptyMountpoint(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "existing"), []byte("image content"), 0o644); err != nil {
-		t.Fatalf("write existing file: %v", err)
-	}
-
-	err := ensureCacheOutputDir(dir, 0o755, false, true)
-	if err == nil {
-		t.Fatal("expected non-empty directory to fail")
-	}
-	if !strings.Contains(err.Error(), "not empty") {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
 func TestSeedCacheOutputDirCopiesExistingOutputDirectory(t *testing.T) {
 	t.Parallel()
 
@@ -241,7 +224,7 @@ func TestSeedCacheOutputDirRejectsSymlinkInsideSource(t *testing.T) {
 func TestEnsureCacheOutputDirRequiresExistingHitSource(t *testing.T) {
 	t.Parallel()
 
-	err := ensureCacheOutputDir(filepath.Join(t.TempDir(), "missing"), 0o755, true, false)
+	err := ensureCacheOutputDir(filepath.Join(t.TempDir(), "missing"), 0o755, true)
 	if err == nil {
 		t.Fatal("expected missing hit source directory to fail")
 	}

--- a/cmd/cleanroom-guest-agent/cache_output_mounts_test.go
+++ b/cmd/cleanroom-guest-agent/cache_output_mounts_test.go
@@ -37,10 +37,39 @@ func TestCacheOutputMountActionsMapsDirsAndRestoresFiles(t *testing.T) {
 		{Kind: cacheOutputActionMkdir, Target: "/run/cleanroom/cache-output-volumes/cacheout0", Mode: 0o755},
 		{Kind: cacheOutputActionMount, Source: "/dev/vdb", Target: "/run/cleanroom/cache-output-volumes/cacheout0", FSType: "ext4"},
 		{Kind: cacheOutputActionMkdir, Source: "/run/cleanroom/cache-output-volumes/cacheout0/dirs/0", VolumeRoot: "/run/cleanroom/cache-output-volumes/cacheout0", VolumeSubpath: "dirs/0", Mode: 0o755, RequireExisting: true},
-		{Kind: cacheOutputActionMkdir, Target: "/root/.local/share/mise", Mode: 0o755, RequireEmpty: true},
+		{Kind: cacheOutputActionMkdir, Target: "/root/.local/share/mise", Mode: 0o755},
 		{Kind: cacheOutputActionBind, Source: "/run/cleanroom/cache-output-volumes/cacheout0/dirs/0", Target: "/root/.local/share/mise", VolumeRoot: "/run/cleanroom/cache-output-volumes/cacheout0", VolumeSubpath: "dirs/0", Flags: unix.MS_BIND},
 		{Kind: cacheOutputActionMkdir, Target: "/root/.config/mise", Mode: 0o755},
 		{Kind: cacheOutputActionRestoreFile, Source: "/run/cleanroom/cache-output-volumes/cacheout0/files/0", Target: "/root/.config/mise/config.toml", VolumeRoot: "/run/cleanroom/cache-output-volumes/cacheout0", VolumeSubpath: "files/0", Mode: 0o600, Required: true},
+	}
+	if !reflect.DeepEqual(actions, want) {
+		t.Fatalf("unexpected actions:\n got %#v\nwant %#v", actions, want)
+	}
+}
+
+func TestCacheOutputMountActionsSeedsDirMappingsOnMiss(t *testing.T) {
+	t.Parallel()
+
+	actions, err := cacheOutputMountActions([]vsockexec.CacheOutputMount{
+		{
+			DevicePath: "/dev/vdb",
+			MountPath:  "/run/cleanroom/cache-output-volumes/cacheout0",
+			DirMappings: []vsockexec.CacheOutputDirMount{
+				{GuestPath: "/workspace/public/assets", Subpath: "dirs/0"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("cacheOutputMountActions returned error: %v", err)
+	}
+
+	want := []cacheOutputMountAction{
+		{Kind: cacheOutputActionMkdir, Target: "/run/cleanroom/cache-output-volumes/cacheout0", Mode: 0o755},
+		{Kind: cacheOutputActionMount, Source: "/dev/vdb", Target: "/run/cleanroom/cache-output-volumes/cacheout0", FSType: "ext4"},
+		{Kind: cacheOutputActionMkdir, Source: "/run/cleanroom/cache-output-volumes/cacheout0/dirs/0", VolumeRoot: "/run/cleanroom/cache-output-volumes/cacheout0", VolumeSubpath: "dirs/0", Mode: 0o755},
+		{Kind: cacheOutputActionMkdir, Target: "/workspace/public/assets", Mode: 0o755},
+		{Kind: cacheOutputActionSeedDir, Source: "/workspace/public/assets", Target: "/run/cleanroom/cache-output-volumes/cacheout0/dirs/0", VolumeRoot: "/run/cleanroom/cache-output-volumes/cacheout0", VolumeSubpath: "dirs/0"},
+		{Kind: cacheOutputActionBind, Source: "/run/cleanroom/cache-output-volumes/cacheout0/dirs/0", Target: "/workspace/public/assets", VolumeRoot: "/run/cleanroom/cache-output-volumes/cacheout0", VolumeSubpath: "dirs/0", Flags: unix.MS_BIND},
 	}
 	if !reflect.DeepEqual(actions, want) {
 		t.Fatalf("unexpected actions:\n got %#v\nwant %#v", actions, want)
@@ -85,6 +114,127 @@ func TestEnsureCacheOutputDirRejectsNonEmptyMountpoint(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "not empty") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSeedCacheOutputDirCopiesExistingOutputDirectory(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	sourceRoot := filepath.Join(root, "workspace", "public", "assets")
+	targetRoot := filepath.Join(root, "volume", "dirs", "0")
+	if err := os.MkdirAll(filepath.Join(sourceRoot, "images"), 0o755); err != nil {
+		t.Fatalf("create source dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceRoot, ".keep"), []byte(""), 0o644); err != nil {
+		t.Fatalf("write .keep: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceRoot, "images", "logo.txt"), []byte("logo"), 0o640); err != nil {
+		t.Fatalf("write logo: %v", err)
+	}
+	if err := os.MkdirAll(targetRoot, 0o755); err != nil {
+		t.Fatalf("create target dir: %v", err)
+	}
+
+	if err := seedCacheOutputDir(sourceRoot, targetRoot); err != nil {
+		t.Fatalf("seedCacheOutputDir returned error: %v", err)
+	}
+	if data, err := os.ReadFile(filepath.Join(targetRoot, ".keep")); err != nil {
+		t.Fatalf("read seeded .keep: %v", err)
+	} else if got, want := string(data), ""; got != want {
+		t.Fatalf("unexpected .keep content: got %q want %q", got, want)
+	}
+	if data, err := os.ReadFile(filepath.Join(targetRoot, "images", "logo.txt")); err != nil {
+		t.Fatalf("read seeded logo: %v", err)
+	} else if got, want := string(data), "logo"; got != want {
+		t.Fatalf("unexpected logo content: got %q want %q", got, want)
+	}
+	if info, err := os.Stat(filepath.Join(targetRoot, "images", "logo.txt")); err != nil {
+		t.Fatalf("stat seeded logo: %v", err)
+	} else if got, want := info.Mode().Perm(), os.FileMode(0o640); got != want {
+		t.Fatalf("unexpected seeded logo mode: got %v want %v", got, want)
+	}
+}
+
+func TestSeedCacheOutputDirSkipsMissingSource(t *testing.T) {
+	t.Parallel()
+
+	targetRoot := filepath.Join(t.TempDir(), "volume", "dirs", "0")
+	if err := os.MkdirAll(targetRoot, 0o755); err != nil {
+		t.Fatalf("create target dir: %v", err)
+	}
+	if err := seedCacheOutputDir(filepath.Join(t.TempDir(), "missing"), targetRoot); err != nil {
+		t.Fatalf("seedCacheOutputDir returned error: %v", err)
+	}
+	if entries, err := os.ReadDir(targetRoot); err != nil {
+		t.Fatalf("read target dir: %v", err)
+	} else if len(entries) != 0 {
+		t.Fatalf("expected empty target after missing seed source, got %d entries", len(entries))
+	}
+}
+
+func TestSeedCacheOutputDirSkipsNonEmptyTarget(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	sourceRoot := filepath.Join(root, "workspace", "public", "assets")
+	targetRoot := filepath.Join(root, "volume", "dirs", "0")
+	if err := os.MkdirAll(sourceRoot, 0o755); err != nil {
+		t.Fatalf("create source dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceRoot, ".keep"), []byte("seed"), 0o644); err != nil {
+		t.Fatalf("write source seed: %v", err)
+	}
+	if err := os.MkdirAll(targetRoot, 0o755); err != nil {
+		t.Fatalf("create target dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(targetRoot, "existing"), []byte("cached"), 0o644); err != nil {
+		t.Fatalf("write existing target: %v", err)
+	}
+
+	if err := seedCacheOutputDir(sourceRoot, targetRoot); err != nil {
+		t.Fatalf("seedCacheOutputDir returned error: %v", err)
+	}
+	if data, err := os.ReadFile(filepath.Join(targetRoot, "existing")); err != nil {
+		t.Fatalf("read existing target: %v", err)
+	} else if got, want := string(data), "cached"; got != want {
+		t.Fatalf("unexpected existing target content: got %q want %q", got, want)
+	}
+	if _, err := os.Stat(filepath.Join(targetRoot, ".keep")); !os.IsNotExist(err) {
+		t.Fatalf("expected source seed not to be merged into non-empty target, got err=%v", err)
+	}
+}
+
+func TestSeedCacheOutputDirRejectsSymlinkInsideSource(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	sourceRoot := filepath.Join(root, "workspace", "public", "assets")
+	targetRoot := filepath.Join(root, "volume", "dirs", "0")
+	if err := os.MkdirAll(sourceRoot, 0o755); err != nil {
+		t.Fatalf("create source dir: %v", err)
+	}
+	if err := os.MkdirAll(targetRoot, 0o755); err != nil {
+		t.Fatalf("create target dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceRoot, "copied-before-error"), []byte("partial"), 0o644); err != nil {
+		t.Fatalf("write partial source: %v", err)
+	}
+	if err := os.Symlink("/etc/passwd", filepath.Join(sourceRoot, "passwd")); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+
+	err := seedCacheOutputDir(sourceRoot, targetRoot)
+	if err == nil {
+		t.Fatal("expected symlink seed source to fail")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if entries, readErr := os.ReadDir(targetRoot); readErr != nil {
+		t.Fatalf("read target dir: %v", readErr)
+	} else if len(entries) != 0 {
+		t.Fatalf("expected failed seed cleanup to leave target empty, got %d entries", len(entries))
 	}
 }
 

--- a/docs/plans/dependency-service-volume-caches.md
+++ b/docs/plans/dependency-service-volume-caches.md
@@ -188,6 +188,44 @@ detail. A repository at `/workspace` with `outputs.dirs: [node_modules]` and a
 repository at `/src` with the same relative declaration produce different
 normalized guest output paths, output records, and cache identities.
 
+### Output Directory Seeds
+
+Declared output directories may already exist in the checkout. This supports
+normal repository conventions such as keeping `public/assets/.keep` in Git while
+declaring `public/assets` as a generated output.
+
+```yaml
+sandbox:
+  dependencies:
+    - name: frontend-assets
+      command: npm run build
+      inputs:
+        files:
+          - package.json
+          - package-lock.json
+      outputs:
+        dirs:
+          - public/assets
+```
+
+On a block-volume miss, Cleanroom copies the existing output directory contents
+from the checkout into the empty managed output volume before mounting that
+volume at the output path. The block then sees the same seed files it would have
+seen without caching, and any writes land in the managed output volume.
+
+On a hit, Cleanroom treats the cached output volume as authoritative and mounts
+it over the checkout path without merging the current checkout contents into the
+volume. Seed files do not need to be listed separately in `inputs.files` just so
+they can be copied into the output volume. The cache key already includes
+repository source identity and changeset identity, so changing a checked-in seed
+file produces a different block cache identity rather than mutating an existing
+hit.
+
+Seeding is conservative: the declared output path must be a directory when it
+exists, and seed contents must be regular files or directories. Symlinks,
+devices, sockets, and other special files fail instead of being copied into the
+managed output volume.
+
 ### Volatile Writes
 
 `volatile.paths` are explicit unpersisted write allowances. They are for logs,
@@ -260,21 +298,24 @@ until the input manifest format explicitly supports them.
 On a portable block miss, Cleanroom:
 
 1. Starts from the normal sandbox rootfs and normal repository checkout.
-2. Creates a per-block overlay root with the current rootfs as lowerdir.
-3. Mounts scratch paths such as `/tmp`, `/var/tmp`, and `/run` as scratch or
+2. Seeds any pre-existing declared output directories into their empty managed
+   output volumes.
+3. Mounts managed output volumes at declared `outputs.dirs` paths and prepares
+   declared `outputs.files` for post-command capture.
+4. Creates a per-block overlay root with the current rootfs as lowerdir.
+5. Mounts scratch paths such as `/tmp`, `/var/tmp`, and `/run` as scratch or
    filters them from the escaped-write report.
-4. Runs the command inside the overlay view with the normal block working
+6. Runs the command inside the overlay view with the normal block working
    directory, usually `/workspace`.
-5. Scans the overlay upperdir.
-6. Treats declared output writes, volatile writes, and scratch writes as allowed.
-7. Treats every other persistent write as an escaped write.
-8. Copies declared `outputs.dirs` and `outputs.files` from the merged overlay
-   view into a temporary managed output store only after publishability checks
-   pass.
-9. Publishes a portable cache entry only after output metadata is durably
-   persisted.
-10. Materializes the declared outputs back into the real sandbox root for later
-    blocks, services, and user commands.
+7. Scans the overlay upperdir.
+8. Treats declared output writes, volatile writes, and scratch writes as allowed.
+9. Treats every other persistent write as an escaped write.
+10. Captures declared file outputs into their managed output volume only after
+    the command succeeds.
+11. Publishes a portable cache entry only after output metadata is durably
+    persisted.
+12. Leaves declared output volumes mounted for later blocks, services, and user
+    commands.
 
 If escaped writes are found, Cleanroom skips portable publication, discards the
 overlay result, and reruns the block against the real rootfs through the exact
@@ -290,25 +331,17 @@ recorded so leaked storage is not silent.
 ### Cache Hit
 
 On a portable block hit, Cleanroom prepares the repository checkout normally,
-then restores declared outputs at their normalized guest paths before skipping
-the command.
+then mounts declared output volumes at their normalized guest paths before
+skipping the command.
 
 Directory outputs are restored as whole directory trees. File outputs are
 restored as regular files without hiding sibling files in their parent
 directory.
 
-### Baseline Output Collisions
-
-The first implementation should only publish and restore portable directory
-outputs when the output path is absent or an empty directory in the baseline
-checkout. It should only publish and restore portable file outputs when the file
-path is absent in the baseline checkout.
-
-If the committed tree already contains a non-empty output directory or an output
-file at the declared path, Cleanroom should skip portable volume publication for
-that block and use exact full-rootfs caching. Later work can support baseline
-merges by including the baseline output digest in the key, but that is not part
-of the reset slice.
+Directory output hits may mount over existing checkout directories. Cleanroom
+does not merge those checkout contents into the cached volume on hit; the
+cached volume is already tied to the repository and changeset identity that
+created it.
 
 ## Determinism Model
 
@@ -595,14 +628,16 @@ Minimum coverage:
 - declared file outputs are promoted and restored without hiding sibling files
 - escaped persistent writes skip portable publication and trigger exact fallback
 - volatile writes do not skip portable publication and are not restored on hit
-- baseline output collisions skip portable publication
+- pre-existing declared output directories are seeded into empty output volumes
+  on miss and treated as cache-owned volumes on hit
 - temporary output stores are destroyed on command failure, escaped writes,
   undeclared reads, metadata failure, cancellation, and exact fallback
 - cache hits restore output dirs and files before later dependency, service, and
   execution phases
 - source-only commits reuse dependency and service outputs without rerunning
   block commands
-- direct mount optimization is used only for absent or empty output dirs
+- direct mount optimization seeds pre-existing output directories before
+  mounting on miss
 - read audit, when available, rejects undeclared workspace reads
 
 ## Key Learnings From Pressure-Testing
@@ -614,8 +649,8 @@ Minimum coverage:
   commands run normally while still separating declared outputs from escaped
   writes.
 - Direct output-volume mounts are valuable for performance, but only as an
-  optimization. Mounting too early can hide committed files and change command
-  behavior.
+  optimization. Mounting too early or mounting without seeding can hide
+  committed files and change command behavior.
 - Volatile paths are necessary for harmless write noise, but they must stay
   explicit and narrow so they do not become a generic ignore escape hatch.
 - Declared inputs are a correctness contract until read auditing exists. Read
@@ -645,7 +680,6 @@ Minimum coverage:
 
 ## Deferred Work
 
-- Baseline merge support for output paths that already contain committed files.
 - Optional inputs and optional outputs.
 - Per-path output volumes for partial reuse.
 - Explicit service `depends_on`.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -193,6 +193,13 @@ explicit request-time changeset input.
   characters. `${HOME}`, `$HOME`, and `~` expand to the Cleanroom block
   execution home, while `${WORKSPACE}` and `$WORKSPACE` expand to the normalized
   repository path.
+- Directory outputs may already exist in the repository, such as
+  `public/assets/.keep`. On a cache miss, Cleanroom seeds the empty output
+  volume from that directory before the block runs. On a cache hit, the cached
+  output volume is authoritative and is mounted over the checkout directory.
+  Seed files do not need to be listed separately in `inputs.files` just to be
+  copied into the output volume; seed changes are covered by the repository and
+  changeset identity used in the block cache key.
 - Block `env` values are literal strings, except leading home-directory
   and workspace shorthand forms (`~`, `~/`, `$HOME`, `$HOME/`, `${HOME}`,
   `${HOME}/`, `$WORKSPACE`, `$WORKSPACE/`, `${WORKSPACE}`, `${WORKSPACE}/`)


### PR DESCRIPTION
## Problem

Some repositories keep placeholder files inside generated output directories. The concrete case Grant hit is `public/assets/.keep` in Git while `public/assets` is declared as a cache output.

Before this change, the guest agent required directory output mountpoints to be empty before bind-mounting the managed output volume. That protected against accidentally hiding checkout content, but it also made normal placeholder-file patterns fail with `cache output directory ... is not empty`.

## Fix

Treat existing output directory contents as an output seed instead of an error:

- on a block-volume miss, copy the existing checkout directory contents into the empty managed output volume before mounting it
- on a hit, treat the cached output volume as authoritative and mount it over the checkout path without merging current checkout contents
- skip re-seeding when a miss volume is already non-empty, which lets the same sandbox remount an output volume after a workspace-stage unmount
- reject symlinks and special files while seeding, and clean up partial seed copies if validation fails

This keeps the cache mostly invisible for policies like:

```yaml
sandbox:
  dependencies:
    - name: frontend-assets
      command: npm run build
      inputs:
        files:
          - package.json
          - package-lock.json
      outputs:
        dirs:
          - public/assets
```

With a checked-in `public/assets/.keep`, the miss path seeds `.keep` into the volume and the build writes assets into the same managed output directory. Later hits restore the cached volume for that repository/changeset identity.

## Docs

Updated `docs/spec.md` and `docs/plans/dependency-service-volume-caches.md` to document output directory seeds, hit/miss behavior, and the conservative symlink/special-file policy.

## Tests

- `mise exec -- go test -count=1 ./cmd/cleanroom-guest-agent`
- `mise exec -- go test -count=1 ./cmd/cleanroom-guest-agent ./internal/backend/firecracker ./internal/backend/darwinvz ./internal/controlservice`
- `mise run test`
