### PR TITLE
feat: Expose sandbox resource gauges

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -120,6 +120,10 @@ phases.
 The current metric names are:
 
 - `cleanroom_sandbox_create_duration_seconds{backend,source,outcome}`
+- `cleanroom_sandbox_active_count{backend,status}`
+- `cleanroom_sandbox_effective_memory_bytes{backend,status}`
+- `cleanroom_sandbox_effective_vcpus{backend,status}`
+- `cleanroom_sandbox_effective_disk_bytes{backend,status}`
 - `cleanroom_execution_total{backend,kind,outcome}`
 - `cleanroom_execution_duration_seconds{backend,kind,outcome}`
 - `cleanroom_gateway_requests_total{service,action,reason_code,status_class}`
@@ -129,6 +133,11 @@ The current metric names are:
 Metric labels must stay low-cardinality. Execution IDs, sandbox IDs, image
 digests, and host IPs belong in traces, logs, or retained artefacts, not in
 metric labels.
+
+Sandbox resource metrics are aggregate gauges for active sandboxes grouped by
+backend and status. They report the effective launch envelope Cleanroom
+resolved for each sandbox, not guest runtime memory pressure or exact host
+reservations.
 
 ### Common attributes
 

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -233,12 +233,95 @@ func (s *Service) serviceMetrics() *observability.ServiceMetrics {
 		if s.Observability == nil {
 			return
 		}
-		s.metrics, s.metricsErr = observability.NewServiceMetrics(s.Observability.MeterProvider())
+		s.metrics, s.metricsErr = observability.NewServiceMetrics(s.Observability.MeterProvider(), s.sandboxResourceMetricSnapshots)
 		if s.metricsErr != nil && s.Logger != nil {
 			s.Logger.Warn("service metrics unavailable", "error", s.metricsErr)
 		}
 	})
 	return s.metrics
+}
+
+type sandboxResourceMetricKey struct {
+	Backend string
+	Status  string
+}
+
+func (s *Service) sandboxResourceMetricSnapshots(ctx context.Context) []observability.SandboxResourceMetricSnapshot {
+	if s == nil {
+		return nil
+	}
+	select {
+	case <-ctx.Done():
+		return nil
+	default:
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	totals := make(map[sandboxResourceMetricKey]observability.SandboxResourceMetricSnapshot)
+	for _, sb := range s.sandboxes {
+		if sb == nil || !sandboxStatusHasActiveResources(sb.Status) {
+			continue
+		}
+		resources := effectiveSandboxResources(sb.Firecracker)
+		if resources == nil {
+			continue
+		}
+		key := sandboxResourceMetricKey{
+			Backend: strings.TrimSpace(sb.Backend),
+			Status:  sandboxStatusMetricValue(sb.Status),
+		}
+		snapshot := totals[key]
+		snapshot.Backend = key.Backend
+		snapshot.Status = key.Status
+		snapshot.Count++
+		snapshot.EffectiveMemoryBytes += resources.GetMemoryBytes()
+		snapshot.EffectiveVCPUs += resources.GetVcpus()
+		snapshot.EffectiveDiskBytes += resources.GetDiskBytes()
+		totals[key] = snapshot
+	}
+
+	keys := make([]sandboxResourceMetricKey, 0, len(totals))
+	for key := range totals {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].Backend != keys[j].Backend {
+			return keys[i].Backend < keys[j].Backend
+		}
+		return keys[i].Status < keys[j].Status
+	})
+
+	out := make([]observability.SandboxResourceMetricSnapshot, 0, len(keys))
+	for _, key := range keys {
+		out = append(out, totals[key])
+	}
+	return out
+}
+
+func sandboxStatusHasActiveResources(status cleanroomv1.SandboxStatus) bool {
+	switch status {
+	case cleanroomv1.SandboxStatus_SANDBOX_STATUS_PROVISIONING,
+		cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY,
+		cleanroomv1.SandboxStatus_SANDBOX_STATUS_STOPPING:
+		return true
+	default:
+		return false
+	}
+}
+
+func sandboxStatusMetricValue(status cleanroomv1.SandboxStatus) string {
+	switch status {
+	case cleanroomv1.SandboxStatus_SANDBOX_STATUS_PROVISIONING:
+		return "provisioning"
+	case cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY:
+		return "ready"
+	case cleanroomv1.SandboxStatus_SANDBOX_STATUS_STOPPING:
+		return "stopping"
+	default:
+		return "unknown"
+	}
 }
 
 func sandboxCreateSourceMetricValue(snapshotID, sourceKind string) string {

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -676,6 +676,30 @@ func requireInt64SumMetricValue(t *testing.T, metrics metricdata.ResourceMetrics
 	t.Fatalf("metric %q with attrs %#v not found", name, attrs)
 }
 
+func requireInt64GaugeMetricValue(t *testing.T, metrics metricdata.ResourceMetrics, name string, attrs map[string]string, want int64) {
+	t.Helper()
+	for _, scopeMetrics := range metrics.ScopeMetrics {
+		for _, metric := range scopeMetrics.Metrics {
+			if metric.Name != name {
+				continue
+			}
+			gauge, ok := metric.Data.(metricdata.Gauge[int64])
+			if !ok {
+				t.Fatalf("metric %q had unexpected data type %T", name, metric.Data)
+			}
+			for _, point := range gauge.DataPoints {
+				if metricAttributesMatch(point.Attributes, attrs) {
+					if point.Value != want {
+						t.Fatalf("metric %q had value %d, want %d", name, point.Value, want)
+					}
+					return
+				}
+			}
+		}
+	}
+	t.Fatalf("metric %q with attrs %#v not found", name, attrs)
+}
+
 func requireHistogramMetricCount(t *testing.T, metrics metricdata.ResourceMetrics, name string, attrs map[string]string, want uint64) {
 	t.Helper()
 	for _, scopeMetrics := range metrics.ScopeMetrics {
@@ -1062,6 +1086,47 @@ func TestServiceEmitsSandboxAndExecutionMetrics(t *testing.T) {
 		"kind":    "batch",
 		"outcome": "succeeded",
 	}, 1)
+}
+
+func TestServiceEmitsSandboxResourceMetrics(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	tracerProvider := trace.NewTracerProvider()
+	defer func() {
+		_ = meterProvider.Shutdown(context.Background())
+		_ = tracerProvider.Shutdown(context.Background())
+	}()
+
+	obs, err := observability.NewWithProviders(tracerProvider, meterProvider)
+	if err != nil {
+		t.Fatalf("NewWithProviders returned error: %v", err)
+	}
+
+	svc := newTestService(&stubAdapter{})
+	svc.Observability = obs
+
+	policyProto := testPolicy()
+	policyProto.Resources = &cleanroomv1.PolicyResources{
+		Vcpus:       4,
+		MemoryBytes: (3 << 30) + 1,
+		DiskBytes:   16 << 30,
+	}
+	if _, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Backend: "firecracker",
+		Policy:  policyProto,
+	}); err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+
+	attrs := map[string]string{
+		observability.MetricLabelBackend: "firecracker",
+		observability.MetricLabelStatus:  "ready",
+	}
+	metrics := collectResourceMetrics(t, reader)
+	requireInt64GaugeMetricValue(t, metrics, observability.MetricSandboxActiveCount, attrs, 1)
+	requireInt64GaugeMetricValue(t, metrics, observability.MetricSandboxEffectiveVCPUs, attrs, 4)
+	requireInt64GaugeMetricValue(t, metrics, observability.MetricSandboxEffectiveMemoryBytes, attrs, 3073<<20)
+	requireInt64GaugeMetricValue(t, metrics, observability.MetricSandboxEffectiveDiskBytes, attrs, 16<<30)
 }
 
 func TestServiceSandboxCreateMetricsTrackWorkspaceCacheFailureSource(t *testing.T) {

--- a/internal/observability/contract.go
+++ b/internal/observability/contract.go
@@ -20,6 +20,10 @@ const (
 	MetricSandboxCreateDurationSeconds = "cleanroom_sandbox_create_duration_seconds"
 	MetricExecutionTotal               = "cleanroom_execution_total"
 	MetricExecutionDurationSeconds     = "cleanroom_execution_duration_seconds"
+	MetricSandboxEffectiveMemoryBytes  = "cleanroom_sandbox_effective_memory_bytes"
+	MetricSandboxEffectiveVCPUs        = "cleanroom_sandbox_effective_vcpus"
+	MetricSandboxEffectiveDiskBytes    = "cleanroom_sandbox_effective_disk_bytes"
+	MetricSandboxActiveCount           = "cleanroom_sandbox_active_count"
 	MetricGatewayRequestsTotal         = "cleanroom_gateway_requests_total"
 	MetricGatewayRequestDuration       = "cleanroom_gateway_request_duration_seconds"
 	MetricLaunchPhaseDurationSeconds   = "cleanroom_launch_phase_duration_seconds"
@@ -39,6 +43,7 @@ const (
 	MetricLabelAction      = "action"
 	MetricLabelReasonCode  = "reason_code"
 	MetricLabelStatusClass = "status_class"
+	MetricLabelStatus      = "status"
 	MetricLabelPhase       = "phase"
 
 	AttrBackend                = "cleanroom.backend"

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -15,13 +15,33 @@ type ServiceMetrics struct {
 	sandboxCreateDuration     metric.Float64Histogram
 	executionTotal            metric.Int64Counter
 	executionDuration         metric.Float64Histogram
+	sandboxEffectiveMemory    metric.Int64ObservableGauge
+	sandboxEffectiveVCPUs     metric.Int64ObservableGauge
+	sandboxEffectiveDisk      metric.Int64ObservableGauge
+	sandboxActive             metric.Int64ObservableGauge
+	sandboxResourceCallback   metric.Registration
 	cachePeerLookupTotal      metric.Int64Counter
 	cachePeerTransferBytes    metric.Int64Counter
 	cachePeerTransferDuration metric.Float64Histogram
 	cachePeerImportTotal      metric.Int64Counter
 }
 
-func NewServiceMetrics(provider metric.MeterProvider) (*ServiceMetrics, error) {
+// SandboxResourceMetricSnapshot is a low-cardinality aggregate of active
+// sandbox resource ceilings for one backend/status pair.
+type SandboxResourceMetricSnapshot struct {
+	Backend              string
+	Status               string
+	Count                int64
+	EffectiveMemoryBytes int64
+	EffectiveVCPUs       int64
+	EffectiveDiskBytes   int64
+}
+
+// SandboxResourceMetricObserver returns current sandbox resource aggregates for
+// service-level observable gauges.
+type SandboxResourceMetricObserver func(context.Context) []SandboxResourceMetricSnapshot
+
+func NewServiceMetrics(provider metric.MeterProvider, resourceObserver SandboxResourceMetricObserver) (*ServiceMetrics, error) {
 	meter := meterProviderOrNoop(provider).Meter("github.com/buildkite/cleanroom/internal/controlservice")
 	sandboxCreateDuration, err := meter.Float64Histogram(
 		MetricSandboxCreateDurationSeconds,
@@ -45,6 +65,63 @@ func NewServiceMetrics(provider metric.MeterProvider) (*ServiceMetrics, error) {
 	)
 	if err != nil {
 		return nil, err
+	}
+	sandboxEffectiveMemory, err := meter.Int64ObservableGauge(
+		MetricSandboxEffectiveMemoryBytes,
+		metric.WithDescription("Aggregate effective memory launch envelope for active sandboxes by backend and status"),
+		metric.WithUnit("By"),
+	)
+	if err != nil {
+		return nil, err
+	}
+	sandboxEffectiveVCPUs, err := meter.Int64ObservableGauge(
+		MetricSandboxEffectiveVCPUs,
+		metric.WithDescription("Aggregate effective vCPU launch envelope for active sandboxes by backend and status"),
+	)
+	if err != nil {
+		return nil, err
+	}
+	sandboxEffectiveDisk, err := meter.Int64ObservableGauge(
+		MetricSandboxEffectiveDiskBytes,
+		metric.WithDescription("Aggregate effective writable root filesystem capacity for active sandboxes by backend and status"),
+		metric.WithUnit("By"),
+	)
+	if err != nil {
+		return nil, err
+	}
+	sandboxActive, err := meter.Int64ObservableGauge(
+		MetricSandboxActiveCount,
+		metric.WithDescription("Active sandboxes by backend and status"),
+	)
+	if err != nil {
+		return nil, err
+	}
+	var sandboxResourceCallback metric.Registration
+	if resourceObserver != nil {
+		sandboxResourceCallback, err = meter.RegisterCallback(func(ctx context.Context, observer metric.Observer) error {
+			for _, snapshot := range resourceObserver(ctx) {
+				attrs := metric.WithAttributes(
+					attribute.String(MetricLabelBackend, normalizeMetricValue(snapshot.Backend, "unknown")),
+					attribute.String(MetricLabelStatus, normalizeMetricValue(snapshot.Status, "unknown")),
+				)
+				if snapshot.Count > 0 {
+					observer.ObserveInt64(sandboxActive, snapshot.Count, attrs)
+				}
+				if snapshot.EffectiveMemoryBytes > 0 {
+					observer.ObserveInt64(sandboxEffectiveMemory, snapshot.EffectiveMemoryBytes, attrs)
+				}
+				if snapshot.EffectiveVCPUs > 0 {
+					observer.ObserveInt64(sandboxEffectiveVCPUs, snapshot.EffectiveVCPUs, attrs)
+				}
+				if snapshot.EffectiveDiskBytes > 0 {
+					observer.ObserveInt64(sandboxEffectiveDisk, snapshot.EffectiveDiskBytes, attrs)
+				}
+			}
+			return nil
+		}, sandboxEffectiveMemory, sandboxEffectiveVCPUs, sandboxEffectiveDisk, sandboxActive)
+		if err != nil {
+			return nil, err
+		}
 	}
 	cachePeerLookupTotal, err := meter.Int64Counter(
 		MetricCachePeerLookupTotal,
@@ -80,6 +157,11 @@ func NewServiceMetrics(provider metric.MeterProvider) (*ServiceMetrics, error) {
 		sandboxCreateDuration:     sandboxCreateDuration,
 		executionTotal:            executionTotal,
 		executionDuration:         executionDuration,
+		sandboxEffectiveMemory:    sandboxEffectiveMemory,
+		sandboxEffectiveVCPUs:     sandboxEffectiveVCPUs,
+		sandboxEffectiveDisk:      sandboxEffectiveDisk,
+		sandboxActive:             sandboxActive,
+		sandboxResourceCallback:   sandboxResourceCallback,
 		cachePeerLookupTotal:      cachePeerLookupTotal,
 		cachePeerTransferBytes:    cachePeerTransferBytes,
 		cachePeerTransferDuration: cachePeerTransferDuration,


### PR DESCRIPTION
## Summary
- add low-cardinality OTel gauges for active sandbox count and aggregate effective resource ceilings
- group resource gauges by backend and sandbox status, without sandbox IDs or policy hashes in metric labels
- document the metrics as effective launch-envelope telemetry, not runtime memory-pressure reporting

## Metrics
- `cleanroom_sandbox_active_count{backend,status}`
- `cleanroom_sandbox_effective_memory_bytes{backend,status}`
- `cleanroom_sandbox_effective_vcpus{backend,status}`
- `cleanroom_sandbox_effective_disk_bytes{backend,status}`

## Validation
- `mise exec -- go test ./internal/observability ./internal/controlservice`
- `mise exec -- go test ./internal/controlservice ./internal/observability ./internal/cli`
- `mise run build:go`
- `git diff --check`

## Follow-up
This does not add guest runtime used/available/peak memory yet. That should come from a separate guest stats path so we do not make metrics imply pressure data we are not actually collecting.