### PR TITLE
ci: Publish darwin-vz kernel release assets

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@ steps:
   - label: ":shell: Shellcheck"
     plugins:
       - github.com/lox/mise-buildkite-plugin#a172963b3d34e98601e2a65c7dd08211fb49b7f0:
-    command: shellcheck -x scripts/base-image-tag.sh scripts/cleanroom-root-helper.sh scripts/benchmark-tti.sh scripts/build-go.sh scripts/install-go.sh scripts/install.sh scripts/install-global.sh scripts/package-darwin-vz-helper.sh scripts/release.sh scripts/e2e-observability.sh scripts/ci-example-smoke.sh scripts/ci-examples-firecracker.sh scripts/ci-examples-darwin-vz.sh scripts/ci-cleanroom-e2e.sh scripts/ci-darwin-vz-e2e.sh scripts/ci-darwin-vz-filehandle-e2e.sh scripts/build-macos-release-pkg.sh scripts/notarize-macos-package.sh scripts/ci-macos-release-pkg.sh scripts/ci-buildkite-release.sh
+    command: shellcheck -x scripts/base-image-tag.sh scripts/cleanroom-root-helper.sh scripts/benchmark-tti.sh scripts/build-go.sh scripts/install-go.sh scripts/install.sh scripts/install-global.sh scripts/package-darwin-vz-helper.sh scripts/release.sh scripts/e2e-observability.sh scripts/ci-example-smoke.sh scripts/ci-examples-firecracker.sh scripts/ci-examples-darwin-vz.sh scripts/ci-cleanroom-e2e.sh scripts/ci-darwin-vz-e2e.sh scripts/ci-darwin-vz-filehandle-e2e.sh scripts/build-macos-release-pkg.sh scripts/notarize-macos-package.sh scripts/ci-macos-release-pkg.sh scripts/build-darwin-vz-minimal-kernel-release.sh scripts/ci-darwin-vz-kernel-release.sh scripts/ci-buildkite-release.sh
     cache:
       paths:
         - "~/.local/share/mise"
@@ -72,6 +72,15 @@ steps:
       CLEANROOM_DARWIN_VZ_HELPER_SIGN_IDENTIFIER: com.buildkite.cleanroom.darwin-vz
     agents:
       queue: cleanroom-mac-signer
+
+  - label: ":penguin: darwin-vz kernel release assets"
+    key: darwin-vz-kernel-release-assets
+    if: build.tag != null
+    command: scripts/ci-darwin-vz-kernel-release.sh
+    concurrency: 1
+    concurrency_group: cleanroom-darwin-vz-kernel-release
+    agents:
+      queue: cleanroom
 
   - label: ":fire: E2E (Firecracker)"
     plugins:

--- a/docs/backend/darwin-vz.md
+++ b/docs/backend/darwin-vz.md
@@ -126,8 +126,29 @@ backends:
     kernel_image: /path/to/cleanroom/dist/darwin-vz-minimal-rootfs-arm64-kernel-6.1.155-Image
 ```
 
-Use `kernel_image` for local kernel experiments. The managed kernel fallback
-remains the default when `kernel_image` is empty or inaccessible.
+Use `kernel_image` for local kernel experiments. It always wins when the path is
+configured and accessible.
+
+Tagged releases also publish the rootfs-profile kernel as direct GitHub Release
+assets. The manifest is named with this pattern:
+
+```text
+cleanroom-darwin-vz-minimal-rootfs-arm64-linux-<linux-version>.manifest.json
+```
+
+The manifest names the matching `Image`, `.config`, and `.sha256` assets and
+contains the expected image digest.
+
+When `kernel_image` is not configured, `darwin-vz` resolves the managed kernel
+from GitHub Releases:
+
+- released Cleanroom builds use the matching Cleanroom release tag
+- dev, dirty, and non-release builds use the latest published Cleanroom release
+- if the release manifest is not available yet, Cleanroom falls back to the
+  older managed kernel asset
+
+To test an unreleased local kernel, build it locally and point `kernel_image` at
+the generated `Image`.
 
 Rootfs:
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -9,8 +9,17 @@ The public repo owns the pipeline definition and the product-facing CI scripts:
 - `scripts/ci-darwin-vz-e2e.sh`
 - `scripts/ci-darwin-vz-filehandle-e2e.sh`
 - `scripts/ci-macos-release-pkg.sh`
+- `scripts/ci-darwin-vz-kernel-release.sh`
 - `scripts/ci-buildkite-release.sh`
 - `images/`
+
+On tagged builds, `scripts/ci-darwin-vz-kernel-release.sh` builds the
+experimental Apple Silicon `darwin-vz` minimal rootfs-profile kernel and uploads
+it as Buildkite artifacts under `release-extra/kernels/`. The publish job then
+uploads those files as direct assets on the same GitHub Release as the Cleanroom
+archives and macOS packages. Runtime managed-kernel resolution reads the release
+manifest from the matching tag for released builds and from the latest published
+release for dev builds.
 
 Private CI infrastructure, bootstrap, and host recovery documentation now lives
 in the sibling repo `../cleanroom-ops`, especially `../cleanroom-ops/docs/ci.md`.

--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -81,6 +81,7 @@ type Adapter struct {
 	metricsErr       error
 
 	ConfiguredNetworkMode string
+	Version               string
 }
 
 type imageEnsurer interface {
@@ -919,17 +920,26 @@ func (a *Adapter) Doctor(_ context.Context, req backend.DoctorRequest) (*backend
 		}
 	}
 
-	if configured := strings.TrimSpace(req.KernelImagePath); configured == "" {
+	managedKernelMessage := func() (string, bool) {
+		if runtime.GOARCH == "arm64" {
+			return "kernel image will be auto-managed from Cleanroom GitHub Releases (matching tag for released builds, latest for dev builds)", true
+		}
 		if spec, ok := bootassets.LookupManagedKernelForHost(a.Name()); ok {
 			path, _ := bootassets.ManagedKernelPathForHost(a.Name())
-			appendCheck("kernel_image", "pass", fmt.Sprintf("kernel image will be auto-managed (%s -> %s)", spec.ID, path))
+			return fmt.Sprintf("kernel image will be auto-managed (%s -> %s)", spec.ID, path), true
+		}
+		return "", false
+	}
+
+	if configured := strings.TrimSpace(req.KernelImagePath); configured == "" {
+		if message, ok := managedKernelMessage(); ok {
+			appendCheck("kernel_image", "pass", message)
 		} else {
 			appendCheck("kernel_image", "fail", "kernel image must be configured")
 		}
 	} else if _, err := os.Stat(configured); err != nil {
-		if spec, ok := bootassets.LookupManagedKernelForHost(a.Name()); ok {
-			path, _ := bootassets.ManagedKernelPathForHost(a.Name())
-			appendCheck("kernel_image", "warn", fmt.Sprintf("configured kernel image is not accessible (%v); runtime will use managed kernel (%s -> %s)", err, spec.ID, path))
+		if message, ok := managedKernelMessage(); ok {
+			appendCheck("kernel_image", "warn", fmt.Sprintf("configured kernel image is not accessible (%v); runtime will use managed kernel: %s", err, message))
 		} else {
 			appendCheck("kernel_image", "fail", fmt.Sprintf("kernel image not accessible: %v", err))
 		}
@@ -2757,7 +2767,7 @@ func validateRootFSInspectable(rootFSPath string) error {
 }
 
 func (a *Adapter) resolveKernelPath(ctx context.Context, configuredPath string) (path, notice string, err error) {
-	resolved, err := bootassets.ResolveKernelPathForHost(ctx, a.Name(), configuredPath)
+	resolved, err := bootassets.ResolveKernelPathForHostWithVersion(ctx, a.Name(), configuredPath, a.Version)
 	if err != nil {
 		return "", "", err
 	}

--- a/internal/backend/darwinvz/backend_unsupported.go
+++ b/internal/backend/darwinvz/backend_unsupported.go
@@ -21,6 +21,7 @@ type Adapter struct {
 	MeterProvider    metric.MeterProvider
 
 	ConfiguredNetworkMode string
+	Version               string
 }
 
 func New() *Adapter {

--- a/internal/bootassets/manager.go
+++ b/internal/bootassets/manager.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	neturl "net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -19,6 +21,15 @@ import (
 )
 
 var ErrNoManagedKernelAsset = errors.New("no managed kernel asset")
+
+const (
+	defaultGitHubAPIBase           = "https://api.github.com"
+	defaultGitHubRepository        = "buildkite/cleanroom"
+	darwinVZReleaseManifestPrefix  = "cleanroom-darwin-vz-minimal-rootfs-arm64-linux-"
+	darwinVZReleaseManifestSuffix  = ".manifest.json"
+	latestCleanroomReleaseSelector = "latest"
+	releaseManifestResolveTimeout  = 15 * time.Second
+)
 
 type Selector struct {
 	Backend string
@@ -48,16 +59,28 @@ type ResolveResult struct {
 }
 
 type Options struct {
-	HTTPClient *http.Client
-	AssetsDir  func() (string, error)
-	Specs      map[Selector]KernelSpec
+	HTTPClient       *http.Client
+	AssetsDir        func() (string, error)
+	Specs            map[Selector]KernelSpec
+	GitHubAPIBase    string
+	GitHubRepository string
 }
 
 type Manager struct {
-	client    *http.Client
-	assetsDir func() (string, error)
-	specs     map[Selector]KernelSpec
-	mu        sync.Mutex
+	client           *http.Client
+	assetsDir        func() (string, error)
+	specs            map[Selector]KernelSpec
+	githubAPIBase    string
+	githubRepository string
+	releaseSpecCache map[releaseKernelCacheKey]KernelSpec
+	mu               sync.Mutex
+}
+
+type releaseKernelCacheKey struct {
+	Backend string
+	GOOS    string
+	GOARCH  string
+	Release string
 }
 
 func New(opts Options) *Manager {
@@ -78,11 +101,22 @@ func New(opts Options) *Manager {
 	for k, v := range specs {
 		copied[k] = v
 	}
+	githubAPIBase := strings.TrimRight(strings.TrimSpace(opts.GitHubAPIBase), "/")
+	if githubAPIBase == "" {
+		githubAPIBase = defaultGitHubAPIBase
+	}
+	githubRepository := strings.TrimSpace(opts.GitHubRepository)
+	if githubRepository == "" {
+		githubRepository = defaultGitHubRepository
+	}
 
 	return &Manager{
-		client:    client,
-		assetsDir: assetsDir,
-		specs:     copied,
+		client:           client,
+		assetsDir:        assetsDir,
+		specs:            copied,
+		githubAPIBase:    githubAPIBase,
+		githubRepository: githubRepository,
+		releaseSpecCache: make(map[releaseKernelCacheKey]KernelSpec),
 	}
 }
 
@@ -129,6 +163,10 @@ func (m *Manager) KernelPath(backendName, goos, goarch string) (string, error) {
 	if !ok {
 		return "", fmt.Errorf("%w for backend=%s host=%s/%s", ErrNoManagedKernelAsset, backendName, goos, goarch)
 	}
+	return m.kernelPathForSpec(spec)
+}
+
+func (m *Manager) kernelPathForSpec(spec KernelSpec) (string, error) {
 	base, err := m.assetsDir()
 	if err != nil {
 		return "", fmt.Errorf("resolve assets directory: %w", err)
@@ -137,11 +175,15 @@ func (m *Manager) KernelPath(backendName, goos, goarch string) (string, error) {
 }
 
 func (m *Manager) EnsureKernel(ctx context.Context, backendName, goos, goarch string) (EnsureResult, error) {
-	spec, ok := m.Lookup(backendName, goos, goarch)
-	if !ok {
-		return EnsureResult{}, fmt.Errorf("%w for backend=%s host=%s/%s", ErrNoManagedKernelAsset, backendName, goos, goarch)
+	return m.EnsureKernelWithVersion(ctx, backendName, goos, goarch, "")
+}
+
+func (m *Manager) EnsureKernelWithVersion(ctx context.Context, backendName, goos, goarch, appVersion string) (EnsureResult, error) {
+	spec, err := m.resolveKernelSpec(ctx, backendName, goos, goarch, appVersion)
+	if err != nil {
+		return EnsureResult{}, err
 	}
-	dest, err := m.KernelPath(backendName, goos, goarch)
+	dest, err := m.kernelPathForSpec(spec)
 	if err != nil {
 		return EnsureResult{}, err
 	}
@@ -187,6 +229,10 @@ func (m *Manager) EnsureKernel(ctx context.Context, backendName, goos, goarch st
 }
 
 func (m *Manager) ResolveKernelPath(ctx context.Context, backendName, goos, goarch, configuredPath string) (ResolveResult, error) {
+	return m.ResolveKernelPathWithVersion(ctx, backendName, goos, goarch, configuredPath, "")
+}
+
+func (m *Manager) ResolveKernelPathWithVersion(ctx context.Context, backendName, goos, goarch, configuredPath, appVersion string) (ResolveResult, error) {
 	trimmed := strings.TrimSpace(configuredPath)
 	if trimmed != "" {
 		absPath, err := filepath.Abs(trimmed)
@@ -197,7 +243,7 @@ func (m *Manager) ResolveKernelPath(ctx context.Context, backendName, goos, goar
 			return ResolveResult{Path: trimmed}, nil
 		}
 
-		ensured, err := m.EnsureKernel(ctx, backendName, goos, goarch)
+		ensured, err := m.EnsureKernelWithVersion(ctx, backendName, goos, goarch, appVersion)
 		if err != nil {
 			return ResolveResult{}, fmt.Errorf("configured kernel_image %q is not accessible and managed kernel resolution failed: %w", trimmed, err)
 		}
@@ -215,7 +261,7 @@ func (m *Manager) ResolveKernelPath(ctx context.Context, backendName, goos, goar
 		}, nil
 	}
 
-	ensured, err := m.EnsureKernel(ctx, backendName, goos, goarch)
+	ensured, err := m.EnsureKernelWithVersion(ctx, backendName, goos, goarch, appVersion)
 	if err != nil {
 		return ResolveResult{}, err
 	}
@@ -226,6 +272,207 @@ func (m *Manager) ResolveKernelPath(ctx context.Context, backendName, goos, goar
 		Spec:     ensured.Spec,
 		Notice:   fmt.Sprintf("using managed kernel asset %s (%s)", ensured.Spec.ID, cacheState(ensured.CacheHit)),
 	}, nil
+}
+
+func (m *Manager) resolveKernelSpec(ctx context.Context, backendName, goos, goarch, appVersion string) (KernelSpec, error) {
+	if spec, ok, err := m.resolveDarwinVZReleaseKernelSpec(ctx, backendName, goos, goarch, appVersion); ok && err == nil {
+		return spec, nil
+	}
+
+	if spec, ok := m.Lookup(backendName, goos, goarch); ok {
+		return spec, nil
+	}
+	return KernelSpec{}, fmt.Errorf("%w for backend=%s host=%s/%s", ErrNoManagedKernelAsset, backendName, goos, goarch)
+}
+
+func (m *Manager) resolveDarwinVZReleaseKernelSpec(ctx context.Context, backendName, goos, goarch, appVersion string) (KernelSpec, bool, error) {
+	backendName = strings.TrimSpace(backendName)
+	goos = strings.TrimSpace(goos)
+	goarch = strings.TrimSpace(goarch)
+	if backendName != "darwin-vz" || goos != "darwin" || goarch != "arm64" {
+		return KernelSpec{}, false, nil
+	}
+
+	release := cleanroomKernelReleaseSelector(appVersion)
+	cacheKey := releaseKernelCacheKey{
+		Backend: backendName,
+		GOOS:    goos,
+		GOARCH:  goarch,
+		Release: release,
+	}
+	m.mu.Lock()
+	if spec, ok := m.releaseSpecCache[cacheKey]; ok {
+		m.mu.Unlock()
+		return spec, true, nil
+	}
+	m.mu.Unlock()
+
+	spec, err := m.fetchDarwinVZReleaseKernelSpec(ctx, release)
+	if err != nil {
+		return KernelSpec{}, true, err
+	}
+
+	m.mu.Lock()
+	m.releaseSpecCache[cacheKey] = spec
+	m.mu.Unlock()
+	return spec, true, nil
+}
+
+type githubRelease struct {
+	TagName string               `json:"tag_name"`
+	Assets  []githubReleaseAsset `json:"assets"`
+}
+
+type githubReleaseAsset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+}
+
+type kernelReleaseManifest struct {
+	ID      string `json:"id"`
+	Backend string `json:"backend"`
+	Profile string `json:"profile"`
+	Arch    string `json:"arch"`
+	Assets  struct {
+		Image    string `json:"image"`
+		Config   string `json:"config"`
+		SHA256   string `json:"sha256"`
+		Manifest string `json:"manifest"`
+	} `json:"assets"`
+	SHA256 string `json:"sha256"`
+}
+
+func (m *Manager) fetchDarwinVZReleaseKernelSpec(ctx context.Context, releaseSelector string) (KernelSpec, error) {
+	metadataCtx, cancel := context.WithTimeout(ctx, releaseManifestResolveTimeout)
+	defer cancel()
+
+	releaseURL := m.releaseURL(releaseSelector)
+	var release githubRelease
+	if err := m.downloadJSON(metadataCtx, releaseURL, &release); err != nil {
+		return KernelSpec{}, err
+	}
+
+	manifestAsset, ok := findDarwinVZKernelManifestAsset(release.Assets)
+	if !ok {
+		return KernelSpec{}, fmt.Errorf("darwin-vz kernel manifest asset not found in Cleanroom release %s", releaseSelector)
+	}
+
+	var manifest kernelReleaseManifest
+	if err := m.downloadJSON(metadataCtx, manifestAsset.BrowserDownloadURL, &manifest); err != nil {
+		return KernelSpec{}, fmt.Errorf("download darwin-vz kernel manifest %q: %w", manifestAsset.Name, err)
+	}
+	if err := validateDarwinVZKernelManifest(manifest); err != nil {
+		return KernelSpec{}, fmt.Errorf("invalid darwin-vz kernel manifest %q: %w", manifestAsset.Name, err)
+	}
+
+	imageAsset, ok := findReleaseAsset(release.Assets, manifest.Assets.Image)
+	if !ok {
+		return KernelSpec{}, fmt.Errorf("darwin-vz kernel image asset %q not found in Cleanroom release %s", manifest.Assets.Image, releaseSelector)
+	}
+	return KernelSpec{
+		ID:       manifest.ID,
+		Filename: manifest.Assets.Image,
+		URL:      imageAsset.BrowserDownloadURL,
+		SHA256:   manifest.SHA256,
+	}, nil
+}
+
+func (m *Manager) releaseURL(releaseSelector string) string {
+	if releaseSelector == latestCleanroomReleaseSelector {
+		return fmt.Sprintf("%s/repos/%s/releases/latest", m.githubAPIBase, m.githubRepository)
+	}
+	return fmt.Sprintf("%s/repos/%s/releases/tags/%s", m.githubAPIBase, m.githubRepository, neturl.PathEscape(releaseSelector))
+}
+
+func (m *Manager) downloadJSON(ctx context.Context, rawURL string, target any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("User-Agent", "cleanroom")
+	req.Header.Set("Accept", "application/vnd.github+json, application/json")
+
+	res, err := m.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("download %s: %w", rawURL, err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(res.Body, 1024))
+		return fmt.Errorf("download %s: unexpected status %d: %s", rawURL, res.StatusCode, strings.TrimSpace(string(body)))
+	}
+	if err := json.NewDecoder(io.LimitReader(res.Body, 1<<20)).Decode(target); err != nil {
+		return fmt.Errorf("decode %s: %w", rawURL, err)
+	}
+	return nil
+}
+
+func findDarwinVZKernelManifestAsset(assets []githubReleaseAsset) (githubReleaseAsset, bool) {
+	for _, asset := range assets {
+		if strings.HasPrefix(asset.Name, darwinVZReleaseManifestPrefix) && strings.HasSuffix(asset.Name, darwinVZReleaseManifestSuffix) {
+			return asset, strings.TrimSpace(asset.BrowserDownloadURL) != ""
+		}
+	}
+	return githubReleaseAsset{}, false
+}
+
+func findReleaseAsset(assets []githubReleaseAsset, name string) (githubReleaseAsset, bool) {
+	for _, asset := range assets {
+		if asset.Name == name {
+			return asset, strings.TrimSpace(asset.BrowserDownloadURL) != ""
+		}
+	}
+	return githubReleaseAsset{}, false
+}
+
+func validateDarwinVZKernelManifest(manifest kernelReleaseManifest) error {
+	switch {
+	case strings.TrimSpace(manifest.ID) == "":
+		return errors.New("missing id")
+	case manifest.Backend != "darwin-vz":
+		return fmt.Errorf("unexpected backend %q", manifest.Backend)
+	case manifest.Profile != "rootfs":
+		return fmt.Errorf("unexpected profile %q", manifest.Profile)
+	case manifest.Arch != "arm64":
+		return fmt.Errorf("unexpected arch %q", manifest.Arch)
+	case strings.TrimSpace(manifest.Assets.Image) == "":
+		return errors.New("missing image asset name")
+	case strings.TrimSpace(manifest.SHA256) == "":
+		return errors.New("missing image sha256")
+	default:
+		return nil
+	}
+}
+
+func cleanroomKernelReleaseSelector(version string) string {
+	version = strings.TrimSpace(version)
+	if isCleanroomReleaseVersion(version) {
+		if strings.HasPrefix(version, "v") {
+			return version
+		}
+		return "v" + version
+	}
+	return latestCleanroomReleaseSelector
+}
+
+func isCleanroomReleaseVersion(version string) bool {
+	version = strings.TrimPrefix(strings.TrimSpace(version), "v")
+	parts := strings.Split(version, ".")
+	if len(parts) != 3 {
+		return false
+	}
+	for _, part := range parts {
+		if part == "" {
+			return false
+		}
+		for _, r := range part {
+			if r < '0' || r > '9' {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 func (m *Manager) downloadAndVerify(ctx context.Context, spec KernelSpec, tmpPath string) error {
@@ -316,4 +563,8 @@ func ManagedKernelPathForHost(backendName string) (string, error) {
 
 func ResolveKernelPathForHost(ctx context.Context, backendName, configuredPath string) (ResolveResult, error) {
 	return defaultManager.ResolveKernelPath(ctx, backendName, runtime.GOOS, runtime.GOARCH, configuredPath)
+}
+
+func ResolveKernelPathForHostWithVersion(ctx context.Context, backendName, configuredPath, appVersion string) (ResolveResult, error) {
+	return defaultManager.ResolveKernelPathWithVersion(ctx, backendName, runtime.GOOS, runtime.GOARCH, configuredPath, appVersion)
 }

--- a/internal/bootassets/manager_test.go
+++ b/internal/bootassets/manager_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -35,7 +36,7 @@ func TestResolveKernelPathUsesConfiguredPathWhenPresent(t *testing.T) {
 			return filepath.Join(tmpDir, "assets"), nil
 		},
 		Specs: map[Selector]KernelSpec{
-			{Backend: "darwin-vz", GOOS: "darwin", GOARCH: "arm64"}: {
+			{Backend: "firecracker", GOOS: "linux", GOARCH: "amd64"}: {
 				ID:       "test-kernel",
 				Filename: "vmlinux-test",
 				URL:      srv.URL + "/kernel",
@@ -77,7 +78,7 @@ func TestResolveKernelPathDownloadsAndCachesManagedKernel(t *testing.T) {
 			return filepath.Join(tmpDir, "assets"), nil
 		},
 		Specs: map[Selector]KernelSpec{
-			{Backend: "darwin-vz", GOOS: "darwin", GOARCH: "arm64"}: {
+			{Backend: "firecracker", GOOS: "linux", GOARCH: "amd64"}: {
 				ID:       "test-kernel",
 				Filename: "vmlinux-test",
 				URL:      srv.URL + "/kernel",
@@ -86,7 +87,7 @@ func TestResolveKernelPathDownloadsAndCachesManagedKernel(t *testing.T) {
 		},
 	})
 
-	first, err := mgr.ResolveKernelPath(context.Background(), "darwin-vz", "darwin", "arm64", "")
+	first, err := mgr.ResolveKernelPath(context.Background(), "firecracker", "linux", "amd64", "")
 	if err != nil {
 		t.Fatalf("ResolveKernelPath first call returned error: %v", err)
 	}
@@ -100,7 +101,7 @@ func TestResolveKernelPathDownloadsAndCachesManagedKernel(t *testing.T) {
 		t.Fatalf("expected managed notice, got %q", first.Notice)
 	}
 
-	second, err := mgr.ResolveKernelPath(context.Background(), "darwin-vz", "darwin", "arm64", "")
+	second, err := mgr.ResolveKernelPath(context.Background(), "firecracker", "linux", "amd64", "")
 	if err != nil {
 		t.Fatalf("ResolveKernelPath second call returned error: %v", err)
 	}
@@ -163,7 +164,7 @@ func TestResolveKernelPathReturnsErrorWhenUnsupported(t *testing.T) {
 		Specs: map[Selector]KernelSpec{},
 	})
 
-	_, err := mgr.ResolveKernelPath(context.Background(), "darwin-vz", "darwin", "arm64", "")
+	_, err := mgr.ResolveKernelPath(context.Background(), "unknown", "linux", "amd64", "")
 	if err == nil {
 		t.Fatal("expected unsupported-platform error")
 	}
@@ -172,7 +173,186 @@ func TestResolveKernelPathReturnsErrorWhenUnsupported(t *testing.T) {
 	}
 }
 
+func TestResolveKernelPathUsesLatestReleaseManifestForDevDarwinVZ(t *testing.T) {
+	t.Parallel()
+
+	const payload = "release-kernel"
+	var releaseHits atomic.Int32
+	var kernelHits atomic.Int32
+	srv := newDarwinVZKernelReleaseServer(t, "/repos/buildkite/cleanroom/releases/latest", payload, &releaseHits, &kernelHits)
+
+	tmpDir := t.TempDir()
+	mgr := New(Options{
+		HTTPClient: srv.Client(),
+		AssetsDir: func() (string, error) {
+			return filepath.Join(tmpDir, "assets"), nil
+		},
+		Specs:         map[Selector]KernelSpec{},
+		GitHubAPIBase: srv.URL,
+	})
+
+	first, err := mgr.ResolveKernelPathWithVersion(context.Background(), "darwin-vz", "darwin", "arm64", "", "dev")
+	if err != nil {
+		t.Fatalf("ResolveKernelPathWithVersion first call returned error: %v", err)
+	}
+	if got, want := first.Spec.ID, "cleanroom-darwin-vz-minimal-rootfs-arm64-linux-6.1.155"; got != want {
+		t.Fatalf("unexpected release kernel spec ID: got %q want %q", got, want)
+	}
+	if got, want := filepath.Base(first.Path), "cleanroom-darwin-vz-minimal-rootfs-arm64-linux-6.1.155-Image"; got != want {
+		t.Fatalf("unexpected cached release kernel path: got %q want %q", got, want)
+	}
+	if first.CacheHit {
+		t.Fatal("expected first release kernel resolution to be a cache miss")
+	}
+
+	second, err := mgr.ResolveKernelPathWithVersion(context.Background(), "darwin-vz", "darwin", "arm64", "", "dev")
+	if err != nil {
+		t.Fatalf("ResolveKernelPathWithVersion second call returned error: %v", err)
+	}
+	if !second.CacheHit {
+		t.Fatal("expected second release kernel resolution to be a cache hit")
+	}
+	if got := releaseHits.Load(); got != 1 {
+		t.Fatalf("expected one release metadata request, got %d", got)
+	}
+	if got := kernelHits.Load(); got != 1 {
+		t.Fatalf("expected one release kernel download, got %d", got)
+	}
+}
+
+func TestResolveKernelPathUsesMatchingReleaseManifestForTaggedDarwinVZ(t *testing.T) {
+	t.Parallel()
+
+	const payload = "release-kernel"
+	var releaseHits atomic.Int32
+	var kernelHits atomic.Int32
+	srv := newDarwinVZKernelReleaseServer(t, "/repos/buildkite/cleanroom/releases/tags/v1.2.3", payload, &releaseHits, &kernelHits)
+
+	tmpDir := t.TempDir()
+	mgr := New(Options{
+		HTTPClient: srv.Client(),
+		AssetsDir: func() (string, error) {
+			return filepath.Join(tmpDir, "assets"), nil
+		},
+		Specs:         map[Selector]KernelSpec{},
+		GitHubAPIBase: srv.URL,
+	})
+
+	res, err := mgr.ResolveKernelPathWithVersion(context.Background(), "darwin-vz", "darwin", "arm64", "", "1.2.3")
+	if err != nil {
+		t.Fatalf("ResolveKernelPathWithVersion returned error: %v", err)
+	}
+	if !res.Managed {
+		t.Fatal("expected release kernel to be managed")
+	}
+	if got := releaseHits.Load(); got != 1 {
+		t.Fatalf("expected one tagged release metadata request, got %d", got)
+	}
+	if got := kernelHits.Load(); got != 1 {
+		t.Fatalf("expected one tagged release kernel download, got %d", got)
+	}
+}
+
+func TestResolveKernelPathFallsBackToStaticDarwinVZWhenReleaseManifestMissing(t *testing.T) {
+	t.Parallel()
+
+	const payload = "static-kernel"
+	var releaseHits atomic.Int32
+	var kernelHits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/buildkite/cleanroom/releases/latest":
+			releaseHits.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"tag_name":"v1.2.3","assets":[]}`))
+		case "/static-kernel":
+			kernelHits.Add(1)
+			_, _ = w.Write([]byte(payload))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	tmpDir := t.TempDir()
+	mgr := New(Options{
+		HTTPClient: srv.Client(),
+		AssetsDir: func() (string, error) {
+			return filepath.Join(tmpDir, "assets"), nil
+		},
+		Specs: map[Selector]KernelSpec{
+			{Backend: "darwin-vz", GOOS: "darwin", GOARCH: "arm64"}: {
+				ID:       "static-darwin-vz-kernel",
+				Filename: "vmlinux-static",
+				URL:      srv.URL + "/static-kernel",
+				SHA256:   sha256Hex([]byte(payload)),
+			},
+		},
+		GitHubAPIBase: srv.URL,
+	})
+
+	res, err := mgr.ResolveKernelPathWithVersion(context.Background(), "darwin-vz", "darwin", "arm64", "", "dev")
+	if err != nil {
+		t.Fatalf("ResolveKernelPathWithVersion returned error: %v", err)
+	}
+	if got, want := res.Spec.ID, "static-darwin-vz-kernel"; got != want {
+		t.Fatalf("unexpected fallback kernel spec ID: got %q want %q", got, want)
+	}
+	if got := releaseHits.Load(); got != 1 {
+		t.Fatalf("expected one release metadata request, got %d", got)
+	}
+	if got := kernelHits.Load(); got != 1 {
+		t.Fatalf("expected one static kernel download, got %d", got)
+	}
+}
+
 func sha256Hex(b []byte) string {
 	sum := sha256.Sum256(b)
 	return hex.EncodeToString(sum[:])
+}
+
+func newDarwinVZKernelReleaseServer(t *testing.T, releasePath, payload string, releaseHits, kernelHits *atomic.Int32) *httptest.Server {
+	t.Helper()
+
+	const assetBase = "cleanroom-darwin-vz-minimal-rootfs-arm64-linux-6.1.155"
+	const imageName = assetBase + "-Image"
+	const manifestName = assetBase + ".manifest.json"
+
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case releasePath:
+			releaseHits.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{
+  "tag_name": "v1.2.3",
+  "assets": [
+    {"name": %q, "browser_download_url": %q},
+    {"name": %q, "browser_download_url": %q}
+  ]
+}`, manifestName, srv.URL+"/manifest.json", imageName, srv.URL+"/kernel")
+		case "/manifest.json":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{
+  "id": %q,
+  "backend": "darwin-vz",
+  "profile": "rootfs",
+  "arch": "arm64",
+  "assets": {
+    "image": %q,
+    "config": %q,
+    "sha256": %q,
+    "manifest": %q
+  },
+  "sha256": %q
+}`, assetBase, imageName, imageName+".config", imageName+".sha256", manifestName, sha256Hex([]byte(payload)))
+		case "/kernel":
+			kernelHits.Add(1)
+			_, _ = w.Write([]byte(payload))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -171,7 +171,7 @@ func Run(args []string, version string) (runErr error) {
 			"firecracker": firecracker.New(),
 			"darwin-vz":   darwinvz.New(),
 		}
-		configureBackendRuntimeConfig(runtimeCtx.Backends, cfg)
+		configureBackendRuntimeConfig(runtimeCtx.Backends, cfg, version)
 
 		if commandUsesStartupObservability(ctx) {
 			obsRuntime, err := observability.Start(context.Background(), observability.Options{
@@ -216,9 +216,10 @@ func commandUsesStartupObservability(ctx *kong.Context) bool {
 	return !strings.HasPrefix(strings.TrimSpace(ctx.Command()), "daemon ")
 }
 
-func configureBackendRuntimeConfig(backends map[string]backend.Adapter, cfg runtimeconfig.Config) {
+func configureBackendRuntimeConfig(backends map[string]backend.Adapter, cfg runtimeconfig.Config, version string) {
 	if darwinAdapter, ok := backends["darwin-vz"].(*darwinvz.Adapter); ok {
 		darwinAdapter.ConfiguredNetworkMode = strings.TrimSpace(cfg.Backends.DarwinVZ.Network.Mode)
+		darwinAdapter.Version = strings.TrimSpace(version)
 	}
 }
 

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -481,6 +481,6 @@ func (s *DaemonCommand) reloadRuntimeConfig(ctx *runtimeContext) error {
 			"darwin-vz":   darwinvz.New(),
 		}
 	}
-	configureBackendRuntimeConfig(ctx.Backends, cfg)
+	configureBackendRuntimeConfig(ctx.Backends, cfg, ctx.Version)
 	return nil
 }

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -145,10 +145,13 @@ func TestConfigureBackendRuntimeConfigConfiguresDarwinVZCapabilities(t *testing.
 		},
 	}
 
-	configureBackendRuntimeConfig(backends, cfg)
+	configureBackendRuntimeConfig(backends, cfg, "1.2.3")
 
 	if got, want := darwinAdapter.ConfiguredNetworkMode, "filehandle"; got != want {
 		t.Fatalf("unexpected configured darwin-vz network mode: got %q want %q", got, want)
+	}
+	if got, want := darwinAdapter.Version, "1.2.3"; got != want {
+		t.Fatalf("unexpected configured darwin-vz version: got %q want %q", got, want)
 	}
 }
 

--- a/mise.toml
+++ b/mise.toml
@@ -14,7 +14,7 @@ run = "go test ./..."
 
 [tasks.lint-shell]
 description = "Lint shell scripts"
-run = "shellcheck -x scripts/base-image-tag.sh scripts/cleanroom-root-helper.sh scripts/benchmark-tti.sh scripts/build-go.sh scripts/install-go.sh scripts/install.sh scripts/install-global.sh scripts/package-darwin-vz-helper.sh scripts/release.sh scripts/e2e-observability.sh scripts/ci-example-smoke.sh scripts/ci-examples-firecracker.sh scripts/ci-examples-darwin-vz.sh scripts/ci-cleanroom-e2e.sh scripts/ci-darwin-vz-e2e.sh scripts/ci-darwin-vz-filehandle-e2e.sh scripts/build-macos-release-pkg.sh scripts/notarize-macos-package.sh scripts/ci-macos-release-pkg.sh scripts/ci-buildkite-release.sh"
+run = "shellcheck -x scripts/base-image-tag.sh scripts/cleanroom-root-helper.sh scripts/benchmark-tti.sh scripts/build-go.sh scripts/install-go.sh scripts/install.sh scripts/install-global.sh scripts/package-darwin-vz-helper.sh scripts/release.sh scripts/e2e-observability.sh scripts/ci-example-smoke.sh scripts/ci-examples-firecracker.sh scripts/ci-examples-darwin-vz.sh scripts/ci-cleanroom-e2e.sh scripts/ci-darwin-vz-e2e.sh scripts/ci-darwin-vz-filehandle-e2e.sh scripts/build-macos-release-pkg.sh scripts/notarize-macos-package.sh scripts/ci-macos-release-pkg.sh scripts/build-darwin-vz-minimal-kernel-release.sh scripts/ci-darwin-vz-kernel-release.sh scripts/ci-buildkite-release.sh"
 
 [tasks.test-full]
 description = "Run full Go test suite"

--- a/scripts/build-darwin-vz-minimal-kernel-release.sh
+++ b/scripts/build-darwin-vz-minimal-kernel-release.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+die() {
+  printf '[build-darwin-vz-minimal-kernel-release] error: %s\n' "$*" >&2
+  exit 1
+}
+
+require_command() {
+  local name="$1"
+  command -v "$name" >/dev/null 2>&1 || die "missing required command: ${name}"
+}
+
+sha256_file() {
+  local file="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$file" | awk '{print $1}'
+    return
+  fi
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$file" | awk '{print $1}'
+    return
+  fi
+  die "sha256 tool not found (need sha256sum or shasum)"
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+KERNEL_VERSION="${CLEANROOM_DARWIN_VZ_MINIMAL_KERNEL_VERSION:-6.1.155}"
+KERNEL_PROFILE="${CLEANROOM_DARWIN_VZ_MINIMAL_KERNEL_PROFILE:-rootfs}"
+KERNEL_ARCH="${CLEANROOM_DARWIN_VZ_MINIMAL_KERNEL_ARCH:-arm64}"
+DOCKER_IMAGE="${CLEANROOM_DARWIN_VZ_MINIMAL_KERNEL_DOCKER_IMAGE:-ubuntu:22.04}"
+DOCKER_PLATFORM="${CLEANROOM_DARWIN_VZ_MINIMAL_KERNEL_DOCKER_PLATFORM:-linux/${KERNEL_ARCH}}"
+KERNEL_TARBALL_SHA256="${CLEANROOM_DARWIN_VZ_MINIMAL_KERNEL_TARBALL_SHA256:-}"
+if [[ -z "${KERNEL_TARBALL_SHA256}" && "${KERNEL_VERSION}" == "6.1.155" ]]; then
+  KERNEL_TARBALL_SHA256="c29387aeee085fbcbd91236224b9df805063bac43615e75cea2c6b29604a5c73"
+fi
+
+case "${KERNEL_PROFILE}" in
+  rootfs) ;;
+  *)
+    die "release kernel profile must be rootfs, got ${KERNEL_PROFILE}"
+    ;;
+esac
+
+case "${KERNEL_ARCH}" in
+  arm64) ;;
+  *)
+    die "release kernel arch must be arm64, got ${KERNEL_ARCH}"
+    ;;
+esac
+
+require_command docker
+require_command git
+require_command python3
+
+OUTPUT_DIR="${1:-${REPO_ROOT}/release-extra/kernels}"
+ASSET_BASE="${CLEANROOM_DARWIN_VZ_MINIMAL_KERNEL_ASSET_BASE:-cleanroom-darwin-vz-minimal-${KERNEL_PROFILE}-${KERNEL_ARCH}-linux-${KERNEL_VERSION}}"
+IMAGE_NAME="${ASSET_BASE}-Image"
+IMAGE_PATH="${OUTPUT_DIR}/${IMAGE_NAME}"
+CONFIG_PATH="${IMAGE_PATH}.config"
+SHA256_PATH="${IMAGE_PATH}.sha256"
+MANIFEST_PATH="${ASSET_BASE}.manifest.json"
+MANIFEST_PATH="${OUTPUT_DIR}/${MANIFEST_PATH}"
+
+mkdir -p "${OUTPUT_DIR}"
+rm -f "${IMAGE_PATH}" "${CONFIG_PATH}" "${SHA256_PATH}" "${MANIFEST_PATH}"
+
+CLEANROOM_DARWIN_VZ_MINIMAL_KERNEL_PROFILE="${KERNEL_PROFILE}" \
+CLEANROOM_DARWIN_VZ_MINIMAL_KERNEL_ARCH="${KERNEL_ARCH}" \
+CLEANROOM_DARWIN_VZ_MINIMAL_KERNEL_VERSION="${KERNEL_VERSION}" \
+CLEANROOM_DARWIN_VZ_MINIMAL_KERNEL_DOCKER_IMAGE="${DOCKER_IMAGE}" \
+CLEANROOM_DARWIN_VZ_MINIMAL_KERNEL_DOCKER_PLATFORM="${DOCKER_PLATFORM}" \
+CLEANROOM_DARWIN_VZ_MINIMAL_KERNEL_TARBALL_SHA256="${KERNEL_TARBALL_SHA256}" \
+  "${REPO_ROOT}/benchmarks/darwin-vz/minimal/build-kernel.sh" "${IMAGE_PATH}" >/dev/null
+
+[[ -f "${IMAGE_PATH}" ]] || die "kernel image was not created: ${IMAGE_PATH}"
+[[ -f "${CONFIG_PATH}" ]] || die "kernel config was not created: ${CONFIG_PATH}"
+
+KERNEL_SHA256="$(sha256_file "${IMAGE_PATH}")"
+printf '%s  %s\n' "${KERNEL_SHA256}" "${IMAGE_NAME}" > "${SHA256_PATH}"
+
+SOURCE_COMMIT="$(git -C "${REPO_ROOT}" rev-parse HEAD)"
+SOURCE_REPOSITORY="${CLEANROOM_GITHUB_REPOSITORY:-buildkite/cleanroom}"
+RELEASE_TAG="${BUILDKITE_TAG:-}"
+
+ASSET_BASE="${ASSET_BASE}" \
+DOCKER_IMAGE="${DOCKER_IMAGE}" \
+DOCKER_PLATFORM="${DOCKER_PLATFORM}" \
+IMAGE_NAME="${IMAGE_NAME}" \
+KERNEL_ARCH="${KERNEL_ARCH}" \
+KERNEL_PROFILE="${KERNEL_PROFILE}" \
+KERNEL_SHA256="${KERNEL_SHA256}" \
+KERNEL_TARBALL_SHA256="${KERNEL_TARBALL_SHA256}" \
+KERNEL_VERSION="${KERNEL_VERSION}" \
+RELEASE_TAG="${RELEASE_TAG}" \
+SOURCE_COMMIT="${SOURCE_COMMIT}" \
+SOURCE_REPOSITORY="${SOURCE_REPOSITORY}" \
+python3 - <<'PY' > "${MANIFEST_PATH}"
+import json
+import os
+
+image_name = os.environ["IMAGE_NAME"]
+manifest = {
+    "id": os.environ["ASSET_BASE"],
+    "backend": "darwin-vz",
+    "profile": os.environ["KERNEL_PROFILE"],
+    "arch": os.environ["KERNEL_ARCH"],
+    "linux_version": os.environ["KERNEL_VERSION"],
+    "assets": {
+        "image": image_name,
+        "config": image_name + ".config",
+        "sha256": image_name + ".sha256",
+        "manifest": os.environ["ASSET_BASE"] + ".manifest.json",
+    },
+    "sha256": os.environ["KERNEL_SHA256"],
+    "source": {
+        "repository": os.environ["SOURCE_REPOSITORY"],
+        "commit": os.environ["SOURCE_COMMIT"],
+        "tag": os.environ["RELEASE_TAG"],
+    },
+    "builder": {
+        "script": "benchmarks/darwin-vz/minimal/build-kernel.sh",
+        "docker_image": os.environ["DOCKER_IMAGE"],
+        "docker_platform": os.environ["DOCKER_PLATFORM"],
+        "kernel_tarball_sha256": os.environ["KERNEL_TARBALL_SHA256"],
+    },
+}
+print(json.dumps(manifest, indent=2, sort_keys=True))
+PY
+
+printf '[build-darwin-vz-minimal-kernel-release] wrote %s\n' "${IMAGE_PATH}"
+printf '[build-darwin-vz-minimal-kernel-release] wrote %s\n' "${CONFIG_PATH}"
+printf '[build-darwin-vz-minimal-kernel-release] wrote %s\n' "${SHA256_PATH}"
+printf '[build-darwin-vz-minimal-kernel-release] wrote %s\n' "${MANIFEST_PATH}"

--- a/scripts/buildkite_pipeline_test.go
+++ b/scripts/buildkite_pipeline_test.go
@@ -50,6 +50,10 @@ func TestBuildkitePipelineUsesSetupGoForGoSteps(t *testing.T) {
     plugins:
       - ` + setupGoBuildkitePluginRef + `:
     command: scripts/ci-macos-release-pkg.sh`,
+		`- label: ":penguin: darwin-vz kernel release assets"
+    key: darwin-vz-kernel-release-assets
+    if: build.tag != null
+    command: scripts/ci-darwin-vz-kernel-release.sh`,
 		`- label: ":fire: E2E (Firecracker)"
     plugins:
       - ` + setupGoBuildkitePluginRef + `:
@@ -79,6 +83,9 @@ func TestBuildkitePipelineUsesSetupGoForGoSteps(t *testing.T) {
 	if !strings.Contains(pipeline, "command: scripts/ci-macos-release-pkg.sh") {
 		t.Fatalf("expected .buildkite/pipeline.yml to include the macOS release pkg step")
 	}
+	if !strings.Contains(pipeline, "command: scripts/ci-darwin-vz-kernel-release.sh") {
+		t.Fatalf("expected .buildkite/pipeline.yml to include the darwin-vz kernel release step")
+	}
 	if !strings.Contains(pipeline, "command: scripts/ci-buildkite-release.sh") {
 		t.Fatalf("expected .buildkite/pipeline.yml to include the Buildkite release publish step")
 	}
@@ -91,6 +98,8 @@ func TestBuildkitePipelineUsesSetupGoForGoSteps(t *testing.T) {
 		"scripts/ci-examples-darwin-vz.sh",
 		"scripts/build-macos-release-pkg.sh",
 		"scripts/notarize-macos-package.sh",
+		"scripts/build-darwin-vz-minimal-kernel-release.sh",
+		"scripts/ci-darwin-vz-kernel-release.sh",
 	} {
 		if !strings.Contains(pipeline, needle) {
 			t.Fatalf("expected .buildkite/pipeline.yml shellcheck command to include %q", needle)
@@ -187,6 +196,7 @@ func TestBuildkiteCIScriptsDoNotInvokeMiseDirectly(t *testing.T) {
 		"ci-darwin-vz-e2e.sh",
 		"ci-darwin-vz-filehandle-e2e.sh",
 		"ci-macos-release-pkg.sh",
+		"ci-darwin-vz-kernel-release.sh",
 		"ci-buildkite-release.sh",
 	} {
 		path := path
@@ -245,6 +255,8 @@ func TestMiseLintShellCoversSharedE2EObservabilityHelper(t *testing.T) {
 		`scripts/build-macos-release-pkg.sh`,
 		`scripts/notarize-macos-package.sh`,
 		`scripts/ci-macos-release-pkg.sh`,
+		`scripts/build-darwin-vz-minimal-kernel-release.sh`,
+		`scripts/ci-darwin-vz-kernel-release.sh`,
 		`scripts/ci-buildkite-release.sh`,
 	} {
 		if !strings.Contains(mise, needle) {

--- a/scripts/ci-buildkite-release.sh
+++ b/scripts/ci-buildkite-release.sh
@@ -42,6 +42,21 @@ download_darwin_release_artifacts() {
   done
 }
 
+download_kernel_release_artifacts() {
+  local archive_path
+
+  mkdir -p "${RELEASE_EXTRA_DIR}"
+  rm -rf "${RELEASE_EXTRA_DIR}/kernels"
+  rm -f "${RELEASE_EXTRA_DIR}/kernels.tar.gz"
+
+  buildkite-agent artifact download "release-extra/kernels.tar.gz" "${REPO_ROOT}"
+
+  archive_path="${RELEASE_EXTRA_DIR}/kernels.tar.gz"
+  [[ -f "${archive_path}" ]] || die "missing downloaded kernel release archive: ${archive_path}"
+  tar -xzf "${archive_path}" -C "${RELEASE_EXTRA_DIR}"
+  [[ -d "${RELEASE_EXTRA_DIR}/kernels" ]] || die "missing extracted kernel release directory: ${RELEASE_EXTRA_DIR}/kernels"
+}
+
 build_linux_release_extras() {
   mkdir -p "${RELEASE_EXTRA_DIR}/linux_amd64" "${RELEASE_EXTRA_DIR}/linux_arm64"
 
@@ -53,7 +68,7 @@ build_linux_release_extras() {
 
 publish_github_release() {
   local github_token release_json upload_url
-  local -a pkg_assets
+  local -a extra_assets pkg_assets kernel_assets
 
   github_token="$(normalize_secret_value "$(fetch_secret CLEANROOM_GITHUB_RELEASE_TOKEN)")"
   [[ -n "${github_token}" ]] || die "CLEANROOM_GITHUB_RELEASE_TOKEN is empty"
@@ -82,7 +97,12 @@ publish_github_release() {
     "${RELEASE_EXTRA_DIR}/darwin_amd64/cleanroom_Darwin_x86_64.pkg.sha256"
   )
 
-  for asset_path in "${pkg_assets[@]}"; do
+  mapfile -t kernel_assets < <(find "${RELEASE_EXTRA_DIR}/kernels" -maxdepth 1 -type f | sort)
+  [[ "${#kernel_assets[@]}" -gt 0 ]] || die "missing kernel release assets in ${RELEASE_EXTRA_DIR}/kernels"
+
+  extra_assets=("${pkg_assets[@]}" "${kernel_assets[@]}")
+
+  for asset_path in "${extra_assets[@]}"; do
     local asset_name asset_id
 
     [[ -f "${asset_path}" ]] || die "missing release asset: ${asset_path}"
@@ -134,6 +154,9 @@ git fetch --tags origin
 
 echo "--- :package: Download signed macOS release artifacts"
 download_darwin_release_artifacts
+
+echo "--- :package: Download kernel release artifacts"
+download_kernel_release_artifacts
 
 echo "--- :hammer: Build Linux release extras"
 build_linux_release_extras

--- a/scripts/ci-darwin-vz-kernel-release.sh
+++ b/scripts/ci-darwin-vz-kernel-release.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+die() {
+  printf '[ci-darwin-vz-kernel-release] error: %s\n' "$*" >&2
+  exit 1
+}
+
+require_command() {
+  local name="$1"
+  command -v "$name" >/dev/null 2>&1 || die "missing required command: ${name}"
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+KERNEL_RELEASE_DIR="${REPO_ROOT}/release-extra/kernels"
+
+require_command buildkite-agent
+require_command docker
+require_command git
+require_command python3
+require_command tar
+
+cd "${REPO_ROOT}"
+rm -rf "${KERNEL_RELEASE_DIR}"
+
+echo "--- :penguin: Build darwin-vz minimal kernel release assets"
+"${SCRIPT_DIR}/build-darwin-vz-minimal-kernel-release.sh" "${KERNEL_RELEASE_DIR}"
+
+echo "--- :package: Upload darwin-vz kernel release artifacts"
+tar -C "${REPO_ROOT}/release-extra" -czf "${REPO_ROOT}/release-extra/kernels.tar.gz" kernels
+buildkite-agent artifact upload "release-extra/kernels.tar.gz"
+buildkite-agent artifact upload "release-extra/kernels/*"

--- a/scripts/ci_darwin_vz_e2e_test.go
+++ b/scripts/ci_darwin_vz_e2e_test.go
@@ -232,10 +232,15 @@ func TestBuildkiteReleaseScriptPublishesGitHubRelease(t *testing.T) {
 		`fetch_secret CLEANROOM_GITHUB_RELEASE_TOKEN`,
 		`[[ -n "${BUILDKITE_TAG:-}" ]] || die "BUILDKITE_TAG is required for release publishing"`,
 		`buildkite-agent artifact download "release-extra/darwin_*.tar.gz"`,
+		`buildkite-agent artifact download "release-extra/kernels.tar.gz"`,
 		`tar -xzf "${archive_path}" -C "${RELEASE_EXTRA_DIR}"`,
+		`[[ -d "${RELEASE_EXTRA_DIR}/kernels" ]] || die "missing extracted kernel release directory: ${RELEASE_EXTRA_DIR}/kernels"`,
 		`GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -trimpath -ldflags "-s -w"`,
 		`GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -trimpath -ldflags "-s -w"`,
 		`goreleaser release --clean`,
+		`mapfile -t kernel_assets < <(find "${RELEASE_EXTRA_DIR}/kernels" -maxdepth 1 -type f | sort)`,
+		`extra_assets=("${pkg_assets[@]}" "${kernel_assets[@]}")`,
+		`for asset_path in "${extra_assets[@]}"; do`,
 		`"${GITHUB_API_BASE}/releases/tags/${BUILDKITE_TAG}"`,
 		`"${GITHUB_API_BASE}/releases/assets/${asset_id}"`,
 		`"${upload_url}?name=${asset_name}"`,
@@ -244,6 +249,55 @@ func TestBuildkiteReleaseScriptPublishesGitHubRelease(t *testing.T) {
 	} {
 		if !strings.Contains(script, needle) {
 			t.Fatalf("expected ci-buildkite-release.sh to contain %q", needle)
+		}
+	}
+}
+
+func TestBuildkiteDarwinVZKernelReleaseScriptBuildsArtifacts(t *testing.T) {
+	t.Helper()
+
+	content, err := os.ReadFile("ci-darwin-vz-kernel-release.sh")
+	if err != nil {
+		t.Fatalf("read ci-darwin-vz-kernel-release.sh: %v", err)
+	}
+
+	script := string(content)
+	for _, needle := range []string{
+		`KERNEL_RELEASE_DIR="${REPO_ROOT}/release-extra/kernels"`,
+		`"${SCRIPT_DIR}/build-darwin-vz-minimal-kernel-release.sh" "${KERNEL_RELEASE_DIR}"`,
+		`tar -C "${REPO_ROOT}/release-extra" -czf "${REPO_ROOT}/release-extra/kernels.tar.gz" kernels`,
+		`buildkite-agent artifact upload "release-extra/kernels.tar.gz"`,
+		`buildkite-agent artifact upload "release-extra/kernels/*"`,
+	} {
+		if !strings.Contains(script, needle) {
+			t.Fatalf("expected ci-darwin-vz-kernel-release.sh to contain %q", needle)
+		}
+	}
+}
+
+func TestDarwinVZMinimalKernelReleaseScriptPinsRootFSAssets(t *testing.T) {
+	t.Helper()
+
+	content, err := os.ReadFile("build-darwin-vz-minimal-kernel-release.sh")
+	if err != nil {
+		t.Fatalf("read build-darwin-vz-minimal-kernel-release.sh: %v", err)
+	}
+
+	script := string(content)
+	for _, needle := range []string{
+		`KERNEL_VERSION="${CLEANROOM_DARWIN_VZ_MINIMAL_KERNEL_VERSION:-6.1.155}"`,
+		`KERNEL_PROFILE="${CLEANROOM_DARWIN_VZ_MINIMAL_KERNEL_PROFILE:-rootfs}"`,
+		`release kernel profile must be rootfs`,
+		`release kernel arch must be arm64`,
+		`ASSET_BASE="${CLEANROOM_DARWIN_VZ_MINIMAL_KERNEL_ASSET_BASE:-cleanroom-darwin-vz-minimal-${KERNEL_PROFILE}-${KERNEL_ARCH}-linux-${KERNEL_VERSION}}"`,
+		`CLEANROOM_DARWIN_VZ_MINIMAL_KERNEL_DOCKER_IMAGE="${DOCKER_IMAGE}"`,
+		`CLEANROOM_DARWIN_VZ_MINIMAL_KERNEL_TARBALL_SHA256="${KERNEL_TARBALL_SHA256}"`,
+		`"manifest": os.environ["ASSET_BASE"] + ".manifest.json",`,
+		`"repository": os.environ["SOURCE_REPOSITORY"],`,
+		`"tag": os.environ["RELEASE_TAG"],`,
+	} {
+		if !strings.Contains(script, needle) {
+			t.Fatalf("expected build-darwin-vz-minimal-kernel-release.sh to contain %q", needle)
 		}
 	}
 }


### PR DESCRIPTION
Tagged releases should make the experimental `darwin-vz` minimal kernel available without requiring every developer to build it locally. This keeps `kernel_image` available for unreleased local experiments, while giving released and dev builds a repeatable managed path for the faster rootfs-profile kernel.

This publishes the kernel to the existing `buildkite/cleanroom` GitHub Release for the tag, alongside the normal Cleanroom archives and macOS packages. The tag pipeline now builds a rootfs-profile Apple Silicon kernel on Buildkite, uploads the generated files as Buildkite artifacts, and the release publisher attaches them as direct GitHub Release assets:

- `cleanroom-darwin-vz-minimal-rootfs-arm64-linux-<linux-version>-Image`
- `cleanroom-darwin-vz-minimal-rootfs-arm64-linux-<linux-version>-Image.config`
- `cleanroom-darwin-vz-minimal-rootfs-arm64-linux-<linux-version>-Image.sha256`
- `cleanroom-darwin-vz-minimal-rootfs-arm64-linux-<linux-version>.manifest.json`

The runtime resolver is manifest-driven rather than digest-pinned in code. Released Cleanroom builds resolve the manifest from their matching GitHub Release tag. Dev, dirty, and other non-release builds resolve the latest published Cleanroom release. A configured and accessible `backends.darwin-vz.kernel_image` still wins, so testing an unreleased local kernel remains explicit.

If a release manifest is not available yet, the `darwin-vz` managed resolver falls back to the older managed kernel asset instead of blocking local development on a just-added publishing flow.

Validation performed:

- `scripts/build-darwin-vz-minimal-kernel-release.sh "$tmpdir"`
- `mise exec -- go test ./internal/bootassets ./internal/cli ./internal/backend/darwinvz`
- `mise exec -- go test ./scripts`
- `mise run lint-shell`
- `git diff --check`
- `mise exec -- go test ./...`
