### PR TITLE
feat: Trace darwin-vz guest boot timings

### DIFF
--- a/cmd/cleanroom-guest-agent/boot_timing.go
+++ b/cmd/cleanroom-guest-agent/boot_timing.go
@@ -1,0 +1,158 @@
+//go:build linux
+
+package main
+
+import (
+	"errors"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/buildkite/cleanroom/internal/vsockexec"
+)
+
+const guestBootTimingEnv = "CLEANROOM_GUEST_BOOT_TIMINGS"
+
+type guestBootTimingClock func() (int64, error)
+
+type guestBootTimingStore struct {
+	mu      sync.Mutex
+	timings map[string]int64
+	now     guestBootTimingClock
+}
+
+var guestBootTimings = newGuestBootTimingStoreFromEnv(os.Getenv(guestBootTimingEnv))
+
+func newGuestBootTimingStoreFromEnv(env string) *guestBootTimingStore {
+	if strings.TrimSpace(env) == "" {
+		return &guestBootTimingStore{}
+	}
+	return newGuestBootTimingStore(env, newGuestBootTimingClock())
+}
+
+func newGuestBootTimingClock() guestBootTimingClock {
+	start := time.Now()
+	startMS, err := readGuestBootUptimeMS()
+	if err != nil {
+		return readGuestBootUptimeMS
+	}
+	return func() (int64, error) {
+		return startMS + time.Since(start).Milliseconds(), nil
+	}
+}
+
+func newGuestBootTimingStore(env string, now guestBootTimingClock) *guestBootTimingStore {
+	store := &guestBootTimingStore{
+		timings: parseGuestBootTimingEnv(env),
+		now:     now,
+	}
+	store.record(vsockexec.GuestBootTimingAgentStart)
+	return store
+}
+
+func parseGuestBootTimingEnv(env string) map[string]int64 {
+	out := map[string]int64{}
+	for _, entry := range strings.Split(env, ",") {
+		key, value, ok := strings.Cut(strings.TrimSpace(entry), "=")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		ms, err := parseProcUptimeMS(strings.TrimSpace(value))
+		if err != nil || ms < 0 {
+			continue
+		}
+		out[key] = ms
+	}
+	return out
+}
+
+func (s *guestBootTimingStore) record(name string) {
+	name = strings.TrimSpace(name)
+	if s == nil || name == "" || s.now == nil {
+		return
+	}
+	ms, err := s.now()
+	if err != nil || ms < 0 {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.timings == nil {
+		s.timings = map[string]int64{}
+	}
+	s.timings[name] = ms
+}
+
+func (s *guestBootTimingStore) recordOnce(name string) {
+	name = strings.TrimSpace(name)
+	if s == nil || name == "" || s.now == nil {
+		return
+	}
+	s.mu.Lock()
+	_, exists := s.timings[name]
+	s.mu.Unlock()
+	if exists {
+		return
+	}
+	ms, err := s.now()
+	if err != nil || ms < 0 {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.timings[name]; exists {
+		return
+	}
+	if s.timings == nil {
+		s.timings = map[string]int64{}
+	}
+	s.timings[name] = ms
+}
+
+func (s *guestBootTimingStore) snapshot() map[string]int64 {
+	if s == nil || s.now == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.timings) == 0 {
+		return nil
+	}
+	out := make(map[string]int64, len(s.timings))
+	for key, value := range s.timings {
+		out[key] = value
+	}
+	return out
+}
+
+func readGuestBootUptimeMS() (int64, error) {
+	b, err := os.ReadFile("/proc/uptime")
+	if err != nil {
+		return 0, err
+	}
+	return parseProcUptimeMS(string(b))
+}
+
+func parseProcUptimeMS(raw string) (int64, error) {
+	fields := strings.Fields(raw)
+	if len(fields) == 0 {
+		return 0, errors.New("missing uptime")
+	}
+	secondsRaw, fractionRaw, _ := strings.Cut(fields[0], ".")
+	seconds, err := strconv.ParseInt(secondsRaw, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	fractionRaw += "000"
+	millis, err := strconv.ParseInt(fractionRaw[:3], 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	return seconds*1000 + millis, nil
+}

--- a/cmd/cleanroom-guest-agent/boot_timing_test.go
+++ b/cmd/cleanroom-guest-agent/boot_timing_test.go
@@ -1,0 +1,100 @@
+//go:build linux
+
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/vsockexec"
+)
+
+func TestNewGuestBootTimingStoreParsesEnvAndRecordsAgentStart(t *testing.T) {
+	t.Parallel()
+
+	store := newGuestBootTimingStore(
+		"guest_init_vsock_agent_exec=0.042,missing-value,bad=abc,negative=-1",
+		func() (int64, error) { return 57, nil },
+	)
+
+	got := store.snapshot()
+	if got[vsockexec.GuestBootTimingInitVSOCKAgentExec] != 42 {
+		t.Fatalf("expected env timing to be parsed, got %#v", got)
+	}
+	if got[vsockexec.GuestBootTimingAgentStart] != 57 {
+		t.Fatalf("expected agent start timing to be recorded, got %#v", got)
+	}
+	if _, ok := got["bad"]; ok {
+		t.Fatalf("did not expect invalid timing to be recorded, got %#v", got)
+	}
+}
+
+func TestNewGuestBootTimingStoreFromEnvDisablesTimingWhenUnset(t *testing.T) {
+	t.Parallel()
+
+	store := newGuestBootTimingStoreFromEnv("")
+	store.record(vsockexec.GuestBootTimingAgentFirstAccept)
+
+	if got := store.snapshot(); got != nil {
+		t.Fatalf("expected disabled timing snapshot to be nil, got %#v", got)
+	}
+}
+
+func TestGuestBootTimingStoreRecordOnceKeepsFirstValue(t *testing.T) {
+	t.Parallel()
+
+	values := []int64{10, 20, 30}
+	store := newGuestBootTimingStore("", func() (int64, error) {
+		next := values[0]
+		values = values[1:]
+		return next, nil
+	})
+
+	store.recordOnce(vsockexec.GuestBootTimingAgentFirstAccept)
+	store.recordOnce(vsockexec.GuestBootTimingAgentFirstAccept)
+	store.record(vsockexec.GuestBootTimingAgentListenReady)
+
+	got := store.snapshot()
+	if got[vsockexec.GuestBootTimingAgentFirstAccept] != 20 {
+		t.Fatalf("expected first accept to keep first value, got %#v", got)
+	}
+	if got[vsockexec.GuestBootTimingAgentListenReady] != 30 {
+		t.Fatalf("expected explicit record to update value, got %#v", got)
+	}
+}
+
+func TestGuestBootTimingStoreSkipsClockErrors(t *testing.T) {
+	t.Parallel()
+
+	store := newGuestBootTimingStore("", func() (int64, error) {
+		return 0, errors.New("no clock")
+	})
+
+	if got := store.snapshot(); len(got) != 0 {
+		t.Fatalf("expected empty timing snapshot, got %#v", got)
+	}
+}
+
+func TestParseProcUptimeMS(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		raw  string
+		want int64
+	}{
+		{name: "fraction", raw: "12.34 56.78\n", want: 12340},
+		{name: "millisecond precision", raw: "12.345 56.78\n", want: 12345},
+		{name: "whole seconds", raw: "12 56.78\n", want: 12000},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseProcUptimeMS(tc.raw)
+			if err != nil {
+				t.Fatalf("parseProcUptimeMS returned error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("parseProcUptimeMS: got %d want %d", got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/cleanroom-guest-agent/main.go
+++ b/cmd/cleanroom-guest-agent/main.go
@@ -27,6 +27,8 @@ import (
 
 func main() {
 	if strings.EqualFold(strings.TrimSpace(os.Getenv("CLEANROOM_GUEST_TRANSPORT")), "stdio") {
+		guestBootTimings.recordOnce(vsockexec.GuestBootTimingAgentListenReady)
+		guestBootTimings.recordOnce(vsockexec.GuestBootTimingAgentFirstAccept)
 		handleConn(stdioConn{})
 		return
 	}
@@ -43,6 +45,7 @@ func main() {
 		os.Exit(1)
 	}
 	defer ln.Close()
+	guestBootTimings.record(vsockexec.GuestBootTimingAgentListenReady)
 
 	for {
 		conn, err := ln.Accept()
@@ -53,6 +56,7 @@ func main() {
 			fmt.Fprintf(os.Stderr, "accept: %v\n", err)
 			continue
 		}
+		guestBootTimings.recordOnce(vsockexec.GuestBootTimingAgentFirstAccept)
 		handleConn(conn)
 	}
 }
@@ -93,6 +97,7 @@ func handleConn(conn io.ReadWriteCloser) {
 		sendErrorResponse(conn, err)
 		return
 	}
+	guestBootTimings.recordOnce(vsockexec.GuestBootTimingAgentFirstRequestDecode)
 	if len(req.Command) == 0 {
 		sendErrorResponse(conn, errors.New("missing command"))
 		return
@@ -270,9 +275,10 @@ func sendErrorResponse(w io.Writer, err error) {
 		return
 	}
 	if sendErr := sender.Send(vsockexec.ExecStreamFrame{
-		Type:     "exit",
-		ExitCode: 1,
-		Error:    msg,
+		Type:          "exit",
+		ExitCode:      1,
+		Error:         msg,
+		GuestTimingMS: guestBootTimings.snapshot(),
 	}); sendErr != nil {
 		return
 	}
@@ -296,6 +302,7 @@ func sendExitResult(sender *frameSender, waitErr error, capture *vsockexec.Overl
 		ExitCode:       exitCode,
 		Error:          errMsg,
 		OverlayCapture: captureResult,
+		GuestTimingMS:  guestBootTimings.snapshot(),
 	}); err != nil {
 		return
 	}

--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -210,7 +210,11 @@ func (a *Adapter) recordLaunchPhaseMetrics(ctx context.Context, observation darw
 		if durationMS <= 0 {
 			continue
 		}
-		metrics.RecordLaunchPhase(ctx, a.Name(), "helper_"+strings.TrimSpace(phase), time.Duration(durationMS)*time.Millisecond)
+		phase = darwinVZLaunchObservationPhaseName(phase)
+		if phase == "" {
+			continue
+		}
+		metrics.RecordLaunchPhase(ctx, a.Name(), phase, time.Duration(durationMS)*time.Millisecond)
 	}
 }
 
@@ -263,9 +267,31 @@ func darwinVZLaunchPhaseDurations(observation darwinVZRunObservation) []darwinVZ
 		if phase == "" {
 			continue
 		}
-		phases = append(phases, darwinVZLaunchPhaseDuration{Phase: "helper_" + phase, DurationMS: durationMS})
+		phase = darwinVZLaunchObservationPhaseName(phase)
+		if phase == "" {
+			continue
+		}
+		phases = append(phases, darwinVZLaunchPhaseDuration{Phase: phase, DurationMS: durationMS})
 	}
 	return phases
+}
+
+func darwinVZLaunchObservationPhaseName(phase string) string {
+	phase = strings.TrimSpace(phase)
+	if phase == "" {
+		return ""
+	}
+	if strings.HasPrefix(phase, "guest_init_") || strings.HasPrefix(phase, "guest_agent_") {
+		return phase
+	}
+	return "helper_" + phase
+}
+
+func darwinVZGuestBootTimingBootArg(ctx context.Context) string {
+	if trace.SpanFromContext(ctx).IsRecording() {
+		return "cleanroom_guest_boot_timing=1"
+	}
+	return ""
 }
 
 func commandCombinedOutput(ctx context.Context, name string, args ...string) ([]byte, error) {
@@ -1195,10 +1221,11 @@ func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream 
 		return nil, err
 	}
 	bootArgs := fmt.Sprintf(
-		"console=hvc0 root=/dev/vda rw init=%s cleanroom_guest_port=%d %s",
+		"console=hvc0 root=/dev/vda rw init=%s cleanroom_guest_port=%d %s %s",
 		guestInitPath,
 		req.GuestPort,
 		dockerServiceBootArgs(networkPolicy, req.FirecrackerConfig, a.GatewayPort, a.GatewayRoutes),
+		darwinVZGuestBootTimingBootArg(ctx),
 	)
 	consolePath := filepath.Join(runDir, "vm.console.log")
 
@@ -1339,6 +1366,7 @@ func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream 
 		observation.Error = err.Error()
 		return nil, helper.decorateError(fmt.Errorf("decode guest exec response over darwin-vz proxy: %w", err))
 	}
+	applyDarwinVZHelperTimings(&observation, darwinVZGuestBootPhaseTimings(guestRes.GuestTimingMS))
 
 	message := darwinVZResultMessage(guestRes.Error)
 	if timingSummary := darwinVZTimingSummary(startedVM.TimingMS); timingSummary != "" {
@@ -1507,10 +1535,11 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 		return nil, err
 	}
 	bootArgs := fmt.Sprintf(
-		"console=hvc0 root=/dev/vda rw init=%s cleanroom_guest_port=%d %s",
+		"console=hvc0 root=/dev/vda rw init=%s cleanroom_guest_port=%d %s %s",
 		guestInitPath,
 		cfg.GuestPort,
 		dockerServiceBootArgs(compiled, cfg, a.GatewayPort, a.GatewayRoutes),
+		darwinVZGuestBootTimingBootArg(ctx),
 	)
 	consolePath := filepath.Join(runDir, "vm.console.log")
 
@@ -1629,7 +1658,8 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 	bootCtx, cancel := context.WithTimeout(ctx, time.Duration(cfg.LaunchSeconds)*time.Second)
 	defer cancel()
 	guestReadyProbeStart := time.Now()
-	if err := probeGuestExecReadyWithExit(bootCtx, helper, startedVM.ProxySocketPath, instance.exitedCh, instance.exitedErrOrNil); err != nil {
+	guestPhaseTimingMS, err := probeGuestExecReadyWithExit(bootCtx, helper, startedVM.ProxySocketPath, instance.exitedCh, instance.exitedErrOrNil)
+	if err != nil {
 		pidLookup.stop()
 		return nil, err
 	}
@@ -1640,6 +1670,7 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 	recordDarwinVZPhaseTiming(launchTimingMS, darwinVZTimingLaunchSandboxTotal, launchStart)
 	helperTimingMS := mergeHelperTimingMS(launchTimingMS, rootFSTimingMS)
 	helperTimingMS = mergeHelperTimingMS(helperTimingMS, startedVM.TimingMS)
+	helperTimingMS = mergeHelperTimingMS(helperTimingMS, guestPhaseTimingMS)
 	launchObservability := &darwinVZLaunchObservability{
 		RootFSCopyMS:   rootFSCopyMS,
 		HelperTimingMS: helperTimingMS,
@@ -2003,32 +2034,34 @@ func snapshotVolumeDriver(cfg backend.FirecrackerConfig) (volumestore.Driver, er
 }
 
 func probeGuestExecReady(ctx context.Context, helper *helperSession, socketPath string) error {
-	return probeGuestExecReadyWithExit(ctx, helper, socketPath, nil, nil)
+	_, err := probeGuestExecReadyWithExit(ctx, helper, socketPath, nil, nil)
+	return err
 }
 
-func probeGuestExecReadyWithExit(ctx context.Context, helper *helperSession, socketPath string, exitedCh <-chan struct{}, exitedErrOrNil func() error) error {
+func probeGuestExecReadyWithExit(ctx context.Context, helper *helperSession, socketPath string, exitedCh <-chan struct{}, exitedErrOrNil func() error) (map[string]int64, error) {
 	conn, err := dialUnixSocketWithExit(ctx, socketPath, exitedCh, exitedErrOrNil)
 	if err != nil {
 		if helper != nil {
-			return helper.decorateError(fmt.Errorf("connect darwin-vz proxy socket %q for guest readiness probe: %w", socketPath, err))
+			return nil, helper.decorateError(fmt.Errorf("connect darwin-vz proxy socket %q for guest readiness probe: %w", socketPath, err))
 		}
-		return fmt.Errorf("connect darwin-vz proxy socket %q for guest readiness probe: %w", socketPath, err)
+		return nil, fmt.Errorf("connect darwin-vz proxy socket %q for guest readiness probe: %w", socketPath, err)
 	}
 	defer conn.Close()
 
 	if err := vsockexec.EncodeRequest(conn, vsockexec.ExecRequest{}); err != nil {
 		if helper != nil {
-			return helper.decorateError(fmt.Errorf("send guest readiness probe over darwin-vz proxy: %w", err))
+			return nil, helper.decorateError(fmt.Errorf("send guest readiness probe over darwin-vz proxy: %w", err))
 		}
-		return fmt.Errorf("send guest readiness probe over darwin-vz proxy: %w", err)
+		return nil, fmt.Errorf("send guest readiness probe over darwin-vz proxy: %w", err)
 	}
-	if _, err := guestexec.DecodeResponse(conn, backend.OutputStream{}); err != nil {
+	res, err := guestexec.DecodeResponse(conn, backend.OutputStream{})
+	if err != nil {
 		if helper != nil {
-			return helper.decorateError(fmt.Errorf("decode guest readiness probe over darwin-vz proxy: %w", err))
+			return nil, helper.decorateError(fmt.Errorf("decode guest readiness probe over darwin-vz proxy: %w", err))
 		}
-		return fmt.Errorf("decode guest readiness probe over darwin-vz proxy: %w", err)
+		return nil, fmt.Errorf("decode guest readiness probe over darwin-vz proxy: %w", err)
 	}
-	return nil
+	return darwinVZGuestBootPhaseTimings(res.GuestTimingMS), nil
 }
 
 func dialUnixSocketWithExit(ctx context.Context, socketPath string, exitedCh <-chan struct{}, exitedErrOrNil func() error) (net.Conn, error) {

--- a/internal/backend/darwinvz/guest_boot_timing_darwin.go
+++ b/internal/backend/darwinvz/guest_boot_timing_darwin.go
@@ -1,0 +1,55 @@
+//go:build darwin
+
+package darwinvz
+
+import "github.com/buildkite/cleanroom/internal/vsockexec"
+
+const (
+	darwinVZTimingGuestInitAgentExec      = "guest_init_agent_exec"
+	darwinVZTimingGuestAgentStartup       = "guest_agent_startup"
+	darwinVZTimingGuestAgentListen        = "guest_agent_listen"
+	darwinVZTimingGuestAgentAccept        = "guest_agent_accept"
+	darwinVZTimingGuestAgentRequestDecode = "guest_agent_request_decode"
+)
+
+func darwinVZGuestBootPhaseTimings(guestTimingMS map[string]int64) map[string]int64 {
+	if len(guestTimingMS) == 0 {
+		return nil
+	}
+
+	out := map[string]int64{}
+	recordGuestTimingFromBoot(out, darwinVZTimingGuestInitAgentExec, guestTimingMS, vsockexec.GuestBootTimingInitVSOCKAgentExec)
+	recordGuestTimingDelta(out, darwinVZTimingGuestAgentStartup, guestTimingMS, vsockexec.GuestBootTimingInitVSOCKAgentExec, vsockexec.GuestBootTimingAgentStart)
+	recordGuestTimingDelta(out, darwinVZTimingGuestAgentListen, guestTimingMS, vsockexec.GuestBootTimingAgentStart, vsockexec.GuestBootTimingAgentListenReady)
+	recordGuestTimingDelta(out, darwinVZTimingGuestAgentAccept, guestTimingMS, vsockexec.GuestBootTimingAgentListenReady, vsockexec.GuestBootTimingAgentFirstAccept)
+	recordGuestTimingDelta(out, darwinVZTimingGuestAgentRequestDecode, guestTimingMS, vsockexec.GuestBootTimingAgentFirstAccept, vsockexec.GuestBootTimingAgentFirstRequestDecode)
+
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func recordGuestTimingFromBoot(out map[string]int64, phase string, timingMS map[string]int64, endKey string) {
+	endMS, ok := timingMS[endKey]
+	if !ok || endMS <= 0 {
+		return
+	}
+	out[phase] = endMS
+}
+
+func recordGuestTimingDelta(out map[string]int64, phase string, timingMS map[string]int64, startKey, endKey string) {
+	startMS, ok := timingMS[startKey]
+	if !ok {
+		return
+	}
+	endMS, ok := timingMS[endKey]
+	if !ok {
+		return
+	}
+	durationMS := endMS - startMS
+	if durationMS <= 0 {
+		return
+	}
+	out[phase] = durationMS
+}

--- a/internal/backend/darwinvz/guest_boot_timing_darwin_test.go
+++ b/internal/backend/darwinvz/guest_boot_timing_darwin_test.go
@@ -1,0 +1,53 @@
+//go:build darwin
+
+package darwinvz
+
+import (
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/vsockexec"
+)
+
+func TestDarwinVZGuestBootPhaseTimings(t *testing.T) {
+	t.Parallel()
+
+	got := darwinVZGuestBootPhaseTimings(map[string]int64{
+		vsockexec.GuestBootTimingInitVSOCKAgentExec:      190,
+		vsockexec.GuestBootTimingAgentStart:              225,
+		vsockexec.GuestBootTimingAgentListenReady:        250,
+		vsockexec.GuestBootTimingAgentFirstAccept:        280,
+		vsockexec.GuestBootTimingAgentFirstRequestDecode: 285,
+	})
+
+	for phase, want := range map[string]int64{
+		darwinVZTimingGuestInitAgentExec:      190,
+		darwinVZTimingGuestAgentStartup:       35,
+		darwinVZTimingGuestAgentListen:        25,
+		darwinVZTimingGuestAgentAccept:        30,
+		darwinVZTimingGuestAgentRequestDecode: 5,
+	} {
+		if got[phase] != want {
+			t.Fatalf("unexpected %s timing: got %d want %d in %#v", phase, got[phase], want, got)
+		}
+	}
+}
+
+func TestDarwinVZGuestBootPhaseTimingsOmitsMissingOrNonPositiveDeltas(t *testing.T) {
+	t.Parallel()
+
+	got := darwinVZGuestBootPhaseTimings(map[string]int64{
+		vsockexec.GuestBootTimingInitVSOCKAgentExec:      310,
+		vsockexec.GuestBootTimingAgentStart:              300,
+		vsockexec.GuestBootTimingAgentFirstRequestDecode: 320,
+	})
+
+	if got[darwinVZTimingGuestInitAgentExec] != 310 {
+		t.Fatalf("unexpected init agent exec timing: got %#v", got)
+	}
+	if _, ok := got[darwinVZTimingGuestAgentStartup]; ok {
+		t.Fatalf("expected non-positive startup delta to be omitted, got %#v", got)
+	}
+	if _, ok := got[darwinVZTimingGuestAgentRequestDecode]; ok {
+		t.Fatalf("expected missing first accept delta to be omitted, got %#v", got)
+	}
+}

--- a/internal/backend/darwinvz/guest_init_script.go
+++ b/internal/backend/darwinvz/guest_init_script.go
@@ -30,6 +30,31 @@ mount -t tmpfs tmpfs /tmp 2>/dev/null || true
 export HOME=/root
 export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/.local/bin
 
+guest_boot_time() {
+  if ! read -r uptime _ </proc/uptime; then
+    return 1
+  fi
+  printf '%s\n' "$uptime"
+}
+
+mark_guest_boot_timing() {
+  case " ${cmdline:-} " in
+    *" cleanroom_guest_boot_timing=1 "*) ;;
+    *) return 0 ;;
+  esac
+  timing_key="$1"
+  timing_value="$(guest_boot_time 2>/dev/null || true)"
+  if [ -z "$timing_value" ]; then
+    return 0
+  fi
+  if [ -n "${CLEANROOM_GUEST_BOOT_TIMINGS:-}" ]; then
+    CLEANROOM_GUEST_BOOT_TIMINGS="${CLEANROOM_GUEST_BOOT_TIMINGS},${timing_key}=${timing_value}"
+  else
+    CLEANROOM_GUEST_BOOT_TIMINGS="${timing_key}=${timing_value}"
+  fi
+  export CLEANROOM_GUEST_BOOT_TIMINGS
+}
+
 mkdir -p /etc 2>/dev/null || true
 touch /etc/hosts 2>/dev/null || true
 append_hosts_line_if_missing() {
@@ -181,6 +206,7 @@ if [ -n "$AGENT_DEV" ]; then
   ) &
 fi
 
+mark_guest_boot_timing guest_init_vsock_agent_exec
 while true; do
   /usr/local/bin/cleanroom-guest-agent || true
   sleep 1

--- a/internal/backend/darwinvz/guest_init_script_test.go
+++ b/internal/backend/darwinvz/guest_init_script_test.go
@@ -3,9 +3,18 @@
 package darwinvz
 
 import (
+	"os/exec"
 	"strings"
 	"testing"
 )
+
+func TestGuestInitScriptSyntax(t *testing.T) {
+	t.Parallel()
+
+	if out, err := exec.Command("sh", "-n", "-c", guestInitScriptTemplate).CombinedOutput(); err != nil {
+		t.Fatalf("guest init script syntax check failed: %v\n%s", err, out)
+	}
+}
 
 func TestGuestInitScriptAlwaysStartsStdioAgentWhenSerialDeviceExists(t *testing.T) {
 	if strings.Contains(guestInitScriptTemplate, "CLEANROOM_USE_STDIO") {
@@ -24,6 +33,28 @@ func TestGuestInitScriptAlwaysStartsStdioAgentWhenSerialDeviceExists(t *testing.
 func TestGuestInitScriptBootstrapsNetwork(t *testing.T) {
 	if !strings.Contains(guestInitScriptTemplate, "setup_guest_network") {
 		t.Fatal("expected guest network setup function in init script")
+	}
+	if !strings.Contains(guestInitScriptTemplate, "CLEANROOM_GUEST_BOOT_TIMINGS") {
+		t.Fatal("expected init script to export guest boot timings")
+	}
+	if !strings.Contains(guestInitScriptTemplate, "mark_guest_boot_timing()") {
+		t.Fatal("expected init script to define guest boot timing helper")
+	}
+	if !strings.Contains(guestInitScriptTemplate, "cleanroom_guest_boot_timing=1") {
+		t.Fatal("expected init script to gate boot timing on kernel cmdline")
+	}
+	if !strings.Contains(guestInitScriptTemplate, "guest_init_vsock_agent_exec") {
+		t.Fatal("expected init script to mark the vsock guest-agent handoff")
+	}
+	for _, marker := range []string{
+		"guest_init_core_mounts_done",
+		"guest_init_hosts_done",
+		"guest_init_network_done",
+		"guest_init_stdio_agent_exec",
+	} {
+		if strings.Contains(guestInitScriptTemplate, marker) {
+			t.Fatalf("expected init script not to mark %s in the hot path", marker)
+		}
 	}
 	if !strings.Contains(guestInitScriptTemplate, "127.0.0.1 localhost") {
 		t.Fatal("expected localhost IPv4 hosts entry in init script")

--- a/internal/backend/darwinvz/observability_test.go
+++ b/internal/backend/darwinvz/observability_test.go
@@ -145,6 +145,7 @@ func TestRecordLaunchPhaseObservabilityAddsTraceEvents(t *testing.T) {
 		VMReadyMS:    321,
 		HelperTimingMS: map[string]int64{
 			darwinVZTimingGuestExecReadyProbe: 401,
+			darwinVZTimingGuestAgentStartup:   35,
 			"zero":                            0,
 		},
 	})
@@ -157,7 +158,26 @@ func TestRecordLaunchPhaseObservabilityAddsTraceEvents(t *testing.T) {
 	requireLaunchPhaseEvent(t, spans[0], "rootfs_prepare", "27")
 	requireLaunchPhaseEvent(t, spans[0], "guest_wait_ready", "321")
 	requireLaunchPhaseEvent(t, spans[0], "helper_"+darwinVZTimingGuestExecReadyProbe, "401")
+	requireLaunchPhaseEvent(t, spans[0], darwinVZTimingGuestAgentStartup, "35")
 	requireNoLaunchPhaseEvent(t, spans[0], "helper_zero")
+	requireNoLaunchPhaseEvent(t, spans[0], "helper_"+darwinVZTimingGuestAgentStartup)
+}
+
+func TestDarwinVZGuestBootTimingBootArgRequiresRecordingSpan(t *testing.T) {
+	t.Parallel()
+
+	if got := darwinVZGuestBootTimingBootArg(context.Background()); got != "" {
+		t.Fatalf("expected no boot timing arg without recording span, got %q", got)
+	}
+
+	tracerProvider := sdktrace.NewTracerProvider()
+	defer func() { _ = tracerProvider.Shutdown(context.Background()) }()
+	ctx, span := tracerProvider.Tracer("test").Start(context.Background(), "cleanroom.test")
+	defer span.End()
+
+	if got, want := darwinVZGuestBootTimingBootArg(ctx), "cleanroom_guest_boot_timing=1"; got != want {
+		t.Fatalf("unexpected boot timing arg: got %q want %q", got, want)
+	}
 }
 
 func TestWriteDarwinVZRunObservationIncludesNetworkMetadata(t *testing.T) {

--- a/internal/backend/darwinvz/persistent_test.go
+++ b/internal/backend/darwinvz/persistent_test.go
@@ -544,13 +544,27 @@ func TestProbeGuestExecReadyWaitsForGuestResponse(t *testing.T) {
 			Type:     "exit",
 			ExitCode: 1,
 			Error:    "missing command",
+			GuestTimingMS: map[string]int64{
+				vsockexec.GuestBootTimingInitVSOCKAgentExec:      190,
+				vsockexec.GuestBootTimingAgentStart:              225,
+				vsockexec.GuestBootTimingAgentListenReady:        250,
+				vsockexec.GuestBootTimingAgentFirstAccept:        280,
+				vsockexec.GuestBootTimingAgentFirstRequestDecode: 285,
+			},
 		}); encodeErr != nil {
 			t.Errorf("encode probe exit frame: %v", encodeErr)
 		}
 	}()
 
-	if err := probeGuestExecReady(context.Background(), nil, socketPath); err != nil {
+	timingMS, err := probeGuestExecReadyWithExit(context.Background(), nil, socketPath, nil, nil)
+	if err != nil {
 		t.Fatalf("probeGuestExecReady returned error: %v", err)
+	}
+	if got, want := timingMS[darwinVZTimingGuestInitAgentExec], int64(190); got != want {
+		t.Fatalf("unexpected guest init agent exec timing: got %d want %d in %#v", got, want, timingMS)
+	}
+	if got, want := timingMS[darwinVZTimingGuestAgentRequestDecode], int64(5); got != want {
+		t.Fatalf("unexpected guest request decode timing: got %d want %d in %#v", got, want, timingMS)
 	}
 	<-done
 }

--- a/internal/vsockexec/protocol.go
+++ b/internal/vsockexec/protocol.go
@@ -13,6 +13,14 @@ const (
 	DefaultPort uint32 = 10700
 )
 
+const (
+	GuestBootTimingInitVSOCKAgentExec      = "guest_init_vsock_agent_exec"
+	GuestBootTimingAgentStart              = "guest_agent_start"
+	GuestBootTimingAgentListenReady        = "guest_agent_listen_ready"
+	GuestBootTimingAgentFirstAccept        = "guest_agent_first_accept"
+	GuestBootTimingAgentFirstRequestDecode = "guest_agent_first_request_decode"
+)
+
 type ExecRequest struct {
 	Command                 []string                 `json:"command"`
 	Dir                     string                   `json:"dir,omitempty"`
@@ -82,6 +90,7 @@ type ExecResponse struct {
 	ExitCode       int                   `json:"exit_code"`
 	Error          string                `json:"error,omitempty"`
 	OverlayCapture *OverlayCaptureResult `json:"overlay_capture,omitempty"`
+	GuestTimingMS  map[string]int64      `json:"guest_timing_ms,omitempty"`
 }
 
 // ExecStreamFrame is sent from guest to host. Types: stdout|stderr|exit.
@@ -91,6 +100,7 @@ type ExecStreamFrame struct {
 	ExitCode       int                   `json:"exit_code,omitempty"`
 	Error          string                `json:"error,omitempty"`
 	OverlayCapture *OverlayCaptureResult `json:"overlay_capture,omitempty"`
+	GuestTimingMS  map[string]int64      `json:"guest_timing_ms,omitempty"`
 }
 
 func DecodeRequest(r io.Reader) (ExecRequest, error) {
@@ -193,6 +203,11 @@ func DecodeStreamResponse(r io.Reader, callbacks StreamCallbacks) (ExecResponse,
 			}
 			if captureRaw, ok := raw["overlay_capture"]; ok {
 				if err := json.Unmarshal(captureRaw, &out.OverlayCapture); err != nil {
+					return ExecResponse{}, err
+				}
+			}
+			if timingRaw, ok := raw["guest_timing_ms"]; ok {
+				if err := json.Unmarshal(timingRaw, &out.GuestTimingMS); err != nil {
 					return ExecResponse{}, err
 				}
 			}

--- a/internal/vsockexec/protocol_test.go
+++ b/internal/vsockexec/protocol_test.go
@@ -259,6 +259,33 @@ func TestDecodeStreamResponseIncludesOverlayCapture(t *testing.T) {
 	}
 }
 
+func TestDecodeStreamResponseIncludesGuestTiming(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	if err := EncodeStreamFrame(&buf, ExecStreamFrame{
+		Type:     "exit",
+		ExitCode: 0,
+		GuestTimingMS: map[string]int64{
+			GuestBootTimingInitVSOCKAgentExec: 42,
+			GuestBootTimingAgentStart:         57,
+		},
+	}); err != nil {
+		t.Fatalf("EncodeStreamFrame exit: %v", err)
+	}
+
+	res, err := DecodeStreamResponse(&buf, StreamCallbacks{})
+	if err != nil {
+		t.Fatalf("DecodeStreamResponse: %v", err)
+	}
+	if got, want := res.GuestTimingMS[GuestBootTimingInitVSOCKAgentExec], int64(42); got != want {
+		t.Fatalf("unexpected guest init timing: got %d want %d", got, want)
+	}
+	if got, want := res.GuestTimingMS[GuestBootTimingAgentStart], int64(57); got != want {
+		t.Fatalf("unexpected guest agent timing: got %d want %d", got, want)
+	}
+}
+
 func TestDecodeStreamResponseRejectsUntypedPayload(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What changed

- Propagates guest boot milestone timings through the vsock exec response protocol.
- Records a low-overhead guest init handoff marker plus guest-agent startup/listen/accept/request timings.
- Converts guest milestones into darwin-vz launch phase timings so they appear in launch metrics, execution observability, and OTel trace events.

## Why

The remaining darwin-vz startup cost was hidden inside `guest_exec_ready_probe`. This breaks that wait into guest-side phases without changing the CLI/API surface.

## Validation

- `mise run build`
- `mise exec -- go test -count=1 ./...`
- `mise run lint-shell`
- `git diff --check`
- TTI benchmark: `604.1 ms ± 37.7 ms` over 10 runs, warmup 2, `darwin-vz`; observed phase means included `launch_sandbox_total=545.1ms`, `guest_exec_ready_probe=384.0ms`, `guest_init_agent_exec=302.0ms`, `guest_agent_startup=25.0ms`, `guest_agent_accept=21.2ms`.