### PR TITLE
feat: Add daemon log tailing

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -18,6 +18,8 @@ binaries.
 ```bash
 cleanroom daemon status
 cleanroom daemon status --json
+cleanroom daemon logs
+cleanroom daemon logs -f
 cleanroom daemon start
 cleanroom daemon stop
 cleanroom daemon restart
@@ -32,6 +34,11 @@ cleanroom daemon install --init-config --restart
 
 On macOS the daemon runs under launchd user scope. On Linux it runs under
 systemd system scope.
+
+On macOS, launchd writes daemon stdout and stderr to
+`~/Library/Logs/Cleanroom/daemon.log`. Re-run
+`cleanroom daemon install --restart` after upgrading from an older service
+definition so launchd starts capturing that file.
 
 ## Runtime Config
 

--- a/internal/cli/cli_parse_test.go
+++ b/internal/cli/cli_parse_test.go
@@ -1094,6 +1094,39 @@ func TestDaemonStatusJSONParses(t *testing.T) {
 	}
 }
 
+func TestDaemonLogsFlagsParse(t *testing.T) {
+	c := &CLI{}
+	parser := newParserForTest(t, c)
+
+	if _, err := parser.Parse([]string{"daemon", "logs", "--follow", "--lines", "25"}); err != nil {
+		t.Fatalf("parse daemon logs flags returned error: %v", err)
+	}
+	if got := c.Daemon.Action; got != "logs" {
+		t.Fatalf("expected daemon action logs, got %q", got)
+	}
+	if !c.Daemon.Follow {
+		t.Fatal("expected --follow to set Daemon.Follow")
+	}
+	if got, want := c.Daemon.Lines, "25"; got != want {
+		t.Fatalf("expected --lines %q, got %q", want, got)
+	}
+}
+
+func TestDaemonLogsShortFlagsParse(t *testing.T) {
+	c := &CLI{}
+	parser := newParserForTest(t, c)
+
+	if _, err := parser.Parse([]string{"daemon", "logs", "-f", "-n", "10"}); err != nil {
+		t.Fatalf("parse daemon logs short flags returned error: %v", err)
+	}
+	if !c.Daemon.Follow {
+		t.Fatal("expected -f to set Daemon.Follow")
+	}
+	if got, want := c.Daemon.Lines, "10"; got != want {
+		t.Fatalf("expected -n %q, got %q", want, got)
+	}
+}
+
 func TestDaemonStartSystemParses(t *testing.T) {
 	c := &CLI{}
 	parser := newParserForTest(t, c)

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -20,13 +21,15 @@ import (
 )
 
 type DaemonCommand struct {
-	Action        string `arg:"" required:"" help:"Daemon action (install, uninstall, status, start, stop, restart)"`
+	Action        string `arg:"" required:"" help:"Daemon action (install, uninstall, status, logs, start, stop, restart)"`
 	Force         bool   `help:"Start a stopped daemon during restart"`
 	Restart       bool   `help:"Restart or start the daemon after install so the current definition is live"`
 	InitConfig    bool   `help:"Create a default runtime config before install if the config file is missing"`
 	DryRun        bool   `help:"Preview daemon install changes without mutating the service manager"`
-	User          bool   `help:"Use user daemon scope (launchd only; install/uninstall/status/start/stop/restart actions)"`
-	System        bool   `help:"Use system daemon scope (linux only; install/uninstall/status/start/stop/restart actions)"`
+	Follow        bool   `name:"follow" short:"f" help:"Follow daemon logs (logs action only)"`
+	Lines         string `name:"lines" short:"n" help:"Number of recent daemon log lines to show (logs action only; default 100)"`
+	User          bool   `help:"Use user daemon scope (launchd only; install/uninstall/status/logs/start/stop/restart actions)"`
+	System        bool   `help:"Use system daemon scope (linux only; install/uninstall/status/logs/start/stop/restart actions)"`
 	JSON          bool   `help:"Print daemon status as JSON (status action only)"`
 	Listen        string `help:"Listen endpoint for control API (defaults to runtime endpoint)"`
 	GatewayListen string `help:"Listen address for the host gateway (default :8170, use :0 for ephemeral port)"`
@@ -45,6 +48,7 @@ type daemonStatusPayload struct {
 	Domain    string `json:"domain,omitempty"`
 	State     string `json:"state,omitempty"`
 	Listen    string `json:"listen,omitempty"`
+	LogPath   string `json:"log_path,omitempty"`
 }
 
 type daemonStatusResult struct {
@@ -57,11 +61,18 @@ type daemonInstallOptions struct {
 	DryRun  bool
 }
 
+type daemonLogsOptions struct {
+	Follow bool
+	Lines  int
+}
+
 type daemonScope string
 
 const (
 	daemonScopeSystem daemonScope = "system"
 	daemonScopeUser   daemonScope = "user"
+
+	defaultDaemonLogLines = 100
 )
 
 var (
@@ -82,6 +93,7 @@ var (
 	serveInstallSleep            = time.Sleep
 	serveInstallWaitAttempts     = 50
 	serveInstallWaitPollInterval = 100 * time.Millisecond
+	serveInstallRunLogCommand    = runServeInstallLogCommand
 )
 
 func (s *DaemonCommand) Run(ctx *runtimeContext) error {
@@ -97,6 +109,12 @@ func (s *DaemonCommand) Run(ctx *runtimeContext) error {
 	}
 	if s.DryRun && action != "install" {
 		return errors.New("--dry-run is only supported with daemon install")
+	}
+	if s.Follow && action != "logs" {
+		return errors.New("--follow is only supported with daemon logs")
+	}
+	if strings.TrimSpace(s.Lines) != "" && action != "logs" {
+		return errors.New("--lines is only supported with daemon logs")
 	}
 	if s.Force && action == "install" {
 		return errors.New("--force is no longer supported with daemon install")
@@ -115,6 +133,8 @@ func (s *DaemonCommand) Run(ctx *runtimeContext) error {
 		return s.stopDaemon(ctx)
 	case "restart":
 		return s.restartDaemon(ctx)
+	case "logs":
+		return s.daemonLogs(ctx)
 	default:
 		return fmt.Errorf("unsupported daemon action %q", s.Action)
 	}
@@ -409,6 +429,53 @@ func (s *DaemonCommand) daemonStatus(ctx *runtimeContext) error {
 	return err
 }
 
+func (s *DaemonCommand) daemonLogs(ctx *runtimeContext) error {
+	scope, err := s.effectiveDaemonScope()
+	if err != nil {
+		return err
+	}
+	lines, err := parseDaemonLogLines(s.Lines)
+	if err != nil {
+		return err
+	}
+
+	options := daemonLogsOptions{
+		Follow: s.Follow,
+		Lines:  lines,
+	}
+
+	switch serveInstallGOOS {
+	case "linux":
+		return systemdDaemonLogs(ctx.Stdout, ctx.stderr(), options)
+	case "darwin":
+		if scope == daemonScopeUser {
+			return launchdUserDaemonLogs(ctx.Stdout, ctx.stderr(), options)
+		}
+		return launchdDaemonLogs(ctx.Stdout, ctx.stderr(), options)
+	default:
+		return fmt.Errorf("daemon logs is unsupported on %s (expected linux or darwin)", serveInstallGOOS)
+	}
+}
+
+func daemonLogLines(options daemonLogsOptions) int {
+	return options.Lines
+}
+
+func parseDaemonLogLines(raw string) (int, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return defaultDaemonLogLines, nil
+	}
+	lines, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, fmt.Errorf("invalid --lines %q: %w", raw, err)
+	}
+	if lines < 0 {
+		return 0, errors.New("--lines must be zero or greater")
+	}
+	return lines, nil
+}
+
 func isExitError(err error) bool {
 	var exitErr *exec.ExitError
 	return errors.As(err, &exitErr)
@@ -431,6 +498,17 @@ func runServeInstallCommandOutput(name string, args ...string) (string, error) {
 		return "", fmt.Errorf("%s: %w (%s)", strings.Join(parts, " "), err, msg)
 	}
 	return string(out), nil
+}
+
+func runServeInstallLogCommand(stdout, stderr io.Writer, name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	if err := cmd.Run(); err != nil {
+		parts := append([]string{name}, args...)
+		return fmt.Errorf("%s: %w", strings.Join(parts, " "), err)
+	}
+	return nil
 }
 
 func (s *DaemonCommand) ensureRuntimeConfig(ctx *runtimeContext) error {

--- a/internal/cli/daemon_launchd.go
+++ b/internal/cli/daemon_launchd.go
@@ -9,11 +9,17 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/buildkite/cleanroom/internal/endpoint"
 )
+
+type launchdLogPaths struct {
+	Stdout string
+	Stderr string
+}
 
 func uninstallLaunchdDaemon(stdout io.Writer) error {
 	return uninstallLaunchdDaemonInDomain(stdout, serveInstallLaunchdPath, "system")
@@ -263,6 +269,12 @@ func launchdDaemonStatusInDomain(servicePath, domain string) (daemonStatusResult
 			listen = value
 		}
 	}
+	logPath := ""
+	if installed {
+		if value, err := launchdConfiguredStandardErrorPath(servicePath); err == nil {
+			logPath = value
+		}
+	}
 
 	fields := []startupField{
 		{Key: "install", Value: daemonInstalledLabel(installed)},
@@ -275,6 +287,9 @@ func launchdDaemonStatusInDomain(servicePath, domain string) (daemonStatusResult
 	}
 	if listen != "" {
 		fields = append(fields, startupField{Key: "listen", Value: listen})
+	}
+	if logPath != "" {
+		fields = append(fields, startupField{Key: "log", Value: logPath})
 	}
 
 	return daemonStatusResult{
@@ -294,8 +309,46 @@ func launchdDaemonStatusInDomain(servicePath, domain string) (daemonStatusResult
 			Domain:    domain,
 			State:     state,
 			Listen:    listen,
+			LogPath:   logPath,
 		},
 	}, nil
+}
+
+func launchdDaemonLogs(stdout, stderr io.Writer, options daemonLogsOptions) error {
+	return launchdDaemonLogsFromServicePath(stdout, stderr, serveInstallLaunchdPath, options)
+}
+
+func launchdUserDaemonLogs(stdout, stderr io.Writer, options daemonLogsOptions) error {
+	path, err := launchdUserServicePath()
+	if err != nil {
+		return err
+	}
+	return launchdDaemonLogsFromServicePath(stdout, stderr, path, options)
+}
+
+func launchdDaemonLogsFromServicePath(stdout, stderr io.Writer, servicePath string, options daemonLogsOptions) error {
+	logPath, err := launchdConfiguredStandardErrorPath(servicePath)
+	if errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("daemon is not installed at %s (run 'cleanroom daemon install --restart' first)", servicePath)
+	}
+	if err != nil {
+		return fmt.Errorf("read launchd log path from %s: %w", servicePath, err)
+	}
+	if strings.TrimSpace(logPath) == "" {
+		return fmt.Errorf("daemon log file is not configured in %s (run 'cleanroom daemon install --restart' to enable launchd log capture)", servicePath)
+	}
+	if _, err := os.Stat(logPath); err != nil {
+		if !errors.Is(err, os.ErrNotExist) || !options.Follow {
+			return fmt.Errorf("daemon log file %s is not available yet: %w", logPath, err)
+		}
+	}
+
+	args := []string{"-n", strconv.Itoa(daemonLogLines(options))}
+	if options.Follow {
+		args = append(args, "-F")
+	}
+	args = append(args, logPath)
+	return serveInstallRunLogCommand(stdout, stderr, "tail", args...)
 }
 
 func launchdServiceState(output string) string {
@@ -342,6 +395,65 @@ func launchdConfiguredListenEndpoint(plistPath string) (string, error) {
 		}
 	}
 	return "", nil
+}
+
+func launchdConfiguredStandardErrorPath(plistPath string) (string, error) {
+	raw, err := os.ReadFile(plistPath)
+	if err != nil {
+		return "", err
+	}
+	value, _, err := launchdPlistStringValue(raw, "StandardErrorPath")
+	return value, err
+}
+
+func launchdPlistStringValue(plistContent []byte, keyName string) (string, bool, error) {
+	decoder := xml.NewDecoder(bytes.NewReader(plistContent))
+	for {
+		tok, err := decoder.Token()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return "", false, nil
+			}
+			return "", false, err
+		}
+
+		start, ok := tok.(xml.StartElement)
+		if !ok || start.Name.Local != "key" {
+			continue
+		}
+
+		var key string
+		if err := decoder.DecodeElement(&key, &start); err != nil {
+			return "", false, err
+		}
+		if strings.TrimSpace(key) != keyName {
+			continue
+		}
+
+		for {
+			tok, err = decoder.Token()
+			if err != nil {
+				if errors.Is(err, io.EOF) {
+					return "", true, fmt.Errorf("%s value missing", keyName)
+				}
+				return "", true, err
+			}
+
+			start, ok = tok.(xml.StartElement)
+			if !ok {
+				continue
+			}
+			if start.Name.Local != "string" {
+				return "", true, fmt.Errorf("%s must be a string, got <%s>", keyName, start.Name.Local)
+			}
+
+			var value string
+			if err := decoder.DecodeElement(&value, &start); err != nil {
+				return "", true, err
+			}
+			return strings.TrimSpace(value), true, nil
+		}
+	}
 }
 
 func waitForLaunchdBootout(target, servicePath string) error {
@@ -469,7 +581,10 @@ func plistStringArray(decoder *xml.Decoder) ([]string, error) {
 }
 
 func installLaunchdDaemon(stdout io.Writer, executablePath string, args []string, options daemonInstallOptions) error {
-	return installLaunchdDaemonInDomain(stdout, executablePath, args, options, serveInstallLaunchdPath, "system")
+	return installLaunchdDaemonInDomain(stdout, executablePath, args, options, serveInstallLaunchdPath, "system", launchdLogPaths{
+		Stdout: "/Library/Logs/Cleanroom/daemon.log",
+		Stderr: "/Library/Logs/Cleanroom/daemon.log",
+	})
 }
 
 func installLaunchdUserDaemon(stdout io.Writer, executablePath string, args []string, options daemonInstallOptions) error {
@@ -477,7 +592,11 @@ func installLaunchdUserDaemon(stdout io.Writer, executablePath string, args []st
 	if err != nil {
 		return err
 	}
-	return installLaunchdDaemonInDomain(stdout, executablePath, args, options, path, launchdUserDomain())
+	logs, err := launchdUserLogPaths()
+	if err != nil {
+		return err
+	}
+	return installLaunchdDaemonInDomain(stdout, executablePath, args, options, path, launchdUserDomain(), logs)
 }
 
 func launchdUserServicePath() (string, error) {
@@ -496,9 +615,22 @@ func launchdServiceTarget(domain string) string {
 	return strings.TrimSpace(domain) + "/" + launchdServiceName
 }
 
-func installLaunchdDaemonInDomain(stdout io.Writer, executablePath string, args []string, options daemonInstallOptions, servicePath, domain string) error {
+func launchdUserLogPaths() (launchdLogPaths, error) {
+	home, err := serveInstallUserHomeDir()
+	if err != nil {
+		return launchdLogPaths{}, fmt.Errorf("resolve user home directory: %w", err)
+	}
+	dir := filepath.Join(home, "Library", "Logs", "Cleanroom")
+	path := filepath.Join(dir, "daemon.log")
+	return launchdLogPaths{
+		Stdout: path,
+		Stderr: path,
+	}, nil
+}
+
+func installLaunchdDaemonInDomain(stdout io.Writer, executablePath string, args []string, options daemonInstallOptions, servicePath, domain string, logs launchdLogPaths) error {
 	target := launchdServiceTarget(domain)
-	content := renderLaunchdService(executablePath, args)
+	content := renderLaunchdServiceWithLogs(executablePath, args, logs)
 	loaded, state, err := launchdServiceStatus(target)
 	if err != nil {
 		return err
@@ -527,6 +659,9 @@ func installLaunchdDaemonInDomain(stdout io.Writer, executablePath string, args 
 		return err
 	}
 
+	if err := ensureLaunchdLogDirs(logs); err != nil {
+		return err
+	}
 	if err := replaceDaemonFile(servicePath, content, 0o644); err != nil {
 		return err
 	}
@@ -650,6 +785,10 @@ func launchdInstallActionError(action, target, servicePath string, loaded, updat
 }
 
 func renderLaunchdService(executablePath string, args []string) string {
+	return renderLaunchdServiceWithLogs(executablePath, args, launchdLogPaths{})
+}
+
+func renderLaunchdServiceWithLogs(executablePath string, args []string, logs launchdLogPaths) string {
 	cmd := append([]string{executablePath}, args...)
 	var b strings.Builder
 	b.WriteString(`<?xml version="1.0" encoding="UTF-8"?>
@@ -668,6 +807,18 @@ func renderLaunchdService(executablePath string, args []string) string {
 		b.WriteString("</string>\n")
 	}
 	b.WriteString("\t</array>\n")
+	if strings.TrimSpace(logs.Stdout) != "" {
+		b.WriteString("\t<key>StandardOutPath</key>\n")
+		b.WriteString("\t<string>")
+		b.WriteString(escapePlistValue(strings.TrimSpace(logs.Stdout)))
+		b.WriteString("</string>\n")
+	}
+	if strings.TrimSpace(logs.Stderr) != "" {
+		b.WriteString("\t<key>StandardErrorPath</key>\n")
+		b.WriteString("\t<string>")
+		b.WriteString(escapePlistValue(strings.TrimSpace(logs.Stderr)))
+		b.WriteString("</string>\n")
+	}
 	b.WriteString("\t<key>RunAtLoad</key>\n")
 	b.WriteString("\t<true/>\n")
 	b.WriteString("\t<key>KeepAlive</key>\n")
@@ -675,6 +826,19 @@ func renderLaunchdService(executablePath string, args []string) string {
 	b.WriteString("</dict>\n")
 	b.WriteString("</plist>\n")
 	return b.String()
+}
+
+func ensureLaunchdLogDirs(logs launchdLogPaths) error {
+	for _, path := range []string{logs.Stdout, logs.Stderr} {
+		path = strings.TrimSpace(path)
+		if path == "" {
+			continue
+		}
+		if err := serveInstallMkdirAll(filepath.Dir(path), 0o755); err != nil {
+			return fmt.Errorf("create daemon log directory %s: %w", filepath.Dir(path), err)
+		}
+	}
+	return nil
 }
 
 func escapePlistValue(value string) string {

--- a/internal/cli/daemon_systemd.go
+++ b/internal/cli/daemon_systemd.go
@@ -147,6 +147,18 @@ func systemdDaemonStatus() (daemonStatusResult, error) {
 	}, nil
 }
 
+func systemdDaemonLogs(stdout, stderr io.Writer, options daemonLogsOptions) error {
+	args := []string{
+		"-u", systemdServiceName,
+		"--no-pager",
+		"-n", strconv.Itoa(daemonLogLines(options)),
+	}
+	if options.Follow {
+		args = append(args, "--follow")
+	}
+	return serveInstallRunLogCommand(stdout, stderr, "journalctl", args...)
+}
+
 func systemdServiceActive() (bool, error) {
 	if err := serveInstallRunCommand("systemctl", "is-active", "--quiet", systemdServiceName); err == nil {
 		return true, nil

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -699,6 +699,16 @@ func TestDaemonInstallDarwinEnablesBootstrapsAndKickstartsUserService(t *testing
 	if err != nil {
 		t.Fatalf("read user launchd plist: %v", err)
 	}
+	logPath := filepath.Join(tmpDir, "Library", "Logs", "Cleanroom", "daemon.log")
+	if !strings.Contains(string(raw), "<key>StandardErrorPath</key>") || !strings.Contains(string(raw), logPath) {
+		t.Fatalf("expected user launchd plist to capture stderr at %s:\n%s", logPath, raw)
+	}
+	if !strings.Contains(string(raw), "<key>StandardOutPath</key>") || !strings.Contains(string(raw), logPath) {
+		t.Fatalf("expected user launchd plist to capture stdout at %s:\n%s", logPath, raw)
+	}
+	if _, err := os.Stat(filepath.Dir(logPath)); err != nil {
+		t.Fatalf("expected daemon log directory to be created: %v", err)
+	}
 	if strings.Contains(string(raw), "--listen unix:///var/run/cleanroom/cleanroom.sock") {
 		t.Fatalf("did not expect user launchd plist to use system socket:\n%s", raw)
 	}
@@ -2232,6 +2242,39 @@ func TestDaemonStatusSystemdJSONIncludesEnabled(t *testing.T) {
 	}
 }
 
+func TestDaemonLogsSystemdRunsJournalctl(t *testing.T) {
+	prevGOOS := serveInstallGOOS
+	prevRunLogCommand := serveInstallRunLogCommand
+	serveInstallGOOS = "linux"
+	var calls [][]string
+	serveInstallRunLogCommand = func(stdout, stderr io.Writer, name string, args ...string) error {
+		calls = append(calls, append([]string{name}, args...))
+		return nil
+	}
+	t.Cleanup(func() {
+		serveInstallGOOS = prevGOOS
+		serveInstallRunLogCommand = prevRunLogCommand
+	})
+
+	stdout, _ := makeStdoutCapture(t)
+	stderr, _ := makeStdoutCapture(t)
+	cmd := &DaemonCommand{Action: "logs", Follow: true, Lines: "42", System: true}
+	if err := cmd.Run(&runtimeContext{CWD: t.TempDir(), Stdout: stdout, Stderr: stderr}); err != nil {
+		t.Fatalf("DaemonCommand.Run returned error: %v", err)
+	}
+
+	wantCalls := [][]string{{
+		"journalctl",
+		"-u", systemdServiceName,
+		"--no-pager",
+		"-n", "42",
+		"--follow",
+	}}
+	if !reflect.DeepEqual(calls, wantCalls) {
+		t.Fatalf("unexpected log command: got %v want %v", calls, wantCalls)
+	}
+}
+
 func TestDaemonStatusLaunchdNotInstalled(t *testing.T) {
 	tmpDir := t.TempDir()
 
@@ -2467,6 +2510,104 @@ func TestDaemonStatusLaunchdJSONIncludesListenEndpoint(t *testing.T) {
 	}
 	if payload.Listen != "unix:///tmp/custom-cleanroom.sock" {
 		t.Fatalf("expected listen endpoint, got %q", payload.Listen)
+	}
+}
+
+func TestDaemonLogsLaunchdTailsConfiguredErrorLog(t *testing.T) {
+	tmpDir := t.TempDir()
+	plistPath := filepath.Join(tmpDir, "Library", "LaunchAgents", launchdServiceName+".plist")
+	logPath := filepath.Join(tmpDir, "Library", "Logs", "Cleanroom", "daemon.log")
+	content := renderLaunchdServiceWithLogs(
+		"/usr/local/bin/cleanroom",
+		[]string{"serve", "--listen", "unix:///tmp/custom-cleanroom.sock"},
+		launchdLogPaths{
+			Stdout: logPath,
+			Stderr: logPath,
+		},
+	)
+	if err := os.MkdirAll(filepath.Dir(plistPath), 0o755); err != nil {
+		t.Fatalf("mkdir launch agents dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		t.Fatalf("mkdir log dir: %v", err)
+	}
+	if err := os.WriteFile(plistPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write launchd plist: %v", err)
+	}
+	if err := os.WriteFile(logPath, []byte("ready\n"), 0o644); err != nil {
+		t.Fatalf("write daemon log: %v", err)
+	}
+
+	prevGOOS := serveInstallGOOS
+	prevEUID := serveInstallEUID
+	prevUID := serveInstallUID
+	prevUserHomeDir := serveInstallUserHomeDir
+	prevRunLogCommand := serveInstallRunLogCommand
+	serveInstallGOOS = "darwin"
+	serveInstallEUID = func() int { return 501 }
+	serveInstallUID = func() int { return 501 }
+	serveInstallUserHomeDir = func() (string, error) { return tmpDir, nil }
+	var calls [][]string
+	serveInstallRunLogCommand = func(stdout, stderr io.Writer, name string, args ...string) error {
+		calls = append(calls, append([]string{name}, args...))
+		return nil
+	}
+	t.Cleanup(func() {
+		serveInstallGOOS = prevGOOS
+		serveInstallEUID = prevEUID
+		serveInstallUID = prevUID
+		serveInstallUserHomeDir = prevUserHomeDir
+		serveInstallRunLogCommand = prevRunLogCommand
+	})
+
+	stdout, _ := makeStdoutCapture(t)
+	stderr, _ := makeStdoutCapture(t)
+	cmd := &DaemonCommand{Action: "logs", Follow: true, Lines: "25"}
+	if err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout, Stderr: stderr}); err != nil {
+		t.Fatalf("DaemonCommand.Run returned error: %v", err)
+	}
+
+	wantCalls := [][]string{{"tail", "-n", "25", "-F", logPath}}
+	if !reflect.DeepEqual(calls, wantCalls) {
+		t.Fatalf("unexpected log command: got %v want %v", calls, wantCalls)
+	}
+}
+
+func TestDaemonLogsLaunchdRequiresConfiguredLogPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	plistPath := filepath.Join(tmpDir, "Library", "LaunchAgents", launchdServiceName+".plist")
+	content := renderLaunchdService("/usr/local/bin/cleanroom", []string{"serve", "--listen", "unix:///tmp/custom-cleanroom.sock"})
+	if err := os.MkdirAll(filepath.Dir(plistPath), 0o755); err != nil {
+		t.Fatalf("mkdir launch agents dir: %v", err)
+	}
+	if err := os.WriteFile(plistPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write launchd plist: %v", err)
+	}
+
+	prevGOOS := serveInstallGOOS
+	prevEUID := serveInstallEUID
+	prevUID := serveInstallUID
+	prevUserHomeDir := serveInstallUserHomeDir
+	serveInstallGOOS = "darwin"
+	serveInstallEUID = func() int { return 501 }
+	serveInstallUID = func() int { return 501 }
+	serveInstallUserHomeDir = func() (string, error) { return tmpDir, nil }
+	t.Cleanup(func() {
+		serveInstallGOOS = prevGOOS
+		serveInstallEUID = prevEUID
+		serveInstallUID = prevUID
+		serveInstallUserHomeDir = prevUserHomeDir
+	})
+
+	stdout, _ := makeStdoutCapture(t)
+	stderr, _ := makeStdoutCapture(t)
+	cmd := &DaemonCommand{Action: "logs"}
+	err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout, Stderr: stderr})
+	if err == nil {
+		t.Fatal("expected missing log path error")
+	}
+	if !strings.Contains(err.Error(), "cleanroom daemon install --restart") {
+		t.Fatalf("expected reinstall guidance, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
Daemon output is difficult to inspect when Cleanroom is running under the installed service manager, especially on macOS where the LaunchAgent did not declare stdout or stderr capture paths.

This adds `cleanroom daemon logs` with `-f/--follow` and `-n/--lines` so operators can inspect the installed daemon without knowing the underlying service-manager commands. Linux reads from `journalctl -u cleanroom.service`; macOS tails the log path declared in the LaunchAgent.

On macOS, new or refreshed installs capture both daemon stdout and stderr at `~/Library/Logs/Cleanroom/daemon.log`. For example, after `cleanroom daemon install --restart`, `cleanroom daemon logs -f` follows the same file that can be inspected from Console as a normal user log file.