### PR TITLE
ci: Fix mise and macOS Docker CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,6 +2,7 @@ steps:
   - label: ":shell: Shellcheck"
     plugins:
       - github.com/lox/mise-buildkite-plugin#a172963b3d34e98601e2a65c7dd08211fb49b7f0:
+          version: "2026.5.12"
     command: shellcheck -x scripts/base-image-tag.sh scripts/cleanroom-root-helper.sh scripts/benchmark-tti.sh scripts/build-go.sh scripts/install-go.sh scripts/install.sh scripts/install-global.sh scripts/package-darwin-vz-helper.sh scripts/release.sh scripts/e2e-observability.sh scripts/ci-example-smoke.sh scripts/ci-examples-firecracker.sh scripts/ci-examples-darwin-vz.sh scripts/ci-cleanroom-e2e.sh scripts/ci-darwin-vz-e2e.sh scripts/ci-darwin-vz-filehandle-e2e.sh scripts/build-macos-release-pkg.sh scripts/notarize-macos-package.sh scripts/ci-macos-release-pkg.sh scripts/build-darwin-vz-minimal-kernel-release.sh scripts/ci-darwin-vz-kernel-release.sh scripts/ci-buildkite-release.sh
     cache:
       paths:
@@ -115,6 +116,7 @@ steps:
     if: build.tag != null
     plugins:
       - github.com/lox/mise-buildkite-plugin#a172963b3d34e98601e2a65c7dd08211fb49b7f0:
+          version: "2026.5.12"
     command: scripts/ci-buildkite-release.sh
     cache:
       paths:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 steps:
   - label: ":shell: Shellcheck"
     plugins:
-      - github.com/lox/mise-buildkite-plugin#a172963b3d34e98601e2a65c7dd08211fb49b7f0:
+      - github.com/lox/mise-buildkite-plugin#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
           version: "2026.5.12"
     command: shellcheck -x scripts/base-image-tag.sh scripts/cleanroom-root-helper.sh scripts/benchmark-tti.sh scripts/build-go.sh scripts/install-go.sh scripts/install.sh scripts/install-global.sh scripts/package-darwin-vz-helper.sh scripts/release.sh scripts/e2e-observability.sh scripts/ci-example-smoke.sh scripts/ci-examples-firecracker.sh scripts/ci-examples-darwin-vz.sh scripts/ci-cleanroom-e2e.sh scripts/ci-darwin-vz-e2e.sh scripts/ci-darwin-vz-filehandle-e2e.sh scripts/build-macos-release-pkg.sh scripts/notarize-macos-package.sh scripts/ci-macos-release-pkg.sh scripts/build-darwin-vz-minimal-kernel-release.sh scripts/ci-darwin-vz-kernel-release.sh scripts/ci-buildkite-release.sh
     cache:
@@ -115,7 +115,7 @@ steps:
   - label: ":rocket: Publish release"
     if: build.tag != null
     plugins:
-      - github.com/lox/mise-buildkite-plugin#a172963b3d34e98601e2a65c7dd08211fb49b7f0:
+      - github.com/lox/mise-buildkite-plugin#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
           version: "2026.5.12"
     command: scripts/ci-buildkite-release.sh
     cache:

--- a/images/Dockerfile.base-image
+++ b/images/Dockerfile.base-image
@@ -1,6 +1,6 @@
 FROM alpine:3.22
 
-ARG MISE_VERSION=v2026.4.5
+ARG MISE_VERSION=v2026.5.12
 
 RUN apk add --no-cache \
   bash \

--- a/images/Dockerfile.base-image-agents
+++ b/images/Dockerfile.base-image-agents
@@ -1,6 +1,6 @@
 FROM alpine:3.22
 
-ARG MISE_VERSION=v2026.4.5
+ARG MISE_VERSION=v2026.5.12
 # renovate: datasource=npm depName=@openai/codex
 ARG CODEX_VERSION=0.106.0
 # renovate: datasource=npm depName=@anthropic-ai/claude-code

--- a/images/Dockerfile.base-image-debian
+++ b/images/Dockerfile.base-image-debian
@@ -1,6 +1,6 @@
 FROM debian:bookworm-slim
 
-ARG MISE_VERSION=v2026.4.5
+ARG MISE_VERSION=v2026.5.12
 
 RUN apt-get update \
     && apt-get install --yes --no-install-recommends \

--- a/images/Dockerfile.base-image-debian-agents
+++ b/images/Dockerfile.base-image-debian-agents
@@ -1,6 +1,6 @@
 FROM node:22-bookworm-slim
 
-ARG MISE_VERSION=v2026.4.5
+ARG MISE_VERSION=v2026.5.12
 # renovate: datasource=npm depName=@openai/codex
 ARG CODEX_VERSION=0.106.0
 # renovate: datasource=npm depName=@anthropic-ai/claude-code

--- a/images/Dockerfile.base-image-debian-docker
+++ b/images/Dockerfile.base-image-debian-docker
@@ -1,6 +1,6 @@
 FROM debian:bookworm-slim
 
-ARG MISE_VERSION=v2026.4.5
+ARG MISE_VERSION=v2026.5.12
 
 RUN apt-get update \
     && apt-get install --yes --no-install-recommends \

--- a/images/Dockerfile.base-image-debian-ruby
+++ b/images/Dockerfile.base-image-debian-ruby
@@ -1,6 +1,6 @@
 FROM ruby:3.4.9-slim-bookworm
 
-ARG MISE_VERSION=v2026.4.5
+ARG MISE_VERSION=v2026.5.12
 
 RUN apt-get update \
     && apt-get install --yes --no-install-recommends \

--- a/images/Dockerfile.base-image-docker
+++ b/images/Dockerfile.base-image-docker
@@ -1,6 +1,6 @@
 FROM alpine:3.22
 
-ARG MISE_VERSION=v2026.4.5
+ARG MISE_VERSION=v2026.5.12
 
 RUN apk add --no-cache \
   bash \

--- a/images/dockerfiles_test.go
+++ b/images/dockerfiles_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-const expectedMiseVersion = "v2026.4.5"
+const expectedMiseVersion = "v2026.5.12"
 const expectedPICodingAgentVersion = "0.52.9"
 
 func publishedBaseDockerfiles() []string {

--- a/scripts/buildkite_pipeline_test.go
+++ b/scripts/buildkite_pipeline_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 const miseBuildkitePluginRef = "github.com/lox/mise-buildkite-plugin#a172963b3d34e98601e2a65c7dd08211fb49b7f0"
+const miseBuildkitePluginVersion = "2026.5.12"
 const setupGoBuildkitePluginRef = "github.com/buildkite-plugins/setup-go-buildkite-plugin#daa7af945245588f85b76ba7fe0a9af3d87dbf91"
 
 func TestBuildkitePipelineUsesSetupGoForGoSteps(t *testing.T) {
@@ -27,6 +28,7 @@ func TestBuildkitePipelineUsesSetupGoForGoSteps(t *testing.T) {
 		`- label: ":shell: Shellcheck"
     plugins:
       - ` + miseBuildkitePluginRef + `:
+          version: "` + miseBuildkitePluginVersion + `"
     command: shellcheck`,
 		`- label: ":test_tube: Test (Linux)"
     plugins:
@@ -70,6 +72,7 @@ func TestBuildkitePipelineUsesSetupGoForGoSteps(t *testing.T) {
     if: build.tag != null
     plugins:
       - ` + miseBuildkitePluginRef + `:
+          version: "` + miseBuildkitePluginVersion + `"
     command: scripts/ci-buildkite-release.sh`,
 	} {
 		if !strings.Contains(pipeline, snippet) {

--- a/scripts/buildkite_pipeline_test.go
+++ b/scripts/buildkite_pipeline_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-const miseBuildkitePluginRef = "github.com/lox/mise-buildkite-plugin#a172963b3d34e98601e2a65c7dd08211fb49b7f0"
+const miseBuildkitePluginRef = "github.com/lox/mise-buildkite-plugin#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2"
 const miseBuildkitePluginVersion = "2026.5.12"
 const setupGoBuildkitePluginRef = "github.com/buildkite-plugins/setup-go-buildkite-plugin#daa7af945245588f85b76ba7fe0a9af3d87dbf91"
 

--- a/scripts/ci-examples-darwin-vz.sh
+++ b/scripts/ci-examples-darwin-vz.sh
@@ -4,6 +4,37 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 DARWIN_VZ_KERNEL_IMAGE="${CLEANROOM_DARWIN_VZ_KERNEL_IMAGE:-}"
+DARWIN_VZ_DOCKER_KERNEL_URL="${CLEANROOM_DARWIN_VZ_DOCKER_KERNEL_URL:-https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/v1.14/aarch64/vmlinux-6.1.155}"
+DARWIN_VZ_DOCKER_KERNEL_SHA256="${CLEANROOM_DARWIN_VZ_DOCKER_KERNEL_SHA256:-61baeae1ac6197be4fc5c71fa78df266acdc33c54570290d2f611c2b42c105be}"
+DARWIN_VZ_DOCKER_KERNEL_PATH="${CLEANROOM_DARWIN_VZ_DOCKER_KERNEL_PATH:-$HOME/.cache/cleanroom/ci-kernels/darwin-vz-docker-vmlinux-6.1.155}"
+
+ensure_darwin_vz_docker_kernel() {
+  local kernel_path="$DARWIN_VZ_DOCKER_KERNEL_PATH"
+  local tmp_kernel
+
+  mkdir -p "$(dirname "$kernel_path")"
+
+  if [[ -f "$kernel_path" ]]; then
+    if printf '%s  %s\n' "$DARWIN_VZ_DOCKER_KERNEL_SHA256" "$kernel_path" | shasum -a 256 -c - >/dev/null 2>&1; then
+      printf '%s\n' "$kernel_path"
+      return 0
+    fi
+    rm -f "$kernel_path"
+  fi
+
+  tmp_kernel="${kernel_path}.tmp.$$"
+  echo "--- :penguin: Download cgroup-capable darwin-vz Docker kernel" >&2
+  if ! curl -fsSL "$DARWIN_VZ_DOCKER_KERNEL_URL" -o "$tmp_kernel"; then
+    rm -f "$tmp_kernel"
+    return 1
+  fi
+  if ! printf '%s  %s\n' "$DARWIN_VZ_DOCKER_KERNEL_SHA256" "$tmp_kernel" | shasum -a 256 -c - >/dev/null; then
+    rm -f "$tmp_kernel"
+    return 1
+  fi
+  mv "$tmp_kernel" "$kernel_path"
+  printf '%s\n' "$kernel_path"
+}
 
 echo "--- :hammer: Building binaries"
 scripts/build-go.sh
@@ -43,6 +74,9 @@ export XDG_DATA_HOME="$tmpdir/d"
 export CLEANROOM_DARWIN_VZ_HELPER="$helper_path"
 
 mkdir -p "$XDG_CONFIG_HOME" "$XDG_CACHE_HOME" "$XDG_STATE_HOME" "$XDG_RUNTIME_DIR" "$XDG_DATA_HOME"
+if [[ -z "$DARWIN_VZ_KERNEL_IMAGE" ]]; then
+  DARWIN_VZ_KERNEL_IMAGE="$(ensure_darwin_vz_docker_kernel)"
+fi
 mkdir -p "$XDG_CONFIG_HOME/cleanroom"
 cat > "$XDG_CONFIG_HOME/cleanroom/config.yaml" <<EOF
 default_backend: darwin-vz

--- a/scripts/ci_darwin_vz_e2e_test.go
+++ b/scripts/ci_darwin_vz_e2e_test.go
@@ -111,6 +111,29 @@ func TestCiDarwinVZFileHandleE2EUsesAllowlistPolicy(t *testing.T) {
 	}
 }
 
+func TestCiExamplesDarwinVZUsesCgroupCapableKernelForDockerSmoke(t *testing.T) {
+	t.Helper()
+
+	content, err := os.ReadFile("ci-examples-darwin-vz.sh")
+	if err != nil {
+		t.Fatalf("read ci-examples-darwin-vz.sh: %v", err)
+	}
+
+	script := string(content)
+	for _, needle := range []string{
+		"DARWIN_VZ_DOCKER_KERNEL_URL",
+		"DARWIN_VZ_DOCKER_KERNEL_SHA256",
+		"ensure_darwin_vz_docker_kernel",
+		"Download cgroup-capable darwin-vz Docker kernel",
+		`DARWIN_VZ_KERNEL_IMAGE="$(ensure_darwin_vz_docker_kernel)"`,
+		`echo "    kernel_image: $DARWIN_VZ_KERNEL_IMAGE" >> "$XDG_CONFIG_HOME/cleanroom/config.yaml"`,
+	} {
+		if !strings.Contains(script, needle) {
+			t.Fatalf("expected ci-examples-darwin-vz.sh to contain %q", needle)
+		}
+	}
+}
+
 func TestBuildDarwinVZHelperUsesSharedPackager(t *testing.T) {
 	t.Helper()
 


### PR DESCRIPTION
Cleanroom base images and Buildkite release/shellcheck setup paths were using older `mise` versions that fail to install the repo-pinned `svu@3.4.1`. The failure comes from older mise/Aqua verifier behavior expecting GitHub artifact attestations that the `svu` 3.4.1 tarballs do not expose.

This bumps the published Alpine and Debian base-image `MISE_VERSION` pin to `v2026.5.12`, pins the Buildkite mise plugin steps to `2026.5.12`, and moves those steps to the current plugin installer commit. That plugin path downloads the requested mise tarball directly when the hosted cache has an older binary, avoiding the `mise self-update` GitHub API path that hit 403s in CI.

The follow-up Buildkite run also exposed a macOS examples failure after `v0.8.0` became the latest Cleanroom release: the managed darwin-vz rootfs-profile release kernel has `CONFIG_CGROUPS` disabled, but the examples smoke starts guest Docker. The macOS examples script now uses the known cgroup-capable 6.1.155 kernel for that Docker smoke path while still allowing `CLEANROOM_DARWIN_VZ_KERNEL_IMAGE` to override it.

Example mise failure before this bump:

```text
mise ERROR Failed to install aqua:caarlos0/svu@3.4.1: GitHub artifact attestations verification failed: No attestations found
```

Validation performed:

- `mise exec -- go test ./scripts ./images`
- `mise exec -- go test ./scripts`
- `mise exec -- go test ./images`
- `mise run lint-shell`
- `bash -n scripts/ci-examples-darwin-vz.sh`
- `git diff --check`
- `mise --no-config install svu@3.4.1`
- local pinned-plugin hook smoke at `a5845c5082d3a4fe36dd77ae74973dfc86fc91a2` with `BUILDKITE_PLUGIN_MISE_VERSION=2026.5.12`
- `docker build -f images/Dockerfile.base-image-debian -t cleanroom-base:debian-mise-2026.5.12-test .`
- `docker build -f images/Dockerfile.base-image -t cleanroom-base:alpine-mise-2026.5.12-test .`