### PR TITLE
feat: Resolve repository and image tags

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -198,11 +198,12 @@ func commandBypassesStartupRuntimeConfig(ctx *kong.Context) bool {
 		return false
 	}
 
-	switch ctx.Command() {
-	case "config init", "config validate", "version":
+	command := strings.TrimSpace(ctx.Command())
+	switch command {
+	case "config init", "config validate", "image resolve", "version":
 		return true
 	default:
-		return false
+		return strings.HasPrefix(command, "image resolve ")
 	}
 }
 

--- a/internal/cli/cli_parse_test.go
+++ b/internal/cli/cli_parse_test.go
@@ -117,6 +117,27 @@ func TestImageBumpRefAllowsNoArgs(t *testing.T) {
 	}
 }
 
+func TestImageResolveCommandParses(t *testing.T) {
+	c := &CLI{}
+	parser := newParserForTest(t, c)
+
+	if _, err := parser.Parse([]string{"image", "resolve", "ghcr.io/buildkite/cleanroom-base/alpine:latest"}); err != nil {
+		t.Fatalf("parse image resolve returned error: %v", err)
+	}
+	if got, want := c.Image.Resolve.Ref, "ghcr.io/buildkite/cleanroom-base/alpine:latest"; got != want {
+		t.Fatalf("unexpected image resolve ref: got %q want %q", got, want)
+	}
+}
+
+func TestImageResolveCommandAllowsNoArgs(t *testing.T) {
+	c := &CLI{}
+	parser := newParserForTest(t, c)
+
+	if _, err := parser.Parse([]string{"image", "resolve"}); err != nil {
+		t.Fatalf("parse image resolve with default ref returned error: %v", err)
+	}
+}
+
 func TestConfigInitParses(t *testing.T) {
 	c := &CLI{}
 	parser := newParserForTest(t, c)

--- a/internal/cli/execution_shared.go
+++ b/internal/cli/execution_shared.go
@@ -335,7 +335,7 @@ func validateExecutionSandboxArgs(chdir, existingSandboxID, fromSnapshot string,
 	snapshotID := strings.TrimSpace(fromSnapshot)
 	hasChdir := strings.TrimSpace(chdir) != ""
 
-	if _, err := repositoryOverride.resolve(".", nil); err != nil {
+	if err := repositoryOverride.validate(); err != nil {
 		return err
 	}
 	if err := copyFlags.validate(fromSnapshot, repositoryOverride); err != nil {

--- a/internal/cli/image.go
+++ b/internal/cli/image.go
@@ -14,10 +14,15 @@ import (
 
 type ImageCommand struct {
 	Pull    ImagePullCommand    `cmd:"" help:"Pull and cache a digest-pinned OCI image"`
+	Resolve ImageResolveCommand `cmd:"" help:"Resolve an image tag to a digest-pinned reference"`
 	List    ImageListCommand    `name:"ls" aliases:"list" cmd:"" help:"List cached images"`
 	Remove  ImageRemoveCommand  `name:"rm" aliases:"remove" cmd:"" help:"Remove a cached image by ref or digest"`
 	Import  ImageImportCommand  `cmd:"" help:"Import a rootfs tar stream into the cache for a digest-pinned ref"`
 	BumpRef ImageBumpRefCommand `name:"bump-ref" aliases:"set-ref" cmd:"" help:"Resolve an image tag to digest and update sandbox.image.ref in cleanroom policy"`
+}
+
+type ImageResolveCommand struct {
+	Ref string `arg:"" optional:"" help:"Image reference to resolve (defaults to the current base image tag)"`
 }
 
 type ImagePullCommand struct {
@@ -46,6 +51,15 @@ type imageManager interface {
 
 var newImageManager = func() (imageManager, error) {
 	return imagemgr.New(imagemgr.Options{})
+}
+
+func (c *ImageResolveCommand) Run(ctx *runtimeContext) error {
+	resolved, err := resolveReferenceForPolicyUpdate(context.Background(), c.Ref)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(ctx.Stdout, resolved)
+	return err
 }
 
 func (c *ImagePullCommand) Run(ctx *runtimeContext) error {

--- a/internal/cli/image_test.go
+++ b/internal/cli/image_test.go
@@ -69,6 +69,50 @@ func replaceImageManagerFactory(t *testing.T, mgr imageManager, err error) {
 	})
 }
 
+func TestImageResolveCommandRunPrintsDigestPinnedReference(t *testing.T) {
+	const resolvedRef = "ghcr.io/buildkite/cleanroom-base/alpine@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	restore := stubRefResolver(t, func(_ context.Context, source string) (string, error) {
+		if got, want := source, "ghcr.io/buildkite/cleanroom-base/alpine:latest"; got != want {
+			t.Fatalf("unexpected source passed to resolver: got %q want %q", got, want)
+		}
+		return resolvedRef, nil
+	})
+	defer restore()
+
+	stdout, readStdout := makeStdoutCapture(t)
+	t.Cleanup(func() { _ = stdout.Close() })
+
+	err := (&ImageResolveCommand{Ref: "ghcr.io/buildkite/cleanroom-base/alpine:latest"}).Run(&runtimeContext{Stdout: stdout})
+	if err != nil {
+		t.Fatalf("ImageResolveCommand.Run returned error: %v", err)
+	}
+	if got := readStdout(); got != resolvedRef+"\n" {
+		t.Fatalf("unexpected stdout: got %q want %q", got, resolvedRef+"\n")
+	}
+}
+
+func TestImageResolveCommandRunUsesDefaultReference(t *testing.T) {
+	const resolvedRef = "ghcr.io/buildkite/cleanroom-base/alpine@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	restore := stubRefResolver(t, func(_ context.Context, source string) (string, error) {
+		if source != "" {
+			t.Fatalf("expected empty source for resolver default, got %q", source)
+		}
+		return resolvedRef, nil
+	})
+	defer restore()
+
+	stdout, readStdout := makeStdoutCapture(t)
+	t.Cleanup(func() { _ = stdout.Close() })
+
+	err := (&ImageResolveCommand{}).Run(&runtimeContext{Stdout: stdout})
+	if err != nil {
+		t.Fatalf("ImageResolveCommand.Run returned error: %v", err)
+	}
+	if got := readStdout(); got != resolvedRef+"\n" {
+		t.Fatalf("unexpected stdout: got %q want %q", got, resolvedRef+"\n")
+	}
+}
+
 func TestImagePullCommandRunPrintsResult(t *testing.T) {
 	mgr := &stubImageManager{
 		pullResult: imagemgr.EnsureResult{

--- a/internal/cli/repository.go
+++ b/internal/cli/repository.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
@@ -24,32 +25,38 @@ type resolvedRepositoryCheckout struct {
 }
 
 const defaultRepositoryOverridePath = "/workspace"
+const defaultRepositoryOverrideRevision = "latest"
 
 type repositoryOverrideFlags struct {
 	RepoURL    string `name:"repo-url" help:"Bootstrap this repository URL instead of inheriting the current repository"`
-	RepoCommit string `name:"repo-commit" help:"Bootstrap this exact repository commit SHA; requires --repo-url"`
+	RepoCommit string `name:"repo-commit" help:"Bootstrap this repository commit SHA, tag, or latest; defaults to latest when --repo-url is set"`
 }
 
 func (f repositoryOverrideFlags) resolve(cwd string, loader policyLoader) (*resolvedRepositoryCheckout, error) {
+	return f.resolveWithCommitResolver(cwd, loader, resolveRepositoryOverrideCommit)
+}
+
+type repositoryOverrideCommitResolver func(remoteURL, revision string) (string, error)
+
+func (f repositoryOverrideFlags) resolveWithCommitResolver(cwd string, loader policyLoader, resolveCommit repositoryOverrideCommitResolver) (*resolvedRepositoryCheckout, error) {
 	repoURL := strings.TrimSpace(f.RepoURL)
-	repoCommit := strings.TrimSpace(f.RepoCommit)
-	switch {
-	case repoURL == "" && repoCommit == "":
-		return nil, nil
-	case repoURL == "" || repoCommit == "":
-		return nil, errors.New("--repo-url and --repo-commit must be used together")
+	if err := f.validate(); err != nil {
+		return nil, err
 	}
+	if repoURL == "" {
+		return nil, nil
+	}
+	repoCommit := f.revision()
 
 	checkout := &repositorycheckout.Checkout{
 		RemoteURL:      repoURL,
-		CommitSHA:      repoCommit,
 		DestinationDir: defaultRepositoryOverridePath,
-	}
-	if err := checkout.ValidateBootstrap(); err != nil {
-		return nil, err
 	}
 	remoteHost, err := checkout.NormalizeRemoteURL()
 	if err != nil {
+		return nil, err
+	}
+	if err := checkout.ValidateWorkdir(); err != nil {
 		return nil, err
 	}
 
@@ -63,11 +70,170 @@ func (f repositoryOverrideFlags) resolve(cwd string, loader policyLoader) (*reso
 		}
 	}
 
+	resolvedCommit, err := resolveCommit(checkout.RemoteURL, repoCommit)
+	if err != nil {
+		return nil, err
+	}
+	checkout.CommitSHA = resolvedCommit
+	if err := checkout.ValidateBootstrap(); err != nil {
+		return nil, err
+	}
+
 	return &resolvedRepositoryCheckout{
 		RemoteURL:      checkout.RemoteURL,
 		CommitSHA:      checkout.CommitSHA,
 		DestinationDir: checkout.DestinationDir,
 	}, nil
+}
+
+func (f repositoryOverrideFlags) validate() error {
+	repoURL := strings.TrimSpace(f.RepoURL)
+	repoCommit := strings.TrimSpace(f.RepoCommit)
+	switch {
+	case repoURL == "" && repoCommit == "":
+		return nil
+	case repoURL == "":
+		return errors.New("--repo-commit requires --repo-url")
+	default:
+		return nil
+	}
+}
+
+func (f repositoryOverrideFlags) revision() string {
+	if revision := strings.TrimSpace(f.RepoCommit); revision != "" {
+		return revision
+	}
+	return defaultRepositoryOverrideRevision
+}
+
+var resolveRepositoryOverrideCommit = resolveRepositoryOverrideCommitDefault
+
+func resolveRepositoryOverrideCommitDefault(remoteURL, revision string) (string, error) {
+	if commitSHA, ok := normalizeRepositoryCommitSHA(revision); ok {
+		return commitSHA, nil
+	}
+	commitSHA, tagErr := resolveRemoteGitTagCommit(remoteURL, revision)
+	if tagErr == nil {
+		return commitSHA, nil
+	}
+	if strings.EqualFold(strings.TrimSpace(revision), defaultRepositoryOverrideRevision) {
+		commitSHA, headErr := resolveRemoteGitHeadCommit(remoteURL)
+		if headErr == nil {
+			return commitSHA, nil
+		}
+		return "", errors.Join(tagErr, fmt.Errorf("resolve repository latest from remote HEAD: %w", headErr))
+	}
+	return "", tagErr
+}
+
+func normalizeRepositoryCommitSHA(revision string) (string, bool) {
+	normalized := strings.ToLower(strings.TrimSpace(revision))
+	if len(normalized) != 40 {
+		return "", false
+	}
+	if _, err := hex.DecodeString(normalized); err != nil {
+		return "", false
+	}
+	return normalized, true
+}
+
+func resolveRemoteGitTagCommit(remoteURL, tag string) (string, error) {
+	ref, err := repositoryTagRef(tag)
+	if err != nil {
+		return "", err
+	}
+	out, err := gitOutput("", "ls-remote", remoteURL, ref, ref+"^{}")
+	if err != nil {
+		return "", fmt.Errorf("resolve repository tag %q from remote: %w", strings.TrimSpace(tag), err)
+	}
+	commitSHA, err := selectRemoteGitTagCommit(out, ref)
+	if err != nil {
+		return "", err
+	}
+	return commitSHA, nil
+}
+
+func resolveRemoteGitHeadCommit(remoteURL string) (string, error) {
+	out, err := gitOutput("", "ls-remote", "--exit-code", remoteURL, "HEAD")
+	if err != nil {
+		return "", fmt.Errorf("resolve repository HEAD from remote: %w", err)
+	}
+	commitSHA, err := selectRemoteGitRefCommit(out, "HEAD")
+	if err != nil {
+		return "", err
+	}
+	return commitSHA, nil
+}
+
+func repositoryTagRef(tag string) (string, error) {
+	trimmed := strings.TrimSpace(tag)
+	if trimmed == "" {
+		return "", errors.New("repository commit_sha is required")
+	}
+	ref := "refs/tags/" + trimmed
+	if strings.HasPrefix(trimmed, "refs/") {
+		if !strings.HasPrefix(trimmed, "refs/tags/") {
+			return "", fmt.Errorf("repository commit %q must be a full 40-character commit SHA or tag name", trimmed)
+		}
+		ref = trimmed
+	}
+	if _, err := gitOutput("", "check-ref-format", ref); err != nil {
+		return "", fmt.Errorf("repository tag %q is not a valid tag name: %w", trimmed, err)
+	}
+	return ref, nil
+}
+
+func selectRemoteGitRefCommit(output, ref string) (string, error) {
+	for _, line := range strings.Split(output, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		if len(fields) != 2 {
+			return "", fmt.Errorf("parse repository ref lookup: unexpected ls-remote output %q", line)
+		}
+		if fields[1] != ref {
+			continue
+		}
+		if commitSHA, ok := normalizeRepositoryCommitSHA(fields[0]); ok {
+			return commitSHA, nil
+		}
+		return "", fmt.Errorf("repository ref %q resolved to invalid commit %q", ref, fields[0])
+	}
+	return "", fmt.Errorf("repository ref %q was not found", ref)
+}
+
+func selectRemoteGitTagCommit(output, ref string) (string, error) {
+	direct := ""
+	peeled := ""
+	for _, line := range strings.Split(output, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		if len(fields) != 2 {
+			return "", fmt.Errorf("parse repository tag lookup: unexpected ls-remote output %q", line)
+		}
+		switch fields[1] {
+		case ref:
+			direct = fields[0]
+		case ref + "^{}":
+			peeled = fields[0]
+		}
+	}
+	if peeled != "" {
+		if commitSHA, ok := normalizeRepositoryCommitSHA(peeled); ok {
+			return commitSHA, nil
+		}
+		return "", fmt.Errorf("repository tag %q resolved to invalid commit %q", strings.TrimPrefix(ref, "refs/tags/"), peeled)
+	}
+	if direct != "" {
+		if commitSHA, ok := normalizeRepositoryCommitSHA(direct); ok {
+			return commitSHA, nil
+		}
+		return "", fmt.Errorf("repository tag %q resolved to invalid commit %q", strings.TrimPrefix(ref, "refs/tags/"), direct)
+	}
+	return "", fmt.Errorf("repository tag %q was not found", strings.TrimPrefix(ref, "refs/tags/"))
 }
 
 func (f repositoryOverrideFlags) hasRepositoryOverride() bool {

--- a/internal/cli/repository_test.go
+++ b/internal/cli/repository_test.go
@@ -233,6 +233,120 @@ func TestRepositoryOverrideAllowsHostFromWorkspaceStageNetwork(t *testing.T) {
 	}
 }
 
+func TestRepositoryOverrideDefaultsMissingCommitToLatest(t *testing.T) {
+	const wantCommit = "0123456789abcdef0123456789abcdef01234567"
+	checkout, err := (repositoryOverrideFlags{
+		RepoURL: "git@github.com:buildkite/cleanroom.git",
+	}).resolveWithCommitResolver(t.TempDir(), repositoryIntegrationLoader{
+		compiled: stageScopedWorkspaceGitHubPolicy(),
+	}, func(remoteURL, revision string) (string, error) {
+		if got, want := remoteURL, "https://github.com/buildkite/cleanroom.git"; got != want {
+			t.Fatalf("resolver remote URL mismatch: got %q want %q", got, want)
+		}
+		if got, want := revision, "latest"; got != want {
+			t.Fatalf("resolver revision mismatch: got %q want %q", got, want)
+		}
+		return wantCommit, nil
+	})
+	if err != nil {
+		t.Fatalf("repository override resolve returned error: %v", err)
+	}
+	if checkout == nil {
+		t.Fatal("expected repository override checkout")
+	}
+	if got := checkout.CommitSHA; got != wantCommit {
+		t.Fatalf("unexpected resolved commit: got %q want %q", got, wantCommit)
+	}
+}
+
+func TestRepositoryOverrideResolvesTagToCommitSHA(t *testing.T) {
+	const wantCommit = "0123456789abcdef0123456789abcdef01234567"
+	checkout, err := (repositoryOverrideFlags{
+		RepoURL:    "git@github.com:buildkite/cleanroom.git",
+		RepoCommit: "v1.2.3",
+	}).resolveWithCommitResolver(t.TempDir(), repositoryIntegrationLoader{
+		compiled: stageScopedWorkspaceGitHubPolicy(),
+	}, func(remoteURL, revision string) (string, error) {
+		if got, want := remoteURL, "https://github.com/buildkite/cleanroom.git"; got != want {
+			t.Fatalf("resolver remote URL mismatch: got %q want %q", got, want)
+		}
+		if got, want := revision, "v1.2.3"; got != want {
+			t.Fatalf("resolver revision mismatch: got %q want %q", got, want)
+		}
+		return wantCommit, nil
+	})
+	if err != nil {
+		t.Fatalf("repository override resolve returned error: %v", err)
+	}
+	if checkout == nil {
+		t.Fatal("expected repository override checkout")
+	}
+	if got := checkout.CommitSHA; got != wantCommit {
+		t.Fatalf("unexpected resolved commit: got %q want %q", got, wantCommit)
+	}
+}
+
+func TestResolveRepositoryOverrideCommitUsesFullSHAWithoutRemoteLookup(t *testing.T) {
+	got, err := resolveRepositoryOverrideCommit("", "ABCDEF0123456789ABCDEF0123456789ABCDEF01")
+	if err != nil {
+		t.Fatalf("resolveRepositoryOverrideCommit returned error: %v", err)
+	}
+	if want := "abcdef0123456789abcdef0123456789abcdef01"; got != want {
+		t.Fatalf("unexpected commit: got %q want %q", got, want)
+	}
+}
+
+func TestResolveRepositoryOverrideCommitResolvesLightweightTag(t *testing.T) {
+	repoDir := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
+	wantCommit := headCommit(t, repoDir)
+	runGitInRepository(t, repoDir, "tag", "latest")
+
+	got, err := resolveRepositoryOverrideCommit(repoDir, "latest")
+	if err != nil {
+		t.Fatalf("resolveRepositoryOverrideCommit returned error: %v", err)
+	}
+	if got != wantCommit {
+		t.Fatalf("unexpected commit: got %q want %q", got, wantCommit)
+	}
+}
+
+func TestResolveRepositoryOverrideCommitResolvesLatestAliasToRemoteHEAD(t *testing.T) {
+	repoDir := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
+	wantCommit := headCommit(t, repoDir)
+
+	got, err := resolveRepositoryOverrideCommit(repoDir, "latest")
+	if err != nil {
+		t.Fatalf("resolveRepositoryOverrideCommit returned error: %v", err)
+	}
+	if got != wantCommit {
+		t.Fatalf("unexpected commit: got %q want %q", got, wantCommit)
+	}
+}
+
+func TestResolveRepositoryOverrideCommitResolvesAnnotatedTag(t *testing.T) {
+	repoDir := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
+	wantCommit := headCommit(t, repoDir)
+	runGitInRepository(t, repoDir, "tag", "-a", "latest", "-m", "latest")
+
+	got, err := resolveRepositoryOverrideCommit(repoDir, "latest")
+	if err != nil {
+		t.Fatalf("resolveRepositoryOverrideCommit returned error: %v", err)
+	}
+	if got != wantCommit {
+		t.Fatalf("unexpected commit: got %q want %q", got, wantCommit)
+	}
+}
+
+func TestResolveRepositoryOverrideCommitRejectsBranchRef(t *testing.T) {
+	_, err := resolveRepositoryOverrideCommit("https://github.com/buildkite/cleanroom.git", "refs/heads/main")
+	if err == nil {
+		t.Fatal("expected branch refs to be rejected")
+	}
+	if !strings.Contains(err.Error(), "full 40-character commit SHA or tag name") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestCreateCommandShowsDependencyBootstrapOutputDuringSandboxCreate(t *testing.T) {
 	repoDir := initGitRepository(t, "git@github.com:buildkite/cleanroom.git")
 
@@ -382,20 +496,19 @@ func TestCreateCommandBootstrapsRepositoryForExplicitOverride(t *testing.T) {
 	}
 }
 
-func TestCreateCommandRejectsPartialRepositoryOverride(t *testing.T) {
+func TestCreateCommandRejectsRepoCommitWithoutRepoURL(t *testing.T) {
 	outcome := runCreateAliasWithCapture(CreateCommand{
 		repositoryOverrideFlags: repositoryOverrideFlags{
-			RepoURL:    "https://github.com/buildkite/agent.git",
-			RepoCommit: "",
+			RepoCommit: "latest",
 		},
 	}, runtimeContext{})
 	if outcome.cause != nil {
 		t.Fatalf("capture failure: %v", outcome.cause)
 	}
 	if outcome.err == nil {
-		t.Fatal("expected create command to reject partial repository override")
+		t.Fatal("expected create command to reject repository commit without repository URL")
 	}
-	if !strings.Contains(outcome.err.Error(), "--repo-url and --repo-commit must be used together") {
+	if !strings.Contains(outcome.err.Error(), "--repo-commit requires --repo-url") {
 		t.Fatalf("unexpected error: %v", outcome.err)
 	}
 }

--- a/internal/cli/sandbox.go
+++ b/internal/cli/sandbox.go
@@ -419,7 +419,7 @@ func (c *CreateCommand) Run(ctx *runtimeContext) error {
 }
 
 func (c *CreateCommand) validate() error {
-	if _, err := c.repositoryOverrideFlags.resolve(".", nil); err != nil {
+	if err := c.repositoryOverrideFlags.validate(); err != nil {
 		return err
 	}
 	if err := c.workspaceCopyInFlags.validate(c.From, c.repositoryOverrideFlags); err != nil {


### PR DESCRIPTION
## Summary

- allow `--repo-url` without `--repo-commit`, defaulting the repository revision to `latest`
- resolve repository commit refs and tags to a pinned commit SHA before sandbox bootstrap
- add `cleanroom image resolve [ref]` to print digest-pinned image references

## Validation

- `mise exec -- go test ./internal/cli ./internal/repositorycheckout`
- `mise exec -- go test ./...`
- `mise exec -- go run ./cmd/cleanroom image resolve ghcr.io/buildkite/cleanroom-base/alpine:latest`
- `mise exec -- go run ./cmd/cleanroom image resolve --help`
- `git diff --check`