### PR TITLE
feat: Add idle suspend runtime policy

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -53,7 +53,20 @@ cleanroom config validate --json
 
 Runtime config covers host-specific choices such as the default backend,
 control endpoint, backend asset paths, gateway settings, cache peers,
-observability, snapshot drivers, and Docker service defaults.
+observability, sandbox lifecycle timers, snapshot drivers, and Docker service
+defaults.
+
+Idle sandbox suspension is disabled unless the host runtime config opts in:
+
+```yaml
+sandbox_lifecycle:
+  idle_suspend_after_seconds: 600
+  wake_timeout_seconds: 30
+```
+
+Set `idle_suspend_after_seconds` to `0` or omit it to leave automatic idle
+suspend disabled. The policy applies only to backends that report
+`sandbox.suspend=true`.
 
 Repository behavior belongs in `cleanroom.yaml`; see [Policy](policy.md).
 

--- a/docs/plans/sandbox-suspend-wake.md
+++ b/docs/plans/sandbox-suspend-wake.md
@@ -103,16 +103,20 @@ Slice 1 has landed: lifecycle statuses, backend capability inference, explicit
 suspend/resume RPCs, control-client and control-server plumbing, manual CLI
 commands, `darwin-vz` helper calls, and focused unit and integration tests.
 
-Slice 2 is implemented in this change: guest-touching operations now wake
-suspended sandboxes before execution, file transfer, snapshot creation, or
-sandbox port dialing. Client-side local exposure registration also accepts a
-suspended sandbox when the backend advertises suspend and port-dial support, so
-the incoming connection wakes through `DialSandboxPort`. Active port dials hold
-a guest-interaction lease so later idle-suspend work has a concrete busy marker
-for open tunnels.
+Slice 2 has landed: guest-touching operations wake suspended sandboxes before
+execution, file transfer, snapshot creation, or sandbox port dialing.
+Client-side local exposure registration also accepts a suspended sandbox when
+the backend advertises suspend and port-dial support, so the incoming connection
+wakes through `DialSandboxPort`. Active port dials hold a guest-interaction
+lease so idle-suspend work has a concrete busy marker for open tunnels.
 
-The idle suspend scheduler, runtime config, metrics, real installed-daemon
-smoke tests, and Firecracker support remain follow-up slices.
+Slice 3 is implemented in this change: `sandbox_lifecycle` is runtime config,
+the daemon starts an idle suspend worker when
+`idle_suspend_after_seconds` is positive, and transparent wake is bounded by
+`wake_timeout_seconds` or the sandbox launch timeout when unset.
+
+Metrics, real installed-daemon smoke tests, and Firecracker support remain
+follow-up slices.
 
 ## Target Lifecycle Model
 

--- a/internal/cli/config_validate_test.go
+++ b/internal/cli/config_validate_test.go
@@ -79,6 +79,31 @@ func TestConfigValidateRejectsMissingFile(t *testing.T) {
 	}
 }
 
+func TestConfigValidateRejectsInvalidSandboxLifecycleConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	content := `default_backend: firecracker
+sandbox_lifecycle:
+  idle_suspend_after_seconds: -1
+backends:
+  firecracker:
+    binary_path: firecracker
+`
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	stdout, _ := makeStdoutCapture(t)
+	cmd := &ConfigValidateCommand{Path: configPath}
+	err := cmd.Run(&runtimeContext{CWD: tmpDir, Stdout: stdout})
+	if err == nil {
+		t.Fatal("expected invalid lifecycle config error")
+	}
+	if !strings.Contains(err.Error(), "sandbox_lifecycle.idle_suspend_after_seconds") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestRunConfigValidateBypassesBrokenDefaultRuntimeConfig(t *testing.T) {
 	tmpDir := t.TempDir()
 	xdgConfigHome := filepath.Join(tmpDir, "xdg")

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -226,6 +226,7 @@ func (s *ServeCommand) runServer(ctx *runtimeContext) error {
 
 	runCtx, cancel := serveSignalNotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
+	service.StartIdleSuspendWorker(runCtx)
 	interactiveListen, interactiveHost := resolveInteractiveQUICEndpoint(ep)
 	interactiveServer, err := interactivequic.Start(runCtx, interactiveListen, service, interactiveLogger)
 	if err != nil {

--- a/internal/controlservice/runtime.go
+++ b/internal/controlservice/runtime.go
@@ -62,6 +62,7 @@ type serviceRuntime struct {
 	storageCleanupQueueSize         int
 	cachePeerExportTokenTTL         time.Duration
 	cachePeerExportConcurrency      int
+	idleSuspendPollInterval         time.Duration
 }
 
 var defaultRetentionPolicy = retentionPolicy{
@@ -142,4 +143,14 @@ func (s *Service) cachePeerExportConcurrency() int {
 		return s.runtime.cachePeerExportConcurrency
 	}
 	return defaultCachePeerExportConcurrency
+}
+
+func (s *Service) idleSuspendPollInterval(threshold time.Duration) time.Duration {
+	if s.runtime.idleSuspendPollInterval > 0 {
+		return s.runtime.idleSuspendPollInterval
+	}
+	if threshold > 0 && threshold < 30*time.Second {
+		return threshold
+	}
+	return 30 * time.Second
 }

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -1083,8 +1083,28 @@ func (s *Service) SuspendSandbox(ctx context.Context, req *cleanroomv1.SuspendSa
 		return nil, errors.New("missing sandbox_id")
 	}
 	sandboxID := strings.TrimSpace(req.GetSandboxId())
+	sandbox, err := s.suspendSandbox(ctx, sandboxID, suspendSandboxOptions{
+		authorize:        true,
+		requestedMessage: "sandbox suspend requested",
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &cleanroomv1.SuspendSandboxResponse{Sandbox: sandbox}, nil
+}
 
+type suspendSandboxOptions struct {
+	authorize        bool
+	requestedMessage string
+	idleThreshold    time.Duration
+}
+
+func (s *Service) suspendSandbox(ctx context.Context, sandboxID string, opts suspendSandboxOptions) (*cleanroomv1.Sandbox, error) {
 	var suspendable backend.SuspendableAdapter
+	requestedMessage := strings.TrimSpace(opts.requestedMessage)
+	if requestedMessage == "" {
+		requestedMessage = "sandbox suspend requested"
+	}
 
 	s.mu.Lock()
 	s.ensureMapsLocked()
@@ -1093,18 +1113,26 @@ func (s *Service) SuspendSandbox(ctx context.Context, req *cleanroomv1.SuspendSa
 		s.mu.Unlock()
 		return nil, fmt.Errorf("unknown sandbox %q", sandboxID)
 	}
-	if err := s.authorizeOwnedResource(ctx, "sandbox.suspend", "sandbox", sandboxID, state.Owner, nil); err != nil {
-		s.mu.Unlock()
-		return nil, err
+	if opts.authorize {
+		if err := s.authorizeOwnedResource(ctx, "sandbox.suspend", "sandbox", sandboxID, state.Owner, nil); err != nil {
+			s.mu.Unlock()
+			return nil, err
+		}
 	}
 	if state.Status == cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDED {
-		resp := &cleanroomv1.SuspendSandboxResponse{Sandbox: cloneSandboxLocked(state)}
+		resp := cloneSandboxLocked(state)
 		s.mu.Unlock()
 		return resp, nil
 	}
 	if err := ensureSandboxIdleLocked(sandboxID, state, s.executions); err != nil {
 		s.mu.Unlock()
 		return nil, err
+	}
+	if opts.idleThreshold > 0 {
+		if state.UpdatedAt.IsZero() || s.clock().Now().Sub(state.UpdatedAt) < opts.idleThreshold {
+			s.mu.Unlock()
+			return nil, fmt.Errorf("sandbox %q is not idle long enough", sandboxID)
+		}
 	}
 	adapter, ok := s.Backends[state.Backend]
 	if !ok {
@@ -1124,7 +1152,7 @@ func (s *Service) SuspendSandbox(ctx context.Context, req *cleanroomv1.SuspendSa
 		s.mu.Unlock()
 		return nil, fmt.Errorf("backend_capability_mismatch: backend %q reports sandbox suspend but does not implement it", state.Backend)
 	}
-	s.recordSandboxEventLocked(state, cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDING, "sandbox suspend requested")
+	s.recordSandboxEventLocked(state, cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDING, requestedMessage)
 	s.mu.Unlock()
 
 	err := suspendable.SuspendSandbox(ctx, sandboxID)
@@ -1150,7 +1178,7 @@ func (s *Service) SuspendSandbox(ctx context.Context, req *cleanroomv1.SuspendSa
 	if current.Status == cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDING {
 		s.recordSandboxEventLocked(current, cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDED, "sandbox suspended")
 	}
-	return &cleanroomv1.SuspendSandboxResponse{Sandbox: cloneSandboxLocked(current)}, nil
+	return cloneSandboxLocked(current), nil
 }
 
 func (s *Service) ResumeSandbox(ctx context.Context, req *cleanroomv1.ResumeSandboxRequest) (*cleanroomv1.ResumeSandboxResponse, error) {
@@ -1182,7 +1210,13 @@ func (s *Service) wakeSandbox(ctx context.Context, sandboxID string, guestOperat
 		return nil, err
 	}
 	ch := s.sandboxWakeOps.DoChan(sandboxID, func() (any, error) {
-		return s.resumeSandbox(context.WithoutCancel(ctx), sandboxID, guestOperation)
+		wakeCtx := context.WithoutCancel(ctx)
+		if timeout := s.sandboxWakeTimeout(sandboxID); timeout > 0 {
+			var cancel context.CancelFunc
+			wakeCtx, cancel = context.WithTimeout(wakeCtx, timeout)
+			defer cancel()
+		}
+		return s.resumeSandbox(wakeCtx, sandboxID, guestOperation)
 	})
 	select {
 	case result := <-ch:
@@ -1197,6 +1231,18 @@ func (s *Service) wakeSandbox(ctx context.Context, sandboxID string, guestOperat
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	}
+}
+
+func (s *Service) sandboxWakeTimeout(sandboxID string) time.Duration {
+	if seconds := s.Config.SandboxLifecycle.WakeTimeoutSeconds; seconds > 0 {
+		return time.Duration(seconds) * time.Second
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if sb, ok := s.sandboxes[sandboxID]; ok && sb != nil && sb.Firecracker.LaunchSeconds > 0 {
+		return time.Duration(sb.Firecracker.LaunchSeconds) * time.Second
+	}
+	return 30 * time.Second
 }
 
 func (s *Service) resumeSandbox(ctx context.Context, sandboxID string, guestOperation bool) (*cleanroomv1.Sandbox, error) {
@@ -1278,6 +1324,92 @@ func isIndeterminateSandboxLifecycleError(err error) bool {
 	return errors.Is(err, context.Canceled) ||
 		errors.Is(err, context.DeadlineExceeded) ||
 		errors.Is(err, backend.ErrSandboxLifecycleIndeterminate)
+}
+
+func (s *Service) StartIdleSuspendWorker(ctx context.Context) bool {
+	threshold := s.idleSuspendAfter()
+	if threshold <= 0 {
+		return false
+	}
+	go s.runIdleSuspendWorker(ctx, threshold, s.idleSuspendPollInterval(threshold))
+	return true
+}
+
+func (s *Service) idleSuspendAfter() time.Duration {
+	seconds := s.Config.SandboxLifecycle.IdleSuspendAfterSeconds
+	if seconds <= 0 {
+		return 0
+	}
+	return time.Duration(seconds) * time.Second
+}
+
+func (s *Service) runIdleSuspendWorker(ctx context.Context, threshold, interval time.Duration) {
+	if threshold <= 0 {
+		return
+	}
+	if interval <= 0 {
+		interval = s.idleSuspendPollInterval(threshold)
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-s.clock().After(interval):
+			s.runIdleSuspendOnce(ctx, threshold)
+		}
+	}
+}
+
+func (s *Service) runIdleSuspendOnce(ctx context.Context, threshold time.Duration) {
+	if threshold <= 0 {
+		return
+	}
+	for _, sandboxID := range s.idleSuspendCandidates(s.clock().Now(), threshold) {
+		if err := ctx.Err(); err != nil {
+			return
+		}
+		if _, err := s.suspendSandbox(ctx, sandboxID, suspendSandboxOptions{requestedMessage: "sandbox idle suspend requested", idleThreshold: threshold}); err != nil && s.Logger != nil {
+			s.Logger.Debug("idle suspend skipped", observability.LogFieldSandboxID, sandboxID, "error", err)
+		}
+	}
+}
+
+func (s *Service) idleSuspendCandidates(now time.Time, threshold time.Duration) []string {
+	if threshold <= 0 {
+		return nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	ids := make([]string, 0)
+	for sandboxID, sb := range s.sandboxes {
+		if sb == nil || sb.Status != cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY {
+			continue
+		}
+		if !sandboxSupportsSuspend(sb, s.Backends[sb.Backend]) {
+			continue
+		}
+		if err := ensureSandboxIdleLocked(sandboxID, sb, s.executions); err != nil {
+			continue
+		}
+		if sb.UpdatedAt.IsZero() || now.Sub(sb.UpdatedAt) < threshold {
+			continue
+		}
+		ids = append(ids, sandboxID)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func sandboxSupportsSuspend(sb *sandboxState, adapter backend.Adapter) bool {
+	if sb == nil {
+		return false
+	}
+	capabilities := sb.Capabilities
+	if capabilities == nil {
+		capabilities = backend.CapabilitiesForAdapter(adapter)
+	}
+	return capabilities[backend.CapabilitySandboxSuspend]
 }
 
 func (s *Service) ListExecutions(ctx context.Context, req *cleanroomv1.ListExecutionsRequest) (*cleanroomv1.ListExecutionsResponse, error) {
@@ -1862,6 +1994,7 @@ func (s *Service) DialSandboxPort(ctx context.Context, req *cleanroomv1.SandboxP
 		return nil, fmt.Errorf("backend %q does not support sandbox port dialing", backendName)
 	}
 	state.GuestInteractionCount++
+	state.UpdatedAt = s.clock().Now()
 	s.mu.Unlock()
 
 	release := s.finishSandboxGuestInteractionOnce(sandboxID)
@@ -3742,11 +3875,13 @@ func (s *Service) preparePersistentSandboxRepository(
 	switch {
 	case sandbox.Repository == nil:
 		sandbox.RepositoryBusy = true
+		sandbox.UpdatedAt = s.clock().Now()
 	case repositoryCheckoutsEqual(sandbox.Repository, repository) && (!sandbox.RepositoryHasChangeset || sandbox.RepositoryChangesetPendingExecution):
 		s.mu.Unlock()
 		return nil
 	case repositoryCheckoutsEqual(sandbox.Repository, repository):
 		sandbox.RepositoryBusy = true
+		sandbox.UpdatedAt = s.clock().Now()
 		refreshExisting = true
 		commitBundle = cloneRepositoryCommitBundle(sandbox.RepositoryCommitBundle)
 	default:
@@ -3760,6 +3895,7 @@ func (s *Service) preparePersistentSandboxRepository(
 	s.mu.Lock()
 	if sandbox, ok := s.sandboxes[sandboxID]; ok {
 		sandbox.RepositoryBusy = false
+		sandbox.UpdatedAt = s.clock().Now()
 		if err == nil {
 			sandbox.Repository = cloneRepositoryCheckout(repository)
 			sandbox.RepositoryCommitBundle = cloneRepositoryCommitBundle(commitBundle)
@@ -4440,6 +4576,7 @@ func (s *Service) beginSandboxFileTransfer(ctx context.Context, action, sandboxI
 		}
 	}
 	state.FileTransferInProgress = true
+	state.UpdatedAt = s.clock().Now()
 	backendName := state.Backend
 	s.mu.Unlock()
 
@@ -4447,6 +4584,7 @@ func (s *Service) beginSandboxFileTransfer(ctx context.Context, action, sandboxI
 		s.mu.Lock()
 		if current, ok := s.sandboxes[sandboxID]; ok {
 			current.FileTransferInProgress = false
+			current.UpdatedAt = s.clock().Now()
 		}
 		s.mu.Unlock()
 	}
@@ -4460,6 +4598,7 @@ func (s *Service) finishSandboxGuestInteractionOnce(sandboxID string) func() {
 			s.mu.Lock()
 			if current, ok := s.sandboxes[sandboxID]; ok && current.GuestInteractionCount > 0 {
 				current.GuestInteractionCount--
+				current.UpdatedAt = s.clock().Now()
 			}
 			s.mu.Unlock()
 		})

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -877,6 +877,251 @@ func TestSuspendSandboxBackendIndeterminateFailureLeavesSuspended(t *testing.T) 
 	}
 }
 
+func TestIdleSuspendWorkerSuspendsIdleSandboxAndPublishesEvents(t *testing.T) {
+	base := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+	adapter := &suspendableAdapter{}
+	svc := newTestService(adapter)
+	svc.Config.SandboxLifecycle.IdleSuspendAfterSeconds = 600
+	svc.runtime.clock = stubClock{now: base}
+
+	createResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createResp.GetSandbox().GetSandboxId()
+
+	svc.runtime.clock = stubClock{now: base.Add(601 * time.Second)}
+	svc.runIdleSuspendOnce(context.Background(), 600*time.Second)
+
+	if got, want := adapter.suspendCalls, 1; got != want {
+		t.Fatalf("unexpected suspend call count: got %d want %d", got, want)
+	}
+	getResp, err := svc.GetSandbox(context.Background(), &cleanroomv1.GetSandboxRequest{SandboxId: sandboxID})
+	if err != nil {
+		t.Fatalf("GetSandbox returned error: %v", err)
+	}
+	if got, want := getResp.GetSandbox().GetStatus(), cleanroomv1.SandboxStatus_SANDBOX_STATUS_SUSPENDED; got != want {
+		t.Fatalf("unexpected sandbox status: got %v want %v", got, want)
+	}
+
+	history, _, _, unsubscribe, err := svc.SubscribeSandboxEvents(sandboxID)
+	if err != nil {
+		t.Fatalf("SubscribeSandboxEvents returned error: %v", err)
+	}
+	defer unsubscribe()
+	if len(history) < 3 {
+		t.Fatalf("expected create and idle suspend events, got %d", len(history))
+	}
+	if got, want := history[len(history)-2].GetMessage(), "sandbox idle suspend requested"; got != want {
+		t.Fatalf("unexpected idle suspend request event: got %q want %q", got, want)
+	}
+	if got, want := history[len(history)-1].GetMessage(), "sandbox suspended"; got != want {
+		t.Fatalf("unexpected idle suspend result event: got %q want %q", got, want)
+	}
+}
+
+func TestIdleSuspendRechecksThresholdBeforeSuspending(t *testing.T) {
+	base := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+	adapter := &suspendableAdapter{}
+	svc := newTestService(adapter)
+	svc.runtime.clock = stubClock{now: base}
+
+	createResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createResp.GetSandbox().GetSandboxId()
+
+	svc.runtime.clock = stubClock{now: base.Add(10 * time.Second)}
+	_, err = svc.suspendSandbox(context.Background(), sandboxID, suspendSandboxOptions{
+		requestedMessage: "sandbox idle suspend requested",
+		idleThreshold:    600 * time.Second,
+	})
+	if err == nil {
+		t.Fatal("expected idle suspend to reject a recently active sandbox")
+	}
+	if !strings.Contains(err.Error(), "not idle long enough") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := adapter.suspendCalls; got != 0 {
+		t.Fatalf("expected backend suspend not to run, got %d calls", got)
+	}
+}
+
+func TestIdleSuspendWorkerSkipsBusySandboxes(t *testing.T) {
+	base := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+	for _, tc := range []struct {
+		name string
+		busy func(*Service, string)
+	}{
+		{
+			name: "file transfer",
+			busy: func(svc *Service, sandboxID string) {
+				svc.sandboxes[sandboxID].FileTransferInProgress = true
+			},
+		},
+		{
+			name: "repository",
+			busy: func(svc *Service, sandboxID string) {
+				svc.sandboxes[sandboxID].RepositoryBusy = true
+			},
+		},
+		{
+			name: "guest interaction",
+			busy: func(svc *Service, sandboxID string) {
+				svc.sandboxes[sandboxID].GuestInteractionCount = 1
+			},
+		},
+		{
+			name: "execution",
+			busy: func(svc *Service, sandboxID string) {
+				executionID := "exec_busy"
+				svc.sandboxes[sandboxID].ActiveExecutionID = executionID
+				svc.executions[executionKey(sandboxID, executionID)] = &executionState{
+					ID:        executionID,
+					SandboxID: sandboxID,
+					Status:    cleanroomv1.ExecutionStatus_EXECUTION_STATUS_RUNNING,
+				}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			adapter := &suspendableAdapter{}
+			svc := newTestService(adapter)
+			svc.Config.SandboxLifecycle.IdleSuspendAfterSeconds = 600
+			svc.runtime.clock = stubClock{now: base}
+			createResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+			if err != nil {
+				t.Fatalf("CreateSandbox returned error: %v", err)
+			}
+			sandboxID := createResp.GetSandbox().GetSandboxId()
+
+			svc.mu.Lock()
+			tc.busy(svc, sandboxID)
+			svc.sandboxes[sandboxID].UpdatedAt = base
+			svc.mu.Unlock()
+
+			svc.runtime.clock = stubClock{now: base.Add(601 * time.Second)}
+			svc.runIdleSuspendOnce(context.Background(), 600*time.Second)
+
+			if got := adapter.suspendCalls; got != 0 {
+				t.Fatalf("expected busy sandbox not to suspend, got %d suspend calls", got)
+			}
+			getResp, err := svc.GetSandbox(context.Background(), &cleanroomv1.GetSandboxRequest{SandboxId: sandboxID})
+			if err != nil {
+				t.Fatalf("GetSandbox returned error: %v", err)
+			}
+			if got, want := getResp.GetSandbox().GetStatus(), cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY; got != want {
+				t.Fatalf("unexpected sandbox status: got %v want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestIdleSuspendWorkerSkipsUnsupportedBackends(t *testing.T) {
+	base := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+	svc := newTestService(&stubAdapter{})
+	svc.Config.SandboxLifecycle.IdleSuspendAfterSeconds = 600
+	svc.runtime.clock = stubClock{now: base}
+
+	createResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createResp.GetSandbox().GetSandboxId()
+
+	svc.runtime.clock = stubClock{now: base.Add(601 * time.Second)}
+	svc.runIdleSuspendOnce(context.Background(), 600*time.Second)
+
+	getResp, err := svc.GetSandbox(context.Background(), &cleanroomv1.GetSandboxRequest{SandboxId: sandboxID})
+	if err != nil {
+		t.Fatalf("GetSandbox returned error: %v", err)
+	}
+	if got, want := getResp.GetSandbox().GetStatus(), cleanroomv1.SandboxStatus_SANDBOX_STATUS_READY; got != want {
+		t.Fatalf("unexpected sandbox status: got %v want %v", got, want)
+	}
+}
+
+func TestResumeSandboxUsesConfiguredWakeTimeout(t *testing.T) {
+	adapter := &suspendableAdapter{}
+	var sawDeadline bool
+	var deadlineErr error
+	adapter.resumeFn = func(ctx context.Context, _ string) error {
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			deadlineErr = errors.New("expected resume context to have a deadline")
+			return nil
+		}
+		remaining := time.Until(deadline)
+		if remaining <= 0 || remaining > 6*time.Second {
+			deadlineErr = fmt.Errorf("unexpected resume deadline: %s", remaining)
+			return nil
+		}
+		sawDeadline = true
+		return nil
+	}
+	svc := newTestService(adapter)
+	svc.Config.SandboxLifecycle.WakeTimeoutSeconds = 5
+	createResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createResp.GetSandbox().GetSandboxId()
+	if _, err := svc.SuspendSandbox(context.Background(), &cleanroomv1.SuspendSandboxRequest{SandboxId: sandboxID}); err != nil {
+		t.Fatalf("SuspendSandbox returned error: %v", err)
+	}
+
+	if _, err := svc.ResumeSandbox(context.Background(), &cleanroomv1.ResumeSandboxRequest{SandboxId: sandboxID}); err != nil {
+		t.Fatalf("ResumeSandbox returned error: %v", err)
+	}
+	if deadlineErr != nil {
+		t.Fatal(deadlineErr)
+	}
+	if !sawDeadline {
+		t.Fatal("resume adapter was not called")
+	}
+}
+
+func TestResumeSandboxDefaultsWakeTimeoutToLaunchTimeout(t *testing.T) {
+	adapter := &suspendableAdapter{}
+	var sawDeadline bool
+	var deadlineErr error
+	adapter.resumeFn = func(ctx context.Context, _ string) error {
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			deadlineErr = errors.New("expected resume context to have a deadline")
+			return nil
+		}
+		remaining := time.Until(deadline)
+		if remaining <= 0 || remaining > 8*time.Second {
+			deadlineErr = fmt.Errorf("unexpected resume deadline: %s", remaining)
+			return nil
+		}
+		sawDeadline = true
+		return nil
+	}
+	svc := newTestService(adapter)
+	svc.Config.Backends.Firecracker.LaunchSeconds = 7
+	createResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createResp.GetSandbox().GetSandboxId()
+	if _, err := svc.SuspendSandbox(context.Background(), &cleanroomv1.SuspendSandboxRequest{SandboxId: sandboxID}); err != nil {
+		t.Fatalf("SuspendSandbox returned error: %v", err)
+	}
+
+	if _, err := svc.ResumeSandbox(context.Background(), &cleanroomv1.ResumeSandboxRequest{SandboxId: sandboxID}); err != nil {
+		t.Fatalf("ResumeSandbox returned error: %v", err)
+	}
+	if deadlineErr != nil {
+		t.Fatal(deadlineErr)
+	}
+	if !sawDeadline {
+		t.Fatal("resume adapter was not called")
+	}
+}
+
 func TestResumeSandboxTransitionsSuspendedToReady(t *testing.T) {
 	adapter := &suspendableAdapter{}
 	svc := newTestService(adapter)

--- a/internal/runtimeconfig/config.go
+++ b/internal/runtimeconfig/config.go
@@ -12,6 +12,7 @@ import (
 	"runtime"
 	"strings"
 	"text/template"
+	"time"
 
 	"github.com/buildkite/cleanroom/internal/backend"
 	"github.com/buildkite/cleanroom/internal/bytesize"
@@ -20,13 +21,14 @@ import (
 )
 
 type Config struct {
-	DefaultBackend string              `yaml:"default_backend"`
-	ControlHost    string              `yaml:"control_host,omitempty"`
-	Auth           AuthConfig          `yaml:"auth,omitempty"`
-	Cache          CacheConfig         `yaml:"cache,omitempty"`
-	Gateway        GatewayConfig       `yaml:"gateway,omitempty"`
-	Observability  ObservabilityConfig `yaml:"observability,omitempty"`
-	Backends       Backends            `yaml:"backends"`
+	DefaultBackend   string                 `yaml:"default_backend"`
+	ControlHost      string                 `yaml:"control_host,omitempty"`
+	Auth             AuthConfig             `yaml:"auth,omitempty"`
+	Cache            CacheConfig            `yaml:"cache,omitempty"`
+	Gateway          GatewayConfig          `yaml:"gateway,omitempty"`
+	Observability    ObservabilityConfig    `yaml:"observability,omitempty"`
+	SandboxLifecycle SandboxLifecycleConfig `yaml:"sandbox_lifecycle,omitempty"`
+	Backends         Backends               `yaml:"backends"`
 }
 
 const (
@@ -64,6 +66,11 @@ type CacheConfig struct {
 type CachePeerConfig struct {
 	URL      string `yaml:"url"`
 	TokenEnv string `yaml:"token_env,omitempty"`
+}
+
+type SandboxLifecycleConfig struct {
+	IdleSuspendAfterSeconds int64 `yaml:"idle_suspend_after_seconds,omitempty"`
+	WakeTimeoutSeconds      int64 `yaml:"wake_timeout_seconds,omitempty"`
 }
 
 type GatewayConfig struct {
@@ -134,13 +141,14 @@ type TraceSamplingConfig struct {
 }
 
 type configFile struct {
-	DefaultBackend string              `yaml:"default_backend"`
-	ControlHost    string              `yaml:"control_host,omitempty"`
-	Auth           AuthConfig          `yaml:"auth,omitempty"`
-	Cache          CacheConfig         `yaml:"cache,omitempty"`
-	Gateway        GatewayConfig       `yaml:"gateway,omitempty"`
-	Observability  ObservabilityConfig `yaml:"observability,omitempty"`
-	Backends       backendsFile        `yaml:"backends"`
+	DefaultBackend   string                 `yaml:"default_backend"`
+	ControlHost      string                 `yaml:"control_host,omitempty"`
+	Auth             AuthConfig             `yaml:"auth,omitempty"`
+	Cache            CacheConfig            `yaml:"cache,omitempty"`
+	Gateway          GatewayConfig          `yaml:"gateway,omitempty"`
+	Observability    ObservabilityConfig    `yaml:"observability,omitempty"`
+	SandboxLifecycle SandboxLifecycleConfig `yaml:"sandbox_lifecycle,omitempty"`
+	Backends         backendsFile           `yaml:"backends"`
 }
 
 type backendsFile struct {
@@ -151,12 +159,13 @@ type backendsFile struct {
 
 func (f configFile) config() Config {
 	cfg := Config{
-		DefaultBackend: f.DefaultBackend,
-		ControlHost:    f.ControlHost,
-		Auth:           f.Auth,
-		Cache:          f.Cache,
-		Gateway:        f.Gateway,
-		Observability:  f.Observability,
+		DefaultBackend:   f.DefaultBackend,
+		ControlHost:      f.ControlHost,
+		Auth:             f.Auth,
+		Cache:            f.Cache,
+		Gateway:          f.Gateway,
+		Observability:    f.Observability,
+		SandboxLifecycle: f.SandboxLifecycle,
 		Backends: Backends{
 			Firecracker: f.Backends.Firecracker,
 			DarwinVZ:    f.Backends.DarwinVZ,
@@ -512,6 +521,30 @@ func validateConfig(cfg Config) error {
 	}
 	if err := validateObservabilityConfig(cfg.Observability); err != nil {
 		return err
+	}
+	if err := validateSandboxLifecycleConfig(cfg.SandboxLifecycle); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateSandboxLifecycleConfig(cfg SandboxLifecycleConfig) error {
+	if err := validateDurationSeconds("sandbox_lifecycle.idle_suspend_after_seconds", cfg.IdleSuspendAfterSeconds); err != nil {
+		return err
+	}
+	if err := validateDurationSeconds("sandbox_lifecycle.wake_timeout_seconds", cfg.WakeTimeoutSeconds); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateDurationSeconds(name string, seconds int64) error {
+	if seconds < 0 {
+		return fmt.Errorf("%s must be greater than or equal to 0", name)
+	}
+	const maxDurationSeconds = int64(1<<63-1) / int64(time.Second)
+	if seconds > maxDurationSeconds {
+		return fmt.Errorf("%s is too large", name)
 	}
 	return nil
 }

--- a/internal/runtimeconfig/config_test.go
+++ b/internal/runtimeconfig/config_test.go
@@ -1498,6 +1498,118 @@ backends:
 	}
 }
 
+func TestLoadSandboxLifecycleConfig(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	configPath := filepath.Join(tmp, "cleanroom", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+
+	content := `default_backend: firecracker
+sandbox_lifecycle:
+  idle_suspend_after_seconds: 600
+  wake_timeout_seconds: 30
+backends:
+  firecracker:
+    binary_path: firecracker
+`
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, _, err := Load()
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if got, want := cfg.SandboxLifecycle.IdleSuspendAfterSeconds, int64(600); got != want {
+		t.Fatalf("unexpected idle suspend timeout: got %d want %d", got, want)
+	}
+	if got, want := cfg.SandboxLifecycle.WakeTimeoutSeconds, int64(30); got != want {
+		t.Fatalf("unexpected wake timeout: got %d want %d", got, want)
+	}
+}
+
+func TestLoadDefaultsSandboxLifecycleToDisabled(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	configPath := filepath.Join(tmp, "cleanroom", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+
+	content := `default_backend: firecracker
+backends:
+  firecracker:
+    binary_path: firecracker
+`
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, _, err := Load()
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if got := cfg.SandboxLifecycle.IdleSuspendAfterSeconds; got != 0 {
+		t.Fatalf("expected idle suspend timeout to default to 0, got %d", got)
+	}
+	if got := cfg.SandboxLifecycle.WakeTimeoutSeconds; got != 0 {
+		t.Fatalf("expected wake timeout to default to 0, got %d", got)
+	}
+}
+
+func TestLoadRejectsInvalidSandboxLifecycleConfig(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name: "negative idle suspend timeout",
+			content: `default_backend: firecracker
+sandbox_lifecycle:
+  idle_suspend_after_seconds: -1
+backends:
+  firecracker:
+    binary_path: firecracker
+`,
+			want: "sandbox_lifecycle.idle_suspend_after_seconds",
+		},
+		{
+			name: "negative wake timeout",
+			content: `default_backend: firecracker
+sandbox_lifecycle:
+  wake_timeout_seconds: -1
+backends:
+  firecracker:
+    binary_path: firecracker
+`,
+			want: "sandbox_lifecycle.wake_timeout_seconds",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			t.Setenv("XDG_CONFIG_HOME", tmp)
+			configPath := filepath.Join(tmp, "cleanroom", "config.yaml")
+			if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+				t.Fatalf("mkdir config dir: %v", err)
+			}
+			if err := os.WriteFile(configPath, []byte(tc.content), 0o644); err != nil {
+				t.Fatalf("write config: %v", err)
+			}
+
+			_, _, err := Load()
+			if err == nil {
+				t.Fatal("expected Load to reject invalid sandbox lifecycle config")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected error to mention %q, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
 func TestLoadTrimsControlHost(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)


### PR DESCRIPTION
Persistent sandboxes can now be paused manually and woken transparently, but hosts still had no daemon-owned way to decide when idle sandboxes should pause. That kept suspend timing out of repository policy but left no runtime knob for host resource reclamation.

This adds host runtime config:

```yaml
sandbox_lifecycle:
  idle_suspend_after_seconds: 600
  wake_timeout_seconds: 30
```

`idle_suspend_after_seconds` stays disabled when omitted or set to `0`. When set, `cleanroom serve` starts an idle scanner that only suspends ready, idle sandboxes whose backend reports `sandbox.suspend=true`; busy execution, file transfer, repository, snapshot, and port-dial states are skipped. Transparent wake now uses `wake_timeout_seconds`, falling back to the sandbox launch timeout when unset.

The operations docs and suspend-wake plan are updated for the new config boundary.