### PR TITLE
fix: Retry stalled image rootfs streams

### DIFF
--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -247,6 +247,7 @@ type ProvisionRequest struct {
 	SandboxID          string
 	Policy             *policy.CompiledPolicy
 	CacheOutputVolumes []CacheOutputVolumeSpec
+	Progress           ProvisionProgressFunc
 	FirecrackerConfig
 }
 

--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -486,6 +486,7 @@ func (a *Adapter) ProvisionSandbox(ctx context.Context, req backend.ProvisionReq
 	if req.Policy == nil {
 		return errors.New("missing compiled policy")
 	}
+	ctx = backend.ContextWithProvisionProgress(ctx, req.Progress)
 	return a.provisionSandbox(ctx, sandboxID, req.Policy, req.FirecrackerConfig, req.CacheOutputVolumes)
 }
 
@@ -2551,9 +2552,15 @@ func (a *Adapter) ensureImageArtifact(ctx context.Context, imageRef string) (ima
 		return imageArtifact{}, fmt.Errorf("initialise image manager: %w", err)
 	}
 
+	backend.ReportProvisionProgress(ctx, "resolving sandbox image rootfs...")
 	result, err := mgr.Ensure(ctx, trimmedRef)
 	if err != nil {
 		return imageArtifact{}, fmt.Errorf("resolve image %q: %w", trimmedRef, err)
+	}
+	if result.CacheHit {
+		backend.ReportProvisionProgress(ctx, "using cached sandbox image rootfs...")
+	} else {
+		backend.ReportProvisionProgress(ctx, "materialized sandbox image rootfs...")
 	}
 	return imageArtifact{
 		Ref:        result.Record.Ref,

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -322,6 +322,7 @@ func (a *Adapter) ProvisionSandbox(ctx context.Context, req backend.ProvisionReq
 	if req.Policy.HasStageScopedNetwork() {
 		return errors.New("firecracker backend does not support stage-scoped network policies yet")
 	}
+	ctx = backend.ContextWithProvisionProgress(ctx, req.Progress)
 
 	a.sandboxMu.Lock()
 	if a.sandboxes == nil {
@@ -1471,9 +1472,15 @@ func (a *Adapter) ensureImageArtifact(ctx context.Context, imageRef string) (ima
 		return imageArtifact{}, fmt.Errorf("initialise image manager: %w", err)
 	}
 
+	backend.ReportProvisionProgress(ctx, "resolving sandbox image rootfs...")
 	result, err := mgr.Ensure(ctx, trimmedRef)
 	if err != nil {
 		return imageArtifact{}, fmt.Errorf("resolve image %q: %w", trimmedRef, err)
+	}
+	if result.CacheHit {
+		backend.ReportProvisionProgress(ctx, "using cached sandbox image rootfs...")
+	} else {
+		backend.ReportProvisionProgress(ctx, "materialized sandbox image rootfs...")
 	}
 
 	return imageArtifact{

--- a/internal/backend/progress.go
+++ b/internal/backend/progress.go
@@ -1,0 +1,32 @@
+package backend
+
+import (
+	"context"
+	"strings"
+)
+
+// ProvisionProgressFunc receives short user-facing provisioning progress messages.
+type ProvisionProgressFunc func(message string)
+
+type provisionProgressContextKey struct{}
+
+// ContextWithProvisionProgress attaches request-scoped provisioning progress to ctx.
+func ContextWithProvisionProgress(ctx context.Context, progress ProvisionProgressFunc) context.Context {
+	if progress == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, provisionProgressContextKey{}, progress)
+}
+
+// ReportProvisionProgress emits a provisioning progress message when ctx carries a reporter.
+func ReportProvisionProgress(ctx context.Context, message string) {
+	message = strings.TrimSpace(message)
+	if message == "" {
+		return
+	}
+	progress, _ := ctx.Value(provisionProgressContextKey{}).(ProvisionProgressFunc)
+	if progress == nil {
+		return
+	}
+	progress(message)
+}

--- a/internal/cli/progress.go
+++ b/internal/cli/progress.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 	"time"
 )
@@ -12,6 +13,8 @@ var (
 	sandboxProgressTickInterval = 100 * time.Millisecond
 )
 
+const defaultSandboxProgressMessage = "Preparing sandbox (first use may take a bit)..."
+
 var sandboxProgressFrames = []string{"⣾ ", "⣽ ", "⣻ ", "⢿ ", "⡿ ", "⣟ ", "⣯ ", "⣷ "}
 
 type sandboxProgress struct {
@@ -20,6 +23,7 @@ type sandboxProgress struct {
 	useANSI    bool
 	shown      bool
 	suppressed bool
+	message    string
 }
 
 func (p *sandboxProgress) renderStart() bool {
@@ -33,7 +37,7 @@ func (p *sandboxProgress) renderStart() bool {
 	}
 	p.shown = true
 	if p.stderr != nil {
-		writeSandboxProgressStart(p.stderr)
+		writeSandboxProgressStart(p.stderr, p.messageLocked())
 	}
 	return true
 }
@@ -49,9 +53,28 @@ func (p *sandboxProgress) renderFrame(frame string, elapsed time.Duration) bool 
 	}
 	p.shown = true
 	if p.stderr != nil {
-		writeSandboxProgressFrame(p.stderr, frame, elapsed)
+		writeSandboxProgressFrameMessage(p.stderr, frame, p.messageLocked(), elapsed)
 	}
 	return true
+}
+
+func (p *sandboxProgress) setMessage(message string) {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.suppressed {
+		return
+	}
+	message = sanitizeSandboxProgressMessage(message)
+	if message == "" || message == p.message {
+		return
+	}
+	p.message = message
+	if p.shown && !p.useANSI && p.stderr != nil {
+		writeSandboxProgressStart(p.stderr, p.messageLocked())
+	}
 }
 
 func (p *sandboxProgress) suppress() {
@@ -76,6 +99,13 @@ func (p *sandboxProgress) wasShown() bool {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return p.shown
+}
+
+func (p *sandboxProgress) messageLocked() string {
+	if p == nil || p.message == "" {
+		return defaultSandboxProgressMessage
+	}
+	return p.message
 }
 
 func (p *sandboxProgress) complete(success bool, elapsed time.Duration) {
@@ -150,18 +180,26 @@ func withSandboxProgress(stderr *os.File, fn func(progress *sandboxProgress) err
 	return err
 }
 
-func writeSandboxProgressStart(stderr *os.File) {
+func writeSandboxProgressStart(stderr *os.File, messages ...string) {
 	if stderr == nil {
 		return
 	}
-	_, _ = fmt.Fprintln(stderr, "Preparing sandbox (first use may take a bit)...")
+	message := defaultSandboxProgressMessage
+	if len(messages) > 0 {
+		message = messages[0]
+	}
+	_, _ = fmt.Fprintln(stderr, sanitizeSandboxProgressMessage(message))
 }
 
 func writeSandboxProgressFrame(stderr *os.File, frame string, elapsed time.Duration) {
+	writeSandboxProgressFrameMessage(stderr, frame, defaultSandboxProgressMessage, elapsed)
+}
+
+func writeSandboxProgressFrameMessage(stderr *os.File, frame, message string, elapsed time.Duration) {
 	if stderr == nil {
 		return
 	}
-	_, _ = fmt.Fprintf(stderr, "\r\033[2K%s Preparing sandbox (first use may take a bit)... %s", frame, formatSandboxProgressDuration(elapsed))
+	_, _ = fmt.Fprintf(stderr, "\r\033[2K%s %s %s", frame, sanitizeSandboxProgressMessage(message), formatSandboxProgressDuration(elapsed))
 }
 
 func writeSandboxProgressComplete(stderr *os.File, success bool, elapsed time.Duration) {
@@ -193,4 +231,23 @@ func formatSandboxProgressDuration(elapsed time.Duration) string {
 		return elapsed.Round(10 * time.Millisecond).String()
 	}
 	return elapsed.Round(100 * time.Millisecond).String()
+}
+
+func sanitizeSandboxProgressMessage(message string) string {
+	message = strings.TrimSpace(message)
+	if message == "" {
+		return defaultSandboxProgressMessage
+	}
+	message = strings.ReplaceAll(message, "\r", " ")
+	message = strings.ReplaceAll(message, "\n", " ")
+	return strings.Join(strings.Fields(message), " ")
+}
+
+func sandboxProgressMessage(message string) string {
+	message = sanitizeSandboxProgressMessage(message)
+	lower := strings.ToLower(message)
+	if strings.Contains(lower, "sandbox image") || strings.Contains(lower, "rootfs") {
+		return message
+	}
+	return ""
 }

--- a/internal/cli/progress_test.go
+++ b/internal/cli/progress_test.go
@@ -180,6 +180,34 @@ func TestWithSandboxProgressSuppressAfterSpinnerKeepsStreamedOutput(t *testing.T
 	}
 }
 
+func TestWithSandboxProgressCanUpdateImageMessage(t *testing.T) {
+	forceSandboxProgressTTY(t)
+	t.Setenv("CLICOLOR_FORCE", "1")
+
+	output, err := captureSandboxProgressOutput(t, func(stderr *os.File) error {
+		return withSandboxProgress(stderr, func(progress *sandboxProgress) error {
+			progress.setMessage("resolving sandbox image rootfs...")
+			time.Sleep(25 * time.Millisecond)
+			return nil
+		})
+	})
+	if err != nil {
+		t.Fatalf("withSandboxProgress returned error: %v", err)
+	}
+	if !strings.Contains(output, "resolving sandbox image rootfs...") {
+		t.Fatalf("expected updated image progress message, got %q", output)
+	}
+}
+
+func TestSandboxProgressMessageKeepsGenericPhaseMessagesHidden(t *testing.T) {
+	if got := sandboxProgressMessage("provisioning sandbox"); got != "" {
+		t.Fatalf("expected generic provisioning message to remain hidden, got %q", got)
+	}
+	if got := sandboxProgressMessage("resolving sandbox image rootfs..."); got == "" {
+		t.Fatal("expected image/rootfs progress message to be visible")
+	}
+}
+
 func TestWriteSandboxProgressFrameClearsTheLine(t *testing.T) {
 	tmpDir := t.TempDir()
 	stderrPath := filepath.Join(tmpDir, "stderr.log")

--- a/internal/cli/sandbox.go
+++ b/internal/cli/sandbox.go
@@ -522,6 +522,9 @@ func createSandboxWithProgress(
 			event := stream.Msg()
 			switch payload := event.Payload.(type) {
 			case *cleanroomv1.CreateSandboxEvent_Message:
+				if message := sandboxProgressMessage(payload.Message); message != "" {
+					progress.setMessage(message)
+				}
 				continue
 			case *cleanroomv1.CreateSandboxEvent_Stdout:
 				if stderr != nil && len(payload.Stdout) > 0 {

--- a/internal/cli/sandbox_progress_integration_test.go
+++ b/internal/cli/sandbox_progress_integration_test.go
@@ -10,20 +10,50 @@ import (
 )
 
 type delayedPersistentAdapter struct {
-	provisionDelay time.Duration
-	runResult      backend.ExecutionResult
-	runStdout      string
-	runStderr      string
+	provisionDelay  time.Duration
+	progressMessage string
+	runResult       backend.ExecutionResult
+	runStdout       string
+	runStderr       string
 }
 
 func (a *delayedPersistentAdapter) Name() string { return "firecracker" }
 
-func (a *delayedPersistentAdapter) ProvisionSandbox(ctx context.Context, _ backend.ProvisionRequest) error {
+func (a *delayedPersistentAdapter) ProvisionSandbox(ctx context.Context, req backend.ProvisionRequest) error {
+	if req.Progress != nil && a.progressMessage != "" {
+		req.Progress(a.progressMessage)
+	}
 	select {
 	case <-time.After(a.provisionDelay):
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()
+	}
+}
+
+func TestSandboxCreateIntegrationShowsImageProgressMessages(t *testing.T) {
+	forceProgressTTY(t)
+
+	host, _ := startIntegrationServer(t, &delayedPersistentAdapter{
+		provisionDelay:  25 * time.Millisecond,
+		progressMessage: "resolving sandbox image rootfs...",
+	})
+	cwd := t.TempDir()
+
+	outcome := runSandboxCreateWithCapture(SandboxCreateCommand{
+		clientFlags: clientFlags{Host: host},
+	}, runtimeContext{
+		CWD:    cwd,
+		Loader: integrationLoader{},
+	})
+	if outcome.cause != nil {
+		t.Fatalf("capture failure: %v", outcome.cause)
+	}
+	if outcome.err != nil {
+		t.Fatalf("SandboxCreateCommand.Run returned error: %v", outcome.err)
+	}
+	if !strings.Contains(outcome.stderr, "resolving sandbox image rootfs...") {
+		t.Fatalf("expected image progress message in stderr, got %q", outcome.stderr)
 	}
 }
 

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -730,12 +730,19 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 		)
 	}
 	emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_PROVISION_SANDBOX, "provisioning sandbox")
+	var provisionProgress backend.ProvisionProgressFunc
+	if reporter != nil {
+		provisionProgress = func(message string) {
+			emitCreateSandboxMessage(reporter, cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_PROVISION_SANDBOX, message)
+		}
+	}
 	provisionStarted := s.clock().Now()
 	var provisionDuration time.Duration
 	if err := adapter.ProvisionSandbox(ctx, backend.ProvisionRequest{
 		SandboxID:          sandboxID,
 		Policy:             compiled,
 		CacheOutputVolumes: appendCacheOutputVolumeSpecs(dependencyCacheOutputVolumes, serviceCacheOutputVolumes),
+		Progress:           provisionProgress,
 		FirecrackerConfig:  firecrackerCfg,
 	}); err != nil {
 		provisionDuration = s.clock().Now().Sub(provisionStarted)

--- a/internal/imagemgr/imagemgr.go
+++ b/internal/imagemgr/imagemgr.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -23,6 +24,13 @@ import (
 )
 
 const defaultMkfsBinary = "mkfs.ext4"
+
+const (
+	defaultResolveAttempts       = 2
+	defaultRootFSStreamIdleLimit = 2 * time.Minute
+)
+
+var errRootFSStreamIdleTimeout = errors.New("image rootfs stream stalled")
 
 type OCIConfig struct {
 	Entrypoint   []string
@@ -57,17 +65,21 @@ type Options struct {
 	MkfsBinary     string
 	Now            func() time.Time
 
-	PullImage         func(context.Context, string) (io.ReadCloser, OCIConfig, error)
-	MaterializeRootFS func(context.Context, io.Reader, string) (int64, error)
+	PullImage               func(context.Context, string) (io.ReadCloser, OCIConfig, error)
+	MaterializeRootFS       func(context.Context, io.Reader, string) (int64, error)
+	ResolveAttempts         int
+	RootFSStreamIdleTimeout time.Duration
 }
 
 type Manager struct {
-	cacheDir       string
-	metadataDBPath string
-	mkfsBinary     string
-	now            func() time.Time
-	pullImage      func(context.Context, string) (io.ReadCloser, OCIConfig, error)
-	materialize    func(context.Context, io.Reader, string) (int64, error)
+	cacheDir                string
+	metadataDBPath          string
+	mkfsBinary              string
+	now                     func() time.Time
+	pullImage               func(context.Context, string) (io.ReadCloser, OCIConfig, error)
+	materialize             func(context.Context, io.Reader, string) (int64, error)
+	resolveAttempts         int
+	rootFSStreamIdleTimeout time.Duration
 
 	mu sync.Mutex
 }
@@ -112,10 +124,18 @@ func New(opts Options) (*Manager, error) {
 	}
 
 	manager := &Manager{
-		cacheDir:       cacheDir,
-		metadataDBPath: metadataDBPath,
-		mkfsBinary:     mkfsBinary,
-		now:            now,
+		cacheDir:                cacheDir,
+		metadataDBPath:          metadataDBPath,
+		mkfsBinary:              mkfsBinary,
+		now:                     now,
+		resolveAttempts:         defaultResolveAttempts,
+		rootFSStreamIdleTimeout: defaultRootFSStreamIdleLimit,
+	}
+	if opts.ResolveAttempts > 0 {
+		manager.resolveAttempts = opts.ResolveAttempts
+	}
+	if opts.RootFSStreamIdleTimeout > 0 {
+		manager.rootFSStreamIdleTimeout = opts.RootFSStreamIdleTimeout
 	}
 	if opts.PullImage != nil {
 		manager.pullImage = opts.PullImage
@@ -171,29 +191,64 @@ func (m *Manager) Ensure(ctx context.Context, ref string) (EnsureResult, error) 
 		}
 	}
 
-	tarStream, config, err := m.pullImage(ctx, parsedRef.Original)
-	if err != nil {
-		return EnsureResult{}, err
-	}
-	defer tarStream.Close()
-	if err := ValidateImagePlatformForHost(config.OS, config.Architecture, runtime.GOARCH); err != nil {
-		return EnsureResult{}, fmt.Errorf("image %q platform is incompatible: %w", parsedRef.Original, err)
-	}
+	var lastErr error
+	for attempt := 1; attempt <= m.resolveAttempts; attempt++ {
+		tarStream, config, err := m.pullImage(ctx, parsedRef.Original)
+		if err != nil {
+			return EnsureResult{}, err
+		}
+		if tarStream == nil {
+			return EnsureResult{}, fmt.Errorf("pull image %q returned nil rootfs stream", parsedRef.Original)
+		}
+		rootFSStream := m.withRootFSStreamIdleTimeout(tarStream)
+		if err := ValidateImagePlatformForHost(config.OS, config.Architecture, runtime.GOARCH); err != nil {
+			_ = rootFSStream.Close()
+			return EnsureResult{}, fmt.Errorf("image %q platform is incompatible: %w", parsedRef.Original, err)
+		}
 
-	record, err = m.persistFromTarStream(ctx, persistFromTarRequest{
-		Ref:        parsedRef.Original,
-		Digest:     parsedRef.Digest(),
-		TarStream:  tarStream,
-		OCIConfig:  config,
-		Source:     "registry",
-		CreatedAt:  now,
-		LastUsedAt: now,
-	})
-	if err != nil {
-		return EnsureResult{}, err
+		record, err = m.persistFromTarStream(ctx, persistFromTarRequest{
+			Ref:        parsedRef.Original,
+			Digest:     parsedRef.Digest(),
+			TarStream:  rootFSStream,
+			OCIConfig:  config,
+			Source:     "registry",
+			CreatedAt:  now,
+			LastUsedAt: now,
+		})
+		_ = rootFSStream.Close()
+		if err == nil {
+			return EnsureResult{Record: record, CacheHit: false}, nil
+		}
+		lastErr = err
+		if !m.shouldRetryResolve(ctx, err) {
+			return EnsureResult{}, err
+		}
+		if attempt >= m.resolveAttempts {
+			return EnsureResult{}, fmt.Errorf("resolve image %q after %d attempts: %w", parsedRef.Original, m.resolveAttempts, err)
+		}
+	}
+	if lastErr != nil {
+		return EnsureResult{}, fmt.Errorf("resolve image %q after %d attempts: %w", parsedRef.Original, m.resolveAttempts, lastErr)
 	}
 
 	return EnsureResult{Record: record, CacheHit: false}, nil
+}
+
+func (m *Manager) withRootFSStreamIdleTimeout(stream io.ReadCloser) io.ReadCloser {
+	if stream == nil || m.rootFSStreamIdleTimeout <= 0 {
+		return stream
+	}
+	return &rootFSStreamIdleTimeoutReadCloser{
+		stream:  stream,
+		timeout: m.rootFSStreamIdleTimeout,
+	}
+}
+
+func (m *Manager) shouldRetryResolve(ctx context.Context, err error) bool {
+	if err == nil || ctx.Err() != nil {
+		return false
+	}
+	return errors.Is(err, errRootFSStreamIdleTimeout)
 }
 
 func (m *Manager) validateCachedRecordPlatform(ctx context.Context, parsedRef ociref.DigestReference, record *Record) error {

--- a/internal/imagemgr/imagemgr_test.go
+++ b/internal/imagemgr/imagemgr_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -132,6 +133,60 @@ func TestEnsureRejectsIncompatibleImagePlatformFromCache(t *testing.T) {
 	}
 }
 
+func TestEnsureRetriesStalledRootFSStream(t *testing.T) {
+	t.Parallel()
+
+	cacheDir := filepath.Join(t.TempDir(), "cache")
+	dbPath := filepath.Join(t.TempDir(), "state", "metadata.db")
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		t.Fatalf("create state dir: %v", err)
+	}
+
+	pulls := 0
+	manager, err := New(Options{
+		CacheDir:                cacheDir,
+		MetadataDBPath:          dbPath,
+		ResolveAttempts:         2,
+		RootFSStreamIdleTimeout: 5 * time.Millisecond,
+		PullImage: func(_ context.Context, _ string) (io.ReadCloser, OCIConfig, error) {
+			pulls++
+			if pulls == 1 {
+				return newBlockingReadCloser(), OCIConfig{
+					OS:           "linux",
+					Architecture: NormalizePlatformArch(runtime.GOARCH),
+				}, nil
+			}
+			return io.NopCloser(bytes.NewReader(testRootFSTar(t))), OCIConfig{
+				OS:           "linux",
+				Architecture: NormalizePlatformArch(runtime.GOARCH),
+			}, nil
+		},
+		MaterializeRootFS: func(_ context.Context, stream io.Reader, outputPath string) (int64, error) {
+			if _, err := io.Copy(io.Discard, stream); err != nil {
+				return 0, err
+			}
+			if err := os.WriteFile(outputPath, []byte("fake-ext4"), 0o644); err != nil {
+				return 0, err
+			}
+			return int64(len("fake-ext4")), nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("create manager: %v", err)
+	}
+
+	result, err := manager.Ensure(context.Background(), testImageRef)
+	if err != nil {
+		t.Fatalf("Ensure returned error after retry: %v", err)
+	}
+	if result.CacheHit {
+		t.Fatal("expected retry to materialize a fresh image")
+	}
+	if pulls != 2 {
+		t.Fatalf("expected stalled stream to be retried once, got %d pulls", pulls)
+	}
+}
+
 func TestEnsureUsesLegacyCacheWhenPlatformBackfillUnavailable(t *testing.T) {
 	t.Parallel()
 
@@ -164,6 +219,27 @@ func TestEnsureUsesLegacyCacheWhenPlatformBackfillUnavailable(t *testing.T) {
 	if !result.CacheHit {
 		t.Fatal("expected Ensure to return cache hit for existing rootfs artifact")
 	}
+}
+
+type blockingReadCloser struct {
+	closed chan struct{}
+	once   sync.Once
+}
+
+func newBlockingReadCloser() *blockingReadCloser {
+	return &blockingReadCloser{closed: make(chan struct{})}
+}
+
+func (r *blockingReadCloser) Read([]byte) (int, error) {
+	<-r.closed
+	return 0, os.ErrClosed
+}
+
+func (r *blockingReadCloser) Close() error {
+	r.once.Do(func() {
+		close(r.closed)
+	})
+	return nil
 }
 
 func TestImportAndRemoveByDigestSelector(t *testing.T) {

--- a/internal/imagemgr/stream_timeout.go
+++ b/internal/imagemgr/stream_timeout.go
@@ -1,0 +1,58 @@
+package imagemgr
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type rootFSStreamIdleTimeoutReadCloser struct {
+	stream  io.ReadCloser
+	timeout time.Duration
+
+	closeOnce sync.Once
+	closeErr  error
+	timedOut  atomic.Bool
+}
+
+func (r *rootFSStreamIdleTimeoutReadCloser) Read(p []byte) (int, error) {
+	if r == nil || r.stream == nil {
+		return 0, io.ErrClosedPipe
+	}
+	if r.timeout <= 0 {
+		return r.stream.Read(p)
+	}
+
+	timerDone := make(chan struct{})
+	timer := time.AfterFunc(r.timeout, func() {
+		r.timedOut.Store(true)
+		_ = r.Close()
+		close(timerDone)
+	})
+	n, err := r.stream.Read(p)
+	if !timer.Stop() {
+		<-timerDone
+	}
+	if r.timedOut.Load() {
+		timeoutErr := fmt.Errorf("%w: no data received for %s", errRootFSStreamIdleTimeout, r.timeout)
+		if err == nil {
+			err = timeoutErr
+		} else {
+			err = errors.Join(timeoutErr, err)
+		}
+	}
+	return n, err
+}
+
+func (r *rootFSStreamIdleTimeoutReadCloser) Close() error {
+	if r == nil || r.stream == nil {
+		return nil
+	}
+	r.closeOnce.Do(func() {
+		r.closeErr = r.stream.Close()
+	})
+	return r.closeErr
+}


### PR DESCRIPTION
A stalled GHCR/CDN blob read can leave sandbox creation sitting behind the generic `Preparing sandbox` spinner indefinitely. The darwin-vz Docker example hang showed `cleanroom serve` blocked before VM launch while materializing the Docker image rootfs, with no visible subphase in the CLI.

This change bounds registry rootfs stream idleness and retries one stalled image resolve before failing. It also passes provisioning progress through the backend path so image/rootfs-specific messages can update the CLI spinner, while generic create-sandbox phase chatter remains hidden.

Developer impact:

- Sandbox creation should recover from a single stalled image rootfs stream instead of hanging forever.
- If image resolution is slow, the spinner can now show messages like `resolving sandbox image rootfs...`.
- Existing bootstrap stdout/stderr behavior is unchanged.

Validation:

```sh
mise trust
mise exec -- go test ./...
```