### PR TITLE
build: Add pi to agent base images

### DIFF
--- a/images/Dockerfile.base-image-agents
+++ b/images/Dockerfile.base-image-agents
@@ -4,6 +4,7 @@ ARG MISE_VERSION=v2026.4.5
 ARG CODEX_VERSION=0.106.0
 ARG CLAUDE_CODE_VERSION=2.1.63
 ARG GEMINI_CLI_VERSION=0.31.0
+ARG PI_CODING_AGENT_VERSION=0.52.9
 
 # `gemini` currently needs native build deps on Alpine and GNU `env` for `env -S`.
 RUN apk add --no-cache \
@@ -28,19 +29,25 @@ RUN mise settings add trusted_config_paths /workspace
 RUN mise use -g --pin \
   npm:@openai/codex@"${CODEX_VERSION}" \
   npm:@anthropic-ai/claude-code@"${CLAUDE_CODE_VERSION}" \
-  npm:@google/gemini-cli@"${GEMINI_CLI_VERSION}"
+  npm:@google/gemini-cli@"${GEMINI_CLI_VERSION}" \
+  npm:@mariozechner/pi-coding-agent@"${PI_CODING_AGENT_VERSION}" \
+  && npm cache clean --force \
+  && rm -rf /root/.cache /root/.npm /tmp/*
 
 # Ensure agent binaries are available on the default PATH even when OCI env
 # metadata is not propagated.
 RUN ln -sf /root/.local/share/mise/shims/codex /usr/local/bin/codex \
   && ln -sf /root/.local/share/mise/shims/claude /usr/local/bin/claude \
-  && ln -sf /root/.local/share/mise/shims/gemini /usr/local/bin/gemini
+  && ln -sf /root/.local/share/mise/shims/gemini /usr/local/bin/gemini \
+  && ln -sf /root/.local/share/mise/shims/pi /usr/local/bin/pi
 
 ENV PATH="/root/.local/share/mise/shims:${PATH}"
 
 RUN mise --version && node --version && npm --version && python3 --version \
   && PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" codex --version \
   && PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" claude --version \
-  && PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" gemini --version
+  && PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" gemini --version \
+  && PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" pi --version \
+  && rm -rf /root/.cache /root/.npm /tmp/*
 
 CMD ["/bin/sh"]

--- a/images/Dockerfile.base-image-debian-agents
+++ b/images/Dockerfile.base-image-debian-agents
@@ -4,6 +4,7 @@ ARG MISE_VERSION=v2026.4.5
 ARG CODEX_VERSION=0.106.0
 ARG CLAUDE_CODE_VERSION=2.1.63
 ARG GEMINI_CLI_VERSION=0.31.0
+ARG PI_CODING_AGENT_VERSION=0.52.9
 
 RUN apt-get update \
     && apt-get install --yes --no-install-recommends \
@@ -28,19 +29,25 @@ RUN mise settings add trusted_config_paths /workspace
 RUN mise use -g --pin \
   npm:@openai/codex@"${CODEX_VERSION}" \
   npm:@anthropic-ai/claude-code@"${CLAUDE_CODE_VERSION}" \
-  npm:@google/gemini-cli@"${GEMINI_CLI_VERSION}"
+  npm:@google/gemini-cli@"${GEMINI_CLI_VERSION}" \
+  npm:@mariozechner/pi-coding-agent@"${PI_CODING_AGENT_VERSION}" \
+  && npm cache clean --force \
+  && rm -rf /root/.cache /root/.npm /tmp/*
 
 # Ensure agent binaries are available on the default PATH even when OCI env
 # metadata is not propagated.
 RUN ln -sf /root/.local/share/mise/shims/codex /usr/local/bin/codex \
   && ln -sf /root/.local/share/mise/shims/claude /usr/local/bin/claude \
-  && ln -sf /root/.local/share/mise/shims/gemini /usr/local/bin/gemini
+  && ln -sf /root/.local/share/mise/shims/gemini /usr/local/bin/gemini \
+  && ln -sf /root/.local/share/mise/shims/pi /usr/local/bin/pi
 
 ENV PATH="/root/.local/share/mise/shims:${PATH}"
 
 RUN mise --version && node --version && npm --version && python3 --version \
   && PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" codex --version \
   && PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" claude --version \
-  && PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" gemini --version
+  && PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" gemini --version \
+  && PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" pi --version \
+  && rm -rf /root/.cache /root/.npm /tmp/*
 
 CMD ["/bin/sh"]

--- a/images/dockerfiles_test.go
+++ b/images/dockerfiles_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 const expectedMiseVersion = "v2026.4.5"
+const expectedPICodingAgentVersion = "0.52.9"
 
 func publishedBaseDockerfiles() []string {
 	return []string{
@@ -29,6 +30,13 @@ func debianPublishedBaseDockerfiles() []string {
 func allPublishedBaseDockerfiles() []string {
 	paths := publishedBaseDockerfiles()
 	return append(paths, debianPublishedBaseDockerfiles()...)
+}
+
+func agentDockerfiles() []string {
+	return []string{
+		"Dockerfile.base-image-agents",
+		"Dockerfile.base-image-debian-agents",
+	}
 }
 
 func dockerfileHasTrimmedLine(dockerfile, want string) bool {
@@ -226,6 +234,39 @@ func TestPublishedBaseImagesTrustWorkspaceMiseConfig(t *testing.T) {
 			}
 			if !strings.Contains(string(raw), "mise settings add trusted_config_paths /workspace") {
 				t.Fatalf("%s does not trust /workspace for repo-local mise config", relPath)
+			}
+		})
+	}
+}
+
+func TestAgentBaseImagesInstallPinnedPICodingAgent(t *testing.T) {
+	t.Parallel()
+
+	for _, relPath := range agentDockerfiles() {
+		relPath := relPath
+		t.Run(relPath, func(t *testing.T) {
+			t.Parallel()
+
+			raw, err := os.ReadFile(filepath.Join(".", relPath))
+			if err != nil {
+				t.Fatalf("read %s: %v", relPath, err)
+			}
+
+			dockerfile := string(raw)
+			if !strings.Contains(dockerfile, "ARG PI_CODING_AGENT_VERSION="+expectedPICodingAgentVersion) {
+				t.Fatalf("%s does not pin pi-coding-agent to %s", relPath, expectedPICodingAgentVersion)
+			}
+			if !strings.Contains(dockerfile, `npm:@mariozechner/pi-coding-agent@"${PI_CODING_AGENT_VERSION}"`) {
+				t.Fatalf("%s does not install pi-coding-agent through mise", relPath)
+			}
+			if !strings.Contains(dockerfile, "ln -sf /root/.local/share/mise/shims/pi /usr/local/bin/pi") {
+				t.Fatalf("%s does not expose pi on the default PATH", relPath)
+			}
+			if !strings.Contains(dockerfile, `PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" pi --version`) {
+				t.Fatalf("%s does not smoke-test pi on the default PATH", relPath)
+			}
+			if strings.Count(dockerfile, "rm -rf /root/.cache /root/.npm /tmp/*") < 2 {
+				t.Fatalf("%s does not remove npm, node-gyp, and temporary build caches after install and smoke checks", relPath)
 			}
 		})
 	}


### PR DESCRIPTION
This updates both agent base images to install `@mariozechner/pi-coding-agent@0.52.9`, expose `/usr/local/bin/pi`, and include `pi --version` in the image smoke checks. The install and smoke-check layers also remove `/root/.cache`, `/root/.npm`, and `/tmp/*`; in local arm64 validation that kept the pi-enabled images about 61 MB smaller than a pi-enabled build that retained npm/node-gyp/tmp cache artifacts.

Local validation measured the final built image sizes as:

- Debian agents: 1,413,623,227 bytes
- Alpine agents: 1,137,036,292 bytes