### PR TITLE
fix: Reuse image rootfs cache without metadata

### DIFF
--- a/internal/imagemgr/imagemgr.go
+++ b/internal/imagemgr/imagemgr.go
@@ -28,6 +28,7 @@ const defaultMkfsBinary = "mkfs.ext4"
 const (
 	defaultResolveAttempts       = 2
 	defaultRootFSStreamIdleLimit = 2 * time.Minute
+	defaultResolveAttemptTimeout = 10 * time.Minute
 )
 
 var errRootFSStreamIdleTimeout = errors.New("image rootfs stream stalled")
@@ -68,6 +69,7 @@ type Options struct {
 	PullImage               func(context.Context, string) (io.ReadCloser, OCIConfig, error)
 	MaterializeRootFS       func(context.Context, io.Reader, string) (int64, error)
 	ResolveAttempts         int
+	ResolveAttemptTimeout   time.Duration
 	RootFSStreamIdleTimeout time.Duration
 }
 
@@ -79,6 +81,7 @@ type Manager struct {
 	pullImage               func(context.Context, string) (io.ReadCloser, OCIConfig, error)
 	materialize             func(context.Context, io.Reader, string) (int64, error)
 	resolveAttempts         int
+	resolveAttemptTimeout   time.Duration
 	rootFSStreamIdleTimeout time.Duration
 
 	mu sync.Mutex
@@ -129,10 +132,14 @@ func New(opts Options) (*Manager, error) {
 		mkfsBinary:              mkfsBinary,
 		now:                     now,
 		resolveAttempts:         defaultResolveAttempts,
+		resolveAttemptTimeout:   defaultResolveAttemptTimeout,
 		rootFSStreamIdleTimeout: defaultRootFSStreamIdleLimit,
 	}
 	if opts.ResolveAttempts > 0 {
 		manager.resolveAttempts = opts.ResolveAttempts
+	}
+	if opts.ResolveAttemptTimeout > 0 {
+		manager.resolveAttemptTimeout = opts.ResolveAttemptTimeout
 	}
 	if opts.RootFSStreamIdleTimeout > 0 {
 		manager.rootFSStreamIdleTimeout = opts.RootFSStreamIdleTimeout
@@ -191,18 +198,35 @@ func (m *Manager) Ensure(ctx context.Context, ref string) (EnsureResult, error) 
 		}
 	}
 
+	if record, found, err := m.recoverDigestCacheFile(ctx, parsedRef.Original, parsedRef.Digest(), now); err != nil {
+		return EnsureResult{}, err
+	} else if found {
+		return EnsureResult{Record: record, CacheHit: true}, nil
+	}
+
 	var lastErr error
 	for attempt := 1; attempt <= m.resolveAttempts; attempt++ {
-		tarStream, config, err := m.pullImage(ctx, parsedRef.Original)
+		attemptCtx, cancelAttempt := m.resolveAttemptContext(ctx)
+		tarStream, config, err := m.pullImage(attemptCtx, parsedRef.Original)
 		if err != nil {
-			return EnsureResult{}, err
+			cancelAttempt()
+			lastErr = err
+			if !m.shouldRetryResolve(ctx, err) {
+				return EnsureResult{}, err
+			}
+			if attempt >= m.resolveAttempts {
+				return EnsureResult{}, fmt.Errorf("resolve image %q after %d attempts: %w", parsedRef.Original, m.resolveAttempts, err)
+			}
+			continue
 		}
 		if tarStream == nil {
+			cancelAttempt()
 			return EnsureResult{}, fmt.Errorf("pull image %q returned nil rootfs stream", parsedRef.Original)
 		}
 		rootFSStream := m.withRootFSStreamIdleTimeout(tarStream)
 		if err := ValidateImagePlatformForHost(config.OS, config.Architecture, runtime.GOARCH); err != nil {
 			_ = rootFSStream.Close()
+			cancelAttempt()
 			return EnsureResult{}, fmt.Errorf("image %q platform is incompatible: %w", parsedRef.Original, err)
 		}
 
@@ -216,6 +240,7 @@ func (m *Manager) Ensure(ctx context.Context, ref string) (EnsureResult, error) 
 			LastUsedAt: now,
 		})
 		_ = rootFSStream.Close()
+		cancelAttempt()
 		if err == nil {
 			return EnsureResult{Record: record, CacheHit: false}, nil
 		}
@@ -234,6 +259,48 @@ func (m *Manager) Ensure(ctx context.Context, ref string) (EnsureResult, error) 
 	return EnsureResult{Record: record, CacheHit: false}, nil
 }
 
+func (m *Manager) resolveAttemptContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if m.resolveAttemptTimeout <= 0 {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, m.resolveAttemptTimeout)
+}
+
+func (m *Manager) recoverDigestCacheFile(ctx context.Context, ref, digest string, now time.Time) (Record, bool, error) {
+	rootFSPath := m.cachedRootFSPath(digest)
+	info, err := os.Stat(rootFSPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return Record{}, false, nil
+		}
+		return Record{}, false, fmt.Errorf("stat cached rootfs %q: %w", rootFSPath, err)
+	}
+	if info.IsDir() {
+		return Record{}, false, fmt.Errorf("cached rootfs %q is a directory", rootFSPath)
+	}
+
+	record := Record{
+		Digest:     digest,
+		Ref:        ref,
+		RootFSPath: rootFSPath,
+		SizeBytes:  info.Size(),
+		CreatedAt:  now,
+		LastUsedAt: now,
+		Source:     "cache-file",
+		OCIConfig: OCIConfig{
+			OS:           "linux",
+			Architecture: NormalizePlatformArch(runtime.GOARCH),
+		},
+	}
+	if err := ValidateImagePlatformForHost(record.OCIConfig.OS, record.OCIConfig.Architecture, runtime.GOARCH); err != nil {
+		return Record{}, false, err
+	}
+	if err := m.upsertRecord(ctx, record); err != nil {
+		return Record{}, false, fmt.Errorf("recover cached image metadata for %s: %w", digest, err)
+	}
+	return record, true, nil
+}
+
 func (m *Manager) withRootFSStreamIdleTimeout(stream io.ReadCloser) io.ReadCloser {
 	if stream == nil || m.rootFSStreamIdleTimeout <= 0 {
 		return stream
@@ -248,7 +315,7 @@ func (m *Manager) shouldRetryResolve(ctx context.Context, err error) bool {
 	if err == nil || ctx.Err() != nil {
 		return false
 	}
-	return errors.Is(err, errRootFSStreamIdleTimeout)
+	return errors.Is(err, errRootFSStreamIdleTimeout) || errors.Is(err, context.DeadlineExceeded)
 }
 
 func (m *Manager) validateCachedRecordPlatform(ctx context.Context, parsedRef ociref.DigestReference, record *Record) error {
@@ -256,7 +323,9 @@ func (m *Manager) validateCachedRecordPlatform(ctx context.Context, parsedRef oc
 		return nil
 	}
 	if needsPlatformMetadata(record.OCIConfig) && strings.EqualFold(strings.TrimSpace(record.Source), "registry") {
-		resolvedConfig, err := m.resolveOCIConfigFromRegistry(ctx, parsedRef.Original)
+		resolveCtx, cancel := m.resolveAttemptContext(ctx)
+		resolvedConfig, err := m.resolveOCIConfigFromRegistry(resolveCtx, parsedRef.Original)
+		cancel()
 		if err == nil {
 			record.OCIConfig = mergeOCIConfig(record.OCIConfig, resolvedConfig)
 		}
@@ -447,7 +516,7 @@ func (m *Manager) persistFromTarStream(ctx context.Context, req persistFromTarRe
 		req.CreatedAt = existing.CreatedAt
 	}
 
-	outputPath := filepath.Join(m.cacheDir, strings.TrimPrefix(req.Digest, "sha256:")+".ext4")
+	outputPath := m.cachedRootFSPath(req.Digest)
 	tmpFile, err := os.CreateTemp(m.cacheDir, strings.TrimPrefix(req.Digest, "sha256:")+".tmp-*.ext4")
 	if err != nil {
 		return Record{}, fmt.Errorf("create temporary image artifact for %q: %w", req.Digest, err)
@@ -483,6 +552,10 @@ func (m *Manager) persistFromTarStream(ctx context.Context, req persistFromTarRe
 	}
 
 	return record, nil
+}
+
+func (m *Manager) cachedRootFSPath(digest string) string {
+	return filepath.Join(m.cacheDir, strings.TrimPrefix(digest, "sha256:")+".ext4")
 }
 
 func (m *Manager) initDB(ctx context.Context) error {

--- a/internal/imagemgr/imagemgr.go
+++ b/internal/imagemgr/imagemgr.go
@@ -149,8 +149,8 @@ func New(opts Options) (*Manager, error) {
 		manager.rootFSStreamIdleTimeout = opts.RootFSStreamIdleTimeout
 	}
 	if opts.PullImage != nil {
-		manager.pullImage = func(resolveCtx, _ context.Context, ref string) (io.ReadCloser, OCIConfig, error) {
-			return opts.PullImage(resolveCtx, ref)
+		manager.pullImage = func(_, streamCtx context.Context, ref string) (io.ReadCloser, OCIConfig, error) {
+			return opts.PullImage(streamCtx, ref)
 		}
 	} else {
 		manager.pullImage = pullImageFromRegistry

--- a/internal/imagemgr/imagemgr.go
+++ b/internal/imagemgr/imagemgr.go
@@ -73,12 +73,14 @@ type Options struct {
 	RootFSStreamIdleTimeout time.Duration
 }
 
+type pullImageFunc func(resolveCtx, streamCtx context.Context, ref string) (io.ReadCloser, OCIConfig, error)
+
 type Manager struct {
 	cacheDir                string
 	metadataDBPath          string
 	mkfsBinary              string
 	now                     func() time.Time
-	pullImage               func(context.Context, string) (io.ReadCloser, OCIConfig, error)
+	pullImage               pullImageFunc
 	materialize             func(context.Context, io.Reader, string) (int64, error)
 	resolveAttempts         int
 	resolveAttemptTimeout   time.Duration
@@ -145,7 +147,9 @@ func New(opts Options) (*Manager, error) {
 		manager.rootFSStreamIdleTimeout = opts.RootFSStreamIdleTimeout
 	}
 	if opts.PullImage != nil {
-		manager.pullImage = opts.PullImage
+		manager.pullImage = func(resolveCtx, _ context.Context, ref string) (io.ReadCloser, OCIConfig, error) {
+			return opts.PullImage(resolveCtx, ref)
+		}
 	} else {
 		manager.pullImage = pullImageFromRegistry
 	}
@@ -207,7 +211,7 @@ func (m *Manager) Ensure(ctx context.Context, ref string) (EnsureResult, error) 
 	var lastErr error
 	for attempt := 1; attempt <= m.resolveAttempts; attempt++ {
 		attemptCtx, cancelAttempt := m.resolveAttemptContext(ctx)
-		tarStream, config, err := m.pullImage(attemptCtx, parsedRef.Original)
+		tarStream, config, err := m.pullImage(attemptCtx, ctx, parsedRef.Original)
 		if err != nil {
 			cancelAttempt()
 			lastErr = err
@@ -340,7 +344,7 @@ func (m *Manager) resolveOCIConfigFromRegistry(ctx context.Context, ref string) 
 	if m == nil || m.pullImage == nil {
 		return OCIConfig{}, fmt.Errorf("image puller is not configured")
 	}
-	stream, config, err := m.pullImage(ctx, ref)
+	stream, config, err := m.pullImage(ctx, ctx, ref)
 	if stream != nil {
 		_ = stream.Close()
 	}

--- a/internal/imagemgr/imagemgr.go
+++ b/internal/imagemgr/imagemgr.go
@@ -67,6 +67,7 @@ type Options struct {
 	Now            func() time.Time
 
 	PullImage               func(context.Context, string) (io.ReadCloser, OCIConfig, error)
+	ResolveOCIConfig        func(context.Context, string) (OCIConfig, error)
 	MaterializeRootFS       func(context.Context, io.Reader, string) (int64, error)
 	ResolveAttempts         int
 	ResolveAttemptTimeout   time.Duration
@@ -81,6 +82,7 @@ type Manager struct {
 	mkfsBinary              string
 	now                     func() time.Time
 	pullImage               pullImageFunc
+	resolveOCIConfig        func(context.Context, string) (OCIConfig, error)
 	materialize             func(context.Context, io.Reader, string) (int64, error)
 	resolveAttempts         int
 	resolveAttemptTimeout   time.Duration
@@ -153,6 +155,22 @@ func New(opts Options) (*Manager, error) {
 	} else {
 		manager.pullImage = pullImageFromRegistry
 	}
+	if opts.ResolveOCIConfig != nil {
+		manager.resolveOCIConfig = opts.ResolveOCIConfig
+	} else if opts.PullImage != nil {
+		manager.resolveOCIConfig = func(ctx context.Context, ref string) (OCIConfig, error) {
+			stream, config, err := opts.PullImage(ctx, ref)
+			if stream != nil {
+				_ = stream.Close()
+			}
+			if err != nil {
+				return OCIConfig{}, err
+			}
+			return config, nil
+		}
+	} else {
+		manager.resolveOCIConfig = resolveOCIConfigFromRegistry
+	}
 	if opts.MaterializeRootFS != nil {
 		manager.materialize = opts.MaterializeRootFS
 	} else {
@@ -202,7 +220,7 @@ func (m *Manager) Ensure(ctx context.Context, ref string) (EnsureResult, error) 
 		}
 	}
 
-	if record, found, err := m.recoverDigestCacheFile(ctx, parsedRef.Original, parsedRef.Digest(), now); err != nil {
+	if record, found, err := m.recoverDigestCacheFile(ctx, parsedRef, now); err != nil {
 		return EnsureResult{}, err
 	} else if found {
 		return EnsureResult{Record: record, CacheHit: true}, nil
@@ -270,8 +288,8 @@ func (m *Manager) resolveAttemptContext(ctx context.Context) (context.Context, c
 	return context.WithTimeout(ctx, m.resolveAttemptTimeout)
 }
 
-func (m *Manager) recoverDigestCacheFile(ctx context.Context, ref, digest string, now time.Time) (Record, bool, error) {
-	rootFSPath := m.cachedRootFSPath(digest)
+func (m *Manager) recoverDigestCacheFile(ctx context.Context, parsedRef ociref.DigestReference, now time.Time) (Record, bool, error) {
+	rootFSPath := m.cachedRootFSPath(parsedRef.Digest())
 	info, err := os.Stat(rootFSPath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -283,24 +301,26 @@ func (m *Manager) recoverDigestCacheFile(ctx context.Context, ref, digest string
 		return Record{}, false, fmt.Errorf("cached rootfs %q is a directory", rootFSPath)
 	}
 
+	config, err := m.resolveOCIConfigWithRetries(ctx, parsedRef.Original)
+	if err != nil {
+		return Record{}, false, fmt.Errorf("resolve image metadata for cached rootfs %s: %w", parsedRef.Digest(), err)
+	}
+	if err := validateResolvedOCIConfigPlatform(parsedRef.Original, config); err != nil {
+		return Record{}, false, err
+	}
+
 	record := Record{
-		Digest:     digest,
-		Ref:        ref,
+		Digest:     parsedRef.Digest(),
+		Ref:        parsedRef.Original,
 		RootFSPath: rootFSPath,
 		SizeBytes:  info.Size(),
 		CreatedAt:  now,
 		LastUsedAt: now,
 		Source:     "cache-file",
-		OCIConfig: OCIConfig{
-			OS:           "linux",
-			Architecture: NormalizePlatformArch(runtime.GOARCH),
-		},
-	}
-	if err := ValidateImagePlatformForHost(record.OCIConfig.OS, record.OCIConfig.Architecture, runtime.GOARCH); err != nil {
-		return Record{}, false, err
+		OCIConfig:  config,
 	}
 	if err := m.upsertRecord(ctx, record); err != nil {
-		return Record{}, false, fmt.Errorf("recover cached image metadata for %s: %w", digest, err)
+		return Record{}, false, fmt.Errorf("recover cached image metadata for %s: %w", parsedRef.Digest(), err)
 	}
 	return record, true, nil
 }
@@ -327,9 +347,7 @@ func (m *Manager) validateCachedRecordPlatform(ctx context.Context, parsedRef oc
 		return nil
 	}
 	if needsPlatformMetadata(record.OCIConfig) && strings.EqualFold(strings.TrimSpace(record.Source), "registry") {
-		resolveCtx, cancel := m.resolveAttemptContext(ctx)
-		resolvedConfig, err := m.resolveOCIConfigFromRegistry(resolveCtx, parsedRef.Original)
-		cancel()
+		resolvedConfig, err := m.resolveOCIConfigWithRetries(ctx, parsedRef.Original)
 		if err == nil {
 			record.OCIConfig = mergeOCIConfig(record.OCIConfig, resolvedConfig)
 		}
@@ -340,22 +358,45 @@ func (m *Manager) validateCachedRecordPlatform(ctx context.Context, parsedRef oc
 	return nil
 }
 
-func (m *Manager) resolveOCIConfigFromRegistry(ctx context.Context, ref string) (OCIConfig, error) {
-	if m == nil || m.pullImage == nil {
-		return OCIConfig{}, fmt.Errorf("image puller is not configured")
+func (m *Manager) resolveOCIConfigWithRetries(ctx context.Context, ref string) (OCIConfig, error) {
+	if m == nil || m.resolveOCIConfig == nil {
+		return OCIConfig{}, fmt.Errorf("image metadata resolver is not configured")
 	}
-	stream, config, err := m.pullImage(ctx, ctx, ref)
-	if stream != nil {
-		_ = stream.Close()
+
+	var lastErr error
+	for attempt := 1; attempt <= m.resolveAttempts; attempt++ {
+		attemptCtx, cancelAttempt := m.resolveAttemptContext(ctx)
+		config, err := m.resolveOCIConfig(attemptCtx, ref)
+		cancelAttempt()
+		if err == nil {
+			return config, nil
+		}
+		lastErr = err
+		if !m.shouldRetryResolve(ctx, err) {
+			return OCIConfig{}, err
+		}
+		if attempt >= m.resolveAttempts {
+			return OCIConfig{}, fmt.Errorf("resolve image metadata %q after %d attempts: %w", ref, m.resolveAttempts, err)
+		}
 	}
-	if err != nil {
-		return OCIConfig{}, err
+	if lastErr != nil {
+		return OCIConfig{}, fmt.Errorf("resolve image metadata %q after %d attempts: %w", ref, m.resolveAttempts, lastErr)
 	}
-	return config, nil
+	return OCIConfig{}, nil
 }
 
 func needsPlatformMetadata(cfg OCIConfig) bool {
 	return strings.TrimSpace(cfg.OS) == "" || strings.TrimSpace(cfg.Architecture) == ""
+}
+
+func validateResolvedOCIConfigPlatform(ref string, cfg OCIConfig) error {
+	if strings.TrimSpace(cfg.OS) == "" || strings.TrimSpace(cfg.Architecture) == "" {
+		return fmt.Errorf("image %q metadata does not include a platform", ref)
+	}
+	if err := ValidateImagePlatformForHost(cfg.OS, cfg.Architecture, runtime.GOARCH); err != nil {
+		return fmt.Errorf("image %q platform is incompatible: %w", ref, err)
+	}
+	return nil
 }
 
 func mergeOCIConfig(base, overlay OCIConfig) OCIConfig {

--- a/internal/imagemgr/imagemgr_test.go
+++ b/internal/imagemgr/imagemgr_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -281,6 +282,60 @@ func TestEnsureRetriesTimedOutImageResolve(t *testing.T) {
 	}
 }
 
+func TestEnsureKeepsActiveRootFSStreamPastResolveAttemptDeadline(t *testing.T) {
+	t.Parallel()
+
+	cacheDir := filepath.Join(t.TempDir(), "cache")
+	dbPath := filepath.Join(t.TempDir(), "state", "metadata.db")
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		t.Fatalf("create state dir: %v", err)
+	}
+
+	pulls := 0
+	manager, err := New(Options{
+		CacheDir:              cacheDir,
+		MetadataDBPath:        dbPath,
+		ResolveAttemptTimeout: 5 * time.Millisecond,
+		MaterializeRootFS: func(_ context.Context, stream io.Reader, outputPath string) (int64, error) {
+			if _, err := io.Copy(io.Discard, stream); err != nil {
+				return 0, err
+			}
+			if err := os.WriteFile(outputPath, []byte("fake-ext4"), 0o644); err != nil {
+				return 0, err
+			}
+			return int64(len("fake-ext4")), nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("create manager: %v", err)
+	}
+	manager.pullImage = func(resolveCtx, streamCtx context.Context, _ string) (io.ReadCloser, OCIConfig, error) {
+		pulls++
+		if err := resolveCtx.Err(); err != nil {
+			return nil, OCIConfig{}, err
+		}
+		return &delayedContextReadCloser{
+				reader: bytes.NewReader(testRootFSTar(t)),
+				ctx:    streamCtx,
+				delay:  25 * time.Millisecond,
+			}, OCIConfig{
+				OS:           "linux",
+				Architecture: NormalizePlatformArch(runtime.GOARCH),
+			}, nil
+	}
+
+	result, err := manager.Ensure(context.Background(), testImageRef)
+	if err != nil {
+		t.Fatalf("Ensure returned error for active stream after resolve deadline: %v", err)
+	}
+	if result.CacheHit {
+		t.Fatal("expected active stream to materialize a fresh image")
+	}
+	if pulls != 1 {
+		t.Fatalf("expected one pull for active stream, got %d", pulls)
+	}
+}
+
 func TestEnsureUsesLegacyCacheWhenPlatformBackfillUnavailable(t *testing.T) {
 	t.Parallel()
 
@@ -318,6 +373,28 @@ func TestEnsureUsesLegacyCacheWhenPlatformBackfillUnavailable(t *testing.T) {
 type blockingReadCloser struct {
 	closed chan struct{}
 	once   sync.Once
+}
+
+type delayedContextReadCloser struct {
+	reader  *bytes.Reader
+	ctx     context.Context
+	delay   time.Duration
+	checked bool
+}
+
+func (r *delayedContextReadCloser) Read(p []byte) (int, error) {
+	if !r.checked {
+		time.Sleep(r.delay)
+		r.checked = true
+		if err := r.ctx.Err(); err != nil {
+			return 0, fmt.Errorf("stream context should remain active after resolve deadline: %w", err)
+		}
+	}
+	return r.reader.Read(p)
+}
+
+func (r *delayedContextReadCloser) Close() error {
+	return nil
 }
 
 func newBlockingReadCloser() *blockingReadCloser {
@@ -575,7 +652,7 @@ func newTestManager(t *testing.T, pullFn func(context.Context, string) (io.ReadC
 	}
 
 	if manager.pullImage == nil {
-		manager.pullImage = func(_ context.Context, _ string) (io.ReadCloser, OCIConfig, error) {
+		manager.pullImage = func(_, _ context.Context, _ string) (io.ReadCloser, OCIConfig, error) {
 			return io.NopCloser(bytes.NewReader(testRootFSTar(t))), OCIConfig{}, nil
 		}
 	}

--- a/internal/imagemgr/imagemgr_test.go
+++ b/internal/imagemgr/imagemgr_test.go
@@ -89,12 +89,27 @@ func TestEnsureReusesDigestCacheFileWhenMetadataIsMissing(t *testing.T) {
 	}
 
 	pulls := 0
+	metadataResolves := 0
 	manager, err := New(Options{
 		CacheDir:       cacheDir,
 		MetadataDBPath: dbPath,
 		PullImage: func(context.Context, string) (io.ReadCloser, OCIConfig, error) {
 			pulls++
-			return nil, OCIConfig{}, errors.New("registry should not be used")
+			return nil, OCIConfig{}, errors.New("registry rootfs should not be pulled")
+		},
+		ResolveOCIConfig: func(_ context.Context, ref string) (OCIConfig, error) {
+			metadataResolves++
+			if ref != testImageRef {
+				return OCIConfig{}, fmt.Errorf("unexpected metadata ref: got %q want %q", ref, testImageRef)
+			}
+			return OCIConfig{
+				Workdir:      "/workspace",
+				OS:           "linux",
+				Architecture: NormalizePlatformArch(runtime.GOARCH),
+			}, nil
+		},
+		MaterializeRootFS: func(context.Context, io.Reader, string) (int64, error) {
+			return 0, errors.New("cached rootfs should not be materialized")
 		},
 	})
 	if err != nil {
@@ -109,10 +124,16 @@ func TestEnsureReusesDigestCacheFileWhenMetadataIsMissing(t *testing.T) {
 		t.Fatal("expected digest cache file to be reused as a cache hit")
 	}
 	if pulls != 0 {
-		t.Fatalf("expected no registry pulls, got %d", pulls)
+		t.Fatalf("expected no registry rootfs pulls, got %d", pulls)
+	}
+	if metadataResolves != 1 {
+		t.Fatalf("expected one registry metadata resolve, got %d", metadataResolves)
 	}
 	if got := result.Record.RootFSPath; got != rootFSPath {
 		t.Fatalf("unexpected rootfs path: got %q want %q", got, rootFSPath)
+	}
+	if got, want := result.Record.OCIConfig.Workdir, "/workspace"; got != want {
+		t.Fatalf("unexpected recovered OCI workdir: got %q want %q", got, want)
 	}
 
 	items, err := manager.List(context.Background())
@@ -124,6 +145,66 @@ func TestEnsureReusesDigestCacheFileWhenMetadataIsMissing(t *testing.T) {
 	}
 	if got := items[0].Digest; got != digest {
 		t.Fatalf("unexpected recovered digest: got %q want %q", got, digest)
+	}
+	if got, want := items[0].OCIConfig.Architecture, NormalizePlatformArch(runtime.GOARCH); got != want {
+		t.Fatalf("unexpected recovered architecture: got %q want %q", got, want)
+	}
+}
+
+func TestEnsureRejectsDigestCacheFileWhenResolvedPlatformIsIncompatible(t *testing.T) {
+	t.Parallel()
+
+	cacheDir := filepath.Join(t.TempDir(), "cache")
+	dbPath := filepath.Join(t.TempDir(), "state", "metadata.db")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatalf("create cache dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		t.Fatalf("create state dir: %v", err)
+	}
+
+	digest := "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	rootFSPath := filepath.Join(cacheDir, strings.TrimPrefix(digest, "sha256:")+".ext4")
+	if err := os.WriteFile(rootFSPath, []byte("fake-ext4"), 0o644); err != nil {
+		t.Fatalf("write cached rootfs: %v", err)
+	}
+
+	incompatibleArch := "amd64"
+	if runtime.GOARCH == "amd64" {
+		incompatibleArch = "arm64"
+	}
+
+	manager, err := New(Options{
+		CacheDir:       cacheDir,
+		MetadataDBPath: dbPath,
+		PullImage: func(context.Context, string) (io.ReadCloser, OCIConfig, error) {
+			return nil, OCIConfig{}, errors.New("registry rootfs should not be pulled")
+		},
+		ResolveOCIConfig: func(context.Context, string) (OCIConfig, error) {
+			return OCIConfig{
+				OS:           "linux",
+				Architecture: incompatibleArch,
+			}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("create manager: %v", err)
+	}
+
+	_, err = manager.Ensure(context.Background(), testImageRef)
+	if err == nil {
+		t.Fatal("expected Ensure to reject incompatible recovered cache file")
+	}
+	if got, want := strings.ToLower(err.Error()), "incompatible"; !strings.Contains(got, want) {
+		t.Fatalf("expected incompatibility error, got %v", err)
+	}
+
+	items, err := manager.List(context.Background())
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if len(items) != 0 {
+		t.Fatalf("expected incompatible cache file not to recover metadata, got %d entries", len(items))
 	}
 }
 

--- a/internal/imagemgr/imagemgr_test.go
+++ b/internal/imagemgr/imagemgr_test.go
@@ -69,6 +69,63 @@ func TestEnsureCachesAndReusesImage(t *testing.T) {
 	}
 }
 
+func TestEnsureReusesDigestCacheFileWhenMetadataIsMissing(t *testing.T) {
+	t.Parallel()
+
+	cacheDir := filepath.Join(t.TempDir(), "cache")
+	dbPath := filepath.Join(t.TempDir(), "state", "metadata.db")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatalf("create cache dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		t.Fatalf("create state dir: %v", err)
+	}
+
+	digest := "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	rootFSPath := filepath.Join(cacheDir, strings.TrimPrefix(digest, "sha256:")+".ext4")
+	if err := os.WriteFile(rootFSPath, []byte("fake-ext4"), 0o644); err != nil {
+		t.Fatalf("write cached rootfs: %v", err)
+	}
+
+	pulls := 0
+	manager, err := New(Options{
+		CacheDir:       cacheDir,
+		MetadataDBPath: dbPath,
+		PullImage: func(context.Context, string) (io.ReadCloser, OCIConfig, error) {
+			pulls++
+			return nil, OCIConfig{}, errors.New("registry should not be used")
+		},
+	})
+	if err != nil {
+		t.Fatalf("create manager: %v", err)
+	}
+
+	result, err := manager.Ensure(context.Background(), testImageRef)
+	if err != nil {
+		t.Fatalf("Ensure returned error: %v", err)
+	}
+	if !result.CacheHit {
+		t.Fatal("expected digest cache file to be reused as a cache hit")
+	}
+	if pulls != 0 {
+		t.Fatalf("expected no registry pulls, got %d", pulls)
+	}
+	if got := result.Record.RootFSPath; got != rootFSPath {
+		t.Fatalf("unexpected rootfs path: got %q want %q", got, rootFSPath)
+	}
+
+	items, err := manager.List(context.Background())
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected recovered metadata row, got %d entries", len(items))
+	}
+	if got := items[0].Digest; got != digest {
+		t.Fatalf("unexpected recovered digest: got %q want %q", got, digest)
+	}
+}
+
 func TestEnsureRejectsIncompatibleImagePlatformOnPull(t *testing.T) {
 	t.Parallel()
 
@@ -184,6 +241,43 @@ func TestEnsureRetriesStalledRootFSStream(t *testing.T) {
 	}
 	if pulls != 2 {
 		t.Fatalf("expected stalled stream to be retried once, got %d pulls", pulls)
+	}
+}
+
+func TestEnsureRetriesTimedOutImageResolve(t *testing.T) {
+	t.Parallel()
+
+	cacheDir := filepath.Join(t.TempDir(), "cache")
+	dbPath := filepath.Join(t.TempDir(), "state", "metadata.db")
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		t.Fatalf("create state dir: %v", err)
+	}
+
+	pulls := 0
+	manager, err := New(Options{
+		CacheDir:              cacheDir,
+		MetadataDBPath:        dbPath,
+		ResolveAttempts:       2,
+		ResolveAttemptTimeout: 5 * time.Millisecond,
+		PullImage: func(ctx context.Context, _ string) (io.ReadCloser, OCIConfig, error) {
+			pulls++
+			<-ctx.Done()
+			return nil, OCIConfig{}, ctx.Err()
+		},
+	})
+	if err != nil {
+		t.Fatalf("create manager: %v", err)
+	}
+
+	_, err = manager.Ensure(context.Background(), testImageRef)
+	if err == nil {
+		t.Fatal("expected Ensure to fail after timed out resolve attempts")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline error, got %v", err)
+	}
+	if pulls != 2 {
+		t.Fatalf("expected timed out resolve to be retried once, got %d pulls", pulls)
 	}
 }
 

--- a/internal/imagemgr/imagemgr_test.go
+++ b/internal/imagemgr/imagemgr_test.go
@@ -341,14 +341,14 @@ func TestEnsureRetriesTimedOutImageResolve(t *testing.T) {
 		MetadataDBPath:        dbPath,
 		ResolveAttempts:       2,
 		ResolveAttemptTimeout: 5 * time.Millisecond,
-		PullImage: func(ctx context.Context, _ string) (io.ReadCloser, OCIConfig, error) {
-			pulls++
-			<-ctx.Done()
-			return nil, OCIConfig{}, ctx.Err()
-		},
 	})
 	if err != nil {
 		t.Fatalf("create manager: %v", err)
+	}
+	manager.pullImage = func(resolveCtx, _ context.Context, _ string) (io.ReadCloser, OCIConfig, error) {
+		pulls++
+		<-resolveCtx.Done()
+		return nil, OCIConfig{}, resolveCtx.Err()
 	}
 
 	_, err = manager.Ensure(context.Background(), testImageRef)
@@ -377,6 +377,17 @@ func TestEnsureKeepsActiveRootFSStreamPastResolveAttemptDeadline(t *testing.T) {
 		CacheDir:              cacheDir,
 		MetadataDBPath:        dbPath,
 		ResolveAttemptTimeout: 5 * time.Millisecond,
+		PullImage: func(ctx context.Context, _ string) (io.ReadCloser, OCIConfig, error) {
+			pulls++
+			return &delayedContextReadCloser{
+					reader: bytes.NewReader(testRootFSTar(t)),
+					ctx:    ctx,
+					delay:  25 * time.Millisecond,
+				}, OCIConfig{
+					OS:           "linux",
+					Architecture: NormalizePlatformArch(runtime.GOARCH),
+				}, nil
+		},
 		MaterializeRootFS: func(_ context.Context, stream io.Reader, outputPath string) (int64, error) {
 			if _, err := io.Copy(io.Discard, stream); err != nil {
 				return 0, err
@@ -389,20 +400,6 @@ func TestEnsureKeepsActiveRootFSStreamPastResolveAttemptDeadline(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("create manager: %v", err)
-	}
-	manager.pullImage = func(resolveCtx, streamCtx context.Context, _ string) (io.ReadCloser, OCIConfig, error) {
-		pulls++
-		if err := resolveCtx.Err(); err != nil {
-			return nil, OCIConfig{}, err
-		}
-		return &delayedContextReadCloser{
-				reader: bytes.NewReader(testRootFSTar(t)),
-				ctx:    streamCtx,
-				delay:  25 * time.Millisecond,
-			}, OCIConfig{
-				OS:           "linux",
-				Architecture: NormalizePlatformArch(runtime.GOARCH),
-			}, nil
 	}
 
 	result, err := manager.Ensure(context.Background(), testImageRef)

--- a/internal/imagemgr/registry.go
+++ b/internal/imagemgr/registry.go
@@ -30,7 +30,32 @@ func pullImageFromRegistry(resolveCtx, streamCtx context.Context, ref string) (i
 		return nil, OCIConfig{}, fmt.Errorf("read OCI config for %q: %w", ref, err)
 	}
 
-	return newRegistryRootFSStream(streamCtx, digestRef, platform), OCIConfig{
+	return newRegistryRootFSStream(streamCtx, digestRef, platform), ociConfigFromConfigFile(cfg), nil
+}
+
+func resolveOCIConfigFromRegistry(ctx context.Context, ref string) (OCIConfig, error) {
+	digestRef, err := name.NewDigest(ref)
+	if err != nil {
+		return OCIConfig{}, fmt.Errorf("parse digest reference %q: %w", ref, err)
+	}
+
+	img, err := remote.Image(digestRef, remote.WithContext(ctx), remote.WithPlatform(hostLinuxPlatform()))
+	if err != nil {
+		return OCIConfig{}, fmt.Errorf("pull OCI image metadata %q: %w", ref, err)
+	}
+
+	cfg, err := img.ConfigFile()
+	if err != nil {
+		return OCIConfig{}, fmt.Errorf("read OCI config for %q: %w", ref, err)
+	}
+	return ociConfigFromConfigFile(cfg), nil
+}
+
+func ociConfigFromConfigFile(cfg *v1.ConfigFile) OCIConfig {
+	if cfg == nil {
+		return OCIConfig{}
+	}
+	return OCIConfig{
 		Entrypoint:   append([]string(nil), cfg.Config.Entrypoint...),
 		Cmd:          append([]string(nil), cfg.Config.Cmd...),
 		Env:          append([]string(nil), cfg.Config.Env...),
@@ -39,7 +64,7 @@ func pullImageFromRegistry(resolveCtx, streamCtx context.Context, ref string) (i
 		OS:           cfg.OS,
 		Architecture: cfg.Architecture,
 		Variant:      cfg.Variant,
-	}, nil
+	}
 }
 
 type registryRootFSStream struct {

--- a/internal/imagemgr/registry.go
+++ b/internal/imagemgr/registry.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"runtime"
+	"sync"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -12,13 +13,14 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 )
 
-func pullImageFromRegistry(ctx context.Context, ref string) (io.ReadCloser, OCIConfig, error) {
+func pullImageFromRegistry(resolveCtx, streamCtx context.Context, ref string) (io.ReadCloser, OCIConfig, error) {
 	digestRef, err := name.NewDigest(ref)
 	if err != nil {
 		return nil, OCIConfig{}, fmt.Errorf("parse digest reference %q: %w", ref, err)
 	}
 
-	img, err := remote.Image(digestRef, remote.WithContext(ctx), remote.WithPlatform(hostLinuxPlatform()))
+	platform := hostLinuxPlatform()
+	img, err := remote.Image(digestRef, remote.WithContext(resolveCtx), remote.WithPlatform(platform))
 	if err != nil {
 		return nil, OCIConfig{}, fmt.Errorf("pull OCI image %q: %w", ref, err)
 	}
@@ -28,9 +30,7 @@ func pullImageFromRegistry(ctx context.Context, ref string) (io.ReadCloser, OCIC
 		return nil, OCIConfig{}, fmt.Errorf("read OCI config for %q: %w", ref, err)
 	}
 
-	rootFSTar := mutate.Extract(img)
-
-	return rootFSTar, OCIConfig{
+	return newRegistryRootFSStream(streamCtx, digestRef, platform), OCIConfig{
 		Entrypoint:   append([]string(nil), cfg.Config.Entrypoint...),
 		Cmd:          append([]string(nil), cfg.Config.Cmd...),
 		Env:          append([]string(nil), cfg.Config.Env...),
@@ -40,6 +40,59 @@ func pullImageFromRegistry(ctx context.Context, ref string) (io.ReadCloser, OCIC
 		Architecture: cfg.Architecture,
 		Variant:      cfg.Variant,
 	}, nil
+}
+
+type registryRootFSStream struct {
+	reader *io.PipeReader
+	cancel context.CancelFunc
+	once   sync.Once
+}
+
+func newRegistryRootFSStream(ctx context.Context, digestRef name.Digest, platform v1.Platform) io.ReadCloser {
+	streamCtx, cancel := context.WithCancel(ctx)
+	reader, writer := io.Pipe()
+	stream := &registryRootFSStream{
+		reader: reader,
+		cancel: cancel,
+	}
+
+	go func() {
+		defer cancel()
+
+		img, err := remote.Image(digestRef, remote.WithContext(streamCtx), remote.WithPlatform(platform))
+		if err != nil {
+			_ = writer.CloseWithError(fmt.Errorf("pull OCI image rootfs %q: %w", digestRef.Name(), err))
+			return
+		}
+
+		rootFSTar := mutate.Extract(img)
+		_, copyErr := io.Copy(writer, rootFSTar)
+		closeErr := rootFSTar.Close()
+		if copyErr != nil {
+			_ = writer.CloseWithError(copyErr)
+			return
+		}
+		if closeErr != nil {
+			_ = writer.CloseWithError(closeErr)
+			return
+		}
+		_ = writer.Close()
+	}()
+
+	return stream
+}
+
+func (s *registryRootFSStream) Read(p []byte) (int, error) {
+	return s.reader.Read(p)
+}
+
+func (s *registryRootFSStream) Close() error {
+	var err error
+	s.once.Do(func() {
+		s.cancel()
+		err = s.reader.Close()
+	})
+	return err
 }
 
 func hostLinuxPlatform() v1.Platform {


### PR DESCRIPTION
The darwin-vz filehandle E2E can run with a temporary `XDG_STATE_HOME` while still sharing the host image cache. When the metadata DB is empty, `imagemgr.Ensure` ignored an existing digest-named rootfs file and went back to GHCR. If registry resolution stalled, the job sat at `resolving sandbox image rootfs...` even though the rootfs artifact was already present on disk.

This changes image resolution so a warm `<cache>/images/<digest>.ext4` file can recover its metadata row and be reused. Recovery now resolves real OCI metadata for the requested ref before accepting that file, so the cache hit is still checked against the host platform instead of synthesizing architecture from the local runtime. Cold metadata resolution is wrapped in a per-attempt timeout and retried, while rootfs streams remain governed by the existing stream idle timeout.

A concrete example covered by the tests: with an empty metadata DB and an existing `sha256:<digest>.ext4` cache file, `Ensure` now performs a metadata-only platform resolve, records the recovered OCI config, returns a cache hit, and does not pull or materialize the rootfs again. If the resolved platform is incompatible, the cache file is rejected instead of being trusted.
