### PR TITLE
fix: Adapt cache output volume sizing

### DIFF
--- a/docs/caching.md
+++ b/docs/caching.md
@@ -86,12 +86,22 @@ inputs.
 
 Cache output volumes are sparse ext4 images on the host. When Cleanroom creates
 a new volume — or restores one from an older snapshot — it enforces a minimum
-size. The default is 512 MiB.
+size. The default is 16 GiB.
 <!-- tracks cacheoutput.DefaultVolumeMinimumBytes -->
 
-If your service block pulls large container images into `/var/lib/docker`
-(Kafka, Postgres builds, schema-registry, and similar), you may need more
-headroom. Set `minimum_cache_output_volume_bytes` in your runtime config:
+Because the images are sparse, the default is logical capacity rather than
+immediate host disk use. Host disk is consumed by actual writes and filesystem
+metadata. For example, a 16 GiB Docker cache-output volume can occupy much less
+than 16 GiB on the host until Docker writes that data.
+
+Cleanroom also uses prior successful snapshots for the same block shape as a
+sizing hint. If a block's declared inputs change and it needs to rebuild, the
+next cold cache-output volume can be created with enough logical capacity for
+the previous successful output's allocated bytes plus headroom.
+
+Most users should not need to configure cache-output sizing. If a host needs a
+larger or smaller floor for every cache-output volume, set
+`minimum_cache_output_volume_bytes` in runtime config:
 
 ```yaml
 backends:
@@ -104,11 +114,9 @@ backends:
   firecracker:
     minimum_cache_output_volume_bytes: 16GiB
 ```
-
-Because the images are sparse, raising this value doesn't immediately consume
-host disk space — only actual writes do. Existing on-disk writable volumes keep
-their current size; the new minimum only applies when a volume is first created
-or restored from a snapshot that predates the setting.
+Existing on-disk writable volumes keep their current size; the new minimum only
+applies when a volume is first created or restored from a snapshot that predates
+the setting.
 
 ## Host Cache Peers
 

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -276,6 +276,7 @@ type CacheOutputVolumeSpec struct {
 	BlockName         string
 	CacheKey          string
 	VolumeID          string
+	MinimumBytes      int64
 	SourceSnapshotRef string
 	StorageDriver     string
 	StorageRef        string
@@ -413,7 +414,7 @@ type FirecrackerConfig struct {
 	// Backends may provide this as logical capacity or a larger backend default;
 	// it is not an exact host-disk allocation promise. Zero means fall back to
 	// the backend's package-level default.
-	MinimumCacheOutputVolumeBytes int64
+	MinimumCacheOutputVolumeBytes             int64
 	DarwinVZNetworkMode                       string
 	DarwinVZNetworkSubnet                     string
 	DarwinVZNetworkExternalInterface          string

--- a/internal/backend/cacheoutput/cacheoutput.go
+++ b/internal/backend/cacheoutput/cacheoutput.go
@@ -17,7 +17,7 @@ import (
 	"github.com/buildkite/cleanroom/internal/vsockexec"
 )
 
-const DefaultVolumeMinimumBytes int64 = 512 << 20
+const DefaultVolumeMinimumBytes int64 = 16 << 30
 const GuestMountRoot = "/run/cleanroom/cache-output-volumes"
 
 type PreparedMount struct {

--- a/internal/backend/darwinvz/cache_output_volumes_darwin.go
+++ b/internal/backend/darwinvz/cache_output_volumes_darwin.go
@@ -20,9 +20,9 @@ const defaultDarwinVZCacheOutputVolumeMinimumBytes int64 = cacheoutput.DefaultVo
 const darwinVZCacheOutputGuestMountRoot = cacheoutput.GuestMountRoot
 
 var (
-	darwinVZCacheOutputVolumeMinimumBytes          = defaultDarwinVZCacheOutputVolumeMinimumBytes
-	createEmptyDarwinVZCacheOutputExt4ImageFn      = createEmptyDarwinVZCacheOutputExt4Image
-	prepareDarwinVZCacheOutputWritableVolumeFn     = prepareDarwinVZCacheOutputWritableVolume
+	darwinVZCacheOutputVolumeMinimumBytes      = defaultDarwinVZCacheOutputVolumeMinimumBytes
+	createEmptyDarwinVZCacheOutputExt4ImageFn  = createEmptyDarwinVZCacheOutputExt4Image
+	prepareDarwinVZCacheOutputWritableVolumeFn = prepareDarwinVZCacheOutputWritableVolume
 )
 
 type preparedDarwinVZCacheOutputVolume struct {
@@ -37,6 +37,14 @@ func resolveDarwinVZCacheOutputVolumeMinimumBytes(cfg backend.FirecrackerConfig)
 		return cfg.MinimumCacheOutputVolumeBytes
 	}
 	return darwinVZCacheOutputVolumeMinimumBytes
+}
+
+func effectiveDarwinVZCacheOutputVolumeMinimumBytes(cfg backend.FirecrackerConfig, spec backend.CacheOutputVolumeSpec) int64 {
+	minimumBytes := resolveDarwinVZCacheOutputVolumeMinimumBytes(cfg)
+	if spec.MinimumBytes > minimumBytes {
+		return spec.MinimumBytes
+	}
+	return minimumBytes
 }
 
 func prepareDarwinVZCacheOutputVolumes(ctx context.Context, cfg backend.FirecrackerConfig, sandboxID, runDir string, specs []backend.CacheOutputVolumeSpec) ([]preparedDarwinVZCacheOutputVolume, func(), error) {
@@ -78,7 +86,7 @@ func prepareDarwinVZCacheOutputVolumes(ctx context.Context, cfg backend.Firecrac
 		}
 		runtimeVolumeID := darwinVZCacheOutputRuntimeVolumeID(sandboxID, spec.VolumeID, i)
 		attachmentPath := filepath.Join(runDir, fmt.Sprintf("cache-output-%02d.ext4", i))
-		volume, volumeCleanup, err := prepareDarwinVZCacheOutputWritableVolumeFn(ctx, volumeCfg, runtimeVolumeID, attachmentPath, sourceRef, resolveDarwinVZCacheOutputVolumeMinimumBytes(volumeCfg))
+		volume, volumeCleanup, err := prepareDarwinVZCacheOutputWritableVolumeFn(ctx, volumeCfg, runtimeVolumeID, attachmentPath, sourceRef, effectiveDarwinVZCacheOutputVolumeMinimumBytes(volumeCfg, spec))
 		if err != nil {
 			cleanup()
 			return nil, nil, fmt.Errorf("cache output volume %q: %w", spec.VolumeID, err)
@@ -103,7 +111,7 @@ func darwinVZCacheOutputVolumeSource(ctx context.Context, cfg backend.Firecracke
 	}
 	if sourceRef == "" {
 		sourceRef = filepath.Join(runDir, "cache-output-empty-base.ext4")
-		if err := createEmptyDarwinVZCacheOutputExt4ImageFn(ctx, sourceRef, resolveDarwinVZCacheOutputVolumeMinimumBytes(volumeCfg)); err != nil {
+		if err := createEmptyDarwinVZCacheOutputExt4ImageFn(ctx, sourceRef, effectiveDarwinVZCacheOutputVolumeMinimumBytes(volumeCfg, spec)); err != nil {
 			return "", volumeCfg, fmt.Errorf("create empty cache output volume source: %w", err)
 		}
 		return sourceRef, volumeCfg, nil

--- a/internal/backend/darwinvz/cache_output_volumes_test.go
+++ b/internal/backend/darwinvz/cache_output_volumes_test.go
@@ -192,3 +192,48 @@ func TestPrepareDarwinVZCacheOutputVolumesCfgMinimumBytesOverridesPackageDefault
 		t.Fatalf("minimumBytes passed to prepareDarwinVZCacheOutputWritableVolumeFn: got %d want %d", got, want)
 	}
 }
+
+func TestPrepareDarwinVZCacheOutputVolumesSpecMinimumBytesOverridesCfgMinimum(t *testing.T) {
+	runDir := t.TempDir()
+	prevCreateEmpty := createEmptyDarwinVZCacheOutputExt4ImageFn
+	prevPrepareFn := prepareDarwinVZCacheOutputWritableVolumeFn
+	t.Cleanup(func() {
+		createEmptyDarwinVZCacheOutputExt4ImageFn = prevCreateEmpty
+		prepareDarwinVZCacheOutputWritableVolumeFn = prevPrepareFn
+	})
+
+	var capturedEmptyMinimumBytes int64
+	createEmptyDarwinVZCacheOutputExt4ImageFn = func(_ context.Context, path string, minimumBytes int64) error {
+		capturedEmptyMinimumBytes = minimumBytes
+		return os.WriteFile(path, []byte("empty-ext4"), 0o644)
+	}
+	var capturedWritableMinimumBytes int64
+	prepareDarwinVZCacheOutputWritableVolumeFn = func(_ context.Context, _ backend.FirecrackerConfig, volumeID, attachmentPath, sourceRef string, minimumBytes int64) (volumestore.WritableVolume, func(), error) {
+		capturedWritableMinimumBytes = minimumBytes
+		return volumestore.WritableVolume{Ref: "volume:" + volumeID, AttachmentPath: attachmentPath}, func() {}, nil
+	}
+
+	_, cleanup, err := prepareDarwinVZCacheOutputVolumes(context.Background(), backend.FirecrackerConfig{
+		MinimumCacheOutputVolumeBytes: 16 << 30,
+	}, "sandbox-1", runDir, []backend.CacheOutputVolumeSpec{{
+		Stage:        "service-volume",
+		BlockName:    "docker-images",
+		CacheKey:     "service-volume:v1:docker-images",
+		VolumeID:     "service-volume-def456",
+		MinimumBytes: 32 << 30,
+		DirMappings: []backend.CacheOutputDirMapping{
+			{GuestPath: "/var/lib/docker", Subpath: "dirs/0"},
+		},
+	}})
+	if err != nil {
+		t.Fatalf("prepareDarwinVZCacheOutputVolumes returned error: %v", err)
+	}
+	defer cleanup()
+
+	if got, want := capturedEmptyMinimumBytes, int64(32<<30); got != want {
+		t.Fatalf("minimumBytes passed to createEmptyDarwinVZCacheOutputExt4ImageFn: got %d want %d", got, want)
+	}
+	if got, want := capturedWritableMinimumBytes, int64(32<<30); got != want {
+		t.Fatalf("minimumBytes passed to prepareDarwinVZCacheOutputWritableVolumeFn: got %d want %d", got, want)
+	}
+}

--- a/internal/backend/firecracker/cache_output_volumes.go
+++ b/internal/backend/firecracker/cache_output_volumes.go
@@ -36,6 +36,14 @@ func resolveCacheOutputVolumeMinimumBytes(cfg backend.FirecrackerConfig) int64 {
 	return cacheOutputVolumeMinimumBytes
 }
 
+func effectiveCacheOutputVolumeMinimumBytes(cfg backend.FirecrackerConfig, spec backend.CacheOutputVolumeSpec) int64 {
+	minimumBytes := resolveCacheOutputVolumeMinimumBytes(cfg)
+	if spec.MinimumBytes > minimumBytes {
+		return spec.MinimumBytes
+	}
+	return minimumBytes
+}
+
 func prepareCacheOutputVolumes(ctx context.Context, logger *charmlog.Logger, cfg backend.FirecrackerConfig, sandboxID, runDir string, specs []backend.CacheOutputVolumeSpec) ([]preparedCacheOutputVolume, func(), error) {
 	if len(specs) == 0 {
 		return nil, func() {}, nil
@@ -73,7 +81,7 @@ func prepareCacheOutputVolumes(ctx context.Context, logger *charmlog.Logger, cfg
 		}
 		runtimeVolumeID := cacheOutputRuntimeVolumeID(sandboxID, spec.VolumeID, i)
 		attachmentPath := filepath.Join(runDir, fmt.Sprintf("cache-output-%02d.ext4", i))
-		volume, volumeCleanup, err := prepareWritableVolumeWithLogger(ctx, logger, volumeCfg, runtimeVolumeID, attachmentPath, sourceRef, resolveCacheOutputVolumeMinimumBytes(volumeCfg))
+		volume, volumeCleanup, err := prepareWritableVolumeWithLogger(ctx, logger, volumeCfg, runtimeVolumeID, attachmentPath, sourceRef, effectiveCacheOutputVolumeMinimumBytes(volumeCfg, spec))
 		if err != nil {
 			cleanup()
 			return nil, nil, fmt.Errorf("cache output volume %q: %w", spec.VolumeID, err)
@@ -101,7 +109,7 @@ func cacheOutputVolumeSource(ctx context.Context, cfg backend.FirecrackerConfig,
 	}
 	if sourceRef == "" {
 		sourceRef = filepath.Join(runDir, "cache-output-empty-base.ext4")
-		if err := createEmptyCacheOutputExt4ImageFn(ctx, sourceRef, resolveCacheOutputVolumeMinimumBytes(volumeCfg)); err != nil {
+		if err := createEmptyCacheOutputExt4ImageFn(ctx, sourceRef, effectiveCacheOutputVolumeMinimumBytes(volumeCfg, spec)); err != nil {
 			return "", volumeCfg, fmt.Errorf("create empty cache output volume source: %w", err)
 		}
 		return sourceRef, volumeCfg, nil

--- a/internal/backend/firecracker/cache_output_volumes_test.go
+++ b/internal/backend/firecracker/cache_output_volumes_test.go
@@ -370,6 +370,53 @@ func TestPrepareCacheOutputVolumesCfgMinimumBytesOverridesPackageDefault(t *test
 	}
 }
 
+func TestPrepareCacheOutputVolumesSpecMinimumBytesOverridesCfgMinimum(t *testing.T) {
+	runDir := t.TempDir()
+	prevDriverFn := rootFSVolumeStoreDriverFn
+	prevCreateEmpty := createEmptyCacheOutputExt4ImageFn
+	t.Cleanup(func() {
+		rootFSVolumeStoreDriverFn = prevDriverFn
+		createEmptyCacheOutputExt4ImageFn = prevCreateEmpty
+	})
+
+	var capturedMinimumBytes int64
+	createEmptyCacheOutputExt4ImageFn = func(_ context.Context, path string, minimumBytes int64) error {
+		capturedMinimumBytes = minimumBytes
+		return os.WriteFile(path, []byte("empty-ext4"), 0o644)
+	}
+	rootFSVolumeStoreDriverFn = func(backend.FirecrackerConfig) (volumestore.Driver, error) {
+		return resizingTestVolumeDriver{
+			ensureBaseVolumeFn: func(_ context.Context, req volumestore.EnsureBaseVolumeRequest) (volumestore.BaseVolume, error) {
+				return volumestore.BaseVolume{Ref: "base:" + filepath.Base(req.SourcePath)}, nil
+			},
+			createWritableVolumeFn: func(_ context.Context, req volumestore.CreateWritableVolumeRequest) (volumestore.WritableVolume, error) {
+				return volumestore.WritableVolume{Ref: "volume:" + req.VolumeID, AttachmentPath: req.AttachmentPath}, nil
+			},
+		}, nil
+	}
+
+	_, cleanup, err := prepareCacheOutputVolumes(context.Background(), nil, backend.FirecrackerConfig{
+		MinimumCacheOutputVolumeBytes: 16 << 30,
+	}, "sandbox-1", runDir, []backend.CacheOutputVolumeSpec{{
+		Stage:        "service-volume",
+		BlockName:    "docker-images",
+		CacheKey:     "service-volume:v1:docker-images",
+		VolumeID:     "service-volume-def456",
+		MinimumBytes: 32 << 30,
+		DirMappings: []backend.CacheOutputDirMapping{
+			{GuestPath: "/var/lib/docker", Subpath: "dirs/0"},
+		},
+	}})
+	if err != nil {
+		t.Fatalf("prepareCacheOutputVolumes returned error: %v", err)
+	}
+	defer cleanup()
+
+	if got, want := capturedMinimumBytes, int64(32<<30); got != want {
+		t.Fatalf("minimumBytes passed to createEmptyCacheOutputExt4ImageFn: got %d want %d", got, want)
+	}
+}
+
 type resizingTestVolumeDriver struct {
 	ensureBaseVolumeFn     func(context.Context, volumestore.EnsureBaseVolumeRequest) (volumestore.BaseVolume, error)
 	createWritableVolumeFn func(context.Context, volumestore.CreateWritableVolumeRequest) (volumestore.WritableVolume, error)

--- a/internal/controlservice/block_volume_plan.go
+++ b/internal/controlservice/block_volume_plan.go
@@ -20,6 +20,12 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+const (
+	blockVolumeAdaptiveHeadroomBytes   int64 = 1 << 30
+	blockVolumeAdaptiveHeadroomDivisor int64 = 4
+	blockVolumeMaxInt64                int64 = 9223372036854775807
+)
+
 type blockVolumeBlockPlan struct {
 	BlockName                       string
 	Command                         []string
@@ -37,6 +43,7 @@ type blockVolumeBlockPlan struct {
 	PriorServiceOutputKeysDigest    string
 	OutputVolumeLayoutVersion       string
 	ProducerVersion                 string
+	CacheOutputMinimumBytes         int64
 	CacheHit                        bool
 	LookupReason                    string
 	CacheRecord                     cachestore.Record
@@ -168,16 +175,74 @@ func lookupBlockVolumeCache(ctx context.Context, store cacheMetadataStore, stage
 	}
 	if !ok {
 		block.LookupReason = observability.CacheLookupReasonRecordNotFound
+		block.CacheOutputMinimumBytes = suggestedBlockVolumeMinimumBytes(ctx, store, stageName, backendName, compiled, block)
 		return block, nil
 	}
 	if reason := blockVolumeRecordMissReason(record, backendName, compiled, block); reason != "" {
 		block.LookupReason = reason
+		block.CacheOutputMinimumBytes = suggestedBlockVolumeMinimumBytes(ctx, store, stageName, backendName, compiled, block)
 		return block, nil
 	}
 	block.CacheHit = true
 	block.LookupReason = ""
 	block.CacheRecord = record
 	return block, nil
+}
+
+func suggestedBlockVolumeMinimumBytes(ctx context.Context, store cacheMetadataStore, stageName, backendName string, compiled *policy.CompiledPolicy, block blockVolumeBlockPlan) int64 {
+	if store == nil || compiled == nil {
+		return 0
+	}
+	records, err := store.List(ctx)
+	if err != nil {
+		return 0
+	}
+	var maxSize int64
+	for _, record := range records {
+		if !blockVolumeRecordCanInformMinimum(record, stageName, backendName, compiled, block) {
+			continue
+		}
+		if size := blockVolumeRecordMinimumBasisBytes(record); size > maxSize {
+			maxSize = size
+		}
+	}
+	return blockVolumeMinimumBytesWithHeadroom(maxSize)
+}
+
+func blockVolumeRecordMinimumBasisBytes(record cachestore.Record) int64 {
+	if record.ExclusiveSizeBytes > 0 {
+		return record.ExclusiveSizeBytes
+	}
+	return record.StorageSizeBytes
+}
+
+func blockVolumeRecordCanInformMinimum(record cachestore.Record, stageName, backendName string, compiled *policy.CompiledPolicy, block blockVolumeBlockPlan) bool {
+	if strings.TrimSpace(record.State) != cacheStateReady ||
+		strings.TrimSpace(record.Stage) != strings.TrimSpace(stageName) ||
+		strings.TrimSpace(record.Backend) != strings.TrimSpace(backendName) ||
+		strings.TrimSpace(record.PolicyHash) != strings.TrimSpace(compiled.Hash) ||
+		strings.TrimSpace(record.CommandDigest) != strings.TrimSpace(block.CommandDigest) ||
+		strings.TrimSpace(record.EnvDigest) != strings.TrimSpace(block.EnvDigest) ||
+		strings.TrimSpace(record.NormalizedOutputsDigest) != strings.TrimSpace(block.NormalizedOutputsDigest) ||
+		strings.TrimSpace(record.ProducerVersion) != strings.TrimSpace(block.ProducerVersion) ||
+		blockVolumeRecordMinimumBasisBytes(record) <= 0 {
+		return false
+	}
+	return blockVolumeOutputRecordMissReason(block.Outputs, record.OutputRecords) == ""
+}
+
+func blockVolumeMinimumBytesWithHeadroom(sizeBytes int64) int64 {
+	if sizeBytes <= 0 {
+		return 0
+	}
+	headroom := sizeBytes / blockVolumeAdaptiveHeadroomDivisor
+	if headroom < blockVolumeAdaptiveHeadroomBytes {
+		headroom = blockVolumeAdaptiveHeadroomBytes
+	}
+	if sizeBytes > blockVolumeMaxInt64-headroom {
+		return blockVolumeMaxInt64
+	}
+	return sizeBytes + headroom
 }
 
 func dependencyBlockVolumePlanCacheKeys(plan dependencyBlockVolumePlan) []string {

--- a/internal/controlservice/block_volume_plan_test.go
+++ b/internal/controlservice/block_volume_plan_test.go
@@ -1,0 +1,92 @@
+package controlservice
+
+import (
+	"context"
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/cachestore"
+	"github.com/buildkite/cleanroom/internal/observability"
+	"github.com/buildkite/cleanroom/internal/policy"
+)
+
+func TestLookupBlockVolumeCacheSuggestsMinimumFromPriorMatchingRecord(t *testing.T) {
+	ctx := context.Background()
+	store := newMemoryCacheStore()
+	compiled := &policy.CompiledPolicy{Hash: "policy-hash"}
+	block := blockVolumeBlockPlan{
+		BlockName:               "docker-images",
+		CacheKey:                "service-volume:new-input",
+		CommandDigest:           "sha256:command",
+		EnvDigest:               "sha256:env",
+		NormalizedOutputsDigest: "sha256:outputs",
+		ProducerVersion:         serviceVolumeProducerVersion,
+		Outputs: policy.StageBlockOutputs{
+			Dirs: []string{"/var/lib/docker"},
+		},
+	}
+	if err := store.Create(ctx, cachestore.Record{
+		CacheKey:                "service-volume:old-input",
+		Stage:                   serviceVolumeStageName,
+		State:                   cacheStateReady,
+		Backend:                 "darwin-vz",
+		PolicyHash:              compiled.Hash,
+		CommandDigest:           block.CommandDigest,
+		EnvDigest:               block.EnvDigest,
+		NormalizedOutputsDigest: block.NormalizedOutputsDigest,
+		ProducerVersion:         block.ProducerVersion,
+		StorageSizeBytes:        32 << 30,
+		ExclusiveSizeBytes:      20 << 30,
+		OutputRecords: []cachestore.OutputRecord{{
+			Kind:          "dir",
+			Path:          "/var/lib/docker",
+			VolumeSubpath: "dirs/0",
+			StorageDriver: "apfs",
+			StorageRef:    "/snapshots/docker.ext4",
+			SnapshotRef:   "/snapshots/docker.ext4",
+		}},
+	}); err != nil {
+		t.Fatalf("create prior cache record: %v", err)
+	}
+	if err := store.Create(ctx, cachestore.Record{
+		CacheKey:                "service-volume:wrong-output",
+		Stage:                   serviceVolumeStageName,
+		State:                   cacheStateReady,
+		Backend:                 "darwin-vz",
+		PolicyHash:              compiled.Hash,
+		CommandDigest:           block.CommandDigest,
+		EnvDigest:               block.EnvDigest,
+		NormalizedOutputsDigest: block.NormalizedOutputsDigest,
+		ProducerVersion:         block.ProducerVersion,
+		StorageSizeBytes:        64 << 30,
+		OutputRecords: []cachestore.OutputRecord{{
+			Kind:          "dir",
+			Path:          "/var/lib/postgresql",
+			VolumeSubpath: "dirs/0",
+			StorageDriver: "apfs",
+			StorageRef:    "/snapshots/postgres.ext4",
+			SnapshotRef:   "/snapshots/postgres.ext4",
+		}},
+	}); err != nil {
+		t.Fatalf("create nonmatching cache record: %v", err)
+	}
+
+	got, err := lookupBlockVolumeCache(ctx, store, serviceVolumeStageName, "darwin-vz", compiled, block)
+	if err != nil {
+		t.Fatalf("lookupBlockVolumeCache returned error: %v", err)
+	}
+	if got.CacheHit {
+		t.Fatal("expected cache miss for new input")
+	}
+	if got.LookupReason != observability.CacheLookupReasonRecordNotFound {
+		t.Fatalf("unexpected lookup reason: got %q", got.LookupReason)
+	}
+	if got, want := got.CacheOutputMinimumBytes, int64(25<<30); got != want {
+		t.Fatalf("unexpected adaptive minimum bytes: got %d want %d", got, want)
+	}
+}
+
+func TestBlockVolumeMinimumBytesWithHeadroomUsesAtLeastOneGiB(t *testing.T) {
+	if got, want := blockVolumeMinimumBytesWithHeadroom(2<<30), int64(3<<30); got != want {
+		t.Fatalf("unexpected minimum bytes with headroom: got %d want %d", got, want)
+	}
+}

--- a/internal/controlservice/block_volume_specs.go
+++ b/internal/controlservice/block_volume_specs.go
@@ -12,24 +12,26 @@ import (
 )
 
 type blockVolumeOutputSpecBlock struct {
-	Stage       string
-	BlockName   string
-	CacheKey    string
-	Outputs     policy.StageBlockOutputs
-	CacheHit    bool
-	CacheRecord cachestore.Record
+	Stage        string
+	BlockName    string
+	CacheKey     string
+	MinimumBytes int64
+	Outputs      policy.StageBlockOutputs
+	CacheHit     bool
+	CacheRecord  cachestore.Record
 }
 
 func dependencyBlockVolumeOutputSpecs(plan dependencyBlockVolumePlan) ([]backend.CacheOutputVolumeSpec, error) {
 	blocks := make([]blockVolumeOutputSpecBlock, 0, len(plan.Blocks))
 	for _, block := range plan.Blocks {
 		blocks = append(blocks, blockVolumeOutputSpecBlock{
-			Stage:       dependencyVolumeStageName,
-			BlockName:   block.BlockName,
-			CacheKey:    block.CacheKey,
-			Outputs:     block.Outputs,
-			CacheHit:    block.CacheHit,
-			CacheRecord: block.CacheRecord,
+			Stage:        dependencyVolumeStageName,
+			BlockName:    block.BlockName,
+			CacheKey:     block.CacheKey,
+			MinimumBytes: block.CacheOutputMinimumBytes,
+			Outputs:      block.Outputs,
+			CacheHit:     block.CacheHit,
+			CacheRecord:  block.CacheRecord,
 		})
 	}
 	return blockVolumeOutputSpecs(blocks)
@@ -39,12 +41,13 @@ func serviceBlockVolumeOutputSpecs(plan serviceBlockVolumePlan) ([]backend.Cache
 	blocks := make([]blockVolumeOutputSpecBlock, 0, len(plan.Blocks))
 	for _, block := range plan.Blocks {
 		blocks = append(blocks, blockVolumeOutputSpecBlock{
-			Stage:       serviceVolumeStageName,
-			BlockName:   block.BlockName,
-			CacheKey:    block.CacheKey,
-			Outputs:     block.Outputs,
-			CacheHit:    block.CacheHit,
-			CacheRecord: block.CacheRecord,
+			Stage:        serviceVolumeStageName,
+			BlockName:    block.BlockName,
+			CacheKey:     block.CacheKey,
+			MinimumBytes: block.CacheOutputMinimumBytes,
+			Outputs:      block.Outputs,
+			CacheHit:     block.CacheHit,
+			CacheRecord:  block.CacheRecord,
 		})
 	}
 	return blockVolumeOutputSpecs(blocks)
@@ -96,10 +99,11 @@ func blockVolumeOutputSpec(block blockVolumeOutputSpecBlock) (backend.CacheOutpu
 	}
 
 	spec := backend.CacheOutputVolumeSpec{
-		Stage:     stage,
-		BlockName: blockName,
-		CacheKey:  cacheKey,
-		VolumeID:  blockVolumeID(stage, cacheKey),
+		Stage:        stage,
+		BlockName:    blockName,
+		CacheKey:     cacheKey,
+		VolumeID:     blockVolumeID(stage, cacheKey),
+		MinimumBytes: block.MinimumBytes,
 	}
 	if block.CacheHit {
 		outputRecords, err := blockVolumeOutputRecordsByKey(block)

--- a/internal/controlservice/block_volume_specs_test.go
+++ b/internal/controlservice/block_volume_specs_test.go
@@ -41,8 +41,9 @@ func TestDependencyBlockVolumeOutputSpecsBuildsHitAndMissSpecs(t *testing.T) {
 				},
 			},
 			{
-				BlockName: "go-modules",
-				CacheKey:  "dependency-volume:v1:go-modules",
+				BlockName:               "go-modules",
+				CacheKey:                "dependency-volume:v1:go-modules",
+				CacheOutputMinimumBytes: 20 << 30,
 				Outputs: policy.StageBlockOutputs{
 					Dirs:  []string{"/root/go/pkg/mod"},
 					Files: []string{"/root/.cache/go-build/README"},
@@ -91,6 +92,9 @@ func TestDependencyBlockVolumeOutputSpecsBuildsHitAndMissSpecs(t *testing.T) {
 	}
 	if got, want := miss.FileMappings[0].Subpath, "files/0"; got != want {
 		t.Fatalf("unexpected miss file subpath: got %q want %q", got, want)
+	}
+	if got, want := miss.MinimumBytes, int64(20<<30); got != want {
+		t.Fatalf("unexpected miss minimum bytes: got %d want %d", got, want)
 	}
 	if hit.VolumeID == "" || miss.VolumeID == "" || hit.VolumeID == miss.VolumeID {
 		t.Fatalf("expected stable distinct volume IDs, got hit=%q miss=%q", hit.VolumeID, miss.VolumeID)

--- a/internal/controlservice/service_volume_plan_test.go
+++ b/internal/controlservice/service_volume_plan_test.go
@@ -1694,6 +1694,7 @@ func cacheOutputVolumeSpecsEqual(left, right []backend.CacheOutputVolumeSpec) bo
 			left[i].BlockName != right[i].BlockName ||
 			left[i].CacheKey != right[i].CacheKey ||
 			left[i].VolumeID != right[i].VolumeID ||
+			left[i].MinimumBytes != right[i].MinimumBytes ||
 			left[i].SourceSnapshotRef != right[i].SourceSnapshotRef ||
 			left[i].StorageDriver != right[i].StorageDriver ||
 			left[i].StorageRef != right[i].StorageRef {

--- a/internal/volumestore/allocated_size_fallback.go
+++ b/internal/volumestore/allocated_size_fallback.go
@@ -1,0 +1,12 @@
+//go:build !darwin && !linux
+
+package volumestore
+
+import "os"
+
+func allocatedFileSize(info os.FileInfo) int64 {
+	if info == nil {
+		return 0
+	}
+	return info.Size()
+}

--- a/internal/volumestore/allocated_size_unix.go
+++ b/internal/volumestore/allocated_size_unix.go
@@ -1,0 +1,18 @@
+//go:build darwin || linux
+
+package volumestore
+
+import (
+	"os"
+	"syscall"
+)
+
+func allocatedFileSize(info os.FileInfo) int64 {
+	if info == nil {
+		return 0
+	}
+	if stat, ok := info.Sys().(*syscall.Stat_t); ok && stat.Blocks >= 0 {
+		return int64(stat.Blocks) * 512
+	}
+	return info.Size()
+}

--- a/internal/volumestore/apfs_test.go
+++ b/internal/volumestore/apfs_test.go
@@ -90,6 +90,12 @@ func TestAPFSDriverSnapshotLifecycle(t *testing.T) {
 	if got, want := snapshot.StorageRef, filepath.Join(snapshotBaseDir, "darwin-vz", "snap-1", "rootfs.ext4"); got != want {
 		t.Fatalf("unexpected snapshot storage ref: got %q want %q", got, want)
 	}
+	if got, want := snapshot.StorageSizeBytes, int64(len("snapshot-bytes")); got != want {
+		t.Fatalf("unexpected snapshot storage size: got %d want %d", got, want)
+	}
+	if got := snapshot.ExclusiveSizeBytes; got <= 0 {
+		t.Fatalf("expected snapshot exclusive size to be populated, got %d", got)
+	}
 
 	clone, err := driver.CloneSnapshotToVolume(context.Background(), CloneSnapshotToVolumeRequest{
 		VolumeID:       "sandbox-2",

--- a/internal/volumestore/file.go
+++ b/internal/volumestore/file.go
@@ -115,7 +115,17 @@ func (d *pathDriver) SnapshotVolume(_ context.Context, req SnapshotVolumeRequest
 		_ = os.Remove(target)
 		return Snapshot{}, fmt.Errorf("copy snapshot volume %q: %w", volumeRef, err)
 	}
-	return Snapshot{Ref: target, StorageRef: target}, nil
+	info, err := os.Stat(target)
+	if err != nil {
+		_ = os.Remove(target)
+		return Snapshot{}, fmt.Errorf("stat snapshot volume %q: %w", target, err)
+	}
+	return Snapshot{
+		Ref:                target,
+		StorageRef:         target,
+		StorageSizeBytes:   info.Size(),
+		ExclusiveSizeBytes: allocatedFileSize(info),
+	}, nil
 }
 
 func (d *pathDriver) CloneSnapshotToVolume(_ context.Context, req CloneSnapshotToVolumeRequest) (WritableVolume, error) {

--- a/internal/volumestore/file_sparse_test.go
+++ b/internal/volumestore/file_sparse_test.go
@@ -48,6 +48,12 @@ func TestFileDriverPreservesSparseVolumeCopies(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SnapshotVolume returned error: %v", err)
 	}
+	if got := snapshot.StorageSizeBytes; got != logicalSize {
+		t.Fatalf("unexpected snapshot storage size: got %d want %d", got, int64(logicalSize))
+	}
+	if got := snapshot.ExclusiveSizeBytes; got <= 0 || got > logicalSize/4 {
+		t.Fatalf("unexpected snapshot exclusive size: got %d logical %d", got, int64(logicalSize))
+	}
 	requireSparseVolumeForTest(t, snapshot.Ref, logicalSize)
 
 	clone, err := driver.CloneSnapshotToVolume(context.Background(), CloneSnapshotToVolumeRequest{

--- a/internal/volumestore/file_test.go
+++ b/internal/volumestore/file_test.go
@@ -81,6 +81,12 @@ func TestFileDriverSnapshotLifecycle(t *testing.T) {
 	if got, want := snapshot.StorageRef, filepath.Join(snapshotBaseDir, "firecracker", "snap-1", "rootfs.ext4"); got != want {
 		t.Fatalf("unexpected snapshot storage ref: got %q want %q", got, want)
 	}
+	if got, want := snapshot.StorageSizeBytes, int64(len("snapshot-bytes")); got != want {
+		t.Fatalf("unexpected snapshot storage size: got %d want %d", got, want)
+	}
+	if got := snapshot.ExclusiveSizeBytes; got <= 0 {
+		t.Fatalf("expected snapshot exclusive size to be populated, got %d", got)
+	}
 
 	clone, err := driver.CloneSnapshotToVolume(context.Background(), CloneSnapshotToVolumeRequest{
 		VolumeID:       "sandbox-2",


### PR DESCRIPTION
Cache-output volumes could run out of capacity for large service or dependency outputs, and avoiding that required users to know about `minimum_cache_output_volume_bytes` and tune it manually. That made large Docker-style outputs user-impacting even though Cleanroom already has enough cache metadata to size new cold volumes more intelligently.

This changes the built-in cache-output floor to 16 GiB while keeping those images sparse, so the larger default is logical capacity rather than immediate host disk allocation. It also lets the planner use prior successful matching block snapshots as a sizing hint: on a cold miss, the next writable cache-output volume can be created from the previous allocated size plus headroom. File/APFS-backed snapshots now record both logical size and allocated size so adaptive sizing does not ratchet upward just because the sparse image has a larger logical capacity.

The runtime config override remains available as a host-level escape hatch, but most users should not need to configure cache-output sizing for normal large outputs.

Validation:

```sh
/Users/lachlan/.local/share/mise/installs/go/1.26.2/bin/go test ./internal/backend/cacheoutput ./internal/backend/firecracker ./internal/backend/darwinvz ./internal/volumestore ./internal/controlservice
/Users/lachlan/.local/share/mise/installs/go/1.26.2/bin/go test ./...
git diff --check
```