### PR TITLE
feat: Add minimum_cache_output_volume_bytes config setting

### DIFF
--- a/docs/caching.md
+++ b/docs/caching.md
@@ -82,6 +82,33 @@ Use service blocks for database files, Docker state, fixture stores, or other
 guest-local state that is expensive to rebuild but safe to reuse from declared
 inputs.
 
+## Cache Output Volume Size
+
+Cache output volumes are sparse ext4 images on the host. When Cleanroom creates
+a new volume — or restores one from an older snapshot — it enforces a minimum
+size. The default is 512 MiB.
+
+If your service block pulls large container images into `/var/lib/docker`
+(Kafka, Postgres builds, schema-registry, and similar), you may need more
+headroom. Set `minimum_cache_output_volume_bytes` in your runtime config:
+
+```yaml
+backends:
+  darwin-vz:
+    minimum_cache_output_volume_bytes: 16GiB
+```
+
+```yaml
+backends:
+  firecracker:
+    minimum_cache_output_volume_bytes: 16GiB
+```
+
+Because the images are sparse, raising this value doesn't immediately consume
+host disk space — only actual writes do. Existing on-disk writable volumes keep
+their current size; the new minimum only applies when a volume is first created
+or restored from a snapshot that predates the setting.
+
 ## Host Cache Peers
 
 Runtime config can point Cleanroom at trusted cache peers:

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -86,7 +86,8 @@ inputs.
 
 Cache output volumes are sparse ext4 images on the host. When Cleanroom creates
 a new volume — or restores one from an older snapshot — it enforces a minimum
-size. The default is 512 MiB.
+size. The default is 32 GiB.
+<!-- tracks cacheoutput.DefaultVolumeMinimumBytes -->
 
 If your service block pulls large container images into `/var/lib/docker`
 (Kafka, Postgres builds, schema-registry, and similar), you may need more

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -86,7 +86,7 @@ inputs.
 
 Cache output volumes are sparse ext4 images on the host. When Cleanroom creates
 a new volume — or restores one from an older snapshot — it enforces a minimum
-size. The default is 32 GiB.
+size. The default is 512 MiB.
 <!-- tracks cacheoutput.DefaultVolumeMinimumBytes -->
 
 If your service block pulls large container images into `/var/lib/docker`

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -408,7 +408,12 @@ type FirecrackerConfig struct {
 	// MinimumRootFSBytes is a writable rootfs capacity floor. Backends may
 	// provide this as logical capacity or a larger backend default; it is not an
 	// exact host-disk allocation promise.
-	MinimumRootFSBytes                        int64
+	MinimumRootFSBytes int64
+	// MinimumCacheOutputVolumeBytes is a per-cache-output-volume capacity floor.
+	// Backends may provide this as logical capacity or a larger backend default;
+	// it is not an exact host-disk allocation promise. Zero means fall back to
+	// the backend's package-level default.
+	MinimumCacheOutputVolumeBytes int64
 	DarwinVZNetworkMode                       string
 	DarwinVZNetworkSubnet                     string
 	DarwinVZNetworkExternalInterface          string

--- a/internal/backend/darwinvz/cache_output_volumes_darwin.go
+++ b/internal/backend/darwinvz/cache_output_volumes_darwin.go
@@ -31,6 +31,13 @@ type preparedDarwinVZCacheOutputVolume struct {
 	MountPath  string
 }
 
+func resolveDarwinVZCacheOutputVolumeMinimumBytes(cfg backend.FirecrackerConfig) int64 {
+	if cfg.MinimumCacheOutputVolumeBytes > 0 {
+		return cfg.MinimumCacheOutputVolumeBytes
+	}
+	return darwinVZCacheOutputVolumeMinimumBytes
+}
+
 func prepareDarwinVZCacheOutputVolumes(ctx context.Context, cfg backend.FirecrackerConfig, sandboxID, runDir string, specs []backend.CacheOutputVolumeSpec) ([]preparedDarwinVZCacheOutputVolume, func(), error) {
 	if len(specs) == 0 {
 		return nil, func() {}, nil
@@ -70,7 +77,7 @@ func prepareDarwinVZCacheOutputVolumes(ctx context.Context, cfg backend.Firecrac
 		}
 		runtimeVolumeID := darwinVZCacheOutputRuntimeVolumeID(sandboxID, spec.VolumeID, i)
 		attachmentPath := filepath.Join(runDir, fmt.Sprintf("cache-output-%02d.ext4", i))
-		volume, volumeCleanup, err := prepareDarwinVZCacheOutputWritableVolume(ctx, volumeCfg, runtimeVolumeID, attachmentPath, sourceRef, darwinVZCacheOutputVolumeMinimumBytes)
+		volume, volumeCleanup, err := prepareDarwinVZCacheOutputWritableVolume(ctx, volumeCfg, runtimeVolumeID, attachmentPath, sourceRef, resolveDarwinVZCacheOutputVolumeMinimumBytes(volumeCfg))
 		if err != nil {
 			cleanup()
 			return nil, nil, fmt.Errorf("cache output volume %q: %w", spec.VolumeID, err)
@@ -95,7 +102,7 @@ func darwinVZCacheOutputVolumeSource(ctx context.Context, cfg backend.Firecracke
 	}
 	if sourceRef == "" {
 		sourceRef = filepath.Join(runDir, "cache-output-empty-base.ext4")
-		if err := createEmptyDarwinVZCacheOutputExt4ImageFn(ctx, sourceRef, darwinVZCacheOutputVolumeMinimumBytes); err != nil {
+		if err := createEmptyDarwinVZCacheOutputExt4ImageFn(ctx, sourceRef, resolveDarwinVZCacheOutputVolumeMinimumBytes(volumeCfg)); err != nil {
 			return "", volumeCfg, fmt.Errorf("create empty cache output volume source: %w", err)
 		}
 		return sourceRef, volumeCfg, nil

--- a/internal/backend/darwinvz/cache_output_volumes_darwin.go
+++ b/internal/backend/darwinvz/cache_output_volumes_darwin.go
@@ -20,8 +20,9 @@ const defaultDarwinVZCacheOutputVolumeMinimumBytes int64 = cacheoutput.DefaultVo
 const darwinVZCacheOutputGuestMountRoot = cacheoutput.GuestMountRoot
 
 var (
-	darwinVZCacheOutputVolumeMinimumBytes     = defaultDarwinVZCacheOutputVolumeMinimumBytes
-	createEmptyDarwinVZCacheOutputExt4ImageFn = createEmptyDarwinVZCacheOutputExt4Image
+	darwinVZCacheOutputVolumeMinimumBytes          = defaultDarwinVZCacheOutputVolumeMinimumBytes
+	createEmptyDarwinVZCacheOutputExt4ImageFn      = createEmptyDarwinVZCacheOutputExt4Image
+	prepareDarwinVZCacheOutputWritableVolumeFn     = prepareDarwinVZCacheOutputWritableVolume
 )
 
 type preparedDarwinVZCacheOutputVolume struct {
@@ -77,7 +78,7 @@ func prepareDarwinVZCacheOutputVolumes(ctx context.Context, cfg backend.Firecrac
 		}
 		runtimeVolumeID := darwinVZCacheOutputRuntimeVolumeID(sandboxID, spec.VolumeID, i)
 		attachmentPath := filepath.Join(runDir, fmt.Sprintf("cache-output-%02d.ext4", i))
-		volume, volumeCleanup, err := prepareDarwinVZCacheOutputWritableVolume(ctx, volumeCfg, runtimeVolumeID, attachmentPath, sourceRef, resolveDarwinVZCacheOutputVolumeMinimumBytes(volumeCfg))
+		volume, volumeCleanup, err := prepareDarwinVZCacheOutputWritableVolumeFn(ctx, volumeCfg, runtimeVolumeID, attachmentPath, sourceRef, resolveDarwinVZCacheOutputVolumeMinimumBytes(volumeCfg))
 		if err != nil {
 			cleanup()
 			return nil, nil, fmt.Errorf("cache output volume %q: %w", spec.VolumeID, err)

--- a/internal/backend/darwinvz/cache_output_volumes_test.go
+++ b/internal/backend/darwinvz/cache_output_volumes_test.go
@@ -146,13 +146,15 @@ func TestPrepareDarwinVZCacheOutputVolumesCfgMinimumBytesOverridesPackageDefault
 	})
 	darwinVZCacheOutputVolumeMinimumBytes = 1024
 
-	var capturedMinimumBytes int64
+	var capturedEmptyMinimumBytes int64
 	createEmptyDarwinVZCacheOutputExt4ImageFn = func(_ context.Context, path string, minimumBytes int64) error {
-		capturedMinimumBytes = minimumBytes
+		capturedEmptyMinimumBytes = minimumBytes
 		return os.WriteFile(path, []byte("empty-ext4"), 0o644)
 	}
 
-	prepareDarwinVZCacheOutputWritableVolumeFn = func(_ context.Context, _ backend.FirecrackerConfig, volumeID, attachmentPath, sourceRef string, _ int64) (volumestore.WritableVolume, func(), error) {
+	var capturedWritableMinimumBytes int64
+	prepareDarwinVZCacheOutputWritableVolumeFn = func(_ context.Context, _ backend.FirecrackerConfig, volumeID, attachmentPath, sourceRef string, minimumBytes int64) (volumestore.WritableVolume, func(), error) {
+		capturedWritableMinimumBytes = minimumBytes
 		if sourceRef == "" {
 			return volumestore.WritableVolume{}, nil, errors.New("unexpected empty source ref")
 		}
@@ -183,7 +185,10 @@ func TestPrepareDarwinVZCacheOutputVolumesCfgMinimumBytesOverridesPackageDefault
 	}
 	defer cleanup()
 
-	if got, want := capturedMinimumBytes, int64(16<<30); got != want {
+	if got, want := capturedEmptyMinimumBytes, int64(16<<30); got != want {
 		t.Fatalf("minimumBytes passed to createEmptyDarwinVZCacheOutputExt4ImageFn: got %d want %d", got, want)
+	}
+	if got, want := capturedWritableMinimumBytes, int64(16<<30); got != want {
+		t.Fatalf("minimumBytes passed to prepareDarwinVZCacheOutputWritableVolumeFn: got %d want %d", got, want)
 	}
 }

--- a/internal/backend/darwinvz/cache_output_volumes_test.go
+++ b/internal/backend/darwinvz/cache_output_volumes_test.go
@@ -3,6 +3,9 @@
 package darwinvz
 
 import (
+	"context"
+	"errors"
+	"os"
 	"reflect"
 	"testing"
 
@@ -128,5 +131,59 @@ func TestDarwinVZCacheOutputDevicePathSkipsRootDisk(t *testing.T) {
 		if got := darwinVZCacheOutputDevicePath(index); got != want {
 			t.Fatalf("cacheOutputDevicePath(%d) = %q, want %q", index, got, want)
 		}
+	}
+}
+
+func TestPrepareDarwinVZCacheOutputVolumesCfgMinimumBytesOverridesPackageDefault(t *testing.T) {
+	runDir := t.TempDir()
+	prevCreateEmpty := createEmptyDarwinVZCacheOutputExt4ImageFn
+	prevPrepareFn := prepareDarwinVZCacheOutputWritableVolumeFn
+	prevMinimumBytes := darwinVZCacheOutputVolumeMinimumBytes
+	t.Cleanup(func() {
+		createEmptyDarwinVZCacheOutputExt4ImageFn = prevCreateEmpty
+		prepareDarwinVZCacheOutputWritableVolumeFn = prevPrepareFn
+		darwinVZCacheOutputVolumeMinimumBytes = prevMinimumBytes
+	})
+	darwinVZCacheOutputVolumeMinimumBytes = 1024
+
+	var capturedMinimumBytes int64
+	createEmptyDarwinVZCacheOutputExt4ImageFn = func(_ context.Context, path string, minimumBytes int64) error {
+		capturedMinimumBytes = minimumBytes
+		return os.WriteFile(path, []byte("empty-ext4"), 0o644)
+	}
+
+	prepareDarwinVZCacheOutputWritableVolumeFn = func(_ context.Context, _ backend.FirecrackerConfig, volumeID, attachmentPath, sourceRef string, _ int64) (volumestore.WritableVolume, func(), error) {
+		if sourceRef == "" {
+			return volumestore.WritableVolume{}, nil, errors.New("unexpected empty source ref")
+		}
+		return volumestore.WritableVolume{
+			Ref:            "volume:" + volumeID,
+			AttachmentPath: attachmentPath,
+		}, func() {}, nil
+	}
+
+	cfg := backend.FirecrackerConfig{
+		MinimumCacheOutputVolumeBytes: 16 << 30,
+	}
+	specs := []backend.CacheOutputVolumeSpec{
+		{
+			Stage:     "service-volume",
+			BlockName: "postgres",
+			CacheKey:  "service-volume:v1:postgres",
+			VolumeID:  "service-volume-def456",
+			DirMappings: []backend.CacheOutputDirMapping{
+				{GuestPath: "/var/lib/cleanroom/services/postgres", Subpath: "dirs/0"},
+			},
+		},
+	}
+
+	_, cleanup, err := prepareDarwinVZCacheOutputVolumes(context.Background(), cfg, "sandbox-1", runDir, specs)
+	if err != nil {
+		t.Fatalf("prepareDarwinVZCacheOutputVolumes returned error: %v", err)
+	}
+	defer cleanup()
+
+	if got, want := capturedMinimumBytes, int64(16<<30); got != want {
+		t.Fatalf("minimumBytes passed to createEmptyDarwinVZCacheOutputExt4ImageFn: got %d want %d", got, want)
 	}
 }

--- a/internal/backend/firecracker/cache_output_volumes.go
+++ b/internal/backend/firecracker/cache_output_volumes.go
@@ -29,6 +29,13 @@ type preparedCacheOutputVolume struct {
 	Volume volumestore.WritableVolume
 }
 
+func resolveCacheOutputVolumeMinimumBytes(cfg backend.FirecrackerConfig) int64 {
+	if cfg.MinimumCacheOutputVolumeBytes > 0 {
+		return cfg.MinimumCacheOutputVolumeBytes
+	}
+	return cacheOutputVolumeMinimumBytes
+}
+
 func prepareCacheOutputVolumes(ctx context.Context, logger *charmlog.Logger, cfg backend.FirecrackerConfig, sandboxID, runDir string, specs []backend.CacheOutputVolumeSpec) ([]preparedCacheOutputVolume, func(), error) {
 	if len(specs) == 0 {
 		return nil, func() {}, nil
@@ -66,7 +73,7 @@ func prepareCacheOutputVolumes(ctx context.Context, logger *charmlog.Logger, cfg
 		}
 		runtimeVolumeID := cacheOutputRuntimeVolumeID(sandboxID, spec.VolumeID, i)
 		attachmentPath := filepath.Join(runDir, fmt.Sprintf("cache-output-%02d.ext4", i))
-		volume, volumeCleanup, err := prepareWritableVolumeWithLogger(ctx, logger, volumeCfg, runtimeVolumeID, attachmentPath, sourceRef, cacheOutputVolumeMinimumBytes)
+		volume, volumeCleanup, err := prepareWritableVolumeWithLogger(ctx, logger, volumeCfg, runtimeVolumeID, attachmentPath, sourceRef, resolveCacheOutputVolumeMinimumBytes(volumeCfg))
 		if err != nil {
 			cleanup()
 			return nil, nil, fmt.Errorf("cache output volume %q: %w", spec.VolumeID, err)
@@ -94,7 +101,7 @@ func cacheOutputVolumeSource(ctx context.Context, cfg backend.FirecrackerConfig,
 	}
 	if sourceRef == "" {
 		sourceRef = filepath.Join(runDir, "cache-output-empty-base.ext4")
-		if err := createEmptyCacheOutputExt4ImageFn(ctx, sourceRef, cacheOutputVolumeMinimumBytes); err != nil {
+		if err := createEmptyCacheOutputExt4ImageFn(ctx, sourceRef, resolveCacheOutputVolumeMinimumBytes(volumeCfg)); err != nil {
 			return "", volumeCfg, fmt.Errorf("create empty cache output volume source: %w", err)
 		}
 		return sourceRef, volumeCfg, nil

--- a/internal/backend/firecracker/cache_output_volumes_test.go
+++ b/internal/backend/firecracker/cache_output_volumes_test.go
@@ -312,6 +312,105 @@ func TestPrepareCacheOutputVolumesCleansUpOnFailure(t *testing.T) {
 	}
 }
 
+func TestPrepareCacheOutputVolumesCfgMinimumBytesOverridesPackageDefault(t *testing.T) {
+	runDir := t.TempDir()
+	prevDriverFn := rootFSVolumeStoreDriverFn
+	prevCreateEmpty := createEmptyCacheOutputExt4ImageFn
+	prevMinimumBytes := cacheOutputVolumeMinimumBytes
+	t.Cleanup(func() {
+		rootFSVolumeStoreDriverFn = prevDriverFn
+		createEmptyCacheOutputExt4ImageFn = prevCreateEmpty
+		cacheOutputVolumeMinimumBytes = prevMinimumBytes
+	})
+	cacheOutputVolumeMinimumBytes = 1024
+
+	var capturedMinimumBytes int64
+	createEmptyCacheOutputExt4ImageFn = func(_ context.Context, path string, minimumBytes int64) error {
+		capturedMinimumBytes = minimumBytes
+		return os.WriteFile(path, []byte("empty-ext4"), 0o644)
+	}
+
+	rootFSVolumeStoreDriverFn = func(backend.FirecrackerConfig) (volumestore.Driver, error) {
+		return resizingTestVolumeDriver{
+			ensureBaseVolumeFn: func(_ context.Context, req volumestore.EnsureBaseVolumeRequest) (volumestore.BaseVolume, error) {
+				return volumestore.BaseVolume{Ref: "base:" + filepath.Base(req.SourcePath)}, nil
+			},
+			createWritableVolumeFn: func(_ context.Context, req volumestore.CreateWritableVolumeRequest) (volumestore.WritableVolume, error) {
+				return volumestore.WritableVolume{
+					Ref:            "volume:" + req.VolumeID,
+					AttachmentPath: req.AttachmentPath,
+				}, nil
+			},
+		}, nil
+	}
+
+	cfg := backend.FirecrackerConfig{
+		MinimumCacheOutputVolumeBytes: 16 << 30,
+	}
+	specs := []backend.CacheOutputVolumeSpec{
+		{
+			Stage:     "service-volume",
+			BlockName: "postgres",
+			CacheKey:  "service-volume:v1:postgres",
+			VolumeID:  "service-volume-def456",
+			DirMappings: []backend.CacheOutputDirMapping{
+				{GuestPath: "/var/lib/cleanroom/services/postgres", Subpath: "dirs/0"},
+			},
+		},
+	}
+
+	_, cleanup, err := prepareCacheOutputVolumes(context.Background(), nil, cfg, "sandbox-1", runDir, specs)
+	if err != nil {
+		t.Fatalf("prepareCacheOutputVolumes returned error: %v", err)
+	}
+	defer cleanup()
+
+	if got, want := capturedMinimumBytes, int64(16<<30); got != want {
+		t.Fatalf("minimumBytes passed to createEmptyCacheOutputExt4ImageFn: got %d want %d", got, want)
+	}
+}
+
+type resizingTestVolumeDriver struct {
+	ensureBaseVolumeFn     func(context.Context, volumestore.EnsureBaseVolumeRequest) (volumestore.BaseVolume, error)
+	createWritableVolumeFn func(context.Context, volumestore.CreateWritableVolumeRequest) (volumestore.WritableVolume, error)
+}
+
+func (d resizingTestVolumeDriver) Name() string { return "resizing-test" }
+
+func (d resizingTestVolumeDriver) EnsureBaseVolume(ctx context.Context, req volumestore.EnsureBaseVolumeRequest) (volumestore.BaseVolume, error) {
+	if d.ensureBaseVolumeFn == nil {
+		return volumestore.BaseVolume{}, errors.New("unexpected EnsureBaseVolume call")
+	}
+	return d.ensureBaseVolumeFn(ctx, req)
+}
+
+func (d resizingTestVolumeDriver) CreateWritableVolume(ctx context.Context, req volumestore.CreateWritableVolumeRequest) (volumestore.WritableVolume, error) {
+	if d.createWritableVolumeFn == nil {
+		return volumestore.WritableVolume{}, errors.New("unexpected CreateWritableVolume call")
+	}
+	return d.createWritableVolumeFn(ctx, req)
+}
+
+func (d resizingTestVolumeDriver) SnapshotVolume(_ context.Context, _ volumestore.SnapshotVolumeRequest) (volumestore.Snapshot, error) {
+	return volumestore.Snapshot{}, errors.New("unexpected SnapshotVolume call")
+}
+
+func (d resizingTestVolumeDriver) CloneSnapshotToVolume(_ context.Context, _ volumestore.CloneSnapshotToVolumeRequest) (volumestore.WritableVolume, error) {
+	return volumestore.WritableVolume{}, errors.New("unexpected CloneSnapshotToVolume call")
+}
+
+func (d resizingTestVolumeDriver) DestroyVolume(_ context.Context, _ volumestore.DestroyVolumeRequest) error {
+	return nil
+}
+
+func (d resizingTestVolumeDriver) DestroySnapshot(_ context.Context, _ volumestore.DestroySnapshotRequest) error {
+	return nil
+}
+
+func (d resizingTestVolumeDriver) EnsureWritableVolumeMinimumSize(_ context.Context, _ volumestore.WritableVolume, _ int64) error {
+	return nil
+}
+
 func testCacheOutputVolumeSpecs() []backend.CacheOutputVolumeSpec {
 	return []backend.CacheOutputVolumeSpec{
 		{

--- a/internal/runtimeconfig/config.go
+++ b/internal/runtimeconfig/config.go
@@ -125,22 +125,24 @@ type FirecrackerConfig struct {
 	PrivilegedHelperPath string         `yaml:"privileged_helper_path"`
 	VCPUs                int64          `yaml:"vcpus"`
 	MemoryMiB            int64          `yaml:"memory_mib"`
-	GuestCID             uint32         `yaml:"guest_cid"`
-	GuestPort            uint32         `yaml:"guest_port"`
-	LaunchSeconds        int64          `yaml:"launch_seconds"` // VM boot/guest-agent readiness timeout
+	GuestCID                      uint32         `yaml:"guest_cid"`
+	GuestPort                     uint32         `yaml:"guest_port"`
+	LaunchSeconds                 int64          `yaml:"launch_seconds"` // VM boot/guest-agent readiness timeout
+	MinimumCacheOutputVolumeBytes ByteSize       `yaml:"minimum_cache_output_volume_bytes"`
 }
 
 type DarwinVZConfig struct {
-	KernelImage        string                `yaml:"kernel_image"`
-	RootFS             string                `yaml:"rootfs"`
-	MinimumRootFSBytes ByteSize              `yaml:"minimum_rootfs_bytes"`
-	Network            DarwinVZNetworkConfig `yaml:"network,omitempty"`
-	Services           ServicesConfig        `yaml:"services"`
-	Snapshots          SnapshotConfig        `yaml:"snapshots"`
-	VCPUs              int64                 `yaml:"vcpus"`
-	MemoryMiB          int64                 `yaml:"memory_mib"`
-	GuestPort          uint32                `yaml:"guest_port"`
-	LaunchSeconds      int64                 `yaml:"launch_seconds"` // VM boot/guest-agent readiness timeout
+	KernelImage                   string                `yaml:"kernel_image"`
+	RootFS                        string                `yaml:"rootfs"`
+	MinimumRootFSBytes            ByteSize              `yaml:"minimum_rootfs_bytes"`
+	MinimumCacheOutputVolumeBytes ByteSize              `yaml:"minimum_cache_output_volume_bytes"`
+	Network                       DarwinVZNetworkConfig `yaml:"network,omitempty"`
+	Services                      ServicesConfig        `yaml:"services"`
+	Snapshots                     SnapshotConfig        `yaml:"snapshots"`
+	VCPUs                         int64                 `yaml:"vcpus"`
+	MemoryMiB                     int64                 `yaml:"memory_mib"`
+	GuestPort                     uint32                `yaml:"guest_port"`
+	LaunchSeconds                 int64                 `yaml:"launch_seconds"` // VM boot/guest-agent readiness timeout
 }
 
 type DarwinVZNetworkConfig struct {
@@ -202,11 +204,12 @@ func MergeBackendConfig(cfg Config, backendName string, launchSeconds int64) bac
 			QuiesceTimeoutSeconds: cfg.Backends.Firecracker.Snapshots.QuiesceTimeoutSeconds,
 		},
 		PrivilegedHelperPath: cfg.Backends.Firecracker.PrivilegedHelperPath,
-		VCPUs:                cfg.Backends.Firecracker.VCPUs,
-		MemoryMiB:            cfg.Backends.Firecracker.MemoryMiB,
-		GuestCID:             cfg.Backends.Firecracker.GuestCID,
-		GuestPort:            cfg.Backends.Firecracker.GuestPort,
-		LaunchSeconds:        cfg.Backends.Firecracker.LaunchSeconds,
+		VCPUs:                         cfg.Backends.Firecracker.VCPUs,
+		MemoryMiB:                     cfg.Backends.Firecracker.MemoryMiB,
+		GuestCID:                      cfg.Backends.Firecracker.GuestCID,
+		GuestPort:                     cfg.Backends.Firecracker.GuestPort,
+		LaunchSeconds:                 cfg.Backends.Firecracker.LaunchSeconds,
+		MinimumCacheOutputVolumeBytes: int64(cfg.Backends.Firecracker.MinimumCacheOutputVolumeBytes),
 	}
 	if backendName == "darwin-vz" {
 		out.KernelImagePath = cfg.Backends.DarwinVZ.KernelImage
@@ -233,6 +236,7 @@ func MergeBackendConfig(cfg Config, backendName string, launchSeconds int64) bac
 		out.MemoryMiB = cfg.Backends.DarwinVZ.MemoryMiB
 		out.GuestPort = cfg.Backends.DarwinVZ.GuestPort
 		out.LaunchSeconds = cfg.Backends.DarwinVZ.LaunchSeconds
+		out.MinimumCacheOutputVolumeBytes = int64(cfg.Backends.DarwinVZ.MinimumCacheOutputVolumeBytes)
 	}
 
 	out.Launch = true
@@ -359,8 +363,12 @@ func parseConfig(path string, raw []byte) (Config, error) {
 	presenceCfg := struct {
 		Backends struct {
 			DarwinVZ struct {
-				MinimumRootFSBytes *ByteSize `yaml:"minimum_rootfs_bytes"`
+				MinimumRootFSBytes            *ByteSize `yaml:"minimum_rootfs_bytes"`
+				MinimumCacheOutputVolumeBytes *ByteSize `yaml:"minimum_cache_output_volume_bytes"`
 			} `yaml:"darwin-vz"`
+			Firecracker struct {
+				MinimumCacheOutputVolumeBytes *ByteSize `yaml:"minimum_cache_output_volume_bytes"`
+			} `yaml:"firecracker"`
 		} `yaml:"backends"`
 	}{}
 	if err := yaml.Unmarshal(raw, &presenceCfg); err != nil {
@@ -369,6 +377,10 @@ func parseConfig(path string, raw []byte) (Config, error) {
 
 	darwinVZMinRootFSBytes := cfg.Backends.DarwinVZ.MinimumRootFSBytes
 	darwinVZMinRootFSBytesSet := presenceCfg.Backends.DarwinVZ.MinimumRootFSBytes != nil
+	darwinVZMinCacheOutputVolumeBytes := cfg.Backends.DarwinVZ.MinimumCacheOutputVolumeBytes
+	darwinVZMinCacheOutputVolumeBytesSet := presenceCfg.Backends.DarwinVZ.MinimumCacheOutputVolumeBytes != nil
+	firecrackerMinCacheOutputVolumeBytes := cfg.Backends.Firecracker.MinimumCacheOutputVolumeBytes
+	firecrackerMinCacheOutputVolumeBytesSet := presenceCfg.Backends.Firecracker.MinimumCacheOutputVolumeBytes != nil
 	if darwinVZConfigIsZero(cfg.Backends.DarwinVZ) {
 		if darwinVZConfigHasValues(rawCfg.Backends.DarwinVZLegacy) {
 			cfg.Backends.DarwinVZ = rawCfg.Backends.DarwinVZLegacy
@@ -376,6 +388,12 @@ func parseConfig(path string, raw []byte) (Config, error) {
 	}
 	if darwinVZMinRootFSBytesSet {
 		cfg.Backends.DarwinVZ.MinimumRootFSBytes = darwinVZMinRootFSBytes
+	}
+	if darwinVZMinCacheOutputVolumeBytesSet {
+		cfg.Backends.DarwinVZ.MinimumCacheOutputVolumeBytes = darwinVZMinCacheOutputVolumeBytes
+	}
+	if firecrackerMinCacheOutputVolumeBytesSet {
+		cfg.Backends.Firecracker.MinimumCacheOutputVolumeBytes = firecrackerMinCacheOutputVolumeBytes
 	}
 
 	cfg = normalizeConfig(cfg, inferredDefaultBackend(backendPresence.Backends.Firecracker != nil, backendPresence.Backends.DarwinVZ != nil || backendPresence.Backends.LegacyDarwinVZ != nil))

--- a/internal/runtimeconfig/config.go
+++ b/internal/runtimeconfig/config.go
@@ -137,12 +137,12 @@ type DarwinVZConfig struct {
 	MinimumRootFSBytes            ByteSize              `yaml:"minimum_rootfs_bytes"`
 	MinimumCacheOutputVolumeBytes ByteSize              `yaml:"minimum_cache_output_volume_bytes"`
 	Network                       DarwinVZNetworkConfig `yaml:"network,omitempty"`
-	Services           ServicesConfig        `yaml:"services"`
-	Snapshots          SnapshotConfig        `yaml:"snapshots"`
-	VCPUs              int64                 `yaml:"vcpus"`
-	MemoryMiB          int64                 `yaml:"memory_mib"`
-	GuestPort          uint32                `yaml:"guest_port"`
-	LaunchSeconds      int64                 `yaml:"launch_seconds"` // VM boot/guest-agent readiness timeout
+	Services                      ServicesConfig        `yaml:"services"`
+	Snapshots                     SnapshotConfig        `yaml:"snapshots"`
+	VCPUs                         int64                 `yaml:"vcpus"`
+	MemoryMiB                     int64                 `yaml:"memory_mib"`
+	GuestPort                     uint32                `yaml:"guest_port"`
+	LaunchSeconds                 int64                 `yaml:"launch_seconds"` // VM boot/guest-agent readiness timeout
 }
 
 type DarwinVZNetworkConfig struct {
@@ -203,12 +203,13 @@ func MergeBackendConfig(cfg Config, backendName string, launchSeconds int64) bac
 			ZFSDataset:            cfg.Backends.Firecracker.Snapshots.ZFSDataset,
 			QuiesceTimeoutSeconds: cfg.Backends.Firecracker.Snapshots.QuiesceTimeoutSeconds,
 		},
-		PrivilegedHelperPath: cfg.Backends.Firecracker.PrivilegedHelperPath,
-		VCPUs:                cfg.Backends.Firecracker.VCPUs,
-		MemoryMiB:            cfg.Backends.Firecracker.MemoryMiB,
-		GuestCID:             cfg.Backends.Firecracker.GuestCID,
-		GuestPort:            cfg.Backends.Firecracker.GuestPort,
-		LaunchSeconds:        cfg.Backends.Firecracker.LaunchSeconds,
+		PrivilegedHelperPath:          cfg.Backends.Firecracker.PrivilegedHelperPath,
+		VCPUs:                         cfg.Backends.Firecracker.VCPUs,
+		MemoryMiB:                     cfg.Backends.Firecracker.MemoryMiB,
+		GuestCID:                      cfg.Backends.Firecracker.GuestCID,
+		GuestPort:                     cfg.Backends.Firecracker.GuestPort,
+		LaunchSeconds:                 cfg.Backends.Firecracker.LaunchSeconds,
+		MinimumCacheOutputVolumeBytes: int64(cfg.Backends.Firecracker.MinimumCacheOutputVolumeBytes),
 	}
 	if backendName == "darwin-vz" {
 		out.KernelImagePath = cfg.Backends.DarwinVZ.KernelImage
@@ -235,6 +236,7 @@ func MergeBackendConfig(cfg Config, backendName string, launchSeconds int64) bac
 		out.MemoryMiB = cfg.Backends.DarwinVZ.MemoryMiB
 		out.GuestPort = cfg.Backends.DarwinVZ.GuestPort
 		out.LaunchSeconds = cfg.Backends.DarwinVZ.LaunchSeconds
+		out.MinimumCacheOutputVolumeBytes = int64(cfg.Backends.DarwinVZ.MinimumCacheOutputVolumeBytes)
 	}
 
 	out.Launch = true

--- a/internal/runtimeconfig/config.go
+++ b/internal/runtimeconfig/config.go
@@ -703,7 +703,7 @@ func darwinVZConfigIsZero(cfg DarwinVZConfig) bool {
 }
 
 func darwinVZConfigHasValues(cfg DarwinVZConfig) bool {
-	return !darwinVZConfigIsZero(cfg) || cfg.MinimumRootFSBytes > 0
+	return !darwinVZConfigIsZero(cfg) || cfg.MinimumRootFSBytes > 0 || cfg.MinimumCacheOutputVolumeBytes > 0
 }
 
 func darwinVZNetworkConfigIsZero(cfg DarwinVZNetworkConfig) bool {

--- a/internal/runtimeconfig/config.go
+++ b/internal/runtimeconfig/config.go
@@ -117,18 +117,18 @@ type Backends struct {
 }
 
 type FirecrackerConfig struct {
-	BinaryPath           string         `yaml:"binary_path"`
-	KernelImage          string         `yaml:"kernel_image"`
-	RootFS               string         `yaml:"rootfs"`
-	Services             ServicesConfig `yaml:"services"`
-	Snapshots            SnapshotConfig `yaml:"snapshots"`
-	PrivilegedHelperPath string         `yaml:"privileged_helper_path"`
-	VCPUs                int64          `yaml:"vcpus"`
-	MemoryMiB            int64          `yaml:"memory_mib"`
+	BinaryPath                    string         `yaml:"binary_path"`
+	KernelImage                   string         `yaml:"kernel_image"`
+	RootFS                        string         `yaml:"rootfs"`
+	MinimumCacheOutputVolumeBytes ByteSize       `yaml:"minimum_cache_output_volume_bytes"`
+	Services                      ServicesConfig `yaml:"services"`
+	Snapshots                     SnapshotConfig `yaml:"snapshots"`
+	PrivilegedHelperPath          string         `yaml:"privileged_helper_path"`
+	VCPUs                         int64          `yaml:"vcpus"`
+	MemoryMiB                     int64          `yaml:"memory_mib"`
 	GuestCID                      uint32         `yaml:"guest_cid"`
 	GuestPort                     uint32         `yaml:"guest_port"`
 	LaunchSeconds                 int64          `yaml:"launch_seconds"` // VM boot/guest-agent readiness timeout
-	MinimumCacheOutputVolumeBytes ByteSize       `yaml:"minimum_cache_output_volume_bytes"`
 }
 
 type DarwinVZConfig struct {
@@ -137,12 +137,12 @@ type DarwinVZConfig struct {
 	MinimumRootFSBytes            ByteSize              `yaml:"minimum_rootfs_bytes"`
 	MinimumCacheOutputVolumeBytes ByteSize              `yaml:"minimum_cache_output_volume_bytes"`
 	Network                       DarwinVZNetworkConfig `yaml:"network,omitempty"`
-	Services                      ServicesConfig        `yaml:"services"`
-	Snapshots                     SnapshotConfig        `yaml:"snapshots"`
-	VCPUs                         int64                 `yaml:"vcpus"`
-	MemoryMiB                     int64                 `yaml:"memory_mib"`
-	GuestPort                     uint32                `yaml:"guest_port"`
-	LaunchSeconds                 int64                 `yaml:"launch_seconds"` // VM boot/guest-agent readiness timeout
+	Services           ServicesConfig        `yaml:"services"`
+	Snapshots          SnapshotConfig        `yaml:"snapshots"`
+	VCPUs              int64                 `yaml:"vcpus"`
+	MemoryMiB          int64                 `yaml:"memory_mib"`
+	GuestPort          uint32                `yaml:"guest_port"`
+	LaunchSeconds      int64                 `yaml:"launch_seconds"` // VM boot/guest-agent readiness timeout
 }
 
 type DarwinVZNetworkConfig struct {
@@ -204,12 +204,11 @@ func MergeBackendConfig(cfg Config, backendName string, launchSeconds int64) bac
 			QuiesceTimeoutSeconds: cfg.Backends.Firecracker.Snapshots.QuiesceTimeoutSeconds,
 		},
 		PrivilegedHelperPath: cfg.Backends.Firecracker.PrivilegedHelperPath,
-		VCPUs:                         cfg.Backends.Firecracker.VCPUs,
-		MemoryMiB:                     cfg.Backends.Firecracker.MemoryMiB,
-		GuestCID:                      cfg.Backends.Firecracker.GuestCID,
-		GuestPort:                     cfg.Backends.Firecracker.GuestPort,
-		LaunchSeconds:                 cfg.Backends.Firecracker.LaunchSeconds,
-		MinimumCacheOutputVolumeBytes: int64(cfg.Backends.Firecracker.MinimumCacheOutputVolumeBytes),
+		VCPUs:                cfg.Backends.Firecracker.VCPUs,
+		MemoryMiB:            cfg.Backends.Firecracker.MemoryMiB,
+		GuestCID:             cfg.Backends.Firecracker.GuestCID,
+		GuestPort:            cfg.Backends.Firecracker.GuestPort,
+		LaunchSeconds:        cfg.Backends.Firecracker.LaunchSeconds,
 	}
 	if backendName == "darwin-vz" {
 		out.KernelImagePath = cfg.Backends.DarwinVZ.KernelImage
@@ -236,7 +235,6 @@ func MergeBackendConfig(cfg Config, backendName string, launchSeconds int64) bac
 		out.MemoryMiB = cfg.Backends.DarwinVZ.MemoryMiB
 		out.GuestPort = cfg.Backends.DarwinVZ.GuestPort
 		out.LaunchSeconds = cfg.Backends.DarwinVZ.LaunchSeconds
-		out.MinimumCacheOutputVolumeBytes = int64(cfg.Backends.DarwinVZ.MinimumCacheOutputVolumeBytes)
 	}
 
 	out.Launch = true
@@ -366,9 +364,6 @@ func parseConfig(path string, raw []byte) (Config, error) {
 				MinimumRootFSBytes            *ByteSize `yaml:"minimum_rootfs_bytes"`
 				MinimumCacheOutputVolumeBytes *ByteSize `yaml:"minimum_cache_output_volume_bytes"`
 			} `yaml:"darwin-vz"`
-			Firecracker struct {
-				MinimumCacheOutputVolumeBytes *ByteSize `yaml:"minimum_cache_output_volume_bytes"`
-			} `yaml:"firecracker"`
 		} `yaml:"backends"`
 	}{}
 	if err := yaml.Unmarshal(raw, &presenceCfg); err != nil {
@@ -379,8 +374,6 @@ func parseConfig(path string, raw []byte) (Config, error) {
 	darwinVZMinRootFSBytesSet := presenceCfg.Backends.DarwinVZ.MinimumRootFSBytes != nil
 	darwinVZMinCacheOutputVolumeBytes := cfg.Backends.DarwinVZ.MinimumCacheOutputVolumeBytes
 	darwinVZMinCacheOutputVolumeBytesSet := presenceCfg.Backends.DarwinVZ.MinimumCacheOutputVolumeBytes != nil
-	firecrackerMinCacheOutputVolumeBytes := cfg.Backends.Firecracker.MinimumCacheOutputVolumeBytes
-	firecrackerMinCacheOutputVolumeBytesSet := presenceCfg.Backends.Firecracker.MinimumCacheOutputVolumeBytes != nil
 	if darwinVZConfigIsZero(cfg.Backends.DarwinVZ) {
 		if darwinVZConfigHasValues(rawCfg.Backends.DarwinVZLegacy) {
 			cfg.Backends.DarwinVZ = rawCfg.Backends.DarwinVZLegacy
@@ -391,9 +384,6 @@ func parseConfig(path string, raw []byte) (Config, error) {
 	}
 	if darwinVZMinCacheOutputVolumeBytesSet {
 		cfg.Backends.DarwinVZ.MinimumCacheOutputVolumeBytes = darwinVZMinCacheOutputVolumeBytes
-	}
-	if firecrackerMinCacheOutputVolumeBytesSet {
-		cfg.Backends.Firecracker.MinimumCacheOutputVolumeBytes = firecrackerMinCacheOutputVolumeBytes
 	}
 
 	cfg = normalizeConfig(cfg, inferredDefaultBackend(backendPresence.Backends.Firecracker != nil, backendPresence.Backends.DarwinVZ != nil || backendPresence.Backends.LegacyDarwinVZ != nil))

--- a/internal/runtimeconfig/config_test.go
+++ b/internal/runtimeconfig/config_test.go
@@ -1028,6 +1028,32 @@ backends:
 	}
 }
 
+func TestLoadSupportsLegacyDarwinVZMinimumCacheOutputVolumeBytesOnly(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	configPath := filepath.Join(tmp, "cleanroom", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+
+	content := `default_backend: darwin-vz
+backends:
+  darwin_vz:
+    minimum_cache_output_volume_bytes: 16GiB
+`
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, _, err := Load()
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if got, want := int64(cfg.Backends.DarwinVZ.MinimumCacheOutputVolumeBytes), int64(16<<30); got != want {
+		t.Fatalf("unexpected darwin-vz minimum cache output volume bytes: got %d want %d", got, want)
+	}
+}
+
 func TestLoadRejectsInvalidLegacyDarwinVZMinimumRootFSBytes(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)

--- a/internal/runtimeconfig/config_test.go
+++ b/internal/runtimeconfig/config_test.go
@@ -356,6 +356,143 @@ backends:
 	}
 }
 
+func TestLoadSupportsDarwinVZMinimumCacheOutputVolumeBytes(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	configPath := filepath.Join(tmp, "cleanroom", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+
+	content := `default_backend: darwin-vz
+backends:
+  darwin-vz:
+    rootfs: /tmp/rootfs
+    minimum_cache_output_volume_bytes: 17179869184
+`
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, _, err := Load()
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if got, want := int64(cfg.Backends.DarwinVZ.MinimumCacheOutputVolumeBytes), int64(17179869184); got != want {
+		t.Fatalf("unexpected darwin-vz minimum cache output volume bytes: got %d want %d", got, want)
+	}
+}
+
+func TestLoadSupportsDarwinVZMinimumCacheOutputVolumeBytesHumanString(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	configPath := filepath.Join(tmp, "cleanroom", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+
+	content := `default_backend: darwin-vz
+backends:
+  darwin-vz:
+    rootfs: /tmp/rootfs
+    minimum_cache_output_volume_bytes: 16GiB
+`
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, _, err := Load()
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if got, want := int64(cfg.Backends.DarwinVZ.MinimumCacheOutputVolumeBytes), int64(16<<30); got != want {
+		t.Fatalf("unexpected darwin-vz minimum cache output volume bytes: got %d want %d", got, want)
+	}
+}
+
+func TestLoadRejectsInvalidDarwinVZMinimumCacheOutputVolumeBytes(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	configPath := filepath.Join(tmp, "cleanroom", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+
+	content := `default_backend: darwin-vz
+backends:
+  darwin-vz:
+    rootfs: /tmp/rootfs
+    minimum_cache_output_volume_bytes: giant
+`
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, _, err := Load()
+	if err == nil {
+		t.Fatal("expected Load to reject invalid minimum_cache_output_volume_bytes")
+	}
+	if !strings.Contains(err.Error(), "invalid byte size") {
+		t.Fatalf("expected error to mention invalid byte size, got %v", err)
+	}
+}
+
+func TestLoadAllowsExplicitZeroDarwinVZMinimumCacheOutputVolumeBytesOverride(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	configPath := filepath.Join(tmp, "cleanroom", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+
+	content := `default_backend: darwin-vz
+backends:
+  darwin-vz:
+    minimum_cache_output_volume_bytes: 0
+  darwin_vz:
+    kernel_image: /tmp/legacy-kernel
+    rootfs: /tmp/legacy-rootfs
+    minimum_cache_output_volume_bytes: 16GiB
+`
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, _, err := Load()
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if got, want := int64(cfg.Backends.DarwinVZ.MinimumCacheOutputVolumeBytes), int64(0); got != want {
+		t.Fatalf("unexpected darwin-vz minimum cache output volume bytes: got %d want %d", got, want)
+	}
+}
+
+func TestLoadSupportsFirecrackerMinimumCacheOutputVolumeBytes(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	configPath := filepath.Join(tmp, "cleanroom", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+
+	content := `default_backend: firecracker
+backends:
+  firecracker:
+    minimum_cache_output_volume_bytes: 17179869184
+`
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, _, err := Load()
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if got, want := int64(cfg.Backends.Firecracker.MinimumCacheOutputVolumeBytes), int64(17179869184); got != want {
+		t.Fatalf("unexpected firecracker minimum cache output volume bytes: got %d want %d", got, want)
+	}
+}
+
 func TestLoadTrimsObservabilityConfig(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)


### PR DESCRIPTION
## Description

Adds a `minimum_cache_output_volume_bytes` runtime config setting that lets operators set a per-run capacity floor for cache output volumes on both the `firecracker` and `darwin-vz` backends. Previously the floor was a package-level constant with no way to override it without recompiling.

The resolver pattern follows `MinimumRootFSBytes`: the cfg field wins when non-zero, otherwise the package-level default applies. This preserves the existing test contract where both are zero-valued.

## Changes

- Add `MinimumCacheOutputVolumeBytes` field to `backend.FirecrackerConfig` and both runtimeconfig backend structs (`FirecrackerConfig`, `DarwinVZConfig`) under YAML key `minimum_cache_output_volume_bytes`
- Introduce `resolveCacheOutputVolumeMinimumBytes` (firecracker) and `resolveDarwinVZCacheOutputVolumeMinimumBytes` (darwin-vz) resolver helpers so cfg can override the package-level var without mutating it
- Wire the field through `MergeBackendConfig` — previously it was parsed but never copied into the output struct
- Introduce `prepareDarwinVZCacheOutputWritableVolumeFn` injection point on darwin-vz to make the writable-volume step testable, matching the existing `rootFSVolumeStoreDriverFn` pattern on firecracker
- Add tests covering integer bytes, human string (`16GiB`), invalid input rejection, explicit-zero override, and both call sites in the darwin-vz resolver
- Document the new setting in `docs/caching.md`

## Verification

Set `minimum_cache_output_volume_bytes: 16GiB` under `backends.darwin-vz` or `backends.firecracker` in the runtime config and confirm the cache output volume is created with at least that capacity.

## Rollback

Safe to revert — the new field is additive. Removing it restores the previous behaviour where the package-level default is always used.