### PR TITLE
fix: Scope fetch cache by policy

### DIFF
--- a/docs/plans/deepsec-remediation.md
+++ b/docs/plans/deepsec-remediation.md
@@ -218,7 +218,9 @@ upstream fetch, while misses use policy-pinned HTTP clients and per-policy
 download singleflight groups for direct requests and redirects. The scoped
 handler maps are LRU-bounded, evicted handlers close only after outstanding
 requests release their leases, and evicted policy metadata is removed from the
-shared metadata indexes.
+shared metadata indexes. If the same policy is rebuilt while an old active
+handler is waiting to close, the stale handler closes without deleting metadata
+owned by the replacement.
 
 Focused validation run on 2026-05-28:
 

--- a/docs/plans/deepsec-remediation.md
+++ b/docs/plans/deepsec-remediation.md
@@ -214,10 +214,11 @@ Result: passed.
 Slice 6c is implemented and ready for review. Fetch and Go proxy content-cache
 metadata are now partitioned by compiled sandbox policy. Cache hits therefore
 reuse data only within the same effective policy that authorized the original
-upstream fetch, while misses still use policy-validating HTTP clients for
-direct requests and redirects. The scoped handler maps are LRU-bounded so
-policy partitioning does not introduce unbounded handler growth, and evicted
-handlers are closed only after outstanding requests release their leases.
+upstream fetch, while misses use policy-pinned HTTP clients and per-policy
+download singleflight groups for direct requests and redirects. The scoped
+handler maps are LRU-bounded, evicted handlers close only after outstanding
+requests release their leases, and evicted policy metadata is removed from the
+shared metadata indexes.
 
 Focused validation run on 2026-05-28:
 

--- a/docs/plans/deepsec-remediation.md
+++ b/docs/plans/deepsec-remediation.md
@@ -218,9 +218,9 @@ upstream fetch, while misses use policy-pinned HTTP clients and per-policy
 download singleflight groups for direct requests and redirects. The scoped
 handler maps are LRU-bounded, evicted handlers close only after outstanding
 requests release their leases, and evicted policy metadata is removed from the
-shared metadata indexes. If the same policy is rebuilt while an old active
-handler is waiting to close, the stale handler closes without deleting metadata
-owned by the replacement.
+shared metadata indexes after the evicted handler closes. If the same policy is
+rebuilt while an old active handler is waiting to close, the stale handler
+closes without deleting metadata owned by the replacement.
 
 Focused validation run on 2026-05-28:
 

--- a/docs/plans/deepsec-remediation.md
+++ b/docs/plans/deepsec-remediation.md
@@ -1,8 +1,8 @@
 # DeepSec Remediation Plan
 
 **Spec reference:** `docs/spec.md`; `docs/api.md`; `docs/tls.md`; `docs/plans/multi-principal-control-server.md`; `docs/plans/stage-scoped-egress.md`
-**Status:** Slice 6b ready for review
-**Last reviewed:** 2026-05-27
+**Status:** Slice 6c ready for review
+**Last reviewed:** 2026-05-28
 
 ## Summary
 
@@ -164,7 +164,8 @@ URL path field injection finding without changing normal HTTPS repository
 credential lookup behavior.
 
 The remaining Slice 6 cache authorization findings for git pack responses,
-fetch cache hits, and Go proxy cache hits remain follow-up work.
+fetch cache hits, and Go proxy cache hits were left for follow-up work and are
+covered below.
 
 Focused validation run on 2026-05-27:
 
@@ -181,6 +182,12 @@ MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/eaa8/cleanroom/mise.to
 ```
 
 Result: passed.
+
+Current `main` also includes owner-scoped gateway authorization for Git and OCI
+cache routes. Auth-required Git cache requests now require an authenticated
+sandbox owner and an authorized repository envelope before the gateway reaches
+content-cache or host Git credentials, closing the cached Git pack response
+authorization finding.
 
 Slice 6b is implemented and ready for review. OCI registry handler creation is
 now bounded by a small LRU cache, so request-controlled registry prefixes cannot
@@ -200,6 +207,22 @@ Repository validation run on 2026-05-27:
 
 ```text
 MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/deepsec-oci-handler-bounds/cleanroom/mise.toml mise run check
+```
+
+Result: passed.
+
+Slice 6c is implemented and ready for review. Fetch and Go proxy content-cache
+metadata are now partitioned by compiled sandbox policy. Cache hits therefore
+reuse data only within the same effective policy that authorized the original
+upstream fetch, while misses still use policy-validating HTTP clients for
+direct requests and redirects. The scoped handler maps are LRU-bounded so
+policy partitioning does not introduce unbounded handler growth, and evicted
+handlers are closed only after outstanding requests release their leases.
+
+Focused validation run on 2026-05-28:
+
+```text
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/deepsec-oci-handler-bounds/cleanroom/mise.toml mise exec -- go test ./internal/gateway
 ```
 
 Result: passed.

--- a/internal/gateway/contentcache.go
+++ b/internal/gateway/contentcache.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
@@ -209,7 +210,8 @@ func NewContentCache(cfg ContentCacheConfig) (*ContentCache, error) {
 		handlers:     make(map[string]*goProxyScopedHandler),
 		maxHandlers:  defaultMaxGoProxyScopedHandlers,
 		buildHandler: func(compiled *policy.CompiledPolicy) (goProxyScopedHandler, error) {
-			goProxyIndex, err := newScopedGoProxyIndex(db, compiledPolicyCacheKey(compiled))
+			policyPrefix := scopedMetadataPrefix(compiledPolicyCacheKey(compiled))
+			goProxyIndex, err := newScopedGoProxyIndex(db, policyPrefix)
 			if err != nil {
 				return goProxyScopedHandler{}, err
 			}
@@ -222,12 +224,18 @@ func NewContentCache(cfg ContentCacheConfig) (*ContentCache, error) {
 				cafs,
 				ccgoproxy.WithUpstream(goProxyUpstream),
 				ccgoproxy.WithLogger(logger),
-				ccgoproxy.WithDownloader(dl),
+				ccgoproxy.WithDownloader(download.New()),
 			)
 			entry := goProxyScopedHandler{handler: handler}
 			if closer, ok := any(handler).(interface{ Close() }); ok {
 				entry.closer = closeFunc(closer.Close)
 			}
+			entry.evictCloser = closeFunc(func() {
+				if entry.closer != nil {
+					_ = entry.closer.Close()
+				}
+				_ = deleteScopedEnvelopeEntries(context.Background(), db, "goproxy", []string{"mod", "info", "list"}, policyPrefix)
+			})
 			return entry, nil
 		},
 	}
@@ -358,7 +366,8 @@ func NewContentCache(cfg ContentCacheConfig) (*ContentCache, error) {
 			handlers:     make(map[string]*fetchScopedHandler),
 			maxHandlers:  defaultMaxFetchScopedHandlers,
 			buildHandler: func(compiled *policy.CompiledPolicy) (fetchScopedHandler, error) {
-				fetchIndex, err := newScopedFetchIndex(db, compiledPolicyCacheKey(compiled))
+				policyPrefix := scopedMetadataPrefix(compiledPolicyCacheKey(compiled))
+				fetchIndex, err := newScopedFetchIndex(db, policyPrefix)
 				if err != nil {
 					return fetchScopedHandler{}, err
 				}
@@ -367,13 +376,19 @@ func NewContentCache(cfg ContentCacheConfig) (*ContentCache, error) {
 					cafs,
 					ccfetch.WithHTTPClient(newFetchContentCacheHTTPClient(compiled)),
 					ccfetch.WithLogger(logger),
-					ccfetch.WithDownloader(dl),
+					ccfetch.WithDownloader(download.New()),
 					ccfetch.WithAllowedHosts(allowedFetchHosts),
 				)
 				entry := fetchScopedHandler{handler: handler}
 				if closer, ok := any(handler).(interface{ Close() }); ok {
 					entry.closer = closeFunc(closer.Close)
 				}
+				entry.evictCloser = closeFunc(func() {
+					if entry.closer != nil {
+						_ = entry.closer.Close()
+					}
+					_ = deleteScopedEnvelopeEntries(context.Background(), db, "fetch", []string{"resource"}, policyPrefix)
+				})
 				return entry, nil
 			},
 		}
@@ -381,37 +396,101 @@ func NewContentCache(cfg ContentCacheConfig) (*ContentCache, error) {
 	return cache, nil
 }
 
-func newScopedGoProxyIndex(db metadb.EnvelopeStore, policyKey string) (*ccgoproxy.Index, error) {
-	modIdx, err := newScopedEnvelopeIndex(db, "goproxy", "mod", policyKey, 24*time.Hour)
+func newScopedGoProxyIndex(db metadb.EnvelopeStore, policyPrefix string) (*ccgoproxy.Index, error) {
+	modIdx, err := newScopedEnvelopeIndex(db, "goproxy", "mod", policyPrefix, 24*time.Hour)
 	if err != nil {
 		return nil, fmt.Errorf("create scoped goproxy mod index: %w", err)
 	}
-	infoIdx, err := newScopedEnvelopeIndex(db, "goproxy", "info", policyKey, 24*time.Hour)
+	infoIdx, err := newScopedEnvelopeIndex(db, "goproxy", "info", policyPrefix, 24*time.Hour)
 	if err != nil {
 		return nil, fmt.Errorf("create scoped goproxy info index: %w", err)
 	}
-	listIdx, err := newScopedEnvelopeIndex(db, "goproxy", "list", policyKey, 24*time.Hour)
+	listIdx, err := newScopedEnvelopeIndex(db, "goproxy", "list", policyPrefix, 24*time.Hour)
 	if err != nil {
 		return nil, fmt.Errorf("create scoped goproxy list index: %w", err)
 	}
 	return ccgoproxy.NewIndex(modIdx, infoIdx, listIdx), nil
 }
 
-func newScopedFetchIndex(db metadb.EnvelopeStore, policyKey string) (*ccfetch.Index, error) {
-	resourceIdx, err := newScopedEnvelopeIndex(db, "fetch", "resource", policyKey, 24*time.Hour)
+func newScopedFetchIndex(db metadb.EnvelopeStore, policyPrefix string) (*ccfetch.Index, error) {
+	resourceIdx, err := newScopedEnvelopeIndex(db, "fetch", "resource", policyPrefix, 24*time.Hour)
 	if err != nil {
 		return nil, fmt.Errorf("create scoped fetch resource index: %w", err)
 	}
 	return ccfetch.NewIndex(resourceIdx), nil
 }
 
-func newScopedEnvelopeIndex(db metadb.EnvelopeStore, protocol, kind, policyKey string, ttl time.Duration) (*metadb.EnvelopeIndex, error) {
-	return metadb.NewEnvelopeIndex(db, protocol, scopedMetadataKind(kind, policyKey), ttl)
+func newScopedEnvelopeIndex(db metadb.EnvelopeStore, protocol, kind, policyPrefix string, ttl time.Duration) (*metadb.EnvelopeIndex, error) {
+	return metadb.NewEnvelopeIndex(&scopedEnvelopeStore{base: db, keyPrefix: policyPrefix}, protocol, kind, ttl)
 }
 
-func scopedMetadataKind(kind, policyKey string) string {
+func scopedMetadataPrefix(policyKey string) string {
 	digest := sha256.Sum256([]byte(policyKey))
-	return kind + "-" + hex.EncodeToString(digest[:8])
+	return "policy/" + hex.EncodeToString(digest[:]) + "/"
+}
+
+func deleteScopedEnvelopeEntries(ctx context.Context, db metadb.EnvelopeStore, protocol string, kinds []string, policyPrefix string) error {
+	var errs []error
+	for _, kind := range kinds {
+		keys, err := db.ListEnvelopeKeys(ctx, protocol, kind)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		for _, key := range keys {
+			if !strings.HasPrefix(key, policyPrefix) {
+				continue
+			}
+			if err := db.DeleteEnvelope(ctx, protocol, kind, key); err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+	return errors.Join(errs...)
+}
+
+type scopedEnvelopeStore struct {
+	base      metadb.EnvelopeStore
+	keyPrefix string
+}
+
+func (s *scopedEnvelopeStore) scopedKey(key string) string {
+	return s.keyPrefix + key
+}
+
+func (s *scopedEnvelopeStore) PutEnvelope(ctx context.Context, protocol, kind, key string, env *metadb.MetadataEnvelope) error {
+	return s.base.PutEnvelope(ctx, protocol, kind, s.scopedKey(key), env)
+}
+
+func (s *scopedEnvelopeStore) GetEnvelope(ctx context.Context, protocol, kind, key string) (*metadb.MetadataEnvelope, error) {
+	return s.base.GetEnvelope(ctx, protocol, kind, s.scopedKey(key))
+}
+
+func (s *scopedEnvelopeStore) DeleteEnvelope(ctx context.Context, protocol, kind, key string) error {
+	return s.base.DeleteEnvelope(ctx, protocol, kind, s.scopedKey(key))
+}
+
+func (s *scopedEnvelopeStore) ListEnvelopeKeys(ctx context.Context, protocol, kind string) ([]string, error) {
+	keys, err := s.base.ListEnvelopeKeys(ctx, protocol, kind)
+	if err != nil {
+		return nil, err
+	}
+	scoped := make([]string, 0, len(keys))
+	for _, key := range keys {
+		trimmed, ok := strings.CutPrefix(key, s.keyPrefix)
+		if ok {
+			scoped = append(scoped, trimmed)
+		}
+	}
+	return scoped, nil
+}
+
+func (s *scopedEnvelopeStore) GetEnvelopeBlobRefs(ctx context.Context, protocol, kind, key string) ([]string, error) {
+	return s.base.GetEnvelopeBlobRefs(ctx, protocol, kind, s.scopedKey(key))
+}
+
+func (s *scopedEnvelopeStore) UpdateEnvelope(ctx context.Context, protocol, kind, key string, fn func(*metadb.MetadataEnvelope) (*metadb.MetadataEnvelope, error)) error {
+	return s.base.UpdateEnvelope(ctx, protocol, kind, s.scopedKey(key), fn)
 }
 
 func newGitContentCacheUpstream(client *http.Client, logger *slog.Logger, credentials CredentialProvider) *ccgit.Upstream {

--- a/internal/gateway/contentcache.go
+++ b/internal/gateway/contentcache.go
@@ -230,10 +230,7 @@ func NewContentCache(cfg ContentCacheConfig) (*ContentCache, error) {
 			if closer, ok := any(handler).(interface{ Close() }); ok {
 				entry.closer = closeFunc(closer.Close)
 			}
-			entry.evictCloser = closeFunc(func() {
-				if entry.closer != nil {
-					_ = entry.closer.Close()
-				}
+			entry.evictCleaner = closeFunc(func() {
 				_ = deleteScopedEnvelopeEntries(context.Background(), db, "goproxy", []string{"mod", "info", "list"}, policyPrefix)
 			})
 			return entry, nil
@@ -383,10 +380,7 @@ func NewContentCache(cfg ContentCacheConfig) (*ContentCache, error) {
 				if closer, ok := any(handler).(interface{ Close() }); ok {
 					entry.closer = closeFunc(closer.Close)
 				}
-				entry.evictCloser = closeFunc(func() {
-					if entry.closer != nil {
-						_ = entry.closer.Close()
-					}
+				entry.evictCleaner = closeFunc(func() {
 					_ = deleteScopedEnvelopeEntries(context.Background(), db, "fetch", []string{"resource"}, policyPrefix)
 				})
 				return entry, nil

--- a/internal/gateway/contentcache.go
+++ b/internal/gateway/contentcache.go
@@ -1,6 +1,8 @@
 package gateway
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -105,7 +107,6 @@ func NewContentCache(cfg ContentCacheConfig) (*ContentCache, error) {
 	sumDBHTTPClient := newSumDBContentCacheHTTPClient()
 	ociHTTPClient := newOCIContentCacheHTTPClient(cfg.Credentials)
 	rubyGemsHTTPClient := newRubyGemsContentCacheHTTPClient(cfg.Credentials)
-	fetchHTTPClient := newFetchContentCacheHTTPClient()
 
 	packIdx, err := metadb.NewEnvelopeIndex(db, "git", "pack", 24*time.Hour)
 	if err != nil {
@@ -126,21 +127,6 @@ func NewContentCache(cfg ContentCacheConfig) (*ContentCache, error) {
 	if err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("create oci image index: %w", err)
-	}
-	goProxyModIdx, err := metadb.NewEnvelopeIndex(db, "goproxy", "mod", 24*time.Hour)
-	if err != nil {
-		_ = db.Close()
-		return nil, fmt.Errorf("create goproxy mod index: %w", err)
-	}
-	goProxyInfoIdx, err := metadb.NewEnvelopeIndex(db, "goproxy", "info", 24*time.Hour)
-	if err != nil {
-		_ = db.Close()
-		return nil, fmt.Errorf("create goproxy info index: %w", err)
-	}
-	goProxyListIdx, err := metadb.NewEnvelopeIndex(db, "goproxy", "list", 24*time.Hour)
-	if err != nil {
-		_ = db.Close()
-		return nil, fmt.Errorf("create goproxy list index: %w", err)
 	}
 	sumDBIdx, err := metadb.NewEnvelopeIndex(db, "sumdb", "cache", 0)
 	if err != nil {
@@ -176,14 +162,8 @@ func NewContentCache(cfg ContentCacheConfig) (*ContentCache, error) {
 		_ = db.Close()
 		return nil, fmt.Errorf("create rubygems gemspec index: %w", err)
 	}
-	fetchResourceIdx, err := metadb.NewEnvelopeIndex(db, "fetch", "resource", 24*time.Hour)
-	if err != nil {
-		_ = db.Close()
-		return nil, fmt.Errorf("create fetch resource index: %w", err)
-	}
 
 	gitIndex := ccgit.NewIndex(packIdx)
-	goProxyIndex := ccgoproxy.NewIndex(goProxyModIdx, goProxyInfoIdx, goProxyListIdx)
 	sumDBIndex := ccgoproxy.NewSumdbIndex(sumDBIdx)
 	ociIndex := ccoci.NewIndex(imageIdx, manifestIdx, blobIdx)
 	rubyGemsIndex := ccrubygems.NewIndex(
@@ -194,7 +174,6 @@ func NewContentCache(cfg ContentCacheConfig) (*ContentCache, error) {
 		rubyGemsGemspecIdx,
 		cafs,
 	)
-	fetchIndex := ccfetch.NewIndex(fetchResourceIdx)
 	allowedGitHosts := normalizeAllowedGitHosts(cfg.GitAllowedHosts)
 	allowedFetchHosts := normalizeAllowedHostList(cfg.FetchAllowedHosts)
 	allowedFetchHostSet := normalizeAllowedGitHosts(allowedFetchHosts)
@@ -227,9 +206,13 @@ func NewContentCache(cfg ContentCacheConfig) (*ContentCache, error) {
 		policyPort:   goProxyPolicyPort,
 		upstreamHost: goProxyPolicyHost,
 		upstreamPort: goProxyPolicyPort,
-		handlers:     make(map[string]goProxyScopedHandler),
+		handlers:     make(map[string]*goProxyScopedHandler),
 		maxHandlers:  defaultMaxGoProxyScopedHandlers,
 		buildHandler: func(compiled *policy.CompiledPolicy) (goProxyScopedHandler, error) {
+			goProxyIndex, err := newScopedGoProxyIndex(db, compiledPolicyCacheKey(compiled))
+			if err != nil {
+				return goProxyScopedHandler{}, err
+			}
 			goProxyUpstream := ccgoproxy.NewUpstream(
 				ccgoproxy.WithUpstreamURL(goProxyUpstreamURL),
 				ccgoproxy.WithHTTPClient(newGoProxyContentCacheHTTPClient(compiled)),
@@ -370,23 +353,65 @@ func NewContentCache(cfg ContentCacheConfig) (*ContentCache, error) {
 		cache.rubyGems.closer = closeFunc(closer.Close)
 	}
 	if len(allowedFetchHosts) > 0 {
-		fetchHandler := ccfetch.NewHandler(
-			fetchIndex,
-			cafs,
-			ccfetch.WithHTTPClient(fetchHTTPClient),
-			ccfetch.WithLogger(logger),
-			ccfetch.WithDownloader(dl),
-			ccfetch.WithAllowedHosts(allowedFetchHosts),
-		)
 		cache.fetch = fetchHandlerEntry{
-			handler:      fetchHandler,
 			allowedHosts: allowedFetchHostSet,
-		}
-		if closer, ok := any(fetchHandler).(interface{ Close() }); ok {
-			cache.fetch.closer = closeFunc(closer.Close)
+			handlers:     make(map[string]*fetchScopedHandler),
+			maxHandlers:  defaultMaxFetchScopedHandlers,
+			buildHandler: func(compiled *policy.CompiledPolicy) (fetchScopedHandler, error) {
+				fetchIndex, err := newScopedFetchIndex(db, compiledPolicyCacheKey(compiled))
+				if err != nil {
+					return fetchScopedHandler{}, err
+				}
+				handler := ccfetch.NewHandler(
+					fetchIndex,
+					cafs,
+					ccfetch.WithHTTPClient(newFetchContentCacheHTTPClient(compiled)),
+					ccfetch.WithLogger(logger),
+					ccfetch.WithDownloader(dl),
+					ccfetch.WithAllowedHosts(allowedFetchHosts),
+				)
+				entry := fetchScopedHandler{handler: handler}
+				if closer, ok := any(handler).(interface{ Close() }); ok {
+					entry.closer = closeFunc(closer.Close)
+				}
+				return entry, nil
+			},
 		}
 	}
 	return cache, nil
+}
+
+func newScopedGoProxyIndex(db metadb.EnvelopeStore, policyKey string) (*ccgoproxy.Index, error) {
+	modIdx, err := newScopedEnvelopeIndex(db, "goproxy", "mod", policyKey, 24*time.Hour)
+	if err != nil {
+		return nil, fmt.Errorf("create scoped goproxy mod index: %w", err)
+	}
+	infoIdx, err := newScopedEnvelopeIndex(db, "goproxy", "info", policyKey, 24*time.Hour)
+	if err != nil {
+		return nil, fmt.Errorf("create scoped goproxy info index: %w", err)
+	}
+	listIdx, err := newScopedEnvelopeIndex(db, "goproxy", "list", policyKey, 24*time.Hour)
+	if err != nil {
+		return nil, fmt.Errorf("create scoped goproxy list index: %w", err)
+	}
+	return ccgoproxy.NewIndex(modIdx, infoIdx, listIdx), nil
+}
+
+func newScopedFetchIndex(db metadb.EnvelopeStore, policyKey string) (*ccfetch.Index, error) {
+	resourceIdx, err := newScopedEnvelopeIndex(db, "fetch", "resource", policyKey, 24*time.Hour)
+	if err != nil {
+		return nil, fmt.Errorf("create scoped fetch resource index: %w", err)
+	}
+	return ccfetch.NewIndex(resourceIdx), nil
+}
+
+func newScopedEnvelopeIndex(db metadb.EnvelopeStore, protocol, kind, policyKey string, ttl time.Duration) (*metadb.EnvelopeIndex, error) {
+	return metadb.NewEnvelopeIndex(db, protocol, scopedMetadataKind(kind, policyKey), ttl)
+}
+
+func scopedMetadataKind(kind, policyKey string) string {
+	digest := sha256.Sum256([]byte(policyKey))
+	return kind + "-" + hex.EncodeToString(digest[:8])
 }
 
 func newGitContentCacheUpstream(client *http.Client, logger *slog.Logger, credentials CredentialProvider) *ccgit.Upstream {

--- a/internal/gateway/contentcache_types.go
+++ b/internal/gateway/contentcache_types.go
@@ -40,11 +40,11 @@ type ociHandlerEntry struct {
 }
 
 type goProxyScopedHandler struct {
-	handler     http.Handler
-	closer      io.Closer
-	evictCloser io.Closer
-	active      int
-	evicted     bool
+	handler      http.Handler
+	closer       io.Closer
+	evictCleaner io.Closer
+	active       int
+	evicted      bool
 }
 
 type goProxyHandlerEntry struct {
@@ -88,11 +88,11 @@ type fetchHandlerEntry struct {
 }
 
 type fetchScopedHandler struct {
-	handler     http.Handler
-	closer      io.Closer
-	evictCloser io.Closer
-	active      int
-	evicted     bool
+	handler      http.Handler
+	closer       io.Closer
+	evictCleaner io.Closer
+	active       int
+	evicted      bool
 }
 
 // ContentCache holds the shared storage and protocol handlers.
@@ -244,7 +244,7 @@ func (c *ContentCache) GoProxyHandlerForPolicy(compiled *policy.CompiledPolicy) 
 	if entry, ok := c.goProxy.handlers[key]; ok {
 		entry.active++
 		c.goProxy.touchLocked(key)
-		release := c.goProxy.releaseHandler(entry)
+		release := c.goProxy.releaseHandler(key, entry)
 		c.goProxy.mu.Unlock()
 		return entry.handler, release, nil
 	}
@@ -259,13 +259,10 @@ func (c *ContentCache) GoProxyHandlerForPolicy(compiled *policy.CompiledPolicy) 
 	}
 	entry := &entryValue
 	entry.active = 1
-	if entry.evictCloser == nil {
-		entry.evictCloser = entry.closer
-	}
 	c.goProxy.handlers[key] = entry
 	c.goProxy.touchLocked(key)
 	evicted := c.goProxy.evictLocked()
-	release := c.goProxy.releaseHandler(entry)
+	release := c.goProxy.releaseHandler(key, entry)
 	c.goProxy.mu.Unlock()
 	if evicted != nil {
 		_ = evicted.Close()
@@ -305,10 +302,10 @@ func (e *goProxyHandlerEntry) evictLocked() io.Closer {
 		entry.evicted = true
 		return nil
 	}
-	return entry.evictCloser
+	return e.closeEvictedHandler(evictedKey, entry)
 }
 
-func (e *goProxyHandlerEntry) releaseHandler(entry *goProxyScopedHandler) func() {
+func (e *goProxyHandlerEntry) releaseHandler(key string, entry *goProxyScopedHandler) func() {
 	var once sync.Once
 	return func() {
 		var closer io.Closer
@@ -318,9 +315,7 @@ func (e *goProxyHandlerEntry) releaseHandler(entry *goProxyScopedHandler) func()
 				entry.active--
 			}
 			if entry.active == 0 && entry.evicted {
-				closer = entry.evictCloser
-				entry.closer = nil
-				entry.evictCloser = nil
+				closer = e.closeEvictedHandler(key, entry)
 			}
 			e.mu.Unlock()
 		})
@@ -328,6 +323,26 @@ func (e *goProxyHandlerEntry) releaseHandler(entry *goProxyScopedHandler) func()
 			_ = closer.Close()
 		}
 	}
+}
+
+func (e *goProxyHandlerEntry) closeEvictedHandler(key string, entry *goProxyScopedHandler) io.Closer {
+	return closeFunc(func() {
+		var handlerCloser io.Closer
+		e.mu.Lock()
+		handlerCloser = entry.closer
+		entry.closer = nil
+		cleaner := entry.evictCleaner
+		entry.evictCleaner = nil
+		if cleaner != nil {
+			if replacement, ok := e.handlers[key]; !ok || replacement == entry {
+				_ = cleaner.Close()
+			}
+		}
+		e.mu.Unlock()
+		if handlerCloser != nil {
+			_ = handlerCloser.Close()
+		}
+	})
 }
 
 // HasSumDBHandler reports whether sumdb caching is configured.
@@ -409,7 +424,7 @@ func (c *ContentCache) FetchHandlerForPolicy(compiled *policy.CompiledPolicy) (h
 	if entry, ok := c.fetch.handlers[key]; ok {
 		entry.active++
 		c.fetch.touchLocked(key)
-		release := c.fetch.releaseHandler(entry)
+		release := c.fetch.releaseHandler(key, entry)
 		c.fetch.mu.Unlock()
 		return entry.handler, release, nil
 	}
@@ -424,13 +439,10 @@ func (c *ContentCache) FetchHandlerForPolicy(compiled *policy.CompiledPolicy) (h
 	}
 	entry := &entryValue
 	entry.active = 1
-	if entry.evictCloser == nil {
-		entry.evictCloser = entry.closer
-	}
 	c.fetch.handlers[key] = entry
 	c.fetch.touchLocked(key)
 	evicted := c.fetch.evictLocked()
-	release := c.fetch.releaseHandler(entry)
+	release := c.fetch.releaseHandler(key, entry)
 	c.fetch.mu.Unlock()
 	if evicted != nil {
 		_ = evicted.Close()
@@ -470,10 +482,10 @@ func (e *fetchHandlerEntry) evictLocked() io.Closer {
 		entry.evicted = true
 		return nil
 	}
-	return entry.evictCloser
+	return e.closeEvictedHandler(evictedKey, entry)
 }
 
-func (e *fetchHandlerEntry) releaseHandler(entry *fetchScopedHandler) func() {
+func (e *fetchHandlerEntry) releaseHandler(key string, entry *fetchScopedHandler) func() {
 	var once sync.Once
 	return func() {
 		var closer io.Closer
@@ -483,9 +495,7 @@ func (e *fetchHandlerEntry) releaseHandler(entry *fetchScopedHandler) func() {
 				entry.active--
 			}
 			if entry.active == 0 && entry.evicted {
-				closer = entry.evictCloser
-				entry.closer = nil
-				entry.evictCloser = nil
+				closer = e.closeEvictedHandler(key, entry)
 			}
 			e.mu.Unlock()
 		})
@@ -493,6 +503,26 @@ func (e *fetchHandlerEntry) releaseHandler(entry *fetchScopedHandler) func() {
 			_ = closer.Close()
 		}
 	}
+}
+
+func (e *fetchHandlerEntry) closeEvictedHandler(key string, entry *fetchScopedHandler) io.Closer {
+	return closeFunc(func() {
+		var handlerCloser io.Closer
+		e.mu.Lock()
+		handlerCloser = entry.closer
+		entry.closer = nil
+		cleaner := entry.evictCleaner
+		entry.evictCleaner = nil
+		if cleaner != nil {
+			if replacement, ok := e.handlers[key]; !ok || replacement == entry {
+				_ = cleaner.Close()
+			}
+		}
+		e.mu.Unlock()
+		if handlerCloser != nil {
+			_ = handlerCloser.Close()
+		}
+	})
 }
 
 func compiledPolicyCacheKey(compiled *policy.CompiledPolicy) string {

--- a/internal/gateway/contentcache_types.go
+++ b/internal/gateway/contentcache_types.go
@@ -18,6 +18,7 @@ import (
 
 const (
 	defaultMaxGoProxyScopedHandlers = 32
+	defaultMaxFetchScopedHandlers   = 32
 	defaultMaxOCIHandlers           = 32
 )
 
@@ -41,6 +42,8 @@ type ociHandlerEntry struct {
 type goProxyScopedHandler struct {
 	handler http.Handler
 	closer  io.Closer
+	active  int
+	evicted bool
 }
 
 type goProxyHandlerEntry struct {
@@ -49,7 +52,7 @@ type goProxyHandlerEntry struct {
 	upstreamHost string
 	upstreamPort int
 	mu           sync.Mutex
-	handlers     map[string]goProxyScopedHandler
+	handlers     map[string]*goProxyScopedHandler
 	order        []string
 	maxHandlers  int
 	buildHandler func(*policy.CompiledPolicy) (goProxyScopedHandler, error)
@@ -75,9 +78,19 @@ type rubyGemsHandlerEntry struct {
 }
 
 type fetchHandlerEntry struct {
-	handler      http.Handler
 	allowedHosts map[string]struct{}
-	closer       io.Closer
+	mu           sync.Mutex
+	handlers     map[string]*fetchScopedHandler
+	order        []string
+	maxHandlers  int
+	buildHandler func(*policy.CompiledPolicy) (fetchScopedHandler, error)
+}
+
+type fetchScopedHandler struct {
+	handler http.Handler
+	closer  io.Closer
+	active  int
+	evicted bool
 }
 
 // ContentCache holds the shared storage and protocol handlers.
@@ -129,9 +142,13 @@ func (c *ContentCache) Close() error {
 	if c.rubyGems.closer != nil {
 		closers = append(closers, c.rubyGems.closer)
 	}
-	if c.fetch.closer != nil {
-		closers = append(closers, c.fetch.closer)
+	c.fetch.mu.Lock()
+	for _, entry := range c.fetch.handlers {
+		if entry.closer != nil {
+			closers = append(closers, entry.closer)
+		}
 	}
+	c.fetch.mu.Unlock()
 
 	if c.closer != nil {
 		closers = append(closers, c.closer)
@@ -210,43 +227,45 @@ func (c *ContentCache) GoProxyUpstream() (string, int, string, int, error) {
 // GoProxyHandlerForPolicy returns a Go module proxy cache handler scoped to
 // the provided compiled policy. The handler caches background fills against the
 // same allowlist that authorized the originating sandbox request.
-func (c *ContentCache) GoProxyHandlerForPolicy(compiled *policy.CompiledPolicy) (http.Handler, error) {
+func (c *ContentCache) GoProxyHandlerForPolicy(compiled *policy.CompiledPolicy) (http.Handler, func(), error) {
 	if c == nil || c.goProxy.buildHandler == nil {
-		return nil, errors.New("goproxy cache not configured")
+		return nil, nil, errors.New("goproxy cache not configured")
 	}
 	if compiled == nil {
-		return nil, errors.New("goproxy policy is required")
+		return nil, nil, errors.New("goproxy policy is required")
 	}
 
-	key := strings.TrimSpace(compiled.Hash)
-	if key == "" {
-		key = fmt.Sprintf("%p", compiled)
-	}
+	key := compiledPolicyCacheKey(compiled)
 
 	c.goProxy.mu.Lock()
 
 	if entry, ok := c.goProxy.handlers[key]; ok {
+		entry.active++
 		c.goProxy.touchLocked(key)
+		release := c.goProxy.releaseHandler(entry)
 		c.goProxy.mu.Unlock()
-		return entry.handler, nil
+		return entry.handler, release, nil
 	}
 
-	entry, err := c.goProxy.buildHandler(compiled)
+	entryValue, err := c.goProxy.buildHandler(compiled)
 	if err != nil {
 		c.goProxy.mu.Unlock()
-		return nil, err
+		return nil, nil, err
 	}
 	if c.goProxy.handlers == nil {
-		c.goProxy.handlers = make(map[string]goProxyScopedHandler)
+		c.goProxy.handlers = make(map[string]*goProxyScopedHandler)
 	}
+	entry := &entryValue
+	entry.active = 1
 	c.goProxy.handlers[key] = entry
 	c.goProxy.touchLocked(key)
 	evicted := c.goProxy.evictLocked()
+	release := c.goProxy.releaseHandler(entry)
 	c.goProxy.mu.Unlock()
 	if evicted != nil {
 		_ = evicted.Close()
 	}
-	return entry.handler, nil
+	return entry.handler, release, nil
 }
 
 func (e *goProxyHandlerEntry) touchLocked(key string) {
@@ -277,7 +296,32 @@ func (e *goProxyHandlerEntry) evictLocked() io.Closer {
 		return nil
 	}
 	delete(e.handlers, evictedKey)
+	if entry.active > 0 {
+		entry.evicted = true
+		return nil
+	}
 	return entry.closer
+}
+
+func (e *goProxyHandlerEntry) releaseHandler(entry *goProxyScopedHandler) func() {
+	var once sync.Once
+	return func() {
+		var closer io.Closer
+		once.Do(func() {
+			e.mu.Lock()
+			if entry.active > 0 {
+				entry.active--
+			}
+			if entry.active == 0 && entry.evicted {
+				closer = entry.closer
+				entry.closer = nil
+			}
+			e.mu.Unlock()
+		})
+		if closer != nil {
+			_ = closer.Close()
+		}
+	}
 }
 
 // HasSumDBHandler reports whether sumdb caching is configured.
@@ -325,12 +369,12 @@ func (c *ContentCache) RubyGemsHandler() (http.Handler, error) {
 
 // HasFetchHandler reports whether immutable artifact fetch caching is configured.
 func (c *ContentCache) HasFetchHandler() bool {
-	return c != nil && c.fetch.handler != nil
+	return c != nil && c.fetch.buildHandler != nil
 }
 
 // FetchAllowsHost reports whether the immutable artifact fetch route is configured for host.
 func (c *ContentCache) FetchAllowsHost(host string) bool {
-	if c == nil || c.fetch.handler == nil {
+	if c == nil || c.fetch.buildHandler == nil {
 		return false
 	}
 	host = strings.ToLower(strings.TrimSpace(host))
@@ -341,12 +385,112 @@ func (c *ContentCache) FetchAllowsHost(host string) bool {
 	return ok
 }
 
-// FetchHandler returns the configured immutable artifact fetch cache handler.
-func (c *ContentCache) FetchHandler() (http.Handler, error) {
-	if c == nil || c.fetch.handler == nil {
-		return nil, errors.New("fetch cache not configured")
+// FetchHandlerForPolicy returns an immutable artifact fetch cache handler scoped
+// to the provided compiled policy. Cached fetch metadata is partitioned by
+// policy so a hit cannot skip redirect authorization for a narrower sandbox.
+func (c *ContentCache) FetchHandlerForPolicy(compiled *policy.CompiledPolicy) (http.Handler, func(), error) {
+	if c == nil || c.fetch.buildHandler == nil {
+		return nil, nil, errors.New("fetch cache not configured")
 	}
-	return c.fetch.handler, nil
+	if compiled == nil {
+		return nil, nil, errors.New("fetch policy is required")
+	}
+
+	key := compiledPolicyCacheKey(compiled)
+
+	c.fetch.mu.Lock()
+
+	if entry, ok := c.fetch.handlers[key]; ok {
+		entry.active++
+		c.fetch.touchLocked(key)
+		release := c.fetch.releaseHandler(entry)
+		c.fetch.mu.Unlock()
+		return entry.handler, release, nil
+	}
+
+	entryValue, err := c.fetch.buildHandler(compiled)
+	if err != nil {
+		c.fetch.mu.Unlock()
+		return nil, nil, err
+	}
+	if c.fetch.handlers == nil {
+		c.fetch.handlers = make(map[string]*fetchScopedHandler)
+	}
+	entry := &entryValue
+	entry.active = 1
+	c.fetch.handlers[key] = entry
+	c.fetch.touchLocked(key)
+	evicted := c.fetch.evictLocked()
+	release := c.fetch.releaseHandler(entry)
+	c.fetch.mu.Unlock()
+	if evicted != nil {
+		_ = evicted.Close()
+	}
+	return entry.handler, release, nil
+}
+
+func (e *fetchHandlerEntry) touchLocked(key string) {
+	for i, existing := range e.order {
+		if existing != key {
+			continue
+		}
+		copy(e.order[i:], e.order[i+1:])
+		e.order = e.order[:len(e.order)-1]
+		break
+	}
+	e.order = append(e.order, key)
+}
+
+func (e *fetchHandlerEntry) evictLocked() io.Closer {
+	maxHandlers := e.maxHandlers
+	if maxHandlers <= 0 {
+		maxHandlers = defaultMaxFetchScopedHandlers
+	}
+	if len(e.order) <= maxHandlers {
+		return nil
+	}
+
+	evictedKey := e.order[0]
+	e.order = e.order[1:]
+	entry, ok := e.handlers[evictedKey]
+	if !ok {
+		return nil
+	}
+	delete(e.handlers, evictedKey)
+	if entry.active > 0 {
+		entry.evicted = true
+		return nil
+	}
+	return entry.closer
+}
+
+func (e *fetchHandlerEntry) releaseHandler(entry *fetchScopedHandler) func() {
+	var once sync.Once
+	return func() {
+		var closer io.Closer
+		once.Do(func() {
+			e.mu.Lock()
+			if entry.active > 0 {
+				entry.active--
+			}
+			if entry.active == 0 && entry.evicted {
+				closer = entry.closer
+				entry.closer = nil
+			}
+			e.mu.Unlock()
+		})
+		if closer != nil {
+			_ = closer.Close()
+		}
+	}
+}
+
+func compiledPolicyCacheKey(compiled *policy.CompiledPolicy) string {
+	key := strings.TrimSpace(compiled.Hash)
+	if key == "" {
+		key = fmt.Sprintf("%p", compiled)
+	}
+	return key
 }
 
 // OCIUpstreamForPrefix returns policy/upstream metadata for the requested
@@ -602,8 +746,8 @@ func newRubyGemsContentCacheHTTPClient(_ CredentialProvider) *http.Client {
 	return newPolicyValidatingContentCacheHTTPClient(nil, nil)
 }
 
-func newFetchContentCacheHTTPClient() *http.Client {
-	return newPolicyValidatingContentCacheHTTPClient(nil, nil)
+func newFetchContentCacheHTTPClient(compiled *policy.CompiledPolicy) *http.Client {
+	return newPolicyValidatingContentCacheHTTPClient(nil, compiled)
 }
 
 func newPolicyValidatingContentCacheHTTPClient(credentials CredentialProvider, compiled *policy.CompiledPolicy) *http.Client {

--- a/internal/gateway/contentcache_types.go
+++ b/internal/gateway/contentcache_types.go
@@ -328,19 +328,22 @@ func (e *goProxyHandlerEntry) releaseHandler(key string, entry *goProxyScopedHan
 func (e *goProxyHandlerEntry) closeEvictedHandler(key string, entry *goProxyScopedHandler) io.Closer {
 	return closeFunc(func() {
 		var handlerCloser io.Closer
+		var cleaner io.Closer
 		e.mu.Lock()
 		handlerCloser = entry.closer
 		entry.closer = nil
-		cleaner := entry.evictCleaner
+		cleaner = entry.evictCleaner
 		entry.evictCleaner = nil
-		if cleaner != nil {
-			if replacement, ok := e.handlers[key]; !ok || replacement == entry {
-				_ = cleaner.Close()
-			}
-		}
 		e.mu.Unlock()
 		if handlerCloser != nil {
 			_ = handlerCloser.Close()
+		}
+		if cleaner != nil {
+			e.mu.Lock()
+			if replacement, ok := e.handlers[key]; !ok || replacement == entry {
+				_ = cleaner.Close()
+			}
+			e.mu.Unlock()
 		}
 	})
 }
@@ -508,19 +511,22 @@ func (e *fetchHandlerEntry) releaseHandler(key string, entry *fetchScopedHandler
 func (e *fetchHandlerEntry) closeEvictedHandler(key string, entry *fetchScopedHandler) io.Closer {
 	return closeFunc(func() {
 		var handlerCloser io.Closer
+		var cleaner io.Closer
 		e.mu.Lock()
 		handlerCloser = entry.closer
 		entry.closer = nil
-		cleaner := entry.evictCleaner
+		cleaner = entry.evictCleaner
 		entry.evictCleaner = nil
-		if cleaner != nil {
-			if replacement, ok := e.handlers[key]; !ok || replacement == entry {
-				_ = cleaner.Close()
-			}
-		}
 		e.mu.Unlock()
 		if handlerCloser != nil {
 			_ = handlerCloser.Close()
+		}
+		if cleaner != nil {
+			e.mu.Lock()
+			if replacement, ok := e.handlers[key]; !ok || replacement == entry {
+				_ = cleaner.Close()
+			}
+			e.mu.Unlock()
 		}
 	})
 }

--- a/internal/gateway/contentcache_types.go
+++ b/internal/gateway/contentcache_types.go
@@ -40,10 +40,11 @@ type ociHandlerEntry struct {
 }
 
 type goProxyScopedHandler struct {
-	handler http.Handler
-	closer  io.Closer
-	active  int
-	evicted bool
+	handler     http.Handler
+	closer      io.Closer
+	evictCloser io.Closer
+	active      int
+	evicted     bool
 }
 
 type goProxyHandlerEntry struct {
@@ -87,10 +88,11 @@ type fetchHandlerEntry struct {
 }
 
 type fetchScopedHandler struct {
-	handler http.Handler
-	closer  io.Closer
-	active  int
-	evicted bool
+	handler     http.Handler
+	closer      io.Closer
+	evictCloser io.Closer
+	active      int
+	evicted     bool
 }
 
 // ContentCache holds the shared storage and protocol handlers.
@@ -257,6 +259,9 @@ func (c *ContentCache) GoProxyHandlerForPolicy(compiled *policy.CompiledPolicy) 
 	}
 	entry := &entryValue
 	entry.active = 1
+	if entry.evictCloser == nil {
+		entry.evictCloser = entry.closer
+	}
 	c.goProxy.handlers[key] = entry
 	c.goProxy.touchLocked(key)
 	evicted := c.goProxy.evictLocked()
@@ -300,7 +305,7 @@ func (e *goProxyHandlerEntry) evictLocked() io.Closer {
 		entry.evicted = true
 		return nil
 	}
-	return entry.closer
+	return entry.evictCloser
 }
 
 func (e *goProxyHandlerEntry) releaseHandler(entry *goProxyScopedHandler) func() {
@@ -313,8 +318,9 @@ func (e *goProxyHandlerEntry) releaseHandler(entry *goProxyScopedHandler) func()
 				entry.active--
 			}
 			if entry.active == 0 && entry.evicted {
-				closer = entry.closer
+				closer = entry.evictCloser
 				entry.closer = nil
+				entry.evictCloser = nil
 			}
 			e.mu.Unlock()
 		})
@@ -418,6 +424,9 @@ func (c *ContentCache) FetchHandlerForPolicy(compiled *policy.CompiledPolicy) (h
 	}
 	entry := &entryValue
 	entry.active = 1
+	if entry.evictCloser == nil {
+		entry.evictCloser = entry.closer
+	}
 	c.fetch.handlers[key] = entry
 	c.fetch.touchLocked(key)
 	evicted := c.fetch.evictLocked()
@@ -461,7 +470,7 @@ func (e *fetchHandlerEntry) evictLocked() io.Closer {
 		entry.evicted = true
 		return nil
 	}
-	return entry.closer
+	return entry.evictCloser
 }
 
 func (e *fetchHandlerEntry) releaseHandler(entry *fetchScopedHandler) func() {
@@ -474,8 +483,9 @@ func (e *fetchHandlerEntry) releaseHandler(entry *fetchScopedHandler) func() {
 				entry.active--
 			}
 			if entry.active == 0 && entry.evicted {
-				closer = entry.closer
+				closer = entry.evictCloser
 				entry.closer = nil
+				entry.evictCloser = nil
 			}
 			e.mu.Unlock()
 		})

--- a/internal/gateway/contentcache_types_test.go
+++ b/internal/gateway/contentcache_types_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -288,6 +289,70 @@ func TestGoProxyHandlerForPolicyEvictsLeastRecentlyUsedHandler(t *testing.T) {
 	releaseC()
 }
 
+func TestGoProxyHandlerForPolicyStaleEvictionDoesNotCleanReplacementMetadata(t *testing.T) {
+	t.Parallel()
+
+	var closed []string
+	var cleaned []string
+	builds := make(map[string]int)
+	cache := &ContentCache{}
+	cache.goProxy = goProxyHandlerEntry{
+		handlers:    make(map[string]*goProxyScopedHandler),
+		maxHandlers: 2,
+		buildHandler: func(compiled *policy.CompiledPolicy) (goProxyScopedHandler, error) {
+			key := compiled.Hash
+			builds[key]++
+			id := fmt.Sprintf("%s#%d", key, builds[key])
+			return goProxyScopedHandler{
+				handler: &comparableHandler{},
+				closer: closeFunc(func() {
+					closed = append(closed, id)
+				}),
+				evictCleaner: closeFunc(func() {
+					cleaned = append(cleaned, id)
+				}),
+			}, nil
+		},
+	}
+
+	policyA := &policy.CompiledPolicy{Hash: "policy-a"}
+	policyB := &policy.CompiledPolicy{Hash: "policy-b"}
+	policyC := &policy.CompiledPolicy{Hash: "policy-c"}
+
+	_, releaseA1, err := cache.GoProxyHandlerForPolicy(policyA)
+	if err != nil {
+		t.Fatalf("handler A1: %v", err)
+	}
+	_, releaseB1, err := cache.GoProxyHandlerForPolicy(policyB)
+	if err != nil {
+		t.Fatalf("handler B1: %v", err)
+	}
+	_, releaseC, err := cache.GoProxyHandlerForPolicy(policyC)
+	if err != nil {
+		t.Fatalf("handler C: %v", err)
+	}
+	_, releaseA2, err := cache.GoProxyHandlerForPolicy(policyA)
+	if err != nil {
+		t.Fatalf("handler A2: %v", err)
+	}
+
+	releaseA1()
+	if !slices.Contains(closed, "policy-a#1") {
+		t.Fatalf("expected stale policy-a handler to close, got %v", closed)
+	}
+	if slices.Contains(cleaned, "policy-a#1") {
+		t.Fatalf("expected stale policy-a metadata cleanup to be skipped, got %v", cleaned)
+	}
+
+	releaseB1()
+	if !slices.Contains(cleaned, "policy-b#1") {
+		t.Fatalf("expected evicted policy-b metadata cleanup to run, got %v", cleaned)
+	}
+
+	releaseC()
+	releaseA2()
+}
+
 func TestFetchHandlerForPolicyEvictsLeastRecentlyUsedHandler(t *testing.T) {
 	t.Parallel()
 
@@ -353,6 +418,70 @@ func TestFetchHandlerForPolicyEvictsLeastRecentlyUsedHandler(t *testing.T) {
 	releaseA()
 	releaseReusedA()
 	releaseC()
+}
+
+func TestFetchHandlerForPolicyStaleEvictionDoesNotCleanReplacementMetadata(t *testing.T) {
+	t.Parallel()
+
+	var closed []string
+	var cleaned []string
+	builds := make(map[string]int)
+	cache := &ContentCache{}
+	cache.fetch = fetchHandlerEntry{
+		handlers:    make(map[string]*fetchScopedHandler),
+		maxHandlers: 2,
+		buildHandler: func(compiled *policy.CompiledPolicy) (fetchScopedHandler, error) {
+			key := compiled.Hash
+			builds[key]++
+			id := fmt.Sprintf("%s#%d", key, builds[key])
+			return fetchScopedHandler{
+				handler: &comparableHandler{},
+				closer: closeFunc(func() {
+					closed = append(closed, id)
+				}),
+				evictCleaner: closeFunc(func() {
+					cleaned = append(cleaned, id)
+				}),
+			}, nil
+		},
+	}
+
+	policyA := &policy.CompiledPolicy{Hash: "policy-a"}
+	policyB := &policy.CompiledPolicy{Hash: "policy-b"}
+	policyC := &policy.CompiledPolicy{Hash: "policy-c"}
+
+	_, releaseA1, err := cache.FetchHandlerForPolicy(policyA)
+	if err != nil {
+		t.Fatalf("handler A1: %v", err)
+	}
+	_, releaseB1, err := cache.FetchHandlerForPolicy(policyB)
+	if err != nil {
+		t.Fatalf("handler B1: %v", err)
+	}
+	_, releaseC, err := cache.FetchHandlerForPolicy(policyC)
+	if err != nil {
+		t.Fatalf("handler C: %v", err)
+	}
+	_, releaseA2, err := cache.FetchHandlerForPolicy(policyA)
+	if err != nil {
+		t.Fatalf("handler A2: %v", err)
+	}
+
+	releaseA1()
+	if !slices.Contains(closed, "policy-a#1") {
+		t.Fatalf("expected stale policy-a handler to close, got %v", closed)
+	}
+	if slices.Contains(cleaned, "policy-a#1") {
+		t.Fatalf("expected stale policy-a metadata cleanup to be skipped, got %v", cleaned)
+	}
+
+	releaseB1()
+	if !slices.Contains(cleaned, "policy-b#1") {
+		t.Fatalf("expected evicted policy-b metadata cleanup to run, got %v", cleaned)
+	}
+
+	releaseC()
+	releaseA2()
 }
 
 func TestScopedEnvelopeStoreDeletesOnlyEvictedPolicyEntries(t *testing.T) {

--- a/internal/gateway/contentcache_types_test.go
+++ b/internal/gateway/contentcache_types_test.go
@@ -224,7 +224,7 @@ func TestGoProxyHandlerForPolicyEvictsLeastRecentlyUsedHandler(t *testing.T) {
 	var closed []string
 	cache := &ContentCache{}
 	cache.goProxy = goProxyHandlerEntry{
-		handlers:    make(map[string]goProxyScopedHandler),
+		handlers:    make(map[string]*goProxyScopedHandler),
 		maxHandlers: 2,
 		buildHandler: func(compiled *policy.CompiledPolicy) (goProxyScopedHandler, error) {
 			key := compiled.Hash
@@ -241,21 +241,23 @@ func TestGoProxyHandlerForPolicyEvictsLeastRecentlyUsedHandler(t *testing.T) {
 	policyB := &policy.CompiledPolicy{Hash: "policy-b"}
 	policyC := &policy.CompiledPolicy{Hash: "policy-c"}
 
-	handlerA, err := cache.GoProxyHandlerForPolicy(policyA)
+	handlerA, releaseA, err := cache.GoProxyHandlerForPolicy(policyA)
 	if err != nil {
 		t.Fatalf("handler A: %v", err)
 	}
-	if _, err := cache.GoProxyHandlerForPolicy(policyB); err != nil {
+	_, releaseB, err := cache.GoProxyHandlerForPolicy(policyB)
+	if err != nil {
 		t.Fatalf("handler B: %v", err)
 	}
-	reusedA, err := cache.GoProxyHandlerForPolicy(policyA)
+	reusedA, releaseReusedA, err := cache.GoProxyHandlerForPolicy(policyA)
 	if err != nil {
 		t.Fatalf("reused handler A: %v", err)
 	}
 	if reusedA != handlerA {
 		t.Fatal("expected policy A handler to be reused before eviction")
 	}
-	if _, err := cache.GoProxyHandlerForPolicy(policyC); err != nil {
+	_, releaseC, err := cache.GoProxyHandlerForPolicy(policyC)
+	if err != nil {
 		t.Fatalf("handler C: %v", err)
 	}
 
@@ -271,9 +273,83 @@ func TestGoProxyHandlerForPolicyEvictsLeastRecentlyUsedHandler(t *testing.T) {
 	if _, ok := cache.goProxy.handlers["policy-b"]; ok {
 		t.Fatal("expected policy-b to be evicted")
 	}
+	if len(closed) != 0 {
+		t.Fatalf("expected active policy-b handler to stay open until release, got %v", closed)
+	}
+	releaseB()
 	if !slices.Equal(closed, []string{"policy-b"}) {
 		t.Fatalf("expected policy-b closer to run, got %v", closed)
 	}
+	releaseA()
+	releaseReusedA()
+	releaseC()
+}
+
+func TestFetchHandlerForPolicyEvictsLeastRecentlyUsedHandler(t *testing.T) {
+	t.Parallel()
+
+	var closed []string
+	cache := &ContentCache{}
+	cache.fetch = fetchHandlerEntry{
+		handlers:    make(map[string]*fetchScopedHandler),
+		maxHandlers: 2,
+		buildHandler: func(compiled *policy.CompiledPolicy) (fetchScopedHandler, error) {
+			key := compiled.Hash
+			return fetchScopedHandler{
+				handler: &comparableHandler{},
+				closer: closeFunc(func() {
+					closed = append(closed, key)
+				}),
+			}, nil
+		},
+	}
+
+	policyA := &policy.CompiledPolicy{Hash: "policy-a"}
+	policyB := &policy.CompiledPolicy{Hash: "policy-b"}
+	policyC := &policy.CompiledPolicy{Hash: "policy-c"}
+
+	handlerA, releaseA, err := cache.FetchHandlerForPolicy(policyA)
+	if err != nil {
+		t.Fatalf("handler A: %v", err)
+	}
+	_, releaseB, err := cache.FetchHandlerForPolicy(policyB)
+	if err != nil {
+		t.Fatalf("handler B: %v", err)
+	}
+	reusedA, releaseReusedA, err := cache.FetchHandlerForPolicy(policyA)
+	if err != nil {
+		t.Fatalf("reused handler A: %v", err)
+	}
+	if reusedA != handlerA {
+		t.Fatal("expected policy A handler to be reused before eviction")
+	}
+	_, releaseC, err := cache.FetchHandlerForPolicy(policyC)
+	if err != nil {
+		t.Fatalf("handler C: %v", err)
+	}
+
+	if got, want := len(cache.fetch.handlers), 2; got != want {
+		t.Fatalf("expected %d cached handlers, got %d", want, got)
+	}
+	if _, ok := cache.fetch.handlers["policy-a"]; !ok {
+		t.Fatal("expected policy-a to remain cached after recent reuse")
+	}
+	if _, ok := cache.fetch.handlers["policy-c"]; !ok {
+		t.Fatal("expected policy-c to be cached")
+	}
+	if _, ok := cache.fetch.handlers["policy-b"]; ok {
+		t.Fatal("expected policy-b to be evicted")
+	}
+	if len(closed) != 0 {
+		t.Fatalf("expected active policy-b handler to stay open until release, got %v", closed)
+	}
+	releaseB()
+	if !slices.Equal(closed, []string{"policy-b"}) {
+		t.Fatalf("expected policy-b closer to run, got %v", closed)
+	}
+	releaseA()
+	releaseReusedA()
+	releaseC()
 }
 
 func TestOCIHandlerForPrefixEvictsLeastRecentlyUsedHandler(t *testing.T) {

--- a/internal/gateway/contentcache_types_test.go
+++ b/internal/gateway/contentcache_types_test.go
@@ -3,15 +3,18 @@ package gateway
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/buildkite/cleanroom/internal/policy"
 	ccgit "github.com/buildkite/content-cache/protocol/git"
+	"github.com/buildkite/content-cache/store/metadb"
 )
 
 type roundTripFunc func(*http.Request) (*http.Response, error)
@@ -350,6 +353,49 @@ func TestFetchHandlerForPolicyEvictsLeastRecentlyUsedHandler(t *testing.T) {
 	releaseA()
 	releaseReusedA()
 	releaseC()
+}
+
+func TestScopedEnvelopeStoreDeletesOnlyEvictedPolicyEntries(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := metadb.NewBoltDB()
+	if err := db.Open(t.TempDir() + "/meta.db"); err != nil {
+		t.Fatalf("open metadb: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	prefixA := scopedMetadataPrefix("policy-a")
+	prefixB := scopedMetadataPrefix("policy-b")
+	indexA, err := newScopedEnvelopeIndex(db, "fetch", "resource", prefixA, time.Hour)
+	if err != nil {
+		t.Fatalf("index A: %v", err)
+	}
+	indexB, err := newScopedEnvelopeIndex(db, "fetch", "resource", prefixB, time.Hour)
+	if err != nil {
+		t.Fatalf("index B: %v", err)
+	}
+
+	if err := indexA.Put(ctx, "https://dl.example/tool.tgz", []byte("policy-a"), metadb.ContentType_CONTENT_TYPE_TEXT, nil); err != nil {
+		t.Fatalf("put policy A: %v", err)
+	}
+	if err := indexB.Put(ctx, "https://dl.example/tool.tgz", []byte("policy-b"), metadb.ContentType_CONTENT_TYPE_TEXT, nil); err != nil {
+		t.Fatalf("put policy B: %v", err)
+	}
+
+	if err := deleteScopedEnvelopeEntries(ctx, db, "fetch", []string{"resource"}, prefixA); err != nil {
+		t.Fatalf("delete policy A entries: %v", err)
+	}
+	if _, err := indexA.Get(ctx, "https://dl.example/tool.tgz"); !errors.Is(err, metadb.ErrNotFound) {
+		t.Fatalf("expected policy A entry to be deleted, got %v", err)
+	}
+	gotB, err := indexB.Get(ctx, "https://dl.example/tool.tgz")
+	if err != nil {
+		t.Fatalf("get policy B: %v", err)
+	}
+	if string(gotB) != "policy-b" {
+		t.Fatalf("expected policy B entry to remain, got %q", gotB)
+	}
 }
 
 func TestOCIHandlerForPrefixEvictsLeastRecentlyUsedHandler(t *testing.T) {

--- a/internal/gateway/contentcache_types_test.go
+++ b/internal/gateway/contentcache_types_test.go
@@ -226,6 +226,7 @@ func TestGoProxyHandlerForPolicyEvictsLeastRecentlyUsedHandler(t *testing.T) {
 	t.Parallel()
 
 	var closed []string
+	var events []string
 	cache := &ContentCache{}
 	cache.goProxy = goProxyHandlerEntry{
 		handlers:    make(map[string]*goProxyScopedHandler),
@@ -236,6 +237,10 @@ func TestGoProxyHandlerForPolicyEvictsLeastRecentlyUsedHandler(t *testing.T) {
 				handler: &comparableHandler{},
 				closer: closeFunc(func() {
 					closed = append(closed, key)
+					events = append(events, "close:"+key)
+				}),
+				evictCleaner: closeFunc(func() {
+					events = append(events, "clean:"+key)
 				}),
 			}, nil
 		},
@@ -283,6 +288,9 @@ func TestGoProxyHandlerForPolicyEvictsLeastRecentlyUsedHandler(t *testing.T) {
 	releaseB()
 	if !slices.Equal(closed, []string{"policy-b"}) {
 		t.Fatalf("expected policy-b closer to run, got %v", closed)
+	}
+	if !slices.Equal(events, []string{"close:policy-b", "clean:policy-b"}) {
+		t.Fatalf("expected policy-b cleanup after close, got %v", events)
 	}
 	releaseA()
 	releaseReusedA()
@@ -357,6 +365,7 @@ func TestFetchHandlerForPolicyEvictsLeastRecentlyUsedHandler(t *testing.T) {
 	t.Parallel()
 
 	var closed []string
+	var events []string
 	cache := &ContentCache{}
 	cache.fetch = fetchHandlerEntry{
 		handlers:    make(map[string]*fetchScopedHandler),
@@ -367,6 +376,10 @@ func TestFetchHandlerForPolicyEvictsLeastRecentlyUsedHandler(t *testing.T) {
 				handler: &comparableHandler{},
 				closer: closeFunc(func() {
 					closed = append(closed, key)
+					events = append(events, "close:"+key)
+				}),
+				evictCleaner: closeFunc(func() {
+					events = append(events, "clean:"+key)
 				}),
 			}, nil
 		},
@@ -414,6 +427,9 @@ func TestFetchHandlerForPolicyEvictsLeastRecentlyUsedHandler(t *testing.T) {
 	releaseB()
 	if !slices.Equal(closed, []string{"policy-b"}) {
 		t.Fatalf("expected policy-b closer to run, got %v", closed)
+	}
+	if !slices.Equal(events, []string{"close:policy-b", "clean:policy-b"}) {
+		t.Fatalf("expected policy-b cleanup after close, got %v", events)
 	}
 	releaseA()
 	releaseReusedA()

--- a/internal/gateway/fetch_cached.go
+++ b/internal/gateway/fetch_cached.go
@@ -8,11 +8,12 @@ import (
 
 	"charm.land/log/v2"
 	"github.com/buildkite/cleanroom/internal/observability"
+	"github.com/buildkite/cleanroom/internal/policy"
 )
 
 type fetchHandlerProvider interface {
 	FetchAllowsHost(host string) bool
-	FetchHandler() (http.Handler, error)
+	FetchHandlerForPolicy(compiled *policy.CompiledPolicy) (http.Handler, func(), error)
 }
 
 // cachedFetchHandler wraps content-cache's immutable artifact fetch handler
@@ -58,13 +59,14 @@ func (h *cachedFetchHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	handler, err := h.cache.FetchHandler()
+	handler, releaseHandler, err := h.cache.FetchHandlerForPolicy(scope.Policy)
 	if err != nil {
 		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonUpstreamError)
 		h.auditLog(r.Context(), scope.SandboxID, "fetch", gatewayActionDeny, reasonUpstreamError)
 		writeReasonError(w, http.StatusBadGateway, reasonUpstreamError, "fetch cache is not configured")
 		return
 	}
+	defer releaseHandler()
 
 	setGatewayRequestDecision(r.Context(), gatewayActionAllow, reasonCached)
 	h.auditLog(r.Context(), scope.SandboxID, host, gatewayActionAllow, reasonCached)

--- a/internal/gateway/fetch_cached_test.go
+++ b/internal/gateway/fetch_cached_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/buildkite/cleanroom/internal/policy"
 )
 
 type stubFetchHandlerProvider struct {
@@ -21,11 +23,11 @@ func (s *stubFetchHandlerProvider) FetchAllowsHost(host string) bool {
 	return ok
 }
 
-func (s *stubFetchHandlerProvider) FetchHandler() (http.Handler, error) {
+func (s *stubFetchHandlerProvider) FetchHandlerForPolicy(*policy.CompiledPolicy) (http.Handler, func(), error) {
 	if s.err != nil {
-		return nil, s.err
+		return nil, nil, s.err
 	}
-	return s.handler, nil
+	return s.handler, func() {}, nil
 }
 
 func TestCachedFetchHandlerStripsPrefixAndDelegates(t *testing.T) {

--- a/internal/gateway/goproxy_cached.go
+++ b/internal/gateway/goproxy_cached.go
@@ -12,7 +12,7 @@ import (
 
 type goProxyHandlerProvider interface {
 	GoProxyUpstream() (string, int, string, int, error)
-	GoProxyHandlerForPolicy(compiled *policy.CompiledPolicy) (http.Handler, error)
+	GoProxyHandlerForPolicy(compiled *policy.CompiledPolicy) (http.Handler, func(), error)
 	SumDBUpstream() (string, int, string, int, error)
 	SumDBHandler() (http.Handler, error)
 }
@@ -63,16 +63,20 @@ func (h *cachedGoProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	}
 
 	var handler http.Handler
+	var releaseHandler func()
 	if service == "sumdb" {
 		handler, err = h.cache.SumDBHandler()
 	} else {
-		handler, err = h.cache.GoProxyHandlerForPolicy(scope.Policy)
+		handler, releaseHandler, err = h.cache.GoProxyHandlerForPolicy(scope.Policy)
 	}
 	if err != nil {
 		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonUpstreamError)
 		h.auditLog(r.Context(), scope.SandboxID, service, service, gatewayActionDeny, reasonUpstreamError)
 		writeReasonError(w, http.StatusBadGateway, reasonUpstreamError, service+" cache is not configured")
 		return
+	}
+	if releaseHandler != nil {
+		defer releaseHandler()
 	}
 
 	setGatewayRequestDecision(r.Context(), gatewayActionAllow, reasonCached)

--- a/internal/gateway/goproxy_cached_test.go
+++ b/internal/gateway/goproxy_cached_test.go
@@ -30,11 +30,11 @@ func (s *stubGoProxyHandlerProvider) GoProxyUpstream() (string, int, string, int
 	return s.goPolicyHost, s.goPolicyPort, s.goUpstreamHost, s.goUpstreamPort, nil
 }
 
-func (s *stubGoProxyHandlerProvider) GoProxyHandlerForPolicy(*policy.CompiledPolicy) (http.Handler, error) {
+func (s *stubGoProxyHandlerProvider) GoProxyHandlerForPolicy(*policy.CompiledPolicy) (http.Handler, func(), error) {
 	if s.err != nil {
-		return nil, s.err
+		return nil, nil, s.err
 	}
-	return s.goHandler, nil
+	return s.goHandler, func() {}, nil
 }
 
 func (s *stubGoProxyHandlerProvider) SumDBUpstream() (string, int, string, int, error) {


### PR DESCRIPTION
Fetch and Go proxy cache handlers validated the current sandbox policy on upstream misses, but cached metadata was still shared by URL. That meant a later sandbox could hit data fetched under a broader redirect or module policy without reusing the same effective policy boundary.

This partitions Fetch and Go proxy metadata by compiled policy. Requests still share blobs through CAFS, but the cache metadata that decides whether a request is a hit now lives under a policy-scoped namespace. Misses use policy-pinned HTTP clients, so direct requests and redirects are checked against the same compiled policy that owns the metadata.

The scoped handler maps are LRU-bounded, and evicted handlers are closed only after outstanding requests release their leases. The DeepSec plan now marks Slice 6c ready for review.