### PR TITLE
Disable interactive prompts in git credential fill

### DIFF
--- a/internal/gateway/credentials.go
+++ b/internal/gateway/credentials.go
@@ -135,6 +135,10 @@ func gitCredentialFillFromHost(dir, input string) (string, error) {
 	cmd := exec.Command("git", "credential", "fill")
 	cmd.Dir = dir
 	cmd.Stdin = strings.NewReader(input)
+	cmd.Env = append(os.Environ(),
+		"GIT_TERMINAL_PROMPT=0",
+		"GCM_INTERACTIVE=never",
+	)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", err

--- a/internal/gateway/credentials_test.go
+++ b/internal/gateway/credentials_test.go
@@ -3,6 +3,9 @@ package gateway
 import (
 	"context"
 	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -98,6 +101,37 @@ func TestGitCredentialFillProviderResolveUsesCanonicalRemoteURL(t *testing.T) {
 	wantHeader := "Basic " + base64.StdEncoding.EncodeToString([]byte("git:secret"))
 	if header != wantHeader {
 		t.Fatalf("unexpected authorization header: got %q want %q", header, wantHeader)
+	}
+}
+
+func TestGitCredentialFillFromHostDisablesPrompts(t *testing.T) {
+	tmpDir := t.TempDir()
+	envFile := filepath.Join(tmpDir, "env.txt")
+
+	shimScript := "#!/bin/sh\n/usr/bin/env > " + envFile + "\nexit 1\n"
+	shimPath := filepath.Join(tmpDir, "git")
+	if err := os.WriteFile(shimPath, []byte(shimScript), 0o755); err != nil {
+		t.Fatalf("write git shim: %v", err)
+	}
+
+	t.Setenv("PATH", tmpDir)
+
+	_, err := gitCredentialFillFromHost(tmpDir, "protocol=https\nhost=example.com\n\n")
+	if err == nil {
+		t.Fatal("expected non-nil error from shim exiting non-zero")
+	}
+
+	captured, readErr := os.ReadFile(envFile)
+	if readErr != nil {
+		t.Fatalf("read captured env: %v", readErr)
+	}
+	env := string(captured)
+
+	if !strings.Contains(env, "GIT_TERMINAL_PROMPT=0") {
+		t.Errorf("GIT_TERMINAL_PROMPT=0 not found in captured env:\n%s", env)
+	}
+	if !strings.Contains(env, "GCM_INTERACTIVE=never") {
+		t.Errorf("GCM_INTERACTIVE=never not found in captured env:\n%s", env)
 	}
 }
 


### PR DESCRIPTION
## Description

When no credential helper matches a host, git falls through to its built-in askpass and blocks on the controlling tty. On a cleanroom server this wedges the services stage for Docker Hub and other OCI registry pulls.

Setting `GIT_TERMINAL_PROMPT=0` disables git's built-in askpass for HTTPS. Setting `GCM_INTERACTIVE=never` disables Git Credential Manager's UI for users who have it installed. Credential helpers that do match a host continue to work as before — the change only affects the failure path.

## Changes

- Set `GIT_TERMINAL_PROMPT=0` and `GCM_INTERACTIVE=never` in `git credential fill` execution environment
- Added tests covering the new env vars are passed through correctly

## Verification

Run the unit tests:

```
go test ./internal/gateway/...
```

Credential helpers that match a host should still resolve credentials normally. On a host with no matching helper, `git credential fill` should now fail fast rather than blocking on tty input.

## Rollback

Safe to revert — no state changes, no migrations. Reverting removes the env vars; `git credential fill` would revert to potentially blocking on tty input when no helper matches.