### PR TITLE
refactor: Clarify stage cache resolution

### DIFF
--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -559,23 +559,6 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 				reporter:        reporter,
 			}
 
-			if servicesStageCachingEnabled {
-				servicesHit, err := s.resolveServicesStageCache(ctx, servicesStageResolveRequest{
-					stageCacheResolveContext: cacheResolveContext,
-					plan:                     servicesStagePlan,
-				})
-				if err != nil {
-					return nil, err
-				}
-				if servicesHit.restored != nil {
-					metricSourceKind = "services stage cache"
-					return servicesHit.restored, nil
-				}
-				if servicesHit.replaced != nil {
-					replacedServicesStageRecord = servicesHit.replaced
-				}
-			}
-
 			if dependencyStageBootstrapEnabled {
 				dependencyBlockVolumePlan, dependencyBlockVolumePlanAvailable = s.lookupDependencyBlockVolumePlanForCreateSandbox(ctx, adapter, backendName, compiled, repository, changeset, commitBundle, workspaceStageRuntimeBaseKey)
 				if dependencyBlockVolumePlanAvailable {
@@ -599,58 +582,37 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 				}
 			}
 
-			if dependencyStageCachingEnabled {
-				dependencyHit, err := s.resolveDependencyStageCache(ctx, dependencyStageResolveRequest{
-					stageCacheResolveContext: cacheResolveContext,
-					plan:                     dependencyStagePlan,
-					adapter:                  adapter,
-					servicesPlan:             servicesStagePlan,
-					servicesCaching:          servicesStageCachingEnabled,
-					servicesBootstrap:        servicesStageBootstrapEnabled,
-					serviceCacheOutputs:      serviceCacheOutputVolumes,
-				})
-				if err != nil {
-					return nil, err
-				}
-				if dependencyHit.replacedServices != nil {
-					replacedServicesStageRecord = dependencyHit.replacedServices
-				}
-				if dependencyHit.replacedDependency != nil {
-					replacedDependencyStageRecord = dependencyHit.replacedDependency
-				}
-				if dependencyHit.completed != nil {
-					metricSourceKind = dependencyHit.sourceKind
-					return dependencyHit.completed, nil
-				}
-				if dependencyHit.restored != nil {
-					metricSourceKind = dependencyHit.sourceKind
-					restoredDependencyResp = dependencyHit.restored
-				}
+			stageCacheHit, err := s.resolveStageCaches(ctx, stageCacheResolveRequest{
+				stageCacheResolveContext:     cacheResolveContext,
+				adapter:                      adapter,
+				workspaceStageRuntimeBaseKey: workspaceStageRuntimeBaseKey,
+				workspaceStageCacheKey:       workspaceStageKey,
+				dependencyStagePlan:          dependencyStagePlan,
+				dependencyStageCaching:       dependencyStageCachingEnabled,
+				dependencyStageBootstrap:     dependencyStageBootstrapEnabled,
+				dependencyCacheOutputVolumes: dependencyCacheOutputVolumes,
+				servicesStagePlan:            servicesStagePlan,
+				servicesStageCaching:         servicesStageCachingEnabled,
+				servicesStageBootstrap:       servicesStageBootstrapEnabled,
+				servicesCacheOutputVolumes:   serviceCacheOutputVolumes,
+			})
+			if err != nil {
+				return nil, err
 			}
-
-			if restoredDependencyResp == nil {
-				workspaceHit, err := s.resolveWorkspaceStageCache(ctx, workspaceStageResolveRequest{
-					stageCacheResolveContext: cacheResolveContext,
-					runtimeBaseKey:           workspaceStageRuntimeBaseKey,
-					cacheKey:                 workspaceStageKey,
-					dependencyBootstrap:      dependencyStageBootstrapEnabled,
-					servicesBootstrap:        servicesStageBootstrapEnabled,
-					cacheOutputs:             appendCacheOutputVolumeSpecs(dependencyCacheOutputVolumes, serviceCacheOutputVolumes),
-				})
-				if err != nil {
-					return nil, err
-				}
-				if workspaceHit.replaced != nil {
-					replacedWorkspaceStageRecord = workspaceHit.replaced
-				}
-				if workspaceHit.completed != nil {
-					metricSourceKind = workspaceHit.sourceKind
-					return workspaceHit.completed, nil
-				}
-				if workspaceHit.restored != nil {
-					metricSourceKind = workspaceHit.sourceKind
-					restoredWorkspaceResp = workspaceHit.restored
-				}
+			replacedWorkspaceStageRecord = stageCacheHit.replacedWorkspace
+			replacedDependencyStageRecord = stageCacheHit.replacedDependency
+			replacedServicesStageRecord = stageCacheHit.replacedServices
+			if stageCacheHit.completed != nil {
+				metricSourceKind = stageCacheHit.sourceKind
+				return stageCacheHit.completed, nil
+			}
+			if stageCacheHit.restoredDependency != nil {
+				metricSourceKind = stageCacheHit.sourceKind
+				restoredDependencyResp = stageCacheHit.restoredDependency
+			}
+			if stageCacheHit.restoredWorkspace != nil {
+				metricSourceKind = stageCacheHit.sourceKind
+				restoredWorkspaceResp = stageCacheHit.restoredWorkspace
 			}
 		}
 	}

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -3735,6 +3735,91 @@ func TestCreateSandboxBootstrapsServicesAfterDependencyStageRestoreWithoutServic
 	}
 }
 
+func TestCreateSandboxPrefersExactDependencyStageOverPortableWhenServicesStageMissing(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	store := newMemorySnapshotStore()
+	adapter := &stubAdapter{}
+	var snapshotReqs []backend.SnapshotRequest
+	var restoreReqs []backend.ProvisionFromSnapshotRequest
+	adapter.createSnapshotFn = func(_ context.Context, req backend.SnapshotRequest) (*backend.SnapshotResult, error) {
+		snapshotReqs = append(snapshotReqs, req)
+		return &backend.SnapshotResult{StorageRef: "/snapshots/" + req.SnapshotID + ".ext4"}, nil
+	}
+	adapter.provisionFromSnapshotFn = func(_ context.Context, req backend.ProvisionFromSnapshotRequest) error {
+		restoreReqs = append(restoreReqs, req)
+		return nil
+	}
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"go.mod":             "module example.com/test\n\ngo 1.26.2\n",
+		"go.sum":             "example.com/test v0.0.0 h1:abc123\n",
+		"docker-compose.yml": "services:\n  postgres:\n    image: postgres:17\n",
+	})
+	svc := newTestServiceWithSnapshotStore(adapter, store)
+	svc.RepositoryStore = mirrors
+
+	portableServicesPolicy := testRepositoryDependencyAndServicesPolicy()
+	portableServicesPolicy.Dependencies.Reuse = policy.DependencyReusePortable
+	req := &cleanroomv1.CreateSandboxRequest{
+		Policy:             portableServicesPolicy,
+		RepositoryCheckout: repositoryCheckout,
+	}
+
+	if _, err := svc.CreateSandbox(context.Background(), req); err != nil {
+		t.Fatalf("first CreateSandbox returned error: %v", err)
+	}
+
+	records, err := svc.CacheStore.List(context.Background())
+	if err != nil {
+		t.Fatalf("List cache records returned error: %v", err)
+	}
+	var exactDependencyRecord, portableDependencyRecord *cachestore.Record
+	for i := range records {
+		record := records[i]
+		switch {
+		case record.Stage == dependencyStageName && record.ReuseMode == dependencyStageReuseExact:
+			exactDependencyRecord = &record
+		case record.Stage == dependencyStageName && record.ReuseMode == dependencyStageReusePortable:
+			portableDependencyRecord = &record
+		case record.Stage == servicesStageName:
+			if err := svc.CacheStore.Delete(context.Background(), record.Stage, record.CacheKey); err != nil {
+				t.Fatalf("Delete services cache record returned error: %v", err)
+			}
+		}
+	}
+	if exactDependencyRecord == nil {
+		t.Fatal("expected published exact dependency stage cache record")
+	}
+	if portableDependencyRecord == nil {
+		t.Fatal("expected published portable dependency stage cache record")
+	}
+
+	secondResp, err := svc.CreateSandbox(context.Background(), req)
+	if err != nil {
+		t.Fatalf("second CreateSandbox returned error: %v", err)
+	}
+	if got, want := secondResp.GetSourceKind(), "dependency stage cache"; got != want {
+		t.Fatalf("unexpected response source kind: got %q want %q", got, want)
+	}
+	if got, want := adapter.provisionCalls, 1; got != want {
+		t.Fatalf("expected exact dependency-stage hit to avoid second cold provision, got %d want %d", got, want)
+	}
+	if got, want := adapter.provisionFromSnapshotCalls, 1; got != want {
+		t.Fatalf("expected only one exact dependency-stage restore, got %d want %d", got, want)
+	}
+	if got, want := len(restoreReqs), 1; got != want {
+		t.Fatalf("expected one restore request, got %d want %d", got, want)
+	}
+	if got, want := restoreReqs[0].SnapshotID, exactDependencyRecord.BackingSnapshotID; got != want {
+		t.Fatalf("unexpected restore snapshot id: got %q want %q", got, want)
+	}
+	if got, want := adapter.runCalls, 4; got != want {
+		t.Fatalf("expected only one extra services bootstrap after dependency restore, got %d want %d", got, want)
+	}
+	if got, want := len(snapshotReqs), 4; got != want {
+		t.Fatalf("expected one replacement services-stage snapshot publish, got %d want %d", got, want)
+	}
+}
+
 func TestCreateSandboxDependencyRestoreFailureUsesWorkspaceCache(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	store := newMemorySnapshotStore()

--- a/internal/controlservice/stage_cache_resolution.go
+++ b/internal/controlservice/stage_cache_resolution.go
@@ -39,12 +39,35 @@ type servicesStageResolveResult struct {
 	replaced *cachestore.Record
 }
 
+type stageCacheResolveRequest struct {
+	stageCacheResolveContext
+	adapter                      backend.Adapter
+	workspaceStageRuntimeBaseKey string
+	workspaceStageCacheKey       string
+	dependencyStagePlan          dependencyStagePlan
+	dependencyStageCaching       bool
+	dependencyStageBootstrap     bool
+	dependencyCacheOutputVolumes []backend.CacheOutputVolumeSpec
+	servicesStagePlan            servicesStagePlan
+	servicesStageCaching         bool
+	servicesStageBootstrap       bool
+	servicesCacheOutputVolumes   []backend.CacheOutputVolumeSpec
+}
+
+type stageCacheResolveResult struct {
+	completed          *cleanroomv1.CreateSandboxResponse
+	restoredWorkspace  *cleanroomv1.CreateSandboxResponse
+	restoredDependency *cleanroomv1.CreateSandboxResponse
+	sourceKind         string
+	replacedWorkspace  *cachestore.Record
+	replacedDependency *cachestore.Record
+	replacedServices   *cachestore.Record
+}
+
 type dependencyStageResolveRequest struct {
 	stageCacheResolveContext
 	plan                dependencyStagePlan
 	adapter             backend.Adapter
-	servicesPlan        servicesStagePlan
-	servicesCaching     bool
 	servicesBootstrap   bool
 	serviceCacheOutputs []backend.CacheOutputVolumeSpec
 }
@@ -54,7 +77,6 @@ type dependencyStageResolveResult struct {
 	restored           *cleanroomv1.CreateSandboxResponse
 	sourceKind         string
 	replacedDependency *cachestore.Record
-	replacedServices   *cachestore.Record
 }
 
 type workspaceStageResolveRequest struct {
@@ -71,6 +93,123 @@ type workspaceStageResolveResult struct {
 	restored   *cleanroomv1.CreateSandboxResponse
 	sourceKind string
 	replaced   *cachestore.Record
+}
+
+type dependencyStageLookupResult struct {
+	record cachestore.Record
+	found  bool
+}
+
+func (s *Service) resolveStageCaches(ctx context.Context, req stageCacheResolveRequest) (stageCacheResolveResult, error) {
+	result := stageCacheResolveResult{}
+
+	if req.servicesStageCaching {
+		servicesHit, err := s.resolveServicesStageCache(ctx, servicesStageResolveRequest{
+			stageCacheResolveContext: req.stageCacheResolveContext,
+			plan:                     req.servicesStagePlan,
+		})
+		if err != nil {
+			return stageCacheResolveResult{}, err
+		}
+		if servicesHit.restored != nil {
+			result.completed = servicesHit.restored
+			result.sourceKind = "services stage cache"
+			return result, nil
+		}
+		result.replacedServices = servicesHit.replaced
+	}
+
+	if req.dependencyStageCaching {
+		dependencyReq := dependencyStageResolveRequest{
+			stageCacheResolveContext: req.stageCacheResolveContext,
+			plan:                     req.dependencyStagePlan,
+			adapter:                  req.adapter,
+			servicesBootstrap:        req.servicesStageBootstrap,
+			serviceCacheOutputs:      req.servicesCacheOutputVolumes,
+		}
+		dependencyLookup, err := s.lookupDependencyStageCacheForResolution(ctx, dependencyReq)
+		if err != nil {
+			return stageCacheResolveResult{}, err
+		}
+
+		if dependencyLookup.found {
+			if req.servicesStageCaching {
+				servicesHit, err := s.resolveServicesStageCacheAfterDependency(ctx, servicesStageResolveRequest{
+					stageCacheResolveContext: req.stageCacheResolveContext,
+					plan:                     req.servicesStagePlan,
+				})
+				if err != nil {
+					return stageCacheResolveResult{}, err
+				}
+				if servicesHit.restored != nil {
+					result.completed = servicesHit.restored
+					result.sourceKind = "services stage cache"
+					return result, nil
+				}
+				if servicesHit.replaced != nil {
+					result.replacedServices = servicesHit.replaced
+				}
+			}
+
+			dependencyHit, err := s.restoreDependencyStageCache(ctx, dependencyReq, dependencyLookup.record)
+			if err != nil {
+				return stageCacheResolveResult{}, err
+			}
+			if dependencyHit.replacedDependency != nil {
+				result.replacedDependency = dependencyHit.replacedDependency
+			}
+			if dependencyHit.completed != nil {
+				result.completed = dependencyHit.completed
+				result.sourceKind = dependencyHit.sourceKind
+				return result, nil
+			}
+			if dependencyHit.restored != nil {
+				result.restoredDependency = dependencyHit.restored
+				result.sourceKind = dependencyHit.sourceKind
+				return result, nil
+			}
+		}
+
+		portableHit, err := s.resolvePortableDependencyStageCache(ctx, dependencyReq)
+		if err != nil {
+			return stageCacheResolveResult{}, err
+		}
+		if portableHit.completed != nil {
+			result.completed = portableHit.completed
+			result.sourceKind = portableHit.sourceKind
+			return result, nil
+		}
+		if portableHit.restored != nil {
+			result.restoredDependency = portableHit.restored
+			result.sourceKind = portableHit.sourceKind
+			return result, nil
+		}
+	}
+
+	workspaceHit, err := s.resolveWorkspaceStageCache(ctx, workspaceStageResolveRequest{
+		stageCacheResolveContext: req.stageCacheResolveContext,
+		runtimeBaseKey:           req.workspaceStageRuntimeBaseKey,
+		cacheKey:                 req.workspaceStageCacheKey,
+		dependencyBootstrap:      req.dependencyStageBootstrap,
+		servicesBootstrap:        req.servicesStageBootstrap,
+		cacheOutputs:             appendCacheOutputVolumeSpecs(req.dependencyCacheOutputVolumes, req.servicesCacheOutputVolumes),
+	})
+	if err != nil {
+		return stageCacheResolveResult{}, err
+	}
+	if workspaceHit.replaced != nil {
+		result.replacedWorkspace = workspaceHit.replaced
+	}
+	if workspaceHit.completed != nil {
+		result.completed = workspaceHit.completed
+		result.sourceKind = workspaceHit.sourceKind
+		return result, nil
+	}
+	if workspaceHit.restored != nil {
+		result.restoredWorkspace = workspaceHit.restored
+		result.sourceKind = workspaceHit.sourceKind
+	}
+	return result, nil
 }
 
 func (s *Service) resolveServicesStageCache(ctx context.Context, req servicesStageResolveRequest) (servicesStageResolveResult, error) {
@@ -168,7 +307,7 @@ func (s *Service) resolveServicesStageCacheAfterDependency(ctx context.Context, 
 	return s.resolveServicesStageCache(ctx, req)
 }
 
-func (s *Service) resolveDependencyStageCache(ctx context.Context, req dependencyStageResolveRequest) (dependencyStageResolveResult, error) {
+func (s *Service) lookupDependencyStageCacheForResolution(ctx context.Context, req dependencyStageResolveRequest) (dependencyStageLookupResult, error) {
 	emitCreateSandboxMessage(req.reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_DEPENDENCY_STAGE_CACHE, "checking dependency stage cache")
 	var record cachestore.Record
 	var found bool
@@ -186,7 +325,7 @@ func (s *Service) resolveDependencyStageCache(ctx context.Context, req dependenc
 	})
 	if err != nil {
 		s.logDependencyStageWarning("lookup dependency stage cache", "", err)
-		return s.resolvePortableDependencyStageCache(ctx, req)
+		return dependencyStageLookupResult{}, nil
 	}
 
 	if !found {
@@ -213,80 +352,57 @@ func (s *Service) resolveDependencyStageCache(ctx context.Context, req dependenc
 		}
 	}
 
-	result := dependencyStageResolveResult{}
 	if !found {
 		s.logDependencyStageCacheMiss(req.backendName, req.plan.CacheKey)
 		emitCreateSandboxMessage(req.reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_DEPENDENCY_STAGE_CACHE, "dependency stage cache miss")
-	} else {
-		if req.servicesCaching {
-			servicesHit, err := s.resolveServicesStageCacheAfterDependency(ctx, servicesStageResolveRequest{
-				stageCacheResolveContext: req.stageCacheResolveContext,
-				plan:                     req.servicesPlan,
-			})
-			if err != nil {
-				return dependencyStageResolveResult{}, err
-			}
-			if servicesHit.restored != nil {
-				result.completed = servicesHit.restored
-				result.sourceKind = "services stage cache"
-				return result, nil
-			}
-			result.replacedServices = servicesHit.replaced
-		}
-
-		s.logDependencyStageCacheHit(record)
-		emitCreateSandboxMessage(req.reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_DEPENDENCY_STAGE_CACHE, "dependency stage cache hit")
-		emitCreateSandboxMessage(req.reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_RESTORE_DEPENDENCY_STAGE_CACHE, "restoring dependency stage cache")
-		restoreReq := &cleanroomv1.CreateSandboxRequest{
-			Backend: req.backendName,
-			Options: req.options,
-		}
-		var restoreResp *cleanroomv1.CreateSandboxResponse
-		restoreErr := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.restore_dependency_stage_cache", cachePhaseAttributes(
-			observability.CacheStageDependency,
-			observability.CacheOperationRestore,
-			req.repository,
-			attribute.String(observability.AttrBackend, req.backendName),
-		), func(ctx context.Context) error {
-			var err error
-			restoreResp, err = s.createSandboxFromCacheRecord(ctx, restoreReq, req.compiled, record, req.serviceCacheOutputs, req.reporter)
-			setCacheResultSpanAttribute(ctx, map[bool]string{true: observability.CacheResultFailed, false: observability.CacheResultRestored}[err != nil])
-			return err
-		})
-		if restoreErr == nil {
-			if cacheStore, err := s.cacheStoreOrErr(); err == nil {
-				if err := cacheStore.Touch(ctx, record.Stage, record.CacheKey); err != nil {
-					s.logDependencyStageWarning("touch dependency stage cache", "", err)
-				}
-			}
-			s.retainRestoredSandboxRepositoryState(restoreResp, req.repository, req.commitBundle, req.changeset)
-			s.logDependencyStageRestore(record, restoreResp.GetSandbox().GetSandboxId())
-			result.sourceKind = "dependency stage cache"
-			if !req.servicesBootstrap {
-				result.completed = restoreResp
-				return result, nil
-			}
-			result.restored = restoreResp
-		} else {
-			if errors.Is(restoreErr, errSandboxCreateAborted) {
-				return dependencyStageResolveResult{}, restoreErr
-			}
-			recordCopy := record
-			s.logDependencyStageRestoreWarning(record, restoreErr)
-			result.replacedDependency = &recordCopy
-		}
+		return dependencyStageLookupResult{}, nil
 	}
 
-	portableHit, err := s.resolvePortableDependencyStageCache(ctx, req)
-	if err != nil {
-		return dependencyStageResolveResult{}, err
+	return dependencyStageLookupResult{record: record, found: true}, nil
+}
+
+func (s *Service) restoreDependencyStageCache(ctx context.Context, req dependencyStageResolveRequest, record cachestore.Record) (dependencyStageResolveResult, error) {
+	s.logDependencyStageCacheHit(record)
+	emitCreateSandboxMessage(req.reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_LOOKUP_DEPENDENCY_STAGE_CACHE, "dependency stage cache hit")
+	emitCreateSandboxMessage(req.reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_RESTORE_DEPENDENCY_STAGE_CACHE, "restoring dependency stage cache")
+	restoreReq := &cleanroomv1.CreateSandboxRequest{
+		Backend: req.backendName,
+		Options: req.options,
 	}
-	if portableHit.completed != nil || portableHit.restored != nil {
-		portableHit.replacedDependency = result.replacedDependency
-		portableHit.replacedServices = result.replacedServices
-		return portableHit, nil
+	var restoreResp *cleanroomv1.CreateSandboxResponse
+	restoreErr := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.restore_dependency_stage_cache", cachePhaseAttributes(
+		observability.CacheStageDependency,
+		observability.CacheOperationRestore,
+		req.repository,
+		attribute.String(observability.AttrBackend, req.backendName),
+	), func(ctx context.Context) error {
+		var err error
+		restoreResp, err = s.createSandboxFromCacheRecord(ctx, restoreReq, req.compiled, record, req.serviceCacheOutputs, req.reporter)
+		setCacheResultSpanAttribute(ctx, map[bool]string{true: observability.CacheResultFailed, false: observability.CacheResultRestored}[err != nil])
+		return err
+	})
+	if restoreErr == nil {
+		if cacheStore, err := s.cacheStoreOrErr(); err == nil {
+			if err := cacheStore.Touch(ctx, record.Stage, record.CacheKey); err != nil {
+				s.logDependencyStageWarning("touch dependency stage cache", "", err)
+			}
+		}
+		s.retainRestoredSandboxRepositoryState(restoreResp, req.repository, req.commitBundle, req.changeset)
+		s.logDependencyStageRestore(record, restoreResp.GetSandbox().GetSandboxId())
+		result := dependencyStageResolveResult{sourceKind: "dependency stage cache"}
+		if !req.servicesBootstrap {
+			result.completed = restoreResp
+			return result, nil
+		}
+		result.restored = restoreResp
+		return result, nil
 	}
-	return result, nil
+	if errors.Is(restoreErr, errSandboxCreateAborted) {
+		return dependencyStageResolveResult{}, restoreErr
+	}
+	recordCopy := record
+	s.logDependencyStageRestoreWarning(record, restoreErr)
+	return dependencyStageResolveResult{replacedDependency: &recordCopy}, nil
 }
 
 func (s *Service) resolvePortableDependencyStageCache(ctx context.Context, req dependencyStageResolveRequest) (dependencyStageResolveResult, error) {


### PR DESCRIPTION
## Context

This PR is a cleanup slice for the stage-cache resolution refactor, not a new layered-caching feature.

The previous refactor series moved services, dependency, portable dependency, and workspace cache lookup/restore out of the main `CreateSandbox` body and into `stage_cache_resolution.go`. The goal was to make stage-cache resolution a private control-plane module: `CreateSandbox` should prepare the request and then ask one place whether a ready stage can be reused, while the resolver owns the cache hit order, fallback rules, restore failures, and replacement metadata.

After those PRs, the code was better, but the goal was only partially met. `CreateSandbox` still encoded the stage-cache state machine by calling services, dependency, portable dependency, and workspace resolution separately. That also left an edge case where an exact dependency-stage restore could allocate a sandbox and then fall through to portable dependency restore when services still needed to run.

## What Changed

- Added a single `resolveStageCaches` coordinator for services, dependency, portable dependency, and workspace cache resolution.
- Split dependency-stage lookup from dependency-stage restore, so the resolver can make the exact-vs-portable decision explicitly.
- Made exact dependency-stage restore terminal once it succeeds, including the case where services bootstrap still needs to run afterward.
- Kept follow-on bootstrap and cache publication in `CreateSandbox`, but reduced it to consuming one resolver result instead of manually driving each cache-resolution branch.
- Added a regression test for the exact-plus-portable case where the services cache is missing.

## Why

The important behavior here is not just cache lookup. Stage-cache resolution has to preserve ordering and ownership invariants:

- a services-stage hit should short-circuit all lower-stage work;
- an exact dependency-stage hit should win over portable reuse for the same checkout;
- portable dependency reuse should remain a fallback when exact dependency reuse misses or cannot be restored;
- restore failures should keep enough replacement metadata for later publication to replace stale records;
- `CreateSandbox` should not need to understand every cache branch to preserve those rules.

Putting that decision tree behind one private resolver makes the behavior easier to audit and gives the remaining bootstrap/publish code a smaller interface to depend on.

## Tests

- `mise exec -- go test ./internal/controlservice -run 'TestCreateSandbox(PrefersExactDependencyStageOverPortableWhenServicesStageMissing|BootstrapsServicesAfterDependencyStageRestoreWithoutServicesStageCache|BootstrapsServicesAfterPortableDependencyStageRestore|ReusesPortableDependencyStageAfterCheckoutRefresh|DependencyRestoreFailureUsesWorkspace|PortableDependencyRestoreFailureUsesWorkspace)'`
- `mise exec -- go test ./internal/controlservice`
- `mise exec -- go test ./...`
