### PR TITLE
test: Add VZ memory reporting probe

### DIFF
--- a/benchmarks/darwin-vz/minimal/README.md
+++ b/benchmarks/darwin-vz/minimal/README.md
@@ -2,16 +2,17 @@
 
 This directory contains a deliberately small Virtualization.framework benchmark for darwin-vz boot experiments. It is a lower-bound probe, not a Cleanroom backend and not a replacement for `scripts/benchmark-tti.sh`.
 
-The runner boots a Linux kernel through `VZLinuxBootLoader`, connects to a guest vsock listener, runs `/bin/true`, and prints JSON timings for VM start, vsock readiness, and first exec response.
+The runner boots a Linux kernel through `VZLinuxBootLoader`, connects to a guest vsock listener, runs a probe, and prints JSON timings for VM start, vsock readiness, and first exec response. The default `exec` probe runs `/bin/true`; the `memory-reporting` probe runs `/bin/memprobe`, touches guest memory, frees it, and records host footprint samples so VZ balloon and free-page-reporting behavior can be tested.
 
 ## Layout
 
 - `runner.swift`: standalone Virtualization.framework runner.
 - `initrd-agent`: tiny Linux `/init` that implements enough of the guest exec protocol for `/bin/true`.
 - `initrd-true`: static no-op command used by the initrd benchmark.
+- `initrd-memprobe`: static guest memory lifecycle probe used by the `memory-reporting` benchmark.
 - `build-runner.sh`: builds and signs `dist/darwin-vz-minimal`.
 - `build-initrd.sh`: builds `dist/darwin-vz-minimal-initrd.cpio.gz`.
-- `build-kernel.sh`: Docker-based minimal Linux kernel builder for initrd or rootfs profiles.
+- `build-kernel.sh`: Docker-based minimal Linux kernel builder for initrd or rootfs profiles. The initrd kernel enables virtio balloon and Linux page reporting support for memory experiments.
 
 ## Run
 
@@ -27,6 +28,53 @@ To build the minimal kernel first:
 
 ```bash
 scripts/benchmark-darwin-vz-minimal.sh --build-kernel --iterations 30
+```
+
+To test whether VZ releases host footprint after guest free-page reporting without an explicit balloon target:
+
+```bash
+scripts/benchmark-darwin-vz-minimal.sh \
+  --build-kernel \
+  --iterations 3 \
+  --memory-mib 8192 \
+  --probe memory-reporting \
+  --probe-memory-mib 4096
+```
+
+Useful controls:
+
+```bash
+# Negative control: no VZ balloon device is attached.
+scripts/benchmark-darwin-vz-minimal.sh \
+  --build-kernel \
+  --iterations 1 \
+  --memory-mib 8192 \
+  --probe memory-reporting \
+  --probe-memory-mib 4096 \
+  --balloon-device off
+
+# Positive control: explicitly request VZ to reclaim memory after the guest frees it.
+scripts/benchmark-darwin-vz-minimal.sh \
+  --build-kernel \
+  --iterations 1 \
+  --memory-mib 8192 \
+  --probe memory-reporting \
+  --probe-memory-mib 4096 \
+  --balloon-target-mib 1024
+```
+
+To test an early low target with later growth before the workload:
+
+```bash
+scripts/benchmark-darwin-vz-minimal.sh \
+  --build-kernel \
+  --iterations 1 \
+  --memory-mib 8192 \
+  --initial-balloon-target-mib 1024 \
+  --pre-probe-balloon-target-mib 8192 \
+  --pre-probe-balloon-settle-ms 1000 \
+  --probe memory-reporting \
+  --probe-memory-mib 4096
 ```
 
 The wrapper writes JSONL results to `benchmarks/results/` and leaves build outputs in `dist/`.

--- a/benchmarks/darwin-vz/minimal/build-initrd.sh
+++ b/benchmarks/darwin-vz/minimal/build-initrd.sh
@@ -30,7 +30,13 @@ GOOS=linux GOARCH="${host_arch}" CGO_ENABLED=0 go build \
   -o "${ROOT_DIR}/bin/true" \
   "${SCRIPT_DIR}/initrd-true"
 
-chmod 0755 "${ROOT_DIR}/init" "${ROOT_DIR}/bin/true"
+GOOS=linux GOARCH="${host_arch}" CGO_ENABLED=0 go build \
+  -trimpath \
+  -ldflags "-s -w" \
+  -o "${ROOT_DIR}/bin/memprobe" \
+  "${SCRIPT_DIR}/initrd-memprobe"
+
+chmod 0755 "${ROOT_DIR}/init" "${ROOT_DIR}/bin/true" "${ROOT_DIR}/bin/memprobe"
 chmod 1777 "${ROOT_DIR}/tmp"
 
 mkdir -p "$(dirname "${OUTPUT_PATH}")"

--- a/benchmarks/darwin-vz/minimal/build-kernel.sh
+++ b/benchmarks/darwin-vz/minimal/build-kernel.sh
@@ -122,6 +122,11 @@ docker run --rm \
       -e VIRTIO_MMIO \
       -e VIRTIO_PCI_LEGACY \
       -e VIRTIO_CONSOLE \
+      -e VIRTIO_BALLOON \
+      -e MEMORY_BALLOON \
+      -e BALLOON_COMPACTION \
+      -e COMPACTION \
+      -e PAGE_REPORTING \
       -e VSOCKETS \
       -e VIRTIO_VSOCKETS \
       -e NET \
@@ -130,6 +135,7 @@ docker run --rm \
       -e SYSFS \
       -e FUTEX \
       -e EPOLL \
+      -e ADVISE_SYSCALLS \
       -e ANON_INODES \
       -e EVENTFD \
       -e SIGNALFD \

--- a/benchmarks/darwin-vz/minimal/build_kernel_script_test.go
+++ b/benchmarks/darwin-vz/minimal/build_kernel_script_test.go
@@ -19,6 +19,9 @@ func TestBuildKernelVerifiesCachedSourceWithChecksumStamp(t *testing.T) {
 		`rm -rf "${src}" "${source_stamp}"`,
 		`echo "${KERNEL_TARBALL_SHA256}  ${tarball}" | sha256sum -c -`,
 		`printf "%s\n" "${KERNEL_TARBALL_SHA256}" > "${source_stamp}"`,
+		`-e ADVISE_SYSCALLS \`,
+		`-e VIRTIO_BALLOON \`,
+		`-e PAGE_REPORTING \`,
 	}
 	for _, want := range required {
 		if !strings.Contains(script, want) {

--- a/benchmarks/darwin-vz/minimal/initrd-memprobe/doc_nonlinux.go
+++ b/benchmarks/darwin-vz/minimal/initrd-memprobe/doc_nonlinux.go
@@ -1,0 +1,3 @@
+//go:build !linux
+
+package main

--- a/benchmarks/darwin-vz/minimal/initrd-memprobe/main.go
+++ b/benchmarks/darwin-vz/minimal/initrd-memprobe/main.go
@@ -1,0 +1,180 @@
+//go:build linux
+
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+type options struct {
+	touchMiB   uint64
+	preTouch   time.Duration
+	hold       time.Duration
+	postFree   time.Duration
+	pageStride int
+}
+
+type event struct {
+	Phase        string            `json:"phase"`
+	ElapsedMS    int64             `json:"elapsed_ms"`
+	AllocatedMiB uint64            `json:"allocated_mib,omitempty"`
+	Meminfo      map[string]uint64 `json:"meminfo,omitempty"`
+	Error        string            `json:"error,omitempty"`
+}
+
+func main() {
+	opts, err := parseOptions(os.Args[1:])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "memprobe: %v\n", err)
+		os.Exit(2)
+	}
+
+	start := time.Now()
+	emit(start, event{Phase: "before"})
+	time.Sleep(opts.preTouch)
+
+	size := int(opts.touchMiB * 1024 * 1024)
+	buf, err := unix.Mmap(-1, 0, size, unix.PROT_READ|unix.PROT_WRITE, unix.MAP_PRIVATE|unix.MAP_ANON)
+	if err != nil {
+		emit(start, event{Phase: "error", AllocatedMiB: opts.touchMiB, Error: err.Error()})
+		os.Exit(1)
+	}
+
+	for i := 0; i < len(buf); i += opts.pageStride {
+		buf[i] = 1
+	}
+	if len(buf) > 0 {
+		buf[len(buf)-1] = 1
+	}
+	runtime.KeepAlive(buf)
+	emit(start, event{Phase: "touched", AllocatedMiB: opts.touchMiB})
+
+	time.Sleep(opts.hold)
+
+	madviseErr := unix.Madvise(buf, unix.MADV_DONTNEED)
+	munmapErr := unix.Munmap(buf)
+	if madviseErr != nil || munmapErr != nil {
+		msg := joinErrors(madviseErr, munmapErr)
+		emit(start, event{Phase: "error", AllocatedMiB: opts.touchMiB, Error: msg})
+		os.Exit(1)
+	}
+	emit(start, event{Phase: "freed", AllocatedMiB: opts.touchMiB})
+
+	time.Sleep(opts.postFree)
+	emit(start, event{Phase: "after_free", AllocatedMiB: opts.touchMiB})
+}
+
+func parseOptions(args []string) (options, error) {
+	opts := options{
+		touchMiB:   256,
+		preTouch:   500 * time.Millisecond,
+		hold:       time.Second,
+		postFree:   3 * time.Second,
+		pageStride: unix.Getpagesize(),
+	}
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		value := func() (string, error) {
+			if i+1 >= len(args) {
+				return "", fmt.Errorf("missing value for %s", arg)
+			}
+			i++
+			return args[i], nil
+		}
+		switch arg {
+		case "--touch-mib":
+			raw, err := value()
+			if err != nil {
+				return opts, err
+			}
+			parsed, err := strconv.ParseUint(raw, 10, 64)
+			if err != nil || parsed == 0 {
+				return opts, fmt.Errorf("invalid --touch-mib")
+			}
+			opts.touchMiB = parsed
+		case "--hold-ms":
+			duration, err := parseMillis(value)
+			if err != nil {
+				return opts, fmt.Errorf("invalid --hold-ms: %w", err)
+			}
+			opts.hold = duration
+		case "--pre-touch-ms":
+			duration, err := parseMillis(value)
+			if err != nil {
+				return opts, fmt.Errorf("invalid --pre-touch-ms: %w", err)
+			}
+			opts.preTouch = duration
+		case "--post-free-ms":
+			duration, err := parseMillis(value)
+			if err != nil {
+				return opts, fmt.Errorf("invalid --post-free-ms: %w", err)
+			}
+			opts.postFree = duration
+		default:
+			return opts, fmt.Errorf("unknown argument: %s", arg)
+		}
+	}
+	return opts, nil
+}
+
+func parseMillis(next func() (string, error)) (time.Duration, error) {
+	raw, err := next()
+	if err != nil {
+		return 0, err
+	}
+	parsed, err := strconv.ParseUint(raw, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	return time.Duration(parsed) * time.Millisecond, nil
+}
+
+func emit(start time.Time, ev event) {
+	ev.ElapsedMS = time.Since(start).Milliseconds()
+	ev.Meminfo = readMeminfo()
+	_ = json.NewEncoder(os.Stdout).Encode(ev)
+}
+
+func readMeminfo() map[string]uint64 {
+	file, err := os.Open("/proc/meminfo")
+	if err != nil {
+		return nil
+	}
+	defer file.Close()
+
+	out := map[string]uint64{}
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 2 {
+			continue
+		}
+		key := strings.TrimSuffix(fields[0], ":")
+		value, err := strconv.ParseUint(fields[1], 10, 64)
+		if err != nil {
+			continue
+		}
+		out[key] = value
+	}
+	return out
+}
+
+func joinErrors(first, second error) string {
+	parts := []string{}
+	if first != nil {
+		parts = append(parts, "madvise: "+first.Error())
+	}
+	if second != nil {
+		parts = append(parts, "munmap: "+second.Error())
+	}
+	return strings.Join(parts, "; ")
+}

--- a/benchmarks/darwin-vz/minimal/runner.swift
+++ b/benchmarks/darwin-vz/minimal/runner.swift
@@ -2,6 +2,8 @@ import Darwin
 import Foundation
 import Virtualization
 
+private let maxPreProbeBalloonSettleMS = UInt64(useconds_t.max) / 1000
+
 private struct Options {
     var kernelPath = ""
     var rootFSPath = ""
@@ -155,11 +157,13 @@ private enum BaselineError: LocalizedError {
 private final class VMHandle {
     let vm: VZVirtualMachine
     let queue: DispatchQueue
+    let excludedVirtualizationPIDs: Set<pid_t>
     var virtualizationPIDs: [pid_t] = []
 
-    init(vm: VZVirtualMachine, queue: DispatchQueue) {
+    init(vm: VZVirtualMachine, queue: DispatchQueue, excludedVirtualizationPIDs: Set<pid_t>) {
         self.vm = vm
         self.queue = queue
+        self.excludedVirtualizationPIDs = excludedVirtualizationPIDs
     }
 
     func stop() {
@@ -347,6 +351,9 @@ private func parseOptions(_ args: [String]) throws -> Options {
     if opts.balloonTargetMiB != nil && opts.probe != "memory-reporting" {
         throw BaselineError.invalid("--balloon-target-mib requires --probe memory-reporting")
     }
+    if opts.preProbeBalloonSettleMS > maxPreProbeBalloonSettleMS {
+        throw BaselineError.invalid("--pre-probe-balloon-settle-ms must be less than or equal to \(maxPreProbeBalloonSettleMS)")
+    }
     if opts.consoleLogPath.isEmpty {
         opts.consoleLogPath = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("darwin-vz-minimal-\(UUID().uuidString).console.log")
@@ -438,7 +445,7 @@ private func readLine(fd: Int32, buffer: inout Data, deadline: Date) throws -> D
     }
 }
 
-private func buildVM(opts: Options, queue: DispatchQueue) throws -> VMHandle {
+private func buildVM(opts: Options, queue: DispatchQueue, excludedVirtualizationPIDs: Set<pid_t>) throws -> VMHandle {
     guard VZVirtualMachine.isSupported else {
         throw BaselineError.vm("Virtualization.framework is not supported on this host")
     }
@@ -475,7 +482,11 @@ private func buildVM(opts: Options, queue: DispatchQueue) throws -> VMHandle {
     config.socketDevices = [VZVirtioSocketDeviceConfiguration()]
 
     try config.validate()
-    return VMHandle(vm: VZVirtualMachine(configuration: config, queue: queue), queue: queue)
+    return VMHandle(
+        vm: VZVirtualMachine(configuration: config, queue: queue),
+        queue: queue,
+        excludedVirtualizationPIDs: excludedVirtualizationPIDs
+    )
 }
 
 private func startVM(_ handle: VMHandle, timeoutSeconds: Double) throws {
@@ -612,6 +623,27 @@ private func sampleHostMemory(label: String, start: UInt64, virtualizationPIDs: 
     )
 }
 
+private func sampleVirtualMachineHostMemory(label: String, start: UInt64, handle: VMHandle) throws -> HostMemorySample {
+    if handle.virtualizationPIDs.isEmpty {
+        handle.virtualizationPIDs = discoverVirtualizationMachinePIDs(
+            excluding: handle.excludedVirtualizationPIDs,
+            timeoutSeconds: 0.5
+        )
+    }
+    var sample = try sampleHostMemory(label: label, start: start, virtualizationPIDs: handle.virtualizationPIDs)
+    if sample.virtualizationPIDs.isEmpty {
+        handle.virtualizationPIDs = discoverVirtualizationMachinePIDs(
+            excluding: handle.excludedVirtualizationPIDs,
+            timeoutSeconds: 0.5
+        )
+        sample = try sampleHostMemory(label: label, start: start, virtualizationPIDs: handle.virtualizationPIDs)
+    }
+    if sample.virtualizationPIDs.isEmpty {
+        throw BaselineError.vm("unable to sample Virtualization.framework helper process for \(label)")
+    }
+    return sample
+}
+
 private func setBalloonTarget(handle: VMHandle, targetMiB: UInt64) throws {
     let sem = DispatchSemaphore(value: 0)
     var targetError: Error?
@@ -672,11 +704,11 @@ private func consumeGuestMemoryLines(
         }
         let event = try JSONDecoder().decode(GuestMemoryEvent.self, from: line)
         events.append(event)
-        hostSamples.append(try sampleHostMemory(label: "guest:\(event.phase)", start: start, virtualizationPIDs: handle.virtualizationPIDs))
+        hostSamples.append(try sampleVirtualMachineHostMemory(label: "guest:\(event.phase)", start: start, handle: handle))
         if event.phase == "freed", let targetMiB = opts.balloonTargetMiB, !balloonTargetApplied {
             try setBalloonTarget(handle: handle, targetMiB: targetMiB)
             balloonTargetApplied = true
-            hostSamples.append(try sampleHostMemory(label: "balloon_target:\(targetMiB)mib", start: start, virtualizationPIDs: handle.virtualizationPIDs))
+            hostSamples.append(try sampleVirtualMachineHostMemory(label: "balloon_target:\(targetMiB)mib", start: start, handle: handle))
         }
     }
 }
@@ -698,12 +730,12 @@ private func probeGuest(
             usleep(useconds_t(opts.preProbeBalloonSettleMS * 1000))
         }
         if opts.probe == "memory-reporting" {
-            hostSamples.append(try sampleHostMemory(label: "balloon_pre_probe:\(targetMiB)mib", start: start, virtualizationPIDs: handle.virtualizationPIDs))
+            hostSamples.append(try sampleVirtualMachineHostMemory(label: "balloon_pre_probe:\(targetMiB)mib", start: start, handle: handle))
         }
     }
     try writeExecRequest(connection: connection, command: probeCommand(opts: opts))
     if opts.probe == "memory-reporting" {
-        hostSamples.append(try sampleHostMemory(label: "probe:request_sent", start: start, virtualizationPIDs: handle.virtualizationPIDs))
+        hostSamples.append(try sampleVirtualMachineHostMemory(label: "probe:request_sent", start: start, handle: handle))
     }
     var balloonTargetApplied = false
     while true {
@@ -745,7 +777,7 @@ do {
     if opts.probe == "memory-reporting" {
         hostSamples.append(try sampleHostMemory(label: "host:before_vm", start: t0, virtualizationPIDs: []))
     }
-    let handle = try buildVM(opts: opts, queue: queue)
+    let handle = try buildVM(opts: opts, queue: queue, excludedVirtualizationPIDs: preexistingVirtualizationPIDs)
     defer { handle.stop() }
 
     if let targetMiB = opts.initialBalloonTargetMiB {
@@ -759,7 +791,7 @@ do {
     let startMS = msSince(t0)
     handle.virtualizationPIDs = discoverVirtualizationMachinePIDs(excluding: preexistingVirtualizationPIDs, timeoutSeconds: 2.0)
     if opts.probe == "memory-reporting" {
-        hostSamples.append(try sampleHostMemory(label: "vm:started", start: t0, virtualizationPIDs: handle.virtualizationPIDs))
+        hostSamples.append(try sampleVirtualMachineHostMemory(label: "vm:started", start: t0, handle: handle))
     }
 
     let connection = try connectVsock(
@@ -771,13 +803,13 @@ do {
     defer { connection.close() }
     let connectMS = msSince(t0)
     if opts.probe == "memory-reporting" {
-        hostSamples.append(try sampleHostMemory(label: "vsock:connected", start: t0, virtualizationPIDs: handle.virtualizationPIDs))
+        hostSamples.append(try sampleVirtualMachineHostMemory(label: "vsock:connected", start: t0, handle: handle))
     }
 
     let outcome = try probeGuest(handle: handle, connection: connection, opts: opts, start: t0)
     hostSamples.append(contentsOf: outcome.hostMemorySamples)
     if opts.probe == "memory-reporting" {
-        hostSamples.append(try sampleHostMemory(label: "probe:exit", start: t0, virtualizationPIDs: handle.virtualizationPIDs))
+        hostSamples.append(try sampleVirtualMachineHostMemory(label: "probe:exit", start: t0, handle: handle))
     }
     let execResponseMS = msSince(t0)
 

--- a/benchmarks/darwin-vz/minimal/runner.swift
+++ b/benchmarks/darwin-vz/minimal/runner.swift
@@ -2,7 +2,7 @@ import Darwin
 import Foundation
 import Virtualization
 
-private let maxPreProbeBalloonSettleMS = UInt64(useconds_t.max) / 1000
+private let maxPreProbeBalloonSettleMS = UInt64(Int32.max)
 
 private struct Options {
     var kernelPath = ""
@@ -377,6 +377,24 @@ private func msSince(_ start: UInt64) -> Double {
     Double(now() - start) / 1_000_000.0
 }
 
+private func sleepMilliseconds(_ milliseconds: UInt64) throws {
+    if milliseconds == 0 {
+        return
+    }
+    var request = timespec(
+        tv_sec: time_t(milliseconds / 1000),
+        tv_nsec: CLong((milliseconds % 1000) * 1_000_000)
+    )
+    var remaining = timespec()
+    while Darwin.nanosleep(&request, &remaining) != 0 {
+        if errno == EINTR {
+            request = remaining
+            continue
+        }
+        throw BaselineError.posix("nanosleep", errno)
+    }
+}
+
 private func writeAll(fd: Int32, bytes: [UInt8]) throws {
     var written = 0
     while written < bytes.count {
@@ -727,7 +745,7 @@ private func probeGuest(
     if let targetMiB = opts.preProbeBalloonTargetMiB {
         try setBalloonTarget(handle: handle, targetMiB: targetMiB)
         if opts.preProbeBalloonSettleMS > 0 {
-            usleep(useconds_t(opts.preProbeBalloonSettleMS * 1000))
+            try sleepMilliseconds(opts.preProbeBalloonSettleMS)
         }
         if opts.probe == "memory-reporting" {
             hostSamples.append(try sampleVirtualMachineHostMemory(label: "balloon_pre_probe:\(targetMiB)mib", start: start, handle: handle))

--- a/benchmarks/darwin-vz/minimal/runner.swift
+++ b/benchmarks/darwin-vz/minimal/runner.swift
@@ -11,11 +11,22 @@ private struct Options {
     var guestPort: UInt32 = 10700
     var vcpus = 2
     var memoryMiB: UInt64 = 1024
+    var probe = "exec"
+    var probeMemoryMiB: UInt64 = 256
+    var probePreTouchMS: UInt64 = 500
+    var probeHoldMS: UInt64 = 1000
+    var probePostFreeMS: UInt64 = 3000
+    var balloonDevice = true
+    var initialBalloonTargetMiB: UInt64?
+    var preProbeBalloonTargetMiB: UInt64?
+    var preProbeBalloonSettleMS: UInt64 = 1000
+    var balloonTargetMiB: UInt64?
     var timeoutSeconds = 30.0
     var connectIntervalMS: useconds_t = 10
 }
 
 private struct ProbeResult: Encodable {
+    let probe: String
     let startMS: Double
     let vsockConnectMS: Double
     let execResponseMS: Double
@@ -23,10 +34,18 @@ private struct ProbeResult: Encodable {
     let exitCode: Int
     let error: String?
     let guestTimingMS: [String: Int64]?
+    let guestMemoryEvents: [GuestMemoryEvent]?
+    let hostMemorySamples: [HostMemorySample]?
     let vcpus: Int
     let memoryMiB: UInt64
+    let balloonDevice: Bool
+    let initialBalloonTargetMiB: UInt64?
+    let preProbeBalloonTargetMiB: UInt64?
+    let preProbeBalloonSettleMS: UInt64
+    let balloonTargetMiB: UInt64?
 
     enum CodingKeys: String, CodingKey {
+        case probe
         case startMS = "start_ms"
         case vsockConnectMS = "vsock_connect_ms"
         case execResponseMS = "exec_response_ms"
@@ -34,23 +53,86 @@ private struct ProbeResult: Encodable {
         case exitCode = "exit_code"
         case error
         case guestTimingMS = "guest_timing_ms"
+        case guestMemoryEvents = "guest_memory_events"
+        case hostMemorySamples = "host_memory_samples"
         case vcpus
         case memoryMiB = "memory_mib"
+        case balloonDevice = "balloon_device"
+        case initialBalloonTargetMiB = "initial_balloon_target_mib"
+        case preProbeBalloonTargetMiB = "pre_probe_balloon_target_mib"
+        case preProbeBalloonSettleMS = "pre_probe_balloon_settle_ms"
+        case balloonTargetMiB = "balloon_target_mib"
+    }
+}
+
+private struct ExecRequest: Encodable {
+    let command: [String]
+    let closedEnv: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case command
+        case closedEnv = "closed_env"
     }
 }
 
 private struct ExecFrame: Decodable {
     let type: String
+    let data: Data?
     let exitCode: Int?
     let error: String?
     let guestTimingMS: [String: Int64]?
 
     enum CodingKeys: String, CodingKey {
         case type
+        case data
         case exitCode = "exit_code"
         case error
         case guestTimingMS = "guest_timing_ms"
     }
+}
+
+private struct HostMemorySample: Encodable {
+    let label: String
+    let elapsedMS: Double
+    let runnerResidentSizeBytes: UInt64
+    let runnerPhysFootprintBytes: UInt64
+    let virtualizationResidentSizeBytes: UInt64
+    let virtualizationPhysFootprintBytes: UInt64
+    let virtualizationPIDs: [Int32]
+
+    enum CodingKeys: String, CodingKey {
+        case label
+        case elapsedMS = "elapsed_ms"
+        case runnerResidentSizeBytes = "runner_resident_size_bytes"
+        case runnerPhysFootprintBytes = "runner_phys_footprint_bytes"
+        case virtualizationResidentSizeBytes = "virtualization_resident_size_bytes"
+        case virtualizationPhysFootprintBytes = "virtualization_phys_footprint_bytes"
+        case virtualizationPIDs = "virtualization_pids"
+    }
+}
+
+private struct GuestMemoryEvent: Codable {
+    let phase: String
+    let elapsedMS: Int64
+    let allocatedMiB: UInt64?
+    let meminfo: [String: UInt64]?
+    let error: String?
+
+    enum CodingKeys: String, CodingKey {
+        case phase
+        case elapsedMS = "elapsed_ms"
+        case allocatedMiB = "allocated_mib"
+        case meminfo
+        case error
+    }
+}
+
+private struct ProbeOutcome {
+    let exitCode: Int
+    let error: String?
+    let guestTimingMS: [String: Int64]?
+    let guestMemoryEvents: [GuestMemoryEvent]
+    let hostMemorySamples: [HostMemorySample]
 }
 
 private enum BaselineError: LocalizedError {
@@ -113,11 +195,24 @@ private func usage() -> String {
       --guest-port <port>         Guest vsock port. Default: 10700.
       --vcpus <count>            vCPU count. Default: 2.
       --memory-mib <mib>         Guest memory. Default: 1024.
+      --probe <name>             Probe to run: exec or memory-reporting. Default: exec.
+      --probe-memory-mib <mib>   Memory touched by memory-reporting probe. Default: 256.
+      --probe-pre-touch-ms <ms>  Delay after the before sample. Default: 500.
+      --probe-hold-ms <ms>       Delay after touching memory. Default: 1000.
+      --probe-post-free-ms <ms>  Delay after freeing memory. Default: 3000.
+      --balloon-device <on|off>  Attach the VZ virtio memory balloon. Default: on.
+      --initial-balloon-target-mib <mib>
+                                  Set VZ balloon target before VM start.
+      --pre-probe-balloon-target-mib <mib>
+                                  Set VZ balloon target before running the probe.
+      --pre-probe-balloon-settle-ms <ms>
+                                  Delay after pre-probe balloon target. Default: 1000.
+      --balloon-target-mib <mib> Set explicit VZ balloon target after the guest frees memory.
       --timeout <seconds>        Start/probe timeout. Default: 30.
 
     The rootfs mode must already contain Cleanroom's guest runtime. Use a writable throwaway copy.
     The initrd mode expects an /init process that accepts Cleanroom's guest exec JSON protocol on vsock.
-    The measured probe boots the VM, connects to the guest agent over vsock, runs /bin/true, and prints JSON timings.
+    The exec probe runs /bin/true. The memory-reporting probe runs /bin/memprobe and samples host footprint while guest memory is touched and freed.
     """
 }
 
@@ -160,6 +255,60 @@ private func parseOptions(_ args: [String]) throws -> Options {
                 throw BaselineError.invalid("invalid --memory-mib")
             }
             opts.memoryMiB = memory
+        case "--probe":
+            opts.probe = try value()
+            guard ["exec", "memory-reporting"].contains(opts.probe) else {
+                throw BaselineError.invalid("invalid --probe")
+            }
+        case "--probe-memory-mib":
+            guard let memory = UInt64(try value()), memory > 0 else {
+                throw BaselineError.invalid("invalid --probe-memory-mib")
+            }
+            opts.probeMemoryMiB = memory
+        case "--probe-pre-touch-ms":
+            guard let preTouch = UInt64(try value()) else {
+                throw BaselineError.invalid("invalid --probe-pre-touch-ms")
+            }
+            opts.probePreTouchMS = preTouch
+        case "--probe-hold-ms":
+            guard let hold = UInt64(try value()) else {
+                throw BaselineError.invalid("invalid --probe-hold-ms")
+            }
+            opts.probeHoldMS = hold
+        case "--probe-post-free-ms":
+            guard let postFree = UInt64(try value()) else {
+                throw BaselineError.invalid("invalid --probe-post-free-ms")
+            }
+            opts.probePostFreeMS = postFree
+        case "--balloon-device":
+            switch try value() {
+            case "on":
+                opts.balloonDevice = true
+            case "off":
+                opts.balloonDevice = false
+            default:
+                throw BaselineError.invalid("invalid --balloon-device")
+            }
+        case "--initial-balloon-target-mib":
+            guard let memory = UInt64(try value()), memory > 0 else {
+                throw BaselineError.invalid("invalid --initial-balloon-target-mib")
+            }
+            opts.initialBalloonTargetMiB = memory
+        case "--pre-probe-balloon-target-mib":
+            guard let memory = UInt64(try value()), memory > 0 else {
+                throw BaselineError.invalid("invalid --pre-probe-balloon-target-mib")
+            }
+            opts.preProbeBalloonTargetMiB = memory
+        case "--pre-probe-balloon-settle-ms":
+            guard let settle = UInt64(try value()) else {
+                throw BaselineError.invalid("invalid --pre-probe-balloon-settle-ms")
+            }
+            opts.preProbeBalloonSettleMS = settle
+        case "--balloon-target-mib":
+            guard let memory = UInt64(try value()), memory > 0 else {
+                throw BaselineError.invalid("invalid --balloon-target-mib")
+            }
+            opts.balloonTargetMiB = memory
         case "--timeout":
             guard let timeout = Double(try value()), timeout > 0 else {
                 throw BaselineError.invalid("invalid --timeout")
@@ -175,6 +324,27 @@ private func parseOptions(_ args: [String]) throws -> Options {
 
     if opts.kernelPath.isEmpty || (opts.rootFSPath.isEmpty && opts.initrdPath.isEmpty) {
         throw BaselineError.usage("missing --kernel and either --rootfs or --initrd\n\n\(usage())")
+    }
+    if opts.probe == "memory-reporting" && !opts.rootFSPath.isEmpty {
+        throw BaselineError.invalid("memory-reporting probe currently requires initrd mode")
+    }
+    if opts.probe == "memory-reporting" && opts.probeMemoryMiB >= opts.memoryMiB {
+        throw BaselineError.invalid("--probe-memory-mib must be smaller than --memory-mib")
+    }
+    if let balloonTargetMiB = opts.balloonTargetMiB, balloonTargetMiB > opts.memoryMiB {
+        throw BaselineError.invalid("--balloon-target-mib must be less than or equal to --memory-mib")
+    }
+    if let targetMiB = opts.initialBalloonTargetMiB, targetMiB > opts.memoryMiB {
+        throw BaselineError.invalid("--initial-balloon-target-mib must be less than or equal to --memory-mib")
+    }
+    if let targetMiB = opts.preProbeBalloonTargetMiB, targetMiB > opts.memoryMiB {
+        throw BaselineError.invalid("--pre-probe-balloon-target-mib must be less than or equal to --memory-mib")
+    }
+    if !opts.balloonDevice && (opts.initialBalloonTargetMiB != nil || opts.preProbeBalloonTargetMiB != nil || opts.balloonTargetMiB != nil) {
+        throw BaselineError.invalid("balloon target options require --balloon-device on")
+    }
+    if opts.balloonTargetMiB != nil && opts.probe != "memory-reporting" {
+        throw BaselineError.invalid("--balloon-target-mib requires --probe memory-reporting")
     }
     if opts.consoleLogPath.isEmpty {
         opts.consoleLogPath = URL(fileURLWithPath: NSTemporaryDirectory())
@@ -298,7 +468,9 @@ private func buildVM(opts: Options, queue: DispatchQueue) throws -> VMHandle {
         config.storageDevices = [VZVirtioBlockDeviceConfiguration(attachment: disk)]
     }
     config.entropyDevices = [VZVirtioEntropyDeviceConfiguration()]
-    config.memoryBalloonDevices = [VZVirtioTraditionalMemoryBalloonDeviceConfiguration()]
+    if opts.balloonDevice {
+        config.memoryBalloonDevices = [VZVirtioTraditionalMemoryBalloonDeviceConfiguration()]
+    }
     config.socketDevices = [VZVirtioSocketDeviceConfiguration()]
 
     try config.validate()
@@ -360,20 +532,192 @@ private func connectVsock(handle: VMHandle, port: UInt32, timeoutSeconds: Double
     throw BaselineError.timeout("timed out connecting to guest vsock port \(port)")
 }
 
-private func probeGuest(connection: VZVirtioSocketConnection, timeoutSeconds: Double) throws -> (Int, String?, [String: Int64]?) {
-    let request = #"{"command":["/bin/true"],"closed_env":true}"# + "\n"
-    try writeAll(fd: connection.fileDescriptor, bytes: Array(request.utf8))
+private struct ProcessMemory {
+    let residentSizeBytes: UInt64
+    let physFootprintBytes: UInt64
+}
 
-    let deadline = Date().addingTimeInterval(timeoutSeconds)
+private func sampleProcessMemory(pid: pid_t) throws -> ProcessMemory {
+    var info = rusage_info_current()
+    let rc = withUnsafeMutablePointer(to: &info) { ptr in
+        ptr.withMemoryRebound(
+            to: rusage_info_t?.self,
+            capacity: MemoryLayout<rusage_info_current>.stride / MemoryLayout<rusage_info_t?>.stride
+        ) { rebound in
+            proc_pid_rusage(pid, RUSAGE_INFO_CURRENT, rebound)
+        }
+    }
+    if rc != 0 {
+        throw BaselineError.posix("proc_pid_rusage", errno)
+    }
+    return ProcessMemory(residentSizeBytes: info.ri_resident_size, physFootprintBytes: info.ri_phys_footprint)
+}
+
+private func virtualizationMachinePIDs() -> [pid_t] {
+    let process = Process()
+    let output = Pipe()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/pgrep")
+    process.arguments = ["-f", "com.apple.Virtualization.VirtualMachine"]
+    process.standardOutput = output
+    process.standardError = FileHandle.nullDevice
+    do {
+        try process.run()
+    } catch {
+        return []
+    }
+    process.waitUntilExit()
+    if process.terminationStatus != 0 {
+        return []
+    }
+    let data = output.fileHandleForReading.readDataToEndOfFile()
+    let raw = String(data: data, encoding: .utf8) ?? ""
+    return raw
+        .split(whereSeparator: \.isNewline)
+        .compactMap { pid_t(String($0).trimmingCharacters(in: .whitespacesAndNewlines)) }
+        .filter { $0 > 0 && $0 != getpid() }
+}
+
+private func sampleHostMemory(label: String, start: UInt64) throws -> HostMemorySample {
+    let runner = try sampleProcessMemory(pid: getpid())
+    let virtualization = virtualizationMachinePIDs()
+        .compactMap { pid -> (pid_t, ProcessMemory)? in
+            guard let sample = try? sampleProcessMemory(pid: pid) else {
+                return nil
+            }
+            return (pid, sample)
+        }
+    let virtualizationResident = virtualization.reduce(UInt64(0)) { $0 + $1.1.residentSizeBytes }
+    let virtualizationFootprint = virtualization.reduce(UInt64(0)) { $0 + $1.1.physFootprintBytes }
+    return HostMemorySample(
+        label: label,
+        elapsedMS: msSince(start),
+        runnerResidentSizeBytes: runner.residentSizeBytes,
+        runnerPhysFootprintBytes: runner.physFootprintBytes,
+        virtualizationResidentSizeBytes: virtualizationResident,
+        virtualizationPhysFootprintBytes: virtualizationFootprint,
+        virtualizationPIDs: virtualization.map { $0.0 }
+    )
+}
+
+private func setBalloonTarget(handle: VMHandle, targetMiB: UInt64) throws {
+    let sem = DispatchSemaphore(value: 0)
+    var targetError: Error?
+    handle.queue.async {
+        guard let balloon = handle.vm.memoryBalloonDevices.first as? VZVirtioTraditionalMemoryBalloonDevice else {
+            targetError = BaselineError.vm("--balloon-target-mib requires --balloon-device on")
+            sem.signal()
+            return
+        }
+        balloon.targetVirtualMachineMemorySize = targetMiB * 1024 * 1024
+        sem.signal()
+    }
+    _ = sem.wait(timeout: .now() + .seconds(1))
+    if let targetError {
+        throw targetError
+    }
+}
+
+private func probeCommand(opts: Options) -> [String] {
+    if opts.probe == "memory-reporting" {
+        return [
+            "/bin/memprobe",
+            "--touch-mib",
+            String(opts.probeMemoryMiB),
+            "--pre-touch-ms",
+            String(opts.probePreTouchMS),
+            "--hold-ms",
+            String(opts.probeHoldMS),
+            "--post-free-ms",
+            String(opts.probePostFreeMS),
+        ]
+    }
+    return ["/bin/true"]
+}
+
+private func writeExecRequest(connection: VZVirtioSocketConnection, command: [String]) throws {
+    let request = ExecRequest(command: command, closedEnv: true)
+    let encoded = try JSONEncoder().encode(request)
+    try writeAll(fd: connection.fileDescriptor, bytes: Array(encoded) + [0x0A])
+}
+
+private func consumeGuestMemoryLines(
+    from stdout: inout Data,
+    events: inout [GuestMemoryEvent],
+    hostSamples: inout [HostMemorySample],
+    handle: VMHandle,
+    opts: Options,
+    start: UInt64,
+    balloonTargetApplied: inout Bool
+) throws {
+    while let newline = stdout.firstIndex(of: 0x0A) {
+        let line = stdout.subdata(in: 0..<newline)
+        stdout.removeSubrange(0...newline)
+        if line.isEmpty {
+            continue
+        }
+        let event = try JSONDecoder().decode(GuestMemoryEvent.self, from: line)
+        events.append(event)
+        hostSamples.append(try sampleHostMemory(label: "guest:\(event.phase)", start: start))
+        if event.phase == "freed", let targetMiB = opts.balloonTargetMiB, !balloonTargetApplied {
+            try setBalloonTarget(handle: handle, targetMiB: targetMiB)
+            balloonTargetApplied = true
+            hostSamples.append(try sampleHostMemory(label: "balloon_target:\(targetMiB)mib", start: start))
+        }
+    }
+}
+
+private func probeGuest(
+    handle: VMHandle,
+    connection: VZVirtioSocketConnection,
+    opts: Options,
+    start: UInt64
+) throws -> ProbeOutcome {
+    try writeExecRequest(connection: connection, command: probeCommand(opts: opts))
+
+    let deadline = Date().addingTimeInterval(opts.timeoutSeconds)
     var buffer = Data()
+    var stdout = Data()
+    var guestMemoryEvents: [GuestMemoryEvent] = []
+    var hostSamples: [HostMemorySample] = []
+    if let targetMiB = opts.preProbeBalloonTargetMiB {
+        try setBalloonTarget(handle: handle, targetMiB: targetMiB)
+        if opts.preProbeBalloonSettleMS > 0 {
+            usleep(useconds_t(opts.preProbeBalloonSettleMS * 1000))
+        }
+        if opts.probe == "memory-reporting" {
+            hostSamples.append(try sampleHostMemory(label: "balloon_pre_probe:\(targetMiB)mib", start: start))
+        }
+    }
+    if opts.probe == "memory-reporting" {
+        hostSamples.append(try sampleHostMemory(label: "probe:request_sent", start: start))
+    }
+    var balloonTargetApplied = false
     while true {
         let line = try readLine(fd: connection.fileDescriptor, buffer: &buffer, deadline: deadline)
         if line.isEmpty {
             continue
         }
         let frame = try JSONDecoder().decode(ExecFrame.self, from: line)
+        if opts.probe == "memory-reporting", frame.type == "stdout", let data = frame.data {
+            stdout.append(data)
+            try consumeGuestMemoryLines(
+                from: &stdout,
+                events: &guestMemoryEvents,
+                hostSamples: &hostSamples,
+                handle: handle,
+                opts: opts,
+                start: start,
+                balloonTargetApplied: &balloonTargetApplied
+            )
+        }
         if frame.type == "exit" {
-            return (frame.exitCode ?? 0, frame.error, frame.guestTimingMS)
+            return ProbeOutcome(
+                exitCode: frame.exitCode ?? 0,
+                error: frame.error,
+                guestTimingMS: frame.guestTimingMS,
+                guestMemoryEvents: guestMemoryEvents,
+                hostMemorySamples: hostSamples
+            )
         }
     }
 }
@@ -382,11 +726,25 @@ do {
     let opts = try parseOptions(Array(CommandLine.arguments.dropFirst()))
     let queue = DispatchQueue(label: "cleanroom.benchmark.darwin-vz-minimal.vm")
     let t0 = now()
+    var hostSamples: [HostMemorySample] = []
+    if opts.probe == "memory-reporting" {
+        hostSamples.append(try sampleHostMemory(label: "host:before_vm", start: t0))
+    }
     let handle = try buildVM(opts: opts, queue: queue)
     defer { handle.stop() }
 
+    if let targetMiB = opts.initialBalloonTargetMiB {
+        try setBalloonTarget(handle: handle, targetMiB: targetMiB)
+        if opts.probe == "memory-reporting" {
+            hostSamples.append(try sampleHostMemory(label: "balloon_initial:\(targetMiB)mib", start: t0))
+        }
+    }
+
     try startVM(handle, timeoutSeconds: opts.timeoutSeconds)
     let startMS = msSince(t0)
+    if opts.probe == "memory-reporting" {
+        hostSamples.append(try sampleHostMemory(label: "vm:started", start: t0))
+    }
 
     let connection = try connectVsock(
         handle: handle,
@@ -396,24 +754,39 @@ do {
     )
     defer { connection.close() }
     let connectMS = msSince(t0)
+    if opts.probe == "memory-reporting" {
+        hostSamples.append(try sampleHostMemory(label: "vsock:connected", start: t0))
+    }
 
-    let (exitCode, error, guestTimingMS) = try probeGuest(connection: connection, timeoutSeconds: opts.timeoutSeconds)
+    let outcome = try probeGuest(handle: handle, connection: connection, opts: opts, start: t0)
+    hostSamples.append(contentsOf: outcome.hostMemorySamples)
+    if opts.probe == "memory-reporting" {
+        hostSamples.append(try sampleHostMemory(label: "probe:exit", start: t0))
+    }
     let execResponseMS = msSince(t0)
 
     let result = ProbeResult(
+        probe: opts.probe,
         startMS: startMS,
         vsockConnectMS: connectMS,
         execResponseMS: execResponseMS,
         probeDurationMS: execResponseMS - connectMS,
-        exitCode: exitCode,
-        error: error,
-        guestTimingMS: guestTimingMS,
+        exitCode: outcome.exitCode,
+        error: outcome.error,
+        guestTimingMS: outcome.guestTimingMS,
+        guestMemoryEvents: outcome.guestMemoryEvents.isEmpty ? nil : outcome.guestMemoryEvents,
+        hostMemorySamples: hostSamples.isEmpty ? nil : hostSamples,
         vcpus: opts.vcpus,
-        memoryMiB: opts.memoryMiB
+        memoryMiB: opts.memoryMiB,
+        balloonDevice: opts.balloonDevice,
+        initialBalloonTargetMiB: opts.initialBalloonTargetMiB,
+        preProbeBalloonTargetMiB: opts.preProbeBalloonTargetMiB,
+        preProbeBalloonSettleMS: opts.preProbeBalloonSettleMS,
+        balloonTargetMiB: opts.balloonTargetMiB
     )
     let encoded = try JSONEncoder().encode(result)
     print(String(data: encoded, encoding: .utf8)!)
-    if exitCode != 0 {
+    if outcome.exitCode != 0 {
         Foundation.exit(1)
     }
 } catch BaselineError.usage(let message) {

--- a/benchmarks/darwin-vz/minimal/runner.swift
+++ b/benchmarks/darwin-vz/minimal/runner.swift
@@ -624,7 +624,9 @@ private func setBalloonTarget(handle: VMHandle, targetMiB: UInt64) throws {
         balloon.targetVirtualMachineMemorySize = targetMiB * 1024 * 1024
         sem.signal()
     }
-    _ = sem.wait(timeout: .now() + .seconds(1))
+    if sem.wait(timeout: .now() + .seconds(1)) == .timedOut {
+        throw BaselineError.timeout("timed out setting balloon target to \(targetMiB) MiB")
+    }
     if let targetError {
         throw targetError
     }

--- a/benchmarks/darwin-vz/minimal/runner.swift
+++ b/benchmarks/darwin-vz/minimal/runner.swift
@@ -685,8 +685,6 @@ private func probeGuest(
     opts: Options,
     start: UInt64
 ) throws -> ProbeOutcome {
-    try writeExecRequest(connection: connection, command: probeCommand(opts: opts))
-
     let deadline = Date().addingTimeInterval(opts.timeoutSeconds)
     var buffer = Data()
     var stdout = Data()
@@ -701,6 +699,7 @@ private func probeGuest(
             hostSamples.append(try sampleHostMemory(label: "balloon_pre_probe:\(targetMiB)mib", start: start, virtualizationPIDs: handle.virtualizationPIDs))
         }
     }
+    try writeExecRequest(connection: connection, command: probeCommand(opts: opts))
     if opts.probe == "memory-reporting" {
         hostSamples.append(try sampleHostMemory(label: "probe:request_sent", start: start, virtualizationPIDs: handle.virtualizationPIDs))
     }

--- a/benchmarks/darwin-vz/minimal/runner.swift
+++ b/benchmarks/darwin-vz/minimal/runner.swift
@@ -155,6 +155,7 @@ private enum BaselineError: LocalizedError {
 private final class VMHandle {
     let vm: VZVirtualMachine
     let queue: DispatchQueue
+    var virtualizationPIDs: [pid_t] = []
 
     init(vm: VZVirtualMachine, queue: DispatchQueue) {
         self.vm = vm
@@ -577,15 +578,27 @@ private func virtualizationMachinePIDs() -> [pid_t] {
         .filter { $0 > 0 && $0 != getpid() }
 }
 
-private func sampleHostMemory(label: String, start: UInt64) throws -> HostMemorySample {
-    let runner = try sampleProcessMemory(pid: getpid())
-    let virtualization = virtualizationMachinePIDs()
-        .compactMap { pid -> (pid_t, ProcessMemory)? in
-            guard let sample = try? sampleProcessMemory(pid: pid) else {
-                return nil
-            }
-            return (pid, sample)
+private func discoverVirtualizationMachinePIDs(excluding excludedPIDs: Set<pid_t>, timeoutSeconds: Double) -> [pid_t] {
+    let deadline = Date().addingTimeInterval(timeoutSeconds)
+    var discovered: [pid_t] = []
+    repeat {
+        discovered = virtualizationMachinePIDs().filter { !excludedPIDs.contains($0) }
+        if !discovered.isEmpty {
+            return discovered
         }
+        usleep(20_000)
+    } while Date() < deadline
+    return discovered
+}
+
+private func sampleHostMemory(label: String, start: UInt64, virtualizationPIDs: [pid_t]) throws -> HostMemorySample {
+    let runner = try sampleProcessMemory(pid: getpid())
+    let virtualization = virtualizationPIDs.compactMap { pid -> (pid_t, ProcessMemory)? in
+        guard let sample = try? sampleProcessMemory(pid: pid) else {
+            return nil
+        }
+        return (pid, sample)
+    }
     let virtualizationResident = virtualization.reduce(UInt64(0)) { $0 + $1.1.residentSizeBytes }
     let virtualizationFootprint = virtualization.reduce(UInt64(0)) { $0 + $1.1.physFootprintBytes }
     return HostMemorySample(
@@ -657,11 +670,11 @@ private func consumeGuestMemoryLines(
         }
         let event = try JSONDecoder().decode(GuestMemoryEvent.self, from: line)
         events.append(event)
-        hostSamples.append(try sampleHostMemory(label: "guest:\(event.phase)", start: start))
+        hostSamples.append(try sampleHostMemory(label: "guest:\(event.phase)", start: start, virtualizationPIDs: handle.virtualizationPIDs))
         if event.phase == "freed", let targetMiB = opts.balloonTargetMiB, !balloonTargetApplied {
             try setBalloonTarget(handle: handle, targetMiB: targetMiB)
             balloonTargetApplied = true
-            hostSamples.append(try sampleHostMemory(label: "balloon_target:\(targetMiB)mib", start: start))
+            hostSamples.append(try sampleHostMemory(label: "balloon_target:\(targetMiB)mib", start: start, virtualizationPIDs: handle.virtualizationPIDs))
         }
     }
 }
@@ -685,11 +698,11 @@ private func probeGuest(
             usleep(useconds_t(opts.preProbeBalloonSettleMS * 1000))
         }
         if opts.probe == "memory-reporting" {
-            hostSamples.append(try sampleHostMemory(label: "balloon_pre_probe:\(targetMiB)mib", start: start))
+            hostSamples.append(try sampleHostMemory(label: "balloon_pre_probe:\(targetMiB)mib", start: start, virtualizationPIDs: handle.virtualizationPIDs))
         }
     }
     if opts.probe == "memory-reporting" {
-        hostSamples.append(try sampleHostMemory(label: "probe:request_sent", start: start))
+        hostSamples.append(try sampleHostMemory(label: "probe:request_sent", start: start, virtualizationPIDs: handle.virtualizationPIDs))
     }
     var balloonTargetApplied = false
     while true {
@@ -726,9 +739,10 @@ do {
     let opts = try parseOptions(Array(CommandLine.arguments.dropFirst()))
     let queue = DispatchQueue(label: "cleanroom.benchmark.darwin-vz-minimal.vm")
     let t0 = now()
+    let preexistingVirtualizationPIDs = Set(virtualizationMachinePIDs())
     var hostSamples: [HostMemorySample] = []
     if opts.probe == "memory-reporting" {
-        hostSamples.append(try sampleHostMemory(label: "host:before_vm", start: t0))
+        hostSamples.append(try sampleHostMemory(label: "host:before_vm", start: t0, virtualizationPIDs: []))
     }
     let handle = try buildVM(opts: opts, queue: queue)
     defer { handle.stop() }
@@ -736,14 +750,15 @@ do {
     if let targetMiB = opts.initialBalloonTargetMiB {
         try setBalloonTarget(handle: handle, targetMiB: targetMiB)
         if opts.probe == "memory-reporting" {
-            hostSamples.append(try sampleHostMemory(label: "balloon_initial:\(targetMiB)mib", start: t0))
+            hostSamples.append(try sampleHostMemory(label: "balloon_initial:\(targetMiB)mib", start: t0, virtualizationPIDs: []))
         }
     }
 
     try startVM(handle, timeoutSeconds: opts.timeoutSeconds)
     let startMS = msSince(t0)
+    handle.virtualizationPIDs = discoverVirtualizationMachinePIDs(excluding: preexistingVirtualizationPIDs, timeoutSeconds: 2.0)
     if opts.probe == "memory-reporting" {
-        hostSamples.append(try sampleHostMemory(label: "vm:started", start: t0))
+        hostSamples.append(try sampleHostMemory(label: "vm:started", start: t0, virtualizationPIDs: handle.virtualizationPIDs))
     }
 
     let connection = try connectVsock(
@@ -755,13 +770,13 @@ do {
     defer { connection.close() }
     let connectMS = msSince(t0)
     if opts.probe == "memory-reporting" {
-        hostSamples.append(try sampleHostMemory(label: "vsock:connected", start: t0))
+        hostSamples.append(try sampleHostMemory(label: "vsock:connected", start: t0, virtualizationPIDs: handle.virtualizationPIDs))
     }
 
     let outcome = try probeGuest(handle: handle, connection: connection, opts: opts, start: t0)
     hostSamples.append(contentsOf: outcome.hostMemorySamples)
     if opts.probe == "memory-reporting" {
-        hostSamples.append(try sampleHostMemory(label: "probe:exit", start: t0))
+        hostSamples.append(try sampleHostMemory(label: "probe:exit", start: t0, virtualizationPIDs: handle.virtualizationPIDs))
     }
     let execResponseMS = msSince(t0)
 

--- a/scripts/benchmark-darwin-vz-minimal.sh
+++ b/scripts/benchmark-darwin-vz-minimal.sh
@@ -18,6 +18,20 @@ Options:
   -n, --iterations <count>  Number of runs (default: 10).
   --vcpus <count>           Guest vCPU count (default: 2).
   --memory-mib <mib>        Guest memory in MiB (default: 1024).
+  --probe <name>            Probe to run: exec or memory-reporting (default: exec).
+  --probe-memory-mib <mib>  Memory touched by memory-reporting probe (default: 256).
+  --probe-pre-touch-ms <ms> Delay after the before sample (default: 500).
+  --probe-hold-ms <ms>      Delay after touching memory (default: 1000).
+  --probe-post-free-ms <ms> Delay after freeing memory (default: 3000).
+  --balloon-device <on|off> Attach the VZ virtio memory balloon (default: on).
+  --initial-balloon-target-mib <mib>
+                            Set VZ balloon target before VM start.
+  --pre-probe-balloon-target-mib <mib>
+                            Set VZ balloon target before running the probe.
+  --pre-probe-balloon-settle-ms <ms>
+                            Delay after pre-probe balloon target (default: 1000).
+  --balloon-target-mib <mib>
+                            Set explicit VZ balloon target after the guest frees memory.
   --boot-args <args>        Full Linux command line override.
   --output-dir <path>       JSONL output directory (default: benchmarks/results).
   -h, --help                Show this help.
@@ -38,6 +52,16 @@ kernel_profile=""
 iterations=10
 vcpus=2
 memory_mib=1024
+probe="exec"
+probe_memory_mib=256
+probe_pre_touch_ms=500
+probe_hold_ms=1000
+probe_post_free_ms=3000
+balloon_device="on"
+initial_balloon_target_mib=""
+pre_probe_balloon_target_mib=""
+pre_probe_balloon_settle_ms=1000
+balloon_target_mib=""
 output_dir="${REPO_ROOT}/benchmarks/results"
 build_kernel=0
 
@@ -73,6 +97,46 @@ while [[ $# -gt 0 ]]; do
       ;;
     --memory-mib)
       memory_mib="$2"
+      shift 2
+      ;;
+    --probe)
+      probe="$2"
+      shift 2
+      ;;
+    --probe-memory-mib)
+      probe_memory_mib="$2"
+      shift 2
+      ;;
+    --probe-pre-touch-ms)
+      probe_pre_touch_ms="$2"
+      shift 2
+      ;;
+    --probe-hold-ms)
+      probe_hold_ms="$2"
+      shift 2
+      ;;
+    --probe-post-free-ms)
+      probe_post_free_ms="$2"
+      shift 2
+      ;;
+    --balloon-device)
+      balloon_device="$2"
+      shift 2
+      ;;
+    --initial-balloon-target-mib)
+      initial_balloon_target_mib="$2"
+      shift 2
+      ;;
+    --pre-probe-balloon-target-mib)
+      pre_probe_balloon_target_mib="$2"
+      shift 2
+      ;;
+    --pre-probe-balloon-settle-ms)
+      pre_probe_balloon_settle_ms="$2"
+      shift 2
+      ;;
+    --balloon-target-mib)
+      balloon_target_mib="$2"
       shift 2
       ;;
     --boot-args)
@@ -115,9 +179,66 @@ run_repo_tool() {
 require_positive_int "iterations" "${iterations}"
 require_positive_int "vcpus" "${vcpus}"
 require_positive_int "memory-mib" "${memory_mib}"
+require_positive_int "probe-memory-mib" "${probe_memory_mib}"
+require_positive_int "probe-pre-touch-ms" "${probe_pre_touch_ms}"
+require_positive_int "probe-hold-ms" "${probe_hold_ms}"
+require_positive_int "probe-post-free-ms" "${probe_post_free_ms}"
+require_positive_int "pre-probe-balloon-settle-ms" "${pre_probe_balloon_settle_ms}"
+
+case "${probe}" in
+  exec|memory-reporting) ;;
+  *)
+    echo "unsupported --probe: ${probe}" >&2
+    exit 1
+    ;;
+esac
+case "${balloon_device}" in
+  on|off) ;;
+  *)
+    echo "unsupported --balloon-device: ${balloon_device}" >&2
+    exit 1
+    ;;
+esac
+if [[ -n "${balloon_target_mib}" ]]; then
+  require_positive_int "balloon-target-mib" "${balloon_target_mib}"
+fi
+if [[ -n "${initial_balloon_target_mib}" ]]; then
+  require_positive_int "initial-balloon-target-mib" "${initial_balloon_target_mib}"
+fi
+if [[ -n "${pre_probe_balloon_target_mib}" ]]; then
+  require_positive_int "pre-probe-balloon-target-mib" "${pre_probe_balloon_target_mib}"
+fi
+if [[ "${probe}" == "memory-reporting" && "${probe_memory_mib}" -ge "${memory_mib}" ]]; then
+  echo "--probe-memory-mib must be smaller than --memory-mib" >&2
+  exit 1
+fi
+if [[ -n "${balloon_target_mib}" && "${balloon_target_mib}" -gt "${memory_mib}" ]]; then
+  echo "--balloon-target-mib must be less than or equal to --memory-mib" >&2
+  exit 1
+fi
+if [[ -n "${initial_balloon_target_mib}" && "${initial_balloon_target_mib}" -gt "${memory_mib}" ]]; then
+  echo "--initial-balloon-target-mib must be less than or equal to --memory-mib" >&2
+  exit 1
+fi
+if [[ -n "${pre_probe_balloon_target_mib}" && "${pre_probe_balloon_target_mib}" -gt "${memory_mib}" ]]; then
+  echo "--pre-probe-balloon-target-mib must be less than or equal to --memory-mib" >&2
+  exit 1
+fi
+if [[ "${balloon_device}" == "off" && (-n "${balloon_target_mib}" || -n "${initial_balloon_target_mib}" || -n "${pre_probe_balloon_target_mib}") ]]; then
+  echo "balloon target options require --balloon-device on" >&2
+  exit 1
+fi
+if [[ -n "${balloon_target_mib}" && "${probe}" != "memory-reporting" ]]; then
+  echo "--balloon-target-mib requires --probe memory-reporting" >&2
+  exit 1
+fi
 
 if [[ -n "${initrd_path}" && -n "${rootfs_path}" ]]; then
   echo "--initrd and --rootfs are mutually exclusive" >&2
+  exit 1
+fi
+if [[ "${probe}" == "memory-reporting" && -n "${rootfs_path}" ]]; then
+  echo "--probe memory-reporting currently requires initrd mode" >&2
   exit 1
 fi
 
@@ -205,10 +326,26 @@ for i in $(seq 1 "${iterations}"); do
     "${mode_args[@]}"
     --vcpus "${vcpus}"
     --memory-mib "${memory_mib}"
+    --probe "${probe}"
+    --probe-memory-mib "${probe_memory_mib}"
+    --probe-pre-touch-ms "${probe_pre_touch_ms}"
+    --probe-hold-ms "${probe_hold_ms}"
+    --probe-post-free-ms "${probe_post_free_ms}"
+    --balloon-device "${balloon_device}"
     --console-log "${console_log}"
   )
   if [[ -n "${boot_args}" ]]; then
     runner_args+=(--boot-args "${boot_args}")
+  fi
+  if [[ -n "${initial_balloon_target_mib}" ]]; then
+    runner_args+=(--initial-balloon-target-mib "${initial_balloon_target_mib}")
+  fi
+  if [[ -n "${pre_probe_balloon_target_mib}" ]]; then
+    runner_args+=(--pre-probe-balloon-target-mib "${pre_probe_balloon_target_mib}")
+    runner_args+=(--pre-probe-balloon-settle-ms "${pre_probe_balloon_settle_ms}")
+  fi
+  if [[ -n "${balloon_target_mib}" ]]; then
+    runner_args+=(--balloon-target-mib "${balloon_target_mib}")
   fi
 
   "${runner_path}" "${runner_args[@]}" | tee -a "${output_path}"

--- a/scripts/benchmark-darwin-vz-minimal.sh
+++ b/scripts/benchmark-darwin-vz-minimal.sh
@@ -168,6 +168,15 @@ require_positive_int() {
   fi
 }
 
+require_non_negative_int() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[0-9]+$ ]]; then
+    echo "${name} must be a non-negative integer" >&2
+    exit 1
+  fi
+}
+
 run_repo_tool() {
   if command -v mise >/dev/null 2>&1; then
     mise exec -- "$@"
@@ -180,10 +189,10 @@ require_positive_int "iterations" "${iterations}"
 require_positive_int "vcpus" "${vcpus}"
 require_positive_int "memory-mib" "${memory_mib}"
 require_positive_int "probe-memory-mib" "${probe_memory_mib}"
-require_positive_int "probe-pre-touch-ms" "${probe_pre_touch_ms}"
-require_positive_int "probe-hold-ms" "${probe_hold_ms}"
-require_positive_int "probe-post-free-ms" "${probe_post_free_ms}"
-require_positive_int "pre-probe-balloon-settle-ms" "${pre_probe_balloon_settle_ms}"
+require_non_negative_int "probe-pre-touch-ms" "${probe_pre_touch_ms}"
+require_non_negative_int "probe-hold-ms" "${probe_hold_ms}"
+require_non_negative_int "probe-post-free-ms" "${probe_post_free_ms}"
+require_non_negative_int "pre-probe-balloon-settle-ms" "${pre_probe_balloon_settle_ms}"
 
 case "${probe}" in
   exec|memory-reporting) ;;

--- a/scripts/benchmark_darwin_vz_minimal_test.go
+++ b/scripts/benchmark_darwin_vz_minimal_test.go
@@ -40,6 +40,39 @@ func TestBenchmarkDarwinVZMinimalRejectsInitrdKernelForRootFSBoot(t *testing.T) 
 	requireBenchmarkDarwinVZMinimalFailure(t, out, err, callLog, "--kernel-profile initrd does not match the selected boot medium; expected rootfs")
 }
 
+func TestBenchmarkDarwinVZMinimalAllowsZeroProbeDelays(t *testing.T) {
+	tmpDir := t.TempDir()
+	kernelPath := filepath.Join(tmpDir, "Image")
+	initrdPath := filepath.Join(tmpDir, "initrd.cpio.gz")
+	if err := os.WriteFile(kernelPath, []byte("kernel"), 0o600); err != nil {
+		t.Fatalf("write kernel placeholder: %v", err)
+	}
+	if err := os.WriteFile(initrdPath, []byte("initrd"), 0o600); err != nil {
+		t.Fatalf("write initrd placeholder: %v", err)
+	}
+
+	out, callLog, err := runBenchmarkDarwinVZMinimalExpectingEarlyFailure(t,
+		"--kernel", kernelPath,
+		"--initrd", initrdPath,
+		"--iterations", "1",
+		"--probe", "memory-reporting",
+		"--probe-pre-touch-ms", "0",
+		"--probe-hold-ms", "0",
+		"--probe-post-free-ms", "0",
+		"--pre-probe-balloon-target-mib", "1024",
+		"--pre-probe-balloon-settle-ms", "0",
+	)
+	if err == nil {
+		t.Fatalf("expected fake runner build to fail")
+	}
+	if strings.Contains(string(out), "must be a positive integer") || strings.Contains(string(out), "must be a non-negative integer") {
+		t.Fatalf("expected zero probe delays to pass validation, got:\n%s", out)
+	}
+	if _, err := os.Stat(callLog); err != nil {
+		t.Fatalf("expected runner build to start after zero delay validation, stat xcrun log: %v\n%s", err, out)
+	}
+}
+
 func runBenchmarkDarwinVZMinimalExpectingEarlyFailure(t *testing.T, args ...string) ([]byte, string, error) {
 	t.Helper()
 
@@ -54,6 +87,16 @@ func runBenchmarkDarwinVZMinimalExpectingEarlyFailure(t *testing.T, args ...stri
 set -euo pipefail
 printf '%s\n' "$*" >> "$FAKE_XCRUN_LOG"
 exit 99
+`)
+	writeLocalExecutable(t, binDir, "mise", `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "exec" ]]; then
+  shift
+fi
+if [[ "${1:-}" == "--" ]]; then
+  shift
+fi
+exec "$@"
 `)
 
 	cmdArgs := append([]string{"benchmark-darwin-vz-minimal.sh"}, args...)


### PR DESCRIPTION
## Summary

Adds a controlled memory-reporting probe to the minimal darwin-vz benchmark harness. The PR targets `main` directly.

What changed:

- adds an initrd `/bin/memprobe` that emits JSON phase events, touches guest memory, frees it with `madvise(MADV_DONTNEED)` plus `munmap`, then emits a post-free event
- extends the Swift runner with `--probe memory-reporting`, host-side `com.apple.Virtualization.VirtualMachine` footprint sampling, `--balloon-device on|off`, `--initial-balloon-target-mib`, `--pre-probe-balloon-target-mib`, and `--balloon-target-mib` control support
- enables `ADVISE_SYSCALLS`, `VIRTIO_BALLOON`, `PAGE_REPORTING`, and related compaction symbols in the minimal kernel builder
- documents the free-page-reporting and start-low/grow-before-workload experiments

## Custom-kernel result

After enabling `ADVISE_SYSCALLS`, the custom minimal kernel built and booted. A one-iteration 8 GiB / 4 GiB matrix produced this controlled signal:

| leg | guest MemFree before/touched/freed/after | VZ XPC phys_footprint before/touched/freed/after |
| --- | --- | --- |
| balloon on, no target | 8233540 / 4031944 / 8216876 / 8232784 KiB | 159 / 4264 / 4264 / 4264 MiB |
| balloon off | 8233792 / 4030936 / 8215868 / 8231776 KiB | 159 / 4265 / 4266 / 4265 MiB |
| balloon on, target 1024 MiB | 8233540 / 4031692 / 8224628 / 886732 KiB | 160 / 4264 / 4264 / 4265 MiB |

Interpretation: the guest frees the touched memory, and the explicit balloon target reaches the guest because available memory falls to around 1 GiB. In this harness, VZ XPC `phys_footprint` does not drop over the 10 second post-free window, even with the explicit target.

## Start-low/grow experiment

Boot timing with the custom minimal kernel, five iterations each:

| leg | median start_ms | median vsock_connect_ms | median exec_response_ms |
| --- | ---: | ---: | ---: |
| 1024 MiB cap | 88.7 | 178.4 | 180.0 |
| 8192 MiB cap | 94.6 | 221.5 | 222.9 |
| 8192 MiB cap + initial 1024 MiB target | 86.7 | 210.4 | 212.2 |

The early low target is accepted and helps the 8192 MiB cap path, but it does not get back to the true 1024 MiB boot path.

The grow-before-workload path also works mechanically: with an 8192 MiB cap, initial 1024 MiB target, then pre-probe target 8192 MiB, a 4096 MiB guest allocation succeeds. Guest MemFree moved `5624528 -> 4024616 -> 8209296 -> 8225204 KiB`; VZ XPC `phys_footprint` moved `991 -> 4267 -> 4267 -> 4267 MiB` across before/touched/freed/after.

## Validation

- `mise exec -- shellcheck -x scripts/benchmark-darwin-vz-minimal.sh benchmarks/darwin-vz/minimal/build-runner.sh benchmarks/darwin-vz/minimal/build-initrd.sh benchmarks/darwin-vz/minimal/build-kernel.sh`
- `benchmarks/darwin-vz/minimal/build-runner.sh /tmp/darwin-vz-minimal-test`
- `scripts/benchmark-darwin-vz-minimal.sh --help`
- `git diff --check`
- `mise exec -- go test ./scripts ./benchmarks/darwin-vz/minimal ./benchmarks/darwin-vz/minimal/initrd-agent ./benchmarks/darwin-vz/minimal/initrd-true ./benchmarks/darwin-vz/minimal/initrd-memprobe`
- live exec smoke with the cached managed kernel
- live `memory-reporting` smoke with the cached managed kernel
- custom minimal-kernel `memory-reporting` smoke
- custom minimal-kernel 8 GiB / 4 GiB matrix for no-target, balloon-off, and explicit-target controls
- custom minimal-kernel start-low/grow-before-workload experiment
- explicit validation that `--balloon-target-mib` without `--probe memory-reporting` is rejected