### PR TITLE
fix: Preserve Docker socket during volume bootstrap

### DIFF
--- a/cmd/cleanroom-guest-agent/overlay_capture.go
+++ b/cmd/cleanroom-guest-agent/overlay_capture.go
@@ -22,6 +22,13 @@ type overlayCaptureLayout struct {
 	MergedRoot string
 }
 
+type overlayCaptureRuntimeSocket struct {
+	SourcePath string
+	GuestPath  string
+}
+
+type overlayCaptureFileBinder func(source, target string, mounted *[]string) error
+
 var overlayCaptureRoot = "/run/cleanroom/overlay-captures"
 var overlayCaptureVirtualMounts = []string{"/dev", "/proc", "/sys"}
 var overlayCaptureScratchMounts = []struct {
@@ -31,6 +38,9 @@ var overlayCaptureScratchMounts = []struct {
 	{Path: "/tmp", Data: "mode=1777"},
 	{Path: "/var/tmp", Data: "mode=1777"},
 	{Path: "/run", Data: "mode=0755"},
+}
+var overlayCaptureRuntimeSockets = []overlayCaptureRuntimeSocket{
+	{SourcePath: "/run/docker.sock", GuestPath: "/run/docker.sock"},
 }
 
 func setupOverlayCapture(req vsockexec.ExecRequest) (string, func(), error) {
@@ -89,6 +99,10 @@ func setupOverlayCapture(req vsockexec.ExecRequest) (string, func(), error) {
 			cleanup()
 			return "", nil, err
 		}
+	}
+	if err := bindOverlayCaptureRuntimeSockets(layout.MergedRoot, &mounted); err != nil {
+		cleanup()
+		return "", nil, err
 	}
 	return layout.MergedRoot, cleanup, nil
 }
@@ -232,6 +246,64 @@ func bindOverlayCapturePath(source, target string, readOnly bool, mounted *[]str
 	return nil
 }
 
+func bindOverlayCaptureRuntimeSockets(mergedRoot string, mounted *[]string) error {
+	return bindOverlayCaptureRuntimeSocketsWith(mergedRoot, overlayCaptureRuntimeSockets, mounted, bindOverlayCaptureFile)
+}
+
+func bindOverlayCaptureRuntimeSocketsWith(mergedRoot string, sockets []overlayCaptureRuntimeSocket, mounted *[]string, bindFile overlayCaptureFileBinder) error {
+	mountedTargets := make(map[string]struct{}, len(sockets))
+	for _, socket := range sockets {
+		source, target, ok, err := overlayCaptureRuntimeSocketBind(mergedRoot, socket)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			continue
+		}
+		if _, exists := mountedTargets[target]; exists {
+			continue
+		}
+		if err := bindFile(source, target, mounted); err != nil {
+			return err
+		}
+		mountedTargets[target] = struct{}{}
+	}
+	return nil
+}
+
+func overlayCaptureRuntimeSocketBind(mergedRoot string, socket overlayCaptureRuntimeSocket) (string, string, bool, error) {
+	source, err := cleanOverlayCaptureAbsolutePath("overlay capture runtime socket source", socket.SourcePath)
+	if err != nil {
+		return "", "", false, err
+	}
+	target, err := overlayCaptureGuestTarget(mergedRoot, socket.GuestPath)
+	if err != nil {
+		return "", "", false, err
+	}
+	info, err := os.Stat(source)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", "", false, nil
+		}
+		return "", "", false, fmt.Errorf("stat overlay capture runtime socket %s: %w", source, err)
+	}
+	if info.Mode()&os.ModeSocket == 0 {
+		return "", "", false, nil
+	}
+	return source, target, true, nil
+}
+
+func bindOverlayCaptureFile(source, target string, mounted *[]string) error {
+	if err := ensureOverlayCaptureFile(target); err != nil {
+		return err
+	}
+	if err := unix.Mount(source, target, "", unix.MS_BIND, ""); err != nil {
+		return fmt.Errorf("bind overlay capture file %s at %s: %w", source, target, err)
+	}
+	*mounted = append(*mounted, target)
+	return nil
+}
+
 func mountOverlayCaptureScratchPath(mergedRoot, guestPath, data string, mounted *[]string) error {
 	target, err := overlayCaptureGuestTarget(mergedRoot, guestPath)
 	if err != nil {
@@ -324,6 +396,30 @@ func ensureOverlayCaptureDir(path string) error {
 	}
 	if err := os.MkdirAll(path, 0o755); err != nil {
 		return fmt.Errorf("create overlay capture path %s: %w", path, err)
+	}
+	return nil
+}
+
+func ensureOverlayCaptureFile(path string) error {
+	info, err := os.Lstat(path)
+	if err == nil {
+		if info.IsDir() {
+			return fmt.Errorf("overlay capture path %s is a directory", path)
+		}
+		return nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("stat overlay capture path %s: %w", path, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create overlay capture path parent %s: %w", filepath.Dir(path), err)
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("create overlay capture file %s: %w", path, err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close overlay capture file %s: %w", path, err)
 	}
 	return nil
 }

--- a/cmd/cleanroom-guest-agent/overlay_capture_test.go
+++ b/cmd/cleanroom-guest-agent/overlay_capture_test.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"bytes"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -204,6 +205,119 @@ func TestOverlayCaptureInputProjectionBindUsesSourceRootWhenMountedReadOnly(t *t
 	}
 }
 
+func TestBindOverlayCaptureRuntimeSocketsPreservesVarRunDockerSocketThroughRunScratch(t *testing.T) {
+	t.Parallel()
+
+	mergedRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(mergedRoot, "run"), 0o755); err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(mergedRoot, "var"), 0o755); err != nil {
+		t.Fatalf("create var: %v", err)
+	}
+	if err := os.Symlink("/run", filepath.Join(mergedRoot, "var", "run")); err != nil {
+		t.Fatalf("create var/run symlink: %v", err)
+	}
+
+	socketPath := listenOverlayCaptureTestSocket(t)
+	var gotSource, gotTarget string
+	var mounted []string
+	err := bindOverlayCaptureRuntimeSocketsWith(mergedRoot, []overlayCaptureRuntimeSocket{
+		{SourcePath: socketPath, GuestPath: "/var/run/docker.sock"},
+	}, &mounted, func(source, target string, mounted *[]string) error {
+		gotSource = source
+		gotTarget = target
+		*mounted = append(*mounted, target)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("bindOverlayCaptureRuntimeSocketsWith returned error: %v", err)
+	}
+	if gotSource != socketPath {
+		t.Fatalf("unexpected source: got %q want %q", gotSource, socketPath)
+	}
+	if want := filepath.Join(mergedRoot, "run", "docker.sock"); gotTarget != want {
+		t.Fatalf("unexpected target: got %q want %q", gotTarget, want)
+	}
+	if len(mounted) != 1 || mounted[0] != gotTarget {
+		t.Fatalf("unexpected mounted targets: %#v", mounted)
+	}
+}
+
+func TestBindOverlayCaptureRuntimeSocketsDeduplicatesVarRunSymlink(t *testing.T) {
+	t.Parallel()
+
+	mergedRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(mergedRoot, "run"), 0o755); err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(mergedRoot, "var"), 0o755); err != nil {
+		t.Fatalf("create var: %v", err)
+	}
+	if err := os.Symlink("/run", filepath.Join(mergedRoot, "var", "run")); err != nil {
+		t.Fatalf("create var/run symlink: %v", err)
+	}
+
+	socketPath := listenOverlayCaptureTestSocket(t)
+	binds := 0
+	var mounted []string
+	err := bindOverlayCaptureRuntimeSocketsWith(mergedRoot, []overlayCaptureRuntimeSocket{
+		{SourcePath: socketPath, GuestPath: "/run/docker.sock"},
+		{SourcePath: socketPath, GuestPath: "/var/run/docker.sock"},
+	}, &mounted, func(source, target string, mounted *[]string) error {
+		binds++
+		*mounted = append(*mounted, target)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("bindOverlayCaptureRuntimeSocketsWith returned error: %v", err)
+	}
+	if binds != 1 {
+		t.Fatalf("unexpected bind count: got %d want 1", binds)
+	}
+	if want := []string{filepath.Join(mergedRoot, "run", "docker.sock")}; len(mounted) != len(want) || mounted[0] != want[0] {
+		t.Fatalf("unexpected mounted targets: got %#v want %#v", mounted, want)
+	}
+}
+
+func TestBindOverlayCaptureRuntimeSocketsIgnoresMissingAndNonSocketPaths(t *testing.T) {
+	t.Parallel()
+
+	mergedRoot := t.TempDir()
+	regularFile := filepath.Join(t.TempDir(), "docker.sock")
+	if err := os.WriteFile(regularFile, []byte("not a socket"), 0o644); err != nil {
+		t.Fatalf("write regular file: %v", err)
+	}
+
+	var mounted []string
+	err := bindOverlayCaptureRuntimeSocketsWith(mergedRoot, []overlayCaptureRuntimeSocket{
+		{SourcePath: filepath.Join(t.TempDir(), "missing.sock"), GuestPath: "/run/docker.sock"},
+		{SourcePath: regularFile, GuestPath: "/var/run/docker.sock"},
+	}, &mounted, func(source, target string, mounted *[]string) error {
+		t.Fatalf("unexpected bind for source %s target %s", source, target)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("bindOverlayCaptureRuntimeSocketsWith returned error: %v", err)
+	}
+	if len(mounted) != 0 {
+		t.Fatalf("unexpected mounted targets: %#v", mounted)
+	}
+}
+
+func TestOverlayCaptureRuntimeSocketDefaultsStayUnderRunScratch(t *testing.T) {
+	t.Parallel()
+
+	for _, socket := range overlayCaptureRuntimeSockets {
+		if !strings.HasPrefix(socket.SourcePath, "/run/") {
+			t.Fatalf("runtime socket source %q is outside /run", socket.SourcePath)
+		}
+		if !strings.HasPrefix(socket.GuestPath, "/run/") {
+			t.Fatalf("runtime socket guest path %q is outside /run", socket.GuestPath)
+		}
+	}
+}
+
 func TestNewGuestCommandUsesOverlayRootAsChroot(t *testing.T) {
 	t.Parallel()
 
@@ -241,6 +355,19 @@ func TestNewGuestCommandNormalizesOverlayRootRelativeDirs(t *testing.T) {
 			}
 		})
 	}
+}
+
+func listenOverlayCaptureTestSocket(t *testing.T) string {
+	t.Helper()
+	socketPath := filepath.Join(t.TempDir(), "docker.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen on unix socket: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = listener.Close()
+	})
+	return socketPath
 }
 
 func assertOverlayCaptureEntry(t *testing.T, entries []vsockexec.OverlayCaptureEntry, want vsockexec.OverlayCaptureEntry) {


### PR DESCRIPTION
## Problem

Dependency and service block-volume bootstrap commands run inside overlay capture. Overlay capture intentionally mounts `/run` as scratch, but Docker's default socket path usually reaches `/run/docker.sock` through `/var/run/docker.sock`. That scratch mount hid the runtime Docker socket, so Docker-backed dependency or service commands failed during bootstrap with:

```text
Cannot connect to the Docker daemon at unix:///var/run/docker.sock
```

Final execution could still use Docker because it did not run under the same overlay-capture `/run` scratch mount.

## Examples

- A dependency block that runs `docker build` can now connect to the guest runtime Docker daemon during cache bootstrap when `/run/docker.sock` exists.
- A service bootstrap that uses Docker-backed tooling can resolve `/var/run/docker.sock` through the guest's `/var/run -> /run` symlink without exposing the whole host `/run` tree inside the overlay capture.

## Validation

- `docker run --rm -v /Users/lachlan/.codex/worktrees/volume-cache-bugs/docker-block-bootstrap:/src -w /src golang:1.26.2 go test ./cmd/cleanroom-guest-agent`
- Privileged Linux smoke check that a Unix socket can be bind-mounted onto the placeholder file used by the guest-agent code.
- `docker run --rm -v /Users/lachlan/.codex/worktrees/volume-cache-bugs/docker-block-bootstrap:/src -v /Users/lachlan/Develop/cleanroom/.git:/Users/lachlan/Develop/cleanroom/.git:ro -w /src golang:1.26.2 go test ./...`
