### PR TITLE
fix: Enable RTC in minimal darwin-vz kernel

### DIFF
--- a/benchmarks/darwin-vz/minimal/build-kernel.sh
+++ b/benchmarks/darwin-vz/minimal/build-kernel.sh
@@ -127,6 +127,13 @@ docker run --rm \
       -e BALLOON_COMPACTION \
       -e COMPACTION \
       -e PAGE_REPORTING \
+      -e ARM_AMBA \
+      -e RTC_CLASS \
+      -e RTC_HCTOSYS \
+      -e RTC_INTF_DEV \
+      -e RTC_INTF_PROC \
+      -e RTC_INTF_SYSFS \
+      -e RTC_DRV_PL031 \
       -e VSOCKETS \
       -e VIRTIO_VSOCKETS \
       -e NET \

--- a/benchmarks/darwin-vz/minimal/build_kernel_script_test.go
+++ b/benchmarks/darwin-vz/minimal/build_kernel_script_test.go
@@ -22,6 +22,8 @@ func TestBuildKernelVerifiesCachedSourceWithChecksumStamp(t *testing.T) {
 		`-e ADVISE_SYSCALLS \`,
 		`-e VIRTIO_BALLOON \`,
 		`-e PAGE_REPORTING \`,
+		`-e RTC_CLASS \`,
+		`-e RTC_DRV_PL031 \`,
 	}
 	for _, want := range required {
 		if !strings.Contains(script, want) {


### PR DESCRIPTION
The minimal darwin-vz rootfs kernel currently boots with no RTC device. In the production darwin-vz adapter that leaves the guest wall clock at Unix epoch, so TLS certificate validation fails even though filehandle networking is otherwise working.

This enables the ARM PL031 RTC path in the minimal kernel builder so Virtualization.framework guests can set their system clock from the host-provided RTC at boot. With the rebuilt kernel, the guest reports a current date, exposes /dev/rtc0, and allowlisted HTTPS egress succeeds.

Example failure before this change:

```
Thu Jan  1 00:00:00 UTC 1970
wget https://github.com
certificate verify failed
```

Validation performed:

- `mise exec -- go test ./benchmarks/darwin-vz/minimal`
- `CLEANROOM_DARWIN_VZ_MINIMAL_KERNEL_PROFILE=rootfs benchmarks/darwin-vz/minimal/build-kernel.sh dist/darwin-vz-minimal-rootfs-arm64-kernel-6.1.155-Image`
- targeted darwin-vz guest probe with rebuilt kernel: guest date `Tue May 19 13:52:34 UTC 2026`, `/dev/rtc0` present, `wget -T 20 -S -O /dev/null https://github.com` succeeded
- `CLEANROOM_DARWIN_VZ_KERNEL_IMAGE="/Users/lachlan/.codex/worktrees/c9f1/cleanroom/dist/darwin-vz-minimal-rootfs-arm64-kernel-6.1.155-Image" mise exec -- scripts/ci-darwin-vz-filehandle-e2e.sh`
- `mise run test`
- `mise run lint-shell`

I also took a small 5-run TTI sanity sample under fresh temp XDG state with the rebuilt kernel. It completed successfully with median 504ms and min 463ms; this was only a regression check, not a full benchmark run.