### PR TITLE
fix: Avoid stale darwin-vz guest agent aliases

### DIFF
--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -2700,8 +2700,8 @@ func discoverGuestAgentBinaryWith(
 		if self, err := executable(); err == nil {
 			dirs := executableSearchDirs(self)
 			for _, dir := range dirs {
-				candidates = append(candidates, filepath.Join(dir, linuxName))
 				candidates = append(candidates, filepath.Join(dir, "cleanroom-guest-agent"))
+				candidates = append(candidates, filepath.Join(dir, linuxName))
 			}
 		}
 	}

--- a/internal/backend/darwinvz/guest_agent_path_test.go
+++ b/internal/backend/darwinvz/guest_agent_path_test.go
@@ -70,6 +70,39 @@ func TestDiscoverGuestAgentBinaryUsesSiblingBeforePATH(t *testing.T) {
 	}
 }
 
+func TestDiscoverGuestAgentBinaryPrefersGenericSiblingBeforeArchAlias(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	self := tmp + "/cleanroom"
+	genericSibling := tmp + "/cleanroom-guest-agent"
+	archSibling := tmp + "/cleanroom-guest-agent-linux-arm64"
+	if err := os.WriteFile(self, []byte("binary"), 0o755); err != nil {
+		t.Fatalf("write self binary: %v", err)
+	}
+	if err := os.WriteFile(genericSibling, []byte("binary"), 0o755); err != nil {
+		t.Fatalf("write generic sibling guest agent: %v", err)
+	}
+	if err := os.WriteFile(archSibling, []byte("binary"), 0o755); err != nil {
+		t.Fatalf("write arch sibling guest agent: %v", err)
+	}
+
+	got, err := discoverGuestAgentBinaryWith(
+		"arm64",
+		func(string) (string, error) { return "", errors.New("no path") },
+		func() (string, error) { return self, nil },
+		func() (string, error) { return "", errors.New("no working directory") },
+		os.Stat,
+		func(path string) (bool, error) { return path == genericSibling || path == archSibling, nil },
+	)
+	if err != nil {
+		t.Fatalf("discoverGuestAgentBinaryWith returned error: %v", err)
+	}
+	if got != genericSibling {
+		t.Fatalf("unexpected guest agent path: got %q want %q", got, genericSibling)
+	}
+}
+
 func TestDiscoverGuestAgentBinaryPrefersSiblingBeforeAncestorDist(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -209,6 +209,15 @@ install_binary() {
   run_with_optional_sudo install -m 0755 "$src" "$dst"
 }
 
+remove_legacy_darwin_guest_agent_arch_alias() {
+  local path
+
+  [ "$HOST_OS" = "Darwin" ] || return 0
+  path="${INSTALL_DIR}/cleanroom-guest-agent-linux-${HOST_GOARCH}"
+  [ -e "$path" ] || return 0
+  run_with_optional_sudo rm -f "$path"
+}
+
 install_app_bundle() {
   local src="$1"
   local dst="$2"
@@ -401,6 +410,7 @@ try_install_notarized_macos_pkg() {
     warn "failed to install notarized macOS package: ${pkg_asset}; falling back to archive install"
     return 1
   fi
+  remove_legacy_darwin_guest_agent_arch_alias
 
   log "Installed cleanroom via notarized macOS package"
   log "Installed cleanroom to ${INSTALL_DIR}/cleanroom"
@@ -447,8 +457,14 @@ case "$HOST_OS_RAW" in
 esac
 
 case "$HOST_ARCH_RAW" in
-  x86_64|amd64) HOST_ARCH="x86_64" ;;
-  arm64|aarch64) HOST_ARCH="arm64" ;;
+  x86_64|amd64)
+    HOST_ARCH="x86_64"
+    HOST_GOARCH="amd64"
+    ;;
+  arm64|aarch64)
+    HOST_ARCH="arm64"
+    HOST_GOARCH="arm64"
+    ;;
   *) die "unsupported architecture: ${HOST_ARCH_RAW}" ;;
 esac
 
@@ -542,6 +558,7 @@ fi
 prepare_install_dir
 install_binary "${CLEANROOM_EXTRACT_DIR}/cleanroom" "${INSTALL_DIR}/cleanroom"
 install_binary "${CLEANROOM_EXTRACT_DIR}/cleanroom-guest-agent" "${INSTALL_DIR}/cleanroom-guest-agent"
+remove_legacy_darwin_guest_agent_arch_alias
 
 if [ "$HOST_OS" = "Darwin" ] && [ "$INSTALL_DARWIN_HELPER" != "0" ]; then
   HELPER_BUNDLE_SRC="${CLEANROOM_EXTRACT_DIR}/cleanroom-darwin-vz.app"

--- a/scripts/install_test.go
+++ b/scripts/install_test.go
@@ -4,6 +4,7 @@ package scripts_test
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -120,6 +121,40 @@ printf '%s\n' "$*" >> "$SUDO_CALLS"
 	want := cleanroomPath + " daemon install --init-config --restart"
 	if got != want {
 		t.Fatalf("unexpected sudo daemon command: got %q want %q", got, want)
+	}
+}
+
+func TestInstallScriptRemovesDarwinGuestAgentArchAlias(t *testing.T) {
+	content, err := os.ReadFile("install.sh")
+	if err != nil {
+		t.Fatalf("read install.sh: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	aliasPath := filepath.Join(tmpDir, "cleanroom-guest-agent-linux-arm64")
+	if err := os.WriteFile(aliasPath, []byte("stale guest-agent"), 0o755); err != nil {
+		t.Fatalf("write guest agent alias: %v", err)
+	}
+
+	script := strings.Join([]string{
+		"declare -a SUDO_CMD=()",
+		shellFunction(t, string(content), "run_with_optional_sudo"),
+		shellFunction(t, string(content), "remove_legacy_darwin_guest_agent_arch_alias"),
+		`HOST_OS=Darwin`,
+		`HOST_GOARCH=arm64`,
+		`INSTALL_DIR="$TEST_INSTALL_DIR"`,
+		`remove_legacy_darwin_guest_agent_arch_alias`,
+	}, "\n")
+
+	cmd := exec.Command("bash", "-c", script)
+	cmd.Env = append(os.Environ(), "TEST_INSTALL_DIR="+tmpDir)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("remove_legacy_darwin_guest_agent_arch_alias failed: %v\n%s", err, out)
+	}
+
+	if _, err := os.Stat(aliasPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected guest agent alias to be removed, got err %v", err)
 	}
 }
 


### PR DESCRIPTION
Cleanroom's macOS install path could leave an old `/usr/local/bin/cleanroom-guest-agent-linux-<arch>` binary next to a newer release-installed `cleanroom-guest-agent`. The darwin-vz adapter checked that arch-suffixed name first, so a stale guest agent could be injected into prepared runtime rootfs and fail sandbox startup with:

```text
decode guest readiness probe over darwin-vz proxy: missing stream frame type
```

This makes release installs prefer the current sibling `cleanroom-guest-agent` and removes the legacy arch alias during macOS installs after the current agent is installed. Local and development builds can still use the arch-specific `dist/cleanroom-guest-agent-linux-<arch>` fallback.