### PR TITLE
refactor: Resolve workspace cache in stage module

### DIFF
--- a/docs/plans/layered-caching.md
+++ b/docs/plans/layered-caching.md
@@ -2,7 +2,7 @@
 
 **Spec reference:** `spec.md` sections 5.1.1, 5.2, 6.4
 **Status:** In progress
-**Last reviewed:** 2026-05-09
+**Last reviewed:** 2026-05-10
 
 ## Summary
 
@@ -1139,9 +1139,8 @@ This metadata should live in a dedicated `changesetstore`, not in
    replayed outside the original sandbox create request.
 5. Concentrate request-time stage-cache resolution behind a private
    control-plane Module. Services-stage resolution has landed, exact
-   dependency-stage resolution has landed, this slice moves portable
-   dependency-stage resolution behind the same Module, and workspace resolution
-   remains a follow-up slice.
+   dependency-stage and portable dependency-stage resolution have landed, and
+   this slice moves workspace-stage resolution behind the same Module.
 
 The stage-cache flow is architecturally landed, but the full performance win
 still depends on clone-capable storage instead of the default `file` driver,

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -629,66 +629,27 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 			}
 
 			if restoredDependencyResp == nil {
-				emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_WORKSPACE_STAGE_CACHE, "checking workspace stage cache")
-				var record cachestore.Record
-				var found bool
-				var lookupReason string
-				err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.lookup_workspace_stage_cache", cachePhaseAttributes(
-					observability.CacheStageWorkspace,
-					observability.CacheOperationLookup,
-					repository,
-					attribute.String(observability.AttrBackend, backendName),
-				), func(ctx context.Context) error {
-					var lookupErr error
-					record, found, lookupReason, lookupErr = s.lookupWorkspaceStageCache(ctx, backendName, compiled, workspaceStageRuntimeBaseKey, repository, changeset)
-					setCacheLookupSpanAttributes(ctx, found, lookupReason, lookupErr)
-					return lookupErr
+				workspaceHit, err := s.resolveWorkspaceStageCache(ctx, workspaceStageResolveRequest{
+					stageCacheResolveContext: cacheResolveContext,
+					runtimeBaseKey:           workspaceStageRuntimeBaseKey,
+					cacheKey:                 workspaceStageKey,
+					dependencyBootstrap:      dependencyStageBootstrapEnabled,
+					servicesBootstrap:        servicesStageBootstrapEnabled,
+					cacheOutputs:             appendCacheOutputVolumeSpecs(dependencyCacheOutputVolumes, serviceCacheOutputVolumes),
 				})
 				if err != nil {
-					s.logWorkspaceStageWarning("lookup workspace stage cache", "", err)
-				} else if found {
-					s.logWorkspaceStageCacheHit(record)
-					emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_WORKSPACE_STAGE_CACHE, "workspace stage cache hit")
-					emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_RESTORE_WORKSPACE_STAGE_CACHE, "restoring workspace stage cache")
-					restoreReq := &cleanroomv1.CreateSandboxRequest{
-						Backend: backendName,
-						Options: req.GetOptions(),
-					}
-					var restoreResp *cleanroomv1.CreateSandboxResponse
-					restoreErr := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.restore_workspace_stage_cache", cachePhaseAttributes(
-						observability.CacheStageWorkspace,
-						observability.CacheOperationRestore,
-						repository,
-						attribute.String(observability.AttrBackend, backendName),
-					), func(ctx context.Context) error {
-						var err error
-						restoreResp, err = s.createSandboxFromCacheRecord(ctx, restoreReq, compiled, record, appendCacheOutputVolumeSpecs(dependencyCacheOutputVolumes, serviceCacheOutputVolumes), reporter)
-						setCacheResultSpanAttribute(ctx, map[bool]string{true: observability.CacheResultFailed, false: observability.CacheResultRestored}[err != nil])
-						return err
-					})
-					if restoreErr == nil {
-						metricSourceKind = "workspace stage cache"
-						if cacheStore, err := s.cacheStoreOrErr(); err == nil {
-							if err := cacheStore.Touch(ctx, record.Stage, record.CacheKey); err != nil {
-								s.logWorkspaceStageWarning("touch workspace stage cache", "", err)
-							}
-						}
-						s.retainRestoredSandboxRepositoryState(restoreResp, repository, commitBundle, changeset)
-						s.logWorkspaceStageRestore(record, restoreResp.GetSandbox().GetSandboxId())
-						if !dependencyStageBootstrapEnabled && !servicesStageBootstrapEnabled {
-							return restoreResp, nil
-						}
-						restoredWorkspaceResp = restoreResp
-					} else if errors.Is(restoreErr, errSandboxCreateAborted) {
-						return nil, restoreErr
-					} else {
-						recordCopy := record
-						replacedWorkspaceStageRecord = &recordCopy
-						s.logWorkspaceStageRestoreWarning(record, restoreErr)
-					}
-				} else {
-					s.logWorkspaceStageCacheMiss(backendName, workspaceStageKey)
-					emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_WORKSPACE_STAGE_CACHE, "workspace stage cache miss")
+					return nil, err
+				}
+				if workspaceHit.replaced != nil {
+					replacedWorkspaceStageRecord = workspaceHit.replaced
+				}
+				if workspaceHit.completed != nil {
+					metricSourceKind = workspaceHit.sourceKind
+					return workspaceHit.completed, nil
+				}
+				if workspaceHit.restored != nil {
+					metricSourceKind = workspaceHit.sourceKind
+					restoredWorkspaceResp = workspaceHit.restored
 				}
 			}
 		}

--- a/internal/controlservice/stage_cache_resolution.go
+++ b/internal/controlservice/stage_cache_resolution.go
@@ -57,6 +57,22 @@ type dependencyStageResolveResult struct {
 	replacedServices   *cachestore.Record
 }
 
+type workspaceStageResolveRequest struct {
+	stageCacheResolveContext
+	runtimeBaseKey      string
+	cacheKey            string
+	dependencyBootstrap bool
+	servicesBootstrap   bool
+	cacheOutputs        []backend.CacheOutputVolumeSpec
+}
+
+type workspaceStageResolveResult struct {
+	completed  *cleanroomv1.CreateSandboxResponse
+	restored   *cleanroomv1.CreateSandboxResponse
+	sourceKind string
+	replaced   *cachestore.Record
+}
+
 func (s *Service) resolveServicesStageCache(ctx context.Context, req servicesStageResolveRequest) (servicesStageResolveResult, error) {
 	emitCreateSandboxMessage(req.reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_SERVICES_STAGE_CACHE, "checking services stage cache")
 	var record cachestore.Record
@@ -341,6 +357,76 @@ func (s *Service) resolvePortableDependencyStageCache(ctx context.Context, req d
 	}
 	result.restored = restoreResp
 	return result, nil
+}
+
+func (s *Service) resolveWorkspaceStageCache(ctx context.Context, req workspaceStageResolveRequest) (workspaceStageResolveResult, error) {
+	emitCreateSandboxMessage(req.reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_WORKSPACE_STAGE_CACHE, "checking workspace stage cache")
+	var record cachestore.Record
+	var found bool
+	var lookupReason string
+	err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.lookup_workspace_stage_cache", cachePhaseAttributes(
+		observability.CacheStageWorkspace,
+		observability.CacheOperationLookup,
+		req.repository,
+		attribute.String(observability.AttrBackend, req.backendName),
+	), func(ctx context.Context) error {
+		var lookupErr error
+		record, found, lookupReason, lookupErr = s.lookupWorkspaceStageCache(ctx, req.backendName, req.compiled, req.runtimeBaseKey, req.repository, req.changeset)
+		setCacheLookupSpanAttributes(ctx, found, lookupReason, lookupErr)
+		return lookupErr
+	})
+	if err != nil {
+		s.logWorkspaceStageWarning("lookup workspace stage cache", "", err)
+		return workspaceStageResolveResult{}, nil
+	}
+
+	if !found {
+		s.logWorkspaceStageCacheMiss(req.backendName, req.cacheKey)
+		emitCreateSandboxMessage(req.reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_WORKSPACE_STAGE_CACHE, "workspace stage cache miss")
+		return workspaceStageResolveResult{}, nil
+	}
+
+	s.logWorkspaceStageCacheHit(record)
+	emitCreateSandboxMessage(req.reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_WORKSPACE_STAGE_CACHE, "workspace stage cache hit")
+	emitCreateSandboxMessage(req.reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_RESTORE_WORKSPACE_STAGE_CACHE, "restoring workspace stage cache")
+	restoreReq := &cleanroomv1.CreateSandboxRequest{
+		Backend: req.backendName,
+		Options: req.options,
+	}
+	var restoreResp *cleanroomv1.CreateSandboxResponse
+	restoreErr := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.restore_workspace_stage_cache", cachePhaseAttributes(
+		observability.CacheStageWorkspace,
+		observability.CacheOperationRestore,
+		req.repository,
+		attribute.String(observability.AttrBackend, req.backendName),
+	), func(ctx context.Context) error {
+		var err error
+		restoreResp, err = s.createSandboxFromCacheRecord(ctx, restoreReq, req.compiled, record, req.cacheOutputs, req.reporter)
+		setCacheResultSpanAttribute(ctx, map[bool]string{true: observability.CacheResultFailed, false: observability.CacheResultRestored}[err != nil])
+		return err
+	})
+	if restoreErr == nil {
+		if cacheStore, err := s.cacheStoreOrErr(); err == nil {
+			if err := cacheStore.Touch(ctx, record.Stage, record.CacheKey); err != nil {
+				s.logWorkspaceStageWarning("touch workspace stage cache", "", err)
+			}
+		}
+		s.retainRestoredSandboxRepositoryState(restoreResp, req.repository, req.commitBundle, req.changeset)
+		s.logWorkspaceStageRestore(record, restoreResp.GetSandbox().GetSandboxId())
+		result := workspaceStageResolveResult{sourceKind: "workspace stage cache"}
+		if !req.dependencyBootstrap && !req.servicesBootstrap {
+			result.completed = restoreResp
+			return result, nil
+		}
+		result.restored = restoreResp
+		return result, nil
+	}
+	if errors.Is(restoreErr, errSandboxCreateAborted) {
+		return workspaceStageResolveResult{}, restoreErr
+	}
+	recordCopy := record
+	s.logWorkspaceStageRestoreWarning(record, restoreErr)
+	return workspaceStageResolveResult{replaced: &recordCopy}, nil
 }
 
 func (r servicesStageResolveRequest) lookupTraceName() string {


### PR DESCRIPTION
## Problem

Workspace-stage cache lookup and restore was the last request-time resolution path still embedded in `createSandbox`. Services, exact dependency, and portable dependency resolution had already moved behind `stage_cache_resolution.go`, so the caller still had to know too much about workspace lookup, restore, fallback, and stale-record handling.

## Change

- Move workspace-stage lookup, restore, touch, miss logging, abort handling, and stale-record propagation into `resolveWorkspaceStageCache`.
- Keep bootstrap and publication orchestration in `createSandbox`.
- Preserve the existing terminal restore path when no dependency or services bootstrap is needed.
- Update the layered caching plan to mark workspace-stage resolution as the current completed slice.

## Validation

- `mise exec -- go test ./internal/controlservice -run 'Test(CreateSandbox(ReusesWorkspaceStageCache|FallsBackWhenWorkspaceStageRestoreFails|DoesNotFallbackWhenWorkspaceStageRestoreIsTerminated|DependencyRestoreFailureUsesWorkspaceCache|BootstrapsDependenciesAfterWorkspaceStageRestoreWithoutDependencyStageCache)|PortableDependencyRestoreFailureUsesWorkspace)$'`
- `mise exec -- go test ./internal/controlservice`
- `mise run test`
- `mise run check`
