### PR TITLE
build: Add local darwin-vz kernel build targets

### DIFF
--- a/benchmarks/darwin-vz/minimal/README.md
+++ b/benchmarks/darwin-vz/minimal/README.md
@@ -30,6 +30,15 @@ To build the minimal kernel first:
 scripts/benchmark-darwin-vz-minimal.sh --build-kernel --iterations 30
 ```
 
+To build the rootfs-profile kernel for the Cleanroom `darwin-vz` backend:
+
+```bash
+mise run build:kernel:darwin-vz-minimal-rootfs
+```
+
+Then set `backends.darwin-vz.kernel_image` to the generated
+`dist/darwin-vz-minimal-rootfs-arm64-kernel-6.1.155-Image` path.
+
 To test whether VZ releases host footprint after guest free-page reporting without an explicit balloon target:
 
 ```bash

--- a/docs/backend/darwin-vz.md
+++ b/docs/backend/darwin-vz.md
@@ -110,6 +110,24 @@ Kernel:
 
 - if configured kernel exists, use it
 - otherwise resolve and cache a managed kernel asset under XDG data paths
+- `backends.darwin-vz.kernel_image` is an explicit local kernel path override
+
+To build the experimental minimal rootfs-profile kernel locally:
+
+```bash
+mise run build:kernel:darwin-vz-minimal-rootfs
+```
+
+Then point runtime config at the generated kernel:
+
+```yaml
+backends:
+  darwin-vz:
+    kernel_image: /path/to/cleanroom/dist/darwin-vz-minimal-rootfs-arm64-kernel-6.1.155-Image
+```
+
+Use `kernel_image` for local kernel experiments. The managed kernel fallback
+remains the default when `kernel_image` is empty or inaccessible.
 
 Rootfs:
 

--- a/mise.toml
+++ b/mise.toml
@@ -28,6 +28,14 @@ run = "scripts/build-go.sh"
 description = "Build macOS darwin-vz helper into dist/"
 run = "{% if os() == \"macos\" %}scripts/build-darwin-vz-helper.sh dist/cleanroom-darwin-vz.app{% else %}true{% endif %}"
 
+[tasks."build:kernel:darwin-vz-minimal-initrd"]
+description = "Build minimal darwin-vz initrd-profile Linux kernel into dist/"
+run = "CLEANROOM_DARWIN_VZ_MINIMAL_KERNEL_PROFILE=initrd benchmarks/darwin-vz/minimal/build-kernel.sh"
+
+[tasks."build:kernel:darwin-vz-minimal-rootfs"]
+description = "Build minimal darwin-vz rootfs-profile Linux kernel into dist/"
+run = "CLEANROOM_DARWIN_VZ_MINIMAL_KERNEL_PROFILE=rootfs benchmarks/darwin-vz/minimal/build-kernel.sh"
+
 [tasks."build:image:alpine"]
 description = "Build local alpine base image"
 run = "docker build -f images/Dockerfile.base-image -t cleanroom-base:alpine ."


### PR DESCRIPTION
Cleanroom already accepts explicit local darwin-vz kernels through `backends.darwin-vz.kernel_image`, but building the minimal experiment kernels still required knowing the benchmark script internals. That made the local custom-kernel path harder to use than it should be, and the managed asset selector was the wrong first abstraction because local kernel builds are not byte-stable enough to hang UX on a pinned release SHA.

This PR narrows the change to local development ergonomics:

```bash
mise run build:kernel:darwin-vz-minimal-rootfs
```

The target builds the rootfs-profile minimal darwin-vz kernel into:

```text
dist/darwin-vz-minimal-rootfs-arm64-kernel-6.1.155-Image
```

Then runtime config can opt into that local kernel with the existing backend config:

```yaml
backends:
  darwin-vz:
    kernel_image: /path/to/cleanroom/dist/darwin-vz-minimal-rootfs-arm64-kernel-6.1.155-Image
```

The default managed kernel fallback is unchanged. This intentionally does not add `kernel_asset` or any new named-kernel selector.

Validation performed:

- `mise run build:kernel:darwin-vz-minimal-rootfs`
- `shasum -a 256 dist/darwin-vz-minimal-rootfs-arm64-kernel-6.1.155-Image` reported `49ff4b3bf2aa39592d038422c2d95fcf53bf4c2edddca823fa781f0d779e61d2`
- `mise run build`
- temp-config `cleanroom doctor --backend darwin-vz --json` with `kernel_image` pointing at the generated kernel; `kernel_image`, guest agent, and helper checks passed
- `mise exec -- go test ./internal/bootassets ./internal/runtimeconfig ./internal/controlservice ./internal/backend/darwinvz ./internal/backend/firecracker`
- `git diff --check`