### PR TITLE
feat: Support OTel interceptors in public client

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -36,7 +36,8 @@ type TLSOptions struct {
 type Option func(*options)
 
 type options struct {
-	tls tlsconfig.Options
+	tls                 tlsconfig.Options
+	connectInterceptors []connect.Interceptor
 }
 
 // WithTLS configures TLS options for HTTPS endpoints.
@@ -46,6 +47,21 @@ func WithTLS(opts TLSOptions) Option {
 			CertPath: opts.CertPath,
 			KeyPath:  opts.KeyPath,
 			CAPath:   opts.CAPath,
+		}
+	}
+}
+
+// WithConnectInterceptors adds Connect client interceptors to each RPC.
+//
+// This can be used with otelconnect to propagate OpenTelemetry trace context
+// through standard Connect/HTTP headers.
+func WithConnectInterceptors(interceptors ...connect.Interceptor) Option {
+	return func(o *options) {
+		for _, interceptor := range interceptors {
+			if interceptor == nil {
+				continue
+			}
+			o.connectInterceptors = append(o.connectInterceptors, interceptor)
 		}
 	}
 }
@@ -74,7 +90,11 @@ func New(host string, opts ...Option) (*Client, error) {
 	if ep.Scheme == "tssvc" {
 		return nil, errors.New("tssvc:// endpoints are listen-only; use https://<service>.<your-tailnet>.ts.net")
 	}
-	inner, err := controlclient.New(ep, controlclient.WithTLS(o.tls))
+	inner, err := controlclient.New(
+		ep,
+		controlclient.WithTLS(o.tls),
+		controlclient.WithConnectInterceptors(o.connectInterceptors...),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -7,12 +7,19 @@ import (
 	"testing"
 	"time"
 
+	"connectrpc.com/connect"
+	"connectrpc.com/otelconnect"
 	"github.com/buildkite/cleanroom/internal/backend"
 	"github.com/buildkite/cleanroom/internal/controlserver"
 	"github.com/buildkite/cleanroom/internal/controlservice"
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+	"github.com/buildkite/cleanroom/internal/observability"
 	"github.com/buildkite/cleanroom/internal/runtimeconfig"
 	"github.com/buildkite/cleanroom/internal/snapshotstore"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
 )
 
 type integrationAdapter struct{}
@@ -62,6 +69,12 @@ func startIntegrationServer(t *testing.T) string {
 func startSnapshotTestServer(t *testing.T, adapter backend.Adapter) string {
 	t.Helper()
 
+	return startSnapshotTestServerWithObservability(t, adapter, nil)
+}
+
+func startSnapshotTestServerWithObservability(t *testing.T, adapter backend.Adapter, obs *observability.Runtime, interceptors ...connect.Interceptor) string {
+	t.Helper()
+
 	store, err := snapshotstore.New(snapshotstore.Options{
 		MetadataDBPath: t.TempDir() + "/snapshots.db",
 	})
@@ -85,9 +98,10 @@ func startSnapshotTestServer(t *testing.T, adapter backend.Adapter) string {
 		Backends: map[string]backend.Adapter{
 			"firecracker": adapter,
 		},
+		Observability: obs,
 	}
 
-	httpServer := httptest.NewServer(controlserver.New(svc, nil).Handler())
+	httpServer := httptest.NewServer(controlserver.New(svc, nil, interceptors...).Handler())
 	t.Cleanup(httpServer.Close)
 	return httpServer.URL
 }
@@ -227,6 +241,124 @@ func TestClientLifecycle(t *testing.T) {
 	}
 }
 
+func TestWithConnectInterceptorsPropagatesTraceContext(t *testing.T) {
+	t.Parallel()
+
+	recorder := tracetest.NewSpanRecorder()
+	tracerProvider := sdktrace.NewTracerProvider()
+	tracerProvider.RegisterSpanProcessor(recorder)
+	t.Cleanup(func() {
+		_ = tracerProvider.Shutdown(context.Background())
+	})
+
+	serverObs, err := observability.NewWithTracerProvider(tracerProvider)
+	if err != nil {
+		t.Fatalf("NewWithTracerProvider returned error: %v", err)
+	}
+	host := startSnapshotTestServerWithObservability(t, integrationAdapter{}, serverObs, serverObs.ConnectInterceptor())
+
+	clientInterceptor, err := otelconnect.NewInterceptor(
+		otelconnect.WithTracerProvider(tracerProvider),
+		otelconnect.WithPropagator(propagation.NewCompositeTextMapPropagator(
+			propagation.TraceContext{},
+			propagation.Baggage{},
+		)),
+		otelconnect.WithoutMetrics(),
+		otelconnect.WithoutServerPeerAttributes(),
+		otelconnect.WithoutTraceEvents(),
+	)
+	if err != nil {
+		t.Fatalf("create client otelconnect interceptor: %v", err)
+	}
+
+	client, err := New(host, WithConnectInterceptors(clientInterceptor))
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	createSandboxResp, err := client.CreateSandbox(ctx, &CreateSandboxRequest{
+		Policy:  testPolicy(),
+		Backend: "firecracker",
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createSandboxResp.GetSandbox().GetSandboxId()
+	if sandboxID == "" {
+		t.Fatal("expected sandbox_id")
+	}
+
+	rootCtx, rootSpan := tracerProvider.Tracer("github.com/buildkite/cleanroom/client_test").Start(ctx, "bot.turn")
+	rootSpanContext := rootSpan.SpanContext()
+	createExecutionResp, err := client.CreateExecution(rootCtx, &CreateExecutionRequest{
+		SandboxId: sandboxID,
+		Command:   []string{"echo", "hello"},
+	})
+	rootSpan.End()
+	if err != nil {
+		t.Fatalf("CreateExecution returned error: %v", err)
+	}
+	executionID := createExecutionResp.GetExecution().GetExecutionId()
+	if executionID == "" {
+		t.Fatal("expected execution_id")
+	}
+
+	stream, err := client.StreamExecution(ctx, &StreamExecutionRequest{
+		SandboxId:   sandboxID,
+		ExecutionId: executionID,
+		Follow:      true,
+	})
+	if err != nil {
+		t.Fatalf("StreamExecution returned error: %v", err)
+	}
+	sawExit := false
+	for stream.Receive() {
+		if stream.Msg().GetExit() != nil {
+			sawExit = true
+		}
+	}
+	if err := stream.Err(); err != nil {
+		t.Fatalf("StreamExecution stream error: %v", err)
+	}
+	if !sawExit {
+		t.Fatal("expected exit event")
+	}
+
+	clientSpan := waitForEndedSpan(t, recorder, "cleanroom.v1.ExecutionService/CreateExecution", trace.SpanKindClient)
+	serverSpan := waitForEndedSpan(t, recorder, "cleanroom.v1.ExecutionService/CreateExecution", trace.SpanKindServer)
+	createSpan := waitForEndedSpan(t, recorder, observability.SpanExecutionCreate, trace.SpanKindInternal)
+	runSpan := waitForEndedSpan(t, recorder, observability.SpanExecutionRun, trace.SpanKindInternal)
+
+	if got, want := clientSpan.Parent().SpanID(), rootSpanContext.SpanID(); got != want {
+		t.Fatalf("unexpected client span parent: got %s want %s", got, want)
+	}
+	if got, want := serverSpan.Parent().SpanID(), clientSpan.SpanContext().SpanID(); got != want {
+		t.Fatalf("unexpected server span parent: got %s want %s", got, want)
+	}
+	if got, want := createSpan.Parent().SpanID(), serverSpan.SpanContext().SpanID(); got != want {
+		t.Fatalf("unexpected execution create span parent: got %s want %s", got, want)
+	}
+	if got, want := runSpan.Parent().SpanID(), createSpan.SpanContext().SpanID(); got != want {
+		t.Fatalf("unexpected execution run span parent: got %s want %s", got, want)
+	}
+	for _, span := range []struct {
+		name string
+		span sdktrace.ReadOnlySpan
+	}{
+		{name: "client RPC", span: clientSpan},
+		{name: "server RPC", span: serverSpan},
+		{name: "execution create", span: createSpan},
+		{name: "execution run", span: runSpan},
+	} {
+		if got, want := span.span.SpanContext().TraceID(), rootSpanContext.TraceID(); got != want {
+			t.Fatalf("unexpected %s trace id: got %s want %s", span.name, got, want)
+		}
+	}
+}
+
 func TestClientSnapshotLifecycle(t *testing.T) {
 	host := startSnapshotTestServer(t, snapshotIntegrationAdapter{})
 
@@ -305,6 +437,42 @@ func TestClientSnapshotLifecycle(t *testing.T) {
 			t.Fatalf("expected terminated=true for %q", id)
 		}
 	}
+}
+
+func waitForEndedSpan(t *testing.T, recorder *tracetest.SpanRecorder, name string, kind trace.SpanKind) sdktrace.ReadOnlySpan {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		spans := recorder.Ended()
+		if span := findEndedSpan(spans, name, kind); span != nil {
+			return span
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("expected ended %s span %q, got %s", kind, name, endedSpanSummary(spans))
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func findEndedSpan(spans []sdktrace.ReadOnlySpan, name string, kind trace.SpanKind) sdktrace.ReadOnlySpan {
+	for _, span := range spans {
+		if span.Name() == name && span.SpanKind() == kind {
+			return span
+		}
+	}
+	return nil
+}
+
+func endedSpanSummary(spans []sdktrace.ReadOnlySpan) string {
+	if len(spans) == 0 {
+		return "<none>"
+	}
+	names := make([]string, 0, len(spans))
+	for _, span := range spans {
+		names = append(names, span.Name())
+	}
+	return strings.Join(names, ", ")
 }
 
 func TestNewRejectsUnsupportedEndpointScheme(t *testing.T) {

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -75,6 +75,45 @@ In the local Grafana stack:
 - use the `Prometheus` datasource for `cleanroom_*` metrics
 - use the provisioned dashboard for a quick overview
 
+### External Go clients
+
+External callers using `github.com/buildkite/cleanroom/client` can install an
+`otelconnect` client interceptor to propagate W3C TraceContext and Baggage over
+standard Connect/HTTP headers:
+
+```go
+propagator := propagation.NewCompositeTextMapPropagator(
+	propagation.TraceContext{},
+	propagation.Baggage{},
+)
+interceptor, err := otelconnect.NewInterceptor(
+	otelconnect.WithTracerProvider(tracerProvider),
+	otelconnect.WithPropagator(propagator),
+)
+if err != nil {
+	return err
+}
+
+cleanroomClient, err := client.New(
+	os.Getenv("CLEANROOM_HOST"),
+	client.WithConnectInterceptors(interceptor),
+)
+if err != nil {
+	return err
+}
+
+ctx, span := tracerProvider.Tracer("botdash").Start(ctx, "bot.turn")
+defer span.End()
+
+_, err = cleanroomClient.CreateExecution(ctx, &client.CreateExecutionRequest{
+	SandboxId: sandboxID,
+	Command:   []string{"go", "test", "./..."},
+})
+```
+
+Trace propagation does not require any Cleanroom proto fields such as
+`traceparent`; it uses the normal Connect request headers.
+
 ## Related docs
 
 - [examples/observability/README.md](../examples/observability/README.md) for


### PR DESCRIPTION
External SDK callers need Cleanroom RPCs to join an existing OpenTelemetry trace, but the public Go client did not expose a way to install Connect client interceptors. That left botdash/janebot-style integrations unable to pass W3C TraceContext and Baggage through the supported SDK surface even though the server already trusts remote context.

This adds `client.WithConnectInterceptors(...)` and wires it through `client.New` to the internal control client so callers can pass `otelconnect` or other Connect interceptors for all public SDK RPCs.

For example, an external bot can create an `otelconnect` interceptor with TraceContext/Baggage propagation, pass it to `client.New(..., client.WithConnectInterceptors(interceptor))`, and call `CreateExecution` under its bot-turn span. Propagation stays in standard Connect/HTTP headers; no `traceparent` proto fields are added.

The public-client regression test exercises a parent span around `CreateExecution` and asserts the client RPC span, server RPC span, `cleanroom.execution.create`, and `cleanroom.execution.run` all share the same trace.