### PR TITLE
refactor: Extract stage cache restore helper

### DIFF
--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -426,6 +426,15 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 	var restoredDependencyResp *cleanroomv1.CreateSandboxResponse
 	snapshotAdapter, snapshotCapable := adapter.(backend.SnapshottingAdapter)
 	cacheOutputSnapshotAdapter, _ := adapter.(backend.CacheOutputVolumeSnapshottingAdapter)
+	stageMaterialization := createSandboxStageMaterializationConfig{
+		BackendName:  backendName,
+		Compiled:     compiled,
+		Repository:   repository,
+		CommitBundle: commitBundle,
+		Changeset:    changeset,
+		Options:      opts,
+		Reporter:     reporter,
+	}
 	if repository != nil {
 		dependencyStagePlan, dependencyStageBootstrapEnabled = dependencyStagePlanForRepository(compiled, repository)
 		servicesStagePlan, servicesStageBootstrapEnabled = servicesStagePlanForRepository(compiled, repository)
@@ -508,40 +517,15 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 					if found {
 						s.logServicesStageCacheHit(record)
 						emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_SERVICES_STAGE_CACHE, "services stage cache hit")
-						emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_RESTORE_SERVICES_STAGE_CACHE, "restoring services stage cache")
-						restoreReq := &cleanroomv1.CreateSandboxRequest{
-							Backend: backendName,
-							Options: req.GetOptions(),
-						}
-						var restoreResp *cleanroomv1.CreateSandboxResponse
-						restoreErr := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.restore_services_stage_cache", cachePhaseAttributes(
-							observability.CacheStageServices,
-							observability.CacheOperationRestore,
-							repository,
-							attribute.String(observability.AttrBackend, backendName),
-						), func(ctx context.Context) error {
-							var err error
-							restoreResp, err = s.createSandboxFromCacheRecord(ctx, restoreReq, compiled, record, nil, reporter)
-							setCacheResultSpanAttribute(ctx, map[bool]string{true: observability.CacheResultFailed, false: observability.CacheResultRestored}[err != nil])
-							return err
-						})
-						if restoreErr == nil {
+						restoreResult := s.restoreServicesStageCacheForCreateSandbox(ctx, stageMaterialization, record)
+						if restoreResult.Response != nil {
 							metricSourceKind = "services stage cache"
-							if cacheStore, err := s.cacheStoreOrErr(); err == nil {
-								if err := cacheStore.Touch(ctx, record.Stage, record.CacheKey); err != nil {
-									s.logServicesStageWarning("touch services stage cache", "", err)
-								}
-							}
-							s.retainRestoredSandboxRepositoryState(restoreResp, repository, commitBundle, changeset)
-							s.logServicesStageRestore(record, restoreResp.GetSandbox().GetSandboxId())
-							return restoreResp, nil
+							return restoreResult.Response, nil
 						}
-						if errors.Is(restoreErr, errSandboxCreateAborted) {
-							return nil, restoreErr
+						if restoreResult.Err != nil {
+							return nil, restoreResult.Err
 						}
-						recordCopy := record
-						replacedServicesStageRecord = &recordCopy
-						s.logServicesStageRestoreWarning(record, restoreErr)
+						replacedServicesStageRecord = restoreResult.ReplacedRecord
 					} else {
 						s.logServicesStageCacheMiss(backendName, servicesStagePlan.CacheKey)
 						emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_SERVICES_STAGE_CACHE, "services stage cache miss")
@@ -660,82 +644,32 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 								if servicesFound {
 									s.logServicesStageCacheHit(servicesRecord)
 									emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_SERVICES_STAGE_CACHE, "services stage cache hit")
-									emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_RESTORE_SERVICES_STAGE_CACHE, "restoring services stage cache")
-									restoreReq := &cleanroomv1.CreateSandboxRequest{
-										Backend: backendName,
-										Options: req.GetOptions(),
-									}
-									var restoreResp *cleanroomv1.CreateSandboxResponse
-									restoreErr := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.restore_services_stage_cache", cachePhaseAttributes(
-										observability.CacheStageServices,
-										observability.CacheOperationRestore,
-										repository,
-										attribute.String(observability.AttrBackend, backendName),
-									), func(ctx context.Context) error {
-										var err error
-										restoreResp, err = s.createSandboxFromCacheRecord(ctx, restoreReq, compiled, servicesRecord, nil, reporter)
-										setCacheResultSpanAttribute(ctx, map[bool]string{true: observability.CacheResultFailed, false: observability.CacheResultRestored}[err != nil])
-										return err
-									})
-									if restoreErr == nil {
+									restoreResult := s.restoreServicesStageCacheForCreateSandbox(ctx, stageMaterialization, servicesRecord)
+									if restoreResult.Response != nil {
 										metricSourceKind = "services stage cache"
-										if cacheStore, err := s.cacheStoreOrErr(); err == nil {
-											if err := cacheStore.Touch(ctx, servicesRecord.Stage, servicesRecord.CacheKey); err != nil {
-												s.logServicesStageWarning("touch services stage cache", "", err)
-											}
-										}
-										s.retainRestoredSandboxRepositoryState(restoreResp, repository, commitBundle, changeset)
-										s.logServicesStageRestore(servicesRecord, restoreResp.GetSandbox().GetSandboxId())
-										return restoreResp, nil
+										return restoreResult.Response, nil
 									}
-									if errors.Is(restoreErr, errSandboxCreateAborted) {
-										return nil, restoreErr
+									if restoreResult.Err != nil {
+										return nil, restoreResult.Err
 									}
-									recordCopy := servicesRecord
-									replacedServicesStageRecord = &recordCopy
-									s.logServicesStageRestoreWarning(servicesRecord, restoreErr)
+									replacedServicesStageRecord = restoreResult.ReplacedRecord
 								}
 							}
 						}
 
 						s.logDependencyStageCacheHit(record)
 						emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_DEPENDENCY_STAGE_CACHE, "dependency stage cache hit")
-						emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_RESTORE_DEPENDENCY_STAGE_CACHE, "restoring dependency stage cache")
-						restoreReq := &cleanroomv1.CreateSandboxRequest{
-							Backend: backendName,
-							Options: req.GetOptions(),
-						}
-						var restoreResp *cleanroomv1.CreateSandboxResponse
-						restoreErr := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.restore_dependency_stage_cache", cachePhaseAttributes(
-							observability.CacheStageDependency,
-							observability.CacheOperationRestore,
-							repository,
-							attribute.String(observability.AttrBackend, backendName),
-						), func(ctx context.Context) error {
-							var err error
-							restoreResp, err = s.createSandboxFromCacheRecord(ctx, restoreReq, compiled, record, serviceCacheOutputVolumes, reporter)
-							setCacheResultSpanAttribute(ctx, map[bool]string{true: observability.CacheResultFailed, false: observability.CacheResultRestored}[err != nil])
-							return err
-						})
-						if restoreErr == nil {
+						restoreResult := s.restoreDependencyStageCacheForCreateSandbox(ctx, stageMaterialization, record, serviceCacheOutputVolumes)
+						if restoreResult.Response != nil {
 							metricSourceKind = "dependency stage cache"
-							if cacheStore, err := s.cacheStoreOrErr(); err == nil {
-								if err := cacheStore.Touch(ctx, record.Stage, record.CacheKey); err != nil {
-									s.logDependencyStageWarning("touch dependency stage cache", "", err)
-								}
-							}
-							s.retainRestoredSandboxRepositoryState(restoreResp, repository, commitBundle, changeset)
-							s.logDependencyStageRestore(record, restoreResp.GetSandbox().GetSandboxId())
 							if !servicesStageBootstrapEnabled {
-								return restoreResp, nil
+								return restoreResult.Response, nil
 							}
-							restoredDependencyResp = restoreResp
-						} else if errors.Is(restoreErr, errSandboxCreateAborted) {
-							return nil, restoreErr
+							restoredDependencyResp = restoreResult.Response
+						} else if restoreResult.Err != nil {
+							return nil, restoreResult.Err
 						} else {
-							recordCopy := record
-							replacedDependencyStageRecord = &recordCopy
-							s.logDependencyStageRestoreWarning(record, restoreErr)
+							replacedDependencyStageRecord = restoreResult.ReplacedRecord
 						}
 					} else {
 						s.logDependencyStageCacheMiss(backendName, dependencyStagePlan.CacheKey)
@@ -821,42 +755,17 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 				} else if found {
 					s.logWorkspaceStageCacheHit(record)
 					emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_WORKSPACE_STAGE_CACHE, "workspace stage cache hit")
-					emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_RESTORE_WORKSPACE_STAGE_CACHE, "restoring workspace stage cache")
-					restoreReq := &cleanroomv1.CreateSandboxRequest{
-						Backend: backendName,
-						Options: req.GetOptions(),
-					}
-					var restoreResp *cleanroomv1.CreateSandboxResponse
-					restoreErr := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.restore_workspace_stage_cache", cachePhaseAttributes(
-						observability.CacheStageWorkspace,
-						observability.CacheOperationRestore,
-						repository,
-						attribute.String(observability.AttrBackend, backendName),
-					), func(ctx context.Context) error {
-						var err error
-						restoreResp, err = s.createSandboxFromCacheRecord(ctx, restoreReq, compiled, record, appendCacheOutputVolumeSpecs(dependencyCacheOutputVolumes, serviceCacheOutputVolumes), reporter)
-						setCacheResultSpanAttribute(ctx, map[bool]string{true: observability.CacheResultFailed, false: observability.CacheResultRestored}[err != nil])
-						return err
-					})
-					if restoreErr == nil {
+					restoreResult := s.restoreWorkspaceStageCacheForCreateSandbox(ctx, stageMaterialization, record, appendCacheOutputVolumeSpecs(dependencyCacheOutputVolumes, serviceCacheOutputVolumes))
+					if restoreResult.Response != nil {
 						metricSourceKind = "workspace stage cache"
-						if cacheStore, err := s.cacheStoreOrErr(); err == nil {
-							if err := cacheStore.Touch(ctx, record.Stage, record.CacheKey); err != nil {
-								s.logWorkspaceStageWarning("touch workspace stage cache", "", err)
-							}
-						}
-						s.retainRestoredSandboxRepositoryState(restoreResp, repository, commitBundle, changeset)
-						s.logWorkspaceStageRestore(record, restoreResp.GetSandbox().GetSandboxId())
 						if !dependencyStageBootstrapEnabled && !servicesStageBootstrapEnabled {
-							return restoreResp, nil
+							return restoreResult.Response, nil
 						}
-						restoredWorkspaceResp = restoreResp
-					} else if errors.Is(restoreErr, errSandboxCreateAborted) {
-						return nil, restoreErr
+						restoredWorkspaceResp = restoreResult.Response
+					} else if restoreResult.Err != nil {
+						return nil, restoreResult.Err
 					} else {
-						recordCopy := record
-						replacedWorkspaceStageRecord = &recordCopy
-						s.logWorkspaceStageRestoreWarning(record, restoreErr)
+						replacedWorkspaceStageRecord = restoreResult.ReplacedRecord
 					}
 				} else {
 					s.logWorkspaceStageCacheMiss(backendName, workspaceStageKey)

--- a/internal/controlservice/stage_cache_restore.go
+++ b/internal/controlservice/stage_cache_restore.go
@@ -1,0 +1,158 @@
+package controlservice
+
+import (
+	"context"
+	"errors"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/cachestore"
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+	"github.com/buildkite/cleanroom/internal/observability"
+	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/buildkite/cleanroom/internal/repositorybundle"
+	"github.com/buildkite/cleanroom/internal/repositorychangeset"
+	"github.com/buildkite/cleanroom/internal/repositorycheckout"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+type createSandboxStageMaterializationConfig struct {
+	BackendName  string
+	Compiled     *policy.CompiledPolicy
+	Repository   *repositorycheckout.Checkout
+	CommitBundle *repositorybundle.Bundle
+	Changeset    *repositorychangeset.Changeset
+	Options      *cleanroomv1.SandboxOptions
+	Reporter     CreateSandboxReporter
+}
+
+type createSandboxStageCacheRestoreConfig struct {
+	Stage              string
+	TraceName          string
+	Phase              cleanroomv1.CreateSandboxPhase
+	Message            string
+	CacheOutputVolumes []backend.CacheOutputVolumeSpec
+	LogTouchWarning    func(*Service, error)
+	LogRestore         func(*Service, cachestore.Record, string)
+	LogRestoreWarning  func(*Service, cachestore.Record, error)
+}
+
+type createSandboxStageCacheRestoreResult struct {
+	Response       *cleanroomv1.CreateSandboxResponse
+	ReplacedRecord *cachestore.Record
+	Err            error
+}
+
+func (s *Service) restoreStageCacheForCreateSandbox(
+	ctx context.Context,
+	materialization createSandboxStageMaterializationConfig,
+	record cachestore.Record,
+	restore createSandboxStageCacheRestoreConfig,
+) createSandboxStageCacheRestoreResult {
+	emitCreateSandboxMessage(materialization.Reporter, restore.Phase, restore.Message)
+	restoreReq := &cleanroomv1.CreateSandboxRequest{
+		Backend: materialization.BackendName,
+		Options: materialization.Options,
+	}
+	var restoreResp *cleanroomv1.CreateSandboxResponse
+	restoreErr := s.traceCreateSandboxPhase(ctx, restore.TraceName, cachePhaseAttributes(
+		restore.Stage,
+		observability.CacheOperationRestore,
+		materialization.Repository,
+		attribute.String(observability.AttrBackend, materialization.BackendName),
+	), func(ctx context.Context) error {
+		var err error
+		restoreResp, err = s.createSandboxFromCacheRecord(ctx, restoreReq, materialization.Compiled, record, restore.CacheOutputVolumes, materialization.Reporter)
+		setCacheResultSpanAttribute(ctx, map[bool]string{true: observability.CacheResultFailed, false: observability.CacheResultRestored}[err != nil])
+		return err
+	})
+	if restoreErr == nil {
+		if cacheStore, err := s.cacheStoreOrErr(); err == nil {
+			if err := cacheStore.Touch(ctx, record.Stage, record.CacheKey); err != nil && restore.LogTouchWarning != nil {
+				restore.LogTouchWarning(s, err)
+			}
+		}
+		s.retainRestoredSandboxRepositoryState(restoreResp, materialization.Repository, materialization.CommitBundle, materialization.Changeset)
+		if restore.LogRestore != nil {
+			restore.LogRestore(s, record, restoreResp.GetSandbox().GetSandboxId())
+		}
+		return createSandboxStageCacheRestoreResult{Response: restoreResp}
+	}
+	if errors.Is(restoreErr, errSandboxCreateAborted) {
+		return createSandboxStageCacheRestoreResult{Err: restoreErr}
+	}
+	recordCopy := record
+	if restore.LogRestoreWarning != nil {
+		restore.LogRestoreWarning(s, record, restoreErr)
+	}
+	return createSandboxStageCacheRestoreResult{ReplacedRecord: &recordCopy}
+}
+
+func (s *Service) restoreWorkspaceStageCacheForCreateSandbox(
+	ctx context.Context,
+	materialization createSandboxStageMaterializationConfig,
+	record cachestore.Record,
+	cacheOutputVolumes []backend.CacheOutputVolumeSpec,
+) createSandboxStageCacheRestoreResult {
+	return s.restoreStageCacheForCreateSandbox(ctx, materialization, record, createSandboxStageCacheRestoreConfig{
+		Stage:              observability.CacheStageWorkspace,
+		TraceName:          "cleanroom.sandbox.restore_workspace_stage_cache",
+		Phase:              cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_RESTORE_WORKSPACE_STAGE_CACHE,
+		Message:            "restoring workspace stage cache",
+		CacheOutputVolumes: cacheOutputVolumes,
+		LogTouchWarning: func(s *Service, err error) {
+			s.logWorkspaceStageWarning("touch workspace stage cache", "", err)
+		},
+		LogRestore: func(s *Service, record cachestore.Record, sandboxID string) {
+			s.logWorkspaceStageRestore(record, sandboxID)
+		},
+		LogRestoreWarning: func(s *Service, record cachestore.Record, err error) {
+			s.logWorkspaceStageRestoreWarning(record, err)
+		},
+	})
+}
+
+func (s *Service) restoreDependencyStageCacheForCreateSandbox(
+	ctx context.Context,
+	materialization createSandboxStageMaterializationConfig,
+	record cachestore.Record,
+	cacheOutputVolumes []backend.CacheOutputVolumeSpec,
+) createSandboxStageCacheRestoreResult {
+	return s.restoreStageCacheForCreateSandbox(ctx, materialization, record, createSandboxStageCacheRestoreConfig{
+		Stage:              observability.CacheStageDependency,
+		TraceName:          "cleanroom.sandbox.restore_dependency_stage_cache",
+		Phase:              cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_RESTORE_DEPENDENCY_STAGE_CACHE,
+		Message:            "restoring dependency stage cache",
+		CacheOutputVolumes: cacheOutputVolumes,
+		LogTouchWarning: func(s *Service, err error) {
+			s.logDependencyStageWarning("touch dependency stage cache", "", err)
+		},
+		LogRestore: func(s *Service, record cachestore.Record, sandboxID string) {
+			s.logDependencyStageRestore(record, sandboxID)
+		},
+		LogRestoreWarning: func(s *Service, record cachestore.Record, err error) {
+			s.logDependencyStageRestoreWarning(record, err)
+		},
+	})
+}
+
+func (s *Service) restoreServicesStageCacheForCreateSandbox(
+	ctx context.Context,
+	materialization createSandboxStageMaterializationConfig,
+	record cachestore.Record,
+) createSandboxStageCacheRestoreResult {
+	return s.restoreStageCacheForCreateSandbox(ctx, materialization, record, createSandboxStageCacheRestoreConfig{
+		Stage:     observability.CacheStageServices,
+		TraceName: "cleanroom.sandbox.restore_services_stage_cache",
+		Phase:     cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_RESTORE_SERVICES_STAGE_CACHE,
+		Message:   "restoring services stage cache",
+		LogTouchWarning: func(s *Service, err error) {
+			s.logServicesStageWarning("touch services stage cache", "", err)
+		},
+		LogRestore: func(s *Service, record cachestore.Record, sandboxID string) {
+			s.logServicesStageRestore(record, sandboxID)
+		},
+		LogRestoreWarning: func(s *Service, record cachestore.Record, err error) {
+			s.logServicesStageRestoreWarning(record, err)
+		},
+	})
+}


### PR DESCRIPTION
## Summary

Extract the repeated exact stage-cache restore path from `createSandbox` into a small private helper. Workspace, dependency, and services stage cache restores now share the same restore tracing, reporter phase emission, cache touch, repository-state retention, restore logging, abort propagation, and replacement-record capture.

This keeps cache selection and lookup order unchanged. It only gives the already-selected stage cache record a narrower restore Module so the create flow is easier to review before the next materialization refactor.

## Validation

- `mise exec -- go test ./internal/controlservice`
- `git diff --check`
- Earlier in this branch before the file rename: `mise exec -- go test ./...`