### PR TITLE
feat: Key dependency caches by toolchain manifests

### DIFF
--- a/docs/plans/layered-caching.md
+++ b/docs/plans/layered-caching.md
@@ -172,6 +172,8 @@ This phase now means:
   configured dependency bootstrap command
 - portable dependency-stage reuse as an explicit
   `sandbox.dependencies.reuse: portable` mode for declared key-file inputs
+- dependency-stage keys include well-known toolchain manifest files such as
+  `mise.toml`, `.mise.toml`, `mise.lock`, and `.tool-versions`
 - services-stage publish, lookup, restore, and republish on top of the selected
   workspace or dependency stage
 
@@ -180,8 +182,8 @@ This phase now means:
 - Firecracker hot-path materialization is wired through the volume-store path,
   but clone-based behavior still depends on the configured storage driver
 - dependency-stage keying has the first explicit input model, but richer
-  toolchain-derived inputs, lockfile parser inputs, and artifact allowlists are
-  still pending
+  lockfile parser inputs, artifact allowlists, and resolved tool-version inputs
+  are still pending
 - explicit local changes are still supplied through each create request today;
   the durable `changesetstore` records the replay payload and identity, but a
   user-facing `--changeset <id>` reuse surface has not been added yet
@@ -207,8 +209,9 @@ Today that means:
   repository bootstrap can create either a detached checkout or a named local
   branch
 - the dependency-stage key intentionally starts from the workspace-stage key
-  plus policy hash, dependency bootstrap recipe digest, and declared key-file
-  digests; richer toolchain and lockfile-parser inputs are still to come
+  plus policy hash, dependency bootstrap recipe digest, declared key-file
+  digests, and a small set of well-known toolchain manifest digests; richer
+  lockfile-parser inputs and resolved tool-version inputs are still to come
 - because dependency-stage snapshots are full rootfs snapshots, decoupling them
   from exact workspace identity requires a checkout refresh and validation step
   after restore; it is not live layer composition
@@ -1144,16 +1147,16 @@ This metadata should live in a dedicated `changesetstore`, not in
 
 The stage-cache flow is architecturally landed, but the full performance win
 still depends on clone-capable storage instead of the default `file` driver,
-and the dependency stage still needs richer lockfile/toolchain inputs.
+and the dependency stage still needs richer lockfile and resolved-toolchain
+inputs.
 
 ### Remaining
 
-1. Add richer toolchain input digests for dependency-stage keys beyond the
-   current workspace-plus-command-plus-key-files slice.
-2. Add lockfile parser inputs and artifact allowlists so dependency-stage keys
+1. Add lockfile parser inputs and artifact allowlists so dependency-stage keys
    can move beyond manually declared key files.
-3. Broaden block-volume output semantics only after the declared block model is
+2. Broaden block-volume output semantics only after the declared block model is
    stable in real workloads.
+3. Add resolved tool-version inputs beyond checked-in manifest files.
 4. Add additional ecosystems only after the first explicit dependency-stage
    flow is solid.
 5. Add a user-facing `--changeset <id>` or equivalent reuse surface if durable

--- a/internal/cachekey/cachekey.go
+++ b/internal/cachekey/cachekey.go
@@ -43,6 +43,7 @@ type DependencyStageInputs struct {
 	WorkspaceKey          string
 	CompiledPolicyHash    string
 	KeyFilesDigest        string
+	ToolchainInputsDigest string
 	BootstrapRecipeDigest string
 }
 
@@ -65,6 +66,7 @@ type PortableDependencyStageInputs struct {
 	DestinationDir              string
 	CheckoutRefreshRecipeDigest string
 	KeyFilesDigest              string
+	ToolchainInputsDigest       string
 	BootstrapRecipeDigest       string
 	OutputMode                  string
 	ProducerVersion             string
@@ -144,6 +146,7 @@ func DependencyStageKey(in DependencyStageInputs) string {
 		{name: "workspace_key", value: canonicalReference(in.WorkspaceKey)},
 		{name: "compiled_policy_hash", value: canonicalDigest(in.CompiledPolicyHash)},
 		{name: "key_files_digest", value: canonicalDigest(in.KeyFilesDigest)},
+		{name: "toolchain_inputs_digest", value: canonicalDigest(in.ToolchainInputsDigest)},
 		{name: "bootstrap_recipe_digest", value: canonicalDigest(in.BootstrapRecipeDigest)},
 	})
 }
@@ -171,6 +174,7 @@ func PortableDependencyStageKey(in PortableDependencyStageInputs) string {
 		{name: "destination_dir", value: canonicalAbsolutePath(in.DestinationDir)},
 		{name: "checkout_refresh_recipe_digest", value: canonicalDigest(in.CheckoutRefreshRecipeDigest)},
 		{name: "key_files_digest", value: canonicalDigest(in.KeyFilesDigest)},
+		{name: "toolchain_inputs_digest", value: canonicalDigest(in.ToolchainInputsDigest)},
 		{name: "bootstrap_recipe_digest", value: canonicalDigest(in.BootstrapRecipeDigest)},
 		{name: "output_mode", value: canonicalIdentifier(in.OutputMode)},
 		{name: "producer_version", value: canonicalIdentifier(in.ProducerVersion)},

--- a/internal/cachekey/cachekey_test.go
+++ b/internal/cachekey/cachekey_test.go
@@ -71,6 +71,7 @@ func TestDependencyStageKey(t *testing.T) {
 		WorkspaceKey:          "workspace:v1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 		CompiledPolicyHash:    "sha256:7777777777777777777777777777777777777777777777777777777777777777",
 		KeyFilesDigest:        "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		ToolchainInputsDigest: "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
 		BootstrapRecipeDigest: "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
 	}
 
@@ -90,6 +91,12 @@ func TestDependencyStageKey(t *testing.T) {
 	if gotMutated := DependencyStageKey(mutated); got == gotMutated {
 		t.Fatalf("dependency stage key did not change after input mutation: %q", got)
 	}
+
+	mutated = inputs
+	mutated.ToolchainInputsDigest = "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+	if gotMutated := DependencyStageKey(mutated); got == gotMutated {
+		t.Fatalf("dependency stage key did not change after toolchain input mutation: %q", got)
+	}
 }
 
 func TestPortableDependencyStageKey(t *testing.T) {
@@ -102,6 +109,7 @@ func TestPortableDependencyStageKey(t *testing.T) {
 		DestinationDir:              "/workspace",
 		CheckoutRefreshRecipeDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 		KeyFilesDigest:              "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		ToolchainInputsDigest:       "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
 		BootstrapRecipeDigest:       "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
 		OutputMode:                  "outside-workspace",
 		ProducerVersion:             "cleanroom/portable-dependency-stage-v1",
@@ -122,6 +130,12 @@ func TestPortableDependencyStageKey(t *testing.T) {
 	mutated.KeyFilesDigest = "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
 	if gotMutated := PortableDependencyStageKey(mutated); got == gotMutated {
 		t.Fatalf("portable dependency stage key did not change after key-file mutation: %q", got)
+	}
+
+	mutated = inputs
+	mutated.ToolchainInputsDigest = "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+	if gotMutated := PortableDependencyStageKey(mutated); got == gotMutated {
+		t.Fatalf("portable dependency stage key did not change after toolchain input mutation: %q", got)
 	}
 
 	mutated = inputs

--- a/internal/controlservice/dependency_stage.go
+++ b/internal/controlservice/dependency_stage.go
@@ -163,6 +163,9 @@ func (s *Service) dependencyStagePlanInputDigests(
 		return "", "", fmt.Errorf("%s input files require a repository checkout", dependencyStageName)
 	}
 	if s.RepositoryStore == nil {
+		if len(keyFiles) == 0 {
+			return "", "", nil
+		}
 		return "", "", fmt.Errorf("%s input files require repository store", dependencyStageName)
 	}
 

--- a/internal/controlservice/dependency_stage.go
+++ b/internal/controlservice/dependency_stage.go
@@ -35,6 +35,13 @@ const (
 	portableDependencyOutputMode           = "outside-workspace"
 )
 
+var dependencyStageToolchainInputFiles = []string{
+	".mise.toml",
+	".tool-versions",
+	"mise.lock",
+	"mise.toml",
+}
+
 type dependencyStagePlan struct {
 	CacheKey                string
 	PortableCacheKey        string
@@ -44,6 +51,8 @@ type dependencyStagePlan struct {
 	BootstrapRecipeDigest   string
 	KeyFiles                []string
 	KeyFilesDigest          string
+	ToolchainInputFiles     []string
+	ToolchainInputsDigest   string
 	Portable                bool
 }
 
@@ -74,6 +83,7 @@ func dependencyStagePlanForRepository(compiled *policy.CompiledPolicy, repositor
 		BootstrapCommand:      bootstrapCommand,
 		BootstrapRecipeDigest: bootstrapRecipeDigest,
 		KeyFiles:              append([]string(nil), compiled.Dependencies.KeyFiles...),
+		ToolchainInputFiles:   normalizeStageOptionalKeyFiles(dependencyStageToolchainInputFiles),
 		Portable:              compiled.Dependencies.Reuse == policy.DependencyReusePortable,
 	}, true
 }
@@ -93,7 +103,7 @@ func (s *Service) finalizeDependencyStagePlan(
 		return plan, false, nil
 	}
 
-	keyFilesDigest, err := s.dependencyStageKeyFilesDigest(ctx, repository, changeset, commitBundle, plan.KeyFiles)
+	keyFilesDigest, toolchainInputsDigest, err := s.dependencyStagePlanInputDigests(ctx, repository, changeset, commitBundle, plan.KeyFiles, plan.ToolchainInputFiles)
 	if err != nil {
 		return plan, false, err
 	}
@@ -102,6 +112,7 @@ func (s *Service) finalizeDependencyStagePlan(
 		WorkspaceKey:          strings.TrimSpace(workspaceStageKey),
 		CompiledPolicyHash:    strings.TrimSpace(compiled.Hash),
 		KeyFilesDigest:        strings.TrimSpace(keyFilesDigest),
+		ToolchainInputsDigest: strings.TrimSpace(toolchainInputsDigest),
 		BootstrapRecipeDigest: strings.TrimSpace(plan.BootstrapRecipeDigest),
 	})
 	if strings.TrimSpace(cacheKey) == "" {
@@ -112,6 +123,7 @@ func (s *Service) finalizeDependencyStagePlan(
 	plan.ParentWorkspaceCacheKey = strings.TrimSpace(workspaceStageKey)
 	plan.ParentRuntimeCacheKey = strings.TrimSpace(runtimeBaseKey)
 	plan.KeyFilesDigest = strings.TrimSpace(keyFilesDigest)
+	plan.ToolchainInputsDigest = strings.TrimSpace(toolchainInputsDigest)
 	if plan.Portable && strings.TrimSpace(runtimeBaseKey) != "" && strings.TrimSpace(keyFilesDigest) != "" {
 		normalizedRepository := normalizeRepositoryCheckoutForComparison(repository)
 		plan.PortableCacheKey = cachekey.PortableDependencyStageKey(cachekey.PortableDependencyStageInputs{
@@ -123,6 +135,7 @@ func (s *Service) finalizeDependencyStagePlan(
 			DestinationDir:              strings.TrimSpace(normalizedRepository.DestinationDir),
 			CheckoutRefreshRecipeDigest: repositorycheckout.RefreshRecipeDigest(normalizedRepository),
 			KeyFilesDigest:              strings.TrimSpace(keyFilesDigest),
+			ToolchainInputsDigest:       strings.TrimSpace(toolchainInputsDigest),
 			BootstrapRecipeDigest:       strings.TrimSpace(plan.BootstrapRecipeDigest),
 			OutputMode:                  portableDependencyOutputMode,
 			ProducerVersion:             portableDependencyStageProducerVersion,
@@ -133,6 +146,96 @@ func (s *Service) finalizeDependencyStagePlan(
 
 func (s *Service) dependencyStageKeyFilesDigest(ctx context.Context, repository *repositorycheckout.Checkout, changeset *repositorychangeset.Changeset, commitBundle *repositorybundle.Bundle, files []string) (string, error) {
 	return s.stageKeyFilesDigest(ctx, repository, changeset, commitBundle, files, dependencyStageName)
+}
+
+func (s *Service) dependencyStagePlanInputDigests(
+	ctx context.Context,
+	repository *repositorycheckout.Checkout,
+	changeset *repositorychangeset.Changeset,
+	commitBundle *repositorybundle.Bundle,
+	keyFiles []string,
+	toolchainInputFiles []string,
+) (string, string, error) {
+	if len(keyFiles) == 0 && len(toolchainInputFiles) == 0 {
+		return "", "", nil
+	}
+	if repository == nil {
+		return "", "", fmt.Errorf("%s input files require a repository checkout", dependencyStageName)
+	}
+	if s.RepositoryStore == nil {
+		return "", "", fmt.Errorf("%s input files require repository store", dependencyStageName)
+	}
+
+	readDigests := func(repoDir string) (string, string, error) {
+		if changeset != nil {
+			keyFilesDigest := ""
+			if len(keyFiles) > 0 {
+				var err error
+				keyFilesDigest, err = stageKeyFilesDigestWithChangeset(ctx, repoDir, changeset, keyFiles, dependencyStageName, repository.RemoteURL, repository.Submodules, s.RepositoryStore)
+				if err != nil {
+					return "", "", err
+				}
+			}
+			toolchainInputsDigest := ""
+			if len(toolchainInputFiles) > 0 {
+				var err error
+				toolchainInputsDigest, err = stageKeyFilesDigestWithChangeset(ctx, repoDir, changeset, toolchainInputFiles, dependencyStageName+" toolchain", repository.RemoteURL, repository.Submodules, s.RepositoryStore)
+				if err != nil {
+					return "", "", err
+				}
+			}
+			return keyFilesDigest, toolchainInputsDigest, nil
+		}
+		keyFilesDigest := ""
+		if len(keyFiles) > 0 {
+			var err error
+			keyFilesDigest, err = stageKeyFilesDigestAtCommit(ctx, repoDir, repository.RemoteURL, repository.CommitSHA, keyFiles, dependencyStageName, repository.Submodules, s.RepositoryStore)
+			if err != nil {
+				return "", "", err
+			}
+		}
+		toolchainInputsDigest := ""
+		if len(toolchainInputFiles) > 0 {
+			var err error
+			toolchainInputsDigest, err = stageOptionalKeyFilesDigestAtCommit(ctx, repoDir, repository.CommitSHA, toolchainInputFiles, dependencyStageName+" toolchain")
+			if err != nil {
+				return "", "", err
+			}
+		}
+		return keyFilesDigest, toolchainInputsDigest, nil
+	}
+
+	if commitBundle != nil {
+		prerequisiteCommit, err := s.ensureRepositoryCommitBundlePrerequisites(ctx, repository, commitBundle)
+		if err != nil {
+			return "", "", err
+		}
+		var keyFilesDigest string
+		var toolchainInputsDigest string
+		err = s.RepositoryStore.WithRepository(ctx, repository.RemoteURL, prerequisiteCommit, repositorystore.FetchHints{}, func(repoDir string) error {
+			return commitBundle.WithRepository(ctx, repoDir, func(bundleRepoDir string) error {
+				var err error
+				keyFilesDigest, toolchainInputsDigest, err = readDigests(bundleRepoDir)
+				return err
+			})
+		})
+		if err != nil {
+			return "", "", err
+		}
+		return keyFilesDigest, toolchainInputsDigest, nil
+	}
+
+	var keyFilesDigest string
+	var toolchainInputsDigest string
+	err := s.RepositoryStore.WithRepository(ctx, repository.RemoteURL, repository.CommitSHA, repositorystore.FetchHints{}, func(repoDir string) error {
+		var err error
+		keyFilesDigest, toolchainInputsDigest, err = readDigests(repoDir)
+		return err
+	})
+	if err != nil {
+		return "", "", err
+	}
+	return keyFilesDigest, toolchainInputsDigest, nil
 }
 
 func (s *Service) stageKeyFilesDigest(ctx context.Context, repository *repositorycheckout.Checkout, changeset *repositorychangeset.Changeset, commitBundle *repositorybundle.Bundle, files []string, stageName string) (string, error) {
@@ -269,14 +372,73 @@ func stageKeyFilesDigestWithChangeset(ctx context.Context, repoDir string, chang
 			Deleted: file.Deleted,
 		})
 	}
+	return digestStageKeyFileManifest(manifest, stageName)
+}
 
-	payload, err := json.Marshal(manifest)
-	if err != nil {
-		return "", fmt.Errorf("marshal %s key file manifest: %w", stageName, err)
+func stageOptionalKeyFilesDigestAtCommit(ctx context.Context, repoDir, commitSHA string, files []string, stageName string) (string, error) {
+	trimmedCommitSHA := strings.TrimSpace(commitSHA)
+	if trimmedCommitSHA == "" {
+		return "", fmt.Errorf("%s input file commit SHA is empty", stageName)
 	}
 
-	sum := sha256.Sum256(payload)
-	return "sha256:" + hex.EncodeToString(sum[:]), nil
+	normalizedFiles := normalizeStageOptionalKeyFiles(files)
+	if len(normalizedFiles) == 0 {
+		return "", nil
+	}
+
+	entries, err := gitTreeEntriesForFiles(ctx, strings.TrimSpace(repoDir), trimmedCommitSHA, normalizedFiles)
+	if err != nil {
+		return "", fmt.Errorf("inspect %s input files: %w", stageName, err)
+	}
+
+	existingFiles := make([]string, 0, len(normalizedFiles))
+	for _, file := range normalizedFiles {
+		if entry, ok := entries[file]; ok {
+			if entry.Mode == "160000" {
+				return "", fmt.Errorf("%s input file %q is a gitlink; toolchain input files must be blobs", stageName, file)
+			}
+			existingFiles = append(existingFiles, file)
+		}
+	}
+
+	digests := map[string]string{}
+	if len(existingFiles) > 0 {
+		digests, err = gitFileDigestsAtCommit(ctx, strings.TrimSpace(repoDir), trimmedCommitSHA, existingFiles)
+		if err != nil {
+			return "", fmt.Errorf("read %s input files: %w", stageName, err)
+		}
+	}
+
+	manifest := make([]stageKeyFileDigest, 0, len(normalizedFiles))
+	for _, file := range normalizedFiles {
+		if _, ok := entries[file]; !ok {
+			manifest = append(manifest, stageKeyFileDigest{Path: file, Deleted: true})
+			continue
+		}
+		manifest = append(manifest, stageKeyFileDigest{
+			Path:   file,
+			SHA256: digests[file],
+		})
+	}
+	return digestStageKeyFileManifest(manifest, stageName)
+}
+
+func normalizeStageOptionalKeyFiles(files []string) []string {
+	seen := make(map[string]struct{}, len(files))
+	out := make([]string, 0, len(files))
+	for _, file := range files {
+		file = strings.TrimSpace(file)
+		if file == "" {
+			continue
+		}
+		if _, ok := seen[file]; ok {
+			continue
+		}
+		seen[file] = struct{}{}
+		out = append(out, file)
+	}
+	sort.Strings(out)
+	return out
 }
 
 func stageInputFilesDigestWithChangeset(ctx context.Context, repoDir string, changeset *repositorychangeset.Changeset, files []string, stageName string, parentRemoteURL string, submodules bool, store repositorystore.RepositoryStore) (string, error) {
@@ -302,6 +464,15 @@ func stageInputFilesDigestWithChangeset(ctx context.Context, repoDir string, cha
 		})
 	}
 	return digestStageInputFileManifest(manifest, stageName)
+}
+
+func digestStageKeyFileManifest(manifest []stageKeyFileDigest, stageName string) (string, error) {
+	payload, err := json.Marshal(manifest)
+	if err != nil {
+		return "", fmt.Errorf("marshal %s key file manifest: %w", stageName, err)
+	}
+	sum := sha256.Sum256(payload)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
 }
 
 func stageKeyFilesDigestAtCommit(ctx context.Context, repoDir, parentRemoteURL, commitSHA string, files []string, stageName string, submodules bool, store repositorystore.RepositoryStore) (string, error) {
@@ -383,14 +554,7 @@ func stageKeyFilesDigestAtCommit(ctx context.Context, repoDir, parentRemoteURL, 
 			SHA256: allDigests[file],
 		})
 	}
-
-	payload, err := json.Marshal(manifest)
-	if err != nil {
-		return "", fmt.Errorf("marshal %s key file manifest: %w", stageName, err)
-	}
-
-	sum := sha256.Sum256(payload)
-	return "sha256:" + hex.EncodeToString(sum[:]), nil
+	return digestStageKeyFileManifest(manifest, stageName)
 }
 
 func stageInputFilesDigestAtCommit(ctx context.Context, repoDir, parentRemoteURL, commitSHA string, files []string, stageName string, submodules bool, store repositorystore.RepositoryStore) (string, error) {
@@ -759,6 +923,7 @@ func (s *Service) restorePortableDependencyStageCache(
 	changeset *repositorychangeset.Changeset,
 	commitBundle *repositorybundle.Bundle,
 	options *cleanroomv1.SandboxOptions,
+	plan dependencyStagePlan,
 	record cachestore.Record,
 	cacheOutputVolumes []backend.CacheOutputVolumeSpec,
 	reporter CreateSandboxReporter,
@@ -792,6 +957,12 @@ func (s *Service) restorePortableDependencyStageCache(
 			return nil, fmt.Errorf("validate portable dependency stage key files: %w; cleanup failed: %v", err, cleanupErr)
 		}
 		return nil, fmt.Errorf("validate portable dependency stage key files: %w", err)
+	}
+	if err := s.validatePortableDependencyStageToolchainInputs(ctx, adapter, sandboxID, compiled, firecrackerCfg, repository, plan); err != nil {
+		if cleanupErr := s.terminateCreatedSandbox(context.Background(), adapter, sandboxID); cleanupErr != nil {
+			return nil, fmt.Errorf("validate portable dependency stage toolchain inputs: %w; cleanup failed: %v", err, cleanupErr)
+		}
+		return nil, fmt.Errorf("validate portable dependency stage toolchain inputs: %w", err)
 	}
 
 	if sandbox := s.markRestoredSandboxRepositoryReady(sandboxID, repository, commitBundle, changeset != nil); sandbox != nil {
@@ -837,7 +1008,38 @@ func (s *Service) validatePortableDependencyStageKeyFiles(
 	if expectedDigest == "" {
 		return fmt.Errorf("portable dependency stage is missing dependency key-file digest")
 	}
-	command, err := dependencyStageKeyFilesDigestCommand(repository, compiled.Dependencies.KeyFiles)
+	return s.validatePortableDependencyStageFileDigest(ctx, adapter, sandboxID, compiled, firecrackerCfg, repository, compiled.Dependencies.KeyFiles, expectedDigest, "portable dependency key-file")
+}
+
+func (s *Service) validatePortableDependencyStageToolchainInputs(
+	ctx context.Context,
+	adapter backend.Adapter,
+	sandboxID string,
+	compiled *policy.CompiledPolicy,
+	firecrackerCfg backend.FirecrackerConfig,
+	repository *repositorycheckout.Checkout,
+	plan dependencyStagePlan,
+) error {
+	expectedDigest := strings.TrimSpace(plan.ToolchainInputsDigest)
+	files := normalizeStageOptionalKeyFiles(plan.ToolchainInputFiles)
+	if expectedDigest == "" || len(files) == 0 {
+		return nil
+	}
+	return s.validatePortableDependencyStageFileDigest(ctx, adapter, sandboxID, compiled, firecrackerCfg, repository, files, expectedDigest, "portable dependency toolchain input")
+}
+
+func (s *Service) validatePortableDependencyStageFileDigest(
+	ctx context.Context,
+	adapter backend.Adapter,
+	sandboxID string,
+	compiled *policy.CompiledPolicy,
+	firecrackerCfg backend.FirecrackerConfig,
+	repository *repositorycheckout.Checkout,
+	files []string,
+	expectedDigest string,
+	label string,
+) error {
+	command, err := dependencyStageFileDigestCommand(repository, files, label+" validation")
 	if err != nil {
 		return err
 	}
@@ -859,7 +1061,7 @@ func (s *Service) validatePortableDependencyStageKeyFiles(
 		return fmt.Errorf("%s", message)
 	}
 	if result == nil {
-		return fmt.Errorf("portable dependency key-file validation returned no result")
+		return fmt.Errorf("%s validation returned no result", label)
 	}
 	if result.ExitCode != 0 {
 		message := strings.TrimSpace(stderr.String())
@@ -867,23 +1069,27 @@ func (s *Service) validatePortableDependencyStageKeyFiles(
 			message = strings.TrimSpace(stdout.String())
 		}
 		if message == "" {
-			message = fmt.Sprintf("portable dependency key-file validation failed with exit code %d", result.ExitCode)
+			message = fmt.Sprintf("%s validation failed with exit code %d", label, result.ExitCode)
 		}
 		return fmt.Errorf("%s", message)
 	}
 	actualDigest := strings.TrimSpace(stdout.String())
 	if actualDigest != expectedDigest {
-		return fmt.Errorf("portable dependency key-file digest mismatch: expected %s got %s", expectedDigest, actualDigest)
+		return fmt.Errorf("%s digest mismatch: expected %s got %s", label, expectedDigest, actualDigest)
 	}
 	return nil
 }
 
 func dependencyStageKeyFilesDigestCommand(repository *repositorycheckout.Checkout, files []string) ([]string, error) {
+	return dependencyStageFileDigestCommand(repository, files, "portable dependency key-file validation")
+}
+
+func dependencyStageFileDigestCommand(repository *repositorycheckout.Checkout, files []string, label string) ([]string, error) {
 	if repository == nil {
-		return nil, fmt.Errorf("portable dependency key-file validation requires a repository checkout")
+		return nil, fmt.Errorf("%s requires a repository checkout", label)
 	}
 	if len(files) == 0 {
-		return nil, fmt.Errorf("portable dependency key-file validation requires dependency key files")
+		return nil, fmt.Errorf("%s requires input files", label)
 	}
 	var script strings.Builder
 	script.WriteString("set -eu\n")

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -4564,6 +4564,44 @@ func TestDependencyStagePlanNormalizesToolchainInputFilesForValidation(t *testin
 	}
 }
 
+func TestFinalizeDependencyStagePlanAllowsExactCacheWithoutRepositoryStoreWhenNoKeyFiles(t *testing.T) {
+	t.Parallel()
+
+	compiled := &policy.CompiledPolicy{
+		Hash: "sha256:7777777777777777777777777777777777777777777777777777777777777777",
+		Dependencies: policy.Dependencies{
+			Command: []string{"true"},
+		},
+	}
+	repository := &repositorycheckout.Checkout{
+		RemoteURL:      "https://github.com/buildkite/cleanroom.git",
+		CommitSHA:      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		DestinationDir: "/workspace",
+	}
+	plan, ok := dependencyStagePlanForRepository(compiled, repository)
+	if !ok {
+		t.Fatal("expected dependency stage plan")
+	}
+
+	svc := newTestService(&stubAdapter{})
+	plan, ok, err := svc.finalizeDependencyStagePlan(context.Background(), compiled, repository, nil, nil, "firecracker", "workspace:v1:test", "runtime:v1:test", plan)
+	if err != nil {
+		t.Fatalf("finalizeDependencyStagePlan returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected dependency stage cache plan")
+	}
+	if plan.CacheKey == "" {
+		t.Fatal("expected exact dependency stage cache key")
+	}
+	if plan.PortableCacheKey != "" {
+		t.Fatalf("expected no portable dependency stage cache key without dependency key files, got %q", plan.PortableCacheKey)
+	}
+	if plan.ToolchainInputsDigest != "" {
+		t.Fatalf("expected toolchain inputs to be skipped without repository store, got %q", plan.ToolchainInputsDigest)
+	}
+}
+
 func TestDependencyStageKeyFilesDigestExpandsGlobsDeterministically(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -446,6 +446,21 @@ func testRepositoryPortableDependencyPolicy() *cleanroomv1.Policy {
 	return policyProto
 }
 
+func writePortableDependencyValidationDigest(command []string, stream backend.OutputStream, keyFilesDigest, toolchainInputsDigest string) {
+	if stream.OnStdout == nil {
+		return
+	}
+	joined := strings.Join(command, "\n")
+	if !strings.Contains(joined, "sha256sum") {
+		return
+	}
+	if strings.Contains(joined, "mise.toml") || strings.Contains(joined, ".tool-versions") {
+		stream.OnStdout([]byte(toolchainInputsDigest + "\n"))
+		return
+	}
+	stream.OnStdout([]byte(keyFilesDigest + "\n"))
+}
+
 func testPolicyBlock(name string, command, inputFiles, outputDirs, outputFiles []string) *cleanroomv1.PolicyBlock {
 	return &cleanroomv1.PolicyBlock{
 		Name:    name,
@@ -3863,16 +3878,15 @@ func TestCreateSandboxReusesPortableDependencyStageAfterCheckoutRefresh(t *testi
 	adapter := &stubAdapter{}
 	var snapshotReqs []backend.SnapshotRequest
 	var runCommands [][]string
-	validationDigest := ""
+	keyFilesDigest := ""
+	toolchainInputsDigest := ""
 	adapter.createSnapshotFn = func(_ context.Context, req backend.SnapshotRequest) (*backend.SnapshotResult, error) {
 		snapshotReqs = append(snapshotReqs, req)
 		return &backend.SnapshotResult{StorageRef: "/snapshots/" + req.SnapshotID + ".ext4"}, nil
 	}
 	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 		runCommands = append(runCommands, append([]string(nil), req.Command...))
-		if strings.Contains(strings.Join(req.Command, "\n"), "sha256sum") && stream.OnStdout != nil {
-			stream.OnStdout([]byte(validationDigest + "\n"))
-		}
+		writePortableDependencyValidationDigest(req.Command, stream, keyFilesDigest, toolchainInputsDigest)
 		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
 	}
 	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
@@ -3892,9 +3906,10 @@ func TestCreateSandboxReusesPortableDependencyStageAfterCheckoutRefresh(t *testi
 	svc := newTestServiceWithSnapshotStore(adapter, store)
 	svc.RepositoryStore = mirrors
 	var err error
-	validationDigest, err = svc.dependencyStageKeyFilesDigest(context.Background(), repositorycheckout.FromProto(&updatedCheckout), nil, nil, []string{"go.mod", "go.sum"})
+	updatedRepository := repositorycheckout.FromProto(&updatedCheckout)
+	keyFilesDigest, toolchainInputsDigest, err = svc.dependencyStagePlanInputDigests(context.Background(), updatedRepository, nil, nil, []string{"go.mod", "go.sum"}, dependencyStageToolchainInputFiles)
 	if err != nil {
-		t.Fatalf("dependencyStageKeyFilesDigest returned error: %v", err)
+		t.Fatalf("dependencyStagePlanInputDigests returned error: %v", err)
 	}
 
 	if _, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
@@ -3928,8 +3943,8 @@ func TestCreateSandboxReusesPortableDependencyStageAfterCheckoutRefresh(t *testi
 	if got, want := len(snapshotReqs), 2; got != want {
 		t.Fatalf("expected workspace and dependency snapshot publishes only, got %d want %d", got, want)
 	}
-	if got, want := len(runCommands), 4; got != want {
-		t.Fatalf("expected repository bootstrap, dependency bootstrap, and checkout refresh, got %d commands", got)
+	if got, want := len(runCommands), 5; got != want {
+		t.Fatalf("expected repository bootstrap, dependency bootstrap, checkout refresh, and validations, got %d commands", got)
 	}
 	refreshCommand := strings.Join(runCommands[2], "\n")
 	if !strings.Contains(refreshCommand, updatedCommit) || !strings.Contains(refreshCommand, `git -C "$dest" fetch --filter=blob:none --progress origin "$commit"`) {
@@ -3940,6 +3955,9 @@ func TestCreateSandboxReusesPortableDependencyStageAfterCheckoutRefresh(t *testi
 	}
 	if validationCommand := strings.Join(runCommands[3], "\n"); !strings.Contains(validationCommand, "sha256sum") {
 		t.Fatalf("expected portable hit to validate dependency key files, got %q", validationCommand)
+	}
+	if validationCommand := strings.Join(runCommands[4], "\n"); !strings.Contains(validationCommand, "mise.toml") || !strings.Contains(validationCommand, ".tool-versions") {
+		t.Fatalf("expected portable hit to validate dependency toolchain inputs, got %q", validationCommand)
 	}
 
 	cacheStore, ok := svc.CacheStore.(*memoryCacheStore)
@@ -3985,6 +4003,68 @@ func TestCreateSandboxReusesPortableDependencyStageAfterCheckoutRefresh(t *testi
 	}
 	if got, want := restoredState.Repository.CommitSHA, updatedCommit; got != want {
 		t.Fatalf("expected restored sandbox repository to be refreshed: got %q want %q", got, want)
+	}
+}
+
+func TestCreateSandboxDoesNotReusePortableDependencyStageAfterToolchainInputChange(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	store := newMemorySnapshotStore()
+	adapter := &stubAdapter{}
+	var runCommands [][]string
+	adapter.createSnapshotFn = func(_ context.Context, req backend.SnapshotRequest) (*backend.SnapshotResult, error) {
+		return &backend.SnapshotResult{StorageRef: "/snapshots/" + req.SnapshotID + ".ext4"}, nil
+	}
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
+		runCommands = append(runCommands, append([]string(nil), req.Command...))
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+	}
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"go.mod":    "module example.com/test\n\ngo 1.26.2\n",
+		"go.sum":    "example.com/test v0.0.0 h1:abc123\n",
+		"mise.toml": "[tools]\ngo = \"1.26.2\"\n",
+		"app.go":    "package main\n\nfunc main() {}\n",
+	})
+	if err := os.WriteFile(filepath.Join(mirrors.mirrorPath, "mise.toml"), []byte("[tools]\ngo = \"1.27.0\"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(mise.toml) returned error: %v", err)
+	}
+	runTestGit(t, mirrors.mirrorPath, "add", ".")
+	runTestGit(t, mirrors.mirrorPath, "commit", "-m", "toolchain change")
+	updatedCommit := strings.TrimSpace(runTestGit(t, mirrors.mirrorPath, "rev-parse", "HEAD"))
+	updatedCheckout := *repositoryCheckout
+	updatedCheckout.CommitSha = updatedCommit
+
+	svc := newTestServiceWithSnapshotStore(adapter, store)
+	svc.RepositoryStore = mirrors
+
+	if _, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Policy:             testRepositoryPortableDependencyPolicy(),
+		RepositoryCheckout: repositoryCheckout,
+	}); err != nil {
+		t.Fatalf("first CreateSandbox returned error: %v", err)
+	}
+	secondResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Policy:             testRepositoryPortableDependencyPolicy(),
+		RepositoryCheckout: &updatedCheckout,
+	})
+	if err != nil {
+		t.Fatalf("second CreateSandbox returned error: %v", err)
+	}
+	if got := secondResp.GetSourceKind(); got == "portable dependency stage cache" {
+		t.Fatalf("unexpected portable dependency-stage hit after toolchain input changed")
+	}
+	if got, want := adapter.provisionCalls, 2; got != want {
+		t.Fatalf("expected toolchain input change to require a second cold provision, got %d want %d", got, want)
+	}
+	if got, want := adapter.provisionFromSnapshotCalls, 0; got != want {
+		t.Fatalf("expected no portable dependency-stage restore after toolchain input change, got %d want %d", got, want)
+	}
+	if got, want := adapter.createSnapshotCalls, 4; got != want {
+		t.Fatalf("expected both creates to publish workspace and dependency snapshots, got %d want %d", got, want)
+	}
+	for _, command := range runCommands {
+		if strings.Contains(strings.Join(command, "\n"), "sha256sum") {
+			t.Fatalf("did not expect portable dependency-stage validation command after toolchain input change, got %q", command)
+		}
 	}
 }
 
@@ -4123,7 +4203,8 @@ func TestCreateSandboxStoresCommitBundleAfterPortableDependencyStageRestore(t *t
 	store := newMemorySnapshotStore()
 	adapter := &stubAdapter{}
 	var runCommands [][]string
-	validationDigest := ""
+	keyFilesDigest := ""
+	toolchainInputsDigest := ""
 	adapter.createSnapshotFn = func(_ context.Context, req backend.SnapshotRequest) (*backend.SnapshotResult, error) {
 		return &backend.SnapshotResult{StorageRef: "/snapshots/" + req.SnapshotID + ".ext4"}, nil
 	}
@@ -4155,9 +4236,7 @@ func TestCreateSandboxStoresCommitBundleAfterPortableDependencyStageRestore(t *t
 		mu.Lock()
 		runCommands = append(runCommands, append([]string(nil), req.Command...))
 		mu.Unlock()
-		if strings.Contains(strings.Join(req.Command, "\n"), "sha256sum") && stream.OnStdout != nil {
-			stream.OnStdout([]byte(validationDigest + "\n"))
-		}
+		writePortableDependencyValidationDigest(req.Command, stream, keyFilesDigest, toolchainInputsDigest)
 		select {
 		case runCalled <- struct{}{}:
 		default:
@@ -4218,9 +4297,9 @@ func TestCreateSandboxStoresCommitBundleAfterPortableDependencyStageRestore(t *t
 
 	svc := newTestServiceWithSnapshotStore(adapter, store)
 	svc.RepositoryStore = mirrors
-	validationDigest, err = svc.dependencyStageKeyFilesDigest(context.Background(), updatedRepository, changeset, commitBundle, []string{"go.mod", "go.sum"})
+	keyFilesDigest, toolchainInputsDigest, err = svc.dependencyStagePlanInputDigests(context.Background(), updatedRepository, changeset, commitBundle, []string{"go.mod", "go.sum"}, dependencyStageToolchainInputFiles)
 	if err != nil {
-		t.Fatalf("dependencyStageKeyFilesDigest returned error: %v", err)
+		t.Fatalf("dependencyStagePlanInputDigests returned error: %v", err)
 	}
 
 	if _, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
@@ -4295,16 +4374,15 @@ func TestCreateSandboxBootstrapsServicesAfterPortableDependencyStageRestore(t *t
 	adapter := &stubAdapter{}
 	var snapshotReqs []backend.SnapshotRequest
 	var runCommands [][]string
-	validationDigest := ""
+	keyFilesDigest := ""
+	toolchainInputsDigest := ""
 	adapter.createSnapshotFn = func(_ context.Context, req backend.SnapshotRequest) (*backend.SnapshotResult, error) {
 		snapshotReqs = append(snapshotReqs, req)
 		return &backend.SnapshotResult{StorageRef: "/snapshots/" + req.SnapshotID + ".ext4"}, nil
 	}
 	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 		runCommands = append(runCommands, append([]string(nil), req.Command...))
-		if strings.Contains(strings.Join(req.Command, "\n"), "sha256sum") && stream.OnStdout != nil {
-			stream.OnStdout([]byte(validationDigest + "\n"))
-		}
+		writePortableDependencyValidationDigest(req.Command, stream, keyFilesDigest, toolchainInputsDigest)
 		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
 	}
 	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
@@ -4325,9 +4403,10 @@ func TestCreateSandboxBootstrapsServicesAfterPortableDependencyStageRestore(t *t
 	svc := newTestServiceWithSnapshotStore(adapter, store)
 	svc.RepositoryStore = mirrors
 	var err error
-	validationDigest, err = svc.dependencyStageKeyFilesDigest(context.Background(), repositorycheckout.FromProto(&updatedCheckout), nil, nil, []string{"go.mod", "go.sum"})
+	updatedRepository := repositorycheckout.FromProto(&updatedCheckout)
+	keyFilesDigest, toolchainInputsDigest, err = svc.dependencyStagePlanInputDigests(context.Background(), updatedRepository, nil, nil, []string{"go.mod", "go.sum"}, dependencyStageToolchainInputFiles)
 	if err != nil {
-		t.Fatalf("dependencyStageKeyFilesDigest returned error: %v", err)
+		t.Fatalf("dependencyStagePlanInputDigests returned error: %v", err)
 	}
 
 	portableServicesPolicy := testRepositoryDependencyAndServicesPolicy()
@@ -4360,13 +4439,13 @@ func TestCreateSandboxBootstrapsServicesAfterPortableDependencyStageRestore(t *t
 	if got, want := len(snapshotReqs), 4; got != want {
 		t.Fatalf("expected four snapshot publish requests, got %d want %d", got, want)
 	}
-	if got, want := len(runCommands), 6; got != want {
+	if got, want := len(runCommands), 7; got != want {
 		t.Fatalf("expected cold bootstraps plus portable refresh, validation, and services bootstrap, got %d want %d", got, want)
 	}
 	if refreshCommand := strings.Join(runCommands[3], "\n"); !strings.Contains(refreshCommand, updatedCommit) {
 		t.Fatalf("expected portable hit to refresh checkout to %s, got %q", updatedCommit, refreshCommand)
 	}
-	servicesBootstrap := strings.Join(runCommands[5], " ")
+	servicesBootstrap := strings.Join(runCommands[6], " ")
 	if !strings.Contains(servicesBootstrap, "docker") || !strings.Contains(servicesBootstrap, "compose") || !strings.Contains(servicesBootstrap, "postgres") {
 		t.Fatalf("expected services bootstrap after portable restore, got %q", servicesBootstrap)
 	}
@@ -4427,6 +4506,61 @@ func TestDependencyStageKeyFilesDigestDerivesHashesFromRepositoryChangesetPatch(
 	}
 	if got, want := tamperedDigest, changesetDigest; got != want {
 		t.Fatalf("expected dependency key file digest to ignore tampered file hashes: got %q want %q", got, want)
+	}
+}
+
+func TestDependencyStageToolchainInputsDigestDerivesHashesFromRepositoryChangesetPatch(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"go.mod":    "module example.com/test\n\ngo 1.26.2\n",
+		"go.sum":    "example.com/test v0.0.0 h1:abc123\n",
+		"mise.toml": "[tools]\ngo = \"1.26.2\"\n",
+	})
+	repository := repositorycheckout.FromProto(repositoryCheckout)
+	repoDir := mirrors.mirrorPath
+	if err := os.WriteFile(filepath.Join(repoDir, "mise.toml"), []byte("[tools]\ngo = \"1.27.0\"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(mise.toml) returned error: %v", err)
+	}
+	changeset, err := repositorychangeset.BuildFromWorkingTree(repoDir, repository)
+	if err != nil {
+		t.Fatalf("BuildFromWorkingTree returned error: %v", err)
+	}
+	if changeset == nil {
+		t.Fatal("expected repository changeset for modified toolchain input")
+	}
+
+	svc := newTestService(&stubAdapter{})
+	svc.RepositoryStore = mirrors
+
+	_, baseDigest, err := svc.dependencyStagePlanInputDigests(context.Background(), repository, nil, nil, []string{"go.mod", "go.sum"}, dependencyStageToolchainInputFiles)
+	if err != nil {
+		t.Fatalf("dependencyStagePlanInputDigests without changeset returned error: %v", err)
+	}
+	_, changesetDigest, err := svc.dependencyStagePlanInputDigests(context.Background(), repository, changeset, nil, []string{"go.mod", "go.sum"}, dependencyStageToolchainInputFiles)
+	if err != nil {
+		t.Fatalf("dependencyStagePlanInputDigests with changeset returned error: %v", err)
+	}
+	if changesetDigest == "" {
+		t.Fatal("expected dependency toolchain input digest with repository changeset")
+	}
+	if changesetDigest == baseDigest {
+		t.Fatalf("expected changeset-aware dependency toolchain input digest to differ from base digest %q", baseDigest)
+	}
+}
+
+func TestDependencyStagePlanNormalizesToolchainInputFilesForValidation(t *testing.T) {
+	t.Parallel()
+
+	compiled, err := policy.FromProto(testRepositoryPortableDependencyPolicy())
+	if err != nil {
+		t.Fatalf("FromProto returned error: %v", err)
+	}
+	plan, ok := dependencyStagePlanForRepository(compiled, &repositorycheckout.Checkout{DestinationDir: "/workspace"})
+	if !ok {
+		t.Fatal("expected dependency stage plan")
+	}
+	if got, want := strings.Join(plan.ToolchainInputFiles, "\x00"), strings.Join(normalizeStageOptionalKeyFiles(dependencyStageToolchainInputFiles), "\x00"); got != want {
+		t.Fatalf("unexpected toolchain input file order: got %q want %q", got, want)
 	}
 }
 

--- a/internal/controlservice/stage_cache_resolution.go
+++ b/internal/controlservice/stage_cache_resolution.go
@@ -330,7 +330,7 @@ func (s *Service) resolvePortableDependencyStageCache(ctx context.Context, req d
 		attribute.String(observability.AttrBackend, req.backendName),
 	), func(ctx context.Context) error {
 		var err error
-		restoreResp, err = s.restorePortableDependencyStageCache(ctx, req.adapter, req.backendName, req.compiled, req.firecrackerCfg, req.repository, req.changeset, req.commitBundle, req.options, record, req.serviceCacheOutputs, req.reporter)
+		restoreResp, err = s.restorePortableDependencyStageCache(ctx, req.adapter, req.backendName, req.compiled, req.firecrackerCfg, req.repository, req.changeset, req.commitBundle, req.options, req.plan, record, req.serviceCacheOutputs, req.reporter)
 		setCacheResultSpanAttribute(ctx, map[bool]string{true: observability.CacheResultFailed, false: observability.CacheResultRestored}[err != nil])
 		return err
 	})


### PR DESCRIPTION
## Problem
Portable dependency-stage reuse only considered declared dependency key files. A repo could change a checked-in toolchain manifest such as `mise.toml` while leaving `go.mod` and `go.sum` unchanged, which made the portable dependency cache too broad.

## Change
- Add a normalized digest of `.mise.toml`, `.tool-versions`, `mise.lock`, and `mise.toml` to exact and portable dependency cache keys.
- Validate the toolchain digest after a portable dependency-stage checkout refresh, alongside declared dependency key files.
- Compute dependency key-file and toolchain digests through one repository read during plan finalization.
- Update the layered caching plan to mark this slice landed and leave lockfile parsers, artifact allowlists, and resolved tool versions as follow-ups.

## Validation
- `mise run check`