### PR TITLE
feat: Wake suspended sandboxes on guest operations

### DIFF
--- a/docs/plans/sandbox-suspend-wake.md
+++ b/docs/plans/sandbox-suspend-wake.md
@@ -1,7 +1,7 @@
 # Transparent Sandbox Suspend And Wake Plan
 
 **Status:** Active
-**Last reviewed:** 2026-05-24
+**Last reviewed:** 2026-05-27
 **Spec references:** `docs/api.md`, `docs/snapshots.md`, `docs/backend/darwin-vz.md`
 **Related plans:** `docs/plans/system-storage-prune.md`, `docs/plans/layered-caching.md`
 
@@ -99,14 +99,20 @@ changing guest bootstrap, repository bootstrap, or snapshot storage.
 
 ## Current Progress
 
-Slice 1 has been implemented in this change: lifecycle statuses, backend
-capability inference, explicit suspend/resume RPCs, control-client and
-control-server plumbing, manual CLI commands, `darwin-vz` helper calls, and
-focused unit and integration tests.
+Slice 1 has landed: lifecycle statuses, backend capability inference, explicit
+suspend/resume RPCs, control-client and control-server plumbing, manual CLI
+commands, `darwin-vz` helper calls, and focused unit and integration tests.
 
-Transparent wake gates, the idle suspend scheduler, runtime config, metrics,
-real installed-daemon smoke tests, and Firecracker support remain follow-up
-slices.
+Slice 2 is implemented in this change: guest-touching operations now wake
+suspended sandboxes before execution, file transfer, snapshot creation, or
+sandbox port dialing. Client-side local exposure registration also accepts a
+suspended sandbox when the backend advertises suspend and port-dial support, so
+the incoming connection wakes through `DialSandboxPort`. Active port dials hold
+a guest-interaction lease so later idle-suspend work has a concrete busy marker
+for open tunnels.
+
+The idle suspend scheduler, runtime config, metrics, real installed-daemon
+smoke tests, and Firecracker support remain follow-up slices.
 
 ## Target Lifecycle Model
 

--- a/internal/cli/local_exposure.go
+++ b/internal/cli/local_exposure.go
@@ -88,7 +88,13 @@ func ensureSandboxPortDialSupported(ctx context.Context, client *controlclient.C
 	if sandbox == nil {
 		return errors.New("sandbox lookup returned no sandbox")
 	}
-	if sandbox.GetStatus() != cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY {
+	switch sandbox.GetStatus() {
+	case cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY:
+	case cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDED:
+		if !sandbox.GetBackendCapabilities()[backend.CapabilitySandboxSuspend] {
+			return fmt.Errorf("sandbox %q is suspended but backend %q does not support sandbox wake", sandboxID, sandbox.GetBackend())
+		}
+	default:
 		return fmt.Errorf("sandbox %q is not ready", sandboxID)
 	}
 	if !sandbox.GetBackendCapabilities()[backend.CapabilitySandboxPortDial] {

--- a/internal/cli/local_exposure_test.go
+++ b/internal/cli/local_exposure_test.go
@@ -2,9 +2,11 @@ package cli
 
 import (
 	"context"
+	"net"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -20,6 +22,10 @@ import (
 
 type localExposureTestAdapter struct {
 	capabilities map[string]bool
+}
+
+type localExposureSuspendAdapter struct {
+	localExposureTestAdapter
 }
 
 func (a *localExposureTestAdapter) Name() string { return "firecracker" }
@@ -40,6 +46,14 @@ func (a *localExposureTestAdapter) TerminateSandbox(context.Context, string) err
 	return nil
 }
 
+func (a *localExposureSuspendAdapter) SuspendSandbox(context.Context, string) error {
+	return nil
+}
+
+func (a *localExposureSuspendAdapter) ResumeSandbox(context.Context, string) error {
+	return nil
+}
+
 func TestStartClientExposuresRejectsUnsupportedSandboxPortDial(t *testing.T) {
 	client, sandboxID := newLocalExposureTestClient(t, &localExposureTestAdapter{
 		capabilities: map[string]bool{backend.CapabilitySandboxPortDial: false},
@@ -57,6 +71,32 @@ func TestStartClientExposuresRejectsUnsupportedSandboxPortDial(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "does not support sandbox port dialing") {
 		t.Fatalf("unexpected startClientExposures error: %v", err)
+	}
+}
+
+func TestStartClientExposuresAllowsSuspendedWakeableSandbox(t *testing.T) {
+	client, sandboxID := newLocalExposureTestClient(t, &localExposureSuspendAdapter{
+		localExposureTestAdapter: localExposureTestAdapter{
+			capabilities: map[string]bool{
+				backend.CapabilitySandboxPortDial: true,
+				backend.CapabilitySandboxSuspend:  true,
+			},
+		},
+	})
+	if _, err := client.SuspendSandbox(context.Background(), &cleanroomv1.SuspendSandboxRequest{SandboxId: sandboxID}); err != nil {
+		t.Fatalf("SuspendSandbox returned error: %v", err)
+	}
+
+	manager, _, err := startClientExposures(context.Background(), client, sandboxID, []*cleanroomv1.PortExposure{{
+		Protocol:  exposureProtocolTCP,
+		HostPort:  int32(freeLocalExposureTCPPort(t)),
+		GuestPort: 3000,
+	}})
+	if manager != nil {
+		_ = manager.Close()
+	}
+	if err != nil {
+		t.Fatalf("startClientExposures returned error: %v", err)
 	}
 }
 
@@ -121,4 +161,22 @@ func newLocalExposureTestClient(t *testing.T, adapter backend.Adapter) (*control
 		t.Fatal("CreateSandbox returned empty sandbox id")
 	}
 	return client, sandboxID
+}
+
+func freeLocalExposureTCPPort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen on free TCP port: %v", err)
+	}
+	defer ln.Close()
+	_, port, err := net.SplitHostPort(ln.Addr().String())
+	if err != nil {
+		t.Fatalf("split listen address %q: %v", ln.Addr().String(), err)
+	}
+	n, err := strconv.Atoi(port)
+	if err != nil {
+		t.Fatalf("parse listen port %q: %v", port, err)
+	}
+	return n
 }

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -1299,6 +1299,9 @@ func (s *Service) CreateSnapshot(ctx context.Context, req *cleanroomv1.CreateSna
 		snapshotAdapter backend.SnapshottingAdapter
 	)
 
+	if err := s.ensureSandboxSnapshotSupported(sandboxID); err != nil {
+		return nil, err
+	}
 	if err := s.ensureSandboxReadyForGuestOperation(ctx, sandboxID); err != nil {
 		return nil, err
 	}
@@ -1490,6 +1493,41 @@ func (s *Service) DeleteSnapshot(ctx context.Context, req *cleanroomv1.DeleteSna
 		Deleted:    true,
 		Message:    "snapshot deleted",
 	}, nil
+}
+
+func (s *Service) ensureSandboxSnapshotSupported(sandboxID string) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	state, ok := s.sandboxes[sandboxID]
+	if !ok {
+		return fmt.Errorf("unknown sandbox %q", sandboxID)
+	}
+	switch state.Status {
+	case cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY,
+		cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDED,
+		cleanroomv1.SandboxStatus_SANDBOX_STATUS_WAKING:
+	default:
+		return fmt.Errorf("sandbox %q is not ready", sandboxID)
+	}
+	adapter, ok := s.Backends[state.Backend]
+	if !ok {
+		return fmt.Errorf("unknown backend %q", state.Backend)
+	}
+	capabilities := state.Capabilities
+	if capabilities == nil {
+		capabilities = backend.CapabilitiesForAdapter(adapter)
+	}
+	if !capabilities[backend.CapabilitySandboxSnapshot] {
+		return fmt.Errorf("backend %q does not support snapshots", state.Backend)
+	}
+	if _, ok := adapter.(backend.SnapshottingAdapter); !ok {
+		return fmt.Errorf("backend %q does not support snapshots", state.Backend)
+	}
+	if !snapshotOperationsEnabledForBackend(state.Backend, s.Config) {
+		return fmt.Errorf("snapshots are not enabled for backend %q", state.Backend)
+	}
+	return nil
 }
 
 func (s *Service) DownloadSandboxFile(ctx context.Context, req *cleanroomv1.DownloadSandboxFileRequest) (*cleanroomv1.DownloadSandboxFileResponse, error) {

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -73,6 +73,7 @@ type Service struct {
 	executions        map[string]*executionState
 	snapshotOps       map[string]int
 	snapshotDeletions map[string]struct{}
+	sandboxWakeOps    singleflight.Group
 }
 
 type storageCleanupScheduler struct {
@@ -118,6 +119,7 @@ type sandboxState struct {
 	RepositoryBusy                      bool
 	ActiveExecutionID                   string
 	FileTransferInProgress              bool
+	GuestInteractionCount               int
 	CreatedAt                           time.Time
 	UpdatedAt                           time.Time
 	LastExecutionID                     string
@@ -1111,6 +1113,31 @@ func (s *Service) ResumeSandbox(ctx context.Context, req *cleanroomv1.ResumeSand
 	}
 	sandboxID := strings.TrimSpace(req.GetSandboxId())
 
+	result, err, _ := s.sandboxWakeOps.Do(sandboxID, func() (any, error) {
+		return s.resumeSandbox(ctx, sandboxID, false)
+	})
+	if err != nil {
+		return nil, err
+	}
+	sandbox, ok := result.(*cleanroomv1.Sandbox)
+	if !ok || sandbox == nil {
+		return nil, fmt.Errorf("resume sandbox %q returned no sandbox", sandboxID)
+	}
+	return &cleanroomv1.ResumeSandboxResponse{Sandbox: sandbox}, nil
+}
+
+func (s *Service) ensureSandboxReadyForGuestOperation(ctx context.Context, sandboxID string) error {
+	sandboxID = strings.TrimSpace(sandboxID)
+	if sandboxID == "" {
+		return errors.New("missing sandbox_id")
+	}
+	_, err, _ := s.sandboxWakeOps.Do(sandboxID, func() (any, error) {
+		return s.resumeSandbox(ctx, sandboxID, true)
+	})
+	return err
+}
+
+func (s *Service) resumeSandbox(ctx context.Context, sandboxID string, guestOperation bool) (*cleanroomv1.Sandbox, error) {
 	var resumable backend.SuspendableAdapter
 
 	s.mu.Lock()
@@ -1121,9 +1148,16 @@ func (s *Service) ResumeSandbox(ctx context.Context, req *cleanroomv1.ResumeSand
 		return nil, fmt.Errorf("unknown sandbox %q", sandboxID)
 	}
 	if state.Status == cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY {
-		resp := &cleanroomv1.ResumeSandboxResponse{Sandbox: cloneSandboxLocked(state)}
+		resp := cloneSandboxLocked(state)
 		s.mu.Unlock()
 		return resp, nil
+	}
+	if state.Status != cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDED {
+		s.mu.Unlock()
+		if guestOperation {
+			return nil, fmt.Errorf("sandbox %q is not ready", sandboxID)
+		}
+		return nil, fmt.Errorf("sandbox %q is not suspended", sandboxID)
 	}
 	adapter, ok := s.Backends[state.Backend]
 	if !ok {
@@ -1142,10 +1176,6 @@ func (s *Service) ResumeSandbox(ctx context.Context, req *cleanroomv1.ResumeSand
 	if !ok {
 		s.mu.Unlock()
 		return nil, fmt.Errorf("backend_capability_mismatch: backend %q reports sandbox suspend but does not implement it", state.Backend)
-	}
-	if state.Status != cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDED {
-		s.mu.Unlock()
-		return nil, fmt.Errorf("sandbox %q is not suspended", sandboxID)
 	}
 	s.recordSandboxEventLocked(state, cleanroomv1.SandboxStatus_SANDBOX_STATUS_WAKING, "sandbox wake requested")
 	s.mu.Unlock()
@@ -1173,7 +1203,7 @@ func (s *Service) ResumeSandbox(ctx context.Context, req *cleanroomv1.ResumeSand
 	if current.Status == cleanroomv1.SandboxStatus_SANDBOX_STATUS_WAKING {
 		s.recordSandboxEventLocked(current, cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY, "sandbox ready after wake")
 	}
-	return &cleanroomv1.ResumeSandboxResponse{Sandbox: cloneSandboxLocked(current)}, nil
+	return cloneSandboxLocked(current), nil
 }
 
 func isIndeterminateSandboxLifecycleError(err error) bool {
@@ -1254,6 +1284,10 @@ func (s *Service) CreateSnapshot(ctx context.Context, req *cleanroomv1.CreateSna
 		record          snapshotstore.Record
 		snapshotAdapter backend.SnapshottingAdapter
 	)
+
+	if err := s.ensureSandboxReadyForGuestOperation(ctx, sandboxID); err != nil {
+		return nil, err
+	}
 
 	s.mu.Lock()
 	s.ensureMapsLocked()
@@ -1465,49 +1499,16 @@ func (s *Service) DownloadSandboxFile(ctx context.Context, req *cleanroomv1.Down
 		maxBytes = s.downloadMaxBytesDefault()
 	}
 
-	s.mu.Lock()
-	state, ok := s.sandboxes[sandboxID]
-	if !ok {
-		s.mu.Unlock()
-		return nil, fmt.Errorf("unknown sandbox %q", sandboxID)
+	adapter, backendName, finish, err := s.beginSandboxFileTransfer(ctx, sandboxID)
+	if err != nil {
+		return nil, err
 	}
-	if state.Status != cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY {
-		s.mu.Unlock()
-		return nil, fmt.Errorf("sandbox %q is not ready", sandboxID)
-	}
-	adapter, ok := s.Backends[state.Backend]
-	if !ok {
-		s.mu.Unlock()
-		return nil, fmt.Errorf("unknown backend %q", state.Backend)
-	}
+	defer finish()
+
 	downloader, ok := adapter.(backend.SandboxFileDownloadAdapter)
 	if !ok {
-		s.mu.Unlock()
-		return nil, fmt.Errorf("backend %q does not support sandbox file downloads", state.Backend)
+		return nil, fmt.Errorf("backend %q does not support sandbox file downloads", backendName)
 	}
-	if state.FileTransferInProgress {
-		s.mu.Unlock()
-		return nil, fmt.Errorf("sandbox_busy: sandbox %q already has an active file transfer", sandboxID)
-	}
-	if state.RepositoryBusy {
-		s.mu.Unlock()
-		return nil, fmt.Errorf("sandbox_busy: sandbox %q is preparing repository state", sandboxID)
-	}
-	if activeID := strings.TrimSpace(state.ActiveExecutionID); activeID != "" {
-		if activeExecution, ok := s.executions[executionKey(sandboxID, activeID)]; ok && !isFinalExecutionStatus(activeExecution.Status) {
-			s.mu.Unlock()
-			return nil, fmt.Errorf("sandbox_busy: sandbox %q already has active execution %q", sandboxID, activeID)
-		}
-	}
-	state.FileTransferInProgress = true
-	s.mu.Unlock()
-	defer func() {
-		s.mu.Lock()
-		if current, ok := s.sandboxes[sandboxID]; ok {
-			current.FileTransferInProgress = false
-		}
-		s.mu.Unlock()
-	}()
 
 	data, err := downloader.DownloadSandboxFile(ctx, sandboxID, path, maxBytes)
 	if err != nil {
@@ -1543,49 +1544,16 @@ func (s *Service) UploadSandboxFile(ctx context.Context, req *cleanroomv1.Upload
 		return nil, fmt.Errorf("upload data exceeds max_bytes=%d", maxBytes)
 	}
 
-	s.mu.Lock()
-	state, ok := s.sandboxes[sandboxID]
-	if !ok {
-		s.mu.Unlock()
-		return nil, fmt.Errorf("unknown sandbox %q", sandboxID)
+	adapter, backendName, finish, err := s.beginSandboxFileTransfer(ctx, sandboxID)
+	if err != nil {
+		return nil, err
 	}
-	if state.Status != cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY {
-		s.mu.Unlock()
-		return nil, fmt.Errorf("sandbox %q is not ready", sandboxID)
-	}
-	adapter, ok := s.Backends[state.Backend]
-	if !ok {
-		s.mu.Unlock()
-		return nil, fmt.Errorf("unknown backend %q", state.Backend)
-	}
+	defer finish()
+
 	uploader, ok := adapter.(backend.SandboxFileUploadAdapter)
 	if !ok {
-		s.mu.Unlock()
-		return nil, fmt.Errorf("backend %q does not support sandbox file uploads", state.Backend)
+		return nil, fmt.Errorf("backend %q does not support sandbox file uploads", backendName)
 	}
-	if state.FileTransferInProgress {
-		s.mu.Unlock()
-		return nil, fmt.Errorf("sandbox_busy: sandbox %q already has an active file transfer", sandboxID)
-	}
-	if state.RepositoryBusy {
-		s.mu.Unlock()
-		return nil, fmt.Errorf("sandbox_busy: sandbox %q is preparing repository state", sandboxID)
-	}
-	if activeID := strings.TrimSpace(state.ActiveExecutionID); activeID != "" {
-		if activeExecution, ok := s.executions[executionKey(sandboxID, activeID)]; ok && !isFinalExecutionStatus(activeExecution.Status) {
-			s.mu.Unlock()
-			return nil, fmt.Errorf("sandbox_busy: sandbox %q already has active execution %q", sandboxID, activeID)
-		}
-	}
-	state.FileTransferInProgress = true
-	s.mu.Unlock()
-	defer func() {
-		s.mu.Lock()
-		if current, ok := s.sandboxes[sandboxID]; ok {
-			current.FileTransferInProgress = false
-		}
-		s.mu.Unlock()
-	}()
 
 	if err := uploader.UploadSandboxFile(ctx, sandboxID, path, data, mode); err != nil {
 		return nil, fmt.Errorf("upload sandbox file: %w", err)
@@ -1605,7 +1573,7 @@ func (s *Service) StatSandboxPath(ctx context.Context, req *cleanroomv1.StatSand
 	if err != nil {
 		return nil, err
 	}
-	adapter, backendName, finish, err := s.beginSandboxFileTransfer(sandboxID)
+	adapter, backendName, finish, err := s.beginSandboxFileTransfer(ctx, sandboxID)
 	if err != nil {
 		return nil, err
 	}
@@ -1630,7 +1598,7 @@ func (s *Service) WalkSandboxTree(ctx context.Context, req *cleanroomv1.WalkSand
 	if err != nil {
 		return err
 	}
-	adapter, backendName, finish, err := s.beginSandboxFileTransfer(sandboxID)
+	adapter, backendName, finish, err := s.beginSandboxFileTransfer(ctx, sandboxID)
 	if err != nil {
 		return err
 	}
@@ -1663,7 +1631,7 @@ func (s *Service) ReadSandboxFile(ctx context.Context, req *cleanroomv1.ReadSand
 	if maxBytes <= 0 {
 		maxBytes = s.downloadMaxBytesDefault()
 	}
-	adapter, backendName, finish, err := s.beginSandboxFileTransfer(sandboxID)
+	adapter, backendName, finish, err := s.beginSandboxFileTransfer(ctx, sandboxID)
 	if err != nil {
 		return err
 	}
@@ -1699,35 +1667,88 @@ func (s *Service) DialSandboxPort(ctx context.Context, req *cleanroomv1.SandboxP
 	if port < 1 || port > 65535 {
 		return nil, fmt.Errorf("invalid guest port %d", port)
 	}
+	if err := s.ensureSandboxPortDialSupported(sandboxID); err != nil {
+		return nil, err
+	}
+	if err := s.ensureSandboxReadyForGuestOperation(ctx, sandboxID); err != nil {
+		return nil, err
+	}
 
-	s.mu.RLock()
+	s.mu.Lock()
 	state, ok := s.sandboxes[sandboxID]
 	if !ok {
-		s.mu.RUnlock()
+		s.mu.Unlock()
 		return nil, fmt.Errorf("unknown sandbox %q", sandboxID)
 	}
 	if state.Status != cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY {
-		s.mu.RUnlock()
+		s.mu.Unlock()
 		return nil, fmt.Errorf("sandbox %q is not ready", sandboxID)
 	}
 	adapter, ok := s.Backends[state.Backend]
 	backendName := state.Backend
 	capabilities := state.Capabilities
-	s.mu.RUnlock()
 	if !ok {
+		s.mu.Unlock()
 		return nil, fmt.Errorf("unknown backend %q", backendName)
 	}
 	if capabilities == nil {
 		capabilities = backend.CapabilitiesForAdapter(adapter)
 	}
 	if !capabilities[backend.CapabilitySandboxPortDial] {
+		s.mu.Unlock()
 		return nil, fmt.Errorf("backend %q does not support sandbox port dialing", backendName)
 	}
 	dialer, ok := adapter.(backend.SandboxPortDialer)
 	if !ok {
+		s.mu.Unlock()
 		return nil, fmt.Errorf("backend %q does not support sandbox port dialing", backendName)
 	}
-	return dialer.DialSandboxPort(ctx, sandboxID, port)
+	state.GuestInteractionCount++
+	s.mu.Unlock()
+
+	release := s.finishSandboxGuestInteractionOnce(sandboxID)
+	conn, err := dialer.DialSandboxPort(ctx, sandboxID, port)
+	if err != nil {
+		release()
+		return nil, err
+	}
+	if conn == nil {
+		release()
+		return nil, fmt.Errorf("backend %q returned no sandbox port connection", backendName)
+	}
+	return &sandboxGuestInteractionConn{Conn: conn, release: release}, nil
+}
+
+func (s *Service) ensureSandboxPortDialSupported(sandboxID string) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	state, ok := s.sandboxes[sandboxID]
+	if !ok {
+		return fmt.Errorf("unknown sandbox %q", sandboxID)
+	}
+	switch state.Status {
+	case cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY,
+		cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDED,
+		cleanroomv1.SandboxStatus_SANDBOX_STATUS_WAKING:
+	default:
+		return fmt.Errorf("sandbox %q is not ready", sandboxID)
+	}
+	adapter, ok := s.Backends[state.Backend]
+	if !ok {
+		return fmt.Errorf("unknown backend %q", state.Backend)
+	}
+	capabilities := state.Capabilities
+	if capabilities == nil {
+		capabilities = backend.CapabilitiesForAdapter(adapter)
+	}
+	if !capabilities[backend.CapabilitySandboxPortDial] {
+		return fmt.Errorf("backend %q does not support sandbox port dialing", state.Backend)
+	}
+	if _, ok := adapter.(backend.SandboxPortDialer); !ok {
+		return fmt.Errorf("backend %q does not support sandbox port dialing", state.Backend)
+	}
+	return nil
 }
 
 func (s *Service) WriteSandboxFile(ctx context.Context, init *cleanroomv1.WriteSandboxFileInit, r io.Reader) (*cleanroomv1.WriteSandboxFileResponse, error) {
@@ -1746,7 +1767,7 @@ func (s *Service) WriteSandboxFile(ctx context.Context, init *cleanroomv1.WriteS
 	if init.GetMtime() != nil {
 		mtime = init.GetMtime().AsTime()
 	}
-	adapter, backendName, finish, err := s.beginSandboxFileTransfer(sandboxID)
+	adapter, backendName, finish, err := s.beginSandboxFileTransfer(ctx, sandboxID)
 	if err != nil {
 		return nil, err
 	}
@@ -1775,7 +1796,7 @@ func (s *Service) RemoveSandboxPath(ctx context.Context, req *cleanroomv1.Remove
 	if err != nil {
 		return nil, err
 	}
-	adapter, backendName, finish, err := s.beginSandboxFileTransfer(sandboxID)
+	adapter, backendName, finish, err := s.beginSandboxFileTransfer(ctx, sandboxID)
 	if err != nil {
 		return nil, err
 	}
@@ -1811,7 +1832,7 @@ func (s *Service) ArchiveSandboxPaths(ctx context.Context, req *cleanroomv1.Arch
 	if maxBytes <= 0 {
 		maxBytes = s.downloadMaxBytesDefault()
 	}
-	adapter, backendName, finish, err := s.beginSandboxFileTransfer(sandboxID)
+	adapter, backendName, finish, err := s.beginSandboxFileTransfer(ctx, sandboxID)
 	if err != nil {
 		return err
 	}
@@ -1846,7 +1867,7 @@ func (s *Service) ExtractSandboxArchive(ctx context.Context, init *cleanroomv1.E
 	if err != nil {
 		return nil, err
 	}
-	adapter, backendName, finish, err := s.beginSandboxFileTransfer(sandboxID)
+	adapter, backendName, finish, err := s.beginSandboxFileTransfer(ctx, sandboxID)
 	if err != nil {
 		return nil, err
 	}
@@ -2057,6 +2078,10 @@ func (s *Service) createExecution(ctx context.Context, req *cleanroomv1.CreateEx
 
 	now := s.clock().Now()
 	executionID := s.ids().NewExecutionID()
+
+	if err := s.ensureSandboxReadyForGuestOperation(ctx, sandboxID); err != nil {
+		return nil, err
+	}
 
 	s.mu.Lock()
 	s.ensureMapsLocked()
@@ -4006,6 +4031,9 @@ func ensureSandboxIdleLocked(sandboxID string, sb *sandboxState, executions map[
 	if sb.RepositoryBusy {
 		return fmt.Errorf("sandbox_busy: sandbox %q is preparing repository state", sandboxID)
 	}
+	if sb.GuestInteractionCount > 0 {
+		return fmt.Errorf("sandbox_busy: sandbox %q has active guest interactions", sandboxID)
+	}
 	if activeID := strings.TrimSpace(sb.ActiveExecutionID); activeID != "" {
 		if activeExecution, ok := executions[executionKey(sandboxID, activeID)]; ok && !isFinalExecutionStatus(activeExecution.Status) {
 			return fmt.Errorf("sandbox_busy: sandbox %q already has active execution %q", sandboxID, activeID)
@@ -4028,7 +4056,11 @@ func validateSandboxPathRequest(sandboxID, path string) (string, string, error) 
 	return sandboxID, path, nil
 }
 
-func (s *Service) beginSandboxFileTransfer(sandboxID string) (backend.Adapter, string, func(), error) {
+func (s *Service) beginSandboxFileTransfer(ctx context.Context, sandboxID string) (backend.Adapter, string, func(), error) {
+	if err := s.ensureSandboxReadyForGuestOperation(ctx, sandboxID); err != nil {
+		return nil, "", nil, err
+	}
+
 	s.mu.Lock()
 	state, ok := s.sandboxes[sandboxID]
 	if !ok {
@@ -4070,6 +4102,30 @@ func (s *Service) beginSandboxFileTransfer(sandboxID string) (backend.Adapter, s
 		s.mu.Unlock()
 	}
 	return adapter, backendName, finish, nil
+}
+
+func (s *Service) finishSandboxGuestInteractionOnce(sandboxID string) func() {
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			s.mu.Lock()
+			if current, ok := s.sandboxes[sandboxID]; ok && current.GuestInteractionCount > 0 {
+				current.GuestInteractionCount--
+			}
+			s.mu.Unlock()
+		})
+	}
+}
+
+type sandboxGuestInteractionConn struct {
+	net.Conn
+	release func()
+}
+
+func (c *sandboxGuestInteractionConn) Close() error {
+	err := c.Conn.Close()
+	c.release()
+	return err
 }
 
 func sandboxPathInfoToProto(info *backend.SandboxPathInfo) *cleanroomv1.SandboxPathInfo {

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -1113,15 +1113,9 @@ func (s *Service) ResumeSandbox(ctx context.Context, req *cleanroomv1.ResumeSand
 	}
 	sandboxID := strings.TrimSpace(req.GetSandboxId())
 
-	result, err, _ := s.sandboxWakeOps.Do(sandboxID, func() (any, error) {
-		return s.resumeSandbox(ctx, sandboxID, false)
-	})
+	sandbox, err := s.wakeSandbox(ctx, sandboxID, false)
 	if err != nil {
 		return nil, err
-	}
-	sandbox, ok := result.(*cleanroomv1.Sandbox)
-	if !ok || sandbox == nil {
-		return nil, fmt.Errorf("resume sandbox %q returned no sandbox", sandboxID)
 	}
 	return &cleanroomv1.ResumeSandboxResponse{Sandbox: sandbox}, nil
 }
@@ -1131,10 +1125,30 @@ func (s *Service) ensureSandboxReadyForGuestOperation(ctx context.Context, sandb
 	if sandboxID == "" {
 		return errors.New("missing sandbox_id")
 	}
-	_, err, _ := s.sandboxWakeOps.Do(sandboxID, func() (any, error) {
-		return s.resumeSandbox(ctx, sandboxID, true)
-	})
+	_, err := s.wakeSandbox(ctx, sandboxID, true)
 	return err
+}
+
+func (s *Service) wakeSandbox(ctx context.Context, sandboxID string, guestOperation bool) (*cleanroomv1.Sandbox, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	ch := s.sandboxWakeOps.DoChan(sandboxID, func() (any, error) {
+		return s.resumeSandbox(context.WithoutCancel(ctx), sandboxID, guestOperation)
+	})
+	select {
+	case result := <-ch:
+		if result.Err != nil {
+			return nil, result.Err
+		}
+		sandbox, ok := result.Val.(*cleanroomv1.Sandbox)
+		if !ok || sandbox == nil {
+			return nil, fmt.Errorf("resume sandbox %q returned no sandbox", sandboxID)
+		}
+		return sandbox, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 }
 
 func (s *Service) resumeSandbox(ctx context.Context, sandboxID string, guestOperation bool) (*cleanroomv1.Sandbox, error) {
@@ -1499,7 +1513,7 @@ func (s *Service) DownloadSandboxFile(ctx context.Context, req *cleanroomv1.Down
 		maxBytes = s.downloadMaxBytesDefault()
 	}
 
-	adapter, backendName, finish, err := s.beginSandboxFileTransfer(ctx, sandboxID)
+	adapter, backendName, finish, err := s.beginSandboxFileTransfer(ctx, sandboxID, sandboxFileDownloadSupport)
 	if err != nil {
 		return nil, err
 	}
@@ -1544,7 +1558,7 @@ func (s *Service) UploadSandboxFile(ctx context.Context, req *cleanroomv1.Upload
 		return nil, fmt.Errorf("upload data exceeds max_bytes=%d", maxBytes)
 	}
 
-	adapter, backendName, finish, err := s.beginSandboxFileTransfer(ctx, sandboxID)
+	adapter, backendName, finish, err := s.beginSandboxFileTransfer(ctx, sandboxID, sandboxFileUploadSupport)
 	if err != nil {
 		return nil, err
 	}
@@ -1573,7 +1587,7 @@ func (s *Service) StatSandboxPath(ctx context.Context, req *cleanroomv1.StatSand
 	if err != nil {
 		return nil, err
 	}
-	adapter, backendName, finish, err := s.beginSandboxFileTransfer(ctx, sandboxID)
+	adapter, backendName, finish, err := s.beginSandboxFileTransfer(ctx, sandboxID, sandboxPathStatSupport)
 	if err != nil {
 		return nil, err
 	}
@@ -1598,7 +1612,7 @@ func (s *Service) WalkSandboxTree(ctx context.Context, req *cleanroomv1.WalkSand
 	if err != nil {
 		return err
 	}
-	adapter, backendName, finish, err := s.beginSandboxFileTransfer(ctx, sandboxID)
+	adapter, backendName, finish, err := s.beginSandboxFileTransfer(ctx, sandboxID, sandboxTreeWalkSupport)
 	if err != nil {
 		return err
 	}
@@ -1631,7 +1645,7 @@ func (s *Service) ReadSandboxFile(ctx context.Context, req *cleanroomv1.ReadSand
 	if maxBytes <= 0 {
 		maxBytes = s.downloadMaxBytesDefault()
 	}
-	adapter, backendName, finish, err := s.beginSandboxFileTransfer(ctx, sandboxID)
+	adapter, backendName, finish, err := s.beginSandboxFileTransfer(ctx, sandboxID, sandboxFileReadSupport)
 	if err != nil {
 		return err
 	}
@@ -1767,7 +1781,7 @@ func (s *Service) WriteSandboxFile(ctx context.Context, init *cleanroomv1.WriteS
 	if init.GetMtime() != nil {
 		mtime = init.GetMtime().AsTime()
 	}
-	adapter, backendName, finish, err := s.beginSandboxFileTransfer(ctx, sandboxID)
+	adapter, backendName, finish, err := s.beginSandboxFileTransfer(ctx, sandboxID, sandboxFileWriteSupport)
 	if err != nil {
 		return nil, err
 	}
@@ -1796,7 +1810,7 @@ func (s *Service) RemoveSandboxPath(ctx context.Context, req *cleanroomv1.Remove
 	if err != nil {
 		return nil, err
 	}
-	adapter, backendName, finish, err := s.beginSandboxFileTransfer(ctx, sandboxID)
+	adapter, backendName, finish, err := s.beginSandboxFileTransfer(ctx, sandboxID, sandboxPathRemoveSupport)
 	if err != nil {
 		return nil, err
 	}
@@ -1832,7 +1846,7 @@ func (s *Service) ArchiveSandboxPaths(ctx context.Context, req *cleanroomv1.Arch
 	if maxBytes <= 0 {
 		maxBytes = s.downloadMaxBytesDefault()
 	}
-	adapter, backendName, finish, err := s.beginSandboxFileTransfer(ctx, sandboxID)
+	adapter, backendName, finish, err := s.beginSandboxFileTransfer(ctx, sandboxID, sandboxArchiveReadSupport)
 	if err != nil {
 		return err
 	}
@@ -1867,7 +1881,7 @@ func (s *Service) ExtractSandboxArchive(ctx context.Context, init *cleanroomv1.E
 	if err != nil {
 		return nil, err
 	}
-	adapter, backendName, finish, err := s.beginSandboxFileTransfer(ctx, sandboxID)
+	adapter, backendName, finish, err := s.beginSandboxFileTransfer(ctx, sandboxID, sandboxArchiveWriteSupport)
 	if err != nil {
 		return nil, err
 	}
@@ -4056,7 +4070,120 @@ func validateSandboxPathRequest(sandboxID, path string) (string, string, error) 
 	return sandboxID, path, nil
 }
 
-func (s *Service) beginSandboxFileTransfer(ctx context.Context, sandboxID string) (backend.Adapter, string, func(), error) {
+type sandboxFileOperationSupport struct {
+	capability  string
+	description string
+	implements  func(backend.Adapter) bool
+}
+
+var (
+	sandboxFileDownloadSupport = sandboxFileOperationSupport{
+		capability:  backend.CapabilitySandboxFileDownload,
+		description: "sandbox file downloads",
+		implements: func(adapter backend.Adapter) bool {
+			_, ok := adapter.(backend.SandboxFileDownloadAdapter)
+			return ok
+		},
+	}
+	sandboxFileUploadSupport = sandboxFileOperationSupport{
+		capability:  backend.CapabilitySandboxFileUpload,
+		description: "sandbox file uploads",
+		implements: func(adapter backend.Adapter) bool {
+			_, ok := adapter.(backend.SandboxFileUploadAdapter)
+			return ok
+		},
+	}
+	sandboxPathStatSupport = sandboxFileOperationSupport{
+		capability:  backend.CapabilitySandboxPathStat,
+		description: "sandbox path stat",
+		implements: func(adapter backend.Adapter) bool {
+			_, ok := adapter.(backend.SandboxPathStatAdapter)
+			return ok
+		},
+	}
+	sandboxTreeWalkSupport = sandboxFileOperationSupport{
+		capability:  backend.CapabilitySandboxTreeWalk,
+		description: "sandbox tree walks",
+		implements: func(adapter backend.Adapter) bool {
+			_, ok := adapter.(backend.SandboxTreeWalkAdapter)
+			return ok
+		},
+	}
+	sandboxFileReadSupport = sandboxFileOperationSupport{
+		capability:  backend.CapabilitySandboxFileRead,
+		description: "sandbox file reads",
+		implements: func(adapter backend.Adapter) bool {
+			_, ok := adapter.(backend.SandboxFileReadAdapter)
+			return ok
+		},
+	}
+	sandboxFileWriteSupport = sandboxFileOperationSupport{
+		capability:  backend.CapabilitySandboxFileWrite,
+		description: "sandbox file writes",
+		implements: func(adapter backend.Adapter) bool {
+			_, ok := adapter.(backend.SandboxFileWriteAdapter)
+			return ok
+		},
+	}
+	sandboxPathRemoveSupport = sandboxFileOperationSupport{
+		capability:  backend.CapabilitySandboxPathRemove,
+		description: "sandbox path removal",
+		implements: func(adapter backend.Adapter) bool {
+			_, ok := adapter.(backend.SandboxPathRemoveAdapter)
+			return ok
+		},
+	}
+	sandboxArchiveReadSupport = sandboxFileOperationSupport{
+		capability:  backend.CapabilitySandboxArchiveRead,
+		description: "sandbox archive reads",
+		implements: func(adapter backend.Adapter) bool {
+			_, ok := adapter.(backend.SandboxArchiveReadAdapter)
+			return ok
+		},
+	}
+	sandboxArchiveWriteSupport = sandboxFileOperationSupport{
+		capability:  backend.CapabilitySandboxArchiveWrite,
+		description: "sandbox archive writes",
+		implements: func(adapter backend.Adapter) bool {
+			_, ok := adapter.(backend.SandboxArchiveWriteAdapter)
+			return ok
+		},
+	}
+)
+
+func (s *Service) ensureSandboxFileOperationSupported(sandboxID string, support sandboxFileOperationSupport) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	state, ok := s.sandboxes[sandboxID]
+	if !ok {
+		return fmt.Errorf("unknown sandbox %q", sandboxID)
+	}
+	switch state.Status {
+	case cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY,
+		cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDED,
+		cleanroomv1.SandboxStatus_SANDBOX_STATUS_WAKING:
+	default:
+		return fmt.Errorf("sandbox %q is not ready", sandboxID)
+	}
+	adapter, ok := s.Backends[state.Backend]
+	if !ok {
+		return fmt.Errorf("unknown backend %q", state.Backend)
+	}
+	capabilities := state.Capabilities
+	if capabilities == nil {
+		capabilities = backend.CapabilitiesForAdapter(adapter)
+	}
+	if !capabilities[support.capability] || !support.implements(adapter) {
+		return fmt.Errorf("backend %q does not support %s", state.Backend, support.description)
+	}
+	return nil
+}
+
+func (s *Service) beginSandboxFileTransfer(ctx context.Context, sandboxID string, support sandboxFileOperationSupport) (backend.Adapter, string, func(), error) {
+	if err := s.ensureSandboxFileOperationSupported(sandboxID, support); err != nil {
+		return nil, "", nil, err
+	}
 	if err := s.ensureSandboxReadyForGuestOperation(ctx, sandboxID); err != nil {
 		return nil, "", nil, err
 	}
@@ -4126,6 +4253,13 @@ func (c *sandboxGuestInteractionConn) Close() error {
 	err := c.Conn.Close()
 	c.release()
 	return err
+}
+
+func (c *sandboxGuestInteractionConn) CloseWrite() error {
+	if cw, ok := c.Conn.(interface{ CloseWrite() error }); ok {
+		return cw.CloseWrite()
+	}
+	return nil
 }
 
 func sandboxPathInfoToProto(info *backend.SandboxPathInfo) *cleanroomv1.SandboxPathInfo {

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -103,11 +103,51 @@ type suspendableAdapter struct {
 	resumeSandbox  string
 }
 
+type suspendOnlyAdapter struct {
+	resumeFn     func(context.Context, string) error
+	suspendCalls int
+	resumeCalls  int
+}
+
 func (s *suspendableAdapter) SuspendSandbox(ctx context.Context, sandboxID string) error {
 	s.suspendCalls++
 	s.suspendSandbox = sandboxID
 	if s.suspendFn != nil {
 		return s.suspendFn(ctx, sandboxID)
+	}
+	return nil
+}
+
+func (s *suspendOnlyAdapter) Name() string { return "suspend-only" }
+
+func (s *suspendOnlyAdapter) ProvisionSandbox(context.Context, backend.ProvisionRequest) error {
+	return nil
+}
+
+func (s *suspendOnlyAdapter) RunInSandbox(_ context.Context, req backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
+	return &backend.ExecutionResult{
+		ExecutionID: req.ExecutionID,
+		ExitCode:    0,
+		LaunchedVM:  true,
+		PlanPath:    "/tmp/plan",
+		RunDir:      "/tmp/run",
+		Message:     "ok",
+	}, nil
+}
+
+func (s *suspendOnlyAdapter) TerminateSandbox(context.Context, string) error {
+	return nil
+}
+
+func (s *suspendOnlyAdapter) SuspendSandbox(context.Context, string) error {
+	s.suspendCalls++
+	return nil
+}
+
+func (s *suspendOnlyAdapter) ResumeSandbox(ctx context.Context, sandboxID string) error {
+	s.resumeCalls++
+	if s.resumeFn != nil {
+		return s.resumeFn(ctx, sandboxID)
 	}
 	return nil
 }
@@ -1181,6 +1221,43 @@ func TestDialSandboxPortWakesSuspendedSandbox(t *testing.T) {
 	}
 }
 
+func TestDialSandboxPortPreservesCloseWrite(t *testing.T) {
+	var dialedConn *closeWriteTrackingConn
+	adapter := &suspendablePortDialAdapter{
+		dialFn: func(context.Context, string, int) (net.Conn, error) {
+			serverConn, clientConn := net.Pipe()
+			t.Cleanup(func() { _ = serverConn.Close() })
+			dialedConn = &closeWriteTrackingConn{Conn: clientConn}
+			return dialedConn, nil
+		},
+	}
+	svc := newTestService(adapter)
+	createResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+
+	conn, err := svc.DialSandboxPort(context.Background(), &cleanroomv1.SandboxPortOpen{
+		SandboxId: createResp.GetSandbox().GetSandboxId(),
+		GuestPort: 3000,
+	})
+	if err != nil {
+		t.Fatalf("DialSandboxPort returned error: %v", err)
+	}
+	defer conn.Close()
+
+	closeWriter, ok := conn.(interface{ CloseWrite() error })
+	if !ok {
+		t.Fatal("expected sandbox port connection to preserve CloseWrite")
+	}
+	if err := closeWriter.CloseWrite(); err != nil {
+		t.Fatalf("CloseWrite returned error: %v", err)
+	}
+	if got, want := dialedConn.closeWriteCalls, 1; got != want {
+		t.Fatalf("unexpected CloseWrite calls: got %d want %d", got, want)
+	}
+}
+
 func TestDialSandboxPortHoldsGuestInteractionLease(t *testing.T) {
 	var serverConn net.Conn
 	adapter := &suspendablePortDialAdapter{
@@ -1234,6 +1311,16 @@ func TestDialSandboxPortHoldsGuestInteractionLease(t *testing.T) {
 	if got, want := activeInteractions, 0; got != want {
 		t.Fatalf("unexpected active guest interactions after close: got %d want %d", got, want)
 	}
+}
+
+type closeWriteTrackingConn struct {
+	net.Conn
+	closeWriteCalls int
+}
+
+func (c *closeWriteTrackingConn) CloseWrite() error {
+	c.closeWriteCalls++
+	return nil
 }
 
 func TestDialSandboxPortUnsupportedBackendDoesNotWakeSuspendedSandbox(t *testing.T) {
@@ -1333,6 +1420,108 @@ func TestConcurrentWakeAttemptsCoalesce(t *testing.T) {
 	}
 	if got, want := adapter.dialCalls, callers; got != want {
 		t.Fatalf("unexpected dial calls: got %d want %d", got, want)
+	}
+}
+
+func TestConcurrentWakeIgnoresFirstCallerCancellation(t *testing.T) {
+	resumeStarted := make(chan struct{})
+	releaseResume := make(chan struct{})
+	resumeContextErr := make(chan error, 2)
+	var resumeStartedOnce sync.Once
+	adapter := &suspendablePortDialAdapter{}
+	adapter.resumeFn = func(ctx context.Context, _ string) error {
+		resumeStartedOnce.Do(func() { close(resumeStarted) })
+		select {
+		case <-releaseResume:
+			resumeContextErr <- ctx.Err()
+			return nil
+		case <-ctx.Done():
+			resumeContextErr <- ctx.Err()
+			return ctx.Err()
+		}
+	}
+	adapter.dialFn = func(context.Context, string, int) (net.Conn, error) {
+		serverConn, clientConn := net.Pipe()
+		_ = serverConn.Close()
+		return clientConn, nil
+	}
+	svc := newTestService(adapter)
+	createResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createResp.GetSandbox().GetSandboxId()
+	if _, err := svc.SuspendSandbox(context.Background(), &cleanroomv1.SuspendSandboxRequest{SandboxId: sandboxID}); err != nil {
+		t.Fatalf("SuspendSandbox returned error: %v", err)
+	}
+
+	firstCtx, cancelFirst := context.WithCancel(context.Background())
+	firstErr := make(chan error, 1)
+	go func() {
+		conn, err := svc.DialSandboxPort(firstCtx, &cleanroomv1.SandboxPortOpen{
+			SandboxId: sandboxID,
+			GuestPort: 3000,
+		})
+		if conn != nil {
+			_ = conn.Close()
+		}
+		firstErr <- err
+	}()
+	select {
+	case <-resumeStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for resume to start")
+	}
+
+	secondErr := make(chan error, 1)
+	go func() {
+		conn, err := svc.DialSandboxPort(context.Background(), &cleanroomv1.SandboxPortOpen{
+			SandboxId: sandboxID,
+			GuestPort: 3000,
+		})
+		if conn != nil {
+			_ = conn.Close()
+		}
+		secondErr <- err
+	}()
+	select {
+	case err := <-secondErr:
+		t.Fatalf("second caller returned before resume completed: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	cancelFirst()
+	select {
+	case err := <-firstErr:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected first caller cancellation, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first caller cancellation")
+	}
+	select {
+	case err := <-secondErr:
+		t.Fatalf("second caller returned after first cancellation but before resume completed: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(releaseResume)
+	select {
+	case err := <-secondErr:
+		if err != nil {
+			t.Fatalf("second DialSandboxPort returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for second caller")
+	}
+	if got, want := adapter.resumeCalls, 1; got != want {
+		t.Fatalf("unexpected resume calls: got %d want %d", got, want)
+	}
+	select {
+	case err := <-resumeContextErr:
+		if err != nil {
+			t.Fatalf("backend resume context was canceled: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for resume context result")
 	}
 }
 
@@ -8413,6 +8602,149 @@ func TestSandboxArchivePrimitiveDispatch(t *testing.T) {
 	}
 	if got, want := resp.GetSizeBytes(), int64(len("tar-data")); got != want {
 		t.Fatalf("unexpected extract size: got %d want %d", got, want)
+	}
+}
+
+func TestUnsupportedSandboxFileOperationsDoNotWakeSuspendedSandbox(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+		call func(*Service, string) error
+	}{
+		{
+			name: "download",
+			want: "does not support sandbox file downloads",
+			call: func(svc *Service, sandboxID string) error {
+				_, err := svc.DownloadSandboxFile(context.Background(), &cleanroomv1.DownloadSandboxFileRequest{
+					SandboxId: sandboxID,
+					Path:      "/tmp/file",
+				})
+				return err
+			},
+		},
+		{
+			name: "upload",
+			want: "does not support sandbox file uploads",
+			call: func(svc *Service, sandboxID string) error {
+				_, err := svc.UploadSandboxFile(context.Background(), &cleanroomv1.UploadSandboxFileRequest{
+					SandboxId: sandboxID,
+					Path:      "/tmp/file",
+					Data:      []byte("payload"),
+				})
+				return err
+			},
+		},
+		{
+			name: "stat",
+			want: "does not support sandbox path stat",
+			call: func(svc *Service, sandboxID string) error {
+				_, err := svc.StatSandboxPath(context.Background(), &cleanroomv1.StatSandboxPathRequest{
+					SandboxId: sandboxID,
+					Path:      "/tmp/file",
+				})
+				return err
+			},
+		},
+		{
+			name: "walk",
+			want: "does not support sandbox tree walks",
+			call: func(svc *Service, sandboxID string) error {
+				return svc.WalkSandboxTree(context.Background(), &cleanroomv1.WalkSandboxTreeRequest{
+					SandboxId: sandboxID,
+					Path:      "/tmp/tree",
+				}, nil)
+			},
+		},
+		{
+			name: "read",
+			want: "does not support sandbox file reads",
+			call: func(svc *Service, sandboxID string) error {
+				return svc.ReadSandboxFile(context.Background(), &cleanroomv1.ReadSandboxFileRequest{
+					SandboxId: sandboxID,
+					Path:      "/tmp/file",
+				}, nil)
+			},
+		},
+		{
+			name: "write",
+			want: "does not support sandbox file writes",
+			call: func(svc *Service, sandboxID string) error {
+				_, err := svc.WriteSandboxFile(context.Background(), &cleanroomv1.WriteSandboxFileInit{
+					SandboxId: sandboxID,
+					Path:      "/tmp/file",
+				}, strings.NewReader("payload"))
+				return err
+			},
+		},
+		{
+			name: "remove",
+			want: "does not support sandbox path removal",
+			call: func(svc *Service, sandboxID string) error {
+				_, err := svc.RemoveSandboxPath(context.Background(), &cleanroomv1.RemoveSandboxPathRequest{
+					SandboxId: sandboxID,
+					Path:      "/tmp/file",
+				})
+				return err
+			},
+		},
+		{
+			name: "archive",
+			want: "does not support sandbox archive reads",
+			call: func(svc *Service, sandboxID string) error {
+				return svc.ArchiveSandboxPaths(context.Background(), &cleanroomv1.ArchiveSandboxPathsRequest{
+					SandboxId: sandboxID,
+					Paths:     []string{"/tmp/file"},
+				}, nil)
+			},
+		},
+		{
+			name: "extract",
+			want: "does not support sandbox archive writes",
+			call: func(svc *Service, sandboxID string) error {
+				_, err := svc.ExtractSandboxArchive(context.Background(), &cleanroomv1.ExtractSandboxArchiveInit{
+					SandboxId:   sandboxID,
+					Destination: "/tmp/out",
+				}, strings.NewReader("payload"))
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			adapter := &suspendOnlyAdapter{
+				resumeFn: func(context.Context, string) error {
+					return errors.New("unexpected wake")
+				},
+			}
+			svc := newTestService(adapter)
+			createResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+			if err != nil {
+				t.Fatalf("CreateSandbox returned error: %v", err)
+			}
+			sandboxID := createResp.GetSandbox().GetSandboxId()
+			if _, err := svc.SuspendSandbox(context.Background(), &cleanroomv1.SuspendSandboxRequest{SandboxId: sandboxID}); err != nil {
+				t.Fatalf("SuspendSandbox returned error: %v", err)
+			}
+
+			err = tt.call(svc, sandboxID)
+			if err == nil {
+				t.Fatal("expected unsupported operation error")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("unexpected error: got %v want substring %q", err, tt.want)
+			}
+			if got, want := adapter.resumeCalls, 0; got != want {
+				t.Fatalf("unexpected resume calls: got %d want %d", got, want)
+			}
+			getResp, err := svc.GetSandbox(context.Background(), &cleanroomv1.GetSandboxRequest{SandboxId: sandboxID})
+			if err != nil {
+				t.Fatalf("GetSandbox returned error: %v", err)
+			}
+			if got, want := getResp.GetSandbox().GetStatus(), cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDED; got != want {
+				t.Fatalf("unexpected sandbox status: got %v want %v", got, want)
+			}
+		})
 	}
 }
 

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -85,6 +85,13 @@ type portDialAdapter struct {
 	dialFn       func(context.Context, string, int) (net.Conn, error)
 }
 
+type suspendablePortDialAdapter struct {
+	suspendableAdapter
+	dialMu    sync.Mutex
+	dialFn    func(context.Context, string, int) (net.Conn, error)
+	dialCalls int
+}
+
 type suspendableAdapter struct {
 	stubAdapter
 	capabilities   map[string]bool
@@ -119,6 +126,16 @@ func (s *suspendableAdapter) Capabilities() map[string]bool {
 }
 
 func (s *portDialAdapter) DialSandboxPort(ctx context.Context, sandboxID string, port int) (net.Conn, error) {
+	if s.dialFn != nil {
+		return s.dialFn(ctx, sandboxID, port)
+	}
+	return nil, errors.New("dial not configured")
+}
+
+func (s *suspendablePortDialAdapter) DialSandboxPort(ctx context.Context, sandboxID string, port int) (net.Conn, error) {
+	s.dialMu.Lock()
+	s.dialCalls++
+	s.dialMu.Unlock()
 	if s.dialFn != nil {
 		return s.dialFn(ctx, sandboxID, port)
 	}
@@ -1006,6 +1023,316 @@ func TestResumeSandboxBackendIndeterminateFailureLeavesSuspended(t *testing.T) {
 	}
 	if got, want := getResp.GetSandbox().GetStatus(), cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDED; got != want {
 		t.Fatalf("unexpected sandbox status after indeterminate resume: got %v want %v", got, want)
+	}
+}
+
+func TestCreateExecutionWakesSuspendedSandbox(t *testing.T) {
+	adapter := &suspendableAdapter{}
+	svc := newTestService(adapter)
+	createResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createResp.GetSandbox().GetSandboxId()
+	if _, err := svc.SuspendSandbox(context.Background(), &cleanroomv1.SuspendSandboxRequest{SandboxId: sandboxID}); err != nil {
+		t.Fatalf("SuspendSandbox returned error: %v", err)
+	}
+
+	execResp, err := svc.CreateExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
+		SandboxId: sandboxID,
+		Command:   []string{"echo", "awake"},
+	})
+	if err != nil {
+		t.Fatalf("CreateExecution returned error: %v", err)
+	}
+	waitExecutionDone(t, svc, sandboxID, execResp.GetExecution().GetExecutionId())
+
+	if got, want := adapter.resumeCalls, 1; got != want {
+		t.Fatalf("unexpected resume calls: got %d want %d", got, want)
+	}
+	if got, want := adapter.runCalls, 1; got != want {
+		t.Fatalf("unexpected run calls: got %d want %d", got, want)
+	}
+	getResp, err := svc.GetSandbox(context.Background(), &cleanroomv1.GetSandboxRequest{SandboxId: sandboxID})
+	if err != nil {
+		t.Fatalf("GetSandbox returned error: %v", err)
+	}
+	if got, want := getResp.GetSandbox().GetStatus(), cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY; got != want {
+		t.Fatalf("unexpected sandbox status after transparent wake: got %v want %v", got, want)
+	}
+}
+
+func TestReadSandboxFileWakesSuspendedSandbox(t *testing.T) {
+	adapter := &suspendableAdapter{
+		stubAdapter: stubAdapter{
+			readFn: func(_ context.Context, _ string, path string, _ int64, emit func([]byte) error) error {
+				if path != "/tmp/marker" {
+					t.Fatalf("unexpected read path: got %q want /tmp/marker", path)
+				}
+				return emit([]byte("awake"))
+			},
+		},
+	}
+	svc := newTestService(adapter)
+	createResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createResp.GetSandbox().GetSandboxId()
+	if _, err := svc.SuspendSandbox(context.Background(), &cleanroomv1.SuspendSandboxRequest{SandboxId: sandboxID}); err != nil {
+		t.Fatalf("SuspendSandbox returned error: %v", err)
+	}
+
+	var chunks [][]byte
+	err = svc.ReadSandboxFile(context.Background(), &cleanroomv1.ReadSandboxFileRequest{
+		SandboxId: sandboxID,
+		Path:      "/tmp/marker",
+	}, func(resp *cleanroomv1.ReadSandboxFileResponse) error {
+		chunks = append(chunks, append([]byte(nil), resp.GetData()...))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ReadSandboxFile returned error: %v", err)
+	}
+	if got, want := adapter.resumeCalls, 1; got != want {
+		t.Fatalf("unexpected resume calls: got %d want %d", got, want)
+	}
+	if got, want := string(bytes.Join(chunks, nil)), "awake"; got != want {
+		t.Fatalf("unexpected read data: got %q want %q", got, want)
+	}
+}
+
+func TestCreateSnapshotWakesSuspendedSandbox(t *testing.T) {
+	store := newMemorySnapshotStore()
+	adapter := &suspendableAdapter{
+		stubAdapter: stubAdapter{
+			createSnapshotFn: func(_ context.Context, req backend.SnapshotRequest) (*backend.SnapshotResult, error) {
+				return &backend.SnapshotResult{StorageRef: "/snapshots/" + req.SnapshotID + ".ext4"}, nil
+			},
+		},
+	}
+	svc := newTestServiceWithSnapshotStore(adapter, store)
+	createResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createResp.GetSandbox().GetSandboxId()
+	if _, err := svc.SuspendSandbox(context.Background(), &cleanroomv1.SuspendSandboxRequest{SandboxId: sandboxID}); err != nil {
+		t.Fatalf("SuspendSandbox returned error: %v", err)
+	}
+
+	snapshotResp, err := svc.CreateSnapshot(context.Background(), &cleanroomv1.CreateSnapshotRequest{
+		SandboxId: sandboxID,
+		Name:      "after-wake",
+	})
+	if err != nil {
+		t.Fatalf("CreateSnapshot returned error: %v", err)
+	}
+
+	if snapshotResp.GetSnapshot() == nil {
+		t.Fatal("expected snapshot in response")
+	}
+	if got, want := adapter.resumeCalls, 1; got != want {
+		t.Fatalf("unexpected resume calls: got %d want %d", got, want)
+	}
+	if got, want := adapter.createSnapshotCalls, 1; got != want {
+		t.Fatalf("unexpected snapshot calls: got %d want %d", got, want)
+	}
+	getResp, err := svc.GetSandbox(context.Background(), &cleanroomv1.GetSandboxRequest{SandboxId: sandboxID})
+	if err != nil {
+		t.Fatalf("GetSandbox returned error: %v", err)
+	}
+	if got, want := getResp.GetSandbox().GetStatus(), cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY; got != want {
+		t.Fatalf("unexpected sandbox status after snapshot: got %v want %v", got, want)
+	}
+}
+
+func TestDialSandboxPortWakesSuspendedSandbox(t *testing.T) {
+	adapter := &suspendablePortDialAdapter{
+		dialFn: func(context.Context, string, int) (net.Conn, error) {
+			serverConn, clientConn := net.Pipe()
+			_ = serverConn.Close()
+			return clientConn, nil
+		},
+	}
+	svc := newTestService(adapter)
+	createResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createResp.GetSandbox().GetSandboxId()
+	if _, err := svc.SuspendSandbox(context.Background(), &cleanroomv1.SuspendSandboxRequest{SandboxId: sandboxID}); err != nil {
+		t.Fatalf("SuspendSandbox returned error: %v", err)
+	}
+
+	conn, err := svc.DialSandboxPort(context.Background(), &cleanroomv1.SandboxPortOpen{
+		SandboxId: sandboxID,
+		GuestPort: 3000,
+	})
+	if err != nil {
+		t.Fatalf("DialSandboxPort returned error: %v", err)
+	}
+	_ = conn.Close()
+	if got, want := adapter.resumeCalls, 1; got != want {
+		t.Fatalf("unexpected resume calls: got %d want %d", got, want)
+	}
+	if got, want := adapter.dialCalls, 1; got != want {
+		t.Fatalf("unexpected dial calls: got %d want %d", got, want)
+	}
+}
+
+func TestDialSandboxPortHoldsGuestInteractionLease(t *testing.T) {
+	var serverConn net.Conn
+	adapter := &suspendablePortDialAdapter{
+		dialFn: func(context.Context, string, int) (net.Conn, error) {
+			server, client := net.Pipe()
+			serverConn = server
+			return client, nil
+		},
+	}
+	svc := newTestService(adapter)
+	createResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createResp.GetSandbox().GetSandboxId()
+
+	conn, err := svc.DialSandboxPort(context.Background(), &cleanroomv1.SandboxPortOpen{
+		SandboxId: sandboxID,
+		GuestPort: 3000,
+	})
+	if err != nil {
+		t.Fatalf("DialSandboxPort returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = conn.Close()
+		if serverConn != nil {
+			_ = serverConn.Close()
+		}
+	})
+
+	svc.mu.RLock()
+	activeInteractions := svc.sandboxes[sandboxID].GuestInteractionCount
+	svc.mu.RUnlock()
+	if got, want := activeInteractions, 1; got != want {
+		t.Fatalf("unexpected active guest interactions: got %d want %d", got, want)
+	}
+	_, err = svc.SuspendSandbox(context.Background(), &cleanroomv1.SuspendSandboxRequest{SandboxId: sandboxID})
+	if err == nil {
+		t.Fatal("expected SuspendSandbox to reject active guest interaction")
+	}
+	if !strings.Contains(err.Error(), "active guest interactions") {
+		t.Fatalf("unexpected SuspendSandbox error: %v", err)
+	}
+
+	if err := conn.Close(); err != nil {
+		t.Fatalf("port connection close returned error: %v", err)
+	}
+	svc.mu.RLock()
+	activeInteractions = svc.sandboxes[sandboxID].GuestInteractionCount
+	svc.mu.RUnlock()
+	if got, want := activeInteractions, 0; got != want {
+		t.Fatalf("unexpected active guest interactions after close: got %d want %d", got, want)
+	}
+}
+
+func TestDialSandboxPortUnsupportedBackendDoesNotWakeSuspendedSandbox(t *testing.T) {
+	adapter := &suspendableAdapter{
+		resumeFn: func(context.Context, string) error {
+			return errors.New("unexpected wake")
+		},
+	}
+	svc := newTestService(adapter)
+	createResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createResp.GetSandbox().GetSandboxId()
+	if _, err := svc.SuspendSandbox(context.Background(), &cleanroomv1.SuspendSandboxRequest{SandboxId: sandboxID}); err != nil {
+		t.Fatalf("SuspendSandbox returned error: %v", err)
+	}
+
+	_, err = svc.DialSandboxPort(context.Background(), &cleanroomv1.SandboxPortOpen{
+		SandboxId: sandboxID,
+		GuestPort: 3000,
+	})
+	if err == nil {
+		t.Fatal("expected DialSandboxPort to reject unsupported backend")
+	}
+	if !strings.Contains(err.Error(), "does not support sandbox port dialing") {
+		t.Fatalf("unexpected DialSandboxPort error: %v", err)
+	}
+	if got, want := adapter.resumeCalls, 0; got != want {
+		t.Fatalf("unexpected resume calls: got %d want %d", got, want)
+	}
+	getResp, err := svc.GetSandbox(context.Background(), &cleanroomv1.GetSandboxRequest{SandboxId: sandboxID})
+	if err != nil {
+		t.Fatalf("GetSandbox returned error: %v", err)
+	}
+	if got, want := getResp.GetSandbox().GetStatus(), cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDED; got != want {
+		t.Fatalf("unexpected sandbox status after rejected port dial: got %v want %v", got, want)
+	}
+}
+
+func TestConcurrentWakeAttemptsCoalesce(t *testing.T) {
+	resumeStarted := make(chan struct{})
+	releaseResume := make(chan struct{})
+	var resumeStartedOnce sync.Once
+	adapter := &suspendablePortDialAdapter{}
+	adapter.resumeFn = func(context.Context, string) error {
+		resumeStartedOnce.Do(func() { close(resumeStarted) })
+		<-releaseResume
+		return nil
+	}
+	adapter.dialFn = func(context.Context, string, int) (net.Conn, error) {
+		serverConn, clientConn := net.Pipe()
+		_ = serverConn.Close()
+		return clientConn, nil
+	}
+	svc := newTestService(adapter)
+	createResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createResp.GetSandbox().GetSandboxId()
+	if _, err := svc.SuspendSandbox(context.Background(), &cleanroomv1.SuspendSandboxRequest{SandboxId: sandboxID}); err != nil {
+		t.Fatalf("SuspendSandbox returned error: %v", err)
+	}
+
+	const callers = 5
+	start := make(chan struct{})
+	errCh := make(chan error, callers)
+	for i := 0; i < callers; i++ {
+		go func() {
+			<-start
+			conn, err := svc.DialSandboxPort(context.Background(), &cleanroomv1.SandboxPortOpen{
+				SandboxId: sandboxID,
+				GuestPort: 3000,
+			})
+			if conn != nil {
+				_ = conn.Close()
+			}
+			errCh <- err
+		}()
+	}
+	close(start)
+	select {
+	case <-resumeStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for resume to start")
+	}
+	time.Sleep(50 * time.Millisecond)
+	close(releaseResume)
+	for i := 0; i < callers; i++ {
+		if err := <-errCh; err != nil {
+			t.Fatalf("DialSandboxPort caller %d returned error: %v", i+1, err)
+		}
+	}
+	if got, want := adapter.resumeCalls, 1; got != want {
+		t.Fatalf("unexpected resume calls: got %d want %d", got, want)
+	}
+	if got, want := adapter.dialCalls, callers; got != want {
+		t.Fatalf("unexpected dial calls: got %d want %d", got, want)
 	}
 }
 
@@ -10063,5 +10390,21 @@ func collectExecutionEvents(t *testing.T, history []*cleanroomv1.ExecutionStream
 		case <-timer.C:
 			t.Fatalf("timed out collecting execution events")
 		}
+	}
+}
+
+func waitExecutionDone(t *testing.T, svc *Service, sandboxID, executionID string) {
+	t.Helper()
+	key := executionKey(sandboxID, executionID)
+	svc.mu.RLock()
+	ex := svc.executions[key]
+	svc.mu.RUnlock()
+	if ex == nil {
+		t.Fatalf("unknown execution %s", executionID)
+	}
+	select {
+	case <-ex.Done:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for execution %s", executionID)
 	}
 }

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -2723,6 +2723,84 @@ func TestCreateSnapshotRejectsDisabledSnapshots(t *testing.T) {
 	}
 }
 
+func TestCreateSnapshotUnsupportedBackendDoesNotWakeSuspendedSandbox(t *testing.T) {
+	store := newMemorySnapshotStore()
+	adapter := &suspendOnlyAdapter{
+		resumeFn: func(context.Context, string) error {
+			return errors.New("unexpected wake")
+		},
+	}
+	svc := newTestServiceWithSnapshotStore(adapter, store)
+
+	createResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createResp.GetSandbox().GetSandboxId()
+	if _, err := svc.SuspendSandbox(context.Background(), &cleanroomv1.SuspendSandboxRequest{SandboxId: sandboxID}); err != nil {
+		t.Fatalf("SuspendSandbox returned error: %v", err)
+	}
+
+	_, err = svc.CreateSnapshot(context.Background(), &cleanroomv1.CreateSnapshotRequest{SandboxId: sandboxID})
+	if err == nil {
+		t.Fatal("expected CreateSnapshot to reject unsupported backend")
+	}
+	if !strings.Contains(err.Error(), "does not support snapshots") {
+		t.Fatalf("unexpected CreateSnapshot error: %v", err)
+	}
+	if got, want := adapter.resumeCalls, 0; got != want {
+		t.Fatalf("unexpected resume calls: got %d want %d", got, want)
+	}
+	getResp, err := svc.GetSandbox(context.Background(), &cleanroomv1.GetSandboxRequest{SandboxId: sandboxID})
+	if err != nil {
+		t.Fatalf("GetSandbox returned error: %v", err)
+	}
+	if got, want := getResp.GetSandbox().GetStatus(), cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDED; got != want {
+		t.Fatalf("unexpected sandbox status: got %v want %v", got, want)
+	}
+}
+
+func TestCreateSnapshotDisabledBackendDoesNotWakeSuspendedSandbox(t *testing.T) {
+	store := newMemorySnapshotStore()
+	adapter := &suspendableAdapter{
+		resumeFn: func(context.Context, string) error {
+			return errors.New("unexpected wake")
+		},
+	}
+	svc := newTestServiceWithSnapshotStore(adapter, store)
+	svc.Config.Backends.Firecracker.Snapshots.Enabled = false
+
+	createResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createResp.GetSandbox().GetSandboxId()
+	if _, err := svc.SuspendSandbox(context.Background(), &cleanroomv1.SuspendSandboxRequest{SandboxId: sandboxID}); err != nil {
+		t.Fatalf("SuspendSandbox returned error: %v", err)
+	}
+
+	_, err = svc.CreateSnapshot(context.Background(), &cleanroomv1.CreateSnapshotRequest{SandboxId: sandboxID})
+	if err == nil {
+		t.Fatal("expected CreateSnapshot to reject disabled snapshots")
+	}
+	if !strings.Contains(err.Error(), "not enabled") {
+		t.Fatalf("unexpected CreateSnapshot error: %v", err)
+	}
+	if got, want := adapter.resumeCalls, 0; got != want {
+		t.Fatalf("unexpected resume calls: got %d want %d", got, want)
+	}
+	if got, want := adapter.createSnapshotCalls, 0; got != want {
+		t.Fatalf("unexpected snapshot calls: got %d want %d", got, want)
+	}
+	getResp, err := svc.GetSandbox(context.Background(), &cleanroomv1.GetSandboxRequest{SandboxId: sandboxID})
+	if err != nil {
+		t.Fatalf("GetSandbox returned error: %v", err)
+	}
+	if got, want := getResp.GetSandbox().GetStatus(), cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDED; got != want {
+		t.Fatalf("unexpected sandbox status: got %v want %v", got, want)
+	}
+}
+
 func TestCreateSnapshotAllowsWorkspaceStageLikeNames(t *testing.T) {
 	store := newMemorySnapshotStore()
 	adapter := &stubAdapter{}


### PR DESCRIPTION
A suspended sandbox should not make users remember to run a manual resume before doing normal work. This change lets guest-touching operations wake the sandbox and then continue once the backend reports it is ready.

For example, `cleanroom exec --in <sandbox-id> -- ...`, sandbox file reads and writes, snapshot creation, and sandbox port dials now wake a suspended sandbox before they touch the guest. Local exposure registration also accepts suspended sandboxes when the backend supports both suspend and port dialing, so the incoming connection wakes through the same `DialSandboxPort` path.

The control service now coalesces concurrent wake attempts per sandbox and tracks active port dials as guest-interaction leases. That gives the later idle-suspend worker a concrete busy marker for open tunnels instead of relying on timing.