### PR TITLE
fix: Run copy-in refresh without cache mounts

### DIFF
--- a/internal/controlservice/network_stage_test.go
+++ b/internal/controlservice/network_stage_test.go
@@ -2,6 +2,7 @@ package controlservice
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -83,6 +84,93 @@ func TestServicePassesNetworkStagesToBootstrapAndExecution(t *testing.T) {
 		if got[i] != want[i] {
 			t.Fatalf("unexpected network stages: got %v want %v", got, want)
 		}
+	}
+}
+
+func TestInternalWorkspaceCopyInRunsAsWorkspaceStage(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu       sync.Mutex
+		requests []backend.ExecutionRequest
+	)
+	adapter := &stubAdapter{
+		runStreamFn: func(_ context.Context, req backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
+			mu.Lock()
+			requests = append(requests, req)
+			mu.Unlock()
+			return &backend.ExecutionResult{
+				ExecutionID: req.ExecutionID,
+				ExitCode:    0,
+				LaunchedVM:  true,
+				Message:     "ok",
+			}, nil
+		},
+	}
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"public/assets/app.js": "console.log('asset')\n",
+	})
+	svc := newTestService(adapter)
+	svc.RepositoryStore = mirrors
+
+	createResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Policy:             testRepositoryPolicy(),
+		RepositoryCheckout: repositoryCheckout,
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createResp.GetSandbox().GetSandboxId()
+
+	copyResp, err := svc.CreateInternalWorkspaceCopyInExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
+		SandboxId:          sandboxID,
+		Command:            []string{"sh", "-lc", "git -C /workspace clean -ffd"},
+		RepositoryCheckout: repositoryCheckout,
+		Options: &cleanroomv1.ExecutionOptions{
+			SkipRunBefore: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateInternalWorkspaceCopyInExecution returned error: %v", err)
+	}
+	if _, err := svc.WaitExecution(context.Background(), sandboxID, copyResp.GetExecution().GetExecutionId()); err != nil {
+		t.Fatalf("WaitExecution returned error: %v", err)
+	}
+
+	mu.Lock()
+	got := append([]backend.ExecutionRequest(nil), requests...)
+	mu.Unlock()
+	if len(got) < 2 {
+		t.Fatalf("expected repository bootstrap and workspace copy-in execution, got %d request(s)", len(got))
+	}
+	copyInReq := got[len(got)-1]
+	if copyInReq.NetworkStage != policy.NetworkStageWorkspace {
+		t.Fatalf("workspace copy-in should run as workspace stage to clear cache output mounts, got %q", copyInReq.NetworkStage)
+	}
+	if !strings.Contains(strings.Join(copyInReq.Command, "\n"), "git -C /workspace clean -ffd") {
+		t.Fatalf("expected copy-in refresh command, got %#v", copyInReq.Command)
+	}
+
+	diffResp, err := svc.CreateInternalWorkspaceCopyInExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
+		SandboxId: sandboxID,
+		Command:   []string{"sh", "-lc", "git -C /workspace diff --name-only"},
+		Options: &cleanroomv1.ExecutionOptions{
+			SkipRunBefore: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateInternalWorkspaceCopyInExecution for diff returned error: %v", err)
+	}
+	if _, err := svc.WaitExecution(context.Background(), sandboxID, diffResp.GetExecution().GetExecutionId()); err != nil {
+		t.Fatalf("WaitExecution for diff returned error: %v", err)
+	}
+
+	mu.Lock()
+	got = append([]backend.ExecutionRequest(nil), requests...)
+	mu.Unlock()
+	diffReq := got[len(got)-1]
+	if diffReq.NetworkStage != policy.NetworkStageExecution {
+		t.Fatalf("workspace operation without repository refresh should keep execution stage, got %q", diffReq.NetworkStage)
 	}
 }
 

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -209,6 +209,7 @@ type executionOptions struct {
 	LaunchSeconds                               int64
 	PreserveRepositoryChangesetPendingExecution bool
 	SkipRunBefore                               bool
+	WorkspaceCopyIn                             bool
 }
 
 type executionSnapshot struct {
@@ -2114,6 +2115,7 @@ func (s *Service) createExecution(ctx context.Context, req *cleanroomv1.CreateEx
 		}
 		tty = opts.GetTty()
 	}
+	execOpts.WorkspaceCopyIn = internalWorkspaceCopyIn && repository != nil
 	if err := validateInternalExecutionOptions(execOpts, internalWorkspaceCopyIn); err != nil {
 		return nil, err
 	}
@@ -3238,6 +3240,10 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 		})
 	}
 
+	networkStage := policy.NetworkStageExecution
+	if ex.Options.WorkspaceCopyIn {
+		networkStage = policy.NetworkStageWorkspace
+	}
 	executionReq := backend.ExecutionRequest{
 		SandboxID:         sandboxID,
 		ExecutionID:       ex.ID,
@@ -3245,7 +3251,7 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 		Env:               append([]string(nil), ex.Env...),
 		TTY:               ex.TTY,
 		Policy:            sb.Policy,
-		NetworkStage:      policy.NetworkStageExecution,
+		NetworkStage:      networkStage,
 		FirecrackerConfig: firecrackerCfg,
 	}
 	runCtx, span := s.Observability.Tracer("github.com/buildkite/cleanroom/internal/controlservice").Start(


### PR DESCRIPTION
## Problem

Running `--in <kept-sandbox> --copy-in` can refresh repository paths while cache output mounts from the kept sandbox are still active. If an output directory such as `public/assets` is mounted, the copy-in reset/clean path can fail with `Resource busy` instead of replacing the path with the local workspace contents.

The backends already clear cache output mounts for workspace-stage executions. The missing piece was that the internal copy-in execution itself still ran as a normal execution-stage command.

## Examples

- A kept sandbox has a cache output directory mounted at `/workspace/public/assets`.
- A local edit refreshes `public/assets` with `cleanroom exec --in <sandbox> --copy-in -- ...` or `cleanroom workspace copy-in <sandbox>`.
- The repository clean/reset step should clear cache output mounts before touching the checkout path.

## Changes

- Mark internal workspace operations with a repository checkout as workspace copy-in executions so they run with `NetworkStageWorkspace`.
- Leave internal workspace operations without a repository refresh on the execution stage, preserving diff/copy-out behavior.
- Leave ordinary sandbox file-transfer reads and writes untouched so they still see mounted output state.
- Add regression coverage for copy-in stage selection and the non-copy-in internal workspace path.

## Validation

- `mise exec -- go test ./internal/controlservice -run 'TestInternalWorkspaceCopyInRunsAsWorkspaceStage|TestCreateInternalWorkspaceCopyInExecutionCanSkipRunBefore|TestCreateExecutionCanPreservePendingChangesetForInternalWorkspaceCopy|TestServicePassesNetworkStagesToBootstrapAndExecution'`
- `mise exec -- go test ./internal/backend/firecracker ./internal/backend/darwinvz ./internal/backend/cacheoutput`
- `mise exec -- go test ./internal/controlservice ./internal/backend/...`
- `GOOS=linux mise exec -- go test -c -o <tmp> ./cmd/cleanroom-guest-agent`
- Attempted `GOOS=linux mise exec -- go test ./cmd/cleanroom-guest-agent`, but macOS cannot execute the generated Linux test binary: `exec format error`.