### PR TITLE
feat: Add adaptive Darwin VZ memory ballooning

### DIFF
--- a/cmd/cleanroom-darwin-vz/main.swift
+++ b/cmd/cleanroom-darwin-vz/main.swift
@@ -21,6 +21,8 @@ private struct ControlRequest: Decodable {
     let vmnetDisableRouterAdvertisement: Bool?
     let vcpus: Int?
     let memoryMiB: Int64?
+    let initialMemoryBalloonTargetMiB: Int64?
+    let memoryBalloonTargetMiB: Int64?
     let guestPort: UInt32?
     let launchSeconds: Int64?
     let runDir: String?
@@ -44,6 +46,8 @@ private struct ControlRequest: Decodable {
         case vmnetDisableRouterAdvertisement = "vmnet_disable_router_advertisement"
         case vcpus
         case memoryMiB = "memory_mib"
+        case initialMemoryBalloonTargetMiB = "initial_memory_balloon_target_mib"
+        case memoryBalloonTargetMiB = "memory_balloon_target_mib"
         case guestPort = "guest_port"
         case launchSeconds = "launch_seconds"
         case runDir = "run_dir"
@@ -474,6 +478,7 @@ private final class VMRuntime {
     private var vmID: String?
     private var serialChannel: GuestChannel?
     private var guestPort: UInt32 = 0
+    private var memoryMiB: Int64 = 0
     private var launchTimeout: TimeInterval = 30
     private var vmQueue: DispatchQueue?
     private var proxy: ProxyServer?
@@ -502,6 +507,13 @@ private final class VMRuntime {
 
         let vcpus = max(1, req.vcpus ?? 1)
         let memoryMiB = max(Int64(256), req.memoryMiB ?? 512)
+        let initialMemoryBalloonTargetMiB = req.initialMemoryBalloonTargetMiB ?? 0
+        guard initialMemoryBalloonTargetMiB >= 0 else {
+            throw HelperError.invalidRequest("initial_memory_balloon_target_mib must be non-negative")
+        }
+        guard initialMemoryBalloonTargetMiB <= memoryMiB else {
+            throw HelperError.invalidRequest("initial_memory_balloon_target_mib cannot exceed memory_mib")
+        }
         let guestPort = req.guestPort ?? 10_700
         let launchSeconds = max(Int64(5), req.launchSeconds ?? 30)
         let defaultBootArgs = "console=hvc0 root=/dev/vda rw init=/sbin/cleanroom-init cleanroom_guest_port=\(guestPort)"
@@ -548,6 +560,18 @@ private final class VMRuntime {
             releaseFileHandleAttachmentOnFailure?.stop()
         }
 
+        var memoryBalloonInitialMS: Int64?
+        if initialMemoryBalloonTargetMiB > 0 {
+            let memoryBalloonInitialStartedAt = DispatchTime.now()
+            try applyMemoryBalloonTarget(
+                vm: vm,
+                queue: vmQueue,
+                targetMiB: initialMemoryBalloonTargetMiB,
+                memoryMiB: memoryMiB
+            )
+            memoryBalloonInitialMS = elapsedMilliseconds(from: memoryBalloonInitialStartedAt, to: DispatchTime.now())
+        }
+
         let vzStartStartedAt = DispatchTime.now()
         try startVM(vm, queue: vmQueue, timeoutSeconds: launchSeconds)
         let vzStartedAt = DispatchTime.now()
@@ -561,6 +585,7 @@ private final class VMRuntime {
         self.vm = vm
         self.vmID = vmID
         self.proxy = proxy
+        self.memoryMiB = memoryMiB
         self.fileHandleNetworkAttachment = fileHandleNetworkAttachment
         releaseFileHandleAttachmentOnFailure = nil
         proxy.start { [weak self] in
@@ -571,12 +596,15 @@ private final class VMRuntime {
         }
         let proxyReadyAt = DispatchTime.now()
 
-        let timingMS = [
+        var timingMS = [
             "config_build": elapsedMilliseconds(from: startedAt, to: configBuiltAt),
             "vz_start": elapsedMilliseconds(from: vzStartStartedAt, to: vzStartedAt),
             "proxy_ready": elapsedMilliseconds(from: proxyReadyStartedAt, to: proxyReadyAt),
             "vm_ready": elapsedMilliseconds(from: startedAt, to: proxyReadyAt),
         ]
+        if let memoryBalloonInitialMS {
+            timingMS["memory_balloon_initial"] = memoryBalloonInitialMS
+        }
         return ControlResponse(
             ok: true,
             error: nil,
@@ -606,6 +634,7 @@ private final class VMRuntime {
         self.vm = nil
         self.serialChannel = nil
         self.guestPort = 0
+        self.memoryMiB = 0
         self.launchTimeout = 30
         self.vmQueue = nil
         self.proxy = nil
@@ -707,6 +736,39 @@ private final class VMRuntime {
         if let resumeError {
             throw HelperError.vm("failed to resume vm: \(resumeError)")
         }
+    }
+
+    func setMemoryBalloonTarget(vmID requestedID: String?, targetMiB requestedTargetMiB: Int64?) throws {
+        guard let targetMiB = requestedTargetMiB else {
+            throw HelperError.invalidRequest("missing memory_balloon_target_mib")
+        }
+
+        lock.lock()
+        let currentID = vmID
+        let vm = self.vm
+        let vmQueue = self.vmQueue
+        let memoryMiB = self.memoryMiB
+        lock.unlock()
+
+        if let requestedID, !requestedID.isEmpty, let currentID, requestedID != currentID {
+            throw HelperError.invalidRequest("unknown vm_id \(requestedID)")
+        }
+        guard let vm else {
+            throw HelperError.invalidRequest("vm is not running")
+        }
+        guard let vmQueue else {
+            throw HelperError.vm("vm queue is unavailable")
+        }
+        guard memoryMiB > 0 else {
+            throw HelperError.vm("vm memory size is unavailable")
+        }
+
+        try applyMemoryBalloonTarget(
+            vm: vm,
+            queue: vmQueue,
+            targetMiB: targetMiB,
+            memoryMiB: memoryMiB
+        )
     }
 
     private func parseIPv4Address(_ value: String) throws -> in_addr {
@@ -1000,6 +1062,45 @@ private final class VMRuntime {
         return (VZVirtualMachine(configuration: config, queue: queue), channel, networkDetails, fileHandleNetworkAttachment)
     }
 
+    private func applyMemoryBalloonTarget(
+        vm: VZVirtualMachine,
+        queue: DispatchQueue,
+        targetMiB: Int64,
+        memoryMiB: Int64,
+        timeoutSeconds: Int64 = 5
+    ) throws {
+        guard targetMiB > 0 else {
+            throw HelperError.invalidRequest("memory_balloon_target_mib must be greater than zero")
+        }
+        guard targetMiB <= memoryMiB else {
+            throw HelperError.invalidRequest("memory_balloon_target_mib cannot exceed memory_mib")
+        }
+        let bytesPerMiB = Int64(1024 * 1024)
+        guard targetMiB <= Int64.max / bytesPerMiB else {
+            throw HelperError.invalidRequest("memory_balloon_target_mib is too large")
+        }
+        let targetBytes = UInt64(targetMiB * bytesPerMiB)
+
+        let sem = DispatchSemaphore(value: 0)
+        var targetError: Error?
+        queue.async {
+            guard let balloon = vm.memoryBalloonDevices.first as? VZVirtioTraditionalMemoryBalloonDevice else {
+                targetError = HelperError.vm("vm memory balloon device is unavailable")
+                sem.signal()
+                return
+            }
+            balloon.targetVirtualMachineMemorySize = targetBytes
+            sem.signal()
+        }
+
+        if sem.wait(timeout: .now() + .seconds(Int(timeoutSeconds))) == .timedOut {
+            throw HelperError.timeout("timed out waiting for memory balloon target update")
+        }
+        if let targetError {
+            throw targetError
+        }
+    }
+
     private func startVM(_ vm: VZVirtualMachine, queue: DispatchQueue, timeoutSeconds: Int64) throws {
         let sem = DispatchSemaphore(value: 0)
         var startError: Error?
@@ -1186,6 +1287,9 @@ private final class HelperService {
             return ControlResponse(ok: true, error: nil, vmID: nil, proxySocketPath: nil, vmnetSubnetCIDR: nil, vmnetGuestIPv4: nil, vmnetGatewayIPv4: nil, vmnetPrefixLen: nil, timingMS: nil)
         case "ResumeVM":
             try vmRuntime.resume(vmID: req.vmID)
+            return ControlResponse(ok: true, error: nil, vmID: nil, proxySocketPath: nil, vmnetSubnetCIDR: nil, vmnetGuestIPv4: nil, vmnetGatewayIPv4: nil, vmnetPrefixLen: nil, timingMS: nil)
+        case "SetMemoryBalloonTarget":
+            try vmRuntime.setMemoryBalloonTarget(vmID: req.vmID, targetMiB: req.memoryBalloonTargetMiB)
             return ControlResponse(ok: true, error: nil, vmID: nil, proxySocketPath: nil, vmnetSubnetCIDR: nil, vmnetGuestIPv4: nil, vmnetGatewayIPv4: nil, vmnetPrefixLen: nil, timingMS: nil)
         case "Ping":
             return ControlResponse(ok: true, error: nil, vmID: nil, proxySocketPath: nil, vmnetSubnetCIDR: nil, vmnetGuestIPv4: nil, vmnetGatewayIPv4: nil, vmnetPrefixLen: nil, timingMS: nil)

--- a/docs/backend/darwin-vz.md
+++ b/docs/backend/darwin-vz.md
@@ -15,7 +15,7 @@ Implemented:
 
 - launched execution on macOS via `Virtualization.framework`
 - interactive and non-interactive command execution via existing `internal/vsockexec` protocol
-- helper-managed VM lifecycle (`StartVM` / `StopVM` / `PauseVM` / `ResumeVM`)
+- helper-managed VM lifecycle (`StartVM` / `StopVM` / `PauseVM` / `ResumeVM` / `SetMemoryBalloonTarget`)
 - `filehandle` network mode with a Cleanroom-owned guest gateway and stable guest IP
 - TCP allowlist egress filtering for the active effective policy in `filehandle` mode
 - allow-all egress for repo-agnostic sandboxes created with `cleanroom sandbox create --dangerously-allow-all`
@@ -40,7 +40,7 @@ Control plane:
 
 - socket: `<run_dir>/vz-helper.sock`
 - protocol: newline-delimited JSON request/response
-- operations: `StartVM`, `StopVM`, `PauseVM`, `ResumeVM`, `Ping`
+- operations: `StartVM`, `StopVM`, `PauseVM`, `ResumeVM`, `SetMemoryBalloonTarget`, `Ping`
 
 Data plane:
 
@@ -63,6 +63,7 @@ High-level flow:
 - `kernel_path` absolute path to Linux kernel
 - `rootfs_path` absolute path to sandbox-scoped ext4 rootfs copy
 - `vcpus`, `memory_mib`, `guest_port`, `launch_seconds`
+- optional `initial_memory_balloon_target_mib`
 - `run_dir`
 - `proxy_socket_path`
 - `console_log_path`
@@ -70,6 +71,13 @@ High-level flow:
 `vcpus` and `memory_mib` are effective VM launch ceilings after runtime config
 and policy resource minimums are merged. They are not an exact host reservation
 contract.
+
+When `memory_mib` is above 1024 MiB, Go sends `initial_memory_balloon_target_mib=1024`
+so the helper can request a smaller guest memory target during boot. Before guest
+workload execution, Go sends `SetMemoryBalloonTarget` back to `memory_mib` and
+waits briefly for the guest to process the request. This keeps the user-facing
+memory contract as a ceiling while allowing the backend to optimize boot-time
+host memory pressure internally.
 
 `StartVM` response fields:
 
@@ -87,6 +95,12 @@ contract.
 
 - `op=PauseVM` or `op=ResumeVM`
 - optional `vm_id` (validated when provided)
+
+`SetMemoryBalloonTarget` request:
+
+- `op=SetMemoryBalloonTarget`
+- optional `vm_id` (validated when provided)
+- `memory_balloon_target_mib` target guest memory allowance in MiB, capped by `memory_mib`
 
 ## Kernel and RootFS Strategy
 

--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -97,30 +97,32 @@ type preparedRootFS struct {
 }
 
 type sandboxInstance struct {
-	SandboxID           string
-	RunDir              string
-	ConfigPath          string
-	ProxySocketPath     string
-	GuestPort           uint32
-	NetworkProcessPID   int
-	Policy              *policy.CompiledPolicy
-	FirecrackerConfig   backend.FirecrackerConfig
-	ImageRef            string
-	ImageDigest         string
-	LaunchObservability *darwinVZLaunchObservability
-	NetworkMetadata     *darwinVZNetworkMetadata
-	FileHandleGateway   *fileHandleGateway
-	CommandTimeout      int64
-	Helper              *helperSession
-	VMID                string
-	vmRootFSPath        string
-	cacheOutputMounts   []vsockexec.CacheOutputMount
-	cacheOutputVolumes  []preparedDarwinVZCacheOutputVolume
-	cleanupCacheOutputs func()
-	exitedCh            chan struct{}
-	exitMu              sync.RWMutex
-	exitErr             error
-	exitReady           bool
+	SandboxID              string
+	RunDir                 string
+	ConfigPath             string
+	ProxySocketPath        string
+	GuestPort              uint32
+	NetworkProcessPID      int
+	Policy                 *policy.CompiledPolicy
+	FirecrackerConfig      backend.FirecrackerConfig
+	ImageRef               string
+	ImageDigest            string
+	LaunchObservability    *darwinVZLaunchObservability
+	NetworkMetadata        *darwinVZNetworkMetadata
+	FileHandleGateway      *fileHandleGateway
+	CommandTimeout         int64
+	Helper                 *helperSession
+	VMID                   string
+	vmRootFSPath           string
+	cacheOutputMounts      []vsockexec.CacheOutputMount
+	cacheOutputVolumes     []preparedDarwinVZCacheOutputVolume
+	cleanupCacheOutputs    func()
+	exitedCh               chan struct{}
+	memoryBalloonMu        sync.Mutex
+	memoryBalloonTargetMiB int64
+	exitMu                 sync.RWMutex
+	exitErr                error
+	exitReady              bool
 }
 
 const preparedRuntimeRootFSVersion = "v9-darwin-vz"
@@ -1244,22 +1246,23 @@ func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream 
 	}()
 
 	startedVM, err := startDarwinVZHelperVM(ctx, helper, darwinVZVMStartRequest{
-		SandboxID:      req.SandboxID,
-		ConfigPath:     vmPlanPath,
-		BackendName:    a.Name(),
-		RunDir:         runDir,
-		KernelPath:     kernelPath,
-		RootFSPath:     vmRootFSPath,
-		BootArgs:       bootArgs,
-		ConsoleLogPath: consolePath,
-		NetworkCfg:     networkCfg,
-		HostGatewayURL: a.GatewayBridgeURL,
-		GatewayPort:    a.GatewayPort,
-		Policy:         networkPolicy,
-		VCPUs:          req.VCPUs,
-		MemoryMiB:      req.MemoryMiB,
-		GuestPort:      req.GuestPort,
-		LaunchSeconds:  req.LaunchSeconds,
+		SandboxID:                     req.SandboxID,
+		ConfigPath:                    vmPlanPath,
+		BackendName:                   a.Name(),
+		RunDir:                        runDir,
+		KernelPath:                    kernelPath,
+		RootFSPath:                    vmRootFSPath,
+		BootArgs:                      bootArgs,
+		ConsoleLogPath:                consolePath,
+		NetworkCfg:                    networkCfg,
+		HostGatewayURL:                a.GatewayBridgeURL,
+		GatewayPort:                   a.GatewayPort,
+		Policy:                        networkPolicy,
+		VCPUs:                         req.VCPUs,
+		MemoryMiB:                     req.MemoryMiB,
+		InitialMemoryBalloonTargetMiB: darwinVZInitialMemoryBalloonTargetMiB(req.MemoryMiB),
+		GuestPort:                     req.GuestPort,
+		LaunchSeconds:                 req.LaunchSeconds,
 	})
 	if err != nil {
 		observation.Error = err.Error()
@@ -1350,6 +1353,10 @@ func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream 
 	entropy := make([]byte, 64)
 	if _, err := cryptorand.Read(entropy); err == nil {
 		guestReq.EntropySeed = entropy
+	}
+	if err := a.growDarwinVZMemoryBalloonTarget(ctx, helper, vmID, req.MemoryMiB); err != nil {
+		observation.Error = err.Error()
+		return nil, err
 	}
 	if err := guestexec.SendRequest(conn, guestReq); err != nil {
 		observation.Error = err.Error()
@@ -1583,23 +1590,24 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 	)
 	helperStartVMStart := time.Now()
 	startedVM, err := startDarwinVZHelperVM(ctx, helper, darwinVZVMStartRequest{
-		SandboxID:        sandboxID,
-		ConfigPath:       configPath,
-		BackendName:      a.Name(),
-		RunDir:           runDir,
-		KernelPath:       kernelPath,
-		RootFSPath:       vmRootFSPath,
-		SidecarDiskPaths: darwinVZCacheOutputDiskPaths(cacheOutputVolumes),
-		BootArgs:         bootArgs,
-		ConsoleLogPath:   consolePath,
-		NetworkCfg:       networkCfg,
-		HostGatewayURL:   a.GatewayBridgeURL,
-		GatewayPort:      a.GatewayPort,
-		Policy:           compiled,
-		VCPUs:            cfg.VCPUs,
-		MemoryMiB:        cfg.MemoryMiB,
-		GuestPort:        cfg.GuestPort,
-		LaunchSeconds:    cfg.LaunchSeconds,
+		SandboxID:                     sandboxID,
+		ConfigPath:                    configPath,
+		BackendName:                   a.Name(),
+		RunDir:                        runDir,
+		KernelPath:                    kernelPath,
+		RootFSPath:                    vmRootFSPath,
+		SidecarDiskPaths:              darwinVZCacheOutputDiskPaths(cacheOutputVolumes),
+		BootArgs:                      bootArgs,
+		ConsoleLogPath:                consolePath,
+		NetworkCfg:                    networkCfg,
+		HostGatewayURL:                a.GatewayBridgeURL,
+		GatewayPort:                   a.GatewayPort,
+		Policy:                        compiled,
+		VCPUs:                         cfg.VCPUs,
+		MemoryMiB:                     cfg.MemoryMiB,
+		InitialMemoryBalloonTargetMiB: darwinVZInitialMemoryBalloonTargetMiB(cfg.MemoryMiB),
+		GuestPort:                     cfg.GuestPort,
+		LaunchSeconds:                 cfg.LaunchSeconds,
 	})
 	recordDarwinVZPhaseTiming(launchTimingMS, darwinVZTimingHelperStartVM, helperStartVMStart)
 	if err != nil {
@@ -1621,25 +1629,26 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 	defer pidLookup.stop()
 
 	instance := &sandboxInstance{
-		SandboxID:           sandboxID,
-		RunDir:              runDir,
-		ConfigPath:          configPath,
-		ProxySocketPath:     startedVM.ProxySocketPath,
-		GuestPort:           cfg.GuestPort,
-		Policy:              compiled,
-		FirecrackerConfig:   cfg,
-		ImageRef:            imageRef,
-		ImageDigest:         imageDigest,
-		NetworkMetadata:     startedVM.NetworkMetadata,
-		FileHandleGateway:   startedVM.FileHandleGW,
-		CommandTimeout:      cfg.LaunchSeconds,
-		Helper:              helper,
-		VMID:                startedVM.VMID,
-		vmRootFSPath:        vmRootFSPath,
-		cacheOutputMounts:   darwinVZCacheOutputVolumeMounts(cacheOutputVolumes),
-		cacheOutputVolumes:  cacheOutputVolumes,
-		cleanupCacheOutputs: cleanupCacheOutputs,
-		exitedCh:            make(chan struct{}),
+		SandboxID:              sandboxID,
+		RunDir:                 runDir,
+		ConfigPath:             configPath,
+		ProxySocketPath:        startedVM.ProxySocketPath,
+		GuestPort:              cfg.GuestPort,
+		Policy:                 compiled,
+		FirecrackerConfig:      cfg,
+		ImageRef:               imageRef,
+		ImageDigest:            imageDigest,
+		NetworkMetadata:        startedVM.NetworkMetadata,
+		FileHandleGateway:      startedVM.FileHandleGW,
+		CommandTimeout:         cfg.LaunchSeconds,
+		Helper:                 helper,
+		VMID:                   startedVM.VMID,
+		vmRootFSPath:           vmRootFSPath,
+		cacheOutputMounts:      darwinVZCacheOutputVolumeMounts(cacheOutputVolumes),
+		cacheOutputVolumes:     cacheOutputVolumes,
+		cleanupCacheOutputs:    cleanupCacheOutputs,
+		exitedCh:               make(chan struct{}),
+		memoryBalloonTargetMiB: darwinVZInitialMemoryBalloonTargetMiB(cfg.MemoryMiB),
 	}
 	go func() {
 		err, ok := <-helper.done
@@ -1873,6 +1882,9 @@ func (a *Adapter) executeInSandbox(bootCtx context.Context, runCtx context.Conte
 	entropy := make([]byte, 64)
 	if _, err := cryptorand.Read(entropy); err == nil {
 		guestReq.EntropySeed = entropy
+	}
+	if err := instance.growDarwinVZMemoryBalloonTarget(runCtx, a); err != nil {
+		return nil, err
 	}
 	if err := guestexec.SendRequest(conn, guestReq); err != nil {
 		return nil, err

--- a/internal/backend/darwinvz/helper_client.go
+++ b/internal/backend/darwinvz/helper_client.go
@@ -42,6 +42,8 @@ type helperControlRequest struct {
 	VMNetDisableRouterAdvertisement bool     `json:"vmnet_disable_router_advertisement,omitempty"`
 	VCPUs                           int64    `json:"vcpus,omitempty"`
 	MemoryMiB                       int64    `json:"memory_mib,omitempty"`
+	InitialMemoryBalloonTargetMiB   int64    `json:"initial_memory_balloon_target_mib,omitempty"`
+	MemoryBalloonTargetMiB          int64    `json:"memory_balloon_target_mib,omitempty"`
 	GuestPort                       uint32   `json:"guest_port,omitempty"`
 	LaunchSeconds                   int64    `json:"launch_seconds,omitempty"`
 	RunDir                          string   `json:"run_dir,omitempty"`

--- a/internal/backend/darwinvz/memory_balloon_darwin.go
+++ b/internal/backend/darwinvz/memory_balloon_darwin.go
@@ -1,0 +1,76 @@
+//go:build darwin
+
+package darwinvz
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+var darwinVZMemoryBalloonGrowSettle = time.Second
+
+func darwinVZInitialMemoryBalloonTargetMiB(memoryMiB int64) int64 {
+	if memoryMiB > darwinVZAdaptiveMemoryStartMiB {
+		return darwinVZAdaptiveMemoryStartMiB
+	}
+	return 0
+}
+
+func (a *Adapter) setDarwinVZMemoryBalloonTarget(ctx context.Context, helper *helperSession, vmID string, targetMiB int64) error {
+	if targetMiB <= darwinVZAdaptiveMemoryStartMiB {
+		return nil
+	}
+	helperRequest := a.helperRequestFn
+	if helperRequest == nil {
+		helperRequest = func(ctx context.Context, helper *helperSession, req helperControlRequest) (helperControlResponse, error) {
+			return helper.request(ctx, req)
+		}
+	}
+	if _, err := helperRequest(ctx, helper, helperControlRequest{
+		Op:                     "SetMemoryBalloonTarget",
+		VMID:                   vmID,
+		MemoryBalloonTargetMiB: targetMiB,
+	}); err != nil {
+		return fmt.Errorf("set darwin-vz memory balloon target to %d MiB: %w", targetMiB, err)
+	}
+	return nil
+}
+
+func (a *Adapter) growDarwinVZMemoryBalloonTarget(ctx context.Context, helper *helperSession, vmID string, targetMiB int64) error {
+	if targetMiB <= darwinVZAdaptiveMemoryStartMiB {
+		return nil
+	}
+	if err := a.setDarwinVZMemoryBalloonTarget(ctx, helper, vmID, targetMiB); err != nil {
+		return err
+	}
+	if darwinVZMemoryBalloonGrowSettle <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(darwinVZMemoryBalloonGrowSettle)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("wait for darwin-vz memory balloon target settle: %w", ctx.Err())
+	}
+}
+
+func (s *sandboxInstance) growDarwinVZMemoryBalloonTarget(ctx context.Context, adapter *Adapter) error {
+	targetMiB := s.FirecrackerConfig.MemoryMiB
+	if targetMiB <= darwinVZAdaptiveMemoryStartMiB {
+		return nil
+	}
+
+	s.memoryBalloonMu.Lock()
+	defer s.memoryBalloonMu.Unlock()
+	if s.memoryBalloonTargetMiB >= targetMiB {
+		return nil
+	}
+	if err := adapter.growDarwinVZMemoryBalloonTarget(ctx, s.Helper, s.VMID, targetMiB); err != nil {
+		return err
+	}
+	s.memoryBalloonTargetMiB = targetMiB
+	return nil
+}

--- a/internal/backend/darwinvz/memory_balloon_darwin_test.go
+++ b/internal/backend/darwinvz/memory_balloon_darwin_test.go
@@ -1,0 +1,191 @@
+//go:build darwin
+
+package darwinvz
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/buildkite/cleanroom/internal/vsockexec"
+)
+
+func TestDarwinVZInitialMemoryBalloonTargetMiB(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		memoryMiB int64
+		want      int64
+	}{
+		{name: "below adaptive start", memoryMiB: 512, want: 0},
+		{name: "at adaptive start", memoryMiB: 1024, want: 0},
+		{name: "above adaptive start", memoryMiB: 1025, want: 1024},
+		{name: "large cap", memoryMiB: 8192, want: 1024},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := darwinVZInitialMemoryBalloonTargetMiB(tt.memoryMiB); got != tt.want {
+				t.Fatalf("darwinVZInitialMemoryBalloonTargetMiB(%d) = %d, want %d", tt.memoryMiB, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWriteDarwinVZConfigIncludesInitialMemoryBalloonTarget(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "darwin-vz-config.json")
+	if err := writeDarwinVZConfig(
+		configPath,
+		"darwin-vz",
+		"/kernel",
+		"/rootfs",
+		"console=hvc0",
+		2,
+		8192,
+		1024,
+		10_700,
+		30,
+		darwinVZNetwork{Mode: darwinVZNetworkModeFileHandle},
+		nil,
+	); err != nil {
+		t.Fatalf("writeDarwinVZConfig returned error: %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	var cfg darwinVZConfigFile
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("decode config: %v", err)
+	}
+	if got, want := cfg.InitialMemoryBalloonTargetMiB, int64(1024); got != want {
+		t.Fatalf("initial memory balloon target = %d, want %d", got, want)
+	}
+}
+
+func TestExecuteInSandboxRestoresMemoryBalloonTargetBeforeGuestExec(t *testing.T) {
+	socketDir, err := os.MkdirTemp("", "cr-balloon-")
+	if err != nil {
+		t.Fatalf("create temp dir: %v", err)
+	}
+	defer os.RemoveAll(socketDir)
+	socketPath := filepath.Join(socketDir, "proxy.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen on unix socket: %v", err)
+	}
+	defer listener.Close()
+
+	serverErr := make(chan error, 1)
+	go func() {
+		conn, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			serverErr <- acceptErr
+			return
+		}
+		defer conn.Close()
+
+		var req vsockexec.ExecRequest
+		if err := json.NewDecoder(conn).Decode(&req); err != nil {
+			serverErr <- err
+			return
+		}
+		if got, want := req.Command, []string{"true"}; len(got) != len(want) || got[0] != want[0] {
+			t.Errorf("unexpected guest command: got %#v want %#v", got, want)
+		}
+		if err := vsockexec.EncodeStreamFrame(conn, vsockexec.ExecStreamFrame{Type: "exit", ExitCode: 0}); err != nil {
+			serverErr <- err
+			return
+		}
+		serverErr <- nil
+	}()
+
+	var helperReqs []helperControlRequest
+	adapter := &Adapter{
+		helperRequestFn: func(_ context.Context, helper *helperSession, req helperControlRequest) (helperControlResponse, error) {
+			if helper == nil {
+				t.Fatal("expected helper session")
+			}
+			helperReqs = append(helperReqs, req)
+			return helperControlResponse{OK: true}, nil
+		},
+	}
+
+	_, err = adapter.executeInSandbox(context.Background(), context.Background(), &sandboxInstance{
+		SandboxID: "cr-test",
+		VMID:      "vm-test",
+		FirecrackerConfig: backend.FirecrackerConfig{
+			MemoryMiB: 8192,
+		},
+		ProxySocketPath: socketPath,
+		Policy:          &policy.CompiledPolicy{NetworkDefault: "deny"},
+		Helper:          &helperSession{},
+		exitedCh:        make(chan struct{}),
+	}, backend.ExecutionRequest{
+		SandboxID:   "cr-test",
+		ExecutionID: "run-123",
+		Command:     []string{"true"},
+		Policy:      &policy.CompiledPolicy{NetworkDefault: "deny"},
+	}, backend.OutputStream{})
+	if err != nil {
+		t.Fatalf("executeInSandbox returned error: %v", err)
+	}
+	if err := <-serverErr; err != nil {
+		t.Fatalf("guest exec server returned error: %v", err)
+	}
+	if len(helperReqs) != 1 {
+		t.Fatalf("helper requests = %#v, want one SetMemoryBalloonTarget request", helperReqs)
+	}
+	req := helperReqs[0]
+	if req.Op != "SetMemoryBalloonTarget" {
+		t.Fatalf("helper op = %q, want SetMemoryBalloonTarget", req.Op)
+	}
+	if req.VMID != "vm-test" {
+		t.Fatalf("helper vm_id = %q, want vm-test", req.VMID)
+	}
+	if got, want := req.MemoryBalloonTargetMiB, int64(8192); got != want {
+		t.Fatalf("memory balloon target = %d, want %d", got, want)
+	}
+}
+
+func TestSandboxInstanceGrowsMemoryBalloonTargetOnce(t *testing.T) {
+	var helperReqs []helperControlRequest
+	adapter := &Adapter{
+		helperRequestFn: func(_ context.Context, _ *helperSession, req helperControlRequest) (helperControlResponse, error) {
+			helperReqs = append(helperReqs, req)
+			return helperControlResponse{OK: true}, nil
+		},
+	}
+	instance := &sandboxInstance{
+		VMID:   "vm-test",
+		Helper: &helperSession{},
+		FirecrackerConfig: backend.FirecrackerConfig{
+			MemoryMiB: 8192,
+		},
+		memoryBalloonTargetMiB: 1024,
+	}
+
+	if err := instance.growDarwinVZMemoryBalloonTarget(context.Background(), adapter); err != nil {
+		t.Fatalf("first grow returned error: %v", err)
+	}
+	if err := instance.growDarwinVZMemoryBalloonTarget(context.Background(), adapter); err != nil {
+		t.Fatalf("second grow returned error: %v", err)
+	}
+	if len(helperReqs) != 1 {
+		t.Fatalf("helper requests = %#v, want exactly one grow request", helperReqs)
+	}
+	if got, want := instance.memoryBalloonTargetMiB, int64(8192); got != want {
+		t.Fatalf("tracked memory balloon target = %d, want %d", got, want)
+	}
+}

--- a/internal/backend/darwinvz/vm_launch.go
+++ b/internal/backend/darwinvz/vm_launch.go
@@ -40,6 +40,7 @@ const (
 	darwinVZTimingGuestExecReadyProbe             = "guest_exec_ready_probe"
 	darwinVZTimingLaunchSandboxTotal              = "launch_sandbox_total"
 	darwinVZRootFSTimingExpectedPhaseCount        = 4
+	darwinVZAdaptiveMemoryStartMiB                = 1024
 )
 
 type darwinVZNetworkMetadata struct {
@@ -51,39 +52,41 @@ type darwinVZNetworkMetadata struct {
 }
 
 type darwinVZConfigFile struct {
-	Backend           string `json:"backend"`
-	KernelImage       string `json:"kernel_image"`
-	RootFS            string `json:"rootfs"`
-	VCPUs             int64  `json:"vcpus"`
-	MemoryMiB         int64  `json:"memory_mib"`
-	GuestPort         uint32 `json:"guest_port"`
-	LaunchSeconds     int64  `json:"launch_secs"`
-	NetworkMode       string `json:"network_mode,omitempty"`
-	NetworkSubnetCIDR string `json:"network_subnet_cidr,omitempty"`
-	NetworkGuestIP    string `json:"network_guest_ip,omitempty"`
-	NetworkGatewayIP  string `json:"network_gateway_ip,omitempty"`
-	NetworkPrefixLen  int    `json:"network_prefix_len,omitempty"`
-	BootArgs          string `json:"boot_args"`
+	Backend                       string `json:"backend"`
+	KernelImage                   string `json:"kernel_image"`
+	RootFS                        string `json:"rootfs"`
+	VCPUs                         int64  `json:"vcpus"`
+	MemoryMiB                     int64  `json:"memory_mib"`
+	InitialMemoryBalloonTargetMiB int64  `json:"initial_memory_balloon_target_mib,omitempty"`
+	GuestPort                     uint32 `json:"guest_port"`
+	LaunchSeconds                 int64  `json:"launch_secs"`
+	NetworkMode                   string `json:"network_mode,omitempty"`
+	NetworkSubnetCIDR             string `json:"network_subnet_cidr,omitempty"`
+	NetworkGuestIP                string `json:"network_guest_ip,omitempty"`
+	NetworkGatewayIP              string `json:"network_gateway_ip,omitempty"`
+	NetworkPrefixLen              int    `json:"network_prefix_len,omitempty"`
+	BootArgs                      string `json:"boot_args"`
 }
 
 type darwinVZVMStartRequest struct {
-	SandboxID        string
-	ConfigPath       string
-	BackendName      string
-	RunDir           string
-	KernelPath       string
-	RootFSPath       string
-	SidecarDiskPaths []string
-	BootArgs         string
-	ConsoleLogPath   string
-	NetworkCfg       darwinVZNetwork
-	HostGatewayURL   string
-	GatewayPort      int
-	Policy           *policy.CompiledPolicy
-	VCPUs            int64
-	MemoryMiB        int64
-	GuestPort        uint32
-	LaunchSeconds    int64
+	SandboxID                     string
+	ConfigPath                    string
+	BackendName                   string
+	RunDir                        string
+	KernelPath                    string
+	RootFSPath                    string
+	SidecarDiskPaths              []string
+	BootArgs                      string
+	ConsoleLogPath                string
+	NetworkCfg                    darwinVZNetwork
+	HostGatewayURL                string
+	GatewayPort                   int
+	Policy                        *policy.CompiledPolicy
+	VCPUs                         int64
+	MemoryMiB                     int64
+	InitialMemoryBalloonTargetMiB int64
+	GuestPort                     uint32
+	LaunchSeconds                 int64
 }
 
 type darwinVZVMStartResult struct {
@@ -103,6 +106,7 @@ func startDarwinVZHelperVM(ctx context.Context, helper *helperSession, req darwi
 		req.BootArgs,
 		req.VCPUs,
 		req.MemoryMiB,
+		req.InitialMemoryBalloonTargetMiB,
 		req.GuestPort,
 		req.LaunchSeconds,
 		req.NetworkCfg,
@@ -142,21 +146,22 @@ func startDarwinVZHelperVM(ctx context.Context, helper *helperSession, req darwi
 	startCtx, cancelStart := context.WithTimeout(ctx, time.Duration(req.LaunchSeconds)*time.Second)
 	defer cancelStart()
 	startRes, err := helper.request(startCtx, helperControlRequest{
-		Op:                   "StartVM",
-		KernelPath:           req.KernelPath,
-		RootFSPath:           req.RootFSPath,
-		SidecarDiskPaths:     append([]string(nil), req.SidecarDiskPaths...),
-		BootArgs:             req.BootArgs,
-		NetworkMode:          req.NetworkCfg.Mode,
-		VMNetSubnetCIDR:      req.NetworkCfg.SubnetCIDR,
-		VCPUs:                req.VCPUs,
-		MemoryMiB:            req.MemoryMiB,
-		GuestPort:            req.GuestPort,
-		LaunchSeconds:        req.LaunchSeconds,
-		RunDir:               req.RunDir,
-		FileHandleSocketPath: fileHandleGW.SocketPath(),
-		ProxySocketPath:      proxySocketPath,
-		ConsoleLogPath:       req.ConsoleLogPath,
+		Op:                            "StartVM",
+		KernelPath:                    req.KernelPath,
+		RootFSPath:                    req.RootFSPath,
+		SidecarDiskPaths:              append([]string(nil), req.SidecarDiskPaths...),
+		BootArgs:                      req.BootArgs,
+		NetworkMode:                   req.NetworkCfg.Mode,
+		VMNetSubnetCIDR:               req.NetworkCfg.SubnetCIDR,
+		VCPUs:                         req.VCPUs,
+		MemoryMiB:                     req.MemoryMiB,
+		InitialMemoryBalloonTargetMiB: req.InitialMemoryBalloonTargetMiB,
+		GuestPort:                     req.GuestPort,
+		LaunchSeconds:                 req.LaunchSeconds,
+		RunDir:                        req.RunDir,
+		FileHandleSocketPath:          fileHandleGW.SocketPath(),
+		ProxySocketPath:               proxySocketPath,
+		ConsoleLogPath:                req.ConsoleLogPath,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("start vm via darwin-vz helper: %w", err)
@@ -171,6 +176,7 @@ func startDarwinVZHelperVM(ctx context.Context, helper *helperSession, req darwi
 		req.BootArgs,
 		req.VCPUs,
 		req.MemoryMiB,
+		req.InitialMemoryBalloonTargetMiB,
 		req.GuestPort,
 		req.LaunchSeconds,
 		req.NetworkCfg,
@@ -207,6 +213,7 @@ func writeDarwinVZConfig(
 	path, backendName, kernelPath, rootFSPath, bootArgs string,
 	vcpus int64,
 	memoryMiB int64,
+	initialMemoryBalloonTargetMiB int64,
 	guestPort uint32,
 	launchSeconds int64,
 	networkCfg darwinVZNetwork,
@@ -216,15 +223,16 @@ func writeDarwinVZConfig(
 		return nil
 	}
 	cfg := darwinVZConfigFile{
-		Backend:       backendName,
-		KernelImage:   kernelPath,
-		RootFS:        rootFSPath,
-		VCPUs:         vcpus,
-		MemoryMiB:     memoryMiB,
-		GuestPort:     guestPort,
-		LaunchSeconds: launchSeconds,
-		NetworkMode:   networkCfg.Mode,
-		BootArgs:      bootArgs,
+		Backend:                       backendName,
+		KernelImage:                   kernelPath,
+		RootFS:                        rootFSPath,
+		VCPUs:                         vcpus,
+		MemoryMiB:                     memoryMiB,
+		InitialMemoryBalloonTargetMiB: initialMemoryBalloonTargetMiB,
+		GuestPort:                     guestPort,
+		LaunchSeconds:                 launchSeconds,
+		NetworkMode:                   networkCfg.Mode,
+		BootArgs:                      bootArgs,
 	}
 	if networkMetadata != nil {
 		cfg.NetworkMode = networkMetadata.Mode


### PR DESCRIPTION
Darwin VZ sandboxes can boot faster when the guest starts with a smaller effective memory target, but Cleanroom's user-facing resource contract still needs `memory_mib` to behave as the workload cap. Previously the helper always exposed the full configured memory target from VM creation onward, so there was no backend-owned way to keep boot small and still let larger workloads run without more config.

This keeps `memory_mib` as the launch ceiling and adds an internal balloon target flow:

- for caps above 1024 MiB, `StartVM` includes `initial_memory_balloon_target_mib=1024`
- the Swift helper applies that target before `vm.start`
- Go requests expansion back to `memory_mib` before guest workload execution and waits briefly for the guest to process the request
- persistent `sandbox create` remains at the low boot target until the first workload, then tracks that it has already grown so later execs do not pay the settle cost again

Example: a sandbox configured with `memory_mib=8192` still has an 8192 MiB cap, but the Darwin VZ helper asks the guest balloon to start at 1024 MiB during boot and expands back to 8192 MiB before workload execution. No policy or runtime config is added. The balloon operation is still a VZ/guest request, so the benchmark harness remains the source of truth for quantifying timing and host-footprint effects.

Validation:

- `scripts/build-darwin-vz-helper.sh /tmp/cleanroom-darwin-vz-adaptive-memory.app`
- `mise exec -- go test ./internal/backend/darwinvz`
- `mise exec -- go test ./internal/backend/... ./internal/vsockexec`
- `mise exec -- go test ./...`
- `git diff --check`