### PR TITLE
fix: Harden daemon install listeners

### DIFF
--- a/docs/plans/deepsec-remediation.md
+++ b/docs/plans/deepsec-remediation.md
@@ -1,7 +1,7 @@
 # DeepSec Remediation Plan
 
 **Spec reference:** `docs/spec.md`; `docs/api.md`; `docs/tls.md`; `docs/plans/multi-principal-control-server.md`; `docs/plans/stage-scoped-egress.md`
-**Status:** Slice 3 ready for review
+**Status:** Slice 4a ready for review
 **Last reviewed:** 2026-05-27
 
 ## Summary
@@ -95,6 +95,32 @@ MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/eaa8/cleanroom/mise.to
 
 Result: passed.
 
+Slice 4a is implemented and ready for review. Daemon install now rejects
+newlines, carriage returns, and NUL bytes in the generated service command
+before writing systemd or launchd service files. It also refuses non-loopback
+TCP control-plane daemon listeners unless runtime `auth.required` is enabled.
+When auth is enabled, non-loopback plain HTTP is still rejected because bearer
+tokens are only allowed over HTTPS or loopback HTTP.
+
+The DNS resolver install and exposure certificate symlink hardening findings
+remain in Slice 4b.
+
+Focused validation run on 2026-05-27:
+
+```text
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/eaa8/cleanroom/mise.toml mise exec -- go test ./internal/cli
+```
+
+Result: passed.
+
+Repository validation run on 2026-05-27:
+
+```text
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/eaa8/cleanroom/mise.toml mise run check
+```
+
+Result: passed.
+
 ## Triage
 
 | Finding | Severity | Decision | Remediation slice |
@@ -106,39 +132,40 @@ Result: passed.
 | Remote control-plane RPCs are exposed without authentication | High | Needs fix | Slice 3: multi-principal control-server enforcement |
 | Sandbox port dial RPC lacks caller authentication and authorization | High | Needs fix | Slice 3: multi-principal control-server enforcement |
 | Network control-plane listeners do not enforce configured caller authentication | High | Needs fix | Slice 3: multi-principal control-server enforcement |
-| Daemon install can expose the unauthenticated control plane on TCP | High | Needs fix | Slice 4: privileged installer argument and path hardening, plus TCP auth guardrails |
-| Newlines in daemon arguments can inject systemd unit directives | High | Needs fix | Slice 4: privileged installer argument and path hardening |
-| Privileged DNS install writes and chowns certificate paths in a user-controlled directory without symlink checks | High | Needs fix | Slice 4: privileged installer argument and path hardening |
-| Privileged certificate writes follow user-controlled symlinks | High | Needs fix | Slice 4: privileged installer argument and path hardening |
-| Remote URL path can inject fields into git credential fill lookup | High | Needs fix | Slice 5: gateway credential and cache authorization hardening |
-| Cached Git pack responses are not scoped to current repo authorization | High | Needs fix | Slice 5: gateway credential and cache authorization hardening |
-| Policy protobufs can request allow-all sandbox egress | High | Needs fix | Slice 6: policy compile and protobuf validation hardening |
+| Daemon install can expose the unauthenticated control plane on TCP | High | Needs fix | Slice 4a: daemon install listener and argument hardening |
+| Newlines in daemon arguments can inject systemd unit directives | High | Needs fix | Slice 4a: daemon install listener and argument hardening |
+| Privileged DNS install writes and chowns certificate paths in a user-controlled directory without symlink checks | High | Needs fix | Slice 4b: DNS and exposure certificate path hardening |
+| Privileged certificate writes follow user-controlled symlinks | High | Needs fix | Slice 4b: DNS and exposure certificate path hardening |
+| Remote URL path can inject fields into git credential fill lookup | High | Needs fix | Slice 6: gateway credential and cache authorization hardening |
+| Cached Git pack responses are not scoped to current repo authorization | High | Needs fix | Slice 6: gateway credential and cache authorization hardening |
+| Policy protobufs can request allow-all sandbox egress | High | Needs fix | Slice 7: policy compile and protobuf validation hardening |
 | Repository-controlled submodule URLs are mirrored by the host without policy validation | High | Needs fix | Slice 2: host-side repository mirror policy enforcement |
-| Unbounded OCI handler creation from request-controlled registry prefixes | High bug | Needs fix | Slice 5: gateway credential and cache authorization hardening |
-| Unbounded rootfs tar extraction can exhaust host disk | High bug | Needs fix | Slice 7: image and boot asset resource bounds |
+| Unbounded OCI handler creation from request-controlled registry prefixes | High bug | Needs fix | Slice 6: gateway credential and cache authorization hardening |
+| Unbounded rootfs tar extraction can exhaust host disk | High bug | Needs fix | Slice 8: image and boot asset resource bounds |
 | Submodule digesting conflates identical mirror paths at different commits | High bug | Needs fix | Slice 2: host-side repository mirror policy enforcement |
-| Mutable GitHub Action refs run with package publish permission | Medium | Needs fix | Slice 8: CI supply-chain pinning |
-| Release manifest fields are used as host cache path components | Medium | Needs fix | Slice 7: image and boot asset resource bounds |
-| Fetch cache hits can bypass per-sandbox redirect policy | Medium | Needs fix | Slice 5: gateway credential and cache authorization hardening |
-| Go proxy cache hits can bypass effective policy validation | Medium | Needs fix | Slice 5: gateway credential and cache authorization hardening |
-| Snapshot storage can be orphaned when VM resume fails | Bug | Needs fix | Slice 9: darwin-vz lifecycle cleanup |
-| Portable dependency validation treats glob key files as literals | Bug | Needs fix | Slice 10: dependency validation correctness |
-| Newline-containing Git paths break batched digest calculation | Bug | Needs fix | Slice 10: dependency validation correctness |
-| Workspace copy-out trusts guest-reported paths before applying the guest patch | High | Needs fix | Slice 11: workspace copy-out trust-boundary hardening |
+| Mutable GitHub Action refs run with package publish permission | Medium | Needs fix | Slice 9: CI supply-chain pinning |
+| Release manifest fields are used as host cache path components | Medium | Needs fix | Slice 8: image and boot asset resource bounds |
+| Fetch cache hits can bypass per-sandbox redirect policy | Medium | Needs fix | Slice 6: gateway credential and cache authorization hardening |
+| Go proxy cache hits can bypass effective policy validation | Medium | Needs fix | Slice 6: gateway credential and cache authorization hardening |
+| Snapshot storage can be orphaned when VM resume fails | Bug | Needs fix | Slice 10: darwin-vz lifecycle cleanup |
+| Portable dependency validation treats glob key files as literals | Bug | Needs fix | Slice 11: dependency validation correctness |
+| Newline-containing Git paths break batched digest calculation | Bug | Needs fix | Slice 11: dependency validation correctness |
+| Workspace copy-out trusts guest-reported paths before applying the guest patch | High | Needs fix | Slice 12: workspace copy-out trust-boundary hardening |
 
 ## Slice Order
 
 1. Block unsafe darwin-vz file-handle gateway host dials.
 2. Enforce repository mirror policy for submodules, including `file://` and host-local targets, and repair submodule cache keys.
 3. Land configured multi-principal control-server enforcement using the existing auth plan.
-4. Harden privileged installer argument handling, certificate writes, symlink behavior, and daemon TCP auth guardrails.
-5. Bind gateway credentials and cache hits to the current authorization and effective policy.
-6. Reject unsafe policy protobufs before backend execution.
-7. Bound image/rootfs extraction and sanitize boot asset cache path components.
-8. Pin publish-capable GitHub Actions workflows to immutable refs.
-9. Clean up darwin-vz snapshot storage when resume fails.
-10. Fix dependency and Git path validation edge cases.
-11. Apply guest workspace patches before trusting copy-out paths.
+4. Harden daemon install listener and argument handling.
+5. Harden DNS installer and exposure certificate path behavior.
+6. Bind gateway credentials and cache hits to the current authorization and effective policy.
+7. Reject unsafe policy protobufs before backend execution.
+8. Bound image/rootfs extraction and sanitize boot asset cache path components.
+9. Pin publish-capable GitHub Actions workflows to immutable refs.
+10. Clean up darwin-vz snapshot storage when resume fails.
+11. Fix dependency and Git path validation edge cases.
+12. Apply guest workspace patches before trusting copy-out paths.
 
 ## Key Learnings From Pressure-Testing
 

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -293,10 +294,75 @@ func (s *DaemonCommand) installDaemon(ctx *runtimeContext) error {
 	if err != nil {
 		return err
 	}
+	if err := validateDaemonServiceCommand(executablePath, args); err != nil {
+		return err
+	}
+	if err := validateDaemonInstallListenAuth(args, ctx.Config); err != nil {
+		return err
+	}
 	return installFn(ctx.Stdout, executablePath, args, daemonInstallOptions{
 		Restart: s.Restart,
 		DryRun:  s.DryRun,
 	})
+}
+
+func validateDaemonServiceCommand(executablePath string, args []string) error {
+	values := append([]string{executablePath}, args...)
+	for i, value := range values {
+		if !strings.ContainsAny(value, "\x00\r\n") {
+			continue
+		}
+		name := "executable path"
+		if i > 0 {
+			name = fmt.Sprintf("argument %d", i)
+		}
+		return fmt.Errorf("daemon service %s must not contain newlines or NUL bytes", name)
+	}
+	return nil
+}
+
+func validateDaemonInstallListenAuth(args []string, cfg runtimeconfig.Config) error {
+	listen := daemonServiceArgValue(args, "--listen")
+	ep, err := endpoint.ResolveListen(listen)
+	if err != nil {
+		return fmt.Errorf("validate daemon listen endpoint: %w", err)
+	}
+	if ep.Scheme == "unix" {
+		return nil
+	}
+	if cfg.Auth.Required {
+		if err := validateBearerAuthListenEndpoint(ep); err != nil {
+			return err
+		}
+		return nil
+	}
+	if daemonTCPEndpointIsLoopback(ep) {
+		return nil
+	}
+	return errors.New("daemon install with a non-loopback TCP listener requires auth.required=true; use a unix socket, loopback listener, or enable auth")
+}
+
+func daemonServiceArgValue(args []string, name string) string {
+	for i := 0; i < len(args)-1; i++ {
+		if strings.TrimSpace(args[i]) == name {
+			return strings.TrimSpace(args[i+1])
+		}
+	}
+	return ""
+}
+
+func daemonTCPEndpointIsLoopback(ep endpoint.Endpoint) bool {
+	switch ep.Scheme {
+	case "http", "https":
+	default:
+		return false
+	}
+	parsed, err := url.Parse(strings.TrimSpace(ep.Address))
+	if err != nil {
+		return false
+	}
+	host := strings.TrimSpace(parsed.Hostname())
+	return host != "" && isLoopbackListenHost(host)
 }
 
 func (s *DaemonCommand) uninstallDaemon(ctx *runtimeContext) error {

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -727,6 +727,197 @@ func TestDaemonInstallUsesProvidedListenInUnit(t *testing.T) {
 	}
 }
 
+func TestDaemonInstallRejectsControlCharactersInServiceArgs(t *testing.T) {
+	tmpDir := t.TempDir()
+	unitPath := filepath.Join(tmpDir, "cleanroom.service")
+
+	prevEUID := serveInstallEUID
+	prevGOOS := serveInstallGOOS
+	prevSystemdPath := serveInstallSystemdUnitPath
+	prevExecutable := serveInstallExecutablePath
+	prevRunCommand := serveInstallRunCommand
+	serveInstallEUID = func() int { return 0 }
+	serveInstallGOOS = "linux"
+	serveInstallSystemdUnitPath = unitPath
+	serveInstallExecutablePath = func() (string, error) { return "/usr/local/bin/cleanroom", nil }
+	serveInstallRunCommand = func(name string, args ...string) error {
+		t.Fatalf("did not expect service manager command %s %v", name, args)
+		return nil
+	}
+	t.Cleanup(func() {
+		serveInstallEUID = prevEUID
+		serveInstallGOOS = prevGOOS
+		serveInstallSystemdUnitPath = prevSystemdPath
+		serveInstallExecutablePath = prevExecutable
+		serveInstallRunCommand = prevRunCommand
+	})
+
+	stdout, _ := makeStdoutCapture(t)
+	cmd := &DaemonCommand{
+		Action: "install",
+		Listen: "unix:///tmp/cleanroom.sock\n" +
+			"Environment=EVIL=1",
+	}
+	err := cmd.Run(daemonInstallContext(tmpDir, stdout))
+	if err == nil {
+		t.Fatal("expected control-character rejection")
+	}
+	if !strings.Contains(err.Error(), "must not contain newlines or NUL bytes") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, statErr := os.Stat(unitPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("expected no service file to be written, stat err=%v", statErr)
+	}
+}
+
+func TestDaemonInstallRejectsNonLoopbackTCPWithoutAuth(t *testing.T) {
+	tmpDir := t.TempDir()
+	unitPath := filepath.Join(tmpDir, "cleanroom.service")
+
+	prevEUID := serveInstallEUID
+	prevGOOS := serveInstallGOOS
+	prevSystemdPath := serveInstallSystemdUnitPath
+	prevExecutable := serveInstallExecutablePath
+	prevRunCommand := serveInstallRunCommand
+	serveInstallEUID = func() int { return 0 }
+	serveInstallGOOS = "linux"
+	serveInstallSystemdUnitPath = unitPath
+	serveInstallExecutablePath = func() (string, error) { return "/usr/local/bin/cleanroom", nil }
+	serveInstallRunCommand = func(name string, args ...string) error {
+		t.Fatalf("did not expect service manager command %s %v", name, args)
+		return nil
+	}
+	t.Cleanup(func() {
+		serveInstallEUID = prevEUID
+		serveInstallGOOS = prevGOOS
+		serveInstallSystemdUnitPath = prevSystemdPath
+		serveInstallExecutablePath = prevExecutable
+		serveInstallRunCommand = prevRunCommand
+	})
+
+	stdout, _ := makeStdoutCapture(t)
+	cmd := &DaemonCommand{Action: "install", Listen: "https://0.0.0.0:7777"}
+	err := cmd.Run(daemonInstallContext(tmpDir, stdout))
+	if err == nil {
+		t.Fatal("expected non-loopback TCP auth error")
+	}
+	if !strings.Contains(err.Error(), "requires auth.required=true") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, statErr := os.Stat(unitPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("expected no service file to be written, stat err=%v", statErr)
+	}
+}
+
+func TestDaemonInstallAllowsNonLoopbackHTTPSWithAuth(t *testing.T) {
+	tmpDir := t.TempDir()
+	unitPath := filepath.Join(tmpDir, "cleanroom.service")
+	stdout, _ := makeStdoutCapture(t)
+	ctx := daemonInstallContext(tmpDir, stdout)
+	writeDaemonAuthRuntimeConfig(t, ctx.ConfigPath)
+
+	prevEUID := serveInstallEUID
+	prevGOOS := serveInstallGOOS
+	prevSystemdPath := serveInstallSystemdUnitPath
+	prevExecutable := serveInstallExecutablePath
+	prevRunCommand := serveInstallRunCommand
+	serveInstallEUID = func() int { return 0 }
+	serveInstallGOOS = "linux"
+	serveInstallSystemdUnitPath = unitPath
+	serveInstallExecutablePath = func() (string, error) { return "/usr/local/bin/cleanroom", nil }
+	var calls [][]string
+	serveInstallRunCommand = func(name string, args ...string) error {
+		calls = append(calls, append([]string{name}, args...))
+		if len(args) > 0 && args[0] == "is-active" {
+			return &exec.ExitError{ProcessState: &os.ProcessState{}}
+		}
+		return nil
+	}
+	t.Cleanup(func() {
+		serveInstallEUID = prevEUID
+		serveInstallGOOS = prevGOOS
+		serveInstallSystemdUnitPath = prevSystemdPath
+		serveInstallExecutablePath = prevExecutable
+		serveInstallRunCommand = prevRunCommand
+	})
+
+	cmd := &DaemonCommand{Action: "install", Listen: "https://0.0.0.0:7777"}
+	if err := cmd.Run(ctx); err != nil {
+		t.Fatalf("DaemonCommand.Run returned error: %v", err)
+	}
+
+	raw, err := os.ReadFile(unitPath)
+	if err != nil {
+		t.Fatalf("read generated unit: %v", err)
+	}
+	if !strings.Contains(string(raw), "--listen https://0.0.0.0:7777") {
+		t.Fatalf("expected configured https listener in unit, got:\n%s", raw)
+	}
+	if len(calls) == 0 {
+		t.Fatal("expected service manager calls")
+	}
+}
+
+func TestDaemonInstallRejectsNonLoopbackHTTPWithAuth(t *testing.T) {
+	tmpDir := t.TempDir()
+	unitPath := filepath.Join(tmpDir, "cleanroom.service")
+	stdout, _ := makeStdoutCapture(t)
+	ctx := daemonInstallContext(tmpDir, stdout)
+	writeDaemonAuthRuntimeConfig(t, ctx.ConfigPath)
+
+	prevEUID := serveInstallEUID
+	prevGOOS := serveInstallGOOS
+	prevSystemdPath := serveInstallSystemdUnitPath
+	prevExecutable := serveInstallExecutablePath
+	prevRunCommand := serveInstallRunCommand
+	serveInstallEUID = func() int { return 0 }
+	serveInstallGOOS = "linux"
+	serveInstallSystemdUnitPath = unitPath
+	serveInstallExecutablePath = func() (string, error) { return "/usr/local/bin/cleanroom", nil }
+	serveInstallRunCommand = func(name string, args ...string) error {
+		t.Fatalf("did not expect service manager command %s %v", name, args)
+		return nil
+	}
+	t.Cleanup(func() {
+		serveInstallEUID = prevEUID
+		serveInstallGOOS = prevGOOS
+		serveInstallSystemdUnitPath = prevSystemdPath
+		serveInstallExecutablePath = prevExecutable
+		serveInstallRunCommand = prevRunCommand
+	})
+
+	cmd := &DaemonCommand{Action: "install", Listen: "http://0.0.0.0:7777"}
+	err := cmd.Run(ctx)
+	if err == nil {
+		t.Fatal("expected non-loopback HTTP auth error")
+	}
+	if !strings.Contains(err.Error(), "non-loopback http listen endpoint") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, statErr := os.Stat(unitPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("expected no service file to be written, stat err=%v", statErr)
+	}
+}
+
+func writeDaemonAuthRuntimeConfig(t *testing.T, path string) {
+	t.Helper()
+	content := `default_backend: firecracker
+auth:
+  required: true
+  policy_file: /tmp/cleanroom-auth-policy.yaml
+  oidc:
+    issuers:
+      - name: test
+        issuer: https://issuer.example
+        audiences:
+          - cleanroom
+        jwks_url: https://issuer.example/jwks
+`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write auth runtime config: %v", err)
+	}
+}
+
 func TestDaemonInstallDarwinEnablesBootstrapsAndKickstartsUserService(t *testing.T) {
 	tmpDir := t.TempDir()
 	plistPath := filepath.Join(tmpDir, "Library", "LaunchAgents", launchdServiceName+".plist")


### PR DESCRIPTION
Daemon-installed Cleanroom services are durable, so a bad install command can leave a host with either a malformed service file or an unauthenticated remote control-plane listener.

This PR rejects newlines, carriage returns, and NUL bytes in the generated daemon service command before writing systemd or launchd service files. It also blocks daemon installs that would bind the control plane to a non-loopback TCP listener unless runtime `auth.required` is enabled. With auth enabled, non-loopback plain HTTP is still rejected because bearer tokens must use HTTPS or loopback HTTP.

This covers the daemon install part of the DeepSec installer hardening slice. DNS resolver install and exposure certificate symlink hardening remain in the next slice.
