### PR TITLE
refactor: Extract services stage cache resolution

### DIFF
--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -465,88 +465,27 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 			}
 
 			if servicesStageCachingEnabled {
-				emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_SERVICES_STAGE_CACHE, "checking services stage cache")
-				var record cachestore.Record
-				var found bool
-				var lookupReason string
-				err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.lookup_services_stage_cache", cachePhaseAttributes(
-					observability.CacheStageServices,
-					observability.CacheOperationLookup,
-					repository,
-					attribute.String(observability.AttrBackend, backendName),
-				), func(ctx context.Context) error {
-					var lookupErr error
-					record, found, lookupReason, lookupErr = s.lookupServicesStageCache(ctx, backendName, compiled, repository, changeset, servicesStagePlan)
-					setCacheLookupSpanAttributes(ctx, found, lookupReason, lookupErr)
-					return lookupErr
+				servicesHit, err := s.resolveServicesStageCache(ctx, servicesStageResolveRequest{
+					backendName:     backendName,
+					snapshotAdapter: snapshotAdapter,
+					compiled:        compiled,
+					firecrackerCfg:  firecrackerCfg,
+					repository:      repository,
+					changeset:       changeset,
+					commitBundle:    commitBundle,
+					options:         req.GetOptions(),
+					plan:            servicesStagePlan,
+					reporter:        reporter,
 				})
 				if err != nil {
-					s.logServicesStageWarning("lookup services stage cache", "", err)
-				} else {
-					if !found {
-						emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_SERVICES_STAGE_CACHE, "checking services stage cache peers")
-						importErr := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.import_services_stage_cache", cachePhaseAttributes(
-							observability.CacheStageServices,
-							observability.CacheOperationLookup,
-							repository,
-							attribute.String(observability.AttrBackend, backendName),
-						), func(ctx context.Context) error {
-							var imported bool
-							var err error
-							record, imported, err = s.importServicesStageCacheFromPeers(ctx, snapshotAdapter, backendName, compiled, firecrackerCfg, repository, changeset, servicesStagePlan)
-							found = imported
-							reason := lookupReason
-							if imported {
-								reason = ""
-							}
-							setCacheLookupSpanAttributes(ctx, imported, reason, err)
-							return err
-						})
-						if importErr != nil {
-							s.logServicesStageWarning("import services stage cache from peer", "", importErr)
-						}
-					}
-					if found {
-						s.logServicesStageCacheHit(record)
-						emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_SERVICES_STAGE_CACHE, "services stage cache hit")
-						emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_RESTORE_SERVICES_STAGE_CACHE, "restoring services stage cache")
-						restoreReq := &cleanroomv1.CreateSandboxRequest{
-							Backend: backendName,
-							Options: req.GetOptions(),
-						}
-						var restoreResp *cleanroomv1.CreateSandboxResponse
-						restoreErr := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.restore_services_stage_cache", cachePhaseAttributes(
-							observability.CacheStageServices,
-							observability.CacheOperationRestore,
-							repository,
-							attribute.String(observability.AttrBackend, backendName),
-						), func(ctx context.Context) error {
-							var err error
-							restoreResp, err = s.createSandboxFromCacheRecord(ctx, restoreReq, compiled, record, nil, reporter)
-							setCacheResultSpanAttribute(ctx, map[bool]string{true: observability.CacheResultFailed, false: observability.CacheResultRestored}[err != nil])
-							return err
-						})
-						if restoreErr == nil {
-							metricSourceKind = "services stage cache"
-							if cacheStore, err := s.cacheStoreOrErr(); err == nil {
-								if err := cacheStore.Touch(ctx, record.Stage, record.CacheKey); err != nil {
-									s.logServicesStageWarning("touch services stage cache", "", err)
-								}
-							}
-							s.retainRestoredSandboxRepositoryState(restoreResp, repository, commitBundle, changeset)
-							s.logServicesStageRestore(record, restoreResp.GetSandbox().GetSandboxId())
-							return restoreResp, nil
-						}
-						if errors.Is(restoreErr, errSandboxCreateAborted) {
-							return nil, restoreErr
-						}
-						recordCopy := record
-						replacedServicesStageRecord = &recordCopy
-						s.logServicesStageRestoreWarning(record, restoreErr)
-					} else {
-						s.logServicesStageCacheMiss(backendName, servicesStagePlan.CacheKey)
-						emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_SERVICES_STAGE_CACHE, "services stage cache miss")
-					}
+					return nil, err
+				}
+				if servicesHit.restored != nil {
+					metricSourceKind = "services stage cache"
+					return servicesHit.restored, nil
+				}
+				if servicesHit.replaced != nil {
+					replacedServicesStageRecord = servicesHit.replaced
 				}
 			}
 
@@ -617,85 +556,27 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 					}
 					if found {
 						if servicesStageCachingEnabled {
-							emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_SERVICES_STAGE_CACHE, "checking services stage cache")
-							var servicesRecord cachestore.Record
-							var servicesFound bool
-							var servicesLookupReason string
-							servicesLookupErr := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.lookup_services_stage_cache_after_dependency", cachePhaseAttributes(
-								observability.CacheStageServices,
-								observability.CacheOperationLookup,
-								repository,
-								attribute.String(observability.AttrBackend, backendName),
-							), func(ctx context.Context) error {
-								var lookupErr error
-								servicesRecord, servicesFound, servicesLookupReason, lookupErr = s.lookupServicesStageCache(ctx, backendName, compiled, repository, changeset, servicesStagePlan)
-								setCacheLookupSpanAttributes(ctx, servicesFound, servicesLookupReason, lookupErr)
-								return lookupErr
+							servicesHit, err := s.resolveServicesStageCacheAfterDependency(ctx, servicesStageResolveRequest{
+								backendName:     backendName,
+								snapshotAdapter: snapshotAdapter,
+								compiled:        compiled,
+								firecrackerCfg:  firecrackerCfg,
+								repository:      repository,
+								changeset:       changeset,
+								commitBundle:    commitBundle,
+								options:         req.GetOptions(),
+								plan:            servicesStagePlan,
+								reporter:        reporter,
 							})
-							if servicesLookupErr != nil {
-								s.logServicesStageWarning("lookup services stage cache after dependency stage cache", "", servicesLookupErr)
-							} else {
-								if !servicesFound {
-									emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_SERVICES_STAGE_CACHE, "checking services stage cache peers")
-									importErr := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.import_services_stage_cache_after_dependency", cachePhaseAttributes(
-										observability.CacheStageServices,
-										observability.CacheOperationLookup,
-										repository,
-										attribute.String(observability.AttrBackend, backendName),
-									), func(ctx context.Context) error {
-										var imported bool
-										var err error
-										servicesRecord, imported, err = s.importServicesStageCacheFromPeers(ctx, snapshotAdapter, backendName, compiled, firecrackerCfg, repository, changeset, servicesStagePlan)
-										servicesFound = imported
-										reason := servicesLookupReason
-										if imported {
-											reason = ""
-										}
-										setCacheLookupSpanAttributes(ctx, imported, reason, err)
-										return err
-									})
-									if importErr != nil {
-										s.logServicesStageWarning("import services stage cache from peer after dependency stage cache", "", importErr)
-									}
-								}
-								if servicesFound {
-									s.logServicesStageCacheHit(servicesRecord)
-									emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_SERVICES_STAGE_CACHE, "services stage cache hit")
-									emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_RESTORE_SERVICES_STAGE_CACHE, "restoring services stage cache")
-									restoreReq := &cleanroomv1.CreateSandboxRequest{
-										Backend: backendName,
-										Options: req.GetOptions(),
-									}
-									var restoreResp *cleanroomv1.CreateSandboxResponse
-									restoreErr := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.restore_services_stage_cache", cachePhaseAttributes(
-										observability.CacheStageServices,
-										observability.CacheOperationRestore,
-										repository,
-										attribute.String(observability.AttrBackend, backendName),
-									), func(ctx context.Context) error {
-										var err error
-										restoreResp, err = s.createSandboxFromCacheRecord(ctx, restoreReq, compiled, servicesRecord, nil, reporter)
-										setCacheResultSpanAttribute(ctx, map[bool]string{true: observability.CacheResultFailed, false: observability.CacheResultRestored}[err != nil])
-										return err
-									})
-									if restoreErr == nil {
-										metricSourceKind = "services stage cache"
-										if cacheStore, err := s.cacheStoreOrErr(); err == nil {
-											if err := cacheStore.Touch(ctx, servicesRecord.Stage, servicesRecord.CacheKey); err != nil {
-												s.logServicesStageWarning("touch services stage cache", "", err)
-											}
-										}
-										s.retainRestoredSandboxRepositoryState(restoreResp, repository, commitBundle, changeset)
-										s.logServicesStageRestore(servicesRecord, restoreResp.GetSandbox().GetSandboxId())
-										return restoreResp, nil
-									}
-									if errors.Is(restoreErr, errSandboxCreateAborted) {
-										return nil, restoreErr
-									}
-									recordCopy := servicesRecord
-									replacedServicesStageRecord = &recordCopy
-									s.logServicesStageRestoreWarning(servicesRecord, restoreErr)
-								}
+							if err != nil {
+								return nil, err
+							}
+							if servicesHit.restored != nil {
+								metricSourceKind = "services stage cache"
+								return servicesHit.restored, nil
+							}
+							if servicesHit.replaced != nil {
+								replacedServicesStageRecord = servicesHit.replaced
 							}
 						}
 

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -3655,6 +3655,143 @@ func TestCreateSandboxBootstrapsServicesAfterDependencyStageRestoreWithoutServic
 	}
 }
 
+func TestCreateSandboxDependencyRestoreFailureUsesWorkspaceCache(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	store := newMemorySnapshotStore()
+	adapter := &stubAdapter{}
+	var snapshotReqs []backend.SnapshotRequest
+	adapter.createSnapshotFn = func(_ context.Context, req backend.SnapshotRequest) (*backend.SnapshotResult, error) {
+		snapshotReqs = append(snapshotReqs, req)
+		return &backend.SnapshotResult{StorageRef: "/snapshots/" + req.SnapshotID + ".ext4"}, nil
+	}
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"go.mod":             "module example.com/test\n\ngo 1.26.2\n",
+		"go.sum":             "example.com/test v0.0.0 h1:abc123\n",
+		"docker-compose.yml": "services:\n  postgres:\n    image: postgres:17\n",
+	})
+	svc := newTestServiceWithSnapshotStore(adapter, store)
+	svc.RepositoryStore = mirrors
+
+	req := &cleanroomv1.CreateSandboxRequest{
+		Policy:             testRepositoryDependencyAndServicesPolicy(),
+		RepositoryCheckout: repositoryCheckout,
+	}
+
+	if _, err := svc.CreateSandbox(context.Background(), req); err != nil {
+		t.Fatalf("first CreateSandbox returned error: %v", err)
+	}
+
+	records, err := svc.CacheStore.List(context.Background())
+	if err != nil {
+		t.Fatalf("List cache records returned error: %v", err)
+	}
+	var (
+		workspaceRecord  *cachestore.Record
+		dependencyRecord *cachestore.Record
+	)
+	for _, record := range records {
+		switch record.Stage {
+		case workspaceStageName:
+			recordCopy := record
+			workspaceRecord = &recordCopy
+		case dependencyStageName:
+			recordCopy := record
+			dependencyRecord = &recordCopy
+		case servicesStageName:
+			if err := svc.CacheStore.Delete(context.Background(), record.Stage, record.CacheKey); err != nil {
+				t.Fatalf("Delete services cache record returned error: %v", err)
+			}
+		}
+	}
+	if workspaceRecord == nil {
+		t.Fatal("expected published workspace stage cache record")
+	}
+	if dependencyRecord == nil {
+		t.Fatal("expected published dependency stage cache record")
+	}
+
+	var restoreReqs []backend.ProvisionFromSnapshotRequest
+	adapter.provisionFromSnapshotFn = func(_ context.Context, req backend.ProvisionFromSnapshotRequest) error {
+		restoreReqs = append(restoreReqs, req)
+		if req.SnapshotID == dependencyRecord.BackingSnapshotID {
+			return errors.New("dependency stage restore failed")
+		}
+		return nil
+	}
+
+	secondResp, err := svc.CreateSandbox(context.Background(), req)
+	if err != nil {
+		t.Fatalf("second CreateSandbox returned error: %v", err)
+	}
+	if got, want := secondResp.GetSourceKind(), "workspace stage cache"; got != want {
+		t.Fatalf("unexpected response source kind: got %q want %q", got, want)
+	}
+	if got, want := secondResp.GetSandbox().GetSourceKind(), "workspace stage cache"; got != want {
+		t.Fatalf("unexpected sandbox source kind: got %q want %q", got, want)
+	}
+	if got, want := adapter.provisionCalls, 1; got != want {
+		t.Fatalf("expected dependency restore failure to fall back through workspace cache without cold provision, got %d want %d", got, want)
+	}
+	if got, want := adapter.provisionFromSnapshotCalls, 2; got != want {
+		t.Fatalf("expected failed dependency restore plus successful workspace restore, got %d want %d", got, want)
+	}
+	if got, want := len(restoreReqs), 2; got != want {
+		t.Fatalf("expected two restore requests, got %d want %d", got, want)
+	}
+	if got, want := restoreReqs[0].SnapshotID, dependencyRecord.BackingSnapshotID; got != want {
+		t.Fatalf("unexpected first restore snapshot id: got %q want %q", got, want)
+	}
+	if got, want := restoreReqs[1].SnapshotID, workspaceRecord.BackingSnapshotID; got != want {
+		t.Fatalf("unexpected second restore snapshot id: got %q want %q", got, want)
+	}
+	if got, want := adapter.runCalls, 5; got != want {
+		t.Fatalf("expected dependency and services bootstrap after workspace restore, got %d want %d", got, want)
+	}
+	if got, want := adapter.createSnapshotCalls, 5; got != want {
+		t.Fatalf("expected replacement dependency and services stage snapshots, got %d want %d", got, want)
+	}
+	if got, want := len(snapshotReqs), 5; got != want {
+		t.Fatalf("expected five snapshot publish requests, got %d want %d", got, want)
+	}
+	if got, want := adapter.deleteSnapshotCalls, 1; got != want {
+		t.Fatalf("expected stale dependency stage snapshot deletion, got %d want %d", got, want)
+	}
+	if got, want := adapter.deleteSnapshotReq.SnapshotID, dependencyRecord.BackingSnapshotID; got != want {
+		t.Fatalf("unexpected deleted snapshot id: got %q want %q", got, want)
+	}
+	if got, want := adapter.deleteSnapshotReq.StorageRef, dependencyRecord.StorageRef; got != want {
+		t.Fatalf("unexpected deleted storage ref: got %q want %q", got, want)
+	}
+
+	records, err = svc.CacheStore.List(context.Background())
+	if err != nil {
+		t.Fatalf("List cache records returned error: %v", err)
+	}
+	var (
+		replacementDependencyRecord *cachestore.Record
+		replacementServicesRecord   *cachestore.Record
+	)
+	for _, record := range records {
+		switch record.Stage {
+		case dependencyStageName:
+			recordCopy := record
+			replacementDependencyRecord = &recordCopy
+		case servicesStageName:
+			recordCopy := record
+			replacementServicesRecord = &recordCopy
+		}
+	}
+	if replacementDependencyRecord == nil {
+		t.Fatal("expected replacement dependency stage cache record")
+	}
+	if replacementServicesRecord == nil {
+		t.Fatal("expected replacement services stage cache record")
+	}
+	if got, stale := replacementDependencyRecord.BackingSnapshotID, dependencyRecord.BackingSnapshotID; got == stale {
+		t.Fatalf("expected dependency stage cache record to be replaced, still has backing snapshot id %q", got)
+	}
+}
+
 func TestCreateSandboxReusesPortableDependencyStageAfterCheckoutRefresh(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	store := newMemorySnapshotStore()

--- a/internal/controlservice/stage_cache_resolution.go
+++ b/internal/controlservice/stage_cache_resolution.go
@@ -1,0 +1,158 @@
+package controlservice
+
+import (
+	"context"
+	"errors"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/cachestore"
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+	"github.com/buildkite/cleanroom/internal/observability"
+	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/buildkite/cleanroom/internal/repositorybundle"
+	"github.com/buildkite/cleanroom/internal/repositorychangeset"
+	"github.com/buildkite/cleanroom/internal/repositorycheckout"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+type servicesStageResolveRequest struct {
+	backendName     string
+	snapshotAdapter backend.SnapshottingAdapter
+	compiled        *policy.CompiledPolicy
+	firecrackerCfg  backend.FirecrackerConfig
+	repository      *repositorycheckout.Checkout
+	changeset       *repositorychangeset.Changeset
+	commitBundle    *repositorybundle.Bundle
+	options         *cleanroomv1.SandboxOptions
+	plan            servicesStagePlan
+	reporter        CreateSandboxReporter
+	afterDependency bool
+}
+
+type servicesStageResolveResult struct {
+	restored *cleanroomv1.CreateSandboxResponse
+	replaced *cachestore.Record
+}
+
+func (s *Service) resolveServicesStageCache(ctx context.Context, req servicesStageResolveRequest) (servicesStageResolveResult, error) {
+	emitCreateSandboxMessage(req.reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_SERVICES_STAGE_CACHE, "checking services stage cache")
+	var record cachestore.Record
+	var found bool
+	var lookupReason string
+	err := s.traceCreateSandboxPhase(ctx, req.lookupTraceName(), cachePhaseAttributes(
+		observability.CacheStageServices,
+		observability.CacheOperationLookup,
+		req.repository,
+		attribute.String(observability.AttrBackend, req.backendName),
+	), func(ctx context.Context) error {
+		var lookupErr error
+		record, found, lookupReason, lookupErr = s.lookupServicesStageCache(ctx, req.backendName, req.compiled, req.repository, req.changeset, req.plan)
+		setCacheLookupSpanAttributes(ctx, found, lookupReason, lookupErr)
+		return lookupErr
+	})
+	if err != nil {
+		s.logServicesStageWarning(req.lookupWarning(), "", err)
+		return servicesStageResolveResult{}, nil
+	}
+
+	if !found {
+		emitCreateSandboxMessage(req.reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_SERVICES_STAGE_CACHE, "checking services stage cache peers")
+		importErr := s.traceCreateSandboxPhase(ctx, req.importTraceName(), cachePhaseAttributes(
+			observability.CacheStageServices,
+			observability.CacheOperationLookup,
+			req.repository,
+			attribute.String(observability.AttrBackend, req.backendName),
+		), func(ctx context.Context) error {
+			var imported bool
+			var err error
+			record, imported, err = s.importServicesStageCacheFromPeers(ctx, req.snapshotAdapter, req.backendName, req.compiled, req.firecrackerCfg, req.repository, req.changeset, req.plan)
+			found = imported
+			reason := lookupReason
+			if imported {
+				reason = ""
+			}
+			setCacheLookupSpanAttributes(ctx, imported, reason, err)
+			return err
+		})
+		if importErr != nil {
+			s.logServicesStageWarning(req.importWarning(), "", importErr)
+		}
+	}
+
+	if !found {
+		if !req.afterDependency {
+			s.logServicesStageCacheMiss(req.backendName, req.plan.CacheKey)
+			emitCreateSandboxMessage(req.reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_SERVICES_STAGE_CACHE, "services stage cache miss")
+		}
+		return servicesStageResolveResult{}, nil
+	}
+
+	s.logServicesStageCacheHit(record)
+	emitCreateSandboxMessage(req.reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_SERVICES_STAGE_CACHE, "services stage cache hit")
+	emitCreateSandboxMessage(req.reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_RESTORE_SERVICES_STAGE_CACHE, "restoring services stage cache")
+	restoreReq := &cleanroomv1.CreateSandboxRequest{
+		Backend: req.backendName,
+		Options: req.options,
+	}
+	var restoreResp *cleanroomv1.CreateSandboxResponse
+	restoreErr := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.restore_services_stage_cache", cachePhaseAttributes(
+		observability.CacheStageServices,
+		observability.CacheOperationRestore,
+		req.repository,
+		attribute.String(observability.AttrBackend, req.backendName),
+	), func(ctx context.Context) error {
+		var err error
+		restoreResp, err = s.createSandboxFromCacheRecord(ctx, restoreReq, req.compiled, record, nil, req.reporter)
+		setCacheResultSpanAttribute(ctx, map[bool]string{true: observability.CacheResultFailed, false: observability.CacheResultRestored}[err != nil])
+		return err
+	})
+	if restoreErr == nil {
+		if cacheStore, err := s.cacheStoreOrErr(); err == nil {
+			if err := cacheStore.Touch(ctx, record.Stage, record.CacheKey); err != nil {
+				s.logServicesStageWarning("touch services stage cache", "", err)
+			}
+		}
+		s.retainRestoredSandboxRepositoryState(restoreResp, req.repository, req.commitBundle, req.changeset)
+		s.logServicesStageRestore(record, restoreResp.GetSandbox().GetSandboxId())
+		return servicesStageResolveResult{restored: restoreResp}, nil
+	}
+	if errors.Is(restoreErr, errSandboxCreateAborted) {
+		return servicesStageResolveResult{}, restoreErr
+	}
+	recordCopy := record
+	s.logServicesStageRestoreWarning(record, restoreErr)
+	return servicesStageResolveResult{replaced: &recordCopy}, nil
+}
+
+func (s *Service) resolveServicesStageCacheAfterDependency(ctx context.Context, req servicesStageResolveRequest) (servicesStageResolveResult, error) {
+	req.afterDependency = true
+	return s.resolveServicesStageCache(ctx, req)
+}
+
+func (r servicesStageResolveRequest) lookupTraceName() string {
+	if r.afterDependency {
+		return "cleanroom.sandbox.lookup_services_stage_cache_after_dependency"
+	}
+	return "cleanroom.sandbox.lookup_services_stage_cache"
+}
+
+func (r servicesStageResolveRequest) importTraceName() string {
+	if r.afterDependency {
+		return "cleanroom.sandbox.import_services_stage_cache_after_dependency"
+	}
+	return "cleanroom.sandbox.import_services_stage_cache"
+}
+
+func (r servicesStageResolveRequest) lookupWarning() string {
+	if r.afterDependency {
+		return "lookup services stage cache after dependency stage cache"
+	}
+	return "lookup services stage cache"
+}
+
+func (r servicesStageResolveRequest) importWarning() string {
+	if r.afterDependency {
+		return "import services stage cache from peer after dependency stage cache"
+	}
+	return "import services stage cache from peer"
+}


### PR DESCRIPTION
## What changed

- Extracted services-stage cache lookup, peer import, restore, touch, and stale-record handling from `createSandbox` into a private `resolveServicesStageCache` flow.
- Reused the same resolution flow for both direct services-stage hits and services-after-dependency hits.
- Added coverage for a dependency-stage restore failure falling back through the workspace cache, then republishing dependency and services snapshots while deleting the stale dependency snapshot.

## Why

The services-stage cache restore path was duplicated inside `createSandbox`, making it hard to change cache resolution ordering without editing a large inline control flow. This is the first small slice toward a deeper stage-cache resolution module without moving the dependency/workspace continuation logic yet.

## Validation

- `mise exec -- go test ./internal/controlservice`
- `git diff --check origin/main...HEAD`
