### PR TITLE
fix: Constrain submodule mirror remotes

### DIFF
--- a/docs/plans/deepsec-remediation.md
+++ b/docs/plans/deepsec-remediation.md
@@ -1,7 +1,7 @@
 # DeepSec Remediation Plan
 
 **Spec reference:** `docs/spec.md`; `docs/api.md`; `docs/tls.md`; `docs/plans/multi-principal-control-server.md`; `docs/plans/stage-scoped-egress.md`
-**Status:** Slice 1 ready for review
+**Status:** Slice 2 ready for review
 **Last reviewed:** 2026-05-27
 
 ## Summary
@@ -27,6 +27,32 @@ Focused validation run on 2026-05-27:
 
 ```text
 MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise exec -- go test ./internal/backend/darwinvz
+```
+
+Result: passed.
+
+Slice 2 is implemented and ready for review. It rejects file/local submodule
+mirror remotes, canonicalizes mirror submodule remotes with the same repository
+remote rules used for parent checkouts, and allows repository-controlled
+submodule mirroring only when the resolved submodule host matches the already
+validated parent repository host. This intentionally rejects cross-host
+submodules until Cleanroom has an explicit submodule allowlist or host-side
+policy contract for them. Slice 2 also keys mirror-backed submodule digests by
+submodule path, mirror path, and gitlink SHA so two submodules that share a
+remote cannot reuse the wrong commit's digest data.
+
+Focused validation run on 2026-05-27:
+
+```text
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise exec -- go test ./internal/controlservice ./internal/submodule ./internal/repositorystore ./internal/repositorychangeset
+```
+
+Result: passed.
+
+Repository validation run on 2026-05-27:
+
+```text
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise run check
 ```
 
 Result: passed.
@@ -95,6 +121,11 @@ The blocked set also needs to include non-obvious special-use ranges, not just
 RFC1918 and loopback. The Slice 1 test matrix includes CGNAT, documentation,
 benchmarking, reserved, NAT64, AS112, AMT, ORCHIDv2, SRv6 SID, unallocated IPv6,
 and IPv4-mapped private destinations to keep that boundary explicit.
+
+For Slice 2, same-host-only submodule mirroring is the narrow fix. It is stricter
+than allowing any host listed in the workspace egress policy, but it avoids
+turning repository content into a host-side network selector before a dedicated
+submodule mirror policy exists.
 
 ## Validation Standard
 

--- a/internal/controlservice/dependency_stage_test.go
+++ b/internal/controlservice/dependency_stage_test.go
@@ -13,6 +13,11 @@ import (
 	"github.com/buildkite/cleanroom/internal/repositorystore"
 )
 
+const (
+	testParentRemoteURL    = "https://github.com/buildkite/cleanroom.git"
+	testSubmoduleRemoteURL = "https://github.com/buildkite/emojis.git"
+)
+
 func TestExpandStageKeyFilesAtCommitDoublestarGlob(t *testing.T) {
 	repoDir := initControlServiceGitRepo(t)
 	if err := os.MkdirAll(filepath.Join(repoDir, "vendor", "lib"), 0o755); err != nil {
@@ -121,6 +126,8 @@ func initControlServiceGitRepoWithSubmodule(t *testing.T) (superDir, subDir, sup
 	runControlServiceGit(t, superDir, "add", "README.md")
 	runControlServiceGit(t, superDir, "commit", "-m", "initial")
 	runControlServiceGitWithEnv(t, superDir, []string{"GIT_ALLOW_PROTOCOL=file"}, "-c", "protocol.file.allow=always", "submodule", "add", subDir, "vendor/emojis")
+	runControlServiceGit(t, superDir, "config", "-f", ".gitmodules", "submodule.vendor/emojis.url", testSubmoduleRemoteURL)
+	runControlServiceGit(t, superDir, "add", ".gitmodules")
 	runControlServiceGit(t, superDir, "commit", "-m", "add submodule")
 
 	subMirror = t.TempDir()
@@ -184,7 +191,7 @@ func TestStageInputFilesDigestAtCommitDigestsSubmoduleFiles(t *testing.T) {
 
 	store := &testSubmoduleStore{mirrorDir: subMirror}
 
-	digest, err := stageInputFilesDigestAtCommit(context.Background(), superMirror, "", commitSHA, []string{"vendor/emojis/**"}, "test", true, store)
+	digest, err := stageInputFilesDigestAtCommit(context.Background(), superMirror, testParentRemoteURL, commitSHA, []string{"vendor/emojis/**"}, "test", true, store)
 	if err != nil {
 		t.Fatalf("stageInputFilesDigestAtCommit: %v", err)
 	}
@@ -217,7 +224,7 @@ func TestStageInputFilesDigestAtCommitMatchesChangesetPath(t *testing.T) {
 	}
 
 	checkout := &repositorycheckout.Checkout{
-		RemoteURL:      "https://github.com/buildkite/cleanroom.git",
+		RemoteURL:      testParentRemoteURL,
 		CommitSHA:      commitSHA,
 		DestinationDir: "/workspace",
 		Submodules:     true,
@@ -251,7 +258,7 @@ func TestStageInputFilesDigestAtCommitMatchesChangesetPath(t *testing.T) {
 	}
 
 	store := &testSubmoduleStore{mirrorDir: subMirror}
-	atCommitDigest, err := stageInputFilesDigestAtCommit(context.Background(), superMirror, "", commitSHA, pattern, "test", true, store)
+	atCommitDigest, err := stageInputFilesDigestAtCommit(context.Background(), superMirror, testParentRemoteURL, commitSHA, pattern, "test", true, store)
 	if err != nil {
 		t.Fatalf("stageInputFilesDigestAtCommit: %v", err)
 	}
@@ -287,7 +294,7 @@ func TestStageInputFilesDigestWithChangesetResolvesSubmoduleViaMirror(t *testing
 	}
 
 	checkout := &repositorycheckout.Checkout{
-		RemoteURL:      "https://github.com/buildkite/cleanroom.git",
+		RemoteURL:      testParentRemoteURL,
 		CommitSHA:      commitSHA,
 		DestinationDir: "/workspace",
 		Submodules:     true,
@@ -302,7 +309,7 @@ func TestStageInputFilesDigestWithChangesetResolvesSubmoduleViaMirror(t *testing
 
 	store := &testSubmoduleStore{mirrorDir: subMirror}
 
-	digest, err := stageInputFilesDigestWithChangeset(context.Background(), superMirror, changeset, []string{"vendor/emojis/**"}, "test", "", true, store)
+	digest, err := stageInputFilesDigestWithChangeset(context.Background(), superMirror, changeset, []string{"vendor/emojis/**"}, "test", testParentRemoteURL, true, store)
 	if err != nil {
 		t.Fatalf("stageInputFilesDigestWithChangeset (submodules on, mirror): %v", err)
 	}
@@ -340,7 +347,7 @@ func TestStageKeyFilesDigestWithChangesetResolvesGitlinkLiteralViaMirror(t *test
 	}
 
 	checkout := &repositorycheckout.Checkout{
-		RemoteURL:      "https://github.com/buildkite/cleanroom.git",
+		RemoteURL:      testParentRemoteURL,
 		CommitSHA:      commitSHA,
 		DestinationDir: "/workspace",
 		Submodules:     true,
@@ -355,7 +362,7 @@ func TestStageKeyFilesDigestWithChangesetResolvesGitlinkLiteralViaMirror(t *test
 
 	store := &testSubmoduleStore{mirrorDir: subMirror}
 
-	digest, err := stageKeyFilesDigestWithChangeset(context.Background(), superMirror, changeset, []string{"vendor/emojis/**"}, "dependency", "", true, store)
+	digest, err := stageKeyFilesDigestWithChangeset(context.Background(), superMirror, changeset, []string{"vendor/emojis/**"}, "dependency", testParentRemoteURL, true, store)
 	if err != nil {
 		t.Fatalf("stageKeyFilesDigestWithChangeset (mirror, glob): %v", err)
 	}
@@ -398,7 +405,7 @@ func TestStageInputFilesDigestAtCommitRejectsGitlinkLiteral(t *testing.T) {
 
 	store := &testSubmoduleStore{mirrorDir: subMirror}
 
-	_, err := stageInputFilesDigestAtCommit(context.Background(), superMirror, "", commitSHA, []string{"vendor/emojis"}, "test", true, store)
+	_, err := stageInputFilesDigestAtCommit(context.Background(), superMirror, testParentRemoteURL, commitSHA, []string{"vendor/emojis"}, "test", true, store)
 	if err == nil {
 		t.Fatal("expected error for gitlink literal")
 	}
@@ -415,7 +422,7 @@ func TestStageKeyFilesDigestAtCommitRejectsGitlinkLiteral(t *testing.T) {
 
 	store := &testSubmoduleStore{mirrorDir: subMirror}
 
-	_, err := stageKeyFilesDigestAtCommit(context.Background(), superMirror, "", commitSHA, []string{"vendor/emojis"}, "dependency", true, store)
+	_, err := stageKeyFilesDigestAtCommit(context.Background(), superMirror, testParentRemoteURL, commitSHA, []string{"vendor/emojis"}, "dependency", true, store)
 	if err == nil {
 		t.Fatal("expected error for gitlink literal")
 	}

--- a/internal/repositorychangeset/changeset.go
+++ b/internal/repositorychangeset/changeset.go
@@ -200,38 +200,38 @@ func listSubmoduleFiles(sub submoduleSource) ([]string, error) {
 }
 
 type submoduleResolutionKey struct {
-	sourceDir    string
+	source       submoduleDigestSourceKey
 	strippedPath string
 }
 
-func resolveSubmoduleDigests(subs submoduleSet, expandedPaths []string) (map[string]submoduleResolutionKey, map[string]map[string]gitbatch.TreeEntry, map[string]map[string]string, error) {
+type submoduleDigestSourceKey struct {
+	path       string
+	sourceDir  string
+	gitlinkSHA string
+}
+
+func resolveSubmoduleDigests(subs submoduleSet, expandedPaths []string) (map[string]submoduleResolutionKey, map[submoduleDigestSourceKey]map[string]gitbatch.TreeEntry, map[submoduleDigestSourceKey]map[string]string, error) {
 	subFiles := make(map[string]submoduleResolutionKey)
-	type sourceInfo struct {
-		dir        string
-		gitlinkSHA string
-	}
-	pathsBySource := make(map[string]sourceInfo)
-	stripped := make(map[string][]string)
+	stripped := make(map[submoduleDigestSourceKey][]string)
 	for _, normalizedPath := range expandedPaths {
 		sub, ok := subs.FindForPath(normalizedPath)
 		if !ok {
 			continue
 		}
 		strippedPath := strings.TrimPrefix(normalizedPath, sub.Path+"/")
-		subFiles[normalizedPath] = submoduleResolutionKey{sourceDir: sub.SourceDir, strippedPath: strippedPath}
-		pathsBySource[sub.SourceDir] = sourceInfo{dir: sub.SourceDir, gitlinkSHA: sub.GitlinkSHA}
-		stripped[sub.SourceDir] = append(stripped[sub.SourceDir], strippedPath)
+		source := submoduleDigestSourceKey{path: sub.Path, sourceDir: sub.SourceDir, gitlinkSHA: sub.GitlinkSHA}
+		subFiles[normalizedPath] = submoduleResolutionKey{source: source, strippedPath: strippedPath}
+		stripped[source] = append(stripped[source], strippedPath)
 	}
 
-	subEntries := make(map[string]map[string]gitbatch.TreeEntry)
-	subDigests := make(map[string]map[string]string)
-	for sourceDir, strippedPaths := range stripped {
-		info := pathsBySource[sourceDir]
-		entries, err := readSubmoduleTreeEntries(info.dir, info.gitlinkSHA, strippedPaths)
+	subEntries := make(map[submoduleDigestSourceKey]map[string]gitbatch.TreeEntry)
+	subDigests := make(map[submoduleDigestSourceKey]map[string]string)
+	for source, strippedPaths := range stripped {
+		entries, err := readSubmoduleTreeEntries(source.sourceDir, source.gitlinkSHA, strippedPaths)
 		if err != nil {
-			return nil, nil, nil, fmt.Errorf("read submodule index at %q: %w", sourceDir, err)
+			return nil, nil, nil, fmt.Errorf("read submodule index at %q: %w", source.sourceDir, err)
 		}
-		subEntries[sourceDir] = entries
+		subEntries[source] = entries
 
 		var regularPaths []string
 		for _, sp := range strippedPaths {
@@ -240,11 +240,11 @@ func resolveSubmoduleDigests(subs submoduleSet, expandedPaths []string) (map[str
 			}
 		}
 		if len(regularPaths) > 0 {
-			digests, err := readSubmoduleFileDigests(info.dir, info.gitlinkSHA, regularPaths)
+			digests, err := readSubmoduleFileDigests(source.sourceDir, source.gitlinkSHA, regularPaths)
 			if err != nil {
-				return nil, nil, nil, fmt.Errorf("read submodule file digests at %q: %w", sourceDir, err)
+				return nil, nil, nil, fmt.Errorf("read submodule file digests at %q: %w", source.sourceDir, err)
 			}
-			subDigests[sourceDir] = digests
+			subDigests[source] = digests
 		}
 	}
 	return subFiles, subEntries, subDigests, nil
@@ -358,7 +358,7 @@ func (c *Changeset) digestPathsFromBase(repoRoot string, paths []string, regular
 		file := File{Path: normalizedPath}
 
 		if key, inSub := subFiles[normalizedPath]; inSub {
-			entries := subEntries[key.sourceDir]
+			entries := subEntries[key.source]
 			entry, exists := entries[key.strippedPath]
 			if !exists {
 				if regularFilesOnly {
@@ -372,7 +372,7 @@ func (c *Changeset) digestPathsFromBase(repoRoot string, paths []string, regular
 			if regularFilesOnly && !isRegularGitFileMode(entry.Mode) {
 				return nil, fmt.Errorf("repository changeset input path %q is %s; inputs.files must name regular files", normalizedPath, gitModeKind(entry.Mode))
 			}
-			digest, ok := subDigests[key.sourceDir][key.strippedPath]
+			digest, ok := subDigests[key.source][key.strippedPath]
 			if !ok {
 				return nil, fmt.Errorf("read repository changeset path %q from submodule: missing digest", normalizedPath)
 			}

--- a/internal/repositorychangeset/changeset_test.go
+++ b/internal/repositorychangeset/changeset_test.go
@@ -727,6 +727,52 @@ func sha256Hex(data []byte) string {
 	return "sha256:" + hex.EncodeToString(sum[:])
 }
 
+func TestResolveSubmoduleDigestsSeparatesMirrorCommits(t *testing.T) {
+	repoDir := initGitRepository(t)
+
+	firstContent := []byte("first\n")
+	if err := os.WriteFile(filepath.Join(repoDir, "shared.txt"), firstContent, 0o644); err != nil {
+		t.Fatalf("write first shared.txt: %v", err)
+	}
+	runGit(t, repoDir, "add", "shared.txt")
+	runGit(t, repoDir, "commit", "-m", "first shared")
+	firstSHA := headCommit(t, repoDir)
+
+	secondContent := []byte("second\n")
+	if err := os.WriteFile(filepath.Join(repoDir, "shared.txt"), secondContent, 0o644); err != nil {
+		t.Fatalf("write second shared.txt: %v", err)
+	}
+	runGit(t, repoDir, "add", "shared.txt")
+	runGit(t, repoDir, "commit", "-m", "second shared")
+	secondSHA := headCommit(t, repoDir)
+
+	subs := submoduleSet{
+		{Path: "vendor/first", SourceDir: repoDir, GitlinkSHA: firstSHA},
+		{Path: "vendor/second", SourceDir: repoDir, GitlinkSHA: secondSHA},
+	}
+	subFiles, _, subDigests, err := resolveSubmoduleDigests(subs, []string{
+		"vendor/first/shared.txt",
+		"vendor/second/shared.txt",
+	})
+	if err != nil {
+		t.Fatalf("resolveSubmoduleDigests: %v", err)
+	}
+
+	for path, wantDigest := range map[string]string{
+		"vendor/first/shared.txt":  sha256Hex(firstContent),
+		"vendor/second/shared.txt": sha256Hex(secondContent),
+	} {
+		key, ok := subFiles[path]
+		if !ok {
+			t.Fatalf("missing submodule resolution key for %q", path)
+		}
+		got := subDigests[key.source][key.strippedPath]
+		if got != wantDigest {
+			t.Fatalf("wrong digest for %q: got %q want %q", path, got, wantDigest)
+		}
+	}
+}
+
 func TestDigestRegularFilesFromBaseExpandsSubmoduleGlob(t *testing.T) {
 	superDir, subDir := initGitRepositoryWithSubmodule(t)
 
@@ -772,7 +818,7 @@ func TestDigestRegularFilesFromBaseExpandsSubmoduleGlob(t *testing.T) {
 	}
 
 	wantFiles := map[string][]byte{
-		"vendor/emojis/README.md":  []byte("submodule\n"),
+		"vendor/emojis/README.md":   []byte("submodule\n"),
 		"vendor/emojis/emoji1.json": subContents["emoji1.json"],
 		"vendor/emojis/emoji2.json": subContents["emoji2.json"],
 		"vendor/emojis/emoji3.json": subContents["emoji3.json"],

--- a/internal/repositorystore/store.go
+++ b/internal/repositorystore/store.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/buildkite/cleanroom/internal/repositorycheckout"
 )
 
 type FetchHints struct {
@@ -97,10 +99,14 @@ func (s *mirrorBackedRepositoryStore) EnsureSubmoduleMirror(ctx context.Context,
 	if s == nil || s.mirrors == nil {
 		return "", fmt.Errorf("repository store is nil")
 	}
-	if err := s.mirrors.EnsureMirrorContains(ctx, submoduleRemoteURL, gitlinkSHA); err != nil {
+	canonicalRemoteURL, _, err := repositorycheckout.CanonicalizeRemoteURL(submoduleRemoteURL)
+	if err != nil {
+		return "", fmt.Errorf("validate submodule remote URL: %w", err)
+	}
+	if err := s.mirrors.EnsureMirrorContains(ctx, canonicalRemoteURL, gitlinkSHA); err != nil {
 		return "", err
 	}
-	return s.mirrors.MirrorPath(submoduleRemoteURL)
+	return s.mirrors.MirrorPath(canonicalRemoteURL)
 }
 
 func (s *mirrorBackedRepositoryStore) repositoryPath(ctx context.Context, remoteURL string) (string, error) {

--- a/internal/repositorystore/store_test.go
+++ b/internal/repositorystore/store_test.go
@@ -115,6 +115,20 @@ func TestEnsureSubmoduleMirror(t *testing.T) {
 	}
 }
 
+func TestEnsureSubmoduleMirrorRejectsLocalRemote(t *testing.T) {
+	t.Parallel()
+
+	store := NewMirrorBacked(&mockMirrorSource{mirrorPath: "/mirrors/submodule"})
+
+	_, err := store.EnsureSubmoduleMirror(context.Background(), "file:///private/repo.git", "abc1234abc1234abc1234abc1234abc1234abc12")
+	if err == nil {
+		t.Fatal("expected file remote to be rejected")
+	}
+	if !strings.Contains(err.Error(), "must use https") {
+		t.Fatalf("expected canonicalization error, got %v", err)
+	}
+}
+
 type mockMirrorSource struct {
 	mirrorPath              string
 	ensureMirrorContainsURL string

--- a/internal/submodule/mirror_test.go
+++ b/internal/submodule/mirror_test.go
@@ -35,7 +35,8 @@ func headCommit(t *testing.T, dir string) string {
 func TestListMirrorSubmodulesAtCommit(t *testing.T) {
 	subDir := initSubmoduleRepo(t)
 	subMirrorDir := initBareMirror(t, subDir)
-	subURL := "https://example.com/sub.git"
+	parentURL := "https://example.com/org/super.git"
+	subURL := "https://example.com/org/sub.git"
 
 	superDir := t.TempDir()
 	runGit(t, superDir, "init")
@@ -56,7 +57,7 @@ func TestListMirrorSubmodulesAtCommit(t *testing.T) {
 		return subMirrorDir, nil
 	}
 
-	subs, err := ListMirrorSubmodulesAtCommit(context.Background(), superMirrorDir, "", commitSHA, ensureMirror)
+	subs, err := ListMirrorSubmodulesAtCommit(context.Background(), superMirrorDir, parentURL, commitSHA, ensureMirror)
 	if err != nil {
 		t.Fatalf("ListMirrorSubmodulesAtCommit returned error: %v", err)
 	}

--- a/internal/submodule/submodule.go
+++ b/internal/submodule/submodule.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/buildkite/cleanroom/internal/repositorycheckout"
 )
 
 type WorktreeSubmodule struct {
@@ -134,9 +136,9 @@ func ListMirrorSubmodulesAtCommit(ctx context.Context, parentMirrorDir, parentRe
 			return nil, err
 		}
 
-		resolvedURL, err := ResolveSubmoduleURL(parentRemoteURL, entry.URL)
+		resolvedURL, err := ResolveMirrorSubmoduleURL(parentRemoteURL, entry.URL)
 		if err != nil {
-			return nil, fmt.Errorf("resolve submodule URL for %q: %w", entry.Path, err)
+			return nil, fmt.Errorf("validate mirror submodule URL for %q: %w", entry.Path, err)
 		}
 
 		mirrorDir, err := ensureMirror(ctx, resolvedURL, gitlinkSHA)
@@ -194,9 +196,9 @@ func ListMirrorSubmodulesAtIndex(ctx context.Context, repoRoot string, env []str
 			return nil, err
 		}
 
-		resolvedURL, err := ResolveSubmoduleURL(parentRemoteURL, entry.URL)
+		resolvedURL, err := ResolveMirrorSubmoduleURL(parentRemoteURL, entry.URL)
 		if err != nil {
-			return nil, fmt.Errorf("resolve submodule URL for %q: %w", entry.Path, err)
+			return nil, fmt.Errorf("validate mirror submodule URL for %q: %w", entry.Path, err)
 		}
 
 		mirrorDir, err := ensureMirror(ctx, resolvedURL, gitlinkSHA)
@@ -334,6 +336,25 @@ func ResolveSubmoduleURL(parentRemoteURL, submoduleURL string) (string, error) {
 			return scheme + base + string(sep) + submoduleURL, nil
 		}
 	}
+}
+
+func ResolveMirrorSubmoduleURL(parentRemoteURL, submoduleURL string) (string, error) {
+	resolved, err := ResolveSubmoduleURL(parentRemoteURL, submoduleURL)
+	if err != nil {
+		return "", err
+	}
+	_, parentHost, err := repositorycheckout.CanonicalizeRemoteURL(parentRemoteURL)
+	if err != nil {
+		return "", fmt.Errorf("canonicalize parent remote: %w", err)
+	}
+	canonicalSubmoduleURL, submoduleHost, err := repositorycheckout.CanonicalizeRemoteURL(resolved)
+	if err != nil {
+		return "", fmt.Errorf("canonicalize submodule remote: %w", err)
+	}
+	if submoduleHost != parentHost {
+		return "", fmt.Errorf("submodule remote host %q does not match parent repository host %q", submoduleHost, parentHost)
+	}
+	return canonicalSubmoduleURL, nil
 }
 
 func splitNullTerminated(data []byte) []string {

--- a/internal/submodule/submodule_test.go
+++ b/internal/submodule/submodule_test.go
@@ -296,3 +296,65 @@ func TestResolveSubmoduleURL(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveMirrorSubmoduleURL(t *testing.T) {
+	cases := []struct {
+		name      string
+		parent    string
+		submodule string
+		want      string
+		wantErr   string
+	}{
+		{
+			name:      "relative same host",
+			parent:    "https://github.com/buildkite/cleanroom.git",
+			submodule: "../tooling.git",
+			want:      "https://github.com/buildkite/tooling.git",
+		},
+		{
+			name:      "ssh form same host",
+			parent:    "https://github.com/buildkite/cleanroom.git",
+			submodule: "git@github.com:buildkite/tooling.git",
+			want:      "https://github.com/buildkite/tooling.git",
+		},
+		{
+			name:      "file rejected",
+			parent:    "https://github.com/buildkite/cleanroom.git",
+			submodule: "file:///private/repo.git",
+			wantErr:   "must use https",
+		},
+		{
+			name:      "http rejected",
+			parent:    "https://github.com/buildkite/cleanroom.git",
+			submodule: "http://github.com/buildkite/tooling.git",
+			wantErr:   "must use https",
+		},
+		{
+			name:      "different host rejected",
+			parent:    "https://github.com/buildkite/cleanroom.git",
+			submodule: "https://example.com/buildkite/tooling.git",
+			wantErr:   "does not match parent",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ResolveMirrorSubmoduleURL(tc.parent, tc.submodule)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error, got %q", got)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("expected error containing %q, got %v", tc.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ResolveMirrorSubmoduleURL: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %q want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Repository-controlled `.gitmodules` entries could make the host mirror layer fetch arbitrary HTTPS or file remotes while computing dependency, service, or changeset digests. That bypassed the parent repository's workspace network boundary and also let two submodules sharing one mirror path collide when they pointed at different gitlink commits.

This PR is stacked on PR #448 and covers the next DeepSec remediation slice. It canonicalizes mirror submodule remotes with the repository checkout rules, rejects file/local remotes, and only mirrors submodules whose resolved host matches the already validated parent repository host. It also keys mirror-backed submodule digest reads by submodule path, mirror path, and gitlink SHA so identical remotes at different commits stay separate.

Cross-host submodules now fail closed until Cleanroom has an explicit submodule mirror allowlist or host-side policy contract. I validated the change with the focused controlservice/submodule/repositorystore/repositorychangeset tests and `mise run check`.
