### PR TITLE
perf: Retry darwin-vz vsock connects faster

### DIFF
--- a/cmd/cleanroom-darwin-vz/main.swift
+++ b/cmd/cleanroom-darwin-vz/main.swift
@@ -1209,7 +1209,7 @@ private final class VMRuntime {
                 } else {
                     lastError = HelperError.vm("guest vsock connect returned no connection")
                 }
-                usleep(100_000)
+                usleep(10_000)
             }
             if let lastError {
                 fputs("cleanroom-darwin-vz: vsock connect fallback to serial after error: \(lastError)\n", stderr)


### PR DESCRIPTION
The darwin-vz helper was waiting 100ms between failed guest VSOCK connection attempts while the VM was still booting. The minimal darwin-vz harness uses a 10ms retry cadence, and local TTI experiments showed that the coarser production interval can add avoidable readiness latency before the first guest exec.

This changes only the guest VSOCK connect retry sleep from 100ms to 10ms. The overall launch timeout and serial fallback behavior stay the same; the helper just checks for guest readiness more frequently during the existing timeout window.

Local benchmark context from the rootfs boot experiments:

- baseline Cleanroom create + first exec: ~523ms median TTI
- faster VSOCK retry: ~486ms median TTI

Validation:

- `scripts/build-darwin-vz-helper.sh dist/cleanroom-darwin-vz.app`
- `mise exec -- go test ./internal/backend/darwinvz`

A follow-up benchmark attempt against a fresh isolated state directory paid cold runtime preparation and timed out before producing useful warm TTI samples, so I did not include it as validation evidence.
