### PR TITLE
fix: Harden git credential lookup

### DIFF
--- a/docs/plans/deepsec-remediation.md
+++ b/docs/plans/deepsec-remediation.md
@@ -1,7 +1,7 @@
 # DeepSec Remediation Plan
 
 **Spec reference:** `docs/spec.md`; `docs/api.md`; `docs/tls.md`; `docs/plans/multi-principal-control-server.md`; `docs/plans/stage-scoped-egress.md`
-**Status:** Slice 4b ready for review
+**Status:** Slice 6a ready for review
 **Last reviewed:** 2026-05-27
 
 ## Summary
@@ -145,6 +145,32 @@ Focused validation run on 2026-05-27:
 
 ```text
 MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/eaa8/cleanroom/mise.toml mise exec -- go test ./internal/cli
+```
+
+Result: passed.
+
+Repository validation run on 2026-05-27:
+
+```text
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/eaa8/cleanroom/mise.toml mise run check
+```
+
+Result: passed.
+
+Slice 6a is implemented and ready for review. Git credential fill lookup now
+rejects NUL, CR, and LF characters in line-based credential protocol fields
+before invoking the host `git credential fill` helper. This closes the remote
+URL path field injection finding without changing normal HTTPS repository
+credential lookup behavior.
+
+The remaining Slice 6 cache authorization findings for git pack responses,
+fetch cache hits, Go proxy cache hits, and OCI handler allocation remain follow-up
+work.
+
+Focused validation run on 2026-05-27:
+
+```text
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/eaa8/cleanroom/mise.toml mise exec -- go test ./internal/gateway
 ```
 
 Result: passed.

--- a/internal/gateway/credentials.go
+++ b/internal/gateway/credentials.go
@@ -154,17 +154,28 @@ func buildGitCredentialFillLookup(remoteURL string) (string, error) {
 
 	var lookup strings.Builder
 	lookup.WriteString("protocol=https\n")
-	lookup.WriteString("host=")
-	lookup.WriteString(parsed.Host)
-	lookup.WriteString("\n")
-	path := strings.TrimPrefix(strings.TrimSpace(parsed.Path), "/")
+	if err := writeGitCredentialFillField(&lookup, "host", parsed.Host); err != nil {
+		return "", err
+	}
+	path := strings.TrimPrefix(parsed.Path, "/")
 	if path != "" {
-		lookup.WriteString("path=")
-		lookup.WriteString(path)
-		lookup.WriteString("\n")
+		if err := writeGitCredentialFillField(&lookup, "path", path); err != nil {
+			return "", err
+		}
 	}
 	lookup.WriteString("\n")
 	return lookup.String(), nil
+}
+
+func writeGitCredentialFillField(lookup *strings.Builder, key, value string) error {
+	if strings.ContainsAny(value, "\x00\r\n") {
+		return fmt.Errorf("remote URL %s contains characters that cannot be passed to git credential fill", key)
+	}
+	lookup.WriteString(key)
+	lookup.WriteString("=")
+	lookup.WriteString(value)
+	lookup.WriteString("\n")
+	return nil
 }
 
 func parseGitCredentialFillOutput(raw string) (string, string) {

--- a/internal/gateway/credentials_test.go
+++ b/internal/gateway/credentials_test.go
@@ -104,6 +104,27 @@ func TestGitCredentialFillProviderResolveUsesCanonicalRemoteURL(t *testing.T) {
 	}
 }
 
+func TestGitCredentialFillProviderRejectsInjectedPathFields(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	provider := NewGitCredentialFillProvider("/tmp/repo", func(string, string) (string, error) {
+		called = true
+		return "", nil
+	})
+
+	_, err := provider.Resolve(context.Background(), "https://github.com/buildkite/cleanroom.git%0ahost=evil.example")
+	if err == nil {
+		t.Fatal("expected credential fill lookup to reject injected path field")
+	}
+	if !strings.Contains(err.Error(), "git credential fill") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if called {
+		t.Fatal("expected git credential fill not to be invoked")
+	}
+}
+
 func TestGitCredentialFillFromHostDisablesPrompts(t *testing.T) {
 	tmpDir := t.TempDir()
 	envFile := filepath.Join(tmpDir, "env.txt")


### PR DESCRIPTION
Host-side Git credential lookup uses the line-based `git credential fill` protocol. Before this change, a repository URL path containing an encoded newline could be decoded into an extra credential field before the host helper was invoked.

This makes the lookup fail closed by rejecting NUL, carriage return, and newline characters in credential protocol field values before writing them to `git credential fill`. Normal HTTPS repository paths still produce the same host/path lookup input.

This PR covers the credential-fill injection item from DeepSec Slice 6a. The remaining Slice 6 cache authorization findings stay separate so each trust boundary gets its own focused review.
