### PR TITLE
feat: Partition stage cache by owner

### DIFF
--- a/docs/plans/multi-principal-control-server.md
+++ b/docs/plans/multi-principal-control-server.md
@@ -1,8 +1,8 @@
 # Multi-Principal Control Server Authorization Plan
 
 **Spec reference:** `docs/spec.md` sections 5.4, 6.1, and 6.2; `docs/api.md`; `docs/tls.md`
-**Status:** Slice 2A implemented; Slice 2B next
-**Last reviewed:** 2026-05-26
+**Status:** Slice 2B-1 implemented; gateway and content-cache auth next
+**Last reviewed:** 2026-05-27
 
 ## Summary
 
@@ -41,6 +41,11 @@ Slice 2 is split into PR-sized enforcement work:
   create-time grant checks, and exact owner checks for control-plane resources.
 - Slice 2B carries owner authorization into embedded gateway routes,
   `content-cache` request envelopes, and stage-cache metadata partitioning.
+- Slice 2B-1 now stamps owner metadata on stage-cache records, partitions
+  stage-cache lookups and touches by exact principal, keeps ownerless cache
+  records visible only to unauthenticated local callers, migrates the SQLite
+  stage-cache primary key to include owner, and disables cache-peer imports for
+  authenticated requests until the peer protocol carries owner metadata.
 
 Focused validation run on 2026-05-25:
 
@@ -64,6 +69,14 @@ Slice 2A validation run on 2026-05-26:
 mise exec -- go test ./internal/controlservice -run 'TestDeleteSnapshotRejectsSnapshotWithMetadataLoadInFlight|TestAuthzSnapshotRestoreEvaluatesSandboxCreateAgainstSnapshotBackend|TestAuthz' -count=1
 mise exec -- go test ./internal/authz ./internal/controlserver ./internal/controlclient ./internal/cli ./internal/snapshotstore
 mise run check
+```
+
+Result: passed.
+
+Slice 2B-1 focused validation run on 2026-05-27:
+
+```text
+mise exec -- go test ./internal/cachestore ./internal/controlservice ./internal/controlserver ./internal/storagegc
 ```
 
 Result: passed.
@@ -642,6 +655,17 @@ Scope:
 - Deny auth-enabled access to pre-existing cache records that have no owner
   metadata.
 
+Progress:
+
+- 2B-1 completed the stage-cache metadata partition: owner fields are persisted,
+  exact-owner cache lookup is used under authenticated contexts, cache
+  publication stamps the authenticated principal, ownerless legacy records miss
+  under auth, block-volume stage-cache records follow the same owner rules, and
+  storage GC deletes owner-scoped metadata without removing another owner's row
+  for the same logical cache key.
+- Cache-peer imports are disabled for authenticated contexts in this slice
+  because `LookupCachePeerRequest` does not yet include an owner envelope.
+
 Definition of done: with auth enabled, a sandbox can only receive cached Git or
 OCI content and reusable stage-cache filesystem state that is authorized for its
 owner, including warm cache hits. Routes that cannot authorize cached objects
@@ -737,6 +761,8 @@ Runtime smoke test:
 - Relationship-based sharing across teams, bot pools, or repositories.
 - Admin APIs for listing principals, grants, and audit decisions.
 - Persistent sandbox and execution stores beyond current retained server state.
+- Owner-aware cache-peer lookup and transfer envelopes for authenticated cache
+  sharing.
 
 ## Open Questions
 

--- a/internal/cachestore/store.go
+++ b/internal/cachestore/store.go
@@ -19,6 +19,8 @@ import (
 type Record struct {
 	CacheKey                 string
 	Stage                    string
+	OwnerPrincipalID         string
+	OwnerScope               string
 	ReuseMode                string
 	State                    string
 	BackingSnapshotID        string
@@ -165,6 +167,8 @@ func (s *Store) persist(ctx context.Context, record Record, replace bool) error 
 		INSERT INTO cache_entries (
 			cache_key,
 			stage,
+			owner_principal_id,
+			owner_scope,
 			reuse_mode,
 			state,
 			backing_snapshot_id,
@@ -195,7 +199,7 @@ func (s *Store) persist(ctx context.Context, record Record, replace bool) error 
 			last_used_at_unix_nano,
 			last_validated_at_unix_nano,
 			producer_version
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`
 	if replace {
 		verb = "upsert"
@@ -203,6 +207,8 @@ func (s *Store) persist(ctx context.Context, record Record, replace bool) error 
 			INSERT INTO cache_entries (
 				cache_key,
 				stage,
+				owner_principal_id,
+				owner_scope,
 				reuse_mode,
 				state,
 				backing_snapshot_id,
@@ -233,8 +239,9 @@ func (s *Store) persist(ctx context.Context, record Record, replace bool) error 
 				last_used_at_unix_nano,
 				last_validated_at_unix_nano,
 				producer_version
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-			ON CONFLICT(stage, cache_key) DO UPDATE SET
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			ON CONFLICT(stage, cache_key, owner_principal_id) DO UPDATE SET
+				owner_scope = excluded.owner_scope,
 				reuse_mode = excluded.reuse_mode,
 				state = excluded.state,
 				backing_snapshot_id = excluded.backing_snapshot_id,
@@ -271,6 +278,8 @@ func (s *Store) persist(ctx context.Context, record Record, replace bool) error 
 	if _, err := db.ExecContext(ctx, statement,
 		record.CacheKey,
 		record.Stage,
+		strings.TrimSpace(record.OwnerPrincipalID),
+		nullableString(record.OwnerScope),
 		nullableString(record.ReuseMode),
 		record.State,
 		record.BackingSnapshotID,
@@ -308,6 +317,18 @@ func (s *Store) persist(ctx context.Context, record Record, replace bool) error 
 }
 
 func (s *Store) GetReady(ctx context.Context, stage, cacheKey string) (Record, bool, error) {
+	return s.getReadyForOwner(ctx, stage, cacheKey, "")
+}
+
+func (s *Store) GetReadyForOwner(ctx context.Context, stage, cacheKey, ownerPrincipalID string) (Record, bool, error) {
+	ownerPrincipalID = strings.TrimSpace(ownerPrincipalID)
+	if ownerPrincipalID == "" {
+		return Record{}, false, nil
+	}
+	return s.getReadyForOwner(ctx, stage, cacheKey, ownerPrincipalID)
+}
+
+func (s *Store) getReadyForOwner(ctx context.Context, stage, cacheKey, ownerPrincipalID string) (Record, bool, error) {
 	db, err := s.open(ctx)
 	if err != nil {
 		return Record{}, false, err
@@ -318,6 +339,8 @@ func (s *Store) GetReady(ctx context.Context, stage, cacheKey string) (Record, b
 		SELECT
 			cache_key,
 			stage,
+			owner_principal_id,
+			owner_scope,
 			reuse_mode,
 			state,
 			backing_snapshot_id,
@@ -349,8 +372,8 @@ func (s *Store) GetReady(ctx context.Context, stage, cacheKey string) (Record, b
 			last_validated_at_unix_nano,
 			producer_version
 		FROM cache_entries
-		WHERE stage = ? AND cache_key = ? AND state = 'ready'
-	`, strings.TrimSpace(stage), strings.TrimSpace(cacheKey))
+		WHERE stage = ? AND cache_key = ? AND owner_principal_id = ? AND state = 'ready'
+	`, strings.TrimSpace(stage), strings.TrimSpace(cacheKey), strings.TrimSpace(ownerPrincipalID))
 
 	record, err := scanRecord(row)
 	if err != nil {
@@ -363,6 +386,18 @@ func (s *Store) GetReady(ctx context.Context, stage, cacheKey string) (Record, b
 }
 
 func (s *Store) UpdateLastUsedAt(ctx context.Context, stage, cacheKey string, lastUsedAt time.Time) error {
+	return s.updateLastUsedAtForOwner(ctx, stage, cacheKey, "", lastUsedAt)
+}
+
+func (s *Store) UpdateLastUsedAtForOwner(ctx context.Context, stage, cacheKey, ownerPrincipalID string, lastUsedAt time.Time) error {
+	ownerPrincipalID = strings.TrimSpace(ownerPrincipalID)
+	if ownerPrincipalID == "" {
+		return fmt.Errorf("cache metadata %q/%q missing owner principal", stage, cacheKey)
+	}
+	return s.updateLastUsedAtForOwner(ctx, stage, cacheKey, ownerPrincipalID, lastUsedAt)
+}
+
+func (s *Store) updateLastUsedAtForOwner(ctx context.Context, stage, cacheKey, ownerPrincipalID string, lastUsedAt time.Time) error {
 	if lastUsedAt.IsZero() {
 		lastUsedAt = time.Now().UTC()
 	}
@@ -376,8 +411,8 @@ func (s *Store) UpdateLastUsedAt(ctx context.Context, stage, cacheKey string, la
 	result, err := db.ExecContext(ctx, `
 		UPDATE cache_entries
 		SET last_used_at_unix_nano = ?
-		WHERE stage = ? AND cache_key = ?
-	`, lastUsedAt.UTC().UnixNano(), strings.TrimSpace(stage), strings.TrimSpace(cacheKey))
+		WHERE stage = ? AND cache_key = ? AND owner_principal_id = ?
+	`, lastUsedAt.UTC().UnixNano(), strings.TrimSpace(stage), strings.TrimSpace(cacheKey), strings.TrimSpace(ownerPrincipalID))
 	if err != nil {
 		return fmt.Errorf("update cache last used time %q/%q: %w", stage, cacheKey, err)
 	}
@@ -391,6 +426,10 @@ func (s *Store) Touch(ctx context.Context, stage, cacheKey string) error {
 	return s.UpdateLastUsedAt(ctx, stage, cacheKey, time.Now().UTC())
 }
 
+func (s *Store) TouchForOwner(ctx context.Context, stage, cacheKey, ownerPrincipalID string) error {
+	return s.UpdateLastUsedAtForOwner(ctx, stage, cacheKey, ownerPrincipalID, time.Now().UTC())
+}
+
 func (s *Store) List(ctx context.Context) ([]Record, error) {
 	db, err := s.open(ctx)
 	if err != nil {
@@ -402,6 +441,8 @@ func (s *Store) List(ctx context.Context) ([]Record, error) {
 		SELECT
 			cache_key,
 			stage,
+			owner_principal_id,
+			owner_scope,
 			reuse_mode,
 			state,
 			backing_snapshot_id,
@@ -433,7 +474,7 @@ func (s *Store) List(ctx context.Context) ([]Record, error) {
 			last_validated_at_unix_nano,
 			producer_version
 		FROM cache_entries
-		ORDER BY created_at_unix_nano ASC, cache_key ASC
+		ORDER BY created_at_unix_nano ASC, cache_key ASC, owner_principal_id ASC
 	`)
 	if err != nil {
 		return nil, fmt.Errorf("query cache metadata: %w", err)
@@ -470,6 +511,22 @@ func (s *Store) Delete(ctx context.Context, stage, cacheKey string) error {
 	return nil
 }
 
+func (s *Store) DeleteForOwner(ctx context.Context, stage, cacheKey, ownerPrincipalID string) error {
+	db, err := s.open(ctx)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	if _, err := db.ExecContext(ctx, `
+		DELETE FROM cache_entries
+		WHERE stage = ? AND cache_key = ? AND owner_principal_id = ?
+	`, strings.TrimSpace(stage), strings.TrimSpace(cacheKey), strings.TrimSpace(ownerPrincipalID)); err != nil {
+		return fmt.Errorf("delete cache metadata %q/%q for owner %q: %w", stage, cacheKey, ownerPrincipalID, err)
+	}
+	return nil
+}
+
 func (s *Store) open(ctx context.Context) (*sql.DB, error) {
 	if err := s.initDB(ctx); err != nil {
 		return nil, err
@@ -492,6 +549,8 @@ func (s *Store) initDB(ctx context.Context) error {
 		CREATE TABLE IF NOT EXISTS cache_entries (
 			cache_key TEXT NOT NULL,
 			stage TEXT NOT NULL,
+			owner_principal_id TEXT NOT NULL DEFAULT '',
+			owner_scope TEXT,
 			reuse_mode TEXT,
 			state TEXT NOT NULL,
 			backend TEXT NOT NULL,
@@ -521,7 +580,7 @@ func (s *Store) initDB(ctx context.Context) error {
 			last_used_at_unix_nano INTEGER NOT NULL,
 			last_validated_at_unix_nano INTEGER NOT NULL DEFAULT 0,
 			producer_version TEXT NOT NULL,
-			PRIMARY KEY (stage, cache_key)
+			PRIMARY KEY (stage, cache_key, owner_principal_id)
 		);
 		CREATE INDEX IF NOT EXISTS idx_cache_entries_state_created_at ON cache_entries(state, created_at_unix_nano);
 		CREATE INDEX IF NOT EXISTS idx_cache_entries_last_used_at ON cache_entries(last_used_at_unix_nano);
@@ -583,7 +642,221 @@ func (s *Store) initDB(ctx context.Context) error {
 	if _, err := db.ExecContext(ctx, `ALTER TABLE cache_entries ADD COLUMN last_validated_at_unix_nano INTEGER NOT NULL DEFAULT 0`); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
 		return fmt.Errorf("ensure cache metadata last_validated_at_unix_nano column: %w", err)
 	}
+	if _, err := db.ExecContext(ctx, `ALTER TABLE cache_entries ADD COLUMN owner_principal_id TEXT NOT NULL DEFAULT ''`); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
+		return fmt.Errorf("ensure cache metadata owner_principal_id column: %w", err)
+	}
+	if _, err := db.ExecContext(ctx, `ALTER TABLE cache_entries ADD COLUMN owner_scope TEXT`); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
+		return fmt.Errorf("ensure cache metadata owner_scope column: %w", err)
+	}
+	if err := ensureCacheEntriesOwnerPrimaryKey(ctx, db); err != nil {
+		return err
+	}
+	if _, err := db.ExecContext(ctx, `
+		CREATE INDEX IF NOT EXISTS idx_cache_entries_state_created_at ON cache_entries(state, created_at_unix_nano);
+		CREATE INDEX IF NOT EXISTS idx_cache_entries_last_used_at ON cache_entries(last_used_at_unix_nano);
+	`); err != nil {
+		return fmt.Errorf("ensure cache metadata indexes: %w", err)
+	}
 	return nil
+}
+
+func ensureCacheEntriesOwnerPrimaryKey(ctx context.Context, db *sql.DB) error {
+	primaryKey, err := cacheEntriesPrimaryKeyColumns(ctx, db)
+	if err != nil {
+		return err
+	}
+	if stringSlicesEqual(primaryKey, []string{"stage", "cache_key", "owner_principal_id"}) {
+		return nil
+	}
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin cache metadata owner primary key migration: %w", err)
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.ExecContext(ctx, `
+		CREATE TABLE cache_entries_owner_pk (
+			cache_key TEXT NOT NULL,
+			stage TEXT NOT NULL,
+			owner_principal_id TEXT NOT NULL DEFAULT '',
+			owner_scope TEXT,
+			reuse_mode TEXT,
+			state TEXT NOT NULL,
+			backing_snapshot_id TEXT NOT NULL DEFAULT '',
+			backend TEXT NOT NULL,
+			architecture TEXT,
+			runtime_base_key TEXT,
+			policy_hash TEXT NOT NULL,
+			policy_proto BLOB NOT NULL,
+			repository_proto BLOB,
+			repository_has_changeset INTEGER NOT NULL DEFAULT 0,
+			repository_changeset_id TEXT,
+			parent_cache_key TEXT,
+			storage_driver TEXT NOT NULL DEFAULT 'file',
+			storage_ref TEXT NOT NULL,
+			storage_size_bytes INTEGER NOT NULL DEFAULT 0,
+			exclusive_size_bytes INTEGER NOT NULL DEFAULT 0,
+			driver_metadata TEXT,
+			input_manifest_digest TEXT,
+			command_digest TEXT,
+			env_digest TEXT,
+			normalized_outputs_digest TEXT,
+			output_manifest_digest TEXT,
+			dependency_key_files_digest TEXT,
+			output_records_json BLOB,
+			checkout_refresh_required INTEGER NOT NULL DEFAULT 0,
+			imported_from_peer INTEGER NOT NULL DEFAULT 0,
+			created_at_unix_nano INTEGER NOT NULL,
+			last_used_at_unix_nano INTEGER NOT NULL,
+			last_validated_at_unix_nano INTEGER NOT NULL DEFAULT 0,
+			producer_version TEXT NOT NULL,
+			PRIMARY KEY (stage, cache_key, owner_principal_id)
+		)
+	`); err != nil {
+		return fmt.Errorf("create cache metadata owner primary key table: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO cache_entries_owner_pk (
+			cache_key,
+			stage,
+			owner_principal_id,
+			owner_scope,
+			reuse_mode,
+			state,
+			backing_snapshot_id,
+			backend,
+			architecture,
+			runtime_base_key,
+			policy_hash,
+			policy_proto,
+			repository_proto,
+			repository_has_changeset,
+			repository_changeset_id,
+			parent_cache_key,
+			storage_driver,
+			storage_ref,
+			storage_size_bytes,
+			exclusive_size_bytes,
+			driver_metadata,
+			input_manifest_digest,
+			command_digest,
+			env_digest,
+			normalized_outputs_digest,
+			output_manifest_digest,
+			dependency_key_files_digest,
+			output_records_json,
+			checkout_refresh_required,
+			imported_from_peer,
+			created_at_unix_nano,
+			last_used_at_unix_nano,
+			last_validated_at_unix_nano,
+			producer_version
+		)
+		SELECT
+			cache_key,
+			stage,
+			COALESCE(owner_principal_id, ''),
+			owner_scope,
+			reuse_mode,
+			state,
+			backing_snapshot_id,
+			backend,
+			architecture,
+			runtime_base_key,
+			policy_hash,
+			policy_proto,
+			repository_proto,
+			repository_has_changeset,
+			repository_changeset_id,
+			parent_cache_key,
+			storage_driver,
+			storage_ref,
+			storage_size_bytes,
+			exclusive_size_bytes,
+			driver_metadata,
+			input_manifest_digest,
+			command_digest,
+			env_digest,
+			normalized_outputs_digest,
+			output_manifest_digest,
+			dependency_key_files_digest,
+			output_records_json,
+			checkout_refresh_required,
+			imported_from_peer,
+			created_at_unix_nano,
+			last_used_at_unix_nano,
+			last_validated_at_unix_nano,
+			producer_version
+		FROM cache_entries
+	`); err != nil {
+		return fmt.Errorf("copy cache metadata into owner primary key table: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DROP TABLE cache_entries`); err != nil {
+		return fmt.Errorf("drop old cache metadata table: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `ALTER TABLE cache_entries_owner_pk RENAME TO cache_entries`); err != nil {
+		return fmt.Errorf("rename cache metadata owner primary key table: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit cache metadata owner primary key migration: %w", err)
+	}
+	return nil
+}
+
+func cacheEntriesPrimaryKeyColumns(ctx context.Context, db *sql.DB) ([]string, error) {
+	rows, err := db.QueryContext(ctx, `PRAGMA table_info(cache_entries)`)
+	if err != nil {
+		return nil, fmt.Errorf("inspect cache metadata primary key: %w", err)
+	}
+	defer rows.Close()
+
+	type primaryKeyColumn struct {
+		name string
+		pos  int
+	}
+	var cols []primaryKeyColumn
+	for rows.Next() {
+		var (
+			cid       int
+			name      string
+			columnTyp string
+			notNull   int
+			defaultV  any
+			pk        int
+		)
+		if err := rows.Scan(&cid, &name, &columnTyp, &notNull, &defaultV, &pk); err != nil {
+			return nil, fmt.Errorf("scan cache metadata primary key: %w", err)
+		}
+		if pk > 0 {
+			cols = append(cols, primaryKeyColumn{name: name, pos: pk})
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate cache metadata primary key: %w", err)
+	}
+	for i := 1; i < len(cols); i++ {
+		for j := i; j > 0 && cols[j-1].pos > cols[j].pos; j-- {
+			cols[j-1], cols[j] = cols[j], cols[j-1]
+		}
+	}
+	names := make([]string, 0, len(cols))
+	for _, col := range cols {
+		names = append(names, col.name)
+	}
+	return names, nil
+}
+
+func stringSlicesEqual(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
 }
 
 type recordScanner interface {
@@ -598,6 +871,7 @@ func scanRecord(row recordScanner) (Record, error) {
 		repositoryHasChangeset   int
 		checkoutRefreshRequired  int
 		importedFromPeer         int
+		ownerScope               sql.NullString
 		reuseMode                sql.NullString
 		architecture             sql.NullString
 		runtimeBaseKey           sql.NullString
@@ -618,6 +892,8 @@ func scanRecord(row recordScanner) (Record, error) {
 	if err := row.Scan(
 		&record.CacheKey,
 		&record.Stage,
+		&record.OwnerPrincipalID,
+		&ownerScope,
 		&reuseMode,
 		&record.State,
 		&record.BackingSnapshotID,
@@ -663,6 +939,9 @@ func scanRecord(row recordScanner) (Record, error) {
 		}
 	}
 	record.RepositoryHasChangeset = repositoryHasChangeset != 0
+	if ownerScope.Valid {
+		record.OwnerScope = ownerScope.String
+	}
 	if repositoryChangesetID.Valid {
 		record.RepositoryChangesetID = repositoryChangesetID.String
 	}

--- a/internal/cachestore/store_test.go
+++ b/internal/cachestore/store_test.go
@@ -313,6 +313,169 @@ func TestStoreCreateRejectsDuplicateStageCacheKey(t *testing.T) {
 	}
 }
 
+func TestStorePartitionsReadyRecordsByOwner(t *testing.T) {
+	t.Parallel()
+
+	store, err := New(Options{MetadataDBPath: filepath.Join(t.TempDir(), "caches.db")})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	record := Record{
+		CacheKey:          "workspace-stage:test",
+		Stage:             "workspace",
+		State:             "ready",
+		BackingSnapshotID: "snapshot-workspace-test",
+		Backend:           "firecracker",
+		PolicyHash:        "policy-hash",
+		Policy:            testPolicy(),
+		StorageRef:        "/tmp/workspace-test.ext4",
+		StorageDriver:     "file",
+		ProducerVersion:   "cleanroom-test/1",
+	}
+	alice := record
+	alice.OwnerPrincipalID = "oidc:test:alice"
+	alice.OwnerScope = "scope:alice"
+	alice.BackingSnapshotID = "snapshot-alice"
+	alice.StorageRef = "/tmp/alice.ext4"
+	bob := record
+	bob.OwnerPrincipalID = "oidc:test:bob"
+	bob.OwnerScope = "scope:bob"
+	bob.BackingSnapshotID = "snapshot-bob"
+	bob.StorageRef = "/tmp/bob.ext4"
+	if err := store.Create(context.Background(), alice); err != nil {
+		t.Fatalf("Create alice returned error: %v", err)
+	}
+	if err := store.Create(context.Background(), bob); err != nil {
+		t.Fatalf("Create bob with same stage/cache_key returned error: %v", err)
+	}
+
+	if _, ok, err := store.GetReady(context.Background(), record.Stage, record.CacheKey); err != nil {
+		t.Fatalf("ownerless GetReady returned error: %v", err)
+	} else if ok {
+		t.Fatal("ownerless GetReady returned an owned record")
+	}
+	gotAlice, ok, err := store.GetReadyForOwner(context.Background(), record.Stage, record.CacheKey, "oidc:test:alice")
+	if err != nil {
+		t.Fatalf("GetReadyForOwner alice returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected alice-owned record")
+	}
+	if gotAlice.StorageRef != alice.StorageRef || gotAlice.OwnerScope != alice.OwnerScope {
+		t.Fatalf("unexpected alice record: %#v", gotAlice)
+	}
+	gotBob, ok, err := store.GetReadyForOwner(context.Background(), record.Stage, record.CacheKey, "oidc:test:bob")
+	if err != nil {
+		t.Fatalf("GetReadyForOwner bob returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected bob-owned record")
+	}
+	if gotBob.StorageRef != bob.StorageRef || gotBob.OwnerScope != bob.OwnerScope {
+		t.Fatalf("unexpected bob record: %#v", gotBob)
+	}
+
+	next := time.Unix(1700000300, 0).UTC()
+	if err := store.UpdateLastUsedAtForOwner(context.Background(), record.Stage, record.CacheKey, "oidc:test:alice", next); err != nil {
+		t.Fatalf("UpdateLastUsedAtForOwner returned error: %v", err)
+	}
+	gotAlice, ok, err = store.GetReadyForOwner(context.Background(), record.Stage, record.CacheKey, "oidc:test:alice")
+	if err != nil || !ok {
+		t.Fatalf("GetReadyForOwner alice after touch = ok %v err %v", ok, err)
+	}
+	gotBob, ok, err = store.GetReadyForOwner(context.Background(), record.Stage, record.CacheKey, "oidc:test:bob")
+	if err != nil || !ok {
+		t.Fatalf("GetReadyForOwner bob after touch = ok %v err %v", ok, err)
+	}
+	if !gotAlice.LastUsedAt.Equal(next) {
+		t.Fatalf("unexpected alice last_used_at: got %s want %s", gotAlice.LastUsedAt.Format(time.RFC3339Nano), next.Format(time.RFC3339Nano))
+	}
+	if gotBob.LastUsedAt.Equal(next) {
+		t.Fatalf("bob last_used_at changed when touching alice: %s", gotBob.LastUsedAt.Format(time.RFC3339Nano))
+	}
+}
+
+func TestNewMigratesLegacyOwnerlessPrimaryKey(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "caches.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open legacy cache db: %v", err)
+	}
+	if _, err := db.ExecContext(context.Background(), `
+		CREATE TABLE cache_entries (
+			cache_key TEXT NOT NULL,
+			stage TEXT NOT NULL,
+			reuse_mode TEXT,
+			state TEXT NOT NULL,
+			backend TEXT NOT NULL,
+			architecture TEXT,
+			runtime_base_key TEXT,
+			policy_hash TEXT NOT NULL,
+			policy_proto BLOB NOT NULL,
+			repository_proto BLOB,
+			repository_has_changeset INTEGER NOT NULL DEFAULT 0,
+			repository_changeset_id TEXT,
+			parent_cache_key TEXT,
+			storage_driver TEXT NOT NULL DEFAULT 'file',
+			storage_ref TEXT NOT NULL,
+			storage_size_bytes INTEGER NOT NULL DEFAULT 0,
+			exclusive_size_bytes INTEGER NOT NULL DEFAULT 0,
+			driver_metadata TEXT,
+			input_manifest_digest TEXT,
+			command_digest TEXT,
+			env_digest TEXT,
+			normalized_outputs_digest TEXT,
+			output_manifest_digest TEXT,
+			dependency_key_files_digest TEXT,
+			output_records_json BLOB,
+			checkout_refresh_required INTEGER NOT NULL DEFAULT 0,
+			imported_from_peer INTEGER NOT NULL DEFAULT 0,
+			created_at_unix_nano INTEGER NOT NULL,
+			last_used_at_unix_nano INTEGER NOT NULL,
+			last_validated_at_unix_nano INTEGER NOT NULL DEFAULT 0,
+			producer_version TEXT NOT NULL,
+			PRIMARY KEY (stage, cache_key)
+		)
+	`); err != nil {
+		t.Fatalf("create legacy cache table: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close legacy cache db: %v", err)
+	}
+
+	store, err := New(Options{MetadataDBPath: dbPath})
+	if err != nil {
+		t.Fatalf("New returned error for legacy cache db: %v", err)
+	}
+	record := Record{
+		CacheKey:          "workspace-stage:test",
+		Stage:             "workspace",
+		State:             "ready",
+		BackingSnapshotID: "snapshot-workspace-test",
+		Backend:           "firecracker",
+		PolicyHash:        "policy-hash",
+		Policy:            testPolicy(),
+		StorageRef:        "/tmp/workspace-test.ext4",
+		StorageDriver:     "file",
+		ProducerVersion:   "cleanroom-test/1",
+	}
+	alice := record
+	alice.OwnerPrincipalID = "oidc:test:alice"
+	alice.StorageRef = "/tmp/alice.ext4"
+	bob := record
+	bob.OwnerPrincipalID = "oidc:test:bob"
+	bob.StorageRef = "/tmp/bob.ext4"
+	if err := store.Create(context.Background(), alice); err != nil {
+		t.Fatalf("Create alice after legacy migration returned error: %v", err)
+	}
+	if err := store.Create(context.Background(), bob); err != nil {
+		t.Fatalf("Create bob with same stage/cache_key after legacy migration returned error: %v", err)
+	}
+}
+
 func TestNewMigratesLegacySchemalessDatabase(t *testing.T) {
 	t.Parallel()
 

--- a/internal/controlserver/cache_peer_test.go
+++ b/internal/controlserver/cache_peer_test.go
@@ -282,17 +282,29 @@ func newHandlerCacheStore() *handlerCacheStore {
 }
 
 func (s *handlerCacheStore) Create(_ context.Context, record cachestore.Record) error {
-	s.records[handlerCacheStoreKey(record.Stage, record.CacheKey)] = record
+	s.records[handlerCacheStoreOwnerKey(record.Stage, record.CacheKey, record.OwnerPrincipalID)] = record
 	return nil
 }
 
 func (s *handlerCacheStore) Upsert(_ context.Context, record cachestore.Record) error {
-	s.records[handlerCacheStoreKey(record.Stage, record.CacheKey)] = record
+	s.records[handlerCacheStoreOwnerKey(record.Stage, record.CacheKey, record.OwnerPrincipalID)] = record
 	return nil
 }
 
 func (s *handlerCacheStore) GetReady(_ context.Context, stage, cacheKey string) (cachestore.Record, bool, error) {
-	record, ok := s.records[handlerCacheStoreKey(stage, cacheKey)]
+	record, ok := s.records[handlerCacheStoreOwnerKey(stage, cacheKey, "")]
+	if !ok || record.State != "ready" {
+		return cachestore.Record{}, false, nil
+	}
+	return record, true, nil
+}
+
+func (s *handlerCacheStore) GetReadyForOwner(_ context.Context, stage, cacheKey, ownerPrincipalID string) (cachestore.Record, bool, error) {
+	ownerPrincipalID = strings.TrimSpace(ownerPrincipalID)
+	if ownerPrincipalID == "" {
+		return cachestore.Record{}, false, nil
+	}
+	record, ok := s.records[handlerCacheStoreOwnerKey(stage, cacheKey, ownerPrincipalID)]
 	if !ok || record.State != "ready" {
 		return cachestore.Record{}, false, nil
 	}
@@ -300,6 +312,10 @@ func (s *handlerCacheStore) GetReady(_ context.Context, stage, cacheKey string) 
 }
 
 func (s *handlerCacheStore) Touch(context.Context, string, string) error {
+	return nil
+}
+
+func (s *handlerCacheStore) TouchForOwner(context.Context, string, string, string) error {
 	return nil
 }
 
@@ -312,12 +328,25 @@ func (s *handlerCacheStore) List(context.Context) ([]cachestore.Record, error) {
 }
 
 func (s *handlerCacheStore) Delete(_ context.Context, stage, cacheKey string) error {
-	delete(s.records, handlerCacheStoreKey(stage, cacheKey))
+	for key, record := range s.records {
+		if strings.TrimSpace(record.Stage) == strings.TrimSpace(stage) && strings.TrimSpace(record.CacheKey) == strings.TrimSpace(cacheKey) {
+			delete(s.records, key)
+		}
+	}
+	return nil
+}
+
+func (s *handlerCacheStore) DeleteForOwner(_ context.Context, stage, cacheKey, ownerPrincipalID string) error {
+	delete(s.records, handlerCacheStoreOwnerKey(stage, cacheKey, ownerPrincipalID))
 	return nil
 }
 
 func handlerCacheStoreKey(stage, cacheKey string) string {
 	return strings.TrimSpace(stage) + "\x00" + strings.TrimSpace(cacheKey)
+}
+
+func handlerCacheStoreOwnerKey(stage, cacheKey, ownerPrincipalID string) string {
+	return handlerCacheStoreKey(stage, cacheKey) + "\x00" + strings.TrimSpace(ownerPrincipalID)
 }
 
 type handlerCachePeerRecordOptions struct {

--- a/internal/controlservice/authz_test.go
+++ b/internal/controlservice/authz_test.go
@@ -10,7 +10,10 @@ import (
 
 	"github.com/buildkite/cleanroom/internal/authz"
 	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/cachestore"
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+	"github.com/buildkite/cleanroom/internal/observability"
+	"github.com/buildkite/cleanroom/internal/policy"
 	"github.com/buildkite/cleanroom/internal/repositorychangeset"
 	"github.com/buildkite/cleanroom/internal/repositorycheckout"
 	"github.com/buildkite/cleanroom/internal/runtimeconfig"
@@ -330,6 +333,111 @@ func TestAuthzDeniesOwnerlessSnapshotWhenAuthenticated(t *testing.T) {
 	_, err := svc.GetSnapshot(testAuthContext(t, "alice"), &cleanroomv1.GetSnapshotRequest{SnapshotId: "snap-ownerless"})
 	if !errors.Is(err, ErrAuthorizationDenied) {
 		t.Fatalf("GetSnapshot ownerless error = %v, want authorization denied", err)
+	}
+}
+
+func TestAuthzStageCacheLookupRequiresMatchingOwner(t *testing.T) {
+	cacheStore := newMemoryCacheStore()
+	svc := &Service{CacheStore: cacheStore}
+	compiled, err := policy.FromProto(testRepositoryPolicy())
+	if err != nil {
+		t.Fatalf("FromProto returned error: %v", err)
+	}
+	repository := repositorycheckout.FromProto(testRepositoryCheckoutProto())
+	cacheKey := workspaceStageCacheKey("firecracker", "runtime-base:test", compiled.Hash, repository, nil)
+	record := cachestore.Record{
+		CacheKey:          cacheKey,
+		Stage:             workspaceStageName,
+		OwnerPrincipalID:  "oidc:test:alice",
+		OwnerScope:        "scope:alice",
+		State:             cacheStateReady,
+		BackingSnapshotID: "snapshot-alice",
+		Backend:           "firecracker",
+		PolicyHash:        compiled.Hash,
+		Policy:            compiled.ToProto(),
+		Repository:        cloneRepositoryCheckout(normalizeRepositoryCheckoutForComparison(repository)).ToProto(),
+		ParentCacheKey:    "runtime-base:test",
+		StorageDriver:     "file",
+		StorageRef:        "/tmp/alice.ext4",
+		ProducerVersion:   workspaceStageProducerVersion,
+	}
+	if err := cacheStore.Create(context.Background(), record); err != nil {
+		t.Fatalf("Create owned cache record returned error: %v", err)
+	}
+	ownerlessRecord := record
+	ownerlessRecord.OwnerPrincipalID = ""
+	ownerlessRecord.OwnerScope = ""
+	ownerlessRecord.BackingSnapshotID = "snapshot-ownerless"
+	ownerlessRecord.StorageRef = "/tmp/ownerless.ext4"
+	if err := cacheStore.Create(context.Background(), ownerlessRecord); err != nil {
+		t.Fatalf("Create ownerless cache record returned error: %v", err)
+	}
+
+	got, ok, reason, err := svc.lookupWorkspaceStageCache(testAuthContext(t, "alice"), "firecracker", compiled, "runtime-base:test", repository, nil)
+	if err != nil {
+		t.Fatalf("lookup as owner returned error: %v", err)
+	}
+	if !ok {
+		t.Fatalf("lookup as owner missed with reason %q", reason)
+	}
+	if got.OwnerPrincipalID != "oidc:test:alice" {
+		t.Fatalf("lookup as owner returned owner %q", got.OwnerPrincipalID)
+	}
+
+	if _, ok, reason, err := svc.lookupWorkspaceStageCache(testAuthContext(t, "bob"), "firecracker", compiled, "runtime-base:test", repository, nil); err != nil {
+		t.Fatalf("lookup as other principal returned error: %v", err)
+	} else if ok || reason != observability.CacheLookupReasonRecordNotFound {
+		t.Fatalf("lookup as other principal = ok %v reason %q, want owner miss", ok, reason)
+	}
+
+	got, ok, reason, err = svc.lookupWorkspaceStageCache(context.Background(), "firecracker", compiled, "runtime-base:test", repository, nil)
+	if err != nil {
+		t.Fatalf("ownerless lookup returned error: %v", err)
+	}
+	if !ok {
+		t.Fatalf("ownerless lookup missed with reason %q", reason)
+	}
+	if got.OwnerPrincipalID != "" || got.StorageRef != "/tmp/ownerless.ext4" {
+		t.Fatalf("ownerless lookup returned %#v", got)
+	}
+}
+
+func TestAuthzStageCachePublishStampsOwner(t *testing.T) {
+	adapter := &stubAdapter{}
+	svc := newTestServiceWithSnapshotStore(adapter, newMemorySnapshotStore())
+	cacheStore := newMemoryCacheStore()
+	svc.CacheStore = cacheStore
+	compiled, err := policy.FromProto(testRepositoryPolicy())
+	if err != nil {
+		t.Fatalf("FromProto returned error: %v", err)
+	}
+	repository := repositorycheckout.FromProto(testRepositoryCheckoutProto())
+
+	svc.maybePublishWorkspaceStageCache(
+		testAuthContext(t, "alice"),
+		adapter,
+		"sandbox-1",
+		"firecracker",
+		compiled,
+		backend.FirecrackerConfig{},
+		"runtime-base:test",
+		repository,
+		nil,
+		nil,
+	)
+
+	records, err := cacheStore.List(context.Background())
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if got, want := len(records), 1; got != want {
+		t.Fatalf("unexpected cache record count: got %d want %d", got, want)
+	}
+	if got, want := records[0].OwnerPrincipalID, "oidc:test:alice"; got != want {
+		t.Fatalf("cache owner mismatch: got %q want %q", got, want)
+	}
+	if got, want := records[0].OwnerScope, "scope:alice"; got != want {
+		t.Fatalf("cache owner scope mismatch: got %q want %q", got, want)
 	}
 }
 

--- a/internal/controlservice/block_volume_plan.go
+++ b/internal/controlservice/block_volume_plan.go
@@ -169,7 +169,7 @@ func blockVolumeRepositorySourceDigest(repository *repositorycheckout.Checkout, 
 }
 
 func lookupBlockVolumeCache(ctx context.Context, store cacheMetadataStore, stageName, backendName string, compiled *policy.CompiledPolicy, block blockVolumeBlockPlan) (blockVolumeBlockPlan, error) {
-	record, ok, err := store.GetReady(ctx, stageName, block.CacheKey)
+	record, ok, err := lookupReadyCacheRecord(ctx, store, stageName, block.CacheKey)
 	if err != nil {
 		return block, err
 	}
@@ -199,6 +199,9 @@ func suggestedBlockVolumeMinimumBytes(ctx context.Context, store cacheMetadataSt
 	}
 	var maxSize int64
 	for _, record := range records {
+		if !cacheRecordVisibleToContext(ctx, record) {
+			continue
+		}
 		if !blockVolumeRecordCanInformMinimum(record, stageName, backendName, compiled, block) {
 			continue
 		}

--- a/internal/controlservice/block_volume_publish.go
+++ b/internal/controlservice/block_volume_publish.go
@@ -115,6 +115,7 @@ func (s *Service) maybePublishBlockVolumeCaches(
 	for i, block := range missed {
 		snapshot := snapshots[i]
 		record := blockVolumeCacheRecordFromSnapshot(backendName, compiled, repository, changeset, phase.StageName, block, snapshot, now)
+		stampCacheRecordOwner(ctx, &record)
 		if reason := blockVolumeOutputRecordMissReason(block.Outputs, record.OutputRecords); reason != "" {
 			s.cleanupBlockVolumeSnapshots(adapter, backendName, firecrackerCfg, phase, snapshots)
 			phase.warn(s, phase.PublishWarning, sandboxID, fmt.Errorf("snapshot output records for block %q do not match declared outputs: %s", block.BlockName, reason))

--- a/internal/controlservice/cache_owner.go
+++ b/internal/controlservice/cache_owner.go
@@ -1,0 +1,58 @@
+package controlservice
+
+import (
+	"context"
+	"strings"
+
+	"github.com/buildkite/cleanroom/internal/cachestore"
+)
+
+func stampCacheRecordOwner(ctx context.Context, record *cachestore.Record) {
+	if record == nil {
+		return
+	}
+	owner, ok := ownerForContext(ctx)
+	if !ok {
+		return
+	}
+	record.OwnerPrincipalID = strings.TrimSpace(owner.PrincipalID)
+	record.OwnerScope = strings.TrimSpace(owner.Scope)
+}
+
+func lookupReadyCacheRecord(ctx context.Context, store cacheMetadataStore, stage, cacheKey string) (cachestore.Record, bool, error) {
+	if store == nil {
+		return cachestore.Record{}, false, nil
+	}
+	owner, ok := ownerForContext(ctx)
+	if !ok {
+		return store.GetReady(ctx, stage, cacheKey)
+	}
+	return store.GetReadyForOwner(ctx, stage, cacheKey, owner.PrincipalID)
+}
+
+func touchCacheRecord(ctx context.Context, store cacheMetadataStore, record cachestore.Record) error {
+	if store == nil {
+		return nil
+	}
+	ownerPrincipalID := strings.TrimSpace(record.OwnerPrincipalID)
+	if ownerPrincipalID != "" {
+		return store.TouchForOwner(ctx, record.Stage, record.CacheKey, ownerPrincipalID)
+	}
+	return store.Touch(ctx, record.Stage, record.CacheKey)
+}
+
+func deleteCacheRecord(ctx context.Context, store cacheMetadataStore, record cachestore.Record) error {
+	if store == nil {
+		return nil
+	}
+	return store.DeleteForOwner(ctx, record.Stage, record.CacheKey, strings.TrimSpace(record.OwnerPrincipalID))
+}
+
+func cacheRecordVisibleToContext(ctx context.Context, record cachestore.Record) bool {
+	owner, ok := ownerForContext(ctx)
+	recordOwner := strings.TrimSpace(record.OwnerPrincipalID)
+	if !ok {
+		return recordOwner == ""
+	}
+	return recordOwner != "" && recordOwner == strings.TrimSpace(owner.PrincipalID)
+}

--- a/internal/controlservice/cache_peer.go
+++ b/internal/controlservice/cache_peer.go
@@ -317,6 +317,9 @@ func (s *Service) planCachePeerExport(ctx context.Context, lookup cachePeerLooku
 	if !ok {
 		return cachePeerExportMatch{}, cachePeerMissRecordNotFound, nil
 	}
+	if strings.TrimSpace(child.OwnerPrincipalID) != "" {
+		return cachePeerExportMatch{}, cachePeerMissRecordNotFound, nil
+	}
 	if missReason := cachePeerChildRecordMissReason(child, lookup); missReason != "" {
 		return cachePeerExportMatch{}, missReason, nil
 	}
@@ -326,6 +329,9 @@ func (s *Service) planCachePeerExport(ctx context.Context, lookup cachePeerLooku
 		return cachePeerExportMatch{}, "", err
 	}
 	if !ok {
+		return cachePeerExportMatch{}, cachePeerMissParentRecordNotFound, nil
+	}
+	if strings.TrimSpace(parent.OwnerPrincipalID) != "" {
 		return cachePeerExportMatch{}, cachePeerMissParentRecordNotFound, nil
 	}
 	if strings.TrimSpace(parent.Backend) != lookup.Backend || strings.TrimSpace(parent.StorageDriver) != lookup.StorageDriver {

--- a/internal/controlservice/cache_peer_import.go
+++ b/internal/controlservice/cache_peer_import.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
+	"github.com/buildkite/cleanroom/internal/authz"
 	"github.com/buildkite/cleanroom/internal/backend"
 	"github.com/buildkite/cleanroom/internal/cachestore"
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
@@ -254,6 +255,11 @@ func (s *Service) importCachePeerStage(ctx context.Context, adapter backend.Snap
 	if len(s.Config.Cache.Peers) == 0 || s.CachePeerTransferDriver == nil || opts.NewRecord == nil || opts.ValidateRecord == nil {
 		return cachePeerImportResult{}, nil
 	}
+	if _, ok := authz.BoundPrincipalFromContext(ctx); ok {
+		s.recordCachePeerImport(ctx, opts.Stage, observability.CacheResultFallback)
+		trace.SpanFromContext(ctx).SetAttributes(attribute.String(observability.AttrCachePeerFallback, "cache peer import disabled for authenticated principal"))
+		return cachePeerImportResult{}, nil
+	}
 	if opts.Backend != "firecracker" || opts.StorageDriver != "zfs" {
 		return cachePeerImportResult{}, nil
 	}
@@ -265,7 +271,7 @@ func (s *Service) importCachePeerStage(ctx context.Context, adapter backend.Snap
 	if err != nil {
 		return cachePeerImportResult{}, nil
 	}
-	parent, ok, err := store.GetReady(ctx, opts.ParentStage, opts.ParentCacheKey)
+	parent, ok, err := lookupReadyCacheRecord(ctx, store, opts.ParentStage, opts.ParentCacheKey)
 	if err != nil {
 		return cachePeerImportResult{}, err
 	}
@@ -370,6 +376,7 @@ func (s *Service) importCachePeerCandidate(
 	}
 
 	record := opts.NewRecord(snapshotID, imported, s.clock().Now())
+	stampCacheRecordOwner(ctx, &record)
 	if err := store.Create(ctx, record); err != nil {
 		existing, found, _, lookupErr := opts.ValidateRecord(ctx)
 		_ = adapter.DeleteSnapshot(context.Background(), backend.DeleteSnapshotRequest{
@@ -399,7 +406,7 @@ func (s *Service) importCachePeerCandidate(
 
 	validated, found, reason, err := opts.ValidateRecord(ctx)
 	if err != nil {
-		_ = store.Delete(context.Background(), record.Stage, record.CacheKey)
+		_ = deleteCacheRecord(context.Background(), store, record)
 		_ = adapter.DeleteSnapshot(context.Background(), backend.DeleteSnapshotRequest{
 			SnapshotID:        snapshotID,
 			StorageRef:        imported.StorageRef,
@@ -412,7 +419,7 @@ func (s *Service) importCachePeerCandidate(
 		return cachePeerImportResult{}, true, err
 	}
 	if !found {
-		_ = store.Delete(context.Background(), record.Stage, record.CacheKey)
+		_ = deleteCacheRecord(context.Background(), store, record)
 		_ = adapter.DeleteSnapshot(context.Background(), backend.DeleteSnapshotRequest{
 			SnapshotID:        snapshotID,
 			StorageRef:        imported.StorageRef,
@@ -604,5 +611,5 @@ func (s *Service) cacheRecordByKey(ctx context.Context, stage, cacheKey string) 
 	if err != nil {
 		return cachestore.Record{}, false, nil
 	}
-	return store.GetReady(ctx, stage, cacheKey)
+	return lookupReadyCacheRecord(ctx, store, stage, cacheKey)
 }

--- a/internal/controlservice/cache_peer_import_test.go
+++ b/internal/controlservice/cache_peer_import_test.go
@@ -61,6 +61,46 @@ func TestCachePeerImportHTTPClientsHaveBoundedTimeouts(t *testing.T) {
 	}
 }
 
+func TestCachePeerImportSkipsAuthenticatedPrincipals(t *testing.T) {
+	t.Setenv("CACHE_PEER_TOKEN", "token")
+	driver := &stubCachePeerTransferDriver{}
+	svc := &Service{
+		Config: runtimeconfig.Config{
+			Cache: runtimeconfig.CacheConfig{Peers: []runtimeconfig.CachePeerConfig{{
+				URL:      "http://cache-peer.example.test",
+				TokenEnv: "CACHE_PEER_TOKEN",
+			}}},
+		},
+		CachePeerTransferDriver: driver,
+	}
+
+	result, err := svc.importCachePeerStage(testAuthContext(t, "alice"), &stubAdapter{}, backend.FirecrackerConfig{}, cachePeerImportOptions{
+		Stage:          dependencyStageName,
+		CacheKey:       "dependency-stage:test",
+		ParentStage:    workspaceStageName,
+		ParentCacheKey: "workspace-stage:test",
+		Backend:        "firecracker",
+		StorageDriver:  "zfs",
+		NewRecord: func(string, volumestore.Snapshot, time.Time) cachestore.Record {
+			t.Fatal("NewRecord should not run for authenticated cache peer import")
+			return cachestore.Record{}
+		},
+		ValidateRecord: func(context.Context) (cachestore.Record, bool, string, error) {
+			t.Fatal("ValidateRecord should not run for authenticated cache peer import")
+			return cachestore.Record{}, false, "", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("importCachePeerStage returned error: %v", err)
+	}
+	if result.imported {
+		t.Fatal("authenticated cache peer import should not import")
+	}
+	if got := len(driver.describeRequests); got != 0 {
+		t.Fatalf("expected no snapshot metadata lookup, got %d", got)
+	}
+}
+
 func TestCachePeerTimeoutConnReadTimesOutWhenIdle(t *testing.T) {
 	reader, writer := net.Pipe()
 	t.Cleanup(func() {

--- a/internal/controlservice/dependency_stage.go
+++ b/internal/controlservice/dependency_stage.go
@@ -839,7 +839,7 @@ func (s *Service) lookupDependencyStageCache(ctx context.Context, backendName st
 		return cachestore.Record{}, false, "", nil
 	}
 
-	record, ok, err := store.GetReady(ctx, dependencyStageName, plan.CacheKey)
+	record, ok, err := lookupReadyCacheRecord(ctx, store, dependencyStageName, plan.CacheKey)
 	if err != nil {
 		return cachestore.Record{}, false, "", err
 	}
@@ -876,7 +876,7 @@ func (s *Service) lookupPortableDependencyStageCache(ctx context.Context, backen
 		return cachestore.Record{}, false, "", nil
 	}
 
-	record, ok, err := store.GetReady(ctx, dependencyStageName, plan.PortableCacheKey)
+	record, ok, err := lookupReadyCacheRecord(ctx, store, dependencyStageName, plan.PortableCacheKey)
 	if err != nil {
 		return cachestore.Record{}, false, "", err
 	}
@@ -1222,6 +1222,7 @@ func (s *Service) maybePublishDependencyStageCache(
 		ProducerVersion:          dependencyStageProducerVersion,
 	}
 	populateStageCacheRecordMetadata(&record, plan.ParentRuntimeCacheKey, result, now)
+	stampCacheRecordOwner(ctx, &record)
 
 	persist := store.Create
 	if replacedRecord != nil && strings.TrimSpace(replacedRecord.CacheKey) == plan.CacheKey {

--- a/internal/controlservice/dependency_volume_plan_test.go
+++ b/internal/controlservice/dependency_volume_plan_test.go
@@ -1045,8 +1045,22 @@ func (s *recordingCacheStore) GetReady(ctx context.Context, stage, cacheKey stri
 	return record, ok, err
 }
 
+func (s *recordingCacheStore) GetReadyForOwner(ctx context.Context, stage, cacheKey, ownerPrincipalID string) (cachestore.Record, bool, error) {
+	record, ok, err := s.inner.GetReadyForOwner(ctx, stage, cacheKey, ownerPrincipalID)
+	s.lookups = append(s.lookups, recordingCacheStoreLookup{
+		stage:    stage,
+		cacheKey: cacheKey,
+		hit:      ok,
+	})
+	return record, ok, err
+}
+
 func (s *recordingCacheStore) Touch(ctx context.Context, stage, cacheKey string) error {
 	return s.inner.Touch(ctx, stage, cacheKey)
+}
+
+func (s *recordingCacheStore) TouchForOwner(ctx context.Context, stage, cacheKey, ownerPrincipalID string) error {
+	return s.inner.TouchForOwner(ctx, stage, cacheKey, ownerPrincipalID)
 }
 
 func (s *recordingCacheStore) List(ctx context.Context) ([]cachestore.Record, error) {
@@ -1055,6 +1069,10 @@ func (s *recordingCacheStore) List(ctx context.Context) ([]cachestore.Record, er
 
 func (s *recordingCacheStore) Delete(ctx context.Context, stage, cacheKey string) error {
 	return s.inner.Delete(ctx, stage, cacheKey)
+}
+
+func (s *recordingCacheStore) DeleteForOwner(ctx context.Context, stage, cacheKey, ownerPrincipalID string) error {
+	return s.inner.DeleteForOwner(ctx, stage, cacheKey, ownerPrincipalID)
 }
 
 func (s *recordingCacheStore) getReadyCount(stage string) int {

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -202,9 +202,12 @@ type cacheMetadataStore interface {
 	Create(context.Context, cachestore.Record) error
 	Upsert(context.Context, cachestore.Record) error
 	GetReady(context.Context, string, string) (cachestore.Record, bool, error)
+	GetReadyForOwner(context.Context, string, string, string) (cachestore.Record, bool, error)
 	Touch(context.Context, string, string) error
+	TouchForOwner(context.Context, string, string, string) error
 	List(context.Context) ([]cachestore.Record, error)
 	Delete(context.Context, string, string) error
+	DeleteForOwner(context.Context, string, string, string) error
 }
 
 type changesetMetadataStore interface {

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -2362,7 +2362,7 @@ func newMemoryCacheStore() *memoryCacheStore {
 func (s *memoryCacheStore) Create(_ context.Context, record cachestore.Record) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	key := cacheStoreKey(record.Stage, record.CacheKey)
+	key := cacheStoreOwnerKey(record.Stage, record.CacheKey, record.OwnerPrincipalID)
 	if _, exists := s.records[key]; exists {
 		return errors.New("cache record already exists")
 	}
@@ -2373,14 +2373,26 @@ func (s *memoryCacheStore) Create(_ context.Context, record cachestore.Record) e
 func (s *memoryCacheStore) Upsert(_ context.Context, record cachestore.Record) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.records[cacheStoreKey(record.Stage, record.CacheKey)] = record
+	s.records[cacheStoreOwnerKey(record.Stage, record.CacheKey, record.OwnerPrincipalID)] = record
 	return nil
 }
 
 func (s *memoryCacheStore) GetReady(_ context.Context, stage, cacheKey string) (cachestore.Record, bool, error) {
+	return s.getReadyForOwner(stage, cacheKey, "")
+}
+
+func (s *memoryCacheStore) GetReadyForOwner(_ context.Context, stage, cacheKey, ownerPrincipalID string) (cachestore.Record, bool, error) {
+	ownerPrincipalID = strings.TrimSpace(ownerPrincipalID)
+	if ownerPrincipalID == "" {
+		return cachestore.Record{}, false, nil
+	}
+	return s.getReadyForOwner(stage, cacheKey, ownerPrincipalID)
+}
+
+func (s *memoryCacheStore) getReadyForOwner(stage, cacheKey, ownerPrincipalID string) (cachestore.Record, bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	record, ok := s.records[cacheStoreKey(stage, cacheKey)]
+	record, ok := s.records[cacheStoreOwnerKey(stage, cacheKey, ownerPrincipalID)]
 	if !ok || record.State != cacheStateReady {
 		return cachestore.Record{}, false, nil
 	}
@@ -2388,9 +2400,21 @@ func (s *memoryCacheStore) GetReady(_ context.Context, stage, cacheKey string) (
 }
 
 func (s *memoryCacheStore) Touch(_ context.Context, stage, cacheKey string) error {
+	return s.touchForOwner(stage, cacheKey, "")
+}
+
+func (s *memoryCacheStore) TouchForOwner(_ context.Context, stage, cacheKey, ownerPrincipalID string) error {
+	ownerPrincipalID = strings.TrimSpace(ownerPrincipalID)
+	if ownerPrincipalID == "" {
+		return errors.New("cache record missing owner")
+	}
+	return s.touchForOwner(stage, cacheKey, ownerPrincipalID)
+}
+
+func (s *memoryCacheStore) touchForOwner(stage, cacheKey, ownerPrincipalID string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	key := cacheStoreKey(stage, cacheKey)
+	key := cacheStoreOwnerKey(stage, cacheKey, ownerPrincipalID)
 	record, ok := s.records[key]
 	if !ok {
 		return errors.New("cache record not found")
@@ -2413,7 +2437,18 @@ func (s *memoryCacheStore) List(_ context.Context) ([]cachestore.Record, error) 
 func (s *memoryCacheStore) Delete(_ context.Context, stage, cacheKey string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	delete(s.records, cacheStoreKey(stage, cacheKey))
+	for key, record := range s.records {
+		if strings.TrimSpace(record.Stage) == strings.TrimSpace(stage) && strings.TrimSpace(record.CacheKey) == strings.TrimSpace(cacheKey) {
+			delete(s.records, key)
+		}
+	}
+	return nil
+}
+
+func (s *memoryCacheStore) DeleteForOwner(_ context.Context, stage, cacheKey, ownerPrincipalID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.records, cacheStoreOwnerKey(stage, cacheKey, ownerPrincipalID))
 	return nil
 }
 
@@ -2476,6 +2511,10 @@ func (s *memoryChangesetStore) Put(_ context.Context, repository *repositorychec
 
 func cacheStoreKey(stage, cacheKey string) string {
 	return strings.TrimSpace(stage) + "\x00" + strings.TrimSpace(cacheKey)
+}
+
+func cacheStoreOwnerKey(stage, cacheKey, ownerPrincipalID string) string {
+	return cacheStoreKey(stage, cacheKey) + "\x00" + strings.TrimSpace(ownerPrincipalID)
 }
 
 func cacheRecordBackingSnapshotID(record cachestore.Record) (string, bool) {

--- a/internal/controlservice/services_stage.go
+++ b/internal/controlservice/services_stage.go
@@ -94,7 +94,7 @@ func (s *Service) lookupServicesStageCache(ctx context.Context, backendName stri
 		return cachestore.Record{}, false, "", nil
 	}
 
-	record, ok, err := store.GetReady(ctx, servicesStageName, plan.CacheKey)
+	record, ok, err := lookupReadyCacheRecord(ctx, store, servicesStageName, plan.CacheKey)
 	if err != nil {
 		return cachestore.Record{}, false, "", err
 	}
@@ -184,6 +184,7 @@ func (s *Service) maybePublishServicesStageCache(
 		ProducerVersion:        servicesStageProducerVersion,
 	}
 	populateStageCacheRecordMetadata(&record, plan.RuntimeBaseKey, result, now)
+	stampCacheRecordOwner(ctx, &record)
 
 	persist := store.Create
 	if replacedRecord != nil && strings.TrimSpace(replacedRecord.CacheKey) == plan.CacheKey {

--- a/internal/controlservice/stage_cache_resolution.go
+++ b/internal/controlservice/stage_cache_resolution.go
@@ -286,7 +286,7 @@ func (s *Service) resolveServicesStageCache(ctx context.Context, req servicesSta
 	})
 	if restoreErr == nil {
 		if cacheStore, err := s.cacheStoreOrErr(); err == nil {
-			if err := cacheStore.Touch(ctx, record.Stage, record.CacheKey); err != nil {
+			if err := touchCacheRecord(ctx, cacheStore, record); err != nil {
 				s.logServicesStageWarning("touch services stage cache", "", err)
 			}
 		}
@@ -383,7 +383,7 @@ func (s *Service) restoreDependencyStageCache(ctx context.Context, req dependenc
 	})
 	if restoreErr == nil {
 		if cacheStore, err := s.cacheStoreOrErr(); err == nil {
-			if err := cacheStore.Touch(ctx, record.Stage, record.CacheKey); err != nil {
+			if err := touchCacheRecord(ctx, cacheStore, record); err != nil {
 				s.logDependencyStageWarning("touch dependency stage cache", "", err)
 			}
 		}
@@ -459,7 +459,7 @@ func (s *Service) resolvePortableDependencyStageCache(ctx context.Context, req d
 	}
 
 	if cacheStore, err := s.cacheStoreOrErr(); err == nil {
-		if err := cacheStore.Touch(ctx, record.Stage, record.CacheKey); err != nil {
+		if err := touchCacheRecord(ctx, cacheStore, record); err != nil {
 			s.logDependencyStageWarning("touch portable dependency stage cache", "", err)
 		}
 	}
@@ -523,7 +523,7 @@ func (s *Service) resolveWorkspaceStageCache(ctx context.Context, req workspaceS
 	})
 	if restoreErr == nil {
 		if cacheStore, err := s.cacheStoreOrErr(); err == nil {
-			if err := cacheStore.Touch(ctx, record.Stage, record.CacheKey); err != nil {
+			if err := touchCacheRecord(ctx, cacheStore, record); err != nil {
 				s.logWorkspaceStageWarning("touch workspace stage cache", "", err)
 			}
 		}

--- a/internal/controlservice/workspace_stage.go
+++ b/internal/controlservice/workspace_stage.go
@@ -84,7 +84,7 @@ func (s *Service) lookupWorkspaceStageCache(ctx context.Context, backendName str
 		return cachestore.Record{}, false, "", nil
 	}
 
-	record, ok, err := store.GetReady(ctx, workspaceStageName, cacheKey)
+	record, ok, err := lookupReadyCacheRecord(ctx, store, workspaceStageName, cacheKey)
 	if err != nil {
 		return cachestore.Record{}, false, "", err
 	}
@@ -176,6 +176,7 @@ func (s *Service) maybePublishWorkspaceStageCache(
 		ProducerVersion:        workspaceStageProducerVersion,
 	}
 	populateStageCacheRecordMetadata(&record, runtimeBaseKey, result, now)
+	stampCacheRecordOwner(ctx, &record)
 
 	persist := store.Create
 	if replacedRecord != nil && strings.TrimSpace(replacedRecord.CacheKey) == cacheKey {

--- a/internal/storagegc/storagegc.go
+++ b/internal/storagegc/storagegc.go
@@ -42,6 +42,10 @@ type CacheStore interface {
 	Delete(context.Context, string, string) error
 }
 
+type ownerCacheStore interface {
+	DeleteForOwner(context.Context, string, string, string) error
+}
+
 type ImageManager interface {
 	List(context.Context) ([]imagemgr.Record, error)
 	Remove(context.Context, string) ([]imagemgr.Record, error)
@@ -75,19 +79,21 @@ type InventoryOptions struct {
 }
 
 type Entry struct {
-	Kind        string    `json:"kind"`
-	ID          string    `json:"id,omitempty"`
-	Backend     string    `json:"backend,omitempty"`
-	Stage       string    `json:"stage,omitempty"`
-	CacheKey    string    `json:"cache_key,omitempty"`
-	Path        string    `json:"path,omitempty"`
-	StorageRef  string    `json:"storage_ref,omitempty"`
-	SizeBytes   int64     `json:"size_bytes"`
-	Reclaimable bool      `json:"reclaimable"`
-	Reason      string    `json:"reason,omitempty"`
-	ProtectedBy []string  `json:"protected_by,omitempty"`
-	CreatedAt   time.Time `json:"created_at,omitempty"`
-	LastUsedAt  time.Time `json:"last_used_at,omitempty"`
+	Kind             string    `json:"kind"`
+	ID               string    `json:"id,omitempty"`
+	Backend          string    `json:"backend,omitempty"`
+	Stage            string    `json:"stage,omitempty"`
+	CacheKey         string    `json:"cache_key,omitempty"`
+	OwnerPrincipalID string    `json:"owner_principal_id,omitempty"`
+	OwnerScope       string    `json:"owner_scope,omitempty"`
+	Path             string    `json:"path,omitempty"`
+	StorageRef       string    `json:"storage_ref,omitempty"`
+	SizeBytes        int64     `json:"size_bytes"`
+	Reclaimable      bool      `json:"reclaimable"`
+	Reason           string    `json:"reason,omitempty"`
+	ProtectedBy      []string  `json:"protected_by,omitempty"`
+	CreatedAt        time.Time `json:"created_at,omitempty"`
+	LastUsedAt       time.Time `json:"last_used_at,omitempty"`
 }
 
 type CategoryTotal struct {
@@ -526,7 +532,14 @@ func executeAction(ctx context.Context, report Report, action Action, roots []st
 		if cacheStore == nil {
 			return errors.New("cache metadata store is not configured")
 		}
-		if err := cacheStore.Delete(ctx, action.Entry.Stage, action.Entry.CacheKey); err != nil {
+		owner := strings.TrimSpace(action.Entry.OwnerPrincipalID)
+		if ownerStore, ok := cacheStore.(ownerCacheStore); ok {
+			if err := ownerStore.DeleteForOwner(ctx, action.Entry.Stage, action.Entry.CacheKey, owner); err != nil {
+				return fmt.Errorf("delete stage-cache metadata %q/%q for owner %q: %w", action.Entry.Stage, action.Entry.CacheKey, owner, err)
+			}
+		} else if owner != "" {
+			return fmt.Errorf("cache metadata store cannot delete owner-scoped stage-cache metadata %q/%q for owner %q", action.Entry.Stage, action.Entry.CacheKey, owner)
+		} else if err := cacheStore.Delete(ctx, action.Entry.Stage, action.Entry.CacheKey); err != nil {
 			return fmt.Errorf("delete stage-cache metadata %q/%q: %w", action.Entry.Stage, action.Entry.CacheKey, err)
 		}
 		return removeOwnedPath(stageCachePath, roots)
@@ -567,18 +580,20 @@ func entryFromCacheRecord(record cachestore.Record) Entry {
 		reason = "stage-cache metadata uses non-filesystem storage"
 	}
 	return Entry{
-		Kind:        KindStageCache,
-		ID:          record.Stage + "/" + record.CacheKey,
-		Backend:     record.Backend,
-		Stage:       record.Stage,
-		CacheKey:    record.CacheKey,
-		Path:        path,
-		StorageRef:  record.StorageRef,
-		Reclaimable: false,
-		Reason:      reason,
-		ProtectedBy: protectedBy,
-		CreatedAt:   record.CreatedAt,
-		LastUsedAt:  record.LastUsedAt,
+		Kind:             KindStageCache,
+		ID:               record.Stage + "/" + record.CacheKey,
+		Backend:          record.Backend,
+		Stage:            record.Stage,
+		CacheKey:         record.CacheKey,
+		OwnerPrincipalID: record.OwnerPrincipalID,
+		OwnerScope:       record.OwnerScope,
+		Path:             path,
+		StorageRef:       record.StorageRef,
+		Reclaimable:      false,
+		Reason:           reason,
+		ProtectedBy:      protectedBy,
+		CreatedAt:        record.CreatedAt,
+		LastUsedAt:       record.LastUsedAt,
 	}
 }
 

--- a/internal/storagegc/storagegc_test.go
+++ b/internal/storagegc/storagegc_test.go
@@ -43,6 +43,18 @@ func (s *stubCacheStore) Delete(_ context.Context, stage, cacheKey string) error
 	return nil
 }
 
+func (s *stubCacheStore) DeleteForOwner(_ context.Context, stage, cacheKey, ownerPrincipalID string) error {
+	if ownerPrincipalID == "" {
+		s.deleted = append(s.deleted, stage+"/"+cacheKey)
+	} else {
+		s.deleted = append(s.deleted, stage+"/"+cacheKey+"/"+ownerPrincipalID)
+	}
+	if s.deleteErr != nil {
+		return s.deleteErr
+	}
+	return nil
+}
+
 type stubImageManager struct {
 	records []imagemgr.Record
 	err     error


### PR DESCRIPTION
A shared auth-enabled server cannot let a warm stage cache record become a filesystem side channel between principals. This PR takes the bounded Slice 2B-1 step from the multi-principal plan: stage-cache records now carry owner metadata, authenticated lookups only see the exact principal's records, and ownerless legacy records stay local-only.

It also migrates the cache metadata primary key to include owner, applies the same boundary to block-volume stage caches, keeps cache-peer exports ownerless-only, and disables authenticated cache-peer imports until the peer request carries an owner envelope.