### PR TITLE
perf: Remove darwin-vz memory grow wait

### DIFF
--- a/docs/backend/darwin-vz.md
+++ b/docs/backend/darwin-vz.md
@@ -73,12 +73,13 @@ and policy resource minimums are merged. They are not an exact host reservation
 contract.
 
 When `memory_mib` is above 1024 MiB, Go sends `initial_memory_balloon_target_mib=1024`
-so the helper can request a smaller guest memory target during boot. Before guest
-workload execution, Go sends `SetMemoryBalloonTarget` back to `memory_mib` and
-does not add a fixed settle delay before sending the exec request. This keeps
-the user-facing memory contract as a ceiling while allowing the backend to
-optimize boot-time host memory pressure internally without adding unconditional
-latency to tiny commands.
+so the helper can request a smaller guest memory target during boot. After the
+VM starts, Go sends `SetMemoryBalloonTarget` back to `memory_mib` before the
+guest readiness probe, then re-sends the target before workload execution
+without adding a fixed settle delay before exec requests. This keeps the
+user-facing memory contract as a ceiling while allowing the backend to optimize
+boot-time host memory pressure internally without adding unconditional latency
+to tiny commands.
 
 `StartVM` response fields:
 

--- a/docs/backend/darwin-vz.md
+++ b/docs/backend/darwin-vz.md
@@ -75,9 +75,10 @@ contract.
 When `memory_mib` is above 1024 MiB, Go sends `initial_memory_balloon_target_mib=1024`
 so the helper can request a smaller guest memory target during boot. Before guest
 workload execution, Go sends `SetMemoryBalloonTarget` back to `memory_mib` and
-waits briefly for the guest to process the request. This keeps the user-facing
-memory contract as a ceiling while allowing the backend to optimize boot-time
-host memory pressure internally.
+does not add a fixed settle delay before sending the exec request. This keeps
+the user-facing memory contract as a ceiling while allowing the backend to
+optimize boot-time host memory pressure internally without adding unconditional
+latency to tiny commands.
 
 `StartVM` response fields:
 

--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -1284,6 +1284,11 @@ func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream 
 		}
 	}()
 
+	if err := a.growDarwinVZMemoryBalloonTarget(ctx, helper, vmID, req.MemoryMiB); err != nil {
+		observation.Error = err.Error()
+		return nil, err
+	}
+
 	networkProcessPID := 0
 	lookupCtx, cancelLookup := context.WithTimeout(ctx, networkProcessLookupTimeout)
 	networkProcessPID, _ = resolveVirtualizationProcessPID(lookupCtx, vmRootFSPath)
@@ -1663,6 +1668,11 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 		instance.setExited(err)
 		close(instance.exitedCh)
 	}()
+
+	if err := a.setDarwinVZMemoryBalloonTarget(ctx, helper, startedVM.VMID, cfg.MemoryMiB); err != nil {
+		pidLookup.stop()
+		return nil, err
+	}
 
 	bootCtx, cancel := context.WithTimeout(ctx, time.Duration(cfg.LaunchSeconds)*time.Second)
 	defer cancel()

--- a/internal/backend/darwinvz/memory_balloon_darwin.go
+++ b/internal/backend/darwinvz/memory_balloon_darwin.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-var darwinVZMemoryBalloonGrowSettle = time.Second
+var darwinVZMemoryBalloonGrowSettle time.Duration
 
 func darwinVZInitialMemoryBalloonTargetMiB(memoryMiB int64) int64 {
 	if memoryMiB > darwinVZAdaptiveMemoryStartMiB {

--- a/internal/backend/darwinvz/memory_balloon_darwin_test.go
+++ b/internal/backend/darwinvz/memory_balloon_darwin_test.go
@@ -167,6 +167,79 @@ func TestExecuteInSandboxRestoresMemoryBalloonTargetBeforeGuestExec(t *testing.T
 	}
 }
 
+func TestExecuteInSandboxSkipsMemoryBalloonGrowWhenLaunchAlreadyRestoredTarget(t *testing.T) {
+	socketDir, err := os.MkdirTemp("", "cr-balloon-ready-")
+	if err != nil {
+		t.Fatalf("create temp dir: %v", err)
+	}
+	defer os.RemoveAll(socketDir)
+	socketPath := filepath.Join(socketDir, "proxy.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen on unix socket: %v", err)
+	}
+	defer listener.Close()
+
+	serverErr := make(chan error, 1)
+	go func() {
+		conn, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			serverErr <- acceptErr
+			return
+		}
+		defer conn.Close()
+
+		var req vsockexec.ExecRequest
+		if err := json.NewDecoder(conn).Decode(&req); err != nil {
+			serverErr <- err
+			return
+		}
+		if got, want := req.Command, []string{"true"}; len(got) != len(want) || got[0] != want[0] {
+			t.Errorf("unexpected guest command: got %#v want %#v", got, want)
+		}
+		if err := vsockexec.EncodeStreamFrame(conn, vsockexec.ExecStreamFrame{Type: "exit", ExitCode: 0}); err != nil {
+			serverErr <- err
+			return
+		}
+		serverErr <- nil
+	}()
+
+	var helperReqs []helperControlRequest
+	adapter := &Adapter{
+		helperRequestFn: func(_ context.Context, _ *helperSession, req helperControlRequest) (helperControlResponse, error) {
+			helperReqs = append(helperReqs, req)
+			return helperControlResponse{OK: true}, nil
+		},
+	}
+
+	_, err = adapter.executeInSandbox(context.Background(), context.Background(), &sandboxInstance{
+		SandboxID: "cr-test",
+		VMID:      "vm-test",
+		FirecrackerConfig: backend.FirecrackerConfig{
+			MemoryMiB: 8192,
+		},
+		ProxySocketPath:        socketPath,
+		Policy:                 &policy.CompiledPolicy{NetworkDefault: "deny"},
+		Helper:                 &helperSession{},
+		exitedCh:               make(chan struct{}),
+		memoryBalloonTargetMiB: 8192,
+	}, backend.ExecutionRequest{
+		SandboxID:   "cr-test",
+		ExecutionID: "run-123",
+		Command:     []string{"true"},
+		Policy:      &policy.CompiledPolicy{NetworkDefault: "deny"},
+	}, backend.OutputStream{})
+	if err != nil {
+		t.Fatalf("executeInSandbox returned error: %v", err)
+	}
+	if err := <-serverErr; err != nil {
+		t.Fatalf("guest exec server returned error: %v", err)
+	}
+	if len(helperReqs) != 0 {
+		t.Fatalf("helper requests = %#v, want no SetMemoryBalloonTarget request when launch already restored target", helperReqs)
+	}
+}
+
 func TestSandboxInstanceGrowsMemoryBalloonTargetOnce(t *testing.T) {
 	var helperReqs []helperControlRequest
 	adapter := &Adapter{

--- a/internal/backend/darwinvz/memory_balloon_darwin_test.go
+++ b/internal/backend/darwinvz/memory_balloon_darwin_test.go
@@ -74,6 +74,14 @@ func TestWriteDarwinVZConfigIncludesInitialMemoryBalloonTarget(t *testing.T) {
 	}
 }
 
+func TestDarwinVZMemoryBalloonGrowDoesNotBlindlySleep(t *testing.T) {
+	t.Parallel()
+
+	if darwinVZMemoryBalloonGrowSettle != 0 {
+		t.Fatalf("darwin-vz memory balloon grow settle = %s, want no fixed settle delay", darwinVZMemoryBalloonGrowSettle)
+	}
+}
+
 func TestExecuteInSandboxRestoresMemoryBalloonTargetBeforeGuestExec(t *testing.T) {
 	socketDir, err := os.MkdirTemp("", "cr-balloon-")
 	if err != nil {


### PR DESCRIPTION
The adaptive darwin-vz memory path starts VMs with a 1024 MiB balloon target when the configured memory ceiling is larger. Before this change, the first execution always paid a fixed 1s host-side settle delay after asking VZ to grow the balloon target back to the configured ceiling.

That delay dominates time-to-interactive for tiny commands. The helper already applies `targetVirtualMachineMemorySize` synchronously on the VM queue; the extra Go-side sleep is blind latency rather than a readiness signal.

This changes the production default to request the larger memory target without a fixed settle sleep, and updates the backend doc to describe the behavior. The user-facing memory value remains a ceiling; the backend still requests the full target before sending the guest exec request.

Benchmark signal:

- Previous local matrix: `4096 MiB + 1s settle` median TTI ~`1.690s`, first exec observed ~`1001ms`
- Previous local `settle0` experiment: median TTI ~`0.679s`, first exec observed ~`1ms`
- This patch, quick manual run with rebuilt `./dist/cleanroom`: measured runs total `0.569s`, `0.566s`, `0.555s`, `0.559s`, `0.549s`; first exec `0.026s`, `0.025s`, `0.022s`, `0.025s`, `0.024s`

Validation performed:

- `git diff --check`
- `mise exec -- go test ./internal/backend/darwinvz`
- `mise run build:go`
- manual TTI smoke benchmark with `./dist/cleanroom` and `dist/cleanroom-darwin-vz.app`