### PR TITLE
perf: Speed up darwin-vz sandbox startup

### DIFF
--- a/cmd/cleanroom-darwin-vz/main.swift
+++ b/cmd/cleanroom-darwin-vz/main.swift
@@ -519,9 +519,9 @@ private final class VMRuntime {
         }
         lock.unlock()
 
+        let startedAt = DispatchTime.now()
         let vmQueue = DispatchQueue(label: "cleanroom.darwin-vz.vm")
         let vmID = UUID().uuidString
-        let startedAt = Date()
 
         let (vm, serialChannel, networkDetails, fileHandleNetworkAttachment) = try buildVM(
             runDir: runDir,
@@ -542,13 +542,17 @@ private final class VMRuntime {
             consoleLogPath: consoleLogPath,
             queue: vmQueue
         )
+        let configBuiltAt = DispatchTime.now()
         var releaseFileHandleAttachmentOnFailure = fileHandleNetworkAttachment
         defer {
             releaseFileHandleAttachmentOnFailure?.stop()
         }
 
+        let vzStartStartedAt = DispatchTime.now()
         try startVM(vm, queue: vmQueue, timeoutSeconds: launchSeconds)
+        let vzStartedAt = DispatchTime.now()
 
+        let proxyReadyStartedAt = DispatchTime.now()
         let proxy = try ProxyServer(path: proxySocketPath)
         self.guestPort = guestPort
         self.launchTimeout = TimeInterval(launchSeconds)
@@ -565,8 +569,14 @@ private final class VMRuntime {
             }
             return try self.connectGuestChannel()
         }
+        let proxyReadyAt = DispatchTime.now()
 
-        let vmReadyMS = Int64(Date().timeIntervalSince(startedAt) * 1000)
+        let timingMS = [
+            "config_build": elapsedMilliseconds(from: startedAt, to: configBuiltAt),
+            "vz_start": elapsedMilliseconds(from: vzStartStartedAt, to: vzStartedAt),
+            "proxy_ready": elapsedMilliseconds(from: proxyReadyStartedAt, to: proxyReadyAt),
+            "vm_ready": elapsedMilliseconds(from: startedAt, to: proxyReadyAt),
+        ]
         return ControlResponse(
             ok: true,
             error: nil,
@@ -576,7 +586,7 @@ private final class VMRuntime {
             vmnetGuestIPv4: networkDetails?.guestIPv4,
             vmnetGatewayIPv4: networkDetails?.gatewayIPv4,
             vmnetPrefixLen: networkDetails?.prefixLength,
-            timingMS: ["vm_ready": vmReadyMS]
+            timingMS: timingMS
         )
     }
 
@@ -1247,6 +1257,13 @@ private func ensureDirectory(_ path: String) throws {
         throw HelperError.invalidRequest("directory path is empty")
     }
     try FileManager.default.createDirectory(atPath: path, withIntermediateDirectories: true)
+}
+
+private func elapsedMilliseconds(from start: DispatchTime, to end: DispatchTime) -> Int64 {
+    guard end.uptimeNanoseconds >= start.uptimeNanoseconds else {
+        return 0
+    }
+    return Int64((end.uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000)
 }
 
 private func pumpBytes(src: Int32, dst: Int32) throws {

--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -69,7 +69,7 @@ type Adapter struct {
 	executeInSandboxFn func(context.Context, context.Context, *sandboxInstance, backend.ExecutionRequest, backend.OutputStream) (*backend.ExecutionResult, error)
 	helperRequestFn    func(context.Context, *helperSession, helperControlRequest) (helperControlResponse, error)
 
-	ensurePreparedRootFSFn func(context.Context, string) (preparedRootFS, error)
+	ensurePreparedRootFSFn func(context.Context, string, int64) (preparedRootFS, error)
 
 	GatewayRegistry  gatewayRegistry
 	GatewayPort      int
@@ -165,6 +165,17 @@ var (
 	networkProcessLookupPollInterval = 50 * time.Millisecond
 )
 
+type virtualizationProcessPIDLookup struct {
+	cancel   context.CancelFunc
+	resultCh <-chan virtualizationProcessPIDLookupResult
+}
+
+type virtualizationProcessPIDLookupResult struct {
+	pid      int
+	err      error
+	duration time.Duration
+}
+
 func New() *Adapter {
 	return &Adapter{
 		newImageManager: defaultImageManagerFactory,
@@ -257,6 +268,39 @@ func resolveVirtualizationProcessPID(ctx context.Context, rootFSPath string) (in
 	}
 
 	return 0, fmt.Errorf("resolve virtualization network process pid for %s: %w", rootFSPath, lastErr)
+}
+
+func startVirtualizationProcessPIDLookup(ctx context.Context, rootFSPath string) *virtualizationProcessPIDLookup {
+	lookupCtx, cancel := context.WithTimeout(ctx, networkProcessLookupTimeout)
+	resultCh := make(chan virtualizationProcessPIDLookupResult, 1)
+	start := time.Now()
+	go func() {
+		pid, err := resolveVirtualizationProcessPID(lookupCtx, rootFSPath)
+		resultCh <- virtualizationProcessPIDLookupResult{
+			pid:      pid,
+			err:      err,
+			duration: time.Since(start),
+		}
+	}()
+	return &virtualizationProcessPIDLookup{
+		cancel:   cancel,
+		resultCh: resultCh,
+	}
+}
+
+func (l *virtualizationProcessPIDLookup) wait() virtualizationProcessPIDLookupResult {
+	if l == nil {
+		return virtualizationProcessPIDLookupResult{}
+	}
+	result := <-l.resultCh
+	l.cancel()
+	return result
+}
+
+func (l *virtualizationProcessPIDLookup) stop() {
+	if l != nil {
+		l.cancel()
+	}
 }
 
 func lookupPIDsForOpenFile(ctx context.Context, lsofPath, filePath string) ([]int, error) {
@@ -1037,32 +1081,45 @@ func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream 
 	if err != nil {
 		return nil, err
 	}
+	rootFSTimingMS := make(map[string]int64, darwinVZRootFSTimingExpectedPhaseCount)
+	observation.HelperTimingMS = rootFSTimingMS
+	baseVolumeStart := time.Now()
 	baseVolume, err := driver.EnsureBaseVolume(ctx, volumestore.EnsureBaseVolumeRequest{
-		BaseID:     strings.TrimSuffix(filepath.Base(rootFSPath), filepath.Ext(rootFSPath)),
-		SourcePath: rootFSPath,
+		BaseID:       strings.TrimSuffix(filepath.Base(rootFSPath), filepath.Ext(rootFSPath)),
+		SourcePath:   rootFSPath,
+		MinimumBytes: req.MinimumRootFSBytes,
 	})
+	recordDarwinVZPhaseTiming(rootFSTimingMS, darwinVZTimingRootFSBaseVolumePrepare, baseVolumeStart)
 	if err != nil {
 		return nil, fmt.Errorf("prepare base volume: %w", err)
 	}
 	vmRootFSPath := filepath.Join(runDir, "rootfs-ephemeral.ext4")
 	copyStart := time.Now()
+	writableVolumeStart := time.Now()
 	writableVolume, err := driver.CreateWritableVolume(ctx, volumestore.CreateWritableVolumeRequest{
 		VolumeID:       req.ExecutionID,
 		BaseRef:        baseVolume.Ref,
 		AttachmentPath: vmRootFSPath,
 	})
+	recordDarwinVZPhaseTiming(rootFSTimingMS, darwinVZTimingRootFSWritableVolumeCreateClone, writableVolumeStart)
 	if err != nil {
 		observation.Error = err.Error()
 		return nil, fmt.Errorf("prepare per-run rootfs: %w", err)
 	}
 	vmRootFSPath = writableVolume.AttachmentPath
-	if err := ext4image.EnsureMinimumSize(ctx, vmRootFSPath, req.MinimumRootFSBytes); err != nil {
-		observation.Error = err.Error()
-		return nil, fmt.Errorf("resize writable rootfs: %w", err)
+	resizeStart := time.Now()
+	resizeErr := ext4image.EnsureMinimumSize(ctx, vmRootFSPath, req.MinimumRootFSBytes)
+	recordDarwinVZPhaseTiming(rootFSTimingMS, darwinVZTimingRootFSMinimumSizeResize, resizeStart)
+	if resizeErr != nil {
+		observation.Error = resizeErr.Error()
+		return nil, fmt.Errorf("resize writable rootfs: %w", resizeErr)
 	}
-	if err := validateRootFSInspectable(vmRootFSPath); err != nil {
-		observation.Error = err.Error()
-		return nil, fmt.Errorf("validate writable rootfs: %w", err)
+	validateStart := time.Now()
+	validateErr := validateRootFSInspectable(vmRootFSPath)
+	recordDarwinVZPhaseTiming(rootFSTimingMS, darwinVZTimingRootFSInspectValidate, validateStart)
+	if validateErr != nil {
+		observation.Error = validateErr.Error()
+		return nil, fmt.Errorf("validate writable rootfs: %w", validateErr)
 	}
 	observation.RootFSCopyMS = time.Since(copyStart).Milliseconds()
 	defer func() {
@@ -1246,6 +1303,9 @@ func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream 
 }
 
 func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compiled *policy.CompiledPolicy, cfg backend.FirecrackerConfig, cacheOutputVolumeSpecs []backend.CacheOutputVolumeSpec) (*sandboxInstance, error) {
+	launchStart := time.Now()
+	launchTimingMS := make(map[string]int64, 12+darwinVZRootFSTimingExpectedPhaseCount)
+	policyValidateStart := time.Now()
 	if compiled == nil {
 		return nil, errors.New("missing compiled policy")
 	}
@@ -1262,6 +1322,7 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 	if runtime.GOOS != "darwin" {
 		return nil, fmt.Errorf("darwin-vz backend is darwin-only, current OS is %s", runtime.GOOS)
 	}
+	recordDarwinVZPhaseTiming(launchTimingMS, darwinVZTimingLaunchPolicyValidate, policyValidateStart)
 
 	if cfg.VCPUs <= 0 {
 		cfg.VCPUs = 1
@@ -1280,7 +1341,9 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 		"configured_kernel_path", strings.TrimSpace(cfg.KernelImagePath),
 	)
 
+	kernelResolveStart := time.Now()
 	kernelPath, _, err := a.resolveKernelPath(ctx, cfg.KernelImagePath)
+	recordDarwinVZPhaseTiming(launchTimingMS, darwinVZTimingKernelResolve, kernelResolveStart)
 	if err != nil {
 		return nil, err
 	}
@@ -1288,14 +1351,17 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 		"sandbox_id", sandboxID,
 		"image_ref", strings.TrimSpace(compiled.ImageRef),
 	)
+	rootFSResolveStart := time.Now()
 	rootFSPath, imageRef, imageDigest, _, err := a.resolveRootFSPath(ctx, backend.ExecutionRequest{
 		Policy:            compiled,
 		FirecrackerConfig: cfg,
 	})
+	recordDarwinVZPhaseTiming(launchTimingMS, darwinVZTimingRootFSResolve, rootFSResolveStart)
 	if err != nil {
 		return nil, err
 	}
 
+	runDirPrepareStart := time.Now()
 	runBaseDir, err := sandboxRuntimeBaseDir()
 	if err != nil {
 		return nil, fmt.Errorf("resolve sandbox runtime base directory: %w", err)
@@ -1310,7 +1376,9 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 	if err := os.MkdirAll(runDir, 0o755); err != nil {
 		return nil, fmt.Errorf("create sandbox runtime directory: %w", err)
 	}
+	recordDarwinVZPhaseTiming(launchTimingMS, darwinVZTimingRunDirPrepare, runDirPrepareStart)
 
+	rootFSPreflightStart := time.Now()
 	rootFSPath, err = filepath.Abs(rootFSPath)
 	if err != nil {
 		return nil, fmt.Errorf("resolve rootfs path: %w", err)
@@ -1321,6 +1389,7 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 	if err := backend.ValidateDockerServiceRootFS(rootFSPath, imageRef, compiled.RequiresDockerService()); err != nil {
 		return nil, err
 	}
+	recordDarwinVZPhaseTiming(launchTimingMS, darwinVZTimingRootFSPreflight, rootFSPreflightStart)
 
 	driver, err := rootFSVolumeDriver(cfg)
 	if err != nil {
@@ -1332,32 +1401,45 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 		"image_ref", imageRef,
 		"image_digest", imageDigest,
 	)
+	rootFSTimingMS := make(map[string]int64, darwinVZRootFSTimingExpectedPhaseCount)
+	baseVolumeStart := time.Now()
 	baseVolume, err := driver.EnsureBaseVolume(ctx, volumestore.EnsureBaseVolumeRequest{
-		BaseID:     strings.TrimSuffix(filepath.Base(rootFSPath), filepath.Ext(rootFSPath)),
-		SourcePath: rootFSPath,
+		BaseID:       strings.TrimSuffix(filepath.Base(rootFSPath), filepath.Ext(rootFSPath)),
+		SourcePath:   rootFSPath,
+		MinimumBytes: cfg.MinimumRootFSBytes,
 	})
+	recordDarwinVZPhaseTiming(rootFSTimingMS, darwinVZTimingRootFSBaseVolumePrepare, baseVolumeStart)
 	if err != nil {
 		return nil, fmt.Errorf("prepare base volume: %w", err)
 	}
 	vmRootFSPath := filepath.Join(runDir, "rootfs-persistent.ext4")
 	copyStart := time.Now()
+	writableVolumeStart := time.Now()
 	writableVolume, err := driver.CreateWritableVolume(ctx, volumestore.CreateWritableVolumeRequest{
 		VolumeID:       sandboxID,
 		BaseRef:        baseVolume.Ref,
 		AttachmentPath: vmRootFSPath,
 	})
+	recordDarwinVZPhaseTiming(rootFSTimingMS, darwinVZTimingRootFSWritableVolumeCreateClone, writableVolumeStart)
 	if err != nil {
 		return nil, fmt.Errorf("prepare persistent rootfs: %w", err)
 	}
 	vmRootFSPath = writableVolume.AttachmentPath
-	if err := ext4image.EnsureMinimumSize(ctx, vmRootFSPath, cfg.MinimumRootFSBytes); err != nil {
-		return nil, fmt.Errorf("resize persistent rootfs: %w", err)
+	resizeStart := time.Now()
+	resizeErr := ext4image.EnsureMinimumSize(ctx, vmRootFSPath, cfg.MinimumRootFSBytes)
+	recordDarwinVZPhaseTiming(rootFSTimingMS, darwinVZTimingRootFSMinimumSizeResize, resizeStart)
+	if resizeErr != nil {
+		return nil, fmt.Errorf("resize persistent rootfs: %w", resizeErr)
 	}
-	if err := validateRootFSInspectable(vmRootFSPath); err != nil {
-		return nil, fmt.Errorf("validate persistent rootfs: %w", err)
+	validateStart := time.Now()
+	validateErr := validateRootFSInspectable(vmRootFSPath)
+	recordDarwinVZPhaseTiming(rootFSTimingMS, darwinVZTimingRootFSInspectValidate, validateStart)
+	if validateErr != nil {
+		return nil, fmt.Errorf("validate persistent rootfs: %w", validateErr)
 	}
 	rootFSCopyMS := time.Since(copyStart).Milliseconds()
 
+	guestBootConfigStart := time.Now()
 	guestInitPath, _ := guestInitExecutableForRootFS(vmRootFSPath)
 	networkCfg, err := resolveDarwinVZNetwork(cfg)
 	if err != nil {
@@ -1372,8 +1454,11 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 	consolePath := filepath.Join(runDir, "vm.console.log")
 
 	configPath := filepath.Join(runDir, "darwin-vz-config.json")
+	recordDarwinVZPhaseTiming(launchTimingMS, darwinVZTimingGuestBootConfig, guestBootConfigStart)
 
+	helperSessionStart := time.Now()
 	helper, err := startHelperSession(ctx, runDir, cfg.LaunchSeconds)
+	recordDarwinVZPhaseTiming(launchTimingMS, darwinVZTimingHelperSessionStart, helperSessionStart)
 	if err != nil {
 		return nil, fmt.Errorf("start darwin-vz helper: %w", err)
 	}
@@ -1388,7 +1473,9 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 		}
 	}()
 
+	cacheOutputPrepareStart := time.Now()
 	cacheOutputVolumes, cleanupCacheOutputs, err := prepareDarwinVZCacheOutputVolumes(ctx, cfg, sandboxID, runDir, cacheOutputVolumeSpecs)
+	recordDarwinVZPhaseTiming(launchTimingMS, darwinVZTimingCacheOutputPrepare, cacheOutputPrepareStart)
 	if err != nil {
 		return nil, err
 	}
@@ -1404,6 +1491,7 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 		"network_mode", strings.TrimSpace(networkCfg.Mode),
 		"launch_seconds", cfg.LaunchSeconds,
 	)
+	helperStartVMStart := time.Now()
 	startedVM, err := startDarwinVZHelperVM(ctx, helper, darwinVZVMStartRequest{
 		SandboxID:        sandboxID,
 		ConfigPath:       configPath,
@@ -1423,6 +1511,7 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 		GuestPort:        cfg.GuestPort,
 		LaunchSeconds:    cfg.LaunchSeconds,
 	})
+	recordDarwinVZPhaseTiming(launchTimingMS, darwinVZTimingHelperStartVM, helperStartVMStart)
 	if err != nil {
 		return nil, err
 	}
@@ -1438,27 +1527,19 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 		}
 	}()
 
-	networkProcessPID := 0
-	lookupCtx, cancelLookup := context.WithTimeout(ctx, networkProcessLookupTimeout)
-	networkProcessPID, _ = resolveVirtualizationProcessPID(lookupCtx, vmRootFSPath)
-	cancelLookup()
+	pidLookup := startVirtualizationProcessPIDLookup(ctx, vmRootFSPath)
+	defer pidLookup.stop()
 
 	instance := &sandboxInstance{
-		SandboxID:         sandboxID,
-		RunDir:            runDir,
-		ConfigPath:        configPath,
-		ProxySocketPath:   startedVM.ProxySocketPath,
-		GuestPort:         cfg.GuestPort,
-		NetworkProcessPID: networkProcessPID,
-		Policy:            compiled,
-		FirecrackerConfig: cfg,
-		ImageRef:          imageRef,
-		ImageDigest:       imageDigest,
-		LaunchObservability: &darwinVZLaunchObservability{
-			RootFSCopyMS:   rootFSCopyMS,
-			HelperTimingMS: startedVM.TimingMS,
-			Network:        startedVM.NetworkMetadata,
-		},
+		SandboxID:           sandboxID,
+		RunDir:              runDir,
+		ConfigPath:          configPath,
+		ProxySocketPath:     startedVM.ProxySocketPath,
+		GuestPort:           cfg.GuestPort,
+		Policy:              compiled,
+		FirecrackerConfig:   cfg,
+		ImageRef:            imageRef,
+		ImageDigest:         imageDigest,
 		NetworkMetadata:     startedVM.NetworkMetadata,
 		FileHandleGateway:   startedVM.FileHandleGW,
 		CommandTimeout:      cfg.LaunchSeconds,
@@ -1486,8 +1567,22 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 
 	bootCtx, cancel := context.WithTimeout(ctx, time.Duration(cfg.LaunchSeconds)*time.Second)
 	defer cancel()
+	guestReadyProbeStart := time.Now()
 	if err := probeGuestExecReadyWithExit(bootCtx, helper, startedVM.ProxySocketPath, instance.exitedCh, instance.exitedErrOrNil); err != nil {
+		pidLookup.stop()
 		return nil, err
+	}
+	recordDarwinVZPhaseTiming(launchTimingMS, darwinVZTimingGuestExecReadyProbe, guestReadyProbeStart)
+	pidLookupResult := pidLookup.wait()
+	instance.NetworkProcessPID = pidLookupResult.pid
+	recordDarwinVZPhaseTimingDuration(launchTimingMS, darwinVZTimingVirtualizationPIDLookup, pidLookupResult.duration)
+	recordDarwinVZPhaseTiming(launchTimingMS, darwinVZTimingLaunchSandboxTotal, launchStart)
+	helperTimingMS := mergeHelperTimingMS(launchTimingMS, rootFSTimingMS)
+	helperTimingMS = mergeHelperTimingMS(helperTimingMS, startedVM.TimingMS)
+	instance.LaunchObservability = &darwinVZLaunchObservability{
+		RootFSCopyMS:   rootFSCopyMS,
+		HelperTimingMS: helperTimingMS,
+		Network:        startedVM.NetworkMetadata,
 	}
 
 	cacheOutputsNeedCleanup = false
@@ -2010,7 +2105,7 @@ func (a *Adapter) resolveRootFSPath(ctx context.Context, req backend.ExecutionRe
 	if ensurePrepared == nil {
 		ensurePrepared = a.ensurePreparedRuntimeRootFSFromImage
 	}
-	prepared, err := ensurePrepared(ctx, ref)
+	prepared, err := ensurePrepared(ctx, ref, req.MinimumRootFSBytes)
 	if err != nil {
 		return "", "", "", "", err
 	}
@@ -2033,7 +2128,7 @@ func (a *Adapter) RuntimeBaseKey(ctx context.Context, compiled *policy.CompiledP
 			if err != nil {
 				return "", err
 			}
-			return fmt.Sprintf("configured-rootfs:%s|%d|%d", absPath, info.Size(), info.ModTime().UTC().UnixNano()), nil
+			return fmt.Sprintf("configured-rootfs:%s|%d|%d%s", absPath, info.Size(), info.ModTime().UTC().UnixNano(), rootFSMinimumCacheKeySuffix(cfg.MinimumRootFSBytes)), nil
 		}
 	}
 
@@ -2055,14 +2150,14 @@ func (a *Adapter) RuntimeBaseKey(ctx context.Context, compiled *policy.CompiledP
 		return "", err
 	}
 
-	preparedPath, err := preparedRuntimeRootFSPath(imageDigest, guestAgentHash)
+	preparedPath, err := preparedRuntimeRootFSPath(imageDigest, guestAgentHash, cfg.MinimumRootFSBytes)
 	if err != nil {
 		return "", err
 	}
 	return "prepared-rootfs:" + preparedPath, nil
 }
 
-func (a *Adapter) ensurePreparedRuntimeRootFSFromImage(ctx context.Context, imageRef string) (preparedRootFS, error) {
+func (a *Adapter) ensurePreparedRuntimeRootFSFromImage(ctx context.Context, imageRef string, minimumBytes int64) (preparedRootFS, error) {
 	artifact, err := a.ensureImageArtifact(ctx, imageRef)
 	if err != nil {
 		return preparedRootFS{}, err
@@ -2079,12 +2174,12 @@ func (a *Adapter) ensurePreparedRuntimeRootFSFromImage(ctx context.Context, imag
 		return preparedRootFS{}, err
 	}
 
-	preparedPath, err := preparedRuntimeRootFSPath(artifact.Digest, guestAgentHash)
+	preparedPath, err := preparedRuntimeRootFSPath(artifact.Digest, guestAgentHash, minimumBytes)
 	if err != nil {
 		return preparedRootFS{}, err
 	}
 	if _, err := os.Stat(preparedPath); err == nil {
-		if preparedRuntimeRootFSCacheHitIsValid(preparedPath) {
+		if preparedRuntimeRootFSCacheHitIsValid(preparedPath, minimumBytes) {
 			return preparedRootFS{
 				Ref:    artifact.Ref,
 				Digest: artifact.Digest,
@@ -2103,7 +2198,7 @@ func (a *Adapter) ensurePreparedRuntimeRootFSFromImage(ctx context.Context, imag
 	defer a.runtimeImageMu.Unlock()
 
 	if _, err := os.Stat(preparedPath); err == nil {
-		if preparedRuntimeRootFSCacheHitIsValid(preparedPath) {
+		if preparedRuntimeRootFSCacheHitIsValid(preparedPath, minimumBytes) {
 			return preparedRootFS{
 				Ref:    artifact.Ref,
 				Digest: artifact.Digest,
@@ -2132,6 +2227,10 @@ func (a *Adapter) ensurePreparedRuntimeRootFSFromImage(ctx context.Context, imag
 		_ = os.Remove(tmpPath)
 		return preparedRootFS{}, err
 	}
+	if err := ensurePreparedRuntimeRootFSMinimumSize(ctx, tmpPath, minimumBytes); err != nil {
+		_ = os.Remove(tmpPath)
+		return preparedRootFS{}, fmt.Errorf("resize prepared runtime rootfs %q: %w", tmpPath, err)
+	}
 	if err := validatePreparedRuntimeRootFS(tmpPath); err != nil {
 		_ = os.Remove(tmpPath)
 		return preparedRootFS{}, fmt.Errorf("validate prepared runtime rootfs %q: %w", tmpPath, err)
@@ -2139,7 +2238,7 @@ func (a *Adapter) ensurePreparedRuntimeRootFSFromImage(ctx context.Context, imag
 	if err := os.Rename(tmpPath, preparedPath); err != nil {
 		_ = os.Remove(tmpPath)
 		if _, statErr := os.Stat(preparedPath); statErr == nil {
-			if validateErr := validatePreparedRuntimeRootFS(preparedPath); validateErr == nil {
+			if preparedRuntimeRootFSCacheHitIsValid(preparedPath, minimumBytes) {
 				_ = writePreparedRuntimeRootFSMarker(preparedPath)
 				return preparedRootFS{
 					Ref:    artifact.Ref,
@@ -2166,7 +2265,10 @@ var preparedRuntimeRootFSRequiredPaths = []string{
 	guestAgentPath,
 }
 
-var validatePreparedRuntimeRootFSFn = validatePreparedRuntimeRootFS
+var (
+	validatePreparedRuntimeRootFSFn        = validatePreparedRuntimeRootFS
+	ensurePreparedRuntimeRootFSMinimumSize = ext4image.EnsureMinimumSize
+)
 
 func validatePreparedRuntimeRootFS(path string) error {
 	for _, requiredPath := range preparedRuntimeRootFSRequiredPaths {
@@ -2191,7 +2293,10 @@ type preparedRuntimeRootFSMarkerState struct {
 	changeTimeNanos int64
 }
 
-func preparedRuntimeRootFSCacheHitIsValid(path string) bool {
+func preparedRuntimeRootFSCacheHitIsValid(path string, minimumBytes int64) bool {
+	if !preparedRuntimeRootFSMeetsMinimum(path, minimumBytes) {
+		return false
+	}
 	if preparedRuntimeRootFSMarkerMatches(path) {
 		return true
 	}
@@ -2200,6 +2305,17 @@ func preparedRuntimeRootFSCacheHitIsValid(path string) bool {
 	}
 	_ = writePreparedRuntimeRootFSMarker(path)
 	return true
+}
+
+func preparedRuntimeRootFSMeetsMinimum(path string, minimumBytes int64) bool {
+	if minimumBytes <= 0 {
+		return true
+	}
+	currentBytes, _, err := ext4image.PathSizeBytes(path)
+	if err != nil {
+		return false
+	}
+	return currentBytes >= minimumBytes
 }
 
 func preparedRuntimeRootFSMarkerPath(path string) string {
@@ -2269,18 +2385,34 @@ func writePreparedRuntimeRootFSMarker(path string) error {
 	return nil
 }
 
-func preparedRuntimeRootFSPath(imageDigest, guestAgentHash string) (string, error) {
+func preparedRuntimeRootFSPath(imageDigest, guestAgentHash string, minimumBytes int64) (string, error) {
 	cacheBase, err := paths.CacheBaseDir()
 	if err != nil {
 		return "", fmt.Errorf("resolve cache base directory: %w", err)
 	}
-	key := runtimeRootFSCacheKey(imageDigest, guestAgentHash)
+	key := runtimeRootFSCacheKey(imageDigest, guestAgentHash, minimumBytes)
 	return filepath.Join(cacheBase, "darwin-vz", "runtime-rootfs", key+".ext4"), nil
 }
 
-func runtimeRootFSCacheKey(imageDigest, guestAgentHash string) string {
-	sum := sha256.Sum256([]byte(strings.TrimSpace(imageDigest) + "|" + guestAgentHash + "|" + runtime.GOARCH + "|" + preparedRuntimeRootFSVersion + "|" + guestInitScriptTemplate))
+func runtimeRootFSCacheKey(imageDigest, guestAgentHash string, minimumBytes int64) string {
+	keyMaterial := strings.TrimSpace(imageDigest) + "|" + guestAgentHash + "|" + runtime.GOARCH + "|" + preparedRuntimeRootFSVersion + "|" + guestInitScriptTemplate + rootFSMinimumCacheKeySuffix(minimumBytes)
+	sum := sha256.Sum256([]byte(keyMaterial))
 	return hex.EncodeToString(sum[:])
+}
+
+func rootFSMinimumCacheKeySuffix(minimumBytes int64) string {
+	normalized := normalizedRootFSMinimumBytes(minimumBytes)
+	if normalized <= 0 {
+		return ""
+	}
+	return "|minimum_rootfs_bytes:" + strconv.FormatInt(normalized, 10)
+}
+
+func normalizedRootFSMinimumBytes(minimumBytes int64) int64 {
+	if minimumBytes <= 0 {
+		return 0
+	}
+	return ext4image.AlignBytes(minimumBytes)
 }
 
 func (a *Adapter) ensureImageArtifact(ctx context.Context, imageRef string) (imageArtifact, error) {

--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -214,6 +214,60 @@ func (a *Adapter) recordLaunchPhaseMetrics(ctx context.Context, observation darw
 	}
 }
 
+func (a *Adapter) recordLaunchPhaseObservability(ctx context.Context, observation darwinVZRunObservation) {
+	a.recordLaunchPhaseMetrics(ctx, observation)
+	recordLaunchPhaseTraceEvents(ctx, a.Name(), observation)
+}
+
+type darwinVZLaunchPhaseDuration struct {
+	Phase      string
+	DurationMS int64
+}
+
+func recordLaunchPhaseTraceEvents(ctx context.Context, backendName string, observation darwinVZRunObservation) {
+	span := trace.SpanFromContext(ctx)
+	if !span.IsRecording() {
+		return
+	}
+	for _, phase := range darwinVZLaunchPhaseDurations(observation) {
+		span.AddEvent(
+			observability.EventLaunchPhase,
+			trace.WithAttributes(
+				attribute.String(observability.AttrBackend, backendName),
+				attribute.String(observability.AttrLaunchPhase, phase.Phase),
+				attribute.Int64(observability.AttrLaunchPhaseDurationMS, phase.DurationMS),
+			),
+		)
+	}
+}
+
+func darwinVZLaunchPhaseDurations(observation darwinVZRunObservation) []darwinVZLaunchPhaseDuration {
+	phases := make([]darwinVZLaunchPhaseDuration, 0, len(observation.HelperTimingMS)+2)
+	if observation.RootFSCopyMS > 0 {
+		phases = append(phases, darwinVZLaunchPhaseDuration{Phase: "rootfs_prepare", DurationMS: observation.RootFSCopyMS})
+	}
+	if observation.VMReadyMS > 0 {
+		phases = append(phases, darwinVZLaunchPhaseDuration{Phase: "guest_wait_ready", DurationMS: observation.VMReadyMS})
+	}
+	helperPhases := make([]string, 0, len(observation.HelperTimingMS))
+	for phase := range observation.HelperTimingMS {
+		helperPhases = append(helperPhases, phase)
+	}
+	sort.Strings(helperPhases)
+	for _, phase := range helperPhases {
+		durationMS := observation.HelperTimingMS[phase]
+		if durationMS <= 0 {
+			continue
+		}
+		phase = strings.TrimSpace(phase)
+		if phase == "" {
+			continue
+		}
+		phases = append(phases, darwinVZLaunchPhaseDuration{Phase: "helper_" + phase, DurationMS: durationMS})
+	}
+	return phases
+}
+
 func commandCombinedOutput(ctx context.Context, name string, args ...string) ([]byte, error) {
 	return exec.CommandContext(ctx, name, args...).CombinedOutput()
 }
@@ -470,8 +524,12 @@ func (a *Adapter) RunInSandbox(ctx context.Context, req backend.ExecutionRequest
 		PlanPath:    instance.ConfigPath,
 	}
 	applyDarwinVZNetworkMetadata(&observation, instance.NetworkMetadata)
+	launchObservabilityRecorded := false
 	a.sandboxMu.Lock()
 	if current, ok := a.sandboxes[sandboxID]; ok && current == instance {
+		if current.LaunchObservability != nil {
+			launchObservabilityRecorded = current.LaunchObservability.Recorded
+		}
 		applyDarwinVZLaunchObservability(&observation, current.LaunchObservability)
 		current.LaunchObservability = nil
 	}
@@ -481,7 +539,9 @@ func (a *Adapter) RunInSandbox(ctx context.Context, req backend.ExecutionRequest
 		if err := writeDarwinVZRunObservation(runDir, &observation, time.Since(runStart).Milliseconds()); err != nil {
 			log.Warn("write darwin-vz run observability failed", "execution_id", req.ExecutionID, "error", err)
 		}
-		a.recordLaunchPhaseMetrics(ctx, observation)
+		if !launchObservabilityRecorded {
+			a.recordLaunchPhaseObservability(ctx, observation)
+		}
 	}()
 
 	connectSeconds := req.LaunchSeconds
@@ -984,6 +1044,7 @@ func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream 
 		if err := writeDarwinVZRunObservation(runDir, &observation, time.Since(runStart).Milliseconds()); err != nil {
 			log.Warn("write darwin-vz run observability failed", "execution_id", req.ExecutionID, "error", err)
 		}
+		a.recordLaunchPhaseObservability(ctx, observation)
 	}()
 
 	if req.VCPUs <= 0 {
@@ -1579,11 +1640,20 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 	recordDarwinVZPhaseTiming(launchTimingMS, darwinVZTimingLaunchSandboxTotal, launchStart)
 	helperTimingMS := mergeHelperTimingMS(launchTimingMS, rootFSTimingMS)
 	helperTimingMS = mergeHelperTimingMS(helperTimingMS, startedVM.TimingMS)
-	instance.LaunchObservability = &darwinVZLaunchObservability{
+	launchObservability := &darwinVZLaunchObservability{
 		RootFSCopyMS:   rootFSCopyMS,
 		HelperTimingMS: helperTimingMS,
 		Network:        startedVM.NetworkMetadata,
 	}
+	a.recordLaunchPhaseObservability(ctx, darwinVZRunObservation{
+		Backend:        a.Name(),
+		LaunchedVM:     true,
+		RootFSCopyMS:   launchObservability.RootFSCopyMS,
+		VMReadyMS:      launchObservability.HelperTimingMS["vm_ready"],
+		HelperTimingMS: launchObservability.HelperTimingMS,
+	})
+	launchObservability.Recorded = true
+	instance.LaunchObservability = launchObservability
 
 	cacheOutputsNeedCleanup = false
 	helperNeedsClose = false

--- a/internal/backend/darwinvz/observability_test.go
+++ b/internal/backend/darwinvz/observability_test.go
@@ -31,16 +31,22 @@ func TestWriteDarwinVZRunObservationIncludesHelperTimings(t *testing.T) {
 	t.Parallel()
 
 	runDir := t.TempDir()
+	helperTimingMS := map[string]int64{
+		"vm_ready":    321,
+		"proxy_ready": 45,
+	}
+	helperTimingMS[darwinVZTimingRootFSBaseVolumePrepare] = 11
+	helperTimingMS[darwinVZTimingRootFSWritableVolumeCreateClone] = 12
+	helperTimingMS[darwinVZTimingRootFSMinimumSizeResize] = 13
+	helperTimingMS[darwinVZTimingRootFSInspectValidate] = 14
+
 	obs := darwinVZRunObservation{
-		ExecutionID:  "run-123",
-		Backend:      "darwin-vz",
-		LaunchedVM:   true,
-		RunDir:       runDir,
-		RootFSCopyMS: 27,
-		HelperTimingMS: map[string]int64{
-			"vm_ready":    321,
-			"proxy_ready": 45,
-		},
+		ExecutionID:    "run-123",
+		Backend:        "darwin-vz",
+		LaunchedVM:     true,
+		RunDir:         runDir,
+		RootFSCopyMS:   27,
+		HelperTimingMS: helperTimingMS,
 	}
 	applyDarwinVZHelperTimings(&obs, obs.HelperTimingMS)
 
@@ -79,6 +85,44 @@ func TestWriteDarwinVZRunObservationIncludesHelperTimings(t *testing.T) {
 	}
 	if got, want := helperTimingPayload["vm_ready"], float64(321); got != want {
 		t.Fatalf("unexpected helper_timing_ms.vm_ready: got %v want %v", got, want)
+	}
+	if got, want := helperTimingPayload[darwinVZTimingRootFSBaseVolumePrepare], float64(11); got != want {
+		t.Fatalf("unexpected helper_timing_ms.%s: got %v want %v", darwinVZTimingRootFSBaseVolumePrepare, got, want)
+	}
+	if got, want := helperTimingPayload[darwinVZTimingRootFSWritableVolumeCreateClone], float64(12); got != want {
+		t.Fatalf("unexpected helper_timing_ms.%s: got %v want %v", darwinVZTimingRootFSWritableVolumeCreateClone, got, want)
+	}
+	if got, want := helperTimingPayload[darwinVZTimingRootFSMinimumSizeResize], float64(13); got != want {
+		t.Fatalf("unexpected helper_timing_ms.%s: got %v want %v", darwinVZTimingRootFSMinimumSizeResize, got, want)
+	}
+	if got, want := helperTimingPayload[darwinVZTimingRootFSInspectValidate], float64(14); got != want {
+		t.Fatalf("unexpected helper_timing_ms.%s: got %v want %v", darwinVZTimingRootFSInspectValidate, got, want)
+	}
+}
+
+func TestApplyDarwinVZHelperTimingsMergesRootFSPhaseTimings(t *testing.T) {
+	t.Parallel()
+
+	obs := darwinVZRunObservation{}
+	rootFSTimingMS := map[string]int64{
+		darwinVZTimingRootFSBaseVolumePrepare: 11,
+	}
+	applyDarwinVZHelperTimings(&obs, rootFSTimingMS)
+
+	helperTimingMS := map[string]int64{
+		"vm_ready": 321,
+	}
+	applyDarwinVZHelperTimings(&obs, helperTimingMS)
+	helperTimingMS["vm_ready"] = 1
+
+	if got, want := obs.HelperTimingMS[darwinVZTimingRootFSBaseVolumePrepare], int64(11); got != want {
+		t.Fatalf("unexpected rootfs phase timing: got %v want %v", got, want)
+	}
+	if got, want := obs.HelperTimingMS["vm_ready"], int64(321); got != want {
+		t.Fatalf("unexpected vm_ready helper timing: got %v want %v", got, want)
+	}
+	if got, want := obs.VMReadyMS, int64(321); got != want {
+		t.Fatalf("unexpected VMReadyMS: got %v want %v", got, want)
 	}
 }
 
@@ -153,7 +197,8 @@ func TestRunInSandboxWritesObservabilityWithPendingLaunchTimings(t *testing.T) {
 				LaunchObservability: &darwinVZLaunchObservability{
 					RootFSCopyMS: 27,
 					HelperTimingMS: map[string]int64{
-						"vm_ready": 321,
+						"vm_ready":                            321,
+						darwinVZTimingRootFSBaseVolumePrepare: 11,
 					},
 					Network: &darwinVZNetworkMetadata{
 						Mode:       darwinVZNetworkModeFileHandle,
@@ -193,6 +238,13 @@ func TestRunInSandboxWritesObservabilityWithPendingLaunchTimings(t *testing.T) {
 	}
 	if got, want := payload["rootfs_copy_ms"], float64(27); got != want {
 		t.Fatalf("unexpected rootfs_copy_ms: got %v want %v", got, want)
+	}
+	helperTimingPayload, ok := payload["helper_timing_ms"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected helper_timing_ms object, got %T", payload["helper_timing_ms"])
+	}
+	if got, want := helperTimingPayload[darwinVZTimingRootFSBaseVolumePrepare], float64(11); got != want {
+		t.Fatalf("unexpected helper_timing_ms.%s: got %v want %v", darwinVZTimingRootFSBaseVolumePrepare, got, want)
 	}
 	if got, want := payload["network_guest_ip"], "10.233.0.2"; got != want {
 		t.Fatalf("unexpected network_guest_ip: got %v want %v", got, want)

--- a/internal/backend/darwinvz/observability_test.go
+++ b/internal/backend/darwinvz/observability_test.go
@@ -5,12 +5,16 @@ package darwinvz
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/observability"
 	"github.com/buildkite/cleanroom/internal/policy"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 func TestDarwinVZTimingSummaryIncludesHelperTimings(t *testing.T) {
@@ -124,6 +128,36 @@ func TestApplyDarwinVZHelperTimingsMergesRootFSPhaseTimings(t *testing.T) {
 	if got, want := obs.VMReadyMS, int64(321); got != want {
 		t.Fatalf("unexpected VMReadyMS: got %v want %v", got, want)
 	}
+}
+
+func TestRecordLaunchPhaseObservabilityAddsTraceEvents(t *testing.T) {
+	t.Parallel()
+
+	recorder := tracetest.NewSpanRecorder()
+	tracerProvider := sdktrace.NewTracerProvider()
+	tracerProvider.RegisterSpanProcessor(recorder)
+	defer func() { _ = tracerProvider.Shutdown(context.Background()) }()
+
+	ctx, span := tracerProvider.Tracer("test").Start(context.Background(), "cleanroom.test")
+	adapter := &Adapter{}
+	adapter.recordLaunchPhaseObservability(ctx, darwinVZRunObservation{
+		RootFSCopyMS: 27,
+		VMReadyMS:    321,
+		HelperTimingMS: map[string]int64{
+			darwinVZTimingGuestExecReadyProbe: 401,
+			"zero":                            0,
+		},
+	})
+	span.End()
+
+	spans := recorder.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("expected one ended span, got %d", len(spans))
+	}
+	requireLaunchPhaseEvent(t, spans[0], "rootfs_prepare", "27")
+	requireLaunchPhaseEvent(t, spans[0], "guest_wait_ready", "321")
+	requireLaunchPhaseEvent(t, spans[0], "helper_"+darwinVZTimingGuestExecReadyProbe, "401")
+	requireNoLaunchPhaseEvent(t, spans[0], "helper_zero")
 }
 
 func TestWriteDarwinVZRunObservationIncludesNetworkMetadata(t *testing.T) {
@@ -249,6 +283,39 @@ func TestRunInSandboxWritesObservabilityWithPendingLaunchTimings(t *testing.T) {
 	if got, want := payload["network_guest_ip"], "10.233.0.2"; got != want {
 		t.Fatalf("unexpected network_guest_ip: got %v want %v", got, want)
 	}
+}
+
+func requireLaunchPhaseEvent(t *testing.T, span sdktrace.ReadOnlySpan, phase, durationMS string) {
+	t.Helper()
+	for _, event := range span.Events() {
+		if event.Name != observability.EventLaunchPhase {
+			continue
+		}
+		if eventAttributeValue(event, observability.AttrLaunchPhase) == phase &&
+			eventAttributeValue(event, observability.AttrLaunchPhaseDurationMS) == durationMS &&
+			eventAttributeValue(event, observability.AttrBackend) == "darwin-vz" {
+			return
+		}
+	}
+	t.Fatalf("expected launch phase event phase=%q duration_ms=%q, got events %#v", phase, durationMS, span.Events())
+}
+
+func requireNoLaunchPhaseEvent(t *testing.T, span sdktrace.ReadOnlySpan, phase string) {
+	t.Helper()
+	for _, event := range span.Events() {
+		if event.Name == observability.EventLaunchPhase && eventAttributeValue(event, observability.AttrLaunchPhase) == phase {
+			t.Fatalf("unexpected launch phase event phase=%q", phase)
+		}
+	}
+}
+
+func eventAttributeValue(event sdktrace.Event, key string) string {
+	for _, attr := range event.Attributes {
+		if string(attr.Key) == key {
+			return fmt.Sprint(attr.Value.AsInterface())
+		}
+	}
+	return ""
 }
 
 func TestRunWritesObservabilityErrorWhenRequestedCommandWriteFails(t *testing.T) {

--- a/internal/backend/darwinvz/pid_lookup_test.go
+++ b/internal/backend/darwinvz/pid_lookup_test.go
@@ -1,0 +1,119 @@
+//go:build darwin
+
+package darwinvz
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestVirtualizationProcessPIDLookupRunsAsynchronously(t *testing.T) {
+	restoreNetworkProcessLookupGlobals(t)
+
+	var startedOnce sync.Once
+	lsofStarted := make(chan struct{})
+	releaseLsof := make(chan struct{})
+	networkProcessLookupTimeout = time.Second
+	networkProcessLookPath = func(name string) (string, error) {
+		return "/test/bin/" + name, nil
+	}
+	networkProcessCombinedOutput = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		switch {
+		case strings.HasSuffix(name, "/lsof"):
+			startedOnce.Do(func() { close(lsofStarted) })
+			select {
+			case <-releaseLsof:
+				return []byte("4321\n"), nil
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		case strings.HasSuffix(name, "/ps"):
+			return []byte(virtualizationNetworkProcessPath + "\n"), nil
+		default:
+			t.Fatalf("unexpected command %q args=%v", name, args)
+			return nil, nil
+		}
+	}
+
+	lookup := startVirtualizationProcessPIDLookup(context.Background(), "/tmp/rootfs.ext4")
+	defer lookup.stop()
+
+	select {
+	case <-lsofStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for async lsof lookup to start")
+	}
+
+	select {
+	case result := <-lookup.resultCh:
+		t.Fatalf("pid lookup finished before lsof was released: %#v", result)
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	close(releaseLsof)
+	result := lookup.wait()
+	if result.err != nil {
+		t.Fatalf("pid lookup returned error: %v", result.err)
+	}
+	if got, want := result.pid, 4321; got != want {
+		t.Fatalf("unexpected pid: got %d want %d", got, want)
+	}
+	if result.duration < 25*time.Millisecond {
+		t.Fatalf("lookup duration was not measured across the blocked lsof call: %s", result.duration)
+	}
+}
+
+func TestVirtualizationProcessPIDLookupStopCancelsLookup(t *testing.T) {
+	restoreNetworkProcessLookupGlobals(t)
+
+	var startedOnce sync.Once
+	lsofStarted := make(chan struct{})
+	networkProcessLookupTimeout = time.Second
+	networkProcessLookPath = func(name string) (string, error) {
+		return "/test/bin/" + name, nil
+	}
+	networkProcessCombinedOutput = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		if !strings.HasSuffix(name, "/lsof") {
+			t.Fatalf("unexpected command %q args=%v", name, args)
+		}
+		startedOnce.Do(func() { close(lsofStarted) })
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+
+	lookup := startVirtualizationProcessPIDLookup(context.Background(), "/tmp/rootfs.ext4")
+	select {
+	case <-lsofStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for async lsof lookup to start")
+	}
+	lookup.stop()
+
+	select {
+	case result := <-lookup.resultCh:
+		if !errors.Is(result.err, context.Canceled) {
+			t.Fatalf("expected canceled lookup, got %v", result.err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for canceled lookup to finish")
+	}
+}
+
+func restoreNetworkProcessLookupGlobals(t *testing.T) {
+	t.Helper()
+
+	origLookPath := networkProcessLookPath
+	origCombinedOutput := networkProcessCombinedOutput
+	origTimeout := networkProcessLookupTimeout
+	origPollInterval := networkProcessLookupPollInterval
+	t.Cleanup(func() {
+		networkProcessLookPath = origLookPath
+		networkProcessCombinedOutput = origCombinedOutput
+		networkProcessLookupTimeout = origTimeout
+		networkProcessLookupPollInterval = origPollInterval
+	})
+}

--- a/internal/backend/darwinvz/rootfs_cache_marker_test.go
+++ b/internal/backend/darwinvz/rootfs_cache_marker_test.go
@@ -24,7 +24,7 @@ func TestPreparedRuntimeRootFSCacheHitUsesValidMarkerWithoutExt4Validation(t *te
 	})
 	defer restore()
 
-	if !preparedRuntimeRootFSCacheHitIsValid(rootFSPath) {
+	if !preparedRuntimeRootFSCacheHitIsValid(rootFSPath, 0) {
 		t.Fatal("expected prepared rootfs cache hit to be valid")
 	}
 	if validateCalls != 0 {
@@ -42,7 +42,7 @@ func TestPreparedRuntimeRootFSCacheHitValidatesAndMarksWhenMarkerMissing(t *test
 	})
 	defer restore()
 
-	if !preparedRuntimeRootFSCacheHitIsValid(rootFSPath) {
+	if !preparedRuntimeRootFSCacheHitIsValid(rootFSPath, 0) {
 		t.Fatal("expected prepared rootfs cache hit to be valid after validation")
 	}
 	if validateCalls != 1 {
@@ -52,7 +52,7 @@ func TestPreparedRuntimeRootFSCacheHitValidatesAndMarksWhenMarkerMissing(t *test
 		t.Fatalf("expected prepared rootfs marker to be written: %v", err)
 	}
 
-	if !preparedRuntimeRootFSCacheHitIsValid(rootFSPath) {
+	if !preparedRuntimeRootFSCacheHitIsValid(rootFSPath, 0) {
 		t.Fatal("expected marked prepared rootfs cache hit to remain valid")
 	}
 	if validateCalls != 1 {
@@ -76,7 +76,7 @@ func TestPreparedRuntimeRootFSCacheHitRevalidatesStaleMarker(t *testing.T) {
 	})
 	defer restore()
 
-	if !preparedRuntimeRootFSCacheHitIsValid(rootFSPath) {
+	if !preparedRuntimeRootFSCacheHitIsValid(rootFSPath, 0) {
 		t.Fatal("expected stale marker to be refreshed after validation")
 	}
 	if validateCalls != 1 {
@@ -110,7 +110,7 @@ func TestPreparedRuntimeRootFSCacheHitRevalidatesWhenContentsChangeWithPreserved
 	})
 	defer restore()
 
-	if !preparedRuntimeRootFSCacheHitIsValid(rootFSPath) {
+	if !preparedRuntimeRootFSCacheHitIsValid(rootFSPath, 0) {
 		t.Fatal("expected marker with changed contents to be refreshed after validation")
 	}
 	if validateCalls != 1 {
@@ -162,7 +162,7 @@ func TestPreparedRuntimeRootFSCacheHitRejectsInvalidPreparedRootFS(t *testing.T)
 	})
 	defer restore()
 
-	if preparedRuntimeRootFSCacheHitIsValid(rootFSPath) {
+	if preparedRuntimeRootFSCacheHitIsValid(rootFSPath, 0) {
 		t.Fatal("expected invalid prepared rootfs cache hit to be rejected")
 	}
 	if validateCalls != 1 {
@@ -170,6 +170,27 @@ func TestPreparedRuntimeRootFSCacheHitRejectsInvalidPreparedRootFS(t *testing.T)
 	}
 	if _, err := os.Stat(preparedRuntimeRootFSMarkerPath(rootFSPath)); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("expected marker not to be written, got err=%v", err)
+	}
+}
+
+func TestPreparedRuntimeRootFSCacheHitRejectsRootFSBelowMinimum(t *testing.T) {
+	rootFSPath := writeTestPreparedRootFS(t, "prepared-rootfs")
+	if err := writePreparedRuntimeRootFSMarker(rootFSPath); err != nil {
+		t.Fatalf("write prepared rootfs marker: %v", err)
+	}
+
+	validateCalls := 0
+	restore := stubPreparedRuntimeRootFSValidator(t, func(string) error {
+		validateCalls++
+		return nil
+	})
+	defer restore()
+
+	if preparedRuntimeRootFSCacheHitIsValid(rootFSPath, 1<<20) {
+		t.Fatal("expected prepared rootfs below minimum to be rejected")
+	}
+	if validateCalls != 0 {
+		t.Fatalf("expected size check to reject before validation, got %d validation calls", validateCalls)
 	}
 }
 

--- a/internal/backend/darwinvz/rootfs_test.go
+++ b/internal/backend/darwinvz/rootfs_test.go
@@ -53,10 +53,12 @@ func TestResolveRootFSPathDerivesFromPolicyImageRef(t *testing.T) {
 	t.Parallel()
 
 	adapter := New()
-	adapter.ensurePreparedRootFSFn = func(_ context.Context, imageRef string) (preparedRootFS, error) {
+	var gotMinimumBytes int64
+	adapter.ensurePreparedRootFSFn = func(_ context.Context, imageRef string, minimumBytes int64) (preparedRootFS, error) {
 		if got, want := imageRef, "ghcr.io/buildkite/cleanroom-base/alpine@sha256:def"; got != want {
 			t.Fatalf("unexpected image ref: got %q want %q", got, want)
 		}
+		gotMinimumBytes = minimumBytes
 		return preparedRootFS{
 			Ref:    imageRef,
 			Digest: "sha256:def",
@@ -68,6 +70,9 @@ func TestResolveRootFSPathDerivesFromPolicyImageRef(t *testing.T) {
 	req := backend.ExecutionRequest{
 		Policy: &policy.CompiledPolicy{
 			ImageRef: "ghcr.io/buildkite/cleanroom-base/alpine@sha256:def",
+		},
+		FirecrackerConfig: backend.FirecrackerConfig{
+			MinimumRootFSBytes: 9 << 20,
 		},
 	}
 
@@ -86,6 +91,9 @@ func TestResolveRootFSPathDerivesFromPolicyImageRef(t *testing.T) {
 	}
 	if notice == "" {
 		t.Fatal("expected non-empty derivation notice")
+	}
+	if got, want := gotMinimumBytes, int64(9<<20); got != want {
+		t.Fatalf("unexpected minimum rootfs bytes: got %d want %d", got, want)
 	}
 }
 
@@ -106,7 +114,10 @@ func TestResolveRootFSPathFallsBackWhenConfiguredRootFSMissing(t *testing.T) {
 	t.Parallel()
 
 	adapter := New()
-	adapter.ensurePreparedRootFSFn = func(_ context.Context, imageRef string) (preparedRootFS, error) {
+	adapter.ensurePreparedRootFSFn = func(_ context.Context, imageRef string, minimumBytes int64) (preparedRootFS, error) {
+		if minimumBytes != 0 {
+			t.Fatalf("unexpected minimum rootfs bytes: got %d want 0", minimumBytes)
+		}
 		return preparedRootFS{
 			Ref:    imageRef,
 			Digest: "sha256:xyz",
@@ -136,5 +147,58 @@ func TestResolveRootFSPathFallsBackWhenConfiguredRootFSMissing(t *testing.T) {
 	}
 	if notice == "" {
 		t.Fatal("expected fallback notice")
+	}
+}
+
+func TestRuntimeRootFSCacheKeyIncludesAlignedMinimumRootFSBytes(t *testing.T) {
+	t.Parallel()
+
+	baseKey := runtimeRootFSCacheKey("sha256:def", "guest-agent", 0)
+	minimumKey := runtimeRootFSCacheKey("sha256:def", "guest-agent", (9<<20)+1)
+	alignedEquivalentKey := runtimeRootFSCacheKey("sha256:def", "guest-agent", 12<<20)
+
+	if baseKey == minimumKey {
+		t.Fatal("expected minimum rootfs bytes to change prepared rootfs cache key")
+	}
+	if minimumKey != alignedEquivalentKey {
+		t.Fatalf("expected cache key to use aligned minimum size: got %q want %q", minimumKey, alignedEquivalentKey)
+	}
+}
+
+func TestRuntimeBaseKeyIncludesConfiguredRootFSMinimumRootFSBytes(t *testing.T) {
+	t.Parallel()
+
+	configuredPath := filepath.Join(t.TempDir(), "rootfs.ext4")
+	if err := os.WriteFile(configuredPath, []byte("fake-ext4"), 0o644); err != nil {
+		t.Fatalf("write configured rootfs: %v", err)
+	}
+
+	adapter := New()
+	baseKey, err := adapter.RuntimeBaseKey(context.Background(), &policy.CompiledPolicy{}, backend.FirecrackerConfig{
+		RootFSPath: configuredPath,
+	})
+	if err != nil {
+		t.Fatalf("RuntimeBaseKey without minimum returned error: %v", err)
+	}
+	minimumKey, err := adapter.RuntimeBaseKey(context.Background(), &policy.CompiledPolicy{}, backend.FirecrackerConfig{
+		RootFSPath:         configuredPath,
+		MinimumRootFSBytes: 9 << 20,
+	})
+	if err != nil {
+		t.Fatalf("RuntimeBaseKey with minimum returned error: %v", err)
+	}
+	alignedEquivalentKey, err := adapter.RuntimeBaseKey(context.Background(), &policy.CompiledPolicy{}, backend.FirecrackerConfig{
+		RootFSPath:         configuredPath,
+		MinimumRootFSBytes: 12 << 20,
+	})
+	if err != nil {
+		t.Fatalf("RuntimeBaseKey with aligned minimum returned error: %v", err)
+	}
+
+	if baseKey == minimumKey {
+		t.Fatal("expected configured rootfs runtime base key to include minimum rootfs bytes")
+	}
+	if minimumKey != alignedEquivalentKey {
+		t.Fatalf("expected configured rootfs runtime base key to align minimum size: got %q want %q", minimumKey, alignedEquivalentKey)
 	}
 }

--- a/internal/backend/darwinvz/vm_launch.go
+++ b/internal/backend/darwinvz/vm_launch.go
@@ -19,6 +19,7 @@ type darwinVZLaunchObservability struct {
 	RootFSCopyMS   int64
 	HelperTimingMS map[string]int64
 	Network        *darwinVZNetworkMetadata
+	Recorded       bool
 }
 
 const (

--- a/internal/backend/darwinvz/vm_launch.go
+++ b/internal/backend/darwinvz/vm_launch.go
@@ -21,6 +21,26 @@ type darwinVZLaunchObservability struct {
 	Network        *darwinVZNetworkMetadata
 }
 
+const (
+	darwinVZTimingLaunchPolicyValidate            = "launch_policy_validate"
+	darwinVZTimingKernelResolve                   = "kernel_resolve"
+	darwinVZTimingRootFSResolve                   = "rootfs_resolve"
+	darwinVZTimingRunDirPrepare                   = "run_dir_prepare"
+	darwinVZTimingRootFSPreflight                 = "rootfs_preflight"
+	darwinVZTimingRootFSBaseVolumePrepare         = "rootfs_base_volume_prepare"
+	darwinVZTimingRootFSWritableVolumeCreateClone = "rootfs_writable_volume_create_clone"
+	darwinVZTimingRootFSMinimumSizeResize         = "rootfs_minimum_size_resize"
+	darwinVZTimingRootFSInspectValidate           = "rootfs_inspect_validate"
+	darwinVZTimingGuestBootConfig                 = "guest_boot_config"
+	darwinVZTimingHelperSessionStart              = "helper_session_start"
+	darwinVZTimingCacheOutputPrepare              = "cache_output_prepare"
+	darwinVZTimingHelperStartVM                   = "helper_start_vm"
+	darwinVZTimingVirtualizationPIDLookup         = "virtualization_pid_lookup"
+	darwinVZTimingGuestExecReadyProbe             = "guest_exec_ready_probe"
+	darwinVZTimingLaunchSandboxTotal              = "launch_sandbox_total"
+	darwinVZRootFSTimingExpectedPhaseCount        = 4
+)
+
 type darwinVZNetworkMetadata struct {
 	Mode       string
 	SubnetCIDR string
@@ -233,7 +253,7 @@ func applyDarwinVZHelperTimings(observation *darwinVZRunObservation, timingMS ma
 	if observation == nil || len(timingMS) == 0 {
 		return
 	}
-	observation.HelperTimingMS = cloneHelperTimingMS(timingMS)
+	observation.HelperTimingMS = mergeHelperTimingMS(observation.HelperTimingMS, timingMS)
 	if vmReadyMS, ok := timingMS["vm_ready"]; ok {
 		observation.VMReadyMS = vmReadyMS
 	}
@@ -290,6 +310,34 @@ func cloneHelperTimingMS(timingMS map[string]int64) map[string]int64 {
 		out[key] = value
 	}
 	return out
+}
+
+func mergeHelperTimingMS(dst, src map[string]int64) map[string]int64 {
+	if len(src) == 0 {
+		return cloneHelperTimingMS(dst)
+	}
+	out := make(map[string]int64, len(dst)+len(src))
+	for key, value := range dst {
+		out[key] = value
+	}
+	for key, value := range src {
+		out[key] = value
+	}
+	return out
+}
+
+func recordDarwinVZPhaseTiming(timingMS map[string]int64, phase string, start time.Time) {
+	if timingMS == nil {
+		return
+	}
+	timingMS[phase] = time.Since(start).Milliseconds()
+}
+
+func recordDarwinVZPhaseTimingDuration(timingMS map[string]int64, phase string, duration time.Duration) {
+	if timingMS == nil {
+		return
+	}
+	timingMS[phase] = duration.Milliseconds()
 }
 
 func writeJSON(path string, v any) error {

--- a/internal/cli/image_override.go
+++ b/internal/cli/image_override.go
@@ -117,11 +117,6 @@ var (
 	}
 	resolveReferenceForImageOverride = func(ctx context.Context, source string, allowLocal bool) (string, error) {
 		if digestRef, err := ociref.ParseDigestReference(source); err == nil && digestReferenceHasExplicitRegistryHost(digestRef) {
-			if allowLocal {
-				if err := validateImageOverridePlatform(ctx, source, digestRef.Original); err != nil {
-					return "", err
-				}
-			}
 			return digestRef.Original, nil
 		}
 

--- a/internal/cli/image_override_resolution_test.go
+++ b/internal/cli/image_override_resolution_test.go
@@ -168,7 +168,7 @@ func TestResolveReferenceForImageOverrideReturnsExplicitRegistryDigestWithoutRes
 	}
 }
 
-func TestResolveReferenceForImageOverrideValidatesExplicitRegistryDigestPlatform(t *testing.T) {
+func TestResolveReferenceForImageOverrideSkipsExplicitRegistryDigestPlatformValidation(t *testing.T) {
 	localCalls := 0
 	remoteCalls := 0
 	platformCalls := 0
@@ -189,18 +189,15 @@ func TestResolveReferenceForImageOverrideValidatesExplicitRegistryDigestPlatform
 		if got, want := ref.Name(), pinnedRef; got != want {
 			t.Fatalf("unexpected platform resolver ref: got %q want %q", got, want)
 		}
-		if runtime.GOARCH == "arm64" {
-			return "linux", "amd64", nil
-		}
-		return "linux", "arm64", nil
+		return "", "", errors.New("platform resolver should not be called")
 	}
 
-	_, err := resolveReferenceForImageOverride(context.Background(), pinnedRef, true)
-	if err == nil {
-		t.Fatal("expected resolveReferenceForImageOverride to reject mismatched platform")
+	got, err := resolveReferenceForImageOverride(context.Background(), pinnedRef, true)
+	if err != nil {
+		t.Fatalf("resolveReferenceForImageOverride returned error: %v", err)
 	}
-	if !strings.Contains(err.Error(), "incompatible") {
-		t.Fatalf("expected platform mismatch error, got %v", err)
+	if got != pinnedRef {
+		t.Fatalf("unexpected resolved ref: got %q want %q", got, pinnedRef)
 	}
 	if localCalls != 0 {
 		t.Fatalf("expected local resolver call count 0, got %d", localCalls)
@@ -208,8 +205,8 @@ func TestResolveReferenceForImageOverrideValidatesExplicitRegistryDigestPlatform
 	if remoteCalls != 0 {
 		t.Fatalf("expected remote resolver call count 0, got %d", remoteCalls)
 	}
-	if platformCalls != 1 {
-		t.Fatalf("expected platform resolver call count 1, got %d", platformCalls)
+	if platformCalls != 0 {
+		t.Fatalf("expected platform resolver call count 0, got %d", platformCalls)
 	}
 }
 

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -978,17 +978,21 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 		)
 	}
 	emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_PROVISION_SANDBOX, "provisioning sandbox")
+	provisionStarted := s.clock().Now()
+	var provisionDuration time.Duration
 	if err := adapter.ProvisionSandbox(ctx, backend.ProvisionRequest{
 		SandboxID:          sandboxID,
 		Policy:             compiled,
 		CacheOutputVolumes: appendCacheOutputVolumeSpecs(dependencyCacheOutputVolumes, serviceCacheOutputVolumes),
 		FirecrackerConfig:  firecrackerCfg,
 	}); err != nil {
+		provisionDuration = s.clock().Now().Sub(provisionStarted)
 		if stateErr := s.dropProvisioningSandboxAfterCreateError(sandboxID); stateErr != nil {
 			return nil, stateErr
 		}
 		return nil, fmt.Errorf("provision sandbox: %w", err)
 	}
+	provisionDuration = s.clock().Now().Sub(provisionStarted)
 	if err := s.ensureSandboxCreateStillProvisioning(sandboxID); err != nil {
 		return nil, err
 	}
@@ -1148,6 +1152,8 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 			observability.LogFieldSandboxID, sandboxID,
 			observability.LogFieldBackend, backendName,
 			"policy_hash", compiled.Hash,
+			"duration_ms", s.clock().Now().Sub(createStarted).Milliseconds(),
+			"provision_ms", provisionDuration.Milliseconds(),
 		)
 	}
 

--- a/internal/observability/contract.go
+++ b/internal/observability/contract.go
@@ -15,6 +15,8 @@ const (
 	SpanExecutionCreate = "cleanroom.execution.create"
 	SpanExecutionRun    = "cleanroom.execution.run"
 
+	EventLaunchPhase = "cleanroom.launch.phase"
+
 	MetricSandboxCreateDurationSeconds = "cleanroom_sandbox_create_duration_seconds"
 	MetricExecutionTotal               = "cleanroom_execution_total"
 	MetricExecutionDurationSeconds     = "cleanroom_execution_duration_seconds"
@@ -79,6 +81,8 @@ const (
 	AttrCachePeerBytes         = "cleanroom.cache.peer.bytes"
 	AttrCachePeerFallback      = "cleanroom.cache.peer.fallback_reason"
 	AttrVMLaunched             = "cleanroom.vm.launched"
+	AttrLaunchPhase            = "cleanroom.launch.phase"
+	AttrLaunchPhaseDurationMS  = "cleanroom.launch.phase.duration_ms"
 	AttrExitCode               = "cleanroom.exit_code"
 
 	LogFieldTraceID     = "trace_id"


### PR DESCRIPTION
## What changed

This PR keeps the darwin-vz TTI improvements that survived the benchmark experiments:

- avoids CLI-side platform resolution for explicit registry digest image refs
- pre-sizes prepared darwin-vz runtime rootfs cache entries so each sandbox clone no longer pays the resize cost
- overlaps Virtualization process PID lookup with guest readiness probing
- records finer-grained darwin-vz launch timing fields in execution observability and server create logs

## Why

The benchmark was spending time in work that did not need to be on the critical path for every sandbox create. The largest avoidable cost was resizing the writable rootfs after each clone. Explicit digest refs also caused unnecessary registry/platform lookup in the benchmark path, and PID lookup could run while the guest is booting.

## Benchmark

Local darwin-vz `sandbox create + exec echo` benchmark:

- original baseline: `2.7089s` mean
- after digest image lookup fix: `964.5ms` mean
- final branch result: `642.8ms ± 41.0ms`, median `626.2ms`, range `602.6-724.3ms`

Final server-side timing components from the 10-run benchmark:

- `launch_sandbox_total`: `582.4ms` mean
- `rootfs_minimum_size_resize`: `0ms`
- `rootfs_copy_ms`: `22.6ms`
- `rootfs_writable_volume_create_clone`: `12.4ms`
- `rootfs_inspect_validate`: `10.0ms`
- `helper_start_vm`: `92.0ms`
- `guest_exec_ready_probe`: `401.4ms`
- `virtualization_pid_lookup`: `122.8ms`, now overlapped
- first exec server-side `total_ms`: `1.7ms`

## Validation

- `mise exec -- go test -count=1 ./...`
- `mise run build`
- `xcrun swiftc -typecheck -framework Virtualization cmd/cleanroom-darwin-vz/main.swift`
- `git diff --check`
