### PR TITLE
feat: Harden auth runtime denials

### DIFF
--- a/docs/plans/multi-principal-control-server.md
+++ b/docs/plans/multi-principal-control-server.md
@@ -1,8 +1,8 @@
 # Multi-Principal Control Server Authorization Plan
 
 **Spec reference:** `docs/spec.md` sections 5.4, 6.1, and 6.2; `docs/api.md`; `docs/tls.md`
-**Status:** Slice 2B-2 implemented; runtime hardening and sharing follow-ups next
-**Last reviewed:** 2026-05-27
+**Status:** Slice 3 implemented; controlled sharing follow-ups next
+**Last reviewed:** 2026-05-28
 
 ## Summary
 
@@ -55,6 +55,12 @@ Slice 2 is split into PR-sized enforcement work:
   or host-side Git credentials can serve bytes. The first envelope is exact:
   Git is limited to the sandbox checkout repository, and OCI is limited to the
   sandbox image repository.
+- Slice 3 now makes policy-runtime failures and auth failures explainable with
+  stable reason codes: binding-level CEL runtime errors fail closed instead of
+  falling through to later bindings, `cleanroom auth check` renders those
+  structured denials, server bearer-token failures emit redacted audit logs, and
+  control-service authorization denials emit audit logs with reason, action,
+  resource, principal, binding, and grant fields.
 
 Focused validation run on 2026-05-25:
 
@@ -99,6 +105,22 @@ mise exec -- go test ./internal/gatewayauth ./internal/gateway ./internal/contro
 Result: passed.
 
 Slice 2B-2 repository validation run on 2026-05-27:
+
+```text
+mise run check
+```
+
+Result: passed.
+
+Slice 3 focused validation run on 2026-05-28:
+
+```text
+mise exec -- go test ./internal/authz ./internal/cli ./internal/controlserver ./internal/controlservice
+```
+
+Result: passed.
+
+Slice 3 repository validation run on 2026-05-28:
 
 ```text
 mise run check
@@ -711,6 +733,21 @@ Scope:
 - Add audit events and denial reason codes.
 - Reject bearer tokens over insecure non-loopback HTTP when auth is required.
 - Add transport and token redaction tests.
+
+Progress:
+
+- Binding-level CEL runtime errors now fail closed with
+  `auth_condition_error`, rather than being treated as a skipped binding.
+- Structured authorization decision errors carry stable reason codes into
+  `cleanroom auth check`, ConnectRPC auth errors, and control-service
+  authorization-denied errors.
+- Invalid bearer-token responses and audit logs report `auth_invalid_token`
+  without wrapping validator errors that may contain token material.
+- Control-service authorization denials emit audit logs with stable reason
+  codes and resource/principal context, without token fields.
+- Insecure non-loopback HTTP rejection for bearer tokens was already enforced
+  on client and server configuration surfaces and remains covered by existing
+  transport tests.
 
 Definition of done: auth failures are observable without leaking token material,
 transport behavior is fail-closed for bearer tokens, and every deny path returns

--- a/internal/authz/authz_test.go
+++ b/internal/authz/authz_test.go
@@ -293,7 +293,7 @@ func TestPolicyBindsPrincipalAndAuthorizesGrant(t *testing.T) {
 	}
 }
 
-func TestPolicyContinuesBindingEvaluationAfterWhenError(t *testing.T) {
+func TestPolicyFailsClosedBindingEvaluationAfterWhenError(t *testing.T) {
 	policy := compileTestPolicy(t, `bindings:
   - name: missing-claim
     when: 'claims.repository.owner == "buildkite"'
@@ -317,10 +317,20 @@ func TestPolicyContinuesBindingEvaluationAfterWhenError(t *testing.T) {
 			"sub": "repo:buildkite/cleanroom:ref:refs/heads/main",
 		},
 	})
-	if err != nil {
-		t.Fatalf("Bind returned error: %v", err)
+	if err == nil {
+		t.Fatal("expected binding condition error")
 	}
-	if got, want := bound.Binding, "fallback"; got != want {
+	if bound.Principal.ID != "" {
+		t.Fatalf("expected no bound principal, got %#v", bound.Principal)
+	}
+	decision, ok := DecisionFromError(err)
+	if !ok {
+		t.Fatalf("expected decision error, got %v", err)
+	}
+	if got, want := decision.Reason, ReasonConditionError; got != want {
+		t.Fatalf("unexpected deny reason: got %q want %q", got, want)
+	}
+	if got, want := decision.Binding, "missing-claim"; got != want {
 		t.Fatalf("unexpected binding: got %q want %q", got, want)
 	}
 }

--- a/internal/authz/errors.go
+++ b/internal/authz/errors.go
@@ -1,0 +1,60 @@
+package authz
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// DecisionError carries the stable authorization decision that caused a
+// request to fail without requiring callers to parse human-readable text.
+type DecisionError struct {
+	Decision Decision
+	Cause    error
+}
+
+func NewDecisionError(decision Decision, cause error) error {
+	decision.Allowed = false
+	if strings.TrimSpace(decision.Reason) == "" {
+		decision.Reason = ReasonNoGrant
+	}
+	return &DecisionError{Decision: decision, Cause: cause}
+}
+
+func (e *DecisionError) Error() string {
+	if e == nil {
+		return ""
+	}
+	reason := strings.TrimSpace(e.Decision.Reason)
+	if reason == "" {
+		reason = ReasonNoGrant
+	}
+	action := strings.TrimSpace(e.Decision.Action)
+	resourceKind := strings.TrimSpace(e.Decision.Resource.Kind)
+	resourceID := strings.TrimSpace(e.Decision.Resource.ID)
+	switch {
+	case action != "" && resourceKind != "" && resourceID != "":
+		return fmt.Sprintf("%s for %s on %s %q", reason, action, resourceKind, resourceID)
+	case action != "" && resourceKind != "":
+		return fmt.Sprintf("%s for %s on %s", reason, action, resourceKind)
+	case e.Decision.Binding != "":
+		return fmt.Sprintf("%s in binding %q", reason, e.Decision.Binding)
+	default:
+		return reason
+	}
+}
+
+func (e *DecisionError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
+}
+
+func DecisionFromError(err error) (Decision, bool) {
+	var decisionErr *DecisionError
+	if !errors.As(err, &decisionErr) || decisionErr == nil {
+		return Decision{}, false
+	}
+	return decisionErr.Decision, true
+}

--- a/internal/authz/policy.go
+++ b/internal/authz/policy.go
@@ -176,7 +176,11 @@ func (p *CompiledPolicy) Bind(token ValidatedToken) (BoundPrincipal, error) {
 		binding := &p.bindings[i]
 		matched, err := binding.when.eval(activation)
 		if err != nil {
-			continue
+			return BoundPrincipal{}, NewDecisionError(Decision{
+				Allowed: false,
+				Binding: binding.name,
+				Reason:  ReasonConditionError,
+			}, err)
 		}
 		if !matched {
 			continue

--- a/internal/authz/types.go
+++ b/internal/authz/types.go
@@ -64,4 +64,6 @@ const (
 	ReasonConditionError = "auth_condition_error"
 	ReasonOwnerMismatch  = "auth_owner_mismatch"
 	ReasonMissingOwner   = "auth_resource_missing_owner"
+	ReasonInvalidToken   = "auth_invalid_token"
+	ReasonPolicyError    = "auth_policy_error"
 )

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -76,6 +76,9 @@ func (c *AuthCheckCommand) Run(ctx *runtimeContext) error {
 	}
 	bound, err := policy.Bind(token)
 	if err != nil {
+		if decision, ok := authz.DecisionFromError(err); ok {
+			return writeAuthCheckDecision(ctx, completeAuthCheckDecision(decision, c), c.JSON)
+		}
 		if errors.Is(err, authz.ErrNoBinding) {
 			decision := authz.Decision{
 				Allowed: false,
@@ -107,6 +110,26 @@ func (c *AuthCheckCommand) Run(ctx *runtimeContext) error {
 		Request: request,
 	})
 	return writeAuthCheckDecision(ctx, decision, c.JSON)
+}
+
+func completeAuthCheckDecision(decision authz.Decision, c *AuthCheckCommand) authz.Decision {
+	decision.Allowed = false
+	if strings.TrimSpace(decision.Action) == "" {
+		decision.Action = strings.TrimSpace(c.Action)
+	}
+	if strings.TrimSpace(decision.Resource.Kind) == "" {
+		decision.Resource.Kind = resourceKindForAction(c.Action, c.Resource)
+	}
+	if strings.TrimSpace(decision.Resource.ID) == "" {
+		decision.Resource.ID = strings.TrimSpace(c.ResourceID)
+	}
+	if strings.TrimSpace(decision.Resource.Owner.PrincipalID) == "" {
+		decision.Resource.Owner.PrincipalID = strings.TrimSpace(c.OwnerPrincipalID)
+	}
+	if strings.TrimSpace(decision.Resource.Owner.Scope) == "" {
+		decision.Resource.Owner.Scope = strings.TrimSpace(c.OwnerScope)
+	}
+	return decision
 }
 
 func writeAuthCheckDecision(ctx *runtimeContext, decision authz.Decision, asJSON bool) error {

--- a/internal/cli/auth_check_test.go
+++ b/internal/cli/auth_check_test.go
@@ -89,6 +89,58 @@ func TestAuthCheckCommandReportsDeniedDecision(t *testing.T) {
 	}
 }
 
+func TestAuthCheckCommandReportsBindingConditionError(t *testing.T) {
+	fixture := newAuthCheckFixture(t)
+	if err := os.WriteFile(fixture.policyPath, []byte(`bindings:
+  - name: broken-binding
+    when: 'claims.repository.owner == "buildkite"'
+    principal:
+      id: 'oidc:${token.issuer}:${claims.sub}'
+    grants:
+      - actions: [sandbox.create]
+        resources: [sandbox]
+  - name: fallback
+    when: 'token.issuer == "github-actions"'
+    principal:
+      id: 'oidc:${token.issuer}:${claims.sub}'
+    grants:
+      - actions: [sandbox.create]
+        resources: [sandbox]
+`), 0o644); err != nil {
+		t.Fatalf("write auth policy: %v", err)
+	}
+
+	stdout, readStdout := makeStdoutCapture(t)
+	err := (&AuthCheckCommand{
+		Config:    fixture.configPath,
+		TokenFile: fixture.tokenPath,
+		Action:    "sandbox.create",
+		Request:   fixture.requestPath,
+		JSON:      true,
+	}).Run(&runtimeContext{CWD: fixture.dir, Stdout: stdout})
+	var exitErr hasExitCode
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 1 {
+		t.Fatalf("expected denied exit code 1, got %v", err)
+	}
+
+	var decision authz.Decision
+	if err := json.Unmarshal([]byte(readStdout()), &decision); err != nil {
+		t.Fatalf("decode auth check json: %v", err)
+	}
+	if decision.Allowed {
+		t.Fatalf("expected denied decision, got %#v", decision)
+	}
+	if got, want := decision.Reason, authz.ReasonConditionError; got != want {
+		t.Fatalf("unexpected deny reason: got %q want %q", got, want)
+	}
+	if got, want := decision.Binding, "broken-binding"; got != want {
+		t.Fatalf("unexpected binding: got %q want %q", got, want)
+	}
+	if got, want := decision.Resource.Kind, "sandbox"; got != want {
+		t.Fatalf("unexpected resource kind: got %q want %q", got, want)
+	}
+}
+
 func TestRunAuthCheckBypassesBrokenDefaultRuntimeConfig(t *testing.T) {
 	fixture := newAuthCheckFixture(t)
 	xdgConfigHome := filepath.Join(fixture.dir, "xdg")

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -201,7 +201,7 @@ func (s *ServeCommand) runServer(ctx *runtimeContext) error {
 			KeyPath:  s.TLSKey,
 		}
 	}
-	authInterceptor, err := s.authInterceptor(ctx, ep)
+	authInterceptor, err := s.authInterceptor(ctx, ep, httpLogger)
 	if err != nil {
 		return err
 	}
@@ -251,7 +251,7 @@ func (s *ServeCommand) runServer(ctx *runtimeContext) error {
 	return runErr
 }
 
-func (s *ServeCommand) authInterceptor(ctx *runtimeContext, ep endpoint.Endpoint) (connect.Interceptor, error) {
+func (s *ServeCommand) authInterceptor(ctx *runtimeContext, ep endpoint.Endpoint, logger *log.Logger) (connect.Interceptor, error) {
 	if ctx == nil || !ctx.Config.Auth.Required || ep.Scheme == "unix" {
 		return nil, nil
 	}
@@ -273,6 +273,7 @@ func (s *ServeCommand) authInterceptor(ctx *runtimeContext, ep endpoint.Endpoint
 	return controlserver.BearerAuthenticator{
 		Validator: validator,
 		Policy:    policy,
+		Logger:    logger,
 	}.Interceptor(), nil
 }
 

--- a/internal/controlserver/auth.go
+++ b/internal/controlserver/auth.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"strings"
 
+	"charm.land/log/v2"
 	"connectrpc.com/connect"
 	"github.com/buildkite/cleanroom/internal/authz"
+	"github.com/buildkite/cleanroom/internal/observability"
 )
 
 type TokenValidator interface {
@@ -17,6 +19,7 @@ type TokenValidator interface {
 type BearerAuthenticator struct {
 	Validator TokenValidator
 	Policy    *authz.CompiledPolicy
+	Logger    *log.Logger
 }
 
 func (a BearerAuthenticator) Interceptor() connect.Interceptor {
@@ -26,23 +29,69 @@ func (a BearerAuthenticator) Interceptor() connect.Interceptor {
 func (a BearerAuthenticator) Authenticate(ctx context.Context, header string) (authz.BoundPrincipal, error) {
 	token, err := bearerToken(header)
 	if err != nil {
-		return authz.BoundPrincipal{}, connect.NewError(connect.CodeUnauthenticated, err)
+		return a.authFailure(ctx, connect.CodeUnauthenticated, authz.ReasonMissing, err.Error())
 	}
 	if a.Validator == nil {
-		return authz.BoundPrincipal{}, connect.NewError(connect.CodeUnauthenticated, errors.New("auth validator is not configured"))
+		return a.authFailure(ctx, connect.CodeUnauthenticated, authz.ReasonPolicyError, "auth validator is not configured")
 	}
 	if a.Policy == nil {
-		return authz.BoundPrincipal{}, connect.NewError(connect.CodeUnauthenticated, errors.New("auth policy is not configured"))
+		return a.authFailure(ctx, connect.CodeUnauthenticated, authz.ReasonPolicyError, "auth policy is not configured")
 	}
 	validated, err := a.Validator.Validate(ctx, token)
 	if err != nil {
-		return authz.BoundPrincipal{}, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("invalid bearer token: %w", err))
+		return a.authFailure(ctx, connect.CodeUnauthenticated, authz.ReasonInvalidToken, "invalid bearer token")
 	}
 	bound, err := a.Policy.Bind(validated)
 	if err != nil {
-		return authz.BoundPrincipal{}, connect.NewError(connect.CodePermissionDenied, err)
+		return a.authFailure(ctx, connect.CodePermissionDenied, authErrorReason(err), "bearer token is not authorized")
 	}
 	return bound, nil
+}
+
+func (a BearerAuthenticator) authFailure(ctx context.Context, code connect.Code, reason, message string) (authz.BoundPrincipal, error) {
+	a.logAuthFailure(ctx, code, reason)
+	return authz.BoundPrincipal{}, authConnectError(code, reason, message)
+}
+
+func (a BearerAuthenticator) logAuthFailure(ctx context.Context, code connect.Code, reason string) {
+	if a.Logger == nil {
+		return
+	}
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		reason = authz.ReasonPolicyError
+	}
+	observability.WithTraceContext(a.Logger, ctx).Warn(
+		"control server auth denied",
+		observability.LogFieldComponent, "auth",
+		observability.LogFieldSubsystem, "controlserver",
+		observability.LogFieldReasonCode, reason,
+		"connect_code", code.String(),
+	)
+}
+
+func authConnectError(code connect.Code, reason, message string) error {
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		reason = authz.ReasonPolicyError
+	}
+	message = strings.TrimSpace(message)
+	if message == "" {
+		message = reason
+	}
+	return connect.NewError(code, fmt.Errorf("%s: %s", reason, message))
+}
+
+func authErrorReason(err error) string {
+	if decision, ok := authz.DecisionFromError(err); ok {
+		if reason := strings.TrimSpace(decision.Reason); reason != "" {
+			return reason
+		}
+	}
+	if errors.Is(err, authz.ErrNoBinding) {
+		return authz.ReasonNoBinding
+	}
+	return authz.ReasonPolicyError
 }
 
 type bearerAuthInterceptor struct {

--- a/internal/controlserver/auth_test.go
+++ b/internal/controlserver/auth_test.go
@@ -1,10 +1,13 @@
 package controlserver
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -14,6 +17,7 @@ import (
 	"github.com/buildkite/cleanroom/internal/controlservice"
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
 	"github.com/buildkite/cleanroom/internal/gen/cleanroom/v1/cleanroomv1connect"
+	"github.com/buildkite/cleanroom/internal/observability"
 	"github.com/buildkite/cleanroom/internal/runtimeconfig"
 )
 
@@ -38,6 +42,85 @@ func TestBearerAuthenticatorRejectsMissingToken(t *testing.T) {
 
 	if _, err := auth.Authenticate(context.Background(), ""); connect.CodeOf(err) != connect.CodeUnauthenticated {
 		t.Fatalf("Authenticate missing token code = %v, want unauthenticated (err=%v)", connect.CodeOf(err), err)
+	}
+}
+
+func TestBearerAuthenticatorRedactsInvalidToken(t *testing.T) {
+	var logs bytes.Buffer
+	logger, err := observability.NewLogger(&logs, "info", runtimeconfig.ObservabilityConfig{
+		Logs: runtimeconfig.LogConfig{Format: "json"},
+	})
+	if err != nil {
+		t.Fatalf("NewLogger returned error: %v", err)
+	}
+	policy := testServerAuthPolicy(t)
+	auth := BearerAuthenticator{
+		Validator: leakingTokenValidator{},
+		Policy:    policy,
+		Logger:    logger,
+	}
+
+	secret := "super-secret-token"
+	_, err = auth.Authenticate(context.Background(), "Bearer "+secret)
+	if connect.CodeOf(err) != connect.CodeUnauthenticated {
+		t.Fatalf("Authenticate invalid token code = %v, want unauthenticated (err=%v)", connect.CodeOf(err), err)
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Fatalf("invalid token error leaked token: %v", err)
+	}
+	if !strings.Contains(err.Error(), authz.ReasonInvalidToken) {
+		t.Fatalf("invalid token error missing reason code %q: %v", authz.ReasonInvalidToken, err)
+	}
+	if strings.Contains(logs.String(), secret) {
+		t.Fatalf("invalid token audit log leaked token: %s", logs.String())
+	}
+	payload := findControlServerAuthDeniedLog(t, logs.String())
+	if got, want := payload[observability.LogFieldReasonCode], authz.ReasonInvalidToken; got != want {
+		t.Fatalf("unexpected auth log reason code: got %#v want %#v", got, want)
+	}
+}
+
+func TestBearerAuthenticatorReportsBindingConditionError(t *testing.T) {
+	policy, err := authz.CompilePolicy(authz.Policy{Bindings: []authz.Binding{
+		{
+			Name: "broken-binding",
+			When: `claims.repository.owner == "buildkite"`,
+			Principal: authz.PrincipalTemplate{
+				ID: "oidc:${token.issuer}:${token.subject}",
+			},
+			Grants: []authz.Grant{{
+				Actions:   []string{"sandbox.create"},
+				Resources: []string{"sandbox"},
+			}},
+		},
+		{
+			Name: "fallback",
+			When: `token.issuer == "test"`,
+			Principal: authz.PrincipalTemplate{
+				ID: "oidc:${token.issuer}:${token.subject}",
+			},
+			Grants: []authz.Grant{{
+				Actions:   []string{"sandbox.create"},
+				Resources: []string{"sandbox"},
+			}},
+		},
+	}})
+	if err != nil {
+		t.Fatalf("CompilePolicy returned error: %v", err)
+	}
+	auth := BearerAuthenticator{
+		Validator: fakeTokenValidator{tokens: map[string]authz.ValidatedToken{
+			"alice-token": testValidatedToken("alice"),
+		}},
+		Policy: policy,
+	}
+
+	_, err = auth.Authenticate(context.Background(), "Bearer alice-token")
+	if connect.CodeOf(err) != connect.CodePermissionDenied {
+		t.Fatalf("Authenticate code = %v, want permission denied (err=%v)", connect.CodeOf(err), err)
+	}
+	if !strings.Contains(err.Error(), authz.ReasonConditionError) {
+		t.Fatalf("binding condition error missing reason code %q: %v", authz.ReasonConditionError, err)
 	}
 }
 
@@ -73,6 +156,30 @@ func TestBearerAuthenticatorBindsPrincipalIntoHandlers(t *testing.T) {
 	if resp.Msg.GetSandbox().GetSandboxId() == "" {
 		t.Fatal("expected created sandbox id")
 	}
+}
+
+type leakingTokenValidator struct{}
+
+func (leakingTokenValidator) Validate(_ context.Context, token string) (authz.ValidatedToken, error) {
+	return authz.ValidatedToken{}, errors.New("token rejected: " + token)
+}
+
+func findControlServerAuthDeniedLog(t *testing.T, raw string) map[string]any {
+	t.Helper()
+	for _, line := range strings.Split(strings.TrimSpace(raw), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var payload map[string]any
+		if err := json.Unmarshal([]byte(line), &payload); err != nil {
+			t.Fatalf("decode auth log %q: %v", line, err)
+		}
+		if payload["msg"] == "control server auth denied" {
+			return payload
+		}
+	}
+	t.Fatalf("control server auth denied log not found in:\n%s", raw)
+	return nil
 }
 
 func testServerAuthPolicy(t *testing.T) *authz.CompiledPolicy {

--- a/internal/controlservice/authz.go
+++ b/internal/controlservice/authz.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/buildkite/cleanroom/internal/authz"
 	"github.com/buildkite/cleanroom/internal/backend"
+	"github.com/buildkite/cleanroom/internal/observability"
 	"github.com/buildkite/cleanroom/internal/policy"
 	"github.com/buildkite/cleanroom/internal/repositorychangeset"
 	"github.com/buildkite/cleanroom/internal/repositorycheckout"
@@ -43,7 +44,7 @@ func (s *Service) authorizeCreate(ctx context.Context, action, resourceKind stri
 		Request:  request,
 	})
 	if !decision.Allowed {
-		return owner, authDenied(decision)
+		return owner, s.denyAuthorization(ctx, decision)
 	}
 	return owner, nil
 }
@@ -59,7 +60,7 @@ func (s *Service) authorizeOwnedResource(ctx context.Context, action, resourceKi
 		Owner: owner,
 	}
 	if strings.TrimSpace(owner.PrincipalID) == "" {
-		return authDenied(authz.Decision{
+		return s.denyAuthorization(ctx, authz.Decision{
 			Allowed:   false,
 			Principal: bound.Principal,
 			Action:    action,
@@ -69,7 +70,7 @@ func (s *Service) authorizeOwnedResource(ctx context.Context, action, resourceKi
 		})
 	}
 	if owner.PrincipalID != bound.Principal.ID {
-		return authDenied(authz.Decision{
+		return s.denyAuthorization(ctx, authz.Decision{
 			Allowed:   false,
 			Principal: bound.Principal,
 			Action:    action,
@@ -84,7 +85,7 @@ func (s *Service) authorizeOwnedResource(ctx context.Context, action, resourceKi
 		Request:  request,
 	})
 	if !decision.Allowed {
-		return authDenied(decision)
+		return s.denyAuthorization(ctx, decision)
 	}
 	return nil
 }
@@ -137,7 +138,43 @@ func authDenied(decision authz.Decision) error {
 	if reason == "" {
 		reason = authz.ReasonNoGrant
 	}
-	return fmt.Errorf("%w: %s for %s on %s %q", ErrAuthorizationDenied, reason, decision.Action, decision.Resource.Kind, decision.Resource.ID)
+	decision.Reason = reason
+	return authz.NewDecisionError(decision, ErrAuthorizationDenied)
+}
+
+func (s *Service) denyAuthorization(ctx context.Context, decision authz.Decision) error {
+	s.logAuthorizationDeny(ctx, decision)
+	return authDenied(decision)
+}
+
+func (s *Service) logAuthorizationDeny(ctx context.Context, decision authz.Decision) {
+	if s == nil || s.Logger == nil {
+		return
+	}
+	reason := strings.TrimSpace(decision.Reason)
+	if reason == "" {
+		reason = authz.ReasonNoGrant
+	}
+	fields := []any{
+		observability.LogFieldComponent, "authz",
+		observability.LogFieldSubsystem, "controlservice",
+		observability.LogFieldReasonCode, reason,
+		"action", strings.TrimSpace(decision.Action),
+		"resource_kind", strings.TrimSpace(decision.Resource.Kind),
+	}
+	if id := strings.TrimSpace(decision.Resource.ID); id != "" {
+		fields = append(fields, "resource_id", id)
+	}
+	if principalID := strings.TrimSpace(decision.Principal.ID); principalID != "" {
+		fields = append(fields, "principal_id", principalID)
+	}
+	if binding := strings.TrimSpace(decision.Binding); binding != "" {
+		fields = append(fields, "binding", binding)
+	}
+	if grant := strings.TrimSpace(decision.Grant); grant != "" {
+		fields = append(fields, "grant", grant)
+	}
+	observability.WithTraceContext(s.Logger, ctx).Warn("authorization denied", fields...)
 }
 
 func createSandboxAuthorizationRequest(backendName string, compiled *policy.CompiledPolicy, repository *repositorycheckout.Checkout, changeset *repositorychangeset.Changeset, snapshotID string, effectiveResources policy.Resources) map[string]any {

--- a/internal/controlservice/authz_test.go
+++ b/internal/controlservice/authz_test.go
@@ -1,11 +1,14 @@
 package controlservice
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -73,6 +76,47 @@ func TestAuthzEnforcesExactSandboxAndExecutionOwnership(t *testing.T) {
 	}
 }
 
+func TestAuthzAuditLogIncludesStableReason(t *testing.T) {
+	var logs bytes.Buffer
+	logger, err := observability.NewLogger(&logs, "info", runtimeconfig.ObservabilityConfig{
+		Logs: runtimeconfig.LogConfig{Format: "json"},
+	})
+	if err != nil {
+		t.Fatalf("NewLogger returned error: %v", err)
+	}
+	svc := &Service{
+		Config: runtimeconfig.Config{DefaultBackend: "firecracker"},
+		Backends: map[string]backend.Adapter{
+			"firecracker": &stubAdapter{},
+		},
+		Logger: logger,
+	}
+	aliceCtx := testAuthContext(t, "alice")
+	bobCtx := testAuthContext(t, "bob")
+
+	createResp, err := svc.CreateSandbox(aliceCtx, &cleanroomv1.CreateSandboxRequest{
+		Backend: "firecracker",
+		Policy:  testPolicy(),
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	if _, err := svc.GetSandbox(bobCtx, &cleanroomv1.GetSandboxRequest{SandboxId: createResp.GetSandbox().GetSandboxId()}); !errors.Is(err, ErrAuthorizationDenied) {
+		t.Fatalf("GetSandbox as different principal error = %v, want authorization denied", err)
+	}
+
+	payload := findAuthorizationDeniedLog(t, logs.String())
+	if got, want := payload[observability.LogFieldReasonCode], authz.ReasonOwnerMismatch; got != want {
+		t.Fatalf("unexpected reason code: got %#v want %#v", got, want)
+	}
+	if got, want := payload["principal_id"], "oidc:test:bob"; got != want {
+		t.Fatalf("unexpected principal_id: got %#v want %#v", got, want)
+	}
+	if _, ok := payload["token"]; ok {
+		t.Fatalf("authorization audit log must not include token material: %#v", payload)
+	}
+}
+
 func TestAuthzPropagatesGatewayScopeToBackendRequests(t *testing.T) {
 	adapter := &stubAdapter{}
 	svc := &Service{
@@ -115,6 +159,24 @@ func TestAuthzPropagatesGatewayScopeToBackendRequests(t *testing.T) {
 	if got, want := adapter.req.GatewayScope.Authorization.GitRepoPrefixes, []string{"github.com/buildkite/cleanroom"}; !slices.Equal(got, want) {
 		t.Fatalf("execution git auth mismatch: got %v want %v", got, want)
 	}
+}
+
+func findAuthorizationDeniedLog(t *testing.T, raw string) map[string]any {
+	t.Helper()
+	for _, line := range strings.Split(strings.TrimSpace(raw), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var payload map[string]any
+		if err := json.Unmarshal([]byte(line), &payload); err != nil {
+			t.Fatalf("decode authorization log %q: %v", line, err)
+		}
+		if payload["msg"] == "authorization denied" {
+			return payload
+		}
+	}
+	t.Fatalf("authorization denied log not found in:\n%s", raw)
+	return nil
 }
 
 func TestAuthzPropagatesRequestedRepositoryToBootstrapGatewayScope(t *testing.T) {


### PR DESCRIPTION
Shared Cleanroom servers need auth failures to fail closed and be explainable without exposing bearer-token material. This hardens the runtime deny path for policy evaluation and server auth.

This change makes binding-level CEL runtime errors produce structured `auth_condition_error` denials instead of falling through to later bindings, and lets `cleanroom auth check` render those decisions. It also adds stable auth reason codes to ConnectRPC bearer failures, logs redacted auth failures at the control-server interceptor, and logs control-service authorization denials with reason/action/resource/principal context.

The plan doc is updated to mark Slice 3 complete and records the focused and full validation runs.