### PR TITLE
fix: Harden DNS certificate paths

### DIFF
--- a/docs/plans/deepsec-remediation.md
+++ b/docs/plans/deepsec-remediation.md
@@ -127,8 +127,9 @@ the opened file still matches the inspected regular file, and write refreshed
 certificate material through a same-directory temporary file before rename. The
 privileged DNS installer also refuses to trust, remove trust for, or chown
 certificate paths when the invoking user's TLS directory path contains symlink
-components from the user's home or configured XDG config root, and it uses
-`lchown` for the ownership handoff.
+components from the user's home or configured XDG config root. During sudo
+installs, `XDG_CONFIG_HOME` must stay inside the invoking user's home, and the
+ownership handoff uses `lchown`.
 
 Focused validation run on 2026-05-27:
 

--- a/docs/plans/deepsec-remediation.md
+++ b/docs/plans/deepsec-remediation.md
@@ -122,12 +122,13 @@ MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/eaa8/cleanroom/mise.to
 Result: passed.
 
 Slice 4b is implemented and ready for review. Exposure certificate reads now
-reject symlinked certificate/key paths, verify the opened file still matches the
-inspected regular file, and write refreshed certificate material through a
-same-directory temporary file before rename. The privileged DNS installer also
-refuses to trust, remove trust for, or chown certificate paths when the invoking
-user's TLS directory path contains symlink components from the user's home or
-configured XDG config root, and it uses `lchown` for the ownership handoff.
+reject symlinked certificate/key paths and symlinked TLS path ancestors, verify
+the opened file still matches the inspected regular file, and write refreshed
+certificate material through a same-directory temporary file before rename. The
+privileged DNS installer also refuses to trust, remove trust for, or chown
+certificate paths when the invoking user's TLS directory path contains symlink
+components from the user's home or configured XDG config root, and it uses
+`lchown` for the ownership handoff.
 
 Focused validation run on 2026-05-27:
 

--- a/docs/plans/deepsec-remediation.md
+++ b/docs/plans/deepsec-remediation.md
@@ -1,7 +1,7 @@
 # DeepSec Remediation Plan
 
 **Spec reference:** `docs/spec.md`; `docs/api.md`; `docs/tls.md`; `docs/plans/multi-principal-control-server.md`; `docs/plans/stage-scoped-egress.md`
-**Status:** Slice 4a ready for review
+**Status:** Slice 4b ready for review
 **Last reviewed:** 2026-05-27
 
 ## Summary
@@ -102,8 +102,40 @@ TCP control-plane daemon listeners unless runtime `auth.required` is enabled.
 When auth is enabled, non-loopback plain HTTP is still rejected because bearer
 tokens are only allowed over HTTPS or loopback HTTP.
 
-The DNS resolver install and exposure certificate symlink hardening findings
-remain in Slice 4b.
+The DNS resolver install and exposure certificate symlink hardening findings are
+covered in Slice 4b.
+
+Focused validation run on 2026-05-27:
+
+```text
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/eaa8/cleanroom/mise.toml mise exec -- go test ./internal/cli
+```
+
+Result: passed.
+
+Repository validation run on 2026-05-27:
+
+```text
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/eaa8/cleanroom/mise.toml mise run check
+```
+
+Result: passed.
+
+Slice 4b is implemented and ready for review. Exposure certificate reads now
+reject symlinked certificate/key paths, verify the opened file still matches the
+inspected regular file, and write refreshed certificate material through a
+same-directory temporary file before rename. The privileged DNS installer also
+refuses to trust, remove trust for, or chown certificate paths when the invoking
+user's TLS directory path contains symlink components from the user's home or
+configured XDG config root, and it uses `lchown` for the ownership handoff.
+
+Focused validation run on 2026-05-27:
+
+```text
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/eaa8/cleanroom/mise.toml mise exec -- go test ./internal/exposure
+```
+
+Result: passed.
 
 Focused validation run on 2026-05-27:
 

--- a/docs/plans/deepsec-remediation.md
+++ b/docs/plans/deepsec-remediation.md
@@ -127,9 +127,10 @@ the opened file still matches the inspected regular file, and write refreshed
 certificate material through a same-directory temporary file before rename. The
 privileged DNS installer also refuses to trust, remove trust for, or chown
 certificate paths when the invoking user's TLS directory path contains symlink
-components from the user's home or configured XDG config root. During sudo
-installs, `XDG_CONFIG_HOME` must stay inside the invoking user's home, and the
-ownership handoff uses `lchown`.
+components from the user's home or configured XDG config root, and it validates
+the existing certificate/key pair before changing trust-store state. During
+sudo installs, `XDG_CONFIG_HOME` must stay inside the invoking user's home, and
+the ownership handoff uses `lchown`.
 
 Focused validation run on 2026-05-27:
 

--- a/docs/plans/deepsec-remediation.md
+++ b/docs/plans/deepsec-remediation.md
@@ -130,7 +130,8 @@ certificate paths when the invoking user's TLS directory path contains symlink
 components from the user's home or configured XDG config root, and it validates
 the existing certificate/key pair before changing trust-store state. During
 sudo installs, `XDG_CONFIG_HOME` must stay inside the invoking user's home, and
-the ownership handoff uses `lchown`.
+`dns status` reports that configuration error instead of hiding it. The
+ownership handoff uses `lchown`.
 
 Focused validation run on 2026-05-27:
 

--- a/internal/cli/dns.go
+++ b/internal/cli/dns.go
@@ -98,12 +98,22 @@ func (c *DNSCommand) installDNS(ctx *runtimeContext) error {
 		return err
 	}
 	certPath := filepath.Join(tlsDir, exposure.LocalCertificateFilename)
-	if _, err := dnsInstallReadRegularFile(certPath); err == nil {
+	certExists, err := dnsInstallRegularFileExists(certPath)
+	if err != nil {
+		return fmt.Errorf("read exposure certificate %s: %w", certPath, err)
+	}
+	if certExists {
+		keyPath := filepath.Join(tlsDir, exposure.LocalCertificateKeyFilename)
+		keyExists, err := dnsInstallRegularFileExists(keyPath)
+		if err != nil {
+			return fmt.Errorf("read exposure certificate key %s: %w", keyPath, err)
+		}
+		if !keyExists {
+			return fmt.Errorf("read exposure certificate key %s: %w", keyPath, fs.ErrNotExist)
+		}
 		if err := removeExposureCertificateTrust(certPath); err != nil {
 			return err
 		}
-	} else if err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return fmt.Errorf("read exposure certificate %s: %w", certPath, err)
 	}
 	parentDirs := exposureTLSParentDirsToChown(tlsDir)
 	cert, err := exposure.EnsureLocalCertificate(exposure.Domain, tlsDir)
@@ -480,6 +490,16 @@ func dnsInstallReadRegularFile(path string) ([]byte, error) {
 		return nil, fmt.Errorf("%s is not a regular file", path)
 	}
 	return dnsInstallReadRegularFileMatchingInfo(path, info)
+}
+
+func dnsInstallRegularFileExists(path string) (bool, error) {
+	if _, err := dnsInstallReadRegularFile(path); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 func dnsInstallReadRegularFileMatchingInfo(path string, info os.FileInfo) ([]byte, error) {

--- a/internal/cli/dns.go
+++ b/internal/cli/dns.go
@@ -312,6 +312,10 @@ func resolverFileListen(data []byte, fallback string) string {
 
 func dnsExposureTLSDir() (string, error) {
 	if configHome := strings.TrimSpace(dnsInstallGetenv("XDG_CONFIG_HOME")); configHome != "" {
+		configHome = filepath.Clean(configHome)
+		if home := dnsExposureInvokingHomeDir(); home != "" && !pathWithinDir(home, configHome) {
+			return "", fmt.Errorf("XDG_CONFIG_HOME %s must be inside invoking user home %s for dns install", configHome, home)
+		}
 		return filepath.Join(configHome, "cleanroom", "tls"), nil
 	}
 	if home := dnsExposureInvokingHomeDir(); home != "" {

--- a/internal/cli/dns.go
+++ b/internal/cli/dns.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"net"
 	"os"
@@ -41,12 +42,13 @@ var (
 	dnsInstallGOOS         = runtime.GOOS
 	dnsInstallEUID         = os.Geteuid
 	dnsInstallMkdirAll     = os.MkdirAll
+	dnsInstallLstat        = os.Lstat
 	dnsInstallReadFile     = os.ReadFile
 	dnsInstallWriteFile    = os.WriteFile
 	dnsInstallRemoveFile   = os.Remove
 	dnsInstallRunCommand   = runDNSInstallCommand
 	dnsInstallLookupUser   = user.Lookup
-	dnsInstallChown        = os.Chown
+	dnsInstallChown        = os.Lchown
 	dnsInstallGetenv       = os.Getenv
 	dnsInstallUserHomeDir  = os.UserHomeDir
 	dnsResolverInstallPath = filepath.Join("/etc", "resolver", exposure.Domain)
@@ -96,7 +98,7 @@ func (c *DNSCommand) installDNS(ctx *runtimeContext) error {
 		return err
 	}
 	certPath := filepath.Join(tlsDir, exposure.LocalCertificateFilename)
-	if _, err := dnsInstallReadFile(certPath); err == nil {
+	if _, err := dnsInstallReadRegularFile(certPath); err == nil {
 		if err := removeExposureCertificateTrust(certPath); err != nil {
 			return err
 		}
@@ -392,7 +394,11 @@ func chownExposureTLSMaterial(dir string, parentDirs []string) error {
 		filepath.Join(dir, exposure.LocalCertificateFilename),
 		filepath.Join(dir, exposure.LocalCertificateKeyFilename),
 	)
+	symlinkRoot := dnsExposureTLSSymlinkRoot()
 	for _, path := range paths {
+		if err := rejectDNSInstallSymlinkPath(path, symlinkRoot); err != nil {
+			return fmt.Errorf("chown %s: %w", path, err)
+		}
 		if err := dnsInstallChown(path, uid, gid); err != nil && !errors.Is(err, fs.ErrNotExist) {
 			return fmt.Errorf("chown %s: %w", path, err)
 		}
@@ -431,7 +437,7 @@ func uninstallExposureCertificateTrustAndFiles() error {
 		return err
 	}
 	certPath := filepath.Join(tlsDir, exposure.LocalCertificateFilename)
-	if _, err := dnsInstallReadFile(certPath); err == nil {
+	if _, err := dnsInstallReadRegularFile(certPath); err == nil {
 		if err := removeExposureCertificateTrust(certPath); err != nil {
 			return err
 		}
@@ -442,7 +448,7 @@ func uninstallExposureCertificateTrustAndFiles() error {
 }
 
 func exposureCertificateTrustStatus(certPath string) (bool, string) {
-	if _, err := dnsInstallReadFile(certPath); err != nil {
+	if _, err := dnsInstallReadRegularFile(certPath); err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return false, "certificate not found"
 		}
@@ -456,6 +462,93 @@ func exposureCertificateTrustStatus(certPath string) (bool, string) {
 		return false, err.Error()
 	}
 	return true, "trusted"
+}
+
+func dnsInstallReadRegularFile(path string) ([]byte, error) {
+	if err := rejectDNSInstallSymlinkPath(path, dnsExposureTLSSymlinkRoot()); err != nil {
+		return nil, err
+	}
+	info, err := dnsInstallLstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("%s is not a regular file", path)
+	}
+	return dnsInstallReadRegularFileMatchingInfo(path, info)
+}
+
+func dnsInstallReadRegularFileMatchingInfo(path string, info os.FileInfo) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	openedInfo, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if !os.SameFile(info, openedInfo) {
+		return nil, fmt.Errorf("%s changed while opening", path)
+	}
+	return io.ReadAll(f)
+}
+
+func dnsExposureTLSSymlinkRoot() string {
+	if configHome := strings.TrimSpace(dnsInstallGetenv("XDG_CONFIG_HOME")); configHome != "" {
+		configHome = filepath.Clean(configHome)
+		if home := dnsExposureInvokingHomeDir(); home != "" && pathWithinDir(home, configHome) {
+			return filepath.Clean(home)
+		}
+		return configHome
+	}
+	if home := dnsExposureInvokingHomeDir(); home != "" {
+		return filepath.Clean(home)
+	}
+	return ""
+}
+
+func rejectDNSInstallSymlinkPath(path, root string) error {
+	path = filepath.Clean(path)
+	root = filepath.Clean(strings.TrimSpace(root))
+	if path == "" || path == "." {
+		return nil
+	}
+	if root == "" || root == "." || !pathWithinDir(root, path) {
+		return rejectDNSInstallSymlinkLeaf(path)
+	}
+	if err := rejectDNSInstallSymlinkLeaf(root); err != nil {
+		return err
+	}
+	rel, err := filepath.Rel(root, path)
+	if err != nil || rel == "." {
+		return nil
+	}
+	current := root
+	for _, elem := range strings.Split(rel, string(filepath.Separator)) {
+		if elem == "" || elem == "." {
+			continue
+		}
+		current = filepath.Join(current, elem)
+		if err := rejectDNSInstallSymlinkLeaf(current); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func rejectDNSInstallSymlinkLeaf(path string) error {
+	info, err := dnsInstallLstat(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%s is a symbolic link", path)
+	}
+	return nil
 }
 
 func exposureTrustKeychainPath() (string, error) {

--- a/internal/cli/dns.go
+++ b/internal/cli/dns.go
@@ -214,18 +214,20 @@ func (c *DNSCommand) currentDNSStatus() dnsStatusPayload {
 		Domain:    exposure.Domain,
 		Listen:    listen,
 	}
-	if tlsDir, err := dnsExposureTLSDir(); err == nil {
-		status.CertificatePath = filepath.Join(tlsDir, exposure.LocalCertificateFilename)
-	}
 	if !status.Supported {
 		status.Message = "dns resolver install is unsupported on this platform"
 		return status
 	}
-	if strings.TrimSpace(status.CertificatePath) != "" {
-		trusted, trustMessage := exposureCertificateTrustStatus(status.CertificatePath)
-		status.Trusted = trusted
-		status.TrustMessage = trustMessage
+	tlsDir, err := dnsExposureTLSDir()
+	if err != nil {
+		status.Message = err.Error()
+		status.TrustMessage = err.Error()
+		return status
 	}
+	status.CertificatePath = filepath.Join(tlsDir, exposure.LocalCertificateFilename)
+	trusted, trustMessage := exposureCertificateTrustStatus(status.CertificatePath)
+	status.Trusted = trusted
+	status.TrustMessage = trustMessage
 
 	data, err := dnsInstallReadFile(dnsResolverInstallPath)
 	switch {

--- a/internal/cli/dns_test.go
+++ b/internal/cli/dns_test.go
@@ -166,6 +166,139 @@ func TestDNSInstallRefreshesExistingCertificateTrust(t *testing.T) {
 	}
 }
 
+func TestDNSInstallRejectsSymlinkedCertificateBeforeTrust(t *testing.T) {
+	home := t.TempDir()
+	resolverPath := filepath.Join(t.TempDir(), "resolver", exposure.Domain)
+	var calls [][]string
+	stubDNSInstallEnvironment(t, home, resolverPath, &calls)
+	tlsDir := filepath.Join(home, ".config", "cleanroom", "tls")
+	if err := os.MkdirAll(tlsDir, 0o700); err != nil {
+		t.Fatalf("mkdir tls dir: %v", err)
+	}
+	outside := filepath.Join(t.TempDir(), "outside.pem")
+	if err := os.WriteFile(outside, []byte("do not trust"), 0o644); err != nil {
+		t.Fatalf("write outside file: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(tlsDir, exposure.LocalCertificateFilename)); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	stdout, _ := makeStdoutCapture(t)
+	cmd := &DNSCommand{Action: "install"}
+	err := cmd.Run(&runtimeContext{Stdout: stdout})
+	if err == nil {
+		t.Fatal("expected symlinked certificate error")
+	}
+	if !strings.Contains(err.Error(), "symbolic link") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(calls) != 0 {
+		t.Fatalf("expected no trust commands for symlinked certificate, got %v", calls)
+	}
+}
+
+func TestDNSInstallRejectsSymlinkedTLSParentBeforeWrite(t *testing.T) {
+	home := t.TempDir()
+	resolverPath := filepath.Join(t.TempDir(), "resolver", exposure.Domain)
+	var calls [][]string
+	stubDNSInstallEnvironment(t, home, resolverPath, &calls)
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(home, ".config")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	stdout, _ := makeStdoutCapture(t)
+	cmd := &DNSCommand{Action: "install"}
+	err := cmd.Run(&runtimeContext{Stdout: stdout})
+	if err == nil {
+		t.Fatal("expected symlinked TLS parent error")
+	}
+	if !strings.Contains(err.Error(), "symbolic link") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(calls) != 0 {
+		t.Fatalf("expected no trust commands for symlinked TLS parent, got %v", calls)
+	}
+	if _, err := os.Stat(filepath.Join(outside, "cleanroom")); !os.IsNotExist(err) {
+		t.Fatalf("expected symlink target not to receive certificate files, got err=%v", err)
+	}
+}
+
+func TestDNSInstallRejectsSymlinkedXDGConfigHomeBeforeWrite(t *testing.T) {
+	home := t.TempDir()
+	resolverPath := filepath.Join(t.TempDir(), "resolver", exposure.Domain)
+	var calls [][]string
+	stubDNSInstallEnvironment(t, home, resolverPath, &calls)
+	outside := t.TempDir()
+	xdgConfigHome := filepath.Join(home, "xdg-config")
+	if err := os.Symlink(outside, xdgConfigHome); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	baseGetenv := dnsInstallGetenv
+	dnsInstallGetenv = func(key string) string {
+		if key == "XDG_CONFIG_HOME" {
+			return xdgConfigHome
+		}
+		return baseGetenv(key)
+	}
+
+	stdout, _ := makeStdoutCapture(t)
+	cmd := &DNSCommand{Action: "install"}
+	err := cmd.Run(&runtimeContext{Stdout: stdout})
+	if err == nil {
+		t.Fatal("expected symlinked XDG config home error")
+	}
+	if !strings.Contains(err.Error(), "symbolic link") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(calls) != 0 {
+		t.Fatalf("expected no trust commands for symlinked XDG config home, got %v", calls)
+	}
+	if _, err := os.Stat(filepath.Join(outside, "cleanroom")); !os.IsNotExist(err) {
+		t.Fatalf("expected symlink target not to receive certificate files, got err=%v", err)
+	}
+}
+
+func TestChownExposureTLSMaterialRejectsSymlinkedTarget(t *testing.T) {
+	dir := t.TempDir()
+	parent := filepath.Join(t.TempDir(), "parent-link")
+	if err := os.Symlink(t.TempDir(), parent); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	prevGetenv := dnsInstallGetenv
+	prevChown := dnsInstallChown
+	t.Cleanup(func() {
+		dnsInstallGetenv = prevGetenv
+		dnsInstallChown = prevChown
+	})
+	dnsInstallGetenv = func(key string) string {
+		switch key {
+		case "SUDO_UID":
+			return "501"
+		case "SUDO_GID":
+			return "20"
+		default:
+			return ""
+		}
+	}
+	var chownCalls int
+	dnsInstallChown = func(string, int, int) error {
+		chownCalls++
+		return nil
+	}
+
+	err := chownExposureTLSMaterial(dir, []string{parent})
+	if err == nil {
+		t.Fatal("expected symlinked chown target to be rejected")
+	}
+	if !strings.Contains(err.Error(), "symbolic link") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if chownCalls != 0 {
+		t.Fatalf("expected chown not to run after symlink detection, got %d calls", chownCalls)
+	}
+}
+
 func TestDNSInstallUsesXDGConfigHomeForExposureCertificate(t *testing.T) {
 	home := t.TempDir()
 	xdgConfigHome := filepath.Join(home, "xdg-config")
@@ -341,6 +474,7 @@ func stubDNSInstallEnvironment(t *testing.T, home, resolverPath string, calls *[
 	prevEUID := dnsInstallEUID
 	prevRunCommand := dnsInstallRunCommand
 	prevLookupUser := dnsInstallLookupUser
+	prevLstat := dnsInstallLstat
 	prevChown := dnsInstallChown
 	prevGetenv := dnsInstallGetenv
 	prevUserHomeDir := dnsInstallUserHomeDir
@@ -378,6 +512,7 @@ func stubDNSInstallEnvironment(t *testing.T, home, resolverPath string, calls *[
 		dnsInstallEUID = prevEUID
 		dnsInstallRunCommand = prevRunCommand
 		dnsInstallLookupUser = prevLookupUser
+		dnsInstallLstat = prevLstat
 		dnsInstallChown = prevChown
 		dnsInstallGetenv = prevGetenv
 		dnsInstallUserHomeDir = prevUserHomeDir

--- a/internal/cli/dns_test.go
+++ b/internal/cli/dns_test.go
@@ -259,6 +259,37 @@ func TestDNSInstallRejectsSymlinkedXDGConfigHomeBeforeWrite(t *testing.T) {
 	}
 }
 
+func TestDNSInstallRejectsXDGConfigHomeOutsideInvokingHome(t *testing.T) {
+	home := t.TempDir()
+	resolverPath := filepath.Join(t.TempDir(), "resolver", exposure.Domain)
+	var calls [][]string
+	stubDNSInstallEnvironment(t, home, resolverPath, &calls)
+	outside := filepath.Join(t.TempDir(), "xdg-config")
+	baseGetenv := dnsInstallGetenv
+	dnsInstallGetenv = func(key string) string {
+		if key == "XDG_CONFIG_HOME" {
+			return outside
+		}
+		return baseGetenv(key)
+	}
+
+	stdout, _ := makeStdoutCapture(t)
+	cmd := &DNSCommand{Action: "install"}
+	err := cmd.Run(&runtimeContext{Stdout: stdout})
+	if err == nil {
+		t.Fatal("expected XDG_CONFIG_HOME outside invoking home to be rejected")
+	}
+	if !strings.Contains(err.Error(), "must be inside invoking user home") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(calls) != 0 {
+		t.Fatalf("expected no trust commands for outside XDG config home, got %v", calls)
+	}
+	if _, err := os.Stat(filepath.Join(outside, "cleanroom")); !os.IsNotExist(err) {
+		t.Fatalf("expected outside XDG config home not to receive certificate files, got err=%v", err)
+	}
+}
+
 func TestChownExposureTLSMaterialRejectsSymlinkedTarget(t *testing.T) {
 	dir := t.TempDir()
 	parent := filepath.Join(t.TempDir(), "parent-link")

--- a/internal/cli/dns_test.go
+++ b/internal/cli/dns_test.go
@@ -455,6 +455,35 @@ func TestDNSStatusReportsCertificateTrust(t *testing.T) {
 	}
 }
 
+func TestDNSStatusReportsInvalidXDGConfigHome(t *testing.T) {
+	home := t.TempDir()
+	resolverPath := filepath.Join(t.TempDir(), "resolver", exposure.Domain)
+	var calls [][]string
+	stubDNSInstallEnvironment(t, home, resolverPath, &calls)
+	outside := filepath.Join(t.TempDir(), "xdg-config")
+	baseGetenv := dnsInstallGetenv
+	dnsInstallGetenv = func(key string) string {
+		if key == "XDG_CONFIG_HOME" {
+			return outside
+		}
+		return baseGetenv(key)
+	}
+
+	status := (&DNSCommand{}).currentDNSStatus()
+	if !strings.Contains(status.Message, "must be inside invoking user home") {
+		t.Fatalf("expected invalid XDG_CONFIG_HOME message, got %+v", status)
+	}
+	if !strings.Contains(status.TrustMessage, "must be inside invoking user home") {
+		t.Fatalf("expected invalid XDG_CONFIG_HOME trust message, got %+v", status)
+	}
+	if status.CertificatePath != "" {
+		t.Fatalf("expected no certificate path for invalid config home, got %+v", status)
+	}
+	if len(calls) != 0 {
+		t.Fatalf("expected no trust commands for invalid config home, got %v", calls)
+	}
+}
+
 func TestDNSUninstallRemovesCertificateTrustAndFiles(t *testing.T) {
 	home := t.TempDir()
 	resolverPath := filepath.Join(t.TempDir(), "resolver", exposure.Domain)

--- a/internal/cli/dns_test.go
+++ b/internal/cli/dns_test.go
@@ -197,6 +197,41 @@ func TestDNSInstallRejectsSymlinkedCertificateBeforeTrust(t *testing.T) {
 	}
 }
 
+func TestDNSInstallRejectsSymlinkedKeyBeforeTrustRemoval(t *testing.T) {
+	home := t.TempDir()
+	resolverPath := filepath.Join(t.TempDir(), "resolver", exposure.Domain)
+	var calls [][]string
+	stubDNSInstallEnvironment(t, home, resolverPath, &calls)
+	tlsDir := filepath.Join(home, ".config", "cleanroom", "tls")
+	cert, err := exposure.EnsureLocalCertificate(exposure.Domain, tlsDir)
+	if err != nil {
+		t.Fatalf("EnsureLocalCertificate returned error: %v", err)
+	}
+	if err := os.Remove(cert.KeyPath); err != nil {
+		t.Fatalf("remove generated key: %v", err)
+	}
+	outside := filepath.Join(t.TempDir(), "outside.key")
+	if err := os.WriteFile(outside, []byte("do not read"), 0o600); err != nil {
+		t.Fatalf("write outside key: %v", err)
+	}
+	if err := os.Symlink(outside, cert.KeyPath); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	stdout, _ := makeStdoutCapture(t)
+	cmd := &DNSCommand{Action: "install"}
+	err = cmd.Run(&runtimeContext{Stdout: stdout})
+	if err == nil {
+		t.Fatal("expected symlinked key error")
+	}
+	if !strings.Contains(err.Error(), "symbolic link") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(calls) != 0 {
+		t.Fatalf("expected no trust commands for symlinked key, got %v", calls)
+	}
+}
+
 func TestDNSInstallRejectsSymlinkedTLSParentBeforeWrite(t *testing.T) {
 	home := t.TempDir()
 	resolverPath := filepath.Join(t.TempDir(), "resolver", exposure.Domain)

--- a/internal/exposure/tls.go
+++ b/internal/exposure/tls.go
@@ -305,15 +305,52 @@ func rejectLocalCertificateReplacement(path string) error {
 }
 
 func rejectLocalCertificateSymlinkPath(path string) error {
-	info, err := os.Lstat(path)
-	if errors.Is(err, os.ErrNotExist) {
+	path = filepath.Clean(path)
+	if path == "" || path == "." {
 		return nil
 	}
-	if err != nil {
-		return err
+	ancestor := path
+	for {
+		info, err := os.Lstat(ancestor)
+		switch {
+		case err == nil:
+			if info.Mode()&os.ModeSymlink != 0 {
+				return fmt.Errorf("%s contains symbolic link component %s", path, ancestor)
+			}
+			return rejectLocalCertificateSymlinkPathFromAncestor(path, ancestor)
+		case errors.Is(err, os.ErrNotExist):
+			parent := filepath.Dir(ancestor)
+			if parent == ancestor {
+				return nil
+			}
+			ancestor = parent
+		default:
+			return err
+		}
 	}
-	if info.Mode()&os.ModeSymlink != 0 {
-		return fmt.Errorf("%s is a symbolic link", path)
+}
+
+func rejectLocalCertificateSymlinkPathFromAncestor(path, ancestor string) error {
+	rel, err := filepath.Rel(ancestor, path)
+	if err != nil || rel == "." {
+		return nil
+	}
+	current := ancestor
+	for _, elem := range strings.Split(rel, string(filepath.Separator)) {
+		if elem == "" || elem == "." {
+			continue
+		}
+		current = filepath.Join(current, elem)
+		info, err := os.Lstat(current)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("%s contains symbolic link component %s", path, current)
+		}
 	}
 	return nil
 }

--- a/internal/exposure/tls.go
+++ b/internal/exposure/tls.go
@@ -9,6 +9,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"io"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -53,8 +54,8 @@ func EnsureLocalCertificate(domain, dir string) (*LocalCertificate, error) {
 	certPath := filepath.Join(dir, LocalCertificateFilename)
 	keyPath := filepath.Join(dir, LocalCertificateKeyFilename)
 
-	certPEM, certErr := os.ReadFile(certPath)
-	keyPEM, keyErr := os.ReadFile(keyPath)
+	certPEM, certErr := readLocalCertificateFile(certPath)
+	keyPEM, keyErr := readLocalCertificateFile(keyPath)
 	switch {
 	case certErr == nil && keyErr == nil:
 		cert, err := parseLocalCertificate(certPEM, keyPEM)
@@ -71,18 +72,18 @@ func EnsureLocalCertificate(domain, dir string) (*LocalCertificate, error) {
 		return nil, fmt.Errorf("load exposure certificate from %s: cert error=%v key error=%v", dir, certErr, keyErr)
 	}
 
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return nil, fmt.Errorf("create exposure TLS directory %s: %w", dir, err)
+	if err := ensureLocalCertificateDir(dir); err != nil {
+		return nil, err
 	}
 	cert, err := generateLocalCertificateAuthority(domain)
 	if err != nil {
 		return nil, err
 	}
-	if err := os.WriteFile(certPath, cert.CertPEM, 0o644); err != nil {
+	if err := writeLocalCertificateFile(certPath, cert.CertPEM, 0o644); err != nil {
 		return nil, fmt.Errorf("write exposure certificate: %w", err)
 	}
 	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(cert.Key)})
-	if err := os.WriteFile(keyPath, keyPEM, 0o600); err != nil {
+	if err := writeLocalCertificateFile(keyPath, keyPEM, 0o600); err != nil {
 		return nil, fmt.Errorf("write exposure certificate key: %w", err)
 	}
 	cert.CertPath = certPath
@@ -177,8 +178,8 @@ func EnsureRuntimeCertificateAuthority(domain, dir string) (*LocalCertificate, e
 	certPath := filepath.Join(dir, LocalCertificateFilename)
 	keyPath := filepath.Join(dir, LocalCertificateKeyFilename)
 
-	certPEM, certErr := os.ReadFile(certPath)
-	keyPEM, keyErr := os.ReadFile(keyPath)
+	certPEM, certErr := readLocalCertificateFile(certPath)
+	keyPEM, keyErr := readLocalCertificateFile(keyPath)
 	switch {
 	case certErr == nil && keyErr == nil:
 		cert, err := parseLocalCertificate(certPEM, keyPEM)
@@ -196,6 +197,125 @@ func EnsureRuntimeCertificateAuthority(domain, dir string) (*LocalCertificate, e
 	default:
 		return nil, fmt.Errorf("load exposure certificate from %s: cert error=%v key error=%v", dir, certErr, keyErr)
 	}
+}
+
+func readLocalCertificateFile(path string) ([]byte, error) {
+	if err := rejectLocalCertificateSymlinkPath(path); err != nil {
+		return nil, err
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("%s is not a regular file", path)
+	}
+	return readLocalCertificateFileMatchingInfo(path, info)
+}
+
+func readLocalCertificateFileMatchingInfo(path string, info os.FileInfo) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	openedInfo, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if !os.SameFile(info, openedInfo) {
+		return nil, fmt.Errorf("%s changed while opening", path)
+	}
+	return io.ReadAll(f)
+}
+
+func writeLocalCertificateFile(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	if err := ensureLocalCertificateDir(dir); err != nil {
+		return err
+	}
+	if err := rejectLocalCertificateReplacement(path); err != nil {
+		return err
+	}
+
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	keepTemp := false
+	defer func() {
+		if !keepTemp {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if err := tmp.Chmod(perm); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return err
+	}
+	keepTemp = true
+	return nil
+}
+
+func ensureLocalCertificateDir(dir string) error {
+	if err := rejectLocalCertificateSymlinkPath(dir); err != nil {
+		return fmt.Errorf("create exposure TLS directory %s: %w", dir, err)
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create exposure TLS directory %s: %w", dir, err)
+	}
+	if err := rejectLocalCertificateSymlinkPath(dir); err != nil {
+		return fmt.Errorf("create exposure TLS directory %s: %w", dir, err)
+	}
+	info, err := os.Lstat(dir)
+	if err != nil {
+		return fmt.Errorf("create exposure TLS directory %s: %w", dir, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("create exposure TLS directory %s: not a directory", dir)
+	}
+	return nil
+}
+
+func rejectLocalCertificateReplacement(path string) error {
+	if err := rejectLocalCertificateSymlinkPath(path); err != nil {
+		return err
+	}
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("%s is not a regular file", path)
+	}
+	return nil
+}
+
+func rejectLocalCertificateSymlinkPath(path string) error {
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%s is a symbolic link", path)
+	}
+	return nil
 }
 
 func parseLocalCertificate(certPEM, keyPEM []byte) (*LocalCertificate, error) {

--- a/internal/exposure/tls.go
+++ b/internal/exposure/tls.go
@@ -309,34 +309,17 @@ func rejectLocalCertificateSymlinkPath(path string) error {
 	if path == "" || path == "." {
 		return nil
 	}
-	ancestor := path
-	for {
-		info, err := os.Lstat(ancestor)
-		switch {
-		case err == nil:
-			if info.Mode()&os.ModeSymlink != 0 {
-				return fmt.Errorf("%s contains symbolic link component %s", path, ancestor)
-			}
-			return rejectLocalCertificateSymlinkPathFromAncestor(path, ancestor)
-		case errors.Is(err, os.ErrNotExist):
-			parent := filepath.Dir(ancestor)
-			if parent == ancestor {
-				return nil
-			}
-			ancestor = parent
-		default:
-			return err
-		}
+	current := ""
+	rest := path
+	if volume := filepath.VolumeName(path); volume != "" {
+		current = volume
+		rest = strings.TrimPrefix(path, volume)
 	}
-}
-
-func rejectLocalCertificateSymlinkPathFromAncestor(path, ancestor string) error {
-	rel, err := filepath.Rel(ancestor, path)
-	if err != nil || rel == "." {
-		return nil
+	if filepath.IsAbs(path) {
+		current += string(filepath.Separator)
+		rest = strings.TrimPrefix(rest, string(filepath.Separator))
 	}
-	current := ancestor
-	for _, elem := range strings.Split(rel, string(filepath.Separator)) {
+	for _, elem := range strings.Split(rest, string(filepath.Separator)) {
 		if elem == "" || elem == "." {
 			continue
 		}
@@ -348,11 +331,31 @@ func rejectLocalCertificateSymlinkPathFromAncestor(path, ancestor string) error 
 		if err != nil {
 			return err
 		}
-		if info.Mode()&os.ModeSymlink != 0 {
+		if info.Mode()&os.ModeSymlink != 0 && !allowLocalCertificateSymlinkComponent(current) {
 			return fmt.Errorf("%s contains symbolic link component %s", path, current)
 		}
 	}
 	return nil
+}
+
+func allowLocalCertificateSymlinkComponent(path string) bool {
+	target, err := os.Readlink(path)
+	if err != nil {
+		return false
+	}
+	if !filepath.IsAbs(target) {
+		target = filepath.Clean(filepath.Join(filepath.Dir(path), target))
+	}
+	switch filepath.Clean(path) {
+	case "/etc":
+		return target == "/private/etc"
+	case "/tmp":
+		return target == "/private/tmp"
+	case "/var":
+		return target == "/private/var"
+	default:
+		return false
+	}
 }
 
 func parseLocalCertificate(certPEM, keyPEM []byte) (*LocalCertificate, error) {

--- a/internal/exposure/tls_test.go
+++ b/internal/exposure/tls_test.go
@@ -11,6 +11,7 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -127,6 +128,57 @@ func TestGenerateServerCertificateDoesNotReplaceLegacyLeafCertificate(t *testing
 	}
 	if bytes.Equal(migrated.CertPEM, before) {
 		t.Fatal("expected dns install path to write a new certificate authority")
+	}
+}
+
+func TestEnsureLocalCertificateRejectsSymlinkedCertificatePath(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "outside.pem")
+	if err := os.WriteFile(outside, []byte("do not replace"), 0o644); err != nil {
+		t.Fatalf("write outside file: %v", err)
+	}
+	certPath := filepath.Join(dir, LocalCertificateFilename)
+	if err := os.Symlink(outside, certPath); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	_, err := EnsureLocalCertificate(Domain, dir)
+	if err == nil {
+		t.Fatal("expected symlinked certificate path to be rejected")
+	}
+	if !strings.Contains(err.Error(), "symbolic link") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data, err := os.ReadFile(outside)
+	if err != nil {
+		t.Fatalf("read outside file: %v", err)
+	}
+	if got, want := string(data), "do not replace"; got != want {
+		t.Fatalf("outside file was changed: got %q want %q", got, want)
+	}
+}
+
+func TestEnsureLocalCertificateRejectsSymlinkedTLSDir(t *testing.T) {
+	t.Parallel()
+
+	parent := t.TempDir()
+	outside := t.TempDir()
+	dir := filepath.Join(parent, "tls")
+	if err := os.Symlink(outside, dir); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	_, err := EnsureLocalCertificate(Domain, dir)
+	if err == nil {
+		t.Fatal("expected symlinked TLS directory to be rejected")
+	}
+	if !strings.Contains(err.Error(), "symbolic link") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(outside, LocalCertificateFilename)); !os.IsNotExist(err) {
+		t.Fatalf("expected symlink target not to receive certificate files, got err=%v", err)
 	}
 }
 

--- a/internal/exposure/tls_test.go
+++ b/internal/exposure/tls_test.go
@@ -182,6 +182,28 @@ func TestEnsureLocalCertificateRejectsSymlinkedTLSDir(t *testing.T) {
 	}
 }
 
+func TestEnsureLocalCertificateRejectsSymlinkedTLSParent(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(home, ".config")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	dir := filepath.Join(home, ".config", "cleanroom", "tls")
+
+	_, err := EnsureLocalCertificate(Domain, dir)
+	if err == nil {
+		t.Fatal("expected symlinked TLS parent to be rejected")
+	}
+	if !strings.Contains(err.Error(), "symbolic link") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(outside, "cleanroom")); !os.IsNotExist(err) {
+		t.Fatalf("expected symlink target not to receive certificate files, got err=%v", err)
+	}
+}
+
 func writeLegacyLeafCertificate(t *testing.T, dir, domain string) {
 	t.Helper()
 

--- a/internal/exposure/tls_test.go
+++ b/internal/exposure/tls_test.go
@@ -204,6 +204,29 @@ func TestEnsureLocalCertificateRejectsSymlinkedTLSParent(t *testing.T) {
 	}
 }
 
+func TestEnsureLocalCertificateRejectsExistingCertificateUnderSymlinkedTLSParent(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	outside := t.TempDir()
+	actualDir := filepath.Join(outside, "cleanroom", "tls")
+	if _, err := EnsureLocalCertificate(Domain, actualDir); err != nil {
+		t.Fatalf("seed outside certificate: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(home, ".config")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	dir := filepath.Join(home, ".config", "cleanroom", "tls")
+
+	_, err := EnsureLocalCertificate(Domain, dir)
+	if err == nil {
+		t.Fatal("expected existing certificate under symlinked TLS parent to be rejected")
+	}
+	if !strings.Contains(err.Error(), "symbolic link") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func writeLegacyLeafCertificate(t *testing.T, dir, domain string) {
 	t.Helper()
 


### PR DESCRIPTION
Privileged `cleanroom dns install` writes the local exposure certificate under the invoking user's config directory. Before this change, symlinked certificate paths could make root read, refresh trust for, write, or chown a path outside the intended TLS directory.

This hardens that boundary by refusing symlinked certificate/key files, checking the opened cert file still matches the inspected regular file, and refreshing certificate material through a same-directory temporary file before rename. The DNS installer also checks the invoking user's TLS path for symlink components before trust/removal/chown and uses `lchown` for the ownership handoff.

The user-facing behavior is fail-closed: a symlinked TLS path now makes `cleanroom dns install`, `cleanroom dns status`, or `cleanroom dns uninstall` report a certificate path error instead of following it.
