### PR TITLE
feat: Authorize gateway cache routes by owner

### DIFF
--- a/docs/plans/multi-principal-control-server.md
+++ b/docs/plans/multi-principal-control-server.md
@@ -1,7 +1,7 @@
 # Multi-Principal Control Server Authorization Plan
 
 **Spec reference:** `docs/spec.md` sections 5.4, 6.1, and 6.2; `docs/api.md`; `docs/tls.md`
-**Status:** Slice 2B-1 implemented; gateway and content-cache auth next
+**Status:** Slice 2B-2 implemented; runtime hardening and sharing follow-ups next
 **Last reviewed:** 2026-05-27
 
 ## Summary
@@ -46,6 +46,15 @@ Slice 2 is split into PR-sized enforcement work:
   records visible only to unauthenticated local callers, migrates the SQLite
   stage-cache primary key to include owner, and disables cache-peer imports for
   authenticated requests until the peer protocol carries owner metadata.
+- Slice 2B-2 now carries authenticated sandbox owner metadata and a small
+  gateway authorization envelope into gateway scopes for both Firecracker
+  source-IP registration and DarwinVZ scope-token registration. Under
+  `auth.required`, gateway Git, cached Git fallback, OCI registry, and Docker
+  Hub mirror routes deny ownerless scopes and deny requested repositories that
+  are outside the sandbox's envelope before embedded `content-cache` handlers
+  or host-side Git credentials can serve bytes. The first envelope is exact:
+  Git is limited to the sandbox checkout repository, and OCI is limited to the
+  sandbox image repository.
 
 Focused validation run on 2026-05-25:
 
@@ -77,6 +86,22 @@ Slice 2B-1 focused validation run on 2026-05-27:
 
 ```text
 mise exec -- go test ./internal/cachestore ./internal/controlservice ./internal/controlserver ./internal/storagegc
+```
+
+Result: passed.
+
+Slice 2B-2 focused validation run on 2026-05-27:
+
+```text
+mise exec -- go test ./internal/gatewayauth ./internal/gateway ./internal/controlservice ./internal/backend/firecracker ./internal/backend/darwinvz ./internal/cli
+```
+
+Result: passed.
+
+Slice 2B-2 repository validation run on 2026-05-27:
+
+```text
+mise run check
 ```
 
 Result: passed.
@@ -663,6 +688,13 @@ Progress:
   under auth, block-volume stage-cache records follow the same owner rules, and
   storage GC deletes owner-scoped metadata without removing another owner's row
   for the same logical cache key.
+- 2B-2 completed the embedded gateway owner envelope: controlservice derives
+  gateway scope metadata from the authenticated sandbox owner, repository
+  checkout, and compiled image; backend provision and execution requests carry
+  that metadata into Firecracker and DarwinVZ gateway registrations; and Git,
+  cached Git fallback, OCI registry, and Docker Hub mirror handlers deny
+  ownerless or out-of-envelope requests before embedded `content-cache` or
+  host-side Git credential paths can serve cached or upstream content.
 - Cache-peer imports are disabled for authenticated contexts in this slice
   because `LookupCachePeerRequest` does not yet include an owner envelope.
 

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/buildkite/cleanroom/internal/gatewayauth"
 	"github.com/buildkite/cleanroom/internal/policy"
 )
 
@@ -263,6 +264,7 @@ type SandboxPortDialer interface {
 type ProvisionRequest struct {
 	SandboxID          string
 	Policy             *policy.CompiledPolicy
+	GatewayScope       gatewayauth.ScopeMetadata
 	CacheOutputVolumes []CacheOutputVolumeSpec
 	Progress           ProvisionProgressFunc
 	FirecrackerConfig
@@ -286,6 +288,7 @@ type ProvisionFromSnapshotRequest struct {
 	SnapshotID         string
 	StorageRef         string
 	Policy             *policy.CompiledPolicy
+	GatewayScope       gatewayauth.ScopeMetadata
 	CacheOutputVolumes []CacheOutputVolumeSpec
 	FirecrackerConfig
 }
@@ -379,6 +382,7 @@ type ExecutionRequest struct {
 	CacheOutputFileCaptures []CacheOutputFileCapture
 	OverlayCapture          *OverlayCapture
 	Policy                  *policy.CompiledPolicy
+	GatewayScope            gatewayauth.ScopeMetadata
 	NetworkStage            policy.NetworkStage
 	SkipDockerServiceStart  bool
 	FirecrackerConfig

--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -1416,7 +1416,7 @@ func (a *Adapter) run(ctx context.Context, req backend.ExecutionRequest, stream 
 		if scopeSandboxID == "" {
 			scopeSandboxID = vmID
 		}
-		if err := a.GatewayRegistry.RegisterScopeToken(token, scopeSandboxID, networkPolicy); err != nil {
+		if err := a.GatewayRegistry.RegisterScopeToken(token, scopeSandboxID, networkPolicy, req.GatewayScope); err != nil {
 			return nil, fmt.Errorf("register sandbox in gateway: %w", err)
 		}
 		a.GatewayRegistry.SetActiveExecutionTrace(scopeSandboxID, req.ExecutionID, trace.SpanContextFromContext(ctx))
@@ -1938,7 +1938,7 @@ func (a *Adapter) executeInSandbox(bootCtx context.Context, runCtx context.Conte
 		if tokenErr != nil {
 			return nil, fmt.Errorf("generate gateway scope token: %w", tokenErr)
 		}
-		if err := a.GatewayRegistry.RegisterScopeToken(token, scopeSandboxID, networkPolicy); err != nil {
+		if err := a.GatewayRegistry.RegisterScopeToken(token, scopeSandboxID, networkPolicy, req.GatewayScope); err != nil {
 			return nil, fmt.Errorf("register sandbox in gateway: %w", err)
 		}
 		a.GatewayRegistry.SetActiveExecutionTrace(scopeSandboxID, req.ExecutionID, trace.SpanContextFromContext(runCtx))

--- a/internal/backend/darwinvz/gateway_env.go
+++ b/internal/backend/darwinvz/gateway_env.go
@@ -2,6 +2,7 @@ package darwinvz
 
 import (
 	"github.com/buildkite/cleanroom/internal/gateway"
+	"github.com/buildkite/cleanroom/internal/gatewayauth"
 	"github.com/buildkite/cleanroom/internal/policy"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -9,7 +10,7 @@ import (
 // gatewayRegistry is the subset of gateway.Registry used by the darwin
 // adapter.
 type gatewayRegistry interface {
-	RegisterScopeToken(scopeToken, sandboxID string, p *policy.CompiledPolicy) error
+	RegisterScopeToken(scopeToken, sandboxID string, p *policy.CompiledPolicy, metadata ...gatewayauth.ScopeMetadata) error
 	ReleaseScopeToken(scopeToken string)
 	SetActiveExecutionTrace(sandboxID, executionID string, spanContext trace.SpanContext)
 	ClearActiveExecutionTrace(sandboxID, executionID string)

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -29,6 +29,7 @@ import (
 	"github.com/buildkite/cleanroom/internal/bootassets"
 	"github.com/buildkite/cleanroom/internal/ext4edit"
 	"github.com/buildkite/cleanroom/internal/gateway"
+	"github.com/buildkite/cleanroom/internal/gatewayauth"
 	"github.com/buildkite/cleanroom/internal/hosttools"
 	"github.com/buildkite/cleanroom/internal/imagemgr"
 	"github.com/buildkite/cleanroom/internal/observability"
@@ -65,8 +66,8 @@ type Adapter struct {
 	sandboxMu                   sync.Mutex
 	sandboxes                   map[string]*sandboxInstance
 	provisioning                map[string]struct{}
-	launchSandboxVMFn           func(context.Context, string, *policy.CompiledPolicy, backend.FirecrackerConfig, []backend.CacheOutputVolumeSpec) (*sandboxInstance, error)
-	launchSandboxVMFromRootFSFn func(context.Context, string, *policy.CompiledPolicy, backend.FirecrackerConfig, string, []backend.CacheOutputVolumeSpec) (*sandboxInstance, error)
+	launchSandboxVMFn           func(context.Context, string, *policy.CompiledPolicy, gatewayauth.ScopeMetadata, backend.FirecrackerConfig, []backend.CacheOutputVolumeSpec) (*sandboxInstance, error)
+	launchSandboxVMFromRootFSFn func(context.Context, string, *policy.CompiledPolicy, gatewayauth.ScopeMetadata, backend.FirecrackerConfig, string, []backend.CacheOutputVolumeSpec) (*sandboxInstance, error)
 	runGuestCommandFn           func(context.Context, context.Context, <-chan struct{}, func() error, string, uint32, vsockexec.ExecRequest, backend.OutputStream) (vsockexec.ExecResponse, guestExecTiming, error)
 
 	GatewayRegistry gatewayRegistry
@@ -81,7 +82,7 @@ type Adapter struct {
 
 // gatewayRegistry is the subset of gateway.Registry used by the adapter.
 type gatewayRegistry interface {
-	Register(guestIP, sandboxID string, p *policy.CompiledPolicy) error
+	Register(guestIP, sandboxID string, p *policy.CompiledPolicy, metadata ...gatewayauth.ScopeMetadata) error
 	Release(guestIP string)
 	SetActiveExecutionTrace(sandboxID, executionID string, spanContext trace.SpanContext)
 	ClearActiveExecutionTrace(sandboxID, executionID string)
@@ -347,7 +348,7 @@ func (a *Adapter) ProvisionSandbox(ctx context.Context, req backend.ProvisionReq
 		launch = a.launchSandboxVM
 	}
 
-	instance, err := launch(ctx, sandboxID, req.Policy, req.FirecrackerConfig, req.CacheOutputVolumes)
+	instance, err := launch(ctx, sandboxID, req.Policy, req.GatewayScope, req.FirecrackerConfig, req.CacheOutputVolumes)
 	if err != nil {
 		a.sandboxMu.Lock()
 		delete(a.provisioning, sandboxID)
@@ -741,7 +742,7 @@ func (a *Adapter) ProvisionSandboxFromSnapshot(ctx context.Context, req backend.
 	if launch == nil {
 		launch = a.launchSandboxVMFromRootFS
 	}
-	instance, err := launch(ctx, sandboxID, req.Policy, req.FirecrackerConfig, storageRef, req.CacheOutputVolumes)
+	instance, err := launch(ctx, sandboxID, req.Policy, req.GatewayScope, req.FirecrackerConfig, storageRef, req.CacheOutputVolumes)
 	if err != nil {
 		a.sandboxMu.Lock()
 		delete(a.provisioning, sandboxID)
@@ -1695,7 +1696,7 @@ func (a *Adapter) getImageManager() (imageEnsurer, error) {
 	return a.imageManager, nil
 }
 
-func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compiled *policy.CompiledPolicy, cfg backend.FirecrackerConfig, cacheOutputVolumeSpecs []backend.CacheOutputVolumeSpec) (*sandboxInstance, error) {
+func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compiled *policy.CompiledPolicy, gatewayScope gatewayauth.ScopeMetadata, cfg backend.FirecrackerConfig, cacheOutputVolumeSpecs []backend.CacheOutputVolumeSpec) (*sandboxInstance, error) {
 	if compiled == nil {
 		return nil, errors.New("missing compiled policy")
 	}
@@ -1707,7 +1708,7 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 	if err != nil {
 		return nil, err
 	}
-	instance, err := a.launchSandboxVMFromRootFS(ctx, sandboxID, compiled, cfg, preparedRootFSPath, cacheOutputVolumeSpecs)
+	instance, err := a.launchSandboxVMFromRootFS(ctx, sandboxID, compiled, gatewayScope, cfg, preparedRootFSPath, cacheOutputVolumeSpecs)
 	if err != nil {
 		return nil, err
 	}
@@ -1716,7 +1717,7 @@ func (a *Adapter) launchSandboxVM(ctx context.Context, sandboxID string, compile
 	return instance, nil
 }
 
-func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID string, compiled *policy.CompiledPolicy, cfg backend.FirecrackerConfig, sourceRootFSPath string, cacheOutputVolumeSpecs []backend.CacheOutputVolumeSpec) (*sandboxInstance, error) {
+func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID string, compiled *policy.CompiledPolicy, gatewayScope gatewayauth.ScopeMetadata, cfg backend.FirecrackerConfig, sourceRootFSPath string, cacheOutputVolumeSpecs []backend.CacheOutputVolumeSpec) (*sandboxInstance, error) {
 	if compiled == nil {
 		return nil, errors.New("missing compiled policy")
 	}
@@ -1849,7 +1850,7 @@ func (a *Adapter) launchSandboxVMFromRootFS(ctx context.Context, sandboxID strin
 	}
 
 	if a.GatewayRegistry != nil {
-		if err := a.GatewayRegistry.Register(networkCfg.GuestIP, sandboxID, compiled); err != nil {
+		if err := a.GatewayRegistry.Register(networkCfg.GuestIP, sandboxID, compiled, gatewayScope); err != nil {
 			cleanupNetwork()
 			cleanupStorage()
 			return nil, fmt.Errorf("register sandbox in gateway: %w", err)

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -85,6 +85,7 @@ type gatewayRegistry interface {
 	Register(guestIP, sandboxID string, p *policy.CompiledPolicy, metadata ...gatewayauth.ScopeMetadata) error
 	Release(guestIP string)
 	SetActiveExecutionTrace(sandboxID, executionID string, spanContext trace.SpanContext)
+	SetActiveExecutionScope(sandboxID, executionID string, spanContext trace.SpanContext, metadata gatewayauth.ScopeMetadata)
 	ClearActiveExecutionTrace(sandboxID, executionID string)
 }
 
@@ -453,7 +454,7 @@ func (a *Adapter) RunInSandbox(ctx context.Context, req backend.ExecutionRequest
 		defer instance.warnings.SetHandler(nil)
 	}
 	if a.GatewayRegistry != nil {
-		a.GatewayRegistry.SetActiveExecutionTrace(sandboxID, req.ExecutionID, trace.SpanContextFromContext(ctx))
+		a.GatewayRegistry.SetActiveExecutionScope(sandboxID, req.ExecutionID, trace.SpanContextFromContext(ctx), req.GatewayScope)
 		defer a.GatewayRegistry.ClearActiveExecutionTrace(sandboxID, req.ExecutionID)
 	}
 

--- a/internal/backend/firecracker/persistent_test.go
+++ b/internal/backend/firecracker/persistent_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/gatewayauth"
 	"github.com/buildkite/cleanroom/internal/policy"
 	"github.com/buildkite/cleanroom/internal/vsockexec"
 	"go.opentelemetry.io/otel/trace"
@@ -26,7 +27,7 @@ func TestProvisionSandboxRejectsConcurrentProvisionForSameID(t *testing.T) {
 	block := make(chan struct{})
 	started := make(chan struct{})
 	adapter := &Adapter{
-		launchSandboxVMFn: func(_ context.Context, sandboxID string, _ *policy.CompiledPolicy, _ backend.FirecrackerConfig, _ []backend.CacheOutputVolumeSpec) (*sandboxInstance, error) {
+		launchSandboxVMFn: func(_ context.Context, sandboxID string, _ *policy.CompiledPolicy, _ gatewayauth.ScopeMetadata, _ backend.FirecrackerConfig, _ []backend.CacheOutputVolumeSpec) (*sandboxInstance, error) {
 			if sandboxID != "cr-test" {
 				t.Fatalf("unexpected sandbox id %q", sandboxID)
 			}
@@ -63,7 +64,7 @@ func TestProvisionSandboxRejectsStageScopedNetworkPolicy(t *testing.T) {
 	t.Parallel()
 
 	adapter := &Adapter{
-		launchSandboxVMFn: func(context.Context, string, *policy.CompiledPolicy, backend.FirecrackerConfig, []backend.CacheOutputVolumeSpec) (*sandboxInstance, error) {
+		launchSandboxVMFn: func(context.Context, string, *policy.CompiledPolicy, gatewayauth.ScopeMetadata, backend.FirecrackerConfig, []backend.CacheOutputVolumeSpec) (*sandboxInstance, error) {
 			t.Fatal("launchSandboxVMFn should not be called")
 			return nil, nil
 		},
@@ -87,7 +88,7 @@ func TestProvisionSandboxForwardsCacheOutputVolumes(t *testing.T) {
 	specs := testCacheOutputVolumeSpecs()
 	var gotSpecs []backend.CacheOutputVolumeSpec
 	adapter := &Adapter{
-		launchSandboxVMFn: func(_ context.Context, sandboxID string, _ *policy.CompiledPolicy, _ backend.FirecrackerConfig, cacheOutputVolumes []backend.CacheOutputVolumeSpec) (*sandboxInstance, error) {
+		launchSandboxVMFn: func(_ context.Context, sandboxID string, _ *policy.CompiledPolicy, _ gatewayauth.ScopeMetadata, _ backend.FirecrackerConfig, cacheOutputVolumes []backend.CacheOutputVolumeSpec) (*sandboxInstance, error) {
 			if sandboxID != "cr-test" {
 				t.Fatalf("unexpected sandbox id %q", sandboxID)
 			}
@@ -625,8 +626,10 @@ func TestRunInSandboxClosedEnvSkipsGatewayEnv(t *testing.T) {
 
 type testGatewayRegistry struct{}
 
-func (testGatewayRegistry) Register(string, string, *policy.CompiledPolicy) error { return nil }
-func (testGatewayRegistry) Release(string)                                        {}
+func (testGatewayRegistry) Register(string, string, *policy.CompiledPolicy, ...gatewayauth.ScopeMetadata) error {
+	return nil
+}
+func (testGatewayRegistry) Release(string) {}
 func (testGatewayRegistry) SetActiveExecutionTrace(string, string, trace.SpanContext) {
 }
 func (testGatewayRegistry) ClearActiveExecutionTrace(string, string) {}

--- a/internal/backend/firecracker/persistent_test.go
+++ b/internal/backend/firecracker/persistent_test.go
@@ -632,7 +632,64 @@ func (testGatewayRegistry) Register(string, string, *policy.CompiledPolicy, ...g
 func (testGatewayRegistry) Release(string) {}
 func (testGatewayRegistry) SetActiveExecutionTrace(string, string, trace.SpanContext) {
 }
+func (testGatewayRegistry) SetActiveExecutionScope(string, string, trace.SpanContext, gatewayauth.ScopeMetadata) {
+}
 func (testGatewayRegistry) ClearActiveExecutionTrace(string, string) {}
+
+type capturingGatewayRegistry struct {
+	testGatewayRegistry
+	scope gatewayauth.ScopeMetadata
+}
+
+func (r *capturingGatewayRegistry) SetActiveExecutionScope(_ string, _ string, _ trace.SpanContext, metadata gatewayauth.ScopeMetadata) {
+	r.scope = metadata.Clone()
+}
+
+func TestRunInSandboxUpdatesGatewayScope(t *testing.T) {
+	t.Parallel()
+
+	registry := &capturingGatewayRegistry{}
+	adapter := &Adapter{
+		GatewayRegistry: registry,
+		GatewayPort:     8170,
+	}
+	adapter.runGuestCommandFn = func(_ context.Context, _ context.Context, _ <-chan struct{}, _ func() error, _ string, _ uint32, _ vsockexec.ExecRequest, _ backend.OutputStream) (vsockexec.ExecResponse, guestExecTiming, error) {
+		return vsockexec.ExecResponse{ExitCode: 0}, guestExecTiming{}, nil
+	}
+	adapter.sandboxes = map[string]*sandboxInstance{
+		"cr-test": {
+			SandboxID: "cr-test",
+			VsockPath: "/tmp/fake.sock",
+			GuestPort: 10700,
+			HostIP:    "192.168.127.1",
+			Policy: &policy.CompiledPolicy{
+				Version:        1,
+				NetworkDefault: "deny",
+				Allow:          []policy.AllowRule{{Host: "github.com", Ports: []int{443}}},
+			},
+		},
+	}
+
+	if _, err := adapter.RunInSandbox(context.Background(), backend.ExecutionRequest{
+		SandboxID:   "cr-test",
+		ExecutionID: "run-gateway-scope",
+		Command:     []string{"true"},
+		GatewayScope: gatewayauth.ScopeMetadata{
+			Owner: gatewayauth.Owner{PrincipalID: "oidc:test:alice"},
+			Authorization: gatewayauth.Authorization{
+				GitRepoPrefixes: []string{"github.com/buildkite/cleanroom"},
+			},
+		},
+	}, backend.OutputStream{}); err != nil {
+		t.Fatalf("RunInSandbox returned error: %v", err)
+	}
+	if got, want := registry.scope.Owner.PrincipalID, "oidc:test:alice"; got != want {
+		t.Fatalf("gateway scope owner mismatch: got %q want %q", got, want)
+	}
+	if got, want := registry.scope.Authorization.GitRepoPrefixes, []string{"github.com/buildkite/cleanroom"}; !slices.Equal(got, want) {
+		t.Fatalf("gateway scope git prefixes mismatch: got %v want %v", got, want)
+	}
+}
 
 func TestRunInSandboxWritesRunObservabilityForStatusCommand(t *testing.T) {
 	t.Parallel()

--- a/internal/backend/firecracker/snapshot_test.go
+++ b/internal/backend/firecracker/snapshot_test.go
@@ -15,6 +15,7 @@ import (
 
 	"charm.land/log/v2"
 	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/gatewayauth"
 	"github.com/buildkite/cleanroom/internal/policy"
 	"github.com/buildkite/cleanroom/internal/volumestore"
 	"github.com/buildkite/cleanroom/internal/vsockexec"
@@ -686,7 +687,7 @@ func TestProvisionSandboxFromSnapshotUsesSnapshotRootFS(t *testing.T) {
 	)
 	specs := testCacheOutputVolumeSpecs()
 	adapter := &Adapter{
-		launchSandboxVMFromRootFSFn: func(_ context.Context, sandboxID string, compiled *policy.CompiledPolicy, _ backend.FirecrackerConfig, sourceRootFSPath string, cacheOutputVolumes []backend.CacheOutputVolumeSpec) (*sandboxInstance, error) {
+		launchSandboxVMFromRootFSFn: func(_ context.Context, sandboxID string, compiled *policy.CompiledPolicy, _ gatewayauth.ScopeMetadata, _ backend.FirecrackerConfig, sourceRootFSPath string, cacheOutputVolumes []backend.CacheOutputVolumeSpec) (*sandboxInstance, error) {
 			gotSandbox = sandboxID
 			gotPolicy = compiled
 			gotRootFS = sourceRootFSPath

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -159,6 +159,7 @@ func (s *ServeCommand) runServer(ctx *runtimeContext) error {
 		ctx.Observability.MeterProvider(),
 		logger.With("subsystem", "gateway"),
 		darwinGatewayHost,
+		ctx.Config.Auth.Required,
 	))
 	if err := gwServer.Start(); err != nil {
 		return fmt.Errorf("start gateway: %w", err)
@@ -301,7 +302,7 @@ func isLoopbackListenHost(host string) bool {
 	return ip != nil && ip.IsLoopback()
 }
 
-func gatewayServerConfig(listen string, registry *gateway.Registry, credentials gateway.CredentialProvider, mirrors gateway.GitMirrorStore, contentCache *gateway.ContentCache, tracerProvider trace.TracerProvider, meterProvider metric.MeterProvider, logger *log.Logger, darwinGatewayHost string) gateway.ServerConfig {
+func gatewayServerConfig(listen string, registry *gateway.Registry, credentials gateway.CredentialProvider, mirrors gateway.GitMirrorStore, contentCache *gateway.ContentCache, tracerProvider trace.TracerProvider, meterProvider metric.MeterProvider, logger *log.Logger, darwinGatewayHost string, requireOwner bool) gateway.ServerConfig {
 	sourcePolicy := gatewayScopeTokenSourcePolicyForGatewayHost(strings.TrimSpace(darwinGatewayHost))
 	return gateway.ServerConfig{
 		ListenAddr:                      listen,
@@ -312,6 +313,7 @@ func gatewayServerConfig(listen string, registry *gateway.Registry, credentials 
 		Logger:                          logger,
 		TracerProvider:                  tracerProvider,
 		MeterProvider:                   meterProvider,
+		RequireOwner:                    requireOwner,
 		ScopeTokenTrustedSourcePrefixes: sourcePolicy.TrustedSourcePrefixes,
 		AllowScopeTokenFromAnySource:    sourcePolicy.AllowScopeTokenFromAnySource,
 	}

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -159,7 +159,7 @@ func (s *ServeCommand) runServer(ctx *runtimeContext) error {
 		ctx.Observability.MeterProvider(),
 		logger.With("subsystem", "gateway"),
 		darwinGatewayHost,
-		ctx.Config.Auth.Required,
+		gatewayRequiresAuthenticatedOwner(ctx, ep),
 	))
 	if err := gwServer.Start(); err != nil {
 		return fmt.Errorf("start gateway: %w", err)
@@ -317,6 +317,10 @@ func gatewayServerConfig(listen string, registry *gateway.Registry, credentials 
 		ScopeTokenTrustedSourcePrefixes: sourcePolicy.TrustedSourcePrefixes,
 		AllowScopeTokenFromAnySource:    sourcePolicy.AllowScopeTokenFromAnySource,
 	}
+}
+
+func gatewayRequiresAuthenticatedOwner(ctx *runtimeContext, ep endpoint.Endpoint) bool {
+	return ctx != nil && ctx.Config.Auth.Required && ep.Scheme != "unix"
 }
 
 func (s *ServeCommand) githubAppCredentialsConfig(base runtimeconfig.GatewayGitHubAppCredentialsConfig, cwd string) (runtimeconfig.GatewayGitHubAppCredentialsConfig, error) {

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -269,10 +269,14 @@ func TestGatewayServerConfigUsesDarwinGatewayHostForTrustedPrefixes(t *testing.T
 		nil,
 		log.New(io.Discard),
 		"  gateway.local  ",
+		true,
 	)
 
 	if !reflect.DeepEqual(cfg.ScopeTokenTrustedSourcePrefixes, want) {
 		t.Fatalf("unexpected trusted source prefixes: got %v want %v", cfg.ScopeTokenTrustedSourcePrefixes, want)
+	}
+	if !cfg.RequireOwner {
+		t.Fatal("expected gateway owner requirement to propagate")
 	}
 	if !cfg.AllowScopeTokenFromAnySource {
 		t.Fatal("expected allow-any-source fallback to be preserved in server config")

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/buildkite/cleanroom/internal/backend/firecracker"
 	"github.com/buildkite/cleanroom/internal/cachestore"
 	"github.com/buildkite/cleanroom/internal/changesetstore"
+	"github.com/buildkite/cleanroom/internal/endpoint"
 	"github.com/buildkite/cleanroom/internal/gateway"
 	"github.com/buildkite/cleanroom/internal/observability"
 	"github.com/buildkite/cleanroom/internal/runtimeconfig"
@@ -280,6 +281,24 @@ func TestGatewayServerConfigUsesDarwinGatewayHostForTrustedPrefixes(t *testing.T
 	}
 	if !cfg.AllowScopeTokenFromAnySource {
 		t.Fatal("expected allow-any-source fallback to be preserved in server config")
+	}
+}
+
+func TestGatewayRequiresAuthenticatedOwnerMatchesControlServerAuth(t *testing.T) {
+	t.Parallel()
+
+	ctx := &runtimeContext{Config: runtimeconfig.Config{
+		Auth: runtimeconfig.AuthConfig{Required: true},
+	}}
+
+	if gatewayRequiresAuthenticatedOwner(ctx, endpoint.Endpoint{Scheme: "unix"}) {
+		t.Fatal("expected trusted unix socket control server to keep ownerless gateway scopes allowed")
+	}
+	if !gatewayRequiresAuthenticatedOwner(ctx, endpoint.Endpoint{Scheme: "tcp"}) {
+		t.Fatal("expected authenticated tcp control server to require gateway owners")
+	}
+	if gatewayRequiresAuthenticatedOwner(&runtimeContext{}, endpoint.Endpoint{Scheme: "tcp"}) {
+		t.Fatal("expected gateway owner requirement to stay off when auth is not required")
 	}
 }
 

--- a/internal/controlservice/authz_test.go
+++ b/internal/controlservice/authz_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 
@@ -72,6 +73,50 @@ func TestAuthzEnforcesExactSandboxAndExecutionOwnership(t *testing.T) {
 	}
 }
 
+func TestAuthzPropagatesGatewayScopeToBackendRequests(t *testing.T) {
+	adapter := &stubAdapter{}
+	svc := &Service{
+		Config: runtimeconfig.Config{DefaultBackend: "firecracker"},
+		Backends: map[string]backend.Adapter{
+			"firecracker": adapter,
+		},
+	}
+	ctx := testAuthContext(t, "alice")
+
+	createResp, err := svc.CreateSandbox(ctx, &cleanroomv1.CreateSandboxRequest{
+		Backend:            "firecracker",
+		Policy:             testRepositoryPolicy(),
+		RepositoryCheckout: testRepositoryCheckoutProto(),
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	if got, want := adapter.provisionReq.GatewayScope.Owner.PrincipalID, "oidc:test:alice"; got != want {
+		t.Fatalf("provision owner mismatch: got %q want %q", got, want)
+	}
+	if got, want := adapter.provisionReq.GatewayScope.Authorization.GitRepoPrefixes, []string{"github.com/buildkite/cleanroom"}; !slices.Equal(got, want) {
+		t.Fatalf("provision git auth mismatch: got %v want %v", got, want)
+	}
+	if got, want := adapter.provisionReq.GatewayScope.Authorization.OCIRepoPrefixes, []string{"ghcr.io/buildkite/cleanroom-base/alpine"}; !slices.Equal(got, want) {
+		t.Fatalf("provision OCI auth mismatch: got %v want %v", got, want)
+	}
+
+	execResp, err := svc.CreateExecution(ctx, &cleanroomv1.CreateExecutionRequest{
+		SandboxId: createResp.GetSandbox().GetSandboxId(),
+		Command:   []string{"true"},
+	})
+	if err != nil {
+		t.Fatalf("CreateExecution returned error: %v", err)
+	}
+	waitExecutionDone(t, svc, createResp.GetSandbox().GetSandboxId(), execResp.GetExecution().GetExecutionId())
+	if got, want := adapter.req.GatewayScope.Owner.PrincipalID, "oidc:test:alice"; got != want {
+		t.Fatalf("execution owner mismatch: got %q want %q", got, want)
+	}
+	if got, want := adapter.req.GatewayScope.Authorization.GitRepoPrefixes, []string{"github.com/buildkite/cleanroom"}; !slices.Equal(got, want) {
+		t.Fatalf("execution git auth mismatch: got %v want %v", got, want)
+	}
+}
+
 func TestAuthzStampsAndEnforcesSnapshotOwnership(t *testing.T) {
 	store := newMemorySnapshotStore()
 	svc := &Service{
@@ -128,6 +173,43 @@ func TestAuthzStampsAndEnforcesSnapshotOwnership(t *testing.T) {
 		Source: &cleanroomv1.CreateSandboxRequest_SnapshotId{SnapshotId: snapshotID},
 	}); !errors.Is(err, ErrAuthorizationDenied) {
 		t.Fatalf("restore as different principal error = %v, want authorization denied", err)
+	}
+}
+
+func TestAuthzPropagatesGatewayScopeToSnapshotProvision(t *testing.T) {
+	store := newMemorySnapshotStore()
+	record := snapshotstoreRecord("snap-owner")
+	record.Repository = testRepositoryCheckoutProto()
+	record.OwnerPrincipalID = "oidc:test:alice"
+	record.OwnerScope = "scope:alice"
+	if err := store.Create(context.Background(), record); err != nil {
+		t.Fatalf("Create snapshot record returned error: %v", err)
+	}
+	adapter := &stubAdapter{}
+	svc := &Service{
+		Config: runtimeconfig.Config{
+			DefaultBackend: "firecracker",
+			Backends: runtimeconfig.Backends{Firecracker: runtimeconfig.FirecrackerConfig{
+				Snapshots: runtimeconfig.SnapshotConfig{Enabled: true, Driver: "file"},
+			}},
+		},
+		Backends: map[string]backend.Adapter{
+			"firecracker": adapter,
+		},
+		SnapshotStore: store,
+	}
+
+	if _, err := svc.CreateSandbox(testAuthContext(t, "alice"), &cleanroomv1.CreateSandboxRequest{
+		Source: &cleanroomv1.CreateSandboxRequest_SnapshotId{SnapshotId: record.SnapshotID},
+	}); err != nil {
+		t.Fatalf("CreateSandbox from snapshot returned error: %v", err)
+	}
+
+	if got, want := adapter.provisionFromSnapshotReq.GatewayScope.Owner.PrincipalID, "oidc:test:alice"; got != want {
+		t.Fatalf("snapshot provision owner mismatch: got %q want %q", got, want)
+	}
+	if got, want := adapter.provisionFromSnapshotReq.GatewayScope.Authorization.GitRepoPrefixes, []string{"github.com/buildkite/cleanroom"}; !slices.Equal(got, want) {
+		t.Fatalf("snapshot provision git auth mismatch: got %v want %v", got, want)
 	}
 }
 

--- a/internal/controlservice/authz_test.go
+++ b/internal/controlservice/authz_test.go
@@ -117,6 +117,58 @@ func TestAuthzPropagatesGatewayScopeToBackendRequests(t *testing.T) {
 	}
 }
 
+func TestAuthzPropagatesRequestedRepositoryToBootstrapGatewayScope(t *testing.T) {
+	var requests []backend.ExecutionRequest
+	adapter := &stubAdapter{
+		runStreamFn: func(_ context.Context, req backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
+			requests = append(requests, req)
+			return &backend.ExecutionResult{
+				ExecutionID: req.ExecutionID,
+				ExitCode:    0,
+				LaunchedVM:  true,
+				PlanPath:    "/tmp/plan",
+				RunDir:      "/tmp/run",
+				Message:     "ok",
+			}, nil
+		},
+	}
+	svc := &Service{
+		Config: runtimeconfig.Config{DefaultBackend: "firecracker"},
+		Backends: map[string]backend.Adapter{
+			"firecracker": adapter,
+		},
+	}
+	ctx := testAuthContext(t, "alice")
+
+	createResp, err := svc.CreateSandbox(ctx, &cleanroomv1.CreateSandboxRequest{
+		Backend: "firecracker",
+		Policy:  testRepositoryPolicy(),
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	execResp, err := svc.CreateExecution(ctx, &cleanroomv1.CreateExecutionRequest{
+		SandboxId:          createResp.GetSandbox().GetSandboxId(),
+		Command:            []string{"true"},
+		RepositoryCheckout: testRepositoryCheckoutProto(),
+	})
+	if err != nil {
+		t.Fatalf("CreateExecution returned error: %v", err)
+	}
+	waitExecutionDone(t, svc, createResp.GetSandbox().GetSandboxId(), execResp.GetExecution().GetExecutionId())
+
+	if got := len(requests); got < 2 {
+		t.Fatalf("expected bootstrap and execution requests, got %d", got)
+	}
+	bootstrapReq := requests[0]
+	if got, want := bootstrapReq.GatewayScope.Owner.PrincipalID, "oidc:test:alice"; got != want {
+		t.Fatalf("bootstrap owner mismatch: got %q want %q", got, want)
+	}
+	if got, want := bootstrapReq.GatewayScope.Authorization.GitRepoPrefixes, []string{"github.com/buildkite/cleanroom"}; !slices.Equal(got, want) {
+		t.Fatalf("bootstrap git auth mismatch: got %v want %v", got, want)
+	}
+}
+
 func TestAuthzStampsAndEnforcesSnapshotOwnership(t *testing.T) {
 	store := newMemorySnapshotStore()
 	svc := &Service{

--- a/internal/controlservice/bootstrap_runner.go
+++ b/internal/controlservice/bootstrap_runner.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/gatewayauth"
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
 	"github.com/buildkite/cleanroom/internal/policy"
 )
@@ -32,6 +33,7 @@ type persistentSandboxCommandOptions struct {
 	InputProjection         *backend.InputProjection
 	CacheOutputFileCaptures []backend.CacheOutputFileCapture
 	OverlayCapture          *backend.OverlayCapture
+	GatewayScope            gatewayauth.ScopeMetadata
 }
 
 func (s *Service) runPersistentSandboxCommandWithOptions(
@@ -47,6 +49,10 @@ func (s *Service) runPersistentSandboxCommandWithOptions(
 	opts persistentSandboxCommandOptions,
 	stream backend.OutputStream,
 ) (*backend.ExecutionResult, error) {
+	gatewayScope := opts.GatewayScope
+	if !gatewayScope.HasOwner() {
+		gatewayScope = s.gatewayScopeForSandbox(sandboxID)
+	}
 	return adapter.RunInSandbox(ctx, backend.ExecutionRequest{
 		SandboxID:               sandboxID,
 		ExecutionID:             executionID,
@@ -58,7 +64,7 @@ func (s *Service) runPersistentSandboxCommandWithOptions(
 		CacheOutputFileCaptures: cloneCacheOutputFileCaptures(opts.CacheOutputFileCaptures),
 		OverlayCapture:          cloneOverlayCapture(opts.OverlayCapture),
 		Policy:                  compiled,
-		GatewayScope:            s.gatewayScopeForSandbox(sandboxID),
+		GatewayScope:            gatewayScope,
 		NetworkStage:            networkStage,
 		FirecrackerConfig:       withRunDir(firecrackerCfg, internalBootstrapArtifactsDir(sandboxID, executionID)),
 	}, stream)

--- a/internal/controlservice/bootstrap_runner.go
+++ b/internal/controlservice/bootstrap_runner.go
@@ -58,6 +58,7 @@ func (s *Service) runPersistentSandboxCommandWithOptions(
 		CacheOutputFileCaptures: cloneCacheOutputFileCaptures(opts.CacheOutputFileCaptures),
 		OverlayCapture:          cloneOverlayCapture(opts.OverlayCapture),
 		Policy:                  compiled,
+		GatewayScope:            s.gatewayScopeForSandbox(sandboxID),
 		NetworkStage:            networkStage,
 		FirecrackerConfig:       withRunDir(firecrackerCfg, internalBootstrapArtifactsDir(sandboxID, executionID)),
 	}, stream)

--- a/internal/controlservice/gateway_scope.go
+++ b/internal/controlservice/gateway_scope.go
@@ -1,0 +1,47 @@
+package controlservice
+
+import (
+	"strings"
+
+	"github.com/buildkite/cleanroom/internal/authz"
+	"github.com/buildkite/cleanroom/internal/gatewayauth"
+	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/buildkite/cleanroom/internal/repositorycheckout"
+)
+
+func gatewayScopeMetadata(owner authz.ResourceOwner, repository *repositorycheckout.Checkout, compiled *policy.CompiledPolicy) gatewayauth.ScopeMetadata {
+	metadata := gatewayauth.ScopeMetadata{Owner: gatewayauth.Owner{
+		PrincipalID: strings.TrimSpace(owner.PrincipalID),
+		Scope:       strings.TrimSpace(owner.Scope),
+	}}
+	if strings.TrimSpace(owner.PrincipalID) == "" {
+		return metadata
+	}
+	if repository != nil {
+		if canonicalRemote, _, err := repositorycheckout.CanonicalizeRemoteURL(repository.RemoteURL); err == nil {
+			if prefix, err := gatewayauth.GitRepoPrefixFromURL(canonicalRemote); err == nil && prefix != "" {
+				metadata.Authorization.GitRepoPrefixes = append(metadata.Authorization.GitRepoPrefixes, prefix)
+			}
+		}
+	}
+	if compiled != nil && strings.TrimSpace(compiled.ImageRef) != "" {
+		if prefix, err := gatewayauth.OCIRepoPrefixFromImageRef(compiled.ImageRef); err == nil && prefix != "" {
+			metadata.Authorization.OCIRepoPrefixes = append(metadata.Authorization.OCIRepoPrefixes, prefix)
+		}
+	}
+	return metadata
+}
+
+func (s *Service) gatewayScopeForSandbox(sandboxID string) gatewayauth.ScopeMetadata {
+	sandboxID = strings.TrimSpace(sandboxID)
+	if sandboxID == "" {
+		return gatewayauth.ScopeMetadata{}
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	sb, ok := s.sandboxes[sandboxID]
+	if !ok {
+		return gatewayauth.ScopeMetadata{}
+	}
+	return gatewayScopeMetadata(sb.Owner, sb.Repository, sb.Policy)
+}

--- a/internal/controlservice/gateway_scope.go
+++ b/internal/controlservice/gateway_scope.go
@@ -33,6 +33,10 @@ func gatewayScopeMetadata(owner authz.ResourceOwner, repository *repositorycheck
 }
 
 func (s *Service) gatewayScopeForSandbox(sandboxID string) gatewayauth.ScopeMetadata {
+	return s.gatewayScopeForSandboxRepository(sandboxID, nil)
+}
+
+func (s *Service) gatewayScopeForSandboxRepository(sandboxID string, repository *repositorycheckout.Checkout) gatewayauth.ScopeMetadata {
 	sandboxID = strings.TrimSpace(sandboxID)
 	if sandboxID == "" {
 		return gatewayauth.ScopeMetadata{}
@@ -43,5 +47,9 @@ func (s *Service) gatewayScopeForSandbox(sandboxID string) gatewayauth.ScopeMeta
 	if !ok {
 		return gatewayauth.ScopeMetadata{}
 	}
-	return gatewayScopeMetadata(sb.Owner, sb.Repository, sb.Policy)
+	scopeRepository := sb.Repository
+	if repository != nil {
+		scopeRepository = repository
+	}
+	return gatewayScopeMetadata(sb.Owner, scopeRepository, sb.Policy)
 }

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -767,6 +767,7 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 	if err := adapter.ProvisionSandbox(ctx, backend.ProvisionRequest{
 		SandboxID:          sandboxID,
 		Policy:             compiled,
+		GatewayScope:       gatewayScopeMetadata(owner, repository, compiled),
 		CacheOutputVolumes: appendCacheOutputVolumeSpecs(dependencyCacheOutputVolumes, serviceCacheOutputVolumes),
 		Progress:           provisionProgress,
 		FirecrackerConfig:  firecrackerCfg,
@@ -3553,6 +3554,7 @@ func (s *Service) runExecution(sandboxID, executionID string) {
 		Env:               append([]string(nil), ex.Env...),
 		TTY:               ex.TTY,
 		Policy:            sb.Policy,
+		GatewayScope:      gatewayScopeMetadata(sb.Owner, sb.Repository, sb.Policy),
 		NetworkStage:      networkStage,
 		FirecrackerConfig: firecrackerCfg,
 	}

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -3962,7 +3962,7 @@ func (s *Service) bootstrapRepositoryInPersistentSandbox(
 		}
 	}
 
-	bootstrapExecutionID, result, stdout, stderr, err := s.runPersistentBootstrapCommand(
+	bootstrapExecutionID, result, stdout, stderr, err := s.runPersistentBootstrapCommandWithOptions(
 		ctx,
 		adapter,
 		sandboxID,
@@ -3971,7 +3971,9 @@ func (s *Service) bootstrapRepositoryInPersistentSandbox(
 		cleanroomv1.CreateSandboxPhase_CREATE_SANDBOX_PHASE_BOOTSTRAP_REPOSITORY,
 		policy.NetworkStageWorkspace,
 		command,
+		nil,
 		stdin,
+		persistentSandboxCommandOptions{GatewayScope: s.gatewayScopeForSandboxRepository(sandboxID, repository)},
 		reporter,
 	)
 	if s.Logger != nil {

--- a/internal/controlservice/stored_rootfs.go
+++ b/internal/controlservice/stored_rootfs.go
@@ -179,6 +179,7 @@ func (s *Service) createSandboxFromStoredRootFS(ctx context.Context, req *cleanr
 			SnapshotID:         provisionSnapshotID,
 			StorageRef:         record.StorageRef,
 			Policy:             effectivePolicy,
+			GatewayScope:       gatewayScopeMetadata(owner, record.Repository, effectivePolicy),
 			CacheOutputVolumes: cloneCacheOutputVolumeSpecs(cacheOutputVolumes),
 			FirecrackerConfig:  firecrackerCfg,
 		})

--- a/internal/gateway/dockerhub_cached.go
+++ b/internal/gateway/dockerhub_cached.go
@@ -17,14 +17,16 @@ const dockerHubMirrorPrefix = "docker.io"
 // dockerHubMirrorHandler exposes a Docker Hub-compatible pull-through mirror at
 // /v2/ so guest dockerd can use the shared gateway as a registry mirror.
 type dockerHubMirrorHandler struct {
-	cache  registryPrefixHandlerProvider
-	logger *log.Logger
+	cache        registryPrefixHandlerProvider
+	logger       *log.Logger
+	requireOwner bool
 }
 
-func newDockerHubMirrorHandler(cache registryPrefixHandlerProvider, logger *log.Logger) *dockerHubMirrorHandler {
+func newDockerHubMirrorHandler(cache registryPrefixHandlerProvider, logger *log.Logger, requireOwner bool) *dockerHubMirrorHandler {
 	return &dockerHubMirrorHandler{
-		cache:  cache,
-		logger: logger,
+		cache:        cache,
+		logger:       logger,
+		requireOwner: requireOwner,
 	}
 }
 
@@ -75,6 +77,19 @@ func (h *dockerHubMirrorHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 		span.SetStatus(codes.Error, "upstream registry host is not allowed by sandbox policy")
 		h.auditLog(r.Context(), scope.SandboxID, policyHost, gatewayActionDeny, reasonHostNotAllowed)
 		writeReasonError(w, http.StatusForbidden, reasonHostNotAllowed, "upstream registry host is not allowed by sandbox policy")
+		return
+	}
+	rest := strings.TrimPrefix(r.URL.Path, "/v2/")
+	if err := authorizeOCIGatewayRequest(scope, dockerHubMirrorPrefix, rest, h.requireOwner); err != nil {
+		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonGatewayAuthDenied)
+		span.RecordError(err)
+		span.SetAttributes(
+			attribute.String(observability.AttrGatewayAction, gatewayActionDeny),
+			attribute.String(observability.AttrReasonCode, reasonGatewayAuthDenied),
+		)
+		span.SetStatus(codes.Error, err.Error())
+		h.auditLog(r.Context(), scope.SandboxID, dockerHubMirrorPrefix, gatewayActionDeny, reasonGatewayAuthDenied)
+		writeReasonError(w, http.StatusForbidden, reasonGatewayAuthDenied, err.Error())
 		return
 	}
 

--- a/internal/gateway/dockerhub_cached_test.go
+++ b/internal/gateway/dockerhub_cached_test.go
@@ -22,7 +22,7 @@ func TestDockerHubMirrorHandlerRewritesManifestPath(t *testing.T) {
 		upstreamHost: "registry-1.docker.io",
 		upstreamPort: 443,
 	}
-	h := newDockerHubMirrorHandler(provider, nil)
+	h := newDockerHubMirrorHandler(provider, nil, false)
 
 	req := httptest.NewRequest(http.MethodGet, "/v2/library/alpine/manifests/latest", nil)
 	req = withScope(req, registryTestScope("docker.io"))
@@ -55,7 +55,7 @@ func TestDockerHubMirrorHandlerRewritesVersionProbe(t *testing.T) {
 		upstreamHost: "registry-1.docker.io",
 		upstreamPort: 443,
 	}
-	h := newDockerHubMirrorHandler(provider, nil)
+	h := newDockerHubMirrorHandler(provider, nil, false)
 
 	req := httptest.NewRequest(http.MethodGet, "/v2/", nil)
 	req = withScope(req, registryTestScope("docker.io"))
@@ -83,7 +83,7 @@ func TestDockerHubMirrorHandlerDeniesPolicyMiss(t *testing.T) {
 		upstreamHost: "registry-1.docker.io",
 		upstreamPort: 443,
 	}
-	h := newDockerHubMirrorHandler(provider, nil)
+	h := newDockerHubMirrorHandler(provider, nil, false)
 
 	req := httptest.NewRequest(http.MethodGet, "/v2/library/alpine/manifests/latest", nil)
 	req = withScope(req, registryTestScope("ghcr.io"))
@@ -98,13 +98,74 @@ func TestDockerHubMirrorHandlerDeniesPolicyMiss(t *testing.T) {
 	}
 }
 
+func TestDockerHubMirrorHandlerDeniesRepoOutsideGatewayEnvelope(t *testing.T) {
+	t.Parallel()
+
+	backend := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Fatal("backend should not be called for unauthorized repo")
+	})
+	provider := &stubRegistryPrefixHandlerProvider{
+		handler:      backend,
+		policyHost:   "docker.io",
+		policyPort:   443,
+		upstreamHost: "registry-1.docker.io",
+		upstreamPort: 443,
+	}
+	h := newDockerHubMirrorHandler(provider, nil, true)
+
+	req := httptest.NewRequest(http.MethodGet, "/v2/library/redis/manifests/latest", nil)
+	req = withScope(req, registryOwnedScope([]string{"docker.io/library/alpine"}, "docker.io"))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", w.Code)
+	}
+	if got := w.Header().Get(reasonCodeHeader); got != reasonGatewayAuthDenied {
+		t.Fatalf("expected reason %s, got %q", reasonGatewayAuthDenied, got)
+	}
+	if provider.handlerCalls != 0 {
+		t.Fatalf("expected denied request to avoid handler creation, got %d handler calls", provider.handlerCalls)
+	}
+}
+
+func TestDockerHubMirrorHandlerAllowsRepoInGatewayEnvelope(t *testing.T) {
+	t.Parallel()
+
+	var capturedPath string
+	backend := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	})
+	provider := &stubRegistryPrefixHandlerProvider{
+		handler:      backend,
+		policyHost:   "docker.io",
+		policyPort:   443,
+		upstreamHost: "registry-1.docker.io",
+		upstreamPort: 443,
+	}
+	h := newDockerHubMirrorHandler(provider, nil, true)
+
+	req := httptest.NewRequest(http.MethodGet, "/v2/library/alpine/manifests/latest", nil)
+	req = withScope(req, registryOwnedScope([]string{"docker.io/library/alpine"}, "docker.io"))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if capturedPath == "" {
+		t.Fatal("expected cache handler to be called")
+	}
+}
+
 func TestDockerHubMirrorHandlerRejectsPost(t *testing.T) {
 	t.Parallel()
 
 	backend := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal("backend should not be called for POST")
 	})
-	h := newDockerHubMirrorHandler(&stubRegistryPrefixHandlerProvider{handler: backend}, nil)
+	h := newDockerHubMirrorHandler(&stubRegistryPrefixHandlerProvider{handler: backend}, nil, false)
 
 	req := httptest.NewRequest(http.MethodPost, "/v2/library/alpine/manifests/latest", nil)
 	req = withScope(req, registryTestScope("docker.io"))
@@ -125,7 +186,7 @@ func TestDockerHubMirrorHandlerRequiresConfiguredOCI(t *testing.T) {
 	h := newDockerHubMirrorHandler(&stubRegistryPrefixHandlerProvider{
 		handler: backend,
 		err:     errors.New("unknown prefix"),
-	}, nil)
+	}, nil, false)
 
 	req := httptest.NewRequest(http.MethodGet, "/v2/library/alpine/manifests/latest", nil)
 	req = withScope(req, registryTestScope("docker.io"))

--- a/internal/gateway/gateway_auth.go
+++ b/internal/gateway/gateway_auth.go
@@ -1,0 +1,44 @@
+package gateway
+
+import (
+	"fmt"
+
+	"github.com/buildkite/cleanroom/internal/gatewayauth"
+)
+
+func authorizeGitGatewayRequest(scope *SandboxScope, upstreamHost, repoPath string, requireOwner bool) error {
+	if !requireOwner {
+		return nil
+	}
+	if scope == nil || !scope.GatewayScope.HasOwner() {
+		return fmt.Errorf("gateway route requires an authenticated sandbox owner")
+	}
+	repoKey, err := gatewayauth.GitRepoKeyFromRequest(upstreamHost, repoPath)
+	if err != nil {
+		return err
+	}
+	if !gatewayauth.AllowsGitRepo(scope.GatewayScope.Authorization.GitRepoPrefixes, repoKey) {
+		return fmt.Errorf("git repository %q is not authorized for sandbox owner", repoKey)
+	}
+	return nil
+}
+
+func authorizeOCIGatewayRequest(scope *SandboxScope, prefix, rest string, requireOwner bool) error {
+	if !requireOwner {
+		return nil
+	}
+	if scope == nil || !scope.GatewayScope.HasOwner() {
+		return fmt.Errorf("gateway route requires an authenticated sandbox owner")
+	}
+	repoKey, ok, err := gatewayauth.OCIRepoKeyFromPath(prefix, rest)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+	if !gatewayauth.AllowsOCIRepo(scope.GatewayScope.Authorization.OCIRepoPrefixes, repoKey) {
+		return fmt.Errorf("OCI repository %q is not authorized for sandbox owner", repoKey)
+	}
+	return nil
+}

--- a/internal/gateway/git.go
+++ b/internal/gateway/git.go
@@ -38,6 +38,7 @@ const (
 	reasonCached                = observability.ReasonCached
 	reasonFallback              = observability.ReasonFallback
 	reasonRubyGemsUnavailable   = observability.ReasonRubyGemsUnavailable
+	reasonGatewayAuthDenied     = observability.ReasonGatewayAuthDenied
 	gatewayActionAllow          = observability.GatewayActionAllow
 	gatewayActionDeny           = observability.GatewayActionDeny
 )
@@ -48,21 +49,23 @@ var (
 )
 
 type gitHandler struct {
-	credentials CredentialProvider
-	mirrors     GitMirrorStore
-	logger      *log.Logger
-	client      *http.Client
+	credentials  CredentialProvider
+	mirrors      GitMirrorStore
+	logger       *log.Logger
+	client       *http.Client
+	requireOwner bool
 }
 
 func newGitHandler(creds CredentialProvider, logger *log.Logger) *gitHandler {
-	return newGitHandlerWithMirrors(creds, nil, logger)
+	return newGitHandlerWithMirrors(creds, nil, logger, false)
 }
 
-func newGitHandlerWithMirrors(creds CredentialProvider, mirrors GitMirrorStore, logger *log.Logger) *gitHandler {
+func newGitHandlerWithMirrors(creds CredentialProvider, mirrors GitMirrorStore, logger *log.Logger, requireOwner bool) *gitHandler {
 	return &gitHandler{
-		credentials: creds,
-		mirrors:     mirrors,
-		logger:      logger,
+		credentials:  creds,
+		mirrors:      mirrors,
+		logger:       logger,
+		requireOwner: requireOwner,
 		client: &http.Client{
 			Transport: &http.Transport{
 				DialContext:           (&net.Dialer{Timeout: defaultUpstreamTimeout}).DialContext,
@@ -109,6 +112,18 @@ func (h *gitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		span.SetStatus(codes.Error, "upstream host is not allowed by sandbox policy")
 		h.auditLog(r.Context(), scope.SandboxID, upstreamHost, repoPath, gatewayActionDeny, reasonHostNotAllowed)
 		writeReasonError(w, http.StatusForbidden, reasonHostNotAllowed, "upstream host is not allowed by sandbox policy")
+		return
+	}
+	if err := authorizeGitGatewayRequest(scope, upstreamHost, repoPath, h.requireOwner); err != nil {
+		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonGatewayAuthDenied)
+		span.RecordError(err)
+		span.SetAttributes(
+			attribute.String(observability.AttrGatewayAction, gatewayActionDeny),
+			attribute.String(observability.AttrReasonCode, reasonGatewayAuthDenied),
+		)
+		span.SetStatus(codes.Error, err.Error())
+		h.auditLog(r.Context(), scope.SandboxID, upstreamHost, repoPath, gatewayActionDeny, reasonGatewayAuthDenied)
+		writeReasonError(w, http.StatusForbidden, reasonGatewayAuthDenied, err.Error())
 		return
 	}
 

--- a/internal/gateway/git_cached.go
+++ b/internal/gateway/git_cached.go
@@ -20,13 +20,14 @@ type gitHostHandlerProvider interface {
 // upstream proxying, caching, and singleflight deduplication; this wrapper
 // handles sandbox scope validation and host allowlisting.
 type cachedGitHandler struct {
-	cache    gitHostHandlerProvider
-	fallback http.Handler
-	logger   *log.Logger
+	cache        gitHostHandlerProvider
+	fallback     http.Handler
+	logger       *log.Logger
+	requireOwner bool
 }
 
-func newCachedGitHandler(cache gitHostHandlerProvider, fallback http.Handler, logger *log.Logger) *cachedGitHandler {
-	return &cachedGitHandler{cache: cache, fallback: fallback, logger: logger}
+func newCachedGitHandler(cache gitHostHandlerProvider, fallback http.Handler, logger *log.Logger, requireOwner bool) *cachedGitHandler {
+	return &cachedGitHandler{cache: cache, fallback: fallback, logger: logger, requireOwner: requireOwner}
 }
 
 func (h *cachedGitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -39,6 +40,13 @@ func (h *cachedGitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	upstreamHost, repoPath, err := splitGitRequestPath(r.URL.Path)
 	if err != nil {
 		http.Error(w, "bad request: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if err := authorizeGitGatewayRequest(scope, upstreamHost, repoPath, h.requireOwner); err != nil {
+		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonGatewayAuthDenied)
+		h.auditLog(r.Context(), scope.SandboxID, upstreamHost, repoPath, gatewayActionDeny, reasonGatewayAuthDenied)
+		writeReasonError(w, http.StatusForbidden, reasonGatewayAuthDenied, err.Error())
 		return
 	}
 

--- a/internal/gateway/git_cached_test.go
+++ b/internal/gateway/git_cached_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/buildkite/cleanroom/internal/gatewayauth"
 	"github.com/buildkite/cleanroom/internal/policy"
 )
 
@@ -14,6 +15,20 @@ type stubGitHostHandlerProvider struct {
 	handler http.Handler
 	err     error
 	host    string
+}
+
+func cachedGitOwnedScope(repoPrefixes ...string) *SandboxScope {
+	scope := cachedGitTestScope()
+	scope.GatewayScope = gatewayauth.ScopeMetadata{
+		Owner: gatewayauth.Owner{
+			PrincipalID: "oidc:test:alice",
+			Scope:       "repo:buildkite/cleanroom",
+		},
+		Authorization: gatewayauth.Authorization{
+			GitRepoPrefixes: repoPrefixes,
+		},
+	}
+	return scope
 }
 
 func (s *stubGitHostHandlerProvider) GitHandlerForHost(host string) (http.Handler, error) {
@@ -64,7 +79,7 @@ func TestCachedGitHandlerPolicyDeniesUnallowedHost(t *testing.T) {
 	backend := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal("backend should not be called for denied host")
 	})
-	h := newCachedGitHandler(&stubGitHostHandlerProvider{handler: backend}, nil, nil)
+	h := newCachedGitHandler(&stubGitHostHandlerProvider{handler: backend}, nil, nil, false)
 
 	req := httptest.NewRequest("GET", "/git/evil.com/org/repo.git/info/refs?service=git-upload-pack", nil)
 	req = withScope(req, cachedGitTestScope())
@@ -87,7 +102,7 @@ func TestCachedGitHandlerRejectsReceivePack(t *testing.T) {
 	backend := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal("backend should not be called for receive-pack")
 	})
-	h := newCachedGitHandler(&stubGitHostHandlerProvider{handler: backend}, nil, nil)
+	h := newCachedGitHandler(&stubGitHostHandlerProvider{handler: backend}, nil, nil, false)
 
 	req := httptest.NewRequest("POST", "/git/github.com/org/repo.git/git-receive-pack", nil)
 	req = withScope(req, cachedGitTestScope())
@@ -107,7 +122,7 @@ func TestCachedGitHandlerNoScope(t *testing.T) {
 	backend := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal("backend should not be called without scope")
 	})
-	h := newCachedGitHandler(&stubGitHostHandlerProvider{handler: backend}, nil, nil)
+	h := newCachedGitHandler(&stubGitHostHandlerProvider{handler: backend}, nil, nil, false)
 
 	req := httptest.NewRequest("GET", "/git/github.com/org/repo.git/info/refs?service=git-upload-pack", nil)
 	w := httptest.NewRecorder()
@@ -115,6 +130,77 @@ func TestCachedGitHandlerNoScope(t *testing.T) {
 
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("expected 403, got %d", w.Code)
+	}
+}
+
+func TestCachedGitHandlerRequiresOwnerWhenConfigured(t *testing.T) {
+	t.Parallel()
+
+	backend := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Fatal("backend should not be called without owner")
+	})
+	h := newCachedGitHandler(&stubGitHostHandlerProvider{handler: backend}, nil, nil, true)
+
+	req := httptest.NewRequest("GET", "/git/github.com/org/repo.git/info/refs?service=git-upload-pack", nil)
+	req = withScope(req, cachedGitTestScope())
+	req, obs := withGatewayRequestObservability(req)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", w.Code)
+	}
+	if got := w.Header().Get(reasonCodeHeader); got != reasonGatewayAuthDenied {
+		t.Fatalf("expected reason %s, got %q", reasonGatewayAuthDenied, got)
+	}
+	requireGatewayRequestDecision(t, obs, gatewayActionDeny, reasonGatewayAuthDenied)
+}
+
+func TestCachedGitHandlerDeniesRepoOutsideGatewayEnvelope(t *testing.T) {
+	t.Parallel()
+
+	provider := &stubGitHostHandlerProvider{
+		handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			t.Fatal("backend should not be called for unauthorized repo")
+		}),
+	}
+	h := newCachedGitHandler(provider, nil, nil, true)
+
+	req := httptest.NewRequest("GET", "/git/github.com/buildkite/private.git/info/refs?service=git-upload-pack", nil)
+	req = withScope(req, cachedGitOwnedScope("github.com/buildkite/cleanroom"))
+	req, obs := withGatewayRequestObservability(req)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", w.Code)
+	}
+	if provider.host != "" {
+		t.Fatalf("expected cache handler lookup to be skipped, got %q", provider.host)
+	}
+	requireGatewayRequestDecision(t, obs, gatewayActionDeny, reasonGatewayAuthDenied)
+}
+
+func TestCachedGitHandlerAllowsRepoInGatewayEnvelope(t *testing.T) {
+	t.Parallel()
+
+	var called bool
+	backend := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+	h := newCachedGitHandler(&stubGitHostHandlerProvider{handler: backend}, nil, nil, true)
+
+	req := httptest.NewRequest("GET", "/git/github.com/buildkite/cleanroom.git/info/refs?service=git-upload-pack", nil)
+	req = withScope(req, cachedGitOwnedScope("github.com/buildkite/cleanroom"))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if !called {
+		t.Fatal("expected cache handler to be called")
 	}
 }
 
@@ -127,7 +213,7 @@ func TestCachedGitHandlerStripsGitPrefixAndDelegates(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 	provider := &stubGitHostHandlerProvider{handler: backend}
-	h := newCachedGitHandler(provider, nil, nil)
+	h := newCachedGitHandler(provider, nil, nil, false)
 
 	req := httptest.NewRequest("GET", "/git/github.com/org/repo.git/info/refs?service=git-upload-pack", nil)
 	req = withScope(req, cachedGitTestScope())
@@ -157,7 +243,7 @@ func TestCachedGitHandlerUploadPackDelegates(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 	provider := &stubGitHostHandlerProvider{handler: backend}
-	h := newCachedGitHandler(provider, nil, nil)
+	h := newCachedGitHandler(provider, nil, nil, false)
 
 	req := httptest.NewRequest("POST", "/git/github.com/org/repo.git/git-upload-pack", nil)
 	req = withScope(req, cachedGitTestScope())
@@ -192,7 +278,7 @@ func TestCachedGitHandlerFallsBackForUnconfiguredCacheHost(t *testing.T) {
 	provider := &stubGitHostHandlerProvider{
 		err: fmt.Errorf("%w: github.enterprise.test", errGitHostNotConfiguredForCaching),
 	}
-	h := newCachedGitHandler(provider, fallback, nil)
+	h := newCachedGitHandler(provider, fallback, nil, false)
 
 	req := httptest.NewRequest("GET", "/git/github.enterprise.test/org/repo.git/info/refs?service=git-upload-pack", nil)
 	req = withScope(req, &SandboxScope{
@@ -239,7 +325,7 @@ func TestCachedGitHandlerFallsBackForNonDotGitRemotes(t *testing.T) {
 			t.Fatal("cache handler should not be used for non-.git remotes")
 		}),
 	}
-	h := newCachedGitHandler(provider, fallback, nil)
+	h := newCachedGitHandler(provider, fallback, nil, false)
 
 	req := httptest.NewRequest("GET", "/git/github.com/org/repo/info/refs?service=git-upload-pack", nil)
 	req = withScope(req, cachedGitTestScope())

--- a/internal/gateway/git_test.go
+++ b/internal/gateway/git_test.go
@@ -70,6 +70,23 @@ func TestGitHandlerHostNotAllowed(t *testing.T) {
 	}
 }
 
+func TestGitHandlerRequiresOwnerWhenConfigured(t *testing.T) {
+	t.Parallel()
+
+	h := newGitHandlerWithMirrors(nil, nil, nil, true)
+	req := httptest.NewRequest("GET", "/git/github.com/org/repo.git/info/refs?service=git-upload-pack", nil)
+	req = withScope(req, gitTestScope())
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", w.Code)
+	}
+	if got := w.Header().Get(reasonCodeHeader); got != reasonGatewayAuthDenied {
+		t.Fatalf("expected reason %s, got %q", reasonGatewayAuthDenied, got)
+	}
+}
+
 func TestGitHandlerReceivePackDenied(t *testing.T) {
 	t.Parallel()
 

--- a/internal/gateway/oci_cached.go
+++ b/internal/gateway/oci_cached.go
@@ -24,14 +24,16 @@ type registryPrefixHandlerProvider interface {
 // and extracts the upstream registry host from the configured prefix mapping
 // for policy evaluation.
 type cachedRegistryHandler struct {
-	cache  registryPrefixHandlerProvider
-	logger *log.Logger
+	cache        registryPrefixHandlerProvider
+	logger       *log.Logger
+	requireOwner bool
 }
 
-func newCachedRegistryHandler(cache registryPrefixHandlerProvider, logger *log.Logger) *cachedRegistryHandler {
+func newCachedRegistryHandler(cache registryPrefixHandlerProvider, logger *log.Logger, requireOwner bool) *cachedRegistryHandler {
 	return &cachedRegistryHandler{
-		cache:  cache,
-		logger: logger,
+		cache:        cache,
+		logger:       logger,
+		requireOwner: requireOwner,
 	}
 }
 
@@ -100,6 +102,18 @@ func (h *cachedRegistryHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		span.SetStatus(codes.Error, "upstream registry host is not allowed by sandbox policy")
 		h.auditLog(r.Context(), scope.SandboxID, policyHost, gatewayActionDeny, reasonHostNotAllowed)
 		writeReasonError(w, http.StatusForbidden, reasonHostNotAllowed, "upstream registry host is not allowed by sandbox policy")
+		return
+	}
+	if err := authorizeOCIGatewayRequest(scope, normalizedPrefix, rest, h.requireOwner); err != nil {
+		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonGatewayAuthDenied)
+		span.RecordError(err)
+		span.SetAttributes(
+			attribute.String(observability.AttrGatewayAction, gatewayActionDeny),
+			attribute.String(observability.AttrReasonCode, reasonGatewayAuthDenied),
+		)
+		span.SetStatus(codes.Error, err.Error())
+		h.auditLog(r.Context(), scope.SandboxID, normalizedPrefix, gatewayActionDeny, reasonGatewayAuthDenied)
+		writeReasonError(w, http.StatusForbidden, reasonGatewayAuthDenied, err.Error())
 		return
 	}
 	span.SetAttributes(

--- a/internal/gateway/oci_cached_test.go
+++ b/internal/gateway/oci_cached_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/buildkite/cleanroom/internal/gatewayauth"
 	"github.com/buildkite/cleanroom/internal/policy"
 )
 
@@ -55,6 +56,20 @@ func registryTestScope(allowedHosts ...string) *SandboxScope {
 	}
 }
 
+func registryOwnedScope(ociPrefixes []string, allowedHosts ...string) *SandboxScope {
+	scope := registryTestScope(allowedHosts...)
+	scope.GatewayScope = gatewayauth.ScopeMetadata{
+		Owner: gatewayauth.Owner{
+			PrincipalID: "oidc:test:alice",
+			Scope:       "repo:buildkite/cleanroom",
+		},
+		Authorization: gatewayauth.Authorization{
+			OCIRepoPrefixes: ociPrefixes,
+		},
+	}
+	return scope
+}
+
 func registryTestScopeWithRule(host string, ports ...int) *SandboxScope {
 	return &SandboxScope{
 		SandboxID: "sandbox-registry-test",
@@ -84,7 +99,7 @@ func TestCachedRegistryHandlerRewritesPathToV2(t *testing.T) {
 		upstreamHost: "registry-1.docker.io",
 		upstreamPort: 443,
 	}
-	h := newCachedRegistryHandler(provider, nil)
+	h := newCachedRegistryHandler(provider, nil, false)
 
 	req := httptest.NewRequest("GET", "/registry/docker.io/library/nginx/manifests/latest", nil)
 	req = withScope(req, registryTestScope("docker.io"))
@@ -115,7 +130,7 @@ func TestCachedRegistryHandlerPolicyDeniesUnallowedHost(t *testing.T) {
 		upstreamHost: "registry-1.docker.io",
 		upstreamPort: 443,
 	}
-	h := newCachedRegistryHandler(provider, nil)
+	h := newCachedRegistryHandler(provider, nil, false)
 
 	req := httptest.NewRequest("GET", "/registry/docker.io/library/nginx/manifests/latest", nil)
 	req = withScope(req, registryTestScope("ghcr.io"))
@@ -145,7 +160,7 @@ func TestCachedRegistryHandlerUnknownPrefix(t *testing.T) {
 	h := newCachedRegistryHandler(&stubRegistryPrefixHandlerProvider{
 		handler: backend,
 		err:     errors.New("unknown prefix"),
-	}, nil)
+	}, nil, false)
 
 	req := httptest.NewRequest("GET", "/registry/unknown-prefix/library/nginx/manifests/latest", nil)
 	req = withScope(req, registryTestScope("registry-1.docker.io"))
@@ -163,7 +178,7 @@ func TestCachedRegistryHandlerNoScope(t *testing.T) {
 	backend := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal("backend should not be called without scope")
 	})
-	h := newCachedRegistryHandler(&stubRegistryPrefixHandlerProvider{handler: backend}, nil)
+	h := newCachedRegistryHandler(&stubRegistryPrefixHandlerProvider{handler: backend}, nil, false)
 
 	req := httptest.NewRequest("GET", "/registry/docker.io/library/nginx/manifests/latest", nil)
 	w := httptest.NewRecorder()
@@ -174,13 +189,102 @@ func TestCachedRegistryHandlerNoScope(t *testing.T) {
 	}
 }
 
+func TestCachedRegistryHandlerRequiresOwnerWhenConfigured(t *testing.T) {
+	t.Parallel()
+
+	backend := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Fatal("backend should not be called without owner")
+	})
+	provider := &stubRegistryPrefixHandlerProvider{
+		handler:      backend,
+		policyHost:   "docker.io",
+		policyPort:   443,
+		upstreamHost: "registry-1.docker.io",
+		upstreamPort: 443,
+	}
+	h := newCachedRegistryHandler(provider, nil, true)
+
+	req := httptest.NewRequest("GET", "/registry/docker.io/library/nginx/manifests/latest", nil)
+	req = withScope(req, registryTestScope("docker.io"))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", w.Code)
+	}
+	if got := w.Header().Get(reasonCodeHeader); got != reasonGatewayAuthDenied {
+		t.Fatalf("expected reason %s, got %q", reasonGatewayAuthDenied, got)
+	}
+	if provider.handlerCalls != 0 {
+		t.Fatalf("expected denied request to avoid handler creation, got %d handler calls", provider.handlerCalls)
+	}
+}
+
+func TestCachedRegistryHandlerDeniesRepoOutsideGatewayEnvelope(t *testing.T) {
+	t.Parallel()
+
+	backend := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Fatal("backend should not be called for unauthorized repo")
+	})
+	provider := &stubRegistryPrefixHandlerProvider{
+		handler:      backend,
+		policyHost:   "ghcr.io",
+		policyPort:   443,
+		upstreamHost: "ghcr.io",
+		upstreamPort: 443,
+	}
+	h := newCachedRegistryHandler(provider, nil, true)
+
+	req := httptest.NewRequest("GET", "/registry/ghcr.io/buildkite/private/manifests/latest", nil)
+	req = withScope(req, registryOwnedScope([]string{"ghcr.io/buildkite/cleanroom-base/alpine"}, "ghcr.io"))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", w.Code)
+	}
+	if provider.handlerCalls != 0 {
+		t.Fatalf("expected denied request to avoid handler creation, got %d handler calls", provider.handlerCalls)
+	}
+}
+
+func TestCachedRegistryHandlerAllowsRepoInGatewayEnvelope(t *testing.T) {
+	t.Parallel()
+
+	var capturedPath string
+	backend := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	})
+	provider := &stubRegistryPrefixHandlerProvider{
+		handler:      backend,
+		policyHost:   "ghcr.io",
+		policyPort:   443,
+		upstreamHost: "ghcr.io",
+		upstreamPort: 443,
+	}
+	h := newCachedRegistryHandler(provider, nil, true)
+
+	req := httptest.NewRequest("GET", "/registry/ghcr.io/buildkite/cleanroom-base/alpine/manifests/latest", nil)
+	req = withScope(req, registryOwnedScope([]string{"ghcr.io/buildkite/cleanroom-base/alpine"}, "ghcr.io"))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if capturedPath == "" {
+		t.Fatal("expected cache handler to be called")
+	}
+}
+
 func TestCachedRegistryHandlerRejectsPost(t *testing.T) {
 	t.Parallel()
 
 	backend := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal("backend should not be called for POST")
 	})
-	h := newCachedRegistryHandler(&stubRegistryPrefixHandlerProvider{handler: backend}, nil)
+	h := newCachedRegistryHandler(&stubRegistryPrefixHandlerProvider{handler: backend}, nil, false)
 
 	req := httptest.NewRequest("POST", "/registry/docker.io/library/nginx/manifests/latest", nil)
 	req = withScope(req, registryTestScope("registry-1.docker.io"))
@@ -207,7 +311,7 @@ func TestCachedRegistryHandlerBlobsRewritePath(t *testing.T) {
 		upstreamHost: "ghcr.io",
 		upstreamPort: 443,
 	}
-	h := newCachedRegistryHandler(provider, nil)
+	h := newCachedRegistryHandler(provider, nil, false)
 
 	req := httptest.NewRequest("GET", "/registry/ghcr.io/myorg/myimage/blobs/sha256:abc123", nil)
 	req = withScope(req, registryTestScope("ghcr.io"))
@@ -240,7 +344,7 @@ func TestCachedRegistryHandlerRegistryProbeRewritesToVersionCheck(t *testing.T) 
 		upstreamHost: "registry-1.docker.io",
 		upstreamPort: 443,
 	}
-	h := newCachedRegistryHandler(provider, nil)
+	h := newCachedRegistryHandler(provider, nil, false)
 
 	req := httptest.NewRequest("GET", "/registry/docker.io/v2/", nil)
 	req = withScope(req, registryTestScope("docker.io"))
@@ -273,7 +377,7 @@ func TestCachedRegistryHandlerStripsClientV2Prefix(t *testing.T) {
 		upstreamHost: "registry-1.docker.io",
 		upstreamPort: 443,
 	}
-	h := newCachedRegistryHandler(provider, nil)
+	h := newCachedRegistryHandler(provider, nil, false)
 
 	req := httptest.NewRequest("GET", "/registry/docker.io/v2/library/nginx/manifests/latest", nil)
 	req = withScope(req, registryTestScope("docker.io"))
@@ -305,7 +409,7 @@ func TestCachedRegistryHandlerHeadAllowed(t *testing.T) {
 		policyPort:   443,
 		upstreamHost: "registry-1.docker.io",
 		upstreamPort: 443,
-	}, nil)
+	}, nil, false)
 
 	req := httptest.NewRequest("HEAD", "/registry/docker.io/library/nginx/manifests/latest", nil)
 	req = withScope(req, registryTestScope("docker.io"))
@@ -327,7 +431,7 @@ func TestCachedRegistryHandlerEmptyPrefix(t *testing.T) {
 		t.Fatal("backend should not be called for empty prefix")
 	})
 	provider := &stubRegistryPrefixHandlerProvider{handler: backend}
-	h := newCachedRegistryHandler(provider, nil)
+	h := newCachedRegistryHandler(provider, nil, false)
 
 	req := httptest.NewRequest("GET", "/registry/", nil)
 	req = withScope(req, registryTestScope("registry-1.docker.io"))
@@ -354,7 +458,7 @@ func TestCachedRegistryHandlerBarePrefixSetsGatewayDecision(t *testing.T) {
 		t.Fatal("backend should not be called for bare prefix")
 	})
 	provider := &stubRegistryPrefixHandlerProvider{handler: backend}
-	h := newCachedRegistryHandler(provider, nil)
+	h := newCachedRegistryHandler(provider, nil, false)
 
 	req := httptest.NewRequest("GET", "/registry/docker.io", nil)
 	req = withScope(req, registryTestScope("docker.io"))
@@ -386,7 +490,7 @@ func TestCachedRegistryHandlerUsesResolvedPolicyPort(t *testing.T) {
 		policyPort:   5000,
 		upstreamHost: "registry.internal",
 		upstreamPort: 5000,
-	}, nil)
+	}, nil, false)
 
 	req := httptest.NewRequest("GET", "/registry/internal/library/nginx/manifests/latest", nil)
 	req = withScope(req, registryTestScopeWithRule("registry.internal", 5000))

--- a/internal/gateway/registry.go
+++ b/internal/gateway/registry.go
@@ -125,6 +125,22 @@ func (r *Registry) SetActiveExecutionTrace(sandboxID, executionID string, spanCo
 	}
 }
 
+func (r *Registry) SetActiveExecutionScope(sandboxID, executionID string, spanContext trace.SpanContext, metadata gatewayauth.ScopeMetadata) {
+	sandboxID = strings.TrimSpace(sandboxID)
+	if sandboxID == "" {
+		return
+	}
+	executionID = strings.TrimSpace(executionID)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, scope := range r.byGuestIP {
+		setActiveExecutionScopeForScope(scope, sandboxID, executionID, spanContext, metadata)
+	}
+	for _, scope := range r.byScopeToken {
+		setActiveExecutionScopeForScope(scope, sandboxID, executionID, spanContext, metadata)
+	}
+}
+
 func (r *Registry) ClearActiveExecutionTrace(sandboxID, executionID string) {
 	sandboxID = strings.TrimSpace(sandboxID)
 	if sandboxID == "" {
@@ -156,6 +172,15 @@ func setActiveExecutionTraceForScope(scope *SandboxScope, sandboxID, executionID
 	}
 	scope.ExecutionID = executionID
 	scope.TraceContext = spanContext
+}
+
+func setActiveExecutionScopeForScope(scope *SandboxScope, sandboxID, executionID string, spanContext trace.SpanContext, metadata gatewayauth.ScopeMetadata) {
+	if scope == nil || scope.SandboxID != sandboxID {
+		return
+	}
+	scope.ExecutionID = executionID
+	scope.TraceContext = spanContext
+	scope.GatewayScope = metadata.Clone()
 }
 
 func clearActiveExecutionTraceForScope(scope *SandboxScope, sandboxID, executionID string) {

--- a/internal/gateway/registry.go
+++ b/internal/gateway/registry.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/buildkite/cleanroom/internal/gatewayauth"
 	"github.com/buildkite/cleanroom/internal/policy"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -14,6 +15,7 @@ type SandboxScope struct {
 	SandboxID    string
 	GuestIP      string
 	Policy       *policy.CompiledPolicy
+	GatewayScope gatewayauth.ScopeMetadata
 	ExecutionID  string
 	TraceContext trace.SpanContext
 }
@@ -35,16 +37,17 @@ func NewRegistry() *Registry {
 
 // Register adds a sandbox scope keyed by guest IP. Returns an error if the IP
 // is already registered (possible hash collision).
-func (r *Registry) Register(guestIP, sandboxID string, p *policy.CompiledPolicy) error {
+func (r *Registry) Register(guestIP, sandboxID string, p *policy.CompiledPolicy, metadata ...gatewayauth.ScopeMetadata) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if _, exists := r.byGuestIP[guestIP]; exists {
 		return fmt.Errorf("guest IP %s already registered (possible IP collision)", guestIP)
 	}
 	r.byGuestIP[guestIP] = &SandboxScope{
-		SandboxID: sandboxID,
-		GuestIP:   guestIP,
-		Policy:    p,
+		SandboxID:    sandboxID,
+		GuestIP:      guestIP,
+		Policy:       p,
+		GatewayScope: firstScopeMetadata(metadata).Clone(),
 	}
 	return nil
 }
@@ -66,7 +69,7 @@ func (r *Registry) Lookup(guestIP string) (*SandboxScope, bool) {
 
 // RegisterScopeToken adds a sandbox scope keyed by a capability token.
 // Returns an error if the token is already registered.
-func (r *Registry) RegisterScopeToken(scopeToken, sandboxID string, p *policy.CompiledPolicy) error {
+func (r *Registry) RegisterScopeToken(scopeToken, sandboxID string, p *policy.CompiledPolicy, metadata ...gatewayauth.ScopeMetadata) error {
 	scopeToken = strings.TrimSpace(scopeToken)
 	if scopeToken == "" {
 		return fmt.Errorf("scope token must not be empty")
@@ -77,10 +80,18 @@ func (r *Registry) RegisterScopeToken(scopeToken, sandboxID string, p *policy.Co
 		return fmt.Errorf("scope token already registered")
 	}
 	r.byScopeToken[scopeToken] = &SandboxScope{
-		SandboxID: sandboxID,
-		Policy:    p,
+		SandboxID:    sandboxID,
+		Policy:       p,
+		GatewayScope: firstScopeMetadata(metadata).Clone(),
 	}
 	return nil
+}
+
+func firstScopeMetadata(values []gatewayauth.ScopeMetadata) gatewayauth.ScopeMetadata {
+	if len(values) == 0 {
+		return gatewayauth.ScopeMetadata{}
+	}
+	return values[0]
 }
 
 // ReleaseScopeToken removes a sandbox scope by token.
@@ -135,6 +146,7 @@ func cloneSandboxScope(scope *SandboxScope) *SandboxScope {
 		return nil
 	}
 	clone := *scope
+	clone.GatewayScope = scope.GatewayScope.Clone()
 	return &clone
 }
 

--- a/internal/gateway/registry_test.go
+++ b/internal/gateway/registry_test.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/buildkite/cleanroom/internal/gatewayauth"
 	"github.com/buildkite/cleanroom/internal/policy"
 )
 
@@ -36,6 +37,42 @@ func TestRegistryRegisterAndLookup(t *testing.T) {
 	}
 	if scope.Policy != p {
 		t.Fatal("policy mismatch")
+	}
+}
+
+func TestRegistryRegisterCopiesGatewayScopeMetadata(t *testing.T) {
+	t.Parallel()
+	r := NewRegistry()
+
+	metadata := gatewayauth.ScopeMetadata{
+		Owner: gatewayauth.Owner{
+			PrincipalID: "oidc:test:alice",
+			Scope:       "repo:buildkite/cleanroom",
+		},
+		Authorization: gatewayauth.Authorization{
+			GitRepoPrefixes: []string{"github.com/buildkite/cleanroom"},
+			OCIRepoPrefixes: []string{"ghcr.io/buildkite/cleanroom-base/alpine"},
+		},
+	}
+	if err := r.Register("10.1.1.2", "sandbox-1", testPolicy(), metadata); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	metadata.Authorization.GitRepoPrefixes[0] = "github.com/other/repo"
+
+	scope, ok := r.Lookup("10.1.1.2")
+	if !ok {
+		t.Fatal("expected lookup to succeed")
+	}
+	if got, want := scope.GatewayScope.Owner.PrincipalID, "oidc:test:alice"; got != want {
+		t.Fatalf("unexpected owner: got %q want %q", got, want)
+	}
+	if got, want := scope.GatewayScope.Authorization.GitRepoPrefixes[0], "github.com/buildkite/cleanroom"; got != want {
+		t.Fatalf("unexpected git authorization: got %q want %q", got, want)
+	}
+	scope.GatewayScope.Authorization.GitRepoPrefixes[0] = "github.com/mutated/repo"
+	scope, _ = r.Lookup("10.1.1.2")
+	if got, want := scope.GatewayScope.Authorization.GitRepoPrefixes[0], "github.com/buildkite/cleanroom"; got != want {
+		t.Fatalf("lookup returned mutable metadata: got %q want %q", got, want)
 	}
 }
 
@@ -134,6 +171,29 @@ func TestRegistryRegisterScopeTokenAndLookup(t *testing.T) {
 	}
 	if scope.Policy != p {
 		t.Fatal("policy mismatch")
+	}
+}
+
+func TestRegistryRegisterScopeTokenCopiesGatewayScopeMetadata(t *testing.T) {
+	t.Parallel()
+	r := NewRegistry()
+
+	metadata := gatewayauth.ScopeMetadata{
+		Owner: gatewayauth.Owner{PrincipalID: "oidc:test:alice"},
+		Authorization: gatewayauth.Authorization{
+			GitRepoPrefixes: []string{"github.com/buildkite/cleanroom"},
+		},
+	}
+	if err := r.RegisterScopeToken("token-1", "sandbox-1", testPolicy(), metadata); err != nil {
+		t.Fatalf("register scope token: %v", err)
+	}
+
+	scope, ok := r.LookupScopeToken("token-1")
+	if !ok {
+		t.Fatal("expected token lookup to succeed")
+	}
+	if got, want := scope.GatewayScope.Owner.PrincipalID, "oidc:test:alice"; got != want {
+		t.Fatalf("unexpected owner: got %q want %q", got, want)
 	}
 }
 

--- a/internal/gateway/registry_test.go
+++ b/internal/gateway/registry_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/buildkite/cleanroom/internal/gatewayauth"
 	"github.com/buildkite/cleanroom/internal/policy"
+	"go.opentelemetry.io/otel/trace"
 )
 
 func testPolicy() *policy.CompiledPolicy {
@@ -194,6 +195,38 @@ func TestRegistryRegisterScopeTokenCopiesGatewayScopeMetadata(t *testing.T) {
 	}
 	if got, want := scope.GatewayScope.Owner.PrincipalID, "oidc:test:alice"; got != want {
 		t.Fatalf("unexpected owner: got %q want %q", got, want)
+	}
+}
+
+func TestRegistrySetActiveExecutionScopeUpdatesGatewayScope(t *testing.T) {
+	t.Parallel()
+	r := NewRegistry()
+
+	if err := r.Register("10.1.1.2", "sandbox-1", testPolicy(), gatewayauth.ScopeMetadata{
+		Owner: gatewayauth.Owner{PrincipalID: "oidc:test:old"},
+	}); err != nil {
+		t.Fatalf("register scope: %v", err)
+	}
+
+	r.SetActiveExecutionScope("sandbox-1", "exec-1", trace.SpanContext{}, gatewayauth.ScopeMetadata{
+		Owner: gatewayauth.Owner{PrincipalID: "oidc:test:alice"},
+		Authorization: gatewayauth.Authorization{
+			GitRepoPrefixes: []string{"github.com/buildkite/cleanroom"},
+		},
+	})
+
+	scope, ok := r.Lookup("10.1.1.2")
+	if !ok {
+		t.Fatal("expected scope lookup to succeed")
+	}
+	if got, want := scope.ExecutionID, "exec-1"; got != want {
+		t.Fatalf("execution id mismatch: got %q want %q", got, want)
+	}
+	if got, want := scope.GatewayScope.Owner.PrincipalID, "oidc:test:alice"; got != want {
+		t.Fatalf("gateway owner mismatch: got %q want %q", got, want)
+	}
+	if got, want := scope.GatewayScope.Authorization.GitRepoPrefixes[0], "github.com/buildkite/cleanroom"; got != want {
+		t.Fatalf("gateway git prefix mismatch: got %q want %q", got, want)
 	}
 }
 

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -164,6 +164,7 @@ type ServerConfig struct {
 	Logger                          *log.Logger
 	TracerProvider                  trace.TracerProvider
 	MeterProvider                   metric.MeterProvider
+	RequireOwner                    bool
 	ScopeTokenTrustedSourcePrefixes []netip.Prefix
 	AllowScopeTokenFromAnySource    bool
 }
@@ -217,18 +218,19 @@ func NewServer(cfg ServerConfig) *Server {
 	mux := http.NewServeMux()
 
 	// Git: prefer content-cache, fall back to mirror-backed proxy.
+	fallbackGit := newGitHandlerWithMirrors(cfg.Credentials, cfg.GitMirrors, cfg.Logger, cfg.RequireOwner)
 	if cfg.ContentCache != nil && cfg.ContentCache.HasGitHandler() {
-		mux.Handle(RouteGit, newCachedGitHandler(cfg.ContentCache, newGitHandlerWithMirrors(cfg.Credentials, cfg.GitMirrors, cfg.Logger), cfg.Logger))
+		mux.Handle(RouteGit, newCachedGitHandler(cfg.ContentCache, fallbackGit, cfg.Logger, cfg.RequireOwner))
 	} else {
-		mux.Handle(RouteGit, newGitHandlerWithMirrors(cfg.Credentials, cfg.GitMirrors, cfg.Logger))
+		mux.Handle(RouteGit, fallbackGit)
 	}
 
 	// Registry: prefer content-cache OCI handler, fall back to stub.
 	if cfg.ContentCache != nil && cfg.ContentCache.HasOCIHandler() {
-		dockerHubMirror := newDockerHubMirrorHandler(cfg.ContentCache, cfg.Logger)
+		dockerHubMirror := newDockerHubMirrorHandler(cfg.ContentCache, cfg.Logger, cfg.RequireOwner)
 		mux.Handle("/v2", dockerHubMirror)
 		mux.Handle(RouteDockerHubMirror, dockerHubMirror)
-		mux.Handle(RouteRegistry, newCachedRegistryHandler(cfg.ContentCache, cfg.Logger))
+		mux.Handle(RouteRegistry, newCachedRegistryHandler(cfg.ContentCache, cfg.Logger, cfg.RequireOwner))
 	} else {
 		mux.HandleFunc("/v2", stubHandler("dockerhub mirror"))
 		mux.HandleFunc(RouteDockerHubMirror, stubHandler("dockerhub mirror"))

--- a/internal/gatewayauth/gatewayauth.go
+++ b/internal/gatewayauth/gatewayauth.go
@@ -126,7 +126,7 @@ func OCIRepoKeyFromPath(prefix, rest string) (repoKey string, ok bool, err error
 	parts := strings.Split(rest, "/")
 	for i := len(parts) - 2; i >= 1; i-- {
 		switch parts[i] {
-		case "manifests", "blobs":
+		case "manifests", "blobs", "referrers":
 			return NormalizeOCIRepoPrefix(prefix + "/" + strings.Join(parts[:i], "/")), true, nil
 		}
 	}
@@ -153,6 +153,10 @@ func NormalizeOCIRepoPrefix(value string) string {
 			return "docker.io/library/" + repo
 		}
 		return "docker.io/" + repo
+	}
+	if first == "index.docker.io" || first == "registry-1.docker.io" {
+		parts[0] = "docker.io"
+		return strings.Join(parts, "/")
 	}
 	return repo
 }

--- a/internal/gatewayauth/gatewayauth.go
+++ b/internal/gatewayauth/gatewayauth.go
@@ -1,0 +1,186 @@
+// Package gatewayauth contains the owner and resource envelope that Cleanroom
+// registers with gateway routes for a sandbox.
+package gatewayauth
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// Authorization describes upstream resources a sandbox owner may access through
+// privileged gateway handlers.
+type Authorization struct {
+	GitRepoPrefixes []string
+	OCIRepoPrefixes []string
+	FetchURLs       []string
+}
+
+// Owner identifies the control-plane principal that created a sandbox.
+type Owner struct {
+	PrincipalID string
+	Scope       string
+}
+
+// ScopeMetadata is attached to a registered sandbox gateway scope.
+type ScopeMetadata struct {
+	Owner         Owner
+	Authorization Authorization
+}
+
+// Clone returns a detached copy of scope metadata.
+func (m ScopeMetadata) Clone() ScopeMetadata {
+	return ScopeMetadata{
+		Owner: m.Owner,
+		Authorization: Authorization{
+			GitRepoPrefixes: append([]string(nil), m.Authorization.GitRepoPrefixes...),
+			OCIRepoPrefixes: append([]string(nil), m.Authorization.OCIRepoPrefixes...),
+			FetchURLs:       append([]string(nil), m.Authorization.FetchURLs...),
+		},
+	}
+}
+
+// HasOwner reports whether the scope came from an authenticated resource owner.
+func (m ScopeMetadata) HasOwner() bool {
+	return strings.TrimSpace(m.Owner.PrincipalID) != ""
+}
+
+// GitRepoPrefixFromURL returns the normalized host/path key used to authorize
+// Git gateway requests.
+func GitRepoPrefixFromURL(raw string) (string, error) {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return "", fmt.Errorf("parse git remote URL: %w", err)
+	}
+	host := strings.TrimSpace(strings.ToLower(parsed.Hostname()))
+	if host == "" {
+		return "", fmt.Errorf("git remote URL has no host")
+	}
+	if parsed.Port() != "" {
+		host = host + ":" + parsed.Port()
+	}
+	return NormalizeGitRepoPrefix(host + "/" + strings.TrimPrefix(parsed.Path, "/")), nil
+}
+
+// GitRepoKeyFromRequest returns the normalized host/path key for a gateway Git
+// request after the operation suffix has been removed.
+func GitRepoKeyFromRequest(upstreamHost, repoPath string) (string, error) {
+	repositoryPath := repoPath
+	switch {
+	case strings.HasSuffix(repositoryPath, "/info/refs"):
+		repositoryPath = strings.TrimSuffix(repositoryPath, "/info/refs")
+	case strings.HasSuffix(repositoryPath, "/git-upload-pack"):
+		repositoryPath = strings.TrimSuffix(repositoryPath, "/git-upload-pack")
+	case strings.HasSuffix(repositoryPath, "/git-receive-pack"):
+		repositoryPath = strings.TrimSuffix(repositoryPath, "/git-receive-pack")
+	default:
+		return "", fmt.Errorf("unsupported git request path %q", repoPath)
+	}
+	return NormalizeGitRepoPrefix(strings.TrimSpace(upstreamHost) + "/" + strings.TrimPrefix(repositoryPath, "/")), nil
+}
+
+// NormalizeGitRepoPrefix normalizes host/path Git repository keys. Repository
+// suffixes are stored without .git so remotes with and without the suffix match.
+func NormalizeGitRepoPrefix(value string) string {
+	normalized := strings.Trim(strings.ToLower(strings.TrimSpace(value)), "/")
+	if strings.HasSuffix(normalized, ".git") {
+		normalized = strings.TrimSuffix(normalized, ".git")
+	}
+	return normalized
+}
+
+// AllowsGitRepo reports whether a Git repo key is covered by the authorization
+// envelope.
+func AllowsGitRepo(prefixes []string, repoKey string) bool {
+	return allowsPrefix(prefixes, NormalizeGitRepoPrefix(repoKey), NormalizeGitRepoPrefix)
+}
+
+// OCIRepoPrefixFromImageRef returns the normalized registry/repository key from
+// an OCI image reference, ignoring tags and digests.
+func OCIRepoPrefixFromImageRef(imageRef string) (string, error) {
+	repo := strings.TrimSpace(imageRef)
+	if repo == "" {
+		return "", fmt.Errorf("image reference is empty")
+	}
+	if beforeDigest, _, ok := strings.Cut(repo, "@"); ok {
+		repo = beforeDigest
+	}
+	lastSlash := strings.LastIndex(repo, "/")
+	if colon := strings.LastIndex(repo, ":"); colon > lastSlash {
+		repo = repo[:colon]
+	}
+	return NormalizeOCIRepoPrefix(repo), nil
+}
+
+// OCIRepoKeyFromPath returns the registry/repository key from a gateway OCI
+// request path. Bare /v2/ version probes return ok=false because they do not
+// identify a repository.
+func OCIRepoKeyFromPath(prefix, rest string) (repoKey string, ok bool, err error) {
+	prefix = strings.Trim(strings.ToLower(strings.TrimSpace(prefix)), "/")
+	rest = strings.Trim(strings.TrimSpace(rest), "/")
+	rest = strings.TrimPrefix(rest, "v2/")
+	rest = strings.Trim(rest, "/")
+	if rest == "" || rest == "v2" {
+		return "", false, nil
+	}
+	parts := strings.Split(rest, "/")
+	for i := len(parts) - 2; i >= 1; i-- {
+		switch parts[i] {
+		case "manifests", "blobs":
+			return NormalizeOCIRepoPrefix(prefix + "/" + strings.Join(parts[:i], "/")), true, nil
+		}
+	}
+	for i := len(parts) - 2; i >= 1; i-- {
+		if parts[i] == "tags" && parts[i+1] == "list" {
+			return NormalizeOCIRepoPrefix(prefix + "/" + strings.Join(parts[:i], "/")), true, nil
+		}
+	}
+	return "", false, fmt.Errorf("missing OCI repository in request path")
+}
+
+// NormalizeOCIRepoPrefix normalizes an OCI registry/repository key. References
+// without an explicit registry use Docker Hub's canonical repository shape.
+func NormalizeOCIRepoPrefix(value string) string {
+	repo := strings.Trim(strings.ToLower(strings.TrimSpace(value)), "/")
+	if repo == "" {
+		return ""
+	}
+	parts := strings.Split(repo, "/")
+	first := parts[0]
+	hasRegistry := strings.Contains(first, ".") || strings.Contains(first, ":") || first == "localhost"
+	if !hasRegistry {
+		if len(parts) == 1 {
+			return "docker.io/library/" + repo
+		}
+		return "docker.io/" + repo
+	}
+	return repo
+}
+
+// AllowsOCIRepo reports whether an OCI repo key is covered by the authorization
+// envelope.
+func AllowsOCIRepo(prefixes []string, repoKey string) bool {
+	return allowsPrefix(prefixes, NormalizeOCIRepoPrefix(repoKey), NormalizeOCIRepoPrefix)
+}
+
+func allowsPrefix(prefixes []string, key string, normalize func(string) string) bool {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return false
+	}
+	for _, prefix := range prefixes {
+		trimmed := strings.TrimSpace(prefix)
+		prefixMatch := strings.HasSuffix(trimmed, "/")
+		normalized := normalize(trimmed)
+		if normalized == "" {
+			continue
+		}
+		if key == normalized {
+			return true
+		}
+		if prefixMatch && strings.HasPrefix(key, normalized+"/") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/gatewayauth/gatewayauth.go
+++ b/internal/gatewayauth/gatewayauth.go
@@ -156,9 +156,11 @@ func NormalizeOCIRepoPrefix(value string) string {
 	}
 	if first == "index.docker.io" || first == "registry-1.docker.io" {
 		parts[0] = "docker.io"
-		return strings.Join(parts, "/")
 	}
-	return repo
+	if parts[0] == "docker.io" && len(parts) == 2 {
+		return "docker.io/library/" + parts[1]
+	}
+	return strings.Join(parts, "/")
 }
 
 // AllowsOCIRepo reports whether an OCI repo key is covered by the authorization

--- a/internal/gatewayauth/gatewayauth_test.go
+++ b/internal/gatewayauth/gatewayauth_test.go
@@ -38,6 +38,23 @@ func TestOCIRepoPrefixFromImageRefDefaultsDockerHubLibrary(t *testing.T) {
 	}
 }
 
+func TestOCIRepoPrefixFromImageRefCanonicalizesDockerHubAliases(t *testing.T) {
+	t.Parallel()
+
+	for _, imageRef := range []string{
+		"index.docker.io/library/docker:latest",
+		"registry-1.docker.io/library/docker@sha256:0123456789abcdef",
+	} {
+		got, err := OCIRepoPrefixFromImageRef(imageRef)
+		if err != nil {
+			t.Fatalf("OCIRepoPrefixFromImageRef(%q) returned error: %v", imageRef, err)
+		}
+		if want := "docker.io/library/docker"; got != want {
+			t.Fatalf("OCIRepoPrefixFromImageRef(%q) = %q, want %q", imageRef, got, want)
+		}
+	}
+}
+
 func TestOCIRepoKeyFromPathExtractsRepository(t *testing.T) {
 	t.Parallel()
 
@@ -49,6 +66,21 @@ func TestOCIRepoKeyFromPathExtractsRepository(t *testing.T) {
 		t.Fatal("expected repository to be present")
 	}
 	if want := "ghcr.io/buildkite/cleanroom"; got != want {
+		t.Fatalf("unexpected key: got %q want %q", got, want)
+	}
+}
+
+func TestOCIRepoKeyFromPathExtractsReferrersRepository(t *testing.T) {
+	t.Parallel()
+
+	got, ok, err := OCIRepoKeyFromPath("docker.io", "library/alpine/referrers/sha256:abc")
+	if err != nil {
+		t.Fatalf("OCIRepoKeyFromPath returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected repository to be present")
+	}
+	if want := "docker.io/library/alpine"; got != want {
 		t.Fatalf("unexpected key: got %q want %q", got, want)
 	}
 }

--- a/internal/gatewayauth/gatewayauth_test.go
+++ b/internal/gatewayauth/gatewayauth_test.go
@@ -1,0 +1,81 @@
+package gatewayauth
+
+import "testing"
+
+func TestGitRepoPrefixFromURLNormalizesRepositorySuffix(t *testing.T) {
+	t.Parallel()
+
+	got, err := GitRepoPrefixFromURL("https://github.com/buildkite/cleanroom.git")
+	if err != nil {
+		t.Fatalf("GitRepoPrefixFromURL returned error: %v", err)
+	}
+	if want := "github.com/buildkite/cleanroom"; got != want {
+		t.Fatalf("unexpected prefix: got %q want %q", got, want)
+	}
+}
+
+func TestGitRepoKeyFromRequestMatchesRemoteWithoutGitSuffix(t *testing.T) {
+	t.Parallel()
+
+	got, err := GitRepoKeyFromRequest("github.com", "/buildkite/cleanroom.git/info/refs")
+	if err != nil {
+		t.Fatalf("GitRepoKeyFromRequest returned error: %v", err)
+	}
+	if !AllowsGitRepo([]string{"github.com/buildkite/cleanroom"}, got) {
+		t.Fatalf("expected repo key %q to be allowed", got)
+	}
+}
+
+func TestOCIRepoPrefixFromImageRefDefaultsDockerHubLibrary(t *testing.T) {
+	t.Parallel()
+
+	got, err := OCIRepoPrefixFromImageRef("alpine@sha256:0123456789abcdef")
+	if err != nil {
+		t.Fatalf("OCIRepoPrefixFromImageRef returned error: %v", err)
+	}
+	if want := "docker.io/library/alpine"; got != want {
+		t.Fatalf("unexpected prefix: got %q want %q", got, want)
+	}
+}
+
+func TestOCIRepoKeyFromPathExtractsRepository(t *testing.T) {
+	t.Parallel()
+
+	got, ok, err := OCIRepoKeyFromPath("ghcr.io", "buildkite/cleanroom/manifests/sha256:abc")
+	if err != nil {
+		t.Fatalf("OCIRepoKeyFromPath returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected repository to be present")
+	}
+	if want := "ghcr.io/buildkite/cleanroom"; got != want {
+		t.Fatalf("unexpected key: got %q want %q", got, want)
+	}
+}
+
+func TestOCIRepoKeyFromPathUsesDistributionMarkerFromRight(t *testing.T) {
+	t.Parallel()
+
+	got, ok, err := OCIRepoKeyFromPath("ghcr.io", "org/tags/manifests/image/manifests/latest")
+	if err != nil {
+		t.Fatalf("OCIRepoKeyFromPath returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected repository to be present")
+	}
+	if want := "ghcr.io/org/tags/manifests/image"; got != want {
+		t.Fatalf("unexpected key: got %q want %q", got, want)
+	}
+}
+
+func TestOCIRepoKeyFromPathAllowsVersionProbeWithoutRepository(t *testing.T) {
+	t.Parallel()
+
+	got, ok, err := OCIRepoKeyFromPath("docker.io", "v2/")
+	if err != nil {
+		t.Fatalf("OCIRepoKeyFromPath returned error: %v", err)
+	}
+	if ok || got != "" {
+		t.Fatalf("expected no repository for version probe, got ok=%v key=%q", ok, got)
+	}
+}

--- a/internal/gatewayauth/gatewayauth_test.go
+++ b/internal/gatewayauth/gatewayauth_test.go
@@ -42,8 +42,11 @@ func TestOCIRepoPrefixFromImageRefCanonicalizesDockerHubAliases(t *testing.T) {
 	t.Parallel()
 
 	for _, imageRef := range []string{
+		"docker.io/docker:latest",
 		"index.docker.io/library/docker:latest",
+		"index.docker.io/docker:latest",
 		"registry-1.docker.io/library/docker@sha256:0123456789abcdef",
+		"registry-1.docker.io/docker@sha256:0123456789abcdef",
 	} {
 		got, err := OCIRepoPrefixFromImageRef(imageRef)
 		if err != nil {

--- a/internal/observability/contract.go
+++ b/internal/observability/contract.go
@@ -119,6 +119,7 @@ const (
 	ReasonCached                = "cached"
 	ReasonFallback              = "fallback"
 	ReasonRubyGemsUnavailable   = "rubygems_unavailable"
+	ReasonGatewayAuthDenied     = "gateway_auth_denied"
 
 	CacheStageRuntime    = "runtime"
 	CacheStageWorkspace  = "workspace"


### PR DESCRIPTION
Auth-enabled Cleanroom servers can stamp sandboxes with owners now, but the embedded gateway was still relying on sandbox network policy alone when serving Git and OCI cache routes. That is not enough for private cached content or host-side credentials: a warm cache hit still needs to be checked against the sandbox owner.

This PR carries a small gateway scope envelope from controlservice into Firecracker source-IP registration and DarwinVZ scope-token registration. When `auth.required` is on, Git, cached Git fallback, OCI registry, and Docker Hub mirror requests now require an authenticated sandbox owner and deny repositories outside the sandbox envelope before `content-cache` or host Git credentials can serve data.

The first envelope is deliberately exact. Git is limited to the sandbox checkout repository, and OCI is limited to the sandbox image repository. For example, a sandbox created for `github.com/buildkite/cleanroom` can use that repo through the gateway, but another GitHub repo is denied even if the host is allowed by policy. Broader submodule and image grants stay as follow-up work in the plan.

This covers Slice 2B-2 of `docs/plans/multi-principal-control-server.md`.
