### PR TITLE
refactor: Extract dependency stage cache resolution

### DIFF
--- a/docs/plans/layered-caching.md
+++ b/docs/plans/layered-caching.md
@@ -2,7 +2,7 @@
 
 **Spec reference:** `spec.md` sections 5.1.1, 5.2, 6.4
 **Status:** In progress
-**Last reviewed:** 2026-05-05
+**Last reviewed:** 2026-05-09
 
 ## Summary
 
@@ -1137,6 +1137,10 @@ This metadata should live in a dedicated `changesetstore`, not in
    workspace-plus-command-plus-key-files slice.
 4. Add a user-facing changeset reuse surface if durable changesets need to be
    replayed outside the original sandbox create request.
+5. Concentrate request-time stage-cache resolution behind a private
+   control-plane Module. Services-stage resolution has landed, exact
+   dependency-stage resolution is the current slice, and portable dependency
+   plus workspace resolution remain follow-up slices.
 
 The stage-cache flow is architecturally landed, but the full performance win
 still depends on clone-capable storage instead of the default `file` driver,

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -547,18 +547,22 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 				}
 			}
 
+			cacheResolveContext := stageCacheResolveContext{
+				backendName:     backendName,
+				snapshotAdapter: snapshotAdapter,
+				compiled:        compiled,
+				firecrackerCfg:  firecrackerCfg,
+				repository:      repository,
+				changeset:       changeset,
+				commitBundle:    commitBundle,
+				options:         req.GetOptions(),
+				reporter:        reporter,
+			}
+
 			if servicesStageCachingEnabled {
 				servicesHit, err := s.resolveServicesStageCache(ctx, servicesStageResolveRequest{
-					backendName:     backendName,
-					snapshotAdapter: snapshotAdapter,
-					compiled:        compiled,
-					firecrackerCfg:  firecrackerCfg,
-					repository:      repository,
-					changeset:       changeset,
-					commitBundle:    commitBundle,
-					options:         req.GetOptions(),
-					plan:            servicesStagePlan,
-					reporter:        reporter,
+					stageCacheResolveContext: cacheResolveContext,
+					plan:                     servicesStagePlan,
 				})
 				if err != nil {
 					return nil, err
@@ -596,116 +600,30 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 			}
 
 			if dependencyStageCachingEnabled {
-				emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_DEPENDENCY_STAGE_CACHE, "checking dependency stage cache")
-				var record cachestore.Record
-				var found bool
-				var lookupReason string
-				err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.lookup_dependency_stage_cache", cachePhaseAttributes(
-					observability.CacheStageDependency,
-					observability.CacheOperationLookup,
-					repository,
-					attribute.String(observability.AttrBackend, backendName),
-				), func(ctx context.Context) error {
-					var lookupErr error
-					record, found, lookupReason, lookupErr = s.lookupDependencyStageCache(ctx, backendName, compiled, repository, changeset, dependencyStagePlan)
-					setCacheLookupSpanAttributes(ctx, found, lookupReason, lookupErr)
-					return lookupErr
+				dependencyHit, err := s.resolveDependencyStageCache(ctx, dependencyStageResolveRequest{
+					stageCacheResolveContext: cacheResolveContext,
+					plan:                     dependencyStagePlan,
+					servicesPlan:             servicesStagePlan,
+					servicesCaching:          servicesStageCachingEnabled,
+					servicesBootstrap:        servicesStageBootstrapEnabled,
+					serviceCacheOutputs:      serviceCacheOutputVolumes,
 				})
 				if err != nil {
-					s.logDependencyStageWarning("lookup dependency stage cache", "", err)
-				} else {
-					if !found {
-						emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_DEPENDENCY_STAGE_CACHE, "checking dependency stage cache peers")
-						importErr := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.import_dependency_stage_cache", cachePhaseAttributes(
-							observability.CacheStageDependency,
-							observability.CacheOperationLookup,
-							repository,
-							attribute.String(observability.AttrBackend, backendName),
-						), func(ctx context.Context) error {
-							var imported bool
-							var err error
-							record, imported, err = s.importDependencyStageCacheFromPeers(ctx, snapshotAdapter, backendName, compiled, firecrackerCfg, repository, changeset, dependencyStagePlan)
-							found = imported
-							reason := lookupReason
-							if imported {
-								reason = ""
-							}
-							setCacheLookupSpanAttributes(ctx, imported, reason, err)
-							return err
-						})
-						if importErr != nil {
-							s.logDependencyStageWarning("import dependency stage cache from peer", "", importErr)
-						}
-					}
-					if found {
-						if servicesStageCachingEnabled {
-							servicesHit, err := s.resolveServicesStageCacheAfterDependency(ctx, servicesStageResolveRequest{
-								backendName:     backendName,
-								snapshotAdapter: snapshotAdapter,
-								compiled:        compiled,
-								firecrackerCfg:  firecrackerCfg,
-								repository:      repository,
-								changeset:       changeset,
-								commitBundle:    commitBundle,
-								options:         req.GetOptions(),
-								plan:            servicesStagePlan,
-								reporter:        reporter,
-							})
-							if err != nil {
-								return nil, err
-							}
-							if servicesHit.restored != nil {
-								metricSourceKind = "services stage cache"
-								return servicesHit.restored, nil
-							}
-							if servicesHit.replaced != nil {
-								replacedServicesStageRecord = servicesHit.replaced
-							}
-						}
-
-						s.logDependencyStageCacheHit(record)
-						emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_DEPENDENCY_STAGE_CACHE, "dependency stage cache hit")
-						emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_RESTORE_DEPENDENCY_STAGE_CACHE, "restoring dependency stage cache")
-						restoreReq := &cleanroomv1.CreateSandboxRequest{
-							Backend: backendName,
-							Options: req.GetOptions(),
-						}
-						var restoreResp *cleanroomv1.CreateSandboxResponse
-						restoreErr := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.restore_dependency_stage_cache", cachePhaseAttributes(
-							observability.CacheStageDependency,
-							observability.CacheOperationRestore,
-							repository,
-							attribute.String(observability.AttrBackend, backendName),
-						), func(ctx context.Context) error {
-							var err error
-							restoreResp, err = s.createSandboxFromCacheRecord(ctx, restoreReq, compiled, record, serviceCacheOutputVolumes, reporter)
-							setCacheResultSpanAttribute(ctx, map[bool]string{true: observability.CacheResultFailed, false: observability.CacheResultRestored}[err != nil])
-							return err
-						})
-						if restoreErr == nil {
-							metricSourceKind = "dependency stage cache"
-							if cacheStore, err := s.cacheStoreOrErr(); err == nil {
-								if err := cacheStore.Touch(ctx, record.Stage, record.CacheKey); err != nil {
-									s.logDependencyStageWarning("touch dependency stage cache", "", err)
-								}
-							}
-							s.retainRestoredSandboxRepositoryState(restoreResp, repository, commitBundle, changeset)
-							s.logDependencyStageRestore(record, restoreResp.GetSandbox().GetSandboxId())
-							if !servicesStageBootstrapEnabled {
-								return restoreResp, nil
-							}
-							restoredDependencyResp = restoreResp
-						} else if errors.Is(restoreErr, errSandboxCreateAborted) {
-							return nil, restoreErr
-						} else {
-							recordCopy := record
-							replacedDependencyStageRecord = &recordCopy
-							s.logDependencyStageRestoreWarning(record, restoreErr)
-						}
-					} else {
-						s.logDependencyStageCacheMiss(backendName, dependencyStagePlan.CacheKey)
-						emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_DEPENDENCY_STAGE_CACHE, "dependency stage cache miss")
-					}
+					return nil, err
+				}
+				if dependencyHit.replacedServices != nil {
+					replacedServicesStageRecord = dependencyHit.replacedServices
+				}
+				if dependencyHit.replacedDependency != nil {
+					replacedDependencyStageRecord = dependencyHit.replacedDependency
+				}
+				if dependencyHit.completed != nil {
+					metricSourceKind = dependencyHit.sourceKind
+					return dependencyHit.completed, nil
+				}
+				if dependencyHit.restored != nil {
+					metricSourceKind = dependencyHit.sourceKind
+					restoredDependencyResp = dependencyHit.restored
 				}
 
 				if strings.TrimSpace(dependencyStagePlan.PortableCacheKey) != "" {

--- a/internal/controlservice/stage_cache_resolution.go
+++ b/internal/controlservice/stage_cache_resolution.go
@@ -16,6 +16,12 @@ import (
 )
 
 type servicesStageResolveRequest struct {
+	stageCacheResolveContext
+	plan            servicesStagePlan
+	afterDependency bool
+}
+
+type stageCacheResolveContext struct {
 	backendName     string
 	snapshotAdapter backend.SnapshottingAdapter
 	compiled        *policy.CompiledPolicy
@@ -24,14 +30,29 @@ type servicesStageResolveRequest struct {
 	changeset       *repositorychangeset.Changeset
 	commitBundle    *repositorybundle.Bundle
 	options         *cleanroomv1.SandboxOptions
-	plan            servicesStagePlan
 	reporter        CreateSandboxReporter
-	afterDependency bool
 }
 
 type servicesStageResolveResult struct {
 	restored *cleanroomv1.CreateSandboxResponse
 	replaced *cachestore.Record
+}
+
+type dependencyStageResolveRequest struct {
+	stageCacheResolveContext
+	plan                dependencyStagePlan
+	servicesPlan        servicesStagePlan
+	servicesCaching     bool
+	servicesBootstrap   bool
+	serviceCacheOutputs []backend.CacheOutputVolumeSpec
+}
+
+type dependencyStageResolveResult struct {
+	completed          *cleanroomv1.CreateSandboxResponse
+	restored           *cleanroomv1.CreateSandboxResponse
+	sourceKind         string
+	replacedDependency *cachestore.Record
+	replacedServices   *cachestore.Record
 }
 
 func (s *Service) resolveServicesStageCache(ctx context.Context, req servicesStageResolveRequest) (servicesStageResolveResult, error) {
@@ -127,6 +148,118 @@ func (s *Service) resolveServicesStageCache(ctx context.Context, req servicesSta
 func (s *Service) resolveServicesStageCacheAfterDependency(ctx context.Context, req servicesStageResolveRequest) (servicesStageResolveResult, error) {
 	req.afterDependency = true
 	return s.resolveServicesStageCache(ctx, req)
+}
+
+func (s *Service) resolveDependencyStageCache(ctx context.Context, req dependencyStageResolveRequest) (dependencyStageResolveResult, error) {
+	emitCreateSandboxMessage(req.reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_DEPENDENCY_STAGE_CACHE, "checking dependency stage cache")
+	var record cachestore.Record
+	var found bool
+	var lookupReason string
+	err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.lookup_dependency_stage_cache", cachePhaseAttributes(
+		observability.CacheStageDependency,
+		observability.CacheOperationLookup,
+		req.repository,
+		attribute.String(observability.AttrBackend, req.backendName),
+	), func(ctx context.Context) error {
+		var lookupErr error
+		record, found, lookupReason, lookupErr = s.lookupDependencyStageCache(ctx, req.backendName, req.compiled, req.repository, req.changeset, req.plan)
+		setCacheLookupSpanAttributes(ctx, found, lookupReason, lookupErr)
+		return lookupErr
+	})
+	if err != nil {
+		s.logDependencyStageWarning("lookup dependency stage cache", "", err)
+		return dependencyStageResolveResult{}, nil
+	}
+
+	if !found {
+		emitCreateSandboxMessage(req.reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_DEPENDENCY_STAGE_CACHE, "checking dependency stage cache peers")
+		importErr := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.import_dependency_stage_cache", cachePhaseAttributes(
+			observability.CacheStageDependency,
+			observability.CacheOperationLookup,
+			req.repository,
+			attribute.String(observability.AttrBackend, req.backendName),
+		), func(ctx context.Context) error {
+			var imported bool
+			var err error
+			record, imported, err = s.importDependencyStageCacheFromPeers(ctx, req.snapshotAdapter, req.backendName, req.compiled, req.firecrackerCfg, req.repository, req.changeset, req.plan)
+			found = imported
+			reason := lookupReason
+			if imported {
+				reason = ""
+			}
+			setCacheLookupSpanAttributes(ctx, imported, reason, err)
+			return err
+		})
+		if importErr != nil {
+			s.logDependencyStageWarning("import dependency stage cache from peer", "", importErr)
+		}
+	}
+
+	if !found {
+		s.logDependencyStageCacheMiss(req.backendName, req.plan.CacheKey)
+		emitCreateSandboxMessage(req.reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_DEPENDENCY_STAGE_CACHE, "dependency stage cache miss")
+		return dependencyStageResolveResult{}, nil
+	}
+
+	result := dependencyStageResolveResult{}
+	if req.servicesCaching {
+		servicesHit, err := s.resolveServicesStageCacheAfterDependency(ctx, servicesStageResolveRequest{
+			stageCacheResolveContext: req.stageCacheResolveContext,
+			plan:                     req.servicesPlan,
+		})
+		if err != nil {
+			return dependencyStageResolveResult{}, err
+		}
+		if servicesHit.restored != nil {
+			result.completed = servicesHit.restored
+			result.sourceKind = "services stage cache"
+			return result, nil
+		}
+		result.replacedServices = servicesHit.replaced
+	}
+
+	s.logDependencyStageCacheHit(record)
+	emitCreateSandboxMessage(req.reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_DEPENDENCY_STAGE_CACHE, "dependency stage cache hit")
+	emitCreateSandboxMessage(req.reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_RESTORE_DEPENDENCY_STAGE_CACHE, "restoring dependency stage cache")
+	restoreReq := &cleanroomv1.CreateSandboxRequest{
+		Backend: req.backendName,
+		Options: req.options,
+	}
+	var restoreResp *cleanroomv1.CreateSandboxResponse
+	restoreErr := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.restore_dependency_stage_cache", cachePhaseAttributes(
+		observability.CacheStageDependency,
+		observability.CacheOperationRestore,
+		req.repository,
+		attribute.String(observability.AttrBackend, req.backendName),
+	), func(ctx context.Context) error {
+		var err error
+		restoreResp, err = s.createSandboxFromCacheRecord(ctx, restoreReq, req.compiled, record, req.serviceCacheOutputs, req.reporter)
+		setCacheResultSpanAttribute(ctx, map[bool]string{true: observability.CacheResultFailed, false: observability.CacheResultRestored}[err != nil])
+		return err
+	})
+	if restoreErr == nil {
+		if cacheStore, err := s.cacheStoreOrErr(); err == nil {
+			if err := cacheStore.Touch(ctx, record.Stage, record.CacheKey); err != nil {
+				s.logDependencyStageWarning("touch dependency stage cache", "", err)
+			}
+		}
+		s.retainRestoredSandboxRepositoryState(restoreResp, req.repository, req.commitBundle, req.changeset)
+		s.logDependencyStageRestore(record, restoreResp.GetSandbox().GetSandboxId())
+		result.sourceKind = "dependency stage cache"
+		if !req.servicesBootstrap {
+			result.completed = restoreResp
+			return result, nil
+		}
+		result.restored = restoreResp
+		return result, nil
+	}
+	if errors.Is(restoreErr, errSandboxCreateAborted) {
+		return dependencyStageResolveResult{}, restoreErr
+	}
+	recordCopy := record
+	s.logDependencyStageRestoreWarning(record, restoreErr)
+	result.replacedDependency = &recordCopy
+	return result, nil
 }
 
 func (r servicesStageResolveRequest) lookupTraceName() string {


### PR DESCRIPTION
## What changed

This moves exact dependency-stage cache resolution out of `createSandbox` and into the private stage-cache resolution Module.

The new resolver owns the exact dependency lookup, peer import, services-after-dependency check, restore, cache touch, and stale dependency record capture. `createSandbox` still owns portable dependency and workspace fallback, so this stays as the next narrow slice after #352.

I also updated `docs/plans/layered-caching.md` to record the current progress: services-stage resolution has landed, exact dependency-stage resolution is this slice, and portable dependency plus workspace resolution remain follow-ups.

## Validation

- `mise exec -- go test -count=1 ./internal/controlservice`
- `git diff --check`
