### PR TITLE
ci: Limit shellcheck tool install

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,6 +3,7 @@ steps:
     plugins:
       - github.com/lox/mise-buildkite-plugin#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
           version: "2026.5.12"
+          install_args: shellcheck
     command: shellcheck -x scripts/base-image-tag.sh scripts/cleanroom-root-helper.sh scripts/benchmark-tti.sh scripts/build-go.sh scripts/install-go.sh scripts/install.sh scripts/install-global.sh scripts/package-darwin-vz-helper.sh scripts/release.sh scripts/e2e-observability.sh scripts/ci-with-host-lock.sh scripts/ci-example-smoke.sh scripts/ci-examples-firecracker.sh scripts/ci-examples-darwin-vz.sh scripts/ci-cleanroom-e2e.sh scripts/ci-darwin-vz-e2e.sh scripts/ci-darwin-vz-filehandle-e2e.sh scripts/build-macos-release-pkg.sh scripts/notarize-macos-package.sh scripts/ci-macos-release-pkg.sh scripts/build-darwin-vz-minimal-kernel-release.sh scripts/ci-darwin-vz-kernel-release.sh scripts/ci-buildkite-release.sh
     cache:
       paths:

--- a/scripts/buildkite_pipeline_test.go
+++ b/scripts/buildkite_pipeline_test.go
@@ -29,6 +29,7 @@ func TestBuildkitePipelineUsesSetupGoForGoSteps(t *testing.T) {
     plugins:
       - ` + miseBuildkitePluginRef + `:
           version: "` + miseBuildkitePluginVersion + `"
+          install_args: shellcheck
     command: shellcheck`,
 		`- label: ":test_tube: Test (Linux)"
     plugins:


### PR DESCRIPTION
Main branch CI started failing before it reached tests because the Shellcheck step installed every tool from mise.toml, including release-only tools such as svu. That made a Shellcheck-only job depend on unrelated release tool downloads and attestation checks.

This scopes the mise plugin install for the Shellcheck step to `shellcheck` only, while leaving the rest of the pipeline unchanged.

Validation:
- git diff --check origin/main...HEAD
- MISE_TRUSTED_CONFIG_PATHS=$PWD mise x go@1.26.2 -- go test ./scripts
- MISE_TRUSTED_CONFIG_PATHS=$PWD mise x shellcheck@0.11.0 -- shellcheck -x scripts/base-image-tag.sh scripts/cleanroom-root-helper.sh scripts/benchmark-tti.sh scripts/build-go.sh scripts/install-go.sh scripts/install.sh scripts/install-global.sh scripts/package-darwin-vz-helper.sh scripts/release.sh scripts/e2e-observability.sh scripts/ci-example-smoke.sh scripts/ci-examples-firecracker.sh scripts/ci-examples-darwin-vz.sh scripts/ci-cleanroom-e2e.sh scripts/ci-darwin-vz-e2e.sh scripts/ci-darwin-vz-filehandle-e2e.sh scripts/build-macos-release-pkg.sh scripts/notarize-macos-package.sh scripts/ci-macos-release-pkg.sh scripts/build-darwin-vz-minimal-kernel-release.sh scripts/ci-darwin-vz-kernel-release.sh scripts/ci-buildkite-release.sh