### PR TITLE
test: Add minimal darwin-vz benchmark harness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,4 +2,5 @@
 
 - Keep implementation backend-agnostic by default.
 - Prefer backend-neutral CLI/API surfaces; place backend-specific runtime details in runtime config (XDG config) and adapter internals.
+- For darwin-vz boot-time experiments, prefer the minimal benchmark harness under `benchmarks/darwin-vz/minimal` before changing the production adapter path.
 - This project is in early development: breaking changes are acceptable, and legacy/backwards-compat paths are not required unless explicitly requested.

--- a/benchmarks/darwin-vz/minimal/README.md
+++ b/benchmarks/darwin-vz/minimal/README.md
@@ -1,0 +1,34 @@
+# Minimal darwin-vz Benchmark
+
+This directory contains a deliberately small Virtualization.framework benchmark for darwin-vz boot experiments. It is a lower-bound probe, not a Cleanroom backend and not a replacement for `scripts/benchmark-tti.sh`.
+
+The runner boots a Linux kernel through `VZLinuxBootLoader`, connects to a guest vsock listener, runs `/bin/true`, and prints JSON timings for VM start, vsock readiness, and first exec response.
+
+## Layout
+
+- `runner.swift`: standalone Virtualization.framework runner.
+- `initrd-agent`: tiny Linux `/init` that implements enough of the guest exec protocol for `/bin/true`.
+- `initrd-true`: static no-op command used by the initrd benchmark.
+- `build-runner.sh`: builds and signs `dist/darwin-vz-minimal`.
+- `build-initrd.sh`: builds `dist/darwin-vz-minimal-initrd.cpio.gz`.
+- `build-kernel.sh`: Docker-based minimal Linux kernel builder for initrd or rootfs profiles.
+
+## Run
+
+To run with an existing kernel:
+
+```bash
+scripts/benchmark-darwin-vz-minimal.sh \
+  --kernel dist/darwin-vz-minimal-initrd-arm64-kernel-6.1.155-Image \
+  --iterations 30
+```
+
+To build the minimal kernel first:
+
+```bash
+scripts/benchmark-darwin-vz-minimal.sh --build-kernel --iterations 30
+```
+
+The wrapper writes JSONL results to `benchmarks/results/` and leaves build outputs in `dist/`.
+
+Use this benchmark when testing kernel, initrd, VZ device, or guest-readiness experiments. Use `scripts/benchmark-tti.sh` when measuring end-to-end Cleanroom user-facing startup.

--- a/benchmarks/darwin-vz/minimal/build-initrd.sh
+++ b/benchmarks/darwin-vz/minimal/build-initrd.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+OUTPUT_PATH="${1:-${REPO_ROOT}/dist/darwin-vz-minimal-initrd.cpio.gz}"
+ROOT_DIR="${REPO_ROOT}/dist/darwin-vz-minimal-initrd-root"
+
+host_arch="$(go env GOARCH)"
+
+rm -rf "${ROOT_DIR}"
+mkdir -p \
+  "${ROOT_DIR}/bin" \
+  "${ROOT_DIR}/dev" \
+  "${ROOT_DIR}/proc" \
+  "${ROOT_DIR}/root" \
+  "${ROOT_DIR}/run" \
+  "${ROOT_DIR}/sys" \
+  "${ROOT_DIR}/tmp"
+
+GOOS=linux GOARCH="${host_arch}" CGO_ENABLED=0 go build \
+  -trimpath \
+  -ldflags "-s -w" \
+  -o "${ROOT_DIR}/init" \
+  "${SCRIPT_DIR}/initrd-agent"
+
+GOOS=linux GOARCH="${host_arch}" CGO_ENABLED=0 go build \
+  -trimpath \
+  -ldflags "-s -w" \
+  -o "${ROOT_DIR}/bin/true" \
+  "${SCRIPT_DIR}/initrd-true"
+
+chmod 0755 "${ROOT_DIR}/init" "${ROOT_DIR}/bin/true"
+chmod 1777 "${ROOT_DIR}/tmp"
+
+mkdir -p "$(dirname "${OUTPUT_PATH}")"
+(
+  cd "${ROOT_DIR}"
+  find . -print | LC_ALL=C sort | cpio -o -H newc 2>/dev/null | gzip -n >"${OUTPUT_PATH}"
+)
+
+printf '%s\n' "${OUTPUT_PATH}"

--- a/benchmarks/darwin-vz/minimal/build-kernel.sh
+++ b/benchmarks/darwin-vz/minimal/build-kernel.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+
+KERNEL_VERSION="${CLEANROOM_DARWIN_VZ_MINIMAL_KERNEL_VERSION:-6.1.155}"
+KERNEL_PROFILE="${CLEANROOM_DARWIN_VZ_MINIMAL_KERNEL_PROFILE:-initrd}"
+KERNEL_ARCH="${CLEANROOM_DARWIN_VZ_MINIMAL_KERNEL_ARCH:-arm64}"
+DOCKER_IMAGE="${CLEANROOM_DARWIN_VZ_MINIMAL_KERNEL_DOCKER_IMAGE:-ubuntu:22.04}"
+DOCKER_PLATFORM="${CLEANROOM_DARWIN_VZ_MINIMAL_KERNEL_DOCKER_PLATFORM:-linux/${KERNEL_ARCH}}"
+BUILD_VOLUME="${CLEANROOM_DARWIN_VZ_MINIMAL_KERNEL_BUILD_VOLUME:-cleanroom-darwin-vz-minimal-kernel}"
+DEFAULT_KERNEL_TARBALL_SHA256=""
+if [[ "${KERNEL_VERSION}" == "6.1.155" ]]; then
+  DEFAULT_KERNEL_TARBALL_SHA256="c29387aeee085fbcbd91236224b9df805063bac43615e75cea2c6b29604a5c73"
+fi
+KERNEL_TARBALL_SHA256="${CLEANROOM_DARWIN_VZ_MINIMAL_KERNEL_TARBALL_SHA256:-${DEFAULT_KERNEL_TARBALL_SHA256}}"
+
+case "${KERNEL_ARCH}" in
+  arm64) ;;
+  *)
+    echo "unsupported CLEANROOM_DARWIN_VZ_MINIMAL_KERNEL_ARCH: ${KERNEL_ARCH}" >&2
+    echo "only arm64 is currently supported" >&2
+    exit 1
+    ;;
+esac
+
+if [[ -z "${KERNEL_TARBALL_SHA256}" ]]; then
+  echo "missing CLEANROOM_DARWIN_VZ_MINIMAL_KERNEL_TARBALL_SHA256 for Linux ${KERNEL_VERSION}" >&2
+  exit 1
+fi
+
+case "${KERNEL_PROFILE}" in
+  initrd|rootfs) ;;
+  *)
+    echo "unsupported CLEANROOM_DARWIN_VZ_MINIMAL_KERNEL_PROFILE: ${KERNEL_PROFILE}" >&2
+    echo "expected initrd or rootfs" >&2
+    exit 1
+    ;;
+esac
+
+OUTPUT_PATH="${1:-${REPO_ROOT}/dist/darwin-vz-minimal-${KERNEL_PROFILE}-${KERNEL_ARCH}-kernel-${KERNEL_VERSION}-Image}"
+CONFIG_PATH="${OUTPUT_PATH}.config"
+mkdir -p "$(dirname "${OUTPUT_PATH}")"
+OUTPUT_DIR="$(cd "$(dirname "${OUTPUT_PATH}")" && pwd)"
+OUTPUT_BASENAME="$(basename "${OUTPUT_PATH}")"
+CONFIG_BASENAME="$(basename "${CONFIG_PATH}")"
+
+docker run --rm \
+  --platform "${DOCKER_PLATFORM}" \
+  -e "KERNEL_VERSION=${KERNEL_VERSION}" \
+  -e "KERNEL_PROFILE=${KERNEL_PROFILE}" \
+  -e "KERNEL_ARCH=${KERNEL_ARCH}" \
+  -e "KERNEL_TARBALL_SHA256=${KERNEL_TARBALL_SHA256}" \
+  -e "OUTPUT_BASENAME=${OUTPUT_BASENAME}" \
+  -e "CONFIG_BASENAME=${CONFIG_BASENAME}" \
+  -v "${BUILD_VOLUME}:/build" \
+  -v "${OUTPUT_DIR}:/out" \
+  "${DOCKER_IMAGE}" \
+  bash -lc '
+    set -euo pipefail
+
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update
+    apt-get install -y --no-install-recommends \
+      bc \
+      bison \
+      build-essential \
+      ca-certificates \
+      curl \
+      flex \
+      libelf-dev \
+      libssl-dev \
+      xz-utils
+
+    src="/build/linux-${KERNEL_VERSION}"
+    tarball="/build/linux-${KERNEL_VERSION}.tar.xz"
+    source_stamp="${src}.source.sha256"
+
+    download_kernel_tarball() {
+      rm -f "${tarball}.tmp"
+      curl -fsSL \
+        "https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-${KERNEL_VERSION}.tar.xz" \
+        -o "${tarball}.tmp"
+      mv "${tarball}.tmp" "${tarball}"
+    }
+
+    verify_kernel_tarball() {
+      echo "${KERNEL_TARBALL_SHA256}  ${tarball}" | sha256sum -c -
+    }
+
+    if [[ ! -d "${src}" || ! -f "${source_stamp}" || "$(<"${source_stamp}")" != "${KERNEL_TARBALL_SHA256}" ]]; then
+      rm -rf "${src}" "${source_stamp}"
+      if [[ ! -f "${tarball}" ]]; then
+        download_kernel_tarball
+      fi
+      if ! verify_kernel_tarball; then
+        rm -f "${tarball}"
+        download_kernel_tarball
+        verify_kernel_tarball
+      fi
+      tar -C /build -xf "${tarball}"
+      printf "%s\n" "${KERNEL_TARBALL_SHA256}" > "${source_stamp}"
+    fi
+
+    out="/build/out-vz-${KERNEL_PROFILE}-pci-${KERNEL_VERSION}"
+    rm -rf "${out}"
+    mkdir -p "${out}"
+
+    make -C "${src}" O="${out}" ARCH="${KERNEL_ARCH}" tinyconfig
+    "${src}/scripts/config" --file "${out}/.config" \
+      -e 64BIT \
+      -e ARM64_4K_PAGES \
+      -e BINFMT_ELF \
+      -e TTY \
+      -e VT \
+      -e UNIX98_PTYS \
+      -e HVC_DRIVER \
+      -e VIRTIO \
+      -e VIRTIO_MENU \
+      -e VIRTIO_PCI \
+      -e VIRTIO_MMIO \
+      -e VIRTIO_PCI_LEGACY \
+      -e VIRTIO_CONSOLE \
+      -e VSOCKETS \
+      -e VIRTIO_VSOCKETS \
+      -e NET \
+      -e INET \
+      -e PROC_FS \
+      -e SYSFS \
+      -e FUTEX \
+      -e EPOLL \
+      -e ANON_INODES \
+      -e EVENTFD \
+      -e SIGNALFD \
+      -e TIMERFD \
+      -e PRINTK \
+      -e BUG \
+      -e DEVTMPFS \
+      -e TMPFS \
+      -e EMBEDDED \
+      -e EXPERT \
+      -e PCI \
+      -e PCI_HOST_GENERIC \
+      -e PCI_MSI \
+      -e PCI_MSI_IRQ_DOMAIN \
+      -e GENERIC_MSI_IRQ_DOMAIN \
+      -e CC_OPTIMIZE_FOR_PERFORMANCE \
+      -d CC_OPTIMIZE_FOR_SIZE \
+      -d MODULES \
+      -d DEBUG_INFO \
+      -d DEBUG_KERNEL \
+      -d KALLSYMS \
+      -d IKCONFIG \
+      -d IPV6 \
+      -d WIRELESS \
+      -d WLAN \
+      -d BT \
+      -d BLOCK \
+      -d SCSI \
+      -d MD \
+      -d INPUT \
+      -d HID \
+      -d USB_SUPPORT \
+      -d CGROUPS \
+      -d NAMESPACES \
+      -d AUDIT \
+      -d SECURITY \
+      -d BPF_SYSCALL \
+      -d ZSWAP
+
+    if [[ "${KERNEL_PROFILE}" = "initrd" ]]; then
+      "${src}/scripts/config" --file "${out}/.config" \
+        -e BLK_DEV_INITRD \
+        -e RD_GZIP \
+        -e CMDLINE_BOOL \
+        --set-str CMDLINE "rdinit=/init"
+    fi
+
+    if [[ "${KERNEL_PROFILE}" = "rootfs" ]]; then
+      "${src}/scripts/config" --file "${out}/.config" \
+        -e BLOCK \
+        -e BLK_DEV \
+        -e VIRTIO_BLK \
+        -e EXT4_FS \
+        -e EXT4_USE_FOR_EXT2 \
+        -e JBD2 \
+        -e CRC16 \
+        -e CRYPTO \
+        -e CRYPTO_CRC32C \
+        -e NETDEVICES \
+        -e VIRTIO_NET \
+        -e PACKET \
+        -e UNIX \
+        -e DEVTMPFS_MOUNT
+    fi
+
+    make -C "${src}" O="${out}" ARCH="${KERNEL_ARCH}" olddefconfig
+    make -C "${src}" O="${out}" ARCH="${KERNEL_ARCH}" -j"$(nproc)" Image
+
+    cp "${out}/arch/${KERNEL_ARCH}/boot/Image" "/out/${OUTPUT_BASENAME}"
+    cp "${out}/.config" "/out/${CONFIG_BASENAME}"
+  '
+
+printf '%s\n' "${OUTPUT_PATH}"

--- a/benchmarks/darwin-vz/minimal/build-runner.sh
+++ b/benchmarks/darwin-vz/minimal/build-runner.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+OUTPUT_PATH="${1:-${REPO_ROOT}/dist/darwin-vz-minimal}"
+ENTITLEMENTS_PATH="${CLEANROOM_DARWIN_VZ_HELPER_ENTITLEMENTS:-${REPO_ROOT}/cmd/cleanroom-darwin-vz/entitlements.plist}"
+
+mkdir -p "$(dirname "${OUTPUT_PATH}")"
+xcrun swiftc \
+  -O \
+  -framework Virtualization \
+  "${SCRIPT_DIR}/runner.swift" \
+  -o "${OUTPUT_PATH}"
+
+codesign --force --sign "${CLEANROOM_DARWIN_VZ_MINIMAL_SIGN_IDENTITY:--}" \
+  --entitlements "${ENTITLEMENTS_PATH}" \
+  "${OUTPUT_PATH}"

--- a/benchmarks/darwin-vz/minimal/build_kernel_script_test.go
+++ b/benchmarks/darwin-vz/minimal/build_kernel_script_test.go
@@ -1,0 +1,28 @@
+package minimal_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestBuildKernelVerifiesCachedSourceWithChecksumStamp(t *testing.T) {
+	raw, err := os.ReadFile("build-kernel.sh")
+	if err != nil {
+		t.Fatalf("read build-kernel.sh: %v", err)
+	}
+	script := string(raw)
+
+	required := []string{
+		`source_stamp="${src}.source.sha256"`,
+		`[[ ! -d "${src}" || ! -f "${source_stamp}" || "$(<"${source_stamp}")" != "${KERNEL_TARBALL_SHA256}" ]]`,
+		`rm -rf "${src}" "${source_stamp}"`,
+		`echo "${KERNEL_TARBALL_SHA256}  ${tarball}" | sha256sum -c -`,
+		`printf "%s\n" "${KERNEL_TARBALL_SHA256}" > "${source_stamp}"`,
+	}
+	for _, want := range required {
+		if !strings.Contains(script, want) {
+			t.Fatalf("expected build-kernel.sh to contain %q", want)
+		}
+	}
+}

--- a/benchmarks/darwin-vz/minimal/initrd-agent/doc_nonlinux.go
+++ b/benchmarks/darwin-vz/minimal/initrd-agent/doc_nonlinux.go
@@ -1,0 +1,3 @@
+//go:build !linux
+
+package main

--- a/benchmarks/darwin-vz/minimal/initrd-agent/main.go
+++ b/benchmarks/darwin-vz/minimal/initrd-agent/main.go
@@ -1,0 +1,312 @@
+//go:build linux
+
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+const defaultPort uint32 = 10700
+
+type execRequest struct {
+	Command   []string `json:"command"`
+	Dir       string   `json:"dir,omitempty"`
+	Env       []string `json:"env,omitempty"`
+	ClosedEnv bool     `json:"closed_env,omitempty"`
+}
+
+type execFrame struct {
+	Type          string           `json:"type,omitempty"`
+	Data          []byte           `json:"data,omitempty"`
+	ExitCode      int              `json:"exit_code,omitempty"`
+	Error         string           `json:"error,omitempty"`
+	GuestTimingMS map[string]int64 `json:"guest_timing_ms,omitempty"`
+}
+
+type timingStore struct {
+	mu      sync.Mutex
+	timings map[string]int64
+}
+
+type frameSender struct {
+	mu sync.Mutex
+	w  io.Writer
+}
+
+func main() {
+	mountProc()
+	prepareDev()
+	timings := &timingStore{timings: map[string]int64{}}
+	timings.record("guest_init_start")
+
+	port := resolvePort(readKernelCmdline())
+	listener, err := listenVsock(port)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "listen vsock: %v\n", err)
+		os.Exit(1)
+	}
+	defer unix.Close(listener)
+	timings.record("guest_agent_listen_ready")
+
+	for {
+		fd, _, err := unix.Accept4(listener, unix.SOCK_CLOEXEC)
+		if err != nil {
+			if errors.Is(err, unix.EINTR) {
+				continue
+			}
+			fmt.Fprintf(os.Stderr, "accept: %v\n", err)
+			continue
+		}
+		timings.recordOnce("guest_agent_first_accept")
+		go handleConn(os.NewFile(uintptr(fd), "vsock-conn"), timings)
+	}
+}
+
+func mountProc() {
+	if err := os.MkdirAll("/proc", 0o755); err != nil {
+		return
+	}
+	if err := unix.Mount("proc", "/proc", "proc", 0, ""); err != nil && !errors.Is(err, unix.EBUSY) {
+		fmt.Fprintf(os.Stderr, "mount proc: %v\n", err)
+	}
+}
+
+func prepareDev() {
+	if err := os.MkdirAll("/dev", 0o755); err != nil {
+		return
+	}
+	if err := unix.Mknod("/dev/null", unix.S_IFCHR|0o666, int(unix.Mkdev(1, 3))); err != nil && !errors.Is(err, unix.EEXIST) {
+		fmt.Fprintf(os.Stderr, "mknod /dev/null: %v\n", err)
+	}
+}
+
+func readKernelCmdline() string {
+	raw, err := os.ReadFile("/proc/cmdline")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(raw))
+}
+
+func resolvePort(cmdline string) uint32 {
+	if raw, ok := kernelCmdlineValue(cmdline, "cleanroom_guest_port"); ok {
+		if parsed, err := strconv.ParseUint(raw, 10, 32); err == nil && parsed > 0 {
+			return uint32(parsed)
+		}
+	}
+	return defaultPort
+}
+
+func kernelCmdlineValue(cmdline, key string) (string, bool) {
+	prefix := key + "="
+	for _, token := range strings.Fields(cmdline) {
+		if strings.HasPrefix(token, prefix) {
+			return strings.TrimPrefix(token, prefix), true
+		}
+	}
+	return "", false
+}
+
+func listenVsock(port uint32) (int, error) {
+	fd, err := unix.Socket(unix.AF_VSOCK, unix.SOCK_STREAM|unix.SOCK_CLOEXEC, 0)
+	if err != nil {
+		return -1, err
+	}
+	if err := unix.Bind(fd, &unix.SockaddrVM{CID: unix.VMADDR_CID_ANY, Port: port}); err != nil {
+		_ = unix.Close(fd)
+		return -1, err
+	}
+	if err := unix.Listen(fd, unix.SOMAXCONN); err != nil {
+		_ = unix.Close(fd)
+		return -1, err
+	}
+	return fd, nil
+}
+
+func handleConn(conn *os.File, timings *timingStore) {
+	defer conn.Close()
+
+	dec := json.NewDecoder(conn)
+	var req execRequest
+	if err := dec.Decode(&req); err != nil {
+		sendError(conn, timings, err)
+		return
+	}
+	timings.recordOnce("guest_agent_first_request_decode")
+	if len(req.Command) == 0 || strings.TrimSpace(req.Command[0]) == "" {
+		sendError(conn, timings, errors.New("missing command"))
+		return
+	}
+
+	cmd := exec.Command(req.Command[0], req.Command[1:]...)
+	if strings.TrimSpace(req.Dir) != "" {
+		cmd.Dir = req.Dir
+	}
+	if req.ClosedEnv {
+		cmd.Env = req.Env
+	} else {
+		cmd.Env = append(os.Environ(), req.Env...)
+	}
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		sendError(conn, timings, err)
+		return
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		sendError(conn, timings, err)
+		return
+	}
+
+	timings.recordOnce("guest_command_start")
+	if err := cmd.Start(); err != nil {
+		sendError(conn, timings, err)
+		return
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	sender := &frameSender{w: conn}
+	go copyFrame(&wg, sender, "stdout", stdout)
+	go copyFrame(&wg, sender, "stderr", stderr)
+	wg.Wait()
+
+	waitErr := cmd.Wait()
+	timings.recordOnce("guest_command_exit")
+	sendExit(sender, timings, waitErr)
+}
+
+func copyFrame(wg *sync.WaitGroup, sender *frameSender, kind string, r io.Reader) {
+	defer wg.Done()
+	buf := make([]byte, 4096)
+	for {
+		n, err := r.Read(buf)
+		if n > 0 {
+			_ = sender.send(execFrame{
+				Type: kind,
+				Data: append([]byte(nil), buf[:n]...),
+			})
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+func sendError(w io.Writer, timings *timingStore, err error) {
+	msg := err.Error()
+	sender := &frameSender{w: w}
+	_ = sender.send(execFrame{Type: "stderr", Data: []byte(msg + "\n")})
+	_ = sender.send(execFrame{
+		Type:          "exit",
+		ExitCode:      1,
+		Error:         msg,
+		GuestTimingMS: timings.snapshot(),
+	})
+}
+
+func sendExit(sender *frameSender, timings *timingStore, waitErr error) {
+	exitCode := 0
+	errMsg := ""
+	if waitErr != nil {
+		exitCode = 1
+		errMsg = waitErr.Error()
+		var exitErr *exec.ExitError
+		if errors.As(waitErr, &exitErr) {
+			exitCode = exitErr.ExitCode()
+			errMsg = ""
+		}
+	}
+	_ = sender.send(execFrame{
+		Type:          "exit",
+		ExitCode:      exitCode,
+		Error:         errMsg,
+		GuestTimingMS: timings.snapshot(),
+	})
+}
+
+func (s *frameSender) send(frame execFrame) error {
+	if s == nil || s.w == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return json.NewEncoder(s.w).Encode(frame)
+}
+
+func (s *timingStore) record(name string) {
+	if s == nil {
+		return
+	}
+	ms, err := uptimeMS()
+	if err != nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.timings[name] = ms
+}
+
+func (s *timingStore) recordOnce(name string) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	_, exists := s.timings[name]
+	s.mu.Unlock()
+	if exists {
+		return
+	}
+	s.record(name)
+}
+
+func (s *timingStore) snapshot() map[string]int64 {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make(map[string]int64, len(s.timings))
+	for key, value := range s.timings {
+		out[key] = value
+	}
+	return out
+}
+
+func uptimeMS() (int64, error) {
+	raw, err := os.ReadFile("/proc/uptime")
+	if err != nil {
+		return 0, err
+	}
+	fields := strings.Fields(string(raw))
+	if len(fields) == 0 {
+		return 0, errors.New("missing uptime")
+	}
+	seconds, fraction, _ := strings.Cut(fields[0], ".")
+	sec, err := strconv.ParseInt(seconds, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	fraction += "000"
+	ms, err := strconv.ParseInt(fraction[:3], 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	return sec*1000 + ms, nil
+}
+
+func init() {
+	syscall.Umask(0)
+}

--- a/benchmarks/darwin-vz/minimal/initrd-true/doc_nonlinux.go
+++ b/benchmarks/darwin-vz/minimal/initrd-true/doc_nonlinux.go
@@ -1,0 +1,3 @@
+//go:build !linux
+
+package main

--- a/benchmarks/darwin-vz/minimal/initrd-true/main.go
+++ b/benchmarks/darwin-vz/minimal/initrd-true/main.go
@@ -1,0 +1,5 @@
+//go:build linux
+
+package main
+
+func main() {}

--- a/benchmarks/darwin-vz/minimal/runner.swift
+++ b/benchmarks/darwin-vz/minimal/runner.swift
@@ -1,0 +1,425 @@
+import Darwin
+import Foundation
+import Virtualization
+
+private struct Options {
+    var kernelPath = ""
+    var rootFSPath = ""
+    var initrdPath = ""
+    var bootArgs = ""
+    var consoleLogPath = ""
+    var guestPort: UInt32 = 10700
+    var vcpus = 2
+    var memoryMiB: UInt64 = 1024
+    var timeoutSeconds = 30.0
+    var connectIntervalMS: useconds_t = 10
+}
+
+private struct ProbeResult: Encodable {
+    let startMS: Double
+    let vsockConnectMS: Double
+    let execResponseMS: Double
+    let probeDurationMS: Double
+    let exitCode: Int
+    let error: String?
+    let guestTimingMS: [String: Int64]?
+    let vcpus: Int
+    let memoryMiB: UInt64
+
+    enum CodingKeys: String, CodingKey {
+        case startMS = "start_ms"
+        case vsockConnectMS = "vsock_connect_ms"
+        case execResponseMS = "exec_response_ms"
+        case probeDurationMS = "probe_duration_ms"
+        case exitCode = "exit_code"
+        case error
+        case guestTimingMS = "guest_timing_ms"
+        case vcpus
+        case memoryMiB = "memory_mib"
+    }
+}
+
+private struct ExecFrame: Decodable {
+    let type: String
+    let exitCode: Int?
+    let error: String?
+    let guestTimingMS: [String: Int64]?
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case exitCode = "exit_code"
+        case error
+        case guestTimingMS = "guest_timing_ms"
+    }
+}
+
+private enum BaselineError: LocalizedError {
+    case usage(String)
+    case invalid(String)
+    case timeout(String)
+    case posix(String, Int32)
+    case vm(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .usage(let message), .invalid(let message), .timeout(let message), .vm(let message):
+            return message
+        case .posix(let op, let code):
+            return "\(op): \(String(cString: strerror(code)))"
+        }
+    }
+}
+
+private final class VMHandle {
+    let vm: VZVirtualMachine
+    let queue: DispatchQueue
+
+    init(vm: VZVirtualMachine, queue: DispatchQueue) {
+        self.vm = vm
+        self.queue = queue
+    }
+
+    func stop() {
+        let requestStopSem = DispatchSemaphore(value: 0)
+        queue.async {
+            if self.vm.canRequestStop {
+                _ = try? self.vm.requestStop()
+            }
+            requestStopSem.signal()
+        }
+        _ = requestStopSem.wait(timeout: .now() + .seconds(1))
+
+        let stopSem = DispatchSemaphore(value: 0)
+        queue.async {
+            if self.vm.canStop {
+                self.vm.stop { _ in stopSem.signal() }
+            } else {
+                stopSem.signal()
+            }
+        }
+        _ = stopSem.wait(timeout: .now() + .seconds(3))
+    }
+}
+
+private func usage() -> String {
+    """
+    Usage:
+      darwin-vz-minimal --kernel <vmlinux> (--rootfs <rootfs.ext4> | --initrd <initramfs.cpio.gz>) [options]
+
+    Options:
+      --boot-args <args>          Full Linux command line. If omitted, a default line is selected for the boot mode.
+      --initrd <path>             Linux initramfs image. If no rootfs is provided, no block storage is attached.
+      --console-log <path>        Console log path. Default: temporary file under /tmp.
+      --guest-port <port>         Guest vsock port. Default: 10700.
+      --vcpus <count>            vCPU count. Default: 2.
+      --memory-mib <mib>         Guest memory. Default: 1024.
+      --timeout <seconds>        Start/probe timeout. Default: 30.
+
+    The rootfs mode must already contain Cleanroom's guest runtime. Use a writable throwaway copy.
+    The initrd mode expects an /init process that accepts Cleanroom's guest exec JSON protocol on vsock.
+    The measured probe boots the VM, connects to the guest agent over vsock, runs /bin/true, and prints JSON timings.
+    """
+}
+
+private func parseOptions(_ args: [String]) throws -> Options {
+    var opts = Options()
+    var i = 0
+    while i < args.count {
+        let arg = args[i]
+        func value() throws -> String {
+            guard i + 1 < args.count else {
+                throw BaselineError.usage("missing value for \(arg)\n\n\(usage())")
+            }
+            i += 1
+            return args[i]
+        }
+
+        switch arg {
+        case "--kernel":
+            opts.kernelPath = try value()
+        case "--rootfs":
+            opts.rootFSPath = try value()
+        case "--initrd":
+            opts.initrdPath = try value()
+        case "--boot-args":
+            opts.bootArgs = try value()
+        case "--console-log":
+            opts.consoleLogPath = try value()
+        case "--guest-port":
+            guard let port = UInt32(try value()) else {
+                throw BaselineError.invalid("invalid --guest-port")
+            }
+            opts.guestPort = port
+        case "--vcpus":
+            guard let vcpus = Int(try value()), vcpus > 0 else {
+                throw BaselineError.invalid("invalid --vcpus")
+            }
+            opts.vcpus = vcpus
+        case "--memory-mib":
+            guard let memory = UInt64(try value()), memory > 0 else {
+                throw BaselineError.invalid("invalid --memory-mib")
+            }
+            opts.memoryMiB = memory
+        case "--timeout":
+            guard let timeout = Double(try value()), timeout > 0 else {
+                throw BaselineError.invalid("invalid --timeout")
+            }
+            opts.timeoutSeconds = timeout
+        case "-h", "--help":
+            throw BaselineError.usage(usage())
+        default:
+            throw BaselineError.usage("unknown argument: \(arg)\n\n\(usage())")
+        }
+        i += 1
+    }
+
+    if opts.kernelPath.isEmpty || (opts.rootFSPath.isEmpty && opts.initrdPath.isEmpty) {
+        throw BaselineError.usage("missing --kernel and either --rootfs or --initrd\n\n\(usage())")
+    }
+    if opts.consoleLogPath.isEmpty {
+        opts.consoleLogPath = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("darwin-vz-minimal-\(UUID().uuidString).console.log")
+            .path
+    }
+    if opts.bootArgs.isEmpty {
+        if opts.rootFSPath.isEmpty {
+            opts.bootArgs = "console=hvc0 rdinit=/init cleanroom_guest_port=\(opts.guestPort) cleanroom_guest_boot_timing=1"
+        } else {
+            opts.bootArgs = "console=hvc0 root=/dev/vda rw init=/usr/local/bin/cleanroom-guest-agent cleanroom_guest_port=\(opts.guestPort) cleanroom_guest_boot_timing=1"
+        }
+    }
+    return opts
+}
+
+private func now() -> UInt64 {
+    DispatchTime.now().uptimeNanoseconds
+}
+
+private func msSince(_ start: UInt64) -> Double {
+    Double(now() - start) / 1_000_000.0
+}
+
+private func writeAll(fd: Int32, bytes: [UInt8]) throws {
+    var written = 0
+    while written < bytes.count {
+        let n = bytes.withUnsafeBytes { raw -> Int in
+            guard let base = raw.baseAddress else { return 0 }
+            return Darwin.write(fd, base.advanced(by: written), bytes.count - written)
+        }
+        if n < 0 {
+            if errno == EINTR {
+                continue
+            }
+            throw BaselineError.posix("write", errno)
+        }
+        written += n
+    }
+}
+
+private func waitForReadable(fd: Int32, deadline: Date) throws {
+    while true {
+        let remaining = deadline.timeIntervalSinceNow
+        if remaining <= 0 {
+            throw BaselineError.timeout("timed out waiting for guest exit frame")
+        }
+        let timeoutMS = Int32(max(1, min(remaining * 1000, Double(Int32.max))))
+        var pfd = pollfd(fd: fd, events: Int16(POLLIN), revents: 0)
+        let n = Darwin.poll(&pfd, 1, timeoutMS)
+        if n < 0 {
+            if errno == EINTR {
+                continue
+            }
+            throw BaselineError.posix("poll", errno)
+        }
+        if n == 0 {
+            throw BaselineError.timeout("timed out waiting for guest exit frame")
+        }
+        if (pfd.revents & Int16(POLLIN | POLLHUP | POLLERR | POLLNVAL)) != 0 {
+            return
+        }
+    }
+}
+
+private func readLine(fd: Int32, buffer: inout Data, deadline: Date) throws -> Data {
+    var chunk = [UInt8](repeating: 0, count: 4096)
+    while true {
+        if let newline = buffer.firstIndex(of: 0x0A) {
+            let line = buffer.subdata(in: 0..<newline)
+            buffer.removeSubrange(0...newline)
+            return line
+        }
+        try waitForReadable(fd: fd, deadline: deadline)
+        let chunkCount = chunk.count
+        let n = chunk.withUnsafeMutableBytes { raw -> Int in
+            guard let base = raw.baseAddress else { return 0 }
+            return Darwin.read(fd, base, chunkCount)
+        }
+        if n < 0 {
+            if errno == EINTR {
+                continue
+            }
+            throw BaselineError.posix("read", errno)
+        }
+        if n == 0 {
+            throw BaselineError.vm("guest connection closed before exit frame")
+        }
+        buffer.append(contentsOf: chunk[0..<n])
+    }
+}
+
+private func buildVM(opts: Options, queue: DispatchQueue) throws -> VMHandle {
+    guard VZVirtualMachine.isSupported else {
+        throw BaselineError.vm("Virtualization.framework is not supported on this host")
+    }
+
+    let bootLoader = VZLinuxBootLoader(kernelURL: URL(fileURLWithPath: opts.kernelPath))
+    bootLoader.commandLine = opts.bootArgs
+    if !opts.initrdPath.isEmpty {
+        bootLoader.initialRamdiskURL = URL(fileURLWithPath: opts.initrdPath)
+    }
+
+    let config = VZVirtualMachineConfiguration()
+    config.bootLoader = bootLoader
+    config.cpuCount = opts.vcpus
+    config.memorySize = opts.memoryMiB * 1024 * 1024
+
+    let serial = VZVirtioConsoleDeviceSerialPortConfiguration()
+    serial.attachment = try VZFileSerialPortAttachment(
+        url: URL(fileURLWithPath: opts.consoleLogPath),
+        append: false
+    )
+    config.serialPorts = [serial]
+
+    if !opts.rootFSPath.isEmpty {
+        let disk = try VZDiskImageStorageDeviceAttachment(
+            url: URL(fileURLWithPath: opts.rootFSPath),
+            readOnly: false
+        )
+        config.storageDevices = [VZVirtioBlockDeviceConfiguration(attachment: disk)]
+    }
+    config.entropyDevices = [VZVirtioEntropyDeviceConfiguration()]
+    config.memoryBalloonDevices = [VZVirtioTraditionalMemoryBalloonDeviceConfiguration()]
+    config.socketDevices = [VZVirtioSocketDeviceConfiguration()]
+
+    try config.validate()
+    return VMHandle(vm: VZVirtualMachine(configuration: config, queue: queue), queue: queue)
+}
+
+private func startVM(_ handle: VMHandle, timeoutSeconds: Double) throws {
+    let sem = DispatchSemaphore(value: 0)
+    var startError: Error?
+    handle.queue.async {
+        handle.vm.start { result in
+            if case .failure(let error) = result {
+                startError = error
+            }
+            sem.signal()
+        }
+    }
+    if sem.wait(timeout: .now() + timeoutSeconds) == .timedOut {
+        throw BaselineError.timeout("timed out waiting for VM start")
+    }
+    if let startError {
+        throw BaselineError.vm("VM start failed: \(startError)")
+    }
+}
+
+private func connectVsock(handle: VMHandle, port: UInt32, timeoutSeconds: Double, intervalMS: useconds_t) throws -> VZVirtioSocketConnection {
+    guard let socketDevice = handle.vm.socketDevices.first as? VZVirtioSocketDevice else {
+        throw BaselineError.vm("VM has no virtio socket device")
+    }
+    let deadline = Date().addingTimeInterval(timeoutSeconds)
+    var lastError: Error?
+    while Date() < deadline {
+        let sem = DispatchSemaphore(value: 0)
+        var connection: VZVirtioSocketConnection?
+        var connectError: Error?
+        handle.queue.async {
+            socketDevice.connect(toPort: port) { result in
+                switch result {
+                case .success(let conn):
+                    connection = conn
+                case .failure(let error):
+                    connectError = error
+                }
+                sem.signal()
+            }
+        }
+        _ = sem.wait(timeout: .now() + .milliseconds(500))
+        if let connection {
+            return connection
+        }
+        if let connectError {
+            lastError = connectError
+        }
+        usleep(intervalMS * 1000)
+    }
+    if let lastError {
+        throw BaselineError.timeout("timed out connecting to guest vsock port \(port): \(lastError)")
+    }
+    throw BaselineError.timeout("timed out connecting to guest vsock port \(port)")
+}
+
+private func probeGuest(connection: VZVirtioSocketConnection, timeoutSeconds: Double) throws -> (Int, String?, [String: Int64]?) {
+    let request = #"{"command":["/bin/true"],"closed_env":true}"# + "\n"
+    try writeAll(fd: connection.fileDescriptor, bytes: Array(request.utf8))
+
+    let deadline = Date().addingTimeInterval(timeoutSeconds)
+    var buffer = Data()
+    while true {
+        let line = try readLine(fd: connection.fileDescriptor, buffer: &buffer, deadline: deadline)
+        if line.isEmpty {
+            continue
+        }
+        let frame = try JSONDecoder().decode(ExecFrame.self, from: line)
+        if frame.type == "exit" {
+            return (frame.exitCode ?? 0, frame.error, frame.guestTimingMS)
+        }
+    }
+}
+
+do {
+    let opts = try parseOptions(Array(CommandLine.arguments.dropFirst()))
+    let queue = DispatchQueue(label: "cleanroom.benchmark.darwin-vz-minimal.vm")
+    let t0 = now()
+    let handle = try buildVM(opts: opts, queue: queue)
+    defer { handle.stop() }
+
+    try startVM(handle, timeoutSeconds: opts.timeoutSeconds)
+    let startMS = msSince(t0)
+
+    let connection = try connectVsock(
+        handle: handle,
+        port: opts.guestPort,
+        timeoutSeconds: opts.timeoutSeconds,
+        intervalMS: opts.connectIntervalMS
+    )
+    defer { connection.close() }
+    let connectMS = msSince(t0)
+
+    let (exitCode, error, guestTimingMS) = try probeGuest(connection: connection, timeoutSeconds: opts.timeoutSeconds)
+    let execResponseMS = msSince(t0)
+
+    let result = ProbeResult(
+        startMS: startMS,
+        vsockConnectMS: connectMS,
+        execResponseMS: execResponseMS,
+        probeDurationMS: execResponseMS - connectMS,
+        exitCode: exitCode,
+        error: error,
+        guestTimingMS: guestTimingMS,
+        vcpus: opts.vcpus,
+        memoryMiB: opts.memoryMiB
+    )
+    let encoded = try JSONEncoder().encode(result)
+    print(String(data: encoded, encoding: .utf8)!)
+    if exitCode != 0 {
+        Foundation.exit(1)
+    }
+} catch BaselineError.usage(let message) {
+    fputs(message + "\n", stderr)
+    Foundation.exit(message.hasPrefix("Usage:") ? 0 : 2)
+} catch {
+    fputs("darwin-vz-minimal: \(error.localizedDescription)\n", stderr)
+    Foundation.exit(1)
+}

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -9,11 +9,12 @@ The goal is consistency, not perfect synthetic accuracy.
 
 ## Scope
 
-We currently track three benchmark categories:
+We currently track four benchmark categories:
 
 - TTI (time-to-interactive): sandbox create -> first successful command
 - repository bootstrap: repo-aware sandbox create under cold/warm host-cache scenarios
 - in-sandbox workloads: IOPS-like file throughput, git clone latency, CPU hashing throughput
+- darwin-vz lower-bound boot probes: minimal Virtualization.framework VM -> first guest exec response
 
 ## Methodology
 
@@ -95,6 +96,37 @@ Example:
 Output:
 
 - `benchmarks/results/<timestamp>-sandbox-workloads.json`
+
+### 4) Minimal darwin-vz benchmark
+
+Script: `scripts/benchmark-darwin-vz-minimal.sh`
+
+- Builds a standalone Virtualization.framework runner
+- Boots a supplied Linux kernel with either a minimal initrd or a supplied rootfs
+- Connects to the guest over vsock
+- Runs `/bin/true`
+- Reports VM start, vsock readiness, and first exec response timings as JSONL
+
+This is a lower-bound probe for darwin-vz experiments. It intentionally bypasses the Cleanroom control plane, image materialization, policy setup, cache lookup, and full guest runtime.
+
+Example:
+
+```bash
+scripts/benchmark-darwin-vz-minimal.sh \
+  --kernel dist/darwin-vz-minimal-initrd-arm64-kernel-6.1.155-Image \
+  --iterations 30
+```
+
+To build the minimal kernel first:
+
+```bash
+scripts/benchmark-darwin-vz-minimal.sh --build-kernel --iterations 30
+```
+
+Output:
+
+- `benchmarks/results/<timestamp>-darwin-vz-minimal.jsonl`
+- console logs under `benchmarks/results/<timestamp>-darwin-vz-minimal-console/`
 
 ## Host Baseline (Latest Run)
 

--- a/scripts/benchmark-darwin-vz-minimal.sh
+++ b/scripts/benchmark-darwin-vz-minimal.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Benchmark the minimal darwin-vz boot path.
+
+Usage:
+  scripts/benchmark-darwin-vz-minimal.sh --kernel <Image> [options]
+  scripts/benchmark-darwin-vz-minimal.sh --build-kernel [options]
+
+Options:
+  --kernel <path>           Linux kernel Image to boot.
+  --build-kernel            Build the minimal benchmark kernel with Docker before running.
+  --kernel-profile <name>   Kernel profile for --build-kernel: initrd or rootfs (default: initrd, or rootfs with --rootfs). Must match the selected boot medium.
+  --initrd <path>           Initrd to boot. If omitted and --rootfs is omitted, the minimal initrd is built.
+  --rootfs <path>           Writable rootfs image to boot instead of initrd.
+  -n, --iterations <count>  Number of runs (default: 10).
+  --vcpus <count>           Guest vCPU count (default: 2).
+  --memory-mib <mib>        Guest memory in MiB (default: 1024).
+  --boot-args <args>        Full Linux command line override.
+  --output-dir <path>       JSONL output directory (default: benchmarks/results).
+  -h, --help                Show this help.
+
+This is a lower-bound Virtualization.framework probe, not a Cleanroom TTI benchmark.
+EOF
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+MINIMAL_DIR="${REPO_ROOT}/benchmarks/darwin-vz/minimal"
+
+kernel_path=""
+initrd_path=""
+rootfs_path=""
+boot_args=""
+kernel_profile=""
+iterations=10
+vcpus=2
+memory_mib=1024
+output_dir="${REPO_ROOT}/benchmarks/results"
+build_kernel=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --kernel)
+      kernel_path="$2"
+      shift 2
+      ;;
+    --build-kernel)
+      build_kernel=1
+      shift
+      ;;
+    --kernel-profile)
+      kernel_profile="$2"
+      shift 2
+      ;;
+    --initrd)
+      initrd_path="$2"
+      shift 2
+      ;;
+    --rootfs)
+      rootfs_path="$2"
+      shift 2
+      ;;
+    -n|--iterations)
+      iterations="$2"
+      shift 2
+      ;;
+    --vcpus)
+      vcpus="$2"
+      shift 2
+      ;;
+    --memory-mib)
+      memory_mib="$2"
+      shift 2
+      ;;
+    --boot-args)
+      boot_args="$2"
+      shift 2
+      ;;
+    --output-dir)
+      output_dir="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+require_positive_int() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[0-9]+$ ]] || [[ "${value}" -le 0 ]]; then
+    echo "${name} must be a positive integer" >&2
+    exit 1
+  fi
+}
+
+run_repo_tool() {
+  if command -v mise >/dev/null 2>&1; then
+    mise exec -- "$@"
+  else
+    "$@"
+  fi
+}
+
+require_positive_int "iterations" "${iterations}"
+require_positive_int "vcpus" "${vcpus}"
+require_positive_int "memory-mib" "${memory_mib}"
+
+if [[ -n "${initrd_path}" && -n "${rootfs_path}" ]]; then
+  echo "--initrd and --rootfs are mutually exclusive" >&2
+  exit 1
+fi
+
+if [[ -z "${kernel_profile}" ]]; then
+  if [[ -n "${rootfs_path}" ]]; then
+    kernel_profile="rootfs"
+  else
+    kernel_profile="initrd"
+  fi
+fi
+case "${kernel_profile}" in
+  initrd|rootfs) ;;
+  *)
+    echo "unsupported --kernel-profile: ${kernel_profile}" >&2
+    exit 1
+    ;;
+esac
+
+if [[ "${build_kernel}" -eq 1 && -n "${kernel_path}" ]]; then
+  echo "--kernel and --build-kernel are mutually exclusive" >&2
+  exit 1
+fi
+if [[ "${build_kernel}" -eq 0 && -z "${kernel_path}" ]]; then
+  echo "missing --kernel <path> or --build-kernel" >&2
+  usage >&2
+  exit 1
+fi
+if [[ "${build_kernel}" -eq 1 ]]; then
+  expected_kernel_profile="initrd"
+  if [[ -n "${rootfs_path}" ]]; then
+    expected_kernel_profile="rootfs"
+  fi
+  if [[ "${kernel_profile}" != "${expected_kernel_profile}" ]]; then
+    echo "--kernel-profile ${kernel_profile} does not match the selected boot medium; expected ${expected_kernel_profile}" >&2
+    exit 1
+  fi
+fi
+
+runner_path="${REPO_ROOT}/dist/darwin-vz-minimal"
+run_repo_tool "${MINIMAL_DIR}/build-runner.sh" "${runner_path}" >/dev/null
+
+if [[ -z "${rootfs_path}" && -z "${initrd_path}" ]]; then
+  initrd_path="${REPO_ROOT}/dist/darwin-vz-minimal-initrd.cpio.gz"
+  run_repo_tool "${MINIMAL_DIR}/build-initrd.sh" "${initrd_path}" >/dev/null
+fi
+
+if [[ "${build_kernel}" -eq 1 ]]; then
+  kernel_arch="${CLEANROOM_DARWIN_VZ_MINIMAL_KERNEL_ARCH:-arm64}"
+  kernel_version="${CLEANROOM_DARWIN_VZ_MINIMAL_KERNEL_VERSION:-6.1.155}"
+  kernel_path="${REPO_ROOT}/dist/darwin-vz-minimal-${kernel_profile}-${kernel_arch}-kernel-${kernel_version}-Image"
+  CLEANROOM_DARWIN_VZ_MINIMAL_KERNEL_PROFILE="${kernel_profile}" \
+    "${MINIMAL_DIR}/build-kernel.sh" "${kernel_path}" >/dev/null
+fi
+
+if [[ ! -r "${kernel_path}" ]]; then
+  echo "kernel not found or unreadable: ${kernel_path}" >&2
+  exit 1
+fi
+if [[ -n "${initrd_path}" && ! -r "${initrd_path}" ]]; then
+  echo "initrd not found or unreadable: ${initrd_path}" >&2
+  exit 1
+fi
+if [[ -n "${rootfs_path}" && ! -r "${rootfs_path}" ]]; then
+  echo "rootfs not found or unreadable: ${rootfs_path}" >&2
+  exit 1
+fi
+
+mkdir -p "${output_dir}"
+timestamp="$(date -u +%Y-%m-%dT%H-%M-%SZ)"
+output_path="${output_dir}/${timestamp}-darwin-vz-minimal.jsonl"
+console_dir="${output_dir}/${timestamp}-darwin-vz-minimal-console"
+mkdir -p "${console_dir}"
+
+mode_args=()
+if [[ -n "${rootfs_path}" ]]; then
+  mode_args=(--rootfs "${rootfs_path}")
+else
+  mode_args=(--initrd "${initrd_path}")
+fi
+
+boot_arg_flags=()
+if [[ -n "${boot_args}" ]]; then
+  boot_arg_flags=(--boot-args "${boot_args}")
+fi
+
+for i in $(seq 1 "${iterations}"); do
+  console_log="${console_dir}/run-${i}.log"
+  "${runner_path}" \
+    --kernel "${kernel_path}" \
+    "${mode_args[@]}" \
+    --vcpus "${vcpus}" \
+    --memory-mib "${memory_mib}" \
+    --console-log "${console_log}" \
+    "${boot_arg_flags[@]}" | tee -a "${output_path}"
+done
+
+printf 'wrote %s\n' "${output_path}"
+
+if command -v jq >/dev/null 2>&1; then
+  jq -s -r '
+    def round1: (. * 10 | round / 10);
+    def stat($xs): ($xs | sort) as $s |
+      "n=" + (($s|length)|tostring) +
+      " median=" + ((if ($s|length)%2==1 then $s[(($s|length)/2|floor)] else (($s[(($s|length)/2)-1] + $s[(($s|length)/2)]) / 2) end)|round1|tostring) +
+      " mean=" + (($s|add/length)|round1|tostring) +
+      " min=" + ($s[0]|round1|tostring) +
+      " max=" + ($s[-1]|round1|tostring);
+    "exec_response_ms " + stat(map(.exec_response_ms)) + "\n" +
+    "vsock_connect_ms " + stat(map(.vsock_connect_ms))
+  ' "${output_path}"
+fi

--- a/scripts/benchmark_darwin_vz_minimal_test.go
+++ b/scripts/benchmark_darwin_vz_minimal_test.go
@@ -1,0 +1,84 @@
+package scripts_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBenchmarkDarwinVZMinimalRequiresKernelBeforeBuild(t *testing.T) {
+	out, callLog, err := runBenchmarkDarwinVZMinimalExpectingEarlyFailure(t,
+		"--iterations", "1",
+	)
+	requireBenchmarkDarwinVZMinimalFailure(t, out, err, callLog, "missing --kernel <path> or --build-kernel")
+}
+
+func TestBenchmarkDarwinVZMinimalRejectsRootFSKernelForInitrdBoot(t *testing.T) {
+	out, callLog, err := runBenchmarkDarwinVZMinimalExpectingEarlyFailure(t,
+		"--build-kernel",
+		"--kernel-profile", "rootfs",
+		"--iterations", "1",
+	)
+	requireBenchmarkDarwinVZMinimalFailure(t, out, err, callLog, "--kernel-profile rootfs does not match the selected boot medium; expected initrd")
+}
+
+func TestBenchmarkDarwinVZMinimalRejectsInitrdKernelForRootFSBoot(t *testing.T) {
+	tmpDir := t.TempDir()
+	rootFSPath := filepath.Join(tmpDir, "rootfs.ext4")
+	if err := os.WriteFile(rootFSPath, []byte("placeholder"), 0o600); err != nil {
+		t.Fatalf("write rootfs placeholder: %v", err)
+	}
+
+	out, callLog, err := runBenchmarkDarwinVZMinimalExpectingEarlyFailure(t,
+		"--build-kernel",
+		"--rootfs", rootFSPath,
+		"--kernel-profile", "initrd",
+		"--iterations", "1",
+	)
+	requireBenchmarkDarwinVZMinimalFailure(t, out, err, callLog, "--kernel-profile initrd does not match the selected boot medium; expected rootfs")
+}
+
+func runBenchmarkDarwinVZMinimalExpectingEarlyFailure(t *testing.T, args ...string) ([]byte, string, error) {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	binDir := filepath.Join(tmpDir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+
+	callLog := filepath.Join(tmpDir, "xcrun-calls.log")
+	writeLocalExecutable(t, binDir, "xcrun", `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$FAKE_XCRUN_LOG"
+exit 99
+`)
+
+	cmdArgs := append([]string{"benchmark-darwin-vz-minimal.sh"}, args...)
+	cmdArgs = append(cmdArgs, "--output-dir", filepath.Join(tmpDir, "out"))
+	cmd := exec.Command("bash", cmdArgs...)
+	cmd.Env = append(os.Environ(),
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"FAKE_XCRUN_LOG="+callLog,
+	)
+	out, err := cmd.CombinedOutput()
+	return out, callLog, err
+}
+
+func requireBenchmarkDarwinVZMinimalFailure(t *testing.T, out []byte, err error, callLog, wantMessage string) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatalf("expected benchmark-darwin-vz-minimal.sh to fail\n%s", out)
+	}
+	if !strings.Contains(string(out), wantMessage) {
+		t.Fatalf("expected error %q, got:\n%s", wantMessage, out)
+	}
+	if _, err := os.Stat(callLog); err == nil {
+		t.Fatalf("runner build should not start before kernel validation")
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("stat xcrun call log: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Add a standalone minimal Virtualization.framework runner under `benchmarks/darwin-vz/minimal`.
- Add initrd and minimal-kernel build helpers plus `scripts/benchmark-darwin-vz-minimal.sh` as the runnable entrypoint.
- Fail fast when `--build-kernel` profile and boot medium disagree, and stamp cached kernel sources with the verified tarball checksum.
- Document the lower-bound benchmark in `docs/benchmarks.md` and point agents to it from `AGENTS.md`.

## Why
This gives us a clean place to test darwin-vz boot experiments without mixing lower-bound VZ measurements into the production backend path. It should make kernel, initrd, VZ device, and guest-readiness experiments easier to reproduce.

## Validation
- `bash -n scripts/benchmark-darwin-vz-minimal.sh benchmarks/darwin-vz/minimal/build-runner.sh benchmarks/darwin-vz/minimal/build-initrd.sh benchmarks/darwin-vz/minimal/build-kernel.sh`
- `scripts/benchmark-darwin-vz-minimal.sh --help`
- `scripts/benchmark-darwin-vz-minimal.sh --iterations 0`
- `scripts/benchmark-darwin-vz-minimal.sh --iterations 1` verifies missing-kernel failure happens before local builds
- `benchmarks/darwin-vz/minimal/build-runner.sh /tmp/darwin-vz-minimal-pr-check`
- `mise exec -- benchmarks/darwin-vz/minimal/build-initrd.sh /tmp/darwin-vz-minimal-pr-check.cpio.gz`
- `mise exec -- go test ./scripts ./benchmarks/darwin-vz/minimal ./benchmarks/darwin-vz/minimal/initrd-agent ./benchmarks/darwin-vz/minimal/initrd-true`
- `mise exec -- env GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go test ./benchmarks/darwin-vz/minimal/initrd-agent ./benchmarks/darwin-vz/minimal/initrd-true`
- `git diff --check`

Not run: full Docker kernel compile or a live VZ benchmark run in this PR pass.