### PR TITLE
refactor: Resolve portable dependency cache in stage module

### DIFF
--- a/docs/plans/layered-caching.md
+++ b/docs/plans/layered-caching.md
@@ -1139,8 +1139,9 @@ This metadata should live in a dedicated `changesetstore`, not in
    replayed outside the original sandbox create request.
 5. Concentrate request-time stage-cache resolution behind a private
    control-plane Module. Services-stage resolution has landed, exact
-   dependency-stage resolution is the current slice, and portable dependency
-   plus workspace resolution remain follow-up slices.
+   dependency-stage resolution has landed, this slice moves portable
+   dependency-stage resolution behind the same Module, and workspace resolution
+   remains a follow-up slice.
 
 The stage-cache flow is architecturally landed, but the full performance win
 still depends on clone-capable storage instead of the default `file` driver,

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -603,6 +603,7 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 				dependencyHit, err := s.resolveDependencyStageCache(ctx, dependencyStageResolveRequest{
 					stageCacheResolveContext: cacheResolveContext,
 					plan:                     dependencyStagePlan,
+					adapter:                  adapter,
 					servicesPlan:             servicesStagePlan,
 					servicesCaching:          servicesStageCachingEnabled,
 					servicesBootstrap:        servicesStageBootstrapEnabled,
@@ -624,62 +625,6 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 				if dependencyHit.restored != nil {
 					metricSourceKind = dependencyHit.sourceKind
 					restoredDependencyResp = dependencyHit.restored
-				}
-
-				if strings.TrimSpace(dependencyStagePlan.PortableCacheKey) != "" {
-					emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_DEPENDENCY_STAGE_CACHE, "checking portable dependency stage cache")
-					var portableRecord cachestore.Record
-					var portableFound bool
-					var portableLookupReason string
-					portableLookupErr := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.lookup_portable_dependency_stage_cache", cachePhaseAttributes(
-						observability.CacheStageDependency,
-						observability.CacheOperationLookup,
-						repository,
-						attribute.String(observability.AttrBackend, backendName),
-					), func(ctx context.Context) error {
-						var lookupErr error
-						portableRecord, portableFound, portableLookupReason, lookupErr = s.lookupPortableDependencyStageCache(ctx, backendName, compiled, repository, dependencyStagePlan)
-						setCacheLookupSpanAttributes(ctx, portableFound, portableLookupReason, lookupErr)
-						return lookupErr
-					})
-					if portableLookupErr != nil {
-						s.logDependencyStageWarning("lookup portable dependency stage cache", "", portableLookupErr)
-					} else if portableFound {
-						s.logDependencyStageCacheHit(portableRecord)
-						emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_DEPENDENCY_STAGE_CACHE, "portable dependency stage cache hit")
-						var restoreResp *cleanroomv1.CreateSandboxResponse
-						restoreErr := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.restore_portable_dependency_stage_cache", cachePhaseAttributes(
-							observability.CacheStageDependency,
-							observability.CacheOperationRestore,
-							repository,
-							attribute.String(observability.AttrBackend, backendName),
-						), func(ctx context.Context) error {
-							var err error
-							restoreResp, err = s.restorePortableDependencyStageCache(ctx, adapter, backendName, compiled, firecrackerCfg, repository, changeset, commitBundle, req.GetOptions(), portableRecord, serviceCacheOutputVolumes, reporter)
-							setCacheResultSpanAttribute(ctx, map[bool]string{true: observability.CacheResultFailed, false: observability.CacheResultRestored}[err != nil])
-							return err
-						})
-						if restoreErr == nil {
-							metricSourceKind = "portable dependency stage cache"
-							if cacheStore, err := s.cacheStoreOrErr(); err == nil {
-								if err := cacheStore.Touch(ctx, portableRecord.Stage, portableRecord.CacheKey); err != nil {
-									s.logDependencyStageWarning("touch portable dependency stage cache", "", err)
-								}
-							}
-							s.logDependencyStageRestore(portableRecord, restoreResp.GetSandbox().GetSandboxId())
-							if !servicesStageBootstrapEnabled {
-								return restoreResp, nil
-							}
-							restoredDependencyResp = restoreResp
-						} else if errors.Is(restoreErr, errSandboxCreateAborted) {
-							return nil, restoreErr
-						} else {
-							s.logDependencyStageRestoreWarning(portableRecord, restoreErr)
-						}
-					} else {
-						s.logDependencyStageCacheMiss(backendName, dependencyStagePlan.PortableCacheKey)
-						emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_DEPENDENCY_STAGE_CACHE, "portable dependency stage cache miss")
-					}
 				}
 			}
 

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -3988,6 +3988,136 @@ func TestCreateSandboxReusesPortableDependencyStageAfterCheckoutRefresh(t *testi
 	}
 }
 
+func TestPortableDependencyRestoreFailureUsesWorkspace(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	store := newMemorySnapshotStore()
+	adapter := &stubAdapter{}
+	var snapshotReqs []backend.SnapshotRequest
+	adapter.createSnapshotFn = func(_ context.Context, req backend.SnapshotRequest) (*backend.SnapshotResult, error) {
+		snapshotReqs = append(snapshotReqs, req)
+		return &backend.SnapshotResult{StorageRef: "/snapshots/" + req.SnapshotID + ".ext4"}, nil
+	}
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"go.mod": "module example.com/test\n\ngo 1.26.2\n",
+		"go.sum": "example.com/test v0.0.0 h1:abc123\n",
+	})
+	svc := newTestServiceWithSnapshotStore(adapter, store)
+	svc.RepositoryStore = mirrors
+
+	req := &cleanroomv1.CreateSandboxRequest{
+		Policy:             testRepositoryPortableDependencyPolicy(),
+		RepositoryCheckout: repositoryCheckout,
+	}
+
+	if _, err := svc.CreateSandbox(context.Background(), req); err != nil {
+		t.Fatalf("first CreateSandbox returned error: %v", err)
+	}
+
+	records, err := svc.CacheStore.List(context.Background())
+	if err != nil {
+		t.Fatalf("List cache records returned error: %v", err)
+	}
+	var (
+		workspaceRecord *cachestore.Record
+		exactRecord     *cachestore.Record
+		portableRecord  *cachestore.Record
+	)
+	for i := range records {
+		record := records[i]
+		switch {
+		case record.Stage == workspaceStageName:
+			workspaceRecord = &record
+		case record.Stage == dependencyStageName && record.ReuseMode == dependencyStageReuseExact:
+			exactRecord = &record
+		case record.Stage == dependencyStageName && record.ReuseMode == dependencyStageReusePortable:
+			portableRecord = &record
+		}
+	}
+	if workspaceRecord == nil {
+		t.Fatal("expected published workspace stage cache record")
+	}
+	if exactRecord == nil {
+		t.Fatal("expected published exact dependency stage cache record")
+	}
+	if portableRecord == nil {
+		t.Fatal("expected published portable dependency stage cache record")
+	}
+	if err := svc.CacheStore.Delete(context.Background(), exactRecord.Stage, exactRecord.CacheKey); err != nil {
+		t.Fatalf("Delete exact dependency cache record returned error: %v", err)
+	}
+
+	var restoreReqs []backend.ProvisionFromSnapshotRequest
+	adapter.provisionFromSnapshotFn = func(_ context.Context, req backend.ProvisionFromSnapshotRequest) error {
+		restoreReqs = append(restoreReqs, req)
+		if req.SnapshotID == portableRecord.BackingSnapshotID {
+			return errors.New("portable dependency stage restore failed")
+		}
+		return nil
+	}
+
+	secondResp, err := svc.CreateSandbox(context.Background(), req)
+	if err != nil {
+		t.Fatalf("second CreateSandbox returned error: %v", err)
+	}
+	if got, want := secondResp.GetSourceKind(), "workspace stage cache"; got != want {
+		t.Fatalf("unexpected response source kind: got %q want %q", got, want)
+	}
+	if got, want := secondResp.GetSandbox().GetSourceKind(), "workspace stage cache"; got != want {
+		t.Fatalf("unexpected sandbox source kind: got %q want %q", got, want)
+	}
+	if got, want := adapter.provisionCalls, 1; got != want {
+		t.Fatalf("expected portable restore failure to fall back through workspace cache without cold provision, got %d want %d", got, want)
+	}
+	if got, want := adapter.provisionFromSnapshotCalls, 2; got != want {
+		t.Fatalf("expected failed portable restore plus successful workspace restore, got %d want %d", got, want)
+	}
+	if got, want := len(restoreReqs), 2; got != want {
+		t.Fatalf("expected two restore requests, got %d want %d", got, want)
+	}
+	if got, want := restoreReqs[0].SnapshotID, portableRecord.BackingSnapshotID; got != want {
+		t.Fatalf("unexpected first restore snapshot id: got %q want %q", got, want)
+	}
+	if got, want := restoreReqs[1].SnapshotID, workspaceRecord.BackingSnapshotID; got != want {
+		t.Fatalf("unexpected second restore snapshot id: got %q want %q", got, want)
+	}
+	if got, want := adapter.runCalls, 3; got != want {
+		t.Fatalf("expected only dependency bootstrap after workspace restore, got %d want %d", got, want)
+	}
+	if got, want := adapter.createSnapshotCalls, 3; got != want {
+		t.Fatalf("expected replacement dependency snapshot after workspace restore, got %d want %d", got, want)
+	}
+	if got, want := len(snapshotReqs), 3; got != want {
+		t.Fatalf("expected three snapshot publish requests, got %d want %d", got, want)
+	}
+
+	records, err = svc.CacheStore.List(context.Background())
+	if err != nil {
+		t.Fatalf("List cache records returned error: %v", err)
+	}
+	var replacementExactRecord, replacementPortableRecord *cachestore.Record
+	for i := range records {
+		record := records[i]
+		switch {
+		case record.Stage == dependencyStageName && record.ReuseMode == dependencyStageReuseExact:
+			replacementExactRecord = &record
+		case record.Stage == dependencyStageName && record.ReuseMode == dependencyStageReusePortable:
+			replacementPortableRecord = &record
+		}
+	}
+	if replacementExactRecord == nil {
+		t.Fatal("expected replacement exact dependency stage cache record")
+	}
+	if replacementPortableRecord == nil {
+		t.Fatal("expected replacement portable dependency stage cache record")
+	}
+	if got, stale := replacementExactRecord.BackingSnapshotID, exactRecord.BackingSnapshotID; got == stale {
+		t.Fatalf("expected exact dependency stage cache record to be republished, still has backing snapshot id %q", got)
+	}
+	if got, want := replacementPortableRecord.BackingSnapshotID, replacementExactRecord.BackingSnapshotID; got != want {
+		t.Fatalf("expected portable metadata to share replacement dependency snapshot: got %q want %q", got, want)
+	}
+}
+
 func TestCreateSandboxStoresCommitBundleAfterPortableDependencyStageRestore(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	store := newMemorySnapshotStore()

--- a/internal/controlservice/stage_cache_resolution.go
+++ b/internal/controlservice/stage_cache_resolution.go
@@ -3,6 +3,7 @@ package controlservice
 import (
 	"context"
 	"errors"
+	"strings"
 
 	"github.com/buildkite/cleanroom/internal/backend"
 	"github.com/buildkite/cleanroom/internal/cachestore"
@@ -41,6 +42,7 @@ type servicesStageResolveResult struct {
 type dependencyStageResolveRequest struct {
 	stageCacheResolveContext
 	plan                dependencyStagePlan
+	adapter             backend.Adapter
 	servicesPlan        servicesStagePlan
 	servicesCaching     bool
 	servicesBootstrap   bool
@@ -168,7 +170,7 @@ func (s *Service) resolveDependencyStageCache(ctx context.Context, req dependenc
 	})
 	if err != nil {
 		s.logDependencyStageWarning("lookup dependency stage cache", "", err)
-		return dependencyStageResolveResult{}, nil
+		return s.resolvePortableDependencyStageCache(ctx, req)
 	}
 
 	if !found {
@@ -195,70 +197,149 @@ func (s *Service) resolveDependencyStageCache(ctx context.Context, req dependenc
 		}
 	}
 
+	result := dependencyStageResolveResult{}
 	if !found {
 		s.logDependencyStageCacheMiss(req.backendName, req.plan.CacheKey)
 		emitCreateSandboxMessage(req.reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_DEPENDENCY_STAGE_CACHE, "dependency stage cache miss")
+	} else {
+		if req.servicesCaching {
+			servicesHit, err := s.resolveServicesStageCacheAfterDependency(ctx, servicesStageResolveRequest{
+				stageCacheResolveContext: req.stageCacheResolveContext,
+				plan:                     req.servicesPlan,
+			})
+			if err != nil {
+				return dependencyStageResolveResult{}, err
+			}
+			if servicesHit.restored != nil {
+				result.completed = servicesHit.restored
+				result.sourceKind = "services stage cache"
+				return result, nil
+			}
+			result.replacedServices = servicesHit.replaced
+		}
+
+		s.logDependencyStageCacheHit(record)
+		emitCreateSandboxMessage(req.reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_DEPENDENCY_STAGE_CACHE, "dependency stage cache hit")
+		emitCreateSandboxMessage(req.reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_RESTORE_DEPENDENCY_STAGE_CACHE, "restoring dependency stage cache")
+		restoreReq := &cleanroomv1.CreateSandboxRequest{
+			Backend: req.backendName,
+			Options: req.options,
+		}
+		var restoreResp *cleanroomv1.CreateSandboxResponse
+		restoreErr := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.restore_dependency_stage_cache", cachePhaseAttributes(
+			observability.CacheStageDependency,
+			observability.CacheOperationRestore,
+			req.repository,
+			attribute.String(observability.AttrBackend, req.backendName),
+		), func(ctx context.Context) error {
+			var err error
+			restoreResp, err = s.createSandboxFromCacheRecord(ctx, restoreReq, req.compiled, record, req.serviceCacheOutputs, req.reporter)
+			setCacheResultSpanAttribute(ctx, map[bool]string{true: observability.CacheResultFailed, false: observability.CacheResultRestored}[err != nil])
+			return err
+		})
+		if restoreErr == nil {
+			if cacheStore, err := s.cacheStoreOrErr(); err == nil {
+				if err := cacheStore.Touch(ctx, record.Stage, record.CacheKey); err != nil {
+					s.logDependencyStageWarning("touch dependency stage cache", "", err)
+				}
+			}
+			s.retainRestoredSandboxRepositoryState(restoreResp, req.repository, req.commitBundle, req.changeset)
+			s.logDependencyStageRestore(record, restoreResp.GetSandbox().GetSandboxId())
+			result.sourceKind = "dependency stage cache"
+			if !req.servicesBootstrap {
+				result.completed = restoreResp
+				return result, nil
+			}
+			result.restored = restoreResp
+		} else {
+			if errors.Is(restoreErr, errSandboxCreateAborted) {
+				return dependencyStageResolveResult{}, restoreErr
+			}
+			recordCopy := record
+			s.logDependencyStageRestoreWarning(record, restoreErr)
+			result.replacedDependency = &recordCopy
+		}
+	}
+
+	portableHit, err := s.resolvePortableDependencyStageCache(ctx, req)
+	if err != nil {
+		return dependencyStageResolveResult{}, err
+	}
+	if portableHit.completed != nil || portableHit.restored != nil {
+		portableHit.replacedDependency = result.replacedDependency
+		portableHit.replacedServices = result.replacedServices
+		return portableHit, nil
+	}
+	return result, nil
+}
+
+func (s *Service) resolvePortableDependencyStageCache(ctx context.Context, req dependencyStageResolveRequest) (dependencyStageResolveResult, error) {
+	if strings.TrimSpace(req.plan.PortableCacheKey) == "" {
 		return dependencyStageResolveResult{}, nil
 	}
 
-	result := dependencyStageResolveResult{}
-	if req.servicesCaching {
-		servicesHit, err := s.resolveServicesStageCacheAfterDependency(ctx, servicesStageResolveRequest{
-			stageCacheResolveContext: req.stageCacheResolveContext,
-			plan:                     req.servicesPlan,
-		})
-		if err != nil {
-			return dependencyStageResolveResult{}, err
-		}
-		if servicesHit.restored != nil {
-			result.completed = servicesHit.restored
-			result.sourceKind = "services stage cache"
-			return result, nil
-		}
-		result.replacedServices = servicesHit.replaced
+	emitCreateSandboxMessage(req.reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_DEPENDENCY_STAGE_CACHE, "checking portable dependency stage cache")
+	var record cachestore.Record
+	var found bool
+	var lookupReason string
+	err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.lookup_portable_dependency_stage_cache", cachePhaseAttributes(
+		observability.CacheStageDependency,
+		observability.CacheOperationLookup,
+		req.repository,
+		attribute.String(observability.AttrBackend, req.backendName),
+	), func(ctx context.Context) error {
+		var lookupErr error
+		record, found, lookupReason, lookupErr = s.lookupPortableDependencyStageCache(ctx, req.backendName, req.compiled, req.repository, req.plan)
+		setCacheLookupSpanAttributes(ctx, found, lookupReason, lookupErr)
+		return lookupErr
+	})
+	if err != nil {
+		s.logDependencyStageWarning("lookup portable dependency stage cache", "", err)
+		return dependencyStageResolveResult{}, nil
+	}
+
+	if !found {
+		s.logDependencyStageCacheMiss(req.backendName, req.plan.PortableCacheKey)
+		emitCreateSandboxMessage(req.reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_DEPENDENCY_STAGE_CACHE, "portable dependency stage cache miss")
+		return dependencyStageResolveResult{}, nil
 	}
 
 	s.logDependencyStageCacheHit(record)
-	emitCreateSandboxMessage(req.reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_DEPENDENCY_STAGE_CACHE, "dependency stage cache hit")
-	emitCreateSandboxMessage(req.reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_RESTORE_DEPENDENCY_STAGE_CACHE, "restoring dependency stage cache")
-	restoreReq := &cleanroomv1.CreateSandboxRequest{
-		Backend: req.backendName,
-		Options: req.options,
-	}
+	emitCreateSandboxMessage(req.reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_DEPENDENCY_STAGE_CACHE, "portable dependency stage cache hit")
 	var restoreResp *cleanroomv1.CreateSandboxResponse
-	restoreErr := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.restore_dependency_stage_cache", cachePhaseAttributes(
+	restoreErr := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.restore_portable_dependency_stage_cache", cachePhaseAttributes(
 		observability.CacheStageDependency,
 		observability.CacheOperationRestore,
 		req.repository,
 		attribute.String(observability.AttrBackend, req.backendName),
 	), func(ctx context.Context) error {
 		var err error
-		restoreResp, err = s.createSandboxFromCacheRecord(ctx, restoreReq, req.compiled, record, req.serviceCacheOutputs, req.reporter)
+		restoreResp, err = s.restorePortableDependencyStageCache(ctx, req.adapter, req.backendName, req.compiled, req.firecrackerCfg, req.repository, req.changeset, req.commitBundle, req.options, record, req.serviceCacheOutputs, req.reporter)
 		setCacheResultSpanAttribute(ctx, map[bool]string{true: observability.CacheResultFailed, false: observability.CacheResultRestored}[err != nil])
 		return err
 	})
-	if restoreErr == nil {
-		if cacheStore, err := s.cacheStoreOrErr(); err == nil {
-			if err := cacheStore.Touch(ctx, record.Stage, record.CacheKey); err != nil {
-				s.logDependencyStageWarning("touch dependency stage cache", "", err)
-			}
+	if restoreErr != nil {
+		if errors.Is(restoreErr, errSandboxCreateAborted) {
+			return dependencyStageResolveResult{}, restoreErr
 		}
-		s.retainRestoredSandboxRepositoryState(restoreResp, req.repository, req.commitBundle, req.changeset)
-		s.logDependencyStageRestore(record, restoreResp.GetSandbox().GetSandboxId())
-		result.sourceKind = "dependency stage cache"
-		if !req.servicesBootstrap {
-			result.completed = restoreResp
-			return result, nil
+		s.logDependencyStageRestoreWarning(record, restoreErr)
+		return dependencyStageResolveResult{}, nil
+	}
+
+	if cacheStore, err := s.cacheStoreOrErr(); err == nil {
+		if err := cacheStore.Touch(ctx, record.Stage, record.CacheKey); err != nil {
+			s.logDependencyStageWarning("touch portable dependency stage cache", "", err)
 		}
-		result.restored = restoreResp
+	}
+	s.logDependencyStageRestore(record, restoreResp.GetSandbox().GetSandboxId())
+	result := dependencyStageResolveResult{
+		sourceKind: "portable dependency stage cache",
+	}
+	if !req.servicesBootstrap {
+		result.completed = restoreResp
 		return result, nil
 	}
-	if errors.Is(restoreErr, errSandboxCreateAborted) {
-		return dependencyStageResolveResult{}, restoreErr
-	}
-	recordCopy := record
-	s.logDependencyStageRestoreWarning(record, restoreErr)
-	result.replacedDependency = &recordCopy
+	result.restored = restoreResp
 	return result, nil
 }
 


### PR DESCRIPTION
## Problem

Portable dependency-stage lookup and restore still lived inline in `createSandbox`, even after services and exact dependency-stage resolution moved behind `stage_cache_resolution.go`. That left request-time ordering, fallback behavior, and replacement metadata split across two places.

## Change

- Move portable dependency-stage lookup, restore, touch, abort, and fallback handling into `resolveDependencyStageCache`.
- Preserve exact dependency and services replacement propagation, including the degraded path that still tries portable resolution after an exact lookup error.
- Add a regression test for failed portable restore falling through to the workspace cache and republishing exact plus portable dependency metadata.
- Update the layered caching plan progress note for this slice.

## Validation

- `mise exec -- go test ./internal/controlservice`
- `mise run test`
- `mise run check`
