### PR TITLE
fix: Reject cache blocks without repository bootstrap

### DIFF
--- a/examples/rails/cleanroom.yaml
+++ b/examples/rails/cleanroom.yaml
@@ -1,6 +1,4 @@
 version: 1
-repository:
-  enabled: false
 sandbox:
   image:
     ref: ghcr.io/buildkite/cleanroom-base/debian-ruby@sha256:cba9876d67beb8971e791f1bc6af175f0bff47e938f955059813c4dd6914eb53

--- a/internal/controlservice/repository_helpers.go
+++ b/internal/controlservice/repository_helpers.go
@@ -83,3 +83,16 @@ func validateRepositoryCheckoutForPolicy(compiled *policy.CompiledPolicy, reposi
 	}
 	return nil
 }
+
+func validateRepositoryScopedCreatePolicy(compiled *policy.CompiledPolicy, repository *repositorycheckout.Checkout) error {
+	if compiled == nil || repository != nil {
+		return nil
+	}
+	if len(compiled.Dependencies.Blocks) > 0 {
+		return errors.New("sandbox.dependencies blocks require repository checkout")
+	}
+	if len(compiled.Services.Blocks) > 0 {
+		return errors.New("sandbox.services blocks require repository checkout")
+	}
+	return nil
+}

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -360,13 +360,16 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 	if err != nil {
 		return nil, fmt.Errorf("invalid policy: %w", err)
 	}
+	repository := repositorycheckout.FromProto(req.GetRepositoryCheckout())
+	if err := validateRepositoryScopedCreatePolicy(compiled, repository); err != nil {
+		return nil, err
+	}
 
 	span.SetAttributes(attribute.String(observability.AttrBackend, backendName))
 	adapter, ok := s.Backends[backendName]
 	if !ok {
 		return nil, fmt.Errorf("unknown backend %q", backendName)
 	}
-	repository := repositorycheckout.FromProto(req.GetRepositoryCheckout())
 	if repository != nil {
 		if commitSHA := strings.TrimSpace(repository.CommitSHA); commitSHA != "" {
 			span.SetAttributes(attribute.String(observability.AttrRepositoryCommitSHA, commitSHA))

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -262,19 +262,19 @@ type stubLoader struct {
 }
 
 type stubRepositoryMirrorStore struct {
-	remoteURL                  string
-	commitSHA                  string
-	commitSHAs                 []string
-	withRepositorySHAs         []string
-	calls                      int
-	err                        error
-	ensureContainsFn           func(remoteURL, commitSHA string) error
-	mirrorPath                 string
-	mirrorPathCalls            int
-	mirrorPathErr              error
-	ensureMirrorCalls          int
-	ensureMirrorErr            error
-	ensureSubmoduleMirrorFunc  func(ctx context.Context, submoduleRemoteURL, gitlinkSHA string) (string, error)
+	remoteURL                 string
+	commitSHA                 string
+	commitSHAs                []string
+	withRepositorySHAs        []string
+	calls                     int
+	err                       error
+	ensureContainsFn          func(remoteURL, commitSHA string) error
+	mirrorPath                string
+	mirrorPathCalls           int
+	mirrorPathErr             error
+	ensureMirrorCalls         int
+	ensureMirrorErr           error
+	ensureSubmoduleMirrorFunc func(ctx context.Context, submoduleRemoteURL, gitlinkSHA string) (string, error)
 }
 
 type stubClock struct {
@@ -6360,6 +6360,53 @@ func TestCreateSandboxRejectsMutableRepositoryCommitRef(t *testing.T) {
 	}
 	if got := adapter.provisionCalls; got != 0 {
 		t.Fatalf("expected no provision call on invalid repository commit ref, got %d", got)
+	}
+}
+
+func TestCreateSandboxRejectsDependencyBlocksWithoutRepositoryCheckout(t *testing.T) {
+	adapter := &stubAdapter{}
+	svc := newTestService(adapter)
+
+	_, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Policy: testRepositoryDependencyPolicy(),
+	})
+	if err == nil {
+		t.Fatal("expected dependency blocks to require repository checkout")
+	}
+	if !strings.Contains(err.Error(), "sandbox.dependencies") || !strings.Contains(err.Error(), "repository checkout") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := adapter.provisionCalls; got != 0 {
+		t.Fatalf("expected no provision call without repository checkout, got %d", got)
+	}
+}
+
+func TestCreateSandboxRejectsServiceBlocksWithoutRepositoryCheckout(t *testing.T) {
+	adapter := &stubAdapter{}
+	svc := newTestService(adapter)
+
+	policyProto := testRepositoryPolicy()
+	policyProto.Services = &cleanroomv1.PolicyServices{
+		Blocks: []*cleanroomv1.PolicyBlock{testPolicyBlock(
+			"postgres",
+			[]string{"docker", "compose", "up", "-d", "postgres"},
+			[]string{"docker-compose.yml"},
+			[]string{"/var/lib/cleanroom/services/postgres"},
+			nil,
+		)},
+	}
+
+	_, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Policy: policyProto,
+	})
+	if err == nil {
+		t.Fatal("expected service blocks to require repository checkout")
+	}
+	if !strings.Contains(err.Error(), "sandbox.services") || !strings.Contains(err.Error(), "repository checkout") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := adapter.provisionCalls; got != 0 {
+		t.Fatalf("expected no provision call without repository checkout, got %d", got)
 	}
 }
 

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -383,6 +383,9 @@ func Compile(raw rawPolicy) (*CompiledPolicy, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err := validateRepositoryScopedBlocks(raw, repository); err != nil {
+		return nil, err
+	}
 
 	docker := normalizeDocker(raw.Sandbox.Docker)
 	dependencies, err := normalizeDependencies(raw.Sandbox.Dependencies, repository.Path)
@@ -832,6 +835,23 @@ func normalizeRepositoryConfig(raw *rawRepository) (RepositoryConfig, error) {
 		Path:       repositoryPath,
 		Submodules: raw.Submodules,
 	}, nil
+}
+
+func validateRepositoryScopedBlocks(raw rawPolicy, repository RepositoryConfig) error {
+	if repository.Enabled() {
+		return nil
+	}
+	if len(raw.Sandbox.Dependencies.Blocks) > 0 {
+		field := raw.Sandbox.Dependencies.blocksField
+		if field == "" {
+			field = "sandbox.dependencies"
+		}
+		return fmt.Errorf("%s cannot be declared when repository bootstrap is disabled", field)
+	}
+	if len(raw.Sandbox.Services) > 0 {
+		return errors.New("sandbox.services cannot be declared when repository bootstrap is disabled")
+	}
+	return nil
 }
 
 func readPolicy(path string) (rawPolicy, error) {

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -567,6 +567,42 @@ func TestCompileDefaultsDependenciesDisabled(t *testing.T) {
 	}
 }
 
+func TestCompileRejectsRepositoryDisabledWithDependencyBlocks(t *testing.T) {
+	t.Parallel()
+
+	var raw rawPolicy
+	if err := yaml.Unmarshal([]byte(`
+version: 1
+repository:
+  enabled: false
+sandbox:
+  image:
+    ref: ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+  dependencies:
+    - name: go-modules
+      command: go mod download
+      inputs:
+        files:
+          - go.mod
+          - go.sum
+      outputs:
+        dirs:
+          - ${HOME}/go/pkg/mod
+  network:
+    default: deny
+`), &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	_, err := Compile(raw)
+	if err == nil {
+		t.Fatal("expected compile to reject dependency blocks without repository bootstrap")
+	}
+	if !strings.Contains(err.Error(), "sandbox.dependencies") || !strings.Contains(err.Error(), "repository bootstrap is disabled") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestCompileNormalizesDependencyBootstrapConfig(t *testing.T) {
 	t.Parallel()
 
@@ -770,6 +806,41 @@ func TestCompileNormalizesServicesBootstrapConfig(t *testing.T) {
 	}
 	if got, want := compiled.Services.KeyFiles, []string{"docker-compose.yml"}; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
 		t.Fatalf("unexpected services key files: got %v want %v", got, want)
+	}
+}
+
+func TestCompileRejectsRepositoryDisabledWithServiceBlocks(t *testing.T) {
+	t.Parallel()
+
+	var raw rawPolicy
+	if err := yaml.Unmarshal([]byte(`
+version: 1
+repository:
+  enabled: false
+sandbox:
+  image:
+    ref: ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+  services:
+    - name: postgres
+      command: docker compose up -d postgres
+      inputs:
+        files:
+          - docker-compose.yml
+      outputs:
+        dirs:
+          - /var/lib/cleanroom/services/postgres
+  network:
+    default: deny
+`), &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	_, err := Compile(raw)
+	if err == nil {
+		t.Fatal("expected compile to reject service blocks without repository bootstrap")
+	}
+	if !strings.Contains(err.Error(), "sandbox.services") || !strings.Contains(err.Error(), "repository bootstrap is disabled") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Problem

Policies can currently combine `repository.enabled: false` with dependency or service cache blocks. That validates, but the block-volume planning and bootstrap path is repository-scoped, so those blocks are silently skipped instead of running.

Because block `inputs.files` and `outputs` are interpreted relative to the repository workspace, the policy compiler now rejects dependency or service blocks when repository bootstrap is disabled. The control service also rejects proto `CreateSandbox` requests that contain dependency or service blocks without a `RepositoryCheckout`, covering API callers that bypass YAML policy compilation.

## Examples

- `repository.enabled: false` with `sandbox.dependencies` blocks now fails policy compilation.
- `repository.enabled: false` with `sandbox.services` blocks now fails policy compilation.
- `CreateSandbox` with dependency or service blocks but no `RepositoryCheckout` now fails before provisioning.
- `examples/rails/cleanroom.yaml` no longer disables repository bootstrap in policy; the README's `cleanroom exec --repo-url ... --repo-commit ...` flow still supplies the explicit checkout.

## Validation

- `mise exec -- go test ./internal/policy`
- `mise exec -- go test ./internal/controlservice -run 'TestCreateSandboxRejects(DependencyBlocksWithoutRepositoryCheckout|ServiceBlocksWithoutRepositoryCheckout|RepositoryRemoteOutsidePolicy|RepositoryFileRemote|MutableRepositoryCommitRef)'`
- `mise exec -- go test ./internal/controlservice`
- `mise exec -- go run ./cmd/cleanroom policy validate --chdir examples/rails`
- `mise exec -- go run ./cmd/cleanroom policy validate --chdir examples/buildkite-agent`
- `mise exec -- go run ./cmd/cleanroom policy validate --chdir examples/basic`
- `mise exec -- go run ./cmd/cleanroom policy validate --chdir examples/docker`
- `mise exec -- go test ./...`
