### PR TITLE
fix: Refresh repository remote tracking refs

### DIFF
--- a/internal/repositorycheckout/checkout.go
+++ b/internal/repositorycheckout/checkout.go
@@ -321,9 +321,37 @@ func refreshScriptWithBundle(checkout *Checkout, bundleRef string) []string {
 		)
 		script = append(script, bundleFetchScript(bundleRef)...)
 	} else {
-		script = append(script, `git -C "$dest" fetch --filter=blob:none --progress origin "$commit"`)
+		script = append(script, refreshFetchScript(checkout)...)
 	}
 	return append(script, checkoutVerificationScript(checkout)...)
+}
+
+func refreshFetchScript(checkout *Checkout) []string {
+	if strings.TrimSpace(checkout.Branch) != "" {
+		return []string{
+			`# Prefer the branch ref so origin/$branch stays useful after refreshing cached checkouts.`,
+			`if ! git -C "$dest" fetch --filter=blob:none --progress origin "+refs/heads/$branch:refs/remotes/origin/$branch"; then`,
+			`  git -C "$dest" fetch --filter=blob:none --progress origin "$commit"`,
+			`fi`,
+			`git -C "$dest" cat-file -e "$commit^{commit}" 2>/dev/null || git -C "$dest" fetch --filter=blob:none --progress origin "$commit"`,
+		}
+	}
+	return []string{
+		`default_ref="$(git -C "$dest" ls-remote --symref origin HEAD | while read -r marker ref target; do if [ "$marker" = "ref:" ] && [ "$target" = "HEAD" ]; then printf '%s\n' "$ref"; break; fi; done)"`,
+		`case "$default_ref" in`,
+		`  refs/heads/*)`,
+		`    default_branch="${default_ref#refs/heads/}"`,
+		`    if ! git -C "$dest" fetch --filter=blob:none --progress origin "+$default_ref:refs/remotes/origin/$default_branch"; then`,
+		`      git -C "$dest" fetch --filter=blob:none --progress origin "$commit"`,
+		`    fi`,
+		`    git -C "$dest" remote set-head origin "$default_branch" >/dev/null 2>&1 || true`,
+		`    ;;`,
+		`  *)`,
+		`    git -C "$dest" fetch --filter=blob:none --progress origin "$commit"`,
+		`    ;;`,
+		`esac`,
+		`git -C "$dest" cat-file -e "$commit^{commit}" 2>/dev/null || git -C "$dest" fetch --filter=blob:none --progress origin "$commit"`,
+	}
 }
 
 func bundleInputScript() []string {

--- a/internal/repositorycheckout/checkout_test.go
+++ b/internal/repositorycheckout/checkout_test.go
@@ -128,8 +128,11 @@ func TestBuildRefreshCommandResetsExistingCheckoutInPlace(t *testing.T) {
 	if !strings.Contains(joined, `if ! git -C "$dest" rev-parse --is-inside-work-tree >/dev/null 2>&1; then`) {
 		t.Fatalf("expected refresh command to require an existing git checkout, got %q", joined)
 	}
+	if !strings.Contains(joined, `git -C "$dest" fetch --filter=blob:none --progress origin "+refs/heads/$branch:refs/remotes/origin/$branch"`) {
+		t.Fatalf("expected refresh command to fetch the requested branch ref, got %q", joined)
+	}
 	if !strings.Contains(joined, `git -C "$dest" fetch --filter=blob:none --progress origin "$commit"`) {
-		t.Fatalf("expected refresh command to fetch the target commit, got %q", joined)
+		t.Fatalf("expected refresh command to fall back to fetching the target commit, got %q", joined)
 	}
 	if !strings.Contains(joined, `git -C "$dest" clean -ffdx`) {
 		t.Fatalf("expected refresh command to discard untracked repository state, got %q", joined)
@@ -203,6 +206,105 @@ func TestBuildRefreshCommandResetsWorkingTreeToExactCommit(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(checkoutDir, "local.txt")); !os.IsNotExist(err) {
 		t.Fatalf("expected untracked file cleanup after refresh, stat error=%v", err)
 	}
+}
+
+func TestBuildRefreshCommandUpdatesRemoteTrackingBranch(t *testing.T) {
+	remoteDir, checkoutDir, firstCommit, secondCommit := createStaleRemoteTrackingCheckout(t)
+
+	if got := strings.TrimSpace(runGit(t, checkoutDir, "rev-parse", "origin/main")); got != firstCommit {
+		t.Fatalf("test setup expected stale origin/main: got %q want %q", got, firstCommit)
+	}
+
+	command := BuildRefreshCommand(&Checkout{
+		RemoteURL:      remoteDir,
+		CommitSHA:      secondCommit,
+		DestinationDir: checkoutDir,
+		Branch:         "main",
+	})
+	cmd := exec.Command(command[0], command[1:]...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("refresh command failed: %v\n%s", err, string(out))
+	}
+
+	if got := strings.TrimSpace(runGit(t, checkoutDir, "rev-parse", "HEAD")); got != secondCommit {
+		t.Fatalf("unexpected checkout commit: got %q want %q", got, secondCommit)
+	}
+	if got := strings.TrimSpace(runGit(t, checkoutDir, "rev-parse", "origin/main")); got != secondCommit {
+		t.Fatalf("unexpected remote-tracking branch: got %q want %q", got, secondCommit)
+	}
+	ahead := strings.TrimSpace(runGit(t, checkoutDir, "rev-list", "--count", "origin/main..HEAD"))
+	behind := strings.TrimSpace(runGit(t, checkoutDir, "rev-list", "--count", "HEAD..origin/main"))
+	if ahead != "0" || behind != "0" {
+		t.Fatalf("expected sandbox branch to match origin/main after refresh, ahead=%s behind=%s", ahead, behind)
+	}
+}
+
+func TestBuildRefreshCommandUpdatesRemoteHeadTrackingBranchWithoutCheckoutBranch(t *testing.T) {
+	remoteDir, checkoutDir, firstCommit, secondCommit := createStaleRemoteTrackingCheckout(t)
+
+	if got := strings.TrimSpace(runGit(t, checkoutDir, "rev-parse", "origin/main")); got != firstCommit {
+		t.Fatalf("test setup expected stale origin/main: got %q want %q", got, firstCommit)
+	}
+
+	command := BuildRefreshCommand(&Checkout{
+		RemoteURL:      remoteDir,
+		CommitSHA:      secondCommit,
+		DestinationDir: checkoutDir,
+	})
+	cmd := exec.Command(command[0], command[1:]...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("refresh command failed: %v\n%s", err, string(out))
+	}
+
+	if got := strings.TrimSpace(runGit(t, checkoutDir, "rev-parse", "HEAD")); got != secondCommit {
+		t.Fatalf("unexpected checkout commit: got %q want %q", got, secondCommit)
+	}
+	if got := strings.TrimSpace(runGit(t, checkoutDir, "rev-parse", "origin/main")); got != secondCommit {
+		t.Fatalf("unexpected remote HEAD tracking branch: got %q want %q", got, secondCommit)
+	}
+	if got := strings.TrimSpace(runGit(t, checkoutDir, "rev-parse", "--abbrev-ref", "HEAD")); got != "HEAD" {
+		t.Fatalf("expected checkout to remain detached without a requested branch, got %q", got)
+	}
+	if got := strings.TrimSpace(runGit(t, checkoutDir, "symbolic-ref", "--short", "refs/remotes/origin/HEAD")); got != "origin/main" {
+		t.Fatalf("expected origin/HEAD to point at origin/main, got %q", got)
+	}
+}
+
+func createStaleRemoteTrackingCheckout(t *testing.T) (remoteDir, checkoutDir, firstCommit, secondCommit string) {
+	t.Helper()
+
+	remoteDir = filepath.Join(t.TempDir(), "remote.git")
+	runGit(t, "", "init", "--bare", remoteDir)
+	runGit(t, remoteDir, "symbolic-ref", "HEAD", "refs/heads/main")
+
+	sourceDir := filepath.Join(t.TempDir(), "source")
+	runGit(t, "", "init", sourceDir)
+	runGit(t, sourceDir, "config", "user.name", "Test User")
+	runGit(t, sourceDir, "config", "user.email", "test@example.com")
+	runGit(t, sourceDir, "checkout", "-B", "main")
+	runGit(t, sourceDir, "remote", "add", "origin", remoteDir)
+
+	readmePath := filepath.Join(sourceDir, "README.md")
+	if err := os.WriteFile(readmePath, []byte("first\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(README.md) returned error: %v", err)
+	}
+	runGit(t, sourceDir, "add", "README.md")
+	runGit(t, sourceDir, "commit", "-m", "first")
+	runGit(t, sourceDir, "push", "-u", "origin", "main")
+	firstCommit = strings.TrimSpace(runGit(t, sourceDir, "rev-parse", "HEAD"))
+
+	checkoutDir = filepath.Join(t.TempDir(), "checkout")
+	runGit(t, "", "clone", remoteDir, checkoutDir)
+
+	if err := os.WriteFile(readmePath, []byte("second\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(README.md) returned error: %v", err)
+	}
+	runGit(t, sourceDir, "commit", "-am", "second")
+	runGit(t, sourceDir, "push", "origin", "main")
+	secondCommit = strings.TrimSpace(runGit(t, sourceDir, "rev-parse", "HEAD"))
+	return remoteDir, checkoutDir, firstCommit, secondCommit
 }
 
 func TestNormalizeRemoteURLPreservesIPv6Brackets(t *testing.T) {


### PR DESCRIPTION
Cached workspace checkouts could refresh to the requested commit while leaving `origin/<branch>` behind from the snapshot. In the release smoke on `main`, that made a clean sandbox report `main...origin/main [ahead 158]` even though `HEAD` matched the requested commit.

This changes repository refreshes to fetch the requested branch ref when Cleanroom knows the branch. For detached refreshes, such as `--repo-url ... --repo-commit latest`, it discovers remote `HEAD` and updates that tracking ref. The exact commit fetch remains as a fallback when the branch ref is unavailable.

The regression tests build stale `origin/main` checkouts and verify both branch and detached refreshes update the tracking refs while preserving the checkout mode.
