### PR TITLE
feat: Report effective sandbox resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,10 +310,13 @@ sandbox:
 ```
 
 `sandbox.resources` is optional and declares backend-neutral minimum workload
-requirements. `vcpus` is a positive integer, while `memory` and `disk` accept
-raw bytes or human-friendly sizes such as `4096MiB`, `8GiB`, or `16GiB`.
-Cleanroom raises the selected backend runtime config to meet these minimums,
-but does not lower larger host defaults.
+requirements. These are resource floors, not exact host reservations. `vcpus`
+is a positive integer, while `memory` and `disk` accept raw bytes or
+human-friendly sizes such as `4096MiB`, `8GiB`, or `16GiB`. Cleanroom raises the
+selected backend runtime config to meet these minimums, but does not lower
+larger host defaults. Backends expose the resulting effective ceilings in their
+own backend-specific way. CPU remains a launch-time ceiling; Cleanroom reports
+the effective vCPU count but does not hotplug CPUs into a running sandbox.
 
 Enable Docker as a guest service:
 

--- a/client/types.go
+++ b/client/types.go
@@ -17,6 +17,7 @@ const (
 
 type PolicyAllowRule = cleanroomv1.PolicyAllowRule
 type PolicyResources = cleanroomv1.PolicyResources
+type SandboxResources = cleanroomv1.SandboxResources
 type Policy = cleanroomv1.Policy
 type Snapshot = cleanroomv1.Snapshot
 type SandboxOptions = cleanroomv1.SandboxOptions

--- a/docs/backend/darwin-vz.md
+++ b/docs/backend/darwin-vz.md
@@ -67,6 +67,10 @@ High-level flow:
 - `proxy_socket_path`
 - `console_log_path`
 
+`vcpus` and `memory_mib` are effective VM launch ceilings after runtime config
+and policy resource minimums are merged. They are not an exact host reservation
+contract.
+
 `StartVM` response fields:
 
 - `ok`
@@ -98,9 +102,10 @@ Rootfs:
 - inject guest runtime (`cleanroom-guest-agent` and `/usr/sbin/cleanroom-init`) into a prepared cached rootfs image
 - create a per-sandbox copy (`rootfs-persistent.ext4`) and attach it read-write to the VM
 - `/workspace` is not a separate volume on `darwin-vz`; it lives on the guest rootfs
-- `backends.darwin-vz.minimum_rootfs_bytes` lets the runtime grow the guest rootfs copy before boot for non-trivial workloads that need more writable space
+- `backends.darwin-vz.minimum_rootfs_bytes` lets the runtime grow the guest rootfs copy before boot for non-trivial workloads that need more writable space; policy `sandbox.resources.disk` raises this floor when it is larger
 - `minimum_rootfs_bytes` accepts either raw bytes (`2147483648`) or human-friendly sizes (`2GiB`, `700MiB`, `"2147483648"`)
 - the same setting is also honored under the legacy underscore config key: `backends.darwin_vz.minimum_rootfs_bytes`
+- effective vCPUs are fixed at VM launch; `darwin-vz` does not hotplug CPUs into a running VM
 
 Snapshot/rootfs volume drivers:
 

--- a/docs/backend/firecracker.md
+++ b/docs/backend/firecracker.md
@@ -21,6 +21,8 @@ supported layered-cache path.
 - Deny-by-default egress with explicit allow rules.
 - Stage-local network policies currently fail closed until Firecracker has
   active per-command egress rule updates.
+- Effective vCPUs are fixed at VM launch. Cleanroom reports the resolved CPU
+  ceiling but does not hotplug CPUs into a running Firecracker microVM.
 - Route git egress through the shared host gateway, with embedded
   `content-cache` for Git and OCI transport caching.
 - Keep secret values out of guest env and policy files.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -170,10 +170,13 @@ explicit request-time changeset input.
 - `repository.remote` defaults to `origin`.
 - `repository.path` defaults to `/workspace` and must be an absolute guest path.
 - `repository.submodules` defaults to `false`.
-- `sandbox.resources` defaults to unset. When present, it declares backend-neutral minimum workload requirements.
+- `sandbox.resources` defaults to unset. When present, it declares backend-neutral minimum workload requirements, not exact host reservations.
 - `sandbox.resources.vcpus` must be a positive integer.
 - `sandbox.resources.memory` and `sandbox.resources.disk` must be positive byte sizes. They accept raw bytes or size strings such as `4096MiB`, `8GiB`, or `16GiB`.
-- Resource requirements raise the effective backend runtime settings when the host runtime config is lower; they do not lower larger host defaults.
+- Resource floors raise the effective backend runtime settings when the host runtime config is lower; they do not lower larger host defaults.
+- Backends decide how effective resource ceilings map to host resources.
+- Sandbox API responses include `effective_resources`, which reports the resolved vCPU, memory, and disk ceilings after backend config, defaults, and policy resource floors are merged.
+- `effective_resources.vcpus` is a launch-time CPU ceiling; Cleanroom does not hotplug CPUs into an already running sandbox.
 - `sandbox.docker.required` defaults to `false`; when true, Cleanroom starts the guest Docker daemon for the sandbox.
 - `sandbox.dependencies` defaults to an empty block list; each block has `name`, `command`, `inputs.files`, and `outputs.dirs` or `outputs.files`. It may be a block list directly, or an object with `reuse` and `blocks` when dependency-stage options are needed.
 - `sandbox.dependencies.reuse` may be `portable` when `sandbox.dependencies.blocks` declares at least one input file; omitted or `exact` means exact checkout reuse only.
@@ -407,7 +410,7 @@ Minimum required fields:
 - `run`
   - optional pre-run command
 - `resources`
-  - optional `vcpus`, `memory_bytes`, and `disk_bytes`
+  - optional minimum `vcpus`, `memory_bytes`, and `disk_bytes` resource floors
 - `hash` (digest of the compiled policy payload)
 
 Requirements:

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -396,10 +396,18 @@ type OverlayCaptureEntry struct {
 	Mode fs.FileMode
 }
 
+const (
+	DefaultVCPUs     int64 = 1
+	DefaultMemoryMiB int64 = 512
+)
+
 type FirecrackerConfig struct {
-	BinaryPath                                string
-	KernelImagePath                           string
-	RootFSPath                                string
+	BinaryPath      string
+	KernelImagePath string
+	RootFSPath      string
+	// MinimumRootFSBytes is a writable rootfs capacity floor. Backends may
+	// provide this as logical capacity or a larger backend default; it is not an
+	// exact host-disk allocation promise.
 	MinimumRootFSBytes                        int64
 	DarwinVZNetworkMode                       string
 	DarwinVZNetworkSubnet                     string
@@ -415,12 +423,15 @@ type FirecrackerConfig struct {
 	PrivilegedMode                            string
 	PrivilegedHelperPath                      string
 	RunDir                                    string
-	VCPUs                                     int64
-	MemoryMiB                                 int64
-	GuestCID                                  uint32
-	GuestPort                                 uint32
-	Launch                                    bool
-	LaunchSeconds                             int64
+	// VCPUs and MemoryMiB are effective VM launch ceilings after runtime config,
+	// policy floors, and backend defaults are merged. They are not exact workload
+	// reservations.
+	VCPUs         int64
+	MemoryMiB     int64
+	GuestCID      uint32
+	GuestPort     uint32
+	Launch        bool
+	LaunchSeconds int64
 }
 
 type SnapshotConfig struct {

--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -1074,10 +1074,10 @@ func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream 
 	}()
 
 	if req.VCPUs <= 0 {
-		req.VCPUs = 1
+		req.VCPUs = backend.DefaultVCPUs
 	}
 	if req.MemoryMiB <= 0 {
-		req.MemoryMiB = 512
+		req.MemoryMiB = backend.DefaultMemoryMiB
 	}
 	if req.GuestPort == 0 {
 		req.GuestPort = vsockexec.DefaultPort
@@ -1414,10 +1414,10 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 	recordDarwinVZPhaseTiming(launchTimingMS, darwinVZTimingLaunchPolicyValidate, policyValidateStart)
 
 	if cfg.VCPUs <= 0 {
-		cfg.VCPUs = 1
+		cfg.VCPUs = backend.DefaultVCPUs
 	}
 	if cfg.MemoryMiB <= 0 {
-		cfg.MemoryMiB = 512
+		cfg.MemoryMiB = backend.DefaultMemoryMiB
 	}
 	if cfg.GuestPort == 0 {
 		cfg.GuestPort = vsockexec.DefaultPort

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -1065,10 +1065,10 @@ func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream 
 	defer writeObservation()
 
 	if req.VCPUs <= 0 {
-		req.VCPUs = 1
+		req.VCPUs = backend.DefaultVCPUs
 	}
 	if req.MemoryMiB <= 0 {
-		req.MemoryMiB = 512
+		req.MemoryMiB = backend.DefaultMemoryMiB
 	}
 	if req.GuestCID == 0 {
 		req.GuestCID = randomGuestCID()
@@ -1719,10 +1719,10 @@ func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID strin
 		return nil, fmt.Errorf("firecracker backend is linux-only, current OS is %s", runtime.GOOS)
 	}
 	if cfg.VCPUs <= 0 {
-		cfg.VCPUs = 1
+		cfg.VCPUs = backend.DefaultVCPUs
 	}
 	if cfg.MemoryMiB <= 0 {
-		cfg.MemoryMiB = 512
+		cfg.MemoryMiB = backend.DefaultMemoryMiB
 	}
 	if cfg.GuestCID == 0 {
 		cfg.GuestCID = randomGuestCID()

--- a/internal/cli/sandbox.go
+++ b/internal/cli/sandbox.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"text/tabwriter"
@@ -176,6 +177,9 @@ func (c *SandboxInspectCommand) Run(ctx *runtimeContext) error {
 			return err
 		}
 	}
+	if err := writeSandboxEffectiveResources(ctx.Stdout, sandbox.GetEffectiveResources()); err != nil {
+		return err
+	}
 	if sourceKind := strings.TrimSpace(sandbox.GetSourceKind()); sourceKind != "" {
 		if _, err := fmt.Fprintf(ctx.Stdout, "source_kind: %s\n", sourceKind); err != nil {
 			return err
@@ -218,6 +222,42 @@ func (c *SandboxInspectCommand) Run(ctx *runtimeContext) error {
 		}
 	}
 	return nil
+}
+
+func writeSandboxEffectiveResources(w io.Writer, resources *cleanroomv1.SandboxResources) error {
+	if resources == nil {
+		return nil
+	}
+	if resources.GetVcpus() == 0 && resources.GetMemoryBytes() == 0 && resources.GetDiskBytes() == 0 {
+		return nil
+	}
+	if _, err := fmt.Fprintln(w, "effective_resources:"); err != nil {
+		return err
+	}
+	if vcpus := resources.GetVcpus(); vcpus > 0 {
+		if _, err := fmt.Fprintf(w, "  vcpus: %d\n", vcpus); err != nil {
+			return err
+		}
+	}
+	if memoryBytes := resources.GetMemoryBytes(); memoryBytes > 0 {
+		if _, err := fmt.Fprintf(w, "  memory: %s\n", formatMemoryBytes(memoryBytes)); err != nil {
+			return err
+		}
+	}
+	if diskBytes := resources.GetDiskBytes(); diskBytes > 0 {
+		if _, err := fmt.Fprintf(w, "  disk: %s\n", formatStorageBytes(diskBytes)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func formatMemoryBytes(bytes int64) string {
+	const bytesPerMiB int64 = 1024 * 1024
+	if bytes > 0 && bytes%bytesPerMiB == 0 {
+		return fmt.Sprintf("%d MiB", bytes/bytesPerMiB)
+	}
+	return formatStorageBytes(bytes)
 }
 
 func filterSandboxList(sandboxes []*cleanroomv1.Sandbox, includeStopped bool) []*cleanroomv1.Sandbox {

--- a/internal/cli/sandbox_inspect_integration_test.go
+++ b/internal/cli/sandbox_inspect_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+	"github.com/buildkite/cleanroom/internal/runtimeconfig"
 )
 
 func runSandboxInspectWithCapture(cmd SandboxInspectCommand, ctx runtimeContext) execOutcome {
@@ -57,6 +58,53 @@ func TestSandboxInspectIntegrationShowsExecutionPointers(t *testing.T) {
 	if !strings.Contains(outcome.stdout, "inspect_last_execution: cleanroom execution inspect "+executionID) {
 		t.Fatalf("expected inspect hint in output, got %q", outcome.stdout)
 	}
+}
+
+func TestSandboxInspectIntegrationShowsEffectiveResources(t *testing.T) {
+	host, _ := startIntegrationServerWithConfig(t, &integrationAdapter{}, runtimeconfig.Config{
+		DefaultBackend: "firecracker",
+		Backends: runtimeconfig.Backends{
+			Firecracker: runtimeconfig.FirecrackerConfig{
+				VCPUs:     2,
+				MemoryMiB: 1024,
+			},
+		},
+	})
+	cwd := t.TempDir()
+
+	client := mustNewControlClient(t, host)
+	compiled, _, err := integrationLoader{}.LoadAndCompile(cwd)
+	if err != nil {
+		t.Fatalf("load policy: %v", err)
+	}
+	policyProto := compiled.ToProto()
+	policyProto.Resources = &cleanroomv1.PolicyResources{
+		Vcpus:       4,
+		MemoryBytes: (3 << 30) + 1,
+		DiskBytes:   16 << 30,
+	}
+	createResp, err := client.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: policyProto})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createResp.GetSandbox().GetSandboxId()
+
+	outcome := runSandboxInspectWithCapture(SandboxInspectCommand{
+		clientFlags: clientFlags{Host: host},
+		SandboxID:   sandboxID,
+	}, runtimeContext{CWD: cwd})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err != nil {
+		t.Fatalf("SandboxInspectCommand.Run returned error: %v", outcome.err)
+	}
+	assertContainsAll(t, outcome.stdout,
+		"effective_resources:",
+		"  vcpus: 4",
+		"  memory: 3073 MiB",
+		"  disk: 16.0 GiB",
+	)
 }
 
 func TestSandboxInspectIntegrationJSON(t *testing.T) {

--- a/internal/controlservice/resource_requirements.go
+++ b/internal/controlservice/resource_requirements.go
@@ -7,7 +7,24 @@ import (
 
 const mibBytes int64 = 1 << 20
 
-func withPolicyResourceRequirements(cfg backend.FirecrackerConfig, resources *policy.Resources) backend.FirecrackerConfig {
+func withBackendLaunchResourceDefaults(cfg backend.FirecrackerConfig) backend.FirecrackerConfig {
+	if cfg.VCPUs <= 0 {
+		cfg.VCPUs = backend.DefaultVCPUs
+	}
+	if cfg.MemoryMiB <= 0 {
+		cfg.MemoryMiB = backend.DefaultMemoryMiB
+	}
+	return cfg
+}
+
+// withPolicyResourceMinimums translates sandbox.resources floors into the
+// backend launch envelope.
+//
+// Policy resources are minimum workload requirements, not exact allocations.
+// The selected runtime config may already provide larger effective ceilings; in
+// that case the larger runtime values are preserved. Backends may expose those
+// ceilings as fixed launch config or another backend-specific mechanism.
+func withPolicyResourceMinimums(cfg backend.FirecrackerConfig, resources *policy.Resources) backend.FirecrackerConfig {
 	if resources == nil {
 		return cfg
 	}

--- a/internal/controlservice/resource_requirements_test.go
+++ b/internal/controlservice/resource_requirements_test.go
@@ -1,0 +1,97 @@
+package controlservice
+
+import (
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/policy"
+)
+
+func TestWithPolicyResourceMinimumsRaisesLowerRuntimeConfig(t *testing.T) {
+	cfg := backend.FirecrackerConfig{
+		VCPUs:              2,
+		MemoryMiB:          1024,
+		MinimumRootFSBytes: 8 << 30,
+	}
+
+	got := withPolicyResourceMinimums(cfg, &policy.Resources{
+		VCPUs:       4,
+		MemoryBytes: (3 << 30) + 1,
+		DiskBytes:   16 << 30,
+	})
+
+	if got.VCPUs != 4 {
+		t.Fatalf("unexpected vcpus: got %d want 4", got.VCPUs)
+	}
+	if got.MemoryMiB != 3073 {
+		t.Fatalf("unexpected memory_mib: got %d want 3073", got.MemoryMiB)
+	}
+	if got.MinimumRootFSBytes != 16<<30 {
+		t.Fatalf("unexpected minimum_rootfs_bytes: got %d want %d", got.MinimumRootFSBytes, int64(16<<30))
+	}
+}
+
+func TestWithPolicyResourceMinimumsPreservesHigherRuntimeConfig(t *testing.T) {
+	cfg := backend.FirecrackerConfig{
+		VCPUs:              8,
+		MemoryMiB:          8192,
+		MinimumRootFSBytes: 64 << 30,
+	}
+
+	got := withPolicyResourceMinimums(cfg, &policy.Resources{
+		VCPUs:       4,
+		MemoryBytes: 3 << 30,
+		DiskBytes:   16 << 30,
+	})
+
+	if got.VCPUs != cfg.VCPUs {
+		t.Fatalf("vcpus should preserve higher runtime ceiling: got %d want %d", got.VCPUs, cfg.VCPUs)
+	}
+	if got.MemoryMiB != cfg.MemoryMiB {
+		t.Fatalf("memory_mib should preserve higher runtime ceiling: got %d want %d", got.MemoryMiB, cfg.MemoryMiB)
+	}
+	if got.MinimumRootFSBytes != cfg.MinimumRootFSBytes {
+		t.Fatalf("minimum_rootfs_bytes should preserve higher runtime ceiling: got %d want %d", got.MinimumRootFSBytes, cfg.MinimumRootFSBytes)
+	}
+}
+
+func TestWithPolicyResourceMinimumsNilResourcesIsNoOp(t *testing.T) {
+	cfg := backend.FirecrackerConfig{
+		VCPUs:              2,
+		MemoryMiB:          1024,
+		MinimumRootFSBytes: 8 << 30,
+	}
+
+	got := withPolicyResourceMinimums(cfg, nil)
+
+	if got != cfg {
+		t.Fatalf("expected nil resources to preserve config: got %#v want %#v", got, cfg)
+	}
+}
+
+func TestWithBackendLaunchResourceDefaultsFillsUnsetLaunchCeilings(t *testing.T) {
+	got := withBackendLaunchResourceDefaults(backend.FirecrackerConfig{})
+
+	if got.VCPUs != backend.DefaultVCPUs {
+		t.Fatalf("unexpected default vcpus: got %d want %d", got.VCPUs, backend.DefaultVCPUs)
+	}
+	if got.MemoryMiB != backend.DefaultMemoryMiB {
+		t.Fatalf("unexpected default memory_mib: got %d want %d", got.MemoryMiB, backend.DefaultMemoryMiB)
+	}
+}
+
+func TestWithBackendLaunchResourceDefaultsPreservesExplicitLaunchCeilings(t *testing.T) {
+	cfg := backend.FirecrackerConfig{
+		VCPUs:     4,
+		MemoryMiB: 2048,
+	}
+
+	got := withBackendLaunchResourceDefaults(cfg)
+
+	if got.VCPUs != cfg.VCPUs {
+		t.Fatalf("vcpus should preserve explicit runtime ceiling: got %d want %d", got.VCPUs, cfg.VCPUs)
+	}
+	if got.MemoryMiB != cfg.MemoryMiB {
+		t.Fatalf("memory_mib should preserve explicit runtime ceiling: got %d want %d", got.MemoryMiB, cfg.MemoryMiB)
+	}
+}

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -400,7 +400,8 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 	}
 	firecrackerCfg := runtimeconfig.MergeBackendConfig(s.Config, backendName, execOpts.LaunchSeconds)
 	firecrackerCfg.RunDir = ""
-	firecrackerCfg = withPolicyResourceRequirements(firecrackerCfg, compiled.Resources)
+	firecrackerCfg = withPolicyResourceMinimums(firecrackerCfg, compiled.Resources)
+	firecrackerCfg = withBackendLaunchResourceDefaults(firecrackerCfg)
 	firecrackerCfg = withRepositoryBootstrapRootFSMinimum(firecrackerCfg, compiled, repository)
 
 	var replacedWorkspaceStageRecord *cachestore.Record

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -6577,7 +6577,7 @@ func TestCreateSandboxAppliesPolicyResourceMinimums(t *testing.T) {
 		DiskBytes:   16 << 30,
 	}
 
-	_, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+	resp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
 		Policy: policyProto,
 	})
 	if err != nil {
@@ -6593,6 +6593,20 @@ func TestCreateSandboxAppliesPolicyResourceMinimums(t *testing.T) {
 	}
 	if got, want := gotCfg.MinimumRootFSBytes, int64(16<<30); got != want {
 		t.Fatalf("unexpected minimum_rootfs_bytes: got %d want %d", got, want)
+	}
+
+	resources := resp.GetSandbox().GetEffectiveResources()
+	if resources == nil {
+		t.Fatal("expected sandbox effective resources")
+	}
+	if got, want := resources.GetVcpus(), int64(4); got != want {
+		t.Fatalf("unexpected effective vcpus: got %d want %d", got, want)
+	}
+	if got, want := resources.GetMemoryBytes(), int64(3073<<20); got != want {
+		t.Fatalf("unexpected effective memory_bytes: got %d want %d", got, want)
+	}
+	if got, want := resources.GetDiskBytes(), int64(16<<30); got != want {
+		t.Fatalf("unexpected effective disk_bytes: got %d want %d", got, want)
 	}
 }
 

--- a/internal/controlservice/state_helpers.go
+++ b/internal/controlservice/state_helpers.go
@@ -143,7 +143,25 @@ func cloneSandboxLocked(state *sandboxState) *cleanroomv1.Sandbox {
 		BackingSnapshotId:   state.BackingSnapshotID,
 		RepositoryCheckout:  cloneRepositoryCheckout(state.Repository).ToProto(),
 		BackendCapabilities: backend.CloneCapabilities(state.Capabilities),
+		EffectiveResources:  effectiveSandboxResources(state.Firecracker),
 	}
+}
+
+func effectiveSandboxResources(cfg backend.FirecrackerConfig) *cleanroomv1.SandboxResources {
+	resources := &cleanroomv1.SandboxResources{}
+	if cfg.VCPUs > 0 {
+		resources.Vcpus = cfg.VCPUs
+	}
+	if cfg.MemoryMiB > 0 {
+		resources.MemoryBytes = cfg.MemoryMiB * mibBytes
+	}
+	if cfg.MinimumRootFSBytes > 0 {
+		resources.DiskBytes = cfg.MinimumRootFSBytes
+	}
+	if resources.GetVcpus() == 0 && resources.GetMemoryBytes() == 0 && resources.GetDiskBytes() == 0 {
+		return nil
+	}
+	return resources
 }
 
 func cloneExecutionLocked(state *executionState) *cleanroomv1.Execution {

--- a/internal/controlservice/stored_rootfs.go
+++ b/internal/controlservice/stored_rootfs.go
@@ -110,7 +110,8 @@ func (s *Service) createSandboxFromStoredRootFS(ctx context.Context, req *cleanr
 	}
 	firecrackerCfg := runtimeconfig.MergeBackendConfig(s.Config, backendName, execOpts.LaunchSeconds)
 	firecrackerCfg.RunDir = ""
-	firecrackerCfg = withPolicyResourceRequirements(firecrackerCfg, effectivePolicy.Resources)
+	firecrackerCfg = withPolicyResourceMinimums(firecrackerCfg, effectivePolicy.Resources)
+	firecrackerCfg = withBackendLaunchResourceDefaults(firecrackerCfg)
 	firecrackerCfg = withSnapshotDriver(backendName, firecrackerCfg, record.StorageDriver)
 
 	now := s.clock().Now()

--- a/internal/gen/cleanroom/v1/control.pb.go
+++ b/internal/gen/cleanroom/v1/control.pb.go
@@ -352,8 +352,10 @@ type Sandbox struct {
 	BackingSnapshotId   string                 `protobuf:"bytes,11,opt,name=backing_snapshot_id,json=backingSnapshotId,proto3" json:"backing_snapshot_id,omitempty"`
 	RepositoryCheckout  *RepositoryCheckout    `protobuf:"bytes,12,opt,name=repository_checkout,json=repositoryCheckout,proto3" json:"repository_checkout,omitempty"`
 	BackendCapabilities map[string]bool        `protobuf:"bytes,13,rep,name=backend_capabilities,json=backendCapabilities,proto3" json:"backend_capabilities,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"varint,2,opt,name=value"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	// Resolved backend resource ceilings for this sandbox.
+	EffectiveResources *SandboxResources `protobuf:"bytes,14,opt,name=effective_resources,json=effectiveResources,proto3" json:"effective_resources,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *Sandbox) Reset() {
@@ -473,6 +475,13 @@ func (x *Sandbox) GetRepositoryCheckout() *RepositoryCheckout {
 func (x *Sandbox) GetBackendCapabilities() map[string]bool {
 	if x != nil {
 		return x.BackendCapabilities
+	}
+	return nil
+}
+
+func (x *Sandbox) GetEffectiveResources() *SandboxResources {
+	if x != nil {
+		return x.EffectiveResources
 	}
 	return nil
 }
@@ -1391,11 +1400,18 @@ func (x *PolicyNetworkStages) GetExecution() *PolicyNetwork {
 	return nil
 }
 
+// PolicyResources declares backend-neutral minimum workload requirements.
+// These values are floors, not exact reservations: control-plane code raises
+// lower backend runtime settings to meet them and preserves larger runtime
+// defaults. Backends decide how those effective ceilings map to host resources.
 type PolicyResources struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Vcpus         int64                  `protobuf:"varint,1,opt,name=vcpus,proto3" json:"vcpus,omitempty"`
-	MemoryBytes   int64                  `protobuf:"varint,2,opt,name=memory_bytes,json=memoryBytes,proto3" json:"memory_bytes,omitempty"`
-	DiskBytes     int64                  `protobuf:"varint,3,opt,name=disk_bytes,json=diskBytes,proto3" json:"disk_bytes,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Minimum effective vCPU ceiling required by the workload.
+	Vcpus int64 `protobuf:"varint,1,opt,name=vcpus,proto3" json:"vcpus,omitempty"`
+	// Minimum effective memory ceiling required by the workload, in bytes.
+	MemoryBytes int64 `protobuf:"varint,2,opt,name=memory_bytes,json=memoryBytes,proto3" json:"memory_bytes,omitempty"`
+	// Minimum writable root filesystem capacity required by the workload, in bytes.
+	DiskBytes     int64 `protobuf:"varint,3,opt,name=disk_bytes,json=diskBytes,proto3" json:"disk_bytes,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -6109,11 +6125,76 @@ func (x *SandboxPortOpenResult) GetError() string {
 	return ""
 }
 
+// SandboxResources reports backend-effective resource ceilings for a sandbox.
+//
+// Values are resolved after runtime config, backend defaults, and policy
+// resource floors are merged. They describe the sandbox's effective launch
+// envelope, not exact host reservations.
+type SandboxResources struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Vcpus         int64                  `protobuf:"varint,1,opt,name=vcpus,proto3" json:"vcpus,omitempty"`
+	MemoryBytes   int64                  `protobuf:"varint,2,opt,name=memory_bytes,json=memoryBytes,proto3" json:"memory_bytes,omitempty"`
+	DiskBytes     int64                  `protobuf:"varint,3,opt,name=disk_bytes,json=diskBytes,proto3" json:"disk_bytes,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SandboxResources) Reset() {
+	*x = SandboxResources{}
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[88]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SandboxResources) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SandboxResources) ProtoMessage() {}
+
+func (x *SandboxResources) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[88]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SandboxResources.ProtoReflect.Descriptor instead.
+func (*SandboxResources) Descriptor() ([]byte, []int) {
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{88}
+}
+
+func (x *SandboxResources) GetVcpus() int64 {
+	if x != nil {
+		return x.Vcpus
+	}
+	return 0
+}
+
+func (x *SandboxResources) GetMemoryBytes() int64 {
+	if x != nil {
+		return x.MemoryBytes
+	}
+	return 0
+}
+
+func (x *SandboxResources) GetDiskBytes() int64 {
+	if x != nil {
+		return x.DiskBytes
+	}
+	return 0
+}
+
 var File_proto_cleanroom_v1_control_proto protoreflect.FileDescriptor
 
 const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\n" +
-	" proto/cleanroom/v1/control.proto\x12\fcleanroom.v1\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xd6\x05\n" +
+	" proto/cleanroom/v1/control.proto\x12\fcleanroom.v1\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xa7\x06\n" +
 	"\aSandbox\x12\x1d\n" +
 	"\n" +
 	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\x123\n" +
@@ -6133,7 +6214,8 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	" \x01(\tR\bsourceId\x12.\n" +
 	"\x13backing_snapshot_id\x18\v \x01(\tR\x11backingSnapshotId\x12Q\n" +
 	"\x13repository_checkout\x18\f \x01(\v2 .cleanroom.v1.RepositoryCheckoutR\x12repositoryCheckout\x12a\n" +
-	"\x14backend_capabilities\x18\r \x03(\v2..cleanroom.v1.Sandbox.BackendCapabilitiesEntryR\x13backendCapabilities\x1aF\n" +
+	"\x14backend_capabilities\x18\r \x03(\v2..cleanroom.v1.Sandbox.BackendCapabilitiesEntryR\x13backendCapabilities\x12O\n" +
+	"\x13effective_resources\x18\x0e \x01(\v2\x1e.cleanroom.v1.SandboxResourcesR\x12effectiveResources\x1aF\n" +
 	"\x18BackendCapabilitiesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\bR\x05value:\x028\x01\"\xa8\x01\n" +
@@ -6596,7 +6678,12 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	" \x01(\tR\vimageDigestB\t\n" +
 	"\apayload\"-\n" +
 	"\x15SandboxPortOpenResult\x12\x14\n" +
-	"\x05error\x18\x01 \x01(\tR\x05error*\xbe\x01\n" +
+	"\x05error\x18\x01 \x01(\tR\x05error\"j\n" +
+	"\x10SandboxResources\x12\x14\n" +
+	"\x05vcpus\x18\x01 \x01(\x03R\x05vcpus\x12!\n" +
+	"\fmemory_bytes\x18\x02 \x01(\x03R\vmemoryBytes\x12\x1d\n" +
+	"\n" +
+	"disk_bytes\x18\x03 \x01(\x03R\tdiskBytes*\xbe\x01\n" +
 	"\rSandboxStatus\x12\x1e\n" +
 	"\x1aSANDBOX_STATUS_UNSPECIFIED\x10\x00\x12\x1f\n" +
 	"\x1bSANDBOX_STATUS_PROVISIONING\x10\x01\x12\x18\n" +
@@ -6690,7 +6777,7 @@ func file_proto_cleanroom_v1_control_proto_rawDescGZIP() []byte {
 }
 
 var file_proto_cleanroom_v1_control_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_proto_cleanroom_v1_control_proto_msgTypes = make([]protoimpl.MessageInfo, 90)
+var file_proto_cleanroom_v1_control_proto_msgTypes = make([]protoimpl.MessageInfo, 91)
 var file_proto_cleanroom_v1_control_proto_goTypes = []any{
 	(SandboxStatus)(0),                    // 0: cleanroom.v1.SandboxStatus
 	(CreateSandboxPhase)(0),               // 1: cleanroom.v1.CreateSandboxPhase
@@ -6785,148 +6872,150 @@ var file_proto_cleanroom_v1_control_proto_goTypes = []any{
 	(*ExecutionExit)(nil),                 // 90: cleanroom.v1.ExecutionExit
 	(*ExecutionStreamEvent)(nil),          // 91: cleanroom.v1.ExecutionStreamEvent
 	(*SandboxPortOpenResult)(nil),         // 92: cleanroom.v1.SandboxPortOpenResult
-	nil,                                   // 93: cleanroom.v1.Sandbox.BackendCapabilitiesEntry
-	nil,                                   // 94: cleanroom.v1.PolicyBlock.EnvEntry
-	(*timestamppb.Timestamp)(nil),         // 95: google.protobuf.Timestamp
-	(*structpb.Struct)(nil),               // 96: google.protobuf.Struct
+	(*SandboxResources)(nil),              // 93: cleanroom.v1.SandboxResources
+	nil,                                   // 94: cleanroom.v1.Sandbox.BackendCapabilitiesEntry
+	nil,                                   // 95: cleanroom.v1.PolicyBlock.EnvEntry
+	(*timestamppb.Timestamp)(nil),         // 96: google.protobuf.Timestamp
+	(*structpb.Struct)(nil),               // 97: google.protobuf.Struct
 }
 var file_proto_cleanroom_v1_control_proto_depIdxs = []int32{
 	0,   // 0: cleanroom.v1.Sandbox.status:type_name -> cleanroom.v1.SandboxStatus
-	95,  // 1: cleanroom.v1.Sandbox.created_at:type_name -> google.protobuf.Timestamp
-	95,  // 2: cleanroom.v1.Sandbox.updated_at:type_name -> google.protobuf.Timestamp
+	96,  // 1: cleanroom.v1.Sandbox.created_at:type_name -> google.protobuf.Timestamp
+	96,  // 2: cleanroom.v1.Sandbox.updated_at:type_name -> google.protobuf.Timestamp
 	24,  // 3: cleanroom.v1.Sandbox.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
-	93,  // 4: cleanroom.v1.Sandbox.backend_capabilities:type_name -> cleanroom.v1.Sandbox.BackendCapabilitiesEntry
-	8,   // 5: cleanroom.v1.SandboxPortFrame.open:type_name -> cleanroom.v1.SandboxPortOpen
-	9,   // 6: cleanroom.v1.SandboxPortFrame.close_write:type_name -> cleanroom.v1.SandboxPortCloseWrite
-	92,  // 7: cleanroom.v1.SandboxPortFrame.open_result:type_name -> cleanroom.v1.SandboxPortOpenResult
-	95,  // 8: cleanroom.v1.Snapshot.created_at:type_name -> google.protobuf.Timestamp
-	24,  // 9: cleanroom.v1.Snapshot.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
-	13,  // 10: cleanroom.v1.PolicyBlock.inputs:type_name -> cleanroom.v1.PolicyBlockInputs
-	94,  // 11: cleanroom.v1.PolicyBlock.env:type_name -> cleanroom.v1.PolicyBlock.EnvEntry
-	14,  // 12: cleanroom.v1.PolicyBlock.outputs:type_name -> cleanroom.v1.PolicyBlockOutputs
-	15,  // 13: cleanroom.v1.PolicyServices.blocks:type_name -> cleanroom.v1.PolicyBlock
-	15,  // 14: cleanroom.v1.PolicyDependencies.blocks:type_name -> cleanroom.v1.PolicyBlock
-	11,  // 15: cleanroom.v1.PolicyNetwork.allow:type_name -> cleanroom.v1.PolicyAllowRule
-	19,  // 16: cleanroom.v1.PolicyNetworkStages.workspace:type_name -> cleanroom.v1.PolicyNetwork
-	19,  // 17: cleanroom.v1.PolicyNetworkStages.dependencies:type_name -> cleanroom.v1.PolicyNetwork
-	19,  // 18: cleanroom.v1.PolicyNetworkStages.services:type_name -> cleanroom.v1.PolicyNetwork
-	19,  // 19: cleanroom.v1.PolicyNetworkStages.execution:type_name -> cleanroom.v1.PolicyNetwork
-	11,  // 20: cleanroom.v1.Policy.allow:type_name -> cleanroom.v1.PolicyAllowRule
-	16,  // 21: cleanroom.v1.Policy.services:type_name -> cleanroom.v1.PolicyServices
-	17,  // 22: cleanroom.v1.Policy.dependencies:type_name -> cleanroom.v1.PolicyDependencies
-	18,  // 23: cleanroom.v1.Policy.run:type_name -> cleanroom.v1.PolicyRun
-	21,  // 24: cleanroom.v1.Policy.resources:type_name -> cleanroom.v1.PolicyResources
-	20,  // 25: cleanroom.v1.Policy.network_stages:type_name -> cleanroom.v1.PolicyNetworkStages
-	12,  // 26: cleanroom.v1.Policy.docker:type_name -> cleanroom.v1.PolicyDocker
-	25,  // 27: cleanroom.v1.RepositoryChangeset.files:type_name -> cleanroom.v1.RepositoryChangesetFile
-	23,  // 28: cleanroom.v1.CreateSandboxRequest.options:type_name -> cleanroom.v1.SandboxOptions
-	22,  // 29: cleanroom.v1.CreateSandboxRequest.policy:type_name -> cleanroom.v1.Policy
-	24,  // 30: cleanroom.v1.CreateSandboxRequest.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
-	26,  // 31: cleanroom.v1.CreateSandboxRequest.repository_changeset:type_name -> cleanroom.v1.RepositoryChangeset
-	27,  // 32: cleanroom.v1.CreateSandboxRequest.repository_commit_bundle:type_name -> cleanroom.v1.RepositoryCommitBundle
-	5,   // 33: cleanroom.v1.CreateSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
-	1,   // 34: cleanroom.v1.CreateSandboxEvent.phase:type_name -> cleanroom.v1.CreateSandboxPhase
-	29,  // 35: cleanroom.v1.CreateSandboxEvent.response:type_name -> cleanroom.v1.CreateSandboxResponse
-	95,  // 36: cleanroom.v1.CreateSandboxEvent.occurred_at:type_name -> google.protobuf.Timestamp
-	5,   // 37: cleanroom.v1.GetSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
-	5,   // 38: cleanroom.v1.ListSandboxesResponse.sandboxes:type_name -> cleanroom.v1.Sandbox
-	73,  // 39: cleanroom.v1.ListExecutionsResponse.executions:type_name -> cleanroom.v1.Execution
-	2,   // 40: cleanroom.v1.SandboxPathInfo.type:type_name -> cleanroom.v1.SandboxPathType
-	95,  // 41: cleanroom.v1.SandboxPathInfo.mtime:type_name -> google.protobuf.Timestamp
-	41,  // 42: cleanroom.v1.StatSandboxPathResponse.info:type_name -> cleanroom.v1.SandboxPathInfo
-	41,  // 43: cleanroom.v1.WalkSandboxTreeResponse.info:type_name -> cleanroom.v1.SandboxPathInfo
-	95,  // 44: cleanroom.v1.WriteSandboxFileInit.mtime:type_name -> google.protobuf.Timestamp
-	48,  // 45: cleanroom.v1.WriteSandboxFileRequest.init:type_name -> cleanroom.v1.WriteSandboxFileInit
-	55,  // 46: cleanroom.v1.ExtractSandboxArchiveRequest.init:type_name -> cleanroom.v1.ExtractSandboxArchiveInit
-	0,   // 47: cleanroom.v1.SandboxEvent.status:type_name -> cleanroom.v1.SandboxStatus
-	95,  // 48: cleanroom.v1.SandboxEvent.occurred_at:type_name -> google.protobuf.Timestamp
-	10,  // 49: cleanroom.v1.CreateSnapshotResponse.snapshot:type_name -> cleanroom.v1.Snapshot
-	10,  // 50: cleanroom.v1.GetSnapshotResponse.snapshot:type_name -> cleanroom.v1.Snapshot
-	10,  // 51: cleanroom.v1.ListSnapshotsResponse.snapshots:type_name -> cleanroom.v1.Snapshot
-	72,  // 52: cleanroom.v1.LookupCachePeerResponse.candidate:type_name -> cleanroom.v1.CachePeerCandidate
-	95,  // 53: cleanroom.v1.CachePeerCandidate.expires_at:type_name -> google.protobuf.Timestamp
-	3,   // 54: cleanroom.v1.Execution.status:type_name -> cleanroom.v1.ExecutionStatus
-	95,  // 55: cleanroom.v1.Execution.started_at:type_name -> google.protobuf.Timestamp
-	95,  // 56: cleanroom.v1.Execution.finished_at:type_name -> google.protobuf.Timestamp
-	4,   // 57: cleanroom.v1.Execution.kind:type_name -> cleanroom.v1.ExecutionKind
-	74,  // 58: cleanroom.v1.CreateExecutionRequest.options:type_name -> cleanroom.v1.ExecutionOptions
-	4,   // 59: cleanroom.v1.CreateExecutionRequest.kind:type_name -> cleanroom.v1.ExecutionKind
-	24,  // 60: cleanroom.v1.CreateExecutionRequest.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
-	73,  // 61: cleanroom.v1.CreateExecutionResponse.execution:type_name -> cleanroom.v1.Execution
-	95,  // 62: cleanroom.v1.AttachExecutionResponse.expires_at:type_name -> google.protobuf.Timestamp
-	73,  // 63: cleanroom.v1.GetExecutionResponse.execution:type_name -> cleanroom.v1.Execution
-	73,  // 64: cleanroom.v1.InspectExecutionResponse.execution:type_name -> cleanroom.v1.Execution
-	96,  // 65: cleanroom.v1.InspectExecutionResponse.observability:type_name -> google.protobuf.Struct
-	3,   // 66: cleanroom.v1.CancelExecutionResponse.status:type_name -> cleanroom.v1.ExecutionStatus
-	3,   // 67: cleanroom.v1.ExecutionExit.status:type_name -> cleanroom.v1.ExecutionStatus
-	3,   // 68: cleanroom.v1.ExecutionStreamEvent.status:type_name -> cleanroom.v1.ExecutionStatus
-	90,  // 69: cleanroom.v1.ExecutionStreamEvent.exit:type_name -> cleanroom.v1.ExecutionExit
-	95,  // 70: cleanroom.v1.ExecutionStreamEvent.occurred_at:type_name -> google.protobuf.Timestamp
-	28,  // 71: cleanroom.v1.SandboxService.CreateSandbox:input_type -> cleanroom.v1.CreateSandboxRequest
-	28,  // 72: cleanroom.v1.SandboxService.CreateSandboxStream:input_type -> cleanroom.v1.CreateSandboxRequest
-	31,  // 73: cleanroom.v1.SandboxService.GetSandbox:input_type -> cleanroom.v1.GetSandboxRequest
-	33,  // 74: cleanroom.v1.SandboxService.ListSandboxes:input_type -> cleanroom.v1.ListSandboxesRequest
-	37,  // 75: cleanroom.v1.SandboxService.DownloadSandboxFile:input_type -> cleanroom.v1.DownloadSandboxFileRequest
-	39,  // 76: cleanroom.v1.SandboxService.UploadSandboxFile:input_type -> cleanroom.v1.UploadSandboxFileRequest
-	42,  // 77: cleanroom.v1.SandboxService.StatSandboxPath:input_type -> cleanroom.v1.StatSandboxPathRequest
-	44,  // 78: cleanroom.v1.SandboxService.WalkSandboxTree:input_type -> cleanroom.v1.WalkSandboxTreeRequest
-	46,  // 79: cleanroom.v1.SandboxService.ReadSandboxFile:input_type -> cleanroom.v1.ReadSandboxFileRequest
-	49,  // 80: cleanroom.v1.SandboxService.WriteSandboxFile:input_type -> cleanroom.v1.WriteSandboxFileRequest
-	51,  // 81: cleanroom.v1.SandboxService.RemoveSandboxPath:input_type -> cleanroom.v1.RemoveSandboxPathRequest
-	53,  // 82: cleanroom.v1.SandboxService.ArchiveSandboxPaths:input_type -> cleanroom.v1.ArchiveSandboxPathsRequest
-	56,  // 83: cleanroom.v1.SandboxService.ExtractSandboxArchive:input_type -> cleanroom.v1.ExtractSandboxArchiveRequest
-	58,  // 84: cleanroom.v1.SandboxService.TerminateSandbox:input_type -> cleanroom.v1.TerminateSandboxRequest
-	60,  // 85: cleanroom.v1.SandboxService.StreamSandboxEvents:input_type -> cleanroom.v1.StreamSandboxEventsRequest
-	7,   // 86: cleanroom.v1.SandboxService.DialSandboxPort:input_type -> cleanroom.v1.SandboxPortFrame
-	62,  // 87: cleanroom.v1.SnapshotService.CreateSnapshot:input_type -> cleanroom.v1.CreateSnapshotRequest
-	64,  // 88: cleanroom.v1.SnapshotService.GetSnapshot:input_type -> cleanroom.v1.GetSnapshotRequest
-	66,  // 89: cleanroom.v1.SnapshotService.ListSnapshots:input_type -> cleanroom.v1.ListSnapshotsRequest
-	68,  // 90: cleanroom.v1.SnapshotService.DeleteSnapshot:input_type -> cleanroom.v1.DeleteSnapshotRequest
-	70,  // 91: cleanroom.v1.CachePeerService.LookupCachePeer:input_type -> cleanroom.v1.LookupCachePeerRequest
-	35,  // 92: cleanroom.v1.ExecutionService.ListExecutions:input_type -> cleanroom.v1.ListExecutionsRequest
-	75,  // 93: cleanroom.v1.ExecutionService.CreateExecution:input_type -> cleanroom.v1.CreateExecutionRequest
-	77,  // 94: cleanroom.v1.ExecutionService.AttachExecution:input_type -> cleanroom.v1.AttachExecutionRequest
-	79,  // 95: cleanroom.v1.ExecutionService.GetExecution:input_type -> cleanroom.v1.GetExecutionRequest
-	81,  // 96: cleanroom.v1.ExecutionService.InspectExecution:input_type -> cleanroom.v1.InspectExecutionRequest
-	83,  // 97: cleanroom.v1.ExecutionService.CancelExecution:input_type -> cleanroom.v1.CancelExecutionRequest
-	85,  // 98: cleanroom.v1.ExecutionService.WriteExecutionStdin:input_type -> cleanroom.v1.WriteExecutionStdinRequest
-	87,  // 99: cleanroom.v1.ExecutionService.CloseExecutionStdin:input_type -> cleanroom.v1.CloseExecutionStdinRequest
-	89,  // 100: cleanroom.v1.ExecutionService.StreamExecution:input_type -> cleanroom.v1.StreamExecutionRequest
-	29,  // 101: cleanroom.v1.SandboxService.CreateSandbox:output_type -> cleanroom.v1.CreateSandboxResponse
-	30,  // 102: cleanroom.v1.SandboxService.CreateSandboxStream:output_type -> cleanroom.v1.CreateSandboxEvent
-	32,  // 103: cleanroom.v1.SandboxService.GetSandbox:output_type -> cleanroom.v1.GetSandboxResponse
-	34,  // 104: cleanroom.v1.SandboxService.ListSandboxes:output_type -> cleanroom.v1.ListSandboxesResponse
-	38,  // 105: cleanroom.v1.SandboxService.DownloadSandboxFile:output_type -> cleanroom.v1.DownloadSandboxFileResponse
-	40,  // 106: cleanroom.v1.SandboxService.UploadSandboxFile:output_type -> cleanroom.v1.UploadSandboxFileResponse
-	43,  // 107: cleanroom.v1.SandboxService.StatSandboxPath:output_type -> cleanroom.v1.StatSandboxPathResponse
-	45,  // 108: cleanroom.v1.SandboxService.WalkSandboxTree:output_type -> cleanroom.v1.WalkSandboxTreeResponse
-	47,  // 109: cleanroom.v1.SandboxService.ReadSandboxFile:output_type -> cleanroom.v1.ReadSandboxFileResponse
-	50,  // 110: cleanroom.v1.SandboxService.WriteSandboxFile:output_type -> cleanroom.v1.WriteSandboxFileResponse
-	52,  // 111: cleanroom.v1.SandboxService.RemoveSandboxPath:output_type -> cleanroom.v1.RemoveSandboxPathResponse
-	54,  // 112: cleanroom.v1.SandboxService.ArchiveSandboxPaths:output_type -> cleanroom.v1.ArchiveSandboxPathsResponse
-	57,  // 113: cleanroom.v1.SandboxService.ExtractSandboxArchive:output_type -> cleanroom.v1.ExtractSandboxArchiveResponse
-	59,  // 114: cleanroom.v1.SandboxService.TerminateSandbox:output_type -> cleanroom.v1.TerminateSandboxResponse
-	61,  // 115: cleanroom.v1.SandboxService.StreamSandboxEvents:output_type -> cleanroom.v1.SandboxEvent
-	7,   // 116: cleanroom.v1.SandboxService.DialSandboxPort:output_type -> cleanroom.v1.SandboxPortFrame
-	63,  // 117: cleanroom.v1.SnapshotService.CreateSnapshot:output_type -> cleanroom.v1.CreateSnapshotResponse
-	65,  // 118: cleanroom.v1.SnapshotService.GetSnapshot:output_type -> cleanroom.v1.GetSnapshotResponse
-	67,  // 119: cleanroom.v1.SnapshotService.ListSnapshots:output_type -> cleanroom.v1.ListSnapshotsResponse
-	69,  // 120: cleanroom.v1.SnapshotService.DeleteSnapshot:output_type -> cleanroom.v1.DeleteSnapshotResponse
-	71,  // 121: cleanroom.v1.CachePeerService.LookupCachePeer:output_type -> cleanroom.v1.LookupCachePeerResponse
-	36,  // 122: cleanroom.v1.ExecutionService.ListExecutions:output_type -> cleanroom.v1.ListExecutionsResponse
-	76,  // 123: cleanroom.v1.ExecutionService.CreateExecution:output_type -> cleanroom.v1.CreateExecutionResponse
-	78,  // 124: cleanroom.v1.ExecutionService.AttachExecution:output_type -> cleanroom.v1.AttachExecutionResponse
-	80,  // 125: cleanroom.v1.ExecutionService.GetExecution:output_type -> cleanroom.v1.GetExecutionResponse
-	82,  // 126: cleanroom.v1.ExecutionService.InspectExecution:output_type -> cleanroom.v1.InspectExecutionResponse
-	84,  // 127: cleanroom.v1.ExecutionService.CancelExecution:output_type -> cleanroom.v1.CancelExecutionResponse
-	86,  // 128: cleanroom.v1.ExecutionService.WriteExecutionStdin:output_type -> cleanroom.v1.WriteExecutionStdinResponse
-	88,  // 129: cleanroom.v1.ExecutionService.CloseExecutionStdin:output_type -> cleanroom.v1.CloseExecutionStdinResponse
-	91,  // 130: cleanroom.v1.ExecutionService.StreamExecution:output_type -> cleanroom.v1.ExecutionStreamEvent
-	101, // [101:131] is the sub-list for method output_type
-	71,  // [71:101] is the sub-list for method input_type
-	71,  // [71:71] is the sub-list for extension type_name
-	71,  // [71:71] is the sub-list for extension extendee
-	0,   // [0:71] is the sub-list for field type_name
+	94,  // 4: cleanroom.v1.Sandbox.backend_capabilities:type_name -> cleanroom.v1.Sandbox.BackendCapabilitiesEntry
+	93,  // 5: cleanroom.v1.Sandbox.effective_resources:type_name -> cleanroom.v1.SandboxResources
+	8,   // 6: cleanroom.v1.SandboxPortFrame.open:type_name -> cleanroom.v1.SandboxPortOpen
+	9,   // 7: cleanroom.v1.SandboxPortFrame.close_write:type_name -> cleanroom.v1.SandboxPortCloseWrite
+	92,  // 8: cleanroom.v1.SandboxPortFrame.open_result:type_name -> cleanroom.v1.SandboxPortOpenResult
+	96,  // 9: cleanroom.v1.Snapshot.created_at:type_name -> google.protobuf.Timestamp
+	24,  // 10: cleanroom.v1.Snapshot.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
+	13,  // 11: cleanroom.v1.PolicyBlock.inputs:type_name -> cleanroom.v1.PolicyBlockInputs
+	95,  // 12: cleanroom.v1.PolicyBlock.env:type_name -> cleanroom.v1.PolicyBlock.EnvEntry
+	14,  // 13: cleanroom.v1.PolicyBlock.outputs:type_name -> cleanroom.v1.PolicyBlockOutputs
+	15,  // 14: cleanroom.v1.PolicyServices.blocks:type_name -> cleanroom.v1.PolicyBlock
+	15,  // 15: cleanroom.v1.PolicyDependencies.blocks:type_name -> cleanroom.v1.PolicyBlock
+	11,  // 16: cleanroom.v1.PolicyNetwork.allow:type_name -> cleanroom.v1.PolicyAllowRule
+	19,  // 17: cleanroom.v1.PolicyNetworkStages.workspace:type_name -> cleanroom.v1.PolicyNetwork
+	19,  // 18: cleanroom.v1.PolicyNetworkStages.dependencies:type_name -> cleanroom.v1.PolicyNetwork
+	19,  // 19: cleanroom.v1.PolicyNetworkStages.services:type_name -> cleanroom.v1.PolicyNetwork
+	19,  // 20: cleanroom.v1.PolicyNetworkStages.execution:type_name -> cleanroom.v1.PolicyNetwork
+	11,  // 21: cleanroom.v1.Policy.allow:type_name -> cleanroom.v1.PolicyAllowRule
+	16,  // 22: cleanroom.v1.Policy.services:type_name -> cleanroom.v1.PolicyServices
+	17,  // 23: cleanroom.v1.Policy.dependencies:type_name -> cleanroom.v1.PolicyDependencies
+	18,  // 24: cleanroom.v1.Policy.run:type_name -> cleanroom.v1.PolicyRun
+	21,  // 25: cleanroom.v1.Policy.resources:type_name -> cleanroom.v1.PolicyResources
+	20,  // 26: cleanroom.v1.Policy.network_stages:type_name -> cleanroom.v1.PolicyNetworkStages
+	12,  // 27: cleanroom.v1.Policy.docker:type_name -> cleanroom.v1.PolicyDocker
+	25,  // 28: cleanroom.v1.RepositoryChangeset.files:type_name -> cleanroom.v1.RepositoryChangesetFile
+	23,  // 29: cleanroom.v1.CreateSandboxRequest.options:type_name -> cleanroom.v1.SandboxOptions
+	22,  // 30: cleanroom.v1.CreateSandboxRequest.policy:type_name -> cleanroom.v1.Policy
+	24,  // 31: cleanroom.v1.CreateSandboxRequest.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
+	26,  // 32: cleanroom.v1.CreateSandboxRequest.repository_changeset:type_name -> cleanroom.v1.RepositoryChangeset
+	27,  // 33: cleanroom.v1.CreateSandboxRequest.repository_commit_bundle:type_name -> cleanroom.v1.RepositoryCommitBundle
+	5,   // 34: cleanroom.v1.CreateSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
+	1,   // 35: cleanroom.v1.CreateSandboxEvent.phase:type_name -> cleanroom.v1.CreateSandboxPhase
+	29,  // 36: cleanroom.v1.CreateSandboxEvent.response:type_name -> cleanroom.v1.CreateSandboxResponse
+	96,  // 37: cleanroom.v1.CreateSandboxEvent.occurred_at:type_name -> google.protobuf.Timestamp
+	5,   // 38: cleanroom.v1.GetSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
+	5,   // 39: cleanroom.v1.ListSandboxesResponse.sandboxes:type_name -> cleanroom.v1.Sandbox
+	73,  // 40: cleanroom.v1.ListExecutionsResponse.executions:type_name -> cleanroom.v1.Execution
+	2,   // 41: cleanroom.v1.SandboxPathInfo.type:type_name -> cleanroom.v1.SandboxPathType
+	96,  // 42: cleanroom.v1.SandboxPathInfo.mtime:type_name -> google.protobuf.Timestamp
+	41,  // 43: cleanroom.v1.StatSandboxPathResponse.info:type_name -> cleanroom.v1.SandboxPathInfo
+	41,  // 44: cleanroom.v1.WalkSandboxTreeResponse.info:type_name -> cleanroom.v1.SandboxPathInfo
+	96,  // 45: cleanroom.v1.WriteSandboxFileInit.mtime:type_name -> google.protobuf.Timestamp
+	48,  // 46: cleanroom.v1.WriteSandboxFileRequest.init:type_name -> cleanroom.v1.WriteSandboxFileInit
+	55,  // 47: cleanroom.v1.ExtractSandboxArchiveRequest.init:type_name -> cleanroom.v1.ExtractSandboxArchiveInit
+	0,   // 48: cleanroom.v1.SandboxEvent.status:type_name -> cleanroom.v1.SandboxStatus
+	96,  // 49: cleanroom.v1.SandboxEvent.occurred_at:type_name -> google.protobuf.Timestamp
+	10,  // 50: cleanroom.v1.CreateSnapshotResponse.snapshot:type_name -> cleanroom.v1.Snapshot
+	10,  // 51: cleanroom.v1.GetSnapshotResponse.snapshot:type_name -> cleanroom.v1.Snapshot
+	10,  // 52: cleanroom.v1.ListSnapshotsResponse.snapshots:type_name -> cleanroom.v1.Snapshot
+	72,  // 53: cleanroom.v1.LookupCachePeerResponse.candidate:type_name -> cleanroom.v1.CachePeerCandidate
+	96,  // 54: cleanroom.v1.CachePeerCandidate.expires_at:type_name -> google.protobuf.Timestamp
+	3,   // 55: cleanroom.v1.Execution.status:type_name -> cleanroom.v1.ExecutionStatus
+	96,  // 56: cleanroom.v1.Execution.started_at:type_name -> google.protobuf.Timestamp
+	96,  // 57: cleanroom.v1.Execution.finished_at:type_name -> google.protobuf.Timestamp
+	4,   // 58: cleanroom.v1.Execution.kind:type_name -> cleanroom.v1.ExecutionKind
+	74,  // 59: cleanroom.v1.CreateExecutionRequest.options:type_name -> cleanroom.v1.ExecutionOptions
+	4,   // 60: cleanroom.v1.CreateExecutionRequest.kind:type_name -> cleanroom.v1.ExecutionKind
+	24,  // 61: cleanroom.v1.CreateExecutionRequest.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
+	73,  // 62: cleanroom.v1.CreateExecutionResponse.execution:type_name -> cleanroom.v1.Execution
+	96,  // 63: cleanroom.v1.AttachExecutionResponse.expires_at:type_name -> google.protobuf.Timestamp
+	73,  // 64: cleanroom.v1.GetExecutionResponse.execution:type_name -> cleanroom.v1.Execution
+	73,  // 65: cleanroom.v1.InspectExecutionResponse.execution:type_name -> cleanroom.v1.Execution
+	97,  // 66: cleanroom.v1.InspectExecutionResponse.observability:type_name -> google.protobuf.Struct
+	3,   // 67: cleanroom.v1.CancelExecutionResponse.status:type_name -> cleanroom.v1.ExecutionStatus
+	3,   // 68: cleanroom.v1.ExecutionExit.status:type_name -> cleanroom.v1.ExecutionStatus
+	3,   // 69: cleanroom.v1.ExecutionStreamEvent.status:type_name -> cleanroom.v1.ExecutionStatus
+	90,  // 70: cleanroom.v1.ExecutionStreamEvent.exit:type_name -> cleanroom.v1.ExecutionExit
+	96,  // 71: cleanroom.v1.ExecutionStreamEvent.occurred_at:type_name -> google.protobuf.Timestamp
+	28,  // 72: cleanroom.v1.SandboxService.CreateSandbox:input_type -> cleanroom.v1.CreateSandboxRequest
+	28,  // 73: cleanroom.v1.SandboxService.CreateSandboxStream:input_type -> cleanroom.v1.CreateSandboxRequest
+	31,  // 74: cleanroom.v1.SandboxService.GetSandbox:input_type -> cleanroom.v1.GetSandboxRequest
+	33,  // 75: cleanroom.v1.SandboxService.ListSandboxes:input_type -> cleanroom.v1.ListSandboxesRequest
+	37,  // 76: cleanroom.v1.SandboxService.DownloadSandboxFile:input_type -> cleanroom.v1.DownloadSandboxFileRequest
+	39,  // 77: cleanroom.v1.SandboxService.UploadSandboxFile:input_type -> cleanroom.v1.UploadSandboxFileRequest
+	42,  // 78: cleanroom.v1.SandboxService.StatSandboxPath:input_type -> cleanroom.v1.StatSandboxPathRequest
+	44,  // 79: cleanroom.v1.SandboxService.WalkSandboxTree:input_type -> cleanroom.v1.WalkSandboxTreeRequest
+	46,  // 80: cleanroom.v1.SandboxService.ReadSandboxFile:input_type -> cleanroom.v1.ReadSandboxFileRequest
+	49,  // 81: cleanroom.v1.SandboxService.WriteSandboxFile:input_type -> cleanroom.v1.WriteSandboxFileRequest
+	51,  // 82: cleanroom.v1.SandboxService.RemoveSandboxPath:input_type -> cleanroom.v1.RemoveSandboxPathRequest
+	53,  // 83: cleanroom.v1.SandboxService.ArchiveSandboxPaths:input_type -> cleanroom.v1.ArchiveSandboxPathsRequest
+	56,  // 84: cleanroom.v1.SandboxService.ExtractSandboxArchive:input_type -> cleanroom.v1.ExtractSandboxArchiveRequest
+	58,  // 85: cleanroom.v1.SandboxService.TerminateSandbox:input_type -> cleanroom.v1.TerminateSandboxRequest
+	60,  // 86: cleanroom.v1.SandboxService.StreamSandboxEvents:input_type -> cleanroom.v1.StreamSandboxEventsRequest
+	7,   // 87: cleanroom.v1.SandboxService.DialSandboxPort:input_type -> cleanroom.v1.SandboxPortFrame
+	62,  // 88: cleanroom.v1.SnapshotService.CreateSnapshot:input_type -> cleanroom.v1.CreateSnapshotRequest
+	64,  // 89: cleanroom.v1.SnapshotService.GetSnapshot:input_type -> cleanroom.v1.GetSnapshotRequest
+	66,  // 90: cleanroom.v1.SnapshotService.ListSnapshots:input_type -> cleanroom.v1.ListSnapshotsRequest
+	68,  // 91: cleanroom.v1.SnapshotService.DeleteSnapshot:input_type -> cleanroom.v1.DeleteSnapshotRequest
+	70,  // 92: cleanroom.v1.CachePeerService.LookupCachePeer:input_type -> cleanroom.v1.LookupCachePeerRequest
+	35,  // 93: cleanroom.v1.ExecutionService.ListExecutions:input_type -> cleanroom.v1.ListExecutionsRequest
+	75,  // 94: cleanroom.v1.ExecutionService.CreateExecution:input_type -> cleanroom.v1.CreateExecutionRequest
+	77,  // 95: cleanroom.v1.ExecutionService.AttachExecution:input_type -> cleanroom.v1.AttachExecutionRequest
+	79,  // 96: cleanroom.v1.ExecutionService.GetExecution:input_type -> cleanroom.v1.GetExecutionRequest
+	81,  // 97: cleanroom.v1.ExecutionService.InspectExecution:input_type -> cleanroom.v1.InspectExecutionRequest
+	83,  // 98: cleanroom.v1.ExecutionService.CancelExecution:input_type -> cleanroom.v1.CancelExecutionRequest
+	85,  // 99: cleanroom.v1.ExecutionService.WriteExecutionStdin:input_type -> cleanroom.v1.WriteExecutionStdinRequest
+	87,  // 100: cleanroom.v1.ExecutionService.CloseExecutionStdin:input_type -> cleanroom.v1.CloseExecutionStdinRequest
+	89,  // 101: cleanroom.v1.ExecutionService.StreamExecution:input_type -> cleanroom.v1.StreamExecutionRequest
+	29,  // 102: cleanroom.v1.SandboxService.CreateSandbox:output_type -> cleanroom.v1.CreateSandboxResponse
+	30,  // 103: cleanroom.v1.SandboxService.CreateSandboxStream:output_type -> cleanroom.v1.CreateSandboxEvent
+	32,  // 104: cleanroom.v1.SandboxService.GetSandbox:output_type -> cleanroom.v1.GetSandboxResponse
+	34,  // 105: cleanroom.v1.SandboxService.ListSandboxes:output_type -> cleanroom.v1.ListSandboxesResponse
+	38,  // 106: cleanroom.v1.SandboxService.DownloadSandboxFile:output_type -> cleanroom.v1.DownloadSandboxFileResponse
+	40,  // 107: cleanroom.v1.SandboxService.UploadSandboxFile:output_type -> cleanroom.v1.UploadSandboxFileResponse
+	43,  // 108: cleanroom.v1.SandboxService.StatSandboxPath:output_type -> cleanroom.v1.StatSandboxPathResponse
+	45,  // 109: cleanroom.v1.SandboxService.WalkSandboxTree:output_type -> cleanroom.v1.WalkSandboxTreeResponse
+	47,  // 110: cleanroom.v1.SandboxService.ReadSandboxFile:output_type -> cleanroom.v1.ReadSandboxFileResponse
+	50,  // 111: cleanroom.v1.SandboxService.WriteSandboxFile:output_type -> cleanroom.v1.WriteSandboxFileResponse
+	52,  // 112: cleanroom.v1.SandboxService.RemoveSandboxPath:output_type -> cleanroom.v1.RemoveSandboxPathResponse
+	54,  // 113: cleanroom.v1.SandboxService.ArchiveSandboxPaths:output_type -> cleanroom.v1.ArchiveSandboxPathsResponse
+	57,  // 114: cleanroom.v1.SandboxService.ExtractSandboxArchive:output_type -> cleanroom.v1.ExtractSandboxArchiveResponse
+	59,  // 115: cleanroom.v1.SandboxService.TerminateSandbox:output_type -> cleanroom.v1.TerminateSandboxResponse
+	61,  // 116: cleanroom.v1.SandboxService.StreamSandboxEvents:output_type -> cleanroom.v1.SandboxEvent
+	7,   // 117: cleanroom.v1.SandboxService.DialSandboxPort:output_type -> cleanroom.v1.SandboxPortFrame
+	63,  // 118: cleanroom.v1.SnapshotService.CreateSnapshot:output_type -> cleanroom.v1.CreateSnapshotResponse
+	65,  // 119: cleanroom.v1.SnapshotService.GetSnapshot:output_type -> cleanroom.v1.GetSnapshotResponse
+	67,  // 120: cleanroom.v1.SnapshotService.ListSnapshots:output_type -> cleanroom.v1.ListSnapshotsResponse
+	69,  // 121: cleanroom.v1.SnapshotService.DeleteSnapshot:output_type -> cleanroom.v1.DeleteSnapshotResponse
+	71,  // 122: cleanroom.v1.CachePeerService.LookupCachePeer:output_type -> cleanroom.v1.LookupCachePeerResponse
+	36,  // 123: cleanroom.v1.ExecutionService.ListExecutions:output_type -> cleanroom.v1.ListExecutionsResponse
+	76,  // 124: cleanroom.v1.ExecutionService.CreateExecution:output_type -> cleanroom.v1.CreateExecutionResponse
+	78,  // 125: cleanroom.v1.ExecutionService.AttachExecution:output_type -> cleanroom.v1.AttachExecutionResponse
+	80,  // 126: cleanroom.v1.ExecutionService.GetExecution:output_type -> cleanroom.v1.GetExecutionResponse
+	82,  // 127: cleanroom.v1.ExecutionService.InspectExecution:output_type -> cleanroom.v1.InspectExecutionResponse
+	84,  // 128: cleanroom.v1.ExecutionService.CancelExecution:output_type -> cleanroom.v1.CancelExecutionResponse
+	86,  // 129: cleanroom.v1.ExecutionService.WriteExecutionStdin:output_type -> cleanroom.v1.WriteExecutionStdinResponse
+	88,  // 130: cleanroom.v1.ExecutionService.CloseExecutionStdin:output_type -> cleanroom.v1.CloseExecutionStdinResponse
+	91,  // 131: cleanroom.v1.ExecutionService.StreamExecution:output_type -> cleanroom.v1.ExecutionStreamEvent
+	102, // [102:132] is the sub-list for method output_type
+	72,  // [72:102] is the sub-list for method input_type
+	72,  // [72:72] is the sub-list for extension type_name
+	72,  // [72:72] is the sub-list for extension extendee
+	0,   // [0:72] is the sub-list for field type_name
 }
 
 func init() { file_proto_cleanroom_v1_control_proto_init() }
@@ -6971,7 +7060,7 @@ func file_proto_cleanroom_v1_control_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proto_cleanroom_v1_control_proto_rawDesc), len(file_proto_cleanroom_v1_control_proto_rawDesc)),
 			NumEnums:      5,
-			NumMessages:   90,
+			NumMessages:   91,
 			NumExtensions: 0,
 			NumServices:   4,
 		},

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -204,6 +204,9 @@ type StageBlockOutputs struct {
 	Files []string `json:"files,omitempty"`
 }
 
+// Resources declares backend-neutral workload floors. The control plane raises
+// backend launch settings to satisfy these values but preserves larger runtime
+// defaults and leaves the exact allocation strategy to each backend.
 type Resources struct {
 	VCPUs       int64 `json:"vcpus,omitempty"`
 	MemoryBytes int64 `json:"memory_bytes,omitempty"`

--- a/proto/cleanroom/v1/control.proto
+++ b/proto/cleanroom/v1/control.proto
@@ -63,6 +63,8 @@ message Sandbox {
   string backing_snapshot_id = 11;
   RepositoryCheckout repository_checkout = 12;
   map<string, bool> backend_capabilities = 13;
+  // Resolved backend resource ceilings for this sandbox.
+  SandboxResources effective_resources = 14;
 }
 
 message PortExposure {
@@ -165,9 +167,16 @@ message PolicyNetworkStages {
   PolicyNetwork execution = 4;
 }
 
+// PolicyResources declares backend-neutral minimum workload requirements.
+// These values are floors, not exact reservations: control-plane code raises
+// lower backend runtime settings to meet them and preserves larger runtime
+// defaults. Backends decide how those effective ceilings map to host resources.
 message PolicyResources {
+  // Minimum effective vCPU ceiling required by the workload.
   int64 vcpus = 1;
+  // Minimum effective memory ceiling required by the workload, in bytes.
   int64 memory_bytes = 2;
+  // Minimum writable root filesystem capacity required by the workload, in bytes.
   int64 disk_bytes = 3;
 }
 
@@ -685,4 +694,15 @@ message ExecutionStreamEvent {
 
 message SandboxPortOpenResult {
   string error = 1;
+}
+
+// SandboxResources reports backend-effective resource ceilings for a sandbox.
+//
+// Values are resolved after runtime config, backend defaults, and policy
+// resource floors are merged. They describe the sandbox's effective launch
+// envelope, not exact host reservations.
+message SandboxResources {
+  int64 vcpus = 1;
+  int64 memory_bytes = 2;
+  int64 disk_bytes = 3;
 }


### PR DESCRIPTION
## Summary
- clarify `sandbox.resources` as backend-neutral floors instead of exact reservations
- expose resolved `Sandbox.effective_resources` through proto/client/server responses
- show effective resources in plain `cleanroom sandbox inspect` output
- share default launch resource values so reported resources match adapter launch behavior

## Why
Users need to see the actual sandbox launch envelope after runtime defaults and policy floors are merged. This makes the UX explicit without adding adaptive memory or extra configuration.

## Non-goals
- no memory balloon or adaptive memory behavior
- no CPU hotplug behavior
- no sparse-copy changes in this PR

## Validation
- `mise exec -- buf generate`
- `mise exec -- go test ./internal/controlservice ./internal/cli ./internal/backend ./internal/backend/firecracker ./internal/backend/darwinvz ./client`
- `git diff --check`

## Adversarial review
Local adversarial review found that the initial report could omit adapter default launch resources. Fixed by applying shared backend defaults before sandbox state is exposed and by making both adapters use the same constants.