### PR TITLE
ci: Add Renovate agent image updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update pinned agent CLI versions in base image Dockerfiles",
+      "managerFilePatterns": [
+        "/^images\\/Dockerfile\\.base-image(?:-debian)?-agents$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>\\S+)(?: versioning=(?<versioning>\\S+))?\\s+ARG [A-Z0-9_]+_VERSION=(?<currentValue>\\S+)"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+    }
+  ]
+}

--- a/images/Dockerfile.base-image-agents
+++ b/images/Dockerfile.base-image-agents
@@ -1,9 +1,13 @@
 FROM alpine:3.22
 
 ARG MISE_VERSION=v2026.4.5
+# renovate: datasource=npm depName=@openai/codex
 ARG CODEX_VERSION=0.106.0
+# renovate: datasource=npm depName=@anthropic-ai/claude-code
 ARG CLAUDE_CODE_VERSION=2.1.63
+# renovate: datasource=npm depName=@google/gemini-cli
 ARG GEMINI_CLI_VERSION=0.31.0
+# renovate: datasource=npm depName=@mariozechner/pi-coding-agent
 ARG PI_CODING_AGENT_VERSION=0.52.9
 
 # `gemini` currently needs native build deps on Alpine and GNU `env` for `env -S`.

--- a/images/Dockerfile.base-image-debian-agents
+++ b/images/Dockerfile.base-image-debian-agents
@@ -1,9 +1,13 @@
 FROM node:22-bookworm-slim
 
 ARG MISE_VERSION=v2026.4.5
+# renovate: datasource=npm depName=@openai/codex
 ARG CODEX_VERSION=0.106.0
+# renovate: datasource=npm depName=@anthropic-ai/claude-code
 ARG CLAUDE_CODE_VERSION=2.1.63
+# renovate: datasource=npm depName=@google/gemini-cli
 ARG GEMINI_CLI_VERSION=0.31.0
+# renovate: datasource=npm depName=@mariozechner/pi-coding-agent
 ARG PI_CODING_AGENT_VERSION=0.52.9
 
 RUN apt-get update \

--- a/images/dockerfiles_test.go
+++ b/images/dockerfiles_test.go
@@ -201,6 +201,39 @@ func TestPublishedBaseImagesInstallPinnedMiseRelease(t *testing.T) {
 	}
 }
 
+func TestAgentBaseImagesAnnotatePinnedAgentCLIsForRenovate(t *testing.T) {
+	t.Parallel()
+
+	wantAnnotations := map[string]string{
+		"CODEX_VERSION":           "# renovate: datasource=npm depName=@openai/codex",
+		"CLAUDE_CODE_VERSION":     "# renovate: datasource=npm depName=@anthropic-ai/claude-code",
+		"GEMINI_CLI_VERSION":      "# renovate: datasource=npm depName=@google/gemini-cli",
+		"PI_CODING_AGENT_VERSION": "# renovate: datasource=npm depName=@mariozechner/pi-coding-agent",
+	}
+
+	for _, relPath := range []string{
+		"Dockerfile.base-image-agents",
+		"Dockerfile.base-image-debian-agents",
+	} {
+		relPath := relPath
+		t.Run(relPath, func(t *testing.T) {
+			t.Parallel()
+
+			raw, err := os.ReadFile(filepath.Join(".", relPath))
+			if err != nil {
+				t.Fatalf("read %s: %v", relPath, err)
+			}
+
+			dockerfile := string(raw)
+			for argName, annotation := range wantAnnotations {
+				if !strings.Contains(dockerfile, annotation+"\nARG "+argName+"=") {
+					t.Fatalf("%s does not annotate %s for Renovate", relPath, argName)
+				}
+			}
+		})
+	}
+}
+
 func TestPublishedBaseImagesExposeMiseShimsOnPATH(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Agent base images pin several CLI versions in Dockerfile `ARG` values, but Renovate does not infer those custom version variables. That leaves Codex, Claude Code, Gemini CLI, and Pi Coding Agent bumps as manual image maintenance even after Renovate is enabled for the repository.

This adds a Renovate regex custom manager scoped to the two agent base image Dockerfiles:

- `images/Dockerfile.base-image-agents`
- `images/Dockerfile.base-image-debian-agents`

Each pinned agent CLI arg now carries package metadata, for example:

```dockerfile
# renovate: datasource=npm depName=@openai/codex
ARG CODEX_VERSION=0.106.0
```

Renovate can now detect and propose npm version bumps for:

- `@openai/codex`
- `@anthropic-ai/claude-code`
- `@google/gemini-cli`
- `@mariozechner/pi-coding-agent`

I also added a Dockerfile regression test so future agent CLI version args do not silently lose Renovate annotations.

Validation:

- `MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/b8c6/cleanroom mise exec -- go test ./images`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/b8c6/cleanroom mise x node@24.11.1 -- npm exec --yes --package=renovate@43.150.0 -- renovate-config-validator .github/renovate.json`
- `RENOVATE_CONFIG_FILE=.github/renovate.json MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/b8c6/cleanroom mise x node@24.11.1 -- npm exec --yes --package=renovate@43.150.0 -- renovate --platform=local --dry-run=full --require-config=required`
  - The dry run reported `regex` extraction across 2 files and 8 dependencies.
- `git diff --check`
