### PR TITLE
perf: Preserve sparse file volume copies

### DIFF
--- a/internal/volumestore/file.go
+++ b/internal/volumestore/file.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -38,7 +37,11 @@ func copyFile(src, dst string) error {
 		return err
 	}
 	defer out.Close()
-	if _, err := io.Copy(out, in); err != nil {
+	info, err := in.Stat()
+	if err != nil {
+		return err
+	}
+	if err := copySparseFile(out, in, info.Size()); err != nil {
 		return err
 	}
 	if err := out.Chmod(0o644); err != nil {

--- a/internal/volumestore/file_sparse_test.go
+++ b/internal/volumestore/file_sparse_test.go
@@ -1,0 +1,135 @@
+//go:build darwin || linux
+
+package volumestore
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+func TestFileDriverPreservesSparseVolumeCopies(t *testing.T) {
+	const logicalSize = 64 << 20
+
+	sourcePath := filepath.Join(t.TempDir(), "prepared.ext4")
+	writeSparseVolumeForTest(t, sourcePath, logicalSize)
+
+	driver, err := NewFileDriver(FileDriverOptions{
+		SnapshotBaseDir: t.TempDir(),
+		Namespace:       "firecracker",
+	})
+	if err != nil {
+		t.Fatalf("NewFileDriver returned error: %v", err)
+	}
+
+	base, err := driver.EnsureBaseVolume(context.Background(), EnsureBaseVolumeRequest{
+		BaseID:     "runtime-key",
+		SourcePath: sourcePath,
+	})
+	if err != nil {
+		t.Fatalf("EnsureBaseVolume returned error: %v", err)
+	}
+	volume, err := driver.CreateWritableVolume(context.Background(), CreateWritableVolumeRequest{
+		VolumeID:       "sandbox-1",
+		BaseRef:        base.Ref,
+		AttachmentPath: filepath.Join(t.TempDir(), "sandbox-1.ext4"),
+	})
+	if err != nil {
+		t.Fatalf("CreateWritableVolume returned error: %v", err)
+	}
+	requireSparseVolumeForTest(t, volume.AttachmentPath, logicalSize)
+
+	snapshot, err := driver.SnapshotVolume(context.Background(), SnapshotVolumeRequest{
+		SnapshotID: "snap-1",
+		VolumeRef:  volume.AttachmentPath,
+	})
+	if err != nil {
+		t.Fatalf("SnapshotVolume returned error: %v", err)
+	}
+	requireSparseVolumeForTest(t, snapshot.Ref, logicalSize)
+
+	clone, err := driver.CloneSnapshotToVolume(context.Background(), CloneSnapshotToVolumeRequest{
+		VolumeID:       "sandbox-2",
+		SnapshotRef:    snapshot.Ref,
+		AttachmentPath: filepath.Join(t.TempDir(), "sandbox-2.ext4"),
+	})
+	if err != nil {
+		t.Fatalf("CloneSnapshotToVolume returned error: %v", err)
+	}
+	requireSparseVolumeForTest(t, clone.AttachmentPath, logicalSize)
+}
+
+func writeSparseVolumeForTest(t *testing.T, path string, logicalSize int64) {
+	t.Helper()
+
+	source, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create sparse source: %v", err)
+	}
+	if _, err := source.WriteAt([]byte("root"), 0); err != nil {
+		t.Fatalf("write source head: %v", err)
+	}
+	if _, err := source.WriteAt([]byte("tail"), logicalSize-4096); err != nil {
+		t.Fatalf("write source tail: %v", err)
+	}
+	if err := source.Truncate(logicalSize); err != nil {
+		t.Fatalf("truncate source: %v", err)
+	}
+	if err := source.Close(); err != nil {
+		t.Fatalf("close source: %v", err)
+	}
+	if allocated := allocatedSizeForTest(t, path); allocated > logicalSize/4 {
+		t.Skipf("test filesystem did not keep source sparse enough: allocated %d of %d bytes", allocated, logicalSize)
+	}
+}
+
+func requireSparseVolumeForTest(t *testing.T, path string, logicalSize int64) {
+	t.Helper()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat sparse volume: %v", err)
+	}
+	if got := info.Size(); got != logicalSize {
+		t.Fatalf("unexpected logical size: got %d want %d", got, int64(logicalSize))
+	}
+	if allocated := allocatedSizeForTest(t, path); allocated > logicalSize/4 {
+		t.Fatalf("writable volume did not stay sparse: allocated %d of %d bytes", allocated, logicalSize)
+	}
+	requireBytesAt(t, path, 0, []byte("root"))
+	requireBytesAt(t, path, logicalSize-4096, []byte("tail"))
+}
+
+func allocatedSizeForTest(t *testing.T, path string) int64 {
+	t.Helper()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %q: %v", path, err)
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Fatalf("stat %q did not include syscall.Stat_t", path)
+	}
+	return int64(stat.Blocks) * 512
+}
+
+func requireBytesAt(t *testing.T, path string, offset int64, want []byte) {
+	t.Helper()
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open %q: %v", path, err)
+	}
+	defer f.Close()
+
+	got := make([]byte, len(want))
+	if _, err := f.ReadAt(got, offset); err != nil {
+		t.Fatalf("read %q at %d: %v", path, offset, err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("unexpected bytes at %d: got %q want %q", offset, got, want)
+	}
+}

--- a/internal/volumestore/sparse_copy.go
+++ b/internal/volumestore/sparse_copy.go
@@ -1,0 +1,20 @@
+package volumestore
+
+import (
+	"io"
+	"os"
+)
+
+func copyDenseFile(dst, src *os.File) error {
+	if _, err := src.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+	if err := dst.Truncate(0); err != nil {
+		return err
+	}
+	if _, err := dst.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+	_, err := io.Copy(dst, src)
+	return err
+}

--- a/internal/volumestore/sparse_copy_fallback.go
+++ b/internal/volumestore/sparse_copy_fallback.go
@@ -1,0 +1,9 @@
+//go:build !darwin && !linux
+
+package volumestore
+
+import "os"
+
+func copySparseFile(dst, src *os.File, _ int64) error {
+	return copyDenseFile(dst, src)
+}

--- a/internal/volumestore/sparse_copy_unix.go
+++ b/internal/volumestore/sparse_copy_unix.go
@@ -1,0 +1,67 @@
+//go:build darwin || linux
+
+package volumestore
+
+import (
+	"errors"
+	"io"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func copySparseFile(dst, src *os.File, size int64) error {
+	if size <= 0 {
+		return dst.Truncate(0)
+	}
+	if err := dst.Truncate(size); err != nil {
+		return err
+	}
+
+	for offset := int64(0); offset < size; {
+		dataOffset, err := src.Seek(offset, unix.SEEK_DATA)
+		if err != nil {
+			if errors.Is(err, unix.ENXIO) {
+				return nil
+			}
+			if sparseSeekUnsupported(err) {
+				return copyDenseFile(dst, src)
+			}
+			return err
+		}
+		if dataOffset >= size {
+			return nil
+		}
+
+		holeOffset, err := src.Seek(dataOffset, unix.SEEK_HOLE)
+		if err != nil {
+			if sparseSeekUnsupported(err) {
+				return copyDenseFile(dst, src)
+			}
+			return err
+		}
+		if holeOffset > size {
+			holeOffset = size
+		}
+		if holeOffset <= dataOffset {
+			return copyDenseFile(dst, src)
+		}
+
+		if _, err := src.Seek(dataOffset, io.SeekStart); err != nil {
+			return err
+		}
+		if _, err := dst.Seek(dataOffset, io.SeekStart); err != nil {
+			return err
+		}
+		if _, err := io.CopyN(dst, src, holeOffset-dataOffset); err != nil {
+			return err
+		}
+		offset = holeOffset
+	}
+
+	return nil
+}
+
+func sparseSeekUnsupported(err error) bool {
+	return errors.Is(err, unix.EINVAL) || errors.Is(err, unix.ENOTTY) || errors.Is(err, unix.ENOTSUP)
+}


### PR DESCRIPTION
## Summary
- preserve sparse holes when the file volume driver copies writable volumes, snapshots, and cloned snapshots on Darwin/Linux
- keep dense-copy fallback behavior for unsupported platforms or filesystems
- add sparse allocation coverage across the file-driver copy paths

## Why
Large ext4 rootfs images can be logically large but mostly empty. The previous file driver copied every byte and could densify those images during volume and snapshot copies.

## Validation
- `mise exec -- go test ./internal/volumestore`
- `git diff --check`

## Adversarial review
Local adversarial review found the first test only covered writable volume creation; the branch now also covers snapshot and clone copy paths before push.