### PR TITLE
feat: Add auth policy check engine

### DIFF
--- a/docs/plans/multi-principal-control-server.md
+++ b/docs/plans/multi-principal-control-server.md
@@ -1,0 +1,744 @@
+# Multi-Principal Control Server Authorization Plan
+
+**Spec reference:** `docs/spec.md` sections 5.4, 6.1, and 6.2; `docs/api.md`; `docs/tls.md`
+**Status:** Slice 1 in progress
+**Last reviewed:** 2026-05-25
+
+## Summary
+
+Allow many bots to share one Cleanroom server without being able to see, reuse,
+or mutate each other's sandboxes, executions, snapshots, files, ports, or stage
+caches.
+
+The first durable shape should separate three concerns:
+
+- OIDC JWT validation establishes who the caller is.
+- Cleanroom server authorization decides what that caller can do.
+- Repository policy still decides what a sandbox workload can reach once it is
+  running.
+
+Use OIDC JWTs as the first identity provider because they fit bot and CI
+deployments without requiring a SPIFFE/SPIRE control plane. Keep the
+authorization model Cleanroom-native: typed actions, typed resources,
+server-stamped ownership, and optional CEL conditions over normalized request
+data. Do not try to encode Cleanroom safety with broad OAuth scopes alone.
+
+## Current Progress
+
+Slice 1 now has the backend-neutral auth engine and local operator check path:
+
+- runtime config accepts OIDC issuer trust roots and an auth policy file
+- OIDC JWT validation covers issuer, audience, signature, expiry, `kid`,
+  allowed algorithm, clock skew, and maximum token lifetime
+- auth policies bind validated token claims to derived Cleanroom principals
+- typed grants compile CEL conditions against a bounded request schema
+- `cleanroom auth check` evaluates a token, local policy, action, resource, and
+  JSON request fixture without starting the control server
+
+Control server behavior is intentionally unchanged in Slice 1. Enforcement,
+ownership stamping, embedded `content-cache` gateway envelopes, and stage-cache
+partitioning remain Slice 2 work.
+
+Focused validation run on 2026-05-25:
+
+```text
+mise exec -- go test ./internal/authz ./internal/runtimeconfig ./internal/cli
+```
+
+Result: passed.
+
+Repository validation run on 2026-05-25:
+
+```text
+mise run check
+```
+
+Result: passed.
+
+## Problem
+
+Cleanroom's control server is currently designed around a trusted creator. That
+is fine for local use and a single trusted automation, but it is not enough for a
+shared server used by many bots.
+
+Current state:
+
+- HTTPS transport is server-auth TLS only. Client certificate authentication is
+  explicitly unsupported today.
+- `cleanroom serve` installs observability interceptors but has no control-plane
+  caller identity for normal sandbox, execution, snapshot, or file APIs.
+- Most ConnectRPC handlers call directly into `controlservice`.
+- `Sandbox`, `Execution`, `Snapshot`, stage-cache, and snapshot metadata do not
+  carry an owner or authorization scope.
+- The client compiles policy and sends it to `CreateSandbox`, so a shared server
+  must validate requested policy and repository inputs before it uses host-side
+  credentials, mirrors, or backends.
+
+Without a server-side authorization boundary, any caller that can reach the
+control API can try global resource IDs directly, list retained state, attach to
+executions, read sandbox files, restore snapshots, or warm-hit caches created by
+another caller. Random resource IDs are not an access-control mechanism.
+
+## Goals
+
+- Authenticate remote bot callers with OIDC JWT bearer tokens.
+- Validate trusted issuers, audiences, expiry, and signing keys server-side.
+- Derive a stable Cleanroom principal from trusted token claims.
+- Stamp every created resource with immutable server-derived ownership.
+- Enforce exact-principal ownership first: by default, a principal can only
+  access resources it created.
+- Keep an authorization scope field for later controlled sharing, but do not
+  make scope sharing the first default.
+- Support typed grants for Cleanroom actions and resource kinds.
+- Support CEL conditions inside typed grants for request constraints.
+- Constrain `CreateSandbox` before repository mirrors, host credentials, stage
+  caches, snapshots, or backend work can be used.
+- Filter list APIs at the resource store or state snapshot boundary.
+- Partition stage-cache lookup and publication by owner so warm caches do not
+  become cross-principal side channels.
+- Fail closed when identity, grant matching, CEL evaluation, owner lookup, or
+  resource metadata is ambiguous.
+- Keep auth configuration in runtime/server config, not in `cleanroom.yaml`.
+
+## Non-goals
+
+- Do not introduce SPIFFE or mTLS in the first implementation.
+- Do not make Cleanroom an OAuth authorization server.
+- Do not mint delegated child-bot tokens in the first implementation.
+- Do not add a user or service-account management database.
+- Do not support broad relationship-based sharing in the first implementation.
+- Do not move sandbox egress policy into the auth policy.
+- Do not expose host secrets or upstream credentials to guests.
+- Do not use OPA, Cedar, OpenFGA, or Zanzibar as the first authorization engine.
+- Do not add policy mutation or prompt-time approval flows.
+
+## Target Model
+
+### Identity
+
+Remote callers send an OIDC JWT access token:
+
+```text
+Authorization: Bearer <jwt>
+```
+
+The server validates:
+
+- issuer matches a configured trusted issuer
+- audience contains a configured Cleanroom audience
+- token is not expired and not before its validity window
+- signing key matches issuer JWKS and allowed algorithms
+- token lifetime and clock skew fit configured bounds
+- a configured binding maps the validated claims to a Cleanroom principal
+
+The derived principal is an internal value, not raw user input:
+
+```go
+type Principal struct {
+    ID      string // stable Cleanroom principal ID
+    Subject string // original OIDC subject for audit
+    Issuer  string // configured issuer name or URL
+    Scope   string // grouping label for future sharing and cache partitioning
+}
+```
+
+The principal ID should be stable across server restarts and should include the
+issuer identity. A safe default is `oidc:<issuer-name>:<sub>`, after canonical
+normalization. Do not use the raw `sub` alone because different issuers can reuse
+subject strings.
+
+### Runtime Config
+
+The main runtime config should define trust roots and point to authorization
+bindings. It should not require listing every principal for dynamic bot fleets.
+
+```yaml
+auth:
+  required: true
+  oidc:
+    issuers:
+      - name: github-actions
+        issuer: https://token.actions.githubusercontent.com
+        audiences:
+          - cleanroom
+        jwks_url: https://token.actions.githubusercontent.com/.well-known/jwks
+  policy_file: ~/.config/cleanroom/auth-policy.yaml
+```
+
+The policy file maps trusted claims to derived principals and grants:
+
+```yaml
+bindings:
+  - name: cleanroom-repo-bots
+    when: >
+      token.issuer == "github-actions" &&
+      claims.repository == "buildkite/cleanroom"
+    principal:
+      id: 'oidc:${token.issuer}:${claims.sub}'
+      scope: 'repo:${claims.repository}'
+    grants:
+      - actions:
+          - sandbox.create
+          - sandbox.get
+          - sandbox.list
+          - sandbox.terminate
+          - execution.create
+          - execution.get
+          - execution.list
+          - execution.stream
+        resources:
+          - sandbox
+          - execution
+        condition: >
+          request.repository.remote_url == "https://github.com/buildkite/cleanroom.git" &&
+          request.backend in ["darwin-vz"] &&
+          request.policy.resources.vcpus <= 4 &&
+          request.policy.resources.memory_bytes <= 8589934592 &&
+          request.policy.docker.required == false &&
+          request.policy.network_default == "deny"
+```
+
+The exact schema can change during implementation, but the ownership boundary
+must not: the server derives identity and grants from validated claims, not from
+client-provided owner fields.
+
+### Actions
+
+Use explicit action names. This keeps CEL conditions from becoming the only
+source of truth for what an expression is allowed to affect.
+
+Initial action set:
+
+```text
+sandbox.create
+sandbox.get
+sandbox.list
+sandbox.terminate
+sandbox.file.stat
+sandbox.file.walk
+sandbox.file.read
+sandbox.file.write
+sandbox.file.remove
+sandbox.file.archive
+sandbox.file.extract
+sandbox.port.dial
+
+execution.create
+execution.get
+execution.list
+execution.inspect
+execution.cancel
+execution.stdin.write
+execution.stdin.close
+execution.stream
+execution.attach
+
+snapshot.create
+snapshot.get
+snapshot.list
+snapshot.delete
+snapshot.restore
+```
+
+Cache-peer actions should stay separate from normal bot permissions because
+cache replication already has a peer-token model:
+
+```text
+cache_peer.lookup
+cache_peer.export
+```
+
+### CEL Conditions
+
+Use CEL for conditional grants over a small typed input schema:
+
+```text
+principal.id
+principal.issuer
+principal.subject
+principal.scope
+claims
+action
+resource.kind
+resource.id
+resource.owner.principal_id
+resource.owner.scope
+request
+```
+
+Rules:
+
+- compile and type-check all CEL expressions at server startup or config reload
+- reject unknown fields at config load time
+- deny on CEL runtime error
+- set an evaluation cost limit
+- do not expose secret values, bearer tokens, or host credential material to CEL
+- expose normalized request data, not raw protobufs with unstable internals
+- keep helper functions minimal and deterministic
+
+CEL grants should only narrow typed grants. They must not be able to invent new
+actions, skip ownership checks, or grant access to resources outside the server's
+resource model.
+
+## Resource Ownership
+
+Every resource created through an authenticated request should be stamped by the
+server:
+
+```go
+type ResourceOwner struct {
+    PrincipalID string
+    Scope       string
+}
+```
+
+The first rule is exact ownership:
+
+```text
+caller.principal_id == resource.owner.principal_id
+```
+
+`Scope` is retained for future controlled sharing and cache partitioning, but
+scope should not allow access by itself in the first implementation. This avoids
+accidentally making a repo-level scope such as `repo:buildkite/cleanroom` a
+shared resource pool before the sharing semantics are deliberate.
+
+Ownership rules by resource:
+
+- Sandboxes are owned by the principal that created them.
+- Executions inherit ownership from their sandbox.
+- Interactive sessions inherit ownership from their execution.
+- Snapshots inherit ownership from the source sandbox.
+- Sandboxes restored from snapshots require same-principal snapshot ownership in
+  the first implementation.
+- Stage-cache records are stamped with the creating principal and scope.
+- Cache lookup only considers records owned by the caller unless a later sharing
+  model explicitly allows scope-level reuse.
+
+Client requests must not contain owner fields. If a future API returns owner
+metadata, it should return display-safe fields and never trust echoed owner data
+on writes.
+
+## Authorization Flow
+
+### Unary RPCs
+
+1. Authenticate the request and place `Principal` in context.
+2. Classify the handler into a typed `Action`.
+3. For create operations, normalize the request and evaluate grants and CEL
+   conditions before side effects.
+4. For existing-resource operations, load minimal resource metadata, check exact
+   ownership, then evaluate grants and CEL conditions.
+5. Proceed to `controlservice` only after authorization succeeds.
+
+### Streaming RPCs
+
+Streaming APIs need an explicit first-frame authorization boundary:
+
+- server-streaming APIs authorize before opening the stream
+- `WriteSandboxFile` and `ExtractSandboxArchive` authorize after reading the
+  init frame and before consuming file bytes
+- `DialSandboxPort` authorizes the open frame before dialing the sandbox port
+- execution and sandbox event streams authorize the target resource before
+  sending any retained events
+
+### List APIs
+
+List APIs must not build a global response and filter it at the CLI. Filter at
+the service or store boundary before results are returned:
+
+- `ListSandboxes` returns only owned sandboxes
+- `ListExecutions` returns only executions under owned sandboxes
+- `ListSnapshots` returns only owned snapshots
+
+### Health And Local Sockets
+
+`/healthz` can remain unauthenticated.
+
+Unix-socket behavior should be explicit:
+
+- default: when `auth.required` is false, behavior remains local-trusted
+- when `auth.required` is true, remote HTTP(S) requires OIDC
+- add a separate `auth.require_unix_socket` option only if operators need to
+  lock down local callers too
+
+Do not silently treat remote HTTP as trusted. If auth is required and a caller
+uses plain HTTP from a non-loopback endpoint, reject bearer-token auth rather
+than accepting tokens over cleartext.
+
+## Create-Time Constraints
+
+`CreateSandbox` is the most important authorization point because it can use
+host credentials, repository mirrors, backend resources, snapshots, and stage
+caches.
+
+Minimum constraints to expose to CEL or typed helpers:
+
+- backend name
+- repository remote URL
+- repository commit SHA and branch hints
+- snapshot source ID
+- requested image ref and digest
+- Docker requirement
+- resource floors for vCPU, memory, and disk
+- network default
+- network allow hosts and ports by stage
+- dependency and service block count
+- cache reuse mode
+- local changeset presence
+
+The server must authorize repository input before `RepositoryStore` or gateway
+credentials can satisfy a mirror hit. A local mirror hit for a private repository
+must not bypass the same grant that would be required for a cold fetch.
+
+## Content-Cache Boundary
+
+Cleanroom uses `content-cache` in two different ways, and the authorization
+model should treat them differently.
+
+### Embedded `content-cache`
+
+The embedded cache remains an implementation detail behind the Cleanroom host
+gateway. It should not validate OIDC tokens, evaluate CEL, or understand
+Cleanroom principals directly. Cleanroom should authenticate the control-plane
+caller, stamp the sandbox owner, and register an enriched gateway scope when the
+sandbox is provisioned.
+
+Extend the gateway scope with owner and authorization metadata:
+
+```go
+type SandboxScope struct {
+    SandboxID string
+    Policy    *policy.CompiledPolicy
+    Owner     ResourceOwner
+    GatewayAuth GatewayAuthorization
+}
+
+type GatewayAuthorization struct {
+    GitRepoPrefixes []string
+    OCIRefs         []string
+    FetchURLs       []string
+}
+```
+
+The exact field names can change, but the invariant is that gateway wrappers
+authorize the request before handing it to a `content-cache` protocol handler.
+The protocol handler handles caching, upstream proxying, and singleflight. The
+Cleanroom wrapper handles sandbox identity, principal-derived authorization,
+policy allowlisting, and audit.
+
+This matters for cached hits. A private Git or OCI object already present in the
+cache must not be served just because the requesting sandbox has `github.com:443`
+or a registry host in its network policy. The wrapper must authorize the
+requested upstream resource for the sandbox owner on every request, including
+cache hits, before the embedded handler can serve bytes.
+
+For the first implementation:
+
+- control-plane create grants produce a gateway authorization envelope for the
+  sandbox
+- gateway git wrappers check requested `host/owner/repo` against that envelope
+  before calling `GitHandlerForHost`
+- gateway OCI wrappers check the requested registry/image reference against
+  that envelope before calling `OCIHandlerForPrefix`
+- gateway Go, RubyGems, and fetch routes keep using sandbox network policy, and
+  gain owner-aware constraints only when host credentials or private upstreams
+  are added for those routes
+- content-addressed blob storage can remain physically shared only if every
+  route authorizes before serving cached data
+- if a route cannot authorize a cached object precisely, partition that route's
+  cache metadata by owner or disable that cached path under auth-enabled servers
+
+Stage caches are different from transport caches. Dependency and service stage
+caches restore filesystem state into a sandbox, so they should be owner-scoped
+in Cleanroom's `cachestore` from the first auth-enabled version. Do not rely on
+embedded `content-cache` boundaries to protect stage-cache reuse.
+
+### Standalone `content-cache`
+
+Standalone `content-cache` should not import Cleanroom's sandbox model. If it is
+run as a shared service, it needs its own caller authorization around requested
+upstream resources. That can reuse the same ideas:
+
+- validate OIDC JWTs from callers
+- map claims to route grants
+- preflight cached Git/OCI hits before serving them
+- keep upstream credentials host-side
+
+The shared contract between Cleanroom and standalone `content-cache` should be a
+small request-authorizer or credential-provider hook, not Cleanroom's
+`Principal`, `SandboxScope`, or CEL schema. Cleanroom can pass a request-scoped
+authorizer into embedded handlers when `content-cache` exposes that hook.
+Standalone deployments can implement the same hook from their own config.
+
+## Data Model Changes
+
+Add owner metadata to in-memory state:
+
+- `sandboxState.Owner`
+- `executionState.Owner`
+- `interactiveSessionState.Owner`
+
+Add owner metadata to durable metadata stores:
+
+- `snapshotstore.Record.OwnerPrincipalID`
+- `snapshotstore.Record.OwnerScope`
+- `cachestore.Record.OwnerPrincipalID`
+- `cachestore.Record.OwnerScope`
+
+Stage-cache lookup interfaces should include the caller owner, or cache keys
+should include a stable owner prefix. Prefer explicit owner columns plus indexed
+queries so future scope-sharing can be implemented without rewriting every cache
+key.
+
+Snapshot and cache SQLite stores need migrations that add nullable columns for
+existing local metadata. When auth is enabled, missing owner metadata should deny
+access rather than treating old records as globally readable.
+
+## CLI And SDK Changes
+
+Add a client auth option:
+
+```bash
+cleanroom exec --host https://server.example.com:7777 \
+  --auth-token-env CLEANROOM_AUTH_TOKEN \
+  -- echo hello
+```
+
+Useful environment and config hooks:
+
+- `CLEANROOM_AUTH_TOKEN`
+- `--auth-token-file` for local short-lived token files
+- `--auth-token-env` for explicit env selection in scripts
+
+Avoid printing tokens in debug logs, trace attributes, errors, or startup
+headers.
+
+Add an operator diagnostic command:
+
+```bash
+cleanroom auth check \
+  --token-file /tmp/token.jwt \
+  --action sandbox.create \
+  --request create-sandbox.json
+```
+
+The command should explain which issuer, binding, grant, ownership rule, or CEL
+condition allowed or denied the request. This is important because expression
+policies become hard to operate without a local explain path.
+
+## Observability And Audit
+
+Every auth decision should emit structured audit data:
+
+- decision: allow or deny
+- principal ID
+- issuer
+- subject
+- scope
+- action
+- resource kind and ID when available
+- owner principal ID and scope when available
+- matching binding and grant name when available
+- deny reason code
+
+Do not log token strings or secret claim values. Logs should prefer stable
+reason codes over raw expression errors, with detailed expression diagnostics
+available only through local config validation or `auth check`.
+
+Suggested deny reason codes:
+
+```text
+auth_missing
+auth_invalid_token
+auth_untrusted_issuer
+auth_audience_mismatch
+auth_no_binding
+auth_no_grant
+auth_condition_false
+auth_condition_error
+auth_owner_mismatch
+auth_resource_missing_owner
+auth_insecure_transport
+```
+
+## Delivery Strategy
+
+### Slice 1: Auth Engine And Config Validation
+
+Scope:
+
+- Add runtime auth config types for OIDC issuers and policy file path.
+- Add an internal auth package for OIDC token validation with fake-JWKS tests.
+- Add binding evaluation from token claims to `Principal`.
+- Add typed grant parsing and CEL compilation.
+- Add an internal authorizer that can answer allow/deny for normalized requests.
+- Add `cleanroom auth check` against local config and a JSON request fixture.
+- Keep the control server behavior unchanged until enforcement lands.
+
+Definition of done: invalid issuers, audiences, signatures, expiry, malformed
+bindings, unknown CEL fields, and condition failures are covered by unit tests,
+and operators can run a local auth check without starting a server.
+
+### Slice 2: Server Enforcement, Exact Ownership, And Create Constraints
+
+Scope:
+
+- Add client bearer-token support.
+- Add server authentication middleware for ConnectRPC handlers.
+- Require auth for configured remote HTTP(S) endpoints.
+- Add normalized request views for repository, policy, resources, image, Docker,
+  network, and snapshot source attributes.
+- Evaluate create-time grants and CEL conditions before repository mirror,
+  snapshot restore, stage-cache lookup, or backend work.
+- Register owner and gateway authorization metadata with the sandbox gateway
+  scope.
+- Authorize Git and OCI gateway requests against the sandbox owner's gateway
+  authorization envelope before embedded `content-cache` handlers can serve
+  cached or upstream responses.
+- Stamp owner metadata on new sandboxes, executions, interactive sessions,
+  snapshots, and cache records.
+- Enforce exact-owner access on every sandbox, execution, snapshot, file,
+  archive, extract, port, and stream RPC.
+- Filter list APIs by owner.
+- Partition stage-cache lookup and publication by owner.
+- Deny auth-enabled access to pre-existing snapshot or cache records that have no
+  owner metadata.
+- Add docs for OIDC setup and ownership behavior.
+
+Definition of done: with auth enabled, two valid principals can use the same
+server and cannot list, get, execute in, attach to, copy from, snapshot, restore,
+port-forward, stream, or warm-cache-hit each other's resources. A principal can
+create sandboxes only within its configured repository, backend, image, resource,
+and network constraints, and attempts outside those constraints fail before any
+host-side fetch, restore, cache lookup, or VM provisioning begins.
+
+### Slice 3: Runtime Hardening And Audit
+
+Scope:
+
+- Add fail-closed handling for CEL runtime errors.
+- Add audit events and denial reason codes.
+- Reject bearer tokens over insecure non-loopback HTTP when auth is required.
+- Add transport and token redaction tests.
+
+Definition of done: auth failures are observable without leaking token material,
+transport behavior is fail-closed for bearer tokens, and every deny path returns
+stable reason codes that can be explained by `cleanroom auth check`.
+
+### Slice 4: Controlled Sharing
+
+Scope:
+
+- Decide whether scope-level sharing is needed for bot pools.
+- Add explicit grant actions for sharing, if needed.
+- Support scope-level cache reuse only when both producer and consumer grants
+  allow it.
+- Add snapshot publish or import semantics only after same-principal isolation is
+  proven.
+
+Definition of done: sharing is opt-in, audited, and impossible to confuse with
+default exact-principal ownership.
+
+## Verification
+
+Unit tests:
+
+- OIDC validator rejects bad issuer, audience, signature, expiry, not-before,
+  missing `kid`, and unsupported algorithms.
+- JWKS cache refreshes on key rotation and fails closed on fetch errors.
+- Binding evaluation derives stable principal IDs from fake claims.
+- CEL expressions compile at config load and deny on runtime errors.
+- Grant evaluation requires both action/resource match and condition success.
+- Create-request normalization exposes only stable fields.
+
+Control server tests:
+
+- unauthenticated remote requests fail when auth is required
+- authenticated principal A cannot direct-get principal B's sandbox
+- list APIs hide other principals' resources
+- `CreateExecution` denies cross-owner sandbox IDs
+- file read/write/archive/extract denies cross-owner sandbox IDs
+- `DialSandboxPort` denies cross-owner sandbox IDs
+- execution stream and sandbox event stream deny before sending retained events
+- snapshot create inherits owner and restore requires same owner
+- interactive attach only returns a session token after owner authorization
+- stage-cache lookup does not hit records owned by another principal
+- embedded Git and OCI cache hits are denied when the sandbox owner is not
+  authorized for the requested upstream repo or image
+- auth-enabled access to ownerless old metadata fails closed
+
+CLI and integration tests:
+
+- `CLEANROOM_AUTH_TOKEN` attaches bearer auth to ConnectRPC requests
+- `auth check` reports allow and deny decisions with binding and grant names
+- tokens are absent from logs, errors, traces, and startup output
+- HTTPS with valid token succeeds; insecure non-loopback HTTP with bearer token
+  fails when auth is required
+
+Runtime smoke test:
+
+- start a local HTTPS test server with two signed tokens
+- create one sandbox per token
+- prove cross-principal list/get/execute/file/snapshot attempts are denied
+- prove same-principal operations still work
+
+## Resolved Decisions
+
+- Start with OIDC JWT identity rather than SPIFFE or mTLS.
+- Keep authorization config in runtime/server config, not repository policy.
+- Use Cleanroom-native typed actions and resources.
+- Use CEL only as a conditional expression language inside typed grants.
+- Stamp ownership server-side and reject client-provided ownership.
+- Enforce exact-principal ownership before adding scope-level sharing.
+- Partition stage-cache records by owner in the first auth-enabled version.
+- Treat missing owner metadata as deny when auth is enabled.
+
+## Deferred Work
+
+- SPIFFE or client-certificate identity provider support.
+- OAuth token exchange for delegated child-bot credentials.
+- External OPA or Cedar integration for operators that already run those
+  systems.
+- Relationship-based sharing across teams, bot pools, or repositories.
+- Admin APIs for listing principals, grants, and audit decisions.
+- Persistent sandbox and execution stores beyond current retained server state.
+
+## Open Questions
+
+- Should unix-socket callers remain local-trusted when remote auth is required?
+  Recommended default: yes for the first implementation, with an explicit
+  `auth.require_unix_socket` hardening option later.
+- Which OIDC issuer should the examples use first?
+  Recommended default: GitHub Actions because it is widely available and has
+  useful repository claims, while keeping the implementation generic.
+- Should stage-cache sharing ever be allowed at repo scope?
+  Recommended default: no for the first auth-enabled version; exact-principal
+  cache partitioning is simpler and avoids leaking private dependency outputs.
+
+## Key Learnings From Pressure-Testing
+
+Partial enforcement is more dangerous than no enforcement. An auth-enabled
+server must not protect only list APIs while leaving direct `Get`, stream, file,
+snapshot, or port APIs unchecked. The plan therefore requires ownership checks
+for every resource-bearing RPC before enforcement is considered done.
+
+Repository mirrors and warm stage caches can bypass upstream fetch paths if
+authorization only happens around cold network work. The plan therefore requires
+create-time authorization before mirror use and owner partitioning for cache
+lookup and publication.
+
+Embedded `content-cache` can also bypass upstream checks if Cleanroom authorizes
+only cold upstream requests. The plan therefore keeps Cleanroom's gateway
+wrappers responsible for owner and policy checks on every request before cached
+bytes can be served.
+
+CEL is useful for constraints, but it should not define the resource model.
+Keeping typed actions, typed resources, and exact-owner checks outside CEL makes
+authorization easier to audit and keeps expression bugs from widening access.
+
+Interactive QUIC remains a bearer-session-token transport after
+`AttachExecution`. The first implementation should keep those tokens
+short-lived and issue them only after owner authorization. Stronger binding of
+the QUIC leg to the authenticated principal can be a follow-up if the bearer
+session token becomes an unacceptable risk.

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,8 @@ require (
 	github.com/creack/pty v1.1.24
 	github.com/firecracker-microvm/firecracker-go-sdk v1.0.0
 	github.com/florianl/go-nflog/v2 v2.3.0
+	github.com/golang-jwt/jwt/v5 v5.3.1
+	github.com/google/cel-go v0.28.1
 	github.com/google/go-containerregistry v0.21.6
 	github.com/inetaf/tcpproxy v0.0.0-20260515195445-c159a6051109
 	github.com/mdlayher/netlink v1.11.2
@@ -42,13 +44,15 @@ require (
 )
 
 require (
+	cel.dev/expr v0.25.1 // indirect
+	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20251205161215-1948445e3318 // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect
 	github.com/charmbracelet/x/windows v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
-	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
+	go.yaml.in/yaml/v3 v3.0.4 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 bazil.org/fuse v0.0.0-20160811212531-371fbbdaa898/go.mod h1:Xbm+BRKSBEpa4q4hTSxohYNQpsxXPbPry4JJWOB3LB8=
+cel.dev/expr v0.25.1 h1:1KrZg61W6TWSxuNZ37Xy49ps13NUovb66QLprthtwi4=
+cel.dev/expr v0.25.1/go.mod h1:hrXvqGP6G6gyx8UAHSHJ5RGk//1Oj5nXQ2NI02Nrsg4=
 charm.land/lipgloss/v2 v2.0.3 h1:yM2zJ4Cf5Y51b7RHIwioil4ApI/aypFXXVHSwlM6RzU=
 charm.land/lipgloss/v2 v2.0.3/go.mod h1:7myLU9iG/3xluAWzpY/fSxYYHCgoKTie7laxk6ATwXA=
 charm.land/log/v2 v2.0.0 h1:SY3Cey7ipx86/MBXQHwsguOT6X1exT94mmJRdzTNs+s=
@@ -79,6 +81,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae/go.mod h1:CgnQgUtFrFz9mxFNtED3jI5tLDjKlOM+oUF/sTk6ps0=
 github.com/alexflint/go-filemutex v1.1.0/go.mod h1:7P4iRhttt/nUvUOrYIhcpMzv2G6CY9UnI16Z+UJqRyk=
+github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
+github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
 github.com/apparentlymart/go-cidr v1.1.1 h1:oEEk8CE0HP0YpHxsegk/TaOtR2FLHdWv4p3eM4ceUwg=
 github.com/apparentlymart/go-cidr v1.1.1/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
@@ -421,6 +425,8 @@ github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Z
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.1.2 h1:xf4v41cLI2Z6FxbKm+8Bu+m8ifhj15JuZ9sa0jZCMUU=
 github.com/google/btree v1.1.2/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
+github.com/google/cel-go v0.28.1 h1:YWIwi77J4xIsYUwAF/iIuS6haffzIHS8yWI8glSbLWM=
+github.com/google/cel-go v0.28.1/go.mod h1:X0bD6iVNR8pkROSOoHVdgTkzmRcosof7WQqCD6wcMc8=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
@@ -858,6 +864,8 @@ go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.yaml.in/yaml/v2 v2.4.4 h1:tuyd0P+2Ont/d6e2rl3be67goVK4R6deVxCUX5vyPaQ=
 go.yaml.in/yaml/v2 v2.4.4/go.mod h1:gMZqIpDtDqOfM0uNfy0SkpRhvUryYH0Z6wdMYcacYXQ=
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.0.0-20171113213409-9f005a07e0d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181009213950-7c1a557ab941/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/internal/authz/actions.go
+++ b/internal/authz/actions.go
@@ -1,0 +1,90 @@
+package authz
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+var knownActions = map[string]struct{}{
+	"sandbox.create":       {},
+	"sandbox.get":          {},
+	"sandbox.list":         {},
+	"sandbox.terminate":    {},
+	"sandbox.file.stat":    {},
+	"sandbox.file.walk":    {},
+	"sandbox.file.read":    {},
+	"sandbox.file.write":   {},
+	"sandbox.file.remove":  {},
+	"sandbox.file.archive": {},
+	"sandbox.file.extract": {},
+	"sandbox.port.dial":    {},
+
+	"execution.create":      {},
+	"execution.get":         {},
+	"execution.list":        {},
+	"execution.inspect":     {},
+	"execution.cancel":      {},
+	"execution.stdin.write": {},
+	"execution.stdin.close": {},
+	"execution.stream":      {},
+	"execution.attach":      {},
+
+	"snapshot.create":  {},
+	"snapshot.get":     {},
+	"snapshot.list":    {},
+	"snapshot.delete":  {},
+	"snapshot.restore": {},
+
+	"cache_peer.lookup": {},
+	"cache_peer.export": {},
+}
+
+var knownResourceKinds = map[string]struct{}{
+	"sandbox":    {},
+	"execution":  {},
+	"snapshot":   {},
+	"cache_peer": {},
+}
+
+func normalizeActionSet(actions []string) (map[string]struct{}, error) {
+	if len(actions) == 0 {
+		return nil, errors.New("must contain at least one action")
+	}
+	out := make(map[string]struct{}, len(actions))
+	for _, action := range actions {
+		action = strings.TrimSpace(action)
+		if action == "" {
+			continue
+		}
+		if _, ok := knownActions[action]; !ok {
+			return nil, fmt.Errorf("unknown action %q", action)
+		}
+		out[action] = struct{}{}
+	}
+	if len(out) == 0 {
+		return nil, errors.New("must contain at least one action")
+	}
+	return out, nil
+}
+
+func normalizeResourceSet(resources []string) (map[string]struct{}, error) {
+	if len(resources) == 0 {
+		return nil, errors.New("must contain at least one resource")
+	}
+	out := make(map[string]struct{}, len(resources))
+	for _, resource := range resources {
+		resource = strings.TrimSpace(resource)
+		if resource == "" {
+			continue
+		}
+		if _, ok := knownResourceKinds[resource]; !ok {
+			return nil, fmt.Errorf("unknown resource %q", resource)
+		}
+		out[resource] = struct{}{}
+	}
+	if len(out) == 0 {
+		return nil, errors.New("must contain at least one resource")
+	}
+	return out, nil
+}

--- a/internal/authz/authz_test.go
+++ b/internal/authz/authz_test.go
@@ -90,6 +90,94 @@ func TestOIDCValidatorRefreshesJWKSOnReusedKidSignatureFailure(t *testing.T) {
 	}
 }
 
+func TestOIDCValidatorIgnoresUnsupportedJWKSKeys(t *testing.T) {
+	now := time.Unix(1_800_000_000, 0).UTC()
+	key := mustRSAKey(t)
+	jwks := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"keys": []map[string]any{
+				{"kty": "oct", "kid": "symmetric", "k": "secret"},
+				jwkPayload("kid-1", &key.PublicKey),
+			},
+		}); err != nil {
+			t.Fatalf("encode jwks: %v", err)
+		}
+	}))
+	t.Cleanup(jwks.Close)
+	validator := newTestOIDCValidator(t, jwks.URL, now)
+	token := signTestToken(t, key, "kid-1", jwt.MapClaims{
+		"iss": "https://issuer.example",
+		"sub": "bot-123",
+		"aud": []string{"cleanroom"},
+		"iat": jwt.NewNumericDate(now.Add(-time.Minute)),
+		"nbf": jwt.NewNumericDate(now.Add(-time.Minute)),
+		"exp": jwt.NewNumericDate(now.Add(time.Minute)),
+	})
+	if _, err := validator.Validate(context.Background(), token); err != nil {
+		t.Fatalf("Validate returned error: %v", err)
+	}
+}
+
+func TestOIDCValidatorExpiresJWKSCache(t *testing.T) {
+	now := time.Unix(1_800_000_000, 0).UTC()
+	firstKey := mustRSAKey(t)
+	secondKey := mustRSAKey(t)
+	var mu sync.Mutex
+	currentKid := "kid-1"
+	currentKey := firstKey
+	jwks := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		kid := currentKid
+		key := currentKey
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"keys": []map[string]any{
+				jwkPayload(kid, &key.PublicKey),
+			},
+		}); err != nil {
+			t.Fatalf("encode jwks: %v", err)
+		}
+	}))
+	t.Cleanup(jwks.Close)
+	validator, err := NewOIDCValidator([]runtimeconfig.AuthOIDCIssuerConfig{
+		{
+			Name:                    "issuer",
+			Issuer:                  "https://issuer.example",
+			Audiences:               []string{"cleanroom"},
+			JWKSURL:                 jwks.URL,
+			AllowedAlgorithms:       []string{"RS256"},
+			ClockSkewSeconds:        60,
+			MaxTokenLifetimeSeconds: 3600,
+		},
+	}, WithNow(func() time.Time { return now }))
+	if err != nil {
+		t.Fatalf("NewOIDCValidator returned error: %v", err)
+	}
+	claims := jwt.MapClaims{
+		"iss": "https://issuer.example",
+		"sub": "bot-123",
+		"aud": []string{"cleanroom"},
+		"iat": jwt.NewNumericDate(now.Add(-time.Minute)),
+		"nbf": jwt.NewNumericDate(now.Add(-time.Minute)),
+		"exp": jwt.NewNumericDate(now.Add(10 * time.Minute)),
+	}
+	oldToken := signTestToken(t, firstKey, "kid-1", claims)
+	if _, err := validator.Validate(context.Background(), oldToken); err != nil {
+		t.Fatalf("Validate with first key returned error: %v", err)
+	}
+
+	mu.Lock()
+	currentKid = "kid-2"
+	currentKey = secondKey
+	mu.Unlock()
+	now = now.Add(defaultJWKSCacheMaxAge + time.Second)
+	if _, err := validator.Validate(context.Background(), oldToken); err == nil {
+		t.Fatal("expected old token to fail after JWKS cache expiry")
+	}
+}
+
 func TestOIDCValidatorRejectsInvalidTokens(t *testing.T) {
 	now := time.Unix(1_800_000_000, 0).UTC()
 	trustedKey := mustRSAKey(t)
@@ -202,6 +290,114 @@ func TestPolicyBindsPrincipalAndAuthorizesGrant(t *testing.T) {
 	}
 	if got, want := decision.Grant, "create-cleanroom-sandbox"; got != want {
 		t.Fatalf("unexpected grant: got %q want %q", got, want)
+	}
+}
+
+func TestPolicyContinuesBindingEvaluationAfterWhenError(t *testing.T) {
+	policy := compileTestPolicy(t, `bindings:
+  - name: missing-claim
+    when: 'claims.repository.owner == "buildkite"'
+    principal:
+      id: 'bad:${claims.repository}'
+    grants:
+      - actions: [sandbox.create]
+        resources: [sandbox]
+  - name: fallback
+    when: 'token.issuer == "github-actions"'
+    principal:
+      id: 'oidc:${token.issuer}:${claims.sub}'
+    grants:
+      - actions: [sandbox.create]
+        resources: [sandbox]
+`)
+	bound, err := policy.Bind(ValidatedToken{
+		IssuerName: "github-actions",
+		Subject:    "repo:buildkite/cleanroom:ref:refs/heads/main",
+		Claims: map[string]any{
+			"sub": "repo:buildkite/cleanroom:ref:refs/heads/main",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Bind returned error: %v", err)
+	}
+	if got, want := bound.Binding, "fallback"; got != want {
+		t.Fatalf("unexpected binding: got %q want %q", got, want)
+	}
+}
+
+func TestPolicyContinuesGrantEvaluationAfterConditionError(t *testing.T) {
+	policy := compileTestPolicy(t, `bindings:
+  - name: cleanroom-repo-bots
+    when: 'token.issuer == "github-actions"'
+    principal:
+      id: 'oidc:${token.issuer}:${claims.sub}'
+    grants:
+      - name: optional-request-field
+        actions: [sandbox.create]
+        resources: [sandbox]
+        condition: 'request.repository.remote_url == "https://github.com/buildkite/cleanroom.git"'
+      - name: fallback
+        actions: [sandbox.create]
+        resources: [sandbox]
+`)
+	bound, err := policy.Bind(ValidatedToken{
+		IssuerName: "github-actions",
+		Subject:    "repo:buildkite/cleanroom:ref:refs/heads/main",
+		Claims: map[string]any{
+			"sub": "repo:buildkite/cleanroom:ref:refs/heads/main",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Bind returned error: %v", err)
+	}
+	decision := bound.Authorize(DecisionRequest{
+		Action:   "sandbox.create",
+		Resource: Resource{Kind: "sandbox"},
+		Request:  map[string]any{},
+	})
+	if !decision.Allowed {
+		t.Fatalf("expected fallback grant to allow, got %#v", decision)
+	}
+	if got, want := decision.Grant, "fallback"; got != want {
+		t.Fatalf("unexpected grant: got %q want %q", got, want)
+	}
+}
+
+func TestPolicyCompilesCELComprehensionVariables(t *testing.T) {
+	policy := compileTestPolicy(t, `bindings:
+  - name: cleanroom-repo-bots
+    when: 'token.issuer == "github-actions"'
+    principal:
+      id: 'oidc:${token.issuer}:${claims.sub}'
+    grants:
+      - name: private-hosts
+        actions: [sandbox.create]
+        resources: [sandbox]
+        condition: 'request.policy.network.hosts.all(host, host == "github.com")'
+`)
+	bound, err := policy.Bind(ValidatedToken{
+		IssuerName: "github-actions",
+		Subject:    "repo:buildkite/cleanroom:ref:refs/heads/main",
+		Claims: map[string]any{
+			"sub": "repo:buildkite/cleanroom:ref:refs/heads/main",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Bind returned error: %v", err)
+	}
+	decision := bound.Authorize(DecisionRequest{
+		Action:   "sandbox.create",
+		Resource: Resource{Kind: "sandbox"},
+		Request: map[string]any{
+			"policy": map[string]any{
+				"network": map[string]any{
+					"hosts": []any{"github.com"},
+				},
+			},
+		},
+	})
+	if !decision.Allowed {
+		t.Fatalf("expected comprehension grant to allow, got %#v", decision)
 	}
 }
 

--- a/internal/authz/authz_test.go
+++ b/internal/authz/authz_test.go
@@ -1,0 +1,474 @@
+package authz
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/buildkite/cleanroom/internal/runtimeconfig"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+func TestOIDCValidatorAcceptsValidToken(t *testing.T) {
+	now := time.Unix(1_800_000_000, 0).UTC()
+	key := mustRSAKey(t)
+	jwks := jwksServer(t, "kid-1", key)
+	validator := newTestOIDCValidator(t, jwks.URL, now)
+
+	token := signTestToken(t, key, "kid-1", jwt.MapClaims{
+		"iss":        "https://issuer.example",
+		"sub":        "bot-123",
+		"aud":        []string{"cleanroom"},
+		"iat":        jwt.NewNumericDate(now.Add(-time.Minute)),
+		"nbf":        jwt.NewNumericDate(now.Add(-time.Minute)),
+		"exp":        jwt.NewNumericDate(now.Add(time.Minute)),
+		"repository": "buildkite/cleanroom",
+	})
+	validated, err := validator.Validate(context.Background(), token)
+	if err != nil {
+		t.Fatalf("Validate returned error: %v", err)
+	}
+	if got, want := validated.IssuerName, "issuer"; got != want {
+		t.Fatalf("unexpected issuer name: got %q want %q", got, want)
+	}
+	if got, want := validated.Subject, "bot-123"; got != want {
+		t.Fatalf("unexpected subject: got %q want %q", got, want)
+	}
+	if got, want := validated.Claims["repository"], "buildkite/cleanroom"; got != want {
+		t.Fatalf("unexpected repository claim: got %v want %v", got, want)
+	}
+}
+
+func TestOIDCValidatorRefreshesJWKSOnReusedKidSignatureFailure(t *testing.T) {
+	now := time.Unix(1_800_000_000, 0).UTC()
+	firstKey := mustRSAKey(t)
+	secondKey := mustRSAKey(t)
+	var mu sync.Mutex
+	currentKey := firstKey
+	jwks := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		key := currentKey
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"keys": []map[string]any{
+				jwkPayload("kid-1", &key.PublicKey),
+			},
+		}); err != nil {
+			t.Fatalf("encode jwks: %v", err)
+		}
+	}))
+	t.Cleanup(jwks.Close)
+	validator := newTestOIDCValidator(t, jwks.URL, now)
+	claims := jwt.MapClaims{
+		"iss": "https://issuer.example",
+		"sub": "bot-123",
+		"aud": []string{"cleanroom"},
+		"iat": jwt.NewNumericDate(now.Add(-time.Minute)),
+		"nbf": jwt.NewNumericDate(now.Add(-time.Minute)),
+		"exp": jwt.NewNumericDate(now.Add(time.Minute)),
+	}
+	if _, err := validator.Validate(context.Background(), signTestToken(t, firstKey, "kid-1", claims)); err != nil {
+		t.Fatalf("Validate with first key returned error: %v", err)
+	}
+
+	mu.Lock()
+	currentKey = secondKey
+	mu.Unlock()
+	if _, err := validator.Validate(context.Background(), signTestToken(t, secondKey, "kid-1", claims)); err != nil {
+		t.Fatalf("Validate after key rotation returned error: %v", err)
+	}
+}
+
+func TestOIDCValidatorRejectsInvalidTokens(t *testing.T) {
+	now := time.Unix(1_800_000_000, 0).UTC()
+	trustedKey := mustRSAKey(t)
+	jwks := jwksServer(t, "kid-1", trustedKey)
+	validator := newTestOIDCValidator(t, jwks.URL, now)
+	otherKey := mustRSAKey(t)
+
+	baseClaims := func() jwt.MapClaims {
+		return jwt.MapClaims{
+			"iss": "https://issuer.example",
+			"sub": "bot-123",
+			"aud": []string{"cleanroom"},
+			"iat": jwt.NewNumericDate(now.Add(-time.Minute)),
+			"nbf": jwt.NewNumericDate(now.Add(-time.Minute)),
+			"exp": jwt.NewNumericDate(now.Add(time.Minute)),
+		}
+	}
+
+	tests := []struct {
+		name    string
+		token   string
+		wantErr string
+	}{
+		{
+			name:    "issuer",
+			token:   signTestToken(t, trustedKey, "kid-1", withClaim(baseClaims(), "iss", "https://evil.example")),
+			wantErr: "untrusted issuer",
+		},
+		{
+			name:    "audience",
+			token:   signTestToken(t, trustedKey, "kid-1", withClaim(baseClaims(), "aud", []string{"other"})),
+			wantErr: "aud",
+		},
+		{
+			name:    "signature",
+			token:   signTestToken(t, otherKey, "kid-1", baseClaims()),
+			wantErr: "signature",
+		},
+		{
+			name:    "expiry",
+			token:   signTestToken(t, trustedKey, "kid-1", withClaim(baseClaims(), "exp", jwt.NewNumericDate(now.Add(-2*time.Minute)))),
+			wantErr: "expired",
+		},
+		{
+			name:    "missing kid",
+			token:   signTestToken(t, trustedKey, "", baseClaims()),
+			wantErr: "kid header is required",
+		},
+		{
+			name:    "unsupported algorithm",
+			token:   signHS256TestToken(t, "kid-1", baseClaims()),
+			wantErr: "signing method",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := validator.Validate(context.Background(), tt.token)
+			if err == nil {
+				t.Fatal("expected token validation error")
+			}
+			if !strings.Contains(strings.ToLower(err.Error()), strings.ToLower(tt.wantErr)) {
+				t.Fatalf("expected error to contain %q, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestPolicyBindsPrincipalAndAuthorizesGrant(t *testing.T) {
+	policy := compileTestPolicy(t, testPolicyYAML())
+	token := ValidatedToken{
+		IssuerName: "github-actions",
+		Issuer:     "https://token.actions.githubusercontent.com",
+		Subject:    "repo:buildkite/cleanroom:ref:refs/heads/main",
+		Claims: map[string]any{
+			"sub":        "repo:buildkite/cleanroom:ref:refs/heads/main",
+			"repository": "buildkite/cleanroom",
+		},
+	}
+	bound, err := policy.Bind(token)
+	if err != nil {
+		t.Fatalf("Bind returned error: %v", err)
+	}
+	if got, want := bound.Principal.ID, "oidc:github-actions:repo:buildkite/cleanroom:ref:refs/heads/main"; got != want {
+		t.Fatalf("unexpected principal ID: got %q want %q", got, want)
+	}
+	if got, want := bound.Principal.Scope, "repo:buildkite/cleanroom"; got != want {
+		t.Fatalf("unexpected principal scope: got %q want %q", got, want)
+	}
+
+	decision := bound.Authorize(DecisionRequest{
+		Action:   "sandbox.create",
+		Resource: Resource{Kind: "sandbox"},
+		Request: map[string]any{
+			"repository": map[string]any{"remote_url": "https://github.com/buildkite/cleanroom.git"},
+			"backend":    "darwin-vz",
+			"policy": map[string]any{
+				"resources":       map[string]any{"vcpus": int64(4), "memory_bytes": int64(8 << 30)},
+				"docker":          map[string]any{"required": false},
+				"network_default": "deny",
+			},
+		},
+	})
+	if !decision.Allowed {
+		t.Fatalf("expected authorization to allow, got %#v", decision)
+	}
+	if got, want := decision.Binding, "cleanroom-repo-bots"; got != want {
+		t.Fatalf("unexpected binding: got %q want %q", got, want)
+	}
+	if got, want := decision.Grant, "create-cleanroom-sandbox"; got != want {
+		t.Fatalf("unexpected grant: got %q want %q", got, want)
+	}
+}
+
+func TestPolicyRejectsMalformedBindingsAndUnknownCELFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		wantErr string
+	}{
+		{
+			name: "missing principal id",
+			raw: `bindings:
+  - name: bad
+    when: 'token.issuer == "github-actions"'
+    principal:
+      scope: repo
+    grants:
+      - actions: [sandbox.create]
+        resources: [sandbox]
+`,
+			wantErr: "principal.id is required",
+		},
+		{
+			name: "unknown binding field",
+			raw: `bindings:
+  - name: bad
+    when: 'token.missing == "github-actions"'
+    principal:
+      id: 'oidc:${token.issuer}:${claims.sub}'
+    grants:
+      - actions: [sandbox.create]
+        resources: [sandbox]
+`,
+			wantErr: `unknown CEL field "token.missing"`,
+		},
+		{
+			name: "unknown grant field",
+			raw: `bindings:
+  - name: bad
+    when: 'token.issuer == "github-actions"'
+    principal:
+      id: 'oidc:${token.issuer}:${claims.sub}'
+    grants:
+      - actions: [sandbox.create]
+        resources: [sandbox]
+        condition: 'request.nope == "x"'
+`,
+			wantErr: `unknown CEL field "request.nope"`,
+		},
+		{
+			name: "wildcard action",
+			raw: `bindings:
+  - name: bad
+    when: 'token.issuer == "github-actions"'
+    principal:
+      id: 'oidc:${token.issuer}:${claims.sub}'
+    grants:
+      - actions: ["*"]
+        resources: [sandbox]
+`,
+			wantErr: `unknown action "*"`,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParsePolicy([]byte(tt.raw))
+			if err == nil {
+				t.Fatal("expected policy parse error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error to contain %q, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestPolicyDeniesConditionFailures(t *testing.T) {
+	policy := compileTestPolicy(t, testPolicyYAML())
+	bound, err := policy.Bind(ValidatedToken{
+		IssuerName: "github-actions",
+		Subject:    "repo:buildkite/cleanroom:ref:refs/heads/main",
+		Claims: map[string]any{
+			"sub":        "repo:buildkite/cleanroom:ref:refs/heads/main",
+			"repository": "buildkite/cleanroom",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Bind returned error: %v", err)
+	}
+	decision := bound.Authorize(DecisionRequest{
+		Action:   "sandbox.create",
+		Resource: Resource{Kind: "sandbox"},
+		Request: map[string]any{
+			"repository": map[string]any{"remote_url": "https://github.com/buildkite/other.git"},
+			"backend":    "darwin-vz",
+			"policy": map[string]any{
+				"resources":       map[string]any{"vcpus": int64(4), "memory_bytes": int64(8 << 30)},
+				"docker":          map[string]any{"required": false},
+				"network_default": "deny",
+			},
+		},
+	})
+	if decision.Allowed {
+		t.Fatalf("expected authorization to deny, got %#v", decision)
+	}
+	if got, want := decision.Reason, ReasonConditionFalse; got != want {
+		t.Fatalf("unexpected deny reason: got %q want %q", got, want)
+	}
+}
+
+func TestPolicyRejectsStructuredTemplateClaims(t *testing.T) {
+	policy := compileTestPolicy(t, `bindings:
+  - name: structured-claim
+    when: 'token.issuer == "github-actions"'
+    principal:
+      id: 'oidc:${token.issuer}:${claims.repository}'
+    grants:
+      - actions: [sandbox.create]
+        resources: [sandbox]
+`)
+	_, err := policy.Bind(ValidatedToken{
+		IssuerName: "github-actions",
+		Subject:    "repo:buildkite/cleanroom:ref:refs/heads/main",
+		Claims: map[string]any{
+			"repository": map[string]any{"name": "buildkite/cleanroom"},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected structured template claim error")
+	}
+	if !strings.Contains(err.Error(), "must resolve to a scalar") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPolicyReportsNoBinding(t *testing.T) {
+	policy := compileTestPolicy(t, testPolicyYAML())
+	_, err := policy.Bind(ValidatedToken{
+		IssuerName: "github-actions",
+		Subject:    "repo:buildkite/other:ref:refs/heads/main",
+		Claims: map[string]any{
+			"sub":        "repo:buildkite/other:ref:refs/heads/main",
+			"repository": "buildkite/other",
+		},
+	})
+	if !errors.Is(err, ErrNoBinding) {
+		t.Fatalf("expected ErrNoBinding, got %v", err)
+	}
+}
+
+func newTestOIDCValidator(t *testing.T, jwksURL string, now time.Time) *OIDCValidator {
+	t.Helper()
+	validator, err := NewOIDCValidator([]runtimeconfig.AuthOIDCIssuerConfig{
+		{
+			Name:                    "issuer",
+			Issuer:                  "https://issuer.example",
+			Audiences:               []string{"cleanroom"},
+			JWKSURL:                 jwksURL,
+			AllowedAlgorithms:       []string{"RS256"},
+			ClockSkewSeconds:        60,
+			MaxTokenLifetimeSeconds: 3600,
+		},
+	}, WithNow(func() time.Time { return now }))
+	if err != nil {
+		t.Fatalf("NewOIDCValidator returned error: %v", err)
+	}
+	return validator
+}
+
+func mustRSAKey(t *testing.T) *rsa.PrivateKey {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate RSA key: %v", err)
+	}
+	return key
+}
+
+func jwksServer(t *testing.T, kid string, key *rsa.PrivateKey) *httptest.Server {
+	t.Helper()
+	payload := map[string]any{
+		"keys": []map[string]any{
+			jwkPayload(kid, &key.PublicKey),
+		},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(payload); err != nil {
+			t.Fatalf("encode jwks: %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func jwkPayload(kid string, key *rsa.PublicKey) map[string]any {
+	return map[string]any{
+		"kty": "RSA",
+		"kid": kid,
+		"use": "sig",
+		"alg": "RS256",
+		"n":   base64.RawURLEncoding.EncodeToString(key.N.Bytes()),
+		"e":   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(key.E)).Bytes()),
+	}
+}
+
+func signTestToken(t *testing.T, key *rsa.PrivateKey, kid string, claims jwt.MapClaims) string {
+	t.Helper()
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	if kid != "" {
+		token.Header["kid"] = kid
+	}
+	signed, err := token.SignedString(key)
+	if err != nil {
+		t.Fatalf("sign token: %v", err)
+	}
+	return signed
+}
+
+func signHS256TestToken(t *testing.T, kid string, claims jwt.MapClaims) string {
+	t.Helper()
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	token.Header["kid"] = kid
+	signed, err := token.SignedString([]byte("secret"))
+	if err != nil {
+		t.Fatalf("sign HS256 token: %v", err)
+	}
+	return signed
+}
+
+func withClaim(claims jwt.MapClaims, key string, value any) jwt.MapClaims {
+	claims[key] = value
+	return claims
+}
+
+func compileTestPolicy(t *testing.T, raw string) *CompiledPolicy {
+	t.Helper()
+	policy, err := ParsePolicy([]byte(raw))
+	if err != nil {
+		t.Fatalf("ParsePolicy returned error: %v", err)
+	}
+	return policy
+}
+
+func testPolicyYAML() string {
+	return `bindings:
+  - name: cleanroom-repo-bots
+    when: >
+      token.issuer == "github-actions" &&
+      claims.repository == "buildkite/cleanroom"
+    principal:
+      id: 'oidc:${token.issuer}:${claims.sub}'
+      scope: 'repo:${claims.repository}'
+    grants:
+      - name: create-cleanroom-sandbox
+        actions:
+          - sandbox.create
+        resources:
+          - sandbox
+        condition: >
+          request.repository.remote_url == "https://github.com/buildkite/cleanroom.git" &&
+          request.backend in ["darwin-vz"] &&
+          request.policy.resources.vcpus <= 4 &&
+          request.policy.resources.memory_bytes <= 8589934592 &&
+          request.policy.docker.required == false &&
+          request.policy.network_default == "deny"
+`
+}

--- a/internal/authz/cel.go
+++ b/internal/authz/cel.go
@@ -3,6 +3,7 @@ package authz
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"unicode"
 
@@ -125,7 +126,10 @@ var celKeywords = map[string]struct{}{
 	"in":    {},
 }
 
+var celComprehensionVarRE = regexp.MustCompile(`\.(?:exists|exists_one|all|map|filter)\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*,`)
+
 func validateCELPaths(source string, rules celPathRules) error {
+	localRoots := collectCELLocalRoots(source)
 	for i := 0; i < len(source); {
 		r := rune(source[i])
 		if source[i] == '"' || source[i] == '\'' {
@@ -153,15 +157,55 @@ func validateCELPaths(source string, rules celPathRules) error {
 			continue
 		}
 		root := strings.Split(path, ".")[0]
+		if _, ok := localRoots[root]; ok {
+			continue
+		}
 		if _, ok := rules.allowedDynamicRoot[root]; ok {
 			continue
 		}
 		if next < len(source) && source[next] == '(' {
-			continue
+			if base, ok := methodBase(path); ok && celPathAllowed(base, rules, localRoots) {
+				continue
+			}
+			if _, ok := methodBase(path); !ok {
+				continue
+			}
 		}
 		return fmt.Errorf("unknown CEL field %q", path)
 	}
 	return nil
+}
+
+func collectCELLocalRoots(source string) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, match := range celComprehensionVarRE.FindAllStringSubmatch(source, -1) {
+		if len(match) == 2 {
+			out[match[1]] = struct{}{}
+		}
+	}
+	return out
+}
+
+func methodBase(path string) (string, bool) {
+	idx := strings.LastIndexByte(path, '.')
+	if idx <= 0 {
+		return "", false
+	}
+	return path[:idx], true
+}
+
+func celPathAllowed(path string, rules celPathRules, localRoots map[string]struct{}) bool {
+	if _, ok := rules.allowedExact[path]; ok {
+		return true
+	}
+	root := strings.Split(path, ".")[0]
+	if _, ok := localRoots[root]; ok {
+		return true
+	}
+	if _, ok := rules.allowedDynamicRoot[root]; ok {
+		return true
+	}
+	return false
 }
 
 func skipQuoted(source string, start int) (int, error) {

--- a/internal/authz/cel.go
+++ b/internal/authz/cel.go
@@ -1,0 +1,210 @@
+package authz
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"unicode"
+
+	"github.com/google/cel-go/cel"
+)
+
+const celRuntimeCostLimit uint64 = 10_000
+
+type compiledBoolExpression struct {
+	source  string
+	program cel.Program
+}
+
+func compileBoolExpression(source string, rules celPathRules) (*compiledBoolExpression, error) {
+	source = strings.TrimSpace(source)
+	if source == "" {
+		return &compiledBoolExpression{}, nil
+	}
+	if err := validateCELPaths(source, rules); err != nil {
+		return nil, err
+	}
+	env, err := cel.NewEnv(
+		cel.Variable("token", cel.MapType(cel.StringType, cel.DynType)),
+		cel.Variable("claims", cel.MapType(cel.StringType, cel.DynType)),
+		cel.Variable("principal", cel.MapType(cel.StringType, cel.DynType)),
+		cel.Variable("action", cel.StringType),
+		cel.Variable("resource", cel.MapType(cel.StringType, cel.DynType)),
+		cel.Variable("request", cel.MapType(cel.StringType, cel.DynType)),
+	)
+	if err != nil {
+		return nil, err
+	}
+	ast, issues := env.Compile(source)
+	if issues != nil && issues.Err() != nil {
+		return nil, issues.Err()
+	}
+	if !ast.OutputType().IsExactType(cel.BoolType) {
+		return nil, fmt.Errorf("expression must return bool, got %s", ast.OutputType())
+	}
+	program, err := env.Program(ast, cel.CostLimit(celRuntimeCostLimit))
+	if err != nil {
+		return nil, err
+	}
+	return &compiledBoolExpression{
+		source:  source,
+		program: program,
+	}, nil
+}
+
+func (e *compiledBoolExpression) eval(vars map[string]any) (bool, error) {
+	if e == nil || strings.TrimSpace(e.source) == "" {
+		return true, nil
+	}
+	val, _, err := e.program.Eval(vars)
+	if err != nil {
+		return false, err
+	}
+	native, ok := val.Value().(bool)
+	if !ok {
+		return false, fmt.Errorf("expression returned %T, expected bool", val.Value())
+	}
+	return native, nil
+}
+
+type celPathRules struct {
+	allowedExact       map[string]struct{}
+	allowedDynamicRoot map[string]struct{}
+}
+
+func bindingCELRules() celPathRules {
+	return celPathRules{
+		allowedExact: map[string]struct{}{
+			"token.issuer":  {},
+			"token.subject": {},
+		},
+		allowedDynamicRoot: map[string]struct{}{
+			"claims": {},
+		},
+	}
+}
+
+func grantCELRules() celPathRules {
+	return celPathRules{
+		allowedExact: map[string]struct{}{
+			"action":                                {},
+			"principal.id":                          {},
+			"principal.issuer":                      {},
+			"principal.subject":                     {},
+			"principal.scope":                       {},
+			"resource.kind":                         {},
+			"resource.id":                           {},
+			"resource.owner.principal_id":           {},
+			"resource.owner.scope":                  {},
+			"request.backend":                       {},
+			"request.repository.remote_url":         {},
+			"request.repository.commit":             {},
+			"request.repository.branch":             {},
+			"request.image.ref":                     {},
+			"request.image.digest":                  {},
+			"request.snapshot.id":                   {},
+			"request.policy.resources.vcpus":        {},
+			"request.policy.resources.memory_bytes": {},
+			"request.policy.resources.disk_bytes":   {},
+			"request.policy.docker.required":        {},
+			"request.policy.network_default":        {},
+			"request.policy.network.hosts":          {},
+			"request.policy.network.ports":          {},
+			"request.cache.reuse":                   {},
+		},
+		allowedDynamicRoot: map[string]struct{}{
+			"claims": {},
+		},
+	}
+}
+
+var celKeywords = map[string]struct{}{
+	"true":  {},
+	"false": {},
+	"null":  {},
+	"in":    {},
+}
+
+func validateCELPaths(source string, rules celPathRules) error {
+	for i := 0; i < len(source); {
+		r := rune(source[i])
+		if source[i] == '"' || source[i] == '\'' {
+			next, err := skipQuoted(source, i)
+			if err != nil {
+				return err
+			}
+			i = next
+			continue
+		}
+		if !isIdentStart(r) || (i > 0 && source[i-1] == '.') {
+			i++
+			continue
+		}
+
+		path, next := readPath(source, i)
+		i = next
+		if path == "" {
+			continue
+		}
+		if _, ok := celKeywords[path]; ok {
+			continue
+		}
+		if _, ok := rules.allowedExact[path]; ok {
+			continue
+		}
+		root := strings.Split(path, ".")[0]
+		if _, ok := rules.allowedDynamicRoot[root]; ok {
+			continue
+		}
+		if next < len(source) && source[next] == '(' {
+			continue
+		}
+		return fmt.Errorf("unknown CEL field %q", path)
+	}
+	return nil
+}
+
+func skipQuoted(source string, start int) (int, error) {
+	quote := source[start]
+	escaped := false
+	for i := start + 1; i < len(source); i++ {
+		switch {
+		case escaped:
+			escaped = false
+		case source[i] == '\\':
+			escaped = true
+		case source[i] == quote:
+			return i + 1, nil
+		}
+	}
+	return len(source), errors.New("unterminated string literal")
+}
+
+func readPath(source string, start int) (string, int) {
+	var parts []string
+	i := start
+	for {
+		if i >= len(source) || !isIdentStart(rune(source[i])) {
+			break
+		}
+		partStart := i
+		i++
+		for i < len(source) && isIdentPart(rune(source[i])) {
+			i++
+		}
+		parts = append(parts, source[partStart:i])
+		if i >= len(source) || source[i] != '.' || i+1 >= len(source) || !isIdentStart(rune(source[i+1])) {
+			break
+		}
+		i++
+	}
+	return strings.Join(parts, "."), i
+}
+
+func isIdentStart(r rune) bool {
+	return r == '_' || unicode.IsLetter(r)
+}
+
+func isIdentPart(r rune) bool {
+	return r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r)
+}

--- a/internal/authz/oidc.go
+++ b/internal/authz/oidc.go
@@ -1,0 +1,340 @@
+package authz
+
+import (
+	"context"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/big"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/buildkite/cleanroom/internal/runtimeconfig"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+type OIDCValidator struct {
+	issuersByURL map[string]*trustedOIDCIssuer
+	httpClient   *http.Client
+	now          func() time.Time
+}
+
+type trustedOIDCIssuer struct {
+	Name             string
+	Issuer           string
+	Audiences        []string
+	JWKSURL          string
+	AllowedAlgs      []string
+	ClockSkew        time.Duration
+	MaxTokenLifetime time.Duration
+	keys             *jwksCache
+}
+
+type OIDCValidatorOption func(*OIDCValidator)
+
+func WithHTTPClient(client *http.Client) OIDCValidatorOption {
+	return func(v *OIDCValidator) {
+		if client != nil {
+			v.httpClient = client
+		}
+	}
+}
+
+func WithNow(now func() time.Time) OIDCValidatorOption {
+	return func(v *OIDCValidator) {
+		if now != nil {
+			v.now = now
+		}
+	}
+}
+
+func NewOIDCValidator(issuers []runtimeconfig.AuthOIDCIssuerConfig, opts ...OIDCValidatorOption) (*OIDCValidator, error) {
+	v := &OIDCValidator{
+		issuersByURL: map[string]*trustedOIDCIssuer{},
+		httpClient: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+		now: time.Now,
+	}
+	for _, opt := range opts {
+		opt(v)
+	}
+
+	for i, cfg := range issuers {
+		issuer := strings.TrimRight(strings.TrimSpace(cfg.Issuer), "/")
+		if issuer == "" {
+			return nil, fmt.Errorf("issuer[%d].issuer is required", i)
+		}
+		if _, exists := v.issuersByURL[issuer]; exists {
+			return nil, fmt.Errorf("duplicate trusted issuer %q", issuer)
+		}
+		name := strings.TrimSpace(cfg.Name)
+		if name == "" {
+			name = issuer
+		}
+		allowedAlgs := trimStrings(cfg.AllowedAlgorithms)
+		if len(allowedAlgs) == 0 {
+			allowedAlgs = []string{"RS256"}
+		}
+		for _, alg := range allowedAlgs {
+			if alg != "RS256" {
+				return nil, fmt.Errorf("issuer[%d].allowed_algorithms contains unsupported algorithm %q", i, alg)
+			}
+		}
+		audiences := trimStrings(cfg.Audiences)
+		if len(audiences) == 0 {
+			return nil, fmt.Errorf("issuer[%d].audiences must contain at least one audience", i)
+		}
+		clockSkew := time.Duration(cfg.ClockSkewSeconds) * time.Second
+		if clockSkew < 0 {
+			return nil, fmt.Errorf("issuer[%d].clock_skew_seconds must be non-negative", i)
+		}
+		if clockSkew == 0 {
+			clockSkew = time.Duration(runtimeconfig.DefaultAuthOIDCClockSkewSeconds) * time.Second
+		}
+		maxLifetime := time.Duration(cfg.MaxTokenLifetimeSeconds) * time.Second
+		if maxLifetime < 0 {
+			return nil, fmt.Errorf("issuer[%d].max_token_lifetime_seconds must be non-negative", i)
+		}
+		if maxLifetime == 0 {
+			maxLifetime = time.Duration(runtimeconfig.DefaultAuthOIDCMaxTokenLifetimeSeconds) * time.Second
+		}
+		trusted := &trustedOIDCIssuer{
+			Name:             name,
+			Issuer:           issuer,
+			Audiences:        audiences,
+			JWKSURL:          strings.TrimSpace(cfg.JWKSURL),
+			AllowedAlgs:      allowedAlgs,
+			ClockSkew:        clockSkew,
+			MaxTokenLifetime: maxLifetime,
+		}
+		trusted.keys = &jwksCache{
+			url:        trusted.JWKSURL,
+			httpClient: v.httpClient,
+			keys:       map[string]any{},
+		}
+		v.issuersByURL[issuer] = trusted
+	}
+	if len(v.issuersByURL) == 0 {
+		return nil, errors.New("at least one trusted issuer is required")
+	}
+	return v, nil
+}
+
+func (v *OIDCValidator) Validate(ctx context.Context, tokenString string) (ValidatedToken, error) {
+	tokenString = strings.TrimSpace(tokenString)
+	if tokenString == "" {
+		return ValidatedToken{}, errors.New("token is empty")
+	}
+
+	untrustedClaims := jwt.MapClaims{}
+	if _, _, err := jwt.NewParser(jwt.WithoutClaimsValidation()).ParseUnverified(tokenString, untrustedClaims); err != nil {
+		return ValidatedToken{}, fmt.Errorf("parse token: %w", err)
+	}
+	issuerURL, err := untrustedClaims.GetIssuer()
+	if err != nil || strings.TrimSpace(issuerURL) == "" {
+		return ValidatedToken{}, errors.New("token issuer is required")
+	}
+	trusted, ok := v.issuersByURL[strings.TrimRight(strings.TrimSpace(issuerURL), "/")]
+	if !ok {
+		return ValidatedToken{}, fmt.Errorf("untrusted issuer %q", issuerURL)
+	}
+
+	parsedToken, claims, err := v.parseToken(ctx, tokenString, trusted)
+	if errors.Is(err, jwt.ErrTokenSignatureInvalid) {
+		if refreshErr := trusted.keys.refresh(ctx); refreshErr == nil {
+			parsedToken, claims, err = v.parseToken(ctx, tokenString, trusted)
+		}
+	}
+	if err != nil {
+		return ValidatedToken{}, fmt.Errorf("validate token: %w", err)
+	}
+	if parsedToken == nil || !parsedToken.Valid {
+		return ValidatedToken{}, errors.New("token is invalid")
+	}
+
+	subject, err := claims.GetSubject()
+	if err != nil || strings.TrimSpace(subject) == "" {
+		return ValidatedToken{}, errors.New("token subject is required")
+	}
+	exp, err := claims.GetExpirationTime()
+	if err != nil || exp == nil {
+		return ValidatedToken{}, errors.New("token expiration is required")
+	}
+	iat, err := claims.GetIssuedAt()
+	if err != nil || iat == nil {
+		return ValidatedToken{}, errors.New("token issued-at time is required")
+	}
+	if exp.Time.Sub(iat.Time) > trusted.MaxTokenLifetime {
+		return ValidatedToken{}, fmt.Errorf("token lifetime %s exceeds maximum %s", exp.Time.Sub(iat.Time), trusted.MaxTokenLifetime)
+	}
+
+	return ValidatedToken{
+		IssuerName: trusted.Name,
+		Issuer:     trusted.Issuer,
+		Subject:    subject,
+		Claims:     copyMapStringAny(claims),
+		ExpiresAt:  exp.Time,
+		IssuedAt:   iat.Time,
+	}, nil
+}
+
+func (v *OIDCValidator) parseToken(ctx context.Context, tokenString string, trusted *trustedOIDCIssuer) (*jwt.Token, jwt.MapClaims, error) {
+	claims := jwt.MapClaims{}
+	parser := jwt.NewParser(
+		jwt.WithValidMethods(trusted.AllowedAlgs),
+		jwt.WithIssuer(trusted.Issuer),
+		jwt.WithAudience(trusted.Audiences...),
+		jwt.WithExpirationRequired(),
+		jwt.WithIssuedAt(),
+		jwt.WithLeeway(trusted.ClockSkew),
+		jwt.WithTimeFunc(v.now),
+	)
+	parsedToken, err := parser.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (any, error) {
+		kid, _ := token.Header["kid"].(string)
+		kid = strings.TrimSpace(kid)
+		if kid == "" {
+			return nil, errors.New("token kid header is required")
+		}
+		return trusted.keys.key(ctx, kid)
+	})
+	return parsedToken, claims, err
+}
+
+type jwksCache struct {
+	url        string
+	httpClient *http.Client
+
+	mu   sync.Mutex
+	keys map[string]any
+}
+
+func (c *jwksCache) key(ctx context.Context, kid string) (any, error) {
+	c.mu.Lock()
+	key, ok := c.keys[kid]
+	c.mu.Unlock()
+	if ok {
+		return key, nil
+	}
+
+	if err := c.refresh(ctx); err != nil {
+		return nil, err
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	key, ok = c.keys[kid]
+	if !ok {
+		return nil, fmt.Errorf("jwks key %q not found", kid)
+	}
+	return key, nil
+}
+
+func (c *jwksCache) refresh(ctx context.Context) error {
+	if strings.TrimSpace(c.url) == "" {
+		return errors.New("jwks_url is required")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.url, nil)
+	if err != nil {
+		return fmt.Errorf("create jwks request: %w", err)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("fetch jwks: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("fetch jwks: status %d", resp.StatusCode)
+	}
+
+	var payload jwksPayload
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return fmt.Errorf("decode jwks: %w", err)
+	}
+	keys := map[string]any{}
+	for _, jwk := range payload.Keys {
+		key, err := jwk.publicKey()
+		if err != nil {
+			return err
+		}
+		if strings.TrimSpace(jwk.KID) == "" {
+			return errors.New("jwks key is missing kid")
+		}
+		keys[jwk.KID] = key
+	}
+
+	c.mu.Lock()
+	c.keys = keys
+	c.mu.Unlock()
+	return nil
+}
+
+type jwksPayload struct {
+	Keys []jwkKey `json:"keys"`
+}
+
+type jwkKey struct {
+	KTY string `json:"kty"`
+	KID string `json:"kid"`
+	Alg string `json:"alg,omitempty"`
+	Use string `json:"use,omitempty"`
+	N   string `json:"n"`
+	E   string `json:"e"`
+}
+
+func (k jwkKey) publicKey() (any, error) {
+	if k.KTY != "RSA" {
+		return nil, fmt.Errorf("unsupported jwks key type %q", k.KTY)
+	}
+	if k.Use != "" && k.Use != "sig" {
+		return nil, fmt.Errorf("unsupported jwks key use %q", k.Use)
+	}
+	if k.Alg != "" && k.Alg != "RS256" {
+		return nil, fmt.Errorf("unsupported jwks key algorithm %q", k.Alg)
+	}
+	n, err := base64.RawURLEncoding.DecodeString(k.N)
+	if err != nil {
+		return nil, fmt.Errorf("decode jwks modulus: %w", err)
+	}
+	e, err := base64.RawURLEncoding.DecodeString(k.E)
+	if err != nil {
+		return nil, fmt.Errorf("decode jwks exponent: %w", err)
+	}
+	exponent := new(big.Int).SetBytes(e)
+	if !exponent.IsInt64() {
+		return nil, errors.New("jwks exponent overflows int64")
+	}
+	return &rsa.PublicKey{
+		N: new(big.Int).SetBytes(n),
+		E: int(exponent.Int64()),
+	}, nil
+}
+
+func trimStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+func copyMapStringAny(in map[string]any) map[string]any {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}

--- a/internal/authz/oidc.go
+++ b/internal/authz/oidc.go
@@ -17,6 +17,10 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 )
 
+const defaultJWKSCacheMaxAge = 5 * time.Minute
+
+var errUnsupportedJWK = errors.New("unsupported jwk")
+
 type OIDCValidator struct {
 	issuersByURL map[string]*trustedOIDCIssuer
 	httpClient   *http.Client
@@ -116,6 +120,8 @@ func NewOIDCValidator(issuers []runtimeconfig.AuthOIDCIssuerConfig, opts ...OIDC
 			url:        trusted.JWKSURL,
 			httpClient: v.httpClient,
 			keys:       map[string]any{},
+			now:        v.now,
+			maxAge:     defaultJWKSCacheMaxAge,
 		}
 		v.issuersByURL[issuer] = trusted
 	}
@@ -211,13 +217,18 @@ type jwksCache struct {
 
 	mu   sync.Mutex
 	keys map[string]any
+	at   time.Time
+	now  func() time.Time
+
+	maxAge time.Duration
 }
 
 func (c *jwksCache) key(ctx context.Context, kid string) (any, error) {
 	c.mu.Lock()
 	key, ok := c.keys[kid]
+	fresh := c.maxAge <= 0 || (!c.at.IsZero() && c.now().Sub(c.at) < c.maxAge)
 	c.mu.Unlock()
-	if ok {
+	if ok && fresh {
 		return key, nil
 	}
 
@@ -259,16 +270,23 @@ func (c *jwksCache) refresh(ctx context.Context) error {
 	for _, jwk := range payload.Keys {
 		key, err := jwk.publicKey()
 		if err != nil {
+			if errors.Is(err, errUnsupportedJWK) {
+				continue
+			}
 			return err
 		}
 		if strings.TrimSpace(jwk.KID) == "" {
-			return errors.New("jwks key is missing kid")
+			continue
 		}
 		keys[jwk.KID] = key
+	}
+	if len(keys) == 0 {
+		return errors.New("jwks contained no supported RSA signing keys")
 	}
 
 	c.mu.Lock()
 	c.keys = keys
+	c.at = c.now()
 	c.mu.Unlock()
 	return nil
 }
@@ -288,13 +306,13 @@ type jwkKey struct {
 
 func (k jwkKey) publicKey() (any, error) {
 	if k.KTY != "RSA" {
-		return nil, fmt.Errorf("unsupported jwks key type %q", k.KTY)
+		return nil, fmt.Errorf("%w: key type %q", errUnsupportedJWK, k.KTY)
 	}
 	if k.Use != "" && k.Use != "sig" {
-		return nil, fmt.Errorf("unsupported jwks key use %q", k.Use)
+		return nil, fmt.Errorf("%w: key use %q", errUnsupportedJWK, k.Use)
 	}
 	if k.Alg != "" && k.Alg != "RS256" {
-		return nil, fmt.Errorf("unsupported jwks key algorithm %q", k.Alg)
+		return nil, fmt.Errorf("%w: key algorithm %q", errUnsupportedJWK, k.Alg)
 	}
 	n, err := base64.RawURLEncoding.DecodeString(k.N)
 	if err != nil {

--- a/internal/authz/policy.go
+++ b/internal/authz/policy.go
@@ -176,7 +176,7 @@ func (p *CompiledPolicy) Bind(token ValidatedToken) (BoundPrincipal, error) {
 		binding := &p.bindings[i]
 		matched, err := binding.when.eval(activation)
 		if err != nil {
-			return BoundPrincipal{}, fmt.Errorf("binding %q: evaluate when: %w", binding.name, err)
+			continue
 		}
 		if !matched {
 			continue
@@ -225,6 +225,7 @@ func (b BoundPrincipal) Authorize(req DecisionRequest) Decision {
 	}
 
 	matchedGrant := false
+	var conditionErrorDecision *Decision
 	for _, grant := range b.binding.grants {
 		if !grant.matches(decision.Action, req.Resource.Kind) {
 			continue
@@ -232,9 +233,13 @@ func (b BoundPrincipal) Authorize(req DecisionRequest) Decision {
 		matchedGrant = true
 		ok, err := grant.condition.eval(grantActivation(req))
 		if err != nil {
-			decision.Grant = grant.name
-			decision.Reason = ReasonConditionError
-			return decision
+			if conditionErrorDecision == nil {
+				errorDecision := decision
+				errorDecision.Grant = grant.name
+				errorDecision.Reason = ReasonConditionError
+				conditionErrorDecision = &errorDecision
+			}
+			continue
 		}
 		if !ok {
 			decision.Grant = grant.name
@@ -245,6 +250,9 @@ func (b BoundPrincipal) Authorize(req DecisionRequest) Decision {
 		decision.Grant = grant.name
 		decision.Reason = ReasonAllowed
 		return decision
+	}
+	if conditionErrorDecision != nil {
+		return *conditionErrorDecision
 	}
 	if matchedGrant && decision.Reason == ReasonNoGrant {
 		decision.Reason = ReasonConditionFalse

--- a/internal/authz/policy.go
+++ b/internal/authz/policy.go
@@ -1,0 +1,362 @@
+package authz
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+var ErrNoBinding = errors.New("no matching auth binding")
+
+type Policy struct {
+	Bindings []Binding `yaml:"bindings" json:"bindings"`
+}
+
+type Binding struct {
+	Name      string            `yaml:"name" json:"name"`
+	When      string            `yaml:"when,omitempty" json:"when,omitempty"`
+	Principal PrincipalTemplate `yaml:"principal" json:"principal"`
+	Grants    []Grant           `yaml:"grants" json:"grants"`
+}
+
+type PrincipalTemplate struct {
+	ID    string `yaml:"id" json:"id"`
+	Scope string `yaml:"scope,omitempty" json:"scope,omitempty"`
+}
+
+type Grant struct {
+	Name      string   `yaml:"name,omitempty" json:"name,omitempty"`
+	Actions   []string `yaml:"actions" json:"actions"`
+	Resources []string `yaml:"resources" json:"resources"`
+	Condition string   `yaml:"condition,omitempty" json:"condition,omitempty"`
+}
+
+type CompiledPolicy struct {
+	bindings []compiledBinding
+}
+
+type compiledBinding struct {
+	name      string
+	when      *compiledBoolExpression
+	principal PrincipalTemplate
+	grants    []compiledGrant
+}
+
+type compiledGrant struct {
+	name      string
+	actions   map[string]struct{}
+	resources map[string]struct{}
+	condition *compiledBoolExpression
+}
+
+type BoundPrincipal struct {
+	Principal Principal
+	Claims    map[string]any
+	Binding   string
+
+	binding *compiledBinding
+}
+
+func LoadPolicyFile(path string) (*CompiledPolicy, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil, errors.New("auth policy path is empty")
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read auth policy %s: %w", path, err)
+	}
+	policy, err := ParsePolicy(raw)
+	if err != nil {
+		return nil, fmt.Errorf("parse auth policy %s: %w", path, err)
+	}
+	return policy, nil
+}
+
+func ParsePolicy(raw []byte) (*CompiledPolicy, error) {
+	spec := Policy{}
+	dec := yaml.NewDecoder(strings.NewReader(string(raw)))
+	dec.KnownFields(true)
+	if err := dec.Decode(&spec); err != nil {
+		return nil, err
+	}
+	return CompilePolicy(spec)
+}
+
+func CompilePolicy(spec Policy) (*CompiledPolicy, error) {
+	if len(spec.Bindings) == 0 {
+		return nil, errors.New("auth policy must contain at least one binding")
+	}
+	compiled := &CompiledPolicy{
+		bindings: make([]compiledBinding, 0, len(spec.Bindings)),
+	}
+	seenBindings := map[string]struct{}{}
+	for i, binding := range spec.Bindings {
+		name := strings.TrimSpace(binding.Name)
+		if name == "" {
+			return nil, fmt.Errorf("bindings[%d].name is required", i)
+		}
+		if _, ok := seenBindings[name]; ok {
+			return nil, fmt.Errorf("duplicate bindings[%d].name %q", i, name)
+		}
+		seenBindings[name] = struct{}{}
+		if strings.TrimSpace(binding.Principal.ID) == "" {
+			return nil, fmt.Errorf("bindings[%d].principal.id is required", i)
+		}
+		when, err := compileBoolExpression(binding.When, bindingCELRules())
+		if err != nil {
+			return nil, fmt.Errorf("bindings[%d].when: %w", i, err)
+		}
+		grants, err := compileGrants(i, binding.Grants)
+		if err != nil {
+			return nil, err
+		}
+		compiled.bindings = append(compiled.bindings, compiledBinding{
+			name: name,
+			when: when,
+			principal: PrincipalTemplate{
+				ID:    strings.TrimSpace(binding.Principal.ID),
+				Scope: strings.TrimSpace(binding.Principal.Scope),
+			},
+			grants: grants,
+		})
+	}
+	return compiled, nil
+}
+
+func compileGrants(bindingIndex int, grants []Grant) ([]compiledGrant, error) {
+	if len(grants) == 0 {
+		return nil, fmt.Errorf("bindings[%d].grants must contain at least one grant", bindingIndex)
+	}
+	compiled := make([]compiledGrant, 0, len(grants))
+	for i, grant := range grants {
+		actions, err := normalizeActionSet(grant.Actions)
+		if err != nil {
+			return nil, fmt.Errorf("bindings[%d].grants[%d].actions: %w", bindingIndex, i, err)
+		}
+		resources, err := normalizeResourceSet(grant.Resources)
+		if err != nil {
+			return nil, fmt.Errorf("bindings[%d].grants[%d].resources: %w", bindingIndex, i, err)
+		}
+		condition, err := compileBoolExpression(grant.Condition, grantCELRules())
+		if err != nil {
+			return nil, fmt.Errorf("bindings[%d].grants[%d].condition: %w", bindingIndex, i, err)
+		}
+		name := strings.TrimSpace(grant.Name)
+		if name == "" {
+			name = fmt.Sprintf("grant[%d]", i)
+		}
+		compiled = append(compiled, compiledGrant{
+			name:      name,
+			actions:   actions,
+			resources: resources,
+			condition: condition,
+		})
+	}
+	return compiled, nil
+}
+
+func (p *CompiledPolicy) Bind(token ValidatedToken) (BoundPrincipal, error) {
+	if p == nil {
+		return BoundPrincipal{}, errors.New("auth policy is nil")
+	}
+	tokenVars := map[string]any{
+		"issuer":  token.IssuerName,
+		"subject": token.Subject,
+	}
+	activation := map[string]any{
+		"token":  tokenVars,
+		"claims": token.Claims,
+	}
+	for i := range p.bindings {
+		binding := &p.bindings[i]
+		matched, err := binding.when.eval(activation)
+		if err != nil {
+			return BoundPrincipal{}, fmt.Errorf("binding %q: evaluate when: %w", binding.name, err)
+		}
+		if !matched {
+			continue
+		}
+		principalID, err := renderPrincipalTemplate(binding.principal.ID, token, tokenVars)
+		if err != nil {
+			return BoundPrincipal{}, fmt.Errorf("binding %q principal.id: %w", binding.name, err)
+		}
+		scope, err := renderPrincipalTemplate(binding.principal.Scope, token, tokenVars)
+		if err != nil {
+			return BoundPrincipal{}, fmt.Errorf("binding %q principal.scope: %w", binding.name, err)
+		}
+		return BoundPrincipal{
+			Principal: Principal{
+				ID:      principalID,
+				Subject: token.Subject,
+				Issuer:  token.IssuerName,
+				Scope:   scope,
+			},
+			Claims:  copyMapStringAny(token.Claims),
+			Binding: binding.name,
+			binding: binding,
+		}, nil
+	}
+	return BoundPrincipal{}, ErrNoBinding
+}
+
+func (b BoundPrincipal) Authorize(req DecisionRequest) Decision {
+	req.Principal = b.Principal
+	if req.Claims == nil {
+		req.Claims = b.Claims
+	}
+	req.Action = strings.TrimSpace(req.Action)
+	req.Resource.Kind = strings.TrimSpace(req.Resource.Kind)
+	decision := Decision{
+		Allowed:   false,
+		Principal: b.Principal,
+		Action:    req.Action,
+		Resource:  req.Resource,
+		Binding:   b.Binding,
+		Reason:    ReasonNoGrant,
+	}
+	if b.binding == nil {
+		decision.Reason = ReasonNoBinding
+		return decision
+	}
+
+	matchedGrant := false
+	for _, grant := range b.binding.grants {
+		if !grant.matches(decision.Action, req.Resource.Kind) {
+			continue
+		}
+		matchedGrant = true
+		ok, err := grant.condition.eval(grantActivation(req))
+		if err != nil {
+			decision.Grant = grant.name
+			decision.Reason = ReasonConditionError
+			return decision
+		}
+		if !ok {
+			decision.Grant = grant.name
+			decision.Reason = ReasonConditionFalse
+			continue
+		}
+		decision.Allowed = true
+		decision.Grant = grant.name
+		decision.Reason = ReasonAllowed
+		return decision
+	}
+	if matchedGrant && decision.Reason == ReasonNoGrant {
+		decision.Reason = ReasonConditionFalse
+	}
+	return decision
+}
+
+func grantActivation(req DecisionRequest) map[string]any {
+	return map[string]any{
+		"principal": map[string]any{
+			"id":      req.Principal.ID,
+			"issuer":  req.Principal.Issuer,
+			"subject": req.Principal.Subject,
+			"scope":   req.Principal.Scope,
+		},
+		"claims": req.Claims,
+		"action": req.Action,
+		"resource": map[string]any{
+			"kind": req.Resource.Kind,
+			"id":   req.Resource.ID,
+			"owner": map[string]any{
+				"principal_id": req.Resource.Owner.PrincipalID,
+				"scope":        req.Resource.Owner.Scope,
+			},
+		},
+		"request": req.Request,
+	}
+}
+
+func (g compiledGrant) matches(action, resourceKind string) bool {
+	action = strings.TrimSpace(action)
+	resourceKind = strings.TrimSpace(resourceKind)
+	if _, ok := g.actions[action]; !ok {
+		return false
+	}
+	if _, ok := g.resources[resourceKind]; !ok {
+		return false
+	}
+	return true
+}
+
+var templateRefRE = regexp.MustCompile(`\$\{([A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*)\}`)
+
+func renderPrincipalTemplate(template string, token ValidatedToken, tokenVars map[string]any) (string, error) {
+	template = strings.TrimSpace(template)
+	if template == "" {
+		return "", nil
+	}
+	var renderErr error
+	rendered := templateRefRE.ReplaceAllStringFunc(template, func(match string) string {
+		if renderErr != nil {
+			return ""
+		}
+		parts := templateRefRE.FindStringSubmatch(match)
+		if len(parts) != 2 {
+			renderErr = fmt.Errorf("malformed template reference %q", match)
+			return ""
+		}
+		value, err := lookupTemplateValue(parts[1], token, tokenVars)
+		if err != nil {
+			renderErr = err
+			return ""
+		}
+		return value
+	})
+	if renderErr != nil {
+		return "", renderErr
+	}
+	if strings.Contains(rendered, "${") {
+		return "", fmt.Errorf("malformed template %q", template)
+	}
+	return rendered, nil
+}
+
+func lookupTemplateValue(path string, token ValidatedToken, tokenVars map[string]any) (string, error) {
+	switch {
+	case strings.HasPrefix(path, "token."):
+		key := strings.TrimPrefix(path, "token.")
+		value, ok := tokenVars[key]
+		if !ok {
+			return "", fmt.Errorf("unknown token template field %q", path)
+		}
+		return templateScalar(path, value)
+	case strings.HasPrefix(path, "claims."):
+		key := strings.TrimPrefix(path, "claims.")
+		value, ok := token.Claims[key]
+		if !ok {
+			return "", fmt.Errorf("missing claim %q", key)
+		}
+		return templateScalar(path, value)
+	default:
+		return "", fmt.Errorf("unsupported template reference %q", path)
+	}
+}
+
+func templateScalar(path string, value any) (string, error) {
+	switch v := value.(type) {
+	case string:
+		return v, nil
+	case fmt.Stringer:
+		return v.String(), nil
+	case bool:
+		return fmt.Sprint(v), nil
+	case int:
+		return fmt.Sprint(v), nil
+	case int64:
+		return fmt.Sprint(v), nil
+	case float64:
+		return fmt.Sprint(v), nil
+	case nil:
+		return "", fmt.Errorf("template reference %q is null", path)
+	default:
+		return "", fmt.Errorf("template reference %q must resolve to a scalar, got %T", path, value)
+	}
+}

--- a/internal/authz/types.go
+++ b/internal/authz/types.go
@@ -1,0 +1,64 @@
+// Package authz validates caller identity and evaluates Cleanroom authorization
+// grants.
+package authz
+
+import "time"
+
+// Principal is the server-derived caller identity used for authorization.
+type Principal struct {
+	ID      string `json:"id"`
+	Subject string `json:"subject"`
+	Issuer  string `json:"issuer"`
+	Scope   string `json:"scope"`
+}
+
+// ResourceOwner identifies the principal that created a resource.
+type ResourceOwner struct {
+	PrincipalID string `json:"principal_id,omitempty"`
+	Scope       string `json:"scope,omitempty"`
+}
+
+// Resource describes the authorization target.
+type Resource struct {
+	Kind  string        `json:"kind"`
+	ID    string        `json:"id,omitempty"`
+	Owner ResourceOwner `json:"owner,omitempty"`
+}
+
+// ValidatedToken is the trusted token shape after OIDC validation.
+type ValidatedToken struct {
+	IssuerName string         `json:"issuer_name"`
+	Issuer     string         `json:"issuer"`
+	Subject    string         `json:"subject"`
+	Claims     map[string]any `json:"claims"`
+	ExpiresAt  time.Time      `json:"expires_at,omitempty"`
+	IssuedAt   time.Time      `json:"issued_at,omitempty"`
+}
+
+// DecisionRequest is the normalized input to a grant decision.
+type DecisionRequest struct {
+	Principal Principal      `json:"principal"`
+	Claims    map[string]any `json:"claims,omitempty"`
+	Action    string         `json:"action"`
+	Resource  Resource       `json:"resource"`
+	Request   map[string]any `json:"request,omitempty"`
+}
+
+// Decision explains why an authorization request was allowed or denied.
+type Decision struct {
+	Allowed   bool      `json:"allowed"`
+	Principal Principal `json:"principal"`
+	Action    string    `json:"action"`
+	Resource  Resource  `json:"resource"`
+	Binding   string    `json:"binding,omitempty"`
+	Grant     string    `json:"grant,omitempty"`
+	Reason    string    `json:"reason,omitempty"`
+}
+
+const (
+	ReasonAllowed        = "allowed"
+	ReasonNoBinding      = "auth_no_binding"
+	ReasonNoGrant        = "auth_no_grant"
+	ReasonConditionFalse = "auth_condition_false"
+	ReasonConditionError = "auth_condition_error"
+)

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -220,6 +220,16 @@ func readAuthCheckRequest(cwd, path string) (map[string]any, error) {
 	if err := dec.Decode(&request); err != nil {
 		return nil, fmt.Errorf("decode request fixture %s: %w", path, err)
 	}
+	if request == nil {
+		return nil, fmt.Errorf("request fixture %s must contain a JSON object", path)
+	}
+	var extra any
+	if err := dec.Decode(&extra); err != io.EOF {
+		if err != nil {
+			return nil, fmt.Errorf("decode request fixture %s: %w", path, err)
+		}
+		return nil, fmt.Errorf("request fixture %s must contain one JSON object", path)
+	}
 	return normalizeJSONNumbers(request).(map[string]any), nil
 }
 

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -1,0 +1,274 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/buildkite/cleanroom/internal/authz"
+	"github.com/buildkite/cleanroom/internal/runtimeconfig"
+)
+
+type AuthCommand struct {
+	Check AuthCheckCommand `cmd:"" help:"Check local auth policy for a token and request"`
+}
+
+type AuthCheckCommand struct {
+	Config           string `help:"Runtime config path (default: $XDG_CONFIG_HOME/cleanroom/config.yaml)"`
+	PolicyFile       string `name:"policy-file" help:"Auth policy path (default: auth.policy_file from runtime config)"`
+	TokenFile        string `name:"token-file" required:"" help:"Path to OIDC JWT token file, or '-' for stdin"`
+	Action           string `required:"" help:"Cleanroom action to check, for example sandbox.create"`
+	Resource         string `help:"Resource kind (default: derived from action prefix)"`
+	ResourceID       string `name:"resource-id" help:"Existing resource ID for get, stream, file, or snapshot checks"`
+	OwnerPrincipalID string `name:"owner-principal-id" help:"Existing resource owner principal ID"`
+	OwnerScope       string `name:"owner-scope" help:"Existing resource owner scope"`
+	Request          string `help:"JSON request fixture path (default: empty object)"`
+	JSON             bool   `help:"Print decision as JSON"`
+}
+
+func (c *AuthCheckCommand) Run(ctx *runtimeContext) error {
+	if strings.TrimSpace(c.Action) == "" {
+		return errors.New("--action is required")
+	}
+	configPath, err := resolveRuntimeConfigPath(ctx.CWD, c.Config)
+	if err != nil {
+		return err
+	}
+	if st, err := os.Stat(configPath); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("runtime config does not exist at %s", configPath)
+		}
+		return fmt.Errorf("stat %s: %w", configPath, err)
+	} else if st.IsDir() {
+		return fmt.Errorf("runtime config path %s is a directory", configPath)
+	}
+
+	cfg, resolvedConfigPath, err := runtimeconfig.LoadPath(configPath)
+	if err != nil {
+		return err
+	}
+	policyPath, err := resolveAuthPolicyPath(ctx.CWD, resolvedConfigPath, c.PolicyFile, cfg.Auth.PolicyFile)
+	if err != nil {
+		return err
+	}
+	policy, err := authz.LoadPolicyFile(policyPath)
+	if err != nil {
+		return err
+	}
+	validator, err := authz.NewOIDCValidator(cfg.Auth.OIDC.Issuers)
+	if err != nil {
+		return err
+	}
+
+	tokenString, err := readAuthToken(ctx.CWD, c.TokenFile)
+	if err != nil {
+		return err
+	}
+	token, err := validator.Validate(context.Background(), tokenString)
+	if err != nil {
+		return err
+	}
+	bound, err := policy.Bind(token)
+	if err != nil {
+		if errors.Is(err, authz.ErrNoBinding) {
+			decision := authz.Decision{
+				Allowed: false,
+				Action:  strings.TrimSpace(c.Action),
+				Resource: authz.Resource{
+					Kind: resourceKindForAction(c.Action, c.Resource),
+					ID:   strings.TrimSpace(c.ResourceID),
+				},
+				Reason: authz.ReasonNoBinding,
+			}
+			return writeAuthCheckDecision(ctx, decision, c.JSON)
+		}
+		return err
+	}
+	request, err := readAuthCheckRequest(ctx.CWD, c.Request)
+	if err != nil {
+		return err
+	}
+	decision := bound.Authorize(authz.DecisionRequest{
+		Action: strings.TrimSpace(c.Action),
+		Resource: authz.Resource{
+			Kind: resourceKindForAction(c.Action, c.Resource),
+			ID:   strings.TrimSpace(c.ResourceID),
+			Owner: authz.ResourceOwner{
+				PrincipalID: strings.TrimSpace(c.OwnerPrincipalID),
+				Scope:       strings.TrimSpace(c.OwnerScope),
+			},
+		},
+		Request: request,
+	})
+	return writeAuthCheckDecision(ctx, decision, c.JSON)
+}
+
+func writeAuthCheckDecision(ctx *runtimeContext, decision authz.Decision, asJSON bool) error {
+	if asJSON {
+		enc := json.NewEncoder(stdout(ctx))
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(decision); err != nil {
+			return err
+		}
+	} else {
+		status := "auth check denied"
+		if decision.Allowed {
+			status = "auth check allowed"
+		}
+		var out strings.Builder
+		out.WriteString(renderStatusValueLine(status, decision.Reason, defaultTerminalPalette().info, shouldUseANSI(stdout(ctx))))
+		out.WriteByte('\n')
+		out.WriteString(renderKeyValueLine("", "action", decision.Action, shouldUseANSI(stdout(ctx)), defaultTerminalPalette()))
+		out.WriteByte('\n')
+		out.WriteString(renderKeyValueLine("", "resource", decision.Resource.Kind, shouldUseANSI(stdout(ctx)), defaultTerminalPalette()))
+		out.WriteByte('\n')
+		if decision.Principal.ID != "" {
+			out.WriteString(renderKeyValueLine("", "principal", decision.Principal.ID, shouldUseANSI(stdout(ctx)), defaultTerminalPalette()))
+			out.WriteByte('\n')
+		}
+		if decision.Binding != "" {
+			out.WriteString(renderKeyValueLine("", "binding", decision.Binding, shouldUseANSI(stdout(ctx)), defaultTerminalPalette()))
+			out.WriteByte('\n')
+		}
+		if decision.Grant != "" {
+			out.WriteString(renderKeyValueLine("", "grant", decision.Grant, shouldUseANSI(stdout(ctx)), defaultTerminalPalette()))
+			out.WriteByte('\n')
+		}
+		if _, err := fmt.Fprint(stdout(ctx), out.String()); err != nil {
+			return err
+		}
+	}
+	if !decision.Allowed {
+		return exitCodeError{code: 1}
+	}
+	return nil
+}
+
+func resolveAuthPolicyPath(cwd, configPath, explicit, configured string) (string, error) {
+	path := strings.TrimSpace(explicit)
+	if path == "" {
+		path = strings.TrimSpace(configured)
+	}
+	if path == "" {
+		return "", errors.New("auth policy file is required (set --policy-file or auth.policy_file)")
+	}
+	if strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil || strings.TrimSpace(home) == "" {
+			if err != nil {
+				return "", err
+			}
+			return "", errors.New("home directory is not available")
+		}
+		return filepath.Join(home, strings.TrimPrefix(path, "~/")), nil
+	}
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path), nil
+	}
+	if strings.TrimSpace(explicit) != "" {
+		return filepath.Join(cwd, path), nil
+	}
+	return filepath.Join(filepath.Dir(configPath), path), nil
+}
+
+func readAuthToken(cwd, path string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", errors.New("--token-file is required")
+	}
+	var raw []byte
+	var err error
+	if path == "-" {
+		raw, err = io.ReadAll(os.Stdin)
+		if err != nil {
+			return "", fmt.Errorf("read token from stdin: %w", err)
+		}
+	} else {
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(cwd, path)
+		}
+		raw, err = os.ReadFile(path)
+		if err != nil {
+			return "", fmt.Errorf("read token file %s: %w", path, err)
+		}
+	}
+	return strings.TrimSpace(string(raw)), nil
+}
+
+func readAuthCheckRequest(cwd, path string) (map[string]any, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return map[string]any{}, nil
+	}
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(cwd, path)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open request fixture %s: %w", path, err)
+	}
+	defer f.Close()
+	dec := json.NewDecoder(f)
+	dec.UseNumber()
+	var request map[string]any
+	if err := dec.Decode(&request); err != nil {
+		return nil, fmt.Errorf("decode request fixture %s: %w", path, err)
+	}
+	return normalizeJSONNumbers(request).(map[string]any), nil
+}
+
+func normalizeJSONNumbers(value any) any {
+	switch v := value.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(v))
+		for key, item := range v {
+			out[key] = normalizeJSONNumbers(item)
+		}
+		return out
+	case []any:
+		out := make([]any, len(v))
+		for i, item := range v {
+			out[i] = normalizeJSONNumbers(item)
+		}
+		return out
+	case json.Number:
+		if i, err := strconv.ParseInt(v.String(), 10, 64); err == nil {
+			return i
+		}
+		if f, err := strconv.ParseFloat(v.String(), 64); err == nil {
+			return f
+		}
+		return v.String()
+	default:
+		return value
+	}
+}
+
+func resourceKindForAction(action, explicit string) string {
+	explicit = strings.TrimSpace(explicit)
+	if explicit != "" {
+		return explicit
+	}
+	action = strings.TrimSpace(action)
+	switch {
+	case strings.HasPrefix(action, "sandbox."):
+		return "sandbox"
+	case strings.HasPrefix(action, "execution."):
+		return "execution"
+	case strings.HasPrefix(action, "snapshot."):
+		return "snapshot"
+	case strings.HasPrefix(action, "cache_peer."):
+		return "cache_peer"
+	default:
+		if idx := strings.IndexByte(action, '.'); idx > 0 {
+			return action[:idx]
+		}
+		return action
+	}
+}

--- a/internal/cli/auth_check_test.go
+++ b/internal/cli/auth_check_test.go
@@ -1,0 +1,284 @@
+package cli
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/buildkite/cleanroom/internal/authz"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+func TestAuthCheckCommandReportsAllowedDecision(t *testing.T) {
+	fixture := newAuthCheckFixture(t)
+
+	stdout, readStdout := makeStdoutCapture(t)
+	err := (&AuthCheckCommand{
+		Config:    fixture.configPath,
+		TokenFile: fixture.tokenPath,
+		Action:    "sandbox.create",
+		Request:   fixture.requestPath,
+		JSON:      true,
+	}).Run(&runtimeContext{CWD: fixture.dir, Stdout: stdout})
+	if err != nil {
+		t.Fatalf("AuthCheckCommand.Run returned error: %v", err)
+	}
+
+	var decision authz.Decision
+	if err := json.Unmarshal([]byte(readStdout()), &decision); err != nil {
+		t.Fatalf("decode auth check json: %v", err)
+	}
+	if !decision.Allowed {
+		t.Fatalf("expected allowed decision, got %#v", decision)
+	}
+	if got, want := decision.Principal.ID, "oidc:github-actions:repo:buildkite/cleanroom:ref:refs/heads/main"; got != want {
+		t.Fatalf("unexpected principal ID: got %q want %q", got, want)
+	}
+	if got, want := decision.Binding, "cleanroom-repo-bots"; got != want {
+		t.Fatalf("unexpected binding: got %q want %q", got, want)
+	}
+}
+
+func TestAuthCheckCommandReportsDeniedDecision(t *testing.T) {
+	fixture := newAuthCheckFixture(t)
+	denyRequestPath := filepath.Join(fixture.dir, "deny-request.json")
+	if err := os.WriteFile(denyRequestPath, []byte(`{
+  "repository": {"remote_url": "https://github.com/buildkite/other.git"},
+  "backend": "darwin-vz",
+  "policy": {
+    "resources": {"vcpus": 4, "memory_bytes": 8589934592},
+    "docker": {"required": false},
+    "network_default": "deny"
+  }
+}`), 0o644); err != nil {
+		t.Fatalf("write deny request: %v", err)
+	}
+
+	stdout, readStdout := makeStdoutCapture(t)
+	err := (&AuthCheckCommand{
+		Config:    fixture.configPath,
+		TokenFile: fixture.tokenPath,
+		Action:    "sandbox.create",
+		Request:   denyRequestPath,
+		JSON:      true,
+	}).Run(&runtimeContext{CWD: fixture.dir, Stdout: stdout})
+	var exitErr hasExitCode
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 1 {
+		t.Fatalf("expected denied exit code 1, got %v", err)
+	}
+
+	var decision authz.Decision
+	if err := json.Unmarshal([]byte(readStdout()), &decision); err != nil {
+		t.Fatalf("decode auth check json: %v", err)
+	}
+	if decision.Allowed {
+		t.Fatalf("expected denied decision, got %#v", decision)
+	}
+	if got, want := decision.Reason, authz.ReasonConditionFalse; got != want {
+		t.Fatalf("unexpected deny reason: got %q want %q", got, want)
+	}
+}
+
+func TestRunAuthCheckBypassesBrokenDefaultRuntimeConfig(t *testing.T) {
+	fixture := newAuthCheckFixture(t)
+	xdgConfigHome := filepath.Join(fixture.dir, "xdg")
+	defaultConfigPath := filepath.Join(xdgConfigHome, "cleanroom", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(defaultConfigPath), 0o755); err != nil {
+		t.Fatalf("mkdir default config dir: %v", err)
+	}
+	if err := os.WriteFile(defaultConfigPath, []byte("default_backend: broken\n"), 0o644); err != nil {
+		t.Fatalf("write broken config: %v", err)
+	}
+
+	t.Setenv("XDG_CONFIG_HOME", xdgConfigHome)
+	if err := Run([]string{"auth", "check", "--config", fixture.configPath, "--token-file", fixture.tokenPath, "--action", "sandbox.create", "--request", fixture.requestPath, "--json"}, "dev"); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+}
+
+type authCheckFixture struct {
+	dir         string
+	configPath  string
+	policyPath  string
+	tokenPath   string
+	requestPath string
+}
+
+func newAuthCheckFixture(t *testing.T) authCheckFixture {
+	t.Helper()
+	dir := t.TempDir()
+	now := time.Now().UTC().Truncate(time.Second)
+	key := mustCLIAuthRSAKey(t)
+	jwks := cliAuthJWKSServer(t, "kid-1", key)
+
+	policyPath := filepath.Join(dir, "auth-policy.yaml")
+	if err := os.WriteFile(policyPath, []byte(cliAuthPolicyYAML()), 0o644); err != nil {
+		t.Fatalf("write policy: %v", err)
+	}
+	configPath := filepath.Join(dir, "config.yaml")
+	config := `default_backend: firecracker
+auth:
+  required: true
+  oidc:
+    issuers:
+      - name: github-actions
+        issuer: https://token.actions.githubusercontent.com
+        audiences: [cleanroom]
+        jwks_url: ` + jwks.URL + `
+        clock_skew_seconds: 60
+        max_token_lifetime_seconds: 3600
+  policy_file: auth-policy.yaml
+`
+	if err := os.WriteFile(configPath, []byte(config), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	tokenPath := filepath.Join(dir, "token.jwt")
+	token := cliAuthSignToken(t, key, "kid-1", jwt.MapClaims{
+		"iss":        "https://token.actions.githubusercontent.com",
+		"sub":        "repo:buildkite/cleanroom:ref:refs/heads/main",
+		"aud":        []string{"cleanroom"},
+		"iat":        jwt.NewNumericDate(now.Add(-time.Minute)),
+		"nbf":        jwt.NewNumericDate(now.Add(-time.Minute)),
+		"exp":        jwt.NewNumericDate(now.Add(time.Minute)),
+		"repository": "buildkite/cleanroom",
+	})
+	if err := os.WriteFile(tokenPath, []byte(token+"\n"), 0o600); err != nil {
+		t.Fatalf("write token: %v", err)
+	}
+	requestPath := filepath.Join(dir, "request.json")
+	if err := os.WriteFile(requestPath, []byte(`{
+  "repository": {"remote_url": "https://github.com/buildkite/cleanroom.git"},
+  "backend": "darwin-vz",
+  "policy": {
+    "resources": {"vcpus": 4, "memory_bytes": 8589934592},
+    "docker": {"required": false},
+    "network_default": "deny"
+  }
+}`), 0o644); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+	return authCheckFixture{
+		dir:         dir,
+		configPath:  configPath,
+		policyPath:  policyPath,
+		tokenPath:   tokenPath,
+		requestPath: requestPath,
+	}
+}
+
+func mustCLIAuthRSAKey(t *testing.T) *rsa.PrivateKey {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate RSA key: %v", err)
+	}
+	return key
+}
+
+func cliAuthJWKSServer(t *testing.T, kid string, key *rsa.PrivateKey) *httptest.Server {
+	t.Helper()
+	payload := map[string]any{
+		"keys": []map[string]any{
+			{
+				"kty": "RSA",
+				"kid": kid,
+				"use": "sig",
+				"alg": "RS256",
+				"n":   base64.RawURLEncoding.EncodeToString(key.PublicKey.N.Bytes()),
+				"e":   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(key.PublicKey.E)).Bytes()),
+			},
+		},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(payload); err != nil {
+			t.Fatalf("encode jwks: %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func cliAuthSignToken(t *testing.T, key *rsa.PrivateKey, kid string, claims jwt.MapClaims) string {
+	t.Helper()
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = kid
+	signed, err := token.SignedString(key)
+	if err != nil {
+		t.Fatalf("sign token: %v", err)
+	}
+	return signed
+}
+
+func cliAuthPolicyYAML() string {
+	return `bindings:
+  - name: cleanroom-repo-bots
+    when: >
+      token.issuer == "github-actions" &&
+      claims.repository == "buildkite/cleanroom"
+    principal:
+      id: 'oidc:${token.issuer}:${claims.sub}'
+      scope: 'repo:${claims.repository}'
+    grants:
+      - name: create-cleanroom-sandbox
+        actions: [sandbox.create]
+        resources: [sandbox]
+        condition: >
+          request.repository.remote_url == "https://github.com/buildkite/cleanroom.git" &&
+          request.backend in ["darwin-vz"] &&
+          request.policy.resources.vcpus <= 4 &&
+          request.policy.resources.memory_bytes <= 8589934592 &&
+          request.policy.docker.required == false &&
+          request.policy.network_default == "deny"
+`
+}
+
+func TestResourceKindForAction(t *testing.T) {
+	tests := map[string]string{
+		"sandbox.file.read": "sandbox",
+		"execution.stream":  "execution",
+		"snapshot.restore":  "snapshot",
+		"cache_peer.lookup": "cache_peer",
+	}
+	for action, want := range tests {
+		if got := resourceKindForAction(action, ""); got != want {
+			t.Fatalf("resourceKindForAction(%q) = %q, want %q", action, got, want)
+		}
+	}
+	if got := resourceKindForAction("sandbox.create", "snapshot"); got != "snapshot" {
+		t.Fatalf("explicit resource should win, got %q", got)
+	}
+}
+
+func TestResolveAuthPolicyPath(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	got, err := resolveAuthPolicyPath("/work", configPath, "", "auth-policy.yaml")
+	if err != nil {
+		t.Fatalf("resolveAuthPolicyPath returned error: %v", err)
+	}
+	if want := filepath.Join(dir, "auth-policy.yaml"); got != want {
+		t.Fatalf("unexpected policy path: got %q want %q", got, want)
+	}
+	got, err = resolveAuthPolicyPath("/work", configPath, "explicit.yaml", "auth-policy.yaml")
+	if err != nil {
+		t.Fatalf("resolve explicit path returned error: %v", err)
+	}
+	if want := filepath.Join("/work", "explicit.yaml"); got != want {
+		t.Fatalf("unexpected explicit policy path: got %q want %q", got, want)
+	}
+	_, err = resolveAuthPolicyPath("/work", configPath, "", " ")
+	if err == nil || !strings.Contains(err.Error(), "auth policy file is required") {
+		t.Fatalf("expected missing policy error, got %v", err)
+	}
+}

--- a/internal/cli/auth_check_test.go
+++ b/internal/cli/auth_check_test.go
@@ -282,3 +282,18 @@ func TestResolveAuthPolicyPath(t *testing.T) {
 		t.Fatalf("expected missing policy error, got %v", err)
 	}
 }
+
+func TestReadAuthCheckRequestRejectsNullFixture(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "request.json")
+	if err := os.WriteFile(path, []byte("null\n"), 0o644); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+	_, err := readAuthCheckRequest(dir, path)
+	if err == nil {
+		t.Fatal("expected null request fixture error")
+	}
+	if !strings.Contains(err.Error(), "must contain a JSON object") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -52,6 +52,7 @@ type runtimeContext struct {
 }
 
 type CLI struct {
+	Auth        AuthCommand        `cmd:"" help:"Authentication and authorization diagnostics"`
 	Policy      PolicyCommand      `cmd:"" help:"Policy commands"`
 	Config      ConfigCommand      `cmd:"" help:"Runtime config commands"`
 	Image       ImageCommand       `cmd:"" help:"Manage OCI image cache artifacts"`
@@ -202,7 +203,7 @@ func commandBypassesStartupRuntimeConfig(ctx *kong.Context) bool {
 
 	command := strings.TrimSpace(ctx.Command())
 	switch command {
-	case "config init", "config validate", "image resolve", "version":
+	case "auth check", "config init", "config validate", "image resolve", "version":
 		return true
 	default:
 		return strings.HasPrefix(command, "image resolve ")

--- a/internal/cli/cli_parse_test.go
+++ b/internal/cli/cli_parse_test.go
@@ -162,6 +162,33 @@ func TestConfigValidateParses(t *testing.T) {
 	}
 }
 
+func TestAuthCheckParses(t *testing.T) {
+	c := &CLI{}
+	parser := newParserForTest(t, c)
+
+	if _, err := parser.Parse([]string{"auth", "check", "--config", "./config.yaml", "--policy-file", "./auth-policy.yaml", "--token-file", "./token.jwt", "--action", "sandbox.create", "--request", "./request.json", "--json"}); err != nil {
+		t.Fatalf("parse auth check returned error: %v", err)
+	}
+	if got, want := c.Auth.Check.Config, "./config.yaml"; got != want {
+		t.Fatalf("unexpected auth check config: got %q want %q", got, want)
+	}
+	if got, want := c.Auth.Check.PolicyFile, "./auth-policy.yaml"; got != want {
+		t.Fatalf("unexpected auth check policy file: got %q want %q", got, want)
+	}
+	if got, want := c.Auth.Check.TokenFile, "./token.jwt"; got != want {
+		t.Fatalf("unexpected auth check token file: got %q want %q", got, want)
+	}
+	if got, want := c.Auth.Check.Action, "sandbox.create"; got != want {
+		t.Fatalf("unexpected auth check action: got %q want %q", got, want)
+	}
+	if got, want := c.Auth.Check.Request, "./request.json"; got != want {
+		t.Fatalf("unexpected auth check request: got %q want %q", got, want)
+	}
+	if !c.Auth.Check.JSON {
+		t.Fatal("expected auth check --json flag to be set")
+	}
+}
+
 func TestSnapshotInspectParses(t *testing.T) {
 	c := &CLI{}
 	parser := newParserForTest(t, c)

--- a/internal/runtimeconfig/config.go
+++ b/internal/runtimeconfig/config.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -21,10 +22,37 @@ import (
 type Config struct {
 	DefaultBackend string              `yaml:"default_backend"`
 	ControlHost    string              `yaml:"control_host,omitempty"`
+	Auth           AuthConfig          `yaml:"auth,omitempty"`
 	Cache          CacheConfig         `yaml:"cache,omitempty"`
 	Gateway        GatewayConfig       `yaml:"gateway,omitempty"`
 	Observability  ObservabilityConfig `yaml:"observability,omitempty"`
 	Backends       Backends            `yaml:"backends"`
+}
+
+const (
+	DefaultAuthOIDCClockSkewSeconds        int64 = 60
+	DefaultAuthOIDCMaxTokenLifetimeSeconds int64 = 3600
+)
+
+// AuthConfig configures control-plane caller authentication.
+type AuthConfig struct {
+	Required   bool           `yaml:"required,omitempty"`
+	OIDC       AuthOIDCConfig `yaml:"oidc,omitempty"`
+	PolicyFile string         `yaml:"policy_file,omitempty"`
+}
+
+type AuthOIDCConfig struct {
+	Issuers []AuthOIDCIssuerConfig `yaml:"issuers,omitempty"`
+}
+
+type AuthOIDCIssuerConfig struct {
+	Name                    string   `yaml:"name,omitempty"`
+	Issuer                  string   `yaml:"issuer"`
+	Audiences               []string `yaml:"audiences,omitempty"`
+	JWKSURL                 string   `yaml:"jwks_url,omitempty"`
+	AllowedAlgorithms       []string `yaml:"allowed_algorithms,omitempty"`
+	ClockSkewSeconds        int64    `yaml:"clock_skew_seconds,omitempty"`
+	MaxTokenLifetimeSeconds int64    `yaml:"max_token_lifetime_seconds,omitempty"`
 }
 
 // CacheConfig configures host-to-host cache reuse.
@@ -108,6 +136,7 @@ type TraceSamplingConfig struct {
 type configFile struct {
 	DefaultBackend string              `yaml:"default_backend"`
 	ControlHost    string              `yaml:"control_host,omitempty"`
+	Auth           AuthConfig          `yaml:"auth,omitempty"`
 	Cache          CacheConfig         `yaml:"cache,omitempty"`
 	Gateway        GatewayConfig       `yaml:"gateway,omitempty"`
 	Observability  ObservabilityConfig `yaml:"observability,omitempty"`
@@ -124,6 +153,7 @@ func (f configFile) config() Config {
 	cfg := Config{
 		DefaultBackend: f.DefaultBackend,
 		ControlHost:    f.ControlHost,
+		Auth:           f.Auth,
 		Cache:          f.Cache,
 		Gateway:        f.Gateway,
 		Observability:  f.Observability,
@@ -428,6 +458,7 @@ func normalizeConfig(cfg Config, inferredDefaultBackend string) Config {
 		cfg.DefaultBackend = inferredDefaultBackend
 	}
 	cfg.ControlHost = strings.TrimSpace(cfg.ControlHost)
+	cfg.Auth = normalizeAuthConfig(cfg.Auth)
 	cfg.Cache.Peers = normalizeCachePeers(cfg.Cache.Peers)
 	cfg.Gateway.Git.CacheHosts = trimStringSlice(cfg.Gateway.Git.CacheHosts)
 	cfg.Gateway.OCI.Registries = trimStringMap(cfg.Gateway.OCI.Registries)
@@ -470,6 +501,9 @@ func validateConfig(cfg Config) error {
 	if err := validateCacheConfig(cfg.Cache); err != nil {
 		return err
 	}
+	if err := validateAuthConfig(cfg.Auth); err != nil {
+		return err
+	}
 	if err := validateGatewayConfig(cfg.Gateway); err != nil {
 		return err
 	}
@@ -478,6 +512,146 @@ func validateConfig(cfg Config) error {
 	}
 	if err := validateObservabilityConfig(cfg.Observability); err != nil {
 		return err
+	}
+	return nil
+}
+
+func normalizeAuthConfig(cfg AuthConfig) AuthConfig {
+	cfg.PolicyFile = strings.TrimSpace(cfg.PolicyFile)
+	for i := range cfg.OIDC.Issuers {
+		issuer := &cfg.OIDC.Issuers[i]
+		issuer.Name = strings.TrimSpace(issuer.Name)
+		issuer.Issuer = strings.TrimRight(strings.TrimSpace(issuer.Issuer), "/")
+		issuer.JWKSURL = strings.TrimSpace(issuer.JWKSURL)
+		issuer.Audiences = trimStringSlice(issuer.Audiences)
+		issuer.AllowedAlgorithms = trimStringSlice(issuer.AllowedAlgorithms)
+		if len(issuer.AllowedAlgorithms) == 0 && issuerConfigHasValues(*issuer) {
+			issuer.AllowedAlgorithms = []string{"RS256"}
+		}
+		if issuer.ClockSkewSeconds == 0 && issuerConfigHasValues(*issuer) {
+			issuer.ClockSkewSeconds = DefaultAuthOIDCClockSkewSeconds
+		}
+		if issuer.MaxTokenLifetimeSeconds == 0 && issuerConfigHasValues(*issuer) {
+			issuer.MaxTokenLifetimeSeconds = DefaultAuthOIDCMaxTokenLifetimeSeconds
+		}
+	}
+	return cfg
+}
+
+func issuerConfigHasValues(cfg AuthOIDCIssuerConfig) bool {
+	return strings.TrimSpace(cfg.Name) != "" ||
+		strings.TrimSpace(cfg.Issuer) != "" ||
+		strings.TrimSpace(cfg.JWKSURL) != "" ||
+		len(cfg.Audiences) > 0 ||
+		len(cfg.AllowedAlgorithms) > 0 ||
+		cfg.ClockSkewSeconds != 0 ||
+		cfg.MaxTokenLifetimeSeconds != 0
+}
+
+func validateAuthConfig(cfg AuthConfig) error {
+	configured := cfg.Required || strings.TrimSpace(cfg.PolicyFile) != "" || len(cfg.OIDC.Issuers) > 0
+	if !configured {
+		return nil
+	}
+	if len(cfg.OIDC.Issuers) == 0 {
+		return errors.New("auth.oidc.issuers must contain at least one issuer when auth is configured")
+	}
+	if strings.TrimSpace(cfg.PolicyFile) == "" {
+		return errors.New("auth.policy_file is required when auth is configured")
+	}
+
+	seenNames := map[string]struct{}{}
+	seenIssuers := map[string]struct{}{}
+	for i, issuer := range cfg.OIDC.Issuers {
+		if strings.TrimSpace(issuer.Name) == "" {
+			return fmt.Errorf("auth.oidc.issuers[%d].name is required", i)
+		}
+		if strings.ContainsAny(issuer.Name, " \t\r\n/") {
+			return fmt.Errorf("auth.oidc.issuers[%d].name must not contain whitespace or slash", i)
+		}
+		if _, ok := seenNames[issuer.Name]; ok {
+			return fmt.Errorf("duplicate auth.oidc.issuers[%d].name %q", i, issuer.Name)
+		}
+		seenNames[issuer.Name] = struct{}{}
+
+		if strings.TrimSpace(issuer.Issuer) == "" {
+			return fmt.Errorf("auth.oidc.issuers[%d].issuer is required", i)
+		}
+		if err := validateAuthURL(issuer.Issuer); err != nil {
+			return fmt.Errorf("invalid auth.oidc.issuers[%d].issuer: %w", i, err)
+		}
+		if _, ok := seenIssuers[issuer.Issuer]; ok {
+			return fmt.Errorf("duplicate auth.oidc.issuers[%d].issuer %q", i, issuer.Issuer)
+		}
+		seenIssuers[issuer.Issuer] = struct{}{}
+
+		if len(issuer.Audiences) == 0 {
+			return fmt.Errorf("auth.oidc.issuers[%d].audiences must contain at least one audience", i)
+		}
+		if strings.TrimSpace(issuer.JWKSURL) == "" {
+			return fmt.Errorf("auth.oidc.issuers[%d].jwks_url is required", i)
+		}
+		if err := validateAuthURL(issuer.JWKSURL); err != nil {
+			return fmt.Errorf("invalid auth.oidc.issuers[%d].jwks_url: %w", i, err)
+		}
+		for j, alg := range issuer.AllowedAlgorithms {
+			switch alg {
+			case "RS256":
+			default:
+				return fmt.Errorf("unsupported auth.oidc.issuers[%d].allowed_algorithms[%d] %q (expected RS256)", i, j, alg)
+			}
+		}
+		if issuer.ClockSkewSeconds < 0 {
+			return fmt.Errorf("auth.oidc.issuers[%d].clock_skew_seconds must be non-negative", i)
+		}
+		if issuer.MaxTokenLifetimeSeconds <= 0 {
+			return fmt.Errorf("auth.oidc.issuers[%d].max_token_lifetime_seconds must be positive", i)
+		}
+	}
+	return nil
+}
+
+func validateAuthURL(value string) error {
+	parsed, err := url.Parse(value)
+	if err != nil {
+		return err
+	}
+	switch parsed.Scheme {
+	case "https":
+	case "http":
+		if !isLoopbackHost(parsed.Hostname()) {
+			return errors.New("http scheme is only allowed for loopback hosts")
+		}
+	default:
+		return fmt.Errorf("unsupported scheme %q (expected https, or http for loopback)", parsed.Scheme)
+	}
+	if parsed.Host == "" {
+		return errors.New("must include a host")
+	}
+	return nil
+}
+
+func isLoopbackHost(host string) bool {
+	host = strings.TrimSpace(host)
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+func validateHTTPURL(value string) error {
+	parsed, err := url.Parse(value)
+	if err != nil {
+		return err
+	}
+	switch parsed.Scheme {
+	case "http", "https":
+	default:
+		return fmt.Errorf("unsupported scheme %q (expected http or https)", parsed.Scheme)
+	}
+	if parsed.Host == "" {
+		return errors.New("must include a host")
 	}
 	return nil
 }

--- a/internal/runtimeconfig/config_test.go
+++ b/internal/runtimeconfig/config_test.go
@@ -147,6 +147,151 @@ cache:
 	}
 }
 
+func TestLoadParsesAuthOIDCConfig(t *testing.T) {
+	cfg, err := loadConfigFromContent(t, `default_backend: firecracker
+auth:
+  required: true
+  oidc:
+    issuers:
+      - name: " github-actions "
+        issuer: " https://token.actions.githubusercontent.com/ "
+        audiences:
+          - " cleanroom "
+        jwks_url: " https://token.actions.githubusercontent.com/.well-known/jwks "
+  policy_file: " ~/.config/cleanroom/auth-policy.yaml "
+`)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if !cfg.Auth.Required {
+		t.Fatal("expected auth.required")
+	}
+	if got, want := cfg.Auth.PolicyFile, "~/.config/cleanroom/auth-policy.yaml"; got != want {
+		t.Fatalf("unexpected auth policy file: got %q want %q", got, want)
+	}
+	if got, want := len(cfg.Auth.OIDC.Issuers), 1; got != want {
+		t.Fatalf("unexpected issuer count: got %d want %d", got, want)
+	}
+	issuer := cfg.Auth.OIDC.Issuers[0]
+	if got, want := issuer.Name, "github-actions"; got != want {
+		t.Fatalf("unexpected issuer name: got %q want %q", got, want)
+	}
+	if got, want := issuer.Issuer, "https://token.actions.githubusercontent.com"; got != want {
+		t.Fatalf("unexpected issuer URL: got %q want %q", got, want)
+	}
+	if got, want := issuer.Audiences, []string{"cleanroom"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected audiences: got %v want %v", got, want)
+	}
+	if got, want := issuer.AllowedAlgorithms, []string{"RS256"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected allowed algorithms: got %v want %v", got, want)
+	}
+	if got, want := issuer.ClockSkewSeconds, DefaultAuthOIDCClockSkewSeconds; got != want {
+		t.Fatalf("unexpected clock skew: got %d want %d", got, want)
+	}
+	if got, want := issuer.MaxTokenLifetimeSeconds, DefaultAuthOIDCMaxTokenLifetimeSeconds; got != want {
+		t.Fatalf("unexpected max token lifetime: got %d want %d", got, want)
+	}
+}
+
+func TestLoadRejectsInvalidAuthOIDCConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		auth    string
+		wantErr string
+	}{
+		{
+			name: "missing issuers",
+			auth: `auth:
+  required: true
+  policy_file: ./auth-policy.yaml
+`,
+			wantErr: "auth.oidc.issuers must contain at least one issuer",
+		},
+		{
+			name: "missing policy file",
+			auth: `auth:
+  required: true
+  oidc:
+    issuers:
+      - name: github-actions
+        issuer: https://token.actions.githubusercontent.com
+        audiences: [cleanroom]
+        jwks_url: https://token.actions.githubusercontent.com/.well-known/jwks
+`,
+			wantErr: "auth.policy_file is required",
+		},
+		{
+			name: "missing audience",
+			auth: `auth:
+  required: true
+  oidc:
+    issuers:
+      - name: github-actions
+        issuer: https://token.actions.githubusercontent.com
+        jwks_url: https://token.actions.githubusercontent.com/.well-known/jwks
+  policy_file: ./auth-policy.yaml
+`,
+			wantErr: "auth.oidc.issuers[0].audiences must contain at least one audience",
+		},
+		{
+			name: "bad issuer url",
+			auth: `auth:
+  required: true
+  oidc:
+    issuers:
+      - name: github-actions
+        issuer: not-a-url
+        audiences: [cleanroom]
+        jwks_url: https://token.actions.githubusercontent.com/.well-known/jwks
+  policy_file: ./auth-policy.yaml
+`,
+			wantErr: "invalid auth.oidc.issuers[0].issuer",
+		},
+		{
+			name: "unsupported algorithm",
+			auth: `auth:
+  required: true
+  oidc:
+    issuers:
+      - name: github-actions
+        issuer: https://token.actions.githubusercontent.com
+        audiences: [cleanroom]
+        jwks_url: https://token.actions.githubusercontent.com/.well-known/jwks
+        allowed_algorithms: [none]
+  policy_file: ./auth-policy.yaml
+`,
+			wantErr: `unsupported auth.oidc.issuers[0].allowed_algorithms[0] "none"`,
+		},
+		{
+			name: "remote http jwks",
+			auth: `auth:
+  required: true
+  oidc:
+    issuers:
+      - name: github-actions
+        issuer: https://token.actions.githubusercontent.com
+        audiences: [cleanroom]
+        jwks_url: http://metadata.example/.well-known/jwks
+  policy_file: ./auth-policy.yaml
+`,
+			wantErr: "http scheme is only allowed for loopback hosts",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := loadConfigFromContent(t, "default_backend: firecracker\n"+tt.auth)
+			if err == nil {
+				t.Fatal("expected Load to reject invalid auth config")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error to contain %q, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
 func TestLoadSupportsDarwinVZMinimumRootFSBytes(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)


### PR DESCRIPTION
Shared Cleanroom servers need a way to trust bot identity and test grants locally before server enforcement starts. This PR lands the first slice of the multi-principal auth plan without changing control server behavior yet.

What changes:

- Adds runtime auth config for OIDC issuers, audiences, JWKS URLs, allowed algorithms, clock skew, token lifetime, and the auth policy file.
- Adds an internal auth engine that validates OIDC JWTs, maps trusted claims to a Cleanroom principal, compiles typed grants with CEL conditions, and returns allow/deny decisions.
- Adds `cleanroom auth check` so operators can test a token, action, resource, and JSON request fixture without starting `cleanroom serve`.
- Documents the broader rollout plan, including the boundary for embedded and standalone `content-cache`.

Example:

```bash
cleanroom auth check \
  --config ./config.yaml \
  --token-file /tmp/token.jwt \
  --action sandbox.create \
  --request create-sandbox.json \
  --json
```

The next slice is where this starts enforcing on the control server: owner stamping, exact-principal checks, create-time constraints, gateway authorization envelopes for embedded `content-cache`, and owner-scoped stage-cache lookup.

Checked locally with `mise run check`.