### PR TITLE
fix: Bound OCI registry handler cache

### DIFF
--- a/docs/plans/deepsec-remediation.md
+++ b/docs/plans/deepsec-remediation.md
@@ -185,13 +185,21 @@ Result: passed.
 Slice 6b is implemented and ready for review. OCI registry handler creation is
 now bounded by a small LRU cache, so request-controlled registry prefixes cannot
 grow one handler per prefix for the lifetime of the daemon. Cache hits refresh
-recency, evicted handlers have their closers released outside the cache lock,
-and normal registry prefix reuse keeps the existing handler.
+recency, evicted handlers are removed from the cache immediately, and handler
+closers run only after outstanding requests release their leases.
 
 Focused validation run on 2026-05-27:
 
 ```text
-MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/eaa8/cleanroom/mise.toml mise exec -- go test ./internal/gateway
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/deepsec-oci-handler-bounds/cleanroom/mise.toml mise exec -- go test ./internal/gateway
+```
+
+Result: passed.
+
+Repository validation run on 2026-05-27:
+
+```text
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/deepsec-oci-handler-bounds/cleanroom/mise.toml mise run check
 ```
 
 Result: passed.

--- a/docs/plans/deepsec-remediation.md
+++ b/docs/plans/deepsec-remediation.md
@@ -1,7 +1,7 @@
 # DeepSec Remediation Plan
 
 **Spec reference:** `docs/spec.md`; `docs/api.md`; `docs/tls.md`; `docs/plans/multi-principal-control-server.md`; `docs/plans/stage-scoped-egress.md`
-**Status:** Slice 6a ready for review
+**Status:** Slice 6b ready for review
 **Last reviewed:** 2026-05-27
 
 ## Summary
@@ -164,8 +164,7 @@ URL path field injection finding without changing normal HTTPS repository
 credential lookup behavior.
 
 The remaining Slice 6 cache authorization findings for git pack responses,
-fetch cache hits, Go proxy cache hits, and OCI handler allocation remain follow-up
-work.
+fetch cache hits, and Go proxy cache hits remain follow-up work.
 
 Focused validation run on 2026-05-27:
 
@@ -179,6 +178,20 @@ Repository validation run on 2026-05-27:
 
 ```text
 MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/eaa8/cleanroom/mise.toml mise run check
+```
+
+Result: passed.
+
+Slice 6b is implemented and ready for review. OCI registry handler creation is
+now bounded by a small LRU cache, so request-controlled registry prefixes cannot
+grow one handler per prefix for the lifetime of the daemon. Cache hits refresh
+recency, evicted handlers have their closers released outside the cache lock,
+and normal registry prefix reuse keeps the existing handler.
+
+Focused validation run on 2026-05-27:
+
+```text
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/eaa8/cleanroom/mise.toml mise exec -- go test ./internal/gateway
 ```
 
 Result: passed.

--- a/internal/gateway/contentcache.go
+++ b/internal/gateway/contentcache.go
@@ -213,6 +213,7 @@ func NewContentCache(cfg ContentCacheConfig) (*ContentCache, error) {
 		closer:         db,
 		gitHandlers:    make(map[string]http.Handler),
 		ociHandlers:    make(map[string]ociHandlerEntry),
+		maxOCIHandlers: defaultMaxOCIHandlers,
 		ociMirrorHosts: ociMirrorHosts(cfg.OCIRegistries),
 	}
 	goProxyUpstreamURL := strings.TrimSpace(ccgoproxy.DefaultUpstreamURL)

--- a/internal/gateway/contentcache.go
+++ b/internal/gateway/contentcache.go
@@ -212,7 +212,7 @@ func NewContentCache(cfg ContentCacheConfig) (*ContentCache, error) {
 	cache := &ContentCache{
 		closer:         db,
 		gitHandlers:    make(map[string]http.Handler),
-		ociHandlers:    make(map[string]ociHandlerEntry),
+		ociHandlers:    make(map[string]*ociHandlerEntry),
 		maxOCIHandlers: defaultMaxOCIHandlers,
 		ociMirrorHosts: ociMirrorHosts(cfg.OCIRegistries),
 	}

--- a/internal/gateway/contentcache_types.go
+++ b/internal/gateway/contentcache_types.go
@@ -34,6 +34,8 @@ type ociHandlerEntry struct {
 	upstreamHost string
 	upstreamPort int
 	closer       io.Closer
+	active       int
+	evicted      bool
 }
 
 type goProxyScopedHandler struct {
@@ -87,7 +89,7 @@ type ContentCache struct {
 	buildGitHandler gitHandlerFactory
 
 	ociMu           sync.Mutex
-	ociHandlers     map[string]ociHandlerEntry
+	ociHandlers     map[string]*ociHandlerEntry
 	ociOrder        []string
 	maxOCIHandlers  int
 	buildOCIHandler ociHandlerFactory
@@ -375,39 +377,44 @@ func (c *ContentCache) OCIUpstreamForPrefix(prefix string) (string, int, string,
 
 // OCIHandlerForPrefix returns an OCI cache handler for the requested registry
 // prefix, creating and caching it on first use.
-func (c *ContentCache) OCIHandlerForPrefix(prefix string) (http.Handler, error) {
+func (c *ContentCache) OCIHandlerForPrefix(prefix string) (http.Handler, func(), error) {
 	if c == nil || c.buildOCIHandler == nil {
-		return nil, errors.New("oci cache not configured")
+		return nil, nil, errors.New("oci cache not configured")
 	}
 
 	prefix = strings.ToLower(strings.TrimSpace(prefix))
 	if prefix == "" {
-		return nil, errors.New("empty registry prefix")
+		return nil, nil, errors.New("empty registry prefix")
 	}
 
 	c.ociMu.Lock()
 	if entry, ok := c.ociHandlers[prefix]; ok {
+		entry.active++
 		c.touchOCIHandlerLocked(prefix)
+		release := c.releaseOCIHandler(entry)
 		c.ociMu.Unlock()
-		return entry.handler, nil
+		return entry.handler, release, nil
 	}
 
-	entry, err := c.buildOCIHandler(prefix)
+	entryValue, err := c.buildOCIHandler(prefix)
 	if err != nil {
 		c.ociMu.Unlock()
-		return nil, err
+		return nil, nil, err
 	}
 	if c.ociHandlers == nil {
-		c.ociHandlers = make(map[string]ociHandlerEntry)
+		c.ociHandlers = make(map[string]*ociHandlerEntry)
 	}
+	entry := &entryValue
+	entry.active = 1
 	c.ociHandlers[prefix] = entry
 	c.touchOCIHandlerLocked(prefix)
 	evicted := c.evictOCIHandlerLocked()
+	release := c.releaseOCIHandler(entry)
 	c.ociMu.Unlock()
 	if evicted != nil {
 		_ = evicted.Close()
 	}
-	return entry.handler, nil
+	return entry.handler, release, nil
 }
 
 func (c *ContentCache) touchOCIHandlerLocked(prefix string) {
@@ -438,7 +445,32 @@ func (c *ContentCache) evictOCIHandlerLocked() io.Closer {
 		return nil
 	}
 	delete(c.ociHandlers, evictedPrefix)
+	if entry.active > 0 {
+		entry.evicted = true
+		return nil
+	}
 	return entry.closer
+}
+
+func (c *ContentCache) releaseOCIHandler(entry *ociHandlerEntry) func() {
+	var once sync.Once
+	return func() {
+		var closer io.Closer
+		once.Do(func() {
+			c.ociMu.Lock()
+			if entry.active > 0 {
+				entry.active--
+			}
+			if entry.active == 0 && entry.evicted {
+				closer = entry.closer
+				entry.closer = nil
+			}
+			c.ociMu.Unlock()
+		})
+		if closer != nil {
+			_ = closer.Close()
+		}
+	}
 }
 
 // registryHostname extracts the hostname from a registry URL for policy checks.

--- a/internal/gateway/contentcache_types.go
+++ b/internal/gateway/contentcache_types.go
@@ -16,7 +16,10 @@ import (
 	"github.com/buildkite/cleanroom/internal/policy"
 )
 
-const defaultMaxGoProxyScopedHandlers = 32
+const (
+	defaultMaxGoProxyScopedHandlers = 32
+	defaultMaxOCIHandlers           = 32
+)
 
 type gitHandlerFactory func(host string) (http.Handler, error)
 
@@ -85,6 +88,8 @@ type ContentCache struct {
 
 	ociMu           sync.Mutex
 	ociHandlers     map[string]ociHandlerEntry
+	ociOrder        []string
+	maxOCIHandlers  int
 	buildOCIHandler ociHandlerFactory
 	resolveOCIRoute ociRouteResolver
 	ociMirrorHosts  []string
@@ -381,18 +386,59 @@ func (c *ContentCache) OCIHandlerForPrefix(prefix string) (http.Handler, error) 
 	}
 
 	c.ociMu.Lock()
-	defer c.ociMu.Unlock()
-
 	if entry, ok := c.ociHandlers[prefix]; ok {
+		c.touchOCIHandlerLocked(prefix)
+		c.ociMu.Unlock()
 		return entry.handler, nil
 	}
 
 	entry, err := c.buildOCIHandler(prefix)
 	if err != nil {
+		c.ociMu.Unlock()
 		return nil, err
 	}
+	if c.ociHandlers == nil {
+		c.ociHandlers = make(map[string]ociHandlerEntry)
+	}
 	c.ociHandlers[prefix] = entry
+	c.touchOCIHandlerLocked(prefix)
+	evicted := c.evictOCIHandlerLocked()
+	c.ociMu.Unlock()
+	if evicted != nil {
+		_ = evicted.Close()
+	}
 	return entry.handler, nil
+}
+
+func (c *ContentCache) touchOCIHandlerLocked(prefix string) {
+	for i, existing := range c.ociOrder {
+		if existing != prefix {
+			continue
+		}
+		copy(c.ociOrder[i:], c.ociOrder[i+1:])
+		c.ociOrder = c.ociOrder[:len(c.ociOrder)-1]
+		break
+	}
+	c.ociOrder = append(c.ociOrder, prefix)
+}
+
+func (c *ContentCache) evictOCIHandlerLocked() io.Closer {
+	maxHandlers := c.maxOCIHandlers
+	if maxHandlers <= 0 {
+		maxHandlers = defaultMaxOCIHandlers
+	}
+	if len(c.ociOrder) <= maxHandlers {
+		return nil
+	}
+
+	evictedPrefix := c.ociOrder[0]
+	c.ociOrder = c.ociOrder[1:]
+	entry, ok := c.ociHandlers[evictedPrefix]
+	if !ok {
+		return nil
+	}
+	delete(c.ociHandlers, evictedPrefix)
+	return entry.closer
 }
 
 // registryHostname extracts the hostname from a registry URL for policy checks.

--- a/internal/gateway/contentcache_types_test.go
+++ b/internal/gateway/contentcache_types_test.go
@@ -275,3 +275,55 @@ func TestGoProxyHandlerForPolicyEvictsLeastRecentlyUsedHandler(t *testing.T) {
 		t.Fatalf("expected policy-b closer to run, got %v", closed)
 	}
 }
+
+func TestOCIHandlerForPrefixEvictsLeastRecentlyUsedHandler(t *testing.T) {
+	t.Parallel()
+
+	var closed []string
+	cache := &ContentCache{
+		ociHandlers:    make(map[string]ociHandlerEntry),
+		maxOCIHandlers: 2,
+		buildOCIHandler: func(prefix string) (ociHandlerEntry, error) {
+			return ociHandlerEntry{
+				handler: &comparableHandler{},
+				closer: closeFunc(func() {
+					closed = append(closed, prefix)
+				}),
+			}, nil
+		},
+	}
+
+	handlerA, err := cache.OCIHandlerForPrefix("registry-a.test")
+	if err != nil {
+		t.Fatalf("handler A: %v", err)
+	}
+	if _, err := cache.OCIHandlerForPrefix("registry-b.test"); err != nil {
+		t.Fatalf("handler B: %v", err)
+	}
+	reusedA, err := cache.OCIHandlerForPrefix("registry-a.test")
+	if err != nil {
+		t.Fatalf("reused handler A: %v", err)
+	}
+	if reusedA != handlerA {
+		t.Fatal("expected registry-a handler to be reused before eviction")
+	}
+	if _, err := cache.OCIHandlerForPrefix("registry-c.test"); err != nil {
+		t.Fatalf("handler C: %v", err)
+	}
+
+	if got, want := len(cache.ociHandlers), 2; got != want {
+		t.Fatalf("expected %d cached handlers, got %d", want, got)
+	}
+	if _, ok := cache.ociHandlers["registry-a.test"]; !ok {
+		t.Fatal("expected registry-a to remain cached after recent reuse")
+	}
+	if _, ok := cache.ociHandlers["registry-c.test"]; !ok {
+		t.Fatal("expected registry-c to be cached")
+	}
+	if _, ok := cache.ociHandlers["registry-b.test"]; ok {
+		t.Fatal("expected registry-b to be evicted")
+	}
+	if !slices.Equal(closed, []string{"registry-b.test"}) {
+		t.Fatalf("expected registry-b closer to run, got %v", closed)
+	}
+}

--- a/internal/gateway/contentcache_types_test.go
+++ b/internal/gateway/contentcache_types_test.go
@@ -281,7 +281,7 @@ func TestOCIHandlerForPrefixEvictsLeastRecentlyUsedHandler(t *testing.T) {
 
 	var closed []string
 	cache := &ContentCache{
-		ociHandlers:    make(map[string]ociHandlerEntry),
+		ociHandlers:    make(map[string]*ociHandlerEntry),
 		maxOCIHandlers: 2,
 		buildOCIHandler: func(prefix string) (ociHandlerEntry, error) {
 			return ociHandlerEntry{
@@ -293,21 +293,23 @@ func TestOCIHandlerForPrefixEvictsLeastRecentlyUsedHandler(t *testing.T) {
 		},
 	}
 
-	handlerA, err := cache.OCIHandlerForPrefix("registry-a.test")
+	handlerA, releaseA, err := cache.OCIHandlerForPrefix("registry-a.test")
 	if err != nil {
 		t.Fatalf("handler A: %v", err)
 	}
-	if _, err := cache.OCIHandlerForPrefix("registry-b.test"); err != nil {
+	_, releaseB, err := cache.OCIHandlerForPrefix("registry-b.test")
+	if err != nil {
 		t.Fatalf("handler B: %v", err)
 	}
-	reusedA, err := cache.OCIHandlerForPrefix("registry-a.test")
+	reusedA, releaseReusedA, err := cache.OCIHandlerForPrefix("registry-a.test")
 	if err != nil {
 		t.Fatalf("reused handler A: %v", err)
 	}
 	if reusedA != handlerA {
 		t.Fatal("expected registry-a handler to be reused before eviction")
 	}
-	if _, err := cache.OCIHandlerForPrefix("registry-c.test"); err != nil {
+	_, releaseC, err := cache.OCIHandlerForPrefix("registry-c.test")
+	if err != nil {
 		t.Fatalf("handler C: %v", err)
 	}
 
@@ -323,7 +325,14 @@ func TestOCIHandlerForPrefixEvictsLeastRecentlyUsedHandler(t *testing.T) {
 	if _, ok := cache.ociHandlers["registry-b.test"]; ok {
 		t.Fatal("expected registry-b to be evicted")
 	}
+	if len(closed) != 0 {
+		t.Fatalf("expected active registry-b handler to stay open until release, got %v", closed)
+	}
+	releaseB()
 	if !slices.Equal(closed, []string{"registry-b.test"}) {
 		t.Fatalf("expected registry-b closer to run, got %v", closed)
 	}
+	releaseA()
+	releaseReusedA()
+	releaseC()
 }

--- a/internal/gateway/dockerhub_cached.go
+++ b/internal/gateway/dockerhub_cached.go
@@ -78,7 +78,7 @@ func (h *dockerHubMirrorHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	cacheHandler, err := h.cache.OCIHandlerForPrefix(dockerHubMirrorPrefix)
+	cacheHandler, releaseHandler, err := h.cache.OCIHandlerForPrefix(dockerHubMirrorPrefix)
 	if err != nil {
 		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonUnknownRegistryPrefix)
 		span.RecordError(err)
@@ -92,6 +92,7 @@ func (h *dockerHubMirrorHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 		writeReasonError(w, http.StatusNotFound, reasonUnknownRegistryPrefix, "docker hub mirror is not configured")
 		return
 	}
+	defer releaseHandler()
 
 	span.SetAttributes(
 		attribute.String(observability.AttrGatewayAction, gatewayActionAllow),

--- a/internal/gateway/oci_cached.go
+++ b/internal/gateway/oci_cached.go
@@ -15,7 +15,7 @@ import (
 
 type registryPrefixHandlerProvider interface {
 	OCIUpstreamForPrefix(prefix string) (string, int, string, int, error)
-	OCIHandlerForPrefix(prefix string) (http.Handler, error)
+	OCIHandlerForPrefix(prefix string) (http.Handler, func(), error)
 }
 
 // cachedRegistryHandler wraps a content-cache OCI handler with cleanroom's
@@ -111,7 +111,7 @@ func (h *cachedRegistryHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	setGatewayRequestDecision(r.Context(), gatewayActionAllow, reasonCached)
 	h.auditLog(r.Context(), scope.SandboxID, upstreamHost, gatewayActionAllow, reasonCached)
 
-	cacheHandler, err := h.cache.OCIHandlerForPrefix(normalizedPrefix)
+	cacheHandler, releaseHandler, err := h.cache.OCIHandlerForPrefix(normalizedPrefix)
 	if err != nil {
 		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonUnknownRegistryPrefix)
 		span.RecordError(err)
@@ -124,6 +124,7 @@ func (h *cachedRegistryHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		writeReasonError(w, http.StatusNotFound, reasonUnknownRegistryPrefix, fmt.Sprintf("unknown registry prefix %q", prefix))
 		return
 	}
+	defer releaseHandler()
 
 	r = r.Clone(withOCIUpstreamPolicy(r.Context(), policyHost, policyPort, upstreamHost, upstreamPort))
 	r.URL.Path = rewriteOCICachePath(normalizedPrefix, rest)

--- a/internal/gateway/oci_cached_test.go
+++ b/internal/gateway/oci_cached_test.go
@@ -30,13 +30,13 @@ func (s *stubRegistryPrefixHandlerProvider) OCIUpstreamForPrefix(prefix string) 
 	return s.policyHost, s.policyPort, s.upstreamHost, s.upstreamPort, nil
 }
 
-func (s *stubRegistryPrefixHandlerProvider) OCIHandlerForPrefix(prefix string) (http.Handler, error) {
+func (s *stubRegistryPrefixHandlerProvider) OCIHandlerForPrefix(prefix string) (http.Handler, func(), error) {
 	s.prefix = prefix
 	s.handlerCalls++
 	if s.err != nil {
-		return nil, s.err
+		return nil, nil, s.err
 	}
-	return s.handler, nil
+	return s.handler, func() {}, nil
 }
 
 func registryTestScope(allowedHosts ...string) *SandboxScope {


### PR DESCRIPTION
Request-controlled OCI registry prefixes currently get a cached content-cache handler per prefix for the daemon lifetime. A sandbox with broad registry egress can churn arbitrary host-style prefixes and keep growing handler state.

This caps per-prefix OCI handlers with the same LRU shape used by scoped Go proxy handlers. Reused prefixes refresh recency; when the cache is full, the least recently used handler is removed and its closer is released after dropping the cache lock.

The remediation plan now marks Slice 6b ready for review and leaves the git pack, fetch, and Go proxy cache authorization findings for follow-up slices.