### PR TITLE
ci: Enable Renovate automerge for safe updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "platformAutomerge": true,
   "customManagers": [
     {
       "customType": "regex",
@@ -11,6 +12,19 @@
         "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>\\S+)(?: versioning=(?<versioning>\\S+))?\\s+ARG [A-Z0-9_]+_VERSION=(?<currentValue>\\S+)"
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Automerge non-major dependency updates after required checks pass",
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "digest"
+      ],
+      "automerge": true,
+      "automergeType": "pr"
     }
   ]
 }


### PR DESCRIPTION
Renovate is now enabled for Cleanroom and the `renovate-approve` GitHub app has repository access, but the repo config still leaves every dependency PR as a manual merge. That means low-risk patch, minor, pin, and digest updates still require human merge clicks even after CI and approval requirements are satisfied.

This enables Renovate automerge for non-major dependency updates only:

- minor updates
- patch updates
- pin updates
- digest updates

Major updates remain manual.

The rule uses PR-based automerge with GitHub platform automerge, so GitHub still enforces the repository ruleset before merging. I checked the current repo settings and ruleset while preparing this:

- GitHub `allow_auto_merge` is enabled.
- The default branch ruleset requires the `buildkite/cleanroom` status check.
- The default branch ruleset allows squash merges only.
- CODEOWNERS is limited to a few scripts and `.github/CODEOWNERS`, so the current Renovate updates in `images/` and `go.mod`/`go.sum` are not code-owner-owned paths.

Validation:

- `MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/b8c6/cleanroom mise x node@24.11.1 -- npm exec --yes --package=renovate@43.150.0 -- renovate-config-validator .github/renovate.json`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/b8c6/cleanroom mise x node@24.11.1 -- npm exec --yes --package=renovate@43.150.0 -- renovate --platform=local --dry-run=full --require-config=required`
  - The dry run reported `regex` extraction across 2 files and 8 dependencies.
- `git diff --check`
