### PR TITLE
fix: Handle omitted VZ benchmark boot args

### DIFF
--- a/scripts/benchmark-darwin-vz-minimal.sh
+++ b/scripts/benchmark-darwin-vz-minimal.sh
@@ -198,20 +198,20 @@ else
   mode_args=(--initrd "${initrd_path}")
 fi
 
-boot_arg_flags=()
-if [[ -n "${boot_args}" ]]; then
-  boot_arg_flags=(--boot-args "${boot_args}")
-fi
-
 for i in $(seq 1 "${iterations}"); do
   console_log="${console_dir}/run-${i}.log"
-  "${runner_path}" \
-    --kernel "${kernel_path}" \
-    "${mode_args[@]}" \
-    --vcpus "${vcpus}" \
-    --memory-mib "${memory_mib}" \
-    --console-log "${console_log}" \
-    "${boot_arg_flags[@]}" | tee -a "${output_path}"
+  runner_args=(
+    --kernel "${kernel_path}"
+    "${mode_args[@]}"
+    --vcpus "${vcpus}"
+    --memory-mib "${memory_mib}"
+    --console-log "${console_log}"
+  )
+  if [[ -n "${boot_args}" ]]; then
+    runner_args+=(--boot-args "${boot_args}")
+  fi
+
+  "${runner_path}" "${runner_args[@]}" | tee -a "${output_path}"
 done
 
 printf 'wrote %s\n' "${output_path}"


### PR DESCRIPTION
## Summary

Fixes the minimal darwin-vz benchmark wrapper when `--boot-args` is omitted. The script previously expanded an empty `boot_arg_flags` array under `set -u`, which fails on the system Bash before the runner is invoked.

The wrapper now builds a non-empty runner argument array for each iteration and appends `--boot-args` only when the user provided an override.

## Validation

- `mise exec -- shellcheck -x scripts/benchmark-darwin-vz-minimal.sh benchmarks/darwin-vz/minimal/build-runner.sh benchmarks/darwin-vz/minimal/build-initrd.sh benchmarks/darwin-vz/minimal/build-kernel.sh`
- `scripts/benchmark-darwin-vz-minimal.sh --help`
- `scripts/benchmark-darwin-vz-minimal.sh --kernel "$HOME/.local/share/cleanroom/assets/kernels/fc-ci-v1.14-darwin-arm64-vmlinux-6.1.155/vmlinux-6.1.155" --iterations 1 --memory-mib 1024`
- `scripts/benchmark-darwin-vz-minimal.sh --kernel "$HOME/.local/share/cleanroom/assets/kernels/fc-ci-v1.14-darwin-arm64-vmlinux-6.1.155/vmlinux-6.1.155" --iterations 1 --memory-mib 1024 --boot-args "console=hvc0 rdinit=/init cleanroom_guest_port=10700 cleanroom_guest_boot_timing=1"`
- `git diff --check`
- `mise exec -- go test ./scripts ./benchmarks/darwin-vz/minimal/initrd-agent ./benchmarks/darwin-vz/minimal/initrd-true`