### PR TITLE
perf: Reuse darwin-vz rootfs cache across disk floors

### DIFF
--- a/docs/backend/darwin-vz.md
+++ b/docs/backend/darwin-vz.md
@@ -118,9 +118,11 @@ Rootfs:
 - inject guest runtime (`cleanroom-guest-agent` and `/usr/sbin/cleanroom-init`) into a prepared cached rootfs image
 - create a per-sandbox copy (`rootfs-persistent.ext4`) and attach it read-write to the VM
 - `/workspace` is not a separate volume on `darwin-vz`; it lives on the guest rootfs
-- `backends.darwin-vz.minimum_rootfs_bytes` lets the runtime grow the guest rootfs copy before boot for non-trivial workloads that need more writable space; policy `sandbox.resources.disk` raises this floor when it is larger
+- `backends.darwin-vz.minimum_rootfs_bytes` is an operator-wide writable rootfs floor; policy `sandbox.resources.disk` raises this floor when it is larger
 - `minimum_rootfs_bytes` accepts either raw bytes (`2147483648`) or human-friendly sizes (`2GiB`, `700MiB`, `"2147483648"`)
 - the same setting is also honored under the legacy underscore config key: `backends.darwin_vz.minimum_rootfs_bytes`
+- image-derived prepared runtime rootfs cache entries are shared by image digest and guest runtime version; writable disk floors apply later to the per-sandbox rootfs copy
+- see [Storage](../storage.md) for the storage model, sizing sources, and diagnostics
 - effective vCPUs are fixed at VM launch; `darwin-vz` does not hotplug CPUs into a running VM
 
 Snapshot/rootfs volume drivers:

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -84,6 +84,10 @@ inputs.
 
 ## Cache Output Volume Size
 
+See [Storage](storage.md#cache-output-volumes) for how cache-output volumes fit
+alongside image artifacts, prepared runtime rootfs entries, writable rootfs
+copies, and snapshots.
+
 Cache output volumes are sparse ext4 images on the host. When Cleanroom creates
 a new volume — or restores one from an older snapshot — it enforces a minimum
 size. The default is 16 GiB.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -155,6 +155,13 @@ structured logs where applicable:
 - `cleanroom.command.argc`
 - `cleanroom.command.name`
 - `cleanroom.command.summary`
+- `cleanroom.rootfs.minimum_bytes`
+- `cleanroom.rootfs.minimum_source`
+
+`cleanroom.rootfs.minimum_source` identifies the winning writable rootfs disk
+floor source, such as `config`, `policy`, `repository_bootstrap`, or
+`docker_repository_bootstrap`. See [Storage](storage.md#writable-sandbox-rootfs)
+for how those floors are resolved.
 
 ### Outcomes and reason codes
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -90,6 +90,9 @@ cleanroom system prune --all --older-than 7d
 `system prune` protects active sandboxes and does not delete explicit snapshots
 by default. Use `cleanroom snapshot rm` for named snapshots.
 
+See [Storage](storage.md#inspect-and-prune) for storage categories, sizing
+sources, and startup diagnostics.
+
 ## Observability
 
 Cleanroom can emit OTLP traces and metrics, and can write structured logs:

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -180,6 +180,7 @@ explicit request-time changeset input.
 - `sandbox.resources.memory` and `sandbox.resources.disk` must be positive byte sizes. They accept raw bytes or size strings such as `4096MiB`, `8GiB`, or `16GiB`.
 - Resource floors raise the effective backend runtime settings when the host runtime config is lower; they do not lower larger host defaults.
 - Backends decide how effective resource ceilings map to host resources.
+- See [Storage](storage.md#writable-sandbox-rootfs) for how disk floors apply to the writable rootfs and how they differ from image and cache-output sizing.
 - Sandbox API responses include `effective_resources`, which reports the resolved vCPU, memory, and disk ceilings after backend config, defaults, and policy resource floors are merged.
 - `effective_resources.vcpus` is a launch-time CPU ceiling; Cleanroom does not hotplug CPUs into an already running sandbox.
 - `sandbox.docker.required` defaults to `false`; when true, Cleanroom starts the guest Docker daemon for the sandbox.

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -1,0 +1,178 @@
+# Storage
+
+Cleanroom stores several different kinds of host-side state. They have different
+owners, lifetimes, and sizing rules, so a storage knob for one layer should not
+be treated as a prewarm or cache-size knob for another.
+
+Related docs:
+
+- [Caching](caching.md) covers dependency and service cache semantics.
+- [Operations](operations.md) covers `cleanroom system df` and prune commands.
+- [Darwin VZ Backend](backend/darwin-vz.md) covers macOS-specific rootfs and
+  snapshot driver behavior.
+- [Spec](spec.md) defines the repository-facing `sandbox.resources.disk`
+  contract.
+
+## Model
+
+For an image-backed sandbox, the root filesystem path is layered like this:
+
+```text
+OCI image
+  -> image rootfs artifact
+  -> prepared runtime rootfs
+  -> writable sandbox rootfs
+```
+
+Declared dependency and service outputs use a separate path:
+
+```text
+declared output path
+  -> cache-output volume
+  -> cache-output snapshot
+```
+
+Stage caches and user snapshots capture reusable rootfs or output-volume state
+after a sandbox has already run. They are metadata-backed storage records, not
+image cache entries.
+
+## RootFS Artifacts
+
+### Image RootFS Artifact
+
+The image manager materializes an OCI image into an ext4 rootfs artifact under
+the image cache. It is keyed by image digest and represents image contents.
+
+This artifact is not sized from `minimum_rootfs_bytes` or
+`sandbox.resources.disk`. It only needs enough space for image contents and
+materialization headroom.
+
+### Prepared Runtime RootFS
+
+The prepared runtime rootfs is a shared immutable image-derived artifact. On
+`darwin-vz`, Cleanroom copies the image rootfs artifact and injects the guest
+runtime files needed to boot and execute commands.
+
+The prepared runtime rootfs is keyed by:
+
+- image digest
+- guest agent hash
+- host architecture
+- guest runtime versions
+
+It is not keyed by writable disk floors such as `minimum_rootfs_bytes` or
+`sandbox.resources.disk`. Changing a writable disk floor should not force a new
+prepared runtime rootfs cache entry.
+
+### Writable Sandbox RootFS
+
+The writable sandbox rootfs is the per-sandbox or per-execution copy attached to
+the VM read-write. This is where writable disk capacity applies.
+
+The effective writable rootfs minimum is resolved from the largest applicable
+floor:
+
+| Source | When It Applies |
+|--------|-----------------|
+| `config` | backend runtime config sets `minimum_rootfs_bytes` |
+| `policy` | `sandbox.resources.disk` is larger than the current floor |
+| `repository_bootstrap` | repository bootstrap needs at least 8 GiB |
+| `docker_repository_bootstrap` | repository bootstrap with Docker required needs at least 16 GiB |
+
+If no floor applies, the backend uses the image or snapshot size as-is.
+
+On `darwin-vz`, rootfs resizing happens after the writable clone is created and
+before VM boot. The launch phase is reported as
+`rootfs_minimum_size_resize`. The run observation also records
+`rootfs_minimum_bytes` and `rootfs_minimum_source` when available, and traces use
+`cleanroom.rootfs.minimum_bytes` and `cleanroom.rootfs.minimum_source`.
+
+## Cache Output Volumes
+
+Cache output volumes back declared dependency and service output paths. They are
+separate from the rootfs floor and are controlled by cache-output sizing.
+
+Use these for dependency or service state such as:
+
+- `${HOME}/go/pkg/mod`
+- package manager stores
+- `/var/lib/docker`
+- database files built by a service block
+
+The default cache-output volume floor is 16 GiB. Runtime config can override it
+per backend with `minimum_cache_output_volume_bytes`.
+
+Cleanroom may also use the previous successful output size for the same block
+shape as a sizing hint when creating a new cold volume. Existing on-disk volumes
+keep their current size; the floor applies when a volume is created or restored
+from an older snapshot.
+
+## Configuration
+
+Most image-only sandboxes should not set a global rootfs floor. Let the image
+size define the writable rootfs size unless the workload actually needs more
+space.
+
+Use `sandbox.resources.disk` for repository-declared workload requirements:
+
+```yaml
+sandbox:
+  resources:
+    disk: 16GiB
+```
+
+Use backend `minimum_rootfs_bytes` only as an operator-wide writable rootfs
+floor for that host:
+
+```yaml
+backends:
+  darwin-vz:
+    minimum_rootfs_bytes: 16GiB
+```
+
+Use `minimum_cache_output_volume_bytes` for declared output volume defaults:
+
+```yaml
+backends:
+  darwin-vz:
+    minimum_cache_output_volume_bytes: 16GiB
+```
+
+These settings are independent. Increasing `minimum_rootfs_bytes` should not
+increase prepared runtime rootfs cache entries, and increasing
+`minimum_cache_output_volume_bytes` should not resize the rootfs.
+
+## Backend Notes
+
+`darwin-vz` uses sparse ext4 files and APFS clonefile-backed copies when the
+`apfs` snapshot driver is selected. Logical capacity can be larger than current
+host disk use, but filesystem metadata and actual guest writes still consume
+host storage.
+
+`firecracker` uses the same backend-neutral resource contract, but the physical
+storage behavior depends on the configured snapshot driver, such as `file` or
+`zfs`.
+
+## Inspect And Prune
+
+Use the system commands to see where host storage is going:
+
+```bash
+cleanroom system df
+cleanroom system df --json
+cleanroom system prune --dry-run
+```
+
+Use `cleanroom system prune --all --older-than 7d` only when the dry run shows
+the expected reclaimable entries. Prune protects active sandboxes and does not
+delete explicit snapshots by default.
+
+When sandbox creation is slow, check:
+
+- `cleanroom system df` for unusually large runtime-rootfs or snapshot caches
+- launch phase metrics for `rootfs_resolve`, `rootfs_minimum_size_resize`, and
+  cache-output phases
+- `rootfs_minimum_bytes` and `rootfs_minimum_source` in the darwin-vz run
+  observation file or trace attributes
+- whether the request is image-only, repository-backed, Docker-backed, or
+  policy-declared with `sandbox.resources.disk`

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"net"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/buildkite/cleanroom/internal/policy"
@@ -402,6 +403,25 @@ const (
 	DefaultMemoryMiB int64 = 512
 )
 
+const (
+	RootFSMinimumSourceUnset                     = "unset"
+	RootFSMinimumSourceUnknown                   = "unknown"
+	RootFSMinimumSourceConfig                    = "config"
+	RootFSMinimumSourcePolicy                    = "policy"
+	RootFSMinimumSourceRepositoryBootstrap       = "repository_bootstrap"
+	RootFSMinimumSourceDockerRepositoryBootstrap = "docker_repository_bootstrap"
+)
+
+func EffectiveRootFSMinimumSource(cfg FirecrackerConfig) string {
+	if cfg.MinimumRootFSBytes <= 0 {
+		return RootFSMinimumSourceUnset
+	}
+	if source := strings.TrimSpace(cfg.MinimumRootFSBytesSource); source != "" {
+		return source
+	}
+	return RootFSMinimumSourceUnknown
+}
+
 type FirecrackerConfig struct {
 	BinaryPath      string
 	KernelImagePath string
@@ -409,7 +429,8 @@ type FirecrackerConfig struct {
 	// MinimumRootFSBytes is a writable rootfs capacity floor. Backends may
 	// provide this as logical capacity or a larger backend default; it is not an
 	// exact host-disk allocation promise.
-	MinimumRootFSBytes int64
+	MinimumRootFSBytes       int64
+	MinimumRootFSBytesSource string
 	// MinimumCacheOutputVolumeBytes is a per-cache-output-volume capacity floor.
 	// Backends may provide this as logical capacity or a larger backend default;
 	// it is not an exact host-disk allocation promise. Zero means fall back to

--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -69,7 +69,7 @@ type Adapter struct {
 	executeInSandboxFn func(context.Context, context.Context, *sandboxInstance, backend.ExecutionRequest, backend.OutputStream) (*backend.ExecutionResult, error)
 	helperRequestFn    func(context.Context, *helperSession, helperControlRequest) (helperControlResponse, error)
 
-	ensurePreparedRootFSFn func(context.Context, string, int64) (preparedRootFS, error)
+	ensurePreparedRootFSFn func(context.Context, string) (preparedRootFS, error)
 
 	GatewayRegistry  gatewayRegistry
 	GatewayPort      int
@@ -129,26 +129,28 @@ const preparedRuntimeRootFSVersion = "v9-darwin-vz"
 const runObservabilityFile = "execution-observability.json"
 
 type darwinVZRunObservation struct {
-	ExecutionID       string           `json:"execution_id"`
-	TraceID           string           `json:"trace_id,omitempty"`
-	Backend           string           `json:"backend"`
-	LaunchedVM        bool             `json:"launched_vm"`
-	ImageRef          string           `json:"image_ref,omitempty"`
-	ImageDigest       string           `json:"image_digest,omitempty"`
-	PlanPath          string           `json:"plan_path,omitempty"`
-	RunDir            string           `json:"run_dir,omitempty"`
-	ExitCode          int              `json:"exit_code,omitempty"`
-	Error             string           `json:"error,omitempty"`
-	GuestError        string           `json:"guest_error,omitempty"`
-	NetworkMode       string           `json:"network_mode,omitempty"`
-	NetworkSubnetCIDR string           `json:"network_subnet_cidr,omitempty"`
-	NetworkGuestIP    string           `json:"network_guest_ip,omitempty"`
-	NetworkGatewayIP  string           `json:"network_gateway_ip,omitempty"`
-	NetworkPrefixLen  int              `json:"network_prefix_len,omitempty"`
-	RootFSCopyMS      int64            `json:"rootfs_copy_ms,omitempty"`
-	VMReadyMS         int64            `json:"vm_ready_ms,omitempty"`
-	HelperTimingMS    map[string]int64 `json:"helper_timing_ms,omitempty"`
-	TotalMS           int64            `json:"total_ms,omitempty"`
+	ExecutionID         string           `json:"execution_id"`
+	TraceID             string           `json:"trace_id,omitempty"`
+	Backend             string           `json:"backend"`
+	LaunchedVM          bool             `json:"launched_vm"`
+	ImageRef            string           `json:"image_ref,omitempty"`
+	ImageDigest         string           `json:"image_digest,omitempty"`
+	PlanPath            string           `json:"plan_path,omitempty"`
+	RunDir              string           `json:"run_dir,omitempty"`
+	ExitCode            int              `json:"exit_code,omitempty"`
+	Error               string           `json:"error,omitempty"`
+	GuestError          string           `json:"guest_error,omitempty"`
+	NetworkMode         string           `json:"network_mode,omitempty"`
+	NetworkSubnetCIDR   string           `json:"network_subnet_cidr,omitempty"`
+	NetworkGuestIP      string           `json:"network_guest_ip,omitempty"`
+	NetworkGatewayIP    string           `json:"network_gateway_ip,omitempty"`
+	NetworkPrefixLen    int              `json:"network_prefix_len,omitempty"`
+	RootFSMinimumBytes  int64            `json:"rootfs_minimum_bytes,omitempty"`
+	RootFSMinimumSource string           `json:"rootfs_minimum_source,omitempty"`
+	RootFSCopyMS        int64            `json:"rootfs_copy_ms,omitempty"`
+	VMReadyMS           int64            `json:"vm_ready_ms,omitempty"`
+	HelperTimingMS      map[string]int64 `json:"helper_timing_ms,omitempty"`
+	TotalMS             int64            `json:"total_ms,omitempty"`
 }
 
 func traceIDFromSpanContext(spanContext trace.SpanContext) string {
@@ -235,6 +237,12 @@ func recordLaunchPhaseTraceEvents(ctx context.Context, backendName string, obser
 	if !span.IsRecording() {
 		return
 	}
+	if observation.RootFSMinimumBytes > 0 || strings.TrimSpace(observation.RootFSMinimumSource) != "" {
+		span.SetAttributes(
+			attribute.Int64(observability.AttrRootFSMinimumBytes, observation.RootFSMinimumBytes),
+			attribute.String(observability.AttrRootFSMinimumSource, rootFSMinimumSourceForObservation(observation)),
+		)
+	}
 	for _, phase := range darwinVZLaunchPhaseDurations(observation) {
 		span.AddEvent(
 			observability.EventLaunchPhase,
@@ -245,6 +253,17 @@ func recordLaunchPhaseTraceEvents(ctx context.Context, backendName string, obser
 			),
 		)
 	}
+}
+
+func rootFSMinimumSourceForObservation(observation darwinVZRunObservation) string {
+	source := strings.TrimSpace(observation.RootFSMinimumSource)
+	if observation.RootFSMinimumBytes <= 0 {
+		return backend.RootFSMinimumSourceUnset
+	}
+	if source == "" {
+		return backend.RootFSMinimumSourceUnknown
+	}
+	return source
 }
 
 func darwinVZLaunchPhaseDurations(observation darwinVZRunObservation) []darwinVZLaunchPhaseDuration {
@@ -543,13 +562,15 @@ func (a *Adapter) RunInSandbox(ctx context.Context, req backend.ExecutionRequest
 	}
 	req.RunDir = runDir
 	observation := darwinVZRunObservation{
-		ExecutionID: req.ExecutionID,
-		TraceID:     traceIDFromSpanContext(trace.SpanContextFromContext(ctx)),
-		Backend:     a.Name(),
-		RunDir:      runDir,
-		ImageRef:    instance.ImageRef,
-		ImageDigest: instance.ImageDigest,
-		PlanPath:    instance.ConfigPath,
+		ExecutionID:         req.ExecutionID,
+		TraceID:             traceIDFromSpanContext(trace.SpanContextFromContext(ctx)),
+		Backend:             a.Name(),
+		RunDir:              runDir,
+		ImageRef:            instance.ImageRef,
+		ImageDigest:         instance.ImageDigest,
+		PlanPath:            instance.ConfigPath,
+		RootFSMinimumBytes:  instance.FirecrackerConfig.MinimumRootFSBytes,
+		RootFSMinimumSource: backend.EffectiveRootFSMinimumSource(instance.FirecrackerConfig),
 	}
 	applyDarwinVZNetworkMetadata(&observation, instance.NetworkMetadata)
 	launchObservabilityRecorded := false
@@ -1059,11 +1080,13 @@ func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream 
 		return nil, fmt.Errorf("create run directory: %w", err)
 	}
 	observation := darwinVZRunObservation{
-		ExecutionID: req.ExecutionID,
-		Backend:     a.Name(),
-		RunDir:      runDir,
-		ImageRef:    req.Policy.ImageRef,
-		ImageDigest: req.Policy.ImageDigest,
+		ExecutionID:         req.ExecutionID,
+		Backend:             a.Name(),
+		RunDir:              runDir,
+		ImageRef:            req.Policy.ImageRef,
+		ImageDigest:         req.Policy.ImageDigest,
+		RootFSMinimumBytes:  req.MinimumRootFSBytes,
+		RootFSMinimumSource: backend.EffectiveRootFSMinimumSource(req.FirecrackerConfig),
 	}
 	defer func() {
 		if err != nil && strings.TrimSpace(observation.Error) == "" {
@@ -1696,11 +1719,13 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 		Network:        startedVM.NetworkMetadata,
 	}
 	a.recordLaunchPhaseObservability(ctx, darwinVZRunObservation{
-		Backend:        a.Name(),
-		LaunchedVM:     true,
-		RootFSCopyMS:   launchObservability.RootFSCopyMS,
-		VMReadyMS:      launchObservability.HelperTimingMS["vm_ready"],
-		HelperTimingMS: launchObservability.HelperTimingMS,
+		Backend:             a.Name(),
+		LaunchedVM:          true,
+		RootFSMinimumBytes:  cfg.MinimumRootFSBytes,
+		RootFSMinimumSource: backend.EffectiveRootFSMinimumSource(cfg),
+		RootFSCopyMS:        launchObservability.RootFSCopyMS,
+		VMReadyMS:           launchObservability.HelperTimingMS["vm_ready"],
+		HelperTimingMS:      launchObservability.HelperTimingMS,
 	})
 	launchObservability.Recorded = true
 	instance.LaunchObservability = launchObservability
@@ -2230,7 +2255,7 @@ func (a *Adapter) resolveRootFSPath(ctx context.Context, req backend.ExecutionRe
 	if ensurePrepared == nil {
 		ensurePrepared = a.ensurePreparedRuntimeRootFSFromImage
 	}
-	prepared, err := ensurePrepared(ctx, ref, req.MinimumRootFSBytes)
+	prepared, err := ensurePrepared(ctx, ref)
 	if err != nil {
 		return "", "", "", "", err
 	}
@@ -2275,14 +2300,14 @@ func (a *Adapter) RuntimeBaseKey(ctx context.Context, compiled *policy.CompiledP
 		return "", err
 	}
 
-	preparedPath, err := preparedRuntimeRootFSPath(imageDigest, guestAgentHash, cfg.MinimumRootFSBytes)
+	preparedPath, err := preparedRuntimeRootFSPath(imageDigest, guestAgentHash)
 	if err != nil {
 		return "", err
 	}
 	return "prepared-rootfs:" + preparedPath, nil
 }
 
-func (a *Adapter) ensurePreparedRuntimeRootFSFromImage(ctx context.Context, imageRef string, minimumBytes int64) (preparedRootFS, error) {
+func (a *Adapter) ensurePreparedRuntimeRootFSFromImage(ctx context.Context, imageRef string) (preparedRootFS, error) {
 	artifact, err := a.ensureImageArtifact(ctx, imageRef)
 	if err != nil {
 		return preparedRootFS{}, err
@@ -2299,12 +2324,12 @@ func (a *Adapter) ensurePreparedRuntimeRootFSFromImage(ctx context.Context, imag
 		return preparedRootFS{}, err
 	}
 
-	preparedPath, err := preparedRuntimeRootFSPath(artifact.Digest, guestAgentHash, minimumBytes)
+	preparedPath, err := preparedRuntimeRootFSPath(artifact.Digest, guestAgentHash)
 	if err != nil {
 		return preparedRootFS{}, err
 	}
 	if _, err := os.Stat(preparedPath); err == nil {
-		if preparedRuntimeRootFSCacheHitIsValid(preparedPath, minimumBytes) {
+		if preparedRuntimeRootFSCacheHitIsValid(preparedPath) {
 			return preparedRootFS{
 				Ref:    artifact.Ref,
 				Digest: artifact.Digest,
@@ -2323,7 +2348,7 @@ func (a *Adapter) ensurePreparedRuntimeRootFSFromImage(ctx context.Context, imag
 	defer a.runtimeImageMu.Unlock()
 
 	if _, err := os.Stat(preparedPath); err == nil {
-		if preparedRuntimeRootFSCacheHitIsValid(preparedPath, minimumBytes) {
+		if preparedRuntimeRootFSCacheHitIsValid(preparedPath) {
 			return preparedRootFS{
 				Ref:    artifact.Ref,
 				Digest: artifact.Digest,
@@ -2352,10 +2377,6 @@ func (a *Adapter) ensurePreparedRuntimeRootFSFromImage(ctx context.Context, imag
 		_ = os.Remove(tmpPath)
 		return preparedRootFS{}, err
 	}
-	if err := ensurePreparedRuntimeRootFSMinimumSize(ctx, tmpPath, minimumBytes); err != nil {
-		_ = os.Remove(tmpPath)
-		return preparedRootFS{}, fmt.Errorf("resize prepared runtime rootfs %q: %w", tmpPath, err)
-	}
 	if err := validatePreparedRuntimeRootFS(tmpPath); err != nil {
 		_ = os.Remove(tmpPath)
 		return preparedRootFS{}, fmt.Errorf("validate prepared runtime rootfs %q: %w", tmpPath, err)
@@ -2363,7 +2384,7 @@ func (a *Adapter) ensurePreparedRuntimeRootFSFromImage(ctx context.Context, imag
 	if err := os.Rename(tmpPath, preparedPath); err != nil {
 		_ = os.Remove(tmpPath)
 		if _, statErr := os.Stat(preparedPath); statErr == nil {
-			if preparedRuntimeRootFSCacheHitIsValid(preparedPath, minimumBytes) {
+			if preparedRuntimeRootFSCacheHitIsValid(preparedPath) {
 				_ = writePreparedRuntimeRootFSMarker(preparedPath)
 				return preparedRootFS{
 					Ref:    artifact.Ref,
@@ -2391,8 +2412,7 @@ var preparedRuntimeRootFSRequiredPaths = []string{
 }
 
 var (
-	validatePreparedRuntimeRootFSFn        = validatePreparedRuntimeRootFS
-	ensurePreparedRuntimeRootFSMinimumSize = ext4image.EnsureMinimumSize
+	validatePreparedRuntimeRootFSFn = validatePreparedRuntimeRootFS
 )
 
 func validatePreparedRuntimeRootFS(path string) error {
@@ -2412,10 +2432,7 @@ type preparedRuntimeRootFSMarkerState struct {
 	changeTimeNanos int64
 }
 
-func preparedRuntimeRootFSCacheHitIsValid(path string, minimumBytes int64) bool {
-	if !preparedRuntimeRootFSMeetsMinimum(path, minimumBytes) {
-		return false
-	}
+func preparedRuntimeRootFSCacheHitIsValid(path string) bool {
 	if preparedRuntimeRootFSMarkerMatches(path) {
 		return true
 	}
@@ -2424,17 +2441,6 @@ func preparedRuntimeRootFSCacheHitIsValid(path string, minimumBytes int64) bool 
 	}
 	_ = writePreparedRuntimeRootFSMarker(path)
 	return true
-}
-
-func preparedRuntimeRootFSMeetsMinimum(path string, minimumBytes int64) bool {
-	if minimumBytes <= 0 {
-		return true
-	}
-	currentBytes, _, err := ext4image.PathSizeBytes(path)
-	if err != nil {
-		return false
-	}
-	return currentBytes >= minimumBytes
 }
 
 func preparedRuntimeRootFSMarkerPath(path string) string {
@@ -2504,17 +2510,17 @@ func writePreparedRuntimeRootFSMarker(path string) error {
 	return nil
 }
 
-func preparedRuntimeRootFSPath(imageDigest, guestAgentHash string, minimumBytes int64) (string, error) {
+func preparedRuntimeRootFSPath(imageDigest, guestAgentHash string) (string, error) {
 	cacheBase, err := paths.CacheBaseDir()
 	if err != nil {
 		return "", fmt.Errorf("resolve cache base directory: %w", err)
 	}
-	key := runtimeRootFSCacheKey(imageDigest, guestAgentHash, minimumBytes)
+	key := runtimeRootFSCacheKey(imageDigest, guestAgentHash)
 	return filepath.Join(cacheBase, "darwin-vz", "runtime-rootfs", key+".ext4"), nil
 }
 
-func runtimeRootFSCacheKey(imageDigest, guestAgentHash string, minimumBytes int64) string {
-	keyMaterial := strings.TrimSpace(imageDigest) + "|" + guestAgentHash + "|" + runtime.GOARCH + "|" + preparedRuntimeRootFSVersion + "|" + guestRuntimeInitVersion + rootFSMinimumCacheKeySuffix(minimumBytes)
+func runtimeRootFSCacheKey(imageDigest, guestAgentHash string) string {
+	keyMaterial := strings.TrimSpace(imageDigest) + "|" + guestAgentHash + "|" + runtime.GOARCH + "|" + preparedRuntimeRootFSVersion + "|" + guestRuntimeInitVersion
 	sum := sha256.Sum256([]byte(keyMaterial))
 	return hex.EncodeToString(sum[:])
 }

--- a/internal/backend/darwinvz/observability_test.go
+++ b/internal/backend/darwinvz/observability_test.go
@@ -45,12 +45,14 @@ func TestWriteDarwinVZRunObservationIncludesHelperTimings(t *testing.T) {
 	helperTimingMS[darwinVZTimingRootFSInspectValidate] = 14
 
 	obs := darwinVZRunObservation{
-		ExecutionID:    "run-123",
-		Backend:        "darwin-vz",
-		LaunchedVM:     true,
-		RunDir:         runDir,
-		RootFSCopyMS:   27,
-		HelperTimingMS: helperTimingMS,
+		ExecutionID:         "run-123",
+		Backend:             "darwin-vz",
+		LaunchedVM:          true,
+		RunDir:              runDir,
+		RootFSMinimumBytes:  16 << 30,
+		RootFSMinimumSource: backend.RootFSMinimumSourceDockerRepositoryBootstrap,
+		RootFSCopyMS:        27,
+		HelperTimingMS:      helperTimingMS,
 	}
 	applyDarwinVZHelperTimings(&obs, obs.HelperTimingMS)
 
@@ -75,6 +77,12 @@ func TestWriteDarwinVZRunObservationIncludesHelperTimings(t *testing.T) {
 	}
 	if got, want := payload["rootfs_copy_ms"], float64(27); got != want {
 		t.Fatalf("unexpected rootfs_copy_ms: got %v want %v", got, want)
+	}
+	if got, want := payload["rootfs_minimum_bytes"], float64(16<<30); got != want {
+		t.Fatalf("unexpected rootfs_minimum_bytes: got %v want %v", got, want)
+	}
+	if got, want := payload["rootfs_minimum_source"], backend.RootFSMinimumSourceDockerRepositoryBootstrap; got != want {
+		t.Fatalf("unexpected rootfs_minimum_source: got %v want %v", got, want)
 	}
 	if got, want := payload["total_ms"], float64(1500); got != want {
 		t.Fatalf("unexpected total_ms: got %v want %v", got, want)
@@ -141,8 +149,10 @@ func TestRecordLaunchPhaseObservabilityAddsTraceEvents(t *testing.T) {
 	ctx, span := tracerProvider.Tracer("test").Start(context.Background(), "cleanroom.test")
 	adapter := &Adapter{}
 	adapter.recordLaunchPhaseObservability(ctx, darwinVZRunObservation{
-		RootFSCopyMS: 27,
-		VMReadyMS:    321,
+		RootFSCopyMS:        27,
+		VMReadyMS:           321,
+		RootFSMinimumBytes:  16 << 30,
+		RootFSMinimumSource: backend.RootFSMinimumSourceDockerRepositoryBootstrap,
 		HelperTimingMS: map[string]int64{
 			darwinVZTimingGuestExecReadyProbe: 401,
 			darwinVZTimingGuestAgentStartup:   35,
@@ -161,6 +171,12 @@ func TestRecordLaunchPhaseObservabilityAddsTraceEvents(t *testing.T) {
 	requireLaunchPhaseEvent(t, spans[0], darwinVZTimingGuestAgentStartup, "35")
 	requireNoLaunchPhaseEvent(t, spans[0], "helper_zero")
 	requireNoLaunchPhaseEvent(t, spans[0], "helper_"+darwinVZTimingGuestAgentStartup)
+	if got, want := spanAttributeValue(spans[0], observability.AttrRootFSMinimumBytes), fmt.Sprint(16<<30); got != want {
+		t.Fatalf("unexpected rootfs minimum bytes span attribute: got %q want %q", got, want)
+	}
+	if got, want := spanAttributeValue(spans[0], observability.AttrRootFSMinimumSource), backend.RootFSMinimumSourceDockerRepositoryBootstrap; got != want {
+		t.Fatalf("unexpected rootfs minimum source span attribute: got %q want %q", got, want)
+	}
 }
 
 func TestDarwinVZGuestBootTimingBootArgRequiresRecordingSpan(t *testing.T) {
@@ -331,6 +347,15 @@ func requireNoLaunchPhaseEvent(t *testing.T, span sdktrace.ReadOnlySpan, phase s
 
 func eventAttributeValue(event sdktrace.Event, key string) string {
 	for _, attr := range event.Attributes {
+		if string(attr.Key) == key {
+			return fmt.Sprint(attr.Value.AsInterface())
+		}
+	}
+	return ""
+}
+
+func spanAttributeValue(span sdktrace.ReadOnlySpan, key string) string {
+	for _, attr := range span.Attributes() {
 		if string(attr.Key) == key {
 			return fmt.Sprint(attr.Value.AsInterface())
 		}

--- a/internal/backend/darwinvz/rootfs_cache_marker_test.go
+++ b/internal/backend/darwinvz/rootfs_cache_marker_test.go
@@ -24,7 +24,7 @@ func TestPreparedRuntimeRootFSCacheHitUsesValidMarkerWithoutExt4Validation(t *te
 	})
 	defer restore()
 
-	if !preparedRuntimeRootFSCacheHitIsValid(rootFSPath, 0) {
+	if !preparedRuntimeRootFSCacheHitIsValid(rootFSPath) {
 		t.Fatal("expected prepared rootfs cache hit to be valid")
 	}
 	if validateCalls != 0 {
@@ -42,7 +42,7 @@ func TestPreparedRuntimeRootFSCacheHitValidatesAndMarksWhenMarkerMissing(t *test
 	})
 	defer restore()
 
-	if !preparedRuntimeRootFSCacheHitIsValid(rootFSPath, 0) {
+	if !preparedRuntimeRootFSCacheHitIsValid(rootFSPath) {
 		t.Fatal("expected prepared rootfs cache hit to be valid after validation")
 	}
 	if validateCalls != 1 {
@@ -52,7 +52,7 @@ func TestPreparedRuntimeRootFSCacheHitValidatesAndMarksWhenMarkerMissing(t *test
 		t.Fatalf("expected prepared rootfs marker to be written: %v", err)
 	}
 
-	if !preparedRuntimeRootFSCacheHitIsValid(rootFSPath, 0) {
+	if !preparedRuntimeRootFSCacheHitIsValid(rootFSPath) {
 		t.Fatal("expected marked prepared rootfs cache hit to remain valid")
 	}
 	if validateCalls != 1 {
@@ -76,7 +76,7 @@ func TestPreparedRuntimeRootFSCacheHitRevalidatesStaleMarker(t *testing.T) {
 	})
 	defer restore()
 
-	if !preparedRuntimeRootFSCacheHitIsValid(rootFSPath, 0) {
+	if !preparedRuntimeRootFSCacheHitIsValid(rootFSPath) {
 		t.Fatal("expected stale marker to be refreshed after validation")
 	}
 	if validateCalls != 1 {
@@ -110,7 +110,7 @@ func TestPreparedRuntimeRootFSCacheHitRevalidatesWhenContentsChangeWithPreserved
 	})
 	defer restore()
 
-	if !preparedRuntimeRootFSCacheHitIsValid(rootFSPath, 0) {
+	if !preparedRuntimeRootFSCacheHitIsValid(rootFSPath) {
 		t.Fatal("expected marker with changed contents to be refreshed after validation")
 	}
 	if validateCalls != 1 {
@@ -162,7 +162,7 @@ func TestPreparedRuntimeRootFSCacheHitRejectsInvalidPreparedRootFS(t *testing.T)
 	})
 	defer restore()
 
-	if preparedRuntimeRootFSCacheHitIsValid(rootFSPath, 0) {
+	if preparedRuntimeRootFSCacheHitIsValid(rootFSPath) {
 		t.Fatal("expected invalid prepared rootfs cache hit to be rejected")
 	}
 	if validateCalls != 1 {
@@ -170,27 +170,6 @@ func TestPreparedRuntimeRootFSCacheHitRejectsInvalidPreparedRootFS(t *testing.T)
 	}
 	if _, err := os.Stat(preparedRuntimeRootFSMarkerPath(rootFSPath)); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("expected marker not to be written, got err=%v", err)
-	}
-}
-
-func TestPreparedRuntimeRootFSCacheHitRejectsRootFSBelowMinimum(t *testing.T) {
-	rootFSPath := writeTestPreparedRootFS(t, "prepared-rootfs")
-	if err := writePreparedRuntimeRootFSMarker(rootFSPath); err != nil {
-		t.Fatalf("write prepared rootfs marker: %v", err)
-	}
-
-	validateCalls := 0
-	restore := stubPreparedRuntimeRootFSValidator(t, func(string) error {
-		validateCalls++
-		return nil
-	})
-	defer restore()
-
-	if preparedRuntimeRootFSCacheHitIsValid(rootFSPath, 1<<20) {
-		t.Fatal("expected prepared rootfs below minimum to be rejected")
-	}
-	if validateCalls != 0 {
-		t.Fatalf("expected size check to reject before validation, got %d validation calls", validateCalls)
 	}
 }
 

--- a/internal/backend/darwinvz/rootfs_test.go
+++ b/internal/backend/darwinvz/rootfs_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/imagemgr"
 	"github.com/buildkite/cleanroom/internal/policy"
 )
 
@@ -53,12 +54,10 @@ func TestResolveRootFSPathDerivesFromPolicyImageRef(t *testing.T) {
 	t.Parallel()
 
 	adapter := New()
-	var gotMinimumBytes int64
-	adapter.ensurePreparedRootFSFn = func(_ context.Context, imageRef string, minimumBytes int64) (preparedRootFS, error) {
+	adapter.ensurePreparedRootFSFn = func(_ context.Context, imageRef string) (preparedRootFS, error) {
 		if got, want := imageRef, "ghcr.io/buildkite/cleanroom-base/alpine@sha256:def"; got != want {
 			t.Fatalf("unexpected image ref: got %q want %q", got, want)
 		}
-		gotMinimumBytes = minimumBytes
 		return preparedRootFS{
 			Ref:    imageRef,
 			Digest: "sha256:def",
@@ -92,9 +91,6 @@ func TestResolveRootFSPathDerivesFromPolicyImageRef(t *testing.T) {
 	if notice == "" {
 		t.Fatal("expected non-empty derivation notice")
 	}
-	if got, want := gotMinimumBytes, int64(9<<20); got != want {
-		t.Fatalf("unexpected minimum rootfs bytes: got %d want %d", got, want)
-	}
 }
 
 func TestResolveRootFSPathRequiresImageRefWhenRootFSUnset(t *testing.T) {
@@ -114,10 +110,7 @@ func TestResolveRootFSPathFallsBackWhenConfiguredRootFSMissing(t *testing.T) {
 	t.Parallel()
 
 	adapter := New()
-	adapter.ensurePreparedRootFSFn = func(_ context.Context, imageRef string, minimumBytes int64) (preparedRootFS, error) {
-		if minimumBytes != 0 {
-			t.Fatalf("unexpected minimum rootfs bytes: got %d want 0", minimumBytes)
-		}
+	adapter.ensurePreparedRootFSFn = func(_ context.Context, imageRef string) (preparedRootFS, error) {
 		return preparedRootFS{
 			Ref:    imageRef,
 			Digest: "sha256:xyz",
@@ -150,18 +143,49 @@ func TestResolveRootFSPathFallsBackWhenConfiguredRootFSMissing(t *testing.T) {
 	}
 }
 
-func TestRuntimeRootFSCacheKeyIncludesAlignedMinimumRootFSBytes(t *testing.T) {
+func TestRuntimeBaseKeyForImageIgnoresWritableRootFSMinimum(t *testing.T) {
 	t.Parallel()
 
-	baseKey := runtimeRootFSCacheKey("sha256:def", "guest-agent", 0)
-	minimumKey := runtimeRootFSCacheKey("sha256:def", "guest-agent", (9<<20)+1)
-	alignedEquivalentKey := runtimeRootFSCacheKey("sha256:def", "guest-agent", 12<<20)
-
-	if baseKey == minimumKey {
-		t.Fatal("expected minimum rootfs bytes to change prepared rootfs cache key")
+	adapter := New()
+	adapter.newImageManager = func() (imageEnsurer, error) {
+		return stubImageEnsurer{result: imagemgr.EnsureResult{
+			Record: imagemgr.Record{
+				Digest:     "sha256:def",
+				Ref:        "ghcr.io/buildkite/cleanroom-base/alpine@sha256:def",
+				RootFSPath: "/tmp/prepared-image.ext4",
+			},
+			CacheHit: true,
+		}}, nil
 	}
-	if minimumKey != alignedEquivalentKey {
-		t.Fatalf("expected cache key to use aligned minimum size: got %q want %q", minimumKey, alignedEquivalentKey)
+	adapter.guestAgentOnce.Do(func() {
+		adapter.guestAgentPath = "/tmp/cleanroom-guest-agent-linux-arm64"
+		adapter.guestAgentHash = "guest-agent"
+	})
+
+	baseKey, err := adapter.RuntimeBaseKey(context.Background(), &policy.CompiledPolicy{
+		ImageRef: "ghcr.io/buildkite/cleanroom-base/alpine@sha256:def",
+	}, backend.FirecrackerConfig{})
+	if err != nil {
+		t.Fatalf("RuntimeBaseKey without minimum returned error: %v", err)
+	}
+	minimumKey, err := adapter.RuntimeBaseKey(context.Background(), &policy.CompiledPolicy{
+		ImageRef: "ghcr.io/buildkite/cleanroom-base/alpine@sha256:def",
+	}, backend.FirecrackerConfig{
+		MinimumRootFSBytes: 9 << 20,
+	})
+	if err != nil {
+		t.Fatalf("RuntimeBaseKey with minimum returned error: %v", err)
+	}
+
+	if baseKey != minimumKey {
+		t.Fatalf("expected image-derived runtime base key to ignore writable minimum: got %q want %q", minimumKey, baseKey)
+	}
+	wantPath, err := preparedRuntimeRootFSPath("sha256:def", "guest-agent")
+	if err != nil {
+		t.Fatalf("preparedRuntimeRootFSPath returned error: %v", err)
+	}
+	if got, want := baseKey, "prepared-rootfs:"+wantPath; got != want {
+		t.Fatalf("unexpected image-derived runtime base key: got %q want %q", got, want)
 	}
 }
 
@@ -201,4 +225,13 @@ func TestRuntimeBaseKeyIncludesConfiguredRootFSMinimumRootFSBytes(t *testing.T) 
 	if minimumKey != alignedEquivalentKey {
 		t.Fatalf("expected configured rootfs runtime base key to align minimum size: got %q want %q", minimumKey, alignedEquivalentKey)
 	}
+}
+
+type stubImageEnsurer struct {
+	result imagemgr.EnsureResult
+	err    error
+}
+
+func (s stubImageEnsurer) Ensure(context.Context, string) (imagemgr.EnsureResult, error) {
+	return s.result, s.err
 }

--- a/internal/backend/rootfs_minimum_test.go
+++ b/internal/backend/rootfs_minimum_test.go
@@ -1,0 +1,55 @@
+package backend
+
+import "testing"
+
+func TestEffectiveRootFSMinimumSource(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cfg  FirecrackerConfig
+		want string
+	}{
+		{
+			name: "unset when no floor",
+			cfg: FirecrackerConfig{
+				MinimumRootFSBytesSource: RootFSMinimumSourcePolicy,
+			},
+			want: RootFSMinimumSourceUnset,
+		},
+		{
+			name: "unknown when floor has no source",
+			cfg: FirecrackerConfig{
+				MinimumRootFSBytes: 8 << 30,
+			},
+			want: RootFSMinimumSourceUnknown,
+		},
+		{
+			name: "configured source",
+			cfg: FirecrackerConfig{
+				MinimumRootFSBytes:       8 << 30,
+				MinimumRootFSBytesSource: RootFSMinimumSourceConfig,
+			},
+			want: RootFSMinimumSourceConfig,
+		},
+		{
+			name: "trimmed source",
+			cfg: FirecrackerConfig{
+				MinimumRootFSBytes:       8 << 30,
+				MinimumRootFSBytesSource: " " + RootFSMinimumSourcePolicy + " ",
+			},
+			want: RootFSMinimumSourcePolicy,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := EffectiveRootFSMinimumSource(tt.cfg); got != tt.want {
+				t.Fatalf("EffectiveRootFSMinimumSource() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/cli/config_init_test.go
+++ b/internal/cli/config_init_test.go
@@ -84,8 +84,8 @@ func TestConfigInitWritesRuntimeConfig(t *testing.T) {
 		if got, want := cfg.Backends.DarwinVZ.MemoryMiB, int64(4096); got != want {
 			t.Fatalf("expected backends.darwin-vz.memory_mib=%d, got %d", want, got)
 		}
-		if got, want := int64(cfg.Backends.DarwinVZ.MinimumRootFSBytes), int64(4<<30); got != want {
-			t.Fatalf("expected backends.darwin-vz.minimum_rootfs_bytes=%d, got %d", want, got)
+		if got := int64(cfg.Backends.DarwinVZ.MinimumRootFSBytes); got != 0 {
+			t.Fatalf("expected backends.darwin-vz.minimum_rootfs_bytes to default unset, got %d", got)
 		}
 		if got, want := cfg.Backends.DarwinVZ.Services.Docker.StorageDriver, "overlay2"; got != want {
 			t.Fatalf("expected backends.darwin-vz.services.docker.storage_driver=%q, got %q", want, got)
@@ -93,10 +93,7 @@ func TestConfigInitWritesRuntimeConfig(t *testing.T) {
 		if !strings.Contains(string(raw), "memory_mib: 4096") {
 			t.Fatalf("expected generated config to include memory_mib: 4096, got:\n%s", raw)
 		}
-		if !strings.Contains(string(raw), "minimum_rootfs_bytes: 4GiB") {
-			t.Fatalf("expected generated config to include minimum_rootfs_bytes: 4GiB, got:\n%s", raw)
-		}
-		for _, forbidden := range []string{"kernel_image:", "rootfs:", "iptables:"} {
+		for _, forbidden := range []string{"kernel_image:", "rootfs:", "minimum_rootfs_bytes:", "iptables:"} {
 			if strings.Contains(string(raw), forbidden) {
 				t.Fatalf("expected generated config to omit zero-value field %q, got:\n%s", forbidden, raw)
 			}
@@ -204,8 +201,8 @@ func TestConfigInitDisablesDarwinVZSnapshotsWhenSupportUnavailable(t *testing.T)
 	if got, want := cfg.Backends.DarwinVZ.MemoryMiB, int64(4096); got != want {
 		t.Fatalf("expected backends.darwin-vz.memory_mib=%d, got %d", want, got)
 	}
-	if got, want := int64(cfg.Backends.DarwinVZ.MinimumRootFSBytes), int64(4<<30); got != want {
-		t.Fatalf("expected backends.darwin-vz.minimum_rootfs_bytes=%d, got %d", want, got)
+	if got := int64(cfg.Backends.DarwinVZ.MinimumRootFSBytes); got != 0 {
+		t.Fatalf("expected backends.darwin-vz.minimum_rootfs_bytes to default unset, got %d", got)
 	}
 	if out := readStderr(); !strings.Contains(out, "darwin-vz snapshots remain disabled: helper unavailable") {
 		t.Fatalf("expected darwin-vz snapshot warning, got %q", out)
@@ -213,10 +210,7 @@ func TestConfigInitDisablesDarwinVZSnapshotsWhenSupportUnavailable(t *testing.T)
 	if !strings.Contains(string(raw), "memory_mib: 4096") {
 		t.Fatalf("expected generated config to include memory_mib: 4096, got:\n%s", raw)
 	}
-	if !strings.Contains(string(raw), "minimum_rootfs_bytes: 4GiB") {
-		t.Fatalf("expected generated config to include minimum_rootfs_bytes: 4GiB, got:\n%s", raw)
-	}
-	for _, forbidden := range []string{"enabled: false", "kernel_image:", "rootfs:", "iptables:"} {
+	for _, forbidden := range []string{"enabled: false", "kernel_image:", "rootfs:", "minimum_rootfs_bytes:", "iptables:"} {
 		if strings.Contains(string(raw), forbidden) {
 			t.Fatalf("expected generated config to omit zero-value field %q, got:\n%s", forbidden, raw)
 		}

--- a/internal/cli/policy_config.go
+++ b/internal/cli/policy_config.go
@@ -285,9 +285,8 @@ func defaultRuntimeConfig(defaultBackend string, firecrackerSnapshots, darwinVZS
 	switch defaultBackend {
 	case "darwin-vz":
 		tpl.Backends.DarwinVZ = &runtimeConfigDarwinVZ{
-			KernelImage:        "",
-			RootFS:             "",
-			MinimumRootFSBytes: "4GiB",
+			KernelImage: "",
+			RootFS:      "",
 			Services: runtimeConfigServices{
 				Docker: runtimeConfigDockerService{
 					StartupTimeoutSeconds: 20,

--- a/internal/controlservice/resource_requirements.go
+++ b/internal/controlservice/resource_requirements.go
@@ -2,7 +2,9 @@ package controlservice
 
 import (
 	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/observability"
 	"github.com/buildkite/cleanroom/internal/policy"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 const mibBytes int64 = 1 << 20
@@ -36,8 +38,16 @@ func withPolicyResourceMinimums(cfg backend.FirecrackerConfig, resources *policy
 	}
 	if resources.DiskBytes > cfg.MinimumRootFSBytes {
 		cfg.MinimumRootFSBytes = resources.DiskBytes
+		cfg.MinimumRootFSBytesSource = backend.RootFSMinimumSourcePolicy
 	}
 	return cfg
+}
+
+func rootFSMinimumTraceAttributes(cfg backend.FirecrackerConfig) []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.Int64(observability.AttrRootFSMinimumBytes, cfg.MinimumRootFSBytes),
+		attribute.String(observability.AttrRootFSMinimumSource, backend.EffectiveRootFSMinimumSource(cfg)),
+	}
 }
 
 func bytesToMiBCeil(value int64) int64 {

--- a/internal/controlservice/resource_requirements_test.go
+++ b/internal/controlservice/resource_requirements_test.go
@@ -29,13 +29,17 @@ func TestWithPolicyResourceMinimumsRaisesLowerRuntimeConfig(t *testing.T) {
 	if got.MinimumRootFSBytes != 16<<30 {
 		t.Fatalf("unexpected minimum_rootfs_bytes: got %d want %d", got.MinimumRootFSBytes, int64(16<<30))
 	}
+	if got, want := got.MinimumRootFSBytesSource, backend.RootFSMinimumSourcePolicy; got != want {
+		t.Fatalf("unexpected minimum_rootfs_bytes source: got %q want %q", got, want)
+	}
 }
 
 func TestWithPolicyResourceMinimumsPreservesHigherRuntimeConfig(t *testing.T) {
 	cfg := backend.FirecrackerConfig{
-		VCPUs:              8,
-		MemoryMiB:          8192,
-		MinimumRootFSBytes: 64 << 30,
+		VCPUs:                    8,
+		MemoryMiB:                8192,
+		MinimumRootFSBytes:       64 << 30,
+		MinimumRootFSBytesSource: backend.RootFSMinimumSourceConfig,
 	}
 
 	got := withPolicyResourceMinimums(cfg, &policy.Resources{
@@ -52,6 +56,9 @@ func TestWithPolicyResourceMinimumsPreservesHigherRuntimeConfig(t *testing.T) {
 	}
 	if got.MinimumRootFSBytes != cfg.MinimumRootFSBytes {
 		t.Fatalf("minimum_rootfs_bytes should preserve higher runtime ceiling: got %d want %d", got.MinimumRootFSBytes, cfg.MinimumRootFSBytes)
+	}
+	if got.MinimumRootFSBytesSource != cfg.MinimumRootFSBytesSource {
+		t.Fatalf("minimum_rootfs_bytes source should preserve higher runtime ceiling: got %q want %q", got.MinimumRootFSBytesSource, cfg.MinimumRootFSBytesSource)
 	}
 }
 

--- a/internal/controlservice/rootfs_sizing.go
+++ b/internal/controlservice/rootfs_sizing.go
@@ -21,11 +21,14 @@ func withRepositoryBootstrapRootFSMinimum(
 	}
 
 	minimumBytes := repositoryBootstrapMinimumRootFSBytes
+	minimumSource := backend.RootFSMinimumSourceRepositoryBootstrap
 	if compiled != nil && compiled.Docker.Required {
 		minimumBytes = repositoryBootstrapDockerMinimumRootFSBytes
+		minimumSource = backend.RootFSMinimumSourceDockerRepositoryBootstrap
 	}
 	if cfg.MinimumRootFSBytes < minimumBytes {
 		cfg.MinimumRootFSBytes = minimumBytes
+		cfg.MinimumRootFSBytesSource = minimumSource
 	}
 	return cfg
 }

--- a/internal/controlservice/rootfs_sizing_test.go
+++ b/internal/controlservice/rootfs_sizing_test.go
@@ -1,0 +1,44 @@
+package controlservice
+
+import (
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/buildkite/cleanroom/internal/repositorycheckout"
+)
+
+func TestWithRepositoryBootstrapRootFSMinimumSetsSource(t *testing.T) {
+	got := withRepositoryBootstrapRootFSMinimum(
+		backend.FirecrackerConfig{},
+		&policy.CompiledPolicy{},
+		&repositorycheckout.Checkout{},
+	)
+
+	if got.MinimumRootFSBytes != repositoryBootstrapMinimumRootFSBytes {
+		t.Fatalf("unexpected minimum_rootfs_bytes: got %d want %d", got.MinimumRootFSBytes, repositoryBootstrapMinimumRootFSBytes)
+	}
+	if got.MinimumRootFSBytesSource != backend.RootFSMinimumSourceRepositoryBootstrap {
+		t.Fatalf("unexpected minimum_rootfs_bytes source: got %q want %q", got.MinimumRootFSBytesSource, backend.RootFSMinimumSourceRepositoryBootstrap)
+	}
+}
+
+func TestWithRepositoryBootstrapRootFSMinimumPreservesHigherConfigSource(t *testing.T) {
+	cfg := backend.FirecrackerConfig{
+		MinimumRootFSBytes:       64 << 30,
+		MinimumRootFSBytesSource: backend.RootFSMinimumSourceConfig,
+	}
+
+	got := withRepositoryBootstrapRootFSMinimum(
+		cfg,
+		&policy.CompiledPolicy{Docker: policy.DockerService{Required: true}},
+		&repositorycheckout.Checkout{},
+	)
+
+	if got.MinimumRootFSBytes != cfg.MinimumRootFSBytes {
+		t.Fatalf("minimum_rootfs_bytes should preserve higher runtime ceiling: got %d want %d", got.MinimumRootFSBytes, cfg.MinimumRootFSBytes)
+	}
+	if got.MinimumRootFSBytesSource != cfg.MinimumRootFSBytesSource {
+		t.Fatalf("minimum_rootfs_bytes source should preserve higher runtime ceiling: got %q want %q", got.MinimumRootFSBytesSource, cfg.MinimumRootFSBytesSource)
+	}
+}

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -486,6 +486,7 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 	firecrackerCfg = withPolicyResourceMinimums(firecrackerCfg, compiled.Resources)
 	firecrackerCfg = withBackendLaunchResourceDefaults(firecrackerCfg)
 	firecrackerCfg = withRepositoryBootstrapRootFSMinimum(firecrackerCfg, compiled, repository)
+	span.SetAttributes(rootFSMinimumTraceAttributes(firecrackerCfg)...)
 
 	var replacedWorkspaceStageRecord *cachestore.Record
 	var replacedDependencyStageRecord *cachestore.Record

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -7276,6 +7276,9 @@ func TestCreateSandboxSetsRepositoryBootstrapRootFSMinimum(t *testing.T) {
 	if got, want := adapter.provisionReq.FirecrackerConfig.MinimumRootFSBytes, repositoryBootstrapDockerMinimumRootFSBytes; got != want {
 		t.Fatalf("unexpected minimum_rootfs_bytes: got %d want %d", got, want)
 	}
+	if got, want := adapter.provisionReq.FirecrackerConfig.MinimumRootFSBytesSource, backend.RootFSMinimumSourceDockerRepositoryBootstrap; got != want {
+		t.Fatalf("unexpected minimum_rootfs_bytes source: got %q want %q", got, want)
+	}
 }
 
 func TestCreateExecutionRejectsWhenSandboxBusy(t *testing.T) {

--- a/internal/controlservice/stored_rootfs.go
+++ b/internal/controlservice/stored_rootfs.go
@@ -14,6 +14,7 @@ import (
 	"github.com/buildkite/cleanroom/internal/runtimeconfig"
 	"github.com/buildkite/cleanroom/internal/snapshotstore"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 type storedRootFSRecord struct {
@@ -113,6 +114,8 @@ func (s *Service) createSandboxFromStoredRootFS(ctx context.Context, req *cleanr
 	firecrackerCfg = withPolicyResourceMinimums(firecrackerCfg, effectivePolicy.Resources)
 	firecrackerCfg = withBackendLaunchResourceDefaults(firecrackerCfg)
 	firecrackerCfg = withSnapshotDriver(backendName, firecrackerCfg, record.StorageDriver)
+	rootFSAttrs := rootFSMinimumTraceAttributes(firecrackerCfg)
+	trace.SpanFromContext(ctx).SetAttributes(rootFSAttrs...)
 
 	now := s.clock().Now()
 	sandboxID := s.ids().NewSandboxID()
@@ -163,11 +166,12 @@ func (s *Service) createSandboxFromStoredRootFS(ctx context.Context, req *cleanr
 	s.ensureMapsLocked()
 	s.sandboxes[sandboxID] = state
 	s.mu.Unlock()
-	if err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.restore_snapshot", []attribute.KeyValue{
+	restoreAttrs := append([]attribute.KeyValue{
 		attribute.String(observability.AttrBackend, backendName),
 		attribute.String(observability.AttrSandboxID, sandboxID),
 		attribute.String("cleanroom.source_kind", sourceKind),
-	}, func(ctx context.Context) error {
+	}, rootFSAttrs...)
+	if err := s.traceCreateSandboxPhase(ctx, "cleanroom.sandbox.restore_snapshot", restoreAttrs, func(ctx context.Context) error {
 		return snapshotAdapter.ProvisionSandboxFromSnapshot(ctx, backend.ProvisionFromSnapshotRequest{
 			SandboxID:          sandboxID,
 			SnapshotID:         provisionSnapshotID,

--- a/internal/observability/contract.go
+++ b/internal/observability/contract.go
@@ -88,6 +88,8 @@ const (
 	AttrVMLaunched             = "cleanroom.vm.launched"
 	AttrLaunchPhase            = "cleanroom.launch.phase"
 	AttrLaunchPhaseDurationMS  = "cleanroom.launch.phase.duration_ms"
+	AttrRootFSMinimumBytes     = "cleanroom.rootfs.minimum_bytes"
+	AttrRootFSMinimumSource    = "cleanroom.rootfs.minimum_source"
 	AttrExitCode               = "cleanroom.exit_code"
 
 	LogFieldTraceID     = "trace_id"

--- a/internal/runtimeconfig/config.go
+++ b/internal/runtimeconfig/config.go
@@ -215,6 +215,9 @@ func MergeBackendConfig(cfg Config, backendName string, launchSeconds int64) bac
 		out.KernelImagePath = cfg.Backends.DarwinVZ.KernelImage
 		out.RootFSPath = cfg.Backends.DarwinVZ.RootFS
 		out.MinimumRootFSBytes = int64(cfg.Backends.DarwinVZ.MinimumRootFSBytes)
+		if out.MinimumRootFSBytes > 0 {
+			out.MinimumRootFSBytesSource = backend.RootFSMinimumSourceConfig
+		}
 		out.DarwinVZNetworkMode = cfg.Backends.DarwinVZ.Network.Mode
 		out.DarwinVZNetworkSubnet = cfg.Backends.DarwinVZ.Network.Subnet
 		out.DarwinVZNetworkExternalInterface = cfg.Backends.DarwinVZ.Network.ExternalInterface

--- a/internal/runtimeconfig/config_test.go
+++ b/internal/runtimeconfig/config_test.go
@@ -1577,6 +1577,9 @@ func TestMergeBackendConfig(t *testing.T) {
 	if got, want := darwinCfg.MinimumRootFSBytes, int64(2147483648); got != want {
 		t.Fatalf("unexpected darwin-vz minimum rootfs bytes: got %d want %d", got, want)
 	}
+	if got, want := darwinCfg.MinimumRootFSBytesSource, backend.RootFSMinimumSourceConfig; got != want {
+		t.Fatalf("unexpected darwin-vz minimum rootfs bytes source: got %q want %q", got, want)
+	}
 	if got, want := darwinCfg.DarwinVZNetworkMode, "filehandle"; got != want {
 		t.Fatalf("unexpected darwin-vz network mode: got %q want %q", got, want)
 	}


### PR DESCRIPTION
Image-backed `darwin-vz` sandbox creation was treating writable disk floors as part of prepared runtime rootfs identity. That made a config or policy floor expensive in the wrong layer: the shared image-derived rootfs could be resized and keyed separately even though the requested disk capacity only needs to apply to the writable sandbox clone.

This change keeps the image-derived prepared runtime rootfs keyed by image digest, guest agent hash, host architecture, and runtime versions. The writable rootfs still gets resized after the clone or snapshot-backed attach is created, so `minimum_rootfs_bytes`, `sandbox.resources.disk`, and repository bootstrap floors continue to apply where guest writes actually happen.

It also removes the generated `darwin-vz` `minimum_rootfs_bytes` default from `cleanroom config init`, adds low-cardinality rootfs minimum source attribution for config, policy, repository bootstrap, and Docker repository bootstrap, and documents the storage model in `docs/storage.md` with links from the existing backend, caching, operations, observability, and spec docs.

Validation:

```bash
mise trust
mise exec -- gofmt -w internal/backend/rootfs_minimum_test.go internal/controlservice/rootfs_sizing_test.go internal/backend/backend.go internal/backend/darwinvz/backend_darwin.go internal/backend/darwinvz/observability_test.go internal/backend/darwinvz/rootfs_cache_marker_test.go internal/backend/darwinvz/rootfs_test.go internal/cli/config_init_test.go internal/cli/policy_config.go internal/controlservice/resource_requirements.go internal/controlservice/resource_requirements_test.go internal/controlservice/rootfs_sizing.go internal/controlservice/service.go internal/controlservice/service_test.go internal/controlservice/stored_rootfs.go internal/observability/contract.go internal/runtimeconfig/config.go internal/runtimeconfig/config_test.go
git diff --check
mise exec -- go test ./internal/backend
mise exec -- go test ./...
```

I also moved the diff onto a clean branch from `origin/main` before committing so the unrelated image changes from `lox/add-pi-agent-images` are not part of this PR.