### PR TITLE
feat: Add manual sandbox suspend lifecycle

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -176,6 +176,20 @@ func (c *Client) ExtractSandboxArchive(ctx context.Context) (*connect.ClientStre
 	return c.inner.ExtractSandboxArchive(ctx), nil
 }
 
+func (c *Client) SuspendSandbox(ctx context.Context, req *SuspendSandboxRequest) (*SuspendSandboxResponse, error) {
+	if c == nil || c.inner == nil {
+		return nil, errors.New("nil client")
+	}
+	return c.inner.SuspendSandbox(ctx, req)
+}
+
+func (c *Client) ResumeSandbox(ctx context.Context, req *ResumeSandboxRequest) (*ResumeSandboxResponse, error) {
+	if c == nil || c.inner == nil {
+		return nil, errors.New("nil client")
+	}
+	return c.inner.ResumeSandbox(ctx, req)
+}
+
 func (c *Client) TerminateSandbox(ctx context.Context, req *TerminateSandboxRequest) (*TerminateSandboxResponse, error) {
 	if c == nil || c.inner == nil {
 		return nil, errors.New("nil client")

--- a/client/types.go
+++ b/client/types.go
@@ -13,6 +13,9 @@ const (
 	SandboxStatus_SANDBOX_STATUS_STOPPING     = cleanroomv1.SandboxStatus_SANDBOX_STATUS_STOPPING
 	SandboxStatus_SANDBOX_STATUS_STOPPED      = cleanroomv1.SandboxStatus_SANDBOX_STATUS_STOPPED
 	SandboxStatus_SANDBOX_STATUS_FAILED       = cleanroomv1.SandboxStatus_SANDBOX_STATUS_FAILED
+	SandboxStatus_SANDBOX_STATUS_SUSPENDING   = cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDING
+	SandboxStatus_SANDBOX_STATUS_SUSPENDED    = cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDED
+	SandboxStatus_SANDBOX_STATUS_WAKING       = cleanroomv1.SandboxStatus_SANDBOX_STATUS_WAKING
 )
 
 type PolicyAllowRule = cleanroomv1.PolicyAllowRule
@@ -60,6 +63,10 @@ type ArchiveSandboxPathsResponse = cleanroomv1.ArchiveSandboxPathsResponse
 type ExtractSandboxArchiveInit = cleanroomv1.ExtractSandboxArchiveInit
 type ExtractSandboxArchiveRequest = cleanroomv1.ExtractSandboxArchiveRequest
 type ExtractSandboxArchiveResponse = cleanroomv1.ExtractSandboxArchiveResponse
+type SuspendSandboxRequest = cleanroomv1.SuspendSandboxRequest
+type SuspendSandboxResponse = cleanroomv1.SuspendSandboxResponse
+type ResumeSandboxRequest = cleanroomv1.ResumeSandboxRequest
+type ResumeSandboxResponse = cleanroomv1.ResumeSandboxResponse
 type TerminateSandboxRequest = cleanroomv1.TerminateSandboxRequest
 type TerminateSandboxResponse = cleanroomv1.TerminateSandboxResponse
 type StreamSandboxEventsRequest = cleanroomv1.StreamSandboxEventsRequest

--- a/docs/api.md
+++ b/docs/api.md
@@ -82,8 +82,10 @@ Two services are sufficient.
 10. `RemoveSandboxPath(RemoveSandboxPathRequest) returns (RemoveSandboxPathResponse)` (unary)
 11. `ArchiveSandboxPaths(ArchiveSandboxPathsRequest) returns (stream ArchiveSandboxPathsResponse)` (server-streaming)
 12. `ExtractSandboxArchive(stream ExtractSandboxArchiveRequest) returns (ExtractSandboxArchiveResponse)` (client-streaming)
-13. `TerminateSandbox(TerminateSandboxRequest) returns (TerminateSandboxResponse)` (unary)
-14. `StreamSandboxEvents(StreamSandboxEventsRequest) returns (stream SandboxEvent)` (server-streaming)
+13. `SuspendSandbox(SuspendSandboxRequest) returns (SuspendSandboxResponse)` (unary)
+14. `ResumeSandbox(ResumeSandboxRequest) returns (ResumeSandboxResponse)` (unary)
+15. `TerminateSandbox(TerminateSandboxRequest) returns (TerminateSandboxResponse)` (unary)
+16. `StreamSandboxEvents(StreamSandboxEventsRequest) returns (stream SandboxEvent)` (server-streaming)
 
 ### 4.2 ExecutionService
 
@@ -110,6 +112,9 @@ Two services are sufficient.
 - `SANDBOX_STATUS_STOPPING`
 - `SANDBOX_STATUS_STOPPED`
 - `SANDBOX_STATUS_FAILED`
+- `SANDBOX_STATUS_SUSPENDING`
+- `SANDBOX_STATUS_SUSPENDED`
+- `SANDBOX_STATUS_WAKING`
 
 ### 5.2 Execution statuses
 
@@ -177,6 +182,8 @@ service SandboxService {
   rpc RemoveSandboxPath(RemoveSandboxPathRequest) returns (RemoveSandboxPathResponse);
   rpc ArchiveSandboxPaths(ArchiveSandboxPathsRequest) returns (stream ArchiveSandboxPathsResponse);
   rpc ExtractSandboxArchive(stream ExtractSandboxArchiveRequest) returns (ExtractSandboxArchiveResponse);
+  rpc SuspendSandbox(SuspendSandboxRequest) returns (SuspendSandboxResponse);
+  rpc ResumeSandbox(ResumeSandboxRequest) returns (ResumeSandboxResponse);
   rpc TerminateSandbox(TerminateSandboxRequest) returns (TerminateSandboxResponse);
   rpc StreamSandboxEvents(StreamSandboxEventsRequest) returns (stream SandboxEvent);
 }
@@ -211,6 +218,25 @@ enum SandboxStatus {
   SANDBOX_STATUS_STOPPING = 3;
   SANDBOX_STATUS_STOPPED = 4;
   SANDBOX_STATUS_FAILED = 5;
+  SANDBOX_STATUS_SUSPENDING = 6;
+  SANDBOX_STATUS_SUSPENDED = 7;
+  SANDBOX_STATUS_WAKING = 8;
+}
+
+message SuspendSandboxRequest {
+  string sandbox_id = 1;
+}
+
+message SuspendSandboxResponse {
+  Sandbox sandbox = 1;
+}
+
+message ResumeSandboxRequest {
+  string sandbox_id = 1;
+}
+
+message ResumeSandboxResponse {
+  Sandbox sandbox = 1;
 }
 
 message Execution {
@@ -304,6 +330,8 @@ Expose a server mode and API-driven commands in the same binary.
 - `cleanroom sandbox inspect <sandbox-id>`
 - `cleanroom sandbox inspect --last`
 - `cleanroom sandbox ls`
+- `cleanroom sandbox suspend <sandbox-id>`
+- `cleanroom sandbox resume <sandbox-id>`
 - `cleanroom sandbox rm <sandbox-id>`
 
 `sandbox inspect` is the primary way to discover a sandbox's `last_execution_id` and `active_execution_id`.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -137,7 +137,8 @@ metric labels.
 Sandbox resource metrics are aggregate gauges for active sandboxes grouped by
 backend and status. They report the effective launch envelope Cleanroom
 resolved for each sandbox, not guest runtime memory pressure or exact host
-reservations.
+reservations. Failed sandboxes remain in these aggregates until termination,
+because a failed wake can leave backend resources allocated.
 
 ### Common attributes
 

--- a/docs/plans/sandbox-suspend-wake.md
+++ b/docs/plans/sandbox-suspend-wake.md
@@ -1,0 +1,544 @@
+# Transparent Sandbox Suspend And Wake Plan
+
+**Status:** Active
+**Last reviewed:** 2026-05-24
+**Spec references:** `docs/api.md`, `docs/snapshots.md`, `docs/backend/darwin-vz.md`
+**Related plans:** `docs/plans/system-storage-prune.md`, `docs/plans/layered-caching.md`
+
+## Summary
+
+Allow idle persistent sandboxes to suspend on the same host and wake
+transparently when a user performs an operation that needs the guest VM. The
+first useful version should reduce idle CPU and memory pressure without changing
+the normal `cleanroom exec --in`, file-transfer, or local exposure workflows.
+
+This is not a replacement for snapshots. Existing snapshots save a sandbox
+filesystem so future sandboxes can fresh-boot from that state. Transparent
+suspend keeps the same sandbox identity and guest process state on the same
+daemon while the VM is paused. Later live checkpoint or hibernation work can
+build on the lifecycle surface, but it needs a separate backend capability and
+stronger restore semantics.
+
+Start with `darwin-vz`, because the helper already exposes `PauseVM` and
+`ResumeVM`, and the backend already uses those operations internally while
+capturing filesystem snapshots. Firecracker can follow with a same-host freeze
+using its existing `SIGSTOP` / `SIGCONT` helpers, but that should be described
+as a CPU freeze until we prove memory reclamation or durable checkpointing.
+
+## Problem
+
+Cleanroom persistent sandboxes stay fully running until explicit termination.
+That is useful for fast repeated commands, long-lived service processes, and
+local port exposures, but it makes idle sandboxes consume host resources even
+when the user is not interacting with them.
+
+The current lifecycle model has no suspended state. `SandboxStatus` only
+distinguishes provisioning, ready, stopping, stopped, and failed. Control-service
+operations generally require `READY` before touching the guest, and the backend
+adapter interface only exposes provision, run, and terminate. That leaves no
+place to express "this sandbox still exists, but the VM must wake before the
+next guest operation."
+
+The project already has filesystem snapshot semantics, but those are fresh-boot
+restore points. Reusing snapshot language for idle VM suspension would create
+the wrong expectation around live processes, network identity, open sockets, and
+daemon restart durability.
+
+## Goals
+
+- Add backend-neutral sandbox lifecycle states for suspended and waking
+  sandboxes.
+- Wake suspended sandboxes automatically for guest-touching operations.
+- Keep pure control-plane inspection from waking a VM.
+- Keep policy and repository behavior unchanged.
+- Make host resource policy runtime config, not `cleanroom.yaml`.
+- Fail closed when a backend or sandbox does not support suspend.
+- Preserve existing busy-state invariants around active executions, repository
+  preparation, and file transfers.
+- Provide enough events and observability to explain why an operation waited.
+- Land a small `darwin-vz` first slice before broader backend or hibernation
+  work.
+
+## Non-goals
+
+- Do not add live VM memory checkpoint/restore in the first slice.
+- Do not make user snapshots represent live process state.
+- Do not promise suspended sandboxes survive daemon restart.
+- Do not promise open TCP connections survive suspension.
+- Do not add project policy fields for suspend behavior.
+- Do not add a cross-machine VM fork or fan-out contract.
+- Do not silently terminate unsupported backend sandboxes to mimic suspension.
+
+## Current State
+
+Relevant current behavior:
+
+- `docs/snapshots.md` says snapshots are filesystem savepoints, not live process
+  or memory checkpoints.
+- `proto/cleanroom/v1/control.proto` exposes `Sandbox.status` and the current
+  `SandboxStatus` enum with `PROVISIONING`, `READY`, `STOPPING`, `STOPPED`, and
+  `FAILED`.
+- There are no suspend/resume RPCs, control-client methods, control-server
+  handlers, or `cleanroom sandbox` subcommands today.
+- `internal/backend/backend.go` has capability flags and small optional backend
+  interfaces for snapshots, file transfer, and port dialing.
+- `internal/controlservice/service.go` tracks each sandbox's backend,
+  capabilities, policy, active execution, repository busy state, file-transfer
+  state, status, and event feed.
+- `beginSandboxFileTransfer`, `CreateExecution`, `DialSandboxPort`, and
+  snapshot creation all reject non-ready sandboxes before touching the guest.
+- `cmd/cleanroom-darwin-vz/main.swift` implements helper `PauseVM` and
+  `ResumeVM`.
+- `internal/backend/darwinvz/backend_darwin.go` uses helper pause/resume while
+  creating filesystem snapshots.
+- `internal/backend/firecracker/backend.go` has process-level pause/resume
+  helpers for snapshot capture.
+
+These are enough for a same-daemon, same-host suspend/wake feature without
+changing guest bootstrap, repository bootstrap, or snapshot storage.
+
+## Current Progress
+
+Slice 1 has been implemented in this change: lifecycle statuses, backend
+capability inference, explicit suspend/resume RPCs, control-client and
+control-server plumbing, manual CLI commands, `darwin-vz` helper calls, and
+focused unit and integration tests.
+
+Transparent wake gates, the idle suspend scheduler, runtime config, metrics,
+real installed-daemon smoke tests, and Firecracker support remain follow-up
+slices.
+
+## Target Lifecycle Model
+
+Extend sandbox status with explicit transient and stable suspended states:
+
+```proto
+enum SandboxStatus {
+  SANDBOX_STATUS_UNSPECIFIED = 0;
+  SANDBOX_STATUS_PROVISIONING = 1;
+  SANDBOX_STATUS_READY = 2;
+  SANDBOX_STATUS_STOPPING = 3;
+  SANDBOX_STATUS_STOPPED = 4;
+  SANDBOX_STATUS_FAILED = 5;
+  SANDBOX_STATUS_SUSPENDING = 6;
+  SANDBOX_STATUS_SUSPENDED = 7;
+  SANDBOX_STATUS_WAKING = 8;
+}
+```
+
+State transitions:
+
+```text
+READY -> SUSPENDING -> SUSPENDED -> WAKING -> READY
+READY -> STOPPING -> STOPPED
+SUSPENDED -> STOPPING -> STOPPED
+WAKING -> FAILED
+SUSPENDING -> READY
+```
+
+`SUSPENDED` means the sandbox identity, metadata, rootfs, helper process, and
+backend instance still exist, but guest execution is paused. The control service
+must wake the sandbox before any operation that requires guest code or guest
+network connectivity.
+
+`SUSPENDING -> READY` is the normal failure recovery path for a suspend attempt,
+especially automatic idle suspend. If the backend cannot pause a still-running
+sandbox, the control service should publish a failed-suspend event and leave the
+sandbox usable. It should mark the sandbox `FAILED` only when the backend reports
+that the instance is gone, corrupt, or otherwise cannot safely continue.
+
+`STOPPED` remains terminal. Stopped sandboxes are not wakeable.
+
+## Wake Semantics
+
+Guest-touching operations should wake a suspended sandbox before continuing:
+
+- `CreateExecution`, including `sandbox.run.before`.
+- Internal workspace copy-in executions.
+- `DownloadSandboxFile`, `UploadSandboxFile`, `StatSandboxPath`,
+  `WalkSandboxTree`, `ReadSandboxFile`, `WriteSandboxFile`,
+  `RemoveSandboxPath`, `ArchiveSandboxPaths`, and `ExtractSandboxArchive`.
+- `DialSandboxPort`, including local exposure connections.
+- Snapshot creation, because it runs guest `sync` before capturing storage.
+
+Pure control-plane operations should not wake the sandbox:
+
+- `GetSandbox`
+- `ListSandboxes`
+- `ListExecutions`
+- `GetExecution`
+- `InspectExecution`
+- `StreamSandboxEvents`
+- `StreamExecution`
+- `TerminateSandbox`
+
+Local exposures need special handling. Today client-side exposure setup checks
+that the sandbox is `READY` before registering listeners. That should change to
+allow `SUSPENDED` when the sandbox reports the new suspend capability. The
+actual incoming connection should wake through `DialSandboxPort`, then dial the
+guest port after the backend reports ready.
+
+## Runtime Config
+
+Suspend policy belongs in runtime config because it is host resource management.
+The first implementation should add one host-level section:
+
+```yaml
+sandbox_lifecycle:
+  idle_suspend_after_seconds: 600
+  wake_timeout_seconds: 30
+```
+
+Semantics:
+
+- omitted or zero `idle_suspend_after_seconds` disables automatic idle suspend
+  by default
+- `wake_timeout_seconds` bounds transparent wake waits, defaulting to the
+  backend launch timeout when unset
+- the policy applies only to backends that report `sandbox.suspend=true`
+
+The first slice should implement the manual suspend/resume API and CLI before
+enabling the idle timer by default. Once the wake path is proven, automatic idle
+suspend can be turned on by config.
+
+Avoid per-project fields in `cleanroom.yaml`. A repository should not decide how
+aggressively a developer or CI host reclaims idle VM resources.
+
+## Adapter Contract
+
+Add one capability and one optional interface:
+
+```go
+const CapabilitySandboxSuspend = "sandbox.suspend"
+
+type SuspendableAdapter interface {
+    Adapter
+    SuspendSandbox(ctx context.Context, sandboxID string) error
+    ResumeSandbox(ctx context.Context, sandboxID string) error
+}
+```
+
+`CapabilitiesForAdapter` should infer `sandbox.suspend=true` when the adapter
+implements `SuspendableAdapter`, while still allowing backend-specific
+capability reporting to force it off if runtime config makes it unavailable.
+
+Adapter requirements:
+
+- `SuspendSandbox` must be idempotent for an already suspended backend instance
+  when the backend can detect that state.
+- `ResumeSandbox` must be idempotent for an already running backend instance
+  when the backend can detect that state.
+- Both operations must return an error for unknown sandboxes.
+- The adapter must not mutate policy, repository state, snapshot metadata, or
+  user-visible sandbox identity.
+- Backends that cannot suspend must simply not implement the interface.
+
+## Control-Service Design
+
+Expose explicit control-plane methods for manual lifecycle testing and operator
+use:
+
+```proto
+rpc SuspendSandbox(SuspendSandboxRequest) returns (SuspendSandboxResponse);
+rpc ResumeSandbox(ResumeSandboxRequest) returns (ResumeSandboxResponse);
+
+message SuspendSandboxRequest {
+  string sandbox_id = 1;
+}
+
+message SuspendSandboxResponse {
+  Sandbox sandbox = 1;
+}
+
+message ResumeSandboxRequest {
+  string sandbox_id = 1;
+}
+
+message ResumeSandboxResponse {
+  Sandbox sandbox = 1;
+}
+```
+
+These RPCs should also be exposed through the control client, control server, and
+`cleanroom sandbox suspend|resume` commands in the first slice. Transparent wake
+for guest-touching operations remains implicit and does not require users to call
+`ResumeSandbox` directly.
+
+Add a small lifecycle gate around guest-touching operations. It should replace
+the repeated "status must be `READY`" checks with a common helper that can wake
+first, then claim the operation-specific busy marker.
+
+The helper should:
+
+1. Look up the sandbox and adapter.
+2. Reject terminal, provisioning, stopping, or failed states.
+3. If the sandbox is `SUSPENDED`, transition it to `WAKING`, publish a sandbox
+   event, and call `ResumeSandbox` without holding `s.mu`.
+4. Coalesce concurrent wake attempts so only one backend resume call runs.
+5. On successful wake, transition to `READY` and continue.
+6. On wake failure, transition to `FAILED` and return a clear error.
+7. Claim the requested operation marker, such as active execution or file
+   transfer, only after the sandbox is ready.
+
+Add a generic guest-interaction lease or explicit counters for interaction types
+that do not currently have a busy marker. `DialSandboxPort` is the important
+case: an accepted local exposure connection should hold a lease until the
+proxied connection closes, so the idle worker does not pause the VM underneath
+an active tunnel.
+
+The gate should keep the existing idle checks:
+
+- no active non-final execution
+- no repository preparation
+- no file transfer unless the caller is claiming that transfer
+- no suspension while another lifecycle operation is in flight
+- no active guest-interaction leases such as port dials
+
+The idle suspend worker should use the same checks before calling
+`SuspendSandbox`. It must not suspend a sandbox while a file transfer, execution,
+repository refresh, snapshot, or port dial is active.
+
+For observability, publish sandbox events such as:
+
+- `sandbox idle suspend requested`
+- `sandbox suspended`
+- `sandbox suspend failed: ...`
+- `sandbox wake requested`
+- `sandbox ready after wake`
+- `sandbox wake failed: ...`
+
+Metrics should include backend, outcome, and duration for suspend and wake. Do
+not include sandbox ids in metric labels.
+
+## Backend Notes
+
+### darwin-vz
+
+The first backend should call helper `PauseVM` and `ResumeVM` for the existing
+helper session and VM id. That is the narrowest path because these operations
+already exist and are used in snapshot capture.
+
+The backend should keep the helper process, proxy socket, filehandle gateway,
+rootfs attachment, cache-output volumes, and sandbox runtime directory alive
+while suspended. Wake should use the same proxy socket and guest agent path that
+normal executions already use.
+
+A follow-up optimization can lower the memory balloon target before pausing and
+restore it on wake. That should not be part of the first correctness slice
+unless local measurements show pause alone does not reduce the resource pressure
+we care about.
+
+### Firecracker
+
+Firecracker can support a later same-host freeze using the existing
+`pauseSandboxProcess` and `resumeSandboxProcess` helpers. Treat that as a CPU
+freeze and process scheduling control only. It does not release rootfs storage,
+does not prove memory reclamation, and does not survive daemon restart.
+
+Do not expose Firecracker support until a real host smoke proves:
+
+- command execution succeeds after suspend and wake
+- local port dialing wakes and connects
+- gateway firewall state remains correct
+- termination works from both suspended and waking states
+
+### Hibernation And Checkpointing
+
+Live checkpoint/restore should be a separate later capability, for example
+`sandbox.hibernate`, not an implementation detail hidden behind
+`sandbox.suspend`.
+
+That design must handle:
+
+- restoring network identity and gateway registration
+- reopening vsock, serial, helper, or proxy transports
+- invalidating stale local exposure connections
+- guest clock and timer behavior after restore
+- daemon restart and host reboot semantics
+- whether memory image size makes the feature faster than fresh boot
+
+Until then, suspended sandboxes are same-daemon and same-host only.
+
+## Safety Invariants
+
+- Unsupported backends fail closed and never pretend termination is suspension.
+- Waking a sandbox must not widen network policy or skip stage-scoped egress
+  selection.
+- Suspension must not run while guest-mutating work is active.
+- `TerminateSandbox` must work from `READY`, `SUSPENDING`, `SUSPENDED`, and
+  `WAKING`.
+- `CreateSnapshot` must either wake and run the existing guest `sync` path or
+  return a clear error. It must not snapshot an unknown paused filesystem state
+  without the existing sync boundary.
+- Pure inspection should not wake a VM.
+- Control-service locks must not be held while calling backend suspend or
+  resume.
+- Failed suspend must be non-terminal when the sandbox is still running: publish
+  an event, revert to `READY`, and retry only after the next idle window. Mark
+  `FAILED` only when the backend reports a lost or unusable instance.
+- Failed wake should be visible as a sandbox event and final `FAILED` state, not
+  an endless `WAKING` state.
+- Idle timers must be disabled by default until real backend smoke tests prove
+  the behavior.
+
+## Delivery Strategy
+
+### Slice 1: Lifecycle Surface And Manual darwin-vz Wake
+
+Add the enum states, capability, `SuspendableAdapter`, and `darwin-vz`
+implementation. Add explicit suspend/resume RPCs, control-client methods,
+control-server handlers, service methods, CLI commands, and status formatting,
+but keep automatic idle suspend disabled.
+
+Definition of done:
+
+- unit tests cover status transitions, capability reporting, unsupported
+  backend errors, failed suspend recovery to `READY`, and wake failure
+- `darwin-vz` unit tests prove `PauseVM` and `ResumeVM` are called
+- `cleanroom sandbox suspend <sandbox-id>` pauses a ready `darwin-vz` sandbox
+- `cleanroom sandbox resume <sandbox-id>` resumes a suspended `darwin-vz`
+  sandbox
+- `GetSandbox` and `ListSandboxes` show suspended state without waking
+- CLI inspect/list output renders `SUSPENDING`, `SUSPENDED`, and `WAKING`
+  explicitly rather than as `unknown`
+
+The first CLI surface is intentionally narrow and manual. It exists to prove the
+backend and control-plane lifecycle before transparent wake and idle timers are
+enabled:
+
+```console
+cleanroom sandbox suspend <sandbox-id>
+cleanroom sandbox resume <sandbox-id>
+```
+
+### Slice 2: Transparent Wake Gates
+
+Wire wake into `CreateExecution`, file transfer operations, snapshot creation,
+and `DialSandboxPort`.
+
+Definition of done:
+
+- suspended sandbox `CreateExecution` wakes and runs
+- suspended sandbox file read/write wakes and completes
+- suspended sandbox local exposure connection wakes through `DialSandboxPort`
+- concurrent wake attempts coalesce
+- unsupported backends still return clear capability errors
+
+### Slice 3: Idle Suspend Runtime Policy
+
+Add `sandbox_lifecycle` runtime config and an idle scheduler in the daemon.
+Keep the default disabled. When enabled, suspend only sandboxes that remain idle
+past the configured threshold.
+
+Definition of done:
+
+- config loading and validation tests cover zero, positive, and invalid values
+- idle worker skips busy sandboxes
+- idle worker publishes events for suspend attempts and results
+- `cleanroom config validate` rejects invalid lifecycle values
+
+### Slice 4: Observability And Real Host Smoke
+
+Add metrics, logs, and a real `darwin-vz` smoke test path.
+
+Definition of done:
+
+- traces or metrics include suspend and wake duration and outcome
+- smoke test creates a sandbox, suspends it, runs a command after wake, reads a
+  file after wake, and terminates it
+- local exposure smoke confirms an incoming connection wakes and reaches the
+  guest service
+
+### Slice 5: Firecracker Freeze Experiment
+
+Implement Firecracker same-host freeze only after the `darwin-vz` path has
+landed.
+
+Definition of done:
+
+- capability reports accurately on supported hosts
+- host smoke proves execution and port dialing after wake
+- docs describe it as freeze/resume, not memory hibernation
+
+## Verification
+
+Unit tests:
+
+- capability inference for `SuspendableAdapter`
+- status transition helpers
+- wake coalescing
+- idle eligibility
+- unsupported backend errors
+- terminal state rejection
+- pure inspection does not wake
+- file transfer and execution wake before claiming busy state
+
+Integration tests:
+
+- service-level fake adapter test for suspended `CreateExecution`
+- service-level fake adapter test for suspended file transfer
+- service-level fake adapter test for suspended `DialSandboxPort`
+- concurrent wake test with multiple callers
+- termination from suspended and waking states
+
+Runtime smoke:
+
+```bash
+mise run build
+CLEANROOM_DARWIN_VZ_E2E=1 mise exec -- go test ./internal/backend/darwinvz -run TestPersistentSandboxSuspendWakeE2E -v
+```
+
+Manual installed-daemon proof before enabling automatic idle suspend:
+
+```bash
+/usr/local/bin/cleanroom doctor --backend darwin-vz --json
+/usr/local/bin/cleanroom daemon status
+/usr/local/bin/cleanroom sandbox create --image ghcr.io/buildkite/cleanroom-base/alpine:latest
+/usr/local/bin/cleanroom sandbox suspend <sandbox-id>
+/usr/local/bin/cleanroom exec --in <sandbox-id> -- uname -a
+/usr/local/bin/cleanroom sandbox inspect <sandbox-id>
+```
+
+## Key Learnings From Pressure-Testing
+
+The main risk is overpromising. "Suspend" can mean pause, hibernate, checkpoint,
+or stop depending on the system. The first Cleanroom contract should be explicit:
+same-host, same-daemon VM pause with transparent wake for the next guest
+operation. That avoids contaminating user snapshots with live memory semantics.
+
+The second risk is hidden operation paths. File transfer, snapshots, and port
+dialing all execute guest-sensitive work without looking like normal `exec`.
+The control service should centralize wake gating instead of adding one-off
+status exceptions.
+
+The third risk is racing lifecycle transitions with active work. The plan keeps
+busy checks and backend calls separate: decide and mark lifecycle transitions
+under the service lock, perform backend work outside the lock, then re-check and
+publish final state.
+
+Automatic idle suspend is deliberately not the first behavior. Manual
+suspend/resume plus transparent wake gives a narrow correctness target before a
+daemon timer starts changing user-visible lifecycle behavior.
+
+## Resolved Decisions
+
+- Use a new lifecycle surface, not snapshot semantics.
+- Keep suspend policy in runtime config rather than repository policy.
+- Start with `darwin-vz`.
+- Make `SUSPENDED` visible in `GetSandbox`, `ListSandboxes`, and event streams.
+- Do not wake for pure control-plane inspection.
+- Expose manual `sandbox suspend` and `sandbox resume` commands in the first PR
+  so the lifecycle can be proven against an installed daemon before idle timers
+  exist.
+- Treat Firecracker and hibernation as follow-up work.
+
+## Deferred Questions
+
+- What idle timeout should the installer eventually recommend for local
+  developer machines?
+- Should automatic idle suspend ever be enabled by default, or remain explicit
+  host config?
+- Can memory ballooning before `darwin-vz` pause materially reduce host memory
+  pressure without adding surprising wake latency?
+- What is the right support boundary for suspended sandboxes with open local
+  exposure connections?

--- a/docs/plans/sandbox-suspend-wake.md
+++ b/docs/plans/sandbox-suspend-wake.md
@@ -283,7 +283,9 @@ The helper should:
    event, and call `ResumeSandbox` without holding `s.mu`.
 4. Coalesce concurrent wake attempts so only one backend resume call runs.
 5. On successful wake, transition to `READY` and continue.
-6. On wake failure, transition to `FAILED` and return a clear error.
+6. On wake failure, transition to `FAILED` and return a clear error. Keep
+   `FAILED` sandboxes in active-resource metrics until termination confirms
+   resources are gone.
 7. Claim the requested operation marker, such as active execution or file
    transfer, only after the sandbox is ready.
 
@@ -388,7 +390,8 @@ Until then, suspended sandboxes are same-daemon and same-host only.
   backend proves it is running. Use `SUSPENDED` as the retryable conservative
   state.
 - Failed wake should be visible as a sandbox event and final `FAILED` state for
-  definite backend errors, not an endless `WAKING` state.
+  definite backend errors, not an endless `WAKING` state. `FAILED` still counts
+  in active-resource metrics until termination confirms cleanup.
 - Idle timers must be disabled by default until real backend smoke tests prove
   the behavior.
 

--- a/docs/plans/sandbox-suspend-wake.md
+++ b/docs/plans/sandbox-suspend-wake.md
@@ -148,10 +148,11 @@ especially automatic idle suspend. If the backend cannot pause a still-running
 sandbox, the control service should publish a failed-suspend event and leave the
 sandbox usable. It should mark the sandbox `FAILED` only when the backend reports
 that the instance is gone, corrupt, or otherwise cannot safely continue.
-Deadline or cancellation errors are indeterminate because the backend may have
-already applied the lifecycle operation before the response failed. In those
-cases, the control plane should keep the sandbox in the conservative retryable
-state: `SUSPENDED` after ambiguous suspend or wake results.
+Deadline, cancellation, or backend-signaled transport/response errors are
+indeterminate because the backend may have already applied the lifecycle
+operation before the response failed. In those cases, the control plane should
+keep the sandbox in the conservative retryable state: `SUSPENDED` after
+ambiguous suspend or wake results.
 
 `STOPPED` remains terminal. Stopped sandboxes are not wakeable.
 
@@ -382,9 +383,10 @@ Until then, suspended sandboxes are same-daemon and same-host only.
 - Failed suspend must be non-terminal when the sandbox is still running: publish
   an event, revert to `READY`, and retry only after the next idle window. Mark
   `FAILED` only when the backend reports a lost or unusable instance.
-- Ambiguous suspend or wake results, such as deadline and cancellation errors,
-  must not leave the sandbox in `READY` unless the backend proves it is running.
-  Use `SUSPENDED` as the retryable conservative state.
+- Ambiguous suspend or wake results, such as deadline, cancellation, and helper
+  transport or response errors, must not leave the sandbox in `READY` unless the
+  backend proves it is running. Use `SUSPENDED` as the retryable conservative
+  state.
 - Failed wake should be visible as a sandbox event and final `FAILED` state for
   definite backend errors, not an endless `WAKING` state.
 - Idle timers must be disabled by default until real backend smoke tests prove

--- a/docs/plans/sandbox-suspend-wake.md
+++ b/docs/plans/sandbox-suspend-wake.md
@@ -134,6 +134,8 @@ READY -> STOPPING -> STOPPED
 SUSPENDED -> STOPPING -> STOPPED
 WAKING -> FAILED
 SUSPENDING -> READY
+SUSPENDING -> SUSPENDED
+WAKING -> SUSPENDED
 ```
 
 `SUSPENDED` means the sandbox identity, metadata, rootfs, helper process, and
@@ -146,6 +148,10 @@ especially automatic idle suspend. If the backend cannot pause a still-running
 sandbox, the control service should publish a failed-suspend event and leave the
 sandbox usable. It should mark the sandbox `FAILED` only when the backend reports
 that the instance is gone, corrupt, or otherwise cannot safely continue.
+Deadline or cancellation errors are indeterminate because the backend may have
+already applied the lifecycle operation before the response failed. In those
+cases, the control plane should keep the sandbox in the conservative retryable
+state: `SUSPENDED` after ambiguous suspend or wake results.
 
 `STOPPED` remains terminal. Stopped sandboxes are not wakeable.
 
@@ -376,8 +382,11 @@ Until then, suspended sandboxes are same-daemon and same-host only.
 - Failed suspend must be non-terminal when the sandbox is still running: publish
   an event, revert to `READY`, and retry only after the next idle window. Mark
   `FAILED` only when the backend reports a lost or unusable instance.
-- Failed wake should be visible as a sandbox event and final `FAILED` state, not
-  an endless `WAKING` state.
+- Ambiguous suspend or wake results, such as deadline and cancellation errors,
+  must not leave the sandbox in `READY` unless the backend proves it is running.
+  Use `SUSPENDED` as the retryable conservative state.
+- Failed wake should be visible as a sandbox event and final `FAILED` state for
+  definite backend errors, not an endless `WAKING` state.
 - Idle timers must be disabled by default until real backend smoke tests prove
   the behavior.
 

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -25,6 +25,7 @@ const (
 	CapabilitySandboxPathRemove           = "sandbox.path_remove"
 	CapabilitySandboxArchiveRead          = "sandbox.archive_read"
 	CapabilitySandboxArchiveWrite         = "sandbox.archive_write"
+	CapabilitySandboxSuspend              = "sandbox.suspend"
 	CapabilityNetworkDefaultDeny          = "network.default_deny"
 	CapabilityNetworkAllowlistEgress      = "network.allowlist_egress"
 	CapabilityNetworkStageScopedEgress    = "network.stage_scoped_egress"
@@ -48,6 +49,7 @@ var knownCapabilityKeys = []string{
 	CapabilitySandboxPathRemove,
 	CapabilitySandboxArchiveRead,
 	CapabilitySandboxArchiveWrite,
+	CapabilitySandboxSuspend,
 	CapabilityNetworkDefaultDeny,
 	CapabilityNetworkAllowlistEgress,
 	CapabilityNetworkStageScopedEgress,
@@ -86,6 +88,7 @@ type CapabilityReporter interface {
 // - SandboxPathRemoveAdapter => sandbox.path_remove
 // - SandboxArchiveReadAdapter => sandbox.archive_read
 // - SandboxArchiveWriteAdapter => sandbox.archive_write
+// - SuspendableAdapter => sandbox.suspend
 // - SandboxPortDialer => sandbox.port_dial
 //
 // Additional backend-specific capabilities can be provided by implementing
@@ -129,6 +132,9 @@ func CapabilitiesForAdapter(adapter Adapter) map[string]bool {
 	}
 	if _, ok := adapter.(SandboxArchiveWriteAdapter); ok {
 		caps[CapabilitySandboxArchiveWrite] = true
+	}
+	if _, ok := adapter.(SuspendableAdapter); ok {
+		caps[CapabilitySandboxSuspend] = true
 	}
 	if _, ok := adapter.(SandboxPortDialer); ok {
 		caps[CapabilitySandboxPortDial] = true
@@ -175,6 +181,14 @@ type SnapshottingAdapter interface {
 type CacheOutputVolumeSnapshottingAdapter interface {
 	Adapter
 	SnapshotCacheOutputVolumes(ctx context.Context, req SnapshotCacheOutputVolumesRequest) (*SnapshotCacheOutputVolumesResult, error)
+}
+
+// SuspendableAdapter supports pausing and resuming a persistent sandbox instance
+// without changing its identity or durable filesystem state.
+type SuspendableAdapter interface {
+	Adapter
+	SuspendSandbox(ctx context.Context, sandboxID string) error
+	ResumeSandbox(ctx context.Context, sandboxID string) error
 }
 
 // RuntimeBaseKeyProvider returns a stable identifier for the backend runtime

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"context"
+	"errors"
 	"io"
 	"io/fs"
 	"maps"
@@ -12,6 +13,8 @@ import (
 
 	"github.com/buildkite/cleanroom/internal/policy"
 )
+
+var ErrSandboxLifecycleIndeterminate = errors.New("sandbox lifecycle result indeterminate")
 
 const (
 	CapabilityExecStreaming               = "exec.streaming"

--- a/internal/backend/capabilities_test.go
+++ b/internal/backend/capabilities_test.go
@@ -68,6 +68,12 @@ func (testReporterAdapter) Capabilities() map[string]bool {
 	}
 }
 
+type testSuspendableAdapter struct{ testAdapter }
+
+func (testSuspendableAdapter) SuspendSandbox(context.Context, string) error { return nil }
+
+func (testSuspendableAdapter) ResumeSandbox(context.Context, string) error { return nil }
+
 func TestCapabilitiesForAdapterInfersInterfaceCapabilities(t *testing.T) {
 	caps := CapabilitiesForAdapter(testPersistentAdapter{})
 
@@ -101,6 +107,14 @@ func TestCapabilitiesForAdapterInfersInterfaceCapabilities(t *testing.T) {
 		if caps[key] {
 			t.Fatalf("expected %s=false without backend reporter", key)
 		}
+	}
+}
+
+func TestCapabilitiesForAdapterInfersSuspendCapability(t *testing.T) {
+	caps := CapabilitiesForAdapter(testSuspendableAdapter{})
+
+	if !caps[CapabilitySandboxSuspend] {
+		t.Fatalf("expected %s=true", CapabilitySandboxSuspend)
 	}
 }
 

--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -464,6 +464,68 @@ func (a *Adapter) Capabilities() map[string]bool {
 	}
 }
 
+func (a *Adapter) SuspendSandbox(ctx context.Context, sandboxID string) error {
+	instance, err := a.lifecycleSandboxInstance(sandboxID)
+	if err != nil {
+		return err
+	}
+	if err := a.requestVMControl(ctx, instance, "PauseVM"); err != nil {
+		return fmt.Errorf("pause darwin-vz sandbox: %w", err)
+	}
+	return nil
+}
+
+func (a *Adapter) ResumeSandbox(ctx context.Context, sandboxID string) error {
+	instance, err := a.lifecycleSandboxInstance(sandboxID)
+	if err != nil {
+		return err
+	}
+	if err := a.requestVMControl(ctx, instance, "ResumeVM"); err != nil {
+		return fmt.Errorf("resume darwin-vz sandbox: %w", err)
+	}
+	return nil
+}
+
+func (a *Adapter) lifecycleSandboxInstance(sandboxID string) (*sandboxInstance, error) {
+	sandboxID = strings.TrimSpace(sandboxID)
+	if sandboxID == "" {
+		return nil, errors.New("missing sandbox_id")
+	}
+
+	a.sandboxMu.Lock()
+	instance, ok := a.sandboxes[sandboxID]
+	a.sandboxMu.Unlock()
+	if !ok {
+		return nil, fmt.Errorf("unknown sandbox %q", sandboxID)
+	}
+	if err := instance.exitedErrOrNil(); err != nil {
+		return nil, fmt.Errorf("sandbox %q is not running: %w", sandboxID, err)
+	}
+	return instance, nil
+}
+
+func (a *Adapter) requestVMControl(ctx context.Context, instance *sandboxInstance, op string) error {
+	if instance == nil {
+		return errors.New("missing sandbox instance")
+	}
+	if instance.Helper == nil {
+		return errors.New("darwin-vz sandbox helper is not available")
+	}
+	if strings.TrimSpace(instance.VMID) == "" {
+		return errors.New("darwin-vz sandbox vm id is empty")
+	}
+	helperRequest := a.helperRequestFn
+	if helperRequest == nil {
+		helperRequest = func(ctx context.Context, helper *helperSession, req helperControlRequest) (helperControlResponse, error) {
+			return helper.request(ctx, req)
+		}
+	}
+	if _, err := helperRequest(ctx, instance.Helper, helperControlRequest{Op: op, VMID: instance.VMID}); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (a *Adapter) ProvisionSandbox(ctx context.Context, req backend.ProvisionRequest) (retErr error) {
 	ctx, span := trace.SpanFromContext(ctx).TracerProvider().Tracer("github.com/buildkite/cleanroom/internal/backend/darwinvz").Start(
 		ctx,

--- a/internal/backend/darwinvz/helper_client.go
+++ b/internal/backend/darwinvz/helper_client.go
@@ -15,6 +15,8 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/buildkite/cleanroom/internal/backend"
 )
 
 const (
@@ -196,12 +198,18 @@ func (s *helperSession) request(ctx context.Context, req helperControlRequest) (
 	defer s.conn.SetDeadline(time.Time{})
 
 	if err := s.enc.Encode(req); err != nil {
-		return helperControlResponse{}, s.decorateError(fmt.Errorf("send helper request %q: %w", req.Op, err))
+		return helperControlResponse{}, fmt.Errorf("%w: %w",
+			backend.ErrSandboxLifecycleIndeterminate,
+			s.decorateError(fmt.Errorf("send helper request %q: %w", req.Op, err)),
+		)
 	}
 
 	var res helperControlResponse
 	if err := s.dec.Decode(&res); err != nil {
-		return helperControlResponse{}, s.decorateError(fmt.Errorf("decode helper response %q: %w", req.Op, err))
+		return helperControlResponse{}, fmt.Errorf("%w: %w",
+			backend.ErrSandboxLifecycleIndeterminate,
+			s.decorateError(fmt.Errorf("decode helper response %q: %w", req.Op, err)),
+		)
 	}
 	if !res.OK {
 		msg := strings.TrimSpace(res.Error)

--- a/internal/backend/darwinvz/helper_client_test.go
+++ b/internal/backend/darwinvz/helper_client_test.go
@@ -1,11 +1,58 @@
 package darwinvz
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
 	"os/exec"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/buildkite/cleanroom/internal/backend"
 )
+
+func TestHelperRequestDecodeErrorIsLifecycleIndeterminate(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	session := &helperSession{
+		conn: clientConn,
+		enc:  json.NewEncoder(clientConn),
+		dec:  json.NewDecoder(clientConn),
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := session.request(context.Background(), helperControlRequest{Op: "PauseVM", VMID: "vm-test"})
+		errCh <- err
+	}()
+
+	var req helperControlRequest
+	if err := json.NewDecoder(serverConn).Decode(&req); err != nil {
+		t.Fatalf("decode request: %v", err)
+	}
+	if req.Op != "PauseVM" {
+		t.Fatalf("unexpected request op: got %q want PauseVM", req.Op)
+	}
+	if err := serverConn.Close(); err != nil {
+		t.Fatalf("close server conn: %v", err)
+	}
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("expected request error")
+		}
+		if !errors.Is(err, backend.ErrSandboxLifecycleIndeterminate) {
+			t.Fatalf("expected indeterminate lifecycle error, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for request error")
+	}
+}
 
 func TestCloseProcessReturnsWhenDoneChannelIsDrained(t *testing.T) {
 	sleepPath, err := exec.LookPath("sleep")

--- a/internal/backend/darwinvz/persistent_test.go
+++ b/internal/backend/darwinvz/persistent_test.go
@@ -44,6 +44,9 @@ func TestCapabilitiesExposeSnapshotAndFileTransfer(t *testing.T) {
 	if !caps[backend.CapabilitySandboxOverlayWriteCapture] {
 		t.Fatalf("expected %s=true", backend.CapabilitySandboxOverlayWriteCapture)
 	}
+	if !caps[backend.CapabilitySandboxSuspend] {
+		t.Fatalf("expected %s=true", backend.CapabilitySandboxSuspend)
+	}
 	for _, key := range []string{
 		backend.CapabilitySandboxPathStat,
 		backend.CapabilitySandboxTreeWalk,
@@ -56,6 +59,35 @@ func TestCapabilitiesExposeSnapshotAndFileTransfer(t *testing.T) {
 		if !caps[key] {
 			t.Fatalf("expected %s=true", key)
 		}
+	}
+}
+
+func TestSuspendAndResumeSandboxCallHelper(t *testing.T) {
+	t.Parallel()
+
+	var helperOps []string
+	adapter := &Adapter{
+		sandboxes: map[string]*sandboxInstance{
+			"cr-test": {
+				SandboxID: "cr-test",
+				Helper:    &helperSession{},
+				VMID:      "vm-test",
+			},
+		},
+		helperRequestFn: func(_ context.Context, _ *helperSession, req helperControlRequest) (helperControlResponse, error) {
+			helperOps = append(helperOps, req.Op+":"+req.VMID)
+			return helperControlResponse{OK: true}, nil
+		},
+	}
+
+	if err := adapter.SuspendSandbox(context.Background(), "cr-test"); err != nil {
+		t.Fatalf("SuspendSandbox returned error: %v", err)
+	}
+	if err := adapter.ResumeSandbox(context.Background(), "cr-test"); err != nil {
+		t.Fatalf("ResumeSandbox returned error: %v", err)
+	}
+	if got, want := strings.Join(helperOps, ","), "PauseVM:vm-test,ResumeVM:vm-test"; got != want {
+		t.Fatalf("unexpected helper ops: got %q want %q", got, want)
 	}
 }
 

--- a/internal/cli/sandbox.go
+++ b/internal/cli/sandbox.go
@@ -20,6 +20,8 @@ type SandboxCommand struct {
 	Create    SandboxCreateCommand    `cmd:"" help:"Create a repo-agnostic sandbox"`
 	Inspect   SandboxInspectCommand   `name:"inspect" aliases:"show" cmd:"" help:"Inspect sandbox state and related execution IDs"`
 	List      SandboxListCommand      `name:"ls" aliases:"list" cmd:"" help:"List active sandboxes"`
+	Suspend   SandboxSuspendCommand   `cmd:"" help:"Suspend a sandbox until it is resumed or woken"`
+	Resume    SandboxResumeCommand    `cmd:"" help:"Resume a suspended sandbox"`
 	Terminate SandboxTerminateCommand `name:"rm" aliases:"terminate" cmd:"" help:"Terminate a sandbox"`
 }
 
@@ -52,6 +54,16 @@ type SandboxInspectCommand struct {
 type SandboxTerminateCommand struct {
 	clientFlags
 	SandboxID string `arg:"" required:"" help:"Sandbox ID to terminate"`
+}
+
+type SandboxSuspendCommand struct {
+	clientFlags
+	SandboxID string `arg:"" required:"" help:"Sandbox ID to suspend"`
+}
+
+type SandboxResumeCommand struct {
+	clientFlags
+	SandboxID string `arg:"" required:"" help:"Sandbox ID to resume"`
 }
 
 type CreateCommand struct {
@@ -288,6 +300,46 @@ func (c *SandboxTerminateCommand) Run(ctx *runtimeContext) error {
 	}
 
 	_, err = fmt.Fprintln(ctx.Stdout, resp.Message)
+	return err
+}
+
+func (c *SandboxSuspendCommand) Run(ctx *runtimeContext) error {
+	client, err := c.connect(ctx)
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.SuspendSandbox(context.Background(), &cleanroomv1.SuspendSandboxRequest{
+		SandboxId: c.SandboxID,
+	})
+	if err != nil {
+		return err
+	}
+	sandboxID := strings.TrimSpace(resp.GetSandbox().GetSandboxId())
+	if sandboxID == "" {
+		sandboxID = strings.TrimSpace(c.SandboxID)
+	}
+	_, err = fmt.Fprintf(ctx.Stdout, "sandbox %s suspended\n", sandboxID)
+	return err
+}
+
+func (c *SandboxResumeCommand) Run(ctx *runtimeContext) error {
+	client, err := c.connect(ctx)
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.ResumeSandbox(context.Background(), &cleanroomv1.ResumeSandboxRequest{
+		SandboxId: c.SandboxID,
+	})
+	if err != nil {
+		return err
+	}
+	sandboxID := strings.TrimSpace(resp.GetSandbox().GetSandboxId())
+	if sandboxID == "" {
+		sandboxID = strings.TrimSpace(c.SandboxID)
+	}
+	_, err = fmt.Fprintf(ctx.Stdout, "sandbox %s resumed\n", sandboxID)
 	return err
 }
 
@@ -657,6 +709,12 @@ func sandboxStatusString(s cleanroomv1.SandboxStatus) string {
 		return "stopped"
 	case cleanroomv1.SandboxStatus_SANDBOX_STATUS_FAILED:
 		return "failed"
+	case cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDING:
+		return "suspending"
+	case cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDED:
+		return "suspended"
+	case cleanroomv1.SandboxStatus_SANDBOX_STATUS_WAKING:
+		return "waking"
 	default:
 		return "unknown"
 	}

--- a/internal/cli/sandbox_suspend_integration_test.go
+++ b/internal/cli/sandbox_suspend_integration_test.go
@@ -1,0 +1,115 @@
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+)
+
+type suspendIntegrationAdapter struct {
+	integrationAdapter
+	suspendCalls int
+	resumeCalls  int
+}
+
+func (a *suspendIntegrationAdapter) SuspendSandbox(context.Context, string) error {
+	a.suspendCalls++
+	return nil
+}
+
+func (a *suspendIntegrationAdapter) ResumeSandbox(context.Context, string) error {
+	a.resumeCalls++
+	return nil
+}
+
+func runSandboxSuspendWithCapture(cmd SandboxSuspendCommand, ctx runtimeContext) execOutcome {
+	return runWithCapture(func(runCtx *runtimeContext) error {
+		return cmd.Run(runCtx)
+	}, nil, ctx)
+}
+
+func runSandboxResumeWithCapture(cmd SandboxResumeCommand, ctx runtimeContext) execOutcome {
+	return runWithCapture(func(runCtx *runtimeContext) error {
+		return cmd.Run(runCtx)
+	}, nil, ctx)
+}
+
+func TestSandboxSuspendResumeIntegration(t *testing.T) {
+	adapter := &suspendIntegrationAdapter{}
+	host, _ := startIntegrationServer(t, adapter)
+	cwd := t.TempDir()
+
+	client := mustNewControlClient(t, host)
+	sandboxID := mustCreateSandbox(t, client)
+
+	suspendOutcome := runSandboxSuspendWithCapture(SandboxSuspendCommand{
+		clientFlags: clientFlags{Host: host},
+		SandboxID:   sandboxID,
+	}, runtimeContext{CWD: cwd})
+	if suspendOutcome.cause != nil {
+		t.Fatalf("capture failure: %v", suspendOutcome.cause)
+	}
+	if suspendOutcome.err != nil {
+		t.Fatalf("SandboxSuspendCommand.Run returned error: %v", suspendOutcome.err)
+	}
+	if !strings.Contains(suspendOutcome.stdout, "sandbox "+sandboxID+" suspended") {
+		t.Fatalf("expected suspend output for %q, got %q", sandboxID, suspendOutcome.stdout)
+	}
+	if got, want := adapter.suspendCalls, 1; got != want {
+		t.Fatalf("unexpected suspend call count: got %d want %d", got, want)
+	}
+	requireSandboxStatus(t, client, sandboxID, cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDED)
+
+	listOutcome := runSandboxListWithCapture(SandboxListCommand{
+		clientFlags: clientFlags{Host: host},
+	}, runtimeContext{CWD: cwd})
+	if listOutcome.cause != nil {
+		t.Fatalf("capture failure: %v", listOutcome.cause)
+	}
+	if listOutcome.err != nil {
+		t.Fatalf("SandboxListCommand.Run returned error: %v", listOutcome.err)
+	}
+	if !strings.Contains(listOutcome.stdout, "suspended") {
+		t.Fatalf("expected list output to include suspended status, got %q", listOutcome.stdout)
+	}
+
+	resumeOutcome := runSandboxResumeWithCapture(SandboxResumeCommand{
+		clientFlags: clientFlags{Host: host},
+		SandboxID:   sandboxID,
+	}, runtimeContext{CWD: cwd})
+	if resumeOutcome.cause != nil {
+		t.Fatalf("capture failure: %v", resumeOutcome.cause)
+	}
+	if resumeOutcome.err != nil {
+		t.Fatalf("SandboxResumeCommand.Run returned error: %v", resumeOutcome.err)
+	}
+	if !strings.Contains(resumeOutcome.stdout, "sandbox "+sandboxID+" resumed") {
+		t.Fatalf("expected resume output for %q, got %q", sandboxID, resumeOutcome.stdout)
+	}
+	if got, want := adapter.resumeCalls, 1; got != want {
+		t.Fatalf("unexpected resume call count: got %d want %d", got, want)
+	}
+	requireSandboxStatus(t, client, sandboxID, cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY)
+}
+
+func TestSandboxStatusStringIncludesSuspendStates(t *testing.T) {
+	tests := map[cleanroomv1.SandboxStatus]string{
+		cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDING: "suspending",
+		cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDED:  "suspended",
+		cleanroomv1.SandboxStatus_SANDBOX_STATUS_WAKING:     "waking",
+	}
+	for status, want := range tests {
+		if got := sandboxStatusString(status); got != want {
+			t.Fatalf("sandboxStatusString(%v) = %q, want %q", status, got, want)
+		}
+	}
+}
+
+func TestSandboxSuspendCapabilityKeyIsStable(t *testing.T) {
+	if got, want := backend.CapabilitySandboxSuspend, "sandbox.suspend"; got != want {
+		t.Fatalf("unexpected suspend capability key: got %q want %q", got, want)
+	}
+}

--- a/internal/controlclient/client.go
+++ b/internal/controlclient/client.go
@@ -143,6 +143,22 @@ func (c *Client) ListSandboxes(ctx context.Context, req *cleanroomv1.ListSandbox
 	return resp.Msg, nil
 }
 
+func (c *Client) SuspendSandbox(ctx context.Context, req *cleanroomv1.SuspendSandboxRequest) (*cleanroomv1.SuspendSandboxResponse, error) {
+	resp, err := c.sandboxClient.SuspendSandbox(ctx, connect.NewRequest(req))
+	if err != nil {
+		return nil, err
+	}
+	return resp.Msg, nil
+}
+
+func (c *Client) ResumeSandbox(ctx context.Context, req *cleanroomv1.ResumeSandboxRequest) (*cleanroomv1.ResumeSandboxResponse, error) {
+	resp, err := c.sandboxClient.ResumeSandbox(ctx, connect.NewRequest(req))
+	if err != nil {
+		return nil, err
+	}
+	return resp.Msg, nil
+}
+
 func (c *Client) DownloadSandboxFile(ctx context.Context, req *cleanroomv1.DownloadSandboxFileRequest) (*cleanroomv1.DownloadSandboxFileResponse, error) {
 	resp, err := c.sandboxClient.DownloadSandboxFile(ctx, connect.NewRequest(req))
 	if err != nil {

--- a/internal/controlserver/server.go
+++ b/internal/controlserver/server.go
@@ -212,6 +212,22 @@ func (s *Server) ListSandboxes(ctx context.Context, req *connect.Request[cleanro
 	return connect.NewResponse(resp), nil
 }
 
+func (s *Server) SuspendSandbox(ctx context.Context, req *connect.Request[cleanroomv1.SuspendSandboxRequest]) (*connect.Response[cleanroomv1.SuspendSandboxResponse], error) {
+	resp, err := s.service.SuspendSandbox(ctx, req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (s *Server) ResumeSandbox(ctx context.Context, req *connect.Request[cleanroomv1.ResumeSandboxRequest]) (*connect.Response[cleanroomv1.ResumeSandboxResponse], error) {
+	resp, err := s.service.ResumeSandbox(ctx, req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
 func (s *Server) DownloadSandboxFile(ctx context.Context, req *connect.Request[cleanroomv1.DownloadSandboxFileRequest]) (*connect.Response[cleanroomv1.DownloadSandboxFileResponse], error) {
 	resp, err := s.service.DownloadSandboxFile(ctx, req.Msg)
 	if err != nil {
@@ -709,7 +725,7 @@ func toConnectError(err error) error {
 		code = connect.CodeInvalidArgument
 	case strings.Contains(message, "unknown sandbox"), strings.Contains(message, "unknown cleanroom"), strings.Contains(message, "unknown execution"):
 		code = connect.CodeNotFound
-	case strings.Contains(message, "not ready"):
+	case strings.Contains(message, "not ready"), strings.Contains(message, "not suspended"):
 		code = connect.CodeFailedPrecondition
 	}
 	return connect.NewError(code, err)

--- a/internal/controlserver/server.go
+++ b/internal/controlserver/server.go
@@ -725,7 +725,9 @@ func toConnectError(err error) error {
 		code = connect.CodeInvalidArgument
 	case strings.Contains(message, "unknown sandbox"), strings.Contains(message, "unknown cleanroom"), strings.Contains(message, "unknown execution"):
 		code = connect.CodeNotFound
-	case strings.Contains(message, "not ready"), strings.Contains(message, "not suspended"):
+	case strings.Contains(message, "not ready"),
+		strings.Contains(message, "not suspended"),
+		strings.Contains(message, "does not support sandbox suspend"):
 		code = connect.CodeFailedPrecondition
 	}
 	return connect.NewError(code, err)

--- a/internal/controlserver/server_handler_test.go
+++ b/internal/controlserver/server_handler_test.go
@@ -530,6 +530,11 @@ func TestToConnectErrorMapsExpectedCodes(t *testing.T) {
 			want: connect.CodeFailedPrecondition,
 		},
 		{
+			name: "unsupported suspend maps to failed precondition",
+			err:  errors.New("backend \"firecracker\" does not support sandbox suspend"),
+			want: connect.CodeFailedPrecondition,
+		},
+		{
 			name: "existing connect error passes through",
 			err:  connectErr,
 			want: connect.CodeUnauthenticated,

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -1174,7 +1174,9 @@ func (s *Service) ResumeSandbox(ctx context.Context, req *cleanroomv1.ResumeSand
 }
 
 func isIndeterminateSandboxLifecycleError(err error) bool {
-	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+	return errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(err, backend.ErrSandboxLifecycleIndeterminate)
 }
 
 func (s *Service) ListExecutions(_ context.Context, req *cleanroomv1.ListExecutionsRequest) (*cleanroomv1.ListExecutionsResponse, error) {

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -1086,7 +1086,13 @@ func (s *Service) SuspendSandbox(ctx context.Context, req *cleanroomv1.SuspendSa
 	}
 	if err != nil {
 		if current.Status == cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDING {
-			s.recordSandboxEventLocked(current, cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY, fmt.Sprintf("sandbox suspend failed: %v", err))
+			status := cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY
+			message := fmt.Sprintf("sandbox suspend failed: %v", err)
+			if isIndeterminateSandboxLifecycleError(err) {
+				status = cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDED
+				message = fmt.Sprintf("sandbox suspend result indeterminate: %v", err)
+			}
+			s.recordSandboxEventLocked(current, status, message)
 		}
 		return nil, fmt.Errorf("suspend backend sandbox: %w", err)
 	}
@@ -1111,6 +1117,11 @@ func (s *Service) ResumeSandbox(ctx context.Context, req *cleanroomv1.ResumeSand
 		s.mu.Unlock()
 		return nil, fmt.Errorf("unknown sandbox %q", sandboxID)
 	}
+	if state.Status == cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY {
+		resp := &cleanroomv1.ResumeSandboxResponse{Sandbox: cloneSandboxLocked(state)}
+		s.mu.Unlock()
+		return resp, nil
+	}
 	adapter, ok := s.Backends[state.Backend]
 	if !ok {
 		s.mu.Unlock()
@@ -1129,11 +1140,6 @@ func (s *Service) ResumeSandbox(ctx context.Context, req *cleanroomv1.ResumeSand
 		s.mu.Unlock()
 		return nil, fmt.Errorf("backend_capability_mismatch: backend %q reports sandbox suspend but does not implement it", state.Backend)
 	}
-	if state.Status == cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY {
-		resp := &cleanroomv1.ResumeSandboxResponse{Sandbox: cloneSandboxLocked(state)}
-		s.mu.Unlock()
-		return resp, nil
-	}
 	if state.Status != cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDED {
 		s.mu.Unlock()
 		return nil, fmt.Errorf("sandbox %q is not suspended", sandboxID)
@@ -1151,7 +1157,13 @@ func (s *Service) ResumeSandbox(ctx context.Context, req *cleanroomv1.ResumeSand
 	}
 	if err != nil {
 		if current.Status == cleanroomv1.SandboxStatus_SANDBOX_STATUS_WAKING {
-			s.recordSandboxEventLocked(current, cleanroomv1.SandboxStatus_SANDBOX_STATUS_FAILED, fmt.Sprintf("sandbox wake failed: %v", err))
+			status := cleanroomv1.SandboxStatus_SANDBOX_STATUS_FAILED
+			message := fmt.Sprintf("sandbox wake failed: %v", err)
+			if isIndeterminateSandboxLifecycleError(err) {
+				status = cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDED
+				message = fmt.Sprintf("sandbox wake result indeterminate: %v", err)
+			}
+			s.recordSandboxEventLocked(current, status, message)
 		}
 		return nil, fmt.Errorf("resume backend sandbox: %w", err)
 	}
@@ -1159,6 +1171,10 @@ func (s *Service) ResumeSandbox(ctx context.Context, req *cleanroomv1.ResumeSand
 		s.recordSandboxEventLocked(current, cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY, "sandbox ready after wake")
 	}
 	return &cleanroomv1.ResumeSandboxResponse{Sandbox: cloneSandboxLocked(current)}, nil
+}
+
+func isIndeterminateSandboxLifecycleError(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
 }
 
 func (s *Service) ListExecutions(_ context.Context, req *cleanroomv1.ListExecutionsRequest) (*cleanroomv1.ListExecutionsResponse, error) {

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -304,7 +304,10 @@ func sandboxStatusHasActiveResources(status cleanroomv1.SandboxStatus) bool {
 	switch status {
 	case cleanroomv1.SandboxStatus_SANDBOX_STATUS_PROVISIONING,
 		cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY,
-		cleanroomv1.SandboxStatus_SANDBOX_STATUS_STOPPING:
+		cleanroomv1.SandboxStatus_SANDBOX_STATUS_STOPPING,
+		cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDING,
+		cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDED,
+		cleanroomv1.SandboxStatus_SANDBOX_STATUS_WAKING:
 		return true
 	default:
 		return false
@@ -319,6 +322,12 @@ func sandboxStatusMetricValue(status cleanroomv1.SandboxStatus) string {
 		return "ready"
 	case cleanroomv1.SandboxStatus_SANDBOX_STATUS_STOPPING:
 		return "stopping"
+	case cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDING:
+		return "suspending"
+	case cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDED:
+		return "suspended"
+	case cleanroomv1.SandboxStatus_SANDBOX_STATUS_WAKING:
+		return "waking"
 	default:
 		return "unknown"
 	}
@@ -1020,6 +1029,136 @@ func (s *Service) ListSandboxes(_ context.Context, _ *cleanroomv1.ListSandboxesR
 		resp.Sandboxes = append(resp.Sandboxes, item.sandbox)
 	}
 	return resp, nil
+}
+
+func (s *Service) SuspendSandbox(ctx context.Context, req *cleanroomv1.SuspendSandboxRequest) (*cleanroomv1.SuspendSandboxResponse, error) {
+	if req == nil || strings.TrimSpace(req.GetSandboxId()) == "" {
+		return nil, errors.New("missing sandbox_id")
+	}
+	sandboxID := strings.TrimSpace(req.GetSandboxId())
+
+	var suspendable backend.SuspendableAdapter
+
+	s.mu.Lock()
+	s.ensureMapsLocked()
+	state, ok := s.sandboxes[sandboxID]
+	if !ok {
+		s.mu.Unlock()
+		return nil, fmt.Errorf("unknown sandbox %q", sandboxID)
+	}
+	if state.Status == cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDED {
+		resp := &cleanroomv1.SuspendSandboxResponse{Sandbox: cloneSandboxLocked(state)}
+		s.mu.Unlock()
+		return resp, nil
+	}
+	if err := ensureSandboxIdleLocked(sandboxID, state, s.executions); err != nil {
+		s.mu.Unlock()
+		return nil, err
+	}
+	adapter, ok := s.Backends[state.Backend]
+	if !ok {
+		s.mu.Unlock()
+		return nil, fmt.Errorf("unknown backend %q", state.Backend)
+	}
+	capabilities := state.Capabilities
+	if capabilities == nil {
+		capabilities = backend.CapabilitiesForAdapter(adapter)
+	}
+	if !capabilities[backend.CapabilitySandboxSuspend] {
+		s.mu.Unlock()
+		return nil, fmt.Errorf("backend %q does not support sandbox suspend", state.Backend)
+	}
+	suspendable, ok = adapter.(backend.SuspendableAdapter)
+	if !ok {
+		s.mu.Unlock()
+		return nil, fmt.Errorf("backend_capability_mismatch: backend %q reports sandbox suspend but does not implement it", state.Backend)
+	}
+	s.recordSandboxEventLocked(state, cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDING, "sandbox suspend requested")
+	s.mu.Unlock()
+
+	err := suspendable.SuspendSandbox(ctx, sandboxID)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	current, ok := s.sandboxes[sandboxID]
+	if !ok {
+		return nil, fmt.Errorf("unknown sandbox %q", sandboxID)
+	}
+	if err != nil {
+		if current.Status == cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDING {
+			s.recordSandboxEventLocked(current, cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY, fmt.Sprintf("sandbox suspend failed: %v", err))
+		}
+		return nil, fmt.Errorf("suspend backend sandbox: %w", err)
+	}
+	if current.Status == cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDING {
+		s.recordSandboxEventLocked(current, cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDED, "sandbox suspended")
+	}
+	return &cleanroomv1.SuspendSandboxResponse{Sandbox: cloneSandboxLocked(current)}, nil
+}
+
+func (s *Service) ResumeSandbox(ctx context.Context, req *cleanroomv1.ResumeSandboxRequest) (*cleanroomv1.ResumeSandboxResponse, error) {
+	if req == nil || strings.TrimSpace(req.GetSandboxId()) == "" {
+		return nil, errors.New("missing sandbox_id")
+	}
+	sandboxID := strings.TrimSpace(req.GetSandboxId())
+
+	var resumable backend.SuspendableAdapter
+
+	s.mu.Lock()
+	s.ensureMapsLocked()
+	state, ok := s.sandboxes[sandboxID]
+	if !ok {
+		s.mu.Unlock()
+		return nil, fmt.Errorf("unknown sandbox %q", sandboxID)
+	}
+	adapter, ok := s.Backends[state.Backend]
+	if !ok {
+		s.mu.Unlock()
+		return nil, fmt.Errorf("unknown backend %q", state.Backend)
+	}
+	capabilities := state.Capabilities
+	if capabilities == nil {
+		capabilities = backend.CapabilitiesForAdapter(adapter)
+	}
+	if !capabilities[backend.CapabilitySandboxSuspend] {
+		s.mu.Unlock()
+		return nil, fmt.Errorf("backend %q does not support sandbox suspend", state.Backend)
+	}
+	resumable, ok = adapter.(backend.SuspendableAdapter)
+	if !ok {
+		s.mu.Unlock()
+		return nil, fmt.Errorf("backend_capability_mismatch: backend %q reports sandbox suspend but does not implement it", state.Backend)
+	}
+	if state.Status == cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY {
+		resp := &cleanroomv1.ResumeSandboxResponse{Sandbox: cloneSandboxLocked(state)}
+		s.mu.Unlock()
+		return resp, nil
+	}
+	if state.Status != cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDED {
+		s.mu.Unlock()
+		return nil, fmt.Errorf("sandbox %q is not suspended", sandboxID)
+	}
+	s.recordSandboxEventLocked(state, cleanroomv1.SandboxStatus_SANDBOX_STATUS_WAKING, "sandbox wake requested")
+	s.mu.Unlock()
+
+	err := resumable.ResumeSandbox(ctx, sandboxID)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	current, ok := s.sandboxes[sandboxID]
+	if !ok {
+		return nil, fmt.Errorf("unknown sandbox %q", sandboxID)
+	}
+	if err != nil {
+		if current.Status == cleanroomv1.SandboxStatus_SANDBOX_STATUS_WAKING {
+			s.recordSandboxEventLocked(current, cleanroomv1.SandboxStatus_SANDBOX_STATUS_FAILED, fmt.Sprintf("sandbox wake failed: %v", err))
+		}
+		return nil, fmt.Errorf("resume backend sandbox: %w", err)
+	}
+	if current.Status == cleanroomv1.SandboxStatus_SANDBOX_STATUS_WAKING {
+		s.recordSandboxEventLocked(current, cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY, "sandbox ready after wake")
+	}
+	return &cleanroomv1.ResumeSandboxResponse{Sandbox: cloneSandboxLocked(current)}, nil
 }
 
 func (s *Service) ListExecutions(_ context.Context, req *cleanroomv1.ListExecutionsRequest) (*cleanroomv1.ListExecutionsResponse, error) {

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -305,6 +305,7 @@ func sandboxStatusHasActiveResources(status cleanroomv1.SandboxStatus) bool {
 	case cleanroomv1.SandboxStatus_SANDBOX_STATUS_PROVISIONING,
 		cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY,
 		cleanroomv1.SandboxStatus_SANDBOX_STATUS_STOPPING,
+		cleanroomv1.SandboxStatus_SANDBOX_STATUS_FAILED,
 		cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDING,
 		cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDED,
 		cleanroomv1.SandboxStatus_SANDBOX_STATUS_WAKING:
@@ -322,6 +323,8 @@ func sandboxStatusMetricValue(status cleanroomv1.SandboxStatus) string {
 		return "ready"
 	case cleanroomv1.SandboxStatus_SANDBOX_STATUS_STOPPING:
 		return "stopping"
+	case cleanroomv1.SandboxStatus_SANDBOX_STATUS_FAILED:
+		return "failed"
 	case cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDING:
 		return "suspending"
 	case cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDED:

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -752,6 +752,44 @@ func TestSuspendSandboxFailureRecoversReady(t *testing.T) {
 	}
 }
 
+func TestSuspendSandboxIndeterminateFailureLeavesSuspended(t *testing.T) {
+	adapter := &suspendableAdapter{
+		suspendFn: func(context.Context, string) error {
+			return context.DeadlineExceeded
+		},
+	}
+	svc := newTestService(adapter)
+	createResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createResp.GetSandbox().GetSandboxId()
+
+	_, err = svc.SuspendSandbox(context.Background(), &cleanroomv1.SuspendSandboxRequest{SandboxId: sandboxID})
+	if err == nil {
+		t.Fatal("expected SuspendSandbox to return backend error")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline error, got %v", err)
+	}
+
+	getResp, err := svc.GetSandbox(context.Background(), &cleanroomv1.GetSandboxRequest{SandboxId: sandboxID})
+	if err != nil {
+		t.Fatalf("GetSandbox returned error: %v", err)
+	}
+	if got, want := getResp.GetSandbox().GetStatus(), cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDED; got != want {
+		t.Fatalf("unexpected sandbox status after indeterminate suspend: got %v want %v", got, want)
+	}
+
+	adapter.suspendFn = nil
+	if _, err := svc.ResumeSandbox(context.Background(), &cleanroomv1.ResumeSandboxRequest{SandboxId: sandboxID}); err != nil {
+		t.Fatalf("ResumeSandbox returned error: %v", err)
+	}
+	if got, want := adapter.resumeCalls, 1; got != want {
+		t.Fatalf("unexpected resume call count: got %d want %d", got, want)
+	}
+}
+
 func TestResumeSandboxTransitionsSuspendedToReady(t *testing.T) {
 	adapter := &suspendableAdapter{}
 	svc := newTestService(adapter)
@@ -779,18 +817,39 @@ func TestResumeSandboxTransitionsSuspendedToReady(t *testing.T) {
 	}
 }
 
-func TestResumeSandboxUnsupportedBackendReturnsCapabilityError(t *testing.T) {
+func TestResumeSandboxReadyUnsupportedBackendIsNoop(t *testing.T) {
 	svc := newTestService(&stubAdapter{})
 	createResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
 	if err != nil {
 		t.Fatalf("CreateSandbox returned error: %v", err)
 	}
 
-	_, err = svc.ResumeSandbox(context.Background(), &cleanroomv1.ResumeSandboxRequest{
+	resp, err := svc.ResumeSandbox(context.Background(), &cleanroomv1.ResumeSandboxRequest{
 		SandboxId: createResp.GetSandbox().GetSandboxId(),
 	})
+	if err != nil {
+		t.Fatalf("ResumeSandbox returned error: %v", err)
+	}
+	if got, want := resp.GetSandbox().GetStatus(), cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY; got != want {
+		t.Fatalf("unexpected resume response status: got %v want %v", got, want)
+	}
+}
+
+func TestResumeSandboxSuspendedUnsupportedBackendReturnsCapabilityError(t *testing.T) {
+	svc := newTestService(&stubAdapter{})
+	createResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createResp.GetSandbox().GetSandboxId()
+
+	svc.mu.Lock()
+	svc.sandboxes[sandboxID].Status = cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDED
+	svc.mu.Unlock()
+
+	_, err = svc.ResumeSandbox(context.Background(), &cleanroomv1.ResumeSandboxRequest{SandboxId: sandboxID})
 	if err == nil {
-		t.Fatal("expected ResumeSandbox to reject unsupported backend")
+		t.Fatal("expected ResumeSandbox to reject unsupported suspended backend")
 	}
 	if !strings.Contains(err.Error(), "does not support sandbox suspend") {
 		t.Fatalf("unexpected ResumeSandbox error: %v", err)
@@ -826,6 +885,46 @@ func TestResumeSandboxFailureMarksFailed(t *testing.T) {
 	}
 	if got, want := getResp.GetSandbox().GetStatus(), cleanroomv1.SandboxStatus_SANDBOX_STATUS_FAILED; got != want {
 		t.Fatalf("unexpected sandbox status after failed resume: got %v want %v", got, want)
+	}
+}
+
+func TestResumeSandboxIndeterminateFailureLeavesSuspended(t *testing.T) {
+	adapter := &suspendableAdapter{}
+	svc := newTestService(adapter)
+	createResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createResp.GetSandbox().GetSandboxId()
+	if _, err := svc.SuspendSandbox(context.Background(), &cleanroomv1.SuspendSandboxRequest{SandboxId: sandboxID}); err != nil {
+		t.Fatalf("SuspendSandbox returned error: %v", err)
+	}
+	adapter.resumeFn = func(context.Context, string) error {
+		return context.DeadlineExceeded
+	}
+
+	_, err = svc.ResumeSandbox(context.Background(), &cleanroomv1.ResumeSandboxRequest{SandboxId: sandboxID})
+	if err == nil {
+		t.Fatal("expected ResumeSandbox to return backend error")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline error, got %v", err)
+	}
+
+	getResp, err := svc.GetSandbox(context.Background(), &cleanroomv1.GetSandboxRequest{SandboxId: sandboxID})
+	if err != nil {
+		t.Fatalf("GetSandbox returned error: %v", err)
+	}
+	if got, want := getResp.GetSandbox().GetStatus(), cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDED; got != want {
+		t.Fatalf("unexpected sandbox status after indeterminate resume: got %v want %v", got, want)
+	}
+
+	adapter.resumeFn = nil
+	if _, err := svc.ResumeSandbox(context.Background(), &cleanroomv1.ResumeSandboxRequest{SandboxId: sandboxID}); err != nil {
+		t.Fatalf("second ResumeSandbox returned error: %v", err)
+	}
+	if got, want := adapter.resumeCalls, 2; got != want {
+		t.Fatalf("unexpected resume call count: got %d want %d", got, want)
 	}
 }
 

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -790,6 +790,36 @@ func TestSuspendSandboxIndeterminateFailureLeavesSuspended(t *testing.T) {
 	}
 }
 
+func TestSuspendSandboxBackendIndeterminateFailureLeavesSuspended(t *testing.T) {
+	adapter := &suspendableAdapter{
+		suspendFn: func(context.Context, string) error {
+			return fmt.Errorf("helper response lost: %w", backend.ErrSandboxLifecycleIndeterminate)
+		},
+	}
+	svc := newTestService(adapter)
+	createResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createResp.GetSandbox().GetSandboxId()
+
+	_, err = svc.SuspendSandbox(context.Background(), &cleanroomv1.SuspendSandboxRequest{SandboxId: sandboxID})
+	if err == nil {
+		t.Fatal("expected SuspendSandbox to return backend error")
+	}
+	if !errors.Is(err, backend.ErrSandboxLifecycleIndeterminate) {
+		t.Fatalf("expected indeterminate lifecycle error, got %v", err)
+	}
+
+	getResp, err := svc.GetSandbox(context.Background(), &cleanroomv1.GetSandboxRequest{SandboxId: sandboxID})
+	if err != nil {
+		t.Fatalf("GetSandbox returned error: %v", err)
+	}
+	if got, want := getResp.GetSandbox().GetStatus(), cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDED; got != want {
+		t.Fatalf("unexpected sandbox status after indeterminate suspend: got %v want %v", got, want)
+	}
+}
+
 func TestResumeSandboxTransitionsSuspendedToReady(t *testing.T) {
 	adapter := &suspendableAdapter{}
 	svc := newTestService(adapter)
@@ -925,6 +955,38 @@ func TestResumeSandboxIndeterminateFailureLeavesSuspended(t *testing.T) {
 	}
 	if got, want := adapter.resumeCalls, 2; got != want {
 		t.Fatalf("unexpected resume call count: got %d want %d", got, want)
+	}
+}
+
+func TestResumeSandboxBackendIndeterminateFailureLeavesSuspended(t *testing.T) {
+	adapter := &suspendableAdapter{}
+	svc := newTestService(adapter)
+	createResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createResp.GetSandbox().GetSandboxId()
+	if _, err := svc.SuspendSandbox(context.Background(), &cleanroomv1.SuspendSandboxRequest{SandboxId: sandboxID}); err != nil {
+		t.Fatalf("SuspendSandbox returned error: %v", err)
+	}
+	adapter.resumeFn = func(context.Context, string) error {
+		return fmt.Errorf("helper response lost: %w", backend.ErrSandboxLifecycleIndeterminate)
+	}
+
+	_, err = svc.ResumeSandbox(context.Background(), &cleanroomv1.ResumeSandboxRequest{SandboxId: sandboxID})
+	if err == nil {
+		t.Fatal("expected ResumeSandbox to return backend error")
+	}
+	if !errors.Is(err, backend.ErrSandboxLifecycleIndeterminate) {
+		t.Fatalf("expected indeterminate lifecycle error, got %v", err)
+	}
+
+	getResp, err := svc.GetSandbox(context.Background(), &cleanroomv1.GetSandboxRequest{SandboxId: sandboxID})
+	if err != nil {
+		t.Fatalf("GetSandbox returned error: %v", err)
+	}
+	if got, want := getResp.GetSandbox().GetStatus(), cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDED; got != want {
+		t.Fatalf("unexpected sandbox status after indeterminate resume: got %v want %v", got, want)
 	}
 }
 

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -85,6 +85,39 @@ type portDialAdapter struct {
 	dialFn       func(context.Context, string, int) (net.Conn, error)
 }
 
+type suspendableAdapter struct {
+	stubAdapter
+	capabilities   map[string]bool
+	suspendFn      func(context.Context, string) error
+	resumeFn       func(context.Context, string) error
+	suspendCalls   int
+	resumeCalls    int
+	suspendSandbox string
+	resumeSandbox  string
+}
+
+func (s *suspendableAdapter) SuspendSandbox(ctx context.Context, sandboxID string) error {
+	s.suspendCalls++
+	s.suspendSandbox = sandboxID
+	if s.suspendFn != nil {
+		return s.suspendFn(ctx, sandboxID)
+	}
+	return nil
+}
+
+func (s *suspendableAdapter) ResumeSandbox(ctx context.Context, sandboxID string) error {
+	s.resumeCalls++
+	s.resumeSandbox = sandboxID
+	if s.resumeFn != nil {
+		return s.resumeFn(ctx, sandboxID)
+	}
+	return nil
+}
+
+func (s *suspendableAdapter) Capabilities() map[string]bool {
+	return s.capabilities
+}
+
 func (s *portDialAdapter) DialSandboxPort(ctx context.Context, sandboxID string, port int) (net.Conn, error) {
 	if s.dialFn != nil {
 		return s.dialFn(ctx, sandboxID, port)
@@ -615,6 +648,211 @@ func TestDialSandboxPortRejectsBackendWithoutDialer(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "does not support sandbox port dialing") {
 		t.Fatalf("unexpected DialSandboxPort error: %v", err)
+	}
+}
+
+func TestSuspendSandboxTransitionsReadyToSuspended(t *testing.T) {
+	adapter := &suspendableAdapter{}
+	svc := newTestService(adapter)
+	createResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createResp.GetSandbox().GetSandboxId()
+	if !createResp.GetSandbox().GetBackendCapabilities()[backend.CapabilitySandboxSuspend] {
+		t.Fatalf("expected sandbox to report %s=true", backend.CapabilitySandboxSuspend)
+	}
+
+	resp, err := svc.SuspendSandbox(context.Background(), &cleanroomv1.SuspendSandboxRequest{SandboxId: sandboxID})
+	if err != nil {
+		t.Fatalf("SuspendSandbox returned error: %v", err)
+	}
+	if got, want := resp.GetSandbox().GetStatus(), cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDED; got != want {
+		t.Fatalf("unexpected suspend response status: got %v want %v", got, want)
+	}
+	if got, want := adapter.suspendCalls, 1; got != want {
+		t.Fatalf("unexpected suspend call count: got %d want %d", got, want)
+	}
+	if adapter.suspendSandbox != sandboxID {
+		t.Fatalf("unexpected suspended sandbox id: got %q want %q", adapter.suspendSandbox, sandboxID)
+	}
+
+	getResp, err := svc.GetSandbox(context.Background(), &cleanroomv1.GetSandboxRequest{SandboxId: sandboxID})
+	if err != nil {
+		t.Fatalf("GetSandbox returned error: %v", err)
+	}
+	if got, want := getResp.GetSandbox().GetStatus(), cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDED; got != want {
+		t.Fatalf("unexpected sandbox status: got %v want %v", got, want)
+	}
+
+	listResp, err := svc.ListSandboxes(context.Background(), &cleanroomv1.ListSandboxesRequest{})
+	if err != nil {
+		t.Fatalf("ListSandboxes returned error: %v", err)
+	}
+	if len(listResp.GetSandboxes()) != 1 {
+		t.Fatalf("unexpected sandbox count: got %d want 1", len(listResp.GetSandboxes()))
+	}
+	if got, want := listResp.GetSandboxes()[0].GetStatus(), cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDED; got != want {
+		t.Fatalf("unexpected listed sandbox status: got %v want %v", got, want)
+	}
+}
+
+func TestSuspendSandboxUnsupportedBackendLeavesSandboxReady(t *testing.T) {
+	svc := newTestService(&stubAdapter{})
+	createResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createResp.GetSandbox().GetSandboxId()
+
+	_, err = svc.SuspendSandbox(context.Background(), &cleanroomv1.SuspendSandboxRequest{SandboxId: sandboxID})
+	if err == nil {
+		t.Fatal("expected SuspendSandbox to reject unsupported backend")
+	}
+	if !strings.Contains(err.Error(), "does not support sandbox suspend") {
+		t.Fatalf("unexpected SuspendSandbox error: %v", err)
+	}
+
+	getResp, err := svc.GetSandbox(context.Background(), &cleanroomv1.GetSandboxRequest{SandboxId: sandboxID})
+	if err != nil {
+		t.Fatalf("GetSandbox returned error: %v", err)
+	}
+	if got, want := getResp.GetSandbox().GetStatus(), cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY; got != want {
+		t.Fatalf("unexpected sandbox status: got %v want %v", got, want)
+	}
+}
+
+func TestSuspendSandboxFailureRecoversReady(t *testing.T) {
+	adapter := &suspendableAdapter{
+		suspendFn: func(context.Context, string) error {
+			return errors.New("pause failed")
+		},
+	}
+	svc := newTestService(adapter)
+	createResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createResp.GetSandbox().GetSandboxId()
+
+	_, err = svc.SuspendSandbox(context.Background(), &cleanroomv1.SuspendSandboxRequest{SandboxId: sandboxID})
+	if err == nil {
+		t.Fatal("expected SuspendSandbox to return backend error")
+	}
+	if !strings.Contains(err.Error(), "suspend backend sandbox") {
+		t.Fatalf("unexpected SuspendSandbox error: %v", err)
+	}
+
+	getResp, err := svc.GetSandbox(context.Background(), &cleanroomv1.GetSandboxRequest{SandboxId: sandboxID})
+	if err != nil {
+		t.Fatalf("GetSandbox returned error: %v", err)
+	}
+	if got, want := getResp.GetSandbox().GetStatus(), cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY; got != want {
+		t.Fatalf("unexpected sandbox status after failed suspend: got %v want %v", got, want)
+	}
+}
+
+func TestResumeSandboxTransitionsSuspendedToReady(t *testing.T) {
+	adapter := &suspendableAdapter{}
+	svc := newTestService(adapter)
+	createResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createResp.GetSandbox().GetSandboxId()
+	if _, err := svc.SuspendSandbox(context.Background(), &cleanroomv1.SuspendSandboxRequest{SandboxId: sandboxID}); err != nil {
+		t.Fatalf("SuspendSandbox returned error: %v", err)
+	}
+
+	resp, err := svc.ResumeSandbox(context.Background(), &cleanroomv1.ResumeSandboxRequest{SandboxId: sandboxID})
+	if err != nil {
+		t.Fatalf("ResumeSandbox returned error: %v", err)
+	}
+	if got, want := resp.GetSandbox().GetStatus(), cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY; got != want {
+		t.Fatalf("unexpected resume response status: got %v want %v", got, want)
+	}
+	if got, want := adapter.resumeCalls, 1; got != want {
+		t.Fatalf("unexpected resume call count: got %d want %d", got, want)
+	}
+	if adapter.resumeSandbox != sandboxID {
+		t.Fatalf("unexpected resumed sandbox id: got %q want %q", adapter.resumeSandbox, sandboxID)
+	}
+}
+
+func TestResumeSandboxUnsupportedBackendReturnsCapabilityError(t *testing.T) {
+	svc := newTestService(&stubAdapter{})
+	createResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+
+	_, err = svc.ResumeSandbox(context.Background(), &cleanroomv1.ResumeSandboxRequest{
+		SandboxId: createResp.GetSandbox().GetSandboxId(),
+	})
+	if err == nil {
+		t.Fatal("expected ResumeSandbox to reject unsupported backend")
+	}
+	if !strings.Contains(err.Error(), "does not support sandbox suspend") {
+		t.Fatalf("unexpected ResumeSandbox error: %v", err)
+	}
+}
+
+func TestResumeSandboxFailureMarksFailed(t *testing.T) {
+	adapter := &suspendableAdapter{}
+	svc := newTestService(adapter)
+	createResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createResp.GetSandbox().GetSandboxId()
+	if _, err := svc.SuspendSandbox(context.Background(), &cleanroomv1.SuspendSandboxRequest{SandboxId: sandboxID}); err != nil {
+		t.Fatalf("SuspendSandbox returned error: %v", err)
+	}
+	adapter.resumeFn = func(context.Context, string) error {
+		return errors.New("resume failed")
+	}
+
+	_, err = svc.ResumeSandbox(context.Background(), &cleanroomv1.ResumeSandboxRequest{SandboxId: sandboxID})
+	if err == nil {
+		t.Fatal("expected ResumeSandbox to return backend error")
+	}
+	if !strings.Contains(err.Error(), "resume backend sandbox") {
+		t.Fatalf("unexpected ResumeSandbox error: %v", err)
+	}
+
+	getResp, err := svc.GetSandbox(context.Background(), &cleanroomv1.GetSandboxRequest{SandboxId: sandboxID})
+	if err != nil {
+		t.Fatalf("GetSandbox returned error: %v", err)
+	}
+	if got, want := getResp.GetSandbox().GetStatus(), cleanroomv1.SandboxStatus_SANDBOX_STATUS_FAILED; got != want {
+		t.Fatalf("unexpected sandbox status after failed resume: got %v want %v", got, want)
+	}
+}
+
+func TestTerminateSandboxStopsSuspendedSandbox(t *testing.T) {
+	adapter := &suspendableAdapter{}
+	svc := newTestService(adapter)
+	createResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createResp.GetSandbox().GetSandboxId()
+	if _, err := svc.SuspendSandbox(context.Background(), &cleanroomv1.SuspendSandboxRequest{SandboxId: sandboxID}); err != nil {
+		t.Fatalf("SuspendSandbox returned error: %v", err)
+	}
+
+	if _, err := svc.TerminateSandbox(context.Background(), &cleanroomv1.TerminateSandboxRequest{SandboxId: sandboxID}); err != nil {
+		t.Fatalf("TerminateSandbox returned error: %v", err)
+	}
+	getResp, err := svc.GetSandbox(context.Background(), &cleanroomv1.GetSandboxRequest{SandboxId: sandboxID})
+	if err != nil {
+		t.Fatalf("GetSandbox returned error: %v", err)
+	}
+	if got, want := getResp.GetSandbox().GetStatus(), cleanroomv1.SandboxStatus_SANDBOX_STATUS_STOPPED; got != want {
+		t.Fatalf("unexpected sandbox status after terminate: got %v want %v", got, want)
+	}
+	if got, want := adapter.terminateCalls, 1; got != want {
+		t.Fatalf("unexpected terminate call count: got %d want %d", got, want)
 	}
 }
 

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -889,7 +889,13 @@ func TestResumeSandboxSuspendedUnsupportedBackendReturnsCapabilityError(t *testi
 func TestResumeSandboxFailureMarksFailed(t *testing.T) {
 	adapter := &suspendableAdapter{}
 	svc := newTestService(adapter)
-	createResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+	policyProto := testPolicy()
+	policyProto.Resources = &cleanroomv1.PolicyResources{
+		Vcpus:       2,
+		MemoryBytes: 2048 << 20,
+		DiskBytes:   8 << 30,
+	}
+	createResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: policyProto})
 	if err != nil {
 		t.Fatalf("CreateSandbox returned error: %v", err)
 	}
@@ -915,6 +921,19 @@ func TestResumeSandboxFailureMarksFailed(t *testing.T) {
 	}
 	if got, want := getResp.GetSandbox().GetStatus(), cleanroomv1.SandboxStatus_SANDBOX_STATUS_FAILED; got != want {
 		t.Fatalf("unexpected sandbox status after failed resume: got %v want %v", got, want)
+	}
+	snapshots := svc.sandboxResourceMetricSnapshots(context.Background())
+	if len(snapshots) != 1 {
+		t.Fatalf("expected one resource metric snapshot, got %#v", snapshots)
+	}
+	if got, want := snapshots[0].Status, "failed"; got != want {
+		t.Fatalf("unexpected resource metric status: got %q want %q", got, want)
+	}
+	if got, want := snapshots[0].Count, int64(1); got != want {
+		t.Fatalf("unexpected resource metric count: got %d want %d", got, want)
+	}
+	if got, want := snapshots[0].EffectiveMemoryBytes, int64(2048<<20); got != want {
+		t.Fatalf("unexpected resource metric memory: got %d want %d", got, want)
 	}
 }
 

--- a/internal/gen/cleanroom/v1/cleanroomv1connect/control.connect.go
+++ b/internal/gen/cleanroom/v1/cleanroomv1connect/control.connect.go
@@ -78,6 +78,12 @@ const (
 	// SandboxServiceExtractSandboxArchiveProcedure is the fully-qualified name of the SandboxService's
 	// ExtractSandboxArchive RPC.
 	SandboxServiceExtractSandboxArchiveProcedure = "/cleanroom.v1.SandboxService/ExtractSandboxArchive"
+	// SandboxServiceSuspendSandboxProcedure is the fully-qualified name of the SandboxService's
+	// SuspendSandbox RPC.
+	SandboxServiceSuspendSandboxProcedure = "/cleanroom.v1.SandboxService/SuspendSandbox"
+	// SandboxServiceResumeSandboxProcedure is the fully-qualified name of the SandboxService's
+	// ResumeSandbox RPC.
+	SandboxServiceResumeSandboxProcedure = "/cleanroom.v1.SandboxService/ResumeSandbox"
 	// SandboxServiceTerminateSandboxProcedure is the fully-qualified name of the SandboxService's
 	// TerminateSandbox RPC.
 	SandboxServiceTerminateSandboxProcedure = "/cleanroom.v1.SandboxService/TerminateSandbox"
@@ -146,6 +152,8 @@ type SandboxServiceClient interface {
 	RemoveSandboxPath(context.Context, *connect.Request[v1.RemoveSandboxPathRequest]) (*connect.Response[v1.RemoveSandboxPathResponse], error)
 	ArchiveSandboxPaths(context.Context, *connect.Request[v1.ArchiveSandboxPathsRequest]) (*connect.ServerStreamForClient[v1.ArchiveSandboxPathsResponse], error)
 	ExtractSandboxArchive(context.Context) *connect.ClientStreamForClient[v1.ExtractSandboxArchiveRequest, v1.ExtractSandboxArchiveResponse]
+	SuspendSandbox(context.Context, *connect.Request[v1.SuspendSandboxRequest]) (*connect.Response[v1.SuspendSandboxResponse], error)
+	ResumeSandbox(context.Context, *connect.Request[v1.ResumeSandboxRequest]) (*connect.Response[v1.ResumeSandboxResponse], error)
 	TerminateSandbox(context.Context, *connect.Request[v1.TerminateSandboxRequest]) (*connect.Response[v1.TerminateSandboxResponse], error)
 	StreamSandboxEvents(context.Context, *connect.Request[v1.StreamSandboxEventsRequest]) (*connect.ServerStreamForClient[v1.SandboxEvent], error)
 	DialSandboxPort(context.Context) *connect.BidiStreamForClient[v1.SandboxPortFrame, v1.SandboxPortFrame]
@@ -240,6 +248,18 @@ func NewSandboxServiceClient(httpClient connect.HTTPClient, baseURL string, opts
 			connect.WithSchema(sandboxServiceMethods.ByName("ExtractSandboxArchive")),
 			connect.WithClientOptions(opts...),
 		),
+		suspendSandbox: connect.NewClient[v1.SuspendSandboxRequest, v1.SuspendSandboxResponse](
+			httpClient,
+			baseURL+SandboxServiceSuspendSandboxProcedure,
+			connect.WithSchema(sandboxServiceMethods.ByName("SuspendSandbox")),
+			connect.WithClientOptions(opts...),
+		),
+		resumeSandbox: connect.NewClient[v1.ResumeSandboxRequest, v1.ResumeSandboxResponse](
+			httpClient,
+			baseURL+SandboxServiceResumeSandboxProcedure,
+			connect.WithSchema(sandboxServiceMethods.ByName("ResumeSandbox")),
+			connect.WithClientOptions(opts...),
+		),
 		terminateSandbox: connect.NewClient[v1.TerminateSandboxRequest, v1.TerminateSandboxResponse](
 			httpClient,
 			baseURL+SandboxServiceTerminateSandboxProcedure,
@@ -276,6 +296,8 @@ type sandboxServiceClient struct {
 	removeSandboxPath     *connect.Client[v1.RemoveSandboxPathRequest, v1.RemoveSandboxPathResponse]
 	archiveSandboxPaths   *connect.Client[v1.ArchiveSandboxPathsRequest, v1.ArchiveSandboxPathsResponse]
 	extractSandboxArchive *connect.Client[v1.ExtractSandboxArchiveRequest, v1.ExtractSandboxArchiveResponse]
+	suspendSandbox        *connect.Client[v1.SuspendSandboxRequest, v1.SuspendSandboxResponse]
+	resumeSandbox         *connect.Client[v1.ResumeSandboxRequest, v1.ResumeSandboxResponse]
 	terminateSandbox      *connect.Client[v1.TerminateSandboxRequest, v1.TerminateSandboxResponse]
 	streamSandboxEvents   *connect.Client[v1.StreamSandboxEventsRequest, v1.SandboxEvent]
 	dialSandboxPort       *connect.Client[v1.SandboxPortFrame, v1.SandboxPortFrame]
@@ -346,6 +368,16 @@ func (c *sandboxServiceClient) ExtractSandboxArchive(ctx context.Context) *conne
 	return c.extractSandboxArchive.CallClientStream(ctx)
 }
 
+// SuspendSandbox calls cleanroom.v1.SandboxService.SuspendSandbox.
+func (c *sandboxServiceClient) SuspendSandbox(ctx context.Context, req *connect.Request[v1.SuspendSandboxRequest]) (*connect.Response[v1.SuspendSandboxResponse], error) {
+	return c.suspendSandbox.CallUnary(ctx, req)
+}
+
+// ResumeSandbox calls cleanroom.v1.SandboxService.ResumeSandbox.
+func (c *sandboxServiceClient) ResumeSandbox(ctx context.Context, req *connect.Request[v1.ResumeSandboxRequest]) (*connect.Response[v1.ResumeSandboxResponse], error) {
+	return c.resumeSandbox.CallUnary(ctx, req)
+}
+
 // TerminateSandbox calls cleanroom.v1.SandboxService.TerminateSandbox.
 func (c *sandboxServiceClient) TerminateSandbox(ctx context.Context, req *connect.Request[v1.TerminateSandboxRequest]) (*connect.Response[v1.TerminateSandboxResponse], error) {
 	return c.terminateSandbox.CallUnary(ctx, req)
@@ -376,6 +408,8 @@ type SandboxServiceHandler interface {
 	RemoveSandboxPath(context.Context, *connect.Request[v1.RemoveSandboxPathRequest]) (*connect.Response[v1.RemoveSandboxPathResponse], error)
 	ArchiveSandboxPaths(context.Context, *connect.Request[v1.ArchiveSandboxPathsRequest], *connect.ServerStream[v1.ArchiveSandboxPathsResponse]) error
 	ExtractSandboxArchive(context.Context, *connect.ClientStream[v1.ExtractSandboxArchiveRequest]) (*connect.Response[v1.ExtractSandboxArchiveResponse], error)
+	SuspendSandbox(context.Context, *connect.Request[v1.SuspendSandboxRequest]) (*connect.Response[v1.SuspendSandboxResponse], error)
+	ResumeSandbox(context.Context, *connect.Request[v1.ResumeSandboxRequest]) (*connect.Response[v1.ResumeSandboxResponse], error)
 	TerminateSandbox(context.Context, *connect.Request[v1.TerminateSandboxRequest]) (*connect.Response[v1.TerminateSandboxResponse], error)
 	StreamSandboxEvents(context.Context, *connect.Request[v1.StreamSandboxEventsRequest], *connect.ServerStream[v1.SandboxEvent]) error
 	DialSandboxPort(context.Context, *connect.BidiStream[v1.SandboxPortFrame, v1.SandboxPortFrame]) error
@@ -466,6 +500,18 @@ func NewSandboxServiceHandler(svc SandboxServiceHandler, opts ...connect.Handler
 		connect.WithSchema(sandboxServiceMethods.ByName("ExtractSandboxArchive")),
 		connect.WithHandlerOptions(opts...),
 	)
+	sandboxServiceSuspendSandboxHandler := connect.NewUnaryHandler(
+		SandboxServiceSuspendSandboxProcedure,
+		svc.SuspendSandbox,
+		connect.WithSchema(sandboxServiceMethods.ByName("SuspendSandbox")),
+		connect.WithHandlerOptions(opts...),
+	)
+	sandboxServiceResumeSandboxHandler := connect.NewUnaryHandler(
+		SandboxServiceResumeSandboxProcedure,
+		svc.ResumeSandbox,
+		connect.WithSchema(sandboxServiceMethods.ByName("ResumeSandbox")),
+		connect.WithHandlerOptions(opts...),
+	)
 	sandboxServiceTerminateSandboxHandler := connect.NewUnaryHandler(
 		SandboxServiceTerminateSandboxProcedure,
 		svc.TerminateSandbox,
@@ -512,6 +558,10 @@ func NewSandboxServiceHandler(svc SandboxServiceHandler, opts ...connect.Handler
 			sandboxServiceArchiveSandboxPathsHandler.ServeHTTP(w, r)
 		case SandboxServiceExtractSandboxArchiveProcedure:
 			sandboxServiceExtractSandboxArchiveHandler.ServeHTTP(w, r)
+		case SandboxServiceSuspendSandboxProcedure:
+			sandboxServiceSuspendSandboxHandler.ServeHTTP(w, r)
+		case SandboxServiceResumeSandboxProcedure:
+			sandboxServiceResumeSandboxHandler.ServeHTTP(w, r)
 		case SandboxServiceTerminateSandboxProcedure:
 			sandboxServiceTerminateSandboxHandler.ServeHTTP(w, r)
 		case SandboxServiceStreamSandboxEventsProcedure:
@@ -577,6 +627,14 @@ func (UnimplementedSandboxServiceHandler) ArchiveSandboxPaths(context.Context, *
 
 func (UnimplementedSandboxServiceHandler) ExtractSandboxArchive(context.Context, *connect.ClientStream[v1.ExtractSandboxArchiveRequest]) (*connect.Response[v1.ExtractSandboxArchiveResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cleanroom.v1.SandboxService.ExtractSandboxArchive is not implemented"))
+}
+
+func (UnimplementedSandboxServiceHandler) SuspendSandbox(context.Context, *connect.Request[v1.SuspendSandboxRequest]) (*connect.Response[v1.SuspendSandboxResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cleanroom.v1.SandboxService.SuspendSandbox is not implemented"))
+}
+
+func (UnimplementedSandboxServiceHandler) ResumeSandbox(context.Context, *connect.Request[v1.ResumeSandboxRequest]) (*connect.Response[v1.ResumeSandboxResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cleanroom.v1.SandboxService.ResumeSandbox is not implemented"))
 }
 
 func (UnimplementedSandboxServiceHandler) TerminateSandbox(context.Context, *connect.Request[v1.TerminateSandboxRequest]) (*connect.Response[v1.TerminateSandboxResponse], error) {

--- a/internal/gen/cleanroom/v1/control.pb.go
+++ b/internal/gen/cleanroom/v1/control.pb.go
@@ -32,6 +32,9 @@ const (
 	SandboxStatus_SANDBOX_STATUS_STOPPING     SandboxStatus = 3
 	SandboxStatus_SANDBOX_STATUS_STOPPED      SandboxStatus = 4
 	SandboxStatus_SANDBOX_STATUS_FAILED       SandboxStatus = 5
+	SandboxStatus_SANDBOX_STATUS_SUSPENDING   SandboxStatus = 6
+	SandboxStatus_SANDBOX_STATUS_SUSPENDED    SandboxStatus = 7
+	SandboxStatus_SANDBOX_STATUS_WAKING       SandboxStatus = 8
 )
 
 // Enum value maps for SandboxStatus.
@@ -43,6 +46,9 @@ var (
 		3: "SANDBOX_STATUS_STOPPING",
 		4: "SANDBOX_STATUS_STOPPED",
 		5: "SANDBOX_STATUS_FAILED",
+		6: "SANDBOX_STATUS_SUSPENDING",
+		7: "SANDBOX_STATUS_SUSPENDED",
+		8: "SANDBOX_STATUS_WAKING",
 	}
 	SandboxStatus_value = map[string]int32{
 		"SANDBOX_STATUS_UNSPECIFIED":  0,
@@ -51,6 +57,9 @@ var (
 		"SANDBOX_STATUS_STOPPING":     3,
 		"SANDBOX_STATUS_STOPPED":      4,
 		"SANDBOX_STATUS_FAILED":       5,
+		"SANDBOX_STATUS_SUSPENDING":   6,
+		"SANDBOX_STATUS_SUSPENDED":    7,
+		"SANDBOX_STATUS_WAKING":       8,
 	}
 )
 
@@ -3907,6 +3916,182 @@ func (x *TerminateSandboxResponse) GetMessage() string {
 	return ""
 }
 
+type SuspendSandboxRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SandboxId     string                 `protobuf:"bytes,1,opt,name=sandbox_id,json=sandboxId,proto3" json:"sandbox_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SuspendSandboxRequest) Reset() {
+	*x = SuspendSandboxRequest{}
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[55]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SuspendSandboxRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SuspendSandboxRequest) ProtoMessage() {}
+
+func (x *SuspendSandboxRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[55]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SuspendSandboxRequest.ProtoReflect.Descriptor instead.
+func (*SuspendSandboxRequest) Descriptor() ([]byte, []int) {
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{55}
+}
+
+func (x *SuspendSandboxRequest) GetSandboxId() string {
+	if x != nil {
+		return x.SandboxId
+	}
+	return ""
+}
+
+type SuspendSandboxResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Sandbox       *Sandbox               `protobuf:"bytes,1,opt,name=sandbox,proto3" json:"sandbox,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SuspendSandboxResponse) Reset() {
+	*x = SuspendSandboxResponse{}
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[56]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SuspendSandboxResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SuspendSandboxResponse) ProtoMessage() {}
+
+func (x *SuspendSandboxResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[56]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SuspendSandboxResponse.ProtoReflect.Descriptor instead.
+func (*SuspendSandboxResponse) Descriptor() ([]byte, []int) {
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{56}
+}
+
+func (x *SuspendSandboxResponse) GetSandbox() *Sandbox {
+	if x != nil {
+		return x.Sandbox
+	}
+	return nil
+}
+
+type ResumeSandboxRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SandboxId     string                 `protobuf:"bytes,1,opt,name=sandbox_id,json=sandboxId,proto3" json:"sandbox_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ResumeSandboxRequest) Reset() {
+	*x = ResumeSandboxRequest{}
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[57]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ResumeSandboxRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ResumeSandboxRequest) ProtoMessage() {}
+
+func (x *ResumeSandboxRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[57]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ResumeSandboxRequest.ProtoReflect.Descriptor instead.
+func (*ResumeSandboxRequest) Descriptor() ([]byte, []int) {
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{57}
+}
+
+func (x *ResumeSandboxRequest) GetSandboxId() string {
+	if x != nil {
+		return x.SandboxId
+	}
+	return ""
+}
+
+type ResumeSandboxResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Sandbox       *Sandbox               `protobuf:"bytes,1,opt,name=sandbox,proto3" json:"sandbox,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ResumeSandboxResponse) Reset() {
+	*x = ResumeSandboxResponse{}
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[58]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ResumeSandboxResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ResumeSandboxResponse) ProtoMessage() {}
+
+func (x *ResumeSandboxResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[58]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ResumeSandboxResponse.ProtoReflect.Descriptor instead.
+func (*ResumeSandboxResponse) Descriptor() ([]byte, []int) {
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{58}
+}
+
+func (x *ResumeSandboxResponse) GetSandbox() *Sandbox {
+	if x != nil {
+		return x.Sandbox
+	}
+	return nil
+}
+
 type StreamSandboxEventsRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	SandboxId     string                 `protobuf:"bytes,1,opt,name=sandbox_id,json=sandboxId,proto3" json:"sandbox_id,omitempty"`
@@ -3917,7 +4102,7 @@ type StreamSandboxEventsRequest struct {
 
 func (x *StreamSandboxEventsRequest) Reset() {
 	*x = StreamSandboxEventsRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[55]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3929,7 +4114,7 @@ func (x *StreamSandboxEventsRequest) String() string {
 func (*StreamSandboxEventsRequest) ProtoMessage() {}
 
 func (x *StreamSandboxEventsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[55]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3942,7 +4127,7 @@ func (x *StreamSandboxEventsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamSandboxEventsRequest.ProtoReflect.Descriptor instead.
 func (*StreamSandboxEventsRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{55}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *StreamSandboxEventsRequest) GetSandboxId() string {
@@ -3971,7 +4156,7 @@ type SandboxEvent struct {
 
 func (x *SandboxEvent) Reset() {
 	*x = SandboxEvent{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[56]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3983,7 +4168,7 @@ func (x *SandboxEvent) String() string {
 func (*SandboxEvent) ProtoMessage() {}
 
 func (x *SandboxEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[56]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3996,7 +4181,7 @@ func (x *SandboxEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxEvent.ProtoReflect.Descriptor instead.
 func (*SandboxEvent) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{56}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *SandboxEvent) GetSandboxId() string {
@@ -4037,7 +4222,7 @@ type CreateSnapshotRequest struct {
 
 func (x *CreateSnapshotRequest) Reset() {
 	*x = CreateSnapshotRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[57]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4049,7 +4234,7 @@ func (x *CreateSnapshotRequest) String() string {
 func (*CreateSnapshotRequest) ProtoMessage() {}
 
 func (x *CreateSnapshotRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[57]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4062,7 +4247,7 @@ func (x *CreateSnapshotRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSnapshotRequest.ProtoReflect.Descriptor instead.
 func (*CreateSnapshotRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{57}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *CreateSnapshotRequest) GetSandboxId() string {
@@ -4089,7 +4274,7 @@ type CreateSnapshotResponse struct {
 
 func (x *CreateSnapshotResponse) Reset() {
 	*x = CreateSnapshotResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[58]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4101,7 +4286,7 @@ func (x *CreateSnapshotResponse) String() string {
 func (*CreateSnapshotResponse) ProtoMessage() {}
 
 func (x *CreateSnapshotResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[58]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4114,7 +4299,7 @@ func (x *CreateSnapshotResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSnapshotResponse.ProtoReflect.Descriptor instead.
 func (*CreateSnapshotResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{58}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *CreateSnapshotResponse) GetSnapshot() *Snapshot {
@@ -4140,7 +4325,7 @@ type GetSnapshotRequest struct {
 
 func (x *GetSnapshotRequest) Reset() {
 	*x = GetSnapshotRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[59]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4152,7 +4337,7 @@ func (x *GetSnapshotRequest) String() string {
 func (*GetSnapshotRequest) ProtoMessage() {}
 
 func (x *GetSnapshotRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[59]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4165,7 +4350,7 @@ func (x *GetSnapshotRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSnapshotRequest.ProtoReflect.Descriptor instead.
 func (*GetSnapshotRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{59}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *GetSnapshotRequest) GetSnapshotId() string {
@@ -4184,7 +4369,7 @@ type GetSnapshotResponse struct {
 
 func (x *GetSnapshotResponse) Reset() {
 	*x = GetSnapshotResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[60]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4196,7 +4381,7 @@ func (x *GetSnapshotResponse) String() string {
 func (*GetSnapshotResponse) ProtoMessage() {}
 
 func (x *GetSnapshotResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[60]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4209,7 +4394,7 @@ func (x *GetSnapshotResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSnapshotResponse.ProtoReflect.Descriptor instead.
 func (*GetSnapshotResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{60}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *GetSnapshotResponse) GetSnapshot() *Snapshot {
@@ -4227,7 +4412,7 @@ type ListSnapshotsRequest struct {
 
 func (x *ListSnapshotsRequest) Reset() {
 	*x = ListSnapshotsRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[61]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4239,7 +4424,7 @@ func (x *ListSnapshotsRequest) String() string {
 func (*ListSnapshotsRequest) ProtoMessage() {}
 
 func (x *ListSnapshotsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[61]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4252,7 +4437,7 @@ func (x *ListSnapshotsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSnapshotsRequest.ProtoReflect.Descriptor instead.
 func (*ListSnapshotsRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{61}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{65}
 }
 
 type ListSnapshotsResponse struct {
@@ -4264,7 +4449,7 @@ type ListSnapshotsResponse struct {
 
 func (x *ListSnapshotsResponse) Reset() {
 	*x = ListSnapshotsResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[62]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4276,7 +4461,7 @@ func (x *ListSnapshotsResponse) String() string {
 func (*ListSnapshotsResponse) ProtoMessage() {}
 
 func (x *ListSnapshotsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[62]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4289,7 +4474,7 @@ func (x *ListSnapshotsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSnapshotsResponse.ProtoReflect.Descriptor instead.
 func (*ListSnapshotsResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{62}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *ListSnapshotsResponse) GetSnapshots() []*Snapshot {
@@ -4308,7 +4493,7 @@ type DeleteSnapshotRequest struct {
 
 func (x *DeleteSnapshotRequest) Reset() {
 	*x = DeleteSnapshotRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[63]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4320,7 +4505,7 @@ func (x *DeleteSnapshotRequest) String() string {
 func (*DeleteSnapshotRequest) ProtoMessage() {}
 
 func (x *DeleteSnapshotRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[63]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4333,7 +4518,7 @@ func (x *DeleteSnapshotRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSnapshotRequest.ProtoReflect.Descriptor instead.
 func (*DeleteSnapshotRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{63}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *DeleteSnapshotRequest) GetSnapshotId() string {
@@ -4354,7 +4539,7 @@ type DeleteSnapshotResponse struct {
 
 func (x *DeleteSnapshotResponse) Reset() {
 	*x = DeleteSnapshotResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[64]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4366,7 +4551,7 @@ func (x *DeleteSnapshotResponse) String() string {
 func (*DeleteSnapshotResponse) ProtoMessage() {}
 
 func (x *DeleteSnapshotResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[64]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4379,7 +4564,7 @@ func (x *DeleteSnapshotResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSnapshotResponse.ProtoReflect.Descriptor instead.
 func (*DeleteSnapshotResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{64}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *DeleteSnapshotResponse) GetSnapshotId() string {
@@ -4421,7 +4606,7 @@ type LookupCachePeerRequest struct {
 
 func (x *LookupCachePeerRequest) Reset() {
 	*x = LookupCachePeerRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[65]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4433,7 +4618,7 @@ func (x *LookupCachePeerRequest) String() string {
 func (*LookupCachePeerRequest) ProtoMessage() {}
 
 func (x *LookupCachePeerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[65]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4446,7 +4631,7 @@ func (x *LookupCachePeerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LookupCachePeerRequest.ProtoReflect.Descriptor instead.
 func (*LookupCachePeerRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{65}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{69}
 }
 
 func (x *LookupCachePeerRequest) GetStage() string {
@@ -4529,7 +4714,7 @@ type LookupCachePeerResponse struct {
 
 func (x *LookupCachePeerResponse) Reset() {
 	*x = LookupCachePeerResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[66]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4541,7 +4726,7 @@ func (x *LookupCachePeerResponse) String() string {
 func (*LookupCachePeerResponse) ProtoMessage() {}
 
 func (x *LookupCachePeerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[66]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4554,7 +4739,7 @@ func (x *LookupCachePeerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LookupCachePeerResponse.ProtoReflect.Descriptor instead.
 func (*LookupCachePeerResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{66}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *LookupCachePeerResponse) GetCandidate() *CachePeerCandidate {
@@ -4595,7 +4780,7 @@ type CachePeerCandidate struct {
 
 func (x *CachePeerCandidate) Reset() {
 	*x = CachePeerCandidate{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[67]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4607,7 +4792,7 @@ func (x *CachePeerCandidate) String() string {
 func (*CachePeerCandidate) ProtoMessage() {}
 
 func (x *CachePeerCandidate) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[67]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4620,7 +4805,7 @@ func (x *CachePeerCandidate) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CachePeerCandidate.ProtoReflect.Descriptor instead.
 func (*CachePeerCandidate) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{67}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *CachePeerCandidate) GetTransferToken() string {
@@ -4752,7 +4937,7 @@ type Execution struct {
 
 func (x *Execution) Reset() {
 	*x = Execution{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[68]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4764,7 +4949,7 @@ func (x *Execution) String() string {
 func (*Execution) ProtoMessage() {}
 
 func (x *Execution) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[68]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4777,7 +4962,7 @@ func (x *Execution) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Execution.ProtoReflect.Descriptor instead.
 func (*Execution) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{68}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *Execution) GetExecutionId() string {
@@ -4855,7 +5040,7 @@ type ExecutionOptions struct {
 
 func (x *ExecutionOptions) Reset() {
 	*x = ExecutionOptions{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[69]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4867,7 +5052,7 @@ func (x *ExecutionOptions) String() string {
 func (*ExecutionOptions) ProtoMessage() {}
 
 func (x *ExecutionOptions) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[69]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4880,7 +5065,7 @@ func (x *ExecutionOptions) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionOptions.ProtoReflect.Descriptor instead.
 func (*ExecutionOptions) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{69}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *ExecutionOptions) GetLaunchSeconds() int64 {
@@ -4925,7 +5110,7 @@ type CreateExecutionRequest struct {
 
 func (x *CreateExecutionRequest) Reset() {
 	*x = CreateExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[70]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4937,7 +5122,7 @@ func (x *CreateExecutionRequest) String() string {
 func (*CreateExecutionRequest) ProtoMessage() {}
 
 func (x *CreateExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[70]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4950,7 +5135,7 @@ func (x *CreateExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateExecutionRequest.ProtoReflect.Descriptor instead.
 func (*CreateExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{70}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{74}
 }
 
 func (x *CreateExecutionRequest) GetSandboxId() string {
@@ -5004,7 +5189,7 @@ type CreateExecutionResponse struct {
 
 func (x *CreateExecutionResponse) Reset() {
 	*x = CreateExecutionResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[71]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5016,7 +5201,7 @@ func (x *CreateExecutionResponse) String() string {
 func (*CreateExecutionResponse) ProtoMessage() {}
 
 func (x *CreateExecutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[71]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5029,7 +5214,7 @@ func (x *CreateExecutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateExecutionResponse.ProtoReflect.Descriptor instead.
 func (*CreateExecutionResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{71}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{75}
 }
 
 func (x *CreateExecutionResponse) GetExecution() *Execution {
@@ -5051,7 +5236,7 @@ type AttachExecutionRequest struct {
 
 func (x *AttachExecutionRequest) Reset() {
 	*x = AttachExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[72]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5063,7 +5248,7 @@ func (x *AttachExecutionRequest) String() string {
 func (*AttachExecutionRequest) ProtoMessage() {}
 
 func (x *AttachExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[72]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5076,7 +5261,7 @@ func (x *AttachExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachExecutionRequest.ProtoReflect.Descriptor instead.
 func (*AttachExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{72}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{76}
 }
 
 func (x *AttachExecutionRequest) GetSandboxId() string {
@@ -5121,7 +5306,7 @@ type AttachExecutionResponse struct {
 
 func (x *AttachExecutionResponse) Reset() {
 	*x = AttachExecutionResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[73]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5133,7 +5318,7 @@ func (x *AttachExecutionResponse) String() string {
 func (*AttachExecutionResponse) ProtoMessage() {}
 
 func (x *AttachExecutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[73]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5146,7 +5331,7 @@ func (x *AttachExecutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachExecutionResponse.ProtoReflect.Descriptor instead.
 func (*AttachExecutionResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{73}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{77}
 }
 
 func (x *AttachExecutionResponse) GetSessionId() string {
@@ -5201,7 +5386,7 @@ type GetExecutionRequest struct {
 
 func (x *GetExecutionRequest) Reset() {
 	*x = GetExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[74]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5213,7 +5398,7 @@ func (x *GetExecutionRequest) String() string {
 func (*GetExecutionRequest) ProtoMessage() {}
 
 func (x *GetExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[74]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5226,7 +5411,7 @@ func (x *GetExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetExecutionRequest.ProtoReflect.Descriptor instead.
 func (*GetExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{74}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{78}
 }
 
 func (x *GetExecutionRequest) GetSandboxId() string {
@@ -5252,7 +5437,7 @@ type GetExecutionResponse struct {
 
 func (x *GetExecutionResponse) Reset() {
 	*x = GetExecutionResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[75]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5264,7 +5449,7 @@ func (x *GetExecutionResponse) String() string {
 func (*GetExecutionResponse) ProtoMessage() {}
 
 func (x *GetExecutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[75]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5277,7 +5462,7 @@ func (x *GetExecutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetExecutionResponse.ProtoReflect.Descriptor instead.
 func (*GetExecutionResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{75}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{79}
 }
 
 func (x *GetExecutionResponse) GetExecution() *Execution {
@@ -5297,7 +5482,7 @@ type InspectExecutionRequest struct {
 
 func (x *InspectExecutionRequest) Reset() {
 	*x = InspectExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[76]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5309,7 +5494,7 @@ func (x *InspectExecutionRequest) String() string {
 func (*InspectExecutionRequest) ProtoMessage() {}
 
 func (x *InspectExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[76]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5322,7 +5507,7 @@ func (x *InspectExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectExecutionRequest.ProtoReflect.Descriptor instead.
 func (*InspectExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{76}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{80}
 }
 
 func (x *InspectExecutionRequest) GetSandboxId() string {
@@ -5359,7 +5544,7 @@ type InspectExecutionResponse struct {
 
 func (x *InspectExecutionResponse) Reset() {
 	*x = InspectExecutionResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[77]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5371,7 +5556,7 @@ func (x *InspectExecutionResponse) String() string {
 func (*InspectExecutionResponse) ProtoMessage() {}
 
 func (x *InspectExecutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[77]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5384,7 +5569,7 @@ func (x *InspectExecutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectExecutionResponse.ProtoReflect.Descriptor instead.
 func (*InspectExecutionResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{77}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{81}
 }
 
 func (x *InspectExecutionResponse) GetExecution() *Execution {
@@ -5482,7 +5667,7 @@ type CancelExecutionRequest struct {
 
 func (x *CancelExecutionRequest) Reset() {
 	*x = CancelExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[78]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5494,7 +5679,7 @@ func (x *CancelExecutionRequest) String() string {
 func (*CancelExecutionRequest) ProtoMessage() {}
 
 func (x *CancelExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[78]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5507,7 +5692,7 @@ func (x *CancelExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelExecutionRequest.ProtoReflect.Descriptor instead.
 func (*CancelExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{78}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{82}
 }
 
 func (x *CancelExecutionRequest) GetSandboxId() string {
@@ -5543,7 +5728,7 @@ type CancelExecutionResponse struct {
 
 func (x *CancelExecutionResponse) Reset() {
 	*x = CancelExecutionResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[79]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5555,7 +5740,7 @@ func (x *CancelExecutionResponse) String() string {
 func (*CancelExecutionResponse) ProtoMessage() {}
 
 func (x *CancelExecutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[79]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5568,7 +5753,7 @@ func (x *CancelExecutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelExecutionResponse.ProtoReflect.Descriptor instead.
 func (*CancelExecutionResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{79}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{83}
 }
 
 func (x *CancelExecutionResponse) GetSandboxId() string {
@@ -5610,7 +5795,7 @@ type WriteExecutionStdinRequest struct {
 
 func (x *WriteExecutionStdinRequest) Reset() {
 	*x = WriteExecutionStdinRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[80]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5622,7 +5807,7 @@ func (x *WriteExecutionStdinRequest) String() string {
 func (*WriteExecutionStdinRequest) ProtoMessage() {}
 
 func (x *WriteExecutionStdinRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[80]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5635,7 +5820,7 @@ func (x *WriteExecutionStdinRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WriteExecutionStdinRequest.ProtoReflect.Descriptor instead.
 func (*WriteExecutionStdinRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{80}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{84}
 }
 
 func (x *WriteExecutionStdinRequest) GetSandboxId() string {
@@ -5667,7 +5852,7 @@ type WriteExecutionStdinResponse struct {
 
 func (x *WriteExecutionStdinResponse) Reset() {
 	*x = WriteExecutionStdinResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[81]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5679,7 +5864,7 @@ func (x *WriteExecutionStdinResponse) String() string {
 func (*WriteExecutionStdinResponse) ProtoMessage() {}
 
 func (x *WriteExecutionStdinResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[81]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5692,7 +5877,7 @@ func (x *WriteExecutionStdinResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WriteExecutionStdinResponse.ProtoReflect.Descriptor instead.
 func (*WriteExecutionStdinResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{81}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{85}
 }
 
 type CloseExecutionStdinRequest struct {
@@ -5705,7 +5890,7 @@ type CloseExecutionStdinRequest struct {
 
 func (x *CloseExecutionStdinRequest) Reset() {
 	*x = CloseExecutionStdinRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[82]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[86]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5717,7 +5902,7 @@ func (x *CloseExecutionStdinRequest) String() string {
 func (*CloseExecutionStdinRequest) ProtoMessage() {}
 
 func (x *CloseExecutionStdinRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[82]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[86]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5730,7 +5915,7 @@ func (x *CloseExecutionStdinRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CloseExecutionStdinRequest.ProtoReflect.Descriptor instead.
 func (*CloseExecutionStdinRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{82}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{86}
 }
 
 func (x *CloseExecutionStdinRequest) GetSandboxId() string {
@@ -5755,7 +5940,7 @@ type CloseExecutionStdinResponse struct {
 
 func (x *CloseExecutionStdinResponse) Reset() {
 	*x = CloseExecutionStdinResponse{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[83]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5767,7 +5952,7 @@ func (x *CloseExecutionStdinResponse) String() string {
 func (*CloseExecutionStdinResponse) ProtoMessage() {}
 
 func (x *CloseExecutionStdinResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[83]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5780,7 +5965,7 @@ func (x *CloseExecutionStdinResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CloseExecutionStdinResponse.ProtoReflect.Descriptor instead.
 func (*CloseExecutionStdinResponse) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{83}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{87}
 }
 
 type StreamExecutionRequest struct {
@@ -5794,7 +5979,7 @@ type StreamExecutionRequest struct {
 
 func (x *StreamExecutionRequest) Reset() {
 	*x = StreamExecutionRequest{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[84]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5806,7 +5991,7 @@ func (x *StreamExecutionRequest) String() string {
 func (*StreamExecutionRequest) ProtoMessage() {}
 
 func (x *StreamExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[84]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5819,7 +6004,7 @@ func (x *StreamExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamExecutionRequest.ProtoReflect.Descriptor instead.
 func (*StreamExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{84}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{88}
 }
 
 func (x *StreamExecutionRequest) GetSandboxId() string {
@@ -5854,7 +6039,7 @@ type ExecutionExit struct {
 
 func (x *ExecutionExit) Reset() {
 	*x = ExecutionExit{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[85]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5866,7 +6051,7 @@ func (x *ExecutionExit) String() string {
 func (*ExecutionExit) ProtoMessage() {}
 
 func (x *ExecutionExit) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[85]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5879,7 +6064,7 @@ func (x *ExecutionExit) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionExit.ProtoReflect.Descriptor instead.
 func (*ExecutionExit) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{85}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{89}
 }
 
 func (x *ExecutionExit) GetExitCode() int32 {
@@ -5925,7 +6110,7 @@ type ExecutionStreamEvent struct {
 
 func (x *ExecutionStreamEvent) Reset() {
 	*x = ExecutionStreamEvent{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[86]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[90]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5937,7 +6122,7 @@ func (x *ExecutionStreamEvent) String() string {
 func (*ExecutionStreamEvent) ProtoMessage() {}
 
 func (x *ExecutionStreamEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[86]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[90]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5950,7 +6135,7 @@ func (x *ExecutionStreamEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionStreamEvent.ProtoReflect.Descriptor instead.
 func (*ExecutionStreamEvent) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{86}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{90}
 }
 
 func (x *ExecutionStreamEvent) GetSandboxId() string {
@@ -6090,7 +6275,7 @@ type SandboxPortOpenResult struct {
 
 func (x *SandboxPortOpenResult) Reset() {
 	*x = SandboxPortOpenResult{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[87]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[91]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6102,7 +6287,7 @@ func (x *SandboxPortOpenResult) String() string {
 func (*SandboxPortOpenResult) ProtoMessage() {}
 
 func (x *SandboxPortOpenResult) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[87]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[91]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6115,7 +6300,7 @@ func (x *SandboxPortOpenResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxPortOpenResult.ProtoReflect.Descriptor instead.
 func (*SandboxPortOpenResult) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{87}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{91}
 }
 
 func (x *SandboxPortOpenResult) GetError() string {
@@ -6141,7 +6326,7 @@ type SandboxResources struct {
 
 func (x *SandboxResources) Reset() {
 	*x = SandboxResources{}
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[88]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[92]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6153,7 +6338,7 @@ func (x *SandboxResources) String() string {
 func (*SandboxResources) ProtoMessage() {}
 
 func (x *SandboxResources) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[88]
+	mi := &file_proto_cleanroom_v1_control_proto_msgTypes[92]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6166,7 +6351,7 @@ func (x *SandboxResources) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxResources.ProtoReflect.Descriptor instead.
 func (*SandboxResources) Descriptor() ([]byte, []int) {
-	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{88}
+	return file_proto_cleanroom_v1_control_proto_rawDescGZIP(), []int{92}
 }
 
 func (x *SandboxResources) GetVcpus() int64 {
@@ -6487,7 +6672,17 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\n" +
 	"terminated\x18\x02 \x01(\bR\n" +
 	"terminated\x12\x18\n" +
-	"\amessage\x18\x03 \x01(\tR\amessage\"S\n" +
+	"\amessage\x18\x03 \x01(\tR\amessage\"6\n" +
+	"\x15SuspendSandboxRequest\x12\x1d\n" +
+	"\n" +
+	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\"I\n" +
+	"\x16SuspendSandboxResponse\x12/\n" +
+	"\asandbox\x18\x01 \x01(\v2\x15.cleanroom.v1.SandboxR\asandbox\"5\n" +
+	"\x14ResumeSandboxRequest\x12\x1d\n" +
+	"\n" +
+	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\"H\n" +
+	"\x15ResumeSandboxResponse\x12/\n" +
+	"\asandbox\x18\x01 \x01(\v2\x15.cleanroom.v1.SandboxR\asandbox\"S\n" +
 	"\x1aStreamSandboxEventsRequest\x12\x1d\n" +
 	"\n" +
 	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\x12\x16\n" +
@@ -6683,14 +6878,17 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\x05vcpus\x18\x01 \x01(\x03R\x05vcpus\x12!\n" +
 	"\fmemory_bytes\x18\x02 \x01(\x03R\vmemoryBytes\x12\x1d\n" +
 	"\n" +
-	"disk_bytes\x18\x03 \x01(\x03R\tdiskBytes*\xbe\x01\n" +
+	"disk_bytes\x18\x03 \x01(\x03R\tdiskBytes*\x96\x02\n" +
 	"\rSandboxStatus\x12\x1e\n" +
 	"\x1aSANDBOX_STATUS_UNSPECIFIED\x10\x00\x12\x1f\n" +
 	"\x1bSANDBOX_STATUS_PROVISIONING\x10\x01\x12\x18\n" +
 	"\x14SANDBOX_STATUS_READY\x10\x02\x12\x1b\n" +
 	"\x17SANDBOX_STATUS_STOPPING\x10\x03\x12\x1a\n" +
 	"\x16SANDBOX_STATUS_STOPPED\x10\x04\x12\x19\n" +
-	"\x15SANDBOX_STATUS_FAILED\x10\x05*\xe8\x06\n" +
+	"\x15SANDBOX_STATUS_FAILED\x10\x05\x12\x1d\n" +
+	"\x19SANDBOX_STATUS_SUSPENDING\x10\x06\x12\x1c\n" +
+	"\x18SANDBOX_STATUS_SUSPENDED\x10\a\x12\x19\n" +
+	"\x15SANDBOX_STATUS_WAKING\x10\b*\xe8\x06\n" +
 	"\x12CreateSandboxPhase\x12$\n" +
 	" CREATE_SANDBOX_PHASE_UNSPECIFIED\x10\x00\x12)\n" +
 	"%CREATE_SANDBOX_PHASE_RESTORE_SNAPSHOT\x10\x01\x126\n" +
@@ -6727,7 +6925,7 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\rExecutionKind\x12\x1e\n" +
 	"\x1aEXECUTION_KIND_UNSPECIFIED\x10\x00\x12\x18\n" +
 	"\x14EXECUTION_KIND_BATCH\x10\x01\x12\x1e\n" +
-	"\x1aEXECUTION_KIND_INTERACTIVE\x10\x022\xb0\f\n" +
+	"\x1aEXECUTION_KIND_INTERACTIVE\x10\x022\xe7\r\n" +
 	"\x0eSandboxService\x12X\n" +
 	"\rCreateSandbox\x12\".cleanroom.v1.CreateSandboxRequest\x1a#.cleanroom.v1.CreateSandboxResponse\x12]\n" +
 	"\x13CreateSandboxStream\x12\".cleanroom.v1.CreateSandboxRequest\x1a .cleanroom.v1.CreateSandboxEvent0\x01\x12O\n" +
@@ -6742,7 +6940,9 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	"\x10WriteSandboxFile\x12%.cleanroom.v1.WriteSandboxFileRequest\x1a&.cleanroom.v1.WriteSandboxFileResponse(\x01\x12d\n" +
 	"\x11RemoveSandboxPath\x12&.cleanroom.v1.RemoveSandboxPathRequest\x1a'.cleanroom.v1.RemoveSandboxPathResponse\x12l\n" +
 	"\x13ArchiveSandboxPaths\x12(.cleanroom.v1.ArchiveSandboxPathsRequest\x1a).cleanroom.v1.ArchiveSandboxPathsResponse0\x01\x12r\n" +
-	"\x15ExtractSandboxArchive\x12*.cleanroom.v1.ExtractSandboxArchiveRequest\x1a+.cleanroom.v1.ExtractSandboxArchiveResponse(\x01\x12a\n" +
+	"\x15ExtractSandboxArchive\x12*.cleanroom.v1.ExtractSandboxArchiveRequest\x1a+.cleanroom.v1.ExtractSandboxArchiveResponse(\x01\x12[\n" +
+	"\x0eSuspendSandbox\x12#.cleanroom.v1.SuspendSandboxRequest\x1a$.cleanroom.v1.SuspendSandboxResponse\x12X\n" +
+	"\rResumeSandbox\x12\".cleanroom.v1.ResumeSandboxRequest\x1a#.cleanroom.v1.ResumeSandboxResponse\x12a\n" +
 	"\x10TerminateSandbox\x12%.cleanroom.v1.TerminateSandboxRequest\x1a&.cleanroom.v1.TerminateSandboxResponse\x12]\n" +
 	"\x13StreamSandboxEvents\x12(.cleanroom.v1.StreamSandboxEventsRequest\x1a\x1a.cleanroom.v1.SandboxEvent0\x01\x12U\n" +
 	"\x0fDialSandboxPort\x12\x1e.cleanroom.v1.SandboxPortFrame\x1a\x1e.cleanroom.v1.SandboxPortFrame(\x010\x012\xf9\x02\n" +
@@ -6777,7 +6977,7 @@ func file_proto_cleanroom_v1_control_proto_rawDescGZIP() []byte {
 }
 
 var file_proto_cleanroom_v1_control_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_proto_cleanroom_v1_control_proto_msgTypes = make([]protoimpl.MessageInfo, 91)
+var file_proto_cleanroom_v1_control_proto_msgTypes = make([]protoimpl.MessageInfo, 95)
 var file_proto_cleanroom_v1_control_proto_goTypes = []any{
 	(SandboxStatus)(0),                    // 0: cleanroom.v1.SandboxStatus
 	(CreateSandboxPhase)(0),               // 1: cleanroom.v1.CreateSandboxPhase
@@ -6839,59 +7039,63 @@ var file_proto_cleanroom_v1_control_proto_goTypes = []any{
 	(*ExtractSandboxArchiveResponse)(nil), // 57: cleanroom.v1.ExtractSandboxArchiveResponse
 	(*TerminateSandboxRequest)(nil),       // 58: cleanroom.v1.TerminateSandboxRequest
 	(*TerminateSandboxResponse)(nil),      // 59: cleanroom.v1.TerminateSandboxResponse
-	(*StreamSandboxEventsRequest)(nil),    // 60: cleanroom.v1.StreamSandboxEventsRequest
-	(*SandboxEvent)(nil),                  // 61: cleanroom.v1.SandboxEvent
-	(*CreateSnapshotRequest)(nil),         // 62: cleanroom.v1.CreateSnapshotRequest
-	(*CreateSnapshotResponse)(nil),        // 63: cleanroom.v1.CreateSnapshotResponse
-	(*GetSnapshotRequest)(nil),            // 64: cleanroom.v1.GetSnapshotRequest
-	(*GetSnapshotResponse)(nil),           // 65: cleanroom.v1.GetSnapshotResponse
-	(*ListSnapshotsRequest)(nil),          // 66: cleanroom.v1.ListSnapshotsRequest
-	(*ListSnapshotsResponse)(nil),         // 67: cleanroom.v1.ListSnapshotsResponse
-	(*DeleteSnapshotRequest)(nil),         // 68: cleanroom.v1.DeleteSnapshotRequest
-	(*DeleteSnapshotResponse)(nil),        // 69: cleanroom.v1.DeleteSnapshotResponse
-	(*LookupCachePeerRequest)(nil),        // 70: cleanroom.v1.LookupCachePeerRequest
-	(*LookupCachePeerResponse)(nil),       // 71: cleanroom.v1.LookupCachePeerResponse
-	(*CachePeerCandidate)(nil),            // 72: cleanroom.v1.CachePeerCandidate
-	(*Execution)(nil),                     // 73: cleanroom.v1.Execution
-	(*ExecutionOptions)(nil),              // 74: cleanroom.v1.ExecutionOptions
-	(*CreateExecutionRequest)(nil),        // 75: cleanroom.v1.CreateExecutionRequest
-	(*CreateExecutionResponse)(nil),       // 76: cleanroom.v1.CreateExecutionResponse
-	(*AttachExecutionRequest)(nil),        // 77: cleanroom.v1.AttachExecutionRequest
-	(*AttachExecutionResponse)(nil),       // 78: cleanroom.v1.AttachExecutionResponse
-	(*GetExecutionRequest)(nil),           // 79: cleanroom.v1.GetExecutionRequest
-	(*GetExecutionResponse)(nil),          // 80: cleanroom.v1.GetExecutionResponse
-	(*InspectExecutionRequest)(nil),       // 81: cleanroom.v1.InspectExecutionRequest
-	(*InspectExecutionResponse)(nil),      // 82: cleanroom.v1.InspectExecutionResponse
-	(*CancelExecutionRequest)(nil),        // 83: cleanroom.v1.CancelExecutionRequest
-	(*CancelExecutionResponse)(nil),       // 84: cleanroom.v1.CancelExecutionResponse
-	(*WriteExecutionStdinRequest)(nil),    // 85: cleanroom.v1.WriteExecutionStdinRequest
-	(*WriteExecutionStdinResponse)(nil),   // 86: cleanroom.v1.WriteExecutionStdinResponse
-	(*CloseExecutionStdinRequest)(nil),    // 87: cleanroom.v1.CloseExecutionStdinRequest
-	(*CloseExecutionStdinResponse)(nil),   // 88: cleanroom.v1.CloseExecutionStdinResponse
-	(*StreamExecutionRequest)(nil),        // 89: cleanroom.v1.StreamExecutionRequest
-	(*ExecutionExit)(nil),                 // 90: cleanroom.v1.ExecutionExit
-	(*ExecutionStreamEvent)(nil),          // 91: cleanroom.v1.ExecutionStreamEvent
-	(*SandboxPortOpenResult)(nil),         // 92: cleanroom.v1.SandboxPortOpenResult
-	(*SandboxResources)(nil),              // 93: cleanroom.v1.SandboxResources
-	nil,                                   // 94: cleanroom.v1.Sandbox.BackendCapabilitiesEntry
-	nil,                                   // 95: cleanroom.v1.PolicyBlock.EnvEntry
-	(*timestamppb.Timestamp)(nil),         // 96: google.protobuf.Timestamp
-	(*structpb.Struct)(nil),               // 97: google.protobuf.Struct
+	(*SuspendSandboxRequest)(nil),         // 60: cleanroom.v1.SuspendSandboxRequest
+	(*SuspendSandboxResponse)(nil),        // 61: cleanroom.v1.SuspendSandboxResponse
+	(*ResumeSandboxRequest)(nil),          // 62: cleanroom.v1.ResumeSandboxRequest
+	(*ResumeSandboxResponse)(nil),         // 63: cleanroom.v1.ResumeSandboxResponse
+	(*StreamSandboxEventsRequest)(nil),    // 64: cleanroom.v1.StreamSandboxEventsRequest
+	(*SandboxEvent)(nil),                  // 65: cleanroom.v1.SandboxEvent
+	(*CreateSnapshotRequest)(nil),         // 66: cleanroom.v1.CreateSnapshotRequest
+	(*CreateSnapshotResponse)(nil),        // 67: cleanroom.v1.CreateSnapshotResponse
+	(*GetSnapshotRequest)(nil),            // 68: cleanroom.v1.GetSnapshotRequest
+	(*GetSnapshotResponse)(nil),           // 69: cleanroom.v1.GetSnapshotResponse
+	(*ListSnapshotsRequest)(nil),          // 70: cleanroom.v1.ListSnapshotsRequest
+	(*ListSnapshotsResponse)(nil),         // 71: cleanroom.v1.ListSnapshotsResponse
+	(*DeleteSnapshotRequest)(nil),         // 72: cleanroom.v1.DeleteSnapshotRequest
+	(*DeleteSnapshotResponse)(nil),        // 73: cleanroom.v1.DeleteSnapshotResponse
+	(*LookupCachePeerRequest)(nil),        // 74: cleanroom.v1.LookupCachePeerRequest
+	(*LookupCachePeerResponse)(nil),       // 75: cleanroom.v1.LookupCachePeerResponse
+	(*CachePeerCandidate)(nil),            // 76: cleanroom.v1.CachePeerCandidate
+	(*Execution)(nil),                     // 77: cleanroom.v1.Execution
+	(*ExecutionOptions)(nil),              // 78: cleanroom.v1.ExecutionOptions
+	(*CreateExecutionRequest)(nil),        // 79: cleanroom.v1.CreateExecutionRequest
+	(*CreateExecutionResponse)(nil),       // 80: cleanroom.v1.CreateExecutionResponse
+	(*AttachExecutionRequest)(nil),        // 81: cleanroom.v1.AttachExecutionRequest
+	(*AttachExecutionResponse)(nil),       // 82: cleanroom.v1.AttachExecutionResponse
+	(*GetExecutionRequest)(nil),           // 83: cleanroom.v1.GetExecutionRequest
+	(*GetExecutionResponse)(nil),          // 84: cleanroom.v1.GetExecutionResponse
+	(*InspectExecutionRequest)(nil),       // 85: cleanroom.v1.InspectExecutionRequest
+	(*InspectExecutionResponse)(nil),      // 86: cleanroom.v1.InspectExecutionResponse
+	(*CancelExecutionRequest)(nil),        // 87: cleanroom.v1.CancelExecutionRequest
+	(*CancelExecutionResponse)(nil),       // 88: cleanroom.v1.CancelExecutionResponse
+	(*WriteExecutionStdinRequest)(nil),    // 89: cleanroom.v1.WriteExecutionStdinRequest
+	(*WriteExecutionStdinResponse)(nil),   // 90: cleanroom.v1.WriteExecutionStdinResponse
+	(*CloseExecutionStdinRequest)(nil),    // 91: cleanroom.v1.CloseExecutionStdinRequest
+	(*CloseExecutionStdinResponse)(nil),   // 92: cleanroom.v1.CloseExecutionStdinResponse
+	(*StreamExecutionRequest)(nil),        // 93: cleanroom.v1.StreamExecutionRequest
+	(*ExecutionExit)(nil),                 // 94: cleanroom.v1.ExecutionExit
+	(*ExecutionStreamEvent)(nil),          // 95: cleanroom.v1.ExecutionStreamEvent
+	(*SandboxPortOpenResult)(nil),         // 96: cleanroom.v1.SandboxPortOpenResult
+	(*SandboxResources)(nil),              // 97: cleanroom.v1.SandboxResources
+	nil,                                   // 98: cleanroom.v1.Sandbox.BackendCapabilitiesEntry
+	nil,                                   // 99: cleanroom.v1.PolicyBlock.EnvEntry
+	(*timestamppb.Timestamp)(nil),         // 100: google.protobuf.Timestamp
+	(*structpb.Struct)(nil),               // 101: google.protobuf.Struct
 }
 var file_proto_cleanroom_v1_control_proto_depIdxs = []int32{
 	0,   // 0: cleanroom.v1.Sandbox.status:type_name -> cleanroom.v1.SandboxStatus
-	96,  // 1: cleanroom.v1.Sandbox.created_at:type_name -> google.protobuf.Timestamp
-	96,  // 2: cleanroom.v1.Sandbox.updated_at:type_name -> google.protobuf.Timestamp
+	100, // 1: cleanroom.v1.Sandbox.created_at:type_name -> google.protobuf.Timestamp
+	100, // 2: cleanroom.v1.Sandbox.updated_at:type_name -> google.protobuf.Timestamp
 	24,  // 3: cleanroom.v1.Sandbox.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
-	94,  // 4: cleanroom.v1.Sandbox.backend_capabilities:type_name -> cleanroom.v1.Sandbox.BackendCapabilitiesEntry
-	93,  // 5: cleanroom.v1.Sandbox.effective_resources:type_name -> cleanroom.v1.SandboxResources
+	98,  // 4: cleanroom.v1.Sandbox.backend_capabilities:type_name -> cleanroom.v1.Sandbox.BackendCapabilitiesEntry
+	97,  // 5: cleanroom.v1.Sandbox.effective_resources:type_name -> cleanroom.v1.SandboxResources
 	8,   // 6: cleanroom.v1.SandboxPortFrame.open:type_name -> cleanroom.v1.SandboxPortOpen
 	9,   // 7: cleanroom.v1.SandboxPortFrame.close_write:type_name -> cleanroom.v1.SandboxPortCloseWrite
-	92,  // 8: cleanroom.v1.SandboxPortFrame.open_result:type_name -> cleanroom.v1.SandboxPortOpenResult
-	96,  // 9: cleanroom.v1.Snapshot.created_at:type_name -> google.protobuf.Timestamp
+	96,  // 8: cleanroom.v1.SandboxPortFrame.open_result:type_name -> cleanroom.v1.SandboxPortOpenResult
+	100, // 9: cleanroom.v1.Snapshot.created_at:type_name -> google.protobuf.Timestamp
 	24,  // 10: cleanroom.v1.Snapshot.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
 	13,  // 11: cleanroom.v1.PolicyBlock.inputs:type_name -> cleanroom.v1.PolicyBlockInputs
-	95,  // 12: cleanroom.v1.PolicyBlock.env:type_name -> cleanroom.v1.PolicyBlock.EnvEntry
+	99,  // 12: cleanroom.v1.PolicyBlock.env:type_name -> cleanroom.v1.PolicyBlock.EnvEntry
 	14,  // 13: cleanroom.v1.PolicyBlock.outputs:type_name -> cleanroom.v1.PolicyBlockOutputs
 	15,  // 14: cleanroom.v1.PolicyServices.blocks:type_name -> cleanroom.v1.PolicyBlock
 	15,  // 15: cleanroom.v1.PolicyDependencies.blocks:type_name -> cleanroom.v1.PolicyBlock
@@ -6916,106 +7120,112 @@ var file_proto_cleanroom_v1_control_proto_depIdxs = []int32{
 	5,   // 34: cleanroom.v1.CreateSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
 	1,   // 35: cleanroom.v1.CreateSandboxEvent.phase:type_name -> cleanroom.v1.CreateSandboxPhase
 	29,  // 36: cleanroom.v1.CreateSandboxEvent.response:type_name -> cleanroom.v1.CreateSandboxResponse
-	96,  // 37: cleanroom.v1.CreateSandboxEvent.occurred_at:type_name -> google.protobuf.Timestamp
+	100, // 37: cleanroom.v1.CreateSandboxEvent.occurred_at:type_name -> google.protobuf.Timestamp
 	5,   // 38: cleanroom.v1.GetSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
 	5,   // 39: cleanroom.v1.ListSandboxesResponse.sandboxes:type_name -> cleanroom.v1.Sandbox
-	73,  // 40: cleanroom.v1.ListExecutionsResponse.executions:type_name -> cleanroom.v1.Execution
+	77,  // 40: cleanroom.v1.ListExecutionsResponse.executions:type_name -> cleanroom.v1.Execution
 	2,   // 41: cleanroom.v1.SandboxPathInfo.type:type_name -> cleanroom.v1.SandboxPathType
-	96,  // 42: cleanroom.v1.SandboxPathInfo.mtime:type_name -> google.protobuf.Timestamp
+	100, // 42: cleanroom.v1.SandboxPathInfo.mtime:type_name -> google.protobuf.Timestamp
 	41,  // 43: cleanroom.v1.StatSandboxPathResponse.info:type_name -> cleanroom.v1.SandboxPathInfo
 	41,  // 44: cleanroom.v1.WalkSandboxTreeResponse.info:type_name -> cleanroom.v1.SandboxPathInfo
-	96,  // 45: cleanroom.v1.WriteSandboxFileInit.mtime:type_name -> google.protobuf.Timestamp
+	100, // 45: cleanroom.v1.WriteSandboxFileInit.mtime:type_name -> google.protobuf.Timestamp
 	48,  // 46: cleanroom.v1.WriteSandboxFileRequest.init:type_name -> cleanroom.v1.WriteSandboxFileInit
 	55,  // 47: cleanroom.v1.ExtractSandboxArchiveRequest.init:type_name -> cleanroom.v1.ExtractSandboxArchiveInit
-	0,   // 48: cleanroom.v1.SandboxEvent.status:type_name -> cleanroom.v1.SandboxStatus
-	96,  // 49: cleanroom.v1.SandboxEvent.occurred_at:type_name -> google.protobuf.Timestamp
-	10,  // 50: cleanroom.v1.CreateSnapshotResponse.snapshot:type_name -> cleanroom.v1.Snapshot
-	10,  // 51: cleanroom.v1.GetSnapshotResponse.snapshot:type_name -> cleanroom.v1.Snapshot
-	10,  // 52: cleanroom.v1.ListSnapshotsResponse.snapshots:type_name -> cleanroom.v1.Snapshot
-	72,  // 53: cleanroom.v1.LookupCachePeerResponse.candidate:type_name -> cleanroom.v1.CachePeerCandidate
-	96,  // 54: cleanroom.v1.CachePeerCandidate.expires_at:type_name -> google.protobuf.Timestamp
-	3,   // 55: cleanroom.v1.Execution.status:type_name -> cleanroom.v1.ExecutionStatus
-	96,  // 56: cleanroom.v1.Execution.started_at:type_name -> google.protobuf.Timestamp
-	96,  // 57: cleanroom.v1.Execution.finished_at:type_name -> google.protobuf.Timestamp
-	4,   // 58: cleanroom.v1.Execution.kind:type_name -> cleanroom.v1.ExecutionKind
-	74,  // 59: cleanroom.v1.CreateExecutionRequest.options:type_name -> cleanroom.v1.ExecutionOptions
-	4,   // 60: cleanroom.v1.CreateExecutionRequest.kind:type_name -> cleanroom.v1.ExecutionKind
-	24,  // 61: cleanroom.v1.CreateExecutionRequest.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
-	73,  // 62: cleanroom.v1.CreateExecutionResponse.execution:type_name -> cleanroom.v1.Execution
-	96,  // 63: cleanroom.v1.AttachExecutionResponse.expires_at:type_name -> google.protobuf.Timestamp
-	73,  // 64: cleanroom.v1.GetExecutionResponse.execution:type_name -> cleanroom.v1.Execution
-	73,  // 65: cleanroom.v1.InspectExecutionResponse.execution:type_name -> cleanroom.v1.Execution
-	97,  // 66: cleanroom.v1.InspectExecutionResponse.observability:type_name -> google.protobuf.Struct
-	3,   // 67: cleanroom.v1.CancelExecutionResponse.status:type_name -> cleanroom.v1.ExecutionStatus
-	3,   // 68: cleanroom.v1.ExecutionExit.status:type_name -> cleanroom.v1.ExecutionStatus
-	3,   // 69: cleanroom.v1.ExecutionStreamEvent.status:type_name -> cleanroom.v1.ExecutionStatus
-	90,  // 70: cleanroom.v1.ExecutionStreamEvent.exit:type_name -> cleanroom.v1.ExecutionExit
-	96,  // 71: cleanroom.v1.ExecutionStreamEvent.occurred_at:type_name -> google.protobuf.Timestamp
-	28,  // 72: cleanroom.v1.SandboxService.CreateSandbox:input_type -> cleanroom.v1.CreateSandboxRequest
-	28,  // 73: cleanroom.v1.SandboxService.CreateSandboxStream:input_type -> cleanroom.v1.CreateSandboxRequest
-	31,  // 74: cleanroom.v1.SandboxService.GetSandbox:input_type -> cleanroom.v1.GetSandboxRequest
-	33,  // 75: cleanroom.v1.SandboxService.ListSandboxes:input_type -> cleanroom.v1.ListSandboxesRequest
-	37,  // 76: cleanroom.v1.SandboxService.DownloadSandboxFile:input_type -> cleanroom.v1.DownloadSandboxFileRequest
-	39,  // 77: cleanroom.v1.SandboxService.UploadSandboxFile:input_type -> cleanroom.v1.UploadSandboxFileRequest
-	42,  // 78: cleanroom.v1.SandboxService.StatSandboxPath:input_type -> cleanroom.v1.StatSandboxPathRequest
-	44,  // 79: cleanroom.v1.SandboxService.WalkSandboxTree:input_type -> cleanroom.v1.WalkSandboxTreeRequest
-	46,  // 80: cleanroom.v1.SandboxService.ReadSandboxFile:input_type -> cleanroom.v1.ReadSandboxFileRequest
-	49,  // 81: cleanroom.v1.SandboxService.WriteSandboxFile:input_type -> cleanroom.v1.WriteSandboxFileRequest
-	51,  // 82: cleanroom.v1.SandboxService.RemoveSandboxPath:input_type -> cleanroom.v1.RemoveSandboxPathRequest
-	53,  // 83: cleanroom.v1.SandboxService.ArchiveSandboxPaths:input_type -> cleanroom.v1.ArchiveSandboxPathsRequest
-	56,  // 84: cleanroom.v1.SandboxService.ExtractSandboxArchive:input_type -> cleanroom.v1.ExtractSandboxArchiveRequest
-	58,  // 85: cleanroom.v1.SandboxService.TerminateSandbox:input_type -> cleanroom.v1.TerminateSandboxRequest
-	60,  // 86: cleanroom.v1.SandboxService.StreamSandboxEvents:input_type -> cleanroom.v1.StreamSandboxEventsRequest
-	7,   // 87: cleanroom.v1.SandboxService.DialSandboxPort:input_type -> cleanroom.v1.SandboxPortFrame
-	62,  // 88: cleanroom.v1.SnapshotService.CreateSnapshot:input_type -> cleanroom.v1.CreateSnapshotRequest
-	64,  // 89: cleanroom.v1.SnapshotService.GetSnapshot:input_type -> cleanroom.v1.GetSnapshotRequest
-	66,  // 90: cleanroom.v1.SnapshotService.ListSnapshots:input_type -> cleanroom.v1.ListSnapshotsRequest
-	68,  // 91: cleanroom.v1.SnapshotService.DeleteSnapshot:input_type -> cleanroom.v1.DeleteSnapshotRequest
-	70,  // 92: cleanroom.v1.CachePeerService.LookupCachePeer:input_type -> cleanroom.v1.LookupCachePeerRequest
-	35,  // 93: cleanroom.v1.ExecutionService.ListExecutions:input_type -> cleanroom.v1.ListExecutionsRequest
-	75,  // 94: cleanroom.v1.ExecutionService.CreateExecution:input_type -> cleanroom.v1.CreateExecutionRequest
-	77,  // 95: cleanroom.v1.ExecutionService.AttachExecution:input_type -> cleanroom.v1.AttachExecutionRequest
-	79,  // 96: cleanroom.v1.ExecutionService.GetExecution:input_type -> cleanroom.v1.GetExecutionRequest
-	81,  // 97: cleanroom.v1.ExecutionService.InspectExecution:input_type -> cleanroom.v1.InspectExecutionRequest
-	83,  // 98: cleanroom.v1.ExecutionService.CancelExecution:input_type -> cleanroom.v1.CancelExecutionRequest
-	85,  // 99: cleanroom.v1.ExecutionService.WriteExecutionStdin:input_type -> cleanroom.v1.WriteExecutionStdinRequest
-	87,  // 100: cleanroom.v1.ExecutionService.CloseExecutionStdin:input_type -> cleanroom.v1.CloseExecutionStdinRequest
-	89,  // 101: cleanroom.v1.ExecutionService.StreamExecution:input_type -> cleanroom.v1.StreamExecutionRequest
-	29,  // 102: cleanroom.v1.SandboxService.CreateSandbox:output_type -> cleanroom.v1.CreateSandboxResponse
-	30,  // 103: cleanroom.v1.SandboxService.CreateSandboxStream:output_type -> cleanroom.v1.CreateSandboxEvent
-	32,  // 104: cleanroom.v1.SandboxService.GetSandbox:output_type -> cleanroom.v1.GetSandboxResponse
-	34,  // 105: cleanroom.v1.SandboxService.ListSandboxes:output_type -> cleanroom.v1.ListSandboxesResponse
-	38,  // 106: cleanroom.v1.SandboxService.DownloadSandboxFile:output_type -> cleanroom.v1.DownloadSandboxFileResponse
-	40,  // 107: cleanroom.v1.SandboxService.UploadSandboxFile:output_type -> cleanroom.v1.UploadSandboxFileResponse
-	43,  // 108: cleanroom.v1.SandboxService.StatSandboxPath:output_type -> cleanroom.v1.StatSandboxPathResponse
-	45,  // 109: cleanroom.v1.SandboxService.WalkSandboxTree:output_type -> cleanroom.v1.WalkSandboxTreeResponse
-	47,  // 110: cleanroom.v1.SandboxService.ReadSandboxFile:output_type -> cleanroom.v1.ReadSandboxFileResponse
-	50,  // 111: cleanroom.v1.SandboxService.WriteSandboxFile:output_type -> cleanroom.v1.WriteSandboxFileResponse
-	52,  // 112: cleanroom.v1.SandboxService.RemoveSandboxPath:output_type -> cleanroom.v1.RemoveSandboxPathResponse
-	54,  // 113: cleanroom.v1.SandboxService.ArchiveSandboxPaths:output_type -> cleanroom.v1.ArchiveSandboxPathsResponse
-	57,  // 114: cleanroom.v1.SandboxService.ExtractSandboxArchive:output_type -> cleanroom.v1.ExtractSandboxArchiveResponse
-	59,  // 115: cleanroom.v1.SandboxService.TerminateSandbox:output_type -> cleanroom.v1.TerminateSandboxResponse
-	61,  // 116: cleanroom.v1.SandboxService.StreamSandboxEvents:output_type -> cleanroom.v1.SandboxEvent
-	7,   // 117: cleanroom.v1.SandboxService.DialSandboxPort:output_type -> cleanroom.v1.SandboxPortFrame
-	63,  // 118: cleanroom.v1.SnapshotService.CreateSnapshot:output_type -> cleanroom.v1.CreateSnapshotResponse
-	65,  // 119: cleanroom.v1.SnapshotService.GetSnapshot:output_type -> cleanroom.v1.GetSnapshotResponse
-	67,  // 120: cleanroom.v1.SnapshotService.ListSnapshots:output_type -> cleanroom.v1.ListSnapshotsResponse
-	69,  // 121: cleanroom.v1.SnapshotService.DeleteSnapshot:output_type -> cleanroom.v1.DeleteSnapshotResponse
-	71,  // 122: cleanroom.v1.CachePeerService.LookupCachePeer:output_type -> cleanroom.v1.LookupCachePeerResponse
-	36,  // 123: cleanroom.v1.ExecutionService.ListExecutions:output_type -> cleanroom.v1.ListExecutionsResponse
-	76,  // 124: cleanroom.v1.ExecutionService.CreateExecution:output_type -> cleanroom.v1.CreateExecutionResponse
-	78,  // 125: cleanroom.v1.ExecutionService.AttachExecution:output_type -> cleanroom.v1.AttachExecutionResponse
-	80,  // 126: cleanroom.v1.ExecutionService.GetExecution:output_type -> cleanroom.v1.GetExecutionResponse
-	82,  // 127: cleanroom.v1.ExecutionService.InspectExecution:output_type -> cleanroom.v1.InspectExecutionResponse
-	84,  // 128: cleanroom.v1.ExecutionService.CancelExecution:output_type -> cleanroom.v1.CancelExecutionResponse
-	86,  // 129: cleanroom.v1.ExecutionService.WriteExecutionStdin:output_type -> cleanroom.v1.WriteExecutionStdinResponse
-	88,  // 130: cleanroom.v1.ExecutionService.CloseExecutionStdin:output_type -> cleanroom.v1.CloseExecutionStdinResponse
-	91,  // 131: cleanroom.v1.ExecutionService.StreamExecution:output_type -> cleanroom.v1.ExecutionStreamEvent
-	102, // [102:132] is the sub-list for method output_type
-	72,  // [72:102] is the sub-list for method input_type
-	72,  // [72:72] is the sub-list for extension type_name
-	72,  // [72:72] is the sub-list for extension extendee
-	0,   // [0:72] is the sub-list for field type_name
+	5,   // 48: cleanroom.v1.SuspendSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
+	5,   // 49: cleanroom.v1.ResumeSandboxResponse.sandbox:type_name -> cleanroom.v1.Sandbox
+	0,   // 50: cleanroom.v1.SandboxEvent.status:type_name -> cleanroom.v1.SandboxStatus
+	100, // 51: cleanroom.v1.SandboxEvent.occurred_at:type_name -> google.protobuf.Timestamp
+	10,  // 52: cleanroom.v1.CreateSnapshotResponse.snapshot:type_name -> cleanroom.v1.Snapshot
+	10,  // 53: cleanroom.v1.GetSnapshotResponse.snapshot:type_name -> cleanroom.v1.Snapshot
+	10,  // 54: cleanroom.v1.ListSnapshotsResponse.snapshots:type_name -> cleanroom.v1.Snapshot
+	76,  // 55: cleanroom.v1.LookupCachePeerResponse.candidate:type_name -> cleanroom.v1.CachePeerCandidate
+	100, // 56: cleanroom.v1.CachePeerCandidate.expires_at:type_name -> google.protobuf.Timestamp
+	3,   // 57: cleanroom.v1.Execution.status:type_name -> cleanroom.v1.ExecutionStatus
+	100, // 58: cleanroom.v1.Execution.started_at:type_name -> google.protobuf.Timestamp
+	100, // 59: cleanroom.v1.Execution.finished_at:type_name -> google.protobuf.Timestamp
+	4,   // 60: cleanroom.v1.Execution.kind:type_name -> cleanroom.v1.ExecutionKind
+	78,  // 61: cleanroom.v1.CreateExecutionRequest.options:type_name -> cleanroom.v1.ExecutionOptions
+	4,   // 62: cleanroom.v1.CreateExecutionRequest.kind:type_name -> cleanroom.v1.ExecutionKind
+	24,  // 63: cleanroom.v1.CreateExecutionRequest.repository_checkout:type_name -> cleanroom.v1.RepositoryCheckout
+	77,  // 64: cleanroom.v1.CreateExecutionResponse.execution:type_name -> cleanroom.v1.Execution
+	100, // 65: cleanroom.v1.AttachExecutionResponse.expires_at:type_name -> google.protobuf.Timestamp
+	77,  // 66: cleanroom.v1.GetExecutionResponse.execution:type_name -> cleanroom.v1.Execution
+	77,  // 67: cleanroom.v1.InspectExecutionResponse.execution:type_name -> cleanroom.v1.Execution
+	101, // 68: cleanroom.v1.InspectExecutionResponse.observability:type_name -> google.protobuf.Struct
+	3,   // 69: cleanroom.v1.CancelExecutionResponse.status:type_name -> cleanroom.v1.ExecutionStatus
+	3,   // 70: cleanroom.v1.ExecutionExit.status:type_name -> cleanroom.v1.ExecutionStatus
+	3,   // 71: cleanroom.v1.ExecutionStreamEvent.status:type_name -> cleanroom.v1.ExecutionStatus
+	94,  // 72: cleanroom.v1.ExecutionStreamEvent.exit:type_name -> cleanroom.v1.ExecutionExit
+	100, // 73: cleanroom.v1.ExecutionStreamEvent.occurred_at:type_name -> google.protobuf.Timestamp
+	28,  // 74: cleanroom.v1.SandboxService.CreateSandbox:input_type -> cleanroom.v1.CreateSandboxRequest
+	28,  // 75: cleanroom.v1.SandboxService.CreateSandboxStream:input_type -> cleanroom.v1.CreateSandboxRequest
+	31,  // 76: cleanroom.v1.SandboxService.GetSandbox:input_type -> cleanroom.v1.GetSandboxRequest
+	33,  // 77: cleanroom.v1.SandboxService.ListSandboxes:input_type -> cleanroom.v1.ListSandboxesRequest
+	37,  // 78: cleanroom.v1.SandboxService.DownloadSandboxFile:input_type -> cleanroom.v1.DownloadSandboxFileRequest
+	39,  // 79: cleanroom.v1.SandboxService.UploadSandboxFile:input_type -> cleanroom.v1.UploadSandboxFileRequest
+	42,  // 80: cleanroom.v1.SandboxService.StatSandboxPath:input_type -> cleanroom.v1.StatSandboxPathRequest
+	44,  // 81: cleanroom.v1.SandboxService.WalkSandboxTree:input_type -> cleanroom.v1.WalkSandboxTreeRequest
+	46,  // 82: cleanroom.v1.SandboxService.ReadSandboxFile:input_type -> cleanroom.v1.ReadSandboxFileRequest
+	49,  // 83: cleanroom.v1.SandboxService.WriteSandboxFile:input_type -> cleanroom.v1.WriteSandboxFileRequest
+	51,  // 84: cleanroom.v1.SandboxService.RemoveSandboxPath:input_type -> cleanroom.v1.RemoveSandboxPathRequest
+	53,  // 85: cleanroom.v1.SandboxService.ArchiveSandboxPaths:input_type -> cleanroom.v1.ArchiveSandboxPathsRequest
+	56,  // 86: cleanroom.v1.SandboxService.ExtractSandboxArchive:input_type -> cleanroom.v1.ExtractSandboxArchiveRequest
+	60,  // 87: cleanroom.v1.SandboxService.SuspendSandbox:input_type -> cleanroom.v1.SuspendSandboxRequest
+	62,  // 88: cleanroom.v1.SandboxService.ResumeSandbox:input_type -> cleanroom.v1.ResumeSandboxRequest
+	58,  // 89: cleanroom.v1.SandboxService.TerminateSandbox:input_type -> cleanroom.v1.TerminateSandboxRequest
+	64,  // 90: cleanroom.v1.SandboxService.StreamSandboxEvents:input_type -> cleanroom.v1.StreamSandboxEventsRequest
+	7,   // 91: cleanroom.v1.SandboxService.DialSandboxPort:input_type -> cleanroom.v1.SandboxPortFrame
+	66,  // 92: cleanroom.v1.SnapshotService.CreateSnapshot:input_type -> cleanroom.v1.CreateSnapshotRequest
+	68,  // 93: cleanroom.v1.SnapshotService.GetSnapshot:input_type -> cleanroom.v1.GetSnapshotRequest
+	70,  // 94: cleanroom.v1.SnapshotService.ListSnapshots:input_type -> cleanroom.v1.ListSnapshotsRequest
+	72,  // 95: cleanroom.v1.SnapshotService.DeleteSnapshot:input_type -> cleanroom.v1.DeleteSnapshotRequest
+	74,  // 96: cleanroom.v1.CachePeerService.LookupCachePeer:input_type -> cleanroom.v1.LookupCachePeerRequest
+	35,  // 97: cleanroom.v1.ExecutionService.ListExecutions:input_type -> cleanroom.v1.ListExecutionsRequest
+	79,  // 98: cleanroom.v1.ExecutionService.CreateExecution:input_type -> cleanroom.v1.CreateExecutionRequest
+	81,  // 99: cleanroom.v1.ExecutionService.AttachExecution:input_type -> cleanroom.v1.AttachExecutionRequest
+	83,  // 100: cleanroom.v1.ExecutionService.GetExecution:input_type -> cleanroom.v1.GetExecutionRequest
+	85,  // 101: cleanroom.v1.ExecutionService.InspectExecution:input_type -> cleanroom.v1.InspectExecutionRequest
+	87,  // 102: cleanroom.v1.ExecutionService.CancelExecution:input_type -> cleanroom.v1.CancelExecutionRequest
+	89,  // 103: cleanroom.v1.ExecutionService.WriteExecutionStdin:input_type -> cleanroom.v1.WriteExecutionStdinRequest
+	91,  // 104: cleanroom.v1.ExecutionService.CloseExecutionStdin:input_type -> cleanroom.v1.CloseExecutionStdinRequest
+	93,  // 105: cleanroom.v1.ExecutionService.StreamExecution:input_type -> cleanroom.v1.StreamExecutionRequest
+	29,  // 106: cleanroom.v1.SandboxService.CreateSandbox:output_type -> cleanroom.v1.CreateSandboxResponse
+	30,  // 107: cleanroom.v1.SandboxService.CreateSandboxStream:output_type -> cleanroom.v1.CreateSandboxEvent
+	32,  // 108: cleanroom.v1.SandboxService.GetSandbox:output_type -> cleanroom.v1.GetSandboxResponse
+	34,  // 109: cleanroom.v1.SandboxService.ListSandboxes:output_type -> cleanroom.v1.ListSandboxesResponse
+	38,  // 110: cleanroom.v1.SandboxService.DownloadSandboxFile:output_type -> cleanroom.v1.DownloadSandboxFileResponse
+	40,  // 111: cleanroom.v1.SandboxService.UploadSandboxFile:output_type -> cleanroom.v1.UploadSandboxFileResponse
+	43,  // 112: cleanroom.v1.SandboxService.StatSandboxPath:output_type -> cleanroom.v1.StatSandboxPathResponse
+	45,  // 113: cleanroom.v1.SandboxService.WalkSandboxTree:output_type -> cleanroom.v1.WalkSandboxTreeResponse
+	47,  // 114: cleanroom.v1.SandboxService.ReadSandboxFile:output_type -> cleanroom.v1.ReadSandboxFileResponse
+	50,  // 115: cleanroom.v1.SandboxService.WriteSandboxFile:output_type -> cleanroom.v1.WriteSandboxFileResponse
+	52,  // 116: cleanroom.v1.SandboxService.RemoveSandboxPath:output_type -> cleanroom.v1.RemoveSandboxPathResponse
+	54,  // 117: cleanroom.v1.SandboxService.ArchiveSandboxPaths:output_type -> cleanroom.v1.ArchiveSandboxPathsResponse
+	57,  // 118: cleanroom.v1.SandboxService.ExtractSandboxArchive:output_type -> cleanroom.v1.ExtractSandboxArchiveResponse
+	61,  // 119: cleanroom.v1.SandboxService.SuspendSandbox:output_type -> cleanroom.v1.SuspendSandboxResponse
+	63,  // 120: cleanroom.v1.SandboxService.ResumeSandbox:output_type -> cleanroom.v1.ResumeSandboxResponse
+	59,  // 121: cleanroom.v1.SandboxService.TerminateSandbox:output_type -> cleanroom.v1.TerminateSandboxResponse
+	65,  // 122: cleanroom.v1.SandboxService.StreamSandboxEvents:output_type -> cleanroom.v1.SandboxEvent
+	7,   // 123: cleanroom.v1.SandboxService.DialSandboxPort:output_type -> cleanroom.v1.SandboxPortFrame
+	67,  // 124: cleanroom.v1.SnapshotService.CreateSnapshot:output_type -> cleanroom.v1.CreateSnapshotResponse
+	69,  // 125: cleanroom.v1.SnapshotService.GetSnapshot:output_type -> cleanroom.v1.GetSnapshotResponse
+	71,  // 126: cleanroom.v1.SnapshotService.ListSnapshots:output_type -> cleanroom.v1.ListSnapshotsResponse
+	73,  // 127: cleanroom.v1.SnapshotService.DeleteSnapshot:output_type -> cleanroom.v1.DeleteSnapshotResponse
+	75,  // 128: cleanroom.v1.CachePeerService.LookupCachePeer:output_type -> cleanroom.v1.LookupCachePeerResponse
+	36,  // 129: cleanroom.v1.ExecutionService.ListExecutions:output_type -> cleanroom.v1.ListExecutionsResponse
+	80,  // 130: cleanroom.v1.ExecutionService.CreateExecution:output_type -> cleanroom.v1.CreateExecutionResponse
+	82,  // 131: cleanroom.v1.ExecutionService.AttachExecution:output_type -> cleanroom.v1.AttachExecutionResponse
+	84,  // 132: cleanroom.v1.ExecutionService.GetExecution:output_type -> cleanroom.v1.GetExecutionResponse
+	86,  // 133: cleanroom.v1.ExecutionService.InspectExecution:output_type -> cleanroom.v1.InspectExecutionResponse
+	88,  // 134: cleanroom.v1.ExecutionService.CancelExecution:output_type -> cleanroom.v1.CancelExecutionResponse
+	90,  // 135: cleanroom.v1.ExecutionService.WriteExecutionStdin:output_type -> cleanroom.v1.WriteExecutionStdinResponse
+	92,  // 136: cleanroom.v1.ExecutionService.CloseExecutionStdin:output_type -> cleanroom.v1.CloseExecutionStdinResponse
+	95,  // 137: cleanroom.v1.ExecutionService.StreamExecution:output_type -> cleanroom.v1.ExecutionStreamEvent
+	106, // [106:138] is the sub-list for method output_type
+	74,  // [74:106] is the sub-list for method input_type
+	74,  // [74:74] is the sub-list for extension type_name
+	74,  // [74:74] is the sub-list for extension extendee
+	0,   // [0:74] is the sub-list for field type_name
 }
 
 func init() { file_proto_cleanroom_v1_control_proto_init() }
@@ -7047,7 +7257,7 @@ func file_proto_cleanroom_v1_control_proto_init() {
 		(*ExtractSandboxArchiveRequest_Init)(nil),
 		(*ExtractSandboxArchiveRequest_Data)(nil),
 	}
-	file_proto_cleanroom_v1_control_proto_msgTypes[86].OneofWrappers = []any{
+	file_proto_cleanroom_v1_control_proto_msgTypes[90].OneofWrappers = []any{
 		(*ExecutionStreamEvent_Stdout)(nil),
 		(*ExecutionStreamEvent_Stderr)(nil),
 		(*ExecutionStreamEvent_Exit)(nil),
@@ -7060,7 +7270,7 @@ func file_proto_cleanroom_v1_control_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proto_cleanroom_v1_control_proto_rawDesc), len(file_proto_cleanroom_v1_control_proto_rawDesc)),
 			NumEnums:      5,
-			NumMessages:   91,
+			NumMessages:   95,
 			NumExtensions: 0,
 			NumServices:   4,
 		},

--- a/proto/cleanroom/v1/control.proto
+++ b/proto/cleanroom/v1/control.proto
@@ -21,6 +21,8 @@ service SandboxService {
   rpc RemoveSandboxPath(RemoveSandboxPathRequest) returns (RemoveSandboxPathResponse);
   rpc ArchiveSandboxPaths(ArchiveSandboxPathsRequest) returns (stream ArchiveSandboxPathsResponse);
   rpc ExtractSandboxArchive(stream ExtractSandboxArchiveRequest) returns (ExtractSandboxArchiveResponse);
+  rpc SuspendSandbox(SuspendSandboxRequest) returns (SuspendSandboxResponse);
+  rpc ResumeSandbox(ResumeSandboxRequest) returns (ResumeSandboxResponse);
   rpc TerminateSandbox(TerminateSandboxRequest) returns (TerminateSandboxResponse);
   rpc StreamSandboxEvents(StreamSandboxEventsRequest) returns (stream SandboxEvent);
   rpc DialSandboxPort(stream SandboxPortFrame) returns (stream SandboxPortFrame);
@@ -111,6 +113,9 @@ enum SandboxStatus {
   SANDBOX_STATUS_STOPPING = 3;
   SANDBOX_STATUS_STOPPED = 4;
   SANDBOX_STATUS_FAILED = 5;
+  SANDBOX_STATUS_SUSPENDING = 6;
+  SANDBOX_STATUS_SUSPENDED = 7;
+  SANDBOX_STATUS_WAKING = 8;
 }
 
 message PolicyAllowRule {
@@ -452,6 +457,22 @@ message TerminateSandboxResponse {
   string sandbox_id = 1;
   bool terminated = 2;
   string message = 3;
+}
+
+message SuspendSandboxRequest {
+  string sandbox_id = 1;
+}
+
+message SuspendSandboxResponse {
+  Sandbox sandbox = 1;
+}
+
+message ResumeSandboxRequest {
+  string sandbox_id = 1;
+}
+
+message ResumeSandboxResponse {
+  Sandbox sandbox = 1;
 }
 
 message StreamSandboxEventsRequest {


### PR DESCRIPTION
Cleanroom can keep persistent sandboxes alive across executions, but the control plane had no way to represent an idle sandbox that still exists while its VM is paused. That forced future suspend work to either overload stopped/snapshot semantics or leave the feature hidden inside backend-specific code.

This adds the first manual lifecycle slice for suspend and wake:
- exposes SUSPENDING, SUSPENDED, and WAKING sandbox states
- adds suspend/resume RPCs plus internal and public client methods
- adds backend-neutral sandbox.suspend capability inference
- wires darwin-vz suspend/resume through the existing PauseVM and ResumeVM helper operations
- adds cleanroom sandbox suspend and cleanroom sandbox resume commands
- documents the broader transparent suspend/wake plan in docs/plans

Unsupported backends fail closed. Failed suspend attempts move the sandbox back to READY, while failed wake attempts mark it FAILED so operators do not get stuck in an in-between state.